### PR TITLE
[Miles] Update P2P RDMA weight sync with flashinfer compatibility and NIC affinity

### DIFF
--- a/examples/p2p_weight_transfer/test_qwen3_235b_a22b_p2p.py
+++ b/examples/p2p_weight_transfer/test_qwen3_235b_a22b_p2p.py
@@ -1,0 +1,133 @@
+"""P2P weight transfer test for Qwen3-235B-A22B across 16 nodes (128 GPUs).
+
+Uses the author's tested config from scripts/run-qwen3-235B-A22B.sh:
+  Trainer: 64 GPUs (8 nodes), TP=4, PP=4, CP=2, EP=16
+  Sampler: 64 GPUs (8 nodes), 2 engines × 32 GPUs, TP=32, EP=32, DP=4
+"""
+
+import os
+import miles.utils.external_utils.command_utils as U
+
+MODEL_NAME = "Qwen3-235B-A22B"
+MODEL_TYPE = "qwen3-235B-A22B"
+NUM_GPUS_PER_NODE = 8
+
+# Model paths on shared Weka storage (/data/)
+HF_CHECKPOINT = os.environ.get("HF_CHECKPOINT", "/data/models/Qwen3-235B-A22B")
+TORCH_DIST_CHECKPOINT = os.environ.get("TORCH_DIST_CHECKPOINT", "/data/models/Qwen3-235B-A22B_torch_dist")
+PROMPT_DATA = os.environ.get("PROMPT_DATA", "/data/dapo-math-17k/dapo-math-17k.jsonl")
+
+# Trainer: 8 nodes × 8 GPUs = 64 GPUs
+ACTOR_NUM_NODES = 8
+ACTOR_NUM_GPUS_PER_NODE = 8
+
+# Sampler: 2 engines × 32 GPUs = 64 GPUs
+ROLLOUT_NUM_GPUS_PER_ENGINE = 32
+ROLLOUT_NUM_GPUS = 64
+
+
+def execute():
+    ckpt_args = f"--hf-checkpoint {HF_CHECKPOINT} " f"--ref-load {TORCH_DIST_CHECKPOINT} "
+
+    rollout_args = (
+        f"--prompt-data {PROMPT_DATA} "
+        "--input-key prompt "
+        "--label-key label "
+        "--apply-chat-template "
+        "--rollout-shuffle "
+        "--rm-type deepscaler "
+        "--num-rollout 3 "
+        "--rollout-batch-size 8 "
+        "--n-samples-per-prompt 8 "
+        "--rollout-max-response-len 100 "
+        "--rollout-temperature 1 "
+        "--global-batch-size 64 "
+        "--balance-data "
+    )
+
+    perf_args = (
+        "--tensor-model-parallel-size 4 "
+        "--sequence-parallel "
+        "--pipeline-model-parallel-size 4 "
+        "--context-parallel-size 2 "
+        "--expert-model-parallel-size 16 "
+        "--expert-tensor-parallel-size 1 "
+        "--decoder-last-pipeline-num-layers 22 "
+        "--recompute-granularity full "
+        "--recompute-method uniform "
+        "--recompute-num-layers 1 "
+        "--use-dynamic-batch-size "
+        "--max-tokens-per-gpu 16384 "
+    )
+
+    grpo_args = (
+        "--advantage-estimator gspo "
+        "--kl-loss-coef 0.00 "
+        "--kl-loss-type low_var_kl "
+        "--entropy-coef 0.00 "
+        "--eps-clip 4e-4 "
+    )
+
+    optimizer_args = (
+        "--optimizer adam "
+        "--lr 1e-6 "
+        "--lr-decay-style constant "
+        "--weight-decay 0.1 "
+        "--adam-beta1 0.9 "
+        "--adam-beta2 0.98 "
+        "--optimizer-cpu-offload "
+        "--overlap-cpu-optimizer-d2h-h2d "
+        "--use-precision-aware-optimizer "
+    )
+
+    # Per-GPU RDMA NIC mapping for B200 nodes (GPU index -> PIX-affine mlx5 device)
+    ib_device_json = (
+        '{"0":"mlx5_1","1":"mlx5_5","2":"mlx5_2","3":"mlx5_0","4":"mlx5_11","5":"mlx5_15","6":"mlx5_14","7":"mlx5_6"}'
+    )
+
+    sglang_args = (
+        f"--rollout-num-gpus-per-engine {ROLLOUT_NUM_GPUS_PER_ENGINE} "
+        f"--rollout-num-gpus {ROLLOUT_NUM_GPUS} "
+        "--sglang-mem-fraction-static 0.7 "
+        "--sglang-enable-dp-attention "
+        "--sglang-dp-size 4 "
+        "--sglang-ep-size 32 "
+        "--sglang-enable-dp-lm-head "
+        "--sglang-remote-instance-weight-loader-start-seed-via-transfer-engine "
+        f"--update-weight-p2p-ib-device '{ib_device_json}' "
+    )
+
+    misc_args = (
+        "--attention-dropout 0.0 "
+        "--hidden-dropout 0.0 "
+        "--accumulate-allreduce-grads-in-fp32 "
+        "--attention-softmax-in-fp32 "
+        "--attention-backend flash "
+        f"--actor-num-nodes {ACTOR_NUM_NODES} "
+        f"--actor-num-gpus-per-node {ACTOR_NUM_GPUS_PER_NODE} "
+        f"--update-weight-buffer-size {4 * 1024 ** 3} "
+        "--update-weight-transfer-mode p2p "
+        "--check-weight-update-equal "
+    )
+
+    train_args = (
+        f"{ckpt_args} "
+        f"{rollout_args} "
+        f"{optimizer_args} "
+        f"{grpo_args} "
+        f"{U.get_default_wandb_args(__file__)} "
+        f"{perf_args} "
+        f"{sglang_args} "
+        f"{misc_args} "
+    )
+
+    U.execute_train(
+        train_args=train_args,
+        num_gpus_per_node=NUM_GPUS_PER_NODE,
+        megatron_model_type=MODEL_TYPE,
+        train_script="train_async.py",
+    )
+
+
+if __name__ == "__main__":
+    execute()

