### PR TITLE
feat: disk-delta weight sync for non-colocated rollout engines

### DIFF
--- a/.github/workflows/_run-ci.yml
+++ b/.github/workflows/_run-ci.yml
@@ -145,14 +145,14 @@ jobs:
           cd /sgl-workspace/sglang && git reset --hard HEAD && git clean -fd && git fetch origin "$SGLANG_PR" && git checkout -f FETCH_HEAD && git log --oneline -1 && pip install -e python --no-deps --break-system-packages
           cd /root/Megatron-LM && git reset --hard HEAD && git clean -fd && git fetch origin "$MEGATRON_PR" && git checkout -f FETCH_HEAD && git log --oneline -1 && pip install -e . --no-deps --break-system-packages
           cd $GITHUB_WORKSPACE && pip install -e . --no-deps --break-system-packages
-          pip install polars --break-system-packages
+          pip install polars zstandard xxhash blake3 --break-system-packages
 
       - name: Install (miles only)
         if: ${{ inputs.skip_dependency_install }}
         shell: bash
         run: |
           cd $GITHUB_WORKSPACE && pip install -e . --no-deps --break-system-packages
-          pip install polars --break-system-packages
+          pip install polars zstandard xxhash blake3 --break-system-packages
 
       - name: Resolve suite plan
         shell: bash

--- a/miles/backends/megatron_utils/actor.py
+++ b/miles/backends/megatron_utils/actor.py
@@ -177,6 +177,11 @@ class MegatronTrainRayActor(TrainRayActor):
         else:
             if self.args.update_weight_transfer_mode == "broadcast":
                 update_weight_cls = UpdateWeightFromDistributed
