### PR TITLE
Prioritize session-server /health so heartbeats don't starve

### DIFF
--- a/miles/rollout/session/sessions.py
+++ b/miles/rollout/session/sessions.py
@@ -40,8 +40,14 @@ def setup_session_routes(app, backend, args):
 
     registry = SessionRegistry(args, tokenizer, tito_tokenizer=tito_tokenizer)
 
+    # /health is defined as a sync function so Starlette dispatches it to the
+    # default threadpool rather than the asyncio event loop. The event loop is
+    # occasionally starved by CPU-bound tokenization in chat_completions, which
+    # makes async /health responses miss the agent-server's 60s heartbeat
+    # window and triggers Flushed-group cancellation on the agent server.
+    # Running /health in a threadpool worker sidesteps that queueing.
     @app.get("/health")
-    async def health():
+    def health():
         body = {"status": "ok"}
         if session_server_instance_id is not None:
             body["session_server_instance_id"] = session_server_instance_id
@@ -52,6 +58,11 @@ def setup_session_routes(app, backend, args):
 
     @app.middleware("http")
     async def debug_request_logger(request: Request, call_next):
+        # Heartbeat probes are high-frequency and latency-sensitive; skip the
+        # per-request INFO logging (two string formats + log calls per request)
+        # so a backed-up event loop does not delay the /health response.
+        if request.url.path == "/health":
+            return await call_next(request)
         client = request.client
         client_info = f"{client.host}:{client.port}" if client else "unknown"
         logger.info(


### PR DESCRIPTION
## Summary
- The Harbor agent server (harbor-private) heartbeat-polls every registered miles session server's `/health` every 30 s; after 3 consecutive failures (each with a 60 s HTTP timeout) it **bulk-cancels every in-flight trial** bound to that session (`Flushed N trial(s)` in the server log).
- We observed **~55% of completed v2-run trials coming back as `exit_status=Flushed, reward=0.0`** on our GLM-4.7-Flash SWE-bench training job, each preceded by `Health check failed (3/3)`. No session-server restart; just event-loop starvation blocking the async `/health` handler.
- This PR makes the session server's `/health` responsive even when the asyncio event loop is briefly CPU-blocked by tokenization inside `prepare_pretokenized` / `update_pretokenized_state`.

## Changes (all in `miles/rollout/session/sessions.py`)
1. Declare `/health` as a **synchronous** handler (`def`, not `async def`). Starlette/FastAPI dispatches sync handlers to the default threadpool, so `/health` no longer needs to wait for the asyncio event loop to drain the chat-completions queue.
2. Short-circuit the `debug_request_logger` middleware for `/health`. Heartbeat probes are high-frequency; skipping the two `logger.info(...)` calls + string formatting trims a bit more event-loop work per probe.

Net diff: **+12 / -1**, single file.

## Why not the other options we discussed
- **Run tokenization in a threadpool** (move `prepare_pretokenized` / `update_pretokenized_state` off the event loop): structurally the deepest fix, but larger surface area — left as a follow-up if heartbeats keep missing under truly sustained bursts.
- **Second uvicorn worker on a sibling port for heartbeats**: explicitly ruled out to keep the API surface unchanged.

## Default behavior preserved
- No API changes. Same `/health` response body.
- All other routes unchanged — the debug logging for `/sessions/*` still happens.
- No new ports, no new processes.

## Test plan
- [ ] Run a Flash agentic-async training job; confirm the aws-agent-server log stops emitting `Health check failed` bursts during rollout.
- [ ] Verify `curl http://<session-server>:<port>/health` returns `{"status":"ok", ...}` the same as before.
- [ ] Tests in `tests/fast/router/test_sessions.py` already exercise `/health` via `requests.get` — they are protocol-agnostic and should keep passing.