### PR TITLE
[TITO] deepseek v32 support

### DIFF
--- a/miles/utils/chat_template_utils/deepseek_v32.py
+++ b/miles/utils/chat_template_utils/deepseek_v32.py
@@ -48,6 +48,10 @@ def is_deepseek_v32(tokenizer: Any) -> bool:
 
 
 def _build_deepseek_encode_config(kwargs: dict) -> dict:
+    kwargs = dict(kwargs)
+    enable_thinking = kwargs.pop("enable_thinking", None)
+    if enable_thinking is not None:
+        kwargs.setdefault("thinking_mode", "thinking" if enable_thinking else "chat")
     # reject unknown kwargs to avoid silent config drop
     unknown = set(kwargs) - _KNOWN_KWARGS
     if unknown:

--- a/miles/utils/chat_template_utils/deepseek_v32.py
+++ b/miles/utils/chat_template_utils/deepseek_v32.py
@@ -49,8 +49,7 @@ def is_deepseek_v32(tokenizer: Any) -> bool:
 
 def _build_deepseek_encode_config(kwargs: dict) -> dict:
     kwargs = dict(kwargs)
-    enable_thinking = kwargs.pop("enable_thinking", None)
-    if enable_thinking is not None:
+    if (enable_thinking := kwargs.pop("enable_thinking", None)) is not None:
         kwargs.setdefault("thinking_mode", "thinking" if enable_thinking else "chat")
     # reject unknown kwargs to avoid silent config drop
     unknown = set(kwargs) - _KNOWN_KWARGS

--- a/miles/utils/chat_template_utils/deepseek_v4.py
+++ b/miles/utils/chat_template_utils/deepseek_v4.py
@@ -49,6 +49,10 @@ def is_deepseek_v4(tokenizer: Any) -> bool:
 
 
 def _build_deepseek_encode_config(kwargs: dict) -> dict:
+    kwargs = dict(kwargs)
+    enable_thinking = kwargs.pop("enable_thinking", None)
+    if enable_thinking is not None:
+        kwargs.setdefault("thinking_mode", "thinking" if enable_thinking else "chat")
     # reject unknown kwargs to avoid silent config drop
     unknown = set(kwargs) - _KNOWN_KWARGS
     if unknown:

--- a/miles/utils/chat_template_utils/deepseek_v4.py
+++ b/miles/utils/chat_template_utils/deepseek_v4.py
@@ -50,8 +50,7 @@ def is_deepseek_v4(tokenizer: Any) -> bool:
 
 def _build_deepseek_encode_config(kwargs: dict) -> dict:
     kwargs = dict(kwargs)
-    enable_thinking = kwargs.pop("enable_thinking", None)
-    if enable_thinking is not None:
+    if (enable_thinking := kwargs.pop("enable_thinking", None)) is not None:
         kwargs.setdefault("thinking_mode", "thinking" if enable_thinking else "chat")
     # reject unknown kwargs to avoid silent config drop
     unknown = set(kwargs) - _KNOWN_KWARGS

--- a/miles/utils/chat_template_utils/tito_tokenizer.py
+++ b/miles/utils/chat_template_utils/tito_tokenizer.py
@@ -710,6 +710,91 @@ class MinimaxM27TITOTokenizer(MinimaxM25TITOTokenizer):
 
 
 # ---------------------------------------------------------------------------
