### PR TITLE
[fix] balance_data: don't require sample count divisible by dp_size (#969)

### DIFF
--- a/miles/ray/rollout/train_data_conversion.py
+++ b/miles/ray/rollout/train_data_conversion.py
@@ -132,7 +132,12 @@ def split_train_data_by_dp(args, data, dp_size):
     data["total_lengths"] = total_lengths
 
     if args.balance_data:
-        partitions = get_seqlen_balanced_partitions(total_lengths, dp_size, equal_size=True)
+        # Require equal per-rank sample counts only when the totals divide evenly.
+        # When invalid samples are dropped, the valid count may not be divisible by
+        # dp_size (e.g. 206 % 4); in that case balance by token count alone, matching
+        # the strided path below which already yields uneven per-rank counts.
+        equal_size = len(total_lengths) % dp_size == 0
+        partitions = get_seqlen_balanced_partitions(total_lengths, dp_size, equal_size=equal_size)
     else:
         partitions = [range(i, len(total_lengths), dp_size) for i in range(dp_size)]
 

--- a/miles/ray/rollout/train_data_conversion.py
+++ b/miles/ray/rollout/train_data_conversion.py
@@ -131,11 +131,13 @@ def split_train_data_by_dp(args, data, dp_size):
     total_lengths = [len(t) for t in data["tokens"]]
     data["total_lengths"] = total_lengths
 
-    if args.balance_data:
+    if args.balance_data and len(total_lengths) >= dp_size:
         # Require equal per-rank sample counts only when the totals divide evenly.
         # When invalid samples are dropped, the valid count may not be divisible by
         # dp_size (e.g. 206 % 4); in that case balance by token count alone, matching
         # the strided path below which already yields uneven per-rank counts.
+        # (Token balancing needs at least dp_size samples; below that we fall through
+        # to the strided split, again matching the non-balance path.)
         equal_size = len(total_lengths) % dp_size == 0
         partitions = get_seqlen_balanced_partitions(total_lengths, dp_size, equal_size=equal_size)
     else:

--- a/miles/ray/rollout/train_data_conversion.py
+++ b/miles/ray/rollout/train_data_conversion.py
@@ -353,8 +353,15 @@ def split_train_data_by_dp_raw(args, data: dict[str, Any], *, dp_size: int) -> l
     total_lengths = [len(t) for t in data["tokens"]]
     data["total_lengths"] = total_lengths
 
-    if args.balance_data:
-        partitions = get_seqlen_balanced_partitions(total_lengths, dp_size, equal_size=True)
+    if args.balance_data and len(total_lengths) >= dp_size:
+        # Require equal per-rank sample counts only when the totals divide evenly.
+        # When invalid samples are dropped, the valid count may not be divisible by
+        # dp_size (e.g. 206 % 4); in that case balance by token count alone, matching
+        # the strided path below which already yields uneven per-rank counts.
+        # (Token balancing needs at least dp_size samples; below that we fall through
+        # to the strided split, again matching the non-balance path.)
+        equal_size = len(total_lengths) % dp_size == 0
+        partitions = get_seqlen_balanced_partitions(total_lengths, dp_size, equal_size=equal_size)
     else:
         partitions = [range(i, len(total_lengths), dp_size) for i in range(dp_size)]
 

--- a/tests/fast/ray/rollout/test_train_data_conversion.py
+++ b/tests/fast/ray/rollout/test_train_data_conversion.py
@@ -472,3 +472,31 @@ class TestSplitTrainDataByDp:
         parts = [ray.get(r.inner) for r in refs]
         all_indices = sorted(i for p in parts for i in p["partition"])
         assert all_indices == list(range(n))
+
+    def test_balance_data_handles_count_not_divisible_by_dp_size(self):
+        """Regression for #969: with --balance-data, a valid sample count that is
+        not divisible by dp_size (e.g. after invalid rollout samples are dropped)
+        must still partition by token balance instead of asserting `N % dp != 0`.
+
+        The strided non-balance path already tolerates this; the balance path
+        should too. We require a real partition (every sample assigned exactly
+        once, no empty rank), matching the documented token-balancing intent."""
+        args = make_args(balance_data=True)
+        n = 6  # 6 % 4 != 0 — the divisibility that used to crash
+        # varied lengths so token balancing is actually exercised
+        lengths = [1, 2, 3, 4, 5, 6]
+        data = {
+            "tokens": [list(range(length)) for length in lengths],
+            "response_lengths": lengths,
+            "rewards": [0] * n,
+            "truncated": [0] * n,
+            "loss_masks": [[1] * length for length in lengths],
+            "sample_indices": list(range(n)),
+        }
+        refs = split_train_data_by_dp(args, data, dp_size=4)
+        parts = [ray.get(r.inner) for r in refs]
+        # every sample assigned exactly once
+        all_indices = sorted(i for p in parts for i in p["partition"])
+        assert all_indices == list(range(n))
+        # no rank left empty
+        assert all(len(p["partition"]) >= 1 for p in parts)

