### PR TITLE
use sglang router in deepseek v32 script

### DIFF
--- a/tests/e2e/megatron/test_deepseek_v32_5layer_fp8.py
+++ b/tests/e2e/megatron/test_deepseek_v32_5layer_fp8.py
@@ -29,7 +29,7 @@ def _args() -> ScriptArgs:
         num_rollout=2,
         extra_args=(
             "--ci-test --bf16 --freeze-indexer "
-            "--use-rollout-routing-replay --use-miles-router "
+            "--use-rollout-routing-replay "
             "--sglang-disable-shared-experts-fusion "
         ),
     )

--- a/tests/e2e/megatron/test_deepseek_v32_5layer_mxfp8.py
+++ b/tests/e2e/megatron/test_deepseek_v32_5layer_mxfp8.py
@@ -216,7 +216,6 @@ def execute():
 
     misc_args = (
         "--use-rollout-routing-replay "
-        "--use-miles-router "
         "--freeze-indexer "
         "--sglang-disable-shared-experts-fusion "
         "--attention-dropout 0.0 "


### PR DESCRIPTION
## Summary

Drop `--use-miles-router` from the DeepSeek-V3.2 5-layer CI tests so they use the native SGLang router:
- `tests/e2e/megatron/test_deepseek_v32_5layer_fp8.py` (stage-c-8-gpu-h100)
- `tests/e2e/megatron/test_deepseek_v32_5layer_mxfp8.py` (stage-c-8-gpu-b200)

## Why

- There is no v3.2 reason to force miles-router. It is only hardcoded in these CI tests' extra args, not in the production launcher `scripts/run_deepseek_v32.py`, and the comparable `scripts/run_deepseek_v4.py` already uses the sglang router.
- The router is selected by `if parse(sglang_router.__version__) <= parse("0.2.1") or args.use_miles_router`. The installed router is 0.3.2, so dropping the flag makes these tests use the native (token-based) sglang router. `--use-rollout-routing-replay` / the indexer do not depend on it.
- miles-router is unstable and was implicated in the v32 rollout hang: a straggler `/generate` never returned, leaving a zombie request in the engine (`#running-req:1, #token:0`) and timing out the rollout. The native sglang router handles request completion/abort correctly (as in the stable v4 path).

Colocated single-engine CI does not use the only miles-router feature (text-based routing), and miles-router does not support PD disaggregation anyway.