### PR TITLE
Fix Qwen3 Next MTP bridge block-spec wiring and add regression coverage

### DIFF
--- a/miles_plugins/mbridge/qwen3_next.py
+++ b/miles_plugins/mbridge/qwen3_next.py
@@ -1,4 +1,6 @@
 import torch
+from megatron.core.models.gpt.gpt_layer_specs import get_gpt_mtp_block_spec
+
 from mbridge.core import register_model
 from mbridge.models import Qwen2MoEBridge
 
@@ -75,9 +77,24 @@ class Qwen3NextBridge(Qwen2MoEBridge):
 
         return super()._weight_to_mcore_format(mcore_weights_name, hf_weights)
 
+    def _get_transformer_layer_spec(self, vp_stage=None):
+        transformer_layer_spec = super()._get_transformer_layer_spec(vp_stage)
+        self._last_transformer_layer_spec = transformer_layer_spec
+        return transformer_layer_spec
+
+    def _get_gptmodel_args(self) -> dict:
+        ret = super()._get_gptmodel_args()
+        if getattr(self.hf_config, "num_nextn_predict_layers", None) is not None:
+            transformer_layer_spec = getattr(self, "_last_transformer_layer_spec", None)
+            if transformer_layer_spec is None:
+                transformer_layer_spec = self._get_transformer_layer_spec()
+            mtp_block_spec = get_gpt_mtp_block_spec(self.config, transformer_layer_spec, use_transformer_engine=True)
+            ret["mtp_block_spec"] = mtp_block_spec
+        return ret
+
     def _build_config(self):
         mtp_args = {}
