### PR TITLE
CI: Kimi-K2.5 python launch and 4-layer CI test

### DIFF
--- a/miles/backends/megatron_utils/megatron_to_hf/processors/quantizer_compressed_tensors.py
+++ b/miles/backends/megatron_utils/megatron_to_hf/processors/quantizer_compressed_tensors.py
@@ -268,15 +268,25 @@ def quantize_params_compressed_tensors(converted_named_params, quantization_conf
     group_size = w_cfg["group_size"]
     is_symmetric = w_cfg["symmetric"]
     ignore_rules = quantization_config.get("ignore", [])
+    # Base names of params the checkpoint actually stores packed (see
+    # HfWeightIteratorBridge). The published ignore list of multimodal
+    # checkpoints (e.g. Kimi-K2.5 VL) only covers LLM submodules, so relying
+    # on it alone would wrongly quantize the vision tower / projector.
+    quantized_basenames = quantization_config.get("_miles_quantized_basenames")
 
     results = []
 
     for name, param in converted_named_params:
-        is_ignored = any(
-            (r.startswith("re:") and re.match(r[3:], name)) or r == name or name.startswith(r) for r in ignore_rules
-        )
+        if quantized_basenames is not None:
+            should_quantize = name.endswith(".weight") and name.removesuffix(".weight") in quantized_basenames
+        else:
+            is_ignored = any(
+                (r.startswith("re:") and re.match(r[3:], name)) or r == name or name.startswith(r)
+                for r in ignore_rules
+            )
+            should_quantize = not is_ignored and name.endswith(".weight") and param.dim() >= 2
 
-        if is_ignored or not name.endswith(".weight") or param.dim() < 2:
+        if not should_quantize:
             results.append((name, param))
             continue
 

--- a/miles/backends/megatron_utils/update_weight/hf_weight_iterator_bridge.py
+++ b/miles/backends/megatron_utils/update_weight/hf_weight_iterator_bridge.py
@@ -1,4 +1,6 @@
 import dataclasses
+import json
+import os
 
 from miles.backends.megatron_utils.lora_utils import is_lora_weight_name
 from miles.utils import megatron_bridge_utils
@@ -17,6 +19,21 @@ class HfWeightIteratorBridge(HfWeightIteratorBase):
         from megatron.bridge import AutoBridge
 
         self._bridge = AutoBridge.from_hf_pretrained(self.args.hf_checkpoint, trust_remote_code=True)
+
+        if (
+            self.quantization_config is not None
+            and self.quantization_config.get("quant_method") == "compressed-tensors"
+        ):
+            quantized_basenames = _load_quantized_param_basenames(self.args.hf_checkpoint)
+            if quantized_basenames is not None:
+                # Quantize exactly the params the checkpoint stores packed; the
+                # published ignore list of multimodal checkpoints (e.g.
+                # Kimi-K2.5 VL) omits vision_tower/mm_projector, so it cannot
+                # be trusted as the sole quantization criterion.
+                self.quantization_config = {
+                    **self.quantization_config,
+                    "_miles_quantized_basenames": quantized_basenames,
+                }
 
     def get_hf_weight_chunks(self, megatron_local_weights, weight_type: str = "base"):
         renamed_megatron_local_weights = {strip_param_name_prefix(k): v for k, v in megatron_local_weights.items()}
@@ -66,6 +83,16 @@ class HfWeightIteratorBridge(HfWeightIteratorBase):
                 yield from quantize_params(self.args, qmegatron_name, [(hf_name, weight)], self.quantization_config)
             else:
                 yield hf_name, weight
+
+
+def _load_quantized_param_basenames(hf_checkpoint):
+    """Base names of params stored packed (`<base>.weight_packed`) in the checkpoint, or None if unknown."""
+    index_path = os.path.join(hf_checkpoint, "model.safetensors.index.json")
+    if not os.path.exists(index_path):
+        return None
+    with open(index_path) as f:
+        names = json.load(f)["weight_map"]
+    return {n.removesuffix(".weight_packed") for n in names if n.endswith(".weight_packed")}
 
 
 def _process_conversion_tasks(vanilla_conversion_tasks, new_weight_dict):

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -2005,7 +2005,14 @@ def miles_validate_args(args):
 
     # TODO: During loading, we need to set the start_rollout_id here.
     if args.megatron_to_hf_mode == "bridge":
-        if args.load is None:
+        # Fresh runs pass a not-yet-created `--load` dir; fall back to the reference
+        # weights (loaded via the HF bridge) instead of asserting in load_checkpoint.
+        # Mirrors the non-bridge branch below.
+        if (
+            args.load is None
+            or not os.path.exists(args.load)
+            or not os.path.exists(os.path.join(args.load, "latest_checkpointed_iteration.txt"))
+        ):
             args.load = args.ref_load or args.hf_checkpoint
         args.start_rollout_id = 0
     else:

--- a/scripts/models/kimi-k25_4layer.sh
+++ b/scripts/models/kimi-k25_4layer.sh
@@ -1,0 +1,26 @@
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")" &>/dev/null && pwd)"
+source "${SCRIPT_DIR}/kimi-k2-thinking.sh"
+
+# Override for the 4-layer pruned debugging model (first_k_dense_replace=1):
+# 1 dense layer + 3 MoE layers. Architecture is otherwise identical to the full
+# Kimi-K2.5 / K2-Thinking, so we reuse those MODEL_ARGS and only patch the
+# layer count and the MoE-layer-frequency mask.
+NLAYERS=4
+FIRST_K_DENSE_REPLACE=1
+
+arr=()
+for ((i = 0; i < NLAYERS; i++)); do
+    if ((i < FIRST_K_DENSE_REPLACE)); then
+        arr+=(0)
+    else
+        arr+=(1)
+    fi
+done
+printf -v MOE_LAYER_FREQ "[%s]" "$(IFS=', '; echo "${arr[*]}")"
+
+for ((i = 0; i < ${#MODEL_ARGS[@]}; i++)); do
+    case "${MODEL_ARGS[$i]}" in
+        --num-layers) MODEL_ARGS[$((i + 1))]=$NLAYERS ;;
+        --moe-layer-freq) MODEL_ARGS[$((i + 1))]="$MOE_LAYER_FREQ" ;;
+    esac
+done

--- a/scripts/run_kimi_k25.py
+++ b/scripts/run_kimi_k25.py
@@ -1,0 +1,276 @@
+"""
+Kimi-K2.5 full-parameter GRPO training script.
+
+=====================
+
+Kimi-K2.5 is a MoE + MLA model (61 layers, 384 experts) shipped as an INT4
+(compressed-tensors, group-quantized) checkpoint. Training keeps the INT4
+weights for the SGLang rollout while Megatron loads a BF16 reference via the
+HF<->Megatron bridge (`--megatron-to-hf-mode bridge`), so there is no offline
+`torch_dist` conversion step. The architecture is shared with Kimi-K2-Thinking,
+whose Megatron MODEL_ARGS we reuse (`scripts/models/kimi-k2-thinking.sh`).
+
+=====================
+
+Args:
+  --model-name: Model variant.
+      Kimi-K2.5         Full 61-layer model (requires many nodes; default 32)
+      Kimi-K2.5-4layer  4-layer pruned model (single-node CI / smoke test)
+  --num-nodes: Number of training nodes. 1 -> single-node 4-layer minimal test.
+  --num-gpus-per-node: GPUs per node (default: 8).
+  --mode: "normal" or "debug_minimal" (short responses for quick testing).
+  --enable-eval: Run AIME evaluation every 20 steps.
+  --data-dir / --model-dir: Dataset / model directories (default shared NFS).
+
+=====================
+
+Single-node minimal test (4-layer):
+  python scripts/run_kimi_k25.py full-train --model-name Kimi-K2.5-4layer --num-nodes 1
+
+Full model (e.g. 32 nodes):
+  1. Start a Ray cluster on all nodes.
+  2. On the head node: python scripts/run_kimi_k25.py prepare --model-name Kimi-K2.5 --num-nodes 32
+  3. On the head node: python scripts/run_kimi_k25.py train   --model-name Kimi-K2.5 --num-nodes 32
+"""
+
+from dataclasses import dataclass
+from typing import Literal
+
+import typer
+
+import miles.utils.external_utils.command_utils as U
+
+app = typer.Typer()
+
+# INT4 dequant group size of the published Kimi-K2.5 checkpoints (compressed-tensors).
+INT4_GROUP_SIZE = 32
+
+# Megatron bridge identifier consumed by megatron_to_hf dispatch ("kimi_k25" in model_name).
+BRIDGE_MODEL_NAME = "kimi_k25"
+
+
+@dataclass
+class ScriptArgs(U.ExecuteTrainConfig):
+    mode: Literal["normal", "debug_minimal"] = "normal"
+    run_id: str = U.create_run_id()
+    model_org: str = "moonshotai"
+    model_name: str = "Kimi-K2.5"
+    megatron_model_type: str = "kimi-k2-thinking"
+    num_gpus_per_node: int = 8
+    enable_eval: bool = False
+    num_rollout: int = 20
+    extra_args: str = ""
+    data_dir: str = "/root/datasets"
+    model_dir: str = "/root/models"
+    megatron_path: str = "/root/Megatron-LM"
+    hardware: Literal["H200", "H100", "B200"] = "H200"
+
+    def __post_init__(self):
+        if self.model_name == "Kimi-K2.5":
+            self.model_org = "moonshotai"
+            self.megatron_model_type = "kimi-k2-thinking"
+        elif self.model_name == "Kimi-K2.5-4layer":
+            self.model_org = "CharyZeng"
+            self.megatron_model_type = "kimi-k25_4layer"
+        else:
+            raise NotImplementedError(f"{self.model_name} is not supported")
+
+        if self.num_nodes == 1:
+            self.mode = "debug_minimal"
+
+
+def _bf16_ref_dir(args: ScriptArgs) -> str:
+    return f"{args.model_dir}/{args.model_name}-bf16"
+
+
+def _prepare_download(args: ScriptArgs):
+    U.exec_command(f"mkdir -p {args.model_dir} {args.data_dir}")
+    U.exec_command(f"hf download {args.model_org}/{args.model_name} --local-dir {args.model_dir}/{args.model_name}")
+    U.hf_download_dataset("zhuzilin/dapo-math-17k", data_dir=args.data_dir)
+    if args.enable_eval:
+        U.hf_download_dataset("zhuzilin/aime-2024", data_dir=args.data_dir)
+
+
+def _convert_to_bf16(args: ScriptArgs):
+    """Dequantize the INT4 checkpoint to a BF16 reference for the Megatron bridge."""
+    U.exec_command(
+        f"python {U.repo_base_dir}/tools/convert_kimi_int4_to_bf16.py "
+        f"--model-dir {args.model_dir}/{args.model_name} "
+        f"--output-dir {_bf16_ref_dir(args)} "
+    )
+
+
+def _execute_train(args: ScriptArgs):
+    load_save_path = f"{args.output_dir}/{args.run_id}/checkpoints"
+    ckpt_args = (
+        f"--hf-checkpoint {args.model_dir}/{args.model_name} "
+        f"--ref-load {_bf16_ref_dir(args)} "
+        "--megatron-to-hf-mode bridge "
+        f"--model-name {BRIDGE_MODEL_NAME} "
+        f"--load {load_save_path} "
+        f"--save {load_save_path} "
+        f"--save-interval {2 if args.mode == 'debug_minimal' else 20} "
+    )
+
+    rollout_args = (
+        f"--prompt-data {args.data_dir}/dapo-math-17k/dapo-math-17k.jsonl "
+        "--input-key prompt "
+        "--label-key label "
+        "--apply-chat-template "
+        "--rollout-shuffle "
+        "--balance-data "
+        "--rm-type deepscaler "
+        f"--num-rollout {args.num_rollout} "
+        "--rollout-batch-size 32 "
+        "--n-samples-per-prompt 8 "
+        f"--rollout-max-response-len {100 if args.mode == 'debug_minimal' else 16384} "
+        "--rollout-temperature 1 "
+        "--global-batch-size 256 "
+        "--use-dynamic-global-batch-size "
+    )
+
+    eval_args = ""
+    if (args.mode != "debug_minimal") and args.enable_eval:
+        eval_args += (
+            "--eval-interval 20 "
+            f"--eval-prompt-data aime {args.data_dir}/aime-2024/aime-2024.jsonl "
+            "--n-samples-per-eval-prompt 16 "
+            "--eval-max-response-len 16384 "
+            "--eval-top-p 1 "
+        )
+
+    if args.num_nodes == 1:  # single-node 4-layer minimal test
+        perf_args = (
+            "--tensor-model-parallel-size 8 "
+            "--sequence-parallel "
+            "--pipeline-model-parallel-size 1 "
+            "--context-parallel-size 1 "
+            "--expert-model-parallel-size 8 "
+            "--expert-tensor-parallel-size 1 "
+        )
+        max_tokens_per_gpu = 2048
+    else:  # full model, slime's 32-node setting
+        perf_args = (
+            "--tensor-model-parallel-size 8 "
+            "--sequence-parallel "
+            "--pipeline-model-parallel-size 8 "
+            "--context-parallel-size 4 "
+            "--expert-model-parallel-size 32 "
+            "--expert-tensor-parallel-size 1 "
+            "--decoder-last-pipeline-num-layers 5 "
+        )
+        max_tokens_per_gpu = 4096
+
+    perf_args += (
+        "--recompute-granularity full "
+        "--recompute-method uniform "
+        "--recompute-num-layers 1 "
+        "--use-dynamic-batch-size "
+        f"--max-tokens-per-gpu {max_tokens_per_gpu} "
+    )
+
+    grpo_args = (
+        "--advantage-estimator grpo "
+        "--kl-loss-coef 0.00 "
+        "--kl-loss-type low_var_kl "
+        "--entropy-coef 0.00 "
+        "--eps-clip 0.2 "
+        "--eps-clip-high 0.28 "
+    )
+
+    optimizer_args = (
+        "--optimizer adam "
+        "--lr 1e-6 "
+        "--lr-decay-style constant "
+        "--weight-decay 0.1 "
+        "--adam-beta1 0.9 "
+        "--adam-beta2 0.98 "
+        "--optimizer-cpu-offload "
+        "--overlap-cpu-optimizer-d2h-h2d "
+        "--use-precision-aware-optimizer "
+        "--use-distributed-optimizer "
+    )
+
+    sglang_args = (
+        f"--rollout-num-gpus-per-engine {args.num_gpus_per_node} "
+        "--sglang-mem-fraction-static 0.7 "
+        f"--sglang-ep-size {args.num_gpus_per_node} "
+        "--sglang-server-concurrency 1024 "
+        "--use-rollout-routing-replay "
+    )
+
+    misc_args = (
+        # default dropout in megatron is 0.1
+        "--attention-dropout 0.0 "
+        "--hidden-dropout 0.0 "
+        # should be good for model performance
+        "--accumulate-allreduce-grads-in-fp32 "
+        "--attention-softmax-in-fp32 "
+        "--attention-backend flash "
+        "--no-check-for-nan-in-loss-and-grad "
+        "--colocate "
+        "--use-miles-router "
+        f"--update-weight-buffer-size {4 * 512 * 1024 * 1024} "
+        f"--actor-num-nodes {args.num_nodes} "
+        f"--actor-num-gpus-per-node {args.num_gpus_per_node} "
+        f"--num-gpus-per-node {args.num_gpus_per_node} "
+    )
+
+    train_args = (
+        f"{ckpt_args} "
+        f"{rollout_args} "
+        f"{optimizer_args} "
+        f"{grpo_args} "
+        f"{U.get_default_wandb_args(__file__, run_id=args.run_id)} "
+        f"{perf_args} "
+        f"{eval_args} "
+        f"{sglang_args} "
+        f"{misc_args} "
+        f"{args.extra_args} "
+    )
+
+    U.execute_train(
+        train_args=train_args,
+        config=args,
+        num_gpus_per_node=args.num_gpus_per_node,
+        megatron_model_type=args.megatron_model_type,
+        extra_env_vars={
+            "NCCL_TIMEOUT": "3600",
+            "OPEN_TRAINING_INT4_FAKE_QAT_FLAG": "1",
+            "OPEN_TRAINING_INT4_GROUP_SIZE": str(INT4_GROUP_SIZE),
+        },
+        megatron_path=args.megatron_path,
+    )
+
+
+@app.command()
+@U.dataclass_cli
+def full_train(args: ScriptArgs):
+    """Full pipeline: download, convert INT4->BF16, train."""
+    _prepare_download(args)
+    _convert_to_bf16(args)
+    _execute_train(args)
+
+
+@app.command()
+@U.dataclass_cli
+def prepare(args: ScriptArgs):
+    """Download model/data and dequantize the BF16 reference (run on head node)."""
+    _prepare_download(args)
+    _convert_to_bf16(args)
+
+
+@app.command()
+@U.dataclass_cli
+def train(args: ScriptArgs):
+    """Run training only (assumes data is prepared)."""
+    _execute_train(args)
+
+
+@app.callback()
+def _callback() -> None:
+    pass
+
+
+if __name__ == "__main__":
+    app()

--- a/scripts/run_kimi_k25.py
+++ b/scripts/run_kimi_k25.py
@@ -58,7 +58,7 @@ class ScriptArgs(U.ExecuteTrainConfig):
     megatron_model_type: str = "kimi-k2-thinking"
     num_gpus_per_node: int = 8
     enable_eval: bool = False
-    num_rollout: int = 20
+    num_rollout: int = 3000
     extra_args: str = ""
     data_dir: str = "/root/datasets"
     model_dir: str = "/root/models"

--- a/tests/e2e/megatron/test_kimi_k25_4layer_ci.py
+++ b/tests/e2e/megatron/test_kimi_k25_4layer_ci.py
@@ -1,0 +1,41 @@
+import os
+
+from scripts.run_kimi_k25 import ScriptArgs, _convert_to_bf16, _execute_train, _prepare_download
+from tests.ci.ci_register import register_cuda_ci
+
+import miles.utils.external_utils.command_utils as U
+
+# Smoke test for the Kimi-K2.5 (MoE + MLA, INT4 rollout + BF16 Megatron bridge) training
+# script. It runs the 4-layer pruned model on a single 8-GPU node and only verifies that
+# the training script is functional, not model accuracy.
+
+
+register_cuda_ci(est_time=1800, suite="stage-c-8-gpu-h100", labels=["model-scripts"])
+
+
+def _args() -> ScriptArgs:
+    return ScriptArgs(
+        model_name="Kimi-K2.5-4layer",
+        num_nodes=1,
+        num_gpus_per_node=8,
+        num_rollout=2,
+        extra_args=("--ci-test " "--ci-disable-logprobs-checker " "--disable-weights-backuper "),
+    )
+
+
+def prepare(args: ScriptArgs):
+    U.exec_command(f"mkdir -p {args.output_dir}")
+    _prepare_download(args)
+    _convert_to_bf16(args)
+
+
+def execute(args: ScriptArgs):
+    _execute_train(args)
+
+
+if __name__ == "__main__":
+    args = _args()
+    prepare(args)
+    for proxy_var in ("http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY"):
+        os.environ.pop(proxy_var, None)
+    execute(args)


### PR DESCRIPTION
## What

Adds a Python launch script for **Kimi-K2.5** full-parameter GRPO plus a CI smoke test, following the established model-script pattern (`run_qwen3_30b_a3b.py` / `run_glm5_744b_a40b.py` + the GLM-5 4-layer CI).

### Files
- **`scripts/run_kimi_k25.py`** — Python launch script with importable `prepare` / `execute` functions and `full-train` / `prepare` / `train` subcommands. Encodes the working config from `scripts/run-kimi-k25.sh`:
  - INT4 checkpoint feeds the SGLang rollout; Megatron loads a BF16 reference via the HF bridge (`--megatron-to-hf-mode bridge`) — no offline `torch_dist` conversion.
  - Dequantizes INT4→BF16 with `tools/convert_kimi_int4_to_bf16.py` in `prepare`.
  - MLA + MoE Megatron args reused from `scripts/models/kimi-k2-thinking.sh`; parallelism scales between single-node (4-layer) and the full 32-node setting.
- **`tests/e2e/megatron/test_kimi_k25_4layer_ci.py`** — single-node 8-GPU smoke test on the 4-layer pruned model `CharyZeng/Kimi-K2.5-4layer`. Registered with `register_cuda_ci(suite="stage-c-8-gpu-h100", labels=["model-scripts"])`, identical to the GLM-5 4-layer CI; auto-discovered by the suite runner and gated on the `run-ci-model-scripts` label.
- **`scripts/models/kimi-k25_4layer.sh`** — Megatron `MODEL_ARGS` override sourcing `kimi-k2-thinking.sh` and patching `num-layers=4`, `moe-layer-freq=[0,1,1,1]` (1 dense + 3 MoE).

### CI model
`CharyZeng/Kimi-K2.5-4layer` (public) is a 4-layer truncation of `moonshotai/Kimi-K2.5` — keeps embeddings / lm_head / final norm / full vision tower and decoder layers 0–3 — analogous to `Pinaster/GLM-5_4layer`.

## Test
Smoke test only verifies the training script is functional (not model accuracy). It runs the 4-layer model on one 8-GPU H100 node via the `model-scripts` CI suite.