### PR TITLE
4/5 support kimi 2.5 full + lora: shared-outer grouped-expert LoRA

### DIFF
--- a/examples/lora/run-kimi-k25-megatron-lora.sh
+++ b/examples/lora/run-kimi-k25-megatron-lora.sh
@@ -1,0 +1,182 @@
+#!/bin/bash
+
+# Kimi-K2.5 LoRA GRPO — 16 nodes × 8 GPUs (H200), colocated.
+# Inherits the full-param Kimi-K2.5 recipe and only overrides LoRA-specific
+# bits (rank/alpha, target modules, shared-outer adapters, LR, parallelism).
+
+# for rerun the task
+pkill -9 sglang
+sleep 3
+ray stop --force
+pkill -9 ray
+pkill -9 python
+sleep 3
+pkill -9 ray
+pkill -9 python
+
+set -ex
+
+# will prevent ray from buffering stdout/stderr
+export PYTHONBUFFERED=16
+
+NVLINK_COUNT=$(nvidia-smi topo -m 2>/dev/null | grep -o 'NV[0-9][0-9]*' | wc -l)
+if [ "$NVLINK_COUNT" -gt 0 ]; then
+    HAS_NVLINK=1
+else
+    HAS_NVLINK=0
+fi
+echo "HAS_NVLINK: $HAS_NVLINK (detected $NVLINK_COUNT NVLink references)"
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+source "${SCRIPT_DIR}/../../scripts/models/kimi-k2-thinking.sh"
+
+CKPT_ARGS=(
+   --hf-checkpoint $BASE_DIR/Kimi-K2.5-int4
+   --ref-load $BASE_DIR/Kimi-K2.5-bf16
+   --megatron-to-hf-mode bridge
+   --model-name kimi_k25
+)
+
+LORA_ARGS=(
+   --lora-rank 32                       # LoRA rank (typical values: 8, 16, 32, 64)
+   --lora-alpha 32                      # LoRA alpha (usually equal to rank for RL)
+   --lora-dropout 0.0                   # LoRA dropout (0.0 for RL training)
+   --target-modules "q_a_proj,kv_a_proj_with_mqa,o_proj,gate_proj,up_proj,down_proj"
+   --experts-shared-outer-loras         # shared A on fc1 / shared B on fc2 across experts
+   --no-gradient-accumulation-fusion
+   --sglang-lora-backend triton         # !!! must for moe-lora !!!
+   --sglang-lora-use-virtual-experts    # virtual-experts MoE LoRA path
+)
+
+ROLLOUT_ARGS=(
+   --prompt-data $BASE_DIR/dapo-math-17k/dapo-math-17k.jsonl
+   --input-key prompt
+   --label-key label
+   --apply-chat-template
+   --rollout-shuffle
+   --balance-data
+   --rm-type deepscaler
+
+   --num-rollout 20
+   --rollout-batch-size 32
+   --n-samples-per-prompt 8
+   --rollout-max-response-len 16384
+   --rollout-temperature 1
+
+   --global-batch-size 256
+   --filter-zero-reward-samples
+   --use-dynamic-global-batch-size
+)
+
+EVAL_ARGS=(
+   --eval-interval 20
+   --eval-prompt-data aime $BASE_DIR/aime-2024.jsonl
+   --n-samples-per-eval-prompt 16
+   --eval-max-response-len 16384
+   --eval-top-p 1
+)
+
+PERF_ARGS=(
+   --tensor-model-parallel-size 8
+   --sequence-parallel
+   --pipeline-model-parallel-size 2
+   --context-parallel-size 8
+   --expert-model-parallel-size 64
+   --expert-tensor-parallel-size 1
+   --decoder-last-pipeline-num-layers 30
+
+   --recompute-granularity full
+   --recompute-method uniform
+   --recompute-num-layers 1
+
+   --use-dynamic-batch-size
+   --max-tokens-per-gpu 4096
+)
+
+GRPO_ARGS=(
+   --advantage-estimator grpo
+   --kl-loss-coef 0.00
+   --kl-loss-type low_var_kl
+   --entropy-coef 0.00
+   --eps-clip 0.2
+   --eps-clip-high 0.28
+   # Off-policy IS correction: PPO operates on within-train ratio; TIS clamps
+   # the cross-engine (sglang Marlin int4 vs Megatron fake-QAT bf16) ratio with
+   # a wider bound than PPO's eps_clip, keeping kernel-rounding bias out of
+   # PPO clipping.
+   --use-tis
+)
+
+OPTIMIZER_ARGS=(
+   --optimizer adam
+   --lr 1e-5                            # PEFT tolerates ~10x full-param LR
+   --lr-decay-style constant
+   --weight-decay 0.1
+   --adam-beta1 0.9
+   --adam-beta2 0.98
+
+   --optimizer-cpu-offload
+   --overlap-cpu-optimizer-d2h-h2d
+   --use-precision-aware-optimizer
+   --use-distributed-optimizer
+)
+
+WANDB_ARGS=(
+   --use-wandb
+   --wandb-project miles-kimi-k25
+   --wandb-group kimi-k25-lora
+   --disable-wandb-random-suffix
+)
+
+SGLANG_ARGS=(
+   --rollout-num-gpus-per-engine 8
+   --sglang-mem-fraction-static 0.7
+   --sglang-ep-size 8
+   --sglang-server-concurrency 1024
+   --sglang-cuda-graph-bs 1 2 4 8 16 24 32 40 48 56 64 72 80 88 96 104 112 120 128
+   --use-rollout-routing-replay
+)
+
+MISC_ARGS=(
+   # default dropout in megatron is 0.1
+   --attention-dropout 0.0
+   --hidden-dropout 0.0
+   # should be good for model performance
+   --accumulate-allreduce-grads-in-fp32
+   --attention-softmax-in-fp32
+   --attention-backend flash
+   --no-check-for-nan-in-loss-and-grad
+)
+
+RUNTIME_ENV_JSON="{
+  \"env_vars\": {
+    \"PYTHONPATH\": \"/root/Megatron-LM/\",
+    \"CUDA_DEVICE_MAX_CONNECTIONS\": \"1\",
+    \"NCCL_NVLS_ENABLE\": \"${HAS_NVLINK}\",
+    \"NCCL_TIMEOUT\": \"3600\",
+    \"OPEN_TRAINING_INT4_FAKE_QAT_FLAG\": \"1\",
+    \"OPEN_TRAINING_INT4_GROUP_SIZE\": \"32\",
+    \"no_proxy\": \"${no_proxy}\",
+    \"MASTER_ADDR\": \"${MASTER_ADDR}\"
+  }
+}"
+
+ray job submit --address="http://127.0.0.1:8265" \
+   --runtime-env-json="${RUNTIME_ENV_JSON}" \
+   -- python3 train.py \
+   --actor-num-nodes 16 \
+   --actor-num-gpus-per-node 8 \
+   --colocate \
+   --use-miles-router \
+   --update-weight-buffer-size $(( 4 * 512 * 1024 * 1024 )) \
+   ${MODEL_ARGS[@]} \
+   ${CKPT_ARGS[@]} \
+   ${LORA_ARGS[@]} \
+   ${ROLLOUT_ARGS[@]} \
+   ${OPTIMIZER_ARGS[@]} \
+   ${GRPO_ARGS[@]} \
+   ${WANDB_ARGS[@]} \
+   ${PERF_ARGS[@]} \
+   ${EVAL_ARGS[@]} \
+   ${SGLANG_ARGS[@]} \
+   ${MISC_ARGS[@]}

