### PR TITLE
[9/12] Harden launch command and runtime utilities

### DIFF
--- a/miles/backends/training_utils/cp_utils.py
+++ b/miles/backends/training_utils/cp_utils.py
@@ -252,8 +252,12 @@ def slice_with_cp(
     """
     if parallel_state is None:
         parallel_state = get_parallel_state()
-    cp_rank = parallel_state.cp.rank
-    cp_size = parallel_state.cp.size
+    if hasattr(parallel_state, "cp"):
+        cp_rank = parallel_state.cp.rank
+        cp_size = parallel_state.cp.size
+    else:
+        cp_rank = parallel_state.cp_rank
+        cp_size = parallel_state.cp_size
 
     if qkv_format == "bshd":
         assert max_seq_len is not None

--- a/miles/utils/external_utils/command_utils.py
+++ b/miles/utils/external_utils/command_utils.py
@@ -6,6 +6,7 @@ import datetime
 import json
 import os
 import random
+import shlex
 import time
 from dataclasses import dataclass
 from functools import partial
@@ -17,6 +18,32 @@ from miles.utils.typer_utils import dataclass_cli
 _ = exec_command, exec_command_all_ray_node, dataclass_cli
 
 repo_base_dir = Path(os.path.abspath(__file__)).resolve().parents[3]
+
+
+def _runtime_pythonpath(megatron_path: str) -> str:
+    paths = [
+        str(repo_base_dir),
+        megatron_path,
+    ]
+    sglang_python = repo_base_dir.parent / "sglang" / "python"
+    if sglang_python.exists():
+        paths.append(str(sglang_python))
+    if existing := os.environ.get("PYTHONPATH"):
+        paths.extend(existing.split(os.pathsep))
+
+    deduped = []
+    seen = set()
+    for path in paths:
+        if path and path not in seen:
+            deduped.append(path)
+            seen.add(path)
+    return os.pathsep.join(deduped)
+
+
+def _shell_export_env_vars(env_vars: dict[str, str]) -> str:
+    if not env_vars:
+        return ""
+    return "".join(f"export {key}={shlex.quote(str(value))} && " for key, value in env_vars.items())
 
 
 def convert_checkpoint(
@@ -143,10 +170,15 @@ def execute_train(
     if (f := before_ray_job_submit) is not None:
         f()
 
+    runtime_env_vars = {
+        **extra_env_vars,
+        **_parse_extra_env_vars(config.extra_env_vars),
+    }
+
     runtime_env_json = json.dumps(
         {
             "env_vars": {
-                "PYTHONPATH": megatron_path,
+                "PYTHONPATH": _runtime_pythonpath(megatron_path),
                 # If setting this in FSDP, the computation communication overlapping may have issues
                 **(
                     {}
@@ -170,13 +202,13 @@ def execute_train(
                     if config.cuda_core_dump
                     else {}
                 ),
-                **extra_env_vars,
-                **_parse_extra_env_vars(config.extra_env_vars),
+                **runtime_env_vars,
             }
         }
     )
 
     if get_bool_env_var("MILES_SCRIPT_ENABLE_RAY_SUBMIT", "1"):
+        source_env_exports = _shell_export_env_vars(runtime_env_vars)
         cmd_megatron_model_source = (
             f'source "{repo_base_dir}/scripts/models/{megatron_model_type}.sh" && '
             if megatron_model_type is not None
@@ -184,6 +216,7 @@ def execute_train(
         )
         exec_command(
             f"export no_proxy=127.0.0.1 && export PYTHONBUFFERED=16 && "
+            f"{source_env_exports}"
             f"{cmd_megatron_model_source}"
             f"""ray job submit {'' if 'RAY_ADDRESS' in os.environ else '--address="http://127.0.0.1:8265" '}"""
             f"--runtime-env-json='{runtime_env_json}' "
@@ -221,13 +254,12 @@ def get_default_wandb_args(test_file: str, run_name_prefix: str | None = None, r
     if (x := run_name_prefix) is not None:
         wandb_run_name = f"{x}_{wandb_run_name}"
 
-    # Use the actual key value from environment to avoid shell expansion issues
-    wandb_key = os.environ.get("WANDB_API_KEY")
+    # W&B reads WANDB_API_KEY from the environment. Do not place the key on the
+    # command line, because Ray stores and prints entrypoint commands.
     return (
         "--use-wandb "
         f"--wandb-project miles-{test_name} "
         f"--wandb-group {wandb_run_name} "
-        f"--wandb-key '{wandb_key}' "
         "--disable-wandb-random-suffix "
     )
 

--- a/miles/utils/reloadable_process_group.py
+++ b/miles/utils/reloadable_process_group.py
@@ -120,6 +120,7 @@ class ReloadableProcessGroup(torch.distributed.ProcessGroup):
         self.group_info = {
             "ranks": ranks,
         }
+        self._is_member = dist.get_rank(group) >= 0
         pid = os.getpid()
         if pid not in ReloadableProcessGroup.GROUPS:
             ReloadableProcessGroup.GROUPS[pid] = []
@@ -151,9 +152,11 @@ class ReloadableProcessGroup(torch.distributed.ProcessGroup):
         reloadable_groups = ReloadableProcessGroup.GROUPS.get(pid, [])
         logger.info(f"Reloading {len(reloadable_groups)} process groups in pid {pid}")
         old_new_group = old_new_group_dict.get(pid)
-        for reloadable_group in reloadable_groups:
-            if reloadable_group.group is not None:
-                continue
+        pending_groups = sorted(
+            (group for group in reloadable_groups if group.group is None),
+            key=lambda group: tuple(group.group_info["ranks"]),
+        )
+        for reloadable_group in pending_groups:
             group = old_new_group(ranks=reloadable_group.group_info["ranks"], backend="nccl")
             reloadable_group.group = group
 

--- a/miles/utils/tracking_utils/wandb_utils.py
+++ b/miles/utils/tracking_utils/wandb_utils.py
@@ -9,6 +9,21 @@ from miles.utils.env_report import decode_env_report
 logger = logging.getLogger(__name__)
 
 
+def _get_wandb_key(args) -> str | None:
+    if args.wandb_key is not None:
+        return args.wandb_key
+    if key := os.environ.get("WANDB_API_KEY"):
+        return key
+
+    key_file = os.environ.get("WANDB_API_KEY_FILE", "/tmp/.wandb_key_moe")
+    if not key_file or not os.path.exists(key_file):
+        return None
+
+    with open(key_file, encoding="utf-8") as f:
+        key = f.read().strip()
+    return key or None
+
+
 def _is_offline_mode(args) -> bool:
     """Detect whether W&B should run in offline mode.
 
@@ -42,9 +57,8 @@ def init_wandb_primary(args):
 
     offline = _is_offline_mode(args)
 
-    # Only perform explicit login when NOT offline
-    if (not offline) and args.wandb_key is not None:
-        wandb.login(key=args.wandb_key, host=args.wandb_host)
+    if (not offline) and (wandb_key := _get_wandb_key(args)) is not None:
+        wandb.login(key=wandb_key, host=args.wandb_host)
 
     # Prepare wandb init parameters
     # add random 6 length string with characters
@@ -113,8 +127,8 @@ def init_wandb_secondary(args, router_addr=None):
 
     offline = _is_offline_mode(args)
 
-    if (not offline) and args.wandb_key is not None:
-        wandb.login(key=args.wandb_key, host=args.wandb_host)
+    if (not offline) and (wandb_key := _get_wandb_key(args)) is not None:
+        wandb.login(key=wandb_key, host=args.wandb_host)
 
     # Configure settings based on offline/online mode
     if offline:

--- a/tests/fast/test_command_utils.py
+++ b/tests/fast/test_command_utils.py
@@ -1,0 +1,37 @@
+from miles.utils.external_utils import command_utils
+
+
+def test_execute_train_exports_extra_envs_before_model_args_source(monkeypatch):
+    commands = []
+
+    def fake_exec_command(cmd, capture_output=False):
+        commands.append(cmd)
+        return "0" if capture_output else None
+
+    monkeypatch.setattr(command_utils, "exec_command", fake_exec_command)
+    monkeypatch.setattr(command_utils, "check_has_nvlink", lambda: True)
+
+    command_utils.execute_train(
+        train_args="--dummy-train-arg",
+        num_gpus_per_node=8,
+        megatron_model_type="qwen3-30B-A3B",
+        extra_env_vars={
+            "MODEL_ARGS_DISABLE_MOE_PERMUTE_FUSION": "1",
+            "SPACE_VALUE": "a b",
+        },
+        config=command_utils.ExecuteTrainConfig(
+            extra_env_vars='{"CONFIG_VALUE": "from config"}',
+        ),
+    )
+
+    submit_cmd = next(cmd for cmd in commands if "ray job submit" in cmd)
+    source_index = submit_cmd.index("source ")
+    disable_index = submit_cmd.index("export MODEL_ARGS_DISABLE_MOE_PERMUTE_FUSION=1")
+    space_index = submit_cmd.index("export SPACE_VALUE='a b'")
+    config_index = submit_cmd.index("export CONFIG_VALUE='from config'")
+
+    assert disable_index < source_index
+    assert space_index < source_index
+    assert config_index < source_index
+    assert '"MODEL_ARGS_DISABLE_MOE_PERMUTE_FUSION": "1"' in submit_cmd
+    assert '"CONFIG_VALUE": "from config"' in submit_cmd


### PR DESCRIPTION
Stacked split of #1059, rebuilt after rebasing onto latest `main`.

Base branch: `split/pr1059-08-rollout-env`
Head branch: `split/pr1059-09-command-utils`

This is PR 9 of 12. The stack is cumulative; the final branch is the rebased equivalent of the original PR head without stale-base reversions.