### PR TITLE
fixing cannot found pid in ReloadableProcessGroup.GROUPS

### DIFF
--- a/miles/utils/reloadable_process_group.py
+++ b/miles/utils/reloadable_process_group.py
@@ -131,7 +131,10 @@ class ReloadableProcessGroup(torch.distributed.ProcessGroup):
     @staticmethod
     def destroy_process_groups():
         pid = os.getpid()
-        for reloadable_group in ReloadableProcessGroup.GROUPS[pid]:
+        groups = ReloadableProcessGroup.GROUPS.get(pid)
+        if groups is None:
+            return
+        for reloadable_group in groups:
             if reloadable_group.group is None:
                 continue
             dist.destroy_process_group(reloadable_group.group)
@@ -142,6 +145,10 @@ class ReloadableProcessGroup(torch.distributed.ProcessGroup):
     @staticmethod
     def reload_process_groups():
         pid = os.getpid()
+        groups = ReloadableProcessGroup.GROUPS.get(pid)
+        if groups is None:
+            return
+            
         logger.info(f"Reloading {len(ReloadableProcessGroup.GROUPS[pid])} process groups in pid {pid}")
         old_new_group = old_new_group_dict[pid]
         for reloadable_group in ReloadableProcessGroup.GROUPS[pid]:


### PR DESCRIPTION
Fixes #354 
This PR makes ReloadableProcessGroup.destroy_process_groups() and reload_process_groups() safe when no process groups were created for the current process. Previously, both methods assumed that ReloadableProcessGroup.GROUPS[pid] always existed. In valid execution paths (e.g., world_size = 1), this assumption does not hold and leads to a KeyError. The fix makes cleanup and reload logic idempotent by guarding against missing PID entries.

Testing Results: Single-GPU runs no longer crash during cleanup and no behavior change for distributed GPUs.