### PR TITLE
Set per-process DeepGEMM cache env

### DIFF
--- a/miles/ray/rollout/server_group.py
+++ b/miles/ray/rollout/server_group.py
@@ -100,6 +100,9 @@ class ServerGroup:
                 key: os.environ.get(key, default_val)
                 for key, default_val in {
                     "SGLANG_JIT_DEEPGEMM_PRECOMPILE": "false",
+                    # TODO: this is hacky. Use env var SGLANG_DG_CACHE_DIR_PER_PROCESS=1
+                    # to enable this isolation.
+                    "SGLANG_DG_CACHE_DIR": f"/tmp/sglang_deep_gemm/{self.worker_type}_rank_{global_rank}",
                     "SGL_DISABLE_TP_MEMORY_INBALANCE_CHECK": "true",
                     "SGLANG_DISABLE_TP_MEMORY_INBALANCE_CHECK": "true",
                     "SGLANG_MEMORY_SAVER_CUDA_GRAPH": "true",

--- a/scripts/run_deepseek_v4.py
+++ b/scripts/run_deepseek_v4.py
@@ -456,6 +456,9 @@ def _train(args: ScriptArgs):
     extra_env_vars = {
         "SGLANG_SKIP_CHECKPOINT_LOAD_CHECK": "1",
         "SGLANG_DSV4_FP4_EXPERTS": "0",
+        # TODO: this is hacky
+        "SGLANG_DG_CACHE_DIR": "/tmp/sglang_deep_gemm",
+        "SGLANG_DG_CACHE_DIR_PER_PROCESS": "1",
     }
     if args.model_name == "DeepSeek-V4-Pro-FP8":
         extra_env_vars["SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK"] = "256"

--- a/scripts/run_deepseek_v4.py
+++ b/scripts/run_deepseek_v4.py
@@ -456,8 +456,6 @@ def _train(args: ScriptArgs):
     extra_env_vars = {
         "SGLANG_SKIP_CHECKPOINT_LOAD_CHECK": "1",
         "SGLANG_DSV4_FP4_EXPERTS": "0",
-        # TODO: this is hacky
-        "SGLANG_DG_CACHE_DIR": "/tmp/sglang_deep_gemm",
         "SGLANG_DG_CACHE_DIR_PER_PROCESS": "1",
     }
     if args.model_name == "DeepSeek-V4-Pro-FP8":


### PR DESCRIPTION
## Summary
- Set a rank-scoped `SGLANG_DG_CACHE_DIR` for rollout SGLang engines
- Set `SGLANG_DG_CACHE_DIR_PER_PROCESS=1` from the DeepSeek V4 launcher to enable per-process DeepGEMM cache isolation
- Keep the TODO note marking this as a hacky rollout-side workaround

## Root cause
DeepSeek V4 launches multiple rollout SGLang processes during cold-cache startup. Without per-process DeepGEMM cache isolation, concurrent JIT/cache writes can race in the same cache directory and fail during directory creation.

## Validation
- `pre-commit run --all-files`
- Covered by the DeepSeek V4 16-node disaggregate debug run that reached step 1 with this change in place

Requires the matching SGLang cache-dir support PR: https://github.com/sgl-project/sglang/pull/27604
