### PR TITLE
[CI] qwen3-30B-A3B: restore 4-variant matrix sweep via CONFIGS loop

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -76,7 +76,7 @@ jobs:
       execute_command: "python tests/ci/run_suite.py --hw cuda --suite stage-b-fast-1-gpu"
     secrets: inherit
 
-  # Stage B: SGLang patch tests (1 GPU)
+  # Stage B: SGLang patch tests (8 GPU)
   stage-b-sglang:
     needs: [stage-a-fast]
     if: |
@@ -84,12 +84,12 @@ jobs:
       ((github.event_name == 'workflow_dispatch') || (github.event.pull_request && contains(github.event.pull_request.labels.*.name, 'run-ci-sglang')))
     uses: ./.github/workflows/_run-ci.yml
     with:
-      gpu_count: 1
+      gpu_count: 8
       infinite_run: ${{ inputs.infinite_run || false }}
       ci_megatron_pr: ${{ inputs.ci_megatron_pr || '' }}
       ci_sglang_pr: ${{ inputs.ci_sglang_pr || '' }}
       pr_body: ${{ github.event.pull_request.body || '' }}
-      execute_command: "python tests/ci/run_suite.py --hw cuda --suite stage-b-sglang-1-gpu"
+      execute_command: "python tests/ci/run_suite.py --hw cuda --suite stage-b-sglang-8-gpu"
     secrets: inherit
 
   # Stage B: Short 8-GPU tests

