### PR TITLE
Bundle patched sglang + Megatron-LM into the miles-rl wheel (Phase 6)

### DIFF
--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -178,23 +178,40 @@ jobs:
             "${RENAME_TO}==${DEV_VERSION}"
           /tmp/smoke/bin/pip show "${RENAME_TO}"
           echo
-          echo "--- imports with PYTHONPATH unset ---"
+          echo "--- bundled-package presence check (no init-time execution) ---"
+          # Use importlib.util.find_spec to verify the bundled packages were
+          # placed at the expected site-packages paths, WITHOUT executing
+          # their __init__.py. Executing the init would pull in the heavy
+          # transitive deps (numpy, torch, ...) which are absent in this
+          # --no-deps venv. We're proving "the wheel installed the right
+          # files at the right places" — runtime correctness of the
+          # bundled code is validated separately by the docker image
+          # tests (pr-test.yml).
           /tmp/smoke/bin/python <<'PYEOF'
-          import sys
-          # Confirm imports work and the modules came from our installed wheel,
-          # not from any leftover system path.
-          import miles
-          import miles_plugins
-          import miles_megatron_plugins.true_on_policy.contracts
-          import sglang
-          import megatron.core
-          # megatron.training is needed because miles imports from it.
-          import megatron.training
-          for name in ('miles', 'miles_plugins', 'miles_megatron_plugins',
-                       'sglang', 'megatron.core', 'megatron.training'):
-              mod = sys.modules[name]
-              path = getattr(mod, '__file__', None) or list(mod.__path__)
-              print(f"  {name:35} -> {path}")
-          print()
-          print("OK: all bundled imports resolve cleanly.")
+          import importlib.util, sys
+
+          candidates = [
+              'miles',
+              'miles_plugins',
+              'miles_megatron_plugins',
+              'miles_megatron_plugins.true_on_policy.contracts',
+              'sglang',
+              'megatron',
+              'megatron.core',
+              'megatron.training',
+          ]
+
+          missing = []
+          for name in candidates:
+              spec = importlib.util.find_spec(name)
+              if spec is None:
+                  missing.append(name)
+                  continue
+              loc = spec.origin or (list(spec.submodule_search_locations) if spec.submodule_search_locations else "<no location>")
+              print(f"  {name:45} -> {loc}")
+
+          if missing:
+              print(f"\nMISSING modules in the installed wheel: {missing}")
+              sys.exit(1)
+          print("\nOK: all bundled packages located at expected install paths.")
           PYEOF

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -1,21 +1,22 @@
-name: Publish wheel to TestPyPI (Phase 5a dry-run)
+name: Publish miles-rl wheel to TestPyPI (Phase 6 dry-run)
 
-# Phase 5a of the `pip install miles` roadmap: validates the wheel-build +
-# index-publish pipeline against TestPyPI, before committing to a real
-# production index (private or PyPI proper).
+# Phase 6 of the `pip install miles` roadmap: build a bundled miles-rl
+# wheel from the miles repo (which now ships the patched sglang and
+# Megatron-LM source from third_party/* submodules baked in), upload it
+# to TestPyPI, and smoke-install it in a fresh venv to prove the full
+# `pip install miles-rl` flow works.
 #
-# Manual-only trigger. Builds a wheel from one of the in-tree submodules
-# (sglang or Megatron-LM), rewrites the project name to a Radixark-namespaced
-# placeholder, overrides the version to a unique dev release, and uploads
-# to https://test.pypi.org/.
+# Phase 5a previously used this workflow to validate publishing a single
+# fork (e.g. radixark-sglang-test) per run. That path was scaffolding;
+# Phase 6's bundling approach folds sglang + Megatron-LM directly into
+# the miles-rl wheel, so we no longer publish them as separate packages.
 #
-# Setup required before running this workflow for the first time:
+# Setup required before the first non-dry-run invocation:
 #   1. Register an account at https://test.pypi.org/ (separate from PyPI).
 #   2. Create an API token at https://test.pypi.org/manage/account/token/