--- a/examples/p2p_weight_transfer/test_qwen3_235b_a22b_p2p_bigrun.py
+++ b/examples/p2p_weight_transfer/test_qwen3_235b_a22b_p2p_bigrun.py
@@ -1,0 +1,131 @@
+"""P2P weight transfer test for Qwen3-235B-A22B across 16 nodes (128 GPUs).
+
+Uses the big-run config from docs/bigrun/parallelism-breakdown.md:
+  Trainer: 32 GPUs (4 nodes), TP=4, PP=4, CP=2, EP=8
+  Sampler: 96 GPUs (12 nodes), 12 engines × 8 GPUs, TP=8, EP=2, DP=2
+"""
+
+import os
+import miles.utils.external_utils.command_utils as U
+
+MODEL_NAME = "Qwen3-235B-A22B"
+MODEL_TYPE = "qwen3-235B-A22B"
+NUM_GPUS_PER_NODE = 8
+
+HF_CHECKPOINT = os.environ.get("HF_CHECKPOINT", "/data/models/Qwen3-235B-A22B")
+TORCH_DIST_CHECKPOINT = os.environ.get("TORCH_DIST_CHECKPOINT", "/data/models/Qwen3-235B-A22B_torch_dist")
+PROMPT_DATA = os.environ.get("PROMPT_DATA", "/data/dapo-math-17k/dapo-math-17k.jsonl")
+
+# Trainer: 4 nodes × 8 GPUs = 32 GPUs
+ACTOR_NUM_NODES = 4
+ACTOR_NUM_GPUS_PER_NODE = 8
+
+# Sampler: 12 engines × 8 GPUs = 96 GPUs
+ROLLOUT_NUM_GPUS_PER_ENGINE = 8
+ROLLOUT_NUM_GPUS = 96
+
+
+def execute():
+    ckpt_args = f"--hf-checkpoint {HF_CHECKPOINT} " f"--ref-load {TORCH_DIST_CHECKPOINT} "
+
+    rollout_args = (
+        f"--prompt-data {PROMPT_DATA} "
+        "--input-key prompt "
+        "--label-key label "
+        "--apply-chat-template "
+        "--rollout-shuffle "
+        "--rm-type deepscaler "
+        "--num-rollout 3 "
+        "--rollout-batch-size 8 "
+        "--n-samples-per-prompt 8 "
+        "--rollout-max-response-len 100 "
+        "--rollout-temperature 1 "
+        "--global-batch-size 64 "
+        "--balance-data "
+    )
+
+    perf_args = (
+        "--tensor-model-parallel-size 4 "
+        "--sequence-parallel "
+        "--pipeline-model-parallel-size 4 "
+        "--context-parallel-size 2 "
+        "--expert-model-parallel-size 8 "
+        "--expert-tensor-parallel-size 1 "
+        "--decoder-last-pipeline-num-layers 22 "
+        "--recompute-granularity full "
+        "--recompute-method uniform "
+        "--recompute-num-layers 1 "
+        "--use-dynamic-batch-size "
+        "--max-tokens-per-gpu 16384 "
+    )
+
+    grpo_args = (
+        "--advantage-estimator gspo "
+        "--kl-loss-coef 0.00 "
+        "--kl-loss-type low_var_kl "
+        "--entropy-coef 0.00 "
+        "--eps-clip 4e-4 "
+    )
+
+    optimizer_args = (
+        "--optimizer adam "
+        "--lr 1e-6 "
+        "--lr-decay-style constant "
+        "--weight-decay 0.1 "
+        "--adam-beta1 0.9 "
+        "--adam-beta2 0.98 "
+        "--optimizer-cpu-offload "
+        "--overlap-cpu-optimizer-d2h-h2d "
+        "--use-precision-aware-optimizer "
+    )
+
+    # Per-GPU RDMA NIC mapping for B200 nodes (GPU index -> PIX-affine mlx5 device)
+    ib_device_json = (
+        '{"0":"mlx5_1","1":"mlx5_5","2":"mlx5_2","3":"mlx5_0","4":"mlx5_11","5":"mlx5_15","6":"mlx5_14","7":"mlx5_6"}'
+    )
+
+    sglang_args = (
+        f"--rollout-num-gpus-per-engine {ROLLOUT_NUM_GPUS_PER_ENGINE} "
+        f"--rollout-num-gpus {ROLLOUT_NUM_GPUS} "
+        "--sglang-mem-fraction-static 0.7 "
+        "--sglang-enable-dp-attention "
+        "--sglang-dp-size 2 "
+        "--sglang-ep-size 2 "
+        "--sglang-remote-instance-weight-loader-start-seed-via-transfer-engine "
+        f"--update-weight-p2p-ib-device '{ib_device_json}' "
+    )
+
+    misc_args = (
+        "--attention-dropout 0.0 "
+        "--hidden-dropout 0.0 "
+        "--accumulate-allreduce-grads-in-fp32 "
+        "--attention-softmax-in-fp32 "
+        "--attention-backend flash "
+        f"--actor-num-nodes {ACTOR_NUM_NODES} "
+        f"--actor-num-gpus-per-node {ACTOR_NUM_GPUS_PER_NODE} "
+        f"--update-weight-buffer-size {4 * 1024 ** 3} "
+        "--update-weight-transfer-mode p2p "
+        "--check-weight-update-equal "
+    )
+
+    train_args = (
+        f"{ckpt_args} "
+        f"{rollout_args} "
+        f"{optimizer_args} "
+        f"{grpo_args} "
+        f"{U.get_default_wandb_args(__file__)} "
+        f"{perf_args} "
+        f"{sglang_args} "
+        f"{misc_args} "
+    )
+
+    U.execute_train(
+        train_args=train_args,
+        num_gpus_per_node=NUM_GPUS_PER_NODE,
+        megatron_model_type=MODEL_TYPE,
+        train_script="train_async.py",
+    )
+
+
+if __name__ == "__main__":
+    execute()

