### PR TITLE
Support zero host or device memory waste for weight update

### DIFF
--- a/miles/backends/megatron_utils/actor.py
+++ b/miles/backends/megatron_utils/actor.py
@@ -91,7 +91,10 @@ class MegatronTrainRayActor(TrainRayActor):
 
         self.weights_backuper = TensorBackuper.create(
             source_getter=lambda: named_params_and_buffers(
-                self.args, self.model, convert_to_global_name=args.megatron_to_hf_mode == "raw"
+                self.args,
+                self.model,
+                convert_to_global_name=args.megatron_to_hf_mode == "raw",
+                translate_gpu_to_cpu=not self.args.enable_weights_backuper,
             ),
             single_tag=None if args.enable_weights_backuper else "actor",
         )

--- a/train.py
+++ b/train.py
@@ -28,12 +28,8 @@ def train(args):
     if args.offload_rollout:
         ray.get(rollout_manager.onload.remote(tags=[GPU_MEMORY_TYPE_WEIGHTS]))
 
-    if args.offload_train and not args.enable_weights_backuper:
-        actor_model.onload()
     # always update weight first so that sglang has the loaded weights from training.
     actor_model.update_weights()
-    if args.offload_train and not args.enable_weights_backuper:
-        actor_model.offload()
 
     if args.check_weight_update_equal:
         ray.get(rollout_manager.check_weights.remote(action="compare"))
@@ -93,15 +89,9 @@ def train(args):
             if args.rollout_global_dataset:
                 ray.get(rollout_manager.save.remote(rollout_id))
 
-        if args.enable_weights_backuper:
-            offload_train()
-            onload_rollout()
-            actor_model.update_weights()
-        else:
-            actor_model.clear_memory()
-            onload_rollout()
-            actor_model.update_weights()
-            offload_train()
+        offload_train()
+        onload_rollout()
+        actor_model.update_weights()
 
         if args.offload_rollout:
             if GPU_MEMORY_TYPE_CUDA_GRAPH is not None:


### PR DESCRIPTION
before this pr
* enable_weights_backuper=true: waste a copy of weights on host
* enable_weights_backuper=false: need model and optimizer be awake on gpu when update weight, which is impossible for gpu w/ smaller cuda mem