### PR TITLE
debug(r3): diagnostic wrapper around all_to_all_single for split-size crash

### DIFF
--- a/.github/workflows/maintain-deploy.yml
+++ b/.github/workflows/maintain-deploy.yml
@@ -60,10 +60,17 @@ jobs:
     if: needs.check.outputs.skip != 'true'
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.DEPLOY_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Configure git
         run: |

--- a/.github/workflows/maintain-deploy.yml
+++ b/.github/workflows/maintain-deploy.yml
@@ -1,18 +1,72 @@
 name: Maintain deploy branch
 
 on:
-  # Rebuild nightly
   schedule:
-    - cron: '0 10 * * *'  # 3 AM California (10 AM UTC)
-  # Rebuild when any feature branch is pushed
-  push:
-    branches:
-      - 'fix/**'
-  # Manual trigger
+    - cron: '*/15 * * * *'
   workflow_dispatch:
+    inputs:
+      force:
+        description: 'Rebuild even if no changes detected'
+        type: boolean
+        default: false
+
+env:
+  UPSTREAM: radixark/miles
 
 jobs:
-  rebuild-deploy:
+  check:
+    runs-on: ubuntu-latest
+    outputs:
+      skip: ${{ steps.fingerprint.outputs.skip }}
+      state: ${{ steps.fingerprint.outputs.state }}
+      branches: ${{ steps.fingerprint.outputs.branches }}
+    steps:
+      - name: Compute desired state and compare
+        id: fingerprint
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          FORCE: ${{ inputs.force }}
+          REPO: ${{ github.repository }}
+        run: |
+          UPSTREAM_SHA=$(gh api "repos/${UPSTREAM}/commits/main" --jq '.sha' 2>/dev/null || echo "unknown")
+
+          PR_STATE=$(gh pr list \
+            --repo "$UPSTREAM" \
+            --author DavidBellamy \
+            --state open \
+            --base main \
+            --json headRefName,headRefOid \
+            --jq 'sort_by(.headRefName) | map(.headRefName + "=" + .headRefOid) | join(",")')
+
+          BRANCHES=$(gh pr list \
+            --repo "$UPSTREAM" \
+            --author DavidBellamy \
+            --state open \
+            --base main \
+            --json headRefName \
+            --jq '.[].headRefName' | tr '\n' ' ')
+
+          STATE="${UPSTREAM_SHA}|${PR_STATE}"
+          echo "state=$STATE" >> "$GITHUB_OUTPUT"
+          echo "branches=$BRANCHES" >> "$GITHUB_OUTPUT"
+          echo "Desired state: $STATE"
+
+          CURRENT=$(gh api "repos/${REPO}/commits/deploy" \
+            --jq '.commit.message' 2>/dev/null \
+            | grep '^state:' | head -1 | cut -d: -f2- || echo "")
+
+          echo "Current state: $CURRENT"
+
+          if [ "$CURRENT" = "$STATE" ] && [ "$FORCE" != "true" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::No changes detected, skipping rebuild"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  rebuild:
+    needs: check
+    if: needs.check.outputs.skip != 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -27,29 +81,13 @@ jobs:
 
       - name: Fetch upstream
         run: |
-          git remote add upstream https://github.com/radixark/miles.git || true
+          git remote add upstream "https://github.com/${UPSTREAM}.git" || true
           git fetch upstream main
           git fetch origin
 
-      - name: Get branches with open PRs targeting upstream
-        id: branches
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          BRANCHES=$(gh pr list \
-            --repo radixark/miles \
-            --author DavidBellamy \
-            --state open \
-            --base main \
-            --json headRefName \
-            -q '.[].headRefName' | tr '\n' ' ')
-
-          echo "branches=$BRANCHES" >> "$GITHUB_OUTPUT"
-          echo "Open PR branches: ${BRANCHES:-<none>}"
-
       - name: Build deploy branch
         env:
-          PR_BRANCHES: ${{ steps.branches.outputs.branches }}
+          PR_BRANCHES: ${{ needs.check.outputs.branches }}
         run: |
           git checkout -B deploy upstream/main
 
@@ -68,9 +106,40 @@ jobs:
 
           echo "Successfully merged:${MERGED:-<none>}"
           if [ -n "$FAILED" ]; then
-            echo "::error::Failed to merge (conflicts):$FAILED"
-            exit 1
+            echo "::warning::Failed to merge (conflicts):$FAILED"
+          fi
+          echo "FAILED_BRANCHES=$FAILED" >> "$GITHUB_ENV"
+
+      - name: Stamp fingerprint and push
+        env:
+          STATE: ${{ needs.check.outputs.state }}
+        run: |
+          git commit --allow-empty -m "state:${STATE}"
+          git push origin deploy --force
+
+      - name: Report merge conflicts
+        if: always() && needs.check.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ISSUE_TITLE="Deploy: merge conflict"
+          EXISTING=$(gh issue list --label deploy-conflict --state open --json number --jq '.[0].number' 2>/dev/null || echo "")
+
+          if [ -z "$FAILED_BRANCHES" ]; then
+            if [ -n "$EXISTING" ]; then
+              gh issue close "$EXISTING" --comment "Resolved: all branches merged cleanly."
+            fi
+            exit 0
           fi
 
-      - name: Force-push deploy
-        run: git push origin deploy --force
+          BODY=$(printf "The following branches failed to merge into deploy:\n\n")
+          for b in $FAILED_BRANCHES; do
+            BODY=$(printf "%s\n- \`%s\`" "$BODY" "$b")
+          done
+          BODY=$(printf "%s\n\nThis issue auto-closes when the next build merges all branches cleanly." "$BODY")
+
+          if [ -n "$EXISTING" ]; then
+            gh issue edit "$EXISTING" --body "$BODY"
+          else
+            gh issue create --title "$ISSUE_TITLE" --body "$BODY" --label deploy-conflict
+          fi

--- a/.github/workflows/maintain-deploy.yml
+++ b/.github/workflows/maintain-deploy.yml
@@ -1,0 +1,76 @@
+name: Maintain deploy branch
+
+on:
+  # Rebuild nightly
+  schedule:
+    - cron: '0 10 * * *'  # 3 AM California (10 AM UTC)
+  # Rebuild when any feature branch is pushed
+  push:
+    branches:
+      - 'fix/**'
+  # Manual trigger
+  workflow_dispatch:
+
+jobs:
+  rebuild-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Fetch upstream
+        run: |
+          git remote add upstream https://github.com/radixark/miles.git || true
+          git fetch upstream main
+          git fetch origin
+
+      - name: Get branches with open PRs targeting upstream
+        id: branches
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BRANCHES=$(gh pr list \
+            --repo radixark/miles \
+            --author DavidBellamy \
+            --state open \
+            --base main \
+            --json headRefName \
+            -q '.[].headRefName' | tr '\n' ' ')
+
+          echo "branches=$BRANCHES" >> "$GITHUB_OUTPUT"
+          echo "Open PR branches: ${BRANCHES:-<none>}"
+
+      - name: Build deploy branch
+        env:
+          PR_BRANCHES: ${{ steps.branches.outputs.branches }}
+        run: |
+          git checkout -B deploy upstream/main
+
+          MERGED=""
+          FAILED=""
+          for branch in $PR_BRANCHES; do
+            echo "Merging $branch..."
+            if git merge "origin/$branch" --no-edit -m "Deploy: merge $branch"; then
+              MERGED="$MERGED $branch"
+            else
+              echo "::error::Merge conflict on $branch, skipping"
+              git merge --abort
+              FAILED="$FAILED $branch"
+            fi
+          done
+
+          echo "Successfully merged:${MERGED:-<none>}"
+          if [ -n "$FAILED" ]; then
+            echo "::error::Failed to merge (conflicts):$FAILED"
+            exit 1
+          fi
+
+      - name: Force-push deploy
+        run: git push origin deploy --force

--- a/.github/workflows/maintain-deploy.yml
+++ b/.github/workflows/maintain-deploy.yml
@@ -30,21 +30,12 @@ jobs:
         run: |
           UPSTREAM_SHA=$(gh api "repos/${UPSTREAM}/commits/main" --jq '.sha' 2>/dev/null || echo "unknown")
 
-          PR_STATE=$(gh pr list \
-            --repo "$UPSTREAM" \
-            --author DavidBellamy \
-            --state open \
-            --base main \
-            --json headRefName,headRefOid \
-            --jq 'sort_by(.headRefName) | map(.headRefName + "=" + .headRefOid) | join(",")')
+          FORK_OWNER="${REPO%%/*}"
+          PR_STATE=$(gh api "repos/${UPSTREAM}/pulls?state=open&base=main&per_page=100" \
+            --jq "[.[] | select(.head.repo.owner.login == \"${FORK_OWNER}\")] | sort_by(.head.ref) | map(.head.ref + \"=\" + .head.sha) | join(\",\")")
 
-          BRANCHES=$(gh pr list \
-            --repo "$UPSTREAM" \
-            --author DavidBellamy \
-            --state open \
-            --base main \
-            --json headRefName \
-            --jq '.[].headRefName' | tr '\n' ' ')
+          BRANCHES=$(gh api "repos/${UPSTREAM}/pulls?state=open&base=main&per_page=100" \
+            --jq "[.[] | select(.head.repo.owner.login == \"${FORK_OWNER}\")] | .[].head.ref" | tr '\n' ' ')
 
           STATE="${UPSTREAM_SHA}|${PR_STATE}"
           echo "state=$STATE" >> "$GITHUB_OUTPUT"
@@ -72,7 +63,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.DEPLOY_TOKEN }}
 
       - name: Configure git
         run: |

