### PR TITLE
[CI] Add dense true-on-policy E2E gate

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -177,6 +177,18 @@ jobs:
       execute_command: "python tests/ci/gpu_lock_exec.py --count 8 -- python tests/e2e/megatron/test_glm5_744b_a40b_4layer.py"
     secrets: inherit
 
+  # Stage C: Dense true-on-policy E2E gate (8 GPU)
+  stage-c-true-on-policy:
+    needs: [stage-b-sglang, stage-b-short]
+    if: |
+      always() && !failure() && !cancelled() &&
+      ((github.event_name == 'workflow_dispatch') || (github.event.pull_request && contains(github.event.pull_request.labels.*.name, 'run-ci-true-on-policy')))
+    uses: ./.github/workflows/_run-ci.yml
+    with:
+      gpu_count: 8
+      execute_command: "python tests/ci/run_suite.py --hw cuda --suite stage-c-true-on-policy-8-gpu"
+    secrets: inherit
+
   # Stage C: All suites (triggered by run-ci-image label)
   stage-c-all:
     needs: [stage-b-sglang, stage-b-short]
@@ -193,6 +205,7 @@ jobs:
           - stage-c-ckpt-8-gpu
           - stage-c-long-8-gpu
           - stage-c-lora-8-gpu
+          - stage-c-true-on-policy-8-gpu
           - stage-b-short-8-gpu
     uses: ./.github/workflows/_run-ci.yml
     with:

--- a/miles/backends/training_utils/log_utils.py
+++ b/miles/backends/training_utils/log_utils.py
@@ -448,6 +448,14 @@ def log_train_step(
 
     log_dict_out["train/step"] = accumulated_step_id
 
+    if getattr(args, "ci_test", False) and getattr(args, "true_on_policy_mode", False) and role == "actor":
+        diff_key = "train/train_rollout_logprob_abs_diff"
+        assert diff_key in log_dict_out, f"CI check failed: missing {diff_key} in true_on_policy_mode"
+        assert log_dict_out[diff_key] == 0.0, (
+            "CI check failed: true_on_policy_mode requires exact train/rollout logprob equality, "
+            f"but {diff_key} is {log_dict_out[diff_key]}"
+        )
+
     if should_log is None:
         should_log = dist.get_rank() == 0
 

--- a/miles/true_on_policy/config.py
+++ b/miles/true_on_policy/config.py
@@ -208,7 +208,6 @@ class TrueOnPolicyConfig:
             (
                 "--deterministic-mode",
                 "--true-on-policy-mode",
-                "--recompute-logprobs-via-prefill",
             )
         )
 

--- a/tests/ci/run_suite.py
+++ b/tests/ci/run_suite.py
@@ -27,6 +27,7 @@ PER_COMMIT_SUITES = {
         "stage-c-long-8-gpu",
         "stage-c-lora-8-gpu",
         "stage-c-glm5-8-gpu",
+        "stage-c-true-on-policy-8-gpu",
     ],
 }
 

--- a/tests/e2e/megatron/test_qwen3_4B_true_on_policy.py
+++ b/tests/e2e/megatron/test_qwen3_4B_true_on_policy.py
@@ -1,0 +1,39 @@
+import os
+
+from scripts.run_qwen3_4b import ScriptArgs, execute, prepare
+from tests.ci.ci_register import register_cuda_ci
+
+import miles.utils.external_utils.command_utils as U
+
+register_cuda_ci(est_time=1200, suite="stage-c-true-on-policy-8-gpu", num_gpus=8)
+
+
+def _clear_proxy_env():
+    for proxy_var in ("http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY"):
+        os.environ.pop(proxy_var, None)
+
+
+def _build_args() -> ScriptArgs:
+    run_id = os.environ.get("GITHUB_COMMIT_NAME") or f"qwen3-dense-top-tp2-cp4-ci-{U.create_run_id()}"
+    args = ScriptArgs(
+        mode="debug_one_sample",
+        run_id=run_id,
+        model_name="Qwen3-4B",
+        train_backend="megatron",
+        true_on_policy=True,
+        enable_eval=False,
+        # Keep the CI gate close to the manual dense TP=2/CP=4 correctness gate:
+        # one 1024-token rollout with exact train/rollout logprob equality.
+        extra_args="--num-rollout 1 --rollout-max-response-len 1024 ",
+    )
+    args.tensor_model_parallel_size = 2
+    args.context_parallel_size = 4
+    args.cp_comm_type = "a2a"
+    return args
+
+
+if __name__ == "__main__":
+    args = _build_args()
+    prepare(args)
+    _clear_proxy_env()
+    execute(args)

