### PR TITLE
[CI] tito-logprob: restore qwen3 / glm47 family sweep via CONFIGS loop

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -76,7 +76,7 @@ jobs:
       execute_command: "python tests/ci/run_suite.py --hw cuda --suite stage-b-fast-1-gpu"
     secrets: inherit
 
-  # Stage B: SGLang patch tests (1 GPU)
+  # Stage B: SGLang patch tests (8 GPU)
   stage-b-sglang:
     needs: [stage-a-fast]
     if: |
@@ -84,12 +84,12 @@ jobs:
       ((github.event_name == 'workflow_dispatch') || (github.event.pull_request && contains(github.event.pull_request.labels.*.name, 'run-ci-sglang')))
     uses: ./.github/workflows/_run-ci.yml
     with:
-      gpu_count: 1
+      gpu_count: 8
       infinite_run: ${{ inputs.infinite_run || false }}
       ci_megatron_pr: ${{ inputs.ci_megatron_pr || '' }}
       ci_sglang_pr: ${{ inputs.ci_sglang_pr || '' }}
       pr_body: ${{ github.event.pull_request.body || '' }}
-      execute_command: "python tests/ci/run_suite.py --hw cuda --suite stage-b-sglang-1-gpu"
+      execute_command: "python tests/ci/run_suite.py --hw cuda --suite stage-b-sglang-8-gpu"
     secrets: inherit
 
   # Stage B: Short 8-GPU tests

