### PR TITLE
Fix SGLang TP memory imbalance env var

### DIFF
--- a/examples/experimental/swe-agent-v2/run-glm47-flash-agentic-async.py
+++ b/examples/experimental/swe-agent-v2/run-glm47-flash-agentic-async.py
@@ -351,7 +351,7 @@ def execute(args: ScriptArgs):
         "PYTHONPATH": f"{args.megatron_path}:{SCRIPT_DIR}:{FULLY_ASYNC_DIR}:{miles_root}",
         "MILES_EXPERIMENTAL_ROLLOUT_REFACTOR": "1",
         "NCCL_NVLS_ENABLE": os.environ.get("HAS_NVLINK", "0"),
-        "SGL_DISABLE_TP_MEMORY_INBALANCE_CHECK": "false",
+        "SGLANG_ENABLE_TP_MEMORY_INBALANCE_CHECK": "true",
         "AGENT_SERVER_URL": args.agent_server_url,
         "AGENT_MODEL_NAME": args.agent_model_name,
         "HARBOR_TASKS_DIR": args.harbor_tasks_dir,

--- a/examples/experimental/swe-agent-v2/run-glm47-reasoning-async.py
+++ b/examples/experimental/swe-agent-v2/run-glm47-reasoning-async.py
@@ -327,7 +327,7 @@ def execute(args: ScriptArgs):
         "PYTHONPATH": f"{args.megatron_path}:{SCRIPT_DIR}:{FULLY_ASYNC_DIR}:{miles_root}",
         "MILES_EXPERIMENTAL_ROLLOUT_REFACTOR": "1",
         "NCCL_NVLS_ENABLE": "0",
-        "SGL_DISABLE_TP_MEMORY_INBALANCE_CHECK": "false",
+        "SGLANG_ENABLE_TP_MEMORY_INBALANCE_CHECK": "true",
         **sglang_extra_env_vars,
     }
 

--- a/examples/experimental/swe-agent-v2/run-glm47-reasoning.py
+++ b/examples/experimental/swe-agent-v2/run-glm47-reasoning.py
@@ -282,7 +282,7 @@ def execute(args: ScriptArgs):
         "PYTHONPATH": f"{args.megatron_path}:{SCRIPT_DIR}:{miles_root}",
         "MILES_EXPERIMENTAL_ROLLOUT_REFACTOR": "1",
         "NCCL_NVLS_ENABLE": "0",
-        "SGL_DISABLE_TP_MEMORY_INBALANCE_CHECK": "false",
+        "SGLANG_ENABLE_TP_MEMORY_INBALANCE_CHECK": "true",
         **sglang_extra_env_vars,
     }
 

--- a/miles/ray/rollout/server_group.py
+++ b/miles/ray/rollout/server_group.py
@@ -103,8 +103,7 @@ class ServerGroup:
                     # TODO: this is hacky. Use env var SGLANG_DG_CACHE_DIR_PER_PROCESS=1
                     # to enable this isolation.
                     "SGLANG_DG_CACHE_DIR": f"/tmp/sglang_deep_gemm/{self.worker_type}_rank_{global_rank}",
-                    "SGL_DISABLE_TP_MEMORY_INBALANCE_CHECK": "true",
-                    "SGLANG_DISABLE_TP_MEMORY_INBALANCE_CHECK": "true",
+                    "SGLANG_ENABLE_TP_MEMORY_INBALANCE_CHECK": "false",
                     "SGLANG_MEMORY_SAVER_CUDA_GRAPH": "true",
                     "SGLANG_OPT_USE_CUSTOM_ALL_REDUCE_V2": (
                         "0" if self.args.colocate and self.args.rollout_num_gpus_per_engine > 1 else "1"


### PR DESCRIPTION
## Summary

- replace deprecated SGLang TP memory imbalance env vars with `SGLANG_ENABLE_TP_MEMORY_INBALANCE_CHECK`
- preserve existing behavior by mapping old disable-style values to the new enable-style values
- update both rollout server setup and SWE agent example launch configs

## Context

SGLang changed the runtime control from `SGL_DISABLE_TP_MEMORY_INBALANCE_CHECK` to `SGLANG_ENABLE_TP_MEMORY_INBALANCE_CHECK` in sgl-project/sglang#15802 (`f4e835af2faa18220e327264efaa02e74dc2f60a`).

Fixes #1348.

## Test plan

- `python3 -m py_compile miles/ray/rollout/server_group.py examples/experimental/swe-agent-v2/run-glm47-flash-agentic-async.py examples/experimental/swe-agent-v2/run-glm47-reasoning.py examples/experimental/swe-agent-v2/run-glm47-reasoning-async.py`
