### PR TITLE
[BUGFIX] [P2PRDMA] Add rollout post-processing after P2PRDMA weight updates

### DIFF
--- a/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/p2p.py
+++ b/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/p2p.py
@@ -127,6 +127,7 @@ class UpdateWeightP2P(DistBucketedWeightUpdateMixin):
             )
             post_process_weights(
                 rollout_engines=self.rollout_engines,
+                post_process_quantization=True,
                 post_load_weights=True,
             )
         super()._finalize_and_resume_engines()


### PR DESCRIPTION
### Problem
P2P/RDMA weight updates bypass the normal `/update_weights` flow, so rollout-side post-processing is not re-applied after the transfer finishes. For example, Qwen3MoE `process_weights_after_loading()` is skipped for MoE expert weights, which normally shuffles w13 and w2: https://github.com/sgl-project/sglang/blob/8732b2e9c6f10d581059ea056a075af9b3feb103/python/sglang/srt/layers/quantization/unquant.py#L235. Without that step, w13_weight and w2_weight remain in the pre-shuffle layout, while the aiter MoE kernel consumes them as if they were already shuffled. WeightChecker can still pass because it validates only the copied model tensors themselves, not the kernels' layout. This causes silent rollout corruption: `train_rollout_logprob_abs_diff` jumps from the normal ~0.015 to 6+.

### Note
Although this issue was observed on ROCm, the bug is not ROCm-specific. NV also has this type of hard-coded shuffle (e.g. https://github.com/sgl-project/sglang/blob/8732b2e9c6f10d581059ea056a075af9b3feb103/python/sglang/srt/layers/quantization/unquant.py#L252)
