### PR TITLE
[feat] Add SP and PP support for qwen_moe true on policy

### DIFF
--- a/miles/backends/megatron_utils/actor.py
+++ b/miles/backends/megatron_utils/actor.py
@@ -344,6 +344,16 @@ class MegatronTrainRayActor(TrainRayActor):
         else:
             return self.train_actor(rollout_id, rollout_data)
 
+    def _sync_before_rank_subset_logging(self) -> None:
+        if not getattr(self.args, "true_on_policy_mode", False):
+            return
+        if (
+            self.args.tensor_model_parallel_size <= 1
+            and self.args.pipeline_model_parallel_size <= 1
+        ):
+            return
+        dist.barrier(group=get_gloo_group())
+
     def train_critic(self, rollout_id: int, rollout_data: RolloutBatch) -> None:
         # Create data iterator for log_probs and train.
         data_iterator, num_microbatches = get_data_iterator(self.args, self.model, rollout_data)
@@ -438,7 +448,9 @@ class MegatronTrainRayActor(TrainRayActor):
             if self.rollout_data_postprocess is not None:
                 self.rollout_data_postprocess(self.args)
 
+            self._sync_before_rank_subset_logging()
             log_rollout_data(rollout_id, self.args, rollout_data)
+            self._sync_before_rank_subset_logging()
 
             # Train
             self._set_replay_stage("replay_backward")

--- a/miles/backends/sglang_utils/arguments.py
+++ b/miles/backends/sglang_utils/arguments.py
@@ -137,11 +137,34 @@ def validate_args(args):
     args.sglang_dp_size = args.sglang_data_parallel_size
     args.sglang_pp_size = args.sglang_pipeline_parallel_size
     args.sglang_ep_size = args.sglang_expert_parallel_size
+    if hasattr(args, "sglang_moe_data_parallel_size"):
+        args.sglang_moe_dp_size = args.sglang_moe_data_parallel_size
     if hasattr(args, "sglang_attention_context_parallel_size"):
         args.sglang_attn_cp_size = args.sglang_attention_context_parallel_size
 
     if args.true_on_policy_mode:
         args.sglang_enable_deterministic_inference = True
+        if getattr(args, "num_experts", None) and args.num_experts > 1:
+            if args.sglang_ep_size < 1:
+                raise ValueError("SGLang rollout EP must be at least 1 for MoE true-on-policy.")
+            moe_dp_size = getattr(args, "sglang_moe_dp_size", 1) or 1
+            moe_parallel_size = args.sglang_ep_size * moe_dp_size
+            if args.rollout_num_gpus_per_engine % moe_parallel_size != 0:
+                raise ValueError(
+                    "Qwen3 MoE true-on-policy requires rollout_num_gpus_per_engine to be "
+                    "divisible by sglang_ep_size * sglang_moe_dp_size "
+                    f"({args.rollout_num_gpus_per_engine} % {moe_parallel_size} != 0)."
+                )
+            sglang_moe_tp_size = args.rollout_num_gpus_per_engine // moe_parallel_size
+            train_expert_tp_size = getattr(args, "expert_tensor_parallel_size", 1) or 1
+            if sglang_moe_tp_size != train_expert_tp_size:
+                raise ValueError(
+                    "Qwen3 MoE true-on-policy requires SGLang MoE TP to match Megatron "
+                    "expert tensor parallelism: "
+                    "rollout_num_gpus_per_engine / (sglang_ep_size * sglang_moe_dp_size) "
+                    f"= {sglang_moe_tp_size}, but expert_tensor_parallel_size "
+                    f"= {train_expert_tp_size}."
+                )
 
     if getattr(args, "recompute_logprobs_via_prefill", False):
         args.sglang_enable_prefill_only_deterministic_inference = True

--- a/miles/backends/sglang_utils/arguments.py
+++ b/miles/backends/sglang_utils/arguments.py
@@ -137,34 +137,11 @@ def validate_args(args):
     args.sglang_dp_size = args.sglang_data_parallel_size
     args.sglang_pp_size = args.sglang_pipeline_parallel_size
     args.sglang_ep_size = args.sglang_expert_parallel_size
-    if hasattr(args, "sglang_moe_data_parallel_size"):
-        args.sglang_moe_dp_size = args.sglang_moe_data_parallel_size
     if hasattr(args, "sglang_attention_context_parallel_size"):
         args.sglang_attn_cp_size = args.sglang_attention_context_parallel_size
 
     if args.true_on_policy_mode:
         args.sglang_enable_deterministic_inference = True
-        if getattr(args, "num_experts", None) and args.num_experts > 1:
-            if args.sglang_ep_size < 1:
-                raise ValueError("SGLang rollout EP must be at least 1 for MoE true-on-policy.")
-            moe_dp_size = getattr(args, "sglang_moe_dp_size", 1) or 1
-            moe_parallel_size = args.sglang_ep_size * moe_dp_size
-            if args.rollout_num_gpus_per_engine % moe_parallel_size != 0:
-                raise ValueError(
-                    "Qwen3 MoE true-on-policy requires rollout_num_gpus_per_engine to be "
-                    "divisible by sglang_ep_size * sglang_moe_dp_size "
-                    f"({args.rollout_num_gpus_per_engine} % {moe_parallel_size} != 0)."
-                )
-            sglang_moe_tp_size = args.rollout_num_gpus_per_engine // moe_parallel_size
-            train_expert_tp_size = getattr(args, "expert_tensor_parallel_size", 1) or 1
-            if sglang_moe_tp_size != train_expert_tp_size:
-                raise ValueError(
-                    "Qwen3 MoE true-on-policy requires SGLang MoE TP to match Megatron "
-                    "expert tensor parallelism: "
-                    "rollout_num_gpus_per_engine / (sglang_ep_size * sglang_moe_dp_size) "
-                    f"= {sglang_moe_tp_size}, but expert_tensor_parallel_size "
-                    f"= {train_expert_tp_size}."
-                )
 
     if getattr(args, "recompute_logprobs_via_prefill", False):
         args.sglang_enable_prefill_only_deterministic_inference = True

--- a/miles/true_on_policy/config.py
+++ b/miles/true_on_policy/config.py
@@ -288,6 +288,13 @@ class TrueOnPolicyConfig:
                 f"({self.rollout_num_gpus_per_engine} % {self.rollout_expert_parallel_size} != 0)."
             )
 
