### PR TITLE
Rename `rollout/rewards` metric to `rollout/normalized_reward`

### DIFF
--- a/miles/backends/training_utils/loss.py
+++ b/miles/backends/training_utils/loss.py
@@ -298,13 +298,13 @@ def compute_advantages_and_returns(args: Namespace, parallel_state: ParallelStat
         args: Configuration specifying estimator type, KL coefficient,
             normalization settings, and other hyperparameters.
         rollout_data: Dict containing input lists ("log_probs", "ref_log_probs",
-            "rewards", "values", "response_lengths", "loss_masks",
+            "normalized_reward", "values", "response_lengths", "loss_masks",
             "total_lengths"). Modified in-place to add "advantages" and
             "returns" keys, each mapping to lists of tensors per sample.
     """
     log_probs: list[torch.Tensor] = rollout_data.get("rollout_log_probs" if args.use_rollout_logprobs else "log_probs")
     ref_log_probs: list[torch.Tensor] = rollout_data.get("ref_log_probs")
-    rewards: list[float] = rollout_data.get("rewards")
+    rewards: list[float] = rollout_data.get("normalized_reward")
     values: None | list[torch.Tensor] = rollout_data.get("values")
     response_lengths: list[int] = rollout_data.get("response_lengths")
     loss_masks: list[torch.Tensor] = rollout_data.get("loss_masks")

--- a/miles/ray/rollout.py
+++ b/miles/ray/rollout.py
@@ -369,7 +369,7 @@ class RolloutManager:
             "response_lengths": [sample.response_length for sample in samples],
             # some reward model, e.g. remote rm, may return multiple rewards,
             # we could use key to select the reward.
-            "rewards": rewards,
+            "normalized_reward": rewards,
             "raw_reward": raw_rewards,
             "truncated": [1 if sample.status == Sample.Status.TRUNCATED else 0 for sample in samples],
             "sample_indices": [sample.index for sample in samples],
@@ -445,7 +445,7 @@ class RolloutManager:
                 "tokens",
                 "multimodal_train_inputs",
                 "response_lengths",
-                "rewards",
+                "normalized_reward",
                 "truncated",
                 "loss_masks",
                 "round_number",


### PR DESCRIPTION
When normalization is enabled, the `rollout/rewards` metric records the mean reward of a rollout group after normalization.  Therefore renaming the metric to `rollout/normalized_reward` affords more clarity.