### PR TITLE
[SGLang v0.5.13] Add configurable Miles DSA top-k backend

### DIFF
--- a/miles/backends/megatron_utils/arguments.py
+++ b/miles/backends/megatron_utils/arguments.py
@@ -38,4 +38,7 @@ def set_default_megatron_args(args):
         args.tokenizer_model = args.hf_checkpoint
         args.tokenizer_type = "HuggingFaceTokenizer"
 
+    if not hasattr(args, "miles_dsa_topk_backend"):
+        args.miles_dsa_topk_backend = "torch"
+
     return args

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -151,6 +151,13 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 ),
             )
             parser.add_argument(
+                "--miles-dsa-topk-backend",
+                type=str,
+                choices=["torch", "flashinfer"],
+                default="torch",
+                help="Top-k backend for Miles DSA indexer.",
+            )
+            parser.add_argument(
                 "--true-on-policy-mode",
                 action="store_true",
                 default=False,

--- a/miles_plugins/models/deepseek_v4/deepseek_v4.py
+++ b/miles_plugins/models/deepseek_v4/deepseek_v4.py
@@ -169,9 +169,16 @@ class DeepSeekV4Attention(MegatronModule):
                 cp_group=self.cp_group,
             )
             if self.compress_ratio == 4:
-                if os.environ.get("V4_INDEXER_IMPL", "tilelang") == "tilelang":
+                indexer_impl = os.environ.get("V4_INDEXER_IMPL", "tilelang")
+                topk_backend = getattr(config, "miles_dsa_topk_backend", "torch")
+                if indexer_impl == "tilelang":
                     self.indexer = V4Indexer(config=config, pg_collection=pg_collection)
                 else:
+                    if topk_backend != "torch":
+                        raise ValueError(
+                            "DeepSeek V4 miles DSA topk backend is only supported with V4_INDEXER_IMPL=tilelang; "
+                            f"got {topk_backend=} with {indexer_impl=}."
+                        )
                     indexer_submodules = DSAIndexerSubmodules(
                         linear_wq_b=TELinear,
                         linear_wk=TELinear,
@@ -339,6 +346,7 @@ def get_dsv4_spec(args, config, vp_stage):
     """
     Usage: --spec miles_plugins.models.deepseek_v4.deepseek_v4 get_dsv4_spec
     """
+    config.miles_dsa_topk_backend = args.miles_dsa_topk_backend
     _orig_get_spec = _eav_specs.get_experimental_attention_variant_module_spec
 
     def _patched_get_spec(config, backend=None):

--- a/miles_plugins/models/deepseek_v4/deepseek_v4.py
+++ b/miles_plugins/models/deepseek_v4/deepseek_v4.py
@@ -170,7 +170,7 @@ class DeepSeekV4Attention(MegatronModule):
             )
             if self.compress_ratio == 4:
                 indexer_impl = os.environ.get("V4_INDEXER_IMPL", "tilelang")
-                topk_backend = getattr(config, "miles_dsa_topk_backend", "torch")
+                topk_backend = config.miles_dsa_topk_backend
                 if indexer_impl == "tilelang":
                     self.indexer = V4Indexer(config=config, pg_collection=pg_collection)
                 else:

--- a/miles_plugins/models/deepseek_v4/ops/v4_indexer.py
+++ b/miles_plugins/models/deepseek_v4/ops/v4_indexer.py
@@ -16,6 +16,7 @@ from miles_plugins.models.deepseek_v4.ops.kernel.tilelang_indexer_fwd import (
 from miles_plugins.models.deepseek_v4.ops.qat import fp8_simulate_qat
 from miles_plugins.models.deepseek_v4.ops.rope import apply_rotary_emb, wrapped_precompute_freqs_cis
 from miles_plugins.models.deepseek_v4.ops.utils import rotate_activation
+from miles_plugins.models.dsa_topk import get_dsa_topk_fn
 
 
 class V4Indexer(MegatronModule):
@@ -29,6 +30,7 @@ class V4Indexer(MegatronModule):
         self.index_n_heads = config.dsa_indexer_n_heads
         self.index_head_dim = config.dsa_indexer_head_dim
         self.index_topk = config.dsa_indexer_topk
+        self.topk_backend = getattr(config, "miles_dsa_topk_backend", "torch")
         self.rope_head_dim = config.qk_pos_emb_head_dim
         self.compress_ratio = 4
         self.use_fp8_qat = config.fp8 is not None
@@ -129,6 +131,6 @@ class V4Indexer(MegatronModule):
         index_scores = batched_indexer_fwd(q, k, weights.float(), cu_ks, cu_ke)
 
         topk_count = min(self.index_topk, index_scores.size(-1))
-        topk_indices = index_scores.topk(topk_count, dim=-1)[1]
+        topk_indices = get_dsa_topk_fn(self.topk_backend)(index_scores, topk_count)
 
         return topk_indices

--- a/miles_plugins/models/deepseek_v4/ops/v4_indexer.py
+++ b/miles_plugins/models/deepseek_v4/ops/v4_indexer.py
@@ -30,7 +30,7 @@ class V4Indexer(MegatronModule):
         self.index_n_heads = config.dsa_indexer_n_heads
         self.index_head_dim = config.dsa_indexer_head_dim
         self.index_topk = config.dsa_indexer_topk
-        self.topk_backend = getattr(config, "miles_dsa_topk_backend", "torch")
+        self.topk_backend = config.miles_dsa_topk_backend
         self.rope_head_dim = config.qk_pos_emb_head_dim
         self.compress_ratio = 4
         self.use_fp8_qat = config.fp8 is not None

--- a/miles_plugins/models/dsa_topk.py
+++ b/miles_plugins/models/dsa_topk.py
@@ -1,0 +1,59 @@
+import torch
+
+
+_FLASHINFER_TIE_BREAK_VALUES = {
+    "small": 1,
+    "large": 2,
+}
+
+
+def torch_dsa_topk(logits: torch.Tensor, topk: int) -> torch.Tensor:
+    score, indices = torch.topk(logits, topk, dim=-1)
+    indices = indices.to(torch.int32)
+    return indices.masked_fill(score == -torch.inf, -1)
+
+
+def flashinfer_dsa_topk(logits: torch.Tensor, topk: int) -> torch.Tensor:
+    import flashinfer
+    from sglang.srt.environ import envs
+
+    orig_shape = logits.shape
+    if logits.dim() > 2:
+        logits = logits.reshape(-1, logits.shape[-1])
+
+    score, indices = flashinfer.top_k(
+        logits,
+        topk,
+        sorted=False,
+        deterministic=envs.SGLANG_DSA_TOPK_FLASHINFER_DETERMINISTIC.get(),
+        tie_break=_flashinfer_tie_break_value(),
+        dsa_graph_safe=True,
+    )
+    indices = indices.to(torch.int32)
+    indices = indices.masked_fill(score == -torch.inf, -1)
+    if len(orig_shape) > 2:
+        indices = indices.reshape(*orig_shape[:-1], topk)
+    return indices
+
+
+def get_dsa_topk_fn(topk_backend: str):
+    if topk_backend == "torch":
+        return torch_dsa_topk
+    if topk_backend == "flashinfer":
+        return flashinfer_dsa_topk
+    raise ValueError(f"Unsupported miles DSA topk backend: {topk_backend}")
+
+
+def _flashinfer_tie_break_value() -> int:
+    from sglang.srt.environ import envs
+
+    mode = envs.SGLANG_DSA_TOPK_FLASHINFER_TIE_BREAK.get()
+    if mode is None:
+        return 0
+    mode = mode.lower()
+    if mode not in _FLASHINFER_TIE_BREAK_VALUES:
+        raise RuntimeError(
+            "SGLANG_DSA_TOPK_FLASHINFER_TIE_BREAK must be one of "
+            f"{tuple(_FLASHINFER_TIE_BREAK_VALUES)} or unset, got {mode!r}."
+        )
+    return _FLASHINFER_TIE_BREAK_VALUES[mode]

--- a/miles_plugins/models/glm5/glm5.py
+++ b/miles_plugins/models/glm5/glm5.py
@@ -66,6 +66,7 @@ class DSAMultiLatentAttention(Attention):
         layer_number: int,
         attn_mask_type: AttnMaskType,
         attention_type: str,
+        topk_backend: str = "torch",
         is_mtp_layer: bool = False,
         cp_comm_type: str | None = None,
         model_comm_pgs=None,
@@ -138,6 +139,9 @@ class DSAMultiLatentAttention(Attention):
         )
 
         self.index_topk = 2048
+        if topk_backend not in ("torch", "flashinfer"):
+            raise ValueError(f"Unsupported miles DSA topk backend: {topk_backend}")
+        self.topk_backend = topk_backend
         indexer_replay_manager.register_to_module(self, "indexer_replay", stream_idx=self.layer_number - 1)
 
     def forward(
@@ -204,6 +208,7 @@ class DSAMultiLatentAttention(Attention):
                     starts_block,
                     ends_block,
                     self.index_topk,
+                    topk_backend=self.topk_backend,
                 )
 
                 indexer_topk_scores_block = torch.softmax(indexer_topk_scores_block, dim=-1)