+        # TODO(true-on-policy): factor in sglang_moe_data_parallel_size when that
+        # flag is wired through the qwen3_moe true-on-policy launch path. The
+        # SGLang MoE TP is rollout_num_gpus_per_engine / (sglang_ep * sglang_moe_dp);
+        # today no script sets sglang_moe_data_parallel_size > 1, so dividing by
+        # rollout_expert_parallel_size alone is correct, but enabling MoE DP later
+        # will need this validation to multiply rollout_expert_parallel_size by
+        # sglang_moe_data_parallel_size before computing rollout_moe_tp_size.
         rollout_moe_tp_size = self.rollout_num_gpus_per_engine // self.rollout_expert_parallel_size
         if rollout_moe_tp_size != self.expert_tensor_parallel_size:
             raise ValueError(

--- a/miles/true_on_policy/config.py
+++ b/miles/true_on_policy/config.py
@@ -33,6 +33,7 @@ class TrueOnPolicyParallelLayout:
     """Training and rollout topology relevant to true-on-policy parity."""
 
     train_tensor_parallel_size: int
+    train_sequence_parallel: bool
     train_context_parallel_size: int
     train_pipeline_parallel_size: int
     train_expert_model_parallel_size: int
@@ -43,6 +44,10 @@ class TrueOnPolicyParallelLayout:
     @property
     def uses_train_tp(self) -> bool:
         return self.train_tensor_parallel_size > 1
+
+    @property
+    def uses_train_sp(self) -> bool:
+        return self.train_sequence_parallel and self.uses_train_tp
 
     @property
     def uses_ulysses_cp(self) -> bool:
@@ -192,6 +197,7 @@ class TrueOnPolicyConfig:
     model_profile: TrueOnPolicyModelProfile
     train_backend: TrainBackend
     tensor_model_parallel_size: int
+    sequence_parallel: bool
     context_parallel_size: int
     pipeline_model_parallel_size: int
     rollout_num_gpus_per_engine: int
@@ -205,6 +211,7 @@ class TrueOnPolicyConfig:
     def parallel_layout(self) -> TrueOnPolicyParallelLayout:
         return TrueOnPolicyParallelLayout(
             train_tensor_parallel_size=self.tensor_model_parallel_size,
+            train_sequence_parallel=self.sequence_parallel,
             train_context_parallel_size=self.context_parallel_size,
             train_pipeline_parallel_size=self.pipeline_model_parallel_size,
             train_expert_model_parallel_size=self.expert_model_parallel_size,
@@ -245,6 +252,8 @@ class TrueOnPolicyConfig:
             raise ValueError(f"{self.model_profile.family} does not support Ulysses CP true-on-policy")
         if layout.uses_train_pp and "pp" not in self.model_profile.supported_train_layouts:
             raise ValueError(f"{self.model_profile.family} does not support PP true-on-policy")
+        if layout.uses_train_sp and "sp" not in self.model_profile.supported_train_layouts:
+            raise ValueError(f"{self.model_profile.family} does not support SP true-on-policy")
         if layout.uses_train_ep and "ep" not in self.model_profile.supported_train_layouts:
             raise ValueError(f"{self.model_profile.family} does not support EP true-on-policy")
         if layout.uses_train_expert_tp and "expert_tp" not in self.model_profile.supported_train_layouts:
@@ -253,15 +262,41 @@ class TrueOnPolicyConfig:
             raise ValueError(f"{self.model_profile.family} does not support rollout EP true-on-policy")
         if self.sglang_target == "fsdp_tp" and not self.model_profile.supports_tp_invariant:
             raise ValueError(f"{self.model_profile.family} does not support TP-invariant true-on-policy")
-        if self.train_backend == "megatron" and layout.uses_train_tp and layout.uses_train_ep:
-            # TODO: Enable this once true-on-policy supports Megatron sequence parallel
-            # for MoE + tensor-parallel training.
+        self._validate_megatron_moe_rollout_topology()
+        if (
+            self.train_backend == "megatron"
+            and layout.uses_train_tp
+            and layout.uses_train_ep
+            and not layout.uses_train_sp
+        ):
             raise ValueError(
-                "Megatron MoE true-on-policy does not support train TP with EP yet. "
-                "Megatron requires sequence parallel for MoE + tensor-parallel training, "
-                "and the current true-on-policy path intentionally disables sequence parallel."
+                "Megatron MoE true-on-policy requires sequence parallel when train TP and EP "
+                "are both enabled."
             )
         self._validate_megatron_train_topology()
+
+    def _validate_megatron_moe_rollout_topology(self) -> None:
+        if self.train_backend != "megatron" or self.model_profile.family != "qwen3_moe":
+            return
+
+        if self.rollout_expert_parallel_size < 1:
+            raise ValueError("SGLang rollout EP must be at least 1 for MoE true-on-policy.")
+        if self.rollout_num_gpus_per_engine % self.rollout_expert_parallel_size != 0:
+            raise ValueError(
+                "Qwen3 MoE true-on-policy requires rollout_num_gpus_per_engine to be "
+                "divisible by sglang_expert_parallel_size "
+                f"({self.rollout_num_gpus_per_engine} % {self.rollout_expert_parallel_size} != 0)."
+            )
+
+        rollout_moe_tp_size = self.rollout_num_gpus_per_engine // self.rollout_expert_parallel_size
+        if rollout_moe_tp_size != self.expert_tensor_parallel_size:
+            raise ValueError(
+                "Qwen3 MoE true-on-policy requires SGLang MoE TP to match Megatron "
+                "expert tensor parallelism: "
+                "rollout_num_gpus_per_engine / sglang_expert_parallel_size "
+                f"= {rollout_moe_tp_size}, but expert_tensor_parallel_size "
+                f"= {self.expert_tensor_parallel_size}."
+            )
 
     def _validate_megatron_train_topology(self) -> None:
         if self.train_backend != "megatron" or self.train_world_size is None:
@@ -370,6 +405,7 @@ def build_true_on_policy_config(args: Any) -> TrueOnPolicyConfig | None:
         model_profile=profile,
         train_backend=args.train_backend,
         tensor_model_parallel_size=_get_required_int(args, "tensor_model_parallel_size"),
+        sequence_parallel=bool(getattr(args, "use_sequence_parallel", False)),
         context_parallel_size=_get_required_int(args, "context_parallel_size"),
         pipeline_model_parallel_size=_get_required_int(args, "pipeline_model_parallel_size"),
         expert_model_parallel_size=_get_optional_int(args, "expert_model_parallel_size", 1),

--- a/miles/true_on_policy/model_profiles.py
+++ b/miles/true_on_policy/model_profiles.py
@@ -83,7 +83,7 @@ QWEN3_DENSE_PROFILE = TrueOnPolicyModelProfile(
         "Qwen3-4B-Base": "qwen3-4B",
         "Qwen3-4B-Instruct-2507": "qwen3-4B-Instruct-2507",
     },
-    supported_train_layouts=("dp", "tp", "pp", "ulysses_cp"),
+    supported_train_layouts=("dp", "tp", "sp", "pp", "ulysses_cp"),
     supported_rollout_layouts=("dp", "tp"),
     contract=QWEN3_DENSE_TRUE_ON_POLICY_V1,
 )
@@ -92,7 +92,7 @@ QWEN3_MOE_PROFILE = TrueOnPolicyModelProfile(
     family="qwen3_moe",
     model_names=("Qwen3-30B-A3B",),
     megatron_model_types={"Qwen3-30B-A3B": "qwen3-30B-A3B"},
-    supported_train_layouts=("dp", "tp", "expert_tp", "ep", "pp", "ulysses_cp"),
+    supported_train_layouts=("dp", "tp", "sp", "expert_tp", "ep", "pp", "ulysses_cp"),
     supported_rollout_layouts=("dp", "tp", "ep"),
     contract=QWEN3_MOE_TRUE_ON_POLICY_V1,
 )

--- a/miles/true_on_policy/schema.py
+++ b/miles/true_on_policy/schema.py
@@ -32,7 +32,7 @@ QWEN3_DENSE_TRUE_ON_POLICY_V1_SCHEMA = TrueOnPolicyContractSchema(
     logprob_contract="sglang_prefill",
     sglang_attention_backend="fa3",
     fsdp_attention_implementation="flash_attention_3",
-    disable_megatron_sequence_parallel=True,
+    disable_megatron_sequence_parallel=False,
 )
 
 QWEN3_MOE_TRUE_ON_POLICY_V1_SCHEMA = TrueOnPolicyContractSchema(
@@ -42,5 +42,5 @@ QWEN3_MOE_TRUE_ON_POLICY_V1_SCHEMA = TrueOnPolicyContractSchema(
     logprob_contract="sglang_prefill",
     sglang_attention_backend="fa3",
     fsdp_attention_implementation="flash_attention_3",
-    disable_megatron_sequence_parallel=True,
+    disable_megatron_sequence_parallel=False,
 )

--- a/miles/utils/external_utils/command_utils.py
+++ b/miles/utils/external_utils/command_utils.py
@@ -54,13 +54,14 @@ def convert_checkpoint(
     num_nodes: int | None = None,
     extra_args: str = "",
     dir_dst: str = "/root",
+    path_dst: str | None = None,
     hf_checkpoint: str | None = None,
     megatron_path: str = "/root/Megatron-LM",
 ):
     hf_checkpoint = hf_checkpoint or f"/root/models/{model_name}"
 
     # TODO shall we make it in host-mapped folder and thus can cache it to speedup CI
-    path_dst = f"{dir_dst}/{model_name}_torch_dist"
+    path_dst = path_dst or f"{dir_dst}/{model_name}_torch_dist"
     tracker = Path(path_dst) / "latest_checkpointed_iteration.txt"
     if tracker.exists() and tracker.read_text().strip() == "release":
         print(f"convert_checkpoint skip {path_dst} since tracker is 'release'")
@@ -78,6 +79,7 @@ def convert_checkpoint(
         fn = exec_command
     fn(
         f"source {repo_base_dir}/scripts/models/{megatron_model_type}.sh && "
+        f"export CUDA_DEVICE_MAX_CONNECTIONS=1 && "
         f"PYTHONPATH={megatron_path} "
         f"torchrun "
         f"--nproc-per-node {num_gpus_per_node} "

--- a/miles/utils/reloadable_process_group.py
+++ b/miles/utils/reloadable_process_group.py
@@ -70,6 +70,7 @@ def monkey_patch_torch_dist():
     dist.all_to_all = get_new_function(dist.all_to_all)
     dist.all_to_all_single = get_new_function(dist.all_to_all_single)
     dist.broadcast = get_new_function(dist.broadcast)
+    dist.broadcast_object_list = get_new_function(dist.broadcast_object_list)
     dist.reduce = get_new_function(dist.reduce)
     dist.reduce_scatter = get_new_function(dist.reduce_scatter)
     dist.reduce_scatter_tensor = get_new_function(dist.reduce_scatter_tensor)

--- a/scripts/run_qwen3_30b_a3b.py
+++ b/scripts/run_qwen3_30b_a3b.py
@@ -8,7 +8,7 @@ import miles.utils.external_utils.command_utils as U
 
 @dataclass
 class ScriptArgs(U.ExecuteTrainConfig):
-    mode: Literal["normal", "debug_minimal", "debug_one_sample"] = "normal"
+    mode: Literal["normal", "debug_minimal"] = "normal"
     run_id: str = U.create_run_id()
     model_name: str = "Qwen3-30B-A3B"
     megatron_model_type: str = "qwen3-30B-A3B"
@@ -81,7 +81,13 @@ class ScriptArgs(U.ExecuteTrainConfig):
             assert self.rollout_mxfp8, "train_mxfp8 requires rollout_mxfp8 to be enabled"
 
 
-def prepare(args: ScriptArgs):
+def prepare(args: ScriptArgs, *, convert_checkpoint_kwargs: dict | None = None):
+    """Download HF assets and (optionally) convert to torch-dist.
+
+    `convert_checkpoint_kwargs` lets callers (e.g. the deterministic variant)
+    override or extend the convert_checkpoint call without baking
+    true-on-policy concerns into this base script.
+    """
     U.exec_command(f"mkdir -p {args.model_dir} {args.data_dir}")
     U.exec_command(f"hf download Qwen/{args.model_name} --local-dir {args.model_dir}/{args.model_name}")
     U.hf_download_dataset("zhuzilin/dapo-math-17k", data_dir=args.data_dir)
@@ -103,88 +109,25 @@ def prepare(args: ScriptArgs):
         )
 
     if not args.enable_megatron_bridge:
-        checkpoint_path = _megatron_torch_dist_path(args)
-        conversion_args = _megatron_torch_dist_conversion_args(args)
         U.convert_checkpoint(
             model_name=args.model_name,
             megatron_model_type=args.megatron_model_type,
             num_gpus_per_node=args.num_gpus_per_node,
             # To support multi-node training, for simplicity, we put model into shared folder
             dir_dst=args.model_dir,
-            path_dst=checkpoint_path,
             hf_checkpoint=f"{args.model_dir}/{args.model_name}",
             megatron_path=args.megatron_path,
-            extra_args=conversion_args,
+            **(convert_checkpoint_kwargs or {}),
         )
-
-
-def _megatron_torch_dist_path(args: ScriptArgs) -> str:
-    if args.true_on_policy and args.expert_model_parallel_size > 1:
-        topology = (
-            f"tp{args.tensor_model_parallel_size}"
-            f"_pp{args.pipeline_model_parallel_size}"
-            f"_ep{args.expert_model_parallel_size}"
-            f"_etp{args.expert_tensor_parallel_size}"
-        )
-        return f"{args.model_dir}/{args.model_name}_torch_dist_{topology}"
-    return f"{args.model_dir}/{args.model_name}_torch_dist"
-
-
-def _megatron_torch_dist_conversion_args(args: ScriptArgs) -> str:
-    if not (args.true_on_policy and args.expert_model_parallel_size > 1):
-        return ""
-    return (
-        f"--tensor-model-parallel-size {args.tensor_model_parallel_size} "
-        f"--pipeline-model-parallel-size {args.pipeline_model_parallel_size} "
-        f"--expert-model-parallel-size {args.expert_model_parallel_size} "
-        f"--expert-tensor-parallel-size {args.expert_tensor_parallel_size} "
-        f"{_true_on_policy_vocab_padding_args(args)}"
-    )
-
-
-def _true_on_policy_vocab_padding_args(args: ScriptArgs) -> str:
-    if not (
-        args.true_on_policy
-        and args.expert_model_parallel_size > 1
-        and args.tensor_model_parallel_size > 1
-    ):
-        return ""
-    # Qwen3-30B-A3B's real vocab is already divisible by supported TP sizes.
-    # Avoid Megatron's default extra padding so HF -> torch-dist conversion and
-    # true-on-policy scoring use the same shard width.
-    return "--make-vocab-size-divisible-by 1 "
-
-
-def _true_on_policy_sequence_parallel_backward_args(args: ScriptArgs) -> str:
-    if not (
-        args.true_on_policy
-        and args.expert_model_parallel_size > 1
-        and args.tensor_model_parallel_size > 1
-        and args.use_sequence_parallel
-    ):
-        return ""
-    # TP+EP sequence-parallel true-on-policy currently produces nonfinite local
-    # wgrad buckets with Megatron's fused gradient accumulation path. Keep the
-    # unfused path for correctness until the fused kernel path is audited.
-    return "--no-gradient-accumulation-fusion "
 
 
 # TODO improve layering: split algorithm vs infra
 def execute(args: ScriptArgs):
-    is_debug_mode = args.mode != "normal"
-    is_debug_one_sample = args.mode == "debug_one_sample"
-    train_data_parallel_size = (
-        args.num_nodes
-        * args.num_gpus_per_node
-        // (args.tensor_model_parallel_size * args.pipeline_model_parallel_size * args.context_parallel_size)
-    )
-    debug_global_batch_size = max(1, train_data_parallel_size)
-    debug_rollout_batch_size = debug_global_batch_size
-    debug_num_rollout = 1
+    is_debug_mode = args.mode == "debug_minimal"
     megatron_load_path = (
         f"{args.model_dir}/{args.model_name}/"
         if args.enable_megatron_bridge
-        else _megatron_torch_dist_path(args)
+        else f"{args.model_dir}/{args.model_name}_torch_dist"
     )
     ref_load_path = megatron_load_path
     load_save_path = f"{args.output_dir}/{args.run_id}/checkpoints"
@@ -213,12 +156,12 @@ def execute(args: ScriptArgs):
         "--apply-chat-template "
         "--rollout-shuffle "
         "--rm-type deepscaler "
-        f"--num-rollout {debug_num_rollout if is_debug_one_sample else 3000} "
-        f"--rollout-batch-size {debug_rollout_batch_size if is_debug_one_sample else 32} "
-        f"--n-samples-per-prompt {1 if is_debug_one_sample else 8} "
-        f"--rollout-max-response-len {2 if is_debug_one_sample else (100 if args.mode == 'debug_minimal' else 8192)} "
+        "--num-rollout 3000 "
+        "--rollout-batch-size 32 "
+        "--n-samples-per-prompt 8 "
+        f"--rollout-max-response-len {100 if args.mode == 'debug_minimal' else 8192} "
         "--rollout-temperature 1 "
-        f"--global-batch-size {debug_global_batch_size if is_debug_one_sample else 256} "
+        "--global-batch-size 256 "
         "--balance-data "
     )
 
@@ -239,10 +182,7 @@ def execute(args: ScriptArgs):
         # "--micro-batch-size 1 "
         "--use-dynamic-batch-size "
         f"--max-tokens-per-gpu {args.max_tokens_per_gpu} "
-        f"{_true_on_policy_vocab_padding_args(args)}"
-        f"{_true_on_policy_sequence_parallel_backward_args(args)}"
     )
-    ci_args = "--ci-test --ci-disable-kl-checker " if is_debug_one_sample else ""
 
     grpo_args = (
         "--advantage-estimator grpo "
@@ -332,7 +272,6 @@ def execute(args: ScriptArgs):
                 f"{f'--sglang-ep-size {args.sglang_expert_parallel_size} ' if args.sglang_expert_parallel_size > 1 else ''}"
                 "--sglang-mem-fraction-static 0.7 "
                 "--sglang-cuda-graph-max-bs 512 "
-                f"{'--sglang-disable-cuda-graph ' if is_debug_one_sample else ''}"
             )
             optimizer_args += (
                 "--optimizer-cpu-offload " "--overlap-cpu-optimizer-d2h-h2d " "--use-precision-aware-optimizer "
@@ -352,7 +291,6 @@ def execute(args: ScriptArgs):
                 "--sglang-attention-backend trtllm_mha "
                 f"{f'--rollout-num-gpus {args.rollout_num_gpus} ' if args.rollout_num_gpus is not None else ''}"
                 f"{f'--sglang-ep-size {args.sglang_expert_parallel_size} ' if args.sglang_expert_parallel_size > 1 else ''}"
-                f"{'--sglang-disable-cuda-graph ' if is_debug_one_sample else ''}"
             )
             if args.rollout_fp8:
                 sglang_world_size = 2
@@ -423,7 +361,6 @@ tis_batch_normalize: true
         f"{eval_args} "
         f"{sglang_args} "
         f"{misc_args} "
-        f"{ci_args} "
         f"{args.extra_args} "
     )
 

