### PR TITLE
docs: fix --rollout-function-path arg help signature

### DIFF
--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -261,12 +261,14 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                     else "miles.rollout.sglang_rollout.generate_rollout"
                 ),
                 help=(
-                    "Path to the rollout generation function."
-                    "You should use this model to create your own custom rollout function, "
-                    "and then set this to the path of your custom rollout function. "
-                    "The signature of the function should be "
-                    "`def generate_rollout(args, rollout_id, *, evaluation=False) -> list[list[Sample]]`"
-                    "and within the output sample, you should at least set `tokens`, `response_length`, `reward` "
+                    "Path to the rollout generation function. "
+                    "Use this to create your own custom rollout function and set this to its path. "
+                    "The function is called as `fn(args, rollout_id, data_source, evaluation=evaluation)`, "
+                    "so its signature should be "
+                    "`def generate_rollout(args, rollout_id, data_source, evaluation=False) "
+                    "-> RolloutFnTrainOutput | RolloutFnEvalOutput` "
+                    "(see `miles.rollout.sglang_rollout.generate_rollout` for the default impl). "
+                    "Within each output sample, set at least `tokens`, `response_length`, `reward`, "
                     "and `truncated`."
                 ),
             )


### PR DESCRIPTION
## Summary

The signature in the `--rollout-function-path` help string in `miles/utils/arguments.py` doesn't match the actual call surface. Three issues:

1. **Missing `data_source` positional arg.** The default impl `miles.rollout.sglang_rollout.generate_rollout` is declared:
   ```python
   def generate_rollout(
       args: Namespace, rollout_id: int, data_source: Any, evaluation: bool = False
   ) -> RolloutFnTrainOutput | RolloutFnEvalOutput:
   ```
   and the legacy `call_rollout_fn` in `miles/rollout/base_types.py:82-86` invokes it as `fn(args, rollout_id, data_source, evaluation=evaluation)`. The help string omits `data_source` entirely.

2. **`*, evaluation=False`** (keyword-only after `*`) doesn't reflect reality. `evaluation` is a regular keyword argument in both the default impl and reference examples (e.g. `examples/fully_async/fully_async_rollout.py:333`).

3. **Return type was `list[list[Sample]]`.** Real return is `RolloutFnTrainOutput | RolloutFnEvalOutput` (the legacy path wraps bare lists for backward compat, but new code should return the typed objects).

A user copy-pasting the previous signature into a custom rollout function would crash with `TypeError: ...() takes 2 positional arguments but 3 were given` because Miles passes `data_source` as the third positional.

## Test plan

- [x] `python3 train.py --help` renders the new help string cleanly.
- [ ] Smoke-test a custom rollout function written from the new signature.