### PR TITLE
[TITO] feat (3/N): verify chat templates through TITO tokenizer

### DIFF
--- a/miles/utils/test_utils/chat_template_verify.py
+++ b/miles/utils/test_utils/chat_template_verify.py
@@ -17,7 +17,7 @@ from copy import deepcopy
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
-from miles.utils.chat_template_utils.template import apply_chat_template, apply_chat_template_from_str
+from miles.utils.chat_template_utils.template import apply_chat_template_from_str
 
 if TYPE_CHECKING:
     from miles.utils.chat_template_utils.tito_tokenizer import TITOTokenizer, TITOTokenizerType
@@ -456,21 +456,15 @@ def verify_append_only_via_tito_instance(
         prefix_msgs = deepcopy(messages[:n])
         full_msgs = deepcopy(messages[:m])
 
-        prefix_text = apply_chat_template(
+        prefix_text = tito._render_messages(
             prefix_msgs,
-            tokenizer=tokenizer,
             tools=tools,
             add_generation_prompt=False,
-            tokenize=False,
-            **template_kwargs,
         )
-        full_text = apply_chat_template(
+        full_text = tito._render_messages(
             full_msgs,
-            tokenizer=tokenizer,
             tools=tools,
             add_generation_prompt=True,
-            tokenize=False,
-            **template_kwargs,
         )
 
         prefix_ids = tokenizer.encode(prefix_text, add_special_tokens=False)

--- a/scripts/tools/verify_chat_template.py
+++ b/scripts/tools/verify_chat_template.py
@@ -3,15 +3,19 @@
 
 Usage examples::
 
-    # Verify a local .jinja template file
+    # Verify a local .jinja template file at raw template-string level
     python scripts/tools/verify_chat_template.py --template path/to/template.jinja
 
-    # Verify a HuggingFace model's chat template
+    # Verify a HuggingFace model's chat template at raw template-string level
     python scripts/tools/verify_chat_template.py --model Qwen/Qwen3-0.6B
 
-    # Resolve a bundled fixed template for a TITO tokenizer family
+    # Verify through the registered TITO tokenizer family
     python scripts/tools/verify_chat_template.py --model Qwen/Qwen3-0.6B \\
         --tito-model qwen3 --tito-allowed-append-roles tool
+
+    # Verify through TITO while testing a local template override
+    python scripts/tools/verify_chat_template.py --model Qwen/Qwen3-0.6B \\
+        --tito-model qwen3 --template miles/utils/chat_template_utils/templates/qwen3_fixed.jinja
 
     # Restrict which append roles the session is allowed to use (tool is implicit)
     python scripts/tools/verify_chat_template.py --model Qwen/Qwen3-0.6B \\
@@ -37,32 +41,11 @@ def _load_template_from_file(path: str) -> str:
 
 def _load_template_from_model(
     model_id: str,
-    *,
-    tito_model: str | None,
-    allowed_roles: list[str],
-) -> tuple[str, str, dict]:
-    """Load chat template for a HF model.
-
-    Returns ``(template_str, source_description, resolved_kwargs)``. When the
-    matched fixed-template row registers extra kwargs, the caller is expected
-    to merge ``resolved_kwargs`` into its own template kwargs (with explicit
-    user values winning on conflict).
-    """
-    if tito_model:
-        from miles.utils.chat_template_utils import resolve_fixed_chat_template
-
-        fixed_path, resolved_kwargs = resolve_fixed_chat_template(tito_model, allowed_roles)
-        if fixed_path:
-            return _load_template_from_file(fixed_path), f"fixed template: {fixed_path}", resolved_kwargs
-        # No template path matched, but the row may still carry kwargs (e.g. an
-        # HF-native + clear_thinking=False fix).  Fall through to HF-native
-        # loading and bubble the kwargs up.
-    else:
-        resolved_kwargs = {}
-
+) -> tuple[str, str]:
+    """Load the raw HuggingFace chat template for a model."""
     from miles.utils.chat_template_utils.template import load_hf_chat_template
 
-    return load_hf_chat_template(model_id), f"HuggingFace: {model_id}", resolved_kwargs
+    return load_hf_chat_template(model_id), f"HuggingFace: {model_id}"
 
 
 def main() -> int:
@@ -72,16 +55,19 @@ def main() -> int:
         epilog=__doc__,
     )
 
-    source = parser.add_mutually_exclusive_group(required=True)
-    source.add_argument(
+    parser.add_argument(
         "--template",
         metavar="PATH",
-        help="Path to a local .jinja chat template file.",
+        help=(
+            "Path to a local .jinja chat template file. Without --tito-model this "
+            "runs the legacy raw template-string verifier; with --tito-model this "
+            "overrides the registered TITO template while still using --model for tokenizer loading."
+        ),
     )
-    source.add_argument(
+    parser.add_argument(
         "--model",
         metavar="MODEL_ID",
-        help="HuggingFace model ID (e.g. Qwen/Qwen3-0.6B).",
+        help="HuggingFace model ID or local checkpoint path (e.g. Qwen/Qwen3-0.6B).",
     )
 
     parser.add_argument(
@@ -89,9 +75,10 @@ def main() -> int:
         choices=[t.value for t in TITOTokenizerType],
         default=None,
         help=(
-            "When using --model, look up a bundled fixed template registered for this "
-            "TITO tokenizer family under the given --tito-allowed-append-roles surface. "
-            "Falls back to the HF default chat template when no entry is registered."
+            "Verify through the registered TITO tokenizer family under the given "
+            "--tito-allowed-append-roles surface. Requires --model and exercises "
+            "the production-shape TITO merge/tokenize path instead of the raw "
+            "template-string verifier."
         ),
     )
     parser.add_argument(
@@ -120,7 +107,7 @@ def main() -> int:
     parser.add_argument(
         "--chat-template-kwargs",
         type=json.loads,
-        default={},
+        default=None,
         metavar="JSON",
         help=(
             "Extra kwargs threaded into the chat template on every render, as a "
@@ -131,33 +118,55 @@ def main() -> int:
 
     args = parser.parse_args()
 
-    extra_template_kwargs = args.chat_template_kwargs
+    if args.model is None and args.template is None:
+        parser.error("one of --model or --template is required")
+    if args.tito_model is not None and args.model is None:
+        parser.error("--tito-model requires --model so the TITO verifier can load the tokenizer")
+
+    extra_template_kwargs = dict(args.chat_template_kwargs or {})
 
     # ``--tito-allowed-append-roles`` lists the *optional* extra roles; ``tool``
     # is implicit for tool-capable agentic workflows and unioned in here so both
     # the fixed-template lookup and the trajectory filter see the same surface.
     allowed_roles = set(args.tito_allowed_append_roles) | {"tool"}
 
-    # ── Load template ──────────────────────────────────────────────────
-    if args.template:
-        chat_template = _load_template_from_file(args.template)
-        source_desc = f"file: {args.template}"
-    else:
-        chat_template, source_desc, resolved_kwargs = _load_template_from_model(
-            args.model,
-            tito_model=args.tito_model,
-            allowed_roles=sorted(allowed_roles),
-        )
-        # Merge auto-resolved kwargs into the user's --chat-template-kwargs.
-        # Explicit user values win on conflict; only keys the user did not set
-        # are auto-filled.
+    use_tito_instance = args.tito_model is not None
+
+    # ── Load template/tokenizer ────────────────────────────────────────
+    if use_tito_instance:
+        from miles.utils.chat_template_utils import resolve_fixed_chat_template
+        from miles.utils.processing_utils import load_tokenizer
+
+        fixed_path, resolved_kwargs = resolve_fixed_chat_template(args.tito_model, sorted(allowed_roles))
         for key, value in resolved_kwargs.items():
             if key in extra_template_kwargs:
                 continue
             extra_template_kwargs[key] = value
             print(f"Auto-set --chat-template-kwargs {key}={value!r} (from --tito-model={args.tito_model})")
 
-    from miles.utils.test_utils.chat_template_verify import ALL_CASES, check_coverage, run_all_checks, select_cases
+        template_path = args.template or fixed_path
+        tokenizer = load_tokenizer(args.model, chat_template_path=template_path, trust_remote_code=True)
+        if args.template:
+            source_desc = f"template override via TITO: {args.template}"
+        elif fixed_path:
+            source_desc = f"fixed template via TITO: {fixed_path}"
+        elif getattr(tokenizer, "chat_template", None) is not None:
+            source_desc = f"HuggingFace via TITO: {args.model}"
+        else:
+            source_desc = f"TITO encoder: {args.tito_model}"
+    elif args.template:
+        chat_template = _load_template_from_file(args.template)
+        source_desc = f"file: {args.template}"
+    else:
+        chat_template, source_desc = _load_template_from_model(args.model)
+
+    from miles.utils.test_utils.chat_template_verify import (
+        ALL_CASES,
+        check_coverage,
+        run_all_checks,
+        run_all_checks_via_tito,
+        select_cases,
+    )
 
     is_thinking_filter = {"off": False, "on": True, "both": None}[args.thinking]
     selected = select_cases(allowed_append_roles=allowed_roles, is_thinking=is_thinking_filter)
@@ -184,12 +193,21 @@ def main() -> int:
         print()
 
     # ── Run verification ───────────────────────────────────────────────
-    results = run_all_checks(
-        chat_template,
-        allowed_append_roles=allowed_roles,
-        thinking=args.thinking,
-        extra_template_kwargs=extra_template_kwargs,
-    )
+    if use_tito_instance:
+        results = run_all_checks_via_tito(
+            tokenizer,
+            args.tito_model,
+            allowed_append_roles=allowed_roles,
+            thinking=args.thinking,
+            extra_template_kwargs=extra_template_kwargs,
+        )
+    else:
+        results = run_all_checks(
+            chat_template,
+            allowed_append_roles=allowed_roles,
+            thinking=args.thinking,
+            extra_template_kwargs=extra_template_kwargs,
+        )
 
     # ── Print results ──────────────────────────────────────────────────
     passed = sum(1 for r in results if r.passed)
@@ -211,10 +229,16 @@ def main() -> int:
     print(f"Results: {passed}/{len(results)} passed, {failed} failed")
 
     if failed:
-        print("\nVerdict: FAIL - template is NOT append-only after last user message")
+        if use_tito_instance:
+            print("\nVerdict: FAIL - TITO incremental tokenization did NOT match standard render")
+        else:
+            print("\nVerdict: FAIL - template is NOT append-only after last user message")
         return 1
     else:
-        print("\nVerdict: PASS - template IS append-only after last user message")
+        if use_tito_instance:
+            print("\nVerdict: PASS - TITO incremental tokenization matched standard render")
+        else:
+            print("\nVerdict: PASS - template IS append-only after last user message")
         return 0
 
 


### PR DESCRIPTION
## Summary

Changes `verify_chat_template.py --tito-model` from raw chat-template prefix check into a TITO verifier:
- instantiate the registered TITO tokenizer family
- load the model tokenizer when verifying TITO behavior
- exercise `merge_tokens` / `tokenize_additional_non_assistant`
- compare decoded merged tokens against the canonical full render
- allow `--template` as a local override while still using `--model` for tokenizer loading

It also aligns tool canonicalization with SGLang’s chat-template path so the verifier checks the same shape used by the session server.

## Test
Ran the registered TITO tokenizer verifier for all existing model families and supported role surfaces:

```bash
python scripts/tools/verify_chat_template.py --model Qwen/Qwen3-30B-A3B --tito-model qwen3 --tito-allowed-append-roles tool --thinking both
python scripts/tools/verify_chat_template.py --model Qwen/Qwen3-30B-A3B --tito-model qwen3 --tito-allowed-append-roles tool user --thinking both

python scripts/tools/verify_chat_template.py --model Qwen/Qwen3.5-35B-A3B --tito-model qwen35 --tito-allowed-append-roles tool --thinking both
python scripts/tools/verify_chat_template.py --model Qwen/Qwen3.5-35B-A3B --tito-model qwen35 --tito-allowed-append-roles tool user --thinking both

python scripts/tools/verify_chat_template.py --model Qwen/Qwen3-Next-80B-A3B-Thinking --tito-model qwennext --tito-allowed-append-roles tool --thinking both
python scripts/tools/verify_chat_template.py --model Qwen/Qwen3-Next-80B-A3B-Thinking --tito-model qwennext --tito-allowed-append-roles tool user --thinking both

python scripts/tools/verify_chat_template.py --model zai-org/GLM-4.7-Flash --tito-model glm47 --tito-allowed-append-roles tool --thinking both
python scripts/tools/verify_chat_template.py --model zai-org/GLM-4.7-Flash --tito-model glm47 --tito-allowed-append-roles tool user --thinking both
python scripts/tools/verify