### PR TITLE
fix(ray): retry transient ActorUnavailableError at bringup

### DIFF
--- a/miles/ray/rollout/rollout_server.py
+++ b/miles/ray/rollout/rollout_server.py
@@ -3,6 +3,7 @@ import dataclasses
 import logging
 
 import ray
+from ray.exceptions import ActorUnavailableError
 
 from miles.backends.sglang_utils.arguments import collect_eval_sglang_overrides
 from miles.backends.sglang_utils.sglang_config import ModelConfig, ServerGroupConfig, SglangConfig
@@ -10,6 +11,7 @@ from miles.ray.rollout.addr_allocator import PortCursors
 from miles.ray.rollout.router_manager import start_router
 from miles.ray.rollout.server_engine import ServerEngine
 from miles.ray.rollout.server_group import ServerGroup
+from miles.utils.retry_utils import retry_sync
 
 logger = logging.getLogger(__name__)
 
@@ -85,7 +87,16 @@ def start_rollout_servers(args, pg) -> dict[str, "RolloutServer"]:
             gpu_offset += group_cfg.num_gpus
 
         if all_init_handles:
-            ray.get(all_init_handles)
+            # A momentary Ray control-plane heartbeat miss during this long wait
+            # can mark a healthy, still-initializing engine actor temporarily
+            # unavailable. Retry the *wait* only — re-getting submitted refs is
+            # idempotent, no engines are recreated. ActorDiedError and real init
+            # errors are not ActorUnavailableError and propagate immediately.
+            retry_sync(
+                lambda h=all_init_handles: ray.get(h),
+                should_retry=lambda e: isinstance(e, ActorUnavailableError),
+                what=f"rollout engine bringup ({model_cfg.name})",
+            )
 
         for group, new_engine_indices in zip(server_groups, new_engine_indices_per_group, strict=True):
             group.mark_alive(engine_indices=new_engine_indices)

--- a/miles/utils/retry_utils.py
+++ b/miles/utils/retry_utils.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import time
 from collections.abc import Awaitable, Callable
 from typing import Any
 
@@ -35,4 +36,43 @@ async def retry(
                 raise
             logger.warning(f"retry: attempt {attempt} failed, retrying in {delay:.1f}s", exc_info=True)
             await sleep_fn(delay)
+            delay = min(delay * backoff_factor, max_delay)
+
+
+def retry_sync(
+    fn: Callable[[], Any],
+    *,
+    should_retry: Callable[[Exception], bool],
+    what: str,
+    initial_delay: float = _DEFAULT_INITIAL_DELAY,
+    max_delay: float = _DEFAULT_MAX_DELAY,
+    backoff_factor: float = _DEFAULT_BACKOFF_FACTOR,
+    sleep_fn: Callable[[float], None] | None = None,
+    max_attempts: int = 3,
+) -> Any:
+    """Run ``fn`` with bounded retries, gated by ``should_retry``.
+
+    ``fn`` must be safe to re-invoke on a retried failure — wrap an idempotent
+    operation (e.g. a ``ray.get`` on already-submitted object refs), not a
+    non-idempotent side effect. Errors ``should_retry`` rejects propagate on
+    the first attempt. ``BaseException``s that are not ``Exception``s
+    (``KeyboardInterrupt``, ``SystemExit``) are never intercepted.
+    """
+    assert max_attempts >= 1
+
+    attempt = 0
+    delay = initial_delay
+    while True:
+        try:
+            return fn()
+        except Exception as e:
+            attempt += 1
+            if not should_retry(e) or attempt >= max_attempts:
+                if should_retry(e):
+                    logger.warning(
+                        f"retry ({what}): attempt {attempt} failed, giving up (max_attempts={max_attempts})"
+                    )
+                raise
+            logger.warning(f"retry ({what}): attempt {attempt} failed, retrying in {delay:.1f}s", exc_info=True)
+            (sleep_fn or time.sleep)(delay)
             delay = min(delay * backoff_factor, max_delay)

--- a/tests/fast/ray/rollout/real_ray/test_rollout_manager.py
+++ b/tests/fast/ray/rollout/real_ray/test_rollout_manager.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import asyncio
 import textwrap
 import time
+import types
 
 import pytest
 import ray
@@ -120,6 +121,33 @@ def _make_test_args(tmp_path, *, models: list[tuple[str, bool]]):
         use_distributed_post=False,
         sglang_server_concurrency=1,
     )
