### PR TITLE
fix: add barrier to reload_process_groups() to prevent NCCL race condition

### DIFF
--- a/miles/utils/reloadable_process_group.py
+++ b/miles/utils/reloadable_process_group.py
@@ -157,6 +157,14 @@ class ReloadableProcessGroup(torch.distributed.ProcessGroup):
             group = old_new_group(ranks=reloadable_group.group_info["ranks"], backend="nccl")
             reloadable_group.group = group
 
+        # Synchronize all ranks after reload to prevent race conditions
+        # where fast ranks start collective ops before slow ranks finish reloading
+        torch.cuda.synchronize()
+        from miles.utils.distributed_utils import get_gloo_group
+
+        dist.barrier(group=get_gloo_group())
+        logger.info(f"Process group reload complete and synchronized in pid {pid}")
+
     def rank(self) -> int:
         return self.group.rank()
 


### PR DESCRIPTION
## Related Issue
Fixes #384

## Problem
When training on multi-node setups (e.g. qwen-30b-a3b on two nodes), NCCL errors occur after ~1600 steps because:
1. Each rank independently reloads 45+ process groups via \
ew_group()\
2. There is no synchronization after all groups are reloaded
3. Fast ranks can start \ll_gather\ while slower ranks are still reloading
4. This causes NCCL timeout/deadlock

## Fix
Added \	orch.cuda.synchronize()\ and \dist.barrier(group=get_gloo_group())\ at the end of \ReloadableProcessGroup.reload_process_groups()\ to ensure all ranks complete their process group reload before any collective operations begin.

## Changes
- [miles/utils/reloadable_process_group.py](miles/utils/reloadable_process_group.py): Added synchronization barrier after process group reload loop