### PR TITLE
[lora] avoid merge adapter weights for base weight sync

### DIFF
--- a/miles/backends/megatron_utils/update_weight/hf_weight_iterator_bridge.py
+++ b/miles/backends/megatron_utils/update_weight/hf_weight_iterator_bridge.py
@@ -34,6 +34,7 @@ class HfWeightIteratorBridge(HfWeightIteratorBase):
                     self.model,
                     cpu=False,
                     conversion_tasks=conversion_tasks,
+                    merge_adapter_weights=False,
                 )
 
             # TODO: verify if postprocess_hf_param is needed for LoRA weights


### PR DESCRIPTION
noticed the base weight sync issue when lora is enabled, base weight will be exported with merged lora weights, causing correctness issue