+
+
+def _inject_init_wait_failures(monkeypatch, exc_factory, times: int) -> dict:
+    """Make the next ``times`` ``ray.get`` calls issued from inside
+    ``rollout_server`` raise ``exc_factory()``, then delegate to the real
+    ``ray.get``. Patches the module's ``ray`` name binding (not the global
+    module), so ``ray.get`` calls elsewhere (mock engines, addr allocator,
+    conftest) are untouched. Returns a state dict; ``remaining`` reaches 0
+    once every injected failure has fired."""
+    import miles.ray.rollout.rollout_server as rsrv
+
+    state = {"remaining": times}
+
+    class _FlakyRay:
+        def __getattr__(self, name):
+            return getattr(ray, name)
+
+        @staticmethod
+        def get(*a, **kw):
+            if state["remaining"] > 0:
+                state["remaining"] -= 1
+                raise exc_factory()
+            return ray.get(*a, **kw)
+
+    monkeypatch.setattr(rsrv, "ray", _FlakyRay())
+    monkeypatch.setattr("miles.utils.retry_utils.time", types.SimpleNamespace(sleep=lambda _s: None))
+    return state
 
 
 async def _assert_engine_dies(actor_handle, *, deadline_s: float = 15.0, poll_interval_s: float = 0.2) -> None:
@@ -254,6 +282,54 @@ class TestRolloutManagerInit:
         for h in eal.rollout_engines:
             assert isinstance(h, ray.actor.ActorHandle)
             assert ray.get(h.health_generate.remote(timeout=1.0)) is True
+
+    async def test_init_retries_transient_actor_unavailable_during_bringup(
+        self,
+        ray_local_mode,
+        placement_group_factory,
+        tmp_path,
+        patch_low_level,
+        monkeypatch,
+    ):
+        """A transient ``ActorUnavailableError`` from the engine-init wait must
+        not crash bringup: ``start_rollout_servers`` re-drives the (idempotent)
+        wait and the engines still come up. Fails at ``__init__`` if the retry
+        wiring around ``ray.get(all_init_handles)`` is removed."""
+        state = _inject_init_wait_failures(
+            monkeypatch,
+            lambda: ray.exceptions.ActorUnavailableError("transient heartbeat miss", None),
+            times=1,
+        )
+        args = _make_test_args(tmp_path, models=[("actor", True)])
+        pg = placement_group_factory(2)
+
+        manager = _make_manager(args, pg)
+        eal = await manager.get_updatable_engines_and_lock()
+
+        assert state["remaining"] == 0, "injected failure never reached the init wait"
+        assert len(eal.rollout_engines) == 2
+        for h in eal.rollout_engines:
+            assert ray.get(h.health_generate.remote(timeout=1.0)) is True
+
+    async def test_init_does_not_retry_non_transient_bringup_error(
+        self,
+        ray_local_mode,
+        placement_group_factory,
+        tmp_path,
+        patch_low_level,
+        monkeypatch,
+    ):
+        """Only ``ActorUnavailableError`` is retried. A genuine init failure
+        surfacing from the same wait propagates on the first attempt — an
+        over-wide predicate would retry past it and bring the engines up,
+        making this raise nothing."""
+        state = _inject_init_wait_failures(monkeypatch, lambda: RuntimeError("engine init failed"), times=1)
+        args = _make_test_args(tmp_path, models=[("actor", True)])
+        pg = placement_group_factory(2)
+
+        with pytest.raises(RuntimeError, match="engine init failed"):
+            _make_manager(args, pg)
+        assert state["remaining"] == 0
 
 
 @pytest.mark.asyncio

