### PR TITLE
[WIP, not validated] fix: initialize grad_norm to avoid UnboundLocalError with FP16

### DIFF
--- a/miles/backends/megatron_utils/model.py
+++ b/miles/backends/megatron_utils/model.py
@@ -423,6 +423,7 @@ def train_one_step(
     )
 
     valid_step = True
+    grad_norm = float("nan")  # default for skipped steps (e.g., inf gradients in FP16)
     if not getattr(args, "check_for_nan_in_loss_and_grad", True):
         found_inf_flag = optimizer.prepare_grads()
         if found_inf_flag:


### PR DESCRIPTION
## Summary
- Fix `UnboundLocalError: cannot access local variable 'grad_norm'` when using FP16 mixed precision training
- When `found_inf_flag=True` (gradient overflow), `grad_norm` was never initialized before being returned
- Initialize `grad_norm` to `float("nan")` as a sentinel value for skipped steps

## Root Cause
FP16 has a narrow dynamic range (max ~65,504) compared to BF16 (max ~3.4×10³⁸). During RL training with large advantages or policy ratios, gradients can overflow in FP16, triggering `found_inf_flag=True`. The existing code path didn't initialize `grad_norm` in this case.

## Context
Related to user report about FP16 mixed precision for reducing KL divergence between inference and training log-probs (ref: https://arxiv.org/html/2510.26788v1).

## Test plan
- [ ] Run FP16 training with `--fp16` flag
- [ ] Verify no UnboundLocalError when gradient overflow occurs
- [ ] Verify grad_norm is logged as NaN for skipped steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)