### PR TITLE
fix(filter_hub): guard check_reward_nonzero_std against None rewards

### DIFF
--- a/.github/workflows/maintain-deploy.yml
+++ b/.github/workflows/maintain-deploy.yml
@@ -2,7 +2,7 @@ name: Maintain deploy branch
 
 on:
   schedule:
-    - cron: '*/15 * * * *'
+    - cron: '0 2 * * *'
   workflow_dispatch:
     inputs:
       force:
@@ -31,11 +31,35 @@ jobs:
           UPSTREAM_SHA=$(gh api "repos/${UPSTREAM}/commits/main" --jq '.sha' 2>/dev/null || echo "unknown")
 
           FORK_OWNER="${REPO%%/*}"
-          PR_STATE=$(gh api "repos/${UPSTREAM}/pulls?state=open&base=main&per_page=100" \
+          NOT_BLOCKED='select(([.labels[].name] | index("blocked")) == null)'
+
+          # Branches with open PRs against upstream (no blocked filter; upstream PRs always merge)
+          UPSTREAM_PR_STATE=$(gh api "repos/${UPSTREAM}/pulls?state=open&base=main&per_page=100" \
             --jq "[.[] | select(.head.repo.owner.login == \"${FORK_OWNER}\")] | sort_by(.head.ref) | map(.head.ref + \"=\" + .head.sha) | join(\",\")")
 
-          BRANCHES=$(gh api "repos/${UPSTREAM}/pulls?state=open&base=main&per_page=100" \
+          UPSTREAM_BRANCHES=$(gh api "repos/${UPSTREAM}/pulls?state=open&base=main&per_page=100" \
             --jq "[.[] | select(.head.repo.owner.login == \"${FORK_OWNER}\")] | .[].head.ref" | tr '\n' ' ')
+
+          # Branches with open PRs against the fork's own main (fork-only changes), excluding blocked PRs
+          FORK_PR_STATE=$(gh api "repos/${REPO}/pulls?state=open&base=main&per_page=100" \
+            --jq "[.[] | select(.head.repo.full_name == \"${REPO}\") | ${NOT_BLOCKED}] | sort_by(.head.ref) | map(.head.ref + \"=\" + .head.sha) | join(\",\")")
+
+          FORK_BRANCHES=$(gh api "repos/${REPO}/pulls?state=open&base=main&per_page=100" \
+            --jq "[.[] | select(.head.repo.full_name == \"${REPO}\") | ${NOT_BLOCKED}] | .[].head.ref" | tr '\n' ' ')
+
+          # Deduplicate: upstream PRs first, then fork-only PRs
+          BRANCHES="$UPSTREAM_BRANCHES"
+          for fb in $FORK_BRANCHES; do
+            if ! echo " $UPSTREAM_BRANCHES " | grep -q " $fb "; then
+              BRANCHES="$BRANCHES $fb"
+            fi
+          done
+
+          # Combine state fingerprints
+          PR_STATE="${UPSTREAM_PR_STATE}"
+          if [ -n "$FORK_PR_STATE" ]; then
+            PR_STATE="${PR_STATE:+${PR_STATE},}${FORK_PR_STATE}"
+          fi
 
           STATE="${UPSTREAM_SHA}|${PR_STATE}"
           echo "state=$STATE" >> "$GITHUB_OUTPUT"
@@ -107,6 +131,21 @@ jobs:
             echo "::warning::Failed to merge (conflicts):$FAILED"
           fi
           echo "FAILED_BRANCHES=$FAILED" >> "$GITHUB_ENV"
+
+      - name: Preserve fork-local .github/workflows
+        # GitHub Actions only reads workflow files on the branch where the trigger
+        # fires. Fork-local CI (e.g. release-binary.yml that triggers on push to
+        # deploy) lives on fork main, not upstream. Overlay fork-main workflows
+        # onto the deploy tree so those workflows survive the rebuild.
+        run: |
+          git fetch origin main
+          if git ls-tree -r origin/main -- .github/workflows/ 2>/dev/null | grep -q .
+          then
+            git checkout origin/main -- .github/workflows/
+            git add .github/workflows/
+            git diff --cached --quiet || \
+              git commit -m "Deploy: preserve fork-local .github/workflows from main"
+          fi
 
       - name: Stamp fingerprint and push
         env:

--- a/.github/workflows/maintain-deploy.yml
+++ b/.github/workflows/maintain-deploy.yml
@@ -60,10 +60,17 @@ jobs:
     if: needs.check.outputs.skip != 'true'
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.DEPLOY_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Configure git
         run: |

--- a/.github/workflows/maintain-deploy.yml
+++ b/.github/workflows/maintain-deploy.yml
@@ -1,18 +1,72 @@
 name: Maintain deploy branch
 
 on:
-  # Rebuild nightly
   schedule:
-    - cron: '0 10 * * *'  # 3 AM California (10 AM UTC)
-  # Rebuild when any feature branch is pushed
-  push:
-    branches:
-      - 'fix/**'
-  # Manual trigger
+    - cron: '*/15 * * * *'
   workflow_dispatch:
+    inputs:
+      force:
+        description: 'Rebuild even if no changes detected'
+        type: boolean
+        default: false
+
+env:
+  UPSTREAM: radixark/miles
 
 jobs:
-  rebuild-deploy:
+  check:
+    runs-on: ubuntu-latest
+    outputs:
+      skip: ${{ steps.fingerprint.outputs.skip }}
+      state: ${{ steps.fingerprint.outputs.state }}
+      branches: ${{ steps.fingerprint.outputs.branches }}
+    steps:
+      - name: Compute desired state and compare
+        id: fingerprint
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          FORCE: ${{ inputs.force }}
+          REPO: ${{ github.repository }}
+        run: |
+          UPSTREAM_SHA=$(gh api "repos/${UPSTREAM}/commits/main" --jq '.sha' 2>/dev/null || echo "unknown")
+
+          PR_STATE=$(gh pr list \
+            --repo "$UPSTREAM" \
+            --author DavidBellamy \
+            --state open \
+            --base main \
+            --json headRefName,headRefOid \
+            --jq 'sort_by(.headRefName) | map(.headRefName + "=" + .headRefOid) | join(",")')
+
+          BRANCHES=$(gh pr list \
+            --repo "$UPSTREAM" \
+            --author DavidBellamy \
+            --state open \
+            --base main \
+            --json headRefName \
+            --jq '.[].headRefName' | tr '\n' ' ')
+
+          STATE="${UPSTREAM_SHA}|${PR_STATE}"
+          echo "state=$STATE" >> "$GITHUB_OUTPUT"
+          echo "branches=$BRANCHES" >> "$GITHUB_OUTPUT"
+          echo "Desired state: $STATE"
+
+          CURRENT=$(gh api "repos/${REPO}/commits/deploy" \
+            --jq '.commit.message' 2>/dev/null \
+            | grep '^state:' | head -1 | cut -d: -f2- || echo "")
+
+          echo "Current state: $CURRENT"
+
+          if [ "$CURRENT" = "$STATE" ] && [ "$FORCE" != "true" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::No changes detected, skipping rebuild"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  rebuild:
+    needs: check
+    if: needs.check.outputs.skip != 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -27,29 +81,13 @@ jobs:
 
       - name: Fetch upstream
         run: |
-          git remote add upstream https://github.com/radixark/miles.git || true
+          git remote add upstream "https://github.com/${UPSTREAM}.git" || true
           git fetch upstream main
           git fetch origin
 
-      - name: Get branches with open PRs targeting upstream
-        id: branches
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          BRANCHES=$(gh pr list \
-            --repo radixark/miles \
-            --author DavidBellamy \
-            --state open \
-            --base main \
-            --json headRefName \
-            -q '.[].headRefName' | tr '\n' ' ')
-
-          echo "branches=$BRANCHES" >> "$GITHUB_OUTPUT"
-          echo "Open PR branches: ${BRANCHES:-<none>}"
-
       - name: Build deploy branch
         env:
-          PR_BRANCHES: ${{ steps.branches.outputs.branches }}
+          PR_BRANCHES: ${{ needs.check.outputs.branches }}
         run: |
           git checkout -B deploy upstream/main
 
@@ -68,9 +106,40 @@ jobs:
 
           echo "Successfully merged:${MERGED:-<none>}"
           if [ -n "$FAILED" ]; then
-            echo "::error::Failed to merge (conflicts):$FAILED"
-            exit 1
+            echo "::warning::Failed to merge (conflicts):$FAILED"
+          fi
+          echo "FAILED_BRANCHES=$FAILED" >> "$GITHUB_ENV"
+
+      - name: Stamp fingerprint and push
+        env:
+          STATE: ${{ needs.check.outputs.state }}
+        run: |
+          git commit --allow-empty -m "state:${STATE}"
+          git push origin deploy --force
+
+      - name: Report merge conflicts
+        if: always() && needs.check.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ISSUE_TITLE="Deploy: merge conflict"
+          EXISTING=$(gh issue list --label deploy-conflict --state open --json number --jq '.[0].number' 2>/dev/null || echo "")
+
+          if [ -z "$FAILED_BRANCHES" ]; then
+            if [ -n "$EXISTING" ]; then
+              gh issue close "$EXISTING" --comment "Resolved: all branches merged cleanly."
+            fi
+            exit 0
           fi
 
-      - name: Force-push deploy
-        run: git push origin deploy --force
+          BODY=$(printf "The following branches failed to merge into deploy:\n\n")
+          for b in $FAILED_BRANCHES; do
+            BODY=$(printf "%s\n- \`%s\`" "$BODY" "$b")
+          done
+          BODY=$(printf "%s\n\nThis issue auto-closes when the next build merges all branches cleanly." "$BODY")
+
+          if [ -n "$EXISTING" ]; then
+            gh issue edit "$EXISTING" --body "$BODY"
+          else
+            gh issue create --title "$ISSUE_TITLE" --body "$BODY" --label deploy-conflict
+          fi

--- a/.github/workflows/maintain-deploy.yml
+++ b/.github/workflows/maintain-deploy.yml
@@ -2,7 +2,7 @@ name: Maintain deploy branch
 
 on:
   schedule:
-    - cron: '0 2 * * *'
+    - cron: '0 9 * * *'  # 2 AM Pacific (PDT) / 1 AM PST. GitHub Actions cron is UTC only; accepts the ~1hr DST drift.
   workflow_dispatch:
     inputs:
       force:

--- a/.github/workflows/maintain-deploy.yml
+++ b/.github/workflows/maintain-deploy.yml
@@ -1,0 +1,76 @@
+name: Maintain deploy branch
+
+on:
+  # Rebuild nightly
+  schedule:
+    - cron: '0 10 * * *'  # 3 AM California (10 AM UTC)
+  # Rebuild when any feature branch is pushed
+  push:
+    branches:
+      - 'fix/**'
+  # Manual trigger
+  workflow_dispatch:
+
+jobs:
+  rebuild-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Fetch upstream
+        run: |
+          git remote add upstream https://github.com/radixark/miles.git || true
+          git fetch upstream main
+          git fetch origin
+
+      - name: Get branches with open PRs targeting upstream
+        id: branches
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BRANCHES=$(gh pr list \
+            --repo radixark/miles \
+            --author DavidBellamy \
+            --state open \
+            --base main \
+            --json headRefName \
+            -q '.[].headRefName' | tr '\n' ' ')
+
+          echo "branches=$BRANCHES" >> "$GITHUB_OUTPUT"
+          echo "Open PR branches: ${BRANCHES:-<none>}"
+
+      - name: Build deploy branch
+        env:
+          PR_BRANCHES: ${{ steps.branches.outputs.branches }}
+        run: |
+          git checkout -B deploy upstream/main
+
+          MERGED=""
+          FAILED=""
+          for branch in $PR_BRANCHES; do
+            echo "Merging $branch..."
+            if git merge "origin/$branch" --no-edit -m "Deploy: merge $branch"; then
+              MERGED="$MERGED $branch"
+            else
+              echo "::error::Merge conflict on $branch, skipping"
+              git merge --abort
+              FAILED="$FAILED $branch"
+            fi
+          done
+
+          echo "Successfully merged:${MERGED:-<none>}"
+          if [ -n "$FAILED" ]; then
+            echo "::error::Failed to merge (conflicts):$FAILED"
+            exit 1
+          fi
+
+      - name: Force-push deploy
+        run: git push origin deploy --force

--- a/.github/workflows/maintain-deploy.yml
+++ b/.github/workflows/maintain-deploy.yml
@@ -30,21 +30,12 @@ jobs:
         run: |
           UPSTREAM_SHA=$(gh api "repos/${UPSTREAM}/commits/main" --jq '.sha' 2>/dev/null || echo "unknown")
 
-          PR_STATE=$(gh pr list \
-            --repo "$UPSTREAM" \
-            --author DavidBellamy \
-            --state open \
-            --base main \
-            --json headRefName,headRefOid \
-            --jq 'sort_by(.headRefName) | map(.headRefName + "=" + .headRefOid) | join(",")')
+          FORK_OWNER="${REPO%%/*}"
+          PR_STATE=$(gh api "repos/${UPSTREAM}/pulls?state=open&base=main&per_page=100" \
+            --jq "[.[] | select(.head.repo.owner.login == \"${FORK_OWNER}\")] | sort_by(.head.ref) | map(.head.ref + \"=\" + .head.sha) | join(\",\")")
 
-          BRANCHES=$(gh pr list \
-            --repo "$UPSTREAM" \
-            --author DavidBellamy \
-            --state open \
-            --base main \
-            --json headRefName \
-            --jq '.[].headRefName' | tr '\n' ' ')
+          BRANCHES=$(gh api "repos/${UPSTREAM}/pulls?state=open&base=main&per_page=100" \
+            --jq "[.[] | select(.head.repo.owner.login == \"${FORK_OWNER}\")] | .[].head.ref" | tr '\n' ' ')
 
           STATE="${UPSTREAM_SHA}|${PR_STATE}"
           echo "state=$STATE" >> "$GITHUB_OUTPUT"
@@ -72,7 +63,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.DEPLOY_TOKEN }}
 
       - name: Configure git
         run: |

--- a/miles/rollout/filter_hub/dynamic_sampling_filters.py
+++ b/miles/rollout/filter_hub/dynamic_sampling_filters.py
@@ -8,6 +8,12 @@ __all__ = ["check_reward_nonzero_std", "check_no_aborted"]
 
 def check_reward_nonzero_std(args, samples: list[Sample], **kwargs):
     rewards = [sample.get_reward_value(args) for sample in samples]
+    # Aborted samples never get a reward computed (see generate_and_rm in
+    # sglang_rollout.py). Reject the group when any reward is None, matching
+    # the check_no_aborted convention — a group with a missing reward can't
+    # yield a reliable std and shouldn't contribute gradient signal.
+    if any(r is None for r in rewards):
+        return DynamicFilterOutput(keep=False, reason="group_has_aborted")
     keep = torch.tensor(rewards, dtype=torch.float64).std() > 1e-8
     return DynamicFilterOutput(
         keep=keep,

--- a/miles/utils/wandb_utils.py
+++ b/miles/utils/wandb_utils.py
@@ -89,6 +89,7 @@ def _compute_config_for_logging(args):
         # We may insert more default values here, and may also allow users to configure a whitelist
     ]
     output["env_vars"] = {k: v for k, v in os.environ.items() if k in whitelist_env_vars}
+    output["launched_by"] = os.environ.get("USER")
 
     if env_report_raw := args.env_report:
         if launcher_report := decode_env_report(env_report_raw):


### PR DESCRIPTION
## Why

`generate_and_rm` in `sglang_rollout.py` (lines 267-283) deliberately skips reward computation for samples with `status == Sample.Status.ABORTED`:

\`\`\`python
if any([sample.status == Sample.Status.ABORTED for sample in samples]):
    return samples  # rewards stay None
...
if sample.status == Sample.Status.ABORTED:
    return sample   # reward stays None
\`\`\`

This is the correct design — aborted samples legitimately exist when the sandbox times out, Docker crashes, or the LLM router times out. These are real runtime conditions, not bugs. \`Sample.reward\` defaults to \`None\` precisely so downstream can distinguish "real 0.0 reward" from "no reward computed."

The sibling filter `check_no_aborted` handles this correctly by rejecting the whole group. But `check_reward_nonzero_std` does not — it passes the reward list straight to `torch.tensor(rewards, dtype=torch.float64)`, which raises:

\`\`\`
TypeError: must be real number, not NoneType
\`\`\`

Observed tonight on LLM360 RL360 agentic RL pilot (GLM-4.7-Flash on tblite, job 1566511): first train step landed fine, filter crashed on the second rollout cycle after a sandbox-aborted sample.

## Fix

Mirror `check_no_aborted`'s convention: if any reward is None, reject the group with `reason="group_has_aborted"`. A group with a missing reward can't yield a reliable std and shouldn't contribute gradient signal regardless.

No behavior change when all rewards are real numbers; only the aborted-sample crash path is affected.

## Test plan

- [x] Patch applied, import still works locally
- [ ] Resubmit blocked RL360 pilots after image rebuild, confirm train loop progresses past the first rollout cycle