### PR TITLE
Revert "feat: Implement lazy data loading for Dataset"

### DIFF
--- a/miles/ray/rollout_data_source.py
+++ b/miles/ray/rollout_data_source.py
@@ -43,7 +43,6 @@ class RolloutDataSource:
                 apply_chat_template=args.apply_chat_template,
                 apply_chat_template_kwargs=args.apply_chat_template_kwargs,
                 seed=args.rollout_seed,
-                num_proc=args.num_proc,
             )
             if self.args.rollout_shuffle:
                 self.dataset.shuffle(self.epoch_id)

--- a/miles/rollout/data_source.py
+++ b/miles/rollout/data_source.py
@@ -75,7 +75,6 @@ class RolloutDataSource(DataSource):
                 apply_chat_template=args.apply_chat_template,
                 apply_chat_template_kwargs=args.apply_chat_template_kwargs,
                 seed=args.rollout_seed,
-                num_proc=args.num_proc,
             )
             if self.args.rollout_shuffle:
                 self.dataset.shuffle(self.epoch_id)

--- a/miles/rollout/sglang_rollout.py
+++ b/miles/rollout/sglang_rollout.py
@@ -478,7 +478,6 @@ async def eval_rollout_single_dataset(
             tool_key=dataset_cfg.tool_key,
             apply_chat_template=args.apply_chat_template,
             apply_chat_template_kwargs=args.apply_chat_template_kwargs,
-            num_proc=args.num_proc,
         )
     dataset = EVAL_PROMPT_DATASET[cache_key]
 

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -577,12 +577,6 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                     "and should be set to a larger value than `max_tokens_per_gpu` if you want better performance. "
                 ),
             )
-            parser.add_argument(
-                "--num-proc",
-                type=int,
-                default=8,
-                help="Number of processes for dataset initialization and filtering.",
-            )
             return parser
 
         def add_eval_arguments(parser):


### PR DESCRIPTION
Sorry for the trouble merging. Just discussed with the community, we decided to revert this PR for now. While the direction of using lazy loading to solve OOM issues is correct, several critical engineering concerns need to be addressed before a final merge:

1. Resumable Training Determinism: The PR refactored the shuffle logic. For production SFT/RL workloads, we must ensure strict determinism: loading a checkpoint at Step N and resuming must yield exactly the same data/loss for Step N+1 as continuous training. The reproducibility of the shuffle sequence under different num_proc or epoch_id settings needs verification.

2. Cross-Workload Stability: Miles handles various data pipelines (SFT, RL, VLM). We need to ensure that the integration of HF Datasets doesn't introduce deadlocks or I/O regressions under different DataLoader configurations (e.g., num_workers, pin_memory).

We need comprehensive unit tests focused on "data consistency" (e.g., Checksum validation, resumable mock tests) to prevent regressions in dataset/ckpt quality.

A final comment: The --num-proc argument should be more explicitly named (e.g., --dataset-num-proc) to avoid ambiguity with other process-related configurations.