### PR TITLE
wandb: co-log train/rollout_id and rollout/step across all log sites

### DIFF
--- a/miles/backends/training_utils/log_utils.py
+++ b/miles/backends/training_utils/log_utils.py
@@ -56,6 +56,7 @@ def gather_log_data(
         # Calculate step once to avoid duplication
         step = compute_rollout_step(args, rollout_id)
         reduced_log_dict["rollout/step"] = step
+        reduced_log_dict["train/rollout_id"] = rollout_id
         tracking_utils.log(args, reduced_log_dict, step_key="rollout/step")
 
         return reduced_log_dict
@@ -353,7 +354,11 @@ def log_cpu_memory(rollout_id: int, args: Namespace, label: str) -> None:
     logger.info(f"[CPU memory] {label}: {cpu_mem_gb:.2f} GB (rollout_id={rollout_id}, step={step})")
     tracking_utils.log(
         args,
-        {f"perf/cpu_memory_{label}_gb": cpu_mem_gb, "rollout/step": step},
+        {
+            f"perf/cpu_memory_{label}_gb": cpu_mem_gb,
+            "rollout/step": step,
+            "train/rollout_id": rollout_id,
+        },
         step_key="rollout/step",
     )
 
@@ -444,6 +449,10 @@ def log_train_step(
             log_dict_out[f"train/{role_tag}{key}"] = val
 
     log_dict_out["train/step"] = accumulated_step_id
+    # Co-log the rollout counter in both forms so train/* metrics can be
+    # cross-plotted against rollout-side axes in the wandb UI.
+    log_dict_out["train/rollout_id"] = rollout_id
+    log_dict_out["rollout/step"] = compute_rollout_step(args, rollout_id)
 
     if should_log is None:
         should_log = dist.get_rank() == 0

--- a/miles/ray/rollout.py
+++ b/miles/ray/rollout.py
@@ -1171,6 +1171,7 @@ def _log_eval_rollout_data(rollout_id, args, data, extra_metrics: dict[str, Any]
 
     step = compute_rollout_step(args, rollout_id)
     log_dict["eval/step"] = step
+    log_dict["train/rollout_id"] = rollout_id
     tracking_utils.log(args, log_dict, step_key="eval/step")
 
     return log_dict
@@ -1191,6 +1192,7 @@ def _log_rollout_data(rollout_id, args, samples, rollout_extra_metrics, rollout_
     logger.info(f"perf {rollout_id}: {log_dict}")
     step = compute_rollout_step(args, rollout_id)
     log_dict["rollout/step"] = step
+    log_dict["train/rollout_id"] = rollout_id
     tracking_utils.log(args, log_dict, step_key="rollout/step")
 
 

--- a/miles/utils/train_metric_utils.py
+++ b/miles/utils/train_metric_utils.py
@@ -45,4 +45,5 @@ def log_perf_data_raw(
 
     step = compute_rollout_step(args, rollout_id)
     log_dict["rollout/step"] = step
+    log_dict["train/rollout_id"] = rollout_id
     tracking_utils.log(args, log_dict, step_key="rollout/step")

--- a/miles/utils/wandb_utils.py
+++ b/miles/utils/wandb_utils.py
@@ -163,3 +163,8 @@ def _init_wandb_common():
     wandb.define_metric("eval/step")
     wandb.define_metric("eval/*", step_metric="eval/step")
     wandb.define_metric("perf/*", step_metric="rollout/step")
+    # train/rollout_id is co-logged on both rollout-side and train-side log() calls
+    # so that any train/* or rollout/* metric can be cross-plotted against the
+    # rollout counter. Declared after the "train/*" wildcard so the specific name
+    # isn't inadvertently treated as step-metric'd against train/step.
+    wandb.define_metric("train/rollout_id")


### PR DESCRIPTION
## Problem

In async RL, the rollout workers and the trainer log on different cadences to wandb. Each `wandb.log({...})` writes a single row that only has values for the keys present in that call dict. Because rollout-side and train-side log calls are disjoint, plotting a metric against any x-axis other than its own declared `step_metric` shows inconsistent point counts on the same run.

Concretely, on a recent run I observed the same run showing different max x-values across pinned panels: `rollout/step` going to 4 on reward charts, 3 on perf charts, and `Step` going to 1 on throughput charts. Root cause is not lost data, it's that each metric's log() call had no value for the x-axis key the other side was using. That also makes it impossible today to cross-plot a rollout-side metric like `rollout/raw_reward` on a chart keyed off `train/rollout_id`.

## Fix

Every wandb.log() site that has `rollout_id` in scope now stamps two additional keys into its existing log dict:
- `rollout/step` (already present on rollout-side calls; now also stamped on train-side `log_train_step`)
- `train/rollout_id` (new key, stamped on every rollout-side, train-side, eval-side, perf-side, and cpu-memory log call)

`train/rollout_id` is also declared via `wandb.define_metric` so the wandb UI treats it as a selectable x-axis. It is declared after the `train/*` wildcard to make sure it isn't inadvertently step-metric'd against `train/step`.

No `step_metric` associations change. Existing default axes remain the same. The only effect is that every log row now carries both cross-axis values, so any metric is plottable against any of the three semantic step axes.

## Sites touched

- `miles/backends/training_utils/log_utils.py` — `gather_log_data` (rollout/perf/multi_turn/passrate funnel), `log_cpu_memory`, `log_train_step`
- `miles/utils/train_metric_utils.py` — `log_perf_data_raw`
- `miles/ray/rollout.py` — `_log_rollout_data`, `_log_eval_rollout_data`
- `miles/utils/wandb_utils.py` — declare `train/rollout_id` as a step metric in `_init_wandb_common`

## Behavior change

Each log row is ~16 bytes larger (one extra int key plus one extra step value). No change to what metrics exist, no change to default chart axes, no change to the meaning of any existing metric.