### PR TITLE
Move miles_megatron_plugins into the miles repo as a top-level package

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -25,7 +25,7 @@ jobs:
     with:
       gpu_count: 0
       cpu_runner: true
-      container_image: "radixark/miles:dev-submodule-test"  # TEMP — REMOVE BEFORE MERGE
+      container_image: "radixark/miles:dev-phase1-test"  # TEMP — REMOVE BEFORE MERGE
       execute_command: "python tests/ci/run_suite.py --hw cpu --suite stage-a-fast"
     secrets: inherit
 
@@ -37,7 +37,7 @@ jobs:
     uses: ./.github/workflows/_run-ci.yml
     with:
       gpu_count: 8
-      container_image: "radixark/miles:dev-submodule-test"  # TEMP — REMOVE BEFORE MERGE
+      container_image: "radixark/miles:dev-phase1-test"  # TEMP — REMOVE BEFORE MERGE
       execute_command: "pytest tests/e2e/fsdp/test_qwen3_4B_fsdp_true_on_policy.py -x -v"
     secrets: inherit
 
@@ -52,7 +52,7 @@ jobs:
     uses: ./.github/workflows/_run-ci.yml
     with:
       gpu_count: 1
-      container_image: "radixark/miles:dev-submodule-test"  # TEMP — REMOVE BEFORE MERGE
+      container_image: "radixark/miles:dev-phase1-test"  # TEMP — REMOVE BEFORE MERGE
       execute_command: "python tests/ci/run_suite.py --hw cuda --suite stage-b-fast-1-gpu"
     secrets: inherit
 
@@ -65,7 +65,7 @@ jobs:
     uses: ./.github/workflows/_run-ci.yml
     with:
       gpu_count: 8
-      container_image: "radixark/miles:dev-submodule-test"  # TEMP — REMOVE BEFORE MERGE
+      container_image: "radixark/miles:dev-phase1-test"  # TEMP — REMOVE BEFORE MERGE
       execute_command: "python tests/ci/run_suite.py --hw cuda --suite stage-b-sglang-8-gpu"
     secrets: inherit
 
@@ -78,7 +78,7 @@ jobs:
     uses: ./.github/workflows/_run-ci.yml
     with:
       gpu_count: 8
-      container_image: "radixark/miles:dev-submodule-test"  # TEMP — REMOVE BEFORE MERGE
+      container_image: "radixark/miles:dev-phase1-test"  # TEMP — REMOVE BEFORE MERGE
       execute_command: "python tests/ci/run_suite.py --hw cuda --suite stage-b-short-8-gpu"
     secrets: inherit
 
@@ -91,7 +91,7 @@ jobs:
     uses: ./.github/workflows/_run-ci.yml
     with:
       gpu_count: 8
-      container_image: "radixark/miles:dev-submodule-test"  # TEMP — REMOVE BEFORE MERGE
+      container_image: "radixark/miles:dev-phase1-test"  # TEMP — REMOVE BEFORE MERGE
       execute_command: "python tests/ci/run_suite.py --hw cuda --suite stage-c-fsdp-8-gpu"
     secrets: inherit
 
@@ -108,7 +108,7 @@ jobs:
     uses: ./.github/workflows/_run-ci.yml
     with:
       gpu_count: 8
-      container_image: "radixark/miles:dev-submodule-test"  # TEMP — REMOVE BEFORE MERGE
+      container_image: "radixark/miles:dev-phase1-test"  # TEMP — REMOVE BEFORE MERGE
       execute_command: "python tests/ci/run_suite.py --hw cuda --suite stage-c-megatron-8-gpu --auto-partition-id ${{ matrix.partition_id }} --auto-partition-size 3"
     secrets: inherit
 
@@ -121,7 +121,7 @@ jobs:
     uses: ./.github/workflows/_run-ci.yml
     with:
       gpu_count: 8
-      container_image: "radixark/miles:dev-submodule-test"  # TEMP — REMOVE BEFORE MERGE
+      container_image: "radixark/miles:dev-phase1-test"  # TEMP — REMOVE BEFORE MERGE
       execute_command: "python tests/ci/run_suite.py --hw cuda --suite stage-c-precision-8-gpu"
     secrets: inherit
 
@@ -134,7 +134,7 @@ jobs:
     uses: ./.github/workflows/_run-ci.yml
     with:
       gpu_count: 8
-      container_image: "radixark/miles:dev-submodule-test"  # TEMP — REMOVE BEFORE MERGE
+      container_image: "radixark/miles:dev-phase1-test"  # TEMP — REMOVE BEFORE MERGE
       execute_command: "python tests/ci/run_suite.py --hw cuda --suite stage-c-ckpt-8-gpu"
     secrets: inherit
 
@@ -147,7 +147,7 @@ jobs:
     uses: ./.github/workflows/_run-ci.yml
     with:
       gpu_count: 8
-      container_image: "radixark/miles:dev-submodule-test"  # TEMP — REMOVE BEFORE MERGE
+      container_image: "radixark/miles:dev-phase1-test"  # TEMP — REMOVE BEFORE MERGE
       execute_command: "python tests/ci/run_suite.py --hw cuda --suite stage-c-long-8-gpu"
     secrets: inherit
 
@@ -160,7 +160,7 @@ jobs:
     uses: ./.github/workflows/_run-ci.yml
     with:
       gpu_count: 8
