### PR TITLE
[refactor] hf_config: single entry point with alias registration and overrides

### DIFF
--- a/miles/backends/experimental/fsdp_utils/actor.py
+++ b/miles/backends/experimental/fsdp_utils/actor.py
@@ -7,12 +7,12 @@ import ray
 import torch
 import torch.distributed as dist
 from tqdm import tqdm
-from transformers import AutoConfig
 
 from miles.ray.train_actor import TrainRayActor
 from miles.utils import train_dump_utils, train_metric_utils
 from miles.utils.context_utils import with_defer
 from miles.utils.distributed_utils import get_gloo_group
+from miles.utils.hf_config import load_hf_config
 from miles.utils.memory_utils import clear_memory, print_memory
 from miles.utils.processing_utils import load_processor, load_tokenizer
 from miles.utils.ray_utils import Box
@@ -88,7 +88,7 @@ class FSDPTrainRayActor(TrainRayActor):
 
         for i in range(dist.get_world_size()):
             if i == dist.get_rank():
-                self.hf_config = AutoConfig.from_pretrained(self.args.hf_checkpoint, trust_remote_code=True)
+                self.hf_config = load_hf_config(self.args.hf_checkpoint)
                 self.tokenizer = load_tokenizer(
                     self.args.hf_checkpoint, chat_template_path=self.args.chat_template_path, trust_remote_code=True
                 )

--- a/miles/backends/megatron_utils/actor.py
+++ b/miles/backends/megatron_utils/actor.py
@@ -9,12 +9,12 @@ import torch
 import torch.distributed as dist
 from ray.actor import ActorHandle
 from torch_memory_saver import torch_memory_saver
-from transformers import AutoConfig
 
 from miles.ray.train_actor import TrainRayActor
 from miles.utils import train_dump_utils
 from miles.utils.context_utils import with_defer
 from miles.utils.distributed_utils import get_gloo_group, init_process_group
+from miles.utils.hf_config import load_hf_config
 from miles.utils.memory_utils import clear_memory, print_memory
 from miles.utils.processing_utils import load_tokenizer
 from miles.utils.ray_utils import Box
@@ -81,7 +81,7 @@ class MegatronTrainRayActor(TrainRayActor):
         # read config and tokenizer serialized to prevent concurrent writing bug.
         for i in range(dist.get_world_size()):
             if i == dist.get_rank():
-                self.hf_config = AutoConfig.from_pretrained(args.hf_checkpoint, trust_remote_code=True)
+                self.hf_config = load_hf_config(args.hf_checkpoint)
                 self.tokenizer = load_tokenizer(
                     self.args.hf_checkpoint, chat_template_path=self.args.chat_template_path, trust_remote_code=True
                 )

--- a/miles/backends/megatron_utils/bridge_lora_helpers.py
+++ b/miles/backends/megatron_utils/bridge_lora_helpers.py
@@ -11,6 +11,8 @@ from dataclasses import dataclass
 
 from megatron.core.utils import get_attr_wrapped_model
 
+from miles.utils.hf_config import load_hf_config
+
 from .lora_utils import create_lora_instance, patch_param_grad_buffer_for_colocate_mode_lora
 
 
@@ -80,9 +82,8 @@ def _setup_lora_model_via_bridge(args: Namespace) -> list:
     """
     from megatron.bridge import AutoBridge
     from megatron.bridge.training.config import DistributedDataParallelConfig
-    from transformers import AutoConfig
 
-    hf_config = AutoConfig.from_pretrained(args.hf_checkpoint, trust_remote_code=True)
+    hf_config = load_hf_config(args.hf_checkpoint)
     bridge = AutoBridge.from_hf_pretrained(args.hf_checkpoint, trust_remote_code=True)
     provider = bridge.to_megatron_provider(load_weights=False)
 

--- a/miles/backends/megatron_utils/initialize.py
+++ b/miles/backends/megatron_utils/initialize.py
@@ -9,6 +9,7 @@ from megatron.core.num_microbatches_calculator import init_num_microbatches_calc
 from megatron.training.global_vars import _build_tokenizer, set_args
 
 from miles.backends.training_utils.parallel import get_parallel_state, set_parallel_state
+from miles.utils.hf_config import register_hf_config_aliases
 
 from .parallel import create_megatron_parallel_state
 
@@ -80,6 +81,7 @@ def init(args):
         args.te_rng_tracker,
         args.inference_rng_tracker,
     )
+    register_hf_config_aliases()
     _build_tokenizer(args)
     # We won't use this. initialize to pass some validation in megatron.
     init_num_microbatches_calculator(

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -6,13 +6,13 @@ from typing import Any
 
 import yaml
 from sglang_router.launch_router import RouterArgs
-from transformers import AutoConfig
 
 from miles.backends.sglang_utils.arguments import add_sglang_arguments
 from miles.backends.sglang_utils.arguments import validate_args as sglang_validate_args
 from miles.utils.chat_template_utils.tito_tokenizer import TITOTokenizerType
 from miles.utils.environ import enable_experimental_rollout_refactor
 from miles.utils.eval_config import EvalDatasetConfig, build_eval_dataset_configs, ensure_dataset_list
+from miles.utils.hf_config import load_hf_config
 from miles.utils.logging_utils import configure_logger
 from miles.utils.misc import load_function
 
@@ -1779,7 +1779,7 @@ def parse_args(add_custom_arguments=None):
 
         args = megatron_parse_args(extra_args_provider=add_miles_arguments)
         if args.hf_checkpoint:
-            hf_config = AutoConfig.from_pretrained(args.hf_checkpoint, trust_remote_code=True)
+            hf_config = load_hf_config(args.hf_checkpoint)
             hf_validate_args(args, hf_config)
 
         args.rank = 0

--- a/miles/utils/hf_config.py
+++ b/miles/utils/hf_config.py
@@ -27,6 +27,8 @@ class _HFConfigAlias:
     base_module: str
     base_class: str
     compat_class_name: str
+    # Set True to override transformers' native config.
+    override_hf_native: bool = False
 
 
 _CONFIG_ALIASES: tuple[_HFConfigAlias, ...] = (
@@ -48,10 +50,16 @@ def _register_hf_config_aliases() -> None:
     load_hf_config; not intended for external use.
     """
     from transformers import AutoConfig
