### PR TITLE
[feat] gpt-oss support v1

### DIFF
--- a/miles/backends/fsdp_utils/actor.py
+++ b/miles/backends/fsdp_utils/actor.py
@@ -346,6 +346,7 @@ class FSDPTrainRayActor(TrainRayActor):
                             self.args.data_pad_size_multiplier,
                             self.args.qkv_format,
                             get_position_ids=True,
+                            pad_token_id=self.args.pad_token_id,
                         )
 
                         model_args = self._get_model_inputs_args(batch)
@@ -459,6 +460,7 @@ class FSDPTrainRayActor(TrainRayActor):
                         self.args.data_pad_size_multiplier,
                         self.args.qkv_format,
                         get_position_ids=True,
+                        pad_token_id=self.args.pad_token_id,
                     )
 
                     log_dict = self._train_step(

--- a/miles/backends/megatron_utils/model.py
+++ b/miles/backends/megatron_utils/model.py
@@ -220,6 +220,7 @@ def forward_only(
             parallel_state,
             args.data_pad_size_multiplier,
             args.qkv_format,
+            pad_token_id=args.pad_token_id,
         )
         unconcat_tokens = batch["unconcat_tokens"]
         tokens = batch["tokens"]
@@ -368,6 +369,7 @@ def train_one_step(
             parallel_state,
             args.data_pad_size_multiplier,
             args.qkv_format,
+            pad_token_id=args.pad_token_id,
         )
 
         if os.environ.get("ENABLE_ROUTING_REPLAY", "0") == "1":

--- a/miles/backends/training_utils/data.py
+++ b/miles/backends/training_utils/data.py
@@ -90,6 +90,7 @@ def get_batch(
     pad_multiplier: int = 128,
     qkv_format: str = "thd",
     get_position_ids: bool = False,
+    pad_token_id: int = 0,
 ) -> dict[str, torch.Tensor | list[torch.Tensor] | None]:
     """
     Generate a CP-ready micro-batch with packed sequence parameters.
@@ -104,6 +105,7 @@ def get_batch(
         data_iterator: Iterator providing micro-batch data.
         keys: List of keys to fetch from the iterator.
         pad_multiplier: Multiplier for padding size calculation (default: 128).
+        pad_token_id: Token id used when padding token sequences.
 
     Returns a dict including:
     - "tokens": torch.LongTensor of shape [1, T_padded] on the current CUDA device
@@ -119,8 +121,6 @@ def get_batch(
         batch["dynamic_global_batch_size"] = data_iterator.rollout_data["dynamic_global_batch_size"]
 
     tokens = batch["tokens"]
-    # use 0 as the pad token id should be fine?
-    pad_token_id = 0
     pad_size = parallel_state.tp_size * pad_multiplier
 
     # for cp, we need all tokens to calculate logprob

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -176,6 +176,12 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
             parser.add_argument(
                 "--log-probs-chunk-size", type=int, default=-1, help="Chunk size to compute log probs to save memory"
             )
+            parser.add_argument(
+                "--pad-token-id",
+                type=int,
+                default=0,
+                help="The pad token id for the tokens during training.",
+            )
 
             return parser
 

--- a/scripts/models/gpt-oss-20b.sh
+++ b/scripts/models/gpt-oss-20b.sh
@@ -1,0 +1,49 @@
+# gpt-oss-20b model architecture
+# Expected to match HF config for gpt-oss-20b-BF16 (MoE + sliding window attention).
+
+MODEL_ARGS=(
+   # Base architecture
+   --num-layers 24
+   --hidden-size 2880
+   --ffn-hidden-size 2880
+   --num-attention-heads 64
+   --group-query-attention
+   --num-query-groups 8
+   --kv-channels 64
+
+   # Positional embeddings
+   --position-embedding-type rope
+   --rotary-percent 1.0
+   --rotary-base 150000
+   # Train with a 4k context, but keep max positions aligned with the HF checkpoint (YaRN scaling).
+   --seq-length 4096
+   --max-position-embeddings 131072
+
+   # Normalization
+   --normalization "RMSNorm"
+   --norm-epsilon 1e-5
+
+   # Activation & embeddings
+   --swiglu
+   --untie-embeddings-and-output-weights
+   --vocab-size 201088
+
+   # Note: attention_bias is true in HF config, so we may need bias
+   # --disable-bias-linear  # commented out since attention_bias=true
+
+   # Sliding window attention + learnable softmax offset (alternating SWA/full attention).
+   --softmax-type learnable
+   --window-size 128,0
+   --window-attn-skip-freq 2
+   # Fusions can be incompatible with this attention pattern on some stacks.
+   --no-masked-softmax-fusion
+   --no-rope-fusion
+
+   # MoE parameters
+   --num-experts 32
+   --moe-router-topk 4
+   --moe-aux-loss-coeff 0.0
+   --moe-token-dispatcher-type alltoall
+   --moe-router-dtype fp32
+   --moe-grouped-gemm
+)

--- a/scripts/models/gpt-oss-20b.sh
+++ b/scripts/models/gpt-oss-20b.sh
@@ -12,11 +12,10 @@ MODEL_ARGS=(
    --kv-channels 64
 
    # Positional embeddings
-   --position-embedding-type rope
+   --use-rotary-position-embeddings
    --rotary-percent 1.0
    --rotary-base 150000
    # Train with a 4k context, but keep max positions aligned with the HF checkpoint (YaRN scaling).
-   --seq-length 4096
    --max-position-embeddings 131072
 
    # Normalization

--- a/scripts/run-gpt-oss-20b.sh
+++ b/scripts/run-gpt-oss-20b.sh
@@ -1,0 +1,133 @@
+#!/bin/bash
+
+# for rerun the task
+pkill -9 sglang
+sleep 3
+ray stop --force
+pkill -9 ray
+pkill -9 python
+sleep 3
+pkill -9 ray
+pkill -9 python
+
+set -ex
+
+# will prevent ray from buffering stdout/stderr
+export PYTHONBUFFERED=16
+export HF_HOME=/workspace/hf_cache
+
+# Load model architecture config
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+source "${SCRIPT_DIR}/models/gpt-oss-20b.sh"
+
+CKPT_ARGS=(
+   --hf-checkpoint /root/shared/gpt-oss-20b-BF16
+   --megatron-to-hf-mode bridge
+#    --save /root/shared/gpt-oss-20b-BF16
+#    --save-interval 50
+)
+
+ROLLOUT_ARGS=(
+   --prompt-data /root/shared/dapo-math-17k/dapo-math-17k.jsonl
+   --input-key prompt
+   --label-key label
+   --apply-chat-template
+   --rollout-shuffle
+   --rm-type math
+   --num-rollout 1000
+   --rollout-batch-size 32
+   --n-samples-per-prompt 8
+   --rollout-max-response-len 8192
+   --rollout-temperature 1.0
+
+   --num-steps-per-rollout 1
+)
+
+PERF_ARGS=(
+   # Parallelism: TP=8, EP=4, PP=1, CP=1
+   # SP is required when combining TP + EP
+   --tensor-model-parallel-size 8
+   --sequence-parallel
+   --pipeline-model-parallel-size 1
+   --context-parallel-size 1
+   --expert-model-parallel-size 8
+   --expert-tensor-parallel-size 1
+
+   # Recomputation: full recompute needed to fit optimizer states in 80GB
+   --recompute-granularity full
+   --recompute-method uniform
+   --recompute-num-layers 1
+
+   # Batch size settings
+   # Note: --use-dynamic-batch-size is not supported with --qkv-format bshd
+   --micro-batch-size 1
+)
+
+GRPO_ARGS=(
+   --advantage-estimator grpo
+   # --use-kl-loss
+   --kl-loss-coef 0.00
+   --kl-loss-type low_var_kl
+   --kl-coef 0.00
+   --entropy-coef 0.00
+   --eps-clip 0.2
+   --eps-clip-high 0.28
+)
+
+OPTIMIZER_ARGS=(
+   --optimizer adam
+   --lr 1e-6
+   --lr-decay-style constant
+   --weight-decay 0.1
+   --adam-beta1 0.9
+   --adam-beta2 0.98
+   # CPU offload optimizer states (fp32 master weights + Adam moments) to free ~30GB GPU memory
+   --optimizer-cpu-offload
+   --overlap-cpu-optimizer-d2h-h2d
+   --use-precision-aware-optimizer
+)
+
+SGLANG_ARGS=(
+   # TP size for sglang inference engine
+   --rollout-num-gpus-per-engine 4
+   --sglang-dtype bfloat16
+   --sglang-decode-log-interval 1000
+   --sglang-mem-fraction-static 0.70
+)
+
+WANDB_ARGS=(
+   --use-wandb
+   --wandb-project miles-mgt-oss
+   --wandb-group "20b-bf16"
+   --wandb-key ${WANDB_API_KEY}
+)
+
+MISC_ARGS=(
+   # default dropout in megatron is 0.1
+   --attention-dropout 0.0
+   --hidden-dropout 0.0
+   # Sink attention (sliding window + learnable softmax) in TE only supports BSHD/SBHD, not THD.
+   # Must use --qkv-format bshd for the fused backend to work with this model's attention pattern.
+   --qkv-format bshd
+   --attention-backend fused
+)
+
+
+# Set environment for Megatron
+export PYTHONPATH="/root/Megatron-LM/:$PYTHONPATH"
+export CUDA_DEVICE_MAX_CONNECTIONS=1
+
+python3 train.py \
+   --actor-num-nodes 1 \
+   --actor-num-gpus-per-node 8 \
+   --colocate \
+   --train-backend megatron \
+   ${MODEL_ARGS[@]} \
+   ${CKPT_ARGS[@]} \
+   ${ROLLOUT_ARGS[@]} \
+   ${OPTIMIZER_ARGS[@]} \
+   ${GRPO_ARGS[@]} \
+   ${WANDB_ARGS[@]} \
+   ${PERF_ARGS[@]} \
+   ${SGLANG_ARGS[@]} \
+   ${MISC_ARGS[@]}

--- a/scripts/run-gpt-oss-20b.sh
+++ b/scripts/run-gpt-oss-20b.sh
@@ -20,15 +20,18 @@ export HF_HOME=/workspace/hf_cache
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 source "${SCRIPT_DIR}/models/gpt-oss-20b.sh"
 
+BASE_DIR=/root/shared
+
 CKPT_ARGS=(
-   --hf-checkpoint /root/shared/gpt-oss-20b-BF16
+   --hf-checkpoint $BASE_DIR/gpt-oss-20b
+   # --hf-checkpoint $BASE_DIR/gpt-oss-20b-BF16
    --megatron-to-hf-mode bridge
-#    --save /root/shared/gpt-oss-20b-BF16
-#    --save-interval 50
+   # --save $BASE_DIR/gpt-oss-20b-BF16
+   # --save-interval 50
 )
 
 ROLLOUT_ARGS=(
-   --prompt-data /root/shared/dapo-math-17k/dapo-math-17k.jsonl
+   --prompt-data $BASE_DIR/dapo-math-17k/dapo-math-17k.jsonl
    --input-key prompt
    --label-key label
    --apply-chat-template
@@ -65,10 +68,11 @@ PERF_ARGS=(
 
 GRPO_ARGS=(
    --advantage-estimator grpo
+   # TODO: need gpt oss ckpt conversion.
    # --use-kl-loss
-   --kl-loss-coef 0.00
-   --kl-loss-type low_var_kl
-   --kl-coef 0.00
+   # --kl-loss-coef 0.00
+   # --kl-loss-type low_var_kl
+   # --kl-coef 0.00
    --entropy-coef 0.00
    --eps-clip 0.2
    --eps-clip-high 0.28
@@ -96,10 +100,10 @@ SGLANG_ARGS=(
 )
 
 WANDB_ARGS=(
-   --use-wandb
-   --wandb-project miles-mgt-oss
-   --wandb-group "20b-bf16"
-   --wandb-key ${WANDB_API_KEY}
+   # --use-wandb
+   # --wandb-project miles-gpt-oss
+   # --wandb-group "20b-bf16"
+   # --wandb-key ${WANDB_API_KEY}
 )
 
 MISC_ARGS=(


### PR DESCRIPTION
Exists:
- SGLang full gpt-oss inference support
- Megatron gpt-oss training support (bf16, mxfp4)

Steps:
- [ ] 20b-bf16 https://github.com/radixark/miles/pull/590
- [ ] 20b-fp4 acc verify. 
  - [ ] fp4 weight upd

Will no cover in this PR:
- fp4 ckpt conversion. Which affect:
  - Ckpt load/save. Current mbridge does not support native low precision ckpt conversion. Using Megeatron-Bridge cannot do ckpt conversion directly.
  - KL loss.
- Need further investigate Megeatron-Bridge.
