### PR TITLE
fix(rollout): score SGLang logprobs at rollout temperature

### DIFF
--- a/miles/rollout/generate_utils/prefill_logprobs.py
+++ b/miles/rollout/generate_utils/prefill_logprobs.py
@@ -38,7 +38,7 @@ def _build_prefill_scoring_payload(
         "sampling_params": {
             **dict(sampling_params),
             "max_new_tokens": 0,
-            "temperature": 0,
+            "temperature": args.rollout_temperature,
             "skip_special_tokens": False,
         },
         "return_logprob": True,

--- a/miles/rollout/on_policy_distillation.py
+++ b/miles/rollout/on_policy_distillation.py
@@ -97,11 +97,13 @@ def _score_payload(
     top_k: int = 0,
     token_ids: list[int] | None = None,
     token_ids_positions: list[list[int]] | None = None,
+    *,
+    temperature: float,
 ) -> dict[str, Any]:
     payload = {
         "input_ids": input_ids,
         "sampling_params": {
-            "temperature": 0,
+            "temperature": temperature,
             "max_new_tokens": 0,
             "skip_special_tokens": False,
         },
@@ -351,6 +353,7 @@ def _compute_topk_reverse_kl(
 
 async def reward_func(args: Namespace, sample: Sample, **kwargs: Any) -> dict[str, Any]:
     top_k = _get_opd_top_k(args)
+    temperature = args.rollout_temperature
     # Optional per-request timeout so a hung teacher/student scoring call cannot stall
     # the whole rollout (no-op when unset).
     request_timeout = getattr(args, "sglang_router_request_timeout_secs", None)
@@ -358,7 +361,9 @@ async def reward_func(args: Namespace, sample: Sample, **kwargs: Any) -> dict[st
     # --rm-url when --opd-teacher-urls is unset).
     teacher_url = _teacher_url_for_sample(args, sample)
     if top_k == 0:
-        return await _post_json(teacher_url, _score_payload(sample.tokens), timeout_secs=request_timeout)
+        return await _post_json(
+            teacher_url, _score_payload(sample.tokens, temperature=temperature), timeout_secs=request_timeout
+        )
 
     strategy = _get_top_k_strategy(args)
     # Per-position scoring requires a patched teacher/student server that understands
@@ -376,12 +381,17 @@ async def reward_func(args: Namespace, sample: Sample, **kwargs: Any) -> dict[st
 
     if student_top is not None and per_position:
         teacher_payload = _score_payload(
-            sample.tokens, top_k=teacher_top_k, token_ids_positions=_per_position_ids(student_top, prompt_len)
+            sample.tokens,
+            top_k=teacher_top_k,
+            token_ids_positions=_per_position_ids(student_top, prompt_len),
+            temperature=temperature,
         )
     elif teacher_token_ids is not None:
-        teacher_payload = _score_payload(sample.tokens, top_k=teacher_top_k, token_ids=teacher_token_ids)
+        teacher_payload = _score_payload(
+            sample.tokens, top_k=teacher_top_k, token_ids=teacher_token_ids, temperature=temperature
+        )
     else:
-        teacher_payload = _score_payload(sample.tokens, top_k=teacher_top_k)
+        teacher_payload = _score_payload(sample.tokens, top_k=teacher_top_k, temperature=temperature)
     teacher_response = await _post_json(teacher_url, teacher_payload, timeout_secs=request_timeout)
 
     reward_payload = {"teacher": teacher_response}
@@ -389,10 +399,14 @@ async def reward_func(args: Namespace, sample: Sample, **kwargs: Any) -> dict[st
         teacher_top = _trim_input_field(teacher_response["meta_info"], "input_top_logprobs", sample.response_length)
         if per_position:
             student_payload = _score_payload(
-                sample.tokens, token_ids_positions=_per_position_ids(teacher_top, prompt_len)
+                sample.tokens,
+                token_ids_positions=_per_position_ids(teacher_top, prompt_len),
+                temperature=temperature,
             )
         else:
-            student_payload = _score_payload(sample.tokens, token_ids=_unique_ids(teacher_top))
+            student_payload = _score_payload(
+                sample.tokens, token_ids=_unique_ids(teacher_top), temperature=temperature
+            )
         reward_payload["student_on_teacher"] = await _post_json(
             _student_score_url(args), student_payload, timeout_secs=request_timeout
         )

--- a/tests/fast/rollout/generate_utils/test_prefill_logprobs.py
+++ b/tests/fast/rollout/generate_utils/test_prefill_logprobs.py
@@ -14,7 +14,7 @@ async def test_recompute_rollout_logprobs_via_prefill_uses_response_tail(monkeyp
         rollout_log_probs=[-9.0, -9.0, -9.0],
         status=Sample.Status.COMPLETED,
     )
-    args = SimpleNamespace(recompute_logprobs_via_prefill=True, sglang_enable_lora=False)
+    args = SimpleNamespace(recompute_logprobs_via_prefill=True, sglang_enable_lora=False, rollout_temperature=0.7)
     seen = {}
 
     async def fake_post(url, payload, headers=None):
@@ -50,13 +50,13 @@ async def test_recompute_rollout_logprobs_via_prefill_uses_response_tail(monkeyp
     assert seen["payload"]["return_logprob"] is True
     assert seen["payload"]["logprob_start_len"] == 2
     assert seen["payload"]["sampling_params"]["max_new_tokens"] == 0
-    assert seen["payload"]["sampling_params"]["temperature"] == 0
+    assert seen["payload"]["sampling_params"]["temperature"] == 0.7
 
 
 @pytest.mark.asyncio
 async def test_recompute_rollout_logprobs_via_prefill_checks_token_alignment(monkeypatch):
     sample = Sample(tokens=[10, 11, 20], response_length=1, status=Sample.Status.COMPLETED)
-    args = SimpleNamespace(recompute_logprobs_via_prefill=True, sglang_enable_lora=False)
+    args = SimpleNamespace(recompute_logprobs_via_prefill=True, sglang_enable_lora=False, rollout_temperature=1.0)
 
     async def fake_post(url, payload, headers=None):
         return {"meta_info": {"input_token_logprobs": [(None, 11), (-0.1, 999)]}}
@@ -82,6 +82,7 @@ async def test_recompute_samples_flushes_each_batch_and_batches_prefill_score(mo
         recompute_logprobs_via_prefill=True,
         sglang_enable_lora=False,
         sglang_router_policy="round_robin",
+        rollout_temperature=1.0,
     )
     calls = []
 
@@ -124,7 +125,7 @@ async def test_recompute_uses_per_sample_adapter_lora_path(monkeypatch):
         adapter=AdapterRef(name="run-a", slot=3),
     )
     # Multi-LoRA forces lora_rank > 0, so is_lora_enabled(args) is always true.
-    args = SimpleNamespace(recompute_logprobs_via_prefill=True, lora_rank=8)
+    args = SimpleNamespace(recompute_logprobs_via_prefill=True, lora_rank=8, rollout_temperature=1.0)
     seen = {}
 
     async def fake_post(url, payload, headers=None):
@@ -172,6 +173,7 @@ async def test_recompute_samples_batches_group_by_adapter(monkeypatch):
         recompute_logprobs_via_prefill=True,
         lora_rank=8,
         sglang_router_policy="round_robin",
+        rollout_temperature=1.0,
     )
     generate_payloads = []
 
@@ -206,7 +208,7 @@ def test_batch_payload_rejects_mixed_lora_paths():
         Sample(tokens=[10, 11, 20], response_length=1, adapter=AdapterRef(name="run-a", slot=0)),
         Sample(tokens=[10, 11, 21], response_length=1, adapter=AdapterRef(name="run-b", slot=1)),
     ]
-    args = SimpleNamespace(lora_rank=8)
+    args = SimpleNamespace(lora_rank=8, rollout_temperature=1.0)
 
     with pytest.raises(ValueError, match="shared lora_path"):
         prefill_logprobs._build_batch_prefill_scoring_payload(args, samples, {})
@@ -223,6 +225,7 @@ async def test_recompute_samples_batches_by_logprob_start_len(monkeypatch):
         recompute_logprobs_via_prefill=True,
         sglang_enable_lora=False,
         sglang_router_policy="round_robin",
+        rollout_temperature=1.0,
     )
     calls = []
 

--- a/tests/fast/rollout/test_on_policy_distillation.py
+++ b/tests/fast/rollout/test_on_policy_distillation.py
@@ -122,11 +122,12 @@ def test_per_position_ids_pads_prompt_and_keeps_response_order():
 
 
 def test_score_payload_routes_per_position_vs_flat():
-    flat = _score_payload([1, 2, 3], token_ids=[5, 7])
+    flat = _score_payload([1, 2, 3], token_ids=[5, 7], temperature=0.7)
     assert flat["token_ids_logprob"] == [5, 7]
     assert "token_ids_logprob_positions" not in flat
+    assert flat["sampling_params"]["temperature"] == 0.7
 
-    per_pos = _score_payload([1, 2, 3], token_ids_positions=[[], [5, 7], [9, 11]])
+    per_pos = _score_payload([1, 2, 3], token_ids_positions=[[], [5, 7], [9, 11]], temperature=0.7)
     assert per_pos["token_ids_logprob_positions"] == [[], [5, 7], [9, 11]]
     assert "token_ids_logprob" not in per_pos
 


### PR DESCRIPTION
Twin of THUDM/slime#2085 (OPD teacher temperature), plus the Miles-only prefill recompute path. Recut onto current `main`.

## Problem

Importance-sampling corrections (TIS / `--use-rollout-logprobs`), train/rollout mismatch metrics, and on-policy distillation compare SGLang-computed log-probs against training-side log-probs. The invariant is consistency: both sides must use the same temperature, not always T=1.

Two re-score paths were still hardcoding `temperature: 0`:

- `--recompute-logprobs-via-prefill`
- the on-policy-distillation teacher scorer

When `rollout_temperature != 1`, those paths score at the wrong temperature.

## Fix

Score both paths with `args.rollout_temperature` instead of hardcoded `0`. Unchanged at the default `rollout_temperature=1.0`.

## Tests

- `tests/fast/rollout/generate_utils/test_prefill_logprobs.py`
- `tests/fast/rollout/test_on_policy_distillation.py`