### PR TITLE
chore: fix ruff config deprecation warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,8 @@ line_length = 119
 
 [tool.ruff]
 line-length = 320  # TODO
+
+[tool.ruff.lint]
 select = [
     "E",      # Pycodestyle Errors (Structural/Fundamental Errors like bad indentation)
     "F",      # Pyflakes (Core Errors: Unused imports, undefined names)


### PR DESCRIPTION
## Summary

Fixes the ruff deprecation warning by moving linter settings to the new `[tool.ruff.lint]` section.

### Before
```
$ ruff check .
warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in `pyproject.toml`:
  - 'ignore' -> 'lint.ignore'
  - 'select' -> 'lint.select'
```

### After
```
$ ruff check .
All checks passed!
```

### Changes
- Move `select` and `ignore` from `[tool.ruff]` to `[tool.ruff.lint]`

This is a small cleanup related to #283 (linter improvements).

## Test plan
- [x] Run `ruff check .` - no warnings
- [x] All checks still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)