### PR TITLE
Add --debug-skip-weight-update and --debug-disable-optimizer

### DIFF
--- a/miles/backends/megatron_utils/actor.py
+++ b/miles/backends/megatron_utils/actor.py
@@ -524,10 +524,7 @@ class MegatronTrainRayActor(TrainRayActor):
 
         if self.args.debug_skip_weight_update:
             if dist.get_rank() == 0:
-                logger.warning(
-                    "Skipping actor-to-rollout weight update because "
-                    "--debug-skip-weight-update is set."
-                )
+                logger.warning("Skipping actor-to-rollout weight update because " "--debug-skip-weight-update is set.")
             if self.args.offload_train:
                 destroy_process_groups()
             return

--- a/miles/backends/megatron_utils/actor.py
+++ b/miles/backends/megatron_utils/actor.py
@@ -522,6 +522,16 @@ class MegatronTrainRayActor(TrainRayActor):
             if dist.get_rank() == 0:
                 ray.get(self.rollout_manager.clear_updatable_num_new_engines.remote())
 
+        if self.args.debug_skip_weight_update:
+            if dist.get_rank() == 0:
+                logger.warning(
+                    "Skipping actor-to-rollout weight update because "
+                    "--debug-skip-weight-update is set."
+                )
+            if self.args.offload_train:
+                destroy_process_groups()
+            return
+
         with torch_memory_saver.disable() if self.args.offload_train else nullcontext():
             print_memory("before update_weights")
             self.weight_updater.update_weights()

