### PR TITLE
feat(loss): add --loss-aggregation pg_loss modes

### DIFF
--- a/docs/user-guide/cli-reference.md
+++ b/docs/user-guide/cli-reference.md
@@ -234,7 +234,9 @@ Sections mirror the launch-script argument groups.
 | `--use-tis` | flag | off | Truncated Importance Sampling. |
 | `--use-routing-replay` | flag | off | Forward/backward routing consistency. |
 | `--use-rollout-routing-replay` | flag | off | R3 — capture inference-side expert routing and replay it during training. |
-| `--calculate-per-token-loss` | flag | off | Per-token loss reduction. |
+| `--calculate-per-token-loss` | flag | off | Legacy alias for `--loss-aggregation token_mean` (global per-token mean); kept for backward compatibility. Prefer `--loss-aggregation token_mean`. |
+| `--loss-aggregation` | enum | `sample_mean` | How pg_loss is aggregated (pg_loss only): `sample_mean` (GRPO), `prompt_mean` (DAPO), `token_mean` (= legacy `--calculate-per-token-loss`), `constant` (Dr.GRPO). See [customization](/user-guide/customization). |
+| `--loss-aggregation-divisor` | float | unset | Constant divisor `L` for `--loss-aggregation constant`; required and validated `> 0`. Combines with the standard `/ global_batch_size` step average for an effective `/(L * global_batch_size)`; incompatible with `--calculate-per-token-loss`. |
 | `--no-check-for-nan-in-loss-and-grad` | flag | off | Skip NaN/Inf guard (Megatron flag, debug only). |
 | `--true-on-policy-mode` | flag | off | Strict on-policy: reject samples from a prior policy. |
 

