### PR TITLE
Fix Qwen3 30B A3B rotary-base handling for 2507 checkpoint helpers

### DIFF
--- a/docs/en/examples/qwen3-30B-A3B.md
+++ b/docs/en/examples/qwen3-30B-A3B.md
@@ -5,6 +5,16 @@
 
 The environment setup, model download, data, and checkpoint conversion are the same as for the Qwen3-4B model. You can refer to [Example: Qwen3-4B Model](qwen3-4B.md), replacing mentions of Qwen3-4B with Qwen3-30B-A3B.
 
+The helper script you source must match the checkpoint family you are using:
+
+| Checkpoint family | Helper script | `--rotary-base` |
+| --- | --- | --- |
+| `Qwen3-30B-A3B` and the base-family FP8/INT4 examples in this repo | `scripts/models/qwen3-30B-A3B.sh` | `1000000` |
+| `Qwen3-30B-A3B-Instruct-2507` | `scripts/models/qwen3-30B-A3B-Instruct-2507.sh` | `10000000` |
+| `Qwen3-30B-A3B-Thinking-2507` | `scripts/models/qwen3-30B-A3B-Thinking-2507.sh` | `10000000` |
+
+Even when two checkpoints share the same architecture, variant-specific settings such as `--rotary-base` still need to match the Hugging Face config exactly.
+
 To convert huggingface checkpoint to torch_dist, please try:
 
 ```bash
@@ -16,6 +26,17 @@ PYTHONPATH=/root/Megatron-LM/ torchrun --nproc-per-node 8 \
    ${MODEL_ARGS[@]} \
    --hf-checkpoint /root/Qwen3-30B-A3B/ \
    --save /root/Qwen3-30B-A3B_torch_dist/
+```
+
+For `Qwen3-30B-A3B-Instruct-2507` or `Qwen3-30B-A3B-Thinking-2507`, source the matching helper instead before conversion or training. For example:
+
+```bash
+source scripts/models/qwen3-30B-A3B-Instruct-2507.sh
+PYTHONPATH=/root/Megatron-LM/ torchrun --nproc-per-node 8 \
+   tools/convert_hf_to_torch_dist.py \
+   ${MODEL_ARGS[@]} \
+   --hf-checkpoint /root/Qwen3-30B-A3B-Instruct-2507/ \
+   --save /root/Qwen3-30B-A3B-Instruct-2507_torch_dist/
 ```
 
 ## Run Training

--- a/scripts/models/qwen3-30B-A3B-Instruct-2507.sh
+++ b/scripts/models/qwen3-30B-A3B-Instruct-2507.sh
@@ -1,0 +1,1 @@
+MODEL_ARGS_ROTARY_BASE=10000000 source "$(dirname -- "${BASH_SOURCE[0]}")/qwen3-30B-A3B.sh"

--- a/scripts/models/qwen3-30B-A3B-Thinking-2507.sh
+++ b/scripts/models/qwen3-30B-A3B-Thinking-2507.sh
@@ -1,0 +1,1 @@
+MODEL_ARGS_ROTARY_BASE=10000000 source "$(dirname -- "${BASH_SOURCE[0]}")/qwen3-30B-A3B.sh"

