### PR TITLE
Sync pr-test.yml.j2 with sglang_config tests

### DIFF
--- a/.github/workflows/pr-test.yml.j2
+++ b/.github/workflows/pr-test.yml.j2
@@ -27,6 +27,9 @@
     {'test_file': 'e2e/short/test_qwen2.5_0.5B_gsm8k_async_short.py', 'num_gpus': 8},
     {'test_file': 'e2e/short/test_qwen2.5_0.5B_gsm8k_short.py', 'num_gpus': 8},
     {'test_file': 'e2e/short/test_qwen3_0.6B_fsdp_colocated_2xGPU.py', 'num_gpus': 8},
+    {'test_file': 'e2e/sglang_config/test_sglang_config.py', 'num_gpus': 8},
+    {'test_file': 'e2e/sglang_config/test_sglang_config_mixed_offload.py', 'num_gpus': 8},
+    {'test_file': 'e2e/sglang_config/test_sglang_config_mixed_offload_ft.py', 'num_gpus': 8},
 ] %>
 
 <% set precision_tests = [
@@ -60,6 +63,7 @@
       'test_executor': 'pytest',
       'tests': [
         {'test_file': 'fast', 'num_gpus': 0},
+        {'test_file': 'utils/test_sglang_config.py', 'num_gpus': 0},
       ],
     },
     'unit-test': {


### PR DESCRIPTION
## Summary
- sglang_config tests were added directly to `pr-test.yml` but the `.j2` template was not updated
- Added the missing tests to `pr-test.yml.j2` (`short_tests` list + `fast` job)
- Regenerated `pr-test.yml` — output matches current `main` exactly (zero diff)

## Test plan
- [x] Generated `.yml` matches `origin/main` `.yml` (verified via `git diff`)