### PR TITLE
ci(qwen3-30B-A3B): document bridge+deepep blockers and use normal dee…

### DIFF
--- a/tests/e2e/megatron/test_qwen3_30B_A3B.py
+++ b/tests/e2e/megatron/test_qwen3_30B_A3B.py
@@ -24,7 +24,10 @@ CONFIGS: list[dict] = [
         "USE_INT4_ROLLOUT": False,
         "USE_BRIDGE": False,
     },
-    # TODO: This deepep test need fix.
+    # TODO(bridge+deepep): Two issues prevent this config from passing:
+    # 1. HfWeightIteratorBridge does not EP-gather expert weights before export,
+    #    causing shape mismatch (hidden/TP/EP vs hidden) during weight sync.
+    # 2. bridge.load_hf_weights() cannot load FP8 checkpoints correctly.
     # {
     #     "USE_DEEPEP": True,
     #     "USE_FP8_ROLLOUT": True,
@@ -161,7 +164,7 @@ def execute(USE_DEEPEP: bool, USE_FP8_ROLLOUT: bool, USE_INT4_ROLLOUT: bool, USE
         )
 
     if USE_DEEPEP:
-        sglang_args += "--sglang-moe-a2a-backend deepep --sglang-deepep-mode auto "
+        sglang_args += "--sglang-moe-a2a-backend deepep --sglang-deepep-mode normal "
 
     ci_args = "--ci-test "
 


### PR DESCRIPTION
…pep mode

Two changes to the Qwen3-30B-A3B e2e megatron test:

1. Replace the vague "TODO: This deepep test need fix" with a detailed explanation of the two framework bugs blocking the bridge+deepep config:
   - HfWeightIteratorBridge does not EP-gather expert weights before export, causing shape mismatch during weight sync to SGLang.
   - bridge.load_hf_weights() cannot properly handle FP8 checkpoints.

2. Switch --sglang-deepep-mode from "auto" to "normal". The "auto" mode may select low_latency mode which requires NVSHMEM IBGDA (InfiniBand GPU Direct Async). Using "normal" mode avoids this dependency and uses P2P/NVLink for intra-node communication, which is sufficient for single-node 8-GPU CI runners.