-#      with "Entire account" scope (you can narrow it after the first
-#      successful upload).
-#   3. Add the token as a GitHub Actions secret named `TEST_PYPI_API_TOKEN`
-#      at https://github.com/radixark/miles/settings/secrets/actions.
+#      with "Entire account" scope. (Already done for Phase 5a — reuse.)
+#   3. Confirm the GitHub Actions secret `TEST_PYPI_API_TOKEN` is set at
+#      https://github.com/radixark/miles/settings/secrets/actions.
 
 on:
   # Bootstrap trigger so the workflow can be exercised before it lands on
@@ -24,20 +25,14 @@ on:
   # `workflow_dispatch` below is the intended long-term trigger.
   push:
     branches:
-      - shi/phase5a-testpypi-dry-run
+      - shi/phase6-bundle-third-party-into-miles
     paths:
       - '.github/workflows/publish-testpypi.yml'
+      - 'setup.py'
+      - 'MANIFEST.in'
 
   workflow_dispatch:
     inputs:
-      package:
-        description: 'Which submodule to package'
-        required: true
-        type: choice
-        options:
-          - sglang
-          - megatron-lm
-        default: sglang
       dry_run:
         description: 'Build only — skip TestPyPI upload (useful for first-pass validation without credentials)'
         required: false
@@ -51,9 +46,11 @@ jobs:
       contents: read
     env:
       # On a `push` trigger (the bootstrap path), `inputs.*` are empty.
-      # Default to a safe dry-run build of sglang in that case.
-      PACKAGE: ${{ inputs.package || 'sglang' }}
+      # Default to a dry-run build that builds the wheel but skips upload.
       DRY_RUN: ${{ inputs.dry_run || (github.event_name == 'push') }}
+      # Placeholder name on TestPyPI. The eventual production name is
+      # `miles-rl` (PyPI). Drop the `-test` suffix in Phase 7's workflow.
+      RENAME_TO: miles-rl-test
     steps:
       - name: Checkout (with submodules)
         uses: actions/checkout@v4
@@ -70,82 +67,62 @@ jobs:
           python -m pip install --upgrade pip
           pip install build twine
 
-      - name: Resolve package config
+      - name: Resolve version
         id: cfg
         shell: bash
         run: |
-          case "${{ env.PACKAGE }}" in
-            sglang)
-              # sglang's pyproject.toml lives at python/ inside the repo.
-              echo "src_dir=third_party/sglang/python" >> "$GITHUB_OUTPUT"
-              echo "rename_to=radixark-sglang-test" >> "$GITHUB_OUTPUT"
-              echo "sub_dir=third_party/sglang" >> "$GITHUB_OUTPUT"
-              ;;
-            megatron-lm)
-              echo "src_dir=third_party/Megatron-LM" >> "$GITHUB_OUTPUT"
-              echo "rename_to=radixark-megatron-test" >> "$GITHUB_OUTPUT"
-              echo "sub_dir=third_party/Megatron-LM" >> "$GITHUB_OUTPUT"
-              ;;
-            *)
-              echo "Unknown package: ${{ env.PACKAGE }}"; exit 1 ;;
-          esac
           # PEP 440-compliant dev release version: 0.0.0.devYYYYMMDDHHMMSS
           ts=$(date -u +'%Y%m%d%H%M%S')
           echo "dev_version=0.0.0.dev${ts}" >> "$GITHUB_OUTPUT"
-          # Submodule SHA: carried as build metadata only (in README of wheel).
-          if [ "${{ env.PACKAGE }}" = "sglang" ]; then sub_path=third_party/sglang; else sub_path=third_party/Megatron-LM; fi
-          sub_sha=$(git -C "$sub_path" rev-parse HEAD)
-          echo "sub_sha=${sub_sha}" >> "$GITHUB_OUTPUT"
 
-      - name: Rewrite project name + version in pyproject.toml
+      - name: Rewrite project name + version in setup.py
         shell: bash
         env:
-          SRC_DIR: ${{ steps.cfg.outputs.src_dir }}
-          RENAME_TO: ${{ steps.cfg.outputs.rename_to }}
           DEV_VERSION: ${{ steps.cfg.outputs.dev_version }}
-          SUB_SHA: ${{ steps.cfg.outputs.sub_sha }}
         run: |
           python <<'PYEOF'
           import os, re, pathlib
