### PR TITLE
support `--allgather-cp` for `bshd` tokens/loss + replay data

### DIFF
--- a/miles/backends/megatron_utils/actor.py
+++ b/miles/backends/megatron_utils/actor.py
@@ -291,12 +291,7 @@ class MegatronTrainRayActor(TrainRayActor):
                     assert max_seqlen % cp_size == 0, f"max_seqlen {max_seqlen} must be divisible by cp_size {cp_size}"
                     local_len = max_seqlen // cp_size
                     start = cp_rank * local_len
-                    replay_data = [
-                        pad_func(r, max_seqlen - r.size(0))[start : start + local_len]
-                        if max_seqlen > r.size(0)
-                        else r[start : start + local_len]
-                        for r in replay_data
-                    ]
+                    replay_data = [pad_func(r, max_seqlen - r.size(0))[start : start + local_len] for r in replay_data]
                 else:
                     replay_data = [slice_with_cp(r, pad_func, qkv_format, max_seqlen) for r in replay_data]
                 replay_data = torch.stack(replay_data, dim=0)

--- a/miles/backends/megatron_utils/actor.py
+++ b/miles/backends/megatron_utils/actor.py
@@ -288,10 +288,15 @@ class MegatronTrainRayActor(TrainRayActor):
             if qkv_format == "bshd":
                 max_seqlen = batch["max_seq_lens"][0]
                 if self.args.allgather_cp and cp_size > 1:
-                    assert max_seqlen % cp_size == 0
+                    assert max_seqlen % cp_size == 0, f"max_seqlen {max_seqlen} must be divisible by cp_size {cp_size}"
                     local_len = max_seqlen // cp_size
                     start = cp_rank * local_len
-                    replay_data = [pad_func(r, max_seqlen - r.size(0))[start : start + local_len] for r in replay_data]
+                    replay_data = [
+                        pad_func(r, max_seqlen - r.size(0))[start : start + local_len]
+                        if max_seqlen > r.size(0)
+                        else r[start : start + local_len]
+                        for r in replay_data
+                    ]
                 else:
                     replay_data = [slice_with_cp(r, pad_func, qkv_format, max_seqlen) for r in replay_data]
                 replay_data = torch.stack(replay_data, dim=0)

--- a/miles/backends/megatron_utils/actor.py
+++ b/miles/backends/megatron_utils/actor.py
@@ -283,19 +283,35 @@ class MegatronTrainRayActor(TrainRayActor):
             replay_data = [pad_func(r, 1) for r in replay_data]
             # TODO: maybe extract a common process function for here and get_batch?
 
+            cp_size = parallel_state.cp.size
+            cp_rank = parallel_state.cp.rank
             if qkv_format == "bshd":
                 max_seqlen = batch["max_seq_lens"][0]
-                replay_data = [slice_with_cp(r, pad_func, qkv_format, max_seqlen) for r in replay_data]
+                if self.args.allgather_cp and cp_size > 1:
+                    assert max_seqlen % cp_size == 0
+                    local_len = max_seqlen // cp_size
+                    start = cp_rank * local_len
+                    replay_data = [pad_func(r, max_seqlen - r.size(0))[start : start + local_len] for r in replay_data]
+                else:
+                    replay_data = [slice_with_cp(r, pad_func, qkv_format, max_seqlen) for r in replay_data]
                 replay_data = torch.stack(replay_data, dim=0)
                 batch_size, seqlen, num_layers, topk = replay_data.shape
                 replay_data = replay_data.reshape(batch_size * seqlen, num_layers, topk)
             else:
-                replay_data = [slice_with_cp(r, pad_func, qkv_format) for r in replay_data]
-                replay_data = torch.cat(replay_data, dim=0)
                 pad_size = parallel_state.tp.size * self.args.data_pad_size_multiplier
