### PR TITLE
Use q lora atomic update groups

### DIFF
--- a/miles/backends/megatron_utils/megatron_to_hf/__init__.py
+++ b/miles/backends/megatron_utils/megatron_to_hf/__init__.py
@@ -36,11 +36,22 @@ def convert_to_hf(args, model_name, name, param, quantization_config=None):
 
 
 def get_atomic_update_groups(args, model_name) -> list[AtomicUpdateGroup]:
-    return []
+    return _get_q_lora_atomic_update_groups(args)
 
 
-# TODO optimize
-_cached_tensors = {}
+def _get_q_lora_atomic_update_groups(args) -> list[AtomicUpdateGroup]:
+    if args.q_lora_rank is None:
+        return []
+
+    return [
+        AtomicUpdateGroup(
+            key="q_lora_a_proj",
+            suffixes=(
+                ".self_attention.linear_q_down_proj.weight",
+                ".self_attention.linear_kv_down_proj.weight",
+            ),
+        )
+    ]
 
 
 # TODO optimize code details
@@ -76,33 +87,6 @@ def _convert_to_hf_core(args, model_name, name, param):
     else:
         raise ValueError(f"Unsupported model: {model_name}")
 
-    # to compatible with sglang implementation
-    if args.q_lora_rank is not None:
-        old_converted_named_tensors = converted_named_tensors
-        converted_named_tensors = []
-        for converted_name, converted_param in old_converted_named_tensors:
-            if "q_a_proj" in converted_name:
-                pair_name = converted_name.replace("q_a_proj", "kv_a_proj_with_mqa")
-                if pair_name in _cached_tensors:
-                    converted_named_tensors += [
-                        (converted_name, converted_param),
-                        (pair_name, _cached_tensors[pair_name]),
-                    ]
-                    del _cached_tensors[pair_name]
-                else:
-                    _cached_tensors[converted_name] = converted_param
-            elif "kv_a_proj_with_mqa" in converted_name:
-                pair_name = converted_name.replace("kv_a_proj_with_mqa", "q_a_proj")
-                if pair_name in _cached_tensors:
-                    converted_named_tensors += [
-                        (converted_name, converted_param),
-                        (pair_name, _cached_tensors[pair_name]),
-                    ]
-                    del _cached_tensors[pair_name]
-                else:
-                    _cached_tensors[converted_name] = converted_param
-            else:
-                converted_named_tensors.append((converted_name, converted_param))
     return converted_named_tensors
 
 


### PR DESCRIPTION
## Summary
- replace q_lora conversion cache with static atomic update groups
- keep q_a_proj and kv_a_proj_with_mqa in the same update unit before HF conversion
- keep convert_to_hf stateless for q_lora weights

## Validation
- python -m compileall miles/backends/megatron_utils/megatron_to_hf/__init__.py
- python -m pytest --confcutdir=tests/fast/backends/megatron_utils tests/fast/backends/megatron_utils/test_hf_weight_iterator_direct.py -q
- pre-commit run --all-files