### PR TITLE
Support atomic weight update groups

### DIFF
--- a/miles/backends/megatron_utils/megatron_to_hf/__init__.py
+++ b/miles/backends/megatron_utils/megatron_to_hf/__init__.py
@@ -16,7 +16,7 @@ from .qwen3moe import convert_qwen3moe_to_hf
 @dataclass(frozen=True)
 class AtomicUpdateGroup:
     key: str
-    names: tuple[str, ...]
+    suffixes: tuple[str, ...]
 
 
 # TODO unify w/ `convert_to_hf`

--- a/miles/backends/megatron_utils/megatron_to_hf/__init__.py
+++ b/miles/backends/megatron_utils/megatron_to_hf/__init__.py
@@ -27,6 +27,10 @@ def convert_to_hf(args, model_name, name, param, quantization_config=None):
     return quantize_params(args, name, converted_named_tensors, quantization_config)
 
 
+def get_atomic_update_group(model_name, name):
+    return None
+
+
 # TODO optimize
 _cached_tensors = {}
 

--- a/miles/backends/megatron_utils/megatron_to_hf/__init__.py
+++ b/miles/backends/megatron_utils/megatron_to_hf/__init__.py
@@ -35,7 +35,7 @@ def convert_to_hf(args, model_name, name, param, quantization_config=None):
     return quantize_params(args, name, converted_named_tensors, quantization_config)
 
 
-def get_atomic_update_groups(model_name, param_infos) -> list[AtomicUpdateGroup]:
+def get_atomic_update_groups(args, model_name) -> list[AtomicUpdateGroup]:
     return []
 
 

--- a/miles/backends/megatron_utils/megatron_to_hf/__init__.py
+++ b/miles/backends/megatron_utils/megatron_to_hf/__init__.py
@@ -1,3 +1,5 @@
+from dataclasses import dataclass
+
 from .deepseekv3 import convert_deepseekv3_to_hf
 from .glm4 import convert_glm4_to_hf
 from .glm4moe import convert_glm4moe_to_hf
@@ -9,6 +11,12 @@ from .qwen2 import convert_qwen2_to_hf
 from .qwen3_5 import convert_qwen3_5_to_hf
 from .qwen3_next import convert_qwen3_next_to_hf
 from .qwen3moe import convert_qwen3moe_to_hf
+
+
+@dataclass(frozen=True)
+class AtomicUpdateGroup:
+    key: str
+    names: tuple[str, ...]
 
 
 # TODO unify w/ `convert_to_hf`
@@ -27,8 +35,8 @@ def convert_to_hf(args, model_name, name, param, quantization_config=None):
     return quantize_params(args, name, converted_named_tensors, quantization_config)
 
 
-def get_atomic_update_group(model_name, name):
-    return None
+def get_atomic_update_groups(model_name, param_infos) -> list[AtomicUpdateGroup]:
+    return []
 
 
 # TODO optimize

--- a/miles/backends/megatron_utils/update_weight/common.py
+++ b/miles/backends/megatron_utils/update_weight/common.py
@@ -34,7 +34,7 @@ def get_named_update_units(param_names: Sequence[str], atomic_update_groups) -> 
     grouped_names: set[str] = set()
     group_keys: set[str] = set()
     ordered_units: list[tuple[int, NamedUpdateUnit]] = []
-    pending_groups: dict[tuple[str, str], tuple[tuple[str, ...], list[str | None]]] = {}
+    pending_groups: dict[tuple[str, str], list[str | None]] = {}
     matched_group_keys: set[str] = set()
 
     for group in atomic_update_groups:
@@ -59,9 +59,7 @@ def get_named_update_units(param_names: Sequence[str], atomic_update_groups) -> 
 
         group, suffix_idx, suffix = matches[0]
         prefix = name[: -len(suffix)]
-        suffixes, names = pending_groups.setdefault(
-            (prefix, group.key), (group.suffixes, [None] * len(group.suffixes))
-        )
+        names = pending_groups.setdefault((prefix, group.key), [None] * len(group.suffixes))
         assert names[suffix_idx] is None, f"Atomic update group {prefix}:{group.key} has duplicate suffix {suffix}"
         names[suffix_idx] = name
         grouped_names.add(name)
@@ -72,10 +70,9 @@ def get_named_update_units(param_names: Sequence[str], atomic_update_groups) -> 
             group.key in matched_group_keys
         ), f"Atomic update group {group.key} references no params matching suffixes {group.suffixes}"
 
-    for (prefix, key), (suffixes, names) in pending_groups.items():
-        missing_suffixes = tuple(suffix for suffix, name in zip(suffixes, names, strict=True) if name is None)
-        assert not missing_suffixes, f"Atomic update group {prefix}:{key} missing suffixes {missing_suffixes}"
-        resolved_names = tuple(name for name in names if name is not None)
+    for (prefix, key), names in pending_groups.items():
+        assert all(names), f"Atomic update group {prefix}:{key} is incomplete: {names}"
+        resolved_names = tuple(names)
         ordered_units.append((min(position[name] for name in resolved_names), NamedUpdateUnit(names=resolved_names)))
 
     for name in param_names:

--- a/miles/backends/megatron_utils/update_weight/common.py
+++ b/miles/backends/megatron_utils/update_weight/common.py
@@ -34,21 +34,49 @@ def get_named_update_units(param_names: Sequence[str], atomic_update_groups) -> 
     grouped_names: set[str] = set()
     group_keys: set[str] = set()
     ordered_units: list[tuple[int, NamedUpdateUnit]] = []
+    pending_groups: dict[tuple[str, str], tuple[tuple[str, ...], list[str | None]]] = {}
+    matched_group_keys: set[str] = set()
 
     for group in atomic_update_groups:
         key = group.key
-        names = group.names
+        suffixes = group.suffixes
         assert key not in group_keys, f"Duplicate atomic update group: {key}"
-        assert names, f"Atomic update group {key} has no params"
-        assert len(set(names)) == len(names), f"Atomic update group {key} contains duplicate params"
+        assert suffixes, f"Atomic update group {key} has no suffixes"
+        assert all(suffixes), f"Atomic update group {key} contains empty suffix"
+        assert len(set(suffixes)) == len(suffixes), f"Atomic update group {key} contains duplicate suffixes"
         group_keys.add(key)
 
-        for name in names:
-            assert name not in grouped_names, f"Param {name} appears in multiple atomic update groups"
-            assert name in position, f"Atomic update group {key} references unknown param {name}"
-            grouped_names.add(name)
+    for name in param_names:
+        matches = [
+            (group, suffix_idx, suffix)
+            for group in atomic_update_groups
+            for suffix_idx, suffix in enumerate(group.suffixes)
+            if name.endswith(suffix)
+        ]
+        assert len(matches) <= 1, f"Param {name} matches multiple atomic update groups"
+        if not matches:
+            continue
 
