### PR TITLE
[8/12] Add rollout environment wiring for true-on-policy

### DIFF
--- a/miles/ray/rollout.py
+++ b/miles/ray/rollout.py
@@ -2,7 +2,6 @@ import dataclasses
 import itertools
 import logging
 import multiprocessing
-import os
 import random
 import time
 import uuid
@@ -46,7 +45,8 @@ from miles.utils.tracking_utils import init_tracking
 from miles.utils.types import Sample
 
 from ..utils.metric_utils import has_repetition
-from .utils import NOSET_VISIBLE_DEVICES_ENV_VARS_LIST, Lock
+from .rollout_env import build_sglang_rollout_env_vars
+from .utils import Lock
 
 logging.getLogger("httpx").setLevel(logging.WARNING)
 logging.getLogger("httpcore").setLevel(logging.WARNING)
@@ -127,22 +127,12 @@ class ServerGroup:
                 placement_group_bundle_index=reordered_bundle_indices[gpu_index],
             )
 
-            env_vars = {name: "1" for name in NOSET_VISIBLE_DEVICES_ENV_VARS_LIST} | {
-                key: os.environ.get(key, default_val)
-                for key, default_val in {
-                    "SGLANG_JIT_DEEPGEMM_PRECOMPILE": "false",
-                    "SGL_DISABLE_TP_MEMORY_INBALANCE_CHECK": "true",
-                    "SGLANG_DISABLE_TP_MEMORY_INBALANCE_CHECK": "true",
-                    "SGLANG_MEMORY_SAVER_CUDA_GRAPH": "true",
-                    "SGLANG_OPT_USE_CUSTOM_ALL_REDUCE_V2": (
-                        "0" if self.args.colocate and self.args.rollout_num_gpus_per_engine > 1 else "1"
-                    ),
-                    "SGLANG_BATCH_INVARIANT_OPS_ENABLE_MM_FALLBACK_VARIANT": "true",
-                    "SGLANG_ENABLE_HEALTH_ENDPOINT_GENERATION": "false",
-                    "SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_IDLE": "false",
-                }.items()
-            }
-            env_vars.update(dumper_utils.get_sglang_env(self.args))
+            env_vars = build_sglang_rollout_env_vars(
+                dumper_utils.get_sglang_env(self.args),
+                custom_all_reduce_v2_default=(
+                    "0" if self.args.colocate and self.args.rollout_num_gpus_per_engine > 1 else "1"
+                ),
+            )
 
             rollout_engine = RolloutRayActor.options(
                 num_cpus=num_cpus,
@@ -543,7 +533,20 @@ class RolloutManager:
             srv.num_new_engines = 0
 
     def check_weights(self, action: str):
-        return ray.get([engine.check_weights.remote(action=action) for engine in self.rollout_engines])
+        results = ray.get([engine.check_weights.remote(action=action) for engine in self.rollout_engines])
+        failures = []
+        for index, result in enumerate(results):
+            if isinstance(result, dict):
+                success = result.get("success", True)
+                message = result.get("message", result)
+            else:
+                success = getattr(result, "success", True)
+                message = getattr(result, "message", result)
+            if success is False:
+                failures.append(f"engine[{index}]: {message}")
+        if failures:
+            raise RuntimeError(f"SGLang weight checker failed for action={action}: " + "; ".join(failures))
+        return results
 
     def _get_rollout_data(self, rollout_id):
         if self.args.load_debug_rollout_data:
@@ -689,6 +692,14 @@ class RolloutManager:
             "truncated": [1 if sample.status == Sample.Status.TRUNCATED else 0 for sample in samples],
             "sample_indices": [sample.index for sample in samples],
         }
+        rollout_dp_ranks = [
+            sample.metadata.get("rollout_log_probs_dp_rank") if isinstance(sample.metadata, dict) else None
+            for sample in samples
+        ]
+        if any(dp_rank is not None for dp_rank in rollout_dp_ranks):
+            train_data["rollout_dp_ranks"] = [
+                int(dp_rank) if dp_rank is not None else -1 for dp_rank in rollout_dp_ranks
+            ]
 
         # loss mask
         # TODO: compress the loss mask
