### PR TITLE
5/5 support kimi 2.5 full + lora: LoRA base-weight CPU backup

### DIFF
--- a/examples/lora/run-kimi-k25-megatron-lora.sh
+++ b/examples/lora/run-kimi-k25-megatron-lora.sh
@@ -43,6 +43,7 @@ LORA_ARGS=(
    --lora-dropout 0.0                   # LoRA dropout (0.0 for RL training)
    --target-modules "q_a_proj,kv_a_proj_with_mqa,o_proj,gate_proj,up_proj,down_proj"
    --experts-shared-outer-loras         # shared A on fc1 / shared B on fc2 across experts
+   --lora-base-cpu-backup               # keep frozen base on CPU to free GPU
    --no-gradient-accumulation-fusion
    --sglang-lora-backend triton         # !!! must for moe-lora !!!
    --sglang-lora-use-virtual-experts    # virtual-experts MoE LoRA path

--- a/miles/backends/megatron_utils/lora_utils.py
+++ b/miles/backends/megatron_utils/lora_utils.py
@@ -96,6 +96,11 @@ def is_lora_enabled(args: Namespace) -> bool:
     return getattr(args, "lora_rank", 0) > 0 or getattr(args, "lora_adapter_path", None) is not None
 
 
+def lora_base_cpu_backup_enabled(args: Namespace) -> bool:
+    """LoRA + --colocate + --lora-base-cpu-backup all set."""
+    return is_lora_enabled(args) and getattr(args, "colocate", False) and getattr(args, "lora_base_cpu_backup", False)
+
+
 def is_lora_model(model: Sequence[torch.nn.Module]) -> bool:
     """Check if model has LoRA layers applied."""
     for model_chunk in model:

--- a/miles/backends/megatron_utils/update_weight/update_weight_from_tensor.py
+++ b/miles/backends/megatron_utils/update_weight/update_weight_from_tensor.py
@@ -9,7 +9,12 @@ import torch.distributed as dist
 from ray import ObjectRef
 from ray.actor import ActorHandle
 
-from miles.backends.megatron_utils.lora_utils import LORA_ADAPTER_NAME, build_lora_sync_config, is_lora_weight_name
+from miles.backends.megatron_utils.lora_utils import (
+    LORA_ADAPTER_NAME,
+    build_lora_sync_config,
+    is_lora_weight_name,
+    lora_base_cpu_backup_enabled,
+)
 from miles.backends.training_utils.parallel import get_parallel_state
 from miles.utils.distributed_utils import get_gloo_group
 
@@ -176,12 +181,12 @@ class UpdateWeightFromTensor:
 
         rank = dist.get_rank()
 
-        # LoRA never mutates the base. Under distributed weight update the base
-        # stays resident on the rollout GPU, so we can skip the base sync
-        # entirely along with the surrounding restore_weights_before_load /
-        # post_process_quantization calls that would otherwise prep / re-quantize
-        # fresh base bytes.
-        skip_base_sync = self.is_lora and self.use_distribute
+        # LoRA never mutates the base. With either path that retains it on the
+        # rollout side (distributed keeps it on GPU; colocate + cpu_backup keeps
+        # a host mirror across pause/resume), we can skip the base sync entirely
+        # and the surrounding restore_weights_before_load / post_process_quantization
+        # calls that would otherwise prep / re-quantize fresh base bytes.
+        skip_base_sync = self.is_lora and (self.use_distribute or lora_base_cpu_backup_enabled(self.args))
 
         if rank == 0:
             mode = self.args.pause_generation_mode

--- a/miles/backends/sglang_utils/sglang_engine.py
+++ b/miles/backends/sglang_utils/sglang_engine.py
@@ -13,7 +13,12 @@ from sglang.srt.server_args import ServerArgs
 from sglang.srt.utils import kill_process_tree
 from urllib3.exceptions import NewConnectionError
 
-from miles.backends.megatron_utils.lora_utils import LORA_ADAPTER_NAME, convert_target_modules_to_hf, is_lora_enabled
+from miles.backends.megatron_utils.lora_utils import (
+    LORA_ADAPTER_NAME,
+    convert_target_modules_to_hf,
+    is_lora_enabled,
+    lora_base_cpu_backup_enabled,
+)
 from miles.ray.ray_actor import RayActor
 from miles.utils.env_report import collect_and_print_node_env_report
 from miles.utils.http_utils import get_host_info
@@ -664,6 +669,18 @@ def _compute_server_args(
             kwargs["lora_paths"] = {LORA_ADAPTER_NAME: args.lora_adapter_path}
         else:
             logger.info("No pre-trained LoRA adapter_path provided, will use random initial weights")
+
+        if lora_base_cpu_backup_enabled(args):
+            # Host-RAM mirror of the base weights so they survive
+            # torch_memory_saver.pause() across rollout/training swaps without
+            # needing to be re-shipped from the trainer. The trainer mirrors
+            # this by skipping the base weight sync entirely (see
+            # UpdateWeightFromTensor.update_weights).
+            kwargs["enable_weights_cpu_backup"] = True
+            logger.info(
+                "LoRA + colocate: enabling SGLang enable_weights_cpu_backup=True; "
+                "the trainer will skip per-step base weight sync."
+            )
 
     unused_keys = set(kwargs.keys())
     for attr in dataclasses.fields(ServerArgs):

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -1124,6 +1124,16 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 help="Sync LoRA weights via tensor instead of file (more efficient)",
             )
             parser.add_argument(
+                "--lora-base-cpu-backup",
+                action="store_true",
+                default=False,
+                help=(
+                    "LoRA + colocate: keep SGLang-side CPU mirror of base weights "
+                    "and skip per-step base sync. Trades host RAM for faster "
+                    "onload/offload. Ignored unless --colocate and LoRA are both on."
+                ),
+            )
+            parser.add_argument(
                 "--experts-shared-outer-loras",
                 action="store_true",
                 default=False,


### PR DESCRIPTION
Part 5/5 of splitting #1057 (Kimi K2.5 full-param + LoRA support) into reviewable PRs, rebased on latest main.

Add `--lora-base-cpu-backup`: with `--colocate`, keep a host-RAM mirror of the base weights in SGLang (`enable_weights_cpu_backup`) so they survive `torch_memory_saver.pause()` across rollout/training swaps, and have the trainer skip the per-step base weight sync (and the surrounding restore / re-quantize calls) entirely. Trades host RAM for faster onload/offload; ignored unless `--colocate` and LoRA are both on.

**Stacks on #1222** (shared files: arguments.py, lora_utils.py, sglang_engine.py, update_weight_from_tensor.py). Until #1222 merges, the diff here also shows that PR's changes; review the last commit (`perf: LoRA base-weight CPU backup`) in isolation, or after #1222 lands.