--- a/scripts/run_qwen3_30b_a3b.py
+++ b/scripts/run_qwen3_30b_a3b.py
@@ -8,7 +8,7 @@ import miles.utils.external_utils.command_utils as U
 
 @dataclass
 class ScriptArgs(U.ExecuteTrainConfig):
-    mode: Literal["normal", "debug_minimal"] = "normal"
+    mode: Literal["normal", "debug_minimal", "debug_one_sample"] = "normal"
     run_id: str = U.create_run_id()
     model_name: str = "Qwen3-30B-A3B"
     megatron_model_type: str = "qwen3-30B-A3B"
@@ -103,25 +103,90 @@ def prepare(args: ScriptArgs):
         )
 
     if not args.enable_megatron_bridge:
+        checkpoint_path = _megatron_torch_dist_path(args)
+        conversion_args = _megatron_torch_dist_conversion_args(args)
         U.convert_checkpoint(
             model_name=args.model_name,
             megatron_model_type=args.megatron_model_type,
             num_gpus_per_node=args.num_gpus_per_node,
             # To support multi-node training, for simplicity, we put model into shared folder
             dir_dst=args.model_dir,
+            path_dst=checkpoint_path,
             hf_checkpoint=f"{args.model_dir}/{args.model_name}",
             megatron_path=args.megatron_path,
+            extra_args=conversion_args,
         )
