### PR TITLE
Add dense true-on-policy CI coverage

### DIFF
--- a/examples/true_on_policy/run_simple.py
+++ b/examples/true_on_policy/run_simple.py
@@ -102,7 +102,6 @@ def execute():
 
     true_on_policy_args = (
         "--sglang-enable-deterministic-inference "
-        "--sglang-rl-on-policy-target fsdp "
         "--sglang-attention-backend fa3 "
         "--attn-implementation flash_attention_3 "
         "--deterministic-mode "

--- a/examples/true_on_policy_vlm/run_simple.py
+++ b/examples/true_on_policy_vlm/run_simple.py
@@ -97,12 +97,7 @@ def execute():
     #     "--max-tokens-per-gpu 2048 "
     # )
 
-    true_on_policy_args = (
-        "--sglang-enable-deterministic-inference "
-        "--sglang-rl-on-policy-target fsdp "
-        "--deterministic-mode "
-        "--true-on-policy-mode "
-    )
+    true_on_policy_args = "--sglang-enable-deterministic-inference " "--deterministic-mode " "--true-on-policy-mode "
     true_on_policy_envs = {
         # TODO note: "Ring" in original RL PR, "allreduce:tree" in SGLang
         # "NCCL_ALGO": "Ring",

--- a/miles/backends/training_utils/data.py
+++ b/miles/backends/training_utils/data.py
@@ -1,19 +1,22 @@
+from __future__ import annotations
+
 import logging
 from argparse import Namespace
 from collections.abc import Sequence
+from typing import TYPE_CHECKING
 
 import torch
 import torch.distributed as dist
 import torch.nn.functional as F
 
-from miles.utils.data import get_minimum_num_micro_batch_size
 from miles.utils.seqlen_balancing import get_seqlen_balanced_partitions
 from miles.utils.types import RolloutBatch
 
-from ...utils.data import process_rollout_data
-from ...utils.ray_utils import Box
 from .cp_utils import slice_log_prob_with_cp, slice_with_cp
 from .parallel import get_parallel_state
+
+if TYPE_CHECKING:
+    from ...utils.ray_utils import Box
 
 logger = logging.getLogger(__name__)
 
@@ -28,6 +31,8 @@ def _rollout_logprob_dtype(args: Namespace) -> torch.dtype:
 
 
 def get_rollout_data(args: Namespace, rollout_data_ref: Box) -> RolloutBatch:
+    from ...utils.data import process_rollout_data
+
     parallel_state = get_parallel_state()
     # Fetch data through ray on CPU, not sure if this will be performance bottleneck.
     # Both first pp stage and the last pp stage will receive the data.
@@ -382,6 +387,8 @@ def get_data_iterator(
         num_microbatches = [num_local_gbs // args.micro_batch_size for _ in range(num_steps_per_rollout)]
         data_iterator = _generate_data_iterator(rollout_data, args.micro_batch_size)
     else:
+        from miles.utils.data import get_minimum_num_micro_batch_size
+
         assert args.max_tokens_per_gpu is not None
         # calculate the number of mirobatches for each step
         samples = rollout_data["total_lengths"]

--- a/miles/backends/training_utils/data.py
+++ b/miles/backends/training_utils/data.py
@@ -99,7 +99,7 @@ def get_rollout_data(args: Namespace, rollout_data_ref: Box) -> RolloutBatch:
 
 
 def get_batch(
-    data_iterator: "DataIterator",
+    data_iterator: DataIterator,
     keys: Sequence[str],
     pad_multiplier: int = 128,
     qkv_format: str = "thd",
@@ -332,7 +332,7 @@ class DataIterator:
             self.offset += self.micro_batch_size
         return batch
 
-    def reset(self) -> "DataIterator":
+    def reset(self) -> DataIterator:
         """Reset internal offset to the start and return self."""
         self.offset = 0
         return self

--- a/miles/backends/training_utils/loss_hub/losses.py
+++ b/miles/backends/training_utils/loss_hub/losses.py
@@ -303,7 +303,7 @@ def policy_loss_function(
     if log_probs.numel() == 0:
         loss += 0 * logits.sum()
 
-    train_scored_log_probs = old_log_probs
+    train_scored_log_probs = log_probs
     train_rollout_logprob_abs_diff = None
     train_rollout_kl = None
     if "rollout_log_probs" in batch and batch["rollout_log_probs"]:

--- a/scripts/run_mcore_fsdp.py
+++ b/scripts/run_mcore_fsdp.py
@@ -215,10 +215,7 @@ eval:
     true_on_policy_envs = {}
     if args.true_on_policy:
         true_on_policy_args = (
-            "--sglang-enable-deterministic-inference "
-            "--sglang-rl-on-policy-target fsdp "
-            "--deterministic-mode "
-            "--true-on-policy-mode "
+            "--sglang-enable-deterministic-inference " "--deterministic-mode " "--true-on-policy-mode "
         )
         true_on_policy_envs = {
             "NCCL_ALGO": "allreduce:tree",

--- a/tests/ci/__init__.py
+++ b/tests/ci/__init__.py
@@ -1,0 +1,1 @@
+"""CI test registration and suite runner helpers."""

--- a/tests/ci/labels.py
+++ b/tests/ci/labels.py
@@ -26,4 +26,5 @@ KNOWN_LABELS: dict[str, str] = {
     "ckpt": "Checkpoint save / load tests",
     "lora": "LoRA training tests",
     "precision": "Numerical precision parity tests",
+    "true-on-policy": "Dense true-on-policy E2E tests",
 }

--- a/tests/ci/run_suite.py
+++ b/tests/ci/run_suite.py
@@ -6,6 +6,10 @@ import warnings
 from collections.abc import Iterable
 from pathlib import Path
 
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
 from tests.ci.ci_register import CIRegistry, HWBackend, collect_tests
 from tests.ci.ci_utils import run_unittest_files
 

--- a/tests/ci/test_labels.py
+++ b/tests/ci/test_labels.py
@@ -18,6 +18,7 @@ def test_known_labels_initial_labels_present():
         "ckpt",
         "lora",
         "precision",
+        "true-on-policy",
     }
     assert expected <= set(KNOWN_LABELS), f"Missing canonical labels: {expected - set(KNOWN_LABELS)}"
 

--- a/tests/e2e/fsdp/test_qwen3_4B_fsdp_true_on_policy.py
+++ b/tests/e2e/fsdp/test_qwen3_4B_fsdp_true_on_policy.py
@@ -76,7 +76,6 @@ def execute():
         "--sglang-decode-log-interval 1000 "
         "--sglang-enable-metrics "
         "--sglang-enable-deterministic-inference "
-        "--sglang-rl-on-policy-target fsdp "
         "--sglang-attention-backend fa3 "
         "--attn-implementation flash_attention_3 "
         "--deterministic-mode "

--- a/tests/e2e/megatron/test_qwen3_4B_true_on_policy.py
+++ b/tests/e2e/megatron/test_qwen3_4B_true_on_policy.py
@@ -14,7 +14,8 @@ def _clear_proxy_env():
 
 
 def _build_args() -> ScriptArgs:
-    run_id = os.environ.get("GITHUB_COMMIT_NAME") or f"qwen3-dense-top-tp2-cp4-ci-{U.create_run_id()}"
+    commit_name = os.environ.get("GITHUB_COMMIT_NAME")
+    run_id = f"{commit_name}-tp2-cp4" if commit_name else f"qwen3-dense-top-tp2-cp4-ci-{U.create_run_id()}"
     args = ScriptArgs(
         mode="debug_one_sample",
         run_id=run_id,

--- a/tests/e2e/megatron/test_qwen3_4B_true_on_policy.py
+++ b/tests/e2e/megatron/test_qwen3_4B_true_on_policy.py
@@ -1,0 +1,39 @@
+import os
+
+from scripts.run_qwen3_4b import ScriptArgs, execute, prepare
+from tests.ci.ci_register import register_cuda_ci
+
+import miles.utils.external_utils.command_utils as U
+
+register_cuda_ci(est_time=1200, suite="stage-c-8-gpu-h100", labels=["megatron", "precision"])
+
+
+def _clear_proxy_env():
+    for proxy_var in ("http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY"):
+        os.environ.pop(proxy_var, None)
+
+
+def _build_args() -> ScriptArgs:
+    run_id = os.environ.get("GITHUB_COMMIT_NAME") or f"qwen3-dense-top-tp2-cp4-ci-{U.create_run_id()}"
+    args = ScriptArgs(
+        mode="debug_one_sample",
+        run_id=run_id,
+        model_name="Qwen3-4B",
+        train_backend="megatron",
+        true_on_policy=True,
+        enable_eval=False,
+        # Keep the CI gate close to the manual dense TP=2/CP=4 correctness gate:
+        # one 1024-token rollout with exact train/rollout logprob equality.
+        extra_args="--num-rollout 1 --rollout-max-response-len 1024 ",
+    )
+    args.tensor_model_parallel_size = 2
+    args.context_parallel_size = 4
+    args.cp_comm_type = "a2a"
+    return args
+
+
+if __name__ == "__main__":
+    args = _build_args()
+    prepare(args)
+    _clear_proxy_env()
+    execute(args)

--- a/tests/e2e/megatron/test_qwen3_4B_true_on_policy.py
+++ b/tests/e2e/megatron/test_qwen3_4B_true_on_policy.py
@@ -5,7 +5,7 @@ from tests.ci.ci_register import register_cuda_ci
 
 import miles.utils.external_utils.command_utils as U
 
-register_cuda_ci(est_time=1200, suite="stage-c-8-gpu-h100", labels=["megatron", "precision"])
+register_cuda_ci(est_time=1200, suite="stage-c-8-gpu-h100", labels=["megatron", "precision", "true-on-policy"])
 
 
 def _clear_proxy_env():

--- a/tests/e2e/megatron/test_qwen3_4B_true_on_policy_tp4_cp2.py
+++ b/tests/e2e/megatron/test_qwen3_4B_true_on_policy_tp4_cp2.py
@@ -1,0 +1,38 @@
+import os
+
+from scripts.run_qwen3_4b import ScriptArgs, execute, prepare
+from tests.ci.ci_register import register_cuda_ci
+
+import miles.utils.external_utils.command_utils as U
+
+register_cuda_ci(est_time=1200, suite="stage-c-8-gpu-h100", labels=["megatron", "precision"])
+
+
+def _clear_proxy_env():
+    for proxy_var in ("http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY"):
+        os.environ.pop(proxy_var, None)
+
+
+def _build_args() -> ScriptArgs:
+    run_id = os.environ.get("GITHUB_COMMIT_NAME") or f"qwen3-dense-top-tp4-cp2-ci-{U.create_run_id()}"
+    args = ScriptArgs(
+        mode="debug_one_sample",
+        run_id=run_id,
+        model_name="Qwen3-4B",
+        train_backend="megatron",
+        true_on_policy=True,
+        enable_eval=False,
+        # Covers the complementary 8-GPU dense layout: TP=4, CP=2.
+        extra_args="--num-rollout 1 --rollout-max-response-len 1024 ",
+    )
+    args.tensor_model_parallel_size = 4
+    args.context_parallel_size = 2
+    args.cp_comm_type = "a2a"
+    return args
+
+
+if __name__ == "__main__":
+    args = _build_args()
+    prepare(args)
+    _clear_proxy_env()
+    execute(args)

--- a/tests/e2e/megatron/test_qwen3_4B_true_on_policy_tp4_cp2.py
+++ b/tests/e2e/megatron/test_qwen3_4B_true_on_policy_tp4_cp2.py
@@ -14,7 +14,8 @@ def _clear_proxy_env():
 
 
 def _build_args() -> ScriptArgs:
-    run_id = os.environ.get("GITHUB_COMMIT_NAME") or f"qwen3-dense-top-tp4-cp2-ci-{U.create_run_id()}"
+    commit_name = os.environ.get("GITHUB_COMMIT_NAME")
+    run_id = f"{commit_name}-tp4-cp2" if commit_name else f"qwen3-dense-top-tp4-cp2-ci-{U.create_run_id()}"
     args = ScriptArgs(
         mode="debug_one_sample",
         run_id=run_id,

--- a/tests/e2e/megatron/test_qwen3_4B_true_on_policy_tp4_cp2.py
+++ b/tests/e2e/megatron/test_qwen3_4B_true_on_policy_tp4_cp2.py
@@ -5,7 +5,7 @@ from tests.ci.ci_register import register_cuda_ci
 
 import miles.utils.external_utils.command_utils as U
 
-register_cuda_ci(est_time=1200, suite="stage-c-8-gpu-h100", labels=["megatron", "precision"])
+register_cuda_ci(est_time=1200, suite="stage-c-8-gpu-h100", labels=["megatron", "precision", "true-on-policy"])
 
 
 def _clear_proxy_env():

--- a/tests/fast/backends/training_utils/test_true_on_policy_data_log_dtype.py
+++ b/tests/fast/backends/training_utils/test_true_on_policy_data_log_dtype.py
@@ -2,11 +2,11 @@ from argparse import Namespace
 from types import SimpleNamespace
 
 import torch
+from tests.ci.ci_register import register_cpu_ci
 
 from miles.backends.training_utils import cp_utils
 from miles.backends.training_utils import data as data_utils
 from miles.backends.training_utils import log_utils
-from tests.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=10, suite="stage-a-cpu")
 

--- a/tests/fast/backends/training_utils/test_true_on_policy_data_log_dtype.py
+++ b/tests/fast/backends/training_utils/test_true_on_policy_data_log_dtype.py
@@ -6,6 +6,9 @@ import torch
 from miles.backends.training_utils import cp_utils
 from miles.backends.training_utils import data as data_utils
 from miles.backends.training_utils import log_utils
+from tests.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=10, suite="stage-a-cpu")
 
 
 def test_true_on_policy_rollout_logprob_dtype_follows_training_precision():

--- a/tests/fast/backends/training_utils/test_true_on_policy_loss_metrics.py
+++ b/tests/fast/backends/training_utils/test_true_on_policy_loss_metrics.py
@@ -3,9 +3,9 @@ from types import SimpleNamespace
 
 import pytest
 import torch
+from tests.ci.ci_register import register_cpu_ci
 
 from miles.backends.training_utils.loss_hub import losses as loss_utils
-from tests.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=10, suite="stage-a-cpu")
 

--- a/tests/fast/backends/training_utils/test_true_on_policy_loss_metrics.py
+++ b/tests/fast/backends/training_utils/test_true_on_policy_loss_metrics.py
@@ -4,7 +4,10 @@ from types import SimpleNamespace
 import pytest
 import torch
 
-from miles.backends.training_utils import loss as loss_utils
+from miles.backends.training_utils.loss_hub import losses as loss_utils
+from tests.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=10, suite="stage-a-cpu")
 
 
 def _make_args(*, use_rollout_logprobs: bool) -> Namespace:
@@ -49,6 +52,11 @@ def _patch_single_rank_masks(monkeypatch):
         loss_utils,
         "get_local_response_loss_masks",
         lambda total_lengths, response_lengths, loss_masks, qkv_format="thd", max_seq_lens=None: loss_masks,
+    )
+    monkeypatch.setattr(
+        loss_utils,
+        "compute_ess_ratio_contribution",
+        lambda **kwargs: torch.zeros((), dtype=torch.float32),
     )
 
 

--- a/tests/fast/true_on_policy/test_config.py
+++ b/tests/fast/true_on_policy/test_config.py
@@ -12,6 +12,9 @@ from miles.true_on_policy import (
     get_true_on_policy_contract,
     get_true_on_policy_model_profile,
 )
+from tests.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=10, suite="stage-a-cpu")
 
 
 def _args(**overrides):

--- a/tests/fast/true_on_policy/test_config.py
+++ b/tests/fast/true_on_policy/test_config.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 import pytest
+from tests.ci.ci_register import register_cpu_ci
 
 from miles.true_on_policy import (
     QWEN3_DENSE_TRUE_ON_POLICY_V1,
@@ -12,7 +13,6 @@ from miles.true_on_policy import (
     get_true_on_policy_contract,
     get_true_on_policy_model_profile,
 )
-from tests.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=10, suite="stage-a-cpu")
 

--- a/tests/fast/true_on_policy/test_run_qwen3_4b.py
+++ b/tests/fast/true_on_policy/test_run_qwen3_4b.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 from scripts import run_qwen3_4b
+from tests.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=10, suite="stage-a-cpu")
 
 
 def test_qwen3_script_true_on_policy_single_knob_expands_to_megatron_contract(monkeypatch):
@@ -20,7 +23,6 @@ def test_qwen3_script_true_on_policy_single_knob_expands_to_megatron_contract(mo
         use_kl_loss=False,
     )
 
-    assert args.sglang_rl_on_policy_target is None
     assert args.use_sequence_parallel is False
 
     run_qwen3_4b.execute(args)
@@ -61,15 +63,14 @@ def test_qwen3_script_true_on_policy_tp2_cp4_normal_topology_contract(monkeypatc
         true_on_policy=True,
         enable_eval=False,
         use_kl_loss=False,
-        tensor_model_parallel_size=2,
-        context_parallel_size=4,
-        pipeline_model_parallel_size=1,
-        cp_comm_type="a2a",
-        rollout_num_gpus=8,
-        rollout_num_gpus_per_engine=8,
     )
+    args.tensor_model_parallel_size = 2
+    args.context_parallel_size = 4
+    args.pipeline_model_parallel_size = 1
+    args.cp_comm_type = "a2a"
+    args.rollout_num_gpus_per_engine = 8
+    args.extra_args = "--rollout-num-gpus 8 "
 
-    assert args.sglang_rl_on_policy_target is None
     assert args.use_sequence_parallel is False
 
     run_qwen3_4b.execute(args)

--- a/tests/fast/utils/test_true_on_policy_logprobs.py
+++ b/tests/fast/utils/test_true_on_policy_logprobs.py
@@ -1,11 +1,11 @@
 import torch
+from tests.ci.ci_register import register_cpu_ci
 
 from miles.backends.training_utils.loss_hub.math_utils import (
     _calculate_log_probs_and_entropy_true_on_policy,
     _prepare_true_on_policy_full_logits,
     _split_replicated_loss_gather_grad,
 )
-from tests.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=10, suite="stage-a-cpu")
 

