### PR TITLE
P2P: GPU-affine NIC binding for RDMA weight transfer

### DIFF
--- a/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/p2p.py
+++ b/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/p2p.py
@@ -205,7 +205,10 @@ class UpdateWeightP2P(DistBucketedWeightUpdateMixin):
                 targets_grouped_by_engine_rank.setdefault(target.engine_rank, []).append(target)
 
             # Create ONE transfer engine for all engine ranks
-            self._transfer_engine = create_transfer_engine()
+            self._transfer_engine = create_transfer_engine(
+                gpu_id=torch.cuda.current_device(),
+                ib_device=getattr(self.args, "update_weight_p2p_ib_device", None),
+            )
             self._shared_params_dict: dict[str, torch.Tensor] = {}
             self._shared_param_mapper: ParameterMapper | None = None
             # in self._transfer_engine_meta_list: tuple of

--- a/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/p2p_transfer_utils.py
+++ b/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/p2p_transfer_utils.py
@@ -11,6 +11,7 @@ import torch.distributed as dist
 from megatron.core import mpu
 from mooncake.engine import TransferEngine
 from ray.actor import ActorHandle
+from sglang.srt.distributed.device_communicators.mooncake_transfer_engine import get_ib_devices_for_gpu
 from sglang.srt.server_args import ServerArgs
 
 logger = logging.getLogger(__name__)
@@ -205,10 +206,25 @@ def register_cpu_memory(params_dict: dict, transfer_engine) -> dict:
     return weight_dict
 
 
-def create_transfer_engine():
+def create_transfer_engine(gpu_id: int | None = None, ib_device: str | None = None):
+    """Create and initialize a Mooncake TransferEngine for P2P weight transfer.
+
+    Args:
+        gpu_id: CUDA device index. When provided with ``ib_device``, the
+            per-GPU RDMA device is resolved via ``get_ib_devices_for_gpu``.
+        ib_device: IB device specification — a JSON GPU-to-device mapping
+            (e.g. '{"0":"mlx5_1","1":"mlx5_5"}') or a single device name.
+            Passed from ``--update-weight-p2p-ib-device``.
+    """
     transfer_engine = TransferEngine()
     local_ip = ray._private.services.get_node_ip_address()
-    transfer_engine.initialize(local_ip, "P2PHANDSHAKE", "rdma", "")
+    device_name = ""
+
+    if gpu_id is not None and ib_device:
+        device_name = get_ib_devices_for_gpu(ib_device, gpu_id) or ""
+
+    logger.info(f"[P2P] Initializing TransferEngine: ip={local_ip}, nic={device_name}")
+    transfer_engine.initialize(local_ip, "P2PHANDSHAKE", "rdma", device_name)
     return transfer_engine
 
 

--- a/miles/backends/sglang_utils/sglang_engine.py
+++ b/miles/backends/sglang_utils/sglang_engine.py
@@ -630,6 +630,7 @@ def _compute_server_args(
         "skip_server_warmup": True,
         # always enable draft weights cpu backup so that we run training without mtp weights.
         "enable_draft_weights_cpu_backup": True,
+        "mooncake_ib_device": args.update_weight_p2p_ib_device,
     }
 
     if sglang_overrides:

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -521,6 +521,17 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 default=30.0,
                 help="Timeout in seconds for each P2P transfer operation.",
             )
+            parser.add_argument(
+                "--update-weight-p2p-ib-device",
+                type=str,
+                default=None,
+                help="InfiniBand device mapping for P2P RDMA weight transfer. "
+                "Accepts a JSON GPU-to-device mapping "
+                '(e.g., \'{"0":"mlx5_1","1":"mlx5_5"}\') '
+                "or a single device name (e.g., mlx5_0). "
+                "Used by both the training side (Mooncake TransferEngine) and "
+                "the sglang rollout side for GPU-affine NIC binding.",
+            )
             return parser
 
         def add_fault_tolerance_arguments(parser):


### PR DESCRIPTION
Add --update-weight-p2p-ib-device flag to specify per-GPU InfiniBand device mapping for P2P RDMA transfers. This allows explicit NIC affinity on multi-NIC nodes (e.g. RoCE setups), improving transfer throughput by binding each GPU to its closest NIC.

The flag accepts a JSON GPU-to-device mapping (e.g. '{"0":"mlx5_1","1":"mlx5_5"}') or a single device name, and is passed through to both the training-side Mooncake TransferEngine and the sglang rollout side via mooncake_ib_device.

Made-with: Cursor