### PR TITLE
[2/12] Add Qwen3 MoE true-on-policy contract schema

### DIFF
--- a/miles/true_on_policy/__init__.py
+++ b/miles/true_on_policy/__init__.py
@@ -8,7 +8,12 @@ from .config import (
     apply_true_on_policy_script_defaults,
     build_true_on_policy_launch_plan,
 )
-from .contracts import QWEN3_DENSE_TRUE_ON_POLICY_V1, TrueOnPolicyContract, get_true_on_policy_contract
+from .contracts import (
+    QWEN3_DENSE_TRUE_ON_POLICY_V1,
+    QWEN3_MOE_TRUE_ON_POLICY_V1,
+    TrueOnPolicyContract,
+    get_true_on_policy_contract,
+)
 from .model_profiles import TrueOnPolicyModelProfile, get_megatron_model_type, get_true_on_policy_model_profile
 
 __all__ = [
@@ -19,6 +24,7 @@ __all__ = [
     "TrueOnPolicyModelProfile",
     "TrueOnPolicyParallelLayout",
     "QWEN3_DENSE_TRUE_ON_POLICY_V1",
+    "QWEN3_MOE_TRUE_ON_POLICY_V1",
     "apply_true_on_policy_script_defaults",
     "build_true_on_policy_launch_plan",
     "get_true_on_policy_contract",

--- a/miles/true_on_policy/contracts.py
+++ b/miles/true_on_policy/contracts.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 
 from .schema import (
     QWEN3_DENSE_TRUE_ON_POLICY_V1_SCHEMA,
+    QWEN3_MOE_TRUE_ON_POLICY_V1_SCHEMA,
     KernelContract,
     LogprobContract,
     ModelFamily,
@@ -54,6 +55,11 @@ class TrueOnPolicyContract:
     ) -> dict[str, object]:
         uses_megatron = train_backend == "megatron"
         uses_tp_invariant_rollout = sglang_target == "fsdp_tp"
+        uses_ep_invariant_moe = False
+        is_moe = self.model_family == "qwen3_moe"
+        # SGLang attention-DP + EP is not parity-gated for Qwen3-30B-A3B yet.
+        # Keep the true-on-policy launch on the verified EP-only rollout path.
+        sglang_attention_data_parallel_size = 1
         return {
             "deterministic_inference": True,
             "deterministic_training": True,
@@ -64,6 +70,15 @@ class TrueOnPolicyContract:
             "batch_invariant_mode": uses_megatron,
             "tp_invariant_row_linear": uses_tp_invariant_rollout,
             "deterministic_tp_allreduce": uses_tp_invariant_rollout,
+            "deterministic_moe_routing": is_moe,
+            "moe_topk_tiebreak": "stable_sort" if is_moe else None,
+            "deterministic_moe_dispatch": is_moe and uses_ep_invariant_moe,
+            "deterministic_moe_combine": is_moe and uses_ep_invariant_moe,
+            "ep_invariant_moe": is_moe and uses_ep_invariant_moe,
+            "sglang_attention_data_parallel_size": sglang_attention_data_parallel_size,
+            # Qwen3-MoE strict CUDA graph replay returns logits in the same dtype
+            # as eager decode, so the sampler/logprob path remains exact-zero.
+            "disable_sglang_cuda_graph": False,
         }
 
 
@@ -71,9 +86,14 @@ QWEN3_DENSE_TRUE_ON_POLICY_V1 = TrueOnPolicyContract(
     schema=QWEN3_DENSE_TRUE_ON_POLICY_V1_SCHEMA,
 )
 
+QWEN3_MOE_TRUE_ON_POLICY_V1 = TrueOnPolicyContract(
+    schema=QWEN3_MOE_TRUE_ON_POLICY_V1_SCHEMA,
+)
+
 
 _CONTRACT_BY_NAME = {
     QWEN3_DENSE_TRUE_ON_POLICY_V1.name: QWEN3_DENSE_TRUE_ON_POLICY_V1,
+    QWEN3_MOE_TRUE_ON_POLICY_V1.name: QWEN3_MOE_TRUE_ON_POLICY_V1,
 }
 
 

--- a/miles/true_on_policy/model_profiles.py
+++ b/miles/true_on_policy/model_profiles.py
@@ -2,7 +2,13 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from .contracts import QWEN3_DENSE_TRUE_ON_POLICY_V1, LogprobContract, ModelFamily, TrueOnPolicyContract
+from .contracts import (
+    QWEN3_DENSE_TRUE_ON_POLICY_V1,
+    QWEN3_MOE_TRUE_ON_POLICY_V1,
+    LogprobContract,
+    ModelFamily,
+    TrueOnPolicyContract,
+)
 
 ParallelLayout = str
 
@@ -48,6 +54,10 @@ class TrueOnPolicyModelProfile:
     def supports_tp_invariant(self) -> bool:
         return "tp" in self.supported_train_layouts or "tp" in self.supported_rollout_layouts
 
+    @property
+    def supports_ep_invariant(self) -> bool:
+        return "ep" in self.supported_train_layouts or "ep" in self.supported_rollout_layouts
+
     def megatron_model_type_for(self, model_name: str) -> str:
         try:
             return self.megatron_model_types[model_name]
@@ -78,8 +88,17 @@ QWEN3_DENSE_PROFILE = TrueOnPolicyModelProfile(
     contract=QWEN3_DENSE_TRUE_ON_POLICY_V1,
 )
 
+QWEN3_MOE_PROFILE = TrueOnPolicyModelProfile(
+    family="qwen3_moe",
+    model_names=("Qwen3-30B-A3B",),
+    megatron_model_types={"Qwen3-30B-A3B": "qwen3-30B-A3B"},
+    supported_train_layouts=("dp", "tp", "expert_tp", "ep", "pp", "ulysses_cp"),
+    supported_rollout_layouts=("dp", "tp", "ep"),
+    contract=QWEN3_MOE_TRUE_ON_POLICY_V1,
+)
 
-_MODEL_PROFILES = (QWEN3_DENSE_PROFILE,)
+
+_MODEL_PROFILES = (QWEN3_DENSE_PROFILE, QWEN3_MOE_PROFILE)
 _PROFILE_BY_MODEL_NAME = {model_name: profile for profile in _MODEL_PROFILES for model_name in profile.model_names}
 
 

--- a/miles/true_on_policy/schema.py
+++ b/miles/true_on_policy/schema.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Literal
 
-
-TrueOnPolicyContractName = Literal["qwen3_dense_true_on_policy_v1"]
+TrueOnPolicyContractName = Literal[
+    "qwen3_dense_true_on_policy_v1",
+    "qwen3_moe_true_on_policy_v1",
+]
 ModelFamily = Literal["qwen3_dense", "qwen3_moe", "qwen3_next"]
-KernelContract = Literal["qwen3_dense_sglang_math"]
+KernelContract = Literal["qwen3_dense_sglang_math", "qwen3_moe_sglang_math"]
 LogprobContract = Literal["sglang_prefill"]
 
 
@@ -27,6 +29,16 @@ QWEN3_DENSE_TRUE_ON_POLICY_V1_SCHEMA = TrueOnPolicyContractSchema(
     name="qwen3_dense_true_on_policy_v1",
     model_family="qwen3_dense",
     required_kernel_contracts=("qwen3_dense_sglang_math",),
+    logprob_contract="sglang_prefill",
+    sglang_attention_backend="fa3",
+    fsdp_attention_implementation="flash_attention_3",
+    disable_megatron_sequence_parallel=True,
+)
+
+QWEN3_MOE_TRUE_ON_POLICY_V1_SCHEMA = TrueOnPolicyContractSchema(
+    name="qwen3_moe_true_on_policy_v1",
+    model_family="qwen3_moe",
+    required_kernel_contracts=("qwen3_dense_sglang_math", "qwen3_moe_sglang_math"),
     logprob_contract="sglang_prefill",
     sglang_attention_backend="fa3",
     fsdp_attention_implementation="flash_attention_3",


### PR DESCRIPTION
Stacked split of #1059, rebuilt after rebasing onto latest `main`.

Base branch: `split/pr1059-01-ci-gates`
Head branch: `split/pr1059-02-contract-schema`

This is PR 2 of 12. The stack is cumulative; the final branch is the rebased equivalent of the original PR head without stale-base reversions.