### PR TITLE
Use q lora atomic update groups

### DIFF
--- a/miles/backends/megatron_utils/megatron_to_hf/__init__.py
+++ b/miles/backends/megatron_utils/megatron_to_hf/__init__.py
@@ -1,7 +1,3 @@
-from __future__ import annotations
-
-from typing import TYPE_CHECKING
-
 from .deepseekv3 import convert_deepseekv3_to_hf
 from .glm4 import convert_glm4_to_hf
 from .glm4moe import convert_glm4moe_to_hf
@@ -13,9 +9,6 @@ from .qwen2 import convert_qwen2_to_hf
 from .qwen3_5 import convert_qwen3_5_to_hf
 from .qwen3_next import convert_qwen3_next_to_hf
 from .qwen3moe import convert_qwen3moe_to_hf
-
-if TYPE_CHECKING:
-    from ..update_weight.common import AtomicUpdateGroup
 
 
 # TODO unify w/ `convert_to_hf`
@@ -32,27 +25,6 @@ def convert_to_hf(args, model_name, name, param, quantization_config=None):
     converted_named_tensors = _convert_to_hf_core(args, model_name, name, param)
 
     return quantize_params(args, name, converted_named_tensors, quantization_config)
-
-
-def get_atomic_update_groups(args, model_name) -> list[AtomicUpdateGroup]:
-    return _get_q_lora_atomic_update_groups(args)
-
-
-def _get_q_lora_atomic_update_groups(args) -> list[AtomicUpdateGroup]:
-    if args.q_lora_rank is None:
-        return []
-
-    from ..update_weight.common import AtomicUpdateGroup
-
-    return [
-        AtomicUpdateGroup(
-            key="q_lora_a_proj",
-            suffixes=(
-                ".self_attention.linear_q_down_proj.weight",
-                ".self_attention.linear_kv_down_proj.weight",
-            ),
-        )
-    ]
 
 
 # TODO optimize code details

--- a/miles/backends/megatron_utils/megatron_to_hf/__init__.py
+++ b/miles/backends/megatron_utils/megatron_to_hf/__init__.py
@@ -1,4 +1,6 @@
-from dataclasses import dataclass
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 from .deepseekv3 import convert_deepseekv3_to_hf
 from .glm4 import convert_glm4_to_hf
@@ -12,11 +14,8 @@ from .qwen3_5 import convert_qwen3_5_to_hf
 from .qwen3_next import convert_qwen3_next_to_hf
 from .qwen3moe import convert_qwen3moe_to_hf
 
-
-@dataclass(frozen=True)
-class AtomicUpdateGroup:
-    key: str
-    suffixes: tuple[str, ...]
+if TYPE_CHECKING:
+    from ..update_weight.common import AtomicUpdateGroup
 
 
 # TODO unify w/ `convert_to_hf`
@@ -42,6 +41,8 @@ def get_atomic_update_groups(args, model_name) -> list[AtomicUpdateGroup]:
 def _get_q_lora_atomic_update_groups(args) -> list[AtomicUpdateGroup]:
     if args.q_lora_rank is None:
         return []
