### PR TITLE
chore: [lora] avoid merge adapter weights

### DIFF
--- a/miles/backends/megatron_utils/update_weight/hf_weight_iterator_bridge.py
+++ b/miles/backends/megatron_utils/update_weight/hf_weight_iterator_bridge.py
@@ -34,12 +34,13 @@ class HfWeightIteratorBridge(HfWeightIteratorBase):
                     self.model,
                     cpu=False,
                     conversion_tasks=conversion_tasks,
+                    merge_adapter_weights=False,
                 )
 
             # TODO: verify if postprocess_hf_param is needed for LoRA weights
             named_weights = (
                 (
-                    hf_param_name,
+                    hf_param_name.replace(".base_layer.", "."),
                     postprocess_hf_param(
                         args=self.args,
                         megatron_param_name=megatron_param_name,

--- a/miles/backends/megatron_utils/update_weight/hf_weight_iterator_bridge.py
+++ b/miles/backends/megatron_utils/update_weight/hf_weight_iterator_bridge.py
@@ -44,7 +44,7 @@ class HfWeightIteratorBridge(HfWeightIteratorBase):
                     postprocess_hf_param(
                         args=self.args,
                         megatron_param_name=megatron_param_name,
-                        hf_param_name=hf_param_name,
+                        hf_param_name=hf_param_name.replace(".base_layer.", "."),
                         param=weight,
                     ),
                 )


### PR DESCRIPTION
follow up of this PR: https://github.com/radixark/miles/pull/1087
due to the hf param name changes after disable merge_adapter_weights, need to remove the ".base_layer." part so that it can be successfully synced to sglang.