### PR TITLE
utils/ppo_utils: fix OPSM mask using sequence-level advantage instead of per-token comparison

### DIFF
--- a/miles/backends/training_utils/loss_hub/math_utils.py
+++ b/miles/backends/training_utils/loss_hub/math_utils.py
@@ -189,11 +189,13 @@ def compute_opsm_mask(
         # Calculate sequence-level KL
         seq_kl = ((full_old_log_prob - full_log_prob) * loss_mask).sum() / torch.clamp_min(loss_mask.sum(), 1)
 
+        # Compute sequence-level advantage (masked mean) for the OPSM decision
+        seq_adv = (advantage * loss_mask).sum() / torch.clamp_min(loss_mask.sum(), 1)
         # Create mask: 0 if (advantage < 0 and seq_kl > delta), else 1
-        mask = ((advantage < 0) & (seq_kl > args.opsm_delta)).float()
-        opsm_clipfrac += mask.sum() / torch.clamp_min(loss_mask.sum(), 1)
+        mask = ((seq_adv < 0) & (seq_kl > args.opsm_delta)).float()
+        opsm_clipfrac += mask * loss_mask.sum() / torch.clamp_min(loss_mask.sum(), 1)
 
-        opsm_mask_list.append(1 - mask)
+        opsm_mask_list.append((1 - mask) * loss_mask + (1 - loss_mask))
 
     opsm_mask = torch.cat(opsm_mask_list, dim=0)
     return opsm_mask, opsm_clipfrac

--- a/miles/backends/training_utils/loss_hub/math_utils.py
+++ b/miles/backends/training_utils/loss_hub/math_utils.py
@@ -193,9 +193,9 @@ def compute_opsm_mask(
         seq_adv = (advantage * loss_mask).sum() / torch.clamp_min(loss_mask.sum(), 1)
         # Create mask: 0 if (advantage < 0 and seq_kl > delta), else 1
         mask = ((seq_adv < 0) & (seq_kl > args.opsm_delta)).float()
-        opsm_clipfrac += mask * loss_mask.sum() / torch.clamp_min(loss_mask.sum(), 1)
+        opsm_clipfrac += mask
 
-        opsm_mask_list.append((1 - mask) * loss_mask + (1 - loss_mask))
+        opsm_mask_list.append(1.0 - mask * loss_mask)
 
     opsm_mask = torch.cat(opsm_mask_list, dim=0)
     return opsm_mask, opsm_clipfrac


### PR DESCRIPTION
## What

`compute_opsm_mask` was comparing the per-token `advantage` tensor directly
against `0` to decide whether to mask a sequence:

```python
# Before (buggy)
mask = ((advantage < 0) & (seq_kl > args.opsm_delta)).float()
```

`advantage` has shape `[seq_len]`, so this produced a **per-token** boolean
instead of a **per-sequence** decision. OPSM is defined at the sequence level:
if the whole sequence has a negative advantage *and* is off-policy (KL > δ),
exclude that sequence entirely.

## Why it matters

1. **Wrong masking granularity** — tokens within a sequence were individually
   accepted or rejected based on their own advantage sign, breaking the
   sequence-level semantics of OPSM.
2. **Corrupted `opsm_clipfrac` metric** — `mask.sum()` counted masked *tokens*,
   not masked *sequences*, so the reported metric was never a clean 0/1 per
   sequence.
3. **Silent failure** — because `loss_mask` also has shape `[seq_len]`, all
   tensor ops still broadcast correctly and no error was raised.

## How

Compute a masked mean of the per-token advantage over the sequence (mirroring
exactly how `seq_kl` is computed), then compare that scalar to `0`:

```python
# After (fixed)
seq_adv = (advantage * loss_mask).sum() / torch.clamp_min(loss_mask.sum(), 1)
mask = ((seq_adv < 0) & (seq_kl > args.opsm_delta)).float()
opsm_clipfrac += mask * loss_mask.sum() / torch.clamp_min(loss_mask.sum(), 1)
opsm_mask_list.append((1 - mask) * loss_mask + (1 - loss_mask))
```

The `opsm_mask_list.append` is also corrected so that padding positions
(where `loss_mask == 0`) stay at `1.0`, preventing the scalar broadcast from
accidentally scaling pad-position gradients in `pg_loss * opsm_mask`.

## Testing

- Verified the bug by reading `compute_opsm_mask` and tracing `advantage`
  shapes from `batch["advantages"]` through `compute_advantages_and_returns`.
- The fix is logically consistent with the `seq_kl` computation on the line
  immediately above.

## Affected code path

`use_opsm=True` training runs only. No changes to any other loss path.