### PR TITLE
[CI] Add GLM-5 4-layer CI e2e test + model-scripts test suite

### DIFF
--- a/scripts/run_glm5_744b_a40b.py
+++ b/scripts/run_glm5_744b_a40b.py
@@ -82,6 +82,7 @@ class ScriptArgs(U.ExecuteTrainConfig):
     enable_mtp: bool = False
     enable_pd: bool = True
     enable_optimizer_offload: bool = False
+    num_rollout: int = 3000
     extra_args: str = ""
     data_dir: str = "/root/datasets"
     model_dir: str = "/root/models"
@@ -230,7 +231,7 @@ def _execute_train(args: ScriptArgs):
         "--apply-chat-template "
         "--rollout-shuffle "
         "--rm-type deepscaler "
-        "--num-rollout 3000 "
+        f"--num-rollout {args.num_rollout} "
         "--rollout-batch-size 8 "
         "--n-samples-per-prompt 8 "
         f"--rollout-max-response-len {100 if args.mode == 'debug_minimal' else 32768} "

--- a/tests/ci/labels.py
+++ b/tests/ci/labels.py
@@ -18,6 +18,7 @@ here: they bypass the per-test labels filter and run the full suite via the
 
 KNOWN_LABELS: dict[str, str] = {
     "megatron": "Megatron-LM training tests",
+    "model-scripts": "Model launch script smoke tests",
     "sglang": "SGLang patch / equivalence tests",
     "fsdp": "FSDP training tests",
     "short": "Short 8-GPU smoke tests",

--- a/tests/ci/test_labels.py
+++ b/tests/ci/test_labels.py
@@ -7,9 +7,10 @@ def test_known_labels_is_dict():
     assert isinstance(KNOWN_LABELS, dict)
 
 
-def test_known_labels_initial_eight_present():
+def test_known_labels_initial_labels_present():
     expected = {
         "megatron",
+        "model-scripts",
         "sglang",
         "fsdp",
         "short",

--- a/tests/e2e/megatron/test_glm5_744b_a40b_4layer_ci.py
+++ b/tests/e2e/megatron/test_glm5_744b_a40b_4layer_ci.py
@@ -23,6 +23,7 @@ def _args() -> ScriptArgs:
         model_name="GLM-5_4layer",
         num_nodes=1,
         num_gpus_per_node=8,
+        num_rollout=2,
         extra_args=(
             "--ci-test "
             "--ci-disable-logprobs-checker "

--- a/tests/e2e/megatron/test_glm5_744b_a40b_4layer_ci.py
+++ b/tests/e2e/megatron/test_glm5_744b_a40b_4layer_ci.py
@@ -1,0 +1,51 @@
+import os
+
+from scripts.run_glm5_744b_a40b import (
+    ScriptArgs,
+    _convert_to_fp8,
+    _execute_train,
+    _prepare_download,
+    _prepare_megatron_ckpt,
+    _validate_glm_checkpoint,
+)
+from tests.ci.ci_register import register_cuda_ci
+
+import miles.utils.external_utils.command_utils as U
+
+
+register_cuda_ci(est_time=1800, suite="stage-c-8-gpu-h100", labels=["megatron"])
+
+
+def _args() -> ScriptArgs:
+    return ScriptArgs(
+        model_name="GLM-5_4layer",
+        num_nodes=1,
+        num_gpus_per_node=8,
+        extra_args=(
+            "--ci-test "
+            "--ci-disable-logprobs-checker "
+            "--dump-details /root/shared_data/dump_details "
+            "--disable-weights-backuper "
+        ),
+    )
+
+
+def prepare(args: ScriptArgs):
+    U.exec_command(f"mkdir -p {args.output_dir}")
+    _prepare_download(args)
+    _validate_glm_checkpoint(args)
+    if args.fp8_rollout:
+        _convert_to_fp8(args)
+    _prepare_megatron_ckpt(args)
+
+
+def execute(args: ScriptArgs):
+    _execute_train(args)
+
+
+if __name__ == "__main__":
+    args = _args()
+    prepare(args)
+    for proxy_var in ("http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY"):
+        os.environ.pop(proxy_var, None)
+    execute(args)

--- a/tests/e2e/megatron/test_glm5_744b_a40b_4layer_ci.py
+++ b/tests/e2e/megatron/test_glm5_744b_a40b_4layer_ci.py
@@ -15,7 +15,7 @@ from tests.ci.ci_register import register_cuda_ci
 import miles.utils.external_utils.command_utils as U
 
 
-register_cuda_ci(est_time=1800, suite="stage-c-8-gpu-h100", labels=["megatron"])
+register_cuda_ci(est_time=1800, suite="stage-c-8-gpu-h100", labels=["model-scripts"])
 
 
 def _args() -> ScriptArgs:

--- a/tests/e2e/megatron/test_glm5_744b_a40b_4layer_ci.py
+++ b/tests/e2e/megatron/test_glm5_744b_a40b_4layer_ci.py
@@ -1,7 +1,5 @@
 import os
 
-# This CI test is an example smoke test for the DSA model code path used by DeepSeek V3.2 and GLM-5. It only verifies that the training script is functional, not model accuracy.
-
 from scripts.run_glm5_744b_a40b import (
     ScriptArgs,
     _convert_to_fp8,
@@ -13,6 +11,8 @@ from scripts.run_glm5_744b_a40b import (
 from tests.ci.ci_register import register_cuda_ci
 
 import miles.utils.external_utils.command_utils as U
+
+# This CI test is an example smoke test for the DSA model code path used by DeepSeek V3.2 and GLM-5. It only verifies that the training script is functional, not model accuracy.
 
 
 register_cuda_ci(est_time=1800, suite="stage-c-8-gpu-h100", labels=["model-scripts"])

--- a/tests/e2e/megatron/test_glm5_744b_a40b_4layer_ci.py
+++ b/tests/e2e/megatron/test_glm5_744b_a40b_4layer_ci.py
@@ -24,12 +24,7 @@ def _args() -> ScriptArgs:
         num_nodes=1,
         num_gpus_per_node=8,
         num_rollout=2,
-        extra_args=(
-            "--ci-test "
-            "--ci-disable-logprobs-checker "
-            "--dump-details /root/shared_data/dump_details "
-            "--disable-weights-backuper "
-        ),
+        extra_args=("--ci-test " "--ci-disable-logprobs-checker " "--disable-weights-backuper "),
     )
 
 

--- a/tests/e2e/megatron/test_glm5_744b_a40b_4layer_ci.py
+++ b/tests/e2e/megatron/test_glm5_744b_a40b_4layer_ci.py
@@ -1,5 +1,7 @@
 import os
 
+# This CI test is an example smoke test for the DSA model code path used by DeepSeek V3.2 and GLM-5. It only verifies that the training script is functional, not model accuracy.
+
 from scripts.run_glm5_744b_a40b import (
     ScriptArgs,
     _convert_to_fp8,


### PR DESCRIPTION
## Summary
- Add a new `model-scripts` CI domain label, triggered by the PR label `run-ci-model-scripts`.
- Add an enabled GLM-5 4-layer model script e2e smoke test under that category.
- Reuse `scripts/run_glm5_744b_a40b.py` prepare/train logic so the CI run stays aligned with the validated GLM-5 4-layer script.
- Keep the test out of `run-ci-megatron`; `run-ci-image` still includes it through `--match-all-labels`.

This CI test is an example smoke test for the DSA model code path used by DeepSeek V3.2 and GLM-5. It verifies that the training script is functional, not model accuracy.

## Validation
- `python -m py_compile tests/e2e/megatron/test_glm5_744b_a40b_4layer_ci.py tests/ci/labels.py tests/ci/test_labels.py`
- `PYTHONPATH=. python -m pytest tests/ci/test_labels.py tests/ci/test_ci_register.py tests/ci/test_run_suite.py -q`
- `PYTHONPATH=. python tests/ci/run_suite.py --hw cuda --suite stage-c-8-gpu-h100 --labels run-ci-model-scripts --list-only`
- `PYTHONPATH=. python tests/ci/run_suite.py --hw cuda --suite stage-c-8-gpu-h100 --labels run-ci-megatron --list-only`
- `PYTHONPATH=. python tests/ci/run_suite.py --hw cuda --suite stage-c-8-gpu-h100 --match-all-labels --list-only`

Note: local `ruff` is not installed in this Python environment, so I did not run ruff locally.
