### PR TITLE
fix(grpo): count each rollout once under fan-out

### DIFF
--- a/miles/backends/training_utils/loss_hub/math_utils.py
+++ b/miles/backends/training_utils/loss_hub/math_utils.py
@@ -439,6 +439,75 @@ def get_grpo_returns(
     return returns
 
 
+def group_relative_advantages(
+    raw_rewards: list[float],
+    rollout_ids: list,
+    prompt_ids: list | None,
+    *,
+    n_samples_per_prompt: int,
+    rollout_batch_size: int,
+    std_normalization: bool,
+) -> list[float]:
+    """GRPO group-relative advantages with the *rollout* as the unit.
+
+    A rollout may be fanned into several training samples (segments) that share a
+    ``rollout_id`` -- the compaction / sub-agent / fork branches of one agent attempt. GRPO
+    compares attempts, so each rollout contributes its single outcome reward once: reduce to
+    one reward per ``rollout_id``, subtract the per-prompt group mean (optionally divide by
+    the group std), and broadcast the advantage back to every sample of the rollout.
+
+    When ``prompt_ids`` is present (every value non-``None``), rollouts are bucketed by
+    prompt id, so uneven rollout counts per prompt (e.g. dynamic sampling) still get true
+    per-prompt baselines. Without it, grouping is positional: reshape by
+    ``n_samples_per_prompt`` when counts match, else one global group. On the rigid default
+    path both groupings coincide and match the plain per-prompt group norm exactly.
+    """
+    if any(rid is None for rid in rollout_ids):
+        raise ValueError(
+            "every sample must carry a rollout id (Sample.index at the default call site); a None id "
+            "would silently merge unrelated samples into one rollout and zero out their advantages"
+        )
+
+    # Segments of a rollout share its outcome reward; take the first occurrence. Dict insertion
+    # order keeps the deduped rollout_ids in prompt-major order, so no parallel order list is needed.
+    reward_of_rollout: dict = {}
+    for rid, reward in zip(rollout_ids, raw_rewards, strict=True):
+        reward_of_rollout.setdefault(rid, reward)
+
+    if prompt_ids is not None and all(pid is not None for pid in prompt_ids):
+        prompt_of_rollout: dict = {}
+        for rid, pid in zip(rollout_ids, prompt_ids, strict=True):
+            if prompt_of_rollout.setdefault(rid, pid) != pid:
+                raise ValueError(
+                    f"rollout id {rid!r} appears under prompt ids {prompt_of_rollout[rid]!r} and {pid!r}; "
+                    "a rollout belongs to exactly one prompt"
+                )
+        rollouts_of_prompt: dict = {}
+        for rid, pid in prompt_of_rollout.items():
+            rollouts_of_prompt.setdefault(pid, []).append(rid)
+
+        advantage_of_rollout: dict = {}
+        for rids in rollouts_of_prompt.values():
+            bucket = torch.tensor([reward_of_rollout[rid] for rid in rids], dtype=torch.float)
+            bucket = bucket - bucket.mean(dim=-1, keepdim=True)
+            if std_normalization:
+                bucket = bucket / (bucket.std(dim=-1, keepdim=True) + 1e-6)
+            advantage_of_rollout.update(zip(rids, bucket.tolist(), strict=True))
+    else:
+        rollout_rewards = torch.tensor(list(reward_of_rollout.values()), dtype=torch.float)
+        if rollout_rewards.numel() == n_samples_per_prompt * rollout_batch_size:
+            grouped = rollout_rewards.reshape(-1, n_samples_per_prompt)
+        else:
+            # uneven rollout counts per prompt (e.g. dynamic sampling): one global group
+            grouped = rollout_rewards.view(-1, rollout_rewards.shape[-1])
+        grouped = grouped - grouped.mean(dim=-1, keepdim=True)
+        if std_normalization:
+            grouped = grouped / (grouped.std(dim=-1, keepdim=True) + 1e-6)
+        advantage_of_rollout = dict(zip(reward_of_rollout.keys(), grouped.flatten().tolist(), strict=True))
+
+    return [advantage_of_rollout[rid] for rid in rollout_ids]
+
+
 def get_reinforce_plus_plus_returns(
     rewards: torch.Tensor,
     kl: list[torch.Tensor],

--- a/miles/ray/rollout/train_data_conversion.py
+++ b/miles/ray/rollout/train_data_conversion.py
@@ -1,8 +1,8 @@
 from typing import Any
 
 import ray
-import torch
 
+from miles.backends.training_utils.loss_hub.math_utils import group_relative_advantages
 from miles.utils.ray_utils import Box
 from miles.utils.seqlen_balancing import get_seqlen_balanced_partitions
 from miles.utils.types import Sample
@@ -102,21 +102,24 @@ def _post_process_rewards(args, samples: list[Sample] | list[list[Sample]], cust
 
     raw_rewards = [sample.get_reward_value(args) for sample in samples]
     if args.advantage_estimator in ["grpo", "gspo", "reinforce_plus_plus_baseline"] and args.rewards_normalization:
-        # group norm
-        rewards = torch.tensor(raw_rewards, dtype=torch.float)
-        if rewards.shape[-1] == args.n_samples_per_prompt * args.rollout_batch_size:
-            rewards = rewards.reshape(-1, args.n_samples_per_prompt)
-        else:
-            # when samples count are not equal in each group
-            rewards = rewards.view(-1, rewards.shape[-1])
-        mean = rewards.mean(dim=-1, keepdim=True)
-        rewards = rewards - mean
-
-        if args.advantage_estimator in ["grpo", "gspo"] and args.grpo_std_normalization:
-            std = rewards.std(dim=-1, keepdim=True)
-            rewards = rewards / (std + 1e-6)
-
-        return raw_rewards, rewards.flatten().tolist()
+        # Sample.index defaults to None, so the helper raises on a None id rather than letting
+        # the dedup silently merge every unset sample into one rollout (advantage 0 everywhere).
+        rollout_ids = [sample.index for sample in samples]
+        # The data source sets group_index on every real path; custom rollouts that skip it
+        # fall back to positional grouping inside the helper.
+        prompt_ids = [sample.group_index for sample in samples]
+        if any(pid is None for pid in prompt_ids):
+            prompt_ids = None
+        std_normalization = args.advantage_estimator in ["grpo", "gspo"] and args.grpo_std_normalization
+        rewards = group_relative_advantages(
+            raw_rewards,
+            rollout_ids,
+            prompt_ids,
+            n_samples_per_prompt=args.n_samples_per_prompt,
+            rollout_batch_size=args.rollout_batch_size,
+            std_normalization=std_normalization,
+        )
+        return raw_rewards, rewards
 
     return raw_rewards, raw_rewards
 

--- a/tests/fast/backends/training_utils/loss/test_group_relative_advantages.py
+++ b/tests/fast/backends/training_utils/loss/test_group_relative_advantages.py
@@ -1,0 +1,143 @@
+"""GRPO group-relative advantage with the rollout (not the training sample) as the unit.
+
+Pins the reward-attribution contract for fanned agent rollouts: a rollout split into
+several segments (compaction / sub-agent / fork branches) that share a ``rollout_id``
+counts once in the per-prompt baseline, and every segment carries the rollout's advantage.
+In miles ``rollout_id`` is ``Sample.index`` and ``prompt_id`` is ``Sample.group_index`` --
+fanned segments are ``deepcopy`` of the same sample and therefore share both. With prompt
+ids the baseline is bucketed per prompt even when rollout counts are uneven; without them
+the legacy positional grouping is preserved verbatim.
+
+These tests are CPU-only (torch on CPU, no GPU) and live under ``tests/fast`` so the CI
+collector assigns them to the stage-a-cpu suite implicitly.
+"""
+
+import pytest
+import torch
+
+from miles.backends.training_utils.loss_hub.math_utils import group_relative_advantages
+
+
+def test_default_one_sample_per_rollout_is_plain_per_prompt_group_norm():
+    # 2 prompts x 2 rollouts, one sample each (unique rollout_ids) -> identity reduction.
+    advantages = group_relative_advantages(
+        [1.0, 3.0, 5.0, 11.0],
+        rollout_ids=[0, 1, 2, 3],
+        prompt_ids=[0, 0, 1, 1],
+        n_samples_per_prompt=2,
+        rollout_batch_size=2,
+        std_normalization=False,
+    )
+    assert advantages == pytest.approx([-1.0, 1.0, -3.0, 3.0])
+
+
+def test_rigid_input_is_bit_identical_to_legacy_reshape_group_norm():
+    # On the rigid default path (every prompt has exactly n_samples_per_prompt rollouts, in
+    # prompt-major order) the prompt buckets are exactly the legacy reshape rows, so the
+    # result must equal the previous inline reshape/mean/std computation bit for bit.
+    raw_rewards = [0.13, 0.71, 1.37, 2.93, 0.29, 1.11, 3.71, 0.017]
+    advantages = group_relative_advantages(
+        raw_rewards,
+        rollout_ids=list(range(8)),
+        prompt_ids=[0, 0, 0, 0, 1, 1, 1, 1],
+        n_samples_per_prompt=4,
+        rollout_batch_size=2,
+        std_normalization=True,
+    )
+
+    legacy = torch.tensor(raw_rewards, dtype=torch.float).reshape(-1, 4)
+    legacy = legacy - legacy.mean(dim=-1, keepdim=True)
+    legacy = legacy / (legacy.std(dim=-1, keepdim=True) + 1e-6)
+    assert advantages == legacy.flatten().tolist()
+
+
+def test_fanned_rollout_counts_once_and_segments_share_the_advantage():
+    # Rollout 1 (rollout_id 1) fans into two segments that repeat its outcome reward 3.0.
+    # The baseline is over the 4 rollouts, NOT the 5 samples, so each prompt's mean is
+    # unchanged by the fan-out: the two segments share rollout 1's advantage (+1), and
+    # rollout 0 stays at -1. A double-counting / global baseline would subtract
+    # mean([1,3,3,5,11]) or mean([1,3,5,11]) and shift these values.
+    advantages = group_relative_advantages(
+        [1.0, 3.0, 3.0, 5.0, 11.0],
+        rollout_ids=[0, 1, 1, 2, 3],
+        prompt_ids=[0, 0, 0, 1, 1],
+        n_samples_per_prompt=2,
+        rollout_batch_size=2,
+        std_normalization=False,
+    )
+    assert advantages == pytest.approx([-1.0, 1.0, 1.0, -3.0, 3.0])
+
+
+def test_std_normalization_divides_by_per_prompt_group_std():
+    advantages = group_relative_advantages(
+        [0.0, 2.0, 10.0, 14.0],
+        rollout_ids=[0, 1, 2, 3],
+        prompt_ids=[0, 0, 1, 1],
+        n_samples_per_prompt=2,
+        rollout_batch_size=2,
+        std_normalization=True,
+    )
+    # Each prompt has two rollouts symmetric about the mean, so both prompts normalize to
+    # +-1/sqrt(2) regardless of scale (unbiased std), confirming per-prompt std division.
+    assert advantages == pytest.approx([-0.70710, 0.70710, -0.70710, 0.70710], abs=1e-4)
+
+
+def test_uneven_groups_get_per_prompt_baselines():
+    # 3 rollouts on prompt 0, 2 on prompt 1 (5 != 2 * 2): the legacy positional path could
+    # only fall back to one global group (mean 6.0 -> [-5, -4, -3, 4, 8]); prompt ids
+    # recover the true per-prompt centering instead.
+    advantages = group_relative_advantages(
+        [1.0, 2.0, 3.0, 10.0, 14.0],
+        rollout_ids=[0, 1, 2, 3, 4],
+        prompt_ids=[0, 0, 0, 1, 1],
+        n_samples_per_prompt=2,
+        rollout_batch_size=2,
+        std_normalization=False,
+    )
+    assert advantages == pytest.approx([-1.0, 0.0, 1.0, -2.0, 2.0])
+    assert advantages != pytest.approx([-5.0, -4.0, -3.0, 4.0, 8.0])
+
+
+def test_without_prompt_ids_uneven_counts_fall_back_to_one_global_group():
+    # 3 rollouts when 4 are expected and no prompt metadata -> single global group
+    # (the documented legacy fallback for custom rollout paths).
+    advantages = group_relative_advantages(
+        [1.0, 2.0, 3.0],
+        rollout_ids=[0, 1, 2],
+        prompt_ids=None,
+        n_samples_per_prompt=2,
+        rollout_batch_size=2,
+        std_normalization=False,
+    )
+    assert advantages == pytest.approx([-1.0, 0.0, 1.0])
+
+
+def test_none_rollout_id_raises():
+    # Sample.index defaults to None; without the guard, the dedup would silently merge all
+    # None-id samples into one rollout and zero out their advantages. prompt_ids is absent
+    # here (the custom-rollout scenario that hits this), so only the guard can catch it.
+    with pytest.raises(ValueError, match="rollout id"):
+        group_relative_advantages(
+            [1.0, 3.0, 5.0, 11.0],
+            rollout_ids=[None, None, None, None],
+            prompt_ids=None,
+            n_samples_per_prompt=2,
+            rollout_batch_size=2,
+            std_normalization=False,
+        )
+
+
+def test_rollout_id_spanning_two_prompts_raises():
+    with pytest.raises(ValueError, match="exactly one prompt"):
+        group_relative_advantages(
+            [1.0, 3.0, 5.0, 11.0],
+            rollout_ids=[0, 1, 1, 2],
+            prompt_ids=[0, 0, 1, 1],
+            n_samples_per_prompt=2,
+            rollout_batch_size=2,
+            std_normalization=False,
+        )
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__]))