+# DeepSeek V3.2 implementation
+# ---------------------------------------------------------------------------
+
+
+class DeepSeekV32TITOTokenizer(TITOTokenizer):
+    """DeepSeek V3.2 — official encoder via sglang's ``encoding_dsv32``.
+
+    V3.2 ships no jinja chat_template; sglang renders prompts through
+    ``encoding_dsv32.encode_messages``, and miles' ``apply_chat_template`` routes
+    any V3.2 tokenizer to the thin ``chat_template_utils.deepseek_v32`` bridge.
+    TITO incremental tokenization rides that same bridge so it stays
+    byte-aligned with what the runtime serves.
+
+    Only the ``{tool}`` surface is registered.  DeepSeek's official
+    ``encoding_dsv32`` gates an assistant's thinking block on
+    ``index > last_user_idx``: appending a *user* turn re-classifies every prior
+    assistant as "before last user" and strips its thinking block, which is not
+    append-only.  Tool-only append is safe because ``find_last_user_index``
+    ignores tool roles, so the last-user position never moves.
+    """
+
+    reasoning_parser = "deepseek-v3"
+    tool_call_parser = "deepseekv32"
+
+    SUPPORTED_TEMPLATES = (
+        FixedTemplateRow(
+            allowed_roles=frozenset({"tool"}),
+            template=None,
+        ),
+    )
+
+    _DEFAULT_ASSISTANT_START = "<｜Assistant｜>"
+
+    def __init__(
+        self,
+        tokenizer: Any,
+        chat_template_kwargs: dict[str, Any] | None = None,
+        assistant_start_str: str | None = None,
+        allowed_append_roles: list[str] | None = None,
+    ):
+        # V3.2 has no jinja template, so assistant_start_str can't be sniffed
+        # from one; pin it explicitly.  The comparator keys off the User /
+        # Assistant sentinels to find assistant-content boundaries.
+        super().__init__(
+            tokenizer,
+            chat_template_kwargs=chat_template_kwargs,
+            assistant_start_str=assistant_start_str or self._DEFAULT_ASSISTANT_START,
+            special_token_ids={
+                tokenizer.convert_tokens_to_ids("<｜User｜>"),
+                tokenizer.convert_tokens_to_ids("<｜Assistant｜>"),
+            },
+            allowed_append_roles=allowed_append_roles,
+        )
+
+    def render_messages(
+        self,
+        messages: list[dict[str, Any]],
+        *,
+        add_generation_prompt: bool,
+        tools: list[dict[str, Any]] | None = None,
+        tokenize: bool = False,
+    ) -> str | list[int]:
+        """Render through the V3.2 bridge, translating miles' ``enable_thinking``
+        knob into the encoder's ``thinking_mode``.
+
+        Tool defs and the empty-system anchor are handled downstream by
+        ``deepseek_v32.render_messages`` (sglang-aligned), so ``tools`` is just
+        forwarded.  ``add_generation_prompt`` is forwarded but is a no-op on this
+        path: the encoder always emits the next-turn opener as part of the last
+        message, so there is no separate generation-prompt suffix to add or strip.
+        """
+        encode_kwargs = dict(self.chat_template_kwargs)
+        enable_thinking = encode_kwargs.pop("enable_thinking", False)
+        encode_kwargs.setdefault("thinking_mode", "thinking" if enable_thinking else "chat")
+        return apply_chat_template(
+            messages,
+            tokenizer=self.tokenizer,
+            tokenize=tokenize,
+            add_generation_prompt=add_generation_prompt,
+            tools=tools,
+            **encode_kwargs,
+        )
+
+
+# ---------------------------------------------------------------------------
 # Enum + Factory
 # ---------------------------------------------------------------------------
 
@@ -725,6 +810,7 @@ class TITOTokenizerType(StrEnum):
     KIMI26 = "kimi26"
     MINIMAX_M25 = "minimax_m25"
     MINIMAX_M27 = "minimax_m27"
+    DEEPSEEKV32 = "deepseekv32"
 
     @classmethod
     def get_tokenizer_class(cls, t: TITOTokenizerType) -> type[TITOTokenizer]:
@@ -750,6 +836,8 @@ class TITOTokenizerType(StrEnum):
                 return MinimaxM25TITOTokenizer
             case cls.MINIMAX_M27:
                 return MinimaxM27TITOTokenizer
+            case cls.DEEPSEEKV32:
+                return DeepSeekV32TITOTokenizer
             case _:
                 raise ValueError(f"Unknown TITOTokenizerType: {t!r}")
 

