### PR TITLE
[feat] rollout indexer replay support

### DIFF
--- a/miles/backends/megatron_utils/actor.py
+++ b/miles/backends/megatron_utils/actor.py
@@ -19,24 +19,24 @@ from miles.utils.memory_utils import clear_memory, print_memory
 from miles.utils.processing_utils import load_tokenizer
 from miles.utils.ray_utils import Box
 from miles.utils.reloadable_process_group import destroy_process_groups, monkey_patch_torch_dist, reload_process_groups
-from miles.utils.replay_base import all_replay_managers
+from miles.utils.replay_base import all_replay_managers, routing_replay_manager
 from miles.utils.timer import Timer, inverse_timer, timer
 from miles.utils.tracking_utils import init_tracking
 from miles.utils.types import RolloutBatch
 
 from ...utils.profile_utils import TrainProfiler
 from ...utils.tensor_backper import TensorBackuper
-from ..training_utils.cp_utils import slice_with_cp
 from ..training_utils.data import DataIterator, get_data_iterator, get_rollout_data, sync_actor_critic_data
 from ..training_utils.log_utils import log_cpu_memory, log_perf_data, log_rollout_data
 from ..training_utils.loss import compute_advantages_and_returns, get_log_probs_and_entropy, get_values
 from ..training_utils.parallel import get_parallel_state
+from ..training_utils.replay_data import fill_replay_data, register_replay_list_sequential
 from .checkpoint import load_checkpoint
 from .initialize import init, is_megatron_main_rank
 from .lora_utils import is_lora_enabled
 from .model import forward_only, initialize_model_and_optimizer, save, train
 from .parallel import verify_megatron_parallel_state
-from .replay_utils import get_register_replay_list_func
+from .replay_utils import register_replay_list_moe
 from .update_weight.common import named_params_and_buffers
 from .update_weight.update_weight_from_distributed.broadcast import UpdateWeightFromDistributed
 from .update_weight.update_weight_from_distributed.p2p import UpdateWeightP2P
@@ -58,6 +58,10 @@ class MegatronTrainRayActor(TrainRayActor):
         monkey_patch_torch_dist()
 
         super().init(args, role, with_ref)
+
+        for m in all_replay_managers:
+            m.register_replay_list_func = register_replay_list_sequential
+        routing_replay_manager.register_replay_list_func = register_replay_list_moe
 
         init(args)
 
@@ -108,10 +112,10 @@ class MegatronTrainRayActor(TrainRayActor):
             self.args.lr_warmup_iters = self.args.critic_lr_warmup_iters
         else:
             for m in all_replay_managers:
-                m.enabled = getattr(self.args, f"use_{m.name}_replay")
+                m.enabled = getattr(self.args, f"use_{m.name}_replay", False)
                 m.enable_check_replay_result = m.enabled and self.args.ci_test
 
