### PR TITLE
Auto-enable router dp_aware routing when DP attention is on

### DIFF
--- a/miles/ray/rollout/router_manager.py
+++ b/miles/ray/rollout/router_manager.py
@@ -30,7 +30,8 @@ def _maybe_enable_router_dp_aware(args, router_args) -> None:
     ``MILES_DISABLE_AUTO_DP_AWARE=1`` opt-out, warning loudly in the opt-out case
     since it reintroduces the prefix-cache fragmentation.
     """
-    if getattr(args, "sglang_dp_size", 1) <= 1 or router_args.dp_aware:
+    dp_size = getattr(args, "sglang_dp_size", 1) or 1
+    if dp_size <= 1 or getattr(router_args, "dp_aware", False):
         return
     if os.environ.get("MILES_DISABLE_AUTO_DP_AWARE") == "1":
         logger.warning(
@@ -39,14 +40,14 @@ def _maybe_enable_router_dp_aware(args, router_args) -> None:
             "per-engine and SGLang will scatter requests across DP ranks by load, fragmenting "
             "the radix prefix cache and likely reducing the KV-cache hit rate. Unset the env "
             "var to restore prefix-affinity routing.",
-            args.sglang_dp_size,
+            dp_size,
         )
         return
     router_args.dp_aware = True
     logger.info(
         "DP attention enabled (sglang_dp_size=%d); auto-enabling router dp_aware routing to "
         "preserve prefix-cache locality.",
-        args.sglang_dp_size,
+        dp_size,
     )
 
 

--- a/miles/ray/rollout/router_manager.py
+++ b/miles/ray/rollout/router_manager.py
@@ -1,5 +1,6 @@
 import logging
 import multiprocessing
+import os
 import random
 import uuid
 
@@ -14,6 +15,39 @@ from miles.utils.http_utils import (
 
 
 logger = logging.getLogger(__name__)
+
+
+def _maybe_enable_router_dp_aware(args, router_args) -> None:
+    """Auto-enable sgl-router DP-aware routing when DP attention shards the KV cache.
+
+    With ``sglang_dp_size > 1`` each DP rank owns an independent KV pool and radix
+    prefix tree. Unless the router routes at DP-rank granularity, requests scatter
+    across ranks by load and the prefix cache fragments, sharply lowering the
+    KV-cache hit rate. Enabling ``dp_aware`` keeps prefix-sharing requests on the
+    same rank.
+
+    Honors an explicit ``--router-dp-aware`` (already True -> left untouched) and the
+    ``MILES_DISABLE_AUTO_DP_AWARE=1`` opt-out, warning loudly in the opt-out case
+    since it reintroduces the prefix-cache fragmentation.
+    """
+    if getattr(args, "sglang_dp_size", 1) <= 1 or router_args.dp_aware:
+        return
+    if os.environ.get("MILES_DISABLE_AUTO_DP_AWARE") == "1":
+        logger.warning(
+            "DP attention is enabled (sglang_dp_size=%d) but router dp_aware routing is "
+            "explicitly disabled via MILES_DISABLE_AUTO_DP_AWARE=1. The router will dispatch "
+            "per-engine and SGLang will scatter requests across DP ranks by load, fragmenting "
+            "the radix prefix cache and likely reducing the KV-cache hit rate. Unset the env "
+            "var to restore prefix-affinity routing.",
+            args.sglang_dp_size,
+        )
+        return
+    router_args.dp_aware = True
+    logger.info(
+        "DP attention enabled (sglang_dp_size=%d); auto-enabling router dp_aware routing to "
+        "preserve prefix-cache locality.",
+        args.sglang_dp_size,
+    )
 
 
 def start_router(args, *, has_pd_disaggregation: bool = False, force_new: bool = False) -> tuple[str, int]:
@@ -57,6 +91,8 @@ def start_router(args, *, has_pd_disaggregation: bool = False, force_new: bool =
 
         if args.sglang_router_policy:
             router_args.policy = args.sglang_router_policy
+
+        _maybe_enable_router_dp_aware(args, router_args)
 
         if has_pd_disaggregation:
             router_args.pd_disaggregation = True

--- a/tests/fast/router/test_router_dp_aware.py
+++ b/tests/fast/router/test_router_dp_aware.py
@@ -7,7 +7,7 @@ from types import SimpleNamespace
 from miles.ray.rollout.router_manager import _maybe_enable_router_dp_aware
 
 
-def _make(dp_size: int, dp_aware: bool = False):
+def _make(dp_size: int | None, dp_aware: bool = False):
     args = SimpleNamespace(sglang_dp_size=dp_size)
     router_args = SimpleNamespace(dp_aware=dp_aware)
     return args, router_args
@@ -23,6 +23,13 @@ def test_auto_enables_when_dp_attention_on(monkeypatch):
 def test_noop_when_dp_size_one(monkeypatch):
     monkeypatch.delenv("MILES_DISABLE_AUTO_DP_AWARE", raising=False)
     args, router_args = _make(dp_size=1)
+    _maybe_enable_router_dp_aware(args, router_args)
+    assert router_args.dp_aware is False
+
+
+def test_noop_when_dp_size_none(monkeypatch):
+    monkeypatch.delenv("MILES_DISABLE_AUTO_DP_AWARE", raising=False)
+    args, router_args = _make(dp_size=None)
     _maybe_enable_router_dp_aware(args, router_args)
     assert router_args.dp_aware is False
 

--- a/tests/fast/router/test_router_dp_aware.py
+++ b/tests/fast/router/test_router_dp_aware.py
@@ -1,0 +1,43 @@
+from tests.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="stage-a-fast")
+
+from types import SimpleNamespace
+
+from miles.ray.rollout.router_manager import _maybe_enable_router_dp_aware
+
+
+def _make(dp_size: int, dp_aware: bool = False):
+    args = SimpleNamespace(sglang_dp_size=dp_size)
+    router_args = SimpleNamespace(dp_aware=dp_aware)
+    return args, router_args
+
+
+def test_auto_enables_when_dp_attention_on(monkeypatch):
+    monkeypatch.delenv("MILES_DISABLE_AUTO_DP_AWARE", raising=False)
+    args, router_args = _make(dp_size=4)
+    _maybe_enable_router_dp_aware(args, router_args)
+    assert router_args.dp_aware is True
+
+
+def test_noop_when_dp_size_one(monkeypatch):
+    monkeypatch.delenv("MILES_DISABLE_AUTO_DP_AWARE", raising=False)
+    args, router_args = _make(dp_size=1)
+    _maybe_enable_router_dp_aware(args, router_args)
+    assert router_args.dp_aware is False
+
+
+def test_respects_explicit_dp_aware(monkeypatch):
+    monkeypatch.delenv("MILES_DISABLE_AUTO_DP_AWARE", raising=False)
+    args, router_args = _make(dp_size=4, dp_aware=True)
+    _maybe_enable_router_dp_aware(args, router_args)
+    assert router_args.dp_aware is True
+
+
+def test_opt_out_warns_and_keeps_disabled(monkeypatch, caplog):
+    monkeypatch.setenv("MILES_DISABLE_AUTO_DP_AWARE", "1")
+    args, router_args = _make(dp_size=4)
+    with caplog.at_level("WARNING"):
+        _maybe_enable_router_dp_aware(args, router_args)
+    assert router_args.dp_aware is False
+    assert "MILES_DISABLE_AUTO_DP_AWARE" in caplog.text


### PR DESCRIPTION
## Summary

When DP attention is enabled (`--sglang-data-parallel-size > 1`, which Miles already forces alongside `--sglang-enable-dp-attention`), the SGLang engine shards its KV cache across DP ranks — each rank keeps an independent KV pool and its own radix prefix tree. The sgl-router, however, defaults to `dp_aware = False`, so it dispatches at engine granularity and lets SGLang scatter requests across DP ranks by load. That fragments the radix prefix cache across ranks and can sharply reduce the KV-cache hit rate (a shared prefix that used to be cached once is recomputed on every rank it lands on).

This PR couples the two: in the sgl-router path, when `sglang_dp_size > 1`, Miles now auto-enables `router_args.dp_aware` so the router routes at DP-rank granularity (preserving prefix-cache locality).

## Behavior

- Triggers only on the **sgl-router** path (`start_router`'s non-`use_miles_router` branch). The miles-router path (`RadixTreeMiddleware`) and externally-managed routers (`--sglang-router-ip` set) are untouched.
- Honors an explicit `--router-dp-aware` (already `True` → left as-is).
- Provides an opt-out via `MILES_DISABLE_AUTO_DP_AWARE=1`. Because `--router-dp-aware` is a `store_true` flag (no native "explicit False"), the env var is the supported way to keep DP attention on while routing per-engine — and it **warns** when used, since it reintroduces the prefix-cache fragmentation.
- Routing policy is left alone (router already defaults to `cache_aware`; `dp_aware` is orthogonal, controlling worker granularity rather than the selection policy).

## Test plan

- [x] Unit test (`tests/fast/router/test_router_dp_aware.py`) covering the four branches: auto-enable when `dp_size > 1`, no-op when `dp_size == 1`, respect an explicit `dp_aware=True`, and opt-out keeps it disabled + warns.
- [x] Helper logic exercised directly across all four cases locally.
- [ ] Smoke: a short DP-attention rollout run (`dp_size >= 2`) confirming the router log shows `dp_aware` active and the KV-cache prefix hit-rate metric recovers vs. a baseline without the change.
