### PR TITLE
Fix dump details debug import

### DIFF
--- a/miles/backends/training_utils/loss_hub/losses.py
+++ b/miles/backends/training_utils/loss_hub/losses.py
@@ -177,8 +177,8 @@ def policy_loss_function(
 
     pg_loss, pg_clipfrac = compute_policy_loss(ppo_kl, advantages, args.eps_clip, args.eps_clip_high)
 
-    if getattr(args, "dump_details", None) is not None:
-        from .debug_dump import maybe_dump_policy_loss_debug
+    if args.dump_details is not None:
+        from miles.backends.training_utils.debug_dump import maybe_dump_policy_loss_debug
 
         maybe_dump_policy_loss_debug(
             args=args,

--- a/miles/backends/training_utils/loss_hub/losses.py
+++ b/miles/backends/training_utils/loss_hub/losses.py
@@ -177,7 +177,7 @@ def policy_loss_function(
 
     pg_loss, pg_clipfrac = compute_policy_loss(ppo_kl, advantages, args.eps_clip, args.eps_clip_high)
 
-    if args.dump_details is not None:
+    if getattr(args, "dump_details", None) is not None:
         from miles.backends.training_utils.debug_dump import maybe_dump_policy_loss_debug
 
         maybe_dump_policy_loss_debug(

--- a/tests/fast/backends/training_utils/loss/loss_test_utils.py
+++ b/tests/fast/backends/training_utils/loss/loss_test_utils.py
@@ -93,6 +93,7 @@ _ARGS_DEFAULTS = dict(
     use_opsm=False,
     opsm_delta=0.1,
     calculate_per_token_loss=False,
+    dump_details=None,
     # value_loss_function
     value_clip=0.2,
     # loss_function dispatcher

--- a/tests/fast/backends/training_utils/loss/loss_test_utils.py
+++ b/tests/fast/backends/training_utils/loss/loss_test_utils.py
@@ -93,7 +93,6 @@ _ARGS_DEFAULTS = dict(
     use_opsm=False,
     opsm_delta=0.1,
     calculate_per_token_loss=False,
-    dump_details=None,
     # value_loss_function
     value_clip=0.2,
     # loss_function dispatcher


### PR DESCRIPTION
## Summary
- Fix `--dump-details` policy loss debug dump by importing `maybe_dump_policy_loss_debug` from the actual `miles.backends.training_utils.debug_dump` module.

## Validation
- `python -m py_compile miles/backends/training_utils/loss_hub/losses.py tests/fast/backends/training_utils/loss/loss_test_utils.py`
- `pre-commit run --all-files`

Note: `PYTHONPATH=. python -m pytest tests/fast/backends/training_utils/loss/test_loss_snapshot.py -q` is blocked in this local environment by missing `sglang` during `tests/fast/conftest.py` import.
