### PR TITLE
fix(rollout): drain engines before offload memory release

### DIFF
--- a/miles/ray/rollout/rollout_manager.py
+++ b/miles/ray/rollout/rollout_manager.py
@@ -297,6 +297,8 @@ class RolloutManager:
 
     async def onload_kv(self):
         await self.onload(tags=[GPU_MEMORY_TYPE_KV_CACHE, GPU_MEMORY_TYPE_CUDA_GRAPH])
+        # Matching resume for offload()'s pause: only un-pause once KV and CUDA graphs are back.
+        await asyncio.gather(*[srv.continue_generation() for srv in self.servers.values()])
 
     # -------------------------- engine management -----------------------------
 

--- a/miles/ray/rollout/rollout_server.py
+++ b/miles/ray/rollout/rollout_server.py
@@ -266,10 +266,32 @@ class RolloutServer:
         await asyncio.gather(*[g.recover(port_cursors=port_cursors) for g in self.server_groups])
 
     async def offload(self, tags: list[str] | None = None):
+        """Pause and drain every engine before any memory release.
+
+        This layer sees all groups of a model: in PD disaggregation, no
+        decode-side request or in-flight KV transfer may be alive while the
+        prefill group releases memory.
+        """
+        pause_handles = []
+        for g in self.server_groups:
+            pause_handles.extend(g.pause_generation())
+        await asyncio.gather(*pause_handles)
+
+        flush_handles = []
+        for g in self.server_groups:
+            flush_handles.extend(g.flush_cache())
+        await asyncio.gather(*flush_handles)
+
+        release_handles = []
+        for g in self.server_groups:
+            release_handles.extend(g.offload(tags=tags))
+        return await asyncio.gather(*release_handles)
+
+    async def continue_generation(self):
         handles = []
         for g in self.server_groups:
-            handles.extend(g.offload(tags=tags))
-        return await asyncio.gather(*handles)
+            handles.extend(g.continue_generation())
+        await asyncio.gather(*handles)
 
     async def onload(self, tags: list[str] | None = None):
         handles = []

--- a/miles/ray/rollout/server_group.py
+++ b/miles/ray/rollout/server_group.py
@@ -232,6 +232,26 @@ class ServerGroup:
         for engine_index in engine_indices:
             self.all_engines[engine_index].mark_alive()
 
+    def pause_generation(self):
+        if not self.needs_offload:
+            return []
+        # abort: leftover requests at this boundary are unowned. retract would
+        # park them to be resumed into a released KV cache, and is unsupported
+        # in PD disaggregation.
+        return [
+            engine.actor_handle.pause_generation.remote(mode="abort") for engine in self.engines if engine.is_allocated
+        ]
+
+    def flush_cache(self):
+        if not self.needs_offload:
+            return []
+        return [engine.actor_handle.flush_cache.remote() for engine in self.engines if engine.is_allocated]
+
+    def continue_generation(self):
+        if not self.needs_offload:
+            return []
+        return [engine.actor_handle.continue_generation.remote() for engine in self.engines if engine.is_allocated]
+
     def offload(self, tags: list[str] | None = None):
         if not self.needs_offload:
             return []

--- a/tests/fast/ray/rollout/real_ray/test_rollout_manager.py
+++ b/tests/fast/ray/rollout/real_ray/test_rollout_manager.py
@@ -478,6 +478,52 @@ class TestGetUpdatableEnginesAndLock:
 
 
 @pytest.mark.asyncio