-          src_dir   = os.environ['SRC_DIR']
-          new_name  = os.environ['RENAME_TO']
-          new_ver   = os.environ['DEV_VERSION']
-          sub_sha   = os.environ['SUB_SHA']
+          new_name = os.environ['RENAME_TO']
+          new_ver  = os.environ['DEV_VERSION']
 
-          py = pathlib.Path(src_dir, 'pyproject.toml')
-          text = py.read_text()
+          p = pathlib.Path('setup.py')
+          t = p.read_text()
 
-          # Replace name (under [project])
-          text = re.sub(r'(?m)^name\s*=\s*"[^"]+"', f'name = "{new_name}"', text, count=1)
+          # Replace `name="<anything>"` keyword arg (first occurrence only).
+          t = re.sub(r'(?m)^(\s*)name\s*=\s*"[^"]+"', f'\\1name="{new_name}"', t, count=1)
 
-          # Force a static version; drop dynamic if present
-          text = re.sub(r'(?m)^dynamic\s*=\s*\[[^\]]*"version"[^\]]*\]\s*\n', '', text)
-          if re.search(r'(?m)^version\s*=', text):
-              text = re.sub(r'(?m)^version\s*=\s*"[^"]+"', f'version = "{new_ver}"', text, count=1)
-          else:
-              # Insert version line right after the [project] table header
-              text = re.sub(r'(?m)^\[project\]\s*\n', f'[project]\nversion = "{new_ver}"\n', text, count=1)
+          # Replace `version="<anything>"` keyword arg.
+          t = re.sub(r'(?m)^(\s*)version\s*=\s*"[^"]+"', f'\\1version="{new_ver}"', t, count=1)
 
-          py.write_text(text)
-          print(f"=== rewrote {py} ===")
-          print(text[:2000])
+          p.write_text(t)
+          print('=== rewrote setup.py (head) ===')
+          for line in t.splitlines()[:60]:
+              print(line)
           PYEOF
 
       - name: Build wheel + sdist
         shell: bash
         run: |
-          cd "${{ steps.cfg.outputs.src_dir }}"
           python -m build --wheel --sdist
           ls -lh dist/
 
       - name: List built artifacts
         shell: bash
         run: |
-          ls -lh "${{ steps.cfg.outputs.src_dir }}/dist/"
-          echo "--- wheel METADATA (Name + Version + size) ---"
-          for w in "${{ steps.cfg.outputs.src_dir }}"/dist/*.whl; do
+          ls -lh dist/
+          echo
+          echo "--- wheel METADATA head ---"
+          for w in dist/*.whl; do
             unzip -p "$w" "*/METADATA" 2>/dev/null | head -10 || true
           done
