### PR TITLE
sft: --async-rollout-prefetch for colocate SFT

### DIFF
--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -716,6 +716,19 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 ),
             )
             parser.add_argument(
+                "--async-rollout-prefetch",
+                action="store_true",
+                default=False,
+                help=(
+                    "Prefetch the next rollout's data generation concurrently with the current train step "
+                    "(double-buffered pipeline). Hides rollout-gen latency behind training. Only valid when the "
+                    "rollout is weight-INDEPENDENT (e.g. SFT data tokenization/packing) -- NOT for RL/online "
+                    "rollout, where generation uses the just-updated weights. Incompatible with --offload-rollout "
+                    "and --use-critic. trunk's train_async.py provides the same overlap but asserts non-colocate, "
+                    "so it cannot serve the colocate SFT path this flag targets."
+                ),
+            )
+            parser.add_argument(
                 "--n-samples-per-prompt", type=int, default=1, help="Number of responses for each prompt in generation"
             )
 

--- a/train.py
+++ b/train.py
@@ -66,11 +66,37 @@ async def train(args):
 
     # train loop.
     # note that for async training, one can change the position of the sync operation(ray.get).
-    for rollout_id in range(args.start_rollout_id, args.num_rollout):
-        if args.eval_interval is not None and rollout_id == 0 and not args.skip_eval_before_train:
-            await rollout_manager.eval.remote(rollout_id)
+    #
+    # --async-rollout-prefetch: double-buffer the rollout data generation. The next rollout's data
+    # (CPU tokenization/packing on the RolloutManager) is generated WHILE the current step trains,
+    # hiding rollout-gen latency behind training. Safe ONLY when generation is weight-INDEPENDENT
+    # (SFT): rollout N+1's data does not depend on step N's updated weights. Gated off by default.
+    # (train_async.py does the same overlap but asserts non-colocate, so it can't serve colocate SFT.)
+    # Run the initial evaluation (if any) BEFORE priming the prefetch pipeline, so the eval and the
+    # primed generation never run concurrently on the RolloutManager -- otherwise both would hit the
+    # first-step SGLang compile / KV-cache warmup at once. Equivalent to the old in-loop rollout_id==0
+    # eval (that check was only ever true on the first iteration, when start_rollout_id == 0).
+    if args.eval_interval is not None and args.start_rollout_id == 0 and not args.skip_eval_before_train:
+        await rollout_manager.eval.remote(args.start_rollout_id)
 
-        rollout_data_ref = await rollout_manager.generate.remote(rollout_id)
+    prefetch = args.async_rollout_prefetch
+    if prefetch:
+        assert not args.offload_rollout, "--async-rollout-prefetch is incompatible with --offload-rollout"
+        assert not args.use_critic, "--async-rollout-prefetch is not supported with --use-critic"
+        # prime the pipeline: first rollout's data-gen in flight on the RolloutManager (not awaited).
+        # guard start_rollout_id < num_rollout so eval-only / resume-past-end runs don't waste a gen.
+        pending_rollout_ref = None
+        if args.start_rollout_id < args.num_rollout:
+            pending_rollout_ref = rollout_manager.generate.remote(args.start_rollout_id)
+
+    for rollout_id in range(args.start_rollout_id, args.num_rollout):
+        if prefetch:
+            rollout_data_ref = await pending_rollout_ref
+            # launch the NEXT rollout's data-gen now so it overlaps with the train step below
+            if rollout_id + 1 < args.num_rollout:
+                pending_rollout_ref = rollout_manager.generate.remote(rollout_id + 1)
+        else:
+            rollout_data_ref = await rollout_manager.generate.remote(rollout_id)
 
         if args.offload_rollout:
             offload_tags = [GPU_MEMORY_TYPE_CUDA_GRAPH]


### PR DESCRIPTION
## What

Adds an opt-in `--async-rollout-prefetch` flag that double-buffers SFT rollout
data generation: the next rollout's data (CPU tokenization/packing on the
RolloutManager) is generated **while the current step trains**, hiding
rollout-gen latency behind the train step.

- **Off by default** — only changes behavior when the flag is passed.
- **Safe only for weight-independent rollout (SFT)**: rollout N+1's data does not
  depend on step N's updated weights. Asserts incompatibility with
  `--offload-rollout` and `--use-critic`.
- Fills a gap: `train_async.py` provides the same overlap but asserts
  non-colocate, so it can't serve the colocate SFT path this targets.

## Implementation

Primes the pipeline before the loop (`pending_rollout_ref =
rollout_manager.generate.remote(start)`), then each iteration awaits the pending
ref and launches the next rollout's generation concurrently with the train step.
A pure reordering of *when* `generate(rollout_id)` is called — its inputs and
outputs are unchanged.

## Validation

Measured on **8×8 H20, DeepSeek-V4-Flash colocate SFT, 32K seq (CP=2,
TP4/PP8/EP8), max-tokens-per-gpu=8192**, identical recipe/data, only
`--async-rollout-prefetch` toggled:

| metric | off (12 steps) | on (6 steps) | Δ |
|---|---|---|---|
| `perf/train_wait_time` | 7.49 s | 5.05 s | **−2.44 s (−33%)** |
| `perf/wait_time_ratio` | 8.3% | 6.3% | −2.0 pt |
| `perf/step_time` (median) | 82.2 s | 79.4 s | −2.8 s (−3.4%) |
| `perf/rollout_time` | ~4.2 s | ~4.35 s | unchanged (now overlapped) |
| loss range | 0.2234–0.2961 | 0.2242–0.2960 | identical |

- **Correctness**: loss distribution identical; the prefetch path runs cleanly,
  no divergence/NaN. (Runs are not seed-pinned, so per-step loss differs by data
  order, but the range matches — consistent with prefetch being a pure reorder of
  weight-independent work.)
- **Perf**: per-step train-wait drops ~⅓ by overlapping the ~4.2 s rollout
  tokenization/packing behind the step.
- The absolute step-time gain is modest *here* because rollout-gen is only ~5% of
  the long 32K step; the benefit scales with rollout-gen / step-time, so it is
  larger for shorter steps or heavier rollout.