--- a/miles/utils/chat_template_utils/tito_tokenizer.py
+++ b/miles/utils/chat_template_utils/tito_tokenizer.py
@@ -764,35 +764,6 @@ class DeepSeekV32TITOTokenizer(TITOTokenizer):
             allowed_append_roles=allowed_append_roles,
         )
 
-    def render_messages(
-        self,
-        messages: list[dict[str, Any]],
-        *,
-        add_generation_prompt: bool,
-        tools: list[dict[str, Any]] | None = None,
-        tokenize: bool = False,
-    ) -> str | list[int]:
-        """Render through the V3.2 bridge, translating miles' ``enable_thinking``
-        knob into the encoder's ``thinking_mode``.
-
-        Tool defs and the empty-system anchor are handled downstream by
-        ``deepseek_v32.render_messages`` (sglang-aligned), so ``tools`` is just
-        forwarded.  ``add_generation_prompt`` is forwarded but is a no-op on this
-        path: the encoder always emits the next-turn opener as part of the last
-        message, so there is no separate generation-prompt suffix to add or strip.
-        """
-        encode_kwargs = dict(self.chat_template_kwargs)
-        enable_thinking = encode_kwargs.pop("enable_thinking", False)
-        encode_kwargs.setdefault("thinking_mode", "thinking" if enable_thinking else "chat")
-        return apply_chat_template(
-            messages,
-            tokenizer=self.tokenizer,
-            tokenize=tokenize,
-            add_generation_prompt=add_generation_prompt,
-            tools=tools,
-            **encode_kwargs,
-        )
-
 
 # ---------------------------------------------------------------------------
 # Enum + Factory

--- a/miles/utils/test_utils/session_verify_runner.py
+++ b/miles/utils/test_utils/session_verify_runner.py
@@ -162,6 +162,11 @@ def namespace_to_train_args(ns: argparse.Namespace) -> str:
     ]
     if ns.sglang_tool_call_parser:
         parts.append(f"--sglang-tool-call-parser {ns.sglang_tool_call_parser}")
+    # DeepSeek V3.2 (and other NSA/MoE archs) requires expert-parallel > 1 in
+    # sglang; the default is 1, which is fatal at engine init.  Only emit the
+    # flag when the caller asks for ep>1 so single-expert models stay untouched.
+    if ns.sglang_expert_parallel_size > 1:
+        parts.append(f"--sglang-expert-parallel-size {ns.sglang_expert_parallel_size}")
     if ns.use_session_server:
         parts.append("--use-session-server")
     if ns.debug_rollout_only:

--- a/miles/utils/test_utils/session_verify_runner.py
+++ b/miles/utils/test_utils/session_verify_runner.py
@@ -70,6 +70,7 @@ SESSION_VERIFY_INVARIANT_ARGS: dict[str, Any] = {
     "ci_test": True,
     "colocate": True,
     "train_backend": "fsdp",
+    "sglang_expert_parallel_size": 1,
 }
 
 

--- a/scripts/tools/verify_session_tito_tokenizer.py
+++ b/scripts/tools/verify_session_tito_tokenizer.py
@@ -96,6 +96,7 @@ def main() -> int:
     print(f"sglang reasoning parser:{args.sglang_reasoning_parser}")
     print(f"sglang tool-call parser:{args.sglang_tool_call_parser or '(none)'}")
     print(f"Rollout GPUs per engine:{args.rollout_num_gpus_per_engine}")
+    print(f"sglang expert-parallel: {args.sglang_expert_parallel_size}")
     print(f"Actor nodes:            {args.actor_num_nodes}")
     print(f"Actor GPUs per node:    {args.actor_num_gpus_per_node}")
     print(f"Samples per prompt:     {args.n_samples_per_prompt}")

--- a/tests/fast/utils/chat_template_utils/test_deepseek_v32.py
+++ b/tests/fast/utils/chat_template_utils/test_deepseek_v32.py
@@ -255,6 +255,54 @@ def test_accept_none_tools_and_known_kwargs():
 
 
 # ---------------------------------------------------------------------------
