### PR TITLE
[alignment-miles] PR11A: Miles Ulysses CP true-on-policy data and loss contract

### DIFF
--- a/miles/backends/megatron_utils/parallel.py
+++ b/miles/backends/megatron_utils/parallel.py
@@ -43,6 +43,17 @@ def create_megatron_parallel_state() -> ParallelState:
     )
 
 
+def _extract_cp_comm_type(
+    model: torch.nn.Module | Sequence[torch.nn.Module],
+) -> str | None:
+    model_to_check = model[0] if isinstance(model, Sequence) else model
+    config = get_model_config(model_to_check)
+    cp_comm_type = getattr(config, "cp_comm_type", None)
+    if isinstance(cp_comm_type, list):
+        return cp_comm_type[0]
+    return cp_comm_type
+
+
 def _compute_vpp_fields() -> tuple[int, int | None]:
     vpp_size_value = mpu.get_virtual_pipeline_model_parallel_world_size()
     if vpp_size_value is None or vpp_size_value <= 1:
@@ -56,6 +67,7 @@ def verify_megatron_parallel_state(
 ) -> None:
     """Verify that ParallelState fields match what the model config produces."""
     parallel_state = get_parallel_state()
+    parallel_state.cp_comm_type = _extract_cp_comm_type(model)
     vpp_size_value = mpu.get_virtual_pipeline_model_parallel_world_size()
     if vpp_size_value is not None and vpp_size_value > 1:
         model_to_check = model[0] if isinstance(model, Sequence) else model

