### PR TITLE
fix(ray): wait for rollout engine actors to terminate

### DIFF
--- a/miles/ray/rollout/server_group.py
+++ b/miles/ray/rollout/server_group.py
@@ -198,18 +198,11 @@ class ServerGroup:
                     logger.info(f"Engine actor at index {i} is already terminated")
                 except Exception as e:
                     logger.warning(
-                        "Fail to gracefully terminate engine actor at index %s; " "force killing (e: %s)",
+                        "Fail to terminate engine actor at index %s; force killing (e: %s)",
                         i,
                         e,
                     )
-                    try:
-                        ray.kill(actor_handle)
-                    except Exception as kill_error:
-                        logger.warning(
-                            "Fail to kill engine actor at index %s (e: %s)",
-                            i,
-                            kill_error,
-                        )
+                    ray.kill(actor_handle)
             else:
                 logger.info(f"Engine at index {i} is already None")
             self.all_engines[i].mark_stopped()

--- a/miles/ray/rollout/server_group.py
+++ b/miles/ray/rollout/server_group.py
@@ -19,6 +19,7 @@ from miles.ray.utils import NOSET_VISIBLE_DEVICES_ENV_VARS_LIST
 from miles.utils import dumper_utils
 
 logger = logging.getLogger(__name__)
+_ACTOR_TERMINATE_TIMEOUT_S = 10.0
 
 
 @dataclasses.dataclass
@@ -182,12 +183,33 @@ class ServerGroup:
             engine = self.all_engines[i]
             if engine.is_allocated:
                 logger.info(f"Shutting down and killing engine at index {i}")
+                actor_handle = engine.actor_handle
                 try:
-                    ray.get(engine.actor_handle.shutdown.remote())
-                    ray.kill(engine.actor_handle)
-                    logger.info(f"Successfully killed engine at index {i}")
+                    ray.get(actor_handle.shutdown.remote())
                 except Exception as e:
-                    logger.warning(f"Fail to kill engine at index {i} (e: {e})")
+                    logger.warning(f"Fail to shutdown engine at index {i} (e: {e})")
+                try:
+                    ray.get(
+                        actor_handle.__ray_terminate__.remote(),
+                        timeout=_ACTOR_TERMINATE_TIMEOUT_S,
+                    )
+                    logger.info(f"Successfully terminated engine actor at index {i}")
+                except (ray.exceptions.RayActorError, ray.exceptions.RayTaskError):
+                    logger.info(f"Engine actor at index {i} is already terminated")
+                except Exception as e:
+                    logger.warning(
+                        "Fail to gracefully terminate engine actor at index %s; " "force killing (e: %s)",
+                        i,
+                        e,
+                    )
+                    try:
+                        ray.kill(actor_handle)
+                    except Exception as kill_error:
+                        logger.warning(
+                            "Fail to kill engine actor at index %s (e: %s)",
+                            i,
+                            kill_error,
+                        )
             else:
                 logger.info(f"Engine at index {i} is already None")
             self.all_engines[i].mark_stopped()


### PR DESCRIPTION
## Summary
Wait for rollout engine actors to terminate before marking them stopped

## Symptom & Reproduction
- **Symptom:** `ServerGroup.stop_engines()` returned while old Ray actor handles could still answer `health_generate`.
- **Reproduction:** `RAY_ADDRESS=local python -m pytest -q tests/fast/ray/rollout/real_ray/test_server_group.py::TestStopEnginesRealKill`
- **Observed CI failure:** `stage-a-cpu / run-cpu` in https://github.com/radixark/miles/actions/runs/26812911173/job/79047349076.
- **Reproduction limit:** This is a timing-sensitive Ray actor termination race; the pre-fix test may pass when Ray finishes killing the actor before the follow-up health check.

## Context
- #911 extracted the rollout engine stop path from `RolloutHealthMonitor._kill_engine` into `ServerGroup.stop_engines`.
- #943 kept `stop_engines` synchronous for state consistency.
- #943 generalized `stop_engines` to `engine_indices`.
- #1082 added `TestStopEnginesRealKill`.
- `TestStopEnginesRealKill` checks that a stopped actor cannot answer a follow-up `.remote()` call.
- This PR does not revert #911, #943, or #1082.
- #1082 expected a wait boundary before `mark_stopped`.
- The old implementation did not provide that wait boundary reliably.

## Root Cause
1. `stop_engines` used non-waitable `ray.kill` after `shutdown`.
2. `ServerEngine.mark_stopped` ran before actor death was observable.

## Fix
Call actor `shutdown`, then wait on `actor_handle.__ray_terminate__` with `_ACTOR_TERMINATE_TIMEOUT_S` before `ServerEngine.mark_stopped`. Treat actor-death errors as success because they prove the actor is gone. Use `ray.kill` only when the terminate wait fails, and let hard-kill failures propagate instead of marking the engine stopped.

## Why This Fix Is Correct
- `ray.kill(actor_handle)` only sends a kill request.
- `ray.kill(actor_handle)` returns no `ObjectRef` that `stop_engines` can wait on.
- `actor_handle.__ray_terminate__.remote()` is a Ray actor task that calls `exit_actor()`.
- `ray.get(..., timeout=...)` gives `stop_engines` a concrete termination barrier.
- The failing CI observed `health_generate` succeeding after `stop_engines()` returned.
- With the termination barrier, the same follow-up call sees actor death.
- The observed actor death surfaces as `RayActorError` or `RayTaskError`.
- This is not a test-only change.
- Once local state is cleared by `ServerEngine.mark_stopped`, the old actor must no longer accept rollout requests.
- This is not changing the stop flow back to the pre-#911 location.
- It keeps the `ServerGroup.stop_engines` ownership introduced by #911.

## Verification
- **New / updated test:** Existing `TestStopEnginesRealKill` passes with `RAY_ADDRESS=local`.
- **Local check:** `python -m compileall miles/ray/rollout/server_group.py`.

## Review Focus
- Scrutinize `ServerGroup.stop_engines` ordering from `shutdown` to `__ray_terminate__` to fallback `ray.kill`.
- Scrutinize actor-dead exception handling before `ServerEngine.mark_stopped`.
