### PR TITLE
[doc] [4/N] fix typos and stale defaults

### DIFF
--- a/docs/en/advanced/fault-tolerance.md
+++ b/docs/en/advanced/fault-tolerance.md
@@ -8,6 +8,6 @@ To enable the fault tolerance function in miles, please set `--use-fault-toleran
 
 During the rollout process, miles periodically sends heartbeat requests (`/health_generate`) to all SGLang servers. If a heartbeat times out, that SGLang server will be stopped. After the current rollout round is complete, the server will be restarted and its parameters will be correctly updated.
 
-- `--rollout-health-check-first-wait`: Since some large MoE models require compilation on their first run, miles will wait for `rollout_health_check_first_wait` seconds before the first rollout to start sending heartbeats. Defaults to 300s.
-- `--rollout-health-check-interval`: The interval between heartbeat checks. Defaults to 10s.
-- `--rollout-health-check-timeout`: The timeout limit for a heartbeat request. Defaults to 5s.
+- `--rollout-health-check-first-wait`: Since some large MoE models require compilation on their first run, miles will wait for `rollout_health_check_first_wait` seconds before the first rollout to start sending heartbeats. Defaults to 0s. Increase this value significantly when using deepgemm.
+- `--rollout-health-check-interval`: The interval between heartbeat checks. Defaults to 30s.
+- `--rollout-health-check-timeout`: The timeout limit for a heartbeat request. Defaults to 30s.

--- a/docs/en/examples/glm4-9B.md
+++ b/docs/en/examples/glm4-9B.md
@@ -126,7 +126,7 @@ During evaluation, most rollout parameters are inherited, but we provide some pa
 ```bash
 EVAL_ARGS=(
    --eval-interval 5
-   --eval-prompt-data /root/aime-2024/aime-2024.jsonl
+   --eval-prompt-data aime /root/aime-2024/aime-2024.jsonl
    --n-samples-per-eval-prompt 16
    --eval-max-response-len 16384
    --eval-top-p 1

--- a/docs/en/examples/glm4.5-355B-A32B.md
+++ b/docs/en/examples/glm4.5-355B-A32B.md
@@ -42,10 +42,10 @@ bash scripts/run-glm4.5-355B-A32B.sh
 On other nodes, you need to join the Ray cluster with the following command:
 
 ```bash
-ray start --address=${MASTER_ADDR}:6379 --num-gpus 8 --node-ip-address ${WORKER_IP} --disable-usage-stats"
+ray start --address=${MASTER_ADDR}:6379 --num-gpus 8 --node-ip-address ${WORKER_IP} --disable-usage-stats
 ```
 
-Alternatively, if you have a list of all node IPs, for example, an MPI hostfile (where each line is `ip slot=8`), you can add the following commands after the `ray start --head` command in `scripts/run-glm4.5-355B-A32B.sh.sh`. This allows you to execute the training entirely from node0:
+Alternatively, if you have a list of all node IPs, for example, an MPI hostfile (where each line is `ip slot=8`), you can add the following commands after the `ray start --head` command in `scripts/run-glm4.5-355B-A32B.sh`. This allows you to execute the training entirely from node0:
 
 ```bash
 for WORKER_IP in $(awk '{print $1}' $BASE_DIR/mpi_hostfile); do

--- a/docs/en/examples/qwen3-4B.md
+++ b/docs/en/examples/qwen3-4B.md
@@ -126,7 +126,7 @@ During evaluation, most rollout parameters are inherited, but we provide some pa
 ```bash
 EVAL_ARGS=(
    --eval-interval 5
-   --eval-prompt-data /root/aime-2024/aime-2024.jsonl
+   --eval-prompt-data aime /root/aime-2024/aime-2024.jsonl
    --n-samples-per-eval-prompt 16
    --eval-max-response-len 16384
    --eval-top-p 1

--- a/docs/en/examples/qwen3-4b-base-openhermes.md
+++ b/docs/en/examples/qwen3-4b-base-openhermes.md
@@ -45,7 +45,7 @@ Execute the training:
 
 ```bash
 cd /root/miles
-bash script/run-qwen3-4B-base-sft.sh
+bash scripts/run-qwen3-4B-base-sft.sh
 ```
 
 ### Parameter Introduction

--- a/docs/en/get_started/usage.md
+++ b/docs/en/get_started/usage.md
@@ -81,7 +81,7 @@ We provide configurations for common models in [scripts/models](../../../scripts
 Note:
 
   - miles will load all parameters of Megatron found in the `PYTHONPATH`, so you can find parameters and their descriptions within the Megatron in your environment.
-  - miles uses data packing (also known as varlen or thd) for training. There is no need to configure `--seq-length` or `--max-positional-embedding`, as these parameters do not affect the maximum context length of the trained model.
+  - miles uses data packing (also known as varlen or thd) for training. There is no need to configure `--seq-length` or `--max-position-embeddings`, as these parameters do not affect the maximum context length of the trained model.
 
 #### Setting Up Parallelism and Recomputation
 
@@ -325,7 +325,7 @@ In some customized Megatron implementations, special operations need to be perfo
 
 ## How to Use FSDP
 
-miles also support FSDP2 as the training backend, docs [here](https://lmsys.org/blog/2025-12-03-miles-fsdp/). 
+miles also supports FSDP2 as the training backend, docs [here](https://lmsys.org/blog/2025-12-03-miles-fsdp/). 
 
 > FSDP automatically reads all architecture information via `AutoModelForCausalLM.from_pretrained()`, without manual specification. Megatron requires manual configuration of parameters to read model architecture information. FSDP can read entirely from `config.json`, directly avoiding the weight format conversion step.
 
@@ -379,6 +379,6 @@ pip install -e . --no-deps
 
 # FSDP does not require weight conversion, natively supports huggingface format
 # Enable reference model, train Qwen3-4B in colocate mode
-source /root/miles/scripts/run-qwen3-4B-fsdp.sh
+bash scripts/run-qwen3-4B-fsdp.sh
 ```
 


### PR DESCRIPTION
- usage.md: --max-positional-embedding -> --max-position-embeddings (typo)
- usage.md: 'miles also support' -> 'supports'
- usage.md: fsdp quick-start uses bash instead of source on the .sh
- examples/qwen3-4B.md, glm4-9B.md: --eval-prompt-data now takes name path pair
- examples/qwen3-4b-base-openhermes.md: script/ -> scripts/
- examples/glm4.5-355B-A32B.md: fix double .sh.sh suffix and stray trailing quote
- advanced/fault-tolerance.md: health check defaults 300/10/5 -> 0/30/30 (matches current code and miles_server_args.md)