-        if hasattr(self.hf_config, "num_nextn_predict_layers"):
+        if getattr(self.hf_config, "num_nextn_predict_layers", None) is not None:
             mtp_args["mtp_num_layers"] = self.hf_config.num_nextn_predict_layers
 
         return self._build_base_config(

--- a/tests/test_qwen3_next_mtp_bridge_mapping.py
+++ b/tests/test_qwen3_next_mtp_bridge_mapping.py
@@ -1,0 +1,273 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import torch
+
+
+def install_bridge_stubs():
+    megatron_mod = types.ModuleType("megatron")
+    core_mod = types.ModuleType("megatron.core")
+    models_mod = types.ModuleType("megatron.core.models")
+    gpt_mod = types.ModuleType("megatron.core.models.gpt")
+    gpt_layer_specs_mod = types.ModuleType("megatron.core.models.gpt.gpt_layer_specs")
+    gpt_layer_specs_mod.get_gpt_mtp_block_spec = lambda _config, transformer_layer_spec, **_kwargs: (
+        "mtp-spec",
+        transformer_layer_spec,
+    )
+
+    mbridge_mod = types.ModuleType("mbridge")
+    mbridge_core_mod = types.ModuleType("mbridge.core")
+    mbridge_models_mod = types.ModuleType("mbridge.models")
+
+    def register_model(_names):
+        def decorator(cls):
+            return cls
+
+        return decorator
+
+    class Qwen2MoEBridge:
+        _ATTENTION_MAPPING = {}
+        _MLP_MAPPING = {
+            "mlp.linear_fc1.weight": [
+                "model.layers.{layer_number}.mlp.gate_proj.weight",
+                "model.layers.{layer_number}.mlp.up_proj.weight",
+            ],
+            "mlp.linear_fc2.weight": ["model.layers.{layer_number}.mlp.down_proj.weight"],
+            "shared_experts.linear_fc1.weight": [
+                "model.layers.{layer_number}.mlp.shared_expert.gate_proj.weight",
+                "model.layers.{layer_number}.mlp.shared_expert.up_proj.weight",
+            ],
+            "pre_mlp_layernorm": ["model.layers.{layer_number}.post_attention_layernorm.weight"],
+            "shared_experts.linear_fc2.weight": ["model.layers.{layer_number}.mlp.shared_expert.down_proj.weight"],
+            "mlp.router.weight": ["model.layers.{layer_number}.mlp.gate.weight"],
+            "shared_experts.gate_weight": ["model.layers.{layer_number}.mlp.shared_expert_gate.weight"],
+            "mlp.experts.linear_fc1": [
+                "model.layers.{layer_number}.mlp.experts.{expert_id}.gate_proj.weight",
+                "model.layers.{layer_number}.mlp.experts.{expert_id}.up_proj.weight",
+            ],
+            "mlp.experts.linear_fc2": ["model.layers.{layer_number}.mlp.experts.{expert_id}.down_proj.weight"],
+        }
+
+        def _weight_name_mapping_mlp(self, name: str) -> list[str]:
+            layer_number = name.split(".")[2]
+            convert_names = []
+            for keyword, mapping_names in self._MLP_MAPPING.items():
+                if keyword in name:
+                    if "{expert_id}" in mapping_names[0]:
+                        expert_id = name.split("weight")[-1]
+                        convert_names.extend(
+                            [x.format(layer_number=layer_number, expert_id=expert_id) for x in mapping_names]
+                        )
+                    else:
+                        convert_names.extend([x.format(layer_number=layer_number) for x in mapping_names])
+                    break
+            if len(convert_names) == 0:
+                raise NotImplementedError(f"Unsupported parameter name: {name}")
+            return convert_names
+
+        def _weight_name_mapping_attention(self, name: str) -> list[str]:
+            layer_number = name.split(".")[2]
+            convert_names = []
+            for keyword, mapping_names in self._ATTENTION_MAPPING.items():
+                if keyword in name:
+                    convert_names.extend([x.format(layer_number=layer_number) for x in mapping_names])
+                    break
+            if len(convert_names) == 0:
+                raise NotImplementedError(f"Unsupported attention parameter name: {name}")
+            return convert_names
+
+        def _get_transformer_layer_spec(self, vp_stage=None):
+            return "REAL_LAYER_SPEC" if vp_stage is None else f"REAL_LAYER_SPEC_VP{vp_stage}"
+
+        def _get_gptmodel_args(self) -> dict:
+            return {"base": "ok"}
+
+        def _model_provider(self, callbacks):
+            def provider(pre_process, post_process, vp_stage=None):
+                transformer_layer_spec = self._get_transformer_layer_spec(vp_stage)
+                gptmodel_args = self._get_gptmodel_args()
+                return {"transformer_layer_spec": transformer_layer_spec, **gptmodel_args}
+
+            return provider
+
+        def _weight_to_mcore_format(self, _mcore_weights_name, hf_weights):
+            assert len(hf_weights) == 1
+            return hf_weights[0]
+
+        def _weight_to_hf_format(self, mcore_weights_name, mcore_weights):
+            return [mcore_weights_name], [mcore_weights]
+
+        def _build_base_config(self, **kwargs):
+            return kwargs
+
+    mbridge_core_mod.register_model = register_model
+    mbridge_models_mod.Qwen2MoEBridge = Qwen2MoEBridge
+
+    sys.modules["megatron"] = megatron_mod
+    sys.modules["megatron.core"] = core_mod
+    sys.modules["megatron.core.models"] = models_mod
+    sys.modules["megatron.core.models.gpt"] = gpt_mod
+    sys.modules["megatron.core.models.gpt.gpt_layer_specs"] = gpt_layer_specs_mod
+    sys.modules["mbridge"] = mbridge_mod
+    sys.modules["mbridge.core"] = mbridge_core_mod
+    sys.modules["mbridge.models"] = mbridge_models_mod
+
+
+def load_bridge_module():
+    install_bridge_stubs()
+    module_path = Path(__file__).resolve().parents[1] / "miles_plugins" / "mbridge" / "qwen3_next.py"
+    module_name = "test_qwen3_next_bridge_module"
+    sys.modules.pop(module_name, None)
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def load_raw_export_module():
+    module_path = (
+        Path(__file__).resolve().parents[1]
+        / "miles"
+        / "backends"
+        / "megatron_utils"
+        / "megatron_to_hf"
+        / "qwen3_next.py"
+    )
+    module_name = "test_qwen3_next_raw_export_module"
+    sys.modules.pop(module_name, None)
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def make_raw_export_args():
+    return types.SimpleNamespace(
+        kv_channels=None,
+        hidden_size=16,
+        num_attention_heads=4,
+        num_query_groups=2,
+    )
+
+
+def test_mtp_direct_name_mapping_uses_expected_hf_names():
+    module = load_bridge_module()
+    bridge = module.Qwen3NextBridge.__new__(module.Qwen3NextBridge)
+
+    assert bridge._convert_mtp_param("mtp.layers.0.enorm.weight") == ["mtp.pre_fc_norm_embedding.weight"]
+    assert bridge._convert_mtp_param("mtp.layers.0.hnorm.weight") == ["mtp.pre_fc_norm_hidden.weight"]
+    assert bridge._convert_mtp_param("mtp.layers.0.eh_proj.weight") == ["mtp.fc.weight"]
+    assert bridge._convert_mtp_param("mtp.layers.0.final_layernorm.weight") == ["mtp.norm.weight"]
+
+
+def test_mtp_transformer_layer_attention_mapping_uses_mtp_prefix():
+    module = load_bridge_module()
+    bridge = module.Qwen3NextBridge.__new__(module.Qwen3NextBridge)
+
+    names = bridge._convert_mtp_param("mtp.layers.0.transformer_layer.self_attention.linear_attn.out_proj.weight")
+
+    assert names == ["mtp.layers.0.linear_attn.out_proj.weight"]
+
+
+def test_mtp_transformer_layer_dense_mlp_mapping_uses_dense_hf_weights():
+    module = load_bridge_module()
+    bridge = module.Qwen3NextBridge.__new__(module.Qwen3NextBridge)
+
+    fc1_names = bridge._convert_mtp_param("mtp.layers.0.transformer_layer.mlp.linear_fc1.weight")
+    fc2_names = bridge._convert_mtp_param("mtp.layers.0.transformer_layer.mlp.linear_fc2.weight")
+
+    assert fc1_names == ["mtp.layers.0.mlp.gate_proj.weight", "mtp.layers.0.mlp.up_proj.weight"]
+    assert fc2_names == ["mtp.layers.0.mlp.down_proj.weight"]
+
+
+def test_mtp_transformer_layer_moe_expert_mapping_uses_individual_hf_weights():
+    module = load_bridge_module()
+    bridge = module.Qwen3NextBridge.__new__(module.Qwen3NextBridge)
+
+    fc1_names = bridge._convert_mtp_param("mtp.layers.0.transformer_layer.mlp.experts.linear_fc1.weight42")
+    fc2_names = bridge._convert_mtp_param("mtp.layers.0.transformer_layer.mlp.experts.linear_fc2.weight42")
+
+    assert fc1_names == [
+        "mtp.layers.0.mlp.experts.42.gate_proj.weight",
+        "mtp.layers.0.mlp.experts.42.up_proj.weight",
+    ]
+    assert fc2_names == ["mtp.layers.0.mlp.experts.42.down_proj.weight"]
+
+
+def test_mtp_block_spec_uses_current_transformer_layer_spec():
+    module = load_bridge_module()
+    bridge = module.Qwen3NextBridge.__new__(module.Qwen3NextBridge)
+    bridge.config = "CONFIG_OBJECT"
+    bridge.hf_config = types.SimpleNamespace(num_nextn_predict_layers=1)
+
+    provider = bridge._model_provider([])
+    result = provider(True, True, vp_stage=3)
+
+    assert result["transformer_layer_spec"] == "REAL_LAYER_SPEC_VP3"
+    assert result["mtp_block_spec"] == ("mtp-spec", "REAL_LAYER_SPEC_VP3")
+
+
+def test_eh_proj_keeps_column_order_when_loading_to_mcore():
+    module = load_bridge_module()
+    bridge = module.Qwen3NextBridge.__new__(module.Qwen3NextBridge)
+
+    weight = torch.arange(24, dtype=torch.float32).view(3, 8)
+    converted = bridge._weight_to_mcore_format("mtp.layers.0.eh_proj.weight", [weight])
+
+    assert torch.equal(converted, weight)
+
+
+def test_build_config_sets_mtp_num_layers_and_attention_output_gate():
+    module = load_bridge_module()
+    bridge = module.Qwen3NextBridge.__new__(module.Qwen3NextBridge)
+    bridge.hf_config = types.SimpleNamespace(
+        num_nextn_predict_layers=1,
+        moe_intermediate_size=512,
+        num_experts_per_tok=8,
+        num_experts=64,
+        router_aux_loss_coef=0.0,
+    )
+
+    config = bridge._build_config()
+
+    assert config["mtp_num_layers"] == 1
+    assert config["attention_output_gate"] is True
+    assert config["moe_shared_expert_gate"] is True
+
+
+def test_raw_qwen3_next_mtp_export_keeps_eh_proj_column_order():
+    module = load_raw_export_module()
+
+    weight = torch.arange(24, dtype=torch.float32).view(3, 8)
+    converted = module.convert_qwen3_next_to_hf(
+        make_raw_export_args(), "module.module.mtp.layers.0.eh_proj.weight", weight
+    )
+
+    assert len(converted) == 1
+    assert converted[0][0] == "mtp.fc.weight"
+    assert torch.equal(converted[0][1], weight)
+
+
+def test_raw_qwen3_next_mtp_export_reuses_decoder_mapping_for_transformer_layer_mlp():
+    module = load_raw_export_module()
+
+    weight = torch.arange(24, dtype=torch.float32).view(6, 4)
+    converted = module.convert_qwen3_next_to_hf(
+        make_raw_export_args(),
+        "module.module.mtp.layers.0.transformer_layer.mlp.linear_fc1.weight",
+        weight,
+    )
+
+    gate_weight, up_weight = weight.chunk(2, dim=0)
+    assert [name for name, _ in converted] == [
+        "mtp.layers.0.mlp.gate_proj.weight",
+        "mtp.layers.0.mlp.up_proj.weight",
+    ]
+    assert torch.equal(converted[0][1], gate_weight)
+    assert torch.equal(converted[1][1], up_weight)


### PR DESCRIPTION
## Summary

Addresses radixark/miles#366.

This PR fixes the missing Qwen3 Next bridge-side MTP block-spec wiring and adds dedicated regression coverage for Qwen3 Next MTP bridge/raw-export behavior.

## Root Cause

Qwen3 Next already had partial MTP support in Miles:

- MTP config was exposed through `num_nextn_predict_layers`
- direct MTP tensors were mapped in `miles_plugins/mbridge/qwen3_next.py`
- raw Megatron-to-HF export already handled Qwen3 Next MTP tensor names

However, unlike the existing Qwen3.5 and MiMo bridge implementations, the Qwen3 Next bridge did not inject `mtp_block_spec` from `_get_gptmodel_args()`. That left Qwen3 Next without bridge-side MTP model-construction parity.

The repo also had no dedicated Qwen3 Next MTP bridge regression tests, which made this gap easy to miss.

## Changes

- add `get_gpt_mtp_block_spec` import to `miles_plugins/mbridge/qwen3_next.py`
- cache the active transformer layer spec in `Qwen3NextBridge._get_transformer_layer_spec()`
- add `Qwen3NextBridge._get_gptmodel_args()` so bridge mode injects `mtp_block_spec` when `num_nextn_predict_layers` is present
- tighten the `mtp_num_layers` config check to use `getattr(..., None)` instead of a bare `hasattr(...)`
- add `tests/test_qwen3_next_mtp_bridge_mapping.py` covering:
  - direct MTP tensor name mappings
  - transformer-layer attention remapping under `mtp.layers.*`
  - transformer-layer dense/MoE MLP remapping
  - bridge-side `mtp_block_spec` propagation
  - current `eh_proj` passthrough behavior
  - raw export consistency for direct and transformer-layer MTP tensors

## Validation

Ran locally in the isolated worktree:

- `python3.12 -m py_compile miles_plugins/mbridge/qwen3_next.py tests/test_qwen3_next_mtp_bridge_mapping.py`
- `git diff --check`
- direct Python 3.12 semantic validation script covering:
  - Qwen3 Next bridge-side `mtp_block_spec` injection
  - Qwen3 Next MTP direct / attention / MLP remapping
  - raw-export reuse of decoder mapping for MTP tensors

## Notes

- This PR is intentionally narrow. It fixes bridge-construction parity and adds regression coverage; it does not change Qwen3 Next `eh_proj` layout semantics or add model-specific numerical tuning.
- I could not run the full pytest path in this local environment because the repo requires Python `>=3.10`, while the locally available Python with `torch` installed is older; the available Python 3.12 environment here does not have `torch` installed.
