### PR TITLE
Fix flaky real-Ray stop_cell tests by polling for actor death

### DIFF
--- a/tests/fast/ray/rollout/real_ray/test_rollout_manager.py
+++ b/tests/fast/ray/rollout/real_ray/test_rollout_manager.py
@@ -126,9 +126,11 @@ async def _assert_engine_dies(actor_handle, *, deadline_s: float = 15.0, poll_in
     deadline = time.monotonic() + deadline_s
     while True:
         try:
-            await actor_handle.health_generate.remote(timeout=1.0)
+            ray.get(actor_handle.health_generate.remote(timeout=1.0), timeout=5.0)
         except (ray.exceptions.RayActorError, ray.exceptions.RayTaskError):
             return
+        except ray.exceptions.GetTimeoutError:
+            pass
         if time.monotonic() >= deadline:
             pytest.fail(f"engine actor still alive {deadline_s}s after stop_cell")
         await asyncio.sleep(poll_interval_s)

--- a/tests/fast/ray/rollout/real_ray/test_rollout_manager.py
+++ b/tests/fast/ray/rollout/real_ray/test_rollout_manager.py
@@ -123,24 +123,12 @@ def _make_test_args(tmp_path, *, models: list[tuple[str, bool]]):
 
 
 async def _assert_engine_dies(actor_handle, *, deadline_s: float = 15.0, poll_interval_s: float = 0.2) -> None:
-    """Poll ``actor_handle`` until a health call raises a Ray error.
-
-    ``stop_cell`` tears the actor down via ``ray.kill``, which is asynchronous:
-    the actor process may briefly outlive the call, so a single health check
-    right after ``stop_cell`` races the kill and can still reach a live actor
-    (returning ``True`` instead of raising). Retry until the actor is confirmed
-    gone, failing only if it never dies within ``deadline_s``."""
     deadline = time.monotonic() + deadline_s
     while True:
         try:
-            # ``ray.get`` blocks, so run it off the event loop; track the
-            # deadline with a real clock since each blocking call can take up
-            # to its own timeout, not just ``poll_interval_s``.
-            await asyncio.to_thread(ray.get, actor_handle.health_generate.remote(timeout=1.0), timeout=5.0)
+            await actor_handle.health_generate.remote(timeout=1.0)
         except (ray.exceptions.RayActorError, ray.exceptions.RayTaskError):
             return
-        except ray.exceptions.GetTimeoutError:
-            pass  # actor mid-teardown — keep polling until it raises an actor error
         if time.monotonic() >= deadline:
             pytest.fail(f"engine actor still alive {deadline_s}s after stop_cell")
         await asyncio.sleep(poll_interval_s)

--- a/tests/fast/ray/rollout/real_ray/test_rollout_manager.py
+++ b/tests/fast/ray/rollout/real_ray/test_rollout_manager.py
@@ -11,6 +11,7 @@ Pure routing/flag-flip helpers without Ray content live in
 
 from __future__ import annotations
 
+import asyncio
 import textwrap
 
 import pytest
@@ -120,6 +121,28 @@ def _make_test_args(tmp_path, *, models: list[tuple[str, bool]]):
     )
 
 
