### PR TITLE
[CI] Drop --use-miles-router from R3 tests and add r3 comparasion test between sgl & miles router

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -92,6 +92,7 @@ jobs:
       MILES_TEST_ENABLE_EVAL: ${{ matrix.info.enable_eval || '1' }}
       MILES_TEST_FEW_GPU: '0'
       SESSION_TEST_MODEL_FAMILY: ${{ matrix.info.model_family || '' }}
+      ROUTER_EQ_MODEL_FAMILY: ${{ matrix.info.model_family || '' }}
 
     steps:
       - name: Checkout repository
@@ -188,7 +189,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        info: [{"num_gpus": 1, "test_file": "e2e/sglang/test_chat_input_ids_equivalence.py"}, {"model_family": "qwen3", "num_gpus": 1, "test_file": "e2e/sglang/test_session_server_tool_call.py"}, {"model_family": "glm47", "num_gpus": 1, "test_file": "e2e/sglang/test_session_server_tool_call.py"}, {"model_family": "qwen3", "num_gpus": 1, "test_file": "e2e/sglang/test_tito_logprob_equivalence.py"}, {"model_family": "glm47", "num_gpus": 1, "test_file": "e2e/sglang/test_tito_logprob_equivalence.py"}]
+        info: [{"num_gpus": 1, "test_file": "e2e/sglang/test_chat_input_ids_equivalence.py"}, {"model_family": "qwen3", "num_gpus": 1, "test_file": "e2e/sglang/test_session_server_tool_call.py"}, {"model_family": "glm47", "num_gpus": 1, "test_file": "e2e/sglang/test_session_server_tool_call.py"}, {"model_family": "qwen3", "num_gpus": 1, "test_file": "e2e/sglang/test_tito_logprob_equivalence.py"}, {"model_family": "glm47", "num_gpus": 1, "test_file": "e2e/sglang/test_tito_logprob_equivalence.py"}, {"model_family": "qwen3_30b_a3b", "num_gpus": 1, "test_file": "e2e/sglang/test_r3_router_equivalence.py"}, {"model_family": "glm47_flash", "num_gpus": 1, "test_file": "e2e/sglang/test_r3_router_equivalence.py"}]
     defaults:
       run:
         working-directory: ${{ github.workspace }}
@@ -204,6 +205,7 @@ jobs:
       MILES_TEST_ENABLE_EVAL: ${{ matrix.info.enable_eval || '1' }}
       MILES_TEST_FEW_GPU: '0'
       SESSION_TEST_MODEL_FAMILY: ${{ matrix.info.model_family || '' }}
+      ROUTER_EQ_MODEL_FAMILY: ${{ matrix.info.model_family || '' }}
 
     steps:
       - name: Checkout repository
@@ -316,6 +318,7 @@ jobs:
       MILES_TEST_ENABLE_EVAL: ${{ matrix.info.enable_eval || '1' }}
       MILES_TEST_FEW_GPU: '0'
       SESSION_TEST_MODEL_FAMILY: ${{ matrix.info.model_family || '' }}
+      ROUTER_EQ_MODEL_FAMILY: ${{ matrix.info.model_family || '' }}
 
     steps:
       - name: Checkout repository
@@ -428,6 +431,7 @@ jobs:
       MILES_TEST_ENABLE_EVAL: ${{ matrix.info.enable_eval || '1' }}
       MILES_TEST_FEW_GPU: '0'
       SESSION_TEST_MODEL_FAMILY: ${{ matrix.info.model_family || '' }}
+      ROUTER_EQ_MODEL_FAMILY: ${{ matrix.info.model_family || '' }}
 
     steps:
       - name: Checkout repository
@@ -540,6 +544,7 @@ jobs:
       MILES_TEST_ENABLE_EVAL: ${{ matrix.info.enable_eval || '1' }}
       MILES_TEST_FEW_GPU: '0'
       SESSION_TEST_MODEL_FAMILY: ${{ matrix.info.model_family || '' }}
+      ROUTER_EQ_MODEL_FAMILY: ${{ matrix.info.model_family || '' }}
 
     steps:
       - name: Checkout repository
