### PR TITLE
feat: Refactor the original `UpdateWeightFromDistributed`

### DIFF
--- a/miles/backends/megatron_utils/update_weight/bucketed_weight_gather_mixin.py
+++ b/miles/backends/megatron_utils/update_weight/bucketed_weight_gather_mixin.py
@@ -1,0 +1,115 @@
+from collections.abc import Callable
+
+import torch
+import torch.distributed as dist
+from megatron.core import mpu
+from tqdm import tqdm
+
+
+from ..megatron_to_hf import convert_to_hf
+from .common import all_gather_param, expert_named_params_and_buffers, non_expert_named_params_and_buffers
+
+
+class BucketedWeightGatherMixin:
+    """Mixin providing bucketed TP/EP all-gather and HF format conversion."""
+
+    def _gather_and_convert_non_expert_weights(
+        self,
+        bucket_weight_transfer: Callable[[list[tuple[str, torch.Tensor]]], None],
+    ) -> None:
+        """Bucketed TP all-gather + HF conversion for non-expert parameters."""
+        pbar = tqdm(desc="[Update Weights]", total=0) if self._is_source else None
+        buffer_size = 0
+        converted_named_tensors: list[tuple[str, torch.Tensor]] = []
+
+        for name, param in non_expert_named_params_and_buffers(self.args, self.model):
+            param = all_gather_param(self.args, name, param)
+            if not self._is_source:
+                continue
+
+            param_size = param.numel() * param.element_size()
+            if buffer_size + param_size > self.args.update_weight_buffer_size:
+                bucket_weight_transfer(converted_named_tensors)
+                converted_named_tensors = []
+                buffer_size = 0
+                if pbar:
+                    pbar.update(1)
+
+            converted_named_tensors += convert_to_hf(self.args, self.model_name, name, param, self.quantization_config)
+            buffer_size += param_size
+
+        if converted_named_tensors:
+            bucket_weight_transfer(converted_named_tensors)
+            if pbar:
+                pbar.update(1)
+
+    def _gather_and_convert_expert_weights(
+        self,
+        bucket_weight_transfer: Callable[[list[tuple[str, torch.Tensor]]], None],
+    ) -> None:
+        """Bucketed TP + EP all-gather + HF conversion for expert parameters."""
+        pbar = tqdm(desc="[Update Expert Weights]", total=0) if self._is_source else None
+        buffer_size = 0
+        named_tensors: list[tuple[str, torch.Tensor]] = []
+
+        for name, param in expert_named_params_and_buffers(self.args, self.model):
+            param = all_gather_param(self.args, name, param)
+            param_size = param.numel() * param.element_size()
+            if (
+                buffer_size + param_size
+            ) * mpu.get_expert_model_parallel_world_size() > self.args.update_weight_buffer_size and named_tensors:
+                self._handle_expert_bucket(named_tensors, bucket_weight_transfer, pbar)
+                named_tensors = []
+                buffer_size = 0
+
+            named_tensors.append((name, param))
+            buffer_size += param_size
+
+        if named_tensors:
+            self._handle_expert_bucket(named_tensors, bucket_weight_transfer, pbar)
+
+    def _handle_expert_bucket(
+        self,
+        named_tensors: list[tuple[str, torch.Tensor]],
+        bucket_weight_transfer: Callable[[list[tuple[str, torch.Tensor]]], None],
+        pbar: tqdm | None,
+    ) -> None:
+
+        names = [name for name, _ in named_tensors]
+        all_names: list[list[str] | None] = [None] * mpu.get_expert_model_parallel_world_size()
+        dist.all_gather_object(all_names, names, group=mpu.get_expert_model_parallel_group())
+
+        for ep_names in all_names:
+            assert len(named_tensors) == len(
+                ep_names
+            ), f"mismatch names length: {len(named_tensors)} != {len(ep_names)}"
+
+        all_gathered_params: list[list[tuple[str, torch.Tensor]]] = [
+            [] for _ in range(mpu.get_expert_model_parallel_world_size())
+        ]
+        handles = []
+        for i, (_name, param) in enumerate(named_tensors):
+            params = [
+                torch.empty_like(param.data, device=torch.cuda.current_device())
+                for _ in range(mpu.get_expert_model_parallel_world_size())
+            ]
+            handle = dist.all_gather(params, param.data, group=mpu.get_expert_model_parallel_group(), async_op=True)
+            handles.append(handle)
+            for ep_rank, ep_names in enumerate(all_names):
+                all_gathered_params[ep_rank].append((ep_names[i], params[ep_rank]))
+        for handle in handles:
+            handle.wait()
+
+        named_tensors.clear()
+        if not self._is_source:
+            return
+
+        flat_gathered = sum(all_gathered_params, [])
+
+        converted_hf_tensors: list[tuple[str, torch.Tensor]] = []
+        for name, param in flat_gathered:
+            converted_hf_tensors += convert_to_hf(self.args, self.model_name, name, param, self.quantization_config)
+
+        bucket_weight_transfer(converted_hf_tensors)
+        if pbar:
+            pbar.update(1)

