### PR TITLE
tau-bench: let user simulator use any litellm provider (e.g. DeepSeek)

### DIFF
--- a/examples/tau-bench/README.md
+++ b/examples/tau-bench/README.md
@@ -42,27 +42,31 @@ PYTHONPATH=/root/Megatron-LM python tools/convert_hf_to_torch_dist.py \
 
 ## Running the Script
 
-You need to configure your litellm API in `generate_with_tau.py` for user simulation:
+The user simulator runs through litellm, so any litellm-supported provider works.
+Select the provider/model and supply the matching key via environment variables —
+no need to edit `generate_with_tau.py`. The launch script forwards these to the
+ray workers.
 
-```python
-TAU_CONFIGS = {
-    "env": "retail",  # Select between ["retail", "airline"]
-    "agent": "tool-calling",  # Select between ["tool-calling", "act", "react", "few-shot"], only tool-calling implemented for now
-    "user_model": "gemini-2.0-flash-lite",  # Cheap Model for user simulator
-    "user_model_provider": "gemini",
-    "task_split": "train",  # Select between ["train", "test", "dev"] for retail, ["test"] for airline
-    "user_strategy": "llm",  # Select between ["llm", "react", "verify", "reflection"]
-    "model_provider": "auto_router", # Unused, required
-    "model": "qwen3-4b", # Unused, reqired
-}
-# Replace with your actual API key for user sim    
-GEMINI_API_KEY = "YOUR KEY" 
-```
-
-And run:
-
+**DeepSeek:**
 
 ```bash
+export TAU_USER_MODEL_PROVIDER=deepseek
+export TAU_USER_MODEL=deepseek-chat
+export DEEPSEEK_API_KEY=sk-...
+
 cd /root/miles
 bash examples/tau-bench/run_qwen3_4B.sh
 ```
+
+**Gemini (default):**
+
+```bash
+export TAU_USER_MODEL_PROVIDER=gemini          # optional, this is the default
+export TAU_USER_MODEL=gemini-2.5-flash-lite    # optional, this is the default
+export GEMINI_API_KEY=...
+
+cd /root/miles
+bash examples/tau-bench/run_qwen3_4B.sh
+```
+
+If the matching `*_API_KEY` is not set, the run fails fast at startup with a clear error.

--- a/examples/tau-bench/generate_with_tau.py
+++ b/examples/tau-bench/generate_with_tau.py
@@ -19,20 +19,37 @@ from miles.utils.types import Sample
 # Set up logger for this module
 logger = logging.getLogger(__name__)
 
+# User simulator configuration.
+# tau-bench drives the user simulator through litellm, so any litellm-supported
+# provider works. Pick the provider/model with the env vars below and supply the
+# matching key through that provider's own *_API_KEY env var:
+#   Gemini  : TAU_USER_MODEL_PROVIDER=gemini   TAU_USER_MODEL=gemini-2.5-flash-lite  GEMINI_API_KEY=...
+#   DeepSeek: TAU_USER_MODEL_PROVIDER=deepseek TAU_USER_MODEL=deepseek-chat          DEEPSEEK_API_KEY=...
+# Defaults preserve the original Gemini behavior.
+USER_MODEL_PROVIDER = os.environ.get("TAU_USER_MODEL_PROVIDER", "gemini")
+USER_MODEL = os.environ.get("TAU_USER_MODEL", "gemini-2.5-flash-lite")
+
+# litellm reads the provider's own *_API_KEY env var; just confirm it is set so
+# the run fails fast with a clear message instead of deep inside a rollout.
+_PROVIDER_KEY_ENV = {"gemini": "GEMINI_API_KEY", "deepseek": "DEEPSEEK_API_KEY"}
+_key_env = _PROVIDER_KEY_ENV.get(USER_MODEL_PROVIDER, f"{USER_MODEL_PROVIDER.upper()}_API_KEY")
+if not os.environ.get(_key_env):
+    raise RuntimeError(
+        f"tau-bench user simulator needs {_key_env} set for provider "
+        f"'{USER_MODEL_PROVIDER}'. Export it before launching the run."
+    )
+
 # Tau-bench configuration
 TAU_CONFIGS = {
     "env": "retail",  # Select between ["retail", "airline"]
     "agent": "tool-calling",  # Select between ["tool-calling", "act", "react", "few-shot"]
-    "user_model": "gemini-2.5-flash-lite",  # Cheap Model for user simulator
+    "user_model": USER_MODEL,  # Cheap model for the user simulator
     "task_split": "train",  # Select between ["train", "test", "dev"] for retail
     "user_strategy": "llm",  # Select between ["llm", "react", "verify", "reflection"]
     "model_provider": "auto_router",  # Unused, required
     "model": "qwen3-4b",  # Unused, required
-    "user_model_provider": "gemini",
+    "user_model_provider": USER_MODEL_PROVIDER,
 }
-# Replace with your actual API key for user sim
-GEMINI_API_KEY = "NONE"
-os.environ["GEMINI_API_KEY"] = GEMINI_API_KEY
 tau_config = RunConfig(**TAU_CONFIGS)
 
 

