### PR TITLE
[11/12] Add deterministic Qwen3 MoE launch scripts

### DIFF
--- a/scripts/models/qwen3-30B-A3B.sh
+++ b/scripts/models/qwen3-30B-A3B.sh
@@ -44,6 +44,9 @@ MODEL_ARGS=(
    --moe-grouped-gemm
    --moe-token-drop-policy probs
    --moe-router-dtype fp32
-   --moe-permute-fusion
    --moe-aux-loss-coeff 0
 )
+
+if [[ "${MODEL_ARGS_DISABLE_MOE_PERMUTE_FUSION:-0}" != "1" ]]; then
+  MODEL_ARGS+=(--moe-permute-fusion)
+fi

--- a/scripts/run_qwen3_30b_a3b.py
+++ b/scripts/run_qwen3_30b_a3b.py
@@ -15,6 +15,17 @@ class ScriptArgs(U.ExecuteTrainConfig):
     num_gpus_per_node: int | None = None
     hardware: Literal["H100", "B200", "B300", "GB200", "GB300"] = "H100"
     enable_eval: bool = True
+    tensor_model_parallel_size: int | None = None
+    pipeline_model_parallel_size: int = 1
+    context_parallel_size: int | None = None
+    cp_comm_type: Literal["p2p", "a2a", "all_gather", "allgather", "a2a+p2p"] | None = None
+    expert_model_parallel_size: int | None = None
+    expert_tensor_parallel_size: int = 1
+    rollout_num_gpus: int | None = None
+    rollout_num_gpus_per_engine: int | None = None
+    sglang_expert_parallel_size: int | None = None
+    use_sequence_parallel: bool = True
+    max_tokens_per_gpu: int = 32768
     extra_args: str = ""
     data_dir: str = "/root/datasets"
     model_dir: str = "/root/models"
@@ -27,11 +38,37 @@ class ScriptArgs(U.ExecuteTrainConfig):
     train_mxfp8: bool = False
     enable_megatron_bridge: bool = False
     enable_mis: bool = False
-    # TODO improve, should be able to override more easily
     tis_use_rs: bool = True
 
     def __post_init__(self):
+        if self.cp_comm_type == "allgather":
+            self.cp_comm_type = "all_gather"
         self.num_gpus_per_node = self.num_gpus_per_node or U.NUM_GPUS_OF_HARDWARE[self.hardware]
+        if self.tensor_model_parallel_size is None:
+            self.tensor_model_parallel_size = 4
+        if self.context_parallel_size is None:
+            self.context_parallel_size = 1
+        if self.expert_model_parallel_size is None:
+            if self.hardware == "H100":
+                self.expert_model_parallel_size = 8
+            else:
+                self.expert_model_parallel_size = self.num_gpus_per_node if self.train_mxfp8 else 4
+        if self.rollout_num_gpus_per_engine is None:
+            if self.rollout_fp8:
+                self.rollout_num_gpus_per_engine = 2
+            elif self.rollout_int4:
+                self.rollout_num_gpus_per_engine = 1
+            elif self.hardware == "H100":
+                self.rollout_num_gpus_per_engine = 8
+            else:
+                self.rollout_num_gpus_per_engine = 4
+        if self.sglang_expert_parallel_size is None:
+            self.sglang_expert_parallel_size = 1
+        if self.sglang_expert_parallel_size > self.rollout_num_gpus_per_engine:
+            raise ValueError(
+                "sglang_expert_parallel_size cannot exceed rollout_num_gpus_per_engine "
+                f"({self.sglang_expert_parallel_size} > {self.rollout_num_gpus_per_engine})"
+            )
         if self.rollout_int4:
             assert not self.rollout_fp8, "rollout_int4 and rollout_fp8 cannot be enabled at the same time"
             assert not self.rollout_mxfp8, "rollout_int4 and rollout_mxfp8 cannot be enabled at the same time"
@@ -79,6 +116,7 @@ def prepare(args: ScriptArgs):
 
 # TODO improve layering: split algorithm vs infra
 def execute(args: ScriptArgs):
+    is_debug_mode = args.mode == "debug_minimal"
     ref_load_path = (
         f"{args.model_dir}/{args.model_name}/"
         if args.enable_megatron_bridge
@@ -99,8 +137,8 @@ def execute(args: ScriptArgs):
         f"--ref-load {ref_load_path} "
         f"--load {load_save_path} "
         f"--save {load_save_path} "
-        f"--save-interval {2 if args.mode == 'debug_minimal' else 20} "
-        f"--save-retain-interval {2 if args.mode == 'debug_minimal' else 20} "
+        f"--save-interval {2 if is_debug_mode else 20} "
+        f"--save-retain-interval {2 if is_debug_mode else 20} "
     )
 
     rollout_args = (
@@ -120,7 +158,7 @@ def execute(args: ScriptArgs):
     )
 
     eval_args = ""
