### PR TITLE
[doc] [2/N] recommend .py scripts over legacy .sh

### DIFF
--- a/docs/en/examples/deepseek-r1.md
+++ b/docs/en/examples/deepseek-r1.md
@@ -51,12 +51,18 @@ Here, `MASTER_ADDR` is the IP of node0, and `NODE_RANK` indicates the node's ind
 
 ## Executing the Training
 
-On node0, run:
+We recommend using the Python script:
 
 ```bash
 cd miles/
+# Recommended: Python script (handles Ray cluster, download, conversion)
+python scripts/run_deepseek.py train --num-nodes 16
+
+# Legacy: Shell script
 bash scripts/run-deepseek-r1.sh
 ```
+
+When using the legacy shell script, on node0, run `bash scripts/run-deepseek-r1.sh`.
 
 On other nodes, you need to join the Ray cluster with the following command:
 

--- a/docs/en/examples/glm4-9B.md
+++ b/docs/en/examples/glm4-9B.md
@@ -47,6 +47,8 @@ cd /root/miles
 bash scripts/run-glm4-9B.sh
 ```
 
+> **Note**: For GLM-4.7-Flash, a Python-style script is also available: `python scripts/run_glm47_flash.py`.
+
 ### Parameter Introduction
 
 Here, we will briefly introduce the various components of the [run-glm4-9B.sh](https://github.com/radixark/miles/blob/main/scripts/run-glm4-9B.sh) script:

--- a/docs/en/examples/glm4.5-355B-A32B.md
+++ b/docs/en/examples/glm4.5-355B-A32B.md
@@ -32,14 +32,21 @@ Here, `MASTER_ADDR` is the IP of node0, and `NODE_RANK` indicates the node's ind
 
 ## Executing the Training
 
-On node0, run:
+We recommend using the Python script, which handles Ray cluster setup and multi-node coordination automatically:
 
 ```bash
 cd miles/
+# Recommended: Python script
+python scripts/run_glm45_355b_a32b.py train --num-nodes 8
+
+# With FP8 rollout:
+python scripts/run_glm45_355b_a32b.py train --num-nodes 8 --rollout-fp8
+
+# Legacy: Shell script
 bash scripts/run-glm4.5-355B-A32B.sh
 ```
 
-On other nodes, you need to join the Ray cluster with the following command:
+When using the shell script, on other nodes, you need to join the Ray cluster with the following command:
 
 ```bash
 ray start --address=${MASTER_ADDR}:6379 --num-gpus 8 --node-ip-address ${WORKER_IP} --disable-usage-stats"
@@ -67,6 +74,8 @@ source "${SCRIPT_DIR}/models/glm4.5-355B-A32B.sh"
 ```
 
 This reads the model's config from [scripts/models/glm4.5-355B-A32B.sh](https://github.com/radixark/miles/blob/main/scripts/models/glm4.5-355B-A32B.sh). These configs are all Megatron parameters. When training with Megatron, it cannot read the model config from the checkpoint, so we need to configure it ourselves. We provide some examples in [scripts/models](https://github.com/radixark/miles/tree/main/scripts/models/).
+
+> **Note**: The Python script `run_glm45_355b_a32b.py` handles model type resolution automatically via the `megatron_model_type` field.
 
 #### PERF\_ARGS
 

--- a/docs/en/examples/qwen3-30B-A3B.md
+++ b/docs/en/examples/qwen3-30B-A3B.md
@@ -24,12 +24,18 @@ Execute the training script:
 
 ```bash
 cd /root/miles
