### PR TITLE
Add 2-node TB2 training example targeting the harbor-private agent server

### DIFF
--- a/examples/experimental/swe-agent-v2/train-tb2-via-harbor-private-server/README.md
+++ b/examples/experimental/swe-agent-v2/train-tb2-via-harbor-private-server/README.md
@@ -82,7 +82,8 @@ Pass any short tag (`pr-smoke`, `260527-2n-v1`, ...) — it threads through
 `--save-dir`, `--save-traces-dir`, and `--wandb-run-name` so multiple
 attempts don't collide.
 
-The full launcher invocation (from `launch.sh`):
+The full launcher invocation (from `launch.sh`, with optional env
+overrides expanded):
 
 ```bash
 python examples/experimental/swe-agent-v2/run-glm47-flash-agentic-async.py \
@@ -92,16 +93,21 @@ python examples/experimental/swe-agent-v2/run-glm47-flash-agentic-async.py \
     --save-traces-dir /workspace/flash-2node-traces-<run-tag>/traces \
     --rollout-batch-size 4 --n-samples-per-prompt 8 --global-batch-size 32 \
     --save-interval 5 \
-    --agent-server-url http://ts-egress-aws-agent-server:8080 \
-    --router-external-host <rcli-job-name>-ts-ingress.tail134ba0.ts.net \
+    --agent-server-url "$AGENT_SERVER_URL" \
     --wandb-project glm47-flash-agentic-async \
-    --wandb-team ch271828n-team \
     --wandb-run-name <run-tag>
+    # optional, only added when the corresponding env var is set:
+    # --router-external-host "$ROUTER_EXTERNAL_HOST"
+    # --wandb-team           "$WANDB_TEAM"
 ```
 
