### PR TITLE
Fix: truncate rollout_routed_experts in _truncate_sample_output

### DIFF
--- a/miles/rollout/generate_utils/openai_endpoint_utils.py
+++ b/miles/rollout/generate_utils/openai_endpoint_utils.py
@@ -228,4 +228,8 @@ def _truncate_sample_output(sample: Sample, keep_tokens: int, tokenizer) -> None
         sample.rollout_log_probs = sample.rollout_log_probs[:keep_tokens]
     if sample.loss_mask is not None:
         sample.loss_mask = sample.loss_mask[:keep_tokens]
+    if sample.rollout_routed_experts is not None:
+        # rollout_routed_experts has shape (len(tokens) - 1, ...), so slice to
+        # match the new total token count minus one.
+        sample.rollout_routed_experts = sample.rollout_routed_experts[:prompt_len - 1 + keep_tokens]
     sample.status = Sample.Status.TRUNCATED

--- a/miles/rollout/generate_utils/openai_endpoint_utils.py
+++ b/miles/rollout/generate_utils/openai_endpoint_utils.py
@@ -229,7 +229,5 @@ def _truncate_sample_output(sample: Sample, keep_tokens: int, tokenizer) -> None
     if sample.loss_mask is not None:
         sample.loss_mask = sample.loss_mask[:keep_tokens]
     if sample.rollout_routed_experts is not None:
-        # rollout_routed_experts has shape (len(tokens) - 1, ...), so slice to
-        # match the new total token count minus one.
-        sample.rollout_routed_experts = sample.rollout_routed_experts[:prompt_len - 1 + keep_tokens]
+        sample.rollout_routed_experts = sample.rollout_routed_experts[:len(sample.tokens) - 1]
     sample.status = Sample.Status.TRUNCATED


### PR DESCRIPTION
## Summary
Add missing `rollout_routed_experts` truncation in `_truncate_sample_output()`, fixing `Sample.validate()` assertion failures when agentic sessions exceed `max_seq_len` with `--use-rollout-routing-replay` enabled.

Closes #861.

## Context
`_truncate_sample_output()` truncates `tokens`, `rollout_log_probs`, and `loss_mask`, but not `rollout_routed_experts`. After truncation, `len(tokens) - 1 != rollout_routed_experts.shape[0]`, which fails validation. `Sample.strip_last_output_tokens()` in `types.py` already handles this correctly; this change adds the same logic to the truncation path.

## Changes
- `miles/rollout/generate_utils/openai_endpoint_utils.py`: Truncate `rollout_routed_experts` to `prompt_len - 1 + keep_tokens` (matching the `(len(tokens) - 1, ...)` shape convention)