### PR TITLE
Fix: recover from SGLang rollback failures in session proxy

### DIFF
--- a/miles/rollout/session/sessions.py
+++ b/miles/rollout/session/sessions.py
@@ -167,7 +167,24 @@ def setup_session_routes(app, backend, args):
             # pass it through to the agent without recording — the agent can retry
             # or handle the error.
             if result["status_code"] != 200:
-                return backend.build_proxy_response(result)
+                # Rollback failures indicate corrupted prefix-cache state in SGLang.
+                # Retry once without pretokenized input_ids so SGLang processes the
+                # request from scratch instead of attempting prefix continuation.
+                error_body = result.get("response_body", b"")
+                if isinstance(error_body, bytes):
+                    error_body = error_body.decode("utf-8", errors="replace")
+                if result["status_code"] == 400 and "rollback failed" in error_body:
+                    logger.warning(
+                        "SGLang rollback failed for session %s, retrying without prefix continuation",
+                        session_id,
+                    )
+                    request_body.pop("input_ids", None)
+                    retry_body = json.dumps(request_body).encode()
+                    result = await backend.do_proxy(request, "v1/chat/completions", body=retry_body)
+                    if result["status_code"] != 200:
+                        return backend.build_proxy_response(result)
+                else:
+                    return backend.build_proxy_response(result)
 
             response = json.loads(result["response_body"])
 

--- a/miles/rollout/session/sessions.py
+++ b/miles/rollout/session/sessions.py
@@ -170,10 +170,14 @@ def setup_session_routes(app, backend, args):
                 # Rollback failures indicate corrupted prefix-cache state in SGLang.
                 # Retry once without pretokenized input_ids so SGLang processes the
                 # request from scratch instead of attempting prefix continuation.
-                error_body = result.get("response_body", b"")
+                error_body = result.get("response_body") or b""
                 if isinstance(error_body, bytes):
                     error_body = error_body.decode("utf-8", errors="replace")
-                if result["status_code"] == 400 and "rollback failed" in error_body:
+                if (
+                    result["status_code"] == 400
+                    and "rollback failed" in error_body.lower()
+                    and "input_ids" in request_body
+                ):
                     logger.warning(
                         "SGLang rollback failed for session %s, retrying without prefix continuation",
                         session_id,


### PR DESCRIPTION
## Summary
When SGLang returns 400 "rollback failed" (prefix-cache state mismatch between stored and incoming messages), retry the request once without pretokenized `input_ids`. This bypasses prefix continuation and lets SGLang process the request from scratch.

## Motivation
During multi-turn sessions, SGLang's rollback validation can fail when the stored message count doesn't match the incoming request (e.g., "no assistant message found in the first 1 matched messages"). Previously this was a fatal error that immediately killed the session. With this fix, the session proxy retries without prefix continuation, allowing the request to succeed.