--- a/tests/fast/ray/rollout/test_train_data_conversion.py
+++ b/tests/fast/ray/rollout/test_train_data_conversion.py
@@ -500,3 +500,25 @@ class TestSplitTrainDataByDp:
         assert all_indices == list(range(n))
         # no rank left empty
         assert all(len(p["partition"]) >= 1 for p in parts)
+
+    def test_balance_data_falls_back_when_fewer_samples_than_dp_size(self):
+        """Also #969: when so many samples are dropped that the valid count is
+        below dp_size, token balancing cannot fill every rank (Karmarkar-Karp
+        requires len >= k_partitions). The balance path must not crash — it
+        falls back to the strided split, exactly as the non-balance path does
+        for the same degenerate input. Samples are still assigned exactly once;
+        some ranks are legitimately empty."""
+        args = make_args(balance_data=True)
+        n = 2  # fewer samples than dp_size=4
+        data = {
+            "tokens": [[1, 2], [3, 4, 5]],
+            "response_lengths": [2, 3],
+            "rewards": [0] * n,
+            "truncated": [0] * n,
+            "loss_masks": [[1, 1], [1, 1, 1]],
+            "sample_indices": list(range(n)),
+        }
+        refs = split_train_data_by_dp(args, data, dp_size=4)
+        parts = [ray.get(r.inner) for r in refs]
+        all_indices = sorted(i for p in parts for i in p["partition"])
+        assert all_indices == list(range(n))

--- a/tests/fast/ray/rollout/test_train_data_conversion.py
+++ b/tests/fast/ray/rollout/test_train_data_conversion.py
@@ -820,6 +820,66 @@ class TestSplitTrainDataRaw:
             assert len(part["rollout_indexer_topk"]) == 2
             assert len(part["opd_reverse_kl"]) == 2
 
