### PR TITLE
fix: nemotron H megatron bridge bug, recover test_dumper.py & test_run_megatron.py

### DIFF
--- a/miles/backends/training_utils/cp_utils.py
+++ b/miles/backends/training_utils/cp_utils.py
@@ -252,11 +252,8 @@ def slice_with_cp(
     """
     if parallel_state is None:
         parallel_state = get_parallel_state()
-        cp_rank = parallel_state.cp.rank
-        cp_size = parallel_state.cp.size
-    else:
-        cp_rank = parallel_state.cp_rank
-        cp_size = parallel_state.cp_size
+    cp_rank = parallel_state.cp_rank
+    cp_size = parallel_state.cp_size
 
     if qkv_format == "bshd":
         assert max_seq_len is not None

--- a/miles/backends/training_utils/cp_utils.py
+++ b/miles/backends/training_utils/cp_utils.py
@@ -245,10 +245,18 @@ def slice_with_cp(
     pad_value: tuple[int, float, Callable],
     qkv_format: str = "thd",
     max_seq_len: int | None = None,
+    parallel_state: object | None = None,
 ) -> torch.Tensor:
-    parallel_state = get_parallel_state()
-    cp_rank = parallel_state.cp.rank
-    cp_size = parallel_state.cp.size
+    """
+    Slice tokens into the local zigzag CP layout.
+    """
+    if parallel_state is None:
+        parallel_state = get_parallel_state()
+        cp_rank = parallel_state.cp.rank
+        cp_size = parallel_state.cp.size
+    else:
+        cp_rank = parallel_state.cp_rank
+        cp_size = parallel_state.cp_size
 
     if qkv_format == "bshd":
         assert max_seq_len is not None

--- a/miles_plugins/megatron_bridge/nemotron_h.py
+++ b/miles_plugins/megatron_bridge/nemotron_h.py
@@ -7,11 +7,12 @@ This plugin is a non-invasive drop-in that:
    Super-120B-A12B) round-trip correctly through the HF↔Megatron
    ``mapping_registry`` and get the right ``moe_router_*`` fields on the
    provider.
-2. Patches :class:`~megatron.core.transformer.transformer_layer.TransformerLayer`
-   so hybrid layers whose ``self_attention`` / ``mlp`` is an ``IdentityOp``
-   don't blow up on the 2-tuple unpack in ``_forward_attention`` /
-   ``_forward_mlp``.
-3. Patches :class:`~megatron.core.models.mamba.MambaModel` ``forward`` to
+2. For Nemotron-H models, patches
+   :class:`~megatron.core.transformer.transformer_layer.TransformerLayer` so
+   hybrid layers whose ``self_attention`` / ``mlp`` is an ``IdentityOp`` don't
+   blow up on the 2-tuple unpack in ``_forward_attention`` / ``_forward_mlp``.
+3. For Nemotron-H models, patches
+   :class:`~megatron.core.models.mamba.MambaModel` ``forward`` to
    transparently swallow the ``loss_mask`` kwarg so miles' generic training
    loop (which was designed around ``GPTModel``) can keep passing it
    unconditionally.
@@ -75,6 +76,8 @@ def _build_bridge_subclass():
         """
 
         def provider_bridge(self, hf_pretrained):
+            _install_nemotronh_hybrid_layer_shims()
+            _install_mamba_model_loss_mask_shim()
             provider = super().provider_bridge(hf_pretrained)
             hf = hf_pretrained.config
 
@@ -199,12 +202,8 @@ def _install_mamba_model_loss_mask_shim() -> None:
 
 
 def install() -> None:
-    """Apply all Nemotron-H shims and register the miles bridge subclass."""
-    for fn in (
-        _install_nemotronh_hybrid_layer_shims,
-        _install_mamba_model_loss_mask_shim,
-        _build_bridge_subclass,
-    ):
+    """Register the Nemotron-H bridge subclass."""
+    for fn in (_build_bridge_subclass,):
         try:
             fn()
         except Exception as e:  # best-effort; avoid breaking unrelated models

--- a/tests/e2e/conftest_dumper.py
+++ b/tests/e2e/conftest_dumper.py
@@ -50,7 +50,7 @@ patches:
         append: "dumper.dump('attn_output', attention_output_with_bias[0], dims='t[cp:zigzag,sp] 1 h # tp:replicated ep:replicated')"
   - target: megatron.core.transformer.transformer_layer.TransformerLayer._forward_mlp
     edits:
-      - match: "residual = hidden_states"
+      - match: 'residual = getattr(self, "_sglang_pre_mlp_residual", hidden_states)'
         append: "dumper.dump('pre_mlp_residual', residual, dims='t[cp:zigzag,sp] 1 h # tp:replicated ep:replicated')"
       - match: "pre_mlp_layernorm_output = self._forward_pre_mlp_layernorm(hidden_states)"
         append: "dumper.dump('pre_mlp_layernorm_output', pre_mlp_layernorm_output, dims='t[cp:zigzag,sp] 1 h # tp:replicated ep:replicated')"
@@ -89,7 +89,7 @@ patches:
         append: "dumper.dump('attn_output', attention_output_with_bias[0], dims='s[cp:zigzag,sp] 1 h # tp:replicated ep:replicated')"
   - target: megatron.core.transformer.transformer_layer.TransformerLayer._forward_mlp
     edits:
-      - match: "residual = hidden_states"
+      - match: 'residual = getattr(self, "_sglang_pre_mlp_residual", hidden_states)'
         append: "dumper.dump('pre_mlp_residual', residual, dims='s[cp:zigzag,sp] 1 h # tp:replicated ep:replicated')"
       - match: "pre_mlp_layernorm_output = self._forward_pre_mlp_layernorm(hidden_states)"
         append: "dumper.dump('pre_mlp_layernorm_output', pre_mlp_layernorm_output, dims='s[cp:zigzag,sp] 1 h # tp:replicated ep:replicated')"

--- a/tests/e2e/megatron/test_qwen3_30B_A3B/test_deepep_fp8_bridge.py
+++ b/tests/e2e/megatron/test_qwen3_30B_A3B/test_deepep_fp8_bridge.py
@@ -4,7 +4,7 @@ from tests.ci.ci_register import register_cuda_ci
 from tests.e2e.megatron.test_qwen3_30B_A3B._common import CaseConfig, execute, prepare
 
 # Limited by host memory
-register_cuda_ci(est_time=1800, suite="stage-c-8-gpu-h100", labels=["megatron"])
+register_cuda_ci(est_time=900, suite="stage-c-8-gpu-h100", labels=["megatron"])
 
 CASE = CaseConfig(
     use_deepep=True,

--- a/tests/e2e/short/test_dumper.py
+++ b/tests/e2e/short/test_dumper.py
@@ -13,13 +13,13 @@ import sys
 import tempfile
 from pathlib import Path
 from typing import Annotated
-from tests.ci.ci_register import register_cuda_ci
 
 _MILES_ROOT: Path = Path(__file__).resolve().parents[3]
 if str(_MILES_ROOT) not in sys.path:
     sys.path.insert(0, str(_MILES_ROOT))
 
 import typer
+from tests.ci.ci_register import register_cuda_ci
 from tests.e2e.conftest_dumper import (
     MEGATRON_PATCHER_YAMLS,
     SGLANG_SOURCE_PATCHER_CONFIG_YAML,
@@ -31,9 +31,7 @@ from tests.e2e.conftest_dumper import (
 
 import miles.utils.external_utils.command_utils as U
 
-
-# FIXME: this CI is buggy.
-register_cuda_ci(est_time=2000, suite="stage-c-8-gpu-h100", labels=["short"], disabled="Disabled due to bugs.")
+register_cuda_ci(est_time=2000, suite="stage-c-8-gpu-h100", labels=["short"])
 
 
 app: typer.Typer = typer.Typer()

--- a/tests/e2e/short/test_run_megatron.py
+++ b/tests/e2e/short/test_run_megatron.py
@@ -1,6 +1,6 @@
 # WARNING: Do NOT relax any assert logic in this file. All assertions must remain strict.
 # The comparator must report all-passed with zero failures — no exceptions.
-# FIXME: this CI is buggy.
+
 # Usage: This is a typer CLI with 2 commands:
 #   python test_run_megatron.py run --mode <mode>         Full: prepare + run baseline + run target + compare
 #   python test_run_megatron.py compare --mode <mode> --dump-dir <path>
@@ -12,13 +12,13 @@ import sys
 import tempfile
 from pathlib import Path
 from typing import Annotated
-from tests.ci.ci_register import register_cuda_ci
 
 _MILES_ROOT: Path = Path(__file__).resolve().parents[3]
 if str(_MILES_ROOT) not in sys.path:
     sys.path.insert(0, str(_MILES_ROOT))
 
 import typer
+from tests.ci.ci_register import register_cuda_ci
 from tests.e2e.conftest_dumper import MEGATRON_PATCHER_YAMLS, clear_proxy_env
 
 import miles.utils.external_utils.command_utils as U
@@ -35,8 +35,7 @@ NUM_LAYERS: int = 5
 
 _RUN_DIR: Path = Path(tempfile.mkdtemp(prefix="test_run_megatron_"))
 
-# FIXME: this CI is buggy.
-register_cuda_ci(est_time=2000, suite="stage-c-8-gpu-h100", labels=["short"], disabled="Disabled due to bugs.")
+register_cuda_ci(est_time=2000, suite="stage-c-8-gpu-h100", labels=["short"])
 
 
 @dataclasses.dataclass(frozen=True)

--- a/tests/fast/backends/training_utils/test_ulysses_cp_utils.py
+++ b/tests/fast/backends/training_utils/test_ulysses_cp_utils.py
@@ -10,6 +10,9 @@ def _parallel_state(*, cp_size: int, cp_rank: int = 0, cp_comm_type: str | None 
         intra_dp_cp=GroupInfo(rank=0, size=cp_size, group=None),
         cp=GroupInfo(rank=cp_rank, size=cp_size, group=None),
         tp=GroupInfo(rank=0, size=1, group=None),
+        pp=GroupInfo(rank=0, size=1, group=None),
+        ep=GroupInfo(rank=0, size=1, group=None),
+        etp=GroupInfo(rank=0, size=1, group=None),
         cp_comm_type=cp_comm_type,
     )
 


### PR DESCRIPTION
(cc generated)
## Summary
Fix global Nemotron-H shims and restore the short Megatron dumper checks.

## Symptom & Reproduction
- **Symptom:** `tests/e2e/short/test_dumper.py` failed before dump comparison because the Megatron source patcher could not find its target text in `TransformerLayer._forward_attention` / `TransformerLayer._forward_mlp`.
- **Reproduction:** `CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 python tests/e2e/short/test_dumper.py run --mode tp2_pp2_cp2_ep2_etp2`
- **Linked log:** `PatchApplicationError: match text not found in source: inference_context = deprecate_inference_params(...)`

## Root Cause
`miles_plugins/megatron_bridge/nemotron_h.py` installed Nemotron-H compatibility shims at plugin import time. A regular Megatron training actor importing the bridge plugins therefore saw wrapped `TransformerLayer._forward_attention` / `_forward_mlp` methods, so the dumper source patcher matched against wrapper source instead of the original Megatron methods. The dumper patch config also still matched `residual = hidden_states` after Megatron changed that assignment to `residual = getattr(self, "_sglang_pre_mlp_residual", hidden_states)`. Separately, `miles.utils.debug_utils.run_megatron.worker.batch.prepare_batch` needed CP slicing from worker-local `cp_rank` / `cp_size`, while `miles.backends.training_utils.cp_utils.slice_with_cp()` only read the process-global `get_parallel_state()`.

## Fix
The Nemotron-H plugin now registers the bridge subclass at import time and installs the Nemotron-H-only shims inside `MilesNemotronHBridge.provider_bridge()`. The THD and BSHD dumper patch configs now match Megatron's current `_forward_mlp` residual assignment. `slice_with_cp()` accepts an explicit `parallel_state` for the run_megatron worker path, and the disabled short CI registrations for `test_dumper.py` and `test_run_megatron.py` are restored.

## Verification
- **New / updated test:** `python -m pytest tests/fast/backends/training_utils/test_ulysses_cp_utils.py -q` passed: 5 tests.
- **New / updated test:** `python -m pytest tests/fast/utils/debug_utils/run_megatron/worker/test_batch.py -q` passed: 60 tests.
- **Manual repro now passes:** `CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 python tests/e2e/short/test_dumper.py run --mode tp2_pp2_cp2_ep2_etp2` passed dump verification; comparator summary was `total=100 passed=40 failed=0 skipped=60 errored=0`.
- **Manual repro now passes:** `CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 python tests/e2e/short/test_dumper.py run --mode tp2_pp2_cp2_ep2_etp2_bshd` passed dump verification; comparator summary was `total=52 passed=40 failed=0 skipped=12 errored=0`.
