### PR TITLE
[7/12] Track true-on-policy training metric dtypes

### DIFF
--- a/miles/backends/megatron_utils/actor.py
+++ b/miles/backends/megatron_utils/actor.py
@@ -220,6 +220,7 @@ class MegatronTrainRayActor(TrainRayActor):
 
         clear_memory()
         reload_process_groups()
+        dist.barrier(group=get_gloo_group())
         print_memory("after wake_up model")
 
     @property

--- a/miles/backends/megatron_utils/megatron_to_hf/qwen3moe.py
+++ b/miles/backends/megatron_utils/megatron_to_hf/qwen3moe.py
@@ -28,6 +28,7 @@ def convert_qwen3moe_to_hf(args, name, param):
         if match:
             rest, expert_idx = match.groups()
             if rest == "linear_fc1":
+                param = param.contiguous()
                 gate_weight, up_weight = param.chunk(2, dim=0)
                 outputs = [
                     (f"model.layers.{layer_idx}.mlp.experts.{expert_idx}.gate_proj.weight", gate_weight),
@@ -35,6 +36,7 @@ def convert_qwen3moe_to_hf(args, name, param):
                 ]
                 return outputs
             elif rest == "linear_fc2":
+                param = param.contiguous()
                 outputs = [
                     (f"model.layers.{layer_idx}.mlp.experts.{expert_idx}.down_proj.weight", param),
                 ]
@@ -98,6 +100,8 @@ def convert_qwen3moe_to_hf(args, name, param):
         elif rest == "mlp.linear_fc2.weight":
             return [(f"model.layers.{layer_idx}.mlp.down_proj.weight", param)]
         elif rest == "self_attention.linear_qkv.layer_norm_weight":
+            return [(f"model.layers.{layer_idx}.input_layernorm.weight", param)]
+        elif rest == "input_layernorm.weight":
             return [(f"model.layers.{layer_idx}.input_layernorm.weight", param)]
         elif rest == "mlp.linear_fc1.layer_norm_weight":
             return [(f"model.layers.{layer_idx}.post_attention_layernorm.weight", param)]

--- a/miles/backends/megatron_utils/model.py
+++ b/miles/backends/megatron_utils/model.py
@@ -4,6 +4,7 @@ import logging
 import math
 from argparse import Namespace
 from collections.abc import Callable, Sequence
+from contextlib import nullcontext
 from functools import partial
 from pathlib import Path
 
@@ -46,6 +47,19 @@ logger = logging.getLogger(__name__)
 
 from .bridge_lora_helpers import _ensure_model_list, _setup_lora_model_via_bridge  # noqa: F401
 from .lora_utils import save_lora_checkpoint
+
+
+def _sglang_moe_rollout_context(batch):
+    try:
+        from miles_megatron_plugins.true_on_policy.moe import sglang_moe_rollout_context
+    except Exception:
+        return nullcontext()
+
+    return sglang_moe_rollout_context(
+        sample_indices=batch.get("sample_indices"),
+        rollout_dp_ranks=batch.get("rollout_dp_ranks"),
+        token_counts=batch.get("local_token_counts"),
+    )
 
 
 def get_optimizer_param_scheduler(args: Namespace, optimizer: MegatronOptimizer) -> OptimizerParamScheduler:
@@ -252,6 +266,8 @@ def forward_only(
                 "total_lengths",
                 "response_lengths",
                 "max_seq_lens",
+                "sample_indices",
+                "rollout_dp_ranks",
             ],
             args.data_pad_size_multiplier,
             args.qkv_format,