-        ordered_units.append((min(position[name] for name in names), NamedUpdateUnit(names=tuple(names))))
+        group, suffix_idx, suffix = matches[0]
+        prefix = name[: -len(suffix)]
+        suffixes, names = pending_groups.setdefault(
+            (prefix, group.key), (group.suffixes, [None] * len(group.suffixes))
+        )
+        assert names[suffix_idx] is None, f"Atomic update group {prefix}:{group.key} has duplicate suffix {suffix}"
+        names[suffix_idx] = name
+        grouped_names.add(name)
+        matched_group_keys.add(group.key)
+
+    for group in atomic_update_groups:
+        assert (
+            group.key in matched_group_keys
+        ), f"Atomic update group {group.key} references no params matching suffixes {group.suffixes}"
+
+    for (prefix, key), (suffixes, names) in pending_groups.items():
+        missing_suffixes = tuple(suffix for suffix, name in zip(suffixes, names, strict=True) if name is None)
+        assert not missing_suffixes, f"Atomic update group {prefix}:{key} missing suffixes {missing_suffixes}"
+        resolved_names = tuple(name for name in names if name is not None)
+        ordered_units.append((min(position[name] for name in resolved_names), NamedUpdateUnit(names=resolved_names)))
 
     for name in param_names:
         if name not in grouped_names:

--- a/miles/backends/megatron_utils/update_weight/common.py
+++ b/miles/backends/megatron_utils/update_weight/common.py
@@ -60,7 +60,6 @@ def get_named_update_units(param_names: Sequence[str], atomic_update_groups) -> 
         group, suffix_idx, suffix = matches[0]
         prefix = name[: -len(suffix)]
         names = pending_groups.setdefault((prefix, group.key), [None] * len(group.suffixes))
-        assert names[suffix_idx] is None, f"Atomic update group {prefix}:{group.key} has duplicate suffix {suffix}"
         names[suffix_idx] = name
         grouped_names.add(name)
         matched_group_keys.add(group.key)

--- a/miles/backends/megatron_utils/update_weight/common.py
+++ b/miles/backends/megatron_utils/update_weight/common.py
@@ -1,3 +1,4 @@
+import dataclasses
 import inspect
 import logging
 import re
@@ -15,6 +16,60 @@ from miles.backends.training_utils.parallel import get_parallel_state
 from miles.utils.types import ParamInfo
 
 logger = logging.getLogger(__name__)
