### PR TITLE
fix: skip actor CPU backup for disaggregated Megatron training

### DIFF
--- a/miles/backends/megatron_utils/actor.py
+++ b/miles/backends/megatron_utils/actor.py
@@ -143,7 +143,8 @@ class MegatronTrainRayActor(TrainRayActor):
             single_tag=None if args.enable_weights_backuper else "actor",
         )
         self._active_model_tag: str | None = "actor"
-        self.weights_backuper.backup("actor")
+        if self._enable_weight_backup:
+            self.weights_backuper.backup("actor")
 
         if with_ref:
             self.load_other_checkpoint("ref", args.ref_load)
@@ -221,7 +222,14 @@ class MegatronTrainRayActor(TrainRayActor):
         reload_process_groups()
         print_memory("after wake_up model")
 
+    @property
+    def _enable_weight_backup(self) -> bool:
+        """Weight backup is only needed for CPU-side model switching or colocated tensor weight sync."""
+        return self.with_ref or self.args.keep_old_actor or self.args.colocate
+
     def _switch_model(self, target_tag: str) -> None:
+        if not self._enable_weight_backup:
+            return
         if target_tag not in self.weights_backuper.backup_tags:
             raise ValueError(f"Cannot switch to unknown model tag: {target_tag}")
         self.weights_backuper.restore(target_tag)
@@ -452,7 +460,10 @@ class MegatronTrainRayActor(TrainRayActor):
                 m.clear_all()
 
         # update the cpu actor weight to the latest model
-        self.weights_backuper.backup("actor")
+        if self._enable_weight_backup:
+            self.weights_backuper.backup("actor")
+        else:
+            torch.cuda.synchronize()
 
         # Update ref model if needed
         if (


### PR DESCRIPTION
## Summary
Avoid storing an actor CPU backup for disaggregated mode without ref or old_actor.

## Problem
In disaggregated training with no ref model and no old_actor, host memory still holds actor weights even though disaggregated weight sync reads live model parameters, cause a waste in CPU memory and potential CPU OOM.

## Root Cause
`MegatronTrainRayActor.init` always backed up the `"actor"` tag through `weights_backuper`, and `train_actor` refreshed that CPU copy after every train step. That coupled three separate concerns: CPU-side model switching for `ref` / `old_actor`, colocated tensor weight sync, and the disaggregated weight-sync path. In disaggregated mode, `UpdateWeightFromDistributed` and `UpdateWeightP2P` gather weights from the live Megatron model and do not use `weights_getter`, so the actor CPU backup is redundant when no CPU-side model switching is needed.

## Fix
Gate actor backup and model restore behind `_enable_weight_backup`, which is true only for `with_ref`, `keep_old_actor`, or `colocate`, to skipp the redundant actor backup for disaggregated actor-only training.