### PR TITLE
[bug fix] Install flashinfer_python>=0.6.2 in Dockerfile.dev

### DIFF
--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -124,6 +124,7 @@ RUN cd /sgl-workspace/sglang && \
     pip install -e "python[all]" --no-deps
 
 # Current sglang requires "flashinfer_python>=0.6.2"
+RUN pip uninstall flashinfer-jit-cache -y
 RUN pip install "flashinfer_python>=0.6.2" --no-deps
 
 # ====================================== Install main package ============================================


### PR DESCRIPTION
Current sglanf requires flashinfer_python>=0.6.2, or it will fail when you launch the training.