### PR TITLE
[TITO] model-support: add DeepSeek V4 TITO support 

### DIFF
--- a/miles/utils/chat_template_utils/tito_tokenizer.py
+++ b/miles/utils/chat_template_utils/tito_tokenizer.py
@@ -766,6 +766,53 @@ class DeepSeekV32TITOTokenizer(TITOTokenizer):
 
 
 # ---------------------------------------------------------------------------
+# DeepSeek V4 implementation
+# ---------------------------------------------------------------------------
+
+
+class DeepSeekV4TITOTokenizer(TITOTokenizer):
+    """DeepSeek V4 — official encoder via sglang's ``encoding_dsv4``.
+
+    Like V3.2, V4 ships no jinja chat_template; miles' ``apply_chat_template``
+    routes any V4 tokenizer to the ``chat_template_utils.deepseek_v4`` bridge, and
+    TITO incremental tokenization rides that same bridge to stay byte-aligned
+    with what the runtime serves.  Only the ``{tool}`` surface is registered, so
+    the base ``_split_appended_segments`` (contiguous tool runs) covers it
+    without a custom override.
+    """
+
+    reasoning_parser = "deepseek-v4"
+    tool_call_parser = "deepseekv4"
+
+    SUPPORTED_TEMPLATES = (
+        FixedTemplateRow(
+            allowed_roles=frozenset({"tool"}),
+            template=None,
+        ),
+    )
+
+    _DEFAULT_ASSISTANT_START = "<｜Assistant｜>"
+
+    def __init__(
+        self,
+        tokenizer: Any,
+        chat_template_kwargs: dict[str, Any] | None = None,
+        assistant_start_str: str | None = None,
+        allowed_append_roles: list[str] | None = None,
+    ):
+        super().__init__(
+            tokenizer,
+            chat_template_kwargs=chat_template_kwargs,
+            assistant_start_str=assistant_start_str or self._DEFAULT_ASSISTANT_START,
+            special_token_ids={
+                tokenizer.convert_tokens_to_ids("<｜User｜>"),
+                tokenizer.convert_tokens_to_ids("<｜Assistant｜>"),
+            },
+            allowed_append_roles=allowed_append_roles,
+        )
+
+
+# ---------------------------------------------------------------------------
 # Enum + Factory
 # ---------------------------------------------------------------------------
 
@@ -782,6 +829,7 @@ class TITOTokenizerType(StrEnum):
     MINIMAX_M25 = "minimax_m25"
     MINIMAX_M27 = "minimax_m27"
     DEEPSEEKV32 = "deepseekv32"
+    DEEPSEEKV4 = "deepseekv4"
 
     @classmethod
     def get_tokenizer_class(cls, t: TITOTokenizerType) -> type[TITOTokenizer]:
@@ -809,6 +857,8 @@ class TITOTokenizerType(StrEnum):
                 return MinimaxM27TITOTokenizer
             case cls.DEEPSEEKV32:
                 return DeepSeekV32TITOTokenizer
+            case cls.DEEPSEEKV4:
+                return DeepSeekV4TITOTokenizer
             case _:
                 raise ValueError(f"Unknown TITOTokenizerType: {t!r}")
 

--- a/tests/fast/utils/chat_template_utils/test_template.py
+++ b/tests/fast/utils/chat_template_utils/test_template.py
@@ -18,6 +18,7 @@ Each test asserts that our ``apply_chat_template`` produces identical token IDs.
 from __future__ import annotations
 
 import copy
