### PR TITLE
Fix AttributeError in --log-reward-category help text

### DIFF
--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -1171,7 +1171,7 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 default=None,
                 help=(
                     "Log statistics of the category of reward, such as why the reward function considers it as failed. "
-                    "Specify the key in the reward dict using this argument.",
+                    "Specify the key in the reward dict using this argument."
                 ),
             )
             parser.add_argument(


### PR DESCRIPTION
## Summary
Fixes #635

The `help` parameter for `--log-reward-category` in `miles/utils/arguments.py` had a trailing comma after the string literal, turning it into a single-element tuple instead of a string. This caused `argparse` to crash with `AttributeError: 'tuple' object has no attribute 'strip'` when running `--help`.

Removed the trailing comma so `help` is a plain string.

## Verification
- `python3 train.py --help` no longer crashes with an `AttributeError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)