### PR TITLE
[OPD] [1/N] Decouple on-policy distillation from advantage estimators and add Megatron teacher mode

### DIFF
--- a/examples/on_policy_distillation/README.md
+++ b/examples/on_policy_distillation/README.md
@@ -1,17 +1,42 @@
 # On-Policy Distillation Example
 
-This example shows how to run **on-policy distillation** using miles. A small student (Qwen3-8B) is aligned to imitate a larger teacher (Qwen3-32B) by training only on the student's own rollouts and matching the teacher's token-level log-probabilities.
+This example shows how to run **on-policy distillation (OPD)** using miles. A small student (Qwen3-8B) is aligned to imitate a larger teacher (Qwen3-32B) by training only on the student's own rollouts and matching the teacher's token-level log-probabilities.
 
-In this example, the teacher model acts as a reward model (RM) by providing teacher log probabilities as the supervision signal.
+## Key Features
+
+- **OPD is orthogonal to advantage estimators**: OPD works as an additive KL penalty on top of any advantage estimator (GRPO, PPO, REINFORCE++, etc.), not as a separate estimator.
+- **Two teacher modes**:
+  - **sglang**: Teacher runs on an external SGLang server, teacher log-probs are obtained during rollout.
+  - **megatron**: Teacher is loaded directly into Megatron via `--opd-teacher-load`, teacher log-probs are computed during training forward pass.
+
+## Key Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `--use-opd` | Enable on-policy distillation. Required flag to use OPD. |
+| `--opd-type` | Type of OPD: `sglang` or `megatron`. Required when `--use-opd` is set. |
+| `--opd-kl-coef` | OPD KL penalty coefficient (default: 1.0). |
+| `--opd-teacher-load` | Path to teacher checkpoint. **Required** when `--opd-type=megatron`, **must not be set** when `--opd-type=sglang`. |
+| `--opd-teacher-ckpt-step` | Optional checkpoint step for teacher model. |
+
+## Mode Comparison
+
+| Mode | Teacher Location | When to use |
+|------|------------------|-------------|
+| `sglang` | External SGLang server | Teacher has different architecture or larger than GPU memory |
+| `megatron` | Loaded into Megatron training | Teacher has same architecture as policy/ref model |
 
 ## Components
 
-- `on_policy_distillation.py` implements::
+- `on_policy_distillation.py` implements (for SGLang mode):
   - `reward_func` calls the teacher server (via `args.rm_url`) with every sample to obtain token-level logprobs.
   - `post_process_rewards` trims the teacher logprobs to the generated response span and writes the tensors back to each `Sample` to compute advantages.
 - `run-qwen3-8B-opd.sh` launches an SGLang teacher server, then submits a Ray job that runs `train.py`.
+- `run-qwen3-8B-opd-megatron.sh` uses Megatron-loaded teacher model (no external server needed).
 
 ## Running the example
+
+### Using SGLang Teacher (External Server)
 
 1. Download or prepare the required checkpoints and data.
 ```bash
@@ -30,9 +55,36 @@ PYTHONPATH=/root/Megatron-LM python tools/convert_hf_to_torch_dist.py \
     --hf-checkpoint /root/Qwen3-8B \
     --save /root/Qwen3-8B_torch_dist
 ```
-3. run on-policy distillation:
+
+3. Run on-policy distillation:
 ```bash
 bash examples/on_policy_distillation/run-qwen3-8B-opd.sh
+```
+
+### Using Megatron Teacher (No External Server)
+
+1. Prepare student checkpoint (same as above).
+
+2. **IMPORTANT**: Convert your teacher model to Megatron format (change the path to your actual teacher):
+```bash
+# This example uses the same model as both student and teacher (for demonstration only)
+# In practice, use a different (stronger) model as the teacher!
+cd /root/miles
+source scripts/models/qwen3-8B.sh  # Or your teacher model config
+
+PYTHONPATH=/root/Megatron-LM python tools/convert_hf_to_torch_dist.py \
+    ${MODEL_ARGS[@]} \
+    --hf-checkpoint /root/YourTeacherModel \
+    --save /root/YourTeacherModel_torch_dist
+```
+
+3. Edit `run-qwen3-8B-opd-megatron.sh` to update paths:
+   - Change `--opd-teacher-load` to your teacher model path
+   - Adjust `--opd-kl-coef` based on your task
+
+4. Run:
+```bash
+bash examples/on_policy_distillation/run-qwen3-8B-opd-megatron.sh
 ```
 
 
