### PR TITLE
[OPD] Per-position teacher scoring (sparse top-k) + kaixih's robustness fixes

### DIFF
--- a/docs/advanced/on-policy-distillation.md
+++ b/docs/advanced/on-policy-distillation.md
@@ -12,6 +12,8 @@ On-policy distillation (OPD) trains a student model on its own rollouts while us
 | `--opd-log-prob-top-k` | Number of top-k tokens retained for the Rethinking OPD token reward. `0` uses sampled-token OPD; `16` matches the paper recipe default. |
 | `--opd-top-k-strategy` | Top-k token set strategy: `only-student`, `only-teacher`, `intersection`, `union`, or `xor`. |
 | `--opd-reward-weight-mode` | Weighting scheme for top-k rewards: `student_p`, `teacher_p`, or `none`. |
+| `--opd-teacher-urls` | Optional multi-teacher routing map (`NAME=URL` pairs, SGLang mode only). Routes each sample to a teacher by `sample.metadata[--opd-teacher-key]`; reserved name `default` is the fallback. Unset = single teacher at `--rm-url`. |
+| `--opd-teacher-key` | Metadata key holding the teacher name for routing (default: `opd_teacher`). |
 | `--opd-teacher-load` | Path to teacher Megatron checkpoint. **Required** when `--opd-type=megatron`, **must not be set** when `--opd-type=sglang`. |
 | `--opd-teacher-ckpt-step` | Optional checkpoint step for teacher model. |
 
