### PR TITLE
Clamp PPO ratio exponentials to fix NaN logits

### DIFF
--- a/miles/backends/training_utils/loss_hub/math_utils.py
+++ b/miles/backends/training_utils/loss_hub/math_utils.py
@@ -14,15 +14,18 @@ from miles.backends.training_utils.parallel import get_parallel_state
 _LOG_RATIO_EXP_CLAMP = 20.0
 
 
-def _safe_exp_neg_ppo_kl(ppo_kl: torch.Tensor) -> torch.Tensor:
+def _safe_clamp_log_ratio(log_ratio: torch.Tensor) -> torch.Tensor:
     log_ratio = torch.nan_to_num(
-        -ppo_kl.float(),
+        log_ratio.float(),
         nan=0.0,
         posinf=_LOG_RATIO_EXP_CLAMP,
         neginf=-_LOG_RATIO_EXP_CLAMP,
     )
-    log_ratio = torch.clamp(log_ratio, min=-_LOG_RATIO_EXP_CLAMP, max=_LOG_RATIO_EXP_CLAMP)
-    return log_ratio.exp()
+    return torch.clamp(log_ratio, min=-_LOG_RATIO_EXP_CLAMP, max=_LOG_RATIO_EXP_CLAMP)
+
+
+def _safe_exp_neg_ppo_kl(ppo_kl: torch.Tensor) -> torch.Tensor:
+    return _safe_clamp_log_ratio(-ppo_kl).exp()
 
 
 def compute_ess_ratio_contribution(
@@ -157,13 +160,7 @@ def compute_approx_kl(
         # Besides non negative, it is also unbiased and have lower variance.
         log_ratio = -log_ratio
         if kl_loss_type == "low_var_kl":
-            log_ratio = torch.nan_to_num(
-                log_ratio.float(),
-                nan=0.0,
-                posinf=_LOG_RATIO_EXP_CLAMP,
-                neginf=-_LOG_RATIO_EXP_CLAMP,
-            )
-            log_ratio = torch.clamp(log_ratio, min=-_LOG_RATIO_EXP_CLAMP, max=_LOG_RATIO_EXP_CLAMP)
+            log_ratio = _safe_clamp_log_ratio(log_ratio)
         kl = log_ratio.exp() - 1 - log_ratio
     else:
         raise ValueError(f"Unknown kl_loss_type: {kl_loss_type}")

--- a/miles/backends/training_utils/loss_hub/math_utils.py
+++ b/miles/backends/training_utils/loss_hub/math_utils.py
@@ -11,6 +11,19 @@ import torch.nn.functional as F
 from miles.backends.training_utils.cp_utils import slice_loss_masks_for_local_cp
 from miles.backends.training_utils.parallel import get_parallel_state
 
+_LOG_RATIO_EXP_CLAMP = 20.0
+
+
+def _safe_exp_neg_ppo_kl(ppo_kl: torch.Tensor) -> torch.Tensor:
+    log_ratio = torch.nan_to_num(
+        -ppo_kl.float(),
+        nan=0.0,
+        posinf=_LOG_RATIO_EXP_CLAMP,
+        neginf=-_LOG_RATIO_EXP_CLAMP,
+    )
+    log_ratio = torch.clamp(log_ratio, min=-_LOG_RATIO_EXP_CLAMP, max=_LOG_RATIO_EXP_CLAMP)
+    return log_ratio.exp()
+
 
 def compute_ess_ratio_contribution(
     ppo_kl: torch.Tensor,
@@ -38,7 +51,7 @@ def compute_ess_ratio_contribution(
         max_seq_lens,
     )
     local_lengths = [mask.size(0) for mask in local_masks]
-    is_weights_per_sample = (-ppo_kl.detach().float()).exp().split(local_lengths, dim=0)
+    is_weights_per_sample = _safe_exp_neg_ppo_kl(ppo_kl.detach()).split(local_lengths, dim=0)
 
     partial_sums = torch.zeros(len(loss_masks), 2, device=ppo_kl.device, dtype=torch.float32)
     for i, (weights, mask) in enumerate(zip(is_weights_per_sample, local_masks, strict=False)):
@@ -143,6 +156,14 @@ def compute_approx_kl(
         # http://joschu.net/blog/kl-approx.html
         # Besides non negative, it is also unbiased and have lower variance.
         log_ratio = -log_ratio
+        if kl_loss_type == "low_var_kl":
+            log_ratio = torch.nan_to_num(
+                log_ratio.float(),
+                nan=0.0,
+                posinf=_LOG_RATIO_EXP_CLAMP,
+                neginf=-_LOG_RATIO_EXP_CLAMP,
+            )
+            log_ratio = torch.clamp(log_ratio, min=-_LOG_RATIO_EXP_CLAMP, max=_LOG_RATIO_EXP_CLAMP)
         kl = log_ratio.exp() - 1 - log_ratio
     else:
         raise ValueError(f"Unknown kl_loss_type: {kl_loss_type}")
@@ -236,7 +257,7 @@ def compute_policy_loss(
     eps_clip_high: float,
     eps_clip_c: float | None = None,
 ):
-    ratio = (-ppo_kl).exp()
+    ratio = _safe_exp_neg_ppo_kl(ppo_kl)
     pg_losses1 = -ratio * advantages
     pg_losses2 = -ratio.clamp(1 - eps_clip, 1 + eps_clip_high) * advantages
     clip_pg_losses1 = torch.maximum(pg_losses1, pg_losses2)

--- a/tests/fast/backends/training_utils/test_ppo_ratio_numerics.py
+++ b/tests/fast/backends/training_utils/test_ppo_ratio_numerics.py
@@ -39,5 +39,14 @@ def test_low_var_kl_extreme_log_ratios_stay_finite():
     kl = compute_approx_kl(log_probs, log_probs_base, kl_loss_type="low_var_kl")
 
     assert torch.isfinite(kl).all().item()
-    assert torch.all(kl <= 10).item()
-    assert torch.all(kl >= -10).item()
+
+
+def test_low_var_kl_matches_unclamped_formula_for_normal_log_ratios():
+    log_probs = torch.tensor([-0.1, 0.0, 0.1], dtype=torch.float32)
+    log_probs_base = torch.zeros_like(log_probs)
+
+    kl = compute_approx_kl(log_probs, log_probs_base, kl_loss_type="low_var_kl")
+
+    log_ratio = -(log_probs - log_probs_base)
+    expected_kl = log_ratio.exp() - 1 - log_ratio
+    torch.testing.assert_close(kl, expected_kl)

--- a/tests/fast/backends/training_utils/test_ppo_ratio_numerics.py
+++ b/tests/fast/backends/training_utils/test_ppo_ratio_numerics.py
@@ -1,0 +1,43 @@
+import torch
+
+from miles.backends.training_utils.loss_hub.math_utils import compute_approx_kl, compute_policy_loss
+
+
+def test_policy_loss_extreme_log_ratios_with_zero_advantages_stay_finite():
+    ppo_kl = torch.tensor([-1000.0, 1000.0, float("nan"), float("inf"), float("-inf")])
+    advantages = torch.zeros_like(ppo_kl)
+
+    pg_losses, clipfrac = compute_policy_loss(ppo_kl, advantages, eps_clip=0.2, eps_clip_high=0.2)
+
+    assert torch.isfinite(pg_losses).all().item()
+    assert torch.isfinite(clipfrac).all().item()
+    torch.testing.assert_close(pg_losses, torch.zeros_like(pg_losses))
+
+
+def test_policy_loss_matches_unclamped_ratio_for_normal_log_ratios():
+    ppo_kl = torch.tensor([-0.1, 0.0, 0.1], dtype=torch.float32)
+    advantages = torch.tensor([1.0, -2.0, 0.5], dtype=torch.float32)
+    eps_clip = 0.2
+    eps_clip_high = 0.2
+
+    pg_losses, clipfrac = compute_policy_loss(ppo_kl, advantages, eps_clip=eps_clip, eps_clip_high=eps_clip_high)
+
+    ratio = (-ppo_kl).exp()
+    expected_losses1 = -ratio * advantages
+    expected_losses2 = -ratio.clamp(1 - eps_clip, 1 + eps_clip_high) * advantages
+    expected_losses = torch.maximum(expected_losses1, expected_losses2)
+    expected_clipfrac = torch.gt(expected_losses2, expected_losses1).float()
+
+    torch.testing.assert_close(pg_losses, expected_losses)
+    torch.testing.assert_close(clipfrac, expected_clipfrac)
+
+
+def test_low_var_kl_extreme_log_ratios_stay_finite():
+    log_probs = torch.tensor([-1000.0, 1000.0, float("nan"), float("inf"), float("-inf")])
+    log_probs_base = torch.zeros_like(log_probs)
+
+    kl = compute_approx_kl(log_probs, log_probs_base, kl_loss_type="low_var_kl")
+
+    assert torch.isfinite(kl).all().item()
+    assert torch.all(kl <= 10).item()
+    assert torch.all(kl >= -10).item()

--- a/tests/fast/backends/training_utils/test_ppo_ratio_numerics.py
+++ b/tests/fast/backends/training_utils/test_ppo_ratio_numerics.py
@@ -2,12 +2,15 @@ import torch
 
 from miles.backends.training_utils.loss_hub.math_utils import compute_approx_kl, compute_policy_loss
 
+compute_approx_kl_eager = compute_approx_kl.__wrapped__
+compute_policy_loss_eager = compute_policy_loss.__wrapped__
+
 
 def test_policy_loss_extreme_log_ratios_with_zero_advantages_stay_finite():
     ppo_kl = torch.tensor([-1000.0, 1000.0, float("nan"), float("inf"), float("-inf")])
     advantages = torch.zeros_like(ppo_kl)
 
-    pg_losses, clipfrac = compute_policy_loss(ppo_kl, advantages, eps_clip=0.2, eps_clip_high=0.2)
+    pg_losses, clipfrac = compute_policy_loss_eager(ppo_kl, advantages, eps_clip=0.2, eps_clip_high=0.2)
 
     assert torch.isfinite(pg_losses).all().item()
     assert torch.isfinite(clipfrac).all().item()
@@ -20,7 +23,12 @@ def test_policy_loss_matches_unclamped_ratio_for_normal_log_ratios():
     eps_clip = 0.2
     eps_clip_high = 0.2
 
-    pg_losses, clipfrac = compute_policy_loss(ppo_kl, advantages, eps_clip=eps_clip, eps_clip_high=eps_clip_high)
+    pg_losses, clipfrac = compute_policy_loss_eager(
+        ppo_kl,
+        advantages,
+        eps_clip=eps_clip,
+        eps_clip_high=eps_clip_high,
+    )
 
     ratio = (-ppo_kl).exp()
     expected_losses1 = -ratio * advantages
@@ -36,7 +44,7 @@ def test_low_var_kl_extreme_log_ratios_stay_finite():
     log_probs = torch.tensor([-1000.0, 1000.0, float("nan"), float("inf"), float("-inf")])
     log_probs_base = torch.zeros_like(log_probs)
 
-    kl = compute_approx_kl(log_probs, log_probs_base, kl_loss_type="low_var_kl")
+    kl = compute_approx_kl_eager(log_probs, log_probs_base, kl_loss_type="low_var_kl")
 
     assert torch.isfinite(kl).all().item()
 
@@ -45,7 +53,7 @@ def test_low_var_kl_matches_unclamped_formula_for_normal_log_ratios():
     log_probs = torch.tensor([-0.1, 0.0, 0.1], dtype=torch.float32)
     log_probs_base = torch.zeros_like(log_probs)
 
-    kl = compute_approx_kl(log_probs, log_probs_base, kl_loss_type="low_var_kl")
+    kl = compute_approx_kl_eager(log_probs, log_probs_base, kl_loss_type="low_var_kl")
 
     log_ratio = -(log_probs - log_probs_base)
     expected_kl = log_ratio.exp() - 1 - log_ratio


### PR DESCRIPTION
## Summary

This PR adds a small numerical guard around PPO log-ratio exponentials in the training loss utilities.

It clamps the exponent input before computing importance ratios, and applies the same guard to the `low_var_kl` estimator before its exponential. The change is intentionally local to `miles/backends/training_utils/loss_hub/math_utils.py`.

## Motivation

During long-context agentic RL runs, a small number of samples can produce extreme token log-ratios. The current code computes the PPO importance ratio directly with:

```python
ratio = (-ppo_kl).exp()
```

For very large exponent inputs, this can overflow to `inf`. Once that happens, normal PPO arithmetic can produce `NaN`, for example through `inf * 0` when the corresponding advantage is zero. The clipped PPO branch does not fully avoid this because the unclipped branch is still computed.

The same direct exponential pattern also appears in ESS metric computation, and `low_var_kl` has the same overflow risk when computing `log_ratio.exp() - 1 - log_ratio`.

## What Changed

- Added `_safe_clamp_log_ratio`, which centralizes finite-input handling and exponent-input clamping.
- Added `_safe_exp_neg_ppo_kl`, which:
  - casts the log-ratio to fp32 before exponentiation;
  - maps non-finite inputs to bounded values;
  - clamps the exponent input to `[-20, 20]`;
  - returns a finite importance ratio.
- Replaced direct `exp(-ppo_kl)` usage in policy loss and ESS contribution.
- Added the same finite-input guard before the `low_var_kl` exponential.

## Why This Is Safe

`exp(20)` is already far outside the normal PPO clipping range, so the clamp only affects pathological outliers that would otherwise overflow. For normal PPO ratios, behavior is unchanged.

This does not change rollout behavior, rewards, optimizer state, parallelism, checkpoint format, or data loading. It only prevents non-finite arithmetic in the loss helper.

## Testing

```bash
PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile miles/backends/training_utils/loss_hub/math_utils.py
PYTHONPATH=. python3 -m py_compile tests/fast/backends/training_utils/test_ppo_ratio_numerics.py
PYTHONPATH=. python3 tests/ci/run_suite.py --hw cpu --suite stage-a-cpu --list-only
```