@@ -652,6 +657,7 @@ jobs:
       MILES_TEST_ENABLE_EVAL: ${{ matrix.info.enable_eval || '1' }}
       MILES_TEST_FEW_GPU: '0'
       SESSION_TEST_MODEL_FAMILY: ${{ matrix.info.model_family || '' }}
+      ROUTER_EQ_MODEL_FAMILY: ${{ matrix.info.model_family || '' }}
 
     steps:
       - name: Checkout repository
@@ -764,6 +770,7 @@ jobs:
       MILES_TEST_ENABLE_EVAL: ${{ matrix.info.enable_eval || '1' }}
       MILES_TEST_FEW_GPU: '0'
       SESSION_TEST_MODEL_FAMILY: ${{ matrix.info.model_family || '' }}
+      ROUTER_EQ_MODEL_FAMILY: ${{ matrix.info.model_family || '' }}
 
     steps:
       - name: Checkout repository
@@ -876,6 +883,7 @@ jobs:
       MILES_TEST_ENABLE_EVAL: ${{ matrix.info.enable_eval || '1' }}
       MILES_TEST_FEW_GPU: '0'
       SESSION_TEST_MODEL_FAMILY: ${{ matrix.info.model_family || '' }}
+      ROUTER_EQ_MODEL_FAMILY: ${{ matrix.info.model_family || '' }}
 
     steps:
       - name: Checkout repository
@@ -988,6 +996,7 @@ jobs:
       MILES_TEST_ENABLE_EVAL: ${{ matrix.info.enable_eval || '1' }}
       MILES_TEST_FEW_GPU: '0'
       SESSION_TEST_MODEL_FAMILY: ${{ matrix.info.model_family || '' }}
+      ROUTER_EQ_MODEL_FAMILY: ${{ matrix.info.model_family || '' }}
 
     steps:
       - name: Checkout repository
@@ -1100,6 +1109,7 @@ jobs:
       MILES_TEST_ENABLE_EVAL: ${{ matrix.info.enable_eval || '1' }}
       MILES_TEST_FEW_GPU: '0'
       SESSION_TEST_MODEL_FAMILY: ${{ matrix.info.model_family || '' }}
+      ROUTER_EQ_MODEL_FAMILY: ${{ matrix.info.model_family || '' }}
 
     steps:
       - name: Checkout repository
@@ -1212,6 +1222,7 @@ jobs:
       MILES_TEST_ENABLE_EVAL: ${{ matrix.info.enable_eval || '1' }}
       MILES_TEST_FEW_GPU: '0'
       SESSION_TEST_MODEL_FAMILY: ${{ matrix.info.model_family || '' }}
+      ROUTER_EQ_MODEL_FAMILY: ${{ matrix.info.model_family || '' }}
 
     steps:
       - name: Checkout repository
@@ -1279,6 +1290,7 @@ jobs:
       MILES_TEST_ENABLE_EVAL: ${{ matrix.info.enable_eval || '1' }}
       MILES_TEST_FEW_GPU: '0'
       SESSION_TEST_MODEL_FAMILY: ${{ matrix.info.model_family || '' }}
