### PR TITLE
[4/12] Cover true-on-policy config resolution

### DIFF
--- a/miles/true_on_policy/__init__.py
+++ b/miles/true_on_policy/__init__.py
@@ -8,7 +8,12 @@ from .config import (
     apply_true_on_policy_script_defaults,
     build_true_on_policy_launch_plan,
 )
-from .contracts import QWEN3_DENSE_TRUE_ON_POLICY_V1, TrueOnPolicyContract, get_true_on_policy_contract
+from .contracts import (
+    QWEN3_DENSE_TRUE_ON_POLICY_V1,
+    QWEN3_MOE_TRUE_ON_POLICY_V1,
+    TrueOnPolicyContract,
+    get_true_on_policy_contract,
+)
 from .model_profiles import TrueOnPolicyModelProfile, get_megatron_model_type, get_true_on_policy_model_profile
 
 __all__ = [
@@ -19,6 +24,7 @@ __all__ = [
     "TrueOnPolicyModelProfile",
     "TrueOnPolicyParallelLayout",
     "QWEN3_DENSE_TRUE_ON_POLICY_V1",
+    "QWEN3_MOE_TRUE_ON_POLICY_V1",
     "apply_true_on_policy_script_defaults",
     "build_true_on_policy_launch_plan",
     "get_true_on_policy_contract",

--- a/miles/true_on_policy/config.py
+++ b/miles/true_on_policy/config.py
@@ -35,7 +35,10 @@ class TrueOnPolicyParallelLayout:
     train_tensor_parallel_size: int
     train_context_parallel_size: int
     train_pipeline_parallel_size: int
+    train_expert_model_parallel_size: int
+    train_expert_tensor_parallel_size: int
     rollout_num_gpus_per_engine: int
+    rollout_expert_parallel_size: int = 1
 
     @property
     def uses_train_tp(self) -> bool:
@@ -50,8 +53,20 @@ class TrueOnPolicyParallelLayout:
         return self.train_pipeline_parallel_size > 1
 
     @property
+    def uses_train_ep(self) -> bool:
+        return self.train_expert_model_parallel_size > 1
+
+    @property
+    def uses_train_expert_tp(self) -> bool:
+        return self.train_expert_tensor_parallel_size > 1
+
+    @property
     def uses_rollout_tp(self) -> bool:
         return self.rollout_num_gpus_per_engine > 1
+
+    @property
+    def uses_rollout_ep(self) -> bool:
+        return self.rollout_expert_parallel_size > 1
 
 
 @dataclass(frozen=True)
@@ -68,6 +83,14 @@ class TrueOnPolicyKernelPolicy:
     batch_invariant_mode: bool
     tp_invariant_row_linear: bool
     deterministic_tp_allreduce: bool
+    deterministic_moe_routing: bool
+    moe_topk_tiebreak: str | None
+    deterministic_moe_dispatch: bool
+    deterministic_moe_combine: bool
+    ep_invariant_moe: bool
+    sglang_attention_data_parallel_size: int
+    disable_sglang_cuda_graph: bool
+    rollout_tp_size: int
 
     def build_sglang_args(self) -> TrueOnPolicyArgList:
         values = [
@@ -76,8 +99,18 @@ class TrueOnPolicyKernelPolicy:
             "--sglang-attention-backend",
             self.sglang_attention_backend,
         ]
+        if self.disable_sglang_cuda_graph:
+            values.insert(0, "--sglang-disable-cuda-graph")
         if self.deterministic_inference:
             values.insert(0, "--sglang-enable-deterministic-inference")
+        if self.sglang_attention_data_parallel_size > 1:
+            values.extend(
+                [
+                    "--sglang-data-parallel-size",
+                    str(self.sglang_attention_data_parallel_size),
+                    "--sglang-enable-dp-attention",
+                ]
+            )
         return TrueOnPolicyArgList(tuple(values))
 
     def build_megatron_args(self) -> TrueOnPolicyArgList:
@@ -92,7 +125,7 @@ class TrueOnPolicyKernelPolicy:
                     "--use-cpu-initialization",
                 ]
             )
