### PR TITLE
Use flashinfer_trtllm for mxfp8 gemm

### DIFF
--- a/scripts/run_deepseek_v32.py
+++ b/scripts/run_deepseek_v32.py
@@ -337,7 +337,7 @@ def _execute_train(args: ScriptArgs):
                 sglang_decode_max_bs = 256
                 sglang_args += (
                     f"--rollout-num-gpus-per-engine {sglang_world_size} "
-                    "--sglang-fp8-gemm-backend flashinfer_cutlass "
+                    "--sglang-fp8-gemm-backend flashinfer_trtllm "
                     "--sglang-moe-runner-backend flashinfer_trtllm_routed "
                     f"--sglang-tp-size {sglang_world_size} "
                     f"--sglang-dp-size {sglang_world_size} "

--- a/scripts/run_joy_ai_llm_flash.py
+++ b/scripts/run_joy_ai_llm_flash.py
@@ -230,7 +230,7 @@ def execute(args: ScriptArgs, *, wandb_file: str = __file__):
                 sglang_args += (
                     "--sglang-enable-dp-attention "
                     f"--rollout-num-gpus-per-engine {sglang_world_size} "
-                    "--sglang-fp8-gemm-backend flashinfer_cutlass "
+                    "--sglang-fp8-gemm-backend flashinfer_trtllm "
                     "--sglang-moe-runner-backend flashinfer_trtllm_routed "
                     f"--sglang-tp-size {sglang_world_size} "
                     f"--sglang-dp-size {sglang_world_size} "

--- a/tests/e2e/megatron/test_deepseek_v32_5layer_mxfp8.py
+++ b/tests/e2e/megatron/test_deepseek_v32_5layer_mxfp8.py
@@ -177,7 +177,7 @@ def execute():
         "--sglang-kv-cache-dtype bf16 "
         "--sglang-page-size 64 "
         f"--rollout-num-gpus-per-engine {ROLLOUT_GPUS_PER_ENGINE} "
-        "--sglang-fp8-gemm-backend flashinfer_cutlass "
+        "--sglang-fp8-gemm-backend flashinfer_trtllm "
         "--sglang-moe-runner-backend flashinfer_trtllm_routed "
         f"--sglang-tp-size {ROLLOUT_GPUS_PER_ENGINE} "
         f"--sglang-dp-size {ROLLOUT_GPUS_PER_ENGINE} "


### PR DESCRIPTION
@humansand

`flashinfer_trtllm` has better performance and sm103 support than `flashinfer_cutlass`.

After https://github.com/sgl-project/sglang/pull/28459 , `flashinfer_trtllm` supports non multiple of 128 shape gemm correctly, common in MLA qkv proj.

Test: `PYTHONPATH=/root/miles python3 -m tests.e2e.megatron.test_deepseek_v32_5layer_mxfp8`
- `(MegatronTrainRayActor pid=19828) [2026-06-19 06:39:53] model.py:695 - step 23: {'train/loss': 0.0, 'train/pg_loss': 0.0, 'train/entropy_loss': 0.0, 'train/pg_clipfrac': 0.0, 'train/ppo_kl': 0.0, 'train/ess_ratio': 1.0, 'train/train_rollout_logprob_abs_diff': 0.02429734542965889, 'train/train_rollout_kl': 0.0006071622483432293, 'train/kl_loss': 0.0006574811413884163, 'train/grad_norm': 0.0, 'train/lr-pg_0': 1e-06, 'train/lr-pg_1': 1e-06, 'train/lr-pg_2': 1e-06, 'train/step': 23}`
- `(MegatronTrainRayActor pid=19828) [2026-06-19 06:39:53] train_metric_utils.py:44 - perf 2: {'perf/update_weights_implementation_time': 0.33532023429870605, 'perf/finalize_and_resume_engines_time': 0.05447983741760254, 'perf/update_weights_time': 0.4123406410217285, 'perf/data_preprocess_time': 0.33495354652404785, 'perf/train_wait_time': 113.34508395195007, 'perf/ref_log_probs_time': 33.723676919937134, 'perf/log_probs_time': 34.26167893409729, 'perf/actor_train_time': 195.2054147720337, 'perf/train_time': 263.75729513168335, 'perf/log_probs_tflops': 130.51752428378126, 'perf/ref_log_probs_tflops': 132.59970206986836, 'perf/actor_train_tflops': 68.72375211783536, 'perf/actor_train_tok_per_s': 10520.010433103036, 'perf/step_time': 377.1023790836334, 'perf/wait_time_ratio': 0.30056846691707695}`