### PR TITLE
Default geo3k_vlm_multi_turn to megatron backend

### DIFF
--- a/examples/geo3k_vlm_multi_turn/README.md
+++ b/examples/geo3k_vlm_multi_turn/README.md
@@ -30,7 +30,7 @@ The reward model is the default math RM.
 export WANDB_API_KEY=...
 export MILES_SCRIPT_MODEL_NAME=Qwen3-VL-2B-Instruct
 export MILES_SCRIPT_NUM_GPUS=4
-export MILES_SCRIPT_TRAIN_BACKEND=fsdp
+export MILES_SCRIPT_TRAIN_BACKEND=megatron
 
 # 2) Download the dataset
 hf download --repo-type dataset VeraIsHere/geo3k_imgurl_processed --local-dir /root/datasets/geo3k_imgurl_processed

--- a/examples/geo3k_vlm_multi_turn/run_geo3k_vlm_multi_turn.py
+++ b/examples/geo3k_vlm_multi_turn/run_geo3k_vlm_multi_turn.py
@@ -15,7 +15,7 @@ assert MODEL_NAME in {
 
 NUM_GPUS = int(os.environ.get("MILES_SCRIPT_NUM_GPUS", "4"))
 EXTERNAL_RAY = int(os.environ.get("MILES_SCRIPT_EXTERNAL_RAY", "0"))
-TRAIN_BACKEND = os.environ.get("MILES_SCRIPT_TRAIN_BACKEND", "fsdp").lower()
+TRAIN_BACKEND = os.environ.get("MILES_SCRIPT_TRAIN_BACKEND", "megatron").lower()
 assert TRAIN_BACKEND in {"fsdp", "megatron"}
 
 DATASET_NAME = "VeraIsHere/geo3k_imgurl_processed"


### PR DESCRIPTION
The geo3k_vlm_multi_turn launcher defaulted to the FSDP backend (MILES_SCRIPT_TRAIN_BACKEND), but FSDP has been moved to miles.backends.experimental and is no longer maintained for the current SGLang version. Launching the example with the default now raises ValueError: The FSDP backend has known issues with SGLang v0.5.10 ... before training starts.

This switches the default to megatron, which runs the example end-to-end (verified with a 4xH200 smoke run: 3 GRPO iterations, rollout + reward + train, clean exit). The companion geo3k_vlm launcher already defaults to megatron. fsdp remains selectable via MILES_SCRIPT_TRAIN_BACKEND=fsdp for anyone using the experimental backend.

Changes:
- run_geo3k_vlm_multi_turn.py: default TRAIN_BACKEND fsdp -> megatron
- README.md: reproduce snippet uses megatron