### PR TITLE
Point README Documentation link at the Mintlify docs site

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![License](https://img.shields.io/github/license/radixark/miles)](LICENSE)
 [![Slack](https://img.shields.io/badge/slack-join-brightgreen.svg)](https://slack.sglang.ai)
 
-[**Latest Updates**](#latest-updates) | [**Quick Start**](#quick-start) | [**Key Features**](#key-features) | [**Documentation**](docs/en/get_started/quick_start.md)
+[**Latest Updates**](#latest-updates) | [**Quick Start**](#quick-start) | [**Key Features**](#key-features) | [**Documentation**](https://www.radixark.com/miles/docs)
 
 </div>
 


### PR DESCRIPTION
## Summary
The header link in the project README pointed at an in-repo markdown page (`docs/en/get_started/quick_start.md`). The canonical Miles documentation now lives at https://www.radixark.com/miles/docs (the Mintlify site built from `radixark/miles-doc`), so the link from the project README should land there.

## Test plan
- [ ] Rendered README on GitHub: the 'Documentation' link in the header row navigates to https://www.radixark.com/miles/docs.