-                pad = (pad_size - replay_data.size(0) % pad_size) % pad_size
-                if pad != 0:
-                    replay_data = pad_func(replay_data, pad)
+                if self.args.allgather_cp and cp_size > 1:
+                    replay_data = torch.cat(replay_data, dim=0)
+                    global_pad_size = cp_size * pad_size
+                    pad = (global_pad_size - replay_data.size(0) % global_pad_size) % global_pad_size
+                    if pad != 0:
+                        replay_data = pad_func(replay_data, pad)
+                    replay_data = replay_data.chunk(cp_size, dim=0)[cp_rank]
+                else:
+                    replay_data = [slice_with_cp(r, pad_func, qkv_format) for r in replay_data]
+                    replay_data = torch.cat(replay_data, dim=0)
+                    pad = (pad_size - replay_data.size(0) % pad_size) % pad_size
+                    if pad != 0:
+                        replay_data = pad_func(replay_data, pad)
 
             if self.args.sequence_parallel and if_sp_region:
                 seqlen = replay_data.size(0)

--- a/miles/backends/training_utils/data.py
+++ b/miles/backends/training_utils/data.py
@@ -155,10 +155,7 @@ def get_batch(
             local_len = max_seqlen // cp_size
             start = parallel_state.cp.rank * local_len
             tokens = [
-                F.pad(t, (0, max_seqlen - t.size(0)), value=pad_token_id)[start : start + local_len]
-                if max_seqlen > t.size(0)
-                else t[start : start + local_len]
-                for t in tokens
+                F.pad(t, (0, max_seqlen - t.size(0)), value=pad_token_id)[start : start + local_len] for t in tokens
             ]
         else:
             tokens = [slice_with_cp(t, pad_token_id, qkv_format, max_seqlen) for t in tokens]
@@ -260,10 +257,7 @@ def get_batch(
             local_len = max_seqlen // cp_size
             start = parallel_state.cp.rank * local_len
             loss_masks = [
-                F.pad(lm, (0, max_seqlen - lm.size(0)), value=0)[start : start + local_len]
-                if max_seqlen > lm.size(0)
-                else lm[start : start + local_len]
-                for lm in loss_masks
+                F.pad(lm, (0, max_seqlen - lm.size(0)), value=0)[start : start + local_len] for lm in loss_masks
             ]
         loss_masks = torch.stack(loss_masks)
     elif qkv_format == "thd" and allgather_cp:

--- a/miles/backends/training_utils/data.py
+++ b/miles/backends/training_utils/data.py
@@ -148,9 +148,6 @@ def get_batch(
         max_seqlen = batch["max_seq_lens"][0]
         assert max([t.size(0) for t in tokens]) <= max_seqlen
         if allgather_cp:
-            # Contiguous CP: pad each sample to max_seqlen, then take chunk cp_rank.
-            # Requires max_seqlen divisible by cp_size; the caller pads max_seq_len to a
-            # cp_size multiple, and the assert enforces that contract.
             assert max_seqlen % cp_size == 0, f"max_seqlen {max_seqlen} not divisible by cp_size {cp_size}"
             local_len = max_seqlen // cp_size
             start = parallel_state.cp.rank * local_len
@@ -251,9 +248,6 @@ def get_batch(
 
     if qkv_format == "bshd":
         if allgather_cp:
-            # Same contiguous CP slicing as tokens above. loss_masks currently hold
-            # per-sample full-length masks (pad to total_length via the prompt/right pad
-            # above); pad up to max_seqlen, then take cp_rank's chunk.
             local_len = max_seqlen // cp_size
             start = parallel_state.cp.rank * local_len
             loss_masks = [

--- a/miles/backends/training_utils/data.py
+++ b/miles/backends/training_utils/data.py
@@ -155,7 +155,10 @@ def get_batch(
             local_len = max_seqlen // cp_size
             start = parallel_state.cp.rank * local_len
             tokens = [
-                F.pad(t, (0, max_seqlen - t.size(0)), value=pad_token_id)[start : start + local_len] for t in tokens
+                F.pad(t, (0, max_seqlen - t.size(0)), value=pad_token_id)[start : start + local_len]
+                if max_seqlen > t.size(0)
+                else t[start : start + local_len]
+                for t in tokens
             ]
         else:
             tokens = [slice_with_cp(t, pad_token_id, qkv_format, max_seqlen) for t in tokens]
@@ -257,7 +260,10 @@ def get_batch(
             local_len = max_seqlen // cp_size
             start = parallel_state.cp.rank * local_len
             loss_masks = [
-                F.pad(lm, (0, max_seqlen - lm.size(0)), value=0)[start : start + local_len] for lm in loss_masks
+                F.pad(lm, (0, max_seqlen - lm.size(0)), value=0)[start : start + local_len]
+                if max_seqlen > lm.size(0)
+                else lm[start : start + local_len]
+                for lm in loss_masks
             ]
         loss_masks = torch.stack(loss_masks)
     elif qkv_format == "thd" and allgather_cp:

--- a/miles/backends/training_utils/data.py
+++ b/miles/backends/training_utils/data.py
@@ -147,7 +147,18 @@ def get_batch(
     if qkv_format == "bshd":
         max_seqlen = batch["max_seq_lens"][0]
         assert max([t.size(0) for t in tokens]) <= max_seqlen
-        tokens = [slice_with_cp(t, pad_token_id, qkv_format, max_seqlen) for t in tokens]
+        if allgather_cp:
+            # Contiguous CP: pad each sample to max_seqlen, then take chunk cp_rank.
+            # Requires max_seqlen divisible by cp_size; the caller pads max_seq_len to a
+            # cp_size multiple, and the assert enforces that contract.
+            assert max_seqlen % cp_size == 0, f"max_seqlen {max_seqlen} not divisible by cp_size {cp_size}"
+            local_len = max_seqlen // cp_size
+            start = parallel_state.cp.rank * local_len
+            tokens = [
+                F.pad(t, (0, max_seqlen - t.size(0)), value=pad_token_id)[start : start + local_len] for t in tokens
+            ]
+        else:
+            tokens = [slice_with_cp(t, pad_token_id, qkv_format, max_seqlen) for t in tokens]
         tokens = torch.stack(tokens)
 
     elif qkv_format == "thd":
@@ -239,6 +250,15 @@ def get_batch(
         loss_masks.append(loss_mask)
 
     if qkv_format == "bshd":
+        if allgather_cp:
+            # Same contiguous CP slicing as tokens above. loss_masks currently hold
+            # per-sample full-length masks (pad to total_length via the prompt/right pad
+            # above); pad up to max_seqlen, then take cp_rank's chunk.
+            local_len = max_seqlen // cp_size
+            start = parallel_state.cp.rank * local_len
+            loss_masks = [
+                F.pad(lm, (0, max_seqlen - lm.size(0)), value=0)[start : start + local_len] for lm in loss_masks
+            ]
         loss_masks = torch.stack(loss_masks)
     elif qkv_format == "thd" and allgather_cp:
         # DSA: concatenate first (same as tokens), pad globally (same pad as above), then slice once.


### PR DESCRIPTION
## What

Extend the existing `allgather_cp` (contiguous context-parallel) data path — which main already supports for the `thd` qkv_format — to the `bshd` qkv_format and to replay data:

- **`get_batch` (`training_utils/data.py`)** — bshd `tokens` and `loss_masks`: pad each sample to `max_seqlen`, then take this CP rank's contiguous chunk, instead of the strided `slice_with_cp`.
- **replay-list register path (`megatron_utils/actor.py`)** — `replay_data` for both `bshd` and `thd`: slice/pad contiguously when `allgather_cp` so replayed per-token data matches the contiguous token layout. Previously this path always used the strided `slice_with_cp`, which is inconsistent with the contiguous token/loss layout under `allgather_cp`.

## Why

`allgather_cp` already exists in main and is used (e.g. `run_deepseek_v32.py`, `run_glm5_744b_a40b.py`) — but only the `thd` path had contiguous slicing in `get_batch`, and the replay path had none. This fills the `bshd` + replay gaps so contiguous CP is consistent across tokens, loss masks, and replay data.

## Contract

Contiguous CP requires `max_seqlen % cp_size == 0`. The caller pads `max_seq_len` to a `cp_size` multiple; the `assert`s enforce the contract (fail-fast). Model-agnostic — gated only on `args.allgather_cp` / `cp_size`. When `allgather_cp` is off, the code falls through to the existing `slice_with_cp` path, so **no behavior change** for current configs.

## Notes

- Split out of the DeepSeek-V4 work (#1181). V4 is the first consumer of `bshd` + `allgather_cp`; it supplies the `cp_size`-aligned padding (kept in #1181) that satisfies the divisibility contract here.
- No existing **non-V4** config combines `bshd` + `allgather_cp`, so this path isn't exercised by current CI models on its own; correctness is covered downstream by the V4 runs that turn it on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