--- a/miles/utils/reloadable_process_group.py
+++ b/miles/utils/reloadable_process_group.py
@@ -15,18 +15,75 @@ old_new_group_dict = {}
 def _maybe_wrap_alltoall_diag(func):
     """Wrap all_to_all_single to emit per-rank diagnostic info on RuntimeError.
 
-    Activated via MILES_R3_DIAG_ALLTOALL=1. The diagnostic makes the R3 replay
-    'Split sizes doesn't match total dim 0 size' crash locally-inspectable: each
-    rank prints its own input shape, split sizes, and the sum check before
-    re-raising. Without this, the crash surfaces as a bare RuntimeError with no
-    indication of WHICH rank's split sizes diverged.
+    Activated via MILES_R3_DIAG_ALLTOALL=1. On crash, log: (a) the split sizes
+    and tensor shapes (b) the calling frame's local torch.Tensor variables —
+    this surfaces Megatron token_dispatcher's num_tokens_per_expert histogram,
+    permutation order, probs tensor, etc., which tells us whether the bug is
+    in Megatron's derivation of split sizes from (replayed) top_indices or
+    in the replay manager's choice of top_indices itself.
 
     See radixark/miles#1002.
     """
     if os.environ.get("MILES_R3_DIAG_ALLTOALL", "0") != "1":
         return func
 
