### PR TITLE
ci: fix ci-sglang-pr and ci-megatron-pr input

### DIFF
--- a/.github/workflows/_run-ci.yml
+++ b/.github/workflows/_run-ci.yml
@@ -95,7 +95,7 @@ jobs:
           resolve_fetch_ref() {
             local ref="$1"
             if [[ "$ref" =~ ^#([0-9]+)$ ]]; then
-              echo "refs/pull/${BASH_REMATCH[1]}/head"
+              echo "pull/${BASH_REMATCH[1]}/head"
             else
               echo "$ref"
             fi
@@ -181,7 +181,7 @@ jobs:
           resolve_fetch_ref() {
             local ref="$1"
             if [[ "$ref" =~ ^#([0-9]+)$ ]]; then
-              echo "refs/pull/${BASH_REMATCH[1]}/head"
+              echo "pull/${BASH_REMATCH[1]}/head"
             else
               echo "$ref"
             fi

--- a/.github/workflows/_run-ci.yml
+++ b/.github/workflows/_run-ci.yml
@@ -85,8 +85,8 @@ jobs:
           MEGATRON_PR="${INPUT_MEGATRON_PR}"
           SGLANG_PR="${INPUT_SGLANG_PR}"
           if [ -n "$PR_BODY" ]; then
-            PR_MEGATRON_PR=$(echo "$PR_BODY" | grep -oP '(?<=ci-megatron-pr:\s)\S+' || true)
-            PR_SGLANG_PR=$(echo "$PR_BODY" | grep -oP '(?<=ci-sglang-pr:\s)\S+' || true)
+            PR_MEGATRON_PR=$(echo "$PR_BODY" | grep -m1 -oP '^ci-megatron-pr:\s+\K\S+' || true)
+            PR_SGLANG_PR=$(echo "$PR_BODY" | grep -m1 -oP '^ci-sglang-pr:\s+\K\S+' || true)
             [ -z "$MEGATRON_PR" ] && [ -n "$PR_MEGATRON_PR" ] && MEGATRON_PR="$PR_MEGATRON_PR"
             [ -z "$SGLANG_PR" ] && [ -n "$PR_SGLANG_PR" ] && SGLANG_PR="$PR_SGLANG_PR"
           fi
@@ -95,7 +95,7 @@ jobs:
           resolve_fetch_ref() {
             local ref="$1"
             if [[ "$ref" =~ ^#([0-9]+)$ ]]; then
-              echo "pull/${BASH_REMATCH[1]}/head"
+              echo "refs/pull/${BASH_REMATCH[1]}/head"
             else
               echo "$ref"
             fi
@@ -171,8 +171,8 @@ jobs:
           MEGATRON_PR="${INPUT_MEGATRON_PR}"
           SGLANG_PR="${INPUT_SGLANG_PR}"
           if [ -n "$PR_BODY" ]; then
-            PR_MEGATRON_PR=$(echo "$PR_BODY" | grep -oP '(?<=ci-megatron-pr:\s)\S+' || true)
-            PR_SGLANG_PR=$(echo "$PR_BODY" | grep -oP '(?<=ci-sglang-pr:\s)\S+' || true)
+            PR_MEGATRON_PR=$(echo "$PR_BODY" | grep -m1 -oP '^ci-megatron-pr:\s+\K\S+' || true)
+            PR_SGLANG_PR=$(echo "$PR_BODY" | grep -m1 -oP '^ci-sglang-pr:\s+\K\S+' || true)
             [ -z "$MEGATRON_PR" ] && [ -n "$PR_MEGATRON_PR" ] && MEGATRON_PR="$PR_MEGATRON_PR"
             [ -z "$SGLANG_PR" ] && [ -n "$PR_SGLANG_PR" ] && SGLANG_PR="$PR_SGLANG_PR"
           fi
@@ -181,7 +181,7 @@ jobs:
           resolve_fetch_ref() {
             local ref="$1"
             if [[ "$ref" =~ ^#([0-9]+)$ ]]; then
-              echo "pull/${BASH_REMATCH[1]}/head"
+              echo "refs/pull/${BASH_REMATCH[1]}/head"
             else
               echo "$ref"
             fi

--- a/.github/workflows/_run-ci.yml
+++ b/.github/workflows/_run-ci.yml
@@ -9,6 +9,22 @@ on:
       execute_command:
         type: string
         required: true
+      infinite_run:
+        type: boolean
+        required: false
+        default: false
+      ci_megatron_pr:
+        type: string
+        required: false
+        default: ''
+      ci_sglang_pr:
+        type: string
+        required: false
+        default: ''
+      pr_body:
+        type: string
+        required: false
+        default: ''
       runs_on:
         type: string
         required: false
@@ -55,7 +71,7 @@ jobs:
       PYTHONPATH: ${{ github.workspace }}
       GITHUB_COMMIT_NAME: ${{ github.sha }}_${{ github.event.pull_request.number || 'non-pr' }}
       WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}
-      MILES_TEST_ENABLE_INFINITE_RUN: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.infinite_run) || 'false' }}
+      MILES_TEST_ENABLE_INFINITE_RUN: ${{ inputs.infinite_run }}
       MILES_TEST_FEW_GPU: '0'
     steps:
       - name: Checkout repository
@@ -78,9 +94,9 @@ jobs:
         id: resolve-refs
         shell: bash
         env:
-          PR_BODY: ${{ github.event.pull_request.body || '' }}
-          INPUT_MEGATRON_PR: ${{ github.event.inputs.ci_megatron_pr || '' }}
-          INPUT_SGLANG_PR: ${{ github.event.inputs.ci_sglang_pr || '' }}
+          PR_BODY: ${{ inputs.pr_body }}
+          INPUT_MEGATRON_PR: ${{ inputs.ci_megatron_pr }}
+          INPUT_SGLANG_PR: ${{ inputs.ci_sglang_pr }}
         run: |
           MEGATRON_PR="${INPUT_MEGATRON_PR}"
           SGLANG_PR="${INPUT_SGLANG_PR}"
@@ -95,7 +111,7 @@ jobs:
           resolve_fetch_ref() {
             local ref="$1"
             if [[ "$ref" =~ ^#([0-9]+)$ ]]; then
-              echo "pull/${BASH_REMATCH[1]}/head"
+              echo "refs/pull/${BASH_REMATCH[1]}/head"
             else
               echo "$ref"
             fi
@@ -160,18 +176,50 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v5
 
+      - name: Resolve dependency refs
+        id: resolve-refs
+        shell: bash
+        env:
+          PR_BODY: ${{ inputs.pr_body }}
+          INPUT_MEGATRON_PR: ${{ inputs.ci_megatron_pr }}
+          INPUT_SGLANG_PR: ${{ inputs.ci_sglang_pr }}
+        run: |
+          MEGATRON_PR="${INPUT_MEGATRON_PR}"
+          SGLANG_PR="${INPUT_SGLANG_PR}"
+          if [ -n "$PR_BODY" ]; then
+            PR_MEGATRON_PR=$(echo "$PR_BODY" | grep -oP '(?<=ci-megatron-pr:\s)\S+' || true)
+            PR_SGLANG_PR=$(echo "$PR_BODY" | grep -oP '(?<=ci-sglang-pr:\s)\S+' || true)
+            [ -z "$MEGATRON_PR" ] && [ -n "$PR_MEGATRON_PR" ] && MEGATRON_PR="$PR_MEGATRON_PR"
+            [ -z "$SGLANG_PR" ] && [ -n "$PR_SGLANG_PR" ] && SGLANG_PR="$PR_SGLANG_PR"
+          fi
+          [ -z "$MEGATRON_PR" ] && MEGATRON_PR="miles-main"
+          [ -z "$SGLANG_PR" ] && SGLANG_PR="sglang-miles"
+          resolve_fetch_ref() {
+            local ref="$1"
+            if [[ "$ref" =~ ^#([0-9]+)$ ]]; then
+              echo "refs/pull/${BASH_REMATCH[1]}/head"
+            else
+              echo "$ref"
+            fi
+          }
+          MEGATRON_FETCH=$(resolve_fetch_ref "$MEGATRON_PR")
+          SGLANG_FETCH=$(resolve_fetch_ref "$SGLANG_PR")
+          echo "ci_megatron_pr=$MEGATRON_FETCH" >> $GITHUB_OUTPUT
+          echo "ci_sglang_pr=$SGLANG_FETCH" >> $GITHUB_OUTPUT
+          echo "Resolved: megatron=$MEGATRON_PR -> fetch=$MEGATRON_FETCH, sglang=$SGLANG_PR -> fetch=$SGLANG_FETCH"
+
       - name: Checkout sglang
         uses: actions/checkout@v4
         with:
           repository: sgl-project/sglang
-          ref: sglang-miles
+          ref: ${{ steps.resolve-refs.outputs.ci_sglang_pr }}
           path: sglang
 
       - name: Checkout Megatron-LM
         uses: actions/checkout@v4
         with:
           repository: radixark/Megatron-LM
-          ref: miles-main
+          ref: ${{ steps.resolve-refs.outputs.ci_megatron_pr }}
           path: Megatron-LM
 
       - name: Install dependencies

--- a/.github/workflows/_run-ci.yml
+++ b/.github/workflows/_run-ci.yml
@@ -9,22 +9,6 @@ on:
       execute_command:
         type: string
         required: true
-      infinite_run:
-        type: boolean
-        required: false
-        default: false
-      ci_megatron_pr:
-        type: string
-        required: false
-        default: ''
-      ci_sglang_pr:
-        type: string
-        required: false
-        default: ''
-      pr_body:
-        type: string
-        required: false
-        default: ''
       runs_on:
         type: string
         required: false
@@ -71,7 +55,7 @@ jobs:
       PYTHONPATH: ${{ github.workspace }}
       GITHUB_COMMIT_NAME: ${{ github.sha }}_${{ github.event.pull_request.number || 'non-pr' }}
       WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}
-      MILES_TEST_ENABLE_INFINITE_RUN: ${{ inputs.infinite_run }}
+      MILES_TEST_ENABLE_INFINITE_RUN: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.infinite_run) || 'false' }}
       MILES_TEST_FEW_GPU: '0'
     steps:
       - name: Checkout repository
@@ -94,9 +78,9 @@ jobs:
         id: resolve-refs
         shell: bash
         env:
-          PR_BODY: ${{ inputs.pr_body }}
-          INPUT_MEGATRON_PR: ${{ inputs.ci_megatron_pr }}
-          INPUT_SGLANG_PR: ${{ inputs.ci_sglang_pr }}
+          PR_BODY: ${{ github.event.pull_request.body || '' }}
+          INPUT_MEGATRON_PR: ${{ github.event.inputs.ci_megatron_pr || '' }}
+          INPUT_SGLANG_PR: ${{ github.event.inputs.ci_sglang_pr || '' }}
         run: |
           MEGATRON_PR="${INPUT_MEGATRON_PR}"
           SGLANG_PR="${INPUT_SGLANG_PR}"
@@ -180,9 +164,9 @@ jobs:
         id: resolve-refs
         shell: bash
         env:
-          PR_BODY: ${{ inputs.pr_body }}
-          INPUT_MEGATRON_PR: ${{ inputs.ci_megatron_pr }}
-          INPUT_SGLANG_PR: ${{ inputs.ci_sglang_pr }}
+          PR_BODY: ${{ github.event.pull_request.body || '' }}
+          INPUT_MEGATRON_PR: ${{ github.event.inputs.ci_megatron_pr || '' }}
+          INPUT_SGLANG_PR: ${{ github.event.inputs.ci_sglang_pr || '' }}
         run: |
           MEGATRON_PR="${INPUT_MEGATRON_PR}"
           SGLANG_PR="${INPUT_SGLANG_PR}"

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -35,6 +35,10 @@ jobs:
     with:
       gpu_count: 0
       cpu_runner: true
+      infinite_run: ${{ inputs.infinite_run || false }}
+      ci_megatron_pr: ${{ inputs.ci_megatron_pr || '' }}
+      ci_sglang_pr: ${{ inputs.ci_sglang_pr || '' }}
+      pr_body: ${{ github.event.pull_request.body || '' }}
       execute_command: "python tests/ci/run_suite.py --hw cpu --suite stage-a-fast"
     secrets: inherit
 
@@ -46,12 +50,17 @@ jobs:
     uses: ./.github/workflows/_run-ci.yml
     with:
       gpu_count: 8
+      infinite_run: ${{ inputs.infinite_run || false }}
+      ci_megatron_pr: ${{ inputs.ci_megatron_pr || '' }}
+      ci_sglang_pr: ${{ inputs.ci_sglang_pr || '' }}
+      pr_body: ${{ github.event.pull_request.body || '' }}
       execute_command: "pytest tests/e2e/fsdp/test_qwen3_4B_fsdp_true_on_policy.py -x -v"
     secrets: inherit
 
   # Stage B: Fast GPU tests (1 GPU, runs every PR)
   # For fast tests that require GPU (e.g. deterministic inference paths that
-  # pull in flash_attn). Parallel with stage-b-sglang; one self-hosted daemon slot.
+  # pull in flash_attn). This can start in parallel with stage-b-sglang at the
+  # workflow level; gpu_lock_exec gates actual GPU access on the runner.
   stage-b-fast-gpu:
     needs: [stage-a-fast]
     if: |
@@ -60,6 +69,10 @@ jobs:
     uses: ./.github/workflows/_run-ci.yml
     with:
       gpu_count: 1
+      infinite_run: ${{ inputs.infinite_run || false }}
+      ci_megatron_pr: ${{ inputs.ci_megatron_pr || '' }}
+      ci_sglang_pr: ${{ inputs.ci_sglang_pr || '' }}
+      pr_body: ${{ github.event.pull_request.body || '' }}
       execute_command: "python tests/ci/run_suite.py --hw cuda --suite stage-b-fast-1-gpu"
     secrets: inherit
 
@@ -72,6 +85,10 @@ jobs:
     uses: ./.github/workflows/_run-ci.yml
     with:
       gpu_count: 1
+      infinite_run: ${{ inputs.infinite_run || false }}
+      ci_megatron_pr: ${{ inputs.ci_megatron_pr || '' }}
+      ci_sglang_pr: ${{ inputs.ci_sglang_pr || '' }}
+      pr_body: ${{ github.event.pull_request.body || '' }}
       execute_command: "python tests/ci/run_suite.py --hw cuda --suite stage-b-sglang-1-gpu"
     secrets: inherit
 
@@ -84,6 +101,10 @@ jobs:
     uses: ./.github/workflows/_run-ci.yml
     with:
       gpu_count: 8
+      infinite_run: ${{ inputs.infinite_run || false }}
+      ci_megatron_pr: ${{ inputs.ci_megatron_pr || '' }}
+      ci_sglang_pr: ${{ inputs.ci_sglang_pr || '' }}
+      pr_body: ${{ github.event.pull_request.body || '' }}
       execute_command: "python tests/ci/run_suite.py --hw cuda --suite stage-b-short-8-gpu"
     secrets: inherit
 
@@ -96,6 +117,10 @@ jobs:
     uses: ./.github/workflows/_run-ci.yml
     with:
       gpu_count: 8
+      infinite_run: ${{ inputs.infinite_run || false }}
+      ci_megatron_pr: ${{ inputs.ci_megatron_pr || '' }}
+      ci_sglang_pr: ${{ inputs.ci_sglang_pr || '' }}
+      pr_body: ${{ github.event.pull_request.body || '' }}
       execute_command: "python tests/ci/run_suite.py --hw cuda --suite stage-c-fsdp-8-gpu"
     secrets: inherit
 
@@ -112,6 +137,10 @@ jobs:
     uses: ./.github/workflows/_run-ci.yml
     with:
       gpu_count: 8
+      infinite_run: ${{ inputs.infinite_run || false }}
+      ci_megatron_pr: ${{ inputs.ci_megatron_pr || '' }}
+      ci_sglang_pr: ${{ inputs.ci_sglang_pr || '' }}
+      pr_body: ${{ github.event.pull_request.body || '' }}
       execute_command: "python tests/ci/run_suite.py --hw cuda --suite stage-c-megatron-8-gpu --auto-partition-id ${{ matrix.partition_id }} --auto-partition-size 3"
     secrets: inherit
 
@@ -124,6 +153,10 @@ jobs:
     uses: ./.github/workflows/_run-ci.yml
     with:
       gpu_count: 8
+      infinite_run: ${{ inputs.infinite_run || false }}
+      ci_megatron_pr: ${{ inputs.ci_megatron_pr || '' }}
+      ci_sglang_pr: ${{ inputs.ci_sglang_pr || '' }}
+      pr_body: ${{ github.event.pull_request.body || '' }}
       execute_command: "python tests/ci/run_suite.py --hw cuda --suite stage-c-precision-8-gpu"
     secrets: inherit
 
@@ -136,6 +169,10 @@ jobs:
     uses: ./.github/workflows/_run-ci.yml
     with:
       gpu_count: 8
+      infinite_run: ${{ inputs.infinite_run || false }}
+      ci_megatron_pr: ${{ inputs.ci_megatron_pr || '' }}
+      ci_sglang_pr: ${{ inputs.ci_sglang_pr || '' }}
+      pr_body: ${{ github.event.pull_request.body || '' }}
       execute_command: "python tests/ci/run_suite.py --hw cuda --suite stage-c-ckpt-8-gpu"
     secrets: inherit
 
@@ -148,6 +185,10 @@ jobs:
     uses: ./.github/workflows/_run-ci.yml
     with:
       gpu_count: 8
+      infinite_run: ${{ inputs.infinite_run || false }}
+      ci_megatron_pr: ${{ inputs.ci_megatron_pr || '' }}
+      ci_sglang_pr: ${{ inputs.ci_sglang_pr || '' }}
+      pr_body: ${{ github.event.pull_request.body || '' }}
       execute_command: "python tests/ci/run_suite.py --hw cuda --suite stage-c-long-8-gpu"
     secrets: inherit
 
@@ -160,6 +201,10 @@ jobs:
     uses: ./.github/workflows/_run-ci.yml
     with:
       gpu_count: 8
+      infinite_run: ${{ inputs.infinite_run || false }}
+      ci_megatron_pr: ${{ inputs.ci_megatron_pr || '' }}
+      ci_sglang_pr: ${{ inputs.ci_sglang_pr || '' }}
+      pr_body: ${{ github.event.pull_request.body || '' }}
       execute_command: "python tests/ci/run_suite.py --hw cuda --suite stage-c-lora-8-gpu"
     secrets: inherit
 
@@ -174,7 +219,11 @@ jobs:
       gpu_count: 8
       container_image: "radixark/miles:glm5"
       skip_dependency_install: true
-      execute_command: "python tests/ci/gpu_lock_exec.py --count 8 -- python tests/e2e/megatron/test_glm5_744b_a40b_4layer.py"
+      infinite_run: ${{ inputs.infinite_run || false }}
+      ci_megatron_pr: ${{ inputs.ci_megatron_pr || '' }}
+      ci_sglang_pr: ${{ inputs.ci_sglang_pr || '' }}
+      pr_body: ${{ github.event.pull_request.body || '' }}
+      execute_command: "python tests/e2e/megatron/test_glm5_744b_a40b_4layer.py"
     secrets: inherit
 
   # Stage C: All suites (triggered by run-ci-image label)
@@ -197,5 +246,9 @@ jobs:
     uses: ./.github/workflows/_run-ci.yml
     with:
       gpu_count: 8
+      infinite_run: ${{ inputs.infinite_run || false }}
+      ci_megatron_pr: ${{ inputs.ci_megatron_pr || '' }}
+      ci_sglang_pr: ${{ inputs.ci_sglang_pr || '' }}
+      pr_body: ${{ github.event.pull_request.body || '' }}
       execute_command: "python tests/ci/run_suite.py --hw cuda --suite ${{ matrix.suite }}"
     secrets: inherit

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -35,10 +35,6 @@ jobs:
     with:
       gpu_count: 0
       cpu_runner: true
-      infinite_run: ${{ inputs.infinite_run || false }}
-      ci_megatron_pr: ${{ inputs.ci_megatron_pr || '' }}
-      ci_sglang_pr: ${{ inputs.ci_sglang_pr || '' }}
-      pr_body: ${{ github.event.pull_request.body || '' }}
       execute_command: "python tests/ci/run_suite.py --hw cpu --suite stage-a-fast"
     secrets: inherit
 
@@ -50,17 +46,12 @@ jobs:
     uses: ./.github/workflows/_run-ci.yml
     with:
       gpu_count: 8
-      infinite_run: ${{ inputs.infinite_run || false }}
-      ci_megatron_pr: ${{ inputs.ci_megatron_pr || '' }}
-      ci_sglang_pr: ${{ inputs.ci_sglang_pr || '' }}
-      pr_body: ${{ github.event.pull_request.body || '' }}
       execute_command: "pytest tests/e2e/fsdp/test_qwen3_4B_fsdp_true_on_policy.py -x -v"
     secrets: inherit
 
   # Stage B: Fast GPU tests (1 GPU, runs every PR)
   # For fast tests that require GPU (e.g. deterministic inference paths that
-  # pull in flash_attn). This can start in parallel with stage-b-sglang at the
-  # workflow level; gpu_lock_exec gates actual GPU access on the runner.
+  # pull in flash_attn). Parallel with stage-b-sglang; one self-hosted daemon slot.
   stage-b-fast-gpu:
     needs: [stage-a-fast]
     if: |
@@ -69,10 +60,6 @@ jobs:
     uses: ./.github/workflows/_run-ci.yml
     with:
       gpu_count: 1
-      infinite_run: ${{ inputs.infinite_run || false }}
-      ci_megatron_pr: ${{ inputs.ci_megatron_pr || '' }}
-      ci_sglang_pr: ${{ inputs.ci_sglang_pr || '' }}
-      pr_body: ${{ github.event.pull_request.body || '' }}
       execute_command: "python tests/ci/run_suite.py --hw cuda --suite stage-b-fast-1-gpu"
     secrets: inherit
 
@@ -85,10 +72,6 @@ jobs:
     uses: ./.github/workflows/_run-ci.yml
     with:
       gpu_count: 1
-      infinite_run: ${{ inputs.infinite_run || false }}
-      ci_megatron_pr: ${{ inputs.ci_megatron_pr || '' }}
-      ci_sglang_pr: ${{ inputs.ci_sglang_pr || '' }}
-      pr_body: ${{ github.event.pull_request.body || '' }}
       execute_command: "python tests/ci/run_suite.py --hw cuda --suite stage-b-sglang-1-gpu"
     secrets: inherit
 
@@ -101,10 +84,6 @@ jobs:
     uses: ./.github/workflows/_run-ci.yml
     with:
       gpu_count: 8
-      infinite_run: ${{ inputs.infinite_run || false }}
-      ci_megatron_pr: ${{ inputs.ci_megatron_pr || '' }}
-      ci_sglang_pr: ${{ inputs.ci_sglang_pr || '' }}
-      pr_body: ${{ github.event.pull_request.body || '' }}
       execute_command: "python tests/ci/run_suite.py --hw cuda --suite stage-b-short-8-gpu"
     secrets: inherit
 
@@ -117,10 +96,6 @@ jobs:
     uses: ./.github/workflows/_run-ci.yml
     with:
       gpu_count: 8
-      infinite_run: ${{ inputs.infinite_run || false }}
-      ci_megatron_pr: ${{ inputs.ci_megatron_pr || '' }}
-      ci_sglang_pr: ${{ inputs.ci_sglang_pr || '' }}
-      pr_body: ${{ github.event.pull_request.body || '' }}
       execute_command: "python tests/ci/run_suite.py --hw cuda --suite stage-c-fsdp-8-gpu"
     secrets: inherit
 
@@ -137,10 +112,6 @@ jobs:
     uses: ./.github/workflows/_run-ci.yml
     with:
       gpu_count: 8
-      infinite_run: ${{ inputs.infinite_run || false }}
-      ci_megatron_pr: ${{ inputs.ci_megatron_pr || '' }}
-      ci_sglang_pr: ${{ inputs.ci_sglang_pr || '' }}
-      pr_body: ${{ github.event.pull_request.body || '' }}
       execute_command: "python tests/ci/run_suite.py --hw cuda --suite stage-c-megatron-8-gpu --auto-partition-id ${{ matrix.partition_id }} --auto-partition-size 3"
     secrets: inherit
 
@@ -153,10 +124,6 @@ jobs:
     uses: ./.github/workflows/_run-ci.yml
     with:
       gpu_count: 8
-      infinite_run: ${{ inputs.infinite_run || false }}
-      ci_megatron_pr: ${{ inputs.ci_megatron_pr || '' }}
-      ci_sglang_pr: ${{ inputs.ci_sglang_pr || '' }}
-      pr_body: ${{ github.event.pull_request.body || '' }}
       execute_command: "python tests/ci/run_suite.py --hw cuda --suite stage-c-precision-8-gpu"
     secrets: inherit
 
@@ -169,10 +136,6 @@ jobs:
     uses: ./.github/workflows/_run-ci.yml
     with:
       gpu_count: 8
-      infinite_run: ${{ inputs.infinite_run || false }}
-      ci_megatron_pr: ${{ inputs.ci_megatron_pr || '' }}
-      ci_sglang_pr: ${{ inputs.ci_sglang_pr || '' }}
-      pr_body: ${{ github.event.pull_request.body || '' }}
       execute_command: "python tests/ci/run_suite.py --hw cuda --suite stage-c-ckpt-8-gpu"
     secrets: inherit
 
@@ -185,10 +148,6 @@ jobs:
     uses: ./.github/workflows/_run-ci.yml
     with:
       gpu_count: 8
-      infinite_run: ${{ inputs.infinite_run || false }}
-      ci_megatron_pr: ${{ inputs.ci_megatron_pr || '' }}
-      ci_sglang_pr: ${{ inputs.ci_sglang_pr || '' }}
-      pr_body: ${{ github.event.pull_request.body || '' }}
       execute_command: "python tests/ci/run_suite.py --hw cuda --suite stage-c-long-8-gpu"
     secrets: inherit
 
@@ -201,10 +160,6 @@ jobs:
     uses: ./.github/workflows/_run-ci.yml
     with:
       gpu_count: 8
-      infinite_run: ${{ inputs.infinite_run || false }}
-      ci_megatron_pr: ${{ inputs.ci_megatron_pr || '' }}
-      ci_sglang_pr: ${{ inputs.ci_sglang_pr || '' }}
-      pr_body: ${{ github.event.pull_request.body || '' }}
       execute_command: "python tests/ci/run_suite.py --hw cuda --suite stage-c-lora-8-gpu"
     secrets: inherit
 
@@ -219,11 +174,7 @@ jobs:
       gpu_count: 8
       container_image: "radixark/miles:glm5"
       skip_dependency_install: true
-      infinite_run: ${{ inputs.infinite_run || false }}
-      ci_megatron_pr: ${{ inputs.ci_megatron_pr || '' }}
-      ci_sglang_pr: ${{ inputs.ci_sglang_pr || '' }}
-      pr_body: ${{ github.event.pull_request.body || '' }}
-      execute_command: "python tests/e2e/megatron/test_glm5_744b_a40b_4layer.py"
+      execute_command: "python tests/ci/gpu_lock_exec.py --count 8 -- python tests/e2e/megatron/test_glm5_744b_a40b_4layer.py"
     secrets: inherit
 
   # Stage C: All suites (triggered by run-ci-image label)
@@ -246,9 +197,5 @@ jobs:
     uses: ./.github/workflows/_run-ci.yml
     with:
       gpu_count: 8
-      infinite_run: ${{ inputs.infinite_run || false }}
-      ci_megatron_pr: ${{ inputs.ci_megatron_pr || '' }}
-      ci_sglang_pr: ${{ inputs.ci_sglang_pr || '' }}
-      pr_body: ${{ github.event.pull_request.body || '' }}
       execute_command: "python tests/ci/run_suite.py --hw cuda --suite ${{ matrix.suite }}"
     secrets: inherit


### PR DESCRIPTION
1. The refactor PR #677 make `run-cpu:` failed to inject `ci-sglang-pr` and `ci-megatron-pr` 
2. Accept  `ci-sglang-pr` and `ci-megatron-pr` only at the begining line of PR descriptions.