### PR TITLE
[fix] create parallel_state before debug_rollout_only early return

### DIFF
--- a/miles/backends/megatron_utils/actor.py
+++ b/miles/backends/megatron_utils/actor.py
@@ -82,8 +82,8 @@ class MegatronTrainRayActor(TrainRayActor):
                 logger.info(f"Set torch_memory_saver.memory_margin_bytes to {x}")
                 torch_memory_saver.memory_margin_bytes = x
 
-        self.parallel_state = create_megatron_parallel_state(model=None)
         if self.args.debug_rollout_only:
+            self.parallel_state = create_megatron_parallel_state(model=None)
             return 0
 
         if role == "critic":
@@ -99,6 +99,8 @@ class MegatronTrainRayActor(TrainRayActor):
         (self.model, self.optimizer, self.opt_param_scheduler, loaded_rollout_id) = initialize_model_and_optimizer(
             args, role
         )
+
+        self.parallel_state = create_megatron_parallel_state(model=self.model)
 
         if role == "critic":
             if self.args.offload_train:


### PR DESCRIPTION
debug_rollout_only will crash if we do not construct parallel_state