+    from transformers.models.auto.configuration_auto import CONFIG_MAPPING_NAMES
 
     for alias in _CONFIG_ALIASES:
         if alias.model_type in _REGISTERED_ALIASES:
             continue
+        if alias.model_type in CONFIG_MAPPING_NAMES and not alias.override_hf_native:
+            raise RuntimeError(
+                f"transformers now natively supports model_type={alias.model_type!r}; "
+                f"set override_hf_native=True to override."
+            )
         try:
             module = importlib.import_module(alias.base_module)
         except ImportError:
@@ -69,13 +77,7 @@ def _register_hf_config_aliases() -> None:
             (base_config,),
             {"model_type": alias.model_type, "__module__": __name__},
         )
-        try:
-            AutoConfig.register(alias.model_type, compat_config)
-        except ValueError as exc:
-            msg = str(exc).lower()
-            if "already registered" not in msg and "already used" not in msg:
-                raise
-            # transformers added native support, or another path registered first
+        AutoConfig.register(alias.model_type, compat_config, exist_ok=alias.override_hf_native)
         _REGISTERED_ALIASES.add(alias.model_type)
 
 

--- a/miles/utils/hf_config.py
+++ b/miles/utils/hf_config.py
@@ -16,6 +16,9 @@ import importlib
 import logging
 from dataclasses import dataclass
 
+from transformers import AutoConfig
+from transformers.models.auto.configuration_auto import CONFIG_MAPPING_NAMES
+
 logger = logging.getLogger(__name__)
 
 __all__ = ["load_hf_config"]
@@ -49,9 +52,6 @@ def _register_hf_config_aliases() -> None:
     Idempotent: rerunning is a cheap set check. Called automatically by
     load_hf_config; not intended for external use.
     """
-    from transformers import AutoConfig
-    from transformers.models.auto.configuration_auto import CONFIG_MAPPING_NAMES
-
     for alias in _CONFIG_ALIASES:
         if alias.model_type in _REGISTERED_ALIASES:
             continue
@@ -100,8 +100,6 @@ def load_hf_config(
     autoconfig_kwargs: extra kwargs forwarded to AutoConfig.from_pretrained.
     """
     _register_hf_config_aliases()
-    from transformers import AutoConfig
-
     config = AutoConfig.from_pretrained(checkpoint_path, trust_remote_code=trust_remote_code, **autoconfig_kwargs)
 
     if overrides:

--- a/miles/utils/hf_config.py
+++ b/miles/utils/hf_config.py
@@ -14,7 +14,7 @@ The default behavior is exactly the same as `AutoConfig.from_pretrained`.
 import importlib
 from dataclasses import dataclass
 
-from transformers import AutoConfig
+from transformers import AutoConfig, AutoModelForCausalLM
 from transformers.models.auto.configuration_auto import CONFIG_MAPPING_NAMES
 
 __all__ = ["load_hf_config"]
@@ -26,6 +26,7 @@ class _HFConfigAlias:
     base_module: str
     base_class: str
     compat_class_name: str
+    auto_model_classes: tuple = (AutoModelForCausalLM,)
     # Set True to override transformers' native config.
     override_hf_native: bool = False
 
@@ -60,6 +61,12 @@ def _register_hf_config_aliases() -> None:
             {"model_type": alias.model_type, "__module__": __name__},
         )
         AutoConfig.register(alias.model_type, compat_config, exist_ok=alias.override_hf_native)
