### PR TITLE
Allow PR CI to trigger on any target branch

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -29,7 +29,6 @@ on:
   # push:
   #   branches: [main]
   pull_request:
-    branches: [main]
     types: [synchronize, labeled]
   workflow_dispatch:
     inputs:

--- a/.github/workflows/pr-test.yml.j2
+++ b/.github/workflows/pr-test.yml.j2
@@ -134,7 +134,6 @@ on:
   # push:
   #   branches: [main]
   pull_request:
-    branches: [main]
     types: [synchronize, labeled]
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
## Summary
- Remove `branches: [main]` filter from `pull_request` trigger in `pr-test.yml`
- This allows label-triggered CI jobs (megatron, precision, ckpt, etc.) to run on PRs targeting any branch, not just `main`

## Motivation
PRs targeting feature branches (e.g. `feat/refactor_dp/5`) cannot trigger CI via labels because the workflow only listened to PRs against `main`. The only workaround was `workflow_dispatch`, which runs all jobs unconditionally.