@@ -262,15 +278,21 @@ def forward_only(
         packed_seq_params = get_packed_seq_params(batch, args)
         total_lengths = batch["total_lengths"]
         response_lengths = batch["response_lengths"]
-        output_tensor = model(
-            input_ids=tokens,
-            position_ids=None,
-            attention_mask=None,
-            labels=None,
-            packed_seq_params=packed_seq_params,
-            loss_mask=batch["full_loss_masks"],
-            **(batch["multimodal_train_inputs"] if batch["multimodal_train_inputs"] is not None else {}),
-        )
+        model_kwargs = {}
+        if args.true_on_policy_mode:
+            model_kwargs["fp32_output"] = False
+        with _sglang_moe_rollout_context(batch):
+            output_tensor = model(
+                input_ids=tokens,
+                position_ids=None,
+                attention_mask=None,
+                labels=None,
+                packed_seq_params=packed_seq_params,
+                loss_mask=batch["full_loss_masks"],
+                padding_mask=batch["padding_mask"],
+                **model_kwargs,
+                **(batch["multimodal_train_inputs"] if batch["multimodal_train_inputs"] is not None else {}),
+            )
 
         return output_tensor, partial(
             f,
@@ -403,6 +425,8 @@ def train_one_step(
                 "returns",
                 "rollout_log_probs",
                 "max_seq_lens",
+                "sample_indices",
+                "rollout_dp_ranks",
             ],
             args.data_pad_size_multiplier,
             args.qkv_format,
@@ -417,14 +441,16 @@ def train_one_step(
 
         if return_schedule_plan:
             assert not args.enable_mtp_training, "MTP training should not be enabled when using combined 1f1b"
-            output_tensor = model.build_schedule_plan(
-                input_ids=batch["tokens"],
-                position_ids=None,
-                attention_mask=None,
-                labels=None,
-                packed_seq_params=get_packed_seq_params(batch, args),
-                loss_mask=batch["full_loss_masks"],
-            )
+            with _sglang_moe_rollout_context(batch):
+                output_tensor = model.build_schedule_plan(
+                    input_ids=batch["tokens"],
+                    position_ids=None,
+                    attention_mask=None,
+                    labels=None,
+                    packed_seq_params=get_packed_seq_params(batch, args),
+                    loss_mask=batch["full_loss_masks"],
+                    padding_mask=batch["padding_mask"],
+                )
         else:
             forward_kwargs = {
                 "input_ids": batch["tokens"],
@@ -433,6 +459,7 @@ def train_one_step(
                 "labels": None,
                 "packed_seq_params": get_packed_seq_params(batch, args),
                 "loss_mask": batch["full_loss_masks"],
+                "padding_mask": batch["padding_mask"],
             }
 
             if args.enable_mtp_training:
@@ -441,7 +468,8 @@ def train_one_step(
             if batch["multimodal_train_inputs"] is not None:
                 forward_kwargs.update(batch["multimodal_train_inputs"])
 
-            output_tensor = model(**forward_kwargs)
+            with _sglang_moe_rollout_context(batch):
+                output_tensor = model(**forward_kwargs)
 
         for m, old_stage in zip(all_replay_managers, old_stages, strict=True):
             m.stage = old_stage

--- a/miles/backends/megatron_utils/update_weight/update_weight_from_tensor.py
+++ b/miles/backends/megatron_utils/update_weight/update_weight_from_tensor.py
@@ -65,14 +65,9 @@ class UpdateWeightFromTensor:
             self._lora_loaded = False
             self._lora_base_synced = False
 
-        # Create IPC gather groups within megatron.
-        for start_rank in range(0, dist.get_world_size(), self.args.rollout_num_gpus_per_engine):
-            end_rank = start_rank + self.args.rollout_num_gpus_per_engine
-            group_ranks = list(range(start_rank, end_rank))
-            new_group = dist.new_group(ranks=group_ranks, backend="gloo")
-            if dist.get_rank() in group_ranks:
-                self._ipc_gather_group = new_group
-                self._ipc_gather_src = start_rank
+        self._ipc_gather_group = None
+        self._ipc_gather_src = None
+        self._ipc_engine = None
 
         self._model_update_groups = None
 
@@ -134,38 +129,90 @@ class UpdateWeightFromTensor:
 
         colocate_gpu_offsets = engine_gpu_offsets[:colocate_engine_nums]
         colocate_gpu_counts = engine_gpu_counts[:colocate_engine_nums]
+        colocate_ipc_group_ranks = self._get_colocated_ipc_group_ranks(
+            colocate_engine_nums,
+            colocate_gpu_offsets,
+            colocate_gpu_counts,
+        )
 
         # Determine whether this rank is covered by any colocated engine.
-        all_colocated_ranks = set()
-        for offset, count in zip(colocate_gpu_offsets, colocate_gpu_counts, strict=True):
-            all_colocated_ranks.update(range(offset, offset + count))
+        all_colocated_ranks = {rank for group_ranks in colocate_ipc_group_ranks for rank in group_ranks}
         rank_has_engine = dist.get_rank() in all_colocated_ranks
 
         # Create IPC Gloo gather groups matching actual engine layout.
-        # Re-create on first call or when engine layout changes (placeholder ranks
-        # that had a group from __init__ but no actual engine need to be reset).
-        if rank_has_engine:
-            if self._ipc_gather_group is None:
-                for i in range(colocate_engine_nums):
-                    group_ranks = list(
-                        range(colocate_gpu_offsets[i], colocate_gpu_offsets[i] + colocate_gpu_counts[i])
-                    )
-                    new_group = dist.new_group(ranks=group_ranks, backend="gloo")
-                    if dist.get_rank() in group_ranks:
-                        self._ipc_gather_group = new_group
-                        self._ipc_gather_src = colocate_gpu_offsets[i]
-        else:
-            # Ranks not covered by any engine (e.g. placeholder GPU slots)
-            self._ipc_gather_group = None
-            self._ipc_gather_src = None
+        # Re-create on connect because MoE EP rollout groups are not necessarily
+        # contiguous global ranks once CP is present.
+        self._ipc_gather_group = None
+        self._ipc_gather_src = None
+        for group_ranks in colocate_ipc_group_ranks:
+            new_group = dist.new_group(ranks=group_ranks, backend="gloo")
+            if rank_has_engine and dist.get_rank() in group_ranks:
+                self._ipc_gather_group = new_group
+                self._ipc_gather_src = group_ranks[0]
 
         # Map training ranks to colocated engine actors.
         self._ipc_engine = None
-        for i, engine in enumerate(self.rollout_engines):
-            start = colocate_gpu_offsets[i]
-            end = start + colocate_gpu_counts[i]
-            if start <= dist.get_rank() < end:
+        for engine, group_ranks in zip(
+            self.rollout_engines[:colocate_engine_nums],
+            colocate_ipc_group_ranks,
+            strict=True,
+        ):
+            if dist.get_rank() in group_ranks:
                 self._ipc_engine = engine
+
+    def _get_colocated_ipc_group_ranks(
+        self,
+        colocate_engine_nums: int,
+        colocate_gpu_offsets: Sequence[int],
+        colocate_gpu_counts: Sequence[int],
+    ) -> list[list[int]]:
+        if colocate_engine_nums == 0:
+            return []
+
+        rollout_ep_size = (
+            getattr(self.args, "sglang_expert_parallel_size", None) or getattr(self.args, "sglang_ep_size", 1) or 1
+        )
+        if rollout_ep_size <= 1:
+            return [
+                list(range(offset, offset + count))
+                for offset, count in zip(
+                    colocate_gpu_offsets,
+                    colocate_gpu_counts,
+                    strict=True,
+                )
+            ]
+
+        parallel_state = get_parallel_state()
+        train_ep_size = parallel_state.ep.size
+        if train_ep_size != rollout_ep_size:
+            raise NotImplementedError(
+                "Colocated SGLang EP weight sync currently requires rollout EP "
+                f"to match Megatron EP ({rollout_ep_size} != {train_ep_size})."
+            )
+        if any(count != rollout_ep_size for count in colocate_gpu_counts):
+            raise NotImplementedError(
+                "Colocated SGLang EP weight sync currently requires each rollout "
+                f"engine to contain exactly one EP group of size {rollout_ep_size}; "
+                f"got engine sizes {list(colocate_gpu_counts)}."
+            )
+
+        if parallel_state.ep.group is None:
+            raise RuntimeError("Megatron EP process group is not initialized.")
+
+        local_ep_group = tuple(dist.get_process_group_ranks(parallel_state.ep.group))
+        all_ep_groups: list[tuple[int, ...] | None] = [None] * dist.get_world_size()
+        dist.all_gather_object(
+            all_ep_groups,
+            local_ep_group,
+            group=get_gloo_group(),
+        )
+        unique_ep_groups = sorted({group for group in all_ep_groups if group is not None})
+        if len(unique_ep_groups) < colocate_engine_nums:
+            raise RuntimeError(
+                "Not enough Megatron EP groups to map colocated SGLang EP engines: "
+                f"need {colocate_engine_nums}, got {len(unique_ep_groups)}."
+            )
+        return [list(group) for group in unique_ep_groups[:colocate_engine_nums]]
 
     @torch.no_grad()
     def update_weights(self) -> None:
@@ -188,7 +235,6 @@ class UpdateWeightFromTensor:
         dist.barrier(group=get_gloo_group())
 
         megatron_local_weights = self.weights_getter()
-
         # For LoRA+distributed: base weights are frozen, skip after first round.
         if not (self.is_lora and self.use_distribute and self._lora_base_synced):
             for hf_named_tensors in self._hf_weight_iterator.get_hf_weight_chunks(

--- a/miles/backends/training_utils/data.py
+++ b/miles/backends/training_utils/data.py
@@ -140,11 +140,16 @@ def get_batch(
 
     cp_size = parallel_state.cp.size
 
+    valid_tokens = [torch.ones_like(t, dtype=torch.bool) for t in tokens]
+
     if qkv_format == "bshd":
         max_seqlen = batch["max_seq_lens"][0]
         assert max([t.size(0) for t in tokens]) <= max_seqlen
         tokens = [slice_with_cp(t, pad_token_id, qkv_format, max_seqlen) for t in tokens]
+        valid_tokens = [slice_with_cp(t, False, qkv_format, max_seqlen) for t in valid_tokens]
+        batch["local_token_counts"] = None
         tokens = torch.stack(tokens)
+        padding_mask = ~torch.stack(valid_tokens)
 
     elif qkv_format == "thd":
         cp_rank = parallel_state.cp.rank
@@ -157,6 +162,7 @@ def get_batch(
                 cu_seqlens_list.append(cu_seqlens_list[-1] + t.size(0))
 
             tokens = torch.cat(tokens, dim=0)
+            valid_tokens = torch.cat(valid_tokens, dim=0)
 
             # Pad global stream so (1) divisible by cp_size (equal chunks),
             # (2) divisible by pad_size (reduce fragmentation).
@@ -164,23 +170,30 @@ def get_batch(
             pad = (global_pad_size - tokens.size(0) % global_pad_size) % global_pad_size
             if pad != 0:
                 tokens = F.pad(tokens, (0, pad), value=pad_token_id)
+                valid_tokens = F.pad(valid_tokens, (0, pad), value=False)
                 cu_seqlens_list.append(cu_seqlens_list[-1] + pad)
 
             cu_seqlens = torch.tensor(cu_seqlens_list, dtype=torch.int, device=torch.cuda.current_device())
             tokens = tokens.chunk(cp_size, dim=0)[cp_rank]
+            valid_tokens = valid_tokens.chunk(cp_size, dim=0)[cp_rank]
+            batch["local_token_counts"] = None
         else:
             tokens = [slice_with_cp(t, pad_token_id, qkv_format) for t in tokens]
+            valid_tokens = [slice_with_cp(t, False, qkv_format) for t in valid_tokens]
+            batch["local_token_counts"] = [int(v.sum().item()) for v in valid_tokens]
 
             cu_seqlens = [0]
             for t in tokens:
                 cu_seqlens.append(cu_seqlens[-1] + t.size(0))
 
             tokens = torch.cat(tokens)
+            valid_tokens = torch.cat(valid_tokens)
 
             # Always pad to reduce memory fragmentation and maybe make the computation faster
             pad = (pad_size - tokens.size(0) % pad_size) % pad_size
             if pad != 0:
                 tokens = F.pad(tokens, (0, pad), value=pad_token_id)
+                valid_tokens = F.pad(valid_tokens, (0, pad), value=False)
                 cu_seqlens.append(cu_seqlens[-1] + pad)
 
             # thd requires the cu_seqlens to be of the origin length
@@ -189,6 +202,7 @@ def get_batch(
         max_seqlen = (cu_seqlens[1:] - cu_seqlens[:-1]).max().item()
 
         tokens = tokens.unsqueeze(0)
+        padding_mask = ~valid_tokens.unsqueeze(0)
 
         batch["cu_seqlens"] = cu_seqlens
         batch["max_seqlen"] = max_seqlen
@@ -196,6 +210,7 @@ def get_batch(
         raise ValueError(f"Unsupported qkv_format: {qkv_format}")
 
     batch["tokens"] = tokens
+    batch["padding_mask"] = padding_mask
 
     if get_position_ids:
         assert not allgather_cp, "allgather CP is not supported for FSDP"

--- a/miles/backends/training_utils/log_utils.py
+++ b/miles/backends/training_utils/log_utils.py
@@ -20,6 +20,11 @@ from .parallel import get_parallel_state
 logger = logging.getLogger(__name__)
 
 
+def _concatenate_log_tensors(values: list[torch.Tensor] | tuple[torch.Tensor, ...]) -> torch.Tensor:
+    """Concatenate rollout tensors after normalizing scalar values."""
+    return torch.cat([value.reshape(1) if value.dim() == 0 else value for value in values]).clone().detach()
+
+
 def gather_log_data(
     metric_name: str,
     args: Namespace,
@@ -132,7 +137,7 @@ def log_rollout_data(rollout_id: int, args: Namespace, rollout_data: RolloutBatc
                 if isinstance(val[0], torch.Tensor):
                     # NOTE: Here we have to do the clone().detach(), otherwise the tensor will be
                     # modified in place and will cause problem for the next rollout.
-                    val = torch.cat(val).clone().detach()
+                    val = _concatenate_log_tensors(val)
                     if key in [
                         "log_probs",
                         "ref_log_probs",
@@ -448,6 +453,14 @@ def log_train_step(
             log_dict_out[f"train/{role_tag}{key}"] = val
 
     log_dict_out["train/step"] = accumulated_step_id
+
+    if getattr(args, "ci_test", False) and getattr(args, "true_on_policy_mode", False) and role == "actor":
+        diff_key = "train/train_rollout_logprob_abs_diff"
+        assert diff_key in log_dict_out, f"CI check failed: missing {diff_key} in true_on_policy_mode"
+        assert log_dict_out[diff_key] == 0.0, (
+            "CI check failed: true_on_policy_mode requires exact train/rollout logprob equality, "
+            f"but {diff_key} is {log_dict_out[diff_key]}"
+        )
 
     if should_log is None:
         should_log = dist.get_rank() == 0

--- a/miles/backends/training_utils/loss_hub/logit_processors.py
+++ b/miles/backends/training_utils/loss_hub/logit_processors.py
@@ -182,7 +182,7 @@ def get_log_probs_and_entropy(
             vocab_size=getattr(args, "vocab_size", None),
         )
 
-        log_probs_list.append(log_prob.squeeze(-1))
+        log_probs_list.append(log_prob.reshape(-1))
         entropy_list.append(entropy)
 
     res = {

--- a/miles/backends/training_utils/loss_hub/losses.py
+++ b/miles/backends/training_utils/loss_hub/losses.py
@@ -108,8 +108,6 @@ def policy_loss_function(
     )
 
     log_probs = log_probs_and_entropy["log_probs"]
-    train_log_probs_list = log_probs
-    old_log_probs_list = old_log_probs
 
     # Pre-gather log probs if needed by OPSM or GSPO to avoid duplicate gathering
     need_full_log_probs = args.use_opsm or args.advantage_estimator == "gspo"
@@ -176,21 +174,6 @@ def policy_loss_function(
     )
 
     pg_loss, pg_clipfrac = compute_policy_loss(ppo_kl, advantages, args.eps_clip, args.eps_clip_high)
-
-    if getattr(args, "dump_details", None) is not None:
-        from miles.backends.training_utils.debug_dump import maybe_dump_policy_loss_debug
-
-        maybe_dump_policy_loss_debug(
-            args=args,
-            batch=batch,
-            train_log_probs=train_log_probs_list,
-            old_log_probs=old_log_probs_list,
-            rollout_log_probs=batch.get("rollout_log_probs"),
-            advantages=batch["advantages"],
-            local_loss_masks=local_loss_mask_list,
-            ppo_kl=ppo_kl,
-            pg_loss=pg_loss,
-        )
 
     if args.use_opsm:
         pg_loss = pg_loss * opsm_mask

--- a/tests/fast/backends/megatron_utils/test_qwen3moe_true_on_policy_conversion.py
+++ b/tests/fast/backends/megatron_utils/test_qwen3moe_true_on_policy_conversion.py
@@ -1,0 +1,30 @@
+from argparse import Namespace
+
+import torch
+
+from tests.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=10, suite="stage-a-fast")
+
+
+def test_qwen3moe_converter_accepts_explicit_true_on_policy_layernorm_names():
+    from miles.backends.megatron_utils.megatron_to_hf.qwen3moe import convert_qwen3moe_to_hf
+
+    args = Namespace(
+        hidden_size=4,
+        kv_channels=2,
+        num_attention_heads=2,
+        num_query_groups=1,
+    )
+    param = torch.ones(4)
+
+    assert convert_qwen3moe_to_hf(
+        args,
+        "module.module.decoder.layers.0.input_layernorm.weight",
+        param,
+    ) == [("model.layers.0.input_layernorm.weight", param)]
+    assert convert_qwen3moe_to_hf(
+        args,
+        "module.module.decoder.layers.0.pre_mlp_layernorm.weight",
+        param,
+    ) == [("model.layers.0.post_attention_layernorm.weight", param)]

--- a/tests/fast/backends/training_utils/test_true_on_policy_data_log_dtype.py
+++ b/tests/fast/backends/training_utils/test_true_on_policy_data_log_dtype.py
@@ -1,6 +1,7 @@
 from argparse import Namespace
 from types import SimpleNamespace
 
+import pytest
 import torch
 
 from miles.backends.training_utils import cp_utils
@@ -60,3 +61,79 @@ def test_true_on_policy_log_checker_passes_when_values_and_dtype_match(monkeypat
     )
 
     assert captured["log_dict"]["log_probs"] == captured["log_dict"]["rollout_log_probs"]
+
+
+def test_true_on_policy_train_step_checker_passes_on_exact_logprob_match():
+    log_dict = log_utils.log_train_step(
+        args=Namespace(ci_test=True, true_on_policy_mode=True),
+        loss_dict={"train_rollout_logprob_abs_diff": 0.0},
+        grad_norm=0.0,
+        rollout_id=0,
+        step_id=0,
+        num_steps_per_rollout=1,
+        should_log=False,
+    )
+
+    assert log_dict["train/train_rollout_logprob_abs_diff"] == 0.0
+
+
+def test_true_on_policy_train_step_checker_rejects_nonzero_logprob_diff():
+    with pytest.raises(AssertionError, match="exact train/rollout logprob equality"):
+        log_utils.log_train_step(
+            args=Namespace(ci_test=True, true_on_policy_mode=True),
+            loss_dict={"train_rollout_logprob_abs_diff": 1e-6},
+            grad_norm=0.0,
+            rollout_id=0,
+            step_id=0,
+            num_steps_per_rollout=1,
+            should_log=False,
+        )
+
+
+def test_rollout_logging_handles_scalar_tensor_lists(monkeypatch):
+    captured = {}
+    parallel_state = SimpleNamespace(
+        tp=SimpleNamespace(rank=0),
+        cp=SimpleNamespace(size=1),
+        is_pp_last_stage=True,
+    )
+
+    monkeypatch.setattr(log_utils, "get_parallel_state", lambda: parallel_state)
+    monkeypatch.setattr(cp_utils, "get_parallel_state", lambda: parallel_state)
+    monkeypatch.setattr(
+        log_utils,
+        "gather_log_data",
+        lambda metric_name, args, rollout_id, log_dict: captured.setdefault("log_dict", log_dict),
+    )
+
+    rollout_data = {
+        "tokens": [torch.tensor([1, 2, 3])],
+        "total_lengths": [3, 3],
+        "response_lengths": [2, 2],
+        "loss_masks": [torch.tensor([1, 1], dtype=torch.int32), torch.tensor([1, 1], dtype=torch.int32)],
+        "log_probs": [
+            torch.tensor([-13.25, -13.5], dtype=torch.bfloat16),
+            torch.tensor([-13.25, -13.5], dtype=torch.bfloat16),
+        ],
+        "rollout_log_probs": [
+            torch.tensor([-13.25, -13.5], dtype=torch.bfloat16),
+            torch.tensor([-13.25, -13.5], dtype=torch.bfloat16),
+        ],
+        "moe_aux_loss": [torch.tensor(1.0), torch.tensor(3.0)],
+    }
+
+    log_utils.log_rollout_data(
+        1,
+        Namespace(
+            ci_test=False,
+            ci_disable_logprobs_checker=False,
+            true_on_policy_mode=True,
+            qkv_format="thd",
+            log_multi_turn=False,
+            log_passrate=False,
+            log_correct_samples=False,
+        ),
+        rollout_data,
+    )
+
+    assert captured["log_dict"]["moe_aux_loss"] == 2.0

--- a/tests/fast/backends/training_utils/test_true_on_policy_loss_metrics.py
+++ b/tests/fast/backends/training_utils/test_true_on_policy_loss_metrics.py
@@ -52,6 +52,40 @@ def _patch_single_rank_masks(monkeypatch):
     )
 
 
+def test_log_probs_remain_1d_for_single_token_true_on_policy_chunks(monkeypatch):
+    args = _make_args(use_rollout_logprobs=False)
+    args.true_on_policy_mode = True
+    args.bf16 = True
+    args.fp16 = False
+    args.vocab_size = 8
+
+    monkeypatch.setattr(
+        loss_utils,
+        "get_parallel_state",
+        lambda: SimpleNamespace(tp=SimpleNamespace(group=None)),
+    )
+    monkeypatch.setattr(
+        loss_utils,
+        "get_responses",
+        lambda *args, **kwargs: iter([(torch.zeros((1, 8), dtype=torch.bfloat16), torch.tensor([3]))]),
+    )
+    monkeypatch.setattr(
+        loss_utils,
+        "calculate_log_probs_and_entropy",
+        lambda *args, **kwargs: (torch.tensor([-2.0], dtype=torch.bfloat16), None),
+    )
+
+    result = loss_utils.get_log_probs_and_entropy(
+        torch.zeros((1, 1, 8), dtype=torch.bfloat16),
+        args=args,
+        unconcat_tokens=[torch.tensor([3])],
+        total_lengths=[1],
+        response_lengths=[1],
+    )
+
+    assert result["log_probs"][0].shape == (1,)
+
+
 @pytest.mark.parametrize(
     ("use_rollout_logprobs", "train_log_probs", "old_log_probs", "rollout_log_probs", "expected_abs_diff"),
     [


### PR DESCRIPTION
Stacked split of #1059, rebuilt after rebasing onto latest `main`.

Base branch: `split/pr1059-06-qwen3moe-weight-wiring`
Head branch: `split/pr1059-07-training-metrics`

This is PR 7 of 12. The stack is cumulative; the final branch is the rebased equivalent of the original PR head without stale-base reversions.