### PR TITLE
[fix] restore expert_bias to fp32 before bridge weight export

### DIFF
--- a/miles/utils/megatron_bridge_utils.py
+++ b/miles/utils/megatron_bridge_utils.py
@@ -15,6 +15,13 @@ def patch_megatron_model(model):
         model_config.share_embeddings_and_output_weights = unwrapped_model.share_embeddings_and_output_weights
         attribute_was_added = True
 
+    # Float16Module casts buffers to bf16, but expert_bias must stay fp32.
+    # Restore before bridge export reads the values.
+    for m in model:
+        for module in m.modules():
+            if hasattr(module, "_maintain_float32_expert_bias"):
+                module._maintain_float32_expert_bias()
+
     try:
         yield
     finally:


### PR DESCRIPTION
## Summary
- Float16Module casts all buffers to bf16, including `expert_bias` which must stay fp32
- Megatron has `_maintain_float32_expert_bias()` to restore it after `forward()`, but bridge export happens outside the forward path
- This causes bf16-truncated expert_bias values to be sent to SGLang during weight update, failing `--check-weight-update-equal`
- Fix: call `_maintain_float32_expert_bias()` in `patch_megatron_model` before bridge export reads the buffer
