### PR TITLE
1/6 support kimi 2.5 full + lora: HF config loading fallback

### DIFF
--- a/miles_plugins/models/hf_attention.py
+++ b/miles_plugins/models/hf_attention.py
@@ -1,3 +1,5 @@
+import json
+import os
 from abc import ABC, abstractmethod
 
 import torch
@@ -6,7 +8,34 @@ from megatron.core import mpu, tensor_parallel
 from megatron.core.inference.contexts import BaseInferenceContext
 from megatron.core.packed_seq_params import PackedSeqParams
 from megatron.core.transformer.module import MegatronModule
-from transformers import AutoConfig
+
+
+# Common fallback path for HF config loading; may be migrated elsewhere later.
+def _load_hf_config(checkpoint_path):
+    """Load HF config with fallback for unsupported model types."""
+    try:
+        from transformers import AutoConfig
+
+        return AutoConfig.from_pretrained(checkpoint_path, trust_remote_code=True)
+    except (ValueError, KeyError):
+        config_path = os.path.join(checkpoint_path, "config.json")
+        with open(config_path) as f:
+            config_dict = json.load(f)
+
+        _DTYPE_MAP = {"bfloat16": torch.bfloat16, "float16": torch.float16, "float32": torch.float32}
+
+        def _fix_dtype(d):
+            if "torch_dtype" in d:
+                d["torch_dtype"] = _DTYPE_MAP.get(d["torch_dtype"], d["torch_dtype"])
+            if "dtype" in d:
+                d["dtype"] = _DTYPE_MAP.get(d["dtype"], d["dtype"])
+
+        _fix_dtype(config_dict)
+        ns = type("HFConfig", (), config_dict)()
+        if "text_config" in config_dict:
+            _fix_dtype(config_dict["text_config"])
+            ns.text_config = type("TextConfig", (), config_dict["text_config"])()
+        return ns
 
 
 def _get_cp_sequence_lengths(cu_seqlens, cp_size, local_total_len=None):
@@ -167,7 +196,7 @@ class HuggingfaceAttention(MegatronModule, ABC):
         # Note that megatron layer_number starts at 1
         self.layer_number = layer_number
         self.hf_layer_idx = layer_number - 1
-        self.hf_config = AutoConfig.from_pretrained(args.hf_checkpoint, trust_remote_code=True)
+        self.hf_config = _load_hf_config(args.hf_checkpoint)
         # hardcode to fa2 at the moment.
         self.hf_config._attn_implementation = "flash_attention_2"
 

--- a/miles_plugins/models/qwen3_5.py
+++ b/miles_plugins/models/qwen3_5.py
@@ -7,7 +7,6 @@ from megatron.core.models.gpt.gpt_layer_specs import get_gpt_decoder_block_spec
 from megatron.core.transformer.spec_utils import ModuleSpec
 from megatron.core.transformer.transformer_block import get_num_layers_to_build
 from megatron.core.transformer.transformer_layer import get_transformer_layer_offset
-from transformers import AutoConfig
 from transformers.activations import ACT2FN
 
 try:
@@ -19,7 +18,7 @@ except ImportError:
 from miles.backends.megatron_utils.fp32_param_utils import mark_param_dtype
 from miles.backends.training_utils.cp_utils import build_gdn_cp_context
 
-from .hf_attention import HuggingfaceAttention
+from .hf_attention import HuggingfaceAttention, _load_hf_config
 
 
 def _get_text_config(hf_config):
@@ -230,7 +229,7 @@ def get_qwen3_5_spec(args, config, vp_stage):
     num_layers_to_build = get_num_layers_to_build(config, vp_stage=vp_stage)
     offset = get_transformer_layer_offset(config, vp_stage=vp_stage)
 
-    hf_config = AutoConfig.from_pretrained(args.hf_checkpoint, trust_remote_code=True)
+    hf_config = _load_hf_config(args.hf_checkpoint)
     text_config = _get_text_config(hf_config)
 
     # Compute layer_types if the config class doesn't expose it

--- a/miles_plugins/models/qwen3_next.py
+++ b/miles_plugins/models/qwen3_next.py
@@ -7,8 +7,9 @@ from megatron.core.models.gpt.gpt_layer_specs import get_gpt_decoder_block_spec
 from megatron.core.transformer.spec_utils import ModuleSpec
 from megatron.core.transformer.transformer_block import get_num_layers_to_build
 from megatron.core.transformer.transformer_layer import get_transformer_layer_offset
-from transformers import AutoConfig
 from transformers.activations import ACT2FN
+
+from .hf_attention import _load_hf_config
 
 try:
     from fla.modules import FusedRMSNormGated, ShortConvolution
@@ -232,7 +233,7 @@ def get_qwen3_next_spec(args, config, vp_stage):
     num_layers_to_build = get_num_layers_to_build(config, vp_stage=vp_stage)
     offset = get_transformer_layer_offset(config, vp_stage=vp_stage)
 
-    hf_config = AutoConfig.from_pretrained(args.hf_checkpoint, trust_remote_code=True)
+    hf_config = _load_hf_config(args.hf_checkpoint)
 
     # Compute layer_types if the config class doesn't expose it
     if not hasattr(hf_config, "layer_types"):

--- a/tools/convert_hf_to_torch_dist.py
+++ b/tools/convert_hf_to_torch_dist.py
@@ -16,6 +16,7 @@ from miles.backends.megatron_utils.initialize import init
 from miles.backends.megatron_utils.model_provider import get_model_provider_func
 from miles.utils.logging_utils import configure_logger
 from miles.utils.memory_utils import print_memory
+from miles_plugins.models.hf_attention import _load_hf_config
 
 
 def add_convertion_args(parser):
@@ -111,7 +112,11 @@ def main():
 
     # Load model
     hf_model_path = args.hf_checkpoint
-    bridge = AutoBridge.from_pretrained(hf_model_path, trust_remote_code=True)
+    try:
+        bridge = AutoBridge.from_pretrained(hf_model_path, trust_remote_code=True)
+    except (ValueError, KeyError):
+        # Fallback for configs with model_type unknown to installed transformers.
+        bridge = AutoBridge.from_config(_load_hf_config(hf_model_path))
 
     bridge.load_weights(model, hf_model_path, memory_efficient=True)
     print(f"Model loaded: {hf_model_path}")


### PR DESCRIPTION
Part 1/6 of splitting #1057 (Kimi K2.5 full-param + LoRA support) into reviewable PRs.

Centralize HF config loading in `_load_hf_config` (miles_plugins/models/hf_attention.py) with a JSON fallback for model_types that the installed transformers does not register (custom / VL configs). It maps `torch_dtype`/`dtype` strings to torch dtypes and handles nested `text_config`. `qwen3_5`, `qwen3_next`, and `convert_hf_to_torch_dist` route through it.

`AutoConfig.from_pretrained` is still attempted first, so existing models are unaffected.

Independent of PRs 2-6 (disjoint files); reviewable/mergeable in any order.