### PR TITLE
add Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,92 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, maintainers, and leaders of the Miles community pledge to make participation in our project a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, caste, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, respectful, and healthy technical community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for the Miles community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, backgrounds, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility, apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best for the overall community and the long-term health of the project
+* Collaborating in good faith across research, engineering, operations, documentation, and user-support discussions
+* Helping maintain a professional environment in issues, pull requests, discussions, chat channels, meetings, documentation, examples, and community events
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, personal attacks, or political attacks unrelated to the project
+* Public or private harassment
+* Publishing others' private information, such as a physical address, private email address, phone number, credentials, private logs, or internal deployment details, without explicit permission
+* Deliberately disrupting project work, reviews, discussions, meetings, issue triage, release processes, or community spaces
+* Repeatedly ignoring maintainer guidance, review boundaries, or moderation decisions
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior. They will take appropriate and fair corrective action in response to behavior that they deem inappropriate, threatening, offensive, harmful, or disruptive to the Miles community.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, documentation, wiki edits, issues, pull requests, discussions, and other contributions that are not aligned to this Code of Conduct. When appropriate, they will communicate reasons for moderation decisions.
+
+## Scope
+
+This Code of Conduct applies within all Miles community spaces, including but not limited to:
+
+* GitHub repositories, issues, pull requests, discussions, and review comments
+* Documentation, examples, tutorials, and project websites
+* Community chat channels, mailing lists, forums, and meetings
+* Conferences, meetups, workshops, demos, and other online or offline events connected to the project
+
+This Code of Conduct also applies when an individual is officially representing the Miles project or community in public spaces. Examples of representing the project include using an official project email address, posting through an official social media account, publishing official documentation or release notes, speaking on behalf of the project at an event, or acting as an appointed project representative.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at:
+
+miles@radixark.ai
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident. Reports should be handled with appropriate confidentiality, and information should be shared only with those who need it to review, investigate, or resolve the incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for actions they deem to be in violation of this Code of Conduct.
+
+### 1. Correction
+
+**Community Impact:** Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence:** A private, written correction from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested where appropriate.
+
+### 2. Warning
+
+**Community Impact:** A violation through a single incident or a series of actions.
+
+**Consequence:** A warning with consequences for continued behavior. The person may be asked to avoid interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels such as social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact:** A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence:** A temporary ban from any sort of interaction or public communication with the Miles community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact:** Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, aggression toward others, or disparagement of classes of individuals.
+
+**Consequence:** A permanent ban from any sort of public interaction within the Miles community.
+
+## Attribution
+
+This Code of Conduct is adapted from the Contributor Covenant, version 2.0, available at:
+
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html
+
+Community Impact Guidelines were inspired by Mozilla's code of conduct enforcement ladder.


### PR DESCRIPTION
Adapted from Contributor Covenant v2.0. Sets community standards for all Miles community spaces (GitHub, docs, chat, events) and defines the enforcement ladder.

Enforcement contact: miles@radixark.ai