### PR TITLE
Add SGLang rollout profiling controls

### DIFF
--- a/miles/backends/sglang_utils/sglang_engine.py
+++ b/miles/backends/sglang_utils/sglang_engine.py
@@ -4,6 +4,7 @@ import logging
 import multiprocessing
 import os
 import time
+from pathlib import Path
 from urllib.parse import quote
 
 import requests
@@ -105,6 +106,12 @@ def _wait_server_healthy(base_url, api_key, is_process_alive):
                 raise Exception("Server process terminated unexpectedly.")
 
             time.sleep(2)
+
+
+def is_benign_stop_profile_error(text: str | None) -> bool:
+    text = (text or "").lower()
+    benign_markers = ("not in progress", "not started", "already stopped", "/start_profile first")
+    return any(marker in text for marker in benign_markers)
 
 
 class SGLangEngine(RayActor):
@@ -475,6 +482,9 @@ class SGLangEngine(RayActor):
         with_stack: bool | None = None,
         record_shapes: bool | None = None,
     ):
+        if output_dir is not None:
+            Path(output_dir).mkdir(parents=True, exist_ok=True)
+
         response = requests.post(
             f"http://{self.server_host}:{self.server_port}/start_profile",
             json={
@@ -492,6 +502,10 @@ class SGLangEngine(RayActor):
 
     def stop_profile(self):
         response = requests.post(f"http://{self.server_host}:{self.server_port}/stop_profile", json={})
+        if response.status_code == 500 and is_benign_stop_profile_error(response.text):
+            # SGLang can return 500 when profiling is already stopped (e.g. auto-stopped after num_steps).
+            logger.warning("stop_profile: got benign 500 from /stop_profile; ignoring. response=%s", response.text)
+            return response
         response.raise_for_status()
         return response
 

--- a/miles/ray/rollout.py
+++ b/miles/ray/rollout.py
@@ -12,7 +12,7 @@ import torch
 from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 from sglang.srt.constants import GPU_MEMORY_TYPE_CUDA_GRAPH, GPU_MEMORY_TYPE_KV_CACHE, GPU_MEMORY_TYPE_WEIGHTS
 
-from miles.backends.sglang_utils.sglang_engine import SGLangEngine
+from miles.backends.sglang_utils.sglang_engine import SGLangEngine, is_benign_stop_profile_error
 from miles.rollout.base_types import (
     RolloutFnConstructorInput,
     RolloutFnEvalInput,
@@ -182,6 +182,56 @@ class RolloutManager:
                 if engine is not None
             ]
         )
+
+    def start_profile_all(
+        self,
+        output_dir: str | None = None,
+        rollout_id: int | None = None,
+        start_step: int | None = None,
+        num_steps: int | None = None,
+        activities: list[str] | None = None,
+        profile_by_stage: bool = False,
+        with_stack: bool | None = None,
+        record_shapes: bool | None = None,
+    ):
+        handles = []
+        for engine_id, engine in enumerate(self.rollout_engines):
+            if engine is None:
+                continue
+
+            engine_output_dir = None
+            if output_dir is not None:
+                path = Path(output_dir)
+                if rollout_id is not None:
+                    path = path / f"rollout_{rollout_id}"
+                path = path / f"engine_{engine_id}"
+                engine_output_dir = str(path)
+
+            handles.append(
+                engine.start_profile.remote(
+                    output_dir=engine_output_dir,
+                    start_step=start_step,
+                    num_steps=num_steps,
+                    activities=activities,
+                    profile_by_stage=profile_by_stage,
+                    with_stack=with_stack,
+                    record_shapes=record_shapes,
+                )
+            )
+        return ray.get(handles)
+
+    def stop_profile_all(self):
+        stop_refs = [engine.stop_profile.remote() for engine in self.rollout_engines if engine is not None]
+        results = []
+        for ref in stop_refs:
+            try:
+                results.append(ray.get(ref))
+            except Exception as e:
+                if is_benign_stop_profile_error(str(e)):
+                    logger.warning("stop_profile_all: got benign stop-profile error; ignoring: %s", e)
+                    continue
+                raise
+        return results
 
     def onload(self, tags: list[str] | None = None):
         return ray.get(

--- a/miles/ray/rollout.py
+++ b/miles/ray/rollout.py
@@ -223,6 +223,7 @@ class RolloutManager:
     def stop_profile_all(self):
         stop_refs = [engine.stop_profile.remote() for engine in self.rollout_engines if engine is not None]
         results = []
+        non_benign_errors = []
         for ref in stop_refs:
             try:
                 results.append(ray.get(ref))
@@ -230,7 +231,11 @@ class RolloutManager:
                 if is_benign_stop_profile_error(str(e)):
                     logger.warning("stop_profile_all: got benign stop-profile error; ignoring: %s", e)
                     continue
-                raise
+                non_benign_errors.append(e)
+        if non_benign_errors:
+            for e in non_benign_errors:
+                logger.error("stop_profile_all: non-benign stop-profile error: %s", e)
+            raise non_benign_errors[0]
         return results
 
     def onload(self, tags: list[str] | None = None):

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -1228,6 +1228,67 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 choices=["torch", "memray"],
                 default="torch",
             )
+            parser.add_argument(
+                "--use-rollout-profiler",
+                action="store_true",
+                default=False,
+                help="Enable profiler on rollout engines (SGLang) during rollout generation.",
+            )
+            parser.add_argument(
+                "--rollout-profile-rollout-start",
+                type=int,
+                default=0,
+                help="Start rollout_id (inclusive) to enable rollout profiler.",
+            )
+            parser.add_argument(
+                "--rollout-profile-rollout-end",
+                type=int,
+                default=1,
+                help="End rollout_id (exclusive) to enable rollout profiler.",
+            )
+            parser.add_argument(
+                "--rollout-profile-output-dir",
+                type=str,
+                default=None,
+                help="Directory to store rollout profiler traces. One subdirectory per rollout/engine will be created.",
+            )
+            parser.add_argument(
+                "--rollout-profile-start-step",
+                type=int,
+                default=None,
+                help="Optional rollout-engine internal profile start step passed to SGLang.",
+            )
+            parser.add_argument(
+                "--rollout-profile-num-steps",
+                type=int,
+                default=None,
+                help="Optional number of rollout-engine internal steps to profile, passed to SGLang.",
+            )
+            parser.add_argument(
+                "--rollout-profile-activities",
+                type=str,
+                nargs="+",
+                default=None,
+                help="Optional activity list passed to SGLang rollout profiler.",
+            )
+            parser.add_argument(
+                "--rollout-profile-by-stage",
+                action="store_true",
+                default=False,
+                help="Enable stage-level breakdown in rollout profiler (if supported by SGLang).",
+            )
+            parser.add_argument(
+                "--rollout-profile-with-stack",
+                action=argparse.BooleanOptionalAction,
+                default=None,
+                help="Whether rollout profiler should collect Python stacks (if supported by SGLang).",
+            )
+            parser.add_argument(
+                "--rollout-profile-record-shapes",
+                action=argparse.BooleanOptionalAction,
+                default=None,
+                help="Whether rollout profiler should record tensor shapes (if supported by SGLang).",
+            )
             parser.add_argument("--check-weight-update-equal", action="store_true")
             return parser
 
@@ -1743,6 +1804,18 @@ def miles_validate_args(args):
             "will not instantiate sglang servers and will only run the training process."
         )
         args.debug_train_only = True
