### PR TITLE
[Perf] Optimize sequence data packing and unpacking

### DIFF
--- a/miles/backends/fsdp_utils/data_packing.py
+++ b/miles/backends/fsdp_utils/data_packing.py
@@ -159,7 +159,7 @@ def unpack_sequences(packed_batch: dict) -> list[dict]:
 
         # Copy and slice attributes
         for key, value in packed_batch.items():
-            if key == "multimodal_num_items":
+            if key in ["multimodal_num_items", "cu_seqlens"]:
                 continue
 
             # Handle multimodal training tensors: O(1) slice using pre-calculated offsets


### PR DESCRIPTION




This PR optimizes the data processing performance in the FSDP backend by resolving quadratic time complexity bottlenecks in sequence packing and unpacking. These changes significantly reduce CPU overhead, particularly for large-scale reinforcement learning workloads where the number of sequences  ($N$) per batch is high.



1. **Unpacking**: The` unpack_sequences` function previously used sum(list[:i]) inside a loop over $N$ sequences. Since sum() is $O(i)$, the total complexity was $\sum_{i=1}^{N} i$, resulting in $O(N^2)$.
2. **Packing**: In `pack_sequences`, multimodal tensors were being concatenated iteratively using `torch.cat` inside a loop. Because `torch.cat` re-allocates and copies the entire existing buffer each time, this also resulted in **** complexity.

### **The Optimization** 

* **Prefix-Sum Offsets**: Replaced nested `sum()` calls in `unpack_sequences` with a single pre-calculated list of cumulative offsets using `itertools.accumulate`. This turns range-slicing into an  lookup.
* **Single Concatenation**: Modified `pack_sequences` to collect multimodal tensors into a list and perform a single `torch.cat` operation after the loop, ensuring linear time complexity.

---

## **Benchmark Results**

Benchmarks were conducted on CPU-side unpacking logic with varying batch sizes (N):

| N (Sequences) | Naive (ms) | Optimized (ms) | Speedup |
| --- | --- | --- | --- |
| 100 | 6.34 | 4.44 | **1.4x** |
| 1,000 | 210.69 | 39.28 | **5.4x** |
| 10,000 | 5,886.46 | 255.33 | **23.1x** |
| 40,000 | 93,117.61 | 1,057.57 | **88.0x** |
| **80,000** | **373,264.72** | **2,196.63** | **169.9x** |

### **Impact**

For a batch of 80,000 sequences, the processing time dropped from **~373 seconds (over 6 minutes)** to just **~2.2 seconds**. 

---

## **Files Modified**

* `miles/backends/fsdp_utils/data_packing.py`

