### PR TITLE
[tiny] tune qwen3.5-35B-A3B MTP cp2 ep8 sglang/perf args

### DIFF
--- a/scripts/run_qwen3_5_35b_a3b_mtp_cp2_ep8.py
+++ b/scripts/run_qwen3_5_35b_a3b_mtp_cp2_ep8.py
@@ -89,7 +89,8 @@ def execute(args: ScriptArgs):
         "--recompute-method uniform "
         "--recompute-num-layers 1 "
         "--use-dynamic-batch-size "
-        "--max-tokens-per-gpu 8192 "
+        "--max-tokens-per-gpu 8192 "  # 32768 on H200
+        "--log-probs-chunk-size 4096 "  # chunk logits when computing log probs to avoid OOM
     )
 
     grpo_args = (
@@ -117,7 +118,6 @@ def execute(args: ScriptArgs):
     sglang_args = (
         "--rollout-num-gpus-per-engine 8 "
         "--sglang-mem-fraction-static 0.7 "
-        "--sglang-ep-size 8 "
         "--sglang-cuda-graph-bs 1 2 4 8 16 24 32 40 48 56 64 72 80 88 96 104 112 120 128 136 144 152 160 168 176 184 192 200 208 216 224 232 240 248 256 "
     )
 


### PR DESCRIPTION
## What

Small perf/config tweaks to `scripts/run_qwen3_5_35b_a3b_mtp_cp2_ep8.py`:

- Add `--log-probs-chunk-size 4096` to cap log-prob memory.
- Annotate `--max-tokens-per-gpu` (default stays `8192`) with a `# 32768 on H200` comment.
- Drop `--sglang-ep-size 8` (slow after running experiments).

## Why

Tuning the run config; recording the H200 max-tokens-per-gpu value inline without changing the default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)