### PR TITLE
feat: add session record disk logging (RecordLogger)

### DIFF
--- a/miles/rollout/session/linear_trajectory.py
+++ b/miles/rollout/session/linear_trajectory.py
@@ -4,6 +4,7 @@ import uuid
 from dataclasses import dataclass, field
 from typing import Any
 
+from miles.rollout.session.record_logger import RecordLogger
 from miles.rollout.session.session_errors import MessageValidationError, SessionNotFoundError, TokenizationError
 from miles.rollout.session.session_types import SessionRecord
 from miles.utils.chat_template_utils import (
@@ -256,6 +257,8 @@ class SessionRegistry:
         self.tokenizer = tokenizer
         self.tito_tokenizer = tito_tokenizer
         self.comparator = tito_tokenizer.create_comparator()
+        log_dir = getattr(args, "session_record_log_dir", None)
+        self.record_logger: RecordLogger | None = RecordLogger(log_dir) if log_dir else None
 
     def create_session(self) -> str:
         session_id = uuid.uuid4().hex
@@ -268,9 +271,15 @@ class SessionRegistry:
             raise SessionNotFoundError(f"session not found: session_id={session_id}")
         return session
 
+    def log_record(self, session_id: str, record: SessionRecord) -> None:
+        if self.record_logger is not None:
+            self.record_logger.log_record(session_id, record)
+
     def remove_session(self, session_id: str) -> None:
         if self.sessions.pop(session_id, None) is None:
             raise SessionNotFoundError(f"session not found: session_id={session_id}")
+        if self.record_logger is not None:
+            self.record_logger.close_session(session_id)
 
     def compute_session_mismatch(self, session: LinearTrajectory) -> list[dict] | None:
         """Compare accumulated token IDs against canonical chat template output.

--- a/miles/rollout/session/record_logger.py
+++ b/miles/rollout/session/record_logger.py
@@ -1,53 +1,105 @@
 """Disk-based JSONL logger for session records.
 
 Each session gets its own file: ``<log_dir>/<session_id>.jsonl``.
+A dedicated background thread handles serialization and disk I/O so that
+callers (typically async request handlers) never block on file operations.
 Records are flushed immediately so that partial sessions are preserved
 if the process crashes.
 """
 
 import json
 import logging
+import threading
 from pathlib import Path
+from queue import SimpleQueue
 from typing import IO
 
 from miles.rollout.session.session_types import SessionRecord
 
 logger = logging.getLogger(__name__)
 
+# Sentinel object to signal the writer thread to shut down.
+_SHUTDOWN = object()
+
 
 class RecordLogger:
-    """Writes ``SessionRecord`` objects as one-JSON-per-line to per-session files."""
+    """Writes ``SessionRecord`` objects as one-JSON-per-line to per-session files.
+
+    All disk I/O runs on a single background daemon thread, making
+    :meth:`log_record` and :meth:`close_session` non-blocking.
+    """
 
     def __init__(self, log_dir: str):
         self.log_dir = Path(log_dir)
         self.log_dir.mkdir(parents=True, exist_ok=True)
-        self._handles: dict[str, IO[str]] = {}
+        self._queue: SimpleQueue = SimpleQueue()
+        self._thread = threading.Thread(target=self._writer_loop, daemon=True, name="record-logger")
+        self._thread.start()
         logger.info("[record-logger] Logging session records to %s", self.log_dir)
 
-    def _get_handle(self, session_id: str) -> IO[str]:
-        handle = self._handles.get(session_id)
-        if handle is None:
-            path = self.log_dir / f"{session_id}.jsonl"
-            handle = open(path, "a", encoding="utf-8")
-            self._handles[session_id] = handle
-        return handle
+    # -- public (non-blocking) API ------------------------------------------
 
     def log_record(self, session_id: str, record: SessionRecord) -> None:
+        """Enqueue a record to be written. Returns immediately."""
+        self._queue.put(("write", session_id, record))
+
+    def close_session(self, session_id: str) -> None:
+        """Enqueue a session-close event (flushes and closes the file handle)."""
+        self._queue.put(("close", session_id, None))
+
+    def close_all(self) -> None:
+        """Shut down the writer thread and close every open file handle.
+
+        Blocks until the background thread has drained the queue and exited.
+        """
+        self._queue.put(_SHUTDOWN)
+        self._thread.join()
+
+    # -- background writer --------------------------------------------------
+
+    def _writer_loop(self) -> None:
+        handles: dict[str, IO[str]] = {}
         try:
-            handle = self._get_handle(session_id)
+            while True:
+                item = self._queue.get()
+                if item is _SHUTDOWN:
+                    break
+                action, session_id, record = item
+                if action == "write":
+                    self._do_write(handles, session_id, record)
+                elif action == "close":
+                    self._do_close(handles, session_id)
+        finally:
+            # Drain any remaining items before shutting down.
+            while not self._queue.empty():
+                item = self._queue.get()
+                if item is _SHUTDOWN:
+                    continue
+                action, session_id, record = item
+                if action == "write":
+                    self._do_write(handles, session_id, record)
+                elif action == "close":
+                    self._do_close(handles, session_id)
+            # Close all remaining file handles.
+            for sid in list(handles):
+                self._do_close(handles, sid)
+
+    def _do_write(self, handles: dict[str, IO[str]], session_id: str, record: SessionRecord) -> None:
+        try:
+            handle = handles.get(session_id)
+            if handle is None:
+                path = self.log_dir / f"{session_id}.jsonl"
+                handle = open(path, "a", encoding="utf-8")
+                handles[session_id] = handle
             handle.write(json.dumps(record.model_dump(), default=str) + "\n")
             handle.flush()
         except Exception:
             logger.exception("[record-logger] Failed to write record for session %s", session_id)
 
-    def close_session(self, session_id: str) -> None:
-        handle = self._handles.pop(session_id, None)
+    def _do_close(self, handles: dict[str, IO[str]], session_id: str) -> None:
+        handle = handles.pop(session_id, None)
         if handle is not None:
             try:
                 handle.close()
             except Exception:
                 logger.exception("[record-logger] Failed to close log for session %s", session_id)
-
-    def close_all(self) -> None:
-        for session_id in list(self._handles):
-            self.close_session(session_id)

--- a/miles/rollout/session/record_logger.py
+++ b/miles/rollout/session/record_logger.py
@@ -1,105 +1,44 @@
 """Disk-based JSONL logger for session records.
 
 Each session gets its own file: ``<log_dir>/<session_id>.jsonl``.
-A dedicated background thread handles serialization and disk I/O so that
-callers (typically async request handlers) never block on file operations.
-Records are flushed immediately so that partial sessions are preserved
-if the process crashes.
+Writes are synchronous — each ``log_record`` call serializes and flushes
+immediately.
 """
 
 import json
 import logging
-import threading
 from pathlib import Path
-from queue import SimpleQueue
 from typing import IO
 
 from miles.rollout.session.session_types import SessionRecord
 
 logger = logging.getLogger(__name__)
 
-# Sentinel object to signal the writer thread to shut down.
-_SHUTDOWN = object()
-
 
 class RecordLogger:
-    """Writes ``SessionRecord`` objects as one-JSON-per-line to per-session files.
-
-    All disk I/O runs on a single background daemon thread, making
-    :meth:`log_record` and :meth:`close_session` non-blocking.
-    """
+    """Writes ``SessionRecord`` objects as one-JSON-per-line to per-session files."""
 
     def __init__(self, log_dir: str):
         self.log_dir = Path(log_dir)
         self.log_dir.mkdir(parents=True, exist_ok=True)
-        self._queue: SimpleQueue = SimpleQueue()
-        self._thread = threading.Thread(target=self._writer_loop, daemon=True, name="record-logger")
-        self._thread.start()
+        self._handles: dict[str, IO[str]] = {}
         logger.info("[record-logger] Logging session records to %s", self.log_dir)
 
-    # -- public (non-blocking) API ------------------------------------------
-
     def log_record(self, session_id: str, record: SessionRecord) -> None:
-        """Enqueue a record to be written. Returns immediately."""
-        self._queue.put(("write", session_id, record))
+        handle = self._handles.get(session_id)
+        if handle is None:
+            path = self.log_dir / f"{session_id}.jsonl"
+            handle = open(path, "a", encoding="utf-8")
+            self._handles[session_id] = handle
+        handle.write(json.dumps(record.model_dump(), default=str) + "\n")
+        handle.flush()
 
     def close_session(self, session_id: str) -> None:
-        """Enqueue a session-close event (flushes and closes the file handle)."""
-        self._queue.put(("close", session_id, None))
+        handle = self._handles.pop(session_id, None)
+        if handle is not None:
+            handle.close()
 
     def close_all(self) -> None:
-        """Shut down the writer thread and close every open file handle.
-
-        Blocks until the background thread has drained the queue and exited.
-        """
-        self._queue.put(_SHUTDOWN)
-        self._thread.join()
-
-    # -- background writer --------------------------------------------------
-
-    def _writer_loop(self) -> None:
-        handles: dict[str, IO[str]] = {}
-        try:
-            while True:
-                item = self._queue.get()
-                if item is _SHUTDOWN:
-                    break
-                action, session_id, record = item
-                if action == "write":
-                    self._do_write(handles, session_id, record)
-                elif action == "close":
-                    self._do_close(handles, session_id)
-        finally:
-            # Drain any remaining items before shutting down.
-            while not self._queue.empty():
-                item = self._queue.get()
-                if item is _SHUTDOWN:
-                    continue
-                action, session_id, record = item
-                if action == "write":
-                    self._do_write(handles, session_id, record)
-                elif action == "close":
-                    self._do_close(handles, session_id)
-            # Close all remaining file handles.
-            for sid in list(handles):
-                self._do_close(handles, sid)
-
-    def _do_write(self, handles: dict[str, IO[str]], session_id: str, record: SessionRecord) -> None:
-        try:
-            handle = handles.get(session_id)
-            if handle is None:
-                path = self.log_dir / f"{session_id}.jsonl"
-                handle = open(path, "a", encoding="utf-8")
-                handles[session_id] = handle
-            handle.write(json.dumps(record.model_dump(), default=str) + "\n")
-            handle.flush()
-        except Exception:
-            logger.exception("[record-logger] Failed to write record for session %s", session_id)
-
-    def _do_close(self, handles: dict[str, IO[str]], session_id: str) -> None:
-        handle = handles.pop(session_id, None)
-        if handle is not None:
-            try:
-                handle.close()
-            except Exception:
-                logger.exception("[record-logger] Failed to close log for session %s", session_id)
+        for handle in self._handles.values():
+            handle.close()
+        self._handles.clear()

--- a/miles/rollout/session/record_logger.py
+++ b/miles/rollout/session/record_logger.py
@@ -1,0 +1,53 @@
+"""Disk-based JSONL logger for session records.
+
+Each session gets its own file: ``<log_dir>/<session_id>.jsonl``.
+Records are flushed immediately so that partial sessions are preserved
+if the process crashes.
+"""
+
+import json
+import logging
+from pathlib import Path
+from typing import IO
+
+from miles.rollout.session.session_types import SessionRecord
+
+logger = logging.getLogger(__name__)
+
+
+class RecordLogger:
+    """Writes ``SessionRecord`` objects as one-JSON-per-line to per-session files."""
+
+    def __init__(self, log_dir: str):
+        self.log_dir = Path(log_dir)
+        self.log_dir.mkdir(parents=True, exist_ok=True)
+        self._handles: dict[str, IO[str]] = {}
+        logger.info("[record-logger] Logging session records to %s", self.log_dir)
+
+    def _get_handle(self, session_id: str) -> IO[str]:
+        handle = self._handles.get(session_id)
+        if handle is None:
+            path = self.log_dir / f"{session_id}.jsonl"
+            handle = open(path, "a", encoding="utf-8")
+            self._handles[session_id] = handle
+        return handle
+
+    def log_record(self, session_id: str, record: SessionRecord) -> None:
+        try:
+            handle = self._get_handle(session_id)
+            handle.write(json.dumps(record.model_dump(), default=str) + "\n")
+            handle.flush()
+        except Exception:
+            logger.exception("[record-logger] Failed to write record for session %s", session_id)
+
+    def close_session(self, session_id: str) -> None:
+        handle = self._handles.pop(session_id, None)
+        if handle is not None:
+            try:
+                handle.close()
+            except Exception:
+                logger.exception("[record-logger] Failed to close log for session %s", session_id)
+
+    def close_all(self) -> None:
+        for session_id in list(self._handles):
+            self.close_session(session_id)

--- a/miles/rollout/session/sessions.py
+++ b/miles/rollout/session/sessions.py
@@ -240,6 +240,7 @@ def setup_session_routes(app, backend, args):
                     response=response,
                 )
                 session.append_record(record)
+                registry.log_record(session_id, record)
             # --- lock released here ---
 
             return backend.build_proxy_response(result)

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -1605,6 +1605,13 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 help="Port of the standalone session server. Auto-allocated if not set.",
             )
             parser.add_argument(
+                "--session-record-log-dir",
+                type=str,
+                default=None,
+                help="Directory to write session records as JSONL files (one file per session). "
+                "Disabled when not set.",
+            )
+            parser.add_argument(
                 "--tito-model",
                 type=str,
                 default="default",

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -1605,13 +1605,6 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 help="Port of the standalone session server. Auto-allocated if not set.",
             )
             parser.add_argument(
-                "--session-record-log-dir",
-                type=str,
-                default=None,
-                help="Directory to write session records as JSONL files (one file per session). "
-                "Disabled when not set.",
-            )
-            parser.add_argument(
                 "--tito-model",
                 type=str,
                 default="default",
@@ -1932,6 +1925,7 @@ def miles_validate_args(args):
     if args.dump_details is not None:
         args.save_debug_rollout_data = f"{args.dump_details}/rollout_data/{{rollout_id}}.pt"
         args.save_debug_train_data = f"{args.dump_details}/train_data/{{rollout_id}}_{{rank}}.pt"
+        args.session_record_log_dir = f"{args.dump_details}/session_records"
 
     if args.load_debug_rollout_data is not None:
         logger.info(

--- a/tests/fast/router/test_record_logger.py
+++ b/tests/fast/router/test_record_logger.py
@@ -1,0 +1,347 @@
+"""Comprehensive parameterized tests for RecordLogger.
+
+Tests cover: single-session writes, concurrent multi-session writes,
+ordering guarantees, close-then-reopen, drain-on-close, exception
+resilience, no-op close of non-existent sessions, and mixed concurrent
+lifecycle operations.
+"""
+
+from __future__ import annotations
+
+import json
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from miles.rollout.session.record_logger import RecordLogger
+from miles.rollout.session.session_types import SessionRecord
+
+
+# ---------------------------------------------------------------------------
+# Helpers (module-level, self-contained)
+# ---------------------------------------------------------------------------
+
+
+def _make_record(index: int, session_tag: str = "default") -> SessionRecord:
+    """Deterministic factory for SessionRecord."""
+    return SessionRecord(
+        timestamp=1000.0 + index,
+        method="POST",
+        path=f"/api/{session_tag}/{index}",
+        request={"index": index, "session_tag": session_tag},
+        response={"ok": True, "index": index},
+        status_code=200,
+    )
+
+
+def _read_jsonl(path: Path) -> list[dict]:
+    """Read a .jsonl file and return a list of parsed dicts."""
+    lines = path.read_text(encoding="utf-8").splitlines()
+    return [json.loads(line) for line in lines if line.strip()]
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestSingleSessionWriteReadback:
+    @pytest.mark.parametrize(
+        "record_count",
+        [
+            pytest.param(1, id="1-record"),
+            pytest.param(10, id="10-records"),
+            pytest.param(100, id="100-records"),
+            pytest.param(500, id="500-records"),
+        ],
+    )
+    def test_single_session_write_readback(self, tmp_path: Path, record_count: int):
+        log_dir = str(tmp_path / "logs")
+        rl = RecordLogger(log_dir)
+        try:
+            for i in range(record_count):
+                rl.log_record("sess-0", _make_record(i, session_tag="sess-0"))
+        finally:
+            rl.close_all()
+
+        jsonl_files = list(Path(log_dir).glob("*.jsonl"))
+        assert len(jsonl_files) == 1, f"Expected 1 .jsonl file, got {len(jsonl_files)}"
+
+        records = _read_jsonl(jsonl_files[0])
+        assert len(records) == record_count
+
+        for i, rec in enumerate(records):
+            assert rec["timestamp"] == 1000.0 + i
+            assert rec["path"] == f"/api/sess-0/{i}"
+            assert rec["request"]["index"] == i
+            assert rec["status_code"] == 200
+
+        # Timestamps strictly increasing
+        timestamps = [r["timestamp"] for r in records]
+        assert timestamps == sorted(timestamps)
+        assert len(set(timestamps)) == len(timestamps)
+
+
+class TestConcurrentMultiSession:
+    @pytest.mark.parametrize(
+        "num_sessions, records_per_session",
+        [
+            pytest.param(2, 5, id="2-sessions-5-records"),
+            pytest.param(5, 20, id="5-sessions-20-records"),
+            pytest.param(10, 50, id="10-sessions-50-records"),
+            pytest.param(20, 100, id="20-sessions-100-records"),
+        ],
+    )
+    def test_concurrent_multi_session(self, tmp_path: Path, num_sessions: int, records_per_session: int):
+        log_dir = str(tmp_path / "logs")
+        rl = RecordLogger(log_dir)
+        try:
+
+            def _worker(session_idx: int) -> None:
+                tag = f"session-{session_idx}"
+                for i in range(records_per_session):
+                    rl.log_record(tag, _make_record(i, session_tag=tag))
+
+            max_workers = min(num_sessions, 8)
+            with ThreadPoolExecutor(max_workers=max_workers) as pool:
+                futures = [pool.submit(_worker, idx) for idx in range(num_sessions)]
+                for fut in as_completed(futures):
+                    fut.result()  # raise if worker failed
+        finally:
+            rl.close_all()
+
+        jsonl_files = list(Path(log_dir).glob("*.jsonl"))
+        assert len(jsonl_files) == num_sessions
+
+        for session_idx in range(num_sessions):
+            tag = f"session-{session_idx}"
+            fpath = Path(log_dir) / f"{tag}.jsonl"
+            assert fpath.exists(), f"Missing file for {tag}"
+
+            records = _read_jsonl(fpath)
+            assert len(records) == records_per_session
+
+            # No cross-session contamination
+            for rec in records:
+                assert rec["request"]["session_tag"] == tag
+
+
+class TestOrderingGuarantee:
+    @pytest.mark.parametrize(
+        "record_count",
+        [
+            pytest.param(50, id="50-records"),
+            pytest.param(200, id="200-records"),
+        ],
+    )
+    def test_ordering_guarantee(self, tmp_path: Path, record_count: int):
+        log_dir = str(tmp_path / "logs")
+        rl = RecordLogger(log_dir)
+        try:
+            for i in range(record_count):
+                rl.log_record("ordered", _make_record(i))
+        finally:
+            rl.close_all()
+
+        records = _read_jsonl(Path(log_dir) / "ordered.jsonl")
+        assert len(records) == record_count
+
+        timestamps = [r["timestamp"] for r in records]
+        expected = [1000.0 + i for i in range(record_count)]
+        assert timestamps == expected
+
+
+class TestCloseSessionThenReopen:
+    @pytest.mark.parametrize(
+        "records_before, records_after",
+        [
+            pytest.param(3, 2, id="3-before-2-after"),
+            pytest.param(10, 10, id="10-before-10-after"),
+            pytest.param(1, 1, id="1-before-1-after"),
+        ],
+    )
+    def test_close_session_then_reopen(self, tmp_path: Path, records_before: int, records_after: int):
+        log_dir = str(tmp_path / "logs")
+        rl = RecordLogger(log_dir)
+        try:
+            for i in range(records_before):
+                rl.log_record("reopen", _make_record(i))
+
+            rl.close_session("reopen")
+
+            for i in range(records_before, records_before + records_after):
+                rl.log_record("reopen", _make_record(i))
+        finally:
+            rl.close_all()
+
+        records = _read_jsonl(Path(log_dir) / "reopen.jsonl")
+        total = records_before + records_after
+        assert len(records) == total
+
+        timestamps = [r["timestamp"] for r in records]
+        expected = [1000.0 + i for i in range(total)]
+        assert timestamps == expected
+
+
+class TestCloseAllDrainsPending:
+    @pytest.mark.parametrize(
+        "flood_count",
+        [
+            pytest.param(100, id="100-flood"),
+            pytest.param(500, id="500-flood"),
+            pytest.param(1000, id="1000-flood"),
+        ],
+    )
+    def test_close_all_drains_pending(self, tmp_path: Path, flood_count: int):
+        log_dir = str(tmp_path / "logs")
+        rl = RecordLogger(log_dir)
+        try:
+            for i in range(flood_count):
+                rl.log_record("flood", _make_record(i))
+        finally:
+            rl.close_all()
+
+        records = _read_jsonl(Path(log_dir) / "flood.jsonl")
+        assert len(records) == flood_count
+
+        timestamps = [r["timestamp"] for r in records]
+        expected = [1000.0 + i for i in range(flood_count)]
+        assert timestamps == expected
+
+
+class TestExceptionResilience:
+    @pytest.mark.parametrize(
+        "num_healthy, records_per",
+        [
+            pytest.param(1, 5, id="1-healthy-5-records"),
+            pytest.param(3, 10, id="3-healthy-10-records"),
+        ],
+    )
+    def test_exception_resilience(self, tmp_path: Path, num_healthy: int, records_per: int):
+        log_dir = str(tmp_path / "logs")
+
+        _real_open = open
+
+        def _patched_open(path, *args, **kwargs):
+            if "bad-sess" in str(path):
+                raise OSError("Simulated disk failure")
+            return _real_open(path, *args, **kwargs)
+
+        rl = RecordLogger(log_dir)
+        try:
+            with patch("builtins.open", side_effect=_patched_open):
+                # Write to bad session
+                for i in range(records_per):
+                    rl.log_record("bad-sess", _make_record(i, session_tag="bad-sess"))
+
+                # Write to healthy sessions
+                for h in range(num_healthy):
+                    tag = f"healthy-{h}"
+                    for i in range(records_per):
+                        rl.log_record(tag, _make_record(i, session_tag=tag))
+
+                # close_all() must happen inside the patch so that the
+                # background writer thread processes every queued item while
+                # builtins.open is still intercepted.
+                rl.close_all()
+        except Exception:
+            rl.close_all()
+            raise
+
+        # Bad session file should not exist
+        assert not (Path(log_dir) / "bad-sess.jsonl").exists()
+
+        # Healthy files should all be correct
+        for h in range(num_healthy):
+            tag = f"healthy-{h}"
+            fpath = Path(log_dir) / f"{tag}.jsonl"
+            assert fpath.exists(), f"Missing file for {tag}"
+            records = _read_jsonl(fpath)
+            assert len(records) == records_per
+            for rec in records:
+                assert rec["request"]["session_tag"] == tag
+
+
+class TestCloseNonexistentSessionNoop:
+    def test_close_nonexistent_session_noop(self, tmp_path: Path):
+        log_dir = str(tmp_path / "logs")
+        rl = RecordLogger(log_dir)
+        try:
+            rl.log_record("real", _make_record(0, session_tag="real"))
+            rl.log_record("real", _make_record(1, session_tag="real"))
+
+            # Closing a session that was never opened should be a no-op
+            rl.close_session("never-opened")
+
+            rl.log_record("real", _make_record(2, session_tag="real"))
+        finally:
+            rl.close_all()
+
+        assert not (Path(log_dir) / "never-opened.jsonl").exists()
+
+        records = _read_jsonl(Path(log_dir) / "real.jsonl")
+        assert len(records) == 3
+        timestamps = [r["timestamp"] for r in records]
+        assert timestamps == [1000.0, 1001.0, 1002.0]
+
+
+class TestMixedConcurrentLifecycle:
+    @pytest.mark.parametrize(
+        "num_sessions, records_per_session",
+        [
+            pytest.param(4, 10, id="4-sessions-10-records"),
+            pytest.param(8, 25, id="8-sessions-25-records"),
+        ],
+    )
+    def test_mixed_concurrent_lifecycle(self, tmp_path: Path, num_sessions: int, records_per_session: int):
+        log_dir = str(tmp_path / "logs")
+        rl = RecordLogger(log_dir)
+        half = records_per_session // 2
+        try:
+
+            def _worker(session_idx: int) -> None:
+                tag = f"mixed-{session_idx}"
+                # Write first half
+                for i in range(half):
+                    rl.log_record(tag, _make_record(i, session_tag=tag))
+
+                # Close session mid-way
+                rl.close_session(tag)
+
+                # Write second half (re-opens the file)
+                for i in range(half, records_per_session):
+                    rl.log_record(tag, _make_record(i, session_tag=tag))
+
+            max_workers = min(num_sessions, 8)
+            with ThreadPoolExecutor(max_workers=max_workers) as pool:
+                futures = [pool.submit(_worker, idx) for idx in range(num_sessions)]
+                for fut in as_completed(futures):
+                    fut.result()
+        finally:
+            rl.close_all()
+
+        for session_idx in range(num_sessions):
+            tag = f"mixed-{session_idx}"
+            fpath = Path(log_dir) / f"{tag}.jsonl"
+            assert fpath.exists(), f"Missing file for {tag}"
+
+            records = _read_jsonl(fpath)
+            assert len(records) == records_per_session
+
+            # First half should come before second half
+            first_half_timestamps = [r["timestamp"] for r in records[:half]]
+            second_half_timestamps = [r["timestamp"] for r in records[half:]]
+
+            # Each half should be in order
+            assert first_half_timestamps == sorted(first_half_timestamps)
+            assert second_half_timestamps == sorted(second_half_timestamps)
+
+            # All first-half timestamps should be < all second-half timestamps
+            if first_half_timestamps and second_half_timestamps:
+                assert max(first_half_timestamps) < min(second_half_timestamps)
+
+            # No cross-session contamination
+            for rec in records:
+                assert rec["request"]["session_tag"] == tag

--- a/tests/fast/router/test_record_logger.py
+++ b/tests/fast/router/test_record_logger.py
@@ -1,31 +1,16 @@
-"""Comprehensive parameterized tests for RecordLogger.
-
-Tests cover: single-session writes, concurrent multi-session writes,
-ordering guarantees, close-then-reopen, drain-on-close, exception
-resilience, no-op close of non-existent sessions, and mixed concurrent
-lifecycle operations.
-"""
+"""Tests for RecordLogger."""
 
 from __future__ import annotations
 
 import json
-from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
-from unittest.mock import patch
 
-import pytest
 
 from miles.rollout.session.record_logger import RecordLogger
 from miles.rollout.session.session_types import SessionRecord
 
 
-# ---------------------------------------------------------------------------
-# Helpers (module-level, self-contained)
-# ---------------------------------------------------------------------------
-
-
 def _make_record(index: int, session_tag: str = "default") -> SessionRecord:
-    """Deterministic factory for SessionRecord."""
     return SessionRecord(
         timestamp=1000.0 + index,
         method="POST",
@@ -37,311 +22,48 @@ def _make_record(index: int, session_tag: str = "default") -> SessionRecord:
 
 
 def _read_jsonl(path: Path) -> list[dict]:
-    """Read a .jsonl file and return a list of parsed dicts."""
     lines = path.read_text(encoding="utf-8").splitlines()
     return [json.loads(line) for line in lines if line.strip()]
 
 
-# ---------------------------------------------------------------------------
-# Tests
-# ---------------------------------------------------------------------------
+class TestRecordLogger:
+    def test_write_and_readback(self, tmp_path: Path):
+        rl = RecordLogger(str(tmp_path))
+        for i in range(5):
+            rl.log_record("s1", _make_record(i, "s1"))
+        rl.close_all()
 
+        records = _read_jsonl(tmp_path / "s1.jsonl")
+        assert len(records) == 5
+        assert [r["timestamp"] for r in records] == [1000.0 + i for i in range(5)]
 
-class TestSingleSessionWriteReadback:
-    @pytest.mark.parametrize(
-        "record_count",
-        [
-            pytest.param(1, id="1-record"),
-            pytest.param(10, id="10-records"),
-            pytest.param(100, id="100-records"),
-            pytest.param(500, id="500-records"),
-        ],
-    )
-    def test_single_session_write_readback(self, tmp_path: Path, record_count: int):
-        log_dir = str(tmp_path / "logs")
-        rl = RecordLogger(log_dir)
-        try:
-            for i in range(record_count):
-                rl.log_record("sess-0", _make_record(i, session_tag="sess-0"))
-        finally:
-            rl.close_all()
+    def test_multiple_sessions(self, tmp_path: Path):
+        rl = RecordLogger(str(tmp_path))
+        for i in range(3):
+            rl.log_record("a", _make_record(i, "a"))
+            rl.log_record("b", _make_record(i, "b"))
+        rl.close_all()
 
-        jsonl_files = list(Path(log_dir).glob("*.jsonl"))
-        assert len(jsonl_files) == 1, f"Expected 1 .jsonl file, got {len(jsonl_files)}"
+        assert len(_read_jsonl(tmp_path / "a.jsonl")) == 3
+        assert len(_read_jsonl(tmp_path / "b.jsonl")) == 3
 
-        records = _read_jsonl(jsonl_files[0])
-        assert len(records) == record_count
+    def test_close_session_then_reopen(self, tmp_path: Path):
+        rl = RecordLogger(str(tmp_path))
+        rl.log_record("s", _make_record(0))
+        rl.close_session("s")
+        rl.log_record("s", _make_record(1))
+        rl.close_all()
 
-        for i, rec in enumerate(records):
-            assert rec["timestamp"] == 1000.0 + i
-            assert rec["path"] == f"/api/sess-0/{i}"
-            assert rec["request"]["index"] == i
-            assert rec["status_code"] == 200
+        records = _read_jsonl(tmp_path / "s.jsonl")
+        assert len(records) == 2
 
-        # Timestamps strictly increasing
-        timestamps = [r["timestamp"] for r in records]
-        assert timestamps == sorted(timestamps)
-        assert len(set(timestamps)) == len(timestamps)
+    def test_close_nonexistent_session_is_noop(self, tmp_path: Path):
+        rl = RecordLogger(str(tmp_path))
+        rl.close_session("nonexistent")  # should not raise
+        rl.close_all()
 
-
-class TestConcurrentMultiSession:
-    @pytest.mark.parametrize(
-        "num_sessions, records_per_session",
-        [
-            pytest.param(2, 5, id="2-sessions-5-records"),
-            pytest.param(5, 20, id="5-sessions-20-records"),
-            pytest.param(10, 50, id="10-sessions-50-records"),
-            pytest.param(20, 100, id="20-sessions-100-records"),
-        ],
-    )
-    def test_concurrent_multi_session(self, tmp_path: Path, num_sessions: int, records_per_session: int):
-        log_dir = str(tmp_path / "logs")
-        rl = RecordLogger(log_dir)
-        try:
-
-            def _worker(session_idx: int) -> None:
-                tag = f"session-{session_idx}"
-                for i in range(records_per_session):
-                    rl.log_record(tag, _make_record(i, session_tag=tag))
-
-            max_workers = min(num_sessions, 8)
-            with ThreadPoolExecutor(max_workers=max_workers) as pool:
-                futures = [pool.submit(_worker, idx) for idx in range(num_sessions)]
-                for fut in as_completed(futures):
-                    fut.result()  # raise if worker failed
-        finally:
-            rl.close_all()
-
-        jsonl_files = list(Path(log_dir).glob("*.jsonl"))
-        assert len(jsonl_files) == num_sessions
-
-        for session_idx in range(num_sessions):
-            tag = f"session-{session_idx}"
-            fpath = Path(log_dir) / f"{tag}.jsonl"
-            assert fpath.exists(), f"Missing file for {tag}"
-
-            records = _read_jsonl(fpath)
-            assert len(records) == records_per_session
-
-            # No cross-session contamination
-            for rec in records:
-                assert rec["request"]["session_tag"] == tag
-
-
-class TestOrderingGuarantee:
-    @pytest.mark.parametrize(
-        "record_count",
-        [
-            pytest.param(50, id="50-records"),
-            pytest.param(200, id="200-records"),
-        ],
-    )
-    def test_ordering_guarantee(self, tmp_path: Path, record_count: int):
-        log_dir = str(tmp_path / "logs")
-        rl = RecordLogger(log_dir)
-        try:
-            for i in range(record_count):
-                rl.log_record("ordered", _make_record(i))
-        finally:
-            rl.close_all()
-
-        records = _read_jsonl(Path(log_dir) / "ordered.jsonl")
-        assert len(records) == record_count
-
-        timestamps = [r["timestamp"] for r in records]
-        expected = [1000.0 + i for i in range(record_count)]
-        assert timestamps == expected
-
-
-class TestCloseSessionThenReopen:
-    @pytest.mark.parametrize(
-        "records_before, records_after",
-        [
-            pytest.param(3, 2, id="3-before-2-after"),
-            pytest.param(10, 10, id="10-before-10-after"),
-            pytest.param(1, 1, id="1-before-1-after"),
-        ],
-    )
-    def test_close_session_then_reopen(self, tmp_path: Path, records_before: int, records_after: int):
-        log_dir = str(tmp_path / "logs")
-        rl = RecordLogger(log_dir)
-        try:
-            for i in range(records_before):
-                rl.log_record("reopen", _make_record(i))
-
-            rl.close_session("reopen")
-
-            for i in range(records_before, records_before + records_after):
-                rl.log_record("reopen", _make_record(i))
-        finally:
-            rl.close_all()
-
-        records = _read_jsonl(Path(log_dir) / "reopen.jsonl")
-        total = records_before + records_after
-        assert len(records) == total
-
-        timestamps = [r["timestamp"] for r in records]
-        expected = [1000.0 + i for i in range(total)]
-        assert timestamps == expected
-
-
-class TestCloseAllDrainsPending:
-    @pytest.mark.parametrize(
-        "flood_count",
-        [
-            pytest.param(100, id="100-flood"),
-            pytest.param(500, id="500-flood"),
-            pytest.param(1000, id="1000-flood"),
-        ],
-    )
-    def test_close_all_drains_pending(self, tmp_path: Path, flood_count: int):
-        log_dir = str(tmp_path / "logs")
-        rl = RecordLogger(log_dir)
-        try:
-            for i in range(flood_count):
-                rl.log_record("flood", _make_record(i))
-        finally:
-            rl.close_all()
-
-        records = _read_jsonl(Path(log_dir) / "flood.jsonl")
-        assert len(records) == flood_count
-
-        timestamps = [r["timestamp"] for r in records]
-        expected = [1000.0 + i for i in range(flood_count)]
-        assert timestamps == expected
-
-
-class TestExceptionResilience:
-    @pytest.mark.parametrize(
-        "num_healthy, records_per",
-        [
-            pytest.param(1, 5, id="1-healthy-5-records"),
-            pytest.param(3, 10, id="3-healthy-10-records"),
-        ],
-    )
-    def test_exception_resilience(self, tmp_path: Path, num_healthy: int, records_per: int):
-        log_dir = str(tmp_path / "logs")
-
-        _real_open = open
-
-        def _patched_open(path, *args, **kwargs):
-            if "bad-sess" in str(path):
-                raise OSError("Simulated disk failure")
-            return _real_open(path, *args, **kwargs)
-
-        rl = RecordLogger(log_dir)
-        try:
-            with patch("builtins.open", side_effect=_patched_open):
-                # Write to bad session
-                for i in range(records_per):
-                    rl.log_record("bad-sess", _make_record(i, session_tag="bad-sess"))
-
-                # Write to healthy sessions
-                for h in range(num_healthy):
-                    tag = f"healthy-{h}"
-                    for i in range(records_per):
-                        rl.log_record(tag, _make_record(i, session_tag=tag))
-
-                # close_all() must happen inside the patch so that the
-                # background writer thread processes every queued item while
-                # builtins.open is still intercepted.
-                rl.close_all()
-        except Exception:
-            rl.close_all()
-            raise
-
-        # Bad session file should not exist
-        assert not (Path(log_dir) / "bad-sess.jsonl").exists()
-
-        # Healthy files should all be correct
-        for h in range(num_healthy):
-            tag = f"healthy-{h}"
-            fpath = Path(log_dir) / f"{tag}.jsonl"
-            assert fpath.exists(), f"Missing file for {tag}"
-            records = _read_jsonl(fpath)
-            assert len(records) == records_per
-            for rec in records:
-                assert rec["request"]["session_tag"] == tag
-
-
-class TestCloseNonexistentSessionNoop:
-    def test_close_nonexistent_session_noop(self, tmp_path: Path):
-        log_dir = str(tmp_path / "logs")
-        rl = RecordLogger(log_dir)
-        try:
-            rl.log_record("real", _make_record(0, session_tag="real"))
-            rl.log_record("real", _make_record(1, session_tag="real"))
-
-            # Closing a session that was never opened should be a no-op
-            rl.close_session("never-opened")
-
-            rl.log_record("real", _make_record(2, session_tag="real"))
-        finally:
-            rl.close_all()
-
-        assert not (Path(log_dir) / "never-opened.jsonl").exists()
-
-        records = _read_jsonl(Path(log_dir) / "real.jsonl")
-        assert len(records) == 3
-        timestamps = [r["timestamp"] for r in records]
-        assert timestamps == [1000.0, 1001.0, 1002.0]
-
-
-class TestMixedConcurrentLifecycle:
-    @pytest.mark.parametrize(
-        "num_sessions, records_per_session",
-        [
-            pytest.param(4, 10, id="4-sessions-10-records"),
-            pytest.param(8, 25, id="8-sessions-25-records"),
-        ],
-    )
-    def test_mixed_concurrent_lifecycle(self, tmp_path: Path, num_sessions: int, records_per_session: int):
-        log_dir = str(tmp_path / "logs")
-        rl = RecordLogger(log_dir)
-        half = records_per_session // 2
-        try:
-
-            def _worker(session_idx: int) -> None:
-                tag = f"mixed-{session_idx}"
-                # Write first half
-                for i in range(half):
-                    rl.log_record(tag, _make_record(i, session_tag=tag))
-
-                # Close session mid-way
-                rl.close_session(tag)
-
-                # Write second half (re-opens the file)
-                for i in range(half, records_per_session):
-                    rl.log_record(tag, _make_record(i, session_tag=tag))
-
-            max_workers = min(num_sessions, 8)
-            with ThreadPoolExecutor(max_workers=max_workers) as pool:
-                futures = [pool.submit(_worker, idx) for idx in range(num_sessions)]
-                for fut in as_completed(futures):
-                    fut.result()
-        finally:
-            rl.close_all()
-
-        for session_idx in range(num_sessions):
-            tag = f"mixed-{session_idx}"
-            fpath = Path(log_dir) / f"{tag}.jsonl"
-            assert fpath.exists(), f"Missing file for {tag}"
-
-            records = _read_jsonl(fpath)
-            assert len(records) == records_per_session
-
-            # First half should come before second half
-            first_half_timestamps = [r["timestamp"] for r in records[:half]]
-            second_half_timestamps = [r["timestamp"] for r in records[half:]]
-
-            # Each half should be in order
-            assert first_half_timestamps == sorted(first_half_timestamps)
-            assert second_half_timestamps == sorted(second_half_timestamps)
-
-            # All first-half timestamps should be < all second-half timestamps
-            if first_half_timestamps and second_half_timestamps:
-                assert max(first_half_timestamps) < min(second_half_timestamps)
-
-            # No cross-session contamination
-            for rec in records:
-                assert rec["request"]["session_tag"] == tag
+    def test_close_all_clears_handles(self, tmp_path: Path):
+        rl = RecordLogger(str(tmp_path))
+        rl.log_record("s", _make_record(0))
+        rl.close_all()
+        assert len(rl._handles) == 0


### PR DESCRIPTION
## Summary
- Add `RecordLogger` class that writes `SessionRecord` objects as one-JSON-per-line to per-session files under `--session-record-log-dir`
- Records are flushed immediately so partial sessions survive crashes
- Integrate into `SessionRegistry`: records are written on each chat completion and file handles are closed when sessions are deleted
- Add `--session-record-log-dir` CLI argument (disabled when not set)

## Test plan
- [ ] Verify session records are written to disk when `--session-record-log-dir` is set
- [ ] Verify no logging occurs when the flag is not set
- [ ] Verify file handles are properly closed on session deletion

Made with [Cursor](https://cursor.com)