### PR TITLE
Try to fix `UnpicklingError: invalid load key`

### DIFF
--- a/miles/backends/megatron_utils/actor.py
+++ b/miles/backends/megatron_utils/actor.py
@@ -241,6 +241,11 @@ class MegatronTrainRayActor(TrainRayActor):
             )
 
     def train(self, rollout_id: int, rollout_data_ref: Box) -> None:
+        self._train_inner(rollout_id, rollout_data_ref)
+        torch.cuda.synchronize()
+        dist.barrier(group=get_gloo_group())
+
+    def _train_inner(self, rollout_id: int, rollout_data_ref: Box) -> None:
         Timer().end("train_wait")
 
         if self.args.offload:


### PR DESCRIPTION
will test whether this fixes

```
0: Traceback (most recent call last):
0:   File "/host_home/primary_synced/miles/train.py", line 86, in <module>
0:     train(args)
0:   File "/host_home/primary_synced/miles/train.py", line 54, in train
0:     actor_model.save_model(rollout_id)
0:   File "/host_home/primary_synced/miles/miles/ray/actor_group.py", line 122, in save_model
0:     return ray.get([actor.save_model.remote(step_id) for actor in self._actor_handlers])
0:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
0:   File "/usr/local/lib/python3.12/dist-packages/ray/_private/auto_init_hook.py", line 22, in auto_init_wrapper
0:     return fn(*args, **kwargs)
0:            ^^^^^^^^^^^^^^^^^^^
0:   File "/usr/local/lib/python3.12/dist-packages/ray/_private/client_mode_hook.py", line 104, in wrapper
0:     return func(*args, **kwargs)
0:            ^^^^^^^^^^^^^^^^^^^^^
0:   File "/usr/local/lib/python3.12/dist-packages/ray/_private/worker.py", line 2962, in get
0:     values, debugger_breakpoint = worker.get_objects(
0:                                   ^^^^^^^^^^^^^^^^^^^
0:   File "/usr/local/lib/python3.12/dist-packages/ray/_private/worker.py", line 1026, in get_objects
0:     raise value.as_instanceof_cause()
0: ray.exceptions.RayTaskError(UnpicklingError): ray::MegatronTrainRayActor.save_model() (pid=3114821, ip=10.78.210.156, actor_id=2a6f84fb443a671f8aa56b6003000000, repr=<miles.backends.megatron_utils.actor.MegatronTrainRayActor object at 0xffe474a12d50>)
0:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
0:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
0:   File "/host_home/primary_synced/miles/miles/backends/megatron_utils/actor.py", line 406, in save_model
0:     save(iteration, self.model, self.optimizer, self.opt_param_scheduler)
0:   File "/host_home/primary_synced/miles/miles/backends/megatron_utils/model.py", line 634, in save
0:     save_checkpoint(
0:   File "/root/Megatron-LM/megatron/training/checkpointing.py", line 555, in save_checkpoint
0:     async_save_request = dist_checkpointing.save(state_dict, checkpoint_name, save_strategy,
0:                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
0:   File "/root/Megatron-LM/megatron/core/dist_checkpointing/serialization.py", line 425, in save
0:     sharded_strategy.save(sharded_state_dict, checkpoint_dir)
0:   File "/root/Megatron-LM/megatron/core/dist_checkpointing/strategies/fully_parallel.py", line 97, in save
0:     self.apply_saving_parallelization(sharded_state_dict)
0:   File "/root/Megatron-LM/megatron/core/dist_checkpointing/strategies/fully_parallel.py", line 121, in apply_saving_parallelization
0:     precomputed_distribution = determine_main_replica_uniform_distribution(
0:                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
0:   File "/root/Megatron-LM/megatron/core/dist_checkpointing/exchange_utils.py", line 216, in determine_main_replica_uniform_distribution
0:     torch.distributed.all_gather_object(
0:   File "/root/Megatron-LM/megatron/core/parallel_state.py", line 214, in new_function
0:     return func(*args, **kwargs)
0:            ^^^^^^^^^^^^^^^^^^^^^
0:   File "/usr/local/lib/python3.12/dist-packages/torch/distributed/c10d_logger.py", line 81, in wrapper
0:     return func(*args, **kwargs)
0:            ^^^^^^^^^^^^^^^^^^^^^
0:   File "/usr/local/lib/python3.12/dist-packages/torch/distributed/distributed_c10d.py", line 3196, in all_gather_object
0:     object_list[i] = _tensor_to_object(tensor, tensor_size, group)
0:                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
0:   File "/usr/local/lib/python3.12/dist-packages/torch/distributed/distributed_c10d.py", line 3101, in _tensor_to_object
0:     return _unpickler(io.BytesIO(buf)).load()
0:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
0: _pickle.UnpicklingError: invalid load key, '\x00'.
```