--- a/examples/p2p_weight_transfer/test_qwen3_30b_a3b_p2p.py
+++ b/examples/p2p_weight_transfer/test_qwen3_30b_a3b_p2p.py
@@ -1,0 +1,130 @@
+"""P2P weight transfer test for Qwen3-30B-A3B across 4 nodes (32 GPUs).
+
+Trainer: 16 GPUs (2 nodes), TP=4, PP=1, CP=1, EP=8, ETP=1
+Sampler: 16 GPUs (2 nodes), 2 engines × 8 GPUs, TP=8, EP=8
+
+Matches the author's tested config for Qwen3-MoE.
+"""
+
+import os
+import miles.utils.external_utils.command_utils as U
+
+MODEL_NAME = "Qwen3-30B-A3B"
+MODEL_TYPE = "qwen3-30B-A3B"
+NUM_GPUS_PER_NODE = 8
+
+HF_CHECKPOINT = os.environ.get("HF_CHECKPOINT", "/data/models/Qwen3-30B-A3B")
+TORCH_DIST_CHECKPOINT = os.environ.get("TORCH_DIST_CHECKPOINT", "/data/models/Qwen3-30B-A3B_torch_dist")
+PROMPT_DATA = os.environ.get("PROMPT_DATA", "/data/dapo-math-17k/dapo-math-17k.jsonl")
+
+# Trainer: 2 nodes × 8 GPUs = 16 GPUs
+ACTOR_NUM_NODES = 2
+ACTOR_NUM_GPUS_PER_NODE = 8
+
+# Sampler: 2 engines × 8 GPUs = 16 GPUs
+ROLLOUT_NUM_GPUS_PER_ENGINE = 8
+ROLLOUT_NUM_GPUS = 16
+
+
+def execute():
+    ckpt_args = f"--hf-checkpoint {HF_CHECKPOINT} " f"--ref-load {TORCH_DIST_CHECKPOINT} "
+
+    rollout_args = (
+        f"--prompt-data {PROMPT_DATA} "
+        "--input-key prompt "
+        "--label-key label "
+        "--apply-chat-template "
+        "--rollout-shuffle "
+        "--rm-type deepscaler "
+        "--num-rollout 3 "
+        "--rollout-batch-size 8 "
+        "--n-samples-per-prompt 8 "
+        "--rollout-max-response-len 100 "
+        "--rollout-temperature 1 "
+        "--global-batch-size 64 "
+        "--balance-data "
+    )
+
+    perf_args = (
+        "--tensor-model-parallel-size 4 "
+        "--sequence-parallel "
+        "--pipeline-model-parallel-size 1 "
+        "--context-parallel-size 1 "
+        "--expert-model-parallel-size 8 "
+        "--expert-tensor-parallel-size 1 "
+        "--recompute-granularity full "
+        "--recompute-method uniform "
+        "--recompute-num-layers 1 "
+        "--use-dynamic-batch-size "
+        "--max-tokens-per-gpu 20480 "
+    )
+
+    grpo_args = (
+        "--advantage-estimator grpo "
+        "--kl-loss-coef 0.00 "
+        "--kl-loss-type low_var_kl "
+        "--entropy-coef 0.00 "
+        "--eps-clip 0.2 "
+        "--eps-clip-high 0.28 "
+    )
+
+    optimizer_args = (
+        "--optimizer adam "
+        "--lr 1e-6 "
+        "--lr-decay-style constant "
+        "--weight-decay 0.1 "
+        "--adam-beta1 0.9 "
+        "--adam-beta2 0.98 "
+        "--optimizer-cpu-offload "
+        "--overlap-cpu-optimizer-d2h-h2d "
+        "--use-precision-aware-optimizer "
+    )
+
+    # Per-GPU RDMA NIC mapping for B200 nodes (GPU index -> PIX-affine mlx5 device)
+    ib_device_json = (
+        '{"0":"mlx5_1","1":"mlx5_5","2":"mlx5_2","3":"mlx5_0","4":"mlx5_11","5":"mlx5_15","6":"mlx5_14","7":"mlx5_6"}'
+    )
+
+    sglang_args = (
+        f"--rollout-num-gpus-per-engine {ROLLOUT_NUM_GPUS_PER_ENGINE} "
+        f"--rollout-num-gpus {ROLLOUT_NUM_GPUS} "
+        "--sglang-mem-fraction-static 0.7 "
+        "--sglang-ep-size 8 "
+        "--sglang-remote-instance-weight-loader-start-seed-via-transfer-engine "
+        f"--update-weight-p2p-ib-device '{ib_device_json}' "
+    )
+
+    misc_args = (
+        "--attention-dropout 0.0 "
+        "--hidden-dropout 0.0 "
+        "--accumulate-allreduce-grads-in-fp32 "
+        "--attention-softmax-in-fp32 "
+        "--attention-backend flash "
+        f"--actor-num-nodes {ACTOR_NUM_NODES} "
+        f"--actor-num-gpus-per-node {ACTOR_NUM_GPUS_PER_NODE} "
+        f"--update-weight-buffer-size {2 * 1024 ** 3} "
+        "--update-weight-transfer-mode p2p "
+        "--check-weight-update-equal "
+    )
+
+    train_args = (
+        f"{ckpt_args} "
+        f"{rollout_args} "
+        f"{optimizer_args} "
+        f"{grpo_args} "
+        f"{U.get_default_wandb_args(__file__)} "
+        f"{perf_args} "
+        f"{sglang_args} "
+        f"{misc_args} "
+    )
+
+    U.execute_train(
+        train_args=train_args,
+        num_gpus_per_node=NUM_GPUS_PER_NODE,
+        megatron_model_type=MODEL_TYPE,
+        train_script="train_async.py",
+    )
+
+
+if __name__ == "__main__":
+    execute()

