### PR TITLE
[3/12] Build true-on-policy launch config

### DIFF
--- a/miles/true_on_policy/config.py
+++ b/miles/true_on_policy/config.py
@@ -35,7 +35,10 @@ class TrueOnPolicyParallelLayout:
     train_tensor_parallel_size: int
     train_context_parallel_size: int
     train_pipeline_parallel_size: int
+    train_expert_model_parallel_size: int
+    train_expert_tensor_parallel_size: int
     rollout_num_gpus_per_engine: int
+    rollout_expert_parallel_size: int = 1
 
     @property
     def uses_train_tp(self) -> bool:
@@ -50,8 +53,20 @@ class TrueOnPolicyParallelLayout:
         return self.train_pipeline_parallel_size > 1
 
     @property
+    def uses_train_ep(self) -> bool:
+        return self.train_expert_model_parallel_size > 1
+
+    @property
+    def uses_train_expert_tp(self) -> bool:
+        return self.train_expert_tensor_parallel_size > 1
+
+    @property
     def uses_rollout_tp(self) -> bool:
         return self.rollout_num_gpus_per_engine > 1
+
+    @property
+    def uses_rollout_ep(self) -> bool:
+        return self.rollout_expert_parallel_size > 1
 
 
 @dataclass(frozen=True)
@@ -68,6 +83,14 @@ class TrueOnPolicyKernelPolicy:
     batch_invariant_mode: bool
     tp_invariant_row_linear: bool
     deterministic_tp_allreduce: bool
+    deterministic_moe_routing: bool
+    moe_topk_tiebreak: str | None
+    deterministic_moe_dispatch: bool
+    deterministic_moe_combine: bool
+    ep_invariant_moe: bool
+    sglang_attention_data_parallel_size: int
+    disable_sglang_cuda_graph: bool
+    rollout_tp_size: int
 
     def build_sglang_args(self) -> TrueOnPolicyArgList:
         values = [
@@ -76,8 +99,18 @@ class TrueOnPolicyKernelPolicy:
             "--sglang-attention-backend",
             self.sglang_attention_backend,
         ]
+        if self.disable_sglang_cuda_graph:
+            values.insert(0, "--sglang-disable-cuda-graph")
         if self.deterministic_inference:
             values.insert(0, "--sglang-enable-deterministic-inference")
+        if self.sglang_attention_data_parallel_size > 1:
+            values.extend(
+                [
+                    "--sglang-data-parallel-size",
+                    str(self.sglang_attention_data_parallel_size),
+                    "--sglang-enable-dp-attention",
+                ]
+            )
         return TrueOnPolicyArgList(tuple(values))
 
     def build_megatron_args(self) -> TrueOnPolicyArgList:
@@ -92,7 +125,7 @@ class TrueOnPolicyKernelPolicy:
                     "--use-cpu-initialization",
                 ]
             )
-        if self.batch_invariant_mode:
+        if self.batch_invariant_mode and os.environ.get("MILES_TRUE_ON_POLICY_DISABLE_BATCH_INVARIANT", "0") != "1":
             values.append("--batch-invariant-mode")
         if self.disable_bias_swiglu_fusion:
             values.append("--no-bias-swiglu-fusion")
@@ -101,11 +134,24 @@ class TrueOnPolicyKernelPolicy:
         return TrueOnPolicyArgList(tuple(values))
 
     def build_env_vars(self) -> dict[str, str]:
-        return {
+        env = {
             "NCCL_ALGO": os.environ.get("NCCL_ALGO", "Ring"),
+            "NCCL_NVLS_ENABLE": "0",
             "NVTE_ALLOW_NONDETERMINISTIC_ALGO": "0",
             "CUBLAS_WORKSPACE_CONFIG": ":4096:8",
+            "MILES_TRUE_ON_POLICY_ROLLOUT_TP_SIZE": str(self.rollout_tp_size),
+            "SGLANG_TRUE_ON_POLICY_FUSED_RMSNORM": "1",
         }
+        if self.batch_invariant_mode:
+            env.update(
+                {
+                    "SGLANG_BATCH_INVARIANT_OPS_ENABLE_MM_DEEPGEMM": "0",
+                    "SGLANG_BATCH_INVARIANT_OPS_ENABLE_MM_FALLBACK_VARIANT": "0",
+                }
+            )
+        if self.deterministic_moe_combine:
+            env["MODEL_ARGS_DISABLE_MOE_PERMUTE_FUSION"] = "1"
+        return env
 
 
 @dataclass(frozen=True)
@@ -146,6 +192,10 @@ class TrueOnPolicyConfig:
     context_parallel_size: int
     pipeline_model_parallel_size: int
     rollout_num_gpus_per_engine: int
+    expert_model_parallel_size: int = 1
+    expert_tensor_parallel_size: int = 1
+    rollout_expert_parallel_size: int = 1
+    train_world_size: int | None = None
     contract_override: str | None = None
 
     @property
@@ -154,13 +204,16 @@ class TrueOnPolicyConfig:
             train_tensor_parallel_size=self.tensor_model_parallel_size,
             train_context_parallel_size=self.context_parallel_size,
             train_pipeline_parallel_size=self.pipeline_model_parallel_size,
+            train_expert_model_parallel_size=self.expert_model_parallel_size,
+            train_expert_tensor_parallel_size=self.expert_tensor_parallel_size,
             rollout_num_gpus_per_engine=self.rollout_num_gpus_per_engine,
+            rollout_expert_parallel_size=self.rollout_expert_parallel_size,
         )
 
     @property
     def requires_tp_invariant_rollout(self) -> bool:
         layout = self.parallel_layout
-        return layout.uses_train_tp or layout.uses_rollout_tp
+        return layout.uses_train_tp or layout.uses_train_expert_tp or layout.uses_rollout_tp
 
     @property
     def sglang_target(self) -> OnPolicyTarget:
@@ -189,28 +242,54 @@ class TrueOnPolicyConfig:
             raise ValueError(f"{self.model_profile.family} does not support Ulysses CP true-on-policy")
         if layout.uses_train_pp and "pp" not in self.model_profile.supported_train_layouts:
             raise ValueError(f"{self.model_profile.family} does not support PP true-on-policy")
+        if layout.uses_train_ep and "ep" not in self.model_profile.supported_train_layouts:
+            raise ValueError(f"{self.model_profile.family} does not support EP true-on-policy")
+        if layout.uses_train_expert_tp and "expert_tp" not in self.model_profile.supported_train_layouts:
+            raise ValueError(f"{self.model_profile.family} does not support expert TP true-on-policy")
+        if layout.uses_rollout_ep and "ep" not in self.model_profile.supported_rollout_layouts:
+            raise ValueError(f"{self.model_profile.family} does not support rollout EP true-on-policy")
         if self.sglang_target == "fsdp_tp" and not self.model_profile.supports_tp_invariant:
             raise ValueError(f"{self.model_profile.family} does not support TP-invariant true-on-policy")
+        if self.train_backend == "megatron" and layout.uses_train_tp and layout.uses_train_ep:
+            # TODO: Enable this once true-on-policy supports Megatron sequence parallel
+            # for MoE + tensor-parallel training.
+            raise ValueError(
+                "Megatron MoE true-on-policy does not support train TP with EP yet. "
+                "Megatron requires sequence parallel for MoE + tensor-parallel training, "
+                "and the current true-on-policy path intentionally disables sequence parallel."
+            )
+        self._validate_megatron_train_topology()
+
+    def _validate_megatron_train_topology(self) -> None:
+        if self.train_backend != "megatron" or self.train_world_size is None:
+            return
+
+        model_parallel_size = (
+            self.tensor_model_parallel_size * self.pipeline_model_parallel_size * self.context_parallel_size
+        )
+
+        train_data_parallel_size = self.train_world_size // model_parallel_size
+        if train_data_parallel_size % self.expert_model_parallel_size != 0:
+            raise ValueError(
+                "Megatron MoE true-on-policy requires train DP to be divisible by EP "
+                f"({train_data_parallel_size} % {self.expert_model_parallel_size} != 0)."
+            )
 
     def build_kernel_policy(self) -> TrueOnPolicyKernelPolicy:
+        policy_kwargs = self.contract.kernel_policy_kwargs_for(
+            train_backend=self.train_backend,
+            parallel_layout=self.parallel_layout,
+        )
+        policy_kwargs["rollout_tp_size"] = self.rollout_num_gpus_per_engine
         return TrueOnPolicyKernelPolicy(
             contract=self.contract,
-            **self.contract.kernel_policy_kwargs_for(
-                train_backend=self.train_backend,
-                sglang_target=self.sglang_target,
-            ),
+            **policy_kwargs,
         )
 
     def build_launch_plan(self) -> TrueOnPolicyLaunchPlan:
         self.validate()
         kernel_policy = self.build_kernel_policy()