+    import sys
     import traceback
+
+    def _describe(val):
+        if isinstance(val, torch.Tensor):
+            info = f"Tensor shape={tuple(val.shape)} dtype={val.dtype}"
+            if val.numel() > 0 and val.numel() <= 32:
+                try:
+                    info += f" values={val.tolist()}"
+                except Exception:
+                    pass
+            elif val.dtype in (torch.int8, torch.int16, torch.int32, torch.int64):
+                try:
+                    info += f" min={int(val.min())} max={int(val.max())}"
+                    if val.numel() < 1_000_000:
+                        flat = val.flatten()
+                        unique = torch.unique(flat)
+                        info += f" n_unique={unique.numel()}"
+                        if unique.numel() <= 16:
+                            info += f" unique={unique.tolist()}"
+                except Exception:
+                    pass
+            return info
+        if isinstance(val, (list, tuple)) and len(val) <= 32:
+            return f"{type(val).__name__}({len(val)})={list(val)}"
+        if isinstance(val, (int, float, bool, str)):
+            return repr(val)
+        return f"<{type(val).__name__}>"
+
+    def _dump_caller_frames(msg_parts, depth=8):
+        frame = sys._getframe(0)
+        for i in range(depth + 3):
+            if frame is None:
+                return
+            frame = frame.f_back
+            if frame is None:
+                return
+            co = frame.f_code
+            fname = co.co_filename
+            lineno = frame.f_lineno
+            func_name = co.co_name
+            # Skip wrapper frames; focus on callers outside reloadable_process_group
+            if "reloadable_process_group" in fname:
+                continue
+            # Only dump frames that look relevant to MoE / dispatch / replay.
+            rel = any(kw in fname for kw in ("moe", "token_dispatcher", "mappings", "replay", "model_provider"))
+            if not rel and i < 2:
+                # Still worth showing the immediate caller once even if not matched.
+                pass
+            msg_parts.append(f"\n  === frame depth={i} {fname}:{lineno} in {func_name} ===\n")
+            for name, val in frame.f_locals.items():
+                if name.startswith("__"):
+                    continue
+                msg_parts.append(f"    {name}: {_describe(val)}\n")
+            if rel and i >= 1:
+                # One relevant frame is enough — bail after dumping it.
+                break
 
     def diag(*args, **kwargs):
         try:
@@ -56,19 +113,23 @@ def _maybe_wrap_alltoall_diag(func):
             except Exception:
                 group_ranks = "<unavailable>"
 
-            msg = (
-                f"[R3_DIAG rank={rank}] all_to_all_single RuntimeError: {e}\n"
-                f"  input: shape={_shape(input_t)} dtype={_dtype(input_t)}\n"
-                f"  output: shape={_shape(output_t)} dtype={_dtype(output_t)}\n"
-                f"  input_split_sizes={input_ss} sum={input_sum} input.dim0={input_dim0}\n"
-                f"  output_split_sizes={output_ss} sum={output_sum} output.dim0={output_dim0}\n"
-                f"  group_ranks={group_ranks}\n"
-                f"  input_sum_matches_dim0={input_sum == input_dim0 if input_sum is not None else 'n/a'}\n"
-                f"  output_sum_matches_dim0={output_sum == output_dim0 if output_sum is not None else 'n/a'}\n"
-                f"  call stack (top 6):\n"
-                + "".join("    " + line for line in traceback.format_stack()[-8:-2])
-            )
-            logger.error(msg)
+            msg_parts = [
+                f"[R3_DIAG rank={rank}] all_to_all_single RuntimeError: {e}\n",
+                f"  input: shape={_shape(input_t)} dtype={_dtype(input_t)}\n",
+                f"  output: shape={_shape(output_t)} dtype={_dtype(output_t)}\n",
+                f"  input_split_sizes={input_ss} sum={input_sum} input.dim0={input_dim0}\n",
+                f"  output_split_sizes={output_ss} sum={output_sum} output.dim0={output_dim0}\n",
+                f"  group_ranks={group_ranks}\n",
+                f"  input_sum_matches_dim0={input_sum == input_dim0 if input_sum is not None else 'n/a'}\n",
+                f"  output_sum_matches_dim0={output_sum == output_dim0 if output_sum is not None else 'n/a'}\n",
+                f"  call stack (top 6):\n",
+                *["    " + line for line in traceback.format_stack()[-8:-2]],
+            ]
+            try:
+                _dump_caller_frames(msg_parts, depth=6)
+            except Exception as dump_err:  # diagnostic must not crash the crash
+                msg_parts.append(f"  (frame dump failed: {dump_err!r})\n")
+            logger.error("".join(msg_parts))
             raise
 
     return diag

--- a/miles/utils/reloadable_process_group.py
+++ b/miles/utils/reloadable_process_group.py
@@ -12,6 +12,68 @@ logger = logging.getLogger(__name__)
 old_new_group_dict = {}
 
 
