### PR TITLE
fix(rollout): propagate PYTHONPATH to Ray remote actors

### DIFF
--- a/.github/workflows/maintain-deploy.yml
+++ b/.github/workflows/maintain-deploy.yml
@@ -60,10 +60,17 @@ jobs:
     if: needs.check.outputs.skip != 'true'
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.DEPLOY_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Configure git
         run: |

--- a/.github/workflows/maintain-deploy.yml
+++ b/.github/workflows/maintain-deploy.yml
@@ -1,18 +1,72 @@
 name: Maintain deploy branch
 
 on:
-  # Rebuild nightly
   schedule:
-    - cron: '0 10 * * *'  # 3 AM California (10 AM UTC)
-  # Rebuild when any feature branch is pushed
-  push:
-    branches:
-      - 'fix/**'
-  # Manual trigger
+    - cron: '*/15 * * * *'
   workflow_dispatch:
+    inputs:
+      force:
+        description: 'Rebuild even if no changes detected'
+        type: boolean
+        default: false
+
+env:
+  UPSTREAM: radixark/miles
 
 jobs:
-  rebuild-deploy:
+  check:
+    runs-on: ubuntu-latest
+    outputs:
+      skip: ${{ steps.fingerprint.outputs.skip }}
+      state: ${{ steps.fingerprint.outputs.state }}
+      branches: ${{ steps.fingerprint.outputs.branches }}
+    steps:
+      - name: Compute desired state and compare
+        id: fingerprint
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          FORCE: ${{ inputs.force }}
+          REPO: ${{ github.repository }}
+        run: |
+          UPSTREAM_SHA=$(gh api "repos/${UPSTREAM}/commits/main" --jq '.sha' 2>/dev/null || echo "unknown")
+
+          PR_STATE=$(gh pr list \
+            --repo "$UPSTREAM" \
+            --author DavidBellamy \
+            --state open \
+            --base main \
+            --json headRefName,headRefOid \
+            --jq 'sort_by(.headRefName) | map(.headRefName + "=" + .headRefOid) | join(",")')
+
+          BRANCHES=$(gh pr list \
+            --repo "$UPSTREAM" \
+            --author DavidBellamy \
+            --state open \
+            --base main \
+            --json headRefName \
+            --jq '.[].headRefName' | tr '\n' ' ')
+
+          STATE="${UPSTREAM_SHA}|${PR_STATE}"
+          echo "state=$STATE" >> "$GITHUB_OUTPUT"
+          echo "branches=$BRANCHES" >> "$GITHUB_OUTPUT"
+          echo "Desired state: $STATE"
+
+          CURRENT=$(gh api "repos/${REPO}/commits/deploy" \
+            --jq '.commit.message' 2>/dev/null \
+            | grep '^state:' | head -1 | cut -d: -f2- || echo "")
+
+          echo "Current state: $CURRENT"
+
+          if [ "$CURRENT" = "$STATE" ] && [ "$FORCE" != "true" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::No changes detected, skipping rebuild"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  rebuild:
+    needs: check
+    if: needs.check.outputs.skip != 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -27,29 +81,13 @@ jobs:
 
       - name: Fetch upstream
         run: |
-          git remote add upstream https://github.com/radixark/miles.git || true
+          git remote add upstream "https://github.com/${UPSTREAM}.git" || true
           git fetch upstream main
           git fetch origin
 
-      - name: Get branches with open PRs targeting upstream
-        id: branches
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          BRANCHES=$(gh pr list \
-            --repo radixark/miles \
-            --author DavidBellamy \
-            --state open \
-            --base main \
-            --json headRefName \
-            -q '.[].headRefName' | tr '\n' ' ')
-
-          echo "branches=$BRANCHES" >> "$GITHUB_OUTPUT"
-          echo "Open PR branches: ${BRANCHES:-<none>}"
-
       - name: Build deploy branch
         env:
-          PR_BRANCHES: ${{ steps.branches.outputs.branches }}
+          PR_BRANCHES: ${{ needs.check.outputs.branches }}
         run: |
           git checkout -B deploy upstream/main
 
@@ -68,9 +106,40 @@ jobs:
 
           echo "Successfully merged:${MERGED:-<none>}"
           if [ -n "$FAILED" ]; then
-            echo "::error::Failed to merge (conflicts):$FAILED"
-            exit 1
+            echo "::warning::Failed to merge (conflicts):$FAILED"
+          fi
+          echo "FAILED_BRANCHES=$FAILED" >> "$GITHUB_ENV"
+
+      - name: Stamp fingerprint and push
+        env:
+          STATE: ${{ needs.check.outputs.state }}
+        run: |
+          git commit --allow-empty -m "state:${STATE}"
+          git push origin deploy --force
+
+      - name: Report merge conflicts
+        if: always() && needs.check.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ISSUE_TITLE="Deploy: merge conflict"
+          EXISTING=$(gh issue list --label deploy-conflict --state open --json number --jq '.[0].number' 2>/dev/null || echo "")
+
+          if [ -z "$FAILED_BRANCHES" ]; then
+            if [ -n "$EXISTING" ]; then
+              gh issue close "$EXISTING" --comment "Resolved: all branches merged cleanly."
+            fi
+            exit 0
           fi
 
-      - name: Force-push deploy
-        run: git push origin deploy --force
+          BODY=$(printf "The following branches failed to merge into deploy:\n\n")
+          for b in $FAILED_BRANCHES; do
+            BODY=$(printf "%s\n- \`%s\`" "$BODY" "$b")
+          done
+          BODY=$(printf "%s\n\nThis issue auto-closes when the next build merges all branches cleanly." "$BODY")
+
+          if [ -n "$EXISTING" ]; then
+            gh issue edit "$EXISTING" --body "$BODY"
+          else
+            gh issue create --title "$ISSUE_TITLE" --body "$BODY" --label deploy-conflict
+          fi

--- a/.github/workflows/maintain-deploy.yml
+++ b/.github/workflows/maintain-deploy.yml
@@ -1,0 +1,76 @@
+name: Maintain deploy branch
+
+on:
+  # Rebuild nightly
+  schedule:
+    - cron: '0 10 * * *'  # 3 AM California (10 AM UTC)
+  # Rebuild when any feature branch is pushed
+  push:
+    branches:
+      - 'fix/**'
+  # Manual trigger
+  workflow_dispatch:
+
+jobs:
+  rebuild-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Fetch upstream
+        run: |
+          git remote add upstream https://github.com/radixark/miles.git || true
+          git fetch upstream main
+          git fetch origin
+
+      - name: Get branches with open PRs targeting upstream
+        id: branches
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BRANCHES=$(gh pr list \
+            --repo radixark/miles \
+            --author DavidBellamy \
+            --state open \
+            --base main \
+            --json headRefName \
+            -q '.[].headRefName' | tr '\n' ' ')
+
+          echo "branches=$BRANCHES" >> "$GITHUB_OUTPUT"
+          echo "Open PR branches: ${BRANCHES:-<none>}"
+
+      - name: Build deploy branch
+        env:
+          PR_BRANCHES: ${{ steps.branches.outputs.branches }}
+        run: |
+          git checkout -B deploy upstream/main
+
+          MERGED=""
+          FAILED=""
+          for branch in $PR_BRANCHES; do
+            echo "Merging $branch..."
+            if git merge "origin/$branch" --no-edit -m "Deploy: merge $branch"; then
+              MERGED="$MERGED $branch"
+            else
+              echo "::error::Merge conflict on $branch, skipping"
+              git merge --abort
+              FAILED="$FAILED $branch"
+            fi
+          done
+
+          echo "Successfully merged:${MERGED:-<none>}"
+          if [ -n "$FAILED" ]; then
+            echo "::error::Failed to merge (conflicts):$FAILED"
+            exit 1
+          fi
+
+      - name: Force-push deploy
+        run: git push origin deploy --force

--- a/.github/workflows/maintain-deploy.yml
+++ b/.github/workflows/maintain-deploy.yml
@@ -30,21 +30,12 @@ jobs:
         run: |
           UPSTREAM_SHA=$(gh api "repos/${UPSTREAM}/commits/main" --jq '.sha' 2>/dev/null || echo "unknown")
 
-          PR_STATE=$(gh pr list \
-            --repo "$UPSTREAM" \
-            --author DavidBellamy \
-            --state open \
-            --base main \
-            --json headRefName,headRefOid \
-            --jq 'sort_by(.headRefName) | map(.headRefName + "=" + .headRefOid) | join(",")')
+          FORK_OWNER="${REPO%%/*}"
+          PR_STATE=$(gh api "repos/${UPSTREAM}/pulls?state=open&base=main&per_page=100" \
+            --jq "[.[] | select(.head.repo.owner.login == \"${FORK_OWNER}\")] | sort_by(.head.ref) | map(.head.ref + \"=\" + .head.sha) | join(\",\")")
 
-          BRANCHES=$(gh pr list \
-            --repo "$UPSTREAM" \
-            --author DavidBellamy \
-            --state open \
-            --base main \
-            --json headRefName \
-            --jq '.[].headRefName' | tr '\n' ' ')
+          BRANCHES=$(gh api "repos/${UPSTREAM}/pulls?state=open&base=main&per_page=100" \
+            --jq "[.[] | select(.head.repo.owner.login == \"${FORK_OWNER}\")] | .[].head.ref" | tr '\n' ' ')
 
           STATE="${UPSTREAM_SHA}|${PR_STATE}"
           echo "state=$STATE" >> "$GITHUB_OUTPUT"
@@ -72,7 +63,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.DEPLOY_TOKEN }}
 
       - name: Configure git
         run: |

