### PR TITLE
chat_template(dsv32): render tools into the system message (sglang-aligned)

### DIFF
--- a/miles/utils/chat_template_utils/deepseek_v32.py
+++ b/miles/utils/chat_template_utils/deepseek_v32.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import functools
 import json
 import logging
@@ -7,6 +8,7 @@ import os
 from typing import Any
 
 from sglang.srt.entrypoints.openai import encoding_dsv32
+from sglang.srt.entrypoints.openai.protocol import Tool
 
 logger = logging.getLogger(__name__)
 
@@ -60,14 +62,27 @@ def _build_deepseek_encode_config(kwargs: dict) -> dict:
     return cfg
 
 
+def _inject_tools_into_system(messages: list[dict[str, Any]], tools: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Put *tools* in the system message, where ``encode_messages`` reads them.
+
+    The encoder serializes each tool dict verbatim into ``<functions>``, so they
+    must round-trip through ``Tool.model_dump()`` (fills defaults / orders fields)
+    or the token ids drift from what sglang serves.
+    """
+    out = copy.deepcopy(messages)
+    if not out or out[0].get("role") != "system":
+        out.insert(0, {"role": "system", "content": ""})
+    out[0]["tools"] = [Tool.model_validate(t).model_dump() for t in tools]
+    return out
+
+
 def render_messages(messages: list[dict[str, Any]], *, tools: list[dict] | None = None, **kwargs: Any) -> str:
     """Render *messages* into a DeepSeek V3.2 prompt via sglang ``encode_messages``.
 
-    Assume input messages tool_call ``arguments`` are already JSON strings.
+    Tool_call ``arguments`` must already be JSON strings; *tools*, if given, are
+    injected into the system message (see ``_inject_tools_into_system``).
     """
-    if tools:
-        raise ValueError(
-            "DeepSeek V3.2 chat template does not support tools def in apply chat template, plz inject it in system message."
-        )
     encode_config = _build_deepseek_encode_config(kwargs)
+    if tools:
+        messages = _inject_tools_into_system(messages, tools)
     return encoding_dsv32.encode_messages(messages, **encode_config)

--- a/tests/fast/utils/chat_template_utils/test_deepseek_v32.py
+++ b/tests/fast/utils/chat_template_utils/test_deepseek_v32.py
@@ -162,6 +162,65 @@ def test_thinking_mode_changes_output():
 
 
 # ---------------------------------------------------------------------------
+# Tool injection (sglang-aligned: tools go into the system <functions> block)
+# ---------------------------------------------------------------------------
+
+_TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get weather",
+            "parameters": {"type": "object", "properties": {"city": {"type": "string"}}, "required": ["city"]},
+        },
+    }
+]
+
+
+def test_render_with_tools_injects_into_system_functions_block():
+    # tools= is accepted (not rejected) and rendered into the system <functions> block.
+    out = deepseek_v32.render_messages([{"role": "user", "content": "hi"}], tools=_TOOLS, thinking_mode="chat")
+    assert "<functions>" in out
+    assert "get_weather" in out
+
+
+def test_render_with_tools_matches_manual_system_injection():
+    # Passing tools= must equal pre-canonicalizing them into the system message and
+    # passing tools=None — i.e. the injection is exactly the Tool-pydantic model_dump
+    # that sglang's serving path applies.
+    from sglang.srt.entrypoints.openai.protocol import Tool
+
+    canonical = [Tool.model_validate(t).model_dump() for t in _TOOLS]
+    msgs = [{"role": "user", "content": "weather?"}]
+    expected = deepseek_v32.render_messages(
+        [{"role": "system", "content": "", "tools": canonical}, *msgs], thinking_mode="chat"
+    )
+    assert deepseek_v32.render_messages(msgs, tools=_TOOLS, thinking_mode="chat") == expected
+
+
+def test_render_with_tools_reuses_existing_system_message():
+    # When a system message is already present, tools attach to it (no extra system inserted).
+    msgs = [{"role": "system", "content": "You are helpful."}, {"role": "user", "content": "hi"}]
+    out = deepseek_v32.render_messages(msgs, tools=_TOOLS, thinking_mode="chat")
+    assert "You are helpful." in out
+    assert "<functions>" in out
+
+
+def test_render_with_tools_does_not_mutate_input():
+    msgs = [{"role": "user", "content": "hi"}]
+    snapshot = copy.deepcopy(msgs)
+    deepseek_v32.render_messages(msgs, tools=_TOOLS, thinking_mode="chat")
+    assert msgs == snapshot
+
+
+def test_apply_chat_template_with_tools_dispatches_to_bridge(tmp_path):
+    tok = _tok_with_model_type(tmp_path, "deepseek_v32")
+    msgs = [{"role": "user", "content": "hi"}]
+    via_apply = apply_chat_template(msgs, tokenizer=tok, tools=_TOOLS, tokenize=False)
+    assert via_apply == deepseek_v32.render_messages(msgs, tools=_TOOLS)
+
+
+# ---------------------------------------------------------------------------
 # Input immutability
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
### Motivation
DeepSeek V3.2 ships no jinja chat_template; miles renders it through the thin `encoding_dsv32` bridge in `chat_template_utils/deepseek_v32.py`. The bridge previously **rejected** a `tools=` arg and required callers to hand-inject tool defs into the system message — inconsistent with every other family and with the runtime, and will cause trouble to user's customized harness.

### Design
This PR makes the bridge mirror sglang's `OpenAIServingChat._apply_jinja_template` `use_dpsk_v32_encoding` branch: canonicalize each tool through the `Tool` pydantic model, and insert an empty system message when the trajectory has none. 

Prerequisite for #1131 (TITO deepseek v32 support), which relies on this to tokenize the tool surface.

Verified: `tests/fast/utils/chat_template_utils/test_deepseek_v32.py` (incl. new tool-injection cases) green.