### PR TITLE
[swe-agent-v2] Randomize agent_name per request

### DIFF
--- a/examples/experimental/swe-agent-v2/run-glm47-flash-agentic-async.py
+++ b/examples/experimental/swe-agent-v2/run-glm47-flash-agentic-async.py
@@ -81,6 +81,7 @@ class ScriptArgs(U.ExecuteTrainConfig):
     harbor_tasks_dir: str = os.environ.get("HARBOR_TASKS_DIR", "/root/harbor_tasks")
     router_external_host: str = os.environ.get("MILES_ROUTER_EXTERNAL_HOST", "")
     miles_host_ip: str = os.environ.get("MILES_HOST_IP", "")
+    randomize_agent_names: bool = False  # per-request pick between mini-swe-agent and terminus-2
 
     # Disaggregated fully-async settings
     train_num_nodes: int = 1
@@ -356,6 +357,7 @@ def execute(args: ScriptArgs):
         "AGENT_SERVER_URL": args.agent_server_url,
         "AGENT_MODEL_NAME": args.agent_model_name,
         "HARBOR_TASKS_DIR": args.harbor_tasks_dir,
+        "MILES_SWE_AGENT_RANDOMIZE_NAMES": "1" if args.randomize_agent_names else "0",
         **sglang_extra_env_vars,
     }
     if args.router_external_host:

--- a/examples/experimental/swe-agent-v2/run.py
+++ b/examples/experimental/swe-agent-v2/run.py
@@ -54,6 +54,7 @@ class ScriptArgs(U.ExecuteTrainConfig):
     harbor_tasks_dir: str = os.environ.get("HARBOR_TASKS_DIR", "/root/harbor_tasks")
     router_external_host: str = os.environ.get("MILES_ROUTER_EXTERNAL_HOST", socket.gethostname())  # public IP
     miles_host_ip: str = os.environ.get("MILES_HOST_IP", socket.gethostname())  # cluster/pod IP
+    randomize_agent_names: bool = False  # per-request pick between mini-swe-agent and terminus-2
 
     # W&B settings
     wandb_key: str = os.environ.get("WANDB_KEY", os.environ.get("WANDB_API_KEY", ""))
@@ -235,6 +236,7 @@ def execute(args: ScriptArgs):
         "MILES_ROUTER_EXTERNAL_HOST": args.router_external_host,
         "HARBOR_TASKS_DIR": args.harbor_tasks_dir,
         "MILES_HOST_IP": args.miles_host_ip,
+        "MILES_SWE_AGENT_RANDOMIZE_NAMES": "1" if args.randomize_agent_names else "0",
     }
 
     U.execute_train(

--- a/examples/experimental/swe-agent-v2/swe_agent_function.py
+++ b/examples/experimental/swe-agent-v2/swe_agent_function.py
@@ -13,12 +13,15 @@ differentiation (environment, grading harness, agent selection).
 import asyncio
 import logging
 import os
+import random
 from typing import Any
 from urllib.parse import urlparse, urlsplit, urlunparse
 
 from miles.utils.http_utils import post
 
 logger = logging.getLogger(__name__)
+
+_RANDOMIZE_AGENT_CHOICES = ("mini-swe-agent", "terminus-2")
 
 
 async def run(
@@ -55,6 +58,9 @@ async def run(
         "model": f"openai/{model_name}",
         "sampling_params": request_kwargs,
     }
+
+    if os.getenv("MILES_SWE_AGENT_RANDOMIZE_NAMES", "").lower() in ("1", "true", "yes"):
+        request["agent_name"] = random.choice(_RANDOMIZE_AGENT_CHOICES)
 
     max_seq_len = metadata.get("max_seq_len")
     if max_seq_len is not None:


### PR DESCRIPTION
## Summary

Add a `--randomize-agent-names` flag to the agentic training launchers (`run.py` and `run-glm47-flash-agentic-async.py`). When enabled, each request sent from miles to the Harbor agent server randomly picks between `mini-swe-agent` and `terminus-2` instead of using the fixed `agent_name` baked into the prompt metadata.

- `swe_agent_function.run()` reads `MILES_SWE_AGENT_RANDOMIZE_NAMES`; if truthy, it overwrites `request["agent_name"]` with a random choice from `("mini-swe-agent", "terminus-2")`.
- Both launchers forward the CLI flag via that env var in `extra_env_vars`.

Flag defaults to `False` — existing training runs are unaffected.

## Test plan

- [ ] Launch training with `--randomize-agent-names` and confirm a mix of `mini-swe-agent` / `terminus-2` entries in the agent-server logs.
- [ ] Launch training without the flag and confirm `agent_name` still comes from the prompt metadata.