### PR TITLE
[miles] Fix bridge-mode async weight transfer for Qwen3-VL

### DIFF
--- a/miles/backends/megatron_utils/actor.py
+++ b/miles/backends/megatron_utils/actor.py
@@ -172,10 +172,26 @@ class MegatronTrainRayActor(TrainRayActor):
                 update_weight_cls = UpdateWeightFromDistributed
             else:
                 update_weight_cls = UpdateWeightP2P
+
+        # _enable_weight_backup only fires for colocate / ref / old_actor flows; non-colocate
+        # bridge runs hit UpdateWeightFromTensor without ever calling backup("actor"), leaving
+        # the backuper empty. Read live params directly in that case.
+        def _weights_getter():
+            if self._enable_weight_backup:
+                return self.weights_backuper.get("actor")
+            return dict(
+                named_params_and_buffers(
+                    self.args,
+                    self.model,
+                    convert_to_global_name=getattr(self.args, "megatron_to_hf_mode", "raw") == "raw",
+                    translate_gpu_to_cpu=not self.args.enable_weights_backuper,
+                )
+            )
+
         self.weight_updater = update_weight_cls(
             self.args,
             self.model,
-            weights_getter=lambda: self.weights_backuper.get("actor"),
+            weights_getter=_weights_getter,
             model_name=type(self.hf_config).__name__.lower() if self.args.model_name is None else self.args.model_name,
             quantization_config=getattr(self.hf_config, "quantization_config", None),
             is_lora=is_lora_enabled(args),

--- a/miles/backends/megatron_utils/actor.py
+++ b/miles/backends/megatron_utils/actor.py
@@ -165,7 +165,7 @@ class MegatronTrainRayActor(TrainRayActor):
         if self.args.vocab_size is None:
             self.args.vocab_size = self.tokenizer.vocab_size
 
-        if self.args.colocate:
+        if self.args.colocate or getattr(self.args, "megatron_to_hf_mode", "raw") == "bridge":
             update_weight_cls = UpdateWeightFromTensor
         else:
             if self.args.update_weight_transfer_mode == "broadcast":

--- a/miles/backends/megatron_utils/update_weight/update_weight_from_tensor.py
+++ b/miles/backends/megatron_utils/update_weight/update_weight_from_tensor.py
@@ -80,6 +80,9 @@ class UpdateWeightFromTensor:
                 self._ipc_gather_src = start_rank
 
         self._model_update_groups = None
+        self.use_distribute = False
+        self.rollout_engines: Sequence[ActorHandle] = []
+        self.distributed_rollout_engines: Sequence[ActorHandle] = []
 
     def connect_rollout_engines(
         self,
@@ -105,12 +108,16 @@ class UpdateWeightFromTensor:
                 offset += c
 
         # Compute colocated engine count: engines whose GPUs fall within actor GPU range.
-        total_actor_gpus = self.args.actor_num_nodes * self.args.actor_num_gpus_per_node
+        # When colocate=false, engines live on separate nodes from the actor —
+        # gpu_offsets are relative to the rollout placement group, not globally
+        # unique, so the range check would wrongly classify them as colocated.
         colocate_engine_nums = 0
-        for gpu_offset, gpu_count in zip(engine_gpu_offsets, engine_gpu_counts, strict=True):
-            if gpu_offset + gpu_count > total_actor_gpus:
-                break
-            colocate_engine_nums += 1
+        if getattr(self.args, "colocate", True):
+            total_actor_gpus = self.args.actor_num_nodes * self.args.actor_num_gpus_per_node
+            for gpu_offset, gpu_count in zip(engine_gpu_offsets, engine_gpu_counts, strict=True):
+                if gpu_offset + gpu_count > total_actor_gpus:
+                    break
+                colocate_engine_nums += 1
 
         self.use_distribute = len(rollout_engines) > colocate_engine_nums
 
@@ -179,6 +186,13 @@ class UpdateWeightFromTensor:
         """
         self.weight_version += 1
 
+        # Bridge / non-colocate runs split engines into self.rollout_engines (colocated)
+        # and self.distributed_rollout_engines; pause / flush / post-process / continue
+        # must reach both.
+        all_engines = list(self.rollout_engines)
+        if self.use_distribute:
+            all_engines += list(self.distributed_rollout_engines)
+
         rank = dist.get_rank()
 
         # LoRA never mutates the base. With either path that retains it on the
@@ -190,15 +204,16 @@ class UpdateWeightFromTensor:
 
         if rank == 0:
             mode = self.args.pause_generation_mode
-            ray.get([engine.pause_generation.remote(mode=mode) for engine in self.rollout_engines])
-            ray.get([engine.flush_cache.remote() for engine in self.rollout_engines])
+            ray.get([engine.pause_generation.remote(mode=mode) for engine in all_engines])
+            if mode != "in_place":
+                ray.get([engine.flush_cache.remote() for engine in all_engines])
             if (
                 not skip_base_sync
                 and self.quantization_config
                 and self.quantization_config["quant_method"] in ["compressed-tensors"]
             ):
                 post_process_weights(
-                    rollout_engines=self.rollout_engines,
+                    rollout_engines=all_engines,
                     restore_weights_before_load=True,
                     post_process_quantization=False,
                 )
@@ -247,11 +262,11 @@ class UpdateWeightFromTensor:
             # transform; skip when no fresh base bytes landed (skip_base_sync).
             if not skip_base_sync:
                 post_process_weights(
-                    rollout_engines=self.rollout_engines,
+                    rollout_engines=all_engines,
                     restore_weights_before_load=False,
                     post_process_quantization=True,
                 )
-            ray.get([engine.continue_generation.remote() for engine in self.rollout_engines])
+            ray.get([engine.continue_generation.remote() for engine in all_engines])
         dist.barrier(group=get_gloo_group())
 
     def _send_base_params(self, hf_named_tensors) -> tuple[list[ObjectRef], Any]:


### PR DESCRIPTION
## Summary

Fixes silent vision-tower corruption on async (non-colocated) RL runs of Qwen3-VL with `--megatron-to-hf-mode bridge`. Two commits:

1. **Route bridge through `UpdateWeightFromTensor` / `HfWeightIteratorBridge`** instead of the regex-based `UpdateWeightFromDistributed` converter. The regex (`miles/backends/megatron_utils/megatron_to_hf/qwen3_vl.py::convert_qwen3vl_to_hf`) round-trips the language tower correctly, but on the vision tower it emits 13/17 bogus HF names (silently dropped by SGLang) and overwrites 4/17 real HF names with the *wrong layout* (Megatron stores QKV concatenated; HF stores it interleaved per-head — the bridge does the swap, the regex doesn't). At the very first weight broadcast — before any gradient ever touches the (typically frozen) ViT — the rollout-side ViT becomes a Frankenstein: partly init values, partly mis-laid-out trainer values, feeding bad visual features into an otherwise-correctly-synced language tower. Plus the small `__init__` / `connect_rollout_engines` / `update_weights` adjustments needed so `UpdateWeightFromTensor` works with non-colocated engines.
2. **Read live params when weight backup is disabled** — `_enable_weight_backup` only fires for `colocate / with_ref / keep_old_actor`, so non-colocate bridge runs hit `UpdateWeightFromTensor` with an empty backuper and crash on the first sync. Falls back to `named_params_and_buffers` when the backup isn't there.

See each commit message for the detailed root-cause writeup.

## Why this only shows up on VLMs

Text-only models touch only the language tower (which the regex round-trips correctly). The bug needed a frozen, structurally-different submodule that the regex could mishandle. ViTs check both boxes — and the rollout-side corruption lands on the very first weight sync (no training time required), which is why log-probs diverge from step 0 rather than drifting over time.

## Repro / evidence

Two non-colocate bridge runs with otherwise-identical configs (Qwen3-VL-32B-Thinking, `colocate=False`, `megatron_to_hf_mode=bridge`):

| Metric | Before fix (broken) | After fix (working) |
| --- | --- | --- |
| `rollout/log_probs` (trainer's view of sampled tokens) | **-11.0** | **-0.216** |
| `rollout/rollout_log_probs` (sglang's view at sample time) | -0.19 | -0.212 |
| `train/train_rollout_logprob_abs_diff` | **11.0** | **0.024** |

A healthy gap is ~0.02 nats/token (bf16 / kernel noise). The broken runs sit at ~11 nats/token from step 0.

<img width="1230" height="633" alt="Screenshot 2026-06-01 at 6 03 11 PM" src="https://github.com/user-attachments/assets/be7fdb4e-5b90-450c-9c92-5b4835462863" />

## Files changed

- `miles/backends/megatron_utils/actor.py` — bridge-mode dispatch + live-params fallback
- `miles/backends/megatron_utils/update_weight/update_weight_from_tensor.py` — non-colocate engine handling