--- a/tests/ci/run_suite.py
+++ b/tests/ci/run_suite.py
@@ -17,7 +17,7 @@ PER_COMMIT_SUITES = {
         "stage-a-fast",
     ],
     HWBackend.CUDA: [
-        "stage-b-sglang-1-gpu",
+        "stage-b-sglang-8-gpu",
         "stage-b-fast-1-gpu",
         "stage-b-short-8-gpu",
         "stage-c-fsdp-8-gpu",

--- a/tests/e2e/sglang/test_chat_input_ids_equivalence.py
+++ b/tests/e2e/sglang/test_chat_input_ids_equivalence.py
@@ -7,7 +7,7 @@ from tests.ci.ci_register import register_cuda_ci
 from tests.e2e.sglang.utils.sglang_server import start_sglang_server
 from transformers import AutoTokenizer
 
-register_cuda_ci(est_time=300, suite="stage-b-sglang-1-gpu", num_gpus=1)
+register_cuda_ci(est_time=300, suite="stage-b-sglang-8-gpu", num_gpus=8)
 
 MODEL_PATH = os.environ.get("SGLANG_E2E_MODEL_PATH", "Qwen/Qwen3-0.6B")
 SEED = 1234

--- a/tests/e2e/sglang/test_r3_router_equivalence.py
+++ b/tests/e2e/sglang/test_r3_router_equivalence.py
@@ -1,6 +1,6 @@
 from tests.ci.ci_register import register_cuda_ci
 
-register_cuda_ci(est_time=600, suite="stage-b-sglang-1-gpu", num_gpus=1)
+register_cuda_ci(est_time=600, suite="stage-b-sglang-8-gpu", num_gpus=8)
 
 """E2E test: verify sglang router and miles router produce identical rollout
 routing replay results across MoE models.
@@ -38,9 +38,10 @@ loaded.  This lets us get away with a single H200 and no
 Controls
 ~~~~~~~~
 - ``ROUTER_EQ_MODEL_FAMILY``: ``qwen3_30b_a3b`` (default) | ``glm47_flash``.
-- Single H200, bf16, rollout batch 10, num_rollout 1. Single engine
-  (``--rollout-num-gpus-per-engine 1``) so both variants hit the same
-  underlying sglang process topology.
+- The CI suite reserves 8 GPUs to avoid sharing the runner with another GPU
+  job while this SGLang/Ray process tree is alive. The test workload itself
+  still uses a single engine (``--rollout-num-gpus-per-engine 1``) so both
+  variants hit the same underlying sglang process topology.
 """
 
 import base64

--- a/tests/e2e/sglang/test_tito_logprob_equivalence.py
+++ b/tests/e2e/sglang/test_tito_logprob_equivalence.py
@@ -15,12 +15,14 @@ Uses the same infrastructure as ``test_session_server_tool_call``:
 ``execute_train --debug-rollout-only`` with a custom generate function
 that wraps the normal agentic flow with re-prefill verification.
 
-Requires 1 GPU.
+The CI suite reserves 8 GPUs to avoid sharing the runner with another GPU job
+while this SGLang/Ray process tree is alive. The test workload itself still
+uses one GPU by default.
 """
 
 from tests.ci.ci_register import register_cuda_ci
 
-register_cuda_ci(est_time=600, suite="stage-b-sglang-1-gpu", num_gpus=1)
+register_cuda_ci(est_time=600, suite="stage-b-sglang-8-gpu", num_gpus=8)
 
 
 import json

--- a/tests/e2e/sglang/test_tito_logprob_equivalence.py
+++ b/tests/e2e/sglang/test_tito_logprob_equivalence.py
@@ -15,6 +15,11 @@ Uses the same infrastructure as ``test_session_server_tool_call``:
 ``execute_train --debug-rollout-only`` with a custom generate function
 that wraps the normal agentic flow with re-prefill verification.
 
+In CI, the file runs every model in :data:`CONFIGS` back-to-back so both
+qwen3 and glm47 paths are covered by a single job. The ``CONFIGS`` default
+can be overridden by setting ``SESSION_TEST_MODEL_FAMILY`` to a single
+family name, which is handy when debugging locally.
+
 The CI suite reserves 8 GPUs to avoid sharing the runner with another GPU job
 while this SGLang/Ray process tree is alive. The test workload itself still
 uses one GPU by default.
@@ -22,7 +27,9 @@ uses one GPU by default.
 
 from tests.ci.ci_register import register_cuda_ci
 
-register_cuda_ci(est_time=600, suite="stage-b-sglang-8-gpu", num_gpus=8)
+# Two model families run sequentially in one job, so est_time is roughly 2x
+# of a single family.
+register_cuda_ci(est_time=1200, suite="stage-b-sglang-8-gpu", num_gpus=8)
 
 
 import json
@@ -34,7 +41,6 @@ import miles.utils.external_utils.command_utils as U
 # Model family registry
 # ---------------------------------------------------------------------------
 
-MODEL_FAMILY = os.environ.get("SESSION_TEST_MODEL_FAMILY", "qwen3")
 ENABLE_R3 = os.environ.get("ENABLE_R3", "0") == "1"
 
 
@@ -63,17 +69,28 @@ MODEL_REGISTRY: dict[str, ModelConfig] = {
     ),
 }
 
+# Default CI sweep. ``SESSION_TEST_MODEL_FAMILY`` (single family) overrides
+# this list, primarily for local debugging.
+CONFIGS: list[str] = ["qwen3", "glm47"]
+
 PROMPT_DATA_PATH = "/root/datasets/session_logprob_verify.jsonl"
 
 
-def _get_config() -> ModelConfig:
-    if MODEL_FAMILY not in MODEL_REGISTRY:
-        raise ValueError(f"Unknown model family {MODEL_FAMILY!r}. " f"Choose from: {list(MODEL_REGISTRY.keys())}")
-    return MODEL_REGISTRY[MODEL_FAMILY]
+def _resolve_configs() -> list[str]:
+    override = os.environ.get("SESSION_TEST_MODEL_FAMILY")
+    if override:
+        return [override]
+    return list(CONFIGS)
 
 
-def prepare():
-    cfg = _get_config()
+def _get_config(model_family: str) -> ModelConfig:
+    if model_family not in MODEL_REGISTRY:
+        raise ValueError(f"Unknown model family {model_family!r}. " f"Choose from: {list(MODEL_REGISTRY.keys())}")
+    return MODEL_REGISTRY[model_family]
+
+
+def prepare(model_family: str):
+    cfg = _get_config(model_family)
     U.exec_command("mkdir -p /root/models /root/datasets")
     U.exec_command(f"hf download {cfg.model_name} --local-dir /root/models/{cfg.model_name.split('/')[-1]}")
 
@@ -101,8 +118,8 @@ def prepare():
             f.write(json.dumps(p) + "\n")
 
 
-def execute():
-    cfg = _get_config()
+def execute(model_family: str):
+    cfg = _get_config(model_family)
     local_model_dir = f"/root/models/{cfg.model_name.split('/')[-1]}"
 
     ckpt_args = f"--hf-checkpoint {local_model_dir} "
@@ -159,15 +176,21 @@ def execute():
     )
 
 
-def test_tito_logprob_equivalence():
-    prepare()
+def _run_all():
     for proxy_var in ("http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY"):
         os.environ.pop(proxy_var, None)
-    execute()
+    for model_family in _resolve_configs():
+        print(
+            f"\n{'=' * 60}\nRunning model_family: {model_family}\n{'=' * 60}\n",
+            flush=True,
+        )
+        prepare(model_family)
+        execute(model_family)
+
+
+def test_tito_logprob_equivalence():
+    _run_all()
 
 
 if __name__ == "__main__":
-    prepare()
-    for proxy_var in ("http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY"):
-        os.environ.pop(proxy_var, None)
-    execute()
+    _run_all()


### PR DESCRIPTION
## Why

The old j2-generated \`pr-test.yml\` dispatched this test twice via \`strategy.matrix.info\`: once with \`SESSION_TEST_MODEL_FAMILY=qwen3\`, once with \`SESSION_TEST_MODEL_FAMILY=glm47\`. The new \`run_suite.py\` framework has no variant dimension — every test is a single \`(suite, num_gpus, est_time)\` triple — so the \`glm47\` variant has been silently dropped since the CI refactor.

## What

Restore coverage by sweeping \`CONFIGS=[\"qwen3\", \"glm47\"]\` inside the test file itself, the same in-file loop pattern already used by \`test_qwen3_30B_A3B_r3.py\`. \`SESSION_TEST_MODEL_FAMILY\` now becomes a single-family override, primarily for local debugging.

- \`MODEL_FAMILY\` module constant → \`CONFIGS\` list + \`_resolve_configs\` helper.
- \`prepare\` / \`execute\` / \`_get_config\` now take \`model_family\` as a parameter instead of reading it from the module-level constant.
- \`__main__\` loops over \`_resolve_configs()\`: \`prepare(fam)\` + \`execute(fam)\` per family.
- \`est_time\` bumped 600 → 1200 since two families run sequentially in one job.

## Verification

Real GPU runs (4× H200 free locally):

- \`SESSION_TEST_MODEL_FAMILY=glm47 python tests/e2e/sglang/test_tito_logprob_equivalence.py\` — 16 samples, \`Logprob diff mean=0.000000\`, \`tito_session_mismatch_rate=0.0\`, Ray job succeeded.
- \`SESSION_TEST_MODEL_FAMILY=qwen3 python tests/e2e/sglang/test_tito_logprob_equivalence.py\` — same: 16 samples, all zero diff.
- Full CONFIGS loop (no override) — both families ran back-to-back in one process, 32 samples total verified zero diff, both Ray jobs succeeded. Sglang + Ray teardown between configs is handled by \`execute_train\`'s built-in \`pkill -9 sglang; ray stop --force\` at the start of each call.

## Stacked PR

Base: pr/2-ci-stage-b-sglang-8gpu (#1107). Depends on the 8-GPU suite rename being in place; otherwise this register would not match any active suite.