### PR TITLE
[feat] Add ESS ratio monitoring metric for off-policy detection

### DIFF
--- a/miles/backends/training_utils/cp_utils.py
+++ b/miles/backends/training_utils/cp_utils.py
@@ -61,6 +61,38 @@ def get_logits_and_tokens_offset_with_cp(
     return chunk_size, (chunk_0, chunk_1), (logits_0, logits_1), (token_0, token_1)
 
 
+def slice_loss_masks_for_local_cp(
+    loss_masks: list[torch.Tensor],
+    total_lengths: list[int],
+    response_lengths: list[int],
+    qkv_format: str = "thd",
+    max_seq_lens: list[int] | None = None,
+) -> list[torch.Tensor]:
+    """Slice global loss masks to the local CP rank's token chunks.
+
+    When CP == 1 returns the original masks unchanged.  When CP > 1, each
+    mask is sliced according to the zigzag token offsets for this rank.
+    """
+    parallel_state = get_parallel_state()
+    if parallel_state.cp.size == 1:
+        return loss_masks
+
+    local_masks = []
+    for i, (loss_mask, total_length, response_length) in enumerate(
+        zip(loss_masks, total_lengths, response_lengths, strict=False)
+    ):
+        max_seq_len = max_seq_lens[i] if max_seq_lens is not None else None
+        prompt_length = total_length - response_length
+        _, _, _, token_offsets = get_logits_and_tokens_offset_with_cp(
+            total_length, response_length, qkv_format, max_seq_len
+        )
+        mask_0 = loss_mask[token_offsets[0][0] - prompt_length : token_offsets[0][1] - prompt_length]
+        mask_1 = loss_mask[token_offsets[1][0] - prompt_length : token_offsets[1][1] - prompt_length]
+        local_masks.append(torch.cat([mask_0, mask_1], dim=0))
+
+    return local_masks
+
+
 def get_sum_of_sample_mean(
     total_lengths: list[int],
     response_lengths: list[int],
@@ -75,58 +107,31 @@ def get_sum_of_sample_mean(
     parallel_state = get_parallel_state()
     cp_size = parallel_state.cp.size
     if cp_size == 1:
-
-        def sum_of_sample_mean(x: torch.Tensor) -> torch.Tensor:
-            return sum(
-                [
-                    (x_i * loss_mask_i).sum() / torch.clamp_min(loss_mask_i.sum(), 1)
-                    for x_i, loss_mask_i in zip(x.split(response_lengths, dim=0), loss_masks, strict=False)
-                ]
-            )
-
-        def sum_of_token(x: torch.Tensor) -> torch.Tensor:
-            return sum(
-                [
-                    (x_i * loss_mask_i).sum()
-                    for x_i, loss_mask_i in zip(x.split(response_lengths, dim=0), loss_masks, strict=False)
-                ]
-            )
-
+        chunk_lengths = response_lengths
+        chunk_masks = loss_masks
     else:
-        cp_chunk_lengths = []
-        chunked_loss_masks = []
-        for i, (total_length, response_length, loss_mask) in enumerate(
-            zip(total_lengths, response_lengths, loss_masks, strict=False)
-        ):
-            max_seq_len = max_seq_lens[i] if max_seq_lens is not None else None
-            prompt_length = total_length - response_length
-            _, _, _, tokens_offset = get_logits_and_tokens_offset_with_cp(
-                total_length, response_length, qkv_format, max_seq_len
-            )
-            loss_mask_0 = loss_mask[tokens_offset[0][0] - prompt_length : tokens_offset[0][1] - prompt_length]
-            loss_mask_1 = loss_mask[tokens_offset[1][0] - prompt_length : tokens_offset[1][1] - prompt_length]
-            chunked_loss_masks.append(torch.cat([loss_mask_0, loss_mask_1], dim=0))
-            cp_chunk_lengths.append(chunked_loss_masks[i].size(0))
+        chunk_masks = slice_loss_masks_for_local_cp(
+            loss_masks, total_lengths, response_lengths, qkv_format, max_seq_lens
+        )
+        chunk_lengths = [m.size(0) for m in chunk_masks]
 
-        def sum_of_sample_mean(x: torch.Tensor) -> torch.Tensor:
-            return sum(
-                [
-                    (x_i * chunked_loss_mask).sum() / torch.clamp_min(loss_mask.sum(), 1)
-                    for x_i, chunked_loss_mask, loss_mask in zip(
-                        x.split(cp_chunk_lengths, dim=0), chunked_loss_masks, loss_masks, strict=False
-                    )
-                ]
-            )
+    def sum_of_sample_mean(x: torch.Tensor) -> torch.Tensor:
+        return sum(
+            [
+                (x_i * chunked_loss_mask).sum() / torch.clamp_min(loss_mask.sum(), 1)
+                for x_i, chunked_loss_mask, loss_mask in zip(
+                    x.split(chunk_lengths, dim=0), chunk_masks, loss_masks, strict=False
+                )
+            ]
+        )
 
-        def sum_of_token(x: torch.Tensor) -> torch.Tensor:
-            return sum(
-                [
-                    (x_i * chunked_loss_mask).sum()
-                    for x_i, chunked_loss_mask in zip(
-                        x.split(cp_chunk_lengths, dim=0), chunked_loss_masks, strict=False
-                    )
-                ]
-            )
+    def sum_of_token(x: torch.Tensor) -> torch.Tensor:
+        return sum(
+            [
+                (x_i * chunked_loss_mask).sum()
+                for x_i, chunked_loss_mask in zip(x.split(chunk_lengths, dim=0), chunk_masks, strict=False)
+            ]
+        )
 
     return sum_of_sample_mean if not calculate_per_token_loss else sum_of_token
 

--- a/miles/backends/training_utils/loss.py
+++ b/miles/backends/training_utils/loss.py
@@ -651,6 +651,20 @@ def policy_loss_function(
     else:
         pg_loss_reducer = sum_of_sample_mean
 
+    # ESS (Effective Sample Size) ratio per sample, computed from per-token IS
+    # weights w = π_new/π_old = exp(-ppo_kl).  ESS_i = (Σw)² / (n·Σw²).
+    # Ratio of 1.0 = on-policy; near 0 = severely off-policy.
+    # Stored as sum across samples; aggregate_train_losses divides by N later.
+    is_weights = (-ppo_kl).detach().exp()
+    is_weights_per_sample = is_weights.split(response_lengths, dim=0)
+    ess_ratio_sum = torch.zeros(1, device=ppo_kl.device)
+    for w_i, mask_i in zip(is_weights_per_sample, batch["loss_masks"], strict=False):
+        w_masked = w_i * mask_i
+        n_i = torch.clamp_min(mask_i.sum(), 1)
+        sum_w = w_masked.sum()
+        sum_w2 = (w_masked * w_masked).sum()
+        ess_ratio_sum += (sum_w * sum_w) / (n_i * torch.clamp_min(sum_w2, 1e-8))
+
     pg_loss = pg_loss_reducer(pg_loss)
     pg_clipfrac = sum_of_sample_mean(pg_clipfrac)
     ppo_kl = sum_of_sample_mean(ppo_kl)
@@ -693,6 +707,7 @@ def policy_loss_function(
         "entropy_loss": entropy_loss.clone().detach(),
         "pg_clipfrac": pg_clipfrac.clone().detach(),
         "ppo_kl": ppo_kl.clone().detach(),
+        "ess_ratio": ess_ratio_sum.squeeze(),
     }
 
     if train_rollout_logprob_abs_diff is not None:

--- a/miles/backends/training_utils/loss.py
+++ b/miles/backends/training_utils/loss.py
@@ -3,6 +3,7 @@ from collections.abc import Callable, Iterator
 from typing import Any
 
 import torch
+import torch.distributed as dist
 from torch.utils.checkpoint import checkpoint
 
 from miles.utils.distributed_utils import distributed_masked_whiten
@@ -25,6 +26,7 @@ from .cp_utils import (
     all_gather_with_cp,
     get_logits_and_tokens_offset_with_cp,
     get_sum_of_sample_mean,
+    slice_loss_masks_for_local_cp,
 )
 from .parallel import get_parallel_state
 
@@ -471,6 +473,59 @@ def vanilla_tis_function(
     return pg_loss, loss_masks, metrics
 
 
+def compute_ess_ratio_contribution(
+    ppo_kl: torch.Tensor,
+    loss_masks: list[torch.Tensor],
+    total_lengths: list[int],
+    response_lengths: list[int],
+    qkv_format: str,
+    max_seq_lens: list[int] | None,
+    calculate_per_token_loss: bool,
+) -> torch.Tensor:
+    """Return an ESS contribution compatible with ``aggregate_train_losses``.
+
+    ESS needs full-sample sums before applying the nonlinear ratio.  Under CP we
+    reconstruct those sums first, then let only CP rank 0 emit the final
+    contribution so the generic CP metric aggregation does not double count it.
+    """
+    parallel_state = get_parallel_state()
+    cp_size = parallel_state.cp.size
+
+    local_masks = slice_loss_masks_for_local_cp(
+        loss_masks,
+        total_lengths,
+        response_lengths,
+        qkv_format,
+        max_seq_lens,
+    )
+    local_lengths = [mask.size(0) for mask in local_masks]
+    is_weights_per_sample = (-ppo_kl.detach().float()).exp().split(local_lengths, dim=0)
+
+    partial_sums = torch.zeros(len(loss_masks), 2, device=ppo_kl.device, dtype=torch.float32)
+    for i, (weights, mask) in enumerate(zip(is_weights_per_sample, local_masks, strict=False)):
+        if weights.numel() != mask.numel():
+            raise ValueError(f"ESS weight/mask length mismatch for sample {i}: {weights.numel()} vs {mask.numel()}")
+        masked_weights = weights * mask.to(device=weights.device, dtype=weights.dtype)
+        partial_sums[i, 0] = masked_weights.sum()
+        partial_sums[i, 1] = (masked_weights * masked_weights).sum()
+
+    if cp_size > 1:
+        dist.all_reduce(partial_sums, op=dist.ReduceOp.SUM, group=parallel_state.cp.group)
+
+    ess_ratio_sum = torch.zeros((), device=ppo_kl.device, dtype=torch.float32)
+    for i, loss_mask in enumerate(loss_masks):
+        num_valid_tokens = torch.clamp_min(loss_mask.to(device=ppo_kl.device, dtype=torch.float32).sum(), 1)
+        sum_w = partial_sums[i, 0]
+        sum_w2 = partial_sums[i, 1]
+        ess_ratio = (sum_w * sum_w) / (num_valid_tokens * torch.clamp_min(sum_w2, 1e-8))
+        ess_ratio_sum += ess_ratio * num_valid_tokens if calculate_per_token_loss else ess_ratio
+
+    if cp_size > 1 and parallel_state.cp.rank != 0:
+        ess_ratio_sum = ess_ratio_sum * 0
+
+    return ess_ratio_sum
+
+
 def icepop_function(
     args,
     *,
@@ -651,19 +706,18 @@ def policy_loss_function(
     else:
         pg_loss_reducer = sum_of_sample_mean
 
-    # ESS (Effective Sample Size) ratio per sample, computed from per-token IS
-    # weights w = π_new/π_old = exp(-ppo_kl).  ESS_i = (Σw)² / (n·Σw²).
-    # Ratio of 1.0 = on-policy; near 0 = severely off-policy.
-    # Stored as sum across samples; aggregate_train_losses divides by N later.
-    is_weights = (-ppo_kl).detach().exp()
-    is_weights_per_sample = is_weights.split(response_lengths, dim=0)
-    ess_ratio_sum = torch.zeros(1, device=ppo_kl.device)
-    for w_i, mask_i in zip(is_weights_per_sample, batch["loss_masks"], strict=False):
-        w_masked = w_i * mask_i
-        n_i = torch.clamp_min(mask_i.sum(), 1)
-        sum_w = w_masked.sum()
-        sum_w2 = (w_masked * w_masked).sum()
-        ess_ratio_sum += (sum_w * sum_w) / (n_i * torch.clamp_min(sum_w2, 1e-8))
+    # ESS (Effective Sample Size) ratio from per-token IS weights
+    # w = π_new/π_old = exp(-ppo_kl).  A value of 1.0 is on-policy; near 0
+    # means the per-token weights are highly concentrated.
+    ess_ratio_sum = compute_ess_ratio_contribution(
+        ppo_kl=ppo_kl,
+        loss_masks=batch["loss_masks"],
+        total_lengths=total_lengths,
+        response_lengths=response_lengths,
+        qkv_format=args.qkv_format,
+        max_seq_lens=max_seq_lens,
+        calculate_per_token_loss=args.calculate_per_token_loss,
+    )
 
     pg_loss = pg_loss_reducer(pg_loss)
     pg_clipfrac = sum_of_sample_mean(pg_clipfrac)


### PR DESCRIPTION
## Summary

- Adds Effective Sample Size (ESS) ratio as a per-step training metric
- ESS is computed from per-token importance sampling weights `w = π_new/π_old = exp(-ppo_kl)`
- Formula: `ESS_i = (Σw)² / (n·Σw²)` per sample, then summed across samples
- ESS ratio of 1.0 = on-policy; near 0 = severely off-policy
- Reported as `ess_ratio` in training loss metrics

## Test plan

- [ ] Verify `ess_ratio` appears in training logs/wandb
- [ ] Confirm ESS ratio ~1.0 at start of training (on-policy)
- [ ] Confirm ESS ratio decreases as policy diverges from rollout policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)