-        miles_args = TrueOnPolicyArgList(
-            (
-                "--deterministic-mode",
-                "--true-on-policy-mode",
-                "--recompute-logprobs-via-prefill",
-            )
-        )
+        miles_args = TrueOnPolicyArgList(("--deterministic-mode", "--true-on-policy-mode"))
 
         if self.train_backend == "megatron":
             megatron_args = kernel_policy.build_megatron_args()
@@ -244,11 +323,23 @@ def _get_required_int(args: Any, name: str) -> int:
     return int(value)
 
 
+def _get_optional_int(args: Any, name: str, default: int) -> int:
+    value = getattr(args, name, default)
+    if value is None:
+        return default
+    return int(value)
+
+
 def build_true_on_policy_config(args: Any) -> TrueOnPolicyConfig | None:
     if not getattr(args, "true_on_policy", False):
         return None
 
     profile = get_true_on_policy_model_profile(args.model_name)
+    num_nodes = getattr(args, "num_nodes", None)
+    num_gpus_per_node = getattr(args, "num_gpus_per_node", None)
+    train_world_size = (
+        None if num_nodes is None or num_gpus_per_node is None else int(num_nodes) * int(num_gpus_per_node)
+    )
     return TrueOnPolicyConfig(
         enabled=True,
         model_profile=profile,
@@ -256,7 +347,11 @@ def build_true_on_policy_config(args: Any) -> TrueOnPolicyConfig | None:
         tensor_model_parallel_size=_get_required_int(args, "tensor_model_parallel_size"),
         context_parallel_size=_get_required_int(args, "context_parallel_size"),
         pipeline_model_parallel_size=_get_required_int(args, "pipeline_model_parallel_size"),
+        expert_model_parallel_size=_get_optional_int(args, "expert_model_parallel_size", 1),
+        expert_tensor_parallel_size=_get_optional_int(args, "expert_tensor_parallel_size", 1),
         rollout_num_gpus_per_engine=_get_required_int(args, "rollout_num_gpus_per_engine"),
+        rollout_expert_parallel_size=_get_optional_int(args, "sglang_expert_parallel_size", 1),
+        train_world_size=train_world_size,
         contract_override=getattr(args, "true_on_policy_contract", None),
     )
 
@@ -277,3 +372,9 @@ def apply_true_on_policy_script_defaults(args: Any) -> None:
     config.validate()
     if args.train_backend == "megatron" and config.model_profile.disable_megatron_sequence_parallel:
         args.use_sequence_parallel = False
+    if (
+        args.train_backend == "megatron"
+        and config.context_parallel_size > 1
+        and getattr(args, "cp_comm_type", None) is None
+    ):
+        args.cp_comm_type = "a2a"

--- a/miles/true_on_policy/contracts.py
+++ b/miles/true_on_policy/contracts.py
@@ -51,11 +51,20 @@ class TrueOnPolicyContract:
         self,
         *,
         train_backend: str,
-        sglang_target: str,
+        parallel_layout=None,
+        sglang_target: str | None = None,
     ) -> dict[str, object]:
         uses_megatron = train_backend == "megatron"
-        uses_tp_invariant_rollout = sglang_target == "fsdp_tp"
-        uses_ep_invariant_moe = False
+        if parallel_layout is not None:
+            uses_tp_invariant_rollout = (
+                parallel_layout.uses_train_tp
+                or parallel_layout.uses_train_expert_tp
+                or parallel_layout.uses_rollout_tp
+            )
+            uses_ep_invariant_moe = parallel_layout.uses_train_ep or parallel_layout.uses_rollout_ep
+        else:
+            uses_tp_invariant_rollout = sglang_target == "fsdp_tp"
+            uses_ep_invariant_moe = False
         is_moe = self.model_family == "qwen3_moe"
         # SGLang attention-DP + EP is not parity-gated for Qwen3-30B-A3B yet.
         # Keep the true-on-policy launch on the verified EP-only rollout path.


### PR DESCRIPTION
Stacked split of #1059, rebuilt after rebasing onto latest `main`.

Base branch: `split/pr1059-02-contract-schema`
Head branch: `split/pr1059-03-contract-config`

This is PR 3 of 12. The stack is cumulative; the final branch is the rebased equivalent of the original PR head without stale-base reversions.