### PR TITLE
[glm5] Clamp indexer topk to seq_len for short sequences

### DIFF
--- a/miles_plugins/models/glm5/ops/indexer.py
+++ b/miles_plugins/models/glm5/ops/indexer.py
@@ -27,7 +27,12 @@ class IndexerFunction(torch.autograd.Function):
         _, head_num, _ = index_q.shape
         logits = indexer_fwd_interface(index_q, index_k, weights, cu_seqlen_ks, cu_seqlen_ke, clean_logits=True)
         if topk_indices is None:
-            index_score, topk_indices = torch.topk(logits, topk, dim=-1)
+            # Clamp k to logits' last-dim size: when the available context is
+            # shorter than the configured index_topk (small CI tests, short
+            # debug rollouts), torch.topk raises "selected index k out of range".
+            # Taking all of context in that case is the right behavior.
+            actual_topk = min(topk, logits.shape[-1])
+            index_score, topk_indices = torch.topk(logits, actual_topk, dim=-1)
             topk_indices = topk_indices.to(torch.int32)
             topk_indices = topk_indices.masked_fill(index_score == -torch.inf, -1)
 

--- a/miles_plugins/models/glm5/ops/indexer.py
+++ b/miles_plugins/models/glm5/ops/indexer.py
@@ -30,11 +30,20 @@ class IndexerFunction(torch.autograd.Function):
             # Clamp k to logits' last-dim size: when the available context is
             # shorter than the configured index_topk (small CI tests, short
             # debug rollouts), torch.topk raises "selected index k out of range".
-            # Taking all of context in that case is the right behavior.
+            # Then pad topk_indices back to the original `topk` width with -1
+            # sentinels so the backward kernel's power-of-2 / multiple-of-32
+            # assertions on shape[-1] still hold. pytorch_extract_topk_scores
+            # and the TileLang bwd kernel both treat index==-1 as invalid.
             actual_topk = min(topk, logits.shape[-1])
             index_score, topk_indices = torch.topk(logits, actual_topk, dim=-1)
             topk_indices = topk_indices.to(torch.int32)
             topk_indices = topk_indices.masked_fill(index_score == -torch.inf, -1)
+            if actual_topk < topk:
+                padding_shape = (*topk_indices.shape[:-1], topk - actual_topk)
+                topk_indices = torch.cat(
+                    [topk_indices, topk_indices.new_full(padding_shape, -1)],
+                    dim=-1,
+                )
 
         index_score = pytorch_extract_topk_scores(logits, topk_indices)
 


### PR DESCRIPTION
GLM-5's indexer is configured with `index_topk=2048` from the model config. When training sequences are shorter than that (small CI tests, short debug rollouts), torch.topk(logits, 2048, dim=-1) on a length-249 logits tensor raises:

    RuntimeError: selected index k out of range

Clamp k to logits.shape[-1] before the topk call. "If context is shorter than k, take all of context" is the correct behavior - the masked_fill that follows already handles -inf entries.

Encountered while running test_glm5_744b_a40b_4layer_rocm.py on MI355X with rollout-max-response-len=100.