@@ -70,6 +72,42 @@ The teacher runs on an external SGLang server. Teacher log-probs are obtained du
 --custom-reward-post-process-path miles.rollout.on_policy_distillation.post_process_rewards
 --rm-url http://<TEACHER_IP>:<TEACHER_PORT>/generate
 ```
+
+### Multi-Teacher Routing (SGLang mode only)
+
+`--opd-teacher-urls` routes each sample to a task-specific teacher, e.g. a math
+specialist for math prompts and a code specialist for code prompts. Each sample
+is still scored by exactly one teacher, so scoring cost is identical to
+single-teacher OPD and the loss is unchanged — `teacher_log_probs` /
+`opd_reverse_kl` are per-sample and do not care which teacher produced them.
+
+**How it works**:
+1. Tag each prompt with a teacher name in its dataset metadata column
+   (read via `--metadata-key`, default `metadata`):
+   ```json
+   {"prompt": "...", "metadata": {"opd_teacher": "math"}}
+   {"prompt": "...", "metadata": {"opd_teacher": "code"}}
+   ```
+2. Map names to teacher endpoints with `--opd-teacher-urls NAME=URL ...`.
+   The reserved name `default` is the fallback for samples whose name is
+   missing or unknown; without a `default` entry such samples raise an error
+   (failing loudly beats silently distilling from the wrong teacher).
+3. `reward_func` resolves the URL per sample; everything downstream is
+   unchanged.
+
+**Configuration** (on top of the SGLang-mode flags above; `--rm-url` is ignored
+when the routing map is set):
+```bash
+--opd-teacher-urls math=http://<H1>:<P1>/generate code=http://<H2>:<P2>/generate default=http://<H1>:<P1>/generate
+--opd-teacher-key opd_teacher   # metadata key holding the teacher name (default)
+```
+
+> **Notes**: All teachers must share the student's tokenizer — scoring sends
+> `input_ids` and gathers per-token-id log-probs. Works with both the
+> sampled-token path and the top-k path (student-side scoring still goes to the
+> student router). For throughput, point multiple names (or one name backed by
+> an sglang router) at replicas; `--opd-teacher-urls` is for *different*
+> teachers, not load balancing.
 
 ### Megatron Mode (`--opd-type megatron`)
 

--- a/examples/on_policy_distillation/README.md
+++ b/examples/on_policy_distillation/README.md
@@ -10,6 +10,10 @@ This directory contains runnable examples:
 - `run-qwen3-8B-opd.sh`: SGLang teacher server OPD. This script enables
   Rethinking OPD with `--opd-log-prob-top-k 16`, `--opd-top-k-strategy only-student`,
   and `--opd-reward-weight-mode student_p`.
+- `run-qwen3-8B-opd-multi-teacher.sh`: Multi-teacher OPD with per-sample routing.
+  Math prompts are scored by a Qwen3-32B teacher and code prompts by a
+  Qwen3-Coder-30B-A3B teacher, selected via `--opd-teacher-urls` and a per-row
+  `{"metadata": {"opd_teacher": ...}}` tag in the dataset.
 - `run-qwen3-8B-opd-megatron.sh`: Megatron-loaded teacher OPD.
 
 Use `--opd-log-prob-top-k 0` to run the original sampled-token OPD path.

--- a/examples/on_policy_distillation/run-qwen3-8B-opd-multi-teacher.sh
+++ b/examples/on_policy_distillation/run-qwen3-8B-opd-multi-teacher.sh
@@ -1,0 +1,243 @@
+#!/bin/bash
+
+# Multi-teacher OPD: route each sample to a task-specific teacher.
+#
+# Student:       Qwen3-8B (2 training GPUs + 4 rollout GPUs)
+# Math teacher:  Qwen3-32B                  (GPU 6) <- "math"-tagged prompts + default
+# Code teacher:  Qwen3-Coder-30B-A3B-Instruct (GPU 7) <- "code"-tagged prompts
+#
+# Routing is per sample via sample.metadata["opd_teacher"] and --opd-teacher-urls.
+# Scoring cost is identical to single-teacher OPD: each rollout is scored once,
+# by exactly one teacher. All teachers must share the student's tokenizer
+# (scoring sends input_ids), which holds for the Qwen3 family used here.
+#
+# usage: bash examples/on_policy_distillation/run-qwen3-8B-opd-multi-teacher.sh
+
+set -ex
+
+MATH_TEACHER_IP="127.0.0.1"
+MATH_TEACHER_PORT=13141
+CODE_TEACHER_IP="127.0.0.1"
+CODE_TEACHER_PORT=13142
+
+start_teacher() {
+    local gpu=$1 model_path=$2 port=$3
+    local log_file
+    log_file="/tmp/sglang_$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 6).log"
+    CUDA_VISIBLE_DEVICES=$gpu python3 -m sglang.launch_server \
+        --model-path "$model_path" \
+        --host 0.0.0.0 \
+        --port "$port" \
+        --tp 1 \
+        --chunked-prefill-size 4096 \
+        --mem-fraction-static 0.6 \
+        > "$log_file" 2>&1 &
+    echo "$log_file"
+}
+
+wait_teacher() {
+    local ip=$1 port=$2 log_file=$3
+    until curl -sf "http://$ip:$port/health_generate" > /dev/null; do
+        echo "Waiting for teacher server at $ip:$port..."
+        tail -n 10 "$log_file"
+        sleep 5
+    done
+    curl "http://$ip:$port/get_model_info"
+    echo "Teacher server is up at $ip:$port."
+}
+
+MATH_LOG=$(start_teacher 6 /root/Qwen3-32B "$MATH_TEACHER_PORT")
+CODE_LOG=$(start_teacher 7 /root/Qwen3-Coder-30B-A3B-Instruct "$CODE_TEACHER_PORT")
+wait_teacher "$MATH_TEACHER_IP" "$MATH_TEACHER_PORT" "$MATH_LOG"
+wait_teacher "$CODE_TEACHER_IP" "$CODE_TEACHER_PORT" "$CODE_LOG"
+sleep 10
+
+
+# Build a mixed prompt set with per-sample teacher tags. Each row's metadata
+# column (--metadata-key, default "metadata") carries the teacher name under
+# the --opd-teacher-key (default "opd_teacher"):
+#   {"prompt": "...", "metadata": {"opd_teacher": "math"}}
+MIXED_DATA=/root/opd-multi-teacher/mixed.jsonl
+mkdir -p "$(dirname $MIXED_DATA)"
+python3 - << 'PYEOF'
+import json
+import os
+
+sources = [
+    ("/root/dapo-math-17k/dapo-math-17k.jsonl", "math"),
+    # Add your code-prompt dataset here, e.g.:
+    # ("/root/code-prompts/code-prompts.jsonl", "code"),
+]
+
+out_path = "/root/opd-multi-teacher/mixed.jsonl"
+n = 0
+with open(out_path, "w") as out:
+    for path, teacher in sources:
+        if not os.path.exists(path):
+            print(f"skip missing {path}")
+            continue
+        with open(path) as f:
+            for line in f:
+                row = json.loads(line)
+                row.setdefault("metadata", {})["opd_teacher"] = teacher
+                out.write(json.dumps(row, ensure_ascii=False) + "\n")
+                n += 1
+print(f"wrote {n} tagged prompts to {out_path}")
+PYEOF
+
+
+export PYTHONBUFFERED=16
+
+NVLINK_COUNT=$(nvidia-smi topo -m 2>/dev/null | grep -o 'NV[0-9][0-9]*' | wc -l)
+if [ "$NVLINK_COUNT" -gt 0 ]; then
+    HAS_NVLINK=1
+else
+    HAS_NVLINK=0
+fi
+echo "HAS_NVLINK: $HAS_NVLINK (detected $NVLINK_COUNT NVLink references)"
+
+source "/root/miles/scripts/models/qwen3-8B.sh"
+
+
+CKPT_ARGS=(
+   --hf-checkpoint /root/Qwen3-8B
+   --ref-load /root/Qwen3-8B_torch_dist
+   --load /root/Qwen3-8B_miles/
+   --save /root/Qwen3-8B_miles/
+   --save-interval 20
+)
+
+ROLLOUT_ARGS=(
+   --prompt-data $MIXED_DATA
+   --input-key prompt
+   --apply-chat-template
+   --rollout-shuffle
+   --num-rollout 300
+   --rollout-batch-size 16
+   --n-samples-per-prompt 4
+   --rollout-max-response-len 16384
+   --rollout-temperature 1
+
+   --global-batch-size 64
+   --balance-data
+)
+
+RM_ARGS=(
+   --custom-rm-path miles.rollout.on_policy_distillation.reward_func
+   --custom-reward-post-process-path miles.rollout.on_policy_distillation.post_process_rewards
+   # Per-task teacher routing; 'default' catches untagged/unknown samples.
+   --opd-teacher-urls
+       math=http://$MATH_TEACHER_IP:$MATH_TEACHER_PORT/generate
+       code=http://$CODE_TEACHER_IP:$CODE_TEACHER_PORT/generate
+       default=http://$MATH_TEACHER_IP:$MATH_TEACHER_PORT/generate
+   --opd-teacher-key opd_teacher
+)
+
+EVAL_ARGS=(
+   # --eval-interval 20
+   # --eval-prompt-data aime ${DATA_DIR}/aime-2024/aime-2024.jsonl
+   # --n-samples-per-eval-prompt 16
+   # --eval-max-response-len 16384
+   # --eval-top-p 1
+)
+
+PERF_ARGS=(
+   --tensor-model-parallel-size 2
+   --sequence-parallel
+   --pipeline-model-parallel-size 1
+   --context-parallel-size 1
+   --expert-model-parallel-size 1
+   --expert-tensor-parallel-size 1
+
+   --recompute-granularity full
+   --recompute-method uniform
+   --recompute-num-layers 1
+
+   # --micro-batch-size 1
+   --use-dynamic-batch-size
+   --max-tokens-per-gpu 16384
+)
+
+GRPO_ARGS=(
+   --advantage-estimator grpo
+   --use-opd
+   --opd-type sglang
+   --opd-kl-coef 1.0
+   --opd-log-prob-top-k 16
+   --opd-top-k-strategy only-student
+   --opd-reward-weight-mode student_p
+   --use-kl-loss
+   --kl-loss-coef 0.00
+   --kl-loss-type low_var_kl
+   --entropy-coef 0.00
+)
+
+OPTIMIZER_ARGS=(
+   --optimizer adam
+   --lr 1e-6
+   --lr-decay-style constant
+   --weight-decay 0.1
+   --adam-beta1 0.9
+   --adam-beta2 0.98
+)
+
+WANDB_ARGS=(
+   #--use-wandb
+   # --wandb-project miles-dev
+   # --wandb-group qwen3-8B-multi-teacher
+   # --wandb-key ${WANDB_KEY}
+)
+
+SGLANG_ARGS=(
+   --rollout-num-gpus-per-engine 1
+   --sglang-mem-fraction-static 0.4
+)
+
+
+MISC_ARGS=(
+   --attention-dropout 0.0
+   --hidden-dropout 0.0
+   --accumulate-allreduce-grads-in-fp32
+   --attention-softmax-in-fp32
+   --attention-backend flash
+)
+
+
+# launch the master node of ray in container
+export MASTER_ADDR=${MASTER_ADDR:-"127.0.0.1"}
+ray start --head --node-ip-address ${MASTER_ADDR} --num-gpus 8 --disable-usage-stats --dashboard-host=0.0.0.0 --dashboard-port=8265
+
+
+ray job submit --address="http://127.0.0.1:8265" \
+   --runtime-env-json='{
+     "env_vars": {
+        "PYTHONPATH": "/root/Megatron-LM/",
+        "CUDA_DEVICE_MAX_CONNECTIONS": "1"
+     }
+   }' \
+   -- python3 train.py \
+   --actor-num-nodes 1 \
+   --actor-num-gpus-per-node 2 \
+   --rollout-num-gpus 4 \
+   ${MODEL_ARGS[@]} \
+   ${CKPT_ARGS[@]} \
+   ${ROLLOUT_ARGS[@]} \
+   ${OPTIMIZER_ARGS[@]} \
+   ${GRPO_ARGS[@]} \
+   ${WANDB_ARGS[@]} \
+   ${PERF_ARGS[@]} \
+   ${EVAL_ARGS[@]} \
+   ${SGLANG_ARGS[@]} \
+   ${MISC_ARGS[@]} \
+   ${RM_ARGS[@]}
+
+
+####clear after training
+pkill -9 sglang
+sleep 3
+ray stop --force
+pkill -9 ray
+pkill -9 python
+sleep 3
+pkill -9 ray
+pkill -9 python

--- a/miles/rollout/on_policy_distillation.py
+++ b/miles/rollout/on_policy_distillation.py
@@ -19,6 +19,60 @@ TEACHER_TOP_STRATEGIES = TOP_K_STRATEGIES - {"only-student"}
 TEACHER_ON_STUDENT_STRATEGIES = {"only-student", "union", "xor"}
 STUDENT_ON_TEACHER_STRATEGIES = {"only-teacher", "union", "xor"}
 
+# Reserved teacher name in --opd-teacher-urls used as the fallback route.
+DEFAULT_TEACHER_NAME = "default"
+
+
+def parse_teacher_urls(values: Iterable[str] | None) -> dict[str, str]:
+    """Parse ``NAME=URL`` entries from ``--opd-teacher-urls`` into a routing map.
+
+    Splits on the first ``=`` only, so URLs containing ``=`` (e.g. query
+    strings) survive intact. Raises on malformed entries and duplicate names
+    so misconfiguration fails at startup, not mid-rollout.
+    """
+    url_map: dict[str, str] = {}
+    for value in values or []:
+        name, sep, url = value.partition("=")
+        name, url = name.strip(), url.strip()
+        if not sep or not name or not url:
+            raise ValueError(f"Invalid --opd-teacher-urls entry {value!r}; expected NAME=URL.")
+        if name in url_map:
+            raise ValueError(f"Duplicate teacher name {name!r} in --opd-teacher-urls.")
+        url_map[name] = url
+    return url_map
+
+
+def _teacher_url_for_sample(args: Namespace, sample: Sample) -> str:
+    """Resolve the teacher scoring endpoint for one sample.
+
+    Without ``--opd-teacher-urls`` every sample goes to ``--rm-url`` (the
+    original single-teacher path, unchanged). With it, the sample is routed by
+    the teacher name in ``sample.metadata[--opd-teacher-key]``; samples whose
+    name is missing or unknown fall back to the reserved ``default`` entry,
+    and raise if no default is configured — silently distilling from the
+    wrong teacher is worse than failing the rollout.
+    """
+    url_map = parse_teacher_urls(getattr(args, "opd_teacher_urls", None))
+    if not url_map:
+        return args.rm_url
+
+    metadata = sample.metadata if isinstance(sample.metadata, dict) else {}
+    key = getattr(args, "opd_teacher_key", "opd_teacher")
+    name = metadata.get(key)
+    if name is not None:
+        url = url_map.get(str(name))
+        if url is not None:
+            return url
+        if DEFAULT_TEACHER_NAME in url_map:
+            return url_map[DEFAULT_TEACHER_NAME]
+        raise ValueError(
+            f"Sample metadata[{key!r}]={name!r} matches no --opd-teacher-urls name "
+            f"(known: {sorted(url_map)}) and no 'default' entry is configured."
+        )
+    if DEFAULT_TEACHER_NAME in url_map:
+        return url_map[DEFAULT_TEACHER_NAME]
+    raise ValueError(f"Sample metadata is missing teacher key {key!r} and --opd-teacher-urls has no 'default' entry.")
+
 
 def _get_opd_top_k(args: Namespace) -> int:
     return max(0, int(getattr(args, "opd_log_prob_top_k", 0) or 0))
@@ -300,8 +354,11 @@ async def reward_func(args: Namespace, sample: Sample, **kwargs: Any) -> dict[st
     # Optional per-request timeout so a hung teacher/student scoring call cannot stall
     # the whole rollout (no-op when unset).
     request_timeout = getattr(args, "sglang_router_request_timeout_secs", None)
+    # Multi-teacher routing: pick this sample's teacher endpoint (falls back to
+    # --rm-url when --opd-teacher-urls is unset).
+    teacher_url = _teacher_url_for_sample(args, sample)
     if top_k == 0:
-        return await _post_json(args.rm_url, _score_payload(sample.tokens), timeout_secs=request_timeout)
+        return await _post_json(teacher_url, _score_payload(sample.tokens), timeout_secs=request_timeout)
 
     strategy = _get_top_k_strategy(args)
     # Per-position scoring requires a patched teacher/student server that understands
@@ -325,7 +382,7 @@ async def reward_func(args: Namespace, sample: Sample, **kwargs: Any) -> dict[st
         teacher_payload = _score_payload(sample.tokens, top_k=teacher_top_k, token_ids=teacher_token_ids)
     else:
         teacher_payload = _score_payload(sample.tokens, top_k=teacher_top_k)
-    teacher_response = await _post_json(args.rm_url, teacher_payload, timeout_secs=request_timeout)
+    teacher_response = await _post_json(teacher_url, teacher_payload, timeout_secs=request_timeout)
 
     reward_payload = {"teacher": teacher_response}
     if strategy in STUDENT_ON_TEACHER_STRATEGIES:

--- a/miles/rollout/on_policy_distillation.py
+++ b/miles/rollout/on_policy_distillation.py
@@ -38,7 +38,12 @@ def _get_reward_weight_mode(args: Namespace) -> str:
     return mode
 
 
-def _score_payload(input_ids: list[int], top_k: int = 0, token_ids: list[int] | None = None) -> dict[str, Any]:
+def _score_payload(
+    input_ids: list[int],
+    top_k: int = 0,
+    token_ids: list[int] | None = None,
+    token_ids_positions: list[list[int]] | None = None,
+) -> dict[str, Any]:
     payload = {
         "input_ids": input_ids,
         "sampling_params": {
@@ -51,9 +56,29 @@ def _score_payload(input_ids: list[int], top_k: int = 0, token_ids: list[int] | 
     }
     if top_k > 0:
         payload["top_logprobs_num"] = top_k
-    if token_ids:
+    if token_ids_positions is not None:
+        # Per-position scoring (patched sglang): one id-list per input position, so the
+        # teacher returns each position's own ids (sparse) instead of the global union
+        # broadcast to every position (dense O(R^2)). Aligned to logprob_start_len=0.
+        payload["token_ids_logprob_positions"] = token_ids_positions
+    elif token_ids:
         payload["token_ids_logprob"] = token_ids
     return payload
+
+
+def _per_position_ids(top_logprobs: TopLogprobs, prompt_len: int) -> list[list[int]]:
+    """Build one token-id list per scored input position for ``token_ids_logprob_positions``.
+
+    ``top_logprobs`` is per response position (length == response_length). Prompt
+    positions are padded with empty id-lists so the layout aligns with
+    ``logprob_start_len=0`` and the existing ``_trim_input_field`` extraction
+    (``values[1:][-response_length:]``) — i.e. response position r lands at index
+    ``prompt_len + r``.
+    """
+    per_pos: list[list[int]] = [[] for _ in range(prompt_len)]
+    for entries in top_logprobs:
+        per_pos.append([_top_entry_token_id(e) for e in (entries or []) if e is not None])
+    return per_pos
 
 
 def _student_score_url(args: Namespace) -> str:
@@ -275,27 +300,39 @@ async def reward_func(args: Namespace, sample: Sample, **kwargs: Any) -> dict[st
         return await _post_json(args.rm_url, _score_payload(sample.tokens))
 
     strategy = _get_top_k_strategy(args)
+    # Per-position scoring requires a patched teacher/student server that understands
+    # token_ids_logprob_positions; default off so an unpatched server keeps working.
+    per_position = getattr(args, "opd_topk_per_position", False)
+    prompt_len = len(sample.tokens) - sample.response_length
 
-    teacher_token_ids = None
+    teacher_top_k = top_k if strategy in TEACHER_TOP_STRATEGIES else 0
     if strategy in TEACHER_ON_STUDENT_STRATEGIES:
         student_top = _student_top_logprobs(sample, sample.response_length)
         teacher_token_ids = _unique_ids(student_top)
+    else:
+        student_top = None
+        teacher_token_ids = None
 
-    teacher_payload = _score_payload(
-        sample.tokens,
-        top_k=top_k if strategy in TEACHER_TOP_STRATEGIES else 0,
-        token_ids=teacher_token_ids,
-    )
+    if student_top is not None and per_position:
+        teacher_payload = _score_payload(
+            sample.tokens, top_k=teacher_top_k, token_ids_positions=_per_position_ids(student_top, prompt_len)
+        )
+    elif teacher_token_ids is not None:
+        teacher_payload = _score_payload(sample.tokens, top_k=teacher_top_k, token_ids=teacher_token_ids)
+    else:
+        teacher_payload = _score_payload(sample.tokens, top_k=teacher_top_k)
     teacher_response = await _post_json(args.rm_url, teacher_payload)
 
     reward_payload = {"teacher": teacher_response}
     if strategy in STUDENT_ON_TEACHER_STRATEGIES:
         teacher_top = _trim_input_field(teacher_response["meta_info"], "input_top_logprobs", sample.response_length)
-        student_token_ids = _unique_ids(teacher_top)
-        reward_payload["student_on_teacher"] = await _post_json(
-            _student_score_url(args),
-            _score_payload(sample.tokens, token_ids=student_token_ids),
-        )
+        if per_position:
+            student_payload = _score_payload(
+                sample.tokens, token_ids_positions=_per_position_ids(teacher_top, prompt_len)
+            )
+        else:
+            student_payload = _score_payload(sample.tokens, token_ids=_unique_ids(teacher_top))
+        reward_payload["student_on_teacher"] = await _post_json(_student_score_url(args), student_payload)
 
     return reward_payload
 

--- a/miles/rollout/on_policy_distillation.py
+++ b/miles/rollout/on_policy_distillation.py
@@ -85,8 +85,9 @@ def _student_score_url(args: Namespace) -> str:
     return f"http://{args.sglang_router_ip}:{args.sglang_router_port}/generate"
 
 
-async def _post_json(url: str, payload: dict[str, Any]) -> dict[str, Any]:
-    async with aiohttp.ClientSession() as session:
+async def _post_json(url: str, payload: dict[str, Any], timeout_secs: int | float | None = None) -> dict[str, Any]:
+    timeout = aiohttp.ClientTimeout(total=timeout_secs)
+    async with aiohttp.ClientSession(timeout=timeout) as session:
         async with session.post(url, json=payload) as resp:
             resp.raise_for_status()
             return await resp.json()
@@ -296,8 +297,11 @@ def _compute_topk_reverse_kl(
 
 async def reward_func(args: Namespace, sample: Sample, **kwargs: Any) -> dict[str, Any]:
     top_k = _get_opd_top_k(args)
+    # Optional per-request timeout so a hung teacher/student scoring call cannot stall
+    # the whole rollout (no-op when unset).
+    request_timeout = getattr(args, "sglang_router_request_timeout_secs", None)
     if top_k == 0:
-        return await _post_json(args.rm_url, _score_payload(sample.tokens))
+        return await _post_json(args.rm_url, _score_payload(sample.tokens), timeout_secs=request_timeout)
 
     strategy = _get_top_k_strategy(args)
     # Per-position scoring requires a patched teacher/student server that understands
@@ -321,7 +325,7 @@ async def reward_func(args: Namespace, sample: Sample, **kwargs: Any) -> dict[st
         teacher_payload = _score_payload(sample.tokens, top_k=teacher_top_k, token_ids=teacher_token_ids)
     else:
         teacher_payload = _score_payload(sample.tokens, top_k=teacher_top_k)
-    teacher_response = await _post_json(args.rm_url, teacher_payload)
+    teacher_response = await _post_json(args.rm_url, teacher_payload, timeout_secs=request_timeout)
 
     reward_payload = {"teacher": teacher_response}
     if strategy in STUDENT_ON_TEACHER_STRATEGIES:
@@ -332,7 +336,9 @@ async def reward_func(args: Namespace, sample: Sample, **kwargs: Any) -> dict[st
             )
         else:
             student_payload = _score_payload(sample.tokens, token_ids=_unique_ids(teacher_top))
-        reward_payload["student_on_teacher"] = await _post_json(_student_score_url(args), student_payload)
+        reward_payload["student_on_teacher"] = await _post_json(
+            _student_score_url(args), student_payload, timeout_secs=request_timeout
+        )
 
     return reward_payload
 

--- a/miles/rollout/sglang_rollout.py
+++ b/miles/rollout/sglang_rollout.py
@@ -40,6 +40,51 @@ __all__ = ["generate_rollout", "get_model_url"]
 logger = logging.getLogger(__name__)
 
 
+def _len_or_value(value: Any) -> Any:
+    if isinstance(value, (dict, list, tuple, str)):
+        return {"type": type(value).__name__, "len": len(value)}
+    return value
+
+
+def _sample_text_preview(sample: Sample, max_chars: int = 512) -> str:
+    text = (str(sample.prompt) + sample.response).replace("\n", "\\n")
+    if len(text) <= max_chars:
+        return text
+    return f"{text[:max_chars]}...<truncated chars={len(text) - max_chars}>"
+
+
+def _reward_log_summary(reward: Any) -> Any:
+    """Summarize a reward (which for OPD scoring can be a large nested dict of logprobs)
+    into shapes/lengths instead of dumping the whole thing into the log."""
+    if not isinstance(reward, dict):
+        return _len_or_value(reward)
+
+    summary: dict[str, Any] = {}
+    for key, value in reward.items():
+        if not isinstance(value, dict):
+            summary[key] = _len_or_value(value)
+            continue
+
+        entry: dict[str, Any] = {"keys": list(value.keys())}
+        meta_info = value.get("meta_info")
+        if isinstance(meta_info, dict):
+            entry["meta_info"] = {
+                meta_key: _len_or_value(meta_info[meta_key])
+                for meta_key in (
+                    "id",
+                    "finish_reason",
+                    "prompt_tokens",
+                    "weight_version",
+                    "input_token_logprobs",
+                    "input_token_ids_logprobs",
+                    "input_top_logprobs",
+                )
+                if meta_key in meta_info
+            }
+        summary[key] = entry
+    return summary
+
+
 def get_model_url(args: Namespace, model_name: str, endpoint: str = "/generate") -> str:
     """Return the router URL for a named model.
 
@@ -433,7 +478,10 @@ async def generate_rollout_async(
             if do_print:
                 sample = group[0][0] if isinstance(group[0], list) else group[0]
                 logger.info(
-                    f"First rollout sample: {[str(sample.prompt) + sample.response]}, label: {str(sample.label)[:100]}, reward: {sample.reward}",
+                    "First rollout sample: text_preview=%s, label=%s, reward_summary=%s",
+                    _sample_text_preview(sample),
+                    str(sample.label)[:100],
+                    _reward_log_summary(sample.reward),
                 )
                 do_print = False
 
@@ -454,7 +502,10 @@ async def generate_rollout_async(
     pbar.close()
     sample = data[-1][0][0] if isinstance(data[-1][0], list) else data[-1][0]
     logger.info(
-        f"Finish rollout: {[str(sample.prompt) + sample.response]}, label: {str(sample.label)[:100]}, reward: {sample.reward}",
+        "Finish rollout: text_preview=%s, label=%s, reward_summary=%s",
+        _sample_text_preview(sample),
+        str(sample.label)[:100],
+        _reward_log_summary(sample.reward),
     )
 
     # there are still some unfinished requests, abort them

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -1162,6 +1162,30 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 ),
             )
             parser.add_argument(
+                "--opd-teacher-urls",
+                type=str,
+                nargs="+",
+                default=None,
+                metavar="NAME=URL",
+                help=(
+                    "Multi-teacher routing map for --opd-type=sglang, e.g. "
+                    "--opd-teacher-urls math=http://h1:30001/generate code=http://h2:30002/generate. "
+                    "Each sample is routed to the teacher named by "
+                    "sample.metadata[--opd-teacher-key]; the reserved name 'default' is the "
+                    "fallback for samples with a missing or unknown name. When unset, all "
+                    "samples are scored by the single teacher at --rm-url (original behavior)."
+                ),
+            )
+            parser.add_argument(
+                "--opd-teacher-key",
+                type=str,
+                default="opd_teacher",
+                help=(
+                    "Sample metadata key holding the teacher name used for --opd-teacher-urls "
+                    "routing. Populated from the dataset's metadata column (see --metadata-key)."
+                ),
+            )
+            parser.add_argument(
                 "--opd-teacher-load",
                 type=str,
                 default=None,
@@ -2112,6 +2136,13 @@ def miles_validate_args(args):
             raise ValueError("--opd-log-prob-top-k must be non-negative.")
         if args.opd_log_prob_top_k > 0 and args.opd_type != "sglang":
             raise ValueError("--opd-log-prob-top-k is currently supported only with --opd-type=sglang.")
+        if args.opd_teacher_urls:
+            if args.opd_type != "sglang":
+                raise ValueError("--opd-teacher-urls is only supported with --opd-type=sglang.")
+            # Local import to keep miles.utils free of rollout imports at module load.
+            from miles.rollout.on_policy_distillation import parse_teacher_urls
+
+            parse_teacher_urls(args.opd_teacher_urls)  # fail fast on malformed/duplicate entries
 
         if args.opd_type == "megatron":
             if args.opd_teacher_load is None:
@@ -2138,6 +2169,8 @@ def miles_validate_args(args):
     else:
         if args.opd_teacher_load is not None:
             raise ValueError("--opd-teacher-load is set but --use-opd is not enabled. Please add --use-opd flag.")
+        if args.opd_teacher_urls:
+            raise ValueError("--opd-teacher-urls is set but --use-opd is not enabled. Please add --use-opd flag.")
 
     # TODO: During loading, we need to set the start_rollout_id here.
     if args.megatron_to_hf_mode == "bridge":

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -1150,6 +1150,18 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 help="Weighting scheme for top-k OPD token rewards.",
             )
             parser.add_argument(
+                "--opd-topk-per-position",
+                action="store_true",
+                default=False,
+                help=(
+                    "Send per-position token ids to the teacher/student scoring server "
+                    "(token_ids_logprob_positions) instead of the global top-k union, so the "
+                    "response is O(response_len * k) instead of O(response_len * |union|). "
+                    "Requires a patched sglang server that supports token_ids_logprob_positions; "
+                    "leave off for an unpatched server."
+                ),
+            )
+            parser.add_argument(
                 "--opd-teacher-load",
                 type=str,
                 default=None,

--- a/tests/fast/rollout/test_on_policy_distillation.py
+++ b/tests/fast/rollout/test_on_policy_distillation.py
@@ -4,7 +4,13 @@ from argparse import Namespace
 import pytest
 from tests.ci.ci_register import register_cpu_ci
 
-from miles.rollout.on_policy_distillation import _compute_topk_reverse_kl, _per_position_ids, _score_payload
+from miles.rollout.on_policy_distillation import (
+    _compute_topk_reverse_kl,
+    _per_position_ids,
+    _score_payload,
+    _teacher_url_for_sample,
+    parse_teacher_urls,
+)
 from miles.utils.types import Sample
 
 register_cpu_ci(est_time=60, suite="stage-a-cpu")
@@ -123,3 +129,79 @@ def test_score_payload_routes_per_position_vs_flat():
     per_pos = _score_payload([1, 2, 3], token_ids_positions=[[], [5, 7], [9, 11]])
     assert per_pos["token_ids_logprob_positions"] == [[], [5, 7], [9, 11]]
     assert "token_ids_logprob" not in per_pos
+
+
+# ---------------------------------------------------------------------------
+# Multi-teacher routing (--opd-teacher-urls)
+# ---------------------------------------------------------------------------
+
+
+def _routing_args(urls=None, key="opd_teacher", rm_url="http://single-teacher/generate"):
+    return Namespace(opd_teacher_urls=urls, opd_teacher_key=key, rm_url=rm_url)
+
+
+def _tagged_sample(metadata=None):
+    return Sample(tokens=[1, 2, 3], response_length=2, metadata=metadata or {})
+
+
+def test_parse_teacher_urls_parses_names_and_keeps_equals_in_url():
+    url_map = parse_teacher_urls(["math=http://h1:30001/generate", "code=http://h2:30002/generate?tag=a=b"])
+    assert url_map == {
+        "math": "http://h1:30001/generate",
+        "code": "http://h2:30002/generate?tag=a=b",
+    }
+
+
+def test_parse_teacher_urls_empty_or_none_gives_empty_map():
+    assert parse_teacher_urls(None) == {}
+    assert parse_teacher_urls([]) == {}
+
+
+@pytest.mark.parametrize("bad", ["math", "=http://h1/generate", "math=", "  =  "])
+def test_parse_teacher_urls_rejects_malformed_entries(bad):
+    with pytest.raises(ValueError, match="expected NAME=URL"):
+        parse_teacher_urls([bad])
+
+
+def test_parse_teacher_urls_rejects_duplicate_names():
+    with pytest.raises(ValueError, match="Duplicate teacher name"):
+        parse_teacher_urls(["math=http://h1/generate", "math=http://h2/generate"])
+
+
+def test_routing_unset_map_falls_back_to_rm_url():
+    args = _routing_args(urls=None)
+    sample = _tagged_sample({"opd_teacher": "math"})
+    assert _teacher_url_for_sample(args, sample) == "http://single-teacher/generate"
+
+
+def test_routing_by_metadata_name():
+    args = _routing_args(urls=["math=http://h1/generate", "code=http://h2/generate"])
+    assert _teacher_url_for_sample(args, _tagged_sample({"opd_teacher": "math"})) == "http://h1/generate"
+    assert _teacher_url_for_sample(args, _tagged_sample({"opd_teacher": "code"})) == "http://h2/generate"
+
+
+def test_routing_respects_custom_metadata_key():
+    args = _routing_args(urls=["math=http://h1/generate"], key="task")
+    assert _teacher_url_for_sample(args, _tagged_sample({"task": "math"})) == "http://h1/generate"
+
+
+def test_routing_missing_name_uses_default_entry():
+    args = _routing_args(urls=["math=http://h1/generate", "default=http://h3/generate"])
+    assert _teacher_url_for_sample(args, _tagged_sample({})) == "http://h3/generate"
+
+
+def test_routing_unknown_name_uses_default_entry():
+    args = _routing_args(urls=["math=http://h1/generate", "default=http://h3/generate"])
+    assert _teacher_url_for_sample(args, _tagged_sample({"opd_teacher": "physics"})) == "http://h3/generate"
+
+
+def test_routing_unknown_name_without_default_raises():
+    args = _routing_args(urls=["math=http://h1/generate"])
+    with pytest.raises(ValueError, match="matches no --opd-teacher-urls name"):
+        _teacher_url_for_sample(args, _tagged_sample({"opd_teacher": "physics"}))
+
+
+def test_routing_missing_name_without_default_raises():
+    args = _routing_args(urls=["math=http://h1/generate"])
+    with pytest.raises(ValueError, match="missing teacher key"):
+        _teacher_url_for_sample(args, _tagged_sample({}))

--- a/tests/fast/rollout/test_on_policy_distillation.py
+++ b/tests/fast/rollout/test_on_policy_distillation.py
@@ -4,7 +4,7 @@ from argparse import Namespace
 import pytest
 from tests.ci.ci_register import register_cpu_ci
 
-from miles.rollout.on_policy_distillation import _compute_topk_reverse_kl
+from miles.rollout.on_policy_distillation import _compute_topk_reverse_kl, _per_position_ids, _score_payload
 from miles.utils.types import Sample
 
 register_cpu_ci(est_time=60, suite="stage-a-cpu")
@@ -100,3 +100,26 @@ def test_topk_xor_uses_symmetric_difference_without_normalization():
     expected_1 = math.log(0.3 / 0.6) + math.log(0.1 / 0.2)
 
     assert reverse_kl.tolist() == pytest.approx([expected_0, expected_1])
+
+
+def test_per_position_ids_pads_prompt_and_keeps_response_order():
+    # Two response positions, each with two top-k entries [logprob, token_id].
+    student_top = [[_entry(0.6, 5), _entry(0.4, 7)], [_entry(0.7, 9), _entry(0.3, 11)]]
+    per_pos = _per_position_ids(student_top, prompt_len=3)
+    # 3 empty prompt slots, then response positions with their own token ids.
+    assert per_pos == [[], [], [], [5, 7], [9, 11]]
+    # Aligns with the existing _trim_input_field extraction values[1:][-R:]: for a
+    # length-5 response, indices 3,4 are the response positions.
+    values = list(range(5))
+    assert values[1:][-2:] == [3, 4]
+    assert per_pos[3] == [5, 7] and per_pos[4] == [9, 11]
+
+
+def test_score_payload_routes_per_position_vs_flat():
+    flat = _score_payload([1, 2, 3], token_ids=[5, 7])
+    assert flat["token_ids_logprob"] == [5, 7]
+    assert "token_ids_logprob_positions" not in flat
+
+    per_pos = _score_payload([1, 2, 3], token_ids_positions=[[], [5, 7], [9, 11]])
+    assert per_pos["token_ids_logprob_positions"] == [[], [5, 7], [9, 11]]
+    assert "token_ids_logprob" not in per_pos


### PR DESCRIPTION
## What

Stacked on #994. Two OPD improvements for top-k teacher scoring:

### 1. Per-position teacher scoring — avoids the O(R²) top-k union (`27873bf`)
Top-k OPD sends the global **union** of all positions' student top-k ids to the teacher as a flat `token_ids_logprob`, so the teacher returns logprobs for the whole union at *every* position → `O(response_len · |union|)` JSON, dominated by client-side parse + map-building (the rollout-tail CPU bottleneck seen on B200).

`--opd-topk-per-position` (default **off**): send one id-list per scored input position via the new sglang `token_ids_logprob_positions` field (prompt positions padded with `[]` so the layout still matches the existing `values[1:][-response_length:]` extraction). Response becomes sparse `O(response_len · k)`.

- **Requires a teacher/student sglang patched for `token_ids_logprob_positions`: sgl-project/sglang#27421** (against the `sglang-miles` branch). Leave off for an unpatched server — the current global-union behavior is preserved.

### 2. kaixih's orthogonal robustness fixes (`c47ea4c`)
From kaixih's `opd-qwen3-b200-fixes`, only the parts orthogonal to the data-volume fix (the inline-KL / return-0.0 move is dropped — its motivation goes away once the response is `O(R·k)`):
- `_post_json`: optional per-request timeout (via `--sglang-router-request-timeout-secs`) so a hung scoring call can't stall the rollout.
- `sglang_rollout`: log a shape/length **summary** of `sample.reward` instead of dumping the whole nested logprob dict in the first/finish-rollout lines.

## Validation

On **sci-h200** (Qwen3-0.6B), off (flat union) vs on (per-position) for the same sequence: per-position teacher logprobs are **byte-for-byte identical** to the flat-union baseline (`0 mismatches over 80 (position, id) pairs`) while the response is **22.9× smaller** (95,823 → 4,184 bytes for R=16, k=5). The miles `_per_position_ids` layout was validated unchanged against the sglang-side alignment.

## Dependencies
- Stacked on #994 (base `feat/opd-ci-docs`).
- Teacher-side: **sgl-project/sglang#27421** must be deployed for `--opd-topk-per-position`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
