### PR TITLE
docs: fix deepseek-v4 launcher env var and path-default guidance

### DIFF
--- a/docs/models/deepseek/deepseek-v4-flash.md
+++ b/docs/models/deepseek/deepseek-v4-flash.md
@@ -52,10 +52,10 @@ The Python launcher (`scripts/run_deepseek_v4.py`) takes its path arguments from
 |---|---|---|
 | `--data-dir` | `/root/datasets` | HF datasets (e.g. dapo-math-17k, …) |
 | `--model-dir` | `/root/models` | parent directory holding the HF checkpoint and Megatron `_torch_dist` artifacts as separate sibling sub-directories |
-| `--model-local-dir` | `/root/local_data` | local NVMe path on each node; `prepare-cp` rsyncs the HF checkpoint and `_torch_dist` here so the trainer reads from local disk instead of shared storage |
+| `--model-local-dir` | unset → same as `--model-dir` | local NVMe path on each node; `prepare-cp` rsyncs the HF checkpoint and `_torch_dist` here so the trainer reads from local disk instead of shared storage (only worth setting when `--model-dir` is on shared/remote storage) |
 | `--save-dir` | `/root/models` | training checkpoints under `{save-dir}/{run-id}/checkpoints/` |
 
-You can override these on the launcher when your cluster mounts a different layout. There are no `MILES_SCRIPT_*` env vars that preconfigure these paths; the only env vars the launcher reads are `MILES_SCRIPT_EXTERNAL_RAY` and `MILES_SCRIPT_ENABLE_RAY_SUBMIT` (both governing Ray bootstrapping, see [§4.3](#43-multi-node-fan-out)).
+You can override these via the CLI flags above or equivalently via env vars — every launcher option binds to `MILES_SCRIPT_<FIELD_NAME_UPPER>` (e.g. `MILES_SCRIPT_MODEL_DIR`), with precedence CLI flag > env var > built-in default; run `train --help` to see each option's `[env var: …]` name.
 
 ## 4. Script breakdown
 

--- a/docs/models/deepseek/deepseek-v4-flash.md
+++ b/docs/models/deepseek/deepseek-v4-flash.md
@@ -35,11 +35,16 @@ One command runs the full pipeline — dataset download, FP8 → BF16 cast, dist
 # Pull the dev image:
 docker pull radixark/miles:dev
 
-# 8-node Flash run, inside the container
+# 8-node Flash run (colocated), inside the container
 cd /root/miles
 python scripts/run_deepseek_v4.py full-train \
    --model-name DeepSeek-V4-Flash-FP8 \
    --num-nodes 8 --num-gpus-per-node 8
+
+# 16-node disaggregated run: 8 actor (training) nodes + 8 dedicated rollout nodes
+python scripts/run_deepseek_v4.py full-train \
+   --model-name DeepSeek-V4-Flash-FP8 \
+   --num-nodes 16 --num-gpus-per-node 8 --rollout-num-nodes 8
 ```
 
 The `full-train` subcommand chains `prepare-download → prepare-single → prepare-spmd → prepare-cp → train`. Each stage has a sentinel-based skip so you can re-run safely after the first invocation.
@@ -56,6 +61,10 @@ The Python launcher (`scripts/run_deepseek_v4.py`) takes its path arguments from
 | `--save-dir` | `/root/models` | training checkpoints under `{save-dir}/{run-id}/checkpoints/` |
 
 You can override these via the CLI flags above or equivalently via env vars — every launcher option binds to `MILES_SCRIPT_<FIELD_NAME_UPPER>` (e.g. `MILES_SCRIPT_MODEL_DIR`), with precedence CLI flag > env var > built-in default; run `train --help` to see each option's `[env var: …]` name.
+
+### 3.3 Colocated vs. disaggregated rollout
+
+By default the launcher runs **colocated**: training and SGLang rollout share all `--num-nodes × --num-gpus-per-node` GPUs. Pass `--rollout-num-nodes N` (`0 < N < --num-nodes`) to run **disaggregated**: `N` nodes serve rollout, the rest train. The verified parallelism recipes are keyed on the **training** nodes, so the 8-node Flash recipe in disaggregated form is `--num-nodes 16 --rollout-num-nodes 8` (8 train + 8 rollout — the validated layout).
 
 ## 4. Script breakdown
 
@@ -128,6 +137,8 @@ These are the validated layouts shipped with the launcher; All parallelisms are 
 | GB300 | 8 × 4 = 32 | 8 | 4 | 1 | 8 | 1 | first 11 / last 10 layers |
 | GB300 | 8 × 4 = 32 | 2 | 8 | 2 | 4 | 1 | first 4 / last 3 layers |
 
+The Nodes × GPUs column counts **training nodes** — in disaggregated mode (see [§3.3](#33-colocated-vs-disaggregated-rollout)) rollout nodes come on top of these.
+
 ### 5.2 Algorithm
 
 Using GRPO as an example, you can configure the algorithm with the following flags:
@@ -158,7 +169,6 @@ SGLANG_ARGS=(
    --sglang-chunked-prefill-size 8192
    --sglang-mem-fraction-static 0.5  # leave headroom for Megatron during wake_up
    --use-rollout-routing-replay  # MoE routing replay (R3)
-   --use-miles-router  # miles router fronts /generate
 )
 ```
 

--- a/docs/models/deepseek/deepseek-v4-pro.md
+++ b/docs/models/deepseek/deepseek-v4-pro.md
@@ -90,7 +90,6 @@ SGLANG_ARGS=(
    --sglang-moe-a2a-backend deepep             # DeepEP normal-mode dispatch
    --sglang-cuda-graph-max-bs 8                # see hang caveat below
    --sglang-mem-fraction-static 0.7            # Pro needs a larger dynamic buffer
-   --use-miles-router
 )
 ```
 

--- a/docs/models/deepseek/deepseek-v4-pro.md
+++ b/docs/models/deepseek/deepseek-v4-pro.md
@@ -50,10 +50,10 @@ The `full-train` subcommand chains `prepare-download → prepare-single → prep
 |---|---|---|
 | `--data-dir` | `/root/datasets` | HF datasets (e.g. dapo-math-17k, …) |
 | `--model-dir` | `/root/models` | parent directory holding the HF checkpoint and Megatron `_torch_dist` artifacts |
-| `--model-local-dir` | `/root/local_data` | local NVMe path on each node; `prepare-cp` rsyncs the HF checkpoint and `_torch_dist` here so the trainer reads from local disk |
+| `--model-local-dir` | unset → same as `--model-dir` | local NVMe path on each node; `prepare-cp` rsyncs the HF checkpoint and `_torch_dist` here so the trainer reads from local disk (set it when `--model-dir` is on shared/remote storage) |
 | `--save-dir` | `/root/models` | training checkpoints under `{save-dir}/{run-id}/checkpoints/` |
 
-TBD — Pro-specific overrides or env-var notes.
+Pro uses the same launcher as V4-Flash, so every option above can also be preconfigured via `MILES_SCRIPT_<FIELD_NAME_UPPER>` env vars (precedence: CLI flag > env var > built-in default) — see [V4-Flash §3.2](deepseek-v4-flash.md#32-launcher-path-defaults) for details.
 
 ## 4. Script breakdown
 


### PR DESCRIPTION
## What

**Env var / path-default guidance (deepseek-v4-flash.md + deepseek-v4-pro.md §3.2)**
- The doc claimed there are no `MILES_SCRIPT_*` env vars that preconfigure launcher paths. This is wrong: every `run_deepseek_v4.py` option is bound to `MILES_SCRIPT_<FIELD_NAME_UPPER>` via the bare `@dataclass_cli` decorator (`miles/utils/typer_utils.py` sets `envvar=` on each typer Option), with precedence CLI flag > env var > built-in default. Verifiable via `python scripts/run_deepseek_v4.py train --help`, which prints `[env var: ...]` on each option.
- `--model-local-dir` default corrected from `/root/local_data` to unset → same as `--model-dir` (matches `ScriptArgs.model_local_dir = None` + the `__post_init__` fallback).
- Pro: replaced the "TBD — Pro-specific overrides or env-var notes" placeholder with a one-line pointer to V4-Flash §3.2.

**Disaggregated rollout mode, per #1310 (deepseek-v4-flash.md)**
- §3.1: add a disaggregated launch example (`--num-nodes 16 --rollout-num-nodes 8`).
- New §3.3: `--rollout-num-nodes` semantics — default colocate; N nodes serve rollout, the rest train; verified parallelism recipes are keyed on training nodes.
- §5.1: note that the parallelism table counts training nodes.
- §5.3 (flash + pro): drop `--use-miles-router` from the example SGLANG_ARGS — since #1310 the DSV4 launcher runs R3 with `--use-rollout-routing-replay` only.