### PR TITLE
[WIP] [fix] Simplify GPU ID remapping for SGLang colocate mode

### DIFF
--- a/miles/backends/sglang_utils/sglang_engine.py
+++ b/miles/backends/sglang_utils/sglang_engine.py
@@ -20,19 +20,6 @@ from miles.utils.http_utils import get_host_info
 logger = logging.getLogger(__name__)
 
 
-def get_base_gpu_id(args, rank):
-    num_gpus = min(args.num_gpus_per_node, args.rollout_num_gpus_per_engine)
-    if args.colocate:
-        start_index = (rank * num_gpus) % args.num_gpus_per_node
-    else:
-        num_actor_gpus = 0 if args.debug_rollout_only else args.actor_num_gpus_per_node * args.actor_num_nodes
-        start_index = (num_actor_gpus + rank * num_gpus) % args.num_gpus_per_node
-        if args.use_critic:
-            num_critic_gpus = args.critic_num_gpus_per_node * args.critic_num_nodes
-            start_index = (num_actor_gpus + num_critic_gpus + rank * num_gpus) % args.num_gpus_per_node
-    return start_index
-
-
 def launch_server_process(server_args: ServerArgs) -> multiprocessing.Process:
     from sglang.srt.entrypoints.http_server import launch_server
 
@@ -585,9 +572,9 @@ def _compute_server_args(
     _gpus_per_engine = num_gpus_per_engine or args.rollout_num_gpus_per_engine
     nnodes = max(1, _gpus_per_engine // args.num_gpus_per_node)
     node_rank = rank % nnodes
-    base = base_gpu_id if base_gpu_id is not None else get_base_gpu_id(args, rank)
-    # base_gpu_id is now always a local ID (0, 1, 2, ...), skip _to_local_gpu_id conversion
-    # to avoid device mapping inconsistency between Ray actor and spawned server process
+    base = base_gpu_id if base_gpu_id is not None else 0
+    # Ray's placement group ensures each engine sees its assigned GPU as local GPU 0.
+    # No conversion needed - Ray handles the physical-to-local mapping via CUDA_VISIBLE_DEVICES.
     kwargs = {
         "model_path": args.hf_checkpoint,
         "trust_remote_code": True,

--- a/miles/backends/sglang_utils/sglang_engine.py
+++ b/miles/backends/sglang_utils/sglang_engine.py
@@ -2,7 +2,6 @@ import dataclasses
 import ipaddress
 import logging
 import multiprocessing
-import os
 import time
 from urllib.parse import quote
 
@@ -32,24 +31,6 @@ def get_base_gpu_id(args, rank):
             num_critic_gpus = args.critic_num_gpus_per_node * args.critic_num_nodes
             start_index = (num_actor_gpus + num_critic_gpus + rank * num_gpus) % args.num_gpus_per_node
     return start_index
-
-
-def _to_local_gpu_id(physical_gpu_id: int) -> int:
-    cvd = os.environ.get("CUDA_VISIBLE_DEVICES")
-    if not cvd:
-        return physical_gpu_id  # no remapping
-    # CUDA_VISIBLE_DEVICES can be like "4,5,6,7"
-    visible = [int(x) for x in cvd.split(",") if x.strip() != ""]
-    # In a remapped process, valid torch device indices are 0..len(visible)-1
-    if physical_gpu_id in visible:
-        return visible.index(physical_gpu_id)
-    # If we're already getting local IDs, allow them
-    if 0 <= physical_gpu_id < len(visible):
-        return physical_gpu_id
-    raise RuntimeError(
-        f"GPU id {physical_gpu_id} is not valid under CUDA_VISIBLE_DEVICES={cvd}. "
-        f"Expected one of {visible} (physical) or 0..{len(visible)-1} (local)."
-    )
 
 
 def launch_server_process(server_args: ServerArgs) -> multiprocessing.Process:
@@ -605,7 +586,8 @@ def _compute_server_args(
     nnodes = max(1, _gpus_per_engine // args.num_gpus_per_node)
     node_rank = rank % nnodes
     base = base_gpu_id if base_gpu_id is not None else get_base_gpu_id(args, rank)
-    base = _to_local_gpu_id(base)
+    # base_gpu_id is now always a local ID (0, 1, 2, ...), skip _to_local_gpu_id conversion
+    # to avoid device mapping inconsistency between Ray actor and spawned server process
     kwargs = {
         "model_path": args.hf_checkpoint,
         "trust_remote_code": True,

--- a/miles/backends/sglang_utils/sglang_engine.py
+++ b/miles/backends/sglang_utils/sglang_engine.py
@@ -20,6 +20,19 @@ from miles.utils.http_utils import get_host_info
 logger = logging.getLogger(__name__)
 
 
+def get_base_gpu_id(args, rank):
+    num_gpus = min(args.num_gpus_per_node, args.rollout_num_gpus_per_engine)
+    if args.colocate:
+        start_index = (rank * num_gpus) % args.num_gpus_per_node
+    else:
+        num_actor_gpus = 0 if args.debug_rollout_only else args.actor_num_gpus_per_node * args.actor_num_nodes
+        start_index = (num_actor_gpus + rank * num_gpus) % args.num_gpus_per_node
+        if args.use_critic:
+            num_critic_gpus = args.critic_num_gpus_per_node * args.critic_num_nodes
+            start_index = (num_actor_gpus + num_critic_gpus + rank * num_gpus) % args.num_gpus_per_node
+    return start_index
+
+
 def launch_server_process(server_args: ServerArgs) -> multiprocessing.Process:
     from sglang.srt.entrypoints.http_server import launch_server
 
@@ -572,9 +585,10 @@ def _compute_server_args(
     _gpus_per_engine = num_gpus_per_engine or args.rollout_num_gpus_per_engine
     nnodes = max(1, _gpus_per_engine // args.num_gpus_per_node)
     node_rank = rank % nnodes
-    base = base_gpu_id if base_gpu_id is not None else 0
-    # Ray's placement group ensures each engine sees its assigned GPU as local GPU 0.
-    # No conversion needed - Ray handles the physical-to-local mapping via CUDA_VISIBLE_DEVICES.
+    base = base_gpu_id if base_gpu_id is not None else get_base_gpu_id(args, rank)
+    # Note: No _to_local_gpu_id() conversion needed because:
+    # 1. RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES=1 ensures parent and child see same CUDA_VISIBLE_DEVICES
+    # 2. get_base_gpu_id() returns local loop indices (0, 1, 2, ...) not physical GPU IDs
     kwargs = {
         "model_path": args.hf_checkpoint,
         "trust_remote_code": True,

--- a/miles/ray/rollout.py
+++ b/miles/ray/rollout.py
@@ -120,11 +120,11 @@ class ServerGroup:
 
             gpu_index = self.gpu_offset + i * num_gpu_per_engine
 
-            # Each SGLang engine should use local GPU 0 as its base, regardless of
-            # its position in the placement group. The placement_group_bundle_index
-            # selects which physical GPU bundle to use, and CUDA_VISIBLE_DEVICES
-            # handles the mapping to local device indices for the spawned server process.
-            base_gpu_id = 0
+            # Use the local loop index as the base GPU ID for each engine.
+            # For TP=4, engine 0 uses GPUs 0,1,2,3; engine 1 uses GPUs 4,5,6,7; etc.
+            # Ray's placement_group_bundle_index selects which physical GPU bundle to use,
+            # and CUDA_VISIBLE_DEVICES handles the physical-to-local mapping.
+            base_gpu_id = i * num_gpu_per_engine
 
             scheduling_strategy = PlacementGroupSchedulingStrategy(
                 placement_group=pg,

--- a/miles/ray/rollout.py
+++ b/miles/ray/rollout.py
@@ -105,7 +105,7 @@ class ServerGroup:
 
         num_gpu_per_engine = min(self.num_gpus_per_engine, self.args.num_gpus_per_node)
 
-        pg, reordered_bundle_indices, reordered_gpu_ids = self.pg
+        pg, reordered_bundle_indices, _ = self.pg
 
         RolloutRayActor = ray.remote(SGLangEngine)
 
@@ -119,7 +119,12 @@ class ServerGroup:
             num_cpus = num_gpus
 
             gpu_index = self.gpu_offset + i * num_gpu_per_engine
-            base_gpu_id = int(reordered_gpu_ids[gpu_index])
+
+            # Each SGLang engine should use local GPU 0 as its base, regardless of
+            # its position in the placement group. The placement_group_bundle_index
+            # selects which physical GPU bundle to use, and CUDA_VISIBLE_DEVICES
+            # handles the mapping to local device indices for the spawned server process.
+            base_gpu_id = 0
 
             scheduling_strategy = PlacementGroupSchedulingStrategy(
                 placement_group=pg,


### PR DESCRIPTION
## Summary

Fix SGLang CUDA graph capture failure in colocate mode by using local loop indices directly instead of physical GPU IDs from Ray placement groups. Removes the workaround that disabled custom all-reduce v2.

## Symptom & Reproduction

- **Symptom:** SGLang v0.5.12 server fails to start in colocate rollout mode with error: `Capture cuda graph failed: Runtime check failed at custom_all_reduce.cuh:37: CUDA error: invalid argument`
- **Reproduction:**
  ```bash
  export CUDA_VISIBLE_DEVICES=1,2,3,4
  python train.py \
    --hf-checkpoint /root/models/Qwen3-30B-A3B \
    --rollout-num-gpus-per-engine 4 \
    --tensor-model-parallel-size 2 \
    --actor-num-gpus-per-node 4 \
    --colocate \
    --num-rollout 1
  ```
- **Linked issue:** #1176

## Root Cause

The original code passed physical GPU IDs from Ray placement groups (e.g., 1,2,3,4) to SGLang engines and then converted them to local IDs via `_to_local_gpu_id()`. The conversion was based on `CUDA_VISIBLE_DEVICES` in the parent Ray actor's context, which might differ from what the spawned SGLang server process sees, causing device index mismatch.

## History: Why the Remapping Was Added

**Before Jan 5, 2026:**
- `base_gpu_id` was computed by `get_base_gpu_id(args, rank)` returning logical indices (0, 1, 2, ...)
- No CUDA_VISIBLE_DEVICES handling

**Jan 5, 2026 (commit c77bdcf2a):**
- Added `_to_local_gpu_id()` to handle `CUDA_VISIBLE_DEVICES=4,5,6,7` style GPU selection
- Purpose: convert physical GPU 4 → local GPU 0, etc.

**Later (around Jan 3, 2026, commit 9dfd33924):**
- Added `reordered_gpu_ids` from placement groups
- Started passing physical GPU IDs: `base_gpu_id = int(reordered_gpu_ids[gpu_index])`
- Then `_to_local_gpu_id()` would convert to local ID

**Why it worked before v0.5.12:**
- v0.5.10: CustomAllReduceV2 disabled by default → device mapping lenient
- v0.5.12: CustomAllReduceV2 enabled by default → strict device mapping, bug exposed

## The Fix

With `RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES=1`, the parent Ray actor and spawned SGLang server see the same `CUDA_VISIBLE_DEVICES`. Therefore, we don't need `_to_local_gpu_id()` conversion - we can use local loop indices directly.

**Code flow:**
```
User: CUDA_VISIBLE_DEVICES=4,5,6,7
  ↓
Ray: Creates placement group with 4 GPUs
  ↓
Engine 0 (i=0): base_gpu_id = 0*4 = 0 → Uses local GPUs 0,1,2,3 ✓
Engine 1 (i=1): base_gpu_id = 1*4 = 4 → Uses local GPUs 4,5,6,7 ✓
```

Changes:
- `rollout.py`: Use `base_gpu_id = i * num_gpu_per_engine` (local loop index)
- `sglang_engine.py`: Remove `_to_local_gpu_id()` function, keep `get_base_gpu_id()` as fallback
- Remove the workaround that disabled `SGLANG_OPT_USE_CUSTOM_ALL_REDUCE_V2`

## How Users Specify Which GPUs to Use

GPU selection happens at the **Ray level** via `CUDA_VISIBLE_DEVICES`:

```bash
# Use specific GPUs (4,5,6,7 instead of 0,1,2,3)
export CUDA_VISIBLE_DEVICES=4,5,6,7
python train.py --colocate ...
```

## Status

- **Status:** WIP - awaiting CI test results
- **Local testing:** No access to multi-GPU hardware for reproduction
- **Relying on:** CI tests for verification

## Verification

CI tests should verify:
- ✅ SGLang server starts successfully
- ✅ "Custom allreduce v2 initialized" appears in logs
- ✅ "Capture cuda graph end" appears in logs
- ✅ No "CUDA error: invalid argument"
- ✅ Training step completes