--- a/tests/fast/utils/test_retry_sync.py
+++ b/tests/fast/utils/test_retry_sync.py
@@ -1,0 +1,96 @@
+"""Sync retry helper used by rollout engine bringup.
+
+Stdlib-only: the bringup call site supplies ``should_retry`` as
+``isinstance(..., ActorUnavailableError)``. These tests drive the same
+predicate shape with stand-in exception types.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from miles.utils.retry_utils import retry_sync
+
+
+class Transient(Exception):
+    """Retryable (stands in for ray.exceptions.ActorUnavailableError)."""
+
+
+class Permanent(Exception):
+    """Not retryable (stands in for ray.exceptions.ActorDiedError)."""
+
+
+def _retry_transient(exc: Exception) -> bool:
+    return isinstance(exc, Transient)
+
+
+def test_recovers_after_retryable_failures():
+    sentinel = object()
+    calls = {"n": 0}
+
+    def thunk():
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise Transient("temporarily unavailable")
+        return sentinel
+
+    result = retry_sync(thunk, should_retry=_retry_transient, what="test", sleep_fn=lambda _s: None)
+
+    assert result is sentinel
+    assert calls["n"] == 3
+
+
+def test_exhaustion_reraises_last_error():
+    calls = {"n": 0}
+
+    def thunk():
+        calls["n"] += 1
+        raise Transient("still unavailable")
+
+    with pytest.raises(Transient):
+        retry_sync(thunk, should_retry=_retry_transient, what="test", sleep_fn=lambda _s: None, max_attempts=3)
+
+    assert calls["n"] == 3
+
+
+def test_non_retryable_error_propagates_immediately():
+    calls = {"n": 0}
+
+    def thunk():
+        calls["n"] += 1
+        raise Permanent("the actor died unexpectedly")
+
+    with pytest.raises(Permanent):
+        retry_sync(thunk, should_retry=_retry_transient, what="test", sleep_fn=lambda _s: None, max_attempts=3)
+
+    assert calls["n"] == 1
+
+
+def test_success_on_first_attempt_calls_thunk_once():
+    calls = {"n": 0}
+
+    def thunk():
+        calls["n"] += 1
+        return "ok"
+
+    assert retry_sync(thunk, should_retry=_retry_transient, what="test") == "ok"
+    assert calls["n"] == 1
+
+
+@pytest.mark.parametrize("exc_type", [KeyboardInterrupt, SystemExit])
+def test_control_flow_exceptions_are_never_intercepted(exc_type):
+    calls = {"n": 0}
+    seen_by_predicate: list[Exception] = []
+
+    def retry_everything(exc: Exception) -> bool:
+        seen_by_predicate.append(exc)
+        return True
+
+    def thunk():
+        calls["n"] += 1
+        raise exc_type()
+
+    with pytest.raises(exc_type):
+        retry_sync(thunk, should_retry=retry_everything, what="test", sleep_fn=lambda _s: None, max_attempts=3)
+    assert calls["n"] == 1
+    assert seen_by_predicate == []


### PR DESCRIPTION
## Problem

During multi-node bringup the driver blocks for minutes on `ray.get(all_init_handles)` in `start_rollout_servers` while every SGLang engine initializes (weight load, cuda-graph capture, offload). A momentary Ray control-plane heartbeat miss (gRPC `UNAVAILABLE`) in that window raises `ActorUnavailableError` even though the engine actors are healthy and still initializing.

**Before:** one transient heartbeat miss during the init wait crashes the whole job at startup with

```
ray.exceptions.ActorUnavailableError: The actor <id> is unavailable: ...
```

while an identical rerun succeeds — a full allocation/bootstrap cycle wasted on a blip.

**After:** the bringup wait retries with the same bounded exponential backoff as `miles.utils.retry_utils.retry` (3 attempts, 1s then 2s sleeps), gated to `ActorUnavailableError` only. The job proceeds once the control plane recovers. Anything else — `ActorDiedError`, OOM, bad config — still propagates on the first attempt.

## Why this fix

The root cause is conflating "actor temporarily unreachable" with "init failed" on one long blocking wait. Retrying only the wait — never actor creation — is the narrowest correct guard:

- Re-`ray.get` on already-submitted object refs is idempotent: no engines are recreated, nothing leaks.
- The predicate gate (`isinstance(e, ActorUnavailableError)`) means permanent actor death and genuine init failures are never masked — they fail on attempt 1. (`ActorDiedError` is not a subclass of `ActorUnavailableError`.)
- The retry bound means a persistent outage still fails fast instead of hanging.

The mechanism is a small synchronous counterpart of the existing async `retry()` in `miles/utils/retry_utils.py`, taking a `should_retry` predicate. The only Ray-specific bit is the one-line `isinstance` classification at the call site.

Sibling fix in slime: THUDM/slime#2059.

## Tests

- `tests/fast/utils/test_retry_sync.py` — helper contract: retry-to-success, exhaustion re-raises after exactly `max_attempts`, predicate-rejected errors propagate immediately, success is never retried, `KeyboardInterrupt`/`SystemExit` are never swallowed.
- `tests/fast/ray/rollout/real_ray/test_rollout_manager.py` — two wiring tests that inject failures into the production init wait (patching the `rollout_server` module's `ray` binding, MockSGLangEngine on local Ray): a transient `ActorUnavailableError` is retried and the engines still come up, and a non-transient error from the same wait propagates immediately.

`tests/fast/**` is implicit CPU CI.

## Validation

- `pytest tests/fast/utils/test_retry_sync.py tests/fast/utils/test_retry_utils.py --noconftest` — 26 passed