### PR TITLE
[OPD] [4/N] Teacher ensembles + exact tail-bucket top-k KL + scoring robustness

### DIFF
--- a/docs/advanced/on-policy-distillation.md
+++ b/docs/advanced/on-policy-distillation.md
@@ -12,6 +12,8 @@ On-policy distillation (OPD) trains a student model on its own rollouts while us
 | `--opd-log-prob-top-k` | Number of top-k tokens retained for the Rethinking OPD token reward. `0` uses sampled-token OPD; `16` matches the paper recipe default. |
 | `--opd-top-k-strategy` | Top-k token set strategy: `only-student`, `only-teacher`, `intersection`, `union`, or `xor`. |
 | `--opd-reward-weight-mode` | Weighting scheme for top-k rewards: `student_p`, `teacher_p`, or `none`. |
+| `--opd-teacher-urls` | Optional multi-teacher routing map (`NAME=URL` pairs, SGLang mode only). Routes each sample to a teacher by `sample.metadata[--opd-teacher-key]`; reserved name `default` is the fallback. Unset = single teacher at `--rm-url`. |
+| `--opd-teacher-key` | Metadata key holding the teacher name for routing (default: `opd_teacher`). |
 | `--opd-teacher-load` | Path to teacher Megatron checkpoint. **Required** when `--opd-type=megatron`, **must not be set** when `--opd-type=sglang`. |
 | `--opd-teacher-ckpt-step` | Optional checkpoint step for teacher model. |
 
