### PR TITLE
fix(chat-template): harden tool-call argument decoding

### DIFF
--- a/miles/utils/chat_template_utils/template.py
+++ b/miles/utils/chat_template_utils/template.py
@@ -60,11 +60,41 @@ def load_hf_chat_template(model_id: str) -> str:
         return f.read()
 
 
+def _dict_arguments(args: Any) -> dict:
+    """Coerce tool_call ``arguments`` to a mapping for HF-Jinja rendering.
+
+    OpenAI wire responses carry ``function.arguments`` as a JSON string; Qwen-family
+    templates expect a mapping and iterate ``arguments|items``. Decode echoed wire
+    strings back to dicts at the render boundary, but never let adversarial args
+    crash render/data-load:
+
+    - already a ``dict`` -> passthrough.
+    - ``str`` -> guarded ``json.loads`` (empty -> ``{}``); a ``JSONDecodeError`` or a
+      value that decodes to a non-dict (list/number) is preserved under
+      ``_raw_arguments`` so it still renders.
+    - ``None`` -> ``{}`` (no arguments).
+    - any other native non-dict -> preserved under ``_raw_arguments``.
+    """
+    if isinstance(args, dict):
+        return args
+    if isinstance(args, str):
+        try:
+            decoded = json.loads(args or "{}")
+        except json.JSONDecodeError:
+            return {"_raw_arguments": args}
+        return decoded if isinstance(decoded, dict) else {"_raw_arguments": args}
+    if args is None:
+        return {}
+    return {"_raw_arguments": args}
+
+
 def normalize_tool_arguments(messages: list[dict], format: Literal["dict", "json"]) -> list[dict]:
     """Deep-copy *messages*, normalize assistant ``content: None`` -> "", and coerce
     tool_call ``arguments`` to the form the downstream renderer needs (``format`` picks
     the direction; never mutates the input):
     - ``"dict"``: JSON string -> dict, for HF-Jinja templates (they index args as objects).
+      Adversarial args (empty, malformed, or decoding to a non-dict / ``None``) are
+      coerced to a mapping rather than crashing render — see ``_dict_arguments``.
     - ``"json"``: dict -> JSON string, for the DeepSeek DSML encoders (they ``json.loads`` them).
     """
     normalized = copy.deepcopy(messages)
