### PR TITLE
fix(session-server): strip stale hop-by-hop headers when re-emitting proxy response

### DIFF
--- a/miles/rollout/session/session_server.py
+++ b/miles/rollout/session/session_server.py
@@ -81,7 +81,20 @@ class SessionServer:
     def build_proxy_response(self, result: dict) -> Response:
         content = result["response_body"]
         status_code = result["status_code"]
-        headers = result["headers"]
+        # Strip hop-by-hop headers that become stale when we re-emit the body.
+        # JSONResponse re-serializes via json.dumps (different whitespace/unicode
+        # escape behavior than the upstream may have used) and Response may be
+        # re-framed with chunked encoding. Forwarding the upstream content-length,
+        # transfer-encoding, or content-encoding produces a mismatch between the
+        # declared framing and the bytes Starlette actually writes, surfacing to
+        # clients as h11 LocalProtocolError ("Too much data for declared
+        # Content-Length") or "peer closed connection without sending complete
+        # message body". Starlette/hyper will recompute the correct values from
+        # the actual body when we omit these headers.
+        headers = {
+            k: v for k, v in result["headers"].items()
+            if k.lower() not in ("content-length", "transfer-encoding", "content-encoding")
+        }
         content_type = headers.get("content-type", "")
         try:
             data = json.loads(content)


### PR DESCRIPTION
## Problem

`SessionServer.build_proxy_response` in `miles/rollout/session/session_server.py` forwards upstream response headers verbatim into either `JSONResponse` or `Response`. Both re-serialize or re-frame the body:

- `JSONResponse` runs `json.dumps` over the parsed content. Whitespace, unicode escape behavior, or key ordering may produce a different byte count than what the upstream produced.
- `Response` may be re-framed by Starlette with chunked transfer encoding.

Forwarding the upstream `content-length`, `transfer-encoding`, or `content-encoding` in these cases causes a mismatch between the declared framing and the bytes Starlette actually writes. Clients (e.g. Miles's own `http_utils.post`) then error with:

- `h11._util.LocalProtocolError: Too much data for declared Content-Length`
- `peer closed connection without sending complete message body (received 0 bytes, expected N)`

and retry.

## Observed

On a mock-agent RL run against an inference gateway that serializes merged prefill+decode logprobs (different whitespace than the raw decode response), a meaningful fraction of `/v1/chat/completions` calls hit this error; retries salvaged forward progress but at substantial request loss.

## Fix

One-hunk change in `build_proxy_response`: strip the three hop-by-hop headers from `result["headers"]` before passing them to the outgoing Response. Starlette/hyper then compute `content-length` from the actual body they write.

This mirrors what `do_proxy` already does on the **incoming** request path (stripping `content-length`, `transfer-encoding`, `host`).