### PR TITLE
refactor: improve RolloutDataSource.get_samples readability and robustness

### DIFF
--- a/miles/rollout/data_source.py
+++ b/miles/rollout/data_source.py
@@ -81,22 +81,30 @@ class RolloutDataSource(DataSource):
         else:
             self.dataset = None
 
-    def get_samples(self, num_samples):
-        # TODO further improve code
-        if self.dataset is not None:
-            if self.sample_offset + num_samples <= len(self.dataset):
-                prompt_samples = self.dataset.samples[self.sample_offset : self.sample_offset + num_samples]
-                self.sample_offset += num_samples
-            else:
-                prompt_samples = self.dataset.samples[self.sample_offset :]
-                num_samples -= len(prompt_samples)
+    def _fetch_prompt_samples(self, num_samples):
+        """Fetch prompt samples from the dataset, wrapping across epoch boundaries."""
+        if self.dataset is None:
+            return [Sample() for _ in range(num_samples)]
+
+        prompt_samples = []
+        remaining = num_samples
+        while remaining > 0:
+            available = len(self.dataset) - self.sample_offset
+            take = min(remaining, available)
+            prompt_samples.extend(self.dataset.samples[self.sample_offset : self.sample_offset + take])
+            self.sample_offset += take
+            remaining -= take
+
+            if self.sample_offset >= len(self.dataset):
                 self.epoch_id += 1
                 if self.args.rollout_shuffle:
                     self.dataset.shuffle(self.epoch_id)
-                prompt_samples += self.dataset.samples[:num_samples]
-                self.sample_offset = num_samples
-        else:
-            prompt_samples = [Sample() for _ in range(num_samples)]
+                self.sample_offset = 0
+
+        return prompt_samples
+
+    def get_samples(self, num_samples):
+        prompt_samples = self._fetch_prompt_samples(num_samples)
 
         samples = []
         for prompt_sample in prompt_samples:


### PR DESCRIPTION
## Related Issue
Fixes #266

## Problem
The original \get_samples\ method had a \# TODO further improve code\ comment. Key issues:

1. **Mutated the \
um_samples\ parameter** mid-function, making the logic harder to follow
2. **Edge case bug**: If \
um_samples > len(dataset)\, the old code only wrapped around one epoch boundary. E.g., with dataset size 100, offset 50, and num_samples 200, it would try to slice \[:150]\ from a 100-element list
3. **Mixed concerns**: prompt fetching and sample group creation were interleaved

## Fix
- Extracted prompt sample fetching into \_fetch_prompt_samples()\ private method
- Used a while loop with \emaining\ counter that correctly handles wrapping across multiple epoch boundaries
- No parameter mutation, cleaner separation of concerns

## Testing
Behavior is identical for the normal case (\
um_samples <= len(dataset)\). The edge case of \
um_samples > len(dataset)\ now wraps correctly across multiple epochs.