### PR TITLE
spawn router/session-server subprocesses instead of forking

### DIFF
--- a/miles/ray/rollout/router_manager.py
+++ b/miles/ray/rollout/router_manager.py
@@ -1,17 +1,16 @@
+import copy
 import logging
 import multiprocessing
 import random
 import uuid
 
+from sglang_router.launch_router import RouterArgs
 
-from miles.utils.http_utils import (
-    _wrap_ipv6,
-    find_available_port,
-    get_host_info,
-    is_port_available,
-    wait_for_server_ready,
-)
-
+from miles.rollout.session.session_server import run_session_server
+from miles.router.router import run_router as run_miles_router
+from miles.utils.http_utils import _wrap_ipv6, find_available_port, get_host_info, is_port_available
+from miles.utils.http_utils import run_router as run_sglang_router
+from miles.utils.http_utils import wait_for_server_ready
 
 logger = logging.getLogger(__name__)
 
@@ -34,20 +33,15 @@ def start_router(args, *, has_pd_disaggregation: bool = False, force_new: bool =
             router_port = find_available_port(random.randint(3000, 4000))
 
     if args.use_miles_router:
-        import copy
-
         assert not has_pd_disaggregation, "miles router does not support PD disaggregation."
-        from miles.router.router import run_router
 
+        run_router = run_miles_router
         router_args = copy.copy(args)
         router_args.sglang_router_ip = router_ip
         router_args.sglang_router_port = router_port
 
     else:
-        from sglang_router.launch_router import RouterArgs
-
-        from miles.utils.http_utils import run_router
-
+        run_router = run_sglang_router
         router_args = RouterArgs.from_cli_args(args, use_router_prefix=True)
         router_args.host = router_ip
         router_args.port = router_port
@@ -112,8 +106,6 @@ def start_session_server(args):
         )
 
     router_url = f"http://{args.sglang_router_ip}:{args.sglang_router_port}"
-
-    from miles.rollout.session.session_server import run_session_server
 
     # spawn (not fork): see start_router for rationale.
     process = multiprocessing.get_context("spawn").Process(target=run_session_server, args=(args, router_url))

--- a/miles/ray/rollout/router_manager.py
+++ b/miles/ray/rollout/router_manager.py
@@ -70,7 +70,9 @@ def start_router(args, *, has_pd_disaggregation: bool = False, force_new: bool =
             f"Run 'pkill -9 python' to kill it, then retry."
         )
 
