### PR TITLE
fix(tito): derive suffix ids by token-level slicing to stop boundary drift

### DIFF
--- a/miles/utils/chat_template_utils/tito_tokenizer.py
+++ b/miles/utils/chat_template_utils/tito_tokenizer.py
@@ -180,7 +180,9 @@ class TITOTokenizer:
         if not text_with.startswith(text_without):
             roles = [msg["role"] for msg in appended_messages] if appended_messages else ["generation_prompt"]
             raise ValueError(f"rendered suffix diff failed for {roles}")
-        return self._encode_text(text_with[len(text_without) :])
+        prefix_ids = self._encode_text(text_without)
+        full_ids = self._encode_text(text_with)
+        return full_ids[len(prefix_ids) :]
 
     def tokenize_additional_messages(
         self,

--- a/miles/utils/chat_template_utils/tito_tokenizer.py
+++ b/miles/utils/chat_template_utils/tito_tokenizer.py
@@ -182,6 +182,9 @@ class TITOTokenizer:
             raise ValueError(f"rendered suffix diff failed for {roles}")
         prefix_ids = self._encode_text(text_without)
         full_ids = self._encode_text(text_with)
+        if full_ids[: len(prefix_ids)] != prefix_ids:
+            roles = [msg["role"] for msg in appended_messages] if appended_messages else ["generation_prompt"]
+            raise ValueError(f"token-id suffix diff failed for {roles}")
         return full_ids[len(prefix_ids) :]
 
     def tokenize_additional_messages(

--- a/tests/fast/utils/chat_template_utils/test_tito_suffix_token_slicing.py
+++ b/tests/fast/utils/chat_template_utils/test_tito_suffix_token_slicing.py
@@ -1,0 +1,44 @@
+"""Regression for token-id drift in ``TITOTokenizer._tokenize_rendered_suffix``.
+
+Suffix ids come from the full prompt's tokenization, not a standalone re-encode
+of the rendered text slice. Re-encoding the slice can insert a start-of-segment
+marker that is absent in context (issue #1319).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from miles.utils.chat_template_utils.tito_tokenizer import TITOTokenizer
+
+
+class StartMarkerTokenizer:
+    """SentencePiece-like stub: the first char of any ``encode`` call gets a
+    start-of-segment variant id, differing from the same char mid-sequence."""
+
+    def __init__(self) -> None:
+        self._vocab: dict[str, int] = {}
+
+    def encode(self, text: str, add_special_tokens: bool = False) -> list[int]:
+        return [self._vocab.setdefault(("^" if i == 0 else "") + ch, len(self._vocab)) for i, ch in enumerate(text)]
+
+
+class _StubTITOTokenizer(TITOTokenizer):
+    """Pins the rendered prefix/suffix text so the test depends only on slicing."""
+
+    def __init__(self, prefix_text: str, suffix_text: str) -> None:
+        super().__init__(StartMarkerTokenizer())
+        self._prefix_text = prefix_text
+        self._suffix_text = suffix_text
+
+    def apply_chat_template(self, messages: list[dict[str, Any]], *, add_generation_prompt, tools=None, tokenize=False):
+        return self._prefix_text + (self._suffix_text if len(messages) > 1 else "")
+
+
+def test_suffix_uses_in_context_ids_not_standalone_reencode():
+    tito = _StubTITOTokenizer(prefix_text="hi ", suffix_text="bye")
+
+    suffix = tito._tokenize_rendered_suffix([{"role": "system"}], [{"role": "user"}])
+
+    assert tito._encode_text("hi ") + suffix == tito._encode_text("hi bye")
+    assert suffix != tito._encode_text("bye")

--- a/tests/fast/utils/chat_template_utils/test_tito_suffix_token_slicing.py
+++ b/tests/fast/utils/chat_template_utils/test_tito_suffix_token_slicing.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 from typing import Any
 
+import pytest
+
 from miles.utils.chat_template_utils.tito_tokenizer import TITOTokenizer
 
 
@@ -23,22 +25,69 @@ class StartMarkerTokenizer:
         return [self._vocab.setdefault(("^" if i == 0 else "") + ch, len(self._vocab)) for i, ch in enumerate(text)]
 
 
+class CharTokenizer:
+    """Context-free stub: each character is its own token."""
+
+    def encode(self, text: str, add_special_tokens: bool = False) -> list[int]:
+        return [ord(ch) for ch in text]
+
+
+class JunctionMergeTokenizer:
+    """Merges a trailing space with the next character, so encode(prefix) is
+    not a token-prefix of encode(prefix + suffix)."""
+
+    def encode(self, text: str, add_special_tokens: bool = False) -> list[int]:
+        ids: list[int] = []
+        i = 0
+        while i < len(text):
+            if text[i] == " " and i + 1 < len(text):
+                ids.append(1000 + ord(text[i + 1]))
+                i += 2
+            else:
+                ids.append(ord(text[i]))
+                i += 1
+        return ids
+
+
 class _StubTITOTokenizer(TITOTokenizer):
     """Pins the rendered prefix/suffix text so the test depends only on slicing."""
 
-    def __init__(self, prefix_text: str, suffix_text: str) -> None:
-        super().__init__(StartMarkerTokenizer())
+    def __init__(self, tokenizer: Any, prefix_text: str, suffix_text: str) -> None:
+        super().__init__(tokenizer)
         self._prefix_text = prefix_text
         self._suffix_text = suffix_text
 
-    def apply_chat_template(self, messages: list[dict[str, Any]], *, add_generation_prompt, tools=None, tokenize=False):
+    def apply_chat_template(
+        self,
+        messages: list[dict[str, Any]],
+        *,
+        add_generation_prompt,
+        tools=None,
+        tokenize=False,
+    ):
         return self._prefix_text + (self._suffix_text if len(messages) > 1 else "")
 
 
 def test_suffix_uses_in_context_ids_not_standalone_reencode():
-    tito = _StubTITOTokenizer(prefix_text="hi ", suffix_text="bye")
+    tito = _StubTITOTokenizer(StartMarkerTokenizer(), prefix_text="hi ", suffix_text="bye")
 
     suffix = tito._tokenize_rendered_suffix([{"role": "system"}], [{"role": "user"}])
 
     assert tito._encode_text("hi ") + suffix == tito._encode_text("hi bye")
     assert suffix != tito._encode_text("bye")
+
+
+def test_suffix_matches_standalone_encode_when_no_boundary_span():
+    tito = _StubTITOTokenizer(CharTokenizer(), prefix_text="hi ", suffix_text="bye")
+
+    suffix = tito._tokenize_rendered_suffix([{"role": "system"}], [{"role": "user"}])
+
+    assert suffix == tito._encode_text("bye")
+    assert tito._encode_text("hi ") + suffix == tito._encode_text("hi bye")
+
+
+def test_raises_when_prefix_ids_are_not_a_prefix_of_full_ids():
+    tito = _StubTITOTokenizer(JunctionMergeTokenizer(), prefix_text="hi ", suffix_text="bye")
+
+    with pytest.raises(ValueError, match="token-id suffix diff failed"):
+        tito._tokenize_rendered_suffix([{"role": "system"}], [{"role": "user"}])


### PR DESCRIPTION
## What

`TITOTokenizer._tokenize_rendered_suffix` derived the appended segment's token ids by slicing the rendered **text** (`text_with[len(text_without):]`) and re-encoding that substring on its own. When a token spans the prefix/suffix boundary — a BPE merge across the cut, or a leading-space token formed differently in isolation — the standalone re-encode diverges from the full-prompt tokenization, so the incremental (token-in-token-out) ids drift from what the model actually saw.

## Fix

Encode the base prompt and the full prompt (both `add_special_tokens=False`) and take the suffix as `full_ids[len(prefix_ids):]`. This matches the model's own tokenization and correctly attributes a start-of-segment marker to the full-prompt encoding (the Zephyr `▁<` vs `<` case in #1319).

If `encode(prefix)` is not a token-prefix of `encode(full)` — a junction-spanning merge that would change the already-frozen prefix — raise `ValueError`, matching the existing text-prefix check, instead of silently dropping or duplicating tokens. Trimming the frozen prefix in `merge_tokens` is out of scope.

Tests: start-of-segment drift, a no-op char tokenizer, and the junction-merge guard.

Fixes #1319