### PR TITLE
[feat] balance_data: bounded-uneven partitioning for non-divisible counts (#970)

### DIFF
--- a/miles/ray/rollout/train_data_conversion.py
+++ b/miles/ray/rollout/train_data_conversion.py
@@ -132,7 +132,12 @@ def split_train_data_by_dp(args, data, dp_size):
     data["total_lengths"] = total_lengths
 
     if args.balance_data:
-        partitions = get_seqlen_balanced_partitions(total_lengths, dp_size, equal_size=True)
+        # Require equal per-rank sample counts only when the totals divide evenly.
+        # When invalid samples are dropped, the valid count may not be divisible by
+        # dp_size (e.g. 206 % 4); in that case balance by token count alone, matching
+        # the strided path below which already yields uneven per-rank counts.
+        equal_size = len(total_lengths) % dp_size == 0
+        partitions = get_seqlen_balanced_partitions(total_lengths, dp_size, equal_size=equal_size)
     else:
         partitions = [range(i, len(total_lengths), dp_size) for i in range(dp_size)]
 

--- a/miles/ray/rollout/train_data_conversion.py
+++ b/miles/ray/rollout/train_data_conversion.py
@@ -131,11 +131,13 @@ def split_train_data_by_dp(args, data, dp_size):
     total_lengths = [len(t) for t in data["tokens"]]
     data["total_lengths"] = total_lengths
 
-    if args.balance_data:
+    if args.balance_data and len(total_lengths) >= dp_size:
         # Require equal per-rank sample counts only when the totals divide evenly.
         # When invalid samples are dropped, the valid count may not be divisible by
         # dp_size (e.g. 206 % 4); in that case balance by token count alone, matching
         # the strided path below which already yields uneven per-rank counts.
+        # (Token balancing needs at least dp_size samples; below that we fall through
+        # to the strided split, again matching the non-balance path.)
         equal_size = len(total_lengths) % dp_size == 0
         partitions = get_seqlen_balanced_partitions(total_lengths, dp_size, equal_size=equal_size)
     else:

--- a/miles/ray/rollout/train_data_conversion.py
+++ b/miles/ray/rollout/train_data_conversion.py
@@ -4,7 +4,7 @@ import ray
 import torch
 
 from miles.utils.ray_utils import Box
-from miles.utils.seqlen_balancing import get_seqlen_balanced_partitions
+from miles.utils.seqlen_balancing import get_seqlen_balanced_partitions, get_seqlen_bounded_partitions
 from miles.utils.types import Sample
 
 
@@ -132,15 +132,16 @@ def split_train_data_by_dp(args, data, dp_size):
     data["total_lengths"] = total_lengths
 
     if args.balance_data and len(total_lengths) >= dp_size:
-        # Require equal per-rank sample counts only when the totals divide evenly.
-        # When invalid samples are dropped, the valid count may not be divisible by
-        # dp_size (e.g. 206 % 4); in that case balance by token count alone, matching
-        # the strided path below which already yields uneven per-rank counts.
-        # (Token balancing needs at least dp_size samples; below that we fall through
-        # to the strided split, again matching the non-balance path.)
-        equal_size = len(total_lengths) % dp_size == 0
-        partitions = get_seqlen_balanced_partitions(total_lengths, dp_size, equal_size=equal_size)
+        if len(total_lengths) % dp_size == 0:
+            # Evenly divisible: exact equal per-rank counts, token-balanced via Karmarkar-Karp.
+            partitions = get_seqlen_balanced_partitions(total_lengths, dp_size, equal_size=True)
+        else:
+            # Not divisible (e.g. invalid samples dropped, 206 % 4): token-balance while
+            # keeping per-rank sample counts within 1 of each other, rather than crashing.
+            partitions = get_seqlen_bounded_partitions(total_lengths, dp_size)
     else:
+        # Fewer samples than dp_size (or balancing disabled): strided split, which
+        # tolerates any count (some ranks may be empty when len < dp_size).
         partitions = [range(i, len(total_lengths), dp_size) for i in range(dp_size)]
 
     rollout_data_refs = []

--- a/miles/utils/seqlen_balancing.py
+++ b/miles/utils/seqlen_balancing.py
@@ -177,6 +177,51 @@ def get_seqlen_balanced_partitions(seqlen_list: list[int], k_partitions: int, eq
     return _check_and_sort_partitions(partitions)
 
 
+def get_seqlen_bounded_partitions(seqlen_list: list[int], k_partitions: int) -> list[list[int]]:
+    """Partition item indices into k groups that balance total sequence length
+    while bounding the per-group item count: any two groups differ by at most
+    one item.
+
+    This sits between the two modes of ``get_seqlen_balanced_partitions``:
+    ``equal_size=True`` gives exactly equal counts but requires
+    ``len(seqlen_list) % k_partitions == 0``; ``equal_size=False`` balances
+    tokens but allows arbitrarily uneven counts. This balances tokens *and*
+    caps the count skew at 1, so it works for any
+    ``len(seqlen_list) >= k_partitions`` (e.g. when dropped samples leave a
+    count not divisible by ``k_partitions``).
+
+    Returns ``k_partitions`` lists of indices, each sorted ascending.
+    """
+    n = len(seqlen_list)
+    assert n >= k_partitions, f"number of items:[{n}] < k_partitions:[{k_partitions}]"
+
+    # At most `rem` groups may hold one extra item (ceil); the rest hold floor.
+    # Tracking the extra-item budget dynamically — rather than pinning which
+    # groups get it — lets the extra items land in whichever groups end up
+    # lightest, improving the token balance while still bounding the count
+    # delta at 1.
+    base, rem = divmod(n, k_partitions)
+    extra_budget = rem
+
+    partitions: list[list[int]] = [[] for _ in range(k_partitions)]
+    sums = [0] * k_partitions
+
+    # Longest-processing-time greedy: place the longest items first into the
+    # lightest group that still has spare capacity.
+    for idx in sorted(range(n), key=lambda i: seqlen_list[i], reverse=True):
+        limit = base + 1 if extra_budget > 0 else base
+        target = min(
+            (j for j in range(k_partitions) if len(partitions[j]) < limit),
+            key=lambda j: sums[j],
+        )
+        partitions[target].append(idx)
+        sums[target] += seqlen_list[idx]
+        if len(partitions[target]) > base:
+            extra_budget -= 1
+
+    return [sorted(p) for p in partitions]
+
+
 def get_reverse_idx(idx_map):
     reverse_idx_map = copy.deepcopy(idx_map)
 

--- a/tests/fast/ray/rollout/test_train_data_conversion.py
+++ b/tests/fast/ray/rollout/test_train_data_conversion.py
@@ -472,3 +472,31 @@ class TestSplitTrainDataByDp:
         parts = [ray.get(r.inner) for r in refs]
         all_indices = sorted(i for p in parts for i in p["partition"])
         assert all_indices == list(range(n))
+
+    def test_balance_data_handles_count_not_divisible_by_dp_size(self):
+        """Regression for #969: with --balance-data, a valid sample count that is
+        not divisible by dp_size (e.g. after invalid rollout samples are dropped)
+        must still partition by token balance instead of asserting `N % dp != 0`.
+
+        The strided non-balance path already tolerates this; the balance path
+        should too. We require a real partition (every sample assigned exactly
+        once, no empty rank), matching the documented token-balancing intent."""
+        args = make_args(balance_data=True)
+        n = 6  # 6 % 4 != 0 — the divisibility that used to crash
+        # varied lengths so token balancing is actually exercised
+        lengths = [1, 2, 3, 4, 5, 6]
+        data = {
+            "tokens": [list(range(length)) for length in lengths],
+            "response_lengths": lengths,
+            "rewards": [0] * n,
+            "truncated": [0] * n,
+            "loss_masks": [[1] * length for length in lengths],
+            "sample_indices": list(range(n)),
+        }
+        refs = split_train_data_by_dp(args, data, dp_size=4)
+        parts = [ray.get(r.inner) for r in refs]
+        # every sample assigned exactly once
+        all_indices = sorted(i for p in parts for i in p["partition"])
+        assert all_indices == list(range(n))
+        # no rank left empty
+        assert all(len(p["partition"]) >= 1 for p in parts)

--- a/tests/fast/ray/rollout/test_train_data_conversion.py
+++ b/tests/fast/ray/rollout/test_train_data_conversion.py
@@ -500,3 +500,25 @@ class TestSplitTrainDataByDp:
         assert all_indices == list(range(n))
         # no rank left empty
         assert all(len(p["partition"]) >= 1 for p in parts)
+
+    def test_balance_data_falls_back_when_fewer_samples_than_dp_size(self):
+        """Also #969: when so many samples are dropped that the valid count is
+        below dp_size, token balancing cannot fill every rank (Karmarkar-Karp
+        requires len >= k_partitions). The balance path must not crash — it
+        falls back to the strided split, exactly as the non-balance path does
+        for the same degenerate input. Samples are still assigned exactly once;
+        some ranks are legitimately empty."""
+        args = make_args(balance_data=True)
+        n = 2  # fewer samples than dp_size=4
+        data = {
+            "tokens": [[1, 2], [3, 4, 5]],
+            "response_lengths": [2, 3],
+            "rewards": [0] * n,
+            "truncated": [0] * n,
+            "loss_masks": [[1, 1], [1, 1, 1]],
+            "sample_indices": list(range(n)),
+        }
+        refs = split_train_data_by_dp(args, data, dp_size=4)
+        parts = [ray.get(r.inner) for r in refs]
+        all_indices = sorted(i for p in parts for i in p["partition"])
+        assert all_indices == list(range(n))

--- a/tests/fast/ray/rollout/test_train_data_conversion.py
+++ b/tests/fast/ray/rollout/test_train_data_conversion.py
@@ -500,6 +500,9 @@ class TestSplitTrainDataByDp:
         assert all_indices == list(range(n))
         # no rank left empty
         assert all(len(p["partition"]) >= 1 for p in parts)
+        # bounded-uneven (#970): per-rank sample counts differ by at most 1
+        sizes = [len(p["partition"]) for p in parts]
+        assert max(sizes) - min(sizes) <= 1
 
     def test_balance_data_falls_back_when_fewer_samples_than_dp_size(self):
         """Also #969: when so many samples are dropped that the valid count is

--- a/tests/fast/utils/test_seqlen_balancing.py
+++ b/tests/fast/utils/test_seqlen_balancing.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import random
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from miles.utils.seqlen_balancing import get_seqlen_bounded_partitions
+
+
+def _counts(partitions: list[list[int]]) -> list[int]:
+    return [len(p) for p in partitions]
+
+
+class TestBoundedPartitions:
+    def test_covers_every_index_exactly_once(self):
+        seqlens = [5, 1, 9, 3, 7, 2, 8, 4, 6, 10]  # n=10
+        partitions = get_seqlen_bounded_partitions(seqlens, k_partitions=4)
+        flat = sorted(i for p in partitions for i in p)
+        assert flat == list(range(len(seqlens)))
+
+    def test_returns_k_partitions(self):
+        partitions = get_seqlen_bounded_partitions([1, 2, 3, 4, 5], k_partitions=3)
+        assert len(partitions) == 3
+
+    def test_sample_count_delta_at_most_one_when_not_divisible(self):
+        # n=10, k=4 -> counts must be {3,3,2,2}; max-min == 1
+        partitions = get_seqlen_bounded_partitions([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], k_partitions=4)
+        counts = _counts(partitions)
+        assert max(counts) - min(counts) <= 1
+        assert sorted(counts) == [2, 2, 3, 3]
+
+    def test_exact_equal_counts_when_divisible(self):
+        # n=12, k=4 -> every rank gets exactly 3 (delta 0)
+        partitions = get_seqlen_bounded_partitions(list(range(1, 13)), k_partitions=4)
+        assert _counts(partitions) == [3, 3, 3, 3]
+
+    def test_balances_token_sums(self):
+        # identical lengths: token sums should track the (bounded) counts, not
+        # pile onto one rank. With n=10,k=4 and equal lengths, sums ratio == counts.
+        partitions = get_seqlen_bounded_partitions([10] * 10, k_partitions=4)
+        sums = sorted(sum(10 for _ in p) for p in partitions)
+        assert sums == [20, 20, 30, 30]
+
+    def test_each_partition_nonempty_when_n_at_least_k(self):
+        partitions = get_seqlen_bounded_partitions([3, 1, 2, 5, 4], k_partitions=4)  # n=5,k=4
+        assert all(len(p) >= 1 for p in partitions)
+
+    def test_extra_item_lands_in_lightest_group(self):
+        """The 'which group gets the extra item' choice must follow token weight,
+        not a fixed index. With lengths [10, 9, 1, 1, 1] and k=2 the optimal split
+        is {10,1} / {9,1,1} -> sums 11/11. A static 'first rem groups get +1'
+        capacity instead forces 12/10."""
+        lengths = [10, 9, 1, 1, 1]
+        partitions = get_seqlen_bounded_partitions(lengths, k_partitions=2)
+        sums = sorted(sum(lengths[i] for i in p) for p in partitions)
+        assert sums == [11, 11]
+        # still bounded
+        counts = sorted(_counts(partitions))
+        assert counts == [2, 3]
+
+
+class TestBoundedPartitionsProperties:
+    @settings(deadline=None, max_examples=80)
+    @given(
+        n=st.integers(min_value=1, max_value=64),
+        k=st.integers(min_value=1, max_value=16),
+        seed=st.integers(min_value=0, max_value=2**31 - 1),
+    )
+    def test_invariants_hold_for_random_inputs(self, n, k, seed):
+        # only defined for n >= k (token balancing needs at least one item per rank)
+        if n < k:
+            return
+        rng = random.Random(seed)
+        seqlens = [rng.randint(1, 1000) for _ in range(n)]
+        partitions = get_seqlen_bounded_partitions(seqlens, k_partitions=k)
+
+        # exactly k partitions
+        assert len(partitions) == k
+        # every index assigned exactly once
+        flat = sorted(i for p in partitions for i in p)
+        assert flat == list(range(n))
+        # bounded unevenness: counts differ by at most 1
+        counts = _counts(partitions)
+        assert max(counts) - min(counts) <= 1
+        # counts are exactly the floor/ceil split
+        base, rem = divmod(n, k)
+        assert sorted(counts) == sorted([base + 1] * rem + [base] * (k - rem))


### PR DESCRIPTION
## Summary

Closes #970. Follow-up to #969 that adds the **bounded-uneven** partitioning mode requested there.

After #969, `--balance-data` no longer crashes when the valid sample count is not divisible by `dp_size`, but the non-divisible case used pure token balancing with **arbitrarily uneven** per-rank counts. #970 asks for the stronger guarantee: token-balanced **and** per-rank sample-count skew bounded to at most 1.

> ⚠️ **Stacked on #1356** (the #969 fix). This branch contains #1356's two commits plus the one net-new commit `93fbc9e`. Easiest path is to merge #1356 first; this PR's diff then collapses to just the bounded-partitioning change. Happy to rebase onto `main` once #1356 lands.

## Behavior

`--balance-data` semantics, with no new CLI flag:

| valid count vs `dp_size` | partitioning | change |
|---|---|---|
| divisible | exact equal counts, Karmarkar-Karp (`equal_size=True`) | unchanged |
| not divisible, `>= dp_size` | **token-balanced, per-rank count delta ≤ 1** | replaces #969's unbounded fallback |
| `< dp_size` | strided split (some ranks empty) | unchanged |

## Implementation

New `get_seqlen_bounded_partitions(seqlen_list, k_partitions)` in `miles/utils/seqlen_balancing.py` (the Karmarkar-Karp code copied from verl is left untouched):

- Each group is capped at `floor`/`ceil(n/k)` items, so the **max count delta is ≤ 1**. The "ceil" budget (`rem = n % k` extra items) is tracked **dynamically** rather than pinned to fixed group indices — so the extra items land in whichever groups end up lightest by token sum.
- Items are placed longest-first into the lightest group with spare capacity (LPT greedy, the same heuristic as the existing `greedy_partition`). Token balance is "as good as possible" per the issue; exact-optimal balance is a non-goal.

Trade-off (vs #969's non-divisible path): swaps Karmarkar-Karp's unbounded token optimum for greedy balancing with the count-skew guarantee — exactly what #970 asks for. The divisible case is byte-for-byte unchanged.

## Tests

`tests/fast/utils/test_seqlen_balancing.py` (new) — unit + Hypothesis property tests for the partitioner:

- Coverage (every index once), exactly `k` partitions, `max(counts) - min(counts) <= 1`, counts equal the floor/ceil split — checked across 80 random `n >= k` inputs.
- A pinned case (`[10, 9, 1, 1, 1]`, k=2 → sums 11/11) asserting the extra item follows token weight, not a fixed index.

The `split_train_data_by_dp` integration test also asserts the bounded property; full `test_train_data_conversion.py` + `test_seqlen_balancing.py` run `36 passed`. `ruff` / `isort` clean. Both new test files auto-register into the `stage-a-cpu` suite.

## Verification note

Unit/property-level only (partitioning is CPU-only); the multi-GPU training path was not exercised locally. The change keeps per-rank counts *closer* to equal than #969's behavior, so it does not introduce a new downstream assumption.
