### PR TITLE
⚡ Performance: Inefficient string allocation inside loop

### DIFF
--- a/examples/search-r1/google_search_server.py
+++ b/examples/search-r1/google_search_server.py
@@ -73,9 +73,10 @@ async def fetch_all(urls: list[str], limit: int = 8) -> list[str]:
 def collect_context(snippet: str, doc: str) -> str:
     snippets = parse_snippet(snippet)
     ctx_paras = []
+    doc_searchable = doc.replace("\n", " ")
 
     for s in snippets:
-        pos = doc.replace("\n", " ").find(s)
+        pos = doc_searchable.find(s)
         if pos == -1:
             continue
         sta = pos


### PR DESCRIPTION
## ⚡ Performance

### Problem
The `doc.replace('\n', ' ')` operation is called inside a `for` loop iterating over `snippets`. Since `doc` represents a fetched web page, it can be a large string. Calling `replace` on a large string inside a loop creates a new large string allocation on every iteration, leading to unnecessary memory allocation and copying overhead (O(N * M) where N is the number of snippets and M is the document length).

**Severity**: `medium`
**File**: `examples/search-r1/google_search_server.py`

### Solution
Hoist the `doc.replace('\n', ' ')` operation outside the `for` loop. Assign it to a variable like `doc_searchable = doc.replace('\n', ' ')` before the loop, and use `doc_searchable.find(s)` inside the loop.

### Changes
- `examples/search-r1/google_search_server.py` (modified)

### Testing
- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced

---

<details>
<summary>🤖 About this PR</summary>

This pull request was generated by [ContribAI](https://github.com/tang-vu/ContribAI), an AI agent
that helps improve open source projects. The change was:

1. **Discovered** by automated code analysis
2. **Generated** by AI with context-aware code generation
3. **Self-reviewed** by AI quality checks

If you have questions or feedback about this PR, please comment below.
We appreciate your time reviewing this contribution!

</details>
