### PR TITLE
[3/N][Weight_update] Multi-node P2P weight transfer example scripts and docs

### DIFF
--- a/docs/en/advanced/p2p-weight-transfer.md
+++ b/docs/en/advanced/p2p-weight-transfer.md
@@ -33,74 +33,49 @@ All the following settings are tested under h100-80g clusters.
 
 ### Single node: Qwen3-4B
 `tests/e2e/megatron/test_qwen3_4B_p2p.py`
-### Multi node: Qwen3-30B-A3B P2P Weight Transfer (4 nodes)
+### Multi node
 
-#### Files
+Each multi-node example ships a **prepare** script (download model/datasets, convert checkpoint) and a **run** script (launch Ray jobs). All scripts accept three positional arguments:
 
-* `examples/p2p_weight_transfer/prepare-qwen3-30B-A3B.sh`: download model/datasets and convert checkpoint.
-* `examples/p2p_weight_transfer/run-qwen3-30B-A3B-4node-profile.sh`: 4-node launch script (`broadcast` or `p2p` mode).
+| Argument | Description |
+|---|---|
+| `MODE` | `broadcast` or `p2p` |
+| `NODE_RANK` | `0` (head node) or `1..N` (worker nodes) |
+| `HEAD_NODE_IP` | IP address of the head node |
 
-#### Quick Start
+#### Qwen3-30B-A3B (4 nodes)
 
-1. Prepare checkpoints (run on a single node).
+| Script | Description |
+|---|---|
+| `examples/p2p_weight_transfer/prepare-qwen3-30B-A3B.sh` | Prepare: download model/datasets, convert checkpoint |
+| `examples/p2p_weight_transfer/run-qwen3-30B-A3B-4node-profile.sh` | Run: 4-node launch (`broadcast` or `p2p`) |
 
 ```bash
+# 1. Prepare (single node)
 bash examples/p2p_weight_transfer/prepare-qwen3-30B-A3B.sh
-```
 
-2. Launch Ray jobs on each node.
-
-```bash
-# On NODE 0 (head node)
-bash examples/p2p_weight_transfer/run-qwen3-30B-A3B-4node-profile.sh p2p 0 $HEAD_NODE_IP
-
-# On NODE 1-3 (worker nodes)
-bash examples/p2p_weight_transfer/run-qwen3-30B-A3B-4node-profile.sh p2p 1 $HEAD_NODE_IP
+# 2. Launch on each node
+bash examples/p2p_weight_transfer/run-qwen3-30B-A3B-4node-profile.sh p2p 0 $HEAD_NODE_IP  # head
+bash examples/p2p_weight_transfer/run-qwen3-30B-A3B-4node-profile.sh p2p 1 $HEAD_NODE_IP  # worker
 bash examples/p2p_weight_transfer/run-qwen3-30B-A3B-4node-profile.sh p2p 2 $HEAD_NODE_IP
 bash examples/p2p_weight_transfer/run-qwen3-30B-A3B-4node-profile.sh p2p 3 $HEAD_NODE_IP
 ```
 
-The script accepts three positional arguments:
+#### Qwen3-235B-A22B (16 nodes)
 
-| Argument | Description |
+| Script | Description |
 |---|---|
-| `MODE` | `broadcast` or `p2p` |
-| `NODE_RANK` | `0` (head node) or `1,2,3` (worker nodes) |
-| `HEAD_NODE_IP` | IP address of the head node |
-
-### Multi node: Qwen3-235B-A22B P2P Weight Transfer (16 nodes)
-
-#### Files
-
-* `examples/p2p_weight_transfer/prepare-qwen3-235b-A22B.sh`: download model/datasets and convert checkpoint.
-* `examples/p2p_weight_transfer/run-qwen3-235B-A22B-16node-profile.sh`: 16-node launch script (`broadcast` or `p2p` mode).
-
-#### Quick Start
-
-1. Prepare checkpoints (run on a single node).
+| `examples/p2p_weight_transfer/prepare-qwen3-235b-A22B.sh` | Prepare: download model/datasets, convert checkpoint |
+| `examples/p2p_weight_transfer/run-qwen3-235B-A22B-16node-profile.sh` | Run: 16-node launch (`broadcast` or `p2p`) |
 
 ```bash
+# 1. Prepare (single node)
 bash examples/p2p_weight_transfer/prepare-qwen3-235b-A22B.sh
-```
 
-2. Launch Ray jobs on each node.
-
-```bash
-# On NODE 0 (head node)
-bash examples/p2p_weight_transfer/run-qwen3-235B-A22B-16node-profile.sh p2p 0 $HEAD_NODE_IP
-
-# On NODE 1-15 (worker nodes)
-bash examples/p2p_weight_transfer/run-qwen3-235B-A22B-16node-profile.sh p2p 1 $HEAD_NODE_IP
-bash examples/p2p_weight_transfer/run-qwen3-235B-A22B-16node-profile.sh p2p 2 $HEAD_NODE_IP
+# 2. Launch on each node
+bash examples/p2p_weight_transfer/run-qwen3-235B-A22B-16node-profile.sh p2p 0 $HEAD_NODE_IP   # head
+bash examples/p2p_weight_transfer/run-qwen3-235B-A22B-16node-profile.sh p2p 1 $HEAD_NODE_IP   # worker
 ...
 bash examples/p2p_weight_transfer/run-qwen3-235B-A22B-16node-profile.sh p2p 15 $HEAD_NODE_IP
 ```
-
-The script accepts three positional arguments:
-
-| Argument | Description |
-|---|---|
-| `MODE` | `broadcast` or `p2p` |
-| `NODE_RANK` | `0` (head node) or `1..15` (worker nodes) |
-| `HEAD_NODE_IP` | IP address of the head node |
 

--- a/docs/en/advanced/p2p-weight-transfer.md
+++ b/docs/en/advanced/p2p-weight-transfer.md
@@ -31,7 +31,7 @@ P2P mode addresses this by having each training rank transfer only the specific 
 
 All the following settings are tested under h100-80g clusters.
 
-### Single node： Qwen3-4B
+### Single node: Qwen3-4B
 `tests/e2e/megatron/test_qwen3_4B_p2p.py`
 ### Multi node: Qwen3-30B-A3B P2P Weight Transfer (4 nodes)
 