@@ -78,8 +108,8 @@ def normalize_tool_arguments(messages: list[dict], format: Literal["dict", "json
                     if not func:
                         continue
                     args = func.get("arguments")
-                    if format == "dict" and isinstance(args, str):
-                        func["arguments"] = json.loads(args)
+                    if format == "dict" and "arguments" in func:
+                        func["arguments"] = _dict_arguments(args)
                     elif format == "json" and isinstance(args, dict):
                         func["arguments"] = json.dumps(args, ensure_ascii=False)
     return normalized

--- a/tests/fast/utils/chat_template_utils/test_tool_args_hardening.py
+++ b/tests/fast/utils/chat_template_utils/test_tool_args_hardening.py
@@ -1,0 +1,113 @@
+"""Adversarial tool-call ``arguments`` must not crash chat-template rendering."""
+
+from __future__ import annotations
+
+import copy
+from collections.abc import Mapping
+
+import pytest
+
+from miles.utils.chat_template_utils import TEMPLATE_DIR, apply_chat_template_from_str, normalize_tool_arguments
+
+_QWEN35_FIXED = (TEMPLATE_DIR / "qwen3.5_fixed.jinja").read_text()
+
+_TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get the weather for a city.",
+            "parameters": {"type": "object", "properties": {"city": {"type": "string"}}},
+        },
+    }
+]
+
+
+def _messages_with_args(arguments) -> list[dict]:
+    return [
+        {"role": "user", "content": "weather?"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "get_weather", "arguments": arguments},
+                }
+            ],
+        },
+        {"role": "tool", "content": "sunny", "tool_call_id": "call_1", "name": "get_weather"},
+    ]
+
+
+_ADVERSARIAL_ARGS = [
+    pytest.param("", id="empty-string"),
+    pytest.param("{not json}", id="malformed-json"),
+    pytest.param("[1, 2, 3]", id="decodes-to-list"),
+    pytest.param("42", id="decodes-to-number"),
+    pytest.param(None, id="none"),
+    pytest.param([1, 2, 3], id="native-list"),
+    pytest.param(42, id="native-number"),
+]
+
+
+def _tool_call_arguments(messages: list[dict]) -> object:
+    return messages[1]["tool_calls"][0]["function"]["arguments"]
+
+
+@pytest.mark.parametrize("arguments", _ADVERSARIAL_ARGS)
+def test_normalize_yields_mapping_and_does_not_raise(arguments):
+    messages = _messages_with_args(arguments)
+    normalized = normalize_tool_arguments(messages, "dict")
+    assert isinstance(_tool_call_arguments(normalized), Mapping)
+
+
+@pytest.mark.parametrize("arguments", _ADVERSARIAL_ARGS)
+def test_render_does_not_raise(arguments):
+    messages = _messages_with_args(arguments)
+    rendered = apply_chat_template_from_str(_QWEN35_FIXED, messages, tools=_TOOLS)
+    assert isinstance(rendered, str)
+
+
+def test_malformed_preserved_under_raw_arguments():
+    for raw in ("{not json}", "[1, 2, 3]", "42"):
+        normalized = normalize_tool_arguments(_messages_with_args(raw), "dict")
+        assert _tool_call_arguments(normalized) == {"_raw_arguments": raw}
+
+
+def test_empty_and_none_become_empty_mapping():
+    for arguments in ("", None):
+        normalized = normalize_tool_arguments(_messages_with_args(arguments), "dict")
+        assert _tool_call_arguments(normalized) == {}
+
+
+def test_native_non_dict_preserved_under_raw_arguments():
+    for arguments in ([1, 2, 3], 42, 0, []):
+        normalized = normalize_tool_arguments(_messages_with_args(arguments), "dict")
+        assert _tool_call_arguments(normalized) == {"_raw_arguments": arguments}
+
+
+def test_default_valid_json_path_unchanged():
+    normalized = normalize_tool_arguments(_messages_with_args('{"city": "London"}'), "dict")
+    assert _tool_call_arguments(normalized) == {"city": "London"}
+
+
+def test_dict_arguments_passthrough_unchanged():
+    normalized = normalize_tool_arguments(_messages_with_args({"city": "Paris"}), "dict")
+    assert _tool_call_arguments(normalized) == {"city": "Paris"}
+
+
+def test_does_not_mutate_input():
+    messages = _messages_with_args("[1, 2, 3]")
+    saved = copy.deepcopy(messages)
+    normalize_tool_arguments(messages, "dict")
+    assert messages == saved
+
+
+def test_outbound_json_path_keeps_string_per_openai_spec():
+    normalized = normalize_tool_arguments(_messages_with_args({"city": "London"}), "json")
+    assert _tool_call_arguments(normalized) == '{"city": "London"}'
+
+    passthrough = normalize_tool_arguments(_messages_with_args('{"city": "London"}'), "json")
+    assert _tool_call_arguments(passthrough) == '{"city": "London"}'


### PR DESCRIPTION
> Draft: tool-call argument decoding needs more discussion before merge.

## Problem

OpenAI wire responses carry `function.arguments` as a JSON **string**, while Qwen-family templates expect a mapping and iterate it as `tool_call.arguments|items` (`miles/utils/chat_template_utils/templates/qwen3.5_fixed.jinja:117`). At the render boundary, `normalize_tool_arguments(messages, "dict")` (`miles/utils/chat_template_utils/template.py`) decodes that echoed wire string back to a dict — but the decode was an unguarded `json.loads(args)` gated only on `isinstance(args, str)`. The only `try/except` wrapping `apply_chat_template` catches `TemplateError`, **not** `JSONDecodeError` (`template.py:124-132`), so three inbound shapes broke render / data-load:

- `""` or malformed JSON → `json.loads` raises an uncaught `json.JSONDecodeError`, crashing render.
- a string that decodes to a non-dict (`"[1, 2, 3]"`, `"42"`) or an explicit `None` → leaks a non-mapping into the template, where `arguments|items` raises `TemplateError`; the tool-format fallback then re-renders the same broken args and surfaces a `ValueError`.
- a native (already-Python) non-dict `arguments` (a list / number) → never enters the `isinstance(args, str)` branch, so normalization is skipped and the raw non-dict hits `arguments|items` directly.

## Before vs After

Same input, fed through `"dict"` normalization and then rendered with `qwen3.5_fixed.jinja` (the original crash site). Reproduces the parametrized cases in the test file.

