### PR TITLE
fix: pass hf_checkpoint to convert_checkpoint using model_dir

### DIFF
--- a/scripts/run_glm5_744b_a40b.py
+++ b/scripts/run_glm5_744b_a40b.py
@@ -191,6 +191,7 @@ def _prepare_megatron_ckpt(args: ScriptArgs):
         num_nodes=num_nodes,
         extra_args=extra_args,
         dir_dst=args.model_dir,
+        hf_checkpoint=f"{args.model_dir}/{args.model_name}",
         megatron_path=args.megatron_path,
     )
 

--- a/scripts/run_mcore_fsdp.py
+++ b/scripts/run_mcore_fsdp.py
@@ -50,6 +50,7 @@ def prepare(args: ScriptArgs):
             megatron_model_type=args.megatron_model_type,
             num_gpus_per_node=args.num_gpus_per_node,
             dir_dst=args.model_dir,
+            hf_checkpoint=f"{args.model_dir}/{args.model_name}",
             megatron_path=args.megatron_path,
         )
 

--- a/scripts/run_qwen3_30b_a3b.py
+++ b/scripts/run_qwen3_30b_a3b.py
@@ -72,6 +72,7 @@ def prepare(args: ScriptArgs):
             num_gpus_per_node=args.num_gpus_per_node,
             # To support multi-node training, for simplicity, we put model into shared folder
             dir_dst=args.model_dir,
+            hf_checkpoint=f"{args.model_dir}/{args.model_name}",
             megatron_path=args.megatron_path,
         )
 

--- a/scripts/run_qwen3_4b.py
+++ b/scripts/run_qwen3_4b.py
@@ -60,6 +60,7 @@ def prepare(args: ScriptArgs):
             megatron_model_type=args.megatron_model_type,
             num_gpus_per_node=args.num_gpus_per_node,
             dir_dst=args.model_dir,
+            hf_checkpoint=f"{args.model_dir}/{args.model_name}",
             megatron_path=args.megatron_path,
         )
 


### PR DESCRIPTION
## Summary
- `convert_checkpoint()` defaults `hf_checkpoint` to `/root/models/{model_name}` when not provided
- This causes `HFValidationError` when `model_dir` is a non-default path

## Fix
Pass `hf_checkpoint=f"{args.model_dir}/{args.model_name}"` explicitly

## Test plan
- [x] Verified with rcli e2e test on sci-h200 (2-node KubeRay)