### PR TITLE
ci: fix and re-enable test_run_megatron_worker_main

### DIFF
--- a/tests/fast-gpu/test_run_megatron_worker_main.py
+++ b/tests/fast-gpu/test_run_megatron_worker_main.py
@@ -37,6 +37,16 @@ def _ensure_module(dotted: str) -> ModuleType:
     return sys.modules[dotted]
 
 
+# Import the real `miles` package tree before any stubbing below. `_ensure_module`
+# walks dotted ancestors and stubs every missing segment, so stubbing a
+# `miles.backends.megatron_utils.*` leaf while `miles` is not yet imported would
+# replace the real `miles` package with an empty (non-package) stub -- and the
+# later `from miles.utils...main import` would then fail with "miles is not a
+# package". Importing the real parent package here registers the genuine
+# `miles`, `miles.backends`, and `miles.backends.megatron_utils` packages in
+# sys.modules so only the leaf modules get stubbed.
+import miles.backends.megatron_utils  # noqa: E402
+
 # Stub modules whose top-level imports in main.py would fail.
 _STUBS: dict[str, dict[str, Any]] = {
     "megatron.training.arguments": {

--- a/tests/fast-gpu/test_run_megatron_worker_main.py
+++ b/tests/fast-gpu/test_run_megatron_worker_main.py
@@ -45,7 +45,7 @@ def _ensure_module(dotted: str) -> ModuleType:
 # package". Importing the real parent package here registers the genuine
 # `miles`, `miles.backends`, and `miles.backends.megatron_utils` packages in
 # sys.modules so only the leaf modules get stubbed.
-import miles.backends.megatron_utils  # noqa: E402
+import miles.backends.megatron_utils  # noqa: E402,F401
 
 # Stub modules whose top-level imports in main.py would fail.
 _STUBS: dict[str, dict[str, Any]] = {

--- a/tests/fast-gpu/test_run_megatron_worker_main.py
+++ b/tests/fast-gpu/test_run_megatron_worker_main.py
@@ -14,7 +14,6 @@ register_cuda_ci(
     est_time=30,
     suite="stage-b-2-gpu-h200",
     labels=[],
-    disabled="FIXME: re-enable after worker/main.py stubbing is safe in script-mode CI.",
 )
 
 import argparse


### PR DESCRIPTION
## Summary

Re-enables and fixes `tests/fast-gpu/test_run_megatron_worker_main.py`, which was disabled with `disabled="FIXME: re-enable after worker/main.py stubbing is safe in script-mode CI."`.

The disable reason was accurate — the test really did fail in script mode. Root cause: the test's `_ensure_module()` helper walks dotted ancestors and stubs every missing segment. When it stubbed the `miles.backends.megatron_utils.*` leaves while the real `miles` package had not yet been imported, it inserted a bare `ModuleType("miles")` into `sys.modules`, shadowing the real (editable-installed) package. The subsequent `from miles.utils...worker.main import` then failed with `ModuleNotFoundError: No module named 'miles.utils'; 'miles' is not a package`.

Fix: import the real `miles.backends.megatron_utils` package before the stub loops, so the genuine `miles` / `miles.backends` / `miles.backends.megatron_utils` packages are already registered and only the leaf modules get stubbed. The megatron stubs are kept as-is — `megatron.training` is genuinely absent in the CI image (only `megatron.core` + `megatron.bridge` are installed), so those stubs are still required.

## Test plan

- [x] Reproduced the original failure on an 8×H200 devbox (image `radixark/miles:dev`) — confirmed the `'miles' is not a package` error before the fix.
- [x] After the fix: `python3 tests/fast-gpu/test_run_megatron_worker_main.py` → **7 passed in 0.78s** (the CI runner's exact per-file invocation).
- [x] `run_suite.py --hw cuda --suite stage-b-2-gpu-h200 --match-all-labels --list-only` now lists the test under **Enabled** (previously Skipped).