+def _maybe_wrap_alltoall_diag(func):
+    """Wrap all_to_all_single to emit per-rank diagnostic info on RuntimeError.
+
+    Activated via MILES_R3_DIAG_ALLTOALL=1. The diagnostic makes the R3 replay
+    'Split sizes doesn't match total dim 0 size' crash locally-inspectable: each
+    rank prints its own input shape, split sizes, and the sum check before
+    re-raising. Without this, the crash surfaces as a bare RuntimeError with no
+    indication of WHICH rank's split sizes diverged.
+
+    See radixark/miles#1002.
+    """
+    if os.environ.get("MILES_R3_DIAG_ALLTOALL", "0") != "1":
+        return func
+
+    import traceback
+
+    def diag(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except RuntimeError as e:
+            rank = dist.get_rank() if dist.is_initialized() else -1
+            output_t = args[0] if len(args) >= 1 else kwargs.get("output")
+            input_t = args[1] if len(args) >= 2 else kwargs.get("input")
+            output_ss = args[2] if len(args) >= 3 else kwargs.get("output_split_sizes")
+            input_ss = args[3] if len(args) >= 4 else kwargs.get("input_split_sizes")
+            group = args[4] if len(args) >= 5 else kwargs.get("group")
+
+            def _shape(t):
+                return tuple(t.shape) if isinstance(t, torch.Tensor) else None
+
+            def _dtype(t):
+                return str(t.dtype) if isinstance(t, torch.Tensor) else None
+
+            input_sum = sum(input_ss) if input_ss is not None else None
+            output_sum = sum(output_ss) if output_ss is not None else None
+            input_dim0 = _shape(input_t)[0] if _shape(input_t) else None
+            output_dim0 = _shape(output_t)[0] if _shape(output_t) else None
+
+            group_ranks = None
+            try:
+                group_ranks = dist.get_process_group_ranks(group) if group is not None else None
+            except Exception:
+                group_ranks = "<unavailable>"
+
+            msg = (
+                f"[R3_DIAG rank={rank}] all_to_all_single RuntimeError: {e}\n"
+                f"  input: shape={_shape(input_t)} dtype={_dtype(input_t)}\n"
+                f"  output: shape={_shape(output_t)} dtype={_dtype(output_t)}\n"
+                f"  input_split_sizes={input_ss} sum={input_sum} input.dim0={input_dim0}\n"
+                f"  output_split_sizes={output_ss} sum={output_sum} output.dim0={output_dim0}\n"
+                f"  group_ranks={group_ranks}\n"
+                f"  input_sum_matches_dim0={input_sum == input_dim0 if input_sum is not None else 'n/a'}\n"
+                f"  output_sum_matches_dim0={output_sum == output_dim0 if output_sum is not None else 'n/a'}\n"
+                f"  call stack (top 6):\n"
+                + "".join("    " + line for line in traceback.format_stack()[-8:-2])
+            )
+            logger.error(msg)
+            raise
+
+    return diag
+
+
 def monkey_patch_torch_dist():
     pid = os.getpid()
     if pid in old_new_group_dict:
@@ -68,7 +130,7 @@ def monkey_patch_torch_dist():
     dist.all_gather_into_tensor = get_new_function(dist.all_gather_into_tensor)
     dist.all_gather_object = get_new_function(dist.all_gather_object)
     dist.all_to_all = get_new_function(dist.all_to_all)
-    dist.all_to_all_single = get_new_function(dist.all_to_all_single)
+    dist.all_to_all_single = _maybe_wrap_alltoall_diag(get_new_function(dist.all_to_all_single))
     dist.broadcast = get_new_function(dist.broadcast)
     dist.reduce = get_new_function(dist.reduce)
     dist.reduce_scatter = get_new_function(dist.reduce_scatter)

--- a/miles/utils/reloadable_process_group.py
+++ b/miles/utils/reloadable_process_group.py
@@ -33,7 +33,7 @@ def _maybe_wrap_alltoall_diag(func):
     def _describe(val):
         if isinstance(val, torch.Tensor):
             info = f"Tensor shape={tuple(val.shape)} dtype={val.dtype}"
-            if val.numel() > 0 and val.numel() <= 32:
+            if val.numel() > 0 and val.numel() <= 64:
                 try:
                     info += f" values={val.tolist()}"
                 except Exception:
@@ -45,45 +45,54 @@ def _maybe_wrap_alltoall_diag(func):
                         flat = val.flatten()
                         unique = torch.unique(flat)
                         info += f" n_unique={unique.numel()}"
-                        if unique.numel() <= 16:
+                        if unique.numel() <= 32:
                             info += f" unique={unique.tolist()}"
                 except Exception:
                     pass
             return info
-        if isinstance(val, (list, tuple)) and len(val) <= 32:
+        # numpy array (common for split sizes in Megatron)
+        try:
+            import numpy as _np
+            if isinstance(val, _np.ndarray):
+                info = f"ndarray shape={val.shape} dtype={val.dtype}"
+                if val.size <= 64:
+                    info += f" values={val.tolist()}"
+                    if val.dtype.kind in ("i", "u"):
+                        info += f" sum={int(val.sum())}"
+                return info
+        except ImportError:
+            pass
+        if isinstance(val, (list, tuple)) and len(val) <= 64:
             return f"{type(val).__name__}({len(val)})={list(val)}"
+        if isinstance(val, dict) and len(val) <= 16:
+            return f"dict({len(val)})={ {k: _describe(v) for k, v in val.items()} }"
         if isinstance(val, (int, float, bool, str)):
-            return repr(val)
+            return repr(val) if len(repr(val)) < 200 else f"<{type(val).__name__}>"
         return f"<{type(val).__name__}>"
 
     def _dump_caller_frames(msg_parts, depth=8):
         frame = sys._getframe(0)
-        for i in range(depth + 3):
-            if frame is None:
-                return
+        dumped = 0
+        while frame is not None and dumped < depth:
             frame = frame.f_back
             if frame is None:
-                return
+                break
             co = frame.f_code
             fname = co.co_filename
-            lineno = frame.f_lineno
-            func_name = co.co_name
-            # Skip wrapper frames; focus on callers outside reloadable_process_group
+            # Skip wrapper frames; keep everything else.
             if "reloadable_process_group" in fname:
                 continue
-            # Only dump frames that look relevant to MoE / dispatch / replay.
-            rel = any(kw in fname for kw in ("moe", "token_dispatcher", "mappings", "replay", "model_provider"))
-            if not rel and i < 2:
-                # Still worth showing the immediate caller once even if not matched.
-                pass
-            msg_parts.append(f"\n  === frame depth={i} {fname}:{lineno} in {func_name} ===\n")
+            lineno = frame.f_lineno
+            func_name = co.co_name
+            msg_parts.append(f"\n  === frame depth={dumped} {fname}:{lineno} in {func_name} ===\n")
             for name, val in frame.f_locals.items():
                 if name.startswith("__"):
                     continue
-                msg_parts.append(f"    {name}: {_describe(val)}\n")
-            if rel and i >= 1:
-                # One relevant frame is enough — bail after dumping it.
-                break
+                try:
+                    msg_parts.append(f"    {name}: {_describe(val)}\n")
+                except Exception as desc_err:
+                    msg_parts.append(f"    {name}: <describe-error: {desc_err!r}>\n")
+            dumped += 1
 
     def diag(*args, **kwargs):
         try:

--- a/miles/utils/wandb_utils.py
+++ b/miles/utils/wandb_utils.py
@@ -89,6 +89,7 @@ def _compute_config_for_logging(args):
         # We may insert more default values here, and may also allow users to configure a whitelist
     ]
     output["env_vars"] = {k: v for k, v in os.environ.items() if k in whitelist_env_vars}