+
+
+@dataclasses.dataclass(frozen=True)
+class NamedUpdateUnit:
+    """A set of params that must be transferred and packed together."""
+
+    names: tuple[str, ...]
+
+
+def get_named_update_units(param_names: Sequence[str], atomic_update_groups) -> list[NamedUpdateUnit]:
+    position = {}
+    for i, name in enumerate(param_names):
+        assert name not in position, f"Duplicate param name: {name}"
+        position[name] = i
+
+    grouped_names: set[str] = set()
+    group_keys: set[str] = set()
+    ordered_units: list[tuple[int, NamedUpdateUnit]] = []
+
+    for group in atomic_update_groups:
+        key = group.key
+        names = group.names
+        assert key not in group_keys, f"Duplicate atomic update group: {key}"
+        assert names, f"Atomic update group {key} has no params"
+        assert len(set(names)) == len(names), f"Atomic update group {key} contains duplicate params"
+        group_keys.add(key)
+
+        for name in names:
+            assert name not in grouped_names, f"Param {name} appears in multiple atomic update groups"
+            assert name in position, f"Atomic update group {key} references unknown param {name}"
+            grouped_names.add(name)
+
+        ordered_units.append((min(position[name] for name in names), NamedUpdateUnit(names=tuple(names))))
+
+    for name in param_names:
+        if name not in grouped_names:
+            ordered_units.append((position[name], NamedUpdateUnit(names=(name,))))
+
+    return [unit for _position, unit in sorted(ordered_units, key=lambda item: item[0])]
+
+
+def get_named_value_update_units(
+    named_values: Sequence[tuple[str, object]], atomic_update_groups
+) -> list[list[tuple[str, object]]]:
+    update_units = get_named_update_units([name for name, _value in named_values], atomic_update_groups)
+    value_by_name = dict(named_values)
+    return [[(name, value_by_name[name]) for name in unit.names] for unit in update_units]
+
+
+def assert_named_value_update_units_are_homogeneous(update_units: Sequence[Sequence[tuple[str, object]]]) -> None:
+    for unit in update_units:
+        has_expert = [".experts." in name for name, _value in unit]
+        if any(has_expert) and not all(has_expert):
+            raise RuntimeError(f"Atomic update group spans expert and non-expert params: {[name for name, _ in unit]}")
 
 
 def _gather_with_stride(
@@ -261,7 +316,7 @@ def collect_named_tensors_for_weight_transfer(
     model: Sequence[torch.nn.Module],
     convert_to_global_name: bool = True,
     translate_gpu_to_cpu: bool = False,
-    is_expert: bool = False,
+    is_expert: bool | None = False,
 ) -> Iterator[tuple[str, torch.Tensor]]:
 
     for name, tensor in named_params_and_buffers(
@@ -270,7 +325,7 @@ def collect_named_tensors_for_weight_transfer(
         convert_to_global_name,
         translate_gpu_to_cpu,
     ):
-        if is_expert == (".experts." in name):
+        if is_expert is None or is_expert == (".experts." in name):
             yield name, tensor
 
 

--- a/miles/backends/megatron_utils/update_weight/common.py
+++ b/miles/backends/megatron_utils/update_weight/common.py
@@ -93,13 +93,6 @@ def get_named_value_update_units(
     return [[(name, value_by_name[name]) for name in unit.names] for unit in update_units]
 
 
-def assert_named_value_update_units_are_homogeneous(update_units: Sequence[Sequence[tuple[str, object]]]) -> None:
-    for unit in update_units:
-        has_expert = [".experts." in name for name, _value in unit]
-        if any(has_expert) and not all(has_expert):
-            raise RuntimeError(f"Atomic update group spans expert and non-expert params: {[name for name, _ in unit]}")
-
-
 def _gather_with_stride(
     param_partitions: list[torch.Tensor], partition_dim: int, partition_stride: int
 ) -> torch.Tensor:

--- a/miles/backends/megatron_utils/update_weight/hf_weight_iterator_direct.py
+++ b/miles/backends/megatron_utils/update_weight/hf_weight_iterator_direct.py
@@ -10,7 +10,7 @@ from miles.backends.training_utils.parallel import get_parallel_state
 from miles.utils.distributed_utils import get_gloo_group
 from miles.utils.types import ParamInfo
 
-from ..megatron_to_hf import convert_to_hf
+from ..megatron_to_hf import convert_to_hf, get_atomic_update_group
 from ..sglang import monkey_patch_torch_reductions
 from .common import all_gather_params_async, named_params_and_buffers
 from .hf_weight_iterator_base import HfWeightIteratorBase
@@ -19,7 +19,9 @@ from .hf_weight_iterator_base import HfWeightIteratorBase
 class HfWeightIteratorDirect(HfWeightIteratorBase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.megatron_local_param_info_buckets = _get_megatron_local_param_info_buckets(self.args, self.model)
+        self.megatron_local_param_info_buckets = _get_megatron_local_param_info_buckets(
+            self.args, self.model, self.model_name
+        )
 
     def get_hf_weight_chunks(self, megatron_local_weights, weight_type="base"):
         rank = dist.get_rank()
@@ -108,15 +110,20 @@ def _get_megatron_full_params(
     return gathered_params
 
 
-def _get_megatron_local_param_info_buckets(args: Namespace, model: Sequence[torch.nn.Module]) -> list[list[ParamInfo]]:
+def _get_megatron_local_param_info_buckets(
+    args: Namespace, model: Sequence[torch.nn.Module], model_name: str
+) -> list[list[ParamInfo]]:
     """
     Partition params into buckets ≤ update_weight_buffer_size (with TP replication).
+
+    Model-specific atomic update groups are kept in the same bucket because
+    some rollout loaders must see related tensors in the same load_weights call.
     """
     param_infos = _get_megatron_local_param_infos(args, model)
-    param_info_buckets = [[]]  # Start with one empty bucket
+    param_info_buckets: list[list[ParamInfo]] = [[]]
     buffer_size = 0  # Track current bucket size in bytes
 
-    for info in param_infos:
+    def _full_size(info: ParamInfo) -> int:
         # Expert params use expert-TP size, others use regular-TP size
         if ".experts." in info.name:
             tp_size = get_parallel_state().etp.size
@@ -124,16 +131,51 @@ def _get_megatron_local_param_info_buckets(args: Namespace, model: Sequence[torc
             tp_size = get_parallel_state().tp.size
 
         # Full param size = shard size × TP replicas (all-gather will reconstruct full param)
-        param_size = info.size * tp_size
+        return info.size * tp_size
 
-        # If adding this param exceeds limit AND current bucket has params: start new bucket
-        if buffer_size + param_size > args.update_weight_buffer_size and len(param_info_buckets[-1]) > 0:
+    def _commit_atomic(items: list[ParamInfo], items_size: int):
+        nonlocal buffer_size
+        # If adding this group would exceed the limit AND the current bucket is
+        # non-empty, start a new bucket so the group lands together.
+        if buffer_size + items_size > args.update_weight_buffer_size and len(param_info_buckets[-1]) > 0:
             param_info_buckets.append([])
             buffer_size = 0
+        param_info_buckets[-1].extend(items)
+        buffer_size += items_size
 
-        # Add param to current bucket and update size
-        param_info_buckets[-1].append(info)
-        buffer_size += param_size
+    pending_groups: dict[str, tuple[list[ParamInfo], int, int]] = {}
+
+    for info in param_infos:
+        param_size = _full_size(info)
+        group = get_atomic_update_group(model_name, info.name)
+
+        if group is None:
+            _commit_atomic([info], param_size)
+            continue
+
+        key, expected_count = group
+        if expected_count <= 0:
+            raise RuntimeError(f"Invalid atomic update group size for {key}: {expected_count}")
+        items, items_size, existing_expected_count = pending_groups.pop(key, ([], 0, expected_count))
+        if existing_expected_count != expected_count:
+            raise RuntimeError(
+                f"Inconsistent atomic update group size for {key}: " f"{existing_expected_count} != {expected_count}"
+            )
+        items.append(info)
+        items_size += param_size
+        if len(items) == expected_count:
+            _commit_atomic(items, items_size)
+        elif len(items) > expected_count:
+            raise RuntimeError(f"Atomic update group {key} has more than {expected_count} params")
+        else:
+            pending_groups[key] = (items, items_size, expected_count)
+
+    if pending_groups:
+        group_names = {
+            key: {"expected_count": expected_count, "params": [item.name for item in items]}
+            for key, (items, _items_size, expected_count) in pending_groups.items()
+        }
+        raise RuntimeError(f"Incomplete atomic update groups: {group_names}")
 
     return param_info_buckets
 

--- a/miles/backends/megatron_utils/update_weight/hf_weight_iterator_direct.py
+++ b/miles/backends/megatron_utils/update_weight/hf_weight_iterator_direct.py
@@ -12,14 +12,8 @@ from miles.utils.types import ParamInfo
 
 from ..megatron_to_hf import convert_to_hf, get_atomic_update_groups
 from ..sglang import monkey_patch_torch_reductions
-from .common import all_gather_params_async, named_params_and_buffers
+from .common import NamedUpdateUnit, all_gather_params_async, get_named_update_units, named_params_and_buffers
 from .hf_weight_iterator_base import HfWeightIteratorBase
-
-
-@dataclasses.dataclass(frozen=True)
-class _UpdateUnit:
-    params: tuple[ParamInfo, ...]
-    size: int
 
 
 class HfWeightIteratorDirect(HfWeightIteratorBase):
@@ -126,8 +120,10 @@ def _get_megatron_local_param_info_buckets(
     some rollout loaders must see related tensors in the same load_weights call.
     """
     param_infos = _get_megatron_local_param_infos(args, model)
-    update_units = _get_update_units(model_name, param_infos)
-    return _pack_update_units(args, update_units)
+    param_names = [info.name for info in param_infos]
+    atomic_update_groups = get_atomic_update_groups(args, model_name)
+    update_units = get_named_update_units(param_names, atomic_update_groups)
+    return _pack_update_units(args, param_infos, update_units)
 
 
 def _get_param_full_size(info: ParamInfo) -> int:
@@ -138,55 +134,21 @@ def _get_param_full_size(info: ParamInfo) -> int:
     return info.size * tp_size
 
 
-def _get_update_units(model_name: str, param_infos: list[ParamInfo]) -> list[_UpdateUnit]:
+def _pack_update_units(
+    args: Namespace, param_infos: list[ParamInfo], update_units: list[NamedUpdateUnit]
+) -> list[list[ParamInfo]]:
     by_name = {info.name: info for info in param_infos}
-    position = {info.name: i for i, info in enumerate(param_infos)}
-    grouped_names: set[str] = set()
-    group_keys: set[str] = set()
-    ordered_units: list[tuple[int, _UpdateUnit]] = []
-
-    for group in get_atomic_update_groups(model_name, param_infos):
-        key = group.key
-        names = group.names
-        if key in group_keys:
-            raise RuntimeError(f"Duplicate atomic update group: {key}")
-        if not names:
-            raise RuntimeError(f"Atomic update group {key} has no params")
-        group_keys.add(key)
-
-        params = []
-        for name in names:
-            if name in grouped_names:
-                raise RuntimeError(f"Param {name} appears in multiple atomic update groups")
-            if name not in by_name:
-                raise RuntimeError(f"Atomic update group {key} references unknown param {name}")
-            grouped_names.add(name)
-            params.append(by_name[name])
-
-        ordered_units.append(
-            (
-                min(position[name] for name in names),
-                _UpdateUnit(params=tuple(params), size=sum(_get_param_full_size(param) for param in params)),
-            )
-        )
-
-    for info in param_infos:
-        if info.name not in grouped_names:
-            ordered_units.append((position[info.name], _UpdateUnit(params=(info,), size=_get_param_full_size(info))))
-
-    return [unit for _position, unit in sorted(ordered_units, key=lambda item: item[0])]
-
-
-def _pack_update_units(args: Namespace, update_units: list[_UpdateUnit]) -> list[list[ParamInfo]]:
     param_info_buckets: list[list[ParamInfo]] = [[]]
     buffer_size = 0
 
     for unit in update_units:
-        if buffer_size + unit.size > args.update_weight_buffer_size and param_info_buckets[-1]:
+        params = [by_name[name] for name in unit.names]
+        unit_size = sum(_get_param_full_size(param) for param in params)
+        if buffer_size + unit_size > args.update_weight_buffer_size and param_info_buckets[-1]:
             param_info_buckets.append([])
             buffer_size = 0
-        param_info_buckets[-1].extend(unit.params)
-        buffer_size += unit.size
+        param_info_buckets[-1].extend(params)
+        buffer_size += unit_size
 
     return param_info_buckets
 

--- a/miles/backends/megatron_utils/update_weight/hf_weight_iterator_direct.py
+++ b/miles/backends/megatron_utils/update_weight/hf_weight_iterator_direct.py
@@ -10,10 +10,16 @@ from miles.backends.training_utils.parallel import get_parallel_state
 from miles.utils.distributed_utils import get_gloo_group
 from miles.utils.types import ParamInfo
 
-from ..megatron_to_hf import convert_to_hf, get_atomic_update_group
+from ..megatron_to_hf import convert_to_hf, get_atomic_update_groups
 from ..sglang import monkey_patch_torch_reductions
 from .common import all_gather_params_async, named_params_and_buffers
 from .hf_weight_iterator_base import HfWeightIteratorBase
+
+
+@dataclasses.dataclass(frozen=True)
+class _UpdateUnit:
+    params: tuple[ParamInfo, ...]
+    size: int
 
 
 class HfWeightIteratorDirect(HfWeightIteratorBase):
@@ -120,62 +126,67 @@ def _get_megatron_local_param_info_buckets(
     some rollout loaders must see related tensors in the same load_weights call.
     """
     param_infos = _get_megatron_local_param_infos(args, model)
-    param_info_buckets: list[list[ParamInfo]] = [[]]
-    buffer_size = 0  # Track current bucket size in bytes
+    update_units = _get_update_units(model_name, param_infos)
+    return _pack_update_units(args, update_units)
 
-    def _full_size(info: ParamInfo) -> int:
-        # Expert params use expert-TP size, others use regular-TP size
-        if ".experts." in info.name:
-            tp_size = get_parallel_state().etp.size
-        else:
-            tp_size = get_parallel_state().tp.size
 
-        # Full param size = shard size × TP replicas (all-gather will reconstruct full param)
-        return info.size * tp_size
+def _get_param_full_size(info: ParamInfo) -> int:
+    if ".experts." in info.name:
+        tp_size = get_parallel_state().etp.size
+    else:
+        tp_size = get_parallel_state().tp.size
+    return info.size * tp_size
 
-    def _commit_atomic(items: list[ParamInfo], items_size: int):
-        nonlocal buffer_size
-        # If adding this group would exceed the limit AND the current bucket is
-        # non-empty, start a new bucket so the group lands together.
-        if buffer_size + items_size > args.update_weight_buffer_size and len(param_info_buckets[-1]) > 0:
-            param_info_buckets.append([])
-            buffer_size = 0
-        param_info_buckets[-1].extend(items)
-        buffer_size += items_size
 
-    pending_groups: dict[str, tuple[list[ParamInfo], int, int]] = {}
+def _get_update_units(model_name: str, param_infos: list[ParamInfo]) -> list[_UpdateUnit]:
+    by_name = {info.name: info for info in param_infos}
+    position = {info.name: i for i, info in enumerate(param_infos)}
+    grouped_names: set[str] = set()
+    group_keys: set[str] = set()
+    ordered_units: list[tuple[int, _UpdateUnit]] = []
+
+    for group in get_atomic_update_groups(model_name, param_infos):
+        key = group.key
+        names = group.names
+        if key in group_keys:
+            raise RuntimeError(f"Duplicate atomic update group: {key}")
+        if not names:
+            raise RuntimeError(f"Atomic update group {key} has no params")
+        group_keys.add(key)
+
+        params = []
+        for name in names:
+            if name in grouped_names:
+                raise RuntimeError(f"Param {name} appears in multiple atomic update groups")
+            if name not in by_name:
+                raise RuntimeError(f"Atomic update group {key} references unknown param {name}")
+            grouped_names.add(name)
+            params.append(by_name[name])
+
+        ordered_units.append(
+            (
+                min(position[name] for name in names),
+                _UpdateUnit(params=tuple(params), size=sum(_get_param_full_size(param) for param in params)),
+            )
+        )
 
     for info in param_infos:
-        param_size = _full_size(info)
-        group = get_atomic_update_group(model_name, info.name)
+        if info.name not in grouped_names:
+            ordered_units.append((position[info.name], _UpdateUnit(params=(info,), size=_get_param_full_size(info))))
 
-        if group is None:
-            _commit_atomic([info], param_size)
-            continue
+    return [unit for _position, unit in sorted(ordered_units, key=lambda item: item[0])]
 
-        key, expected_count = group
-        if expected_count <= 0:
-            raise RuntimeError(f"Invalid atomic update group size for {key}: {expected_count}")
-        items, items_size, existing_expected_count = pending_groups.pop(key, ([], 0, expected_count))
-        if existing_expected_count != expected_count:
-            raise RuntimeError(
-                f"Inconsistent atomic update group size for {key}: " f"{existing_expected_count} != {expected_count}"
-            )
-        items.append(info)
-        items_size += param_size
-        if len(items) == expected_count:
-            _commit_atomic(items, items_size)
-        elif len(items) > expected_count:
-            raise RuntimeError(f"Atomic update group {key} has more than {expected_count} params")
-        else:
-            pending_groups[key] = (items, items_size, expected_count)
 
-    if pending_groups:
-        group_names = {
-            key: {"expected_count": expected_count, "params": [item.name for item in items]}
-            for key, (items, _items_size, expected_count) in pending_groups.items()
-        }
-        raise RuntimeError(f"Incomplete atomic update groups: {group_names}")
+def _pack_update_units(args: Namespace, update_units: list[_UpdateUnit]) -> list[list[ParamInfo]]:
+    param_info_buckets: list[list[ParamInfo]] = [[]]
+    buffer_size = 0
+
+    for unit in update_units:
+        if buffer_size + unit.size > args.update_weight_buffer_size and param_info_buckets[-1]:
+            param_info_buckets.append([])
+            buffer_size = 0
+        param_info_buckets[-1].extend(unit.params)
+        buffer_size += unit.size
 
     return param_info_buckets
 

--- a/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/mixin.py
+++ b/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/mixin.py
@@ -57,12 +57,7 @@ class DistBucketedWeightUpdateMixin:
         converted_named_tensors: list[tuple[str, torch.Tensor]] = []
 
         for update_unit in self._get_weight_transfer_update_units(is_expert=False):
-            gathered_params = []
-            unit_size = 0
-            for name, param in update_unit:
-                param = all_gather_param(self.args, name, param)
-                gathered_params.append((name, param))
-                unit_size += param.numel() * param.element_size()
+            gathered_params, unit_size = self._all_gather_update_unit(update_unit)
 
             if not self._is_source:
                 continue
@@ -94,12 +89,7 @@ class DistBucketedWeightUpdateMixin:
         named_tensors: list[tuple[str, torch.Tensor]] = []
 
         for update_unit in self._get_weight_transfer_update_units(is_expert=True):
-            gathered_params = []
-            unit_size = 0
-            for name, param in update_unit:
-                param = all_gather_param(self.args, name, param)
-                gathered_params.append((name, param))
-                unit_size += param.numel() * param.element_size()
+            gathered_params, unit_size = self._all_gather_update_unit(update_unit)
 
             if (
                 buffer_size + unit_size
@@ -113,6 +103,17 @@ class DistBucketedWeightUpdateMixin:
 
         if named_tensors:
             self._update_expert_bucket_weights(named_tensors, update_bucket_weight_func, pbar)
+
+    def _all_gather_update_unit(
+        self, update_unit: list[tuple[str, torch.Tensor]]
+    ) -> tuple[list[tuple[str, torch.Tensor]], int]:
+        gathered_params = []
+        unit_size = 0
+        for name, param in update_unit:
+            param = all_gather_param(self.args, name, param)
+            gathered_params.append((name, param))
+            unit_size += param.numel() * param.element_size()
+        return gathered_params, unit_size
 
     def _get_weight_transfer_update_units(self, is_expert: bool) -> list[list[tuple[str, torch.Tensor]]]:
         named_tensors = list(collect_named_tensors_for_weight_transfer(self.args, self.model, is_expert=None))

--- a/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/mixin.py
+++ b/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/mixin.py
@@ -9,8 +9,14 @@ from miles.backends.training_utils.parallel import get_parallel_state
 from miles.utils.distributed_utils import get_gloo_group
 from miles.utils.timer import timer
 
-from ...megatron_to_hf import convert_to_hf
-from ..common import all_gather_param, collect_named_tensors_for_weight_transfer, post_process_weights
+from ...megatron_to_hf import convert_to_hf, get_atomic_update_groups
+from ..common import (
+    all_gather_param,
+    assert_named_value_update_units_are_homogeneous,
+    collect_named_tensors_for_weight_transfer,
+    get_named_value_update_units,
+    post_process_weights,
+)
 
 
 class DistBucketedWeightUpdateMixin:
@@ -45,19 +51,27 @@ class DistBucketedWeightUpdateMixin:
         buffer_size = 0
         converted_named_tensors: list[tuple[str, torch.Tensor]] = []
 
-        for name, param in collect_named_tensors_for_weight_transfer(self.args, self.model, is_expert=False):
-            param = all_gather_param(self.args, name, param)
+        for update_unit in self._get_weight_transfer_update_units(is_expert=False):
+            gathered_params = []
+            unit_size = 0
+            for name, param in update_unit:
+                param = all_gather_param(self.args, name, param)
+                gathered_params.append((name, param))
+                unit_size += param.numel() * param.element_size()
+
             if not self._is_source:
                 continue
 
-            param_size = param.numel() * param.element_size()
-            if buffer_size + param_size > self.args.update_weight_buffer_size:
+            if buffer_size + unit_size > self.args.update_weight_buffer_size and converted_named_tensors:
                 update_bucket_weight_func(converted_named_tensors, pbar)
                 converted_named_tensors = []
                 buffer_size = 0
 
-            converted_named_tensors += convert_to_hf(self.args, self.model_name, name, param, self.quantization_config)
-            buffer_size += param_size
+            for name, param in gathered_params:
+                converted_named_tensors += convert_to_hf(
+                    self.args, self.model_name, name, param, self.quantization_config
+                )
+            buffer_size += unit_size
 
         if converted_named_tensors:
             update_bucket_weight_func(converted_named_tensors, pbar)
@@ -74,21 +88,33 @@ class DistBucketedWeightUpdateMixin:
         buffer_size = 0
         named_tensors: list[tuple[str, torch.Tensor]] = []
 
-        for name, param in collect_named_tensors_for_weight_transfer(self.args, self.model, is_expert=True):
-            param = all_gather_param(self.args, name, param)
-            param_size = param.numel() * param.element_size()
+        for update_unit in self._get_weight_transfer_update_units(is_expert=True):
+            gathered_params = []
+            unit_size = 0
+            for name, param in update_unit:
+                param = all_gather_param(self.args, name, param)
+                gathered_params.append((name, param))
+                unit_size += param.numel() * param.element_size()
+
             if (
-                buffer_size + param_size
+                buffer_size + unit_size
             ) * get_parallel_state().ep.size > self.args.update_weight_buffer_size and named_tensors:
                 self._update_expert_bucket_weights(named_tensors, update_bucket_weight_func, pbar)
                 named_tensors = []
                 buffer_size = 0
 
-            named_tensors.append((name, param))
-            buffer_size += param_size
+            named_tensors.extend(gathered_params)
+            buffer_size += unit_size
 
         if named_tensors:
             self._update_expert_bucket_weights(named_tensors, update_bucket_weight_func, pbar)
+
+    def _get_weight_transfer_update_units(self, is_expert: bool) -> list[list[tuple[str, torch.Tensor]]]:
+        named_tensors = list(collect_named_tensors_for_weight_transfer(self.args, self.model, is_expert=None))
+        atomic_update_groups = get_atomic_update_groups(self.args, self.model_name)
+        update_units = get_named_value_update_units(named_tensors, atomic_update_groups)
+        assert_named_value_update_units_are_homogeneous(update_units)
+        return [unit for unit in update_units if (".experts." in unit[0][0]) == is_expert]
 
     def _update_expert_bucket_weights(
         self,

--- a/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/mixin.py
+++ b/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/mixin.py
@@ -12,7 +12,6 @@ from miles.utils.timer import timer
 from ...megatron_to_hf import convert_to_hf, get_atomic_update_groups
 from ..common import (
     all_gather_param,
-    assert_named_value_update_units_are_homogeneous,
     collect_named_tensors_for_weight_transfer,
     get_named_value_update_units,
     post_process_weights,
@@ -119,7 +118,8 @@ class DistBucketedWeightUpdateMixin:
         named_tensors = list(collect_named_tensors_for_weight_transfer(self.args, self.model, is_expert=None))
         atomic_update_groups = get_atomic_update_groups(self.args, self.model_name)
         update_units = get_named_value_update_units(named_tensors, atomic_update_groups)
-        assert_named_value_update_units_are_homogeneous(update_units)
+        for unit in update_units:
+            assert len({".experts." in name for name, _tensor in unit}) == 1, [name for name, _tensor in unit]
         return [unit for unit in update_units if _is_expert_update_unit(unit) == is_expert]
 
     def _update_expert_bucket_weights(

--- a/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/mixin.py
+++ b/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/mixin.py
@@ -19,6 +19,12 @@ from ..common import (
 )
 
 
+def _is_expert_update_unit(update_unit: list[tuple[str, torch.Tensor]]) -> bool:
+    assert update_unit, "Update unit must contain at least one param"
+    name, _tensor = update_unit[0]
+    return ".experts." in name
+
+
 class DistBucketedWeightUpdateMixin:
     """Mixin providing bucketed TP/EP all-gather, HF format conversion, pre-process/post-process
         and the weight updating pipeline.
@@ -114,7 +120,7 @@ class DistBucketedWeightUpdateMixin:
         atomic_update_groups = get_atomic_update_groups(self.args, self.model_name)
         update_units = get_named_value_update_units(named_tensors, atomic_update_groups)
         assert_named_value_update_units_are_homogeneous(update_units)
-        return [unit for unit in update_units if (".experts." in unit[0][0]) == is_expert]
+        return [unit for unit in update_units if _is_expert_update_unit(unit) == is_expert]
 
     def _update_expert_bucket_weights(
         self,

--- a/tests/fast/backends/megatron_utils/test_hf_weight_iterator_direct.py
+++ b/tests/fast/backends/megatron_utils/test_hf_weight_iterator_direct.py
@@ -108,32 +108,32 @@ def _param(name: str, size: int) -> ParamInfo:
 def test_atomic_group_is_single_update_unit_and_packed_together(direct_module, monkeypatch):
     from miles.backends.megatron_utils.megatron_to_hf import AtomicUpdateGroup
 
-    params = [_param("a", 4), _param("b", 4), _param("c", 4)]
+    params = [_param("layer.a", 4), _param("layer.b", 4), _param("layer.c", 4)]
     monkeypatch.setattr(direct_module, "_get_param_full_size", lambda info: info.size)
 
     update_units = direct_module.get_named_update_units(
-        [param.name for param in params], [AtomicUpdateGroup("pair", ("b", "c"))]
+        [param.name for param in params], [AtomicUpdateGroup("pair", (".b", ".c"))]
     )
-    assert [unit.names for unit in update_units] == [("a",), ("b", "c")]
+    assert [unit.names for unit in update_units] == [("layer.a",), ("layer.b", "layer.c")]
 
     buckets = direct_module._pack_update_units(Namespace(update_weight_buffer_size=6), params, update_units)
-    assert [[param.name for param in bucket] for bucket in buckets] == [["a"], ["b", "c"]]
+    assert [[param.name for param in bucket] for bucket in buckets] == [["layer.a"], ["layer.b", "layer.c"]]
 
 
 def test_atomic_group_specs_raise_explicit_errors(direct_module, monkeypatch):
     from miles.backends.megatron_utils.megatron_to_hf import AtomicUpdateGroup
 
-    params = [_param("a", 4), _param("b", 4)]
+    params = [_param("layer.a", 4), _param("layer.b", 4)]
 
     invalid_groups = [
-        ([AtomicUpdateGroup("empty", ())], "Atomic update group empty has no params"),
-        ([AtomicUpdateGroup("missing", ("c",))], "Atomic update group missing references unknown param c"),
+        ([AtomicUpdateGroup("empty", ())], "Atomic update group empty has no suffixes"),
+        ([AtomicUpdateGroup("missing", (".c",))], "Atomic update group missing references no params"),
         (
-            [AtomicUpdateGroup("left", ("a",)), AtomicUpdateGroup("right", ("a",))],
-            "Param a appears in multiple atomic update groups",
+            [AtomicUpdateGroup("left", (".a",)), AtomicUpdateGroup("right", (".a",))],
+            "Param layer.a matches multiple atomic update groups",
         ),
         (
-            [AtomicUpdateGroup("duplicate", ("a",)), AtomicUpdateGroup("duplicate", ("b",))],
+            [AtomicUpdateGroup("duplicate", (".a",)), AtomicUpdateGroup("duplicate", (".b",))],
             "Duplicate atomic update group: duplicate",
         ),
     ]
@@ -198,7 +198,7 @@ def test_distributed_expert_update_units_are_packed_together(direct_module, monk
     monkeypatch.setattr(
         mixin,
         "get_atomic_update_groups",
-        lambda args, model_name: [AtomicUpdateGroup("pair", ("module.experts.b", "module.experts.c"))],
+        lambda args, model_name: [AtomicUpdateGroup("pair", (".b", ".c"))],
     )
     monkeypatch.setattr(mixin, "all_gather_param", lambda args, name, param: param)
     monkeypatch.setattr(mixin, "get_parallel_state", lambda: SimpleNamespace(ep=SimpleNamespace(size=1)))
@@ -218,7 +218,7 @@ def test_distributed_atomic_group_cannot_span_expert_and_non_expert(direct_modul
     from miles.backends.megatron_utils.update_weight.update_weight_from_distributed import mixin
 
     updater = _distributed_updater(mixin)
-    named_tensors = [("a", _tensor(4)), ("module.experts.b", _tensor(4))]
+    named_tensors = [("module.a", _tensor(4)), ("module.experts.b", _tensor(4))]
     monkeypatch.setattr(mixin.dist, "get_rank", lambda: 0)
     monkeypatch.setattr(
         mixin, "collect_named_tensors_for_weight_transfer", lambda *args, **kwargs: iter(named_tensors)
@@ -226,7 +226,7 @@ def test_distributed_atomic_group_cannot_span_expert_and_non_expert(direct_modul
     monkeypatch.setattr(
         mixin,
         "get_atomic_update_groups",
-        lambda args, model_name: [AtomicUpdateGroup("mixed", ("a", "module.experts.b"))],
+        lambda args, model_name: [AtomicUpdateGroup("mixed", (".a", ".experts.b"))],
     )
 
     with pytest.raises(RuntimeError, match="spans expert and non-expert params"):

--- a/tests/fast/backends/megatron_utils/test_hf_weight_iterator_direct.py
+++ b/tests/fast/backends/megatron_utils/test_hf_weight_iterator_direct.py
@@ -1,0 +1,144 @@
+import sys
+import types
+from argparse import Namespace
+
+from tests.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=60, suite="stage-a-cpu", labels=[])
+
+import pytest
+import torch
+
+from miles.utils.types import ParamInfo
+
+
+def _install_import_stubs(monkeypatch):
+    triton = types.ModuleType("triton")
+    triton.jit = lambda fn: fn
+    triton.cdiv = lambda x, y: (x + y - 1) // y
+    tl = types.ModuleType("triton.language")
+    tl.constexpr = int
+    monkeypatch.setitem(sys.modules, "triton", triton)
+    monkeypatch.setitem(sys.modules, "triton.language", tl)
+
+    for name in [
+        "sglang",
+        "sglang.srt",
+        "sglang.srt.utils",
+        "sglang.srt.utils.patch_torch",
+        "sglang.srt.weight_sync",
+        "sglang.srt.weight_sync.tensor_bucket",
+        "sglang.srt.layers",
+        "sglang.srt.layers.quantization",
+        "sglang.srt.layers.quantization.fp8_utils",
+    ]:
+        monkeypatch.setitem(sys.modules, name, types.ModuleType(name))
+
+    sys.modules["sglang.srt.utils"].MultiprocessingSerializer = object
+    sys.modules["sglang.srt.utils.patch_torch"].monkey_patch_torch_reductions = lambda: None
+    sys.modules["sglang.srt.weight_sync.tensor_bucket"].FlattenedTensorBucket = object
+    fp8_utils = sys.modules["sglang.srt.layers.quantization.fp8_utils"]
+    fp8_utils.mxfp8_group_quantize = lambda *args, **kwargs: None
+    fp8_utils.quant_weight_ue8m0 = lambda *args, **kwargs: None
+    fp8_utils.transform_scale_ue8m0 = lambda x, **kwargs: x
+
+    ray = types.ModuleType("ray")
+    ray_actor = types.ModuleType("ray.actor")
+    ray_actor.ActorHandle = object
+    monkeypatch.setitem(sys.modules, "ray", ray)
+    monkeypatch.setitem(sys.modules, "ray.actor", ray_actor)
+
+    for name in [
+        "megatron",
+        "megatron.core",
+        "megatron.core.transformer",
+        "megatron.core.transformer.transformer_layer",
+    ]:
+        monkeypatch.setitem(sys.modules, name, types.ModuleType(name))
+    sys.modules["megatron.core.transformer.transformer_layer"].get_transformer_layer_offset = lambda *args: 0
+
+
+@pytest.fixture
+def direct_module(monkeypatch):
+    module_names = [
+        "miles.backends.megatron_utils.sglang",
+        "miles.backends.megatron_utils.megatron_to_hf",
+        "miles.backends.megatron_utils.megatron_to_hf.processors",
+        "miles.backends.megatron_utils.megatron_to_hf.processors.quantizer_fp8",
+        "miles.backends.megatron_utils.megatron_to_hf.processors.quantizer_mxfp8",
+        "miles.backends.megatron_utils.update_weight.common",
+        "miles.backends.megatron_utils.update_weight.hf_weight_iterator_direct",
+    ]
+    saved_modules = {name: sys.modules.get(name) for name in module_names}
+    for name in module_names:
+        sys.modules.pop(name, None)
+
+    _install_import_stubs(monkeypatch)
+
+    from miles.backends.megatron_utils.update_weight import hf_weight_iterator_direct
+
+    yield hf_weight_iterator_direct
+
+    for name, module in saved_modules.items():
+        if module is None:
+            sys.modules.pop(name, None)
+        else:
+            sys.modules[name] = module
+
+
+def _param(name: str, size: int) -> ParamInfo:
+    return ParamInfo(
+        name=name,
+        dtype=torch.float32,
+        shape=torch.Size([size]),
+        attrs={},
+        size=size,
+        src_rank=0,
+    )
+
+
+def test_atomic_group_is_single_update_unit_and_packed_together(direct_module, monkeypatch):
+    from miles.backends.megatron_utils.megatron_to_hf import AtomicUpdateGroup
+
+    params = [_param("a", 4), _param("b", 4), _param("c", 4)]
+    monkeypatch.setattr(direct_module, "_get_param_full_size", lambda info: info.size)
+    monkeypatch.setattr(
+        direct_module,
+        "get_atomic_update_groups",
+        lambda model_name, param_infos: [AtomicUpdateGroup("pair", ("b", "c"))],
+    )
+
+    update_units = direct_module._get_update_units("test-model", params)
+    assert [[param.name for param in unit.params] for unit in update_units] == [["a"], ["b", "c"]]
+
+    buckets = direct_module._pack_update_units(Namespace(update_weight_buffer_size=6), update_units)
+    assert [[param.name for param in bucket] for bucket in buckets] == [["a"], ["b", "c"]]
+
+
+def test_atomic_group_specs_raise_explicit_errors(direct_module, monkeypatch):
+    from miles.backends.megatron_utils.megatron_to_hf import AtomicUpdateGroup
+
+    params = [_param("a", 4), _param("b", 4)]
+    monkeypatch.setattr(direct_module, "_get_param_full_size", lambda info: info.size)
+
+    invalid_groups = [
+        ([AtomicUpdateGroup("empty", ())], "Atomic update group empty has no params"),
+        ([AtomicUpdateGroup("missing", ("c",))], "Atomic update group missing references unknown param c"),
+        (
+            [AtomicUpdateGroup("left", ("a",)), AtomicUpdateGroup("right", ("a",))],
+            "Param a appears in multiple atomic update groups",
+        ),
+        (
+            [AtomicUpdateGroup("duplicate", ("a",)), AtomicUpdateGroup("duplicate", ("b",))],
+            "Duplicate atomic update group: duplicate",
+        ),
+    ]
+
+    for groups, error in invalid_groups:
+        monkeypatch.setattr(
+            direct_module,
+            "get_atomic_update_groups",
+            lambda model_name, param_infos, groups=groups: groups,
+        )
+        with pytest.raises(RuntimeError, match=error):
+            direct_module._get_update_units("test-model", params)

--- a/tests/fast/backends/megatron_utils/test_hf_weight_iterator_direct.py
+++ b/tests/fast/backends/megatron_utils/test_hf_weight_iterator_direct.py
@@ -229,5 +229,5 @@ def test_distributed_atomic_group_cannot_span_expert_and_non_expert(direct_modul
         lambda args, model_name: [AtomicUpdateGroup("mixed", (".a", ".experts.b"))],
     )
 
-    with pytest.raises(RuntimeError, match="spans expert and non-expert params"):
+    with pytest.raises(AssertionError, match="module.a"):
         updater._get_weight_transfer_update_units(is_expert=False)

--- a/tests/fast/backends/megatron_utils/test_hf_weight_iterator_direct.py
+++ b/tests/fast/backends/megatron_utils/test_hf_weight_iterator_direct.py
@@ -1,6 +1,7 @@
 import sys
 import types
 from argparse import Namespace
+from types import SimpleNamespace
 
 from tests.ci.ci_register import register_cpu_ci
 
@@ -44,9 +45,15 @@ def _install_import_stubs(monkeypatch):
 
     ray = types.ModuleType("ray")
     ray_actor = types.ModuleType("ray.actor")
+    ray_util = types.ModuleType("ray.util")
+    ray_scheduling = types.ModuleType("ray.util.scheduling_strategies")
+    ray.remote = lambda *args, **kwargs: args[0] if args and callable(args[0]) and not kwargs else lambda obj: obj
     ray_actor.ActorHandle = object
+    ray_scheduling.NodeAffinitySchedulingStrategy = object
     monkeypatch.setitem(sys.modules, "ray", ray)
     monkeypatch.setitem(sys.modules, "ray.actor", ray_actor)
+    monkeypatch.setitem(sys.modules, "ray.util", ray_util)
+    monkeypatch.setitem(sys.modules, "ray.util.scheduling_strategies", ray_scheduling)
 
     for name in [
         "megatron",
@@ -68,6 +75,7 @@ def direct_module(monkeypatch):
         "miles.backends.megatron_utils.megatron_to_hf.processors.quantizer_mxfp8",
         "miles.backends.megatron_utils.update_weight.common",
         "miles.backends.megatron_utils.update_weight.hf_weight_iterator_direct",
+        "miles.backends.megatron_utils.update_weight.update_weight_from_distributed.mixin",
     ]
     saved_modules = {name: sys.modules.get(name) for name in module_names}
     for name in module_names:
@@ -102,16 +110,13 @@ def test_atomic_group_is_single_update_unit_and_packed_together(direct_module, m
 
     params = [_param("a", 4), _param("b", 4), _param("c", 4)]
     monkeypatch.setattr(direct_module, "_get_param_full_size", lambda info: info.size)
-    monkeypatch.setattr(
-        direct_module,
-        "get_atomic_update_groups",
-        lambda model_name, param_infos: [AtomicUpdateGroup("pair", ("b", "c"))],
+
+    update_units = direct_module.get_named_update_units(
+        [param.name for param in params], [AtomicUpdateGroup("pair", ("b", "c"))]
     )
+    assert [unit.names for unit in update_units] == [("a",), ("b", "c")]
 
-    update_units = direct_module._get_update_units("test-model", params)
-    assert [[param.name for param in unit.params] for unit in update_units] == [["a"], ["b", "c"]]
-
-    buckets = direct_module._pack_update_units(Namespace(update_weight_buffer_size=6), update_units)
+    buckets = direct_module._pack_update_units(Namespace(update_weight_buffer_size=6), params, update_units)
     assert [[param.name for param in bucket] for bucket in buckets] == [["a"], ["b", "c"]]
 
 
@@ -119,7 +124,6 @@ def test_atomic_group_specs_raise_explicit_errors(direct_module, monkeypatch):
     from miles.backends.megatron_utils.megatron_to_hf import AtomicUpdateGroup
 
     params = [_param("a", 4), _param("b", 4)]
-    monkeypatch.setattr(direct_module, "_get_param_full_size", lambda info: info.size)
 
     invalid_groups = [
         ([AtomicUpdateGroup("empty", ())], "Atomic update group empty has no params"),
@@ -135,10 +139,95 @@ def test_atomic_group_specs_raise_explicit_errors(direct_module, monkeypatch):
     ]
 
     for groups, error in invalid_groups:
-        monkeypatch.setattr(
-            direct_module,
-            "get_atomic_update_groups",
-            lambda model_name, param_infos, groups=groups: groups,
-        )
-        with pytest.raises(RuntimeError, match=error):
-            direct_module._get_update_units("test-model", params)
+        with pytest.raises(AssertionError, match=error):
+            direct_module.get_named_update_units([param.name for param in params], groups)
+
+
+def _tensor(size: int) -> torch.Tensor:
+    return torch.empty(size, dtype=torch.uint8)
+
+
+def _distributed_updater(mixin_module):
+    updater = mixin_module.DistBucketedWeightUpdateMixin()
+    updater.args = Namespace(update_weight_buffer_size=6)
+    updater.model = []
+    updater.model_name = "test-model"
+    updater.quantization_config = None
+    updater._is_source = True
+    return updater
+
+
+def test_distributed_non_expert_update_units_are_packed_together(direct_module, monkeypatch):
+    from miles.backends.megatron_utils.megatron_to_hf import AtomicUpdateGroup
+    from miles.backends.megatron_utils.update_weight.update_weight_from_distributed import mixin
+
+    updater = _distributed_updater(mixin)
+    named_tensors = [("a", _tensor(4)), ("b", _tensor(4)), ("c", _tensor(4))]
+    monkeypatch.setattr(mixin.dist, "get_rank", lambda: 0)
+    monkeypatch.setattr(
+        mixin, "collect_named_tensors_for_weight_transfer", lambda *args, **kwargs: iter(named_tensors)
+    )
+    monkeypatch.setattr(
+        mixin, "get_atomic_update_groups", lambda args, model_name: [AtomicUpdateGroup("pair", ("b", "c"))]
+    )
+    monkeypatch.setattr(mixin, "all_gather_param", lambda args, name, param: param)
+    monkeypatch.setattr(
+        mixin, "convert_to_hf", lambda args, model_name, name, param, quantization_config: [(name, param)]
+    )
+
+    buckets = []
+    updater._gather_and_update_non_expert_weights(lambda tensors, pbar: buckets.append([name for name, _ in tensors]))
+
+    assert buckets == [["a"], ["b", "c"]]
+
+
+def test_distributed_expert_update_units_are_packed_together(direct_module, monkeypatch):
+    from miles.backends.megatron_utils.megatron_to_hf import AtomicUpdateGroup
+    from miles.backends.megatron_utils.update_weight.update_weight_from_distributed import mixin
+
+    updater = _distributed_updater(mixin)
+    named_tensors = [
+        ("module.experts.a", _tensor(4)),
+        ("module.experts.b", _tensor(4)),
+        ("module.experts.c", _tensor(4)),
+    ]
+    monkeypatch.setattr(mixin.dist, "get_rank", lambda: 0)
+    monkeypatch.setattr(
+        mixin, "collect_named_tensors_for_weight_transfer", lambda *args, **kwargs: iter(named_tensors)
+    )
+    monkeypatch.setattr(
+        mixin,
+        "get_atomic_update_groups",
+        lambda args, model_name: [AtomicUpdateGroup("pair", ("module.experts.b", "module.experts.c"))],
+    )
+    monkeypatch.setattr(mixin, "all_gather_param", lambda args, name, param: param)
+    monkeypatch.setattr(mixin, "get_parallel_state", lambda: SimpleNamespace(ep=SimpleNamespace(size=1)))
+
+    buckets = []
+    updater._update_expert_bucket_weights = lambda tensors, update_func, pbar: buckets.append(
+        [name for name, _ in tensors]
+    )
+
+    updater._gather_and_update_expert_weights(lambda tensors, pbar: None)
+
+    assert buckets == [["module.experts.a"], ["module.experts.b", "module.experts.c"]]
+
+
+def test_distributed_atomic_group_cannot_span_expert_and_non_expert(direct_module, monkeypatch):
+    from miles.backends.megatron_utils.megatron_to_hf import AtomicUpdateGroup
+    from miles.backends.megatron_utils.update_weight.update_weight_from_distributed import mixin
+
+    updater = _distributed_updater(mixin)
+    named_tensors = [("a", _tensor(4)), ("module.experts.b", _tensor(4))]
+    monkeypatch.setattr(mixin.dist, "get_rank", lambda: 0)
+    monkeypatch.setattr(
+        mixin, "collect_named_tensors_for_weight_transfer", lambda *args, **kwargs: iter(named_tensors)
+    )
+    monkeypatch.setattr(
+        mixin,
+        "get_atomic_update_groups",
+        lambda args, model_name: [AtomicUpdateGroup("mixed", ("a", "module.experts.b"))],
+    )
+
+    with pytest.raises(RuntimeError, match="spans expert and non-expert params"):
+        updater._get_weight_transfer_update_units(is_expert=False)


### PR DESCRIPTION
## Summary

Add generic infrastructure for atomic weight update groups in the direct Megatron-to-HF weight iterator.

The iterator now asks `megatron_to_hf.get_atomic_update_groups(model_name, param_infos)` for exact `AtomicUpdateGroup(key, names)` specs. It first builds indivisible update units from those specs, validates group invariants explicitly, and then packs the units into `update_weight_buffer_size` buckets.

The default implementation returns no groups, so existing models keep the same bucket behavior.

This PR intentionally does not add any DeepSeek-V4-specific grouping keys.

## Validation

- `python -m compileall miles/backends/megatron_utils/update_weight/hf_weight_iterator_direct.py miles/backends/megatron_utils/megatron_to_hf/__init__.py`
- `python -m pytest --confcutdir=tests/fast/backends/megatron_utils tests/fast/backends/megatron_utils/test_hf_weight_iterator_direct.py -q`
- `pre-commit run --files miles/backends/megatron_utils/megatron_to_hf/__init__.py miles/backends/megatron_utils/update_weight/hf_weight_iterator_direct.py`
- `pre-commit run --all-files`

Note: running the test through the repository root conftest in this local environment fails before test collection because local `sglang` is not installed (`ModuleNotFoundError: No module named 'sglang'`). The targeted command above isolates this pure unit test from that global fixture import chain.