-        if self.batch_invariant_mode:
+        if self.batch_invariant_mode and os.environ.get("MILES_TRUE_ON_POLICY_DISABLE_BATCH_INVARIANT", "0") != "1":
             values.append("--batch-invariant-mode")
         if self.disable_bias_swiglu_fusion:
             values.append("--no-bias-swiglu-fusion")
@@ -101,11 +134,24 @@ class TrueOnPolicyKernelPolicy:
         return TrueOnPolicyArgList(tuple(values))
 
     def build_env_vars(self) -> dict[str, str]:
-        return {
+        env = {
             "NCCL_ALGO": os.environ.get("NCCL_ALGO", "Ring"),
+            "NCCL_NVLS_ENABLE": "0",
             "NVTE_ALLOW_NONDETERMINISTIC_ALGO": "0",
             "CUBLAS_WORKSPACE_CONFIG": ":4096:8",
+            "MILES_TRUE_ON_POLICY_ROLLOUT_TP_SIZE": str(self.rollout_tp_size),
+            "SGLANG_TRUE_ON_POLICY_FUSED_RMSNORM": "1",
         }
+        if self.batch_invariant_mode:
+            env.update(
+                {
+                    "SGLANG_BATCH_INVARIANT_OPS_ENABLE_MM_DEEPGEMM": "0",
+                    "SGLANG_BATCH_INVARIANT_OPS_ENABLE_MM_FALLBACK_VARIANT": "0",
+                }
+            )
+        if self.deterministic_moe_combine:
+            env["MODEL_ARGS_DISABLE_MOE_PERMUTE_FUSION"] = "1"
+        return env
 
 
 @dataclass(frozen=True)
@@ -146,6 +192,10 @@ class TrueOnPolicyConfig:
     context_parallel_size: int
     pipeline_model_parallel_size: int
     rollout_num_gpus_per_engine: int
+    expert_model_parallel_size: int = 1
+    expert_tensor_parallel_size: int = 1
+    rollout_expert_parallel_size: int = 1
+    train_world_size: int | None = None
     contract_override: str | None = None
 
     @property
@@ -154,13 +204,16 @@ class TrueOnPolicyConfig:
             train_tensor_parallel_size=self.tensor_model_parallel_size,
             train_context_parallel_size=self.context_parallel_size,
             train_pipeline_parallel_size=self.pipeline_model_parallel_size,
+            train_expert_model_parallel_size=self.expert_model_parallel_size,
+            train_expert_tensor_parallel_size=self.expert_tensor_parallel_size,
             rollout_num_gpus_per_engine=self.rollout_num_gpus_per_engine,
+            rollout_expert_parallel_size=self.rollout_expert_parallel_size,
         )
 
     @property
     def requires_tp_invariant_rollout(self) -> bool:
         layout = self.parallel_layout
-        return layout.uses_train_tp or layout.uses_rollout_tp
+        return layout.uses_train_tp or layout.uses_train_expert_tp or layout.uses_rollout_tp
 
     @property
     def sglang_target(self) -> OnPolicyTarget:
@@ -189,28 +242,72 @@ class TrueOnPolicyConfig:
             raise ValueError(f"{self.model_profile.family} does not support Ulysses CP true-on-policy")
         if layout.uses_train_pp and "pp" not in self.model_profile.supported_train_layouts:
             raise ValueError(f"{self.model_profile.family} does not support PP true-on-policy")
+        if layout.uses_train_ep and "ep" not in self.model_profile.supported_train_layouts:
+            raise ValueError(f"{self.model_profile.family} does not support EP true-on-policy")
+        if layout.uses_train_expert_tp and "expert_tp" not in self.model_profile.supported_train_layouts:
+            raise ValueError(f"{self.model_profile.family} does not support expert TP true-on-policy")
+        if layout.uses_rollout_ep and "ep" not in self.model_profile.supported_rollout_layouts:
+            raise ValueError(f"{self.model_profile.family} does not support rollout EP true-on-policy")
         if self.sglang_target == "fsdp_tp" and not self.model_profile.supports_tp_invariant:
             raise ValueError(f"{self.model_profile.family} does not support TP-invariant true-on-policy")
