### PR TITLE
ci: use est_time as per-file timeout, fix long test budget

### DIFF
--- a/tests/ci/ci_utils.py
+++ b/tests/ci/ci_utils.py
@@ -159,6 +159,8 @@ def run_unittest_files(
         else:
             filename, estimated_time = file.name, file.estimated_time
 
+        effective_timeout = max(timeout_per_file, int(estimated_time * 1.25))
+
         process = None
         output_lines = []
 
@@ -213,7 +215,7 @@ def run_unittest_files(
                     run_one_file,
                     args=(filename,),
                     kwargs={"capture_output": enable_retry},
-                    timeout=timeout_per_file,
+                    timeout=effective_timeout,
                 )
 
                 if ret_code == 0:
@@ -248,10 +250,10 @@ def run_unittest_files(
             except TimeoutError:
                 _kill_process_tree(process.pid)
                 time.sleep(5)
-                logger.info(f"\nTIMEOUT: {filename} after {timeout_per_file} seconds\n")
+                logger.info(f"\nTIMEOUT: {filename} after {effective_timeout} seconds\n")
                 if was_retried:
                     retried_tests.append((filename, attempt, "timeout"))
-                failed_tests.append((filename, f"timeout after {timeout_per_file}s"))
+                failed_tests.append((filename, f"timeout after {effective_timeout}s"))
                 break
 
         if not file_passed:

--- a/tests/e2e/long/test_qwen2.5_0.5B_gsm8k.py
+++ b/tests/e2e/long/test_qwen2.5_0.5B_gsm8k.py
@@ -4,6 +4,7 @@ from tests.ci.ci_register import register_cuda_ci
 
 import miles.utils.external_utils.command_utils as U
 
+# est_time calibrated against historical CI runtime: ~5071–5923s on 8×H100.
 register_cuda_ci(est_time=6000, suite="stage-c-long-8-gpu", num_gpus=8)
 
 FEW_GPU = U.get_bool_env_var("MILES_TEST_FEW_GPU", "1")

--- a/tests/e2e/long/test_qwen2.5_0.5B_gsm8k.py
+++ b/tests/e2e/long/test_qwen2.5_0.5B_gsm8k.py
@@ -4,7 +4,7 @@ from tests.ci.ci_register import register_cuda_ci
 
 import miles.utils.external_utils.command_utils as U
 
-register_cuda_ci(est_time=1800, suite="stage-c-long-8-gpu", num_gpus=8)
+register_cuda_ci(est_time=6000, suite="stage-c-long-8-gpu", num_gpus=8)
 
 FEW_GPU = U.get_bool_env_var("MILES_TEST_FEW_GPU", "1")
 TIGHT_DEVICE_MEMORY = U.get_bool_env_var("MILES_TEST_TIGHT_DEVICE_MEMORY", "1")

--- a/tests/e2e/long/test_qwen2.5_0.5B_gsm8k_async.py
+++ b/tests/e2e/long/test_qwen2.5_0.5B_gsm8k_async.py
@@ -4,6 +4,7 @@ from tests.ci.ci_register import register_cuda_ci
 
 import miles.utils.external_utils.command_utils as U
 
+# est_time calibrated against historical CI runtime: ~4124–4182s on 8×H100.
 register_cuda_ci(est_time=5000, suite="stage-c-long-8-gpu", num_gpus=8)
 
 FEW_GPU = U.get_bool_env_var("MILES_TEST_FEW_GPU", "1")

--- a/tests/e2e/long/test_qwen2.5_0.5B_gsm8k_async.py
+++ b/tests/e2e/long/test_qwen2.5_0.5B_gsm8k_async.py
@@ -4,7 +4,7 @@ from tests.ci.ci_register import register_cuda_ci
 
 import miles.utils.external_utils.command_utils as U
 
-register_cuda_ci(est_time=1800, suite="stage-c-long-8-gpu", num_gpus=8)
+register_cuda_ci(est_time=5000, suite="stage-c-long-8-gpu", num_gpus=8)
 
 FEW_GPU = U.get_bool_env_var("MILES_TEST_FEW_GPU", "1")
 TIGHT_DEVICE_MEMORY = U.get_bool_env_var("MILES_TEST_TIGHT_DEVICE_MEMORY", "1")


### PR DESCRIPTION
## TL;DR

`stage-c-all (stage-c-long-8-gpu) / run` has been **timing out at exactly 1800s on every CI run since #677** — not once successful. Root cause is not a recent regression: the suite's two tests declare `est_time=1800` while historically taking ~5000–6000s to finish. The runner's `--timeout-per-file` defaulted to 1800 and ignored each test's declared budget, so the wall was hit every single time.

This PR raises the declared `est_time` to match historical reality and makes the runner derive a per-file timeout from each file's `est_time`, so future budget increases automatically take effect.

## Evidence

### The 1800s wall has been hit on every recent run

In the most recent 200 PR Test workflow runs, `stage-c-all (stage-c-long-8-gpu) / run` ran 4 times. **Zero successes.** Two timed out at exactly the 1800s wall:

| run | created | conclusion | duration |
|-----|---------|------------|----------|
| 25379329211 | 2026-05-05 | failure | **1842s** (timeout) |
| 25379775532 | 2026-05-05 | cancelled | 316s |
| 25382167515 (PR #1073, 1st run) | 2026-05-05 | failure | **1841s** (timeout) |
| 25382167515 (PR #1073, retry) | 2026-05-05 | failure | **1841s** (timeout) |
| 25383663782 | 2026-05-05 | failure | 276s (different mode) |

Tail of the timeout log:
```
filename='tests/e2e/long/test_qwen2.5_0.5B_gsm8k.py', elapsed=1800, _estimated_time=1800.0
TIMEOUT: tests/e2e/long/test_qwen2.5_0.5B_gsm8k.py after 1800 seconds
Fail. Time elapsed: 1805.17s
```

The last business log line is consistently within ~2s of the 1800s mark, so the test is actually progressing — it just runs out of budget. This is not a hang.

### Historical durations: ~5000-6000s

Pre-#677 the same test was invoked under a different workflow shape (`e2e-test-long`) without `--timeout-per-file`. It actually passed there, but slowly:

| run | created | result | duration |
|-----|---------|--------|----------|
| 21242432814 (PR #492) | 2026-01-22 | success | **5923s ≈ 99 min** |
| 18436126864 (PR #22)  | 2025-10-11 | success | **5071s ≈ 84 min** |
| 18427949075 (PR #22)  | 2025-10-11 | success | 5672s ≈ 95 min |
| 18427963182 (PR #22)  | 2025-10-11 | failure | 4929s (failed mid-run) |

The async sibling (`test_qwen2.5_0.5B_gsm8k_async.py`) historically took 4124–4182s.

So `est_time=1800` was off by roughly 3×.

### Why it sat broken on main for 13 days

`#677 refactor: miles CI` (2026-04-22) introduced the `register_cuda_ci(est_time=1800, ...)` declaration along with a label-gated `stage-c-*` workflow structure. The `stage-c-long` job is gated by the `run-ci-long` label and `stage-c-all` (which contains the matrix entry that surfaced this) is gated by `run-ci-image`. Most PRs after #677 carried neither label, so this suite skipped silently — which is the same gate that hid the `--ckpt-step None` bug fixed in #1073.

## Mechanism

`tests/ci/run_suite.py:193`:

```python
parser.add_argument(
    "--timeout-per-file",
    type=int,
    default=1800,
    help="The time limit for running one file in seconds (default: 1800).",
)
```

`tests/ci/ci_utils.py:run_unittest_files` previously applied this single `timeout_per_file` value to every file in the suite, regardless of the file's declared `est_time`. So even though the long test declared `est_time=1800` (well, accurately or not — it was ambiguous whether it was an estimate or a budget), the runner only saw the global `1800`.

## Fix

### 1. Realign `est_time` with measured reality

| file | old | new | basis |
|------|-----|-----|-------|
| `tests/e2e/long/test_qwen2.5_0.5B_gsm8k.py` | 1800 | **6000** | history: 5071–5923s |
| `tests/e2e/long/test_qwen2.5_0.5B_gsm8k_async.py` | 1800 | **5000** | history: 4124–4182s |

### 2. Make the runner use est_time as the timeout source

`run_unittest_files` now computes a per-file `effective_timeout`:

```python
effective_timeout = max(timeout_per_file, int(estimated_time * 1.25))
```

- `--timeout-per-file` becomes a **floor** (default 1800), keeping existing fast tests unchanged.
- A test with declared `est_time=N` gets at least `int(N * 1.25)` seconds — so any future bump to `est_time` automatically loosens the timeout. No more hidden coupling between a declared estimate and a hard-coded global cap.
- The TIMEOUT log line and the failed-test summary now report the actual `effective_timeout` used, not the global default.

After this PR, with `est_time=6000`, the long test gets a 7500s budget — comfortably above the historical 5923s max.

## Test plan

- [ ] Add `run-ci-image` (or `run-ci-long`) label to this PR and confirm `stage-c-all (stage-c-long-8-gpu) / run` finishes without hitting the timeout.
- [ ] Confirm fast suites (e.g., `stage-a-fast`) still use the 1800s floor — they declare small `est_time` so `max(1800, est × 1.25)` stays at 1800.

## Out of scope

- The label-gating problem (label-gated stage-c-* jobs hide regressions on main) — see PR #1076.
- The ckpt test's `--ckpt-step None` argparse regression introduced by the same #677 — fixed in #1073.