### PR TITLE
Security: Remote code execution risk from `trust_remote_code=True` in model bridge loading

### DIFF
--- a/miles/backends/megatron_utils/update_weight/hf_weight_iterator_bridge.py
+++ b/miles/backends/megatron_utils/update_weight/hf_weight_iterator_bridge.py
@@ -16,7 +16,10 @@ class HfWeightIteratorBridge(HfWeightIteratorBase):
 
         import miles_plugins.megatron_bridge  # noqa: F401
 
-        self._bridge = AutoBridge.from_hf_pretrained(self.args.hf_checkpoint, trust_remote_code=True)
+        self._bridge = AutoBridge.from_hf_pretrained(
+            self.args.hf_checkpoint,
+            trust_remote_code=getattr(self.args, "hf_trust_remote_code", False),
+        )
 
     def get_hf_weight_chunks(self, megatron_local_weights):
         # TODO: support quantization (e.g. modify megatron-bridge to provide megatron param name)


### PR DESCRIPTION
## Summary

Security: Remote code execution risk from `trust_remote_code=True` in model bridge loading

## Problem

**Severity**: `High` | **File**: `miles/backends/megatron_utils/update_weight/hf_weight_iterator_bridge.py:L19`

`AutoBridge.from_hf_pretrained(..., trust_remote_code=True)` permits execution of repository-provided code when loading models/bridges. If the checkpoint source is attacker-controlled or not pinned, this can execute arbitrary code in the training environment.

## Solution

Disable `trust_remote_code` unless absolutely necessary. Enforce trusted repo allowlists and pinned immutable revisions (commit SHA). Consider a configuration guard requiring explicit opt-in.

## Changes

- `miles/backends/megatron_utils/update_weight/hf_weight_iterator_bridge.py` (modified)