### PR TITLE
[CI] Loose step 0 actor ref logp check threshold when ref model bypass r3 replay

### DIFF
--- a/miles/backends/training_utils/log_utils.py
+++ b/miles/backends/training_utils/log_utils.py
@@ -173,8 +173,7 @@ def log_rollout_data(
             ):
                 # When R3 (rollout routing replay) is enabled, ref model does not use R3
                 # so log_probs and ref_log_probs may diverge; use a relaxed tolerance.
-                r3_enabled = getattr(args, "use_rollout_routing_replay", False)
-                abs_tol = 0.03 if r3_enabled else 1e-9
+                abs_tol = 1e-5 if args.use_rollout_routing_replay else 1e-9
                 assert isclose(
                     reduced_log_dict["rollout/log_probs"], reduced_log_dict["rollout/ref_log_probs"], abs_tol=abs_tol
                 ), f"CI check failed: log_probs ({reduced_log_dict['rollout/log_probs']}) != ref_log_probs ({reduced_log_dict['rollout/ref_log_probs']})"


### PR DESCRIPTION
Bypass r3 replay for ref model is correct, but it will cause step 0 actor == ref logprobs to fail. This PR fix the ci test.