-bash scripts/run-qwen3-30B-A3B.sh
+# Recommended: Python script (auto downloads, converts, and trains)
+python scripts/run_qwen3_30b_a3b.py --model-dir /root --data-dir /root
+
+# With FP8 rollout:
+python scripts/run_qwen3_30b_a3b.py --rollout-fp8
 ```
+
+Use `python scripts/run_qwen3_30b_a3b.py --help` to see all available options.
 
 ### Parameter Introduction
 
-Here, we will briefly introduce the MoE-related parts in the [run-qwen3-30B-A3B.sh](https://github.com/radixark/miles/blob/main/scripts/run-qwen3-30B-A3B.sh) script.
+Here, we will briefly introduce the MoE-related parts in the [run_qwen3_30b_a3b.py](https://github.com/radixark/miles/blob/main/scripts/run_qwen3_30b_a3b.py) script.
 
 1.  To support running Qwen3-30B-A3B in an 8xH800 environment, we need to enable Megatron's CPU Adam to save GPU memory. The corresponding configuration is:
 

--- a/docs/en/examples/qwen3-4B.md
+++ b/docs/en/examples/qwen3-4B.md
@@ -40,16 +40,20 @@ PYTHONPATH=/root/Megatron-LM python tools/convert_hf_to_torch_dist.py \
 
 ## Run Training
 
-Execute the training script:
+Execute the training script. We recommend using the Python script, which handles model download, checkpoint conversion, and training in one step:
 
 ```bash
 cd /root/miles
+# Recommended: Python script (auto downloads, converts, and trains)
+python scripts/run_qwen3_4b.py --model-dir /root --data-dir /root
+
+# Legacy: Shell script (requires manual model download and checkpoint conversion)
 bash scripts/run-qwen3-4B.sh
 ```
 
 ### Parameter Introduction
 
-Here, we will briefly introduce the various components of the [run-qwen3-4B.sh](https://github.com/radixark/miles/blob/main/scripts/run-qwen3-4B.sh) script:
+Here, we will briefly introduce the various components of the [run-qwen3-4B.sh](https://github.com/radixark/miles/blob/main/scripts/run-qwen3-4B.sh) script (the `.py` script uses the same parameters internally):
 
 #### MODEL\_ARGS
 

--- a/docs/en/get_started/quick_start.md
+++ b/docs/en/get_started/quick_start.md
@@ -115,7 +115,33 @@ python tools/convert_fsdp_to_hf.py \
 
 ## Training Script and Parameter Overview
 
-After completing the above preparation work, you can run the training script.
+After completing the above preparation work, you can run the training script. miles provides two styles of training scripts:
+
+- **Python scripts (recommended)**: `scripts/run_*.py` — use `typer` for CLI, handle model download, checkpoint conversion, and training in one command.
+- **Shell scripts (legacy)**: `scripts/run-*.sh` — the older format, still functional.
+
+### Using Python Scripts (Recommended)
+
+Python scripts automatically handle model/data download, checkpoint conversion, and training launch:
+
+```bash
+cd /root/miles
+# Qwen3-4B example (auto downloads model, converts checkpoint, launches training)
+python scripts/run_qwen3_4b.py
+
+# With custom options:
+python scripts/run_qwen3_4b.py --model-dir /root/models --data-dir /root/datasets --hardware H100
+
+# Qwen3-30B-A3B MoE example
+python scripts/run_qwen3_30b_a3b.py
+
+# GLM-4.5-355B-A32B multi-node example
+python scripts/run_glm45_355b_a32b.py train --num-nodes 8
+```
+
+All `.py` scripts accept `--help` to list available options.
+
+### Using Shell Scripts (Legacy)
 
 ```bash
 cd /root/miles
@@ -586,4 +612,4 @@ miles has been deeply optimized for distributed training of large-scale Mixture 
 
 - [Example: 64xH100 Training GLM-4.5](../examples/glm4.5-355B-A32B.md)
 - [Example: 128xH100 Training DeepSeek-R1](../examples/deepseek-r1.md)
-- The scripts such as `scripts/run_qwen3_30b_a3b.py`, `scripts/run_glm45_355b_a32b.py` also support multi-node training, though there are little documentations about it currently.
+- The Python scripts `scripts/run_qwen3_30b_a3b.py`, `scripts/run_glm45_355b_a32b.py`, and `scripts/run_deepseek.py` support multi-node training via `--num-nodes`.


### PR DESCRIPTION
- quick_start.md: add Python Scripts section as the recommended approach
- examples/qwen3-4B.md: add .py script recommendation
- examples/qwen3-30B-A3B.md: replace non-existent run-qwen3-30B-A3B.sh with run_qwen3_30b_a3b.py
- examples/glm4.5-355B-A32B.md: add .py script for multi-node coordination
- examples/deepseek-r1.md: add run_deepseek.py recommendation
- examples/glm4-9B.md: add run_glm47_flash.py note