### PR TITLE
[feat] Add train_rollout_kl metric for outlier-robust train/rollout divergence

### DIFF
--- a/miles/backends/training_utils/loss.py
+++ b/miles/backends/training_utils/loss.py
@@ -751,9 +751,15 @@ def policy_loss_function(
         loss += 0 * logits.sum()
 
     train_rollout_logprob_abs_diff = None
+    train_rollout_kl = None
     if "rollout_log_probs" in batch and batch["rollout_log_probs"]:
         rollout_log_probs = torch.cat(batch["rollout_log_probs"], dim=0)
         train_rollout_logprob_abs_diff = sum_of_sample_mean((old_log_probs - rollout_log_probs).abs())
+        # KL(rollout || train) at sampled tokens via Schulman k3 with per-token clamp [-10, 10]
+        # — preferred over abs_diff because the clamp bounds outlier-token contribution.
+        train_rollout_kl = sum_of_sample_mean(
+            compute_approx_kl(rollout_log_probs, old_log_probs, kl_loss_type="low_var_kl")
+        )
 
     reported_loss = {
         "loss": loss.clone().detach(),
@@ -766,6 +772,8 @@ def policy_loss_function(
 
     if train_rollout_logprob_abs_diff is not None:
         reported_loss["train_rollout_logprob_abs_diff"] = train_rollout_logprob_abs_diff.clone().detach()
+    if train_rollout_kl is not None:
+        reported_loss["train_rollout_kl"] = train_rollout_kl.clone().detach()
 
     if args.use_kl_loss:
         reported_loss["kl_loss"] = kl_loss.clone().detach()

--- a/miles/backends/training_utils/loss.py
+++ b/miles/backends/training_utils/loss.py
@@ -756,7 +756,6 @@ def policy_loss_function(
         rollout_log_probs = torch.cat(batch["rollout_log_probs"], dim=0)
         train_rollout_logprob_abs_diff = sum_of_sample_mean((old_log_probs - rollout_log_probs).abs())
         # KL(rollout || train) at sampled tokens via Schulman k3 with per-token clamp [-10, 10]
-        # — preferred over abs_diff because the clamp bounds outlier-token contribution.
         train_rollout_kl = sum_of_sample_mean(
             compute_approx_kl(rollout_log_probs, old_log_probs, kl_loss_type="low_var_kl")
         )


### PR DESCRIPTION
## Summary
Adds `train_rollout_kl` to `reported_loss` in `policy_loss_function` —
a more outlier-robust complement to the existing
`train_rollout_logprob_abs_diff` metric.

## Why
`train_rollout_logprob_abs_diff` = `mean(|log p_train(a) - log p_rollout(a)|)`
over sampled tokens. A small fraction of tokens with very low rollout
probability can produce huge per-token `|Δlog p|`, dominating the
average and obscuring whether the two distributions actually disagree
in aggregate.

## What
Compute KL(rollout || train) at sampled tokens using the Schulman k3
estimator with per-token clamp to [-10, 10] (`kl_loss_type="low_var_kl"`,
already in `compute_approx_kl`). The clamp bounds any single token's
contribution, so the reported scalar reflects overall distributional
divergence instead of being driven by a handful of tail tokens.

`abs_diff` is kept for backward compatibility (existing dashboards).

## Behavioral check (CPU, synthetic)
| Scenario | abs_diff | train_rollout_kl |
|---|---|---|
| identical (Δ=0) | 0.000 | 0.000 |
| uniform Δ=0.5 | 0.500 | 0.107 (≈ Δ²/2) |
| 5/1000 outlier tokens, \|Δ\|=50 | **0.250** | **0.050** (5 × clamp@10 / 1000) |

The outlier case directly demonstrates the fix: `abs_diff` is dragged
to 0.25 by the 5 tail tokens; the new metric stays at 0.05 because the
per-token clamp absorbs them.

## Test plan
- [ ] CI passes on existing tests (no API/behavior change to existing metric)
- [ ] Inspect `train_rollout_kl` in wandb on next training run; expect
      same trend shape as `abs_diff` but bounded magnitude