+# enable_thinking -> thinking_mode translation (miles alias for the encoder knob)
+# ---------------------------------------------------------------------------
+
+
+def test_enable_thinking_true_maps_to_thinking():
+    assert deepseek_v32.render_messages(_MSGS_BASIC, enable_thinking=True) == deepseek_v32.render_messages(
+        _MSGS_BASIC, thinking_mode="thinking"
+    )
+
+
+def test_enable_thinking_false_maps_to_chat():
+    assert deepseek_v32.render_messages(_MSGS_BASIC, enable_thinking=False) == deepseek_v32.render_messages(
+        _MSGS_BASIC, thinking_mode="chat"
+    )
+
+
+def test_enable_thinking_absent_defaults_to_thinking():
+    # No enable_thinking and no thinking_mode -> the cfg default ("thinking").
+    assert deepseek_v32.render_messages(_MSGS_BASIC) == deepseek_v32.render_messages(
+        _MSGS_BASIC, thinking_mode="thinking"
+    )
+
+
+def test_enable_thinking_none_defaults_to_thinking():
+    # Explicit None is treated as absent: falls through to the "thinking" default.
+    assert deepseek_v32.render_messages(_MSGS_BASIC, enable_thinking=None) == deepseek_v32.render_messages(
+        _MSGS_BASIC, thinking_mode="thinking"
+    )
+
+
+def test_explicit_thinking_mode_wins_over_enable_thinking():
+    assert deepseek_v32.render_messages(
+        _MSGS_BASIC, enable_thinking=False, thinking_mode="thinking"
+    ) == deepseek_v32.render_messages(_MSGS_BASIC, thinking_mode="thinking")
+
+
+def test_enable_thinking_is_consumed_not_rejected():
+    # enable_thinking is translated away, so it is not rejected as an unknown kwarg.
+    deepseek_v32.render_messages(_MSGS_BASIC, enable_thinking=True)
+
+
+def test_build_config_does_not_mutate_input_kwargs():
+    kwargs = {"enable_thinking": True}
+    deepseek_v32._build_deepseek_encode_config(kwargs)
+    assert kwargs == {"enable_thinking": True}
+
+
+# ---------------------------------------------------------------------------
 # Cross-version detection exactness (the V3.2 detector must not match V4)
 # ---------------------------------------------------------------------------
 

--- a/tests/fast/utils/chat_template_utils/test_deepseek_v4.py
+++ b/tests/fast/utils/chat_template_utils/test_deepseek_v4.py
@@ -340,6 +340,54 @@ def test_accept_none_tools_and_known_kwargs():
 
 
 # ---------------------------------------------------------------------------
+# enable_thinking -> thinking_mode translation (miles alias for the encoder knob)
+# ---------------------------------------------------------------------------
+
+
+def test_enable_thinking_true_maps_to_thinking():
+    assert deepseek_v4.render_messages(_MSGS_BASIC, enable_thinking=True) == deepseek_v4.render_messages(
+        _MSGS_BASIC, thinking_mode="thinking"
+    )
+
+
+def test_enable_thinking_false_maps_to_chat():
+    assert deepseek_v4.render_messages(_MSGS_BASIC, enable_thinking=False) == deepseek_v4.render_messages(
+        _MSGS_BASIC, thinking_mode="chat"
+    )
+
+
+def test_enable_thinking_absent_defaults_to_thinking():
+    # No enable_thinking and no thinking_mode -> the cfg default ("thinking").
+    assert deepseek_v4.render_messages(_MSGS_BASIC) == deepseek_v4.render_messages(
+        _MSGS_BASIC, thinking_mode="thinking"
+    )
+
+
+def test_enable_thinking_none_defaults_to_thinking():
+    # Explicit None is treated as absent: falls through to the "thinking" default.
+    assert deepseek_v4.render_messages(_MSGS_BASIC, enable_thinking=None) == deepseek_v4.render_messages(
+        _MSGS_BASIC, thinking_mode="thinking"
+    )
+
+
+def test_explicit_thinking_mode_wins_over_enable_thinking():
+    assert deepseek_v4.render_messages(
+        _MSGS_BASIC, enable_thinking=False, thinking_mode="thinking"
+    ) == deepseek_v4.render_messages(_MSGS_BASIC, thinking_mode="thinking")
+
+
+def test_enable_thinking_is_consumed_not_rejected():
+    # enable_thinking is translated away, so it is not rejected as an unknown kwarg.
+    deepseek_v4.render_messages(_MSGS_BASIC, enable_thinking=True)
+
+
+def test_build_config_does_not_mutate_input_kwargs():
+    kwargs = {"enable_thinking": True}
+    deepseek_v4._build_deepseek_encode_config(kwargs)
+    assert kwargs == {"enable_thinking": True}
+
+
+# ---------------------------------------------------------------------------
 # Generation-prompt behavior: no knob, no suffix surgery
 # ---------------------------------------------------------------------------
 

