### PR TITLE
fix(sglang): authenticate control-plane and router calls

### DIFF
--- a/docs/user-guide/cli-reference.md
+++ b/docs/user-guide/cli-reference.md
@@ -288,6 +288,11 @@ Sections mirror the launch-script argument groups.
 | `--sglang-*` | passthrough | | Any flag accepted by `python -m sglang.launch_server` works with this prefix. |
 | `--router-*` | passthrough | | Any flag accepted by the active router works with this prefix. |
 
+Bearer auth: when SGLang servers are launched with `--sglang-api-key` (and/or the
+router with `--router-api-key`), Miles attaches the matching key to engine
+control-plane calls, router (de)registration, worker list/abort, and generate
+routing headers. With no key set, no `Authorization` header is sent.
+
 Common `--sglang-*` flags:
 
 ```bash

--- a/miles/backends/sglang_utils/sglang_engine.py
+++ b/miles/backends/sglang_utils/sglang_engine.py
@@ -20,7 +20,7 @@ from miles.backends.megatron_utils.lora_utils import (
 )
 from miles.ray.ray_actor import RayActor
 from miles.utils.env_report import collect_and_print_node_env_report
-from miles.utils.http_utils import get_host_info
+from miles.utils.http_utils import bearer_auth_headers, get_host_info
 from miles.utils.lora import LORA_ADAPTER_NAME, lora_rollout_enabled
 from miles.utils.multi_lora import is_multi_lora_enabled
 
@@ -90,7 +90,7 @@ def launch_server_process(server_args: ServerArgs) -> multiprocessing.Process:
 def _wait_server_healthy(base_url, api_key, is_process_alive):
     headers = {
         "Content-Type": "application/json; charset=utf-8",
-        "Authorization": f"Bearer {api_key}",
+        **bearer_auth_headers(api_key),
     }
 
     with requests.Session() as session:
@@ -213,6 +213,9 @@ class SGLangEngine(RayActor):
         self.node_rank = server_args_dict["node_rank"]
         self.server_host = server_args_dict["host"]  # with [] if ipv6
         self.server_port = server_args_dict["port"]
+        # ServerArgs.api_key (--sglang-api-key) makes the server enforce bearer auth
+        # on every endpoint; remember it so control-plane calls can authenticate.
+        self.server_api_key = server_args_dict.get("api_key")
 
         if self.args.rollout_external:
             self._init_external(server_args_dict, external_engine_need_check_fields=external_engine_need_check_fields)
@@ -223,7 +226,10 @@ class SGLangEngine(RayActor):
         logger.info(f"Use external SGLang engine (rank={self.rank}, expect_server_args={expect_server_args})")
 
         def _get_actual_server_args():
-            response = requests.get(f"http://{self.server_host}:{self.server_port}/get_server_info")
+            response = requests.get(
+                f"http://{self.server_host}:{self.server_port}/get_server_info",
+                headers=self._server_headers(),
+            )
             response.raise_for_status()
             return response.json()
 
@@ -237,7 +243,7 @@ class SGLangEngine(RayActor):
 
         _wait_server_healthy(
             base_url=f"http://{self.server_host}:{self.server_port}",
-            api_key=None,
+            api_key=self.server_api_key,
             is_process_alive=lambda: True,
         )
         actual_server_args = _get_actual_server_args()
@@ -248,12 +254,14 @@ class SGLangEngine(RayActor):
         self.process = launch_server_process(ServerArgs(**server_args_dict))
 
         if self.node_rank == 0 and self.router_ip and self.router_port:
+            headers = self._router_headers()
             if parse(sglang_router.__version__) <= parse("0.2.1") or self.args.use_miles_router:
                 assert (
                     self.worker_type == "regular"
                 ), "pd disaggregation is not supported in old router or miles router."
                 response = requests.post(
-                    f"http://{self.router_ip}:{self.router_port}/add_worker?url=http://{self.server_host}:{self.server_port}"
+                    f"http://{self.router_ip}:{self.router_port}/add_worker?url=http://{self.server_host}:{self.server_port}",
+                    headers=headers,
                 )
             else:
                 payload = {
@@ -262,11 +270,20 @@ class SGLangEngine(RayActor):
                 }
                 if self.worker_type == "prefill":
                     payload["bootstrap_port"] = server_args_dict["disaggregation_bootstrap_port"]
+                if worker_api_key := server_args_dict.get("api_key"):
+                    payload["api_key"] = worker_api_key
                 response = requests.post(
                     f"http://{self.router_ip}:{self.router_port}/workers",
                     json=payload,
+                    headers=headers,
                 )
             response.raise_for_status()
+
+    def _server_headers(self) -> dict[str, str]:
+        return bearer_auth_headers(getattr(self, "server_api_key", None))
+
+    def _router_headers(self) -> dict[str, str]:
+        return bearer_auth_headers(getattr(self.args, "router_api_key", None))
 
     def _make_request(self, endpoint: str, payload: dict | None = None):
         """Make a POST request to the specified endpoint with the given payload.
@@ -282,7 +299,7 @@ class SGLangEngine(RayActor):
             return
 
         url = f"http://{self.server_host}:{self.server_port}/{endpoint}"
-        response = requests.post(url, json=payload or {})
+        response = requests.post(url, json=payload or {}, headers=self._server_headers())
         try:
             response.raise_for_status()
         except requests.exceptions.HTTPError as e:
@@ -309,6 +326,7 @@ class SGLangEngine(RayActor):
         response = requests.get(
             f"http://{self.server_host}:{self.server_port}/health_generate",
             timeout=timeout,
+            headers=self._server_headers(),
         )
         response.raise_for_status()
         return True
@@ -346,6 +364,7 @@ class SGLangEngine(RayActor):
             f"http://{self.server_host}:{self.server_port}/get_remote_instance_transfer_engine_info",
             params={"rank": rank},
             timeout=5.0,
+            headers=self._server_headers(),
         )
         response.raise_for_status()
         return response.json()["remote_instance_transfer_engine_info"]
@@ -355,6 +374,7 @@ class SGLangEngine(RayActor):
             f"http://{self.server_host}:{self.server_port}/parallelism_config",
             params={"rank": rank},
             timeout=5.0,
+            headers=self._server_headers(),
         )
         response.raise_for_status()
         return response.json()
@@ -363,6 +383,7 @@ class SGLangEngine(RayActor):
         response = requests.get(
             f"http://{self.server_host}:{self.server_port}/server_info",
             timeout=5.0,
+            headers=self._server_headers(),
         )
         response.raise_for_status()
         return response.json()
@@ -449,15 +470,22 @@ class SGLangEngine(RayActor):
         last_message = None
         for _ in range(60):
             try:
-                response = requests.get(f"http://{self.server_host}:{self.server_port}/flush_cache")
-                if response.status_code == 200:
-                    break
-                last_message = response.text
+                response = requests.get(
+                    f"http://{self.server_host}:{self.server_port}/flush_cache",
+                    headers=self._server_headers(),
+                )
             except NewConnectionError as e:
                 raise e
             except Exception as e:
                 logger.info(f"Error flushing cache: {e}")
                 last_message = str(e)
+                time.sleep(1)
+                continue
+            if response.status_code == 200:
+                break
+            if response.status_code in (401, 403):
+                response.raise_for_status()
+            last_message = response.text
             time.sleep(1)
         else:
             raise TimeoutError(f"Timeout while flushing cache: {last_message}")
@@ -470,21 +498,30 @@ class SGLangEngine(RayActor):
         if self.node_rank == 0:
             worker_url = f"http://{self.server_host}:{self.server_port}"
             response = None
+            headers = self._router_headers()
             if parse(sglang_router.__version__) <= parse("0.2.1") or self.args.use_miles_router:
                 response = requests.post(
-                    f"http://{self.router_ip}:{self.router_port}/remove_worker?url=http://{self.server_host}:{self.server_port}"
+                    f"http://{self.router_ip}:{self.router_port}/remove_worker?url=http://{self.server_host}:{self.server_port}",
+                    headers=headers,
                 )
             elif parse(sglang_router.__version__) < parse("0.3.0"):
                 worker_url = quote(worker_url, safe="")
-                response = requests.delete(f"http://{self.router_ip}:{self.router_port}/workers/{worker_url}")
+                response = requests.delete(
+                    f"http://{self.router_ip}:{self.router_port}/workers/{worker_url}",
+                    headers=headers,
+                )
             else:
                 try:
-                    all_workers = requests.get(f"http://{self.router_ip}:{self.router_port}/workers").json()["workers"]
+                    all_workers = requests.get(
+                        f"http://{self.router_ip}:{self.router_port}/workers",
+                        headers=headers,
+                    ).json()["workers"]
                     for worker in all_workers:
                         if worker["url"] == worker_url:
                             worker_id = worker["id"]
                             response = requests.delete(
-                                f"http://{self.router_ip}:{self.router_port}/workers/{worker_id}"
+                                f"http://{self.router_ip}:{self.router_port}/workers/{worker_id}",
+                                headers=headers,
                             )
                             break
                     else:
@@ -502,7 +539,7 @@ class SGLangEngine(RayActor):
         base = f"http://{self.server_host}:{self.server_port}"
         # new sglang change api from /get_weight_version to /model_info
         for endpoint in ("/model_info", "/get_weight_version"):
-            response = requests.get(f"{base}{endpoint}")
+            response = requests.get(f"{base}{endpoint}", headers=self._server_headers())
             if response.status_code == 200:
                 return response.json()["weight_version"]
         response.raise_for_status()
@@ -624,12 +661,17 @@ class SGLangEngine(RayActor):
         response = requests.post(
             f"http://{self.server_host}:{self.server_port}/pause_generation",
             json={"mode": mode},
+            headers=self._server_headers(),
         )
         response.raise_for_status()
         return response
 
     def continue_generation(self):
-        response = requests.post(f"http://{self.server_host}:{self.server_port}/continue_generation", json={})
+        response = requests.post(
+            f"http://{self.server_host}:{self.server_port}/continue_generation",
+            json={},
+            headers=self._server_headers(),
+        )
         response.raise_for_status()
         return response
 
@@ -672,12 +714,17 @@ class SGLangEngine(RayActor):
                 "with_stack": with_stack,
                 "record_shapes": record_shapes,
             },
+            headers=self._server_headers(),
         )
         response.raise_for_status()
         return response
 
     def stop_profile(self):
-        response = requests.post(f"http://{self.server_host}:{self.server_port}/stop_profile", json={})
+        response = requests.post(
+            f"http://{self.server_host}:{self.server_port}/stop_profile",
+            json={},
+            headers=self._server_headers(),
+        )
         response.raise_for_status()
         return response
 

--- a/miles/ray/multi_lora/backend.py
+++ b/miles/ray/multi_lora/backend.py
@@ -12,7 +12,7 @@ import httpx
 
 from miles.ray.multi_lora.registry import AdapterRegistry, AdapterState
 from miles.utils.adapter_config import AdapterRunConfig
-from miles.utils.http_utils import router_worker_base_urls
+from miles.utils.http_utils import bearer_auth_headers, router_worker_base_urls
 from miles.utils.multi_lora import RID_SEPARATOR, min_groups_per_dp_split
 
 logger = logging.getLogger(__name__)
@@ -168,7 +168,10 @@ class MultiLoRABackend:
             ("/workers", lambda body: [worker["url"] for worker in body["workers"]]),
         ):
             try:
-                resp = await self.client.get(f"{self.router_url}{endpoint}")
+                resp = await self.client.get(
+                    f"{self.router_url}{endpoint}",
+                    headers=bearer_auth_headers(getattr(self.args, "router_api_key", None)),
+                )
                 if resp.status_code == 200:
                     return router_worker_base_urls(extract(resp.json()))
             except Exception:
@@ -182,7 +185,14 @@ class MultiLoRABackend:
             logger.warning(f"Abort for adapter '{adapter_name}': no workers discovered at {self.router_url}")
             return
         results = await asyncio.gather(
-            *(self.client.post(f"{url}/abort_request", json={"rid": prefix, "prefix": True}) for url in urls),
+            *(
+                self.client.post(
+                    f"{url}/abort_request",
+                    json={"rid": prefix, "prefix": True},
+                    headers=bearer_auth_headers(getattr(self.args, "sglang_api_key", None)),
+                )
+                for url in urls
+            ),
             return_exceptions=True,
         )
         if failures := sum(isinstance(r, Exception) for r in results):

--- a/miles/rollout/generate_utils/generate_endpoint_utils.py
+++ b/miles/rollout/generate_utils/generate_endpoint_utils.py
@@ -8,6 +8,7 @@ from typing import Any
 import numpy as np
 import pybase64
 
+from miles.utils.http_utils import bearer_auth_headers
 from miles.utils.lora import LORA_ADAPTER_NAME, lora_rollout_enabled
 from miles.utils.processing_utils import encode_image_for_rollout_engine, extract_multimodal_train_inputs
 from miles.utils.types import Sample
@@ -44,9 +45,11 @@ def compute_routing_headers(args, sample: Sample) -> dict[str, str] | None:
             f"router policy {args.sglang_router_policy} routes by X-SMG-Routing-Key, "
             f"but sample (index={sample.index}) has no routing_key set"
         )
+    headers: dict[str, str] = {}
     if sample.routing_key:
-        return {"X-SMG-Routing-Key": sample.routing_key}
-    return None
+        headers["X-SMG-Routing-Key"] = sample.routing_key
+    headers.update(bearer_auth_headers(getattr(args, "router_api_key", None)))
+    return headers or None
 
 
 def compute_request_payload(

--- a/miles/rollout/generate_utils/prefill_logprobs.py
+++ b/miles/rollout/generate_utils/prefill_logprobs.py
@@ -5,7 +5,7 @@ from collections.abc import Mapping
 from typing import Any
 
 from miles.rollout.generate_utils.generate_endpoint_utils import compute_routing_headers, policy_uses_routing_key
-from miles.utils.http_utils import post
+from miles.utils.http_utils import bearer_auth_headers, post
 from miles.utils.lora import LORA_ADAPTER_NAME, lora_rollout_enabled
 from miles.utils.multi_lora import slot_lora_name
 from miles.utils.processing_utils import encode_image_for_rollout_engine
@@ -159,12 +159,13 @@ async def recompute_samples_rollout_logprobs_via_prefill(
             prompt_len = len(sample.tokens) - sample.response_length
             samples_by_batch_key[(prompt_len - 1, _lora_path_for_sample(args, sample))].append(sample)
 
+        headers = bearer_auth_headers(getattr(args, "router_api_key", None))
         for batch_samples in samples_by_batch_key.values():
             # SGLang can serve scoring requests from radix/KV cache. Flush before
             # each scoring group so every group uses the same clean-prefill path.
-            await post(flush_url, {})
+            await post(flush_url, {}, headers=headers)
             payload = _build_batch_prefill_scoring_payload(args, batch_samples, sampling_params)
-            outputs = await post(url, payload)
+            outputs = await post(url, payload, headers=headers)
             if not isinstance(outputs, list):
                 raise ValueError(f"SGLang batch prefill scoring returned {type(outputs).__name__}, expected list")
             if len(outputs) != len(batch_samples):

--- a/miles/rollout/inference_rollout/inference_rollout_train.py
+++ b/miles/rollout/inference_rollout/inference_rollout_train.py
@@ -14,7 +14,7 @@ from miles.rollout.generate_utils.sample_utils import reward_log_summary, sample
 from miles.rollout.inference_rollout.inference_rollout_common import GenerateState, generate_and_rm_group
 from miles.rollout.submission_scheduler import make_submission_scheduler
 from miles.utils import dumper_utils
-from miles.utils.http_utils import get, post, router_worker_base_urls
+from miles.utils.http_utils import bearer_auth_headers, get, post, router_worker_base_urls
 from miles.utils.misc import as_completed_async, call_agent_abort_hook, load_function
 from miles.utils.types import Sample
 
@@ -29,7 +29,8 @@ async def abort(state: GenerateState, pendings: set, rollout_id: int) -> list[li
 
     urls = await get_worker_urls(args)
     logger.info(f"Abort request for {urls}")
-    await asyncio.gather(*[post(f"{url}/abort_request", {"abort_all": True}) for url in urls])
+    worker_headers = bearer_auth_headers(getattr(args, "sglang_api_key", None))
+    await asyncio.gather(*[post(f"{url}/abort_request", {"abort_all": True}, headers=worker_headers) for url in urls])
 
     # Let the agent integration tear down its in-flight trials so they stop hitting
     # SGLang, instead of running on until their own max_seq_len / timeout.
@@ -54,11 +55,18 @@ async def abort(state: GenerateState, pendings: set, rollout_id: int) -> list[li
 
 
 async def get_worker_urls(args: Namespace):
+    router_headers = bearer_auth_headers(getattr(args, "router_api_key", None))
     if parse(sglang_router.__version__) <= parse("0.2.1") or args.use_miles_router:
-        response = await get(f"http://{args.sglang_router_ip}:{args.sglang_router_port}/list_workers")
+        response = await get(
+            f"http://{args.sglang_router_ip}:{args.sglang_router_port}/list_workers",
+            headers=router_headers,
+        )
         urls = response["urls"]
     else:
-        response = await get(f"http://{args.sglang_router_ip}:{args.sglang_router_port}/workers")
+        response = await get(
+            f"http://{args.sglang_router_ip}:{args.sglang_router_port}/workers",
+            headers=router_headers,
+        )
         urls = [worker["url"] for worker in response["workers"]]
     return router_worker_base_urls(urls)
 

--- a/miles/rollout/sglang_rollout.py
+++ b/miles/rollout/sglang_rollout.py
@@ -20,7 +20,7 @@ from miles.utils import dumper_utils
 from miles.utils.async_utils import run
 from miles.utils.data import Dataset
 from miles.utils.eval_config import EvalDatasetConfig
-from miles.utils.http_utils import get, post, router_worker_base_urls
+from miles.utils.http_utils import bearer_auth_headers, get, post, router_worker_base_urls
 from miles.utils.lifecycle import TrajectoryLifecycle
 from miles.utils.lora import LORA_ADAPTER_NAME, lora_rollout_enabled
 from miles.utils.misc import SingletonMeta, call_agent_abort_hook, load_function
@@ -396,16 +396,24 @@ async def abort(args: Namespace, rollout_id: int) -> list[list[Sample]]:
     assert not state.aborted
     state.aborted = True
 
+    router_headers = bearer_auth_headers(getattr(args, "router_api_key", None))
     if parse(sglang_router.__version__) <= parse("0.2.1") or args.use_miles_router:
-        response = await get(f"http://{args.sglang_router_ip}:{args.sglang_router_port}/list_workers")
+        response = await get(
+            f"http://{args.sglang_router_ip}:{args.sglang_router_port}/list_workers",
+            headers=router_headers,
+        )
         urls = response["urls"]
     else:
-        response = await get(f"http://{args.sglang_router_ip}:{args.sglang_router_port}/workers")
+        response = await get(
+            f"http://{args.sglang_router_ip}:{args.sglang_router_port}/workers",
+            headers=router_headers,
+        )
         urls = [worker["url"] for worker in response["workers"]]
     urls = router_worker_base_urls(urls)
 
     logger.info(f"Abort request for {urls}")
-    abort_tasks = [post(f"{url}/abort_request", {"abort_all": True}) for url in urls]
+    worker_headers = bearer_auth_headers(getattr(args, "sglang_api_key", None))
+    abort_tasks = [post(f"{url}/abort_request", {"abort_all": True}, headers=worker_headers) for url in urls]
     abort_results = await asyncio.gather(*abort_tasks, return_exceptions=True)
     for url, result in zip(urls, abort_results, strict=False):
         if isinstance(result, Exception):

--- a/miles/utils/http_utils.py
+++ b/miles/utils/http_utils.py
@@ -17,6 +17,16 @@ logger = logging.getLogger(__name__)
 MILES_HOST_IP_ENV = "MILES_HOST_IP"
 
 
+def bearer_auth_headers(api_key: str | None) -> dict[str, str]:
+    """Authorization headers for an SGLang/router API key, or empty if unset.
+
+    Falsy keys must not produce a literal ``Bearer None`` header.
+    """
+    if not api_key:
+        return {}
+    return {"Authorization": f"Bearer {api_key}"}
+
+
 def find_available_port(base_port: int):
     port = base_port + random.randint(100, 1000)
     while True:
@@ -361,8 +371,8 @@ async def post(url, payload, max_retries=60, action="post", headers=None):
 
 
 # TODO unify w/ `post` to add retries and remote-execution
-async def get(url):
-    response = await _http_client.get(url)
+async def get(url, headers=None):
+    response = await _http_client.get(url, headers=headers)
     response.raise_for_status()
     output = response.json()
     return output

--- a/tests/fast/backends/sglang_utils/test_sglang_engine.py
+++ b/tests/fast/backends/sglang_utils/test_sglang_engine.py
@@ -1,7 +1,34 @@
 import time
+from types import SimpleNamespace
 
 import pytest
 import requests
+
+
+class _Resp:
+    def __init__(self, status_code=200, json_data=None, text=""):
+        self.status_code = status_code
+        self._json = json_data if json_data is not None else {}
+        self.text = text
+
+    def json(self):
+        return self._json
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.exceptions.HTTPError(f"{self.status_code}", response=self)
+
+
+def _engine(api_key=None):
+    pytest.importorskip("sglang")
+    from miles.backends.sglang_utils.sglang_engine import SGLangEngine
+
+    engine = SGLangEngine.__new__(SGLangEngine)
+    engine.server_host = "127.0.0.1"
+    engine.server_port = 30000
+    engine.node_rank = 0
+    engine.server_api_key = api_key
+    return engine
 
 
 def test_flush_cache_sleeps_between_pending_request_retries(monkeypatch):
@@ -11,17 +38,11 @@ def test_flush_cache_sleeps_between_pending_request_retries(monkeypatch):
     through in a fraction of a second — nowhere near enough time for
     in-flight generation to drain — and flush_cache raises TimeoutError
     almost immediately after pause_generation instead of after ~60s."""
-    pytest.importorskip("sglang")
-    from miles.backends.sglang_utils.sglang_engine import SGLangEngine
-
-    engine = SGLangEngine.__new__(SGLangEngine)
-    engine.node_rank = 0
-    engine.server_host = "fake-host"
-    engine.server_port = 1234
+    engine = _engine()
 
     sleep_calls = []
     monkeypatch.setattr(time, "sleep", lambda s: sleep_calls.append(s))
-    monkeypatch.setattr(requests, "get", lambda url: type("Resp", (), {"status_code": 400})())
+    monkeypatch.setattr(requests, "get", lambda url, **kwargs: _Resp(status_code=400, text="pending"))
 
     with pytest.raises(TimeoutError, match="Timeout while flushing cache"):
         engine.flush_cache()
@@ -30,3 +51,128 @@ def test_flush_cache_sleeps_between_pending_request_retries(monkeypatch):
         f"expected the loop to back off on every one of its 60 attempts, got {len(sleep_calls)} sleeps "
         "-- a 400 response (pending requests) must not skip the retry delay"
     )
+
+
+def test_wait_server_healthy_omits_authorization_when_unset(monkeypatch):
+    pytest.importorskip("sglang")
+    from miles.backends.sglang_utils.sglang_engine import _wait_server_healthy
+
+    seen = []
+
+    class _Session:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def get(self, url, headers=None):
+            seen.append(headers)
+            return _Resp()
+
+    monkeypatch.setattr(requests, "Session", lambda: _Session())
+    _wait_server_healthy("http://127.0.0.1:1", None, lambda: True)
+    assert seen
+    assert all("Authorization" not in headers for headers in seen)
+    assert all("Bearer None" not in str(headers) for headers in seen)
+
+
+def test_wait_server_healthy_sends_bearer_when_key_set(monkeypatch):
+    pytest.importorskip("sglang")
+    from miles.backends.sglang_utils.sglang_engine import _wait_server_healthy
+
+    seen = []
+
+    class _Session:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def get(self, url, headers=None):
+            seen.append(headers)
+            return _Resp()
+
+    monkeypatch.setattr(requests, "Session", lambda: _Session())
+    _wait_server_healthy("http://127.0.0.1:1", "secret", lambda: True)
+    assert all(headers.get("Authorization") == "Bearer secret" for headers in seen)
+
+
+def test_make_request_uses_server_headers(monkeypatch):
+    calls = []
+
+    def fake_post(url, **kwargs):
+        calls.append((url, kwargs.get("headers") or {}, kwargs.get("json")))
+        return _Resp()
+
+    monkeypatch.setattr(requests, "post", fake_post)
+    _engine("secret")._make_request("update_weights_from_tensor", {"x": 1})
+    url, headers, payload = calls[0]
+    assert url.endswith("/update_weights_from_tensor")
+    assert headers == {"Authorization": "Bearer secret"}
+    assert payload == {"x": 1}
+
+
+def test_control_plane_omits_authorization_when_no_key(monkeypatch):
+    calls = []
+
+    def fake_request(method):
+        def _call(url, **kwargs):
+            calls.append(kwargs.get("headers") or {})
+            return _Resp(json_data={"weight_version": "v1"})
+
+        return _call
+
+    monkeypatch.setattr(requests, "get", fake_request("GET"))
+    monkeypatch.setattr(requests, "post", fake_request("POST"))
+    engine = _engine(None)
+    engine.get_server_info()
+    engine.flush_cache()
+    engine._make_request("release_memory_occupation", {"tags": ["kv_cache"]})
+    assert calls
+    assert all("Authorization" not in headers for headers in calls)
+    assert all("Bearer None" not in str(headers) for headers in calls)
+
+
+@pytest.mark.parametrize("status_code", [401, 403])
+def test_flush_cache_fails_fast_on_auth_error(monkeypatch, status_code):
+    engine = _engine("wrong-key")
+    sleep_calls = []
+    monkeypatch.setattr(time, "sleep", lambda s: sleep_calls.append(s))
+    monkeypatch.setattr(requests, "get", lambda url, **kwargs: _Resp(status_code=status_code, text="nope"))
+    with pytest.raises(requests.exceptions.HTTPError):
+        engine.flush_cache()
+    assert sleep_calls == []
+
+
+def test_router_registration_sends_bearer_and_forwards_worker_key(monkeypatch):
+    pytest.importorskip("sglang")
+    from miles.backends.sglang_utils import sglang_engine as mod
+    from miles.backends.sglang_utils.sglang_engine import SGLangEngine
+
+    calls = []
+
+    def fake_post(url, **kwargs):
+        calls.append((url, kwargs.get("headers") or {}, kwargs.get("json")))
+        return _Resp()
+
+    monkeypatch.setattr(mod, "sglang_router", SimpleNamespace(__version__="0.3.0"))
+    monkeypatch.setattr(mod, "ServerArgs", lambda **kwargs: SimpleNamespace(**kwargs))
+    monkeypatch.setattr(mod, "launch_server_process", lambda server_args: SimpleNamespace(pid=0))
+    monkeypatch.setattr(requests, "post", fake_post)
+
+    engine = SGLangEngine.__new__(SGLangEngine)
+    engine.args = SimpleNamespace(use_miles_router=False, router_api_key="router-key", rollout_external=False)
+    engine.node_rank = 0
+    engine.worker_type = "regular"
+    engine.server_host = "127.0.0.1"
+    engine.server_port = 12345
+    engine.router_ip = "router"
+    engine.router_port = 8000
+    engine._init_normal({"api_key": "worker-key"})
+
+    url, headers, payload = calls[0]
+    assert url.endswith("/workers")
+    assert headers == {"Authorization": "Bearer router-key"}
+    assert payload["api_key"] == "worker-key"

--- a/tests/fast/rollout/generate_utils/test_generate_endpoint_utils.py
+++ b/tests/fast/rollout/generate_utils/test_generate_endpoint_utils.py
@@ -1,0 +1,34 @@
+from types import SimpleNamespace
+
+import pytest
+
+from miles.rollout.generate_utils.generate_endpoint_utils import compute_routing_headers
+from miles.utils.types import Sample
+
+
+def test_compute_routing_headers_none_without_key_or_routing():
+    args = SimpleNamespace(sglang_router_policy="round_robin", router_api_key=None)
+    assert compute_routing_headers(args, Sample(index=0)) is None
+
+
+def test_compute_routing_headers_omits_authorization_when_key_unset():
+    args = SimpleNamespace(sglang_router_policy="round_robin")
+    headers = compute_routing_headers(args, Sample(index=0, routing_key="rk"))
+    assert headers == {"X-SMG-Routing-Key": "rk"}
+    assert "Authorization" not in headers
+    assert "Bearer None" not in str(headers)
+
+
+def test_compute_routing_headers_merges_router_bearer():
+    args = SimpleNamespace(sglang_router_policy="round_robin", router_api_key="router-secret")
+    assert compute_routing_headers(args, Sample(index=0)) == {"Authorization": "Bearer router-secret"}
+    assert compute_routing_headers(args, Sample(index=0, routing_key="rk")) == {
+        "X-SMG-Routing-Key": "rk",
+        "Authorization": "Bearer router-secret",
+    }
+
+
+def test_compute_routing_headers_requires_routing_key_for_hash_policy():
+    args = SimpleNamespace(sglang_router_policy="consistent_hashing", router_api_key=None)
+    with pytest.raises(ValueError, match="X-SMG-Routing-Key"):
+        compute_routing_headers(args, Sample(index=7))

--- a/tests/fast/rollout/generate_utils/test_prefill_logprobs.py
+++ b/tests/fast/rollout/generate_utils/test_prefill_logprobs.py
@@ -266,3 +266,39 @@ async def test_recompute_samples_batches_by_logprob_start_len(monkeypatch):
     assert calls[1][1]["input_ids"] == [[10, 11, 20], [10, 11, 22]]
     assert calls[3][1]["logprob_start_len"] == 2
     assert calls[3][1]["input_ids"] == [[10, 11, 12, 21]]
+    assert all(not call[3] or "Authorization" not in call[3] for call in calls)
+    assert all("Bearer None" not in str(call[3]) for call in calls)
+
+
+@pytest.mark.asyncio
+async def test_recompute_samples_batch_sends_router_bearer(monkeypatch):
+    samples = [
+        Sample(tokens=[10, 11, 20], response_length=1, status=Sample.Status.COMPLETED),
+        Sample(tokens=[10, 11, 21], response_length=1, status=Sample.Status.COMPLETED),
+    ]
+    args = SimpleNamespace(
+        recompute_logprobs_via_prefill=True,
+        sglang_enable_lora=False,
+        sglang_router_policy="round_robin",
+        router_api_key="router-secret",
+    )
+    headers_seen = []
+
+    async def fake_post(url, payload, action="post", headers=None):
+        headers_seen.append(headers)
+        if url.endswith("/flush_cache"):
+            return {}
+        return [
+            {"meta_info": {"input_token_logprobs": [(None, 11), (-float(tokens[-1]), tokens[-1])]}}
+            for tokens in payload["input_ids"]
+        ]
+
+    monkeypatch.setattr(prefill_logprobs, "post", fake_post)
+    await prefill_logprobs.recompute_samples_rollout_logprobs_via_prefill(
+        args,
+        samples,
+        url="http://localhost/generate",
+        sampling_params={"max_new_tokens": 32},
+    )
+    expected = {"Authorization": "Bearer router-secret"}
+    assert headers_seen == [expected, expected]

--- a/tests/fast/utils/test_http_utils.py
+++ b/tests/fast/utils/test_http_utils.py
@@ -29,7 +29,17 @@ from unittest.mock import patch
 
 import pytest
 
-from miles.utils.http_utils import wait_for_server_ready
+from miles.utils.http_utils import bearer_auth_headers, wait_for_server_ready
+
+
+@pytest.mark.parametrize("falsy", [None, ""])
+def test_bearer_auth_headers_empty_for_falsy(falsy):
+    assert bearer_auth_headers(falsy) == {}
+    assert "None" not in str(bearer_auth_headers(falsy))
+
+
+def test_bearer_auth_headers_sends_bearer_when_set():
+    assert bearer_auth_headers("secret") == {"Authorization": "Bearer secret"}
 
 
 def _find_free_port() -> int:


### PR DESCRIPTION
## Summary

Recut onto current `main`. When SGLang is launched with `--sglang-api-key` (`ServerArgs.api_key` / `args.sglang_api_key`) it enforces bearer auth on every endpoint, but Miles only authenticated the startup health probe in `_wait_server_healthy` — and that path always sent `Authorization: Bearer {api_key}`, including the literal `Bearer None` when the key was unset.

This change:

- Maps a falsy key to **no** `Authorization` header (`bearer_auth_headers`).
- Stores the engine's `ServerArgs.api_key` and sends it on every engine control-plane call via `_server_headers()`.
- Authenticates router (de)registration with `--router-api-key` (`args.router_api_key`) and forwards the worker's own key on `POST /workers` so the router can proxy to auth-enabled workers.
- Sends the router key on `list_workers` / `/workers` and generate routing headers (`compute_routing_headers`), and the server key on worker `abort_request`.

Unauthenticated setups omit `Authorization` entirely. `flush_cache` fails fast on 401/403 instead of retrying for 60s.

## Test plan

- [x] `tests/fast/utils/test_http_utils.py` — `bearer_auth_headers` never emits `Bearer None`
- [x] `tests/fast/backends/sglang_utils/test_sglang_engine.py` — `_wait_server_healthy` omit/send, control-plane omit, `_make_request` headers, `flush_cache` 401 fail-fast, router register forwards worker key
- [x] `tests/fast/rollout/generate_utils/test_generate_endpoint_utils.py` — router bearer merged into routing headers
- [x] `tests/fast/rollout/generate_utils/test_prefill_logprobs.py` — batch prefill sends router bearer