-    if (args.mode != "debug_minimal") and args.enable_eval:
+    if (not is_debug_mode) and args.enable_eval:
         eval_args += (
             "--eval-interval 20 "
             f"--eval-prompt-data aime {args.data_dir}/aime-2024/aime-2024.jsonl "
@@ -135,7 +173,7 @@ def execute(args: ScriptArgs):
         "--recompute-num-layers 1 "
         # "--micro-batch-size 1 "
         "--use-dynamic-batch-size "
-        "--max-tokens-per-gpu 32768 "
+        f"--max-tokens-per-gpu {args.max_tokens_per_gpu} "
     )
 
     grpo_args = (
@@ -212,15 +250,18 @@ def execute(args: ScriptArgs):
     match (args.hardware, args.num_nodes):
         case ("H100", 1):
             perf_args += (
-                "--tensor-model-parallel-size 4 "
-                "--sequence-parallel "
-                "--pipeline-model-parallel-size 1 "
-                "--context-parallel-size 1 "
-                "--expert-model-parallel-size 8 "
-                "--expert-tensor-parallel-size 1 "
+                f"--tensor-model-parallel-size {args.tensor_model_parallel_size} "
+                f"{'--sequence-parallel ' if args.use_sequence_parallel and args.tensor_model_parallel_size > 1 else ''}"
+                f"--pipeline-model-parallel-size {args.pipeline_model_parallel_size} "
+                f"--context-parallel-size {args.context_parallel_size} "
+                f"{f'--cp-comm-type {args.cp_comm_type} ' if args.cp_comm_type is not None else ''}"
+                f"--expert-model-parallel-size {args.expert_model_parallel_size} "
+                f"--expert-tensor-parallel-size {args.expert_tensor_parallel_size} "
             )
             sglang_args = (
-                f"--rollout-num-gpus-per-engine {2 if args.rollout_fp8 else 1 if args.rollout_int4 else 8} "
+                f"--rollout-num-gpus-per-engine {args.rollout_num_gpus_per_engine} "
+                f"{f'--rollout-num-gpus {args.rollout_num_gpus} ' if args.rollout_num_gpus is not None else ''}"
+                f"{f'--sglang-ep-size {args.sglang_expert_parallel_size} ' if args.sglang_expert_parallel_size > 1 else ''}"
                 "--sglang-mem-fraction-static 0.7 "
                 "--sglang-cuda-graph-max-bs 512 "
             )
@@ -229,20 +270,26 @@ def execute(args: ScriptArgs):
             )
         case ("B200" | "B300" | "GB200" | "GB300", 1 | 2 | 4):
             perf_args += (
-                "--tensor-model-parallel-size 4 "
-                "--sequence-parallel "
-                "--pipeline-model-parallel-size 1 "
-                "--context-parallel-size 1 "
-                f"--expert-model-parallel-size {args.num_gpus_per_node if args.train_mxfp8 else 4} "
-                "--expert-tensor-parallel-size 1 "
+                f"--tensor-model-parallel-size {args.tensor_model_parallel_size} "
+                f"{'--sequence-parallel ' if args.use_sequence_parallel and args.tensor_model_parallel_size > 1 else ''}"
+                f"--pipeline-model-parallel-size {args.pipeline_model_parallel_size} "
+                f"--context-parallel-size {args.context_parallel_size} "
+                f"{f'--cp-comm-type {args.cp_comm_type} ' if args.cp_comm_type is not None else ''}"
+                f"--expert-model-parallel-size {args.expert_model_parallel_size} "
+                f"--expert-tensor-parallel-size {args.expert_tensor_parallel_size} "
             )
