### PR TITLE
[fix] fix sample type non numeric

### DIFF
--- a/miles/utils/types.py
+++ b/miles/utils/types.py
@@ -213,10 +213,20 @@ class Sample:
 
     @property
     def oldest_weight_version(self) -> int | None:
-        """Minimum weight version across all turns (generation calls) for this trajectory."""
+        """Minimum weight version across turns.
+
+        Non-numeric versions are ignored.
+        """
         if not self.weight_versions:
             return None
-        return min(int(v) for v in self.weight_versions)
+
+        versions = []
+        for version in self.weight_versions:
+            try:
+                versions.append(int(version))
+            except (TypeError, ValueError):
+                continue
+        return min(versions) if versions else None
 
     def update_from_meta_info(self, args, meta_info: dict):
         """

--- a/tests/fast/utils/test_types.py
+++ b/tests/fast/utils/test_types.py
@@ -95,3 +95,13 @@ class TestStripLastOutputTokens:
         original_tokens = list(s.tokens)
         s.strip_last_output_tokens(-1, tokenizer)
         assert s.tokens == original_tokens
+
+
+class TestOldestWeightVersion:
+    def test_ignores_non_numeric_versions(self):
+        s = Sample(weight_versions=["default", "3", "x", "10"])
+        assert s.oldest_weight_version == 3
+
+    def test_all_non_numeric_versions_return_none(self):
+        s = Sample(weight_versions=["default", "latest"])
+        assert s.oldest_weight_version is None


### PR DESCRIPTION
The default value of sglang weight version is "default" rather than a numeric value. See https://github.com/sgl-project/sglang/blob/e77bfba24d892563fb2d91192e8841b0c59c7828/python/sglang/srt/server_args.py#L435.


When enabled debug rollout only, there is no explicit weight version so it will fail sglang e2e tests.

Fix this CI error. https://github.com/radixark/miles/actions/runs/24220053896/job/70709321587

```
Traceback (most recent call last):
  File "/__w/miles/miles/train.py", line 109, in <module>
    asyncio.run(train(args))
  File "/usr/lib/python3.12/asyncio/runners.py", line 194, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/asyncio/base_events.py", line 687, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/__w/miles/miles/train.py", line 73, in train
    rollout_data_ref = await rollout_manager.generate.remote(rollout_id)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ray.exceptions.RayTaskError(ValueError): ray::RolloutManager.generate() (pid=9882, ip=172.18.0.2, actor_id=995f53213b22eb599ff8dc8f02000000, repr=<miles.ray.rollout.RolloutManager object at 0x77e5b77202f0>)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/__w/miles/miles/miles/ray/rollout.py", line 453, in generate
    _log_rollout_data(rollout_id, self.args, data, metrics, time.time() - start_time)
  File "/__w/miles/miles/miles/ray/rollout.py", line 1189, in _log_rollout_data
    log_dict |= dict_add_prefix(compute_metrics_from_samples(args, samples), "rollout/")
                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/__w/miles/miles/miles/ray/rollout.py", line 1209, in compute_metrics_from_samples
    oldest_versions = [s.oldest_weight_version for s in samples if s.oldest_weight_version is not None]
                                                                   ^^^^^^^^^^^^^^^^^^^^^^^
  File "/__w/miles/miles/miles/utils/types.py", line 219, in oldest_weight_version
    return min(int(v) for v in self.weight_versions)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/__w/miles/miles/miles/utils/types.py", line 219, in <genexpr>
    return min(int(v) for v in self.weight_versions)
               ^^^^^^
ValueError: invalid literal for int() with base 10: 'default'
```