### PR TITLE
[fix] loss func return torch.tensor for new megatron compatibility

### DIFF
--- a/miles/backends/megatron_utils/loss.py
+++ b/miles/backends/megatron_utils/loss.py
@@ -771,7 +771,7 @@ def loss_function(
 
     return (
         loss,
-        num_tokens if args.calculate_per_token_loss else 1,
+        num_tokens if args.calculate_per_token_loss else torch.tensor(1, dtype=torch.int, device=logits.device),
         {
             "keys": list(log.keys()),
             "values": torch.tensor(


### PR DESCRIPTION
return num_tokens as torch.tensor(1) rather than int(1)
Newer Megatron require receiving num_tokens as a torch tensor for later processing
location: `miles/backends/megatron_utils/loss.py`