### PR TITLE
[feat] Add per-phase profiling for rollout, train, and weight updates

### DIFF
--- a/miles/backends/experimental/fsdp_utils/actor.py
+++ b/miles/backends/experimental/fsdp_utils/actor.py
@@ -405,11 +405,12 @@ class FSDPTrainRayActor(TrainRayActor):
         if self.args.offload_train:
             self.wake_up()
 
-        with inverse_timer("train_wait"), timer("train"):
-            rollout_data = get_rollout_data(self.args, rollout_data_ref)
-            if self.args.debug_rollout_only:
-                return
-            self._train_core(rollout_id=rollout_id, rollout_data=rollout_data)
+        with self.prof.profile_phase("train", rollout_id):
+            with inverse_timer("train_wait"), timer("train"):
+                rollout_data = get_rollout_data(self.args, rollout_data_ref)
+                if self.args.debug_rollout_only:
+                    return
+                self._train_core(rollout_id=rollout_id, rollout_data=rollout_data)
 
         train_metric_utils.log_perf_data_raw(
             rollout_id=rollout_id,
@@ -427,17 +428,19 @@ class FSDPTrainRayActor(TrainRayActor):
         ), f"Invalid num_microbatches {num_microbatches} for micro_batch_size {self.args.micro_batch_size} and global_batch_size {self.args.global_batch_size}"
 
         if self.ref_model is not None:
-            ref_results = self._compute_log_prob("ref", data_iterator, num_microbatches, store_prefix="ref_")
-            rollout_data.update(ref_results)
+            with self.prof.profile_phase("ref_log_probs", rollout_id):
+                ref_results = self._compute_log_prob("ref", data_iterator, num_microbatches, store_prefix="ref_")
+                rollout_data.update(ref_results)
 
-        actor_results = self._compute_log_prob("actor", data_iterator, num_microbatches)
-        rollout_data.update(actor_results)
+        with self.prof.profile_phase("log_probs", rollout_id):
+            actor_results = self._compute_log_prob("actor", data_iterator, num_microbatches)
+            rollout_data.update(actor_results)
 
         compute_advantages_and_returns(self.args, rollout_data)
 
         log_rollout_data(rollout_id, self.args, rollout_data)
 
-        with timer("actor_train"):
+        with timer("actor_train"), self.prof.profile_phase("actor_train", rollout_id):
             data_iterator.reset()
             num_steps_per_rollout = len(num_microbatches)
 
@@ -544,7 +547,7 @@ class FSDPTrainRayActor(TrainRayActor):
         return log_dict
 
     @timer
