### PR TITLE
feat(rollout/session): stub /v1/model_info on session server

### DIFF
--- a/miles/rollout/session/sessions.py
+++ b/miles/rollout/session/sessions.py
@@ -246,6 +246,26 @@ def setup_session_routes(app, backend, args):
         finally:
             _inflight_chat["count"] -= 1
 
+    @app.get("/sessions/{session_id}/v1/model_info")
+    async def session_v1_model_info(session_id: str):
+        """OpenAI-compatible /v1/model_info stub.
+
+        LiteLLM (and other OpenAI-compat clients) probe /v1/model_info on
+        first connect for tokenizer hash and model-ID discovery. SGLang
+        does not expose /v1/model_info (it exposes /model_info without
+        the /v1/ prefix), so the default wildcard proxy below returns
+        404 and clients emit a warning on every new session.
+
+        Return a minimal stub advertising the served model name. Does
+        not validate the session_id because /v1/model_info is
+        session-independent; the session path segment is retained to
+        keep URL shape consistent with the other session endpoints.
+        """
+        return {
+            "id": getattr(args, "sglang_served_model_name", None) or "model",
+            "object": "model",
+        }
+
     @app.api_route("/sessions/{session_id}/{path:path}", methods=["GET", "POST", "PUT", "DELETE", "PATCH"])
     async def session_proxy(request: Request, session_id: str, path: str):
         result = await backend.do_proxy(request, path)


### PR DESCRIPTION
OpenAI-compatible clients (LiteLLM, openai-python) probe `/v1/model_info` on first connection for tokenizer hash and model-ID discovery. SGLang exposes this at `/model_info` (no `/v1/` prefix), so the existing session-proxy wildcard forwards to a non-existent SGLang endpoint and returns 404. Every new session emits a warning like:

```
Could not fetch tokenizer hash from
  http://.../sessions/<id>/v1/model_info: Client error 404 Not Found
```

## Fix

Add a specific route returning a minimal OpenAI-compatible stub with the served model name. Does not validate `session_id` because model_info is session-independent; the session path segment is kept for URL-shape consistency. Declared before the catch-all wildcard so it matches first.

## Scope

20-line addition, no behavior change for any existing route.