--- a/tests/fast/utils/chat_template_utils/test_template.py
+++ b/tests/fast/utils/chat_template_utils/test_template.py
@@ -400,6 +400,21 @@ class TestDeepSeekV32TITOAlignWithSGLang:
         actual = tito.render_messages(messages, add_generation_prompt=True, tools=self._TOOLS, tokenize=True)
         assert actual == expected
 
+    def test_absent_enable_thinking_defaults_to_thinking(self):
+        # With the translation now living in the encoder, an absent enable_thinking
+        # renders in thinking mode (the encoder default), matching sglang thinking=True.
+        tokenizer = _get_deepseek_v32_tokenizer()
+        messages = [{"role": "user", "content": "What is the weather in Paris?"}]
+
+        expected = sglang_dsv32_prompt_ids(tokenizer, messages, self._TOOLS, thinking=True)
+        tito = get_tito_tokenizer(
+            tokenizer,
+            tokenizer_type=TITOTokenizerType.DEEPSEEKV32,
+            chat_template_kwargs={},
+        )
+        actual = tito.render_messages(messages, add_generation_prompt=True, tools=self._TOOLS, tokenize=True)
+        assert actual == expected
+
     @pytest.mark.parametrize("thinking", [False, True], ids=["chat", "thinking"])
     def test_prompt_ids_match_sglang_dsv32_with_tool_history(self, thinking):
         tokenizer = _get_deepseek_v32_tokenizer()

--- a/tests/fast/utils/chat_template_utils/test_template.py
+++ b/tests/fast/utils/chat_template_utils/test_template.py
@@ -18,6 +18,7 @@ Each test asserts that our ``apply_chat_template`` produces identical token IDs.
 from __future__ import annotations
 
 import copy
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
@@ -25,7 +26,7 @@ from sglang.srt.entrypoints.openai.protocol import ChatCompletionRequest
 from sglang.srt.entrypoints.openai.serving_chat import OpenAIServingChat
 from transformers import AutoTokenizer
 
