### PR TITLE
[ci] Add bypass-fastfail label to disable cross-stage and within-stage fast-fail

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -41,9 +41,10 @@ concurrency:
 # unconditionally to bypass the labels predicate inside run_suite.py and run
 # every enabled test in the suite.
 #
-# The `bypass-fastfail` PR label opts a PR out of cross-stage fast-fail: the GPU
-# stages then run even when stage-a-cpu fails, so one CI run surfaces every
-# stage's result instead of stopping at the first failed stage.
+# The `bypass-fastfail` PR label opts a PR out of fast-fail on two levels: GPU
+# stages run even when stage-a-cpu fails (cross-stage), and every stage passes
+# `--continue-on-error` so one failing test no longer stops the rest of its
+# suite (within-stage). One CI run then surfaces every failure.
 
 jobs:
   resolve-ci-image:
@@ -90,6 +91,7 @@ jobs:
         --auto-partition-id ${{ matrix.partition_id }} --auto-partition-size 4
         --labels ${{ join(github.event.pull_request.labels.*.name, ' ') }}
         ${{ (github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'run-ci-image') || contains(github.event.pull_request.labels.*.name, 'run-ci-all')) && '--match-all-labels' || '' }}
+        ${{ contains(github.event.pull_request.labels.*.name, 'bypass-fastfail') && '--continue-on-error' || '' }}
     secrets: inherit
 
   # Stage B: CPU-only bucket (currently empty; reserved for future CPU tests
@@ -104,6 +106,7 @@ jobs:
         python tests/ci/run_suite.py --hw cpu --suite stage-b-cpu
         --labels ${{ join(github.event.pull_request.labels.*.name, ' ') }}
         ${{ (github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'run-ci-image') || contains(github.event.pull_request.labels.*.name, 'run-ci-all')) && '--match-all-labels' || '' }}
+        ${{ contains(github.event.pull_request.labels.*.name, 'bypass-fastfail') && '--continue-on-error' || '' }}
     secrets: inherit
 
   stage-b-2-gpu-h200:
@@ -120,6 +123,7 @@ jobs:
         python tests/ci/run_suite.py --hw cuda --suite stage-b-2-gpu-h200
         --labels ${{ join(github.event.pull_request.labels.*.name, ' ') }}
         ${{ (github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'run-ci-image') || contains(github.event.pull_request.labels.*.name, 'run-ci-all')) && '--match-all-labels' || '' }}
+        ${{ contains(github.event.pull_request.labels.*.name, 'bypass-fastfail') && '--continue-on-error' || '' }}
     secrets: inherit
 
   stage-c-8-gpu-h100:
@@ -141,6 +145,7 @@ jobs:
         --auto-partition-id ${{ matrix.partition_id }} --auto-partition-size 2
         --labels ${{ join(github.event.pull_request.labels.*.name, ' ') }}
         ${{ (github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'run-ci-image') || contains(github.event.pull_request.labels.*.name, 'run-ci-all')) && '--match-all-labels' || '' }}
+        ${{ contains(github.event.pull_request.labels.*.name, 'bypass-fastfail') && '--continue-on-error' || '' }}
     secrets: inherit
 
   stage-c-4-gpu-h200:
@@ -162,6 +167,7 @@ jobs:
         --auto-partition-id ${{ matrix.partition_id }} --auto-partition-size 3
         --labels ${{ join(github.event.pull_request.labels.*.name, ' ') }}
         ${{ (github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'run-ci-image') || contains(github.event.pull_request.labels.*.name, 'run-ci-all')) && '--match-all-labels' || '' }}
+        ${{ contains(github.event.pull_request.labels.*.name, 'bypass-fastfail') && '--continue-on-error' || '' }}
     secrets: inherit
 
   stage-c-2-gpu-h200:
@@ -183,4 +189,5 @@ jobs:
         --auto-partition-id ${{ matrix.partition_id }} --auto-partition-size 2
         --labels ${{ join(github.event.pull_request.labels.*.name, ' ') }}
         ${{ (github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'run-ci-image') || contains(github.event.pull_request.labels.*.name, 'run-ci-all')) && '--match-all-labels' || '' }}
+        ${{ contains(github.event.pull_request.labels.*.name, 'bypass-fastfail') && '--continue-on-error' || '' }}
     secrets: inherit

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -40,6 +40,10 @@ concurrency:
 # `--labels` list collapses to empty; `--match-all-labels` is then added
 # unconditionally to bypass the labels predicate inside run_suite.py and run
 # every enabled test in the suite.
+#
+# The `bypass-fastfail` PR label opts a PR out of cross-stage fast-fail: the GPU
+# stages then run even when stage-a-cpu fails, so one CI run surfaces every
+# stage's result instead of stopping at the first failed stage.
 
 jobs:
   resolve-ci-image:
@@ -105,7 +109,8 @@ jobs:
   stage-b-2-gpu-h200:
     needs: [resolve-ci-image, stage-a-cpu]
     if: |