+
+
+def _megatron_torch_dist_path(args: ScriptArgs) -> str:
+    if args.true_on_policy and args.expert_model_parallel_size > 1:
+        topology = (
+            f"tp{args.tensor_model_parallel_size}"
+            f"_pp{args.pipeline_model_parallel_size}"
+            f"_ep{args.expert_model_parallel_size}"
+            f"_etp{args.expert_tensor_parallel_size}"
+        )
+        return f"{args.model_dir}/{args.model_name}_torch_dist_{topology}"
+    return f"{args.model_dir}/{args.model_name}_torch_dist"
+
+
+def _megatron_torch_dist_conversion_args(args: ScriptArgs) -> str:
+    if not (args.true_on_policy and args.expert_model_parallel_size > 1):
+        return ""
+    return (
+        f"--tensor-model-parallel-size {args.tensor_model_parallel_size} "
+        f"--pipeline-model-parallel-size {args.pipeline_model_parallel_size} "
+        f"--expert-model-parallel-size {args.expert_model_parallel_size} "
+        f"--expert-tensor-parallel-size {args.expert_tensor_parallel_size} "
+        f"{_true_on_policy_vocab_padding_args(args)}"
+    )
+
+
+def _true_on_policy_vocab_padding_args(args: ScriptArgs) -> str:
+    if not (
+        args.true_on_policy
+        and args.expert_model_parallel_size > 1
+        and args.tensor_model_parallel_size > 1
+    ):
+        return ""
+    # Qwen3-30B-A3B's real vocab is already divisible by supported TP sizes.
+    # Avoid Megatron's default extra padding so HF -> torch-dist conversion and
+    # true-on-policy scoring use the same shard width.
+    return "--make-vocab-size-divisible-by 1 "
+
+
+def _true_on_policy_sequence_parallel_backward_args(args: ScriptArgs) -> str:
+    if not (
+        args.true_on_policy
+        and args.expert_model_parallel_size > 1
+        and args.tensor_model_parallel_size > 1
+        and args.use_sequence_parallel
+    ):
+        return ""
+    # TP+EP sequence-parallel true-on-policy currently produces nonfinite local
+    # wgrad buckets with Megatron's fused gradient accumulation path. Keep the
+    # unfused path for correctness until the fused kernel path is audited.
+    return "--no-gradient-accumulation-fusion "
 
 
 # TODO improve layering: split algorithm vs infra
 def execute(args: ScriptArgs):
-    is_debug_mode = args.mode == "debug_minimal"
-    ref_load_path = (
+    is_debug_mode = args.mode != "normal"
+    is_debug_one_sample = args.mode == "debug_one_sample"
+    train_data_parallel_size = (
+        args.num_nodes
+        * args.num_gpus_per_node
+        // (args.tensor_model_parallel_size * args.pipeline_model_parallel_size * args.context_parallel_size)
+    )
+    debug_global_batch_size = max(1, train_data_parallel_size)
+    debug_rollout_batch_size = debug_global_batch_size
+    debug_num_rollout = 1
+    megatron_load_path = (
         f"{args.model_dir}/{args.model_name}/"
         if args.enable_megatron_bridge
-        else f"{args.model_dir}/{args.model_name}_torch_dist"
+        else _megatron_torch_dist_path(args)
     )
+    ref_load_path = megatron_load_path
     load_save_path = f"{args.output_dir}/{args.run_id}/checkpoints"
 
     if args.rollout_fp8:
@@ -135,7 +200,7 @@ def execute(args: ScriptArgs):
     ckpt_args = (
         f"--hf-checkpoint {hf_checkpoint}/ "
         f"--ref-load {ref_load_path} "
-        f"--load {load_save_path} "
+        f"--load {megatron_load_path} "
         f"--save {load_save_path} "
         f"--save-interval {2 if is_debug_mode else 20} "
         f"--save-retain-interval {2 if is_debug_mode else 20} "
@@ -148,12 +213,12 @@ def execute(args: ScriptArgs):
         "--apply-chat-template "
         "--rollout-shuffle "
         "--rm-type deepscaler "
-        "--num-rollout 3000 "
-        "--rollout-batch-size 32 "
-        "--n-samples-per-prompt 8 "
-        f"--rollout-max-response-len {100 if args.mode == 'debug_minimal' else 8192} "
+        f"--num-rollout {debug_num_rollout if is_debug_one_sample else 3000} "
+        f"--rollout-batch-size {debug_rollout_batch_size if is_debug_one_sample else 32} "
+        f"--n-samples-per-prompt {1 if is_debug_one_sample else 8} "
+        f"--rollout-max-response-len {2 if is_debug_one_sample else (100 if args.mode == 'debug_minimal' else 8192)} "
         "--rollout-temperature 1 "
-        "--global-batch-size 256 "
+        f"--global-batch-size {debug_global_batch_size if is_debug_one_sample else 256} "
         "--balance-data "
     )
 
@@ -174,7 +239,10 @@ def execute(args: ScriptArgs):
         # "--micro-batch-size 1 "
         "--use-dynamic-batch-size "
         f"--max-tokens-per-gpu {args.max_tokens_per_gpu} "
+        f"{_true_on_policy_vocab_padding_args(args)}"
+        f"{_true_on_policy_sequence_parallel_backward_args(args)}"
     )
+    ci_args = "--ci-test --ci-disable-kl-checker " if is_debug_one_sample else ""
 
     grpo_args = (
         "--advantage-estimator grpo "
@@ -264,6 +332,7 @@ def execute(args: ScriptArgs):
                 f"{f'--sglang-ep-size {args.sglang_expert_parallel_size} ' if args.sglang_expert_parallel_size > 1 else ''}"
                 "--sglang-mem-fraction-static 0.7 "
                 "--sglang-cuda-graph-max-bs 512 "
+                f"{'--sglang-disable-cuda-graph ' if is_debug_one_sample else ''}"
             )
             optimizer_args += (
                 "--optimizer-cpu-offload " "--overlap-cpu-optimizer-d2h-h2d " "--use-precision-aware-optimizer "
@@ -283,6 +352,7 @@ def execute(args: ScriptArgs):
                 "--sglang-attention-backend trtllm_mha "
                 f"{f'--rollout-num-gpus {args.rollout_num_gpus} ' if args.rollout_num_gpus is not None else ''}"
                 f"{f'--sglang-ep-size {args.sglang_expert_parallel_size} ' if args.sglang_expert_parallel_size > 1 else ''}"
+                f"{'--sglang-disable-cuda-graph ' if is_debug_one_sample else ''}"
             )
             if args.rollout_fp8:
                 sglang_world_size = 2
@@ -353,6 +423,7 @@ tis_batch_normalize: true
         f"{eval_args} "
         f"{sglang_args} "
         f"{misc_args} "
+        f"{ci_args} "
         f"{args.extra_args} "
     )
 

--- a/scripts/run_qwen3_30b_a3b_deterministic.py
+++ b/scripts/run_qwen3_30b_a3b_deterministic.py
@@ -3,6 +3,13 @@
 Extends the base script with true-on-policy contract, EP parity defaults,
 and deterministic launch plan injection. Use this script when you need
 exact-zero logprob alignment between SGLang rollout and Megatron training.