--- a/examples/p2p_weight_transfer/test_qwen3_30b_a3b_p2p_2node.py
+++ b/examples/p2p_weight_transfer/test_qwen3_30b_a3b_p2p_2node.py
@@ -1,0 +1,128 @@
+"""P2P weight transfer test for Qwen3-30B-A3B across 2 nodes (16 GPUs).
+
+Trainer: 8 GPUs (1 node), TP=4, PP=1, EP=8, ETP=1
+Sampler: 8 GPUs (1 node), 1 engine × 8 GPUs, TP=8, EP=8
+
+Matches the author's tested config for Qwen3-MoE on 2 nodes.
+"""
+
+import os
+import miles.utils.external_utils.command_utils as U
+
+MODEL_NAME = "Qwen3-30B-A3B"
+MODEL_TYPE = "qwen3-30B-A3B"
+NUM_GPUS_PER_NODE = 8
+
+HF_CHECKPOINT = os.environ.get("HF_CHECKPOINT", "/data/models/Qwen3-30B-A3B")
+TORCH_DIST_CHECKPOINT = os.environ.get("TORCH_DIST_CHECKPOINT", "/data/models/Qwen3-30B-A3B_torch_dist")
+PROMPT_DATA = os.environ.get("PROMPT_DATA", "/data/dapo-math-17k/dapo-math-17k.jsonl")
+
+ACTOR_NUM_NODES = 1
+ACTOR_NUM_GPUS_PER_NODE = 8
+
+ROLLOUT_NUM_GPUS_PER_ENGINE = 8
+ROLLOUT_NUM_GPUS = 8
+
+
+def execute():
+    ckpt_args = f"--hf-checkpoint {HF_CHECKPOINT} " f"--ref-load {TORCH_DIST_CHECKPOINT} "
+
+    rollout_args = (
+        f"--prompt-data {PROMPT_DATA} "
+        "--input-key prompt "
+        "--label-key label "
+        "--apply-chat-template "
+        "--rollout-shuffle "
+        "--rm-type deepscaler "
+        "--num-rollout 3 "
+        "--rollout-batch-size 8 "
+        "--n-samples-per-prompt 8 "
+        "--rollout-max-response-len 100 "
+        "--rollout-temperature 1 "
+        "--global-batch-size 64 "
+        "--balance-data "
+    )
+
+    perf_args = (
+        "--tensor-model-parallel-size 4 "
+        "--sequence-parallel "
+        "--pipeline-model-parallel-size 1 "
+        "--context-parallel-size 1 "
+        "--expert-model-parallel-size 8 "
+        "--expert-tensor-parallel-size 1 "
+        "--recompute-granularity full "
+        "--recompute-method uniform "
+        "--recompute-num-layers 1 "
+        "--use-dynamic-batch-size "
+        "--max-tokens-per-gpu 20480 "
+    )
+
+    grpo_args = (
+        "--advantage-estimator grpo "
+        "--kl-loss-coef 0.00 "
+        "--kl-loss-type low_var_kl "
+        "--entropy-coef 0.00 "
+        "--eps-clip 0.2 "
+        "--eps-clip-high 0.28 "
+    )
+
+    optimizer_args = (
+        "--optimizer adam "
+        "--lr 1e-6 "
+        "--lr-decay-style constant "
+        "--weight-decay 0.1 "
+        "--adam-beta1 0.9 "
+        "--adam-beta2 0.98 "
+        "--optimizer-cpu-offload "
+        "--overlap-cpu-optimizer-d2h-h2d "
+        "--use-precision-aware-optimizer "
+    )
+
+    # Per-GPU RDMA NIC mapping for B200 nodes (GPU index -> PIX-affine mlx5 device)
+    ib_device_json = (
+        '{"0":"mlx5_1","1":"mlx5_5","2":"mlx5_2","3":"mlx5_0","4":"mlx5_11","5":"mlx5_15","6":"mlx5_14","7":"mlx5_6"}'
+    )
+
+    sglang_args = (
+        f"--rollout-num-gpus-per-engine {ROLLOUT_NUM_GPUS_PER_ENGINE} "
+        f"--rollout-num-gpus {ROLLOUT_NUM_GPUS} "
+        "--sglang-mem-fraction-static 0.7 "
+        "--sglang-ep-size 8 "
+        "--sglang-remote-instance-weight-loader-start-seed-via-transfer-engine "
+        f"--update-weight-p2p-ib-device '{ib_device_json}' "
+    )
+
+    misc_args = (
+        "--attention-dropout 0.0 "
+        "--hidden-dropout 0.0 "
+        "--accumulate-allreduce-grads-in-fp32 "
+        "--attention-softmax-in-fp32 "
+        "--attention-backend flash "
+        f"--actor-num-nodes {ACTOR_NUM_NODES} "
+        f"--actor-num-gpus-per-node {ACTOR_NUM_GPUS_PER_NODE} "
+        f"--update-weight-buffer-size {2 * 1024 ** 3} "
+        "--update-weight-transfer-mode p2p "
+        "--check-weight-update-equal "
+    )
+
+    train_args = (
+        f"{ckpt_args} "
+        f"{rollout_args} "
+        f"{optimizer_args} "
+        f"{grpo_args} "
+        f"{U.get_default_wandb_args(__file__)} "
+        f"{perf_args} "
+        f"{sglang_args} "
+        f"{misc_args} "
+    )
+
+    U.execute_train(
+        train_args=train_args,
+        num_gpus_per_node=NUM_GPUS_PER_NODE,
+        megatron_model_type=MODEL_TYPE,
+        train_script="train_async.py",
+    )
+
+
+if __name__ == "__main__":
+    execute()

