### PR TITLE
feat(rl): add REINFORCE advantage estimator

### DIFF
--- a/docs/user-guide/cli-reference.md
+++ b/docs/user-guide/cli-reference.md
@@ -64,7 +64,7 @@ then push up until you OOM.
 
 | Flag | Default | What |
 |---|---|---|
-| `--advantage-estimator` | `grpo` | `grpo`, `gspo`, `ppo`, `reinforce_plus_plus`, `reinforce_plus_plus_baseline`. On-policy distillation is not an estimator — enable it with `--use-opd` on top of any of these. |
+| `--advantage-estimator` | `grpo` | `grpo`, `gspo`, `ppo`, `reinforce`, `reinforce_plus_plus`, `reinforce_plus_plus_baseline`. On-policy distillation is not an estimator — enable it with `--use-opd` on top of any of these. |
 | `--use-kl-loss` | off | Compute KL against the reference model. |
 | `--kl-loss-coef` | `0.0` | Weight of KL in the loss (0 means monitor only). |
 | `--kl-loss-type` | `k1` | `k1`, `k2`, `k3`, `low_var_kl`. |
@@ -234,7 +234,7 @@ Sections mirror the launch-script argument groups.
 
 | Flag | Type | Default | Notes |
 |---|---|---|---|
-| `--advantage-estimator` | enum | `grpo` | `grpo`, `gspo`, `ppo`, `reinforce_plus_plus`, `reinforce_plus_plus_baseline`. |
+| `--advantage-estimator` | enum | `grpo` | `grpo`, `gspo`, `ppo`, `reinforce`, `reinforce_plus_plus`, `reinforce_plus_plus_baseline`. |
 | `--use-kl-loss` | flag | off | Compute KL vs. reference. |
 | `--kl-loss-coef` | float | `0.0` | KL weight in loss (0 means monitor). |
 | `--kl-loss-type` | enum | `k1` | `k1`, `k2`, `k3`, `low_var_kl`. |