### PR DESCRIPTION
## Problem

GRPO compares attempts within a prompt, so each rollout must contribute its single outcome reward exactly **once** to **its own prompt's** baseline. `_post_process_rewards` (in `miles/ray/rollout/train_data_conversion.py`) builds a flat reward vector over *samples* and reshapes it positionally:

```python
rewards = torch.tensor(raw_rewards, dtype=torch.float)
if rewards.shape[-1] == args.n_samples_per_prompt * args.rollout_batch_size:
    rewards = rewards.reshape(-1, args.n_samples_per_prompt)
else:
    # when sample count is not equal in each group
    rewards = rewards.view(-1, rewards.shape[-1])  # one global group
```

That breaks the invariant in three ways:

1. **Fan-out double counting.** `multi_turn` / `agentic_tool_call` rollouts fan one agent attempt into several training samples (the compaction / sub-agent / fork branches), returned as a `list[Sample]` of `deepcopy` segments that all share the same `Sample.index`. Any fan-out makes the flat sample count exceed `n_samples_per_prompt * rollout_batch_size`, so the guard collapses **every prompt into a single global group**, and a rollout that happens to emit more segments is counted once per segment in that baseline.
2. **Silent None collapse.** Any fix that re-keys the baseline on `Sample.index` has to confront that `Sample.index` *defaults to `None`*. A rollout path that never assigns it would feed all-`None` ids into the dedup, silently merging **every sample into one "rollout"**: one reward survives, the group mean equals it, and every advantage comes out exactly `0.0` — training quietly learns nothing. The id contract must fail loudly, not fall back.
3. **Global-mean fallback for uneven groups.** When rollout counts per prompt are genuinely uneven (e.g. dynamic sampling), position alone cannot recover the prompt structure, so the old code could only center everything against one global mean — even though every sample already carries its prompt id in `Sample.group_index` (assigned by the data source alongside `index`, and already used by the rollout metrics to group samples per prompt).

