### PR TITLE
Add GDPO advantage estimator (per-dimension reward normalization)

### DIFF
--- a/miles/backends/training_utils/loss.py
+++ b/miles/backends/training_utils/loss.py
@@ -329,7 +329,7 @@ def compute_advantages_and_returns(args: Namespace, parallel_state: ParallelStat
             for i in range(len(log_probs))
         ]
 
-    if args.advantage_estimator in ["grpo", "gspo"]:
+    if args.advantage_estimator in ["grpo", "gspo", "gdpo"]:
         rewards = torch.tensor(rewards, dtype=torch.float32, device=kl[0].device)
         returns = get_grpo_returns(rewards, kl)
         # TODO: is the copy necessary?

--- a/miles/ray/rollout.py
+++ b/miles/ray/rollout.py
@@ -329,6 +329,9 @@ class RolloutManager:
         if self.custom_reward_post_process_func is not None:
             return self.custom_reward_post_process_func(self.args, samples)
 
+        if self.args.advantage_estimator == "gdpo":
+            return self._post_process_rewards_gdpo(samples)
+
         raw_rewards = [sample.get_reward_value(self.args) for sample in samples]
         if (
             self.args.advantage_estimator in ["grpo", "gspo", "reinforce_plus_plus_baseline"]
@@ -351,6 +354,46 @@ class RolloutManager:
             return raw_rewards, rewards.flatten().tolist()
 
         return raw_rewards, raw_rewards
+
+    def _post_process_rewards_gdpo(self, samples: list[Sample] | list[list[Sample]]):
+        """GDPO: normalize each reward dimension independently within groups, then combine with weights.
+
+        Instead of sum-then-normalize (GRPO), we normalize-then-sum (GDPO).
+        This prevents one reward dimension from dominating the learning signal.
+        """
+        args = self.args
+        reward_keys = args.gdpo_reward_keys
+        reward_weights = args.gdpo_reward_weights
+        n_samples = args.n_samples_per_prompt
+
+        # Extract raw rewards (sum of weighted raw values for logging)
+        raw_rewards = []
+        for sample in samples:
+            r = sum(w * sample.reward[k] for k, w in zip(reward_keys, reward_weights))
+            raw_rewards.append(r)
+
+        # Per-dimension group normalization, then weighted sum
+        num_samples = len(samples)
+        combined = torch.zeros(num_samples, dtype=torch.float)
+
+        for key, weight in zip(reward_keys, reward_weights):
+            dim_rewards = torch.tensor([sample.reward[key] for sample in samples], dtype=torch.float)
+            dim_rewards = torch.nan_to_num(dim_rewards)
+
+            # Per-dimension group normalization is the core of GDPO and should always be performed.
+            dim_rewards = dim_rewards.view(-1, n_samples)
+
+            mean = dim_rewards.mean(dim=-1, keepdim=True)
+            dim_rewards = dim_rewards - mean
+
+            std = dim_rewards.std(dim=-1, keepdim=True)
+            dim_rewards = dim_rewards / (std + 1e-6)
+
+            dim_rewards = dim_rewards.flatten()
+
+            combined += weight * dim_rewards
+
+        return raw_rewards, combined.tolist()
 
     def _convert_samples_to_train_data(self, samples: list[Sample] | list[list[Sample]]):
         """

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -803,6 +803,7 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 choices=[
                     "grpo",
                     "gspo",
+                    "gdpo",
                     "reinforce_plus_plus",
                     "reinforce_plus_plus_baseline",
                     "ppo",
@@ -1235,6 +1236,28 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 type=str,
                 default=None,
                 help="The eval variant for --reward-key",
+            )
+            parser.add_argument(
+                "--gdpo-reward-keys",
+                type=str,
+                nargs="+",
+                default=None,
+                help=(
+                    "Reward keys for GDPO per-dimension normalization. "
+                    "Each key extracts a reward dimension from the reward dict. "
+                    "Required when --advantage-estimator is gdpo."
+                ),
+            )
+            parser.add_argument(
+                "--gdpo-reward-weights",
+                type=float,
+                nargs="+",
+                default=None,
+                help=(
+                    "Weights for each GDPO reward dimension. "
+                    "Must match the length of --gdpo-reward-keys. "
+                    "Defaults to uniform weights (1.0 for each dimension)."
+                ),
             )
             parser.add_argument(
                 "--group-rm", action="store_true", default=False, help="Whether to do rm on a whole group."
@@ -1774,6 +1797,22 @@ def miles_validate_args(args):
     if args.n_samples_per_prompt == 1:
         args.grpo_std_normalization = False
         logger.info("n_samples_per_prompt is set to 1, grpo_std_normalization will be set to False.")
+
+    if args.advantage_estimator == "gdpo":
+        if args.gdpo_reward_keys is None:
+            raise ValueError("--gdpo-reward-keys is required when using gdpo advantage estimator")
+        if args.gdpo_reward_weights is None:
+            args.gdpo_reward_weights = [1.0] * len(args.gdpo_reward_keys)
+        if len(args.gdpo_reward_weights) != len(args.gdpo_reward_keys):
+            raise ValueError(
+                f"--gdpo-reward-weights length ({len(args.gdpo_reward_weights)}) must match "
+                f"--gdpo-reward-keys length ({len(args.gdpo_reward_keys)})"
+            )
+        # GDPO requires batch-wise normalization after per-dimension group normalization
+        # (consistent with NVlabs reference implementation)
+        if not args.normalize_advantages:
+            args.normalize_advantages = True
+            logger.info("GDPO: enabling normalize_advantages for batch-wise normalization.")
 
     if args.over_sampling_batch_size is None:
         args.over_sampling_batch_size = args.rollout_batch_size


### PR DESCRIPTION
## Summary

Implements GDPO (Group Reward-Decoupled Normalization Policy Optimization) from [arXiv:2601.05242](https://arxiv.org/pdf/2601.05242), referenced from [NVlabs/GDPO](https://github.com/NVlabs/GDPO).

- **Core idea**: normalize each reward dimension independently within groups before combining (normalize-then-sum), instead of GRPO's sum-then-normalize approach
- **3 files changed, 83 insertions**: `rollout.py` (GDPO normalization logic), `arguments.py` (CLI args + validation), `loss.py` (1-line routing)
- **Backward compatible**: single-reward GDPO produces identical results to GRPO
- **Backend-agnostic**: only touches reward normalization (before backend code) and shared `compute_advantages_and_returns`

### New CLI args
- `--advantage-estimator gdpo`
- `--gdpo-reward-keys r_correct r_length` (extract dimensions from reward dict)
- `--gdpo-reward-weights 1.0 1.0` (optional, defaults to uniform)

## Test plan

- [x] Unit tests: 6/6 passed (GDPO vs GRPO difference, per-dim normalization, weights, NaN handling, backward compat, 3+ dimensions)
- [x] FSDP E2E: 5 rollouts + 5 training steps on DeepSeek-R1-Distill-Qwen-1.5B (4x L40S), no OOM/crashes
  - `rollout/rewards ~ 0`: per-dim normalization centering confirmed
  - `rollout/advantages > 0`: batch whitening working
  - `rollout/raw_reward` increasing: gradient flow confirmed
- [x] Megatron E2E: not tested (requires `megatron.training` + Apex + Transformer Engine). Code path is shared with FSDP.
- [ ] Full paper reproduction on DeepScaleR-Preview with AIME-2024 eval still in progress

Closes #495