+      ROUTER_EQ_MODEL_FAMILY: ${{ matrix.info.model_family || '' }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/pr-test.yml.j2
+++ b/.github/workflows/pr-test.yml.j2
@@ -76,6 +76,8 @@
         {'test_file': 'e2e/sglang/test_session_server_tool_call.py', 'num_gpus': 1, 'model_family': 'glm47'},
         {'test_file': 'e2e/sglang/test_tito_logprob_equivalence.py', 'num_gpus': 1, 'model_family': 'qwen3'},
         {'test_file': 'e2e/sglang/test_tito_logprob_equivalence.py', 'num_gpus': 1, 'model_family': 'glm47'},
+        {'test_file': 'e2e/sglang/test_r3_router_equivalence.py', 'num_gpus': 1, 'model_family': 'qwen3_30b_a3b'},
+        {'test_file': 'e2e/sglang/test_r3_router_equivalence.py', 'num_gpus': 1, 'model_family': 'glm47_flash'},
       ],
     },
     'e2e-test-short': {
@@ -191,6 +193,7 @@ jobs:
       MILES_TEST_ENABLE_EVAL: ${{ matrix.info.enable_eval || '1' }}
       MILES_TEST_FEW_GPU: '0'
       SESSION_TEST_MODEL_FAMILY: ${{ matrix.info.model_family || '' }}
+      ROUTER_EQ_MODEL_FAMILY: ${{ matrix.info.model_family || '' }}
 
     steps:
       - name: Checkout repository

--- a/tests/e2e/megatron/test_glm47_flash_r3_mtp.py
+++ b/tests/e2e/megatron/test_glm47_flash_r3_mtp.py
@@ -77,7 +77,6 @@ def execute():
         "--eps-clip 0.2 "
         "--eps-clip-high 0.28 "
         "--use-rollout-routing-replay "
-        "--use-miles-router "
     )
 
     optimizer_args = (

--- a/tests/e2e/megatron/test_moonlight_16B_A3B_r3.py
+++ b/tests/e2e/megatron/test_moonlight_16B_A3B_r3.py
@@ -69,7 +69,6 @@ def execute():
         "--entropy-coef 0.00 "
         "--eps-clip 4e-4 "
         "--use-rollout-routing-replay "
-        "--use-miles-router "
     )
 
     optimizer_args = (

--- a/tests/e2e/megatron/test_qwen3_30B_A3B_r3.py
+++ b/tests/e2e/megatron/test_qwen3_30B_A3B_r3.py
@@ -77,7 +77,6 @@ def execute():
         "--eps-clip 4e-4 "
         "--use-tis "
         "--use-rollout-routing-replay "
-        "--use-miles-router "
     )
 
     optimizer_args = (

--- a/tests/e2e/sglang/test_r3_router_equivalence.py
+++ b/tests/e2e/sglang/test_r3_router_equivalence.py
@@ -67,7 +67,6 @@ class ModelConfig:
     local_dir: str
     megatron_model_type: str
     reasoning_parser: str | None = None
-    extra_prepare: str | None = None
     num_gpus: int = 1
 
 
@@ -86,10 +85,6 @@ MODEL_REGISTRY: dict[str, ModelConfig] = {
         local_dir="/root/models/GLM-4.7-Flash",
         megatron_model_type="glm4.7-flash",
         reasoning_parser="glm45",
-        extra_prepare=(
-            "pip install git+https://github.com/huggingface/transformers.git@"
-            "76732b4e7120808ff989edbd16401f61fa6a0afa --break-system-packages"
-        ),
         num_gpus=1,
     ),
 }
@@ -104,8 +99,6 @@ def _get_config() -> ModelConfig:
 def prepare() -> None:
     cfg = _get_config()
     U.exec_command("mkdir -p /root/models /root/datasets")
-    if cfg.extra_prepare:
-        U.exec_command(cfg.extra_prepare)
     if not Path(cfg.local_dir).exists():
         U.exec_command(f"hf download {cfg.hf_repo} --local-dir {cfg.local_dir}")
     if not Path(PROMPT_DATA_PATH).exists():
@@ -264,5 +257,3 @@ if __name__ == "__main__":
     for proxy_var in ("http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY"):
         os.environ.pop(proxy_var, None)
     execute()
-    if MODEL_FAMILY == "glm47_flash":
-        U.exec_command("pip install transformers==4.57.1 --break-system-packages")

--- a/tests/e2e/sglang/test_r3_router_equivalence.py
+++ b/tests/e2e/sglang/test_r3_router_equivalence.py
@@ -54,6 +54,11 @@ PROMPT_DATA_PATH = "/root/datasets/dapo-math-17k/dapo-math-17k.jsonl"
 NUM_PROMPTS = int(os.environ.get("ROUTER_EQ_NUM_PROMPTS", "10"))
 MAX_RESPONSE_LEN = int(os.environ.get("ROUTER_EQ_MAX_RESPONSE_LEN", "256"))
 
