### PR TITLE
Minor fixes in `swe-agent-v2/run.py`

### DIFF
--- a/examples/experimental/swe-agent-v2/run.py
+++ b/examples/experimental/swe-agent-v2/run.py
@@ -48,7 +48,12 @@ class ScriptArgs(U.ExecuteTrainConfig):
     agent_model_name: str = os.environ.get("AGENT_MODEL_NAME", "model")
     harbor_tasks_dir: str = os.environ.get("HARBOR_TASKS_DIR", "/root/harbor_tasks")
     router_external_host: str = os.environ.get("MILES_ROUTER_EXTERNAL_HOST", socket.gethostname())  # public IP
-    miles_host_ip: str = os.environ.get("MILES_HOST_IP", socket.gethostname())  # cluster/pod IP
+    # Prefer explicit MILES_HOST_IP; else MASTER_ADDR when set (avoids unresolvable pod hostnames on workers).
+    miles_host_ip: str = (
+        os.environ.get("MILES_HOST_IP")
+        or (os.environ.get("MASTER_ADDR") or "").strip()
+        or socket.gethostname()
+    )
 
     # W&B settings
     wandb_key: str = os.environ.get("WANDB_KEY", os.environ.get("WANDB_API_KEY", ""))

--- a/examples/experimental/swe-agent-v2/run.py
+++ b/examples/experimental/swe-agent-v2/run.py
@@ -50,7 +50,7 @@ class ScriptArgs(U.ExecuteTrainConfig):
     router_external_host: str = os.environ.get("MILES_ROUTER_EXTERNAL_HOST", socket.gethostname())  # public IP
     # Prefer explicit MILES_HOST_IP; else MASTER_ADDR when set (avoids unresolvable pod hostnames on workers).
     miles_host_ip: str = (
-        os.environ.get("MILES_HOST_IP") or (os.environ.get("MASTER_ADDR") or "").strip() or socket.gethostname()
+        os.environ.get("MILES_HOST_IP") or os.environ.get("MASTER_ADDR", "").strip() or socket.gethostname()
     )
 
     # W&B settings

--- a/examples/experimental/swe-agent-v2/run.py
+++ b/examples/experimental/swe-agent-v2/run.py
@@ -50,9 +50,7 @@ class ScriptArgs(U.ExecuteTrainConfig):
     router_external_host: str = os.environ.get("MILES_ROUTER_EXTERNAL_HOST", socket.gethostname())  # public IP
     # Prefer explicit MILES_HOST_IP; else MASTER_ADDR when set (avoids unresolvable pod hostnames on workers).
     miles_host_ip: str = (
-        os.environ.get("MILES_HOST_IP")
-        or (os.environ.get("MASTER_ADDR") or "").strip()
-        or socket.gethostname()
+        os.environ.get("MILES_HOST_IP") or (os.environ.get("MASTER_ADDR") or "").strip() or socket.gethostname()
     )
 
     # W&B settings


### PR DESCRIPTION
Make `MILES_HOST_IP` default to `MASTER_ADDR` when the latter is set. In a multi-node environment, this ensures that the workers can resolve the correct address of the head node.