### PR TITLE
Add PyPI metadata + bump to miles-rl 0.0.2

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,10 @@
+# Defensively include the top-level README + LICENSE so they ship in
+# both the sdist and the wheel (PyPI renders the README on the project
+# page; setuptools embeds it into the wheel's METADATA via setup.py's
+# `long_description=`, but a duplicate listing here is harmless and
+# protects the sdist).
+include README.md LICENSE
+
 # MANIFEST.in — additional files to include in the miles-rl wheel.
 #
 # The bundled patched sglang and Megatron-LM source has non-Python data

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,12 @@ def _fetch_requirements(path):
         return [r.strip() for r in fd.readlines() if r.strip() and not r.startswith("#")]
 
 
+def _read_long_description():
+    """Return the README contents so PyPI renders the project page."""
+    from pathlib import Path
+    return Path(__file__).parent.joinpath("README.md").read_text(encoding="utf-8")
+
+
 # Custom wheel class for the bundled miles-rl wheel.
 #
 # After Phase 6 bundles the patched sglang + Megatron-LM Python source
@@ -65,11 +71,23 @@ _megatron_plugins_packages = find_namespace_packages(
 
 # Setup configuration
 setup(
-    author="miles Team",
     name="miles-rl",
-    # First public PyPI release of the bundled miles-rl wheel. Bump for each
-    # subsequent release; PyPI rejects re-uploads of the same version.
-    version="0.0.1",
+    # Bump for each release. PyPI rejects re-uploads of the same version.
+    version="0.0.2",
+    author="Radixark Miles Team",
+    author_email="miles@radixark.ai",
+    description="Enterprise-grade reinforcement learning for large-scale model training.",
+    long_description=_read_long_description(),
+    long_description_content_type="text/markdown",
+    url="https://github.com/radixark/miles",
+    project_urls={
+        "Source": "https://github.com/radixark/miles",
+        "Documentation": "https://www.radixark.com/miles/docs",
+        "Issues": "https://github.com/radixark/miles/issues",
+    },
+    license="Apache-2.0",
+    license_files=("LICENSE",),
+    keywords="reinforcement-learning rlhf rl moe sglang megatron training",
     packages=(
         _miles_packages
         + _sglang_packages


### PR DESCRIPTION
ci-image-tag: dev-phase2-test-v2

## Summary
- Bump `setup.py` `version` to `0.0.2`.
- Fill in the previously-empty PyPI metadata fields: `description`, `long_description` (from README.md), `long_description_content_type`, `url`, `project_urls` (Source / Documentation / Issues), `license="Apache-2.0"` (with `license_files=("LICENSE",)`), `author`, `author_email`, `keywords`.
- Defensively `include README.md LICENSE` in `MANIFEST.in` so they ship in both sdist and wheel.

## Why
PyPI metadata is **locked per uploaded version** — it can't be edited after upload. miles-rl 0.0.1 went up with empty `summary` / `description` / `home_page` / `license` / etc., so https://pypi.org/project/miles-rl/ shows a near-empty project page. PyPI displays the *latest* release's metadata on the project page, so cutting 0.0.2 with full metadata fixes it going forward.

## Test plan
- [x] `python3 -m ast` parses setup.py cleanly.
- [ ] Trigger `publish-pypi.yml` workflow_dispatch with `dry_run=false` on this branch → uploads `miles-rl==0.0.2` via OIDC, polls PyPI index, smoke-installs in a fresh venv.
- [ ] After upload, https://pypi.org/project/miles-rl/ renders the README and shows all the metadata.

## Stacked on
[radixark/miles PR #1231](https://github.com/radixark/miles/pull/1231) (Phase 7 publish workflow).

## What this PR explicitly does NOT do
- Doesn't change any code outside `setup.py` and `MANIFEST.in`.
- Doesn't populate `extras_require["gpu"]` — that's separate work.
- Doesn't modify the `publish-pypi.yml` workflow (only triggers it).
