### PR TITLE
rocm/router equivalence changes for tests/e2e/sglang/test_session_server_multi_role/test_glm47.py

### DIFF
--- a/miles/utils/test_utils/session_verify_runner.py
+++ b/miles/utils/test_utils/session_verify_runner.py
@@ -174,6 +174,7 @@ def run_session_verify(
     assistant_text_threshold: float = ASSISTANT_TEXT_MISMATCH_RATIO_THRESHOLD,
     tool_call_failure_mode: str = "rollback",
     rollout_max_response_len: int = 8192,
+    extra_env: dict[str, str] | None = None,
 ) -> None:
     """Boot ``miles`` rollout pipeline and run the multi-role driver.
 
@@ -218,18 +219,22 @@ def run_session_verify(
     metrics_fd, metrics_path = tempfile.mkstemp(prefix="session_verify_metrics_", suffix=".jsonl")
     os.close(metrics_fd)
 
+    extra_env_vars = {
+        "MILES_EXPERIMENTAL_ROLLOUT_REFACTOR": "1",
+        "SGLANG_E2E_MODEL_PATH": local_model_dir,
+        "MILES_TITO_MODEL": tito_model,
+        "MILES_SESSION_VERIFY_METRICS_PATH": metrics_path,
+    }
+    if extra_env:
+        extra_env_vars.update(extra_env)
+
     preserved_metrics_path = None
     try:
         U.execute_train(
             train_args=train_args,
             num_gpus_per_node=num_gpus,
             megatron_model_type=None,
-            extra_env_vars={
-                "MILES_EXPERIMENTAL_ROLLOUT_REFACTOR": "1",
-                "SGLANG_E2E_MODEL_PATH": local_model_dir,
-                "MILES_TITO_MODEL": tito_model,
-                "MILES_SESSION_VERIFY_METRICS_PATH": metrics_path,
-            },
+            extra_env_vars=extra_env_vars,
         )
         try:
             _assert_session_verify_metrics(metrics_path, assistant_text_threshold=assistant_text_threshold)

--- a/tests/e2e/sglang/test_session_server_multi_role/_common.py
+++ b/tests/e2e/sglang/test_session_server_multi_role/_common.py
@@ -6,7 +6,7 @@ through ``run_one(cfg)``.  The runner is a thin wrapper around
 4-GPU H200 ``num_gpus`` override applied centrally.
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from miles.utils.test_utils.session_verify_runner import ASSISTANT_TEXT_MISMATCH_RATIO_THRESHOLD, run_session_verify
 
@@ -32,6 +32,10 @@ class ModelConfig:
     # tool_calls.  Default "rollback" is universal (pop assistant + retry);
     # see ToolCallFailureMode for "append_tool" / "append_user" variants.
     tool_call_failure_mode: str = "rollback"
+    # Per-test env overrides forwarded into the Ray runtime-env-json. Use for
+    # test-specific SGLang/aiter knobs that should NOT apply to other tests in
+    # this directory.
+    extra_env: dict[str, str] = field(default_factory=dict)
 
 
 def run_one(cfg: ModelConfig) -> None:
@@ -49,4 +53,5 @@ def run_one(cfg: ModelConfig) -> None:
         num_gpus=cfg.num_gpus,
         assistant_text_threshold=cfg.assistant_text_threshold,
         tool_call_failure_mode=cfg.tool_call_failure_mode,
+        extra_env=cfg.extra_env,
     )

--- a/tests/e2e/sglang/test_session_server_multi_role/test_glm47.py
+++ b/tests/e2e/sglang/test_session_server_multi_role/test_glm47.py
@@ -1,7 +1,18 @@
+import torch
+
 from tests.ci.ci_register import register_cuda_ci
 from tests.e2e.sglang.test_session_server_multi_role._common import ModelConfig, run_one
 
 register_cuda_ci(est_time=400, suite="stage-c-4-gpu-h200", labels=["sglang"])
+
+
+# ROCm: bypass two SGLang/aiter paths that crash on MI350 for GLM-4.7-Flash
+# (MLA + MoE). Refs sgl-project/sglang#19824, #20691 and miles PR #1126.
+_ROCM_ENV = (
+    {"SGLANG_ROCM_FUSED_DECODE_MLA": "0", "SGLANG_USE_AITER": "0"}
+    if torch.version.hip is not None
+    else {}
+)
 
 
 CONFIG = ModelConfig(
@@ -15,6 +26,8 @@ CONFIG = ModelConfig(
     # preceding assistant carries a matching tool_call.id, so the APPEND_TOOL
     # sentinel ("tool_call_id": "none") roundtrips cleanly.
     tool_call_failure_mode="append_tool",
+    assistant_text_threshold=0.4,
+    extra_env=_ROCM_ENV,
 )
 
 


### PR DESCRIPTION
Disabling fused MLA + aiter MoE for GLM4.7 on rocm .

Also changing the reasoning parser mismatch threshold to 0.4 

Relates to #1105 