### PR TITLE
fix GLM-5 training script + dsv32/glm-5 config

### DIFF
--- a/miles/backends/megatron_utils/megatron_to_hf/__init__.py
+++ b/miles/backends/megatron_utils/megatron_to_hf/__init__.py
@@ -32,7 +32,13 @@ _cached_tensors = {}
 
 # TODO optimize code details
 def _convert_to_hf_core(args, model_name, name, param):
-    if "glm4moelite" in model_name or "deepseekv3" in model_name:
+    model_name = model_name.lower()
+    if (
+        "glm4moelite" in model_name
+        or "deepseekv3" in model_name
+        or "glmmoedsa" in model_name
+        or "glm_moe_dsa" in model_name
+    ):
         converted_named_tensors = convert_deepseekv3_to_hf(args, name, param)
     elif "glm4moe" in model_name:
         converted_named_tensors = convert_glm4moe_to_hf(args, name, param)

--- a/miles_plugins/mbridge/deepseek_v32.py
+++ b/miles_plugins/mbridge/deepseek_v32.py
@@ -1,4 +1,5 @@
 import copy
+from contextlib import contextmanager
 
 import torch
 
@@ -17,30 +18,45 @@ class DeepseekV32Bridge(DeepseekV3Bridge):
     }
     _ATTENTION_MAPPING = {**DeepseekV3Bridge._ATTENTION_MAPPING, **_DSA_ATTENTION_MAPPING}
 
-    @property
-    def rope_theta(self):
+    def _get_rope_theta(self):
         return self.hf_config.rope_theta
 
-    def _hf_config_with_rope_theta(self):
+    def _normalize_rope_scaling(self, rope_scaling):
+        if rope_scaling is None:
+            return None
+        rope_scaling = dict(rope_scaling)
+        rope_type = rope_scaling.get("type") or rope_scaling.get("rope_type")
+        if rope_type == "default":
+            return None
+        if rope_type is not None:
+            rope_scaling["type"] = rope_type
+        return rope_scaling
+
+    def _get_rope_scaling(self):
+        return self._normalize_rope_scaling(getattr(self.hf_config, "rope_scaling", None))
+
+    def _hf_config_with_rope_fields(self):
         hf_config = copy.copy(self.hf_config)
-        hf_config.rope_theta = self.rope_theta
+        hf_config.rope_theta = self._get_rope_theta()
+        hf_config.rope_scaling = self._get_rope_scaling()
         return hf_config
 
-    def _build_config(self):
+    @contextmanager
+    def _using_hf_config_with_rope_fields(self):
         original_hf_config = self.hf_config
-        self.hf_config = self._hf_config_with_rope_theta()
+        self.hf_config = self._hf_config_with_rope_fields()
         try:
-            return super()._build_config()
+            yield
         finally:
             self.hf_config = original_hf_config
 
+    def _build_config(self):
+        with self._using_hf_config_with_rope_fields():
+            return super()._build_config()
+
     def _get_gptmodel_args(self) -> dict:
-        original_hf_config = self.hf_config
-        self.hf_config = self._hf_config_with_rope_theta()
-        try:
+        with self._using_hf_config_with_rope_fields():
             return super()._get_gptmodel_args()
-        finally:
-            self.hf_config = original_hf_config
 
     def _weight_to_hf_format(
         self, mcore_weights_name: str, mcore_weights: torch.Tensor
@@ -100,6 +116,8 @@ class DeepseekV32Bridge(DeepseekV3Bridge):
 
 @register_model("glm_moe_dsa")
 class GlmMoeDsaBridge(DeepseekV32Bridge):
-    @property
-    def rope_theta(self):
+    def _get_rope_theta(self):
         return self.hf_config.rope_parameters["rope_theta"]
+
+    def _get_rope_scaling(self):
+        return self._normalize_rope_scaling(self.hf_config.rope_parameters)

--- a/miles_plugins/mbridge/deepseek_v32.py
+++ b/miles_plugins/mbridge/deepseek_v32.py
@@ -1,3 +1,5 @@
+import copy
+
 import torch
 
 from mbridge.core import register_model
@@ -14,6 +16,31 @@ class DeepseekV32Bridge(DeepseekV3Bridge):
         "self_attention.k_norm.bias": ["model.layers.{layer_number}.self_attn.indexer.k_norm.bias"],
     }
     _ATTENTION_MAPPING = {**DeepseekV3Bridge._ATTENTION_MAPPING, **_DSA_ATTENTION_MAPPING}