```python
from miles.utils.chat_template_utils import (
    TEMPLATE_DIR, apply_chat_template_from_str, normalize_tool_arguments,
)

def messages(arguments):
    return [
        {"role": "user", "content": "weather?"},
        {"role": "assistant", "content": None, "tool_calls": [
            {"id": "call_1", "type": "function",
             "function": {"name": "get_weather", "arguments": arguments}}]},
        {"role": "tool", "content": "sunny", "tool_call_id": "call_1", "name": "get_weather"},
    ]

qwen = (TEMPLATE_DIR / "qwen3.5_fixed.jinja").read_text()
for arg in ["", "{not json}", "[1, 2, 3]", "42", None, [1, 2, 3], 42]:
    apply_chat_template_from_str(qwen, messages(arg), tools=TOOLS)
```

**Before** — the very first case crashes:

```
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

and the non-dict cases (e.g. `"[1, 2, 3]"`, native `42`) crash later in render:

```
ValueError: Chat template rendering failed (tool format fallback): ...
# arguments|items on a list/number raised TemplateError
```

**After** — every case renders to a `str`. The normalized `arguments` per input:

| inbound `arguments` | normalized to |
|---|---|
| `'{"city": "London"}'` (valid) | `{"city": "London"}` (unchanged) |
| `{"city": "Paris"}` (already dict) | `{"city": "Paris"}` (passthrough) |
| `""` | `{}` |
| `None` | `{}` |
| `"{not json}"` | `{"_raw_arguments": "{not json}"}` |
| `"[1, 2, 3]"` | `{"_raw_arguments": "[1, 2, 3]"}` |
| `"42"` | `{"_raw_arguments": "42"}` |
| `[1, 2, 3]` (native) | `{"_raw_arguments": [1, 2, 3]}` |
| `42` (native) | `{"_raw_arguments": 42}` |
| `0` (native, falsy) | `{"_raw_arguments": 0}` |
| `[]` (native, falsy) | `{"_raw_arguments": []}` |

A malformed/non-dict payload is preserved verbatim under `_raw_arguments` rather than silently dropped to an empty call, so it still renders and stays inspectable.

## Fix

Route the inbound `"dict"` normalization through a new `_dict_arguments()` that always returns a mapping:

- `dict` → passthrough.
- `str` → guarded `json.loads(args or "{}")`; a `JSONDecodeError`, or a value that decodes to a non-dict, is preserved as `{"_raw_arguments": args}`. An empty wire string → `{}` (the OpenAI wire encodes "no arguments" as `""`/`"{}"`).
- `None` → `{}` (no arguments).
- any other native non-dict (list / number, falsy values like `0` / `[]` included) → preserved as `{"_raw_arguments": args}`, mirroring the stringified-non-dict branch. Only `None` means "no arguments": a falsy payload such as `0` or `[]` is still a payload the model emitted, so it is preserved rather than silently rewritten to an empty mapping.

`_raw_arguments` is a render-only sentinel with no programmatic consumer: it gives `arguments|items` a key to iterate so a malformed call surfaces its raw payload in the rendered text instead of being rewritten to an empty one. The call-site guard also changes from `isinstance(args, str)` to `"arguments" in func`, so native non-dict args now reach the coercion instead of being skipped.

## Why this is the right fix

- **Default path is bit-identical.** Valid dict-JSON (`'{"city": "London"}'` → `{"city": "London"}`) and already-dict passthrough are unchanged and pinned by tests; only the previously-crashing branches gain coercion.
- **Lossless.** Truthiness is the wrong gate for "no arguments" — gating the sentinel on `is None` means the normalization never drops a real (even falsy) payload.
- **Scoped to inbound render normalization.** The outbound `"json"` direction (DeepSeek DSML encoders) and the OpenAI wire contract (`arguments` stays a JSON string) are untouched — a test asserts a non-dict wire string is left as-is on the `"json"` path.
- **No new abstraction, no mutation.** One private helper; `normalize_tool_arguments` still deep-copies, so the input message is never mutated (pinned by `test_does_not_mutate_input`).
- **CI-verifiable, CPU-only.** Adds `tests/fast/utils/chat_template_utils/test_tool_args_hardening.py` (pure-Python, no tokenizer / network). It pins that none of the adversarial inbound values raise, each yields a `Mapping`, the full `qwen3.5_fixed.jinja` render does not raise, malformed/native-non-dict payloads survive under `_raw_arguments` (falsy natives `0` / `[]` included), and the valid/passthrough/outbound paths are unchanged. Living under `tests/fast/`, the CPU suite (`stage-a-cpu`) auto-discovers it on every PR with no extra registration.