### PR TITLE
npu support qwen3-4b.

### DIFF
--- a/docker/npu_patch/megatron.patch
+++ b/docker/npu_patch/megatron.patch
@@ -1,0 +1,537 @@
+diff --git a/megatron/core/activations.py b/megatron/core/activations.py
+index 8b422d73a..58fba4667 100644
+--- a/megatron/core/activations.py
++++ b/megatron/core/activations.py
+@@ -5,19 +5,19 @@ import torch.nn.functional as F
+ from megatron.core.jit import jit_fuser
+ 
+ 
+-@jit_fuser
++
+ def squared_relu(x: torch.Tensor) -> torch.Tensor:
+     """Squared ReLU activation"""
+     return torch.pow(F.relu(x), 2)
+ 
+ 
+-@jit_fuser
++
+ def quick_gelu(x: torch.Tensor) -> torch.Tensor:
+     """Quick GELU activation"""
+     return x * torch.sigmoid(1.702 * x)
+ 
+ 
+-@jit_fuser
++
+ def fast_gelu(x: torch.Tensor) -> torch.Tensor:
+     """Fast GELU activation"""
+     return 0.5 * x * (1.0 + torch.tanh(x * 0.7978845608 * (1.0 + 0.044715 * x * x)))
+diff --git a/megatron/core/fusions/fused_bias_dropout.py b/megatron/core/fusions/fused_bias_dropout.py
+index 336452562..614ee1a48 100644
+--- a/megatron/core/fusions/fused_bias_dropout.py
++++ b/megatron/core/fusions/fused_bias_dropout.py
+@@ -64,14 +64,14 @@ def bias_dropout_add_unfused(training):
+     return _bias_dropout_add
+ 
+ 
+-@jit_fuser
++
+ def bias_dropout_add_fused_train(
+     x_with_bias: Tuple[torch.Tensor, Optional[torch.Tensor]], residual: torch.Tensor, prob: float
+ ) -> torch.Tensor:
+     return _bias_dropout_add_func(x_with_bias, residual, prob, True)
+ 
+ 
+-@jit_fuser
++
+ def bias_dropout_add_fused_inference(
+     x_with_bias: Tuple[torch.Tensor, Optional[torch.Tensor]], residual: torch.Tensor, prob: float
+ ) -> torch.Tensor:
+diff --git a/megatron/core/fusions/fused_bias_geglu.py b/megatron/core/fusions/fused_bias_geglu.py
+index 7a7fbe7f9..f9a438953 100644
+--- a/megatron/core/fusions/fused_bias_geglu.py
++++ b/megatron/core/fusions/fused_bias_geglu.py
+@@ -13,7 +13,7 @@ from megatron.core.jit import jit_fuser
+ # x * 0.5 * (1.0 + torch.erf(x * 0.70710678))
+ 
+ 
+-@jit_fuser
++
+ def geglu(y):
+     """Performs GEGLU (GELU-Gated Linear Unit) activation.
+ 
+@@ -27,7 +27,7 @@ def geglu(y):
+     return (y_1 * 0.5 * (1.0 + torch.tanh(0.79788456 * y_1 * (1 + 0.044715 * y_1 * y_1)))) * y_2
+ 
+ 
+-@jit_fuser
++
+ def bias_geglu(bias, y):
+     """Performs GEGLU activation with bias addition.
+ 
+@@ -45,7 +45,7 @@ def bias_geglu(bias, y):
+ # gradient of tanh approximation of gelu
+ # gradient of actual gelu is:
+ # 0.5 * (1. + torch.erf(x * 0.70710678)) + 0.3989423 * x * torch.exp(-0.5 * x * x)
+-@jit_fuser
++
+ def geglu_back(g, y):
+     """Computes the gradient for the GEGLU activation.
+ 
+@@ -65,7 +65,7 @@ def geglu_back(g, y):
+     return torch.cat(((g * y_2) * ff, g * (y_1 * 0.5 * (1.0 + tanh_out))), -1)
+ 
+ 
+-@jit_fuser
++
+ def bias_geglu_back(g, y, bias):
+     """Computes the gradient for the biased GEGLU activation.
+ 
+@@ -181,13 +181,13 @@ def bias_geglu_impl(input, bias):
+ # ------------------------- QUICK GEGLU FUSION --------------------------
+ 
+ 
+-@jit_fuser
++
+ def quick_gelu(y: torch.Tensor) -> torch.Tensor:
+     """Sigmoid approximation of gelu"""
+     return y * torch.sigmoid(1.702 * y)
+ 
+ 
+-@jit_fuser
++
+ def quick_geglu(y: torch.Tensor, linear_offset: float = 0.0) -> torch.Tensor:
+     """Performs Quick-GELU-based GEGLU activation : quick_gelu(y1) * (y2 + offset).
+ 
+@@ -202,7 +202,7 @@ def quick_geglu(y: torch.Tensor, linear_offset: float = 0.0) -> torch.Tensor:
+     return quick_gelu(y_1) * (y_2 + linear_offset)
+ 
+ 
+-@jit_fuser
++
+ def weighted_quick_geglu(
+     y: torch.Tensor, weights: torch.Tensor, linear_offset: float = 0.0
+ ) -> torch.Tensor:
+@@ -217,7 +217,7 @@ def weighted_quick_geglu(
+ 
+ 
+ # gradient of sigmoid approximation of gelu
+-@jit_fuser
++
+ def quick_geglu_back(g, y, linear_offset: float = 0.0) -> torch.Tensor:
+     """Backward helper for Quick-GEGLU.
+ 
+@@ -236,7 +236,7 @@ def quick_geglu_back(g, y, linear_offset: float = 0.0) -> torch.Tensor:
+     return torch.cat((dy_1, dy_2), -1)
+ 
+ 
+-@jit_fuser
++
+ def weighted_quick_geglu_back(g, y, weights, linear_offset: float = 0.0):
+     """Backward helper for weighted Quick-GEGLU.
+     Returns gradient w.r.t input `y` and `weights`.
+@@ -255,7 +255,7 @@ def weighted_quick_geglu_back(g, y, weights, linear_offset: float = 0.0):
+ # ---------------- Weighted Bias Quick-GEGLU helpers -----------------
+ 
+ 
+-@jit_fuser
++
+ def weighted_bias_quick_geglu(
+     y: torch.Tensor, bias: torch.Tensor, weights: torch.Tensor, linear_offset: float = 0.0
+ ) -> torch.Tensor:
+@@ -275,7 +275,7 @@ def weighted_bias_quick_geglu(
+     return res.to(dtype)
+ 
+ 
+-@jit_fuser
++
+ def weighted_bias_quick_geglu_back(g, y, bias, weights, linear_offset: float = 0.0):
+     """Backward helper for weighted Quick-GEGLU with bias.
+ 
+diff --git a/megatron/core/fusions/fused_bias_gelu.py b/megatron/core/fusions/fused_bias_gelu.py
+index 8cc90f617..fda8f2f5f 100644
+--- a/megatron/core/fusions/fused_bias_gelu.py
++++ b/megatron/core/fusions/fused_bias_gelu.py
+@@ -13,7 +13,7 @@ from megatron.core.jit import jit_fuser
+ # x * 0.5 * (1.0 + torch.erf(x * 0.70710678))
+ 
+ 
+-@jit_fuser
++
+ def bias_gelu(bias, y):
+     x = bias + y
+     return x * 0.5 * (1.0 + torch.tanh(0.79788456 * x * (1 + 0.044715 * x * x)))
+@@ -22,7 +22,7 @@ def bias_gelu(bias, y):
+ # gradient of tanh approximation of gelu
+ # gradient of actual gelu is:
+ # 0.5 * (1. + torch.erf(x * 0.70710678)) + 0.3989423 * x * torch.exp(-0.5 * x * x)
+-@jit_fuser
++
+ def bias_gelu_back(g, bias, y):
+     x = bias + y
+     tanh_out = torch.tanh(0.79788456 * x * (1 + 0.044715 * x * x))
+diff --git a/megatron/core/fusions/fused_bias_swiglu.py b/megatron/core/fusions/fused_bias_swiglu.py
+index 632470876..105936786 100644
+--- a/megatron/core/fusions/fused_bias_swiglu.py
++++ b/megatron/core/fusions/fused_bias_swiglu.py
+@@ -12,7 +12,7 @@ from megatron.core.utils import nvtx_decorator
+ ###### BIAS SWIGLU FUSION/ NO AUTOGRAD ################
+ 
+ 
+-@jit_fuser
++
+ def swiglu(y):
+     """Performs SwiGLU (Swish-Gated Linear Unit) activation function.
+ 
+@@ -26,7 +26,7 @@ def swiglu(y):
+     return F.silu(y_1) * y_2
+ 
+ 
+-@jit_fuser
++
+ def bias_swiglu(y, bias):
+     """Performs SwiGLU activation with bias addition.
+ 
+@@ -41,7 +41,7 @@ def bias_swiglu(y, bias):
+     return swiglu(y)
+ 
+ 
+-@jit_fuser
++
+ def weighted_swiglu(y, weights):
+     dtype = y.dtype
+     res = swiglu(y) * weights
+@@ -51,7 +51,7 @@ def weighted_swiglu(y, weights):
+ # gradient of tanh approximation of gelu
+ # gradient of actual gelu is:
+ # 0.5 * (1. + torch.erf(x * 0.70710678)) + 0.3989423 * x * torch.exp(-0.5 * x * x)
+-@jit_fuser
++
+ def swiglu_back(g, y):
+     """Computes the gradient for the SwiGLU activation function.
+ 
+@@ -69,7 +69,7 @@ def swiglu_back(g, y):
+     )
+ 
+ 
+-@jit_fuser
++
+ def bias_swiglu_back(g, y, bias):
+     """Computes the gradient for the biased SwiGLU activation function.
+ 
+@@ -86,7 +86,7 @@ def bias_swiglu_back(g, y, bias):
+     return swiglu_back(g, y)
+ 
+ 
+-@jit_fuser
++
+ def weighted_swiglu_back(g, y, weights):
+     input_dtype = y.dtype
+     w_dtype = weights.dtype
+diff --git a/megatron/core/fusions/fused_cross_entropy.py b/megatron/core/fusions/fused_cross_entropy.py
+index 23e4b6031..4d447e0e0 100644
+--- a/megatron/core/fusions/fused_cross_entropy.py
++++ b/megatron/core/fusions/fused_cross_entropy.py
+@@ -9,7 +9,7 @@ from megatron.core.tensor_parallel.cross_entropy import VocabParallelCrossEntrop
+ from megatron.core.tensor_parallel.utils import VocabUtility
+ 
+ 
+-@jit_fuser
++
+ def calculate_logits_max(vocab_parallel_logits: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+     """
+     Calculates the maximum logits of the predicted tokens.
+@@ -22,7 +22,7 @@ def calculate_logits_max(vocab_parallel_logits: torch.Tensor) -> Tuple[torch.Ten
+     return vocab_parallel_logits, logits_max
+ 
+ 
+-@jit_fuser
++
+ def calculate_predicted_logits(
+     vocab_parallel_logits: torch.Tensor,
+     target: torch.Tensor,
+@@ -44,7 +44,7 @@ def calculate_predicted_logits(
+     return target_mask, masked_target_1d, predicted_logits_sum_exp_logits, exp_logits
+ 
+ 
+-@jit_fuser
++
+ def calculate_cross_entropy_loss(
+     exp_logits: torch.Tensor, predicted_logits_sum_exp_logits: torch.Tensor
+ ) -> Tuple[torch.Tensor, torch.Tensor]:
+@@ -61,7 +61,7 @@ def calculate_cross_entropy_loss(
+     return exp_logits, loss
+ 
+ 
+-@jit_fuser
++
+ def calculate_gradients(
+     softmax: torch.Tensor,
+     grad_output: torch.Tensor,
+diff --git a/megatron/core/fusions/fused_pad_routing_map.py b/megatron/core/fusions/fused_pad_routing_map.py
+index c382178b6..563279edd 100644
+--- a/megatron/core/fusions/fused_pad_routing_map.py
++++ b/megatron/core/fusions/fused_pad_routing_map.py
+@@ -70,7 +70,7 @@ def _pad_routing_map_kernel(
+     tl.store(output_row_ptr + token_indices, output_row, mask=token_mask)
+ 
+ 
+-@jit_fuser
++
+ def fused_pad_routing_map(routing_map: torch.Tensor, pad_multiple: int) -> torch.Tensor:
+     """Fused version of pad_routing_map.
+     Args:
+diff --git a/megatron/core/fusions/fused_weighted_squared_relu.py b/megatron/core/fusions/fused_weighted_squared_relu.py
+index 02dabc14c..137022386 100644
+--- a/megatron/core/fusions/fused_weighted_squared_relu.py
++++ b/megatron/core/fusions/fused_weighted_squared_relu.py
+@@ -10,7 +10,7 @@ from megatron.core.utils import nvtx_decorator
+ ######################  WEIGHTED SQUARED ReLU FUSION  ######################
+ 
+ 
+-@jit_fuser
++
+ def weighted_squared_relu(x: torch.Tensor, weights: torch.Tensor) -> torch.Tensor:
+     """Element-wise weight applied after Squared-ReLU.
+ 
+@@ -28,7 +28,7 @@ def weighted_squared_relu(x: torch.Tensor, weights: torch.Tensor) -> torch.Tenso
+     return res.to(out_dtype)
+ 
+ 
+-@jit_fuser
++
+ def _squared_relu_back(g: torch.Tensor, x: torch.Tensor) -> torch.Tensor:
+     """Gradient of Squared-ReLU.
+ 
+@@ -37,7 +37,7 @@ def _squared_relu_back(g: torch.Tensor, x: torch.Tensor) -> torch.Tensor:
+     return g * 2 * F.relu(x)
+ 
+ 
+-@jit_fuser
++
+ def weighted_squared_relu_back(g: torch.Tensor, x: torch.Tensor, weights: torch.Tensor):
+     """Backward for weighted Squared-ReLU.
+ 
+diff --git a/megatron/core/models/gpt/gpt_layer_specs.py b/megatron/core/models/gpt/gpt_layer_specs.py
+index 712793853..76ea4333b 100755
+--- a/megatron/core/models/gpt/gpt_layer_specs.py
++++ b/megatron/core/models/gpt/gpt_layer_specs.py
+@@ -219,7 +219,7 @@ def get_gpt_layer_with_transformer_engine_spec(
+             'The fp8 argument in "get_gpt_layer_with_transformer_engine_spec" has been deprecated'
+             " and will be removed soon. Please update your code accordingly."
+         )
+-
++    from megatron.core.extensions.transformer_engine_spec_provider import TESpecProvider
+     if use_kitchen:
+         assert HAVE_KITCHEN
+         backend: BackendSpecProvider = KitchenSpecProvider(
+diff --git a/megatron/core/ssm/gated_delta_net.py b/megatron/core/ssm/gated_delta_net.py
+index dfa6e4c35..8b3621819 100644
+--- a/megatron/core/ssm/gated_delta_net.py
++++ b/megatron/core/ssm/gated_delta_net.py
+@@ -413,7 +413,7 @@ class GatedDeltaNet(MegatronModule):
+ 
+         return out, out_bias
+ 
+-    @jit_fuser
++    
+     def _apply_gated_norm(self, x, gate):
+         # Output Norm
+         x_dtype = x.dtype
+diff --git a/megatron/core/transformer/attention.py b/megatron/core/transformer/attention.py
+index 80e9ec6fc..b6bcef6a9 100644
+--- a/megatron/core/transformer/attention.py
++++ b/megatron/core/transformer/attention.py
+@@ -1026,7 +1026,7 @@ class Attention(MegatronModule, ABC):
+ 
+         return output, bias
+ 
+-    @jit_fuser
++    
+     def _apply_output_gate(self, x, gate):
+         x_dtype = x.dtype
+         gate = gate.contiguous()
+diff --git a/megatron/core/transformer/module.py b/megatron/core/transformer/module.py
+index 2330df91b..0446c9097 100644
+--- a/megatron/core/transformer/module.py
++++ b/megatron/core/transformer/module.py
+@@ -16,9 +16,9 @@ from megatron.core.transformer.utils import (
+     sharded_state_dict_default,
+ )
+ 
+-_FLOAT_TYPES = (torch.FloatTensor, torch.cuda.FloatTensor)
+-_HALF_TYPES = (torch.HalfTensor, torch.cuda.HalfTensor)
+-_BF16_TYPES = (torch.BFloat16Tensor, torch.cuda.BFloat16Tensor)
++_FLOAT_TYPES = (torch.FloatTensor, torch.cuda.FloatTensor, torch.npu.FloatTensor)
++_HALF_TYPES = (torch.HalfTensor, torch.cuda.HalfTensor, torch.npu.HalfTensor)
++_BF16_TYPES = (torch.BFloat16Tensor, torch.cuda.BFloat16Tensor, torch.npu.BFloat16Tensor)
+ 
+ 
+ def param_is_not_shared(param):  # pylint: disable=missing-function-docstring
+diff --git a/megatron/core/transformer/moe/experts.py b/megatron/core/transformer/moe/experts.py
+index 5eeafdd8d..a4dce6970 100644
+--- a/megatron/core/transformer/moe/experts.py
++++ b/megatron/core/transformer/moe/experts.py
+@@ -91,7 +91,7 @@ class GroupedMLP(MegatronModule):
+             if self.config.activation_func not in (F.silu, F.gelu):
+                 raise ValueError("Activation function must be silu or gelu when using GroupedMLP.")
+ 
+-            @jit_fuser
++            
+             def glu(x):
+                 x = torch.chunk(x, 2, dim=-1)
+                 return self.config.activation_func(x[0]) * x[1]
+@@ -108,7 +108,7 @@ class GroupedMLP(MegatronModule):
+                 "moe_act recompute for fp8 or fp4 cannot work with the legacy GroupedMLP."
+             )
+ 
+-        @jit_fuser
++        
+         def activation_func_with_probs(x, probs):
+             dtype = x.dtype
+             res = self.activation_func(x) * probs
+diff --git a/megatron/core/transformer/moe/router.py b/megatron/core/transformer/moe/router.py
+index 517944f25..2c5bc0728 100644
+--- a/megatron/core/transformer/moe/router.py
++++ b/megatron/core/transformer/moe/router.py
+@@ -472,7 +472,7 @@ class TopKRouter(Router):
+         else:
+             return input
+ 
+-    @jit_fuser
++    
+     def _apply_expert_bias(self, routing_map: torch.Tensor):
+         """
+         Update expert bias and tokens_per_expert
+diff --git a/megatron/core/transformer/moe/token_dispatcher.py b/megatron/core/transformer/moe/token_dispatcher.py
+index d0da38d63..6d092c88f 100644
+--- a/megatron/core/transformer/moe/token_dispatcher.py
++++ b/megatron/core/transformer/moe/token_dispatcher.py
+@@ -1403,7 +1403,7 @@ class MoEFlexTokenDispatcher(MoETokenDispatcher):
+         ).contiguous()
+         return routing_map, probs
+ 
+-    @jit_fuser
++    
+     def dispatch_preprocess(
+         self, hidden_states: torch.Tensor, routing_map: torch.Tensor, probs: torch.Tensor
+     ):
+diff --git a/megatron/core/transformer/torch_norm.py b/megatron/core/transformer/torch_norm.py
+index d0ceca7af..f16796680 100644
+--- a/megatron/core/transformer/torch_norm.py
++++ b/megatron/core/transformer/torch_norm.py
+@@ -69,7 +69,7 @@ class L2Norm(torch.nn.Module):
+         self.hidden_size = hidden_size
+         self.eps = eps
+ 
+-    @jit_fuser
++    
+     def _norm(self, x):
+         """
+         Performs the actual L2 normalization.
+diff --git a/megatron/core/transformer/utils.py b/megatron/core/transformer/utils.py
+index 880c53099..dbc95736e 100644
+--- a/megatron/core/transformer/utils.py
++++ b/megatron/core/transformer/utils.py
+@@ -51,7 +51,7 @@ def attention_mask_func(attention_scores, attention_mask):
+     return attention_scores
+ 
+ 
+-@jit_fuser
++
+ def gelu_impl(x):
+     """OpenAI's gelu implementation."""
+     return 0.5 * x * (1.0 + torch.tanh(0.7978845608028654 * x * (1.0 + 0.044715 * x * x)))
+@@ -65,7 +65,7 @@ def openai_gelu(x):
+ # This is actually Python equivalent of torch.nn.functional.gelu(), also with
+ # type hints for ONNX exporter
+ # pylint: disable=missing-function-docstring
+-@jit_fuser
++
+ def erf_gelu(x):
+     return (
+         x * 0.5 * (torch.erf(x / 1.41421).to(dtype=x.dtype) + torch.ones_like(x).to(dtype=x.dtype))
+diff --git a/megatron/legacy/model/fused_bias_gelu.py b/megatron/legacy/model/fused_bias_gelu.py
+index e00e63148..ffe4b7ec6 100644
+--- a/megatron/legacy/model/fused_bias_gelu.py
++++ b/megatron/legacy/model/fused_bias_gelu.py
+@@ -12,7 +12,7 @@ from megatron.core.jit import jit_fuser
+ # actual gelu is:
+ # x * 0.5 * (1.0 + torch.erf(x * 0.70710678))
+ 
+-@jit_fuser
++
+ def bias_gelu(bias, y):
+     x = bias + y
+     return  x * 0.5 * (1.0 + torch.tanh(0.79788456 * x * (1 + 0.044715 * x * x)))
+@@ -20,7 +20,7 @@ def bias_gelu(bias, y):
+ # gradient of tanh approximation of gelu
+ # gradient of actual gelu is:
+ # 0.5 * (1. + torch.erf(x * 0.70710678)) + 0.3989423 * x * torch.exp(-0.5 * x * x)
+-@jit_fuser
++
+ def bias_gelu_back(g, bias, y):
+     x = bias + y
+     tanh_out = torch.tanh(0.79788456 * x * (1 + 0.044715 * x * x))
+diff --git a/megatron/legacy/model/transformer.py b/megatron/legacy/model/transformer.py
+index 2a662a55b..2fc3e1bfb 100644
+--- a/megatron/legacy/model/transformer.py
++++ b/megatron/legacy/model/transformer.py
+@@ -856,7 +856,7 @@ def get_bias_dropout_add(training):
+     return _bias_dropout_add
+ 
+ 
+-@jit_fuser
++
+ def bias_dropout_add_fused_train(x: torch.Tensor,
+                                  bias: Optional[torch.Tensor],
+                                  residual: torch.Tensor,
+@@ -864,7 +864,7 @@ def bias_dropout_add_fused_train(x: torch.Tensor,
+     return bias_dropout_add(x, bias, residual, prob, True)
+ 
+ 
+-@jit_fuser
++
+ def bias_dropout_add_fused_inference(x: torch.Tensor,
+                                      bias: Optional[torch.Tensor],
+                                      residual: torch.Tensor,
+diff --git a/megatron/legacy/model/utils.py b/megatron/legacy/model/utils.py
+index 5762000d5..534858df7 100644
+--- a/megatron/legacy/model/utils.py
++++ b/megatron/legacy/model/utils.py
+@@ -43,7 +43,7 @@ def get_linear_layer(rows, columns, init_method):
+     return layer
+ 
+ 
+-@jit_fuser
++
+ def gelu_impl(x):
+     """OpenAI's gelu implementation."""
+     return 0.5 * x * (1.0 + torch.tanh(0.7978845608028654 * x *
+@@ -54,7 +54,7 @@ def openai_gelu(x):
+ 
+ 
+ #This is actually Python equivalent of torch.nn.functional.gelu(), also with type hints for ONNX exporter
+-@jit_fuser
++
+ def erf_gelu(x):
+     return x * 0.5 * (torch.erf(x / 1.41421).to(dtype=x.dtype)+torch.ones_like(x).to(dtype=x.dtype))
+
+
+diff --git a/megatron/core/inference/contexts/dynamic_context.py b/megatron/core/inference/contexts/dynamic_context.py
+index 9b855effb..90c37c8db 100644
+--- a/megatron/core/inference/contexts/dynamic_context.py
++++ b/megatron/core/inference/contexts/dynamic_context.py
+@@ -49,12 +49,8 @@ try:
+ except:
+     HAVE_PACKAGING = False
+ 
+-try:
+-    import flashinfer  # pylint: disable=unused-import
+ 
+-    HAVE_FLASHINFER = True
+-except ImportError:
+-    HAVE_FLASHINFER = False
++HAVE_FLASHINFER = False
+ 
+ try:
+     import wandb  # pylint: disable=unused-import

--- a/docker/npu_patch/megatron_bridge.patch
+++ b/docker/npu_patch/megatron_bridge.patch
@@ -1,0 +1,55 @@
+diff --git a/src/megatron/bridge/models/conversion/param_mapping.py b/src/megatron/bridge/models/conversion/param_mapping.py
+index a0421273..7f9203ab 100644
+--- a/src/megatron/bridge/models/conversion/param_mapping.py
++++ b/src/megatron/bridge/models/conversion/param_mapping.py
+@@ -1097,15 +1097,19 @@ class AutoMapping(MegatronParamMapping[torch.Tensor]):
+             "LinearCrossEntropyModule",
+             "TEColumnParallelLinear",
+             "TELayerNormColumnParallelLinear",
++            "MindSpeedTELayerNormColumnParallelLinear",
+             "TEColumnParallelGroupedLinear",
++            "MindSpeedTEColumnParallelGroupedLinear",
+             "VocabParallelEmbedding",
+             "DotProductAttention",  # for attention sink only
+             "TEDotProductAttention",  # for attention sink only
++            "MindSpeedTEDotProductAttention",
+         },
+         "row": {
+             "RowParallelLinear",
+             "TERowParallelLinear",
+             "TERowParallelGroupedLinear",
++            "MindSpeedTERowParallelGroupedLinear",
+         },
+         "replicated": {
+             # Normalization layers
+@@ -1176,7 +1180,7 @@ class AutoMapping(MegatronParamMapping[torch.Tensor]):
+         # Handle fused modules like TELayerNormColumnParallelLinear
+         # These modules have both column-parallel weights (weight, bias)
+         # and replicated layer norm weights (layer_norm_weight, layer_norm_bias)
+-        if module_type == "TELayerNormColumnParallelLinear":
++        if module_type == "TELayerNormColumnParallelLinear" or module_type == "MindSpeedTELayerNormColumnParallelLinear":
+             # Check the actual parameter name to determine the correct parallelism type
+             if self.megatron_param and (
+                 self.megatron_param.endswith("layer_norm_weight") or self.megatron_param.endswith("layer_norm_bias")
+@@ -1207,7 +1211,7 @@ class AutoMapping(MegatronParamMapping[torch.Tensor]):
+             return "replicated"
+ 
+         # Check parallel_mode for TELinear
+-        if module_type == "TELinear":
++        if module_type == "TELinear" or module_type == "MindSpeedTELinear":
+             if module.parallel_mode == "column":
+                 return "column"
+             elif module.parallel_mode == "row":
+diff --git a/src/megatron/bridge/peft/utils.py b/src/megatron/bridge/peft/utils.py
+index 1ca5b18b..3d8ec12a 100644
+--- a/src/megatron/bridge/peft/utils.py
++++ b/src/megatron/bridge/peft/utils.py
+@@ -62,7 +62,7 @@ HAVE_TE = all(
+     )
+ )
+ 
+-MixedFusedLayerNorm, HAVE_APEX = safe_import_from("apex.normalization.fused_layer_norm", "MixedFusedLayerNorm")
++# MixedFusedLayerNorm, HAVE_APEX = safe_import_from("apex.normalization.fused_layer_norm", "MixedFusedLayerNorm")
+ 
+ TECL = (TEColumnParallelLinear, TELayerNormColumnParallelLinear, TEColumnParallelGroupedLinear)
+ TERL = (TERowParallelLinear, TERowParallelGroupedLinear)

--- a/docker/npu_patch/megatron_common.patch
+++ b/docker/npu_patch/megatron_common.patch
@@ -1,0 +1,772 @@
+diff --git a/megatron/core/dist_checkpointing/strategies/common.py b/megatron/core/dist_checkpointing/strategies/common.py
+index 41c21d93d..ef80f72d6 100644
+--- a/megatron/core/dist_checkpointing/strategies/common.py
++++ b/megatron/core/dist_checkpointing/strategies/common.py
+@@ -86,7 +86,7 @@ class TorchCommonLoadStrategy(LoadCommonStrategy):
+                 msc = MultiStorageClientFeature.import_package()
+                 return msc.torch.load(load_path, map_location='cpu')
+             else:
+-                return torch.load(load_path, map_location='cpu')
++                return torch.load(load_path, map_location='cpu', weights_only=False)
+         except FileNotFoundError as e:
+             err_msg = f'Common file {load_path} does not exist'
+             if MultiStorageClientFeature.is_enabled():
+diff --git a/megatron/core/dist_checkpointing/strategies/torch.py b/megatron/core/dist_checkpointing/strategies/torch.py
+index 5a1ea308d..aa701237f 100644
+--- a/megatron/core/dist_checkpointing/strategies/torch.py
++++ b/megatron/core/dist_checkpointing/strategies/torch.py
+@@ -597,10 +597,12 @@ class MCoreLoadPlanner(DefaultLoadPlanner):
+     def _validate_global_shapes(self, metadata, sharded_tensors):
+         for sh_ten in sharded_tensors:
+             if sh_ten.key not in metadata.state_dict_metadata:
+-                raise KeyError(
+-                    f"{sh_ten.key} from model not in state dict:"
+-                    f" {sorted(metadata.state_dict_metadata.keys())}"
+-                )
++                # raise KeyError(
++                #     f"{sh_ten.key} from model not in state dict:"
++                #     f" {sorted(metadata.state_dict_metadata.keys())}"
++                # )
++                print(f"{sh_ten.key} from model not in state dict, will skip")
++                continue
+             loaded_shape = metadata.state_dict_metadata[sh_ten.key].size
+             expected_shape = self._expected_shape(sh_ten)
+             if loaded_shape != expected_shape:
+@@ -630,7 +632,7 @@ class MCoreLoadPlanner(DefaultLoadPlanner):
+         tensor_metadata = self.metadata.state_dict_metadata
+         metadata_with_sizes = [
+             (tensor_metadata[key], tensor_metadata[key].size, sharded_tensor)
+-            for key, sharded_tensor in self.allow_shape_mismatch_sharded_tensors.items()
++            for key, sharded_tensor in self.allow_shape_mismatch_sharded_tensors.items() if key in tensor_metadata
+         ]
+         try:
+             # Temporarily set sizes to expected shapes
+@@ -959,6 +961,7 @@ class TorchDistLoadShardedStrategy(LoadShardedStrategy):
+             planner=MCoreLoadPlanner(
+                 shapes_validation_sharded_tensors=flexible_shape_sharded_tensors,
+                 allow_shape_mismatch_sharded_tensors=allow_shape_mismatch_sharded_tensors,
++                allow_partial_load=True,
+             ),
+         )
+ 
+diff --git a/megatron/core/extensions/transformer_engine.py b/megatron/core/extensions/transformer_engine.py
+index acb93ef78..d239db4ab 100644
+--- a/megatron/core/extensions/transformer_engine.py
++++ b/megatron/core/extensions/transformer_engine.py
+@@ -408,6 +408,7 @@ class TELinear(te.pytorch.Linear):
+         )
+ 
+         for param in self.parameters():
++            setattr(param, "parallel_mode", parallel_mode)
+             if is_expert:
+                 # Reduce the gradient on the expert_data_parallel group for expert linear layers
+                 setattr(param, "allreduce", not self.expert_parallel)
+@@ -1161,6 +1162,61 @@ class TEDotProductAttention(te.pytorch.DotProductAttention):
+ 
+ 
+ if HAVE_TE and is_te_min_version("1.9.0.dev0"):
++    def ceil_div(x: int, y: int) -> int:
++        return (x + y - 1) // y
++
++    class _FakeInt4QuantizationSTE(torch.autograd.Function):
++        @staticmethod
++        def forward(ctx, x, group_size):
++            m, n = x.shape
++            block_size_m, block_size_n = 1, group_size
++
++
++            m_padded = ceil_div(m, block_size_m) * block_size_m
++            n_padded = ceil_div(n, block_size_n) * block_size_n
++
++            x_padded = torch.zeros(
++                (m_padded, n_padded),
++                dtype=x.dtype, device=x.device
++            )
++            x_padded[:m, :n] = x
++
++            x_view = x_padded.view(
++                m_padded // block_size_m,
++                block_size_m,
++                n_padded // block_size_n,
++                block_size_n
++            )
++
++            x_max = x_view.abs().float().amax(dim=(1, 3), keepdim=True)
++            q_max = 7
++            x_scale = x_max / q_max
++
++            x_scale = x_scale.clamp(min=1e-5)
++
++            x_div = x_view / x_scale
++            x_round = torch.round(x_div)
++
++            x_q_clamped = x_round.clamp(-q_max, q_max)
++
++            x_dequant_view = x_q_clamped * x_scale
++
++            x_dequant_full = x_dequant_view.view_as(x_padded)
++            x_out = x_dequant_full[:m, :n].contiguous().to(x.dtype)
++
++            return x_out
++
++        @staticmethod
++        def backward(ctx, grad_output):
++            return grad_output, None
++
++    def fake_int4_quantization_ste(x, group_size):
++        x_out = _FakeInt4QuantizationSTE.apply(x, group_size)
++        
++        if hasattr(x, 'main_grad'):
++            x_out.main_grad = x.main_grad
++            
++        return x_out
+ 
+     class TEGroupedLinear(te.pytorch.GroupedLinear):
+         """
+@@ -1351,6 +1407,7 @@ if HAVE_TE and is_te_min_version("1.9.0.dev0"):
+             _is_first_microbatch = (
+                 None if self.disable_parameter_transpose_cache else self.is_first_microbatch
+             )
++
+             out = super().forward(x, m_splits, is_first_microbatch=_is_first_microbatch)
+             self.is_first_microbatch = False
+ 
+@@ -1361,6 +1418,20 @@ if HAVE_TE and is_te_min_version("1.9.0.dev0"):
+                 return out
+             return out, None
+ 
++        def _get_weight_tensors(self):
++            """Get the weight tensors of the module."""
++            weight_tensors = super()._get_weight_tensors()
++
++            if os.getenv("OPEN_TRAINING_INT4_FAKE_QAT_FLAG", "0") == "1":
++                group_size = int(os.getenv("OPEN_TRAINING_INT4_GROUP_SIZE", "128"))
++
++                weight_tensors = [
++                    fake_int4_quantization_ste(w, group_size) 
++                    for w in weight_tensors
++                ]
++                
++            return weight_tensors
++
+         def _encode_extra_state(self, state):
+             # TE 2.0 changed the format of extra_state to be a byte tensor
+             if is_te_min_version("2.0.0"):
+diff --git a/megatron/core/fusions/fused_mla_yarn_rope_apply.py b/megatron/core/fusions/fused_mla_yarn_rope_apply.py
+index 1fd5dcfae..c9aeef1f0 100644
+--- a/megatron/core/fusions/fused_mla_yarn_rope_apply.py
++++ b/megatron/core/fusions/fused_mla_yarn_rope_apply.py
+@@ -385,6 +385,7 @@ def rotary_fwd_kv_kernel(
+     SIN,
+     emb_dim: tl.constexpr,
+     k_dim: tl.constexpr,
++    k_dim_ceil: tl.constexpr,
+     v_dim: tl.constexpr,
+     head_num: tl.constexpr,
+     batch_size,
+@@ -434,21 +435,27 @@ def rotary_fwd_kv_kernel(
+     cos_right = tl.load(COS + token_idx * emb_dim + emb_dim // 2 + tl.arange(0, emb_dim // 2))
+     sin_right = tl.load(SIN + token_idx * emb_dim + emb_dim // 2 + tl.arange(0, emb_dim // 2))
+ 
+-    KV_ptr = KV + pid_m * stride_kv_seq + pid_head * BLOCK_H * stride_kv_nheads
+-    kv_off = tl.arange(0, BLOCK_H)[:, None] * stride_kv_nheads
+-    mask = kv_off < head_num * stride_kv_nheads
+-    k_in_off = kv_off + tl.arange(0, k_dim)[None, :]
+-    v_in_off = kv_off + k_dim + tl.arange(0, v_dim)[None, :]
+-    k = tl.load(KV_ptr + k_in_off, mask=mask)
+-    v = tl.load(KV_ptr + v_in_off, mask=mask)
++    KV_ptr = KV + pid_m * stride_kv_seq # + pid_head * BLOCK_H * stride_kv_nheads
++    ki_range = tl.arange(0, BLOCK_H)[:, None] + pid_head * BLOCK_H
++    kj_range = tl.arange(0, k_dim_ceil)[None, :]
++    mask_k = (ki_range < head_num) & (kj_range < k_dim)
++    mask_v = ki_range < head_num
++    k_off = ki_range * stride_kv_nheads + kj_range
++    if v_dim > 0:
++        v_off = ki_range * stride_kv_nheads + k_dim + tl.arange(0, v_dim)[None, :]
++        v = tl.load(KV_ptr + v_off, mask=mask_v)
++    else:
++        v = tl.zeros((BLOCK_H, 1), dtype=KV.dtype.element_ty)
++    k = tl.load(KV_ptr + k_off, mask=mask_k)
+ 
+-    K_ptr = O_KEY + pid_m * stride_k_seq + pid_head * BLOCK_H * stride_k_nheads
+-    V_ptr = O_VALUE + pid_m * stride_v_seq + pid_head * BLOCK_H * stride_v_nheads
++    K_ptr = O_KEY + pid_m * stride_k_seq # + pid_head * BLOCK_H * stride_k_nheads
++    V_ptr = O_VALUE + pid_m * stride_v_seq # + pid_head * BLOCK_H * stride_v_nheads
+ 
+-    k_out_off = tl.arange(0, BLOCK_H)[:, None] * stride_k_nheads + tl.arange(0, k_dim)[None, :]
+-    v_out_off = tl.arange(0, BLOCK_H)[:, None] * stride_v_nheads + tl.arange(0, v_dim)[None, :]
+-    tl.store(K_ptr + k_out_off, k, mask=mask)
+-    tl.store(V_ptr + v_out_off, v, mask=mask)
++    k_out_off = ki_range * stride_k_nheads + kj_range
++    tl.store(K_ptr + k_out_off, k, mask=mask_k)
++    if v_dim > 0:
++        v_out_off = ki_range * stride_v_nheads + tl.arange(0, v_dim)[None, :]
++        tl.store(V_ptr + v_out_off, v, mask=mask_v)
+ 
+     EMB = K_POS_EMB + pid_m * stride_emb_seq
+     # x1 = t[..., 0::2], x2 = t[..., 1::2]
+@@ -460,14 +467,16 @@ def rotary_fwd_kv_kernel(
+     x_left = x_left.expand_dims(0).broadcast_to(BLOCK_H, emb_dim // 2)
+     x_right = x_right.expand_dims(0).broadcast_to(BLOCK_H, emb_dim // 2)
+ 
++    x_range = tl.arange(0, BLOCK_H)[:, None] + pid_head * BLOCK_H
++    mask_x = x_range < head_num
+     x_left_off = (
+-        tl.arange(0, BLOCK_H)[:, None] * stride_k_nheads
++        x_range * stride_k_nheads
+         + k_dim
+         + tl.arange(0, emb_dim // 2)[None, :]
+     )
+     x_right_off = x_left_off + emb_dim // 2
+-    tl.store(K_ptr + x_left_off, x_left, mask=mask)
+-    tl.store(K_ptr + x_right_off, x_right, mask=mask)
++    tl.store(K_ptr + x_left_off, x_left, mask=mask_x)
++    tl.store(K_ptr + x_right_off, x_right, mask=mask_x)
+ 
+ 
+ @triton.autotune(
+@@ -493,6 +502,7 @@ def rotary_bwd_kv_kernel(
+     SIN,
+     emb_dim: tl.constexpr,
+     k_dim: tl.constexpr,
++    k_dim_ceil: tl.constexpr,
+     v_dim: tl.constexpr,
+     head_num: tl.constexpr,
+     batch_size,
+@@ -533,27 +543,32 @@ def rotary_bwd_kv_kernel(
+     else:
+         token_idx = _get_thd_token_idx(cu_seqlens_kv, pid_m, seq_num, cp_rank, cp_size)
+ 
+-    dKV_ptr = dKV + pid_m * stride_dkv_seq + pid_head * BLOCK_H * stride_dkv_nheads
+-    dkv_off = tl.arange(0, BLOCK_H)[:, None] * stride_dkv_nheads
+-    mask = dkv_off < head_num * stride_dkv_nheads
+-    dk_out_off = dkv_off + tl.arange(0, k_dim)[None, :]
+-    dv_out_off = dkv_off + k_dim + tl.arange(0, v_dim)[None, :]
+-
+-    dK_ptr = dK + pid_m * stride_dk_seq + pid_head * BLOCK_H * stride_dk_nheads
+-    dV_ptr = dV + pid_m * stride_dv_seq + pid_head * BLOCK_H * stride_dv_nheads
+-    dk_in_off = tl.arange(0, BLOCK_H)[:, None] * stride_dk_nheads + tl.arange(0, k_dim)[None, :]
+-    dv_in_off = tl.arange(0, BLOCK_H)[:, None] * stride_dv_nheads + tl.arange(0, v_dim)[None, :]
+-    dk = tl.load(dK_ptr + dk_in_off, mask=mask)
+-    dv = tl.load(dV_ptr + dv_in_off, mask=mask)
+-    tl.store(dKV_ptr + dk_out_off, dk, mask=mask)
+-    tl.store(dKV_ptr + dv_out_off, dv, mask=mask)
++    dKV_ptr = dKV + pid_m * stride_dkv_seq # + pid_head * BLOCK_H * stride_dkv_nheads
++    ki_range = tl.arange(0, BLOCK_H)[:, None] + pid_head * BLOCK_H 
++    kj_range = tl.arange(0, k_dim_ceil)[None, :]
++    mask_k = (ki_range < head_num) & (kj_range < k_dim)
++    mask_v = ki_range < head_num
++    dk_out_off = ki_range * stride_dkv_nheads + kj_range
++
++    dK_ptr = dK + pid_m * stride_dk_seq # + pid_head * BLOCK_H * stride_dk_nheads
++    dV_ptr = dV + pid_m * stride_dv_seq # + pid_head * BLOCK_H * stride_dv_nheads
++    dk_in_off = ki_range * stride_dk_nheads + kj_range
++
++    dk = tl.load(dK_ptr + dk_in_off, mask=mask_k)
++    tl.store(dKV_ptr + dk_out_off, dk, mask=mask_k)
++    
++    if v_dim > 0:
++        dv_out_off = ki_range * stride_dkv_nheads + k_dim + tl.arange(0, v_dim)[None, :]
++        dv_in_off = ki_range * stride_dv_nheads + tl.arange(0, v_dim)[None, :]
++        dv = tl.load(dV_ptr + dv_in_off, mask=mask_v)
++        tl.store(dKV_ptr + dv_out_off, dv, mask=mask_v)
+ 
+     if pid_head == 0:
+         x_left_accum = tl.zeros((BLOCK_H, emb_dim // 2), dtype=tl.float32)
+         x_right_accum = tl.zeros((BLOCK_H, emb_dim // 2), dtype=tl.float32)
+         for i in tl.static_range(triton.cdiv(head_num, BLOCK_H)):
+-            dK_ptr = dK + pid_m * stride_dk_seq + i * BLOCK_H * stride_dk_nheads
+-            x_off = tl.arange(0, BLOCK_H)[:, None] * stride_dk_nheads + k_dim
++            dK_ptr = dK + pid_m * stride_dk_seq # + i * BLOCK_H * stride_dk_nheads
++            x_off = tl.arange(0, BLOCK_H)[:, None] * stride_dk_nheads + k_dim + i * BLOCK_H * stride_dk_nheads
+             mask = x_off < head_num * stride_dk_nheads
+             x_left_off = x_off + tl.arange(0, emb_dim // 2)[None, :]
+             x_right_off = x_left_off + emb_dim // 2
+@@ -632,6 +647,7 @@ class ApplyMLARotaryEmbKV(torch.autograd.Function):
+ 
+         o_key = kv.new_empty(total_seqlen, nheads, emb_dim + k_dim)
+         o_value = kv.new_empty(total_seqlen, nheads, v_dim)
++        k_dim_ceil = triton.next_power_of_2(k_dim)
+ 
+         grid = lambda META: (total_seqlen, triton.cdiv(nheads, META["BLOCK_H"]))
+         rotary_fwd_kv_kernel[grid](
+@@ -643,6 +659,7 @@ class ApplyMLARotaryEmbKV(torch.autograd.Function):
+             sin,
+             emb_dim,
+             k_dim,
++            k_dim_ceil,
+             v_dim,
+             nheads,
+             batch_size,
+@@ -700,6 +717,7 @@ class ApplyMLARotaryEmbKV(torch.autograd.Function):
+ 
+         d_kv = dk.new_empty(total_seqlen, nheads, ctx.k_dim + ctx.v_dim)
+         d_emb = dk.new_empty(total_seqlen, 1, ctx.emb_dim)
++        k_dim_ceil = triton.next_power_of_2(ctx.k_dim)
+ 
+         grid = lambda META: (total_seqlen, triton.cdiv(nheads, META["BLOCK_H"]))
+         rotary_bwd_kv_kernel[grid](
+@@ -711,6 +729,7 @@ class ApplyMLARotaryEmbKV(torch.autograd.Function):
+             sin,
+             ctx.emb_dim,
+             ctx.k_dim,
++            k_dim_ceil,
+             ctx.v_dim,
+             nheads,
+             batch_size,
+diff --git a/megatron/core/models/common/language_module/language_module.py b/megatron/core/models/common/language_module/language_module.py
+index 13d74aa52..060898a7a 100644
+--- a/megatron/core/models/common/language_module/language_module.py
++++ b/megatron/core/models/common/language_module/language_module.py
+@@ -184,7 +184,15 @@ class LanguageModule(MegatronModule):
+             assert (
+                 column_parallel_linear is not None
+             ), "column_parallel_linear cannot be None when not using fused linear cross entropy."
+-            logits, _ = column_parallel_linear(hidden, **col_linear_kwargs)
++            # output
++            output_layer_params = {k: v.detach() for k, v in column_parallel_linear.named_parameters()}
++            output_layer_buffers = dict(column_parallel_linear.named_buffers())
++            logits, _ = torch.func.functional_call(
++                column_parallel_linear,
++                {**output_layer_params, **output_layer_buffers},
++                (hidden,),
++                col_linear_kwargs,
++            )
+ 
+             return self.compute_language_model_loss(labels, logits)
+ 
+diff --git a/megatron/core/models/gpt/gpt_layer_specs.py b/megatron/core/models/gpt/gpt_layer_specs.py
+index e21127b87..712793853 100755
+--- a/megatron/core/models/gpt/gpt_layer_specs.py
++++ b/megatron/core/models/gpt/gpt_layer_specs.py
+@@ -188,6 +188,8 @@ def get_gpt_layer_with_transformer_engine_spec(
+     use_kitchen: bool = False,
+     use_te_activation_func: bool = False,
+     fallback_to_eager_attn: bool = False,
++    post_self_attn_layernorm: bool = False,
++    post_mlp_layernorm: bool = False,
+ ) -> ModuleSpec:
+     """Use this spec to use lower-level Transformer Engine modules (required for fp8 training).
+ 
+@@ -260,6 +262,8 @@ def get_gpt_layer_with_transformer_engine_spec(
+         mlp=mlp,
+         sharded_state_dict_keys_map=sharded_state_dict_keys_map,
+         normalization=normalization,
++        post_self_attn_layernorm=post_self_attn_layernorm,
++        post_mlp_layernorm=post_mlp_layernorm,
+     )
+ 
+ 
+@@ -349,6 +353,8 @@ def get_transformer_layer_spec_for_backend(
+     mlp: ModuleSpec,
+     sharded_state_dict_keys_map: Optional[dict] = None,
+     normalization: Optional[str] = None,
++    post_self_attn_layernorm: bool = False,
++    post_mlp_layernorm: bool = False,
+ ) -> ModuleSpec:
+     """Helper function to get module spec for TransformerLayer"""
+ 
+@@ -371,9 +377,11 @@ def get_transformer_layer_spec_for_backend(
+             input_layernorm=input_layernorm,
+             self_attention=attention,
+             self_attn_bda=get_bias_dropout_add,
++            post_self_attn_layernorm=TENorm if post_self_attn_layernorm else IdentityOp,
+             pre_mlp_layernorm=pre_mlp_layernorm,
+             mlp=mlp,
+             mlp_bda=get_bias_dropout_add,
++            post_mlp_layernorm=TENorm if post_mlp_layernorm else IdentityOp,
+             sharded_state_dict_keys_map=sharded_state_dict_keys_map,
+         ),
+     )
+diff --git a/megatron/core/models/gpt/gpt_model.py b/megatron/core/models/gpt/gpt_model.py
+index a1230568c..1fd52f65a 100644
+--- a/megatron/core/models/gpt/gpt_model.py
++++ b/megatron/core/models/gpt/gpt_model.py
+@@ -446,6 +446,7 @@ class GPTModel(LanguageModule):
+         *,
+         inference_params: Optional[BaseInferenceContext] = None,
+         loss_mask: Optional[Tensor] = None,
++        mtp_kwargs: Optional[dict] = {},
+     ) -> Tensor:
+         """Forward function of the GPT Model This function passes the input tensors
+         through the embedding layer, and then the decoder and finally into the post
+@@ -508,6 +509,7 @@ class GPTModel(LanguageModule):
+             runtime_gather_output=runtime_gather_output,
+             extra_block_kwargs=extra_block_kwargs,
+             inference_context=inference_context,
++            mtp_kwargs=mtp_kwargs,
+         )
+ 
+     def _postprocess(
+@@ -529,6 +531,7 @@ class GPTModel(LanguageModule):
+         runtime_gather_output=None,
+         extra_block_kwargs=None,
+         inference_context=None,
++        mtp_kwargs={},
+     ):
+         """Postprocesses decoder hidden states to generate logits or compute loss.
+ 
+@@ -543,7 +546,8 @@ class GPTModel(LanguageModule):
+         output_weight = None
+         if self.share_embeddings_and_output_weights:
+             output_weight = self.shared_embedding_or_output_weight()
+-        if mtp_in_postprocess:
++
++        if mtp_in_postprocess and mtp_kwargs.get('mtp_labels', None) is not None:
+             hidden_states = self.mtp(
+                 input_ids=input_ids,
+                 position_ids=position_ids,
+@@ -563,13 +567,18 @@ class GPTModel(LanguageModule):
+             return hidden_states
+ 
+         # Skip when mtp_num_layers is None or 0
+-        if self.config.mtp_num_layers:
+-            mtp_labels = labels.clone()
++        if self.config.mtp_num_layers and mtp_kwargs.get('mtp_labels', None) is not None:
++            mtp_labels = mtp_kwargs['mtp_labels'].clone()
++            mtp_labels, _ = roll_tensor(mtp_labels, shifts=-1, dims=-1, cp_group=self.cp_group, packed_seq_params=packed_seq_params)
++
+             hidden_states_list = torch.chunk(hidden_states, 1 + self.config.mtp_num_layers, dim=0)
+             hidden_states = hidden_states_list[0]
+             if loss_mask is None:
+                 # if loss_mask is not provided, use all ones as loss_mask
+                 loss_mask = torch.ones_like(mtp_labels)
++            else:
++                # Otherwise, roll the loss_mask to keep up with the mtp_labels
++                loss_mask, _ = roll_tensor(loss_mask, shifts=-1, dims=-1, cp_group=self.cp_group, packed_seq_params=packed_seq_params)
+             for mtp_layer_number in range(self.config.mtp_num_layers):
+                 # Calc loss for the current Multi-Token Prediction (MTP) layers.
+                 mtp_labels, _ = roll_tensor(
+@@ -595,7 +604,7 @@ class GPTModel(LanguageModule):
+                     sequence_parallel_enabled=self.output_layer.sequence_parallel,
+                     column_parallel_linear=self.output_layer,
+                     col_linear_kwargs={
+-                        'weight': output_weight,
++                        'weight': output_weight.detach() if output_weight else None,
+                         'runtime_gather_output': runtime_gather_output,
+                     },
+                 )
+diff --git a/megatron/core/optimizer/distrib_optimizer.py b/megatron/core/optimizer/distrib_optimizer.py
+index 6e093f96f..eac21a3ea 100644
+--- a/megatron/core/optimizer/distrib_optimizer.py
++++ b/megatron/core/optimizer/distrib_optimizer.py
+@@ -677,6 +677,8 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
+                 # TE FusedAdam will not accumulate step for empty param groups, so we need to
+                 # align the step across param groups.
+                 param_group["step"] = int(step)
++            if "step" in param_group and param_group["step"] is None:
++                del param_group["step"]
+ 
+         # Grad scaler state.
+         if self.grad_scaler:
+@@ -1646,6 +1648,8 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
+                             if key == 'padding':
+                                 tensors[key] = LocalNonpersistentObject(tensors[key])
+                                 continue
++                            if key == 'step':
++                                continue
+                             assert tensors[key].shape == (gbuf_local_end - gbuf_local_start,), (
+                                 tensors[key].shape,
+                                 gbuf_local_start,
+diff --git a/megatron/core/parallel_state.py b/megatron/core/parallel_state.py
+index a273002b9..4f821cfd5 100644
+--- a/megatron/core/parallel_state.py
++++ b/megatron/core/parallel_state.py
+@@ -11,6 +11,7 @@ from typing import Callable, List, Optional
+ 
+ import numpy as np
+ import torch
++import torch.distributed as dist
+ 
+ from .utils import GlobalMemoryBuffer, is_torch_min_version
+ 
+diff --git a/megatron/core/pipeline_parallel/p2p_communication.py b/megatron/core/pipeline_parallel/p2p_communication.py
+index ac839c21f..f18309217 100644
+--- a/megatron/core/pipeline_parallel/p2p_communication.py
++++ b/megatron/core/pipeline_parallel/p2p_communication.py
+@@ -26,22 +26,22 @@ def _batched_p2p_ops(
+     ops = []
+     if tensor_send_prev is not None:
+         send_prev_op = torch.distributed.P2POp(
+-            torch.distributed.isend, tensor_send_prev, prev_pipeline_rank, group
++            torch.distributed.isend, tensor_send_prev, prev_pipeline_rank,
+         )
+         ops.append(send_prev_op)
+     if tensor_recv_prev is not None:
+         recv_prev_op = torch.distributed.P2POp(
+-            torch.distributed.irecv, tensor_recv_prev, prev_pipeline_rank, group
++            torch.distributed.irecv, tensor_recv_prev, prev_pipeline_rank,
+         )
+         ops.append(recv_prev_op)
+     if tensor_send_next is not None:
+         send_next_op = torch.distributed.P2POp(
+-            torch.distributed.isend, tensor_send_next, next_pipeline_rank, group
++            torch.distributed.isend, tensor_send_next, next_pipeline_rank,
+         )
+         ops.append(send_next_op)
+     if tensor_recv_next is not None:
+         recv_next_op = torch.distributed.P2POp(
+-            torch.distributed.irecv, tensor_recv_next, next_pipeline_rank, group
++            torch.distributed.irecv, tensor_recv_next, next_pipeline_rank,
+         )
+         ops.append(recv_next_op)
+     if len(ops) > 0:
+diff --git a/megatron/core/transformer/moe/moe_utils.py b/megatron/core/transformer/moe/moe_utils.py
+index 28cff06f5..58dc4bb70 100644
+--- a/megatron/core/transformer/moe/moe_utils.py
++++ b/megatron/core/transformer/moe/moe_utils.py
+@@ -587,6 +587,9 @@ def topk_routing_with_score_function(
+         else:
+             return torch.topk(scores, k=topk, dim=1)
+ 
++    from slime.utils.routing_replay import get_routing_replay_compute_topk
++    compute_topk = get_routing_replay_compute_topk(compute_topk)
++
+     if score_function == "softmax":
+         if use_pre_softmax:
+             scores = torch.softmax(logits, dim=-1, dtype=torch.float32).type_as(logits)
+diff --git a/megatron/core/transformer/moe/router.py b/megatron/core/transformer/moe/router.py
+index 16fc9d9af..517944f25 100644
+--- a/megatron/core/transformer/moe/router.py
++++ b/megatron/core/transformer/moe/router.py
+@@ -201,6 +201,9 @@ class TopKRouter(Router):
+             self.global_tokens_per_expert = None
+             self.ga_steps = None
+ 
++        from slime.utils.routing_replay import register_routing_replay
++        register_routing_replay(self)
++
+     def _maintain_float32_expert_bias(self):
+         """
+         Maintain the expert bias in float32.
+diff --git a/megatron/core/transformer/multi_token_prediction.py b/megatron/core/transformer/multi_token_prediction.py
+index a8f4abfcd..f33f6f05e 100755
+--- a/megatron/core/transformer/multi_token_prediction.py
++++ b/megatron/core/transformer/multi_token_prediction.py
+@@ -6,6 +6,7 @@ from typing import Callable, List, Optional, Union
+ 
+ import torch
+ from torch import Tensor
++import warnings
+ 
+ from megatron.core import InferenceParams, parallel_state, tensor_parallel
+ from megatron.core.dist_checkpointing.mapping import ShardedStateDict
+@@ -714,17 +715,19 @@ class MultiTokenPredictionLayer(MegatronModule):
+             cp_group=self.cp_group,
+             packed_seq_params=packed_seq_params,
+         )
+-        position_ids, _ = roll_tensor(
+-            position_ids,
+-            shifts=-1,
+-            dims=-1,
+-            cp_group=self.cp_group,
+-            packed_seq_params=packed_seq_params,
+-        )
++        if position_ids is not None:
++            position_ids, _ = roll_tensor(
++                position_ids,
++                shifts=-1,
++                dims=-1,
++                cp_group=self.cp_group,
++                packed_seq_params=packed_seq_params,
++            )
+         # embedding
+         decoder_input = embedding(input_ids=input_ids, position_ids=position_ids)
++        decoder_input = decoder_input.detach()
+ 
+-        hidden_states = make_viewless_tensor(inp=hidden_states, requires_grad=True, keep_graph=True)
++        hidden_states = make_viewless_tensor(inp=hidden_states, requires_grad=True, keep_graph=False)
+ 
+         return input_ids, position_ids, decoder_input, hidden_states
+ 
+@@ -826,6 +829,51 @@ class MultiTokenPredictionLayer(MegatronModule):
+         return hidden_states
+ 
+     def _checkpointed_forward(self, forward_func, *args, **kwargs):
++        """Wrap `forward_func` with activation checkpointing while only passing tensors.
++
++        Non-tensor arguments (e.g., configuration objects, None) are captured via closure so
++        that checkpoint implementations never receive them directly, avoiding save_for_backward
++        issues with non-tensor inputs.
++        """
++
++        # TODO(jiajun): Is there any better implementation here?
++        positional_specs = []
++        kw_specs = []
++        tensor_args: List[torch.Tensor] = []
++
++        for arg in args:
++            if torch.is_tensor(arg):
++                positional_specs.append(('tensor', len(tensor_args)))
++                tensor_args.append(arg)
++            else:
++                positional_specs.append(('const', arg))
++
++        for key, value in kwargs.items():
++            if torch.is_tensor(value):
++                kw_specs.append((key, ('tensor', len(tensor_args))))
++                tensor_args.append(value)
++            else:
++                kw_specs.append((key, ('const', value)))
++
++        def run(*flat_tensor_args):
++            rebuilt_args = []
++            for spec_type, payload in positional_specs:
++                if spec_type == 'tensor':
++                    rebuilt_args.append(flat_tensor_args[payload])
++                else:
++                    rebuilt_args.append(payload)
++
++            rebuilt_kwargs = {}
++            for key, (spec_type, payload) in kw_specs:
++                if spec_type == 'tensor':
++                    rebuilt_kwargs[key] = flat_tensor_args[payload]
++                else:
++                    rebuilt_kwargs[key] = payload
++
++            return forward_func(*rebuilt_args, **rebuilt_kwargs)
++
++        tensor_args_tuple = tuple(tensor_args)
++
+         def checkpoint_handler():
+             """Determines whether to use the `te_checkpoint` or `tensor_parallel.checkpoint`"""
+             if self.config.fp8:
+@@ -836,12 +884,11 @@ class MultiTokenPredictionLayer(MegatronModule):
+                     self.config.distribute_saved_activations,
+                     tensor_parallel.random.get_cuda_rng_tracker,
+                     parallel_state.get_tensor_model_parallel_group(),
+-                    *args,
+-                    **kwargs,
++                    *tensor_args_tuple,
+                 )
+             else:
+                 return tensor_parallel.checkpoint(
+-                    forward_func, self.config.distribute_saved_activations, *args, *kwargs.values()
++                    run, self.config.distribute_saved_activations, *tensor_args_tuple
+                 )
+ 
+         if self.config.recompute_method == 'uniform':
+diff --git a/megatron/core/transformer/transformer_config.py b/megatron/core/transformer/transformer_config.py
+index e2705bd9f..a0aa109b5 100644
+--- a/megatron/core/transformer/transformer_config.py
++++ b/megatron/core/transformer/transformer_config.py
+@@ -210,6 +210,9 @@ class TransformerConfig(ModelParallelConfig):
+     attention_output_gate: bool = False
+     """Whether to apply output gate to the attention layers."""
+ 
++    post_self_attn_layernorm: bool = False
++    post_mlp_layernorm: bool = False
++
+     test_mode: bool = False
+     """Whether to run real-time tests."""
+ 
+diff --git a/megatron/core/transformer/transformer_layer.py b/megatron/core/transformer/transformer_layer.py
+index 3ea405770..5a42001b9 100644
+--- a/megatron/core/transformer/transformer_layer.py
++++ b/megatron/core/transformer/transformer_layer.py
+@@ -223,6 +223,7 @@ class TransformerLayerSubmodules:
+     input_layernorm: Union[ModuleSpec, type] = IdentityOp
+     self_attention: Union[ModuleSpec, type] = IdentityOp
+     self_attn_bda: Union[ModuleSpec, type] = IdentityFuncOp
++    post_self_attn_layernorm: Union[ModuleSpec, type] = IdentityOp
+ 
+     pre_cross_attn_layernorm: Union[ModuleSpec, type] = IdentityOp
+     cross_attention: Union[ModuleSpec, type] = IdentityOp
+@@ -231,6 +232,7 @@ class TransformerLayerSubmodules:
+     pre_mlp_layernorm: Union[ModuleSpec, type] = IdentityOp
+     mlp: Union[ModuleSpec, type] = IdentityOp
+     mlp_bda: Union[ModuleSpec, type] = IdentityFuncOp
++    post_mlp_layernorm: Union[ModuleSpec, type] = IdentityOp
+ 
+     # Mapping for sharded tensor keys to be applied in `sharded_state_dict` method
+     sharded_state_dict_keys_map: Dict[str, str] = field(default_factory=dict)
+@@ -310,6 +312,13 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
+         # [Module 3: BiasDropoutFusion]
+         self.self_attn_bda = build_module(submodules.self_attn_bda)
+ 
++        self.post_self_attn_layernorm = build_module(
++            submodules.post_self_attn_layernorm,
++            config=self.config,
++            hidden_size=self.config.hidden_size,
++            eps=self.config.layernorm_epsilon,
++        )
++
+         # [Module 4: Post SelfAttention] Optional Layernorm after self-attn
+         self.pre_cross_attn_layernorm = build_module(
+             submodules.pre_cross_attn_layernorm,
+@@ -375,6 +384,13 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
+ 
+         self.is_moe_layer = isinstance(self.mlp, MoELayer)
+ 
++        self.post_mlp_layernorm = build_module(
++            submodules.post_mlp_layernorm,
++            config=self.config,
++            hidden_size=self.config.hidden_size,
++            eps=self.config.layernorm_epsilon
++        )
++
+         self.recompute_input_layernorm = False
+         self.recompute_pre_mlp_layernorm = False
+         self.recompute_mlp = False
+@@ -551,6 +567,10 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
+                 attention_output_with_bias[0]
+             )
+ 
++        attention_output, attention_output_bias = attention_output_with_bias
++        attention_output = self.post_self_attn_layernorm(attention_output)
++        attention_output_with_bias = (attention_output, attention_output_bias)
++
+         # TODO: could we move `bias_dropout_add_exec_handler` itself
+         # inside the module provided in the `bias_dropout_add_spec` module?
+         nvtx_range_push(suffix="self_attn_bda")
+@@ -677,6 +697,10 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
+         else:
+             mlp_output_with_bias = self.mlp(pre_mlp_layernorm_output)
+ 
++        mlp_output, mlp_output_bias = mlp_output_with_bias
++        mlp_output = self.post_mlp_layernorm(mlp_output)
++        mlp_output_with_bias = (mlp_output, mlp_output_bias)
++
+         if self.recompute_pre_mlp_layernorm:
+             # discard the output of the pre-mlp layernorm and register the recompute
+             # as a gradient hook of mlp_output_with_bias[0]
+diff --git a/megatron/training/arguments.py b/megatron/training/arguments.py
+index b267c8a81..83736acdc 100644
+--- a/megatron/training/arguments.py
++++ b/megatron/training/arguments.py
+@@ -1398,6 +1398,9 @@ def core_transformer_config_from_args(args, config_class=None):
+ 
+     kw_args['inference_sampling_seed'] = args.seed
+ 
++    kw_args['post_self_attn_layernorm'] = args.post_self_attn_layernorm
++    kw_args['post_mlp_layernorm'] = args.post_mlp_layernorm
++
+     # handle quantization config
+     # NOTE: Kitchen arguments are only added to the namespace when
+     # Kitchen library is available.
+@@ -1764,6 +1767,12 @@ def _add_network_size_args(parser):
+                        action='store_true',
+                        help='If set, use original BERT residula connection '
+                        'ordering.')
++    group.add_argument('--post-self-attn-layernorm', action='store_true',
++                       help='If set, use post self attention layernorm.')
++    group.add_argument('--post-mlp-layernorm', action='store_true',
++                       help='If set, use post MLP layernorm.')
++    group.add_argument('--use-gated-attention', action='store_true',
++                       help='If set, use gated attention as in Qwen3Next')
+     group.add_argument('--openai-gelu', action='store_true',
+                        help='Use OpenAIs GeLU implementation. This option'
+                        'should not be used unless for backward compatibility'
+diff --git a/megatron/training/tokenizer/tokenizer.py b/megatron/training/tokenizer/tokenizer.py
+index 13b7526ca..6c590f653 100644
+--- a/megatron/training/tokenizer/tokenizer.py
++++ b/megatron/training/tokenizer/tokenizer.py
+@@ -136,7 +136,7 @@ class _HuggingFaceTokenizer(MegatronLegacyTokenizer):
+         # TODO(bnorick): download tokenizer once to lustre and use force offline to make sure all tasks read it from there
+         self._tokenizer = transformers.AutoTokenizer.from_pretrained(
+             pretrained_model_name_or_path=pretrained_model_name_or_path,
+-            trust_remote_code=trust_remote_code,
++            trust_remote_code=True,
+             **kwargs,
+         )
+         self._vocab = self._tokenizer.get_vocab()

--- a/docker/npu_patch/miles.patch
+++ b/docker/npu_patch/miles.patch
@@ -1,0 +1,568 @@
+diff --git a/miles/backends/experimental/fsdp_utils/update_weight_utils.py b/miles/backends/experimental/fsdp_utils/update_weight_utils.py
+index 98000e7d3..94fb71da5 100644
+--- a/miles/backends/experimental/fsdp_utils/update_weight_utils.py
++++ b/miles/backends/experimental/fsdp_utils/update_weight_utils.py
+@@ -234,12 +234,12 @@ class UpdateWeightFromDistributed(UpdateWeight):
+                     i * self.args.rollout_num_gpus_per_engine + 1,
+                     world_size,
+                     self._group_name,
+-                    backend="nccl",
++                    backend="hccl",
+                 )
+                 for i, engine in enumerate(self.rollout_engines)
+             ]
+             self._model_update_groups = init_process_group(
+-                backend="nccl",
++                backend="hccl",
+                 init_method=f"tcp://{master_address}:{master_port}",
+                 world_size=world_size,
+                 rank=0,
+diff --git a/miles/backends/megatron_utils/__init__.py b/miles/backends/megatron_utils/__init__.py
+index 879b689c8..2f30a4bbd 100644
+--- a/miles/backends/megatron_utils/__init__.py
++++ b/miles/backends/megatron_utils/__init__.py
+@@ -1,6 +1,7 @@
+ import logging
+ 
+ import torch
++import mindspeed.megatron_adaptor
+ 
+ try:
+     import deep_ep
+diff --git a/miles/backends/megatron_utils/actor.py b/miles/backends/megatron_utils/actor.py
+index 54ca4b81a..3f79e49b7 100644
+--- a/miles/backends/megatron_utils/actor.py
++++ b/miles/backends/megatron_utils/actor.py
+@@ -39,12 +39,14 @@ from .parallel import verify_megatron_parallel_state
+ from .replay_utils import get_register_replay_list_func
+ from .update_weight.common import named_params_and_buffers
+ from .update_weight.update_weight_from_distributed.broadcast import UpdateWeightFromDistributed
+-from .update_weight.update_weight_from_distributed.p2p import UpdateWeightP2P
++# from .update_weight.update_weight_from_distributed.p2p import UpdateWeightP2P
+ from .update_weight.update_weight_from_tensor import UpdateWeightFromTensor
+ 
+ logging.getLogger("megatron").setLevel(logging.WARNING)
+ 
+ logger = logging.getLogger(__name__)
++import mindspeed.megatron_adaptor
++from mindspeed.megatron_adaptor import repatch
+ 
+ 
+ class MegatronTrainRayActor(TrainRayActor):
+@@ -58,7 +60,7 @@ class MegatronTrainRayActor(TrainRayActor):
+         monkey_patch_torch_dist()
+ 
+         super().init(args, role, with_ref)
+-
++        repatch(args)
+         init(args)
+ 
+         if args.dumper_enable:
+@@ -598,7 +600,7 @@ class MegatronTrainRayActor(TrainRayActor):
+         group_name = "actor_critic"
+         world_size = 2
+         self._actor_critic_groups = init_process_group(
+-            backend="nccl",
++            backend="hccl",
+             init_method=f"tcp://{master_address}:{master_port}",
+             world_size=world_size,
+             rank=0 if self.role == "actor" else 1,
+diff --git a/miles/backends/megatron_utils/initialize.py b/miles/backends/megatron_utils/initialize.py
+index dd3415c0a..15527171d 100644
+--- a/miles/backends/megatron_utils/initialize.py
++++ b/miles/backends/megatron_utils/initialize.py
+@@ -13,6 +13,7 @@ from miles.backends.training_utils.parallel import get_parallel_state, set_paral
+ from .parallel import create_megatron_parallel_state
+ 
+ logger = logging.getLogger(__name__)
++import mindspeed.megatron_adaptor
+ 
+ 
+ def _set_random_seed(
+diff --git a/miles/backends/megatron_utils/model.py b/miles/backends/megatron_utils/model.py
+index 5d2503dab..69051ddc5 100644
+--- a/miles/backends/megatron_utils/model.py
++++ b/miles/backends/megatron_utils/model.py
+@@ -142,6 +142,11 @@ def setup_model_and_optimizer(
+             kwargs[f.name] = getattr(args, f.name)
+     config = OptimizerConfig(**kwargs)
+     config.timers = None
++    
++    for model_item in model:
++        for name, param in model_item.named_parameters():
++            if not param.is_leaf:
++                print(f"ERROR: param {name} is non-leaf, grad_fn={param.grad_fn}")
+ 
+     optimizer = get_megatron_optimizer(
+         config=config,
+diff --git a/miles/backends/megatron_utils/model_provider.py b/miles/backends/megatron_utils/model_provider.py
+index 45adc8679..c6c307a11 100644
+--- a/miles/backends/megatron_utils/model_provider.py
++++ b/miles/backends/megatron_utils/model_provider.py
+@@ -110,6 +110,20 @@ def get_model_provider_func(
+             provider.moe_router_bias_update_rate = args.moe_router_bias_update_rate
+         if getattr(args, "moe_aux_loss_coeff", None) is not None:
+             provider.moe_aux_loss_coeff = args.moe_aux_loss_coeff
++        
++        if getattr(args, "gradient_accumulation_fusion", None) is not None:
++            provider.gradient_accumulation_fusion = args.gradient_accumulation_fusion
++
++        provider.moe_permute_fusion = args.moe_permute_fusion
++        provider.moe_aux_loss_coeff = args.moe_aux_loss_coeff
++
++        provider.freeze_language_model = False
++        provider.freeze_vision_model = False
++
++        for key, value in vars(args).items():
++            if hasattr(provider, key):
++                continue
++            setattr(provider, key, value)
+         provider.finalize()
+ 
+         def wrapped_bridge_provider(
+diff --git a/miles/backends/megatron_utils/update_weight/common.py b/miles/backends/megatron_utils/update_weight/common.py
+index 677f93c62..79ee57664 100644
+--- a/miles/backends/megatron_utils/update_weight/common.py
++++ b/miles/backends/megatron_utils/update_weight/common.py
+@@ -154,8 +154,8 @@ def named_params_and_buffers(
+ def _maybe_get_cpu_backup(x: torch.Tensor):
+     from torch_memory_saver import torch_memory_saver
+ 
+-    if (cpu_tensor := torch_memory_saver.get_cpu_backup(x)) is not None:
+-        return cpu_tensor
++    # if (cpu_tensor := torch_memory_saver.get_cpu_backup(x)) is not None:
++    #     return cpu_tensor
+ 
+     return x
+ 
+diff --git a/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/broadcast.py b/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/broadcast.py
+index 51afedac4..c31c04a46 100644
+--- a/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/broadcast.py
++++ b/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/broadcast.py
+@@ -129,12 +129,12 @@ def connect_rollout_engines_from_distributed(
+                 rank_cursor,
+                 world_size,
+                 group_name,
+-                backend="nccl",
++                backend="hccl",
+             )
+         )
+         rank_cursor += engine_gpu_counts[i]
+     model_update_groups = init_process_group(
+-        backend="nccl",
++        backend="hccl",
+         init_method=f"tcp://{master_address}:{master_port}",
+         world_size=world_size,
+         rank=0,
+diff --git a/miles/ray/actor_group.py b/miles/ray/actor_group.py
+index 669988b52..723113a69 100644
+--- a/miles/ray/actor_group.py
++++ b/miles/ray/actor_group.py
+@@ -85,7 +85,9 @@ class RayTrainGroup:
+ 
+             actor_impl = FSDPTrainRayActor
+ 
+-        TrainRayActor = ray.remote(num_gpus=1, runtime_env={"env_vars": env_vars})(actor_impl)
++        # TrainRayActor = ray.remote(num_gpus=1, runtime_env={"env_vars": env_vars})(actor_impl)
++        TrainRayActor = ray.remote(runtime_env={"env_vars": env_vars})(actor_impl)
++        device_name = "NPU"
+ 
+         # Create worker actors
+         actor_handles = []
+@@ -93,11 +95,12 @@ class RayTrainGroup:
+         for rank in range(world_size):
+             actor = TrainRayActor.options(
+                 num_cpus=num_gpus_per_actor,
+-                num_gpus=num_gpus_per_actor,
++                # num_gpus=num_gpus_per_actor,
+                 scheduling_strategy=PlacementGroupSchedulingStrategy(
+                     placement_group=pg,
+                     placement_group_bundle_index=reordered_bundle_indices[rank],
+                 ),
++                resources={device_name: num_gpus_per_actor}
+             ).remote(world_size, rank, master_addr, master_port)
+             if rank == 0:
+                 master_addr, master_port = ray.get(actor.get_master_addr_and_port.remote())
+diff --git a/miles/ray/placement_group.py b/miles/ray/placement_group.py
+index bf8244b90..12442d9d6 100644
+--- a/miles/ray/placement_group.py
++++ b/miles/ray/placement_group.py
+@@ -14,10 +14,12 @@ from .rollout import RolloutManager
+ logger = logging.getLogger(__name__)
+ 
+ 
+-@ray.remote(num_gpus=1)
++# @ray.remote(num_gpus=1)
++@ray.remote
+ class InfoActor:
+     def get_ip_and_gpu_id(self):
+-        return ray.util.get_node_ip_address(), ray.get_gpu_ids()[0]
++        # return ray.util.get_node_ip_address(), ray.get_gpu_ids()[0]
++        return ray.util.get_node_ip_address(), ray.get_runtime_context().get_accelerator_ids()["NPU"][0]
+ 
+ 
+ def sort_key(x):
+@@ -38,12 +40,15 @@ def sort_key(x):
+             # representation that allows for sorting.
+             node_ip_parts = [ord(c) for c in node_identifier]
+ 
+-    return (node_ip_parts, gpu_id)
++    # return (node_ip_parts, gpu_id)
++    return (node_ip_parts, int(gpu_id))
+ 
+ 
+ def _create_placement_group(num_gpus):
+     """Create a placement group with the specified number of GPUs."""
+-    bundles = [{"GPU": 1, "CPU": 1} for _ in range(num_gpus)]
++    # bundles = [{"GPU": 1, "CPU": 1} for _ in range(num_gpus)]
++    device_name = "NPU"
++    bundles = [{device_name: 1, "CPU": 1} for _ in range(num_gpus)]
+     pg = placement_group(bundles, strategy="PACK")
+     num_bundles = len(bundles)
+ 
+@@ -56,7 +61,8 @@ def _create_placement_group(num_gpus):
+                 scheduling_strategy=PlacementGroupSchedulingStrategy(
+                     placement_group=pg,
+                     placement_group_bundle_index=i,
+-                )
++                ),
++                resources={device_name: 1}
+             ).remote()
+         )
+     gpu_ids = ray.get([actor.get_ip_and_gpu_id.remote() for actor in info_actors])
+@@ -174,8 +180,9 @@ async def create_training_models(args, pgs, rollout_manager):
+ 
+ 
+ def create_rollout_manager(args, pg):
++    device_name = "NPU"
+     rollout_manager = RolloutManager.options(
+-        num_cpus=1, num_gpus=0, **(compute_ray_pin_head_options() if args.pin_rollout_manager_to_head else {})
++        num_cpus=1, resources={device_name: 0}, **(compute_ray_pin_head_options() if args.pin_rollout_manager_to_head else {})
+     ).remote(args, pg)
+ 
+     # calculate num_rollout from num_epoch
+diff --git a/miles/ray/rollout.py b/miles/ray/rollout.py
+index ded71b511..89f515c9d 100644
+--- a/miles/ray/rollout.py
++++ b/miles/ray/rollout.py
+@@ -140,14 +140,15 @@ class ServerGroup:
+                 }.items()
+             }
+             env_vars.update(dumper_utils.get_sglang_env(self.args))
+-
++            device_name = "NPU"
+             rollout_engine = RolloutRayActor.options(
+                 num_cpus=num_cpus,
+-                num_gpus=num_gpus,
++                # num_gpus=num_gpus,
+                 scheduling_strategy=scheduling_strategy,
+                 runtime_env={
+                     "env_vars": env_vars,
+                 },
++                resources={device_name: num_gpus}
+             ).remote(
+                 self.args,
+                 rank=global_rank,
+@@ -371,7 +372,9 @@ class RolloutManager:
+             init_http_client(args)
+             self.servers = start_rollout_servers(args, pg)
+             _start_session_server(args)
+-        self.rollout_engine_lock = Lock.options(num_cpus=1, num_gpus=0).remote()
++        # self.rollout_engine_lock = Lock.options(num_cpus=1, num_gpus=0).remote()
++        device_name = "NPU"
++        self.rollout_engine_lock = Lock.options(num_cpus=1, resources={device_name: 0}).remote()
+         self.rollout_id = -1
+ 
+         self._metric_checker = MetricChecker.maybe_create(args)
+diff --git a/miles/ray/train_actor.py b/miles/ray/train_actor.py
+index a4145ca27..33340323e 100644
+--- a/miles/ray/train_actor.py
++++ b/miles/ray/train_actor.py
+@@ -20,10 +20,17 @@ logger = logging.getLogger(__name__)
+ 
+ def get_local_gpu_id():
+     cvd = os.environ.get("CUDA_VISIBLE_DEVICES", None)
++    # if cvd is None:
++    #     return ray.get_gpu_ids()[0]
++    # else:
++    #     return cvd.split(",").index(str(ray.get_gpu_ids()[0]))
++    env_var = "ASCEND_RT_VISIBLE_DEVICES"
++    device_ids = ray.get_runtime_context().get_accelerator_ids()["NPU"]
++    cvd = os.environ.get(env_var, None)
+     if cvd is None:
+-        return ray.get_gpu_ids()[0]
++        return device_ids[0]
+     else:
+-        return cvd.split(",").index(str(ray.get_gpu_ids()[0]))
++        return cvd.split(",").index(str(device_ids[0]))
+ 
+ 
+ class TrainRayActor(RayActor):
+diff --git a/miles/utils/arguments.py b/miles/utils/arguments.py
+index abfa137ac..7c5fe007a 100644
+--- a/miles/utils/arguments.py
++++ b/miles/utils/arguments.py
+@@ -119,7 +119,7 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
+                 ),
+             )
+ 
+-            reset_arg(parser, "--distributed-backend", type=str, default="nccl")
++            reset_arg(parser, "--distributed-backend", type=str, default="hccl")
+             reset_arg(parser, "--distributed-timeout-minutes", type=int, default=10)
+ 
+             return parser
+@@ -2252,7 +2252,7 @@ def hf_validate_args(args, hf_config):
+         ("tie_word_embeddings", "untie_embeddings_and_output_weights", lambda x, y: not x == y),
+         (
+             "rms_norm_eps",
+-            "norm_epsilon" if os.getenv("DEPRECATED_MEGATRON_COMPATIBLE", "0") == "1" else "layernorm_epsilon",
++            "norm_epsilon" if os.getenv("DEPRECATED_MEGATRON_COMPATIBLE", "0") == "1" else "norm_epsilon",
+             equal,
+         ),
+         ("rope_theta", "rotary_base", equal),
+diff --git a/miles/utils/debug_utils/run_megatron/worker/main.py b/miles/utils/debug_utils/run_megatron/worker/main.py
+index 359a51c1d..78e697e7c 100644
+--- a/miles/utils/debug_utils/run_megatron/worker/main.py
++++ b/miles/utils/debug_utils/run_megatron/worker/main.py
+@@ -117,9 +117,9 @@ def _parse_args() -> tuple[argparse.Namespace, WorkerScriptArgs]:
+ 
+ 
+ def _initialize_megatron(args: argparse.Namespace) -> None:
+-    torch.distributed.init_process_group(backend="nccl")
++    torch.distributed.init_process_group(backend="hccl")
+     local_rank: int = int(os.environ.get("LOCAL_RANK", 0))
+-    torch.cuda.set_device(local_rank)
++    torch.npu.set_device(local_rank)
+ 
+     args.hf_checkpoint = str(args.script_hf_checkpoint)
+     args.__dict__.setdefault("megatron_to_hf_mode", "raw")
+diff --git a/miles/utils/external_utils/command_utils.py b/miles/utils/external_utils/command_utils.py
+index d016e01ac..08b4d6eff 100644
+--- a/miles/utils/external_utils/command_utils.py
++++ b/miles/utils/external_utils/command_utils.py
+@@ -193,6 +193,112 @@ def execute_train(
+         )
+ 
+ 
++def execute_train_npu(
++    train_args: str,
++    num_gpus_per_node: int,
++    megatron_model_type: str | None,
++    train_script: str = "train.py",
++    before_ray_job_submit=None,
++    extra_env_vars=None,
++    config: ExecuteTrainConfig | None = None,
++    megatron_path: str = "/root/Megatron-LM",
++):
++    if extra_env_vars is None:
++        extra_env_vars = {}
++    if config is None:
++        config = ExecuteTrainConfig()
++    external_ray = get_bool_env_var("SLIME_SCRIPT_EXTERNAL_RAY")
++    master_addr = os.environ.get("MASTER_ADDR", "127.0.0.1")
++
++    train_backend_fsdp = "--train-backend fsdp" in train_args
++    assert train_backend_fsdp == (megatron_model_type is None)
++
++    exec_command(
++        "pkill -9 sglang; "
++        "sleep 3; "
++        f"{'' if external_ray else 'ray stop --force; '}"
++        f"{'' if external_ray else 'pkill -9 ray; '}"
++        # cannot be run in CI, o/w kill the parent script
++        # "pkill -9 python; "
++        "pkill -9 slime; "
++        "sleep 3; "
++        f"{'' if external_ray else 'pkill -9 ray; '}"
++        # "pkill -9 python; "
++        "pkill -9 slime; "
++        "pkill -9 redis; "
++        "true; "
++    )
++
++    if not external_ray:
++        exec_command(
++            # will prevent ray from buffering stdout/stderr
++            f"export PYTHONBUFFERED=16 && "
++            f"ray start --head --node-ip-address {master_addr} --disable-usage-stats "
++        )
++
++    f = before_ray_job_submit
++    if f is not None: 
++        f()
++
++    runtime_env_json = json.dumps(
++        {
++            "env_vars": {
++                "CUDA_DEVICE_MAX_CONNECTIONS": "1",
++                "RAY_EXPERIMENTAL_NOSET_ASCEND_RT_VISIBLE_DEVICES": "1",
++                # Replace with actual Ascend toolkit paths
++                "ASCEND_TOOLKIT_HOME": "/home/w00664509/ascend-toolkit/latest/",
++                "ASCEND_OPP_PATH": "/home/w00664509/cann8.5.2/ascend-toolkit/latest/opp/",
++                "ASCEND_AICPU_PATH": "/home/w00664509/cann8.5.2/ascend-toolkit/latest/",
++                "ASCEND_HOME_PATH": "/home/w00664509/cann8.5.2/ascend-toolkit/latest/",
++                "set_env_path": "/home/w00664509/cann8.5.2/nnal/atb/set_env.sh",
++                "HYDRA_FULL_ERROR": "1",
++                "HCCL_HOST_SOCKET_PORT_RANGE": "60000-60050",
++                "HCCL_NPU_SOCKET_PORT_RANGE": "61000-61050",
++                # If setting this in FSDP, the computation communication overlapping may have issues
++                **(
++                    {}
++                    if train_backend_fsdp
++                    else {
++                        "CUDA_DEVICE_MAX_CONNECTIONS": "1",
++                    }
++                ),
++                "NCCL_NVLS_ENABLE": str(int(check_has_nvlink())),
++                "no_proxy": f"127.0.0.1,{master_addr}",
++                # This is needed by megatron / torch distributed in multi-node setup
++                "MASTER_ADDR": master_addr,
++                **(
++                    {
++                        "CUDA_ENABLE_COREDUMP_ON_EXCEPTION": "1",
++                        "CUDA_COREDUMP_SHOW_PROGRESS": "1",
++                        "CUDA_COREDUMP_GENERATION_FLAGS": "skip_nonrelocated_elf_images,skip_global_memory,skip_shared_memory,skip_local_memory,skip_constbank_memory",
++                        "CUDA_COREDUMP_FILE": "/root/shared_data/cuda_coredump_%h.%p.%t",
++                    }
++                    if config.cuda_core_dump
++                    else {}
++                ),
++                **extra_env_vars,
++                **_parse_extra_env_vars(config.extra_env_vars),
++            }
++        }
++    )
++
++    if get_bool_env_var("SLIME_SCRIPT_ENABLE_RAY_SUBMIT", "1"):
++        cmd_megatron_model_source = (
++            f'source "{repo_base_dir}/scripts/models/{megatron_model_type}.sh" && '
++            if megatron_model_type is not None
++            else ""
++        )
++        exec_command(
++            f"export no_proxy=127.0.0.1 && export PYTHONBUFFERED=16 && "
++            f"{cmd_megatron_model_source}"
++            f'ray job submit --address="http://127.0.0.1:8265" '
++            f"--runtime-env-json='{runtime_env_json}' "
++            f"-- python3 {train_script} "
++            f"{'${MODEL_ARGS[@]}' if megatron_model_type is not None else ''} "
++            f"{train_args}"
++        )
++
++
+ def _parse_extra_env_vars(text: str):
+     try:
+         return json.loads(text)
+diff --git a/miles/utils/ppo_utils.py b/miles/utils/ppo_utils.py
+index 4c09dc508..369d8fda5 100644
+--- a/miles/utils/ppo_utils.py
++++ b/miles/utils/ppo_utils.py
+@@ -10,7 +10,7 @@ import torch.nn.functional as F
+ from miles.backends.training_utils.parallel import get_parallel_state
+ 
+ 
+-@torch.compile(dynamic=True)
++# @torch.compile(dynamic=True)
+ def compute_approx_kl(
+     log_probs: torch.Tensor,
+     log_probs_base: torch.Tensor,
+@@ -123,7 +123,7 @@ def compute_gspo_kl(
+     return ppo_kl
+ 
+ 
+-@torch.compile(dynamic=True)
++# @torch.compile(dynamic=True)
+ def compute_policy_loss(
+     ppo_kl: torch.Tensor,
+     advantages: torch.Tensor,
+@@ -166,7 +166,7 @@ class _VocabParallelEntropy(torch.autograd.Function):
+     @staticmethod
+     def forward(ctx, vocab_parallel_logits: torch.Tensor, process_group: dist.ProcessGroup) -> torch.Tensor:
+ 
+-        @torch.compile(dynamic=True)
++        # @torch.compile(dynamic=True)
+         def mul_reduce(a, b):
+             return (a * b).sum(dim=-1, keepdim=True)
+ 
+diff --git a/miles/utils/reloadable_process_group.py b/miles/utils/reloadable_process_group.py
+index af4878b4e..f796a4ee7 100644
+--- a/miles/utils/reloadable_process_group.py
++++ b/miles/utils/reloadable_process_group.py
+@@ -154,7 +154,7 @@ class ReloadableProcessGroup(torch.distributed.ProcessGroup):
+         for reloadable_group in reloadable_groups:
+             if reloadable_group.group is not None:
+                 continue
+-            group = old_new_group(ranks=reloadable_group.group_info["ranks"], backend="nccl")
++            group = old_new_group(ranks=reloadable_group.group_info["ranks"], backend="hccl")
+             reloadable_group.group = group
+ 
+     def rank(self) -> int:
+diff --git a/miles/utils/tensor_backper.py b/miles/utils/tensor_backper.py
+index 2fc2a6359..6952d1fc1 100644
+--- a/miles/utils/tensor_backper.py
++++ b/miles/utils/tensor_backper.py
+@@ -110,6 +110,6 @@ def _compute_hash_tensor(x: torch.Tensor):
+     # Not a real/good hash, but pretty fast
+     x = x.contiguous()
+     x = x.view(-1)
+-    x = x.view(torch.uint32)
++    x = x.view(torch.int32)
+     x = x.sum()
+     return x.item()
+diff --git a/tools/convert_hf_to_torch_dist.py b/tools/convert_hf_to_torch_dist.py
+index 250af0b68..8e407b471 100644
+--- a/tools/convert_hf_to_torch_dist.py
++++ b/tools/convert_hf_to_torch_dist.py
+@@ -17,6 +17,7 @@ from miles.backends.megatron_utils.model_provider import get_model_provider_func
+ from miles.utils.logging_utils import configure_logger
+ from miles.utils.memory_utils import print_memory
+ from miles_plugins.models.hf_attention import _load_hf_config
++import mindspeed.megatron_adaptor
+ 
+ 
+ def add_convertion_args(parser):
+@@ -94,17 +95,17 @@ def main():
+     local_rank = int(os.getenv("LOCAL_RANK") or os.getenv("SLURM_LOCALID") or 0)
+     global_rank = int(os.getenv("RANK") or os.getenv("SLURM_PROCID") or 0)
+ 
+-    torch.cuda.set_device(local_rank)
++    torch.npu.set_device(local_rank)
+     os.environ.setdefault("WORLD_SIZE", str(world_size))
+     os.environ.setdefault("RANK", str(global_rank))
+     os.environ.setdefault("LOCAL_RANK", str(local_rank))
+     os.environ.setdefault("MASTER_ADDR", "localhost")
+     os.environ.setdefault("MASTER_PORT", "12355")
+     dist.init_process_group(
+-        backend="nccl",
++        backend="hccl",
+         world_size=world_size,
+         rank=global_rank,
+-        device_id=torch.device(f"cuda:{local_rank}"),
++        device_id=torch.device(f"npu:{local_rank}"),
+     )
+     args = get_args()
+     init(args)
+@@ -122,9 +123,9 @@ def main():
+     print(f"Model loaded: {hf_model_path}")
+ 
+     print_memory("after loading model")
+-    torch.cuda.synchronize()
++    torch.npu.synchronize()
+     gc.collect()
+-    torch.cuda.empty_cache()
++    torch.npu.empty_cache()
+ 
+     save_checkpoint(1, model, None, None, 0)
+ 
+diff --git a/train.py b/train.py
+index 9a4a29550..0512bee06 100644
+--- a/train.py
++++ b/train.py
+@@ -8,6 +8,7 @@ from miles.utils.async_utils import eager_create_task
+ from miles.utils.logging_utils import configure_logger
+ from miles.utils.misc import should_run_periodic_action
+ from miles.utils.tracking_utils import finish_tracking, init_tracking
++import mindspeed.megatron_adaptor
+ 
+ 
+ async def train(args):

--- a/docker/npu_patch/mindspeed.patch
+++ b/docker/npu_patch/mindspeed.patch
@@ -1,0 +1,123 @@
+diff --git a/mindspeed/core/megatron_basic/arguments_basic.py b/mindspeed/core/megatron_basic/arguments_basic.py
+index 8ea25b9f..04ad9663 100644
+--- a/mindspeed/core/megatron_basic/arguments_basic.py
++++ b/mindspeed/core/megatron_basic/arguments_basic.py
+@@ -113,3 +113,26 @@ def transformer_config_init_wrapper(fn):
+         fn(self, *args, **known_config)
+ 
+     return wrapper
++
++def transformer_config_init_subclass(cls, **kwargs):
++    mutable_types = (list, dict, set, bytearray)
++    unknown_config = {}
++    full_args = vars(get_full_args()).copy()
++    full_args.update(kwargs)
++
++    config_key = inspect.signature(cls).parameters
++    for key, value in full_args.items():
++        if key not in config_key:
++            unknown_config[key] = value
++
++    for key, value in unknown_config.items():
++        if not hasattr(cls, key):
++            cls.__annotations__[key] = type(value)
++            value = field(default_factory=value) if callable(value) and not isinstance(value, type) else value
++            if callable(value) and not isinstance(value, type):
++                value = field(default_factory=value)
++            elif type(value) in mutable_types:
++                value = field(default_factory=lambda: value)
++            else:
++                value = value
++            setattr(cls, key, value)
+\ No newline at end of file
+diff --git a/mindspeed/features_manager/megatron_basic/megatron_basic.py b/mindspeed/features_manager/megatron_basic/megatron_basic.py
+index 355913e1..18714baf 100644
+--- a/mindspeed/features_manager/megatron_basic/megatron_basic.py
++++ b/mindspeed/features_manager/megatron_basic/megatron_basic.py
+@@ -43,8 +43,11 @@ class MegatronBasicFeature(MindSpeedFeature):
+ 
+     def register_mcore_basic_patches(self, pm, args):
+         # configuration patches
+-        from mindspeed.core.megatron_basic.arguments_basic import transformer_config_init_wrapper, transformer_config_post_init_wrapper
++        from mindspeed.core.megatron_basic.arguments_basic import (transformer_config_init_wrapper,
++                                                                    transformer_config_post_init_wrapper,
++                                                                    transformer_config_init_subclass)
+         pm.register_patch("megatron.core.transformer.transformer_config.TransformerConfig.__init__", transformer_config_init_wrapper)
++        pm.register_patch("megatron.core.transformer.transformer_config.TransformerConfig.__init_subclass__", classmethod(transformer_config_init_subclass))
+         pm.register_patch("megatron.core.transformer.transformer_config.MLATransformerConfig.__init__", transformer_config_init_wrapper)
+         pm.register_patch("megatron.core.transformer.transformer_config.TransformerConfig.__post_init__", transformer_config_post_init_wrapper)
+ 
+
+diff --git a/mindspeed/patch_utils.py b/mindspeed/patch_utils.py
+index a489d58c..d9328555 100644
+--- a/mindspeed/patch_utils.py
++++ b/mindspeed/patch_utils.py
+@@ -2,7 +2,7 @@ import importlib
+ import sys
+ import types
+ from typing import List, Dict, Union
+-
++import inspect
+ _MEGATRON_TRAINING_AVAILABLE = None
+ 
+ 
+@@ -93,8 +93,10 @@ class Patch:
+ 
+     def remove_patch(self):
+         for key, value in sys.modules.copy().items():
+-            if 'mindspeed' in key:
++            if 'mindspeed' in key or 'torch.classes' == key:
+                 continue
++            if inspect.isclass(self.orig_module) and hasattr(value, self.orig_module_name.split('.')[-1]):
++ 	            value = getattr(value, self.orig_module_name.split('.')[-1])
+             if self.orig_func_name is not None and hasattr(value, self.orig_func_name) \
+                     and id(getattr(value, self.orig_func_name)) == id(self.final_patch_func):
+                 setattr(value, self.orig_func_name, self.orig_func)
+diff --git a/mindspeed/core/fusions/fused_rope.py b/mindspeed/core/fusions/fused_rope.py
+index a6f02e07..70f7cb08 100644
+--- a/mindspeed/core/fusions/fused_rope.py
++++ b/mindspeed/core/fusions/fused_rope.py
+@@ -126,5 +126,6 @@ def apply_rotary_pos_emb(
+         freqs,
+         rotary_interleaved=config.rotary_interleaved,
+         multi_latent_attention=config.multi_latent_attention,
+-        mscale=mscale
++        mscale=mscale,
++        cp_group=cp_group
+     )
+diff --git a/mindspeed/megatron_adaptor.py b/mindspeed/megatron_adaptor.py
+index f14b231d..4615590e 100644
+--- a/mindspeed/megatron_adaptor.py
++++ b/mindspeed/megatron_adaptor.py
+@@ -57,6 +57,7 @@ def delete_lock_file():
+ def repatch(args):
+     MindSpeedFeaturesManager.remove_patches()
+     full_args = get_full_args()
++    args = vars(args)
+     for k, v in args.items():
+         setattr(full_args, k, v)
+     MindSpeedFeaturesManager.apply_features_pre_patches(full_args)
+diff --git a/mindspeed/te/pytorch/attention/dot_product_attention/dot_product_attention.py b/mindspeed/te/pytorch/attention/dot_product_attention/dot_product_attention.py
+index ac4eabe5..78c5866d 100644
+--- a/mindspeed/te/pytorch/attention/dot_product_attention/dot_product_attention.py
++++ b/mindspeed/te/pytorch/attention/dot_product_attention/dot_product_attention.py
+@@ -330,6 +330,8 @@ class DotProductAttention(torch.nn.Module):
+         inference_params: Any = None,
+         pad_between_seqs: Optional[bool] = None,
+         fp8_output: Optional[bool] = False,
++        local_cp_size=None,
++        cp_group=None,
+     ) -> torch.Tensor:
+         """
+         Dot Product Attention Layer.
+@@ -659,7 +661,9 @@ class MindSpeedTEDotProductAttention(DotProductAttention):
+         ) and not getattr(self.config, 'is_llava', False):
+             self.config.sparse_mode = 2
+             attention_mask = get_attention_mask(self.config)
+-
++        attention_mask = torch.triu(
++            torch.ones((2048, 2048),
++                       device=query.device, dtype=torch.bool), diagonal=1)
+         packed_seq_kwargs = (
+             {key: getattr(packed_seq_params, key) for key in self.kept_packed_seq_params}
+             if packed_seq_params is not None

--- a/docker/npu_patch/readme.md
+++ b/docker/npu_patch/readme.md
@@ -1,0 +1,140 @@
+# Miles NPU Patch Installation Guide
+
+This guide provides instructions for installing Miles with NPU support, including all required dependencies and patches.
+
+## Component Version Mapping
+
+| Component       | Version/Commit                           | Source                                                                                                              |
+| --------------- | ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| Miles          | 551d15914c89b1229b76fe806ca5f5aa5a826309 | [GitHub](https://github.com/radixark/miles/tree/main)                                             |
+| SGLang          | sglang-miles | [GitHub](https://github.com/sgl-project/sglang/)                                             |
+| SGL Kernel NPU  | 2026.05.01                               | [GitHub](https://github.com/sgl-project/sgl-kernel-npu/releases/tag/2026.05.01)                                     |
+| Megatron-Bridge | bridge | [GitHub](https://github.com/radixark/Megatron-Bridge)                                                                |
+| Megatron-LM     | 3714d81d418c9f1bca4594fc35f9e8289f652862 | [GitHub](https://github.com/NVIDIA/Megatron-LM)                                                                     |
+| MindSpeed       | fc63de5c48426dd019c3b3f39e65f5bdf56e4086 | [GitCode](https://gitcode.com/Ascend/MindSpeed)                                                                     |
+| HDK             | 25.3.RC1                                 | [Ascend](https://www.hiascend.com/hardware/firmware-drivers/commercial?product=7\&model=33)                         |
+| CANN            | 8.5.0                                    | [Ascend](https://www.hiascend.com/developer/download/community/result?module=cann\&cann=8.5.0\&product=7\&model=33) |
+
+## Preparing the Running Environment
+
+### Python Version
+
+Only `python==3.11` is supported currently.
+
+```shell
+conda create -n miles_release python=3.11
+conda activate miles_release
+```
+
+### Working Directory Setup
+
+```shell
+mkdir <WORKSPACE> && cd <WORKSPACE>
+```
+
+### CANN Environment
+
+Prior to start work with miles on Ascend you need to install CANN Toolkit, Kernels operator package and NNAL version 8.5.0, check the [installation guide](https://www.hiascend.com/document/detail/zh/CANNCommunityEdition/83RC1/softwareinst/instg/instg_0008.html?Mode=PmIns\&InstallType=local\&OS=openEuler\&Software=cannToolKit)
+
+```shell
+source <CANN_PATH>/ascend-toolkit/set_env.sh
+source <CANN_PATH>/nnal/atb/set_env.sh
+```
+
+### PyTorch and PyTorch NPU
+
+```shell
+pip install torch-npu==2.8.0
+```
+
+## Installing Dependencies
+
+### SGLang
+
+```shell
+cd <WORKSPACE>
+git clone https://github.com/sgl-project/sglang.git && cd sglang
+git checkout sglang-miles
+mv python/pyproject.toml python/pyproject.toml.backup
+mv python/pyproject_other.toml python/pyproject.toml
+pip install -e "python[srt_npu]"
+pip install torch-npu==2.8.0
+```
+
+### SGL Kernel NPU and Torch Memory Saver
+
+Download `Source code(zip)` from the release link, then install:
+
+```shell
+bash bulid.sh
+bash build.sh -a memory-saver
+pip install output/sgl_kernel_npu*.whl
+pip install output/torch_memory_saver*.whl
+```
+
+### Megatron-Bridge
+
+```shell
+pip install git+https://github.com/ISEEKYAN/mbridge.git@89eb10887887bc74853f89a4de258c0702932a1c --no-deps
+
+cd <WORKSPACE>
+git clone https://github.com/radixark/Megatron-Bridge.git -b bridge
+pip install nvidia-modelopt[torch]>=0.37.0 --no-build-isolation
+```
+
+### Megatron-LM
+
+```shell
+cd <WORKSPACE>
+git clone https://github.com/NVIDIA/Megatron-LM.git --recursive && \
+  cd Megatron-LM/ && git checkout 3714d81d418c9f1bca4594fc35f9e8289f652862 && \
+  pip install -e .
+```
+
+### MindSpeed
+
+```shell
+cd <WORKSPACE>
+git clone https://gitcode.com/Ascend/MindSpeed.git && \
+  cd MindSpeed/ && git checkout fc63de5c48426dd019c3b3f39e65f5bdf56e4086 && \
+  pip install -e .
+```
+
+### Miles
+
+```shell
+cd <WORKSPACE>
+git clone https://github.com/radixark/miles.git && cd miles
+cp -r docker/npu_patch ../npu_patch
+pip install -e .
+```
+
+## Applying Patches
+
+```shell
+cd <WORKSPACE>/miles
+git apply ../npu_patch/miles.patch
+
+cd <WORKSPACE>/sglang
+git apply ../npu_patch/sglang.patch
+
+cd <WORKSPACE>/Megatron-LM
+git apply ../npu_patch/megatron_common.patch
+git apply ../npu_patch/megatron.patch
+
+cd <WORKSPACE>/Megatron-Bridge
+git apply ../npu_patch/megatron-bridge.patch
+
+cd <WORKSPACE>/MindSpeed
+git apply ../npu_patch/mindspeed.patch
+```
+
+## Additional Dependencies
+
+```shell
+cd <WORKSPACE>/miles
+pip install triton-ascend
+pip install torch-npu==2.8.0
+pip install torchvision==0.23.0
+pip install numpy==1.26.0
+```

--- a/docker/npu_patch/sglang.patch
+++ b/docker/npu_patch/sglang.patch
@@ -1,0 +1,58 @@
+diff --git a/python/sglang/srt/configs/model_config.py b/python/sglang/srt/configs/model_config.py
+index 691f06411..0f5964410 100644
+--- a/python/sglang/srt/configs/model_config.py
++++ b/python/sglang/srt/configs/model_config.py
+@@ -297,6 +297,11 @@ class ModelConfig:
+             "GlmMoeDsaForCausalLM",
+         ]:
+             self.hf_config.architectures[0] = "DeepseekV3ForCausalLMNextN"
++        if (
++            is_draft_model
++            and self.hf_config.architectures[0] == "DeepseekV32ForCausalLM"
++        ):
++            self.hf_config.architectures[0] = "DeepseekV3ForCausalLMNextN"
+ 
+         if is_draft_model and self.hf_config.architectures[0] in [
+             "Glm4MoeForCausalLM",
+diff --git a/python/sglang/srt/entrypoints/engine.py b/python/sglang/srt/entrypoints/engine.py
+index fcc4af301..be9de5460 100644
+--- a/python/sglang/srt/entrypoints/engine.py
++++ b/python/sglang/srt/entrypoints/engine.py
+@@ -68,6 +68,7 @@ from sglang.srt.managers.io_struct import (
+     LoadLoRAAdapterFromTensorsReqInput,
+     LoadLoRAAdapterReqInput,
+     MultimodalDataInputFormat,
++    PostProcessWeightsReqInput,
+     OpenSessionReqInput,
+     PostProcessWeightsReqInput,
+     ReleaseMemoryOccupationReqInput,
+diff --git a/python/sglang/srt/entrypoints/http_server.py b/python/sglang/srt/entrypoints/http_server.py
+index 288f2a24c..89959ff30 100644
+--- a/python/sglang/srt/entrypoints/http_server.py
++++ b/python/sglang/srt/entrypoints/http_server.py
+@@ -124,6 +124,7 @@ from sglang.srt.managers.io_struct import (
+     InitWeightsUpdateGroupReqInput,
+     LoadLoRAAdapterFromTensorsReqInput,
+     LoadLoRAAdapterReqInput,
++    PostProcessWeightsReqInput,
+     OpenSessionReqInput,
+     ParseFunctionCallReq,
+     PauseGenerationReqInput,
+diff --git a/python/sglang/srt/models/transformers.py b/python/sglang/srt/models/transformers.py
+index d928870b9..06436aa4a 100644
+--- a/python/sglang/srt/models/transformers.py
++++ b/python/sglang/srt/models/transformers.py
+@@ -266,10 +266,10 @@ def replace_rms_norm_class(rms_norm: nn.Module, hidden_size: int) -> nn.Module:
+         )
+     else:
+         kwargs["has_weight"] = getattr(rms_norm, "with_scale", True)
+-        if weight_meta is not None:
+-            kwargs["weight_dtype"] = weight_meta.dtype
+-        else:
+-            kwargs["has_weight"] = False
++        # if weight_meta is not None:
++        #     kwargs["weight_dtype"] = weight_meta.dtype
++        # else:
++        #     kwargs["has_weight"] = False
+         base_cls = RMSNorm
+         norm = base_cls(**kwargs)

--- a/scripts/run_qwen3_4b_npu.py
+++ b/scripts/run_qwen3_4b_npu.py
@@ -1,0 +1,163 @@
+import os
+
+import miles.utils.misc as U
+from miles.utils.external_utils.command_utils import execute_train_npu
+
+MODEL_NAME = os.environ.get("MILES_SCRIPT_MODEL_NAME", "Qwen3-4B-Instruct-2507")
+
+NUM_GPUS = int(os.environ.get("MILES_SCRIPT_NUM_GPUS", "4"))
+EXTERNAL_RAY = int(os.environ.get("MILES_SCRIPT_EXTERNAL_RAY", "0"))
+TRAIN_BACKEND = os.environ.get("MILES_SCRIPT_TRAIN_BACKEND", "fsdp").lower()
+assert TRAIN_BACKEND in {"fsdp", "megatron"}
+
+DATASET_NAME = "VeraIsHere/geo3k_imgurl_processed"
+DATA_ROOT = "/root/dataset/geo3k_imgurl_processed"
+TRAIN_DATA_PATH = os.path.join(DATA_ROOT, "train.parquet")
+
+
+def get_megatron_model_type(model_name: str) -> str:
+    megatron_model_type = {
+                "Qwen3-4B-Instruct-2507": "qwen3-4B-Instruct-2507",
+                "Qwen3-4B-Base": "qwen3-4B",
+                "Qwen3-4B": "qwen3-4B",
+            }[model_name]
+    return megatron_model_type
+
+
+
+def prepare():
+    U.exec_command("mkdir -p /root/models /root/datasets")
+    U.exec_command(f"hf download Qwen/{MODEL_NAME} --local-dir /root/models/{MODEL_NAME}")
+    data_missing = not os.path.exists(TRAIN_DATA_PATH)
+    if data_missing:
+        U.exec_command(f"hf download --repo-type dataset {DATASET_NAME} --local-dir {DATA_ROOT}")
+    if not os.path.exists(TRAIN_DATA_PATH):
+        raise FileNotFoundError(f"Dataset not found. Expected local dataset at {TRAIN_DATA_PATH}; ")
+
+
+def execute():
+    ckpt_args = f"--hf-checkpoint /root/model/Qwen3-4B-Instruct-2507/ "
+
+    wandb_args = (
+        (
+            "--use-wandb "
+            "--wandb-project miles-dev "
+            "--wandb-group geo3k_vlm_multi_turn "
+            f"--wandb-key '{wandb_api_key}' "
+        )
+        if (wandb_api_key := os.environ.get("WANDB_API_KEY"))
+        else ""
+    )
+
+    rollout_args = (
+        f"--prompt-data /root/dataset/dapo-math-17k/dapo-math-17k.jsonl "
+        "--input-key prompt "
+        "--label-key label "
+        "--apply-chat-template "
+        # By default it is thinking mode
+        # """--apply-chat-template-kwargs '{"enable_thinking":false}' """
+        "--rollout-shuffle "
+        "--rm-type math "
+        "--num-rollout 3000 "
+        "--rollout-batch-size 32 "
+        "--n-samples-per-prompt 8 "
+        f"--rollout-max-response-len 4096 "
+        "--rollout-temperature 1 "
+        "--global-batch-size 256 "
+        "--balance-data "
+    )
+
+    # eval_args = (
+    #     "--eval-interval 20 "
+    #     f"--eval-prompt-data geo3k_eval {TRAIN_DATA_PATH}@[0:64] "
+    #     "--n-samples-per-eval-prompt 1 "
+    #     "--eval-max-response-len 4096 "
+    #     "--eval-top-k 1 "
+    # )
+
+    grpo_args = (
+        "--advantage-estimator grpo "
+        "--kl-loss-coef 0.00 "
+        "--kl-loss-type low_var_kl "
+        "--kl-coef 0.00 "
+        "--entropy-coef 0.00 "
+        "--eps-clip 0.2 "
+        "--eps-clip-high 0.28 "
+    )
+
+    optimizer_args = (
+        "--optimizer adam "
+        "--lr 1e-6 "
+        "--lr-decay-style constant "
+        "--weight-decay 0.1 "
+        "--adam-beta1 0.9 "
+        "--adam-beta2 0.98 "
+    )
+
+    sglang_args = (
+        "--rollout-num-gpus-per-engine 1 "
+        "--sglang-mem-fraction-static 0.6 "
+        f"--sglang-cuda-graph-bs {' '.join(map(str, [4, 8] + list(range(16, 257, 8))))} "
+        "--sglang-mm-attention-backend ascend_attn "
+        "--sglang-device npu "
+        "--sglang-disable-radix-cache "
+        "--sglang-chunked-prefill-size 32768 "
+        "--sglang-max-prefill-tokens 4000 "
+        "--sglang-max-total-tokens 327680 "
+    )
+
+    megatron_args = (
+        "--train-backend megatron "
+        f"--load /root/model/Qwen3-4B-Instruct-2507/ "
+        "--tensor-model-parallel-size 4 "
+        "--sequence-parallel "
+        "--pipeline-model-parallel-size 1 "
+        "--context-parallel-size 1 "
+        "--expert-model-parallel-size 1 "
+        "--expert-tensor-parallel-size 1 "
+        "--recompute-granularity full "
+        "--recompute-method uniform "
+        "--recompute-num-layers 1 "
+        "--use-dynamic-batch-size "
+        "--max-tokens-per-gpu 4096 "
+        "--attention-dropout 0.0 "
+        "--hidden-dropout 0.0 "
+        "--accumulate-allreduce-grads-in-fp32 "
+        "--attention-softmax-in-fp32 "
+        "--attention-backend flash "
+        "--megatron-to-hf-mode bridge "
+    )
+
+    misc_args = (
+        "--actor-num-nodes 1 " f"--actor-num-gpus-per-node {NUM_GPUS} " f"--rollout-num-gpus {NUM_GPUS} "
+        "--no-gradient-accumulation-fusion "
+        "--use-flash-attn "
+    )
+
+    backend_args = megatron_args
+    megatron_model_type = get_megatron_model_type(MODEL_NAME)
+    os.environ["MODEL_ARGS_ROTARY_BASE"] = "5000000"
+    train_args = (
+        f"{ckpt_args} "
+        f"{rollout_args} "
+        f"{optimizer_args} "
+        f"{grpo_args} "
+        f"{sglang_args} "
+        f"{backend_args} "
+        f"{misc_args} "
+        f"{wandb_args} "
+        # f"{get_default_wandb_args(__file__)} "
+    )
+
+    execute_train_npu(
+        train_args=train_args,
+        num_gpus_per_node=NUM_GPUS,
+        megatron_model_type=megatron_model_type,
+        extra_env_vars=({"WANDB_API_KEY": os.environ["WANDB_API_KEY"]} if os.environ.get("WANDB_API_KEY") else {}),
+        megatron_path="/root/Megatron-LM/",
+    )
+
+
+if __name__ == "__main__":
+    # prepare()
+    execute()

--- a/scripts/run_qwen3_4b_npu.sh
+++ b/scripts/run_qwen3_4b_npu.sh
@@ -1,0 +1,15 @@
+export SLIME_SCRIPT_MODEL_NAME=Qwen3-4B-Instruct-2507
+export SLIME_SCRIPT_TRAIN_BACKEND=megatron
+export PYTORCH_ALLOC_CONF=expandable_segments:True
+export PYTHONPATH="/root/Megatron-Bridge/src:/root/Megatron-LM/:/root/sglang/python:$PYTHONPATH"
+export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15
+export CUDA_DEVICE_MAX_CONNECTIONS=1
+export RAY_EXPERIMENTAL_NOSET_ASCEND_RT_VISIBLE_DEVICES=1
+export HCCL_HOST_SOCKET_PORT_RANGE=60000-60050
+export HCCL_NPU_SOCKET_PORT_RANGE=61000-61050
+export HYDRA_FULL_ERROR=1
+export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+export MASTER_PORT=$(shuf -i 20000-65000 -n 1)  # or any free port
+
+
+python run_qwen3_4b.py


### PR DESCRIPTION
# Summary
Adds NPU (Ascend) support to Miles RL training stack, enabling Qwen3-4B GRPO training. Introduces 6 patches + launcher scripts.
# Changes
## miles.patch

- Device migration: NCCL→HCCL across all process groups; torch.cuda.*→torch.npu.* APIs; Ray GPU scheduling→resources={"NPU": N} with get_accelerator_ids()["NPU"].
- Disable CUDA-specific code: @torch.compile, torch_memory_saver.get_cpu_backup, UpdateWeightP2P — all unsupported on NPU.
- MindSpeed integration: add repatch(args) at Megatron init points; add execute_train_npu()helper with Ascend env vars.

## megatron.patch

- Remove all @jit_fuser decorators (~30+ occurrences across activations & fusions) — unsupported on NPU.
- Hard-disable FlashInfer (HAVE_FLASHINFER = False).

## megatron_bridge.patch

- Register MindSpeed-prefixed module types (MindSpeedTELayerNormColumnParallelLinear, etc.) in parallel mode mappings for correct checkpoint sharding.

## mindspeed.patch

- Add __init_subclass__ patch on TransformerConfig to accept dynamic kwargs.
- Fix repatch (namespace→dict) and remove_patch (class-level patches, skip torch.classes).
- Forward cp_group through RoPE and dot-product-attention.

## sglang.patch

- Add missing PostProcessWeightsReqInput import; fix draft model arch mapping for DeepSeekV3.2; relax RMSNorm weight dtype check.

## New files

- scripts/run_qwen3_4b_npu.py/.sh — end-to-end Qwen3-4B GRPO launcher for Ascend.
- docker/npu_patch/readme.md — installation guide with version mapping.