-The cluster's existing `ts-egress-aws-agent-server` ExternalName service
-(in the rcli job's namespace) Tailscale-routes any port through to the
-external agent server's host, so `--agent-server-url` works as written.
+`AGENT_SERVER_URL` defaults to `http://agent-server:8080`; set it to wherever
+your `miles_agent_server` is reachable from the trainer pod.
+
+If the agent server cannot reach the trainer at its default service
+name (e.g. you're running the agent server on a different host/network),
+set `ROUTER_EXTERNAL_HOST` to a hostname the agent server can dial back
+to the trainer's session-server through. Otherwise leave it unset.
 
 ## Sanity checks (in order)
 

--- a/examples/experimental/swe-agent-v2/train-tb2-via-harbor-private-server/README.md
+++ b/examples/experimental/swe-agent-v2/train-tb2-via-harbor-private-server/README.md
@@ -54,22 +54,7 @@ the file on the cluster's shared volume so it survives pod recreate:
 /cluster_personal/job_workspaces/<your-job>/tb2_train.jsonl
 ```
 
-### 3. Model checkpoint at `/models/zai-org/GLM-4.7-Flash`
-
-The launcher's `--hf-checkpoint` default is `/models/zai-org/GLM-4.7-Flash`. On
-some fresh `radixark/miles:dev` pods the actual local copy lives one level
-shallower at `/models/GLM-4.7-Flash` (no `zai-org/` subdir); if so, symlink it
-before launching:
-
-```bash
-mkdir -p /models/zai-org
-ln -sf /models/GLM-4.7-Flash /models/zai-org/GLM-4.7-Flash
-```
-
-If neither path exists, the model lives on shared GPFS at
-`/cluster_public/miles_data/models/GLM-4.7-Flash` — symlink from there.
-
-### 4. The training branch with the threadpool fix
+### 3. The training branch with the threadpool fix
 
 The 5-node baseline branch has a session-server tokenization fix
 (off-loading to a threadpool) without which sglang trips a 500-storm under
@@ -82,31 +67,6 @@ git checkout shi/260421-glm47-flash-2node            # head 83bcfa6 (or newer
 grep -n run_in_threadpool miles/rollout/session/sessions.py | head -3
 # expect lines 7 (import), 173, 245 (call sites)
 ```
-
-On a fresh pod `origin` may be set to a Mac local path
-(`file:///Volumes/x10/miles`); reset to GitHub HTTPS with the PAT from the
-pod's `$GITHUB_URL` first:
-
-```bash
-set -l pat (echo $GITHUB_URL | sed -E "s|https://([^@]+)@.*|\1|")
-git remote set-url origin "https://$pat@github.com/radixark/miles.git"
-```
-
-### 5. Compatible `transformers` version
-
-The launcher calls `transformers.AutoConfig.from_pretrained` on the
-`--hf-checkpoint` path. `transformers>=5.0` rejects absolute local paths
-that look like a Hub repo id (`HFValidationError: Repo id must be in the
-form 'repo_name' or 'namespace/repo_name'`). If you see that, downgrade:
-
-```bash
-pip install "transformers<5"
-```
-
-Note that this image's `sglang` / `megatron-bridge` may pin
-`transformers==5.6.0`; if your image hits a self-conflicting dep graph,
-either re-pin the image or patch `train_async.py` to bypass
-`AutoConfig.from_pretrained` for absolute local paths.
 
 ## Launch
 

--- a/examples/experimental/swe-agent-v2/train-tb2-via-harbor-private-server/README.md
+++ b/examples/experimental/swe-agent-v2/train-tb2-via-harbor-private-server/README.md
@@ -54,7 +54,22 @@ the file on the cluster's shared volume so it survives pod recreate:
 /cluster_personal/job_workspaces/<your-job>/tb2_train.jsonl
 ```
 
-### 3. The training branch with the threadpool fix
+### 3. Model checkpoint at `/models/zai-org/GLM-4.7-Flash`
+
+The launcher's `--hf-checkpoint` default is `/models/zai-org/GLM-4.7-Flash`. On
+some fresh `radixark/miles:dev` pods the actual local copy lives one level
+shallower at `/models/GLM-4.7-Flash` (no `zai-org/` subdir); if so, symlink it
+before launching:
+
+```bash
+mkdir -p /models/zai-org
+ln -sf /models/GLM-4.7-Flash /models/zai-org/GLM-4.7-Flash
+```
+
+If neither path exists, the model lives on shared GPFS at
+`/cluster_public/miles_data/models/GLM-4.7-Flash` — symlink from there.
+
+### 4. The training branch with the threadpool fix
 
 The 5-node baseline branch has a session-server tokenization fix
 (off-loading to a threadpool) without which sglang trips a 500-storm under
@@ -67,6 +82,31 @@ git checkout shi/260421-glm47-flash-2node            # head 83bcfa6 (or newer
 grep -n run_in_threadpool miles/rollout/session/sessions.py | head -3
 # expect lines 7 (import), 173, 245 (call sites)
 ```
+
+On a fresh pod `origin` may be set to a Mac local path
+(`file:///Volumes/x10/miles`); reset to GitHub HTTPS with the PAT from the
+pod's `$GITHUB_URL` first:
+
+```bash
+set -l pat (echo $GITHUB_URL | sed -E "s|https://([^@]+)@.*|\1|")
+git remote set-url origin "https://$pat@github.com/radixark/miles.git"
+```
+
+### 5. Compatible `transformers` version
+
+The launcher calls `transformers.AutoConfig.from_pretrained` on the
+`--hf-checkpoint` path. `transformers>=5.0` rejects absolute local paths
+that look like a Hub repo id (`HFValidationError: Repo id must be in the
+form 'repo_name' or 'namespace/repo_name'`). If you see that, downgrade:
+
+```bash
+pip install "transformers<5"
+```
+
+Note that this image's `sglang` / `megatron-bridge` may pin
+`transformers==5.6.0`; if your image hits a self-conflicting dep graph,
+either re-pin the image or patch `train_async.py` to bypass
+`AutoConfig.from_pretrained` for absolute local paths.
 
 ## Launch
 

--- a/examples/experimental/swe-agent-v2/train-tb2-via-harbor-private-server/README.md
+++ b/examples/experimental/swe-agent-v2/train-tb2-via-harbor-private-server/README.md
@@ -54,18 +54,15 @@ the file on the cluster's shared volume so it survives pod recreate:
 /cluster_personal/job_workspaces/<your-job>/tb2_train.jsonl
 ```
 
-### 3. The training branch with the threadpool fix
+### 3. A current miles checkout
 
-The 5-node baseline branch has a session-server tokenization fix
-(off-loading to a threadpool) without which sglang trips a 500-storm under
-load:
+Run from a current `miles` checkout — `origin/main` is fine. Older topic
+branches may carry stale launcher flags or out-of-date torch / sglang
+glue code; this example was validated against main.
 
 ```bash
 cd /workspace/miles
-git checkout shi/260421-glm47-flash-2node            # head 83bcfa6 (or newer
-                                                     # with the same fix)
-grep -n run_in_threadpool miles/rollout/session/sessions.py | head -3
-# expect lines 7 (import), 173, 245 (call sites)
+git checkout origin/main
 ```
 
 ## Launch
@@ -95,7 +92,6 @@ python examples/experimental/swe-agent-v2/run-glm47-flash-agentic-async.py \
     --save-traces-dir /workspace/flash-2node-traces-<run-tag>/traces \
     --rollout-batch-size 4 --n-samples-per-prompt 8 --global-batch-size 32 \
     --save-interval 5 \
-    --sglang-mem-fraction-static 0.72 \
     --agent-server-url http://ts-egress-aws-agent-server:8080 \
     --router-external-host <rcli-job-name>-ts-ingress.tail134ba0.ts.net \
     --wandb-project glm47-flash-agentic-async \

--- a/examples/experimental/swe-agent-v2/train-tb2-via-harbor-private-server/README.md
+++ b/examples/experimental/swe-agent-v2/train-tb2-via-harbor-private-server/README.md
@@ -89,8 +89,8 @@ overrides expanded):
 python examples/experimental/swe-agent-v2/run-glm47-flash-agentic-async.py \
     --num-nodes 2 --train-num-nodes 1 --skip-prepare \
     --max-seq-len 65536 \
-    --save-dir /workspace/GLM-4.7-Flash_2node_tb2_<run-tag>/ \
-    --save-traces-dir /workspace/flash-2node-traces-<run-tag>/traces \
+    --save-dir "${OUTPUT_ROOT}/GLM-4.7-Flash_2node_tb2_<run-tag>/" \
+    --save-traces-dir "${OUTPUT_ROOT}/flash-2node-traces-<run-tag>/traces" \
     --rollout-batch-size 4 --n-samples-per-prompt 8 --global-batch-size 32 \
     --save-interval 5 \
     --agent-server-url "$AGENT_SERVER_URL" \
@@ -103,6 +103,8 @@ python examples/experimental/swe-agent-v2/run-glm47-flash-agentic-async.py \
 
 `AGENT_SERVER_URL` defaults to `http://agent-server:8080`; set it to wherever
 your `miles_agent_server` is reachable from the trainer pod.
+`OUTPUT_ROOT` defaults to `/workspace` (writable storage on the trainer
+pod that the rollout / save / traces dirs are created under).
 
 If the agent server cannot reach the trainer at its default service
 name (e.g. you're running the agent server on a different host/network),

--- a/examples/experimental/swe-agent-v2/train-tb2-via-harbor-private-server/README.md
+++ b/examples/experimental/swe-agent-v2/train-tb2-via-harbor-private-server/README.md
@@ -1,0 +1,145 @@
+# Train GLM-4.7-Flash on TB2 against a `harbor-private` agent server (2-node example)
+
+End-to-end recipe for a small (2-node) GLM-4.7-Flash agentic-async training
+run that uses the `miles_agent_server.py` shipped on the [`harbor-private`
+branch `shi/rebase-on-upstream-v0.7.0`][harbor-private-branch] as its
+rollout backend.
+
+This is the **training-side** companion to
+[`examples/eval/terminal_bench_via_agent_server/`](../../../eval/terminal_bench_via_agent_server/),
+which is the eval-side client for the same agent server. Both target the
+same `POST /run` endpoint; this one drives it from
+`run-glm47-flash-agentic-async.py` instead of a one-shot Python client.
+
+## What gets exercised
+
+```
+trainer-side (rcli pod, this node)             agent-server (external host)
++--------------------+                         +-----------------------------+
+|  Megatron actor    |  weights -> sglang ---->|                             |
+|  RolloutManager    |                         |   miles_agent_server.py     |
+|     ^              |  POST /run         ---->|     (harbor-private branch) |
+|     | GRPO updates |                         |     spawns Docker -> agent  |
++-----+--------------+                         |     -> verifier -> reward   |
+                                               +-----------------------------+
+```
+
+The training loop dispatches one `/run` per (prompt, sample) and receives a
+verifier-scored reward back. The agent-server side is what we're really
+validating: it must keep up with the trainer's batch cadence without
+crashing under sustained load.
+
+## Prerequisites
+
+### 1. A running `miles_agent_server` from harbor-private
+
+On a Tailscale-reachable host (we use `aws-agent-server` internally), check
+out the [`harbor-private` branch][harbor-private-branch] and run the agent
+server as documented in
+[its README](https://github.com/radixark/harbor-private/blob/shi/rebase-on-upstream-v0.7.0/README.md).
+The default port is 8080; the dashboard at 8081.
+
+For training-style workloads `OPENAI_API_KEY=dummy` is correct (LLM
+credentials flow per request, not from server env).
+
+### 2. The 23-task TB2 variance jsonl on shared GPFS
+
+Each line is `{"prompt": <task-instruction>, "metadata": {"instance_id":
+<task-name>}}`. The 23 task names are the TB2 instances where vanilla
+GLM-4.7-Flash passes 1-3 of 4 trials (the "improvable" middle band). Place
+the file on the cluster's shared volume so it survives pod recreate:
+
+```bash
+# inside the head pod
+/cluster_personal/job_workspaces/<your-job>/tb2_train.jsonl
+```
+
+### 3. The training branch with the threadpool fix
+
+The 5-node baseline branch has a session-server tokenization fix
+(off-loading to a threadpool) without which sglang trips a 500-storm under
+load:
+
+```bash
+cd /workspace/miles
+git checkout shi/260421-glm47-flash-2node            # head 83bcfa6 (or newer
+                                                     # with the same fix)
+grep -n run_in_threadpool miles/rollout/session/sessions.py | head -3
+# expect lines 7 (import), 173, 245 (call sites)
+```
+
+## Launch
+
+The launcher hard-codes `--prompt-data /root/swe_train.jsonl`; symlink it
+to the TB2 jsonl so the same launcher works without editing.
+
+```bash
+# inside the head pod
+ln -sf /cluster_personal/job_workspaces/<your-job>/tb2_train.jsonl /root/swe_train.jsonl
+
+cd /workspace/miles
+bash examples/experimental/swe-agent-v2/train-tb2-via-harbor-private-server/launch.sh <run-tag>
+```
+
+Pass any short tag (`pr-smoke`, `260527-2n-v1`, ...) — it threads through
+`--save-dir`, `--save-traces-dir`, and `--wandb-run-name` so multiple
+attempts don't collide.
+
+The full launcher invocation (from `launch.sh`):
+
+```bash
+python examples/experimental/swe-agent-v2/run-glm47-flash-agentic-async.py \
+    --num-nodes 2 --train-num-nodes 1 --skip-prepare \
+    --max-seq-len 65536 \
+    --save-dir /workspace/GLM-4.7-Flash_2node_tb2_<run-tag>/ \
+    --save-traces-dir /workspace/flash-2node-traces-<run-tag>/traces \
+    --rollout-batch-size 4 --n-samples-per-prompt 8 --global-batch-size 32 \
+    --save-interval 5 \
+    --sglang-mem-fraction-static 0.72 \
+    --agent-server-url http://ts-egress-aws-agent-server:8080 \
+    --router-external-host <rcli-job-name>-ts-ingress.tail134ba0.ts.net \
+    --wandb-project glm47-flash-agentic-async \
+    --wandb-team ch271828n-team \
+    --wandb-run-name <run-tag>
+```
+
+The cluster's existing `ts-egress-aws-agent-server` ExternalName service
+(in the rcli job's namespace) Tailscale-routes any port through to the
+external agent server's host, so `--agent-server-url` works as written.
+
+## Sanity checks (in order)
+
+1. `Job 'raysubmit_<id>' submitted successfully` in the launch log within
+   ~30s.
+2. `ray job status <id> --address http://localhost:8265` reports
+   `RUNNING` within ~2 min.
+3. `wandb: 🚀 View run at https://wandb.ai/.../runs/<wandb-id>` appears in
+   the log within ~3 min. **Record the `<wandb-id>`**; the S3 ckpt prefix
+   is `<YYMMDD>-<wandb-id>` once `--save-interval` kicks in.
+4. The agent-server dashboard at `:8081` starts seeing `mini-swe-agent`
+   trials with the 23 task names from the TB2 variance band. If you see
+   different task names, the dataset symlink didn't take.
+5. First `rollout 0:` and `step 0:` log lines typically appear 30-60 min
+   after launch (long because of sglang weight broadcast on cold pods);
+   subsequent iters at 10-20 min/step.
+
+If `/tmp/<launch-log>` stops growing but `ray job status` says `RUNNING`,
+the shell's `tee` pipe died (e.g. ssh session ended) but training is
+fine — use `ray job logs <id>` to read live progress instead.
+
+## Tuning knobs
+
+| Knob | Default here | Rationale |
+|---|---|---|
+| `--num-nodes 2 --train-num-nodes 1` | 1 trainer + 1 rollout | Minimum useful split; 1-node would co-locate and serialise the loop. |
+| `--rollout-batch-size 4 --n-samples-per-prompt 8` | 32 trials/iter | Same shape as the 5-node baseline so iter cadence is comparable. |
+| `--max-seq-len 65536` | 65536 | The agent server's `poll_steps` wrapper enforces this; raising it costs more truncation, lowering trips it more often. |
+| `--sglang-mem-fraction-static 0.72` | 0.72 | Empirically avoids sglang OOM after weight-transfer broadcast. |
+| `--save-interval 5` | every 5 iters | Checkpoints land under `--save-dir`; sync to S3 separately per your team's playbook. |
+
+## Related
+
+- [`examples/eval/terminal_bench_via_agent_server/`](../../../eval/terminal_bench_via_agent_server/) — same agent server, used from the **eval** side.
+- [`harbor-private` branch `shi/rebase-on-upstream-v0.7.0`][harbor-private-branch] — the agent server code this example talks to.
+
+[harbor-private-branch]: https://github.com/radixark/harbor-private/tree/shi/rebase-on-upstream-v0.7.0

--- a/examples/experimental/swe-agent-v2/train-tb2-via-harbor-private-server/launch.sh
+++ b/examples/experimental/swe-agent-v2/train-tb2-via-harbor-private-server/launch.sh
@@ -4,13 +4,26 @@
 # shi/rebase-on-upstream-v0.7.0 as the rollout backend.
 #
 # See README.md for prerequisites (running agent server, populated
-# /root/swe_train.jsonl, the threadpool-fix training branch).
+# /root/swe_train.jsonl, a current miles checkout).
 #
 # Usage:
 #   bash launch.sh <run-tag>            # e.g. bash launch.sh pr-smoke
 #
 # <run-tag> is threaded through --save-dir, --save-traces-dir, and
 # --wandb-run-name so multiple attempts don't collide.
+#
+# Optional env overrides (sensible defaults shown):
+#   AGENT_SERVER_URL=http://agent-server:8080
+#       Base URL of the running miles_agent_server.
+#   ROUTER_EXTERNAL_HOST=
+#       Hostname/FQDN that the trainer's session-server advertises back
+#       to the agent server, so the agent server can call into the
+#       trainer for tokenization. Required when the agent server cannot
+#       reach the trainer at the trainer's default service name (e.g. an
+#       off-cluster agent server with an explicit ingress/proxy hostname).
+#       Leave unset to omit --router-external-host.
+#   WANDB_TEAM=
+#       Wandb team to log to. Leave unset to omit --wandb-team.
 
 set -euo pipefail
 
@@ -20,40 +33,34 @@ if [ "$#" -lt 1 ]; then
 fi
 RUN_TAG="$1"
 
-# Resolve where the launcher script lives. We expect to be invoked from
-# the miles repo root (cwd-sensitive: run-glm47-flash-agentic-async.py
-# uses relative paths to other tooling and the prompt-data symlink).
 LAUNCHER="examples/experimental/swe-agent-v2/run-glm47-flash-agentic-async.py"
 if [ ! -f "$LAUNCHER" ]; then
     echo "error: $LAUNCHER not found. Run this script from the miles repo root." >&2
     exit 66
 fi
 
-# The rcli job name is used to construct the Tailscale-ingress FQDN that
-# the rollout router advertises back to the external agent server.
-# Default matches what we use; override via $RCLI_JOB_NAME.
-RCLI_JOB_NAME="${RCLI_JOB_NAME:-shidong-flash-pr-train}"
-
-# Dataset symlink check (the launcher hard-codes /root/swe_train.jsonl).
 if [ ! -e /root/swe_train.jsonl ]; then
     echo "error: /root/swe_train.jsonl missing. See README.md step 'Launch'." >&2
     exit 65
 fi
 
-# Make sure the rcli job's namespace can route to the external agent server
-# via the in-cluster ts-egress-aws-agent-server ExternalName.
-AGENT_SERVER_URL="${AGENT_SERVER_URL:-http://ts-egress-aws-agent-server:8080}"
+AGENT_SERVER_URL="${AGENT_SERVER_URL:-http://agent-server:8080}"
+ROUTER_EXTERNAL_HOST="${ROUTER_EXTERNAL_HOST:-}"
+WANDB_TEAM="${WANDB_TEAM:-}"
 
-python "$LAUNCHER" \
-    --num-nodes 2 --train-num-nodes 1 --skip-prepare \
-    --max-seq-len 65536 \
-    --save-dir "/workspace/GLM-4.7-Flash_2node_tb2_${RUN_TAG}/" \
-    --save-traces-dir "/workspace/flash-2node-traces-${RUN_TAG}/traces" \
-    --rollout-batch-size 4 --n-samples-per-prompt 8 --global-batch-size 32 \
-    --save-interval 5 \
-    --agent-server-url "$AGENT_SERVER_URL" \
-    --router-external-host "${RCLI_JOB_NAME}-ts-ingress.tail134ba0.ts.net" \
-    --wandb-project glm47-flash-agentic-async \
-    --wandb-team ch271828n-team \
-    --wandb-run-name "$RUN_TAG" \
+ARGS=(
+    --num-nodes 2 --train-num-nodes 1 --skip-prepare
+    --max-seq-len 65536
+    --save-dir "/workspace/GLM-4.7-Flash_2node_tb2_${RUN_TAG}/"
+    --save-traces-dir "/workspace/flash-2node-traces-${RUN_TAG}/traces"
+    --rollout-batch-size 4 --n-samples-per-prompt 8 --global-batch-size 32
+    --save-interval 5
+    --agent-server-url "$AGENT_SERVER_URL"
+    --wandb-project glm47-flash-agentic-async
+    --wandb-run-name "$RUN_TAG"
+)
+[ -n "$ROUTER_EXTERNAL_HOST" ] && ARGS+=(--router-external-host "$ROUTER_EXTERNAL_HOST")
+[ -n "$WANDB_TEAM" ] && ARGS+=(--wandb-team "$WANDB_TEAM")
+
+python "$LAUNCHER" "${ARGS[@]}" \
     2>&1 | tee "/tmp/flash-2node-launch-${RUN_TAG}.log"

--- a/examples/experimental/swe-agent-v2/train-tb2-via-harbor-private-server/launch.sh
+++ b/examples/experimental/swe-agent-v2/train-tb2-via-harbor-private-server/launch.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Launch a 2-node GLM-4.7-Flash agentic-async training run that uses the
+# miles_agent_server from the harbor-private branch
+# shi/rebase-on-upstream-v0.7.0 as the rollout backend.
+#
+# See README.md for prerequisites (running agent server, populated
+# /root/swe_train.jsonl, the threadpool-fix training branch).
+#
+# Usage:
+#   bash launch.sh <run-tag>            # e.g. bash launch.sh pr-smoke
+#
+# <run-tag> is threaded through --save-dir, --save-traces-dir, and
+# --wandb-run-name so multiple attempts don't collide.
+
+set -euo pipefail
+
+if [ "$#" -lt 1 ]; then
+    echo "usage: $0 <run-tag>" >&2
+    exit 64
+fi
+RUN_TAG="$1"
+
+# Resolve where the launcher script lives. We expect to be invoked from
+# the miles repo root (cwd-sensitive: run-glm47-flash-agentic-async.py
+# uses relative paths to other tooling and the prompt-data symlink).
+LAUNCHER="examples/experimental/swe-agent-v2/run-glm47-flash-agentic-async.py"
+if [ ! -f "$LAUNCHER" ]; then
+    echo "error: $LAUNCHER not found. Run this script from the miles repo root." >&2
+    exit 66
+fi
+
+# The rcli job name is used to construct the Tailscale-ingress FQDN that
+# the rollout router advertises back to the external agent server.
+# Default matches what we use; override via $RCLI_JOB_NAME.
+RCLI_JOB_NAME="${RCLI_JOB_NAME:-shidong-flash-pr-train}"
+
+# Dataset symlink check (the launcher hard-codes /root/swe_train.jsonl).
+if [ ! -e /root/swe_train.jsonl ]; then
+    echo "error: /root/swe_train.jsonl missing. See README.md step 'Launch'." >&2
+    exit 65
+fi
+
+# Make sure the rcli job's namespace can route to the external agent server
+# via the in-cluster ts-egress-aws-agent-server ExternalName.
+AGENT_SERVER_URL="${AGENT_SERVER_URL:-http://ts-egress-aws-agent-server:8080}"
+
+python "$LAUNCHER" \
+    --num-nodes 2 --train-num-nodes 1 --skip-prepare \
+    --max-seq-len 65536 \
+    --save-dir "/workspace/GLM-4.7-Flash_2node_tb2_${RUN_TAG}/" \
+    --save-traces-dir "/workspace/flash-2node-traces-${RUN_TAG}/traces" \
+    --rollout-batch-size 4 --n-samples-per-prompt 8 --global-batch-size 32 \
+    --save-interval 5 \
+    --sglang-mem-fraction-static 0.72 \
+    --agent-server-url "$AGENT_SERVER_URL" \
+    --router-external-host "${RCLI_JOB_NAME}-ts-ingress.tail134ba0.ts.net" \
+    --wandb-project glm47-flash-agentic-async \
+    --wandb-team ch271828n-team \
+    --wandb-run-name "$RUN_TAG" \
+    2>&1 | tee "/tmp/flash-2node-launch-${RUN_TAG}.log"

--- a/examples/experimental/swe-agent-v2/train-tb2-via-harbor-private-server/launch.sh
+++ b/examples/experimental/swe-agent-v2/train-tb2-via-harbor-private-server/launch.sh
@@ -51,7 +51,6 @@ python "$LAUNCHER" \
     --save-traces-dir "/workspace/flash-2node-traces-${RUN_TAG}/traces" \
     --rollout-batch-size 4 --n-samples-per-prompt 8 --global-batch-size 32 \
     --save-interval 5 \
-    --sglang-mem-fraction-static 0.72 \
     --agent-server-url "$AGENT_SERVER_URL" \
     --router-external-host "${RCLI_JOB_NAME}-ts-ingress.tail134ba0.ts.net" \
     --wandb-project glm47-flash-agentic-async \

--- a/examples/experimental/swe-agent-v2/train-tb2-via-harbor-private-server/launch.sh
+++ b/examples/experimental/swe-agent-v2/train-tb2-via-harbor-private-server/launch.sh
@@ -24,6 +24,10 @@
 #       Leave unset to omit --router-external-host.
 #   WANDB_TEAM=
 #       Wandb team to log to. Leave unset to omit --wandb-team.
+#   OUTPUT_ROOT=/workspace
+#       Filesystem root under which save-dir and save-traces-dir are
+#       created. Must point at writable storage shared between the
+#       training nodes; the cluster's persistent volume is usually right.
 
 set -euo pipefail
 
@@ -47,12 +51,13 @@ fi
 AGENT_SERVER_URL="${AGENT_SERVER_URL:-http://agent-server:8080}"
 ROUTER_EXTERNAL_HOST="${ROUTER_EXTERNAL_HOST:-}"
 WANDB_TEAM="${WANDB_TEAM:-}"
+OUTPUT_ROOT="${OUTPUT_ROOT:-/workspace}"
 
 ARGS=(
     --num-nodes 2 --train-num-nodes 1 --skip-prepare
     --max-seq-len 65536
-    --save-dir "/workspace/GLM-4.7-Flash_2node_tb2_${RUN_TAG}/"
-    --save-traces-dir "/workspace/flash-2node-traces-${RUN_TAG}/traces"
+    --save-dir "${OUTPUT_ROOT}/GLM-4.7-Flash_2node_tb2_${RUN_TAG}/"
+    --save-traces-dir "${OUTPUT_ROOT}/flash-2node-traces-${RUN_TAG}/traces"
     --rollout-batch-size 4 --n-samples-per-prompt 8 --global-batch-size 32
     --save-interval 5
     --agent-server-url "$AGENT_SERVER_URL"


### PR DESCRIPTION
## Summary

Adds `examples/experimental/swe-agent-v2/train-tb2-via-harbor-private-server/` — the **training-side companion** to `examples/eval/terminal_bench_via_agent_server/` (merged in #1225). Both examples target the `/run` endpoint of the [`miles_agent_server`](https://github.com/radixark/harbor-private/blob/shi/rebase-on-upstream-v0.7.0/miles_agent_server.py) shipped on the [harbor-private branch `shi/rebase-on-upstream-v0.7.0`](https://github.com/radixark/harbor-private/tree/shi/rebase-on-upstream-v0.7.0); this one drives it from the existing `run-glm47-flash-agentic-async.py` launcher instead of a one-shot Python client.

End-to-end picture:

```
trainer-side (rcli pod, this PR)               agent-server (external host)
+--------------------+                         +-----------------------------+
|  Megatron actor    |  weights -> sglang ---->|                             |
|  RolloutManager    |                         |   miles_agent_server.py     |
|     ^              |  POST /run         ---->|     (harbor-private branch) |
|     | GRPO updates |                         |     spawns Docker -> agent  |
+-----+--------------+                         |     -> verifier -> reward   |
                                               +-----------------------------+
```

## What's in this PR

- `README.md` — full 2-node recipe (prerequisites, dataset symlink, training branch with the threadpool fix, exact launcher invocation with all defaults, sanity-check sequence, tuning notes).
- `launch.sh` — thin bash wrapper around `run-glm47-flash-agentic-async.py` that pre-fills the 2-node defaults and threads a `<run-tag>` positional argument through `--save-dir`, `--save-traces-dir`, and `--wandb-run-name` so multiple attempts don't collide. Asserts that `/root/swe_train.jsonl` (the launcher's hardcoded prompt-data path) is symlinked, and exposes `RCLI_JOB_NAME` + `AGENT_SERVER_URL` env overrides for the few values that change across jobs.

**No new launcher logic.** The 5-node baseline in `run-glm47-flash-agentic-async.py` is unchanged; this PR is documentation + a small bash convenience wrapper.

## Why a separate 2-node example?

The 5-node config in `run-glm47-flash-agentic-async.py` is designed for production scale (4 rollout nodes, 1 trainer). For developers who want to:

- Smoke-test a new agent-server build (like the harbor-private rebase) without booking 5 nodes
- Iterate on training-loop changes with 1/2 the GPU cost
- Reproduce results on a smaller cluster

…the 2-node `--num-nodes 2 --train-num-nodes 1` layout (1 trainer + 1 rollout) is the minimum useful split. This PR captures the canonical recipe so the next person doesn't have to re-derive it.

## Test plan

- [ ] `rcli job new --name flash-pr-train --num-nodes 2 ...` on `sci-h200`.
- [ ] Start a `miles_agent_server` on the harbor-private branch on an external host (we use `aws-agent-server`), with the 23 TB2 variance tasks populated under `$HARBOR_TASKS_DIR`.
- [ ] Inside the head pod: checkout `shi/260421-glm47-flash-2node@83bcfa6`, symlink the 23-task TB2 jsonl to `/root/swe_train.jsonl`, run `bash launch.sh pr-smoke`.
- [ ] Confirm: Ray `RUNNING`, wandb URL appears, first `rollout 0:` / `step 0:` land within ~60 min, then 10 consecutive iters complete cleanly.
- [ ] Post training-side metrics (rollout/raw_reward, step/kl_loss, step/grad_norm) + agent-server-side dashboard snapshot back to this PR as evidence.

I'm executing the test plan now and will follow up with results.
