### PR TITLE
Remove apply-chat-template argument from SFT_ARGS

### DIFF
--- a/examples/geo3k_vlm/run_geo3k_vlm_sft.sh
+++ b/examples/geo3k_vlm/run_geo3k_vlm_sft.sh
@@ -9,9 +9,11 @@ VALID_MODELS="
   Qwen3-VL-2B-Instruct
   Qwen3-VL-4B-Instruct
   Qwen3-VL-8B-Instruct
+  Qwen3-VL-32B-Instruct
   Qwen3-VL-2B-Thinking
   Qwen3-VL-4B-Thinking
   Qwen3-VL-8B-Thinking
+  Qwen3-VL-32B-Thinking
   Qwen3-VL-30B-A3B-Instruct
   Qwen3-VL-235B-A22B-Instruct
   Qwen3-VL-30B-A3B-Thinking

--- a/examples/geo3k_vlm/run_geo3k_vlm_sft.sh
+++ b/examples/geo3k_vlm/run_geo3k_vlm_sft.sh
@@ -78,7 +78,6 @@ SFT_ARGS=(
    --rollout-function-path miles.rollout.sft_rollout.generate_rollout
    --prompt-data /root/datasets/${DATASET_LOCAL_NAME}/train_formatted.parquet
    --input-key messages
-   --apply-chat-template
    --rollout-shuffle
    --num-epoch 3000
    --rollout-batch-size 128

--- a/scripts/models/qwen3-32B.sh
+++ b/scripts/models/qwen3-32B.sh
@@ -10,7 +10,7 @@ MODEL_ARGS=(
    --disable-bias-linear
    --normalization "RMSNorm"
    --norm-epsilon 1e-6
-   --rotary-base 1000000
+   --rotary-base "${MODEL_ARGS_ROTARY_BASE:-1000000}"
    --vocab-size 151936
    --kv-channels 128
    --qk-layernorm


### PR DESCRIPTION
Removed the '--apply-chat-template' argument from SFT_ARGS.

- With the --apply-chat-template, the samples are applied prompt templates which lead to message["role"] failure since the message is str instead of object.
- Support Qwen3 VL 32B model sft
