### PR TITLE
Add GenerateFnInput compatibility shim in sglang_rollout

### DIFF
--- a/miles/rollout/sglang_rollout.py
+++ b/miles/rollout/sglang_rollout.py
@@ -15,7 +15,7 @@ from packaging.version import parse
 from tqdm import tqdm
 
 from miles.backends.megatron_utils.lora_utils import LORA_ADAPTER_NAME, is_lora_enabled
-from miles.rollout.base_types import RolloutFnEvalOutput, RolloutFnTrainOutput
+from miles.rollout.base_types import GenerateFnInput, RolloutFnEvalOutput, RolloutFnTrainOutput
 from miles.rollout.filter_hub.base_types import MetricGatherer, call_dynamic_filter
 from miles.utils import dumper_utils
 from miles.utils.async_utils import run
@@ -262,8 +262,17 @@ async def generate_and_rm(
 
             if custom_func_path is not None:
                 custom_generate_func = load_function(custom_func_path)
-                # if signature has evaluation, pass evaluation
-                if "evaluation" in inspect.signature(custom_generate_func).parameters:
+                sig = inspect.signature(custom_generate_func)
+                params = list(sig.parameters.values())
+                # Support GenerateFnInput-style generate functions (single-arg with typed input)
+                if len(params) == 1:
+                    output = await custom_generate_func(
+                        GenerateFnInput(
+                            state=state, sample=sample, sampling_params=sampling_params, evaluation=evaluation
+                        )
+                    )
+                    sample = output.samples
+                elif "evaluation" in sig.parameters:
                     sample = await custom_generate_func(args, sample, sampling_params, evaluation=evaluation)
                 else:
                     sample = await custom_generate_func(args, sample, sampling_params)


### PR DESCRIPTION
## Summary

Small compatibility shim so `generate_and_rm` can dispatch to the new single-argument `GenerateFnInput`-style custom generate functions (e.g. `miles/rollout/generate_hub/agentic_tool_call.py::generate`) in addition to the legacy 3-arg and 4-arg signatures.

Without the shim, any rollout wired to a `GenerateFnInput`-style function crashes immediately with:

```
TypeError: generate() takes 1 positional argument but 3 were given
```

because the old dispatcher always called the target as `custom_generate_func(args, sample, sampling_params[, evaluation=...])`.

The shim inspects the target's signature: if it has exactly one parameter, the four runtime values are packed into a `GenerateFnInput` dataclass and awaited as a single-arg call, and `output.samples` replaces `sample`. Otherwise it falls through to the existing 3-arg / 4-arg paths. Fully backwards-compatible with all existing custom generate functions.

## Test plan

- [x] Existing 3-arg and 4-arg custom generate functions still dispatch correctly (no behavior change — the `len(params) == 1` branch only fires for the new contract).
- [x] `miles/rollout/generate_hub/agentic_tool_call.py::generate` (single-arg `GenerateFnInput`) dispatches through the new branch without the `TypeError`, verified on a 2-node async agentic rollout against GLM-4.7-Flash on 2026-04-18 PT.