+class TestOffloadOnloadKv:
+    async def test_offload_quiesces_each_engine_and_onload_kv_resumes_after_restore(
+        self,
+        ray_local_mode,
+        placement_group_factory,
+        tmp_path,
+        patch_low_level,
+    ):
+        """Each engine must see pause → flush → release on ``offload`` and
+        resume(KV+CUDA graph) → continue on ``onload_kv``. Frozen models never
+        pass through weight-update pause/continue, so ``onload_kv`` is their
+        resume boundary too."""
+        from sglang.srt.constants import GPU_MEMORY_TYPE_CUDA_GRAPH, GPU_MEMORY_TYPE_KV_CACHE
+
+        args = _make_test_args(tmp_path, models=[("actor", True), ("ref", False)])
+        args.offload_rollout = True
+        args.colocate = True
+        pg = placement_group_factory(4)
+
+        manager = _make_manager(args, pg)
+        for srv in manager.servers.values():
+            await srv.wait_all_engines_alive()
+
+        await manager.offload(tags=[GPU_MEMORY_TYPE_KV_CACHE, GPU_MEMORY_TYPE_CUDA_GRAPH])
+        await manager.onload_kv()
+
+        protocol = [
+            "pause_generation",
+            "flush_cache",
+            "release_memory_occupation",
+            "resume_memory_occupation",
+            "continue_generation",
+        ]
+        handles = [e.actor_handle for srv in manager.servers.values() for e in srv.engines if e.is_allocated]
+        assert len(handles) == 4
+        for handle in handles:
+            calls = ray.get(handle.get_calls.remote())
+            assert [name for name, _args, _kwargs in calls if name in protocol] == protocol
+            kwargs_by_name = {name: kwargs for name, _args, kwargs in calls}
+            assert kwargs_by_name["pause_generation"] == {"mode": "abort"}
+            assert kwargs_by_name["resume_memory_occupation"] == {
+                "tags": [GPU_MEMORY_TYPE_KV_CACHE, GPU_MEMORY_TYPE_CUDA_GRAPH]
+            }
+
+
+@pytest.mark.asyncio
 class TestCheckWeights:
     async def test_check_weights_targets_only_updatable_model(
         self,

--- a/tests/fast/ray/rollout/test_offload_drain.py
+++ b/tests/fast/ray/rollout/test_offload_drain.py
@@ -1,0 +1,114 @@
+"""Offload must quiesce engines before any memory release.
+
+Every offloaded engine acknowledges ``pause_generation``, then ``flush_cache``,
+before any engine is told to ``release_memory_occupation``. Groups that do not
+overlap megatron GPUs are untouched. Fake handles record ``("call", ...)`` when
+a remote method fires and ``("ack", ...)`` when its handle is awaited, so the
+assertions read the real cross-engine ordering.
+"""
+
+from __future__ import annotations
+
+import pytest
+from tests.fast.ray.rollout.conftest import fake_actor_handle, make_args
+
+from miles.ray.rollout.rollout_server import RolloutServer
+from miles.ray.rollout.server_engine import ServerEngine
+from miles.ray.rollout.server_group import ServerGroup
+
+_ENGINE_METHODS = ("pause_generation", "flush_cache", "release_memory_occupation", "continue_generation")
+
+
+class _Remote:
+    def __init__(self, name: str, method: str, log: list):
+        self._name = name
+        self._method = method
+        self._log = log
+
+    def remote(self, **kwargs):
+        self._log.append(("call", self._name, self._method, kwargs))
+
+        async def ack():
+            self._log.append(("ack", self._name, self._method, kwargs))
+            return f"{self._name}:{self._method}"
+
+        return ack()
+
+
+def _logged_handle(name: str, log: list):
+    handle = fake_actor_handle()
+    for method in _ENGINE_METHODS:
+        setattr(handle, method, _Remote(name, method, log))
+    return handle
+
+
+def _group(names: list[str], log: list, *, needs_offload: bool = True, num_dead_engines: int = 0) -> ServerGroup:
+    engines = []
+    for name in names:
+        engine = ServerEngine()
+        engine.mark_allocated_uninitialized(_logged_handle(name, log))
+        engines.append(engine)
+    engines.extend(ServerEngine() for _ in range(num_dead_engines))
+    return ServerGroup(
+        args=make_args(),
+        pg=None,
+        all_engines=engines,
+        num_gpus_per_engine=1,
+        has_new_engines=False,
+        needs_offload=needs_offload,
+    )
+
+
+def _indices(log: list, kind: str, method: str) -> list[int]:
+    return [i for i, (k, _, m, _kw) in enumerate(log) if k == kind and m == method]
+
+
+@pytest.mark.asyncio
+class TestOffloadQuiescence:
+    async def test_every_engine_acks_pause_and_flush_before_any_release(self):
+        # A dead slot in group "a" must be skipped by every phase — touching
+        # its actor_handle would raise inside ServerEngine.
+        log: list = []
+        srv = RolloutServer(
+            server_groups=[
+                _group(["a0", "a1"], log, num_dead_engines=1),
+                _group(["b0"], log),
+            ]
+        )
+
+        results = await srv.offload(tags=["kv_cache"])
+
+        pause_calls = _indices(log, "call", "pause_generation")
+        flush_calls = _indices(log, "call", "flush_cache")
+        release_calls = _indices(log, "call", "release_memory_occupation")
+        assert len(pause_calls) == len(flush_calls) == len(release_calls) == 3
+
+        # Phase barriers: every pause acked before any flush fires; every
+        # flush acked before any release fires.
+        assert max(_indices(log, "ack", "pause_generation")) < min(flush_calls)
+        assert max(_indices(log, "ack", "flush_cache")) < min(release_calls)
+
+        assert all(log[i][3] == {"mode": "abort"} for i in pause_calls)
+        assert all(log[i][3] == {"tags": ["kv_cache"]} for i in release_calls)
+
+        assert sorted(results) == [
+            "a0:release_memory_occupation",
+            "a1:release_memory_occupation",
+            "b0:release_memory_occupation",
+        ]
+
+    async def test_non_offloaded_groups_are_untouched(self):
+        log: list = []
+        srv = RolloutServer(
+            server_groups=[
+                _group(["a0"], log),
+                _group(["p0"], log, needs_offload=False),
+            ]
+        )
+
+        await srv.offload(tags=["kv_cache"])
+        await srv.continue_generation()
+
+        assert [entry for entry in log if entry[1] == "p0"] == []
+        a0_methods = [m for kind, name, m, _kw in log if kind == "call" and name == "a0"]
+        assert a0_methods == ["pause_generation", "flush_cache", "release_memory_occupation", "continue_generation"]


### PR DESCRIPTION
## Problem

`RolloutManager.offload(tags=...)` releases SGLang engine memory by fanning `release_memory_occupation.remote(tags=tags)` across every offloaded `ServerGroup`, without first stopping generation. `SGLangEngine.release_memory_occupation` does call `flush_cache()` internally, but nothing at the offload boundary prevents requests from still being queued, running, or newly admitted while memory release proceeds — the engine stays registered with the router and its scheduler keeps running.

**Before this PR**, offloading while any request is still in flight (e.g. a custom rollout function that returns before its aborts fully drain, or a multi-turn client between turns) has two failure modes:

- the `flush_cache()` retry loop (60 × 1s) spins while requests remain and eventually raises `TimeoutError("Timeout while flushing cache.")`, crashing training; or
- `flush_cache()` succeeds in a momentarily idle window, and a request admitted right after runs against weights/KV memory that is being released.

**After this PR**, offload is a quiescence transition: every offloaded engine is paused and drained before any engine releases memory, and generation resumes only after `onload_kv()` has restored KV-cache and CUDA-graph memory.

## Fix

- `ServerGroup` gains `pause_generation()` / `flush_cache()` / `continue_generation()` — non-blocking mirrors of the existing `offload()` / `onload()` shape (gated on `needs_offload`, allocated node-0 engines only, returning Ray ObjectRefs).
- `RolloutServer.offload(tags=...)` becomes a three-phase transition: pause every engine across all groups and wait; flush every engine and wait; only then release. Coordination sits at the server level because that is the layer that sees all groups of a model: in PD disaggregation, no decode-side request or in-flight KV transfer may be alive while the prefill group releases memory.
- `RolloutManager.onload_kv()` issues `continue_generation()` after the KV-cache/CUDA-graph resume — the matching resume boundary for every offloaded engine, including non-updatable models that never pass through the weight-update path's own pause/continue.

This is the same quiesce idiom the weight-update paths already use before mutating engine state (`pause_generation` → `flush_cache` → update → `continue_generation`). Sibling fix in slime: THUDM/slime#2015.

### Why `pause_generation(mode="abort")` rather than `--pause-generation-mode`

That flag is scoped to weight updates, where the engine keeps its memory. At the offload boundary the rollout step has already returned, so any request still in flight is unowned. `"retract"` would park those requests to be resumed by the weight-update path's `continue_generation` — which runs after `onload_weights()` but **before** `onload_kv()`, i.e. while the KV cache is still released — and the scheduler rejects `retract` in PD disaggregation outright. `"abort"` terminates the stragglers, guarantees the flush barrier completes, and leaves nothing to resume into a KV-less engine.

## Tests

`tests/fast/ray/rollout/test_offload_drain.py` (implicit `tests/fast/**` CPU CI) drives the real `RolloutServer`/`ServerGroup`/`ServerEngine` with fake actor handles that log `call`/`ack` events, so the assertions read the true cross-engine ordering:

- every offloaded engine acknowledges pause, then flush, before any release fires; dead engine slots are skipped; `tags` reach the release;
- `needs_offload=False` groups are untouched by both `offload()` and `continue_generation()`.

`tests/fast/ray/rollout/real_ray/test_rollout_manager.py::TestOffloadOnloadKv` drives the production `RolloutManager` against `MockSGLangEngine` Ray actors for both an updatable actor and a frozen ref, and asserts each engine's call log reads exactly `pause_generation(mode="abort")` → `flush_cache` → `release_memory_occupation` → `resume_memory_occupation(tags=[kv_cache, cuda_graph])` → `continue_generation`.

Both suites fail on the unfixed `offload`; the manager test also fails if `onload_kv` resumes before restoring KV.

## Validation

- `pytest tests/fast/ray/rollout/test_offload_drain.py` — 2 passed; the same file fails on unfixed `origin/main`
- `tests/fast/**` is implicit CPU CI (no `register_cpu_ci`)