### PR TITLE
[CI] glm47-flash-ckpt: run save + async_save back-to-back

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -76,7 +76,7 @@ jobs:
       execute_command: "python tests/ci/run_suite.py --hw cuda --suite stage-b-fast-1-gpu"
     secrets: inherit
 
-  # Stage B: SGLang patch tests (1 GPU)
+  # Stage B: SGLang patch tests (8 GPU)
   stage-b-sglang:
     needs: [stage-a-fast]
     if: |
@@ -84,12 +84,12 @@ jobs:
       ((github.event_name == 'workflow_dispatch') || (github.event.pull_request && contains(github.event.pull_request.labels.*.name, 'run-ci-sglang')))
     uses: ./.github/workflows/_run-ci.yml
     with:
-      gpu_count: 1
+      gpu_count: 8
       infinite_run: ${{ inputs.infinite_run || false }}
       ci_megatron_pr: ${{ inputs.ci_megatron_pr || '' }}
       ci_sglang_pr: ${{ inputs.ci_sglang_pr || '' }}
       pr_body: ${{ github.event.pull_request.body || '' }}
-      execute_command: "python tests/ci/run_suite.py --hw cuda --suite stage-b-sglang-1-gpu"
+      execute_command: "python tests/ci/run_suite.py --hw cuda --suite stage-b-sglang-8-gpu"
     secrets: inherit
 
   # Stage B: Short 8-GPU tests