@@ -70,6 +72,42 @@ The teacher runs on an external SGLang server. Teacher log-probs are obtained du
 --custom-reward-post-process-path miles.rollout.on_policy_distillation.post_process_rewards
 --rm-url http://<TEACHER_IP>:<TEACHER_PORT>/generate
 ```
+
+### Multi-Teacher Routing (SGLang mode only)
+
+`--opd-teacher-urls` routes each sample to a task-specific teacher, e.g. a math
+specialist for math prompts and a code specialist for code prompts. Each sample
+is still scored by exactly one teacher, so scoring cost is identical to
+single-teacher OPD and the loss is unchanged — `teacher_log_probs` /
+`opd_reverse_kl` are per-sample and do not care which teacher produced them.
+
+**How it works**:
+1. Tag each prompt with a teacher name in its dataset metadata column
+   (read via `--metadata-key`, default `metadata`):
+   ```json
+   {"prompt": "...", "metadata": {"opd_teacher": "math"}}
+   {"prompt": "...", "metadata": {"opd_teacher": "code"}}
+   ```
+2. Map names to teacher endpoints with `--opd-teacher-urls NAME=URL ...`.
+   The reserved name `default` is the fallback for samples whose name is
+   missing or unknown; without a `default` entry such samples raise an error
+   (failing loudly beats silently distilling from the wrong teacher).
+3. `reward_func` resolves the URL per sample; everything downstream is
+   unchanged.
+
+**Configuration** (on top of the SGLang-mode flags above; `--rm-url` is ignored
+when the routing map is set):
+```bash
+--opd-teacher-urls math=http://<H1>:<P1>/generate code=http://<H2>:<P2>/generate default=http://<H1>:<P1>/generate
+--opd-teacher-key opd_teacher   # metadata key holding the teacher name (default)
+```
+
+> **Notes**: All teachers must share the student's tokenizer — scoring sends
+> `input_ids` and gathers per-token-id log-probs. Works with both the
+> sampled-token path and the top-k path (student-side scoring still goes to the
+> student router). For throughput, point multiple names (or one name backed by
+> an sglang router) at replicas; `--opd-teacher-urls` is for *different*
+> teachers, not load balancing.
 
 ### Megatron Mode (`--opd-type megatron`)
 

--- a/docs/advanced/on-policy-distillation.md
+++ b/docs/advanced/on-policy-distillation.md
@@ -12,8 +12,10 @@ On-policy distillation (OPD) trains a student model on its own rollouts while us
 | `--opd-log-prob-top-k` | Number of top-k tokens retained for the Rethinking OPD token reward. `0` uses sampled-token OPD; `16` matches the paper recipe default. |
 | `--opd-top-k-strategy` | Top-k token set strategy: `only-student`, `only-teacher`, `intersection`, `union`, or `xor`. |
 | `--opd-reward-weight-mode` | Weighting scheme for top-k rewards: `student_p`, `teacher_p`, or `none`. |
-| `--opd-teacher-urls` | Optional multi-teacher routing map (`NAME=URL` pairs, SGLang mode only). Routes each sample to a teacher by `sample.metadata[--opd-teacher-key]`; reserved name `default` is the fallback. Unset = single teacher at `--rm-url`. |
+| `--opd-topk-tail-bucket` | Compute the top-k reward as the exact reverse KL over the selected ids plus one tail bucket (k+1 buckets summing to 1) instead of the renormalized truncated estimate. Requires `--opd-reward-weight-mode student_p`. |
+| `--opd-teacher-urls` | Optional multi-teacher routing/ensemble map (`NAME=URL[@W][,URL[@W]...]` entries, SGLang mode only). Routes each sample to a teacher group by `sample.metadata[--opd-teacher-key]`; reserved name `default` is the fallback. A group with several comma-separated URLs is a weighted probability-space ensemble. Unset = single teacher at `--rm-url`. |
 | `--opd-teacher-key` | Metadata key holding the teacher name for routing (default: `opd_teacher`). |
+| `--opd-scoring-timeout-secs` | Per-request timeout for teacher/student scoring. Defaults to `--sglang-router-request-timeout-secs`; set it to bound slow teacher servers without changing the shared router timeout. Scoring requests also get one automatic retry on transient failures (timeout, connection error, HTTP 5xx). |
 | `--opd-teacher-load` | Path to teacher Megatron checkpoint. **Required** when `--opd-type=megatron`, **must not be set** when `--opd-type=sglang`. |
 | `--opd-teacher-ckpt-step` | Optional checkpoint step for teacher model. |
 
@@ -44,6 +46,16 @@ The token set is controlled by `--opd-top-k-strategy`:
 | `xor` | Tokens appearing in exactly one top-k set. |
 
 `--opd-reward-weight-mode` controls whether each selected token is weighted by student probability, teacher probability, or uniformly. For compatibility, `--opd-log-prob-top-k=0` keeps the original sampled-token OPD path.
+
+### Tail-Mass Bucket
+
+The default weighting renormalizes over the selected token set, so the estimate cannot see probability mass the student moves *outside* the top-k. `--opd-topk-tail-bucket` instead treats the position as k+1 buckets that sum to 1 — the selected ids at their exact full-softmax probabilities, plus one aggregated tail bucket — and computes the exact reverse KL over that partition:
+
+$$
+D_{\text{KL}} = \sum_{v \in S} p_s(v)\,\big(\log p_s(v) - \log p_T(v)\big) \;+\; \big(1 - \textstyle\sum_{v \in S} p_s(v)\big)\,\big(\log \text{tail}_s - \log \text{tail}_T\big)
+$$
+
+No renormalization is needed because both sides are exact log-probs at the same ids; the tail term penalizes the student for pushing mass off the support. The math runs in float64 (scoring log-probs arrive as JSON doubles) with `log1p` for the tail, so it avoids the precision cliffs a bf16 training-side implementation hits when top-k mass rounds to 1. Requires `--opd-reward-weight-mode student_p` and `--opd-top-k-strategy only-student` or `intersection` — the bucket partition is only exact when all student log-probs at the selected ids come from a single softmax (the rollout harvest); the other strategies fill in student log-probs from a separate rescoring pass, whose mass cannot be combined into one distribution. The per-position result still ships as a single scalar in `sample.opd_reverse_kl`, so training-side cost is unchanged.
 
 ## Two Teacher Modes
 
@@ -108,6 +120,43 @@ when the routing map is set):
 > student router). For throughput, point multiple names (or one name backed by
 > an sglang router) at replicas; `--opd-teacher-urls` is for *different*
 > teachers, not load balancing.
+
+### Teacher Ensembles (SGLang mode only)
+
+A routed name can map to a *group* of teachers. Every group member scores the
+sample and the targets are combined as a **weighted mixture in probability
+space**: per token id, $\log \bar{p}(v) = \log\big(\sum_m w_m\, p_m(v) / \sum_m w_m\big)$
+(a `logsumexp` over weighted log-probs). This is the log-probability of the
+mixture distribution — averaging log-probs directly would be an unnormalized
+geometric mean and is *not* a valid distillation target.
+
+```bash
+# Two peers ensembled uniformly for math prompts; a single default teacher otherwise.
+--opd-teacher-urls math=http://<H1>:<P1>/generate,http://<H2>:<P2>/generate default=http://<H3>:<P3>/generate
+# Optional per-teacher weights (default 1.0):
+--opd-teacher-urls math=http://<H1>:<P1>/generate@2.0,http://<H2>:<P2>/generate@1.0
+```
+
+**How it works**: `reward_func` fans the identical scoring request out to every
+group member in parallel (`asyncio.gather`), so wall clock is the slowest
+member's latency, not the sum, and all teacher compute stays on dedicated
+inference GPUs — training-step time is untouched and the per-sample tensors
+shipped to training are unchanged. With the sampled-token path the mixture is
+taken at each sampled token; with the top-k path each member is scored at the
+student's top-k ids (the global per-sample union by default, or per-position
+ids with `--opd-topk-per-position`) and raw probabilities are mixed per id
+*before* any weighting (a mixture of renormalized truncations is not the
+truncation of the mixture), which is why ensembles require
+`--opd-top-k-strategy only-student`.
+
+**Routing vs. ensembling**: reverse KL to a mixture is mode-seeking, and
+uniformly averaging a confident in-domain specialist with a confused
+out-of-domain teacher pollutes the target. Route *across* domains (one
+specialist per task) and ensemble only same-domain peers within a group —
+e.g. several SFT/RL variants of the same teacher family. Ensemble members may
+have different architectures and sizes as long as they share the student's
+tokenizer. Combines well with `--opd-topk-tail-bucket`: the mixture tail is
+the weighted average of member tails, so the k+1-bucket KL stays exact.
 
 ### Megatron Mode (`--opd-type megatron`)
 

--- a/examples/on_policy_distillation/README.md
+++ b/examples/on_policy_distillation/README.md
@@ -10,6 +10,10 @@ This directory contains runnable examples:
 - `run-qwen3-8B-opd.sh`: SGLang teacher server OPD. This script enables
   Rethinking OPD with `--opd-log-prob-top-k 16`, `--opd-top-k-strategy only-student`,
   and `--opd-reward-weight-mode student_p`.
+- `run-qwen3-8B-opd-multi-teacher.sh`: Multi-teacher OPD with per-sample routing.
+  Math prompts are scored by a Qwen3-32B teacher and code prompts by a
+  Qwen3-Coder-30B-A3B teacher, selected via `--opd-teacher-urls` and a per-row
+  `{"metadata": {"opd_teacher": ...}}` tag in the dataset.
 - `run-qwen3-8B-opd-megatron.sh`: Megatron-loaded teacher OPD.
 
 Use `--opd-log-prob-top-k 0` to run the original sampled-token OPD path.

--- a/examples/on_policy_distillation/README.md
+++ b/examples/on_policy_distillation/README.md
@@ -14,6 +14,11 @@ This directory contains runnable examples:
   Math prompts are scored by a Qwen3-32B teacher and code prompts by a
   Qwen3-Coder-30B-A3B teacher, selected via `--opd-teacher-urls` and a per-row
   `{"metadata": {"opd_teacher": ...}}` tag in the dataset.
+- `run-qwen3-8B-opd-ensemble.sh`: Teacher-ensemble OPD. Every sample is scored
+  by a weighted group of two teachers in parallel and the targets are combined
+  as a probability-space mixture (`--opd-teacher-urls` with comma-separated
+  URLs and `@weight` suffixes), using the exact tail-bucket top-k KL
+  (`--opd-topk-tail-bucket`).
 - `run-qwen3-8B-opd-megatron.sh`: Megatron-loaded teacher OPD.
 
 Use `--opd-log-prob-top-k 0` to run the original sampled-token OPD path.

--- a/examples/on_policy_distillation/run-qwen3-8B-opd-ensemble.sh
+++ b/examples/on_policy_distillation/run-qwen3-8B-opd-ensemble.sh
@@ -1,0 +1,219 @@
+#!/bin/bash
+
+# Teacher-ensemble OPD: every sample is scored by a GROUP of teachers whose
+# distributions are combined as a weighted mixture in probability space
+# (logsumexp of weighted logprobs), with the exact tail-bucket top-k KL.
+#
+# Student:    Qwen3-8B (2 training GPUs + 4 rollout GPUs)
+# Teacher A:  Qwen3-32B            (GPU 6) weight 2.0
+# Teacher B:  Qwen3-30B-A3B        (GPU 7) weight 1.0
+#
+# Both teachers score every sample in parallel (asyncio.gather), so scoring
+# wall clock is max(teacher latencies), not the sum, and training-step time is
+# unchanged versus single-teacher OPD. Ensemble only same-domain peers — for
+# task specialists, use per-sample routing instead (see
+# run-qwen3-8B-opd-multi-teacher.sh); the two compose: each routed name can be
+# its own ensemble group. All teachers must share the student's tokenizer
+# (scoring sends input_ids), which holds for the Qwen3 family used here.
+#
+# usage: bash examples/on_policy_distillation/run-qwen3-8B-opd-ensemble.sh
+
+set -ex
+
+TEACHER_A_IP="127.0.0.1"
+TEACHER_A_PORT=13141
+TEACHER_B_IP="127.0.0.1"
+TEACHER_B_PORT=13142
+
+start_teacher() {
+    local gpu=$1 model_path=$2 port=$3
+    local log_file
+    log_file="/tmp/sglang_$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 6).log"
+    CUDA_VISIBLE_DEVICES=$gpu python3 -m sglang.launch_server \
+        --model-path "$model_path" \
+        --host 0.0.0.0 \
+        --port "$port" \
+        --tp 1 \
+        --chunked-prefill-size 4096 \
+        --mem-fraction-static 0.6 \
+        > "$log_file" 2>&1 &
+    echo "$log_file"
+}
+
+wait_teacher() {
+    local ip=$1 port=$2 log_file=$3
+    until curl -sf "http://$ip:$port/health_generate" > /dev/null; do
+        echo "Waiting for teacher server at $ip:$port..."
+        tail -n 10 "$log_file"
+        sleep 5
+    done
+    curl "http://$ip:$port/get_model_info"
+    echo "Teacher server is up at $ip:$port."
+}
+
+A_LOG=$(start_teacher 6 /root/Qwen3-32B "$TEACHER_A_PORT")
+B_LOG=$(start_teacher 7 /root/Qwen3-30B-A3B "$TEACHER_B_PORT")
+wait_teacher "$TEACHER_A_IP" "$TEACHER_A_PORT" "$A_LOG"
+wait_teacher "$TEACHER_B_IP" "$TEACHER_B_PORT" "$B_LOG"
+sleep 10
+
+
+export PYTHONBUFFERED=16
+
+NVLINK_COUNT=$(nvidia-smi topo -m 2>/dev/null | grep -o 'NV[0-9][0-9]*' | wc -l)
+if [ "$NVLINK_COUNT" -gt 0 ]; then
+    HAS_NVLINK=1
+else
+    HAS_NVLINK=0
+fi
+echo "HAS_NVLINK: $HAS_NVLINK (detected $NVLINK_COUNT NVLink references)"
+
+source "/root/miles/scripts/models/qwen3-8B.sh"
+
+
+CKPT_ARGS=(
+   --hf-checkpoint /root/Qwen3-8B
+   --ref-load /root/Qwen3-8B_torch_dist
+   --load /root/Qwen3-8B_miles/
+   --save /root/Qwen3-8B_miles/
+   --save-interval 20
+)
+
+ROLLOUT_ARGS=(
+   --prompt-data /root/dapo-math-17k/dapo-math-17k.jsonl
+   --input-key prompt
+   --apply-chat-template
+   --rollout-shuffle
+   --num-rollout 300
+   --rollout-batch-size 16
+   --n-samples-per-prompt 4
+   --rollout-max-response-len 16384
+   --rollout-temperature 1
+
+   --global-batch-size 64
+   --balance-data
+)
+
+RM_ARGS=(
+   --custom-rm-path miles.rollout.on_policy_distillation.reward_func
+   --custom-reward-post-process-path miles.rollout.on_policy_distillation.post_process_rewards
+   # One 'default' group of two teachers, mixed 2:1 in probability space.
+   # Every sample is scored by both members in parallel.
+   --opd-teacher-urls
+       default=http://$TEACHER_A_IP:$TEACHER_A_PORT/generate@2.0,http://$TEACHER_B_IP:$TEACHER_B_PORT/generate@1.0
+   # Bound teacher scoring independently of the shared router timeout.
+   --opd-scoring-timeout-secs 600
+)
+
+EVAL_ARGS=(
+   # --eval-interval 20
+   # --eval-prompt-data aime ${DATA_DIR}/aime-2024/aime-2024.jsonl
+   # --n-samples-per-eval-prompt 16
+   # --eval-max-response-len 16384
+   # --eval-top-p 1
+)
+
+PERF_ARGS=(
+   --tensor-model-parallel-size 2
+   --sequence-parallel
+   --pipeline-model-parallel-size 1
+   --context-parallel-size 1
+   --expert-model-parallel-size 1
+   --expert-tensor-parallel-size 1
+
+   --recompute-granularity full
+   --recompute-method uniform
+   --recompute-num-layers 1
+
+   # --micro-batch-size 1
+   --use-dynamic-batch-size
+   --max-tokens-per-gpu 16384
+)
+
+GRPO_ARGS=(
+   --advantage-estimator grpo
+   --use-opd
+   --opd-type sglang
+   --opd-kl-coef 1.0
+   --opd-log-prob-top-k 16
+   # Ensembles require the student-side token set: every member is scored at
+   # the same per-position student top-k ids so raw probabilities mix exactly.
+   --opd-top-k-strategy only-student
+   --opd-reward-weight-mode student_p
+   # Exact (k+1)-bucket reverse KL: top-k ids + tail mass, no renormalization.
+   --opd-topk-tail-bucket
+   --use-kl-loss
+   --kl-loss-coef 0.00
+   --kl-loss-type low_var_kl
+   --entropy-coef 0.00
+)
+
+OPTIMIZER_ARGS=(
+   --optimizer adam
+   --lr 1e-6
+   --lr-decay-style constant
+   --weight-decay 0.1
+   --adam-beta1 0.9
+   --adam-beta2 0.98
+)
+
+WANDB_ARGS=(
+   #--use-wandb
+   # --wandb-project miles-dev
+   # --wandb-group qwen3-8B-opd-ensemble
+   # --wandb-key ${WANDB_KEY}
+)
+
+SGLANG_ARGS=(
+   --rollout-num-gpus-per-engine 1
+   --sglang-mem-fraction-static 0.4
+)
+
+
+MISC_ARGS=(
+   --attention-dropout 0.0
+   --hidden-dropout 0.0
+   --accumulate-allreduce-grads-in-fp32
+   --attention-softmax-in-fp32
+   --attention-backend flash
+)
+
+
+# launch the master node of ray in container
+export MASTER_ADDR=${MASTER_ADDR:-"127.0.0.1"}
+ray start --head --node-ip-address ${MASTER_ADDR} --num-gpus 8 --disable-usage-stats --dashboard-host=0.0.0.0 --dashboard-port=8265
+
+
+ray job submit --address="http://127.0.0.1:8265" \
+   --runtime-env-json='{
+     "env_vars": {
+        "PYTHONPATH": "/root/Megatron-LM/",
+        "CUDA_DEVICE_MAX_CONNECTIONS": "1"
+     }
+   }' \
+   -- python3 train.py \
+   --actor-num-nodes 1 \
+   --actor-num-gpus-per-node 2 \
+   --rollout-num-gpus 4 \
+   ${MODEL_ARGS[@]} \
+   ${CKPT_ARGS[@]} \
+   ${ROLLOUT_ARGS[@]} \
+   ${OPTIMIZER_ARGS[@]} \
+   ${GRPO_ARGS[@]} \
+   ${WANDB_ARGS[@]} \
+   ${PERF_ARGS[@]} \
+   ${EVAL_ARGS[@]} \
+   ${SGLANG_ARGS[@]} \
+   ${MISC_ARGS[@]} \
+   ${RM_ARGS[@]}
+
+
+####clear after training
+pkill -9 sglang
+sleep 3
+ray stop --force
+pkill -9 ray
+pkill -9 python
+sleep 3
+pkill -9 ray
+pkill -9 python

--- a/examples/on_policy_distillation/run-qwen3-8B-opd-multi-teacher.sh
+++ b/examples/on_policy_distillation/run-qwen3-8B-opd-multi-teacher.sh
@@ -1,0 +1,243 @@
+#!/bin/bash
+
+# Multi-teacher OPD: route each sample to a task-specific teacher.
+#
+# Student:       Qwen3-8B (2 training GPUs + 4 rollout GPUs)
+# Math teacher:  Qwen3-32B                  (GPU 6) <- "math"-tagged prompts + default
+# Code teacher:  Qwen3-Coder-30B-A3B-Instruct (GPU 7) <- "code"-tagged prompts
+#
+# Routing is per sample via sample.metadata["opd_teacher"] and --opd-teacher-urls.
+# Scoring cost is identical to single-teacher OPD: each rollout is scored once,
+# by exactly one teacher. All teachers must share the student's tokenizer
+# (scoring sends input_ids), which holds for the Qwen3 family used here.
+#
+# usage: bash examples/on_policy_distillation/run-qwen3-8B-opd-multi-teacher.sh
+
+set -ex
+
+MATH_TEACHER_IP="127.0.0.1"
+MATH_TEACHER_PORT=13141
+CODE_TEACHER_IP="127.0.0.1"
+CODE_TEACHER_PORT=13142
+
+start_teacher() {
+    local gpu=$1 model_path=$2 port=$3
+    local log_file
+    log_file="/tmp/sglang_$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 6).log"
+    CUDA_VISIBLE_DEVICES=$gpu python3 -m sglang.launch_server \
+        --model-path "$model_path" \
+        --host 0.0.0.0 \
+        --port "$port" \
+        --tp 1 \
+        --chunked-prefill-size 4096 \
+        --mem-fraction-static 0.6 \
+        > "$log_file" 2>&1 &
+    echo "$log_file"
+}
+
+wait_teacher() {
+    local ip=$1 port=$2 log_file=$3
+    until curl -sf "http://$ip:$port/health_generate" > /dev/null; do
+        echo "Waiting for teacher server at $ip:$port..."
+        tail -n 10 "$log_file"
+        sleep 5
+    done
+    curl "http://$ip:$port/get_model_info"
+    echo "Teacher server is up at $ip:$port."
+}
+
+MATH_LOG=$(start_teacher 6 /root/Qwen3-32B "$MATH_TEACHER_PORT")
+CODE_LOG=$(start_teacher 7 /root/Qwen3-Coder-30B-A3B-Instruct "$CODE_TEACHER_PORT")
+wait_teacher "$MATH_TEACHER_IP" "$MATH_TEACHER_PORT" "$MATH_LOG"
+wait_teacher "$CODE_TEACHER_IP" "$CODE_TEACHER_PORT" "$CODE_LOG"
+sleep 10
+
+
+# Build a mixed prompt set with per-sample teacher tags. Each row's metadata
+# column (--metadata-key, default "metadata") carries the teacher name under
+# the --opd-teacher-key (default "opd_teacher"):
+#   {"prompt": "...", "metadata": {"opd_teacher": "math"}}
+MIXED_DATA=/root/opd-multi-teacher/mixed.jsonl
+mkdir -p "$(dirname $MIXED_DATA)"
+python3 - << 'PYEOF'
+import json
+import os
+
+sources = [
+    ("/root/dapo-math-17k/dapo-math-17k.jsonl", "math"),
+    # Add your code-prompt dataset here, e.g.:
+    # ("/root/code-prompts/code-prompts.jsonl", "code"),
+]
+
+out_path = "/root/opd-multi-teacher/mixed.jsonl"
+n = 0
+with open(out_path, "w") as out:
+    for path, teacher in sources:
+        if not os.path.exists(path):
+            print(f"skip missing {path}")
+            continue
+        with open(path) as f:
+            for line in f:
+                row = json.loads(line)
+                row.setdefault("metadata", {})["opd_teacher"] = teacher
+                out.write(json.dumps(row, ensure_ascii=False) + "\n")
+                n += 1
+print(f"wrote {n} tagged prompts to {out_path}")
+PYEOF
+
+
+export PYTHONBUFFERED=16
+
+NVLINK_COUNT=$(nvidia-smi topo -m 2>/dev/null | grep -o 'NV[0-9][0-9]*' | wc -l)
+if [ "$NVLINK_COUNT" -gt 0 ]; then
+    HAS_NVLINK=1
+else
+    HAS_NVLINK=0
+fi
+echo "HAS_NVLINK: $HAS_NVLINK (detected $NVLINK_COUNT NVLink references)"
+
+source "/root/miles/scripts/models/qwen3-8B.sh"
+
+
+CKPT_ARGS=(
+   --hf-checkpoint /root/Qwen3-8B
+   --ref-load /root/Qwen3-8B_torch_dist
+   --load /root/Qwen3-8B_miles/
+   --save /root/Qwen3-8B_miles/
+   --save-interval 20
+)
+
+ROLLOUT_ARGS=(
+   --prompt-data $MIXED_DATA
+   --input-key prompt
+   --apply-chat-template
+   --rollout-shuffle
+   --num-rollout 300
+   --rollout-batch-size 16
+   --n-samples-per-prompt 4
+   --rollout-max-response-len 16384
+   --rollout-temperature 1
+
+   --global-batch-size 64
+   --balance-data
+)
+
+RM_ARGS=(
+   --custom-rm-path miles.rollout.on_policy_distillation.reward_func
+   --custom-reward-post-process-path miles.rollout.on_policy_distillation.post_process_rewards
+   # Per-task teacher routing; 'default' catches untagged/unknown samples.
+   --opd-teacher-urls
+       math=http://$MATH_TEACHER_IP:$MATH_TEACHER_PORT/generate
+       code=http://$CODE_TEACHER_IP:$CODE_TEACHER_PORT/generate
+       default=http://$MATH_TEACHER_IP:$MATH_TEACHER_PORT/generate
+   --opd-teacher-key opd_teacher
+)
+
+EVAL_ARGS=(
+   # --eval-interval 20
+   # --eval-prompt-data aime ${DATA_DIR}/aime-2024/aime-2024.jsonl
+   # --n-samples-per-eval-prompt 16
+   # --eval-max-response-len 16384
+   # --eval-top-p 1
+)
+
+PERF_ARGS=(
+   --tensor-model-parallel-size 2
+   --sequence-parallel
+   --pipeline-model-parallel-size 1
+   --context-parallel-size 1
+   --expert-model-parallel-size 1
+   --expert-tensor-parallel-size 1
+
+   --recompute-granularity full
+   --recompute-method uniform
+   --recompute-num-layers 1
+
+   # --micro-batch-size 1
+   --use-dynamic-batch-size
+   --max-tokens-per-gpu 16384
+)
+
+GRPO_ARGS=(
+   --advantage-estimator grpo
+   --use-opd
+   --opd-type sglang
+   --opd-kl-coef 1.0
+   --opd-log-prob-top-k 16
+   --opd-top-k-strategy only-student
+   --opd-reward-weight-mode student_p
+   --use-kl-loss
+   --kl-loss-coef 0.00
+   --kl-loss-type low_var_kl
+   --entropy-coef 0.00
+)
+
+OPTIMIZER_ARGS=(
+   --optimizer adam
+   --lr 1e-6
+   --lr-decay-style constant
+   --weight-decay 0.1
+   --adam-beta1 0.9
+   --adam-beta2 0.98
+)
+
+WANDB_ARGS=(
+   #--use-wandb
+   # --wandb-project miles-dev
+   # --wandb-group qwen3-8B-multi-teacher
+   # --wandb-key ${WANDB_KEY}
+)
+
+SGLANG_ARGS=(
+   --rollout-num-gpus-per-engine 1
+   --sglang-mem-fraction-static 0.4
+)
+
+
+MISC_ARGS=(
+   --attention-dropout 0.0
+   --hidden-dropout 0.0
+   --accumulate-allreduce-grads-in-fp32
+   --attention-softmax-in-fp32
+   --attention-backend flash
+)
+
+
+# launch the master node of ray in container
+export MASTER_ADDR=${MASTER_ADDR:-"127.0.0.1"}
+ray start --head --node-ip-address ${MASTER_ADDR} --num-gpus 8 --disable-usage-stats --dashboard-host=0.0.0.0 --dashboard-port=8265
+
+
+ray job submit --address="http://127.0.0.1:8265" \
+   --runtime-env-json='{
+     "env_vars": {
+        "PYTHONPATH": "/root/Megatron-LM/",
+        "CUDA_DEVICE_MAX_CONNECTIONS": "1"
+     }
+   }' \
+   -- python3 train.py \
+   --actor-num-nodes 1 \
+   --actor-num-gpus-per-node 2 \
+   --rollout-num-gpus 4 \
+   ${MODEL_ARGS[@]} \
+   ${CKPT_ARGS[@]} \
+   ${ROLLOUT_ARGS[@]} \
+   ${OPTIMIZER_ARGS[@]} \
+   ${GRPO_ARGS[@]} \
+   ${WANDB_ARGS[@]} \
+   ${PERF_ARGS[@]} \
+   ${EVAL_ARGS[@]} \
+   ${SGLANG_ARGS[@]} \
+   ${MISC_ARGS[@]} \
+   ${RM_ARGS[@]}
+
+
+####clear after training
+pkill -9 sglang
+sleep 3
+ray stop --force
+pkill -9 ray
+pkill -9 python
+sleep 3
+pkill -9 ray
+pkill -9 python

--- a/miles/backends/training_utils/data.py
+++ b/miles/backends/training_utils/data.py
@@ -93,6 +93,35 @@ def get_rollout_data(args: Namespace, rollout_data_ref: Box) -> RolloutBatch:
                 )
             )
         ]
+    # OPD tensors from sglang-mode rollout scoring arrive full response length and must
+    # be CP-sliced like rollout_log_probs so they line up with the CP-local student
+    # log_probs/advantages in apply_opd_kl_to_advantages. (Megatron-mode teacher
+    # logprobs are produced by the trainer's own CP-sliced forward and never pass
+    # through here.) At cp_size == 1 this is an identity slice.
+    for opd_key in ("teacher_log_probs", "opd_reverse_kl"):
+        if opd_key in rollout_data:
+            sliced_values = []
+            for i, (value, total_length, response_length) in enumerate(
+                zip(
+                    rollout_data[opd_key],
+                    rollout_data["total_lengths"],
+                    rollout_data["response_lengths"],
+                    strict=False,
+                )
+            ):
+                value = slice_log_prob_with_cp(
+                    value,
+                    total_length,
+                    response_length,
+                    args.qkv_format,
+                    rollout_data["max_seq_lens"][i] if args.qkv_format == "bshd" else None,
+                )
+                if not torch.is_tensor(value):
+                    value = torch.tensor(value, dtype=torch.float32)
+                # On GPU like rollout_log_probs: downstream CP collectives (multimodal
+                # re-slicing) run on the NCCL group and need device tensors.
+                sliced_values.append(value.to(device=torch.cuda.current_device()))
+            rollout_data[opd_key] = sliced_values
     if "rollout_routed_experts" in rollout_data:
         rollout_data["rollout_routed_experts"] = [torch.from_numpy(r) for r in rollout_data["rollout_routed_experts"]]
     if "rollout_indexer_topk" in rollout_data:

--- a/miles/backends/training_utils/mm_data.py
+++ b/miles/backends/training_utils/mm_data.py
@@ -171,7 +171,7 @@ def expand_multimodal_rollout_data_in_place(
         parallel_state = get_parallel_state()
         cp_size = parallel_state.cp.size
         if cp_size > 1 and qkv_format == "thd":
-            for key in ("rollout_log_probs", "teacher_log_probs"):
+            for key in ("rollout_log_probs", "teacher_log_probs", "opd_reverse_kl"):
                 values = rollout_data.get(key)
                 if not values:
                     continue

--- a/miles/ray/rollout/train_data_conversion.py
+++ b/miles/ray/rollout/train_data_conversion.py
@@ -82,11 +82,18 @@ def convert_samples_to_train_data(
     if any(sample.weight_versions for sample in samples):
         train_data["weight_versions"] = [sample.weight_versions for sample in samples]
 
-    if samples[0].teacher_log_probs is not None:
-        train_data["teacher_log_probs"] = [sample.teacher_log_probs for sample in samples]
-
-    if samples[0].opd_reverse_kl is not None:
-        train_data["opd_reverse_kl"] = [sample.opd_reverse_kl for sample in samples]
+    for opd_key in ("teacher_log_probs", "opd_reverse_kl"):
+        values = [getattr(sample, opd_key) for sample in samples]
+        num_present = sum(value is not None for value in values)
+        if num_present == 0:
+            continue
+        if num_present != len(samples):
+            missing = [i for i, value in enumerate(values) if value is None]
+            raise ValueError(
+                f"{opd_key} is set on {num_present}/{len(samples)} samples (missing at indices "
+                f"{missing[:5]}{'...' if len(missing) > 5 else ''}); teacher scoring must cover the whole batch."
+            )
+        train_data[opd_key] = values
 
     x = metadata.get("dynamic_global_batch_size")
     assert args.use_dynamic_global_batch_size == (x is not None)

--- a/miles/rollout/on_policy_distillation.py
+++ b/miles/rollout/on_policy_distillation.py
@@ -19,6 +19,60 @@ TEACHER_TOP_STRATEGIES = TOP_K_STRATEGIES - {"only-student"}
 TEACHER_ON_STUDENT_STRATEGIES = {"only-student", "union", "xor"}
 STUDENT_ON_TEACHER_STRATEGIES = {"only-teacher", "union", "xor"}
 
+# Reserved teacher name in --opd-teacher-urls used as the fallback route.
+DEFAULT_TEACHER_NAME = "default"
+
+
+def parse_teacher_urls(values: Iterable[str] | None) -> dict[str, str]:
+    """Parse ``NAME=URL`` entries from ``--opd-teacher-urls`` into a routing map.
+
+    Splits on the first ``=`` only, so URLs containing ``=`` (e.g. query
+    strings) survive intact. Raises on malformed entries and duplicate names
+    so misconfiguration fails at startup, not mid-rollout.
+    """
+    url_map: dict[str, str] = {}
+    for value in values or []:
+        name, sep, url = value.partition("=")
+        name, url = name.strip(), url.strip()
+        if not sep or not name or not url:
+            raise ValueError(f"Invalid --opd-teacher-urls entry {value!r}; expected NAME=URL.")
+        if name in url_map:
+            raise ValueError(f"Duplicate teacher name {name!r} in --opd-teacher-urls.")
+        url_map[name] = url
+    return url_map
+
+
+def _teacher_url_for_sample(args: Namespace, sample: Sample) -> str:
+    """Resolve the teacher scoring endpoint for one sample.
+
+    Without ``--opd-teacher-urls`` every sample goes to ``--rm-url`` (the
+    original single-teacher path, unchanged). With it, the sample is routed by
+    the teacher name in ``sample.metadata[--opd-teacher-key]``; samples whose
+    name is missing or unknown fall back to the reserved ``default`` entry,
+    and raise if no default is configured — silently distilling from the
+    wrong teacher is worse than failing the rollout.
+    """
+    url_map = parse_teacher_urls(getattr(args, "opd_teacher_urls", None))
+    if not url_map:
+        return args.rm_url
+
+    metadata = sample.metadata if isinstance(sample.metadata, dict) else {}
+    key = getattr(args, "opd_teacher_key", "opd_teacher")
+    name = metadata.get(key)
+    if name is not None:
+        url = url_map.get(str(name))
+        if url is not None:
+            return url
+        if DEFAULT_TEACHER_NAME in url_map:
+            return url_map[DEFAULT_TEACHER_NAME]
+        raise ValueError(
+            f"Sample metadata[{key!r}]={name!r} matches no --opd-teacher-urls name "
+            f"(known: {sorted(url_map)}) and no 'default' entry is configured."
+        )
+    if DEFAULT_TEACHER_NAME in url_map:
+        return url_map[DEFAULT_TEACHER_NAME]
+    raise ValueError(f"Sample metadata is missing teacher key {key!r} and --opd-teacher-urls has no 'default' entry.")
+
 
 def _get_opd_top_k(args: Namespace) -> int:
     return max(0, int(getattr(args, "opd_log_prob_top_k", 0) or 0))
@@ -300,8 +354,11 @@ async def reward_func(args: Namespace, sample: Sample, **kwargs: Any) -> dict[st
     # Optional per-request timeout so a hung teacher/student scoring call cannot stall
     # the whole rollout (no-op when unset).
     request_timeout = getattr(args, "sglang_router_request_timeout_secs", None)
+    # Multi-teacher routing: pick this sample's teacher endpoint (falls back to
+    # --rm-url when --opd-teacher-urls is unset).
+    teacher_url = _teacher_url_for_sample(args, sample)
     if top_k == 0:
-        return await _post_json(args.rm_url, _score_payload(sample.tokens), timeout_secs=request_timeout)
+        return await _post_json(teacher_url, _score_payload(sample.tokens), timeout_secs=request_timeout)
 
     strategy = _get_top_k_strategy(args)
     # Per-position scoring requires a patched teacher/student server that understands
@@ -325,7 +382,7 @@ async def reward_func(args: Namespace, sample: Sample, **kwargs: Any) -> dict[st
         teacher_payload = _score_payload(sample.tokens, top_k=teacher_top_k, token_ids=teacher_token_ids)
     else:
         teacher_payload = _score_payload(sample.tokens, top_k=teacher_top_k)
-    teacher_response = await _post_json(args.rm_url, teacher_payload, timeout_secs=request_timeout)
+    teacher_response = await _post_json(teacher_url, teacher_payload, timeout_secs=request_timeout)
 
     reward_payload = {"teacher": teacher_response}
     if strategy in STUDENT_ON_TEACHER_STRATEGIES:

--- a/miles/rollout/on_policy_distillation.py
+++ b/miles/rollout/on_policy_distillation.py
@@ -1,4 +1,6 @@
+import asyncio
 import math
+import random
 from argparse import Namespace
 from collections.abc import Iterable
 from typing import Any
@@ -10,6 +12,8 @@ from miles.utils.types import Sample
 
 TopLogprobs = list[list[Any]]
 LogprobMaps = list[dict[int, float]]
+# One teacher endpoint inside a (possibly singleton) ensemble group: (url, mixture weight).
+TeacherTarget = tuple[str, float]
 
 TOP_K_STRATEGIES = {"only-student", "only-teacher", "intersection", "union", "xor"}
 REWARD_WEIGHT_MODES = {"student_p", "teacher_p", "none"}
@@ -21,48 +25,101 @@ STUDENT_ON_TEACHER_STRATEGIES = {"only-teacher", "union", "xor"}
 
 # Reserved teacher name in --opd-teacher-urls used as the fallback route.
 DEFAULT_TEACHER_NAME = "default"
+# Floor for the teacher's tail probability mass in --opd-topk-tail-bucket mode. Scoring
+# logprobs arrive as JSON doubles, so 1 - sum(p) only goes non-positive through genuine
+# float64 rounding; the floor (log ~= -27.6) is a last-resort guard, not a working range.
+TAIL_PROB_FLOOR = 1e-12
+# Bounded retry for teacher/student scoring requests: one retry on transient failures
+# (timeout, connection error, HTTP 5xx) with jitter. 4xx responses never retry.
+SCORING_MAX_RETRIES = 1
 
 
-def parse_teacher_urls(values: Iterable[str] | None) -> dict[str, str]:
-    """Parse ``NAME=URL`` entries from ``--opd-teacher-urls`` into a routing map.
+def _parse_teacher_target(part: str, entry: str) -> TeacherTarget:
+    """Parse one ``URL[@WEIGHT]`` group member.
 
-    Splits on the first ``=`` only, so URLs containing ``=`` (e.g. query
-    strings) survive intact. Raises on malformed entries and duplicate names
+    Splits on the last ``@`` so userinfo URLs (``user:pass@host``) survive; a
+    suffix that does not parse as a float is treated as part of the URL.
+    """
+    url, sep, weight_str = part.rpartition("@")
+    if sep:
+        try:
+            weight = float(weight_str)
+        except ValueError:
+            return part, 1.0
+        if not math.isfinite(weight) or weight <= 0.0:
+            raise ValueError(f"Teacher weight must be a positive finite number in --opd-teacher-urls entry {entry!r}.")
+        if not url.strip():
+            raise ValueError(f"Empty teacher URL in --opd-teacher-urls entry {entry!r}.")
+        return url.strip(), weight
+    return part, 1.0
+
+
+def parse_teacher_urls(values: Iterable[str] | None) -> dict[str, list[TeacherTarget]]:
+    """Parse ``NAME=URL[@WEIGHT][,URL[@WEIGHT]...]`` entries from ``--opd-teacher-urls``.
+
+    Each name maps to a group of one or more teacher endpoints. A group with a
+    single URL is plain routing (PR 3/N behavior, unchanged); a group with
+    several URLs is an ensemble — every member scores the sample and the
+    targets are combined as a weighted mixture in probability space. Weights
+    default to 1.0 (uniform mixture).
+
+    Splits ``NAME=`` on the first ``=`` only, so URLs containing ``=`` (e.g.
+    query strings) survive intact; group members are comma-separated. Raises
+    on malformed entries, duplicate names, and duplicate URLs within a group
     so misconfiguration fails at startup, not mid-rollout.
     """
-    url_map: dict[str, str] = {}
+    url_map: dict[str, list[TeacherTarget]] = {}
     for value in values or []:
-        name, sep, url = value.partition("=")
-        name, url = name.strip(), url.strip()
-        if not sep or not name or not url:
-            raise ValueError(f"Invalid --opd-teacher-urls entry {value!r}; expected NAME=URL.")
+        name, sep, spec = value.partition("=")
+        name, spec = name.strip(), spec.strip()
+        if not sep or not name or not spec:
+            raise ValueError(f"Invalid --opd-teacher-urls entry {value!r}; expected NAME=URL[@WEIGHT][,...].")
         if name in url_map:
             raise ValueError(f"Duplicate teacher name {name!r} in --opd-teacher-urls.")
-        url_map[name] = url
+        targets = []
+        for part in spec.split(","):
+            part = part.strip()
+            if not part:
+                raise ValueError(f"Empty teacher URL in --opd-teacher-urls entry {value!r}.")
+            target = _parse_teacher_target(part, value)
+            if not target[0].startswith(("http://", "https://")):
+                # Catches comma-split fragments of a single URL (commas separate group
+                # members and cannot appear inside member URLs) at startup instead of
+                # mid-rollout as an invalid scoring endpoint.
+                raise ValueError(
+                    f"Teacher URL {target[0]!r} in --opd-teacher-urls entry {value!r} must start with "
+                    "http:// or https://. Note: ',' separates ensemble group members and a trailing "
+                    "'@<float>' is parsed as the member's mixture weight."
+                )
+            targets.append(target)
+        if len({url for url, _ in targets}) != len(targets):
+            raise ValueError(f"Duplicate URL within teacher group {name!r} in --opd-teacher-urls.")
+        url_map[name] = targets
     return url_map
 
 
-def _teacher_url_for_sample(args: Namespace, sample: Sample) -> str:
-    """Resolve the teacher scoring endpoint for one sample.
+def _teacher_targets_for_sample(args: Namespace, sample: Sample) -> list[TeacherTarget]:
+    """Resolve the teacher scoring endpoint group for one sample.
 
     Without ``--opd-teacher-urls`` every sample goes to ``--rm-url`` (the
     original single-teacher path, unchanged). With it, the sample is routed by
     the teacher name in ``sample.metadata[--opd-teacher-key]``; samples whose
     name is missing or unknown fall back to the reserved ``default`` entry,
     and raise if no default is configured — silently distilling from the
-    wrong teacher is worse than failing the rollout.
+    wrong teacher is worse than failing the rollout. The resolved group has
+    one member for routing and several for an ensemble.
     """
     url_map = parse_teacher_urls(getattr(args, "opd_teacher_urls", None))
     if not url_map:
-        return args.rm_url
+        return [(args.rm_url, 1.0)]
 
     metadata = sample.metadata if isinstance(sample.metadata, dict) else {}
     key = getattr(args, "opd_teacher_key", "opd_teacher")
     name = metadata.get(key)
     if name is not None:
-        url = url_map.get(str(name))
-        if url is not None:
-            return url
+        targets = url_map.get(str(name))
+        if targets is not None:
+            return targets
         if DEFAULT_TEACHER_NAME in url_map:
             return url_map[DEFAULT_TEACHER_NAME]
         raise ValueError(
@@ -139,12 +196,90 @@ def _student_score_url(args: Namespace) -> str:
     return f"http://{args.sglang_router_ip}:{args.sglang_router_port}/generate"
 
 
-async def _post_json(url: str, payload: dict[str, Any], timeout_secs: int | float | None = None) -> dict[str, Any]:
-    timeout = aiohttp.ClientTimeout(total=timeout_secs)
+def _scoring_timeout(args: Namespace) -> int | float | None:
+    """Per-request timeout for teacher/student scoring.
+
+    ``--opd-scoring-timeout-secs`` when set; otherwise falls back to the shared
+    router request timeout. Kept separate because teachers (often much larger
+    than the student) need a different bound than generation requests.
+    """
+    timeout = getattr(args, "opd_scoring_timeout_secs", None)
+    if timeout is not None:
+        return timeout
+    return getattr(args, "sglang_router_request_timeout_secs", None)
+
+
+def _is_retryable_scoring_error(exc: BaseException) -> bool:
+    if isinstance(exc, aiohttp.ClientResponseError):
+        return exc.status >= 500
+    return isinstance(exc, (aiohttp.ClientError, asyncio.TimeoutError))
+
+
+async def _post_json_once(url: str, payload: dict[str, Any], timeout: aiohttp.ClientTimeout) -> dict[str, Any]:
     async with aiohttp.ClientSession(timeout=timeout) as session:
         async with session.post(url, json=payload) as resp:
             resp.raise_for_status()
             return await resp.json()
+
+
+async def _post_json(url: str, payload: dict[str, Any], timeout_secs: int | float | None = None) -> dict[str, Any]:
+    timeout = aiohttp.ClientTimeout(total=timeout_secs)
+    for attempt in range(SCORING_MAX_RETRIES + 1):
+        try:
+            return await _post_json_once(url, payload, timeout)
+        except BaseException as exc:
+            if attempt >= SCORING_MAX_RETRIES or not _is_retryable_scoring_error(exc):
+                raise
+            await asyncio.sleep(min(2**attempt, 4) * (0.5 + 0.5 * random.random()))
+    raise AssertionError("unreachable")
+
+
+def _mixture_log_probs(per_teacher: list[torch.Tensor], weights: list[float]) -> torch.Tensor:
+    """Combine per-teacher logprob tensors into the weighted-mixture logprob.
+
+    log p_bar = log(sum_m w_m * p_m / sum_m w_m), computed stably in log space
+    (float64) so the result is the log-probability of the mixture distribution
+    — not a mean of logprobs, which would be an unnormalized geometric mean.
+    """
+    stacked = torch.stack([t.double() for t in per_teacher])
+    log_w = torch.tensor(weights, dtype=torch.float64).log()
+    log_w = log_w.view(-1, *([1] * (stacked.dim() - 1)))
+    return (torch.logsumexp(stacked + log_w, dim=0) - math.log(sum(weights))).float()
+
+
+def _mixture_logprob_maps(maps_per_teacher: list[LogprobMaps], weights: list[float]) -> LogprobMaps:
+    """Mix per-position ``{token_id: logprob}`` maps across teachers.
+
+    All teachers are scored at the same requested token ids per position, so
+    every map must contain every id — a missing id means a malformed teacher
+    response and raises rather than silently treating the probability as 0.
+    """
+    log_total_w = math.log(sum(weights))
+    log_weights = [math.log(w) for w in weights]
+    mixed: LogprobMaps = []
+    for position_maps in zip(*maps_per_teacher, strict=True):
+        ids = set().union(*(m.keys() for m in position_maps))
+        out: dict[int, float] = {}
+        for token_id in ids:
+            terms = []
+            for log_w, teacher_map in zip(log_weights, position_maps, strict=True):
+                if token_id not in teacher_map:
+                    raise ValueError(
+                        f"Ensemble teacher response is missing logprob for token id {token_id}; "
+                        "all group members must be scored at the same token ids."
+                    )
+                terms.append(log_w + teacher_map[token_id])
+            max_term = max(terms)
+            out[token_id] = max_term + math.log(sum(math.exp(t - max_term) for t in terms)) - log_total_w
+        mixed.append(out)
+    return mixed
+
+
+def _teacher_responses_from_payload(reward_payload: dict[str, Any]) -> tuple[list[dict[str, Any]], list[float]]:
+    """Normalize single-teacher and ensemble reward payloads to (responses, weights)."""
+    if "teachers" in reward_payload:
+        return reward_payload["teachers"], reward_payload["teacher_weights"]
+    return [reward_payload["teacher"]], [1.0]
 
 
 def _top_entry_token_id(entry: list[Any]) -> int:
@@ -278,6 +413,30 @@ def _reward_weights(
     return [v / denom for v in exp_vals]
 
 
+def _tail_bucket_reverse_kl(student_logps: list[float], teacher_logps: list[float]) -> float:
+    """Exact reverse KL over the (k+1)-bucket partition: selected ids + one tail bucket.
+
+    Both logprob lists are exact full-softmax logprobs at the same token ids, so
+    {p(v) for v in S} + tail with tail = 1 - sum_v p(v) is a proper distribution
+    and KL = sum_v p_s(v)(s_v - t_v) + tail_s * (log tail_s - log tail_t) needs
+    no renormalization — the truncated estimate stays sensitive to mass the
+    student pushes outside S. Python floats keep the math in float64; the tail
+    uses log1p for accuracy and a student tail rounded to <= 0 contributes 0
+    (the x*log(x) -> 0 limit).
+    """
+    student_probs = [math.exp(logp) for logp in student_logps]
+    kl = sum(
+        p * (s_logp - t_logp) for p, s_logp, t_logp in zip(student_probs, student_logps, teacher_logps, strict=True)
+    )
+    student_mass = sum(student_probs)
+    if student_mass >= 1.0:
+        return kl
+    teacher_mass = sum(math.exp(logp) for logp in teacher_logps)
+    log_tail_s = math.log1p(-student_mass)
+    log_tail_t = math.log1p(-min(teacher_mass, 1.0 - TAIL_PROB_FLOOR))
+    return kl + (1.0 - student_mass) * (log_tail_s - log_tail_t)
+
+
 def _compute_topk_reverse_kl(
     args: Namespace,
     sample: Sample,
@@ -289,6 +448,15 @@ def _compute_topk_reverse_kl(
 
     strategy = _get_top_k_strategy(args)
     weight_mode = _get_reward_weight_mode(args)
+    tail_bucket = bool(getattr(args, "opd_topk_tail_bucket", False))
+    if tail_bucket and strategy not in ("only-student", "intersection"):
+        # The k+1 partition is only exact when all student logprobs come from one
+        # softmax; only-teacher/union/xor mix the rollout harvest with a
+        # separate rescoring pass (also validated at startup).
+        raise ValueError(
+            "--opd-topk-tail-bucket requires --opd-top-k-strategy only-student "
+            f"or intersection, got {strategy!r}."
+        )
 
     student_top_maps = (
         [_top_entries_to_map(entries) for entries in _student_top_logprobs(sample, response_length)]
@@ -296,17 +464,34 @@ def _compute_topk_reverse_kl(
         else [{} for _ in range(response_length)]
     )
 
-    teacher_response = reward_payload["teacher"]
-    teacher_top_maps = (
-        _input_logprob_maps(teacher_response, "input_top_logprobs", response_length)
-        if strategy in TEACHER_TOP_STRATEGIES
-        else [{} for _ in range(response_length)]
-    )
-    teacher_on_student_maps = (
-        _input_logprob_maps(teacher_response, "input_token_ids_logprobs", response_length)
-        if strategy in TEACHER_ON_STUDENT_STRATEGIES
-        else [{} for _ in range(response_length)]
-    )
+    teacher_responses, teacher_weights = _teacher_responses_from_payload(reward_payload)
+    if len(teacher_responses) == 1:
+        teacher_response = teacher_responses[0]
+        teacher_top_maps = (
+            _input_logprob_maps(teacher_response, "input_top_logprobs", response_length)
+            if strategy in TEACHER_TOP_STRATEGIES
+            else [{} for _ in range(response_length)]
+        )
+        teacher_on_student_maps = (
+            _input_logprob_maps(teacher_response, "input_token_ids_logprobs", response_length)
+            if strategy in TEACHER_ON_STUDENT_STRATEGIES
+            else [{} for _ in range(response_length)]
+        )
+    else:
+        # Ensemble: every group member was scored at the student's per-position
+        # top-k ids (strategy validated to only-student at startup); mix raw teacher
+        # probabilities per token id BEFORE any weighting — a mixture of
+        # renormalized truncations is not the truncation of the mixture.
+        if strategy != "only-student":
+            raise ValueError(f"Teacher ensembles require --opd-top-k-strategy only-student, got {strategy!r}.")
+        teacher_top_maps = [{} for _ in range(response_length)]
+        teacher_on_student_maps = _mixture_logprob_maps(
+            [
+                _input_logprob_maps(response, "input_token_ids_logprobs", response_length)
+                for response in teacher_responses
+            ],
+            teacher_weights,
+        )
     student_on_teacher_maps = (
         _input_logprob_maps(reward_payload["student_on_teacher"], "input_token_ids_logprobs", response_length)
         if strategy in STUDENT_ON_TEACHER_STRATEGIES
@@ -340,25 +525,44 @@ def _compute_topk_reverse_kl(
                 )
             )
 
-        weights = _reward_weights(student_logps, teacher_logps, weight_mode, normalize=normalize_weights)
-        reverse_kl = sum(
-            w * (s_logp - t_logp) for w, s_logp, t_logp in zip(weights, student_logps, teacher_logps, strict=True)
-        )
+        if tail_bucket:
+            reverse_kl = _tail_bucket_reverse_kl(student_logps, teacher_logps)
+        else:
+            weights = _reward_weights(student_logps, teacher_logps, weight_mode, normalize=normalize_weights)
+            reverse_kl = sum(
+                w * (s_logp - t_logp) for w, s_logp, t_logp in zip(weights, student_logps, teacher_logps, strict=True)
+            )
         reverse_kls.append(reverse_kl)
 
     return torch.tensor(reverse_kls, dtype=torch.float32)
 
 
-async def reward_func(args: Namespace, sample: Sample, **kwargs: Any) -> dict[str, Any]:
+async def _post_teacher_group(
+    targets: list[TeacherTarget], payload: dict[str, Any], timeout_secs: int | float | None
+) -> dict[str, Any]:
+    """Score one payload against a teacher group.
+
+    A singleton group returns the raw response (routing/single-teacher path,
+    unchanged shape). An ensemble group fans the same payload out to every
+    member in parallel — wall clock is max(teacher latencies), not the sum —
+    and returns the responses with their mixture weights.
+    """
+    responses = await asyncio.gather(*[_post_json(url, payload, timeout_secs=timeout_secs) for url, _ in targets])
+    if len(responses) == 1:
+        return responses[0]
+    return {"teachers": list(responses), "teacher_weights": [weight for _, weight in targets]}
+
+
+async def reward_func(args, sample, **kwargs):
     top_k = _get_opd_top_k(args)
     # Optional per-request timeout so a hung teacher/student scoring call cannot stall
     # the whole rollout (no-op when unset).
-    request_timeout = getattr(args, "sglang_router_request_timeout_secs", None)
-    # Multi-teacher routing: pick this sample's teacher endpoint (falls back to
+    request_timeout = _scoring_timeout(args)
+    # Multi-teacher routing/ensemble: pick this sample's teacher group (falls back to
     # --rm-url when --opd-teacher-urls is unset).
-    teacher_url = _teacher_url_for_sample(args, sample)
+    teacher_targets = _teacher_targets_for_sample(args, sample)
     if top_k == 0:
-        return await _post_json(teacher_url, _score_payload(sample.tokens), timeout_secs=request_timeout)
+        return await _post_teacher_group(teacher_targets, _score_payload(sample.tokens), request_timeout)
 
     strategy = _get_top_k_strategy(args)
     # Per-position scoring requires a patched teacher/student server that understands
@@ -382,11 +586,15 @@ async def reward_func(args: Namespace, sample: Sample, **kwargs: Any) -> dict[st
         teacher_payload = _score_payload(sample.tokens, top_k=teacher_top_k, token_ids=teacher_token_ids)
     else:
         teacher_payload = _score_payload(sample.tokens, top_k=teacher_top_k)
-    teacher_response = await _post_json(teacher_url, teacher_payload, timeout_secs=request_timeout)
+    group_response = await _post_teacher_group(teacher_targets, teacher_payload, request_timeout)
 
-    reward_payload = {"teacher": teacher_response}
+    reward_payload = group_response if "teachers" in group_response else {"teacher": group_response}
     if strategy in STUDENT_ON_TEACHER_STRATEGIES:
-        teacher_top = _trim_input_field(teacher_response["meta_info"], "input_top_logprobs", sample.response_length)
+        if "teachers" in reward_payload:
+            raise ValueError(f"Teacher ensembles require --opd-top-k-strategy only-student, got {strategy!r}.")
+        teacher_top = _trim_input_field(
+            reward_payload["teacher"]["meta_info"], "input_top_logprobs", sample.response_length
+        )
         if per_position:
             student_payload = _score_payload(
                 sample.tokens, token_ids_positions=_per_position_ids(teacher_top, prompt_len)
@@ -416,11 +624,20 @@ def post_process_rewards(args: Namespace, samples: list[Sample], **kwargs: Any) 
     if _get_opd_top_k(args) > 0:
         for sample, reward in zip(samples, raw_rewards, strict=True):
             sample.opd_reverse_kl = _compute_topk_reverse_kl(args, sample, reward)
+            # The harvested per-position top-logprob lists are large (O(R*k) Python
+            # objects); once the KL is computed they only bloat Ray transfers.
+            sample.metadata.pop("opd_student_top_logprobs", None)
         scalar_rewards = [0.0] * len(samples)
         return scalar_rewards, scalar_rewards
 
+    def _sampled_log_probs(reward: dict[str, Any], response_length: int) -> torch.Tensor:
+        if isinstance(reward, dict) and "teachers" in reward:
+            per_teacher = [_teacher_sampled_log_probs(response, response_length) for response in reward["teachers"]]
+            return _mixture_log_probs(per_teacher, reward["teacher_weights"])
+        return _teacher_sampled_log_probs(reward, response_length)
+
     teacher_log_probs = [
-        _teacher_sampled_log_probs(reward, response_length)
+        _sampled_log_probs(reward, response_length)
         for reward, response_length in zip(raw_rewards, response_lengths, strict=True)
     ]
 

--- a/miles/rollout/on_policy_distillation.py
+++ b/miles/rollout/on_policy_distillation.py
@@ -38,7 +38,12 @@ def _get_reward_weight_mode(args: Namespace) -> str:
     return mode
 
 
-def _score_payload(input_ids: list[int], top_k: int = 0, token_ids: list[int] | None = None) -> dict[str, Any]:
+def _score_payload(
+    input_ids: list[int],
+    top_k: int = 0,
+    token_ids: list[int] | None = None,
+    token_ids_positions: list[list[int]] | None = None,
+) -> dict[str, Any]:
     payload = {
         "input_ids": input_ids,
         "sampling_params": {
@@ -51,9 +56,29 @@ def _score_payload(input_ids: list[int], top_k: int = 0, token_ids: list[int] | 
     }
     if top_k > 0:
         payload["top_logprobs_num"] = top_k
-    if token_ids:
+    if token_ids_positions is not None:
+        # Per-position scoring (patched sglang): one id-list per input position, so the
+        # teacher returns each position's own ids (sparse) instead of the global union
+        # broadcast to every position (dense O(R^2)). Aligned to logprob_start_len=0.
+        payload["token_ids_logprob_positions"] = token_ids_positions
+    elif token_ids:
         payload["token_ids_logprob"] = token_ids
     return payload
+
+
+def _per_position_ids(top_logprobs: TopLogprobs, prompt_len: int) -> list[list[int]]:
+    """Build one token-id list per scored input position for ``token_ids_logprob_positions``.
+
+    ``top_logprobs`` is per response position (length == response_length). Prompt
+    positions are padded with empty id-lists so the layout aligns with
+    ``logprob_start_len=0`` and the existing ``_trim_input_field`` extraction
+    (``values[1:][-response_length:]``) — i.e. response position r lands at index
+    ``prompt_len + r``.
+    """
+    per_pos: list[list[int]] = [[] for _ in range(prompt_len)]
+    for entries in top_logprobs:
+        per_pos.append([_top_entry_token_id(e) for e in (entries or []) if e is not None])
+    return per_pos
 
 
 def _student_score_url(args: Namespace) -> str:
@@ -275,27 +300,39 @@ async def reward_func(args: Namespace, sample: Sample, **kwargs: Any) -> dict[st
         return await _post_json(args.rm_url, _score_payload(sample.tokens))
 
     strategy = _get_top_k_strategy(args)
+    # Per-position scoring requires a patched teacher/student server that understands
+    # token_ids_logprob_positions; default off so an unpatched server keeps working.
+    per_position = getattr(args, "opd_topk_per_position", False)
+    prompt_len = len(sample.tokens) - sample.response_length
 
-    teacher_token_ids = None
+    teacher_top_k = top_k if strategy in TEACHER_TOP_STRATEGIES else 0
     if strategy in TEACHER_ON_STUDENT_STRATEGIES:
         student_top = _student_top_logprobs(sample, sample.response_length)
         teacher_token_ids = _unique_ids(student_top)
+    else:
+        student_top = None
+        teacher_token_ids = None
 
-    teacher_payload = _score_payload(
-        sample.tokens,
-        top_k=top_k if strategy in TEACHER_TOP_STRATEGIES else 0,
-        token_ids=teacher_token_ids,
-    )
+    if student_top is not None and per_position:
+        teacher_payload = _score_payload(
+            sample.tokens, top_k=teacher_top_k, token_ids_positions=_per_position_ids(student_top, prompt_len)
+        )
+    elif teacher_token_ids is not None:
+        teacher_payload = _score_payload(sample.tokens, top_k=teacher_top_k, token_ids=teacher_token_ids)
+    else:
+        teacher_payload = _score_payload(sample.tokens, top_k=teacher_top_k)
     teacher_response = await _post_json(args.rm_url, teacher_payload)
 
     reward_payload = {"teacher": teacher_response}
     if strategy in STUDENT_ON_TEACHER_STRATEGIES:
         teacher_top = _trim_input_field(teacher_response["meta_info"], "input_top_logprobs", sample.response_length)
-        student_token_ids = _unique_ids(teacher_top)
-        reward_payload["student_on_teacher"] = await _post_json(
-            _student_score_url(args),
-            _score_payload(sample.tokens, token_ids=student_token_ids),
-        )
+        if per_position:
+            student_payload = _score_payload(
+                sample.tokens, token_ids_positions=_per_position_ids(teacher_top, prompt_len)
+            )
+        else:
+            student_payload = _score_payload(sample.tokens, token_ids=_unique_ids(teacher_top))
+        reward_payload["student_on_teacher"] = await _post_json(_student_score_url(args), student_payload)
 
     return reward_payload
 

--- a/miles/rollout/on_policy_distillation.py
+++ b/miles/rollout/on_policy_distillation.py
@@ -85,8 +85,9 @@ def _student_score_url(args: Namespace) -> str:
     return f"http://{args.sglang_router_ip}:{args.sglang_router_port}/generate"
 
 
-async def _post_json(url: str, payload: dict[str, Any]) -> dict[str, Any]:
-    async with aiohttp.ClientSession() as session:
+async def _post_json(url: str, payload: dict[str, Any], timeout_secs: int | float | None = None) -> dict[str, Any]:
+    timeout = aiohttp.ClientTimeout(total=timeout_secs)
+    async with aiohttp.ClientSession(timeout=timeout) as session:
         async with session.post(url, json=payload) as resp:
             resp.raise_for_status()
             return await resp.json()
@@ -296,8 +297,11 @@ def _compute_topk_reverse_kl(
 
 async def reward_func(args: Namespace, sample: Sample, **kwargs: Any) -> dict[str, Any]:
     top_k = _get_opd_top_k(args)
+    # Optional per-request timeout so a hung teacher/student scoring call cannot stall
+    # the whole rollout (no-op when unset).
+    request_timeout = getattr(args, "sglang_router_request_timeout_secs", None)
     if top_k == 0:
-        return await _post_json(args.rm_url, _score_payload(sample.tokens))
+        return await _post_json(args.rm_url, _score_payload(sample.tokens), timeout_secs=request_timeout)
 
     strategy = _get_top_k_strategy(args)
     # Per-position scoring requires a patched teacher/student server that understands
@@ -321,7 +325,7 @@ async def reward_func(args: Namespace, sample: Sample, **kwargs: Any) -> dict[st
         teacher_payload = _score_payload(sample.tokens, top_k=teacher_top_k, token_ids=teacher_token_ids)
     else:
         teacher_payload = _score_payload(sample.tokens, top_k=teacher_top_k)
-    teacher_response = await _post_json(args.rm_url, teacher_payload)
+    teacher_response = await _post_json(args.rm_url, teacher_payload, timeout_secs=request_timeout)
 
     reward_payload = {"teacher": teacher_response}
     if strategy in STUDENT_ON_TEACHER_STRATEGIES:
@@ -332,7 +336,9 @@ async def reward_func(args: Namespace, sample: Sample, **kwargs: Any) -> dict[st
             )
         else:
             student_payload = _score_payload(sample.tokens, token_ids=_unique_ids(teacher_top))
-        reward_payload["student_on_teacher"] = await _post_json(_student_score_url(args), student_payload)
+        reward_payload["student_on_teacher"] = await _post_json(
+            _student_score_url(args), student_payload, timeout_secs=request_timeout
+        )
 
     return reward_payload
 

--- a/miles/rollout/sglang_rollout.py
+++ b/miles/rollout/sglang_rollout.py
@@ -40,6 +40,51 @@ __all__ = ["generate_rollout", "get_model_url"]
 logger = logging.getLogger(__name__)
 
 
+def _len_or_value(value: Any) -> Any:
+    if isinstance(value, (dict, list, tuple, str)):
+        return {"type": type(value).__name__, "len": len(value)}
+    return value
+
+
+def _sample_text_preview(sample: Sample, max_chars: int = 512) -> str:
+    text = (str(sample.prompt) + sample.response).replace("\n", "\\n")
+    if len(text) <= max_chars:
+        return text
+    return f"{text[:max_chars]}...<truncated chars={len(text) - max_chars}>"
+
+
+def _reward_log_summary(reward: Any) -> Any:
+    """Summarize a reward (which for OPD scoring can be a large nested dict of logprobs)
+    into shapes/lengths instead of dumping the whole thing into the log."""
+    if not isinstance(reward, dict):
+        return _len_or_value(reward)
+
+    summary: dict[str, Any] = {}
+    for key, value in reward.items():
+        if not isinstance(value, dict):
+            summary[key] = _len_or_value(value)
+            continue
+
+        entry: dict[str, Any] = {"keys": list(value.keys())}
+        meta_info = value.get("meta_info")
+        if isinstance(meta_info, dict):
+            entry["meta_info"] = {
+                meta_key: _len_or_value(meta_info[meta_key])
+                for meta_key in (
+                    "id",
+                    "finish_reason",
+                    "prompt_tokens",
+                    "weight_version",
+                    "input_token_logprobs",
+                    "input_token_ids_logprobs",
+                    "input_top_logprobs",
+                )
+                if meta_key in meta_info
+            }
+        summary[key] = entry
+    return summary
+
+
 def get_model_url(args: Namespace, model_name: str, endpoint: str = "/generate") -> str:
     """Return the router URL for a named model.
 
@@ -433,7 +478,10 @@ async def generate_rollout_async(
             if do_print:
                 sample = group[0][0] if isinstance(group[0], list) else group[0]
                 logger.info(
-                    f"First rollout sample: {[str(sample.prompt) + sample.response]}, label: {str(sample.label)[:100]}, reward: {sample.reward}",
+                    "First rollout sample: text_preview=%s, label=%s, reward_summary=%s",
+                    _sample_text_preview(sample),
+                    str(sample.label)[:100],
+                    _reward_log_summary(sample.reward),
                 )
                 do_print = False
 
@@ -454,7 +502,10 @@ async def generate_rollout_async(
     pbar.close()
     sample = data[-1][0][0] if isinstance(data[-1][0], list) else data[-1][0]
     logger.info(
-        f"Finish rollout: {[str(sample.prompt) + sample.response]}, label: {str(sample.label)[:100]}, reward: {sample.reward}",
+        "Finish rollout: text_preview=%s, label=%s, reward_summary=%s",
+        _sample_text_preview(sample),
+        str(sample.label)[:100],
+        _reward_log_summary(sample.reward),
     )
 
     # there are still some unfinished requests, abort them

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -1166,14 +1166,43 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 type=str,
                 nargs="+",
                 default=None,
-                metavar="NAME=URL",
+                metavar="NAME=URL[@W][,URL[@W]...]",
                 help=(
-                    "Multi-teacher routing map for --opd-type=sglang, e.g. "
+                    "Multi-teacher routing/ensemble map for --opd-type=sglang, e.g. "
                     "--opd-teacher-urls math=http://h1:30001/generate code=http://h2:30002/generate. "
-                    "Each sample is routed to the teacher named by "
+                    "Each sample is routed to the teacher group named by "
                     "sample.metadata[--opd-teacher-key]; the reserved name 'default' is the "
-                    "fallback for samples with a missing or unknown name. When unset, all "
-                    "samples are scored by the single teacher at --rm-url (original behavior)."
+                    "fallback for samples with a missing or unknown name. A name mapping to "
+                    "several comma-separated URLs is an ensemble: every member scores the "
+                    "sample in parallel and the targets are combined as a weighted mixture "
+                    "in probability space (logsumexp of weighted logprobs); per-URL weights "
+                    "default to 1.0 (uniform). With --opd-log-prob-top-k > 0, ensembles "
+                    "require --opd-top-k-strategy only-student. When unset, all samples are "
+                    "scored by the single teacher at --rm-url (original behavior)."
+                ),
+            )
+            parser.add_argument(
+                "--opd-topk-tail-bucket",
+                action="store_true",
+                default=False,
+                help=(
+                    "Compute the top-k OPD reward as the exact reverse KL over the selected "
+                    "token ids plus one tail bucket (k+1 buckets summing to 1), instead of "
+                    "the softmax-renormalized truncated estimate. Keeps the estimate "
+                    "sensitive to probability mass the student moves outside the top-k. "
+                    "Requires --opd-log-prob-top-k > 0 and --opd-reward-weight-mode "
+                    "student_p (the bucket weights are the raw student probabilities)."
+                ),
+            )
+            parser.add_argument(
+                "--opd-scoring-timeout-secs",
+                type=float,
+                default=None,
+                help=(
+                    "Per-request timeout for OPD teacher/student scoring calls. Defaults to "
+                    "--sglang-router-request-timeout-secs; set this to give (typically "
+                    "larger, slower) teacher servers a different bound than generation "
+                    "requests without touching the shared router timeout."
                 ),
             )
             parser.add_argument(
@@ -2142,7 +2171,32 @@ def miles_validate_args(args):
             # Local import to keep miles.utils free of rollout imports at module load.
             from miles.rollout.on_policy_distillation import parse_teacher_urls
 
-            parse_teacher_urls(args.opd_teacher_urls)  # fail fast on malformed/duplicate entries
+            url_map = parse_teacher_urls(args.opd_teacher_urls)  # fail fast on malformed/duplicate entries
+            has_ensemble_group = any(len(targets) > 1 for targets in url_map.values())
+            if has_ensemble_group and args.opd_log_prob_top_k > 0 and args.opd_top_k_strategy != "only-student":
+                raise ValueError(
+                    "Teacher ensembles (--opd-teacher-urls groups with multiple URLs) require "
+                    "--opd-top-k-strategy only-student: every group member must be scored at the "
+                    f"same student top-k token ids, got {args.opd_top_k_strategy!r}."
+                )
+        if args.opd_topk_tail_bucket:
+            if args.opd_log_prob_top_k <= 0:
+                raise ValueError("--opd-topk-tail-bucket requires --opd-log-prob-top-k > 0.")
+            if args.opd_reward_weight_mode != "student_p":
+                raise ValueError(
+                    "--opd-topk-tail-bucket uses raw student probabilities as bucket weights and is "
+                    f"incompatible with --opd-reward-weight-mode {args.opd_reward_weight_mode!r}; use student_p."
+                )
+            if args.opd_top_k_strategy not in ("only-student", "intersection"):
+                raise ValueError(
+                    "--opd-topk-tail-bucket requires --opd-top-k-strategy only-student or intersection: the k+1 "
+                    "bucket partition is only exact when all student logprobs at the selected ids come from "
+                    "one softmax (the rollout harvest). With "
+                    f"{args.opd_top_k_strategy!r}, student logprobs mix the rollout harvest with a separate "
+                    "rescoring pass, so the bucket masses do not come from a single distribution."
+                )
+        if args.opd_scoring_timeout_secs is not None and args.opd_scoring_timeout_secs <= 0:
+            raise ValueError("--opd-scoring-timeout-secs must be positive when set.")
 
         if args.opd_type == "megatron":
             if args.opd_teacher_load is None:
@@ -2171,6 +2225,12 @@ def miles_validate_args(args):
             raise ValueError("--opd-teacher-load is set but --use-opd is not enabled. Please add --use-opd flag.")
         if args.opd_teacher_urls:
             raise ValueError("--opd-teacher-urls is set but --use-opd is not enabled. Please add --use-opd flag.")
+        if args.opd_topk_tail_bucket:
+            raise ValueError("--opd-topk-tail-bucket is set but --use-opd is not enabled. Please add --use-opd flag.")
+        if args.opd_scoring_timeout_secs is not None:
+            raise ValueError(
+                "--opd-scoring-timeout-secs is set but --use-opd is not enabled. Please add --use-opd flag."
+            )
 
     # TODO: During loading, we need to set the start_rollout_id here.
     if args.megatron_to_hf_mode == "bridge":

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -1162,6 +1162,30 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 ),
             )
             parser.add_argument(
+                "--opd-teacher-urls",
+                type=str,
+                nargs="+",
+                default=None,
+                metavar="NAME=URL",
+                help=(
+                    "Multi-teacher routing map for --opd-type=sglang, e.g. "
+                    "--opd-teacher-urls math=http://h1:30001/generate code=http://h2:30002/generate. "
+                    "Each sample is routed to the teacher named by "
+                    "sample.metadata[--opd-teacher-key]; the reserved name 'default' is the "
+                    "fallback for samples with a missing or unknown name. When unset, all "
+                    "samples are scored by the single teacher at --rm-url (original behavior)."
+                ),
+            )
+            parser.add_argument(
+                "--opd-teacher-key",
+                type=str,
+                default="opd_teacher",
+                help=(
+                    "Sample metadata key holding the teacher name used for --opd-teacher-urls "
+                    "routing. Populated from the dataset's metadata column (see --metadata-key)."
+                ),
+            )
+            parser.add_argument(
                 "--opd-teacher-load",
                 type=str,
                 default=None,
@@ -2112,6 +2136,13 @@ def miles_validate_args(args):
             raise ValueError("--opd-log-prob-top-k must be non-negative.")
         if args.opd_log_prob_top_k > 0 and args.opd_type != "sglang":
             raise ValueError("--opd-log-prob-top-k is currently supported only with --opd-type=sglang.")
+        if args.opd_teacher_urls:
+            if args.opd_type != "sglang":
+                raise ValueError("--opd-teacher-urls is only supported with --opd-type=sglang.")
+            # Local import to keep miles.utils free of rollout imports at module load.
+            from miles.rollout.on_policy_distillation import parse_teacher_urls
+
+            parse_teacher_urls(args.opd_teacher_urls)  # fail fast on malformed/duplicate entries
 
         if args.opd_type == "megatron":
             if args.opd_teacher_load is None:
@@ -2138,6 +2169,8 @@ def miles_validate_args(args):
     else:
         if args.opd_teacher_load is not None:
             raise ValueError("--opd-teacher-load is set but --use-opd is not enabled. Please add --use-opd flag.")
+        if args.opd_teacher_urls:
+            raise ValueError("--opd-teacher-urls is set but --use-opd is not enabled. Please add --use-opd flag.")
 
     # TODO: During loading, we need to set the start_rollout_id here.
     if args.megatron_to_hf_mode == "bridge":

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -1150,6 +1150,18 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 help="Weighting scheme for top-k OPD token rewards.",
             )
             parser.add_argument(
+                "--opd-topk-per-position",
+                action="store_true",
+                default=False,
+                help=(
+                    "Send per-position token ids to the teacher/student scoring server "
+                    "(token_ids_logprob_positions) instead of the global top-k union, so the "
+                    "response is O(response_len * k) instead of O(response_len * |union|). "
+                    "Requires a patched sglang server that supports token_ids_logprob_positions; "
+                    "leave off for an unpatched server."
+                ),
+            )
+            parser.add_argument(
                 "--opd-teacher-load",
                 type=str,
                 default=None,

--- a/tests/fast/ray/rollout/test_train_data_conversion.py
+++ b/tests/fast/ray/rollout/test_train_data_conversion.py
@@ -113,6 +113,37 @@ class TestConvertSamplesToTrainData:
         )
         assert out["rollout_log_probs"][0] == [-0.1, -0.2, -0.3, -0.4]
 
+    def test_opd_fields_passed_through_when_set_on_all_samples(self):
+        args = make_args(rewards_normalization=False)
+        samples = [make_sample(index=i) for i in range(2)]
+        for s in samples:
+            s.teacher_log_probs = [-0.1] * s.response_length
+            s.opd_reverse_kl = [0.2] * s.response_length
+        out = convert_samples_to_train_data(
+            args,
+            samples,
+            metadata={},
+            custom_convert_samples_to_train_data_func=None,
+            custom_reward_post_process_func=None,
+        )
+        assert len(out["teacher_log_probs"]) == 2
+        assert len(out["opd_reverse_kl"]) == 2
+
+    def test_opd_fields_partially_set_raises_instead_of_silently_dropping(self):
+        # Gating on samples[0] alone would silently drop the key (or crash later on
+        # a length mismatch) when teacher scoring covered only part of the batch.
+        args = make_args(rewards_normalization=False)
+        samples = [make_sample(index=i) for i in range(2)]
+        samples[1].teacher_log_probs = [-0.1] * samples[1].response_length
+        with pytest.raises(ValueError, match="teacher scoring must cover the whole batch"):
+            convert_samples_to_train_data(
+                args,
+                samples,
+                metadata={},
+                custom_convert_samples_to_train_data_func=None,
+                custom_reward_post_process_func=None,
+            )
+
     def test_optional_field_round_number_from_metadata(self):
         args = make_args(rewards_normalization=False)
         s = make_sample()

--- a/tests/fast/rollout/test_on_policy_distillation.py
+++ b/tests/fast/rollout/test_on_policy_distillation.py
@@ -1,15 +1,26 @@
+import asyncio
 import math
 from argparse import Namespace
 
+import aiohttp
 import pytest
+import torch
 from tests.ci.ci_register import register_cpu_ci
 
+import miles.rollout.on_policy_distillation as opd
 from miles.rollout.on_policy_distillation import (
     _compute_topk_reverse_kl,
+    _is_retryable_scoring_error,
+    _mixture_log_probs,
+    _mixture_logprob_maps,
     _per_position_ids,
     _score_payload,
-    _teacher_url_for_sample,
+    _scoring_timeout,
+    _tail_bucket_reverse_kl,
+    _teacher_targets_for_sample,
     parse_teacher_urls,
+    post_process_rewards,
+    reward_func,
 )
 from miles.utils.types import Sample
 
@@ -147,8 +158,8 @@ def _tagged_sample(metadata=None):
 def test_parse_teacher_urls_parses_names_and_keeps_equals_in_url():
     url_map = parse_teacher_urls(["math=http://h1:30001/generate", "code=http://h2:30002/generate?tag=a=b"])
     assert url_map == {
-        "math": "http://h1:30001/generate",
-        "code": "http://h2:30002/generate?tag=a=b",
+        "math": [("http://h1:30001/generate", 1.0)],
+        "code": [("http://h2:30002/generate?tag=a=b", 1.0)],
     }
 
 
@@ -168,40 +179,450 @@ def test_parse_teacher_urls_rejects_duplicate_names():
         parse_teacher_urls(["math=http://h1/generate", "math=http://h2/generate"])
 
 
+def test_parse_teacher_urls_parses_ensemble_groups_and_weights():
+    url_map = parse_teacher_urls(["ens=http://h1/generate,http://h2/generate@2.5", "solo=http://h3/generate"])
+    assert url_map == {
+        "ens": [("http://h1/generate", 1.0), ("http://h2/generate", 2.5)],
+        "solo": [("http://h3/generate", 1.0)],
+    }
+
+
+def test_parse_teacher_urls_keeps_at_sign_in_userinfo_urls():
+    # rpartition on the last '@': a suffix that is not a float belongs to the URL.
+    url_map = parse_teacher_urls(["m=http://user:pw@h1/generate"])
+    assert url_map == {"m": [("http://user:pw@h1/generate", 1.0)]}
+    url_map = parse_teacher_urls(["m=http://user:pw@h1/generate@0.5"])
+    assert url_map == {"m": [("http://user:pw@h1/generate", 0.5)]}
+
+
+@pytest.mark.parametrize("bad_weight", ["0", "-1", "inf", "nan"])
+def test_parse_teacher_urls_rejects_non_positive_or_non_finite_weights(bad_weight):
+    with pytest.raises(ValueError, match="positive finite"):
+        parse_teacher_urls([f"m=http://h1/generate@{bad_weight}"])
+
+
+def test_parse_teacher_urls_rejects_empty_group_member():
+    with pytest.raises(ValueError, match="Empty teacher URL"):
+        parse_teacher_urls(["ens=http://h1/generate,,http://h2/generate"])
+
+
+def test_parse_teacher_urls_rejects_duplicate_url_within_group():
+    with pytest.raises(ValueError, match="Duplicate URL within teacher group"):
+        parse_teacher_urls(["ens=http://h1/generate,http://h1/generate@2.0"])
+
+
+def test_parse_teacher_urls_rejects_non_http_members_at_startup():
+    # A comma inside a member URL splits it into fragments; the scheme check turns
+    # that into a startup error instead of a mid-rollout invalid-endpoint failure.
+    with pytest.raises(ValueError, match="must start with"):
+        parse_teacher_urls(["math=http://h1/generate?tags=a,b"])
+    with pytest.raises(ValueError, match="must start with"):
+        parse_teacher_urls(["math=h1:30001/generate"])
+
+
 def test_routing_unset_map_falls_back_to_rm_url():
     args = _routing_args(urls=None)
     sample = _tagged_sample({"opd_teacher": "math"})
-    assert _teacher_url_for_sample(args, sample) == "http://single-teacher/generate"
+    assert _teacher_targets_for_sample(args, sample) == [("http://single-teacher/generate", 1.0)]
 
 
 def test_routing_by_metadata_name():
     args = _routing_args(urls=["math=http://h1/generate", "code=http://h2/generate"])
-    assert _teacher_url_for_sample(args, _tagged_sample({"opd_teacher": "math"})) == "http://h1/generate"
-    assert _teacher_url_for_sample(args, _tagged_sample({"opd_teacher": "code"})) == "http://h2/generate"
+    assert _teacher_targets_for_sample(args, _tagged_sample({"opd_teacher": "math"})) == [("http://h1/generate", 1.0)]
+    assert _teacher_targets_for_sample(args, _tagged_sample({"opd_teacher": "code"})) == [("http://h2/generate", 1.0)]
+
+
+def test_routing_resolves_ensemble_group():
+    args = _routing_args(urls=["math=http://h1/generate@1.0,http://h2/generate@3.0"])
+    assert _teacher_targets_for_sample(args, _tagged_sample({"opd_teacher": "math"})) == [
+        ("http://h1/generate", 1.0),
+        ("http://h2/generate", 3.0),
+    ]
 
 
 def test_routing_respects_custom_metadata_key():
     args = _routing_args(urls=["math=http://h1/generate"], key="task")
-    assert _teacher_url_for_sample(args, _tagged_sample({"task": "math"})) == "http://h1/generate"
+    assert _teacher_targets_for_sample(args, _tagged_sample({"task": "math"})) == [("http://h1/generate", 1.0)]
 
 
 def test_routing_missing_name_uses_default_entry():
     args = _routing_args(urls=["math=http://h1/generate", "default=http://h3/generate"])
-    assert _teacher_url_for_sample(args, _tagged_sample({})) == "http://h3/generate"
+    assert _teacher_targets_for_sample(args, _tagged_sample({})) == [("http://h3/generate", 1.0)]
 
 
 def test_routing_unknown_name_uses_default_entry():
     args = _routing_args(urls=["math=http://h1/generate", "default=http://h3/generate"])
-    assert _teacher_url_for_sample(args, _tagged_sample({"opd_teacher": "physics"})) == "http://h3/generate"
+    assert _teacher_targets_for_sample(args, _tagged_sample({"opd_teacher": "physics"})) == [
+        ("http://h3/generate", 1.0)
+    ]
 
 
 def test_routing_unknown_name_without_default_raises():
     args = _routing_args(urls=["math=http://h1/generate"])
     with pytest.raises(ValueError, match="matches no --opd-teacher-urls name"):
-        _teacher_url_for_sample(args, _tagged_sample({"opd_teacher": "physics"}))
+        _teacher_targets_for_sample(args, _tagged_sample({"opd_teacher": "physics"}))
 
 
 def test_routing_missing_name_without_default_raises():
     args = _routing_args(urls=["math=http://h1/generate"])
     with pytest.raises(ValueError, match="missing teacher key"):
-        _teacher_url_for_sample(args, _tagged_sample({}))
+        _teacher_targets_for_sample(args, _tagged_sample({}))
+
+
+# ---------------------------------------------------------------------------
+# Teacher ensembles: probability-space mixtures
+# ---------------------------------------------------------------------------
+
+
+def test_mixture_log_probs_is_arithmetic_mean_in_probability_space():
+    teacher_a = torch.tensor([0.2, 0.8]).log()
+    teacher_b = torch.tensor([0.6, 0.4]).log()
+    mix = _mixture_log_probs([teacher_a, teacher_b], [1.0, 1.0])
+    assert mix.tolist() == pytest.approx([math.log(0.4), math.log(0.6)], rel=1e-6)
+
+
+def test_mixture_log_probs_respects_weights():
+    teacher_a = torch.tensor([0.2, 0.8]).log()
+    teacher_b = torch.tensor([0.6, 0.4]).log()
+    mix = _mixture_log_probs([teacher_a, teacher_b], [1.0, 3.0])
+    # (0.2 + 3*0.6)/4 = 0.5 and (0.8 + 3*0.4)/4 = 0.5
+    assert mix.tolist() == pytest.approx([math.log(0.5), math.log(0.5)], rel=1e-6)
+
+
+def test_mixture_logprob_maps_mixes_per_token_id():
+    maps_a = [{1: math.log(0.2), 2: math.log(0.6)}]
+    maps_b = [{1: math.log(0.4), 2: math.log(0.8)}]
+    mixed = _mixture_logprob_maps([maps_a, maps_b], [1.0, 1.0])
+    assert mixed[0][1] == pytest.approx(math.log(0.3), rel=1e-9)
+    assert mixed[0][2] == pytest.approx(math.log(0.7), rel=1e-9)
+
+
+def test_mixture_logprob_maps_raises_on_missing_token_id():
+    maps_a = [{1: math.log(0.2), 2: math.log(0.6)}]
+    maps_b = [{1: math.log(0.4)}]
+    with pytest.raises(ValueError, match="missing logprob for token id"):
+        _mixture_logprob_maps([maps_a, maps_b], [1.0, 1.0])
+
+
+def _ensemble_teacher_response(probs_by_position):
+    # probs_by_position: list (per response position) of {token_id: prob}.
+    return {
+        "meta_info": {
+            "input_token_ids_logprobs": [None]
+            + [[_entry(p, tid) for tid, p in position.items()] for position in probs_by_position]
+        }
+    }
+
+
+def test_topk_ensemble_uses_mixture_of_teachers():
+    # Per-teacher maps whose uniform mixture equals the single-teacher fixture
+    # (_teacher_payload input_token_ids_logprobs), so the expected KL matches
+    # test_topk_only_student_uses_student_probability_weights exactly.
+    payload = {
+        "teachers": [
+            _ensemble_teacher_response([{1: 0.2, 2: 0.6}, {4: 0.5, 5: 0.7}]),
+            _ensemble_teacher_response([{1: 0.4, 2: 0.8}, {4: 0.3, 5: 0.5}]),
+        ],
+        "teacher_weights": [1.0, 1.0],
+    }
+    reverse_kl = _compute_topk_reverse_kl(_args("only-student"), _sample(), payload)
+
+    expected_0 = 0.6 * math.log(0.6 / 0.3) + 0.4 * math.log(0.4 / 0.7)
+    expected_1 = 0.7 * math.log(0.7 / 0.4) + 0.3 * math.log(0.3 / 0.6)
+    assert reverse_kl.tolist() == pytest.approx([expected_0, expected_1], rel=1e-5)
+
+
+def test_topk_ensemble_rejects_non_student_strategies():
+    payload = {
+        "teachers": [
+            _ensemble_teacher_response([{1: 0.2, 2: 0.6}, {4: 0.5, 5: 0.7}]),
+            _ensemble_teacher_response([{1: 0.4, 2: 0.8}, {4: 0.3, 5: 0.5}]),
+        ],
+        "teacher_weights": [1.0, 1.0],
+    }
+    with pytest.raises(ValueError, match="require --opd-top-k-strategy only-student"):
+        _compute_topk_reverse_kl(_args("union"), _sample(), payload)
+
+
+# ---------------------------------------------------------------------------
+# Tail-mass bucket (--opd-topk-tail-bucket)
+# ---------------------------------------------------------------------------
+
+
+def _tail_args(strategy: str = "only-student"):
+    return Namespace(
+        opd_top_k_strategy=strategy,
+        opd_reward_weight_mode="student_p",
+        opd_topk_tail_bucket=True,
+    )
+
+
+def test_tail_bucket_reverse_kl_matches_hand_computed_bucket_kl():
+    # Buckets: {id1: 0.6, id2: 0.3, tail: 0.1} vs {id1: 0.3, id2: 0.5, tail: 0.2}.
+    student_logps = [math.log(0.6), math.log(0.3)]
+    teacher_logps = [math.log(0.3), math.log(0.5)]
+    expected = 0.6 * math.log(0.6 / 0.3) + 0.3 * math.log(0.3 / 0.5) + 0.1 * (math.log(0.1) - math.log(0.2))
+    assert _tail_bucket_reverse_kl(student_logps, teacher_logps) == pytest.approx(expected, rel=1e-9)
+
+
+def test_tail_bucket_skips_tail_when_student_mass_at_least_one():
+    student_logps = [math.log(0.8), math.log(0.3)]
+    teacher_logps = [math.log(0.4), math.log(0.4)]
+    expected = 0.8 * math.log(0.8 / 0.4) + 0.3 * math.log(0.3 / 0.4)
+    assert _tail_bucket_reverse_kl(student_logps, teacher_logps) == pytest.approx(expected, rel=1e-9)
+
+
+def test_tail_bucket_floors_vanishing_teacher_tail():
+    student_logps = [math.log(0.5)]
+    teacher_logps = [math.log(1.0)]
+    # The teacher tail mass rounds to 0 and is floored to TAIL_PROB_FLOOR; the exact
+    # floored value depends on float64 rounding of 1 - 1e-12, hence the loose rel tol.
+    expected = 0.5 * math.log(0.5 / 1.0) + 0.5 * (math.log1p(-0.5) - math.log(opd.TAIL_PROB_FLOOR))
+    result = _tail_bucket_reverse_kl(student_logps, teacher_logps)
+    assert math.isfinite(result)
+    assert result == pytest.approx(expected, rel=1e-4)
+
+
+def test_tail_bucket_empty_token_set_contributes_zero():
+    assert _tail_bucket_reverse_kl([], []) == pytest.approx(0.0, abs=1e-12)
+
+
+def test_topk_tail_bucket_rejects_mixed_source_strategies():
+    # only-teacher/union/xor fill student logprobs from a separate
+    # rescoring pass, so the k+1 bucket masses do not come from one softmax.
+    with pytest.raises(ValueError, match="only-student.*intersection"):
+        _compute_topk_reverse_kl(_tail_args("union"), _sample(), _teacher_payload())
+
+
+def test_topk_ensemble_with_tail_bucket_and_weights_matches_hand_computed_mixture_kl():
+    # The configuration the ensemble example ships: weighted ensemble (2:1) + tail
+    # bucket. Mixture probs are the weighted average of member probs, and the
+    # mixture tail is the weighted average of member tails over the same ids.
+    sample = Sample(
+        tokens=[10, 11, 12],
+        response_length=2,
+        metadata={
+            "opd_student_top_logprobs": [
+                [_entry(0.6, 1), _entry(0.3, 2)],
+                [_entry(0.5, 4), _entry(0.2, 5)],
+            ]
+        },
+    )
+    payload = {
+        "teachers": [
+            _ensemble_teacher_response([{1: 0.2, 2: 0.6}, {4: 0.5, 5: 0.1}]),
+            _ensemble_teacher_response([{1: 0.5, 2: 0.4}, {4: 0.2, 5: 0.4}]),
+        ],
+        "teacher_weights": [2.0, 1.0],
+    }
+    reverse_kl = _compute_topk_reverse_kl(_tail_args(), sample, payload)
+
+    t0_id1 = (2.0 * 0.2 + 1.0 * 0.5) / 3.0
+    t0_id2 = (2.0 * 0.6 + 1.0 * 0.4) / 3.0
+    t1_id4 = (2.0 * 0.5 + 1.0 * 0.2) / 3.0
+    t1_id5 = (2.0 * 0.1 + 1.0 * 0.4) / 3.0
+    expected_0 = (
+        0.6 * math.log(0.6 / t0_id1)
+        + 0.3 * math.log(0.3 / t0_id2)
+        + 0.1 * (math.log(0.1) - math.log(1.0 - t0_id1 - t0_id2))
+    )
+    expected_1 = (
+        0.5 * math.log(0.5 / t1_id4)
+        + 0.2 * math.log(0.2 / t1_id5)
+        + 0.3 * (math.log(0.3) - math.log(1.0 - t1_id4 - t1_id5))
+    )
+    assert reverse_kl.tolist() == pytest.approx([expected_0, expected_1], rel=1e-5)
+
+
+def test_topk_tail_bucket_end_to_end():
+    sample = Sample(
+        tokens=[10, 11, 12],
+        response_length=2,
+        metadata={
+            "opd_student_top_logprobs": [
+                [_entry(0.6, 1), _entry(0.3, 2)],
+                [_entry(0.5, 4), _entry(0.2, 5)],
+            ]
+        },
+    )
+    payload = {
+        "teacher": {
+            "meta_info": {
+                "input_token_ids_logprobs": [
+                    None,
+                    [_entry(0.3, 1), _entry(0.5, 2)],
+                    [_entry(0.4, 4), _entry(0.1, 5)],
+                ]
+            }
+        }
+    }
+    reverse_kl = _compute_topk_reverse_kl(_tail_args(), sample, payload)
+
+    expected_0 = 0.6 * math.log(0.6 / 0.3) + 0.3 * math.log(0.3 / 0.5) + 0.1 * (math.log(0.1) - math.log(0.2))
+    expected_1 = 0.5 * math.log(0.5 / 0.4) + 0.2 * math.log(0.2 / 0.1) + 0.3 * (math.log(0.3) - math.log(0.5))
+    assert reverse_kl.tolist() == pytest.approx([expected_0, expected_1], rel=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# Scoring robustness: timeout fallback and bounded retry
+# ---------------------------------------------------------------------------
+
+
+def test_scoring_timeout_prefers_dedicated_flag_over_router_timeout():
+    assert _scoring_timeout(Namespace(opd_scoring_timeout_secs=30.0, sglang_router_request_timeout_secs=600)) == 30.0
+    assert _scoring_timeout(Namespace(opd_scoring_timeout_secs=None, sglang_router_request_timeout_secs=600)) == 600
+    assert _scoring_timeout(Namespace()) is None
+
+
+def test_is_retryable_scoring_error_classification():
+    assert _is_retryable_scoring_error(asyncio.TimeoutError())
+    assert _is_retryable_scoring_error(aiohttp.ClientConnectionError())
+    assert _is_retryable_scoring_error(aiohttp.ClientResponseError(request_info=None, history=(), status=503))
+    assert not _is_retryable_scoring_error(aiohttp.ClientResponseError(request_info=None, history=(), status=400))
+    assert not _is_retryable_scoring_error(ValueError("missing logprob"))
+
+
+async def _no_sleep(_secs):
+    return None
+
+
+def test_post_json_retries_transient_failure_once(monkeypatch):
+    calls = []
+
+    async def flaky(url, payload, timeout):
+        calls.append(url)
+        if len(calls) == 1:
+            raise aiohttp.ClientConnectionError("transient")
+        return {"ok": True}
+
+    monkeypatch.setattr(opd, "_post_json_once", flaky)
+    monkeypatch.setattr(asyncio, "sleep", _no_sleep)
+    assert asyncio.run(opd._post_json("http://t/generate", {})) == {"ok": True}
+    assert len(calls) == 2
+
+
+def test_post_json_does_not_retry_client_errors(monkeypatch):
+    calls = []
+
+    async def always_400(url, payload, timeout):
+        calls.append(url)
+        raise aiohttp.ClientResponseError(request_info=None, history=(), status=400)
+
+    monkeypatch.setattr(opd, "_post_json_once", always_400)
+    monkeypatch.setattr(asyncio, "sleep", _no_sleep)
+    with pytest.raises(aiohttp.ClientResponseError):
+        asyncio.run(opd._post_json("http://t/generate", {}))
+    assert len(calls) == 1
+
+
+def test_post_json_raises_after_retries_exhausted(monkeypatch):
+    calls = []
+
+    async def always_down(url, payload, timeout):
+        calls.append(url)
+        raise aiohttp.ClientConnectionError("down")
+
+    monkeypatch.setattr(opd, "_post_json_once", always_down)
+    monkeypatch.setattr(asyncio, "sleep", _no_sleep)
+    with pytest.raises(aiohttp.ClientConnectionError):
+        asyncio.run(opd._post_json("http://t/generate", {}))
+    assert len(calls) == opd.SCORING_MAX_RETRIES + 1
+
+
+# ---------------------------------------------------------------------------
+# reward_func fan-out and post_process_rewards ensemble handling
+# ---------------------------------------------------------------------------
+
+
+def _sampled_token_response(logprobs):
+    # input_token_logprobs: leading placeholder + one [logprob, token_id] per token.
+    return {"meta_info": {"input_token_logprobs": [[0.0, 0]] + [[lp, 0] for lp in logprobs]}}
+
+
+def test_reward_func_fans_out_to_every_ensemble_member(monkeypatch):
+    posted = []
+
+    async def fake_post(url, payload, timeout_secs=None):
+        posted.append((url, payload))
+        return _sampled_token_response([math.log(0.5), math.log(0.5)])
+
+    monkeypatch.setattr(opd, "_post_json", fake_post)
+    args = Namespace(
+        opd_log_prob_top_k=0,
+        opd_teacher_urls=["default=http://h1/generate,http://h2/generate@2.0"],
+        opd_teacher_key="opd_teacher",
+        rm_url=None,
+    )
+    sample = Sample(tokens=[10, 11, 12], response_length=2, metadata={})
+    reward = asyncio.run(reward_func(args, sample))
+
+    assert [url for url, _ in posted] == ["http://h1/generate", "http://h2/generate"]
+    assert posted[0][1] == posted[1][1]  # every member scores the identical payload
+    assert reward["teacher_weights"] == [1.0, 2.0]
+    assert len(reward["teachers"]) == 2
+
+
+def test_reward_func_single_teacher_keeps_raw_response_shape(monkeypatch):
+    async def fake_post(url, payload, timeout_secs=None):
+        return _sampled_token_response([math.log(0.5), math.log(0.5)])
+
+    monkeypatch.setattr(opd, "_post_json", fake_post)
+    args = Namespace(opd_log_prob_top_k=0, opd_teacher_urls=None, rm_url="http://t/generate")
+    sample = Sample(tokens=[10, 11, 12], response_length=2, metadata={})
+    reward = asyncio.run(reward_func(args, sample))
+    assert "teachers" not in reward and "meta_info" in reward
+
+
+def test_reward_func_topk_ensemble_scores_every_member_at_student_ids(monkeypatch):
+    posted = []
+
+    async def fake_post(url, payload, timeout_secs=None):
+        posted.append((url, payload))
+        return {"meta_info": {"input_token_ids_logprobs": [None, [], []]}}
+
+    monkeypatch.setattr(opd, "_post_json", fake_post)
+    args = Namespace(
+        opd_log_prob_top_k=2,
+        opd_top_k_strategy="only-student",
+        opd_teacher_urls=["default=http://h1/generate,http://h2/generate"],
+        opd_teacher_key="opd_teacher",
+        opd_topk_per_position=False,
+        rm_url=None,
+    )
+    sample = _sample()
+    reward = asyncio.run(reward_func(args, sample))
+
+    assert [url for url, _ in posted] == ["http://h1/generate", "http://h2/generate"]
+    # Every member is scored at the same student top-k ids (global union transport).
+    assert posted[0][1]["token_ids_logprob"] == [1, 2, 4, 5]
+    assert posted[0][1] == posted[1][1]
+    assert reward["teacher_weights"] == [1.0, 1.0]
+    assert len(reward["teachers"]) == 2
+
+
+def test_post_process_rewards_mixes_ensemble_sampled_token_logprobs():
+    args = Namespace(opd_log_prob_top_k=0, reward_key="")
+    sample = Sample(tokens=[10, 11, 12], response_length=2, metadata={})
+    sample.reward = {
+        "teachers": [
+            _sampled_token_response([math.log(0.2), math.log(0.8)]),
+            _sampled_token_response([math.log(0.6), math.log(0.4)]),
+        ],
+        "teacher_weights": [1.0, 1.0],
+    }
+    post_process_rewards(args, [sample])
+    assert sample.teacher_log_probs.tolist() == pytest.approx([math.log(0.4), math.log(0.6)], rel=1e-6)
+
+
+def test_post_process_rewards_frees_student_top_logprob_metadata():
+    args = Namespace(
+        opd_log_prob_top_k=2,
+        opd_top_k_strategy="only-student",
+        opd_reward_weight_mode="student_p",
+        reward_key="",
+    )
+    sample = _sample()
+    sample.reward = _teacher_payload()
+    post_process_rewards(args, [sample])
+    assert sample.opd_reverse_kl is not None
+    assert "opd_student_top_logprobs" not in sample.metadata

--- a/tests/fast/rollout/test_on_policy_distillation.py
+++ b/tests/fast/rollout/test_on_policy_distillation.py
@@ -4,7 +4,13 @@ from argparse import Namespace
 import pytest
 from tests.ci.ci_register import register_cpu_ci
 
-from miles.rollout.on_policy_distillation import _compute_topk_reverse_kl, _per_position_ids, _score_payload
+from miles.rollout.on_policy_distillation import (
+    _compute_topk_reverse_kl,
+    _per_position_ids,
+    _score_payload,
+    _teacher_url_for_sample,
+    parse_teacher_urls,
+)
 from miles.utils.types import Sample
 
 register_cpu_ci(est_time=60, suite="stage-a-cpu")
@@ -123,3 +129,79 @@ def test_score_payload_routes_per_position_vs_flat():
     per_pos = _score_payload([1, 2, 3], token_ids_positions=[[], [5, 7], [9, 11]])
     assert per_pos["token_ids_logprob_positions"] == [[], [5, 7], [9, 11]]
     assert "token_ids_logprob" not in per_pos
+
+
+# ---------------------------------------------------------------------------
+# Multi-teacher routing (--opd-teacher-urls)
+# ---------------------------------------------------------------------------
+
+
+def _routing_args(urls=None, key="opd_teacher", rm_url="http://single-teacher/generate"):
+    return Namespace(opd_teacher_urls=urls, opd_teacher_key=key, rm_url=rm_url)
+
+
+def _tagged_sample(metadata=None):
+    return Sample(tokens=[1, 2, 3], response_length=2, metadata=metadata or {})
+
+
+def test_parse_teacher_urls_parses_names_and_keeps_equals_in_url():
+    url_map = parse_teacher_urls(["math=http://h1:30001/generate", "code=http://h2:30002/generate?tag=a=b"])
+    assert url_map == {
+        "math": "http://h1:30001/generate",
+        "code": "http://h2:30002/generate?tag=a=b",
+    }
+
+
+def test_parse_teacher_urls_empty_or_none_gives_empty_map():
+    assert parse_teacher_urls(None) == {}
+    assert parse_teacher_urls([]) == {}
+
+
+@pytest.mark.parametrize("bad", ["math", "=http://h1/generate", "math=", "  =  "])
+def test_parse_teacher_urls_rejects_malformed_entries(bad):
+    with pytest.raises(ValueError, match="expected NAME=URL"):
+        parse_teacher_urls([bad])
+
+
+def test_parse_teacher_urls_rejects_duplicate_names():
+    with pytest.raises(ValueError, match="Duplicate teacher name"):
+        parse_teacher_urls(["math=http://h1/generate", "math=http://h2/generate"])
+
+
+def test_routing_unset_map_falls_back_to_rm_url():
+    args = _routing_args(urls=None)
+    sample = _tagged_sample({"opd_teacher": "math"})
+    assert _teacher_url_for_sample(args, sample) == "http://single-teacher/generate"
+
+
+def test_routing_by_metadata_name():
+    args = _routing_args(urls=["math=http://h1/generate", "code=http://h2/generate"])
+    assert _teacher_url_for_sample(args, _tagged_sample({"opd_teacher": "math"})) == "http://h1/generate"
+    assert _teacher_url_for_sample(args, _tagged_sample({"opd_teacher": "code"})) == "http://h2/generate"
+
+
+def test_routing_respects_custom_metadata_key():
+    args = _routing_args(urls=["math=http://h1/generate"], key="task")
+    assert _teacher_url_for_sample(args, _tagged_sample({"task": "math"})) == "http://h1/generate"
+
+
+def test_routing_missing_name_uses_default_entry():
+    args = _routing_args(urls=["math=http://h1/generate", "default=http://h3/generate"])
+    assert _teacher_url_for_sample(args, _tagged_sample({})) == "http://h3/generate"
+
+
+def test_routing_unknown_name_uses_default_entry():
+    args = _routing_args(urls=["math=http://h1/generate", "default=http://h3/generate"])
+    assert _teacher_url_for_sample(args, _tagged_sample({"opd_teacher": "physics"})) == "http://h3/generate"
+
+
+def test_routing_unknown_name_without_default_raises():
+    args = _routing_args(urls=["math=http://h1/generate"])
+    with pytest.raises(ValueError, match="matches no --opd-teacher-urls name"):
+        _teacher_url_for_sample(args, _tagged_sample({"opd_teacher": "physics"}))
+
+
+def test_routing_missing_name_without_default_raises():
+    args = _routing_args(urls=["math=http://h1/generate"])
+    with pytest.raises(ValueError, match="missing teacher key"):
+        _teacher_url_for_sample(args, _tagged_sample({}))

--- a/tests/fast/rollout/test_on_policy_distillation.py
+++ b/tests/fast/rollout/test_on_policy_distillation.py
@@ -4,7 +4,7 @@ from argparse import Namespace
 import pytest
 from tests.ci.ci_register import register_cpu_ci
 
-from miles.rollout.on_policy_distillation import _compute_topk_reverse_kl
+from miles.rollout.on_policy_distillation import _compute_topk_reverse_kl, _per_position_ids, _score_payload
 from miles.utils.types import Sample
 
 register_cpu_ci(est_time=60, suite="stage-a-cpu")
@@ -100,3 +100,26 @@ def test_topk_xor_uses_symmetric_difference_without_normalization():
     expected_1 = math.log(0.3 / 0.6) + math.log(0.1 / 0.2)
 
     assert reverse_kl.tolist() == pytest.approx([expected_0, expected_1])
+
+
+def test_per_position_ids_pads_prompt_and_keeps_response_order():
+    # Two response positions, each with two top-k entries [logprob, token_id].
+    student_top = [[_entry(0.6, 5), _entry(0.4, 7)], [_entry(0.7, 9), _entry(0.3, 11)]]
+    per_pos = _per_position_ids(student_top, prompt_len=3)
+    # 3 empty prompt slots, then response positions with their own token ids.
+    assert per_pos == [[], [], [], [5, 7], [9, 11]]
+    # Aligns with the existing _trim_input_field extraction values[1:][-R:]: for a
+    # length-5 response, indices 3,4 are the response positions.
+    values = list(range(5))
+    assert values[1:][-2:] == [3, 4]
+    assert per_pos[3] == [5, 7] and per_pos[4] == [9, 11]
+
+
+def test_score_payload_routes_per_position_vs_flat():
+    flat = _score_payload([1, 2, 3], token_ids=[5, 7])
+    assert flat["token_ids_logprob"] == [5, 7]
+    assert "token_ids_logprob_positions" not in flat
+
+    per_pos = _score_payload([1, 2, 3], token_ids_positions=[[], [5, 7], [9, 11]])
+    assert per_pos["token_ids_logprob_positions"] == [[], [5, 7], [9, 11]]
+    assert "token_ids_logprob" not in per_pos


### PR DESCRIPTION
# [OPD] [4/N] Teacher ensembles + exact tail-bucket top-k KL + scoring robustness

**Stacked on #1314** (multi-teacher routing), which stacks on #1298 → #994 → #993 (merged).

## Motivation

[slime PR #2033](https://github.com/THUDM/slime/pull/2033) (draft) adds two OPD capabilities miles lacked: combining **multiple teachers into one distillation target** and treating the top-k support as a **proper distribution with an explicit tail bucket**. We reviewed that PR in depth; this PR adopts the two ideas that are genuinely better — the probability-space mixture formula and the k+1-bucket KL — while keeping them on miles' rollout-side architecture, which is structurally cheaper and more general than slime's training-side design:

| | slime 2033 | this PR |
|---|---|---|
| Teacher placement | weight-swapped copies inside the Megatron train actor | external SGLang servers (unchanged) |
| Teacher constraint | **architecture/vocab/parallelism-homogeneous with the student** (a 32B teacher for an 8B student is impossible; their example self-distills) | any size/architecture sharing the tokenizer |
| Multi-teacher cost | N serialized forwards **on training GPUs** + N+1 full weight restores per step + N resident weight snapshots | parallel HTTP fan-out — wall clock ≈ max(teacher latencies), zero training-step cost |
| Ensemble weights | uniform only | per-teacher weights (`URL@W`) |
| Mixture math | `logsumexp(stack) − log N` ✓ (adopted) | same formula, weighted, float64 |
| Tail bucket | `(1 − Σp).clamp(1e-10).log()` in **bf16** → log≈−23 spikes when top-k mass rounds to ≥1 | float64 + `log1p`; student tail ≥1 → exact 0 contribution; floor only as a last-resort guard |
| Composability | replaces `policy_loss` entirely (no PPO clip, no task reward); forked `train_actor` subclass + module-global actor registry | unchanged: per-token penalty folded into advantages, composes with every estimator and PPO clipping |
| Per-sample data shipped to training | O(R·k) indices + logprobs (~6.3 MB at R=8k, k=64) | O(R) floats (~32 KB), unchanged |

Routing (#1314) and ensembling are complementary, not competing: route *across* domains, ensemble *within* a group of same-domain peers. This PR makes each routed name a (possibly weighted) group, so the two compose.

## What's added

| Flag | Behavior |
|---|---|
| `--opd-teacher-urls NAME=URL[@W][,URL[@W]...]` | Extended: a name now maps to a *group*. One URL = routing (3/N behavior, byte-for-byte unchanged). Multiple comma-separated URLs = ensemble: every member scores the sample in parallel and targets combine as a weighted probability-space mixture `log p̄(v) = logsumexp_m(log w_m + log p_m(v)) − log Σw_m`. Weights default to 1.0. |
| `--opd-topk-tail-bucket` | Top-k reward becomes the exact reverse KL over k+1 buckets: selected ids at raw full-softmax probabilities + one tail bucket `(1 − Σp)`. No renormalization — the estimate stays sensitive to mass the student pushes outside the top-k (the structural blind spot of the renormalized estimate). Float64 + `log1p`; requires `--opd-reward-weight-mode student_p` and `--opd-top-k-strategy only_stu`/`intersection` (the partition is only exact when all student logprobs come from one softmax — the other strategies mix the rollout harvest with a separate rescoring pass). |
| `--opd-scoring-timeout-secs` | Dedicated scoring timeout, defaulting to `--sglang-router-request-timeout-secs`. Previously the only knob was the shared router flag, so bounding a slow 32B teacher also changed every generation request's timeout. |

Plus robustness/correctness fixes flagged in the same review:

- **Bounded retry** in `_post_json`: one retry with jitter on timeout / connection error / HTTP 5xx; 4xx and `CancelledError` propagate immediately. Previously any transient teacher hiccup killed the whole rollout loop.
- **CP hole fixed**: `get_rollout_data` now CP-slices `teacher_log_probs` / `opd_reverse_kl` exactly like `rollout_log_probs`. Previously sglang-mode OPD with `--context-parallel-size > 1` crashed on the shape checks in `apply_opd_kl_to_advantages` (slime 2033 designed for CP; we didn't). Identity at cp=1.
- **Heterogeneous-batch gate**: `convert_samples_to_train_data` gated OPD keys on `samples[0]` only — a partially scored batch silently dropped the key or crashed later on a length mismatch. Now: all-or-raise with per-sample diagnostics.
- **Memory**: `sample.metadata["opd_student_top_logprobs"]` (O(R·k) Python lists, 50–150 MB/sample at 8k×64) is freed after the KL is computed instead of riding every Ray transfer forever.
- **Kimi-VL multimodal + CP**: the media-token-expansion re-slice in `mm_data.py` covered `teacher_log_probs` but not `opd_reverse_kl` (stale zigzag layout after expansion → shape mismatch or silent misalignment), and the OPD tensors are now placed on GPU like `rollout_log_probs` so that path's NCCL all-reduce works.
- **Fail-at-startup URL validation**: every parsed group member must be an `http(s)://` URL, so a comma inside a member URL (which would split into phantom members) fails at launch instead of mid-rollout.

