### PR TITLE
feat: add FlashQLA backend for Qwen GDN linear-attention layers

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -71,6 +71,8 @@ RUN pip install /tmp/wheels/flash_attn_3-*.whl && \
 RUN pip install git+https://github.com/ISEEKYAN/mbridge.git@89eb10887887bc74853f89a4de258c0702932a1c --no-deps
 
 RUN pip install flash-linear-attention==0.4.2
+# FlashQLA backend for Qwen GDN linear-attention layers (requires SM90+, CUDA 12.8+, PyTorch 2.8+)
+RUN pip install -v --no-build-isolation "git+https://github.com/QwenLM/FlashQLA.git"
 # required for DeepSeek V4
 RUN pip install tilelang==0.1.8 -f https://tile-ai.github.io/whl/nightly/cu128/
 RUN pip install --no-deps tile_kernels==1.0.0

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -71,10 +71,10 @@ RUN pip install /tmp/wheels/flash_attn_3-*.whl && \
 RUN pip install git+https://github.com/ISEEKYAN/mbridge.git@89eb10887887bc74853f89a4de258c0702932a1c --no-deps
 
 RUN pip install flash-linear-attention==0.4.2
-# FlashQLA backend for Qwen GDN linear-attention layers (requires SM90+, CUDA 12.8+, PyTorch 2.8+)
-RUN pip install -v --no-build-isolation "git+https://github.com/QwenLM/FlashQLA.git"
 # required for DeepSeek V4
 RUN pip install tilelang==0.1.8 -f https://tile-ai.github.io/whl/nightly/cu128/
+# FlashQLA backend for Qwen GDN linear-attention layers (requires SM90+, CUDA 12.8+, PyTorch 2.8+; built on tilelang above)
+RUN pip install -v --no-build-isolation "git+https://github.com/QwenLM/FlashQLA.git"
 RUN pip install --no-deps tile_kernels==1.0.0
 RUN pip install "git+https://github.com/Dao-AILab/fast-hadamard-transform.git@e7706faf8d1c3b9f241e36860640ad1dac644ede" --no-build-isolation
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -73,9 +73,9 @@ RUN pip install git+https://github.com/ISEEKYAN/mbridge.git@89eb10887887bc74853f
 RUN pip install flash-linear-attention==0.4.2
 # required for DeepSeek V4
 RUN pip install tilelang==0.1.8 -f https://tile-ai.github.io/whl/nightly/cu128/
+RUN pip install --no-deps tile_kernels==1.0.0
 # FlashQLA backend for Qwen GDN linear-attention layers (requires SM90+, CUDA 12.8+, PyTorch 2.8+; built on tilelang above)
 RUN pip install -v --no-build-isolation "git+https://github.com/QwenLM/FlashQLA.git"