--- a/miles/ray/rollout.py
+++ b/miles/ray/rollout.py
@@ -139,6 +139,13 @@ class ServerGroup:
                 }.items()
             }
             env_vars.update(dumper_utils.get_sglang_env(self.args))
+            # Propagate PYTHONPATH so Ray remote actors import the same miles
+            # / sglang modules as the driver. Without this, SGLangEngine
+            # actors inherit only the container's default PYTHONPATH and
+            # `import miles` falls back to a pip-installed /root/miles,
+            # silently bypassing any MILES_OVERRIDE on the driver's PYTHONPATH.
+            if "PYTHONPATH" in os.environ:
+                env_vars["PYTHONPATH"] = os.environ["PYTHONPATH"]
 
             rollout_engine = RolloutRayActor.options(
                 num_cpus=num_cpus,

--- a/miles/utils/wandb_utils.py
+++ b/miles/utils/wandb_utils.py
@@ -89,6 +89,7 @@ def _compute_config_for_logging(args):
         # We may insert more default values here, and may also allow users to configure a whitelist
     ]
     output["env_vars"] = {k: v for k, v in os.environ.items() if k in whitelist_env_vars}
+    output["launched_by"] = os.environ.get("USER")
 
     if env_report_raw := args.env_report:
         if launcher_report := decode_env_report(env_report_raw):


