### PR TITLE
feat(rl): add CISPO advantage estimator (MiniMax-M1)

### DIFF
--- a/docs/user-guide/cli-reference.md
+++ b/docs/user-guide/cli-reference.md
@@ -65,7 +65,7 @@ then push up until you OOM.
 
 | Flag | Default | What |
 |---|---|---|
-| `--advantage-estimator` | `grpo` | `grpo`, `gspo`, `ppo`, `reinforce_plus_plus`, `reinforce_plus_plus_baseline`, `on_policy_distillation` |
+| `--advantage-estimator` | `grpo` | `grpo`, `gspo`, `cispo`, `ppo`, `reinforce_plus_plus`, `reinforce_plus_plus_baseline` |
 | `--use-kl-loss` | off | Compute KL against the reference model. |
 | `--kl-loss-coef` | `0.0` | Weight of KL in the loss (0 means monitor only). |
 | `--kl-loss-type` | `k1` | `k1`, `k2`, `k3`, `low_var_kl`. |
@@ -224,7 +224,7 @@ Sections mirror the launch-script argument groups.
 
 | Flag | Type | Default | Notes |
 |---|---|---|---|
-| `--advantage-estimator` | enum | `grpo` | `grpo`, `gspo`, `ppo`, `reinforce_plus_plus`, `reinforce_plus_plus_baseline`, `on_policy_distillation` |
+| `--advantage-estimator` | enum | `grpo` | `grpo`, `gspo`, `cispo`, `ppo`, `reinforce_plus_plus`, `reinforce_plus_plus_baseline` |
 | `--use-kl-loss` | flag | off | Compute KL vs. reference. |
 | `--kl-loss-coef` | float | `0.0` | KL weight in loss (0 means monitor). |
 | `--kl-loss-type` | enum | `k1` | `k1`, `k2`, `k3`, `low_var_kl`. |

--- a/miles/backends/training_utils/loss.py
+++ b/miles/backends/training_utils/loss.py
@@ -18,9 +18,10 @@ def compute_advantages_and_returns(args: Namespace, rollout_data: RolloutBatch) 
 
     This function extracts rewards, log-probs, values, and masks from
     `rollout_data`, computes KL divergences, then applies the chosen advantage
-    estimator. Supported methods: "grpo", "gspo", "ppo", "reinforce_plus_plus",
-    and "reinforce_plus_plus_baseline". On-policy distillation (OPD) is applied
-    orthogonally on top of any estimator via `args.use_opd`. When
+    estimator. Supported methods: "grpo", "gspo", "cispo", "ppo",
+    "reinforce_plus_plus", and "reinforce_plus_plus_baseline". On-policy
+    distillation (OPD) is applied orthogonally on top of any estimator via
+    `args.use_opd`. When
     `args.normalize_advantages` is True, advantages are whitened across the
     data-parallel group using masked statistics.
 

