### PR TITLE
Fix docs build locale env collision

### DIFF
--- a/docs/build.sh
+++ b/docs/build.sh
@@ -1,13 +1,24 @@
 #!/usr/bin/env bash
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-LANG=$1
+DOC_LANG=${1:-}
 
 # make sure language is only en or zh
-if [ "$LANG" != "en" ] && [ "$LANG" != "zh" ]; then
+if [ "$DOC_LANG" != "en" ] && [ "$DOC_LANG" != "zh" ]; then
     echo "Language must be en or zh"
     exit 1
 fi
 
-cd $SCRIPT_DIR
-MILES_DOC_LANG=$LANG sphinx-build -b html -D language=$LANG --conf-dir ./  ./$LANG ./build/$LANG 
+cd "$SCRIPT_DIR"
+SOURCE_DIR="./$DOC_LANG"
+if [ ! -d "$SOURCE_DIR" ]; then
+    if [ "$DOC_LANG" = "zh" ] && [ -d "./en" ]; then
+        echo "[build] docs/zh not found; building zh output from docs/en sources." >&2
+        SOURCE_DIR="./en"
+    else
+        echo "[build] Source directory not found: $SOURCE_DIR" >&2
+        exit 1
+    fi
+fi
+
+MILES_DOC_LANG="$DOC_LANG" sphinx-build -b html -D language="$DOC_LANG" --conf-dir ./ "$SOURCE_DIR" "./build/$DOC_LANG"

--- a/docs/serve.sh
+++ b/docs/serve.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-LANG="${1:-all}"
+DOC_LANG="${1:-all}"
 PORT="${PORT:-8000}"
 
 cd "$SCRIPT_DIR"
 
-if [ "$LANG" = "all" ]; then
+if [ "$DOC_LANG" = "all" ]; then
     # Expect both builds present
     if [ ! -d build/en ] || [ ! -d build/zh ]; then
         echo "[serve] Missing build/en or build/zh. Run ./build_all.sh first." >&2
@@ -16,14 +16,14 @@ if [ "$LANG" = "all" ]; then
     exit $?
 fi
 
-if [ "$LANG" != "en" ] && [ "$LANG" != "zh" ]; then
+if [ "$DOC_LANG" != "en" ] && [ "$DOC_LANG" != "zh" ]; then
     echo "Usage: $0 [en|zh|all]" >&2
     exit 1
 fi
 
-if [ ! -d "build/$LANG" ]; then
-    echo "[serve] build/$LANG not found. Run ./build.sh $LANG first." >&2
+if [ ! -d "build/$DOC_LANG" ]; then
+    echo "[serve] build/$DOC_LANG not found. Run ./build.sh $DOC_LANG first." >&2
     exit 1
 fi
-echo "[serve] Serving $LANG docs on http://localhost:$PORT" 
-python -m http.server -d ./build/$LANG "$PORT"
+echo "[serve] Serving $DOC_LANG docs on http://localhost:$PORT"
+python -m http.server -d "./build/$DOC_LANG" "$PORT"


### PR DESCRIPTION
## Why this change

docs/build.sh was assigning LANG=$1 (en/zh). LANG is a standard locale environment variable on Linux; Sphinx/Python calls locale.setlocale(LC_ALL, '') and reads LANG.
When LANG gets overwritten with en/zh (not a valid locale like en_US.UTF-8), Sphinx fails with locale.**Error: unsupported locale setting.**

## What this PR does 

- docs/build.sh: rename the script arg variable from LANG to DOC_LANG to avoid clobbering system locale, quote paths, and add a guard/fallback so ./build.sh zh won’t fail if docs/zh doesn’t exist (it builds build/zh from docs/en sources but with -D language=zh).

- docs/serve.sh: rename LANG to DOC_LANG for the same reason (avoid locale env collisions) and keep argument handling consistent.