### PR TITLE
[CI] ban deprecated huggingface-cli in pre-commit gate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,3 +60,9 @@ repos:
         entry: '(AutoConfig|AutoTokenizer)\.from_pretrained'
         types: [python]
         exclude: '(miles/utils/hf_config\.py|miles/utils/processing_utils\.py|tests/|test_utils/|miles_plugins/|examples/)'
+
+      - id: ban-huggingface-cli
+        name: Ban deprecated huggingface-cli (use hf)
+        language: pygrep
+        entry: 'huggingface-cli'
+        types: [python]


### PR DESCRIPTION
## Motivation

`huggingface_hub` has dropped `huggingface-cli`. Invoking it now prints
`Warning: huggingface-cli is deprecated and no longer works. Use hf instead.`
and exits non-zero. This broke a `stage-c-8-gpu-h100` e2e job whose
`prepare()` still ran `huggingface-cli download` ([failed CI job](https://github.com/radixark/miles/actions/runs/27739993969/job/82123022500)):

```
EXEC: huggingface-cli download Qwen/Qwen2.5-0.5B-Instruct --local-dir /root/models/Qwen2.5-0.5B-Instruct
Warning: `huggingface-cli` is deprecated and no longer works. Use `hf` instead.
subprocess.CalledProcessError: Command '['bash', '-c', 'huggingface-cli download ...']' returned non-zero exit status 1.
```

That single occurrence was already migrated to `hf` on `main` by #1352, so
there are currently zero `huggingface-cli` usages in the repo. This PR adds a
guard so the deprecated CLI cannot silently come back.

## What changed

- Add a `local` `pygrep` pre-commit hook `ban-huggingface-cli` next to the
  existing `ban-mpu-get` / `ban-bare-auto-loaders` hooks, banning the
  `huggingface-cli` token in Python sources (`types: [python]` — consistent
  with the sibling ban hooks, and the only file type it has ever appeared in
  here). Use `hf` instead.

## Verification

- `pre-commit run ban-huggingface-cli --all-files` → **Passed** (clean tree).
- Negative test: a throwaway `*.py` containing `huggingface-cli download ...`
  → hook **Failed** and printed the offending line.
- `check-yaml` passes on the modified `.pre-commit-config.yaml`.