-RUN pip install --no-deps tile_kernels==1.0.0
 RUN pip install "git+https://github.com/Dao-AILab/fast-hadamard-transform.git@e7706faf8d1c3b9f241e36860640ad1dac644ede" --no-build-isolation
 
 # Mamba kernels for nemotron_h hybrid (mamba+attention) models.

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -140,11 +140,15 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 help="The qkv layout.",
             )
             parser.add_argument(
-                "--qwen-gdn-backend",
+                "--linear-attention-backend",
                 type=str,
                 choices=["fla", "flashqla"],
                 default="fla",
-                help="GDN implementation backend for Qwen linear-attention layers.",
+                help=(
+                    "Backend for Qwen GDN linear-attention layers. "
+                    "'fla' (flash-linear-attention) is portable and runs on any supported GPU. "
+                    "'flashqla' (FlashQLA) requires NVIDIA SM90 (Hopper) or newer, CUDA 12.8+, and PyTorch 2.8+."
+                ),
             )
             parser.add_argument(
                 "--true-on-policy-mode",

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -140,6 +140,13 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 help="The qkv layout.",
             )
             parser.add_argument(
+                "--qwen-gdn-backend",
+                type=str,
+                choices=["fla", "flashqla"],
+                default="fla",
+                help="GDN implementation backend for Qwen linear-attention layers.",
+            )
+            parser.add_argument(
                 "--true-on-policy-mode",
                 action="store_true",
                 default=False,

--- a/miles_plugins/models/qwen3_5.py
+++ b/miles_plugins/models/qwen3_5.py
@@ -12,7 +12,6 @@ from transformers.activations import ACT2FN
 
 try:
     from fla.modules import FusedRMSNormGated, ShortConvolution
-    from fla.ops.gated_delta_rule import chunk_gated_delta_rule
 except ImportError:
     pass
 
@@ -20,6 +19,7 @@ from miles.backends.megatron_utils.fp32_param_utils import mark_param_dtype
 from miles.backends.training_utils.cp_utils import build_gdn_cp_context
 
 from .hf_attention import HuggingfaceAttention
+from .qwen_gdn_backend import get_chunk_gated_delta_rule
 
 
 def _get_text_config(hf_config):
@@ -37,8 +37,10 @@ class Qwen3_5GatedDeltaNet(nn.Module):
     separate in_proj_qkv (for Q,K,V) and in_proj_z (for Z).
     """
 
-    def __init__(self, config, layer_idx: int):
+    def __init__(self, config, layer_idx: int, args=None):
         super().__init__()
+        self.gdn_backend = getattr(args, "qwen_gdn_backend", "fla")
+        self.chunk_gated_delta_rule = get_chunk_gated_delta_rule(self.gdn_backend)
         self.hidden_size = config.hidden_size
         self.num_v_heads = config.linear_num_value_heads
         self.num_k_heads = config.linear_num_key_heads
@@ -135,7 +137,11 @@ class Qwen3_5GatedDeltaNet(nn.Module):
             key = key.repeat_interleave(self.num_v_heads // self.num_k_heads, dim=2)
 
         if cp_context is not None:
-            core_attn_out, _ = chunk_gated_delta_rule(
+            if self.gdn_backend != "fla":
+                raise NotImplementedError(
+                    f"GDN context parallelism requires the 'fla' backend, got {self.gdn_backend!r}."
+                )
+            core_attn_out, _ = self.chunk_gated_delta_rule(
                 query,
                 key,
                 value,
@@ -146,7 +152,13 @@ class Qwen3_5GatedDeltaNet(nn.Module):
                 cp_context=cp_context,
             )
         else:
-            core_attn_out, _ = chunk_gated_delta_rule(
+            if self.gdn_backend == "flashqla":
+                query = query.contiguous()
+                key = key.contiguous()
+                value = value.contiguous()
+                g = g.contiguous()
+                beta = beta.contiguous()
+            core_attn_out, _ = self.chunk_gated_delta_rule(
                 query,
                 key,
                 value,
@@ -190,7 +202,7 @@ class Attention(HuggingfaceAttention):
         self.hf_config = _get_text_config(self.hf_config)
         self.hf_config._attn_implementation = "flash_attention_2"
 
-        self.linear_attn = Qwen3_5GatedDeltaNet(self.hf_config, self.hf_layer_idx)
+        self.linear_attn = Qwen3_5GatedDeltaNet(self.hf_config, self.hf_layer_idx, args=args)
 
         # Use a simple RMSNorm
         try:

--- a/miles_plugins/models/qwen3_5.py
+++ b/miles_plugins/models/qwen3_5.py
@@ -39,7 +39,7 @@ class Qwen3_5GatedDeltaNet(nn.Module):
 
     def __init__(self, config, layer_idx: int, args=None):
         super().__init__()
-        self.gdn_backend = getattr(args, "qwen_gdn_backend", "fla")
+        self.gdn_backend = getattr(args, "linear_attention_backend", "fla")
         self.chunk_gated_delta_rule = get_chunk_gated_delta_rule(self.gdn_backend)
         self.hidden_size = config.hidden_size
         self.num_v_heads = config.linear_num_value_heads

--- a/miles_plugins/models/qwen3_next.py
+++ b/miles_plugins/models/qwen3_next.py
@@ -12,7 +12,6 @@ from transformers.activations import ACT2FN
 
 try:
     from fla.modules import FusedRMSNormGated, ShortConvolution
-    from fla.ops.gated_delta_rule import chunk_gated_delta_rule
     from transformers.models.qwen3_next.modeling_qwen3_next import Qwen3NextAttention, Qwen3NextRMSNorm
 except ImportError:
     pass
@@ -20,6 +19,7 @@ except ImportError:
 from miles.backends.training_utils.cp_utils import build_gdn_cp_context
 
 from .hf_attention import HuggingfaceAttention
+from .qwen_gdn_backend import get_chunk_gated_delta_rule
 
 
 # adapt from https://github.com/huggingface/transformers/blob/38a08b6e8ae35857109cedad75377997fecbf9d0/src/transformers/models/qwen3_next/modeling_qwen3_next.py#L564
@@ -28,8 +28,10 @@ class Qwen3NextGatedDeltaNet(nn.Module):
     Qwen3NextGatedDeltaNet with varlen support
     """
 
-    def __init__(self, config, layer_idx: int):
+    def __init__(self, config, layer_idx: int, args=None):
         super().__init__()
+        self.gdn_backend = getattr(args, "qwen_gdn_backend", "fla")
+        self.chunk_gated_delta_rule = get_chunk_gated_delta_rule(self.gdn_backend)
         self.hidden_size = config.hidden_size
         self.num_v_heads = config.linear_num_value_heads
         self.num_k_heads = config.linear_num_key_heads
@@ -146,7 +148,11 @@ class Qwen3NextGatedDeltaNet(nn.Module):
             key = key.repeat_interleave(self.num_v_heads // self.num_k_heads, dim=2)
 
         if cp_context is not None:
-            core_attn_out, _ = chunk_gated_delta_rule(
+            if self.gdn_backend != "fla":
+                raise NotImplementedError(
+                    f"GDN context parallelism requires the 'fla' backend, got {self.gdn_backend!r}."
+                )
+            core_attn_out, _ = self.chunk_gated_delta_rule(
                 query,
                 key,
                 value,
@@ -157,7 +163,13 @@ class Qwen3NextGatedDeltaNet(nn.Module):
                 cp_context=cp_context,
             )
         else:
-            core_attn_out, _ = chunk_gated_delta_rule(
+            if self.gdn_backend == "flashqla":
+                query = query.contiguous()
+                key = key.contiguous()
+                value = value.contiguous()
+                g = g.contiguous()
+                beta = beta.contiguous()
+            core_attn_out, _ = self.chunk_gated_delta_rule(
                 query,
                 key,
                 value,
@@ -200,7 +212,7 @@ class Attention(HuggingfaceAttention):
         if Qwen3NextAttention is None:
             raise ImportError("Please install transformers>=4.35.0 to use Qwen3NextAttention.")
 
-        self.linear_attn = Qwen3NextGatedDeltaNet(self.hf_config, self.hf_layer_idx)
+        self.linear_attn = Qwen3NextGatedDeltaNet(self.hf_config, self.hf_layer_idx, args=args)
         self.input_layernorm = Qwen3NextRMSNorm(self.hf_config.hidden_size, eps=self.hf_config.rms_norm_eps)
 
     def hf_forward(self, hidden_states, packed_seq_params):

--- a/miles_plugins/models/qwen3_next.py
+++ b/miles_plugins/models/qwen3_next.py
@@ -30,7 +30,7 @@ class Qwen3NextGatedDeltaNet(nn.Module):
 
     def __init__(self, config, layer_idx: int, args=None):
         super().__init__()
-        self.gdn_backend = getattr(args, "qwen_gdn_backend", "fla")
+        self.gdn_backend = getattr(args, "linear_attention_backend", "fla")
         self.chunk_gated_delta_rule = get_chunk_gated_delta_rule(self.gdn_backend)
         self.hidden_size = config.hidden_size
         self.num_v_heads = config.linear_num_value_heads

--- a/miles_plugins/models/qwen_gdn_backend.py
+++ b/miles_plugins/models/qwen_gdn_backend.py
@@ -1,0 +1,47 @@
+import torch
+
+
+def _parse_version(version):
+    version = version.split("+", 1)[0]
+    parts = version.split(".")
+    major = int(parts[0])
+    minor = int(parts[1]) if len(parts) > 1 else 0
+    return major, minor
+
+
+def _validate_flashqla_runtime():
+    if _parse_version(torch.__version__) < (2, 8):
+        raise RuntimeError(f"FlashQLA backend requires PyTorch 2.8 or newer, got PyTorch {torch.__version__}.")
+
+    if not torch.cuda.is_available():
+        raise RuntimeError("FlashQLA backend requires CUDA and an NVIDIA SM90 GPU.")
+
+    major, minor = torch.cuda.get_device_capability()
+    if (major, minor) < (9, 0):
+        raise RuntimeError(f"FlashQLA backend requires NVIDIA SM90 or newer, got sm{major}{minor}.")
+
+    cuda_version = torch.version.cuda
+    if cuda_version is not None and _parse_version(cuda_version) < (12, 8):
+        raise RuntimeError(f"FlashQLA backend requires CUDA 12.8 or newer, got CUDA {cuda_version}.")
+
+
+def get_chunk_gated_delta_rule(backend: str):
+    """Resolve the chunk_gated_delta_rule kernel for the requested GDN backend."""
+    if backend == "fla":
+        try:
+            from fla.ops.gated_delta_rule import chunk_gated_delta_rule
+        except ImportError as exc:
+            raise ImportError("Qwen GDN backend 'fla' requires flash-linear-attention.") from exc
+        return chunk_gated_delta_rule
+
+    if backend == "flashqla":
+        try:
+            from flash_qla import chunk_gated_delta_rule
+        except ImportError as exc:
+            raise ImportError(
+                "Qwen GDN backend 'flashqla' requires FlashQLA. Install it from https://github.com/QwenLM/FlashQLA."
+            ) from exc
+        _validate_flashqla_runtime()
+        return chunk_gated_delta_rule
+
+    raise ValueError(f"Unsupported Qwen GDN backend: {backend}")

--- a/miles_plugins/models/qwen_gdn_backend.py
+++ b/miles_plugins/models/qwen_gdn_backend.py
@@ -1,5 +1,10 @@
 import torch
 
+try:
+    from fla.ops.gated_delta_rule import chunk_gated_delta_rule as _fla_chunk_gated_delta_rule
+except ImportError:
+    _fla_chunk_gated_delta_rule = None
+
 
 def _parse_version(version):
     version = version.split("+", 1)[0]
@@ -27,11 +32,9 @@ def _validate_flashqla_runtime():
 
 def get_chunk_gated_delta_rule(backend: str):
     if backend == "fla":
-        try:
-            from fla.ops.gated_delta_rule import chunk_gated_delta_rule
-        except ImportError as exc:
-            raise ImportError("Qwen GDN backend 'fla' requires flash-linear-attention.") from exc
-        return chunk_gated_delta_rule
+        if _fla_chunk_gated_delta_rule is None:
+            raise ImportError("Qwen GDN backend 'fla' requires flash-linear-attention.")
+        return _fla_chunk_gated_delta_rule
 
     if backend == "flashqla":
         try:

--- a/miles_plugins/models/qwen_gdn_backend.py
+++ b/miles_plugins/models/qwen_gdn_backend.py
@@ -1,33 +1,7 @@
-import torch
-
 try:
     from fla.ops.gated_delta_rule import chunk_gated_delta_rule as _fla_chunk_gated_delta_rule
 except ImportError:
     _fla_chunk_gated_delta_rule = None
-
-
-def _parse_version(version):
-    version = version.split("+", 1)[0]
-    parts = version.split(".")
-    major = int(parts[0])
-    minor = int(parts[1]) if len(parts) > 1 else 0
-    return major, minor
-
-
-def _validate_flashqla_runtime():
-    if _parse_version(torch.__version__) < (2, 8):
-        raise RuntimeError(f"FlashQLA backend requires PyTorch 2.8 or newer, got PyTorch {torch.__version__}.")
-
-    if not torch.cuda.is_available():
-        raise RuntimeError("FlashQLA backend requires CUDA and an NVIDIA SM90 GPU.")
-
-    major, minor = torch.cuda.get_device_capability()
-    if (major, minor) < (9, 0):
-        raise RuntimeError(f"FlashQLA backend requires NVIDIA SM90 or newer, got sm{major}{minor}.")
-
-    cuda_version = torch.version.cuda
-    if cuda_version is not None and _parse_version(cuda_version) < (12, 8):
-        raise RuntimeError(f"FlashQLA backend requires CUDA 12.8 or newer, got CUDA {cuda_version}.")
 
 
 def get_chunk_gated_delta_rule(backend: str):
@@ -43,7 +17,6 @@ def get_chunk_gated_delta_rule(backend: str):
             raise ImportError(
                 "Qwen GDN backend 'flashqla' requires FlashQLA. Install it from https://github.com/QwenLM/FlashQLA."
             ) from exc
-        _validate_flashqla_runtime()
         return chunk_gated_delta_rule
 
     raise ValueError(f"Unsupported Qwen GDN backend: {backend}")

--- a/miles_plugins/models/qwen_gdn_backend.py
+++ b/miles_plugins/models/qwen_gdn_backend.py
@@ -26,7 +26,6 @@ def _validate_flashqla_runtime():
 
 
 def get_chunk_gated_delta_rule(backend: str):
-    """Resolve the chunk_gated_delta_rule kernel for the requested GDN backend."""
     if backend == "fla":
         try:
             from fla.ops.gated_delta_rule import chunk_gated_delta_rule

--- a/tests/fast/test_qwen_gdn_backend.py
+++ b/tests/fast/test_qwen_gdn_backend.py
@@ -1,0 +1,45 @@
+"""CPU unit tests for the Qwen GDN backend selector (miles_plugins.models.qwen_gdn_backend)."""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def load_backend_module():
+    module_path = Path(__file__).resolve().parents[2] / "miles_plugins" / "models" / "qwen_gdn_backend.py"
+    spec = importlib.util.spec_from_file_location("test_qwen_gdn_backend_module", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_unknown_backend_raises_value_error():
+    module = load_backend_module()
+    with pytest.raises(ValueError, match="Unsupported Qwen GDN backend"):
+        module.get_chunk_gated_delta_rule("nope")
+
+
+def test_fla_backend_returns_fla_kernel():
+    pytest.importorskip("fla.ops.gated_delta_rule")
+    module = load_backend_module()
+    from fla.ops.gated_delta_rule import chunk_gated_delta_rule
+
+    assert module.get_chunk_gated_delta_rule("fla") is chunk_gated_delta_rule
+
+
+def test_flashqla_backend_errors_clearly_when_missing():
+    module = load_backend_module()
+    if "flash_qla" in sys.modules or importlib.util.find_spec("flash_qla") is not None:
+        pytest.skip("flash_qla installed; missing-package error path not applicable")
+    with pytest.raises(ImportError, match="FlashQLA"):
+        module.get_chunk_gated_delta_rule("flashqla")
+
+
+def test_version_parser_handles_local_suffixes():
+    module = load_backend_module()
+    assert module._parse_version("2.11.0+cu130") == (2, 11)
+    assert module._parse_version("13.0") == (13, 0)
+    assert module._parse_version("2") == (2, 0)

--- a/tests/fast/test_qwen_gdn_backend.py
+++ b/tests/fast/test_qwen_gdn_backend.py
@@ -1,5 +1,3 @@
-"""CPU unit tests for the Qwen GDN backend selector (miles_plugins.models.qwen_gdn_backend)."""
-
 import importlib.util
 import sys
 from pathlib import Path

--- a/tests/fast/test_qwen_gdn_backend.py
+++ b/tests/fast/test_qwen_gdn_backend.py
@@ -34,10 +34,3 @@ def test_flashqla_backend_errors_clearly_when_missing():
         pytest.skip("flash_qla installed; missing-package error path not applicable")
     with pytest.raises(ImportError, match="FlashQLA"):
         module.get_chunk_gated_delta_rule("flashqla")
-
-
-def test_version_parser_handles_local_suffixes():
-    module = load_backend_module()
-    assert module._parse_version("2.11.0+cu130") == (2, 11)
-    assert module._parse_version("13.0") == (13, 0)
-    assert module._parse_version("2") == (2, 0)

--- a/tests/fast/test_qwen_gdn_backend.py
+++ b/tests/fast/test_qwen_gdn_backend.py
@@ -1,5 +1,9 @@
+"""fla vs flashqla numerical equivalence for the Qwen GDN backends.
+
+Needs a Hopper (SM90+) GPU with both `fla` and `flash_qla`; skips otherwise.
+"""
+
 import importlib.util
-import sys
 from pathlib import Path
 
 import pytest
@@ -20,17 +24,84 @@ def test_unknown_backend_raises_value_error():
         module.get_chunk_gated_delta_rule("nope")
 
 
-def test_fla_backend_returns_fla_kernel():
+NUM_HEADS = 4
+HEAD_K_DIM = 128
+HEAD_V_DIM = 128
+SEQLENS = [128, 256, 128]
+
+
+def _require_backends():
+    torch = pytest.importorskip("torch")
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA device required to compare GDN kernels")
+    if torch.cuda.get_device_capability()[0] < 9:
+        pytest.skip("FlashQLA requires NVIDIA SM90 (Hopper) or newer")
     pytest.importorskip("fla.ops.gated_delta_rule")
+    pytest.importorskip("flash_qla")
+    return torch
+
+
+def _make_inputs(torch, dtype, device):
+    torch.manual_seed(0)
+    total = sum(SEQLENS)
+
+    def randn(*shape):
+        return torch.randn(*shape, device=device, dtype=dtype)
+
+    query = randn(1, total, NUM_HEADS, HEAD_K_DIM)
+    key = randn(1, total, NUM_HEADS, HEAD_K_DIM)
+    value = randn(1, total, NUM_HEADS, HEAD_V_DIM)
+    # g: per-head log-decay (<= 0); beta: gate in (0, 1) -- as the model feeds them.
+    g = -torch.nn.functional.softplus(randn(1, total, NUM_HEADS).float())
+    beta = randn(1, total, NUM_HEADS).float().sigmoid()
+
+    cu = torch.tensor([0, *SEQLENS], device=device, dtype=torch.int32).cumsum(0).to(torch.int32)
+    return query, key, value, g, beta, cu
+
+
+def _run(kernel, query, key, value, g, beta, cu_seqlens):
+    out, _ = kernel(
+        query.contiguous(),
+        key.contiguous(),
+        value.contiguous(),
+        g=g.contiguous(),
+        beta=beta.contiguous(),
+        initial_state=None,
+        output_final_state=False,
+        use_qk_l2norm_in_kernel=True,
+        cu_seqlens=cu_seqlens,
+    )
+    return out
+
+
+# FlashQLA only supports half precision (asserts on float32).
+@pytest.mark.parametrize(
+    "dtype_name, atol, rtol",
+    [
+        ("bfloat16", 4e-2, 4e-2),
+        ("float16", 1e-2, 1e-2),
+    ],
+)
+def test_fla_flashqla_equivalence(dtype_name, atol, rtol):
+    torch = _require_backends()
+    dtype = getattr(torch, dtype_name)
     module = load_backend_module()
-    from fla.ops.gated_delta_rule import chunk_gated_delta_rule
 
-    assert module.get_chunk_gated_delta_rule("fla") is chunk_gated_delta_rule
+    fla_kernel = module.get_chunk_gated_delta_rule("fla")
+    flashqla_kernel = module.get_chunk_gated_delta_rule("flashqla")
 
+    query, key, value, g, beta, cu = _make_inputs(torch, dtype, device="cuda")
 
-def test_flashqla_backend_errors_clearly_when_missing():
-    module = load_backend_module()
-    if "flash_qla" in sys.modules or importlib.util.find_spec("flash_qla") is not None:
-        pytest.skip("flash_qla installed; missing-package error path not applicable")
-    with pytest.raises(ImportError, match="FlashQLA"):
-        module.get_chunk_gated_delta_rule("flashqla")
+    fla_out = _run(fla_kernel, query, key, value, g, beta, cu).float()
+    flashqla_out = _run(flashqla_kernel, query, key, value, g, beta, cu).float()
+
+    assert fla_out.shape == flashqla_out.shape
+    diff = (fla_out - flashqla_out).abs()
+    denom = fla_out.abs().max().item() + 1e-6
+    print(
+        f"\n[GDN fla vs flashqla] dtype={dtype_name} "
+        f"max_abs_diff={diff.max().item():.3e} mean_abs_diff={diff.mean().item():.3e} "
+        f"max_rel_diff={diff.max().item() / denom:.3e}"
+    )
+
+    torch.testing.assert_close(flashqla_out, fla_out, atol=atol, rtol=rtol)


### PR DESCRIPTION
Sync from slime: THUDM/slime#1947

fla vs flashqla kernel bfloat16: max_abs_diff 4.88e-04, mean 1.15e-05, max_rel 7.84e-03
under Qwen3.5-4B RL 20 steps, the max abs_diff is 0.00746 both for fla and flashqla.