--- a/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/mixin.py
+++ b/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/mixin.py
@@ -136,7 +136,7 @@ class DistBucketedWeightUpdateMixin:
 
         update_bucket_weight_func(converted_hf_tensors, pbar)
 
-    def _pause_and_prepare_engines(self) -> None:
+    def _pause_and_prepare_engines(self, restore_weights_before_load: bool = False) -> None:
         """Pause rollout engines, flush cache, and run pre-process if needed."""
         if dist.get_rank() == 0:
             mode = self.args.pause_generation_mode
@@ -144,8 +144,9 @@ class DistBucketedWeightUpdateMixin:
             if mode not in ("in_place"):
                 ray.get([engine.flush_cache.remote() for engine in self.rollout_engines])
 
-            # int4/fp4 pre_process
-            if self.quantization_config and self.quantization_config["quant_method"] in ["compressed-tensors"]:
+            if restore_weights_before_load or (
+                self.quantization_config and self.quantization_config["quant_method"] in ["compressed-tensors"]
+            ):
                 post_process_weights(
                     rollout_engines=self.rollout_engines,
                     restore_weights_before_load=True,

--- a/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/p2p.py
+++ b/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/p2p.py
@@ -11,6 +11,7 @@ from sglang.srt.configs.device_config import DeviceConfig
 from sglang.srt.configs.load_config import LoadConfig
 from sglang.srt.configs.model_config import ModelConfig
 from sglang.srt.distributed.parallel_state import ParallelismContext, RankParallelismConfig
+from sglang.srt.layers.moe.utils import initialize_moe_config
 from sglang.srt.model_loader import get_model
 from sglang.srt.model_loader.parameter_mapper import ParameterMapper
 from sglang.srt.server_args import ServerArgs
@@ -26,6 +27,7 @@ from .p2p_transfer_utils import (
     create_transfer_engine,
     query_remote_weight_infos,
     register_cpu_memory,
+    maybe_restore_cpu_model_weights,
 )
 
 logger = logging.getLogger(__name__)
@@ -105,7 +107,7 @@ class UpdateWeightP2P(DistBucketedWeightUpdateMixin):
 
     def _pause_and_prepare_engines(self):
         """Register shared CPU pinned memory with P2P on first call."""
-        super()._pause_and_prepare_engines()
+        super()._pause_and_prepare_engines(restore_weights_before_load=True)
         if not self._is_source:
             return
 
@@ -145,7 +147,6 @@ class UpdateWeightP2P(DistBucketedWeightUpdateMixin):
             last_idx = len(self._transfer_engine_meta_list) - 1
             for i, (model_replica, remote_weight_infos) in enumerate(self._transfer_engine_meta_list):
                 model_replica.load_weights(ready_hf_tensors)
-
                 is_last = i == last_idx
                 if is_last:
                     # Last engine rank: fire-and-forget all sessions to background,
@@ -205,7 +206,10 @@ class UpdateWeightP2P(DistBucketedWeightUpdateMixin):
                 targets_grouped_by_engine_rank.setdefault(target.engine_rank, []).append(target)
 
             # Create ONE transfer engine for all engine ranks
-            self._transfer_engine = create_transfer_engine()
+            self._transfer_engine = create_transfer_engine(
+                gpu_id=torch.cuda.current_device(),
+                ib_device=getattr(self.args, "update_weight_p2p_ib_device", None),
+            )
             self._shared_params_dict: dict[str, torch.Tensor] = {}
             self._shared_param_mapper: ParameterMapper | None = None
             # in self._transfer_engine_meta_list: tuple of
@@ -251,26 +255,32 @@ class UpdateWeightP2P(DistBucketedWeightUpdateMixin):
         server_args: ServerArgs,
         first_engine_rank: bool = False,
     ) -> torch.nn.Module:
-        """Create model on GPU (required by sglang), then move to CPU pinned memory for the
-        first engine rank or point all parameters to shared pinned buffers for subsequent ranks."""
+        """Create model directly on CPU pinned memory to avoid GPU OOM.
+
+        For the first engine rank: creates model on CPU and pins memory.
+        For subsequent ranks: points parameters to shared pinned buffers."""
         load_config = LoadConfig(
             load_format="dummy",
             model_loader_extra_config=None,
             rl_quant_profile=server_args.rl_quant_profile,
         )
         server_args_module._global_server_args = server_args
+        initialize_moe_config(server_args)
         with ParallelismContext(parallelism_config):
             model = get_model(
                 model_config=ModelConfig(model_path),
                 load_config=load_config,
-                device_config=DeviceConfig(),
+                device_config=DeviceConfig("cpu"),
             )
+
+        # TODO: Remove once radixark/miles#976 lands — that PR monkey-patches
+        # post_load_weights to no-op so process_weights_after_loading never runs
+        # on the CPU replica, making this undo step unnecessary.
+        maybe_restore_cpu_model_weights(model)
 
         if first_engine_rank:
             for param in model.parameters():
-                cpu_data = param.data.to("cpu", non_blocking=True).pin_memory()
-                param.data = cpu_data
-            torch.cuda.synchronize()
+                param.data = param.data.pin_memory()
         else:
             for name, param in model.named_parameters():
                 assert name in self._shared_params_dict, f"[P2P-Shared] Parameter {name} not found in shared buffers"

