### PR TITLE
fix(rollout): apply rollout sample filter in the manager

### DIFF
--- a/miles/ray/rollout/rollout_data_conversion.py
+++ b/miles/ray/rollout/rollout_data_conversion.py
@@ -1,6 +1,7 @@
 import itertools
 import logging
 
+from miles.utils.misc import load_function
 
 logger = logging.getLogger(__name__)
 
@@ -8,7 +9,11 @@ logger = logging.getLogger(__name__)
 def postprocess_rollout_data(args, data, train_parallel_config):
     metadata = {}
 
-    # flatten the data if it is a list of lists
+    # Generic choke point: every rollout fn honors --rollout-sample-filter-path here,
+    # while `data` is still grouped list[list[Sample]] (before the flatten below).
+    if (filter_func := load_function(args.rollout_sample_filter_path)) is not None:
+        filter_func(args, data)
+
     while isinstance(data[0], list):
         data = list(itertools.chain.from_iterable(data))
 

--- a/miles/rollout/inference_rollout/inference_rollout_train.py
+++ b/miles/rollout/inference_rollout/inference_rollout_train.py
@@ -147,9 +147,12 @@ async def generate_rollout_async(
     # reset the global state to prevent effects on the next rollout or eval.
     state.reset()
 
-    if f := load_function(args.rollout_sample_filter_path):
-        f(args, data)
+    # --rollout-sample-filter-path is now applied generically in the manager
+    # (RolloutManager._get_rollout_data -> postprocess_rollout_data), so it is
+    # no longer applied here to avoid double-filtering.
+
     # There can be circumstances where users want to process all samples including filtered ones.
+    # --rollout-all-samples-process-path stays here: it needs all_samples/data_source the manager lacks.
     if f := load_function(args.rollout_all_samples_process_path):
         f(args, all_samples, data_source)
 

--- a/miles/rollout/sglang_rollout.py
+++ b/miles/rollout/sglang_rollout.py
@@ -468,11 +468,12 @@ async def generate_rollout_async(
 
     # reset the global state to prevent effects on the next rollout or eval.
     state.reset()
-    if (x := args.rollout_sample_filter_path) is not None:
-        filter_func = load_function(x)
-        filter_func(args, data)
+    # --rollout-sample-filter-path is now applied generically in the manager
+    # (RolloutManager._get_rollout_data -> postprocess_rollout_data), so it is
+    # no longer applied here to avoid double-filtering.
 
     # There can be circumstances where users want to process all samples including filtered ones.
+    # --rollout-all-samples-process-path stays here: it needs all_samples/data_source the manager lacks.
     if (x := args.rollout_all_samples_process_path) is not None:
         process_func = load_function(x)
         process_func(args, all_samples, data_source)

--- a/tests/fast/ray/rollout/conftest.py
+++ b/tests/fast/ray/rollout/conftest.py
@@ -39,6 +39,8 @@ def make_args(**overrides: Any) -> Namespace:
         over_sampling_batch_size=None,
         rollout_global_dataset=False,
         num_rollout=1,
+        rollout_sample_filter_path=None,
+        rollout_all_samples_process_path=None,
         # batch / training
         global_batch_size=8,
         use_dynamic_global_batch_size=False,

--- a/tests/fast/ray/rollout/test_rollout_data_conversion.py
+++ b/tests/fast/ray/rollout/test_rollout_data_conversion.py
@@ -4,6 +4,7 @@ import pytest
 from tests.fast.ray.rollout.conftest import make_args, make_sample
 
 from miles.ray.rollout.rollout_data_conversion import _compute_dynamic_global_batch_size, postprocess_rollout_data
+from miles.utils.misc import function_registry
 
 
 class TestComputeDynamicGlobalBatchSize:
@@ -72,3 +73,90 @@ class TestPostprocessRolloutData:
         nested = [[make_sample(index=0), make_sample(index=1)], [make_sample(index=2)]]
         out, _meta = postprocess_rollout_data(args, nested, train_parallel_config={"dp_size": 1})
         assert len(out) == 3
+
+
+class TestRolloutSampleFilterIsAppliedGenerically:
+    """--rollout-sample-filter-path is honored at the single generic choke point
+    (postprocess_rollout_data, reached by RolloutManager._get_rollout_data for
+    EVERY rollout fn), not only inside the two built-in rollout fns. This is what
+    lets a custom --rollout-function-path honor the documented filter hook."""
+
+    def test_filter_receives_grouped_data_before_flatten(self):
+        """The filter must see the documented `fn(args, data)` contract: `data`
+        is the nested `list[list[Sample]]` grouped by n_samples_per_prompt,
+        BEFORE the flatten/trim. It flags Sample.remove_sample in place."""
+        seen: list = []
+
+        def drop_last_in_group(args, data):
+            # data is list[list[Sample]] grouped by n_samples_per_prompt.
+            seen.append([len(group) for group in data])
+            for group in data:
+                group[-1].remove_sample = True
+
+        args = make_args(
+            global_batch_size=2,
+            disable_rollout_trim_samples=True,
+            use_dynamic_global_batch_size=False,
+            rollout_sample_filter_path="test:drop_last_in_group",
+        )
+        nested = [
+            [make_sample(group_index=0, index=0), make_sample(group_index=0, index=1)],
+            [make_sample(group_index=1, index=2), make_sample(group_index=1, index=3)],
+        ]
+        with function_registry.temporary("test:drop_last_in_group", drop_last_in_group):
+            out, _meta = postprocess_rollout_data(args, nested, train_parallel_config={"dp_size": 1})
+
+        # The filter saw grouped data (two groups of two) before flattening.
+        assert seen == [[2, 2]]
+        # Output is flattened; the filter's in-place mutation is preserved.
+        assert len(out) == 4
+        assert [s.remove_sample for s in out] == [False, True, False, True]
+
+    def test_custom_rollout_fn_now_honors_filter_via_manager_path(self):
+        """A *custom* rollout fn (any --rollout-function-path) need not apply the
+        filter itself: its grouped output flows through postprocess_rollout_data,
+        which applies the documented hook. Previously this silently no-op'd for
+        custom fns because only the two built-in fns applied it in-fn."""
+
+        def custom_rollout_fn_output():
+            # Whatever a custom rollout fn produced: grouped, unfiltered.
+            return [
+                [make_sample(group_index=0, index=0, reward=1.0), make_sample(group_index=0, index=1, reward=0.0)],
+                [make_sample(group_index=1, index=2, reward=1.0), make_sample(group_index=1, index=3, reward=0.0)],
+            ]
+
+        def drop_zero_reward(args, data):
+            for group in data:
+                for sample in group:
+                    if sample.reward == 0.0:
+                        sample.remove_sample = True
+
+        args = make_args(
+            global_batch_size=2,
+            disable_rollout_trim_samples=True,
+            use_dynamic_global_batch_size=False,
+            rollout_sample_filter_path="test:drop_zero_reward",
+        )
+        with function_registry.temporary("test:drop_zero_reward", drop_zero_reward):
+            out, _meta = postprocess_rollout_data(
+                args, custom_rollout_fn_output(), train_parallel_config={"dp_size": 1}
+            )
+
+        # Zero-reward samples are flagged for loss exclusion; the consumer
+        # (train_data_conversion: remove_sample -> loss_mask=0) is already generic.
+        flagged = {s.index for s in out if s.remove_sample}
+        assert flagged == {1, 3}
+
+    def test_no_filter_path_is_a_no_op_default(self):
+        """Default path: rollout_sample_filter_path=None must not flag anything
+        and must leave the data bit-identical to the no-filter behavior."""
+        args = make_args(
+            global_batch_size=2,
+            disable_rollout_trim_samples=True,
+            use_dynamic_global_batch_size=False,
+            rollout_sample_filter_path=None,
+        )
+        nested = [[make_sample(index=0), make_sample(index=1)], [make_sample(index=2)]]
+        out, _meta = postprocess_rollout_data(args, nested, train_parallel_config={"dp_size": 1})
+        assert len(out) == 3
+        assert all(s.remove_sample is False for s in out)

--- a/tests/fast/rollout/inference_rollout/integration/test_sample_filter.py
+++ b/tests/fast/rollout/inference_rollout/integration/test_sample_filter.py
@@ -18,27 +18,40 @@ _FILTER_TEST_DATA_ROWS = [
     {"input": "What is 1+6?", "label": "7"},  # reward=1
 ]
 
+_FILTER_HOOK_ARGV = [
+    "--rollout-batch-size",
+    "2",
+    "--over-sampling-batch-size",
+    "4",
+    "--dynamic-sampling-filter-path",
+    "test:filter_by_reward",
+    "--rollout-sample-filter-path",
+    "test:sample_filter",
+    "--rollout-all-samples-process-path",
+    "test:all_samples_process",
+]
+
+# Appended after the modular defaults; argparse keeps the last occurrence, so
+# this routes the same test through the legacy built-in rollout fn, which must
+# equally not re-apply the sample filter the manager now owns.
+_LEGACY_ROLLOUT_FN_ARGV = [
+    "--rollout-function-path",
+    "miles.rollout.sglang_rollout.generate_rollout",
+    "--custom-generate-function-path",
+    "miles.rollout.sglang_rollout.generate",
+]
+
 
 @pytest.mark.parametrize(
     "rollout_env",
     [
         pytest.param(
-            integration_env_config(
-                [
-                    "--rollout-batch-size",
-                    "2",
-                    "--over-sampling-batch-size",
-                    "4",
-                    "--dynamic-sampling-filter-path",
-                    "test:filter_by_reward",
-                    "--rollout-sample-filter-path",
-                    "test:sample_filter",
-                    "--rollout-all-samples-process-path",
-                    "test:all_samples_process",
-                ],
-                data_rows=_FILTER_TEST_DATA_ROWS,
-            ),
+            integration_env_config(_FILTER_HOOK_ARGV, data_rows=_FILTER_TEST_DATA_ROWS),
             id="sample_filter_vs_all_samples",
+        ),
+        pytest.param(
+            integration_env_config(_FILTER_HOOK_ARGV + _LEGACY_ROLLOUT_FN_ARGV, data_rows=_FILTER_TEST_DATA_ROWS),
+            id="sample_filter_vs_all_samples_legacy_rollout_fn",
         ),
     ],
     indirect=True,
@@ -53,15 +66,22 @@ def test_sample_filter_and_all_samples_process(rollout_env):
         function_registry.temporary("test:sample_filter", sample_filter_mock),
         function_registry.temporary("test:all_samples_process", all_samples_process_mock),
     ):
-        load_and_call_train(env.args, env.data_source)
+        out = load_and_call_train(env.args, env.data_source)
 
-    sample_filter_mock.assert_called_once()
-    _, filtered_data = sample_filter_mock.call_args[0]
-    rewards = [g[0][0].reward if isinstance(g[0], list) else g[0].reward for g in filtered_data]
-    assert all(r == 1 for r in rewards)
+    # --rollout-sample-filter-path is applied generically in the manager
+    # (postprocess_rollout_data), NOT inside the rollout fn, so calling the
+    # rollout fn directly here must not invoke the sample filter. See
+    # tests/fast/ray/rollout/test_rollout_data_conversion.py for the
+    # manager-side coverage of the hoisted filter.
+    sample_filter_mock.assert_not_called()
 
+    # --rollout-all-samples-process-path stays in the rollout fn (it needs
+    # all_samples / data_source the manager lacks), so it is still applied here.
     all_samples_process_mock.assert_called_once()
     _, all_samples, data_source = all_samples_process_mock.call_args[0]
     assert data_source is not None
-
-    assert len(all_samples) > len(filtered_data), "all_samples_process should see more samples than sample_filter"
+    # all_samples is the full over-sampled set (4 prompts); the rollout output
+    # keeps only the dynamic-filter survivors (the 2 reward==1 prompts), so
+    # all_samples must strictly exceed the trained set.
+    trained = [s for group in out.samples for s in group]
+    assert len(all_samples) > len(trained) > 0


### PR DESCRIPTION
## Problem

The documented `--rollout-sample-filter-path` hook is silently ignored for any custom `--rollout-function-path`. The filter is applied only *inside* the two built-in rollout functions — `miles/rollout/sglang_rollout.py` (`generate_rollout_async`) and `miles/rollout/inference_rollout/inference_rollout_train.py` (`generate_rollout_async`). The producer side is non-generic, but the consumer side already is: `train_data_conversion.py` does `if sample.remove_sample: sample.loss_mask = [0] * response_length`. So when a user swaps in a custom rollout function whose output does not itself call the filter, the filter callable is never invoked, `remove_sample` is never set, and every sample reaches the loss unfiltered — with no error and no warning.

## Before vs After

Setup: `--rollout-sample-filter-path` points at a `drop_zero_reward` filter, used with a custom `--rollout-function-path` that emits the documented grouped `list[list[Sample]]` shape:

```python
# custom rollout fn output: 2 prompts x 2 samples, rewards [1.0, 0.0] per group
data = [
    [Sample(index=0, reward=1.0), Sample(index=1, reward=0.0)],
    [Sample(index=2, reward=1.0), Sample(index=3, reward=0.0)],
]

def drop_zero_reward(args, data):          # fn(args, data) contract
    for group in data:
        for s in group:
            if s.reward == 0.0:
                s.remove_sample = True
```

**Before** — the filter is never called for a custom rollout fn; nothing is flagged, so the zero-reward samples still contribute to the loss:

```python
{s.index for s in flat if s.remove_sample}   # == set()   (filter never ran)
# samples 1 and 3 (reward 0.0) keep loss_mask = [1, 1, ...] and train as positives
```

**After** — the same input flows through the manager choke point, the filter runs, and the zero-reward samples are flagged → `train_data_conversion` zeros their `loss_mask`:

```python
{s.index for s in flat if s.remove_sample}   # == {1, 3}
# samples 1 and 3 get loss_mask = [0, 0, ...] and are excluded from the loss
```

(This is exactly `test_custom_rollout_fn_now_honors_filter_via_manager_path` in the new test file.)

## Fix

Hoist the filter to the single generic choke point, `postprocess_rollout_data` in `miles/ray/rollout/rollout_data_conversion.py`, which is reached by `RolloutManager._get_rollout_data` for **every** rollout function:

```python
# Generic choke point: every rollout fn honors --rollout-sample-filter-path here,
# while `data` is still grouped list[list[Sample]] (before the flatten below).
if (filter_func := load_function(args.rollout_sample_filter_path)) is not None:
    filter_func(args, data)

while isinstance(data[0], list):
    data = list(itertools.chain.from_iterable(data))
```

The filter runs while `data` is still the documented grouped `list[list[Sample]]` — the `fn(args, data)` contract — *before* the existing flatten/trim, and flags `Sample.remove_sample` in place. The redundant in-function applications are removed from both built-in rollout functions (to avoid double-filtering), with a one-line comment left at each former call site pointing to the new owner.

Scope is kept deliberately tight:
- `--rollout-all-samples-process-path` stays inside the rollout functions: it needs `all_samples` / `data_source`, which the manager does not have.
- The `load_debug_rollout_data` path does not flow through `postprocess_rollout_data`, so the filter applies on the normal post-rollout path only.

## Why this is the right fix

- **Default-path safe / bit-identical when unset.** `load_function(None)` returns `None`, so the walrus-guarded block is a no-op when `--rollout-sample-filter-path` is not set; output is identical to before. Covered by `test_no_filter_path_is_a_no_op_default`.
- **Matches the documented-but-only-partially-implemented contract.** The arg help already specifies `fn(args, data)` with `data` as `list[list[Sample]]` grouped by `n_samples_per_prompt`, and `set sample.remove_sample = True` to exclude from loss. The new call site applies it on exactly that shape, before the flatten — generalizing the existing contract rather than changing it. No new flag is introduced; only *where* the existing argument is applied changes.
- **No new abstraction.** The choke point already existed and already owned the flatten/trim of grouped rollout data; the filter is one guarded line at the natural seam, and the consumer side (`remove_sample → loss_mask = 0`) is untouched.
- **CI-verifiable, torch-free.** New CPU tests in `tests/fast/ray/rollout/test_rollout_data_conversion.py` assert, via the manager path, that (1) the filter receives grouped `list[list[Sample]]` before the flatten, is invoked exactly once per batch, and its in-place mutation survives flattening, (2) a custom rollout fn's grouped output now honors the filter (the previously-broken case above), and (3) `rollout_sample_filter_path=None` flags nothing. The integration test (`tests/fast/rollout/inference_rollout/integration/test_sample_filter.py`) asserts the filter is no longer applied in-function — parametrized over **both** built-in rollout fns (the modular `InferenceRolloutFn` and the legacy `sglang_rollout.generate_rollout`), so reintroducing the in-function filter in either one fails as double-filtering — while all-samples-process is still applied in-function, asserted against the real over-sampling invariant (`all_samples` strictly exceeds the trained set). All run in the existing `tests/fast/` stage.