-    def update_weights(self) -> None:  # type: ignore[override]
+    def update_weights(self, rollout_id=None) -> None:  # type: ignore[override]
         """Synchronize actor weights to rollout engines.
 
         Handles both colocated and distributed update modes. In offload mode,
@@ -553,29 +556,30 @@ class FSDPTrainRayActor(TrainRayActor):
         if self.args.debug_train_only or self.args.debug_rollout_only:
             return
 
-        rollout_engines, rollout_engine_lock, num_new_engines, engine_gpu_counts, engine_gpu_offsets = ray.get(
-            self.rollout_manager.get_updatable_engines_and_lock.remote()
-        )
-        if num_new_engines > 0:
-            self.weight_updater.connect_rollout_engines(
-                rollout_engines,
-                rollout_engine_lock,
-                engine_gpu_counts=engine_gpu_counts,
-                engine_gpu_offsets=engine_gpu_offsets,
+        with self.prof.profile_phase("update_weights", rollout_id):
+            rollout_engines, rollout_engine_lock, num_new_engines, engine_gpu_counts, engine_gpu_offsets = ray.get(
+                self.rollout_manager.get_updatable_engines_and_lock.remote()
             )
-            dist.barrier(group=get_gloo_group())
-            if dist.get_rank() == 0:
-                ray.get(self.rollout_manager.clear_updatable_num_new_engines.remote())
-
-        self.weight_updater.update_weights()
-
-        if self.args.ci_test and len(rollout_engines) > 0:
-            engine = random.choice(rollout_engines)
-            engine_version = ray.get(engine.get_weight_version.remote())
-            if str(engine_version) != str(self.weight_updater.weight_version):
-                raise RuntimeError(
-                    f"Weight version mismatch! Engine: {engine_version}, Updater: {self.weight_updater.weight_version}"
+            if num_new_engines > 0:
+                self.weight_updater.connect_rollout_engines(
+                    rollout_engines,
+                    rollout_engine_lock,
+                    engine_gpu_counts=engine_gpu_counts,
+                    engine_gpu_offsets=engine_gpu_offsets,
                 )
+                dist.barrier(group=get_gloo_group())
+                if dist.get_rank() == 0:
+                    ray.get(self.rollout_manager.clear_updatable_num_new_engines.remote())
+
+            self.weight_updater.update_weights()
+
+            if self.args.ci_test and len(rollout_engines) > 0:
+                engine = random.choice(rollout_engines)
+                engine_version = ray.get(engine.get_weight_version.remote())
+                if str(engine_version) != str(self.weight_updater.weight_version):
+                    raise RuntimeError(
+                        f"Weight version mismatch! Engine: {engine_version}, Updater: {self.weight_updater.weight_version}"
+                    )
 
         clear_memory()
 

--- a/miles/backends/megatron_utils/actor.py
+++ b/miles/backends/megatron_utils/actor.py
@@ -132,6 +132,7 @@ class MegatronTrainRayActor(TrainRayActor):
             return
 
         start_rollout_id = loaded_rollout_id + 1
+        self.args.start_rollout_id = start_rollout_id
 
         self.weights_backuper = TensorBackuper.create(
             source_getter=lambda: named_params_and_buffers(
@@ -324,16 +325,17 @@ class MegatronTrainRayActor(TrainRayActor):
         if self.args.offload_train:
             self.wake_up()
 
-        with timer("data_preprocess"):
-            rollout_data = get_rollout_data(self.args, rollout_data_ref)
-            if self.args.debug_rollout_only:
-                log_rollout_data(rollout_id, self.args, rollout_data)
-                return
+        with self.prof.profile_phase("train", rollout_id):
+            with timer("data_preprocess"):
+                rollout_data = get_rollout_data(self.args, rollout_data_ref)
+                if self.args.debug_rollout_only:
+                    log_rollout_data(rollout_id, self.args, rollout_data)
+                    return
 
-        if self.role == "critic":
-            return self.train_critic(rollout_id, rollout_data)
-        else:
-            return self.train_actor(rollout_id, rollout_data)
+            if self.role == "critic":
+                return self.train_critic(rollout_id, rollout_data)
+            else:
+                return self.train_actor(rollout_id, rollout_data)
 
     def train_critic(self, rollout_id: int, rollout_data: RolloutBatch) -> None:
         # Create data iterator for log_probs and train.
@@ -387,13 +389,14 @@ class MegatronTrainRayActor(TrainRayActor):
                 if "ref" in self.weights_backuper.backup_tags:
                     self._set_replay_stage("fallthrough")
                     self._switch_model("ref")
-                    rollout_data.update(
-                        self.compute_log_prob(
-                            data_iterator,
-                            num_microbatches,
-                            store_prefix="ref_",
+                    with self.prof.profile_phase("ref_log_probs", rollout_id):
+                        rollout_data.update(
+                            self.compute_log_prob(
+                                data_iterator,
+                                num_microbatches,
+                                store_prefix="ref_",
+                            )
                         )
-                    )
                 self._switch_model("old_actor" if self.args.keep_old_actor else "actor")
                 if not self.args.use_rollout_logprobs or self.args.get_mismatch_metrics:
                     for m in all_replay_managers:
@@ -402,13 +405,14 @@ class MegatronTrainRayActor(TrainRayActor):
                                 m.stage = "replay_forward"
                             else:
                                 m.stage = "record"
-                    rollout_data.update(
-                        self.compute_log_prob(
-                            data_iterator,
-                            num_microbatches,
-                            store_prefix="",
+                    with self.prof.profile_phase("log_probs", rollout_id):
+                        rollout_data.update(
+                            self.compute_log_prob(
+                                data_iterator,
+                                num_microbatches,
+                                store_prefix="",
+                            )
                         )
-                    )
                     for m in all_replay_managers:
                         if self._use_rollout_replay(m):
                             m.clear_all_forward()
@@ -433,7 +437,7 @@ class MegatronTrainRayActor(TrainRayActor):
 
             # Train
             self._set_replay_stage("replay_backward")
-            with timer("actor_train"):
+            with timer("actor_train"), self.prof.profile_phase("actor_train", rollout_id):
                 train(
                     rollout_id,
                     self.model,
@@ -495,45 +499,46 @@ class MegatronTrainRayActor(TrainRayActor):
             destroy_process_groups()
 
     @timer
-    def update_weights(self) -> None:
+    def update_weights(self, rollout_id=None) -> None:
         if self.args.debug_train_only or self.args.debug_rollout_only:
             return
 
-        if self.args.use_fault_tolerance:
-            if dist.get_rank() == 0:
-                ray.get(self.rollout_manager.recover_updatable_engines.remote())
-            dist.barrier(group=get_gloo_group())
+        with self.prof.profile_phase("update_weights", rollout_id):
+            if self.args.use_fault_tolerance:
+                if dist.get_rank() == 0:
+                    ray.get(self.rollout_manager.recover_updatable_engines.remote())
+                dist.barrier(group=get_gloo_group())
 
-        rollout_engines, rollout_engine_lock, num_new_engines, engine_gpu_counts, engine_gpu_offsets = ray.get(
-            self.rollout_manager.get_updatable_engines_and_lock.remote()
-        )
-
-        if self.args.offload_train:
-            reload_process_groups()
-
-        if num_new_engines > 0:
-            self.weight_updater.connect_rollout_engines(
-                rollout_engines,
-                rollout_engine_lock,
-                engine_gpu_counts=engine_gpu_counts,
-                engine_gpu_offsets=engine_gpu_offsets,
+            rollout_engines, rollout_engine_lock, num_new_engines, engine_gpu_counts, engine_gpu_offsets = ray.get(
+                self.rollout_manager.get_updatable_engines_and_lock.remote()
             )
-            dist.barrier(group=get_gloo_group())
-            if dist.get_rank() == 0:
-                ray.get(self.rollout_manager.clear_updatable_num_new_engines.remote())
 
-        with torch_memory_saver.disable() if self.args.offload_train else nullcontext():
-            print_memory("before update_weights")
-            self.weight_updater.update_weights()
-            print_memory("after update_weights")
+            if self.args.offload_train:
+                reload_process_groups()
 
-            if self.args.ci_test and len(rollout_engines) > 0 and not is_lora_enabled(self.args):
-                engine = random.choice(rollout_engines)
-                engine_version = ray.get(engine.get_weight_version.remote())
-                if str(engine_version) != str(self.weight_updater.weight_version):
-                    raise RuntimeError(
-                        f"Weight version mismatch! Engine: {engine_version}, Updater: {self.weight_updater.weight_version}"
-                    )
+            if num_new_engines > 0:
+                self.weight_updater.connect_rollout_engines(
+                    rollout_engines,
+                    rollout_engine_lock,
+                    engine_gpu_counts=engine_gpu_counts,
+                    engine_gpu_offsets=engine_gpu_offsets,
+                )
+                dist.barrier(group=get_gloo_group())
+                if dist.get_rank() == 0:
+                    ray.get(self.rollout_manager.clear_updatable_num_new_engines.remote())
+
+            with torch_memory_saver.disable() if self.args.offload_train else nullcontext():
+                print_memory("before update_weights")
+                self.weight_updater.update_weights()
+                print_memory("after update_weights")
+
+                if self.args.ci_test and len(rollout_engines) > 0 and not is_lora_enabled(self.args):
+                    engine = random.choice(rollout_engines)
+                    engine_version = ray.get(engine.get_weight_version.remote())
+                    if str(engine_version) != str(self.weight_updater.weight_version):
+                        raise RuntimeError(
+                            f"Weight version mismatch! Engine: {engine_version}, Updater: {self.weight_updater.weight_version}"
+                        )
 
             if getattr(self.args, "keep_old_actor", False):
                 if self.args.update_weights_interval == 1:

--- a/miles/ray/actor_group.py
+++ b/miles/ray/actor_group.py
@@ -119,9 +119,9 @@ class RayTrainGroup:
         """Save actor model"""
         await self._broadcast("save_model", rollout_id, force_sync=force_sync)
 
-    async def update_weights(self):
+    async def update_weights(self, rollout_id=None):
         """Broadcast weights from rank 0 to all other ranks."""
-        await self._broadcast("update_weights")
+        await self._broadcast("update_weights", rollout_id)
 
     async def onload(self):
         await self._broadcast("wake_up")

--- a/miles/ray/rollout.py
+++ b/miles/ray/rollout.py
@@ -40,6 +40,7 @@ from miles.utils.logging_utils import configure_logger
 from miles.utils.metric_checker import MetricChecker
 from miles.utils.metric_utils import compute_pass_rate, compute_rollout_step, compute_statistics, dict_add_prefix
 from miles.utils.misc import load_function
+from miles.utils.profile_utils import profile_activities_for_sglang, profile_output_dir, should_profile
 from miles.utils.ray_utils import Box
 from miles.utils.seqlen_balancing import get_seqlen_balanced_partitions
 from miles.utils.tracking_utils import init_tracking
@@ -443,6 +444,20 @@ class RolloutManager:
         return len(self.data_source.dataset) // self.args.rollout_batch_size
 
     def generate(self, rollout_id):
+        # args snapshot predates the driver resolving start_rollout_id; capture it lazily.
+        if getattr(self.args, "start_rollout_id", None) is None:
+            self.args.start_rollout_id = rollout_id
+        profile_engines = self._start_profile(rollout_id)
+        generate_error = None
+        try:
+            return self._generate(rollout_id)
+        except BaseException as e:
+            generate_error = e
+            raise
+        finally:
+            self._stop_profile(profile_engines, generate_error)
+
+    def _generate(self, rollout_id):
         start_time = time.time()
         self.rollout_id = rollout_id
         self.health_monitoring_resume()
@@ -453,6 +468,38 @@ class RolloutManager:
         _log_rollout_data(rollout_id, self.args, data, metrics, time.time() - start_time)
         data = self._convert_samples_to_train_data(data)
         return self._split_train_data_by_dp(data, self.train_parallel_config["dp_size"])
+
+    def _start_profile(self, rollout_id):
+        if not should_profile(self.args, "rollout", rollout_id):
+            return []
+
+        num_steps = self.args.profile_rollout_num_steps or None
+        profile_engines = [(i, engine) for i, engine in enumerate(self.rollout_engines) if engine is not None]
+        ray.get(
+            [
+                engine.start_profile.remote(
+                    output_dir=profile_output_dir(self.args, "rollout", rollout_id, worker=f"engine_{i}"),
+                    activities=profile_activities_for_sglang(self.args),
+                    with_stack=self.args.profile_with_stack,
+                    record_shapes=self.args.profile_record_shapes,
+                    num_steps=num_steps,
+                )
+                for i, engine in profile_engines
+            ]
+        )
+        # When num_steps is set, SGLang auto-stops; skip the manual stop_profile call.
+        return [] if num_steps else profile_engines
+
+    def _stop_profile(self, profile_engines, generate_error):
+        if not profile_engines:
+            return
+
+        try:
+            ray.get([engine.stop_profile.remote() for _, engine in profile_engines])
+        except Exception:
+            if generate_error is None:
+                raise
+            logger.exception("Failed to stop rollout profiler while handling rollout failure")
 
     def eval(self, rollout_id):
         if self.args.debug_train_only:

--- a/miles/ray/train_actor.py
+++ b/miles/ray/train_actor.py
@@ -125,7 +125,7 @@ class TrainRayActor(RayActor):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def update_weights(self):
+    def update_weights(self, rollout_id=None):
         raise NotImplementedError
 
     @abc.abstractmethod

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -18,6 +18,18 @@ from miles.utils.misc import load_function
 
 logger = logging.getLogger(__name__)
 
+PROFILE_DEFAULT_TARGETS = ["rollout", "train", "update_weights"]
+PROFILE_LEGACY_TARGETS = ["train_overall"]
+# Sub-phases of `train`, each emitted as its own torch.profiler trace.
+# Mutually exclusive with `train` (which would otherwise nest profilers).
+PROFILE_TRAIN_SUBPHASE_TARGETS = ["ref_log_probs", "log_probs", "actor_train"]
+PROFILE_TARGET_CHOICES = (
+    PROFILE_DEFAULT_TARGETS
+    + PROFILE_LEGACY_TARGETS
+    + PROFILE_TRAIN_SUBPHASE_TARGETS
+    + ["train_actor", "train_log_probs"]
+)
+
 
 def reset_arg(parser, name, **kwargs):
     """
