### PR TITLE
[refactor] hf_config: single entry point for HF config loading with alias + overrides

### DIFF
--- a/miles/backends/fsdp_utils/actor.py
+++ b/miles/backends/fsdp_utils/actor.py
@@ -8,12 +8,12 @@ import torch
 import torch.distributed as dist
 from ring_flash_attn import update_ring_flash_attn_params
 from tqdm import tqdm
-from transformers import AutoConfig
 
 from miles.ray.train_actor import TrainRayActor
 from miles.utils import train_dump_utils, train_metric_utils
 from miles.utils.context_utils import with_defer
 from miles.utils.distributed_utils import get_gloo_group
+from miles.utils.hf_config import load_hf_config
 from miles.utils.memory_utils import clear_memory, print_memory
 from miles.utils.processing_utils import load_processor, load_tokenizer
 from miles.utils.ray_utils import Box
@@ -89,7 +89,7 @@ class FSDPTrainRayActor(TrainRayActor):
 
         for i in range(dist.get_world_size()):
             if i == dist.get_rank():
-                self.hf_config = AutoConfig.from_pretrained(self.args.hf_checkpoint, trust_remote_code=True)
+                self.hf_config = load_hf_config(self.args.hf_checkpoint)
                 self.tokenizer = load_tokenizer(
                     self.args.hf_checkpoint, chat_template_path=self.args.chat_template_path, trust_remote_code=True
                 )

--- a/miles/backends/megatron_utils/actor.py
+++ b/miles/backends/megatron_utils/actor.py
@@ -9,12 +9,12 @@ import torch
 import torch.distributed as dist
 from ray.actor import ActorHandle
 from torch_memory_saver import torch_memory_saver
-from transformers import AutoConfig
 
 from miles.ray.train_actor import TrainRayActor
 from miles.utils import train_dump_utils
 from miles.utils.context_utils import with_defer
 from miles.utils.distributed_utils import get_gloo_group, init_process_group
+from miles.utils.hf_config import load_hf_config
 from miles.utils.memory_utils import clear_memory, print_memory
 from miles.utils.processing_utils import load_tokenizer
 from miles.utils.ray_utils import Box
@@ -81,7 +81,7 @@ class MegatronTrainRayActor(TrainRayActor):
         # read config and tokenizer serialized to prevent concurrent writing bug.
         for i in range(dist.get_world_size()):
             if i == dist.get_rank():
-                self.hf_config = AutoConfig.from_pretrained(args.hf_checkpoint, trust_remote_code=True)
+                self.hf_config = load_hf_config(args.hf_checkpoint)
                 self.tokenizer = load_tokenizer(
                     self.args.hf_checkpoint, chat_template_path=self.args.chat_template_path, trust_remote_code=True
                 )

--- a/miles/backends/megatron_utils/bridge_lora_helpers.py
+++ b/miles/backends/megatron_utils/bridge_lora_helpers.py
@@ -11,6 +11,8 @@ from dataclasses import dataclass
 
 from megatron.core.utils import get_attr_wrapped_model
 
+from miles.utils.hf_config import load_hf_config
+
 from .lora_utils import create_lora_instance
 
 
