### PR TITLE
feat: add Qwen3-0.6B support to run_qwen3_4b.py

### DIFF
--- a/scripts/run_qwen3_4b.py
+++ b/scripts/run_qwen3_4b.py
@@ -177,9 +177,12 @@ eval:
             perf_args = "--use-dynamic-batch-size " "--max-tokens-per-gpu 32768 "
 
         case "megatron":
-            is_small_model = args.model_name in ("Qwen3-0.6B",)
-            tp_size = 1 if is_small_model else (2 if args.num_gpus_per_node == 8 else 1)
-            cp_size = 1 if is_small_model else (4 if args.num_gpus_per_node == 8 else 1)
+            if args.model_name in ("Qwen3-0.6B",):
+                tp_size = 1
+                cp_size = 1
+            else:
+                tp_size = 2 if args.num_gpus_per_node == 8 else 1
+                cp_size = 4 if args.num_gpus_per_node == 8 else 1
             train_backend_args = (
                 f"--tensor-model-parallel-size {tp_size} "
                 "--sequence-parallel "


### PR DESCRIPTION
## Summary
- Add Qwen3-0.6B to the model name mapping in `run_qwen3_4b.py`
- Use tp_size=1, cp_size=1 for small models (Qwen3-0.6B) instead of the default multi-GPU parallelism
- Simplify tp/cp size logic with if/else block

## Test plan
- [ ] Run `run_qwen3_4b.py --model-name Qwen3-0.6B --mode debug_minimal` on a multi-node cluster