### PR TITLE
refactor: mark create_cpu_replica as private

### DIFF
--- a/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/p2p.py
+++ b/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/p2p.py
@@ -224,7 +224,7 @@ class UpdateWeightP2P(DistBucketedWeightUpdateMixin):
                 )
                 server_args = self.session_id_to_server_args[session_id]
 
-                model_replica = self.create_cpu_replica(
+                model_replica = self._create_cpu_replica(
                     parallelism_config,
                     self.args.hf_checkpoint,
                     server_args,
@@ -247,7 +247,7 @@ class UpdateWeightP2P(DistBucketedWeightUpdateMixin):
 
                 self._transfer_engine_meta_list.append((model_replica, remote_infos))
 
-    def create_cpu_replica(
+    def _create_cpu_replica(
         self,
         parallelism_config: RankParallelismConfig,
         model_path: str,


### PR DESCRIPTION
## Summary
- `UpdateWeightP2P.create_cpu_replica` is only called internally via `self.create_cpu_replica(...)` in `connect_rollout_engines` (same class, same file). No external callers.
- Rename to `_create_cpu_replica` to follow the project convention of prefixing private members with `_`.

## Test plan
- [ ] No external imports/usages broken (verified via grep — only one call site, in the same class).