### PR TITLE
fix: fork session/router servers before wandb.init to avoid event-loop deadlock

### DIFF
--- a/miles/ray/rollout/rollout_manager.py
+++ b/miles/ray/rollout/rollout_manager.py
@@ -82,9 +82,7 @@ class RolloutManager:
         # child's single uvicorn event-loop thread blocks it forever and the server
         # stops accepting connections. Forking before wandb.init() avoids inheriting
         # that state entirely.
-        # router_addr stays None when the router was not started (e.g. debug_train_only),
-        # otherwise "http://None:None" would slip past the `is not None` guard in
-        # init_wandb_secondary and point metric forwarding at an invalid endpoint.
+        # No router_addr when the router was not started (e.g. debug_train_only).
         router_addr = (
             f"http://{args.sglang_router_ip}:{args.sglang_router_port}"
             if args.sglang_router_ip and args.sglang_router_port

--- a/miles/ray/rollout/rollout_manager.py
+++ b/miles/ray/rollout/rollout_manager.py
@@ -82,7 +82,15 @@ class RolloutManager:
         # child's single uvicorn event-loop thread blocks it forever and the server
         # stops accepting connections. Forking before wandb.init() avoids inheriting
         # that state entirely.
-        init_tracking(args, primary=False, router_addr=f"http://{args.sglang_router_ip}:{args.sglang_router_port}")
+        # router_addr stays None when the router was not started (e.g. debug_train_only),
+        # otherwise "http://None:None" would slip past the `is not None` guard in
+        # init_wandb_secondary and point metric forwarding at an invalid endpoint.
+        router_addr = (
+            f"http://{args.sglang_router_ip}:{args.sglang_router_port}"
+            if args.sglang_router_ip and args.sglang_router_port
+            else None
+        )
+        init_tracking(args, primary=False, router_addr=router_addr)
 
         self.rollout_engine_lock = Lock.options(num_cpus=1, num_gpus=0).remote()
         self.rollout_id = -1

--- a/miles/ray/rollout/rollout_manager.py
+++ b/miles/ray/rollout/rollout_manager.py
@@ -75,13 +75,9 @@ class RolloutManager:
             self.servers = start_rollout_servers(args, pg)
             start_session_server(args)
 
-        # Initialise tracking only AFTER the router and session-server subprocesses
-        # have been forked. wandb.init() spins up service-backed objects whose
-        # weakref finalizers call into a background service thread; a forked child
-        # inherits those objects but not the thread, so finalizing one inside the
-        # child's single uvicorn event-loop thread blocks it forever and the server
-        # stops accepting connections. Forking before wandb.init() avoids inheriting
-        # that state entirely.
+        # Init tracking only after the servers are forked: a child forked after
+        # wandb.init() inherits its finalizers but not its service thread, which
+        # deadlocks the child's uvicorn event loop.
         # No router_addr when the router was not started (e.g. debug_train_only).
         router_addr = (
             f"http://{args.sglang_router_ip}:{args.sglang_router_port}"

--- a/miles/ray/rollout/rollout_manager.py
+++ b/miles/ray/rollout/rollout_manager.py
@@ -47,7 +47,6 @@ class RolloutManager:
         self.pg = pg
         self.args = args
         # TODO make args immutable
-        init_tracking(args, primary=False, router_addr=f"http://{args.sglang_router_ip}:{args.sglang_router_port}")
 
         data_source_cls = load_function(self.args.data_source_path)
         self.data_source = data_source_cls(args)
@@ -75,6 +74,16 @@ class RolloutManager:
             init_http_client(args)
             self.servers = start_rollout_servers(args, pg)
             start_session_server(args)
+
+        # Initialise tracking only AFTER the router and session-server subprocesses
+        # have been forked. wandb.init() spins up service-backed objects whose
+        # weakref finalizers call into a background service thread; a forked child
+        # inherits those objects but not the thread, so finalizing one inside the
+        # child's single uvicorn event-loop thread blocks it forever and the server
+        # stops accepting connections. Forking before wandb.init() avoids inheriting
+        # that state entirely.
+        init_tracking(args, primary=False, router_addr=f"http://{args.sglang_router_ip}:{args.sglang_router_port}")
+
         self.rollout_engine_lock = Lock.options(num_cpus=1, num_gpus=0).remote()
         self.rollout_id = -1
 


### PR DESCRIPTION
## Summary
The miles session server (`--use-session-server`) and the SGLang router are each launched as a `multiprocessing.Process` forked from `RolloutManager.__init__`. On Linux + Python 3.12 the default start method is `fork`, so the child inherits the parent's memory — including the service-backed objects created by `wandb.init()` (run via `init_tracking(..., primary=False)` earlier in `__init__`).

Those wandb objects carry weakref finalizers that call into a background wandb service thread. The thread is **not** recreated in the fork, so when Python GC finalizes an inherited object inside the child's single uvicorn event-loop thread (during HTTP `handle_events`), the finalizer blocks **forever** on a `concurrent.futures` result that will never be set. The event loop freezes, uvicorn stops `accept()`-ing, the `:30000` accept backlog grows, and every agent `chat/completions` request times out → `collect_records` returns empty → no training step.

This was root-caused with `py-spy dump` on the wedged session-server process; the blocking stack is:
```
wait (threading.py:355) <- result (concurrent/futures/_base.py:451)
<- run (wandb/sdk/lib/asyncio_manager.py:137)
<- api_cleanup_request (wandb/.../service_connection.py:201)
<- _cleanup (wandb/apis/public/service_api.py:31)
<- weakref __call__ ... handle_events (uvicorn/.../h11_impl.py:262)
<- run_session_server (miles/rollout/session/session_server.py:111)
```

## Fix
Move `init_tracking(args, primary=False, ...)` to **after** the router/session-server subprocesses are forked. The children then fork from a process where `wandb.init()` has not yet run, so they never inherit the service-backed objects and the finalizer deadlock cannot occur. Nothing between the old and new call sites logs to wandb, so the ordering change is safe.

This reorder is intentionally a minimal, low-risk stop-the-bleeding fix. The deeper root cause is forking a multi-threaded Ray actor at all: the reorder removes the one wandb instance of the hazard, but the next library that holds a thread or lock before the fork point would reintroduce the same deadlock under a new name. The principled fix is to launch these two processes under a `spawn` context (`mp.get_context("spawn").Process(...)`), so the children inherit none of the parent's threads/finalizers — matching how we already start the SGLang engine from inside a Ray actor (`sglang_engine.py` forces `spawn`). That is left as a follow-up because it needs `args`/`router_args` to be picklable and is best validated with a full run.

## Test plan
- [ ] Relaunch the DeepSeek-V4-Flash disagg agentic run and confirm the session server keeps accepting on `:30000` (Recv-Q stays ~0) and a training step lands.