--- a/docs/en/advanced/p2p-weight-transfer.md
+++ b/docs/en/advanced/p2p-weight-transfer.md
@@ -61,6 +61,22 @@ bash examples/p2p_weight_transfer/run-qwen3-30B-A3B-4node-profile.sh p2p 2 $HEAD
 bash examples/p2p_weight_transfer/run-qwen3-30B-A3B-4node-profile.sh p2p 3 $HEAD_NODE_IP
 ```
 
+#### GLM-4.7-Flash (2 nodes)
+
+| Script | Description |
+|---|---|
+| `examples/p2p_weight_transfer/prepare-glm4.7-flash.sh` | Prepare: install dependencies, download model/datasets, convert checkpoint |
+| `examples/p2p_weight_transfer/run-glm4.7-flash-2node-profile.sh` | Run: 2-node launch (`broadcast` or `p2p`) |
+
+```bash
+# 1. Prepare (single node)
+bash examples/p2p_weight_transfer/prepare-glm4.7-flash.sh
+
+# 2. Launch on each node
+bash examples/p2p_weight_transfer/run-glm4.7-flash-2node-profile.sh p2p 0 $HEAD_NODE_IP  # head
+bash examples/p2p_weight_transfer/run-glm4.7-flash-2node-profile.sh p2p 1 $HEAD_NODE_IP  # worker
+```
+
 #### Qwen3-235B-A22B (16 nodes)
 
 | Script | Description |

--- a/docs/en/advanced/p2p-weight-transfer.md
+++ b/docs/en/advanced/p2p-weight-transfer.md
@@ -67,3 +67,40 @@ The script accepts three positional arguments:
 | `MODE` | `broadcast` or `p2p` |
 | `NODE_RANK` | `0` (head node) or `1,2,3` (worker nodes) |
 | `HEAD_NODE_IP` | IP address of the head node |
+
+### Multi node: Qwen3-235B-A22B P2P Weight Transfer (16 nodes)
+
+#### Files
+
+* `examples/p2p_weight_transfer/prepare-qwen3-235b-A22B.sh`: download model/datasets and convert checkpoint.
+* `examples/p2p_weight_transfer/run-qwen3-235B-A22B-16node-profile.sh`: 16-node launch script (`broadcast` or `p2p` mode).
+
+#### Quick Start
+
+1. Prepare checkpoints (run on a single node).
+
+```bash
+bash examples/p2p_weight_transfer/prepare-qwen3-235b-A22B.sh
+```
+
+2. Launch Ray jobs on each node.
+
+```bash
+# On NODE 0 (head node)
+bash examples/p2p_weight_transfer/run-qwen3-235B-A22B-16node-profile.sh p2p 0 $HEAD_NODE_IP
+
+# On NODE 1-15 (worker nodes)
+bash examples/p2p_weight_transfer/run-qwen3-235B-A22B-16node-profile.sh p2p 1 $HEAD_NODE_IP
+bash examples/p2p_weight_transfer/run-qwen3-235B-A22B-16node-profile.sh p2p 2 $HEAD_NODE_IP
+...
+bash examples/p2p_weight_transfer/run-qwen3-235B-A22B-16node-profile.sh p2p 15 $HEAD_NODE_IP
+```
+
+The script accepts three positional arguments:
+
+| Argument | Description |
+|---|---|
+| `MODE` | `broadcast` or `p2p` |
+| `NODE_RANK` | `0` (head node) or `1..15` (worker nodes) |
+| `HEAD_NODE_IP` | IP address of the head node |
+

--- a/docs/en/advanced/p2p-weight-transfer.md
+++ b/docs/en/advanced/p2p-weight-transfer.md
@@ -26,3 +26,44 @@ P2P mode addresses this by having each training rank transfer only the specific 
 3. **P2P transfer**: Instead of a collective broadcast, each source rank writes bucketed weight tensors directly to the destination rollout rank's memory, in a write-only fashion.
 
 4. **Synchronization**: Once all RDMA writes are confirmed complete, rollout engines increment their weight version and resume generation for the next training step.
+
+## Examples
+
+All the following settings are tested under h100-80g clusters.
+
+### Single node： Qwen3-4B
+`tests/e2e/megatron/test_qwen3_4B_p2p.py`
+### Multi node: Qwen3-30B-A3B P2P Weight Transfer (4 nodes)
+
+#### Files
+
+* `examples/p2p_weight_transfer/prepare-qwen3-30B-A3B.sh`: download model/datasets and convert checkpoint.
+* `examples/p2p_weight_transfer/run-qwen3-30B-A3B-4node-profile.sh`: 4-node launch script (`broadcast` or `p2p` mode).
+
+#### Quick Start
+
+1. Prepare checkpoints (run on a single node).
+
+```bash
+bash examples/p2p_weight_transfer/prepare-qwen3-30B-A3B.sh
+```
+
+2. Launch Ray jobs on each node.
+
+```bash
+# On NODE 0 (head node)
+bash examples/p2p_weight_transfer/run-qwen3-30B-A3B-4node-profile.sh p2p 0 $HEAD_NODE_IP
+
+# On NODE 1-3 (worker nodes)
+bash examples/p2p_weight_transfer/run-qwen3-30B-A3B-4node-profile.sh p2p 1 $HEAD_NODE_IP
+bash examples/p2p_weight_transfer/run-qwen3-30B-A3B-4node-profile.sh p2p 2 $HEAD_NODE_IP
+bash examples/p2p_weight_transfer/run-qwen3-30B-A3B-4node-profile.sh p2p 3 $HEAD_NODE_IP
+```
+
+The script accepts three positional arguments:
+
+| Argument | Description |
+|---|---|
+| `MODE` | `broadcast` or `p2p` |
+| `NODE_RANK` | `0` (head node) or `1,2,3` (worker nodes) |
+| `HEAD_NODE_IP` | IP address of the head node |

--- a/examples/p2p_weight_transfer/prepare-glm4.7-flash.sh
+++ b/examples/p2p_weight_transfer/prepare-glm4.7-flash.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# Prepare script for GLM-4.7-Flash: install dependencies, download model/datasets
+# and convert checkpoint.
+#
+# Run this BEFORE run-glm4.7-flash-2node-profile.sh.
+#
+# Usage:
+#   bash prepare-glm4.7-flash.sh
+
+set -ex
+
+# ---------------------------------------------------------------------------
+# Model config
+# ---------------------------------------------------------------------------
+MODEL_NAME="GLM-4.7-Flash"
+MODEL_TYPE="glm4.7-flash"
+HF_REPO="zai-org/GLM-4.7-Flash"
+GPUS_PER_NODE=8
+
+# ---------------------------------------------------------------------------
+# Install transformers version that supports GLM-4.7-Flash
+# ---------------------------------------------------------------------------
+pip install git+https://github.com/huggingface/transformers.git@76732b4e7120808ff989edbd16401f61fa6a0afa
+
+# ---------------------------------------------------------------------------
+# Download model and datasets
+# ---------------------------------------------------------------------------
+mkdir -p /root/models /root/datasets
+hf download "$HF_REPO" --local-dir "/root/models/${MODEL_NAME}"
+
+python3 -c "
+from miles.utils.external_utils.command_utils import hf_download_dataset
+hf_download_dataset('zhuzilin/dapo-math-17k')
+hf_download_dataset('zhuzilin/aime-2024')
+"
+
+# ---------------------------------------------------------------------------
+# Convert checkpoint
+# ---------------------------------------------------------------------------
+mkdir -p /root/multinode
+python3 -c "
+from miles.utils.external_utils.command_utils import convert_checkpoint
+convert_checkpoint(
+    model_name='${MODEL_NAME}',
+    megatron_model_type='${MODEL_TYPE}',
+    num_gpus_per_node=${GPUS_PER_NODE},
+    dir_dst='/root/multinode',
+)
+"
+
+echo "Prepare done."

--- a/examples/p2p_weight_transfer/prepare-qwen3-235b-A22B.sh
+++ b/examples/p2p_weight_transfer/prepare-qwen3-235b-A22B.sh
@@ -1,0 +1,47 @@
+
+#!/bin/bash
+
+# Prepare script for Qwen3-235B-A22B: download model/datasets and convert checkpoint.
+#
+# Run this BEFORE run-qwen3-235B-A22B-16node-profile.sh.
+#
+# Usage:
+#   bash prepare-qwen3-235b-A22B.sh
+
+set -ex
+
+# ---------------------------------------------------------------------------
+# Model config
+# ---------------------------------------------------------------------------
+MODEL_NAME="Qwen3-235B-A22B-Instruct-2507"
+MODEL_TYPE="qwen3-235B-A22B"
+HF_REPO="Qwen/Qwen3-235B-A22B-Instruct-2507"
+GPUS_PER_NODE=4
+
+# ---------------------------------------------------------------------------
+# Download model and datasets
+# ---------------------------------------------------------------------------
+mkdir -p /root/models /root/datasets
+hf download "$HF_REPO" --local-dir "/root/models/${MODEL_NAME}"
+
+python3 -c "
+from miles.utils.external_utils.command_utils import hf_download_dataset
+hf_download_dataset('zhuzilin/dapo-math-17k')
+hf_download_dataset('zhuzilin/aime-2024')
+"
+
+# ---------------------------------------------------------------------------
+# Convert checkpoint
+# ---------------------------------------------------------------------------
+mkdir -p /root/multinode
+python3 -c "
+from miles.utils.external_utils.command_utils import convert_checkpoint
+convert_checkpoint(
+    model_name='${MODEL_NAME}',
+    megatron_model_type='${MODEL_TYPE}',
+    num_gpus_per_node=${GPUS_PER_NODE},
+    dir_dst='/root/multinode',
+)
+"
+
+echo "Prepare done."

--- a/examples/p2p_weight_transfer/prepare-qwen3-30B-A3B.sh
+++ b/examples/p2p_weight_transfer/prepare-qwen3-30B-A3B.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# Prepare script for Qwen3-30B-A3B: download model/datasets and convert checkpoint.
+#
+# Run this BEFORE run-qwen3-30B-A3B-4node-profile.sh.
+#
+# Usage:
+#   bash prepare-qwen3-30B-A3B.sh
+
+set -ex
+
+# ---------------------------------------------------------------------------
+# Model config
+# ---------------------------------------------------------------------------
+MODEL_NAME="Qwen3-30B-A3B"
+HF_REPO="Qwen/Qwen3-30B-A3B"
+MODEL_TYPE="qwen3-30B-A3B"
+GPUS_PER_NODE=4
+
+# ---------------------------------------------------------------------------
+# Download model and datasets
+# ---------------------------------------------------------------------------
+mkdir -p /root/models /root/datasets
+hf download "$HF_REPO" --local-dir "/root/models/${MODEL_NAME}"
+
+python3 -c "
+from miles.utils.external_utils.command_utils import hf_download_dataset
+hf_download_dataset('zhuzilin/dapo-math-17k')
+hf_download_dataset('zhuzilin/aime-2024')
+"
+
+# ---------------------------------------------------------------------------
+# Convert checkpoint
+# ---------------------------------------------------------------------------
+mkdir -p /root/multinode
+python3 -c "
+from miles.utils.external_utils.command_utils import convert_checkpoint
+convert_checkpoint(
+    model_name='${MODEL_NAME}',
+    megatron_model_type='${MODEL_TYPE}',
+    num_gpus_per_node=${GPUS_PER_NODE},
+    dir_dst='/root/multinode',
+)
+"
+
+echo "Prepare done."

--- a/examples/p2p_weight_transfer/run-glm4.7-flash-2node-profile.sh
+++ b/examples/p2p_weight_transfer/run-glm4.7-flash-2node-profile.sh
@@ -1,0 +1,287 @@
+#!/bin/bash
+
+# Multi-node (2-node) profiling script for GLM-4.7-Flash with broadcasting/p2p weight transfer.
+#
+# Usage:
+#   bash run-glm4.7-flash-2node-profile.sh <MODE> <NODE_RANK> <HEAD_NODE_IP>
+#
+#   MODE          : broadcast | p2p
+#   NODE_RANK     : 0 (head node) | 1 (worker node)
+#   HEAD_NODE_IP  : IP address of the head node
+#
+# Examples:
+#   bash run-glm4.7-flash-2node-profile.sh p2p 0 10.0.0.1   # head node
+#   bash run-glm4.7-flash-2node-profile.sh p2p 1 10.0.0.1   # worker node
+
+set -ex
+
+export PYTHONBUFFERED=16
+
+# ---------------------------------------------------------------------------
+# Positional arguments
+# ---------------------------------------------------------------------------
+if [ $# -lt 3 ]; then
+    echo "Usage: $0 <MODE> <NODE_RANK> <HEAD_NODE_IP>"
+    echo "  MODE         : broadcast | p2p"
+    echo "  NODE_RANK    : 0 (head) | 1 (worker)"
+    echo "  HEAD_NODE_IP : IP of the head node"
+    exit 1
+fi
+
+MODE="$1"              # broadcast | p2p
+NODE_RANK="$2"         # 0 = head, 1 = worker
+HEAD_NODE_IP="$3"      # head node IP address
+
+# ---------------------------------------------------------------------------
+# Cleanup stale processes (head node only)
+# ---------------------------------------------------------------------------
+if [ "$NODE_RANK" -eq 0 ]; then
+    pkill -9 sglang || true
+    sleep 3
+    ray stop --force || true
+    pkill -9 ray || true
+    pkill -9 python || true
+    sleep 3
+    pkill -9 ray || true
+    pkill -9 python || true
+    pkill -9 redis || true
+fi
+
+# ---------------------------------------------------------------------------
+# Fixed config
+# ---------------------------------------------------------------------------
+NNODES=2
+GPUS_PER_NODE=8
+NUM_TRAIN_GPUS=8      # 1 node
+NUM_ROLLOUT_GPUS=8    # 1 node
+SKIP_VALIDATION=0
+BUCKET_SIZE_GB=1.0
+NO_SAVE_OPTIM=0
+ENABLE_NCCL_NVLS=0
+
+NUM_TRAIN_NODES=$((NUM_TRAIN_GPUS / GPUS_PER_NODE))
+
+# ---------------------------------------------------------------------------
+# NVLink detection
+# ---------------------------------------------------------------------------
+NVLINK_COUNT=$(nvidia-smi topo -m 2>/dev/null | grep -o 'NV[0-9][0-9]*' | wc -l)
+if [ "$NVLINK_COUNT" -gt 0 ]; then
+    HAS_NVLINK=1
+else
+    HAS_NVLINK=0
+fi
+echo "HAS_NVLINK: $HAS_NVLINK (detected $NVLINK_COUNT NVLink references)"
+
+# ---------------------------------------------------------------------------
+# Model config
+# ---------------------------------------------------------------------------
+MODEL_NAME="GLM-4.7-Flash"
+MODEL_TYPE="glm4.7-flash"
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+MILES_ROOT="/root/miles"
+source "${MILES_ROOT}/scripts/models/${MODEL_TYPE}.sh"
+
+# ---------------------------------------------------------------------------
+# Determine modes to run
+# ---------------------------------------------------------------------------
+
+MODES=("$MODE")
+
+# ---------------------------------------------------------------------------
+# Execute one mode (broadcast or p2p)
+# ---------------------------------------------------------------------------
+run_mode() {
+    local mode="$1"
+
+    # --- Checkpoint ---
+    CKPT_ARGS=(
+        --hf-checkpoint "/root/models/${MODEL_NAME}/"
+        --ref-load "/root/multinode/${MODEL_NAME}_torch_dist/"
+    )
+    if [ "$NO_SAVE_OPTIM" -eq 1 ]; then
+        CKPT_ARGS+=(--no-save-optim)
+    fi
+
+    # --- Rollout ---
+    ROLLOUT_ARGS=(
+        --prompt-data /root/datasets/dapo-math-17k/dapo-math-17k.jsonl
+        --input-key prompt
+        --label-key label
+        --apply-chat-template
+        --rollout-shuffle
+        --rm-type deepscaler
+        --num-rollout 13
+        --rollout-batch-size 4
+        --n-samples-per-prompt 4
+        --rollout-max-response-len 100
+        --rollout-temperature 1.0
+        --global-batch-size 16
+        --balance-data
+    )
+
+    # --- Eval ---
+    EVAL_ARGS=(
+        --eval-prompt-data aime24 /root/datasets/aime-2024/aime-2024.jsonl
+        --n-samples-per-eval-prompt 16
+        --eval-max-response-len 16384
+        --eval-temperature 0.6
+        --eval-top-p 0.95
+    )
+
+    # --- Training parallelism ---
+    PERF_ARGS=(
+        --tensor-model-parallel-size 4
+        --sequence-parallel
+        --pipeline-model-parallel-size 1
+        --context-parallel-size 1
+        --expert-model-parallel-size 8
+        --expert-tensor-parallel-size 1
+        --recompute-granularity full
+        --recompute-method uniform
+        --recompute-num-layers 1
+        --use-dynamic-batch-size
+        --max-tokens-per-gpu 2048
+    )
+
+    # --- GRPO ---
+    GRPO_ARGS=(
+        --advantage-estimator grpo
+        --use-kl-loss
+        --kl-loss-coef 0.00
+        --kl-loss-type low_var_kl
+        --entropy-coef 0.00
+        --eps-clip 0.2
+        --eps-clip-high 0.28
+    )
+
+    # --- Optimizer ---
+    OPTIMIZER_ARGS=(
+        --optimizer adam
+        --lr 1e-6
+        --lr-decay-style constant
+        --weight-decay 0.1
+        --adam-beta1 0.9
+        --adam-beta2 0.98
+        --optimizer-cpu-offload
+        --overlap-cpu-optimizer-d2h-h2d
+        --use-precision-aware-optimizer
+    )
+
+    # --- WANDB ---
+    WANDB_ARGS=(
+        #--use-wandb
+    )
+
+    # --- SGLang: 2 engines x 4 GPUs ---
+    SGLANG_ARGS=(
+        # tp_size must divide num_attention_heads (GLM-4.7-Flash has 20 heads), so use tp=4.
+        --rollout-num-gpus-per-engine 4
+        --rollout-num-gpus ${NUM_ROLLOUT_GPUS}
+        --sglang-mem-fraction-static 0.7
+        --sglang-ep-size 4
+        --sglang-cuda-graph-bs 1 2 4 8 16
+        # --use-miles-router
+        --sglang-enable-dp-attention
+        --sglang-enable-dp-lm-head
+    )
+    if [ "$mode" = "p2p" ]; then
+        SGLANG_ARGS+=(--sglang-remote-instance-weight-loader-start-seed-via-transfer-engine)
+    fi
+    if [ "$SKIP_VALIDATION" -eq 1 ]; then
+        SGLANG_ARGS+=(--sglang-load-format dummy)
+    fi
+
+    # --- Misc ---
+    BUFFER_SIZE=$((1 * 1024 * 1024 * 1024))
+
+    MISC_ARGS=(
+        --attention-dropout 0.0
+        --hidden-dropout 0.0
+        --accumulate-allreduce-grads-in-fp32
+        --attention-softmax-in-fp32
+        --attention-backend flash
+        --actor-num-nodes ${NUM_TRAIN_NODES}
+        --actor-num-gpus-per-node ${GPUS_PER_NODE}
+        --update-weight-buffer-size ${BUFFER_SIZE}
+        --update-weight-transfer-mode ${mode}
+        --check-weight-update-equal
+    )
+
+    # --- Worker nodes sleep to let head node start first ---
+    if [ "$NODE_RANK" -gt 0 ]; then
+        sleep 20
+    fi
+
+    # --- MC transfer timeout ---
+    MC_TRANSFER_TIMEOUT=300
+
+    NCCL_NVLS_VAL="0"
+    if [ "$ENABLE_NCCL_NVLS" -eq 1 ]; then
+        NCCL_NVLS_VAL="1"
+    fi
+
+    # --- Launch Ray ---
+    if [ "$NODE_RANK" -eq 0 ]; then
+        ray start --head --node-ip-address "${HEAD_NODE_IP}" --num-gpus ${GPUS_PER_NODE} \
+            --disable-usage-stats --dashboard-host=0.0.0.0 --dashboard-port=8265
+    else
+        ray start --address="${HEAD_NODE_IP}:6379" --num-gpus ${GPUS_PER_NODE} --disable-usage-stats
+    fi
+
+    # --- Build runtime env JSON ---
+    RUNTIME_ENV_JSON="{
+  \"env_vars\": {
+    \"MC_TRANSFER_TIMEOUT\": \"${MC_TRANSFER_TIMEOUT}\",
+    \"RAY_DEBUG\": \"1\",
+    \"PYTHONPATH\": \"/root/Megatron-LM/\",
+    \"CUDA_DEVICE_MAX_CONNECTIONS\": \"1\",
+    \"NCCL_NVLS_ENABLE\": \"${NCCL_NVLS_VAL}\"
+  }
+}"
+
+    # --- Wait for all nodes to join Ray cluster (head node only) ---
+    EXPECTED_GPUS=$((NNODES * GPUS_PER_NODE))
+    if [ "$NODE_RANK" -eq 0 ]; then
+        echo "Waiting for ${EXPECTED_GPUS} GPUs in Ray cluster..."
+        while true; do
+            AVAILABLE_GPUS=$(python3 -c "import ray; ray.init(address='auto', ignore_reinit_error=True); print(int(ray.cluster_resources().get('GPU', 0))); ray.shutdown()" 2>/dev/null || echo 0)
+            echo "  ... detected ${AVAILABLE_GPUS}/${EXPECTED_GPUS} GPUs"
+            if [ "$AVAILABLE_GPUS" -ge "$EXPECTED_GPUS" ]; then
+                break
+            fi
+            sleep 5
+        done
+        echo "All ${EXPECTED_GPUS} GPUs available. Submitting job."
+    fi
+
+    # --- Submit Ray job (head node only) ---
+    if [ "$NODE_RANK" -eq 0 ]; then
+        ray job submit --address="http://127.0.0.1:8265" \
+            --runtime-env-json="${RUNTIME_ENV_JSON}" \
+            -- python3 train.py \
+            ${MODEL_ARGS[@]} \
+            ${CKPT_ARGS[@]} \
+            ${ROLLOUT_ARGS[@]} \
+            ${EVAL_ARGS[@]} \
+            ${OPTIMIZER_ARGS[@]} \
+            ${GRPO_ARGS[@]} \
+            ${WANDB_ARGS[@]} \
+            ${PERF_ARGS[@]} \
+            ${SGLANG_ARGS[@]} \
+            ${MISC_ARGS[@]}
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+echo ""
+echo "============================================================"
+echo "  Running: GLM-4.7-Flash / ${MODE}"
+echo "============================================================"
+echo ""
+
+run_mode "$MODE"
+
+echo "Done."

--- a/examples/p2p_weight_transfer/run-qwen3-235B-A22B-16node-profile.sh
+++ b/examples/p2p_weight_transfer/run-qwen3-235B-A22B-16node-profile.sh
@@ -1,0 +1,298 @@
+#!/bin/bash
+
+# Multi-node (16-node) profiling script for Qwen3-235B-A22B with broadcasting/p2p weight transfer.
+#
+# Usage:
+#   bash run-qwen3-235B-A22B-16node-profile.sh <MODE> <NODE_RANK> <HEAD_NODE_IP>
+#
+#   MODE          : broadcast | p2p
+#   NODE_RANK     : 0 (head node) | 1..15 (worker nodes)
+#   HEAD_NODE_IP  : IP address of the head node
+#
+# Examples:
+#   bash run-qwen3-235B-A22B-16node-profile.sh p2p 0 10.0.0.1   # head node
+#   bash run-qwen3-235B-A22B-16node-profile.sh p2p 1 10.0.0.1   # worker node
+
+set -ex
+
+export PYTHONBUFFERED=16
+
+# ---------------------------------------------------------------------------
+# Positional arguments
+# ---------------------------------------------------------------------------
+if [ $# -lt 3 ]; then
+    echo "Usage: $0 <MODE> <NODE_RANK> <HEAD_NODE_IP>"
+    echo "  MODE         : broadcast | p2p"
+    echo "  NODE_RANK    : 0 (head) | 1..15 (workers)"
+    echo "  HEAD_NODE_IP : IP of the head node"
+    exit 1
+fi
+
+MODE="$1"              # broadcast | p2p
+NODE_RANK="$2"         # 0 = head, 1..N = worker
+HEAD_NODE_IP="$3"      # head node IP address
+
+# ---------------------------------------------------------------------------
+# Cleanup stale processes (head node only)
+# ---------------------------------------------------------------------------
+if [ "$NODE_RANK" -eq 0 ]; then
+    pkill -9 sglang || true
+    sleep 3
+    ray stop --force || true
+    pkill -9 ray || true
+    pkill -9 python || true
+    sleep 3
+    pkill -9 ray || true
+    pkill -9 python || true
+    pkill -9 redis || true
+fi
+
+# ---------------------------------------------------------------------------
+# Fixed config
+# ---------------------------------------------------------------------------
+NNODES=16
+GPUS_PER_NODE=8
+NUM_TRAIN_GPUS=64     # 8 nodes
+NUM_ROLLOUT_GPUS=64   # 8 nodes
+SKIP_VALIDATION=0
+BUCKET_SIZE_GB=1.0
+NO_SAVE_OPTIM=0
+ENABLE_NCCL_NVLS=1
+DECODER_LAST_PIPELINE_NUM_LAYERS=22
+
+NUM_TRAIN_NODES=$((NUM_TRAIN_GPUS / GPUS_PER_NODE))
+
+# ---------------------------------------------------------------------------
+# NVLink detection
+# ---------------------------------------------------------------------------
+NVLINK_COUNT=$(nvidia-smi topo -m 2>/dev/null | grep -o 'NV[0-9][0-9]*' | wc -l)
+if [ "$NVLINK_COUNT" -gt 0 ]; then
+    HAS_NVLINK=1
+else
+    HAS_NVLINK=0
+fi
+echo "HAS_NVLINK: $HAS_NVLINK (detected $NVLINK_COUNT NVLink references)"
+
+# ---------------------------------------------------------------------------
+# Model config
+# ---------------------------------------------------------------------------
+MODEL_NAME="Qwen3-235B-A22B-Instruct-2507"
+MODEL_TYPE="qwen3-235B-A22B"
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+MILES_ROOT="/root/miles"
+export MODEL_ARGS_ROTARY_BASE=5000000
+source "${MILES_ROOT}/scripts/models/${MODEL_TYPE}.sh"
+
+
+# ---------------------------------------------------------------------------
+# Determine modes to run
+# ---------------------------------------------------------------------------
+
+MODES=("$MODE")
+
+
+# ---------------------------------------------------------------------------
+# Execute one mode (broadcast or p2p)
+# ---------------------------------------------------------------------------
+run_mode() {
+    local mode="$1"
+
+    # --- Checkpoint ---
+    CKPT_ARGS=(
+        --hf-checkpoint "/root/models/${MODEL_NAME}/"
+        --ref-load "/root/multinode/${MODEL_NAME}_torch_dist/"
+    )
+    if [ "$NO_SAVE_OPTIM" -eq 1 ]; then
+        CKPT_ARGS+=(--no-save-optim)
+    fi
+
+    # --- Rollout ---
+    ROLLOUT_ARGS=(
+        --prompt-data /root/datasets/dapo-math-17k/dapo-math-17k.jsonl
+        --input-key prompt
+        --label-key label
+        --apply-chat-template
+        --rollout-shuffle
+        --rm-type deepscaler
+        --num-rollout 13
+        --rollout-batch-size 8
+        --n-samples-per-prompt 8
+        --rollout-max-response-len 100
+        --rollout-temperature 0.8
+        --global-batch-size 64
+        --balance-data
+    )
+
+    # --- Eval ---
+    EVAL_ARGS=(
+        --eval-prompt-data aime /root/datasets/aime-2024/aime-2024.jsonl
+        --n-samples-per-eval-prompt 16
+        --eval-max-response-len 16384
+        --eval-top-p 0.7
+    )
+
+    # --- Training parallelism ---
+    PERF_ARGS=(
+        --tensor-model-parallel-size 4
+        --sequence-parallel
+        --pipeline-model-parallel-size 4
+        --context-parallel-size 2
+        --expert-model-parallel-size 16
+        --expert-tensor-parallel-size 1
+        --decoder-last-pipeline-num-layers ${DECODER_LAST_PIPELINE_NUM_LAYERS}
+        --recompute-granularity full
+        --recompute-method uniform
+        --recompute-num-layers 1
+        --use-dynamic-batch-size
+        --max-tokens-per-gpu 8192
+    )
+
+    # --- GRPO ---
+    GRPO_ARGS=(
+        --advantage-estimator gspo
+        --kl-loss-coef 0.00
+        --kl-loss-type low_var_kl
+        --entropy-coef 0.00
+        --eps-clip 4e-4
+    )
+
+    # --- Optimizer ---
+    OPTIMIZER_ARGS=(
+        --optimizer adam
+        --lr 1e-6
+        --lr-decay-style constant
+        --weight-decay 0.1
+        --adam-beta1 0.9
+        --adam-beta2 0.98
+        --optimizer-cpu-offload
+        --overlap-cpu-optimizer-d2h-h2d
+        --use-precision-aware-optimizer
+    )
+
+    # --- WANDB ---
+    WANDB_ARGS=(
+        #--use-wandb
+    )
+
+    # --- SGLang: 2 engines x 32 GPUs, with DP attention (ep > 1) ---
+    SGLANG_ARGS=(
+        --rollout-num-gpus-per-engine 32
+        --rollout-num-gpus ${NUM_ROLLOUT_GPUS}
+        --sglang-mem-fraction-static 0.75
+        --sglang-ep-size 32
+        --sglang-dp-size 1
+        --sglang-cuda-graph-bs 1 2 4 8 16
+        --sglang-enable-dp-attention
+        --sglang-enable-dp-lm-head
+    )
+    if [ "$mode" = "p2p" ]; then
+        SGLANG_ARGS+=(--sglang-remote-instance-weight-loader-start-seed-via-transfer-engine)
+    fi
+    if [ "$SKIP_VALIDATION" -eq 1 ]; then
+        SGLANG_ARGS+=(--sglang-load-format dummy)
+    else
+        SGLANG_ARGS+=(--sglang-model-loader-extra-config '{"enable_multithread_load":true,"num_threads":8}')
+    fi
+
+    # --- Misc ---
+    if [ "$mode" = "p2p" ]; then
+        BUFFER_SIZE=$(python3 -c "print(int(${BUCKET_SIZE_GB} * 1024 * 1024 * 1024))")
+    else
+        BUFFER_SIZE=$((1 * 1024 * 1024 * 1024))
+    fi
+
+    MISC_ARGS=(
+        --attention-dropout 0.0
+        --hidden-dropout 0.0
+        --accumulate-allreduce-grads-in-fp32
+        --attention-softmax-in-fp32
+        --attention-backend flash
+        --actor-num-nodes ${NUM_TRAIN_NODES}
+        --actor-num-gpus-per-node ${GPUS_PER_NODE}
+        --update-weight-buffer-size ${BUFFER_SIZE}
+    )
+    if [ "$SKIP_VALIDATION" -eq 0 ]; then
+        MISC_ARGS+=(--check-weight-update-equal)
+    fi
+    if [ "$mode" = "p2p" ]; then
+        MISC_ARGS+=(--update-weight-transfer-mode p2p)
+    fi
+
+    # --- Worker nodes sleep to let head node start first ---
+    if [ "$NODE_RANK" -gt 0 ]; then
+        sleep 20
+    fi
+
+    # --- MC transfer timeout ---
+    MC_TRANSFER_TIMEOUT=300
+
+    NCCL_NVLS_VAL="0"
+    if [ "$ENABLE_NCCL_NVLS" -eq 1 ]; then
+        NCCL_NVLS_VAL="1"
+    fi
+
+    # --- Launch Ray ---
+    if [ "$NODE_RANK" -eq 0 ]; then
+        ray start --head --node-ip-address "${HEAD_NODE_IP}" --num-gpus ${GPUS_PER_NODE} \
+            --disable-usage-stats --dashboard-host=0.0.0.0 --dashboard-port=8265
+    else
+        ray start --address="${HEAD_NODE_IP}:6379" --num-gpus ${GPUS_PER_NODE} --disable-usage-stats
+    fi
+
+    # --- Build runtime env JSON ---
+    RUNTIME_ENV_JSON="{
+  \"env_vars\": {
+    \"MC_TRANSFER_TIMEOUT\": \"${MC_TRANSFER_TIMEOUT}\",
+    \"RAY_DEBUG\": \"1\",
+    \"PYTHONPATH\": \"/root/Megatron-LM/\",
+    \"CUDA_DEVICE_MAX_CONNECTIONS\": \"1\",
+    \"NCCL_NVLS_ENABLE\": \"${NCCL_NVLS_VAL}\"
+  }
+}"
+
+    # --- Wait for all nodes to join Ray cluster (head node only) ---
+    EXPECTED_GPUS=$((NNODES * GPUS_PER_NODE))
+    if [ "$NODE_RANK" -eq 0 ]; then
+        echo "Waiting for ${EXPECTED_GPUS} GPUs in Ray cluster..."
+        while true; do
+            AVAILABLE_GPUS=$(python3 -c "import ray; ray.init(address='auto', ignore_reinit_error=True); print(int(ray.cluster_resources().get('GPU', 0))); ray.shutdown()" 2>/dev/null || echo 0)
+            echo "  ... detected ${AVAILABLE_GPUS}/${EXPECTED_GPUS} GPUs"
+            if [ "$AVAILABLE_GPUS" -ge "$EXPECTED_GPUS" ]; then
+                break
+            fi
+            sleep 5
+        done
+        echo "All ${EXPECTED_GPUS} GPUs available. Submitting job."
+    fi
+
+    # --- Submit Ray job (head node only) ---
+    if [ "$NODE_RANK" -eq 0 ]; then
+        ray job submit --address="http://127.0.0.1:8265" \
+            --runtime-env-json="${RUNTIME_ENV_JSON}" \
+            -- python3 train.py \
+            ${MODEL_ARGS[@]} \
+            ${CKPT_ARGS[@]} \
+            ${ROLLOUT_ARGS[@]} \
+            ${EVAL_ARGS[@]} \
+            ${OPTIMIZER_ARGS[@]} \
+            ${GRPO_ARGS[@]} \
+            ${WANDB_ARGS[@]} \
+            ${PERF_ARGS[@]} \
+            ${SGLANG_ARGS[@]} \
+            ${MISC_ARGS[@]}
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+echo ""
+echo "============================================================"
+echo "  Running: qwen3-235b-a22b / ${MODE}"
+echo "============================================================"
+echo ""
+
+run_mode "$MODE"
+
+echo "Done."

--- a/examples/p2p_weight_transfer/run-qwen3-30B-A3B-4node-profile.sh
+++ b/examples/p2p_weight_transfer/run-qwen3-30B-A3B-4node-profile.sh
@@ -25,7 +25,7 @@ export PYTHONBUFFERED=16
 # ---------------------------------------------------------------------------
 if [ $# -lt 3 ]; then
     echo "Usage: $0 <MODE> <NODE_RANK> <HEAD_NODE_IP>"
-    echo "  MODE         : p2p | p2p"
+    echo "  MODE         : broadcast | p2p"
     echo "  NODE_RANK    : 0 (head) | 1,2,3 (workers)"
     echo "  HEAD_NODE_IP : IP of the head node"
     exit 1

--- a/examples/p2p_weight_transfer/run-qwen3-30B-A3B-4node-profile.sh
+++ b/examples/p2p_weight_transfer/run-qwen3-30B-A3B-4node-profile.sh
@@ -1,0 +1,287 @@
+#!/bin/bash
+
+# Multi-node (4-node) profiling script for Qwen3-30B-A3B with broadcasting/p2p weight transfer.
+#
+# Converted from: examples/p2p_weight_transfer/test_glm5_744b_a40b_4layer.py
+# Only the qwen3-30b model config is included.
+#
+# Usage:
+#   bash run-qwen3-30B-A3B-4node-profile.sh <MODE> <NODE_RANK> <HEAD_NODE_IP>
+#
+#   MODE          : broadcast | p2p
+#   NODE_RANK     : 0 (head node) | 1,2,3 (worker nodes)
+#   HEAD_NODE_IP  : IP address of the head node
+#
+# Examples:
+#   bash run-qwen3-30B-A3B-4node-profile.sh p2p 0 10.0.0.1   # head node
+#   bash run-qwen3-30B-A3B-4node-profile.sh p2p 1 10.0.0.1   # worker node
+
+set -ex
+
+export PYTHONBUFFERED=16
+
+# ---------------------------------------------------------------------------
+# Positional arguments
+# ---------------------------------------------------------------------------
+if [ $# -lt 3 ]; then
+    echo "Usage: $0 <MODE> <NODE_RANK> <HEAD_NODE_IP>"
+    echo "  MODE         : p2p | p2p"
+    echo "  NODE_RANK    : 0 (head) | 1,2,3 (workers)"
+    echo "  HEAD_NODE_IP : IP of the head node"
+    exit 1
+fi
+
+MODE="$1"              # broadcast | p2p
+NODE_RANK="$2"         # 0 = head, 1..N = worker
+HEAD_NODE_IP="$3"      # head node IP address
+
+# ---------------------------------------------------------------------------
+# Cleanup stale processes (head node only)
+# ---------------------------------------------------------------------------
+if [ "$NODE_RANK" -eq 0 ]; then
+    pkill -9 sglang || true
+    sleep 3
+    ray stop --force || true
+    pkill -9 ray || true
+    pkill -9 python || true
+    sleep 3
+    pkill -9 ray || true
+    pkill -9 python || true
+    pkill -9 redis || true
+fi
+
+# ---------------------------------------------------------------------------
+# Fixed config
+# ---------------------------------------------------------------------------
+NNODES=4
+GPUS_PER_NODE=8
+NUM_TRAIN_GPUS=16     # 2 nodes
+NUM_ROLLOUT_GPUS=16   # 2 nodes
+SKIP_VALIDATION=0
+BUCKET_SIZE_GB=1.0
+NO_SAVE_OPTIM=0
+ENABLE_NCCL_NVLS=0
+
+NUM_TRAIN_NODES=$((NUM_TRAIN_GPUS / GPUS_PER_NODE))
+
+
+# ---------------------------------------------------------------------------
+# NVLink detection
+# ---------------------------------------------------------------------------
+NVLINK_COUNT=$(nvidia-smi topo -m 2>/dev/null | grep -o 'NV[0-9][0-9]*' | wc -l)
+if [ "$NVLINK_COUNT" -gt 0 ]; then
+    HAS_NVLINK=1
+else
+    HAS_NVLINK=0
+fi
+echo "HAS_NVLINK: $HAS_NVLINK (detected $NVLINK_COUNT NVLink references)"
+
+# ---------------------------------------------------------------------------
+# Model config
+# ---------------------------------------------------------------------------
+MODEL_NAME="Qwen3-30B-A3B"
+MODEL_TYPE="qwen3-30B-A3B"
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+MILES_ROOT="/root/miles"
+source "${MILES_ROOT}/scripts/models/${MODEL_TYPE}.sh"
+
+# Rotary base override
+export MODEL_ARGS_ROTARY_BASE=1000000
+
+
+# ---------------------------------------------------------------------------
+# Determine modes to run
+# ---------------------------------------------------------------------------
+
+MODES=("$MODE")
+
+
+# ---------------------------------------------------------------------------
+# Execute one mode (broadcast or p2p)
+# ---------------------------------------------------------------------------
+run_mode() {
+    local mode="$1"
+
+    # --- Checkpoint ---
+    CKPT_ARGS=(
+        --hf-checkpoint "/root/models/${MODEL_NAME}/"
+        --ref-load "/root/multinode/${MODEL_NAME}_torch_dist/"
+    )
+    if [ "$NO_SAVE_OPTIM" -eq 1 ]; then
+        CKPT_ARGS+=(--no-save-optim)
+    fi
+
+    # --- Rollout ---
+    ROLLOUT_ARGS=(
+        --prompt-data /root/datasets/dapo-math-17k/dapo-math-17k.jsonl
+        --input-key prompt
+        --label-key label
+        --apply-chat-template
+        --rollout-shuffle
+        --rm-type deepscaler
+        --num-rollout 13
+        --rollout-batch-size 4
+        --n-samples-per-prompt 4
+        --rollout-max-response-len 100
+        --rollout-temperature 0.8
+        --global-batch-size 16
+        --balance-data
+    )
+
+    # --- Eval ---
+    EVAL_ARGS=(
+        --eval-prompt-data aime /root/datasets/aime-2024/aime-2024.jsonl
+        --n-samples-per-eval-prompt 16
+        --eval-max-response-len 16384
+        --eval-top-p 0.7
+    )
+
+    # --- Training parallelism ---
+    PERF_ARGS=(
+        --tensor-model-parallel-size 4
+        --sequence-parallel
+        --pipeline-model-parallel-size 1
+        --context-parallel-size 1
+        --expert-model-parallel-size 8
+        --expert-tensor-parallel-size 1
+        --recompute-granularity full
+        --recompute-method uniform
+        --recompute-num-layers 1
+        --use-dynamic-batch-size
+        --max-tokens-per-gpu 2048
+    )
+
+    # --- GRPO ---
+    GRPO_ARGS=(
+        --advantage-estimator gspo
+        --kl-loss-coef 0.00
+        --kl-loss-type low_var_kl
+        --entropy-coef 0.00
+        --eps-clip 4e-4
+    )
+
+    # --- Optimizer ---
+    OPTIMIZER_ARGS=(
+        --optimizer adam
+        --lr 1e-6
+        --lr-decay-style constant
+        --weight-decay 0.1
+        --adam-beta1 0.9
+        --adam-beta2 0.98
+        --optimizer-cpu-offload
+        --overlap-cpu-optimizer-d2h-h2d
+        --use-precision-aware-optimizer
+    )
+
+    # --- WANDB ---
+    WANDB_ARGS=(
+        #--use-wandb
+    )
+
+    # --- SGLang: 2 engines x 8 GPUs, with DP attention (ep > 1) ---
+    SGLANG_ARGS=(
+        --rollout-num-gpus-per-engine 8
+        --rollout-num-gpus ${NUM_ROLLOUT_GPUS}
+        --sglang-mem-fraction-static 0.8
+        --sglang-ep-size 8
+        --sglang-cuda-graph-bs 1 2 4 8 16
+        --use-miles-router
+        --sglang-enable-dp-attention
+        --sglang-enable-dp-lm-head
+    )
+    if [ "$mode" = "p2p" ]; then
+        SGLANG_ARGS+=(--sglang-remote-instance-weight-loader-start-seed-via-transfer-engine)
+    fi
+
+    # --- Misc ---
+    BUFFER_SIZE=$((1 * 1024 * 1024 * 1024))
+
+    MISC_ARGS=(
+        --attention-dropout 0.0
+        --hidden-dropout 0.0
+        --accumulate-allreduce-grads-in-fp32
+        --attention-softmax-in-fp32
+        --attention-backend flash
+        --actor-num-nodes ${NUM_TRAIN_NODES}
+        --actor-num-gpus-per-node ${GPUS_PER_NODE}
+        --update-weight-buffer-size ${BUFFER_SIZE}
+        --update-weight-transfer-mode ${MODE}
+        --check-weight-update-equal 
+    )
+
+    # --- Worker nodes sleep to let head node start first ---
+    if [ "$NODE_RANK" -gt 0 ]; then
+        sleep 20
+    fi
+
+    # --- MC transfer timeout ---
+    MC_TRANSFER_TIMEOUT=300
+
+    NCCL_NVLS_VAL="1"
+
+
+    # --- Launch Ray ---
+    if [ "$NODE_RANK" -eq 0 ]; then
+        ray start --head --node-ip-address "${HEAD_NODE_IP}" --num-gpus ${GPUS_PER_NODE} \
+            --disable-usage-stats --dashboard-host=0.0.0.0 --dashboard-port=8265
+    else
+        ray start --address="${HEAD_NODE_IP}:6379" --num-gpus ${GPUS_PER_NODE} --disable-usage-stats
+    fi
+
+    # --- Build runtime env JSON ---
+    RUNTIME_ENV_JSON="{
+  \"env_vars\": {
+    \"MC_TRANSFER_TIMEOUT\": \"${MC_TRANSFER_TIMEOUT}\",
+    \"RAY_DEBUG\": \"1\",
+    \"PYTHONPATH\": \"/root/Megatron-LM/\",
+    \"CUDA_DEVICE_MAX_CONNECTIONS\": \"1\",
+    \"NCCL_NVLS_ENABLE\": \"${NCCL_NVLS_VAL}\"
+  }
+}"
+
+    # --- Wait for all nodes to join Ray cluster (head node only) ---
+    EXPECTED_GPUS=$((NNODES * GPUS_PER_NODE))
+    if [ "$NODE_RANK" -eq 0 ]; then
+        echo "Waiting for ${EXPECTED_GPUS} GPUs in Ray cluster..."
+        while true; do
+            AVAILABLE_GPUS=$(python3 -c "import ray; ray.init(address='auto', ignore_reinit_error=True); print(int(ray.cluster_resources().get('GPU', 0))); ray.shutdown()" 2>/dev/null || echo 0)
+            echo "  ... detected ${AVAILABLE_GPUS}/${EXPECTED_GPUS} GPUs"
+            if [ "$AVAILABLE_GPUS" -ge "$EXPECTED_GPUS" ]; then
+                break
+            fi
+            sleep 5
+        done
+        echo "All ${EXPECTED_GPUS} GPUs available. Submitting job."
+    fi
+
+    # --- Submit Ray job (head node only) ---
+    if [ "$NODE_RANK" -eq 0 ]; then
+        ray job submit --address="http://127.0.0.1:8265" \
+            --runtime-env-json="${RUNTIME_ENV_JSON}" \
+            -- python3 train.py \
+            ${MODEL_ARGS[@]} \
+            ${CKPT_ARGS[@]} \
+            ${ROLLOUT_ARGS[@]} \
+            ${EVAL_ARGS[@]} \
+            ${OPTIMIZER_ARGS[@]} \
+            ${GRPO_ARGS[@]} \
+            ${WANDB_ARGS[@]} \
+            ${PERF_ARGS[@]} \
+            ${SGLANG_ARGS[@]} \
+            ${MISC_ARGS[@]}
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+echo ""
+echo "============================================================"
+echo "  Running: qwen3-30b / ${MODE}"
+echo "============================================================"
+echo ""
+
+run_mode "$MODE"
+
+echo "Done."


### PR DESCRIPTION
## Summary
- Add multi-node (4-node) Qwen3-30B-A3B profiling scripts for P2P weight transfer (`prepare-qwen3-30B-A3B.sh` and `run-qwen3-30B-A3B-4node-profile.sh`)
- Update `p2p-weight-transfer.md` with examples section covering single-node and multi-node usage with quick-start guide
- Similar tests for qwen-235b & glm-4.7-flash

## Test plan
under h100-80g
- [X] Run `prepare-qwen3-30B-A3B.sh` on a single node to verify model/dataset download and checkpoint conversion
- [X] Launch `run-qwen3-30B-A3B-4node-profile.sh` in both `broadcast` and `p2p` modes across 4 nodes
- [X] tests for qwen235b (16 nodes) & glm-4.7-flash (2 nodes)