+            elif self.args.update_weight_transfer_mode == "disk-delta":
+                # Lazy import: keeps the delta deps (numpy/zstandard/xxhash) off the other paths.
+                from .update_weight.update_weight_from_distributed.delta import UpdateWeightFromDiskDelta
+
+                update_weight_cls = UpdateWeightFromDiskDelta
             else:
                 update_weight_cls = UpdateWeightP2P
         self.weight_updater = update_weight_cls(
@@ -432,7 +437,7 @@ class MegatronTrainRayActor(TrainRayActor):
                     logger.info(f"Updating ref model at rollout_id {rollout_id}")
                 self.weights_backuper.backup("ref")
 
-        log_perf_data(rollout_id, self.args)
+        log_perf_data(rollout_id, self.args, extra_metrics=self.weight_updater.pop_metrics())
 
     @timer
     def save_model(self, rollout_id: int, force_sync: bool = False) -> None:

--- a/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/delta.py
+++ b/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/delta.py
@@ -157,6 +157,25 @@ class UpdateWeightFromDiskDelta(DistBucketedWeightUpdateMixin):
         self._encode_delta()
         self._write_delta_files()
 
+    def _drop_duplicate_names(self, group, world: int, rank: int) -> None:
+        """A parameter Megatron replicates across PP stages — the word embedding on the last stage
+        when it hosts an MTP block, or tied embeddings — is gathered and diffed by one source rank
+        per stage, so the same HF tensor lands in several ranks' shards. The published artifact
+        must hold each tensor exactly once (the XOR apply is an involution: applied twice it
+        reverts), so keep the lowest-rank copy and drop the rest. The replicas are gradient-synced
+        and byte-identical; a checksum divergence means the sync is broken — never publish it."""
+        all_checksums: list = [None] * world
+        dist.all_gather_object(all_checksums, self._checksums, group=group)
+        for other_rank, other in enumerate(all_checksums[:rank]):
+            for name in self._delta.keys() & other.keys():
+                if other[name] != self._checksums[name]:
+                    raise RuntimeError(
+                        f"{name!r} published by rank {other_rank} and rank {rank} with different bytes; "
+                        "PP-replicated parameters must stay identical across stages."
+                    )
+                del self._delta[name]
+                del self._checksums[name]
+
     def _write_delta_files(self) -> None:
         """Write this rank's changed tensors as one canonical model-NNNNN.safetensors, and on rank
         0 the HF index. The sequential file numbers and the index are coordinated over gloo (small
@@ -164,6 +183,8 @@ class UpdateWeightFromDiskDelta(DistBucketedWeightUpdateMixin):
         rank's writes to another until commit."""
         group = get_gloo_group()
         world, rank = dist.get_world_size(), dist.get_rank()
+
+        self._drop_duplicate_names(group, world, rank)
 
         # number the files sequentially across only the ranks that have one (no gaps)
         counts: list = [None] * world

--- a/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/delta.py
+++ b/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/delta.py
@@ -1,0 +1,333 @@
+from __future__ import annotations
+
+import json
+import logging
+import os
+import queue
+import shutil
+from argparse import Namespace
+from collections import deque
+from collections.abc import Callable, Mapping, Sequence
+from concurrent.futures import ThreadPoolExecutor
+
+import numpy as np
+import ray
+import safetensors.numpy
+import torch
+import torch.distributed as dist
+import zstandard
+from ray.actor import ActorHandle
+from tqdm import tqdm
+
+from miles.backends.training_utils.parallel import get_parallel_state
+from miles.utils.disk_delta import NUM_WORKERS, checksum, make_tensor_reader, overwrite_encode
+from miles.utils.distributed_utils import get_gloo_group
+
+from ..common import _check_weight_sync_results
+from .mixin import DistBucketedWeightUpdateMixin
+
+logger = logging.getLogger(__name__)
+
+
+class UpdateWeightFromDiskDelta(DistBucketedWeightUpdateMixin):
+    """
+    Delta weight sync over a shared filesystem. Source ranks diff each gathered HF tensor against
+    a CPU snapshot of the previous sync and publish the changes as a canonical HF checkpoint dir;
+    each engine's /pull_weights fans the apply out to every host it spans, then the engine reloads
+    the patched local checkpoint via the ordinary update_weights_from_disk path. miles only ever
+    talks to one endpoint per engine, so multi-node serving needs nothing extra.
+    """
+
+    def __init__(
+        self,
+        args: Namespace,
+        model: Sequence[torch.nn.Module],
+        weights_getter: Callable[[], Mapping[str, torch.Tensor]],
+        *,
+        model_name: str,
+        quantization_config: dict[str, int | str | list[str]] | None,
+        is_lora: bool = False,
+    ) -> None:
+        assert not is_lora, "LoRA weight sync is not supported for disk-delta weight transfer."
+        self.args = args
+        self.model = model
+        self.model_name = model_name
+        self.quantization_config = quantization_config
+        self.weight_version = 0
+        self.delta_dir = args.update_weight_disk_dir
+        os.makedirs(self.delta_dir, exist_ok=True)
+        self.delta_encoding = args.update_weight_delta_encoding
+        self.checksum_algorithm = args.update_weight_delta_checksum
+        self._snapshot: dict[str, np.ndarray] = {}
+        self._baseline_captured = False
+        # Post-write hook: object-store-backed shared filesystems lack cross-host
+        # read-after-write consistency, so written files need an explicit step
+        # (e.g. uploading them to the backing object store) before the engines can see them.
+        self._post_write_hook: Callable | None = None
+        if args.custom_update_weight_post_write_path:
+            from miles.utils.misc import load_function
+
+            self._post_write_hook = load_function(args.custom_update_weight_post_write_path)
+        self._init_lora(
+            args=args,
+            model=model,
+            model_name=model_name,
+            quantization_config=quantization_config,
+            is_lora=is_lora,
+        )
+
+    def connect_rollout_engines(
+        self,
+        rollout_engines: Sequence[ActorHandle],
+        rollout_engine_lock: ActorHandle,
+        engine_gpu_counts: Sequence[int] | None = None,
+        engine_gpu_offsets: Sequence[int] | None = None,
+    ) -> None:
+        # No NCCL groups: the transport is the shared filesystem. The rollout_engine_lock the
+        # NCCL path uses isn't needed either — the engine-side apply is serialized by a per-host
+        # flock behind /pull_weights.
+        self.rollout_engines = rollout_engines
+        self._group_name = "miles-disk-delta"
+
+    @property
+    def _is_source(self):
+        """If it's the source gpu producing the gathered HF tensors this rank publishes."""
+        return get_parallel_state().intra_dp_cp.rank == 0 and get_parallel_state().tp.rank == 0
+
+    @torch.no_grad()
+    def update_weights(self) -> None:
+        # The first call only captures the baseline snapshot the next sync diffs against.
+        if not self._baseline_captured:
+            self._capture_baseline()
+            self._baseline_captured = True
+            return
+
+        self.weight_version += 1
+        self._publish()
+        self._reload_engines()
+        self._record_metrics()
+
+    def _capture_baseline(self) -> None:
+        """Capture the baseline snapshot the first delta diffs against (no publish), and clear any
+        stale stream from a prior run. Seeds from hf_checkpoint — what each host materializes its
+        base from — so the invariant ``snapshot == engine base`` holds even where the megatron->HF
+        round-trip trims vocab-padding rows (embed/lm_head). A tensor absent there (rare) falls back
+        to the gathered value. pull_weights(0) makes each host materialize its local base now,
+        overlapped with the snapshot gather, so the first real sync only pays the delta apply."""
+        # a prior run's versions would apply against the wrong base; start the dir clean
+        pulls = []
+        if dist.get_rank() == 0:
+            shutil.rmtree(self.delta_dir, ignore_errors=True)
+            os.makedirs(self.delta_dir, exist_ok=True)
+            if self._post_write_hook is not None:
+                self._post_write_hook(self.args, self.delta_dir, list(self.rollout_engines))
+            pulls = [engine.pull_weights.remote(target_version=0) for engine in self.rollout_engines]
+        dist.barrier(group=get_gloo_group())
+
+        read_hf = make_tensor_reader(self.args.hf_checkpoint)  # index the HF headers once
+
+        def seed_bucket(converted_named_tensors: list[tuple[str, torch.Tensor]], pbar: tqdm | None = None) -> None:
+            for name, tensor in converted_named_tensors:
+                try:
+                    self._snapshot[name] = read_hf(name)
+                except KeyError:
+                    self._snapshot[name] = tensor.detach().cpu().contiguous().view(torch.uint8).numpy().reshape(-1)
+                    logger.warning("seed: %s absent from hf_checkpoint; seeding from current weights", name)
+
+        self._for_each_hf_bucket(seed_bucket)
+        if dist.get_rank() == 0:
+            _check_weight_sync_results(ray.get(pulls), is_lora=False)
+            logger.info(
+                "[disk delta] captured baseline snapshot of %d tensors from %s",
+                len(self._snapshot),
+                self.args.hf_checkpoint,
+            )
+
+    def _for_each_hf_bucket(self, bucket_func: Callable[[list[tuple[str, torch.Tensor]], tqdm | None], None]) -> None:
+        """Feed every gathered HF bucket through ``bucket_func``: the base-class TP pass then the
+        EP pass. All ranks join the gathers; ``bucket_func`` only runs on source ranks."""
+        pbar = tqdm(desc=f"[{self._group_name}] Update weights", total=0) if self._is_source else None
+        self._gather_and_update_non_expert_weights(bucket_func, pbar)
+        dist.barrier(group=get_gloo_group())
+        self._gather_and_update_expert_weights(bucket_func, pbar)
+        dist.barrier(group=get_gloo_group())
+
+    def _publish(self) -> None:
+        """Encode this version's changed tensors (source ranks), then write it as a canonical HF dir."""
+        self._encode_delta()
+        self._write_delta_files()
+
+    def _write_delta_files(self) -> None:
+        """Write this rank's changed tensors as one canonical model-NNNNN.safetensors, and on rank
+        0 the HF index. The sequential file numbers and the index are coordinated over gloo (small
+        object gathers), not the filesystem — a non-POSIX shared filesystem may not surface one
+        rank's writes to another until commit."""
+        group = get_gloo_group()
+        world, rank = dist.get_world_size(), dist.get_rank()
+
+        # number the files sequentially across only the ranks that have one (no gaps)
+        counts: list = [None] * world
+        dist.all_gather_object(counts, int(bool(self._delta)), group=group)
+        offset, total = sum(counts[:rank]), sum(counts)
+
+        fname = None
+        self.wire_bytes = 0
+        if self._delta:
+            fname = f"model-{offset:05d}-of-{total:05d}.safetensors"
+            blob = safetensors.numpy.save(self._delta, metadata=self._checksums)
+            self.wire_bytes = len(blob)
+            _atomic_write(os.path.join(self._version_dir, fname), blob)
+
+        maps: list = [None] * world
+        dist.all_gather_object(maps, {name: fname for name in self._delta}, group=group)
+        if rank == 0:
+            index = {
+                "metadata": {
+                    "version": f"{self.weight_version:06d}",
+                    "base_version": f"{self.weight_version - 1:06d}",
+                    "delta_encoding": self.delta_encoding,
+                    "compression_format": "zstd",
+                    "checksum_format": self.checksum_algorithm,
+                },
+                "weight_map": {name: f for m in maps for name, f in m.items()},
+            }
+            _atomic_write(os.path.join(self._version_dir, "model.safetensors.index.json"), json.dumps(index).encode())
+        dist.barrier(group=group)
+
+    def _reload_engines(self) -> None:
+        """Commit the published files, have each engine pull the delta onto every host it spans
+        (checksum-verified), then reload the engines. The pull is disk-only, so it runs before
+        pause and overlaps generation."""
+        if self._post_write_hook is not None:
+            self._post_write_hook(self.args, self._version_dir, list(self.rollout_engines))
+        dist.barrier(group=get_gloo_group())
+        if dist.get_rank() == 0:
+            pulls = ray.get([engine.pull_weights.remote(self.weight_version) for engine in self.rollout_engines])
+            _check_weight_sync_results(pulls, is_lora=False)
+            mode = self.args.pause_generation_mode
+            ray.get([engine.pause_generation.remote(mode=mode) for engine in self.rollout_engines])
+            if mode not in ("in_place"):
+                ray.get([engine.flush_cache.remote() for engine in self.rollout_engines])
+            results = ray.get(
+                [
+                    engine.update_weights_from_disk.remote(
+                        model_path=self.args.update_weight_local_checkpoint_dir,
+                        weight_version=str(self.weight_version),
+                    )
+                    for engine in self.rollout_engines
+                ]
+            )
+            _check_weight_sync_results(results, is_lora=False)
+            ray.get([engine.continue_generation.remote() for engine in self.rollout_engines])
+        dist.barrier(group=get_gloo_group())
+
+    def _encode_delta(self) -> None:
+        """Diff each gathered HF tensor against the snapshot, keeping the changed ones (compressed)
+        in self._delta with their checksums. The GPU->CPU gather is pipelined into a compute pool:
+        each bucket callback copies one tensor at a time to a pinned buffer and submits it; pool
+        workers diff and compress in parallel (each is a few big GIL-releasing numpy/zstd calls)."""
+        self._version_dir = os.path.join(self.delta_dir, f"weight_v{self.weight_version:06d}")
+        if self._is_source:
+            os.makedirs(self._version_dir, exist_ok=True)
+        snapshot = self._snapshot
+        self._delta: dict[str, np.ndarray] = {}  # changed tensor name -> compressed diff
+        self._checksums: dict[str, str] = {}  # changed tensor name -> new-state checksum
+        self.changed_bytes = self.total_bytes = 0
+
+        # Pinned host-buffer pool: a pinned non_blocking GPU->CPU copy is far faster than .cpu().
+        max_bytes = max((int(v.nbytes) for v in snapshot.values()), default=0)
+        free_q: queue.Queue = queue.Queue()
+        use_pinned = True
+        try:
+            for _ in range(max(4, min(2 * NUM_WORKERS, (32 << 30) // max(max_bytes, 1)))):
+                free_q.put(torch.empty(max_bytes, dtype=torch.uint8, pin_memory=True))
+        except RuntimeError as e:  # low memlock limit
+            logger.warning("pinned host buffers unavailable (%s); using pageable .cpu()", e)
+            use_pinned = False
+
+        def diff_and_compress(name, buf, nbytes, pinned):
+            if pinned:  # copy out and free the pinned buffer before the heavy diff/compress
+                new = np.empty(nbytes, dtype=np.uint8)
+                np.copyto(new, buf.numpy()[:nbytes])
+                free_q.put(buf)
+            else:
+                new = buf
+            old = snapshot[name]
+            if self.delta_encoding == "xor":
+                diff = new ^ old
+                changed = int(np.count_nonzero(diff))
+            elif self.delta_encoding == "overwrite":
+                mask = new != old
+                changed = int(np.count_nonzero(mask))
+                diff = overwrite_encode(new, mask)
+            else:
+                raise ValueError(f"unknown delta encoding {self.delta_encoding!r}")
+            if not changed:
+                return name, new, None, None, 0
+            compressed = np.frombuffer(zstandard.ZstdCompressor(level=1).compress(diff), dtype=np.uint8)
+            return name, new, compressed, checksum(self.checksum_algorithm, new), changed
+
+        def collect(fut):
+            name, new, compressed, digest, changed = fut.result()
+            snapshot[name] = new  # becomes the next sync's base
+            if changed:
+                self.changed_bytes += changed
+                self._delta[name] = compressed
+                self._checksums[name] = digest
+
+        pool = ThreadPoolExecutor(max_workers=NUM_WORKERS)
+        inflight: deque = deque()
+
+        def encode_bucket(converted_named_tensors: list[tuple[str, torch.Tensor]], pbar: tqdm | None = None) -> None:
+            for name, tensor in converted_named_tensors:
+                flat = tensor.detach().contiguous().view(torch.uint8).reshape(-1)
+                nbytes = int(flat.numel())
+                if use_pinned and nbytes <= max_bytes:
+                    buf = free_q.get()  # blocks when all buffers are in flight -> backpressures the gather
+                    buf[:nbytes].copy_(flat, non_blocking=True)
+                    torch.cuda.current_stream().synchronize()
+                    payload, pinned = buf, True
+                else:
+                    payload, pinned = flat.cpu().numpy(), False
+                self.total_bytes += nbytes
+                inflight.append(pool.submit(diff_and_compress, name, payload, nbytes, pinned))
+                if len(inflight) >= 2 * NUM_WORKERS:
+                    collect(inflight.popleft())
+
+        try:
+            self._for_each_hf_bucket(encode_bucket)
+            while inflight:
+                collect(inflight.popleft())
+        finally:
+            pool.shutdown()
+
+    def _record_metrics(self) -> None:
+        """All-reduce the byte counts and record changed-fraction / wire size; the actor drains
+        update_weight_metrics onto the step log."""
+        counts = torch.tensor(
+            [self.changed_bytes, self.total_bytes, self.wire_bytes],
+            dtype=torch.int64,
+            device=torch.cuda.current_device(),
+        )
+        dist.all_reduce(counts)
+        changed, total, wire = counts.tolist()
+        self.update_weight_metrics = {
+            "perf/update_weights_density": changed / max(total, 1),
+            "perf/update_weights_wire_bytes": wire,
+        }
+        if dist.get_rank() == 0:
+            logger.info(
+                "[disk delta v=%s] density=%.2f%% wire=%.2f GB",
+                self.weight_version,
+                100.0 * changed / max(total, 1),
+                wire / 1e9,
+            )
+
+
+def _atomic_write(path: str, data: bytes) -> None:
+    tmp = path + ".tmp"
+    with open(tmp, "wb") as f:
+        f.write(data)
+        f.flush()
+        os.fsync(f.fileno())
+    os.replace(tmp, path)

--- a/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/delta.py
+++ b/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/delta.py
@@ -137,6 +137,21 @@ class UpdateWeightFromDiskDelta(DistBucketedWeightUpdateMixin):
         self._for_each_hf_bucket(seed_bucket)
         if dist.get_rank() == 0:
             _check_weight_sync_results(ray.get(pulls), is_lora=False)
+            if self.args.check_weight_update_equal:
+                # The weights checker resets engine tensors at startup and compares after the
+                # first sync, expecting it to rewrite every tensor. The baseline publishes
+                # nothing, so reload the just-pulled base checkpoint to restore engine state
+                # (and set the engine weight version the CI equality check expects).
+                results = ray.get(
+                    [
+                        engine.update_weights_from_disk.remote(
+                            model_path=self.args.update_weight_local_checkpoint_dir,
+                            weight_version=str(self.weight_version),
+                        )
+                        for engine in self.rollout_engines
+                    ]
+                )
+                _check_weight_sync_results(results, is_lora=False)
             logger.info(
                 "[disk delta] captured baseline snapshot of %d tensors from %s",
                 len(self._snapshot),

--- a/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/mixin.py
+++ b/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/mixin.py
@@ -278,6 +278,12 @@ class DistBucketedWeightUpdateMixin:
             end_weight_update(self.rollout_engines)
             ray.get([engine.continue_generation.remote() for engine in self.rollout_engines])
 
+    def pop_metrics(self) -> dict[str, float]:
+        """Return and clear ``update_weight_metrics``. Drained by the actor onto the step log;
+        empty unless the updater recorded metrics during the last ``update_weights`` call."""
+        out = self.__dict__.pop("update_weight_metrics", {})
+        return out
+
     @torch.no_grad()
     def update_weights(self) -> None:
         """Orchestrate the full weight-update lifecycle.

--- a/miles/backends/megatron_utils/update_weight/update_weight_from_tensor.py
+++ b/miles/backends/megatron_utils/update_weight/update_weight_from_tensor.py
@@ -172,6 +172,12 @@ class UpdateWeightFromTensor:
             if start <= dist.get_rank() < end:
                 self._ipc_engine = engine
 
+    def pop_metrics(self) -> dict[str, float]:
+        """Return and clear ``update_weight_metrics``. Empty under colocate today; kept symmetric
+        with the distributed updaters so the actor can drain unconditionally."""
+        out = self.__dict__.pop("update_weight_metrics", {})
+        return out
+
     @torch.no_grad()
     def update_weights(self) -> None:
         """

--- a/miles/backends/sglang_utils/sglang_engine.py
+++ b/miles/backends/sglang_utils/sglang_engine.py
@@ -495,15 +495,34 @@ class SGLangEngine(RayActor):
             payload["skip_tensor_list"] = skip_list
         return self._make_request("weights_checker", payload)
 
-    def update_weights_from_disk(self, model_path: str, load_format: str | None = None):
+    def pull_weights(self, target_version: int):
+        """Have the engine sync every host it spans to target_version: each host pulls the
+        published weights (a full checkpoint copied as-is, or deltas verified per-tensor and
+        applied onto the local checkpoint) into its local checkpoint dir. The engine reloads
+        it afterwards via update_weights_from_disk."""
+        return self._make_request(
+            "pull_weights",
+            {
+                "local_checkpoint_dir": self.args.update_weight_local_checkpoint_dir,
+                "source_dir": self.args.update_weight_disk_dir,
+                "target_version": target_version,
+            },
+        )
+
+    def update_weights_from_disk(
+        self, model_path: str, load_format: str | None = None, weight_version: str | None = None
+    ):
         """Reload weights from *model_path* without restarting the engine.
 
-        Used for non-updatable (frozen) models that overlap with megatron:
-        after offload, weights are restored from disk instead of CPU cache.
+        Used for non-updatable (frozen) models that overlap with megatron (after offload,
+        weights are restored from disk instead of CPU cache), and by disk-delta weight sync
+        to reload the patched host-local checkpoint.
         """
         payload = {"model_path": model_path}
         if load_format is not None:
             payload["load_format"] = load_format
+        if weight_version is not None:
+            payload["weight_version"] = weight_version
         return self._make_request("update_weights_from_disk", payload)
 
     def init_weights_update_group(self, master_address, master_port, rank_offset, world_size, group_name, backend):

--- a/miles/backends/training_utils/log_utils.py
+++ b/miles/backends/training_utils/log_utils.py
@@ -337,7 +337,7 @@ def log_passrate(rollout_id: int, args: Namespace, rollout_data: RolloutBatch) -
         gather_log_data("passrate", args, rollout_id, log_dict)
 
 
-def log_perf_data(rollout_id: int, args: Namespace) -> None:
+def log_perf_data(rollout_id: int, args: Namespace, extra_metrics: dict | None = None) -> None:
     parallel_state = get_parallel_state()
     train_metric_utils.log_perf_data_raw(
         rollout_id=rollout_id,
@@ -348,6 +348,7 @@ def log_perf_data(rollout_id: int, args: Namespace) -> None:
         compute_total_fwd_flops=lambda seq_lens: calculate_fwd_flops(seqlens=seq_lens, args=args)
         / dist.get_world_size()
         / 1e12,
+        extra_metrics=extra_metrics,
     )
 
 

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -570,9 +570,70 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
             )
             parser.add_argument(
                 "--update-weight-transfer-mode",
-                choices=["broadcast", "p2p"],
+                choices=["broadcast", "p2p", "disk-delta"],
                 default="broadcast",
-                help="The method to transfer weights to remote rollout engines during update weight.",
+                help=(
+                    "The method to transfer weights to remote rollout engines during update weight. "
+                    "'disk-delta' diffs each sync against a CPU snapshot of the previous one and publishes "
+                    "only the changed bytes to --update-weight-disk-dir; each engine's /pull_weights applies "
+                    "them into a host-local checkpoint that the engine reloads from."
+                ),
+            )
+            parser.add_argument(
+                "--update-weight-disk-dir",
+                type=str,
+                default=None,
+                help=(
+                    "Filesystem directory disk-delta weight sync publishes to: one delta directory "
+                    "(changed tensors only) per sync, written by the trainer and read by every "
+                    "rollout host. Required for --update-weight-transfer-mode=disk-delta."
+                ),
+            )
+            parser.add_argument(
+                "--update-weight-local-checkpoint-dir",
+                type=str,
+                default=None,
+                help=(
+                    "Rollout-host-local directory (e.g. NVMe) holding a full HF checkpoint kept in "
+                    "sync by each engine's /pull_weights: every host seeds it from the engine's model "
+                    "path and patches published deltas in place, and the engines reload from it. "
+                    "Required for --update-weight-transfer-mode=disk-delta. The read-side counterpart "
+                    "of --custom-update-weight-post-write-path is the engine's "
+                    "--sglang-custom-pull-weights-pre-read-hook."
+                ),
+            )
+            parser.add_argument(
+                "--update-weight-delta-encoding",
+                choices=["xor", "overwrite"],
+                default="xor",
+                help=(
+                    "On-disk delta encoding for disk-delta weight sync. 'xor' (default): new ^ old — "
+                    "smallest wire and fastest, but an involution that must be applied exactly once "
+                    "against the correct base (applying it twice reverts). 'overwrite': changed positions "
+                    "+ new absolute values — larger, but idempotent. Both are byte-level and dtype-blind; "
+                    "the engine reads the choice from each version's index metadata."
+                ),
+            )
+            parser.add_argument(
+                "--update-weight-delta-checksum",
+                choices=["xxh3-128", "blake3", "adler32"],
+                default="xxh3-128",
+                help=(
+                    "Per-tensor integrity checksum for disk-delta apply. 'xxh3-128' (default): widest fast "
+                    "non-cryptographic digest. 'blake3': cryptographic, for untrusted storage. 'adler32': "
+                    "for interop. The engine reads the choice from each version's index metadata."
+                ),
+            )
+            parser.add_argument(
+                "--custom-update-weight-post-write-path",
+                type=str,
+                default=None,
+                help=(
+                    "Path to a custom function called on each trainer rank after a disk-delta sync's "
+                    "files are written, before the engines read them — to publish the writes on a "
+                    "non-POSIX filesystem (no cross-host visibility without an explicit sync). "
+                    "Signature: ``def hook(args, version_dir: str, rollout_engines) -> None``; the hook gates itself."
+                ),
             )
             parser.add_argument(
                 "--p2p-transfer-num-workers",
@@ -2307,6 +2368,29 @@ def miles_validate_args(args):
             getattr(args, "prefill_num_servers", None) is None
         ), "P2P weight transfer mode has not been tested when PD is enabled."
         assert args.lora_rank <= 0, "LoRA weight sync is not supported for p2p (RDMA) weight transfer."
+
+    if args.update_weight_transfer_mode == "disk-delta":
+        assert not args.colocate, (
+            "Disk-delta weight transfer mode is not compatible with --colocate. Colocate transfers "
+            "weights via CUDA IPC (only a handle crosses processes), so the delta bookkeeping "
+            "(snapshot + diff + encode) is pure overhead."
+        )
+        assert (
+            getattr(args, "prefill_num_servers", None) is None
+        ), "Disk-delta weight transfer mode has not been tested when PD is enabled."
+        assert args.lora_rank <= 0, "LoRA weight sync is not supported for disk-delta weight transfer."
+        assert args.update_weight_disk_dir, (
+            "--update-weight-transfer-mode=disk-delta requires --update-weight-disk-dir to point at "
+            "a filesystem shared between the trainer and the rollout engines."
+        )
+        assert args.update_weight_local_checkpoint_dir, (
+            "--update-weight-transfer-mode=disk-delta requires --update-weight-local-checkpoint-dir "
+            "(a rollout-host-local directory, e.g. NVMe)."
+        )
+        assert os.path.isdir(args.hf_checkpoint), (
+            "--update-weight-transfer-mode=disk-delta requires --hf-checkpoint to be a local directory: "
+            "the baseline snapshot is seeded from its safetensors bytes."
+        )
 
     if args.colocate:
         if args.offload_train is None:

--- a/miles/utils/disk_delta.py
+++ b/miles/utils/disk_delta.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import glob
+import json
+import os
+import struct
+import zlib
+
+import numpy as np
+
+# The delta phases (diff, zstd, checksum) are memory-bandwidth bound and release the GIL,
+# so a thread pool over tensors recovers the bandwidth one thread leaves idle.
+NUM_WORKERS = min(32, (os.cpu_count() or 8))
+
+# Trainer-side (publish) helpers for disk-level delta weight sync. The receive side —
+# materializing the host-local checkpoint and applying published deltas in place — lives in
+# the engine behind its /pull_weights endpoint (sglang.srt.weight_sync.local_checkpoint), so it
+# runs on every host of a multi-node engine while miles only talks to one endpoint.
+
+
+def overwrite_encode(new: np.ndarray, changed_mask: np.ndarray) -> np.ndarray:
+    """The 'overwrite' delta: changed-position count (u4), positions (u4 each), then new values.
+    Idempotent to apply, unlike xor (an involution); the trainer picks the encoding per the docs."""
+    pos = np.flatnonzero(changed_mask).astype("<u4")
+    return np.concatenate([np.array([pos.size], "<u4").view(np.uint8), pos.view(np.uint8), new[changed_mask]])
+
+
+class _Adler32:
+    """adler32 behind the incremental .update / .hexdigest interface the hash objects expose."""
+
+    def __init__(self):
+        self._value = 1
+
+    def update(self, data) -> None:
+        self._value = zlib.adler32(data, self._value)
+
+    def hexdigest(self) -> str:
+        return f"{self._value:08x}"
+
+
+def _new_hasher(algorithm: str):
+    if algorithm == "xxh3-128":
+        import xxhash
+
+        return xxhash.xxh3_128()
+    if algorithm == "blake3":
+        import blake3
+
+        return blake3.blake3()
+    if algorithm == "adler32":
+        return _Adler32()
+    raise KeyError(f"unknown checksum algorithm {algorithm!r}")
+
+
+def checksum(algorithm: str, buf) -> str:
+    hasher = _new_hasher(algorithm)
+    hasher.update(buf)
+    return hasher.hexdigest()
+
+
+def _tensor_locations(ckpt_dir: str) -> dict[str, tuple[str, int, int]]:
+    """Map each tensor name to (file, byte offset, nbytes) by reading every safetensors header."""
+    locations: dict[str, tuple[str, int, int]] = {}
+    for path in glob.glob(os.path.join(ckpt_dir, "*.safetensors")):
+        with open(path, "rb") as f:
+            (header_len,) = struct.unpack("<Q", f.read(8))
+            header = json.loads(f.read(header_len))
+        for name, info in header.items():
+            if name == "__metadata__":
+                continue
+            begin, end = info["data_offsets"]
+            locations[name] = (path, 8 + header_len + begin, end - begin)
+    return locations
+
+
+def make_tensor_reader(ckpt_dir: str):
+    """Index the headers once, then return ``read(name) -> uint8 bytes`` that seeks straight to the
+    tensor — for reading many tensors without rescanning every header. KeyError if absent."""
+    locations = _tensor_locations(ckpt_dir)
+
+    def read(name: str) -> np.ndarray:
+        path, offset, nbytes = locations[name]
+        with open(path, "rb") as f:
+            f.seek(offset)
+            return np.frombuffer(f.read(nbytes), dtype=np.uint8)
+
+    return read

--- a/miles/utils/train_metric_utils.py
+++ b/miles/utils/train_metric_utils.py
@@ -11,7 +11,11 @@ logger = logging.getLogger(__name__)
 
 
 def log_perf_data_raw(
-    rollout_id: int, args: Namespace, is_primary_rank: bool, compute_total_fwd_flops: Callable
+    rollout_id: int,
+    args: Namespace,
+    is_primary_rank: bool,
+    compute_total_fwd_flops: Callable,
+    extra_metrics: dict | None = None,
 ) -> None:
     timer_instance = Timer()
     log_dict_raw = deepcopy(timer_instance.log_dict())
@@ -21,6 +25,8 @@ def log_perf_data_raw(
         return
 
     log_dict = {f"perf/{key}_time": val for key, val in log_dict_raw.items()}
+    if extra_metrics:
+        log_dict.update(extra_metrics)
 
     if ("perf/actor_train_time" in log_dict) and (compute_total_fwd_flops is not None):
         total_fwd_flops = compute_total_fwd_flops(seq_lens=timer_instance.seq_lens)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 accelerate
 backports.strenum; python_version < "3.11"
+blake3  # disk-delta weight sync (checksum)
 blobfile
 datasets
 httpx[http2]
@@ -22,3 +23,5 @@ torchft-nightly==2026.4.3; platform_system == "Linux" and platform_machine == "x
 tqdm
 transformers<5.13  # 5.13.0 registers qwen3_asr natively, colliding with sglang's AutoConfig.register (exist_ok=False); lift once sglang registers with exist_ok=True
 wandb
+xxhash  # disk-delta weight sync (checksum)
+zstandard  # disk-delta weight sync (codec)

--- a/tests/e2e/megatron/test_qwen3_4B_disk_delta.py
+++ b/tests/e2e/megatron/test_qwen3_4B_disk_delta.py
@@ -1,0 +1,118 @@
+from tests.ci.ci_register import register_cuda_ci
+
+import miles.utils.external_utils.command_utils as U
+
+MODEL_NAME = "Qwen3-4B"
+MODEL_TYPE = "qwen3-4B"
+NUM_GPUS = 8
+
+register_cuda_ci(
+    est_time=600,
+    suite="stage-c-8-gpu-h100",
+    labels=["megatron", "weight-update"],
+    disabled="Requires sglang /pull_weights (sgl-project/sglang#30366) in the CI image.",
+)
+
+
+def prepare():
+    U.exec_command("mkdir -p /root/models /root/datasets")
+    U.exec_command("hf download Qwen/Qwen3-4B --local-dir /root/models/Qwen3-4B")
+    U.hf_download_dataset("zhuzilin/dapo-math-17k")
+    U.convert_checkpoint(model_name=MODEL_NAME, megatron_model_type=MODEL_TYPE, num_gpus_per_node=NUM_GPUS)
+
+
+def execute():
+    ckpt_args = f"--hf-checkpoint /root/models/{MODEL_NAME}/ " f"--ref-load /root/{MODEL_NAME}_torch_dist "
+
+    rollout_args = (
+        "--prompt-data /root/datasets/dapo-math-17k/dapo-math-17k.jsonl "
+        "--input-key prompt "
+        "--label-key label "
+        "--apply-chat-template "
+        "--rollout-shuffle "
+        "--rm-type deepscaler "
+        "--num-rollout 2 "
+        "--rollout-batch-size 4 "
+        "--n-samples-per-prompt 2 "
+        "--rollout-max-response-len 100 "
+        "--rollout-temperature 0.8 "
+        "--global-batch-size 8 "
+        "--balance-data "
+    )
+
+    perf_args = (
+        "--tensor-model-parallel-size 2 "
+        "--sequence-parallel "
+        "--pipeline-model-parallel-size 1 "
+        "--context-parallel-size 2 "
+        "--recompute-granularity full "
+        "--recompute-method uniform "
+        "--recompute-num-layers 1 "
+        "--use-dynamic-batch-size "
+        "--max-tokens-per-gpu 2048 "
+    )
+
+    grpo_args = (
+        "--advantage-estimator grpo "
+        "--kl-loss-coef 0.00 "
+        "--kl-loss-type low_var_kl "
+        "--entropy-coef 0.00 "
+        "--eps-clip 0.2 "
+        "--eps-clip-high 0.28 "
+    )
+
+    optimizer_args = (
+        "--optimizer adam "
+        "--lr 1e-6 "
+        "--lr-decay-style constant "
+        "--weight-decay 0.1 "
+        "--adam-beta1 0.9 "
+        "--adam-beta2 0.98 "
+    )
+
+    sglang_args = (
+        "--rollout-num-gpus-per-engine 2 " f"--rollout-num-gpus {NUM_GPUS // 2} " "--sglang-mem-fraction-static 0.8 "
+    )
+
+    ci_args = "--ci-test "
+
+    # Single node, so the "shared" publish dir and the host-local checkpoint are
+    # both plain local paths; the delta pipeline is exercised end to end
+    # (baseline pull + reload, per-sync publish -> /pull_weights apply -> reload).
+    misc_args = (
+        "--attention-dropout 0.0 "
+        "--hidden-dropout 0.0 "
+        "--accumulate-allreduce-grads-in-fp32 "
+        "--attention-softmax-in-fp32 "
+        "--attention-backend flash "
+        "--actor-num-nodes 1 "
+        f"--actor-num-gpus-per-node {NUM_GPUS // 2} "
+        f"--update-weight-buffer-size {1 * 1024 ** 3} "
+        "--update-weight-transfer-mode disk-delta "
+        "--update-weight-disk-dir /root/delta-updates "
+        "--update-weight-local-checkpoint-dir /root/delta-local-ckpt "
+    )
+
+    train_args = (
+        f"{ckpt_args} "
+        f"{rollout_args} "
+        f"{optimizer_args} "
+        f"{grpo_args} "
+        f"{U.get_default_wandb_args(__file__)} "
+        f"{perf_args} "
+        f"{sglang_args} "
+        f"{ci_args} "
+        f"{misc_args} "
+    )
+
+    U.execute_train(
+        train_args=train_args,
+        num_gpus_per_node=NUM_GPUS,
+        megatron_model_type=MODEL_TYPE,
+        train_script="train_async.py",
+    )
+
+
+if __name__ == "__main__":
+    prepare()
+    execute()

--- a/tests/e2e/megatron/test_qwen3_4B_disk_delta.py
+++ b/tests/e2e/megatron/test_qwen3_4B_disk_delta.py
@@ -10,7 +10,6 @@ register_cuda_ci(
     est_time=600,
     suite="stage-c-8-gpu-h100",
     labels=["megatron", "weight-update"],
-    disabled="Requires sglang /pull_weights (sgl-project/sglang#30366) in the CI image.",
 )
 
 


### PR DESCRIPTION
ci-sglang-pr: #30366

Adds `--update-weight-transfer-mode disk-delta`: weight sync for non-colocated rollout engines that ships only the bytes changed between syncs — for cross-cluster/datacenter disaggregation where moving the full model every sync dominates.

Engine-side `/pull_weights`: sgl-project/sglang#30366 (`sglang-miles`), sgl-project/sglang#30367 (`main`). Refs: THUDM/slime#1806, THUDM/slime#2089, THUDM/slime#2181.

## Design

- First `update_weights()` publishes nothing: it seeds a CPU snapshot from `--hf-checkpoint`'s safetensors bytes (= the engines' actual base, robust to non-byte-exact megatron→HF round-trips) and issues `pull_weights(0)` so each host warms its local checkpoint.
- Each sync: source ranks diff gathered HF tensors against the snapshot (pinned-buffer GPU→CPU copies pipelined into a diff+zstd thread pool) and publish `weight_v{N:06d}/` under `--update-weight-disk-dir` as a canonical HF checkpoint dir — compressed-diff shards + an index carrying version/encoding/checksum metadata, coordinated over gloo rather than the filesystem.
- Engines `pull_weights(N)` before pausing (disk-only, overlaps rollout): per-host flock, in-place apply, per-tensor checksum verify, fail-loud. Then pause → flush → vanilla `update_weights_from_disk(local_dir, weight_version=N)` → continue.
- PP-replicated params (word embedding on an MTP-hosting or tied-embedding last stage) are deduped at publish time — name→checksum maps gathered, divergent duplicates raise, lowest rank keeps — since the XOR apply is an involution (applied twice = reverted).
- Built on `DistBucketedWeightUpdateMixin`'s callback gather; no NCCL groups or engine lock; density/wire metrics drain via `pop_metrics()` into the step log.

## Args

```
--update-weight-transfer-mode disk-delta
--update-weight-disk-dir ...              # shared FS: trainer publishes, hosts read
--update-weight-local-checkpoint-dir ...  # host-local full checkpoint, patched in place
--update-weight-delta-encoding xor        # or: overwrite (idempotent, larger)
--update-weight-delta-checksum xxh3-128   # or: blake3, adler32
--custom-update-weight-post-write-path    # non-POSIX FS publish hook
```

Read-side counterpart: `--sglang-custom-pull-weights-pre-read-hook`. New deps: `xxhash`, `zstandard`, `blake3`.

## Validation

GLM-4.7-Flash GRPO on 4× H200: 2-node actor (TP2/PP2/CP2/EP8, MTP on → exercises the dedup) + one tp16/dp16 engine spanning 2 rollout nodes (exercises the multi-host pull fan-out). Disk-delta publishes to an object-store-backed shared volume via the post-write/pre-read hooks (`xor` + `xxh3-128`); the baseline is the same config with the default `--update-weight-transfer-mode broadcast` (full-checkpoint NCCL each sync).

One sync per training step: `vN` is the model after optimizer step N, published and applied before rollout N+1. "baseline" is the startup `update_weights()` before the first rollout: disk-delta ships nothing (the trainer captures its diff-base snapshot while each host copies the engine's base checkpoint to local disk); broadcast pushes the full weights.

### disk-delta vs full-checkpoint NCCL broadcast

| | broadcast (default) | disk-delta |
|---|---|---|
| payload per sync | 62.4 GB (full bf16) | 0.69–0.83 GB (−98.8%) |
| `update_weights` time | 5.9 s first, 3.5 s steady | 54.8 s first, 23.2 s steady |
| generation-paused window | the whole sync (3.5–5.9 s; engines pause before the broadcast) | **3–5 s — just the `update_weights_from_disk` reload**; every other phase runs while the engine serves |
| effective transfer rate | 10.7–17.7 GB/s through gather→convert→NCCL (RDMA) | ≥2.1 GB/s per host volume read (62.4 GB base seed in ≤30 s, hosts in parallel); per-sync wire is ~1% of full |
| connectivity required | NCCL reachability trainer↔every engine GPU | a shared filesystem / object store only |

Broadcast wins on raw sync latency inside one datacenter; disk-delta moves ~80× fewer bytes with a comparable generation-paused window and runs where NCCL can't (cross-cluster/datacenter, object-store-only links).

### disk-delta per-sync detail

| Sync | Density | Wire | `update_weights` time |
|---|---|---|---|
| baseline (pre-rollout 1) | — | — | 48.7 s (snapshot; 62.4 GB host seed overlapped) |
| v1 (after step 1) | 0.37% | 0.69 GB | 54.8 s |
| v2 (after step 2) | 0.44% | 0.79 GB | 23.2 s |
| v3 (after step 3) | 0.44% | 0.78 GB | — (run ends after final sync) |

Steady-state breakdown of the 23.2 s (from engine request timestamps):

| Phase | Time | Engine |
|---|---|---|
| trainer: diff 62.4 GB vs snapshot + zstd + publish shards to shared volume | ~19 s (combined with next row) | **up, generating** |
| engine hosts: pull, decompress, checksum-verify, apply into local checkpoint | ″ (completes before pause) | **up, generating** |
| pause + KV flush | ~1 s | paused |
| `update_weights_from_disk`: local disk → GPU | **3–5 s** | paused |
| resume | <1 s | — |

The only phase that needs the engine stopped is the final `update_weights_from_disk` reload — in a fully async rollout loop the engine keeps serving through diff/publish/pull, so the effective generation pause per sync is just the 3–5 s reload. All pulls checksum-verified on both engine hosts; the index holds each tensor exactly once.

## Caveats

- The baseline call publishes nothing, so a run resumed mid-training serves base weights for its first rollout (engines assumed to start from the trainer's HF checkpoint).
- CI: compatible with `--check-weight-update-equal` (when the checker is armed, the baseline also reloads the pulled v0 checkpoint — the checker resets engine tensors and expects the first sync to rewrite everything). `tests/e2e/megatron/test_qwen3_4B_disk_delta.py` is registered under `run-ci-weight-update`, disabled until the CI image ships sglang `/pull_weights` (sgl-project/sglang#30366).
- LoRA and PD-disaggregation unsupported (validated).