+        for auto_cls in alias.auto_model_classes:
+            base_model_cls = auto_cls._model_mapping[base_config]
+            compat_model_cls = type(
+                base_model_cls.__name__, (base_model_cls,), {"config_class": compat_config, "__module__": __name__}
+            )
+            auto_cls.register(compat_config, compat_model_cls, exist_ok=alias.override_hf_native)
         _REGISTERED_ALIASES.add(alias.model_type)
 
 

--- a/miles/utils/hf_config.py
+++ b/miles/utils/hf_config.py
@@ -17,9 +17,6 @@ from dataclasses import dataclass
 from transformers import AutoConfig, AutoModelForCausalLM
 from transformers.models.auto.configuration_auto import CONFIG_MAPPING_NAMES
 
-__all__ = ["load_hf_config", "register_hf_config_aliases"]
-
-
 @dataclass(frozen=True)
 class _HFConfigAlias:
     model_type: str

--- a/miles/utils/hf_config.py
+++ b/miles/utils/hf_config.py
@@ -17,7 +17,7 @@ from dataclasses import dataclass
 from transformers import AutoConfig, AutoModelForCausalLM
 from transformers.models.auto.configuration_auto import CONFIG_MAPPING_NAMES
 
-__all__ = ["load_hf_config"]
+__all__ = ["load_hf_config", "register_hf_config_aliases"]
 
 
 @dataclass(frozen=True)
