### PR TITLE
Pin Megatron-Bridge to an exact commit instead of branch=bridge

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,6 +25,12 @@ ARG ENABLE_CUDA_13=0
 ARG WHEELS_REPO=yueming-yuan/miles-wheels
 ARG WHEELS_TAG=cu129-x86_64-v0.5.12
 
+# Pinned commit on the `bridge` branch of radixark/Megatron-Bridge. Bumping this
+# value (and only this value) is the prescribed way to upgrade Megatron-Bridge
+# in the image — every miles commit thereby records exactly which Megatron-Bridge
+# revision it ships against.
+ARG MEGATRON_BRIDGE_SHA=6fde1c8538ea4ad966c7fba5f759be54f943b598
+
 # ======================================== Setup =============================================
 
 WORKDIR /root/
@@ -109,7 +115,7 @@ RUN cd /root/Megatron-LM && pip install -e .
 RUN pip install git+https://github.com/fzyzcjy/torch_memory_saver.git@d64a639 --no-cache-dir --force-reinstall
 # RUN pip install git+https://github.com/fzyzcjy/Megatron-Bridge.git@dev_rl --no-build-isolation
 RUN pip install "nvidia-modelopt[torch]>=0.37.0" --no-build-isolation
-RUN pip install git+https://github.com/radixark/Megatron-Bridge.git@bridge --no-deps --no-build-isolation
+RUN pip install "git+https://github.com/radixark/Megatron-Bridge.git@${MEGATRON_BRIDGE_SHA}" --no-deps --no-build-isolation
 RUN pip install megatron-energon --no-deps
 RUN pip install multi-storage-client --no-deps
 


### PR DESCRIPTION
## Summary
- Add a `MEGATRON_BRIDGE_SHA` build-arg to `docker/Dockerfile` (default = current `bridge` HEAD on `radixark/Megatron-Bridge` = `6fde1c8538ea4ad966c7fba5f759be54f943b598`).
- Change the `pip install` line for Megatron-Bridge from `@bridge` to `@${MEGATRON_BRIDGE_SHA}`.

## Why
Today the line installs from a moving branch tip: every docker-build picks up whatever `bridge` is at right now. Two image builds for the same miles commit can ship different Megatron-Bridge code. Pinning eliminates that drift.

Why a build-arg (not a hard-coded SHA in the install line): keeps the "what version" decision in one obvious place near the other build-args, and matches the pattern we'll use for any other git-installed dependency we want to pin in this Dockerfile.

This is Phase 3 of the `pip install miles` roadmap. Megatron-Bridge is already a vanilla pip-installable library (no patches at build time, no overlay onto a base-image directory, no in-tree edits), so submoduling it would be overkill — pinning is enough.

## What does NOT change
- The Megatron-Bridge contents installed by *today's* default build don't change (the new default SHA is exactly what `@bridge` resolved to at PR time).
- No other Dockerfile sections are affected; no CI workflow changes.

## Test plan
- [ ] `docker-build.yml` rebuild against this branch produces an image where `pip show megatron-bridge` shows the pinned commit.
- [ ] Sanity: two back-to-back builds of this branch produce identical Megatron-Bridge contents in the image (reproducibility).

## Stacked on
[radixark/miles PR #1188](https://github.com/radixark/miles/pull/1188) (Phase 2). Once that merges, this PR's base auto-updates.

## How to bump Megatron-Bridge after this lands
1. Push the new code to `bridge` on `radixark/Megatron-Bridge`.
2. In a miles PR, change `MEGATRON_BRIDGE_SHA` in `docker/Dockerfile` to the new SHA.
3. That commit changes `docker/Dockerfile`, fires the existing `docker-build.yml` `paths:` trigger, and produces a new deterministic image. No other action needed.
