### PR TITLE
[fix] tiny fix dumper code path issue

### DIFF
--- a/miles/backends/megatron_utils/arguments.py
+++ b/miles/backends/megatron_utils/arguments.py
@@ -1,8 +1,8 @@
 import logging
 import os
 
-from megatron.core.tokenizers.utils.build_tokenizer import vocab_size_with_padding as _vocab_size_with_padding
 from megatron.training.arguments import parse_args, validate_args
+from megatron.training.tokenizer.tokenizer import _vocab_size_with_padding
 
 __all__ = ["validate_args", "parse_args", "set_default_megatron_args"]
 


### PR DESCRIPTION
ci-sglang-pr: #21644

without this will report this bug:
```
Traceback (most recent call last):
  File "/__w/miles/miles/train.py", line 4, in <module>
    from miles.ray.placement_group import create_placement_groups, create_rollout_manager, create_training_models
  File "/__w/miles/miles/miles/ray/placement_group.py", line 10, in <module>
    from .rollout import RolloutManager
  File "/__w/miles/miles/miles/ray/rollout.py", line 26, in <module>
    from miles.utils import dumper_utils, tracking_utils
  File "/__w/miles/miles/miles/utils/dumper_utils.py", line 15, in <module>
    from sglang.srt.debug_utils.dumper import DumperConfig, _get_rank, dumper
ImportError: cannot import name 'DumperConfig' from 'sglang.srt.debug_utils.dumper' (/sgl-workspace/sglang/python/sglang/srt/debug_utils/dumper.py). Did you mean: '_DumperConfig'? 
```

and a megatron import bug.

https://github.com/sgl-project/sglang/pull/21644