### PR TITLE
Add GDPO advantage estimator

### DIFF
--- a/miles/backends/training_utils/loss.py
+++ b/miles/backends/training_utils/loss.py
@@ -329,7 +329,7 @@ def compute_advantages_and_returns(args: Namespace, parallel_state: ParallelStat
             for i in range(len(log_probs))
         ]
 
-    if args.advantage_estimator in ["grpo", "gspo"]:
+    if args.advantage_estimator in ["grpo", "gspo", "gdpo"]:
         rewards = torch.tensor(rewards, dtype=torch.float32, device=kl[0].device)
         returns = get_grpo_returns(rewards, kl)
         # TODO: is the copy necessary?

--- a/miles/ray/rollout.py
+++ b/miles/ray/rollout.py
@@ -329,6 +329,9 @@ class RolloutManager:
         if self.custom_reward_post_process_func is not None:
             return self.custom_reward_post_process_func(self.args, samples)
 
+        if self.args.advantage_estimator == "gdpo":
+            return self._post_process_rewards_gdpo(samples)
+
         raw_rewards = [sample.get_reward_value(self.args) for sample in samples]
         if (
             self.args.advantage_estimator in ["grpo", "gspo", "reinforce_plus_plus_baseline"]
@@ -351,6 +354,49 @@ class RolloutManager:
             return raw_rewards, rewards.flatten().tolist()
 
         return raw_rewards, raw_rewards
+
+    def _post_process_rewards_gdpo(self, samples: list[Sample] | list[list[Sample]]):
+        """GDPO: normalize each reward dimension independently within groups, then combine with weights.
+
+        Instead of sum-then-normalize (GRPO), we normalize-then-sum (GDPO).
+        This prevents one reward dimension from dominating the learning signal.
+        """
+        args = self.args
+        reward_keys = args.gdpo_reward_keys
+        reward_weights = args.gdpo_reward_weights
+        n_samples = args.n_samples_per_prompt
+
+        # Extract raw rewards (sum of weighted raw values for logging)
+        raw_rewards = []
+        for sample in samples:
+            r = sum(w * sample.reward[k] for k, w in zip(reward_keys, reward_weights))
+            raw_rewards.append(r)
+
+        # Per-dimension group normalization, then weighted sum
+        num_samples = len(samples)
+        combined = torch.zeros(num_samples, dtype=torch.float)
+
+        for key, weight in zip(reward_keys, reward_weights):
+            dim_rewards = torch.tensor([sample.reward[key] for sample in samples], dtype=torch.float)
+
+            if args.rewards_normalization:
+                if num_samples == n_samples * args.rollout_batch_size:
+                    dim_rewards = dim_rewards.reshape(-1, n_samples)
+                else:
+                    dim_rewards = dim_rewards.view(-1, dim_rewards.shape[-1])
+
+                mean = dim_rewards.mean(dim=-1, keepdim=True)
+                dim_rewards = dim_rewards - mean
+
+                # Always std-normalize per dimension in GDPO (core algorithm)
+                std = dim_rewards.std(dim=-1, keepdim=True)
+                dim_rewards = dim_rewards / (std + 1e-6)
+
+                dim_rewards = dim_rewards.flatten()
+
+            combined += weight * dim_rewards
+
+        return raw_rewards, combined.tolist()
 
     def _convert_samples_to_train_data(self, samples: list[Sample] | list[list[Sample]]):
         """

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -803,6 +803,7 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 choices=[
                     "grpo",
                     "gspo",
+                    "gdpo",
                     "reinforce_plus_plus",
                     "reinforce_plus_plus_baseline",
                     "ppo",
@@ -1235,6 +1236,28 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 type=str,
                 default=None,
                 help="The eval variant for --reward-key",
+            )
+            parser.add_argument(
+                "--gdpo-reward-keys",
+                type=str,
+                nargs="+",
+                default=None,
+                help=(
+                    "Reward keys for GDPO per-dimension normalization. "
+                    "Each key extracts a reward dimension from the reward dict. "
+                    "Required when --advantage-estimator is gdpo."
+                ),
+            )
+            parser.add_argument(
+                "--gdpo-reward-weights",
+                type=float,
+                nargs="+",
+                default=None,
+                help=(
+                    "Weights for each GDPO reward dimension. "
+                    "Must match the length of --gdpo-reward-keys. "
+                    "Defaults to uniform weights (1.0 for each dimension)."
+                ),
             )
             parser.add_argument(
                 "--group-rm", action="store_true", default=False, help="Whether to do rm on a whole group."
@@ -1774,6 +1797,15 @@ def miles_validate_args(args):
     if args.n_samples_per_prompt == 1:
         args.grpo_std_normalization = False
         logger.info("n_samples_per_prompt is set to 1, grpo_std_normalization will be set to False.")
+
+    if args.advantage_estimator == "gdpo":
+        assert args.gdpo_reward_keys is not None, "--gdpo-reward-keys is required when using gdpo advantage estimator"
+        if args.gdpo_reward_weights is None:
+            args.gdpo_reward_weights = [1.0] * len(args.gdpo_reward_keys)
+        assert len(args.gdpo_reward_weights) == len(args.gdpo_reward_keys), (
+            f"--gdpo-reward-weights length ({len(args.gdpo_reward_weights)}) must match "
+            f"--gdpo-reward-keys length ({len(args.gdpo_reward_keys)})"
+        )
 
     if args.over_sampling_batch_size is None:
         args.over_sampling_batch_size = args.rollout_batch_size


### PR DESCRIPTION
## Summary

- Add `--advantage-estimator gdpo` for [GDPO (Group Reward-Decoupled Normalization Policy Optimization)](https://arxiv.org/pdf/2601.05242)
- GDPO normalizes each reward dimension independently within groups before combining with weights, preventing any single reward from dominating the learning signal
- Supports arbitrary number of reward dimensions via `--gdpo-reward-keys` and optional `--gdpo-reward-weights`

### Key difference from GRPO

```python
# GRPO: sum then normalize
r_sum = w1*r1 + w2*r2
advantage = (r_sum - mean) / std

# GDPO: normalize then sum
a1 = (r1 - mean(r1)) / std(r1)
a2 = (r2 - mean(r2)) / std(r2)
advantage = w1*a1 + w2*a2
```

### Usage

```bash
--advantage-estimator gdpo \
--gdpo-reward-keys r_correct r_length r_format \
--gdpo-reward-weights 1.0 1.0 0.5
```

Reward function should return a dict with the specified keys. Works with all existing backends (FSDP, Megatron), parallelism strategies, and the existing `--normalize-advantages` batch whitening.

### Reference
- Paper: https://arxiv.org/pdf/2601.05242
- NVlabs reference impl: https://github.com/NVlabs/GDPO

Closes #495, relates to #494

## Test plan
- [ ] Unit test: verify per-dimension normalization produces correct advantages
- [ ] E2E test: run GDPO with multi-reward on a small model (e.g., Qwen-0.5B)
- [ ] Verify backward compatibility: single-reward GDPO equivalent to GRPO with std normalization

🤖 Generated with [Claude Code](https://claude.com/claude-code)