### PR TITLE
Fix flush_cache timeout by aborting stuck requests before flushing

### DIFF
--- a/miles/backends/megatron_utils/update_weight/update_weight_from_distributed.py
+++ b/miles/backends/megatron_utils/update_weight/update_weight_from_distributed.py
@@ -85,6 +85,7 @@ class UpdateWeightFromDistributed:
 
         if dist.get_rank() == 0:
             ray.get([engine.pause_generation.remote() for engine in self.rollout_engines])
+            ray.get([engine.abort_all.remote() for engine in self.rollout_engines])
             ray.get([engine.flush_cache.remote() for engine in self.rollout_engines])
 
             # int4/fp4 pre_process

--- a/miles/backends/megatron_utils/update_weight/update_weight_from_tensor.py
+++ b/miles/backends/megatron_utils/update_weight/update_weight_from_tensor.py
@@ -176,6 +176,7 @@ class UpdateWeightFromTensor:
         rank = dist.get_rank()
         if rank == 0:
             ray.get([engine.pause_generation.remote() for engine in self.rollout_engines])
+            ray.get([engine.abort_all.remote() for engine in self.rollout_engines])
             ray.get([engine.flush_cache.remote() for engine in self.rollout_engines])
             if self.quantization_config and self.quantization_config["quant_method"] in ["compressed-tensors"]:
                 post_process_weights(

--- a/miles/backends/sglang_utils/sglang_engine.py
+++ b/miles/backends/sglang_utils/sglang_engine.py
@@ -328,6 +328,15 @@ class SGLangEngine(RayActor):
             payload,
         )
 
+    def abort_all(self):
+        """Abort all pending requests on the server."""
+        if self.node_rank != 0:
+            return
+        try:
+            requests.post(f"http://{self.server_host}:{self.server_port}/abort_request", json={"abort_all": True})
+        except Exception as e:
+            logger.warning(f"Error aborting requests: {e}")
+
     def flush_cache(self):
         """Flush the cache of the server."""
         if self.node_rank != 0:


### PR DESCRIPTION
## Summary
- Abort all in-flight requests (via `abort_all`) before calling `flush_cache` on rollout engines, preventing timeout when stuck requests block the cache flush.
- Adds `abort_all` method to `SglangEngine` and applies the fix in both `update_weight_from_distributed` and `update_weight_from_tensor` paths.