### PR TITLE
Add empty cpu/gpu/training extras_require slots (Phase 4)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,29 @@ setup(
         "mlflow": [
             "mlflow>=2.0",
         ],
+        # ----------------------------------------------------------------
+        # Placeholders for the `pip install miles` roadmap (Phase 4).
+        # These slots are intentionally empty at this stage; Phase 6 will
+        # populate them with the dependencies that today are installed by
+        # docker/Dockerfile rather than declared in setup.py.
+        # ----------------------------------------------------------------
+        # `cpu` — extras that only the lightweight (rollout/eval/CPU)
+        # subset of miles needs, beyond install_requires. Likely empty
+        # or near-empty.
+        "cpu": [],
+        # `gpu` — the heavy GPU stack: flash-attn, flash-attn-3,
+        # flash-linear-attention, transformer-engine, apex, tilelang,
+        # causal-conv1d, mamba-ssm, nvidia-modelopt, nvidia-cudnn-cu*,
+        # torch_memory_saver, mbridge. Many require a CUDA toolchain at
+        # install time; some are only available as pre-built wheels (see
+        # yueming-yuan/miles-wheels) rather than from PyPI.
+        "gpu": [],
+        # `training` — the full training environment: everything in
+        # `gpu` plus the patched sglang / Megatron-LM / Megatron-Bridge
+        # that today are installed via git+url or COPY-from-submodule
+        # in docker/Dockerfile. Will pull from a private Python index
+        # once Phase 5 publishes the wheels.
+        "training": [],
     },
     python_requires=">=3.10",
     classifiers=[


### PR DESCRIPTION
## Summary
- Add three empty placeholder slots to `setup.py`'s `extras_require`: `cpu`, `gpu`, `training`. Each one is documented inline so the intent is obvious to future contributors.
- No runtime change yet (slots are empty lists). The full categorization is in the audit table below; populating the lists is Phase 6's job, after the patched-fork wheels exist (Phase 5).

## Why
The `pip install miles` roadmap (Phase 4) calls for declaring the extras_require taxonomy now so:
1. Future commits that populate it land in well-named slots without bikeshedding.
2. A user can already type `pip install miles[gpu]` and not get a KeyError on the typo — they just get the install_requires baseline (same as no extras), and the dependency list grows transparently as Phases 5–6 land.
3. The setup.py inline comments serve as the single source of truth for "what goes where", removing the ambiguity that scattered comments across Dockerfile / requirements.txt / docs would create.

## Phase 4 audit: where each current install lands

### Already in `install_requires` (from `requirements.txt`)
20 packages — these are the always-installed dependencies of miles. All install cleanly from PyPI without a CUDA toolchain.

| Package | Notes |
|---|---|
| `accelerate` | Brings in `torch` transitively (key for the eventual CPU path). |
| `blobfile`, `datasets`, `httpx[http2]`, `mcp[cli]`, `memray`, `omegaconf`, `pillow`, `pybase64`, `pylatexenc`, `pytest-asyncio`, `pyyaml`, `qwen_vl_utils`, `tensorboard`, `transformers`, `wandb` | Standard PyPI installs. |
| `ray[default]` | Pure-Python; runs on CPU and GPU. |
| `ring_flash_attn; platform_system == "Linux"` | Conditionally Linux-only. Importable on CPU but exercises GPU code paths. |
| `sglang-router>=0.2.3` | Pure-Python router; today comes from a `radixark/sgl-router-for-miles` pre-built wheel in the image, also published to PyPI. |
| `torchft-nightly==2026.4.3; platform_system == "Linux"` | Linux-only nightly. |

### `extras_require["gpu"]` — heavy GPU stack (Phase 6 target)
Today installed by `docker/Dockerfile`, not setup.py. Each needs CUDA toolchain at install time, a matching torch version, or a pre-built wheel.

| Source | Notes |
|---|---|
| `flash-attn` | Pre-built wheel from `yueming-yuan/miles-wheels` release. Build-from-source is multi-hour. |
| `flash-attn-3 (hopper)` | Hopper-only (sm_90a). Pre-built wheel + sources `flash_attn_interface.py` from Dao-AILab/flash-attention raw. |
| `flash-linear-attention==0.4.2` | PyPI. |
| `tilelang` | Nightly from `https://tile-ai.github.io/whl/nightly/cu128/`. |
| `causal-conv1d==1.6.1` | PyPI, CUDA source build. |
| `mamba-ssm==2.3.1` | PyPI, CUDA source build. |
| `transformer_engine[pytorch]==2.10.0` / `transformer_engine==2.12.0 + transformer_engine_cu13` | PyPI, CUDA build. ENABLE_CUDA_13 branch in Dockerfile picks variants. |
| `apex` | Pre-built wheel; from-source typically requires manual NVCC env. |
| `nvidia-modelopt[torch]>=0.37.0` | PyPI, CUDA. |
| `torch_memory_saver` (`fzyzcjy/torch_memory_saver` @ pinned SHA) | git+url today; eventually point at a stable wheel or pin via a Phase-3-style build arg. |
| `mbridge` (`ISEEKYAN/mbridge` @ pinned SHA) | Same situation as torch_memory_saver. |
| `nvidia-cudnn-cu12==9.16.0.29` or `cu13` | PyPI. CUDA-version-specific. |
| `numpy<2` | Post-install pin needed for Megatron compatibility. Belongs in `install_requires` once we figure out the proper version constraint. |

### `extras_require["training"]` — full training stack (Phase 5 + 6 target)
Everything in `gpu` plus the patched forks. These don't exist on PyPI yet; Phase 5 publishes them to a private index.

| Source | Notes |
|---|---|
| `radixark-sglang` (from `third_party/sglang`) | Published from the submodule on submodule pointer bump. Eventual name TBD. |
| `radixark-megatron` (from `third_party/Megatron-LM`) | Published from the submodule. |
| `radixark-megatron-bridge` (Phase 3-pinned SHA) | Currently `pip install git+...@<sha>` in Dockerfile; Phase 6 may switch to a published wheel for symmetry. |

### Docker-only / vendor-built / system-level (not exposed via pip)
| What | Why we leave it alone |
|---|---|
| `apt install nvtop rsync dnsutils ethtool` | System-level diagnostics, not Python deps. |
| `nccl-tests` (built from NVIDIA/nccl-tests source) | System binary in `/usr/local/bin/`. |
| `int4_qat` (`fake_int4_quant_cuda` wheel) | Custom-built wheel; users get it from the image. |
| `sgl-model-gateway` binary | Rust-built native binary. Goes in `/usr/local/bin/`. |
| `sglang_router` wheel | Has both a pre-built wheel path and a Rust-source path. The PyPI version is in install_requires; the image-specific wheel handles edge cases. |

### `extras_require["cpu"]`
Currently empty. Likely stays empty or gets minor additions for things like docstring-rendering, pretty CLI, etc. that aren't worth bloating install_requires for. Will revisit in Phase 6 once we know what the CPU-only entry point needs.

## Test plan
- [x] `python3 -c 'import ast; ast.parse(open("setup.py").read())'` — syntax OK.
- [ ] On a fresh `python:3.11` container: `pip install miles[cpu]` — should succeed (against an empty list — equivalent to `pip install miles` for now).
- This PR is intentionally a no-op for runtime; the meaningful tests come once Phase 5 lands and Phase 6 fills the slots.

## Stacked on
[radixark/miles PR #1194](https://github.com/radixark/miles/pull/1194) (Phase 3: pin Megatron-Bridge SHA). Once that merges, this PR's base auto-updates.

## What's NOT in this PR
- No new `extras_require` entries with actual packages — that's Phase 6 (after the patched-fork wheels exist).
- No CI / Dockerfile changes — those depend on Phase 6 too.
- No new doc files — keeping the audit in the PR description rather than committing a `.md` to the repo.
