### PR TITLE
fix: remove branches filter so PR Test CI triggers on all PRs

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -29,7 +29,6 @@ on:
   # push:
   #   branches: [main]
   pull_request:
-    branches: [main]
     types: [synchronize, labeled]
   workflow_dispatch:
     inputs:

--- a/.github/workflows/pr-test.yml.j2
+++ b/.github/workflows/pr-test.yml.j2
@@ -134,7 +134,6 @@ on:
   # push:
   #   branches: [main]
   pull_request:
-    branches: [main]
     types: [synchronize, labeled]
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
## Summary
- Remove `branches: [main]` filter from `pr-test.yml` so that CI triggers on PRs targeting any branch, not just `main`
- Previously PRs like #830 (targeting `feat/refactor_dp/3`) silently skipped CI

## Changes
- `.github/workflows/pr-test.yml.j2`: removed `branches: [main]` under `pull_request`
- `.github/workflows/pr-test.yml`: regenerated from template