### PR TITLE
[tiny-refac] TITO: drop prompt token ids response dup

### DIFF
--- a/miles/rollout/generate_utils/openai_endpoint_utils.py
+++ b/miles/rollout/generate_utils/openai_endpoint_utils.py
@@ -115,7 +115,7 @@ def compute_samples_from_openai_records(
 
     for i, record in enumerate(records):
         is_last = i == len(records) - 1
-        prompt_ids = record.response["choices"][0]["prompt_token_ids"]
+        prompt_ids = record.request["input_ids"]
         output_ids = [t[1] for t in record.response["choices"][0]["meta_info"]["output_token_logprobs"]]
 
         trim_count = 0
@@ -165,21 +165,14 @@ def _compute_sample_from_openai_record(
 ) -> Sample:
     choice = record.response["choices"][0]
 
-    if "prompt_token_ids" in choice:
-        prompt_token_ids = choice["prompt_token_ids"]
-    else:
-        raise ValueError("prompt_token_ids not found in response choice — the session server should populate it")
+    prompt_token_ids = record.request.get("input_ids")
+    if prompt_token_ids is None:
+        raise ValueError("input_ids not found in request — the session server should populate it")
 
     output_token_ids = [item[1] for item in choice["meta_info"]["output_token_logprobs"]]
     output_log_probs = [item[0] for item in choice["meta_info"]["output_token_logprobs"]]
 
     sample = deepcopy(input_sample)
-    request_input_ids = record.request.get("input_ids")
-    if request_input_ids is not None:
-        assert (
-            request_input_ids == prompt_token_ids
-        ), "for prompt part, input_ids return by sglang should match with the request input_ids"
-
     sample.tokens = prompt_token_ids + output_token_ids
     sample.rollout_log_probs = output_log_probs
     sample.response = tokenizer.decode(output_token_ids)

--- a/miles/rollout/session/sessions.py
+++ b/miles/rollout/session/sessions.py
@@ -192,9 +192,6 @@ def setup_session_routes(app, backend, args):
                     "an empty content rather than None. Please check your modified SGLang version."
                 )
 
-            choice["prompt_token_ids"] = prompt_token_ids
-            # This must be re-encoded to return the prompt token ids
-            result["response_body"] = json.dumps(response).encode()
             output_token_logprobs = meta_info["output_token_logprobs"]
             completion_tokens = meta_info["completion_tokens"]
 

--- a/tests/e2e/sglang/utils/logprob_verify_generate.py
+++ b/tests/e2e/sglang/utils/logprob_verify_generate.py
@@ -241,7 +241,7 @@ async def _verify_logprobs_via_reprefill(
     ``input_token_logprobs`` (single prefill pass) against per-turn
     ``output_token_logprobs`` (incremental decode) from session records.
     """
-    first_prompt_len = len(records[0].response["choices"][0]["prompt_token_ids"])
+    first_prompt_len = len(records[0].request["input_ids"])
 
     # ── A: send re-prefill request ──
     payload = {
@@ -272,7 +272,7 @@ async def _verify_logprobs_via_reprefill(
     for i, record in enumerate(records):
         is_last = i == len(records) - 1
         choice = record.response["choices"][0]
-        prompt_ids = choice["prompt_token_ids"]
+        prompt_ids = record.request["input_ids"]
         session_output_logprobs = choice["meta_info"]["output_token_logprobs"]
         output_ids = [t[1] for t in session_output_logprobs]
 
@@ -370,7 +370,7 @@ def _verify_routed_experts(
 
     for i, record in enumerate(records):
         choice = record.response["choices"][0]
-        prompt_ids = choice["prompt_token_ids"]
+        prompt_ids = record.request["input_ids"]
         output_logprobs = choice["meta_info"]["output_token_logprobs"]
         output_ids = [t[1] for t in output_logprobs]
 

--- a/tests/fast/rollout/generate_utils/test_openai_endpoint_utils.py
+++ b/tests/fast/rollout/generate_utils/test_openai_endpoint_utils.py
@@ -82,11 +82,10 @@ def _make_record(
         method="POST",
         path="/v1/chat/completions",
         status_code=200,
-        request={"messages": [{"role": "user", "content": "hello"}]},
+        request={"messages": [{"role": "user", "content": "hello"}], "input_ids": prompt_token_ids},
         response={
             "choices": [
                 {
-                    "prompt_token_ids": prompt_token_ids,
                     "message": {"role": "assistant", "content": "response"},
                     "finish_reason": finish_reason,
                     "logprobs": {"content": logprobs_content},

--- a/tests/fast/router/test_session_pretokenized_e2e.py
+++ b/tests/fast/router/test_session_pretokenized_e2e.py
@@ -141,7 +141,6 @@ def test_bundled_fixed_template_session_smoke(config: FixedTemplateSmokeConfig):
 
             body = response.json()
             assert len(body["choices"]) == 1
-            assert "prompt_token_ids" in body["choices"][0]
             if turn_idx > 0:
                 assert "input_ids" in backend.request_log[turn_idx], f"{config.name} turn {turn_idx} missing input_ids"
 

--- a/tests/fast/router/test_sessions.py
+++ b/tests/fast/router/test_sessions.py
@@ -132,8 +132,6 @@ class TestSessionProxy:
         body = resp.json()
         assert "choices" in body
         assert body["choices"]
-        assert isinstance(body["choices"][0]["prompt_token_ids"], list)
-        assert body["choices"][0]["prompt_token_ids"]
 
         get_resp = requests.get(f"{router_env.url}/sessions/{session_id}", timeout=5.0)
         records = get_resp.json()["records"]


### PR DESCRIPTION
Original `session.py` relies on `return_prompt_token_ids` to get prompt part token ids, but now we don't rely on this flag any more. Change some code path to make it fit current TITO wkld.