### PR TITLE
Switch GLM-5 smoke model to 5 layers

### DIFF
--- a/examples/p2p_weight_transfer/GLM-5.sh
+++ b/examples/p2p_weight_transfer/GLM-5.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-# GLM-5 variants: GLM-5_4layer | GLM-5_20layer | GLM-5
+# GLM-5 variants: GLM-5_5layer | GLM-5_20layer | GLM-5
 # Usage: bash GLM-5.sh <VARIANT> [MODE] [NODE_RANK] [HEAD_NODE_IP]
-#   VARIANT      : GLM-5_4layer | GLM-5_20layer | GLM-5
+#   VARIANT      : GLM-5_5layer | GLM-5_20layer | GLM-5
 #   MODE         : p2p (default) | broadcast
 #   NODE_RANK    : 0 (head, default) | 1..N (workers)
 #   HEAD_NODE_IP : IP address of the head node
@@ -15,10 +15,10 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Validate variant
 case "${VARIANT}" in
-    GLM-5_4layer|GLM-5_20layer|GLM-5)
+    GLM-5_5layer|GLM-5_20layer|GLM-5)
         ;;
     *)
-        echo "ERROR: Unknown variant '${VARIANT}'. Use GLM-5_4layer, GLM-5_20layer, or GLM-5."
+        echo "ERROR: Unknown variant '${VARIANT}'. Use GLM-5_5layer, GLM-5_20layer, or GLM-5."
         exit 1
         ;;
 esac

