### PR TITLE
fix: missing comma in runtime env JSON for qwen3-235B-A22B

### DIFF
--- a/scripts/run-qwen3-235B-A22B.sh
+++ b/scripts/run-qwen3-235B-A22B.sh
@@ -161,7 +161,7 @@ RUNTIME_ENV_JSON="{
   \"env_vars\": {
     \"PYTHONPATH\": \"/root/Megatron-LM/\",
     \"CUDA_DEVICE_MAX_CONNECTIONS\": \"1\",
-    \"NCCL_NVLS_ENABLE\": \"${HAS_NVLINK}\"
+    \"NCCL_NVLS_ENABLE\": \"${HAS_NVLINK}\",
     \"no_proxy\": \"${no_proxy}\",
     \"MASTER_ADDR\": \"${MASTER_ADDR}\"
   }


### PR DESCRIPTION
Summary

Fix missing comma after NCCL_NVLS_ENABLE in RUNTIME_ENV_JSON (line 164 of scripts/run-qwen3-235B-A22B.sh), which causes ray job submit to fail JSON parsing before training starts.
