### PR TITLE
Fix: auto-create sessions on first access for restart tolerance

### DIFF
--- a/miles/rollout/session/linear_trajectory.py
+++ b/miles/rollout/session/linear_trajectory.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import time
 import uuid
 from dataclasses import dataclass, field
 from typing import Any
@@ -252,6 +253,7 @@ class SessionRegistry:
 
     def __init__(self, args, tokenizer: Any, *, tito_tokenizer: TITOTokenizer):
         self.sessions: dict[str, LinearTrajectory] = {}
+        self._session_last_access: dict[str, float] = {}
         self.args = args
         self.tokenizer = tokenizer
         self.tito_tokenizer = tito_tokenizer
@@ -271,10 +273,32 @@ class SessionRegistry:
     def get_or_create_session(self, session_id: str) -> LinearTrajectory:
         session = self.sessions.get(session_id)
         if session is None:
+            self._evict_stale_sessions()
             logger.warning("Auto-creating session %s (not found, likely router restart)", session_id)
             session = LinearTrajectory()
             self.sessions[session_id] = session
+            self._session_last_access[session_id] = time.monotonic()
+        else:
+            self._session_last_access[session_id] = time.monotonic()
         return session
+
+    _SESSION_TTL_SECS: int = 7200  # 2 hours
+    _MAX_AUTO_CREATED: int = 10000
+
+    def _evict_stale_sessions(self) -> None:
+        """Remove auto-created sessions older than _SESSION_TTL_SECS."""
+        if not self._session_last_access:
+            return
+        now = time.monotonic()
+        stale = [
+            sid for sid, ts in self._session_last_access.items()
+            if now - ts > self._SESSION_TTL_SECS
+        ]
+        for sid in stale:
+            self.sessions.pop(sid, None)
+            self._session_last_access.pop(sid, None)
+        if stale:
+            logger.info("Evicted %d stale auto-created sessions", len(stale))
 
     def remove_session(self, session_id: str) -> None:
         if self.sessions.pop(session_id, None) is None:

--- a/miles/rollout/session/linear_trajectory.py
+++ b/miles/rollout/session/linear_trajectory.py
@@ -268,6 +268,14 @@ class SessionRegistry:
             raise SessionNotFoundError(f"session not found: session_id={session_id}")
         return session
 
+    def get_or_create_session(self, session_id: str) -> LinearTrajectory:
+        session = self.sessions.get(session_id)
+        if session is None:
+            logger.warning("Auto-creating session %s (not found, likely router restart)", session_id)
+            session = LinearTrajectory()
+            self.sessions[session_id] = session
+        return session
+
     def remove_session(self, session_id: str) -> None:
         if self.sessions.pop(session_id, None) is None:
             raise SessionNotFoundError(f"session not found: session_id={session_id}")

--- a/miles/rollout/session/linear_trajectory.py
+++ b/miles/rollout/session/linear_trajectory.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 import time
 import uuid
+from collections import deque
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -254,6 +255,8 @@ class SessionRegistry:
     def __init__(self, args, tokenizer: Any, *, tito_tokenizer: TITOTokenizer):
         self.sessions: dict[str, LinearTrajectory] = {}
         self._session_last_access: dict[str, float] = {}
+        self._deleted_session_ids: set[str] = set()
+        self._deleted_order: deque[str] = deque()
         self.args = args
         self.tokenizer = tokenizer
         self.tito_tokenizer = tito_tokenizer
@@ -271,6 +274,10 @@ class SessionRegistry:
         return session
 
     def get_or_create_session(self, session_id: str) -> LinearTrajectory:
+        if session_id in self._deleted_session_ids:
+            # Explicitly deleted: do not silently resurrect it. Auto-create is only
+            # for ids the server has never seen (e.g. after a router restart).
+            raise SessionNotFoundError(f"session not found: session_id={session_id}")
         session = self.sessions.get(session_id)
         if session is None:
             self._evict_stale_sessions()
@@ -284,6 +291,7 @@ class SessionRegistry:
 
     _SESSION_TTL_SECS: int = 7200  # 2 hours
     _MAX_AUTO_CREATED: int = 10000
+    _MAX_DELETED_TOMBSTONES: int = 10000  # bound the deleted-id memory
 
     def _evict_stale_sessions(self) -> None:
         """Remove auto-created sessions older than _SESSION_TTL_SECS."""
@@ -303,6 +311,21 @@ class SessionRegistry:
     def remove_session(self, session_id: str) -> None:
         if self.sessions.pop(session_id, None) is None:
             raise SessionNotFoundError(f"session not found: session_id={session_id}")
