### PR TITLE
[feat] exp: weight update sparsity for communication-efficient distributed RL

### DIFF
--- a/miles/backends/megatron_utils/update_weight/delta_filter.py
+++ b/miles/backends/megatron_utils/update_weight/delta_filter.py
@@ -1,0 +1,77 @@
+"""Tensor-level delta weight filter for reducing weight transfer volume.
+
+Between consecutive RL training steps, ~98% of bf16 weight tensors remain
+bit-identical (see: https://arxiv.org/abs/2602.03839). This module caches
+the previous step's HF-format tensors and filters out unchanged ones,
+reducing the data sent to rollout engines by ~50x.
+
+Usage: instantiated once per weight updater; called on each bucket of
+HF-converted (name, tensor) pairs before they are sent to engines.
+"""
+
+import logging
+import time
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+
+class DeltaWeightFilter:
+    """Skip unchanged tensors between consecutive weight update steps.
+
+    Maintains a CPU cache of the last-transferred value for each named
+    parameter.  On each call to :meth:`filter`, tensors that are
+    bitwise-identical to the cached version are dropped.
+    """
+
+    def __init__(self, enabled: bool = False) -> None:
+        self._enabled = enabled
+        self._cache: dict[str, torch.Tensor] = {}
+        self._step_total = 0
+        self._step_changed = 0
+        self._cumulative_total = 0
+        self._cumulative_changed = 0
+        self._step_count = 0
+
+    def filter(
+        self, named_tensors: list[tuple[str, torch.Tensor]]
+    ) -> list[tuple[str, torch.Tensor]]:
+        """Return only tensors whose bits changed since the last call.
+
+        When disabled, returns *named_tensors* unchanged so callers do
+        not need a separate code path.
+        """
+        if not self._enabled:
+            return named_tensors
+
+        filtered: list[tuple[str, torch.Tensor]] = []
+        for name, tensor in named_tensors:
+            self._step_total += 1
+            cpu_tensor = tensor.detach().cpu()
+            cached = self._cache.get(name)
+            if cached is not None and cached.shape == cpu_tensor.shape and torch.equal(cached, cpu_tensor):
+                continue
+            filtered.append((name, tensor))
+            self._cache[name] = cpu_tensor.clone()
+            self._step_changed += 1
+
+        return filtered
+
+    def step_done(self) -> None:
+        """Mark the end of one weight-update step and log sparsity."""
+        if not self._enabled or self._step_total == 0:
+            self._step_total = 0
+            self._step_changed = 0
+            return
+
+        sparsity = 1.0 - self._step_changed / self._step_total
+        logger.info(
+            f"[DeltaWeight] {self._step_changed}/{self._step_total} tensors changed "
+            f"(sparsity={sparsity:.2%})"
+        )
+        self._cumulative_total += self._step_total
+        self._cumulative_changed += self._step_changed
+        self._step_count += 1
+        self._step_total = 0
+        self._step_changed = 0

--- a/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/broadcast.py
+++ b/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/broadcast.py
@@ -13,6 +13,7 @@ from tqdm import tqdm
 
 from miles.utils.distributed_utils import init_process_group
 
+from ..delta_filter import DeltaWeightFilter
 from .mixin import DistBucketedWeightUpdateMixin
 
 
@@ -41,6 +42,9 @@ class UpdateWeightFromDistributed(DistBucketedWeightUpdateMixin):
         self.quantization_config = quantization_config
         self.weight_version = 0
         self._model_update_groups = None
+        self._delta_filter = DeltaWeightFilter(
+            enabled=getattr(args, "delta_weight_update", False),
+        )
 
     def connect_rollout_engines(
         self,
@@ -72,6 +76,10 @@ class UpdateWeightFromDistributed(DistBucketedWeightUpdateMixin):
                 self.args, self._group_name, rollout_engines
             )
 
+    def _finalize_and_resume_engines(self) -> None:
+        self._delta_filter.step_done()
+        super()._finalize_and_resume_engines()
+
     @property
     def _is_source(self):
         """If it's the source gpu that broadcasting weights to rollout side"""
@@ -82,8 +90,12 @@ class UpdateWeightFromDistributed(DistBucketedWeightUpdateMixin):
     def _update_weight_implementation(
         self, converted_named_tensors: list[tuple[str, torch.Tensor]], pbar: tqdm | None = None
     ) -> None:
-        """Lock → broadcast → clear → unlock. Lock prevents NCCL deadlock."""
-        # lock the rollout engines to prevent dead lock on broadcast.
+        """Lock → delta-filter → broadcast → clear → unlock. Lock prevents NCCL deadlock."""
+        converted_named_tensors[:] = self._delta_filter.filter(converted_named_tensors)
+        if not converted_named_tensors:
+            if pbar:
+                pbar.update(1)
+            return
         while not ray.get(self.rollout_engine_lock.acquire.remote()):
             time.sleep(0.1)
         refs = update_weights_from_distributed(

--- a/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/p2p.py
+++ b/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/p2p.py
@@ -19,6 +19,7 @@ from tqdm import tqdm
 from miles.utils.distributed_utils import get_gloo_group
 
 from ..common import post_process_weights
+from ..delta_filter import DeltaWeightFilter
 from .mixin import DistBucketedWeightUpdateMixin
 from .p2p_transfer_utils import (
     P2PTransferManager,
@@ -65,6 +66,9 @@ class UpdateWeightP2P(DistBucketedWeightUpdateMixin):
         self._model_registered = False
         self._tensor_update_pending: dict[str, int] = {}
 
+        self._delta_filter = DeltaWeightFilter(
+            enabled=getattr(args, "delta_weight_update", False),
+        )
         self._staged_tensors: dict[str, list[tuple[str, torch.Tensor]]] = {}
         self.transfer_manager = P2PTransferManager(
             num_workers=getattr(args, "p2p_transfer_num_workers", 4),
@@ -115,9 +119,7 @@ class UpdateWeightP2P(DistBucketedWeightUpdateMixin):
         self._model_registered = True
 
     def _finalize_and_resume_engines(self):
-        # The `update_weight_version` here is necessary because the engine was not aware that the write has happened
-        # After p2p transfering, some models (like the ones with Deepseek-arch) of rollout side should invoke
-        # `post_load_weights` to re-generate the params which are not registered as `model.named_parameters()`
+        self._delta_filter.step_done()
         if dist.get_rank() == 0:
             ray.get(
                 [
@@ -144,7 +146,9 @@ class UpdateWeightP2P(DistBucketedWeightUpdateMixin):
         """
         if not self._is_source or not converted_named_tensors:
             return
-        # `ready_hf_tensors`` here are the complete tensors ready to be transferred.
+        converted_named_tensors[:] = self._delta_filter.filter(converted_named_tensors)
+        if not converted_named_tensors:
+            return
         transfer_ready_params, ready_hf_tensors = self._get_transfer_ready_params(converted_named_tensors)
 
         if transfer_ready_params and ready_hf_tensors:

--- a/miles/backends/megatron_utils/update_weight/update_weight_from_tensor.py
+++ b/miles/backends/megatron_utils/update_weight/update_weight_from_tensor.py
@@ -15,6 +15,7 @@ from miles.utils.distributed_utils import get_gloo_group
 
 from ..sglang import FlattenedTensorBucket, MultiprocessingSerializer
 from .common import post_process_weights
+from .delta_filter import DeltaWeightFilter
 from .hf_weight_iterator_base import HfWeightIteratorBase
 from .update_weight_from_distributed.broadcast import (
     connect_rollout_engines_from_distributed,
@@ -64,6 +65,9 @@ class UpdateWeightFromTensor:
         )
 
         self._lora_config = build_lora_sync_config(args) if self.is_lora else None
+        self._delta_filter = DeltaWeightFilter(
+            enabled=getattr(args, "delta_weight_update", False) and not self.is_lora,
+        )
         # Create IPC gather groups within megatron.
         for start_rank in range(0, dist.get_world_size(), self.args.rollout_num_gpus_per_engine):
             end_rank = start_rank + self.args.rollout_num_gpus_per_engine
@@ -189,11 +193,15 @@ class UpdateWeightFromTensor:
 
         sync_chunk_count = 0
         for hf_named_tensors in self._hf_weight_iterator.get_hf_weight_chunks(megatron_local_weights):
+            hf_named_tensors = self._delta_filter.filter(hf_named_tensors)
+            if not hf_named_tensors:
+                continue
             refs, long_lived_tensors = self._send_hf_params(hf_named_tensors)
             results = ray.get(refs)
             _check_weight_sync_results(results, is_lora=self.is_lora)
             del long_lived_tensors
             sync_chunk_count += 1
+        self._delta_filter.step_done()
 
         if self.is_lora and sync_chunk_count == 0:
             raise RuntimeError(

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -1326,6 +1326,11 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
             )
             parser.add_argument("--check-weight-update-equal", action="store_true")
             parser.add_argument(
+                "--delta-weight-update",
+                action="store_true",
+                help="Only transfer changed weight tensors to rollout engines (tensor-level delta).",
+            )
+            parser.add_argument(
                 "--env-report",
                 type=str,
                 default=os.environ.get("MILES_SCRIPT_ENV_REPORT", ""),


### PR DESCRIPTION
This draft PR is for testing and exp. Off-line sync with Nan and wait for Nan's PR.

## Motivation

Between consecutive RL training steps, ~98% of bf16 weight tensors remain bit-identical
(ref: https://arxiv.org/abs/2602.03839) - github: https://github.com/one-covenant/grail. Currently, all weight tensors are transferred to
rollout engines on every step, regardless of whether they have actually changed. This leads
to significant redundant communication overhead during weight synchronization.

## Summary

This PR introduces a `DeltaWeightFilter` that caches the previous step's HF-format tensors
and skips unchanged ones before transferring to rollout engines, reducing the data volume by
up to ~50x.

### Changes

- **New `DeltaWeightFilter` class** (`miles/backends/megatron_utils/update_weight/delta_filter.py`):
  Maintains a CPU cache of last-transferred tensors and performs bitwise comparison to filter
  out unchanged parameters. Logs per-step sparsity statistics for observability.

- **Integrate delta filtering into all three weight update paths**:
  - `broadcast.py` — NCCL broadcast path: filter before broadcast; skip bucket entirely if
    all tensors unchanged.
  - `p2p.py` — P2P transfer path: filter before staging tensors for transfer.
  - `update_weight_from_tensor.py` — Tensor-based (serialized) path: filter each HF weight
    chunk before sending. Disabled for LoRA sync since LoRA deltas are expected to change
    every step.

- **New CLI argument** (`miles/utils/arguments.py`):
  `--delta-weight-update` (default: off) — opt-in flag to enable the delta filter.

## Usage

```bash
# Add to your training script launch args:
--delta-weight-update

[firework](https://fireworks.ai/blog/frontier-rl-is-cheaper-than-you-think)
[Understanding and Exploiting Weight Update Sparsity
for Communication-Efficient Distributed RL](https://arxiv.org/pdf/2602.03839)