### PR TITLE
docs: fix --rollout-sample-filter-path arg help signature

### DIFF
--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -1487,8 +1487,10 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 help=(
                     "Path to the rollout sample filter function. "
                     "This function determines whether a sample will participate in loss calculation. "
-                    "The function should take args and samples (list[Sample]) as input, and return None. "
-                    "Please directly modify the remove_sample attribute of Sample. "
+                    "The function is called as `fn(args, data)` where `data` is "
+                    "`list[list[Sample]]` (a list of n_samples_per_prompt-size groups), "
+                    "and should return None. To exclude a sample from the loss, set "
+                    "`sample.remove_sample = True` on it (nested-iterate the groups to reach Sample objects). "
                     "Note: This attribute does not determine whether the sample participates in advantage normalization."
                 ),
             )

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -1487,10 +1487,9 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 help=(
                     "Path to the rollout sample filter function. "
                     "This function determines whether a sample will participate in loss calculation. "
-                    "The function is called as `fn(args, data)` where `data` is "
-                    "`list[list[Sample]]` (a list of n_samples_per_prompt-size groups), "
-                    "and should return None. To exclude a sample from the loss, set "
-                    "`sample.remove_sample = True` on it (nested-iterate the groups to reach Sample objects). "
+                    "The function is called as `fn(args, data)` where `data` is `list[list[Sample]]` "
+                    "(grouped by n_samples_per_prompt), and should return None. "
+                    "To exclude a sample from the loss, set `sample.remove_sample = True`. "
                     "Note: This attribute does not determine whether the sample participates in advantage normalization."
                 ),
             )


### PR DESCRIPTION
## Summary

The help string for `--rollout-sample-filter-path` said the filter function takes `samples (list[Sample])`, but the real argument is `list[list[Sample]]` — a list of `n_samples_per_prompt`-size groups.

Verified at the two call sites on `origin/main`:

- `miles/rollout/sglang_rollout.py:462` — `filter_func(args, data)`
- `miles/rollout/inference_rollout/inference_rollout_train.py:151` — `f(args, data)`

In both, `data` is built up via `data.append(group)` where `group: list[Sample]` (e.g. `miles/rollout/sglang_rollout.py:441`), so the outer list is always nested.

A user iterating per the previous help string

```python
for s in samples:
    s.remove_sample = True
```

gets `s` as a `list[Sample]` (a group) and crashes with `AttributeError: 'list' object has no attribute 'remove_sample'`.

## Diff

```diff
                 help=(
                     "Path to the rollout sample filter function. "
                     "This function determines whether a sample will participate in loss calculation. "
-                    "The function should take args and samples (list[Sample]) as input, and return None. "
-                    "Please directly modify the remove_sample attribute of Sample. "
+                    "The function is called as `fn(args, data)` where `data` is "
+                    "`list[list[Sample]]` (a list of n_samples_per_prompt-size groups), "
+                    "and should return None. To exclude a sample from the loss, set "
+                    "`sample.remove_sample = True` on it (nested-iterate the groups to reach Sample objects). "
                     "Note: This attribute does not determine whether the sample participates in advantage normalization."
                 ),
```

A companion PR will land on `radixark/miles-doc` to fix the same signature in the User Guide → Customization page.

## Test plan

- [x] `python3 train.py --help` renders the new help string cleanly.
- [ ] Smoke-test a custom filter using nested iteration.