+        self._tombstone(session_id)
+
+    def is_deleted(self, session_id: str) -> bool:
+        """True if this id was explicitly deleted (and must not be auto-recreated)."""
+        return session_id in self._deleted_session_ids
+
+    def _tombstone(self, session_id: str) -> None:
+        """Remember an explicitly deleted session id so it is not silently
+        auto-recreated. Bounded to the most recent _MAX_DELETED_TOMBSTONES ids."""
+        if session_id in self._deleted_session_ids:
+            return
+        if len(self._deleted_order) >= self._MAX_DELETED_TOMBSTONES:
+            self._deleted_session_ids.discard(self._deleted_order.popleft())
+        self._deleted_order.append(session_id)
+        self._deleted_session_ids.add(session_id)
 
     def compute_session_mismatch(self, session: LinearTrajectory) -> list[dict] | None:
         """Compare accumulated token IDs against canonical chat template output.

--- a/miles/rollout/session/linear_trajectory.py
+++ b/miles/rollout/session/linear_trajectory.py
@@ -298,10 +298,7 @@ class SessionRegistry:
         if not self._session_last_access:
             return
         now = time.monotonic()
-        stale = [
-            sid for sid, ts in self._session_last_access.items()
-            if now - ts > self._SESSION_TTL_SECS
-        ]
+        stale = [sid for sid, ts in self._session_last_access.items() if now - ts > self._SESSION_TTL_SECS]
         for sid in stale:
             self.sessions.pop(sid, None)
             self._session_last_access.pop(sid, None)

--- a/miles/rollout/session/sessions.py
+++ b/miles/rollout/session/sessions.py
@@ -67,7 +67,9 @@ def setup_session_routes(app, backend, args):
 
     @app.get("/sessions/{session_id}")
     async def get_session(session_id: str):
-        session = registry.get_or_create_session(session_id)
+        session = registry.sessions.get(session_id)
+        if session is None:
+            return GetSessionResponse(session_id=session_id, records=[], metadata={})
         metadata = {}
         try:
             mismatch = registry.compute_session_mismatch(session)

--- a/miles/rollout/session/sessions.py
+++ b/miles/rollout/session/sessions.py
@@ -67,7 +67,7 @@ def setup_session_routes(app, backend, args):
 
     @app.get("/sessions/{session_id}")
     async def get_session(session_id: str):
-        session = registry.get_session(session_id)
+        session = registry.get_or_create_session(session_id)
         metadata = {}
         try:
             mismatch = registry.compute_session_mismatch(session)
@@ -114,7 +114,7 @@ def setup_session_routes(app, backend, args):
         """
         _inflight_chat["count"] += 1
         try:
-            session = registry.get_session(session_id)
+            session = registry.get_or_create_session(session_id)
             if session.closing:
                 raise SessionNotFoundError(f"session not found: session_id={session_id}")
 

--- a/miles/rollout/session/sessions.py
+++ b/miles/rollout/session/sessions.py
@@ -69,6 +69,8 @@ def setup_session_routes(app, backend, args):
     async def get_session(session_id: str):
         session = registry.sessions.get(session_id)
         if session is None:
+            if registry.is_deleted(session_id):
+                raise SessionNotFoundError(f"session not found: session_id={session_id}")
             return GetSessionResponse(session_id=session_id, records=[], metadata={})
         metadata = {}
         try:

--- a/tests/fast/router/test_sessions.py
+++ b/tests/fast/router/test_sessions.py
@@ -73,10 +73,22 @@ class TestSessionRoutes:
         assert data["session_id"] == session_id
         assert data["records"] == []
 
-    def test_get_session_not_found(self, router_env):
+    def test_get_unknown_session_returns_empty(self, router_env):
+        # An id the server has never seen (e.g. after a router restart) is returned
+        # as empty rather than 404, so the orchestrator can recover gracefully.
         response = requests.get(f"{router_env.url}/sessions/nonexistent", timeout=5.0)
+        assert response.status_code == 200
+        data = response.json()
+        assert data["session_id"] == "nonexistent"
+        assert data["records"] == []
+
+    def test_get_deleted_session_returns_404(self, router_env):
+        # An explicitly deleted id is tombstoned: a later GET must not resurrect it
+        # as an empty session (that would undo the delete).
+        session_id = requests.post(f"{router_env.url}/sessions", timeout=5.0).json()["session_id"]
+        assert requests.delete(f"{router_env.url}/sessions/{session_id}", timeout=5.0).status_code == 204
+        response = requests.get(f"{router_env.url}/sessions/{session_id}", timeout=5.0)
         assert response.status_code == 404
-        assert response.json()["error"] == "session not found: session_id=nonexistent"
 
     def test_delete_session(self, router_env):
         session_id = requests.post(f"{router_env.url}/sessions", timeout=5.0).json()["session_id"]


### PR DESCRIPTION
## Summary
- Added `SessionRegistry.get_or_create_session()` which auto-creates a `LinearTrajectory` when the session ID is not found, instead of raising `SessionNotFoundError`
- `GET /sessions/{session_id}` now returns empty records for unknown sessions instead of 404
- `POST /sessions/{session_id}/v1/chat/completions` also auto-creates sessions, so agents can transparently resume after a router restart

## Motivation
During long-running RL training jobs, if the session server restarts (e.g., Ray job restart, node failure), all in-memory sessions are lost. Every active agent then receives 404 errors and crashes. This change makes session access idempotent: agents recover transparently instead of cascading failures across all running trials.