+
+    from ..update_weight.common import AtomicUpdateGroup
 
     return [
         AtomicUpdateGroup(

--- a/miles/backends/megatron_utils/megatron_to_hf/__init__.py
+++ b/miles/backends/megatron_utils/megatron_to_hf/__init__.py
@@ -36,11 +36,22 @@ def convert_to_hf(args, model_name, name, param, quantization_config=None):
 
 
 def get_atomic_update_groups(args, model_name) -> list[AtomicUpdateGroup]:
-    return []
+    return _get_q_lora_atomic_update_groups(args)
 
 
-# TODO optimize
-_cached_tensors = {}
+def _get_q_lora_atomic_update_groups(args) -> list[AtomicUpdateGroup]:
+    if args.q_lora_rank is None:
+        return []
+
+    return [
+        AtomicUpdateGroup(
+            key="q_lora_a_proj",
+            suffixes=(
+                ".self_attention.linear_q_down_proj.weight",
+                ".self_attention.linear_kv_down_proj.weight",
+            ),
+        )
+    ]
 
 
 # TODO optimize code details
@@ -76,33 +87,6 @@ def _convert_to_hf_core(args, model_name, name, param):
     else:
         raise ValueError(f"Unsupported model: {model_name}")
 
-    # to compatible with sglang implementation
-    if args.q_lora_rank is not None:
-        old_converted_named_tensors = converted_named_tensors
-        converted_named_tensors = []
-        for converted_name, converted_param in old_converted_named_tensors:
-            if "q_a_proj" in converted_name:
-                pair_name = converted_name.replace("q_a_proj", "kv_a_proj_with_mqa")
-                if pair_name in _cached_tensors:
-                    converted_named_tensors += [
-                        (converted_name, converted_param),
-                        (pair_name, _cached_tensors[pair_name]),
-                    ]
-                    del _cached_tensors[pair_name]
-                else:
-                    _cached_tensors[converted_name] = converted_param
-            elif "kv_a_proj_with_mqa" in converted_name:
-                pair_name = converted_name.replace("kv_a_proj_with_mqa", "q_a_proj")
-                if pair_name in _cached_tensors:
-                    converted_named_tensors += [
-                        (converted_name, converted_param),
-                        (pair_name, _cached_tensors[pair_name]),
-                    ]
-                    del _cached_tensors[pair_name]
-                else:
-                    _cached_tensors[converted_name] = converted_param
-            else:
-                converted_named_tensors.append((converted_name, converted_param))
     return converted_named_tensors
 
 

--- a/miles/backends/megatron_utils/update_weight/common.py
+++ b/miles/backends/megatron_utils/update_weight/common.py
@@ -24,6 +24,25 @@ class AtomicUpdateGroup:
     suffixes: tuple[str, ...]
 
 
+def get_atomic_update_groups(args, model_name) -> list[AtomicUpdateGroup]:
+    return _get_q_lora_atomic_update_groups(args)
+
+
+def _get_q_lora_atomic_update_groups(args) -> list[AtomicUpdateGroup]:
+    if args.q_lora_rank is None:
+        return []
+
+    return [
+        AtomicUpdateGroup(
+            key="q_lora_a_proj",
+            suffixes=(
+                ".self_attention.linear_q_down_proj.weight",
+                ".self_attention.linear_kv_down_proj.weight",
+            ),
+        )
+    ]
+
+
 @dataclasses.dataclass(frozen=True)
 class NamedUpdateUnit:
     """A set of params that must be transferred and packed together."""

--- a/miles/backends/megatron_utils/update_weight/common.py
+++ b/miles/backends/megatron_utils/update_weight/common.py
@@ -19,6 +19,12 @@ logger = logging.getLogger(__name__)
 
 
 @dataclasses.dataclass(frozen=True)
+class AtomicUpdateGroup:
+    key: str
+    suffixes: tuple[str, ...]
+
+
+@dataclasses.dataclass(frozen=True)
 class NamedUpdateUnit:
     """A set of params that must be transferred and packed together."""
 

--- a/miles/backends/megatron_utils/update_weight/hf_weight_iterator_direct.py
+++ b/miles/backends/megatron_utils/update_weight/hf_weight_iterator_direct.py
@@ -10,9 +10,15 @@ from miles.backends.training_utils.parallel import get_parallel_state
 from miles.utils.distributed_utils import get_gloo_group
 from miles.utils.types import ParamInfo
 
-from ..megatron_to_hf import convert_to_hf, get_atomic_update_groups
+from ..megatron_to_hf import convert_to_hf
 from ..sglang import monkey_patch_torch_reductions
-from .common import NamedUpdateUnit, all_gather_params_async, get_named_update_units, named_params_and_buffers
+from .common import (
+    NamedUpdateUnit,
+    all_gather_params_async,
+    get_atomic_update_groups,
+    get_named_update_units,
+    named_params_and_buffers,
+)
 from .hf_weight_iterator_base import HfWeightIteratorBase
 
 

--- a/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/mixin.py
+++ b/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/mixin.py
@@ -9,10 +9,11 @@ from miles.backends.training_utils.parallel import get_parallel_state
 from miles.utils.distributed_utils import get_gloo_group
 from miles.utils.timer import timer
 
-from ...megatron_to_hf import convert_to_hf, get_atomic_update_groups
+from ...megatron_to_hf import convert_to_hf
 from ..common import (
     all_gather_param,
     collect_named_tensors_for_weight_transfer,
+    get_atomic_update_groups,
     get_named_value_update_units,
     post_process_weights,
 )

--- a/tests/fast/backends/megatron_utils/test_hf_weight_iterator_direct.py
+++ b/tests/fast/backends/megatron_utils/test_hf_weight_iterator_direct.py
@@ -106,7 +106,7 @@ def _param(name: str, size: int) -> ParamInfo:
 
 
 def test_atomic_group_is_single_update_unit_and_packed_together(direct_module, monkeypatch):
-    from miles.backends.megatron_utils.megatron_to_hf import AtomicUpdateGroup
+    from miles.backends.megatron_utils.update_weight.common import AtomicUpdateGroup
 
     params = [_param("layer.a", 4), _param("layer.b", 4), _param("layer.c", 4)]
     monkeypatch.setattr(direct_module, "_get_param_full_size", lambda info: info.size)
@@ -121,7 +121,7 @@ def test_atomic_group_is_single_update_unit_and_packed_together(direct_module, m
 
 
 def test_atomic_group_specs_raise_explicit_errors(direct_module, monkeypatch):
-    from miles.backends.megatron_utils.megatron_to_hf import AtomicUpdateGroup
+    from miles.backends.megatron_utils.update_weight.common import AtomicUpdateGroup
 
     params = [_param("layer.a", 4), _param("layer.b", 4)]
 
@@ -158,7 +158,7 @@ def _distributed_updater(mixin_module):
 
 
 def test_distributed_non_expert_update_units_are_packed_together(direct_module, monkeypatch):
-    from miles.backends.megatron_utils.megatron_to_hf import AtomicUpdateGroup
+    from miles.backends.megatron_utils.update_weight.common import AtomicUpdateGroup
     from miles.backends.megatron_utils.update_weight.update_weight_from_distributed import mixin
 
     updater = _distributed_updater(mixin)
@@ -182,7 +182,7 @@ def test_distributed_non_expert_update_units_are_packed_together(direct_module, 
 
 
 def test_distributed_expert_update_units_are_packed_together(direct_module, monkeypatch):
-    from miles.backends.megatron_utils.megatron_to_hf import AtomicUpdateGroup
+    from miles.backends.megatron_utils.update_weight.common import AtomicUpdateGroup
     from miles.backends.megatron_utils.update_weight.update_weight_from_distributed import mixin
 
     updater = _distributed_updater(mixin)
@@ -214,7 +214,7 @@ def test_distributed_expert_update_units_are_packed_together(direct_module, monk
 
 
 def test_distributed_atomic_group_cannot_span_expert_and_non_expert(direct_module, monkeypatch):
-    from miles.backends.megatron_utils.megatron_to_hf import AtomicUpdateGroup
+    from miles.backends.megatron_utils.update_weight.common import AtomicUpdateGroup
     from miles.backends.megatron_utils.update_weight.update_weight_from_distributed import mixin
 
     updater = _distributed_updater(mixin)


### PR DESCRIPTION
## Summary
- replay #1275 onto `main` after the original PR was merged into the wrong target branch
- replace the q-lora conversion cache with static atomic update groups
- move `AtomicUpdateGroup`, `get_atomic_update_groups`, and q-lora group construction into `update_weight/common.py`
- keep `q_a_proj` and `kv_a_proj_with_mqa` in the same update unit before HF conversion
- keep `convert_to_hf` stateless for q-lora weights

## Validation
- `python -m compileall miles/backends/megatron_utils/megatron_to_hf/__init__.py miles/backends/megatron_utils/update_weight/common.py miles/backends/megatron_utils/update_weight/hf_weight_iterator_direct.py miles/backends/megatron_utils/update_weight/update_weight_from_distributed/mixin.py`
- `python -m pytest --confcutdir=tests/fast/backends/megatron_utils tests/fast/backends/megatron_utils/test_hf_weight_iterator_direct.py -q`
- `pre-commit run --all-files`