### PR TITLE
[5/12] Add common Qwen3 MoE weight update helpers

### DIFF
--- a/miles/backends/megatron_utils/update_weight/common.py
+++ b/miles/backends/megatron_utils/update_weight/common.py
@@ -47,6 +47,74 @@ def _check_and_fix_partition(args: Namespace, name: str, partition_stride: int, 
     return partition_stride, partition_dim
 
 
+def _set_tensor_parallel_attrs(
+    tensor: torch.Tensor,
+    *,
+    source: torch.Tensor,
+    partition_dim: int,
+    partition_stride: int,
+) -> torch.Tensor:
+    tensor.tensor_model_parallel = getattr(source, "tensor_model_parallel", False)
+    tensor.partition_dim = partition_dim
+    tensor.partition_stride = partition_stride
+    tensor.parallel_mode = getattr(source, "parallel_mode", None)
+    return tensor
+
+
+def _iter_grouped_moe_expert_params(
+    args: Namespace,
+    *,
+    layer_idx: int,
+    rest: str,
+    param: torch.Tensor,
+    expert_offset: int,
+    ep_size: int,
+) -> Iterator[tuple[str, torch.Tensor]]:
+    """Expand Megatron GroupedMLP tensors into per-expert HF-oriented tensors.
+
+    Megatron's grouped MoE path stores all local experts in two tensors:
+    `mlp.experts.weight1` and `mlp.experts.weight2`. SGLang's update path expects
+    per-expert HF names, so EP ranks must expose globally indexed expert slices.
+    """
+    num_experts = getattr(args, "num_experts", None)
+    hidden_size = getattr(args, "hidden_size", None)
+    if not num_experts or not hidden_size:
+        raise ValueError(f"Cannot expand grouped MoE parameter {rest}: missing num_experts/hidden_size")
+
+    num_local_experts = num_experts // ep_size
+    if num_local_experts <= 0:
+        raise ValueError(f"Cannot expand grouped MoE parameter {rest}: invalid local expert count")
+
+    if rest == "mlp.experts.weight1":
+        experts = param.view(num_local_experts, hidden_size, -1)
+        target_rest = "linear_fc1"
+        partition_dim = 0
+        partition_stride = 2 if getattr(args, "swiglu", False) else 1
+    elif rest == "mlp.experts.weight2":
+        experts = param.view(num_local_experts, -1, hidden_size)
+        target_rest = "linear_fc2"
+        partition_dim = 1
+        partition_stride = 1
+    else:
+        raise ValueError(f"Unexpected grouped MoE parameter name: {rest}")
+
+    for local_expert_idx, expert in enumerate(experts):
+        expert_idx = expert_offset + local_expert_idx
+        # Grouped GEMM stores weights in forward matmul orientation. HF/SGLang
+        # loaders expect Linear weight orientation, so transpose the expert slice.
+        expert = expert.transpose(0, 1)
+        expert = _set_tensor_parallel_attrs(
+            expert,
+            source=param,
+            partition_dim=partition_dim,
+            partition_stride=partition_stride,
+        )
+        yield (
+            f"module.module.decoder.layers.{layer_idx}.mlp.experts.{target_rest}.weight{expert_idx}",
+            expert,
+        )
+
+
 def all_gather_param(args: Namespace, name: str, param: torch.nn.Parameter) -> torch.Tensor:
     """
     All-gather TP-sharded param to full tensor. expert_bias→param, non-TP/duplicated→param.data.
@@ -65,6 +133,9 @@ def all_gather_param(args: Namespace, name: str, param: torch.nn.Parameter) -> t
     else:
         tp_size = get_parallel_state().tp.size
         tp_group = get_parallel_state().tp.group
+
+    if tp_size == 1:
+        return param.data
 
     param_partitions = [torch.empty_like(param.data) for _ in range(tp_size)]
     dist.all_gather(param_partitions, param.data, group=tp_group)
@@ -105,6 +176,11 @@ def all_gather_params_async(
             else:
                 tp_size = get_parallel_state().tp.size
                 tp_group = get_parallel_state().tp.group
+
+            if tp_size == 1:
+                gather_tasks.append((info, param.data, None, None, None, None))
+                handles.append(None)
+                continue
 
             param_partitions = [torch.empty_like(param.data) for _ in range(tp_size)]
             handle = dist.all_gather(param_partitions, param.data, group=tp_group, async_op=True)
@@ -157,6 +233,10 @@ def _maybe_get_cpu_backup(x: torch.Tensor):
     if (cpu_tensor := torch_memory_saver.get_cpu_backup(x)) is not None:
         return cpu_tensor
 
+    base = getattr(x, "_base", None)
+    if base is not None and (cpu_base := torch_memory_saver.get_cpu_backup(base)) is not None:
+        return torch.as_strided(cpu_base, size=x.size(), stride=x.stride(), storage_offset=x.storage_offset())
+
     return x
 
 
@@ -185,8 +265,8 @@ def _named_params_and_buffers_global(
     """
     ep_size = get_parallel_state().ep.size
     ep_rank = get_parallel_state().ep.rank
-    if args.num_experts:
-        expert_offset = ep_rank * args.num_experts // ep_size
+    num_experts = getattr(args, "num_experts", None)
+    expert_offset = ep_rank * num_experts // ep_size if num_experts else 0
 
     sig = inspect.signature(get_transformer_layer_offset)
     need_vp_stage = "vp_stage" in sig.parameters
@@ -226,6 +306,17 @@ def _named_params_and_buffers_global(
 
             layer_idx, rest = match.groups()
             layer_idx = int(layer_idx) + layer_offset
+
+            if rest in ("mlp.experts.weight1", "mlp.experts.weight2"):
+                yield from _iter_grouped_moe_expert_params(
+                    args,
+                    layer_idx=layer_idx,
+                    rest=rest,
+                    param=param,
+                    expert_offset=expert_offset,
+                    ep_size=ep_size,
+                )
+                continue
 
             # this is hardcoded for te grouped matmul
             expert_pattern = r"mlp.experts\.(.+)\.weight(\d+)"

--- a/miles/backends/megatron_utils/update_weight/hf_weight_iterator_direct.py
+++ b/miles/backends/megatron_utils/update_weight/hf_weight_iterator_direct.py
@@ -56,9 +56,12 @@ def _get_megatron_full_params(
     params = []
     for info in megatron_local_param_infos:
         if dist.get_rank() == info.src_rank:
+            local_param = megatron_local_weights[info.name].to(device=torch.cuda.current_device(), non_blocking=True)
+            if not local_param.is_contiguous():
+                local_param = local_param.contiguous()
             params.append(
                 torch.nn.Parameter(
-                    megatron_local_weights[info.name].to(device=torch.cuda.current_device(), non_blocking=True),
+                    local_param,
                     requires_grad=False,
                 )
             )

--- a/tests/fast/backends/megatron_utils/test_update_weight_common.py
+++ b/tests/fast/backends/megatron_utils/test_update_weight_common.py
@@ -1,0 +1,98 @@
+from argparse import Namespace
+
+import torch
+
+from miles.backends.megatron_utils.update_weight import common
+from miles.utils.types import ParamInfo
+
+
+def test_tp_world_size_one_skips_weight_all_gather(monkeypatch):
+    param = torch.nn.Parameter(torch.arange(4, dtype=torch.float32), requires_grad=False)
+    param.tensor_model_parallel = True
+    param.parallel_mode = None
+    param.partition_dim = 0
+    param.partition_stride = 1
+
+    info = ParamInfo(
+        name="module.module.decoder.layers.0.self_attention.linear_qkv.weight",
+        dtype=param.dtype,
+        shape=param.shape,
+        attrs={
+            "tensor_model_parallel": True,
+            "parallel_mode": None,
+            "partition_dim": 0,
+            "partition_stride": 1,
+        },
+        size=param.numel() * param.element_size(),
+        src_rank=0,
+    )
+
+    monkeypatch.setattr(common.mpu, "get_tensor_model_parallel_world_size", lambda: 1)
+    monkeypatch.setattr(common.mpu, "get_tensor_model_parallel_group", lambda: object())
+
+    def _unexpected_all_gather(*args, **kwargs):
+        raise AssertionError("world-size-1 TP params must not call dist.all_gather")
+
+    monkeypatch.setattr(common.dist, "all_gather", _unexpected_all_gather)
+
+    gathered = common.all_gather_params_async(Namespace(swiglu=False), [(info, param)])
+
+    assert len(gathered) == 1
+    assert gathered[0].data_ptr() == param.data.data_ptr()
+    torch.testing.assert_close(gathered[0], param.data)
+
+
+def test_grouped_moe_weight1_expands_to_global_expert_slices():
+    args = Namespace(num_experts=8, hidden_size=2, swiglu=True)
+    param = torch.arange(24, dtype=torch.float32).view(2, 12)
+    param.tensor_model_parallel = True
+    param.parallel_mode = None
+
+    expanded = list(
+        common._iter_grouped_moe_expert_params(
+            args,
+            layer_idx=3,
+            rest="mlp.experts.weight1",
+            param=param,
+            expert_offset=4,
+            ep_size=4,
+        )
+    )
+
+    assert [name for name, _ in expanded] == [
+        "module.module.decoder.layers.3.mlp.experts.linear_fc1.weight4",
+        "module.module.decoder.layers.3.mlp.experts.linear_fc1.weight5",
+    ]
+    torch.testing.assert_close(expanded[0][1], param.view(2, 2, 6)[0].transpose(0, 1))
+    torch.testing.assert_close(expanded[1][1], param.view(2, 2, 6)[1].transpose(0, 1))
+    assert expanded[0][1].tensor_model_parallel is True
+    assert expanded[0][1].partition_dim == 0
+    assert expanded[0][1].partition_stride == 2
+
+
+def test_grouped_moe_weight2_expands_to_global_expert_slices():
+    args = Namespace(num_experts=8, hidden_size=2, swiglu=True)
+    param = torch.arange(12, dtype=torch.float32).view(6, 2)
+    param.tensor_model_parallel = True
+    param.parallel_mode = None
+
+    expanded = list(
+        common._iter_grouped_moe_expert_params(
+            args,
+            layer_idx=3,
+            rest="mlp.experts.weight2",
+            param=param,
+            expert_offset=4,
+            ep_size=4,
+        )
+    )
+
+    assert [name for name, _ in expanded] == [
+        "module.module.decoder.layers.3.mlp.experts.linear_fc2.weight4",
+        "module.module.decoder.layers.3.mlp.experts.linear_fc2.weight5",
+    ]
+    torch.testing.assert_close(expanded[0][1], param.view(2, 3, 2)[0].transpose(0, 1))
+    torch.testing.assert_close(expanded[1][1], param.view(2, 3, 2)[1].transpose(0, 1))
+    assert expanded[0][1].tensor_model_parallel is True
+    assert expanded[0][1].partition_dim == 1
+    assert expanded[0][1].partition_stride == 1


### PR DESCRIPTION
Stacked split of #1059, rebuilt after rebasing onto latest `main`.

Base branch: `split/pr1059-04-config-tests`
Head branch: `split/pr1059-05-weight-update-common`

This is PR 5 of 12. The stack is cumulative; the final branch is the rebased equivalent of the original PR head without stale-base reversions.