-      always() && !failure() && !cancelled() &&
+      always() && !cancelled() &&
+      (!failure() || contains(github.event.pull_request.labels.*.name, 'bypass-fastfail')) &&
       ((github.event_name == 'workflow_dispatch') || (github.event.pull_request))
     uses: ./.github/workflows/_run-ci.yml
     with:
@@ -120,7 +125,8 @@ jobs:
   stage-c-8-gpu-h100:
     needs: [resolve-ci-image, stage-a-cpu]
     if: |
-      always() && !failure() && !cancelled() &&
+      always() && !cancelled() &&
+      (!failure() || contains(github.event.pull_request.labels.*.name, 'bypass-fastfail')) &&
       ((github.event_name == 'workflow_dispatch') || (github.event.pull_request))
     strategy:
       fail-fast: false
@@ -140,7 +146,8 @@ jobs:
   stage-c-4-gpu-h200:
     needs: [resolve-ci-image, stage-a-cpu]
     if: |
-      always() && !failure() && !cancelled() &&
+      always() && !cancelled() &&
+      (!failure() || contains(github.event.pull_request.labels.*.name, 'bypass-fastfail')) &&
       ((github.event_name == 'workflow_dispatch') || (github.event.pull_request))
     strategy:
       fail-fast: false
@@ -160,7 +167,8 @@ jobs:
   stage-c-2-gpu-h200:
     needs: [resolve-ci-image, stage-a-cpu]
     if: |
-      always() && !failure() && !cancelled() &&
+      always() && !cancelled() &&
+      (!failure() || contains(github.event.pull_request.labels.*.name, 'bypass-fastfail')) &&
       ((github.event_name == 'workflow_dispatch') || (github.event.pull_request))
     strategy:
       fail-fast: false

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -113,7 +113,9 @@ jobs:
     needs: [resolve-ci-image, stage-a-cpu]
     if: |
       always() && !cancelled() &&
-      (!failure() || contains(github.event.pull_request.labels.*.name, 'bypass-fastfail')) &&
+      needs.resolve-ci-image.result == 'success' &&
+      (needs.stage-a-cpu.result == 'success' ||
+        (needs.stage-a-cpu.result == 'failure' && contains(github.event.pull_request.labels.*.name, 'bypass-fastfail'))) &&
       ((github.event_name == 'workflow_dispatch') || (github.event.pull_request))
     uses: ./.github/workflows/_run-ci.yml
     with:
@@ -130,7 +132,9 @@ jobs:
     needs: [resolve-ci-image, stage-a-cpu]
     if: |
       always() && !cancelled() &&
-      (!failure() || contains(github.event.pull_request.labels.*.name, 'bypass-fastfail')) &&
+      needs.resolve-ci-image.result == 'success' &&
+      (needs.stage-a-cpu.result == 'success' ||
+        (needs.stage-a-cpu.result == 'failure' && contains(github.event.pull_request.labels.*.name, 'bypass-fastfail'))) &&
       ((github.event_name == 'workflow_dispatch') || (github.event.pull_request))
     strategy:
       fail-fast: false
@@ -152,7 +156,9 @@ jobs:
     needs: [resolve-ci-image, stage-a-cpu]
     if: |
       always() && !cancelled() &&
-      (!failure() || contains(github.event.pull_request.labels.*.name, 'bypass-fastfail')) &&
+      needs.resolve-ci-image.result == 'success' &&
+      (needs.stage-a-cpu.result == 'success' ||
+        (needs.stage-a-cpu.result == 'failure' && contains(github.event.pull_request.labels.*.name, 'bypass-fastfail'))) &&
       ((github.event_name == 'workflow_dispatch') || (github.event.pull_request))
     strategy:
       fail-fast: false
@@ -174,7 +180,9 @@ jobs:
     needs: [resolve-ci-image, stage-a-cpu]
     if: |
       always() && !cancelled() &&
-      (!failure() || contains(github.event.pull_request.labels.*.name, 'bypass-fastfail')) &&
+      needs.resolve-ci-image.result == 'success' &&
+      (needs.stage-a-cpu.result == 'success' ||
+        (needs.stage-a-cpu.result == 'failure' && contains(github.event.pull_request.labels.*.name, 'bypass-fastfail'))) &&
       ((github.event_name == 'workflow_dispatch') || (github.event.pull_request))
     strategy:
       fail-fast: false