@@ -43,8 +43,13 @@ _CONFIG_ALIASES: tuple[_HFConfigAlias, ...] = (
 _REGISTERED_ALIASES: set[str] = set()
 
 
-def _register_hf_config_aliases() -> None:
-    """Register model alias with AutoConfig."""
+def register_hf_config_aliases() -> None:
+    """Register miles model_type aliases with transformers. Idempotent.
+
+    Call once before any third-party `transformers.AutoConfig` / `AutoTokenizer`
+    entry point that won't go through `load_hf_config` (e.g. megatron's
+    `_build_tokenizer`).
+    """
     for alias in _CONFIG_ALIASES:
         if alias.model_type in _REGISTERED_ALIASES:
             continue
@@ -84,7 +89,7 @@ def load_hf_config(
     overrides: optional dict of attributes to setattr on the returned config
         after loading. Lets callers patch fields without mutating the checkpoint.
     """
-    _register_hf_config_aliases()
+    register_hf_config_aliases()
     config = AutoConfig.from_pretrained(checkpoint_path, trust_remote_code=trust_remote_code, **autoconfig_kwargs)
 
     if overrides:

--- a/miles/utils/hf_config.py
+++ b/miles/utils/hf_config.py
@@ -1,0 +1,108 @@
+"""HuggingFace config loader with model-type alias registration and overrides.
+
+`load_hf_config` is the single entry point miles uses to load an HF config from a
+local checkpoint. It:
+
+- Registers miles-local model_type aliases (e.g. `deepseek_v32` -> `DeepseekV3Config`)
+  before calling AutoConfig, so checkpoints don't need to be mutated.
+- Accepts an `overrides` dict applied via setattr after loading, so callers can
+  adjust fields like `max_position_embeddings` without touching the checkpoint.
+
+Unknown model_types raise the standard transformers error -- new types should
+be added to `_CONFIG_ALIASES` rather than silently routed to a fallback.
+"""
+
+import importlib
+import logging
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["load_hf_config"]
+
+
+@dataclass(frozen=True)
+class _HFConfigAlias:
+    model_type: str
+    base_module: str
+    base_class: str
+    compat_class_name: str
+
+
+_CONFIG_ALIASES: tuple[_HFConfigAlias, ...] = (
+    _HFConfigAlias(
+        model_type="deepseek_v32",
+        base_module="transformers.models.deepseek_v3.configuration_deepseek_v3",
+        base_class="DeepseekV3Config",
+        compat_class_name="DeepseekV32Config",
+    ),
+)
+
+_REGISTERED_ALIASES: set[str] = set()
+
+
+def _register_hf_config_aliases() -> None:
+    """Ensure miles' local model_type aliases are registered with AutoConfig.
+
+    Idempotent: rerunning is a cheap set check. Called automatically by
+    load_hf_config; not intended for external use.
+    """
+    from transformers import AutoConfig
+
+    for alias in _CONFIG_ALIASES:
+        if alias.model_type in _REGISTERED_ALIASES:
+            continue
+        try:
+            module = importlib.import_module(alias.base_module)
+        except ImportError:
+            logger.info(
+                "Skip HF config alias %s: base module %s not importable",
+                alias.model_type,
+                alias.base_module,
+            )
+            continue
+        # base_class missing is a real problem (transformers rename or version skew);
+        # let AttributeError surface instead of silently dropping the alias.
+        base_config = getattr(module, alias.base_class)
+        compat_config = type(
+            alias.compat_class_name,
+            (base_config,),
+            {"model_type": alias.model_type, "__module__": __name__},
+        )
+        try:
+            AutoConfig.register(alias.model_type, compat_config)
+        except ValueError as exc:
+            msg = str(exc).lower()
+            if "already registered" not in msg and "already used" not in msg:
+                raise
+            # transformers added native support, or another path registered first
+        _REGISTERED_ALIASES.add(alias.model_type)
+
+
+def load_hf_config(
+    checkpoint_path: str,
+    *,
+    overrides: dict | None = None,
+    trust_remote_code: bool = True,
+    **autoconfig_kwargs,
+):
+    """Load an HF config from a local checkpoint.
+
+    Parameters
+    ----------
+    checkpoint_path: path to a local HF checkpoint directory.
+    overrides: optional dict of attributes to setattr on the returned config
+        after loading. Lets callers patch fields without mutating the checkpoint.
+    trust_remote_code: forwarded to AutoConfig.from_pretrained; defaults to True
+        to match miles' existing call sites.
+    autoconfig_kwargs: extra kwargs forwarded to AutoConfig.from_pretrained.
+    """
+    _register_hf_config_aliases()
+    from transformers import AutoConfig
+
+    config = AutoConfig.from_pretrained(checkpoint_path, trust_remote_code=trust_remote_code, **autoconfig_kwargs)
+
+    if overrides:
+        for key, value in overrides.items():
+            setattr(config, key, value)
+    return config

--- a/miles/utils/hf_config.py
+++ b/miles/utils/hf_config.py
@@ -43,7 +43,7 @@ _REGISTERED_ALIASES: set[str] = set()
 
 
 def _register_hf_config_aliases() -> None:
-    """Ensure miles' local model_type aliases are registered with AutoConfig."""
+    """Register model alias with AutoConfig."""
     for alias in _CONFIG_ALIASES:
         if alias.model_type in _REGISTERED_ALIASES:
             continue
@@ -72,14 +72,10 @@ def load_hf_config(
 ):
     """Load an HF config from a local checkpoint.
 
-    Parameters
-    ----------
-    checkpoint_path: path to a local HF checkpoint directory.
+    Registers model aliases first for pre-set aliases.
+
     overrides: optional dict of attributes to setattr on the returned config
         after loading. Lets callers patch fields without mutating the checkpoint.
-    trust_remote_code: forwarded to AutoConfig.from_pretrained; defaults to True
-        to match miles' existing call sites.
-    autoconfig_kwargs: extra kwargs forwarded to AutoConfig.from_pretrained.
     """
     _register_hf_config_aliases()
     config = AutoConfig.from_pretrained(checkpoint_path, trust_remote_code=trust_remote_code, **autoconfig_kwargs)

--- a/miles/utils/hf_config.py
+++ b/miles/utils/hf_config.py
@@ -17,6 +17,7 @@ from dataclasses import dataclass
 from transformers import AutoConfig, AutoModelForCausalLM
 from transformers.models.auto.configuration_auto import CONFIG_MAPPING_NAMES
 
+
 @dataclass(frozen=True)
 class _HFConfigAlias:
     model_type: str

--- a/miles/utils/hf_config.py
+++ b/miles/utils/hf_config.py
@@ -1,25 +1,21 @@
 """HuggingFace config loader with model-type alias registration and overrides.
 
 `load_hf_config` is the single entry point miles uses to load an HF config from a
-local checkpoint. It:
+local checkpoint. It supports 2 customizations:
 
-- Registers miles-local model_type aliases (e.g. `deepseek_v32` -> `DeepseekV3Config`)
-  before calling AutoConfig, so checkpoints don't need to be mutated.
+- Registers model_type aliases before calling AutoConfig, in case the model is
+  not recognized in huggingface.
 - Accepts an `overrides` dict applied via setattr after loading, so callers can
-  adjust fields like `max_position_embeddings` without touching the checkpoint.
+  adjust fields without touching the checkpoint.
 
-Unknown model_types raise the standard transformers error -- new types should
-be added to `_CONFIG_ALIASES` rather than silently routed to a fallback.
+The default behavior is exactly the same as `AutoConfig.from_pretrained`.
 """
 
 import importlib
-import logging
 from dataclasses import dataclass
 
 from transformers import AutoConfig
 from transformers.models.auto.configuration_auto import CONFIG_MAPPING_NAMES
-
-logger = logging.getLogger(__name__)
 
 __all__ = ["load_hf_config"]
 
@@ -47,11 +43,7 @@ _REGISTERED_ALIASES: set[str] = set()
 
 
 def _register_hf_config_aliases() -> None:
-    """Ensure miles' local model_type aliases are registered with AutoConfig.
-
-    Idempotent: rerunning is a cheap set check. Called automatically by
-    load_hf_config; not intended for external use.
-    """
+    """Ensure miles' local model_type aliases are registered with AutoConfig."""
     for alias in _CONFIG_ALIASES:
         if alias.model_type in _REGISTERED_ALIASES:
             continue
@@ -60,17 +52,7 @@ def _register_hf_config_aliases() -> None:
                 f"transformers now natively supports model_type={alias.model_type!r}; "
                 f"set override_hf_native=True to override."
             )
-        try:
-            module = importlib.import_module(alias.base_module)
-        except ImportError:
-            logger.info(
-                "Skip HF config alias %s: base module %s not importable",
-                alias.model_type,
-                alias.base_module,
-            )
-            continue
-        # base_class missing is a real problem (transformers rename or version skew);
-        # let AttributeError surface instead of silently dropping the alias.
+        module = importlib.import_module(alias.base_module)
         base_config = getattr(module, alias.base_class)
         compat_config = type(
             alias.compat_class_name,

--- a/miles/utils/processing_utils.py
+++ b/miles/utils/processing_utils.py
@@ -8,6 +8,8 @@ from huggingface_hub import hf_hub_download
 from tokenizers import Tokenizer as RawTokenizer
 from transformers import AutoProcessor, AutoTokenizer, PreTrainedTokenizerBase, ProcessorMixin
 
+from miles.utils.hf_config import register_hf_config_aliases
+
 logger = logging.getLogger(__name__)
 
 
@@ -75,6 +77,7 @@ def load_tokenizer(name_or_path: str, chat_template_path: str | None = None, **k
     if cache_key is not None and cache_key in _TOKENIZER_CACHE:
         return _TOKENIZER_CACHE[cache_key]
 
+    register_hf_config_aliases()
     tokenizer = AutoTokenizer.from_pretrained(name_or_path, **kwargs)
     _fix_v5_tokenizer_components(tokenizer, name_or_path)
     if chat_template_path:

--- a/miles/utils/processing_utils.py
+++ b/miles/utils/processing_utils.py
@@ -8,8 +8,6 @@ from huggingface_hub import hf_hub_download
 from tokenizers import Tokenizer as RawTokenizer
 from transformers import AutoProcessor, AutoTokenizer, PreTrainedTokenizerBase, ProcessorMixin
 
-from miles.utils.hf_config import register_hf_config_aliases
-
 logger = logging.getLogger(__name__)
 
 
@@ -77,7 +75,6 @@ def load_tokenizer(name_or_path: str, chat_template_path: str | None = None, **k
     if cache_key is not None and cache_key in _TOKENIZER_CACHE:
         return _TOKENIZER_CACHE[cache_key]
 
-    register_hf_config_aliases()
     tokenizer = AutoTokenizer.from_pretrained(name_or_path, **kwargs)
     _fix_v5_tokenizer_components(tokenizer, name_or_path)
     if chat_template_path:

--- a/miles_plugins/models/glm5/glm5.py
+++ b/miles_plugins/models/glm5/glm5.py
@@ -24,7 +24,7 @@ from megatron.core.transformer.moe.moe_utils import RouterGatingLinearFunction a
 from megatron.core.transformer.spec_utils import ModuleSpec, build_module
 from megatron.core.transformer.transformer_block import get_num_layers_to_build
 from megatron.core.transformer.transformer_config import MLATransformerConfig
-from transformers import AutoConfig
+from miles.utils.hf_config import load_hf_config
 
 from .ops.indexer import generate_varlen_mask_params, lighting_indexer
 from .ops.sparse_mla import SparseMLA
@@ -604,7 +604,7 @@ class DSAMLASelfAttention(DSAMultiLatentAttention):
 
 
 def get_glm5_spec(args, config, vp_stage):
-    hf_config = AutoConfig.from_pretrained(args.hf_checkpoint, trust_remote_code=True)
+    hf_config = load_hf_config(args.hf_checkpoint)
     config.index_num_attention_heads = hf_config.index_n_heads
     config.index_head_dim = hf_config.index_head_dim
     # Define the decoder block spec

--- a/miles_plugins/models/hf_attention.py
+++ b/miles_plugins/models/hf_attention.py
@@ -6,7 +6,8 @@ from megatron.core import mpu, tensor_parallel
 from megatron.core.inference.contexts import BaseInferenceContext
 from megatron.core.packed_seq_params import PackedSeqParams
 from megatron.core.transformer.module import MegatronModule
-from transformers import AutoConfig
+
+from miles.utils.hf_config import load_hf_config
 
 
 def _get_cp_sequence_lengths(cu_seqlens, cp_size, local_total_len=None):
@@ -167,7 +168,7 @@ class HuggingfaceAttention(MegatronModule, ABC):
         # Note that megatron layer_number starts at 1
         self.layer_number = layer_number
         self.hf_layer_idx = layer_number - 1
-        self.hf_config = AutoConfig.from_pretrained(args.hf_checkpoint, trust_remote_code=True)
+        self.hf_config = load_hf_config(args.hf_checkpoint)
         # hardcode to fa2 at the moment.
         self.hf_config._attn_implementation = "flash_attention_2"
 

--- a/tests/utils/test_hf_config.py
+++ b/tests/utils/test_hf_config.py
@@ -1,0 +1,82 @@
+"""Unit tests for miles.utils.hf_config."""
+
+import json
+import os
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+
+def _write_config_json(directory: str, config_dict: dict) -> None:
+    with open(os.path.join(directory, "config.json"), "w", encoding="utf-8") as f:
+        json.dump(config_dict, f)
+
+
+class TestLoadHfConfig:
+    def test_overrides_apply_to_returned_config(self, tmp_path):
+        from miles.utils.hf_config import load_hf_config
+
+        fake_config = SimpleNamespace(max_position_embeddings=4096, hidden_size=128)
+        with patch("transformers.AutoConfig.from_pretrained", return_value=fake_config):
+            cfg = load_hf_config(
+                str(tmp_path),
+                overrides={"max_position_embeddings": 8192, "_attn_implementation": "flash"},
+            )
+        assert cfg.max_position_embeddings == 8192
+        assert cfg.hidden_size == 128
+        assert cfg._attn_implementation == "flash"
+
+    def test_trust_remote_code_default_is_true(self, tmp_path):
+        from miles.utils.hf_config import load_hf_config
+
+        with patch("transformers.AutoConfig.from_pretrained", return_value=SimpleNamespace()) as mock_from_pretrained:
+            load_hf_config(str(tmp_path))
+        _, kwargs = mock_from_pretrained.call_args
+        assert kwargs["trust_remote_code"] is True
+
+    def test_extra_kwargs_forwarded_to_autoconfig(self, tmp_path):
+        from miles.utils.hf_config import load_hf_config
+
+        with patch("transformers.AutoConfig.from_pretrained", return_value=SimpleNamespace()) as mock_from_pretrained:
+            load_hf_config(str(tmp_path), revision="main", trust_remote_code=False)
+        _, kwargs = mock_from_pretrained.call_args
+        assert kwargs["revision"] == "main"
+        assert kwargs["trust_remote_code"] is False
+
+    def test_unknown_model_type_raises(self, tmp_path):
+        """Unrecognized model_type must fail loud, not be silently routed elsewhere."""
+        from miles.utils.hf_config import load_hf_config
+
+        _write_config_json(str(tmp_path), {"model_type": "totally_unknown_model"})
+        with pytest.raises(ValueError):
+            load_hf_config(str(tmp_path))
+
+    def test_repeated_calls_are_idempotent(self, tmp_path):
+        """Alias registration on every call must not raise on the second pass."""
+        from miles.utils.hf_config import load_hf_config
+
+        with patch("transformers.AutoConfig.from_pretrained", return_value=SimpleNamespace()):
+            load_hf_config(str(tmp_path))
+            load_hf_config(str(tmp_path))
+
+
+class TestDeepseekV32Alias:
+    """Integration: alias registration makes AutoConfig recognize deepseek_v32."""
+
+    def test_deepseek_v32_loads_via_alias(self, tmp_path):
+        """A config.json with model_type=deepseek_v32 should load as a DeepseekV3Config subclass."""
+        pytest.importorskip("transformers.models.deepseek_v3.configuration_deepseek_v3")
+        from transformers.models.deepseek_v3.configuration_deepseek_v3 import DeepseekV3Config
+
+        from miles.utils.hf_config import load_hf_config
+
+        # Use DeepseekV3Config's __init__ defaults to produce a valid config dict,
+        # then re-stamp the model_type as deepseek_v32.
+        base_dict = DeepseekV3Config().to_dict()
+        base_dict["model_type"] = "deepseek_v32"
+        _write_config_json(str(tmp_path), base_dict)
+
+        cfg = load_hf_config(str(tmp_path))
+        assert cfg.model_type == "deepseek_v32"
+        assert isinstance(cfg, DeepseekV3Config)

--- a/tests/utils/test_hf_config.py
+++ b/tests/utils/test_hf_config.py
@@ -126,3 +126,29 @@ class TestDeepseekV32Alias:
         cfg = load_hf_config(str(tmp_path))
         assert cfg.model_type == "deepseek_v32"
         assert isinstance(cfg, DeepseekV3Config)
+
+    def test_deepseek_v32_resolves_via_auto_model_for_causal_lm(self, tmp_path):
+        """The returned config must be resolvable by AutoModelForCausalLM.from_config.
+
+        AutoConfig.register only updates CONFIG_MAPPING. AutoModelForCausalLM looks
+        up the model class by exact config type in MODEL_FOR_CAUSAL_LM_MAPPING, so
+        a synthesized DeepseekV32Config subclass that isn't separately registered
+        there makes `AutoModelForCausalLM.from_config(cfg)` raise
+        `ValueError: Unrecognized configuration class`. tools/convert_fsdp_to_hf.py
+        depends on this path working.
+        """
+        pytest.importorskip("transformers.models.deepseek_v3.configuration_deepseek_v3")
+        from transformers import AutoModelForCausalLM
+        from transformers.models.deepseek_v3.configuration_deepseek_v3 import DeepseekV3Config
+
+        from miles.utils.hf_config import load_hf_config
+
+        base_dict = DeepseekV3Config().to_dict()
+        base_dict["model_type"] = "deepseek_v32"
+        _write_config_json(str(tmp_path), base_dict)
+
+        cfg = load_hf_config(str(tmp_path))
+        assert type(cfg) in AutoModelForCausalLM._model_mapping.keys(), (
+            f"{type(cfg).__name__} not registered with AutoModelForCausalLM — "
+            f"AutoModelForCausalLM.from_config(cfg) will raise ValueError."
+        )

--- a/tests/utils/test_hf_config.py
+++ b/tests/utils/test_hf_config.py
@@ -73,10 +73,7 @@ class TestLoadHfConfig:
         with (
             patch.object(hf_config_module, "_CONFIG_ALIASES", (alias,)),
             patch.object(hf_config_module, "_REGISTERED_ALIASES", set()),
-            patch(
-                "transformers.models.auto.configuration_auto.CONFIG_MAPPING_NAMES",
-                {"fake_native_type": "FakeConfig"},
-            ),
+            patch.object(hf_config_module, "CONFIG_MAPPING_NAMES", {"fake_native_type": "FakeConfig"}),
             pytest.raises(RuntimeError, match="natively supports"),
         ):
             hf_config_module.load_hf_config(str(tmp_path))
@@ -95,10 +92,7 @@ class TestLoadHfConfig:
         with (
             patch.object(hf_config_module, "_CONFIG_ALIASES", (alias,)),
             patch.object(hf_config_module, "_REGISTERED_ALIASES", set()),
-            patch(
-                "transformers.models.auto.configuration_auto.CONFIG_MAPPING_NAMES",
-                {"fake_native_type": "FakeConfig"},
-            ),
+            patch.object(hf_config_module, "CONFIG_MAPPING_NAMES", {"fake_native_type": "FakeConfig"}),
             patch("transformers.AutoConfig.register") as mock_register,
             patch("transformers.AutoConfig.from_pretrained", return_value=SimpleNamespace()),
         ):

--- a/tests/utils/test_hf_config.py
+++ b/tests/utils/test_hf_config.py
@@ -60,6 +60,52 @@ class TestLoadHfConfig:
             load_hf_config(str(tmp_path))
             load_hf_config(str(tmp_path))
 
+    def test_native_support_raises_without_override(self, tmp_path):
+        """If transformers ships native support for an alias, registration must fail loud."""
+        from miles.utils import hf_config as hf_config_module
+
+        alias = hf_config_module._HFConfigAlias(
+            model_type="fake_native_type",
+            base_module="transformers.models.deepseek_v3.configuration_deepseek_v3",
+            base_class="DeepseekV3Config",
+            compat_class_name="FakeNativeConfig",
+        )
+        with (
+            patch.object(hf_config_module, "_CONFIG_ALIASES", (alias,)),
+            patch.object(hf_config_module, "_REGISTERED_ALIASES", set()),
+            patch(
+                "transformers.models.auto.configuration_auto.CONFIG_MAPPING_NAMES",
+                {"fake_native_type": "FakeConfig"},
+            ),
+            pytest.raises(RuntimeError, match="natively supports"),
+        ):
+            hf_config_module.load_hf_config(str(tmp_path))
+
+    def test_native_support_overridden_when_flag_set(self, tmp_path):
+        """override_hf_native=True must allow registration to win over native support."""
+        from miles.utils import hf_config as hf_config_module
+
+        alias = hf_config_module._HFConfigAlias(
+            model_type="fake_native_type",
+            base_module="transformers.models.deepseek_v3.configuration_deepseek_v3",
+            base_class="DeepseekV3Config",
+            compat_class_name="FakeNativeConfig",
+            override_hf_native=True,
+        )
+        with (
+            patch.object(hf_config_module, "_CONFIG_ALIASES", (alias,)),
+            patch.object(hf_config_module, "_REGISTERED_ALIASES", set()),
+            patch(
+                "transformers.models.auto.configuration_auto.CONFIG_MAPPING_NAMES",
+                {"fake_native_type": "FakeConfig"},
+            ),
+            patch("transformers.AutoConfig.register") as mock_register,
+            patch("transformers.AutoConfig.from_pretrained", return_value=SimpleNamespace()),
+        ):
+            hf_config_module.load_hf_config(str(tmp_path))
+        _, kwargs = mock_register.call_args
+        assert kwargs["exist_ok"] is True
+
 
 class TestDeepseekV32Alias:
     """Integration: alias registration makes AutoConfig recognize deepseek_v32."""

--- a/tools/convert_fsdp_to_hf.py
+++ b/tools/convert_fsdp_to_hf.py
@@ -6,8 +6,10 @@ import time
 
 import torch
 import torch.distributed.checkpoint as dist_cp
-from transformers import AutoConfig, AutoModelForCausalLM
+from transformers import AutoModelForCausalLM
 from typing_extensions import override
+
+from miles.utils.hf_config import load_hf_config
 
 
 class UnpicklerWrapper(pickle.Unpickler):
@@ -117,7 +119,7 @@ def _convert_fsdp_to_hf(
 
     tensor_items = {k: v for k, v in state_dict.items() if isinstance(v, torch.Tensor)}
 
-    config = AutoConfig.from_pretrained(origin_hf_dir, trust_remote_code=True)
+    config = load_hf_config(origin_hf_dir)
     hf_model = AutoModelForCausalLM.from_config(config)
     target_keys = set(hf_model.state_dict().keys())
 

--- a/tools/convert_to_hf.py
+++ b/tools/convert_to_hf.py
@@ -1,11 +1,12 @@
 import torch
 import torch.distributed as dist
 from megatron.core import mpu
-from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
+from transformers import AutoModelForCausalLM, AutoTokenizer
 
 import miles.backends.megatron_utils as megatron_utils
 from miles.backends.megatron_utils import update_weight_utils
 from miles.utils.arguments import parse_args
+from miles.utils.hf_config import load_hf_config
 
 
 def add_checkpoint_args(parser):
@@ -39,7 +40,7 @@ def main(args):
     args.no_load_rng = True
     model, _, _, _ = megatron_utils.initialize_model_and_optimizer(args)
 
-    hf_config = AutoConfig.from_pretrained(args.hf_checkpoint, trust_remote_code=True)
+    hf_config = load_hf_config(args.hf_checkpoint)
     model_name = type(hf_config).__name__.lower()
 
     tokenizer = AutoTokenizer.from_pretrained(args.hf_checkpoint, trust_remote_code=True)

--- a/tools/convert_torch_dist_to_hf.py
+++ b/tools/convert_torch_dist_to_hf.py
@@ -6,14 +6,13 @@ import re
 import shutil
 import time
 
-
 import safetensors.torch
 import torch
 import torch.distributed.checkpoint as dist_cp
-from transformers import AutoConfig
 from typing_extensions import override
 
 from miles.backends.megatron_utils.megatron_to_hf import convert_to_hf, remove_padding
+from miles.utils.hf_config import load_hf_config
 
 
 class UnpicklerWrapper(pickle.Unpickler):
@@ -195,7 +194,7 @@ if __name__ == "__main__":
         )
 
     if args.model_name is None:
-        hf_config = AutoConfig.from_pretrained(args.origin_hf_dir, trust_remote_code=True)
+        hf_config = load_hf_config(args.origin_hf_dir)
         args.model_name = type(hf_config).__name__.lower()
 
     state_dict = {}


### PR DESCRIPTION
> **Stacked on top of #1215** — review/merge that first.

## Summary

Add `miles/utils/hf_config.py` exposing `load_hf_config` as the single entry point for loading HF configs from local checkpoints. It:

- Registers miles-local `model_type` aliases (e.g. `deepseek_v32` -> `DeepseekV3Config`) before calling `AutoConfig`, so checkpoints don't need to be mutated and callers don't need to remember to register.
- Accepts an `overrides` dict applied via `setattr` after loading — patch fields like `max_position_embeddings` without touching the checkpoint.

Replaces 9 direct `AutoConfig.from_pretrained` call sites with `load_hf_config`.

## Why

Supporting a new `model_type` that transformers doesn't know about (V3.2 today, others later) used to require adding a `register_hf_config_compat()` call at every entry-point that loads HF configs. Easy to forget; failure mode is a confusing `AutoConfig` error far from the missing call site.

Binding register-then-load into one helper turns "forgetting to register" from a latent runtime bug into a non-issue. Unknown `model_type` now fails loud — the fix is "add an entry to `_CONFIG_ALIASES`," not "add a register call somewhere."

## Relation to #963

#963 introduced `miles/utils/hf_config_compat.py` plus six scattered `register_hf_config_compat()` calls. This PR supersedes that file. When #963 rebases on top of this branch, those six register calls become unnecessary and should be dropped.

## Test plan

- [x] `pytest tests/utils/test_hf_config.py` — 6 tests pass locally:
  - `overrides` apply via setattr
  - `trust_remote_code` default and kwarg passthrough
  - Idempotent repeated calls
  - Unknown model_type raises (no silent degradation)
  - End-to-end `deepseek_v32` alias loading via real `AutoConfig` + DeepseekV3Config defaults
- [x] `pre-commit run --files <changed>` passes