### PR TITLE
ROCm/support test_deepep_fp8: e2e docs, aiter/sglang patches, mori rollout harness on gfx950

### DIFF
--- a/miles/utils/chat_template_utils/deepseek_v32.py
+++ b/miles/utils/chat_template_utils/deepseek_v32.py
@@ -7,7 +7,6 @@ import logging
 import os
 from typing import Any
 
-from sglang.srt.entrypoints.openai import encoding_dsv32
 from sglang.srt.entrypoints.openai.protocol import Tool
 
 logger = logging.getLogger(__name__)
@@ -79,6 +78,18 @@ def _inject_tools_into_system(messages: list[dict[str, Any]], tools: list[dict[s
     return out
 
 
+def _encoding_dsv32():
+    """Import sglang's DeepSeek V3.2 encoder lazily.
+
+    Older sglang builds (e.g. the MI350 image) do not export ``encoding_dsv32``;
+    deferring the import until a DeepSeek V3.2 prompt is actually rendered keeps
+    non-DeepSeek jobs importable on those builds.
+    """
+    from sglang.srt.entrypoints.openai import encoding_dsv32
+
+    return encoding_dsv32
+
+
 def render_messages(messages: list[dict[str, Any]], *, tools: list[dict] | None = None, **kwargs: Any) -> str:
     """Render *messages* into a DeepSeek V3.2 prompt via sglang ``encode_messages``.
 
@@ -88,4 +99,4 @@ def render_messages(messages: list[dict[str, Any]], *, tools: list[dict] | None 
     encode_config = _build_deepseek_encode_config(kwargs)
     if tools:
         messages = _inject_tools_into_system(messages, tools)
-    return encoding_dsv32.encode_messages(messages, **encode_config)
+    return _encoding_dsv32().encode_messages(messages, **encode_config)

--- a/miles/utils/chat_template_utils/deepseek_v4.py
+++ b/miles/utils/chat_template_utils/deepseek_v4.py
@@ -7,7 +7,6 @@ import logging
 import os
 from typing import Any
 
-from sglang.srt.entrypoints.openai import encoding_dsv4
 from sglang.srt.entrypoints.openai.protocol import Tool
 
 logger = logging.getLogger(__name__)
@@ -82,6 +81,18 @@ def _inject_tools_into_system(messages: list[dict[str, Any]], tools: list[dict[s
     return out
 
 
+def _encoding_dsv4():
+    """Import sglang's DeepSeek V4 encoder lazily.
+
+    Older sglang builds (e.g. the MI350 image) do not export ``encoding_dsv4``;
+    deferring the import until a DeepSeek V4 prompt is actually rendered keeps
+    non-DeepSeek jobs importable on those builds.
+    """
+    from sglang.srt.entrypoints.openai import encoding_dsv4
+
+    return encoding_dsv4
+
+
 def render_messages(messages: list[dict[str, Any]], *, tools: list[dict] | None = None, **kwargs: Any) -> str:
     """Render *messages* into a DeepSeek V4 prompt via sglang ``encode_messages``.
 
@@ -91,4 +102,4 @@ def render_messages(messages: list[dict[str, Any]], *, tools: list[dict] | None 
     encode_config = _build_deepseek_encode_config(kwargs)
     if tools:
         messages = _inject_tools_into_system(messages, tools)
-    return encoding_dsv4.encode_messages(messages, **encode_config)
+    return _encoding_dsv4().encode_messages(messages, **encode_config)

--- a/patches/aiter.patch
+++ b/patches/aiter.patch
@@ -1,0 +1,52 @@
+diff --git a/aiter/fused_moe.py b/aiter/fused_moe.py
+index 55f2a30f8..a424a42f9 100644
+--- a/aiter/fused_moe.py
++++ b/aiter/fused_moe.py
+@@ -367,6 +367,22 @@ def fused_moe_(
+         )
+ 
+ 
++def _transpose_blockscale_a1_scale(a1_scale):
++    # The asm blockscale stage-1 kernels (``fmoe_fp8_blockscale_g1u1`` in
++    # asm_fmoe.cu, ``moe_stage1_g1u1`` in asm_moe_2stage.cu) read the per-1x128
++    # activation scale in a column-major ``[scaleN, token_cnt]`` layout whose
++    # leading dimension is ``token_cnt = hidden_states.shape[0]`` (they derive it
++    # from ``input/out.size(0)``). When the activation is a caller-supplied,
++    # already-FP8 buffer padded to a max capacity (e.g. an EP dispatch buffer
++    # from mori), the valid-token count is smaller than that physical row count.
++    # ``partial_transpose(num_rows=num_local_tokens)`` laid the scale out with
++    # ``num_local_tokens`` as the leading dimension, so every group ``g>0`` was
++    # read at the wrong offset whenever the buffer was padded. Transposing with
++    # the full physical row count keeps the layout consistent with the kernel
++    # regardless of padding.
++    return a1_scale.transpose(0, 1).contiguous()
++
++
+ def fused_moe_1stage(
+     hidden_states,
+     w1,  # [expert(local_expert:EP), inter_dim*2, dim] N,K
+@@ -449,9 +465,7 @@ def fused_moe_1stage(
+             ), "a1_scale must be provided for quantized input for fused_moe"
+             a1 = hidden_states
+             if quant_type == QuantType.per_1x128:
+-                scale_t = torch.empty_like(a1_scale)
+-                aiter.partial_transpose(scale_t, a1_scale, num_rows=num_local_tokens)
+-                a1_scale = scale_t
++                a1_scale = _transpose_blockscale_a1_scale(a1_scale)
+ 
+         token_num = hidden_states.shape[0]
+         E, model_dim, inter_dim = get_inter_dim(w1.shape, w2.shape)
+@@ -1137,6 +1151,13 @@ def fused_moe_2stages(
+             a1_scale is not None or quant_type == QuantType.No
+         ), "a1_scale must be provided for quantized input for fused_moe"
+         a1 = hidden_states
++        if quant_type == QuantType.per_1x128 and metadata.stage1.func is asm_stage1:
++            # Mirror the internal-quant branch above (which passes
++            # transpose_scale=True): asm_stage1 consumes the per-1x128
++            # activation scale in the transposed, token_cnt-strided layout, so a
++            # caller-supplied row-major scale must be transposed here too. This
++            # transpose was previously missing on the caller-quantized-FP8 path.
++            a1_scale = _transpose_blockscale_a1_scale(a1_scale)
+     if quant_type == QuantType.per_1x128 and metadata.stage1.func is asm_stage1:
+         ratio = a1_scale.element_size() // a1.element_size()
+         a2 = torch.empty(

--- a/patches/sglang.patch
+++ b/patches/sglang.patch
@@ -1,0 +1,288 @@
+diff --git a/python/sglang/srt/layers/moe/ep_moe/layer.py b/python/sglang/srt/layers/moe/ep_moe/layer.py
+index 1359c8313..6ba98ac17 100644
+--- a/python/sglang/srt/layers/moe/ep_moe/layer.py
++++ b/python/sglang/srt/layers/moe/ep_moe/layer.py
+@@ -62,6 +62,53 @@ elif _is_npu:
+ 
+ logger = logging.getLogger(__name__)
+ 
++import os as _os
++
++_MORI_SELFCHECK = get_bool_env_var("MILES_MORI_SELFCHECK", "False")
++_MORI_COMBINE_PROBE = get_bool_env_var("MILES_MORI_COMBINE_PROBE", "False")
++_mori_dbg_budget = {}
++
++
++def _mori_dbg(tag, layer_id, **tensors):
++    if not _MORI_SELFCHECK or layer_id != 0:
++        return
++    try:
++        if torch.cuda.is_current_stream_capturing():
++            return
++        import torch.distributed as dist
++
++        rank = dist.get_rank() if dist.is_initialized() else 0
++        # skip warmup (all-zero) frames
++        h = tensors.get("inp", None)
++        if h is None:
++            h = tensors.get("fmoe_out", None)
++        if h is not None and float(h.float().abs().max()) == 0.0:
++            return
++        key = (rank, tag)
++        if _mori_dbg_budget.get(key, 0) >= 4:
++            return
++        _mori_dbg_budget[key] = _mori_dbg_budget.get(key, 0) + 1
++        parts = []
++        for name, t in tensors.items():
++            if t is None:
++                parts.append(f"{name}=None")
++                continue
++            if not torch.is_tensor(t):
++                parts.append(f"{name}={t}")
++                continue
++            tf = t.float()
++            nzr = ""
++            if t.dim() == 2 and t.shape[0] > 1:
++                nzr = f" nzrows={int((tf.abs().amax(dim=1) > 0).sum())}/{t.shape[0]}"
++            parts.append(
++                f"{name}[{tuple(t.shape)} {str(t.dtype).replace('torch.','')}] "
++                f"amax={tf.abs().max().item():.3e} amean={tf.abs().mean().item():.3e} "
++                f"nan={int(torch.isnan(tf).sum())}{nzr}"
++            )
++        print(f"[MORI_SELFCHECK r{rank} L{layer_id} {tag}] " + " | ".join(parts), flush=True)
++    except Exception as e:
++        print(f"[MORI_SELFCHECK ERROR] {e}", flush=True)
++
+ 
+ if _is_npu:
+     import torch_npu
+@@ -629,14 +676,64 @@ class MoriEPMoE(DeepEPMoE):
+         )
+ 
+         assert _use_aiter, "Mori need to be used together with aiter as of now"
+-        self.expert_mask = torch.zeros(
+-            (self.num_experts),
++        # NOTE: expert_mask marks which GLOBAL experts are local to this EP rank
++        # (1 = local). aiter.fused_moe masks out every expert whose mask entry is
++        # 0, so an all-zero mask makes the kernel produce all-zero output. The
++        # persistent GPU tensor created here gets its memory clobbered (zeroed)
++        # around CUDA-graph capture, which silently turns every real rollout
++        # forward into a no-op. We therefore (1) remember the valid range and
++        # (2) rebuild the mask from scratch on every run_moe_core call, which is
++        # CUDA-graph safe (the memset+fill kernels are captured and replay with
++        # correct values) and immune to any post-init memory reuse.
++        self._expert_start_idx = self.moe_ep_rank * self.num_local_experts
++        self._expert_end_idx = self._expert_start_idx + self.num_local_experts
++        self.expert_mask = self._build_expert_mask()
++
++        if _MORI_COMBINE_PROBE and layer_id == 0:
++            try:
++                import torch.distributed as dist
++                _r = dist.get_rank() if dist.is_initialized() else -1
++                print(
++                    f"[MORI_MASK_INIT global_rank={_r} layer={layer_id}] "
++                    f"moe_ep_rank={self.moe_ep_rank} moe_ep_size={self.moe_ep_size} "
++                    f"num_experts={self.num_experts} num_local_experts={self.num_local_experts} "
++                    f"mask_size={self.expert_mask.numel()} mask_sum={int(self.expert_mask.sum())} "
++                    f"valid_range=[{self._expert_start_idx}:{self._expert_end_idx}]",
++                    flush=True,
++                )
++            except Exception as _e:
++                print(f"[MORI_MASK_INIT ERROR] {_e}", flush=True)
++
++    def _build_expert_mask(self) -> torch.Tensor:
++        mask = torch.zeros(
++            (self.num_experts,),
+             device=torch.cuda.current_device(),
+             dtype=torch.int32,
+         )
+-        expert_start_idx = self.moe_ep_rank * self.num_local_experts
+-        expert_end_idx = expert_start_idx + self.num_local_experts
+-        self.expert_mask[expert_start_idx:expert_end_idx] = 1
++        mask[self._expert_start_idx : self._expert_end_idx] = 1
++        return mask
++
++    def _diag_stale_mask(self):
++        # One-shot check: report whether the persistent expert_mask got clobbered
++        # (sum != num_local_experts) before we rebuild it. Confirms the root cause.
++        try:
++            if torch.cuda.is_current_stream_capturing():
++                return
++            if getattr(self, "_diag_stale_done", False):
++                return
++            stale = int(self.expert_mask.sum())
++            if stale != self.num_local_experts:
++                self._diag_stale_done = True
++                import torch.distributed as dist
++                rank = dist.get_rank() if dist.is_initialized() else 0
++                print(
++                    f"[MORI_MASK_STALE r{rank}] persistent expert_mask.sum()={stale} "
++                    f"expected={self.num_local_experts} -> mask was clobbered "
++                    f"after init; rebuilding each forward",
++                    flush=True,
++                )
++        except Exception as e:
++            print(f"[MORI_MASK_STALE ERROR] {e}", flush=True)
+ 
+     def forward(
+         self,
+@@ -644,6 +741,7 @@ class MoriEPMoE(DeepEPMoE):
+         topk_output: TopKOutput,
+     ):
+         num_token = hidden_states.shape[0]
++        _mori_dbg("00_in", self.layer_id, inp=hidden_states)
+         dispatch_output = self.dispatcher.dispatch(
+             hidden_states=hidden_states, topk_output=topk_output
+         )
+@@ -651,9 +749,95 @@ class MoriEPMoE(DeepEPMoE):
+         hidden_states = self.dispatcher.combine(
+             combine_input=combine_input,
+         )
++        _mori_dbg(
++            "40_combine_out",
++            self.layer_id,
++            inp=combine_input.hidden_states,
++            comb=hidden_states[:num_token],
++        )
++
++        if _MORI_COMBINE_PROBE and self.layer_id == 0 and num_token > 4:
++            self._mori_combine_probe(combine_input, hidden_states, num_token)
+ 
+         return hidden_states[:num_token]
+ 
++    def _mori_fmoe_dump(self, a1, scale, ids, weights, recv, out, w13, w2,
++                        w13_scale, w2_scale, quant_type):
++        try:
++            if torch.cuda.is_current_stream_capturing():
++                return
++            if getattr(self, "_mori_fmoe_dumped", False):
++                return
++            n = int(out.shape[0])
++            nz = int((out.float().abs().amax(dim=1) > 0).sum())
++            rc = int(recv.flatten()[0]) if torch.is_tensor(recv) else int(recv)
++            a1nz = int((a1.float().abs().amax(dim=1) > 0).sum())
++            # only dump the REAL anomaly: input substantially non-zero (not a
++            # warmup/dummy frame) but fused_moe under-fills its output.
++            if rc <= 8 or a1nz < int(rc * 0.9) or nz >= int(rc * 0.9):
++                return
++            self._mori_fmoe_dumped = True
++            import torch.distributed as dist
++            rank = dist.get_rank() if dist.is_initialized() else 0
++            cap = min(n, max(rc + 16, 1))
++            blob = {
++                "a1": a1[:cap].detach().cpu(),
++                "scale": (scale[:cap].detach().cpu() if torch.is_tensor(scale) else None),
++                "ids": ids[:cap].detach().cpu(),
++                "weights": weights[:cap].detach().cpu(),
++                "recv": rc,
++                "out_nonzero": nz,
++                "out_rowmax": out.detach().float().abs().amax(dim=1).cpu(),
++                "w13": w13.detach().cpu(),
++                "w2": w2.detach().cpu(),
++                "w13_scale": (w13_scale.detach().cpu() if torch.is_tensor(w13_scale) else None),
++                "w2_scale": (w2_scale.detach().cpu() if torch.is_tensor(w2_scale) else None),
++                "expert_mask": self.expert_mask.detach().cpu(),
++                "quant_type": str(quant_type),
++                "num_local_experts": self.num_local_experts,
++            }
++            blob["a1_nonzero"] = a1nz
++            path = f"/tmp/mori_fmoe_fail_r{rank}.pt"
++            torch.save(blob, path)
++            print(f"[MORI_FMOE_DUMP r{rank}] recv={rc} a1_nonzero={a1nz} out_nonzero={nz} saved {path}", flush=True)
++        except Exception as e:
++            print(f"[MORI_FMOE_DUMP ERROR] {e}", flush=True)
++
++    def _mori_combine_probe(self, combine_input, hidden_states, num_token):
++        # NOTE: deliberately NO collective ops here (no extra dispatch/combine),
++        # otherwise ranks with num_token<=4 diverge and the live rollout hangs.
++        try:
++            if torch.cuda.is_current_stream_capturing():
++                return
++            ci = combine_input.hidden_states
++            tids = combine_input.topk_ids
++            fin = float(ci.float().abs().max())
++            if fin == 0.0:
++                return
++            amax0 = float(hidden_states[:num_token].float().abs().max())
++            import torch.distributed as dist
++            rank = dist.get_rank() if dist.is_initialized() else 0
++            print(
++                f"[MORI_PROBE r{rank}] num_token={num_token} fmoe_in_amax={fin:.3e} "
++                f"combine_amax={amax0:.3e}",
++                flush=True,
++            )
++            if amax0 == 0.0 and not getattr(self, "_mori_dumped", False):
++                self._mori_dumped = True
++                path = f"/tmp/mori_combine_fail_r{rank}.pt"
++                torch.save(
++                    {
++                        "topk_ids": tids.detach().cpu(),
++                        "topk_weights": combine_input.topk_weights.detach().cpu(),
++                        "num_token": num_token,
++                        "fmoe_in_rowmax": ci.detach().float().abs().amax(dim=1).cpu(),
++                    },
++                    path,
++                )
++                print(f"[MORI_PROBE r{rank}] dumped failing combine routing to {path}", flush=True)
++        except Exception as e:
++            print(f"[MORI_PROBE ERROR] {e}", flush=True)
++
+     def run_moe_core(
+         self,
+         dispatch_output: DispatchOutput,
+@@ -746,6 +930,15 @@ class MoriEPMoE(DeepEPMoE):
+             if quant_type == QuantType.No:
+                 quant_type = QuantType.per_128x128
+ 
++        # The persistent expert_mask can be silently zeroed by CUDA-graph memory
++        # reuse after init; an all-zero mask makes fused_moe emit all-zero output
++        # for every token. Rebuild it from the (constant) valid range each call so
++        # the kernel always sees the correct local-expert mask. Cheap (128 ints)
++        # and CUDA-graph safe.
++        if _MORI_COMBINE_PROBE and self.layer_id == 0:
++            self._diag_stale_mask()
++        self.expert_mask = self._build_expert_mask()
++
+         # [KK TODO] should to call the apply of quant method to handle fused moe
+         hidden_states = fused_moe(
+             hidden_states=dispatch_a1,
+@@ -767,6 +960,27 @@ class MoriEPMoE(DeepEPMoE):
+             dtype=output_dtype,
+         )
+ 
++        _mori_dbg(
++            "30_fmoe",
++            self.layer_id,
++            disp=dispatch_a1,
++            dscale=dispatch_scale,
++            fmoe_out=hidden_states,
++            recv=(
++                dispatch_recv_token_num.float()
++                if torch.is_tensor(dispatch_recv_token_num)
++                else dispatch_recv_token_num
++            ),
++            qt=str(quant_type),
++        )
++
++        if _MORI_COMBINE_PROBE and self.layer_id == 0:
++            self._mori_fmoe_dump(
++                dispatch_a1, dispatch_scale, dispatch_ids, dispatch_weights,
++                dispatch_recv_token_num, hidden_states, w13_weight, w2_weight,
++                w13_scale, w2_scale, quant_type,
++            )
++
+         from sglang.srt.layers.moe.token_dispatcher import DispatchOutputChecker
+ 
+         combine_input_wrapper = (
+diff --git a/python/sglang/srt/models/qwen3_moe.py b/python/sglang/srt/models/qwen3_moe.py
+index 1d10319a5..df142af8c 100644
+--- a/python/sglang/srt/models/qwen3_moe.py
++++ b/python/sglang/srt/models/qwen3_moe.py
+@@ -295,6 +295,7 @@ class Qwen3MoeSparseMoeBlock(nn.Module):
+         if (
+             not get_moe_a2a_backend().is_deepep()
+             and not get_moe_a2a_backend().is_ascend_fuseep()
++            and not get_moe_a2a_backend().is_mori()
+         ):
+             return self.forward_normal(
+                 hidden_states, should_allreduce_fusion, use_reduce_scatter

--- a/readme_deepep_fp8.md
+++ b/readme_deepep_fp8.md
@@ -1,0 +1,109 @@
+# DeepEP FP8 (MoE / mori) setup and test
+
+This document describes how to launch the ROCm **miles** image, apply **aiter** / **sglang** patches shipped in this repo (optional but recommended for mori EP FP8), install **mori** and **uccl** with the **deep_ep** interface from source (ROCm / MI355X-oriented paths), then run the DeepEP FP8 e2e test in this repo.
+
+Paths like `/sgl-workspace/mori` and `/workspace` match a typical SGLang-style container layout; adjust bind mounts and host paths to your machine.
+
+---
+
+## 1) Launch container
+
+On the host, bind your local **`miles`** checkout into the container (adjust the host path in `-v` as needed):
+
+```bash
+docker run -it \
+  --device=/dev/kfd \
+  --device=/dev/dri \
+  --security-opt seccomp=unconfined \
+  --group-add 44 \
+  --group-add 109 \
+  --cap-add=SYS_PTRACE \
+  --ipc=host \
+  --shm-size=32g \
+  --ulimit memlock=-1 \
+  --ulimit stack=67108864 \
+  --memory=0 \
+  --memory-swap=0 \
+  --privileged \
+  --ulimit nofile=65535:65535 \
+  -v /tmp:/tmp \
+  -v /your_miles_path/miles:/workspace/miles \
+  rlsys/miles:MI350-355-latest
+```
+
+Inside the container, the repo is typically at **`/workspace/miles`**. Subsequent steps assume you are in that environment (or equivalent paths).
+
+---
+
+## 2) Apply patches (dry-run first)
+
+Do this **inside the container**, after launching it (step 1). Patch files live under **`patches/`** in the **miles** checkout; use a shell whose working directory is the miles repo root so **`$PWD/patches/...`** resolves (e.g. `cd /workspace/miles`).
+
+### 2.1 Dry-run (recommended)
+
+```bash
+git -C /sgl-workspace/aiter  apply --check "$PWD/patches/aiter.patch"
+git -C /sgl-workspace/sglang apply --check "$PWD/patches/sglang.patch"
+```
+
+If **both** commands succeed with no output, the patches match your tree.
+
+### 2.2 Apply
+
+```bash
+git -C /sgl-workspace/aiter  apply "$PWD/patches/aiter.patch"
+git -C /sgl-workspace/sglang apply "$PWD/patches/sglang.patch"
+```
+
+---
+
+## 3) Install mori from source (editable)
+
+```bash
+# /sgl-workspace/mori is the editable install (mori.egg-link → python/)
+cd /sgl-workspace/mori
+git fetch origin
+git checkout origin/main             # e94694c7, 2026-06-04 — fix(io): bind worker threads within allowed cpuset
+rm -rf build/
+MORI_GPU_ARCHS=gfx950 pip install --no-build-isolation -v -e .
+```
+
+---
+
+## 4) Install uccl with deep interface (deep_ep)
+
+**Important:** `uccl/ep/install_deps.sh` was **not** run. On ROCm it reinstalls PyTorch nightly (`--index-url .../nightly/rocm7.0`), which would overwrite the image’s customized ROCm torch. Only the minimal build dependencies below were added.
+
+```bash
+# 0. Clone uccl
+cd /workspace
+git clone https://github.com/uccl-project/uccl.git
+
+# 1. Minimal build deps (does not touch torch)
+pip install nanobind                       # was missing; setup.py hard-requires it
+# libibverbs-dev / libnl-3-dev / libnl-route-3-dev already present in image
+
+# 2. Build & install uccl.ep for MI355X (gfx950) from source against the image's torch
+cd /workspace/uccl/ep
+TORCH_CUDA_ARCH_LIST=gfx950 PYTORCH_ROCM_ARCH=gfx950 python setup.py install
+
+# 3. Install the drop-in deep_ep package
+# (skip dep resolution so PyPI 'uccl' can't override the local build)
+cd deep_ep_wrapper
+pip install --no-deps --no-build-isolation -e .
+
+# Verify
+python -c "import uccl.ep; from deep_ep import Buffer; print('OK')"
+```
+
+---
+
+## 5) Run the test
+
+From the **`miles` repository root** in the container (e.g. `/workspace/miles`, the directory that contains `tests/`):
+
+```bash
+bash tests/e2e/megatron/test_qwen3_30B_A3B/run_test_deepep_fp8.sh
+```
+
+The script sets `PYTHONPATH`, mori / AITER-related env vars, stops any stale Ray cluster, and runs `tests/e2e/megatron/test_qwen3_30B_A3B/test_deepep_fp8.py`.

--- a/tests/e2e/megatron/test_qwen3_30B_A3B/_common.py
+++ b/tests/e2e/megatron/test_qwen3_30B_A3B/_common.py
@@ -183,7 +183,13 @@ def build_train_args(case: CaseConfig, *, wandb_file: str) -> str:
     )
 
     if case.use_deepep:
-        sglang_args += "--sglang-moe-a2a-backend deepep --sglang-deepep-mode auto "
+        sglang_args += "--sglang-moe-a2a-backend mori --sglang-deepep-mode auto "
+        # DEBUG(mori EP rollout garbage): single-variable test of the CUDA-graph x
+        # mori-combine interaction. A host-side sync/barrier cannot be captured into a
+        # CUDA graph, so disabling the graph is a prerequisite for any host-side combine
+        # ordering mitigation. Env-gated so default behavior is unchanged.
+        if os.environ.get("MILES_DEBUG_DISABLE_CUDA_GRAPH") == "1":
+            sglang_args += "--sglang-disable-cuda-graph "
     if case.sglang_ep_size is not None:
         sglang_args += f"--sglang-expert-parallel-size {case.sglang_ep_size} "
     if case.sglang_dp_size is not None:
@@ -243,6 +249,19 @@ def execute(case: CaseConfig, *, wandb_file: str) -> None:
             "OPEN_TRAINING_INT4_FAKE_QAT_FLAG": "1",
             "OPEN_TRAINING_INT4_GROUP_SIZE": "128",
         }
+
+    # These switches only reach the SGLang subprocess when placed in
+    # extra_env_vars (forwarded via the Ray runtime_env). When unset in the
+    # parent environment, default behavior is unchanged.
+    for _passthrough_key in (
+        "SGLANG_USE_AITER",
+        "SGLANG_MORI_NUM_MAX_DISPATCH_TOKENS_PER_RANK",
+        "SGLANG_MORI_DISPATCH_DTYPE",
+        "MILES_MORI_SELFCHECK",
+        "MILES_MORI_COMBINE_PROBE",
+    ):
+        if _passthrough_key in os.environ:
+            extra_env_vars[_passthrough_key] = os.environ[_passthrough_key]
 
     U.execute_train(
         train_args=train_args,

--- a/tests/e2e/megatron/test_qwen3_30B_A3B/run_test_deepep_fp8.sh
+++ b/tests/e2e/megatron/test_qwen3_30B_A3B/run_test_deepep_fp8.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../../.." && pwd)"
+cd "${REPO_ROOT}"
+
+export GITHUB_WORKSPACE=$PWD
+export PYTHONPATH=$PWD
+
+# mori EP MoE: dispatch cap must be >= chunked_prefill_size (auto = 16384 on
+# MI355X HBM), otherwise server_args._handle_a2a_moe asserts at startup.
+# SGLANG_USE_AITER routes the mori moe core through aiter.fused_moe (the
+# per_128x128 path the fix targets). Both reach the SGLang subprocess only via
+# _common.py's runtime_env passthrough, so they must be exported here.
+export SGLANG_USE_AITER=1
+export SGLANG_MORI_NUM_MAX_DISPATCH_TOKENS_PER_RANK=16384
+unset SGLANG_DEEPEP_BF16_DISPATCH
+
+# Optional debug instrumentation (default off, not needed to reproduce or to
+# apply the fix). When enabled, MoriEPMoE prints per-layer tensor stats and, on a
+# zero-output MoE frame, dumps the failing fused_moe inputs to /tmp.
+# export MILES_MORI_SELFCHECK=1
+# export MILES_MORI_COMBINE_PROBE=1
+
+# Clear any stale Ray cluster left by a previous failed run (port/GPU conflicts).
+ray stop --force >/dev/null 2>&1 || true
+sleep 2
+
+python tests/e2e/megatron/test_qwen3_30B_A3B/test_deepep_fp8.py


### PR DESCRIPTION
<h2>Summary</h2>
<ul>
  <li>
    <strong>Docs (<code>readme_deepep_fp8.md</code>)</strong> — End-to-end guide for
    <strong>MI350–355</strong> / <strong>gfx950</strong>: Docker launch
    (<code>rlsys/miles:MI350-355-latest</code>), <strong>dry-run and apply</strong>
    <code>patches/aiter.patch</code> and <code>patches/sglang.patch</code> against
    <code>/sgl-workspace/aiter</code> and <code>/sgl-workspace/sglang</code>,
    <strong>mori</strong> editable install with <code>MORI_GPU_ARCHS=gfx950</code>,
    <strong>uccl.ep</strong> + <strong>deep_ep</strong> install without
    <code>install_deps.sh</code> (avoids overwriting ROCm torch), how to run the
    DeepEP FP8 test from the miles repo root, and <strong>Python 3.11+</strong> (see
    note below).
  </li>
  <li>
    <strong>Patches (<code>patches/aiter.patch</code>, <code>patches/sglang.patch</code>)</strong>
    — Checked-in diffs for downstream trees:
    <ul>
      <li>
        <strong>AITER</strong> — FP8 <strong>per-1×128</strong> scale layout for
        <strong>caller-quantized</strong> / <strong>padded</strong> mori dispatch
        buffers (transpose vs <code>partial_transpose</code>); 1-stage and 2-stage
        <code>asm_stage1</code> paths.
      </li>
      <li>
        <strong>SGLang</strong> — <strong>MoriEPMoE</strong> expert-mask rebuild
        (CUDA-graph / memory reuse), optional <strong><code>MILES_MORI_*</code></strong>
        diagnostics, <strong>Qwen3</strong> MoE block skips
        <code>forward_normal</code> when backend is <strong>mori</strong>.
      </li>
    </ul>
  </li>
  <li>
    <strong>Megatron e2e harness (<code>tests/e2e/megatron/test_qwen3_30B_A3B/_common.py</code>)</strong>
    — When <code>use_deepep</code>, SGLang MoE A2A backend is <strong><code>mori</code></strong>
    (still <code>--sglang-deepep-mode auto</code>); optional
    <strong><code>MILES_DEBUG_DISABLE_CUDA_GRAPH=1</code></strong> adds
    <code>--sglang-disable-cuda-graph</code>; forwards
    <strong><code>SGLANG_USE_AITER</code></strong>, <strong><code>SGLANG_MORI_*</code></strong>,
    <strong><code>MILES_MORI_*</code></strong> from the parent env into Ray
    <strong><code>extra_env_vars</code></strong> so subprocesses see them.
  </li>
  <li>
    <strong>Runner (<code>run_test_deepep_fp8.sh</code>)</strong> — Sets
    <strong><code>PYTHONPATH</code></strong>, <strong><code>SGLANG_USE_AITER=1</code></strong>,
    <strong><code>SGLANG_MORI_NUM_MAX_DISPATCH_TOKENS_PER_RANK=16384</code></strong>,
    unsets <strong><code>SGLANG_DEEPEP_BF16_DISPATCH</code></strong>, stops stale
    <strong>Ray</strong>, runs <strong><code>test_deepep_fp8.py</code></strong>.
  </li>
  <li>
    <strong>Chat templates (<code>deepseek_v32.py</code>, <code>deepseek_v4.py</code>)</strong>
    — <strong>Lazy</strong> import of <strong><code>encoding_dsv32</code></strong> /
    <strong><code>encoding_dsv4</code></strong> so older SGLang images that do not
    export those symbols still import miles for non–DeepSeek workloads.
  </li>
</ul>

<blockquote>
  <p><strong>Note (Python / <code>enum.StrEnum</code>):</strong> Use
  <strong>Python 3.11+</strong> in the container for this workflow. On
  <strong>Python 3.10</strong>, <code>from enum import StrEnum</code> raises
  <code>ImportError: cannot import name 'StrEnum' from 'enum'</code> because
  <code>enum.StrEnum</code> exists only from 3.11 onward. Upgrade Python (or use a
  3.11+ image) before importing miles or running the e2e test; details are in
  <code>readme_deepep_fp8.md</code>.</p>
</blockquote>

<hr />

<h2>Test plan</h2>
<ul>
  <li>
    <label><input type="checkbox" disabled /> In <strong>MI350–355</strong> image (or matching layout):
    <code>git apply --check</code> both patches, then apply; install mori + uccl per readme
    (or use a prebuilt image that already matches). Confirm <strong>Python 3.11+</strong>
    (or accept that 3.10 will hit <strong><code>StrEnum</code></strong> import errors until upgraded).</label>
  </li>
  <li>
    <label><input type="checkbox" disabled /> From miles repo root:
    <code>bash tests/e2e/megatron/test_qwen3_30B_A3B/run_test_deepep_fp8.sh</code> —
    confirm <strong><code>test_deepep_fp8.py</code></strong> completes (or document known
    infra limits if CI cannot run 8-GPU ROCm).</label>
  </li>
  <li>
    <label><input type="checkbox" disabled /> Smoke: import miles / run a small job that does
    <strong>not</strong> use DeepSeek V3.2/V4 templates — confirm no regression from lazy encoder imports.</label>
  </li>
</ul>