--- a/miles/backends/training_utils/loss.py
+++ b/miles/backends/training_utils/loss.py
@@ -33,8 +33,8 @@ def compute_advantages_and_returns(
 
     This function extracts rewards, log-probs, values, and masks from
     `rollout_data`, computes KL divergences, then applies the chosen advantage
-    estimator. Supported methods: "grpo", "gspo", "ppo", "reinforce_plus_plus",
-    and "reinforce_plus_plus_baseline". On-policy distillation (OPD) is applied
+    estimator. Supported methods: "grpo", "gspo", "ppo", "reinforce",
+    "reinforce_plus_plus", and "reinforce_plus_plus_baseline". On-policy distillation (OPD) is applied
     orthogonally on top of any estimator via `args.use_opd`. When
     `args.normalize_advantages` is True, advantages are whitened across the
     data-parallel group using masked statistics.

--- a/miles/backends/training_utils/loss_hub/advantages.py
+++ b/miles/backends/training_utils/loss_hub/advantages.py
@@ -50,7 +50,7 @@ def compute_advantages(
         `advantages`: List length `B`; `advantages[i]` has shape `[C_i]`.
         `returns`: List length `B`; `returns[i]` has shape `[C_i]`.
     """
-    if args.advantage_estimator in ["grpo", "gspo"]:
+    if args.advantage_estimator in ["grpo", "gspo", "reinforce"]:
         rewards = torch.tensor(rewards, dtype=torch.float32, device=kl[0].device)
         returns = get_grpo_returns(rewards, kl)
         # TODO: is the copy necessary?

--- a/miles/backends/training_utils/loss_hub/losses.py
+++ b/miles/backends/training_utils/loss_hub/losses.py
@@ -17,6 +17,7 @@ from miles.backends.training_utils.loss_hub.math_utils import (
     compute_gspo_kl,
     compute_opsm_mask,
     compute_policy_loss,
+    compute_reinforce_loss,
 )
 from miles.backends.training_utils.parallel import get_parallel_state
 from miles.utils.misc import load_function
@@ -204,9 +205,19 @@ def policy_loss_function(
         advantages.new_zeros(()),
     )
 
-    pg_loss, pg_clipfrac = compute_policy_loss(
-        ppo_kl, advantages, args.eps_clip, args.eps_clip_high, getattr(args, "eps_clip_c", None)
-    )
+    if args.advantage_estimator == "reinforce":
+        # log_probs enters the loss raw here (ppo_kl was sanitized above); guard a
+        # masked-token inf that would become 0 * inf = NaN in the reduction.
+        reinforce_log_probs = torch.where(
+            active_tokens,
+            torch.nan_to_num(log_probs, nan=0.0, posinf=0.0, neginf=0.0),
+            log_probs.new_zeros(()),
+        )
+        pg_loss, pg_clipfrac = compute_reinforce_loss(advantages, reinforce_log_probs)
+    else:
+        pg_loss, pg_clipfrac = compute_policy_loss(
+            ppo_kl, advantages, args.eps_clip, args.eps_clip_high, getattr(args, "eps_clip_c", None)
+        )
 
     if getattr(args, "dump_details", None) is not None:
         from miles.backends.training_utils.debug_dump import maybe_dump_policy_loss_debug

--- a/miles/backends/training_utils/loss_hub/math_utils.py
+++ b/miles/backends/training_utils/loss_hub/math_utils.py
@@ -277,6 +277,20 @@ def compute_policy_loss(
     return pg_losses, clipfrac
 
 
+@torch.compile(dynamic=True)
+def compute_reinforce_loss(
+    advantages: torch.Tensor,
+    log_probs: torch.Tensor,
+):
+    """REINFORCE surrogate ``-A * log pi_theta`` (no IS ratio, no clipping); gradient
+    flows only through ``log_probs``. Same ``(per_token_loss, clipfrac)`` contract as
+    :func:`compute_policy_loss`, with ``clipfrac`` identically zero (nothing is clipped).
+    """
+    pg_losses = -advantages * log_probs
+    clipfrac = torch.zeros_like(pg_losses)
+    return pg_losses, clipfrac
+
+
 def compute_log_probs(
     logits: torch.Tensor,
     tokens: torch.Tensor,

--- a/miles/ray/rollout/train_data_conversion.py
+++ b/miles/ray/rollout/train_data_conversion.py
@@ -239,11 +239,16 @@ def _normalize_rewards_by_rollout(
             shared_rewards.append(sibling_rewards[0])
 
         rollout_rewards = torch.tensor(shared_rewards, dtype=torch.float)
-        normalized_rollout_rewards = rollout_rewards - rollout_rewards.mean()
-        if args.advantage_estimator in ["grpo", "gspo"] and args.grpo_std_normalization and len(rollout_rewards) > 1:
-            rollout_std = rollout_rewards.std()
-            if rollout_std > 0:
-                normalized_rollout_rewards = normalized_rollout_rewards / (rollout_std + 1e-6)
+        if len(rollout_rewards) <= 1:
+            # A group of 1 has no baseline: subtracting its own mean would zero
+            # every advantage (including standard n=1 REINFORCE).
+            normalized_rollout_rewards = rollout_rewards
+        else:
+            normalized_rollout_rewards = rollout_rewards - rollout_rewards.mean()
+            if args.advantage_estimator in ["grpo", "gspo", "reinforce"] and args.grpo_std_normalization:
+                rollout_std = rollout_rewards.std()
+                if rollout_std > 0:
+                    normalized_rollout_rewards = normalized_rollout_rewards / (rollout_std + 1e-6)
 
         for (_, rollout_segments), normalized_reward in zip(
             rollout_segment_groups, normalized_rollout_rewards.tolist(), strict=True
@@ -264,7 +269,10 @@ def _post_process_rewards(
         return f(args, samples)
 
     raw_rewards = [sample.get_reward_value(args) for sample in samples]
-    if args.advantage_estimator in ["grpo", "gspo", "reinforce_plus_plus_baseline"] and args.rewards_normalization:
+    if (
+        args.advantage_estimator in ["grpo", "gspo", "reinforce", "reinforce_plus_plus_baseline"]
+        and args.rewards_normalization
+    ):
         normalized_rewards = _normalize_rewards_by_rollout(args, samples, raw_rewards, prompt_group_sizes)
         return raw_rewards, normalized_rewards
 

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -1424,14 +1424,17 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 choices=[
                     "grpo",
                     "gspo",
+                    "reinforce",
                     "reinforce_plus_plus",
                     "reinforce_plus_plus_baseline",
                     "ppo",
                 ],
                 default="grpo",
                 help=(
-                    "Advantage estimator to use. Note: on-policy distillation (OPD) is now orthogonal "
-                    "to the advantage estimator. Use --opd-kl-coef > 0 to enable OPD on top of any estimator."
+                    "Advantage estimator to use. 'reinforce' uses GRPO-style group-normalized "
+                    "advantages with the plain additive surrogate (no PPO/IS ratio, no clipping). "
+                    "Note: on-policy distillation (OPD) is now orthogonal to the advantage estimator. "
+                    "Use --opd-kl-coef > 0 to enable OPD on top of any estimator."
                 ),
             )
             parser.add_argument(

--- a/tests/fast/backends/training_utils/loss/test_reinforce.py
+++ b/tests/fast/backends/training_utils/loss/test_reinforce.py
@@ -1,0 +1,111 @@
+"""Unit/integration tests for the ``reinforce`` advantage estimator.
+
+``reinforce`` uses GRPO-style group-normalized advantages with the plain additive
+surrogate ``-A * log pi_theta`` (no PPO/IS ratio, no clipping). Mirrors the
+targeted-test style of ``test_opd.py`` (closed-form values + invariants through the
+full ``policy_loss_function`` path) rather than the snapshot harness (whose artifacts
+live in an external repo).
+"""
+
+import torch
+
+from miles.backends.training_utils.cp_utils import get_sum_of_sample_mean
+from miles.backends.training_utils.loss import compute_advantages_and_returns
+from miles.backends.training_utils.loss_hub.losses import policy_loss_function
+from miles.backends.training_utils.loss_hub.math_utils import compute_reinforce_loss
+
+from .loss_test_utils import make_args, make_batch, make_inputs, make_parallel_state, make_rollout_data
+
+# This module intentionally has no explicit CI registration call: modules under
+# tests/fast are implicitly assigned to the stage-a-cpu suite by the CI collector
+# (an explicit default-form call would be rejected by the AC-9 meta-test).
+
+
+def _sum_of_sample_mean(batch, args):
+    return get_sum_of_sample_mean(
+        batch["total_lengths"],
+        batch["response_lengths"],
+        batch["loss_masks"],
+        args.calculate_per_token_loss,
+        args.qkv_format,
+        batch.get("max_seq_lens"),
+    )
+
+
+def test_reinforce_loss_matches_closed_form():
+    advantages = torch.tensor([2.0, -1.0, 0.5])
+    log_probs = torch.tensor([-0.1, -0.2, -0.3])
+
+    pg_loss, clipfrac = compute_reinforce_loss(advantages, log_probs)
+
+    assert torch.allclose(pg_loss, -advantages * log_probs)
+    assert torch.allclose(clipfrac, torch.zeros(3))
+
+
+def test_reinforce_gradient_flows_only_through_log_probs():
+    advantages = torch.tensor([2.0, -1.0, 0.5])
+    log_probs = torch.tensor([-0.1, -0.2, -0.3], requires_grad=True)
+
+    pg_loss, _ = compute_reinforce_loss(advantages, log_probs)
+    pg_loss.sum().backward()
+
+    # d/d log_probs [ -A * log_probs ] = -A
+    assert torch.allclose(log_probs.grad, -advantages)
+
+
+def test_reinforce_advantages_are_reward_broadcast():
+    # `reinforce` reuses the GRPO returns path: the (group-normalized, upstream)
+    # scalar reward is broadcast to every response token, and advantages == returns.
+    make_parallel_state()
+    args = make_args(advantage_estimator="reinforce", kl_coef=0.0)
+    inputs = make_inputs(seed=3, batch_size=2, prompt_lens=[6, 4], response_lens=[5, 7], vocab_size=32, args=args)
+    rollout_data = make_rollout_data(inputs)
+
+    compute_advantages_and_returns(args, rollout_data)
+
+    for i, reward in enumerate(inputs["rewards"]):
+        expected = torch.full((inputs["response_lens"][i],), reward)
+        assert torch.allclose(rollout_data["returns"][i], expected)
+        assert torch.allclose(rollout_data["advantages"][i], rollout_data["returns"][i])
+
+
+def test_reinforce_full_path_is_linear_in_advantages_and_zero_at_zero():
+    # Integration property: with no IS ratio and entropy off, the reduced pg_loss is
+    # linear in the advantages (loss = mean(-A * log pi)), and zero when A == 0.
+    make_parallel_state()
+    args = make_args(advantage_estimator="reinforce", entropy_coef=0.0, observe_training_entropy=False)
+    inputs = make_inputs(seed=2, batch_size=2, prompt_lens=[8, 5], response_lens=[6, 4], vocab_size=32, args=args)
+
+    def run(scale: float) -> torch.Tensor:
+        batch = make_batch(inputs, "policy_loss")
+        batch["advantages"] = [scale * a for a in batch["advantages"]]
+        logits = inputs["policy_logits"].clone().requires_grad_(True)
+        loss, metrics = policy_loss_function(args, batch, logits, _sum_of_sample_mean(batch, args))
+        return metrics["pg_loss"]
+
+    base = run(1.0)
+    assert torch.allclose(run(0.0), torch.zeros(()))
+    assert torch.allclose(run(2.0), 2.0 * base, atol=1e-5)
+
+
+def test_reinforce_full_path_masked_inf_logprob_does_not_poison_loss():
+    # REINFORCE multiplies raw current-policy log_probs into the loss; an inf at a
+    # loss-masked token must be sanitized before the masked reduction (0 * inf = NaN).
+    make_parallel_state()
+    args = make_args(advantage_estimator="reinforce", entropy_coef=0.0, observe_training_entropy=False)
+    inputs = make_inputs(seed=0, batch_size=1, prompt_lens=[4], response_lens=[4], vocab_size=16, args=args)
+
+    inputs["loss_masks"][0][2] = 0.0
+    # response token 2 is predicted from logits row total_len - response_len - 1 + 2 = 5.
+    target_token = inputs["unconcat_tokens"][0][4 + 2]
+    inputs["policy_logits"][0, 5, target_token] = float("-inf")
+
+    batch = make_batch(inputs, "policy_loss")
+    logits = inputs["policy_logits"].requires_grad_(True)
+    loss, metrics = policy_loss_function(args, batch, logits, _sum_of_sample_mean(batch, args))
+    loss.backward()
+
+    assert torch.isfinite(loss)
+    assert torch.isfinite(logits.grad).all()
+    # REINFORCE never clips
+    assert torch.allclose(metrics["pg_clipfrac"], torch.zeros(()))

--- a/tests/fast/ray/rollout/test_train_data_conversion.py
+++ b/tests/fast/ray/rollout/test_train_data_conversion.py
@@ -280,6 +280,34 @@ class TestPostProcessRewards:
         expected_std = float(np.std([-1.5, -0.5, 0.5, 1.5]))
         assert abs(np.std(processed) - expected_std) < 1e-5
 
+    def test_reinforce_uses_grpo_normalization_including_std(self):
+        args = make_args(
+            advantage_estimator="reinforce",
+            rewards_normalization=True,
+            grpo_std_normalization=True,
+            n_samples_per_prompt=4,
+            rollout_batch_size=1,
+        )
+        samples = make_samples_grouped(1, 4, rewards=[1.0, 2.0, 3.0, 4.0])
+        _, processed = _post_process_rewards(args, samples, custom_reward_post_process_func=None)
+        import numpy as np
+
+        assert abs(sum(processed) / 4) < 1e-5
+        assert abs(np.std(processed, ddof=1) - 1.0) < 1e-4
+
+    def test_reinforce_singleton_group_keeps_raw_rewards(self):
+        # A group of 1 has no baseline; subtracting its mean would zero the advantage.
+        args = make_args(
+            advantage_estimator="reinforce",
+            rewards_normalization=True,
+            grpo_std_normalization=True,
+            n_samples_per_prompt=1,
+            rollout_batch_size=1,
+        )
+        samples = make_samples_grouped(1, 1, rewards=[3.5])
+        raw, processed = _post_process_rewards(args, samples, custom_reward_post_process_func=None)
+        assert processed == raw == [3.5]
+
     def test_irregular_group_size_uses_explicit_group_index(self):
         """Explicit group identity keeps an irregularly sized group together."""
         args = make_args(


### PR DESCRIPTION
## What

Adds a plain `reinforce` advantage estimator: GRPO-style group-normalized advantages with the additive `-A·logπ` surrogate (`compute_reinforce_loss`) — no PPO/IS ratio, no clipping, gradient only through `log_probs`. It reuses the existing GRPO returns / group-normalization plumbing; only the surrogate differs from `grpo`.

A singleton reward group keeps raw rewards so n=1 REINFORCE is not zeroed by subtracting its own mean.

This is the on-policy REINFORCE base. Off-policy importance-sampling corrections layer on top of it via the existing TIS hook (companion #1344).

## Changes

- `compute_reinforce_loss` in `math_utils.py`
- `reinforce` routed through the GRPO returns path (`advantages.py`) and group normalization (`train_data_conversion.py`)
- `--advantage-estimator` choices/help, `policy_loss_function` dispatch, CLI reference

## Tests

`tests/fast/backends/training_utils/loss/test_reinforce.py` and `TestPostProcessRewards` in `tests/fast/ray/rollout/test_train_data_conversion.py`.