### PR TITLE
fix: multi-agent example stalls (#979)

### DIFF
--- a/examples/multi_agent/agent_system.py
+++ b/examples/multi_agent/agent_system.py
@@ -1,4 +1,5 @@
 import asyncio
+import copy
 import re
 import time
 import traceback
@@ -189,7 +190,7 @@ async def run_agent_system(args, sample):
     并发运行 num_parallel 组 pipeline。
     """
 
-    args = deepcopy(args)  # 深拷贝 args，因为 args 在 rollout_with_multi_agents 中会被修改
+    args = copy.copy(args)
     args.sample = sample
     args.results_dict = {"solver": [], "rewriter": [], "selector": []}
 

--- a/examples/multi_agent/rollout_with_multi_agents.py
+++ b/examples/multi_agent/rollout_with_multi_agents.py
@@ -1,3 +1,4 @@
+import copy
 import random
 
 from miles.utils.misc import load_function
@@ -11,15 +12,22 @@ MULTI_AGENT_CONFIGS = {
     "correct_reward_weight": 1.2,
 }
 
+_TOKENIZER = None
+
 
 async def generate_with_multi_agents(args, sample: Sample, sampling_params, evaluation=False) -> list[Sample]:
 
-    tokenizer = load_tokenizer(args.hf_checkpoint, chat_template_path=args.chat_template_path, trust_remote_code=True)
+    global _TOKENIZER
+    if _TOKENIZER is None:
+        _TOKENIZER = load_tokenizer(
+            args.hf_checkpoint, chat_template_path=args.chat_template_path, trust_remote_code=True
+        )
     max_context_length = args.rollout_max_context_len if not evaluation else args.eval_max_context_len
 
+    args = copy.copy(args)
     args.sampling_params = sampling_params
     args.rollout_max_context_len = max_context_length
-    args.tokenizer = tokenizer
+    args.tokenizer = _TOKENIZER
 
     for key, value in MULTI_AGENT_CONFIGS.items():
         setattr(args, key, value)


### PR DESCRIPTION
## Summary
- Fix multi-agent rollout stalling at `0/256` with GPUs idle (#979).
- Root cause: per-sample `load_tokenizer` + `deepcopy(args)` copies the `PreTrainedTokenizer`, blocking the event loop under the GIL.
- Cache the tokenizer at module scope and replace `deepcopy(args)` with `copy.copy(args)` at both sites.

## Test plan
- [x] Run `bash examples/multi_agent/run-qwen3-30B-A3B-multi-agent.sh` and confirm `POST /generate` fires immediately after `resume_memory_occupation` and `Rollout generation` progresses.