--- a/examples/tau-bench/run_qwen3_4B.sh
+++ b/examples/tau-bench/run_qwen3_4B.sh
@@ -99,7 +99,7 @@ WANDB_ARGS=(
 SGLANG_ARGS=(
    --rollout-num-gpus-per-engine 1
    --sglang-mem-fraction-static 0.7
-   # If gemini API reports concurrency limit error, set this parameter to reduce the concurrency
+   # If the user-simulator API (Gemini or DeepSeek) reports a concurrency limit error, set this parameter to reduce the concurrency
    # --sglang-server-concurrency 32
 )
 
@@ -129,6 +129,8 @@ ray start --head --node-ip-address ${MASTER_ADDR} --num-gpus ${NUM_GPUS} --disab
 # key in your shell before launching, e.g.:
 #   export TAU_USER_MODEL_PROVIDER=deepseek TAU_USER_MODEL=deepseek-chat
 #   export DEEPSEEK_API_KEY=sk-...
+# NOTE: only the Gemini and DeepSeek keys are forwarded below. To use another
+# litellm provider, add its *_API_KEY to the env_vars block as well.
 RUNTIME_ENV_JSON="{
   \"env_vars\": {
     \"PYTHONPATH\": \"/root/Megatron-LM/:${SCRIPT_DIR}\",

--- a/examples/tau-bench/run_qwen3_4B.sh
+++ b/examples/tau-bench/run_qwen3_4B.sh
@@ -124,10 +124,19 @@ export MASTER_ADDR=${MASTER_ADDR:-"127.0.0.1"}
 NUM_GPUS=2
 ray start --head --node-ip-address ${MASTER_ADDR} --num-gpus ${NUM_GPUS} --disable-usage-stats --dashboard-host=0.0.0.0 --dashboard-port=8265 --temp-dir /root/shared/ray_temp 
 
+# Forward the user-simulator provider/model selection and API keys to the ray
+# workers (the user simulator runs inside the rollout actors). Set the matching
+# key in your shell before launching, e.g.:
+#   export TAU_USER_MODEL_PROVIDER=deepseek TAU_USER_MODEL=deepseek-chat
+#   export DEEPSEEK_API_KEY=sk-...
 RUNTIME_ENV_JSON="{
   \"env_vars\": {
     \"PYTHONPATH\": \"/root/Megatron-LM/:${SCRIPT_DIR}\",
-    \"CUDA_DEVICE_MAX_CONNECTIONS\": \"1\"
+    \"CUDA_DEVICE_MAX_CONNECTIONS\": \"1\",
+    \"TAU_USER_MODEL_PROVIDER\": \"${TAU_USER_MODEL_PROVIDER:-gemini}\",
+    \"TAU_USER_MODEL\": \"${TAU_USER_MODEL:-gemini-2.5-flash-lite}\",
+    \"GEMINI_API_KEY\": \"${GEMINI_API_KEY:-}\",
+    \"DEEPSEEK_API_KEY\": \"${DEEPSEEK_API_KEY:-}\"
   }
 }"
 


### PR DESCRIPTION
## Summary

The tau-bench user simulator runs through **litellm**, so it is not tied to Gemini — any litellm-supported provider works. This makes that explicit in the example:

- Select the user-simulator provider/model with `TAU_USER_MODEL_PROVIDER` / `TAU_USER_MODEL` env vars, and read the key from the provider's own `*_API_KEY` env var. Defaults preserve the original Gemini behavior (`gemini` / `gemini-2.5-flash-lite` / `GEMINI_API_KEY`).
- `run_qwen3_4B.sh` forwards the provider/model selection and both `GEMINI_API_KEY` and `DEEPSEEK_API_KEY` into `RUNTIME_ENV_JSON`, so the key reaches the ray rollout workers (the user simulator runs inside the rollout actors).
- A missing `*_API_KEY` now **fails fast at startup** with a clear message, instead of being silently overwritten with `"NONE"` and failing deep inside a rollout.
- README documents the DeepSeek and Gemini recipes.

No changes outside `examples/tau-bench/`.

## Validation

Ran the example end-to-end on a 2×H200 box with DeepSeek as the user simulator (`TAU_USER_MODEL_PROVIDER=deepseek`, `TAU_USER_MODEL=deepseek-chat`):

- The env forwarding delivered `DEEPSEEK_API_KEY` to the ray rollout actors; the user simulator made **hundreds of successful `deepseek-chat` calls** with no provider/auth errors.
- The Qwen3-4B agent and the DeepSeek user simulator produced valid multi-turn tool-calling trajectories — e.g. an `exchange_delivered_order_items` task completed and was scored `reward: 1.0` by the env.
- Startup weight sync (megatron → sglang) and model loading worked normally.

## Caveat (pre-existing, not addressed here)

The DeepSeek API occasionally returns a very slow response (observed a ~10 min straggler on a single user-sim turn). Because litellm's default `request_timeout` is 6000s and the fork's `completion()` call site does not pass a tighter timeout, one slow user-sim call can stall the synchronous rollout for minutes. This is **provider-agnostic** (the original Gemini path uses the same default) and lives in the tau-bench fork's `tau_bench/envs/user.py`, outside this example — so it is out of scope for this PR. Flagging it in case we want a follow-up that sets a tighter per-call timeout.

## Test plan

- [x] DeepSeek user-sim path: `TAU_USER_MODEL_PROVIDER=deepseek TAU_USER_MODEL=deepseek-chat DEEPSEEK_API_KEY=… bash examples/tau-bench/run_qwen3_4B.sh` — rollouts produce valid rewarded trajectories.
- [x] Missing-key fail-fast: launching without the matching `*_API_KEY` raises a clear `RuntimeError` at startup.
- [x] Gemini default unchanged (no env vars set → `gemini` / `gemini-2.5-flash-lite` / `GEMINI_API_KEY`).
