### PR TITLE
[fix] remove assert for over sampling batch size

### DIFF
--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -1917,8 +1917,8 @@ def miles_validate_args(args):
     if args.over_sampling_batch_size < args.rollout_batch_size:
         logger.warning(
             f"over_sampling_batch_size {args.over_sampling_batch_size} should be greater than or equal to "
-            f"rollout_batch_size {args.rollout_batch_size}, if you use dynamic filtering, you can ignore "
-            f"this warning."
+            f"rollout_batch_size {args.rollout_batch_size}, but if you use dynamic filtering, you can"
+            f"ignore this warning."
         )
 
     if args.num_epoch is not None:


### PR DESCRIPTION
The policy of dynamic filter is:

As long as the (completed, passed filter groups) + (pending to complete groups) < rollout_batch_size. The sampling loop will continue add `over_sampling_batch_size` groups to rollout until the number of groups valid for training touch `rollout_batch_size`. Then the rest of the samples (might not complete, might complete but redundant) will be aborted and abandoned.

The default value of `over_sampling_batch_size`  is equal  to `rollout_batch_size`. So it might generate many waste.. This PR remove the assert and add a small warning.