@@ -773,6 +784,7 @@ class RolloutManager:
                 "loss_masks",
                 "round_number",
                 "sample_indices",
+                "rollout_dp_ranks",
                 "rollout_log_probs",
                 "rollout_routed_experts",
                 "prompt",

--- a/miles/ray/rollout_env.py
+++ b/miles/ray/rollout_env.py
@@ -1,0 +1,48 @@
+import os
+from collections.abc import Mapping
+
+
+# Refer to
+# https://github.com/ray-project/ray/blob/161849364a784442cc659fb9780f1a6adee85fce/python/ray/_private/accelerators/nvidia_gpu.py#L95-L96
+# https://github.com/ray-project/ray/blob/161849364a784442cc659fb9780f1a6adee85fce/python/ray/_private/accelerators/amd_gpu.py#L102-L103
+# https://github.com/ray-project/ray/blob/161849364a784442cc659fb9780f1a6adee85fce/python/ray/_private/accelerators/npu.py#L94-L95
+# https://github.com/ray-project/ray/blob/161849364a784442cc659fb9780f1a6adee85fce/python/ray/_private/accelerators/hpu.py#L116-L117
+# https://github.com/ray-project/ray/blob/161849364a784442cc659fb9780f1a6adee85fce/python/ray/_private/accelerators/neuron.py#L108-L109
+# https://github.com/ray-project/ray/blob/161849364a784442cc659fb9780f1a6adee85fce/python/ray/_private/accelerators/tpu.py#L171-L172
+# https://github.com/ray-project/ray/blob/161849364a784442cc659fb9780f1a6adee85fce/python/ray/_private/accelerators/intel_gpu.py#L97-L98
+NOSET_VISIBLE_DEVICES_ENV_VARS_LIST = [
+    "RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES",
+    "RAY_EXPERIMENTAL_NOSET_ROCR_VISIBLE_DEVICES",
+    "RAY_EXPERIMENTAL_NOSET_ASCEND_RT_VISIBLE_DEVICES",
+    "RAY_EXPERIMENTAL_NOSET_HABANA_VISIBLE_MODULES",
+    "RAY_EXPERIMENTAL_NOSET_NEURON_RT_VISIBLE_CORES",
+    "RAY_EXPERIMENTAL_NOSET_TPU_VISIBLE_CHIPS",
+    "RAY_EXPERIMENTAL_NOSET_ONEAPI_DEVICE_SELECTOR",
+]
+
+
+def build_sglang_rollout_env_vars(
+    dumper_env: dict[str, str] | None = None,
+    env_vars: Mapping[str, str] = os.environ,
+    custom_all_reduce_v2_default: str = "1",
+) -> dict[str, str]:
+    rollout_env = {name: "1" for name in NOSET_VISIBLE_DEVICES_ENV_VARS_LIST} | {
+        key: env_vars.get(key, default_val)
+        for key, default_val in {
+            "SGLANG_JIT_DEEPGEMM_PRECOMPILE": "false",
+            "SGL_DISABLE_TP_MEMORY_INBALANCE_CHECK": "true",
+            "SGLANG_DISABLE_TP_MEMORY_INBALANCE_CHECK": "true",
+            "SGLANG_MEMORY_SAVER_CUDA_GRAPH": "true",
+            "SGLANG_OPT_USE_CUSTOM_ALL_REDUCE_V2": custom_all_reduce_v2_default,
+            "SGLANG_BATCH_INVARIANT_OPS_ENABLE_MM_DEEPGEMM": "1",
+            "SGLANG_BATCH_INVARIANT_OPS_ENABLE_MM_FALLBACK_VARIANT": "true",
+            "SGLANG_ENABLE_HEALTH_ENDPOINT_GENERATION": "false",
+            "SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_IDLE": "false",
+        }.items()
+    }
+    sglang_deepgemm = env_vars.get("SGLANG_ROLLOUT_BATCH_INVARIANT_OPS_ENABLE_MM_DEEPGEMM")
+    if sglang_deepgemm is not None:
+        rollout_env["SGLANG_BATCH_INVARIANT_OPS_ENABLE_MM_DEEPGEMM"] = sglang_deepgemm
+    if dumper_env:
+        rollout_env.update(dumper_env)
+    return rollout_env

