### PR TITLE
Fix aarch64 editable wheel platform tag

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,18 @@ from setuptools import find_packages, setup
 from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
 
 
+def _get_platform_tag():
+    if platform.system() != "Linux":
+        return platform.system().lower()
+
+    machine = platform.machine().lower()
+    if machine in ("x86_64", "amd64"):
+        return "manylinux1_x86_64"
+    if machine in ("aarch64", "arm64"):
+        return "manylinux2014_aarch64"
+    return f"linux_{machine}"
+
+
 def _fetch_requirements(path):
     with open(path) as fd:
         return [r.strip() for r in fd.readlines() if r.strip() and not r.startswith("#")]
@@ -19,11 +31,7 @@ class bdist_wheel(_bdist_wheel):
     def get_tag(self):
         python_version = f"cp{sys.version_info.major}{sys.version_info.minor}"
         abi_tag = f"{python_version}"
-
-        if platform.system() == "Linux":
-            platform_tag = "manylinux1_x86_64"
-        else:
-            platform_tag = platform.system().lower()
+        platform_tag = _get_platform_tag()
 
         return python_version, abi_tag, platform_tag
 


### PR DESCRIPTION
## Summary
- Detect the Linux machine architecture when generating the Miles wheel platform tag.
- Preserve the existing x86_64/amd64 tag behavior.
- Emit `manylinux2014_aarch64` for arm64/aarch64 editable wheels.

## Why
GB300/arm64 image builds fail under `uv pip install --system --break-system-packages --no-deps -e .` because the editable Miles wheel is tagged `manylinux1_x86_64` on aarch64. `pip install -e . --no-deps` tolerates the bad tag, but uv rejects it as incompatible with the aarch64 manylinux environment.

## Validation
- Checked the platform tag helper for x86_64, amd64, aarch64, and arm64.
- Verified `uv pip install --system --break-system-packages --no-deps -e .` succeeds in a GB300/aarch64 container using the patched repo.