--- a/miles/backends/training_utils/cp_utils.py
+++ b/miles/backends/training_utils/cp_utils.py
@@ -74,7 +74,7 @@ def get_sum_of_sample_mean(
     """
     parallel_state = get_parallel_state()
     cp_size = parallel_state.cp.size
-    if cp_size == 1:
+    if cp_size == 1 or parallel_state.is_ulysses_cp:
 
         def sum_of_sample_mean(x: torch.Tensor) -> torch.Tensor:
             return sum(
@@ -146,7 +146,7 @@ def all_gather_with_cp(
     cp_group = parallel_state.cp.group
     cp_size = parallel_state.cp.size
 
-    if cp_size == 1:
+    if cp_size == 1 or parallel_state.is_ulysses_cp:
         return tensor
 
     _, _, logits_offset, _ = get_logits_and_tokens_offset_with_cp(
@@ -215,7 +215,7 @@ def slice_with_cp(
             tokens = F.pad(tokens, pad_tuple, value=pad_value)
         return tokens
 
-    if cp_size == 1:
+    if cp_size == 1 or parallel_state.is_ulysses_cp:
         if qkv_format == "bshd":
             pad = max_seq_len - tokens.size(0)
             tokens = pad_tokens(tokens, pad)
@@ -330,7 +330,7 @@ def slice_log_prob_with_cp(
     parallel_state = get_parallel_state()
     cp_size = parallel_state.cp.size
 
-    if cp_size == 1:
+    if cp_size == 1 or parallel_state.is_ulysses_cp:
         return log_prob
 
     prompt_length = total_length - response_length

--- a/miles/backends/training_utils/data.py
+++ b/miles/backends/training_utils/data.py
@@ -173,8 +173,10 @@ def get_batch(
                 tokens = F.pad(tokens, (0, pad), value=pad_token_id)
                 cu_seqlens.append(cu_seqlens[-1] + pad)
 
-            # thd requires the cu_seqlens to be of the origin length
-            cu_seqlens = torch.tensor(cu_seqlens, dtype=torch.int).cuda() * cp_size
+        # Standard CP shards sequence ownership across ranks. Ulysses keeps the
+        # full sequence on every rank and only shards inside the attention path.
+        cp_scale = parallel_state.effective_cp_size
+        cu_seqlens = torch.tensor(cu_seqlens, dtype=torch.int).cuda() * cp_scale
 
         max_seqlen = (cu_seqlens[1:] - cu_seqlens[:-1]).max().item()
 

--- a/miles/backends/training_utils/loss.py
+++ b/miles/backends/training_utils/loss.py
@@ -74,7 +74,7 @@ def get_responses(
 
     logits = logits.div(args.rollout_temperature)
 
-    cp_size = parallel_state.cp.size
+    effective_cp_size = parallel_state.effective_cp_size
     end = 0
     seq_start = 0
     for i, (tokens, total_length, response_length) in enumerate(
@@ -82,7 +82,7 @@ def get_responses(
     ):
         max_seq_len = max_seq_lens[i] if max_seq_lens is not None else None
 
-        if cp_size == 1:
+        if effective_cp_size == 1:
             if qkv_format == "bshd":
                 end = max_seq_len * i + total_length
                 start = end - response_length
@@ -392,7 +392,7 @@ def compute_advantages_and_returns(args: Namespace, rollout_data: RolloutBatch) 
     if args.normalize_advantages:
         all_advs = torch.cat(advantages)
         cp_size = parallel_state.cp.size
-        if cp_size == 1:
+        if cp_size == 1 or parallel_state.is_ulysses_cp:
             all_masks = torch.cat(loss_masks)
         else:
             mask_chunks = []
@@ -906,12 +906,15 @@ def loss_function(
     global_batch_size = batch.get("dynamic_global_batch_size", args.global_batch_size)
     if not args.calculate_per_token_loss:
         if apply_megatron_loss_scaling:
-            loss = loss * num_microbatches / global_batch_size * parallel_state.intra_dp_cp.size
+            effective_dp_cp_size = (
+                parallel_state.intra_dp.size if parallel_state.is_ulysses_cp else parallel_state.intra_dp_cp.size
+            )
+            loss = loss * num_microbatches / global_batch_size * effective_dp_cp_size
         else:
             loss = loss / global_batch_size * parallel_state.intra_dp.size
     else:
         if apply_megatron_loss_scaling:
-            loss = loss * parallel_state.cp.size
+            loss = loss * parallel_state.effective_cp_size
 
     return (
         loss,

--- a/miles/backends/training_utils/parallel.py
+++ b/miles/backends/training_utils/parallel.py
@@ -53,6 +53,23 @@ class ParallelState:
     intra_dp_cp: GroupInfo
     cp: GroupInfo
     tp: GroupInfo
+    cp_comm_type: str | None = None
     is_pp_last_stage: bool = True
     vpp_size: int | None = 1
     microbatch_group_size_per_vp_stage: int | None = None
+
+    @property
+    def cp_mode(self) -> str:
+        if self.cp.size <= 1:
+            return "none"
+        if self.cp_comm_type == "a2a":
+            return "ulysses"
+        return "standard"
+
+    @property
+    def is_ulysses_cp(self) -> bool:
+        return self.cp_mode == "ulysses"
+
+    @property
+    def effective_cp_size(self) -> int:
+        return 1 if self.is_ulysses_cp else self.cp.size

--- a/tests/fast/backends/training_utils/test_cp_contract.py
+++ b/tests/fast/backends/training_utils/test_cp_contract.py
@@ -1,0 +1,151 @@
+from argparse import Namespace
+
+import pytest
+import torch
+
+from miles.backends.training_utils import cp_utils, loss as loss_utils
+from miles.backends.training_utils.parallel import GroupInfo, ParallelState, set_parallel_state
+
+
+def _make_parallel_state(
+    *,
+    cp_size: int,
+    cp_rank: int = 0,
+    cp_comm_type: str | None = None,
+    intra_dp_size: int = 2,
+    intra_dp_cp_size: int = 8,
+) -> ParallelState:
+    return ParallelState(
+        intra_dp=GroupInfo(rank=0, size=intra_dp_size, group=None),
+        intra_dp_cp=GroupInfo(rank=0, size=intra_dp_cp_size, group=None),
+        cp=GroupInfo(rank=cp_rank, size=cp_size, group=None),
+        tp=GroupInfo(rank=0, size=1, group=None),
+        cp_comm_type=cp_comm_type,
+    )
+
+
+def test_parallel_state_distinguishes_standard_and_ulysses_cp():
+    standard = _make_parallel_state(cp_size=2, cp_comm_type="p2p")
+    ulysses = _make_parallel_state(cp_size=2, cp_comm_type="a2a")
+    no_cp = _make_parallel_state(cp_size=1, cp_comm_type="a2a")
+
+    assert standard.cp_mode == "standard"
+    assert not standard.is_ulysses_cp
+    assert standard.effective_cp_size == 2
+
+    assert ulysses.cp_mode == "ulysses"
+    assert ulysses.is_ulysses_cp
+    assert ulysses.effective_cp_size == 1
+
+    assert no_cp.cp_mode == "none"
+    assert not no_cp.is_ulysses_cp
+    assert no_cp.effective_cp_size == 1
+
+
+def test_slice_helpers_keep_full_sequence_for_ulysses_cp():
+    ulysses = _make_parallel_state(cp_size=2, cp_comm_type="a2a")
+    standard = _make_parallel_state(cp_size=2, cp_comm_type="p2p")
+    tokens = torch.tensor([10, 11, 12, 13, 14], dtype=torch.long)
+    log_probs = torch.tensor([0.1, 0.2, 0.3], dtype=torch.float32)
+
+    set_parallel_state(ulysses)
+    torch.testing.assert_close(cp_utils.slice_with_cp(tokens, 0), tokens)
+    torch.testing.assert_close(cp_utils.slice_log_prob_with_cp(log_probs, 5, 3), log_probs)
+    torch.testing.assert_close(cp_utils.all_gather_with_cp(log_probs, 5, 3), log_probs)
+
+    set_parallel_state(standard)
+    sliced_tokens = cp_utils.slice_with_cp(tokens, 0)
+    sliced_log_probs = cp_utils.slice_log_prob_with_cp(log_probs, 5, 3)
+
+    assert not torch.equal(sliced_tokens, tokens)
+    assert sliced_log_probs.numel() < log_probs.numel()
+
+
+def test_sum_of_sample_mean_uses_full_response_masks_for_ulysses_cp():
+    ulysses = _make_parallel_state(cp_size=2, cp_comm_type="a2a")
+    set_parallel_state(ulysses)
+
+    reducer = cp_utils.get_sum_of_sample_mean(
+        total_lengths=[6],
+        response_lengths=[4],
+        loss_masks=[torch.tensor([1.0, 0.0, 1.0, 1.0], dtype=torch.float32)],
+    )
+
+    x = torch.tensor([1.0, 2.0, 3.0, 4.0], dtype=torch.float32)
+    expected = torch.tensor((1.0 + 3.0 + 4.0) / 3.0, dtype=torch.float32)
+    torch.testing.assert_close(reducer(x), expected)
+
+
+def test_get_responses_treats_ulysses_cp_as_full_sequence():
+    ulysses = _make_parallel_state(cp_size=2, cp_comm_type="a2a")
+    set_parallel_state(ulysses)
+
+    args = Namespace(qkv_format="thd", rollout_temperature=1.0)
+    logits = torch.arange(5, dtype=torch.float32).view(1, 5, 1)
+    tokens = [torch.tensor([20, 21, 22, 23, 24], dtype=torch.long)]
+
+    responses = list(
+        loss_utils.get_responses(
+            logits,
+            args=args,
+            unconcat_tokens=tokens,
+            total_lengths=[5],
+            response_lengths=[2],
+        )
+    )
+
+    assert len(responses) == 1
+    logits_chunk, tokens_chunk = responses[0]
+    torch.testing.assert_close(logits_chunk, torch.tensor([[2.0], [3.0]], dtype=torch.float32))
+    torch.testing.assert_close(tokens_chunk, torch.tensor([23, 24], dtype=torch.long))
+
+
+def test_loss_function_uses_effective_cp_size_for_ulysses_scaling(monkeypatch):
+    args = Namespace(
+        loss_type="policy_loss",
+        calculate_per_token_loss=False,
+        qkv_format="thd",
+        recompute_loss_function=False,
+        global_batch_size=4,
+        use_dynamic_global_batch_size=False,
+        allgather_cp=False,
+    )
+    batch = {
+        "loss_masks": [torch.tensor([1.0, 1.0], dtype=torch.float32)],
+        "response_lengths": [2],
+        "total_lengths": [3],
+    }
+    logits = torch.zeros((1, 3, 8), dtype=torch.float32)
+
+    monkeypatch.setattr(
+        loss_utils,
+        "policy_loss_function",
+        lambda args, batch, logits, sum_of_sample_mean: (
+            torch.tensor(2.0),
+            {"loss": torch.tensor(2.0)},
+        ),
+    )
+
+    ulysses = _make_parallel_state(cp_size=4, cp_comm_type="a2a", intra_dp_size=2, intra_dp_cp_size=8)
+    set_parallel_state(ulysses)
+    ulysses_loss, _, _ = loss_utils.loss_function(
+        args,
+        batch,
+        num_microbatches=2,
+        logits=logits,
+        apply_megatron_loss_scaling=True,
+    )
+
+    standard = _make_parallel_state(cp_size=4, cp_comm_type="p2p", intra_dp_size=2, intra_dp_cp_size=8)
+    set_parallel_state(standard)
+    standard_loss, _, _ = loss_utils.loss_function(
+        args,
+        batch,
+        num_microbatches=2,
+        logits=logits,
+        apply_megatron_loss_scaling=True,
+    )
+
+    torch.testing.assert_close(ulysses_loss, torch.tensor(2.0))
+    torch.testing.assert_close(standard_loss, torch.tensor(8.0))
+    assert ulysses_loss < standard_loss


### PR DESCRIPTION
## Summary

Implements **PR 11A** from [`miles_migration.md`](../blob/main/../miles_migration.md) — *Miles Ulysses CP True-On-Policy Data And Loss Contract*. Stacked on [#1031 (PR 11)](https://github.com/radixark/miles/pull/1031).

Makes CP mode handling explicit for CP=1, standard CP, and Ulysses CP (`cp_comm_type="a2a"`) under true-on-policy, so Ulysses no longer masquerades as standard CP and inflate logprob valid-token counts or apply double CP scaling.

## Contract H: Ulysses CP-aware training data, logprob, and loss

- `ParallelState` now carries `cp_comm_type` and exposes three derived helpers:
  - `cp_mode`: `"none"` / `"standard"` / `"ulysses"`
  - `is_ulysses_cp`: `True` only for `cp_comm_type == "a2a"` with `cp.size > 1`
  - `effective_cp_size`: `1` for Ulysses, `cp.size` for standard CP — this is the CP multiplier that applies to sequence-sharding math, as opposed to `cp.size` which only reflects the physical group size.
- `megatron_utils/parallel.py` extracts `cp_comm_type` from the Megatron model config and populates `ParallelState` during `verify_megatron_parallel_state`, so the mode helper reflects the real training config.

Call sites that previously used `cp_size == 1` or `cp.size` as a proxy for sequence sharding are now gated explicitly:

| Site | Change |
|---|---|
| `cp_utils.slice_with_cp` / `slice_log_prob_with_cp` / `all_gather_with_cp` | Short-circuit on Ulysses (full sequence already on every rank; a2a shards inside attention only) |
| `cp_utils.get_sum_of_sample_mean` | Under Ulysses, normalize by the full response mask instead of the standard-CP per-rank slice |
| `data.get_batch` | `cu_seqlens` scaled by `effective_cp_size`, so Ulysses does not multiply by `cp.size` |
| `loss.get_responses` | Response window selection uses `effective_cp_size` |
| `loss.compute_advantages_and_returns` | Advantage normalization uses full masks under Ulysses |
| `loss.loss_function` | Megatron loss scaling uses `intra_dp.size` under Ulysses and `intra_dp_cp.size` under standard CP; per-token path uses `effective_cp_size` instead of `cp.size` |

## Files changed

- `miles/backends/training_utils/parallel.py` — `cp_comm_type` field + `cp_mode` / `is_ulysses_cp` / `effective_cp_size` properties.
- `miles/backends/megatron_utils/parallel.py` — wire `cp_comm_type` from Megatron config (handles the `list[str]` form some configs use).
- `miles/backends/training_utils/cp_utils.py` — Ulysses short-circuit in the four CP helpers.
- `miles/backends/training_utils/data.py` — `cu_seqlens` uses `effective_cp_size`.
- `miles/backends/training_utils/loss.py` — `get_responses`, advantage normalization, and Megatron loss scaling use the effective-CP helpers.
- `tests/fast/backends/training_utils/test_cp_contract.py` — new consolidated test file for the CP contract.

## Tests added

- `test_parallel_state_distinguishes_standard_and_ulysses_cp` — `cp_mode` / `is_ulysses_cp` / `effective_cp_size` across the three modes.
- `test_slice_helpers_keep_full_sequence_for_ulysses_cp` — Ulysses returns full tensors from `slice_with_cp` / `slice_log_prob_with_cp` / `all_gather_with_cp`; standard CP still slices.
- `test_sum_of_sample_mean_uses_full_response_masks_for_ulysses_cp` — Ulysses normalization uses the full response mask.
- `test_get_responses_treats_ulysses_cp_as_full_sequence` — response window selection.
- `test_loss_function_uses_effective_cp_size_for_ulysses_scaling` — Ulysses uses `intra_dp.size` scaling; standard CP uses `intra_dp_cp.size` (larger) scaling. Asserts the two differ by the full CP factor.

## Compatibility

- **CP=1**: `cp_mode == "none"`, `effective_cp_size == 1`, `is_ulysses_cp == False`. All call sites behave identically to before.
- **Standard CP** (any `cp_comm_type` other than `"a2a"`): `effective_cp_size == cp.size`; all existing standard-CP slicing/scaling math is preserved.
- **`cp_comm_type` defaults to `None`** on `ParallelState`, so constructing one without a Megatron config (e.g. tests outside `verify_megatron_parallel_state`) still works; defaults to standard behavior when `cp.size > 1`.

## Known performance impact

- CP=1 / standard CP: none (only one extra attribute read per call site).
- Ulysses CP: replaces incorrect standard-CP slicing/scaling with correct full-sequence math. Correctness fix, not a throughput change.

## Follow-up / dependencies

- Stacks on [#1031](https://github.com/radixark/miles/pull/1031). Base is that PR's branch; rebase to `main` after #1031 merges.
- Does not require any additional SGLang or Megatron PR to merge — Contract H lives entirely in Miles.
- Dense Qwen3 Ulysses CP exact-zero E2E (PR 17) will depend on this.

## Test plan

- [ ] `pytest tests/fast/backends/training_utils/test_cp_contract.py -v`
- [ ] `pytest tests/fast/ -v` (verify no regression in other fast tests, especially existing CP=1/standard CP paths)
- [ ] Import sanity: `python -c "from miles.backends.training_utils.parallel import ParallelState"`
- [ ] Dense Qwen3 standard CP and Ulysses CP exact-zero E2E once Milestone 1 is ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)