### PR TITLE
Fix: restore weights CPU backup for offloaded SGLang EP rollout

### DIFF
--- a/miles/backends/sglang_utils/sglang_engine.py
+++ b/miles/backends/sglang_utils/sglang_engine.py
@@ -594,6 +594,9 @@ def _compute_server_args(
     if sglang_overrides:
         kwargs.update(sglang_overrides)
 
+    if args.offload_rollout and "weight" in args.offload_rollout_level and args.sglang_ep_size > 1:
+        kwargs["enable_weights_cpu_backup"] = True
+
     if worker_type == "prefill":
         kwargs["disaggregation_mode"] = "prefill"
         kwargs["load_balance_method"] = "round_robin"


### PR DESCRIPTION
## Summary

Fixes garbage rollout outputs when SGLang rollout uses:
- weight offload
- expert parallelism (`ep_size > 1`)

## Root Cause

`enable_weights_cpu_backup` is no longer enabled for non-LoRA rollout by default ([0ca5c441f](https://github.com/radixark/miles/commit/0ca5c441f)). With offloaded EP rollout, this can lead to corrupted / gibberish outputs.

## Fix

Enable `enable_weights_cpu_backup` when:
- `offload_rollout` is enabled
- `"weight"` is in `offload_rollout_level`
- `sglang_ep_size > 1`
