### PR TITLE
feat: add --loss-agg-mode with token-mean support

### DIFF
--- a/miles/backends/training_utils/cp_utils.py
+++ b/miles/backends/training_utils/cp_utils.py
@@ -67,14 +67,15 @@ def get_sum_of_sample_mean(
 
     Modes (selected by loss_agg_mode, falls back to calculate_per_token_loss):
       - "sample-mean" (default): per-sample token-mean, then sum across samples.
-      - "token-mean": masked sum / total masked tokens * dp_size.
-        Every token contributes equally regardless of sequence length.
-      - "token-sum": raw masked sum (no normalization), legacy calculate_per_token_loss=True.
+      - "token-mean": raw masked sum (same reducer as token-sum). The per-token
+        normalization is handled downstream in loss_function, which divides by
+        num_tokens. This is needed for the FSDP backend where the external
+        normalizer is not used. On Megatron, --calculate-per-token-loss already
+        achieves the same effect via the external normalizer.
+      - "token-sum": raw masked sum, legacy calculate_per_token_loss=True.
     """
     if loss_agg_mode is None:
         loss_agg_mode = "token-sum" if calculate_per_token_loss else "sample-mean"
-
-    total_mask_tokens = sum(loss_mask.sum() for loss_mask in loss_masks)
 
     cp_size = parallel_state.cp_size
     if cp_size == 1:
@@ -94,15 +95,6 @@ def get_sum_of_sample_mean(
                     for x_i, loss_mask_i in zip(x.split(response_lengths, dim=0), loss_masks, strict=False)
                 ]
             )
-
-        def sum_of_token_mean(x: torch.Tensor) -> torch.Tensor:
-            raw = sum(
-                [
-                    (x_i * loss_mask_i).sum()
-                    for x_i, loss_mask_i in zip(x.split(response_lengths, dim=0), loss_masks, strict=False)
-                ]
-            )
-            return raw / torch.clamp_min(total_mask_tokens, 1)
 
     else:
         cp_chunk_lengths = []
@@ -140,20 +132,9 @@ def get_sum_of_sample_mean(
                 ]
             )
 
-        def sum_of_token_mean(x: torch.Tensor) -> torch.Tensor:
-            raw = sum(
-                [
-                    (x_i * chunked_loss_mask).sum()
-                    for x_i, chunked_loss_mask in zip(
-                        x.split(cp_chunk_lengths, dim=0), chunked_loss_masks, strict=False
-                    )
-                ]
-            )
-            return raw / torch.clamp_min(total_mask_tokens, 1)
-
-    if loss_agg_mode == "token-mean":
-        return sum_of_token_mean
-    elif loss_agg_mode == "token-sum":
+    # token-mean uses the same raw-sum reducer as token-sum; the per-token
+    # normalization is handled in loss_function (needed for FSDP backend).
+    if loss_agg_mode in ("token-mean", "token-sum"):
         return sum_of_token
     else:
         return sum_of_sample_mean

--- a/miles/backends/training_utils/cp_utils.py
+++ b/miles/backends/training_utils/cp_utils.py
@@ -60,10 +60,22 @@ def get_sum_of_sample_mean(
     calculate_per_token_loss: bool = False,
     qkv_format: str = "thd",
     max_seq_lens: list[int] | None = None,
+    loss_agg_mode: str | None = None,
 ) -> Callable[[torch.Tensor], torch.Tensor]:
     """
-    Calculate correct sample mean for CP
+    Returns a loss reduction callable.
+
+    Modes (selected by loss_agg_mode, falls back to calculate_per_token_loss):
+      - "sample-mean" (default): per-sample token-mean, then sum across samples.
+      - "token-mean": masked sum / total masked tokens * dp_size.
+        Every token contributes equally regardless of sequence length.
+      - "token-sum": raw masked sum (no normalization), legacy calculate_per_token_loss=True.
     """
+    if loss_agg_mode is None:
+        loss_agg_mode = "token-sum" if calculate_per_token_loss else "sample-mean"
+
+    total_mask_tokens = sum(loss_mask.sum() for loss_mask in loss_masks)
+
     cp_size = parallel_state.cp_size
     if cp_size == 1:
 
@@ -82,6 +94,15 @@ def get_sum_of_sample_mean(
                     for x_i, loss_mask_i in zip(x.split(response_lengths, dim=0), loss_masks, strict=False)
                 ]
             )
+
+        def sum_of_token_mean(x: torch.Tensor) -> torch.Tensor:
+            raw = sum(
+                [
+                    (x_i * loss_mask_i).sum()
+                    for x_i, loss_mask_i in zip(x.split(response_lengths, dim=0), loss_masks, strict=False)
+                ]
+            )
+            return raw / torch.clamp_min(total_mask_tokens, 1)
 
     else:
         cp_chunk_lengths = []
@@ -119,7 +140,23 @@ def get_sum_of_sample_mean(
                 ]
             )
 
-    return sum_of_sample_mean if not calculate_per_token_loss else sum_of_token
+        def sum_of_token_mean(x: torch.Tensor) -> torch.Tensor:
+            raw = sum(
+                [
+                    (x_i * chunked_loss_mask).sum()
+                    for x_i, chunked_loss_mask in zip(
+                        x.split(cp_chunk_lengths, dim=0), chunked_loss_masks, strict=False
+                    )
+                ]
+            )
+            return raw / torch.clamp_min(total_mask_tokens, 1)
+
+    if loss_agg_mode == "token-mean":
+        return sum_of_token_mean
+    elif loss_agg_mode == "token-sum":
+        return sum_of_token
+    else:
+        return sum_of_sample_mean
 
 
 def all_gather_with_cp(

--- a/miles/backends/training_utils/loss.py
+++ b/miles/backends/training_utils/loss.py
@@ -645,6 +645,7 @@ def policy_loss_function(
             args.calculate_per_token_loss,
             args.qkv_format,
             max_seq_lens,
+            loss_agg_mode=getattr(args, "loss_agg_mode", None),
         )
 
     # Determine pg_loss reducer: use custom if specified, otherwise default
@@ -878,6 +879,7 @@ def loss_function(
         args.calculate_per_token_loss,
         args.qkv_format,
         batch.get("max_seq_lens", None),
+        loss_agg_mode=getattr(args, "loss_agg_mode", None),
     )
 
     match args.loss_type:

--- a/miles/backends/training_utils/loss.py
+++ b/miles/backends/training_utils/loss.py
@@ -914,25 +914,42 @@ def loss_function(
     if parallel_state.cp_size > 1 and args.allgather_cp:
         loss = loss + 0 * logits.sum()
 
-    # Here we need to divide by cp_size because to cancel the multiply in Megatron.
+    # Resolve effective loss mode: --loss-agg-mode takes precedence over --calculate-per-token-loss
+    loss_agg_mode = getattr(args, "loss_agg_mode", None)
+    if loss_agg_mode is None:
+        loss_agg_mode = "token-sum" if args.calculate_per_token_loss else "sample-mean"
+    uses_token_normalization = loss_agg_mode in ("token-mean", "token-sum")
+
+    # Scale loss for distributed training.
+    # - sample-mean: divide by global_batch_size (number of samples)
+    # - token-mean/token-sum: use num_tokens as normalizer
+    #   For Megatron: the external normalizer handles division by num_tokens.
+    #   For FSDP (apply_megatron_loss_scaling=False): token-mean explicitly
+    #   divides by num_tokens here since FSDP ignores the returned normalizer.
     global_batch_size = batch.get("dynamic_global_batch_size", args.global_batch_size)
-    if not args.calculate_per_token_loss:
+    if not uses_token_normalization:
+        # sample-mean path
         if apply_megatron_loss_scaling:
             loss = loss * num_microbatches / global_batch_size * parallel_state.dp_cp_size
         else:
             loss = loss / global_batch_size * parallel_state.dp_size
     else:
         if apply_megatron_loss_scaling:
+            # Megatron normalizes externally via num_tokens normalizer
             loss = loss * parallel_state.cp_size
+        elif loss_agg_mode == "token-mean":
+            # FSDP: normalize by num_tokens explicitly (FSDP ignores the normalizer)
+            loss = loss / torch.clamp_min(num_tokens, 1) * parallel_state.dp_size
+        # token-sum on FSDP: no normalization (raw sum, legacy behavior)
 
     return (
         loss,
-        torch.tensor(num_tokens if args.calculate_per_token_loss else 1, device=logits.device),
+        torch.tensor(num_tokens if uses_token_normalization else 1, device=logits.device),
         {
             "keys": list(log.keys()),
             "values": torch.tensor(
                 [
-                    num_samples if not args.calculate_per_token_loss else num_tokens,
+                    num_samples if not uses_token_normalization else num_tokens,
                 ]
                 + list(log.values()),
                 device=logits.device,

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -794,6 +794,18 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
             reset_arg(parser, "--seed", type=int, default=1234)
             reset_arg(parser, "--clip-grad", type=float, default=1.0)
             reset_arg(parser, "--calculate-per-token-loss", action="store_true")
+            parser.add_argument(
+                "--loss-agg-mode",
+                type=str,
+                default=None,
+                choices=["sample-mean", "token-mean", "token-sum"],
+                help=(
+                    "Loss aggregation mode. 'sample-mean' (default): per-sample token-mean then sum. "
+                    "'token-mean': masked sum / total masked tokens * dp_size (equal weight per token). "
+                    "'token-sum': raw masked sum (legacy, same as --calculate-per-token-loss). "
+                    "If not set, falls back to --calculate-per-token-loss behavior."
+                ),
+            )
             reset_arg(parser, "--lr", type=float, default=1e-6)
 
             parser.add_argument("--num-critic-only-steps", type=int, default=0, help="Number of critic only steps")

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -800,9 +800,12 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 default=None,
                 choices=["sample-mean", "token-mean", "token-sum"],
                 help=(
-                    "Loss aggregation mode. 'sample-mean' (default): per-sample token-mean then sum. "
-                    "'token-mean': masked sum / total masked tokens * dp_size (equal weight per token). "
-                    "'token-sum': raw masked sum (legacy, same as --calculate-per-token-loss). "
+                    "Loss aggregation mode. Takes precedence over --calculate-per-token-loss. "
+                    "'sample-mean' (default): per-sample token-mean, then sum across samples. "
+                    "'token-mean': masked sum / total tokens — every token contributes equally. "
+                    "On Megatron backend this is equivalent to --calculate-per-token-loss; "
+                    "on FSDP backend this adds explicit normalization that FSDP otherwise skips. "
+                    "'token-sum': raw masked sum with no local normalization (same as --calculate-per-token-loss). "
                     "If not set, falls back to --calculate-per-token-loss behavior."
                 ),
             )


### PR DESCRIPTION
## Summary                                                                                        
  - Adds \`--loss-agg-mode\` argument with choices: \`sample-mean\` (default), \`token-mean\`, \`token-sum\`     
  - \`token-mean\`: \`masked_sum(losses) / total_masked_tokens\` — equal weight per token regardless of sequence 
  length                                                                                                      
  - Fully backward compatible — no behavior change without the flag                                              
  - Works with context parallelism (CP > 1)                                                                      
                                                                                                                 
  ## Motivation                                                                                               
  verl has built-in `loss_agg_mode="token-mean"`. For comparing training runs across frameworks, miles needs 
  the same option. With variable-length responses, `sample-mean` over-weights short sequences relative to long 
  ones. \`token-mean\` gives every token equal gradient contribution.                                            
                                                                                                                 
  ## Changes                                                                                                  
  - `miles/utils/arguments.py` — new `--loss-agg-mode` argument
  - `miles/backends/training_utils/cp_utils.py` — `sum_of_token_mean` reducer for both CP=1 and CP>1         
  - `miles/backends/training_utils/loss.py` — pass `loss_agg_mode` through to `get_sum_of_sample_mean`     
                                                                                                                 
  ## Usage                                                                                                       
  ```bash                                                                                                     
  python train.py ... --loss-agg-mode token-mean                                                              
  ```

  ## Test plan
  - [x] Verified with Qwen2.5-7B-Instruct on logic dataset, CP=2, training steps completing with correct metrics 