+        if self.train_backend == "megatron" and layout.uses_train_tp and layout.uses_train_ep:
+            # TODO: Enable this once true-on-policy supports Megatron sequence parallel
+            # for MoE + tensor-parallel training.
+            raise ValueError(
+                "Megatron MoE true-on-policy does not support train TP with EP yet. "
+                "Megatron requires sequence parallel for MoE + tensor-parallel training, "
+                "and the current true-on-policy path intentionally disables sequence parallel."
+            )
+        self._validate_megatron_train_topology()
+
+    def _validate_megatron_train_topology(self) -> None:
+        if self.train_backend != "megatron" or self.train_world_size is None:
+            return
+
+        model_parallel_size = (
+            self.tensor_model_parallel_size * self.pipeline_model_parallel_size * self.context_parallel_size
+        )
+        if self.train_world_size % model_parallel_size != 0:
+            raise ValueError(
+                "Megatron true-on-policy train world size must be divisible by "
+                "TP * PP * CP "
+                f"({self.train_world_size} % {model_parallel_size} != 0)."
+            )
+
+        train_data_parallel_size = self.train_world_size // model_parallel_size
+        if self.expert_model_parallel_size > train_data_parallel_size:
+            min_world_size = model_parallel_size * self.expert_model_parallel_size
+            raise ValueError(
+                "Megatron MoE true-on-policy requires EP to fit inside the train "
+                "data-parallel dimension: "
+                f"DP={train_data_parallel_size}, EP={self.expert_model_parallel_size}. "
+                f"This topology needs at least {min_world_size} train GPUs "
+                f"for TP={self.tensor_model_parallel_size}, "
+                f"PP={self.pipeline_model_parallel_size}, "
+                f"CP={self.context_parallel_size}, "
+                f"EP={self.expert_model_parallel_size}."
+            )
+        if train_data_parallel_size % self.expert_model_parallel_size != 0:
+            raise ValueError(
+                "Megatron MoE true-on-policy requires train DP to be divisible by EP "
+                f"({train_data_parallel_size} % {self.expert_model_parallel_size} != 0)."
+            )
 
     def build_kernel_policy(self) -> TrueOnPolicyKernelPolicy:
+        policy_kwargs = self.contract.kernel_policy_kwargs_for(
+            train_backend=self.train_backend,
+            parallel_layout=self.parallel_layout,
+        )
+        policy_kwargs["rollout_tp_size"] = self.rollout_num_gpus_per_engine
         return TrueOnPolicyKernelPolicy(
             contract=self.contract,
-            **self.contract.kernel_policy_kwargs_for(
-                train_backend=self.train_backend,
-                sglang_target=self.sglang_target,
-            ),
+            **policy_kwargs,
         )
 
     def build_launch_plan(self) -> TrueOnPolicyLaunchPlan:
         self.validate()
         kernel_policy = self.build_kernel_policy()
-        miles_args = TrueOnPolicyArgList(
-            (
-                "--deterministic-mode",
-                "--true-on-policy-mode",
-                "--recompute-logprobs-via-prefill",
-            )
-        )
+        miles_args = TrueOnPolicyArgList(("--deterministic-mode", "--true-on-policy-mode"))
 
         if self.train_backend == "megatron":
             megatron_args = kernel_policy.build_megatron_args()
@@ -244,11 +341,23 @@ def _get_required_int(args: Any, name: str) -> int:
     return int(value)
 
 
+def _get_optional_int(args: Any, name: str, default: int) -> int:
+    value = getattr(args, name, default)
+    if value is None:
+        return default
+    return int(value)
+
+
 def build_true_on_policy_config(args: Any) -> TrueOnPolicyConfig | None:
     if not getattr(args, "true_on_policy", False):
         return None
 
     profile = get_true_on_policy_model_profile(args.model_name)
