### PR TITLE
fix: fix arg parsing by making help a string instead of a tuple

### DIFF
--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -1022,7 +1022,7 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 default=None,
                 help=(
                     "Log statistics of the category of reward, such as why the reward function considers it as failed. "
-                    "Specify the key in the reward dict using this argument.",
+                    "Specify the key in the reward dict using this argument."
                 ),
             )
             parser.add_argument(


### PR DESCRIPTION
Otherwise `python train.py --help` will raise `AttributeError: 'tuple' object has no attribute 'strip'`