+    def _balance_data_case(self, lengths: list[int]) -> dict:
+        n = len(lengths)
+        return {
+            "tokens": [list(range(length)) for length in lengths],
+            "response_lengths": lengths,
+            "rewards": [0] * n,
+            "truncated": [0] * n,
+            "loss_masks": [[1] * length for length in lengths],
+            "sample_indices": list(range(n)),
+        }
+
+    def test_balance_data_handles_count_not_divisible_by_dp_size(self) -> None:
+        """Regression for #969: with --balance-data, a valid sample count that is
+        not divisible by dp_size (e.g. after invalid rollout samples are dropped)
+        must still partition by token balance instead of asserting `N % dp != 0`.
+
+        The strided non-balance path already tolerates this; the balance path
+        should too. We require a real partition (every sample assigned exactly
+        once, no empty rank), matching the documented token-balancing intent."""
+        args = make_args(balance_data=True)
+        # varied lengths so token balancing is actually exercised
+        lengths = [1, 2, 3, 4, 5, 6]
+        n = len(lengths)  # 6 % 4 != 0 -- the divisibility that used to crash
+        result = split_train_data_by_dp_raw(args, self._balance_data_case(lengths), dp_size=4)
+
+        assert len(result) == 4
+        # every sample assigned exactly once
+        all_indices = sorted(i for shard in result for i in shard["partition"])
+        assert all_indices == list(range(n))
+        # no rank left empty
+        assert all(len(shard["partition"]) >= 1 for shard in result)
+
+    def test_balance_data_falls_back_when_fewer_samples_than_dp_size(self) -> None:
+        """Also #969: when so many samples are dropped that the valid count is
+        below dp_size, token balancing cannot fill every rank (Karmarkar-Karp
+        requires len >= k_partitions). The balance path must not crash -- it
+        falls back to the strided split, exactly as the non-balance path does
+        for the same degenerate input. Samples are still assigned exactly once;
+        some ranks are legitimately empty."""
+        args = make_args(balance_data=True)
+        lengths = [1, 2]
+        n = len(lengths)  # fewer samples than dp_size=4
+        result = split_train_data_by_dp_raw(args, self._balance_data_case(lengths), dp_size=4)
+
+        assert len(result) == 4
+        all_indices = sorted(i for shard in result for i in shard["partition"])
+        assert all_indices == list(range(n))
+
+    def test_balance_data_still_equalises_counts_when_divisible(self) -> None:
+        """The fix must not loosen the divisible case: when the count divides
+        evenly, `equal_size=True` still applies and every rank gets N/dp."""
+        args = make_args(balance_data=True)
+        lengths = [1, 2, 3, 4, 5, 6, 7, 8]
+        result = split_train_data_by_dp_raw(args, self._balance_data_case(lengths), dp_size=4)
+
+        assert len(result) == 4
+        assert all(len(shard["partition"]) == 2 for shard in result)
+        all_indices = sorted(i for shard in result for i in shard["partition"])
+        assert all_indices == list(range(len(lengths)))
+
     def test_no_witness_ids_when_absent(self) -> None:
         tokens = [[1, 2], [3, 4]]
         data = {


### PR DESCRIPTION
## Summary

Closes #969.

`split_train_data_by_dp` hardcoded `equal_size=True` when partitioning a rollout batch across data-parallel ranks under `--balance-data`. When invalid rollout samples are dropped before training conversion, the remaining valid sample count can be non-divisible by `dp_size`, which trips the Karmarkar-Karp assertion `assert len(seqlen_list) % k_partitions == 0` in `miles/utils/seqlen_balancing.py` and crashes the run (`AssertionError: 206 % 4 != 0`).

## Root cause

`miles/ray/rollout/train_data_conversion.py` (`split_train_data_by_dp`):

```python
if args.balance_data:
    partitions = get_seqlen_balanced_partitions(total_lengths, dp_size, equal_size=True)  # <-- always equal_size
else:
    partitions = [range(i, len(total_lengths), dp_size) for i in range(dp_size)]
```

`equal_size=True` forces every rank to receive the same number of samples, which is only possible when the total divides evenly by `dp_size`. The non-balance strided path (the `else` branch, and the default since `--balance-data` is off by default) already tolerates non-divisible totals and produces uneven per-rank counts. The balance path was simply stricter than it needed to be.

## Fix

Only require equal per-rank counts when the totals divide evenly; otherwise balance by token count alone (`equal_size=False`), which is exactly the documented intent of `--balance-data` ("similar total token count via Karmarkar-Karp") and is already the trusted behavior used for micro-batch balancing in `miles/backends/training_utils/data.py`.

```python
if args.balance_data:
    equal_size = len(total_lengths) % dp_size == 0
    partitions = get_seqlen_balanced_partitions(total_lengths, dp_size, equal_size=equal_size)
```

This keeps the **divisible** case byte-for-byte identical to today (still `equal_size=True`, no behavior change), and only relaxes the **non-divisible** case so it matches the strided path instead of crashing. Scope is intentionally minimal — no downstream training code is touched. (The bounded-uneven partitioning mode requested in #970 is left as a separate follow-up.)

## Test: before/after

Added a regression test (`TestSplitTrainDataByDp::test_balance_data_handles_count_not_divisible_by_dp_size`) using `--balance-data` with 6 samples and `dp_size=4` (`6 % 4 != 0`), asserting the split assigns every sample exactly once with no empty rank.

**Before the fix** (test against pre-fix source):

```
>           assert len(seqlen_list) % k_partitions == 0, f"{len(seqlen_list)} % {k_partitions} != 0"
E           AssertionError: 6 % 4 != 0
miles/utils/seqlen_balancing.py:98: AssertionError
FAILED tests/fast/ray/rollout/test_train_data_conversion.py::TestSplitTrainDataByDp::test_balance_data_handles_count_not_divisible_by_dp_size
========================= 1 failed =========================
```

**After the fix:**

```
tests/fast/ray/rollout/test_train_data_conversion.py::TestSplitTrainDataByDp::test_balance_data_handles_count_not_divisible_by_dp_size PASSED
========================= 1 passed =========================
```

Full `TestSplitTrainDataByDp` class (no regression in the existing divisible-count balance test):

```
tests/fast/ray/rollout/test_train_data_conversion.py ......   [100%]
========================= 6 passed =========================
```

The whole `test_train_data_conversion.py` file passes (`27 passed`); `ruff check` and `isort` are clean.

## Verification note

Verified at the unit level on CPU (the partitioning + split logic is CPU-only). I did not exercise the full multi-GPU training path locally. Since this change only makes the balance path produce the same per-rank shape the default strided path already produces for non-divisible totals, it introduces no new downstream assumption — but please let the GPU CI stages confirm the end-to-end path.
