### PR TITLE
fix: address #331 and #349 - multi-GPU conversion and tau-bench tokenization

### DIFF
--- a/docs/en/get_started/quick_start.md
+++ b/docs/en/get_started/quick_start.md
@@ -83,14 +83,22 @@ Next, run the conversion script. Please note the following parameters:
 - `--save`: Specify the save path for the converted `torch_dist` format weights.
 
 ```bash
-PYTHONPATH=/root/Megatron-LM python tools/convert_hf_to_torch_dist.py \
+# For multi-GPU conversion (recommended for speed)
+PYTHONPATH=/root/Megatron-LM torchrun --nproc_per_node=8 tools/convert_hf_to_torch_dist.py \
     ${MODEL_ARGS[@]} \
     --hf-checkpoint /root/GLM-Z1-9B-0414 \
     --save /root/GLM-Z1-9B-0414_torch_dist
+
+# For single-GPU conversion (slower, may OOM on large models)
+# PYTHONPATH=/root/Megatron-LM python tools/convert_hf_to_torch_dist.py \
+#     ${MODEL_ARGS[@]} \
+#     --hf-checkpoint /root/GLM-Z1-9B-0414 \
+#     --save /root/GLM-Z1-9B-0414_torch_dist
 ```
 
-For larger models, you can use `torchrun` to start the conversion script to convert with multi-gpus or even multi-nodes.
-Note: When converting the kimi-k2 model weights, you need to open config.json in the model path and change "model_type": "kimi_k2" to "model_type": "deepseek_v3".
+> **Note**: Using `torchrun` with multiple GPUs significantly speeds up conversion and avoids OOM errors on large models like Qwen3-30B-A3B. Adjust `--nproc_per_node` based on your available GPUs.
+
+> **Note**: When converting the Kimi-K2 model weights, you need to open `config.json` in the model path and change `"model_type": "kimi_k2"` to `"model_type": "deepseek_v3"`.
 
 ### Convert from Megatron Format to Hugging Face Format
 

--- a/miles/backends/megatron_utils/data.py
+++ b/miles/backends/megatron_utils/data.py
@@ -396,9 +396,10 @@ def log_multi_turn_data(rollout_id: int, args: Namespace, rollout_data: RolloutB
                     log_dict["raw_response_length/response_length_mean"] = raw_response_lengths.mean().item()
                     log_dict["raw_response_length/response_length_max"] = raw_response_lengths.max().item()
                     log_dict["raw_response_length/response_length_min"] = raw_response_lengths.min().item()
-                    log_dict["raw_response_length/response_length_clip_ratio"] = (
-                        (raw_response_lengths >= args.rollout_max_response_len).float().mean().item()
-                    )
+                    if args.rollout_max_response_len is not None:
+                        log_dict["raw_response_length/response_length_clip_ratio"] = (
+                            (raw_response_lengths >= args.rollout_max_response_len).float().mean().item()
+                        )
 
                     # Vectorized sum calculation using torch - stay on GPU
                     wo_obs_response_lengths = torch.tensor(

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -240,7 +240,7 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
             parser.add_argument(
                 "--rollout-max-response-len",
                 type=int,
-                default=1024,
+                default=None,
                 help=(
                     "The maximum length of the response for the inference engine during rollout. "
                     "It is basically `max_tokens` in sglang."
@@ -1567,27 +1567,28 @@ def miles_validate_args(args):
                 logger.info(f"Warning: Argument {k} is already set to {getattr(args, k)}, will override with {v}.")
             setattr(args, k, v)
 
-    if args.rollout_max_context_len is None:
+    if args.rollout_max_context_len is None and args.rollout_max_response_len is not None:
         logger.info(
             f"args.rollout_max_context_len is not set. Use args.rollout_max_response_len {args.rollout_max_response_len} as default value."
         )
         args.rollout_max_context_len = args.rollout_max_response_len
 
-    if args.eval_max_context_len is None:
+    if args.eval_max_context_len is None and args.rollout_max_context_len is not None:
         logger.info(
             f"args.eval_max_context_len is not set. Use args.rollout_max_context_len {args.rollout_max_context_len} as default value."
         )
         args.eval_max_context_len = args.rollout_max_context_len
 
-    if args.rollout_max_prompt_len is None:
-        logger.info(
-            f"args.rollout_max_prompt_len is not set. Use args.rollout_max_context_len - 1 ({args.rollout_max_context_len} - 1) as default value so that there is at least one generated token to compute loss."
-        )
-        args.rollout_max_prompt_len = args.rollout_max_context_len - 1
+    if args.rollout_max_context_len is not None:
+        if args.rollout_max_prompt_len is None:
+            logger.info(
+                f"args.rollout_max_prompt_len is not set. Use args.rollout_max_context_len - 1 ({args.rollout_max_context_len} - 1) as default value so that there is at least one generated token to compute loss."
+            )
+            args.rollout_max_prompt_len = args.rollout_max_context_len - 1
 
-    assert (
-        args.rollout_max_prompt_len <= args.rollout_max_context_len - 1
-    ), f"args.rollout_max_prompt_len ({args.rollout_max_prompt_len}) must be smaller than args.rollout_max_context_len ({args.rollout_max_context_len}) so that there is at least one generated token to compute loss."
+        assert (
+            args.rollout_max_prompt_len <= args.rollout_max_context_len - 1
+        ), f"args.rollout_max_prompt_len ({args.rollout_max_prompt_len}) must be smaller than args.rollout_max_context_len ({args.rollout_max_context_len}) so that there is at least one generated token to compute loss."
 
     if args.prefill_num_servers is not None:
         assert not args.use_fault_tolerance, "fault tolerance is not supported when prefill_num_servers is set."


### PR DESCRIPTION
## Summary

This PR addresses two issues:

### Issue #331 - Quick start conversion uses single GPU
- Updated `docs/en/get_started/quick_start.md` to use `torchrun --nproc_per_node=8` for checkpoint conversion
- Multi-GPU conversion significantly improves speed for large models

### Issue #349 - Tau-bench tokenization bug
- Changed `rollout_max_response_len` default from `1024` to `None` in `miles/utils/arguments.py`
- Updated validation logic to properly handle `None` values:
  - Only set `rollout_max_context_len` from `rollout_max_response_len` when response_len is not None
  - Only set `eval_max_context_len` default when context_len is not None
  - Only compute `rollout_max_prompt_len` default and assertion when context_len is not None
- Updated `miles/backends/megatron_utils/data.py` to only log clip ratio when `rollout_max_response_len` is not None

This fix aligns with the approach taken in slime PR #1110 for tau-bench support.

## Test plan
- [ ] Verify quick_start.md conversion command works with multi-GPU setup
- [ ] Run tau-bench example without specifying rollout_max_response_len
- [ ] Verify existing training scripts still work when response_len is explicitly set

Fixes #331
Fixes #349

🤖 Generated with [Claude Code](https://claude.com/claude-code)