--- a/tests/e2e/megatron/test_qwen3_4B_true_on_policy_tp4_cp2.py
+++ b/tests/e2e/megatron/test_qwen3_4B_true_on_policy_tp4_cp2.py
@@ -1,0 +1,38 @@
+import os
+
+from scripts.run_qwen3_4b import ScriptArgs, execute, prepare
+from tests.ci.ci_register import register_cuda_ci
+
+import miles.utils.external_utils.command_utils as U
+
+register_cuda_ci(est_time=1200, suite="stage-c-true-on-policy-8-gpu", num_gpus=8)
+
+
+def _clear_proxy_env():
+    for proxy_var in ("http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY"):
+        os.environ.pop(proxy_var, None)
+
+
+def _build_args() -> ScriptArgs:
+    run_id = os.environ.get("GITHUB_COMMIT_NAME") or f"qwen3-dense-top-tp4-cp2-ci-{U.create_run_id()}"
+    args = ScriptArgs(
+        mode="debug_one_sample",
+        run_id=run_id,
+        model_name="Qwen3-4B",
+        train_backend="megatron",
+        true_on_policy=True,
+        enable_eval=False,
+        # Covers the complementary 8-GPU dense layout: TP=4, CP=2.
+        extra_args="--num-rollout 1 --rollout-max-response-len 1024 ",
+    )
+    args.tensor_model_parallel_size = 4
+    args.context_parallel_size = 2
+    args.cp_comm_type = "a2a"
+    return args
+
+
+if __name__ == "__main__":
+    args = _build_args()
+    prepare(args)
+    _clear_proxy_env()
+    execute(args)

--- a/tests/fast/backends/training_utils/test_true_on_policy_data_log_dtype.py
+++ b/tests/fast/backends/training_utils/test_true_on_policy_data_log_dtype.py
@@ -1,6 +1,7 @@
 from argparse import Namespace
 from types import SimpleNamespace
 
+import pytest
 import torch
 
 from miles.backends.training_utils import cp_utils
@@ -60,3 +61,30 @@ def test_true_on_policy_log_checker_passes_when_values_and_dtype_match(monkeypat
     )
 
     assert captured["log_dict"]["log_probs"] == captured["log_dict"]["rollout_log_probs"]
+
+
+def test_true_on_policy_train_step_checker_passes_on_exact_logprob_match():
+    log_dict = log_utils.log_train_step(
+        args=Namespace(ci_test=True, true_on_policy_mode=True),
+        loss_dict={"train_rollout_logprob_abs_diff": 0.0},
+        grad_norm=0.0,
+        rollout_id=0,
+        step_id=0,
+        num_steps_per_rollout=1,
+        should_log=False,
+    )
+
+    assert log_dict["train/train_rollout_logprob_abs_diff"] == 0.0
+
+
+def test_true_on_policy_train_step_checker_rejects_nonzero_logprob_diff():
+    with pytest.raises(AssertionError, match="exact train/rollout logprob equality"):
+        log_utils.log_train_step(
+            args=Namespace(ci_test=True, true_on_policy_mode=True),
+            loss_dict={"train_rollout_logprob_abs_diff": 1e-6},
+            grad_norm=0.0,
+            rollout_id=0,
+            step_id=0,
+            num_steps_per_rollout=1,
+            should_log=False,
+        )

--- a/tests/fast/true_on_policy/test_config.py
+++ b/tests/fast/true_on_policy/test_config.py
@@ -140,7 +140,7 @@ def test_megatron_true_on_policy_disables_sequence_parallel_and_enables_backend_
     assert "--use-sglang" not in plan.train_args
     assert "--true-on-policy-contract qwen3_dense_true_on_policy_v1" in plan.train_args
     assert "--sglang-true-on-policy-contract qwen3_dense_true_on_policy_v1" in plan.train_args
-    assert "--recompute-logprobs-via-prefill" in plan.train_args
+    assert "--recompute-logprobs-via-prefill" not in plan.train_args
     assert "--batch-invariant-mode" in plan.train_args
     assert "--no-rope-fusion" in plan.train_args
     assert "ROW_LINEAR_ENABLE_INV" not in plan.env_vars
