### PR TITLE
feat(sglang_engine): allow PD worker_type on /add_worker registration path

### DIFF
--- a/.github/workflows/maintain-deploy.yml
+++ b/.github/workflows/maintain-deploy.yml
@@ -60,10 +60,17 @@ jobs:
     if: needs.check.outputs.skip != 'true'
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.DEPLOY_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Configure git
         run: |

--- a/.github/workflows/maintain-deploy.yml
+++ b/.github/workflows/maintain-deploy.yml
@@ -1,18 +1,72 @@
 name: Maintain deploy branch
 
 on:
-  # Rebuild nightly
   schedule:
-    - cron: '0 10 * * *'  # 3 AM California (10 AM UTC)
-  # Rebuild when any feature branch is pushed
-  push:
-    branches:
-      - 'fix/**'
-  # Manual trigger
+    - cron: '*/15 * * * *'
   workflow_dispatch:
+    inputs:
+      force:
+        description: 'Rebuild even if no changes detected'
+        type: boolean
+        default: false
+
+env:
+  UPSTREAM: radixark/miles
 
 jobs:
-  rebuild-deploy:
+  check:
+    runs-on: ubuntu-latest
+    outputs:
+      skip: ${{ steps.fingerprint.outputs.skip }}
+      state: ${{ steps.fingerprint.outputs.state }}
+      branches: ${{ steps.fingerprint.outputs.branches }}
+    steps:
+      - name: Compute desired state and compare
+        id: fingerprint
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          FORCE: ${{ inputs.force }}
+          REPO: ${{ github.repository }}
+        run: |
+          UPSTREAM_SHA=$(gh api "repos/${UPSTREAM}/commits/main" --jq '.sha' 2>/dev/null || echo "unknown")
+
+          PR_STATE=$(gh pr list \
+            --repo "$UPSTREAM" \
+            --author DavidBellamy \
+            --state open \
+            --base main \
+            --json headRefName,headRefOid \
+            --jq 'sort_by(.headRefName) | map(.headRefName + "=" + .headRefOid) | join(",")')
+
+          BRANCHES=$(gh pr list \
+            --repo "$UPSTREAM" \
+            --author DavidBellamy \
+            --state open \
+            --base main \
+            --json headRefName \
+            --jq '.[].headRefName' | tr '\n' ' ')
+
+          STATE="${UPSTREAM_SHA}|${PR_STATE}"
+          echo "state=$STATE" >> "$GITHUB_OUTPUT"
+          echo "branches=$BRANCHES" >> "$GITHUB_OUTPUT"
+          echo "Desired state: $STATE"
+
+          CURRENT=$(gh api "repos/${REPO}/commits/deploy" \
+            --jq '.commit.message' 2>/dev/null \
+            | grep '^state:' | head -1 | cut -d: -f2- || echo "")
+
+          echo "Current state: $CURRENT"
+
+          if [ "$CURRENT" = "$STATE" ] && [ "$FORCE" != "true" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::No changes detected, skipping rebuild"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  rebuild:
+    needs: check
+    if: needs.check.outputs.skip != 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -27,29 +81,13 @@ jobs:
 
       - name: Fetch upstream
         run: |
-          git remote add upstream https://github.com/radixark/miles.git || true
+          git remote add upstream "https://github.com/${UPSTREAM}.git" || true
           git fetch upstream main
           git fetch origin
 
-      - name: Get branches with open PRs targeting upstream
-        id: branches
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          BRANCHES=$(gh pr list \
-            --repo radixark/miles \
-            --author DavidBellamy \
-            --state open \
-            --base main \
-            --json headRefName \
-            -q '.[].headRefName' | tr '\n' ' ')
-
-          echo "branches=$BRANCHES" >> "$GITHUB_OUTPUT"
-          echo "Open PR branches: ${BRANCHES:-<none>}"
-
       - name: Build deploy branch
         env:
-          PR_BRANCHES: ${{ steps.branches.outputs.branches }}
+          PR_BRANCHES: ${{ needs.check.outputs.branches }}
         run: |
           git checkout -B deploy upstream/main
 
@@ -68,9 +106,40 @@ jobs:
 
           echo "Successfully merged:${MERGED:-<none>}"
           if [ -n "$FAILED" ]; then
-            echo "::error::Failed to merge (conflicts):$FAILED"
-            exit 1
+            echo "::warning::Failed to merge (conflicts):$FAILED"
+          fi
+          echo "FAILED_BRANCHES=$FAILED" >> "$GITHUB_ENV"
+
+      - name: Stamp fingerprint and push
+        env:
+          STATE: ${{ needs.check.outputs.state }}
+        run: |
+          git commit --allow-empty -m "state:${STATE}"
+          git push origin deploy --force
+
+      - name: Report merge conflicts
+        if: always() && needs.check.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ISSUE_TITLE="Deploy: merge conflict"
+          EXISTING=$(gh issue list --label deploy-conflict --state open --json number --jq '.[0].number' 2>/dev/null || echo "")
+
+          if [ -z "$FAILED_BRANCHES" ]; then
+            if [ -n "$EXISTING" ]; then
+              gh issue close "$EXISTING" --comment "Resolved: all branches merged cleanly."
+            fi
+            exit 0
           fi
 
-      - name: Force-push deploy
-        run: git push origin deploy --force
+          BODY=$(printf "The following branches failed to merge into deploy:\n\n")
+          for b in $FAILED_BRANCHES; do
+            BODY=$(printf "%s\n- \`%s\`" "$BODY" "$b")
+          done
+          BODY=$(printf "%s\n\nThis issue auto-closes when the next build merges all branches cleanly." "$BODY")
+
+          if [ -n "$EXISTING" ]; then
+            gh issue edit "$EXISTING" --body "$BODY"
+          else
+            gh issue create --title "$ISSUE_TITLE" --body "$BODY" --label deploy-conflict
+          fi

--- a/.github/workflows/maintain-deploy.yml
+++ b/.github/workflows/maintain-deploy.yml
@@ -1,0 +1,76 @@
+name: Maintain deploy branch
+
+on:
+  # Rebuild nightly
+  schedule:
+    - cron: '0 10 * * *'  # 3 AM California (10 AM UTC)
+  # Rebuild when any feature branch is pushed
+  push:
+    branches:
+      - 'fix/**'
+  # Manual trigger
+  workflow_dispatch:
+
+jobs:
+  rebuild-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Fetch upstream
+        run: |
+          git remote add upstream https://github.com/radixark/miles.git || true
+          git fetch upstream main
+          git fetch origin
+
+      - name: Get branches with open PRs targeting upstream
+        id: branches
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BRANCHES=$(gh pr list \
+            --repo radixark/miles \
+            --author DavidBellamy \
+            --state open \
+            --base main \
+            --json headRefName \
+            -q '.[].headRefName' | tr '\n' ' ')
+
+          echo "branches=$BRANCHES" >> "$GITHUB_OUTPUT"
+          echo "Open PR branches: ${BRANCHES:-<none>}"
+
+      - name: Build deploy branch
+        env:
+          PR_BRANCHES: ${{ steps.branches.outputs.branches }}
+        run: |
+          git checkout -B deploy upstream/main
+
+          MERGED=""
+          FAILED=""
+          for branch in $PR_BRANCHES; do
+            echo "Merging $branch..."
+            if git merge "origin/$branch" --no-edit -m "Deploy: merge $branch"; then
+              MERGED="$MERGED $branch"
+            else
+              echo "::error::Merge conflict on $branch, skipping"
+              git merge --abort
+              FAILED="$FAILED $branch"
+            fi
+          done
+
+          echo "Successfully merged:${MERGED:-<none>}"
+          if [ -n "$FAILED" ]; then
+            echo "::error::Failed to merge (conflicts):$FAILED"
+            exit 1
+          fi
+
+      - name: Force-push deploy
+        run: git push origin deploy --force

--- a/.github/workflows/maintain-deploy.yml
+++ b/.github/workflows/maintain-deploy.yml
@@ -30,21 +30,12 @@ jobs:
         run: |
           UPSTREAM_SHA=$(gh api "repos/${UPSTREAM}/commits/main" --jq '.sha' 2>/dev/null || echo "unknown")
 
-          PR_STATE=$(gh pr list \
-            --repo "$UPSTREAM" \
-            --author DavidBellamy \
-            --state open \
-            --base main \
-            --json headRefName,headRefOid \
-            --jq 'sort_by(.headRefName) | map(.headRefName + "=" + .headRefOid) | join(",")')
+          FORK_OWNER="${REPO%%/*}"
+          PR_STATE=$(gh api "repos/${UPSTREAM}/pulls?state=open&base=main&per_page=100" \
+            --jq "[.[] | select(.head.repo.owner.login == \"${FORK_OWNER}\")] | sort_by(.head.ref) | map(.head.ref + \"=\" + .head.sha) | join(\",\")")
 
-          BRANCHES=$(gh pr list \
-            --repo "$UPSTREAM" \
-            --author DavidBellamy \
-            --state open \
-            --base main \
-            --json headRefName \
-            --jq '.[].headRefName' | tr '\n' ' ')
+          BRANCHES=$(gh api "repos/${UPSTREAM}/pulls?state=open&base=main&per_page=100" \
+            --jq "[.[] | select(.head.repo.owner.login == \"${FORK_OWNER}\")] | .[].head.ref" | tr '\n' ' ')
 
           STATE="${UPSTREAM_SHA}|${PR_STATE}"
           echo "state=$STATE" >> "$GITHUB_OUTPUT"
@@ -72,7 +63,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.DEPLOY_TOKEN }}
 
       - name: Configure git
         run: |