@@ -80,9 +82,8 @@ def _setup_lora_model_via_bridge(args: Namespace) -> list:
     """
     from megatron.bridge import AutoBridge
     from megatron.bridge.training.config import DistributedDataParallelConfig
-    from transformers import AutoConfig
 
-    hf_config = AutoConfig.from_pretrained(args.hf_checkpoint, trust_remote_code=True)
+    hf_config = load_hf_config(args.hf_checkpoint)
     bridge = AutoBridge.from_hf_pretrained(args.hf_checkpoint, trust_remote_code=True)
     provider = bridge.to_megatron_provider(load_weights=False)
 

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -6,13 +6,13 @@ from typing import Any
 
 import yaml
 from sglang_router.launch_router import RouterArgs
-from transformers import AutoConfig
 
 from miles.backends.sglang_utils.arguments import add_sglang_arguments
 from miles.backends.sglang_utils.arguments import validate_args as sglang_validate_args
 from miles.utils.chat_template_utils.tito_tokenizer import TITOTokenizerType
 from miles.utils.environ import enable_experimental_rollout_refactor
 from miles.utils.eval_config import EvalDatasetConfig, build_eval_dataset_configs, ensure_dataset_list
+from miles.utils.hf_config import load_hf_config
 from miles.utils.logging_utils import configure_logger
 from miles.utils.misc import load_function
 
@@ -1702,7 +1702,7 @@ def parse_args(add_custom_arguments=None):
 
         args = megatron_parse_args(extra_args_provider=add_miles_arguments)
         if args.hf_checkpoint:
-            hf_config = AutoConfig.from_pretrained(args.hf_checkpoint, trust_remote_code=True)
+            hf_config = load_hf_config(args.hf_checkpoint)
             hf_validate_args(args, hf_config)
 
         args.rank = 0

--- a/miles/utils/hf_config.py
+++ b/miles/utils/hf_config.py
@@ -1,0 +1,139 @@
+"""HuggingFace config loader with model-type alias registration and overrides.
+
+`load_hf_config` is the single entry point miles uses to load an HF config from a
+local checkpoint. It:
+
+- Registers miles-local model_type aliases (e.g. `deepseek_v32` -> `DeepseekV3Config`)
+  before calling AutoConfig, so checkpoints don't need to be mutated.
+- Falls back to a plain namespace object built from `config.json` when
+  AutoConfig can't parse the file (unknown model_type / non-HF-shaped configs).
+- Accepts an `overrides` dict applied via setattr after loading, so callers can
+  adjust fields like `max_position_embeddings` without touching the checkpoint.
+"""
+
+import importlib
+import json
+import logging
+import os
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["load_hf_config"]
+
+
+@dataclass(frozen=True)
+class _HFConfigAlias:
+    model_type: str
+    base_module: str
+    base_class: str
+    compat_class_name: str
+
+
+_CONFIG_ALIASES: tuple[_HFConfigAlias, ...] = (
+    _HFConfigAlias(
+        model_type="deepseek_v32",
+        base_module="transformers.models.deepseek_v3.configuration_deepseek_v3",
+        base_class="DeepseekV3Config",
+        compat_class_name="DeepseekV32Config",
+    ),
+)
+
+_REGISTERED_ALIASES: set[str] = set()
+
+
+def _register_hf_config_aliases() -> None:
+    """Ensure miles' local model_type aliases are registered with AutoConfig.
+
+    Idempotent: rerunning is a cheap set check. Called automatically by
+    load_hf_config; not intended for external use.
+    """
+    from transformers import AutoConfig
+
+    for alias in _CONFIG_ALIASES:
+        if alias.model_type in _REGISTERED_ALIASES:
+            continue
+        try:
+            module = importlib.import_module(alias.base_module)
+        except ImportError:
+            logger.info(
+                "Skip HF config alias %s: base module %s not importable",
+                alias.model_type,
+                alias.base_module,
+            )
+            continue
+        # base_class missing is a real problem (transformers rename or version skew);
+        # let AttributeError surface instead of silently dropping the alias.
+        base_config = getattr(module, alias.base_class)
+        compat_config = type(
+            alias.compat_class_name,
+            (base_config,),
+            {"model_type": alias.model_type, "__module__": __name__},
+        )
+        try:
+            AutoConfig.register(alias.model_type, compat_config)
+        except ValueError as exc:
+            msg = str(exc).lower()
+            if "already registered" not in msg and "already used" not in msg:
+                raise
+            # transformers added native support, or another path registered first
+        _REGISTERED_ALIASES.add(alias.model_type)
+
+
+def _fix_dtype_strings(d: dict) -> None:
+    import torch
+
+    dtype_map = {"bfloat16": torch.bfloat16, "float16": torch.float16, "float32": torch.float32}
+    for key in ("torch_dtype", "dtype"):
+        if key in d and d[key] in dtype_map:
+            d[key] = dtype_map[d[key]]
+
+
+def _namespace_fallback(checkpoint_path: str):
+    """Build a namespace object from config.json when AutoConfig can't parse it."""
+    config_path = os.path.join(checkpoint_path, "config.json")
+    with open(config_path, encoding="utf-8") as f:
+        config_dict = json.load(f)
+    _fix_dtype_strings(config_dict)
+    ns = type("HFConfig", (), config_dict)()
+    if "text_config" in config_dict:
+        _fix_dtype_strings(config_dict["text_config"])
+        ns.text_config = type("TextConfig", (), config_dict["text_config"])()
+    return ns
+
+
+def load_hf_config(
+    checkpoint_path: str,
+    *,
+    overrides: dict | None = None,
+    trust_remote_code: bool = True,
+    **autoconfig_kwargs,
+):
+    """Load an HF config from a local checkpoint.
+
+    Parameters
+    ----------
+    checkpoint_path: path to a local HF checkpoint directory.
+    overrides: optional dict of attributes to setattr on the returned config
+        after loading. Lets callers patch fields without mutating the checkpoint.
+    trust_remote_code: forwarded to AutoConfig.from_pretrained; defaults to True
+        to match miles' existing call sites.
+    autoconfig_kwargs: extra kwargs forwarded to AutoConfig.from_pretrained.
+
+    Returns
+    -------
+    The HF Config object, or a namespace fallback if AutoConfig can't parse the
+    config.json.
+    """
+    _register_hf_config_aliases()
+    from transformers import AutoConfig
+
+    try:
+        config = AutoConfig.from_pretrained(checkpoint_path, trust_remote_code=trust_remote_code, **autoconfig_kwargs)
+    except (ValueError, KeyError):
+        config = _namespace_fallback(checkpoint_path)
+
+    if overrides:
+        for key, value in overrides.items():
+            setattr(config, key, value)
+    return config