--- a/tests/ci/run_suite.py
+++ b/tests/ci/run_suite.py
@@ -17,7 +17,7 @@ PER_COMMIT_SUITES = {
         "stage-a-fast",
     ],
     HWBackend.CUDA: [
-        "stage-b-sglang-1-gpu",
+        "stage-b-sglang-8-gpu",
         "stage-b-fast-1-gpu",
         "stage-b-short-8-gpu",
         "stage-c-fsdp-8-gpu",

--- a/tests/e2e/megatron/test_qwen3_30B_A3B.py
+++ b/tests/e2e/megatron/test_qwen3_30B_A3B.py
@@ -4,25 +4,57 @@ from tests.ci.ci_register import register_cuda_ci
 
 import miles.utils.external_utils.command_utils as U
 
-register_cuda_ci(est_time=900, suite="stage-c-megatron-8-gpu", num_gpus=8)
+# Sweeps four rollout / dispatcher variants in one job (deepep+fp8, bridge,
+# bf16, int4) so the previously matrix-parameterized CI is back. est_time is
+# roughly 4x of a single variant.
+register_cuda_ci(est_time=3600, suite="stage-c-megatron-8-gpu", num_gpus=8)
 
 ENABLE_EVAL = bool(int(os.environ.get("MILES_TEST_ENABLE_EVAL", "1")))
 TIGHT_HOST_MEMORY = bool(int(os.environ.get("MILES_TEST_TIGHT_HOST_MEMORY", "1")))
-USE_DEEPEP = True
-USE_FP8_ROLLOUT = True
-USE_INT4_ROLLOUT = False
 
 MODEL_NAME = "Qwen3-30B-A3B"
 MODEL_TYPE = "qwen3-30B-A3B"
 NUM_GPUS = 8
 
+# Each entry is one matrix variant from the legacy parameterized job.
+CONFIGS: list[dict] = [
+    {
+        "USE_DEEPEP": True,
+        "USE_FP8_ROLLOUT": True,
+        "USE_INT4_ROLLOUT": False,
+        "USE_BRIDGE": False,
+    },
+    {
+        "USE_DEEPEP": True,
+        "USE_FP8_ROLLOUT": True,
+        "USE_INT4_ROLLOUT": False,
+        "USE_BRIDGE": True,
+    },
+    {
+        "USE_DEEPEP": False,
+        "USE_FP8_ROLLOUT": False,
+        "USE_INT4_ROLLOUT": False,
+        "USE_BRIDGE": False,
+    },
+    {
+        "USE_DEEPEP": False,
+        "USE_FP8_ROLLOUT": False,
+        "USE_INT4_ROLLOUT": True,
+        "USE_BRIDGE": False,
+    },
+]
+
+
+def _any_config(key: str) -> bool:
+    return any(c[key] for c in CONFIGS)
+
 
 def prepare():
     U.exec_command("mkdir -p /root/models /root/datasets")
     U.exec_command("hf download Qwen/Qwen3-30B-A3B --local-dir /root/models/Qwen3-30B-A3B")
-    if USE_FP8_ROLLOUT:
+    if _any_config("USE_FP8_ROLLOUT"):
         U.exec_command("hf download Qwen/Qwen3-30B-A3B-FP8 --local-dir /root/models/Qwen3-30B-A3B-FP8")
-    if USE_INT4_ROLLOUT:
+    if _any_config("USE_INT4_ROLLOUT"):
         U.exec_command(
             f"python tools/convert_hf_to_int4_direct.py "
             f"--model-dir /root/models/{MODEL_NAME} "
@@ -31,16 +63,25 @@ def prepare():
     U.hf_download_dataset("zhuzilin/dapo-math-17k")
     U.hf_download_dataset("zhuzilin/aime-2024")
 
-    U.convert_checkpoint(model_name=MODEL_NAME, megatron_model_type=MODEL_TYPE, num_gpus_per_node=NUM_GPUS)
+    # Bridge mode reads the HF checkpoint directly without the torch_dist
+    # conversion, but every non-bridge variant needs it, so do the conversion
+    # if any variant requires it.
+    if not all(c["USE_BRIDGE"] for c in CONFIGS):
+        U.convert_checkpoint(
+            model_name=MODEL_NAME,
+            megatron_model_type=MODEL_TYPE,
+            num_gpus_per_node=NUM_GPUS,
+        )
 
 
-def execute():
+def execute(USE_DEEPEP: bool, USE_FP8_ROLLOUT: bool, USE_INT4_ROLLOUT: bool, USE_BRIDGE: bool):
+    ref_load = f"/root/models/{MODEL_NAME}" if USE_BRIDGE else f"/root/{MODEL_NAME}_torch_dist"
     if USE_INT4_ROLLOUT:
-        ckpt_args = f"--hf-checkpoint /root/models/{MODEL_NAME}-INT4/ " f"--ref-load /root/{MODEL_NAME}_torch_dist "
+        ckpt_args = f"--hf-checkpoint /root/models/{MODEL_NAME}-INT4/ " f"--ref-load {ref_load} "
     elif USE_FP8_ROLLOUT:
-        ckpt_args = f"--hf-checkpoint /root/models/{MODEL_NAME}-FP8 " f"--ref-load /root/{MODEL_NAME}_torch_dist "
+        ckpt_args = f"--hf-checkpoint /root/models/{MODEL_NAME}-FP8 " f"--ref-load {ref_load} "
     else:
-        ckpt_args = f"--hf-checkpoint /root/models/{MODEL_NAME} " f"--ref-load /root/{MODEL_NAME}_torch_dist "
+        ckpt_args = f"--hf-checkpoint /root/models/{MODEL_NAME} " f"--ref-load {ref_load} "
 
     rollout_args = (
         "--prompt-data /root/datasets/dapo-math-17k/dapo-math-17k.jsonl "
@@ -137,6 +178,9 @@ def execute():
         "--colocate "
     )
 
+    if USE_BRIDGE:
+        misc_args += "--megatron-to-hf-mode bridge "
+
     if USE_DEEPEP:
         misc_args += "--moe-token-dispatcher-type flex --moe-enable-deepep "
     else:
@@ -171,8 +215,9 @@ def execute():
 
 
 if __name__ == "__main__":
-    # TODO also use typer
     prepare()
     for proxy_var in ("http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY"):
         os.environ.pop(proxy_var, None)
-    execute()
+    for config in CONFIGS:
+        print(f"\n{'=' * 60}\nRunning config: {config}\n{'=' * 60}\n", flush=True)
+        execute(**config)

--- a/tests/e2e/sglang/test_chat_input_ids_equivalence.py
+++ b/tests/e2e/sglang/test_chat_input_ids_equivalence.py
@@ -7,7 +7,7 @@ from tests.ci.ci_register import register_cuda_ci
 from tests.e2e.sglang.utils.sglang_server import start_sglang_server
 from transformers import AutoTokenizer
 
-register_cuda_ci(est_time=300, suite="stage-b-sglang-1-gpu", num_gpus=1)
+register_cuda_ci(est_time=300, suite="stage-b-sglang-8-gpu", num_gpus=8)
 
 MODEL_PATH = os.environ.get("SGLANG_E2E_MODEL_PATH", "Qwen/Qwen3-0.6B")
 SEED = 1234

--- a/tests/e2e/sglang/test_r3_router_equivalence.py
+++ b/tests/e2e/sglang/test_r3_router_equivalence.py
@@ -1,6 +1,6 @@
 from tests.ci.ci_register import register_cuda_ci
 
-register_cuda_ci(est_time=600, suite="stage-b-sglang-1-gpu", num_gpus=1)
+register_cuda_ci(est_time=600, suite="stage-b-sglang-8-gpu", num_gpus=8)
 
 """E2E test: verify sglang router and miles router produce identical rollout
 routing replay results across MoE models.
@@ -38,9 +38,10 @@ loaded.  This lets us get away with a single H200 and no
 Controls
 ~~~~~~~~
 - ``ROUTER_EQ_MODEL_FAMILY``: ``qwen3_30b_a3b`` (default) | ``glm47_flash``.
-- Single H200, bf16, rollout batch 10, num_rollout 1. Single engine
-  (``--rollout-num-gpus-per-engine 1``) so both variants hit the same
-  underlying sglang process topology.
+- The CI suite reserves 8 GPUs to avoid sharing the runner with another GPU
+  job while this SGLang/Ray process tree is alive. The test workload itself
+  still uses a single engine (``--rollout-num-gpus-per-engine 1``) so both
+  variants hit the same underlying sglang process topology.
 """
 
 import base64

--- a/tests/e2e/sglang/test_tito_logprob_equivalence.py
+++ b/tests/e2e/sglang/test_tito_logprob_equivalence.py
@@ -15,12 +15,14 @@ Uses the same infrastructure as ``test_session_server_tool_call``:
 ``execute_train --debug-rollout-only`` with a custom generate function
 that wraps the normal agentic flow with re-prefill verification.
 
-Requires 1 GPU.
+The CI suite reserves 8 GPUs to avoid sharing the runner with another GPU job
+while this SGLang/Ray process tree is alive. The test workload itself still
+uses one GPU by default.
 """
 
 from tests.ci.ci_register import register_cuda_ci
 
-register_cuda_ci(est_time=600, suite="stage-b-sglang-1-gpu", num_gpus=1)
+register_cuda_ci(est_time=600, suite="stage-b-sglang-8-gpu", num_gpus=8)
 
 
 import json


### PR DESCRIPTION
## Why

The old matrix ran this test as four variants — \`deepep+fp8\`, \`bridge\`, \`bf16\`, \`rollout-int4\` — driven by \`MILES_TEST_USE_DEEPEP\` / \`USE_FP8_ROLLOUT\` / \`USE_INT4_ROLLOUT\` / \`USE_BRIDGE\` env injection. After the CI refactor the test file had \`USE_DEEPEP\` / \`USE_FP8_ROLLOUT\` hardcoded to \`True\` at module level and never read the env, so only one variant was actually being exercised.

## What

Replace the module-level constants with \`CONFIGS=[...]\` (4 entries) and a parameterized \`execute(USE_DEEPEP, USE_FP8_ROLLOUT, USE_INT4_ROLLOUT, USE_BRIDGE)\`. Restore the \`--megatron-to-hf-mode bridge\` flag for the bridge variant (lost in a prior cleanup, making the bridge variant identical to deepep+fp8).

\`prepare\` now only downloads / converts what at least one variant requires (FP8 weights for variant 0/1, INT4 conversion for variant 3, torch_dist conversion for variants 0/2/3 — skipped only if every variant is bridge-mode).

\`est_time\` bumped 900 → 3600 (4 variants in one job).

## Variant table

| # | DEEPEP | FP8_ROLLOUT | INT4_ROLLOUT | BRIDGE | replaces matrix name |
|---|---|---|---|---|---|
| 0 | ✓ | ✓ |   |   | qwen3-30B-A3B-deepep-fp8 |
| 1 | ✓ | ✓ |   | ✓ | qwen3-30B-A3B-bridge |
| 2 |   |   |   |   | qwen3-30B-A3B-bf16 |
| 3 |   |   | ✓ |   | qwen3-30B-A3B-rollout-int4 |

## Verification

Not run locally — needs 8 GPUs exclusively, ~4 hours for the full sweep, and Qwen3-30B-A3B + Qwen3-30B-A3B-FP8 (~120 GB total) are not in \`/cluster-storage/models\`. CI is the right place to exercise this.

The argument-capture smoke (\`monkey-patch execute_train\` to dump \`train_args\` per variant) confirmed the 4 variants produce distinct, correct training argument strings — different \`--hf-checkpoint\` / \`--ref-load\` / \`--moe-token-dispatcher-type\` / \`--moe-enable-deepep\` / \`--megatron-to-hf-mode\` / \`OPEN_TRAINING_INT4_*\` env per variant as expected.

## Stacked PR

Base: pr/2-ci-stage-b-sglang-8gpu (#1107). The suite (stage-c-megatron-8-gpu) is unchanged, but the branch is rebased onto pr/2 to keep the PR series consistent.