@@ -33,6 +45,18 @@ def reset_arg(parser, name, **kwargs):
             break
     else:
         parser.add_argument(name, **kwargs)
+
+
+def add_profile_arg(parser):
+    """Register --profile if Megatron's parser hasn't already defined it."""
+    if any("--profile" in a.option_strings for a in parser._actions):
+        return
+    parser.add_argument(
+        "--profile",
+        action="store_true",
+        default=False,
+        help="Enable unified profiling for rollout, train, and weight update stages.",
+    )
 
 
 def get_miles_extra_args_provider(add_custom_arguments=None):
@@ -1352,12 +1376,54 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 type=int,
                 default=None,
             )
+            add_profile_arg(parser)
             parser.add_argument(
                 "--profile-target",
                 type=str,
-                choices=["train_overall", "train_actor", "train_log_probs"],
-                default=["train_overall"],
+                choices=PROFILE_TARGET_CHOICES,
+                default=None,
                 nargs="+",
+                help="Phases to profile. 'train' is mutually exclusive with its sub-phases "
+                "ref_log_probs/log_probs/actor_train.",
+            )
+            parser.add_argument(
+                "--profile-output-dir",
+                type=str,
+                default=None,
+                help="Directory to store profiler traces.",
+            )
+            parser.add_argument(
+                "--profile-activities",
+                type=str.lower,
+                choices=["cpu", "gpu"],
+                nargs="+",
+                default=["cpu", "gpu"],
+                help="Profiler activities to collect.",
+            )
+            parser.add_argument(
+                "--profile-with-stack",
+                action=argparse.BooleanOptionalAction,
+                default=False,
+                help="Record Python/C++ stack traces in profiler events.",
+            )
+            parser.add_argument(
+                "--profile-record-shapes",
+                action=argparse.BooleanOptionalAction,
+                default=True,
+                help="Record operator input shapes in profiler events.",
+            )
+            parser.add_argument(
+                "--profile-memory",
+                action=argparse.BooleanOptionalAction,
+                default=False,
+                help="Record PyTorch memory events in profiler traces.",
+            )
+            parser.add_argument(
+                "--profile-rollout-num-steps",
+                type=int,
+                default=50,
+                help="Auto-stop rollout profiling after this many forward passes per engine. "
+                "Set to 0 to profile the entire rollout (large traces, high overhead).",
             )
             parser.add_argument(
                 "--memory-recorder",
@@ -2075,6 +2141,8 @@ def miles_validate_args(args):
                 logger.info(f"Warning: Argument {k} is already set to {getattr(args, k)}, will override with {v}.")
             setattr(args, k, v)
 
+    _normalize_profile_args(args)
+
     if args.eval_max_context_len is None:
         logger.info(
             f"args.eval_max_context_len is not set. Use args.rollout_max_context_len {args.rollout_max_context_len} as default value."
@@ -2110,6 +2178,50 @@ def miles_validate_args(args):
         ), "Dynamic batch size is not supported for bshd format. Please specify --micro-batch-size instead."
 
     _maybe_apply_dumper_overrides(args)
+
+
+def _normalize_profile_args(args) -> None:
+    if args.profile_target is None:
+        args.profile_target = (
+            PROFILE_DEFAULT_TARGETS.copy() if getattr(args, "profile", False) else PROFILE_LEGACY_TARGETS.copy()
+        )
+    elif isinstance(args.profile_target, str):
+        args.profile_target = [args.profile_target]
+
+    invalid_targets = set(args.profile_target) - set(PROFILE_TARGET_CHOICES)
+    assert not invalid_targets, f"Invalid profile target(s): {sorted(invalid_targets)}"
+
+    if getattr(args, "profile", False):
+        args.use_pytorch_profiler = True
+
+    assert args.profile_step_end > args.profile_step_start, "profile_step_end must be greater than profile_step_start"
+
+    targets = set(args.profile_target)
+    train_subphase = set(PROFILE_TRAIN_SUBPHASE_TARGETS)
+    assert not (
+        "train_overall" in targets
+        and targets & ({"train", "update_weights", "train_actor", "train_log_probs"} | train_subphase)
+    ), (
+        "train_overall cannot be combined with train/update_weights/train_actor/train_log_probs/sub-phase profiling"
+    )
+    assert not ("train" in targets and targets & ({"train_actor", "train_log_probs"} | train_subphase)), (
+        "train cannot be combined with train_actor/train_log_probs/sub-phase profiling "
+        "(ref_log_probs/log_probs/actor_train)"
+    )
+
+    if isinstance(args.profile_activities, str):
+        args.profile_activities = [args.profile_activities]
+    args.profile_activities = [activity.lower() for activity in args.profile_activities]
+    invalid_activities = set(args.profile_activities) - {"cpu", "gpu"}
+    assert not invalid_activities, f"Invalid profile activities: {sorted(invalid_activities)}"
+
+    if getattr(args, "profile_output_dir", None) is None:
+        if getattr(args, "tensorboard_dir", None) is not None:
+            args.profile_output_dir = args.tensorboard_dir
+        elif getattr(args, "save", None) is not None:
+            args.profile_output_dir = os.path.join(args.save, "profile_traces")
+        else:
+            args.profile_output_dir = "./profile_traces"
 
 
 def _maybe_apply_dumper_overrides(args) -> None:

--- a/miles/utils/profile_utils.py
+++ b/miles/utils/profile_utils.py
@@ -1,6 +1,7 @@
 import logging
 import time
 import traceback
+from contextlib import contextmanager
 from pathlib import Path
 
 import torch
@@ -38,6 +39,16 @@ class TrainProfiler:
         ):
             self._memory_profiler_overall.stop()
 
