### PR TITLE
feat(log_utils): add train/rollout_id and train/step_in_rollout axes

### DIFF
--- a/miles/backends/training_utils/log_utils.py
+++ b/miles/backends/training_utils/log_utils.py
@@ -443,7 +443,24 @@ def log_train_step(
         for key, val in extra_metrics.items():
             log_dict_out[f"train/{role_tag}{key}"] = val
 
+    # `train/step` is the cumulative optimizer-step count across all
+    # rollouts. Because `num_steps_per_rollout` is not a fixed config
+    # value -- it scales with rollout-data volume divided by
+    # `max_tokens_per_gpu` (dynamic batching) -- the gap between
+    # successive rollouts on the `train/step` axis varies, and the
+    # absolute value is hard to interpret at a glance. Emit two
+    # additional axes that are stable by construction:
+    #   - `train/rollout_id`: which rollout cycle produced this data
+    #     (matches `rollout/step`, so train metrics can be plotted
+    #     against the same x-axis as rollout metrics).
+    #   - `train/step_in_rollout`: optimizer step within the rollout
+    #     (0..num_steps_per_rollout-1); useful for inspecting
+    #     within-rollout dynamics.
+    # `train/step` is kept as the canonical step_metric for backward
+    # compatibility.
     log_dict_out["train/step"] = accumulated_step_id
+    log_dict_out["train/rollout_id"] = rollout_id
+    log_dict_out["train/step_in_rollout"] = step_id
 
     if should_log is None:
         should_log = dist.get_rank() == 0

--- a/miles/utils/wandb_utils.py
+++ b/miles/utils/wandb_utils.py
@@ -156,6 +156,13 @@ def init_wandb_secondary(args, router_addr=None):
 def _init_wandb_common():
     wandb.define_metric("train/step")
     wandb.define_metric("train/*", step_metric="train/step")
+    # `train/rollout_id` and `train/step_in_rollout` are alternative x-axes
+    # to `train/step`. They let users view train/* metrics against a
+    # stable rollout-cycle counter or per-rollout-step index rather than
+    # the cumulative optimizer-step count, whose inter-rollout gaps are
+    # not constant under dynamic batching.
+    wandb.define_metric("train/rollout_id", step_metric="train/step")
+    wandb.define_metric("train/step_in_rollout", step_metric="train/step")
     wandb.define_metric("rollout/step")
     wandb.define_metric("rollout/*", step_metric="rollout/step")
     wandb.define_metric("multi_turn/*", step_metric="rollout/step")


### PR DESCRIPTION
`train/step` is the cumulative optimizer-step count across all rollouts, computed as `rollout_id * num_steps_per_rollout + step_id`. Because `num_steps_per_rollout` scales with rollout-data volume divided by `max_tokens_per_gpu` (dynamic batching), the gap between successive rollouts on the `train/step` axis varies, and the absolute value is hard to interpret at a glance.

## Motivation

In one run, `train/step` reached ~250 at `rollout_id=5` (~50 optimizer steps per rollout) purely because long trajectories were being split across many optimizer-sized micro-batches by the dynamic-batching logic. A viewer interpreting train/step as a pace-of-training counter gets confused: 250 sounds like a lot of progress, but really we have just 5 rollout cycles completed.

Cross-plotting train/* against rollout/* is also awkward because their x-axes are different (train/step vs rollout/step=rollout_id).

## Fix

Add two additional x-axes, stable by construction:

- `train/rollout_id`: which rollout cycle produced this data. Matches `rollout/step` so train metrics can share an x-axis with rollout metrics.
- `train/step_in_rollout`: optimizer step within the rollout (`0..num_steps_per_rollout-1`); useful for inspecting within-rollout dynamics.

`train/step` remains the canonical `step_metric` for backward compatibility; existing dashboards and queries are unaffected. The two new metrics are registered via `wandb.define_metric` with `train/step` as their `step_metric`, consistent with the rest of the `train/` namespace.

## Scope

Two-file diff, 24 insertions, 0 deletions. No behavior change to any existing metric.