+
+    if args.use_rollout_profiler:
+        assert not args.debug_train_only, "rollout profiler cannot be used with --debug-train-only."
+        assert (
+            args.rollout_profile_rollout_end > args.rollout_profile_rollout_start
+        ), "rollout_profile_rollout_end must be greater than rollout_profile_rollout_start."
+        if args.rollout_profile_start_step is not None:
+            assert args.rollout_profile_start_step >= 0, "rollout_profile_start_step must be >= 0."
+        if args.rollout_profile_num_steps is not None:
+            assert args.rollout_profile_num_steps > 0, "rollout_profile_num_steps must be > 0."
+        if args.rollout_profile_output_dir is None:
+            args.rollout_profile_output_dir = os.path.join(args.save or ".", "rollout_trace")
 
     args.use_critic = args.advantage_estimator == "ppo"
     if args.critic_num_gpus_per_node is None:

--- a/train.py
+++ b/train.py
@@ -1,3 +1,5 @@
+import logging
+
 import ray
 from sglang.srt.constants import GPU_MEMORY_TYPE_CUDA_GRAPH, GPU_MEMORY_TYPE_KV_CACHE, GPU_MEMORY_TYPE_WEIGHTS
 
@@ -6,6 +8,8 @@ from miles.utils.arguments import parse_args
 from miles.utils.logging_utils import configure_logger
 from miles.utils.misc import should_run_periodic_action
 from miles.utils.tracking_utils import init_tracking
