### PR TITLE
2/5 support kimi 2.5 full + lora: VL-aware quantization/conversion tools

### DIFF
--- a/tools/convert_hf_to_fp8.py
+++ b/tools/convert_hf_to_fp8.py
@@ -137,6 +137,8 @@ def process_file(input_path, output_path, filename, strategy, block_size, result
             and "lm_head" not in key
             and "eh_proj" not in key
             and "weights_proj" not in key
+            and "vision_tower" not in key
+            and "mm_projector" not in key
         ):
             qw, s = quant_fp8(weights[key], strategy, block_size)
             q_weights[key] = qw

--- a/tools/convert_hf_to_int4.py
+++ b/tools/convert_hf_to_int4.py
@@ -77,6 +77,8 @@ def main():
         "re:.*shared_experts.*",
         "re:.*mlp\\.(gate|up|gate_up|down)_proj.*",
         "re:.*mlp\\.gate\\.*",
+        "re:vision_tower.*",
+        "re:mm_projector.*",
     ]
 
     recipe = GPTQModifier(

--- a/tools/convert_hf_to_int4_direct.py
+++ b/tools/convert_hf_to_int4_direct.py
@@ -295,6 +295,8 @@ def parse_args():
             "re:.*shared_experts.*",
             "re:.*mlp\\.(gate|up|gate_up|down)_proj.*",
             "re:.*mlp\\.gate\\.*",
+            "re:vision_tower.*",
+            "re:mm_projector.*",
         ],
         help="Ignore Rules",
     )

--- a/tools/convert_kimi_int4_to_bf16.py
+++ b/tools/convert_kimi_int4_to_bf16.py
@@ -218,15 +218,11 @@ def main():
     for fname in os.listdir(model_dir):
         src_path = os.path.join(model_dir, fname)
         dst_path = os.path.join(output_dir, fname)
+        extensions_to_copy = (".json", ".py", ".jinja", ".model")
+
         if fname == "model.safetensors.index.json":
             continue
-        if (
-            fname.endswith(".json")
-            or fname.endswith(".py")
-            or fname.startswith("tokenizer")
-            or fname.endswith(".jinja")
-            or fname.endswith(".model")
-        ):
+        if fname.startswith("tokenizer") or any(fname.endswith(ext) for ext in extensions_to_copy):
             shutil.copy2(src_path, dst_path)
 
     # Generate new index


### PR DESCRIPTION
Part 2/5 of splitting #1057 (Kimi K2.5 full-param + LoRA support) into reviewable PRs, rebased on latest main.

> 🙏 Split out of the original Kimi K2.5 work by **@GeLee-Q** — thanks! (credited via `Co-authored-by` on the commit).

INT4/FP8 quantization tools leave `vision_tower` and `mm_projector` weights unquantized (VL components stay in native precision). Rename `convert_k2_thinking_int4_to_bf16.py` to `convert_kimi_int4_to_bf16.py` and generalize it for Kimi K2.5 checkpoints.

Independent of the other PRs (disjoint files).