+    @contextmanager
+    def profile_phase(self, name: str, rollout_id: int | None):
+        if rollout_id is None or not should_profile(self.args, name, rollout_id):
+            yield
+            return
+        with _create_torch_profiler(
+            self.args, name, output_dir=profile_output_dir(self.args, name, rollout_id)
+        ):
+            yield
+
     def iterate_train_actor(self, iterator):
         return _profile_simple_loop(iterator, self.args, name="train_actor")
 
@@ -50,30 +61,67 @@ def _profile_simple_loop(iterator, args, name):
         yield from iterator
         return
 
-    torch_profiler = _create_torch_profiler(args, name=name)
+    schedule = torch.profiler.schedule(
+        # TODO the train_actor and train_log_probs ones may need to have different args to control step
+        wait=max(args.profile_step_start - 1, 0),
+        warmup=1 if args.profile_step_start > 0 else 0,
+        active=args.profile_step_end - args.profile_step_start,
+        repeat=1,
+    )
+    torch_profiler = _create_torch_profiler(args, name, schedule=schedule)
     torch_profiler.start()
     for item in iterator:
         yield item
         torch_profiler.step()
 
 
-def _create_torch_profiler(args, name):
+def should_profile(args, stage: str, rollout_id: int) -> bool:
+    step = rollout_id - (getattr(args, "start_rollout_id", None) or 0)
+    return (
+        getattr(args, "use_pytorch_profiler", False)
+        and stage in getattr(args, "profile_target", ())
+        and getattr(args, "profile_step_start", 0) <= step < getattr(args, "profile_step_end", 0)
+    )
+
+
+def profile_output_dir(args, stage: str, rollout_id: int | None = None, worker: str | None = None) -> str:
+    path = Path(args.profile_output_dir) / stage
+    if rollout_id is not None:
+        path = path / f"rollout_{rollout_id}"
+    if worker is not None:
+        path = path / worker
+    return str(path)
+
+
+def profile_activities_for_torch(args):
+    activities = []
+    for activity in getattr(args, "profile_activities", ["cpu", "gpu"]):
+        if activity == "cpu":
+            activities.append(torch.profiler.ProfilerActivity.CPU)
+        elif activity == "gpu":
+            activities.append(torch.profiler.ProfilerActivity.CUDA)
+    return activities
+
+
+def profile_activities_for_sglang(args) -> list[str]:
+    return [
+        activity.upper() if activity == "cpu" else "GPU"
+        for activity in getattr(args, "profile_activities", ["cpu", "gpu"])
+    ]
+
+
+def _create_torch_profiler(args, name, *, schedule=None, output_dir: str | None = None):
     return torch.profiler.profile(
-        schedule=torch.profiler.schedule(
-            # TODO the train_actor and train_log_probs ones may need to have different args to control step
-            wait=max(args.profile_step_start - 1, 0),
-            warmup=1 if args.profile_step_start > 0 else 0,
-            active=args.profile_step_end - args.profile_step_start,
-            repeat=1,
-        ),
+        activities=profile_activities_for_torch(args),
+        schedule=schedule,
         on_trace_ready=torch.profiler.tensorboard_trace_handler(
-            args.tensorboard_dir,
+            output_dir or profile_output_dir(args, name),
             worker_name=f"{name}_rank_{torch.distributed.get_rank()}",
             use_gzip=True,
         ),
-        record_shapes=True,
-        with_stack=True,
-        profile_memory=True,
+        record_shapes=args.profile_record_shapes,
+        with_stack=args.profile_with_stack,
+        profile_memory=args.profile_memory,
         with_flops=True,
     )
 

