### PR TITLE
broadcast from all PP source concurrently

### DIFF
--- a/miles/backends/megatron_utils/update_weight/update_weight_from_distributed.py
+++ b/miles/backends/megatron_utils/update_weight/update_weight_from_distributed.py
@@ -1,5 +1,4 @@
 import socket
-import time
 from argparse import Namespace
 from collections.abc import Callable, Mapping, Sequence
 
@@ -21,6 +20,11 @@ class UpdateWeightFromDistributed:
     """
     Update distributed engines via NCCL. Each PP rank: group "miles-pp_{pp_rank}",
     only DP=TP=0 broadcasts. Non-expert (TP) and expert (EP) params separate.
+
+    When PP>1, source ranks synchronize per-bucket via all_gather_object so that
+    global rank 0 dispatches Ray calls for ALL PP sources before any of them
+    broadcast. This prevents deadlocks from engines joining NCCL groups in
+    inconsistent order.
     """
 
     def __init__(
@@ -42,6 +46,11 @@ class UpdateWeightFromDistributed:
         self.quantization_config = quantization_config
         self.weight_version = 0
         self._model_update_groups = None
+        # Leader rank dispatches Ray calls and waits for engine completion.
+        self._is_leader = dist.get_rank() == 0
+        # Ray ObjectRefs tracking engine-side weight update completion,
+        # accumulated per phase and drained in _finish_phase_sync.
+        self._pending_engine_refs = []
 
     def connect_rollout_engines(
         self,
@@ -51,7 +60,7 @@ class UpdateWeightFromDistributed:
         engine_gpu_offsets: Sequence[int] | None = None,
     ) -> None:
         """
-        Create NCCL "miles-pp_{pp_rank}" if PP source (DP=TP=0). Lock prevents concurrent broadcasts.
+        Create NCCL "miles-pp_{pp_rank}" if PP source (DP=TP=0).
         """
         self.rollout_engines = rollout_engines
         self.rollout_engine_lock = rollout_engine_lock
@@ -63,6 +72,7 @@ class UpdateWeightFromDistributed:
         self._is_pp_src_rank = (
             mpu.get_data_parallel_rank(with_context_parallel=True) == 0 and mpu.get_tensor_model_parallel_rank() == 0
         )
+        assert not self._is_leader or self._is_pp_src_rank, "Leader rank must be a source rank"
         pp_rank = mpu.get_pipeline_model_parallel_rank()
         if self._is_pp_src_rank:
             self._group_name = f"miles-pp_{pp_rank}"
@@ -111,7 +121,8 @@ class UpdateWeightFromDistributed:
         if converted_named_tensors:
             self._update_bucket_weights_from_distributed(converted_named_tensors, pbar=pbar)
 
-        dist.barrier(group=get_gloo_group())
+        if self._is_pp_src_rank:
+            self._finish_phase_sync()
 
         buffer_size = 0
         named_tensors = []
@@ -125,7 +136,9 @@ class UpdateWeightFromDistributed:
         if named_tensors:
             self._update_expert_bucket_weights_from_distributed(named_tensors, pbar=pbar)
 
-        dist.barrier(group=get_gloo_group())
+        if self._is_pp_src_rank:
+            self._finish_phase_sync()
+
         if dist.get_rank() == 0:
             # int4/fp4 post_process, mxfp8 post-process (swizzle MoE scales).
             if self.quantization_config and self.quantization_config["quant_method"] in [
@@ -138,7 +151,6 @@ class UpdateWeightFromDistributed:
                     rollout_engines=self.rollout_engines,
                 )
             ray.get([engine.continue_generation.remote() for engine in self.rollout_engines])
-        dist.barrier(group=get_gloo_group())
 
     def _update_weight_from_distributed(
         self,
@@ -230,24 +242,75 @@ class UpdateWeightFromDistributed:
         self, converted_named_tensors: list[tuple[str, torch.Tensor]], pbar: tqdm | None = None
     ) -> None:
         """
-        Lock → broadcast → clear → unlock → pbar++. Lock prevents NCCL deadlock.
+        Sync PP sources via all_gather_object (no-op for PP=1), rank 0 dispatches
+        Ray calls for ALL PP sources, then each source broadcasts on its own
+        NCCL group concurrently.
         """
-        # lock the rollout engines to prevent dead lock on broadcast.
-        while not ray.get(self.rollout_engine_lock.acquire.remote()):
-            time.sleep(0.1)
+        # Gather tensor metadata across PP sources; leader schedules engine updates
+        self._gather_meta_and_schedule_engines(converted_named_tensors)
+        # NCCL broadcast on own group
+        handles = []
+        for _, param in converted_named_tensors:
+            handles.append(dist.broadcast(param.data, 0, group=self._model_update_groups, async_op=True))
+        for handle in handles:
+            handle.wait()
 
-        refs = update_weights_from_distributed(
-            self._group_name,
-            self._model_update_groups,
-            self.weight_version,
-            self.rollout_engines,
-            converted_named_tensors,
-        )
-
-        ray.get(refs)
         converted_named_tensors.clear()
-        ray.get(self.rollout_engine_lock.release.remote())
         pbar.update(1)
+
+    def _gather_meta_and_schedule_engines(self, converted_named_tensors: list[tuple[str, torch.Tensor]]) -> None:
+        """Gather tensor metadata from all PP sources to leader; leader schedules engine updates."""
+        pp_group = mpu.get_pipeline_model_parallel_group()
+        pp_size = mpu.get_pipeline_model_parallel_world_size()
+        my_meta = (
+            self._group_name,
+            [name for name, _ in converted_named_tensors],
+            [param.dtype for _, param in converted_named_tensors],
+            [tuple(param.shape) for _, param in converted_named_tensors],
+        )
+        per_pp_meta = [None] * pp_size
+        dist.all_gather_object(per_pp_meta, my_meta, group=pp_group)
+        if self._is_leader:
+            self._dispatch_from_gathered_meta(per_pp_meta)
+
+    def _dispatch_from_gathered_meta(self, per_pp_meta: list) -> None:
+        """Dispatch Ray weight-update calls for every PP source that has data."""
+        for group_name, names, dtypes, shapes in per_pp_meta:
+            if names:
+                refs = [
+                    engine.update_weights_from_distributed.remote(
+                        names=names,
+                        dtypes=dtypes,
+                        shapes=shapes,
+                        group_name=group_name,
+                        weight_version=str(self.weight_version),
+                    )
+                    for engine in self.rollout_engines
+                ]
+                self._pending_engine_refs.extend(refs)
+
+    def _finish_phase_sync(self) -> None:
+        """
+        After a transfer phase, sources that finished early participate in empty
+        all_gather_object rounds so sources still broadcasting can synchronize.
+        Exits once every PP source sends empty metadata. Then rank 0 waits for
+        all accumulated engine refs before proceeding.
+        """
+        pp_size = mpu.get_pipeline_model_parallel_world_size()
+        if pp_size > 1:
+            pp_group = mpu.get_pipeline_model_parallel_group()
+            while True:
+                empty_meta = (self._group_name, [], [], [])
+                per_pp_meta = [None] * pp_size
+                dist.all_gather_object(per_pp_meta, empty_meta, group=pp_group)
+                if all(not meta[1] for meta in per_pp_meta):
+                    break
+                if self._is_leader:
+                    self._dispatch_from_gathered_meta(per_pp_meta)
+
+        if self._is_leader and self._pending_engine_refs:
+            ray.get(self._pending_engine_refs)
+        self._pending_engine_refs = []
 
 
 def connect_rollout_engines_from_distributed(

--- a/tests/e2e/megatron/test_weight_transfer_pp2.py
+++ b/tests/e2e/megatron/test_weight_transfer_pp2.py
@@ -1,0 +1,128 @@
+"""
+Integration test for multi-PP concurrent weight transfer.
+
+Verifies that the concurrent broadcast from all PP sources (PR #788)
+correctly transfers weights from Megatron training actors to SGLang
+rollout engines when pipeline-model-parallel-size > 1.
+
+Usage (inside the miles Docker container, 8 GPUs):
+    # Mount host model/dataset dirs to /root/models and /root/datasets:
+    podman run --rm -it --device nvidia.com/gpu=all --shm-size=16g \
+      -v /data/users/mogicianwu/github/miles:/root/miles \
+      -v /data/users/mogicianwu/models:/root/models \
+      -v /data/users/mogicianwu/datasets:/root/datasets \
+      -w /root/miles radixark/miles:nightly-dev-20260113a bash
+
+    CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 python tests/e2e/megatron/test_weight_transfer_pp2.py
+
+The test:
+  1. Downloads Qwen3-0.6B (small model, fast checkpoint conversion)
+  2. Converts to Megatron distributed format with PP=2, TP=2 (4 train GPUs)
+  3. Runs 1 rollout with weight transfer from all PP sources concurrently
+  4. If the weight transfer is broken, the rollout/training step will fail.
+"""
+
+import os
+from pathlib import Path
+
+import miles.utils.external_utils.command_utils as U
+from miles.utils.misc import exec_command
+
+MODEL_NAME = "Qwen3-0.6B"
+MODEL_TYPE = "qwen3-0.6B"
+NUM_GPUS = 8
+
+repo_base_dir = Path(os.path.abspath(__file__)).resolve().parents[3]
+
+
+def prepare():
+    exec_command("mkdir -p /root/models /root/datasets")
+    # If model/dataset are pre-downloaded and mounted, skip download.
+    # Otherwise, download them (requires network access).
+    if not os.path.isdir(f"/root/models/{MODEL_NAME}"):
+        exec_command(f"huggingface-cli download Qwen/{MODEL_NAME} --local-dir /root/models/{MODEL_NAME}")
+    if not os.path.isfile("/root/datasets/dapo-math-17k/dapo-math-17k.jsonl"):
+        U.hf_download_dataset("zhuzilin/dapo-math-17k")
+    U.convert_checkpoint(
+        model_name=MODEL_NAME, megatron_model_type=MODEL_TYPE, num_gpus_per_node=NUM_GPUS, dir_dst="/root/models"
+    )
+
+
+def execute():
+    ckpt_args = f"--hf-checkpoint /root/models/{MODEL_NAME}/ --ref-load /root/models/{MODEL_NAME}_torch_dist"
+
+    rollout_args = (
+        "--prompt-data /root/datasets/dapo-math-17k/dapo-math-17k.jsonl "
+        "--input-key prompt "
+        "--label-key label "
+        "--apply-chat-template "
+        "--rollout-shuffle "
+        "--rm-type deepscaler "
+        "--num-rollout 1 "
+        "--rollout-batch-size 8 "
+        "--n-samples-per-prompt 8 "
+        "--rollout-max-response-len 100 "
+        "--rollout-temperature 0.8 "
+        "--global-batch-size 32"
+    )
+
+    perf_args = (
+        "--tensor-model-parallel-size 2 "
+        "--pipeline-model-parallel-size 2 "
+        "--context-parallel-size 1 "
+        "--expert-model-parallel-size 1 "
+        "--expert-tensor-parallel-size 1 "
+        "--use-dynamic-batch-size "
+        "--max-tokens-per-gpu 2048"
+    )
+
+    grpo_args = (
+        "--advantage-estimator grpo "
+        "--kl-loss-coef 0.00 "
+        "--kl-loss-type low_var_kl "
+        "--entropy-coef 0.00 "
+        "--eps-clip 0.2 "
+        "--eps-clip-high 0.28"
+    )
+
+    optimizer_args = (
+        "--optimizer adam "
+        "--lr 1e-6 "
+        "--lr-decay-style constant "
+        "--weight-decay 0.1 "
+        "--adam-beta1 0.9 "
+        "--adam-beta2 0.98"
+    )
+
+    sglang_args = (
+        "--rollout-num-gpus-per-engine 2 "
+        "--rollout-num-gpus 4 "
+        "--sglang-mem-fraction-static 0.8"
+    )
+
+    misc_args = (
+        "--attention-dropout 0.0 "
+        "--hidden-dropout 0.0 "
+        "--accumulate-allreduce-grads-in-fp32 "
+        "--attention-softmax-in-fp32 "
+        "--attention-backend flash "
+        "--actor-num-nodes 1 "
+        "--actor-num-gpus-per-node 4 "
+        f"--update-weight-buffer-size {1 * 1024 ** 3}"
+    )
+
+    all_args = f"{ckpt_args} {rollout_args} {perf_args} {grpo_args} {optimizer_args} {sglang_args} {misc_args}"
+
+    U.execute_train(
+        train_args=all_args,
+        num_gpus_per_node=NUM_GPUS,
+        megatron_model_type=MODEL_TYPE,
+        train_script="train_async.py",
+    )
+
+
+if __name__ == "__main__":
+    prepare()
+    for proxy_var in ("http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY"):
+        os.environ.pop(proxy_var, None)
+    execute()


### PR DESCRIPTION
Migrated from https://github.com/JD-ETH/slime/pull/22

## Concurrent PP Broadcast

### Problem

When pipeline parallelism (PP) > 1, each PP source rank owns a separate NCCL group
(`miles-pp_{pp_rank}`) and broadcasts its weight buckets to rollout engines independently.
The old approach used a distributed lock to serialize these broadcasts: each PP source
acquired the lock, dispatched Ray calls to tell engines to join its NCCL group, broadcast,
then released the lock. This prevented NCCL deadlocks (engines joining groups in the wrong
order) but forced all PP stages to transfer sequentially.

### Solution

Replace the lock-based serial protocol with a coordinated concurrent broadcast protocol:

- PP sources synchronize per-bucket via `all_gather_object` on the PP process group.
- The leader (global rank 0) collects metadata from all PP sources and dispatches Ray calls
  for all PP groups before any source starts broadcasting.
- Each PP source then broadcasts on its own NCCL group concurrently.
- A `_finish_phase_sync` draining loop handles unequal bucket counts across PP stages.

### Old Protocol (Serial, Lock-Based)

Each PP source acquires a global lock, blocking all others.

```
Time ──►

PP_0:  [acquire lock] → [Ray dispatch] → [NCCL bcast] → [release lock]
                                                             │
         ◄──────────── BLOCKED ──────────────────────────────┘
                                                             │
PP_1:  [acquire lock] → [Ray dispatch] → [NCCL bcast] → [release lock]

Total time = T(pp_0) + T(pp_1) — fully serial.
```

### New Protocol (Concurrent, Coordinated)

All PP sources synchronize metadata via all_gather_object. The leader dispatches
engine-side Ray calls for all groups at once. Each source broadcasts concurrently.

```
Time ──►

[all_gather_object] → Leader dispatches ALL Ray calls
                         │
            ┌────────────┴────────────┐
            ▼                         ▼
PP_0: [NCCL bcast on pp_0]   PP_1: [NCCL bcast on pp_1]  ← CONCURRENT
            │                         │
            └────────────┬────────────┘
                         ▼
                [_finish_phase_sync]
```

### State Machine

```mermaid
stateDiagram-v2
    [*] --> PauseEngines: rank 0 only
    PauseEngines --> FlushCache: ray.get(pause_generation)
    FlushCache --> Barrier: ray.get(flush_cache)
    Barrier --> NonExpertPhase: dist.barrier (all ranks)

    state NonExpertPhase {
        [*] --> TPAllGather: each param
        TPAllGather --> ConvertToHF: PP source ranks only
        ConvertToHF --> BufferFull
        BufferFull --> BucketTransfer: buffer > threshold
        BufferFull --> TPAllGather: buffer ≤ threshold
        BucketTransfer --> TPAllGather
        TPAllGather --> FlushRemaining: no more params
        FlushRemaining --> PhaseSync
    }

    state BucketTransfer {
        [*] --> AllGatherMeta: all_gather_object across PP group
        AllGatherMeta --> LeaderDispatch: leader schedules engine updates for ALL PP sources
        LeaderDispatch --> NCCLBroadcast: each PP source broadcasts on its own group concurrently
        NCCLBroadcast --> [*]
    }

    state PhaseSync {
        [*] --> EmptyAllGather: sources that finished early
        EmptyAllGather --> CheckAllDone
        CheckAllDone --> EmptyAllGather: some PP source still has data
        CheckAllDone --> WaitEngineRefs: all empty
        WaitEngineRefs --> [*]: leader: ray.get(pending_refs)
    }

    NonExpertPhase --> ExpertPhase
    ExpertPhase --> ContinueGeneration: rank 0 only
    ContinueGeneration --> [*]: ray.get(continue_generation)
```

### E2E Test Verification

**Config**: Qwen3-0.6B, PP=2, TP=2, 4 train GPUs + 2 rollout engines × 2 GPUs each (8 GPUs total)

**Test file**: `tests/e2e/megatron/test_weight_transfer_pp2.py`

| Check | Result |
|-------|--------|
| NCCL groups created | ✅ `miles-pp_0` (world_size=5) and `miles-pp_1` (world_size=5) |
| Concurrent broadcast | ✅ Both PP ranks transferred weights (`1it` each) |
| `update_weights_from_distributed` | ✅ 200 OK on all engines |
| Rollout after transfer | ✅ Generate requests completed |
| Training step | ✅ Step 1 completed with valid metrics |
| Job exit | ✅ `Job succeeded` |

#### Log evidence

```
# Two independent NCCL groups created (one per PP source):
init custom process group: ..., group_name=miles-pp_0, backend=nccl
init custom process group: ..., group_name=miles-pp_1, backend=nccl

# Both PP sources transferred weights:
[miles-pp_0] Update weights: 1it [00:01, 1.37s/it]
[miles-pp_1] Update weights: 1it [00:02, 2.15s/it]

# Engine-side NCCL receives completed:
"POST /update_weights_from_distributed HTTP/1.1" 200 OK [repeated 7x across cluster]
```

#### Run command

```bash
podman run --rm --device nvidia.com/gpu=all --shm-size=16g --pids-limit=-1 \
  -v $MILES_DIR:/root/miles -v $MODELS_DIR:/root/models -v $DATASETS_DIR:/root/datasets \
  -w /root/miles radixark/miles:nightly-dev-20260113a \
  bash -c 'CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 python -u tests/e2e/megatron/test_weight_transfer_pp2.py'
```