--- a/miles_plugins/models/glm5/glm5.py
+++ b/miles_plugins/models/glm5/glm5.py
@@ -24,7 +24,7 @@ from megatron.core.transformer.moe.moe_utils import RouterGatingLinearFunction a
 from megatron.core.transformer.spec_utils import ModuleSpec, build_module
 from megatron.core.transformer.transformer_block import get_num_layers_to_build
 from megatron.core.transformer.transformer_config import MLATransformerConfig
-from transformers import AutoConfig
+from miles.utils.hf_config import load_hf_config
 
 from .ops.indexer import generate_varlen_mask_params, lighting_indexer
 from .ops.sparse_mla import SparseMLA
@@ -604,7 +604,7 @@ class DSAMLASelfAttention(DSAMultiLatentAttention):
 
 
 def get_glm5_spec(args, config, vp_stage):
-    hf_config = AutoConfig.from_pretrained(args.hf_checkpoint, trust_remote_code=True)
+    hf_config = load_hf_config(args.hf_checkpoint)
     config.index_num_attention_heads = hf_config.index_n_heads
     config.index_head_dim = hf_config.index_head_dim
     # Define the decoder block spec

--- a/miles_plugins/models/hf_attention.py
+++ b/miles_plugins/models/hf_attention.py
@@ -1,5 +1,3 @@
-import json
-import os
 from abc import ABC, abstractmethod
 
 import torch
@@ -9,33 +7,7 @@ from megatron.core.inference.contexts import BaseInferenceContext
 from megatron.core.packed_seq_params import PackedSeqParams
 from megatron.core.transformer.module import MegatronModule
 