+# Repo root (tests/e2e/sglang/test_*.py → parents[3]).  Used to prepend the
+# miles repo onto the Ray actor PYTHONPATH so the custom generate function is
+# importable regardless of where the worktree lives.
+_REPO_ROOT = str(Path(__file__).resolve().parents[3])
+
 
 @dataclass(frozen=True)
 class ModelConfig:
@@ -182,6 +187,7 @@ def _run_variant(cfg: ModelConfig, variant: str) -> None:
         num_gpus_per_node=cfg.num_gpus,
         megatron_model_type=cfg.megatron_model_type,
         extra_env_vars={
+            "PYTHONPATH": "/root/Megatron-LM",
             "MILES_ROUTER_EQ_DUMP_PATH": str(dump_path),
             "MILES_EXPERIMENTAL_ROLLOUT_REFACTOR": "1",
         },

--- a/tests/e2e/sglang/test_r3_router_equivalence.py
+++ b/tests/e2e/sglang/test_r3_router_equivalence.py
@@ -1,0 +1,262 @@
+"""E2E test: verify sglang router and miles router produce identical rollout
+routing replay results across MoE models.
+
+Design
+~~~~~~
+For each model in ``MODEL_REGISTRY``, run the same rollout workload twice
+under ``--debug-rollout-only --sglang-enable-deterministic-inference
+--use-rollout-routing-replay``:
+
+1. ``variant=miles``: with ``--use-miles-router`` (Python middleware
+   router wrapping the Rust gateway).
+2. ``variant=sgl``: without ``--use-miles-router`` (direct Rust gateway,
+   which is what PR #1015 drops R3 tests onto).
+
+Each run writes a JSONL of per-sample ``(tokens, rollout_log_probs,
+rollout_routed_experts)`` via the custom generate function in
+``utils.router_equivalence_generate``.  Once both runs finish we diff
+the dumps; they must match byte-for-byte (deterministic inference +
+identical prompts).
+
+Backend / checkpoint
+~~~~~~~~~~~~~~~~~~~~
+Megatron backend (same as the sibling ``tests/e2e/megatron/*_r3.py``
+tests) — sourcing ``scripts/models/{type}.sh`` populates
+``args.num_layers`` / ``args.moe_router_topk`` that the rollout-side
+reshape of ``routed_experts`` depends on.  We do *not* set
+``--use-kl-loss`` or ``--kl-coef`` > 0, which is what gates the
+``--ref-load`` existence check (``miles/utils/arguments.py``), and
+``--debug-rollout-only`` makes ``_compute_megatron_num_gpus`` return
+``0`` so no megatron actor is spawned and the checkpoint is never
+loaded.  This lets us get away with a single H200 and no
+``convert_hf_to_torch_dist`` step.
+
+Controls
+~~~~~~~~
+- ``ROUTER_EQ_MODEL_FAMILY``: ``qwen3_30b_a3b`` (default) | ``glm47_flash``.
+- Single H200, bf16, rollout batch 10, num_rollout 1. Single engine
+  (``--rollout-num-gpus-per-engine 1``) so both variants hit the same
+  underlying sglang process topology.
+"""
+
+import base64
+import json
+import os
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+
+import miles.utils.external_utils.command_utils as U
+
+MODEL_FAMILY = os.environ.get("ROUTER_EQ_MODEL_FAMILY", "qwen3_30b_a3b")
+DUMP_ROOT = Path(os.environ.get("ROUTER_EQ_DUMP_ROOT", "/tmp/router-eq"))
+PROMPT_DATA_PATH = "/root/datasets/dapo-math-17k/dapo-math-17k.jsonl"
+NUM_PROMPTS = int(os.environ.get("ROUTER_EQ_NUM_PROMPTS", "10"))
+MAX_RESPONSE_LEN = int(os.environ.get("ROUTER_EQ_MAX_RESPONSE_LEN", "256"))
+
+
+@dataclass(frozen=True)
+class ModelConfig:
+    model_name: str
+    hf_repo: str
+    local_dir: str
+    megatron_model_type: str
+    reasoning_parser: str | None = None
+    extra_prepare: str | None = None
+    num_gpus: int = 1
+
+
+MODEL_REGISTRY: dict[str, ModelConfig] = {
+    "qwen3_30b_a3b": ModelConfig(
+        model_name="Qwen3-30B-A3B",
+        hf_repo="Qwen/Qwen3-30B-A3B",
+        local_dir="/root/models/Qwen3-30B-A3B",
+        megatron_model_type="qwen3-30B-A3B",
+        reasoning_parser=None,
+        num_gpus=1,
+    ),
+    "glm47_flash": ModelConfig(
+        model_name="GLM-4.7-Flash",
+        hf_repo="zai-org/GLM-4.7-Flash",
+        local_dir="/root/models/GLM-4.7-Flash",
+        megatron_model_type="glm4.7-flash",
+        reasoning_parser="glm45",
+        extra_prepare=(
+            "pip install git+https://github.com/huggingface/transformers.git@"
+            "76732b4e7120808ff989edbd16401f61fa6a0afa --break-system-packages"
+        ),
+        num_gpus=1,
+    ),
+}
+
+
+def _get_config() -> ModelConfig:
+    if MODEL_FAMILY not in MODEL_REGISTRY:
+        raise ValueError(f"Unknown ROUTER_EQ_MODEL_FAMILY={MODEL_FAMILY!r}; choose from {list(MODEL_REGISTRY)}")
+    return MODEL_REGISTRY[MODEL_FAMILY]
+
+
+def prepare() -> None:
+    cfg = _get_config()
+    U.exec_command("mkdir -p /root/models /root/datasets")
+    if cfg.extra_prepare:
+        U.exec_command(cfg.extra_prepare)
+    if not Path(cfg.local_dir).exists():
+        U.exec_command(f"hf download {cfg.hf_repo} --local-dir {cfg.local_dir}")
+    if not Path(PROMPT_DATA_PATH).exists():
+        U.hf_download_dataset("zhuzilin/dapo-math-17k")
+
+
+def _variant_dir(variant: str) -> Path:
+    return DUMP_ROOT / MODEL_FAMILY / variant
+
+
+def _variant_dump_path(variant: str) -> Path:
+    return _variant_dir(variant) / "dump.jsonl"
+
+
+def _build_train_args(cfg: ModelConfig, variant: str) -> str:
+    ckpt_args = f"--hf-checkpoint {cfg.local_dir} "
+
+    rollout_args = (
+        f"--prompt-data {PROMPT_DATA_PATH} "
+        "--input-key prompt "
+        "--label-key label "
+        "--apply-chat-template "
+        "--rm-type deepscaler "
+        "--num-rollout 1 "
+        f"--rollout-batch-size {NUM_PROMPTS} "
+        "--n-samples-per-prompt 1 "
+        f"--rollout-max-response-len {MAX_RESPONSE_LEN} "
+        "--rollout-temperature 0.0 "
+        f"--global-batch-size {NUM_PROMPTS} "
+        "--rollout-seed 42 "
+    )
+
+    generate_args = "--custom-generate-function-path " "tests.e2e.sglang.utils.router_equivalence_generate.generate "
+
+    router_args = "--use-rollout-routing-replay "
+    if variant == "miles":
+        router_args += "--use-miles-router "
+
+    # Minimal megatron perf args — 1 GPU, no parallelism. We don't actually
+    # start a megatron actor under --debug-rollout-only, so these are only
+    # consumed by the argument parser.
+    perf_args = (
+        "--tensor-model-parallel-size 1 "
+        "--pipeline-model-parallel-size 1 "
+        "--context-parallel-size 1 "
+        "--expert-model-parallel-size 1 "
+        "--expert-tensor-parallel-size 1 "
+    )
+
+    sglang_args = (
+        f"--rollout-num-gpus-per-engine {cfg.num_gpus} "
+        "--sglang-enable-deterministic-inference "
+        "--sglang-mem-fraction-static 0.85 "
+    )
+    if cfg.reasoning_parser:
+        sglang_args += f"--sglang-reasoning-parser {cfg.reasoning_parser} "
+
+    infra_args = (
+        "--debug-rollout-only "
+        "--ci-test "
+        "--actor-num-nodes 1 "
+        f"--actor-num-gpus-per-node {cfg.num_gpus} "
+        "--colocate "
+    )
+
+    return ckpt_args + rollout_args + generate_args + router_args + perf_args + sglang_args + infra_args
+
+
+def _run_variant(cfg: ModelConfig, variant: str) -> None:
+    dump_dir = _variant_dir(variant)
+    if dump_dir.exists():
+        shutil.rmtree(dump_dir)
+    dump_dir.mkdir(parents=True, exist_ok=True)
+    dump_path = _variant_dump_path(variant)
+
+    train_args = _build_train_args(cfg, variant)
+    U.execute_train(
+        train_args=train_args,
+        num_gpus_per_node=cfg.num_gpus,
+        megatron_model_type=cfg.megatron_model_type,
+        extra_env_vars={
+            "MILES_ROUTER_EQ_DUMP_PATH": str(dump_path),
+            "MILES_EXPERIMENTAL_ROLLOUT_REFACTOR": "1",
+        },
+    )
+
+
+def _load_dump(path: Path) -> list[dict]:
+    with open(path) as f:
+        records = [json.loads(line) for line in f if line.strip()]
+    records.sort(key=lambda r: r["index"])
+    return records
+
+
+def _assert_records_equal(left: list[dict], right: list[dict]) -> None:
+    assert len(left) == len(right), f"dump length differs: {len(left)} vs {len(right)}"
+
+    for i, (a, b) in enumerate(zip(left, right, strict=True)):
+        assert a["index"] == b["index"], f"record {i}: index {a['index']} vs {b['index']}"
+
+        # Tokens and status must match exactly — deterministic decoding.
+        for field in ("status", "response_length", "tokens"):
+            assert (
+                a[field] == b[field]
+            ), f"index={a['index']} field={field} mismatch:\n  miles: {a[field]}\n  sgl:   {b[field]}"
+
+        # Logprobs are f32 from sglang; in deterministic mode they should be
+        # bit-identical, but tolerate tiny float noise as a safety margin.
+        la = a["rollout_log_probs"] or []
+        lb = b["rollout_log_probs"] or []
+        assert len(la) == len(lb), f"index={a['index']} logprob length differs"
+        for j, (xa, xb) in enumerate(zip(la, lb, strict=True)):
+            assert abs(xa - xb) <= 1e-6, f"index={a['index']} logprob[{j}] {xa} vs {xb}"
+
+        # routed_experts: deterministic int32 → must be byte-identical.
+        assert (
+            a["rollout_routed_experts_shape"] == b["rollout_routed_experts_shape"]
+        ), f"index={a['index']} routed_experts_shape mismatch"
+        ea = a["rollout_routed_experts_b64"]
+        eb = b["rollout_routed_experts_b64"]
+        if ea is None and eb is None:
+            continue
+        assert ea is not None and eb is not None, f"index={a['index']} one side missing routed_experts"
+        # Compare raw bytes, not the base64 string (equivalent, but clearer error).
+        ba = base64.b64decode(ea)
+        bb = base64.b64decode(eb)
+        assert ba == bb, f"index={a['index']} routed_experts bytes differ"
+
+
+def execute() -> None:
+    cfg = _get_config()
+    for variant in ("miles", "sgl"):
+        _run_variant(cfg, variant)
+
+    miles_records = _load_dump(_variant_dump_path("miles"))
+    sgl_records = _load_dump(_variant_dump_path("sgl"))
+
+    assert miles_records, "miles-router run produced no dump records"
+    assert sgl_records, "sglang-router run produced no dump records"
+
+    _assert_records_equal(miles_records, sgl_records)
+
+    print(f"[router-eq] model_family={MODEL_FAMILY} variants miles/sgl " f"match across {len(miles_records)} samples")
+
+
+def test_r3_router_equivalence():
+    prepare()
+    for proxy_var in ("http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY"):
+        os.environ.pop(proxy_var, None)
+    execute()
+
+
+if __name__ == "__main__":
+    prepare()
+    for proxy_var in ("http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY"):
+        os.environ.pop(proxy_var, None)
+    execute()
+    if MODEL_FAMILY == "glm47_flash":
+        U.exec_command("pip install transformers==4.57.1 --break-system-packages")