+import json
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -112,14 +113,38 @@ def sglang_dsv32_prompt_ids(
     return result.prompt_ids
 
 
+def sglang_dsv4_prompt_ids(
+    tokenizer,
+    messages: list[dict],
+    tools: list[dict] | None = None,
+    **kwargs,
+) -> list[int]:
+    """Get DeepSeek-V4 prompt_ids through SGLang's DSv4 encoder path."""
+    request_data: dict = {"messages": copy.deepcopy(messages), "model": "test"}
+    if tools:
+        request_data["tools"] = copy.deepcopy(tools)
+    if kwargs:
+        request_data["chat_template_kwargs"] = kwargs
+    request = ChatCompletionRequest(**request_data)
+
+    serving = _make_serving(tokenizer)
+    serving.chat_encoding_spec = "dsv4"
+    serving.reasoning_parser = "deepseek-v4"
+    serving.tool_call_parser = "deepseekv4"
+    result = serving._process_messages(request, is_multimodal=False)
+    return result.prompt_ids
+
+
 # ---------------------------------------------------------------------------
 # Tokenizer cache & fixed-template loader
 # ---------------------------------------------------------------------------
 
 _TOK_CACHE: dict[str, AutoTokenizer] = {}
 
-# V3.2's HF repo is ~1.3 TB and not pulled in CI; tests use the cluster-mounted
-# copy when present and skip otherwise (Stage 2 only needs the tokenizer).
+# DeepSeek V4/V3.2 HF repos are huge and not pulled in CI; tests use the
+# cluster-mounted copy when present and skip otherwise (Stage 2 only needs the
+# tokenizer).
+_DEEPSEEK_V4_MODEL = "/cluster-storage/models/deepseek-ai/DeepSeek-V4-Flash"
 _DEEPSEEK_V32_MODEL = "/cluster-storage/models/deepseek-ai/DeepSeek-V3.2"
 
 
@@ -133,6 +158,12 @@ def _get_deepseek_v32_tokenizer() -> AutoTokenizer:
     if not Path(_DEEPSEEK_V32_MODEL).exists():
         pytest.skip(f"DeepSeek V3.2 tokenizer not found: {_DEEPSEEK_V32_MODEL}")
     return _get_tokenizer(_DEEPSEEK_V32_MODEL)
+
+
+def _get_deepseek_v4_tokenizer() -> AutoTokenizer:
+    if not Path(_DEEPSEEK_V4_MODEL).exists():
+        pytest.skip(f"DeepSeek V4 tokenizer not found: {_DEEPSEEK_V4_MODEL}")
+    return _get_tokenizer(_DEEPSEEK_V4_MODEL)
 
 
 def _load_fixed_or_none(tito_model: TITOTokenizerType | None) -> str | None:
@@ -441,4 +472,85 @@ class TestDeepSeekV32TITOAlignWithSGLang:
             chat_template_kwargs={"enable_thinking": thinking},
         )
         actual = tito.render_messages(messages, add_generation_prompt=True, tools=self._TOOLS, tokenize=True)
+        assert actual == expected
+
+
+# ---------------------------------------------------------------------------
+# DeepSeek V4 TITO alignment
+# ---------------------------------------------------------------------------
+
+
+class TestDeepSeekV4TITOAlignWithSGLang:
+    """DeepSeek V4 TITO prompt tokenization must match SGLang's DSv4 encoder."""
+
+    @pytest.mark.parametrize("thinking", [False, True], ids=["chat", "thinking"])
+    def test_prompt_ids_match_sglang_dsv4_with_tools(self, thinking):
+        tokenizer = _get_deepseek_v4_tokenizer()
+        messages = [{"role": "user", "content": "What is 1+1?"}]
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_year",
+                    "description": "Get current year",
+                    "parameters": {"type": "object", "properties": {}, "required": []},
+                },
+            }
+        ]
+
+        expected = sglang_dsv4_prompt_ids(tokenizer, messages, tools, thinking=thinking)
+        tito = get_tito_tokenizer(
+            tokenizer,
+            tokenizer_type=TITOTokenizerType.DEEPSEEKV4,
+            chat_template_kwargs={"enable_thinking": thinking},
+        )
+
+        actual = tito.render_messages(messages, add_generation_prompt=True, tools=tools, tokenize=True)
+        assert actual == expected
+
+    @pytest.mark.parametrize("thinking", [False, True], ids=["chat", "thinking"])
+    def test_prompt_ids_match_sglang_dsv4_with_tool_history(self, thinking):
+        tokenizer = _get_deepseek_v4_tokenizer()
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "description": "Get weather",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"city": {"type": "string"}},
+                        "required": ["city"],
+                    },
+                },
+            }
+        ]
+        messages = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "What's the weather in Beijing?"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "arguments": json.dumps({"city": "Beijing"}, ensure_ascii=False),
+                        },
+                    }
+                ],
+            },
+            {"role": "tool", "content": '{"temperature": 25}', "tool_call_id": "call_1"},
+        ]
+
+        expected = sglang_dsv4_prompt_ids(tokenizer, messages, tools, thinking=thinking)
+        tito = get_tito_tokenizer(
+            tokenizer,
+            tokenizer_type=TITOTokenizerType.DEEPSEEKV4,
+            chat_template_kwargs={"enable_thinking": thinking},
+        )
+
+        actual = tito.render_messages(messages, add_generation_prompt=True, tools=tools, tokenize=True)
         assert actual == expected

