### PR TITLE
feat: enable partitioned stage-a-cpu CI on pull requests

### DIFF
--- a/.github/workflows/_run-ci.yml
+++ b/.github/workflows/_run-ci.yml
@@ -9,8 +9,7 @@ on:
       runs_on:
         type: string
         required: false
-        default: '["8gpu"]'
-        description: 'JSON-encoded list of runner labels (all required). e.g. ''["h100", "8gpu"]'' picks runners that carry BOTH labels. Default ''["8gpu"]'' preserves the previous bare ''8gpu'' single-label routing.'
+        description: 'JSON-encoded list of runner labels (all required). e.g. ''["h100", "8gpu"]'' picks runners that carry BOTH labels. No default: GPU jobs (cpu_runner: false) must pass this explicitly.'
       container_image:
         type: string
         required: false

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -2,7 +2,7 @@ name: PR Test
 
 on:
   pull_request:
-    types: [synchronize, labeled]
+    types: [opened, synchronize, reopened, ready_for_review, labeled]
   workflow_dispatch:
     inputs:
       infinite_run:
@@ -74,11 +74,16 @@ jobs:
   stage-a-cpu:
     needs: [resolve-ci-image]
     if: (github.event_name == 'workflow_dispatch') || (github.event.pull_request)
+    strategy:
+      fail-fast: false
+      matrix:
+        partition_id: [0, 1, 2, 3]
     uses: ./.github/workflows/_run-ci.yml
     with:
       cpu_runner: true
       execute_command: >-
         python tests/ci/run_suite.py --hw cpu --suite stage-a-cpu
+        --auto-partition-id ${{ matrix.partition_id }} --auto-partition-size 4
         --labels ${{ join(github.event.pull_request.labels.*.name, ' ') }}
         ${{ (github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'run-ci-image') || contains(github.event.pull_request.labels.*.name, 'run-ci-all')) && '--match-all-labels' || '' }}
     secrets: inherit


### PR DESCRIPTION
## Summary
Run the `stage-a-cpu` suite on pull requests across a 4-way partition matrix, and drop the hardcoded `runs-on` default so CPU jobs schedule on the right runner.

## Motivation
After the location-based registration restructure, the CPU suite must actually run on PRs. Without this, `stage-a-cpu` either does not trigger on new PRs or runs unpartitioned and times out.

## Usage
On `opened` / `synchronize` / `reopened` / `ready_for_review` of a PR, `.github/workflows/pr-test.yml` launches `stage-a-cpu` as a `partition_id: [0, 1, 2, 3]` matrix, each shard invoking `run_suite.py ... --auto-partition-id ${{ matrix.partition_id }} --auto-partition-size 4`.

## Design Notes
- **Key choices:** 4-way partition sized to the current `stage-a-cpu` runtime; balancing reuses the existing est_time-based LPT `auto_partition`. The `_run-ci.yml` `runs-on` default is removed so the per-suite runner label applies.
- **Constraints / trade-offs:** must merge **last** in the chain — it enables the job that exercises the test changes from the earlier PRs; enabling it before those land would run a red suite.

## Verification
- Workflow-YAML-only change; exercised by the `stage-a-cpu` job it enables, on top of the chain.