## Ensemble semantics

- Mixture of raw probabilities **before** any weighting/renormalization — a mixture of renormalized truncations is not the truncation of the mixture. The result is the log-probability of the actual mixture distribution (arithmetic mean in probability space), not a geometric mean of logprobs.
- Sampled-token path (`top-k=0`): mixture at each sampled token, stored in `sample.teacher_log_probs` as before.
- Top-k path: ensembles require `--opd-top-k-strategy only_stu` (validated at startup) so every member is scored at the *same* student top-k ids per position and the per-id mixture is exact. A missing id in any member's response raises loudly.
- With `--opd-topk-tail-bucket`, the mixture tail equals the weighted average of member tails over the same id set, so the k+1-bucket KL stays exact for ensembles too.
- Everything downstream of `reward_func`/`post_process_rewards` is untouched — the loss never knows the teacher was a mixture.

**Deliberately not ported from slime 2033** (with reasons, from our review): colocated weight-swapped teachers (homogeneity constraint defeats the main OPD use case; serialized forwards inflate every step), the replacement `topk_opd_loss` (unclipped importance ratios, bf16 logprob arithmetic, forked train actor + module-global registry — their own PR body flags the pattern as provisional). A differentiable train-side bucket loss remains a possible 5/N, tracked separately.

## Files changed

