### PR TITLE
Fix hash file path dp rank instead of dcp rank

### DIFF
--- a/miles/backends/megatron_utils/ci_utils.py
+++ b/miles/backends/megatron_utils/ci_utils.py
@@ -61,7 +61,7 @@ def compute_model_hashes_by_layer(model: Sequence[DDP]) -> dict[str, str]:
 def _hash_file_path(base_dir: str | Path, iteration: int) -> Path:
     tp_rank = mpu.get_tensor_model_parallel_rank()
     pp_rank = mpu.get_pipeline_model_parallel_rank()
-    dp_rank = mpu.get_data_parallel_rank(with_context_parallel=True)
+    dp_rank = mpu.get_data_parallel_rank(with_context_parallel=False)
     cp_rank = mpu.get_context_parallel_rank()
     base = Path(base_dir)
     iter_dir = base if base.name.startswith("iter_") else base / f"iter_{int(iteration):07d}"


### PR DESCRIPTION
found when refactoring mpu.get_data_parallel_rank