### PR TITLE
fix: skip linux-only deps on macOS in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,9 +12,9 @@ pytest-asyncio
 pyyaml
 qwen_vl_utils # for VLM
 ray[default]
-ring_flash_attn
+ring_flash_attn; platform_system == "Linux"
 sglang-router>=0.2.3
 tensorboard
-torchft-nightly==2026.4.3
+torchft-nightly==2026.4.3; platform_system == "Linux"
 transformers
 wandb


### PR DESCRIPTION
want to install miles locally (macos) for ide (not for running)