### PR TITLE
[ci] GB300/cu13 CI validation: PR CI tests all pass on GB300

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,6 +21,7 @@ ARG ENABLE_CUDA_13=0
 
 ARG WHEELS_REPO=yueming-yuan/miles-wheels
 ARG WHEELS_TAG=cu129-x86_64
+ARG GITHUB_TOKEN=""
 
 # ======================================== Setup =============================================
 
@@ -43,9 +44,11 @@ RUN git clone https://github.com/NVIDIA/nccl-tests.git /tmp/nccl-tests && \
 # ====================================== Download pre-built wheels ============================================
 
 RUN mkdir -p /tmp/wheels && \
-    curl -sL "https://api.github.com/repos/${WHEELS_REPO}/releases/tags/${WHEELS_TAG}" \
-    | python3 -c "import sys, json, subprocess; \
-[subprocess.run(['curl', '-fSL', '-o', '/tmp/wheels/' + a['name'], a['browser_download_url']], check=True) \
+    export GH_TOKEN="${GITHUB_TOKEN}" && \
+    curl -sL -H "Authorization: token ${GITHUB_TOKEN}" "https://api.github.com/repos/${WHEELS_REPO}/releases/tags/${WHEELS_TAG}" \
+    | python3 -c "import sys, json, subprocess, os; \
+token = os.environ.get('GH_TOKEN', ''); \
+[subprocess.run(['curl', '-fSL', '-H', 'Authorization: token ' + token, '-H', 'Accept: application/octet-stream', '-o', '/tmp/wheels/' + a['name'], a['url']], check=True) \
  for a in json.load(sys.stdin)['assets'] if a['name'].endswith('.whl')]" && \
     ls -lh /tmp/wheels/
 
@@ -68,7 +71,7 @@ RUN pip install tilelang -f https://tile-ai.github.io/whl/nightly/cu128/
 
 RUN if [ "${ENABLE_CUDA_13}" = "1" ]; then \
       pip install nvidia-mathdx==25.6.0 && \
-      pip -v install --no-build-isolation "transformer_engine[core_cu13,pytorch]==2.10.0"; \
+      pip -v install --no-build-isolation "transformer_engine[core_cu13,pytorch]==2.12.0"; \
     else \
       pip -v install --no-build-isolation "transformer_engine[pytorch]==2.10.0"; \
     fi

--- a/tests/e2e/sglang_config/test_sglang_config.py
+++ b/tests/e2e/sglang_config/test_sglang_config.py
@@ -7,22 +7,24 @@ TIGHT_DEVICE_MEMORY = U.get_bool_env_var("MILES_TEST_TIGHT_DEVICE_MEMORY", "1")
 
 MODEL_NAME = "Qwen2.5-0.5B-Instruct"
 MODEL_TYPE = "qwen2.5-0.5B"
-NUM_GPUS = 8
+FEW_GPU = U.get_bool_env_var("MILES_TEST_FEW_GPU", "0")
+NUM_GPUS = 4 if FEW_GPU else 8
+GROUP_GPUS = NUM_GPUS // 2
 
 # Inline sglang config: same model, 2 engine groups with different sizes.
-# Group 1: 4 GPUs, 1 GPU/engine (tp=1) -> 4 engines
-# Group 2: 4 GPUs, 1 GPU/engine (tp=1) -> 4 engines
+# Group 1: GROUP_GPUS GPUs, 1 GPU/engine (tp=1) -> GROUP_GPUS engines
+# Group 2: GROUP_GPUS GPUs, 1 GPU/engine (tp=1) -> GROUP_GPUS engines
 # Tests that ServerGroup/RolloutServer correctly manages multiple groups
 # behind a single router, with separate port cursors per group.
-SGLANG_CONFIG_YAML = """\
+SGLANG_CONFIG_YAML = f"""\
 sglang:
   - name: default
     server_groups:
       - worker_type: regular
-        num_gpus: 4
+        num_gpus: {GROUP_GPUS}
         num_gpus_per_engine: 1
       - worker_type: regular
-        num_gpus: 4
+        num_gpus: {GROUP_GPUS}
         num_gpus_per_engine: 1
 """
 
@@ -113,7 +115,7 @@ def execute():
         "--attention-softmax-in-fp32 "
         "--attention-backend flash "
         "--actor-num-nodes 1 "
-        "--actor-num-gpus-per-node 8 "
+        f"--actor-num-gpus-per-node {NUM_GPUS} "
         "--colocate "
         "--megatron-to-hf-mode bridge "
     )

--- a/tests/e2e/sglang_config/test_sglang_config_mixed_offload.py
+++ b/tests/e2e/sglang_config/test_sglang_config_mixed_offload.py
@@ -22,22 +22,24 @@ TIGHT_DEVICE_MEMORY = U.get_bool_env_var("MILES_TEST_TIGHT_DEVICE_MEMORY", "1")
 
 MODEL_NAME = "Qwen2.5-0.5B-Instruct"
 MODEL_TYPE = "qwen2.5-0.5B"
-NUM_GPUS = 8
+FEW_GPU = U.get_bool_env_var("MILES_TEST_FEW_GPU", "0")
+NUM_GPUS = 4 if FEW_GPU else 8
+GROUP_GPUS = NUM_GPUS // 2
 
-# Two models on 8 GPUs (colocate): actor gets weight updates, ref is frozen.
-SGLANG_CONFIG_YAML = """\
+# Two models on NUM_GPUS GPUs (colocate): actor gets weight updates, ref is frozen.
+SGLANG_CONFIG_YAML = f"""\
 sglang:
   - name: actor
     update_weights: true
     server_groups:
       - worker_type: regular
-        num_gpus: 4
+        num_gpus: {GROUP_GPUS}
         num_gpus_per_engine: 1
   - name: ref
     update_weights: false
     server_groups:
       - worker_type: regular
-        num_gpus: 4
+        num_gpus: {GROUP_GPUS}
         num_gpus_per_engine: 1
 """
 