--- a/train.py
+++ b/train.py
@@ -94,7 +94,7 @@ async def train(args):
         await offload_train()
         if args.offload_rollout:
             await rollout_manager.onload_weights.remote()
-        await actor_model.update_weights()
+        await actor_model.update_weights(rollout_id)
         if args.offload_rollout:
             await rollout_manager.onload_kv.remote()
 

--- a/train_async.py
+++ b/train_async.py
@@ -65,7 +65,7 @@ async def train(args):
             # sync generate before update weights to prevent update weight in the middle of generation
             rollout_data_curr_ref = (await x) if (x := rollout_data_next_future) is not None else None
             rollout_data_next_future = None
-            await actor_model.update_weights()
+            await actor_model.update_weights(rollout_id)
 
         if should_run_periodic_action(rollout_id, args.eval_interval, num_rollout_per_epoch):
             await rollout_manager.eval.remote(rollout_id)


### PR DESCRIPTION
Opt-in per-phase profiling (`--profile`) that emits one trace per phase per rollout.

| target              | profiler         | what it wraps                                                                 |
|---------------------|------------------|-------------------------------------------------------------------------------|
| `rollout`           | SGLang           | one rollout; auto-stops after `--profile-rollout-num-steps` (default 50)      |
| `train`             | torch.profiler   | the entire train method as one trace                                          |
| `ref_log_probs` / `log_probs` / `actor_train` | torch.profiler | train sub-phases, each its own trace; mutually exclusive with `train` |
| `update_weights`    | torch.profiler   | the weight broadcast/update phase                                             |

Legacy `train_overall` / `train_actor` / `train_log_probs` are unchanged.
