### PR TITLE
Fix session request hanging with asyncio timeout

### DIFF
--- a/miles/rollout/generate_utils/openai_endpoint_utils.py
+++ b/miles/rollout/generate_utils/openai_endpoint_utils.py
@@ -14,7 +14,7 @@ from miles.utils.types import Sample
 
 logger = logging.getLogger(__name__)
 
-SESSION_REQUEST_TIMEOUT = 120
+_SESSION_REQUEST_TIMEOUT = 120
 
 
 class OpenAIEndpointTracer:
@@ -38,17 +38,24 @@ class OpenAIEndpointTracer:
         return OpenAIEndpointTracer(router_url=session_url, session_id=session_id)
 
     async def collect_records(self) -> tuple[list[SessionRecord], dict]:
-        url = f"{self.router_url}/sessions/{self.session_id}"
         try:
             response = await asyncio.wait_for(
-                post(url, {}, action="get"),
-                timeout=SESSION_REQUEST_TIMEOUT,
+                post(self.base_url, {}, action="get"),
+                timeout=_SESSION_REQUEST_TIMEOUT,
             )
         except asyncio.TimeoutError:
             logger.error(
-                f"Timed out waiting for session {self.session_id} records after {SESSION_REQUEST_TIMEOUT}s "
+                f"Timed out waiting for session {self.session_id} records after {_SESSION_REQUEST_TIMEOUT}s "
                 f"(likely stale HTTP keepalive connection). Returning empty records."
             )
+            # Still attempt to clean up the session.
+            try:
+                await asyncio.wait_for(
+                    post(self.base_url, {}, action="delete"),
+                    timeout=_SESSION_REQUEST_TIMEOUT,
+                )
+            except Exception:
+                logger.warning(f"Failed to delete session {self.session_id} after timeout")
             return [], {}
         except Exception as e:
             logger.warning(f"Failed to get session {self.session_id} records: {e}")
@@ -59,11 +66,9 @@ class OpenAIEndpointTracer:
 
         try:
             await asyncio.wait_for(
-                post(url, {}, action="delete"),
-                timeout=SESSION_REQUEST_TIMEOUT,
+                post(self.base_url, {}, action="delete"),
+                timeout=_SESSION_REQUEST_TIMEOUT,
             )
-        except asyncio.TimeoutError:
-            logger.warning(f"Timed out deleting session {self.session_id} after {SESSION_REQUEST_TIMEOUT}s")
         except Exception as e:
             logger.warning(f"Failed to delete session {self.session_id} after collecting records: {e}")
 


### PR DESCRIPTION
## Summary
- Add 120s `asyncio.wait_for` timeout to `collect_records()` (GET) and session deletion (DELETE) in `OpenAIEndpointTracer`
- Prevents indefinite hangs when the session server has stale HTTP keepalive connections — instead of blocking forever, the tracer logs an error and returns empty records
- Timeout applies to both the GET (collect) and DELETE (cleanup) calls independently

## Test plan
- [ ] Run agentic rollout end-to-end; verify sessions are collected normally when server is healthy
- [ ] Kill/restart session server mid-rollout; confirm the tracer logs timeout errors and returns gracefully instead of hanging

🤖 Generated with [Claude Code](https://claude.com/claude-code)