-        (self.model, self.optimizer, self.opt_param_scheduler, loaded_rollout_id) = initialize_model_and_optimizer(
+        self.model, self.optimizer, self.opt_param_scheduler, loaded_rollout_id = initialize_model_and_optimizer(
             args, role
         )
 
@@ -239,77 +243,6 @@ class MegatronTrainRayActor(TrainRayActor):
         for m in all_replay_managers:
             m.stage = stage
 
-    def _fill_replay_data(
-        self,
-        data_iterator,
-        num_microbatches,
-        rollout_data,
-        data_key: str,
-        replay_list: list,
-        register_replay_list_func,
-        if_sp_region=True,
-    ):
-        if data_key not in rollout_data:
-            raise ValueError(f"{data_key} is required in rollout_data for replay.")
-
-        for iterator in data_iterator:
-            iterator.reset()
-
-        parallel_state = get_parallel_state()
-        tp_rank = parallel_state.tp.rank
-        tp_size = parallel_state.tp.size
-        qkv_format = self.args.qkv_format
-
-        def pad_func(data, pad):
-            _, num_layers, topk = data.shape
-            pad_tensor = torch.full(
-                (pad, num_layers, topk),
-                fill_value=-1,
-                device=data.device,
-                dtype=data.dtype,
-            )
-            return torch.cat([data, pad_tensor], dim=0)
-
-        for _ in range(sum(num_microbatches)):
-            batch = data_iterator[0].get_next([data_key, "tokens", "max_seq_lens"])
-            replay_data = batch[data_key]
-            tokens = batch["tokens"]
-            assert len(replay_data) == len(tokens)
-            for a, b in zip(replay_data, tokens, strict=False):
-                assert a.shape[0] == b.shape[0] - 1, f"{a.shape}, {b.shape}"
-
-            # We need to pad the experts to the last token. We won't calculate loss on this token so this should be fine.
-            # TODO: fuse this padding with the following slice_with_cp to reduce memory copy.
-            replay_data = [pad_func(r, 1) for r in replay_data]
-            # TODO: maybe extract a common process function for here and get_batch?
-
-            if qkv_format == "bshd":
-                max_seqlen = batch["max_seq_lens"][0]
-                replay_data = [slice_with_cp(r, pad_func, qkv_format, max_seqlen) for r in replay_data]
-                replay_data = torch.stack(replay_data, dim=0)
-                batch_size, seqlen, num_layers, topk = replay_data.shape
-                replay_data = replay_data.reshape(batch_size * seqlen, num_layers, topk)
-            else:
-                replay_data = [slice_with_cp(r, pad_func, qkv_format) for r in replay_data]
-                replay_data = torch.cat(replay_data, dim=0)
-                pad_size = parallel_state.tp.size * self.args.data_pad_size_multiplier
-                pad = (pad_size - replay_data.size(0) % pad_size) % pad_size
-                if pad != 0:
-                    replay_data = pad_func(replay_data, pad)
-
-            if self.args.sequence_parallel and if_sp_region:
-                seqlen = replay_data.size(0)
-                assert seqlen % tp_size == 0
-                start, end = seqlen // tp_size * tp_rank, seqlen // tp_size * (tp_rank + 1)
-                replay_data = replay_data[start:end]
-
-            register_replay_list_func(replay_list, replay_data, self.model)
-
-        del rollout_data[data_key]
-
-        for iterator in data_iterator:
-            iterator.reset()
-
     def compute_log_prob(
         self,
         data_iterator: list[DataIterator],
@@ -372,7 +305,7 @@ class MegatronTrainRayActor(TrainRayActor):
         )
 
     def _use_rollout_replay(self, m) -> bool:
-        return getattr(self.args, f"use_rollout_{m.name}_replay")
+        return getattr(self.args, f"use_rollout_{m.name}_replay", False)
 
     def train_actor(self, rollout_id: int, rollout_data: RolloutBatch) -> None:
         # Create data iterator for log_probs and train.
@@ -380,13 +313,15 @@ class MegatronTrainRayActor(TrainRayActor):
 
         for m in all_replay_managers:
             if self._use_rollout_replay(m):
-                self._fill_replay_data(
-                    data_iterator,
-                    num_microbatches,
-                    rollout_data,
+                fill_replay_data(
+                    args=self.args,
+                    models=self.model,
+                    data_iterator=data_iterator,
+                    num_microbatches=num_microbatches,
+                    rollout_data=rollout_data,
                     data_key=m.data_key,
                     replay_list=m.replays,
-                    register_replay_list_func=get_register_replay_list_func(m),
+                    register_replay_list_func=m.register_replay_list_func,
                     if_sp_region=m.if_sp_region,
                 )
 

--- a/miles/backends/megatron_utils/replay_utils.py
+++ b/miles/backends/megatron_utils/replay_utils.py
@@ -1,12 +1,9 @@
-from megatron.core.transformer.transformer_block import get_num_layers_to_build
-from megatron.core.transformer.transformer_layer import get_transformer_layer_offset
+def register_replay_list_moe(replay_list, replay_data, *, models, **_kwargs):
+    """Map replay streams to Megatron MoE layers using the local model layout."""
+    from megatron.core.transformer.transformer_block import get_num_layers_to_build
+    from megatron.core.transformer.transformer_layer import get_transformer_layer_offset
 
-from miles.utils.replay_base import BaseReplayManager, RoutingReplayManager
-
-
-def _register_replay_list_moe(replay_list, replay_data, models):
     layer_indices = []
-    replay_idx = 0
     for vp_stage, model in enumerate(models):
         config = model.module.config
         num_layers_to_build = get_num_layers_to_build(config, vp_stage=vp_stage)
@@ -24,10 +21,3 @@ def _register_replay_list_moe(replay_list, replay_data, models):
     for replay_idx, layer_idx in enumerate(layer_indices):
         layer_data = replay_data[:, layer_idx]
         replay_list[replay_idx].record(layer_data)
-
-
-def get_register_replay_list_func(manager: BaseReplayManager):
-    if isinstance(manager, RoutingReplayManager):
-        return _register_replay_list_moe
-    else:
-        raise ValueError(f"Unsupported manager type: {type(manager)}")

--- a/miles/backends/sglang_utils/arguments.py
+++ b/miles/backends/sglang_utils/arguments.py
@@ -61,6 +61,7 @@ def add_sglang_arguments(parser):
         "nccl_port",
         "skip_server_warmup",
         "enable_return_routed_experts",
+        "enable_return_indexer_topk",
     ]
 
     def new_add_argument_wrapper(*name_or_flags, **kwargs):

--- a/miles/backends/sglang_utils/sglang_engine.py
+++ b/miles/backends/sglang_utils/sglang_engine.py
@@ -648,6 +648,8 @@ def _compute_server_args(
 
     if args.use_rollout_routing_replay:
         kwargs["enable_return_routed_experts"] = True
+    if args.use_rollout_indexer_replay:
+        kwargs["enable_return_indexer_topk"] = True
     if args.fp16:
         kwargs["dtype"] = "float16"
     if engine_info_bootstrap_port is not None:

--- a/miles/backends/training_utils/data.py
+++ b/miles/backends/training_utils/data.py
@@ -90,6 +90,8 @@ def get_rollout_data(args: Namespace, rollout_data_ref: Box) -> RolloutBatch:
         ]
     if "rollout_routed_experts" in rollout_data:
         rollout_data["rollout_routed_experts"] = [torch.from_numpy(r) for r in rollout_data["rollout_routed_experts"]]
+    if "rollout_indexer_topk" in rollout_data:
+        rollout_data["rollout_indexer_topk"] = [torch.from_numpy(r) for r in rollout_data["rollout_indexer_topk"]]
     return rollout_data
 
 

--- a/miles/backends/training_utils/log_utils.py
+++ b/miles/backends/training_utils/log_utils.py
@@ -119,6 +119,7 @@ def log_rollout_data(rollout_id: int, args: Namespace, rollout_data: RolloutBatc
                 "loss_masks",
                 "sample_indices",
                 "rollout_routed_experts",
+                "rollout_indexer_topk",
                 "max_seq_lens",
                 "dynamic_global_batch_size",
                 "weight_versions",

--- a/miles/backends/training_utils/replay_data.py
+++ b/miles/backends/training_utils/replay_data.py
@@ -1,0 +1,108 @@
+from collections.abc import Callable
+
+import torch
+
+from .cp_utils import slice_with_cp
+from .parallel import get_parallel_state
+
+RegisterReplayListFunc = Callable[..., None]
+
+
+def register_replay_list_sequential(replay_list, replay_data, **_kwargs):
+    """Map replay streams to registered modules.
+
+    Each replay records `replay_data[:, replay.stream_idx]` if `stream_idx` is
+    set (used for sparse layer layouts under PP/VPP, where the global replay
+    tensor contains more streams than this rank registered). Otherwise falls
+    back to 1:1 enumeration order.
+    """
+    for replay_idx, replay in enumerate(replay_list):
+        stream_idx = replay.stream_idx if replay.stream_idx is not None else replay_idx
+        if not 0 <= stream_idx < replay_data.shape[1]:
+            raise AssertionError(
+                f"replay stream_idx {stream_idx} out of range " f"(replay_data has {replay_data.shape[1]} streams)"
+            )
+        replay.record(replay_data[:, stream_idx])
+
+
+def fill_replay_data(
+    *,
+    args,
+    models,
+    data_iterator,
+    num_microbatches,
+    rollout_data,
+    data_key: str,
+    replay_list: list,
+    register_replay_list_func: RegisterReplayListFunc,
+    if_sp_region=True,
+):
+    """Load rollout replay tensors into module replay queues.
+
+    `rollout_data[data_key]` contains one tensor per sample with shape
+    `[num_tokens - 1, num_streams, topk]`. This function replays the training
+    data iterator to process those tensors in the same microbatch order as
+    log-prob and train forwards, pads/slices them to match the local CP/SP
+    token layout, and then delegates stream-to-module mapping to
+    `register_replay_list_func`.
+    """
+    if data_key not in rollout_data:
+        raise ValueError(f"{data_key} is required in rollout_data for replay.")
+
+    for iterator in data_iterator:
+        iterator.reset()
+
+    parallel_state = get_parallel_state()
+    tp_rank = parallel_state.tp.rank
+    tp_size = parallel_state.tp.size
+    qkv_format = args.qkv_format
+
+    def pad_func(data, pad):
+        _, num_layers, topk = data.shape
+        pad_tensor = torch.full(
+            (pad, num_layers, topk),
+            fill_value=-1,
+            device=data.device,
+            dtype=data.dtype,
+        )
+        return torch.cat([data, pad_tensor], dim=0)
+
+    for _ in range(sum(num_microbatches)):
+        batch = data_iterator[0].get_next([data_key, "tokens", "max_seq_lens"])
+        replay_data = batch[data_key]
+        tokens = batch["tokens"]
+        assert len(replay_data) == len(tokens)
+        for a, b in zip(replay_data, tokens, strict=False):
+            assert a.shape[0] == b.shape[0] - 1, f"{a.shape}, {b.shape}"
+
+        # Pad replay data to align with the token batch's final token. The padded token is masked from loss.
+        # TODO: fuse this padding with the following slice_with_cp to reduce memory copy.
+        replay_data = [pad_func(r, 1) for r in replay_data]
+        # TODO: maybe extract a common process function for here and get_batch?
+
+        if qkv_format == "bshd":
+            max_seqlen = batch["max_seq_lens"][0]
+            replay_data = [slice_with_cp(r, pad_func, qkv_format, max_seqlen) for r in replay_data]
+            replay_data = torch.stack(replay_data, dim=0)
+            batch_size, seqlen, num_layers, topk = replay_data.shape
+            replay_data = replay_data.reshape(batch_size * seqlen, num_layers, topk)
+        else:
+            replay_data = [slice_with_cp(r, pad_func, qkv_format) for r in replay_data]
+            replay_data = torch.cat(replay_data, dim=0)
+            pad_size = parallel_state.tp.size * args.data_pad_size_multiplier
+            pad = (pad_size - replay_data.size(0) % pad_size) % pad_size
+            if pad != 0:
+                replay_data = pad_func(replay_data, pad)
+
+        if args.sequence_parallel and if_sp_region:
+            seqlen = replay_data.size(0)
+            assert seqlen % tp_size == 0
+            start, end = seqlen // tp_size * tp_rank, seqlen // tp_size * (tp_rank + 1)
+            replay_data = replay_data[start:end]
+
+        register_replay_list_func(replay_list, replay_data, models=models)
+
+    del rollout_data[data_key]
+
+    for iterator in data_iterator:
+        iterator.reset()

--- a/miles/ray/rollout.py
+++ b/miles/ray/rollout.py
@@ -721,6 +721,9 @@ class RolloutManager:
         if samples[0].rollout_routed_experts is not None:
             train_data["rollout_routed_experts"] = [sample.rollout_routed_experts for sample in samples]
 
+        if samples[0].rollout_indexer_topk is not None:
+            train_data["rollout_indexer_topk"] = [sample.rollout_indexer_topk for sample in samples]
+
         if samples[0].train_metadata is not None:
             train_data["metadata"] = [sample.train_metadata for sample in samples]
 
@@ -775,6 +778,7 @@ class RolloutManager:
                 "sample_indices",
                 "rollout_log_probs",
                 "rollout_routed_experts",
+                "rollout_indexer_topk",
                 "prompt",
                 "teacher_log_probs",
                 "weight_versions",

--- a/miles/rollout/generate_utils/generate_endpoint_utils.py
+++ b/miles/rollout/generate_utils/generate_endpoint_utils.py
@@ -53,6 +53,7 @@ def compute_request_payload(
         "sampling_params": {**sampling_params, "max_new_tokens": max_new_tokens},
         "return_logprob": True,
         "return_routed_experts": args.use_rollout_routing_replay,
+        "return_indexer_topk": args.use_rollout_indexer_replay,
     }
     if image_data := (multimodal_inputs or {}).get("images"):
         payload["image_data"] = [encode_image_for_rollout_engine(image) for image in image_data]
@@ -97,14 +98,31 @@ async def update_sample_from_response(
 
     # TODO handle multi-turn cases (may need concat instead of assignment)
     sample.rollout_routed_experts = get_rollout_topk_from_response(args, output, sample, "routed_experts")
+    sample.rollout_indexer_topk = get_indexer_topk_from_response(args, output, sample)
 
     # TODO may unify (currently there are both methods inside Sample and separate functions)
     sample.update_from_meta_info(args, output["meta_info"])
 
 
-def get_rollout_topk_from_response(args, output, sample, key):
+def get_rollout_topk_from_response(args, output, sample, key, num_layers=None, topk=None):
     info = output["meta_info"].get(key)
     if info is None:
         return None
     x = np.frombuffer(pybase64.b64decode(info.encode("ascii")), dtype=np.int32)
-    return x.reshape(len(sample.tokens) - 1, args.num_layers, args.moe_router_topk)
+    if num_layers is None:
+        num_layers = args.num_layers
+    if topk is None:
+        topk = args.moe_router_topk
+    return x.reshape(len(sample.tokens) - 1, num_layers, topk)
+
+
+def get_indexer_topk_from_response(args, output, sample):
+    if output["meta_info"].get("indexer_topk") is None:
+        return None
+    num_layers = output["meta_info"].get("indexer_topk_num_layers")
+    assert num_layers is not None, (
+        "Server returned indexer_topk without indexer_topk_num_layers; "
+        "sglang-miles must include the layer count in meta_info."
+    )
+    # topk dim recovered from buffer length via reshape(-1).
+    return get_rollout_topk_from_response(args, output, sample, "indexer_topk", num_layers, -1)

--- a/miles/rollout/generate_utils/openai_endpoint_utils.py
+++ b/miles/rollout/generate_utils/openai_endpoint_utils.py
@@ -7,7 +7,10 @@ import logging
 from argparse import Namespace
 from copy import deepcopy
 
-from miles.rollout.generate_utils.generate_endpoint_utils import get_rollout_topk_from_response
+from miles.rollout.generate_utils.generate_endpoint_utils import (
+    get_indexer_topk_from_response,
+    get_rollout_topk_from_response,
+)
 from miles.rollout.session.session_types import GetSessionResponse, SessionRecord
 from miles.utils.http_utils import post
 from miles.utils.types import Sample
@@ -179,6 +182,7 @@ def _compute_sample_from_openai_record(
     sample.response_length = len(output_token_ids)
     sample.loss_mask = [1] * len(output_token_ids)
     sample.rollout_routed_experts = get_rollout_topk_from_response(args, choice, sample, "routed_experts")
+    sample.rollout_indexer_topk = get_indexer_topk_from_response(args, choice, sample)
 
     if trim_count > 0:
         sample.strip_last_output_tokens(trim_count, tokenizer)

--- a/miles/rollout/generate_utils/sample_utils.py
+++ b/miles/rollout/generate_utils/sample_utils.py
@@ -43,6 +43,8 @@ def _merge_sample_pair(a: Sample, b: Sample, tokenizer) -> Sample:
         assert obs_len > 0, f"obs_len must be > 0, got {obs_len}"
         if a.rollout_routed_experts is not None:
             assert a.rollout_routed_experts.shape[0] <= b.rollout_routed_experts.shape[0]
+        if a.rollout_indexer_topk is not None:
+            assert a.rollout_indexer_topk.shape[0] <= b.rollout_indexer_topk.shape[0]
         assert a.status == Sample.Status.COMPLETED, f"a.status must be COMPLETED, got {a.status}"
 
         return _create_with_all_fields(
@@ -61,6 +63,7 @@ def _merge_sample_pair(a: Sample, b: Sample, tokenizer) -> Sample:
             weight_versions=a.weight_versions + b.weight_versions,
             rollout_log_probs=a.rollout_log_probs + [0.0] * obs_len + b.rollout_log_probs,
             rollout_routed_experts=b.rollout_routed_experts,
+            rollout_indexer_topk=b.rollout_indexer_topk,
             remove_sample=_merge_equal_value("remove_sample"),
             status=b.status,
             metadata=_merge_equal_value("metadata"),

--- a/miles/rollout/session/sessions.py
+++ b/miles/rollout/session/sessions.py
@@ -147,6 +147,8 @@ def setup_session_routes(app, backend, args):
                 request_body["return_meta_info"] = True
                 if getattr(args, "use_rollout_routing_replay", False):
                     request_body["return_routed_experts"] = True
+                if getattr(args, "use_rollout_indexer_replay", False):
+                    request_body["return_indexer_topk"] = True
                 # Must be False so stop-token text is trimmed from assistant
                 # message content; token IDs are still taken from logprobs below.
                 request_body["no_stop_trim"] = False

--- a/miles/rollout/sglang_rollout.py
+++ b/miles/rollout/sglang_rollout.py
@@ -31,6 +31,7 @@ from miles.utils.processing_utils import (
 )
 from miles.utils.types import Sample
 
+from .generate_utils.generate_endpoint_utils import get_indexer_topk_from_response
 from .generate_utils.prefill_logprobs import recompute_samples_rollout_logprobs_via_prefill
 from .rm_hub import async_rm, batched_async_rm
 
@@ -172,6 +173,8 @@ async def generate(args: Namespace, sample: Sample, sampling_params: dict[str, A
 
     if args.use_rollout_routing_replay:
         payload["return_routed_experts"] = True
+    if getattr(args, "use_rollout_indexer_replay", False):
+        payload["return_indexer_topk"] = True
 
     if sample.multimodal_inputs and sample.multimodal_inputs["images"]:
         image_data = sample.multimodal_inputs["images"]
@@ -226,6 +229,8 @@ async def generate(args: Namespace, sample: Sample, sampling_params: dict[str, A
             args.num_layers,
             args.moe_router_topk,
         )
+    if "indexer_topk" in output["meta_info"]:
+        sample.rollout_indexer_topk = get_indexer_topk_from_response(args, output, sample)
 
     sample.update_from_meta_info(args, output["meta_info"])
 

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -1058,6 +1058,18 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 help="The rollout routing replay technique from https://arxiv.org/abs/2510.11370",
             )
             parser.add_argument(
+                "--use-indexer-replay",
+                action="store_true",
+                default=False,
+                help="Replay indexer topk decisions for layers with indexers.",
+            )
+            parser.add_argument(
+                "--use-rollout-indexer-replay",
+                action="store_true",
+                default=False,
+                help="Replay indexer topk from rollout during training.",
+            )
+            parser.add_argument(
                 "--use-opsm",
                 action="store_true",
                 default=False,
@@ -2189,6 +2201,9 @@ def miles_validate_args(args):
             if hasattr(args, k):
                 logger.info(f"Warning: Argument {k} is already set to {getattr(args, k)}, will override with {v}.")
             setattr(args, k, v)
+
+    if args.use_rollout_indexer_replay:
+        args.use_indexer_replay = True
 
     if args.eval_max_context_len is None:
         logger.info(

--- a/miles/utils/replay_base.py
+++ b/miles/utils/replay_base.py
@@ -12,7 +12,8 @@ def _get_rank():
 
 
 class Replay:
-    def __init__(self):
+    def __init__(self, stream_idx: int | None = None):
+        self.stream_idx = stream_idx
         self.forward_index = 0
         self.backward_index = 0
         self.top_indices_list: list[torch.Tensor] = []
@@ -52,15 +53,17 @@ class Replay:
 class BaseReplayManager:
     name: str = ""
     filename: str = ""
+    replay_check_min_overlap_ratio = 0.0  # 0.0 = mismatch only on zero overlap
 
     def __init__(self):
         self.replays: list[Replay] = []
         self.current: Replay | None = None
         self.enabled = False
         self.stage = "fallthrough"
+        self.register_replay_list_func = None
 
-    def create_replay(self) -> Replay:
-        replay = Replay()
+    def create_replay(self, stream_idx: int | None = None) -> Replay:
+        replay = Replay(stream_idx=stream_idx)
         self.replays.append(replay)
         return replay
 
@@ -78,7 +81,10 @@ class BaseReplayManager:
         for replay in self.replays:
             replay.clear_forward()
 
-    def get_topk_fn(self, old_topk_fn, return_probs):
+    def get_topk_fn(self, old_topk_fn, return_probs, *, fill_padding_with_arange=True):
+        if return_probs and not fill_padding_with_arange:
+            raise ValueError("fill_padding_with_arange=False is only supported when return_probs=False")
+
         manager = self
 
         def _get_replay_result(top_indices, scores, topk, *args, **kwargs):
@@ -93,12 +99,13 @@ class BaseReplayManager:
             if self.enable_check_replay_result:
                 self.check_replay_result(old_topk_fn, scores, topk, top_indices, *args, **kwargs)
 
-            padding_mask = top_indices == -1
-            if padding_mask.any():
-                top_indices[padding_mask] = (
-                    torch.arange(padding_mask.sum(), device=top_indices.device, dtype=top_indices.dtype)
-                    % scores.shape[1]
-                )
+            if fill_padding_with_arange:
+                padding_mask = top_indices == -1
+                if padding_mask.any():
+                    top_indices[padding_mask] = (
+                        torch.arange(padding_mask.sum(), device=top_indices.device, dtype=top_indices.dtype)
+                        % scores.shape[1]
+                    )
 
             if return_probs:
                 return scores.gather(1, top_indices), top_indices
@@ -135,10 +142,10 @@ class BaseReplayManager:
 
         return new_topk_fn
 
-    def register_to_module(self, module, attr_name: str):
+    def register_to_module(self, module, attr_name: str, stream_idx: int | None = None):
         if not self.enabled:
             return
-        replay = self.create_replay()
+        replay = self.create_replay(stream_idx=stream_idx)
         setattr(module, attr_name, replay)
         manager = self
 
@@ -150,9 +157,11 @@ class BaseReplayManager:
     def check_replay_result(self, old_topk_fn, scores, topk, top_indices, *args, **kwargs):
         """
         CI checker for R3. Only enable when enable_check_replay_result=True.
-        Calculate the overlapping between training engine's computed routing result
-        and replay routing result.
-        If mismatch token count > n_tokens * replay_check_threshold, raise error.
+        Per token, measure the overlap between the training engine's recomputed
+        topk and the replayed topk (ignoring -1 padding). A token is mismatched
+        when overlap < replay_check_min_overlap_ratio of its valid picks (ratio 0.0 =
+        only zero overlap). Raise when the mismatched fraction exceeds
+        replay_check_max_mismatch_fraction.
         """
         orig_top_indices = old_topk_fn(scores, topk, *args, **kwargs)
         if isinstance(orig_top_indices, tuple):
@@ -160,20 +169,31 @@ class BaseReplayManager:
 
         orig_flat = orig_top_indices.view(-1, orig_top_indices.shape[-1])  # [n_tokens, topk]
         replay_flat = top_indices.view(-1, top_indices.shape[-1])
+        valid_orig = orig_flat != -1
+        valid_replay = replay_flat != -1
 
-        # [n_tokens, topk_orig, 1] == [n_tokens, 1, topk_replay] -> [n_tokens, topk_orig, topk_replay]
-        matches = orig_flat.unsqueeze(2) == replay_flat.unsqueeze(1)
-        # Mask out -1 (padding) matches
-        matches &= (orig_flat != -1).unsqueeze(2) & (replay_flat != -1).unsqueeze(1)
-        has_overlap = matches.any(dim=(1, 2))  # [n_tokens]
-        is_padding = (replay_flat == -1).all(dim=1)
-        is_mismatch = ~has_overlap & ~is_padding
+        # token-wise set overlap via a membership mask, avoiding the O(n*topk^2)
+        # all-pairs tensor; -1 padding is routed to a sentinel column
+        n_kv = int(torch.maximum(orig_flat.max(), replay_flat.max()).clamp_min(0)) + 1
+        membership = orig_flat.new_zeros((orig_flat.shape[0], n_kv + 1), dtype=torch.bool)
+        membership.scatter_(1, torch.where(valid_orig, orig_flat, n_kv).long(), True)
+        replay_idx = torch.where(valid_replay, replay_flat, n_kv).long()
+        hit = membership.gather(1, replay_idx) & valid_replay  # [n_tokens, topk]
+
+        overlap = hit.sum(dim=1)
+        valid_count = valid_replay.sum(dim=1)
+        is_padding = valid_count == 0
+        if self.replay_check_min_overlap_ratio == 0.0:
+            required = torch.ones_like(overlap)  # legacy: mismatch only on zero overlap
+        else:
+            required = (valid_count * self.replay_check_min_overlap_ratio).ceil().to(overlap.dtype)
+        is_mismatch = (overlap < required) & ~is_padding
 
         mismatch_count = is_mismatch.sum().item()
         if mismatch_count == 0:
             return
 
-        threshold = float(os.environ.get("MILES_TEST_R3_THRESHOLD", self.replay_check_threshold))
+        threshold = float(os.environ.get("MILES_TEST_R3_THRESHOLD", self.replay_check_max_mismatch_fraction))
         mismatch_threshold = threshold * orig_flat.shape[0]
         mismatch_indices = is_mismatch.nonzero(as_tuple=False).squeeze(1)
         for idx in mismatch_indices:
@@ -184,7 +204,7 @@ class BaseReplayManager:
                 lines.append(f"  token {j}: orig={orig_flat[j].tolist()}, replay={replay_flat[j].tolist()}{marker}")
             logger.warning(
                 f"Replay check (rank {_get_rank()}, stage {self.stage}): "
-                f"token {i} zero overlap, topk={topk}\n" + "\n".join(lines)
+                f"token {i} overlap {overlap[i].item()}/{valid_count[i].item()}, topk={topk}\n" + "\n".join(lines)
             )
 
         if mismatch_count > mismatch_threshold:
@@ -197,8 +217,19 @@ class RoutingReplayManager(BaseReplayManager):
     data_key = "rollout_routed_experts"
     if_sp_region = True
     enable_check_replay_result = False
-    replay_check_threshold = 1e-2
+    replay_check_max_mismatch_fraction = 1e-2
+
+
+class IndexerReplayManager(BaseReplayManager):
+    name = "indexer"
+    filename = "indexer_replay.pt"
+    data_key = "rollout_indexer_topk"
+    if_sp_region = False
+    enable_check_replay_result = False
+    replay_check_max_mismatch_fraction = 1e-2
+    replay_check_min_overlap_ratio = 0.9
 
 
 routing_replay_manager = RoutingReplayManager()
-all_replay_managers = [routing_replay_manager]
+indexer_replay_manager = IndexerReplayManager()
+all_replay_managers = [routing_replay_manager, indexer_replay_manager]

--- a/miles/utils/types.py
+++ b/miles/utils/types.py
@@ -28,6 +28,9 @@ class Sample:
     rollout_routed_experts: numpy.ndarray | None = (
         None  # Routed experts from rollout engine. shape: (num_tokens-1, num_layers, moe_router_topk), dtype=int32
     )
+    rollout_indexer_topk: numpy.ndarray | None = (
+        None  # Indexer topk from rollout engine. shape: (num_tokens-1, num_indexer_layers, index_topk), dtype=int32
+    )
     remove_sample: bool = False
 
     class Status(Enum):
@@ -170,6 +173,10 @@ class Sample:
             actual = len(self.rollout_routed_experts)
             expect = len(self.tokens) - 1
             assert actual == expect, f"rollout_routed_experts length ({actual}) != len(tokens) - 1 ({expect})"
+        if self.rollout_indexer_topk is not None:
+            actual = len(self.rollout_indexer_topk)
+            expect = len(self.tokens) - 1
+            assert actual == expect, f"rollout_indexer_topk length ({actual}) != len(tokens) - 1 ({expect})"
 
     def strip_last_output_tokens(self, n: int, tokenizer) -> None:
         """Remove the last *n* output tokens and all associated per-token info."""
@@ -187,6 +194,8 @@ class Sample:
         self.response = tokenizer.decode(self.tokens[-self.response_length :]) if self.response_length > 0 else ""
         if self.rollout_routed_experts is not None:
             self.rollout_routed_experts = self.rollout_routed_experts[:-n]
+        if self.rollout_indexer_topk is not None:
+            self.rollout_indexer_topk = self.rollout_indexer_topk[:-n]
 
     def reset_for_retry(self) -> None:
         """Reset generated outputs so the original prompt can be re-sampled.
@@ -204,6 +213,7 @@ class Sample:
         self.weight_versions = []
         self.rollout_log_probs = None
         self.rollout_routed_experts = None
+        self.rollout_indexer_topk = None
         self.status = Sample.Status.ABORTED
         self.non_generation_time = 0.0
         self.spec_info = Sample.SpecInfo()

--- a/miles_plugins/models/glm5/glm5.py
+++ b/miles_plugins/models/glm5/glm5.py
@@ -26,6 +26,8 @@ from megatron.core.transformer.transformer_block import get_num_layers_to_build
 from megatron.core.transformer.transformer_config import MLATransformerConfig
 from transformers import AutoConfig
 
+from miles.utils.replay_base import indexer_replay_manager
+
 from .ops.indexer import generate_varlen_mask_params, lighting_indexer
 from .ops.sparse_mla import SparseMLA
 
@@ -136,6 +138,7 @@ class DSAMultiLatentAttention(Attention):
         )
 
         self.index_topk = 2048
+        indexer_replay_manager.register_to_module(self, "indexer_replay", stream_idx=self.layer_number - 1)
 
     def forward(
         self,
@@ -180,6 +183,9 @@ class DSAMultiLatentAttention(Attention):
 
         def fused_select_topk(index_q, index_k, w, starts, ends, block_size=8192):
             seq_len = index_q.shape[0]
+            # replay records one topk tensor per layer-forward; don't split it
+            if indexer_replay_manager.enabled:
+                block_size = seq_len
             indexer_topk_scores = []
             topk_indices = []
 
@@ -189,14 +195,15 @@ class DSAMultiLatentAttention(Attention):
                 w_block = w[start:end]
                 starts_block = starts[start:end]
                 ends_block = ends[start:end]
+                starts_block = starts_block.to(torch.int32)
+                ends_block = ends_block.to(torch.int32)
                 indexer_topk_scores_block, topk_indices_block = lighting_indexer(
                     index_q_block,
                     index_k,
                     w_block,
-                    starts_block.to(torch.int32),
-                    ends_block.to(torch.int32),
+                    starts_block,
+                    ends_block,
                     self.index_topk,
-                    topk_indices=None,
                 )
 
                 indexer_topk_scores_block = torch.softmax(indexer_topk_scores_block, dim=-1)

--- a/miles_plugins/models/glm5/ops/indexer.py
+++ b/miles_plugins/models/glm5/ops/indexer.py
@@ -1,5 +1,7 @@
 import torch
 
+from miles.utils.replay_base import indexer_replay_manager
+
 from .tilelang_indexer_bwd import indexer_bwd_interface
 from .tilelang_indexer_fwd import indexer_fwd_interface
 
@@ -12,6 +14,12 @@ def pytorch_extract_topk_scores(logits, topk_indices, dim=-1):
     return scores
 
 
+def _original_topk(logits, topk):
+    score, indices = torch.topk(logits, topk, dim=-1)
+    indices = indices.to(torch.int32)
+    return indices.masked_fill(score == -torch.inf, -1)
+
+
 class IndexerFunction(torch.autograd.Function):
     @staticmethod
     def forward(
@@ -21,25 +29,15 @@ class IndexerFunction(torch.autograd.Function):
         weights: torch.Tensor,
         cu_seqlen_ks: torch.Tensor,
         cu_seqlen_ke: torch.Tensor,
-        topk: int,
-        topk_indices: torch.Tensor | None = None,
+        logits: torch.Tensor,
+        topk_indices: torch.Tensor,
     ):
-        _, head_num, _ = index_q.shape
-        logits = indexer_fwd_interface(index_q, index_k, weights, cu_seqlen_ks, cu_seqlen_ke, clean_logits=True)
-        if topk_indices is None:
-            index_score, topk_indices = torch.topk(logits, topk, dim=-1)
-            topk_indices = topk_indices.to(torch.int32)
-            topk_indices = topk_indices.masked_fill(index_score == -torch.inf, -1)
-
         index_score = pytorch_extract_topk_scores(logits, topk_indices)
-
         ctx.save_for_backward(index_q, index_k, weights, cu_seqlen_ks, cu_seqlen_ke, topk_indices)
-        ctx.topk = topk
-        ctx.head_num = head_num
-        return index_score, topk_indices
+        return index_score
 
     @staticmethod
-    def backward(ctx, grad_scores, grad_indices):
+    def backward(ctx, grad_scores):
         index_q, index_k, weights, cu_seqlen_ks, cu_seqlen_ke, topk_indices = ctx.saved_tensors
         grad_q, grad_w, grad_k = indexer_bwd_interface(index_q, weights, index_k, topk_indices, grad_scores)
         return grad_q, grad_k, grad_w, None, None, None, None
@@ -54,7 +52,20 @@ def lighting_indexer(
     topk: int,
     topk_indices: torch.Tensor | None = None,
 ):
-    return IndexerFunction.apply(index_q, index_k, weights.squeeze(-1), cu_seqlen_ks, cu_seqlen_ke, topk, topk_indices)
+    if topk_indices is not None:
+        assert not indexer_replay_manager.enabled
+
+    weights_2d = weights.squeeze(-1)
+    logits = indexer_fwd_interface(index_q, index_k, weights_2d, cu_seqlen_ks, cu_seqlen_ke, clean_logits=True)
+
+    if topk_indices is None:
+        topk_fn = indexer_replay_manager.get_topk_fn(
+            _original_topk, return_probs=False, fill_padding_with_arange=False
+        )
+        topk_indices = topk_fn(logits, topk)
+
+    index_score = IndexerFunction.apply(index_q, index_k, weights_2d, cu_seqlen_ks, cu_seqlen_ke, logits, topk_indices)
+    return index_score, topk_indices
 
 
 def generate_varlen_mask_params(cu_seqlens):

--- a/tests/ci/labels.py
+++ b/tests/ci/labels.py
@@ -26,4 +26,5 @@ KNOWN_LABELS: dict[str, str] = {
     "ckpt": "Checkpoint save / load tests",
     "lora": "LoRA training tests",
     "precision": "Numerical precision parity tests",
+    "r3": "Routing / indexer replay tests",
 }

--- a/tests/e2e/megatron/test_glm47_flash/_common.py
+++ b/tests/e2e/megatron/test_glm47_flash/_common.py
@@ -170,7 +170,7 @@ def build_train_args(case: CaseConfig, *, wandb_file: str) -> str:
 
 
 def execute(case: CaseConfig, *, wandb_file: str) -> None:
-    # Set replay_check_threshold to 1e-1 for GLM-4.7-Flash with MTP
+    # Loosen replay mismatch threshold for GLM-4.7-Flash with MTP
     os.environ["MILES_TEST_R3_THRESHOLD"] = "0.05"
 
     train_args = build_train_args(case, wandb_file=wandb_file)

--- a/tests/e2e/megatron/test_glm5_744b_a40b_4layer_r3.py
+++ b/tests/e2e/megatron/test_glm5_744b_a40b_4layer_r3.py
@@ -1,0 +1,63 @@
+import os
+
+from scripts.run_glm5_744b_a40b import (
+    ScriptArgs,
+    _execute_train,
+    _prepare_download,
+    _prepare_megatron_ckpt,
+    _validate_glm_checkpoint,
+)
+from tests.ci.ci_register import register_cuda_ci
+
+import miles.utils.external_utils.command_utils as U
+
+# Basic smoke test that exercises the rollout indexer-topk replay path on
+# GLM-5 (every layer has an indexer). Enabling --use-rollout-indexer-replay
+# also forces --use-indexer-replay via miles_validate_args, so the training
+# side consumes the per-layer topk emitted by SGLang.
+
+register_cuda_ci(est_time=1800, suite="stage-c-8-gpu-h100", labels=["megatron", "r3"])
+
+
+def _args() -> ScriptArgs:
+    return ScriptArgs(
+        model_name="GLM-5_4layer",
+        num_nodes=1,
+        num_gpus_per_node=8,
+        num_rollout=2,
+        extra_env_vars="MILES_EXPERIMENTAL_ROLLOUT_REFACTOR=1",
+        extra_args=(
+            "--ci-test "
+            "--ci-disable-logprobs-checker "
+            "--disable-weights-backuper "
+            "--use-rollout-indexer-replay "
+            # TODO: support indexer topk in sgl-router
+            "--use-miles-router "
+            "--rollout-max-response-len 4096 "
+            # preserve to avoid CPU OOM
+            "--sglang-max-total-tokens 1900000 "
+            # exercise indexer replay across PP stages
+            "--tensor-model-parallel-size 2 "
+            "--pipeline-model-parallel-size 2 "
+            "--expert-model-parallel-size 4 "
+        ),
+    )
+
+
+def prepare(args: ScriptArgs):
+    U.exec_command(f"mkdir -p {args.output_dir}")
+    _prepare_download(args)
+    _validate_glm_checkpoint(args)
+    _prepare_megatron_ckpt(args)
+
+
+def execute(args: ScriptArgs):
+    _execute_train(args)
+
+
+if __name__ == "__main__":
+    args = _args()
+    prepare(args)
+    for proxy_var in ("http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY"):
+        os.environ.pop(proxy_var, None)
+    execute(args)

--- a/tests/e2e/megatron/test_qwen3_30B_A3B/test_r3_baseline.py
+++ b/tests/e2e/megatron/test_qwen3_30B_A3B/test_r3_baseline.py
@@ -3,7 +3,7 @@ import os
 from tests.ci.ci_register import register_cuda_ci
 from tests.e2e.megatron.test_qwen3_30B_A3B._common import CaseConfig, execute, prepare
 
-register_cuda_ci(est_time=1500, suite="stage-c-4-gpu-h200", labels=["megatron"])
+register_cuda_ci(est_time=1500, suite="stage-c-4-gpu-h200", labels=["megatron", "r3"])
 
 CASE = CaseConfig(
     use_deepep=False,

--- a/tests/e2e/megatron/test_qwen3_30B_A3B/test_r3_deepep_fp8.py
+++ b/tests/e2e/megatron/test_qwen3_30B_A3B/test_r3_deepep_fp8.py
@@ -7,7 +7,7 @@ from tests.e2e.megatron.test_qwen3_30B_A3B._common import CaseConfig, execute, p
 register_cuda_ci(
     est_time=1800,
     suite="stage-c-4-gpu-h200",
-    labels=["megatron"],
+    labels=["megatron", "r3"],
     disabled="Failed due to mismatch between fp8 rollout and bf16 training.",
 )
 

--- a/tests/fast/backends/training_utils/test_replay_data.py
+++ b/tests/fast/backends/training_utils/test_replay_data.py
@@ -1,0 +1,47 @@
+from tests.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=60, suite="stage-a-cpu", labels=[])
+
+import pytest
+import torch
+
+from miles.backends.training_utils.replay_data import register_replay_list_sequential
+
+
+class _Replay:
+    def __init__(self, stream_idx=None):
+        self.stream_idx = stream_idx
+        self.recorded = []
+
+    def record(self, value):
+        self.recorded.append(value)
+
+
+def test_register_replay_list_sequential_falls_back_to_enum_when_no_stream_idx():
+    replay_data = torch.arange(5 * 3 * 2).reshape(5, 3, 2)
+    replays = [_Replay(), _Replay(), _Replay()]
+
+    register_replay_list_sequential(replays, replay_data)
+
+    for replay_idx, replay in enumerate(replays):
+        assert len(replay.recorded) == 1
+        torch.testing.assert_close(replay.recorded[0], replay_data[:, replay_idx])
+
+
+def test_register_replay_list_sequential_uses_stream_idx_when_set():
+    # PP case: 2 local modules at global streams 1 and 3 out of 4.
+    replay_data = torch.arange(5 * 4 * 2).reshape(5, 4, 2)
+    replays = [_Replay(stream_idx=1), _Replay(stream_idx=3)]
+
+    register_replay_list_sequential(replays, replay_data)
+
+    torch.testing.assert_close(replays[0].recorded[0], replay_data[:, 1])
+    torch.testing.assert_close(replays[1].recorded[0], replay_data[:, 3])
+
+
+def test_register_replay_list_sequential_rejects_out_of_range_stream_idx():
+    replay_data = torch.zeros(5, 4, 2)
+    replays = [_Replay(stream_idx=4)]
+
+    with pytest.raises(AssertionError, match="out of range"):
+        register_replay_list_sequential(replays, replay_data)

--- a/tests/fast/rollout/generate_utils/test_indexer_replay.py
+++ b/tests/fast/rollout/generate_utils/test_indexer_replay.py
@@ -1,0 +1,50 @@
+from tests.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=60, suite="stage-a-cpu", labels=[])
+
+from types import SimpleNamespace
+
+import numpy as np
+import pybase64
+import pytest
+
+from miles.rollout.generate_utils.generate_endpoint_utils import get_indexer_topk_from_response
+from miles.utils.types import Sample
+
+
+def _encode_int32(values: np.ndarray) -> str:
+    return pybase64.b64encode(values.astype(np.int32).tobytes()).decode("ascii")
+
+
+def test_get_indexer_topk_from_response_decodes_using_meta_info_num_layers():
+    args = SimpleNamespace()
+    sample = Sample(tokens=[1, 2, 3])
+    values = np.arange(2 * 2 * 3, dtype=np.int32)
+    output = {
+        "meta_info": {
+            "indexer_topk": _encode_int32(values),
+            "indexer_topk_num_layers": 2,
+        }
+    }
+
+    decoded = get_indexer_topk_from_response(args, output, sample)
+
+    np.testing.assert_array_equal(decoded, values.reshape(2, 2, 3))
+
+
+def test_get_indexer_topk_from_response_returns_none_when_absent():
+    args = SimpleNamespace()
+    sample = Sample(tokens=[1, 2, 3])
+    output = {"meta_info": {}}
+
+    assert get_indexer_topk_from_response(args, output, sample) is None
+
+
+def test_get_indexer_topk_from_response_rejects_missing_num_layers():
+    args = SimpleNamespace()
+    sample = Sample(tokens=[1, 2, 3])
+    values = np.arange(2 * 2 * 3, dtype=np.int32)
+    output = {"meta_info": {"indexer_topk": _encode_int32(values)}}
+
+    with pytest.raises(AssertionError, match="indexer_topk_num_layers"):
+        get_indexer_topk_from_response(args, output, sample)

--- a/tests/fast/rollout/generate_utils/test_sample_utils.py
+++ b/tests/fast/rollout/generate_utils/test_sample_utils.py
@@ -4,6 +4,7 @@ register_cpu_ci(est_time=60, suite="stage-a-cpu", labels=[])
 
 from unittest.mock import MagicMock
 
+import numpy
 import pytest
 
 from miles.rollout.generate_utils.sample_utils import _merge_sample_pair
@@ -77,6 +78,26 @@ class TestMergeSamples:
         assert "response1" in merged.response
         assert "response2" in merged.response
         assert "<decoded:[20, 21]>" in merged.response
+
+    def test_merge_preserves_indexer_topk_from_final_sample(self, mock_tokenizer):
+        a = make_sample(
+            tokens=[1, 2, 10],
+            response_length=1,
+            loss_mask=[1],
+            rollout_log_probs=[-0.1],
+        )
+        b = make_sample(
+            tokens=[1, 2, 10, 20, 30],
+            response_length=1,
+            loss_mask=[1],
+            rollout_log_probs=[-0.2],
+        )
+        a.rollout_indexer_topk = numpy.zeros((2, 2, 3), dtype=numpy.int32)
+        b.rollout_indexer_topk = numpy.ones((4, 2, 3), dtype=numpy.int32)
+
+        merged = _merge_sample_pair(a, b, mock_tokenizer)
+
+        numpy.testing.assert_array_equal(merged.rollout_indexer_topk, b.rollout_indexer_topk)
 
     def test_loss_mask_none_defaults_to_all_ones(self, mock_tokenizer):
         a = make_sample(

--- a/tests/fast/utils/test_replay_base.py
+++ b/tests/fast/utils/test_replay_base.py
@@ -1,0 +1,58 @@
+from tests.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=60, suite="stage-a-cpu", labels=[])
+
+import pytest
+import torch
+
+from miles.utils.replay_base import BaseReplayManager
+
+
+class _FakeReplay:
+    def __init__(self, *top_indices):
+        self.top_indices = list(top_indices)
+
+    def pop_forward(self):
+        return self.top_indices.pop(0)
+
+    def pop_backward(self):
+        return self.pop_forward()
+
+
+def _topk(scores, topk):
+    return torch.topk(scores, topk, dim=1).indices.to(torch.int32)
+
+
+def _make_replay_manager(top_indices):
+    manager = BaseReplayManager()
+    manager.enable_check_replay_result = False
+    manager.enabled = True
+    manager.stage = "replay_forward"
+    manager.set_current(_FakeReplay(top_indices))
+    return manager
+
+
+def test_get_topk_fn_fills_invalid_indices_with_arange_by_default():
+    scores = torch.arange(5, dtype=torch.float32).unsqueeze(0)
+    manager = _make_replay_manager(torch.tensor([[2, -1, -1]], dtype=torch.int32))
+
+    topk_fn = manager.get_topk_fn(_topk, return_probs=False)
+
+    torch.testing.assert_close(topk_fn(scores, 3), torch.tensor([[2, 0, 1]], dtype=torch.int32))
+
+
+def test_get_topk_fn_can_preserve_invalid_indices():
+    scores = torch.arange(5, dtype=torch.float32).unsqueeze(0)
+    replayed_top_indices = torch.tensor([[2, -1, -1]], dtype=torch.int32)
+    manager = _make_replay_manager(replayed_top_indices)
+
+    topk_fn = manager.get_topk_fn(_topk, return_probs=False, fill_padding_with_arange=False)
+
+    torch.testing.assert_close(topk_fn(scores, 3), replayed_top_indices)
+
+
+def test_get_topk_fn_rejects_preserving_invalid_indices_with_return_probs():
+    manager = BaseReplayManager()
+
+    with pytest.raises(ValueError, match="fill_padding_with_arange=False"):
+        manager.get_topk_fn(_topk, return_probs=True, fill_padding_with_arange=False)

--- a/tests/fast/utils/test_types.py
+++ b/tests/fast/utils/test_types.py
@@ -20,6 +20,7 @@ def _make_sample(
     log_probs: bool = False,
     loss_mask: bool = False,
     routed_experts: bool = False,
+    indexer_topk: bool = False,
 ) -> Sample:
     """Create a Sample with the given prompt + response token IDs."""
     tokens = prompt_ids + response_ids
@@ -35,6 +36,9 @@ def _make_sample(
     if routed_experts:
         # shape: (num_tokens - 1, ...)
         s.rollout_routed_experts = numpy.zeros((len(tokens) - 1, 2, 2), dtype=numpy.int32)
+    if indexer_topk:
+        # shape: (num_tokens - 1, ...)
+        s.rollout_indexer_topk = numpy.zeros((len(tokens) - 1, 2, 3), dtype=numpy.int32)
     return s
 
 
@@ -88,6 +92,12 @@ class TestStripLastOutputTokens:
         original_len = len(s.rollout_routed_experts)
         s.strip_last_output_tokens(2, tokenizer)
         assert len(s.rollout_routed_experts) == original_len - 2
+
+    def test_strip_truncates_indexer_topk(self, tokenizer):
+        s = _make_sample([1, 2], [3, 4, 5], indexer_topk=True)
+        original_len = len(s.rollout_indexer_topk)
+        s.strip_last_output_tokens(2, tokenizer)
+        assert len(s.rollout_indexer_topk) == original_len - 2
 
     def test_strip_updates_response_text(self, tokenizer):
         s = _make_sample([1, 2], [3, 4, 5])


### PR DESCRIPTION
## Summary
- Add a generic `IndexerReplayManager` and sequential replay registration for indexer top-k streams.
- Thread `indexer_topk` through SGLang rollout/session/OpenAI response handling and training data plumbing.
- Add generic rollout indexer replay shape args without DeepSeek-V4-specific fallbacks.

## Tests
- `python -m compileall miles tests/fast/rollout/generate_utils/test_indexer_replay.py tests/fast/backends/megatron_utils/test_replay_utils.py`
- `uvx ruff check ...` on touched files
- `uvx black --check ...` on touched files
- `python -m pytest --confcutdir=tests/fast/rollout/generate_utils tests/fast/rollout/generate_utils/test_indexer_replay.py tests/fast/rollout/generate_utils/test_sample_utils.py tests/fast/rollout/generate_utils/test_openai_endpoint_utils.py -k 'not test_create_fetches_session_server_instance_id'`
- `python -m pytest --confcutdir=tests/fast/backends/megatron_utils tests/fast/backends/megatron_utils/test_replay_utils.py`
- `python -m pytest --confcutdir=tests/fast/utils tests/fast/utils/test_types.py`