### PR TITLE
[TITO] feat (4/N): Use prompt ids from miles session server

### DIFF
--- a/docs/en/agentic/oai_endpoint.md
+++ b/docs/en/agentic/oai_endpoint.md
@@ -52,8 +52,7 @@ Minimal request shape:
 
 You can pass any OpenAI-compatible parameters in the payload, or any
 SGLang-compatible `ChatCompletionRequest` parameters. Note: with
-`--use-session-server`, the session middleware sets the token-tracking fields
-TITO needs and injects Miles-owned `input_ids` before proxying to SGLang.
+`--use-session-server`, the session middleware sets the token-tracking fields TITO needs.
 Do **not** set `logprob_start_len=0` — it would disable SGLang's prefix
 cache.
 
@@ -130,10 +129,7 @@ three things on your behalf:
   (`logprobs=True`, `return_meta_info=True`, `no_stop_trim=False`); these are
   set by the middleware in `miles/rollout/session/sessions.py` and override any
   agent-passed values.
-- Reuses the token prefix from previous turns by injecting Miles-owned
-  `input_ids` on every proxied chat request. The response
-  `choice.prompt_token_ids` is copied from those `input_ids`; it is not read
-  back from SGLang.
+- Reuses the token prefix from previous turns by injecting Miles-owned `input_ids` on every proxied chat request. 
 - Accumulates per-turn records into the `Sample` you receive at the end of
   the session, with `tokens` and `rollout_log_probs` already populated.
 