--- a/docs/user-guide/customization.md
+++ b/docs/user-guide/customization.md
@@ -189,8 +189,52 @@ def get_pg_loss_reducer(
     ...
 ```
 
-Use case: Dr.GRPO divides by a constant instead of effective token count.
+Use case: a normalization not covered by `--loss-aggregation` below. The four
+standard modes are available first class; reach for this hook only for a custom
+reducer. When set, it takes precedence over `--loss-aggregation`.
 **Reference:** [`examples/DrGRPO/custom_reducer.py`](https://github.com/radixark/miles/blob/main/examples/DrGRPO/custom_reducer.py).
+
+### `--loss-aggregation`
+
+`--loss-aggregation {sample_mean,prompt_mean,token_mean,constant}` selects how
+pg_loss is aggregated across a training step (pg_loss only; every other metric -
+`pg_clipfrac`, `ppo_kl`, `entropy_loss`, `kl_loss` - keeps the default sample-mean
+reducer, the same scope as the custom hook above). Modes follow the ScaleRL
+taxonomy ([arXiv:2510.13786](https://arxiv.org/abs/2510.13786) section 3.2):
+
+| Mode | Paper | pg_loss denominator |
+| :--- | :--- | :--- |
+| `sample_mean` (default) | GRPO sample average | Per-rollout token-weighted mean; each rollout contributes equally regardless of fan-out. Same behavior as the prior default. |
+| `prompt_mean` | DAPO prompt average | Per-prompt-group token-weighted mean (all rollouts sharing a `Sample.group_index` share one denominator). ScaleRL's recommended default for new recipes. |
+| `token_mean` | token average | Global per-token mean. This is the same objective as the legacy `--calculate-per-token-loss` flag (see below); prefer `--loss-aggregation token_mean`. |
+| `constant` | Dr.GRPO ([arXiv:2503.20783](https://arxiv.org/abs/2503.20783)) | `sum(token_loss * loss_mask) / L`, where `L = --loss-aggregation-divisor` (e.g. the max context length). |
+
+`--calculate-per-token-loss` is the legacy spelling of `--loss-aggregation
+token_mean`: both select the global per-token mean. It is kept for backward
+compatibility (existing Megatron-style recipes), but new recipes should prefer
+`--loss-aggregation token_mean`. The two spellings are reconciled onto one axis at
+startup: `--calculate-per-token-loss` alone reports `loss_aggregation=token_mean`,
+and either spelling alone is accepted. They
+may not be combined with a *different* mode: `prompt_mean` or `constant` together
+with `--calculate-per-token-loss` is rejected at startup (per-token loss would
+renormalize by the token count and undo that mode's denominator).
+
+`--loss-aggregation-divisor L` is required (validated `> 0` at startup) only for
+`constant`; it is ignored for the other modes.
+
+Every mode shares the same outer structure: each step's pg_loss sum is divided by
+`global_batch_size` (the standard step average). The per-mode denominator above is
+the *inner* per-sample scale. For `constant`, the effective denominator is therefore
+`L * global_batch_size`: `L` sets the data-independent per-token scale (so loss is
+length-unbiased, Dr.GRPO's point) and the `/ global_batch_size` step average is
+identical to every other mode. Pick `L` on the order of the max response length to
+keep the loss magnitude comparable to the data-dependent modes.
+
+`prompt_mean` weights every prompt group equally: each group's token-weighted
+mean contributes once, and the final scalar is the mean over prompt groups. It
+requires `global_batch_size` to be a multiple of `n_samples_per_prompt`, so a
+contiguous train step keeps each prompt group whole instead of normalizing
+against a partially-present group total.
 
 ### `--custom-convert-samples-to-train-data-path`
 

--- a/miles/backends/experimental/fsdp_utils/actor.py
+++ b/miles/backends/experimental/fsdp_utils/actor.py
@@ -465,6 +465,7 @@ class FSDPTrainRayActor(TrainRayActor):
                             "returns",
                             "ref_log_probs",
                             "rollout_log_probs",
+                            "prompt_mask_sums",
                         ],
                         self.args.data_pad_size_multiplier,
                         self.args.qkv_format,

--- a/miles/backends/megatron_utils/model.py
+++ b/miles/backends/megatron_utils/model.py
@@ -417,6 +417,7 @@ def train_one_step(
                 "rollout_log_probs",
                 "max_seq_lens",
                 "opd_reverse_kl",
+                "prompt_mask_sums",
             ],
             args.data_pad_size_multiplier,
             args.qkv_format,

--- a/miles/backends/training_utils/cp_utils.py
+++ b/miles/backends/training_utils/cp_utils.py
@@ -93,13 +93,21 @@ def get_sum_of_sample_mean(
     total_lengths: list[int],
     response_lengths: list[int],
     loss_masks: list[torch.Tensor],
+    sample_denoms: list[torch.Tensor] | None = None,
     calculate_per_token_loss: bool = False,
     qkv_format: str = "thd",
     max_seq_lens: list[int] | None = None,
+    constant_divisor: float | None = None,
 ) -> Callable[[torch.Tensor], torch.Tensor]:
-    """
-    Calculate correct sample mean for CP
-    """
+    """Build a CP-aware reducer for masked token losses."""
+    if constant_divisor is not None and calculate_per_token_loss:
+        raise ValueError(
+            "constant_divisor (loss-aggregation=constant) and calculate_per_token_loss "
+            "(loss-aggregation=token_mean) are mutually exclusive aggregation modes."
+        )
+    if sample_denoms is None:
+        sample_denoms = [loss_mask.sum() for loss_mask in loss_masks]
+
     parallel_state = get_parallel_state()
     cp_size = parallel_state.cp.size
     if cp_size == 1:
@@ -107,8 +115,10 @@ def get_sum_of_sample_mean(
         def sum_of_sample_mean(x: torch.Tensor) -> torch.Tensor:
             return sum(
                 [
-                    (x_i * loss_mask_i).sum() / torch.clamp_min(loss_mask_i.sum(), 1)
-                    for x_i, loss_mask_i in zip(x.split(response_lengths, dim=0), loss_masks, strict=True)
+                    (x_i * loss_mask_i).sum() / torch.clamp_min(denom, 1)
+                    for x_i, loss_mask_i, denom in zip(
+                        x.split(response_lengths, dim=0), loss_masks, sample_denoms, strict=True
+                    )
                 ]
             )
 
@@ -135,9 +145,9 @@ def get_sum_of_sample_mean(
         def sum_of_sample_mean(x: torch.Tensor) -> torch.Tensor:
             return sum(
                 [
-                    (x_i * chunked_loss_mask).sum() / torch.clamp_min(loss_mask.sum(), 1)
-                    for x_i, chunked_loss_mask, loss_mask in zip(
-                        x.split(cp_chunk_lengths, dim=0), chunked_loss_masks, loss_masks, strict=True
+                    (x_i * chunked_loss_mask).sum() / torch.clamp_min(denom, 1)
+                    for x_i, chunked_loss_mask, denom in zip(
+                        x.split(cp_chunk_lengths, dim=0), chunked_loss_masks, sample_denoms, strict=True
                     )
                 ]
             )
@@ -151,6 +161,13 @@ def get_sum_of_sample_mean(
                     )
                 ]
             )
+
+    if constant_divisor is not None:
+
+        def sum_of_constant(x: torch.Tensor) -> torch.Tensor:
+            return sum_of_token(x) / constant_divisor
+
+        return sum_of_constant
 
     return sum_of_sample_mean if not calculate_per_token_loss else sum_of_token
 

--- a/miles/backends/training_utils/data.py
+++ b/miles/backends/training_utils/data.py
@@ -45,6 +45,11 @@ def get_rollout_data(args: Namespace, rollout_data_ref: Box) -> RolloutBatch:
     rollout_data["loss_masks"] = [
         torch.tensor(t, dtype=torch.int, device=torch.cuda.current_device()) for t in rollout_data["loss_masks"]
     ]
+    if "prompt_mask_sums" in rollout_data:
+        rollout_data["prompt_mask_sums"] = [
+            torch.tensor(d, dtype=torch.float32, device=torch.cuda.current_device())
+            for d in rollout_data["prompt_mask_sums"]
+        ]
     if "multimodal_train_inputs" in rollout_data:
         # Move multimodal training tensors to GPU in advance
         rollout_data["multimodal_train_inputs"] = [

--- a/miles/backends/training_utils/loss.py
+++ b/miles/backends/training_utils/loss.py
@@ -123,13 +123,14 @@ def loss_function(
     num_tokens = sum([torch.clamp_min(loss_mask.sum(), 1) for loss_mask in batch["loss_masks"]])
     num_samples = len(batch["response_lengths"])
 
+    # --loss-aggregation applies to pg_loss only; metrics keep this reducer.
     sum_of_sample_mean = get_sum_of_sample_mean(
         batch["total_lengths"],
         batch["response_lengths"],
         batch["loss_masks"],
-        args.calculate_per_token_loss,
-        args.qkv_format,
-        batch.get("max_seq_lens", None),
+        calculate_per_token_loss=args.calculate_per_token_loss,
+        qkv_format=args.qkv_format,
+        max_seq_lens=batch.get("max_seq_lens", None),
     )
 
     func = get_loss_function(args)

--- a/miles/backends/training_utils/loss_hub/losses.py
+++ b/miles/backends/training_utils/loss_hub/losses.py
@@ -59,6 +59,54 @@ class LossFunction(Protocol):
         ...
 
 
+def get_pg_loss_reducer(
+    args: Namespace,
+    batch: RolloutBatch,
+    *,
+    total_lengths: list[int],
+    response_lengths: list[int],
+    pg_loss_masks: list[torch.Tensor],
+    max_seq_lens: list[int] | None,
+    default_reducer: Callable[[torch.Tensor], torch.Tensor],
+) -> Callable[[torch.Tensor], torch.Tensor]:
+    """Select the pg_loss reducer for ``--loss-aggregation``."""
+    mode = args.loss_aggregation
+    if mode in ("sample_mean", "token_mean"):
+        return default_reducer
+    if mode == "prompt_mean":
+        prompt_mask_sums = batch.get("prompt_mask_sums")
+        if prompt_mask_sums is None:
+            raise ValueError(
+                "--loss-aggregation prompt_mean requires per-prompt-group mask sums "
+                "(batch['prompt_mask_sums']), but they are missing. A custom "
+                "--custom-convert-samples-to-train-data-path must populate "
+                "'prompt_mask_sums' (grouped by Sample.group_index)."
+            )
+        reducer = get_sum_of_sample_mean(
+            total_lengths,
+            response_lengths,
+            pg_loss_masks,
+            prompt_mask_sums,
+            qkv_format=args.qkv_format,
+            max_seq_lens=max_seq_lens,
+        )
+
+        def prompt_mean_reducer(x: torch.Tensor) -> torch.Tensor:
+            return reducer(x) * args.n_samples_per_prompt
+
+        return prompt_mean_reducer
+    if mode == "constant":
+        return get_sum_of_sample_mean(
+            total_lengths,
+            response_lengths,
+            pg_loss_masks,
+            qkv_format=args.qkv_format,
+            max_seq_lens=max_seq_lens,
+            constant_divisor=args.loss_aggregation_divisor,
+        )
+    raise ValueError(f"Unknown --loss-aggregation mode: {mode!r}")
+
+
 def policy_loss_function(
     args: Namespace,
     batch: RolloutBatch,
@@ -234,21 +282,28 @@ def policy_loss_function(
             total_lengths,
             response_lengths,
             modified_response_masks,
-            args.calculate_per_token_loss,
-            args.qkv_format,
-            max_seq_lens,
+            calculate_per_token_loss=args.calculate_per_token_loss,
+            qkv_format=args.qkv_format,
+            max_seq_lens=max_seq_lens,
         )
 
-    # Determine pg_loss reducer: use custom if specified, otherwise default
+    pg_loss_masks = modified_response_masks if (args.get_mismatch_metrics or args.use_tis) else batch["loss_masks"]
+
     if args.custom_pg_loss_reducer_function_path is not None:
         custom_pg_loss_reducer_func = load_function(args.custom_pg_loss_reducer_function_path)
-        # Determine which loss_masks to use for pg_loss reducer
-        pg_loss_masks = modified_response_masks if (args.get_mismatch_metrics or args.use_tis) else batch["loss_masks"]
         pg_loss_reducer = custom_pg_loss_reducer_func(
             total_lengths, response_lengths, pg_loss_masks, args.calculate_per_token_loss
         )
     else:
-        pg_loss_reducer = sum_of_sample_mean
+        pg_loss_reducer = get_pg_loss_reducer(
+            args,
+            batch,
+            total_lengths=total_lengths,
+            response_lengths=response_lengths,
+            pg_loss_masks=pg_loss_masks,
+            max_seq_lens=max_seq_lens,
+            default_reducer=sum_of_sample_mean,
+        )
 
     # ESS (Effective Sample Size) ratio from per-token IS weights
     # w = π_new/π_old = exp(-ppo_kl).  A value of 1.0 is on-policy; near 0

--- a/miles/ray/rollout/train_data_conversion.py
+++ b/miles/ray/rollout/train_data_conversion.py
@@ -55,6 +55,14 @@ def convert_samples_to_train_data(
         loss_masks.append(sample.loss_mask)
     train_data["loss_masks"] = loss_masks
 
+    if getattr(args, "loss_aggregation", "sample_mean") == "prompt_mean":
+        group_mask_totals: dict[int, int] = {}
+        for sample, loss_mask in zip(samples, loss_masks, strict=True):
+            if sample.group_index is None:
+                raise ValueError("--loss-aggregation prompt_mean requires every Sample.group_index to be set.")
+            group_mask_totals[sample.group_index] = group_mask_totals.get(sample.group_index, 0) + sum(loss_mask)
+        train_data["prompt_mask_sums"] = [group_mask_totals[sample.group_index] for sample in samples]
+
     # overwriting the raw reward
     if samples[0].metadata and "raw_reward" in samples[0].metadata:
         train_data["raw_reward"] = [sample.metadata["raw_reward"] for sample in samples]
@@ -158,6 +166,7 @@ def split_train_data_by_dp(args, data, dp_size):
             "teacher_log_probs",
             "opd_reverse_kl",
             "weight_versions",
+            "prompt_mask_sums",
         ]:
             if key not in data:
                 continue

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -1065,6 +1065,39 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 default=None,
                 help="Path to a custom reducer function for pg_loss only. When set, pg_loss will use this custom reducer while other metrics (pg_clipfrac, ppo_kl, entropy_loss, etc.) still use the default sum_of_sample_mean. (e.g., examples/Dr.GRPO/custom_reducer.py:get_pg_loss_reducer).",
             )
+            parser.add_argument(
+                "--loss-aggregation",
+                type=str,
+                default="sample_mean",
+                choices=["sample_mean", "prompt_mean", "token_mean", "constant"],
+                help=(
+                    "How pg_loss is aggregated across the step (applies to pg_loss only; "
+                    "pg_clipfrac, ppo_kl, entropy_loss, kl_loss keep the default sample-mean reducer "
+                    "-- same scope as --custom-pg-loss-reducer-function-path, which still takes "
+                    "precedence when set). Modes follow the ScaleRL taxonomy (arXiv:2510.13786 section "
+                    "3.2): "
+                    "'sample_mean' (default, GRPO): each sequence is averaged by its own active-token "
+                    "count, then averaged across sequences (same behavior as the prior default). "
+                    "'prompt_mean' (DAPO, ScaleRL's recommended default for new recipes): every token in "
+                    "a prompt group weighs equally -- normalize by the group's total active tokens across "
+                    "its completions, then average over prompt groups. "
+                    "'token_mean': global per-token mean; the same objective as the legacy "
+                    "--calculate-per-token-loss flag (prefer --loss-aggregation token_mean). "
+                    "'constant' (Dr.GRPO, arXiv:2503.20783 Eq.2): divide the summed token loss by the "
+                    "fixed --loss-aggregation-divisor (no data-dependent denominator)."
+                ),
+            )
+            parser.add_argument(
+                "--loss-aggregation-divisor",
+                type=float,
+                default=None,
+                help=(
+                    "Constant divisor L for --loss-aggregation constant (Dr.GRPO): the model's max "
+                    "generation/context length (e.g. 40960). Required when --loss-aggregation=constant; "
+                    "must be a positive number. No default is provided, so a missing value raises "
+                    "instead of training with an arbitrary denominator."
+                ),
+            )
 
             parser.add_argument(
                 "--use-routing-replay",
@@ -2008,6 +2041,43 @@ def _resolve_eval_datasets(args) -> list[EvalDatasetConfig]:
     return eval_datasets
 
 
+def _validate_loss_aggregation_args(args):
+    """Reconcile --loss-aggregation with its legacy alias --calculate-per-token-loss."""
+    if args.loss_aggregation == "constant":
+        if args.loss_aggregation_divisor is None or not args.loss_aggregation_divisor > 0:
+            raise ValueError(
+                "--loss-aggregation constant requires --loss-aggregation-divisor <positive number> "
+                "(the model's max generation/context length, e.g. 40960), got "
+                f"{args.loss_aggregation_divisor!r}."
+            )
+    elif args.loss_aggregation_divisor is not None:
+        raise ValueError(
+            "--loss-aggregation-divisor is only used with --loss-aggregation constant, "
+            f"but --loss-aggregation={args.loss_aggregation!r}."
+        )
+
+    if args.loss_aggregation == "token_mean":
+        args.calculate_per_token_loss = True
+    elif args.calculate_per_token_loss:
+        if args.loss_aggregation == "sample_mean":
+            args.loss_aggregation = "token_mean"
+        else:
+            raise ValueError(
+                f"--loss-aggregation {args.loss_aggregation} is incompatible with --calculate-per-token-loss "
+                "(use --loss-aggregation token_mean for the per-token global mean)."
+            )
+    if (
+        args.loss_aggregation == "prompt_mean"
+        and args.global_batch_size is not None
+        and args.global_batch_size % args.n_samples_per_prompt != 0
+    ):
+        raise ValueError(
+            "--loss-aggregation prompt_mean requires global_batch_size to be a multiple of "
+            "n_samples_per_prompt so each prompt group stays within one training step "
+            f"(got global_batch_size={args.global_batch_size}, n_samples_per_prompt={args.n_samples_per_prompt})."
+        )
+
+
 def miles_validate_args(args):
     args.eval_datasets = _resolve_eval_datasets(args)
 
@@ -2139,6 +2209,8 @@ def miles_validate_args(args):
     else:
         if args.opd_teacher_load is not None:
             raise ValueError("--opd-teacher-load is set but --use-opd is not enabled. Please add --use-opd flag.")
+
+    _validate_loss_aggregation_args(args)
 
     # TODO: During loading, we need to set the start_rollout_id here.
     if args.megatron_to_hf_mode == "bridge":

--- a/tests/fast/backends/training_utils/loss/test_loss_snapshot.py
+++ b/tests/fast/backends/training_utils/loss/test_loss_snapshot.py
@@ -117,9 +117,9 @@ def _get_sum_of_sample_mean(batch, args, parallel_state):
         batch["total_lengths"],
         batch["response_lengths"],
         batch["loss_masks"],
-        args.calculate_per_token_loss,
-        args.qkv_format,
-        batch.get("max_seq_lens", None),
+        calculate_per_token_loss=args.calculate_per_token_loss,
+        qkv_format=args.qkv_format,
+        max_seq_lens=batch.get("max_seq_lens", None),
     )
 
 

--- a/tests/fast/backends/training_utils/test_loss_aggregation.py
+++ b/tests/fast/backends/training_utils/test_loss_aggregation.py
@@ -1,0 +1,351 @@
+"""Tests for the ``--loss-aggregation`` pg_loss modes."""
+
+import sys
+import types
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+
+def _install_sglang_protocol_stub():
+    for name in [
+        "sglang",
+        "sglang.srt",
+        "sglang.srt.entrypoints",
+        "sglang.srt.entrypoints.openai",
+    ]:
+        module = types.ModuleType(name)
+        module.__path__ = []
+        sys.modules.setdefault(name, module)
+    protocol = types.ModuleType("sglang.srt.entrypoints.openai.protocol")
+    protocol.Tool = object
+    sys.modules.setdefault("sglang.srt.entrypoints.openai.protocol", protocol)
+    server_args = types.ModuleType("sglang.srt.server_args")
+
+    class _ServerArgs:
+        @staticmethod
+        def add_cli_args(parser):
+            return None
+
+    server_args.ServerArgs = _ServerArgs
+    sys.modules.setdefault("sglang.srt.server_args", server_args)
+
+
+_install_sglang_protocol_stub()
+chat_template_utils = types.ModuleType("miles.utils.chat_template_utils")
+chat_template_utils.__path__ = []
+sys.modules.setdefault("miles.utils.chat_template_utils", chat_template_utils)
+tito_tokenizer = types.ModuleType("miles.utils.chat_template_utils.tito_tokenizer")
+tito_tokenizer.TITOTokenizerType = SimpleNamespace
+sys.modules.setdefault("miles.utils.chat_template_utils.tito_tokenizer", tito_tokenizer)
+sglang_router = types.ModuleType("sglang_router")
+sglang_router.__path__ = []
+sys.modules.setdefault("sglang_router", sglang_router)
+launch_router = types.ModuleType("sglang_router.launch_router")
+launch_router.RouterArgs = object
+sys.modules.setdefault("sglang_router.launch_router", launch_router)
+
+from miles.backends.training_utils import cp_utils
+from miles.backends.training_utils.cp_utils import get_sum_of_sample_mean
+from miles.backends.training_utils.loss_hub.losses import get_pg_loss_reducer
+from miles.backends.training_utils.parallel import GroupInfo, ParallelState
+from miles.ray.rollout.train_data_conversion import convert_samples_to_train_data
+from miles.utils import arguments
+from miles.utils.types import Sample
+
+
+def _parallel_state(*, cp_size: int, cp_rank: int = 0) -> ParallelState:
+    return ParallelState(
+        intra_dp=GroupInfo(rank=0, size=1, group=None),
+        intra_dp_cp=GroupInfo(rank=0, size=cp_size, group=None),
+        cp=GroupInfo(rank=cp_rank, size=cp_size, group=None),
+        tp=GroupInfo(rank=0, size=1, group=None),
+        pp=GroupInfo(rank=0, size=1, group=None),
+        ep=GroupInfo(rank=0, size=1, group=None),
+        etp=GroupInfo(rank=0, size=1, group=None),
+        cp_comm_type=None,
+    )
+
+
+def _legacy_sum_of_sample_mean(response_lengths, loss_masks):
+    def reducer(x: torch.Tensor) -> torch.Tensor:
+        return sum(
+            (x_i * m_i).sum() / torch.clamp_min(m_i.sum(), 1)
+            for x_i, m_i in zip(x.split(response_lengths, dim=0), loss_masks, strict=True)
+        )
+
+    return reducer
+
+
+RESPONSE_LENGTHS = [3, 3, 4, 4]
+TOTAL_LENGTHS = [3, 3, 4, 4]
+LOSS_MASKS = [
+    torch.tensor([1.0, 1.0, 0.0]),  # group 0, mask sum 2
+    torch.tensor([1.0, 1.0, 1.0]),  # group 0, mask sum 3
+    torch.tensor([1.0, 0.0, 0.0, 0.0]),  # group 1, mask sum 1
+    torch.tensor([1.0, 1.0, 1.0, 1.0]),  # group 1, mask sum 4
+]
+X = torch.arange(1.0, 15.0)
+
+
+def test_default_is_byte_identical_to_legacy_reducer(monkeypatch):
+    monkeypatch.setattr(cp_utils, "get_parallel_state", lambda: _parallel_state(cp_size=1))
+
+    new = get_sum_of_sample_mean(TOTAL_LENGTHS, RESPONSE_LENGTHS, LOSS_MASKS)  # sample_denoms=None
+    legacy = _legacy_sum_of_sample_mean(RESPONSE_LENGTHS, LOSS_MASKS)
+
+    torch.testing.assert_close(new(X), legacy(X), rtol=0, atol=0)
+
+
+def test_prompt_mean_denominator_is_group_token_total(monkeypatch):
+    monkeypatch.setattr(cp_utils, "get_parallel_state", lambda: _parallel_state(cp_size=1))
+
+    sample_denoms = [torch.tensor(5.0)] * 4
+    reducer = get_sum_of_sample_mean(TOTAL_LENGTHS, RESPONSE_LENGTHS, LOSS_MASKS, sample_denoms)
+    expected = (3 + 15) / 5 + (7 + 50) / 5
+    torch.testing.assert_close(reducer(X), torch.tensor(expected))
+
+
+def test_constant_divides_summed_token_loss_by_L(monkeypatch):
+    monkeypatch.setattr(cp_utils, "get_parallel_state", lambda: _parallel_state(cp_size=1))
+
+    L = 10.0
+    reducer = get_sum_of_sample_mean(TOTAL_LENGTHS, RESPONSE_LENGTHS, LOSS_MASKS, constant_divisor=L)
+    torch.testing.assert_close(reducer(X), torch.tensor(75.0 / L))
+
+
+def test_constant_distinct_from_sample_and_token_mean(monkeypatch):
+    monkeypatch.setattr(cp_utils, "get_parallel_state", lambda: _parallel_state(cp_size=1))
+
+    sample_mean = get_sum_of_sample_mean(TOTAL_LENGTHS, RESPONSE_LENGTHS, LOSS_MASKS)
+    token_sum = get_sum_of_sample_mean(TOTAL_LENGTHS, RESPONSE_LENGTHS, LOSS_MASKS, calculate_per_token_loss=True)
+    constant = get_sum_of_sample_mean(TOTAL_LENGTHS, RESPONSE_LENGTHS, LOSS_MASKS, constant_divisor=10.0)
+
+    assert sample_mean(X).item() != pytest.approx(constant(X).item())
+    assert token_sum(X).item() != pytest.approx(constant(X).item())
+
+
+def test_constant_and_per_token_loss_are_mutually_exclusive(monkeypatch):
+    monkeypatch.setattr(cp_utils, "get_parallel_state", lambda: _parallel_state(cp_size=1))
+
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        get_sum_of_sample_mean(
+            TOTAL_LENGTHS, RESPONSE_LENGTHS, LOSS_MASKS, calculate_per_token_loss=True, constant_divisor=10.0
+        )
+
+
+def test_token_mean_is_unnormalized_global_token_sum(monkeypatch):
+    monkeypatch.setattr(cp_utils, "get_parallel_state", lambda: _parallel_state(cp_size=1))
+
+    reducer = get_sum_of_sample_mean(TOTAL_LENGTHS, RESPONSE_LENGTHS, LOSS_MASKS, calculate_per_token_loss=True)
+    torch.testing.assert_close(reducer(X), torch.tensor(75.0))
+
+
+@pytest.mark.parametrize("constant_divisor", [None, 20.0])
+def test_cp_zigzag_rank_sum_matches_single_rank(monkeypatch, constant_divisor):
+    total_length, response_length = 10, 8
+    loss_mask = torch.tensor([1.0, 1.0, 1.0, 1.0, 0.0, 1.0, 1.0, 1.0])  # mask sum 7
+    x_full = torch.arange(1.0, 9.0)
+    sample_denoms = None if constant_divisor is not None else [torch.tensor(20.0)]
+
+    def build():
+        return get_sum_of_sample_mean(
+            [total_length],
+            [response_length],
+            [loss_mask],
+            sample_denoms,
+            constant_divisor=constant_divisor,
+        )
+
+    monkeypatch.setattr(cp_utils, "get_parallel_state", lambda: _parallel_state(cp_size=1))
+    ref = build()(x_full)
+
+    total = torch.zeros(())
+    for rank in range(2):
+        monkeypatch.setattr(cp_utils, "get_parallel_state", lambda r=rank: _parallel_state(cp_size=2, cp_rank=r))
+        x_local = cp_utils._slice_loss_mask_for_local_cp(total_length, response_length, x_full, "thd", None)
+        total = total + build()(x_local)
+
+    torch.testing.assert_close(total, ref)
+
+
+def _args(**overrides):
+    base = dict(
+        loss_aggregation="sample_mean",
+        loss_aggregation_divisor=None,
+        calculate_per_token_loss=False,
+        n_samples_per_prompt=2,
+        qkv_format="thd",
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+_DEFAULT_REDUCER = object()
+
+
+def _select(args, batch):
+    return get_pg_loss_reducer(
+        args,
+        batch,
+        total_lengths=TOTAL_LENGTHS,
+        response_lengths=RESPONSE_LENGTHS,
+        pg_loss_masks=LOSS_MASKS,
+        max_seq_lens=None,
+        default_reducer=_DEFAULT_REDUCER,
+    )
+
+
+def test_sample_and_token_mean_reuse_the_metrics_reducer_for_pg_loss():
+    assert _select(_args(loss_aggregation="sample_mean"), {}) is _DEFAULT_REDUCER
+    assert _select(_args(loss_aggregation="token_mean", calculate_per_token_loss=True), {}) is _DEFAULT_REDUCER
+
+
+def test_constant_and_prompt_mean_build_a_pg_loss_only_reducer(monkeypatch):
+    monkeypatch.setattr(cp_utils, "get_parallel_state", lambda: _parallel_state(cp_size=1))
+
+    constant_reducer = _select(_args(loss_aggregation="constant", loss_aggregation_divisor=10.0), {})
+    assert constant_reducer is not _DEFAULT_REDUCER
+    torch.testing.assert_close(constant_reducer(X), torch.tensor(75.0 / 10.0))
+
+    denoms = [torch.tensor(5.0)] * 4
+    prompt_reducer = _select(_args(loss_aggregation="prompt_mean"), {"prompt_mask_sums": denoms})
+    assert prompt_reducer is not _DEFAULT_REDUCER
+    torch.testing.assert_close(prompt_reducer(X), torch.tensor(2 * ((3 + 15) / 5 + (7 + 50) / 5)))
+
+
+def test_prompt_mean_without_prompt_mask_sums_fails():
+    with pytest.raises(ValueError, match="prompt_mask_sums"):
+        _select(_args(loss_aggregation="prompt_mean"), {})
+
+
+def _validate_args(**overrides):
+    base = dict(
+        loss_aggregation="sample_mean",
+        loss_aggregation_divisor=None,
+        calculate_per_token_loss=False,
+        global_batch_size=4,
+        n_samples_per_prompt=2,
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+@pytest.mark.parametrize("divisor", [None, 0.0, -1.0, float("nan")])
+def test_validate_constant_rejects_nonpositive_divisor(divisor):
+    args = _validate_args(loss_aggregation="constant", loss_aggregation_divisor=divisor)
+    with pytest.raises(ValueError, match="loss-aggregation-divisor"):
+        arguments._validate_loss_aggregation_args(args)
+
+
+def test_validate_token_mean_aliases_calculate_per_token_loss():
+    args = _validate_args(loss_aggregation="token_mean")
+    arguments._validate_loss_aggregation_args(args)
+    assert args.calculate_per_token_loss is True
+
+
+def test_validate_calculate_per_token_loss_alone_reconciles_to_token_mean():
+    args = _validate_args(calculate_per_token_loss=True)
+    arguments._validate_loss_aggregation_args(args)
+    assert args.loss_aggregation == "token_mean"
+    assert args.calculate_per_token_loss is True
+
+
+def test_validate_default_leaves_per_token_loss_off():
+    args = _validate_args()
+    arguments._validate_loss_aggregation_args(args)
+    assert args.loss_aggregation == "sample_mean"
+    assert args.calculate_per_token_loss is False
+
+
+def test_validate_constant_rejects_calculate_per_token_loss():
+    args = _validate_args(loss_aggregation="constant", loss_aggregation_divisor=10.0, calculate_per_token_loss=True)
+    with pytest.raises(ValueError, match="incompatible with --calculate-per-token-loss"):
+        arguments._validate_loss_aggregation_args(args)
+
+
+def test_validate_constant_with_per_token_loss_off_passes():
+    args = _validate_args(loss_aggregation="constant", loss_aggregation_divisor=10.0, calculate_per_token_loss=False)
+    arguments._validate_loss_aggregation_args(args)
+    assert args.calculate_per_token_loss is False
+
+
+def test_validate_prompt_mean_rejects_calculate_per_token_loss():
+    args = _validate_args(loss_aggregation="prompt_mean", calculate_per_token_loss=True)
+    with pytest.raises(ValueError, match="incompatible with --calculate-per-token-loss"):
+        arguments._validate_loss_aggregation_args(args)
+
+
+def test_validate_prompt_mean_rejects_non_multiple_global_batch_size():
+    args = _validate_args(loss_aggregation="prompt_mean", global_batch_size=3, n_samples_per_prompt=2)
+    with pytest.raises(ValueError, match="multiple of n_samples_per_prompt"):
+        arguments._validate_loss_aggregation_args(args)
+
+
+def test_validate_prompt_mean_accepts_multiple_global_batch_size():
+    args = _validate_args(loss_aggregation="prompt_mean", global_batch_size=6, n_samples_per_prompt=2)
+    arguments._validate_loss_aggregation_args(args)
+    assert args.loss_aggregation == "prompt_mean"
+
+
+def test_validate_non_prompt_mean_allows_non_multiple_global_batch_size():
+    args = _validate_args(loss_aggregation="sample_mean", global_batch_size=3, n_samples_per_prompt=2)
+    arguments._validate_loss_aggregation_args(args)
+    assert args.loss_aggregation == "sample_mean"
+
+
+def _make_sample(group_index, index, response_length, loss_mask):
+    s = Sample(group_index=group_index, index=index, response_length=response_length, reward=1.0)
+    s.tokens = [0] * response_length
+    s.loss_mask = loss_mask
+    s.status = Sample.Status.COMPLETED
+    return s
+
+
+def _convert_args(**overrides):
+    base = dict(
+        advantage_estimator="grpo",
+        rewards_normalization=False,
+        reward_key=None,
+        use_dynamic_global_batch_size=False,
+        loss_aggregation="prompt_mean",
+        n_samples_per_prompt=2,
+        rollout_batch_size=2,
+        grpo_std_normalization=False,
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def _convert(samples, args):
+    return convert_samples_to_train_data(
+        args,
+        samples,
+        metadata={},
+        custom_convert_samples_to_train_data_func=None,
+        custom_reward_post_process_func=None,
+    )
+
+
+def test_convert_samples_computes_step_level_prompt_group_denoms():
+    samples = [
+        _make_sample(0, 0, 3, [1, 1, 0]),  # group 0, sum 2
+        _make_sample(0, 1, 3, [1, 1, 1]),  # group 0, sum 3
+        _make_sample(1, 2, 4, [1, 0, 0, 0]),  # group 1, sum 1
+        _make_sample(1, 3, 4, [1, 1, 1, 1]),  # group 1, sum 4
+    ]
+    train_data = _convert(samples, _convert_args())
+    assert train_data["prompt_mask_sums"] == [5, 5, 5, 5]
+
+
+def test_convert_samples_prompt_mean_rejects_none_group_index():
+    samples = [_make_sample(None, 0, 2, [1, 1]), _make_sample(None, 1, 2, [1, 0])]
+    with pytest.raises(ValueError, match="group_index"):
+        _convert(samples, _convert_args(rollout_batch_size=1))
+
+
+def test_convert_samples_omits_denoms_for_default_mode():
+    samples = [_make_sample(0, 0, 2, [1, 1]), _make_sample(0, 1, 2, [1, 0])]
+    train_data = _convert(samples, _convert_args(loss_aggregation="sample_mean", rollout_batch_size=1))
+    assert "prompt_mask_sums" not in train_data


### PR DESCRIPTION
Port of THUDM/slime#2090 for miles.

Summary:
- add `--loss-aggregation {sample_mean,prompt_mean,token_mean,constant}` for pg_loss
- keep `sample_mean` as the default and reconcile legacy `--calculate-per-token-loss` with `token_mean`
- sync the current slime `prompt_mean` behavior: rollout conversion emits `prompt_mask_sums`, the reducer scales by `n_samples_per_prompt`, and the final scalar is the direct mean over prompt groups
- validate `prompt_mean` configs with `global_batch_size % n_samples_per_prompt == 0`, so each prompt group stays whole within a train step
- add constant-divisor aggregation for Dr.GRPO while keeping non-pg metrics on the default reducer
- include docs and focused CPU coverage for reducer math, argument validation, and prompt_mean rollout metadata

Validation:
- `uv run --with pytest --with torch --with numpy --with httpx --with pyyaml --with ray --with huggingface_hub --with transformers --with pydantic pytest --confcutdir=tests/fast/backends/training_utils tests/fast/backends/training_utils/test_loss_aggregation.py -q` -> 27 passed
- `uv run --with ruff ruff check miles/backends/training_utils/cp_utils.py miles/backends/training_utils/data.py miles/backends/training_utils/loss.py miles/backends/training_utils/loss_hub/losses.py miles/ray/rollout/train_data_conversion.py miles/utils/arguments.py miles/backends/megatron_utils/model.py miles/backends/experimental/fsdp_utils/actor.py tests/fast/backends/training_utils/test_loss_aggregation.py tests/fast/backends/training_utils/loss/test_loss_snapshot.py` -> passed
- `uv run --with black black --check miles/backends/training_utils/cp_utils.py miles/backends/training_utils/data.py miles/backends/training_utils/loss.py miles/backends/training_utils/loss_hub/losses.py miles/ray/rollout/train_data_conversion.py miles/utils/arguments.py miles/backends/megatron_utils/model.py miles/backends/experimental/fsdp_utils/actor.py tests/fast/backends/training_utils/test_loss_aggregation.py tests/fast/backends/training_utils/loss/test_loss_snapshot.py` -> passed
- `git diff --check upstream/main` -> passed