--- a/tests/ci/run_suite.py
+++ b/tests/ci/run_suite.py
@@ -174,6 +174,20 @@ def pretty_print_tests(args, ci_tests: list[CIRegistry], skipped_tests: list[CIR
     print(msg, flush=True)
 
 
+def build_cpu_pytest_cmd(filenames: list[str], continue_on_error: bool) -> list[str]:
+    """Build the single pytest invocation for a CPU suite.
+
+    `-x` (stop at first failure) is the default per-commit behavior. With
+    continue_on_error -- e.g. a PR carrying the `bypass-fastfail` label -- drop
+    `-x` so every file runs; pytest still exits non-zero if any failed, so the
+    stage stays red.
+    """
+    cmd = ["pytest", *filenames, "-v"]
+    if not continue_on_error:
+        cmd.append("-x")
+    return cmd
+
+
 def run_a_suite(args):
     hw = HW_MAPPING[args.hw]
     suite = args.suite
@@ -207,7 +221,7 @@ def run_a_suite(args):
 
     # CPU tests (fast/) use pytest; CUDA tests use python3 per-file
     if hw == HWBackend.CPU:
-        cmd = ["pytest"] + [t.filename for t in ci_tests] + ["-x", "-v"]
+        cmd = build_cpu_pytest_cmd([t.filename for t in ci_tests], args.continue_on_error)
         print(f"Running: {' '.join(cmd)}", flush=True)
         return subprocess.call(cmd)
 

--- a/tests/ci/test_run_suite.py
+++ b/tests/ci/test_run_suite.py
@@ -20,7 +20,7 @@ from pathlib import Path
 
 import pytest
 from tests.ci.ci_register import CIRegistry, HWBackend, discover_ci_files, register_cpu_ci
-from tests.ci.run_suite import PER_COMMIT_SUITES, filter_tests, strip_run_ci_prefix
+from tests.ci.run_suite import PER_COMMIT_SUITES, build_cpu_pytest_cmd, filter_tests, strip_run_ci_prefix
 
 register_cpu_ci(est_time=1, suite="stage-a-cpu", labels=[])
 
@@ -49,6 +49,23 @@ def _make(
         disabled=disabled,
         implicit=False,
     )
+
+
+# --- build_cpu_pytest_cmd: -x gated on continue_on_error --------------------
+
+
+class TestBuildCpuPytestCmd:
+    def test_x_present_by_default(self):
+        # Default per-commit run stops at the first failure.
+        cmd = build_cpu_pytest_cmd(["tests/fast/a.py", "tests/fast/b.py"], continue_on_error=False)
+        assert "-x" in cmd
+
+    def test_x_dropped_on_continue_on_error(self):
+        # bypass-fastfail passes --continue-on-error -> run every file to the end.
+        cmd = build_cpu_pytest_cmd(["tests/fast/a.py", "tests/fast/b.py"], continue_on_error=True)
+        assert "-x" not in cmd
+        assert cmd[0] == "pytest"
+        assert "tests/fast/a.py" in cmd and "tests/fast/b.py" in cmd
 
 
 # --- PER_COMMIT_SUITES locked to the new taxonomy ---------------------------


### PR DESCRIPTION
## Summary
Add a `bypass-fastfail` PR label that disables fast-fail across and within stages.

## Motivation
On a PR, the GPU stages (`stage-b-2-gpu-h200`, `stage-c-8-gpu-h100`, `stage-c-4-gpu-h200`, `stage-c-2-gpu-h200`) skip when `stage-a-cpu` fails, and inside any stage the first failing test stops the rest (CUDA breaks the file loop; CPU runs `pytest -x`). A PR touching many areas then needs repeated fix-rerun-discover cycles to see every failure.

## Usage
1. Create the label once: `gh label create bypass-fastfail`.
2. Apply `bypass-fastfail` to a PR. Every stage runs regardless of `stage-a-cpu`'s result, and each stage runs all its tests before reporting.

The `contains(...)` check only tests label presence — nothing changes until the label exists and is applied.

## Design Notes
- **Cross-stage:** the GPU stage `if` becomes `(!failure() || contains(... 'bypass-fastfail'))`, so a `stage-a-cpu` failure no longer skips them.
- **Within-stage:** each stage appends `--continue-on-error` when the label is present, so a failing test no longer stops the rest of its suite.
- **CPU path:** `build_cpu_pytest_cmd` drops `pytest -x` under continue-on-error (CUDA already honored it in `run_unittest_files`).
- **Verdict preserved:** `--continue-on-error` collects failures but still exits non-zero, so a stage with any failure stays red.
- **Untouched:** test selection (`--match-all-labels`), `resolve-ci-image`, and triggers.

## Verification
- **Unit tests:** `tests/ci/test_run_suite.py` passes (23), including new coverage that `-x` is dropped only under continue-on-error.
- **Static:** `actionlint` 1.7.12 reports no findings.
- **Runtime (on GitHub; label behavior is not reliably simulated locally):** label a PR whose first test in a stage fails; confirm the rest of that stage still runs and the stage stays red.

## Review Focus
- Scrutinize the GPU stage `if`: confirm the no-label path still gates on `!failure()`, preserving existing fast-fail.
- Scrutinize `build_cpu_pytest_cmd`: confirm `-x` is dropped only under continue-on-error, so default PR runs still stop at the first failure.