+    num_nodes = getattr(args, "num_nodes", None)
+    num_gpus_per_node = getattr(args, "num_gpus_per_node", None)
+    train_world_size = (
+        None if num_nodes is None or num_gpus_per_node is None else int(num_nodes) * int(num_gpus_per_node)
+    )
     return TrueOnPolicyConfig(
         enabled=True,
         model_profile=profile,
@@ -256,7 +365,11 @@ def build_true_on_policy_config(args: Any) -> TrueOnPolicyConfig | None:
         tensor_model_parallel_size=_get_required_int(args, "tensor_model_parallel_size"),
         context_parallel_size=_get_required_int(args, "context_parallel_size"),
         pipeline_model_parallel_size=_get_required_int(args, "pipeline_model_parallel_size"),
+        expert_model_parallel_size=_get_optional_int(args, "expert_model_parallel_size", 1),
+        expert_tensor_parallel_size=_get_optional_int(args, "expert_tensor_parallel_size", 1),
         rollout_num_gpus_per_engine=_get_required_int(args, "rollout_num_gpus_per_engine"),
+        rollout_expert_parallel_size=_get_optional_int(args, "sglang_expert_parallel_size", 1),
+        train_world_size=train_world_size,
         contract_override=getattr(args, "true_on_policy_contract", None),
     )
 
@@ -277,3 +390,9 @@ def apply_true_on_policy_script_defaults(args: Any) -> None:
     config.validate()
     if args.train_backend == "megatron" and config.model_profile.disable_megatron_sequence_parallel:
         args.use_sequence_parallel = False
+    if (
+        args.train_backend == "megatron"
+        and config.context_parallel_size > 1
+        and getattr(args, "cp_comm_type", None) is None
+    ):
+        args.cp_comm_type = "a2a"

--- a/miles/true_on_policy/contracts.py
+++ b/miles/true_on_policy/contracts.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 
 from .schema import (
     QWEN3_DENSE_TRUE_ON_POLICY_V1_SCHEMA,
+    QWEN3_MOE_TRUE_ON_POLICY_V1_SCHEMA,
     KernelContract,
     LogprobContract,
     ModelFamily,
@@ -50,10 +51,24 @@ class TrueOnPolicyContract:
         self,
         *,
         train_backend: str,
-        sglang_target: str,
+        parallel_layout=None,
+        sglang_target: str | None = None,
     ) -> dict[str, object]:
         uses_megatron = train_backend == "megatron"
-        uses_tp_invariant_rollout = sglang_target == "fsdp_tp"
+        if parallel_layout is not None:
+            uses_tp_invariant_rollout = (
+                parallel_layout.uses_train_tp
+                or parallel_layout.uses_train_expert_tp
+                or parallel_layout.uses_rollout_tp
+            )
+            uses_ep_invariant_moe = parallel_layout.uses_train_ep or parallel_layout.uses_rollout_ep
+        else:
+            uses_tp_invariant_rollout = sglang_target == "fsdp_tp"
+            uses_ep_invariant_moe = False
+        is_moe = self.model_family == "qwen3_moe"
+        # SGLang attention-DP + EP is not parity-gated for Qwen3-30B-A3B yet.
+        # Keep the true-on-policy launch on the verified EP-only rollout path.
+        sglang_attention_data_parallel_size = 1
         return {
             "deterministic_inference": True,
             "deterministic_training": True,
@@ -64,6 +79,15 @@ class TrueOnPolicyContract:
             "batch_invariant_mode": uses_megatron,
             "tp_invariant_row_linear": uses_tp_invariant_rollout,
             "deterministic_tp_allreduce": uses_tp_invariant_rollout,
+            "deterministic_moe_routing": is_moe,
+            "moe_topk_tiebreak": "stable_sort" if is_moe else None,
+            "deterministic_moe_dispatch": is_moe and uses_ep_invariant_moe,
+            "deterministic_moe_combine": is_moe and uses_ep_invariant_moe,
+            "ep_invariant_moe": is_moe and uses_ep_invariant_moe,
+            "sglang_attention_data_parallel_size": sglang_attention_data_parallel_size,
+            # Qwen3-MoE strict CUDA graph replay returns logits in the same dtype
+            # as eager decode, so the sampler/logprob path remains exact-zero.
+            "disable_sglang_cuda_graph": False,
         }
 
 
@@ -71,9 +95,14 @@ QWEN3_DENSE_TRUE_ON_POLICY_V1 = TrueOnPolicyContract(
     schema=QWEN3_DENSE_TRUE_ON_POLICY_V1_SCHEMA,
 )
 
