### PR TITLE
fix(metrics): group pass-rate by real sample identity

### DIFF
--- a/miles/backends/training_utils/log_utils.py
+++ b/miles/backends/training_utils/log_utils.py
@@ -318,8 +318,8 @@ def log_passrate(rollout_id: int, args: Namespace, rollout_data: RolloutBatch) -
     """
     Compute pass@k metrics from `raw_reward` groups and log the results.
 
-    `raw_reward` is reshaped to `[group_number, group_size]`, then pass@k is
-    estimated per problem and averaged.
+    `raw_reward` is bucketed by the per-prompt `group_indices` (full-batch,
+    aligned with `raw_reward`), then pass@k is estimated per group and averaged.
     """
     parallel_state = get_parallel_state()
     if parallel_state.tp.rank == 0 and parallel_state.is_pp_last_stage:
@@ -328,10 +328,18 @@ def log_passrate(rollout_id: int, args: Namespace, rollout_data: RolloutBatch) -
             if key != "raw_reward":
                 continue
 
+            # Over-sampling / dynamic-sampling filters / aborted groups make the
+            # flat reward count not an exact multiple of rollout_batch_size *
+            # n_samples_per_prompt; bucket by the group_index assigned at sample
+            # creation. Rewards without group identity (e.g. from custom
+            # conversion functions) fall back to contiguous chunking.
+            group_ids = rollout_data.get("group_indices")
+            if group_ids is not None and any(i is None for i in group_ids):
+                group_ids = None
             log_dict |= compute_pass_rate(
                 flat_rewards=val,
                 group_size=args.n_samples_per_prompt,
-                num_groups=args.rollout_batch_size,
+                group_ids=group_ids,
             )
 
         gather_log_data("passrate", args, rollout_id, log_dict)

