### PR TITLE
fix: use add_argument for --low-memory-resume

### DIFF
--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -199,8 +199,7 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 action="store_true",
                 default=False,
             )
-            reset_arg(
-                parser,
+            parser.add_argument(
                 "--low-memory-resume",
                 action="store_true",
                 default=False,


### PR DESCRIPTION
## Summary
- `--low-memory-resume` is a new argument, not an existing Megatron arg, so `add_argument` is the correct API instead of `reset_arg`
- `reset_arg` is designed to override defaults of pre-existing Megatron arguments; using it for new args is semantically wrong (though functionally equivalent via the fallback path)

## Test plan
- [ ] Verify `--low-memory-resume` flag is still recognized and works correctly