### PR TITLE
[loss refactor] [4] loss function protocol

### DIFF
--- a/miles/backends/training_utils/loss.py
+++ b/miles/backends/training_utils/loss.py
@@ -4,12 +4,20 @@ import torch
 from torch.utils.checkpoint import checkpoint
 
 from miles.backends.training_utils.cp_utils import get_sum_of_sample_mean
+from miles.backends.training_utils.loss_hub import get_loss_function
 from miles.backends.training_utils.loss_hub.advantages import compute_advantages, normalize_advantages
-from miles.backends.training_utils.loss_hub.logits import get_log_probs_and_entropy, get_values  # noqa: F401
-from miles.backends.training_utils.loss_hub.losses import get_loss_function
+from miles.backends.training_utils.loss_hub.base_types import LossFnContext
+from miles.backends.training_utils.loss_hub.logits import get_log_probs_and_entropy, get_values
 from miles.backends.training_utils.parallel import get_parallel_state
 from miles.utils.ppo_utils import compute_approx_kl
 from miles.utils.types import RolloutBatch
+
+__all__ = [
+    "compute_advantages_and_returns",
+    "get_log_probs_and_entropy",
+    "get_values",
+    "loss_function",
+]
 
 
 def compute_advantages_and_returns(args: Namespace, rollout_data: RolloutBatch) -> None:
@@ -123,17 +131,12 @@ def loss_function(
     )
 
     func = get_loss_function(args)
+    ctx = LossFnContext(args=args, batch=batch, sum_of_sample_mean=sum_of_sample_mean)
 
     if args.recompute_loss_function:
-        loss, log = checkpoint(
-            func,
-            args,
-            batch,
-            logits,
-            sum_of_sample_mean,
-        )
+        loss, log = checkpoint(func, logits, ctx)
     else:
-        loss, log = func(args, batch, logits, sum_of_sample_mean)
+        loss, log = func(logits, ctx)
 
     # Forces autograd to traverse the full graph on every rank to avoid hang.
     if parallel_state.cp.size > 1 and args.allgather_cp:

--- a/miles/backends/training_utils/loss_hub/__init__.py
+++ b/miles/backends/training_utils/loss_hub/__init__.py
@@ -1,0 +1,19 @@
+from argparse import Namespace
+
+from miles.backends.training_utils.loss_hub.base_types import LossFunction
+from miles.backends.training_utils.loss_hub.losses import policy_loss_function, sft_loss_function, value_loss_function
+from miles.utils.misc import load_function
+
+
+def get_loss_function(args: Namespace) -> LossFunction:
+    match args.loss_type:
+        case "policy_loss":
+            return policy_loss_function
+        case "value_loss":
+            return value_loss_function
+        case "sft_loss":
+            return sft_loss_function
+        case "custom_loss":
+            return load_function(args.custom_loss_function_path)
+        case _:
+            raise ValueError(f"Unknown loss type: {args.loss_type}")

--- a/miles/backends/training_utils/loss_hub/base_types.py
+++ b/miles/backends/training_utils/loss_hub/base_types.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from argparse import Namespace
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Protocol
+
+import torch
+
+from miles.utils.types import RolloutBatch
+
+
+@dataclass(frozen=True)
+class LossFnContext:
+    args: Namespace
+
+    # Loss-type-dependent. Common keys: unconcat_tokens, response_lengths,
+    # total_lengths, loss_masks (one per sample); max_seq_lens required when
+    # qkv_format == "bshd". policy_loss adds advantages, log_probs (+ optional
+    # ref_/rollout_log_probs); value_loss adds values, returns.
+    batch: RolloutBatch
+
+    # CP-aware reducer: flat per-token tensor → scalar, sample-mean weighted by loss_masks.
+    sum_of_sample_mean: Callable[[torch.Tensor], torch.Tensor]
+
+
+class LossFunction(Protocol):
+    """Per-loss-type function dispatched by `get_loss_function`.
+
+    `logits` is float32; last dim is vocab_size (policy/sft) or 1 (value).
+    Outer shape is [1, T, ...] for qkv_format="thd" (T = sum of total_lengths)
+    or [B, max_seq_len, ...] for "bshd".
+
+    Returns `(loss, metrics)`:
+      * `loss`: scalar tensor with grad, un-rescaled (the dispatcher applies
+        Megatron scaling on top).
+      * `metrics`: dict of detached 0-d scalars, surfaced under `train/` in
+        the training log / wandb.
+    """
+
+    def __call__(
+        self,
+        logits: torch.Tensor,
+        ctx: LossFnContext,
+    ) -> tuple[torch.Tensor, dict[str, torch.Tensor]]: ...

