### PR TITLE
Add Megatron Muon optimizer support

### DIFF
--- a/examples/eval/scripts/run-qwen3-4B.sh
+++ b/examples/eval/scripts/run-qwen3-4B.sh
@@ -16,6 +16,7 @@ pkill -9 python
 set -ex
 
 SKILLS_OPENAI_MODEL_NAME=${SKILLS_OPENAI_MODEL_NAME:-"miles-openai-model"}
+MILES_OPTIMIZER=${MILES_OPTIMIZER:-adam}
 
 
 export PYTHONBUFFERED=16
@@ -92,14 +93,21 @@ GRPO_ARGS=(
    --eps-clip-high 0.28
 )
 
+if [ "${MILES_OPTIMIZER}" != "adam" ] && [ "${MILES_OPTIMIZER}" != "muon" ]; then
+   echo "Unsupported MILES_OPTIMIZER=${MILES_OPTIMIZER}; expected adam or muon" >&2
+   exit 1
+fi
 OPTIMIZER_ARGS=(
-   --optimizer adam
+   --optimizer "${MILES_OPTIMIZER}"
    --lr 1e-6
    --lr-decay-style constant
    --weight-decay 0.1
    --adam-beta1 0.9
    --adam-beta2 0.98
 )
+if [ "${MILES_OPTIMIZER}" = "muon" ]; then
+   OPTIMIZER_ARGS+=(--muon-momentum 0.9)
+fi
 
 WANDB_ARGS=(
    --use-wandb

--- a/miles/backends/megatron_utils/arguments.py
+++ b/miles/backends/megatron_utils/arguments.py
@@ -9,9 +9,14 @@ __all__ = ["validate_args", "parse_args", "set_default_megatron_args"]
 logger = logging.getLogger(__name__)
 
 
+def _is_muon_optimizer(optimizer: str | None) -> bool:
+    return optimizer is not None and "muon" in optimizer.lower()
+
+
 def set_default_megatron_args(args):
-    # always use zero optimizer
-    args.use_distributed_optimizer = True
+    # Muon currently owns its sharding path and is incompatible with Megatron's
+    # distributed optimizer, while Adam/SGD keep the historical ZeRO default.
+    args.use_distributed_optimizer = not _is_muon_optimizer(args.optimizer)
     # TODO: maybe change this after megatron has good fp8 support
     args.bf16 = not args.fp16
     # placeholders

--- a/miles/backends/megatron_utils/bridge_lora_helpers.py
+++ b/miles/backends/megatron_utils/bridge_lora_helpers.py
@@ -115,7 +115,8 @@ def _setup_lora_model_via_bridge(args: Namespace) -> list:
         hidden_size = hf_config.text_config.hidden_size if hasattr(hf_config, "text_config") else hf_config.hidden_size
         provider.register_pre_wrap_hook(_make_value_model_hook(hidden_size, provider.sequence_parallel))
 
-    ddp_config = DistributedDataParallelConfig(use_distributed_optimizer=True)
+    use_distributed_optimizer = "muon" not in (args.optimizer or "").lower()
+    ddp_config = DistributedDataParallelConfig(use_distributed_optimizer=use_distributed_optimizer)
     ddp_config.finalize()
 
     if args.offload_train:

--- a/miles/backends/megatron_utils/model.py
+++ b/miles/backends/megatron_utils/model.py
@@ -14,6 +14,7 @@ from megatron.core.distributed import finalize_model_grads
 from megatron.core.enums import ModelType
 from megatron.core.models.gpt import GPTModel
 from megatron.core.optimizer import OptimizerConfig, get_megatron_optimizer
+from megatron.core.optimizer.muon import get_megatron_muon_optimizer
 from megatron.core.optimizer.optimizer import MegatronOptimizer
 from megatron.core.optimizer_param_scheduler import OptimizerParamScheduler
 from megatron.core.pipeline_parallel import get_forward_backward_func
@@ -101,6 +102,10 @@ def get_optimizer_param_scheduler(args: Namespace, optimizer: MegatronOptimizer)
 # ---------------------------------------------------------------------------
 
 
+def _is_muon_optimizer(optimizer: str | None) -> bool:
+    return optimizer is not None and "muon" in optimizer.lower()
+
+
 def setup_model_and_optimizer(
     args: Namespace,
     role: str = "actor",
@@ -143,11 +148,19 @@ def setup_model_and_optimizer(
     config = OptimizerConfig(**kwargs)
     config.timers = None
 
-    optimizer = get_megatron_optimizer(
-        config=config,
-        model_chunks=model,
-        use_gloo_process_groups=args.enable_gloo_process_groups,
-    )
+    if _is_muon_optimizer(config.optimizer):
+        optimizer = get_megatron_muon_optimizer(
+            config=config,
+            model_chunks=model,
+            use_gloo_process_groups=args.enable_gloo_process_groups,
+            layer_wise_distributed_optimizer="dist" in config.optimizer.lower(),
+        )
+    else:
+        optimizer = get_megatron_optimizer(
+            config=config,
+            model_chunks=model,
+            use_gloo_process_groups=args.enable_gloo_process_groups,
+        )
     opt_param_scheduler = get_optimizer_param_scheduler(args, optimizer)
     return model, optimizer, opt_param_scheduler
 


### PR DESCRIPTION
## Summary
- route `--optimizer muon` through Megatron's Muon optimizer factory
- disable Megatron distributed optimizer for Muon while preserving the existing Adam default
- allow the Qwen3-4B eval script to switch between Adam and Muon via `MILES_OPTIMIZER`

## Validation
- `bash -n examples/eval/scripts/run-qwen3-4B.sh`
- `python -m py_compile miles/backends/megatron_utils/arguments.py miles/backends/megatron_utils/bridge_lora_helpers.py miles/backends/megatron_utils/model.py`
- `git diff --check`

## Manual Notes
- Earlier sci-h200 Qwen3-4B Muon validation reached training and exercised the Megatron Muon path with `use_distributed_optimizer=False`.
- The temporary Qwen3-4B E2E and fast routing tests were removed to keep this PR focused on the minimal integration patch.
