### PR TITLE
fix(rollout/session): reseed instead of erroring when no assistant persisted

### DIFF
--- a/miles/rollout/session/linear_trajectory.py
+++ b/miles/rollout/session/linear_trajectory.py
@@ -77,7 +77,11 @@ class LinearTrajectory:
             return None
 
         # 1. Detect agent retries and roll back (at most one assistant step).
-        self._try_detect_and_rollback_to_assistant_checkpoint(request_messages)
+        #    Returns True iff the session was reseeded (see below); in that case
+        #    there is no stored history to merge against, so fall through to the
+        #    same None-return as an empty session.
+        if self._try_detect_and_rollback_to_assistant_checkpoint(request_messages):
+            return None
         # 2. Confirm the (possibly rolled-back) stored messages are a prefix of request,
         #    and that each appended message role is in tito_tokenizer.allowed_append_roles.
         try:
@@ -143,8 +147,15 @@ class LinearTrajectory:
     def _try_detect_and_rollback_to_assistant_checkpoint(
         self,
         request_messages: list[dict[str, Any]],
-    ) -> None:
+    ) -> bool:
         """Detect if *request_messages* diverges from stored history and roll back.
+
+        Returns ``True`` iff the session was reseeded to empty because the
+        matched prefix contains no assistant and no assistant turn has been
+        persisted yet (see "pre-assistant re-seed" below). Returns ``False``
+        for every other outcome (no rollback, or a normal rollback to a
+        prior assistant checkpoint). Callers should treat a ``True`` return
+        as equivalent to entering a fresh session.
 
         In agentic workflows the agent may retry from an earlier point — for
         example, re-running a tool call with different arguments.  When that
@@ -185,10 +196,21 @@ class LinearTrajectory:
         - The stored history is empty.
         - *request_messages* is a strict extension of stored messages
           (``match_len >= len(stored)``).
+
+        Pre-assistant re-seed: if the matched prefix contains no assistant
+        AND no assistant turn has been persisted yet (``num_assistant == 0``),
+        the stored state is a prompt-only seed (system/user) from a prior
+        request whose first assistant turn never completed, e.g. the LLM hit
+        ``max_tokens`` before emitting a stop token, errored in flight, or
+        timed out before the session record could be written. In that case
+        the session is reseeded to empty and ``True`` is returned so the
+        caller takes the fresh-session branch. This replaces a previous
+        ``MessageValidationError`` that killed trials which would otherwise
+        have recovered on retry.
         """
         stored = self.messages
         if not stored or not self.trajectory_token_ids:
-            return
+            return False
 
         match_len = 0
         for i in range(min(len(request_messages), len(stored))):
@@ -198,7 +220,7 @@ class LinearTrajectory:
                 break
 
         if match_len >= len(stored):
-            return
+            return False
 
         # Find the last assistant message within the matched prefix.
         rollback_msg_end = None
@@ -211,6 +233,23 @@ class LinearTrajectory:
                 assistant_count += 1
 
         if checkpoint_index < 0:
+            if self.num_assistant == 0:
+                # Pre-assistant re-seed: stored is a prompt-only state from
+                # a prior request whose first assistant turn never
+                # persisted. Clear state and let the caller treat this as a
+                # fresh session.
+                logger.info(
+                    "Reseeding session: no assistant checkpoint stored yet, "
+                    "request diverges at index %d (stored=%d msgs, request=%d msgs)",
+                    match_len,
+                    len(stored),
+                    len(request_messages),
+                )
+                self.messages = []
+                self.trajectory_token_ids = []
+                self.records = []
+                self.num_assistant = 0
+                return True
             raise MessageValidationError(
                 f"rollback failed: no assistant message found in the first "
                 f"{match_len} matched messages (stored has {len(stored)} messages, "
@@ -240,6 +279,7 @@ class LinearTrajectory:
         self.trajectory_token_ids = self.trajectory_token_ids[: checkpoint_index + 1]
         self.records = self.records[: checkpoint_index + 1]
         self.num_assistant = checkpoint_index + 1
+        return False
 
 
 class SessionRegistry:


### PR DESCRIPTION
When the agent retries with a divergent user message before the first assistant turn has been persisted, `_try_detect_and_rollback_to_assistant_checkpoint` raises `MessageValidationError` because the matched prefix contains no assistant checkpoint to roll back to. This kills trials that would otherwise recover on retry.

## Repro

Observed on two Harbor trials (`battery-charging-optimization` #6 and #7) aborted with:

```
litellm.BadRequestError: OpenAIException - Error code: 400 - {error: rollback failed: no assistant message found in the first 1 matched messages (stored has 2 messages, request has 3 messages)}
```

Chain of events:
1. Agent emits the first assistant turn, which hits `max_tokens` truncation and errors out before the response can be persisted.
2. Session state is therefore just `[system, user]` with `num_assistant=0`.
3. Agent retry path sends a new request whose user content diverges from the stored user message.
4. `match_len=1` (system matches, user diverges); no assistant in stored[:1], so `checkpoint_index=-1`, and the function raises.

## Fix

In the `checkpoint_index < 0` branch, if `num_assistant == 0` the stored state is a prompt-only seed whose first assistant turn never persisted. Clear the session and return `True` so the caller treats this as a fresh session. The existing raise path is preserved for cases where at least one assistant has been stored (rollback past an assistant turn remains disallowed).

The caller (`prepare_pretokenized`) early-returns `None` on the reseed signal, equivalent to the existing empty-session branch.

## Diff shape

- `_try_detect_and_rollback_to_assistant_checkpoint`: return type `None` -> `bool`
- New `num_assistant == 0` branch inside the existing `if checkpoint_index < 0:`
- Existing early returns get explicit `return False`
- `prepare_pretokenized` propagates the reseed signal

No behavior change for any case where at least one assistant has been persisted.