### PR TITLE
docs: fix Dr.GRPO custom-reducer example path (DrGRPO, not Dr.GRPO)

### DIFF
--- a/examples/DrGRPO/README.md
+++ b/examples/DrGRPO/README.md
@@ -11,7 +11,7 @@ By default, miles divides the policy gradient loss by the number of effective to
 Use `--custom-pg-loss-reducer-function-path` to apply the custom reducer **only to pg_loss**, while other metrics (pg_clipfrac, ppo_kl, entropy_loss, etc.) still use the default sum_of_sample_mean:
 
 ```bash
---custom-pg-loss-reducer-function-path examples.Dr.GRPO.custom_reducer.get_pg_loss_reducer
+--custom-pg-loss-reducer-function-path examples.DrGRPO.custom_reducer.get_pg_loss_reducer
 ```
 
 ## Customization
@@ -43,7 +43,7 @@ Instead of dividing by `loss_mask_i.sum()` (the number of effective tokens), it 
 ```bash
 GRPO_ARGS=(
    --advantage-estimator grpo
-   --custom-pg-loss-reducer-function-path examples.Dr.GRPO.custom_reducer:get_pg_loss_reducer
+   --custom-pg-loss-reducer-function-path examples.DrGRPO.custom_reducer.get_pg_loss_reducer
    # ... other arguments
 )
 ```

--- a/examples/DrGRPO/custom_reducer.py
+++ b/examples/DrGRPO/custom_reducer.py
@@ -4,7 +4,7 @@ This module provides a custom reducer that divides by a constant instead of
 the number of effective tokens. This is useful for Dr.GRPO algorithm.
 
 Usage:
-    --custom-pg-loss-reducer-function-path examples.Dr.GRPO.custom_reducer:get_pg_loss_reducer
+    --custom-pg-loss-reducer-function-path examples.DrGRPO.custom_reducer.get_pg_loss_reducer
 """
 
 from collections.abc import Callable

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -1063,7 +1063,7 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 "--custom-pg-loss-reducer-function-path",
                 type=str,
                 default=None,
-                help="Path to a custom reducer function for pg_loss only. When set, pg_loss will use this custom reducer while other metrics (pg_clipfrac, ppo_kl, entropy_loss, etc.) still use the default sum_of_sample_mean. (e.g., examples/Dr.GRPO/custom_reducer.py:get_pg_loss_reducer).",
+                help="Path to a custom reducer function for pg_loss only. When set, pg_loss will use this custom reducer while other metrics (pg_clipfrac, ppo_kl, entropy_loss, etc.) still use the default sum_of_sample_mean. (e.g., examples/DrGRPO/custom_reducer.py:get_pg_loss_reducer).",
             )
 
             parser.add_argument(


### PR DESCRIPTION
The Dr.GRPO example lives in `examples/DrGRPO/`, but the README, the reducer docstring, and the `--custom-pg-loss-reducer-function-path` help spelled the module/path as `examples.Dr.GRPO` / `examples/Dr.GRPO/` (with a dot). That import path doesn't resolve and the file path doesn't exist, so anyone copy-pasting the documented command hits a load error.

Corrects the four path references to `examples.DrGRPO` / `examples/DrGRPO/`. The algorithm name "Dr.GRPO" in prose is left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)