--- a/tests/fast/utils/test_true_on_policy_logprobs.py
+++ b/tests/fast/utils/test_true_on_policy_logprobs.py
@@ -1,10 +1,13 @@
 import torch
 
-from miles.utils.ppo_utils import (
+from miles.backends.training_utils.loss_hub.math_utils import (
     _calculate_log_probs_and_entropy_true_on_policy,
     _prepare_true_on_policy_full_logits,
     _split_replicated_loss_gather_grad,
 )
+from tests.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=10, suite="stage-a-cpu")
 
 
 def test_true_on_policy_logprobs_tp1_truncate_after_real_vocab():


### PR DESCRIPTION
## Summary
- build on the dense Qwen3 true-on-policy e2e gates from #1198 and make the per-layout run IDs unique when GITHUB_COMMIT_NAME is set
- register the existing true-on-policy fast/unit tests in stage-a-cpu
- wire the existing run-ci-true-on-policy GitHub label through the CI registry so it selects the dense H100 e2e cases
- fix stale true-on-policy test imports/config assumptions and the train-vs-rollout logprob diff metric
- make tests/ci/run_suite.py directly executable by ensuring the repo root is importable

## Tests
- git diff --check
- python tests/ci/run_suite.py --hw cpu --suite stage-a-cpu --list-only
- python tests/ci/run_suite.py --hw cuda --suite stage-c-8-gpu-h100 --labels run-ci-true-on-policy --list-only
- python tests/ci/run_suite.py --hw cuda --suite stage-c-8-gpu-h100 --labels run-ci-precision --list-only
- python -m pytest -q -o addopts='' --confcutdir=tests/fast/true_on_policy tests/fast/true_on_policy/test_config.py tests/fast/true_on_policy/test_run_qwen3_4b.py
- python -m pytest -q -o addopts='' --confcutdir=tests/fast/backends/training_utils tests/fast/backends/training_utils/test_true_on_policy_data_log_dtype.py tests/fast/backends/training_utils/test_true_on_policy_loss_metrics.py
- python -m pytest -q -o addopts='' --confcutdir=tests/fast/utils tests/fast/utils/test_true_on_policy_logprobs.py
- python -m pytest -q tests/ci/test_ci_register.py tests/ci/test_run_suite.py tests/ci/test_labels.py