### PR TITLE
fix: respect NCCL_NVLS_ENABLE from environment

### DIFF
--- a/miles/utils/external_utils/command_utils.py
+++ b/miles/utils/external_utils/command_utils.py
@@ -156,6 +156,7 @@ def execute_train(
                     }
                 ),
                 "NCCL_NVLS_ENABLE": os.environ.get("NCCL_NVLS_ENABLE", str(int(check_has_nvlink()))),
+                **{k: os.environ[k] for k in ("NCCL_SOCKET_IFNAME", "GLOO_SOCKET_IFNAME") if k in os.environ},
                 "no_proxy": f"127.0.0.1,{master_addr}",
                 # This is needed by megatron / torch distributed in multi-node setup
                 "MASTER_ADDR": master_addr,


### PR DESCRIPTION
## Summary
- `check_has_nvlink()` detects intra-node NVLink and hardcodes `NCCL_NVLS_ENABLE=1` in `runtime_env_json`
- NVLS requires NVSwitch for cross-node communication; Docker multi-node setups without NVSwitch hang on `dist.init_process_group`
- Allow callers to override via `NCCL_NVLS_ENABLE=0` environment variable

## Test plan
- [x] Docker multi-node miles training with `NCCL_NVLS_ENABLE=0` exported in exec command