--- a/docs/en/agentic/oai_endpoint.md
+++ b/docs/en/agentic/oai_endpoint.md
@@ -46,16 +46,14 @@ Minimal request shape:
   "messages": [
     {"role": "system", "content": "You are a concise assistant."},
     {"role": "user", "content": "Answer with one word: 2+2?"}
-  ],
-  "logprobs": true,
-  "return_prompt_token_ids": true
+  ]
 }
 ```
 
 You can pass any OpenAI-compatible parameters in the payload, or any
-SGLang-compatible `ChatCompletionRequest` parameters. Note:
-`logprobs=True` and `return_prompt_token_ids=True` are set in
-`request_kwargs` to extract token ids and logprobs for TITO (see below).
+SGLang-compatible `ChatCompletionRequest` parameters. Note: with
+`--use-session-server`, the session middleware sets the token-tracking fields
+TITO needs and injects Miles-owned `input_ids` before proxying to SGLang.
 Do **not** set `logprob_start_len=0` — it would disable SGLang's prefix
 cache.
 
@@ -129,11 +127,13 @@ request. It requires `--use-session-server`; with that on, miles handles
 three things on your behalf:
 
 - Hardcodes the SGLang flags TITO needs on every chat request
-  (`logprobs=True`, `return_meta_info=True`, `return_prompt_token_ids=True`,
-  `no_stop_trim=False`); these are set by the middleware in
-  `miles/rollout/session/sessions.py` and override any agent-passed values.
-- Reuses the token prefix from previous turns by injecting `input_ids` on
-  follow-up requests.
+  (`logprobs=True`, `return_meta_info=True`, `no_stop_trim=False`); these are
+  set by the middleware in `miles/rollout/session/sessions.py` and override any
+  agent-passed values.
+- Reuses the token prefix from previous turns by injecting Miles-owned
+  `input_ids` on every proxied chat request. The response
+  `choice.prompt_token_ids` is copied from those `input_ids`; it is not read
+  back from SGLang.
 - Accumulates per-turn records into the `Sample` you receive at the end of
   the session, with `tokens` and `rollout_log_probs` already populated.
 

--- a/miles/rollout/generate_utils/openai_endpoint_utils.py
+++ b/miles/rollout/generate_utils/openai_endpoint_utils.py
@@ -168,7 +168,7 @@ def _compute_sample_from_openai_record(
     if "prompt_token_ids" in choice:
         prompt_token_ids = choice["prompt_token_ids"]
     else:
-        raise ValueError("prompt_token_ids not found in response choice — ensure return_prompt_token_ids=True is set")
+        raise ValueError("prompt_token_ids not found in response choice — the session server should populate it")
 
     output_token_ids = [item[1] for item in choice["meta_info"]["output_token_logprobs"]]
     output_log_probs = [item[0] for item in choice["meta_info"]["output_token_logprobs"]]

--- a/miles/rollout/session/linear_trajectory.py
+++ b/miles/rollout/session/linear_trajectory.py
@@ -264,10 +264,11 @@ class SessionRegistry:
             return None
         try:
             tools = session.records[-1].request.get("tools") if session.records else None
-            expected_ids = self.tito_tokenizer.tokenize_prompt(
+            expected_ids = self.tito_tokenizer.render_messages(
                 session.messages,
                 tools=tools,
                 add_generation_prompt=False,
+                tokenize=True,
             )
             mismatches = self.comparator.compare_sequences(expected_ids, session.token_ids)
             return [m.to_dict() for m in mismatches]

--- a/miles/rollout/session/linear_trajectory.py
+++ b/miles/rollout/session/linear_trajectory.py
@@ -6,11 +6,7 @@ from typing import Any
 
 from miles.rollout.session.session_errors import MessageValidationError, SessionNotFoundError, TokenizationError
 from miles.rollout.session.session_types import SessionRecord
-from miles.utils.chat_template_utils import (
-    apply_chat_template,
-    assert_messages_append_only_with_allowed_role,
-    message_matches,
-)
+from miles.utils.chat_template_utils import assert_messages_append_only_with_allowed_role, message_matches
 from miles.utils.chat_template_utils.tito_tokenizer import TITOTokenizer
 
 logger = logging.getLogger(__name__)
@@ -19,19 +15,6 @@ logger = logging.getLogger(__name__)
 # TODO: hardcoded to 1 for now; if multi-step rollback is actually needed,
 #  raise this limit or make it configurable and remove the restriction.
 MAX_ASSISTANT_ROLLBACK_STEPS = 1
-
-
-def _assert_no_user_after_assistant(messages: list[dict[str, Any]]) -> None:
-    """Assert no user message appears after the first assistant message."""
-    seen_assistant = False
-    for i, msg in enumerate(messages):
-        role = msg.get("role")
-        if role == "assistant":
-            seen_assistant = True
-        elif role == "user" and seen_assistant:
-            raise MessageValidationError(
-                f"invalid message structure: user message at index {i} " f"appears after the first assistant message"
-            )
 
 
 @dataclass
@@ -281,13 +264,10 @@ class SessionRegistry:
             return None
         try:
             tools = session.records[-1].request.get("tools") if session.records else None
-            expected_ids = apply_chat_template(
+            expected_ids = self.tito_tokenizer.tokenize_prompt(
                 session.messages,
-                tokenizer=self.tokenizer,
                 tools=tools,
                 add_generation_prompt=False,
-                tokenize=True,
-                **self.tito_tokenizer.chat_template_kwargs,
             )
             mismatches = self.comparator.compare_sequences(expected_ids, session.token_ids)
             return [m.to_dict() for m in mismatches]

--- a/miles/rollout/session/session_server.py
+++ b/miles/rollout/session/session_server.py
@@ -81,7 +81,13 @@ class SessionServer:
     def build_proxy_response(self, result: dict) -> Response:
         content = result["response_body"]
         status_code = result["status_code"]
-        headers = result["headers"]
+        # Drop wire-level framing headers from upstream so Starlette rebuilds them
+        # from the body we actually send: transfer-encoding is hop-by-hop
+        headers = {
+            k: v
+            for k, v in result["headers"].items()
+            if k.lower() not in ("content-length", "transfer-encoding", "content-encoding")
+        }
         content_type = headers.get("content-type", "")
         try:
             data = json.loads(content)

--- a/miles/rollout/session/sessions.py
+++ b/miles/rollout/session/sessions.py
@@ -160,9 +160,11 @@ def setup_session_routes(app, backend, args):
                 if pretokenized is not None:
                     request_body["input_ids"] = pretokenized["input_ids"]
                 else:
-                    request_body["input_ids"] = registry.tito_tokenizer.tokenize_prompt(
+                    request_body["input_ids"] = registry.tito_tokenizer.render_messages(
                         request_messages,
                         tools=request_body.get("tools"),
+                        add_generation_prompt=True,
+                        tokenize=True,
                     )
                 logger.debug(
                     "Using TITO input_ids: %d tokens",
@@ -203,11 +205,6 @@ def setup_session_routes(app, backend, args):
             # TITO prompt tokenization is owned by Miles rather than SGLang.
             choice["prompt_token_ids"] = prompt_token_ids
             result["response_body"] = json.dumps(response).encode()
-            result["headers"] = {
-                k: v
-                for k, v in result["headers"].items()
-                if k.lower() not in ("content-length", "transfer-encoding", "content-encoding")
-            }
             output_token_logprobs = meta_info["output_token_logprobs"]
             completion_tokens = meta_info["completion_tokens"]
 

--- a/miles/rollout/session/sessions.py
+++ b/miles/rollout/session/sessions.py
@@ -137,20 +137,18 @@ def setup_session_routes(app, backend, args):
                 body = await request.body()
                 request_body = json.loads(body) if body else {}
 
-                # TITO token tracking requires three SGLang flags working together:
-                #   logprobs=True            → populates meta_info.output_token_logprobs
-                #   return_prompt_token_ids  → adds choice.prompt_token_ids
-                #   return_meta_info         → wraps the above in choice.meta_info
-                # All three are hardcoded (not setdefault) to prevent agent-side
+                # TITO token tracking requires Miles-owned input_ids plus SGLang
+                # output-token metadata:
+                #   logprobs=True     → populates meta_info.output_token_logprobs
+                #   return_meta_info  → wraps the above in choice.meta_info
+                # Both flags are hardcoded (not set default) to prevent agent-side
                 # overrides from breaking the token accumulation invariants.
                 request_body["logprobs"] = True
-                request_body["return_prompt_token_ids"] = True
                 request_body["return_meta_info"] = True
                 if getattr(args, "use_rollout_routing_replay", False):
                     request_body["return_routed_experts"] = True
-                # Must be False so stop tokens are trimmed from output: otherwise the
-                # agent sees stop-token text in content, and the accumulated checkpoint
-                # would duplicate structural delimiters that the chat template also emits.
+                # Must be False so stop-token text is trimmed from assistant
+                # message content; token IDs are still taken from logprobs below.
                 request_body["no_stop_trim"] = False
 
                 request_messages = request_body.get("messages", [])
@@ -161,10 +159,15 @@ def setup_session_routes(app, backend, args):
                 )
                 if pretokenized is not None:
                     request_body["input_ids"] = pretokenized["input_ids"]
-                    logger.debug(
-                        "Using pretokenized input_ids: %d tokens",
-                        len(pretokenized["input_ids"]),
+                else:
+                    request_body["input_ids"] = registry.tito_tokenizer.tokenize_prompt(
+                        request_messages,
+                        tools=request_body.get("tools"),
                     )
+                logger.debug(
+                    "Using TITO input_ids: %d tokens",
+                    len(request_body["input_ids"]),
+                )
 
                 body = json.dumps(request_body).encode()
                 expected_num_assistant = session.num_assistant
@@ -195,7 +198,16 @@ def setup_session_routes(app, backend, args):
                     "an empty content rather than None. Please check your modified SGLang version."
                 )
 
-            prompt_token_ids = choice.get("prompt_token_ids")
+            prompt_token_ids = request_body["input_ids"]
+            # The rollout sample builder still consumes this response field, but
+            # TITO prompt tokenization is owned by Miles rather than SGLang.
+            choice["prompt_token_ids"] = prompt_token_ids
+            result["response_body"] = json.dumps(response).encode()
+            result["headers"] = {
+                k: v
+                for k, v in result["headers"].items()
+                if k.lower() not in ("content-length", "transfer-encoding", "content-encoding")
+            }
             output_token_logprobs = meta_info["output_token_logprobs"]
             completion_tokens = meta_info["completion_tokens"]
 

--- a/miles/rollout/session/sessions.py
+++ b/miles/rollout/session/sessions.py
@@ -157,18 +157,20 @@ def setup_session_routes(app, backend, args):
                     tools=request_body.get("tools"),
                     tito_tokenizer=registry.tito_tokenizer,
                 )
+                prompt_token_ids = None
                 if pretokenized is not None:
-                    request_body["input_ids"] = pretokenized["input_ids"]
+                    prompt_token_ids = pretokenized["input_ids"]
                 else:
-                    request_body["input_ids"] = registry.tito_tokenizer.render_messages(
+                    prompt_token_ids = registry.tito_tokenizer.render_messages(
                         request_messages,
                         tools=request_body.get("tools"),
                         add_generation_prompt=True,
                         tokenize=True,
                     )
+                request_body["input_ids"] = prompt_token_ids
                 logger.debug(
                     "Using TITO input_ids: %d tokens",
-                    len(request_body["input_ids"]),
+                    len(prompt_token_ids),
                 )
 
                 body = json.dumps(request_body).encode()
@@ -200,10 +202,8 @@ def setup_session_routes(app, backend, args):
                     "an empty content rather than None. Please check your modified SGLang version."
                 )
 
-            prompt_token_ids = request_body["input_ids"]
-            # The rollout sample builder still consumes this response field, but
-            # TITO prompt tokenization is owned by Miles rather than SGLang.
             choice["prompt_token_ids"] = prompt_token_ids
+            # This must be re-encoded to return the prompt token ids
             result["response_body"] = json.dumps(response).encode()
             output_token_logprobs = meta_info["output_token_logprobs"]
             completion_tokens = meta_info["completion_tokens"]

--- a/miles/utils/chat_template_utils/tito_tokenizer.py
+++ b/miles/utils/chat_template_utils/tito_tokenizer.py
@@ -139,6 +139,21 @@ class TITOTokenizer:
     def _encode_text(self, text: str) -> list[int]:
         return self.tokenizer.encode(text, add_special_tokens=False)
 
+    def tokenize_prompt(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None = None,
+        *,
+        add_generation_prompt: bool = True,
+    ) -> list[int]:
+        return self._encode_text(
+            self._render_messages(
+                messages,
+                add_generation_prompt=add_generation_prompt,
+                tools=tools,
+            )
+        )
+
     def _split_appended_segments(self, appended_messages: list[dict[str, Any]]) -> list[list[dict[str, Any]]]:
         segments: list[list[dict[str, Any]]] = []
         i = 0

--- a/miles/utils/chat_template_utils/tito_tokenizer.py
+++ b/miles/utils/chat_template_utils/tito_tokenizer.py
@@ -120,17 +120,18 @@ class TITOTokenizer:
             trim_trailing_ids=self.trailing_token_ids or None,
         )
 
-    def _render_messages(
+    def render_messages(
         self,
         messages: list[dict[str, Any]],
         *,
         add_generation_prompt: bool,
         tools: list[dict[str, Any]] | None = None,
-    ) -> str:
+        tokenize: bool = False,
+    ) -> str | list[int]:
         return apply_chat_template(
             messages,
             tokenizer=self.tokenizer,
-            tokenize=False,
+            tokenize=tokenize,
             add_generation_prompt=add_generation_prompt,
             tools=tools,
             **self.chat_template_kwargs,
@@ -138,21 +139,6 @@ class TITOTokenizer:
 
     def _encode_text(self, text: str) -> list[int]:
         return self.tokenizer.encode(text, add_special_tokens=False)
-
-    def tokenize_prompt(
-        self,
-        messages: list[dict[str, Any]],
-        tools: list[dict[str, Any]] | None = None,
-        *,
-        add_generation_prompt: bool = True,
-    ) -> list[int]:
-        return self._encode_text(
-            self._render_messages(
-                messages,
-                add_generation_prompt=add_generation_prompt,
-                tools=tools,
-            )
-        )
 
     def _split_appended_segments(self, appended_messages: list[dict[str, Any]]) -> list[list[dict[str, Any]]]:
         segments: list[list[dict[str, Any]]] = []
@@ -190,8 +176,8 @@ class TITOTokenizer:
         When *add_generation_prompt* is True and *appended_messages* is empty,
         this computes the generation-prompt suffix (the assistant opener tokens).
         """
-        text_without = self._render_messages(base_messages, add_generation_prompt=False, tools=tools)
-        text_with = self._render_messages(
+        text_without = self.render_messages(base_messages, add_generation_prompt=False, tools=tools)
+        text_with = self.render_messages(
             base_messages + appended_messages,
             add_generation_prompt=add_generation_prompt,
             tools=tools,

--- a/miles/utils/test_utils/chat_template_verify.py
+++ b/miles/utils/test_utils/chat_template_verify.py
@@ -456,12 +456,12 @@ def verify_append_only_via_tito_instance(
         prefix_msgs = deepcopy(messages[:n])
         full_msgs = deepcopy(messages[:m])
 
-        prefix_text = tito._render_messages(
+        prefix_text = tito.render_messages(
             prefix_msgs,
             tools=tools,
             add_generation_prompt=False,
         )
-        full_text = tito._render_messages(
+        full_text = tito.render_messages(
             full_msgs,
             tools=tools,
             add_generation_prompt=True,

--- a/miles/utils/test_utils/mock_sglang_server.py
+++ b/miles/utils/test_utils/mock_sglang_server.py
@@ -146,11 +146,13 @@ class MockSGLangServer:
             messages, tokenize=False, add_generation_prompt=True, tools=tools
         )
 
-        input_ids = payload.get("input_ids")
-        if input_ids is not None:
-            prompt_ids = list(input_ids)
-        else:
-            prompt_ids = self.tokenizer.encode(prompt_str, add_special_tokens=False)
+        prompt_ids = None
+        if payload.get("return_prompt_token_ids"):
+            input_ids = payload.get("input_ids")
+            if input_ids is not None:
+                prompt_ids = list(input_ids)
+            else:
+                prompt_ids = self.tokenizer.encode(prompt_str, add_special_tokens=False)
 
         process_result = self.process_fn(prompt_str)
         output_ids = self.tokenizer.encode(process_result.text, add_special_tokens=False)
@@ -187,29 +189,30 @@ class MockSGLangServer:
 
         output_token_logprobs = [(-1 / 128 * i, tid) for i, tid in enumerate(output_ids)]
 
+        choice = {
+            "index": 0,
+            "message": {
+                "role": "assistant",
+                "content": message_content,
+                "tool_calls": tool_calls,
+            },
+            "logprobs": {"content": logprobs_content},
+            "finish_reason": finish_reason,
+            "meta_info": {
+                "output_token_logprobs": output_token_logprobs,
+                "completion_tokens": len(output_ids),
+                **process_result.meta_info.to_dict(),
+            },
+        }
+        if prompt_ids is not None:
+            choice["prompt_token_ids"] = prompt_ids
+
         return {
             "id": f"chatcmpl-{uuid.uuid4().hex[:8]}",
             "object": "chat.completion",
             "created": int(time.time()),
             "model": "mock-model",
-            "choices": [
-                {
-                    "index": 0,
-                    "message": {
-                        "role": "assistant",
-                        "content": message_content,
-                        "tool_calls": tool_calls,
-                    },
-                    "logprobs": {"content": logprobs_content},
-                    "prompt_token_ids": prompt_ids,
-                    "finish_reason": finish_reason,
-                    "meta_info": {
-                        "output_token_logprobs": output_token_logprobs,
-                        "completion_tokens": len(output_ids),
-                        **process_result.meta_info.to_dict(),
-                    },
-                }
-            ],
+            "choices": [choice],
         }
 
 

--- a/tests/fast/rollout/generate_hub/test_multi_turn.py
+++ b/tests/fast/rollout/generate_hub/test_multi_turn.py
@@ -10,6 +10,7 @@ from tests.ci.ci_register import register_cuda_ci
 from tests.fast.fixtures.generation_fixtures import GenerateEnv, generation_env, listify, make_sample, run_generate
 
 
+from miles.utils.chat_template_utils import TITOTokenizerType, get_tito_tokenizer
 from miles.utils.processing_utils import load_tokenizer
 from miles.utils.test_utils.mock_sglang_server import ProcessResult, ProcessResultMetaInfo
 from miles.utils.test_utils.mock_tools import SAMPLE_TOOLS, ThreeTurnStub, TwoTurnStub
@@ -160,7 +161,6 @@ def expected_openai_request(messages: list[dict], **extra) -> dict:
         "tools": SAMPLE_TOOLS,
         # Injected by the session route for TITO token tracking
         "logprobs": True,
-        "return_prompt_token_ids": True,
         "return_meta_info": True,
         "no_stop_trim": False,
         **extra,
@@ -196,7 +196,7 @@ class TestBasicMultiTurn:
         result = _run_generate(variant, generation_env, make_sample(prompt=SINGLE_TURN_PROMPT))
 
         if is_agentic_variant(variant):
-            assert result.requests == [expected_openai_request(SINGLE_TURN_PROMPT)]
+            assert _strip_pretokenized(result.requests) == [expected_openai_request(SINGLE_TURN_PROMPT)]
         else:
             assert result.requests == [expected_request(SINGLE_TURN_PROMPT_TOKEN_IDS)]
         verify_samples(
@@ -318,7 +318,7 @@ class TestExitConditions:
         result = _run_generate(variant, generation_env, make_sample(prompt=S.PROMPT))
 
         if is_agentic_variant(variant):
-            assert result.requests == [expected_openai_request(S.OPENAI_MESSAGES_FIRST_TURN)]
+            assert _strip_pretokenized(result.requests) == [expected_openai_request(S.OPENAI_MESSAGES_FIRST_TURN)]
         else:
             assert result.requests == [expected_request(S.FIRST_PROMPT_TOKEN_IDS)]
         verify_samples(
@@ -344,7 +344,7 @@ class TestExitConditions:
         result = _run_generate(variant, generation_env, make_sample(prompt=S.PROMPT))
 
         if is_agentic_variant(variant):
-            assert result.requests == [expected_openai_request(S.OPENAI_MESSAGES_FIRST_TURN)]
+            assert _strip_pretokenized(result.requests) == [expected_openai_request(S.OPENAI_MESSAGES_FIRST_TURN)]
         else:
             assert result.requests == [expected_request(S.FIRST_PROMPT_TOKEN_IDS)]
         if variant == "multi_turn_single_sample":
@@ -568,6 +568,20 @@ class TestRoutedExpertsMultiTurn:
         num_layers, moe_router_topk = 2, 4
         generation_env.args.num_layers = num_layers
         generation_env.args.moe_router_topk = moe_router_topk
+        if is_agentic_variant(variant):
+            tito = get_tito_tokenizer(
+                TOKENIZER,
+                # Note: tokenizer_type needs to match MODEL_NAME
+                tokenizer_type=TITOTokenizerType.QWEN3,
+                allowed_append_roles=["tool"],
+            )
+            first_prompt_token_ids = tito.tokenize_prompt(S.OPENAI_MESSAGES_FIRST_TURN, tools=SAMPLE_TOOLS)
+            second_prompt_token_ids = tito.tokenize_prompt(
+                S.OPENAI_MESSAGES_SECOND_TURN_FROM_CLIENT, tools=SAMPLE_TOOLS
+            )
+        else:
+            first_prompt_token_ids = S.FIRST_PROMPT_TOKEN_IDS
+            second_prompt_token_ids = S.SECOND_PROMPT_TOKEN_IDS
 
         def make_routed_experts(prompt_token_ids, response_text):
             total_tokens = len(prompt_token_ids) + token_len(response_text)
@@ -576,8 +590,8 @@ class TestRoutedExpertsMultiTurn:
                 routed_experts_len, num_layers, moe_router_topk
             )
 
-        first_routed_experts = make_routed_experts(S.FIRST_PROMPT_TOKEN_IDS, S.FIRST_RESPONSE)
-        second_routed_experts = make_routed_experts(S.SECOND_PROMPT_TOKEN_IDS, S.SECOND_RESPONSE)
+        first_routed_experts = make_routed_experts(first_prompt_token_ids, S.FIRST_RESPONSE)
+        second_routed_experts = make_routed_experts(second_prompt_token_ids, S.SECOND_RESPONSE)
 
         def process_fn(prompt: str) -> ProcessResult:
             if prompt == S.FIRST_PROMPT:
@@ -603,10 +617,10 @@ class TestRoutedExpertsMultiTurn:
             assert result.requests[1]["messages"] == S.OPENAI_MESSAGES_SECOND_TURN_FROM_CLIENT
             for req in result.requests:
                 assert req["logprobs"] is True
-                assert req["return_prompt_token_ids"] is True
                 assert req["return_meta_info"] is True
                 assert req["no_stop_trim"] is False
                 assert req["return_routed_experts"] is True
+                assert "input_ids" in req
         else:
             assert result.requests == [
                 expected_request(S.FIRST_PROMPT_TOKEN_IDS, return_routed_experts=True),

--- a/tests/fast/rollout/generate_hub/test_multi_turn.py
+++ b/tests/fast/rollout/generate_hub/test_multi_turn.py
@@ -575,9 +575,17 @@ class TestRoutedExpertsMultiTurn:
                 tokenizer_type=TITOTokenizerType.QWEN3,
                 allowed_append_roles=["tool"],
             )
-            first_prompt_token_ids = tito.tokenize_prompt(S.OPENAI_MESSAGES_FIRST_TURN, tools=SAMPLE_TOOLS)
-            second_prompt_token_ids = tito.tokenize_prompt(
-                S.OPENAI_MESSAGES_SECOND_TURN_FROM_CLIENT, tools=SAMPLE_TOOLS
+            first_prompt_token_ids = tito.render_messages(
+                S.OPENAI_MESSAGES_FIRST_TURN,
+                tools=SAMPLE_TOOLS,
+                add_generation_prompt=True,
+                tokenize=True,
+            )
+            second_prompt_token_ids = tito.render_messages(
+                S.OPENAI_MESSAGES_SECOND_TURN_FROM_CLIENT,
+                tools=SAMPLE_TOOLS,
+                add_generation_prompt=True,
+                tokenize=True,
             )
         else:
             first_prompt_token_ids = S.FIRST_PROMPT_TOKEN_IDS

--- a/tests/fast/router/test_linear_trajectory.py
+++ b/tests/fast/router/test_linear_trajectory.py
@@ -12,7 +12,7 @@ register_cpu_ci(est_time=60, suite="stage-a-fast")
 from dataclasses import dataclass
 from types import SimpleNamespace
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -662,14 +662,13 @@ class TestComputeSessionMismatch:
         session = registry.get_session(sid)
         assert registry.compute_session_mismatch(session) is None
 
-    @patch("miles.rollout.session.linear_trajectory.apply_chat_template")
-    def test_returns_empty_list_when_no_mismatch(self, mock_template, registry: SessionRegistry):
+    def test_returns_empty_list_when_no_mismatch(self, registry: SessionRegistry):
         sid = registry.create_session()
         session = registry.get_session(sid)
         session.update_pretokenized_state([SYS_MSG, USER_MSG], ASSISTANT_MSG_1, [1, 2, 3], [10, 11], max_trim_tokens=0)
 
         # Simulate: template returns same IDs as stored
-        mock_template.return_value = [1, 2, 3, 10, 11]
+        registry.tito_tokenizer.tokenize_prompt = MagicMock(return_value=[1, 2, 3, 10, 11])
 
         # Need a real comparator; replace the None one
         mock_comparator = MagicMock()
@@ -679,14 +678,18 @@ class TestComputeSessionMismatch:
         result = registry.compute_session_mismatch(session)
         assert result == []
         mock_comparator.compare_sequences.assert_called_once_with([1, 2, 3, 10, 11], [1, 2, 3, 10, 11])
+        registry.tito_tokenizer.tokenize_prompt.assert_called_once_with(
+            session.messages,
+            tools=None,
+            add_generation_prompt=False,
+        )
 
-    @patch("miles.rollout.session.linear_trajectory.apply_chat_template")
-    def test_returns_mismatch_dicts(self, mock_template, registry: SessionRegistry):
+    def test_returns_mismatch_dicts(self, registry: SessionRegistry):
         sid = registry.create_session()
         session = registry.get_session(sid)
         session.update_pretokenized_state([SYS_MSG, USER_MSG], ASSISTANT_MSG_1, [1, 2, 3], [10, 11], max_trim_tokens=0)
 
-        mock_template.return_value = [1, 2, 99, 10, 11]
+        registry.tito_tokenizer.tokenize_prompt = MagicMock(return_value=[1, 2, 99, 10, 11])
 
         @dataclass
         class FakeMismatch:
@@ -702,19 +705,17 @@ class TestComputeSessionMismatch:
         result = registry.compute_session_mismatch(session)
         assert result == [{"position": 2, "detail": "mismatch"}]
 
-    @patch("miles.rollout.session.linear_trajectory.apply_chat_template")
-    def test_raises_tokenization_error_on_exception(self, mock_template, registry: SessionRegistry):
+    def test_raises_tokenization_error_on_exception(self, registry: SessionRegistry):
         sid = registry.create_session()
         session = registry.get_session(sid)
         session.update_pretokenized_state([SYS_MSG, USER_MSG], ASSISTANT_MSG_1, [1, 2, 3], [10, 11], max_trim_tokens=0)
 
-        mock_template.side_effect = RuntimeError("tokenizer failed")
+        registry.tito_tokenizer.tokenize_prompt = MagicMock(side_effect=RuntimeError("tokenizer failed"))
 
         with pytest.raises(TokenizationError, match="tokenizer failed"):
             registry.compute_session_mismatch(session)
 
-    @patch("miles.rollout.session.linear_trajectory.apply_chat_template")
-    def test_uses_tools_from_last_record(self, mock_template, registry: SessionRegistry):
+    def test_uses_tools_from_last_record(self, registry: SessionRegistry):
         sid = registry.create_session()
         session = registry.get_session(sid)
         session.update_pretokenized_state([SYS_MSG, USER_MSG], ASSISTANT_MSG_1, [1, 2], [10], max_trim_tokens=0)
@@ -730,13 +731,15 @@ class TestComputeSessionMismatch:
         )
         session.append_record(record)
 
-        mock_template.return_value = [1, 2, 10]
+        mock_tokenize = MagicMock(return_value=[1, 2, 10])
+        registry.tito_tokenizer.tokenize_prompt = mock_tokenize
         mock_comparator = MagicMock()
         mock_comparator.compare_sequences.return_value = []
         registry.comparator = mock_comparator
 
         registry.compute_session_mismatch(session)
 
-        # Verify tools were passed to apply_chat_template
-        _, kwargs = mock_template.call_args
+        # Verify tools were passed to the TITO renderer.
+        _, kwargs = mock_tokenize.call_args
         assert kwargs["tools"] == tools
+        assert kwargs["add_generation_prompt"] is False

--- a/tests/fast/router/test_linear_trajectory.py
+++ b/tests/fast/router/test_linear_trajectory.py
@@ -668,7 +668,7 @@ class TestComputeSessionMismatch:
         session.update_pretokenized_state([SYS_MSG, USER_MSG], ASSISTANT_MSG_1, [1, 2, 3], [10, 11], max_trim_tokens=0)
 
         # Simulate: template returns same IDs as stored
-        registry.tito_tokenizer.tokenize_prompt = MagicMock(return_value=[1, 2, 3, 10, 11])
+        registry.tito_tokenizer.render_messages = MagicMock(return_value=[1, 2, 3, 10, 11])
 
         # Need a real comparator; replace the None one
         mock_comparator = MagicMock()
@@ -678,10 +678,11 @@ class TestComputeSessionMismatch:
         result = registry.compute_session_mismatch(session)
         assert result == []
         mock_comparator.compare_sequences.assert_called_once_with([1, 2, 3, 10, 11], [1, 2, 3, 10, 11])
-        registry.tito_tokenizer.tokenize_prompt.assert_called_once_with(
+        registry.tito_tokenizer.render_messages.assert_called_once_with(
             session.messages,
             tools=None,
             add_generation_prompt=False,
+            tokenize=True,
         )
 
     def test_returns_mismatch_dicts(self, registry: SessionRegistry):
@@ -689,7 +690,7 @@ class TestComputeSessionMismatch:
         session = registry.get_session(sid)
         session.update_pretokenized_state([SYS_MSG, USER_MSG], ASSISTANT_MSG_1, [1, 2, 3], [10, 11], max_trim_tokens=0)
 
-        registry.tito_tokenizer.tokenize_prompt = MagicMock(return_value=[1, 2, 99, 10, 11])
+        registry.tito_tokenizer.render_messages = MagicMock(return_value=[1, 2, 99, 10, 11])
 
         @dataclass
         class FakeMismatch:
@@ -710,7 +711,7 @@ class TestComputeSessionMismatch:
         session = registry.get_session(sid)
         session.update_pretokenized_state([SYS_MSG, USER_MSG], ASSISTANT_MSG_1, [1, 2, 3], [10, 11], max_trim_tokens=0)
 
-        registry.tito_tokenizer.tokenize_prompt = MagicMock(side_effect=RuntimeError("tokenizer failed"))
+        registry.tito_tokenizer.render_messages = MagicMock(side_effect=RuntimeError("tokenizer failed"))
 
         with pytest.raises(TokenizationError, match="tokenizer failed"):
             registry.compute_session_mismatch(session)
@@ -732,7 +733,7 @@ class TestComputeSessionMismatch:
         session.append_record(record)
 
         mock_tokenize = MagicMock(return_value=[1, 2, 10])
-        registry.tito_tokenizer.tokenize_prompt = mock_tokenize
+        registry.tito_tokenizer.render_messages = mock_tokenize
         mock_comparator = MagicMock()
         mock_comparator.compare_sequences.return_value = []
         registry.comparator = mock_comparator

--- a/tests/fast/router/test_sessions.py
+++ b/tests/fast/router/test_sessions.py
@@ -45,6 +45,9 @@ def router_env():
                 miles_router_timeout=30,
                 hf_checkpoint="Qwen/Qwen3-0.6B",
                 chat_template_path=None,
+                apply_chat_template_kwargs={"enable_thinking": False},
+                tito_model="default",
+                tito_allowed_append_roles=["tool"],
                 trajectory_manager="linear_trajectory",
                 session_server_instance_id=uuid.uuid4().hex,
             )
@@ -57,7 +60,7 @@ def router_env():
             url = f"http://127.0.0.1:{port}"
 
             try:
-                yield SimpleNamespace(url=url)
+                yield SimpleNamespace(url=url, backend=backend)
             finally:
                 server.stop()
 
@@ -129,6 +132,8 @@ class TestSessionProxy:
         body = resp.json()
         assert "choices" in body
         assert body["choices"]
+        assert isinstance(body["choices"][0]["prompt_token_ids"], list)
+        assert body["choices"][0]["prompt_token_ids"]
 
         get_resp = requests.get(f"{router_env.url}/sessions/{session_id}", timeout=5.0)
         records = get_resp.json()["records"]

--- a/tests/fast/utils/chat_template_utils/test_tito_tokenizer.py
+++ b/tests/fast/utils/chat_template_utils/test_tito_tokenizer.py
@@ -389,7 +389,7 @@ class TestTokenizeAdditional:
         )
         tool_messages = [SingleToolThinkingTrajectory.MESSAGES[3]]
         dummy_assistant = _build_dummy_assistant(tool_messages)
-        rendered = thinking_tito._render_messages(
+        rendered = thinking_tito.render_messages(
             [{"role": "system", "content": "dummy system"}, dummy_assistant],
             add_generation_prompt=False,
             tools=SingleToolThinkingTrajectory.TOOLS,

--- a/tests/fast/utils/test_utils/test_mock_sglang_server.py
+++ b/tests/fast/utils/test_utils/test_mock_sglang_server.py
@@ -248,6 +248,7 @@ class TestChatCompletionsEndpoint:
             json={
                 "model": "test-model",
                 "messages": messages,
+                "return_prompt_token_ids": True,
             },
             timeout=5.0,
         )
@@ -288,6 +289,7 @@ class TestChatCompletionsEndpoint:
                     "model": "test",
                     "messages": [{"role": "user", "content": "What year is it?"}],
                     "tools": SAMPLE_TOOLS,
+                    "return_prompt_token_ids": True,
                 },
                 timeout=5.0,
             )
@@ -326,6 +328,7 @@ class TestChatCompletionsEndpoint:
                     "model": "test",
                     "messages": [{"role": "user", "content": "What's the weather?"}],
                     "tools": SAMPLE_TOOLS,
+                    "return_prompt_token_ids": True,
                 },
                 timeout=5.0,
             )
@@ -362,6 +365,7 @@ class TestChatCompletionsEndpoint:
                     "model": "test",
                     "messages": [{"role": "user", "content": "What year and temperature?"}],
                     "tools": SAMPLE_TOOLS,
+                    "return_prompt_token_ids": True,
                 },
                 timeout=5.0,
             )


### PR DESCRIPTION
## Summary

Instead of using SGLang-returnd `prompt_token_ids`, we now move this responsivility to Miles session middleware to better align with TITO's definition. The session server now:

- tokenizes the first turn through Miles
- injects Miles-owned `input_ids` on every proxied chat request
- uses those same `input_ids` as `choice.prompt_token_ids` in the response
- computes session mismatch through the TITO tokenizer path

`return_prompt_token_ids` in SGLang is now unused, but we've decided to temporarily keep it since it's an independent feature and may required by others.

## Test
Fast session / OpenAI-format regression:

```bash
pytest tests/fast/router/test_linear_trajectory.py tests/fast/router/test_sessions.py tests/fast/utils/test_utils/test_mock_sglang_server.py tests/fast/rollout/generate_utils/test_openai_endpoint_utils.py -k 'not test_create_fetches_session_server_instance_id'
```
TITO Regression Test:
```
python scripts/tools/verify_chat_template.py --model Qwen/Qwen3-30B-A3B --tito-model qwen3 --tito-allowed-append-roles tool --thinking both
python scripts/tools/verify_chat_template.py --model Qwen/Qwen3-30B-A3B --tito-model qwen3 --tito-allowed-append-roles tool user --thinking both

python scripts/tools/verify_chat_template.py --model Qwen/Qwen3.5-35B-A3B --tito-model qwen35 --tito-allowed-append-roles tool --thinking both
python scripts/tools/verify_chat_template.py --model Qwen/Qwen3.5-35B-A3B --tito-model qwen35 --tito-allowed-append-roles tool user --thinking both

python scripts/tools/verify_chat_template.py --model Qwen/Qwen3-Next-80B-A3B-Thinking --tito-model qwennext --tito-allowed-append-roles tool --thinking both
python scripts/tools/verify_chat_template.py --model Qwen/Qwen3-Next-80B-A3B-Thinking --tito-model qwennext --tito-allowed-append-roles tool user --thinking both

python scripts/tools/verify_chat_template.py --model zai-org/GLM-4.7-Flash --tito-model glm47 --tito-allowed-append-roles tool --thinking both
python scripts/tools/verify_chat_template.py --model zai-org/GLM-4.7-Flash --tito-model glm47 --tito-allowed-append-roles tool user --thinking both
python scripts/tools/verify_chat_template.py --model zai-org/GLM-4.7-Flash --tito-model glm47 --tito-allowed-append-roles tool user system --thinking both
```