--- a/miles/backends/training_utils/loss_hub/losses.py
+++ b/miles/backends/training_utils/loss_hub/losses.py
@@ -1,7 +1,3 @@
-from argparse import Namespace
-from collections.abc import Callable
-from typing import Protocol
-
 import torch
 import torch.distributed as dist
 
@@ -10,30 +6,12 @@ from miles.backends.training_utils.cp_utils import (
     get_sum_of_sample_mean,
     slice_loss_masks_for_local_cp,
 )
+from miles.backends.training_utils.loss_hub.base_types import LossFnContext
 from miles.backends.training_utils.loss_hub.corrections import vanilla_tis_function
 from miles.backends.training_utils.loss_hub.logits import get_log_probs_and_entropy, get_values
 from miles.backends.training_utils.parallel import get_parallel_state
 from miles.utils.misc import load_function
 from miles.utils.ppo_utils import compute_approx_kl, compute_gspo_kl, compute_opsm_mask, compute_policy_loss
-from miles.utils.types import RolloutBatch
-
-
-class LossFunction(Protocol):
-    """Common signature of the per-loss-type functions dispatched by `get_loss_function`.
-
-    A loss function consumes the configured args, a rollout batch, the model's
-    logits, and a CP-aware per-sample mean reducer, and returns the scalar
-    loss tensor (with gradient) together with a dict of detached scalar
-    metrics for logging.
-    """
-
-    def __call__(
-        self,
-        args: Namespace,
-        batch: RolloutBatch,
-        logits: torch.Tensor,
-        sum_of_sample_mean: Callable[[torch.Tensor], torch.Tensor],
-    ) -> tuple[torch.Tensor, dict[str, torch.Tensor]]: ...
 
 
 def compute_ess_ratio_contribution(
@@ -89,12 +67,7 @@ def compute_ess_ratio_contribution(
     return ess_ratio_sum
 
 
-def policy_loss_function(
-    args: Namespace,
-    batch: RolloutBatch,
-    logits: torch.Tensor,
-    sum_of_sample_mean: Callable[[torch.Tensor], torch.Tensor],
-) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
+def policy_loss_function(logits: torch.Tensor, ctx: LossFnContext) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
     """Compute policy loss (PPO/GSPO) and metrics.
 
     Computes current log-probabilities and entropy from model logits, then
@@ -103,22 +76,14 @@ def policy_loss_function(
     KL. Optionally applies TIS (Truncated Importance Sampling) correction and
     adds KL loss term if configured.
 
-    Args:
-        args: Configuration controlling advantage estimator, clipping thresholds,
-            entropy/KL coefficients, and TIS settings.
-        batch: Mini-batch containing "advantages", "log_probs" (old policy),
-            "unconcat_tokens", "response_lengths", "total_lengths", "loss_masks",
-            and optionally "ref_log_probs" and "rollout_log_probs".
-        logits: Policy logits with shape `[1, T, V]`.
-        sum_of_sample_mean: Reduction function that averages per-sample values.
-
-    Returns:
-        Tuple of `(loss, metrics)` where `loss` is a scalar tensor and `metrics`
-        is a dict containing detached scalars: "loss", "pg_loss",
-        "entropy_loss", "pg_clipfrac", "ppo_kl". Additional keys "kl_loss",
-        "tis", "ois", "tis_clipfrac" are included when the respective features
-        are enabled.
+    Metrics:
+      * Always: "loss", "pg_loss", "entropy_loss", "pg_clipfrac", "ppo_kl", "ess_ratio".
+      * `args.use_kl_loss`: "kl_loss".
+      * `args.use_tis` / `args.get_mismatch_metrics`: "ois", "tis", "tis_clipfrac", "tis_abs".
+      * `args.use_opsm`: "opsm_clipfrac".
+      * `rollout_log_probs` in batch: "train_rollout_logprob_abs_diff", "train_rollout_kl".
     """
+    args, batch, sum_of_sample_mean = ctx.args, ctx.batch, ctx.sum_of_sample_mean
     parallel_state = get_parallel_state()
     advantages = torch.cat(batch["advantages"], dim=0)
     old_log_probs = batch["rollout_log_probs"] if args.use_rollout_logprobs else batch["log_probs"]
@@ -329,29 +294,16 @@ def policy_loss_function(
     return loss, reported_loss
 
 
-def value_loss_function(
-    args: Namespace,
-    batch: RolloutBatch,
-    logits: torch.Tensor,
-    sum_of_sample_mean: Callable[[torch.Tensor], torch.Tensor],
-) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
+def value_loss_function(logits: torch.Tensor, ctx: LossFnContext) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
     """Compute clipped value loss and metrics.
 
     Extracts current value predictions from `logits`, compares them against
     stored old values with clipping, and computes the maximum of clipped and
     unclipped squared errors (PPO-style value clipping).
 
-    Args:
-        args: Configuration containing `value_clip` threshold.
-        batch: Mini-batch with "values" (old predictions), "returns",
-            "unconcat_tokens", "total_lengths", and "response_lengths".
-        logits: Value head output with shape `[1, T, 1]`.
-        sum_of_sample_mean: Reduction function that averages per-sample values.
-
-    Returns:
-        Tuple of `(loss, metrics)` where `loss` is a scalar tensor and
-        `metrics` contains detached scalars "value_loss" and "value_clipfrac".
+    Metrics: "value_loss", "value_clipfrac".
     """
+    args, batch, sum_of_sample_mean = ctx.args, ctx.batch, ctx.sum_of_sample_mean
     old_values = torch.cat(batch["values"], dim=0)
 
     values = get_values(
@@ -387,28 +339,15 @@ def value_loss_function(
     return loss, reported_loss
 
 
-def sft_loss_function(
-    args: Namespace,
-    batch: RolloutBatch,
-    logits: torch.Tensor,
-    sum_of_sample_mean: Callable[[torch.Tensor], torch.Tensor],
-) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
+def sft_loss_function(logits: torch.Tensor, ctx: LossFnContext) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
     """Compute supervised fine-tuning loss over response tokens.
 
     Computes log-probabilities of the ground-truth tokens in the response
     segments and returns the negative log-likelihood as the loss.
 
-    Args:
-        args: Configuration (passed through to helpers).
-        batch: Mini-batch with "unconcat_tokens", "response_lengths", and
-            "total_lengths".
-        logits: Policy logits with shape `[1, T, V]`.
-        sum_of_sample_mean: Reduction function that averages per-sample values.
-
-    Returns:
-        Tuple of `(loss, metrics)` where `metrics` contains a single detached
-        scalar "loss".
+    Metrics: "loss".
     """
+    args, batch, sum_of_sample_mean = ctx.args, ctx.batch, ctx.sum_of_sample_mean
     response_lengths = batch["response_lengths"]
     total_lengths = batch["total_lengths"]
 
@@ -430,23 +369,4 @@ def sft_loss_function(
     if log_probs.numel() == 0:
         loss += 0 * logits.sum()
 
-    return (
-        loss,
-        {
-            "loss": loss.clone().detach(),
-        },
-    )
-
-
-def get_loss_function(args: Namespace) -> LossFunction:
-    match args.loss_type:
-        case "policy_loss":
-            return policy_loss_function
-        case "value_loss":
-            return value_loss_function
-        case "sft_loss":
-            return sft_loss_function
-        case "custom_loss":
-            return load_function(args.custom_loss_function_path)
-        case _:
-            raise ValueError(f"Unknown loss type: {args.loss_type}")
+    return loss, {"loss": loss.clone().detach()}

--- a/tests/fast/backends/training_utils/loss/test_loss_snapshot.py
+++ b/tests/fast/backends/training_utils/loss/test_loss_snapshot.py
@@ -19,6 +19,7 @@ import pytest
 import torch
 
 from miles.backends.training_utils.loss import compute_advantages_and_returns, loss_function
+from miles.backends.training_utils.loss_hub.base_types import LossFnContext
 from miles.backends.training_utils.loss_hub.corrections import icepop_function, vanilla_tis_function
 from miles.backends.training_utils.loss_hub.logits import get_log_probs_and_entropy, get_values
 from miles.backends.training_utils.loss_hub.losses import policy_loss_function, sft_loss_function, value_loss_function
@@ -87,6 +88,16 @@ CONFIGS = [
         2,
         [30, 50],
         [15, 35],
+    ),
+    # recompute path through torch.utils.checkpoint — exercises loss_function's
+    # checkpoint branch and guards against regressions in the LossFnContext
+    # wrapping.
+    (
+        "grpo_recompute_b3",
+        dict(advantage_estimator="grpo", loss_type="policy_loss", recompute_loss_function=True),
+        3,
+        [20, 64, 40],
+        [10, 48, 32],
     ),
 ]
 
@@ -179,7 +190,7 @@ def run_loss_fn(args, parallel_state, inputs):
     fn = {"policy_loss": policy_loss_function, "value_loss": value_loss_function, "sft_loss": sft_loss_function}[
         loss_type
     ]
-    loss, metrics = fn(args, batch, logits, som)
+    loss, metrics = fn(logits, LossFnContext(args=args, batch=batch, sum_of_sample_mean=som))
     loss.backward()
     result = {"loss": loss.detach(), "metrics": {k: v.detach() for k, v in metrics.items()}}
     result["logits_grad"] = logits.grad.clone()


### PR DESCRIPTION
## Summary

Stacked on #1121. Tightens the loss-function interface so that adding or modifying a per-loss-type function has one canonical contract to point at.

| Commit | Change |
|---|---|
| `30f0e5e57` | Add \`LossFnInput\` / \`LossFnOutput\` frozen dataclasses (new \`loss_hub/base_types.py\`). Convert \`policy_loss_function\` / \`value_loss_function\` / \`sft_loss_function\` to take a single \`LossFnInput\` and return \`LossFnOutput\`. \`LossFunction\` Protocol updated to match. Mirrors \`rollout/base_types.py\` (\`GenerateFnInput\`/\`GenerateFnOutput\`). |
| `18c69968f` | Move \`get_loss_function\` dispatcher from \`losses.py\` bottom → \`loss_hub/__init__.py\`. Mirrors \`rm_hub/__init__.py:async_rm\`. \`from miles.backends.training_utils.loss_hub import get_loss_function\` is now the public entry. |
| `ad6ff1a41` | Add \`__all__\` to \`loss.py\`; drop \`# noqa: F401\` from \`get_log_probs_and_entropy\`/\`get_values\` re-export. |
| `683ff2f30` | Class docstring on \`LossFunction\` + per-field \`#\` comment annotations on \`LossFnInput\`/\`LossFnOutput\` (\`batch\` keys per loss type, \`logits\` shape rule, \`sum_of_sample_mean\` lifecycle, \`metrics\` keys per loss type). Intent: make this file the single reference when modifying a loss function. |

## Breaking

Any custom loss function loaded via \`--custom-loss-function-path\` must update its signature to \`fn(input: LossFnInput) -> LossFnOutput\` (was \`fn(args, batch, logits, sum_of_sample_mean) -> tuple[loss, metrics]\`).

## Verification

Snapshot test \`tests/fast/backends/training_utils/loss/test_loss_snapshot.py\` — 11/11 bitwise pass against the snapshots on \`radixark/miles:dev\` (ion-user-7).

## Base

Base branch is \`loss_refactor/code_style\` (#1121); rebase to main once that lands.