### PR TITLE
ci: trigger PR Test on any base branch, not just main

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -2,7 +2,6 @@ name: PR Test
 
 on:
   pull_request:
-    branches: [main]
     types: [synchronize, labeled]
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
## Summary

Drop \`branches: [main]\` from the \`pull_request\` trigger in \`.github/workflows/pr-test.yml\`. Cost-control is already enforced per-job via \`run-ci-*\` labels — the base filter is a redundant second layer that ends up causing real outages.

## Why

Concrete failure that motivated this:

- A stack-diff branch \`rollout_ft/32\` had two PRs sharing it: #1072 (base \`main\`, no label) and #1071 (base \`rollout_ft/31\`, label \`run-ci-image\`).
- \`branches: [main]\` matches via #1072, so the run is attributed to #1072.
- \`stage-c-all\`'s \`if:\` evaluates \`github.event.pull_request.labels\` from #1072 (empty) → skipped, even though #1071 has the label.
- Closing #1072 made it worse: with no PR matching \`branches: [main]\`, the workflow doesn't trigger at all — even the always-on \`stage-a-fast\` / \`pre-commit\` jobs disappear from #1071.

In short: \`branches: [main]\` causes the workflow to silently not trigger on internal-base PRs, while contributing no real cost control beyond what the per-job \`run-ci-*\` label gates already provide.

## After this change

- Any PR (regardless of base) gets \`stage-a-fast\` / \`pre-commit\` / \`CodeQL\` like before.
- Expensive 8-GPU suites are still gated by \`run-ci-*\` labels, unchanged.
- Stack-diff workflows just work.

### Known residual issue (out of scope)

When a head branch has multiple open PRs, GitHub picks one of them as \`github.event.pull_request\` and the per-job label gate evaluates against that PR's labels — not necessarily the one the user expects. This is a GitHub-platform behavior and not solvable in workflow YAML alone.

## Test plan

- [ ] Push a commit to a branch with a PR whose base is \`main\` → workflow triggers, label-gated suites still gated.
- [ ] Push a commit to a branch with a PR whose base is some internal branch → workflow triggers (it does not on main today).