### PR TITLE
Re-enable test_qwen3_4B_ckpt.py

### DIFF
--- a/tests/e2e/ckpt/test_qwen3_4B_ckpt.py
+++ b/tests/e2e/ckpt/test_qwen3_4B_ckpt.py
@@ -4,8 +4,7 @@ from tests.ci.ci_register import register_cuda_ci
 
 import miles.utils.external_utils.command_utils as U
 
-# FIXME: fix this
-register_cuda_ci(est_time=1200, suite="stage-c-8-gpu-h100", labels=["ckpt"], disabled="Disabled due to bugs.")
+register_cuda_ci(est_time=1200, suite="stage-c-8-gpu-h100", labels=["ckpt"])
 
 ENABLE_EVAL = bool(int(os.environ.get("MILES_TEST_ENABLE_EVAL", "1")))
 


### PR DESCRIPTION
## Summary

Re-enables `tests/e2e/ckpt/test_qwen3_4B_ckpt.py`, which was disabled with `disabled="Disabled due to bugs."` and a `# FIXME: fix this` comment.

The test exercises Megatron checkpoint **save → load** round-trips (sync and async save) for Qwen3-4B under TP2/PP2/CP2 + sequence-parallel, and asserts per-`(tp,pp,dp,cp)`-rank SHA256 hash-equality of model parameters across the boundary (`--ci-save-model-hash` on save, `--ci-check-model-hash` + `--low-memory-resume` on load). The hash check runs immediately after load, before the load-run's training loop, so the assertion is deterministic w.r.t. rollout non-determinism. No assert logic is touched — only the registration marker is restored.

## Test plan

- [x] Reproduced end-to-end **twice** on an 8×H200 devbox (image `radixark/miles:dev`) via the exact CI invocation `python3 tests/e2e/ckpt/test_qwen3_4B_ckpt.py` (no args).
- [x] Both runs **identical and deterministic**: `Model hashes match` ×4 (two save/load round-trips: sync + async), `Saved model hashes` ×8 (8 ranks), all 4 Ray jobs `succeeded`, **zero** `AssertionError` / hash mismatch / traceback.
- [x] `--low-memory-resume` peak-GPU-memory guard satisfied: 12.37 GB < 20 GB threshold on every rank.