+
+logger = logging.getLogger(__name__)
 
 
 def train(args):
@@ -68,7 +72,44 @@ def train(args):
         if args.eval_interval is not None and rollout_id == 0 and not args.skip_eval_before_train:
             ray.get(rollout_manager.eval.remote(rollout_id))
 
-        rollout_data_ref = ray.get(rollout_manager.generate.remote(rollout_id))
+        do_rollout_profile = (
+            args.use_rollout_profiler
+            and args.rollout_profile_rollout_start <= rollout_id < args.rollout_profile_rollout_end
+        )
+        if do_rollout_profile:
+            logger.info(
+                "Enable rollout profiler for rollout_id=%s (window=[%s, %s))",
+                rollout_id,
+                args.rollout_profile_rollout_start,
+                args.rollout_profile_rollout_end,
+            )
+            ray.get(
+                rollout_manager.start_profile_all.remote(
+                    output_dir=args.rollout_profile_output_dir,
+                    rollout_id=rollout_id,
+                    start_step=args.rollout_profile_start_step,
+                    num_steps=args.rollout_profile_num_steps,
+                    activities=args.rollout_profile_activities,
+                    profile_by_stage=args.rollout_profile_by_stage,
+                    with_stack=args.rollout_profile_with_stack,
+                    record_shapes=args.rollout_profile_record_shapes,
+                )
+            )
+        rollout_generate_succeeded = False
+        try:
+            rollout_data_ref = ray.get(rollout_manager.generate.remote(rollout_id))
+            rollout_generate_succeeded = True
+        finally:
+            if do_rollout_profile:
+                try:
+                    ray.get(rollout_manager.stop_profile_all.remote())
+                except Exception:
+                    if rollout_generate_succeeded:
+                        raise
+                    logger.exception(
+                        "Failed to stop rollout profiler while handling generate failure for rollout_id=%s",
+                        rollout_id,
+                    )
 
         if args.offload_rollout:
             offload_tags = [GPU_MEMORY_TYPE_CUDA_GRAPH]


### PR DESCRIPTION
## Summary
This PR adds opt-in rollout profiling support for SGLang engines and hardens profiling shutdown behavior.

## Changes
- Add rollout profiling fan-out APIs in `RolloutManager`:
  - `start_profile_all(...)`
  - `stop_profile_all()`
- Add rollout profiling CLI/config args in `miles/utils/arguments.py`:
  - `--use-rollout-profiler`
  - rollout window (`--rollout-profile-rollout-start`, `--rollout-profile-rollout-end`)
  - output and SGLang profiling options (`--rollout-profile-output-dir`, `--rollout-profile-start-step`, `--rollout-profile-num-steps`, `--rollout-profile-activities`, `--rollout-profile-by-stage`, `--rollout-profile-with-stack`, `--rollout-profile-record-shapes`)
- Wire profiling lifecycle into train loop in `train.py`:
  - start profiling for rollout IDs within configured window
  - stop profiling in `finally`
  - preserve original `generate()` failure if stop also fails
- Harden `SGLangEngine.stop_profile()`:
  - ignore benign “profiling already stopped/not started” cases
  - raise for other failures