--- a/tests/e2e/sglang/utils/router_equivalence_generate.py
+++ b/tests/e2e/sglang/utils/router_equivalence_generate.py
@@ -1,0 +1,71 @@
+"""Custom generate function for router-equivalence e2e test.
+
+Wraps the stock ``single_turn.generate`` and, after each rollout, appends a
+JSON record to ``$MILES_ROUTER_EQ_DUMP_PATH`` capturing the fields that
+must match byte-for-byte between two runs using different routers:
+
+- ``tokens`` (the full input + output token ids)
+- ``rollout_log_probs`` (per-output-token logprob)
+- ``rollout_routed_experts`` (shape + base64-encoded int32 bytes)
+
+The dump is later loaded by ``test_r3_router_equivalence`` and diffed
+between a ``--use-miles-router`` run and a sglang-router run.
+"""
+
+import base64
+import json
+import logging
+import os
+from pathlib import Path
+
+import numpy as np
+
+from miles.rollout.base_types import GenerateFnInput, GenerateFnOutput
+from miles.rollout.generate_hub.single_turn import generate as _base_generate
+from miles.utils.types import Sample
+
+logger = logging.getLogger(__name__)
+
+_DUMP_PATH_ENV = "MILES_ROUTER_EQ_DUMP_PATH"
+
+
+def _dump_sample(sample: Sample) -> dict:
+    re = sample.rollout_routed_experts
+    if re is not None:
+        arr = np.ascontiguousarray(re, dtype=np.int32)
+        experts_shape = list(arr.shape)
+        experts_b64 = base64.b64encode(arr.tobytes()).decode("ascii")
+    else:
+        experts_shape = None
+        experts_b64 = None
+
+    return {
+        "index": sample.index,
+        "status": str(sample.status),
+        "response_length": sample.response_length,
+        "tokens": list(sample.tokens) if sample.tokens is not None else None,
+        "rollout_log_probs": list(sample.rollout_log_probs) if sample.rollout_log_probs is not None else None,
+        "rollout_routed_experts_shape": experts_shape,
+        "rollout_routed_experts_b64": experts_b64,
+    }
+
+
+async def generate(input: GenerateFnInput) -> GenerateFnOutput:
+    out = await _base_generate(input)
+
+    dump_path = os.environ.get(_DUMP_PATH_ENV)
+    if not dump_path:
+        logger.warning("%s not set; not dumping", _DUMP_PATH_ENV)
+        return out
+
+    samples = out.samples if isinstance(out.samples, list) else [out.samples]
+
+    Path(dump_path).parent.mkdir(parents=True, exist_ok=True)
+    with open(dump_path, "a") as f:
+        for s in samples:
+            f.write(json.dumps(_dump_sample(s)) + "\n")
+
+    return out
+
+
+generate.add_arguments = getattr(_base_generate, "add_arguments", None)

--- a/tests/e2e/short/test_dumper.py
+++ b/tests/e2e/short/test_dumper.py
@@ -143,7 +143,7 @@ def _execute(perf_args: str, dump_subdir: str, dump_dir: str) -> None:
         "--attention-backend flash "
         f"--actor-num-nodes 1 --actor-num-gpus-per-node {NUM_GPUS} --colocate "
         "--moe-token-dispatcher-type alltoall "
-        "--use-miles-router --use-rollout-routing-replay "
+        "--use-rollout-routing-replay "
     )
 
     train_args = " ".join(


### PR DESCRIPTION
With sgl-router-for-miles preserving routed_experts metadata end-to-end, R3 tests no longer need the Python miles-router wrapper. Dropping the flag lets R3 exercise the Rust gateway path directly.
