### PR TITLE
switch model to actor

### DIFF
--- a/miles/backends/megatron_utils/actor.py
+++ b/miles/backends/megatron_utils/actor.py
@@ -152,9 +152,8 @@ class MegatronTrainRayActor(TrainRayActor):
         # empty cache after initialization
         clear_memory()
 
+        self._switch_model("actor")
         if self.args.offload_train:
-            # recover to actor in the end.
-            self._switch_model("actor")
             self.sleep()
 
         self.rollout_engines = None


### PR DESCRIPTION
        Always restore GPU model to actor before leaving init. Required for:
        1. offload_train: sleep() offloads self.model; wake_up restores it — must be actor.
        2. disagg: first update_weights() reads from self.model to push to rollout engine — must be actor.