-    process = multiprocessing.Process(
+    # spawn (not fork): the child must not inherit threads/finalizers from this
+    # Ray actor (e.g. wandb's service thread), which deadlock a forked child.
+    process = multiprocessing.get_context("spawn").Process(
         target=run_router,
         args=(router_args,),
     )
@@ -113,7 +115,8 @@ def start_session_server(args):
 
     from miles.rollout.session.session_server import run_session_server
 
-    process = multiprocessing.Process(target=run_session_server, args=(args, router_url))
+    # spawn (not fork): see start_router for rationale.
+    process = multiprocessing.get_context("spawn").Process(target=run_session_server, args=(args, router_url))
     process.daemon = True
     process.start()
     wait_for_server_ready(ip, port, process, timeout=30)

--- a/miles/rollout/session/session_server.py
+++ b/miles/rollout/session/session_server.py
@@ -17,6 +17,7 @@ from fastapi.responses import JSONResponse
 from starlette.responses import Response
 
 from miles.rollout.session.sessions import setup_session_routes
+from miles.utils.logging_utils import configure_logger
 
 logger = logging.getLogger(__name__)
 
@@ -55,9 +56,7 @@ class SessionServer:
             body = await request.body()
         if headers is None:
             headers = dict(request.headers)
-        headers = {
-            k: v for k, v in headers.items() if k.lower() not in ("content-length", "transfer-encoding", "host")
-        }
+        headers = {k: v for k, v in headers.items() if k.lower() not in ("content-length", "transfer-encoding", "host")}
 
         try:
             response = await self.client.request(request.method, url, content=body, headers=headers)
@@ -98,6 +97,8 @@ class SessionServer:
 
 def run_session_server(args, backend_url: str):
     """Entry point to start the standalone session server as a subprocess."""
+    # Spawned as a fresh interpreter, so it inherits no logging config.
+    configure_logger()
     # Visible to `pkill -9 miles`; without this the daemon inherits "python".
     setproctitle.setproctitle("miles-session-server")
 

--- a/miles/rollout/session/session_server.py
+++ b/miles/rollout/session/session_server.py
@@ -56,7 +56,9 @@ class SessionServer:
             body = await request.body()
         if headers is None:
             headers = dict(request.headers)
-        headers = {k: v for k, v in headers.items() if k.lower() not in ("content-length", "transfer-encoding", "host")}
+        headers = {
+            k: v for k, v in headers.items() if k.lower() not in ("content-length", "transfer-encoding", "host")
+        }
 
         try:
             response = await self.client.request(request.method, url, content=body, headers=headers)

--- a/miles/router/router.py
+++ b/miles/router/router.py
@@ -49,7 +49,9 @@ class MilesRouter:
 
         max_connections = getattr(args, "miles_router_max_connections", None)
         if max_connections is None:
-            max_connections = args.sglang_server_concurrency * args.rollout_num_gpus // args.rollout_num_gpus_per_engine
+            max_connections = (
+                args.sglang_server_concurrency * args.rollout_num_gpus // args.rollout_num_gpus_per_engine
+            )
 
         timeout = getattr(args, "miles_router_timeout", None)
 

--- a/miles/router/router.py
+++ b/miles/router/router.py
@@ -10,6 +10,8 @@ from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 from starlette.responses import Response
 
+from miles.utils.logging_utils import configure_logger
+
 logger = logging.getLogger(__name__)
 
 
@@ -17,6 +19,8 @@ def run_router(args):
     """
     Run the Miles router with the specified configuration.
     """
+    # Spawned as a fresh interpreter, so it inherits no logging config.
+    configure_logger()
     # Visible to `pkill -9 miles`; without this the daemon inherits "python".
     setproctitle.setproctitle("miles-router")
 
@@ -45,9 +49,7 @@ class MilesRouter:
 
         max_connections = getattr(args, "miles_router_max_connections", None)
         if max_connections is None:
-            max_connections = (
-                args.sglang_server_concurrency * args.rollout_num_gpus // args.rollout_num_gpus_per_engine
-            )
+            max_connections = args.sglang_server_concurrency * args.rollout_num_gpus // args.rollout_num_gpus_per_engine
 
         timeout = getattr(args, "miles_router_timeout", None)
 

--- a/miles/utils/http_utils.py
+++ b/miles/utils/http_utils.py
@@ -10,6 +10,8 @@ import time
 
 import httpx
 
+from miles.utils.logging_utils import configure_logger
+
 logger = logging.getLogger(__name__)
 
 MILES_HOST_IP_ENV = "MILES_HOST_IP"
@@ -138,6 +140,8 @@ def _wrap_ipv6(host):
 
 
 def run_router(args):
+    # Spawned as a fresh interpreter, so it inherits no logging config.
+    configure_logger()
     try:
         from sglang_router.launch_router import launch_router
 


### PR DESCRIPTION
## Summary
Launch the SGLang/miles router and the session server with a `spawn` start method instead of the Linux default `fork`. `RolloutManager` is a Ray actor, and forking a multi-threaded actor lets the child inherit objects whose backing threads/locks do **not** come across the fork. The most recent instance was wandb: a forked session server inherited `wandb.init()` finalizers but not the wandb service thread, so GC of an inherited object deadlocked the child's uvicorn event loop and the run wedged at "Collected 0/N" (root-caused with `py-spy` in #1357).

#1357 fixes that one instance by reordering `init_tracking()` after the fork. This PR removes the underlying hazard for these two processes: a spawned child is a fresh interpreter that inherits none of the parent's threads/finalizers/locks, so the whole class of fork-inheritance deadlocks (wandb today; the next library that holds a thread or lock before the launch point tomorrow) cannot occur. This matches how we already launch the SGLang engine from inside a Ray actor — `sglang_engine.py:58` forces `set_start_method("spawn", force=True)`.

## Why this is safe
The spawn caveats are all satisfied:
- **Targets are importable** — `run_router` / `run_session_server` are module-level functions, not `__main__`.
- **Args are picklable** — `args` is a plain `argparse.Namespace` of config scalars/lists/None; Ray already cloudpickles it into the actor constructor, and a standard `pickle` round-trip succeeds for both the direct-`args` (session server) and `copy.copy(args)` (miles router) paths. If a non-picklable field is ever added, `Process.start()` raises a clear `PicklingError` in the parent.
- **Ray actor + spawn is supported** — spawn re-imports the parent's main module as `__mp_main__` (not `__main__`), so Ray's `default_worker` bootstrap guarded by `if __name__ == "__main__":` is skipped; the child does not re-register as a Ray worker. Ray maintainers recommend `mp.get_context("spawn")` from inside actors and warn that `fork` from a worker is a known hang.
- **Child lifecycle** — unchanged, still `daemon=True`.

## Test plan
- [ ] Relaunch the DeepSeek-V4-Flash disagg agentic run and confirm the router and session server come up and a training step lands.
- [ ] Confirm `:30000` keeps accepting (Recv-Q ~0) across the run.