+    output["launched_by"] = os.environ.get("USER")
 
     if env_report_raw := args.env_report:
         if launcher_report := decode_env_report(env_report_raw):


### PR DESCRIPTION
Companion to #1002.

Adds an opt-in diagnostic wrapper (`MILES_R3_DIAG_ALLTOALL=1`) around `dist.all_to_all_single` that catches `RuntimeError` and logs per-rank context before re-raising:

- rank
- input tensor shape + dtype
- output tensor shape
- `input_split_sizes`, `output_split_sizes`
- sum of split sizes vs tensor dim 0 (the check that's failing)
- group ranks
- call stack (top 6 frames)

When `Split sizes doesn't match total dim 0 size` fires under R3 replay, each rank's log now carries enough info to see exactly where the divergence is — which rank's `input_split_sizes` or `output_split_sizes` disagrees with its local tensor shape, or which ranks disagree with each other.

No behavior change when the env var is unset (wrapping is a no-op).

### Suggested reproduction

```
MILES_R3_DIAG_ALLTOALL=1 \
FAST_ITER_MOCK_AGENT=1 FAST_ITER_CONFIG=pd-disagg \
USE_ROLLOUT_ROUTING_REPLAY=1 \
sbatch scripts/train/agent_harbor/miles/sbatch-harbor-rl.sh
```

(same recipe that reproduces the crash in #1002 on GLM-4.7-Flash + EP=8).

Happy to capture and post the resulting diagnostic lines from a fresh run if that'd help triage.