-from miles.utils.chat_template_utils import TITOTokenizerType, resolve_fixed_chat_template
+from miles.utils.chat_template_utils import TITOTokenizerType, get_tito_tokenizer, resolve_fixed_chat_template
 from miles.utils.chat_template_utils.template import apply_chat_template
 from miles.utils.processing_utils import load_tokenizer
 from miles.utils.test_utils.chat_template_verify import (
@@ -82,17 +83,56 @@ def sglang_prompt_ids(
     return result.prompt_ids
 
 
+def sglang_dsv32_prompt_ids(
+    tokenizer,
+    messages: list[dict],
+    tools: list[dict] | None = None,
+    **kwargs,
+) -> list[int]:
+    """Get prompt_ids through sglang's DeepSeek V3.2 encoding path.
+
+    sglang selects the V3.2 encoder in ``_apply_jinja_template`` when
+    ``chat_encoding_spec == "dsv32"`` (it auto-detects this from architecture +
+    a missing jinja template).  We set it directly so the test does not depend
+    on architecture introspection.  Thinking is requested via the ``thinking``
+    chat-template kwarg, matching the runtime knob.
+    """
+    request_data: dict = {"messages": copy.deepcopy(messages), "model": "test"}
+    if tools:
+        request_data["tools"] = copy.deepcopy(tools)
+    if kwargs:
+        request_data["chat_template_kwargs"] = kwargs
+    request = ChatCompletionRequest(**request_data)
+
+    serving = _make_serving(tokenizer)
+    serving.chat_encoding_spec = "dsv32"
+    serving.reasoning_parser = "deepseek-v3"
+    serving.tool_call_parser = "deepseekv32"
+    result = serving._process_messages(request, is_multimodal=False)
+    return result.prompt_ids
+
+
 # ---------------------------------------------------------------------------
 # Tokenizer cache & fixed-template loader
 # ---------------------------------------------------------------------------
 
 _TOK_CACHE: dict[str, AutoTokenizer] = {}
 
+# V3.2's HF repo is ~1.3 TB and not pulled in CI; tests use the cluster-mounted
+# copy when present and skip otherwise (Stage 2 only needs the tokenizer).
+_DEEPSEEK_V32_MODEL = "/cluster-storage/models/deepseek-ai/DeepSeek-V3.2"
+
 
 def _get_tokenizer(model_id: str) -> AutoTokenizer:
     if model_id not in _TOK_CACHE:
         _TOK_CACHE[model_id] = load_tokenizer(model_id, trust_remote_code=True)
     return _TOK_CACHE[model_id]
+
+
+def _get_deepseek_v32_tokenizer() -> AutoTokenizer:
+    if not Path(_DEEPSEEK_V32_MODEL).exists():
+        pytest.skip(f"DeepSeek V3.2 tokenizer not found: {_DEEPSEEK_V32_MODEL}")
+    return _get_tokenizer(_DEEPSEEK_V32_MODEL)
 
 
 def _load_fixed_or_none(tito_model: TITOTokenizerType | None) -> str | None:
@@ -311,3 +351,79 @@ class TestDatasetRouting:
         dataset = _build_dataset(str(tmp_path), tokenizer, {"text": messages, "tools": tools}, tool_key="tools")
         expected_ids = sglang_prompt_ids(tokenizer, messages, tools)
         assert tokenizer.encode(dataset.samples[0].prompt, add_special_tokens=False) == expected_ids
+
+
+# ---------------------------------------------------------------------------
+# DeepSeek V3.2 TITO alignment
+# ---------------------------------------------------------------------------
+
+
+class TestDeepSeekV32TITOAlignWithSGLang:
+    """V3.2 TITO prompt tokenization must match sglang's dsv32 encoder.
+
+    V3.2 ships no jinja chat_template; the ``DEEPSEEKV32`` TITO family rides
+    miles' ``apply_chat_template`` -> ``chat_template_utils.deepseek_v32`` bridge,
+    which mirrors sglang's ``chat_encoding_spec == "dsv32"`` branch.  These pin
+    that ``get_tito_tokenizer(...).render_messages`` produces identical
+    prompt_ids to sglang for the tool surface actually used in training, with
+    thinking on/off.  ``thinking`` is the sglang request knob; ``enable_thinking``
+    is the equivalent miles chat-template kwarg — both map to the encoder's
+    ``thinking_mode``.
+    """
+
+    _TOOLS = [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "Get weather",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                    "required": ["city"],
+                },
+            },
+        }
+    ]
+
+    @pytest.mark.parametrize("thinking", [False, True], ids=["chat", "thinking"])
+    def test_prompt_ids_match_sglang_dsv32_with_tools(self, thinking):
+        tokenizer = _get_deepseek_v32_tokenizer()
+        messages = [{"role": "user", "content": "What is the weather in Paris?"}]
+
+        expected = sglang_dsv32_prompt_ids(tokenizer, messages, self._TOOLS, thinking=thinking)
+        tito = get_tito_tokenizer(
+            tokenizer,
+            tokenizer_type=TITOTokenizerType.DEEPSEEKV32,
+            chat_template_kwargs={"enable_thinking": thinking},
+        )
+        actual = tito.render_messages(messages, add_generation_prompt=True, tools=self._TOOLS, tokenize=True)
+        assert actual == expected
+
+    @pytest.mark.parametrize("thinking", [False, True], ids=["chat", "thinking"])
+    def test_prompt_ids_match_sglang_dsv32_with_tool_history(self, thinking):
+        tokenizer = _get_deepseek_v32_tokenizer()
+        messages = [
+            {"role": "user", "content": "Weather in Beijing?"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "get_weather", "arguments": '{"city": "Beijing"}'},
+                    }
+                ],
+            },
+            {"role": "tool", "content": "sunny, 22C", "tool_call_id": "call_1", "name": "get_weather"},
+        ]
+
+        expected = sglang_dsv32_prompt_ids(tokenizer, messages, self._TOOLS, thinking=thinking)
+        tito = get_tito_tokenizer(
+            tokenizer,
+            tokenizer_type=TITOTokenizerType.DEEPSEEKV32,
+            chat_template_kwargs={"enable_thinking": thinking},
+        )
+        actual = tito.render_messages(messages, add_generation_prompt=True, tools=self._TOOLS, tokenize=True)
+        assert actual == expected

