### PR TITLE
fix: validate --use-miles-router is required for --use-rollout-routing-replay

### DIFF
--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -1802,6 +1802,13 @@ def miles_validate_args(args):
 
     if args.use_rollout_routing_replay:
         args.use_routing_replay = True
+        if not args.use_miles_router:
+            raise ValueError(
+                "--use-rollout-routing-replay requires --use-miles-router to be set. "
+                "Without the Miles router, the SGLang engine will not be launched with "
+                "enable_return_routed_experts=True and rollout_routed_experts data "
+                "will not be available."
+            )
 
     if args.custom_config_path:
         with open(args.custom_config_path) as f:


### PR DESCRIPTION
## Related Issue
Fixes #407

## Problem
When users enable R3 routing replay with \use_rollout_routing_replay=true\ without setting \--use-miles-router\, the SGLang engine is launched externally without \enable_return_routed_experts=True\. This causes:
1. SGLang silently doesn't return \outed_experts\ data in responses
2. \sample.rollout_routed_experts\ remains \None\
3. Training crashes with a confusing error about missing \ollout_routed_experts\ in \ollout_data\

## Fix
Added an early validation check in argument parsing that raises a clear \ValueError\ when \--use-rollout-routing-replay\ is set without \--use-miles-router\, explaining the dependency.

## Changes
- [miles/utils/arguments.py](miles/utils/arguments.py): Added validation check with descriptive error message