### PR DESCRIPTION
## Problem

`SGLangEngine` Ray actors are created via:

```python
rollout_engine = RolloutRayActor.options(
    ...
    runtime_env={"env_vars": env_vars},
).remote(...)
```

`env_vars` is built by merging `NOSET_VISIBLE_DEVICES_ENV_VARS_LIST` with a small set of `SGLANG_*` overrides and `dumper_utils.get_sglang_env(self.args)`. `PYTHONPATH` is never included.

Ray actors inherit only the explicitly listed env vars, so the actor's `PYTHONPATH` is whatever the container image provides (typically empty + site-packages). If `miles` is installed as a pip package inside the container (e.g. the `radixark/miles:dev` overlay installs it editable into site-packages), `import miles` in the actor resolves to the packaged copy — even when the driver has a different `MILES_OVERRIDE` prepended to `PYTHONPATH`.

Effect: per-cluster local patches kept in a shared `MILES_OVERRIDE` clone never actually execute inside SGLangEngine, because actors silently bypass the override.

## Fix

Copy `os.environ["PYTHONPATH"]` into `env_vars` when it is set, so actors get the driver's `sys.path` layout.

```python
env_vars.update(dumper_utils.get_sglang_env(self.args))
if "PYTHONPATH" in os.environ:
    env_vars["PYTHONPATH"] = os.environ["PYTHONPATH"]
```

No-op when the driver has no `PYTHONPATH` exported (container defaults still apply — same behavior as before).

## Context

Observed on LLM360/RL360#76 during PD-disagg testing. The driver had a patched `miles/backends/sglang_utils/sglang_engine.py` visible via `PYTHONPATH=/mnt/.../shared/miles:...`, but SGLangEngine actors still crashed with an assertion that the patched code had already removed. `pip show miles` inside the container confirmed an editable pip install pointing at `/root/miles` (the un-patched copy).

With this fix, the override flows through end-to-end without requiring an image rebuild.

## Test

No new tests. Trivial env-var propagation.