### PR TITLE
Fix geo3k_vlm Megatron crash on non-tensor multimodal field

### DIFF
--- a/examples/geo3k_vlm/rollout.py
+++ b/examples/geo3k_vlm/rollout.py
@@ -1,0 +1,19 @@
+"""Single-turn geo3k VLM rollout that keeps multimodal_train_inputs tensor-only."""
+
+import torch
+
+from miles.rollout.sglang_rollout import generate as _generate
+from miles.utils.types import Sample
+
+
+async def generate(args, sample: Sample, sampling_params: dict) -> Sample:
+    sample = await _generate(args, sample, sampling_params)
+    # Qwen3-VL's processor returns mm_token_type_ids as a Python list (text-modality
+    # fields use return_tensors=None). The Megatron data path treats every
+    # multimodal_train_inputs value as a torch tensor, so a list-valued field raises
+    # "AttributeError: 'list' object has no attribute 'to'". Drop non-tensor fields,
+    # matching the multi-turn geo3k example's merge behavior.
+    mm = sample.multimodal_train_inputs
+    if mm:
+        sample.multimodal_train_inputs = {k: v for k, v in mm.items() if isinstance(v, torch.Tensor)} or None
+    return sample

--- a/examples/geo3k_vlm/run_geo3k_vlm.sh
+++ b/examples/geo3k_vlm/run_geo3k_vlm.sh
@@ -89,6 +89,7 @@ ROLLOUT_ARGS=(
    --apply-chat-template
    --rollout-shuffle
    --rm-type math
+   --custom-generate-function-path examples.geo3k_vlm.rollout.generate
    --num-rollout 3000
    --rollout-batch-size 64
    --n-samples-per-prompt 8


### PR DESCRIPTION
## Summary

Fixes the `geo3k_vlm` single-turn example crashing on the Megatron backend with:

```
AttributeError: 'list' object has no attribute 'to'
```

Qwen3-VL's processor returns `mm_token_type_ids` as a Python **list** (text-modality fields are produced with `return_tensors=None`). The Megatron data path treats every value in `multimodal_train_inputs` as a `torch.Tensor` (calls `.to()`, `.size(0)`, `torch.cat`), so a list-valued field crashes. FSDP tolerates the list, which is why only Megatron was affected. The existing `geo3k_vlm_multi_turn` example survives because its merge step keeps only `torch.Tensor` values.

## Fix (contained entirely to `examples/geo3k_vlm/`)

- **`rollout.py`** (new): a single-turn generate that wraps the framework's `sglang_rollout.generate` and drops non-tensor `multimodal_train_inputs` fields. The 3-arg signature makes it work in both the legacy and experimental rollout paths.
- **`run_geo3k_vlm.sh`** (+1 line): points `--custom-generate-function-path` at the new function.

No changes to `miles/` core or sglang.

## Why not a launch-script-only change

A launch-script-only fix isn't achievable: the list-valued field is injected by the framework's processor in every rollout path regardless of flags, and no built-in single-turn generate filters non-tensor fields. The minimal contained fix is therefore a small example-local `rollout.py` plus the one-line flag — still touching nothing in `miles/` or sglang.

## Test plan

- [x] Megatron backend (`Qwen3-VL-8B-Instruct`, `num-rollout=3`, TP=4) on an 8×H200 devbox: ray job **succeeded**, 6 `train/step` iterations logged, zero errors (previously crashed at the first data batch).
- [ ] FSDP backend unaffected (the dropped field was already unused there).
