### PR TITLE
[fix] DeepSeek V4 blockwise FP8 on Blackwell

### DIFF
--- a/miles_plugins/models/deepseek_v4/ops/kernel/act_quant.py
+++ b/miles_plugins/models/deepseek_v4/ops/kernel/act_quant.py
@@ -11,15 +11,6 @@ import tilelang
 import tilelang.language as T
 import torch
 
-# Hardware-aware UE8M0 selection: matches SGLang's DEEPGEMM_SCALE_UE8M0
-# (true only on Blackwell + JIT DeepGEMM enabled). Hopper (H100/H200) falls
-# back to fp32 scales, which is also DeepSeek's official default.
-try:
-    from miles.backends.megatron_utils.sglang import should_deepgemm_weight_requant_ue8m0
-except ImportError:
-    should_deepgemm_weight_requant_ue8m0 = None
-
-
 tilelang.set_log_level("WARNING")
 
 pass_configs = {
@@ -116,38 +107,18 @@ def act_quant_kernel(
     return act_quant_kernel_
 
 
-def _resolve_scale_dtype(scale_fmt: str | None, block_size: int) -> torch.dtype:
-    """Pick scale dtype consistent with the SGLang runtime:
-    - UE8M0 (``torch.float8_e8m0fnu``) on Blackwell when DeepGEMM JIT is on.
-    - FP32 elsewhere (Hopper, no DeepGEMM, sglang absent) — DeepSeek default.
-    Only matters when scales are rounded-to-pow2 (``scale_fmt`` set);
-    plain ``scale_fmt=None`` stays fp32 regardless of hardware.
-    """
-    if scale_fmt is None or should_deepgemm_weight_requant_ue8m0 is None:
-        return torch.float32
-    return (
-        torch.float8_e8m0fnu if should_deepgemm_weight_requant_ue8m0(weight_block_size=block_size) else torch.float32
-    )
-
-
 def act_quant(
     x: torch.Tensor,
     block_size: int = 128,
     scale_fmt: str | None = None,
-    scale_dtype: torch.dtype | None = None,
+    scale_dtype: torch.dtype = torch.float32,
     inplace: bool = False,
 ) -> torch.Tensor:
     """Block-wise FP8 quantization. inplace=True does fused quant+dequant back to BF16.
     When scale_fmt is set, scales are rounded to power-of-2 (MXFP).
-
-    ``scale_dtype=None`` (default) auto-selects fp32 vs ``float8_e8m0fnu`` based
-    on the SGLang runtime (Blackwell + DeepGEMM → UE8M0, otherwise fp32).
-    Pass an explicit dtype to override.
     """
     N = x.size(-1)
     assert N % block_size == 0
-    if scale_dtype is None:
-        scale_dtype = _resolve_scale_dtype(scale_fmt, block_size)
     tl_dtype = FE8M0 if scale_dtype == torch.float8_e8m0fnu else FP32
     z = x.contiguous()
     y = torch.empty_like(z) if inplace else torch.empty_like(z, dtype=torch.float8_e4m3fn)

--- a/miles_plugins/models/deepseek_v4/ops/qat.py
+++ b/miles_plugins/models/deepseek_v4/ops/qat.py
@@ -13,7 +13,10 @@ def fp8_simulate(x: torch.Tensor, block_size: int):
     the rest of the DeepSeek stack.
     """
     x_c = x.contiguous()
-    y, scale = act_quant(x_c, block_size, "ue8m0")
+    # Force fp32 scale storage: act_quant's auto dtype picks float8_e8m0fnu on
+    # Blackwell+DeepGEMM, but per_token_cast_back below only accepts int32/fp32
+    # scales. scale_fmt="ue8m0" still rounds the values to powers of two.
+    y, scale = act_quant(x_c, block_size, "ue8m0", scale_dtype=torch.float32)
 
     N = x_c.size(-1)
     y_flat = y.view(-1, N)

--- a/miles_plugins/models/deepseek_v4/ops/qat.py
+++ b/miles_plugins/models/deepseek_v4/ops/qat.py
@@ -13,9 +13,7 @@ def fp8_simulate(x: torch.Tensor, block_size: int):
     the rest of the DeepSeek stack.
     """
     x_c = x.contiguous()
-    # act_quant's auto dtype picks float8_e8m0fnu on Blackwell+DeepGEMM,
-    # but per_token_cast_back below only accepts int32/fp32
-    y, scale = act_quant(x_c, block_size, "ue8m0", scale_dtype=torch.float32)
+    y, scale = act_quant(x_c, block_size, "ue8m0")
 
     N = x_c.size(-1)
     y_flat = y.view(-1, N)

--- a/miles_plugins/models/deepseek_v4/ops/qat.py
+++ b/miles_plugins/models/deepseek_v4/ops/qat.py
@@ -13,9 +13,8 @@ def fp8_simulate(x: torch.Tensor, block_size: int):
     the rest of the DeepSeek stack.
     """
     x_c = x.contiguous()
-    # Force fp32 scale storage: act_quant's auto dtype picks float8_e8m0fnu on
-    # Blackwell+DeepGEMM, but per_token_cast_back below only accepts int32/fp32
-    # scales. scale_fmt="ue8m0" still rounds the values to powers of two.
+    # act_quant's auto dtype picks float8_e8m0fnu on Blackwell+DeepGEMM,
+    # but per_token_cast_back below only accepts int32/fp32
     y, scale = act_quant(x_c, block_size, "ue8m0", scale_dtype=torch.float32)
 
     N = x_c.size(-1)

--- a/scripts/run_deepseek_v4.py
+++ b/scripts/run_deepseek_v4.py
@@ -155,6 +155,7 @@ def _is_blackwell(args: ScriptArgs) -> bool:
     major, _minor = torch.cuda.get_device_capability()
     return major >= 10
 
+
 def _download_dataset(args: ScriptArgs):
     """Download the task-specific dataset(s)."""
     match args.task:

--- a/scripts/run_deepseek_v4.py
+++ b/scripts/run_deepseek_v4.py
@@ -103,7 +103,10 @@ class ScriptArgs(U.ExecuteTrainConfig):
     # precision configs
     enable_r3: bool = True
     train_deterministic: bool = True
-    fp8_training: bool | None = None
+    # Precision recipe for BOTH trainer (Megatron/TE) and rollout (sglang checkpoint):
+    #   fp8   - blockwise FP8 128x128 (Hopper: fp32 scales; Blackwell: pow2 scales, MXFP8-emulated)
+    #   bf16  - BF16 training; rollout serves the source FP8 checkpoint
+    recipe: Literal["fp8", "bf16"] = "fp8"
     enable_mis: bool = False
 
     # pass any extra sglang/miles/megatron args through `--extra-args '--your-arg'`
@@ -151,13 +154,6 @@ def _is_blackwell(args: ScriptArgs) -> bool:
         raise RuntimeError("Cannot auto-detect hardware because CUDA is not available. Pass --hardware explicitly.")
     major, _minor = torch.cuda.get_device_capability()
     return major >= 10
-
-
-def _resolve_precision_defaults(args: ScriptArgs):
-    if args.fp8_training is None:
-        args.fp8_training = not _is_blackwell(args)
-        print(f"[precision] fp8_training auto -> {args.fp8_training}")
-
 
 def _download_dataset(args: ScriptArgs):
     """Download the task-specific dataset(s)."""
@@ -365,7 +361,7 @@ def _get_parallel_config(args: ScriptArgs) -> str:
 
 
 def _train(args: ScriptArgs):
-    _resolve_precision_defaults(args)
+    print(f"[precision] recipe={args.recipe}")
     print(
         f"running on {args.num_nodes} nodes "
         f"({args.actor_num_nodes} actor nodes x {args.actor_num_gpus_per_node} GPUs/node, "
@@ -474,6 +470,7 @@ def _train(args: ScriptArgs):
         sglang_a2a_backend = None
     sglang_args = (
         f"--rollout-num-gpus-per-engine {sglang_world_size} "
+        "--sglang-fp8-gemm-backend auto "
         f"--sglang-tp-size {sglang_tp_size} "
         f"--sglang-dp-size {sglang_dp_size} "
         "--sglang-enable-dp-attention "
@@ -563,11 +560,22 @@ def _train(args: ScriptArgs):
             "CUBLAS_WORKSPACE_CONFIG": ":4096:8",
         }
 
-    if args.fp8_training:
-        misc_args += "--transformer-impl transformer_engine " "--bf16 " "--fp8-format e4m3 " "--fp8-recipe blockwise "
-        extra_env_vars |= {
-            "NVTE_FP8_BLOCK_SCALING_FP32_SCALES": "1",
-        }
+    match args.recipe:
+        case "fp8":
+            misc_args += (
+                "--transformer-impl transformer_engine " "--bf16 " "--fp8-format e4m3 " "--fp8-recipe blockwise "
+            )
+            if not _is_blackwell(args):
+                extra_env_vars |= {
+                    "NVTE_FP8_BLOCK_SCALING_FP32_SCALES": "1",
+                }
+            else:
+                # actor_group.py unconditionally injects NVTE_FP8_BLOCK_SCALING_FP32_SCALES=1
+                # into train actors; on Blackwell the TE blockwise recipe is emulated with
+                # MXFP8 and requires power-of-two scales, so force it back to 0 here.
+                misc_args += """--train-env-vars '{"NVTE_FP8_BLOCK_SCALING_FP32_SCALES":"0"}' """
+        case "bf16":
+            pass
 
     train_args = (
         f"{ckpt_args} "

--- a/scripts/run_deepseek_v4.py
+++ b/scripts/run_deepseek_v4.py
@@ -103,10 +103,10 @@ class ScriptArgs(U.ExecuteTrainConfig):
     # precision configs
     enable_r3: bool = True
     train_deterministic: bool = True
-    # Precision recipe for BOTH trainer (Megatron/TE) and rollout (sglang checkpoint):
-    #   fp8   - blockwise FP8 128x128 (Hopper: fp32 scales; Blackwell: pow2 scales, MXFP8-emulated)
-    #   bf16  - BF16 training; rollout serves the source FP8 checkpoint
-    recipe: Literal["fp8", "bf16"] = "fp8"
+    # Megatron-side training precision: blockwise FP8 128x128 GEMMs when True
+    # (Hopper: fp32 scales; Blackwell: pow2 scales, MXFP8-emulated), BF16 when False.
+    # Rollout always serves the source FP8 checkpoint either way.
+    fp8_training: bool = True
     enable_mis: bool = False
 
     # pass any extra sglang/miles/megatron args through `--extra-args '--your-arg'`
@@ -362,7 +362,7 @@ def _get_parallel_config(args: ScriptArgs) -> str:
 
 
 def _train(args: ScriptArgs):
-    print(f"[precision] recipe={args.recipe}")
+    print(f"[precision] fp8_training={args.fp8_training}")
     print(
         f"running on {args.num_nodes} nodes "
         f"({args.actor_num_nodes} actor nodes x {args.actor_num_gpus_per_node} GPUs/node, "
@@ -560,7 +560,7 @@ def _train(args: ScriptArgs):
             "CUBLAS_WORKSPACE_CONFIG": ":4096:8",
         }
 
-    if args.recipe == "fp8":
+    if args.fp8_training:
         misc_args += "--transformer-impl transformer_engine " "--bf16 " "--fp8-format e4m3 " "--fp8-recipe blockwise "
         # On Blackwell, TE emulates the blockwise recipe with MXFP8, which requires pow2 scales.
         fp32_scales = "0" if _is_blackwell(args) else "1"

--- a/scripts/run_deepseek_v4.py
+++ b/scripts/run_deepseek_v4.py
@@ -471,7 +471,6 @@ def _train(args: ScriptArgs):
         sglang_a2a_backend = None
     sglang_args = (
         f"--rollout-num-gpus-per-engine {sglang_world_size} "
-        "--sglang-fp8-gemm-backend auto "
         f"--sglang-tp-size {sglang_tp_size} "
         f"--sglang-dp-size {sglang_dp_size} "
         "--sglang-enable-dp-attention "
@@ -561,22 +560,11 @@ def _train(args: ScriptArgs):
             "CUBLAS_WORKSPACE_CONFIG": ":4096:8",
         }
 
-    match args.recipe:
-        case "fp8":
-            misc_args += (
-                "--transformer-impl transformer_engine " "--bf16 " "--fp8-format e4m3 " "--fp8-recipe blockwise "
-            )
-            if not _is_blackwell(args):
-                extra_env_vars |= {
-                    "NVTE_FP8_BLOCK_SCALING_FP32_SCALES": "1",
-                }
-            else:
-                # actor_group.py unconditionally injects NVTE_FP8_BLOCK_SCALING_FP32_SCALES=1
-                # into train actors; on Blackwell the TE blockwise recipe is emulated with
-                # MXFP8 and requires power-of-two scales, so force it back to 0 here.
-                misc_args += """--train-env-vars '{"NVTE_FP8_BLOCK_SCALING_FP32_SCALES":"0"}' """
-        case "bf16":
-            pass
+    if args.recipe == "fp8":
+        misc_args += "--transformer-impl transformer_engine " "--bf16 " "--fp8-format e4m3 " "--fp8-recipe blockwise "
+        # On Blackwell, TE emulates the blockwise recipe with MXFP8, which requires pow2 scales.
+        fp32_scales = "0" if _is_blackwell(args) else "1"
+        misc_args += f"""--train-env-vars '{{"NVTE_FP8_BLOCK_SCALING_FP32_SCALES":"{fp32_scales}"}}' """
 
     train_args = (
         f"{ckpt_args} "


### PR DESCRIPTION
Verified end-to-end on B200 (4-layer prune, colocate, tp=ep=2): weight-update check (--check-weight-update-equal) passes bitwise with the deepgemm fp8 GEMM backend; train_rollout_logprob_abs_diff ~= 0.06.

- run_deepseek_v4.py: replace fp8_training with an explicit --recipe {fp8,bf16} selector. On Blackwell, TE emulates the blockwise recipe with MXFP8 and asserts power-of-two scales, so instead of exporting NVTE_FP8_BLOCK_SCALING_FP32_SCALES=1 (Hopper-only now) override the unconditional =1 injection from ray/actor_group.py back to 0 via --train-env-vars.
- deepseek_v4 qat.py: force fp32 scale storage in fp8_simulate. The act_quant auto dtype picks float8_e8m0fnu on Blackwell+DeepGEMM, but TileKernels cast_back only accepts int32/fp32 scales.