### PR TITLE
[fix] set deepseek v32 override_hf_native=True

### DIFF
--- a/miles/utils/hf_config.py
+++ b/miles/utils/hf_config.py
@@ -35,6 +35,7 @@ _CONFIG_ALIASES: tuple[_HFConfigAlias, ...] = (
         base_module="transformers.models.deepseek_v3.configuration_deepseek_v3",
         base_class="DeepseekV3Config",
         compat_class_name="DeepseekV32Config",
+        override_hf_native=True,
     ),
     _HFConfigAlias(
         model_type="deepseek_v4",


### PR DESCRIPTION
Newest transformers (from 6.10) supported deepseek v32 but sglang's stable version does not. Set override.