### PR TITLE
Bump sglang to v0.5.9

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,7 +11,7 @@ FROM lmsysorg/sglang:${SGLANG_IMAGE_TAG} AS sglang
 
 # ======================================== Arguments =============================================
 
-ARG SGLANG_BRANCH=sglang-miles-v0.5.9
+ARG SGLANG_BRANCH=sglang-miles
 ARG SGLANG_COMMIT=""
 
 ARG MEGATRON_REPO=radixark/Megatron-LM


### PR DESCRIPTION
ci-sglang-pr: sglang-miles-v0.5.9

## Summary
- Update sglang base docker image from `v0.5.8.post1` to `v0.5.9`
- Update sglang branch from `sglang-miles` to `sglang-miles-v0.5.9`
- Update cu130 arm64 image tag in comment

The `sglang-miles-v0.5.9` branch rebases all sglang-miles custom commits onto sglang v0.5.9:
1. [1/8] True on-policy training support for FSDP2 (#18639)
2. [2/8] R3 (Rollout Routing Replay) DeepEP and MTP support (#18642)
3. [3/8] Support INT4 QAT for RL (#18565)
4. [4/8] PD disaggregation for RL (#18646)
5. [5/8] MTP related fix (#18647)
6. [6/8] tmp fix for vlm training: use legacy_load_mm_data for qwen-vl (#18781)
7. [7/8] Enhance lora_update_weight_from_tensor for RL training (#19336)
8. [8/8] support better token id return for TITO (#19731)