--- a/miles/ray/utils.py
+++ b/miles/ray/utils.py
@@ -5,24 +5,7 @@ import ray
 import torch
 from miles.ray.ray_actor import RayActor
 
-
-# Refer to
-# https://github.com/ray-project/ray/blob/161849364a784442cc659fb9780f1a6adee85fce/python/ray/_private/accelerators/nvidia_gpu.py#L95-L96
-# https://github.com/ray-project/ray/blob/161849364a784442cc659fb9780f1a6adee85fce/python/ray/_private/accelerators/amd_gpu.py#L102-L103
-# https://github.com/ray-project/ray/blob/161849364a784442cc659fb9780f1a6adee85fce/python/ray/_private/accelerators/npu.py#L94-L95
-# https://github.com/ray-project/ray/blob/161849364a784442cc659fb9780f1a6adee85fce/python/ray/_private/accelerators/hpu.py#L116-L117
-# https://github.com/ray-project/ray/blob/161849364a784442cc659fb9780f1a6adee85fce/python/ray/_private/accelerators/neuron.py#L108-L109
-# https://github.com/ray-project/ray/blob/161849364a784442cc659fb9780f1a6adee85fce/python/ray/_private/accelerators/tpu.py#L171-L172
-# https://github.com/ray-project/ray/blob/161849364a784442cc659fb9780f1a6adee85fce/python/ray/_private/accelerators/intel_gpu.py#L97-L98
-NOSET_VISIBLE_DEVICES_ENV_VARS_LIST = [
-    "RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES",
-    "RAY_EXPERIMENTAL_NOSET_ROCR_VISIBLE_DEVICES",
-    "RAY_EXPERIMENTAL_NOSET_ASCEND_RT_VISIBLE_DEVICES",
-    "RAY_EXPERIMENTAL_NOSET_HABANA_VISIBLE_MODULES",
-    "RAY_EXPERIMENTAL_NOSET_NEURON_RT_VISIBLE_CORES",
-    "RAY_EXPERIMENTAL_NOSET_TPU_VISIBLE_CHIPS",
-    "RAY_EXPERIMENTAL_NOSET_ONEAPI_DEVICE_SELECTOR",
-]
+from .rollout_env import NOSET_VISIBLE_DEVICES_ENV_VARS_LIST
 
 
 def ray_noset_visible_devices(env_vars=os.environ):

--- a/tests/fast/rollout/test_rollout_env.py
+++ b/tests/fast/rollout/test_rollout_env.py
@@ -1,0 +1,19 @@
+from miles.ray.rollout_env import build_sglang_rollout_env_vars
+
+
+def test_rollout_deepgemm_override_is_sglang_actor_local(monkeypatch):
+    monkeypatch.setenv("SGLANG_BATCH_INVARIANT_OPS_ENABLE_MM_DEEPGEMM", "0")
+    monkeypatch.setenv("SGLANG_ROLLOUT_BATCH_INVARIANT_OPS_ENABLE_MM_DEEPGEMM", "1")
+
+    env_vars = build_sglang_rollout_env_vars()
+
+    assert env_vars["SGLANG_BATCH_INVARIANT_OPS_ENABLE_MM_DEEPGEMM"] == "1"
+
+
+def test_rollout_deepgemm_default_follows_global_env(monkeypatch):
+    monkeypatch.setenv("SGLANG_BATCH_INVARIANT_OPS_ENABLE_MM_DEEPGEMM", "0")
+    monkeypatch.delenv("SGLANG_ROLLOUT_BATCH_INVARIANT_OPS_ENABLE_MM_DEEPGEMM", raising=False)
+
+    env_vars = build_sglang_rollout_env_vars()
+
+    assert env_vars["SGLANG_BATCH_INVARIANT_OPS_ENABLE_MM_DEEPGEMM"] == "0"


### PR DESCRIPTION
Stacked split of #1059, rebuilt after rebasing onto latest `main`.

Base branch: `split/pr1059-07-training-metrics`
Head branch: `split/pr1059-08-rollout-env`

This is PR 8 of 12. The stack is cumulative; the final branch is the rebased equivalent of the original PR head without stale-base reversions.