## Before vs After

Take a batch of `n_samples_per_prompt=2`, `rollout_batch_size=2` (so 4 rollouts, 2 prompts), where rollout `1` fans into 2 segments that repeat its outcome reward `3.0`:

```python
raw_rewards = [1.0, 3.0, 3.0, 5.0, 11.0]
rollout_ids = [  0,   1,   1,   2,    3]   # Sample.index; rollout 1 emitted 2 segments
prompt_ids  = [  0,   0,   0,   1,    1]   # Sample.group_index
```

**Before** — 5 samples != `2 * 2 = 4`, so the guard collapses all 5 into one global group and subtracts the global mean `4.6`:

```text
advantages = [-3.6, -1.6, -1.6, 0.4, 6.4]
```

Prompt structure is gone, and rollout `1`'s reward is counted twice in the baseline.

**After** — reduce to one reward per rollout `[1, 3, 5, 11]`, bucket by prompt `[[1, 3], [5, 11]]`, center within each prompt, then broadcast each rollout's advantage back to its segments:

```text
advantages = [-1.0, 1.0, 1.0, -3.0, 3.0]
```

Rollout `1` counts once (its two segments both carry `+1.0`), and prompt 0's mean is unaffected by the fan-out. Pinned by `tests/fast/.../test_group_relative_advantages.py::test_fanned_rollout_counts_once_and_segments_share_the_advantage`.