-
-# Common fallback path for HF config loading; may be migrated elsewhere later.
-def _load_hf_config(checkpoint_path):
-    """Load HF config with fallback for unsupported model types."""
-    try:
-        from transformers import AutoConfig
-
-        return AutoConfig.from_pretrained(checkpoint_path, trust_remote_code=True)
-    except (ValueError, KeyError):
-        config_path = os.path.join(checkpoint_path, "config.json")
-        with open(config_path) as f:
-            config_dict = json.load(f)
-
-        _DTYPE_MAP = {"bfloat16": torch.bfloat16, "float16": torch.float16, "float32": torch.float32}
-
-        def _fix_dtype(d):
-            if "torch_dtype" in d:
-                d["torch_dtype"] = _DTYPE_MAP.get(d["torch_dtype"], d["torch_dtype"])
-            if "dtype" in d:
-                d["dtype"] = _DTYPE_MAP.get(d["dtype"], d["dtype"])
-
-        _fix_dtype(config_dict)
-        ns = type("HFConfig", (), config_dict)()
-        if "text_config" in config_dict:
-            _fix_dtype(config_dict["text_config"])
-            ns.text_config = type("TextConfig", (), config_dict["text_config"])()
-        return ns
+from miles.utils.hf_config import load_hf_config
 
 
 class _AllGatherForDuplicatedComputation(torch.autograd.Function):
@@ -82,7 +54,7 @@ class HuggingfaceAttention(MegatronModule, ABC):
         # Note that megatron layer_number starts at 1
         self.layer_number = layer_number
         self.hf_layer_idx = layer_number - 1
-        self.hf_config = _load_hf_config(args.hf_checkpoint)
+        self.hf_config = load_hf_config(args.hf_checkpoint)
         # hardcode to fa2 at the moment.
         self.hf_config._attn_implementation = "flash_attention_2"
 

