### PR TITLE
Add @Shi-Dong as code owner for backends, rollout, utils

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,11 +1,11 @@
 /.github/CODEOWNERS @fzyzcjy @Ying1123
 /.github/workflows/ @yushengsu-thu @guapisolo @yueming-yuan
 /miles/ @fzyzcjy @yueming-yuan
-/miles/backends/ @fzyzcjy @yueming-yuan @maocheng23 @Zhichenzzz
+/miles/backends/ @fzyzcjy @yueming-yuan @maocheng23 @Zhichenzzz @Shi-Dong
 /miles/backends/megatron_utils/ @fzyzcjy @yueming-yuan @maocheng23 @yushengsu-thu @Zhichenzzz
 /miles/backends/sglang_utils/ @fzyzcjy @yueming-yuan @maocheng23 @yushengsu-thu @Zhichenzzz
 /miles/ray/ @fzyzcjy @yueming-yuan @maocheng23
-/miles/rollout/ @fzyzcjy @yueming-yuan @guapisolo
+/miles/rollout/ @fzyzcjy @yueming-yuan @guapisolo @Shi-Dong
 /miles/rollout/session/ @fzyzcjy @yueming-yuan @guapisolo @maocheng23 @jybsuper
 /miles/router/ @fzyzcjy @yueming-yuan @guapisolo
-/miles/utils/ @fzyzcjy @yueming-yuan @guapisolo @maocheng23 @jybsuper @Zhichenzzz
+/miles/utils/ @fzyzcjy @yueming-yuan @guapisolo @maocheng23 @jybsuper @Zhichenzzz @Shi-Dong


### PR DESCRIPTION
## Summary
- Add `@Shi-Dong` as a code owner for `/miles/backends/`, `/miles/rollout/`, and `/miles/utils/` in `.github/CODEOWNERS`.

This adds Shi-Dong to the reviewer rotation for these three areas.