### PR TITLE
feat(p2p): make Mooncake transport configurable via MOONCAKE_PROTOCOL

### DIFF
--- a/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/p2p_transfer_utils.py
+++ b/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/p2p_transfer_utils.py
@@ -1,5 +1,6 @@
 import dataclasses
 import logging
+import os
 from argparse import Namespace
 from collections import defaultdict
 from collections.abc import Callable, Sequence
@@ -208,7 +209,17 @@ def register_cpu_memory(params_dict: dict, transfer_engine) -> dict:
 def create_transfer_engine():
     transfer_engine = TransferEngine()
     local_ip = ray._private.services.get_node_ip_address()
-    transfer_engine.initialize(local_ip, "P2PHANDSHAKE", "rdma", "")
+    # MOONCAKE_PROTOCOL selects the transport (rdma | efa | tcp | ...).
+    # Default is "rdma"; set MOONCAKE_PROTOCOL=efa on AWS EFA hardware.
+    # MOONCAKE_DEVICE optionally pins the NIC/device ("" = auto-discover).
+    # This mirrors the sglang rollout side, which reads the same envs when
+    # initializing its remote-instance TransferEngine, so a single pair of
+    # env vars configures both ends of the P2P transfer.
+    # `or "rdma"` also covers MOONCAKE_PROTOCOL set to an empty string;
+    # .lower() normalizes case (e.g. "EFA" -> "efa") for the provider match.
+    protocol = (os.getenv("MOONCAKE_PROTOCOL") or "rdma").lower()
+    device = os.getenv("MOONCAKE_DEVICE", "")
+    transfer_engine.initialize(local_ip, "P2PHANDSHAKE", protocol, device)
     return transfer_engine
 
 


### PR DESCRIPTION
## What

P2P weight transfer hardcodes `"rdma"` when it initializes the Mooncake `TransferEngine` in `create_transfer_engine()`:

```python
transfer_engine.initialize(local_ip, "P2PHANDSHAKE", "rdma", "")
```

so it can only run on InfiniBand RDMA and fails on other Mooncake transports such as AWS EFA.

This PR reads the transport from `MOONCAKE_PROTOCOL` (default `"rdma"`, unchanged) and an optional `MOONCAKE_DEVICE` (default `""` = auto-discover):

```python
protocol = (os.getenv("MOONCAKE_PROTOCOL") or "rdma").lower()
device = os.getenv("MOONCAKE_DEVICE", "")
transfer_engine.initialize(local_ip, "P2PHANDSHAKE", protocol, device)
```

## Why this is consistent

The sglang rollout side already reads the same env vars when it initializes its remote-instance `TransferEngine` (`ModelRunner.remote_instance_init_transfer_engine` uses `envs.MOONCAKE_PROTOCOL` / `envs.MOONCAKE_DEVICE`). With this change, one pair of env vars configures **both** ends of the P2P transfer. Default behavior is unchanged for existing InfiniBand users.

## Testing

Verified end-to-end on 2× AWS p5 (8× H100 + EFA each) with `MOONCAKE_PROTOCOL=efa`:

- **Qwen3-4B** (single node, 4 train + 4 rollout): 13 rollouts complete, `--check-weight-update-equal` passes.
- **Moonlight-16B-A3B** (2 nodes, TP=2 / EP=8, 16 ranks): Ray rendezvous over both nodes, all `update_weights` succeed, `--check-weight-update-equal` passes, 13 rollouts complete.

Both `--update-weight-transfer-mode p2p`.

> Note: on EFA the same-host (co-located trainer→rollout) P2P transfer must run over device RDMA rather than the EFA-rdm SHM path, otherwise `batch_transfer_sync_write` hangs. Setting `FI_EFA_ENABLE_SHM_TRANSFER=0` resolves it. That is a libfabric/EFA provider-level knob, orthogonal to this code change.

## Checklist

- [x] No new launch flag (reads an env var, like the sglang rollout side); no `--help` / CLI-reference change needed.
- [x] Default behavior unchanged — `MOONCAKE_PROTOCOL` unset or empty → `"rdma"`, exactly as before; existing InfiniBand users are unaffected.
- [x] Verified end-to-end on EFA hardware (see Testing).
- [ ] No new unit test: the change only swaps a hardcoded literal for an env lookup with the same default; behavior is covered by the e2e run above. Happy to add one if preferred.