@@ -47,10 +99,25 @@ Using Qwen3-8B-Base model sfted on part of the [OpenThoughts3-1.2M](https://hugg
 
 
 
-
 # FAQ
-1. **Why are teacher logits computed via a sglang server instead of inside the training backend?**
-The teacher runs on an independent SGLang server that miles treats as a reward model. Hosting it inside Megatron/FSDP would require maintaining a second, fully configured training stack for the teacher.
+1. **Why are there two OPD modes?**
+   - `sglang` mode: The teacher runs on an independent SGLang server. This is useful when the teacher has a different architecture or is too large to load together with the policy model.
+   - `megatron` mode: The teacher is loaded into Megatron using the same parameter loading mechanism as the reference model. This requires the teacher to have the same architecture as the policy model.
+
+2. **How do I use Megatron-based teacher instead of SGLang server?**
+   Replace your OPD arguments:
+   ```bash
+   # Instead of:
+   --use-opd --opd-type sglang --opd-kl-coef 1.0
+   # Use:
+   --use-opd --opd-type megatron --opd-kl-coef 1.0 --opd-teacher-load /path/to/teacher_checkpoint
+   ```
+
+3. **What happens if I set wrong arguments?**
+   The system will raise clear errors:
+   - `--use-opd` without `--opd-type`: Error asking you to specify type
+   - `--opd-type megatron` without `--opd-teacher-load`: Error asking for teacher checkpoint
+   - `--opd-type sglang` with `--opd-teacher-load`: Error indicating conflict
 
 
 # References

--- a/examples/on_policy_distillation/README.md
+++ b/examples/on_policy_distillation/README.md
@@ -15,16 +15,18 @@ This example shows how to run **on-policy distillation (OPD)** using miles. A sm
 |----------|-------------|
 | `--use-opd` | Enable on-policy distillation. Required flag to use OPD. |
 | `--opd-type` | Type of OPD: `sglang` or `megatron`. Required when `--use-opd` is set. |
-| `--opd-kl-coef` | OPD KL penalty coefficient (default: 1.0). |
-| `--opd-teacher-load` | Path to teacher checkpoint. **Required** when `--opd-type=megatron`, **must not be set** when `--opd-type=sglang`. |
-| `--opd-teacher-ckpt-step` | Optional checkpoint step for teacher model. |
+| `--opd-kl-coef` | OPD KL penalty coefficient (default: 1.0). The teacher KL is added to advantages as: `opd_advantage = base_advantage - opd_kl_coef * (student_logp - teacher_logp)`. Larger values pull the student more strongly toward the teacher. |
+| `--opd-teacher-load` | Path to teacher checkpoint directory. **Required** when `--opd-type=megatron`, **must not be set** when `--opd-type=sglang`. |
+| `--opd-teacher-ckpt-step` | Optional. Selects a specific iteration inside `--opd-teacher-load` (overrides `latest_checkpointed_iteration.txt`). Mirrors `--ref-ckpt-step`. Leave unset to use the latest checkpoint in the directory. |
 
 ## Mode Comparison
 
 | Mode | Teacher Location | When to use |
 |------|------------------|-------------|
-| `sglang` | External SGLang server | Teacher has different architecture or larger than GPU memory |
-| `megatron` | Loaded into Megatron training | Teacher has same architecture as policy/ref model |
+| `sglang` | External SGLang server | Teacher has different architecture, or is larger than fits alongside the policy in training memory |
+| `megatron` | Loaded into Megatron training | Teacher shares architecture with the policy/ref model |
+
+**Which mode should I pick?** If the teacher fits in the training process and shares architecture with the policy, prefer `megatron`. Teacher log-probs are computed in the same forward pass with the same kernels, dtypes, and tokenization as the student, which avoids subtle numerical drift from a separate inference engine and removes the need to manage a second server. Use `sglang` when those constraints can't be met (different architecture, teacher too large to co-locate, or you already have a teacher server you want to reuse).
 
 ## Components
 

--- a/examples/on_policy_distillation/README.md
+++ b/examples/on_policy_distillation/README.md
@@ -1,17 +1,44 @@
 # On-Policy Distillation Example
 
-This example shows how to run **on-policy distillation** using miles. A small student (Qwen3-8B) is aligned to imitate a larger teacher (Qwen3-32B) by training only on the student's own rollouts and matching the teacher's token-level log-probabilities.
+This example shows how to run **on-policy distillation (OPD)** using miles. A small student (Qwen3-8B) is aligned to imitate a larger teacher (Qwen3-32B) by training only on the student's own rollouts and matching the teacher's token-level log-probabilities.
 
-In this example, the teacher model acts as a reward model (RM) by providing teacher log probabilities as the supervision signal.
+## Key Features
+
+- **OPD is orthogonal to advantage estimators**: OPD works as an additive KL penalty on top of any advantage estimator (GRPO, PPO, REINFORCE++, etc.), not as a separate estimator.
+- **Two teacher modes**:
+  - **sglang**: Teacher runs on an external SGLang server, teacher log-probs are obtained during rollout.
+  - **megatron**: Teacher is loaded directly into Megatron via `--opd-teacher-load`, teacher log-probs are computed during training forward pass.
+
+## Key Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `--use-opd` | Enable on-policy distillation. Required flag to use OPD. |
+| `--opd-type` | Type of OPD: `sglang` or `megatron`. Required when `--use-opd` is set. |
+| `--opd-kl-coef` | OPD KL penalty coefficient (default: 1.0). The teacher KL is added to advantages as: `opd_advantage = base_advantage - opd_kl_coef * (student_logp - teacher_logp)`. Larger values pull the student more strongly toward the teacher. |
+| `--opd-teacher-load` | Path to teacher checkpoint directory. **Required** when `--opd-type=megatron`, **must not be set** when `--opd-type=sglang`. |
+| `--opd-teacher-ckpt-step` | Optional. Selects a specific iteration inside `--opd-teacher-load` (overrides `latest_checkpointed_iteration.txt`). Mirrors `--ref-ckpt-step`. Leave unset to use the latest checkpoint in the directory. |
+
+## Mode Comparison
+
+| Mode | Teacher Location | When to use |
+|------|------------------|-------------|
+| `sglang` | External SGLang server | Teacher has different architecture, or is larger than fits alongside the policy in training memory |
+| `megatron` | Loaded into Megatron training | Teacher shares architecture with the policy/ref model |
+
+**Which mode should I pick?** If the teacher fits in the training process and shares architecture with the policy, prefer `megatron`. Teacher log-probs are computed in the same forward pass with the same kernels, dtypes, and tokenization as the student, which avoids subtle numerical drift from a separate inference engine and removes the need to manage a second server. Use `sglang` when those constraints can't be met (different architecture, teacher too large to co-locate, or you already have a teacher server you want to reuse).
 
 ## Components
 
-- `on_policy_distillation.py` implements::
+- `on_policy_distillation.py` implements (for SGLang mode):
   - `reward_func` calls the teacher server (via `args.rm_url`) with every sample to obtain token-level logprobs.
   - `post_process_rewards` trims the teacher logprobs to the generated response span and writes the tensors back to each `Sample` to compute advantages.
 - `run-qwen3-8B-opd.sh` launches an SGLang teacher server, then submits a Ray job that runs `train.py`.
+- `run-qwen3-8B-opd-megatron.sh` uses Megatron-loaded teacher model (no external server needed).
 
 ## Running the example
+
+### Using SGLang Teacher (External Server)
 
 1. Download or prepare the required checkpoints and data.
 ```bash
@@ -30,9 +57,36 @@ PYTHONPATH=/root/Megatron-LM python tools/convert_hf_to_torch_dist.py \
     --hf-checkpoint /root/Qwen3-8B \
     --save /root/Qwen3-8B_torch_dist
 ```
-3. run on-policy distillation:
+
+3. Run on-policy distillation:
 ```bash
 bash examples/on_policy_distillation/run-qwen3-8B-opd.sh
+```
+
+### Using Megatron Teacher (No External Server)
+
+1. Prepare student checkpoint (same as above).
+
+2. **IMPORTANT**: Convert your teacher model to Megatron format (change the path to your actual teacher):
+```bash
+# This example uses the same model as both student and teacher (for demonstration only)
+# In practice, use a different (stronger) model as the teacher!
+cd /root/miles
+source scripts/models/qwen3-8B.sh  # Or your teacher model config
+
+PYTHONPATH=/root/Megatron-LM python tools/convert_hf_to_torch_dist.py \
+    ${MODEL_ARGS[@]} \
+    --hf-checkpoint /root/YourTeacherModel \
+    --save /root/YourTeacherModel_torch_dist
+```
+
+3. Edit `run-qwen3-8B-opd-megatron.sh` to update paths:
+   - Change `--opd-teacher-load` to your teacher model path
+   - Adjust `--opd-kl-coef` based on your task
+
+4. Run:
+```bash
+bash examples/on_policy_distillation/run-qwen3-8B-opd-megatron.sh
 ```
 
 
@@ -47,10 +101,25 @@ Using Qwen3-8B-Base model sfted on part of the [OpenThoughts3-1.2M](https://hugg
 
 
 
-
 # FAQ
-1. **Why are teacher logits computed via a sglang server instead of inside the training backend?**
-The teacher runs on an independent SGLang server that miles treats as a reward model. Hosting it inside Megatron/FSDP would require maintaining a second, fully configured training stack for the teacher.
+1. **Why are there two OPD modes?**
+   - `sglang` mode: The teacher runs on an independent SGLang server. This is useful when the teacher has a different architecture or is too large to load together with the policy model.
+   - `megatron` mode: The teacher is loaded into Megatron using the same parameter loading mechanism as the reference model. This requires the teacher to have the same architecture as the policy model.
+
+2. **How do I use Megatron-based teacher instead of SGLang server?**
+   Replace your OPD arguments:
+   ```bash
+   # Instead of:
+   --use-opd --opd-type sglang --opd-kl-coef 1.0
+   # Use:
+   --use-opd --opd-type megatron --opd-kl-coef 1.0 --opd-teacher-load /path/to/teacher_checkpoint
+   ```
+
+3. **What happens if I set wrong arguments?**
+   The system will raise clear errors:
+   - `--use-opd` without `--opd-type`: Error asking you to specify type
+   - `--opd-type megatron` without `--opd-teacher-load`: Error asking for teacher checkpoint
+   - `--opd-type sglang` with `--opd-teacher-load`: Error indicating conflict
 
 
 # References

--- a/examples/on_policy_distillation/on_policy_distillation.py
+++ b/examples/on_policy_distillation/on_policy_distillation.py
@@ -24,11 +24,25 @@ async def reward_func(args, sample, **kwargs):
 
 
 def post_process_rewards(args, samples: list[Sample], **kwargs):
-    rewards = [sample.get_reward_value(args) for sample in samples]
+    """Process rewards from teacher model and extract teacher log probabilities.
+
+    This function:
+    1. Extracts teacher log-probs from the reward response (which contains sglang's logprob output)
+    2. Trims them to match the response length
+    3. Stores them in sample.teacher_log_probs for OPD KL penalty computation
+    4. Returns scalar rewards (0.0 for pure distillation) compatible with GRPO/PPO
+
+    Note: The reward_func calls the teacher server which returns token-level log-probs.
+    For pure on-policy distillation without task rewards, we return 0.0 for each sample.
+    The actual learning signal comes from the OPD KL penalty applied in compute_advantages_and_returns.
+    """
+    raw_rewards = [sample.get_reward_value(args) for sample in samples]
     response_lengths = [sample.response_length for sample in samples]
+
+    # Extract teacher log-probs from the sglang response
     teacher_log_probs = [
         torch.tensor([item[0] for item in reward["meta_info"]["input_token_logprobs"][1:]], dtype=torch.float32)
-        for reward in rewards
+        for reward in raw_rewards
     ]
     teacher_log_probs = [
         t_log_prob[-response_length:]
@@ -38,4 +52,10 @@ def post_process_rewards(args, samples: list[Sample], **kwargs):
     for sample, t_log_probs in zip(samples, teacher_log_probs, strict=False):
         sample.teacher_log_probs = t_log_probs
 
-    return teacher_log_probs, teacher_log_probs
+    # Return scalar rewards for GRPO/PPO advantage estimator
+    # For pure on-policy distillation, we use 0.0 as the task reward.
+    # The learning signal comes entirely from the OPD KL penalty.
+    # If you have task rewards, you can add them here.
+    scalar_rewards = [0.0] * len(samples)
+
+    return scalar_rewards, scalar_rewards

--- a/examples/on_policy_distillation/run-qwen3-8B-opd-megatron.sh
+++ b/examples/on_policy_distillation/run-qwen3-8B-opd-megatron.sh
@@ -1,38 +1,15 @@
 #!/bin/bash
 
-# usage: bash examples/on_policy_distillation/run-qwen3-8B-opd.sh
+# On-Policy Distillation with Megatron-based teacher model
+# This example uses the original model as the teacher (self-distillation for demonstration)
+# 
+# IMPORTANT: This is just an example configuration!
+# In practice, you should:
+# 1. Use a different (stronger) model as the teacher
+# 2. Adjust --opd-kl-coef based on your task
+# 3. Configure proper evaluation metrics
 
 set -ex
-
-
-# Start the teacher model server
-TEACHER_IP="127.0.0.1" # Use localhost here, you can change it to your IP
-TEACHER_PORT=13141
-LOG_FILE="/tmp/sglang_$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 6).log"
-
-## Launch the teacher model server in the background
-CUDA_VISIBLE_DEVICES=7 python3 -m sglang.launch_server \
-    --model-path /root/Qwen3-32B \
-    --host 0.0.0.0 \
-    --port $TEACHER_PORT \
-    --tp 1 \
-    --chunked-prefill-size 4096 \
-    --mem-fraction-static 0.6 \
-    > "$LOG_FILE" 2>&1 &
-
-echo "Starting teacher model server..."
-
-## Wait for the teacher model server to be ready
-until curl -sf http://$TEACHER_IP:$TEACHER_PORT/health_generate > /dev/null; do
-    echo "Waiting for the teacher model server to start..."
-    tail -n 10 "$LOG_FILE"
-    sleep 5
-done
-
-curl http://$TEACHER_IP:$TEACHER_PORT/get_model_info
-echo "Teacher model server is up and running at $TEACHER_IP:$TEACHER_PORT."
-sleep 10
-
 
 export PYTHONBUFFERED=16
 
@@ -71,9 +48,7 @@ ROLLOUT_ARGS=(
 )
 
 RM_ARGS=(
-   --custom-rm-path examples.on_policy_distillation.on_policy_distillation.reward_func
-   --custom-reward-post-process-path examples.on_policy_distillation.on_policy_distillation.post_process_rewards
-   --rm-url http://$TEACHER_IP:$TEACHER_PORT/generate
+   --rm-type math
 )
 
 EVAL_ARGS=(
@@ -102,10 +77,15 @@ PERF_ARGS=(
 )
 
 GRPO_ARGS=(
-   --advantage-estimator grpo
-   --use-opd
-   --opd-type sglang
-   --opd-kl-coef 1.0
+   --advantage-estimator grpo  # Base advantage estimator (can be ppo, grpo, etc.)
+
+   # OPD Configuration
+   --use-opd                   # Enable on-policy distillation
+   --opd-type megatron         # Use Megatron forward for teacher
+   --opd-kl-coef 1.0           # CHANGE THIS: KL penalty coefficient
+   # Teacher model configuration (CHANGE THIS to a stronger model!)
+   --opd-teacher-load /root/Qwen3-8B_torch_dist  # Teacher model path
+
    --use-kl-loss
    --kl-loss-coef 0.00
    --kl-loss-type low_var_kl
@@ -124,7 +104,7 @@ OPTIMIZER_ARGS=(
 WANDB_ARGS=(
    #--use-wandb
    # --wandb-project miles-dev
-   # --wandb-group qwen3-8B-test
+   # --wandb-group qwen3-8B-opd-megatron
    # --wandb-key ${WANDB_KEY}
 )
 
@@ -184,9 +164,3 @@ pkill -9 python
 sleep 3
 pkill -9 ray
 pkill -9 python
-
-
-
-
-
-

--- a/miles/backends/experimental/fsdp_utils/actor.py
+++ b/miles/backends/experimental/fsdp_utils/actor.py
@@ -56,8 +56,8 @@ class FSDPTrainRayActor(TrainRayActor):
     """
 
     @with_defer(lambda: Timer().start("train_wait"))
-    def init(self, args: Namespace, role: str, with_ref: bool = False) -> int:  # type: ignore[override]
-        super().init(args, role, with_ref)
+    def init(self, args: Namespace, role: str, with_ref: bool = False, with_opd_teacher: bool = False) -> int:  # type: ignore[override]
+        super().init(args, role, with_ref, with_opd_teacher=with_opd_teacher)
 
         if args.dumper_enable:
             from sglang.srt.debug_utils.dumper import dumper

--- a/miles/backends/megatron_utils/actor.py
+++ b/miles/backends/megatron_utils/actor.py
@@ -54,10 +54,11 @@ class MegatronTrainRayActor(TrainRayActor):
         args: Namespace,
         role: str,
         with_ref: bool = False,
+        with_opd_teacher: bool = False,
     ) -> int | None:
         monkey_patch_torch_dist()
 
-        super().init(args, role, with_ref)
+        super().init(args, role, with_ref, with_opd_teacher=with_opd_teacher)
 
         init(args)
 
@@ -147,6 +148,10 @@ class MegatronTrainRayActor(TrainRayActor):
 
         if with_ref:
             self.load_other_checkpoint("ref", args.ref_load)
+
+        # Load teacher model for Megatron-based on-policy distillation
+        if with_opd_teacher:
+            self.load_other_checkpoint("teacher", args.opd_teacher_load)
 
         if self.args.keep_old_actor:
             # Load old_actor checkpoint
@@ -392,6 +397,17 @@ class MegatronTrainRayActor(TrainRayActor):
                             store_prefix="ref_",
                         )
                     )
+                # Forward teacher model to get teacher_log_probs for Megatron-based OPD
+                if "teacher" in self.weights_backuper.backup_tags:
+                    self._set_replay_stage("fallthrough")
+                    self._switch_model("teacher")
+                    rollout_data.update(
+                        self.compute_log_prob(
+                            data_iterator,
+                            num_microbatches,
+                            store_prefix="teacher_",
+                        )
+                    )
                 self._switch_model("old_actor" if self.args.keep_old_actor else "actor")
                 if not self.args.use_rollout_logprobs or self.args.get_mismatch_metrics:
                     for m in all_replay_managers:
@@ -567,6 +583,10 @@ class MegatronTrainRayActor(TrainRayActor):
             old_ckpt_step = self.args.ckpt_step
             self.args.ckpt_step = self.args.ref_ckpt_step
 
+        if model_tag == "teacher" and self.args.opd_teacher_ckpt_step is not None:
+            old_ckpt_step = self.args.ckpt_step
+            self.args.ckpt_step = self.args.opd_teacher_ckpt_step
+
         _, _ = load_checkpoint(
             self.model,
             None,
@@ -577,6 +597,9 @@ class MegatronTrainRayActor(TrainRayActor):
         self.args.load, self.args.no_load_optim, self.args.no_load_rng, self.args.finetune = old_args
 
         if model_tag == "ref" and self.args.ref_ckpt_step is not None:
+            self.args.ckpt_step = old_ckpt_step
+
+        if model_tag == "teacher" and self.args.opd_teacher_ckpt_step is not None:
             self.args.ckpt_step = old_ckpt_step
 
         self.weights_backuper.backup(model_tag)

--- a/miles/backends/megatron_utils/actor.py
+++ b/miles/backends/megatron_utils/actor.py
@@ -579,6 +579,8 @@ class MegatronTrainRayActor(TrainRayActor):
         self.args.no_load_rng = True
         self.args.finetune = True
 
+        # load_checkpoint reads self.args.ckpt_step to pick which iteration to load.
+        # Temporarily override it for ref/teacher loads, then restore after the load below.
         if model_tag == "ref" and self.args.ref_ckpt_step is not None:
             old_ckpt_step = self.args.ckpt_step
             self.args.ckpt_step = self.args.ref_ckpt_step

--- a/miles/backends/megatron_utils/actor.py
+++ b/miles/backends/megatron_utils/actor.py
@@ -238,7 +238,7 @@ class MegatronTrainRayActor(TrainRayActor):
     @property
     def _enable_weight_backup(self) -> bool:
         """Weight backup is only needed for CPU-side model switching or colocated tensor weight sync."""
-        return self.with_ref or self.args.keep_old_actor or self.args.colocate
+        return self.with_ref or self.with_opd_teacher or self.args.keep_old_actor or self.args.colocate
 
     def _switch_model(self, target_tag: str) -> None:
         if not self._enable_weight_backup:

--- a/miles/backends/megatron_utils/actor.py
+++ b/miles/backends/megatron_utils/actor.py
@@ -58,10 +58,11 @@ class MegatronTrainRayActor(TrainRayActor):
         args: Namespace,
         role: str,
         with_ref: bool = False,
+        with_opd_teacher: bool = False,
     ) -> int | None:
         monkey_patch_torch_dist()
 
-        super().init(args, role, with_ref)
+        super().init(args, role, with_ref, with_opd_teacher=with_opd_teacher)
 
         for m in all_replay_managers:
             m.register_replay_list_func = register_replay_list_sequential
@@ -156,6 +157,10 @@ class MegatronTrainRayActor(TrainRayActor):
 
         if with_ref:
             self.load_other_checkpoint("ref", args.ref_load)
+
+        # Load teacher model for Megatron-based on-policy distillation
+        if with_opd_teacher:
+            self.load_other_checkpoint("teacher", args.opd_teacher_load)
 
         if self.args.keep_old_actor:
             # Load old_actor checkpoint
@@ -342,6 +347,17 @@ class MegatronTrainRayActor(TrainRayActor):
                             store_prefix="ref_",
                         )
                     )
+                # Forward teacher model to get teacher_log_probs for Megatron-based OPD
+                if "teacher" in self.weights_backuper.backup_tags:
+                    self._set_replay_stage("fallthrough")
+                    self._switch_model("teacher")
+                    rollout_data.update(
+                        self.compute_log_prob(
+                            data_iterator,
+                            num_microbatches,
+                            store_prefix="teacher_",
+                        )
+                    )
                 self._switch_model("old_actor" if self.args.keep_old_actor else "actor")
                 if not self.args.use_rollout_logprobs or self.args.get_mismatch_metrics:
                     for m in all_replay_managers:
@@ -512,9 +528,15 @@ class MegatronTrainRayActor(TrainRayActor):
         self.args.no_load_rng = True
         self.args.finetune = True
 
+        # load_checkpoint reads self.args.ckpt_step to pick which iteration to load.
+        # Temporarily override it for ref/teacher loads, then restore after the load below.
         if model_tag == "ref" and self.args.ref_ckpt_step is not None:
             old_ckpt_step = self.args.ckpt_step
             self.args.ckpt_step = self.args.ref_ckpt_step
+
+        if model_tag == "teacher" and self.args.opd_teacher_ckpt_step is not None:
+            old_ckpt_step = self.args.ckpt_step
+            self.args.ckpt_step = self.args.opd_teacher_ckpt_step
 
         _, _ = load_checkpoint(
             self.model,
@@ -526,6 +548,9 @@ class MegatronTrainRayActor(TrainRayActor):
         self.args.load, self.args.no_load_optim, self.args.no_load_rng, self.args.finetune = old_args
 
         if model_tag == "ref" and self.args.ref_ckpt_step is not None:
+            self.args.ckpt_step = old_ckpt_step
+
+        if model_tag == "teacher" and self.args.opd_teacher_ckpt_step is not None:
             self.args.ckpt_step = old_ckpt_step
 
         self.weights_backuper.backup(model_tag)

--- a/miles/backends/megatron_utils/model.py
+++ b/miles/backends/megatron_utils/model.py
@@ -395,6 +395,7 @@ def train_one_step(
                 "returns",
                 "rollout_log_probs",
                 "max_seq_lens",
+                "opd_reverse_kl",
             ],
             args.data_pad_size_multiplier,
             args.qkv_format,

--- a/miles/backends/megatron_utils/model.py
+++ b/miles/backends/megatron_utils/model.py
@@ -403,6 +403,7 @@ def train_one_step(
                 "returns",
                 "rollout_log_probs",
                 "max_seq_lens",
+                "opd_reverse_kl",
             ],
             args.data_pad_size_multiplier,
             args.qkv_format,

--- a/miles/backends/training_utils/log_utils.py
+++ b/miles/backends/training_utils/log_utils.py
@@ -133,6 +133,8 @@ def log_rollout_data(rollout_id: int, args: Namespace, rollout_data: RolloutBatc
                     # NOTE: Here we have to do the clone().detach(), otherwise the tensor will be
                     # modified in place and will cause problem for the next rollout.
                     val = torch.cat(val).clone().detach()
+                    if val.device != loss_masks[0].device:
+                        val = val.to(loss_masks[0].device)
                     if key in [
                         "log_probs",
                         "ref_log_probs",

--- a/miles/backends/training_utils/log_utils.py
+++ b/miles/backends/training_utils/log_utils.py
@@ -140,6 +140,8 @@ def log_rollout_data(rollout_id: int, args: Namespace, rollout_data: RolloutBatc
                         "returns",
                         "advantages",
                         "values",
+                        "teacher_log_probs",
+                        "opd_reverse_kl",
                         "entropy",
                     ]:
                         sum_of_sample_mean = get_sum_of_sample_mean(

--- a/miles/backends/training_utils/log_utils.py
+++ b/miles/backends/training_utils/log_utils.py
@@ -134,6 +134,8 @@ def log_rollout_data(rollout_id: int, args: Namespace, rollout_data: RolloutBatc
                     # NOTE: Here we have to do the clone().detach(), otherwise the tensor will be
                     # modified in place and will cause problem for the next rollout.
                     val = torch.cat(val).clone().detach()
+                    if val.device != loss_masks[0].device:
+                        val = val.to(loss_masks[0].device)
                     if key in [
                         "log_probs",
                         "ref_log_probs",
@@ -141,6 +143,8 @@ def log_rollout_data(rollout_id: int, args: Namespace, rollout_data: RolloutBatc
                         "returns",
                         "advantages",
                         "values",
+                        "teacher_log_probs",
+                        "opd_reverse_kl",
                         "entropy",
                     ]:
                         sum_of_sample_mean = get_sum_of_sample_mean(

--- a/miles/backends/training_utils/loss.py
+++ b/miles/backends/training_utils/loss.py
@@ -276,6 +276,47 @@ def get_values(
     return res
 
 
+def apply_opd_kl_to_advantages(
+    args: Namespace,
+    rollout_data: RolloutBatch,
+    advantages: list[torch.Tensor],
+    student_log_probs: list[torch.Tensor] | None,
+) -> None:
+    """Apply on-policy distillation KL penalty to advantages.
+
+    Computes reverse KL (student_logp - teacher_logp) and adds weighted penalty
+    to advantages in-place. This is orthogonal to the base advantage estimator.
+
+    Args:
+        args: Configuration containing `use_opd` and `opd_kl_coef`.
+        rollout_data: Dict containing "teacher_log_probs".
+        advantages: List of advantage tensors to modify in-place.
+        student_log_probs: List of student log-probability tensors.
+
+    References:
+        https://github.com/thinking-machines-lab/tinker-cookbook/blob/main/tinker_cookbook/distillation/train_on_policy.py
+    """
+
+    if student_log_probs is None:
+        return
+
+    teacher_log_probs = rollout_data.get("teacher_log_probs")
+    if teacher_log_probs is None:
+        raise ValueError(f"OPD with opd_type='{args.opd_type}' requires teacher_log_probs, but it is missing.")
+
+    device = student_log_probs[0].device
+    teacher_log_probs = [t.to(device=device) for t in teacher_log_probs]
+
+    reverse_kls = []
+    for i, adv in enumerate(advantages):
+        reverse_kl = student_log_probs[i] - teacher_log_probs[i]
+        advantages[i] = adv - args.opd_kl_coef * reverse_kl
+        reverse_kls.append(reverse_kl)
+
+    # Store reverse KL for logging
+    rollout_data["opd_reverse_kl"] = reverse_kls
+
+
 def compute_advantages_and_returns(args: Namespace, rollout_data: RolloutBatch) -> None:
     """Compute advantages and returns in-place based on `args.advantage_estimator`.
 
@@ -368,24 +409,17 @@ def compute_advantages_and_returns(args: Namespace, rollout_data: RolloutBatch) 
         )
         returns = advantages
 
-    elif args.advantage_estimator == "on_policy_distillation":
-        student_log_probs = log_probs
-        teacher_log_probs = rollout_data.get("teacher_log_probs")
-        response_lengths = rollout_data.get("response_lengths")
-        device = student_log_probs[0].device
-        teacher_log_probs = [t_log_prob.to(device=device) for t_log_prob in teacher_log_probs]
-        teacher_log_probs = [
-            t_log_prob[-response_length:]
-            for t_log_prob, response_length in zip(teacher_log_probs, response_lengths, strict=False)
-        ]
-        advantages = [
-            teacher_log_prob - student_log_prob
-            for teacher_log_prob, student_log_prob in zip(teacher_log_probs, student_log_probs, strict=False)
-        ]
-        returns = advantages
-
     else:
         raise NotImplementedError(f"advantage_estimator {args.advantage_estimator} is not supported. ")
+
+    # Apply on-policy distillation KL penalty to advantages (orthogonal to advantage estimator)
+    if args.use_opd:
+        apply_opd_kl_to_advantages(
+            args=args,
+            rollout_data=rollout_data,
+            advantages=advantages,
+            student_log_probs=log_probs,
+        )
 
     # TODO: OpenRLHF always does advantages normalization but veRL doesn't seem to do it.
     if args.normalize_advantages:
@@ -712,6 +746,11 @@ def policy_loss_function(
 
     if args.use_opsm:
         reported_loss["opsm_clipfrac"] = opsm_clipfrac
+
+    # Add OPD metrics if available
+    if "opd_reverse_kl" in batch:
+        opd_reverse_kl = torch.cat(batch["opd_reverse_kl"], dim=0)
+        reported_loss["opd_reverse_kl"] = sum_of_sample_mean(opd_reverse_kl).clone().detach()
 
     return loss, reported_loss
 

--- a/miles/backends/training_utils/loss.py
+++ b/miles/backends/training_utils/loss.py
@@ -748,7 +748,7 @@ def policy_loss_function(
         reported_loss["opsm_clipfrac"] = opsm_clipfrac
 
     # Add OPD metrics if available
-    if "opd_reverse_kl" in batch:
+    if batch.get("opd_reverse_kl") is not None:
         opd_reverse_kl = torch.cat(batch["opd_reverse_kl"], dim=0)
         reported_loss["opd_reverse_kl"] = sum_of_sample_mean(opd_reverse_kl).clone().detach()
 

--- a/miles/backends/training_utils/loss.py
+++ b/miles/backends/training_utils/loss.py
@@ -8,66 +8,9 @@ from miles.backends.training_utils.loss_hub.advantages import compute_advantages
 from miles.backends.training_utils.loss_hub.logit_processors import get_log_probs_and_entropy, get_values  # noqa: F401
 from miles.backends.training_utils.loss_hub.losses import get_loss_function
 from miles.backends.training_utils.loss_hub.math_utils import compute_approx_kl
+from miles.backends.training_utils.loss_hub.opd import apply_opd_kl_to_advantages
 from miles.backends.training_utils.parallel import get_parallel_state
 from miles.utils.types import RolloutBatch
-
-
-def apply_opd_kl_to_advantages(
-    args: Namespace,
-    rollout_data: RolloutBatch,
-    advantages: list[torch.Tensor],
-    student_log_probs: list[torch.Tensor] | None,
-) -> None:
-    """Apply on-policy distillation KL penalty to advantages.
-
-    Computes reverse KL (student_logp - teacher_logp) and adds weighted penalty
-    to advantages in-place. This is orthogonal to the base advantage estimator.
-
-    Args:
-        args: Configuration containing `use_opd` and `opd_kl_coef`.
-        rollout_data: Dict containing "teacher_log_probs".
-        advantages: List of advantage tensors to modify in-place.
-        student_log_probs: List of student log-probability tensors.
-
-    References:
-        https://github.com/thinking-machines-lab/tinker-cookbook/blob/main/tinker_cookbook/distillation/train_on_policy.py
-    """
-
-    if student_log_probs is None:
-        return
-
-    teacher_log_probs = rollout_data.get("teacher_log_probs")
-    if teacher_log_probs is None:
-        raise ValueError(f"OPD with opd_type='{args.opd_type}' requires teacher_log_probs, but it is missing.")
-
-    if not (len(advantages) == len(student_log_probs) == len(teacher_log_probs)):
-        raise ValueError(
-            f"OPD length mismatch: advantages={len(advantages)}, "
-            f"student_log_probs={len(student_log_probs)}, teacher_log_probs={len(teacher_log_probs)}."
-        )
-
-    device = student_log_probs[0].device
-    teacher_log_probs = [t.to(device=device) for t in teacher_log_probs]
-
-    reverse_kls = []
-    for i, adv in enumerate(advantages):
-        if student_log_probs[i].shape != teacher_log_probs[i].shape:
-            raise ValueError(
-                f"OPD shape mismatch at sample {i}: student_log_probs={tuple(student_log_probs[i].shape)}, "
-                f"teacher_log_probs={tuple(teacher_log_probs[i].shape)}."
-            )
-        if adv.shape != student_log_probs[i].shape:
-            raise ValueError(
-                f"OPD shape mismatch at sample {i}: advantages={tuple(adv.shape)}, "
-                f"student_log_probs={tuple(student_log_probs[i].shape)}. "
-                "OPD expects per-token advantages; broadcast scalar advantages must be expanded before this call."
-            )
-        reverse_kl = student_log_probs[i] - teacher_log_probs[i]
-        advantages[i] = adv - args.opd_kl_coef * reverse_kl
-        reverse_kls.append(reverse_kl)
-
-    # Store reverse KL for logging
-    rollout_data["opd_reverse_kl"] = reverse_kls
 
 
 def compute_advantages_and_returns(args: Namespace, rollout_data: RolloutBatch) -> None:

--- a/miles/backends/training_utils/loss.py
+++ b/miles/backends/training_utils/loss.py
@@ -12,13 +12,72 @@ from miles.backends.training_utils.parallel import get_parallel_state
 from miles.utils.types import RolloutBatch
 
 
+def apply_opd_kl_to_advantages(
+    args: Namespace,
+    rollout_data: RolloutBatch,
+    advantages: list[torch.Tensor],
+    student_log_probs: list[torch.Tensor] | None,
+) -> None:
+    """Apply on-policy distillation KL penalty to advantages.
+
+    Computes reverse KL (student_logp - teacher_logp) and adds weighted penalty
+    to advantages in-place. This is orthogonal to the base advantage estimator.
+
+    Args:
+        args: Configuration containing `use_opd` and `opd_kl_coef`.
+        rollout_data: Dict containing "teacher_log_probs".
+        advantages: List of advantage tensors to modify in-place.
+        student_log_probs: List of student log-probability tensors.
+
+    References:
+        https://github.com/thinking-machines-lab/tinker-cookbook/blob/main/tinker_cookbook/distillation/train_on_policy.py
+    """
+
+    if student_log_probs is None:
+        return
+
+    teacher_log_probs = rollout_data.get("teacher_log_probs")
+    if teacher_log_probs is None:
+        raise ValueError(f"OPD with opd_type='{args.opd_type}' requires teacher_log_probs, but it is missing.")
+
+    if not (len(advantages) == len(student_log_probs) == len(teacher_log_probs)):
+        raise ValueError(
+            f"OPD length mismatch: advantages={len(advantages)}, "
+            f"student_log_probs={len(student_log_probs)}, teacher_log_probs={len(teacher_log_probs)}."
+        )
+
+    device = student_log_probs[0].device
+    teacher_log_probs = [t.to(device=device) for t in teacher_log_probs]
+
+    reverse_kls = []
+    for i, adv in enumerate(advantages):
+        if student_log_probs[i].shape != teacher_log_probs[i].shape:
+            raise ValueError(
+                f"OPD shape mismatch at sample {i}: student_log_probs={tuple(student_log_probs[i].shape)}, "
+                f"teacher_log_probs={tuple(teacher_log_probs[i].shape)}."
+            )
+        if adv.shape != student_log_probs[i].shape:
+            raise ValueError(
+                f"OPD shape mismatch at sample {i}: advantages={tuple(adv.shape)}, "
+                f"student_log_probs={tuple(student_log_probs[i].shape)}. "
+                "OPD expects per-token advantages; broadcast scalar advantages must be expanded before this call."
+            )
+        reverse_kl = student_log_probs[i] - teacher_log_probs[i]
+        advantages[i] = adv - args.opd_kl_coef * reverse_kl
+        reverse_kls.append(reverse_kl)
+
+    # Store reverse KL for logging
+    rollout_data["opd_reverse_kl"] = reverse_kls
+
+
 def compute_advantages_and_returns(args: Namespace, rollout_data: RolloutBatch) -> None:
     """Compute advantages and returns in-place based on `args.advantage_estimator`.
 
     This function extracts rewards, log-probs, values, and masks from
     `rollout_data`, computes KL divergences, then applies the chosen advantage
     estimator. Supported methods: "grpo", "gspo", "ppo", "reinforce_plus_plus",
-    "reinforce_plus_plus_baseline", and "on_policy_distillation". When
+    and "reinforce_plus_plus_baseline". On-policy distillation (OPD) is applied
+    orthogonally on top of any estimator via `args.use_opd`. When
     `args.normalize_advantages` is True, advantages are whitened across the
     data-parallel group using masked statistics.
 
@@ -69,8 +128,16 @@ def compute_advantages_and_returns(args: Namespace, rollout_data: RolloutBatch) 
         total_lengths=total_lengths,
         response_lengths=response_lengths,
         values=values,
-        teacher_log_probs=rollout_data.get("teacher_log_probs"),
     )
+
+    # Apply on-policy distillation KL penalty to advantages (orthogonal to advantage estimator)
+    if args.use_opd:
+        apply_opd_kl_to_advantages(
+            args=args,
+            rollout_data=rollout_data,
+            advantages=advantages,
+            student_log_probs=log_probs,
+        )
 
     if args.normalize_advantages:
         advantages = normalize_advantages(args, advantages, loss_masks, total_lengths, response_lengths, max_seq_lens)

--- a/miles/backends/training_utils/loss.py
+++ b/miles/backends/training_utils/loss.py
@@ -304,11 +304,28 @@ def apply_opd_kl_to_advantages(
     if teacher_log_probs is None:
         raise ValueError(f"OPD with opd_type='{args.opd_type}' requires teacher_log_probs, but it is missing.")
 
+    if not (len(advantages) == len(student_log_probs) == len(teacher_log_probs)):
+        raise ValueError(
+            f"OPD length mismatch: advantages={len(advantages)}, "
+            f"student_log_probs={len(student_log_probs)}, teacher_log_probs={len(teacher_log_probs)}."
+        )
+
     device = student_log_probs[0].device
     teacher_log_probs = [t.to(device=device) for t in teacher_log_probs]
 
     reverse_kls = []
     for i, adv in enumerate(advantages):
+        if student_log_probs[i].shape != teacher_log_probs[i].shape:
+            raise ValueError(
+                f"OPD shape mismatch at sample {i}: student_log_probs={tuple(student_log_probs[i].shape)}, "
+                f"teacher_log_probs={tuple(teacher_log_probs[i].shape)}."
+            )
+        if adv.shape != student_log_probs[i].shape:
+            raise ValueError(
+                f"OPD shape mismatch at sample {i}: advantages={tuple(adv.shape)}, "
+                f"student_log_probs={tuple(student_log_probs[i].shape)}. "
+                "OPD expects per-token advantages; broadcast scalar advantages must be expanded before this call."
+            )
         reverse_kl = student_log_probs[i] - teacher_log_probs[i]
         advantages[i] = adv - args.opd_kl_coef * reverse_kl
         reverse_kls.append(reverse_kl)

--- a/miles/backends/training_utils/loss_hub/advantages.py
+++ b/miles/backends/training_utils/loss_hub/advantages.py
@@ -22,7 +22,6 @@ def compute_advantages(
     total_lengths: list[int],
     response_lengths: list[int],
     values: list[torch.Tensor] | None = None,
-    teacher_log_probs: list[torch.Tensor] | None = None,
 ) -> tuple[list[torch.Tensor], list[torch.Tensor]]:
     """Dispatch to the configured advantage estimator.
 
@@ -70,20 +69,6 @@ def compute_advantages(
             loss_masks=loss_masks,
             kl_coef=args.kl_coef,
         )
-        returns = advantages
-
-    elif args.advantage_estimator == "on_policy_distillation":
-        assert teacher_log_probs is not None, "teacher_log_probs required for on_policy_distillation"
-        device = log_probs[0].device
-        teacher_log_probs = [t_log_prob.to(device=device) for t_log_prob in teacher_log_probs]
-        teacher_log_probs = [
-            t_log_prob[-response_length:]
-            for t_log_prob, response_length in zip(teacher_log_probs, response_lengths, strict=False)
-        ]
-        advantages = [
-            teacher_log_prob - student_log_prob
-            for teacher_log_prob, student_log_prob in zip(teacher_log_probs, log_probs, strict=False)
-        ]
         returns = advantages
 
     else:

--- a/miles/backends/training_utils/loss_hub/losses.py
+++ b/miles/backends/training_utils/loss_hub/losses.py
@@ -354,6 +354,11 @@ def policy_loss_function(
     if args.use_opsm:
         reported_loss["opsm_clipfrac"] = opsm_clipfrac
 
+    # Add OPD metrics if available
+    if batch.get("opd_reverse_kl") is not None:
+        opd_reverse_kl = torch.cat(batch["opd_reverse_kl"], dim=0)
+        reported_loss["opd_reverse_kl"] = sum_of_sample_mean(opd_reverse_kl).clone().detach()
+
     return loss, reported_loss
 
 

--- a/miles/backends/training_utils/loss_hub/opd.py
+++ b/miles/backends/training_utils/loss_hub/opd.py
@@ -1,0 +1,63 @@
+from argparse import Namespace
+
+import torch
+
+from miles.utils.types import RolloutBatch
+
+
+def apply_opd_kl_to_advantages(
+    args: Namespace,
+    rollout_data: RolloutBatch,
+    advantages: list[torch.Tensor],
+    student_log_probs: list[torch.Tensor] | None,
+) -> None:
+    """Apply on-policy distillation KL penalty to advantages.
+
+    Computes reverse KL (student_logp - teacher_logp) and adds weighted penalty
+    to advantages in-place. This is orthogonal to the base advantage estimator.
+
+    Args:
+        args: Configuration containing `use_opd` and `opd_kl_coef`.
+        rollout_data: Dict containing "teacher_log_probs".
+        advantages: List of advantage tensors to modify in-place.
+        student_log_probs: List of student log-probability tensors.
+
+    References:
+        https://github.com/thinking-machines-lab/tinker-cookbook/blob/main/tinker_cookbook/distillation/train_on_policy.py
+    """
+
+    if student_log_probs is None:
+        return
+
+    teacher_log_probs = rollout_data.get("teacher_log_probs")
+    if teacher_log_probs is None:
+        raise ValueError(f"OPD with opd_type='{args.opd_type}' requires teacher_log_probs, but it is missing.")
+
+    if not (len(advantages) == len(student_log_probs) == len(teacher_log_probs)):
+        raise ValueError(
+            f"OPD length mismatch: advantages={len(advantages)}, "
+            f"student_log_probs={len(student_log_probs)}, teacher_log_probs={len(teacher_log_probs)}."
+        )
+
+    device = student_log_probs[0].device
+    teacher_log_probs = [t.to(device=device) for t in teacher_log_probs]
+
+    reverse_kls = []
+    for i, adv in enumerate(advantages):
+        if student_log_probs[i].shape != teacher_log_probs[i].shape:
+            raise ValueError(
+                f"OPD shape mismatch at sample {i}: student_log_probs={tuple(student_log_probs[i].shape)}, "
+                f"teacher_log_probs={tuple(teacher_log_probs[i].shape)}."
+            )
+        if adv.shape != student_log_probs[i].shape:
+            raise ValueError(
+                f"OPD shape mismatch at sample {i}: advantages={tuple(adv.shape)}, "
+                f"student_log_probs={tuple(student_log_probs[i].shape)}. "
+                "OPD expects per-token advantages; broadcast scalar advantages must be expanded before this call."
+            )
+        reverse_kl = student_log_probs[i] - teacher_log_probs[i]
+        advantages[i] = adv - args.opd_kl_coef * reverse_kl
+        reverse_kls.append(reverse_kl)
+
+    # Store reverse KL for logging
+    rollout_data["opd_reverse_kl"] = reverse_kls

--- a/miles/ray/actor_group.py
+++ b/miles/ray/actor_group.py
@@ -32,12 +32,14 @@ class RayTrainGroup:
         num_gpus_per_actor: float = 1,
         role: str,
         with_ref: bool,
+        with_opd_teacher: bool = False,
     ) -> None:
         self.args = args
         self._num_nodes = num_nodes
         self._num_gpus_per_node = num_gpus_per_node
         self.role = role
         self.with_ref = with_ref
+        self.with_opd_teacher = with_opd_teacher
 
         # Allocate the GPUs for actors w/o instantiating them
         self._actor_handles = self._allocate_gpus_for_actor(pg, num_gpus_per_actor)
@@ -109,7 +111,9 @@ class RayTrainGroup:
         """
         Allocate GPU resourced and initialize model, optimizer, local ckpt, etc.
         """
-        return await self._broadcast("init", self.args, self.role, with_ref=self.with_ref)
+        return await self._broadcast(
+            "init", self.args, self.role, with_ref=self.with_ref, with_opd_teacher=self.with_opd_teacher
+        )
 
     async def train(self, rollout_id, rollout_data_ref):
         """Do one rollout training"""

--- a/miles/ray/placement_group.py
+++ b/miles/ray/placement_group.py
@@ -122,7 +122,9 @@ def create_placement_groups(args):
     }
 
 
-def allocate_train_group(args, num_nodes, num_gpus_per_node, pg, role: str, with_ref: bool):
+def allocate_train_group(
+    args, num_nodes, num_gpus_per_node, pg, role: str, with_ref: bool, with_opd_teacher: bool = False
+):
     return RayTrainGroup(
         args=args,
         num_nodes=num_nodes,
@@ -131,6 +133,7 @@ def allocate_train_group(args, num_nodes, num_gpus_per_node, pg, role: str, with
         num_gpus_per_actor=0.4,
         role=role,
         with_ref=with_ref,
+        with_opd_teacher=with_opd_teacher,
     )
 
 
@@ -142,6 +145,7 @@ async def create_training_models(args, pgs, rollout_manager):
         pg=pgs["actor"],
         role="actor",
         with_ref=args.kl_coef != 0 or args.use_kl_loss,
+        with_opd_teacher=args.use_opd and args.opd_type == "megatron",
     )
     if args.use_critic:
         critic_model = allocate_train_group(

--- a/miles/ray/rollout.py
+++ b/miles/ray/rollout.py
@@ -727,7 +727,7 @@ class RolloutManager:
         if any(sample.weight_versions for sample in samples):
             train_data["weight_versions"] = [sample.weight_versions for sample in samples]
 
-        if "teacher_log_probs" in samples[0].__dict__:
+        if samples[0].teacher_log_probs is not None:
             train_data["teacher_log_probs"] = [sample.teacher_log_probs for sample in samples]
 
         # Pass dynamic global_batch_size to training side

--- a/miles/ray/rollout/train_data_conversion.py
+++ b/miles/ray/rollout/train_data_conversion.py
@@ -82,7 +82,7 @@ def convert_samples_to_train_data(
     if any(sample.weight_versions for sample in samples):
         train_data["weight_versions"] = [sample.weight_versions for sample in samples]
 
-    if "teacher_log_probs" in samples[0].__dict__:
+    if samples[0].teacher_log_probs is not None:
         train_data["teacher_log_probs"] = [sample.teacher_log_probs for sample in samples]
 
     x = metadata.get("dynamic_global_batch_size")

--- a/miles/ray/train_actor.py
+++ b/miles/ray/train_actor.py
@@ -48,10 +48,11 @@ class TrainRayActor(RayActor):
         # os.environ["LOCAL_RANK"] = str(ray.get_gpu_ids()[0])
         os.environ["LOCAL_RANK"] = str(get_local_gpu_id())
 
-    def init(self, args, role, with_ref=False):
+    def init(self, args, role, with_ref=False, with_opd_teacher=False):
         self.args = args
         self.role = role
         self.with_ref = with_ref
+        self.with_opd_teacher = with_opd_teacher
 
         if env_report := args.env_report:
             collect_and_print_node_env_report(

--- a/miles/ray/train_actor.py
+++ b/miles/ray/train_actor.py
@@ -53,10 +53,11 @@ class TrainRayActor(RayActor):
         # os.environ["LOCAL_RANK"] = str(ray.get_gpu_ids()[0])
         os.environ["LOCAL_RANK"] = str(get_local_gpu_id())
 
-    def init(self, args, role, with_ref=False):
+    def init(self, args, role, with_ref=False, with_opd_teacher=False):
         self.args = args
         self.role = role
         self.with_ref = with_ref
+        self.with_opd_teacher = with_opd_teacher
 
         if env_report := args.env_report:
             collect_and_print_node_env_report(

--- a/miles/rollout/generate_utils/sample_utils.py
+++ b/miles/rollout/generate_utils/sample_utils.py
@@ -27,6 +27,15 @@ def _merge_sample_pair(a: Sample, b: Sample, tokenizer) -> Sample:
         if sample.rollout_log_probs is None:
             sample.rollout_log_probs = [0.0] * sample.response_length
 
+    def _merge_teacher_log_probs():
+        # Optional OPD teacher log-probs: merge like rollout_log_probs when present
+        # (zeros over the injected observation span), else keep None.
+        if a.teacher_log_probs is None and b.teacher_log_probs is None:
+            return None
+        a_tlp = a.teacher_log_probs if a.teacher_log_probs is not None else [0.0] * a.response_length
+        b_tlp = b.teacher_log_probs if b.teacher_log_probs is not None else [0.0] * b.response_length
+        return a_tlp + [0.0] * obs_len + b_tlp
+
     _fill_defaults(a)
     _fill_defaults(b)
 
@@ -62,6 +71,7 @@ def _merge_sample_pair(a: Sample, b: Sample, tokenizer) -> Sample:
             loss_mask=a.loss_mask + [0] * obs_len + b.loss_mask,
             weight_versions=a.weight_versions + b.weight_versions,
             rollout_log_probs=a.rollout_log_probs + [0.0] * obs_len + b.rollout_log_probs,
+            teacher_log_probs=_merge_teacher_log_probs(),
             rollout_routed_experts=b.rollout_routed_experts,
             rollout_indexer_topk=b.rollout_indexer_topk,
             remove_sample=_merge_equal_value("remove_sample"),

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -881,9 +881,12 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                     "reinforce_plus_plus",
                     "reinforce_plus_plus_baseline",
                     "ppo",
-                    "on_policy_distillation",
                 ],
                 default="grpo",
+                help=(
+                    "Advantage estimator to use. Note: on-policy distillation (OPD) is now orthogonal "
+                    "to the advantage estimator. Use --opd-kl-coef > 0 to enable OPD on top of any estimator."
+                ),
             )
             parser.add_argument(
                 "--disable-compute-advantages-and-returns",
@@ -1020,6 +1023,49 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 type=float,
                 default=1e-4,
                 help="The threshold for Off-Policy Sequence Masking (OPSM).",
+            )
+            return parser
+
+        def add_on_policy_distillation_arguments(parser):
+            """Add on-policy distillation (OPD) related arguments.
+
+            OPD is orthogonal to advantage estimators and can be applied on top of
+            any estimator (GRPO, PPO, etc.) by adding a KL penalty to advantages.
+            """
+            parser.add_argument(
+                "--use-opd",
+                action="store_true",
+                default=False,
+                help="Enable on-policy distillation (OPD). Must specify --opd-type when enabled.",
+            )
+            parser.add_argument(
+                "--opd-type",
+                type=str,
+                choices=["sglang", "megatron"],
+                default=None,
+                help=(
+                    "Type of on-policy distillation. "
+                    "'sglang': Teacher log-probs are obtained from external SGLang server during rollout. "
+                    "'megatron': Teacher model is loaded via --opd-teacher-load and forwarded during training."
+                ),
+            )
+            parser.add_argument(
+                "--opd-kl-coef",
+                type=float,
+                default=1.0,
+                help="On-policy distillation KL penalty coefficient. Default is 1.0.",
+            )
+            parser.add_argument(
+                "--opd-teacher-load",
+                type=str,
+                default=None,
+                help=(
+                    "The checkpoint for OPD teacher model. Required when --opd-type=megatron. "
+                    "The teacher model should have the same architecture as policy/ref model."
+                ),
+            )
+            parser.add_argument(
+                "--opd-teacher-ckpt-step", type=int, default=None, help="The checkpoint step for OPD teacher model."
             )
             return parser
 
@@ -1655,6 +1701,7 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
         parser = add_data_arguments(parser)
         parser = add_eval_arguments(parser)
         parser = add_algo_arguments(parser)
+        parser = add_on_policy_distillation_arguments(parser)
         parser = add_lora_arguments(parser)
         parser = add_wandb_arguments(parser)
         parser = add_tensorboard_arguments(parser)
@@ -1843,6 +1890,37 @@ def miles_validate_args(args):
                 f"ref_load {args.ref_load} does not have latest_checkpointed_iteration.txt, "
                 "please make sure it is a valid megatron checkpoint directory."
             )
+
+    # Validate on-policy distillation (OPD) arguments
+    if args.use_opd:
+        if args.opd_type is None:
+            raise ValueError("--opd-type must be specified when --use-opd is enabled. Choose 'sglang' or 'megatron'.")
+
+        if args.opd_type == "megatron":
+            if args.opd_teacher_load is None:
+                raise ValueError(
+                    "--opd-teacher-load is required when --opd-type=megatron. "
+                    "Please provide the path to the teacher model checkpoint."
+                )
+            if not os.path.exists(args.opd_teacher_load):
+                raise FileNotFoundError(
+                    f"opd_teacher_load {args.opd_teacher_load} does not exist, please check the path."
+                )
+            if not os.path.exists(os.path.join(args.opd_teacher_load, "latest_checkpointed_iteration.txt")):
+                logger.info(
+                    f"opd_teacher_load {args.opd_teacher_load} does not have latest_checkpointed_iteration.txt, "
+                    "please make sure it is a valid megatron checkpoint directory."
+                )
+
+        elif args.opd_type == "sglang":
+            if args.opd_teacher_load is not None:
+                raise ValueError(
+                    "--opd-teacher-load should not be set when --opd-type=sglang. "
+                    "In sglang mode, teacher log-probs are obtained from external server during rollout."
+                )
+    else:
+        if args.opd_teacher_load is not None:
+            raise ValueError("--opd-teacher-load is set but --use-opd is not enabled. Please add --use-opd flag.")
 
     # TODO: During loading, we need to set the start_rollout_id here.
     if args.megatron_to_hf_mode == "bridge":

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -929,9 +929,12 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                     "reinforce_plus_plus",
                     "reinforce_plus_plus_baseline",
                     "ppo",
-                    "on_policy_distillation",
                 ],
                 default="grpo",
+                help=(
+                    "Advantage estimator to use. Note: on-policy distillation (OPD) is now orthogonal "
+                    "to the advantage estimator. Use --opd-kl-coef > 0 to enable OPD on top of any estimator."
+                ),
             )
             parser.add_argument(
                 "--disable-compute-advantages-and-returns",
@@ -1080,6 +1083,49 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 type=float,
                 default=1e-4,
                 help="The threshold for Off-Policy Sequence Masking (OPSM).",
+            )
+            return parser
+
+        def add_on_policy_distillation_arguments(parser):
+            """Add on-policy distillation (OPD) related arguments.
+
+            OPD is orthogonal to advantage estimators and can be applied on top of
+            any estimator (GRPO, PPO, etc.) by adding a KL penalty to advantages.
+            """
+            parser.add_argument(
+                "--use-opd",
+                action="store_true",
+                default=False,
+                help="Enable on-policy distillation (OPD). Must specify --opd-type when enabled.",
+            )
+            parser.add_argument(
+                "--opd-type",
+                type=str,
+                choices=["sglang", "megatron"],
+                default=None,
+                help=(
+                    "Type of on-policy distillation. "
+                    "'sglang': Teacher log-probs are obtained from external SGLang server during rollout. "
+                    "'megatron': Teacher model is loaded via --opd-teacher-load and forwarded during training."
+                ),
+            )
+            parser.add_argument(
+                "--opd-kl-coef",
+                type=float,
+                default=1.0,
+                help="On-policy distillation KL penalty coefficient. Default is 1.0.",
+            )
+            parser.add_argument(
+                "--opd-teacher-load",
+                type=str,
+                default=None,
+                help=(
+                    "The checkpoint for OPD teacher model. Required when --opd-type=megatron. "
+                    "The teacher model should have the same architecture as policy/ref model."
+                ),
+            )
+            parser.add_argument(
+                "--opd-teacher-ckpt-step", type=int, default=None, help="The checkpoint step for OPD teacher model."
             )
             return parser
 
@@ -1766,6 +1812,7 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
         parser = add_data_arguments(parser)
         parser = add_eval_arguments(parser)
         parser = add_algo_arguments(parser)
+        parser = add_on_policy_distillation_arguments(parser)
         parser = add_lora_arguments(parser)
         parser = add_wandb_arguments(parser)
         parser = add_mlflow_arguments(parser)
@@ -2014,6 +2061,37 @@ def miles_validate_args(args):
                 f"ref_load {args.ref_load} does not have latest_checkpointed_iteration.txt, "
                 "please make sure it is a valid megatron checkpoint directory."
             )
+
+    # Validate on-policy distillation (OPD) arguments
+    if args.use_opd:
+        if args.opd_type is None:
+            raise ValueError("--opd-type must be specified when --use-opd is enabled. Choose 'sglang' or 'megatron'.")
+
+        if args.opd_type == "megatron":
+            if args.opd_teacher_load is None:
+                raise ValueError(
+                    "--opd-teacher-load is required when --opd-type=megatron. "
+                    "Please provide the path to the teacher model checkpoint."
+                )
+            if not os.path.exists(args.opd_teacher_load):
+                raise FileNotFoundError(
+                    f"opd_teacher_load {args.opd_teacher_load} does not exist, please check the path."
+                )
+            if not os.path.exists(os.path.join(args.opd_teacher_load, "latest_checkpointed_iteration.txt")):
+                logger.info(
+                    f"opd_teacher_load {args.opd_teacher_load} does not have latest_checkpointed_iteration.txt, "
+                    "please make sure it is a valid megatron checkpoint directory."
+                )
+
+        elif args.opd_type == "sglang":
+            if args.opd_teacher_load is not None:
+                raise ValueError(
+                    "--opd-teacher-load should not be set when --opd-type=sglang. "
+                    "In sglang mode, teacher log-probs are obtained from external server during rollout."
+                )
+    else:
+        if args.opd_teacher_load is not None:
+            raise ValueError("--opd-teacher-load is set but --use-opd is not enabled. Please add --use-opd flag.")
 
     # TODO: During loading, we need to set the start_rollout_id here.
     if args.megatron_to_hf_mode == "bridge":

--- a/miles/utils/types.py
+++ b/miles/utils/types.py
@@ -29,6 +29,7 @@ class Sample:
         None  # Routed experts from rollout engine. shape: (num_tokens-1, num_layers, moe_router_topk), dtype=int32
     )
     remove_sample: bool = False
+    teacher_log_probs: list[float] | None = None  # Log probabilities from teacher model for OPD
 
     class Status(Enum):
         PENDING = "pending"

--- a/miles/utils/types.py
+++ b/miles/utils/types.py
@@ -170,6 +170,10 @@ class Sample:
             assert (
                 len(self.rollout_log_probs) == self.response_length
             ), f"rollout_log_probs length ({len(self.rollout_log_probs)}) != response_length ({self.response_length})"
+        if self.teacher_log_probs is not None:
+            assert (
+                len(self.teacher_log_probs) == self.response_length
+            ), f"teacher_log_probs length ({len(self.teacher_log_probs)}) != response_length ({self.response_length})"
         if self.rollout_routed_experts is not None:
             actual = len(self.rollout_routed_experts)
             expect = len(self.tokens) - 1
@@ -190,6 +194,8 @@ class Sample:
         self.response_length -= n
         if self.rollout_log_probs is not None:
             self.rollout_log_probs = self.rollout_log_probs[:-n]
+        if self.teacher_log_probs is not None:
+            self.teacher_log_probs = self.teacher_log_probs[:-n]
         if self.loss_mask is not None:
             self.loss_mask = self.loss_mask[:-n]
         self.response = tokenizer.decode(self.tokens[-self.response_length :]) if self.response_length > 0 else ""

--- a/miles/utils/types.py
+++ b/miles/utils/types.py
@@ -32,6 +32,7 @@ class Sample:
         None  # Indexer topk from rollout engine. shape: (num_tokens-1, num_indexer_layers, index_topk), dtype=int32
     )
     remove_sample: bool = False
+    teacher_log_probs: list[float] | None = None  # Log probabilities from teacher model for OPD
 
     class Status(Enum):
         PENDING = "pending"

--- a/tests/fast/backends/training_utils/loss/loss_test_utils.py
+++ b/tests/fast/backends/training_utils/loss/loss_test_utils.py
@@ -76,6 +76,10 @@ _ARGS_DEFAULTS = dict(
     gamma=1.0,
     lambd=0.95,
     normalize_advantages=False,
+    # on-policy distillation (OPD); orthogonal to the advantage estimator
+    use_opd=False,
+    opd_type=None,
+    opd_kl_coef=1.0,
     # policy_loss_function
     loss_type="policy_loss",
     eps_clip=0.2,

--- a/tests/fast/backends/training_utils/loss/test_loss_snapshot.py
+++ b/tests/fast/backends/training_utils/loss/test_loss_snapshot.py
@@ -62,7 +62,6 @@ CONFIGS = [
         [50, 80],
         [30, 60],
     ),
-    ("opd_b2", dict(advantage_estimator="on_policy_distillation", loss_type="policy_loss"), 2, [40, 60], [20, 40]),
     ("value_loss_b2", dict(advantage_estimator="grpo", loss_type="value_loss"), 2, [30, 50], [15, 35]),
     ("sft_loss_b2", dict(advantage_estimator="grpo", loss_type="sft_loss"), 2, [64, 128], [32, 64]),
     (

--- a/tests/fast/backends/training_utils/loss/test_opd.py
+++ b/tests/fast/backends/training_utils/loss/test_opd.py
@@ -1,0 +1,75 @@
+"""Unit tests for the decoupled on-policy-distillation (OPD) loss path.
+
+`apply_opd_kl_to_advantages` is orthogonal to the advantage estimator: it adds a
+reverse-KL penalty (student_logp - teacher_logp) to per-token advantages. These
+tests cover the math and the guard rails without needing the external loss
+snapshot artifacts.
+"""
+
+from argparse import Namespace
+
+import pytest
+import torch
+
+from miles.backends.training_utils.loss_hub.opd import apply_opd_kl_to_advantages
+
+# This module intentionally has no explicit CI registration call: modules under
+# tests/fast are implicitly assigned to the stage-a-cpu suite by the CI collector
+# (an explicit default-form call would be rejected by the AC-9 meta-test).
+
+
+def _args(opd_kl_coef: float = 1.0) -> Namespace:
+    return Namespace(use_opd=True, opd_type="sglang", opd_kl_coef=opd_kl_coef)
+
+
+def test_subtracts_weighted_reverse_kl_and_stores_metric():
+    args = _args(opd_kl_coef=0.5)
+    student = [torch.tensor([0.0, 1.0])]
+    teacher = [torch.tensor([0.0, 0.0])]
+    advantages = [torch.tensor([2.0, 2.0])]
+    rollout_data = {"teacher_log_probs": teacher}
+
+    apply_opd_kl_to_advantages(args, rollout_data, advantages, student)
+
+    # reverse_kl = student - teacher = [0, 1]; adv - 0.5 * reverse_kl = [2.0, 1.5]
+    assert torch.allclose(advantages[0], torch.tensor([2.0, 1.5]))
+    assert torch.allclose(rollout_data["opd_reverse_kl"][0], torch.tensor([0.0, 1.0]))
+
+
+def test_noop_when_student_log_probs_none():
+    args = _args()
+    advantages = [torch.tensor([1.0, 2.0])]
+    rollout_data = {"teacher_log_probs": [torch.tensor([0.0, 0.0])]}
+
+    apply_opd_kl_to_advantages(args, rollout_data, advantages, None)
+
+    assert torch.allclose(advantages[0], torch.tensor([1.0, 2.0]))
+    assert "opd_reverse_kl" not in rollout_data
+
+
+def test_raises_when_teacher_log_probs_missing():
+    args = _args()
+    with pytest.raises(ValueError, match="requires teacher_log_probs"):
+        apply_opd_kl_to_advantages(args, {}, [torch.tensor([1.0])], [torch.tensor([1.0])])
+
+
+def test_raises_on_length_mismatch():
+    args = _args()
+    rollout_data = {"teacher_log_probs": [torch.tensor([0.0])]}  # 1 sample
+    advantages = [torch.tensor([1.0]), torch.tensor([1.0])]  # 2 samples
+    student = [torch.tensor([1.0]), torch.tensor([1.0])]
+
+    with pytest.raises(ValueError, match="OPD length mismatch"):
+        apply_opd_kl_to_advantages(args, rollout_data, advantages, student)
+
+
+def test_raises_on_scalar_advantage_broadcast_trap():
+    # GRPO-style per-sample scalar advantage must be expanded to per-token first.
+    args = _args()
+    student = [torch.tensor([0.0, 1.0])]
+    teacher = [torch.tensor([0.0, 0.0])]
+    advantages = [torch.tensor([2.0])]  # shape (1,) != student shape (2,)
+    rollout_data = {"teacher_log_probs": teacher}
+
+    with pytest.raises(ValueError, match="OPD shape mismatch"):
+        apply_opd_kl_to_advantages(args, rollout_data, advantages, student)

--- a/tests/fast/rollout/generate_utils/test_openai_endpoint_utils.py
+++ b/tests/fast/rollout/generate_utils/test_openai_endpoint_utils.py
@@ -261,6 +261,64 @@ class TestMultiTurnPrefixChain:
         with pytest.raises(AssertionError, match="b.tokens must start with a.tokens"):
             merge_samples(samples, tok)
 
+    def test_two_turn_merge_propagates_teacher_log_probs(self):
+        """OPD teacher_log_probs merge like rollout_log_probs: per-turn values
+        concatenated with zeros over the injected observation span."""
+        tok = _mock_tokenizer()
+
+        records = [
+            _make_record(prompt_token_ids=[1, 2, 3], output_token_ids=[10, 11], output_log_probs=[-0.1, -0.2]),
+            _make_record(
+                prompt_token_ids=[1, 2, 3, 10, 11, 20, 21],
+                output_token_ids=[30, 31],
+                output_log_probs=[-0.3, -0.4],
+            ),
+        ]
+        input_sample = _make_input_sample()
+        samples = compute_samples_from_openai_records(_ARGS, input_sample, records, tok)
+
+        # OPD attaches per-response-token teacher log-probs to each turn's sample.
+        samples[0].teacher_log_probs = [-1.0, -1.1]
+        samples[1].teacher_log_probs = [-1.2, -1.3]
+
+        merged = merge_samples(samples, tok)
+
+        # resp1 (2) + obs (2 zeros) + resp2 (2)
+        assert merged.teacher_log_probs == [-1.0, -1.1, 0.0, 0.0, -1.2, -1.3]
+        assert len(merged.teacher_log_probs) == merged.response_length
+        merged.validate()  # the new teacher_log_probs length assertion must hold
+
+    def test_two_turn_merge_teacher_log_probs_none_stays_none(self):
+        """Non-OPD runs leave teacher_log_probs unset; merge must keep it None."""
+        tok = _mock_tokenizer()
+
+        records = [
+            _make_record(prompt_token_ids=[1, 2, 3], output_token_ids=[10, 11]),
+            _make_record(prompt_token_ids=[1, 2, 3, 10, 11, 20, 21], output_token_ids=[30, 31]),
+        ]
+        input_sample = _make_input_sample()
+        samples = compute_samples_from_openai_records(_ARGS, input_sample, records, tok)
+
+        merged = merge_samples(samples, tok)
+
+        assert merged.teacher_log_probs is None
+
+    def test_merge_raises_on_teacher_log_probs_length_mismatch(self):
+        """validate() guards teacher_log_probs length (surfaced via merge_samples)."""
+        tok = _mock_tokenizer()
+
+        records = [
+            _make_record(prompt_token_ids=[1, 2, 3], output_token_ids=[10, 11]),
+            _make_record(prompt_token_ids=[1, 2, 3, 10, 11, 20, 21], output_token_ids=[30, 31]),
+        ]
+        input_sample = _make_input_sample()
+        samples = compute_samples_from_openai_records(_ARGS, input_sample, records, tok)
+
+        samples[0].teacher_log_probs = [-1.0]  # length 1 != response_length 2
+
+        with pytest.raises(AssertionError, match="teacher_log_probs length"):
+            merge_samples(samples, tok)
+
 
 # ── test: TITO trailing token trimming ────────────────────────────────
 


### PR DESCRIPTION
## Summary

- **Refactors OPD to be orthogonal to advantage estimators**: OPD is no longer a separate `advantage_estimator` choice. Instead, it works as an additive KL penalty (`--use-opd --opd-kl-coef`) on top of any estimator (GRPO, PPO, REINFORCE++, etc.). This removes the old `on_policy_distillation` advantage estimator.
- **Adds Megatron-based teacher mode** (`--opd-type megatron`): Teacher model is loaded directly into Megatron using the same checkpoint mechanism as the reference model, computing teacher log-probs during the training forward pass. No external SGLang server needed when teacher shares architecture with the policy model.
- **Retains SGLang teacher mode** (`--opd-type sglang`): Existing flow where teacher log-probs come from an external SGLang server during rollout.

## Key changes

- `loss.py`: New `apply_opd_kl_to_advantages()` computes reverse KL (student - teacher) and adds it as a penalty to advantages in-place
- `actor.py`: Loads teacher checkpoint via `load_other_checkpoint("teacher", ...)` and runs teacher forward pass during training
- `arguments.py`: New `--use-opd`, `--opd-type`, `--opd-kl-coef`, `--opd-teacher-load`, `--opd-teacher-ckpt-step` args with validation
- `on_policy_distillation.py`: `post_process_rewards` now returns scalar rewards (0.0 for pure distillation) compatible with any advantage estimator
- `types.py`: Added `teacher_log_probs` field to `Sample`
- New example script `run-qwen3-8B-opd-megatron.sh` and updated README

## Test plan

- [ ] Run `run-qwen3-8B-opd.sh` (SGLang mode) end-to-end and verify training converges
- [ ] Run `run-qwen3-8B-opd-megatron.sh` (Megatron mode) end-to-end and verify teacher forward pass produces valid log-probs
- [ ] Verify `opd_reverse_kl` metric is logged correctly
- [ ] Test argument validation: `--use-opd` without `--opd-type`, `--opd-type megatron` without `--opd-teacher-load`, etc.
- [ ] Verify existing non-OPD training (GRPO, PPO) is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)