### PR TITLE
Add zero_std all_zero_ratio and all_one_ratio metrics

### DIFF
--- a/miles/ray/rollout.py
+++ b/miles/ray/rollout.py
@@ -1289,8 +1289,8 @@ def _compute_zero_std_metrics(args, all_samples: list[Sample]):
     # rollout batch size.
     total_groups = len(all_sample_groups)
     if total_groups > 0:
-        log_dict["zero_std/all_zero_percentage"] = 100 * counts.get("0.0", 0) / total_groups
-        log_dict["zero_std/all_one_percentage"] = 100 * counts.get("1.0", 0) / total_groups
+        log_dict["zero_std/all_zero_percentage"] = counts.get("0.0", 0) / total_groups
+        log_dict["zero_std/all_one_percentage"] = counts.get("1.0", 0) / total_groups
 
     return log_dict
 

--- a/miles/ray/rollout.py
+++ b/miles/ray/rollout.py
@@ -1284,13 +1284,13 @@ def _compute_zero_std_metrics(args, all_samples: list[Sample]):
     counts = {reward: len(items) for reward, items in group_by(interesting_rewards).items()}
     log_dict = {f"zero_std/count_{reward}": count for reward, count in counts.items()}
 
-    # Ratios over total groups, so "too hard" (all-0) and "too easy" (all-1)
-    # rates are comparable across runs without needing to know the rollout
-    # batch size.
+    # Percentages over total groups, so "too hard" (all-0) and "too easy"
+    # (all-1) rates are comparable across runs without needing to know the
+    # rollout batch size.
     total_groups = len(all_sample_groups)
     if total_groups > 0:
-        log_dict["zero_std/all_zero_ratio"] = counts.get("0.0", 0) / total_groups
-        log_dict["zero_std/all_one_ratio"] = counts.get("1.0", 0) / total_groups
+        log_dict["zero_std/all_zero_percentage"] = 100 * counts.get("0.0", 0) / total_groups
+        log_dict["zero_std/all_one_percentage"] = 100 * counts.get("1.0", 0) / total_groups
 
     return log_dict
 

--- a/miles/ray/rollout.py
+++ b/miles/ray/rollout.py
@@ -1281,7 +1281,18 @@ def _compute_zero_std_metrics(args, all_samples: list[Sample]):
 
     interesting_rewards = [str(round(g[0].get_reward_value(args), 1)) for g in interesting_sample_groups]
 
-    return {f"zero_std/count_{reward}": len(items) for reward, items in group_by(interesting_rewards).items()}
+    counts = {reward: len(items) for reward, items in group_by(interesting_rewards).items()}
+    log_dict = {f"zero_std/count_{reward}": count for reward, count in counts.items()}
+
+    # Ratios over total groups, so "too hard" (all-0) and "too easy" (all-1)
+    # rates are comparable across runs without needing to know the rollout
+    # batch size.
+    total_groups = len(all_sample_groups)
+    if total_groups > 0:
+        log_dict["zero_std/all_zero_ratio"] = counts.get("0.0", 0) / total_groups
+        log_dict["zero_std/all_one_ratio"] = counts.get("1.0", 0) / total_groups
+
+    return log_dict
 
 
 def _compute_spec_metrics(args, all_samples: list[Sample]):


### PR DESCRIPTION
## Summary
- Add two derived metrics inside \`_compute_zero_std_metrics\` so you don't need to know the rollout batch size to interpret them:
  - \`zero_std/all_zero_ratio\` — fraction of GRPO groups where every sample scored 0.0 ("too hard").
  - \`zero_std/all_one_ratio\` — fraction where every sample scored 1.0 ("too easy").
- The existing \`zero_std/count_{reward}\` counters are unchanged.

## Why
The raw counts are hard to compare across runs with different \`rollout_batch_size\` / \`n_samples_per_prompt\` configs, and they require cross-referencing the launcher to compute a percentage. Having both \`all_zero_ratio\` and \`all_one_ratio\` in wandb makes "dead" GRPO groups directly trackable.

Meaningful only for binary rewards; for non-binary schemes the per-bucket \`count_{reward}\` metrics remain the source of truth.

## Test plan
- [x] Touches one function; no call-site signature change; logs additional keys only when the existing GRPO condition already fired.
- [ ] Eyeball the new keys in the first rollout of a live run.