### PR TITLE
chore: migrate ruff config to lint section and enable W, I rules

### DIFF
--- a/miles/backends/fsdp_utils/__init__.py
+++ b/miles/backends/fsdp_utils/__init__.py
@@ -1,6 +1,5 @@
 import logging
 
-
 try:
     _TORCH_MEMORY_SAVER_AVAILABLE = True
 except ImportError:

--- a/miles/backends/fsdp_utils/update_weight_utils.py
+++ b/miles/backends/fsdp_utils/update_weight_utils.py
@@ -19,7 +19,6 @@ from sglang.srt.utils import MultiprocessingSerializer
 
 from miles.utils.distributed_utils import init_process_group
 
-
 try:
     from sglang.srt.weight_sync.tensor_bucket import FlattenedTensorBucket  # type: ignore[import]
 except ImportError:

--- a/miles/backends/megatron_utils/kernels/int4_qat/setup.py
+++ b/miles/backends/megatron_utils/kernels/int4_qat/setup.py
@@ -1,7 +1,8 @@
 import os
+
+import torch
 from setuptools import setup
 from torch.utils.cpp_extension import BuildExtension, CUDAExtension
-import torch
 
 # Get CUDA arch list
 arch_list = []

--- a/miles/backends/megatron_utils/megatron_to_hf/glm4.py
+++ b/miles/backends/megatron_utils/megatron_to_hf/glm4.py
@@ -1,4 +1,5 @@
 import re
+
 import torch
 
 

--- a/miles/backends/megatron_utils/megatron_to_hf/llama.py
+++ b/miles/backends/megatron_utils/megatron_to_hf/llama.py
@@ -1,4 +1,5 @@
 import re
+
 import torch
 
 

--- a/miles/backends/megatron_utils/megatron_to_hf/mimo.py
+++ b/miles/backends/megatron_utils/megatron_to_hf/mimo.py
@@ -1,5 +1,7 @@
 import re
+
 import torch
+
 from .qwen2 import convert_qwen2_to_hf
 
 

--- a/miles/backends/megatron_utils/megatron_to_hf/qwen2.py
+++ b/miles/backends/megatron_utils/megatron_to_hf/qwen2.py
@@ -1,4 +1,5 @@
 import re
+
 import torch
 
 

--- a/miles/backends/sglang_utils/arguments.py
+++ b/miles/backends/sglang_utils/arguments.py
@@ -1,4 +1,5 @@
 from sglang.srt.server_args import ServerArgs
+
 from miles.utils.http_utils import _wrap_ipv6
 
 

--- a/miles/backends/training_utils/parallel.py
+++ b/miles/backends/training_utils/parallel.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+
 import torch.distributed as dist
 
 

--- a/miles/ray/utils.py
+++ b/miles/ray/utils.py
@@ -3,8 +3,8 @@ import os
 
 import ray
 import torch
-from miles.ray.ray_actor import RayActor
 
+from miles.ray.ray_actor import RayActor
 
 # Refer to
 # https://github.com/ray-project/ray/blob/161849364a784442cc659fb9780f1a6adee85fce/python/ray/_private/accelerators/nvidia_gpu.py#L95-L96

--- a/miles/utils/distributed_utils.py
+++ b/miles/utils/distributed_utils.py
@@ -13,7 +13,6 @@ from torch.distributed.distributed_c10d import (
     rendezvous,
 )
 
-
 GLOO_GROUP = None
 
 

--- a/miles/utils/health_monitor.py
+++ b/miles/utils/health_monitor.py
@@ -3,7 +3,6 @@ import threading
 
 import ray
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/miles/utils/ppo_utils.py
+++ b/miles/utils/ppo_utils.py
@@ -6,6 +6,7 @@ from argparse import Namespace
 import torch
 import torch.distributed as dist
 import torch.nn.functional as F
+
 from miles.backends.training_utils.parallel import ParallelState
 
 

--- a/miles/utils/tensorboard_utils.py
+++ b/miles/utils/tensorboard_utils.py
@@ -1,6 +1,7 @@
 import datetime
 import logging
 import os
+
 from miles.utils.misc import SingletonMeta
 
 try:

--- a/miles/utils/tracking_utils.py
+++ b/miles/utils/tracking_utils.py
@@ -1,4 +1,5 @@
 import wandb
+
 from miles.utils.tensorboard_utils import _TensorboardAdapter
 
 from . import wandb_utils

--- a/miles_plugins/mbridge/deepseek_v32.py
+++ b/miles_plugins/mbridge/deepseek_v32.py
@@ -1,5 +1,4 @@
 import torch
-
 from mbridge.core import register_model
 from mbridge.models import DeepseekV3Bridge
 

--- a/miles_plugins/mbridge/glm4.py
+++ b/miles_plugins/mbridge/glm4.py
@@ -1,6 +1,5 @@
-from megatron.core.models.gpt.gpt_layer_specs import get_gpt_layer_with_transformer_engine_spec
-
 from mbridge.core import LLMBridge, register_model
+from megatron.core.models.gpt.gpt_layer_specs import get_gpt_layer_with_transformer_engine_spec
 
 
 @register_model("glm4")

--- a/miles_plugins/mbridge/glm4moe_lite.py
+++ b/miles_plugins/mbridge/glm4moe_lite.py
@@ -1,8 +1,7 @@
 import torch
-from megatron.core.transformer.enums import AttnBackend
-
 from mbridge.core import register_model
 from mbridge.models import DeepseekV3Bridge
+from megatron.core.transformer.enums import AttnBackend
 
 
 @register_model("glm4_moe_lite")

--- a/miles_plugins/mbridge/mimo.py
+++ b/miles_plugins/mbridge/mimo.py
@@ -1,10 +1,9 @@
 # Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
 
 import torch
-from megatron.core.models.gpt.gpt_layer_specs import get_gpt_mtp_block_spec
-
 from mbridge.core import register_model
 from mbridge.models import Qwen2Bridge
+from megatron.core.models.gpt.gpt_layer_specs import get_gpt_mtp_block_spec
 
 
 @register_model("mimo")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,11 +24,15 @@ line_length = 119
 
 [tool.ruff]
 line-length = 320  # TODO
+
+[tool.ruff.lint]
 select = [
     "E",      # Pycodestyle Errors (Structural/Fundamental Errors like bad indentation)
     "F",      # Pyflakes (Core Errors: Unused imports, undefined names)
     "B",      # Flake8-Bugbear (Logic Bugs: Variable shadowing, dangerous default arguments)
     "UP",     # pyupgrade (Modernization and compatibility issues)
+    "W",      # Pycodestyle Warnings
+    "I",      # isort (Import sorting)
 ]
 ignore = [
     "E402", # module-import-not-at-top-of-file


### PR DESCRIPTION
## Related Issue
Closes #283

## Changes
1. **Migrated ruff config** from deprecated top-level \[tool.ruff]\ \select\/\ignore\ to \[tool.ruff.lint]\ section (fixes ruff deprecation warnings)
2. **Enabled \W\ (pycodestyle warnings)** rule set
3. **Enabled \I\ (isort)** rule set and auto-fixed 19 import sorting violations across the codebase

## Files Changed
- \pyproject.toml\: Config structure migration + new rules
- 19 source files: Auto-fixed import ordering via \uff check --select I --fix\

## Testing
- \uff check miles/ miles_plugins/\  All checks passed
- No functional code changes, only config migration and import reordering