### PR TITLE
fix: copy numpy arrays from np.frombuffer to fix R3 read-only tensor warning

### DIFF
--- a/miles/rollout/generate_utils/generate_endpoint_utils.py
+++ b/miles/rollout/generate_utils/generate_endpoint_utils.py
@@ -106,5 +106,7 @@ def _get_rollout_topk_from_response(args, output, sample, key):
     info = output["meta_info"].get(key)
     if info is None:
         return None
-    x = np.frombuffer(pybase64.b64decode(info.encode("ascii")), dtype=np.int32)
+    # Use .copy() because np.frombuffer returns a read-only array,
+    # which causes warnings/undefined behavior in torch.from_numpy later.
+    x = np.frombuffer(pybase64.b64decode(info.encode("ascii")), dtype=np.int32).copy()
     return x.reshape(len(sample.tokens) - 1, args.num_layers, args.moe_router_topk)

--- a/miles/rollout/sglang_rollout.py
+++ b/miles/rollout/sglang_rollout.py
@@ -178,10 +178,12 @@ async def generate(args: Namespace, sample: Sample, sampling_params: dict[str, A
         sample.rollout_log_probs += new_response_log_probs
 
     if "routed_experts" in output["meta_info"]:
+        # Use .copy() because np.frombuffer returns a read-only array,
+        # which causes warnings/undefined behavior in torch.from_numpy later.
         sample.rollout_routed_experts = np.frombuffer(
             pybase64.b64decode(output["meta_info"]["routed_experts"].encode("ascii")),
             dtype=np.int32,
-        ).reshape(
+        ).copy().reshape(
             len(sample.tokens) - 1,
             args.num_layers,
             args.moe_router_topk,


### PR DESCRIPTION
Fixes #599 (partial) - np.frombuffer() returns read-only arrays that cause PyTorch warnings and potential undefined behavior when converted via torch.from_numpy(). Added .copy() in both generate_endpoint_utils.py and sglang_rollout.py.