+async def _assert_engine_dies(actor_handle, *, deadline_s: float = 15.0, poll_interval_s: float = 0.2) -> None:
+    """Poll ``actor_handle`` until a health call raises a Ray error.
+
+    ``stop_cell`` tears the actor down via ``ray.kill``, which is asynchronous:
+    the actor process may briefly outlive the call, so a single health check
+    right after ``stop_cell`` races the kill and can still reach a live actor
+    (returning ``True`` instead of raising). Retry until the actor is confirmed
+    gone, failing only if it never dies within ``deadline_s``."""
+    elapsed_s = 0.0
+    while True:
+        try:
+            ray.get(actor_handle.health_generate.remote(timeout=1.0), timeout=5.0)
+        except (ray.exceptions.RayActorError, ray.exceptions.RayTaskError):
+            return
+        except ray.exceptions.GetTimeoutError:
+            pass  # actor mid-teardown — keep polling until it raises an actor error
+        if elapsed_s >= deadline_s:
+            pytest.fail(f"engine actor still alive {deadline_s}s after stop_cell")
+        await asyncio.sleep(poll_interval_s)
+        elapsed_s += poll_interval_s
+
+
 @pytest.mark.asyncio
 class TestRolloutManagerInit:
     async def test_init_creates_live_mock_engines_via_real_start_rollout_servers(
@@ -162,8 +185,7 @@ class TestStartStopCell:
 
         await manager.stop_cell(0)
 
-        with pytest.raises((ray.exceptions.RayActorError, ray.exceptions.RayTaskError)):
-            ray.get(actor0.health_generate.remote(timeout=1.0), timeout=10.0)
+        await _assert_engine_dies(actor0)
         assert ray.get(actor1.health_generate.remote(timeout=1.0)) is True
 
     async def test_start_cell_recovers_after_stop_cell(
@@ -210,8 +232,7 @@ class TestStartStopCell:
         await manager.stop_cell(1)
 
         assert ray.get(actor0.health_generate.remote(timeout=1.0)) is True
-        with pytest.raises((ray.exceptions.RayActorError, ray.exceptions.RayTaskError)):
-            ray.get(actor1.health_generate.remote(timeout=1.0), timeout=10.0)
+        await _assert_engine_dies(actor1)
 
     async def test_stop_cell_is_idempotent_on_already_stopped(
         self,
@@ -257,8 +278,7 @@ class TestCellDispatchAcrossModels:
         for h in actor_handles:
             assert ray.get(h.health_generate.remote(timeout=1.0)) is True
         # ref engine 0 dead, ref engine 1 alive
-        with pytest.raises((ray.exceptions.RayActorError, ray.exceptions.RayTaskError)):
-            ray.get(ref_handles[0].health_generate.remote(timeout=1.0), timeout=10.0)
+        await _assert_engine_dies(ref_handles[0])
         assert ray.get(ref_handles[1].health_generate.remote(timeout=1.0)) is True
 
 

--- a/tests/fast/ray/rollout/real_ray/test_rollout_manager.py
+++ b/tests/fast/ray/rollout/real_ray/test_rollout_manager.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import asyncio
 import textwrap
+import time
 
 import pytest
 import ray
@@ -129,18 +130,20 @@ async def _assert_engine_dies(actor_handle, *, deadline_s: float = 15.0, poll_in
     right after ``stop_cell`` races the kill and can still reach a live actor
     (returning ``True`` instead of raising). Retry until the actor is confirmed
     gone, failing only if it never dies within ``deadline_s``."""
-    elapsed_s = 0.0
+    deadline = time.monotonic() + deadline_s
     while True:
         try:
-            ray.get(actor_handle.health_generate.remote(timeout=1.0), timeout=5.0)
+            # ``ray.get`` blocks, so run it off the event loop; track the
+            # deadline with a real clock since each blocking call can take up
+            # to its own timeout, not just ``poll_interval_s``.
+            await asyncio.to_thread(ray.get, actor_handle.health_generate.remote(timeout=1.0), timeout=5.0)
         except (ray.exceptions.RayActorError, ray.exceptions.RayTaskError):
             return
         except ray.exceptions.GetTimeoutError:
             pass  # actor mid-teardown — keep polling until it raises an actor error
-        if elapsed_s >= deadline_s:
+        if time.monotonic() >= deadline:
             pytest.fail(f"engine actor still alive {deadline_s}s after stop_cell")
         await asyncio.sleep(poll_interval_s)
-        elapsed_s += poll_interval_s
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

`tests/fast/ray/rollout/real_ray/test_rollout_manager.py` has flaky failures (e.g. `test_stop_cell_kills_target_engine_only`): `DID NOT RAISE (RayActorError, RayTaskError)`.

## Root cause

`RolloutManager.stop_cell` → `server_group.stop_engines` kills the engine actor via `ray.kill`, which tears the actor down **asynchronously**. The tests asserted a single `health_generate` call raises immediately afterwards, racing the kill: when the actor is not yet dead the mock returns `True` and `pytest.raises` sees DID NOT RAISE. The fixture uses a real Ray cluster (not local_mode), so the race is genuine.

## Fix

Replace the three single-shot kill-then-assert sites with `_assert_engine_dies`, which polls the health call until it raises a Ray actor error within a deadline (failing only if the actor never dies).