### PR TITLE
Wire CI to install sglang/Megatron-LM from third_party submodules

### DIFF
--- a/.github/workflows/_run-ci.yml
+++ b/.github/workflows/_run-ci.yml
@@ -17,10 +17,6 @@ on:
         type: string
         required: false
         default: 'radixark/miles:dev'
-      skip_dependency_install:
-        type: boolean
-        required: false
-        default: false
       cpu_runner:
         type: boolean
         required: false
@@ -73,52 +69,10 @@ jobs:
           rm -rf /tmp/ray/* 2>/dev/null || true
           sleep 3
 
-      - name: Resolve dependency refs
-        if: ${{ !inputs.skip_dependency_install }}
-        id: resolve-refs
-        shell: bash
-        env:
-          PR_BODY: ${{ github.event.pull_request.body || '' }}
-          INPUT_MEGATRON_PR: ${{ github.event.inputs.ci_megatron_pr || '' }}
-          INPUT_SGLANG_PR: ${{ github.event.inputs.ci_sglang_pr || '' }}
-        run: |
-          MEGATRON_PR="${INPUT_MEGATRON_PR}"
-          SGLANG_PR="${INPUT_SGLANG_PR}"
-          if [ -n "$PR_BODY" ]; then
-            PR_MEGATRON_PR=$(echo "$PR_BODY" | grep -m1 -oP '^ci-megatron-pr:\s+\K\S+' || true)
-            PR_SGLANG_PR=$(echo "$PR_BODY" | grep -m1 -oP '^ci-sglang-pr:\s+\K\S+' || true)
-            [ -z "$MEGATRON_PR" ] && [ -n "$PR_MEGATRON_PR" ] && MEGATRON_PR="$PR_MEGATRON_PR"
-            [ -z "$SGLANG_PR" ] && [ -n "$PR_SGLANG_PR" ] && SGLANG_PR="$PR_SGLANG_PR"
-          fi
-          [ -z "$MEGATRON_PR" ] && MEGATRON_PR="miles-main"
-          [ -z "$SGLANG_PR" ] && SGLANG_PR="sglang-miles"
-          resolve_fetch_ref() {
-            local ref="$1"
-            if [[ "$ref" =~ ^#([0-9]+)$ ]]; then
-              echo "refs/pull/${BASH_REMATCH[1]}/head"
-            else
-              echo "$ref"
-            fi
-          }
-          MEGATRON_FETCH=$(resolve_fetch_ref "$MEGATRON_PR")
-          SGLANG_FETCH=$(resolve_fetch_ref "$SGLANG_PR")
-          echo "ci_megatron_pr=$MEGATRON_FETCH" >> $GITHUB_OUTPUT
-          echo "ci_sglang_pr=$SGLANG_FETCH" >> $GITHUB_OUTPUT
-          echo "Resolved: megatron=$MEGATRON_PR -> fetch=$MEGATRON_FETCH, sglang=$SGLANG_PR -> fetch=$SGLANG_FETCH"
-
-      - name: Install dependencies
-        if: ${{ !inputs.skip_dependency_install }}
-        shell: bash
-        env:
-          MEGATRON_PR: ${{ steps.resolve-refs.outputs.ci_megatron_pr }}
-          SGLANG_PR: ${{ steps.resolve-refs.outputs.ci_sglang_pr }}
-        run: |
-          cd /sgl-workspace/sglang && git reset --hard HEAD && git clean -fd && git fetch origin "$SGLANG_PR" && git checkout -f FETCH_HEAD && git log --oneline -1 && pip install -e python --no-deps --break-system-packages
-          cd /root/Megatron-LM && git reset --hard HEAD && git clean -fd && git fetch origin "$MEGATRON_PR" && git checkout -f FETCH_HEAD && git log --oneline -1 && pip install -e . --no-deps --break-system-packages
-          cd $GITHUB_WORKSPACE && pip install -e . --no-deps --break-system-packages
-
-      - name: Install (miles only)
-        if: ${{ inputs.skip_dependency_install }}
+      # sglang and Megatron-LM are baked into the container image from the
+      # third_party/ submodules (see docker/Dockerfile), so the only thing CI
+      # has to install is miles itself.
+      - name: Install miles
         shell: bash
         run: |
           cd $GITHUB_WORKSPACE && pip install -e . --no-deps --break-system-packages
@@ -136,10 +90,11 @@ jobs:
     env:
       # Megatron-LM's pyproject declares `packages.find.include = ["megatron.core", "megatron.core.*"]`,
       # so `pip install -e` only exposes megatron.core — not megatron.training / legacy / rl.
-      # miles imports from megatron.training, so put the checkout on PYTHONPATH directly
-      # and skip the pip install for Megatron-LM entirely (its deps — torch, numpy,
-      # packaging — arrive via miles/requirements.txt transitively).
-      PYTHONPATH: ${{ github.workspace }}:${{ github.workspace }}/Megatron-LM
+      # miles imports from megatron.training, so put the third_party/Megatron-LM
+      # submodule checkout on PYTHONPATH directly and skip the pip install for
+      # Megatron-LM entirely (its deps — torch, numpy, packaging — arrive via
+      # miles/requirements.txt transitively).
+      PYTHONPATH: ${{ github.workspace }}:${{ github.workspace }}/third_party/Megatron-LM
     steps:
       - name: Free disk space
         shell: bash
@@ -149,6 +104,8 @@ jobs:
 
       - name: Checkout miles
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -160,58 +117,12 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v5
 
-      - name: Resolve dependency refs
-        id: resolve-refs
-        shell: bash
-        env:
-          PR_BODY: ${{ github.event.pull_request.body || '' }}
-          INPUT_MEGATRON_PR: ${{ github.event.inputs.ci_megatron_pr || '' }}
-          INPUT_SGLANG_PR: ${{ github.event.inputs.ci_sglang_pr || '' }}
-        run: |
-          MEGATRON_PR="${INPUT_MEGATRON_PR}"
-          SGLANG_PR="${INPUT_SGLANG_PR}"
-          if [ -n "$PR_BODY" ]; then
-            PR_MEGATRON_PR=$(echo "$PR_BODY" | grep -m1 -oP '^ci-megatron-pr:\s+\K\S+' || true)
-            PR_SGLANG_PR=$(echo "$PR_BODY" | grep -m1 -oP '^ci-sglang-pr:\s+\K\S+' || true)
-            [ -z "$MEGATRON_PR" ] && [ -n "$PR_MEGATRON_PR" ] && MEGATRON_PR="$PR_MEGATRON_PR"
-            [ -z "$SGLANG_PR" ] && [ -n "$PR_SGLANG_PR" ] && SGLANG_PR="$PR_SGLANG_PR"
-          fi
-          [ -z "$MEGATRON_PR" ] && MEGATRON_PR="miles-main"
-          [ -z "$SGLANG_PR" ] && SGLANG_PR="sglang-miles"
-          resolve_fetch_ref() {
-            local ref="$1"
-            if [[ "$ref" =~ ^#([0-9]+)$ ]]; then
-              echo "refs/pull/${BASH_REMATCH[1]}/head"
-            else
-              echo "$ref"
-            fi
-          }
-          MEGATRON_FETCH=$(resolve_fetch_ref "$MEGATRON_PR")
-          SGLANG_FETCH=$(resolve_fetch_ref "$SGLANG_PR")
-          echo "ci_megatron_pr=$MEGATRON_FETCH" >> $GITHUB_OUTPUT
-          echo "ci_sglang_pr=$SGLANG_FETCH" >> $GITHUB_OUTPUT
-          echo "Resolved: megatron=$MEGATRON_PR -> fetch=$MEGATRON_FETCH, sglang=$SGLANG_PR -> fetch=$SGLANG_FETCH"
-
-      - name: Checkout sglang
-        uses: actions/checkout@v4
-        with:
-          repository: sgl-project/sglang
-          ref: ${{ steps.resolve-refs.outputs.ci_sglang_pr }}
-          path: sglang
-
-      - name: Checkout Megatron-LM
-        uses: actions/checkout@v4
-        with:
-          repository: radixark/Megatron-LM
-          ref: ${{ steps.resolve-refs.outputs.ci_megatron_pr }}
-          path: Megatron-LM
-
       - name: Install dependencies
         shell: bash
         env:
           UV_SYSTEM_PYTHON: "1"
         run: |
-          uv pip install -e sglang/python --no-deps
+          uv pip install -e third_party/sglang/python --no-deps
           # Megatron-LM is surfaced via PYTHONPATH (see job env); no pip install.
           uv pip install -r requirements.txt
           uv pip install -e . --no-deps

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -25,6 +25,7 @@ jobs:
     with:
       gpu_count: 0
       cpu_runner: true
+      container_image: "radixark/miles:dev-submodule-test"  # TEMP — REMOVE BEFORE MERGE
       execute_command: "python tests/ci/run_suite.py --hw cpu --suite stage-a-fast"
     secrets: inherit
 
@@ -36,6 +37,7 @@ jobs:
     uses: ./.github/workflows/_run-ci.yml
     with:
       gpu_count: 8
+      container_image: "radixark/miles:dev-submodule-test"  # TEMP — REMOVE BEFORE MERGE
       execute_command: "pytest tests/e2e/fsdp/test_qwen3_4B_fsdp_true_on_policy.py -x -v"
     secrets: inherit
 
@@ -50,6 +52,7 @@ jobs:
     uses: ./.github/workflows/_run-ci.yml
     with:
       gpu_count: 1
+      container_image: "radixark/miles:dev-submodule-test"  # TEMP — REMOVE BEFORE MERGE
       execute_command: "python tests/ci/run_suite.py --hw cuda --suite stage-b-fast-1-gpu"
     secrets: inherit
 
@@ -62,6 +65,7 @@ jobs:
     uses: ./.github/workflows/_run-ci.yml
     with:
       gpu_count: 8
+      container_image: "radixark/miles:dev-submodule-test"  # TEMP — REMOVE BEFORE MERGE
       execute_command: "python tests/ci/run_suite.py --hw cuda --suite stage-b-sglang-8-gpu"
     secrets: inherit
 
@@ -74,6 +78,7 @@ jobs:
     uses: ./.github/workflows/_run-ci.yml
     with:
       gpu_count: 8
+      container_image: "radixark/miles:dev-submodule-test"  # TEMP — REMOVE BEFORE MERGE
       execute_command: "python tests/ci/run_suite.py --hw cuda --suite stage-b-short-8-gpu"
     secrets: inherit
 
@@ -86,6 +91,7 @@ jobs:
     uses: ./.github/workflows/_run-ci.yml
     with:
       gpu_count: 8
+      container_image: "radixark/miles:dev-submodule-test"  # TEMP — REMOVE BEFORE MERGE
       execute_command: "python tests/ci/run_suite.py --hw cuda --suite stage-c-fsdp-8-gpu"
     secrets: inherit
 
@@ -102,6 +108,7 @@ jobs:
     uses: ./.github/workflows/_run-ci.yml
     with:
       gpu_count: 8
+      container_image: "radixark/miles:dev-submodule-test"  # TEMP — REMOVE BEFORE MERGE
       execute_command: "python tests/ci/run_suite.py --hw cuda --suite stage-c-megatron-8-gpu --auto-partition-id ${{ matrix.partition_id }} --auto-partition-size 3"
     secrets: inherit
 
@@ -114,6 +121,7 @@ jobs:
     uses: ./.github/workflows/_run-ci.yml
     with:
       gpu_count: 8
+      container_image: "radixark/miles:dev-submodule-test"  # TEMP — REMOVE BEFORE MERGE
       execute_command: "python tests/ci/run_suite.py --hw cuda --suite stage-c-precision-8-gpu"
     secrets: inherit
 
@@ -126,6 +134,7 @@ jobs:
     uses: ./.github/workflows/_run-ci.yml
     with:
       gpu_count: 8
+      container_image: "radixark/miles:dev-submodule-test"  # TEMP — REMOVE BEFORE MERGE
       execute_command: "python tests/ci/run_suite.py --hw cuda --suite stage-c-ckpt-8-gpu"
     secrets: inherit
 
@@ -138,6 +147,7 @@ jobs:
     uses: ./.github/workflows/_run-ci.yml
     with:
       gpu_count: 8
+      container_image: "radixark/miles:dev-submodule-test"  # TEMP — REMOVE BEFORE MERGE
       execute_command: "python tests/ci/run_suite.py --hw cuda --suite stage-c-long-8-gpu"
     secrets: inherit
 
@@ -150,6 +160,7 @@ jobs:
     uses: ./.github/workflows/_run-ci.yml
     with:
       gpu_count: 8
+      container_image: "radixark/miles:dev-submodule-test"  # TEMP — REMOVE BEFORE MERGE
       execute_command: "python tests/ci/run_suite.py --hw cuda --suite stage-c-lora-8-gpu"
     secrets: inherit
 
@@ -186,5 +197,6 @@ jobs:
     uses: ./.github/workflows/_run-ci.yml
     with:
       gpu_count: 8
+      container_image: "radixark/miles:dev-submodule-test"  # TEMP — REMOVE BEFORE MERGE
       execute_command: "python tests/ci/run_suite.py --hw cuda --suite ${{ matrix.suite }}"
     secrets: inherit

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -10,16 +10,6 @@ on:
         required: false
         type: boolean
         default: false
-      ci_megatron_pr:
-        description: 'Megatron-LM branch/commit (default: miles-main)'
-        required: false
-        type: string
-        default: 'miles-main'
-      ci_sglang_pr:
-        description: 'SGLang branch/commit (default: sglang-miles)'
-        required: false
-        type: string
-        default: 'sglang-miles'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -173,7 +163,6 @@ jobs:
     with:
       gpu_count: 8
       container_image: "radixark/miles:glm5"
-      skip_dependency_install: true
       execute_command: "python tests/ci/gpu_lock_exec.py --count 8 -- python tests/e2e/megatron/test_glm5_744b_a40b_4layer.py"
     secrets: inherit
 


### PR DESCRIPTION
## DO NOT MERGE YET
Two reasons this PR is a draft:

1. **Testing-pin commit must be reverted first.** Commit \`b310ddb37\` (\`[testing] Pin pr-test jobs to step-2a test image (REVERT BEFORE MERGE)\`) pins every \`pr-test.yml\` job to \`radixark/miles:dev-submodule-test\`. That image was built from #1169 specifically for validating _this_ PR before \`radixark/miles:dev\` gets rebuilt. Once #1168 + #1169 merge and the scheduled docker-build retags \`:dev\` from the new Dockerfile, \`b310ddb37\` must be reverted so this PR uses the production tag again.
2. **Merge ordering matters.** This PR's \`_run-ci.yml\` drops the in-container \`git fetch\` install path for sglang and Megatron-LM, assuming the container image carries them pip-installed (which is true _only_ after #1169's Dockerfile is the one producing \`:dev\`). Landing this PR before \`:dev\` carries the new Dockerfile would break CI for every other PR.

Safe merge sequence: #1168 → #1169 → wait for \`:dev\` rebuild → revert \`b310ddb37\` here → mark this ready for review → merge.

## Summary
- \`_run-ci.yml\` (GPU \`run:\`): collapse the previous three-step install pipeline (\`git fetch\` on \`/sgl-workspace/sglang\`, \`git fetch\` on \`/root/Megatron-LM\`, then miles) into a single \`Install miles\` step. Drop the \`Resolve dependency refs\` step and the \`skip_dependency_install\` workflow_call input (the only thing that branch ever skipped was the in-container reinstall of sglang/Megatron-LM; nothing left to skip).
- \`_run-ci.yml\` (CPU \`run-cpu:\`): switch the miles checkout to \`submodules: recursive\`, drop the two extra \`actions/checkout@v4\` calls for \`sgl-project/sglang\` and \`radixark/Megatron-LM\`, drop the \`Resolve dependency refs\` step, install sglang from \`third_party/sglang/python\`, and PYTHONPATH the Megatron-LM tree from \`third_party/Megatron-LM\`.
- \`pr-test.yml\`: drop the \`ci_megatron_pr\` / \`ci_sglang_pr\` workflow_dispatch inputs (the submodule pointer is the source of truth; per-PR overrides go away). Drop \`skip_dependency_install: true\` from \`stage-c-glm5\` (input no longer exists; glm5 already overrides container_image to \`radixark/miles:glm5\`).
- One additional testing-only commit (\`b310ddb37\`) pins every default-image job to the step-2a test image; see the "DO NOT MERGE YET" section above.

Net: \`-100\` lines from \`_run-ci.yml\` + a smaller pr-test.

## Why
The previous CI install pipeline existed because the image's sglang and Megatron-LM were installed at base-image time and could be out of date relative to \`sglang-miles\` / \`miles-main\`; CI's \`git fetch\` reconciled them at runtime. After #1169, the image is built from the submodule pointer, so by definition it already carries the correct revisions. The reconciliation step becomes dead code. This PR removes it.

Side benefit: the \`ci-sglang-pr:\` / \`ci-megatron-pr:\` per-PR override mechanism goes away. To CI-test a different sglang or Megatron-LM revision, bump the submodule pointer in a commit on the miles branch. That's the right model for a submodule-based monorepo (the pointer = what was tested = what ships) and removes a class of override-drift bugs.

## Test plan
- [x] \`pr-test.yml\` run [26211353043](https://github.com/radixark/miles/actions/runs/26211353043) against \`radixark/miles:dev-submodule-test\` (the image from #1169): \`stage-a-fast\` (CPU, new third_party install), \`stage-b-fast-gpu\`, \`stage-b-short\`, \`stage-b-sglang\`, \`stage-c-lora\` all green. \`stage-b-sglang\` passed on first attempt this time — confirms no install-path-induced instability. \`stage-a-unit-test\` red as expected (pre-existing on \`main\`, verified same root cause).
- [ ] Re-run \`pr-test.yml\` once \`b310ddb37\` is reverted and \`radixark/miles:dev\` carries #1169's Dockerfile, to confirm green against the production image.

## Stacked on
#1169 (step 2a: Dockerfile uses submodules).