+
+    @property
+    def rope_theta(self):
+        return self.hf_config.rope_theta
+
+    def _hf_config_with_rope_theta(self):
+        hf_config = copy.copy(self.hf_config)
+        hf_config.rope_theta = self.rope_theta
+        return hf_config
+
+    def _build_config(self):
+        original_hf_config = self.hf_config
+        self.hf_config = self._hf_config_with_rope_theta()
+        try:
+            return super()._build_config()
+        finally:
+            self.hf_config = original_hf_config
+
+    def _get_gptmodel_args(self) -> dict:
+        original_hf_config = self.hf_config
+        self.hf_config = self._hf_config_with_rope_theta()
+        try:
+            return super()._get_gptmodel_args()
+        finally:
+            self.hf_config = original_hf_config
 
     def _weight_to_hf_format(
         self, mcore_weights_name: str, mcore_weights: torch.Tensor
@@ -73,4 +100,6 @@ class DeepseekV32Bridge(DeepseekV3Bridge):
 
 @register_model("glm_moe_dsa")
 class GlmMoeDsaBridge(DeepseekV32Bridge):
-    pass
+    @property
+    def rope_theta(self):
+        return self.hf_config.rope_parameters["rope_theta"]

--- a/scripts/run_glm5_744b_a40b.py
+++ b/scripts/run_glm5_744b_a40b.py
@@ -66,6 +66,7 @@ import miles.utils.external_utils.command_utils as U
 
 app = typer.Typer()
 
+
 @dataclass
 class ScriptArgs(U.ExecuteTrainConfig):
     mode: Literal["normal", "debug_minimal"] = "normal"

--- a/scripts/run_glm5_744b_a40b.py
+++ b/scripts/run_glm5_744b_a40b.py
@@ -32,7 +32,6 @@ Args:
 =====================
 
 I. Usage for single node minimal test:
-  `ray stop --force && pkill -9 -f sglang || true`
   `python scripts/run_glm5_744b_a40b.py full-train --model-name GLM-5_4layer --num-nodes 1`
 
 =====================
@@ -56,6 +55,7 @@ II. Usage for multi node (20 layers, 6 nodes as an example):
 """
 
 import json
+import os
 import re
 from dataclasses import dataclass
 from pathlib import Path
@@ -66,6 +66,13 @@ import typer
 import miles.utils.external_utils.command_utils as U
 
 app = typer.Typer()
+
+_CUDA13_LIB_PATH = "/usr/local/lib/python3.12/dist-packages/nvidia/cu13/lib"
+
+
+def _prepend_env_path(name: str, path: str) -> str:
+    existing = os.environ.get(name)
+    return f"{path}:{existing}" if existing else path
 
 
 @dataclass
@@ -401,6 +408,7 @@ def _execute_train(args: ScriptArgs):
         extra_env_vars={
             **sglang_extra_env_vars,
             "INDEXER_ROPE_NEOX_STYLE": "0",
+            "LD_LIBRARY_PATH": _prepend_env_path("LD_LIBRARY_PATH", _CUDA13_LIB_PATH),
             "NVSHMEM_DISABLE_NCCL": "1",
         },
         megatron_path=args.megatron_path,

--- a/scripts/run_glm5_744b_a40b.py
+++ b/scripts/run_glm5_744b_a40b.py
@@ -55,7 +55,6 @@ II. Usage for multi node (20 layers, 6 nodes as an example):
 """
 
 import json
-import os
 import re
 from dataclasses import dataclass
 from pathlib import Path
@@ -66,14 +65,6 @@ import typer
 import miles.utils.external_utils.command_utils as U
 
 app = typer.Typer()
-
-_CUDA13_LIB_PATH = "/usr/local/lib/python3.12/dist-packages/nvidia/cu13/lib"
-
-
-def _prepend_env_path(name: str, path: str) -> str:
-    existing = os.environ.get(name)
-    return f"{path}:{existing}" if existing else path
-
 
 @dataclass
 class ScriptArgs(U.ExecuteTrainConfig):
@@ -406,7 +397,6 @@ def _execute_train(args: ScriptArgs):
         extra_env_vars={
             **sglang_extra_env_vars,
             "INDEXER_ROPE_NEOX_STYLE": "0",
-            "LD_LIBRARY_PATH": _prepend_env_path("LD_LIBRARY_PATH", _CUDA13_LIB_PATH),
             "NVSHMEM_DISABLE_NCCL": "1",
         },
         megatron_path=args.megatron_path,

--- a/scripts/run_glm5_744b_a40b.py
+++ b/scripts/run_glm5_744b_a40b.py
@@ -150,9 +150,7 @@ def _validate_glm_checkpoint(args: ScriptArgs):
             f"and num_hidden_layers={expected_num_layers}"
         )
     if "auto_map" in config:
-        raise RuntimeError(
-            f"{config_path} must not contain auto_map. Try update your checkpoint."
-        )
+        raise RuntimeError(f"{config_path} must not contain auto_map. Try update your checkpoint.")
 
 
 def _convert_to_fp8(args: ScriptArgs):

--- a/scripts/run_glm5_744b_a40b.py
+++ b/scripts/run_glm5_744b_a40b.py
@@ -85,7 +85,7 @@ class ScriptArgs(U.ExecuteTrainConfig):
     extra_args: str = ""
     data_dir: str = "/root/datasets"
     model_dir: str = "/root/models"
-    model_local_dir: str = "/root/local_data"
+    model_local_dir: str = "/root/models"
     megatron_path: str = "/root/Megatron-LM"
     hardware: Literal["H200", "B200", "GB300"] = "H200"
 

--- a/scripts/run_glm5_744b_a40b.py
+++ b/scripts/run_glm5_744b_a40b.py
@@ -86,7 +86,7 @@ class ScriptArgs(U.ExecuteTrainConfig):
     extra_args: str = ""
     data_dir: str = "/root/datasets"
     model_dir: str = "/root/models"
-    model_local_dir: str = "/root/models"
+    model_local_dir: str = "/root/local_data"
     megatron_path: str = "/root/Megatron-LM"
     hardware: Literal["H200", "B200", "GB300"] = "H200"
 
@@ -116,30 +116,46 @@ def _is_pruned(args: ScriptArgs):
     return re.search(r"(\d+)layer", args.model_name) is not None
 
 
-def _process_glm_checkpoint(args: ScriptArgs):
-    """Patch config.json to use DeepseekV32 architecture if not already patched."""
+def _validate_glm_checkpoint(args: ScriptArgs):
+    """Validate GLM-5 checkpoint config expected by current Miles/SGLang support."""
     config_path = Path(args.model_dir) / args.model_name / "config.json"
     if not config_path.exists():
-        print(f"Warning: {config_path} not found, skipping checkpoint processing")
+        print(f"Warning: {config_path} not found, skipping checkpoint validation")
         return
 
     with open(config_path) as f:
         config = json.load(f)
 
-    if config.get("model_type") == "deepseek_v32":
-        print("Checkpoint already patched, skipping")
+    architectures = config.get("architectures") or []
+    if args.model_name == "GLM-5":
+        auto_map = config.get("auto_map") or {}
+        stale_auto_map = any("deepseek_v32" in str(v) or "DeepseekV32" in str(v) for v in auto_map.values())
+        if (
+            config.get("model_type") != "glm_moe_dsa"
+            or "GlmMoeDsaForCausalLM" not in architectures
+            or stale_auto_map
+        ):
+            raise RuntimeError(
+                f"{config_path} is not a native GLM-5 config. Expected model_type=glm_moe_dsa "
+                "and architecture GlmMoeDsaForCausalLM. If this directory was patched by an older "
+                "script, remove it and re-run prepare to download a fresh zai-org/GLM-5 checkpoint."
+            )
+        print("Full GLM-5 checkpoint config is valid")
         return
 
-    config["architectures"] = ["DeepseekV32ForCausalLM"]
-    config["auto_map"] = {
-        "AutoConfig": "configuration_deepseek_v32.DeepseekV32Config",
-        "AutoModelForCausalLM": "modeling_deepseek_v32.DeepseekV32ForCausalLM",
-    }
-    config["model_type"] = "deepseek_v32"
+    if config.get("model_type") != "deepseek_v32" or "DeepseekV32ForCausalLM" not in architectures:
+        raise RuntimeError(
+            f"{config_path} is not a supported pruned GLM-5 config. Expected model_type=deepseek_v32 "
+            "and architecture DeepseekV32ForCausalLM."
+        )
 