## Fix

Make the **rollout** the unit of the baseline and the **prompt id** the group key. A new pure helper `group_relative_advantages(raw_rewards, rollout_ids, prompt_ids, *, ...)` (in `loss_hub/math_utils.py`):

1. **raises `ValueError` if any rollout id is `None`** — the silent-collapse hazard above, named in the error message;
2. reduces raw rewards to one reward per rollout id, keeping the first occurrence (dict insertion order preserves prompt-major sample order);
3. **when prompt ids are present** (every value non-`None`): buckets the deduped rollouts by prompt id, validating each rollout id maps to exactly one prompt (raises on conflict), centers each bucket on its mean and optionally divides by the unbiased std + `1e-6` — the identical ops/eps/dtype as the old reshape rows; **otherwise** (metadata absent — custom rollout paths): the legacy positional behavior verbatim, reshape when counts match, else one global group;
4. broadcasts each rollout's advantage back to all of its segments.

`_post_process_rewards` passes `rollout_ids = [s.index for s in samples]` and `prompt_ids = [s.group_index for s in samples]` (collapsed to `None` if any sample lacks it).

## Why this is the right fix

- **Bit-identical default path.** On the rigid path (every prompt exactly `n_samples_per_prompt` single-sample rollouts, prompt-major order) the prompt buckets are exactly the old reshape rows, so non-agentic training is unchanged — `test_rigid_input_is_bit_identical_to_legacy_reshape_group_norm` asserts *exact* float equality against the previous inline computation, std normalization included.
- **Fails loudly, never silently wrong.** Missing rollout ids raise instead of zeroing every advantage (`test_none_rollout_id_raises`), and a rollout id spanning two prompts raises instead of being mis-bucketed (`test_rollout_id_spanning_two_prompts_raises`).
- **Deliberate behavior fix for uneven batches.** The data source assigns `group_index` on every real path, so dynamic-sampling / uneven-count batches now get **true per-prompt baselines** instead of the old global-mean fallback — `test_uneven_groups_get_per_prompt_baselines` pins the per-prompt centering and that it differs from the old global result.
- **Metadata-less custom rollouts see zero change.** Without `group_index` the helper reproduces the legacy positional grouping verbatim, including the documented global-group fallback (`test_without_prompt_ids_uneven_counts_fall_back_to_one_global_group`).
- **Minimal, CI-verifiable, no new abstraction.** One pure function plus a small call-site change; the new tests are CPU-only (torch on CPU, no GPU) and live under `tests/fast/`, so the collector auto-assigns them to the `stage-a-cpu` suite with no workflow change.