--- a/miles/backends/megatron_utils/model.py
+++ b/miles/backends/megatron_utils/model.py
@@ -127,7 +127,7 @@ def setup_model_and_optimizer(
     else:
         model = get_model(get_model_provider_func(args, role), ModelType.encoder_or_decoder)
 
-    if getattr(args, "debug_disable_optimizer", False):
+    if args.debug_disable_optimizer:
         if is_megatron_main_rank():
             logger.warning(
                 "Skipping Megatron optimizer and LR scheduler initialization "
@@ -355,7 +355,7 @@ def train_one_step(
     """
     args = get_args()
     dumper_phase_util = DumperMegatronUtil(args, model, DumperPhase.FWD_BWD)
-    disable_optimizer = getattr(args, "debug_disable_optimizer", False) or optimizer is None
+    disable_optimizer = args.debug_disable_optimizer or optimizer is None
 
     # Set grad to zero.
     for model_chunk in model:
@@ -542,7 +542,7 @@ def train(
     """
     parallel_state = get_parallel_state()
     args = get_args()
-    disable_optimizer = getattr(args, "debug_disable_optimizer", False) or optimizer is None
+    disable_optimizer = args.debug_disable_optimizer or optimizer is None
 
     for iterator in data_iterator:
         iterator.reset()

--- a/miles/backends/megatron_utils/model.py
+++ b/miles/backends/megatron_utils/model.py
@@ -104,7 +104,7 @@ def get_optimizer_param_scheduler(args: Namespace, optimizer: MegatronOptimizer)
 def setup_model_and_optimizer(
     args: Namespace,
     role: str = "actor",
-) -> tuple[list[DDP], MegatronOptimizer, OptimizerParamScheduler]:
+) -> tuple[list[DDP], MegatronOptimizer | None, OptimizerParamScheduler | None]:
     """Build model(s), wrap with DDP, and construct optimizer and scheduler.
 
     Args:
@@ -114,8 +114,10 @@ def setup_model_and_optimizer(
     Returns:
         tuple[list[DDP], MegatronOptimizer, OptimizerParamScheduler]:
             - List of model chunks wrapped by ``DDP``.
-            - The constructed ``MegatronOptimizer`` instance.
-            - The learning-rate/weight-decay scheduler tied to the optimizer.
+            - The constructed ``MegatronOptimizer`` instance, or ``None`` when
+              ``--debug-disable-optimizer`` is set.
+            - The learning-rate/weight-decay scheduler tied to the optimizer, or
+              ``None`` when ``--debug-disable-optimizer`` is set.
     """
     assert not args.moe_use_upcycling
     assert args.load is not None or args.pretrained_checkpoint is not None
@@ -124,6 +126,14 @@ def setup_model_and_optimizer(
         model = _setup_lora_model_via_bridge(args)
     else:
         model = get_model(get_model_provider_func(args, role), ModelType.encoder_or_decoder)
+
+    if getattr(args, "debug_disable_optimizer", False):
+        if is_megatron_main_rank():
+            logger.warning(
+                "Skipping Megatron optimizer and LR scheduler initialization "
+                "because --debug-disable-optimizer is set."
+            )
+        return model, None, None
 
     # Optimizer
     kwargs = {}
@@ -321,8 +331,8 @@ def train_one_step(
     step_id: int,
     data_iterator: Sequence[DataIterator],
     model: Sequence[DDP],
-    optimizer: MegatronOptimizer,
-    opt_param_scheduler: OptimizerParamScheduler,
+    optimizer: MegatronOptimizer | None,
+    opt_param_scheduler: OptimizerParamScheduler | None,
     num_microbatches: int,
 ) -> tuple[dict[str, float], float]:
     """Execute a single pipeline-parallel training step.
@@ -345,11 +355,13 @@ def train_one_step(
     """
     args = get_args()
     dumper_phase_util = DumperMegatronUtil(args, model, DumperPhase.FWD_BWD)
+    disable_optimizer = getattr(args, "debug_disable_optimizer", False) or optimizer is None
 
     # Set grad to zero.
     for model_chunk in model:
         model_chunk.zero_grad_buffer()
-    optimizer.zero_grad()
+    if not disable_optimizer:
+        optimizer.zero_grad()
 
     if args.custom_megatron_before_train_step_hook_path:
         from miles.utils.misc import load_function
@@ -450,7 +462,8 @@ def train_one_step(
     )
 
     valid_step = True
-    if not getattr(args, "check_for_nan_in_loss_and_grad", True):
+    grad_norm = 0.0
+    if (not disable_optimizer) and (not getattr(args, "check_for_nan_in_loss_and_grad", True)):
         found_inf_flag = optimizer.prepare_grads()
         if found_inf_flag:
             valid_step = False
@@ -469,7 +482,13 @@ def train_one_step(
 
         check_mtp_only_grad(model, step_id)
 
-    if valid_step:
+    if disable_optimizer:
+        if is_megatron_main_rank():
+            logger.warning(
+                "Skipping optimizer.prepare_grads(), optimizer.step(), and LR scheduler step "
+                "because --debug-disable-optimizer is set."
+            )
+    elif valid_step:
         # Update parameters.
         update_successful, grad_norm, num_zeros_in_grad = optimizer.step()
 
@@ -480,7 +499,8 @@ def train_one_step(
     # release grad
     for model_chunk in model:
         model_chunk.zero_grad_buffer()
-    optimizer.zero_grad()
+    if not disable_optimizer:
+        optimizer.zero_grad()
 
     dumper_phase_util.finalize(model)
 
@@ -502,8 +522,8 @@ def finalize_model_grads_with_empty_cache(*args, **kwargs):
 def train(
     rollout_id: int,
     model: Sequence[DDP],
-    optimizer: MegatronOptimizer,
-    opt_param_scheduler: OptimizerParamScheduler,
+    optimizer: MegatronOptimizer | None,
+    opt_param_scheduler: OptimizerParamScheduler | None,
     data_iterator: Sequence[DataIterator],
     num_microbatches: Sequence[int],
 ) -> None:
@@ -522,6 +542,7 @@ def train(
     """
     parallel_state = get_parallel_state()
     args = get_args()
+    disable_optimizer = getattr(args, "debug_disable_optimizer", False) or optimizer is None
 
     for iterator in data_iterator:
         iterator.reset()
@@ -532,7 +553,7 @@ def train(
 
     # Setup some training config params.
     config = get_model_config(model[0])
-    config.grad_scale_func = optimizer.scale_loss
+    config.grad_scale_func = None if disable_optimizer else optimizer.scale_loss
     config.timers = None
     if isinstance(model[0], DDP) and args.overlap_grad_reduce:
         assert config.no_sync_func is None, (
@@ -554,7 +575,7 @@ def train(
 
     pre_hook_enabled = False
 
-    if args.reset_optimizer_states:
+    if args.reset_optimizer_states and not disable_optimizer:
         if is_megatron_main_rank():
             print("Reset optimizer states")
         for chained_optimizer in optimizer.chained_optimizers:
@@ -642,8 +663,9 @@ def train(
             if args.enable_mtp_training:
                 extra_metrics["mtp_loss"] = mtp_losses
 
-            for param_group_id, param_group in enumerate(optimizer.param_groups):
-                extra_metrics[f"lr-pg_{param_group_id}"] = opt_param_scheduler.get_lr(param_group)
+            if not disable_optimizer:
+                for param_group_id, param_group in enumerate(optimizer.param_groups):
+                    extra_metrics[f"lr-pg_{param_group_id}"] = opt_param_scheduler.get_lr(param_group)
 
             log_dict = log_train_step(
                 args=args,
@@ -678,7 +700,10 @@ def train(
 
 
 def save(
-    iteration: int, model: Sequence[DDP], optimizer: MegatronOptimizer, opt_param_scheduler: OptimizerParamScheduler
+    iteration: int,
+    model: Sequence[DDP],
+    optimizer: MegatronOptimizer | None,
+    opt_param_scheduler: OptimizerParamScheduler | None,
 ) -> None:
     """Persist a training checkpoint safely with forward hooks disabled.
 
@@ -774,7 +799,7 @@ def save_hf_model(args, rollout_id: int, model: Sequence[DDP]) -> None:
 
 def initialize_model_and_optimizer(
     args: Namespace, role: str = "actor"
-) -> tuple[list[DDP], MegatronOptimizer, OptimizerParamScheduler, int]:
+) -> tuple[list[DDP], MegatronOptimizer | None, OptimizerParamScheduler | None, int]:
     """Initialize model(s), optimizer, scheduler, and load from checkpoint.
 
     Args:
@@ -808,6 +833,7 @@ def initialize_model_and_optimizer(
 
     check_model_hashes(args, model, iteration)
 
-    opt_param_scheduler.step(increment=iteration * args.global_batch_size)
+    if opt_param_scheduler is not None:
+        opt_param_scheduler.step(increment=iteration * args.global_batch_size)
 
     return model, optimizer, opt_param_scheduler, iteration

--- a/miles/backends/megatron_utils/model.py
+++ b/miles/backends/megatron_utils/model.py
@@ -482,13 +482,7 @@ def train_one_step(
 
         check_mtp_only_grad(model, step_id)
 
-    if disable_optimizer:
-        if is_megatron_main_rank():
-            logger.warning(
-                "Skipping optimizer.prepare_grads(), optimizer.step(), and LR scheduler step "
-                "because --debug-disable-optimizer is set."
-            )
-    elif valid_step:
+    if not disable_optimizer and valid_step:
         # Update parameters.
         update_successful, grad_norm, num_zeros_in_grad = optimizer.step()
 

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -1856,11 +1856,6 @@ def miles_validate_args(args):
         )
 
     if args.debug_disable_optimizer:
-        logger.warning(
-            "--debug-disable-optimizer is set: Megatron optimizer and LR scheduler "
-            "will not be initialized, optimizer checkpoint state will not be loaded/saved, "
-            "and actor training will stop after forward/backward."
-        )
         args.no_load_optim = True
         args.no_save_optim = True
 

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -158,6 +158,25 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 help="Add margin for train memory allocation. By default we will reserve 1GB as margin.",
             )
             parser.add_argument(
+                "--debug-skip-weight-update",
+                action="store_true",
+                default=False,
+                help=(
+                    "Debug-only: preserve the train/rollout offload-onload schedule, "
+                    "but skip the actual actor-to-rollout weight update."
+                ),
+            )
+            parser.add_argument(
+                "--debug-disable-optimizer",
+                action="store_true",
+                default=False,
+                help=(
+                    "Debug-only: do not initialize the Megatron optimizer or LR scheduler. "
+                    "Training still runs rollout, log-prob forward, and actor forward/backward, "
+                    "but skips optimizer state allocation and optimizer updates."
+                ),
+            )
+            parser.add_argument(
                 "--disable-weights-backuper",
                 action="store_false",
                 dest="enable_weights_backuper",
@@ -1835,6 +1854,15 @@ def miles_validate_args(args):
             "thinking-token trimming). This can cause input_ids to diverge from "
             "the canonical template output. Use at your own risk."
         )
+
+    if args.debug_disable_optimizer:
+        logger.warning(
+            "--debug-disable-optimizer is set: Megatron optimizer and LR scheduler "
+            "will not be initialized, optimizer checkpoint state will not be loaded/saved, "
+            "and actor training will stop after forward/backward."
+        )
+        args.no_load_optim = True
+        args.no_save_optim = True
 
     if args.chat_template_path == "autofix":
         from miles.utils.chat_template_utils import try_get_fixed_chat_template

--- a/tests/fast/backends/megatron_utils/test_lora_model_branches.py
+++ b/tests/fast/backends/megatron_utils/test_lora_model_branches.py
@@ -76,6 +76,7 @@ class TestSetupModelAndOptimizerLoraBranch:
             lora_adapter_path=None,
             megatron_to_hf_mode=mode,
             moe_use_upcycling=False,
+            debug_disable_optimizer=False,
             load="/some/path",
             pretrained_checkpoint=None,
             # optimizer fields


### PR DESCRIPTION
## Summary
Two narrow debug knobs surfaced during DeepSeek-V4 Pro 1.6T RL bring-up. Both default off; behavior with neither flag set is byte-identical to before.

### `--debug-skip-weight-update`
Preserves the train/rollout offload-onload schedule and the rollout-engine recovery / process-group reload paths, but skips the actual actor-to-rollout weight transfer. Used to isolate the weight-sync code path (CUDA IPC / NCCL broadcast bucketing) from the rest of the RL inner loop.

### `--debug-disable-optimizer`
Skips Megatron optimizer + LR scheduler initialization and skips `optimizer.prepare_grads`/`optimizer.step`/`scheduler.step` in `train_one_step`. Forces `no_load_optim=True` and `no_save_optim=True` so checkpoint I/O stays consistent with the missing optimizer state. Used to validate the full RL loop (rollout, log_probs, actor forward/backward, weight update, offload/onload) without paying for optimizer state allocation, and to A/B-test whether a failure is optimizer-side or elsewhere.

`setup_model_and_optimizer` / `train_one_step` / `train` / `save` / `initialize_model_and_optimizer` now accept `MegatronOptimizer | None` and `OptimizerParamScheduler | None` to thread the no-optimizer case through.

## Test plan
- [ ] CI passes with both flags off (default → no behavior change)
- [ ] Smoke run with `--debug-skip-weight-update`: train loop completes the rollout / log_probs / offload-onload cycle without sending weight tensors
- [ ] Smoke run with `--debug-disable-optimizer`: train loop completes rollout + actor forward/backward; logs `Skipping optimizer.prepare_grads(), optimizer.step(), and LR scheduler step` and never errors on missing optimizer state