### PR TITLE
[CI] add qwen-30b broadcast weight update test and `run-ci-weight-update` CI label

### DIFF
--- a/tests/ci/labels.py
+++ b/tests/ci/labels.py
@@ -26,4 +26,5 @@ KNOWN_LABELS: dict[str, str] = {
     "ckpt": "Checkpoint save / load tests",
     "lora": "LoRA training tests",
     "precision": "Numerical precision parity tests",
+    "weight-update": "Weight update tests",
 }

--- a/tests/ci/test_labels.py
+++ b/tests/ci/test_labels.py
@@ -21,6 +21,7 @@ def test_known_labels_initial_labels_present():
         "ckpt",
         "lora",
         "precision",
+        "weight-update",
     }
     assert expected <= set(KNOWN_LABELS), f"Missing canonical labels: {expected - set(KNOWN_LABELS)}"
 

--- a/tests/e2e/megatron/test_qwen3_30B_A3B/_common.py
+++ b/tests/e2e/megatron/test_qwen3_30B_A3B/_common.py
@@ -22,12 +22,16 @@ class CaseConfig:
     use_bridge: bool = False
     use_r3: bool = False
     max_tokens_per_gpu: int = 8192
+    rollout_num_gpus: int = None
+    update_weight_transfer_mode: str = None
 
     def __post_init__(self):
         if self.tp_size is None:
             self.tp_size = self.num_gpus_per_node // self.cp_size // self.pp_size
         if self.ep_size is None:
             self.ep_size = self.num_gpus_per_node // self.pp_size
+        if self.update_weight_transfer_mode is not None:
+            assert self.update_weight_transfer_mode == "broadcast"
 
 
 def prepare(case: CaseConfig, *, need_fp8: bool, need_int4: bool, all_bridge: bool) -> None:
@@ -168,8 +172,15 @@ def build_train_args(case: CaseConfig, *, wandb_file: str) -> str:
         "--attention-backend flash "
         "--actor-num-nodes 1 "
         f"--actor-num-gpus-per-node {case.num_gpus_per_node} "
-        "--colocate "
     )
+    if case.rollout_num_gpus is None:
+        misc_args += "--colocate "
+    else:
+        misc_args += f"--rollout-num-gpus {case.rollout_num_gpus} "
+
+    if case.update_weight_transfer_mode is not None:
+        misc_args += "--check-weight-update-equal "
+        misc_args += f"--update-weight-transfer-mode {case.update_weight_transfer_mode} "
 
     if case.use_bridge:
         misc_args += "--megatron-to-hf-mode bridge "
@@ -206,7 +217,7 @@ def execute(case: CaseConfig, *, wandb_file: str) -> None:
 
     U.execute_train(
         train_args=train_args,
-        num_gpus_per_node=case.num_gpus_per_node,
+        num_gpus_per_node=case.num_gpus_per_node + (case.rollout_num_gpus or 0),
         megatron_model_type=MODEL_TYPE,
         extra_env_vars=extra_env_vars,
     )

--- a/tests/e2e/megatron/test_qwen3_30B_A3B/test_disagg_broadcast.py
+++ b/tests/e2e/megatron/test_qwen3_30B_A3B/test_disagg_broadcast.py
@@ -3,7 +3,7 @@ import os
 from tests.ci.ci_register import register_cuda_ci
 from tests.e2e.megatron.test_qwen3_30B_A3B._common import CaseConfig, execute, prepare
 
-register_cuda_ci(est_time=900, suite="stage-c-4-gpu-h200", labels=["megatron", "weight-update"])
+register_cuda_ci(est_time=900, suite="stage-c-8-gpu-h100", labels=["megatron", "weight-update"])
 
 CASE = CaseConfig(
     use_deepep=False,
@@ -14,6 +14,8 @@ CASE = CaseConfig(
     num_gpus_per_node=4,
     cp_size=2,
     pp_size=2,
+    rollout_num_gpus=4,
+    update_weight_transfer_mode="broadcast",
 )
 
 

--- a/tests/e2e/megatron/test_qwen3_4B_p2p.py
+++ b/tests/e2e/megatron/test_qwen3_4B_p2p.py
@@ -6,12 +6,11 @@ MODEL_NAME = "Qwen3-4B"
 MODEL_TYPE = "qwen3-4B"
 NUM_GPUS = 8
 
-# FIXME: flaky.
 register_cuda_ci(
     est_time=600,
     suite="stage-c-8-gpu-h100",
-    labels=["megatron"],
-    disabled="Flaky test",
+    labels=["megatron", "weight-update"],
+    disabled="RDMA weight update is not supported by current CI machine.",
 )
 
 


### PR DESCRIPTION
## What changed

- Added the `weight-update` CI domain label, triggered by the PR label `run-ci-weight-update`.
- Added `weight-update` to the existing Qwen3-30B-A3B colocated baseline E2E test.
- Added Qwen3-30B-A3B `test_disagg_broadcast.py` for the 4 train GPU + 4 rollout GPU disaggregated broadcast weight update path, with `--check-weight-update-equal` and `--update-weight-transfer-mode broadcast`.
- Added `megatron` to the disaggregated broadcast test labels, so `run-ci-megatron` also selects it.
- Added `weight-update` to the disabled Qwen3-4B P2P test labels; it remains skipped because RDMA weight update is not supported by current CI machine.
- Created the GitHub repo label `run-ci-weight-update`.

## Validation

- `PYTHONPATH=. python tests/ci/run_suite.py --hw cuda --suite stage-c-4-gpu-h200 --labels run-ci-weight-update --list-only`
- `PYTHONPATH=. python tests/ci/run_suite.py --hw cuda --suite stage-c-8-gpu-h100 --labels run-ci-weight-update --list-only`
- `PYTHONPATH=. python tests/ci/run_suite.py --hw cuda --suite stage-c-8-gpu-h100 --labels run-ci-megatron --list-only`
- `PYTHONPATH=. pytest --confcutdir=tests/ci tests/ci/test_labels.py tests/ci/test_ci_register.py tests/ci/test_run_suite.py`