### PR TITLE
Add ROCm support for CI test_qwen3_4B_ckpt

### DIFF
--- a/miles/backends/megatron_utils/ci_utils.py
+++ b/miles/backends/megatron_utils/ci_utils.py
@@ -169,11 +169,13 @@ def check_peak_gpu_memory_after_load(args) -> None:
         return
 
     # Threshold 20 GB is midpoint between ~16.9 GB (with) and ~22.4 GB (without) on 8xH200.
+    # ROCm async 4+4 config uses TP=1,CP=1 (full model per GPU), so ~34 GB is expected.
     peak_gpu_gb = torch.cuda.max_memory_allocated() / (1024**3)
     rank = torch.distributed.get_rank() if torch.distributed.is_initialized() else 0
     logger.info(f"[CI low-memory-resume] Rank {rank} peak GPU memory: {peak_gpu_gb:.2f} GB")
 
-    threshold_gb = 20.0
+    is_rocm = hasattr(torch.version, "hip") and torch.version.hip is not None
+    threshold_gb = 40.0 if is_rocm else 20.0
     assert peak_gpu_gb < threshold_gb, (
         f"[Rank {rank}] Peak GPU memory ({peak_gpu_gb:.2f} GB) exceeds threshold ({threshold_gb} GB). "
         f"--low-memory-resume optimization may not be working correctly."

--- a/miles/backends/training_utils/ci_utils.py
+++ b/miles/backends/training_utils/ci_utils.py
@@ -19,7 +19,9 @@ def check_kl(args: Namespace, log_dict: dict[str, float], step_id: int, accumula
             # small floating-point differences, so use a relaxed threshold.
             assert abs(log_dict["train/ppo_kl"]) < 1e-8 and abs(log_dict["train/pg_clipfrac"]) < 1e-10, f"{log_dict=}"
         else:
-            assert abs(log_dict["train/ppo_kl"]) < 1e-10 and abs(log_dict["train/pg_clipfrac"]) < 1e-10, f"{log_dict=}"
+            _is_rocm = hasattr(torch.version, "hip") and torch.version.hip is not None
+            _tol = 1e-8 if _is_rocm else 1e-10
+            assert abs(log_dict["train/ppo_kl"]) < _tol and abs(log_dict["train/pg_clipfrac"]) < _tol, f"{log_dict=}"
     if accumulated_step_id == 0 and "train/kl_loss" in log_dict and not args.use_rollout_routing_replay:
         assert abs(log_dict["train/kl_loss"]) < 1e-9, f"{log_dict=}"
 

--- a/miles/utils/external_utils/command_utils.py
+++ b/miles/utils/external_utils/command_utils.py
@@ -45,11 +45,18 @@ def convert_checkpoint(
             "--master-addr {{master_addr}} " "--master-port 23456 " "--nnodes={{nnodes}} " "--node-rank {{node_rank}} "
         )
 
+    rocm_env = ""
+    if os.path.exists("/opt/rocm"):
+        for var in ("NVTE_FUSED_ATTN", "NVTE_FLASH_ATTN", "NVTE_UNFUSED_ATTN"):
+            os.environ.pop(var, None)
+        rocm_env = "unset NVTE_FUSED_ATTN NVTE_FLASH_ATTN NVTE_UNFUSED_ATTN && "
+
     if multinode:
         fn = partial(exec_command_all_ray_node, num_nodes=num_nodes)
     else:
         fn = exec_command
     fn(
+        f"{rocm_env}"
         f"source {repo_base_dir}/scripts/models/{megatron_model_type}.sh && "
         f"PYTHONPATH={megatron_path} "
         f"torchrun "
@@ -132,6 +139,18 @@ def execute_train(
         "pkill -9 redis; "
         "true; "
     )
+
+    rocm_env = ""
+    if os.path.exists("/opt/rocm"):
+        for var in ("NVTE_FUSED_ATTN", "NVTE_FLASH_ATTN", "NVTE_UNFUSED_ATTN"):
+            os.environ.pop(var, None)
+        os.environ.setdefault("RAY_EXPERIMENTAL_NOSET_HIP_VISIBLE_DEVICES", "1")
+        os.environ.setdefault("HIP_VISIBLE_DEVICES", ",".join(str(i) for i in range(num_gpus_per_node)))
+        rocm_env = (
+            f"unset NVTE_FUSED_ATTN NVTE_FLASH_ATTN NVTE_UNFUSED_ATTN && "
+            f"export RAY_EXPERIMENTAL_NOSET_HIP_VISIBLE_DEVICES=1 && "
+            f"export HIP_VISIBLE_DEVICES={os.environ['HIP_VISIBLE_DEVICES']} && "
+        )
 
     if not external_ray:
         exec_command(

--- a/tests/e2e/ckpt/test_qwen3_4B_ckpt.py
+++ b/tests/e2e/ckpt/test_qwen3_4B_ckpt.py
@@ -8,6 +8,7 @@ register_cuda_ci(est_time=1200, suite="stage-c-ckpt-8-gpu", num_gpus=8)
 
 ENABLE_EVAL = bool(int(os.environ.get("MILES_TEST_ENABLE_EVAL", "1")))
 TIGHT_HOST_MEMORY = bool(int(os.environ.get("MILES_TEST_TIGHT_HOST_MEMORY", "1")))
+IS_ROCM = os.path.exists("/opt/rocm")
 
 MODEL_NAME = "Qwen3-4B"
 MODEL_TYPE = "qwen3-4B"
@@ -66,17 +67,33 @@ def execute(mode: str = "", ckpt_step: int | None = None):
         "--balance-data "
     )
 
-    perf_args = (
-        "--tensor-model-parallel-size 2 "
-        "--sequence-parallel "
-        "--pipeline-model-parallel-size 1 "
-        "--context-parallel-size 2 "
-        "--recompute-granularity full "
-        "--recompute-method uniform "
-        "--recompute-num-layers 1 "
-        "--use-dynamic-batch-size "
-        f"--max-tokens-per-gpu {2048 if TIGHT_HOST_MEMORY else 16384} "
-    )
+    if IS_ROCM:
+        # ROCm async 4+4: TP=1, CP=1 (full model per GPU)
+        actor_gpus = 4
+        perf_args = (
+            "--tensor-model-parallel-size 1 "
+            "--sequence-parallel "
+            "--pipeline-model-parallel-size 1 "
+            "--context-parallel-size 1 "
+            "--recompute-granularity full "
+            "--recompute-method uniform "
+            "--recompute-num-layers 1 "
+            "--use-dynamic-batch-size "
+            "--max-tokens-per-gpu 2048 "
+        )
+    else:
+        actor_gpus = NUM_GPUS
+        perf_args = (
+            "--tensor-model-parallel-size 2 "
+            "--sequence-parallel "
+            "--pipeline-model-parallel-size 1 "
+            "--context-parallel-size 2 "
+            "--recompute-granularity full "
+            "--recompute-method uniform "
+            "--recompute-num-layers 1 "
+            "--use-dynamic-batch-size "
+            f"--max-tokens-per-gpu {2048 if TIGHT_HOST_MEMORY else 16384} "
+        )
 
     ppo_args = (
         "--advantage-estimator grpo "
@@ -87,16 +104,38 @@ def execute(mode: str = "", ckpt_step: int | None = None):
         "--eps-clip 0.2 "
     )
 
-    optimizer_args = (
-        "--optimizer adam "
-        "--lr 1e-6 "
-        "--lr-decay-style constant "
-        "--weight-decay 0.1 "
-        "--adam-beta1 0.9 "
-        "--adam-beta2 0.98 "
-    )
+    if IS_ROCM:
+        optimizer_args = (
+            "--optimizer adam "
+            "--lr 1e-6 "
+            "--lr-decay-style constant "
+            "--weight-decay 0.1 "
+            "--adam-beta1 0.9 "
+            "--adam-beta2 0.98 "
+            "--optimizer-cpu-offload "
+            "--overlap-cpu-optimizer-d2h-h2d "
+            "--use-precision-aware-optimizer "
+        )
+    else:
+        optimizer_args = (
+            "--optimizer adam "
+            "--lr 1e-6 "
+            "--lr-decay-style constant "
+            "--weight-decay 0.1 "
+            "--adam-beta1 0.9 "
+            "--adam-beta2 0.98 "
+        )
 
-    sglang_args = "--rollout-num-gpus-per-engine 2 --sglang-mem-fraction-static 0.8 --sglang-cuda-graph-bs 1 2 4 8 16 "
+    if IS_ROCM:
+        rollout_gpus = 4
+        sglang_args = (
+            f"--rollout-num-gpus {rollout_gpus} "
+            "--rollout-num-gpus-per-engine 2 "
+            "--sglang-mem-fraction-static 0.8 "
+            "--sglang-disable-custom-all-reduce "
+        )
+    else:
+        sglang_args = "--rollout-num-gpus-per-engine 2 --sglang-mem-fraction-static 0.8 --sglang-cuda-graph-bs 1 2 4 8 16 "
 
     ci_args = "--ci-test "
     if mode in {"save", "async_save"}:
@@ -104,19 +143,34 @@ def execute(mode: str = "", ckpt_step: int | None = None):
     if mode == "load":
         ci_args += "--ci-check-model-hash "
 
-    misc_args = (
-        # default dropout in megatron is 0.1
-        "--attention-dropout 0.0 "
-        "--hidden-dropout 0.0 "
-        # should be good for model performance
-        "--accumulate-allreduce-grads-in-fp32 "
-        "--attention-softmax-in-fp32 "
-        # need to comment this when using model with MLA
-        "--attention-backend flash "
-        "--actor-num-nodes 1 "
-        "--actor-num-gpus-per-node 8 "
-        "--colocate "
-    )
+    if IS_ROCM:
+        misc_args = (
+            "--attention-dropout 0.0 "
+            "--hidden-dropout 0.0 "
+            "--accumulate-allreduce-grads-in-fp32 "
+            "--attention-softmax-in-fp32 "
+            "--attention-backend auto "
+            "--update-weights-interval 2 "
+            "--actor-num-nodes 1 "
+            f"--actor-num-gpus-per-node {actor_gpus} "
+        )
+    else:
+        misc_args = (
+            "--attention-dropout 0.0 "
+            "--hidden-dropout 0.0 "
+            "--accumulate-allreduce-grads-in-fp32 "
+            "--attention-softmax-in-fp32 "
+            "--attention-backend flash "
+            "--actor-num-nodes 1 "
+            "--actor-num-gpus-per-node 8 "
+            "--colocate "
+        )
+
+    extra_env_vars = {"MILES_EXPERIMENTAL_ROLLOUT_REFACTOR": "1"}
+    if IS_ROCM:
+        extra_env_vars["SGLANG_SET_CPU_AFFINITY"] = "0"
+        extra_env_vars["RAY_EXPERIMENTAL_NOSET_HIP_VISIBLE_DEVICES"] = "1"
+        extra_env_vars["HIP_VISIBLE_DEVICES"] = "0,1,2,3,4,5,6,7"
 
     train_args = (
         f"{ckpt_args} "
@@ -134,7 +188,8 @@ def execute(mode: str = "", ckpt_step: int | None = None):
         train_args=train_args,
         num_gpus_per_node=NUM_GPUS,
         megatron_model_type=MODEL_TYPE,
-        extra_env_vars={"MILES_EXPERIMENTAL_ROLLOUT_REFACTOR": "1"},
+        train_script="train_async.py" if IS_ROCM else "train.py",
+        extra_env_vars=extra_env_vars,
     )
 
 


### PR DESCRIPTION
Added `IS_ROCM` detection and if-else conditions in `execute()` for ROCm-specific args. Uses async 4+4 mode (4 GPUs train, 4 GPUs rollout) with `train_async.py`, `--attention-backend auto`, optimizer CPU offload, `--sglang-disable-custom-all-reduce`, and ROCm env vars. NVIDIA path remains unchanged.
- Added ROCm NVTE env var cleanup (`unset NVTE_FUSED_ATTN`, `NVTE_FLASH_ATTN`, `NVTE_UNFUSED_ATTN`) to `convert_checkpoint()` and `execute_train()` in `command_utils.py`.
- Made KL divergence and peak GPU memory CI thresholds ROCm-conditional in `ci_utils.py`.

Related to #1105