--- a/miles/backends/megatron_utils/bridge_lora_helpers.py
+++ b/miles/backends/megatron_utils/bridge_lora_helpers.py
@@ -93,9 +93,14 @@ def _setup_lora_model_via_bridge(args: Namespace) -> list:
     provider.sequence_parallel = args.sequence_parallel
     provider.virtual_pipeline_model_parallel_size = args.virtual_pipeline_model_parallel_size
     provider.context_parallel_size = args.context_parallel_size
+    provider.gradient_accumulation_fusion = args.gradient_accumulation_fusion
     provider.variable_seq_lengths = True
     provider.moe_token_dispatcher_type = "alltoall"
     provider.moe_router_load_balancing_type = "none"
+    if getattr(args, "decoder_first_pipeline_num_layers", None) is not None:
+        provider.num_layers_in_first_pipeline_stage = args.decoder_first_pipeline_num_layers
+    if getattr(args, "decoder_last_pipeline_num_layers", None) is not None:
+        provider.num_layers_in_last_pipeline_stage = args.decoder_last_pipeline_num_layers
     provider.finalize()
 
     lora = create_lora_instance(args)

--- a/miles/backends/megatron_utils/lora_utils.py
+++ b/miles/backends/megatron_utils/lora_utils.py
@@ -72,6 +72,19 @@ _MEGATRON_TO_HF_MODULES = {
 
 _HF_MODULE_NAMES = {"q_proj", "k_proj", "v_proj", "o_proj", "gate_proj", "up_proj", "down_proj"}
 
+# DeepSeek / Kimi MLA (HF names on checkpoint; Megatron uses linear_* from Megatron-Bridge mappings).
+_MLA_HF_TO_MEGATRON = {
+    "q_a_proj": "linear_q_down_proj",
+    "kv_a_proj_with_mqa": "linear_kv_down_proj",
+    "q_b_proj": "linear_q_up_proj",
+    "kv_b_proj": "linear_kv_up_proj",
+}
+_MEGATRON_MLA_TO_HF = {v: k for k, v in _MLA_HF_TO_MEGATRON.items()}
+
+# SGLang default get_hidden_dim (lora/utils.py) handles fused_qkv_a_proj_with_mqa via q_a / kv_a mapping,
+# but not separate q_b_proj / kv_b_proj yet — omit from rollout adapter config to avoid init crashes.
+_SGLANG_UNSUPPORTED_HF_TARGETS = frozenset({"q_b_proj", "kv_b_proj"})
+
 
 # ---------------------------------------------------------------------------
 # Core helpers
@@ -181,14 +194,20 @@ def convert_target_modules_to_megatron(
         if hf_modules[0] in ("all", "all-linear", "all_linear"):
             return list(all_modules)
 
-    # Check if already in Megatron format
-    if all(m not in _HF_MODULE_NAMES for m in hf_modules if "*" not in m):
-        return hf_modules
+    if isinstance(hf_modules, tuple):
+        hf_modules = list(hf_modules)
+
+    # Check if already in Megatron format (standard / canonical / Kimi MLA linear_*).
+    if all(m not in _HF_MODULE_NAMES and m not in _MLA_HF_TO_MEGATRON for m in hf_modules if "*" not in m):
+        return list(hf_modules)
 
     # Convert HF names to Megatron names (dedup while preserving order)
     megatron_modules: list[str] = []
     for module in hf_modules:
-        megatron_name = hf_to_megatron.get(module, module)
+        if module in _MLA_HF_TO_MEGATRON:
+            megatron_name = _MLA_HF_TO_MEGATRON[module]
+        else:
+            megatron_name = hf_to_megatron.get(module, module)
         if megatron_name not in megatron_modules:
             megatron_modules.append(megatron_name)
 
@@ -204,14 +223,45 @@ def convert_target_modules_to_hf(megatron_modules: list[str]) -> list[str]:
     Megatron canonical:  linear_q, linear_k, linear_v, linear_proj,
                          linear_fc1_up, linear_fc1_gate, linear_fc2
     HF:                  q_proj, k_proj, v_proj, o_proj, gate_proj, up_proj, down_proj
+    Kimi MLA Megatron:   linear_q_down_proj -> q_a_proj, linear_kv_down_proj -> kv_a_proj_with_mqa, ...
+
+    Wildcards (``*.layers.2.mlp.experts.linear_fc1``) get the last dotted
+    segment mapped to an HF leaf name; SGLang uses the result to choose
+    adapter-buffer types, not to scope by layer.
     """
+    if isinstance(megatron_modules, tuple):
+        megatron_modules = list(megatron_modules)
     hf_modules: list[str] = []
     for module in megatron_modules:
-        if module in _MEGATRON_TO_HF_MODULES:
-            hf_modules.extend(_MEGATRON_TO_HF_MODULES[module])
+        lookup_key = module.rsplit(".", 1)[-1] if "*" in module else module
+        if lookup_key in _MEGATRON_MLA_TO_HF:
+            hf_modules.append(_MEGATRON_MLA_TO_HF[lookup_key])
+        elif lookup_key in _MEGATRON_TO_HF_MODULES:
+            hf_modules.extend(_MEGATRON_TO_HF_MODULES[lookup_key])
         else:
             hf_modules.append(module)
-    return hf_modules
+    seen: set[str] = set()
+    unique: list[str] = []
+    for m in hf_modules:
+        if m not in seen:
+            seen.add(m)
+            unique.append(m)
+    return unique
+
+
+def target_modules_hf_for_sglang_rollout(args: Namespace) -> list[str]:
+    """HF target_modules for SGLang LoRA init/sync, with MLA q_b/kv_b dropped (unsupported)."""
+    raw = list(args.target_modules) if args.target_modules else []
+    hf = convert_target_modules_to_hf(raw)
+    out = [m for m in hf if m not in _SGLANG_UNSUPPORTED_HF_TARGETS]
+    dropped = set(hf) - set(out)
+    if dropped:
+        logger.warning(
+            "target_modules_hf_for_sglang_rollout: omitting %s for SGLang (unsupported by default "
+            "get_hidden_dim); Megatron should not train LoRA on these if rollout sync is required.",
+            sorted(dropped),
+        )
+    return out
 
 
 # ---------------------------------------------------------------------------
@@ -251,7 +301,7 @@ def create_lora_instance(args: Namespace):
     target_modules = convert_target_modules_to_megatron(args.target_modules, lora_type=lora_cls)
     exclude_modules = parse_exclude_modules(args, lora_type=lora_cls)
 
-    lora = lora_cls(
+    lora_kwargs = dict(
         target_modules=target_modules,
         exclude_modules=exclude_modules,
         dim=args.lora_rank,
@@ -260,6 +310,12 @@ def create_lora_instance(args: Namespace):
         lora_A_init_method=getattr(args, "lora_A_init_method", "xavier"),
         lora_B_init_method=getattr(args, "lora_B_init_method", "zero"),
     )
+    # Opt-in to SGLang PR #21466's shared-outer grouped-expert LoRA. Only the
+    # standard ``LoRA`` class supports the flag today.
+    if lora_cls is LoRA and getattr(args, "experts_shared_outer_loras", False):
+        lora_kwargs["experts_shared_outer_loras"] = True
+
+    lora = lora_cls(**lora_kwargs)
 
     logger.info(
         f"Created {lora_cls.__name__}: rank={args.lora_rank}, alpha={args.lora_alpha}, "
@@ -490,7 +546,7 @@ def _load_training_state(
 def build_lora_sync_config(args: Namespace) -> dict[str, Any]:
     """Build LoRA config dict for syncing weights to SGLang engines."""
     target_modules_hf = (
-        convert_target_modules_to_hf(list(args.target_modules))
+        target_modules_hf_for_sglang_rollout(args)
         if args.target_modules
         else ["q_proj", "k_proj", "v_proj", "o_proj", "gate_proj", "up_proj", "down_proj"]
     )

--- a/miles/backends/megatron_utils/update_weight/update_weight_from_tensor.py
+++ b/miles/backends/megatron_utils/update_weight/update_weight_from_tensor.py
@@ -9,7 +9,11 @@ import torch.distributed as dist
 from ray import ObjectRef
 from ray.actor import ActorHandle
 
-from miles.backends.megatron_utils.lora_utils import LORA_ADAPTER_NAME, build_lora_sync_config, is_lora_weight_name
+from miles.backends.megatron_utils.lora_utils import (
+    LORA_ADAPTER_NAME,
+    build_lora_sync_config,
+    is_lora_weight_name,
+)
 from miles.backends.training_utils.parallel import get_parallel_state
 from miles.utils.distributed_utils import get_gloo_group
 
@@ -175,11 +179,23 @@ class UpdateWeightFromTensor:
         self.weight_version += 1
 
         rank = dist.get_rank()
+
+        # LoRA never mutates the base. Under distributed weight update the base
+        # stays resident on the rollout GPU, so we can skip the base sync
+        # entirely along with the surrounding restore_weights_before_load /
+        # post_process_quantization calls that would otherwise prep / re-quantize
+        # fresh base bytes.
+        skip_base_sync = self.is_lora and self.use_distribute
+
         if rank == 0:
             mode = self.args.pause_generation_mode
             ray.get([engine.pause_generation.remote(mode=mode) for engine in self.rollout_engines])
             ray.get([engine.flush_cache.remote() for engine in self.rollout_engines])
-            if self.quantization_config and self.quantization_config["quant_method"] in ["compressed-tensors"]:
+            if (
+                not skip_base_sync
+                and self.quantization_config
+                and self.quantization_config["quant_method"] in ["compressed-tensors"]
+            ):
                 post_process_weights(
                     rollout_engines=self.rollout_engines,
                     restore_weights_before_load=True,
@@ -189,8 +205,7 @@ class UpdateWeightFromTensor:
 
         megatron_local_weights = self.weights_getter()
 
-        # For LoRA+distributed: base weights are frozen, skip after first round.
-        if not (self.is_lora and self.use_distribute and self._lora_base_synced):
+        if not skip_base_sync:
             for hf_named_tensors in self._hf_weight_iterator.get_hf_weight_chunks(
                 megatron_local_weights, weight_type="base"
             ):
@@ -200,37 +215,41 @@ class UpdateWeightFromTensor:
                 del long_lived_tensors
 
         if self.is_lora:
-            lora_sync_chunk_count = 0
+            # SGLang's load_lora_adapter_from_tensors expects the full adapter in
+            # one call; drain the bridge's chunker so --update-weight-buffer-size
+            # only bounds the base path.
+            accumulated_named_tensors: list = []
             for hf_named_tensors in self._hf_weight_iterator.get_hf_weight_chunks(
                 megatron_local_weights, weight_type="lora"
             ):
-                refs, long_lived_tensors = self._send_lora_params(hf_named_tensors)
-                results = ray.get(refs)
-                _check_weight_sync_results(results, is_lora=True)
-                del long_lived_tensors
-                lora_sync_chunk_count += 1
+                accumulated_named_tensors.extend(hf_named_tensors)
 
-            if lora_sync_chunk_count == 0:
+            if not accumulated_named_tensors:
                 raise RuntimeError(
                     "LoRA weight sync failed: the weight iterator produced zero chunks. "
                     "No adapter weights were sent to the rollout engine. This usually means "
                     "the Megatron-Bridge or SGLang version is incompatible."
                 )
 
-            if self.use_distribute and not self._lora_base_synced:
+            refs, long_lived_tensors = self._send_lora_params(accumulated_named_tensors)
+            results = ray.get(refs)
+            _check_weight_sync_results(results, is_lora=True)
+            del long_lived_tensors
+
+            if not self._lora_base_synced:
                 self._lora_base_synced = True
 
         dist.barrier(group=get_gloo_group())
 
         if rank == 0:
-            # `post_process_quantization` is related to the `process_weights_after_loading`
-            # in the sglang rollout side, which should always be invoked after weight
-            # updating.
-            post_process_weights(
-                rollout_engines=self.rollout_engines,
-                restore_weights_before_load=False,
-                post_process_quantization=True,
-            )
+            # process_weights_after_loading is a one-shot bf16 → int4/Marlin
+            # transform; skip when no fresh base bytes landed (skip_base_sync).
+            if not skip_base_sync:
+                post_process_weights(
+                    rollout_engines=self.rollout_engines,
+                    restore_weights_before_load=False,
+                    post_process_quantization=True,
+                )
             ray.get([engine.continue_generation.remote() for engine in self.rollout_engines])
         dist.barrier(group=get_gloo_group())
 
@@ -293,6 +312,7 @@ def _send_to_colocated_engine(
         return [], None
 
     is_lora = lora_config is not None
+    is_gather_src = dist.get_rank() == ipc_gather_src
     long_live_tensors = []
 
     if getattr(FlattenedTensorBucket, "supports_multi_dtypes", False):
@@ -305,7 +325,7 @@ def _send_to_colocated_engine(
                 converted_named_tensors_by_dtypes[dtype] = []
             converted_named_tensors_by_dtypes[dtype].append((name, tensor))
 
-    serialized_tensors = []
+    serialized_tensors: list = []
     for _dtype, named_tensors in converted_named_tensors_by_dtypes.items():
         flattened_tensor_bucket = FlattenedTensorBucket(named_tensors=named_tensors)
         flattened_tensor_data = {
@@ -315,9 +335,7 @@ def _send_to_colocated_engine(
         long_live_tensors.append(flattened_tensor_data)
         serialized_tensors.append(MultiprocessingSerializer.serialize(flattened_tensor_data, output_str=True))
 
-    serialized_named_tensors = (
-        [None] * dist.get_world_size(ipc_gather_group) if ipc_gather_src == dist.get_rank() else None
-    )
+    serialized_named_tensors = [None] * dist.get_world_size(ipc_gather_group) if is_gather_src else None
     dist.gather_object(
         serialized_tensors,
         object_gather_list=serialized_named_tensors,
@@ -326,7 +344,7 @@ def _send_to_colocated_engine(
     )
 
     refs = []
-    if dist.get_rank() == ipc_gather_src:
+    if is_gather_src:
         if is_lora:
             if lora_loaded:
                 ray.get(ipc_engine.unload_lora_adapter.remote(lora_name=lora_name))
@@ -340,7 +358,7 @@ def _send_to_colocated_engine(
                 ipc_engine.load_lora_adapter_from_tensors.remote(
                     lora_name=lora_name,
                     config_dict=lora_config,
-                    serialized_tensors=serialized_named_tensors[0][0],
+                    serialized_named_tensors=[per_rank[0] for per_rank in serialized_named_tensors],
                     load_format="flattened_bucket",
                 )
             )

--- a/miles/backends/megatron_utils/update_weight/update_weight_from_tensor.py
+++ b/miles/backends/megatron_utils/update_weight/update_weight_from_tensor.py
@@ -9,11 +9,7 @@ import torch.distributed as dist
 from ray import ObjectRef
 from ray.actor import ActorHandle
 
-from miles.backends.megatron_utils.lora_utils import (
-    LORA_ADAPTER_NAME,
-    build_lora_sync_config,
-    is_lora_weight_name,
-)
+from miles.backends.megatron_utils.lora_utils import LORA_ADAPTER_NAME, build_lora_sync_config, is_lora_weight_name
 from miles.backends.training_utils.parallel import get_parallel_state
 from miles.utils.distributed_utils import get_gloo_group
 

--- a/miles/backends/megatron_utils/update_weight/update_weight_from_tensor.py
+++ b/miles/backends/megatron_utils/update_weight/update_weight_from_tensor.py
@@ -354,7 +354,9 @@ def _send_to_colocated_engine(
                 ipc_engine.load_lora_adapter_from_tensors.remote(
                     lora_name=lora_name,
                     config_dict=lora_config,
-                    serialized_named_tensors=[per_rank[0] for per_rank in serialized_named_tensors],
+                    serialized_named_tensors=[
+                        per_rank[0] if per_rank else None for per_rank in serialized_named_tensors
+                    ],
                     load_format="flattened_bucket",
                 )
             )

--- a/miles/backends/sglang_utils/sglang_engine.py
+++ b/miles/backends/sglang_utils/sglang_engine.py
@@ -13,7 +13,11 @@ from sglang.srt.server_args import ServerArgs
 from sglang.srt.utils import kill_process_tree
 from urllib3.exceptions import NewConnectionError
 
-from miles.backends.megatron_utils.lora_utils import LORA_ADAPTER_NAME, convert_target_modules_to_hf, is_lora_enabled
+from miles.backends.megatron_utils.lora_utils import (
+    LORA_ADAPTER_NAME,
+    convert_target_modules_to_hf,
+    is_lora_enabled,
+)
 from miles.ray.ray_actor import RayActor
 from miles.utils.env_report import collect_and_print_node_env_report
 from miles.utils.http_utils import get_host_info
@@ -334,17 +338,17 @@ class SGLangEngine(RayActor):
     def load_lora_adapter_from_tensors(
         self,
         lora_name: str,
-        serialized_tensors: str,
         config_dict: dict,
+        serialized_named_tensors: list,
         load_format: str | None = None,
         pinned: bool = False,
         added_tokens_config: dict | None = None,
     ):
-        """Load a LoRA adapter from serialized tensor data."""
+        """Load a LoRA adapter. ``serialized_named_tensors[tp_rank]`` is bytes for TP rank N."""
         payload = {
             "lora_name": lora_name,
-            "serialized_tensors": serialized_tensors,
             "config_dict": config_dict,
+            "serialized_named_tensors": serialized_named_tensors,
             "pinned": pinned,
         }
         if load_format is not None:

--- a/miles/backends/sglang_utils/sglang_engine.py
+++ b/miles/backends/sglang_utils/sglang_engine.py
@@ -13,11 +13,7 @@ from sglang.srt.server_args import ServerArgs
 from sglang.srt.utils import kill_process_tree
 from urllib3.exceptions import NewConnectionError
 
-from miles.backends.megatron_utils.lora_utils import (
-    LORA_ADAPTER_NAME,
-    convert_target_modules_to_hf,
-    is_lora_enabled,
-)
+from miles.backends.megatron_utils.lora_utils import LORA_ADAPTER_NAME, convert_target_modules_to_hf, is_lora_enabled
 from miles.ray.ray_actor import RayActor
 from miles.utils.env_report import collect_and_print_node_env_report
 from miles.utils.http_utils import get_host_info

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -1123,6 +1123,14 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 default=False,
                 help="Sync LoRA weights via tensor instead of file (more efficient)",
             )
+            parser.add_argument(
+                "--experts-shared-outer-loras",
+                action="store_true",
+                default=False,
+                help="Enable shared-outer grouped-expert LoRA (gate_up lora_A and "
+                "down lora_B shared across experts, expert_dim=1). Matches SGLang "
+                "PR #21466's experts_shared_outer_loras=True serving contract.",
+            )
             return parser
 
         def add_router_arguments(parser):
@@ -2021,6 +2029,14 @@ def miles_validate_args(args):
             modules = [m for m in modules if m not in exclude_set]
 
         args.target_modules = modules
+
+        # Training and serving must agree on shared-outer grouped-expert LoRA
+        # (expert_dim=1 buffers in SGLang).
+        if args.experts_shared_outer_loras:
+            args.sglang_experts_shared_outer_loras = True
+        assert args.experts_shared_outer_loras == bool(
+            args.sglang_experts_shared_outer_loras
+        ), "experts_shared_outer_loras and sglang_experts_shared_outer_loras must agree"
 
     assert not (args.kl_coef != 0 and args.kl_loss_coef != 0), "Only one of kl_coef and kl_loss_coef can be set"
 


### PR DESCRIPTION
Part 4/5 of splitting #1057 (Kimi K2.5 full-param + LoRA support) into reviewable PRs, rebased on latest main.

Add `--experts-shared-outer-loras`: gate_up lora_A and down lora_B are shared across experts (expert_dim=1), matching SGLang PR #21466's serving contract. Maps DeepSeek/Kimi MLA HF names (`q_a_proj`, `kv_a_proj_with_mqa`, ...) to Megatron `linear_*` and drops `q_b`/`kv_b` from the SGLang rollout adapter config (unsupported by the default get_hidden_dim).

Switch LoRA weight sync to per-TP-rank `serialized_named_tensors` and accumulate the adapter into a single `load_lora_adapter_from_tensors` call; skip base-weight sync under distributed update (base stays on the rollout GPU). Adds `examples/lora/run-kimi-k25-megatron-lora.sh`.

Builds on #1221 (Kimi full-param) at runtime; file set is disjoint from #1219-#1221 so it merges independently. #1223 stacks on this one.