### PR TITLE
Support rfork loading in miles rollout manager

### DIFF
--- a/miles/backends/sglang_utils/sglang_engine.py
+++ b/miles/backends/sglang_utils/sglang_engine.py
@@ -674,8 +674,9 @@ def _compute_server_args(
         else:
             logger.info("No pre-trained LoRA adapter_path provided, will use random initial weights")
 
-    # Override load_format for follower engines that load from a seed
-    if seed_instance_ip is not None and seed_instance_service_port is not None:
+    # Override load_format for follower engines that load from a seed.
+    is_follower = seed_instance_ip is not None and seed_instance_service_port is not None
+    if is_follower:
         kwargs["load_format"] = "remote_instance"
         kwargs["remote_instance_weight_loader_seed_instance_ip"] = seed_instance_ip
         kwargs["remote_instance_weight_loader_seed_instance_service_port"] = seed_instance_service_port
@@ -683,7 +684,6 @@ def _compute_server_args(
         kwargs["remote_instance_weight_loader_start_seed_via_transfer_engine"] = True
 
     unused_keys = set(kwargs.keys())
-    is_follower = seed_instance_ip is not None and seed_instance_service_port is not None
     for attr in dataclasses.fields(ServerArgs):
         if worker_type == "decode" and attr.name == "enable_hierarchical_cache":
             continue

--- a/miles/backends/sglang_utils/sglang_engine.py
+++ b/miles/backends/sglang_utils/sglang_engine.py
@@ -135,6 +135,9 @@ class SGLangEngine(RayActor):
         router_ip=None,
         router_port=None,
         engine_info_bootstrap_port=None,
+        node_hosts=None,
+        seed_instance_ip=None,
+        seed_instance_service_port=None,
     ):
         if env_report := self.args.env_report:
             collect_and_print_node_env_report(
@@ -175,6 +178,9 @@ class SGLangEngine(RayActor):
             engine_info_bootstrap_port=engine_info_bootstrap_port,
             sglang_overrides=self.sglang_overrides,
             num_gpus_per_engine=self.num_gpus_per_engine,
+            node_hosts=node_hosts,
+            seed_instance_ip=seed_instance_ip,
+            seed_instance_service_port=seed_instance_service_port,
         )
 
         self.node_rank = server_args_dict["node_rank"]
@@ -597,6 +603,9 @@ def _compute_server_args(
     engine_info_bootstrap_port: int | None = None,
     sglang_overrides: dict | None = None,
     num_gpus_per_engine: int | None = None,
+    node_hosts: str | None = None,
+    seed_instance_ip: str | None = None,
+    seed_instance_service_port: int | None = None,
 ):
     _gpus_per_engine = num_gpus_per_engine or args.rollout_num_gpus_per_engine
     nnodes = max(1, _gpus_per_engine // args.num_gpus_per_node)
@@ -649,6 +658,8 @@ def _compute_server_args(
         kwargs["dtype"] = "float16"
     if engine_info_bootstrap_port is not None:
         kwargs["engine_info_bootstrap_port"] = engine_info_bootstrap_port
+    if node_hosts is not None and nnodes > 1:
+        kwargs["node_hosts"] = node_hosts
     external_engine_need_check_fields = [k for k in kwargs.keys() if k not in _EXTERNAL_ENGINE_SKIP_CHECK_FIELDS]
 
     if is_lora_enabled(args):
@@ -663,9 +674,22 @@ def _compute_server_args(
         else:
             logger.info("No pre-trained LoRA adapter_path provided, will use random initial weights")
 
+    # Override load_format for follower engines that load from a seed
+    if seed_instance_ip is not None and seed_instance_service_port is not None:
+        kwargs["load_format"] = "remote_instance"
+        kwargs["remote_instance_weight_loader_seed_instance_ip"] = seed_instance_ip
+        kwargs["remote_instance_weight_loader_seed_instance_service_port"] = seed_instance_service_port
+        kwargs["remote_instance_weight_loader_backend"] = "transfer_engine"
+        kwargs["remote_instance_weight_loader_start_seed_via_transfer_engine"] = True
+
     unused_keys = set(kwargs.keys())
+    is_follower = seed_instance_ip is not None and seed_instance_service_port is not None
     for attr in dataclasses.fields(ServerArgs):
         if worker_type == "decode" and attr.name == "enable_hierarchical_cache":
+            continue
+        # model_loader_extra_config is only for DefaultModelLoader (seed);
+        # RemoteInstanceModelLoader (follower) rejects it.
+        if is_follower and attr.name == "model_loader_extra_config":
             continue
         if hasattr(args, f"sglang_{attr.name}") and attr.name not in kwargs:
             kwargs[attr.name] = getattr(args, f"sglang_{attr.name}")

--- a/miles/ray/rollout.py
+++ b/miles/ray/rollout.py
@@ -192,6 +192,12 @@ class ServerGroup:
                 logical_engine_id = rank // engine_nnodes
                 logical_engine_groups.setdefault(logical_engine_id, []).append((rank, engine))
 
+            def node_hosts_for_group(ranks_and_engines):
+                """Comma-separated node IPs for a logical engine group (multi-node TP only)."""
+                if engine_nnodes <= 1:
+                    return None
+                return ",".join(addr_and_ports[r]["host"] for r, _ in ranks_and_engines)
+
             seed_logical_engine_id = min(logical_engine_groups.keys())
             follower_logical_engine_ids = set(logical_engine_groups.keys()) - {seed_logical_engine_id}
             seed_ranks = logical_engine_groups[seed_logical_engine_id]
@@ -201,12 +207,18 @@ class ServerGroup:
             ), f"Seed loading: seed engine group {seed_logical_engine_id} has {len(seed_ranks)} ranks, expected {engine_nnodes}"
 
             seed_head_rank = seed_ranks[0][0]
+            seed_node_hosts = node_hosts_for_group(seed_ranks)
             logger.info(
                 f"Seed loading: initializing seed engine {seed_logical_engine_id} "
                 f"(ranks {[r for r, _ in seed_ranks]}) with {engine_nnodes} node(s) — loads from disk"
             )
             seed_handles = [
-                engine.init.remote(**(addr_and_ports[rank]), router_ip=self.router_ip, router_port=self.router_port)
+                engine.init.remote(
+                    **(addr_and_ports[rank]),
+                    router_ip=self.router_ip,
+                    router_port=self.router_port,
+                    node_hosts=seed_node_hosts,
+                )
                 for rank, engine in seed_ranks
             ]
             ray.get(seed_handles)
@@ -215,13 +227,16 @@ class ServerGroup:
             seed_port = addr_and_ports[seed_head_rank]["port"]
             follower_handles = []
             for logical_engine_id in follower_logical_engine_ids:
-                for rank, engine in logical_engine_groups[logical_engine_id]:
+                follower_ranks = logical_engine_groups[logical_engine_id]
+                follower_node_hosts = node_hosts_for_group(follower_ranks)
+                for rank, engine in follower_ranks:
                     logger.info(f"Seed loading: actor {rank} will load from seed at {seed_host}:{seed_port}")
                     follower_handles.append(
                         engine.init.remote(
                             **(addr_and_ports[rank]),
                             router_ip=self.router_ip,
                             router_port=self.router_port,
+                            node_hosts=follower_node_hosts,
                             seed_instance_ip=seed_host,
                             seed_instance_service_port=seed_port,
                         )

--- a/miles/ray/rollout.py
+++ b/miles/ray/rollout.py
@@ -179,15 +179,67 @@ class ServerGroup:
                 base_port=base_port,
             )
 
-        init_handles = [
-            engine.init.remote(
-                **(addr_and_ports[rank]),
-                router_ip=self.router_ip,
-                router_port=self.router_port,
+        engine_nnodes = max(1, self.num_gpus_per_engine // self.args.num_gpus_per_node)
+        use_seed_loading = (
+            getattr(self.args, "sglang_load_format", None) != "dummy"
+            and getattr(self.args, "sglang_remote_instance_weight_loader_start_seed_via_transfer_engine", False)
+            and len(rollout_engines) > engine_nnodes
+        )
+
+        if use_seed_loading:
+            logical_engine_groups: dict = {}
+            for rank, engine in rollout_engines:
+                logical_engine_id = rank // engine_nnodes
+                logical_engine_groups.setdefault(logical_engine_id, []).append((rank, engine))
+
+            seed_logical_engine_id = min(logical_engine_groups.keys())
+            follower_logical_engine_ids = set(logical_engine_groups.keys()) - {seed_logical_engine_id}
+            seed_ranks = logical_engine_groups[seed_logical_engine_id]
+
+            assert (
+                len(seed_ranks) == engine_nnodes
+            ), f"Seed loading: seed engine group {seed_logical_engine_id} has {len(seed_ranks)} ranks, expected {engine_nnodes}"
+
+            seed_head_rank = seed_ranks[0][0]
+            logger.info(
+                f"Seed loading: initializing seed engine {seed_logical_engine_id} "
+                f"(ranks {[r for r, _ in seed_ranks]}) with {engine_nnodes} node(s) — loads from disk"
             )
-            for rank, engine in rollout_engines
-        ]
-        return init_handles, port_cursors
+            seed_handles = [
+                engine.init.remote(**(addr_and_ports[rank]), router_ip=self.router_ip, router_port=self.router_port)
+                for rank, engine in seed_ranks
+            ]
+            ray.get(seed_handles)
+
+            seed_host = addr_and_ports[seed_head_rank]["host"]
+            seed_port = addr_and_ports[seed_head_rank]["port"]
+            follower_handles = []
+            for logical_engine_id in follower_logical_engine_ids:
+                for rank, engine in logical_engine_groups[logical_engine_id]:
+                    logger.info(f"Seed loading: actor {rank} will load from seed at {seed_host}:{seed_port}")
+                    follower_handles.append(
+                        engine.init.remote(
+                            **(addr_and_ports[rank]),
+                            router_ip=self.router_ip,
+                            router_port=self.router_port,
+                            seed_instance_ip=seed_host,
+                            seed_instance_service_port=seed_port,
+                        )
+                    )
+            ray.get(follower_handles)
+            return [], port_cursors
+        else:
+            # TODO: don't ray.get here to overlap train actor init with rollout engine init.
+            # somehow if we don't sync here, the --debug-rollout-only mode will crash.
+            init_handles = [
+                engine.init.remote(
+                    **(addr_and_ports[rank]),
+                    router_ip=self.router_ip,
+                    router_port=self.router_port,
+                )
+                for rank, engine in rollout_engines
+            ]
+            return init_handles, port_cursors
 
     def offload(self):
         if not self.needs_offload:


### PR DESCRIPTION
This PR also ensures rfork loading composes correctly with p2p weight updates (`--update-weight-transfer-mode p2p`): after startup, both the seed and all followers register their transfer engine info with their own bootstrap servers so the training process can push updated weights to every engine via RDMA after each training step.

> **Dependency:** This feature requires a companion SGLang fix ([sgl-project/sglang#22171](https://github.com/sgl-project/sglang/pull/22171)) that ensures rfork followers register their transfer engine info with their bootstrap server after loading, enabling the training side to query `/get_remote_instance_transfer_engine_info` for p2p weight updates.

## Modifications

**`miles/ray/rollout.py`** — `ServerGroup.start_engines()`

Added seed loading orchestration. When `--sglang-remote-instance-weight-loader-start-seed-via-transfer-engine` is set and there is more than one logical engine, startup is split into two sequential phases:

1. **Seed phase** — the first logical engine group initializes normally (loads from disk). `ray.get()` blocks until the seed is fully ready and its transfer engine info is registered with its bootstrap server.

2. **Follower phase** — all remaining engine groups initialize in parallel, each passing the seed's host and port so they load weights from the seed over RDMA instead of disk.

```
Before: [engine 0, engine 1, engine 2, engine 3] — all load from disk in parallel

After:  [engine 0] loads from disk (seed)
           ↓ ready
        [engine 1, engine 2, engine 3] load from engine 0 via RDMA (followers, parallel)
```

When the feature is not active (single engine, dummy load format, or flag not set), the original code path is preserved unchanged.

**`miles/backends/sglang_utils/sglang_engine.py`** - `SGLangEngine.init()` and `_compute_server_args()`:**

- Added three new parameters: `node_hosts`, `seed_instance_ip`, `seed_instance_service_port`.
- For follower engines (`seed_instance_ip` is set): configures SGLang ServerArgs for rfork loading:
  - `load_format = remote_instance`
  - `remote_instance_weight_loader_seed_instance_ip`
  - `remote_instance_weight_loader_seed_instance_service_port`
  - `remote_instance_weight_loader_backend = transfer_engine`
  - `remote_instance_weight_loader_start_seed_via_transfer_engine = True` — follower's
    bootstrap server must also start so the training side can query the follower's
    transfer engine info for p2p weight updates after startup.
- Skips `model_loader_extra_config` for followers: `RemoteInstanceModelLoader` rejects this argument (only `DefaultModelLoader` accepts it).
- Passes `node_hosts` to SGLang for multi-node engine setups.

## Accuracy Tests

Verified with an end-to-end GRPO training test (`tests/e2e/megatron/test_qwen3_4B_p2p.py`)
```bash
cd miles && python tests/e2e/megatron/test_qwen3_4B_p2p.py
```