@@ -194,7 +194,6 @@ def test_megatron_tp2_cp4_normal_topology_has_complete_true_on_policy_contract(m
     assert plan.miles_args.values == (
         "--deterministic-mode",
         "--true-on-policy-mode",
-        "--recompute-logprobs-via-prefill",
     )
     assert plan.env_vars == {
         "NCCL_ALGO": "Ring",

--- a/tests/fast/true_on_policy/test_run_qwen3_4b.py
+++ b/tests/fast/true_on_policy/test_run_qwen3_4b.py
@@ -34,7 +34,7 @@ def test_qwen3_script_true_on_policy_single_knob_expands_to_megatron_contract(mo
     assert "--sglang-rl-on-policy-target" not in train_args
     assert "--sglang-attention-backend fa3" in train_args
     assert "--true-on-policy-contract qwen3_dense_true_on_policy_v1" in train_args
-    assert "--recompute-logprobs-via-prefill" in train_args
+    assert "--recompute-logprobs-via-prefill" not in train_args
     assert "--load /root/models/Qwen3-4B_torch_dist" in train_args
     assert "--save /root/shared_data/unit-test/checkpoints" in train_args
     assert "--use-sglang" not in train_args
@@ -61,13 +61,13 @@ def test_qwen3_script_true_on_policy_tp2_cp4_normal_topology_contract(monkeypatc
         true_on_policy=True,
         enable_eval=False,
         use_kl_loss=False,
-        tensor_model_parallel_size=2,
-        context_parallel_size=4,
-        pipeline_model_parallel_size=1,
-        cp_comm_type="a2a",
-        rollout_num_gpus=8,
-        rollout_num_gpus_per_engine=8,
     )
+    args.tensor_model_parallel_size = 2
+    args.context_parallel_size = 4
+    args.pipeline_model_parallel_size = 1
+    args.cp_comm_type = "a2a"
+    args.rollout_num_gpus_per_engine = 8
+    args.extra_args = "--rollout-num-gpus 8 "
 
     assert args.sglang_rl_on_policy_target is None
     assert args.use_sequence_parallel is False
@@ -87,7 +87,7 @@ def test_qwen3_script_true_on_policy_tp2_cp4_normal_topology_contract(monkeypatc
     assert "--sglang-true-on-policy-contract qwen3_dense_true_on_policy_v1" in train_args
     assert "--sglang-rl-on-policy-target" not in train_args
     assert "--sglang-attention-backend fa3" in train_args
-    assert "--recompute-logprobs-via-prefill" in train_args
+    assert "--recompute-logprobs-via-prefill" not in train_args
     assert "--use-sglang" not in train_args
     assert "--batch-invariant-mode" in train_args
     assert "--no-bias-swiglu-fusion" in train_args


### PR DESCRIPTION
## Summary
- add Qwen3-4B dense true-on-policy E2E gates for TP=2/CP=4 and TP=4/CP=2 Megatron + SGLang parity
- keep the gate on decode-produced rollout logprobs by removing the default `--recompute-logprobs-via-prefill` true-on-policy launch arg
- add an explicit CI assertion that `train/train_rollout_logprob_abs_diff == 0.0` in true-on-policy actor training
- register a dedicated `stage-c-true-on-policy-8-gpu` CI suite and expose it via the `run-ci-true-on-policy` label / `workflow_dispatch`

## Validation
- `python3 -m py_compile miles/backends/training_utils/log_utils.py miles/true_on_policy/config.py scripts/run_qwen3_4b.py tests/e2e/megatron/test_qwen3_4B_true_on_policy.py tests/e2e/megatron/test_qwen3_4B_true_on_policy_tp4_cp2.py tests/fast/true_on_policy/test_config.py tests/fast/true_on_policy/test_run_qwen3_4b.py tests/fast/backends/training_utils/test_true_on_policy_data_log_dtype.py`
- `PYTHONPATH=. python3 tests/ci/run_suite.py --hw cuda --suite stage-c-true-on-policy-8-gpu --list-only`
- `git diff --check`
- `pre-commit run --files miles/backends/training_utils/log_utils.py miles/true_on_policy/config.py tests/e2e/megatron/test_qwen3_4B_true_on_policy.py tests/e2e/megatron/test_qwen3_4B_true_on_policy_tp4_cp2.py tests/fast/backends/training_utils/test_true_on_policy_data_log_dtype.py tests/fast/true_on_policy/test_config.py tests/fast/true_on_policy/test_run_qwen3_4b.py`

Note: local `python3 -m pytest tests/fast/true_on_policy/test_config.py tests/fast/true_on_policy/test_run_qwen3_4b.py tests/fast/backends/training_utils/test_true_on_policy_data_log_dtype.py -q` was not run because this local Python does not have pytest installed.