### PR TITLE
test: disable flaky TestStopEnginesRealKill pending #1282

### DIFF
--- a/tests/fast/ray/rollout/real_ray/test_server_group.py
+++ b/tests/fast/ray/rollout/real_ray/test_server_group.py
@@ -121,6 +121,10 @@ class TestStartEnginesRealActors:
             ray.kill(h)
 
 
+# FIXME(@fzyzcjy): TestStopEnginesRealKill is a timing-sensitive Ray actor
+# termination race that flakes in CI (stage-a-cpu). Real fix tracked in
+# https://github.com/radixark/miles/pull/1282 — re-enable once that lands.
+@pytest.mark.skip(reason="FIXME(@fzyzcjy): flaky Ray actor termination race; real fix in #1282")
 class TestStopEnginesRealKill:
     """``ray.kill`` is the real thing here — we verify the actor is actually
     dead by issuing a follow-up ``.remote()`` and expecting RayActorError."""


### PR DESCRIPTION
## Summary
Disable the flaky `TestStopEnginesRealKill` class to unblock CI until the real fix lands.

## Motivation
`tests/fast/ray/rollout/real_ray/test_server_group.py::TestStopEnginesRealKill`
asserts that a stopped Ray actor cannot answer a follow-up `health_generate`
call. This is a timing-sensitive Ray actor termination race:
`ServerGroup.stop_engines()` can return while the old actor handle still
answers, so the test flakes in CI (`stage-a-cpu / run-cpu`).

The real fix — waiting on `__ray_terminate__` before `mark_stopped` — is in
#1282 and still under review. This PR is a stopgap so the flake stops blocking
unrelated CI.

## Change
- Mark the whole `TestStopEnginesRealKill` class with `@pytest.mark.skip`.
- Leave a `FIXME(@fzyzcjy)` comment pointing at #1282 to re-enable once it lands.

## Not in scope
- No change to `ServerGroup.stop_engines` behavior; the real fix stays in #1282.

## Verification
- `python -m py_compile tests/fast/ray/rollout/real_ray/test_server_group.py` passes.
- The class is collected as skipped; the other tests in the file are unaffected.