+QWEN3_MOE_TRUE_ON_POLICY_V1 = TrueOnPolicyContract(
+    schema=QWEN3_MOE_TRUE_ON_POLICY_V1_SCHEMA,
+)
+
 
 _CONTRACT_BY_NAME = {
     QWEN3_DENSE_TRUE_ON_POLICY_V1.name: QWEN3_DENSE_TRUE_ON_POLICY_V1,
+    QWEN3_MOE_TRUE_ON_POLICY_V1.name: QWEN3_MOE_TRUE_ON_POLICY_V1,
 }
 
 

--- a/miles/true_on_policy/model_profiles.py
+++ b/miles/true_on_policy/model_profiles.py
@@ -2,7 +2,13 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from .contracts import QWEN3_DENSE_TRUE_ON_POLICY_V1, LogprobContract, ModelFamily, TrueOnPolicyContract
+from .contracts import (
+    QWEN3_DENSE_TRUE_ON_POLICY_V1,
+    QWEN3_MOE_TRUE_ON_POLICY_V1,
+    LogprobContract,
+    ModelFamily,
+    TrueOnPolicyContract,
+)
 
 ParallelLayout = str
 
@@ -48,6 +54,10 @@ class TrueOnPolicyModelProfile:
     def supports_tp_invariant(self) -> bool:
         return "tp" in self.supported_train_layouts or "tp" in self.supported_rollout_layouts
 
+    @property
+    def supports_ep_invariant(self) -> bool:
+        return "ep" in self.supported_train_layouts or "ep" in self.supported_rollout_layouts
+
     def megatron_model_type_for(self, model_name: str) -> str:
         try:
             return self.megatron_model_types[model_name]
@@ -78,8 +88,17 @@ QWEN3_DENSE_PROFILE = TrueOnPolicyModelProfile(
     contract=QWEN3_DENSE_TRUE_ON_POLICY_V1,
 )
 
+QWEN3_MOE_PROFILE = TrueOnPolicyModelProfile(
+    family="qwen3_moe",
+    model_names=("Qwen3-30B-A3B",),
+    megatron_model_types={"Qwen3-30B-A3B": "qwen3-30B-A3B"},
+    supported_train_layouts=("dp", "tp", "expert_tp", "ep", "pp", "ulysses_cp"),
+    supported_rollout_layouts=("dp", "tp", "ep"),
+    contract=QWEN3_MOE_TRUE_ON_POLICY_V1,
+)
 
-_MODEL_PROFILES = (QWEN3_DENSE_PROFILE,)
+
+_MODEL_PROFILES = (QWEN3_DENSE_PROFILE, QWEN3_MOE_PROFILE)
 _PROFILE_BY_MODEL_NAME = {model_name: profile for profile in _MODEL_PROFILES for model_name in profile.model_names}
 
 

--- a/miles/true_on_policy/schema.py
+++ b/miles/true_on_policy/schema.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Literal
 
-
-TrueOnPolicyContractName = Literal["qwen3_dense_true_on_policy_v1"]
+TrueOnPolicyContractName = Literal[
+    "qwen3_dense_true_on_policy_v1",
+    "qwen3_moe_true_on_policy_v1",
+]
 ModelFamily = Literal["qwen3_dense", "qwen3_moe", "qwen3_next"]
-KernelContract = Literal["qwen3_dense_sglang_math"]
+KernelContract = Literal["qwen3_dense_sglang_math", "qwen3_moe_sglang_math"]
 LogprobContract = Literal["sglang_prefill"]
 
 
