### PR TITLE
[chore] drop legacy transformers upgrade pin for glm47-flash and qwen35

### DIFF
--- a/examples/experimental/swe-agent-v2/README.md
+++ b/examples/experimental/swe-agent-v2/README.md
@@ -58,7 +58,6 @@ Docker Network (swe-net)
 - Docker with GPU support (nvidia-container-toolkit)
 - Model weights downloaded (e.g. `zai-org/GLM-4.7-Flash`)
 - `transformers>=5` (`pip install "transformers>=5"` — GLM-4.7-Flash's `glm4_moe_lite` model type is not in transformers 4.x)
-- Recommended transformer version: `pip install git+https://github.com/huggingface/transformers.git@76732b4e7120808ff989edbd16401f61fa6a0afa`
 - Harbor task directories prepared under a shared path
 
 ### Step 1: Create Docker network

--- a/scripts/run-glm4.7-flash.sh
+++ b/scripts/run-glm4.7-flash.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-# Notice: run this command to upgrade transformers version which supports glm4.7-flash.
-# pip install git+https://github.com/huggingface/transformers.git@76732b4e7120808ff989edbd16401f61fa6a0afa
-
 # for rerun the task
 pkill -9 sglang
 sleep 3

--- a/scripts/run_glm47_flash.py
+++ b/scripts/run_glm47_flash.py
@@ -24,10 +24,6 @@ class ScriptArgs(U.ExecuteTrainConfig):
 
 def prepare(args: ScriptArgs):
     U.exec_command(f"mkdir -p {args.model_dir} {args.data_dir}")
-    # GLM-4.7-Flash requires a newer transformers version
-    U.exec_command(
-        "pip install git+https://github.com/huggingface/transformers.git@76732b4e7120808ff989edbd16401f61fa6a0afa"
-    )
     U.exec_command(
         f"hf download {args.model_org}/{args.model_name} " f"--local-dir {args.model_dir}/{args.model_name}"
     )

--- a/scripts/run_qwen3_5_35b_a3b_mtp_cp2_ep8.py
+++ b/scripts/run_qwen3_5_35b_a3b_mtp_cp2_ep8.py
@@ -23,7 +23,6 @@ class ScriptArgs(U.ExecuteTrainConfig):
 
 def prepare(args: ScriptArgs):
     U.exec_command(f"mkdir -p {args.model_dir} {args.data_dir}")
-    U.exec_command("pip install transformers==5.2.0")
     U.exec_command(f"hf download Qwen/{args.model_name} --local-dir {args.model_dir}/{args.model_name}")
     U.hf_download_dataset("zhuzilin/dapo-math-17k", data_dir=args.data_dir)
     U.hf_download_dataset("zhuzilin/aime-2024", data_dir=args.data_dir)

--- a/tests/e2e/ckpt/test_glm47_flash_ckpt.py
+++ b/tests/e2e/ckpt/test_glm47_flash_ckpt.py
@@ -28,11 +28,6 @@ def _get_latest_checkpointed_iteration() -> int:
 
 def prepare():
     U.exec_command("mkdir -p /root/models /root/datasets")
-    # GLM-4.7-Flash requires a newer transformers version.
-    U.exec_command(
-        "pip install git+https://github.com/huggingface/transformers.git@"
-        "76732b4e7120808ff989edbd16401f61fa6a0afa --break-system-packages"
-    )
     U.exec_command(f"hf download zai-org/{MODEL_NAME} --local-dir /root/models/{MODEL_NAME}")
     U.exec_command(f"rm -rf /root/models/{MODEL_NAME}_miles")
     U.hf_download_dataset("zhuzilin/dapo-math-17k")

--- a/tests/e2e/megatron/test_glm47_flash_r3_mtp.py
+++ b/tests/e2e/megatron/test_glm47_flash_r3_mtp.py
@@ -13,10 +13,6 @@ NUM_GPUS = 8
 
 def prepare():
     U.exec_command("mkdir -p /root/models /root/datasets")
-    # GLM-4.7-Flash requires a newer transformers version
-    U.exec_command(
-        "pip install git+https://github.com/huggingface/transformers.git@76732b4e7120808ff989edbd16401f61fa6a0afa --break-system-packages"
-    )
     U.exec_command(f"hf download zai-org/{MODEL_NAME} --local-dir /root/models/{MODEL_NAME}")
     U.hf_download_dataset("zhuzilin/dapo-math-17k")
     U.hf_download_dataset("zhuzilin/aime-2024")

--- a/tests/e2e/sglang/test_session_server_tool_call.py
+++ b/tests/e2e/sglang/test_session_server_tool_call.py
@@ -57,11 +57,6 @@ def _get_config() -> ModelConfig:
 def prepare():
     cfg = _get_config()
     U.exec_command("mkdir -p /root/models /root/datasets")
-    if MODEL_FAMILY == "glm47":
-        U.exec_command(
-            "pip install git+https://github.com/huggingface/transformers.git@"
-            "76732b4e7120808ff989edbd16401f61fa6a0afa --break-system-packages"
-        )
     U.exec_command(f"hf download {cfg.model_name} --local-dir /root/models/{cfg.model_name.split('/')[-1]}")
 
     prompts = [
@@ -156,5 +151,3 @@ if __name__ == "__main__":
     for proxy_var in ("http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY"):
         os.environ.pop(proxy_var, None)
     execute()
-    if MODEL_FAMILY == "glm47":
-        U.exec_command("pip install transformers==4.57.1 --break-system-packages")

--- a/tests/e2e/sglang/test_tito_logprob_equivalence.py
+++ b/tests/e2e/sglang/test_tito_logprob_equivalence.py
@@ -68,11 +68,6 @@ def _get_config() -> ModelConfig:
 def prepare():
     cfg = _get_config()
     U.exec_command("mkdir -p /root/models /root/datasets")
-    if MODEL_FAMILY == "glm47":
-        U.exec_command(
-            "pip install git+https://github.com/huggingface/transformers.git@"
-            "76732b4e7120808ff989edbd16401f61fa6a0afa --break-system-packages"
-        )
     U.exec_command(f"hf download {cfg.model_name} --local-dir /root/models/{cfg.model_name.split('/')[-1]}")
 
     prompts = [
@@ -169,5 +164,3 @@ if __name__ == "__main__":
     for proxy_var in ("http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY"):
         os.environ.pop(proxy_var, None)
     execute()
-    if MODEL_FAMILY == "glm47":
-        U.exec_command("pip install transformers==4.57.1 --break-system-packages")


### PR DESCRIPTION
New docker already support `transformers==5.3.0`, no need to upgrade transformers in scripts and CI.

Not sure why CI didn't display in this page correctly, see https://github.com/radixark/miles/actions/runs/24687428380