### PR TITLE
[fix] fix R3 padding handling

### DIFF
--- a/miles/utils/replay_base.py
+++ b/miles/utils/replay_base.py
@@ -91,12 +91,13 @@ class BaseReplayManager:
 
             if self.enable_check_replay_result:
                 self.check_replay_result(old_topk_fn, scores, topk, top_indices, *args, **kwargs)
-            
+
             padding_mask = top_indices == -1
             if padding_mask.any():
-                top_indices[padding_mask] = torch.arange(
-                    padding_mask.sum(), device=top_indices.device, dtype=top_indices.dtype
-                ) % scores.shape[1]
+                top_indices[padding_mask] = (
+                    torch.arange(padding_mask.sum(), device=top_indices.device, dtype=top_indices.dtype)
+                    % scores.shape[1]
+                )
 
             if return_probs:
                 return scores.gather(1, top_indices), top_indices


### PR DESCRIPTION
The previous version used incorrect padding handling to skip sequence w/ paddings, rather than the padding tokens, which causes R3 to not be fully functional in training. Fix by using a token padding mask and fill with the range routing indices value.

Thanks @zianglih for pointing out the issue