### PR TITLE
Use load_generate_function in legacy sglang_rollout path

### DIFF
--- a/miles/rollout/sglang_rollout.py
+++ b/miles/rollout/sglang_rollout.py
@@ -1,6 +1,5 @@
 import asyncio
 import copy
-import inspect
 import logging
 import uuid
 from argparse import Namespace
@@ -15,8 +14,9 @@ from packaging.version import parse
 from tqdm import tqdm
 
 from miles.backends.megatron_utils.lora_utils import LORA_ADAPTER_NAME, is_lora_enabled
-from miles.rollout.base_types import RolloutFnEvalOutput, RolloutFnTrainOutput
+from miles.rollout.base_types import GenerateFnInput, RolloutFnEvalOutput, RolloutFnTrainOutput
 from miles.rollout.filter_hub.base_types import MetricGatherer, call_dynamic_filter
+from miles.rollout.inference_rollout.compatibility import load_generate_function
 from miles.utils import dumper_utils
 from miles.utils.async_utils import run
 from miles.utils.data import Dataset
@@ -260,13 +260,12 @@ async def generate_and_rm(
             # Check sample.generate_function_path for per-sample custom_generate_function_path (e.g., from eval dataset config)
             custom_func_path = getattr(sample, "generate_function_path", None) or args.custom_generate_function_path
 
-            if custom_func_path is not None:
-                custom_generate_func = load_function(custom_func_path)
-                # if signature has evaluation, pass evaluation
-                if "evaluation" in inspect.signature(custom_generate_func).parameters:
-                    sample = await custom_generate_func(args, sample, sampling_params, evaluation=evaluation)
-                else:
-                    sample = await custom_generate_func(args, sample, sampling_params)
+            generate_fn = load_generate_function(custom_func_path) if custom_func_path else None
+            if generate_fn is not None:
+                output = await generate_fn(
+                    GenerateFnInput(state=state, sample=sample, sampling_params=sampling_params, evaluation=evaluation)
+                )
+                sample = output.samples
             else:
                 sample = await generate(args, sample, sampling_params)
 


### PR DESCRIPTION
## Summary

Replace the inline `inspect.signature`-based dispatch in `sglang_rollout.py::generate_and_rm` with the existing `load_generate_function` from `compatibility.py`.

This allows `GenerateFnInput`-style generate functions (e.g. `agentic_tool_call.generate`) to work on the legacy rollout path (without `MILES_EXPERIMENTAL_ROLLOUT_REFACTOR=1`), while keeping full backward compatibility with existing 3-arg and 4-arg custom generate functions.

### Why not the approach in #1008?

PR #1008 adds an inline shim that `inspect.signature`-sniffs on every per-sample call and duplicates logic already in `compatibility.py`. This PR instead reuses the existing `load_generate_function` + `LegacyGenerateFnAdapter` infrastructure which:

- Detects legacy vs new signatures at load time (not per-call)
- Uses a more precise heuristic (`len(params) >= 3 and params[0] != "input"`) vs `len(params) == 1`
- Keeps a single source of truth for dispatch logic (DRY)
- Has no performance impact relative to the old code (same `load_function` + `inspect.signature` cost that was already there)

### Changes

- `miles/rollout/sglang_rollout.py`: Replace 6-line inline dispatch with 4-line unified `GenerateFnInput` call via `load_generate_function`
- Remove unused `import inspect`

## Test plan

- Existing 3-arg and 4-arg custom generate functions dispatch correctly through `LegacyGenerateFnAdapter` (no behavior change)
- New `GenerateFnInput`-style functions (e.g. `agentic_tool_call.generate`) work without `MILES_EXPERIMENTAL_ROLLOUT_REFACTOR=1`
- Per-sample `generate_function_path` (from eval dataset configs) continues to work


Made with [Cursor](https://cursor.com)