### PR TITLE
fix a bug in mathdx version in dev Dockerfile on CUDA 13

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -39,7 +39,7 @@ RUN pip install tilelang -f https://tile-ai.github.io/whl/nightly/cu128/
 
 # TE does not have wheel on cuda 13 yet, thus need to install from source
 RUN if [ "${ENABLE_CUDA_13}" = "1" ]; then \
-      pip install nvidia-mathdx==26.6.0 && \
+      pip install nvidia-mathdx==25.6.0 && \
       pip -v install --no-build-isolation git+https://github.com/NVIDIA/TransformerEngine.git@release_v2.10; \
     else \
       pip -v install --no-build-isolation "transformer_engine[pytorch]==2.10.0"; \


### PR DESCRIPTION
@humansand

Based on
https://pypi.nvidia.com/nvidia-mathdx/ and
https://pypi.org/project/nvidia-mathdx/

The most recent version is nvidia-mathdx on pip is 25.6.0, with 25.12 available for download.

But on https://github.com/radixark/miles/blob/e365c78c34e1216c64ccd1ee47da62657db3c28b/docker/Dockerfile#L42C19-L42C41

The dependency listed as nvidia-mathdx==26.6.0

Fixed and tested on a local build. 