### PR TITLE
[miles] fix: always enable SGLang Prometheus metrics

### DIFF
--- a/miles/backends/sglang_utils/sglang_engine.py
+++ b/miles/backends/sglang_utils/sglang_engine.py
@@ -635,6 +635,8 @@ def _compute_server_args(
         "skip_server_warmup": True,
         # always enable draft weights cpu backup so that we run training without mtp weights.
         "enable_draft_weights_cpu_backup": True,
+        # always serve /metrics so Prometheus scrapers can read engine stats.
+        "enable_metrics": True,
     }
 
     if sglang_overrides:
@@ -709,5 +711,6 @@ _EXTERNAL_ENGINE_SKIP_CHECK_FIELDS = [
     "dist_init_addr",
     "skip_server_warmup",
     "enable_draft_weights_cpu_backup",
+    "enable_metrics",
     "mem_fraction_static",
 ]


### PR DESCRIPTION
## Summary
- Force `enable_metrics=True` on every SGLang engine launch in `_compute_server_args` so `/metrics` is always served.
- Add `enable_metrics` to `_EXTERNAL_ENGINE_SKIP_CHECK_FIELDS` so externally-launched engines whose flag differs don't trip the parity check.

## Why
`/metrics` is what Prometheus / wandb scrapers read from. SGLang's `ServerArgs.enable_metrics` defaults to `False`, so engines launched without an explicit `--sglang-enable-metrics` serve nothing on `/metrics`, the scrape returns `{}`, and no SGLang engine stats reach the wandb dashboard. Recent Qwen3-VL-32B-Thinking RL runs ship with empty SGLang metric panels vs. earlier runs that had full panels.

The fix mirrors the same hardcoded toggle that exists in slime's equivalent file (`slime/backends/sglang_utils/sglang_engine.py`). Three lines, no behavior change for runs that already pass `--sglang-enable-metrics`.

## Test plan
- [x] `pre-commit run --files miles/backends/sglang_utils/sglang_engine.py` — passes
- [ ] Live verification: an RL run launched with this fix should populate `sglang/*` keys in wandb (compare against a baseline run that omits the fix; both runs should otherwise be identical)