--- a/miles/backends/training_utils/loss_hub/advantages.py
+++ b/miles/backends/training_utils/loss_hub/advantages.py
@@ -28,7 +28,7 @@ def compute_advantages(
     Returns:
         (advantages, returns) — both lists of tensors, one per sample.
     """
-    if args.advantage_estimator in ["grpo", "gspo"]:
+    if args.advantage_estimator in ["grpo", "gspo", "cispo"]:
         rewards = torch.tensor(rewards, dtype=torch.float32, device=kl[0].device)
         returns = get_grpo_returns(rewards, kl)
         # TODO: is the copy necessary?

--- a/miles/backends/training_utils/loss_hub/losses.py
+++ b/miles/backends/training_utils/loss_hub/losses.py
@@ -13,6 +13,7 @@ from miles.backends.training_utils.loss_hub.corrections import vanilla_tis_funct
 from miles.backends.training_utils.loss_hub.logit_processors import get_log_probs_and_entropy, get_values
 from miles.backends.training_utils.loss_hub.math_utils import (
     compute_approx_kl,
+    compute_cispo_loss,
     compute_ess_ratio_contribution,
     compute_gspo_kl,
     compute_opsm_mask,
@@ -65,10 +66,11 @@ def policy_loss_function(
     logits: torch.Tensor,
     sum_of_sample_mean: Callable[[torch.Tensor], torch.Tensor],
 ) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
-    """Compute policy loss (PPO/GSPO) and metrics.
+    """Compute policy loss (PPO/GSPO/CISPO) and metrics.
 
     Computes current log-probabilities and entropy from model logits, then
-    calculates PPO-style clipped policy gradient loss. For GSPO, gathers
+    calculates PPO-style clipped policy gradient loss (or the CISPO clipped-IS
+    surrogate when `args.advantage_estimator == "cispo"`). For GSPO, gathers
     full sequences via context-parallel all-gather before computing per-sample
     KL. Optionally applies TIS (Truncated Importance Sampling) correction and
     adds KL loss term if configured.
@@ -175,7 +177,20 @@ def policy_loss_function(
         advantages.new_zeros(()),
     )
 
-    pg_loss, pg_clipfrac = compute_policy_loss(ppo_kl, advantages, args.eps_clip, args.eps_clip_high)
+    if args.advantage_estimator == "cispo":
+        # CISPO multiplies raw current-policy log_probs into the loss (PPO/GSPO only
+        # consume the sanitized ppo_kl), so sanitize them the same way: an inf at a
+        # masked token would otherwise become 0 * inf = NaN in the masked reduction.
+        cispo_log_probs = torch.where(
+            active_tokens,
+            torch.nan_to_num(log_probs, nan=0.0, posinf=0.0, neginf=0.0),
+            log_probs.new_zeros(()),
+        )
+        pg_loss, pg_clipfrac = compute_cispo_loss(
+            ppo_kl, advantages, cispo_log_probs, args.eps_clip, args.eps_clip_high
+        )
+    else:
+        pg_loss, pg_clipfrac = compute_policy_loss(ppo_kl, advantages, args.eps_clip, args.eps_clip_high)
 
     if getattr(args, "dump_details", None) is not None:
         from miles.backends.training_utils.debug_dump import maybe_dump_policy_loss_debug

--- a/miles/backends/training_utils/loss_hub/math_utils.py
+++ b/miles/backends/training_utils/loss_hub/math_utils.py
@@ -273,6 +273,48 @@ def compute_policy_loss(
     return pg_losses, clipfrac
 
 
+@torch.compile(dynamic=True)
+def compute_cispo_loss(
+    ppo_kl: torch.Tensor,
+    advantages: torch.Tensor,
+    log_probs: torch.Tensor,
+    eps_clip: float,
+    eps_clip_high: float,
+):
+    """CISPO surrogate from MiniMax-M1 (https://arxiv.org/abs/2506.13585).
+
+    Unlike PPO's ``min`` of two ratio-weighted terms, CISPO is an *additive*
+    REINFORCE-style surrogate whose importance-sampling weight is clipped and
+    then stop-gradiented, so gradient flows ONLY through the current-policy
+    ``log_probs`` (no token is ever fully zeroed out by clipping):
+
+        L = -clip(ratio, 1-eps_clip, 1+eps_clip_high).detach() * A * log_probs
+
+    where ``ratio = exp(-ppo_kl) = pi_theta / pi_old``. Returns the same
+    ``(per_token_loss, clipfrac)`` shape as :func:`compute_policy_loss` so the
+    caller's reduction / metric plumbing is reused unchanged.
+
+    Args:
+        ppo_kl: Per-token ``log pi_old - log pi_theta`` (so ``ratio = exp(-ppo_kl)``).
+        advantages: Per-token advantages.
+        log_probs: Current-policy per-token log-probs; the only grad-carrying input.
+        eps_clip: Lower clip range on the IS weight.
+        eps_clip_high: Upper clip range on the IS weight.
+
+    Returns:
+        ``(pg_losses, clipfrac)`` — per-token loss tensor and a per-token float
+        mask marking tokens whose IS weight was clipped.
+    """
+    ratio = (-ppo_kl).exp()
+    clipped = ratio.clamp(1 - eps_clip, 1 + eps_clip_high).detach()
+    pg_losses = -clipped * advantages * log_probs
+    # clipfrac is ratio-band-based (any token whose raw IS weight left the band),
+    # unlike compute_policy_loss's loss-change-based clipfrac, so the two
+    # pg_clipfrac metrics are not numerically comparable across estimators.
+    clipfrac = ((ratio < 1 - eps_clip) | (ratio > 1 + eps_clip_high)).float()
+    return pg_losses, clipfrac
+
+
 def compute_log_probs(
     logits: torch.Tensor,
     tokens: torch.Tensor,

--- a/miles/ray/rollout/train_data_conversion.py
+++ b/miles/ray/rollout/train_data_conversion.py
@@ -101,7 +101,10 @@ def _post_process_rewards(args, samples: list[Sample] | list[list[Sample]], cust
         return f(args, samples)
 
     raw_rewards = [sample.get_reward_value(args) for sample in samples]
-    if args.advantage_estimator in ["grpo", "gspo", "reinforce_plus_plus_baseline"] and args.rewards_normalization:
+    if (
+        args.advantage_estimator in ["grpo", "gspo", "cispo", "reinforce_plus_plus_baseline"]
+        and args.rewards_normalization
+    ):
         # group norm
         rewards = torch.tensor(raw_rewards, dtype=torch.float)
         if rewards.shape[-1] == args.n_samples_per_prompt * args.rollout_batch_size:
@@ -112,7 +115,7 @@ def _post_process_rewards(args, samples: list[Sample] | list[list[Sample]], cust
         mean = rewards.mean(dim=-1, keepdim=True)
         rewards = rewards - mean
 
-        if args.advantage_estimator in ["grpo", "gspo"] and args.grpo_std_normalization:
+        if args.advantage_estimator in ["grpo", "gspo", "cispo"] and args.grpo_std_normalization:
             std = rewards.std(dim=-1, keepdim=True)
             rewards = rewards / (std + 1e-6)
 

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -944,6 +944,7 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 choices=[
                     "grpo",
                     "gspo",
+                    "cispo",
                     "reinforce_plus_plus",
                     "reinforce_plus_plus_baseline",
                     "ppo",

--- a/tests/fast/backends/training_utils/loss/test_cispo.py
+++ b/tests/fast/backends/training_utils/loss/test_cispo.py
@@ -1,0 +1,114 @@
+"""Unit tests for the CISPO advantage-estimator surrogate.
+
+CISPO (MiniMax-M1, https://arxiv.org/abs/2506.13585) replaces PPO's ``min`` of
+two ratio-weighted terms with an *additive* REINFORCE-style surrogate whose
+importance-sampling weight is clipped and then stop-gradiented:
+
+    L = -clip(ratio, 1-eps_clip, 1+eps_clip_high).detach() * A * log_probs
+
+These tests cover the closed-form loss/clipfrac values and the load-bearing
+invariant: gradient flows ONLY through ``log_probs`` (the IS weight is detached),
+without needing the external loss snapshot artifacts.
+"""
+
+import torch
+
+from miles.backends.training_utils.cp_utils import get_sum_of_sample_mean
+from miles.backends.training_utils.loss_hub.losses import policy_loss_function
+from miles.backends.training_utils.loss_hub.math_utils import compute_cispo_loss
+
+from .loss_test_utils import make_args, make_batch, make_inputs, make_parallel_state
+
+# This module intentionally has no explicit CI registration call: modules under
+# tests/fast with no register call are implicitly assigned to the stage-a-cpu
+# suite by collect_tests, so no explicit registration is needed for this to run
+# in CI.
+
+
+def test_unclipped_matches_closed_form_reinforce_surrogate():
+    # ratio = exp(-ppo_kl) = 1 (on-policy); clip is a no-op, so
+    # pg_loss = -ratio * adv * log_probs = -1 * adv * log_probs.
+    ppo_kl = torch.zeros(3)
+    advantages = torch.tensor([2.0, -1.0, 0.5])
+    log_probs = torch.tensor([-0.1, -0.2, -0.3])
+
+    pg_loss, clipfrac = compute_cispo_loss(ppo_kl, advantages, log_probs, eps_clip=0.2, eps_clip_high=0.2)
+
+    assert torch.allclose(pg_loss, -advantages * log_probs)
+    # nothing clipped at ratio == 1
+    assert torch.allclose(clipfrac, torch.zeros(3))
+
+
+def test_is_weight_is_clipped():
+    # ppo_kl = -ln(2) => ratio = 2, above 1 + eps_clip_high = 1.2 -> clamped to 1.2.
+    # ppo_kl = -ln(0.5) => ratio = 0.5, below 1 - eps_clip = 0.8 -> clamped to 0.8.
+    ratios = torch.tensor([2.0, 0.5, 1.0])
+    ppo_kl = -ratios.log()
+    advantages = torch.tensor([1.0, 1.0, 1.0])
+    log_probs = torch.tensor([1.0, 1.0, 1.0])
+
+    pg_loss, clipfrac = compute_cispo_loss(ppo_kl, advantages, log_probs, eps_clip=0.2, eps_clip_high=0.2)
+
+    expected_clipped = torch.tensor([1.2, 0.8, 1.0])
+    assert torch.allclose(pg_loss, -expected_clipped * advantages * log_probs)
+    # first two tokens clipped, the on-policy one is not
+    assert torch.allclose(clipfrac, torch.tensor([1.0, 1.0, 0.0]))
+
+
+def test_gradient_flows_only_through_log_probs():
+    # The defining CISPO property: the stop-gradient on the clipped IS weight means
+    # backprop reaches `log_probs` but NOT `ppo_kl` / the IS ratio.
+    ppo_kl = torch.tensor([0.3, -0.4, 0.0], requires_grad=True)
+    advantages = torch.tensor([2.0, -1.0, 0.5])
+    log_probs = torch.tensor([-0.1, -0.2, -0.3], requires_grad=True)
+
+    pg_loss, _ = compute_cispo_loss(ppo_kl, advantages, log_probs, eps_clip=0.2, eps_clip_high=0.2)
+    pg_loss.sum().backward()
+
+    # gradient does NOT flow through the importance-sampling weight
+    assert ppo_kl.grad is None or torch.allclose(ppo_kl.grad, torch.zeros_like(ppo_kl))
+    # gradient DOES flow through the current-policy log_probs
+    assert log_probs.grad is not None
+    # d/d log_probs [ -clip(ratio) * adv * log_probs ] = -clip(ratio) * adv
+    ratio = (-ppo_kl.detach()).exp()
+    clipped = ratio.clamp(0.8, 1.2)
+    assert torch.allclose(log_probs.grad, -clipped * advantages)
+
+
+def test_inf_log_prob_at_masked_token_does_not_poison_loss():
+    # Unlike PPO/GSPO (which only consume the sanitized ppo_kl), CISPO multiplies
+    # raw current-policy log_probs into the loss. An inf at a loss-masked token
+    # must be sanitized before the masked reduction, where 0 * inf = NaN.
+    make_parallel_state()
+    args = make_args(advantage_estimator="cispo", entropy_coef=0.0)
+    inputs = make_inputs(seed=0, batch_size=1, prompt_lens=[4], response_lens=[4], vocab_size=16, args=args)
+
+    inputs["loss_masks"][0][2] = 0.0
+    # response token 2 is predicted from logits row total_len - response_len - 1 + 2 = 5;
+    # -inf at its target logit makes the current log_prob -inf at that token.
+    target_token = inputs["unconcat_tokens"][0][4 + 2]
+    inputs["policy_logits"][0, 5, target_token] = float("-inf")
+
+    batch = make_batch(inputs, "policy_loss")
+    logits = inputs["policy_logits"].requires_grad_(True)
+    som = get_sum_of_sample_mean(batch["total_lengths"], batch["response_lengths"], batch["loss_masks"])
+
+    loss, _ = policy_loss_function(args, batch, logits, som)
+    loss.backward()
+
+    assert torch.isfinite(loss)
+    assert torch.isfinite(logits.grad).all()
+
+
+def test_returns_match_compute_policy_loss_shapes():
+    # CISPO must return the same (per_token_loss, per_token_clipfrac) shape as
+    # compute_policy_loss so the caller's reduction / metric plumbing is reused.
+    ppo_kl = torch.randn(5)
+    advantages = torch.randn(5)
+    log_probs = torch.randn(5)
+
+    pg_loss, clipfrac = compute_cispo_loss(ppo_kl, advantages, log_probs, eps_clip=0.2, eps_clip_high=0.3)
+
+    assert pg_loss.shape == ppo_kl.shape
+    assert clipfrac.shape == ppo_kl.shape
+    assert clipfrac.dtype == torch.float32


### PR DESCRIPTION
## Problem

PPO/GSPO-style clipped surrogates zero the gradient of any token whose importance ratio is clipped. The MiniMax-M1 report (arXiv:2506.13585) shows these clipped tokens are often exactly the low-probability, high-leverage reasoning fork tokens ("However", "Recheck", ...), and proposes CISPO: keep every token in the gradient, clip only the importance-sampling weight, and stop-gradient it.

## Behavior

**Before:** `--advantage-estimator cispo` is rejected by argparse; no estimator preserves gradients for ratio-clipped tokens.

**After:** `--advantage-estimator cispo` trains with the CISPO surrogate, per token:

```
L = -sg(clip(r, 1-eps_clip, 1+eps_clip_high)) * A * log pi_theta
```

where `r = pi_theta/pi_old` and `A` is the GRPO-style group-normalized advantage (unclipped). Every token always contributes gradient; the IS weight is clamped then detached. The paper's "no lower clipping" configuration is reachable with `--eps-clip 1.0`.

## Why this shape

- **Estimator-level integration, no parallel path.** CISPO's advantage is GRPO's, so `cispo` joins the existing `grpo` gates for group reward normalization and `get_grpo_returns` rather than duplicating that plumbing. The new math is a single function, `compute_cispo_loss`, returning the same `(per_token_loss, per_token_clipfrac)` contract as `compute_policy_loss`, so all reduction/metric/TIS/OPSM handling in `policy_loss_function` is reused unchanged.
- **NaN guard on `log_probs`.** `policy_loss_function` keeps the invariant that every per-token tensor entering the masked reducers is sanitized (`ppo_kl`, `advantages`, `kl`, ... all get `torch.where(active_tokens, nan_to_num(x), 0)`). CISPO is the first consumer of *raw* current-policy `log_probs` in the loss (PPO/GSPO only consume the already-sanitized `ppo_kl`), so the cispo branch sanitizes them the same way — otherwise an inf at a loss-masked token becomes `0 * inf = NaN` in the masked reduction and poisons the loss. A regression test injects a `-inf` target logit at a masked token through the full `policy_loss_function` path and asserts the loss and grads stay finite.
- **Metrics note:** cispo's `pg_clipfrac` counts tokens whose raw IS weight left the clip band, while PPO's counts tokens where clipping changed the loss — the two are not numerically comparable across estimators (commented at the definition).

## Tests

Unit tests pin the closed-form loss value, the clamp bounds/clipfrac, the defining invariant that gradient flows only through `log_probs` (IS weight detached, `ppo_kl` receives no grad), and the masked-token NaN guard above. No `test_loss_snapshot` config was added for cispo because the snapshot artifacts live in the external artifacts repo and an external PR cannot regenerate them — happy to add the config alongside a regenerated snapshot if you'd like.