### PR TITLE
Remove outdated comments about start_rollout_id

### DIFF
--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -1314,7 +1314,6 @@ def miles_validate_args(args):
                 "please make sure it is a valid megatron checkpoint directory."
             )
 
-    # TODO: During loading, we need to set the start_rollout_id here.
     if (
         args.load is None
         or not os.path.exists(args.load)
@@ -1327,9 +1326,6 @@ def miles_validate_args(args):
         if args.ref_ckpt_step is not None:
             args.ckpt_step = args.ref_ckpt_step
         args.start_rollout_id = 0
-    elif args.start_rollout_id is None:
-        with open(os.path.join(args.load, "latest_checkpointed_iteration.txt"), "r") as f:
-            args.start_rollout_id = int(f.read().strip()) + 1
 
     if args.eval_interval is not None:
         assert args.eval_datasets, "Evaluation datasets must be configured when eval_interval is set."


### PR DESCRIPTION
This PR fixes start_rollout_id which was not being correctly initialized when loading from a checkpoint. The fix reads the latest_checkpointed_iteration.txt file during argument validation and sets args.start_rollout_id accordingly, which was #TODO.