--- a/tests/ci/run_suite.py
+++ b/tests/ci/run_suite.py
@@ -17,7 +17,7 @@ PER_COMMIT_SUITES = {
         "stage-a-fast",
     ],
     HWBackend.CUDA: [
-        "stage-b-sglang-1-gpu",
+        "stage-b-sglang-8-gpu",
         "stage-b-fast-1-gpu",
         "stage-b-short-8-gpu",
         "stage-c-fsdp-8-gpu",

--- a/tests/e2e/ckpt/test_glm47_flash_ckpt.py
+++ b/tests/e2e/ckpt/test_glm47_flash_ckpt.py
@@ -1,11 +1,12 @@
 import os
-from argparse import ArgumentParser
 
 from tests.ci.ci_register import register_cuda_ci
 
 import miles.utils.external_utils.command_utils as U
 
-register_cuda_ci(est_time=1200, suite="stage-c-ckpt-8-gpu", num_gpus=8)
+# Covers two ckpt modes back-to-back in one job (save + async_save, each
+# followed by a load roundtrip), so est_time is roughly 2x of a single mode.
+register_cuda_ci(est_time=2400, suite="stage-c-ckpt-8-gpu", num_gpus=8)
 
 
 ENABLE_EVAL = bool(int(os.environ.get("MILES_TEST_ENABLE_EVAL", "1")))
@@ -15,10 +16,6 @@ USE_DEEPEP = bool(int(os.environ.get("MILES_TEST_USE_DEEPEP", "0")))
 MODEL_NAME = "GLM-4.7-Flash"
 MODEL_TYPE = "glm4.7-flash"
 NUM_GPUS = 8
-
-
-parser = ArgumentParser()
-parser.add_argument("--async-save", action="store_true", help="Whether to test async save/load.")
 
 
 def _get_latest_checkpointed_iteration() -> int:
@@ -184,10 +181,10 @@ def execute(mode: str = "", ckpt_step: int | None = None):
 
 
 if __name__ == "__main__":
-    args = parser.parse_args()
     prepare()
     for proxy_var in ("http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY"):
         os.environ.pop(proxy_var, None)
-    execute("save" if not args.async_save else "async_save")
-    latest_step = _get_latest_checkpointed_iteration()
-    execute("load", ckpt_step=latest_step)
+    execute("save")
+    execute("load", ckpt_step=_get_latest_checkpointed_iteration())
+    execute("async_save")
+    execute("load", ckpt_step=_get_latest_checkpointed_iteration())

--- a/tests/e2e/sglang/test_chat_input_ids_equivalence.py
+++ b/tests/e2e/sglang/test_chat_input_ids_equivalence.py
@@ -7,7 +7,7 @@ from tests.ci.ci_register import register_cuda_ci
 from tests.e2e.sglang.utils.sglang_server import start_sglang_server
 from transformers import AutoTokenizer
 
-register_cuda_ci(est_time=300, suite="stage-b-sglang-1-gpu", num_gpus=1)
+register_cuda_ci(est_time=300, suite="stage-b-sglang-8-gpu", num_gpus=8)
 
 MODEL_PATH = os.environ.get("SGLANG_E2E_MODEL_PATH", "Qwen/Qwen3-0.6B")
 SEED = 1234

--- a/tests/e2e/sglang/test_r3_router_equivalence.py
+++ b/tests/e2e/sglang/test_r3_router_equivalence.py
@@ -1,6 +1,6 @@
 from tests.ci.ci_register import register_cuda_ci
 
-register_cuda_ci(est_time=600, suite="stage-b-sglang-1-gpu", num_gpus=1)
+register_cuda_ci(est_time=600, suite="stage-b-sglang-8-gpu", num_gpus=8)
 
 """E2E test: verify sglang router and miles router produce identical rollout
 routing replay results across MoE models.
@@ -38,9 +38,10 @@ loaded.  This lets us get away with a single H200 and no
 Controls
 ~~~~~~~~
 - ``ROUTER_EQ_MODEL_FAMILY``: ``qwen3_30b_a3b`` (default) | ``glm47_flash``.
-- Single H200, bf16, rollout batch 10, num_rollout 1. Single engine
-  (``--rollout-num-gpus-per-engine 1``) so both variants hit the same
-  underlying sglang process topology.
+- The CI suite reserves 8 GPUs to avoid sharing the runner with another GPU
+  job while this SGLang/Ray process tree is alive. The test workload itself
+  still uses a single engine (``--rollout-num-gpus-per-engine 1``) so both
+  variants hit the same underlying sglang process topology.
 """
 
 import base64

--- a/tests/e2e/sglang/test_tito_logprob_equivalence.py
+++ b/tests/e2e/sglang/test_tito_logprob_equivalence.py
@@ -15,12 +15,14 @@ Uses the same infrastructure as ``test_session_server_tool_call``:
 ``execute_train --debug-rollout-only`` with a custom generate function
 that wraps the normal agentic flow with re-prefill verification.
 
-Requires 1 GPU.
+The CI suite reserves 8 GPUs to avoid sharing the runner with another GPU job
+while this SGLang/Ray process tree is alive. The test workload itself still
+uses one GPU by default.
 """
 
 from tests.ci.ci_register import register_cuda_ci
 
-register_cuda_ci(est_time=600, suite="stage-b-sglang-1-gpu", num_gpus=1)
+register_cuda_ci(est_time=600, suite="stage-b-sglang-8-gpu", num_gpus=8)
 
 
 import json


### PR DESCRIPTION
## Why

The old matrix dispatched this file twice — once without \`--async-save\`, once with — via \`test_file\` argv injection. The new \`run_suite.py\` framework drives each test as \`python3 <file>\` with no argv, so only the synchronous \`save\` mode was running.

## What

Mirror the \`test_qwen3_4B_ckpt.py\` pattern: drop the \`argparse\` and run \`save → load → async_save → load\` sequentially in one process. Both ckpt modes now share one model download / one runner.

\`est_time\` bumped 1200 → 2400 (two ckpt-mode roundtrips instead of one).

## Verification

Not run locally — needs 8 GPUs exclusively + ~120 GB \`_torch_dist\` disk write for the megatron→fsdp conversion. CI is the right place.

The argument-capture smoke confirmed all four \`execute()\` calls produce the expected \`train_args\`: \`save\` with \`--save-interval 2\` + \`--ci-save-model-hash\`, \`load\` with \`--ckpt-step <N>\` + \`--ci-check-model-hash\`, \`async_save\` with the additional \`--async-save\` + \`--use-persistent-ckpt-worker\` flags.

## Stacked PR

Base: pr/2-ci-stage-b-sglang-8gpu (#1107). The suite (stage-c-ckpt-8-gpu) is unchanged, but the branch is rebased onto pr/2 to keep the PR series consistent.