### PR TITLE
fix: use float64 and epsilon threshold in dynamic filter to avoid fp precision error

### DIFF
--- a/miles/rollout/filter_hub/dynamic_sampling_filters.py
+++ b/miles/rollout/filter_hub/dynamic_sampling_filters.py
@@ -8,7 +8,7 @@ __all__ = ["check_reward_nonzero_std"]
 
 def check_reward_nonzero_std(args, samples: list[Sample], **kwargs):
     rewards = [sample.get_reward_value(args) for sample in samples]
-    keep = torch.tensor(rewards, dtype=torch.float).std() > 0.0
+    keep = torch.tensor(rewards, dtype=torch.float64).std() > 1e-8
     return DynamicFilterOutput(
         keep=keep,
         reason=None if keep else f"zero_std_{round(rewards[0], 1)}",


### PR DESCRIPTION
Fixes #570 - Use torch.float64 and epsilon (1e-8) threshold in check_reward_nonzero_std to avoid floating-point precision bugs.