### PR TITLE
Offload session-server tokenization to a threadpool

### DIFF
--- a/miles/rollout/session/sessions.py
+++ b/miles/rollout/session/sessions.py
@@ -4,6 +4,7 @@ import time
 
 from fastapi import Request
 from fastapi.responses import JSONResponse
+from starlette.concurrency import run_in_threadpool
 from starlette.responses import Response
 
 from miles.rollout.session.linear_trajectory import SessionRegistry
@@ -153,7 +154,13 @@ def setup_session_routes(app, backend, args):
                 request_body["no_stop_trim"] = False
 
                 request_messages = request_body.get("messages", [])
-                pretokenized = session.prepare_pretokenized(
+                # Tokenization is CPU-bound; run it in a threadpool so the
+                # asyncio event loop stays responsive to other requests (e.g.
+                # /health heartbeats from the agent server). Under high
+                # inflight_chat, synchronous tokenization on the event loop
+                # starves /health, which triggers agent-server flushes.
+                pretokenized = await run_in_threadpool(
+                    session.prepare_pretokenized,
                     request_messages,
                     tools=request_body.get("tools"),
                     tito_tokenizer=registry.tito_tokenizer,
@@ -223,7 +230,9 @@ def setup_session_routes(app, backend, args):
                     )
                     return backend.build_proxy_response(result)
 
-                session.update_pretokenized_state(
+                # See above: CPU-bound tokenization → threadpool.
+                await run_in_threadpool(
+                    session.update_pretokenized_state,
                     request_messages,
                     assistant_message,
                     prompt_token_ids=prompt_token_ids,


### PR DESCRIPTION
## Summary
Replacement for #1037 (closed). Structurally fixes the "/health is starved → agent-server flushes live trials" class of failures by moving the CPU-bound tokenization in `chat_completions` off the asyncio event loop via `starlette.concurrency.run_in_threadpool`.

## Context
- `harbor-private/miles_agent_server.py::_health_checker_loop` polls every registered miles session server's `/health` every 30 s (60 s HTTP timeout, 3 consecutive failures → `_flush(tracking_key)` bulk-cancels all in-flight trials tied to that session and reports them as `exit_status=Flushed, reward=0`).
- `miles/rollout/session/sessions.py::chat_completions` runs two CPU-bound calls inside `async with session.lock`:
  - `session.prepare_pretokenized(...)` (L156-160)
  - `session.update_pretokenized_state(...)` (L226-232)
- At ~190 concurrent chat completions, bursts of synchronous tokenization starve the event loop for seconds, `/health` queues behind them, the agent-server heartbeat checker trips, and ~180 trials get cancelled every ~80 min.
- On our GLM-4.7-Flash SWE-bench run, this pattern accounted for **55% of completed trials** (`exit_status=Flushed`) and kept `Collected: x/32` stuck for hours at a time.

## Change
+11 / -2 in one file:

```diff
 from fastapi import Request
 from fastapi.responses import JSONResponse
+from starlette.concurrency import run_in_threadpool
 from starlette.responses import Response
 ...
-                pretokenized = session.prepare_pretokenized(
+                pretokenized = await run_in_threadpool(
+                    session.prepare_pretokenized,
                     request_messages, tools=..., tito_tokenizer=...,
                 )
 ...
-                session.update_pretokenized_state(
+                await run_in_threadpool(
+                    session.update_pretokenized_state,
                     request_messages, assistant_message, ...,
                 )
```

No API change, no behavior change beyond the concurrency hand-off.

## Why this instead of #1037
#1037 made `/health` sync-`def` and short-circuited the debug middleware for heartbeat probes. [@gemini-code-assist](https://github.com/apps/gemini-code-assist) correctly noted that neither change rescues requests queued on a starved event loop — the async middleware still runs on the event loop and `await call_next(...)` still needs the loop to be unblocked. Empirically confirmed on the Flash v3 run: same flush pattern, same ~80 min cadence, same ~180 trials cancelled. Closed as insufficient.

## Follow-ups (not in this PR)
- `/sessions/{session_id}` GET handler also calls `registry.compute_session_mismatch(session)` which tokenizes; same `run_in_threadpool` treatment would help, though that path is called ~once per trial (much less hot than chat_completions).

## Test plan
- [ ] Deploy to the current GLM-4.7-Flash 5-node training job; watch aws-agent-server's `/var/log` for `Health check failed` triples during rollout. Success = no flush events for the training's session_server_instance_id for at least one full rollout (hours-long).
- [ ] `curl http://<session-server>:<port>/health` should still return `{"status": "ok", ...}` with the same latency characteristics it had before (the handler itself is unchanged).
- [ ] Existing tests in `tests/fast/router/test_sessions.py` + `test_session_pretokenized_e2e.py` + `test_session_race_conditions.py` should pass — the change is transparent to the caller semantics; only the execution context moves.