@@ -124,7 +126,7 @@ def execute():
         "--attention-softmax-in-fp32 "
         "--attention-backend flash "
         "--actor-num-nodes 1 "
-        "--actor-num-gpus-per-node 8 "
+        f"--actor-num-gpus-per-node {NUM_GPUS} "
         "--colocate "
         "--megatron-to-hf-mode bridge "
     )

--- a/tests/e2e/sglang_config/test_sglang_config_mixed_offload_ft.py
+++ b/tests/e2e/sglang_config/test_sglang_config_mixed_offload_ft.py
@@ -19,22 +19,24 @@ TIGHT_DEVICE_MEMORY = U.get_bool_env_var("MILES_TEST_TIGHT_DEVICE_MEMORY", "1")
 
 MODEL_NAME = "Qwen2.5-0.5B-Instruct"
 MODEL_TYPE = "qwen2.5-0.5B"
-NUM_GPUS = 8
+FEW_GPU = U.get_bool_env_var("MILES_TEST_FEW_GPU", "0")
+NUM_GPUS = 4 if FEW_GPU else 8
+GROUP_GPUS = NUM_GPUS // 2
 
-# Two models on 8 GPUs (colocate): actor gets weight updates, ref is frozen.
-SGLANG_CONFIG_YAML = """\
+# Two models on NUM_GPUS GPUs (colocate): actor gets weight updates, ref is frozen.
+SGLANG_CONFIG_YAML = f"""\
 sglang:
   - name: actor
     update_weights: true
     server_groups:
       - worker_type: regular
-        num_gpus: 4
+        num_gpus: {GROUP_GPUS}
         num_gpus_per_engine: 1
   - name: ref
     update_weights: false
     server_groups:
       - worker_type: regular
-        num_gpus: 4
+        num_gpus: {GROUP_GPUS}
         num_gpus_per_engine: 1
 """
 
@@ -130,7 +132,7 @@ def execute():
         "--attention-softmax-in-fp32 "
         "--attention-backend flash "
         "--actor-num-nodes 1 "
-        "--actor-num-gpus-per-node 8 "
+        f"--actor-num-gpus-per-node {NUM_GPUS} "
         "--colocate "
         "--megatron-to-hf-mode bridge "
     )

--- a/tests/e2e/sglang_patch/sglang_server.py
+++ b/tests/e2e/sglang_patch/sglang_server.py
@@ -71,8 +71,10 @@ def start_sglang_server(
     ]
     if enable_deterministic_inference:
         cmd.append("--enable-deterministic-inference")
-        # trtllm_mha (default on Blackwell) does not support deterministic inference;
-        # fall back to flashinfer automatically.
+        # SGLang bug: _get_default_attn_backend() sets attention_backend="trtllm_mha"
+        # before _handle_deterministic_inference() runs, so the None-check there is
+        # bypassed and it raises ValueError instead of auto-selecting flashinfer.
+        # Upstream fix: https://github.com/sgl-project/sglang/pull/21450
         major, _ = torch.cuda.get_device_capability()
         if major >= 10:
             cmd.extend(["--attention-backend", "flashinfer"])

--- a/tests/e2e/sglang_patch/sglang_server.py
+++ b/tests/e2e/sglang_patch/sglang_server.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import IO
 
 import requests
+import torch
 
 from miles.utils.http_utils import find_available_port
 
@@ -70,6 +71,11 @@ def start_sglang_server(
     ]
     if enable_deterministic_inference:
         cmd.append("--enable-deterministic-inference")
+        # trtllm_mha (default on Blackwell) does not support deterministic inference;
+        # fall back to flashinfer automatically.
+        major, _ = torch.cuda.get_device_capability()
+        if major >= 10:
+            cmd.extend(["--attention-backend", "flashinfer"])
     if extra_args:
         cmd.extend(extra_args)
 


### PR DESCRIPTION
# GB300 CI Test Results

**Machine**: GB300 NVL4 node — 4x GPU (Blackwell, CUDA 13, arm64)
**Container**: `miles-cu13-arm64` built on commit `0ad4952d`
**Branch**: `cu13_gb300_ci`
**Run date**: 2026-03-25/26

All tests are from the default PR CI tier (`.github/workflows/pr-test.yml`), run with `MILES_TEST_FEW_GPU=1` (4 GPUs instead of 8).

## Results

| Test | Result |
|------|--------|
| `tests/fast` | ✅ 1040 passed, 31 skipped, 1 xfailed |
| `e2e/short/test_qwen2.5_0.5B_gsm8k_short.py` | ✅ passed |
| `e2e/short/test_qwen2.5_0.5B_gsm8k_async_short.py` | ✅ passed |
| `e2e/short/test_qwen3_0.6B_fsdp_colocated_2xGPU.py` | ✅ passed |
| `e2e/sglang_patch/test_chat_input_ids_equivalence.py` | ✅ passed |
| `e2e/sglang_config/test_sglang_config.py` | ✅ passed |
| `e2e/sglang_config/test_sglang_config_mixed_offload.py` | ✅ passed |
| `e2e/sglang_config/test_sglang_config_mixed_offload_ft.py` | ✅ passed |

## GB300-Specific Fixes

- **`sglang_server.py`**: Auto-detect Blackwell (compute capability ≥ 10) and add `--attention-backend flashinfer` when `--enable-deterministic-inference` is used. Default `trtllm_mha` backend rejects deterministic inference on Blackwell.
- **sglang_config tests**: Added `MILES_TEST_FEW_GPU` support (default 8 GPUs, set to 4 for GB300 NVL4).