--- a/miles/backends/sglang_utils/sglang_engine.py
+++ b/miles/backends/sglang_utils/sglang_engine.py
@@ -216,12 +216,34 @@ class SGLangEngine(RayActor):
 
         if self.node_rank == 0 and self.router_ip and self.router_port:
             if parse(sglang_router.__version__) <= parse("0.2.1") or self.args.use_miles_router:
-                assert (
-                    self.worker_type == "regular"
-                ), "pd disaggregation is not supported in old router or miles router."
-                response = requests.post(
-                    f"http://{self.router_ip}:{self.router_port}/add_worker?url=http://{self.server_host}:{self.server_port}"
+                # Old sglang_router (<=0.2.1) and miles-router use the single-arg
+                # /add_worker?url=... endpoint. For PD disaggregation, forward
+                # worker_type (and bootstrap_port for prefill) as extra query
+                # params so a router that supports PD via /add_worker can act on
+                # them. Routers that only understand the regular form will see
+                # the extra params, ignore them, and register the worker as
+                # regular -- so PD routing through such a router still needs a
+                # server-side update. This at least removes the unconditional
+                # assert that would fail-fast before the request is ever sent.
+                add_worker_url = (
+                    f"http://{self.router_ip}:{self.router_port}/add_worker"
+                    f"?url=http://{self.server_host}:{self.server_port}"
                 )
+                if self.worker_type != "regular":
+                    add_worker_url += f"&worker_type={self.worker_type}"
+                    if self.worker_type == "prefill":
+                        bootstrap_port = server_args_dict.get("disaggregation_bootstrap_port")
+                        if bootstrap_port is not None:
+                            add_worker_url += f"&bootstrap_port={bootstrap_port}"
+                    logger.warning(
+                        "Registering a '%s' worker via /add_worker on the "
+                        "old-style router path. PD disaggregation requires the "
+                        "router to honor worker_type on this endpoint; if it "
+                        "only accepts the single-arg form, workers will be "
+                        "treated as regular and PD routing will not function.",
+                        self.worker_type,
+                    )
+                response = requests.post(add_worker_url)
             else:
                 payload = {
                     "url": f"http://{self.server_host}:{self.server_port}",

--- a/miles/utils/wandb_utils.py
+++ b/miles/utils/wandb_utils.py
@@ -89,6 +89,7 @@ def _compute_config_for_logging(args):
         # We may insert more default values here, and may also allow users to configure a whitelist
     ]
     output["env_vars"] = {k: v for k, v in os.environ.items() if k in whitelist_env_vars}
+    output["launched_by"] = os.environ.get("USER")
 
     if env_report_raw := args.env_report:
         if launcher_report := decode_env_report(env_report_raw):


### PR DESCRIPTION
## Problem

`SGLangEngine._init_normal` asserts `worker_type == "regular"` before POSTing to the old-style `/add_worker?url=...` endpoint:

```python
if parse(sglang_router.__version__) <= parse("0.2.1") or self.args.use_miles_router:
    assert (
        self.worker_type == "regular"
    ), "pd disaggregation is not supported in old router or miles router."
    response = requests.post(
        f"http://{self.router_ip}:{self.router_port}/add_worker?url=http://{self.server_host}:{self.server_port}"
    )
```

Any attempt to stand up prefill/decode workers via the miles-router path (or a gateway that mirrors it) fails fast at engine init, even when the receiving router could handle PD if given the information.

This blocks PD disaggregation throughput scaling in Miles-driven rollouts. Observed on LLM360/RL360#76 when attempting `FAST_ITER_CONFIG=pd-disagg` through a Miles-API-compatible gateway.

## Fix

Relax the assertion. Forward `worker_type` (and `bootstrap_port` for prefill workers) as extra query params on the `/add_worker` URL. Routers that honor them get correct PD registration; routers that only accept the single-arg form ignore the extras and register as regular, with a `logger.warning` so the fallback behavior is visible to operators.

```python
add_worker_url = (
    f"http://{self.router_ip}:{self.router_port}/add_worker"
    f"?url=http://{self.server_host}:{self.server_port}"
)
if self.worker_type != "regular":
    add_worker_url += f"&worker_type={self.worker_type}"
    if self.worker_type == "prefill":
        bootstrap_port = server_args_dict.get("disaggregation_bootstrap_port")
        if bootstrap_port is not None:
            add_worker_url += f"&bootstrap_port={bootstrap_port}"
    logger.warning("Registering a '%s' worker via /add_worker on the old-style router path...")
response = requests.post(add_worker_url)
```

## Companion server-side change

This PR alone doesn't make PD routing functional through an old-style router that didn't previously understand worker_type; it just removes the fail-fast assert. Operators also need one of:

- A router that handles `?worker_type=&bootstrap_port=` on `/add_worker`
- Newer `sglang_router` (`>0.2.1`) with `--no-use-miles-router` so Miles takes the `POST /workers` JSON path that already supports PD

## Test

Unit-checked URL construction for all four shapes:

```python
build_url(..., 'regular')               == '.../add_worker?url=http://h:p'
build_url(..., 'decode')                == '.../add_worker?url=http://h:p&worker_type=decode'
build_url(..., 'prefill', 8998)         == '.../add_worker?url=http://h:p&worker_type=prefill&bootstrap_port=8998'
build_url(..., 'prefill', None)         == '.../add_worker?url=http://h:p&worker_type=prefill'
```

## Context

LLM360/RL360#76 Track G (job 1559336) proved that full PD+Mooncake KV transfer works on M2's SR-IOV IB via SGLang's native `sglang_router.launch_router --mini-lb`. This PR unblocks the same flow through Miles-driven rollouts, so agentic RL can use PD scaling without hand-written sbatch test harnesses.