### PR TITLE
[GLM-5] upgrade deepgemm to include recent fix

### DIFF
--- a/docker/glm5/Dockerfile_glm5
+++ b/docker/glm5/Dockerfile_glm5
@@ -1,13 +1,13 @@
-ARG SGLANG_IMAGE_TAG=nightly-dev-20260107-dce8b060
+ARG SGLANG_IMAGE_TAG=v0.5.9
 FROM slimerl/sglang:${SGLANG_IMAGE_TAG} AS sglang
 
 # ======================================== Arguments =============================================
 
-ARG SGLANG_BRANCH=sglang-slime-patched
+ARG SGLANG_BRANCH=slime-patched-260303
 ARG SGLANG_COMMIT=""
 
-ARG PATCH_VERSION=dev
-ARG MEGATRON_COMMIT=3714d81d418c9f1bca4594fc35f9e8289f652862
+ARG MEGATRON_REPO=radixark/Megatron-LM
+ARG MEGATRON_BRANCH=miles-20260218
 
 ARG ENABLE_CUDA_13=0
 
@@ -59,8 +59,8 @@ RUN if [ "${ENABLE_CUDA_13}" = "1" ]; then \
 # apex
 RUN pip install /tmp/wheels/apex-*.whl
 
-RUN git clone https://github.com/NVIDIA/Megatron-LM.git --recursive && \
-    cd Megatron-LM && git checkout ${MEGATRON_COMMIT} && \
+RUN git clone https://github.com/${MEGATRON_REPO}.git --recursive -b ${MEGATRON_BRANCH} Megatron-LM && \
+    cd Megatron-LM && \
     pip install -e .
 
 RUN pip install git+https://github.com/fzyzcjy/torch_memory_saver.git@dc6876905830430b5054325fa4211ff302169c6b --no-cache-dir --force-reinstall
@@ -84,16 +84,6 @@ RUN rm -rf /root/.cache/pip /root/flash-attention
 
 # ====================================== Patches ============================================
 
-COPY docker/patch/${PATCH_VERSION}/megatron.patch /root/Megatron-LM/
-RUN cd Megatron-LM && \
-    git update-index --refresh && \
-    git apply megatron.patch --3way && \
-    if grep -R -n '^<<<<<<< ' .; then \
-      echo "Patch failed to apply cleanly. Please resolve conflicts." && \
-      exit 1; \
-    fi && \
-    rm megatron.patch
-
 COPY docker/glm5/transformers.patch /tmp/transformers.patch
 RUN cd $(python -c "import transformers, os; print(os.path.dirname(os.path.dirname(transformers.__file__)))") && \
     patch -p2 < /tmp/transformers.patch && \
@@ -111,11 +101,14 @@ RUN cd /sgl-workspace/sglang && \
 
 # ====================================== Install main package ============================================
 
-ARG MILES_COMMIT=glm5
+ARG MILES_COMMIT=main
 RUN git clone https://github.com/radixark/miles.git /root/miles && \
     cd /root/miles && \
     git checkout ${MILES_COMMIT} && \
     pip install -e . --no-deps
+  
+# required for older megatron (miles-20260218)
+ENV DEPRECATED_MEGATRON_COMPATIBLE=1
 
 # int4_qat
 RUN pip install /tmp/wheels/fake_int4_quant_cuda-*.whl

--- a/docker/glm5/Dockerfile_glm5
+++ b/docker/glm5/Dockerfile_glm5
@@ -13,6 +13,7 @@ ARG ENABLE_CUDA_13=0
 
 ARG WHEELS_REPO=yueming-yuan/miles-wheels
 ARG WHEELS_TAG=cu129-x86_64
+ARG SGL_KERNEL_WHEELS_TAG=sgl-kernel-glm5-cu129-x86_64
 
 # ======================================== Setup =============================================
 
@@ -98,6 +99,15 @@ RUN cd /sgl-workspace/sglang && \
       git checkout FETCH_HEAD; \
     fi && \
     pip install -e "python[all]" --no-deps
+
+# sgl-kernel (pre-built wheel with upgraded deepgemm)
+RUN mkdir -p /tmp/sgl-kernel-wheels && \
+    curl -sL "https://api.github.com/repos/${WHEELS_REPO}/releases/tags/${SGL_KERNEL_WHEELS_TAG}" \
+    | python3 -c "import sys, json, subprocess; \
+[subprocess.run(['curl', '-fSL', '-o', '/tmp/sgl-kernel-wheels/' + a['name'], a['browser_download_url']], check=True) \
+ for a in json.load(sys.stdin)['assets'] if a['name'].endswith('.whl')]" && \
+    pip install /tmp/sgl-kernel-wheels/sgl_kernel-*.whl --force-reinstall --no-deps && \
+    rm -rf /tmp/sgl-kernel-wheels
 
 # ====================================== Install main package ============================================
 

--- a/tests/e2e/megatron/test_glm5_744b_a40b_4layer.py
+++ b/tests/e2e/megatron/test_glm5_744b_a40b_4layer.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import miles.utils.external_utils.command_utils as U
 
 
-USE_FP8_ROLLOUT = U.get_bool_env_var("MILES_TEST_USE_FP8_ROLLOUT", "false")
+USE_FP8_ROLLOUT = U.get_bool_env_var("MILES_TEST_USE_FP8_ROLLOUT", "true")
 
 MODEL_NAME = "GLM-5_4layer"
 MODEL_TYPE = "glm5-744B-A40B_4layer"


### PR DESCRIPTION
the `sgl-kernel-glm5-cu129-x86_64` wheel includes the newer DeepGEMM commit, change to
https://github.com/sgl-project/DeepGEMM/commit/fc08e5775a5db960690a41248655168c55bef228
