### PR TITLE
Fix TypeError in FSDP update_weights: inconsistent return type

### DIFF
--- a/miles/ray/rollout.py
+++ b/miles/ray/rollout.py
@@ -332,7 +332,7 @@ class RolloutManager:
 
 def init_rollout_engines(args, pg, all_rollout_engines):
     if args.debug_train_only:
-        return 0, None
+        return 0
 
     num_gpu_per_engine = min(args.rollout_num_gpus_per_engine, args.num_gpus_per_node)
     num_engines = args.rollout_num_gpus // num_gpu_per_engine
@@ -412,7 +412,7 @@ def init_rollout_engines(args, pg, all_rollout_engines):
     num_new_engines = len(rollout_engines)
 
     if num_new_engines == 0:
-        return num_new_engines, None
+        return num_new_engines
 
     if args.rollout_external:
         addr_and_ports = _allocate_rollout_engine_addr_and_ports_external(args=args, rollout_engines=rollout_engines)


### PR DESCRIPTION
## Summary

Fixes #347

The `init_rollout_engines` function had inconsistent return values causing a `TypeError` during FSDP training:

```
TypeError: '>' not supported between instances of 'tuple' and 'int'
```

### Root Cause

| Line | Before | After |
|------|--------|-------|
| 335 | `return 0, None` | `return 0` |
| 415 | `return num_new_engines, None` | `return num_new_engines` |
| 429 | `return num_new_engines` | (unchanged) |

The calling code in `actor.py:789` expects an integer:
```python
if num_new_engines > 0:  # Failed when num_new_engines was (0, None)
```

### Changes

- Removed the unused second element (`None`) from return statements in `init_rollout_engines`
- All code paths now consistently return an integer

## Test plan

- [x] Pre-commit hooks pass
- [ ] FSDP training with colocate mode completes step 0 and continues to step 1
- [ ] Verify `update_weights()` succeeds without TypeError

🤖 Generated with [Claude Code](https://claude.com/claude-code)