### PR TITLE
Fix some bug when calculating tis weights using fsdp

### DIFF
--- a/miles/backends/fsdp_utils/actor.py
+++ b/miles/backends/fsdp_utils/actor.py
@@ -671,7 +671,7 @@ class FSDPTrainRayActor(TrainRayActor):
                 has_rollout_log_probs and rollout_log_probs is not None
             ), "rollout_log_probs must be provided as non-empty torch.Tensor for TIS/MIS"
 
-            train_log_probs_list = list(old_log_probs.split(response_lengths, dim=0).detach())
+            train_log_probs_list = list(old_log_probs.detach().split(response_lengths, dim=0))
             rollout_log_probs_list = list(rollout_log_probs.split(response_lengths, dim=0))
             ois = (-ppo_kl).exp()
             tis_kwargs = {


### PR DESCRIPTION
should use old_log_probs and rollout_log_probs to calculate tis weights, using log_probs may cause GPU OOM