-      container_image: "radixark/miles:dev-submodule-test"  # TEMP — REMOVE BEFORE MERGE
+      container_image: "radixark/miles:dev-phase1-test"  # TEMP — REMOVE BEFORE MERGE
       execute_command: "python tests/ci/run_suite.py --hw cuda --suite stage-c-lora-8-gpu"
     secrets: inherit
 
@@ -197,6 +197,6 @@ jobs:
     uses: ./.github/workflows/_run-ci.yml
     with:
       gpu_count: 8
-      container_image: "radixark/miles:dev-submodule-test"  # TEMP — REMOVE BEFORE MERGE
+      container_image: "radixark/miles:dev-phase1-test"  # TEMP — REMOVE BEFORE MERGE
       execute_command: "python tests/ci/run_suite.py --hw cuda --suite ${{ matrix.suite }}"
     secrets: inherit


### PR DESCRIPTION
## Summary
- Add `miles_megatron_plugins/` at the top level of the miles repo (`__init__.py` + `true_on_policy/` with 13 modules; ~1400 lines).
- Update `setup.py` `find_packages(include=[...])` to expose the new package.
- Update `pyproject.toml` `[tool.isort]` (`known_first_party`, `src_paths`) for consistency with `miles` / `miles_plugins`.
- Bump the `third_party/Megatron-LM` submodule pointer to `c3a94af51` (the matching deletion on `radixark/Megatron-LM` — see [radixark/Megatron-LM#32](https://github.com/radixark/Megatron-LM/pull/32)).
- Temporarily set `.gitmodules` `branch = miles/move-plugins-to-miles` for `third_party/Megatron-LM`. A follow-up commit flips back to `branch = miles-main` once #32 merges.

## Why
`miles_megatron_plugins` is semantically miles' code that Megatron-LM imports back (true-on-policy contracts, sglang backend, matmul / attention / norm replacements). Today it lives inside the `radixark/Megatron-LM` fork and is only on `sys.path` because production sets `PYTHONPATH=/root/Megatron-LM`. That PYTHONPATH workaround doesn't survive packaging miles as a wheel for the eventual `pip install miles` goal.

Moving the package into miles makes it part of miles' regular Python package. The `from miles_megatron_plugins...` imports inside Megatron-LM source (transformer_layer, transformer_block, attention, gpt_model, gpt_layer_specs, distributed_data_parallel, tensor_parallel/{layers, matmul_tp_inv}, models/gpt/{gpt_model, gpt_layer_specs}, extensions/sglang) continue to work because miles is always installed before `megatron.core` is imported — both in production (Dockerfile installs miles last) and in CI (each pr-test job runs `Install miles` after the container starts).

This is Phase 1 of the broader plan toward `pip install miles`. Phase 2 (separate PR) will broaden Megatron-LM's `packages.find.include` so `pip install -e Megatron-LM` exposes `megatron.training` / `megatron.legacy` / `megatron.rl`, removing the remaining piece of the CPU runner's PYTHONPATH hack.

## What does NOT change
- `_run-ci.yml`'s CPU runner PYTHONPATH still includes `${{ github.workspace }}/third_party/Megatron-LM` because that path is still needed for `megatron.training` / `megatron.legacy` / `megatron.rl` (Phase 2's removal target). After this PR, that PYTHONPATH is no longer required for `miles_megatron_plugins` itself.
- No Dockerfile changes. The submodule pointer bump auto-fires a rebuild via the path-trigger added in #1169.

## Test plan
- [ ] **Build a test image** via `gh workflow run docker-build.yml --ref shi/move-miles-megatron-plugins -f variant=primary -f image_tag=custom -f custom_tag=dev-phase1-test`, then on a 1-node H200 devbox:
  - `cat /root/miles/miles_megatron_plugins/__init__.py` exists.
  - `ls /root/Megatron-LM/miles_megatron_plugins` returns "No such file or directory" (proves the Megatron-LM side was deleted).
  - `python -c "import miles_megatron_plugins.true_on_policy.contracts; print(miles_megatron_plugins.__file__)"` resolves to a path under `/root/miles/`, not `/root/Megatron-LM/`. (Key sys.path resolution check.)
  - `python -c "import megatron.core.transformer.transformer_layer"` still succeeds (proves Megatron-LM's `from miles_megatron_plugins...` imports resolve via miles' install).
- [ ] **`pr-test.yml` workflow_dispatch run** on `shi/move-miles-megatron-plugins` against the new test image (commit `b310ddb37` from #1170 keeps the `# TEMP` container_image pin; we'll override it to `dev-phase1-test` if needed). Expect the same matrix as run 26211353043: stage-a-fast, stage-b-fast-gpu, stage-b-short, stage-b-sglang green; stage-a-unit-test red as a pre-existing issue.

## Stacked on
#1170 (step 2b: CI uses submodule paths). Once #1168 / #1169 / #1170 merge in order, this PR's base auto-updates.

## Coordinated change
- radixark/Megatron-LM: [PR #32](https://github.com/radixark/Megatron-LM/pull/32) removes the same directory from `miles-main`. Both should merge together. After both merge:
  1. Flip `.gitmodules` `branch = miles/move-plugins-to-miles` back to `branch = miles-main` (the pointer's SHA is unchanged once #32 lands on `miles-main`).
  2. Optionally delete the `miles/move-plugins-to-miles` branch on radixark/Megatron-LM.