-    with open(config_path, "w") as f:
-        json.dump(config, f, indent=2, ensure_ascii=False)
-    print(f"Patched {config_path}")
+    required_remote_code = ["configuration_deepseek_v32.py", "modeling_deepseek_v32.py"]
+    missing_remote_code = [name for name in required_remote_code if not (config_path.parent / name).exists()]
+    if missing_remote_code:
+        raise RuntimeError(
+            f"{config_path} references deepseek_v32 but is missing remote-code files: {', '.join(missing_remote_code)}"
+        )
+    print("Pruned GLM-5 checkpoint config is valid")
 
 
 def _convert_to_fp8(args: ScriptArgs):
@@ -155,7 +171,6 @@ def _convert_to_fp8(args: ScriptArgs):
 
 def _prepare_download(args: ScriptArgs):
     U.exec_command(f"mkdir -p {args.model_dir} {args.data_dir}")
-    # Skip model download for pruned variants (assumed to already exist in model_dir)
     U.exec_command(f"hf download {args.model_org}/{args.model_name} --local-dir {args.model_dir}/{args.model_name}")
     U.hf_download_dataset("zhuzilin/dapo-math-17k", data_dir=args.data_dir)
 
@@ -339,11 +354,8 @@ def _execute_train(args: ScriptArgs):
     if args.enable_pd:
         sglang_args += "--prefill-num-servers 1 "
     sglang_args += (
-        # dsa
+        # GLM-5/DSA uses SGLang's native NSA path; backend selection is hardware-aware.
         "--sglang-page-size 64 "
-        "--sglang-nsa-decode-backend flashmla_sparse "
-        "--sglang-nsa-prefill-backend flashmla_sparse "
-        "--sglang-attention-backend nsa "
         f"--sglang-cuda-graph-max-bs {sglang_decode_max_bs} "
         # concurrency
         f"--sglang-max-running-requests 512 "
@@ -410,7 +422,7 @@ def _execute_train(args: ScriptArgs):
 def full_train(args: ScriptArgs):
     """Full pipeline: download, convert, copy, train."""
     _prepare_download(args)
-    _process_glm_checkpoint(args)
+    _validate_glm_checkpoint(args)
     if args.fp8_rollout:
         _convert_to_fp8(args)
     _prepare_megatron_ckpt(args)
@@ -423,7 +435,7 @@ def full_train(args: ScriptArgs):
 def prepare(args: ScriptArgs):
     """Download model/data and convert to megatron checkpoint (run on head node)."""
     _prepare_download(args)
-    _process_glm_checkpoint(args)
+    _validate_glm_checkpoint(args)
     if args.fp8_rollout:
         _convert_to_fp8(args)
     _prepare_megatron_ckpt(args)

--- a/scripts/run_glm5_744b_a40b.py
+++ b/scripts/run_glm5_744b_a40b.py
@@ -117,81 +117,39 @@ def _is_pruned(args: ScriptArgs):
 
 
 def _validate_glm_checkpoint(args: ScriptArgs):
-    """Validate that the checkpoint uses the native GLM-5 HF layout."""
-    checkpoint_dir = Path(args.model_dir) / args.model_name
-    config_path = checkpoint_dir / "config.json"
+    """Validate the basic native GLM-5 config fields."""
+    config_path = Path(args.model_dir) / args.model_name / "config.json"
     if not config_path.exists():
         raise FileNotFoundError(f"{config_path} not found")
 
     with open(config_path) as f:
         config = json.load(f)
 
-    architectures = config.get("architectures") or []
-    if config.get("model_type") != "glm_moe_dsa" or architectures != ["GlmMoeDsaForCausalLM"]:
-        raise RuntimeError(
-            f"{config_path} must use the native GLM-5 config: model_type=glm_moe_dsa "
-            "and architectures=[GlmMoeDsaForCausalLM]."
-        )
-
-    if "auto_map" in config:
-        raise RuntimeError(f"{config_path} must not contain auto_map; GLM-5 should not require remote code")
-
-    stale_remote_code = ["configuration_deepseek_v32.py", "modeling_deepseek_v32.py"]
-    stale_files = [name for name in stale_remote_code if (checkpoint_dir / name).exists()]
-    if stale_files:
-        raise RuntimeError(f"{checkpoint_dir} contains stale DeepseekV32 remote-code files: {', '.join(stale_files)}")
-
     if args.model_name == "GLM-5":
         expected_num_layers = 78
+        expected_nextn_layers = 1
     elif (m := re.search(r"(\d+)layer", args.model_name)) is not None:
         expected_num_layers = int(m.group(1))
+        expected_nextn_layers = 0
     else:
         raise NotImplementedError(f"{args.model_name} is not supported")
 
-    if config.get("num_hidden_layers") != expected_num_layers:
+    expected_fields = {
+        "model_type": "glm_moe_dsa",
+        "architectures": ["GlmMoeDsaForCausalLM"],
+        "num_hidden_layers": expected_num_layers,
+        "num_nextn_predict_layers": expected_nextn_layers,
+    }
+    mismatches = {
+        key: (config.get(key), expected)
+        for key, expected in expected_fields.items()
+        if config.get(key) != expected
+    }
+    if mismatches:
+        raise RuntimeError(f"{config_path} has invalid GLM-5 config fields: {mismatches}")
+    if "auto_map" in config:
         raise RuntimeError(
-            f"{config_path} has num_hidden_layers={config.get('num_hidden_layers')}, "
-            f"expected {expected_num_layers} for {args.model_name}"
-        )
-
-    required_files = [
-        "chat_template.jinja",
-        "generation_config.json",
-        "model.safetensors.index.json",
-        "tokenizer.json",
-        "tokenizer_config.json",
-    ]
-    missing_files = [name for name in required_files if not (checkpoint_dir / name).exists()]
-    if missing_files:
-        raise FileNotFoundError(f"{checkpoint_dir} is missing required files: {', '.join(missing_files)}")
-
-    index_path = checkpoint_dir / "model.safetensors.index.json"
-    with open(index_path) as f:
-        weight_map = json.load(f)["weight_map"]
-
-    missing_shards = sorted({shard for shard in weight_map.values() if not (checkpoint_dir / shard).exists()})
-    if missing_shards:
-        raise FileNotFoundError(f"{checkpoint_dir} is missing safetensor shards: {', '.join(missing_shards)}")
-
-    layer_ids = sorted(
-        {
-            int(match.group(1))
-            for key in weight_map
-            if (match := re.search(r"model\.layers\.(\d+)\.", key)) is not None
-        }
-    )
-    expected_main_layers = set(range(expected_num_layers))
-    missing_layers = sorted(expected_main_layers - set(layer_ids))
-    if missing_layers:
-        raise RuntimeError(f"{index_path} is missing model layers: {missing_layers}")
-
-    num_nextn_layers = int(config.get("num_nextn_predict_layers") or 0)
-    expected_extra_layers = set(range(expected_num_layers, expected_num_layers + num_nextn_layers))
-    actual_extra_layers = {layer_id for layer_id in layer_ids if layer_id >= expected_num_layers}
-    if actual_extra_layers != expected_extra_layers:
-        raise RuntimeError(
-            f"{index_path} has extra layer ids {sorted(actual_extra_layers)}, "
-            f"but num_nextn_predict_layers={num_nextn_layers} expects {sorted(expected_extra_layers)}"
+            f"{config_path} must not contain auto_map; native GLM-5 does not require remote code"
         )
 
     print(f"{args.model_name} checkpoint config is valid")

--- a/scripts/run_glm5_744b_a40b.py
+++ b/scripts/run_glm5_744b_a40b.py
@@ -340,7 +340,10 @@ def _execute_train(args: ScriptArgs):
     if args.enable_pd:
         sglang_args += "--prefill-num-servers 1 "
     sglang_args += (
-        # GLM-5/DSA uses SGLang's native NSA path; backend selection is hardware-aware.
+        # use flashmla backend for better precision
+        "--sglang-nsa-decode-backend flashmla_sparse "
+        "--sglang-nsa-prefill-backend flashmla_sparse "
+        "--sglang-attention-backend nsa "
         "--sglang-page-size 64 "
         f"--sglang-cuda-graph-max-bs {sglang_decode_max_bs} "
         # concurrency

--- a/scripts/run_glm5_744b_a40b.py
+++ b/scripts/run_glm5_744b_a40b.py
@@ -32,7 +32,7 @@ Args:
 =====================
 
 I. Usage for single node minimal test:
-  `ray stop --force && pkill -9 -f sglang || true && sleep 3 && ray start --head --port=6378 --dashboard-port=8266`
+  `ray stop --force && pkill -9 -f sglang || true`
   `python scripts/run_glm5_744b_a40b.py full-train --model-name GLM-5_4layer --num-nodes 1`
 
 =====================
@@ -127,32 +127,25 @@ def _validate_glm_checkpoint(args: ScriptArgs):
 
     if args.model_name == "GLM-5":
         expected_num_layers = 78
-        expected_nextn_layers = 1
     elif (m := re.search(r"(\d+)layer", args.model_name)) is not None:
         expected_num_layers = int(m.group(1))
-        expected_nextn_layers = 0
     else:
         raise NotImplementedError(f"{args.model_name} is not supported")
 
-    expected_fields = {
-        "model_type": "glm_moe_dsa",
-        "architectures": ["GlmMoeDsaForCausalLM"],
-        "num_hidden_layers": expected_num_layers,
-        "num_nextn_predict_layers": expected_nextn_layers,
-    }
-    mismatches = {
-        key: (config.get(key), expected)
-        for key, expected in expected_fields.items()
-        if config.get(key) != expected
-    }
-    if mismatches:
-        raise RuntimeError(f"{config_path} has invalid GLM-5 config fields: {mismatches}")
+    if (
+        config.get("model_type") != "glm_moe_dsa"
+        or config.get("architectures") != ["GlmMoeDsaForCausalLM"]
+        or config.get("num_hidden_layers") != expected_num_layers
+    ):
+        raise RuntimeError(
+            f"{config_path} must use native GLM-5 config with "
+            f"model_type=glm_moe_dsa, architectures=[GlmMoeDsaForCausalLM], "
+            f"and num_hidden_layers={expected_num_layers}"
+        )
     if "auto_map" in config:
         raise RuntimeError(
-            f"{config_path} must not contain auto_map; native GLM-5 does not require remote code"
+            f"{config_path} must not contain auto_map. Try update your checkpoint."
         )
-
-    print(f"{args.model_name} checkpoint config is valid")
 
 
 def _convert_to_fp8(args: ScriptArgs):

--- a/scripts/run_glm5_744b_a40b.py
+++ b/scripts/run_glm5_744b_a40b.py
@@ -43,7 +43,7 @@ II. Usage for multi node (20 layers, 6 nodes as an example):
 
   2. Start Ray cluster on all nodes
 
-  3. Download model/data + patch checkpoint + convert to megatron.
+  3. Download model/data + validate checkpoint + convert to megatron.
      Run on **head node**; megatron conversion uses Ray to coordinate multi-node work.
        `python scripts/run_glm5_744b_a40b.py prepare --model-name GLM-5_20layer --num-nodes 6`
 
@@ -117,45 +117,84 @@ def _is_pruned(args: ScriptArgs):
 
 
 def _validate_glm_checkpoint(args: ScriptArgs):
-    """Validate GLM-5 checkpoint config expected by current Miles/SGLang support."""
-    config_path = Path(args.model_dir) / args.model_name / "config.json"
+    """Validate that the checkpoint uses the native GLM-5 HF layout."""
+    checkpoint_dir = Path(args.model_dir) / args.model_name
+    config_path = checkpoint_dir / "config.json"
     if not config_path.exists():
-        print(f"Warning: {config_path} not found, skipping checkpoint validation")
-        return
+        raise FileNotFoundError(f"{config_path} not found")
 
     with open(config_path) as f:
         config = json.load(f)
 
     architectures = config.get("architectures") or []
+    if config.get("model_type") != "glm_moe_dsa" or architectures != ["GlmMoeDsaForCausalLM"]:
+        raise RuntimeError(
+            f"{config_path} must use the native GLM-5 config: model_type=glm_moe_dsa "
+            "and architectures=[GlmMoeDsaForCausalLM]."
+        )
+
+    if "auto_map" in config:
+        raise RuntimeError(f"{config_path} must not contain auto_map; GLM-5 should not require remote code")
+
+    stale_remote_code = ["configuration_deepseek_v32.py", "modeling_deepseek_v32.py"]
+    stale_files = [name for name in stale_remote_code if (checkpoint_dir / name).exists()]
+    if stale_files:
+        raise RuntimeError(f"{checkpoint_dir} contains stale DeepseekV32 remote-code files: {', '.join(stale_files)}")
+
     if args.model_name == "GLM-5":
-        auto_map = config.get("auto_map") or {}
-        stale_auto_map = any("deepseek_v32" in str(v) or "DeepseekV32" in str(v) for v in auto_map.values())
-        if (
-            config.get("model_type") != "glm_moe_dsa"
-            or "GlmMoeDsaForCausalLM" not in architectures
-            or stale_auto_map
-        ):
-            raise RuntimeError(
-                f"{config_path} is not a native GLM-5 config. Expected model_type=glm_moe_dsa "
-                "and architecture GlmMoeDsaForCausalLM. If this directory was patched by an older "
-                "script, remove it and re-run prepare to download a fresh zai-org/GLM-5 checkpoint."
-            )
-        print("Full GLM-5 checkpoint config is valid")
-        return
+        expected_num_layers = 78
+    elif (m := re.search(r"(\d+)layer", args.model_name)) is not None:
+        expected_num_layers = int(m.group(1))
+    else:
+        raise NotImplementedError(f"{args.model_name} is not supported")
 
-    if config.get("model_type") != "deepseek_v32" or "DeepseekV32ForCausalLM" not in architectures:
+    if config.get("num_hidden_layers") != expected_num_layers:
         raise RuntimeError(
-            f"{config_path} is not a supported pruned GLM-5 config. Expected model_type=deepseek_v32 "
-            "and architecture DeepseekV32ForCausalLM."
+            f"{config_path} has num_hidden_layers={config.get('num_hidden_layers')}, "
+            f"expected {expected_num_layers} for {args.model_name}"
         )
 
-    required_remote_code = ["configuration_deepseek_v32.py", "modeling_deepseek_v32.py"]
-    missing_remote_code = [name for name in required_remote_code if not (config_path.parent / name).exists()]
-    if missing_remote_code:
+    required_files = [
+        "chat_template.jinja",
+        "generation_config.json",
+        "model.safetensors.index.json",
+        "tokenizer.json",
+        "tokenizer_config.json",
+    ]
+    missing_files = [name for name in required_files if not (checkpoint_dir / name).exists()]
+    if missing_files:
+        raise FileNotFoundError(f"{checkpoint_dir} is missing required files: {', '.join(missing_files)}")
+
+    index_path = checkpoint_dir / "model.safetensors.index.json"
+    with open(index_path) as f:
+        weight_map = json.load(f)["weight_map"]
+
+    missing_shards = sorted({shard for shard in weight_map.values() if not (checkpoint_dir / shard).exists()})
+    if missing_shards:
+        raise FileNotFoundError(f"{checkpoint_dir} is missing safetensor shards: {', '.join(missing_shards)}")
+
+    layer_ids = sorted(
+        {
+            int(match.group(1))
+            for key in weight_map
+            if (match := re.search(r"model\.layers\.(\d+)\.", key)) is not None
+        }
+    )
+    expected_main_layers = set(range(expected_num_layers))
+    missing_layers = sorted(expected_main_layers - set(layer_ids))
+    if missing_layers:
+        raise RuntimeError(f"{index_path} is missing model layers: {missing_layers}")
+
+    num_nextn_layers = int(config.get("num_nextn_predict_layers") or 0)
+    expected_extra_layers = set(range(expected_num_layers, expected_num_layers + num_nextn_layers))
+    actual_extra_layers = {layer_id for layer_id in layer_ids if layer_id >= expected_num_layers}
+    if actual_extra_layers != expected_extra_layers:
         raise RuntimeError(
-            f"{config_path} references deepseek_v32 but is missing remote-code files: {', '.join(missing_remote_code)}"
+            f"{index_path} has extra layer ids {sorted(actual_extra_layers)}, "
+            f"but num_nextn_predict_layers={num_nextn_layers} expects {sorted(expected_extra_layers)}"
         )
-    print("Pruned GLM-5 checkpoint config is valid")
+
+    print(f"{args.model_name} checkpoint config is valid")
 
 
 def _convert_to_fp8(args: ScriptArgs):


### PR DESCRIPTION
## Summary

- stop patching full GLM-5 checkpoints to the stale DeepseekV32 config
- validate full GLM-5 native glm_moe_dsa config and pruned DeepseekV32 configs before conversion
- let SGLang pick the hardware-aware NSA backend instead of forcing flashmla_sparse
- use /root/local_data as the default node-local model copy directory

## Root Cause

The training script still carried compatibility code from before Miles and SGLang supported the official GLM-5 glm_moe_dsa config. That code rewrote the full zai-org/GLM-5 config to DeepseekV32 and added an auto_map that points to remote-code files that the official checkpoint does not provide.

## Validation

- python -m py_compile miles/scripts/run_glm5_744b_a40b.py
- temporary config smoke test covering native full GLM-5, stale full config failure, pruned DeepseekV32 success, and missing pruned remote-code failure
