### PR TITLE
Fix pre-commit formatting

### DIFF
--- a/examples/eval/terminal_bench_via_agent_server/eval_tb_deepseek_v4_pro.py
+++ b/examples/eval/terminal_bench_via_agent_server/eval_tb_deepseek_v4_pro.py
@@ -142,18 +142,9 @@ def load_task_names(registry_path: Path, dataset_name: str) -> list[str]:
     data: list[dict[str, Any]] = json.loads(registry_path.read_text())
     for dataset in data:
         if dataset.get("name") == dataset_name:
-            return [
-                task["name"]
-                for task in (dataset.get("tasks") or [])
-                if isinstance(task, dict) and "name" in task
-            ]
-    available: list[str] = sorted(
-        d["name"] for d in data if isinstance(d.get("name"), str)
-    )
-    raise ValueError(
-        f"Dataset {dataset_name!r} not found in {registry_path}. "
-        f"Available datasets: {available}"
-    )
+            return [task["name"] for task in (dataset.get("tasks") or []) if isinstance(task, dict) and "name" in task]
+    available: list[str] = sorted(d["name"] for d in data if isinstance(d.get("name"), str))
+    raise ValueError(f"Dataset {dataset_name!r} not found in {registry_path}. " f"Available datasets: {available}")
 
 
 async def run_one_trial(
@@ -214,8 +205,7 @@ async def main(args: argparse.Namespace) -> None:
     api_key = os.environ.get(args.api_key_env)
     if not api_key:
         raise SystemExit(
-            f"Environment variable {args.api_key_env!r} is not set. "
-            f"Export your DeepSeek API key first."
+            f"Environment variable {args.api_key_env!r} is not set. " f"Export your DeepSeek API key first."
         )
 
     task_names = load_task_names(args.registry_path, args.dataset_name)
@@ -238,9 +228,7 @@ async def main(args: argparse.Namespace) -> None:
 
     sem = asyncio.Semaphore(args.max_concurrent)
 
-    async def bounded(
-        client: httpx.AsyncClient, iid: str, idx: int
-    ) -> dict[str, Any]:
+    async def bounded(client: httpx.AsyncClient, iid: str, idx: int) -> dict[str, Any]:
         async with sem:
             return await run_one_trial(client, args, api_key, iid, idx)
 
@@ -266,10 +254,7 @@ async def main(args: argparse.Namespace) -> None:
                 flush=True,
             )
 
-    flat_rows = [
-        {k: v for k, v in row.items() if k not in {"agent_metrics", "eval_report"}}
-        for row in results
-    ]
+    flat_rows = [{k: v for k, v in row.items() if k not in {"agent_metrics", "eval_report"}} for row in results]
     pl.from_dicts(flat_rows).write_parquet(args.output_parquet)
 
     completed = [r for r in results if r.get("reward") is not None]

--- a/scripts/run_qwen3_4b_npu.py
+++ b/scripts/run_qwen3_4b_npu.py
@@ -17,12 +17,11 @@ TRAIN_DATA_PATH = os.path.join(DATA_ROOT, "train.parquet")
 
 def get_megatron_model_type(model_name: str) -> str:
     megatron_model_type = {
-                "Qwen3-4B-Instruct-2507": "qwen3-4B-Instruct-2507",
-                "Qwen3-4B-Base": "qwen3-4B",
-                "Qwen3-4B": "qwen3-4B",
-            }[model_name]
+        "Qwen3-4B-Instruct-2507": "qwen3-4B-Instruct-2507",
+        "Qwen3-4B-Base": "qwen3-4B",
+        "Qwen3-4B": "qwen3-4B",
+    }[model_name]
     return megatron_model_type
-
 
 
 def prepare():
@@ -36,7 +35,7 @@ def prepare():
 
 
 def execute():
-    ckpt_args = f"--hf-checkpoint /root/model/Qwen3-4B-Instruct-2507/ "
+    ckpt_args = "--hf-checkpoint /root/model/Qwen3-4B-Instruct-2507/ "
 
     wandb_args = (
         (
@@ -50,7 +49,7 @@ def execute():
     )
 
     rollout_args = (
-        f"--prompt-data /root/dataset/dapo-math-17k/dapo-math-17k.jsonl "
+        "--prompt-data /root/dataset/dapo-math-17k/dapo-math-17k.jsonl "
         "--input-key prompt "
         "--label-key label "
         "--apply-chat-template "
@@ -61,7 +60,7 @@ def execute():
         "--num-rollout 3000 "
         "--rollout-batch-size 32 "
         "--n-samples-per-prompt 8 "
-        f"--rollout-max-response-len 4096 "
+        "--rollout-max-response-len 4096 "
         "--rollout-temperature 1 "
         "--global-batch-size 256 "
         "--balance-data "
@@ -108,7 +107,7 @@ def execute():
 
     megatron_args = (
         "--train-backend megatron "
-        f"--load /root/model/Qwen3-4B-Instruct-2507/ "
+        "--load /root/model/Qwen3-4B-Instruct-2507/ "
         "--tensor-model-parallel-size 4 "
         "--sequence-parallel "
         "--pipeline-model-parallel-size 1 "
@@ -129,7 +128,9 @@ def execute():
     )
 
     misc_args = (
-        "--actor-num-nodes 1 " f"--actor-num-gpus-per-node {NUM_GPUS} " f"--rollout-num-gpus {NUM_GPUS} "
+        "--actor-num-nodes 1 "
+        f"--actor-num-gpus-per-node {NUM_GPUS} "
+        f"--rollout-num-gpus {NUM_GPUS} "
         "--no-gradient-accumulation-fusion "
         "--use-flash-attn "
     )


### PR DESCRIPTION
## Summary

Apply the formatting changes produced by `pre-commit run --all-files` on current `main`.

This fixes the current pre-commit failure caused by hooks modifying:

- `examples/eval/terminal_bench_via_agent_server/eval_tb_deepseek_v4_pro.py`
- `scripts/run_qwen3_4b_npu.py`

## Validation

- `pre-commit run --all-files`