### PR TITLE
Guard zero rollout temperature logprob scaling

### DIFF
--- a/miles/backends/training_utils/loss_hub/logit_processors.py
+++ b/miles/backends/training_utils/loss_hub/logit_processors.py
@@ -51,7 +51,8 @@ def get_responses(
         assert max_seq_lens is not None
         logits = logits.view(-1, logits.size(-1))
 
-    logits = logits.div(args.rollout_temperature)
+    if args.rollout_temperature > 0:
+        logits = logits.div(args.rollout_temperature)
     if args.true_on_policy_mode:
         if getattr(args, "bf16", False):
             logits = logits.to(torch.bfloat16)

--- a/miles/backends/training_utils/loss_hub/logit_processors.py
+++ b/miles/backends/training_utils/loss_hub/logit_processors.py
@@ -51,7 +51,7 @@ def get_responses(
         assert max_seq_lens is not None
         logits = logits.view(-1, logits.size(-1))
 
-    if args.rollout_temperature > 0:
+    if logits.size(-1) > 1 and args.rollout_temperature > 0 and args.rollout_temperature != 1.0:
         logits = logits.div(args.rollout_temperature)
     if args.true_on_policy_mode:
         if getattr(args, "bf16", False):


### PR DESCRIPTION
## Summary

- Avoid dividing logits by `rollout_temperature` when the configured temperature is `0`.
- Preserve existing temperature scaling for positive rollout temperatures.

## Why

Greedy rollout can use `rollout_temperature=0`. The training-side logprob path previously divided logits by zero in that case, producing non-finite values and downstream backward NaNs.

## Validation

- `python -m py_compile miles/backends/training_utils/loss_hub/logit_processors.py`
- `git diff --check`