--- a/miles/ray/rollout/metrics.py
+++ b/miles/ray/rollout/metrics.py
@@ -35,10 +35,20 @@ def log_eval_rollout_data(rollout_id, args, data, extra_metrics: dict[str, Any] 
             truncated = data[key]["truncated"]
             log_dict[f"eval/{key}-truncated_ratio"] = sum(truncated) / len(truncated)
         if args.log_passrate:
+            # Multi-turn / tool eval list-expands a prompt into variable sample
+            # counts; bucket by the per-prompt group_index assigned at sample
+            # creation. Samples without group identity (e.g. from custom eval
+            # rollout functions) fall back to contiguous chunking.
+            group_ids = None
+            if (samples := data[key].get("samples")) is not None:
+                ids = [s.group_index for s in samples]
+                if all(i is not None for i in ids):
+                    group_ids = ids
             log_dict |= dict_add_prefix(
                 compute_pass_rate(
                     flat_rewards=rewards,
                     group_size=args.n_samples_per_eval_prompt,
+                    group_ids=group_ids,
                 ),
                 f"eval/{key}-",
             )

--- a/miles/ray/rollout/train_data_conversion.py
+++ b/miles/ray/rollout/train_data_conversion.py
@@ -37,6 +37,9 @@ def convert_samples_to_train_data(
         "raw_reward": raw_rewards,
         "truncated": [1 if sample.status == Sample.Status.TRUNCATED else 0 for sample in samples],
         "sample_indices": [sample.index for sample in samples],
+        # group identity for raw_reward, e.g. pass@k bucketing; kept full-batch
+        # (not DP-partitioned) so it stays aligned with raw_reward.
+        "group_indices": [sample.group_index for sample in samples],
     }
 
     # loss mask
@@ -166,6 +169,7 @@ def split_train_data_by_dp(args, data, dp_size):
         # keys that need to be splited at train side
         for key in [
             "raw_reward",
+            "group_indices",
             "total_lengths",
             "dynamic_global_batch_size",
         ]:

--- a/miles/rollout/inference_rollout/inference_rollout_eval.py
+++ b/miles/rollout/inference_rollout/inference_rollout_eval.py
@@ -59,10 +59,11 @@ async def eval_rollout_single_dataset(
     tasks = []
     # do multiple samples for eval prompts
     sample_index = 0
-    for _i, prompt_sample in enumerate(dataset.samples):
+    for group_index, prompt_sample in enumerate(dataset.samples):
         for j in range(dataset_cfg.n_samples_per_eval_prompt):
             # use the same prompt for multiple samples
             sample = copy.deepcopy(prompt_sample)
+            sample.group_index = group_index
             sample.index = sample_index
             sample_index += 1
             sample.metadata = dataset_cfg.inject_metadata(getattr(sample, "metadata", None))

--- a/miles/rollout/sglang_rollout.py
+++ b/miles/rollout/sglang_rollout.py
@@ -553,10 +553,11 @@ async def eval_rollout_single_dataset(
     tasks = []
     # do multiple samples for eval prompts
     sample_index = 0
-    for _i, prompt_sample in enumerate(dataset.samples):
+    for group_index, prompt_sample in enumerate(dataset.samples):
         for j in range(dataset_cfg.n_samples_per_eval_prompt):
             # use the same prompt for multiple samples
             sample = copy.deepcopy(prompt_sample)
+            sample.group_index = group_index
             sample.index = sample_index
             sample_index += 1
             sample.metadata = dataset_cfg.inject_metadata(getattr(sample, "metadata", None))

--- a/miles/utils/metric_utils.py
+++ b/miles/utils/metric_utils.py
@@ -1,4 +1,5 @@
 import math
+from collections import defaultdict
 from typing import Any, Literal
 
 import numpy as np
@@ -11,28 +12,54 @@ def dict_add_prefix(d: dict[str, Any], prefix: str) -> dict[str, Any]:
 def compute_pass_rate(
     flat_rewards: list[float],
     group_size: int,
-    num_groups: int | None = None,
+    group_ids: list | None = None,
 ):
+    """Compute pass@k from a flat list of rewards.
+
+    Groups are formed one of two ways:
+
+    * ``group_ids`` given: bucket ``flat_rewards`` by the per-sample group key.
+      This is the ragged-safe path -- groups may have any (variable) number of
+      samples, e.g. over-sampling, dynamic-sampling filters, aborted/partial
+      groups, or list-expanded multi-turn/tool eval samples.
+    * ``group_ids`` is ``None``: chunk ``flat_rewards`` into contiguous
+      ``group_size`` blocks. This assumes a group-major layout (each group's
+      rewards adjacent, every group full-size) and tolerates only trailing
+      raggedness: a final partial block is kept as a smaller group, while
+      interior raggedness silently mis-groups -- pass ``group_ids`` for that.
+      For exact-multiple input this is numerically identical to the legacy
+      ``reshape(num_groups, group_size)`` path.
+
+    For each ``k`` in the pass@k list, pass@k is averaged only over groups with
+    at least ``k`` samples; undersized groups are skipped and a rung is dropped
+    entirely when no group qualifies.
+    """
     if group_size == 1:
         return {}
 
-    if num_groups is None:
-        num_groups = len(flat_rewards) // group_size
-
     pass_rate_name_list = [2**i for i in range(int(math.log2(group_size)) + 1)]
 
-    assert len(flat_rewards) == num_groups * group_size, f"{len(flat_rewards)=} {num_groups=} {group_size=}"
-    rewards_of_group = np.array(flat_rewards).reshape(num_groups, group_size)
+    if group_ids is not None:
+        assert len(group_ids) == len(flat_rewards), f"{len(group_ids)=} {len(flat_rewards)=}"
+        buckets: dict[Any, list[float]] = defaultdict(list)
+        for reward, gid in zip(flat_rewards, group_ids, strict=True):
+            buckets[gid].append(reward)
+        groups = [np.array(rewards) for rewards in buckets.values()]
+    else:
+        rewards = np.asarray(flat_rewards)
+        groups = [rewards[i : i + group_size] for i in range(0, len(rewards), group_size)]
+
+    group_sizes = np.array([len(g) for g in groups])
+    group_correct = np.array([int(np.sum(g == 1)) for g in groups])
 
     log_dict = {}
     for k in pass_rate_name_list:
-        num_correct = np.sum(rewards_of_group == 1, axis=1)
-        num_samples = np.full(num_groups, group_size)
+        eligible = group_sizes >= k
+        if not eligible.any():
+            continue
 
-        pass_k_estimates = _estimate_pass_at_k(num_samples, num_correct, k)
-
-        pass_k = np.mean(pass_k_estimates)
-        log_dict[f"pass@{k}"] = pass_k
+        pass_k_estimates = _estimate_pass_at_k(group_sizes[eligible], group_correct[eligible], k)
+        log_dict[f"pass@{k}"] = np.mean(pass_k_estimates)
 
     return log_dict
 

--- a/tests/fast/ray/rollout/test_metrics.py
+++ b/tests/fast/ray/rollout/test_metrics.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import pytest
-from tests.fast.ray.rollout.conftest import make_args, make_samples_grouped
+from tests.fast.ray.rollout.conftest import make_args, make_sample, make_samples_grouped
 
-from miles.ray.rollout.metrics import _compute_metrics_from_samples, _compute_zero_std_metrics
+from miles.ray.rollout.metrics import _compute_metrics_from_samples, _compute_zero_std_metrics, log_eval_rollout_data
 
 
 class TestComputeZeroStdMetrics:
@@ -47,6 +47,32 @@ class TestComputeZeroStdMetrics:
         # No groups → no all_zero/all_one keys (the function guards on total_groups>0).
         assert "zero_std/all_zero_percentage" not in out
         assert "zero_std/all_one_percentage" not in out
+
+
+class TestLogEvalRolloutDataPassRate:
+    def test_buckets_by_group_index_not_position(self):
+        """Per-dataset n_samples_per_eval_prompt overrides make the true group
+        stride (4) differ from args.n_samples_per_eval_prompt (2); grouping must
+        follow each sample's group_index, not its position or index arithmetic."""
+        args = make_args(log_passrate=True, n_samples_per_eval_prompt=2, wandb_always_use_train_step=False)
+        rewards = [1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+        samples = [make_sample(group_index=i // 4, index=i, reward=r) for i, r in enumerate(rewards)]
+        out = log_eval_rollout_data(0, args, {"toy": {"rewards": rewards, "samples": samples}})
+        # group 0: n=4, c=2 -> pass@2 = 1 - C(2,2)/C(4,2) = 5/6; group 1: 0.
+        # Positional pairing would give mean(1, 0, 0, 0) = 0.25 instead.
+        assert out["eval/toy-pass@1"] == pytest.approx((0.5 + 0.0) / 2)
+        assert out["eval/toy-pass@2"] == pytest.approx((5 / 6 + 0.0) / 2)
+
+    def test_falls_back_to_chunking_without_group_index(self):
+        """Samples from custom eval rollout functions may carry no group_index;
+        a ragged (non-multiple) reward count must still not crash."""
+        args = make_args(log_passrate=True, n_samples_per_eval_prompt=2, wandb_always_use_train_step=False)
+        rewards = [1.0, 0.0, 1.0, 0.0, 1.0]
+        samples = [make_sample(group_index=None, index=i, reward=r) for i, r in enumerate(rewards)]
+        out = log_eval_rollout_data(0, args, {"toy": {"rewards": rewards, "samples": samples}})
+        # chunks: [1,0], [1,0], [1]
+        assert out["eval/toy-pass@1"] == pytest.approx((0.5 + 0.5 + 1.0) / 3)
+        assert out["eval/toy-pass@2"] == pytest.approx(1.0)
 
 
 class TestTitoMismatchMetrics:

--- a/tests/fast/ray/rollout/test_train_data_conversion.py
+++ b/tests/fast/ray/rollout/test_train_data_conversion.py
@@ -43,10 +43,24 @@ class TestConvertSamplesToTrainData:
             "raw_reward",
             "truncated",
             "sample_indices",
+            "group_indices",
             "loss_masks",
         ):
             assert key in out, f"missing required key {key}"
         assert len(out["tokens"]) == len(samples)
+
+    def test_group_indices_align_with_raw_reward(self):
+        args = make_args(rewards_normalization=False)
+        samples = make_samples_grouped(n_groups=2, group_size=3)
+        out = convert_samples_to_train_data(
+            args,
+            samples,
+            metadata={},
+            custom_convert_samples_to_train_data_func=None,
+            custom_reward_post_process_func=None,
+        )
+        assert out["group_indices"] == [0, 0, 0, 1, 1, 1]
+        assert len(out["group_indices"]) == len(out["raw_reward"])
 
     def test_loss_mask_none_filled_with_ones(self):
         args = make_args(rewards_normalization=False)
@@ -438,7 +452,9 @@ class TestSplitTrainDataByDp:
         assert "round_number" in parts[0]
 
     def test_shared_keys_not_split(self):
-        """raw_reward, total_lengths, dynamic_global_batch_size are shared, not split."""
+        """raw_reward, group_indices, total_lengths, dynamic_global_batch_size are
+        shared, not split — group_indices must stay aligned with the full-batch
+        raw_reward on every rank."""
         args = make_args(balance_data=False)
         data = {
             "tokens": [[1], [2], [3], [4]],
@@ -448,12 +464,14 @@ class TestSplitTrainDataByDp:
             "loss_masks": [[1]] * 4,
             "sample_indices": [0, 1, 2, 3],
             "raw_reward": [9.0, 8.0, 7.0, 6.0],
+            "group_indices": [0, 0, 1, 1],
             "dynamic_global_batch_size": 4,
         }
         refs = split_train_data_by_dp(args, data, dp_size=2)
         parts = [ray.get(r.inner) for r in refs]
         for p in parts:
             assert p["raw_reward"] == [9.0, 8.0, 7.0, 6.0]
+            assert p["group_indices"] == [0, 0, 1, 1]
             assert p["dynamic_global_batch_size"] == 4
 
     def test_partition_indices_form_a_partition(self):

--- a/tests/fast/rollout/inference_rollout/integration/test_basic.py
+++ b/tests/fast/rollout/inference_rollout/integration/test_basic.py
@@ -66,4 +66,4 @@ def test_eval(rollout_env):
     samples = out.data["toy"]["samples"]
     assert len(rewards) == len(samples) == env.args.n_samples_per_eval_prompt
     assert rewards[0] == 1
-    assert samples[0] == expected_sample(group_index=None)
+    assert samples[0] == expected_sample(group_index=0)

--- a/tests/fast/utils/test_metric_utils.py
+++ b/tests/fast/utils/test_metric_utils.py
@@ -1,0 +1,109 @@
+"""CPU tests for ragged-safe pass@k in miles.utils.metric_utils."""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from miles.utils.metric_utils import _estimate_pass_at_k, compute_pass_rate
+
+
+def _legacy_pass_rate(flat_rewards: list[float], group_size: int, num_groups: int) -> dict[str, float]:
+    """The pre-fix implementation: assert exact multiple, reshape, average pass@k."""
+    if group_size == 1:
+        return {}
+    pass_rate_name_list = [2**i for i in range(int(math.log2(group_size)) + 1)]
+    assert len(flat_rewards) == num_groups * group_size
+    rewards_of_group = np.array(flat_rewards).reshape(num_groups, group_size)
+    log_dict = {}
+    for k in pass_rate_name_list:
+        num_correct = np.sum(rewards_of_group == 1, axis=1)
+        num_samples = np.full(num_groups, group_size)
+        log_dict[f"pass@{k}"] = np.mean(_estimate_pass_at_k(num_samples, num_correct, k))
+    return log_dict
+
+
+class TestLegacyEquivalence:
+    """group_ids=None default path is bit-identical to the legacy reshape for
+    well-formed (exact-multiple) input."""
+
+    @pytest.mark.parametrize(
+        "rewards,group_size,num_groups",
+        [
+            ([1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 1.0], 4, 2),
+            ([1.0, 1.0, 0.0, 0.0], 2, 2),
+            ([0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0], 4, 2),
+            ([1.0] * 8, 8, 1),
+        ],
+    )
+    def test_default_path_matches_legacy(self, rewards, group_size, num_groups):
+        legacy = _legacy_pass_rate(rewards, group_size, num_groups)
+        new = compute_pass_rate(rewards, group_size=group_size)
+        assert new.keys() == legacy.keys()
+        for k in legacy:
+            assert new[k] == pytest.approx(legacy[k])
+
+    def test_group_size_one_short_circuits(self):
+        assert compute_pass_rate([1.0, 0.0, 1.0], group_size=1) == {}
+
+
+class TestRaggedDoesNotCrash:
+    def test_train_oversampled_flat_count_no_longer_asserts(self):
+        """TRAIN reproduction: 9 rewards with group_size=4 is not an exact
+        multiple (the legacy reshape raised). New code chunks into
+        [1,0,1,1] (c=3,n=4), [0,0,1,0] (c=1,n=4), [1] (c=1,n=1)."""
+        rewards = [1.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 0.0, 1.0]
+        with pytest.raises(AssertionError):
+            # legacy asserted len == num_groups * group_size (9 != 2 * 4)
+            _legacy_pass_rate(rewards, group_size=4, num_groups=2)
+
+        out = compute_pass_rate(rewards, group_size=4)
+        # pass@1 = mean(3/4, 1/4, 1) over all three groups.
+        assert out["pass@1"] == pytest.approx(np.mean([3 / 4, 1 / 4, 1.0]))
+        # pass@2 eligible groups (size>=2): [1,0,1,1]->1.0, [0,0,1,0]->0.5.
+        assert out["pass@2"] == pytest.approx(np.mean([1.0, 0.5]))
+        # pass@4 eligible groups (size>=4): both fully sampled -> 1.0 each.
+        assert out["pass@4"] == pytest.approx(1.0)
+
+    def test_eval_list_expanded_group_ids_bucket_correctly(self):
+        """EVAL reproduction: list-expanded multi-turn samples give a ragged,
+        non-multiple reward count. Bucketing by per-prompt group_ids must group
+        them by prompt regardless of expansion."""
+        # prompt 0 -> 3 samples (one generation list-expanded), prompt 1 -> 2 samples.
+        rewards = [1.0, 0.0, 1.0, 0.0, 1.0]
+        group_ids = [0, 0, 0, 1, 1]
+        out = compute_pass_rate(rewards, group_size=2, group_ids=group_ids)
+        assert set(out.keys()) == {"pass@1", "pass@2"}
+        # prompt 0 -> [1,0,1] (c=2,n=3), prompt 1 -> [0,1] (c=1,n=2).
+        # pass@1: P(>=1 correct in 1 draw) = c/n per group, averaged.
+        assert out["pass@1"] == pytest.approx(np.mean([2 / 3, 1 / 2]))
+        # pass@2: every group has >=1 correct, so each group's pass@2 is 1.0.
+        assert out["pass@2"] == pytest.approx(1.0)
+
+    def test_group_ids_length_mismatch_asserts(self):
+        with pytest.raises(AssertionError):
+            compute_pass_rate([1.0, 0.0, 1.0], group_size=2, group_ids=[0, 0])
+
+
+class TestRungEligibility:
+    def test_high_rung_dropped_when_all_groups_undersized(self):
+        """Every group has 1 sample, so pass@2 (and above) has no eligible group
+        and that rung is dropped; pass@1 survives."""
+        rewards = [1.0, 0.0, 1.0]
+        group_ids = [0, 1, 2]
+        out = compute_pass_rate(rewards, group_size=4, group_ids=group_ids)
+        assert "pass@1" in out
+        assert "pass@2" not in out
+        assert "pass@4" not in out
+
+    def test_rung_averages_only_over_eligible_groups(self):
+        """One full group (size 4) and one undersized group (size 1): pass@4 is
+        computed only over the eligible size-4 group, not dragged by the
+        singleton."""
+        rewards = [1.0, 1.0, 1.0, 1.0, 0.0]
+        group_ids = [0, 0, 0, 0, 1]
+        out = compute_pass_rate(rewards, group_size=4, group_ids=group_ids)
+        assert out["pass@4"] == pytest.approx(1.0)
+        assert out["pass@1"] == pytest.approx(0.5)


### PR DESCRIPTION
## Problem

`compute_pass_rate` (in `miles/utils/metric_utils.py`) hard-codes a rigid shape: it runs `assert len(flat_rewards) == num_groups * group_size` and then `np.array(flat_rewards).reshape(num_groups, group_size)`. Both call sites can feed it a flat reward count that is *not* an exact multiple of `group_size`, so the assert (or reshape) raises:

- **Train** — `log_passrate` in `miles/backends/training_utils/log_utils.py` pinned `num_groups=args.rollout_batch_size`. Under over-sampling, dynamic-sampling filtering, or aborted/partial groups, the flat reward count is not `rollout_batch_size * n_samples_per_prompt`, so the reshape raises.
- **Eval** — `log_eval_rollout_data` in `miles/ray/rollout/metrics.py` passed `num_groups=None`, which makes the function infer `num_groups = len(flat_rewards) // group_size`. Multi-turn / tool eval list-expands a single prompt into a *variable* number of samples, so the reward count is not a clean multiple of `n_samples_per_eval_prompt` and the assert raises.

And even when the count happens to divide cleanly, positional grouping can silently mis-group: list expansion shifts every later sample's position, and a per-dataset `n_samples_per_eval_prompt` override changes the true group stride away from `args.n_samples_per_eval_prompt`.

## Before vs After

Same input, train over-sampled shape — `9` rewards with `group_size=4` (not a multiple of 4):

```python
rewards = [1.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 0.0, 1.0]

# BEFORE (legacy): num_groups pinned to 2 -> assert 9 == 2 * 4 fails
compute_pass_rate(rewards, group_size=4, num_groups=2)
# AssertionError: len(flat_rewards)=9 num_groups=2 group_size=4
```

```python
# AFTER: chunked into [1,0,1,1] (c=3,n=4), [0,0,1,0] (c=1,n=4), [1] (c=1,n=1)
compute_pass_rate(rewards, group_size=4)
# {'pass@1': 0.666...,   # mean(3/4, 1/4, 1.0) over all 3 groups
#  'pass@2': 0.75,       # eligible groups (size>=2): [1,0,1,1]->1.0, [0,0,1,0]->0.5
#  'pass@4': 1.0}        # eligible groups (size>=4): both fully sampled -> 1.0
```

Eval list-expanded shape — `5` rewards from `2` prompts (prompt 0 expanded to 3 samples), bucketed by the per-prompt `group_index` each sample now carries:

```python
rewards   = [1.0, 0.0, 1.0, 0.0, 1.0]
group_ids = [0,   0,   0,   1,   1]   # s.group_index, assigned at sample creation

# BEFORE: 5 is not a multiple of group_size=2 -> assert raises
# AFTER:
compute_pass_rate(rewards, group_size=2, group_ids=group_ids)
# prompt 0 -> [1,0,1] (c=2,n=3), prompt 1 -> [0,1] (c=1,n=2)
# {'pass@1': 0.583...,  # mean(2/3, 1/2)
#  'pass@2': 1.0}       # every group has >=1 correct
```

## Fix

Replace the `num_groups` parameter with an optional `group_ids` and group rewards by real per-sample identity instead of positional arithmetic:

- **Utility** — `group_ids` given: bucket `flat_rewards` by the per-sample group key; groups may have any number of samples. `group_ids is None`: chunk `flat_rewards` into contiguous `group_size` blocks, keeping a trailing partial block as a smaller group instead of asserting an exact multiple. The docstring states what the fallback assumes: a group-major layout (each group's rewards adjacent, every group full-size), tolerating only trailing raggedness — interior raggedness needs `group_ids`.
- **Eval** — both eval rollout implementations now assign `sample.group_index = <prompt index>` at sample creation, exactly as the train data source already does for train samples; list-expanded multi-turn/tool samples inherit it through `deepcopy`. `log_eval_rollout_data` passes `group_ids = [s.group_index for s in samples]` when every sample carries one, so each sample lands in its true prompt's group regardless of expansion or per-dataset sampling overrides. Samples without group identity (e.g. from custom eval rollout functions) fall back to chunking.
- **Train** — `convert_samples_to_train_data` emits a `group_indices` entry built from `sample.group_index`, aligned 1:1 with `raw_reward` and propagated full-batch (un-partitioned) by `split_train_data_by_dp` exactly like `raw_reward`. `log_passrate` drops the `num_groups` pin and buckets by it; rewards without group identity (custom conversion functions, old debug dumps) fall back to chunking.

For each `k`, pass@k is averaged only over groups with at least `k` samples; a rung is dropped entirely when no group qualifies, so undersized/partial groups never crash or distort the metric.

## Why this is the right fix

- **Group identity is recorded at the source, not reconstructed downstream.** Train samples already carry `group_index` from the data source; eval now assigns it at the same point (sample creation). Both call sites consume that recorded identity, so grouping stays correct under list expansion, per-dataset `n_samples_per_eval_prompt` overrides, and buffer reordering — everything that breaks positional or index-derived grouping.
- **Default-path safety (bit-identical).** For well-formed exact-multiple input the `group_ids=None` chunking path is numerically identical to the legacy `reshape(num_groups, group_size)`, so the common train layout (exact-multiple contiguous groups) is unchanged. A test pins this equivalence against a copy of the pre-fix implementation.
- **No metric distortion.** A singleton/partial group can satisfy pass@1 but cannot represent pass@4; restricting each rung to groups of size `>= k` (and dropping empty rungs) keeps every reported pass@k honest instead of padding or skewing it.
- **Graceful degradation.** Callers whose samples or rewards carry no group identity keep working through the chunk fallback, which never crashes and is exact for well-formed input.
- **Minimal, no new abstraction.** One function's grouping logic changes, the two call sites each change by a few lines, the eval rollout implementations gain a one-line `group_index` assignment, and the train conversion gains one aligned entry; the pass@k estimator (`_estimate_pass_at_k`) is untouched.
- **CI-verifiable.** Adds `tests/fast/utils/test_metric_utils.py` and call-site tests (auto-collected into the `stage-a-cpu` CPU suite by the existing `tests/fast/**` discovery convention). They cover: (1) bit-identical output vs the legacy reshape on exact-multiple input, (2) no crash on the train over-sampled and eval list-expanded ragged shapes, (3) rung eligibility, (4) `log_eval_rollout_data` bucketing by `group_index` rather than position (a positional pairing would report a different pass@2), and (5) the `group_indices` full-batch alignment contract through `convert_samples_to_train_data` / `split_train_data_by_dp`. The existing eval integration test now pins that eval samples carry their per-prompt `group_index`.