### PR TITLE
[rollout] add --max-concurrent-agent-tasks to cap agentic in-flight requests

### DIFF
--- a/miles/rollout/sglang_rollout.py
+++ b/miles/rollout/sglang_rollout.py
@@ -257,25 +257,30 @@ async def generate_and_rm(
 
     state = GenerateState(args)
 
+    # Decide agentic vs. token branch up-front so the agent-task semaphore can gate
+    # *before* state.semaphore / dp_rank_context. Otherwise a throttled agentic task
+    # would hold a sglang slot and a DP rank while idle, starving the token path and
+    # skewing DP-rank balancing.
+    # Check sample.generate_function_path for per-sample custom_generate_function_path (e.g., from eval dataset config)
+    custom_func_path = getattr(sample, "generate_function_path", None) or args.custom_generate_function_path
+    generate_fn = load_generate_function(custom_func_path) if custom_func_path else None
+    agent_cm = (
+        state.agent_semaphore
+        if generate_fn is not None and state.agent_semaphore is not None
+        else nullcontext()
+    )
+
     # generate
-    async with state.semaphore:
+    async with agent_cm, state.semaphore:
         if state.aborted:
             sample.status = Sample.Status.ABORTED
             return sample
 
         with state.dp_rank_context() as _:
-            # Check sample.generate_function_path for per-sample custom_generate_function_path (e.g., from eval dataset config)
-            custom_func_path = getattr(sample, "generate_function_path", None) or args.custom_generate_function_path
-
-            generate_fn = load_generate_function(custom_func_path) if custom_func_path else None
             if generate_fn is not None:
-                agent_cm = state.agent_semaphore if state.agent_semaphore is not None else nullcontext()
-                async with agent_cm:
-                    output = await generate_fn(
-                        GenerateFnInput(
-                            state=state, sample=sample, sampling_params=sampling_params, evaluation=evaluation
-                        )
-                    )
+                output = await generate_fn(
+                    GenerateFnInput(state=state, sample=sample, sampling_params=sampling_params, evaluation=evaluation)
+                )
                 sample = output.samples
             else:
                 sample = await generate(args, sample, sampling_params)

--- a/miles/rollout/sglang_rollout.py
+++ b/miles/rollout/sglang_rollout.py
@@ -4,7 +4,7 @@ import logging
 import uuid
 from argparse import Namespace
 from collections.abc import Callable
-from contextlib import contextmanager
+from contextlib import contextmanager, nullcontext
 from typing import Any
 
 import numpy as np
@@ -72,6 +72,13 @@ class GenerateState(metaclass=SingletonMeta):
 
         self.semaphore = asyncio.Semaphore(
             args.sglang_server_concurrency * args.rollout_num_gpus // args.rollout_num_gpus_per_engine
+        )
+        # Agentic-only cap on concurrent `custom_generate_function_path` calls. Useful for
+        # throttling traffic to an external agent server. None => no extra cap.
+        self.agent_semaphore = (
+            asyncio.Semaphore(args.max_concurrent_agent_tasks)
+            if getattr(args, "max_concurrent_agent_tasks", None) is not None
+            else None
         )
         self.sampling_params: dict[str, Any] = dict(
             temperature=args.rollout_temperature,
@@ -262,9 +269,13 @@ async def generate_and_rm(
 
             generate_fn = load_generate_function(custom_func_path) if custom_func_path else None
             if generate_fn is not None:
-                output = await generate_fn(
-                    GenerateFnInput(state=state, sample=sample, sampling_params=sampling_params, evaluation=evaluation)
-                )
+                agent_cm = state.agent_semaphore if state.agent_semaphore is not None else nullcontext()
+                async with agent_cm:
+                    output = await generate_fn(
+                        GenerateFnInput(
+                            state=state, sample=sample, sampling_params=sampling_params, evaluation=evaluation
+                        )
+                    )
                 sample = output.samples
             else:
                 sample = await generate(args, sample, sampling_params)

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -406,6 +406,18 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 ),
             )
             parser.add_argument(
+                "--max-concurrent-agent-tasks",
+                type=int,
+                default=None,
+                help=(
+                    "Cap on the number of in-flight agentic rollout samples dispatched to "
+                    "`--custom-generate-function-path` concurrently. Only takes effect when "
+                    "`--custom-generate-function-path` is set, i.e. agentic training. Useful "
+                    "for throttling traffic to an external agent server. None (default) means "
+                    "no miles-side cap (the SGLang-side semaphore still applies)."
+                ),
+            )
+            parser.add_argument(
                 "--custom-rollout-log-function-path",
                 type=str,
                 default=None,


### PR DESCRIPTION
## Summary

Adds a new CLI flag `--max-concurrent-agent-tasks` that caps the number of in-flight agentic rollout tasks dispatched concurrently through `--custom-generate-function-path`. When unset (default), behavior is unchanged.

## Why

During agentic RL (e.g. SWE-bench w/ mini-swe-agent), each rollout task fires tool-call chat completions at an external agent server. Miles currently submits up to `over_sampling_batch_size * n_samples_per_prompt` tasks concurrently, gated only by the large `GenerateState.semaphore` (derived from `--sglang-server-concurrency * rollout_num_gpus / rollout_num_gpus_per_engine`, often in the thousands). That semaphore is not really sized for agent-server traffic — its intent is to protect a single sglang HTTP server, and its default of 512 per engine leaves the external agent server's own `max-concurrent` mechanism as the sole effective throttle.

This flag gives a clean miles-side knob so the caller can match the agent server's sustainable capacity without having to shrink `--sglang-server-concurrency` (which also affects non-agentic/token-based rollouts) or lower `--rollout-batch-size` / `--n-samples-per-prompt` (which changes RL batch semantics).

## What changes

- `miles/utils/arguments.py`: add `--max-concurrent-agent-tasks` (default `None`, meaning no extra cap).
- `miles/rollout/sglang_rollout.py`:
  - `GenerateState.__init__`: create `self.agent_semaphore` iff the arg is set.
  - `generate_and_rm`: when taking the agentic branch (`generate_fn is not None`), acquire `state.agent_semaphore` around the `generate_fn` call via a `nullcontext()` fallback. Token-based (`generate(...)`) path is untouched.

Total: +27 / -4 lines across 2 files. No behavior change when the flag is unset.

## Test plan
- [ ] Existing CI passes (no existing tests exercise the agentic + semaphore path specifically).
- [ ] Smoke: run an agentic job with `--max-concurrent-agent-tasks 16`, confirm `inflight_chat` as seen from the agent server session log caps at ~16.
- [ ] Smoke: run the same job without the flag; confirm concurrency is unchanged vs. `main`.