--- a/miles/backends/megatron_utils/update_weight/common.py
+++ b/miles/backends/megatron_utils/update_weight/common.py
@@ -252,3 +252,46 @@ def _named_params_and_buffers_global(
                 layer_idx, rest = match.groups()
                 layer_idx = int(layer_idx) + layer_offset
                 yield f"module.module.decoder.layers.{layer_idx}.{rest}", buffer
+
+
+def split_expert_and_non_expert_param_names(param_names: Sequence[str]) -> tuple[list[str], list[str]]:
+    expert_params = []
+    non_expert_params = []
+    for name in param_names:
+        if ".experts." in name:
+            expert_params.append(name)
+        else:
+            non_expert_params.append(name)
+    return expert_params, non_expert_params
+
+
+def non_expert_named_params_and_buffers(
+    args: Namespace,
+    model: Sequence[torch.nn.Module],
+    convert_to_global_name: bool = True,
+    translate_gpu_to_cpu: bool = False,
+) -> Iterator[tuple[str, torch.Tensor]]:
+    for name, tensor in named_params_and_buffers(
+        args,
+        model,
+        convert_to_global_name,
+        translate_gpu_to_cpu,
+    ):
+        if ".experts." not in name:
+            yield name, tensor
+
+
+def expert_named_params_and_buffers(
+    args: Namespace,
+    model: Sequence[torch.nn.Module],
+    convert_to_global_name: bool = True,
+    translate_gpu_to_cpu: bool = False,
+) -> Iterator[tuple[str, torch.Tensor]]:
+    for name, tensor in named_params_and_buffers(
+        args,
+        model,
+        convert_to_global_name,
+        translate_gpu_to_cpu,
+    ):
+        if ".experts." in name:
+            yield name, tensor

--- a/miles/backends/megatron_utils/update_weight/update_weight_from_distributed.py
+++ b/miles/backends/megatron_utils/update_weight/update_weight_from_distributed.py
@@ -9,15 +9,13 @@ import torch.distributed as dist
 from megatron.core import mpu
 from ray import ObjectRef
 from ray.actor import ActorHandle
-from tqdm import tqdm
 
 from miles.utils.distributed_utils import get_gloo_group, init_process_group
 
-from ..megatron_to_hf import convert_to_hf
-from .common import all_gather_param, named_params_and_buffers
+from .bucketed_weight_gather_mixin import BucketedWeightGatherMixin
 
 
-class UpdateWeightFromDistributed:
+class UpdateWeightFromDistributed(BucketedWeightGatherMixin):
     """
     Update distributed engines via NCCL. Each PP rank: group "miles-pp_{pp_rank}",
     only DP=TP=0 broadcasts. Non-expert (TP) and expert (EP) params separate.
@@ -91,36 +89,11 @@ class UpdateWeightFromDistributed:
                 )
         dist.barrier(group=get_gloo_group())
 
-        buffer_size = 0
-        converted_named_tensors = []
-        # non expert params
-        pbar = tqdm(desc=f"[{self._group_name}] Update weights", total=0) if self._is_pp_src_rank else None
-
-        for name, param in named_params_and_buffers(self.args, self.model):
-            if ".experts." in name:
-                continue
-            buffer_size = self._update_weight_from_distributed(
-                name, param, converted_named_tensors, buffer_size, pbar=pbar
-            )
-
-        if converted_named_tensors:
-            self._update_bucket_weights_from_distributed(converted_named_tensors, pbar=pbar)
-
+        self._gather_and_convert_non_expert_weights(self._nccl_weight_transfer)
+        dist.barrier(group=get_gloo_group())
+        self._gather_and_convert_expert_weights(self._nccl_weight_transfer)
         dist.barrier(group=get_gloo_group())
 
-        buffer_size = 0
-        named_tensors = []
-        for name, param in named_params_and_buffers(self.args, self.model):
-            if ".experts." not in name:
-                continue
-            buffer_size = self._update_expert_weight_from_distributed(
-                name, param, named_tensors, buffer_size, pbar=pbar
-            )
-
-        if named_tensors:
-            self._update_expert_bucket_weights_from_distributed(named_tensors, pbar=pbar)
-
-        dist.barrier(group=get_gloo_group())
         if dist.get_rank() == 0:
             # int4/fp4 post_process, mxfp8 post-process (swizzle MoE scales).
             if self.quantization_config and self.quantization_config["quant_method"] in [
@@ -135,102 +108,10 @@ class UpdateWeightFromDistributed:
             ray.get([engine.continue_generation.remote() for engine in self.rollout_engines])
         dist.barrier(group=get_gloo_group())
 
-    def _update_weight_from_distributed(
-        self,
-        name: str,
-        param: torch.nn.Parameter,
-        converted_named_tensors: list[tuple[str, torch.Tensor]],
-        buffer_size: int,
-        pbar: tqdm | None = None,
-    ) -> int | None:
-        """
-        Non-expert: gather TP → rm pad → HF → buffer (flush if full). All gather, PP source buffers.
-        Returns updated bytes on source, None on non-source.
-        """
-        param = all_gather_param(self.args, name, param)
-        if not self._is_pp_src_rank:
-            return
-
-        param_size = param.numel() * param.element_size()
-        if buffer_size + param_size > self.args.update_weight_buffer_size:
-            self._update_bucket_weights_from_distributed(converted_named_tensors, pbar=pbar)
-            buffer_size = 0
-        converted_named_tensors += convert_to_hf(self.args, self.model_name, name, param, self.quantization_config)
-        buffer_size += param_size
-        return buffer_size
-
-    def _update_expert_weight_from_distributed(
-        self,
-        name: str,
-        param: torch.nn.Parameter,
-        named_tensors: list[tuple[str, torch.Tensor]],
-        buffer_size: int,
-        pbar: tqdm | None = None,
-    ) -> int:
-        """
-        Expert: gather TP → rm pad → buffer. EP gather + HF deferred. Threshold × EP size.
-        """
-        param = all_gather_param(self.args, name, param)
-
-        param_size = param.numel() * param.element_size()
-        if (
-            buffer_size + param_size
-        ) * mpu.get_expert_model_parallel_world_size() > self.args.update_weight_buffer_size:
-            self._update_expert_bucket_weights_from_distributed(named_tensors, pbar=pbar)
-            buffer_size = 0
-
-        named_tensors.append((name, param))
-        buffer_size += param_size
-        return buffer_size
-
-    def _update_expert_bucket_weights_from_distributed(
-        self, named_tensors: list[tuple[str, torch.Tensor]], pbar: tqdm | None = None
-    ) -> None:
-        """
-        Gather EP → HF → broadcast. Clears buffer.
-        """
-        names = [name for name, _ in named_tensors]
-        all_names = [None] * mpu.get_expert_model_parallel_world_size()
-        dist.all_gather_object(all_names, names, group=mpu.get_expert_model_parallel_group())
-
-        for names in all_names:
-            assert len(named_tensors) == len(names), f"mismatch names length: {len(named_tensors)} != {len(names)}"
-
-        all_gathered_params = [[] for _ in range(mpu.get_expert_model_parallel_world_size())]
-        handles = []
-        for i, (_name, param) in enumerate(named_tensors):
-            params = [
-                torch.empty_like(param.data, device=torch.cuda.current_device())
-                for _ in range(mpu.get_expert_model_parallel_world_size())
-            ]
-            handle = dist.all_gather(params, param.data, group=mpu.get_expert_model_parallel_group(), async_op=True)
-            handles.append(handle)
-            for ep_rank, names in enumerate(all_names):
-                all_gathered_params[ep_rank].append((names[i], params[ep_rank]))
-        for handle in handles:
-            handle.wait()
-
-        named_tensors.clear()
-        if not self._is_pp_src_rank:
-            return
-
-        all_gathered_params = sum(all_gathered_params, [])
-        converted_hf_tensors = []
-        for name, param in all_gathered_params:
-            converted_hf_tensors += convert_to_hf(self.args, self.model_name, name, param, self.quantization_config)
-
-        self._update_bucket_weights_from_distributed(converted_hf_tensors, pbar)
-
-    def _update_bucket_weights_from_distributed(
-        self, converted_named_tensors: list[tuple[str, torch.Tensor]], pbar: tqdm | None = None
-    ) -> None:
-        """
-        Lock → broadcast → clear → unlock → pbar++. Lock prevents NCCL deadlock.
-        """
-        # lock the rollout engines to prevent dead lock on broadcast.
+    def _nccl_weight_transfer(self, converted_named_tensors: list[tuple[str, torch.Tensor]]) -> None:
+        """Lock → broadcast → clear → unlock. Lock prevents NCCL deadlock."""
         while not ray.get(self.rollout_engine_lock.acquire.remote()):
             time.sleep(0.1)
-
         refs = update_weights_from_distributed(
             self._group_name,
             self._model_update_groups,
@@ -238,11 +119,9 @@ class UpdateWeightFromDistributed:
             self.rollout_engines,
             converted_named_tensors,
         )
-
         ray.get(refs)
         converted_named_tensors.clear()
         ray.get(self.rollout_engine_lock.release.remote())
-        pbar.update(1)
 
 
 def connect_rollout_engines_from_distributed(


### PR DESCRIPTION
Refactor the original `UpdateWeightFromDistributed`.
- Involve `BucketedWeightGatherMixin` (old `UpdateWeightFromRemote`), to isolate the logic of weight_allgather and convert_to_hf.
- involve `split_expert_and_non_expert_param_names`, `non_expert_named_params_and_buffers`, and `expert_named_params_and_buffers` in `common.py`