### PR TITLE
Expose agent-server trial timeout as a configurable launcher flag

### DIFF
--- a/examples/experimental/swe-agent-v2/run-glm47-flash-agentic-async.py
+++ b/examples/experimental/swe-agent-v2/run-glm47-flash-agentic-async.py
@@ -79,6 +79,10 @@ class ScriptArgs(U.ExecuteTrainConfig):
     agent_server_url: str = os.environ.get("AGENT_SERVER_URL", "http://ts-egress-aws-agent-server:8080")
     agent_model_name: str = os.environ.get("AGENT_MODEL_NAME", "model")
     harbor_tasks_dir: str = os.environ.get("HARBOR_TASKS_DIR", "/root/harbor_tasks")
+    # Per-trial wall-clock cap (seconds) for the agent-server call. Trials that
+    # exceed this are marked aborted in miles and filtered from GRPO groups, so
+    # raise it when p90 trial duration > default (e.g. SWE-bench Verified).
+    agent_trial_timeout: int = 3600
     router_external_host: str = os.environ.get("MILES_ROUTER_EXTERNAL_HOST", "")
     miles_host_ip: str = os.environ.get("MILES_HOST_IP", "")
 
@@ -356,6 +360,7 @@ def execute(args: ScriptArgs):
         "AGENT_SERVER_URL": args.agent_server_url,
         "AGENT_MODEL_NAME": args.agent_model_name,
         "HARBOR_TASKS_DIR": args.harbor_tasks_dir,
+        "AGENT_TRIAL_TIMEOUT": str(args.agent_trial_timeout),
         **sglang_extra_env_vars,
     }
     if args.router_external_host:

--- a/examples/experimental/swe-agent-v2/run.py
+++ b/examples/experimental/swe-agent-v2/run.py
@@ -52,6 +52,10 @@ class ScriptArgs(U.ExecuteTrainConfig):
     )
     agent_model_name: str = os.environ.get("AGENT_MODEL_NAME", "model")
     harbor_tasks_dir: str = os.environ.get("HARBOR_TASKS_DIR", "/root/harbor_tasks")
+    # Per-trial wall-clock cap (seconds) for the agent-server call. Trials that
+    # exceed this are marked aborted in miles and filtered from GRPO groups, so
+    # raise it when p90 trial duration > default (e.g. SWE-bench Verified).
+    agent_trial_timeout: int = 3600
     router_external_host: str = os.environ.get("MILES_ROUTER_EXTERNAL_HOST", socket.gethostname())  # public IP
     miles_host_ip: str = os.environ.get("MILES_HOST_IP", socket.gethostname())  # cluster/pod IP
 
@@ -234,6 +238,7 @@ def execute(args: ScriptArgs):
         "AGENT_MODEL_NAME": args.agent_model_name,
         "MILES_ROUTER_EXTERNAL_HOST": args.router_external_host,
         "HARBOR_TASKS_DIR": args.harbor_tasks_dir,
+        "AGENT_TRIAL_TIMEOUT": str(args.agent_trial_timeout),
         "MILES_HOST_IP": args.miles_host_ip,
     }
 

--- a/examples/experimental/swe-agent-v2/swe_agent_function.py
+++ b/examples/experimental/swe-agent-v2/swe_agent_function.py
@@ -20,6 +20,16 @@ from miles.utils.http_utils import post
 
 logger = logging.getLogger(__name__)
 
+_DEFAULT_AGENT_TRIAL_TIMEOUT_S = 3600
+
+
+def _agent_trial_timeout_s() -> int:
+    """Per-trial wall-clock cap (seconds) for the agent-server call.
+
+    Override via env var AGENT_TRIAL_TIMEOUT (set by launchers).
+    """
+    return int(os.environ.get("AGENT_TRIAL_TIMEOUT", _DEFAULT_AGENT_TRIAL_TIMEOUT_S))
+
 
 async def run(
     base_url: str,
@@ -71,13 +81,14 @@ async def run(
     if session_server_instance_id is not None:
         request["session_server_instance_id"] = session_server_instance_id
 
+    timeout_s = _agent_trial_timeout_s()
     try:
         response = await asyncio.wait_for(
             post(f"{agent_server_url}/run", request),
-            timeout=3600,  # 1 hour max per trial
+            timeout=timeout_s,
         )
     except asyncio.TimeoutError:
-        logger.error("Agent server call timed out after 3600s")
+        logger.error(f"Agent server call timed out after {timeout_s}s")
         return None
     except asyncio.CancelledError:
         logger.warning("Agent server call cancelled (sibling task failure?)")


### PR DESCRIPTION
## Summary
- `swe_agent_function.run` hardcoded a **3600s (1h) per-trial timeout** on the agent-server call.
- This change exposes the timeout as a launcher flag so users can raise it without editing source.

## Changes
- `swe_agent_function.py`: read `AGENT_TRIAL_TIMEOUT` env var (default unchanged at 3600s); log actual value on timeout.
- `run.py` (sync launcher) and `run-glm47-flash-agentic-async.py` (async launcher): add `--agent-trial-timeout` (default `3600`), plumbed via `extra_env_vars`.

## Default behavior preserved
Everything at the previous 3600s default unless a user passes the flag.

Example: `--agent-trial-timeout 5400` (1.5h) for SWE-bench-Verified-sized workloads.

## Test plan
- [ ] Run a Flash agentic async job with `--agent-trial-timeout 5400` and confirm the env var is set in the `train_async.py` entrypoint's runtime env and that `swe_agent_function.run` respects it (log line `Agent server call timed out after 5400s` when hit).
- [ ] Run without the flag; confirm default is 3600 and no behavior change vs. main.