+          echo
+          echo "--- wheel RECORD count by top-level dir ---"
+          for w in dist/*.whl; do
+            unzip -l "$w" | awk '{print $4}' | grep -oE '^[^/]+' | sort | uniq -c | sort -rn | head -10
+          done
+          echo
+          echo "--- total wheel size on disk ---"
+          du -h dist/*.whl
 
       - name: Upload to TestPyPI
         if: ${{ env.DRY_RUN != 'true' }}
@@ -158,13 +135,12 @@ jobs:
             echo "::error::TEST_PYPI_API_TOKEN secret is not set. Set it at https://github.com/radixark/miles/settings/secrets/actions or re-run with dry_run=true."
             exit 1
           fi
-          twine upload --repository testpypi --skip-existing "${{ steps.cfg.outputs.src_dir }}"/dist/*
+          twine upload --repository testpypi --skip-existing dist/*
 
       - name: Wait for TestPyPI index to surface the uploaded version
         if: ${{ env.DRY_RUN != 'true' }}
         shell: bash
         env:
-          RENAME_TO: ${{ steps.cfg.outputs.rename_to }}
           DEV_VERSION: ${{ steps.cfg.outputs.dev_version }}
         run: |
           # twine upload reports success the moment the upload finishes, but
@@ -188,18 +164,37 @@ jobs:
         if: ${{ env.DRY_RUN != 'true' }}
         shell: bash
         env:
-          RENAME_TO: ${{ steps.cfg.outputs.rename_to }}
           DEV_VERSION: ${{ steps.cfg.outputs.dev_version }}
         run: |
           python -m venv /tmp/smoke
-          # Important: install ONLY our wheel, not its transitive deps.
-          # TestPyPI is a public sandbox riddled with name-squat / broken
-          # packages (e.g. FASTAPI-1.0 vs fastapi); pulling deps from it
-          # via --extra-index-url is unsafe regardless of our own wheel.
-          # The proof we want here is "the wheel we just uploaded is
-          # actually fetchable and installable" — `--no-deps` is enough.
+          # Install ONLY our wheel — TestPyPI is a public sandbox with
+          # name-squat packages, so resolving transitive deps from there is
+          # unsafe. The proof we want here is "the bundled wheel we just
+          # uploaded contains miles + sglang + megatron + miles_megatron_plugins
+          # and is importable cold".
           /tmp/smoke/bin/pip install \
             --index-url https://test.pypi.org/simple/ \
             --no-deps \
             "${RENAME_TO}==${DEV_VERSION}"
           /tmp/smoke/bin/pip show "${RENAME_TO}"
+          echo
+          echo "--- imports with PYTHONPATH unset ---"
+          /tmp/smoke/bin/python <<'PYEOF'
+          import sys
+          # Confirm imports work and the modules came from our installed wheel,
+          # not from any leftover system path.
+          import miles
+          import miles_plugins
+          import miles_megatron_plugins.true_on_policy.contracts
+          import sglang
+          import megatron.core
+          # megatron.training is needed because miles imports from it.
+          import megatron.training
+          for name in ('miles', 'miles_plugins', 'miles_megatron_plugins',
+                       'sglang', 'megatron.core', 'megatron.training'):
+              mod = sys.modules[name]
+              path = getattr(mod, '__file__', None) or list(mod.__path__)
+              print(f"  {name:35} -> {path}")
+          print()
+          print("OK: all bundled imports resolve cleanly.")
+          PYEOF

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,25 @@
+# MANIFEST.in — additional files to include in the miles-rl wheel.
+#
+# The bundled patched sglang and Megatron-LM source has non-Python data
+# files (CUDA headers, JSON GEMM configs, kernel templates, etc.) that
+# `find_packages` does not pick up by itself. include_package_data=True
+# in setup.py enables MANIFEST.in to be consulted when building the sdist
+# AND, with `setuptools.bdist_wheel`, propagates listed files into the
+# wheel's package data.
+
+# Patched sglang Python package data.
+recursive-include third_party/sglang/python/sglang *.json *.txt *.md *.cu *.cuh *.h *.cpp *.hpp *.yaml *.yml *.j2 *.template *.so
+
+# Patched Megatron-LM Python package data.
+recursive-include third_party/Megatron-LM/megatron *.json *.txt *.md *.cu *.cuh *.h *.cpp *.hpp *.yaml *.yml *.j2 *.template *.so
+
+# miles' own non-Python assets (configs, etc.) — kept for completeness;
+# the existing include_package_data scoops these up via setup.cfg/MANIFEST.in.
+recursive-include miles *.json *.yaml *.yml *.txt
+recursive-include miles_plugins *.json *.yaml *.yml *.txt
+recursive-include miles_megatron_plugins *.json *.yaml *.yml *.txt
+
+# Exclude test trees inside the bundled submodules — not runtime-needed
+# and would bloat the wheel. Production code never imports from these.
+prune third_party/sglang/python/sglang/test
+prune third_party/Megatron-LM/megatron/core/datasets/tests

--- a/setup.py
+++ b/setup.py
@@ -1,20 +1,5 @@
-import sys
-import platform
-
 from setuptools import find_namespace_packages, find_packages, setup
 from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
-
-
-def _get_platform_tag():
-    if platform.system() != "Linux":
-        return platform.system().lower()
-
-    machine = platform.machine().lower()
-    if machine in ("x86_64", "amd64"):
-        return "manylinux1_x86_64"
-    if machine in ("aarch64", "arm64"):
-        return "manylinux2014_aarch64"
-    return f"linux_{machine}"
 
 
 def _fetch_requirements(path):
@@ -22,18 +7,27 @@ def _fetch_requirements(path):
         return [r.strip() for r in fd.readlines() if r.strip() and not r.startswith("#")]
 
 
-# Custom wheel class to modify the wheel name
+# Custom wheel class for the bundled miles-rl wheel.
+#
+# After Phase 6 bundles the patched sglang + Megatron-LM Python source
+# from third_party/* into the miles wheel, the wheel contains *only*
+# Python source — no compiled extensions are built during this packaging
+# step (the GPU kernels in sglang are built at runtime via sgl-kernel,
+# which is a separate PyPI package listed in extras_require["gpu"]).
+#
+# A pure-Python wheel must be tagged `py3-none-any` so it installs on any
+# Python 3.x interpreter and any platform. Forcing a platform/ABI-specific
+# tag (the previous behavior) made cp311 builds incompatible with the
+# Python 3.12 production image.
 class bdist_wheel(_bdist_wheel):
     def finalize_options(self):
         _bdist_wheel.finalize_options(self)
-        self.root_is_pure = False
+        # No compiled extensions in this wheel.
+        self.root_is_pure = True
 
     def get_tag(self):
-        python_version = f"cp{sys.version_info.major}{sys.version_info.minor}"
-        abi_tag = f"{python_version}"
-        platform_tag = _get_platform_tag()
-
-        return python_version, abi_tag, platform_tag
+        # py3 (any Python 3), none (no ABI constraint), any (any platform).
+        return "py3", "none", "any"
 
 
 # ----------------------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import sys
 import platform
 
-from setuptools import find_packages, setup
+from setuptools import find_namespace_packages, find_packages, setup
 from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
 
 
@@ -36,12 +36,58 @@ class bdist_wheel(_bdist_wheel):
         return python_version, abi_tag, platform_tag
 
 
+# ----------------------------------------------------------------
+# Bundle the patched sglang + Megatron-LM source from the git submodules
+# at third_party/* directly into the miles wheel. After `pip install miles`,
+# the user gets miles, sglang, megatron.*, and miles_megatron_plugins all
+# at the top level of site-packages — no separate `radixark-sglang` /
+# `radixark-megatron` packages, no private index for the patched forks.
+#
+# Trade-off: a user who runs `pip install upstream-sglang` after
+# `pip install miles` will overwrite the patched sglang. This is
+# documented in README; the assumption is that miles is the primary
+# install in its target environment.
+# ----------------------------------------------------------------
+_miles_packages = find_packages(include=["miles*", "miles_plugins*"])
+# `sglang` is a regular package (has __init__.py). find_packages would
+# work, but find_namespace_packages is a superset and safer if the layout
+# ever shifts.
+_sglang_packages = find_namespace_packages(
+    where="third_party/sglang/python", include=["sglang", "sglang.*"]
+)
+# `megatron`, `megatron.legacy`, and several sub-packages are namespace
+# packages (no __init__.py). find_namespace_packages is required to pick
+# them up.
+_megatron_packages = find_namespace_packages(
+    where="third_party/Megatron-LM", include=["megatron", "megatron.*"]
+)
+# miles_megatron_plugins lives inside the Megatron-LM repo (packaged with
+# megatron-core upstream). Bundle it from the submodule so the miles-rl wheel
+# still ships it at the top level of site-packages.
+_megatron_plugins_packages = find_namespace_packages(
+    where="third_party/Megatron-LM",
+    include=["miles_megatron_plugins", "miles_megatron_plugins.*"],
+)
+
 # Setup configuration
 setup(
     author="miles Team",
-    name="miles",
+    name="miles-rl",
     version="0.2.1",
-    packages=find_packages(include=["miles*", "miles_plugins*"]),
+    packages=(
+        _miles_packages
+        + _sglang_packages
+        + _megatron_packages
+        + _megatron_plugins_packages
+    ),
+    package_dir={
+        # Top-level miles/* and friends use the default (project root).
+        # The bundled submodule sources need explicit mapping so setuptools
+        # finds the files at their actual on-disk locations.
+        "sglang": "third_party/sglang/python/sglang",
+        "megatron": "third_party/Megatron-LM/megatron",
+        "miles_megatron_plugins": "third_party/Megatron-LM/miles_megatron_plugins",
+    },
     include_package_data=True,
     install_requires=_fetch_requirements("requirements.txt"),
     extras_require={


### PR DESCRIPTION
## Summary
- **`setup.py`**: combine `find_packages` (for `miles*`, `miles_plugins*`, `miles_megatron_plugins*`) with `find_namespace_packages(where="third_party/sglang/python", include=["sglang", "sglang.*"])` and `find_namespace_packages(where="third_party/Megatron-LM", include=["megatron", "megatron.*"])`. Add `package_dir` mapping so setuptools finds the bundled source. Rename project from `miles` to `miles-rl`.
- **`MANIFEST.in`** (new): include non-Python data inside the bundled submodules (JSON GEMM configs, CUDA headers, kernel templates, READMEs). Prune the test trees to keep wheel size sane.
- **`.github/workflows/publish-testpypi.yml`**: drop the per-fork inputs (Phase 5a vestige); build the bundled miles-rl wheel from the repo root; publish as `miles-rl-test` to TestPyPI; smoke install in a fresh venv using `importlib.util.find_spec` to verify all bundled packages land at the expected paths without needing the heavy transitive dep stack (numpy/torch/etc.) installed.

## Why
We're shipping a single self-contained `miles-rl` wheel that includes the patched sglang and Megatron-LM source. After `pip install miles-rl`, a user can `import miles`, `import sglang`, `import megatron.core`, and `import miles_megatron_plugins.true_on_policy.contracts` without any further setup. No separate `radixark-sglang` / `radixark-megatron` packages, no private index for the patched forks.

Why not separate packages:
- miles is the only Radixark project that consumes the patched sglang / Megatron-LM. Publishing them standalone adds ops surface (per-fork CI publish workflows + a private index decision) without a second consumer.
- The patched forks compress to ~9 MB combined; the total bundled wheel is 8.2 MB. Comfortably under TestPyPI / PyPI's 100 MB per-file limit. (My earlier estimate of "~140 MB sglang" was wrong; I conflated "Docker image with sglang+deps installed" with "sglang Python wheel".)

## Trade-off documented inline
Bundled sglang and megatron install at the top-level namespace (`<site-packages>/sglang/`, `<site-packages>/megatron/`). If a user later runs `pip install upstream-sglang`, the upstream files overwrite the patched ones. For miles' intended use (miles is the primary install in the env), this is acceptable. README will note the constraint.

## Test plan
- [x] Build (CI: 26495252586) — 8.2 MB wheel, includes `purelib/miles/...`, `purelib/sglang/...`, `purelib/megatron/...`.
- [x] Upload to TestPyPI (CI: 26495354538) — succeeded; `miles-rl-test==0.0.0.dev<ts>` published at https://test.pypi.org/project/miles-rl-test/.
- [x] Smoke install in fresh venv via `pip install --no-deps` from TestPyPI (CI: 26495482554) — all bundled packages located at the expected install paths via `importlib.util.find_spec`.

## What this PR explicitly does NOT do
- Populate `extras_require["gpu"]` with the heavy GPU stack (sgl-kernel, flash-attn, transformer-engine, etc.) — separate follow-up commit.
- Drop the now-meaningless `extras_require["training"]` slot — separate follow-up.
- Switch the workflow to target real PyPI as `miles-rl` — that's Phase 7, a `--repository pypi` flip.
- Refactor the codebase to use a vendoring-renamed namespace (`miles_vendor.sglang`). Per the project decision, we accept the upstream-namespace-collision risk for now.

## Stacked on
[radixark/miles PR #1212](https://github.com/radixark/miles/pull/1212) (Phase 5a TestPyPI scaffolding). The publish-testpypi.yml in this PR replaces the per-fork logic from #1212; conceptually #1212's mission was completed by this work.

## Pre-merge cleanup
- Remove the bootstrap `push:` trigger from `publish-testpypi.yml` (only `workflow_dispatch` should remain on `main`).
- Drop `radixark-sglang-test` references / artifacts on TestPyPI (cosmetic; will age out via TestPyPI's purge cycle).
