### PR TITLE
[glm5] Tile sparse-MLA fwd/bwd kernels for gfx950 (MI300/MI355) LDS b…

### DIFF
--- a/miles_plugins/models/glm5/ops/tilelang_sparse_mla_bwd.py
+++ b/miles_plugins/models/glm5/ops/tilelang_sparse_mla_bwd.py
@@ -98,6 +98,7 @@ def bwd(
     indices_dtype=T.int32,
     dtype=T.bfloat16,
     accum_dtype=T.float32,
+    block_H_override=None,
 ):
     assert is_causal == True, "non-casual is not supported now"
     assert topk % block_size == 0, "otherwise will load some index=0 thus causing wrong kv to be loaded"
@@ -122,7 +123,10 @@ def bwd(
 
     H = H_kv
     padded_H = max(tilelang.math.next_power_of_2(H_kv), 16)
-    block_H = min(64, padded_H)
+    # block_H controls the H-axis tile and dominates Q/dO/dQ shared-memory
+    # footprint. Original default min(64, padded_H) targets H100 (228KB LDS);
+    # callers on gfx950 (160KB LDS) pass block_H_override=16 to fit the budget.
+    block_H = block_H_override if block_H_override is not None else min(64, padded_H)
     assert padded_H % block_H == 0
     NH = padded_H // block_H
     BS = block_size
@@ -294,7 +298,16 @@ def sparse_mla_bwd(q, kv, o, do, indices, lse, sm_scale=None, is_casual=True, re
 
     # Get kernels
     preprocess_kernel = preprocess(B, S, H, D)
-    bwd_kernel = bwd(B, S, S_kv, H, D, D_tail, topk, kv_group, sm_scale, is_casual)
+    # gfx950 (MI300/MI355) has 160KB LDS per workgroup; the default tile
+    # (block_H=64, num_stages=2) needs ~217KB. Shrink block_H to 16 and
+    # disable double-buffering on ROCm. NV path unchanged.
+    if torch.version.hip is not None:
+        bwd_kernel = bwd(
+            B, S, S_kv, H, D, D_tail, topk, kv_group, sm_scale, is_casual,
+            block_size=32, num_stages=1, block_H_override=16,
+        )
+    else:
+        bwd_kernel = bwd(B, S, S_kv, H, D, D_tail, topk, kv_group, sm_scale, is_casual)
     postprocess_kernel = postprocess(B, S_kv, D, D_tail, kv_group)
 
     if delta is None:

--- a/miles_plugins/models/glm5/ops/tilelang_sparse_mla_bwd.py
+++ b/miles_plugins/models/glm5/ops/tilelang_sparse_mla_bwd.py
@@ -303,8 +303,19 @@ def sparse_mla_bwd(q, kv, o, do, indices, lse, sm_scale=None, is_casual=True, re
     # disable double-buffering on ROCm. NV path unchanged.
     if torch.version.hip is not None:
         bwd_kernel = bwd(
-            B, S, S_kv, H, D, D_tail, topk, kv_group, sm_scale, is_casual,
-            block_size=32, num_stages=1, block_H_override=16,
+            B,
+            S,
+            S_kv,
+            H,
+            D,
+            D_tail,
+            topk,
+            kv_group,
+            sm_scale,
+            is_casual,
+            block_size=32,
+            num_stages=1,
+            block_H_override=16,
         )
     else:
         bwd_kernel = bwd(B, S, S_kv, H, D, D_tail, topk, kv_group, sm_scale, is_casual)

--- a/miles_plugins/models/glm5/ops/tilelang_sparse_mla_fwd.py
+++ b/miles_plugins/models/glm5/ops/tilelang_sparse_mla_fwd.py
@@ -70,9 +70,10 @@ def sparse_mla_fwd(
     # original H100-tuned behavior.
     if h_per_block is None:
         h_per_block = padded_H if head_kv <= 64 else 64
-    assert padded_H % h_per_block == 0, (
-        f"padded_H={padded_H} must be divisible by h_per_block={h_per_block}"
-    )
+    # Cap at padded_H so callers passing a larger override don't trip the
+    # divisibility assert below (e.g. h_per_block=32 with head_kv=16, padded_H=16).
+    h_per_block = min(h_per_block, padded_H)
+    assert padded_H % h_per_block == 0, f"padded_H={padded_H} must be divisible by h_per_block={h_per_block}"
     H_per_block = h_per_block
     REPLICATE_H = padded_H // H_per_block
 
@@ -177,7 +178,15 @@ def sparse_mla_fwd(
 
 
 def sparse_mla_fwd_interface(
-    q, kv, indices, sm_scale=None, return_p_sum: bool = False, d_v=512, block_I=64, num_stages=2, threads=256,
+    q,
+    kv,
+    indices,
+    sm_scale=None,
+    return_p_sum: bool = False,
+    d_v=512,
+    block_I=64,
+    num_stages=2,
+    threads=256,
     h_per_block=None,
 ):
     # gfx950 (MI300/MI355) has 160KB LDS per workgroup; the default tile

--- a/miles_plugins/models/glm5/ops/tilelang_sparse_mla_fwd.py
+++ b/miles_plugins/models/glm5/ops/tilelang_sparse_mla_fwd.py
@@ -1,6 +1,7 @@
 # ruff: noqa
 # Adapted from https://github.com/tile-ai/tilelang/blob/e666d2d3cc483829c57618c9ebf2e4f4ada0819d/examples/deepseek_v32/sparse_mla_fwd.py
 import tilelang
+import torch
 from tilelang import language as T
 
 
@@ -23,6 +24,7 @@ def sparse_mla_fwd(
     block_I=64,
     num_stages=2,
     threads=256,
+    h_per_block=None,
 ):
     assert dim == tilelang.math.next_power_of_2(dim), f"haven't check padding correctness yet, dim={dim}"
     assert tail_dim == tilelang.math.next_power_of_2(
@@ -61,13 +63,18 @@ def sparse_mla_fwd(
     D = dim
     D_tail = tail_dim
 
-    if head_kv > 64:
-        assert head_kv % 64 == 0, "head_kv should be a multiple of 64"
-        REPLICATE_H = head_kv // 64
-    else:
-        REPLICATE_H = 1
-
-    H_per_block = padded_H if REPLICATE_H == 1 else 64
+    # H_per_block controls Q_shared/O_shared LDS footprint (H_per_block * D * 2 bytes).
+    # Original behavior pins it to padded_H (or 64 when head_kv > 64), which works on
+    # H100 (228KB LDS). On gfx950 (160KB LDS) the wrapper passes h_per_block=32 so
+    # Q_shared+O_shared drop from 128KB to 64KB. Pass h_per_block=None for the
+    # original H100-tuned behavior.
+    if h_per_block is None:
+        h_per_block = padded_H if head_kv <= 64 else 64
+    assert padded_H % h_per_block == 0, (
+        f"padded_H={padded_H} must be divisible by h_per_block={h_per_block}"
+    )
+    H_per_block = h_per_block
+    REPLICATE_H = padded_H // H_per_block
 
     @T.prim_func
     def main(
@@ -108,7 +115,7 @@ def sparse_mla_fwd(
             q_i = s_i
             max_kv_i = q_i
 
-            H0 = g_i * padded_H + (0 if REPLICATE_H == 1 else (bx % REPLICATE_H) * 64)
+            H0 = g_i * padded_H + (0 if REPLICATE_H == 1 else (bx % REPLICATE_H) * H_per_block)
             H1 = H0 + H_per_block
 
             T.copy(Q[b_i, s_i, H0:H1, :D], Q_shared)
@@ -170,8 +177,17 @@ def sparse_mla_fwd(
 
 
 def sparse_mla_fwd_interface(
-    q, kv, indices, sm_scale=None, return_p_sum: bool = False, d_v=512, block_I=64, num_stages=2, threads=256
+    q, kv, indices, sm_scale=None, return_p_sum: bool = False, d_v=512, block_I=64, num_stages=2, threads=256,
+    h_per_block=None,
 ):
+    # gfx950 (MI300/MI355) has 160KB LDS per workgroup; the default tile
+    # (h_per_block=64, num_stages=2) needs ~231KB. Shrink the H tile and
+    # disable double-buffering on ROCm. NV path unchanged.
+    if torch.version.hip is not None:
+        if h_per_block is None:
+            h_per_block = 32
+        if num_stages > 1:
+            num_stages = 1
     q = q.unsqueeze(0)
     kv = kv.unsqueeze(0)
     indices = indices.unsqueeze(0)
@@ -202,6 +218,7 @@ def sparse_mla_fwd_interface(
         block_I=block_I,
         num_stages=num_stages,
         threads=threads,
+        h_per_block=h_per_block,
     )
     out, lse = kernel(q, kv, indices)
     out = out.squeeze(0)


### PR DESCRIPTION
…udget

The TileLang sparse-MLA fwd and bwd kernels were tuned for H100's 228KB shared-memory budget. On gfx950 (MI300/MI355X, 160KB LDS), JIT compilation aborts with:

    RuntimeError: Initialization failed: Requested dynamic shared
    memory 231424 exceeds device limit 163840 for main_kernel

(fwd; bwd hits 217088 bytes for sparse_mla_bwd_kernel.)

Parametrize the two LDS-dominating tile dimensions and pass smaller values on ROCm:

  Kernel               Original (H100)         gfx950
  -------------------- ----------------------- -----------------------
  sparse_mla_fwd       h_per_block=64,         h_per_block=32,
                       num_stages=2  ~231KB    num_stages=1  ~144KB
  sparse_mla_bwd       block_H=64,             block_H=16,
                       num_stages=2  ~217KB    num_stages=1  ~126KB

NV path is unchanged - h_per_block/block_H_override default to None, which preserves the original `padded_H` / `min(64, padded_H)` logic. The ROCm override only fires under `torch.version.hip is not None`.

Verified end-to-end with test_glm5_744b_a40b_4layer_rocm.py on MI355X: training step 0 completes in 26s steady-state with train_rollout_logprob_abs_diff ~= 0.077.