- `miles/rollout/on_policy_distillation.py` — group parsing (`NAME=URL[@W][,...]`, last-`@` weight split so userinfo URLs survive), `_teacher_targets_for_sample`, parallel `_post_teacher_group` fan-out, `_mixture_log_probs` / `_mixture_logprob_maps` (float64 logsumexp), `_tail_bucket_reverse_kl`, retry + `_scoring_timeout`, metadata cleanup.
- `miles/utils/arguments.py` — the three flags + fail-fast validation (ensemble⇒`only_stu` when top-k>0, tail-bucket⇒`student_p`+top-k>0, positive timeout, all rejected without `--use-opd`).
- `miles/backends/training_utils/data.py` — CP slicing for OPD tensors.
- `miles/ray/rollout/train_data_conversion.py` — all-or-raise OPD key gate.
- `docs/advanced/on-policy-distillation.md` — "Teacher Ensembles" + "Tail-Mass Bucket" sections, Key Arguments rows.
- `examples/on_policy_distillation/run-qwen3-8B-opd-ensemble.sh` — Qwen3-8B student, Qwen3-32B + Qwen3-30B-A3B teachers mixed 2:1, tail bucket on. README updated.
- `tests/fast/rollout/test_on_policy_distillation.py` — 36 new tests (parsing groups/weights/userinfo-URLs/malformed, group routing, mixture math vs hand-computed values, tail-bucket KL incl. mass≥1 / floor / empty-set edges, ensemble end-to-end + non-`only_stu` rejection, retry classification + retry/no-retry/exhausted, timeout fallback, `reward_func` fan-out, ensemble `post_process_rewards`, metadata freeing, ensemble+tail-bucket with non-uniform weights vs hand-computed mixture KL, top-k `reward_func` fan-out, mixed-source strategy rejection).
- `tests/fast/ray/rollout/test_train_data_conversion.py` — 2 tests for the batch gate.

The diff was adversarially reviewed pre-submission (3 independent lenses + per-finding verification agents); all confirmed findings — tail-bucket strategy restriction, the Kimi-VL CP gaps, URL-scheme validation, timeout-flag guard — are fixed in this revision.

## Tests

80 passed locally (`tests/fast/rollout/test_on_policy_distillation.py` + `tests/fast/ray/rollout/test_train_data_conversion.py`, run standalone due to local env). `ruff check` clean; `bash -n` clean on the example script. Single-teacher and routing paths are covered by the existing 1314 tests, all updated and passing — single-URL behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
