### PR TITLE
Fix: Miles Router proxy forwards stale Content-Length, crashing rollout generation

### DIFF
--- a/miles/router/router.py
+++ b/miles/router/router.py
@@ -171,6 +171,7 @@ class MilesRouter:
         content = result["response_body"]
         status_code = result["status_code"]
         headers = result["headers"]
+        headers = {k: v for k, v in headers.items() if k.lower() not in ("content-length", "transfer-encoding")}
         content_type = headers.get("content-type", "")
         try:
             data = json.loads(content)


### PR DESCRIPTION
Sometimes when running with `--use-miles-router --use-rollout-routing-replay`, the first rollout generation crashes with repeated `h11.LocalProtocolError: Too much data for declared Content-Length` errors from the Miles Router's uvicorn server.

```
(RolloutManager pid=23501) h11._util.LocalProtocolError: Too much data for declared Content-Length
(RolloutManager pid=23501) [2026-04-01 03:07:32] http_utils.py:187 - Error: peer closed connection without
  sending complete message body (received 0 bytes, expected 928786), retrying...
  (attempt 1/60, url=http://192.168.60.180:4077/generate, response=None)
```
The fix: strip `content-length` and `transfer-encoding` from upstream response headers before constructing the proxy response.

Same as: https://github.com/radixark/miles/blob/978c2fdb78d99085af54702c935dd0403f3cc43a/miles/router/router.py#L154-L155