@@ -249,6 +254,7 @@ class DSAMLASelfAttention(DSAMultiLatentAttention):
         submodules: DSASelfAttentionSubmodules,
         layer_number: int,
         attn_mask_type=AttnMaskType.padding,
+        topk_backend: str = "torch",
         is_mtp_layer: bool = False,
         cp_comm_type: str | None = None,
         model_comm_pgs=None,
@@ -260,6 +266,7 @@ class DSAMLASelfAttention(DSAMultiLatentAttention):
             layer_number=layer_number,
             attn_mask_type=attn_mask_type,
             attention_type="self",
+            topk_backend=topk_backend,
             is_mtp_layer=is_mtp_layer,
             cp_comm_type=cp_comm_type,
             model_comm_pgs=model_comm_pgs,
@@ -654,7 +661,10 @@ def get_glm5_spec(args, config, vp_stage):
 
     self_attn_module_spec = ModuleSpec(
         module=DSAMLASelfAttention,
-        params={"attn_mask_type": AttnMaskType.causal},
+        params={
+            "attn_mask_type": AttnMaskType.causal,
+            "topk_backend": args.miles_dsa_topk_backend,
+        },
         submodules=DSASelfAttentionSubmodules(
             linear_q_down_proj=backend.linear(),
             linear_q_up_proj=backend.column_parallel_layer_norm_linear(),

--- a/miles_plugins/models/glm5/ops/indexer.py
+++ b/miles_plugins/models/glm5/ops/indexer.py
@@ -1,15 +1,10 @@
 import torch
 
 from miles.utils.replay_base import indexer_replay_manager
+from miles_plugins.models.dsa_topk import get_dsa_topk_fn, torch_dsa_topk
 
 from .tilelang_indexer_bwd import indexer_bwd_interface
 from .tilelang_indexer_fwd import indexer_fwd_interface
-
-
-_FLASHINFER_TIE_BREAK_VALUES = {
-    "small": 1,
-    "large": 2,
-}
 
 
 def pytorch_extract_topk_scores(logits, topk_indices, dim=-1):
@@ -21,48 +16,7 @@ def pytorch_extract_topk_scores(logits, topk_indices, dim=-1):
 
 
 def _original_topk(logits, topk):
-    score, indices = torch.topk(logits, topk, dim=-1)
-    indices = indices.to(torch.int32)
-    return indices.masked_fill(score == -torch.inf, -1)
-
-
-def _flashinfer_tie_break_value() -> int:
-    from sglang.srt.environ import envs
-
-    mode = envs.SGLANG_DSA_TOPK_FLASHINFER_TIE_BREAK.get()
-    if mode is None:
-        return 0
-    mode = mode.lower()
-    if mode not in _FLASHINFER_TIE_BREAK_VALUES:
-        raise RuntimeError(
-            "SGLANG_DSA_TOPK_FLASHINFER_TIE_BREAK must be one of "
-            f"{tuple(_FLASHINFER_TIE_BREAK_VALUES)} or unset, got {mode!r}."
-        )
-    return _FLASHINFER_TIE_BREAK_VALUES[mode]
-
-
-def _flashinfer_topk(logits, topk):
-    import flashinfer
-    from sglang.srt.environ import envs
-
-    score, indices = flashinfer.top_k(
-        logits,
-        topk,
-        sorted=False,
-        deterministic=envs.SGLANG_DSA_TOPK_FLASHINFER_DETERMINISTIC.get(),
-        tie_break=_flashinfer_tie_break_value(),
-        dsa_graph_safe=True,
-    )
-    indices = indices.to(torch.int32)
-    return indices.masked_fill(score == -torch.inf, -1)
-
-
-def _get_topk_fn(topk_backend: str):
-    if topk_backend == "torch":
-        return _original_topk
-    if topk_backend == "flashinfer":
-        return _flashinfer_topk
-    raise ValueError(f"Unsupported miles DSA topk backend: {topk_backend}")
+    return torch_dsa_topk(logits, topk)
 
 
 class IndexerFunction(torch.autograd.Function):
@@ -105,7 +59,7 @@ def lighting_indexer(
     logits = indexer_fwd_interface(index_q, index_k, weights_2d, cu_seqlen_ks, cu_seqlen_ke, clean_logits=True)
 
     if topk_indices is None:
-        topk_fn = indexer_replay_manager.get_topk_fn(_get_topk_fn(topk_backend), return_probs=False)
+        topk_fn = indexer_replay_manager.get_topk_fn(get_dsa_topk_fn(topk_backend), return_probs=False)
         topk_indices = topk_fn(logits, topk)
 
     index_score = IndexerFunction.apply(index_q, index_k, weights_2d, cu_seqlen_ks, cu_seqlen_ke, logits, topk_indices)

--- a/miles_plugins/models/glm5/ops/indexer.py
+++ b/miles_plugins/models/glm5/ops/indexer.py
@@ -1,7 +1,7 @@
 import torch
 
 from miles.utils.replay_base import indexer_replay_manager
-from miles_plugins.models.dsa_topk import get_dsa_topk_fn, torch_dsa_topk
+from miles_plugins.models.dsa_topk import get_dsa_topk_fn
 
 from .tilelang_indexer_bwd import indexer_bwd_interface
 from .tilelang_indexer_fwd import indexer_fwd_interface
@@ -13,10 +13,6 @@ def pytorch_extract_topk_scores(logits, topk_indices, dim=-1):
     scores = torch.gather(logits, dim=dim, index=safe_indices)
     scores = torch.where(valid_mask, scores, float("-inf"))
     return scores
-
-
-def _original_topk(logits, topk):
-    return torch_dsa_topk(logits, topk)
 
 
 class IndexerFunction(torch.autograd.Function):

--- a/miles_plugins/models/glm5/ops/indexer.py
+++ b/miles_plugins/models/glm5/ops/indexer.py
@@ -6,6 +6,12 @@ from .tilelang_indexer_bwd import indexer_bwd_interface
 from .tilelang_indexer_fwd import indexer_fwd_interface
 
 
+_FLASHINFER_TIE_BREAK_VALUES = {
+    "small": 1,
+    "large": 2,
+}
+
+
 def pytorch_extract_topk_scores(logits, topk_indices, dim=-1):
     valid_mask = topk_indices != -1
     safe_indices = topk_indices.clamp(min=0).to(torch.int64)
@@ -18,6 +24,45 @@ def _original_topk(logits, topk):
     score, indices = torch.topk(logits, topk, dim=-1)
     indices = indices.to(torch.int32)
     return indices.masked_fill(score == -torch.inf, -1)
+
+
+def _flashinfer_tie_break_value() -> int:
+    from sglang.srt.environ import envs
+
+    mode = envs.SGLANG_DSA_TOPK_FLASHINFER_TIE_BREAK.get()
+    if mode is None:
+        return 0
+    mode = mode.lower()
+    if mode not in _FLASHINFER_TIE_BREAK_VALUES:
+        raise RuntimeError(
+            "SGLANG_DSA_TOPK_FLASHINFER_TIE_BREAK must be one of "
+            f"{tuple(_FLASHINFER_TIE_BREAK_VALUES)} or unset, got {mode!r}."
+        )
+    return _FLASHINFER_TIE_BREAK_VALUES[mode]
+
+
+def _flashinfer_topk(logits, topk):
+    import flashinfer
+    from sglang.srt.environ import envs
+
+    score, indices = flashinfer.top_k(
+        logits,
+        topk,
+        sorted=False,
+        deterministic=envs.SGLANG_DSA_TOPK_FLASHINFER_DETERMINISTIC.get(),
+        tie_break=_flashinfer_tie_break_value(),
+        dsa_graph_safe=True,
+    )
+    indices = indices.to(torch.int32)
+    return indices.masked_fill(score == -torch.inf, -1)
+
+
+def _get_topk_fn(topk_backend: str):
+    if topk_backend == "torch":
+        return _original_topk
+    if topk_backend == "flashinfer":
+        return _flashinfer_topk
+    raise ValueError(f"Unsupported miles DSA topk backend: {topk_backend}")
 
 
 class IndexerFunction(torch.autograd.Function):
@@ -50,6 +95,7 @@ def lighting_indexer(
     cu_seqlen_ks: torch.Tensor,
     cu_seqlen_ke: torch.Tensor,
     topk: int,
+    topk_backend: str = "torch",
     topk_indices: torch.Tensor | None = None,
 ):
     if topk_indices is not None:
@@ -59,7 +105,7 @@ def lighting_indexer(
     logits = indexer_fwd_interface(index_q, index_k, weights_2d, cu_seqlen_ks, cu_seqlen_ke, clean_logits=True)
 
     if topk_indices is None:
-        topk_fn = indexer_replay_manager.get_topk_fn(_original_topk, return_probs=False)
+        topk_fn = indexer_replay_manager.get_topk_fn(_get_topk_fn(topk_backend), return_probs=False)
         topk_indices = topk_fn(logits, topk)
 
     index_score = IndexerFunction.apply(index_q, index_k, weights_2d, cu_seqlen_ks, cu_seqlen_ke, logits, topk_indices)

--- a/tests/e2e/megatron/test_deepseek_v32_5layer_mxfp8.py
+++ b/tests/e2e/megatron/test_deepseek_v32_5layer_mxfp8.py
@@ -171,9 +171,10 @@ def execute():
 
     sglang_args = (
         "--sglang-mem-fraction-static 0.8 "
-        "--sglang-attention-backend nsa "
-        "--sglang-nsa-decode-backend flashmla_sparse "
-        "--sglang-nsa-prefill-backend flashmla_sparse "
+        "--sglang-attention-backend dsa "
+        "--sglang-dsa-decode-backend flashmla_sparse "
+        "--sglang-dsa-prefill-backend flashmla_sparse "
+        "--sglang-dsa-topk-backend flashinfer "
         "--sglang-kv-cache-dtype bf16 "
         "--sglang-page-size 64 "
         f"--rollout-num-gpus-per-engine {ROLLOUT_GPUS_PER_ENGINE} "
@@ -224,6 +225,7 @@ def execute():
         "--attention-softmax-in-fp32 "
         "--attention-backend flash "
         "--allgather-cp "
+        "--miles-dsa-topk-backend flashinfer "
         f"--update-weight-buffer-size {2 * 1024 ** 3} "
         "--actor-num-nodes 1 "
         f"--actor-num-gpus-per-node {ACTOR_NUM_GPUS} "
@@ -251,8 +253,9 @@ def execute():
         megatron_model_type=MODEL_TYPE,
         megatron_path=MEGATRON_PATH,
         extra_env_vars={
-            "SGLANG_NSA_FORCE_MLA": "1",
-            "SGLANG_NSA_PREFILL_DENSE_ATTN_KV_LEN_THRESHOLD": "0",
+            "SGLANG_DSA_FUSE_TOPK": "1",
+            "SGLANG_DSA_PREFILL_DENSE_ATTN_KV_LEN_THRESHOLD": "0",
+            "SGLANG_DSA_TOPK_FLASHINFER_TIE_BREAK": "large",
             "NVSHMEM_DISABLE_NCCL": "1",
         },
     )


### PR DESCRIPTION
## Motivation
@humansand
SGLang has renamed the sparse attention interface from NSA to DSA and merged configurable DSA top-k backend support in https://github.com/sgl-project/sglang/pull/22851.

FlashInfer added deterministic top-k tie-break support in https://github.com/flashinfer-ai/flashinfer/pull/3095 and opt-in CUDA graph safe DSA top-k mode in https://github.com/flashinfer-ai/flashinfer/pull/3133. This PR aligns Miles with the merged SGLang DSA interface and lets Miles use the same FlashInfer DSA top-k behavior for training-side indexer recomputation.

## Changes

- Add `--miles-dsa-topk-backend` with choices `torch` and `flashinfer`, defaulting to `torch`.
- Rename the Miles top-k interface from NSA to DSA to match SGLang.
- Align FlashInfer top-k env handling with SGLang:
  - `SGLANG_DSA_TOPK_FLASHINFER_DETERMINISTIC`
  - `SGLANG_DSA_TOPK_FLASHINFER_TIE_BREAK`, where unset disables explicit tie-breaking and `small` / `large` select deterministic tie-break modes backed by FlashInfer.
- Enable FlashInfer `dsa_graph_safe=True` for Miles DSA top-k to match SGLang and avoid CUDA graph replay-unsafe dynamic top-k dispatch.
- Add a shared Miles DSA top-k helper used by GLM5 / DeepSeek V3.2 and DeepSeek V4 indexers.
- Keep replay-aware GLM5 indexer behavior while allowing the underlying top-k backend to be selected.
- Extend the default DeepSeek V4 tilelang indexer to support `--miles-dsa-topk-backend`.
- Fail fast if DeepSeek V4 is configured with non-torch Miles DSA top-k on the legacy non-tilelang indexer path.
- Update `tests/e2e/megatron/test_deepseek_v32_5layer_mxfp8.py` to exercise FlashInfer DSA top-k on both sides:
  - SGLang rollout: `--sglang-dsa-topk-backend flashinfer`
  - Miles training/indexer: `--miles-dsa-topk-backend flashinfer`
  - Tie-break env: `SGLANG_DSA_TOPK_FLASHINFER_TIE_BREAK=large`

## Validation

- `python3 -m py_compile` on touched Python files passed.
- `pre-commit run --all-files` passed.
- E2E training tests were intentionally not run yet.