--- a/tests/utils/test_hf_config.py
+++ b/tests/utils/test_hf_config.py
@@ -1,0 +1,116 @@
+"""Unit tests for miles.utils.hf_config."""
+
+import json
+import os
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+
+def _write_config_json(directory: str, config_dict: dict) -> None:
+    with open(os.path.join(directory, "config.json"), "w", encoding="utf-8") as f:
+        json.dump(config_dict, f)
+
+
+class TestLoadHfConfig:
+    def test_overrides_apply_to_returned_config(self, tmp_path):
+        from miles.utils.hf_config import load_hf_config
+
+        fake_config = SimpleNamespace(max_position_embeddings=4096, hidden_size=128)
+        with patch("transformers.AutoConfig.from_pretrained", return_value=fake_config):
+            cfg = load_hf_config(
+                str(tmp_path),
+                overrides={"max_position_embeddings": 8192, "_attn_implementation": "flash"},
+            )
+        assert cfg.max_position_embeddings == 8192
+        assert cfg.hidden_size == 128
+        assert cfg._attn_implementation == "flash"
+
+    def test_trust_remote_code_default_is_true(self, tmp_path):
+        from miles.utils.hf_config import load_hf_config
+
+        with patch("transformers.AutoConfig.from_pretrained", return_value=SimpleNamespace()) as mock_from_pretrained:
+            load_hf_config(str(tmp_path))
+        _, kwargs = mock_from_pretrained.call_args
+        assert kwargs["trust_remote_code"] is True
+
+    def test_extra_kwargs_forwarded_to_autoconfig(self, tmp_path):
+        from miles.utils.hf_config import load_hf_config
+
+        with patch("transformers.AutoConfig.from_pretrained", return_value=SimpleNamespace()) as mock_from_pretrained:
+            load_hf_config(str(tmp_path), revision="main", trust_remote_code=False)
+        _, kwargs = mock_from_pretrained.call_args
+        assert kwargs["revision"] == "main"
+        assert kwargs["trust_remote_code"] is False
+
+    def test_namespace_fallback_when_autoconfig_raises(self, tmp_path):
+        """Unknown model_type should fall back to a namespace built from config.json."""
+        import torch
+
+        from miles.utils.hf_config import load_hf_config
+
+        _write_config_json(
+            str(tmp_path),
+            {"model_type": "totally_unknown", "hidden_size": 1024, "torch_dtype": "bfloat16"},
+        )
+
+        cfg = load_hf_config(str(tmp_path))
+        assert cfg.model_type == "totally_unknown"
+        assert cfg.hidden_size == 1024
+        # bfloat16 string in config.json should have been mapped to a torch dtype
+        assert cfg.torch_dtype is torch.bfloat16
+
+    def test_namespace_fallback_with_overrides(self, tmp_path):
+        from miles.utils.hf_config import load_hf_config
+
+        _write_config_json(str(tmp_path), {"model_type": "weird", "hidden_size": 1024})
+        cfg = load_hf_config(str(tmp_path), overrides={"hidden_size": 2048})
+        assert cfg.hidden_size == 2048
+
+    def test_namespace_fallback_handles_text_config(self, tmp_path):
+        """Multimodal configs with nested text_config should be wrapped too."""
+        from miles.utils.hf_config import load_hf_config
+
+        _write_config_json(
+            str(tmp_path),
+            {
+                "model_type": "weird_multimodal",
+                "text_config": {"hidden_size": 4096, "torch_dtype": "float16"},
+            },
+        )
+        cfg = load_hf_config(str(tmp_path))
+        assert cfg.text_config.hidden_size == 4096
+
+        import torch
+
+        assert cfg.text_config.torch_dtype is torch.float16
+
+    def test_repeated_calls_are_idempotent(self, tmp_path):
+        """Alias registration on every call must not raise on the second pass."""
+        from miles.utils.hf_config import load_hf_config
+
+        with patch("transformers.AutoConfig.from_pretrained", return_value=SimpleNamespace()):
+            load_hf_config(str(tmp_path))
+            load_hf_config(str(tmp_path))
+
+
+class TestDeepseekV32Alias:
+    """Integration: alias registration makes AutoConfig recognize deepseek_v32."""
+
+    def test_deepseek_v32_loads_via_alias(self, tmp_path):
+        """A config.json with model_type=deepseek_v32 should load as a DeepseekV3Config subclass."""
+        pytest.importorskip("transformers.models.deepseek_v3.configuration_deepseek_v3")
+        from transformers.models.deepseek_v3.configuration_deepseek_v3 import DeepseekV3Config
+
+        from miles.utils.hf_config import load_hf_config
+
+        # Use DeepseekV3Config's __init__ defaults to produce a valid config dict,
+        # then re-stamp the model_type as deepseek_v32.
+        base_dict = DeepseekV3Config().to_dict()
+        base_dict["model_type"] = "deepseek_v32"
+        _write_config_json(str(tmp_path), base_dict)
+
+        cfg = load_hf_config(str(tmp_path))
+        assert cfg.model_type == "deepseek_v32"
+        assert isinstance(cfg, DeepseekV3Config)

--- a/tools/convert_fsdp_to_hf.py
+++ b/tools/convert_fsdp_to_hf.py
@@ -6,8 +6,10 @@ import time
 
 import torch
 import torch.distributed.checkpoint as dist_cp
-from transformers import AutoConfig, AutoModelForCausalLM
+from transformers import AutoModelForCausalLM
 from typing_extensions import override
+
+from miles.utils.hf_config import load_hf_config
 
 
 class UnpicklerWrapper(pickle.Unpickler):
