### PR TITLE
[feat] Use weight_update version instead of rollout version in train_async

### DIFF
--- a/train_async.py
+++ b/train_async.py
@@ -30,6 +30,14 @@ async def train(args):
         await rollout_manager.check_weights.remote(action="compare")
 
     # async train loop.
+    # Eval/save are keyed on weight_update_count (not rollout_id) so they track
+    # actual model changes — critical for fully async where rollout_id doesn't
+    # correspond 1:1 with weight versions.
+    weight_update_count = 0
+    total_weight_updates = (args.num_rollout - args.start_rollout_id) // args.update_weights_interval
+    num_weight_updates_per_epoch = (
+        num_rollout_per_epoch // args.update_weights_interval if num_rollout_per_epoch is not None else None
+    )
     rollout_data_next_future = rollout_manager.generate.remote(args.start_rollout_id)
     for rollout_id in range(args.start_rollout_id, args.num_rollout):
         # Sync the last generation
@@ -48,27 +56,31 @@ async def train(args):
         else:
             await actor_model.train(rollout_id, rollout_data_curr_ref)
 
-        if should_run_periodic_action(rollout_id, args.save_interval, num_rollout_per_epoch, args.num_rollout):
-            await actor_model.save_model(
-                rollout_id,
-                force_sync=rollout_id == args.num_rollout - 1,
-            )
-            if args.use_critic:
-                await critic_model.save_model(
-                    rollout_id,
-                    force_sync=rollout_id == args.num_rollout - 1,
-                )
-            if args.rollout_global_dataset:
-                await rollout_manager.save.remote(rollout_id)
-
         if (rollout_id + 1) % args.update_weights_interval == 0:
             # sync generate before update weights to prevent update weight in the middle of generation
             rollout_data_curr_ref = (await x) if (x := rollout_data_next_future) is not None else None
             rollout_data_next_future = None
             await actor_model.update_weights()
+            weight_update_count += 1
 
-        if should_run_periodic_action(rollout_id, args.eval_interval, num_rollout_per_epoch):
-            await rollout_manager.eval.remote(rollout_id)
+            is_last = rollout_id == args.num_rollout - 1
+            if should_run_periodic_action(
+                weight_update_count, args.save_interval, num_weight_updates_per_epoch, total_weight_updates
+            ):
+                await actor_model.save_model(
+                    weight_update_count,
+                    force_sync=is_last,
+                )
+                if args.use_critic:
+                    await critic_model.save_model(
+                        weight_update_count,
+                        force_sync=is_last,
+                    )
+                if args.rollout_global_dataset:
+                    await rollout_manager.save.remote(weight_update_count)
+
+            if should_run_periodic_action(weight_update_count, args.eval_interval, num_weight_updates_per_epoch):
+                await rollout_manager.eval.remote(weight_update_count)
 
     await rollout_manager.dispose.remote()
 


### PR DESCRIPTION
## Summary

- In async/fully-async mode, `rollout_id` advances per rollout batch but weight updates only happen every `update_weights_interval` iterations
- Previously, `eval_interval` and `save_interval` were keyed on `rollout_id`, meaning eval/save could fire multiple times for the same model weights
- Now uses `weight_update_count` so eval and checkpoint saves are tied to actual model changes
- Also computes `total_weight_updates` and `num_weight_updates_per_epoch` to correctly handle last-step and epoch-boundary triggers
- Eval/save are moved inside the weight-update block so they only run right after the model actually changes

## Test plan

- [ ] Run `train_async.py` with `update_weights_interval=1` — behavior should be identical to before
- [ ] Run with `update_weights_interval=2` — verify eval/save fire half as often (per weight update, not per rollout)
- [ ] Verify checkpoint directory names use weight_update_count

🤖 Generated with [Claude Code](https://claude.com/claude-code)