--- a/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/p2p_transfer_utils.py
+++ b/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/p2p_transfer_utils.py
@@ -11,6 +11,9 @@ import torch.distributed as dist
 from megatron.core import mpu
 from mooncake.engine import TransferEngine
 from ray.actor import ActorHandle
+from sglang.srt.distributed.device_communicators.mooncake_transfer_engine import get_ib_devices_for_gpu
+from sglang.srt.layers.quantization.unquant import UnquantizedFusedMoEMethod
+from sglang.srt.model_loader.loader import device_loading_context
 from sglang.srt.server_args import ServerArgs
 
 logger = logging.getLogger(__name__)
@@ -188,6 +191,31 @@ def create_server_args_from_dict(data_dict: dict) -> ServerArgs:
     return ServerArgs(**filtered_data)
 
 
+def maybe_restore_cpu_model_weights(model: torch.nn.Module) -> None:
+    """Undo FlashInfer TRT-LLM block-layout on the CPU model replica if active.
+
+    On sm100+ (B200), sglang auto-selects the ``flashinfer_trtllm`` MoE runner
+    which reshapes expert weights from 3D ``[E, N, K]`` to 4D block-layout
+    during ``process_weights_after_loading``.  Since P2P writes raw RDMA bytes
+    (always row-major), the CPU buffer must be restored to 3D so that each
+    iteration's ``load_weights()`` produces bytes matching the GPU layout after
+    ``restore_weights_before_loading`` on the sglang side.
+
+    On sm90 (H100) and below, ``UnquantizedFusedMoEMethod`` has
+    ``use_flashinfer_trtllm_moe=False``, so this function does nothing.
+    """
+
+    target_device = torch.device("cpu")
+    for _, module in model.named_modules():
+        quant_method = getattr(module, "quant_method", None)
+        if (
+            isinstance(quant_method, UnquantizedFusedMoEMethod)
+            and hasattr(quant_method, "restore_weights_before_loading")
+        ):
+            with device_loading_context(module, target_device):
+                quant_method.restore_weights_before_loading(module)
+
+
 def register_cpu_memory(params_dict: dict, transfer_engine) -> dict:
     """Register CPU pinned memory with the transfer engine."""
     weight_dict = {}