@@ -117,7 +119,7 @@ def _convert_fsdp_to_hf(
 
     tensor_items = {k: v for k, v in state_dict.items() if isinstance(v, torch.Tensor)}
 
-    config = AutoConfig.from_pretrained(origin_hf_dir, trust_remote_code=True)
+    config = load_hf_config(origin_hf_dir)
     hf_model = AutoModelForCausalLM.from_config(config)
     target_keys = set(hf_model.state_dict().keys())
 

--- a/tools/convert_to_hf.py
+++ b/tools/convert_to_hf.py
@@ -1,11 +1,12 @@
 import torch
 import torch.distributed as dist
 from megatron.core import mpu
-from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
+from transformers import AutoModelForCausalLM, AutoTokenizer
 
 import miles.backends.megatron_utils as megatron_utils
 from miles.backends.megatron_utils import update_weight_utils
 from miles.utils.arguments import parse_args
+from miles.utils.hf_config import load_hf_config
 
 
 def add_checkpoint_args(parser):
@@ -39,7 +40,7 @@ def main(args):
     args.no_load_rng = True
     model, _, _, _ = megatron_utils.initialize_model_and_optimizer(args)
 
-    hf_config = AutoConfig.from_pretrained(args.hf_checkpoint, trust_remote_code=True)
+    hf_config = load_hf_config(args.hf_checkpoint)
     model_name = type(hf_config).__name__.lower()
 
     tokenizer = AutoTokenizer.from_pretrained(args.hf_checkpoint, trust_remote_code=True)

--- a/tools/convert_torch_dist_to_hf.py
+++ b/tools/convert_torch_dist_to_hf.py
@@ -6,14 +6,13 @@ import re
 import shutil
 import time
 
-
 import safetensors.torch
 import torch
 import torch.distributed.checkpoint as dist_cp
-from transformers import AutoConfig
 from typing_extensions import override
 
 from miles.backends.megatron_utils.megatron_to_hf import convert_to_hf, remove_padding
+from miles.utils.hf_config import load_hf_config
 
 
 class UnpicklerWrapper(pickle.Unpickler):
@@ -195,7 +194,7 @@ if __name__ == "__main__":
         )
 
     if args.model_name is None:
-        hf_config = AutoConfig.from_pretrained(args.origin_hf_dir, trust_remote_code=True)
+        hf_config = load_hf_config(args.origin_hf_dir)
         args.model_name = type(hf_config).__name__.lower()
 
     state_dict = {}


### PR DESCRIPTION
## Summary

Add `miles/utils/hf_config.py` exposing `load_hf_config` as the single entry point for loading HF configs from local checkpoints. It:

- Registers miles-local `model_type` aliases (e.g. `deepseek_v32` -> `DeepseekV3Config`) before calling `AutoConfig`, so checkpoints don't need to be mutated and callers don't need to remember to register.
- Falls back to a namespace object built from `config.json` when `AutoConfig` can't parse the model_type (carried over from `hf_attention._load_hf_config`).
- Accepts an `overrides` dict applied via `setattr` after loading — patch fields like `max_position_embeddings` without touching the checkpoint.

Replaces 9 direct `AutoConfig.from_pretrained` call sites with `load_hf_config`, and removes the duplicated `_load_hf_config` from `miles_plugins/models/hf_attention.py`.

## Why

Until now, supporting a new `model_type` that transformers doesn't know about (V3.2 today, others later) required adding a `register_hf_config_compat()` call at every entry-point that loads HF configs. Easy to forget; failure mode is a confusing `AutoConfig` error far from the missing call site.

Binding register-then-load into one helper turns "forgetting to register" from a latent runtime bug into a non-issue.

## Relation to #963

#963 introduced `miles/utils/hf_config_compat.py` plus `register_hf_config_compat()` calls in 6 modules. This PR supersedes that file. When #963 rebases onto this branch, those 6 scattered `register_hf_config_compat()` calls become unnecessary and should be dropped.

## Test plan

- [x] \`pytest tests/utils/test_hf_config.py\` — 8 tests pass locally, covering:
  - \`overrides\` apply via setattr
  - \`trust_remote_code\` default and kwarg passthrough
  - Namespace fallback (incl. nested \`text_config\`)
  - Idempotent repeated calls
  - End-to-end \`deepseek_v32\` alias loading via real \`AutoConfig\` + DeepseekV3Config defaults
- [x] \`pre-commit run --files <all changed>\` passes