### PR TITLE
perf: replace quadratic list flattening with linear chaining in rollout manager

### DIFF
--- a/miles/ray/rollout.py
+++ b/miles/ray/rollout.py
@@ -1,3 +1,4 @@
+import itertools
 import logging
 import multiprocessing
 import random
@@ -160,7 +161,7 @@ class RolloutManager:
             data = data.samples
             # flatten the data if it is a list of lists
             while isinstance(data[0], list):
-                data = sum(data, [])
+                data = list(itertools.chain.from_iterable(data))
 
             if self.args.disable_rollout_trim_samples:
                 logger.info(f"Collectd {len(data)} samples from rollout to train")


### PR DESCRIPTION
This PR optimizes the data preparation phase in the `RolloutManager` by addressing a performance bottleneck in `miles/ray/rollout.py`.

* **Issue:** The `_get_rollout_data` method previously used `sum(data, [])` to flatten nested lists of rollout samples. In Python, this operation has $O(N^2)$  time complexity because it creates and copies a new list at every step of the summation.
* **Fix:** Replaced the summation loop with `itertools.chain.from_iterable` to achieve $O(N)$ linear time complexity.
* **Impact:** Benchmark testing demonstrated that for large batches (e.g., 20,000 sublists), this change reduces processing time from **~26.14 seconds** to **~0.008 seconds**, significantly  reducing idle time.


Below is a simple benchmark:
```python
import time
import itertools
import random
from typing import List, Any

def flatten_before(data: List[List[Any]]) -> List[Any]:
    temp_data = data
    while isinstance(temp_data[0], list):
        temp_data = sum(temp_data, [])
    return temp_data

def flatten_after(data: List[List[Any]]) -> List[Any]:

    temp_data = data
    while isinstance(temp_data[0], list):
        temp_data = list(itertools.chain.from_iterable(temp_data))
    return temp_data

def run_benchmark():
    # Sizes to test (Number of sublists)
    # N represents the number of elements the sum() function has to aggregate
    test_sizes = [100, 500, 1000, 5000, 10000, 20000]
    elements_per_sublist = 10  # Simulating small sample data objects

    print(f"{'N (Sublists)':<15} | {'Before (sum)':<15} | {'After (chain)':<15} | {'Speedup':<10}")
    print("-" * 65)

    for n in test_sizes:
        # List of N lists, each containing 10 integers
        nested_data = [[random.randint(0, 1000) for _ in range(elements_per_sublist)] for _ in range(n)]

        # Benchmark Before
        start_time = time.perf_counter()
        result_before = flatten_before(nested_data)
        end_time = time.perf_counter()
        time_before = end_time - start_time

        #  Benchmark After
        start_time = time.perf_counter()
        result_after = flatten_after(nested_data)
        end_time = time.perf_counter()
        time_after = end_time - start_time

        
        assert result_before == result_after, "Error: Outputs do not match!"
        
        speedup = time_before / time_after if time_after > 0 else 0
        
        print(f"{n:<15} | {time_before:>13.5f}s | {time_after:>13.5f}s | {speedup:>8.1f}x")

if __name__ == "__main__":
    print("Benchmark: sum(data, []) vs itertools.chain")
    run_benchmark()
```

Results:
| N (Sublists) | Before (sum) | After (chain) | Speedup |
|--------------|--------------|---------------|---------|
| 100          | 0.00034 s    | 0.00003 s     | 12.5×   |
| 500          | 0.00883 s    | 0.00014 s     | 64.8×   |
| 1000         | 0.03989 s    | 0.00040 s     | 98.8×   |
| 5000         | 1.15539 s    | 0.00286 s     | 404.0×  |
| 10000        | 5.44935 s    | 0.00278 s     | 1957.1× |
| 20000        | 26.14263 s   | 0.00794 s     | 3292.5× |