@@ -205,10 +233,25 @@ def register_cpu_memory(params_dict: dict, transfer_engine) -> dict:
     return weight_dict
 
 
-def create_transfer_engine():
+def create_transfer_engine(gpu_id: int | None = None, ib_device: str | None = None):
+    """Create and initialize a Mooncake TransferEngine for P2P weight transfer.
+
+    Args:
+        gpu_id: CUDA device index. When provided with ``ib_device``, the
+            per-GPU RDMA device is resolved via ``get_ib_devices_for_gpu``.
+        ib_device: IB device specification — a JSON GPU-to-device mapping
+            (e.g. '{"0":"mlx5_1","1":"mlx5_5"}') or a single device name.
+            Passed from ``--update-weight-p2p-ib-device``.
+    """
     transfer_engine = TransferEngine()
     local_ip = ray._private.services.get_node_ip_address()
-    transfer_engine.initialize(local_ip, "P2PHANDSHAKE", "rdma", "")
+    device_name = ""
+
+    if gpu_id is not None and ib_device:
+        device_name = get_ib_devices_for_gpu(ib_device, gpu_id) or ""
+
+    logger.info(f"[P2P] Initializing TransferEngine: ip={local_ip}, nic={device_name}")
+    transfer_engine.initialize(local_ip, "P2PHANDSHAKE", "rdma", device_name)
     return transfer_engine
 
 

--- a/miles/backends/sglang_utils/sglang_engine.py
+++ b/miles/backends/sglang_utils/sglang_engine.py
@@ -630,6 +630,7 @@ def _compute_server_args(
         "skip_server_warmup": True,
         # always enable draft weights cpu backup so that we run training without mtp weights.
         "enable_draft_weights_cpu_backup": True,
+        "mooncake_ib_device": args.update_weight_p2p_ib_device,
     }
 
     if sglang_overrides:

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -518,8 +518,19 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
             parser.add_argument(
                 "--p2p-transfer-timeout",
                 type=float,
-                default=30.0,
+                default=60.0,
                 help="Timeout in seconds for each P2P transfer operation.",
+            )
+            parser.add_argument(
+                "--update-weight-p2p-ib-device",
+                type=str,
+                default=None,
+                help="InfiniBand device mapping for P2P RDMA weight transfer. "
+                "Accepts a JSON GPU-to-device mapping "
+                '(e.g., \'{"0":"mlx5_1","1":"mlx5_5"}\') '
+                "or a single device name (e.g., mlx5_0). "
+                "Used by both the training side (Mooncake TransferEngine) and "
+                "the sglang rollout side for GPU-affine NIC binding.",
             )
             return parser
 


### PR DESCRIPTION
Update P2P RDMA weight sync with flashinfer compatibility and NIC affinity.

Tested on 4 node with Qwen3-30B-A3B, 16 node with Qwen3-235B-A22B over RoCE.

This depends on https://github.com/sgl-project/sglang/pull/22468