--- a/scripts/models/qwen3-30B-A3B.sh
+++ b/scripts/models/qwen3-30B-A3B.sh
@@ -32,6 +32,8 @@ MODEL_ARGS=(
    --untie-embeddings-and-output-weights
    --vocab-size 151936
 
+   # Base-family Qwen3-30B-A3B checkpoints use rotary base 1000000.
+   # Instruct-2507 and Thinking-2507 should source dedicated wrappers.
    --rotary-base "${MODEL_ARGS_ROTARY_BASE:-1000000}"
 
    # moe

--- a/tests/fast/utils/test_qwen3_30b_a3b_model_helpers.py
+++ b/tests/fast/utils/test_qwen3_30b_a3b_model_helpers.py
@@ -1,0 +1,36 @@
+import shlex
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _resolve_rotary_base(script_relpath: str) -> str:
+    script_path = REPO_ROOT / script_relpath
+    command = (
+        f"source {shlex.quote(str(script_path))}\n"
+        'printf "%s\\n" "${MODEL_ARGS[@]}"\n'
+    )
+    result = subprocess.run(
+        ["/bin/bash", "-c", command],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    args = result.stdout.splitlines()
+    rotary_base_index = args.index("--rotary-base")
+    return args[rotary_base_index + 1]
+
+
+def test_base_helper_uses_base_checkpoint_rotary_base():
+    assert _resolve_rotary_base("scripts/models/qwen3-30B-A3B.sh") == "1000000"
+
+
+def test_instruct_2507_helper_uses_2507_rotary_base():
+    assert _resolve_rotary_base("scripts/models/qwen3-30B-A3B-Instruct-2507.sh") == "10000000"
+
+
+def test_thinking_2507_helper_uses_2507_rotary_base():
+    assert _resolve_rotary_base("scripts/models/qwen3-30B-A3B-Thinking-2507.sh") == "10000000"

--- a/tests/fast/utils/test_qwen3_30b_a3b_model_helpers.py
+++ b/tests/fast/utils/test_qwen3_30b_a3b_model_helpers.py
@@ -2,6 +2,8 @@ import shlex
 import subprocess
 from pathlib import Path
 
+import pytest
+
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 
@@ -24,13 +26,13 @@ def _resolve_rotary_base(script_relpath: str) -> str:
     return args[rotary_base_index + 1]
 
 
-def test_base_helper_uses_base_checkpoint_rotary_base():
-    assert _resolve_rotary_base("scripts/models/qwen3-30B-A3B.sh") == "1000000"
-
-
-def test_instruct_2507_helper_uses_2507_rotary_base():
-    assert _resolve_rotary_base("scripts/models/qwen3-30B-A3B-Instruct-2507.sh") == "10000000"
-
-
-def test_thinking_2507_helper_uses_2507_rotary_base():
-    assert _resolve_rotary_base("scripts/models/qwen3-30B-A3B-Thinking-2507.sh") == "10000000"
+@pytest.mark.parametrize(
+    ("script_relpath", "expected_rotary_base"),
+    [
+        ("scripts/models/qwen3-30B-A3B.sh", "1000000"),
+        ("scripts/models/qwen3-30B-A3B-Instruct-2507.sh", "10000000"),
+        ("scripts/models/qwen3-30B-A3B-Thinking-2507.sh", "10000000"),
+    ],
+)
+def test_model_helpers_set_correct_rotary_base(script_relpath: str, expected_rotary_base: str):
+    assert _resolve_rotary_base(script_relpath) == expected_rotary_base


### PR DESCRIPTION
## Summary

This PR fixes the Qwen3 30B A3B helper mismatch for the `Instruct-2507` and `Thinking-2507` checkpoint families without breaking the existing base-family workflows.

Changes in this PR:
- add dedicated `scripts/models/qwen3-30B-A3B-Instruct-2507.sh` and `scripts/models/qwen3-30B-A3B-Thinking-2507.sh` wrappers that resolve `--rotary-base` to `10000000`
- keep `scripts/models/qwen3-30B-A3B.sh` at the base-family default and clarify that `*-2507` variants should use dedicated wrappers
- update the Qwen3 30B A3B docs to map checkpoint family to helper script and show a `*-2507` conversion example
- add a focused fast regression test that resolves the helper scripts through a real shell and verifies the resulting rotary base

## Root Cause

The generic `qwen3-30B-A3B.sh` helper currently resolves `--rotary-base` to `1000000`, which matches the base-family checkpoints already used by this repo.

However, `Qwen3-30B-A3B-Instruct-2507` and `Qwen3-30B-A3B-Thinking-2507` ship with `rope_theta = 10000000` in their Hugging Face configs. Miles validates HF config values against the Megatron CLI config in `hf_validate_args()`, so launching a `*-2507` checkpoint with the generic base helper fails on the `rope_theta` vs `rotary_base` mismatch.

## Why This Approach

This change treats the bug as a missing variant-specific helper rather than a broken global default.

That keeps the current base-family runner, examples, and tests correct while making the `*-2507` variants explicit and harder to misuse. It also preserves the current strict validation behavior instead of weakening a useful configuration check.

## User Impact

After this change:
- existing base-family Qwen3 30B A3B flows continue to use the current helper unchanged
- `Instruct-2507` and `Thinking-2507` users get dedicated helper scripts that match the checkpoint configs
- docs clearly explain which helper to source for each checkpoint family

Closes #742.

## Validation

- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest --noconftest tests/fast/utils/test_qwen3_30b_a3b_model_helpers.py -q`
- `python3 -m py_compile tests/fast/utils/test_qwen3_30b_a3b_model_helpers.py`
- `bash -n scripts/models/qwen3-30B-A3B.sh scripts/models/qwen3-30B-A3B-Instruct-2507.sh scripts/models/qwen3-30B-A3B-Thinking-2507.sh`
- direct shell resolution checks:
  - base helper -> `1000000`
  - `Instruct-2507` wrapper -> `10000000`
  - `Thinking-2507` wrapper -> `10000000`
