### PR TITLE
fix(test): pass real ckpt_step to load in test_qwen3_4B_ckpt

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-aaa
-
 <div align="center">
 
 <img src="https://raw.githubusercontent.com/radixark/miles/main/imgs/miles_logo.png" alt="Miles Logo" width="550">

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+aaa
+
 <div align="center">
 
 <img src="https://raw.githubusercontent.com/radixark/miles/main/imgs/miles_logo.png" alt="Miles Logo" width="550">

--- a/tests/e2e/ckpt/test_qwen3_4B_ckpt.py
+++ b/tests/e2e/ckpt/test_qwen3_4B_ckpt.py
@@ -14,6 +14,15 @@ MODEL_TYPE = "qwen3-4B"
 NUM_GPUS = 8
 
 
+def _get_latest_checkpointed_iteration() -> int:
+    latest_path = f"/root/models/{MODEL_NAME}_miles/latest_checkpointed_iteration.txt"
+    with open(latest_path, encoding="utf-8") as f:
+        latest_text = f.read().strip()
+    if not latest_text.isdigit():
+        raise ValueError(f"Invalid latest checkpoint value: {latest_text}")
+    return int(latest_text)
+
+
 def prepare():
     U.exec_command("mkdir -p /root/models /root/datasets")
     U.exec_command(f"hf download Qwen/{MODEL_NAME} --local-dir /root/models/{MODEL_NAME}")
@@ -134,6 +143,6 @@ if __name__ == "__main__":
     for proxy_var in ("http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY"):
         os.environ.pop(proxy_var, None)
     execute("save")
-    execute("load")
+    execute("load", ckpt_step=_get_latest_checkpointed_iteration())
     execute("async_save")
-    execute("load")
+    execute("load", ckpt_step=_get_latest_checkpointed_iteration())


### PR DESCRIPTION
## Summary

`tests/e2e/ckpt/test_qwen3_4B_ckpt.py` was failing CI with:

```
train.py: error: argument --ckpt-step: invalid int value: 'None'
```

`execute("load")` was being called without `ckpt_step`, so the helper formatted `--ckpt-step None` into the command line and Megatron's argparse (`type=int`) rejected it.

## Root cause

PR #677 ("refactor: miles CI") removed `_get_latest_checkpointed_iteration()` and the `latest_step = ...` plumbing while leaving the `load` mode still requiring an `int --ckpt-step`. The diff:

```python
# before
execute("save" if not args.async_save else "async_save")
latest_step = _get_latest_checkpointed_iteration()
execute("load", ckpt_step=latest_step)

# after #677 (broken)
execute("save")
execute("load")        # ckpt_step defaults to None → "--ckpt-step None"
execute("async_save")
execute("load")        # same
```

## Why this regression sat on main for ~13 days unnoticed

`stage-c-ckpt` / `stage-c-all` in `.github/workflows/pr-test.yml` are **label-gated**:

```yaml
stage-c-ckpt:
  if: ... contains(labels, 'run-ci-ckpt')
stage-c-all:
  if: ... contains(labels, 'run-ci-image')
```

- PR #677 (the one that introduced the bug) was labeled `run-ci-short, run-ci-megatron, run-ci-precision, run-ci-sglang, run-ci-lora` — neither `run-ci-ckpt` nor `run-ci-image`. So the ckpt test never executed in that PR's CI.
- For the next 13 days no merged PR carried either label, so the broken test on main was silently never run.
- PR #874's "forgot to rerun full ci" note is a red herring: the bug was already on main from #677. #874 just happened to be the next PR that surfaced it (and this PR #1073, which also carries `run-ci-image`, surfaces it again).

## Fix

- Restore `_get_latest_checkpointed_iteration()` in `tests/e2e/ckpt/test_qwen3_4B_ckpt.py`.
- Pass the real step to both `execute("load", ...)` calls (after `save` and after `async_save`).

This matches the pattern in the sibling `tests/e2e/ckpt/test_glm47_flash_ckpt.py`, which uses the same helper and is passing in this CI run.

## Test plan

- [ ] \`stage-c-all (stage-c-ckpt-8-gpu) / run\` passes in CI on this PR