@@ -27,6 +29,16 @@ QWEN3_DENSE_TRUE_ON_POLICY_V1_SCHEMA = TrueOnPolicyContractSchema(
     name="qwen3_dense_true_on_policy_v1",
     model_family="qwen3_dense",
     required_kernel_contracts=("qwen3_dense_sglang_math",),
+    logprob_contract="sglang_prefill",
+    sglang_attention_backend="fa3",
+    fsdp_attention_implementation="flash_attention_3",
+    disable_megatron_sequence_parallel=True,
+)
+
+QWEN3_MOE_TRUE_ON_POLICY_V1_SCHEMA = TrueOnPolicyContractSchema(
+    name="qwen3_moe_true_on_policy_v1",
+    model_family="qwen3_moe",
+    required_kernel_contracts=("qwen3_dense_sglang_math", "qwen3_moe_sglang_math"),
     logprob_contract="sglang_prefill",
     sglang_attention_backend="fa3",
     fsdp_attention_implementation="flash_attention_3",

--- a/tests/fast/true_on_policy/test_config.py
+++ b/tests/fast/true_on_policy/test_config.py
@@ -6,6 +6,7 @@ import pytest
 
 from miles.true_on_policy import (
     QWEN3_DENSE_TRUE_ON_POLICY_V1,
+    QWEN3_MOE_TRUE_ON_POLICY_V1,
     apply_true_on_policy_script_defaults,
     build_true_on_policy_launch_plan,
     get_megatron_model_type,
@@ -22,10 +23,14 @@ def _args(**overrides):
         "tensor_model_parallel_size": 2,
         "context_parallel_size": 4,
         "pipeline_model_parallel_size": 1,
+        "expert_model_parallel_size": 1,
+        "expert_tensor_parallel_size": 1,
         "rollout_num_gpus_per_engine": 1,
-        "sglang_rl_on_policy_target": None,
+        "sglang_expert_parallel_size": 1,
         "true_on_policy_contract": None,
         "use_sequence_parallel": True,
+        "num_nodes": 1,
+        "num_gpus_per_node": 8,
     }
     values.update(overrides)
     return SimpleNamespace(**values)
@@ -55,6 +60,23 @@ def test_unknown_true_on_policy_model_fails_early():
         get_true_on_policy_model_profile("unknown-model")
 
 
+def test_qwen3_moe_profile_resolves_ep_contract():
+    profile = get_true_on_policy_model_profile("Qwen3-30B-A3B")
+    contract = get_true_on_policy_contract("qwen3_moe_true_on_policy_v1")
+
+    assert profile.family == "qwen3_moe"
+    assert profile.contract is QWEN3_MOE_TRUE_ON_POLICY_V1
+    assert profile.contract is contract
+    assert contract.schema.model_family == "qwen3_moe"
+    assert profile.required_kernel_contracts == (
+        "qwen3_dense_sglang_math",
+        "qwen3_moe_sglang_math",
+    )
+    assert "ep" in profile.supported_train_layouts
+    assert profile.supports_ep_invariant
+    assert get_megatron_model_type("Qwen3-30B-A3B") == "qwen3-30B-A3B"
+
+
 @pytest.mark.parametrize(
     ("tp_size", "rollout_tp_size", "expected_target"),
     [
@@ -77,7 +99,6 @@ def test_true_on_policy_target_is_derived_from_train_and_rollout_tp(
     apply_true_on_policy_script_defaults(args)
     plan = build_true_on_policy_launch_plan(args)
 
-    assert args.sglang_rl_on_policy_target is None
     assert plan.sglang_target == expected_target
     assert plan.contract is QWEN3_DENSE_TRUE_ON_POLICY_V1
     assert plan.sglang_args.values == (
@@ -87,26 +108,145 @@ def test_true_on_policy_target_is_derived_from_train_and_rollout_tp(
         "--sglang-attention-backend",
         "fa3",
     )
-    assert "--sglang-rl-on-policy-target" not in plan.train_args
 
 
-def test_legacy_sglang_target_override_does_not_change_contract_policy():
+def test_qwen3_moe_ep_is_separate_from_tp_invariant_rollout():
     args = _args(
-        tensor_model_parallel_size=2,
-        context_parallel_size=1,
+        model_name="Qwen3-30B-A3B",
+        tensor_model_parallel_size=1,
+        context_parallel_size=2,
+        expert_model_parallel_size=4,
+        expert_tensor_parallel_size=1,
         rollout_num_gpus_per_engine=1,
-        sglang_rl_on_policy_target="fsdp",
+        true_on_policy_contract=None,
     )
 
-    apply_true_on_policy_script_defaults(args)
     plan = build_true_on_policy_launch_plan(args)
 
-    assert args.sglang_rl_on_policy_target == "fsdp"
+    assert plan.sglang_target == "fsdp"
+    assert plan.contract is QWEN3_MOE_TRUE_ON_POLICY_V1
+    assert plan.parallel_layout is not None
+    assert plan.parallel_layout.uses_train_ep
+    assert not plan.parallel_layout.uses_train_tp
+    assert not plan.parallel_layout.uses_train_expert_tp
+    assert plan.kernel_policy is not None
+    assert not plan.kernel_policy.tp_invariant_row_linear
+    assert not plan.kernel_policy.deterministic_tp_allreduce
+    assert plan.kernel_policy.ep_invariant_moe
+    assert plan.kernel_policy.deterministic_moe_routing
+    assert plan.kernel_policy.moe_topk_tiebreak == "stable_sort"
+    assert not plan.kernel_policy.disable_sglang_cuda_graph
+    assert plan.env_vars["MILES_TRUE_ON_POLICY_ROLLOUT_TP_SIZE"] == "1"
+    assert plan.env_vars["SGLANG_TRUE_ON_POLICY_FUSED_RMSNORM"] == "1"
+    assert plan.env_vars["MODEL_ARGS_DISABLE_MOE_PERMUTE_FUSION"] == "1"
+    assert "--sglang-disable-cuda-graph" not in plan.train_args
+    assert "--sglang-true-on-policy-contract qwen3_moe_true_on_policy_v1" in plan.train_args
+    assert "--true-on-policy-contract qwen3_moe_true_on_policy_v1" in plan.train_args
+
+
+def test_qwen3_moe_rollout_ep_does_not_enable_unverified_dp_attention():
+    args = _args(
+        model_name="Qwen3-30B-A3B",
+        tensor_model_parallel_size=1,
+        context_parallel_size=2,
+        expert_model_parallel_size=4,
+        expert_tensor_parallel_size=1,
+        rollout_num_gpus_per_engine=4,
+        sglang_expert_parallel_size=4,
+    )
+
+    plan = build_true_on_policy_launch_plan(args)
+
+    assert plan.kernel_policy is not None
+    assert plan.kernel_policy.sglang_attention_data_parallel_size == 1
+    assert "--sglang-data-parallel-size" not in plan.train_args
+    assert "--sglang-enable-dp-attention" not in plan.train_args
+
+
+def test_qwen3_moe_rollout_tp_still_enables_tp_invariant_math():
+    args = _args(
+        model_name="Qwen3-30B-A3B",
+        tensor_model_parallel_size=1,
+        context_parallel_size=2,
+        expert_model_parallel_size=4,
+        rollout_num_gpus_per_engine=8,
+    )
+
+    plan = build_true_on_policy_launch_plan(args)
+
     assert plan.sglang_target == "fsdp_tp"
     assert plan.kernel_policy is not None
     assert plan.kernel_policy.tp_invariant_row_linear
-    assert "--sglang-rl-on-policy-target" not in plan.train_args
-    assert "ROW_LINEAR_ENABLE_INV" not in plan.env_vars
+    assert plan.kernel_policy.deterministic_tp_allreduce
+    assert plan.kernel_policy.ep_invariant_moe
+    assert plan.env_vars["MILES_TRUE_ON_POLICY_ROLLOUT_TP_SIZE"] == "8"
+    assert plan.env_vars["SGLANG_TRUE_ON_POLICY_FUSED_RMSNORM"] == "1"
+
+
+@pytest.mark.parametrize(
+    ("tp_size", "ep_size", "cp_size"),
+    [
+        (1, 4, 2),
+        (4, 1, 2),
+    ],
+)
+def test_qwen3_moe_valid_8_gpu_megatron_training_topologies(
+    tp_size: int,
+    ep_size: int,
+    cp_size: int,
+):
+    args = _args(
+        model_name="Qwen3-30B-A3B",
+        tensor_model_parallel_size=tp_size,
+        context_parallel_size=cp_size,
+        expert_model_parallel_size=ep_size,
+        expert_tensor_parallel_size=1,
+        rollout_num_gpus_per_engine=max(tp_size, ep_size),
+        sglang_expert_parallel_size=ep_size,
+        num_nodes=1,
+        num_gpus_per_node=8,
+    )
+
+    plan = build_true_on_policy_launch_plan(args)
+
+    assert plan.parallel_layout is not None
+    assert plan.parallel_layout.train_tensor_parallel_size == tp_size
+    assert plan.parallel_layout.train_expert_model_parallel_size == ep_size
+    assert plan.parallel_layout.train_context_parallel_size == cp_size
+
+
+def test_qwen3_moe_rejects_train_tp_with_ep_until_sequence_parallel_is_supported():
+    args = _args(
+        model_name="Qwen3-30B-A3B",
+        tensor_model_parallel_size=2,
+        context_parallel_size=1,
+        expert_model_parallel_size=4,
+        expert_tensor_parallel_size=1,
+        rollout_num_gpus_per_engine=4,
+        sglang_expert_parallel_size=4,
+        num_nodes=1,
+        num_gpus_per_node=8,
+    )
+
+    with pytest.raises(ValueError, match="does not support train TP with EP yet"):
+        build_true_on_policy_launch_plan(args)
+
+
+def test_qwen3_moe_rejects_ep_that_does_not_fit_8_gpu_megatron_dp():
+    args = _args(
+        model_name="Qwen3-30B-A3B",
+        tensor_model_parallel_size=1,
+        context_parallel_size=4,
+        expert_model_parallel_size=4,
+        expert_tensor_parallel_size=1,
+        rollout_num_gpus_per_engine=4,
+        sglang_expert_parallel_size=4,
+        num_nodes=1,
+        num_gpus_per_node=8,
+    )
+
+    with pytest.raises(ValueError, match="needs at least 16 train GPUs"):
+        build_true_on_policy_launch_plan(args)
 
 
 def test_contract_object_owns_miles_kernel_policy_values():
@@ -140,7 +280,7 @@ def test_megatron_true_on_policy_disables_sequence_parallel_and_enables_backend_
     assert "--use-sglang" not in plan.train_args
     assert "--true-on-policy-contract qwen3_dense_true_on_policy_v1" in plan.train_args
     assert "--sglang-true-on-policy-contract qwen3_dense_true_on_policy_v1" in plan.train_args
-    assert "--recompute-logprobs-via-prefill" in plan.train_args
+    assert "--recompute-logprobs-via-prefill" not in plan.train_args
     assert "--batch-invariant-mode" in plan.train_args
     assert "--no-rope-fusion" in plan.train_args
     assert "ROW_LINEAR_ENABLE_INV" not in plan.env_vars
@@ -163,7 +303,6 @@ def test_megatron_tp2_cp4_normal_topology_has_complete_true_on_policy_contract(m
     plan = build_true_on_policy_launch_plan(args)
 
     assert args.use_sequence_parallel is False
-    assert args.sglang_rl_on_policy_target is None
     assert plan.parallel_layout is not None
     assert plan.parallel_layout.train_tensor_parallel_size == 2
     assert plan.parallel_layout.train_context_parallel_size == 4
@@ -194,12 +333,16 @@ def test_megatron_tp2_cp4_normal_topology_has_complete_true_on_policy_contract(m
     assert plan.miles_args.values == (
         "--deterministic-mode",
         "--true-on-policy-mode",
-        "--recompute-logprobs-via-prefill",
     )
     assert plan.env_vars == {
         "NCCL_ALGO": "Ring",
+        "NCCL_NVLS_ENABLE": "0",
         "NVTE_ALLOW_NONDETERMINISTIC_ALGO": "0",
         "CUBLAS_WORKSPACE_CONFIG": ":4096:8",
+        "MILES_TRUE_ON_POLICY_ROLLOUT_TP_SIZE": "8",
+        "SGLANG_TRUE_ON_POLICY_FUSED_RMSNORM": "1",
+        "SGLANG_BATCH_INVARIANT_OPS_ENABLE_MM_DEEPGEMM": "0",
+        "SGLANG_BATCH_INVARIANT_OPS_ENABLE_MM_FALLBACK_VARIANT": "0",
     }
 
 
@@ -237,7 +380,6 @@ def test_off_policy_builds_empty_launch_plan_and_does_not_mutate_args():
     plan = build_true_on_policy_launch_plan(args)
 
     assert args.use_sequence_parallel is True
-    assert args.sglang_rl_on_policy_target is None
     assert not plan.enabled
     assert plan.train_args == ""
     assert plan.env_vars == {}


### PR DESCRIPTION
Stacked split of #1059, rebuilt after rebasing onto latest `main`.

Base branch: `split/pr1059-03-contract-config`
Head branch: `split/pr1059-04-config-tests`

This is PR 4 of 12. The stack is cumulative; the final branch is the rebased equivalent of the original PR head without stale-base reversions.