### PR TITLE
Fix TypeError in update_weights: init_rollout_engines returns tuple instead of int

### DIFF
--- a/miles/ray/rollout.py
+++ b/miles/ray/rollout.py
@@ -332,7 +332,7 @@ class RolloutManager:
 
 def init_rollout_engines(args, pg, all_rollout_engines):
     if args.debug_train_only:
-        return 0, None
+        return 0
 
     num_gpu_per_engine = min(args.rollout_num_gpus_per_engine, args.num_gpus_per_node)
     num_engines = args.rollout_num_gpus // num_gpu_per_engine
@@ -412,7 +412,7 @@ def init_rollout_engines(args, pg, all_rollout_engines):
     num_new_engines = len(rollout_engines)
 
     if num_new_engines == 0:
-        return num_new_engines, None
+        return num_new_engines
 
     if args.rollout_external:
         addr_and_ports = _allocate_rollout_engine_addr_and_ports_external(args=args, rollout_engines=rollout_engines)

--- a/tests/unit/test_rollout_init_rollout_engines_returns_int.py
+++ b/tests/unit/test_rollout_init_rollout_engines_returns_int.py
@@ -1,0 +1,26 @@
+import ast
+from pathlib import Path
+
+import miles
+import pytest
+
+
+@pytest.mark.unit
+def test_init_rollout_engines_never_returns_tuple():
+    rollout_py = Path(miles.__file__).resolve().parent / "ray" / "rollout.py"
+    source = rollout_py.read_text(encoding="utf-8")
+    module = ast.parse(source)
+
+    init_fn = next(
+        (node for node in module.body if isinstance(node, ast.FunctionDef) and node.name == "init_rollout_engines"),
+        None,
+    )
+    assert init_fn is not None, "Expected init_rollout_engines() in miles/ray/rollout.py"
+
+    tuple_return_lines = [
+        node.lineno
+        for node in ast.walk(init_fn)
+        if isinstance(node, ast.Return) and isinstance(getattr(node, "value", None), ast.Tuple)
+    ]
+    assert tuple_return_lines == [], f"init_rollout_engines() returns tuple on lines: {tuple_return_lines}"
+


### PR DESCRIPTION
## Summary
- Fixes #347: FSDP training crashes with `TypeError: '>' not supported between instances of 'tuple' and 'int'` in `update_weights()` method
- Root cause: `init_rollout_engines()` was returning tuples `(0, None)` and `(num_new_engines, None)` instead of integers
- Changed return statements to return only the integer value
- Added AST-based regression test to prevent future tuple returns

## Test plan
- [x] Run `pytest tests/unit/test_rollout_init_rollout_engines_returns_int.py` - verifies no tuple returns in `init_rollout_engines()`
- [ ] Run FSDP training with colocate mode to verify `update_weights()` completes successfully