--- a/tests/fast/utils/chat_template_utils/test_tito_tokenizer.py
+++ b/tests/fast/utils/chat_template_utils/test_tito_tokenizer.py
@@ -516,6 +516,7 @@ class TestParserBinding:
             (TITOTokenizerType.MINIMAX_M25, "minimax-append-think", "minimax-m2"),
             (TITOTokenizerType.MINIMAX_M27, "minimax-append-think", "minimax-m2"),
             (TITOTokenizerType.DEEPSEEKV32, "deepseek-v3", "deepseekv32"),
+            (TITOTokenizerType.DEEPSEEKV4, "deepseek-v4", "deepseekv4"),
             (TITOTokenizerType.DEFAULT, None, None),
         ],
     )
@@ -530,6 +531,7 @@ class TestParserBinding:
         assert resolve_reasoning_and_tool_call_parser(TITOTokenizerType.QWEN3) == ("qwen3", "qwen25")
         assert resolve_reasoning_and_tool_call_parser(TITOTokenizerType.QWEN35) == ("qwen3", "qwen3_coder")
         assert resolve_reasoning_and_tool_call_parser(TITOTokenizerType.GLM47) == ("glm45", "glm47")
+        assert resolve_reasoning_and_tool_call_parser(TITOTokenizerType.DEEPSEEKV4) == ("deepseek-v4", "deepseekv4")
         # DEFAULT family has no binding for either parser; both come back None.
         assert resolve_reasoning_and_tool_call_parser(TITOTokenizerType.DEFAULT) == (None, None)
 


### PR DESCRIPTION
## Summary

Adds TITO support for DeepSeek V4 (tested on Flash due to lack of gpu, but should also work for V4 pro).

Registers a new `deepseekv4` TITO family and wires it to SGLang’s DeepSeek V4 encoder path instead of the regular HF/Jinja chat template path.

**Note**: A temporary compatibility guard is included in `miles/utils/dumper_utils.py` because the current SGLang V4 support branch is not upstreamed and its dumper API is too old. We would remove it after https://github.com/radixark/miles/pull/1045 get merged.

## Test Plan
### 1. DeepSeek V4 TITO tokenizer verifier

Verifies that the registered `deepseekv4` TITO tokenizer can incrementally merge appended tool messages and decode back to the same text as a full prompt render.

```bash
python scripts/tools/verify_chat_template.py \
  --model deepseek-ai/DeepSeek-V4-Flash \
  --tito-model deepseekv4 \
  --tito-allowed-append-roles tool \
  --thinking both
```

### 2. Fast tokenizer regression suite
Verifies the shared chat-template / TITO tokenizer utilities, including DeepSeek V4 prompt-id alignment against SGLang’s DSv4 encoder path.
```
pytest tests/fast/utils/chat_template_utils
```

### 3. DeepSeek V4 session-server e2e
Runs the real Miles session-server TITO path with SGLang inference. This verifies that Miles-owned input_ids, DeepSeek V4 prompt encoding, tool-call parsing, rollback, and accumulated token mismatch checks work together.

```
python scripts/tools/verify_session_tito_tokenizer.py \
  --hf-checkpoint deepseek-ai/DeepSeek-V4-Flash \
  --tito-model deepseekv4 \
  --tito-allowed-append-roles tool \
  --reasoning-parser deepseek-v4 \
  --tool-call-parser deepseekv4 \
  --tp-size 4 \
  --num-gpus 4
```
