### PR TITLE
fix: support Qwen3-VL Megatron training inputs

### DIFF
--- a/miles/backends/megatron_utils/model.py
+++ b/miles/backends/megatron_utils/model.py
@@ -48,6 +48,12 @@ from .bridge_lora_helpers import _ensure_model_list, _setup_lora_model_via_bridg
 from .lora_utils import save_lora_checkpoint
 
 
+def _megatron_multimodal_forward_kwargs(multimodal_train_inputs: dict[str, torch.Tensor] | None) -> dict[str, torch.Tensor]:
+    if multimodal_train_inputs is None:
+        return {}
+    return {key: value for key, value in multimodal_train_inputs.items() if key != "mm_token_type_ids"}
+
+
 def get_optimizer_param_scheduler(args: Namespace, optimizer: MegatronOptimizer) -> OptimizerParamScheduler:
     """Create and configure the optimizer learning-rate/weight-decay scheduler.
 
@@ -269,7 +275,7 @@ def forward_only(
             labels=None,
             packed_seq_params=packed_seq_params,
             loss_mask=batch["full_loss_masks"],
-            **(batch["multimodal_train_inputs"] if batch["multimodal_train_inputs"] is not None else {}),
+            **_megatron_multimodal_forward_kwargs(batch["multimodal_train_inputs"]),
         )
 
         return output_tensor, partial(
@@ -438,8 +444,7 @@ def train_one_step(
             if args.enable_mtp_training:
                 forward_kwargs["mtp_kwargs"] = {"mtp_labels": batch["tokens"]}
 
-            if batch["multimodal_train_inputs"] is not None:
-                forward_kwargs.update(batch["multimodal_train_inputs"])
+            forward_kwargs.update(_megatron_multimodal_forward_kwargs(batch["multimodal_train_inputs"]))
 
             output_tensor = model(**forward_kwargs)
 

--- a/miles/backends/training_utils/data.py
+++ b/miles/backends/training_utils/data.py
@@ -18,6 +18,18 @@ from .parallel import get_parallel_state
 logger = logging.getLogger(__name__)
 
 
+def _move_multimodal_value_to_device(value, device: torch.device | int):
+    if torch.is_tensor(value):
+        return value.to(device=device)
+    return torch.as_tensor(value, device=device)
+
+
+def _skip_multimodal_training_key(args: Namespace, key: str) -> bool:
+    # Qwen3-VL processors emit mm_token_type_ids for HF/SGLang, but Megatron's
+    # Qwen3-VL bridge model consumes image/video tensors directly.
+    return getattr(args, "train_backend", None) == "megatron" and key == "mm_token_type_ids"
+
+
 def get_rollout_data(args: Namespace, rollout_data_ref: Box) -> RolloutBatch:
     parallel_state = get_parallel_state()
     # Fetch data through ray on CPU, not sure if this will be performance bottleneck.
@@ -39,7 +51,11 @@ def get_rollout_data(args: Namespace, rollout_data_ref: Box) -> RolloutBatch:
         # Move multimodal training tensors to GPU in advance
         rollout_data["multimodal_train_inputs"] = [
             (
-                {key: tensor.to(device=torch.cuda.current_device()) for key, tensor in mm_dict.items()}
+                {
+                    key: _move_multimodal_value_to_device(tensor, torch.cuda.current_device())
+                    for key, tensor in mm_dict.items()
+                    if not _skip_multimodal_training_key(args, key)
+                }
                 if mm_dict is not None
                 else None
             )


### PR DESCRIPTION
## Summary
Hi, I ran into an issue while trying to run VLM training with Qwen3-VL. There were two issues:
  1. `get_rollout_data()` assumed every value in multimodal_train_inputs was already a tensor and called `.to(device)` on it. Qwen3-VL processor outputs can include list-backed values, so that path was breaks for VLM data.
  2. The Megatron forward/logprob/train path passed every multimodal key into the Megatron model. Qwen3-VL emits `mm_token_type_ids`, which is valid for the HF/SGLang side, but Megatron’s Qwen3-VL bridge does not accept that kwarg. That caused the training/logprob forward to fail once rollout data was handed back to Megatron.

 
This fix converts non-tensor multimodal values to CUDA tensors and filters `mm_token_type_ids` for the Megatron backend, while keeping the actual image/video tensors needed by the bridge model.
