### PR TITLE
rocm: fix hipBLASLt BGRADB wgrad failure on gfx950

### DIFF
--- a/miles/backends/megatron_utils/model_provider.py
+++ b/miles/backends/megatron_utils/model_provider.py
@@ -110,6 +110,15 @@ def get_model_provider_func(
             provider.moe_router_bias_update_rate = args.moe_router_bias_update_rate
         if getattr(args, "moe_aux_loss_coeff", None) is not None:
             provider.moe_aux_loss_coeff = args.moe_aux_loss_coeff
+        # The bridge provider defaults gradient_accumulation_fusion=True
+        # (via fusions.can_enable_gradient_accumulation_fusion). On ROCm/gfx950,
+        # this makes TE's LayerNormLinear backward issue a bias-fused wgrad GEMM
+        # with bf16 inputs → fp32 output + HIPBLASLT_EPILOGUE_BGRADB + accumulate,
+        # for which hipBLASLt has no algorithm. Honor the Megatron CLI flag so
+        # that --no-gradient-accumulation-fusion actually takes effect.
+        provider.gradient_accumulation_fusion = getattr(
+            args, "gradient_accumulation_fusion", provider.gradient_accumulation_fusion
+        )
         provider.finalize()
 
         def wrapped_bridge_provider(


### PR DESCRIPTION
The bridge provider defaults gradient_accumulation_fusion to True (via can_enable_gradient_accumulation_fusion) and ignores --no-gradient-accumulation-fusion from the CLI. The fix propagates the flag from Megatron args to the bridge provider.

Context:
hipBLASLt on gfx950 (MI350/MI355) has no algorithm for the triple combination of bf16 output with fp32 accumulate + HIPBLASLT_EPILOGUE_BGRADB epilogue + accumulate=True. This fires during TE's LayerNormLinear backward when gradient_accumulation_fusion=True and the layer has bias. So we don't use gradient_accumulation_fusion and need this change for that to take effect.