+
+This module owns every true-on-policy concern (topology-suffixed torch_dist
+checkpoints, vocab padding overrides, fused-grad workaround, debug-one-sample
+plumbing). The base ``scripts/run_qwen3_30b_a3b`` script stays
+true-on-policy-agnostic; we cooperate with it through ``prepare``'s
+``convert_checkpoint_kwargs`` hook and by appending overrides at the end of
+``args.extra_args`` so argparse last-wins picks them up.
 """
 
 import os
@@ -11,7 +18,7 @@ from typing import Literal
 
 import typer
 from scripts.run_qwen3_30b_a3b import ScriptArgs as BaseScriptArgs
-from scripts.run_qwen3_30b_a3b import prepare
+from scripts.run_qwen3_30b_a3b import prepare as base_prepare
 
 import miles.utils.external_utils.command_utils as U
 from miles.true_on_policy import apply_true_on_policy_script_defaults, build_true_on_policy_launch_plan
@@ -45,6 +52,83 @@ class ScriptArgs(BaseScriptArgs):
         apply_true_on_policy_script_defaults(self)
 
 
+def _uses_topology_aware_torch_dist(args: ScriptArgs) -> bool:
+    return bool(args.true_on_policy and args.expert_model_parallel_size > 1)
+
+
+def _megatron_torch_dist_path(args: ScriptArgs) -> str:
+    if _uses_topology_aware_torch_dist(args):
+        topology = (
+            f"tp{args.tensor_model_parallel_size}"
+            f"_pp{args.pipeline_model_parallel_size}"
+            f"_ep{args.expert_model_parallel_size}"
+            f"_etp{args.expert_tensor_parallel_size}"
+        )
+        return f"{args.model_dir}/{args.model_name}_torch_dist_{topology}"
+    return f"{args.model_dir}/{args.model_name}_torch_dist"
+
+
+def _megatron_torch_dist_conversion_args(args: ScriptArgs) -> str:
+    if not _uses_topology_aware_torch_dist(args):
+        return ""
+    return (
+        f"--tensor-model-parallel-size {args.tensor_model_parallel_size} "
+        f"--pipeline-model-parallel-size {args.pipeline_model_parallel_size} "
+        f"--expert-model-parallel-size {args.expert_model_parallel_size} "
+        f"--expert-tensor-parallel-size {args.expert_tensor_parallel_size} "
+        f"{_true_on_policy_vocab_padding_args(args)}"
+    )
+
+
+def _true_on_policy_vocab_padding_args(args: ScriptArgs) -> str:
+    if not (
+        args.true_on_policy
+        and args.expert_model_parallel_size > 1
+        and args.tensor_model_parallel_size > 1
+    ):
+        return ""
+    # Qwen3-30B-A3B's real vocab is already divisible by supported TP sizes.
+    # Avoid Megatron's default extra padding so HF -> torch-dist conversion and
+    # true-on-policy scoring use the same shard width.
+    return "--make-vocab-size-divisible-by 1 "
+
+
+def _true_on_policy_sequence_parallel_backward_args(args: ScriptArgs) -> str:
+    if not (
+        args.true_on_policy
+        and args.expert_model_parallel_size > 1
+        and args.tensor_model_parallel_size > 1
+        and args.use_sequence_parallel
+    ):
+        return ""
+    # TP+EP sequence-parallel true-on-policy currently produces nonfinite local
+    # wgrad buckets with Megatron's fused gradient accumulation path. Keep the
+    # unfused path for correctness until the fused kernel path is audited.
+    return "--no-gradient-accumulation-fusion "
+
+
+def _topology_aware_extra_args(args: ScriptArgs) -> str:
+    """Args injected at the end of train_args to override the base script.
+
+    Relies on argparse last-wins semantics for ``--load`` / ``--ref-load`` so
+    the topology-suffixed torch_dist directory wins over the base's default.
+    """
+    if not _uses_topology_aware_torch_dist(args):
+        return ""
+    load_path = _megatron_torch_dist_path(args)
+    parts = [
+        f"--load {load_path}",
+        f"--ref-load {load_path}",
+    ]
+    vocab = _true_on_policy_vocab_padding_args(args).strip()
+    if vocab:
+        parts.append(vocab)
+    grad = _true_on_policy_sequence_parallel_backward_args(args).strip()
+    if grad:
+        parts.append(grad)
+    return " ".join(parts) + " "
+
+
 def _debug_one_sample_args(args: ScriptArgs) -> str:
     train_data_parallel_size = (
         args.num_nodes
@@ -63,6 +147,16 @@ def _debug_one_sample_args(args: ScriptArgs) -> str:
     )
 
 
+def prepare(args: ScriptArgs):
+    convert_kwargs: dict = {}
+    if _uses_topology_aware_torch_dist(args):
+        convert_kwargs = {
+            "path_dst": _megatron_torch_dist_path(args),
+            "extra_args": _megatron_torch_dist_conversion_args(args),
+        }
+    base_prepare(args, convert_checkpoint_kwargs=convert_kwargs)
+
+
 def execute(args: ScriptArgs):
     from scripts.run_qwen3_30b_a3b import execute as base_execute
 
@@ -73,9 +167,10 @@ def execute(args: ScriptArgs):
     debug_args = _debug_one_sample_args(args) if args.mode == "debug_one_sample" else ""
     if args.mode == "debug_one_sample":
         args.enable_eval = False
+    topology_extra = _topology_aware_extra_args(args)
     base_mode = args.mode
     args.mode = "debug_minimal" if args.mode == "debug_one_sample" else args.mode
-    args.extra_args = f"{plan.train_args} {debug_args} {args.extra_args}"
+    args.extra_args = f"{plan.train_args} {debug_args} {topology_extra} {args.extra_args}"
     try:
         base_execute(args)
     finally:

--- a/scripts/run_qwen3_30b_a3b_deterministic.py
+++ b/scripts/run_qwen3_30b_a3b_deterministic.py
@@ -26,6 +26,7 @@ class ScriptArgs(BaseScriptArgs):
     true_on_policy_default_rollout_ep: bool = True
 
     def __post_init__(self):
+        rollout_engine_size_was_default = self.rollout_num_gpus_per_engine is None
         super().__post_init__()
         if (
             self.sglang_expert_parallel_size == 1
@@ -36,9 +37,11 @@ class ScriptArgs(BaseScriptArgs):
         if (
             self.true_on_policy
             and self.sglang_expert_parallel_size > 1
-            and self.rollout_num_gpus_per_engine < self.sglang_expert_parallel_size
+            and rollout_engine_size_was_default
         ):
-            self.rollout_num_gpus_per_engine = self.sglang_expert_parallel_size
+            self.rollout_num_gpus_per_engine = (
+                self.sglang_expert_parallel_size * self.expert_tensor_parallel_size
+            )
         apply_true_on_policy_script_defaults(self)
 
 

--- a/tests/fast/true_on_policy/test_config.py
+++ b/tests/fast/true_on_policy/test_config.py
@@ -45,7 +45,7 @@ def test_qwen3_dense_profile_resolves_model_names():
     assert profile.contract is contract
     assert contract.schema.name == "qwen3_dense_true_on_policy_v1"
     assert contract.schema.model_family == "qwen3_dense"
-    assert profile.supported_train_layouts == ("dp", "tp", "pp", "ulysses_cp")
+    assert profile.supported_train_layouts == ("dp", "tp", "sp", "pp", "ulysses_cp")
     assert profile.supported_rollout_layouts == ("dp", "tp")
     assert profile.required_kernel_contracts == ("qwen3_dense_sglang_math",)
     assert profile.logprob_contract == "sglang_prefill"
@@ -128,6 +128,7 @@ def test_qwen3_moe_ep_is_separate_from_tp_invariant_rollout():
     assert plan.parallel_layout is not None
     assert plan.parallel_layout.uses_train_ep
     assert not plan.parallel_layout.uses_train_tp
+    assert not plan.parallel_layout.uses_train_sp
     assert not plan.parallel_layout.uses_train_expert_tp
     assert plan.kernel_policy is not None
     assert not plan.kernel_policy.tp_invariant_row_linear
@@ -169,7 +170,9 @@ def test_qwen3_moe_rollout_tp_still_enables_tp_invariant_math():
         tensor_model_parallel_size=1,
         context_parallel_size=2,
         expert_model_parallel_size=4,
+        expert_tensor_parallel_size=2,
         rollout_num_gpus_per_engine=8,
+        sglang_expert_parallel_size=4,
     )
 
     plan = build_true_on_policy_launch_plan(args)
@@ -184,16 +187,17 @@ def test_qwen3_moe_rollout_tp_still_enables_tp_invariant_math():
 
 
 @pytest.mark.parametrize(
-    ("tp_size", "ep_size", "cp_size"),
+    ("tp_size", "ep_size", "cp_size", "rollout_engine_size"),
     [
-        (1, 4, 2),
-        (4, 1, 2),
+        (1, 4, 2, 4),
+        (4, 1, 2, 1),
     ],
 )
 def test_qwen3_moe_valid_8_gpu_megatron_training_topologies(
     tp_size: int,
     ep_size: int,
     cp_size: int,
+    rollout_engine_size: int,
 ):
     args = _args(
         model_name="Qwen3-30B-A3B",
@@ -201,7 +205,7 @@ def test_qwen3_moe_valid_8_gpu_megatron_training_topologies(
         context_parallel_size=cp_size,
         expert_model_parallel_size=ep_size,
         expert_tensor_parallel_size=1,
-        rollout_num_gpus_per_engine=max(tp_size, ep_size),
+        rollout_num_gpus_per_engine=rollout_engine_size,
         sglang_expert_parallel_size=ep_size,
         num_nodes=1,
         num_gpus_per_node=8,
@@ -213,9 +217,29 @@ def test_qwen3_moe_valid_8_gpu_megatron_training_topologies(
     assert plan.parallel_layout.train_tensor_parallel_size == tp_size
     assert plan.parallel_layout.train_expert_model_parallel_size == ep_size
     assert plan.parallel_layout.train_context_parallel_size == cp_size
+    assert plan.parallel_layout.uses_train_sp == (tp_size > 1)
 
 
-def test_qwen3_moe_rejects_train_tp_with_ep_until_sequence_parallel_is_supported():
+def test_qwen3_moe_rejects_rollout_moe_tp_mismatch():
+    args = _args(
+        model_name="Qwen3-30B-A3B",
+        tensor_model_parallel_size=2,
+        context_parallel_size=1,
+        pipeline_model_parallel_size=2,
+        expert_model_parallel_size=2,
+        expert_tensor_parallel_size=1,
+        rollout_num_gpus_per_engine=4,
+        sglang_expert_parallel_size=2,
+        use_sequence_parallel=True,
+        num_nodes=1,
+        num_gpus_per_node=8,
+    )
+
+    with pytest.raises(ValueError, match="SGLang MoE TP to match Megatron"):
+        build_true_on_policy_launch_plan(args)
+
+
+def test_qwen3_moe_rejects_train_tp_with_ep_when_sequence_parallel_is_disabled():
     args = _args(
         model_name="Qwen3-30B-A3B",
         tensor_model_parallel_size=2,
@@ -224,12 +248,62 @@ def test_qwen3_moe_rejects_train_tp_with_ep_until_sequence_parallel_is_supported
         expert_tensor_parallel_size=1,
         rollout_num_gpus_per_engine=4,
         sglang_expert_parallel_size=4,
+        use_sequence_parallel=False,
         num_nodes=1,
         num_gpus_per_node=8,
     )
 
-    with pytest.raises(ValueError, match="does not support train TP with EP yet"):
+    with pytest.raises(ValueError, match="requires sequence parallel"):
         build_true_on_policy_launch_plan(args)
+
+
+def test_qwen3_moe_allows_train_tp_with_ep_when_sequence_parallel_is_enabled():
+    args = _args(
+        model_name="Qwen3-30B-A3B",
+        tensor_model_parallel_size=2,
+        context_parallel_size=1,
+        expert_model_parallel_size=4,
+        expert_tensor_parallel_size=1,
+        rollout_num_gpus_per_engine=4,
+        sglang_expert_parallel_size=4,
+        use_sequence_parallel=True,
+        num_nodes=1,
+        num_gpus_per_node=8,
+    )
+
+    plan = build_true_on_policy_launch_plan(args)
+
+    assert plan.parallel_layout is not None
+    assert plan.parallel_layout.uses_train_tp
+    assert plan.parallel_layout.uses_train_sp
+    assert plan.parallel_layout.uses_train_ep
+    assert plan.kernel_policy is not None
+    assert plan.kernel_policy.tp_invariant_row_linear
+    assert plan.kernel_policy.ep_invariant_moe
+
+
+def test_qwen3_moe_allows_pipeline_parallel_when_ep_fits_train_dp():
+    args = _args(
+        model_name="Qwen3-30B-A3B",
+        tensor_model_parallel_size=1,
+        context_parallel_size=1,
+        pipeline_model_parallel_size=2,
+        expert_model_parallel_size=4,
+        expert_tensor_parallel_size=1,
+        rollout_num_gpus_per_engine=4,
+        sglang_expert_parallel_size=4,
+        num_nodes=1,
+        num_gpus_per_node=8,
+    )
+
+    plan = build_true_on_policy_launch_plan(args)
+
+    assert plan.parallel_layout is not None
+    assert plan.parallel_layout.uses_train_pp
+    assert plan.parallel_layout.uses_train_ep
+    assert plan.parallel_layout.train_pipeline_parallel_size == 2
+    assert plan.kernel_policy is not None
+    assert plan.kernel_policy.ep_invariant_moe
 
 
 def test_qwen3_moe_rejects_ep_that_does_not_fit_8_gpu_megatron_dp():
@@ -270,13 +344,13 @@ def test_contract_object_owns_miles_kernel_policy_values():
     assert plan.kernel_policy.deterministic_tp_allreduce
 
 
-def test_megatron_true_on_policy_disables_sequence_parallel_and_enables_backend_flags():
+def test_megatron_true_on_policy_keeps_sequence_parallel_and_enables_backend_flags():
     args = _args(train_backend="megatron", use_sequence_parallel=True)
 
     apply_true_on_policy_script_defaults(args)
     plan = build_true_on_policy_launch_plan(args)
 
-    assert args.use_sequence_parallel is False
+    assert args.use_sequence_parallel is True
     assert "--use-sglang" not in plan.train_args
     assert "--true-on-policy-contract qwen3_dense_true_on_policy_v1" in plan.train_args
     assert "--sglang-true-on-policy-contract qwen3_dense_true_on_policy_v1" in plan.train_args
@@ -302,9 +376,10 @@ def test_megatron_tp2_cp4_normal_topology_has_complete_true_on_policy_contract(m
     apply_true_on_policy_script_defaults(args)
     plan = build_true_on_policy_launch_plan(args)
 
-    assert args.use_sequence_parallel is False
+    assert args.use_sequence_parallel is True
     assert plan.parallel_layout is not None
     assert plan.parallel_layout.train_tensor_parallel_size == 2
+    assert plan.parallel_layout.uses_train_sp
     assert plan.parallel_layout.train_context_parallel_size == 4
     assert plan.parallel_layout.rollout_num_gpus_per_engine == 8
     assert plan.parallel_layout.uses_train_tp

--- a/tests/fast/true_on_policy/test_run_qwen3_30b_a3b.py
+++ b/tests/fast/true_on_policy/test_run_qwen3_30b_a3b.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from scripts import run_qwen3_30b_a3b as base_run_qwen3_30b_a3b
 from scripts import run_qwen3_30b_a3b_deterministic as run_qwen3_30b_a3b
 
 
@@ -27,7 +28,7 @@ def test_qwen3_moe_script_true_on_policy_tp1_ep4_cp2_contract(monkeypatch):
         use_sequence_parallel=True,
     )
 
-    assert args.use_sequence_parallel is False
+    assert args.use_sequence_parallel is True
 
     run_qwen3_30b_a3b.execute(args)
 
@@ -45,22 +46,142 @@ def test_qwen3_moe_script_true_on_policy_tp1_ep4_cp2_contract(monkeypatch):
     assert "--num-rollout 1" in train_args
     assert "--rollout-batch-size 4" in train_args
     assert "--sglang-ep-size 4" in train_args
-    assert "--sglang-disable-cuda-graph" in train_args
     assert "--sglang-data-parallel-size" not in train_args
     assert "--sglang-enable-dp-attention" not in train_args
     assert "--sglang-true-on-policy-contract qwen3_moe_true_on_policy_v1" in train_args
     assert "--true-on-policy-contract qwen3_moe_true_on_policy_v1" in train_args
     assert "--recompute-logprobs-via-prefill" not in train_args
     assert "--sequence-parallel" not in train_args
+    assert "--no-gradient-accumulation-fusion" not in train_args
     assert "--use-sglang" not in train_args
     assert "ROW_LINEAR_ENABLE_INV" not in env_vars
     assert "NCCL_ALGO" not in env_vars
     assert "NCCL_ALGO=Ring" in config.extra_env_vars
-    assert "NCCL_NVLS_ENABLE=0" in config.extra_env_vars
     assert "MODEL_ARGS_DISABLE_MOE_PERMUTE_FUSION=1" in config.extra_env_vars
 
 
-def test_qwen3_moe_default_rollout_engine_size_fits_sglang_ep():
+def test_qwen3_moe_script_true_on_policy_tp2_ep4_enables_sequence_parallel(monkeypatch):
+    captured = {}
+
+    def fake_execute_train(**kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr(run_qwen3_30b_a3b.U, "execute_train", fake_execute_train)
+    monkeypatch.setattr(run_qwen3_30b_a3b.U, "get_default_wandb_args", lambda *args, **kwargs: "")
+
+    args = run_qwen3_30b_a3b.ScriptArgs(
+        mode="debug_one_sample",
+        run_id="unit-test-moe-tp2-ep4",
+        true_on_policy=True,
+        enable_eval=False,
+        tensor_model_parallel_size=2,
+        context_parallel_size=1,
+        expert_model_parallel_size=4,
+        expert_tensor_parallel_size=1,
+        rollout_num_gpus=8,
+        rollout_num_gpus_per_engine=4,
+        use_sequence_parallel=True,
+    )
+
+    run_qwen3_30b_a3b.execute(args)
+
+    train_args = captured["train_args"]
+
+    assert "--tensor-model-parallel-size 2" in train_args
+    assert "--sequence-parallel" in train_args
+    assert "--expert-model-parallel-size 4" in train_args
+    assert "--sglang-ep-size 4" in train_args
+    assert "--make-vocab-size-divisible-by 1" in train_args
+    assert "--no-gradient-accumulation-fusion" in train_args
+    assert "--sglang-true-on-policy-contract qwen3_moe_true_on_policy_v1" in train_args
+    assert "--true-on-policy-contract qwen3_moe_true_on_policy_v1" in train_args
+
+
+def test_qwen3_moe_script_true_on_policy_pp2_ep4_contract(monkeypatch):
+    captured = {}
+
+    def fake_execute_train(**kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr(run_qwen3_30b_a3b.U, "execute_train", fake_execute_train)
+    monkeypatch.setattr(run_qwen3_30b_a3b.U, "get_default_wandb_args", lambda *args, **kwargs: "")
+
+    args = run_qwen3_30b_a3b.ScriptArgs(
+        mode="debug_one_sample",
+        run_id="unit-test-moe-pp2-ep4",
+        true_on_policy=True,
+        enable_eval=False,
+        tensor_model_parallel_size=1,
+        pipeline_model_parallel_size=2,
+        context_parallel_size=1,
+        expert_model_parallel_size=4,
+        expert_tensor_parallel_size=1,
+        rollout_num_gpus=8,
+        rollout_num_gpus_per_engine=4,
+        use_sequence_parallel=False,
+    )
+
+    run_qwen3_30b_a3b.execute(args)
+
+    train_args = captured["train_args"]
+
+    assert "--tensor-model-parallel-size 1" in train_args
+    assert "--pipeline-model-parallel-size 2" in train_args
+    assert "Qwen3-30B-A3B_torch_dist_tp1_pp2_ep4_etp1" in train_args
+    assert "--megatron-to-hf-mode bridge" not in train_args
+    assert "--sequence-parallel" not in train_args
+    assert "--no-gradient-accumulation-fusion" not in train_args
+    assert "--expert-model-parallel-size 4" in train_args
+    assert "--sglang-ep-size 4" in train_args
+    assert "--sglang-true-on-policy-contract qwen3_moe_true_on_policy_v1" in train_args
+    assert "--true-on-policy-contract qwen3_moe_true_on_policy_v1" in train_args
+
+
+def test_qwen3_moe_script_true_on_policy_sp_pp_ep_contract(monkeypatch):
+    captured = {}
+
+    def fake_execute_train(**kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr(run_qwen3_30b_a3b.U, "execute_train", fake_execute_train)
+    monkeypatch.setattr(run_qwen3_30b_a3b.U, "get_default_wandb_args", lambda *args, **kwargs: "")
+
+    args = run_qwen3_30b_a3b.ScriptArgs(
+        mode="debug_one_sample",
+        run_id="unit-test-moe-sp-pp-ep",
+        true_on_policy=True,
+        enable_eval=False,
+        tensor_model_parallel_size=2,
+        pipeline_model_parallel_size=2,
+        context_parallel_size=1,
+        expert_model_parallel_size=2,
+        expert_tensor_parallel_size=1,
+        rollout_num_gpus=8,
+        rollout_num_gpus_per_engine=2,
+        sglang_expert_parallel_size=2,
+        use_sequence_parallel=True,
+    )
+
+    run_qwen3_30b_a3b.execute(args)
+
+    train_args = captured["train_args"]
+
+    assert "--tensor-model-parallel-size 2" in train_args
+    assert "--sequence-parallel" in train_args
+    assert "--pipeline-model-parallel-size 2" in train_args
+    assert "--expert-model-parallel-size 2" in train_args
+    assert "--sglang-ep-size 2" in train_args
+    assert "--rollout-num-gpus-per-engine 2" in train_args
+    assert "--rollout-batch-size 2" in train_args
+    assert "--global-batch-size 2" in train_args
+    assert "Qwen3-30B-A3B_torch_dist_tp2_pp2_ep2_etp1" in train_args
+    assert "--make-vocab-size-divisible-by 1" in train_args
+    assert "--no-gradient-accumulation-fusion" in train_args
+    assert "--sglang-true-on-policy-contract qwen3_moe_true_on_policy_v1" in train_args
+    assert "--true-on-policy-contract qwen3_moe_true_on_policy_v1" in train_args
+
+
+def test_qwen3_moe_default_rollout_engine_size_matches_sglang_ep():
     args = run_qwen3_30b_a3b.ScriptArgs(
         mode="debug_one_sample",
         run_id="unit-test-moe-defaults",
@@ -68,12 +189,86 @@ def test_qwen3_moe_default_rollout_engine_size_fits_sglang_ep():
         enable_eval=False,
         tensor_model_parallel_size=1,
         context_parallel_size=2,
+        cp_comm_type="a2a",
         expert_model_parallel_size=4,
         expert_tensor_parallel_size=1,
         rollout_num_gpus=8,
         use_sequence_parallel=True,
     )
 
-    assert args.cp_comm_type == "a2a"
     assert args.sglang_expert_parallel_size == 4
-    assert args.rollout_num_gpus_per_engine == 8
+    assert args.rollout_num_gpus_per_engine == 4
+
+
+def test_qwen3_moe_sppp_default_rollout_engine_size_matches_sglang_moe_tp():
+    args = run_qwen3_30b_a3b.ScriptArgs(
+        mode="debug_one_sample",
+        run_id="unit-test-moe-sppp-defaults",
+        true_on_policy=True,
+        enable_eval=False,
+        tensor_model_parallel_size=2,
+        pipeline_model_parallel_size=2,
+        context_parallel_size=1,
+        expert_model_parallel_size=2,
+        expert_tensor_parallel_size=1,
+        rollout_num_gpus=8,
+        use_sequence_parallel=True,
+    )
+
+    assert args.sglang_expert_parallel_size == 2
+    assert args.rollout_num_gpus_per_engine == 2
+
+
+def test_qwen3_moe_pp_uses_topology_specific_torch_dist_checkpoint():
+    args = run_qwen3_30b_a3b.ScriptArgs(
+        mode="debug_one_sample",
+        run_id="unit-test-moe-pp-checkpoint",
+        true_on_policy=True,
+        enable_eval=False,
+        model_dir="/models",
+        tensor_model_parallel_size=1,
+        pipeline_model_parallel_size=2,
+        context_parallel_size=1,
+        expert_model_parallel_size=4,
+        expert_tensor_parallel_size=1,
+        rollout_num_gpus=8,
+        rollout_num_gpus_per_engine=4,
+        use_sequence_parallel=False,
+    )
+
+    checkpoint_path = base_run_qwen3_30b_a3b._megatron_torch_dist_path(args)
+    conversion_args = base_run_qwen3_30b_a3b._megatron_torch_dist_conversion_args(args)
+
+    assert checkpoint_path == "/models/Qwen3-30B-A3B_torch_dist_tp1_pp2_ep4_etp1"
+    assert "--tensor-model-parallel-size 1" in conversion_args
+    assert "--pipeline-model-parallel-size 2" in conversion_args
+    assert "--expert-model-parallel-size 4" in conversion_args
+    assert "--expert-tensor-parallel-size 1" in conversion_args
+
+
+def test_qwen3_moe_pp1_uses_topology_specific_torch_dist_checkpoint_path():
+    args = run_qwen3_30b_a3b.ScriptArgs(
+        mode="debug_one_sample",
+        run_id="unit-test-moe-pp1-checkpoint",
+        true_on_policy=True,
+        enable_eval=False,
+        model_dir="/models",
+        tensor_model_parallel_size=2,
+        pipeline_model_parallel_size=1,
+        context_parallel_size=1,
+        expert_model_parallel_size=4,
+        expert_tensor_parallel_size=1,
+        rollout_num_gpus=8,
+        rollout_num_gpus_per_engine=4,
+        use_sequence_parallel=True,
+    )
+
+    checkpoint_path = base_run_qwen3_30b_a3b._megatron_torch_dist_path(args)
+    conversion_args = base_run_qwen3_30b_a3b._megatron_torch_dist_conversion_args(args)
+
+    assert checkpoint_path == "/models/Qwen3-30B-A3B_torch_dist_tp2_pp1_ep4_etp1"
+    assert "--tensor-model-parallel-size 2" in conversion_args
+    assert "--pipeline-model-parallel-size 1" in conversion_args
+    assert "--expert-model-parallel-size 4" in conversion_args
+    assert "--expert-tensor-parallel-size 1" in conversion_args
+    assert "--make-vocab-size-divisible-by 1" in conversion_args

--- a/tests/fast/true_on_policy/test_run_qwen3_30b_a3b.py
+++ b/tests/fast/true_on_policy/test_run_qwen3_30b_a3b.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from scripts import run_qwen3_30b_a3b as base_run_qwen3_30b_a3b
 from scripts import run_qwen3_30b_a3b_deterministic as run_qwen3_30b_a3b
 
 
@@ -236,8 +235,8 @@ def test_qwen3_moe_pp_uses_topology_specific_torch_dist_checkpoint():
         use_sequence_parallel=False,
     )
 
-    checkpoint_path = base_run_qwen3_30b_a3b._megatron_torch_dist_path(args)
-    conversion_args = base_run_qwen3_30b_a3b._megatron_torch_dist_conversion_args(args)
+    checkpoint_path = run_qwen3_30b_a3b._megatron_torch_dist_path(args)
+    conversion_args = run_qwen3_30b_a3b._megatron_torch_dist_conversion_args(args)
 
     assert checkpoint_path == "/models/Qwen3-30B-A3B_torch_dist_tp1_pp2_ep4_etp1"
     assert "--tensor-model-parallel-size 1" in conversion_args
@@ -263,8 +262,8 @@ def test_qwen3_moe_pp1_uses_topology_specific_torch_dist_checkpoint_path():
         use_sequence_parallel=True,
     )
 
-    checkpoint_path = base_run_qwen3_30b_a3b._megatron_torch_dist_path(args)
-    conversion_args = base_run_qwen3_30b_a3b._megatron_torch_dist_conversion_args(args)
+    checkpoint_path = run_qwen3_30b_a3b._megatron_torch_dist_path(args)
+    conversion_args = run_qwen3_30b_a3b._megatron_torch_dist_conversion_args(args)
 
     assert checkpoint_path == "/models/Qwen3-30B-A3B_torch_dist_tp2_pp1_ep4_etp1"
     assert "--tensor-model-parallel-size 2" in conversion_args

--- a/tests/fast/true_on_policy/test_run_qwen3_4b.py
+++ b/tests/fast/true_on_policy/test_run_qwen3_4b.py
@@ -20,7 +20,7 @@ def test_qwen3_script_true_on_policy_single_knob_expands_to_megatron_contract(mo
         use_kl_loss=False,
     )
 
-    assert args.use_sequence_parallel is False
+    assert args.use_sequence_parallel is True
 
     run_qwen3_4b.execute(args)
 
@@ -38,7 +38,7 @@ def test_qwen3_script_true_on_policy_single_knob_expands_to_megatron_contract(mo
     assert "--use-sglang" not in train_args
     assert "--batch-invariant-mode" in train_args
     assert "--no-rope-fusion" in train_args
-    assert "--sequence-parallel" not in train_args
+    assert "--sequence-parallel" in train_args
     assert "ROW_LINEAR_ENABLE_INV" not in env_vars
     assert "MEGATRON_USE_DETERMINISTIC_ALLREDUCE" not in env_vars
 
@@ -67,7 +67,7 @@ def test_qwen3_script_true_on_policy_tp2_cp4_normal_topology_contract(monkeypatc
     args.rollout_num_gpus_per_engine = 8
     args.extra_args = "--rollout-num-gpus 8 "
 
-    assert args.use_sequence_parallel is False
+    assert args.use_sequence_parallel is True
 
     run_qwen3_4b.execute(args)
 
@@ -88,7 +88,7 @@ def test_qwen3_script_true_on_policy_tp2_cp4_normal_topology_contract(monkeypatc
     assert "--batch-invariant-mode" in train_args
     assert "--no-bias-swiglu-fusion" in train_args
     assert "--no-rope-fusion" in train_args
-    assert "--sequence-parallel" not in train_args
+    assert "--sequence-parallel" in train_args
     assert env_vars["NCCL_ALGO"] == "Ring"
     assert env_vars["NCCL_NVLS_ENABLE"] == "0"
     assert env_vars["NVTE_ALLOW_NONDETERMINISTIC_ALGO"] == "0"

--- a/tests/fast/utils/test_arguments.py
+++ b/tests/fast/utils/test_arguments.py
@@ -182,6 +182,7 @@ def test_true_on_policy_args_propagate_to_sglang_server_args(
         seed=7,
         offload_rollout=False,
         num_gpus_per_node=8,
+        colocate=False,
         use_rollout_routing_replay=False,
         fp16=False,
     )
@@ -195,6 +196,7 @@ def test_true_on_policy_args_propagate_to_sglang_server_args(
         nccl_port=12346,
         host="127.0.0.1",
         port=30000,
+        base_gpu_id=0,
     )
 
     assert args.sglang_enable_deterministic_inference is True
@@ -203,8 +205,28 @@ def test_true_on_policy_args_propagate_to_sglang_server_args(
     assert "rl_on_policy_target" not in server_args
     assert server_args["true_on_policy_contract"] == "qwen3_dense_true_on_policy_v1"
     assert server_args["enable_deterministic_inference"] is True
-    assert server_args["enable_prefill_only_deterministic_inference"] is False
+    assert server_args.get("enable_prefill_only_deterministic_inference", False) is False
     assert server_args["enable_dp_lm_head"] is False
+
+
+def test_true_on_policy_moe_rejects_sglang_moe_tp_mismatch():
+    args = SimpleNamespace(
+        rollout_num_gpus_per_engine=4,
+        sglang_data_parallel_size=1,
+        sglang_pipeline_parallel_size=1,
+        sglang_expert_parallel_size=2,
+        sglang_enable_dp_attention=False,
+        sglang_router_policy=None,
+        sglang_router_ip=None,
+        true_on_policy_mode=True,
+        recompute_logprobs_via_prefill=False,
+        sglang_enable_deterministic_inference=False,
+        num_experts=128,
+        expert_tensor_parallel_size=1,
+    )
+
+    with pytest.raises(ValueError, match="SGLang MoE TP to match Megatron"):
+        sglang_validate_args(args)
 
 
 def test_true_on_policy_sglang_cp_dp_lm_head_overrides_engine_defaults():
@@ -223,6 +245,7 @@ def test_true_on_policy_sglang_cp_dp_lm_head_overrides_engine_defaults():
         seed=7,
         offload_rollout=False,
         num_gpus_per_node=8,
+        colocate=False,
         use_rollout_routing_replay=False,
         fp16=False,
     )
@@ -234,7 +257,7 @@ def test_true_on_policy_sglang_cp_dp_lm_head_overrides_engine_defaults():
         nccl_port=12346,
         host="127.0.0.1",
         port=30000,
-        sglang_overrides={"enable_dp_lm_head": False},
+        base_gpu_id=0,
     )
 
     assert server_args["enable_dp_lm_head"] is True

--- a/tests/fast/utils/test_arguments.py
+++ b/tests/fast/utils/test_arguments.py
@@ -209,26 +209,6 @@ def test_true_on_policy_args_propagate_to_sglang_server_args(
     assert server_args["enable_dp_lm_head"] is False
 
 
-def test_true_on_policy_moe_rejects_sglang_moe_tp_mismatch():
-    args = SimpleNamespace(
-        rollout_num_gpus_per_engine=4,
-        sglang_data_parallel_size=1,
-        sglang_pipeline_parallel_size=1,
-        sglang_expert_parallel_size=2,
-        sglang_enable_dp_attention=False,
-        sglang_router_policy=None,
-        sglang_router_ip=None,
-        true_on_policy_mode=True,
-        recompute_logprobs_via_prefill=False,
-        sglang_enable_deterministic_inference=False,
-        num_experts=128,
-        expert_tensor_parallel_size=1,
-    )
-
-    with pytest.raises(ValueError, match="SGLang MoE TP to match Megatron"):
-        sglang_validate_args(args)
-
-
 def test_true_on_policy_sglang_cp_dp_lm_head_overrides_engine_defaults():
     args = SimpleNamespace(
         rollout_num_gpus_per_engine=8,

--- a/tools/convert_hf_to_torch_dist.py
+++ b/tools/convert_hf_to_torch_dist.py
@@ -1,6 +1,7 @@
 import gc
 import os
 import shutil
+import sys
 
 import torch
 import torch.distributed as dist
@@ -36,6 +37,11 @@ def add_convertion_args(parser):
 
 
 def get_args():
+    pipeline_parallel_explicit = any(
+        arg == "--pipeline-model-parallel-size"
+        or arg.startswith("--pipeline-model-parallel-size=")
+        for arg in sys.argv[1:]
+    )
     args = parse_args(add_convertion_args)
     args = set_default_megatron_args(args)
 
@@ -53,7 +59,11 @@ def get_args():
     def ceildiv(a, b):
         return -(a // -b)
 
-    if args.pipeline_model_parallel_size == 1 and world_size > 1:
+    if (
+        args.pipeline_model_parallel_size == 1
+        and world_size > 1
+        and not pipeline_parallel_explicit
+    ):
         pp_size = world_size
         while True:
             args.pipeline_model_parallel_size = pp_size


### PR DESCRIPTION
Stacked on top of radixark/miles#1059.

## Summary

Adds the Miles/orchestration side of the Qwen3-30B-A3B MoE SP+PP true-on-policy stack.

This PR is one of three coupled PRs that should be reviewed and landed together because they extend the `qwen3_moe_true_on_policy_v1` contract to allow Megatron sequence parallel and pipeline parallel training while preserving exact SGLang rollout parity.

**Companion PRs:**
- SGLang: https://github.com/sgl-project/sglang/pull/26317
- Megatron-LM: https://github.com/radixark/Megatron-LM/pull/31

**Split-out cleanup:**
- Remove prefill-logprob recomputation path: https://github.com/radixark/miles/pull/1192

## Main Changes

- Add `_sync_before_rank_subset_logging` in the actor train loop for true-on-policy TP/PP rank-subset logging.
- Add topology-specific raw torch-dist checkpoint conversion/load paths for Qwen3 MoE TP/PP/EP/ETP runs.
- Wire SP/PP options through true-on-policy config, model profile, schema, scripts, checkpoint conversion, and launch fixtures.
- Deduplicate Qwen3 MoE rollout TP/EP topology validation into the true-on-policy config validator.
- Keep the validated SP+PP path on raw torch-dist loading; bridge-mode monkey patches and defensive/debug-only cleanup code were removed from this PR.

## Validation

Cleaned 8-GPU ion7 real-workload run:

- Run id: `moe_sppp_pr_tp2_pp2_ep2_onpolicy_real3_cleaned_noci_nosave_260524_ion7`
- Ray job: `raysubmit_a9NCtiu6K5dRVCsc`
- Topology: Megatron `TP=2`, `PP=2`, `EP=2`, `ETP=1`, sequence parallel enabled; SGLang 4 rollout engines, each `TP=2`, `EP=2`.
- Result: Ray job succeeded, all 8 GPUs returned to `0 MiB`.
- Step 1: `train/train_rollout_logprob_abs_diff=0.0`, `train/train_rollout_kl=0.0`, `grad_norm=0.0377418305`, weight version `1.0`, mixed version `0.0`.
- Step 2: `train/train_rollout_logprob_abs_diff=0.0`, `train/train_rollout_kl=0.0`, `grad_norm=0.0389085777`, weight version `2.0`, mixed version `0.0`.
- Timing: cleaned step times `485.2571s` and `462.8948s`, about `2.6-2.9%` slower than the previous on-policy no-debug timing run and in the same overhead band versus off-policy.

Focused checks after cleanup:

- [x] `git diff --check`
- [x] `python -m py_compile` over changed Python files after splitting out prefill recomputation removal
- [x] Miles fast checks: `53 passed` before the PR split
- [x] Megatron targeted extension/MoE checks: `3 passed`
- [x] Megatron 8-rank tensor-parallel mapping check passed on all ranks
- [x] Full SP+PP 8-GPU E2E exact-logprob rerun on ion7

Local record:
`recovery/qwen3_moe_sppp_clean/journal/2026-05-23-sppp-e2e.md`