-            sglang_args = "--sglang-mem-fraction-static 0.7 " "--sglang-attention-backend trtllm_mha "
+            sglang_args = (
+                "--sglang-mem-fraction-static 0.7 "
+                "--sglang-attention-backend trtllm_mha "
+                f"{f'--rollout-num-gpus {args.rollout_num_gpus} ' if args.rollout_num_gpus is not None else ''}"
+                f"{f'--sglang-ep-size {args.sglang_expert_parallel_size} ' if args.sglang_expert_parallel_size > 1 else ''}"
+            )
             if args.rollout_fp8:
                 sglang_world_size = 2
                 sglang_attn_tp_size = 2
                 sglang_decode_max_bs = 256
                 sglang_args += (
-                    f"--rollout-num-gpus-per-engine 2 "
+                    f"--rollout-num-gpus-per-engine {args.rollout_num_gpus_per_engine} "
                     f"--sglang-ep-size {sglang_world_size} "
                     "--sglang-moe-runner-backend deep_gemm "
                     "--sglang-moe-a2a-backend deepep "
@@ -255,7 +302,7 @@ def execute(args: ScriptArgs):
                 sglang_attn_tp_size = 1
                 sglang_decode_max_bs = 256
                 sglang_args += (
-                    f"--rollout-num-gpus-per-engine 1 "
+                    f"--rollout-num-gpus-per-engine {args.rollout_num_gpus_per_engine} "
                     "--sglang-fp8-gemm-backend triton "
                     # Currently, only cutlass moe runner is supported in sglang for mxfp8, which does not support ep
                     # f"--sglang-ep-size {sglang_world_size} "
@@ -267,7 +314,10 @@ def execute(args: ScriptArgs):
                     f"--sglang-cuda-graph-max-bs {sglang_decode_max_bs} "
                 )
             else:
-                sglang_args += "--rollout-num-gpus-per-engine 4 " "--sglang-cuda-graph-max-bs 512 "
+                sglang_args += (
+                    f"--rollout-num-gpus-per-engine {args.rollout_num_gpus_per_engine} "
+                    "--sglang-cuda-graph-max-bs 512 "
+                )
         case _:
             raise NotImplementedError
 
@@ -308,9 +358,10 @@ tis_batch_normalize: true
 
     U.execute_train(
         train_args=train_args,
+        config=args,
         num_gpus_per_node=args.num_gpus_per_node,
         megatron_model_type=args.megatron_model_type,
-        extra_env_vars={**misc_env_vars},
+        extra_env_vars=misc_env_vars,
         megatron_path=args.megatron_path,
     )
 

--- a/scripts/run_qwen3_30b_a3b_deterministic.py
+++ b/scripts/run_qwen3_30b_a3b_deterministic.py
@@ -1,0 +1,85 @@
+"""True-on-policy deterministic variant of run_qwen3_30b_a3b.
+
+Extends the base script with true-on-policy contract, EP parity defaults,
+and deterministic launch plan injection. Use this script when you need
+exact-zero logprob alignment between SGLang rollout and Megatron training.
+"""
+
+import os
+from dataclasses import dataclass
+from typing import Literal
+
+import typer
+from scripts.run_qwen3_30b_a3b import ScriptArgs as BaseScriptArgs
+from scripts.run_qwen3_30b_a3b import prepare
+
+import miles.utils.external_utils.command_utils as U
+from miles.true_on_policy import apply_true_on_policy_script_defaults, build_true_on_policy_launch_plan
+
+
+@dataclass
+class ScriptArgs(BaseScriptArgs):
+    mode: Literal["normal", "debug_minimal", "debug_one_sample"] = "normal"
+    train_backend: Literal["megatron"] = "megatron"
+    true_on_policy: bool = True
+    true_on_policy_contract: str | None = None
+    true_on_policy_default_rollout_ep: bool = True
+
+    def __post_init__(self):
+        super().__post_init__()
+        if self.sglang_expert_parallel_size == 1 and self.true_on_policy and self.true_on_policy_default_rollout_ep:
+            self.sglang_expert_parallel_size = self.expert_model_parallel_size
+        if (
+            self.true_on_policy
+            and self.sglang_expert_parallel_size > 1
+            and self.rollout_num_gpus_per_engine < self.sglang_expert_parallel_size
+        ):
+            self.rollout_num_gpus_per_engine = self.sglang_expert_parallel_size
+        apply_true_on_policy_script_defaults(self)
+
+
+def _debug_one_sample_args(args: ScriptArgs) -> str:
+    train_data_parallel_size = (
+        args.num_nodes
+        * args.num_gpus_per_node
+        // (args.tensor_model_parallel_size * args.pipeline_model_parallel_size * args.context_parallel_size)
+    )
+    debug_batch_size = max(1, train_data_parallel_size)
+    return (
+        "--num-rollout 1 "
+        f"--rollout-batch-size {debug_batch_size} "
+        "--n-samples-per-prompt 1 "
+        "--rollout-max-response-len 2 "
+        f"--global-batch-size {debug_batch_size} "
+        "--ci-test --ci-disable-kl-checker "
+        "--sglang-disable-cuda-graph "
+    )
+
+
+def execute(args: ScriptArgs):
+    from scripts.run_qwen3_30b_a3b import execute as base_execute
+
+    plan = build_true_on_policy_launch_plan(args)
+    os.environ.update(plan.env_vars)
+    plan_env_vars = " ".join(f"{key}={value}" for key, value in plan.env_vars.items())
+    args.extra_env_vars = " ".join(part for part in (plan_env_vars, args.extra_env_vars) if part)
+    debug_args = _debug_one_sample_args(args) if args.mode == "debug_one_sample" else ""
+    if args.mode == "debug_one_sample":
+        args.enable_eval = False
+    base_mode = args.mode
+    args.mode = "debug_minimal" if args.mode == "debug_one_sample" else args.mode
+    args.extra_args = f"{plan.train_args} {debug_args} {args.extra_args}"
+    try:
+        base_execute(args)
+    finally:
+        args.mode = base_mode
+
+
+@U.dataclass_cli
+def main(args: ScriptArgs):
+    prepare(args)
+    execute(args)
+
+
+if __name__ == "__main__":
+    typer.run(main)


### PR DESCRIPTION
Stacked split of #1059, rebuilt after rebasing onto latest `main`.

Base branch: `split/pr1059-10-argument-tests`
Head branch: `split/pr1059-11-qwen3-run-scripts`

This is PR 11 of 12. The stack is cumulative; the final branch is the rebased equivalent of the original PR head without stale-base reversions.