--- a/examples/p2p_weight_transfer/README.md
+++ b/examples/p2p_weight_transfer/README.md
@@ -54,8 +54,8 @@ bash examples/p2p_weight_transfer/Qwen3-30B-A3B.sh p2p 1 $HEAD_NODE_IP  # worker
 The `GLM-5.sh` wrapper accepts a `VARIANT` argument:
 
 ```bash
-# GLM-5_4layer (2 nodes)
-bash examples/p2p_weight_transfer/GLM-5.sh GLM-5_4layer p2p 0 $HEAD_NODE_IP
+# GLM-5_5layer (2 nodes)
+bash examples/p2p_weight_transfer/GLM-5.sh GLM-5_5layer p2p 0 $HEAD_NODE_IP
 
 # GLM-5 full (32 nodes)
 bash examples/p2p_weight_transfer/GLM-5.sh GLM-5 p2p 0 $HEAD_NODE_IP

--- a/examples/p2p_weight_transfer/prepare-glm5.sh
+++ b/examples/p2p_weight_transfer/prepare-glm5.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Unified prepare script for all GLM-5 variants:
-#   GLM-5_4layer   - 4-layer pruned (3 dense + 1 MoE)
+#   GLM-5_5layer   - 5-layer pruned (3 dense + 2 MoE)
 #   GLM-5_20layer  - 20-layer pruned (3 dense + 17 MoE)
 #   GLM-5          - full 744B model (3 dense + 75 MoE)
 #
@@ -12,7 +12,7 @@
 #   bash prepare-glm5.sh <MODEL_NAME> [--download-only]
 #
 # MODEL_NAME:
-#   GLM-5_4layer   (Pinaster/GLM-5_4layer)
+#   GLM-5_5layer   (Pinaster/GLM-5_5layer)
 #   GLM-5_20layer  (Pinaster/GLM-5_20layer)
 #   GLM-5          (zai-org/GLM-5)
 #
@@ -26,7 +26,7 @@ set -ex
 # ---------------------------------------------------------------------------
 if [ $# -lt 1 ]; then
     echo "Usage: $0 <MODEL_NAME> [--download-only]"
-    echo "  MODEL_NAME : GLM-5_4layer | GLM-5_20layer | GLM-5"
+    echo "  MODEL_NAME : GLM-5_5layer | GLM-5_20layer | GLM-5"
     exit 1
 fi
 
@@ -44,9 +44,9 @@ done
 # Resolve model config from MODEL_NAME
 # ---------------------------------------------------------------------------
 case "${MODEL_NAME}" in
-    GLM-5_4layer)
-        HF_REPO="Pinaster/GLM-5_4layer"
-        MODEL_TYPE="glm5-744B-A40B_4layer"
+    GLM-5_5layer)
+        HF_REPO="Pinaster/GLM-5_5layer"
+        MODEL_TYPE="glm5-744B-A40B_5layer"
         CONVERT_GPUS=4
         CONVERT_EXTRA_ARGS="--pipeline-model-parallel-size 1 --expert-model-parallel-size 1 --tensor-model-parallel-size 1 --expert-tensor-parallel-size 1"
         CONVERT_MULTINODE="false"
@@ -69,7 +69,7 @@ case "${MODEL_NAME}" in
         CONVERT_NUM_NODES=""
         ;;
     *)
-        echo "ERROR: Unknown model '${MODEL_NAME}'. Use GLM-5_4layer, GLM-5_20layer, or GLM-5."
+        echo "ERROR: Unknown model '${MODEL_NAME}'. Use GLM-5_5layer, GLM-5_20layer, or GLM-5."
         exit 1
         ;;
 esac

--- a/examples/p2p_weight_transfer/run-glm5-disagg-profile.sh
+++ b/examples/p2p_weight_transfer/run-glm5-disagg-profile.sh
@@ -4,20 +4,20 @@
 # Supports broadcast and p2p weight transfer modes.
 #
 # Configurations (from run_glm5_744b_a40b.py):
-#   GLM-5_4layer   2 nodes  (1 train + 1 rollout)   TP=4 PP=1 EP=8
+#   GLM-5_5layer   2 nodes  (1 train + 1 rollout)   TP=4 PP=1 EP=8
 #   GLM-5_20layer  12 nodes (6 train + 6 rollout)   TP=4 PP=3 EP=16
 #   GLM-5          32 nodes (16 train + 16 rollout)  TP=4 PP=4 CP=2 EP=32
 #
 # Usage:
 #   bash run-glm5-disagg-profile.sh <MODEL_NAME> <MODE> <NODE_RANK> <HEAD_NODE_IP>
 #
-#   MODEL_NAME    : GLM-5_4layer | GLM-5_20layer | GLM-5
+#   MODEL_NAME    : GLM-5_5layer | GLM-5_20layer | GLM-5
 #   MODE          : broadcast | p2p
 #   NODE_RANK     : 0 (head node) | 1..N (worker nodes)
 #   HEAD_NODE_IP  : IP address of the head node
 #
 # Examples:
-#   bash run-glm5-disagg-profile.sh GLM-5_4layer  broadcast 0 10.0.0.1
+#   bash run-glm5-disagg-profile.sh GLM-5_5layer  broadcast 0 10.0.0.1
 #   bash run-glm5-disagg-profile.sh GLM-5_20layer p2p       0 10.0.0.1
 #   bash run-glm5-disagg-profile.sh GLM-5         p2p       0 10.0.0.1
 
@@ -30,7 +30,7 @@ export PYTHONBUFFERED=16
 # ---------------------------------------------------------------------------
 if [ $# -lt 4 ]; then
     echo "Usage: $0 <MODEL_NAME> <MODE> <NODE_RANK> <HEAD_NODE_IP>"
-    echo "  MODEL_NAME    : GLM-5_4layer | GLM-5_20layer | GLM-5"
+    echo "  MODEL_NAME    : GLM-5_5layer | GLM-5_20layer | GLM-5"
     echo "  MODE          : broadcast | p2p"
     echo "  NODE_RANK     : 0 (head) | 1..N (workers)"
     echo "  HEAD_NODE_IP  : IP of the head node"
@@ -64,8 +64,8 @@ BUCKET_SIZE_GB="${BUCKET_SIZE_GB:-1.0}"
 ENABLE_NCCL_NVLS=1
 
 case "${MODEL_NAME}" in
-    GLM-5_4layer)
-        MODEL_TYPE="glm5-744B-A40B_4layer"
+    GLM-5_5layer)
+        MODEL_TYPE="glm5-744B-A40B_5layer"
         NNODES=2
         NUM_TRAIN_GPUS=8      # 1 node
         NUM_ROLLOUT_GPUS=8    # 1 node
@@ -108,7 +108,7 @@ case "${MODEL_NAME}" in
         ENABLE_OPTIMIZER_OFFLOAD=1
         ;;
     *)
-        echo "ERROR: Unknown model '${MODEL_NAME}'. Use GLM-5_4layer, GLM-5_20layer, or GLM-5."
+        echo "ERROR: Unknown model '${MODEL_NAME}'. Use GLM-5_5layer, GLM-5_20layer, or GLM-5."
         exit 1
         ;;
 esac

--- a/examples/p2p_weight_transfer/run-qwen3-30B-A3B-4node-profile.sh
+++ b/examples/p2p_weight_transfer/run-qwen3-30B-A3B-4node-profile.sh
@@ -2,7 +2,7 @@
 
 # Multi-node (4-node) profiling script for Qwen3-30B-A3B with broadcasting/p2p weight transfer.
 #
-# Converted from: examples/p2p_weight_transfer/test_glm5_744b_a40b_4layer.py
+# Converted from: examples/p2p_weight_transfer/test_glm5_744b_a40b_5layer.py
 # Only the qwen3-30b model config is included.
 #
 # Usage:

--- a/examples/p2p_weight_transfer/run.py
+++ b/examples/p2p_weight_transfer/run.py
@@ -12,8 +12,8 @@ Usage:
 Examples:
     python run.py prepare GLM-4.7-Flash
     python run.py run     GLM-4.7-Flash --mode p2p --node-rank 0 --head-ip 10.0.0.1
-    python run.py prepare GLM-5_4layer --download-only
-    python run.py run     GLM-5_4layer --mode broadcast --node-rank 1 --head-ip 10.0.0.1
+    python run.py prepare GLM-5_5layer --download-only
+    python run.py run     GLM-5_5layer --mode broadcast --node-rank 1 --head-ip 10.0.0.1
 """
 
 import json
@@ -159,9 +159,9 @@ PREPARE_CONFIGS: dict[str, PrepareConfig] = {
             "git+https://github.com/huggingface/transformers.git" "@76732b4e7120808ff989edbd16401f61fa6a0afa"
         ),
     ),
-    "GLM-5_4layer": PrepareConfig(
-        hf_repo="Pinaster/GLM-5_4layer",
-        model_type="glm5-744B-A40B_4layer",
+    "GLM-5_5layer": PrepareConfig(
+        hf_repo="Pinaster/GLM-5_5layer",
+        model_type="glm5-744B-A40B_5layer",
         convert_gpus_per_node=4,
         convert_extra_args=(
             "--pipeline-model-parallel-size 1 "
@@ -294,8 +294,8 @@ RUN_CONFIGS: dict[str, RunConfig] = {
         sglang_enable_dp_attention=True,
         sglang_enable_dp_lm_head=True,
     ),
-    "GLM-5_4layer": RunConfig(
-        model_type="glm5-744B-A40B_4layer",
+    "GLM-5_5layer": RunConfig(
+        model_type="glm5-744B-A40B_5layer",
         nnodes=2,
         num_train_gpus=8,
         num_rollout_gpus=8,

--- a/scripts/models/glm5-744B-A40B_5layer.sh
+++ b/scripts/models/glm5-744B-A40B_5layer.sh
@@ -1,8 +1,8 @@
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")" &>/dev/null && pwd)"
 source "${SCRIPT_DIR}/glm5-744B-A40B.sh"
 
-# Override for 4-layer pruned model (first 4 layers: 3 dense + 1 MoE)
-N_MOE_LAYERS=1
+# Override for 5-layer pruned model (first 5 layers: 3 dense + 2 MoE)
+N_MOE_LAYERS=2
 
 for ((i=0; i<${#MODEL_ARGS[@]}; i++)); do
     case "${MODEL_ARGS[$i]}" in

--- a/scripts/run_glm5_744b_a40b.py
+++ b/scripts/run_glm5_744b_a40b.py
@@ -222,11 +222,7 @@ def _execute_train(args: ScriptArgs):
     )
     if args.save_checkpoint:
         load_save_path = f"{args.output_dir}/{args.run_id}/checkpoints"
-        ckpt_args += (
-            f"--load {load_save_path} "
-            f"--save {load_save_path} "
-            "--save-interval 20 "
-        )
+        ckpt_args += f"--load {load_save_path} " f"--save {load_save_path} " "--save-interval 20 "
 
     rollout_args = (
         f"--prompt-data {args.data_dir}/dapo-math-17k/dapo-math-17k.jsonl "

--- a/scripts/run_glm5_744b_a40b.py
+++ b/scripts/run_glm5_744b_a40b.py
@@ -13,10 +13,10 @@ For GB300, please use `radixark/miles:glm5-gb300` docker
 Args:
   --model-name: Model variant to use.
       GLM-5         Full 744B model (requires >=16 nodes)
-      GLM-5_4layer  4-layer pruned model (single-node testing)
+      GLM-5_5layer  5-layer pruned model (single-node testing)
       GLM-5_20layer 20-layer pruned model (multi-node testing)
   --num-nodes: Number of nodes for training. Determines parallelism config:
-      1  -> for GLM-5_4layer minimal test
+      1  -> for GLM-5_5layer minimal test
       6  -> for GLM-5_20layer multi-node test
       16+-> for full GLM-5 model
   --num-gpus-per-node: GPUs per node (default: 8)
@@ -32,7 +32,7 @@ Args:
 =====================
 
 I. Usage for single node minimal test:
-  `python scripts/run_glm5_744b_a40b.py full-train --model-name GLM-5_4layer --num-nodes 1`
+  `python scripts/run_glm5_744b_a40b.py full-train --model-name GLM-5_5layer --num-nodes 1`
 
 =====================
 
@@ -106,7 +106,7 @@ class ScriptArgs(U.ExecuteTrainConfig):
 
         if self.model_name == "GLM-5":
             self.model_org = "zai-org"
-        elif self.model_name in ["GLM-5_4layer", "GLM-5_20layer"]:
+        elif self.model_name in ["GLM-5_5layer", "GLM-5_20layer"]:
             self.model_org = "Pinaster"
         else:
             raise NotImplementedError(f"{self.model_name} is not supported")
@@ -170,7 +170,7 @@ def _prepare_megatron_ckpt(args: ScriptArgs):
     num_nodes = None
 
     num_layers_match = re.search(r"(\d+)layer", args.model_name)
-    if num_layers_match and int(num_layers_match.group(1)) <= 4:
+    if num_layers_match and int(num_layers_match.group(1)) <= 5:
         extra_args += "--pipeline-model-parallel-size 1 " "--expert-model-parallel-size 1 "
         num_gpus_per_node = min(4, num_gpus_per_node)
         multinode = False
@@ -243,7 +243,7 @@ def _execute_train(args: ScriptArgs):
     if (args.mode != "debug_minimal") and args.enable_eval:
         eval_args += "--eval-interval 20 " "--eval-top-p 1 "
 
-    if args.num_nodes == 1:  # minimal test for 4 layers model
+    if args.num_nodes == 1:  # minimal test for 5 layers model
         perf_args = (
             "--tensor-model-parallel-size 4 "
             "--sequence-parallel "

--- a/scripts/run_glm5_744b_a40b.py
+++ b/scripts/run_glm5_744b_a40b.py
@@ -82,6 +82,7 @@ class ScriptArgs(U.ExecuteTrainConfig):
     enable_mtp: bool = False
     enable_pd: bool = True
     enable_optimizer_offload: bool = False
+    save_checkpoint: bool = True
     num_rollout: int = 3000
     extra_args: str = ""
     data_dir: str = "/root/datasets"
@@ -214,15 +215,18 @@ def _prepare_cp(args: ScriptArgs, skip_existing: bool = False):
 
 
 def _execute_train(args: ScriptArgs):
-    load_save_path = f"{args.output_dir}/{args.run_id}/checkpoints"
     hf_name = f"{args.model_name}_fp8" if args.fp8_rollout else args.model_name
     ckpt_args = (
         f"--hf-checkpoint {args.model_local_dir}/{hf_name} "
         f"--ref-load {args.model_local_dir}/{args.model_name}_torch_dist "
-        f"--load {load_save_path} "
-        f"--save {load_save_path} "
-        "--save-interval 20 "
     )
+    if args.save_checkpoint:
+        load_save_path = f"{args.output_dir}/{args.run_id}/checkpoints"
+        ckpt_args += (
+            f"--load {load_save_path} "
+            f"--save {load_save_path} "
+            "--save-interval 20 "
+        )
 
     rollout_args = (
         f"--prompt-data {args.data_dir}/dapo-math-17k/dapo-math-17k.jsonl "

--- a/tests/e2e/megatron/test_glm5_744b_a40b_5layer.py
+++ b/tests/e2e/megatron/test_glm5_744b_a40b_5layer.py
@@ -1,6 +1,4 @@
-import json
 import os
-from pathlib import Path
 
 from tests.ci.ci_register import register_cuda_ci
 
@@ -11,8 +9,8 @@ register_cuda_ci(est_time=1800, suite="stage-c-8-gpu-h200", labels=["megatron"],
 
 USE_FP8_ROLLOUT = U.get_bool_env_var("MILES_TEST_USE_FP8_ROLLOUT", "false")
 
-MODEL_NAME = "GLM-5_4layer"
-MODEL_TYPE = "glm5-744B-A40B_4layer"
+MODEL_NAME = "GLM-5_5layer"
+MODEL_TYPE = "glm5-744B-A40B_5layer"
 MODEL_ORG = "Pinaster"
 NUM_GPUS = 8
 
@@ -20,38 +18,10 @@ MODEL_DIR = "/root/models"
 DATA_DIR = "/root/datasets"
 
 
-def _process_glm_checkpoint():
-    """Patch config.json to use DeepseekV32 architecture if not already patched."""
-    config_path = Path(MODEL_DIR) / MODEL_NAME / "config.json"
-    if not config_path.exists():
-        print(f"Warning: {config_path} not found, skipping checkpoint processing")
-        return
-
-    with open(config_path) as f:
-        config = json.load(f)
-
-    if config.get("model_type") == "deepseek_v32":
-        print("Checkpoint already patched, skipping")
-        return
-
-    config["architectures"] = ["DeepseekV32ForCausalLM"]
-    config["auto_map"] = {
-        "AutoConfig": "configuration_deepseek_v32.DeepseekV32Config",
-        "AutoModelForCausalLM": "modeling_deepseek_v32.DeepseekV32ForCausalLM",
-    }
-    config["model_type"] = "deepseek_v32"
-
-    with open(config_path, "w") as f:
-        json.dump(config, f, indent=2, ensure_ascii=False)
-    print(f"Patched {config_path}")
-
-
 def prepare():
     U.exec_command(f"mkdir -p {MODEL_DIR} {DATA_DIR}")
     U.exec_command(f"hf download {MODEL_ORG}/{MODEL_NAME} --local-dir {MODEL_DIR}/{MODEL_NAME}")
     U.hf_download_dataset("zhuzilin/dapo-math-17k", data_dir=DATA_DIR)
-
-    _process_glm_checkpoint()
 
     if USE_FP8_ROLLOUT:
         U.exec_command(
@@ -61,7 +31,7 @@ def prepare():
             "--strategy block --block-size 128 128"
         )
 
-    # For 4-layer model: use 4 GPUs, TP=1, PP=1, EP=1, ETP=1
+    # For 5-layer model: use 4 GPUs, TP=1, PP=1, EP=1, ETP=1
     U.convert_checkpoint(
         model_name=MODEL_NAME,
         megatron_model_type=MODEL_TYPE,
@@ -86,7 +56,7 @@ def execute():
         "--save-interval 20 "
     )
 
-    # debug_minimal mode for single-node 4-layer test: short response length
+    # debug_minimal mode for single-node 5-layer test: short response length
     rollout_args = (
         f"--prompt-data {DATA_DIR}/dapo-math-17k/dapo-math-17k.jsonl "
         "--input-key prompt "

--- a/tests/e2e/megatron/test_glm5_744b_a40b_5layer_ci.py
+++ b/tests/e2e/megatron/test_glm5_744b_a40b_5layer_ci.py
@@ -20,7 +20,7 @@ register_cuda_ci(est_time=1800, suite="stage-c-8-gpu-h100", labels=["model-scrip
 
 def _args() -> ScriptArgs:
     return ScriptArgs(
-        model_name="GLM-5_4layer",
+        model_name="GLM-5_5layer",
         num_nodes=1,
         num_gpus_per_node=8,
         num_rollout=2,

--- a/tests/e2e/megatron/test_glm5_744b_a40b_5layer_ci.py
+++ b/tests/e2e/megatron/test_glm5_744b_a40b_5layer_ci.py
@@ -24,6 +24,7 @@ def _args() -> ScriptArgs:
         num_nodes=1,
         num_gpus_per_node=8,
         num_rollout=2,
+        save_checkpoint=False,
         extra_args=("--ci-test " "--ci-disable-logprobs-checker " "--disable-weights-backuper "),
     )
 


### PR DESCRIPTION
## Summary
- replace the GLM-5 4-layer smoke checkpoint references with the new 5-layer variant
- rename the GLM-5 4-layer model/test scripts to 5-layer names
- update p2p weight transfer examples to use GLM-5_5layer

## Validation
- Created and compared `/cluster_public/miles_data/models/GLM-5_5layer` against the existing 4-layer checkpoint: non-weight files match, non-layer weights match, and layer schema is present for layers 0-4.
- Uploaded `Pinaster/GLM-5_5layer` to Hugging Face.
- Remote rcli smoke on `yueming-glm5-debug-clean` succeeded: Ray job `raysubmit_u5PvY51HDuHEG8wt`, `num_rollout=2`, completed rollout 0/1 and train step 0/1.
- Local syntax checks: `python -m py_compile` for the GLM-5 script/tests and `bash -n` for the touched shell scripts.