--- a/tests/fast/utils/chat_template_utils/test_tito_tokenizer.py
+++ b/tests/fast/utils/chat_template_utils/test_tito_tokenizer.py
@@ -515,6 +515,7 @@ class TestParserBinding:
             (TITOTokenizerType.KIMI26, "kimi_k2", "kimi_k2_raw_id"),
             (TITOTokenizerType.MINIMAX_M25, "minimax-append-think", "minimax-m2"),
             (TITOTokenizerType.MINIMAX_M27, "minimax-append-think", "minimax-m2"),
+            (TITOTokenizerType.DEEPSEEKV32, "deepseek-v3", "deepseekv32"),
             (TITOTokenizerType.DEFAULT, None, None),
         ],
     )

--- a/tests/fast/utils/test_utils/test_session_verify_runner.py
+++ b/tests/fast/utils/test_utils/test_session_verify_runner.py
@@ -24,7 +24,6 @@ def _build_args(**overrides) -> str:
         "tool_call_failure_mode": "rollback",
         "sglang_reasoning_parser": "qwen3",
         "sglang_tool_call_parser": "qwen25",
-        "sglang_expert_parallel_size": 1,
     }
     values.update(overrides)
     return namespace_to_train_args(argparse.Namespace(**values))

--- a/tests/fast/utils/test_utils/test_session_verify_runner.py
+++ b/tests/fast/utils/test_utils/test_session_verify_runner.py
@@ -24,6 +24,7 @@ def _build_args(**overrides) -> str:
         "tool_call_failure_mode": "rollback",
         "sglang_reasoning_parser": "qwen3",
         "sglang_tool_call_parser": "qwen25",
+        "sglang_expert_parallel_size": 1,
     }
     values.update(overrides)
     return namespace_to_train_args(argparse.Namespace(**values))
@@ -46,6 +47,18 @@ def test_namespace_to_train_args_keeps_ci_test_enabled_for_fsdp_debug_rollout():
 
     assert "--train-backend fsdp" in train_args
     assert "--ci-test" in train_args
+
+
+def test_namespace_to_train_args_omits_expert_parallel_for_single_expert():
+    train_args = _build_args()
+
+    assert "--sglang-expert-parallel-size" not in train_args
+
+
+def test_namespace_to_train_args_emits_expert_parallel_for_moe():
+    train_args = _build_args(sglang_expert_parallel_size=8)
+
+    assert "--sglang-expert-parallel-size 8" in train_args
 
 
 def _write_metrics(path, entries: list[dict]) -> None:


### PR DESCRIPTION
## Summary
Add DeepSeek V3.2 to the TITO tokenizer family for session prefix reuse, and extend the shared `enable_thinking`->`thinking_mode` alias to the DeepSeek V4 encoder (`test_deepseek_v4` coverage). V4 rendering already existed on main; this PR adds the alias + tests, not V4 from scratch.
Thanks to this PR as reference #1065 

## Motivation
TITO incremental tokenization reuses a pretokenized assistant prefix in the session server, but had no DeepSeek V3.2 family. main already landed the V3.2 chat-template encoder (`config.json` `model_type` detection plus the `encoding_dsv32` bridge in `chat_template_utils/deepseek_v32.py`, routed from `apply_chat_template`). This PR adds only the missing TITO-family layer on top, so V3.2 sessions tokenize byte-aligned with what sglang serves.

## Usage
Launch a session with `--tito-model deepseekv32 --tito-allowed-append-roles tool`. The session server then computes incremental token ids for appended tool turns and reuses the pretokenized prefix, rather than re-rendering the whole conversation each turn.

## Design Notes
- **Tool-only append surface:** `DeepSeekV32TITOTokenizer` registers only the `{tool}` `SUPPORTED_TEMPLATES` row.
- **Why tool-only:** `encoding_dsv32` gates assistant thinking on `index > last_user_idx`, so a user append restrips prior thinking (not append-only); `find_last_user_index` ignores tool roles, so tool append is safe.
- **enable_thinking lives in the encoder:** `_build_deepseek_encode_config` (v32 + v4) translates the `enable_thinking` bool to `thinking_mode`, so the alias works on every `apply_chat_template` path.
- **Session-verify ep_size:** plumb `--sglang-expert-parallel-size`; DeepSeek V3.2 fails sglang engine init at `ep=1`.

## Verification
- **Tests added:** `TestDeepSeekV32TITOAlignWithSGLang` pins TITO `render_messages` prompt_ids byte-equal to sglang's dsv32 encoder across tools, tool history, thinking on/off, absent default.
- **enable_thinking mapping:** `test_deepseek_v32` / `test_deepseek_v4` cover True, False, absent, None, explicit-wins, consumed-not-rejected, no-input-mutation.
- **Stage 2 (CPU)** — append-only decode-roundtrip 26/26 PASS, full `chat_template_utils` fast suite green:
  ```
  python scripts/tools/verify_chat_template.py \
    --model deepseek-ai/DeepSeek-V3.2 --tito-model deepseekv32 \
    --tito-allowed-append-roles tool --thinking both          # 26/26 passed, Verdict PASS
  python -m pytest tests/fast/utils/chat_template_utils/ -q   # 1439 passed
  ```
- **Stage 3 (GPU, 8×H200, tp=8 / ep=8)** — session-server TITO verifier, every hard mismatch counter 0:
  ```
  python scripts/tools/verify_session_tito_tokenizer.py \
    --hf-checkpoint deepseek-ai/DeepSeek-V3.2 --tito-model deepseekv32 \
    --tito-allowed-append-roles tool \
    --sglang-reasoning-parser deepseek-v3 --sglang-tool-call-parser deepseekv32 \
    --rollout-num-gpus-per-engine 8 --sglang-expert-parallel-size 8
  ```
  → `tito_session_mismatch_rate=0.0` (`special_token_count` / `special_token_type` / `non_assistant_text` / `assistant_text` all 0.0), 64/64 samples coverage-verified, every sample emitted `append_tool`, Verdict PASS.

## Review Focus
- Scrutinize the tool-only `SUPPORTED_TEMPLATES` choice in `DeepSeekV32TITOTokenizer` — user/system appends must stay excluded as non-append-only.
- Scrutinize the `enable_thinking` absent default in `_build_deepseek_encode_config`; it now renders `thinking`, where the prior TITO override rendered `chat`.


