### PR TITLE
fix(http): don't retry /generate after the request was sent

### DIFF
--- a/miles/rollout/generate_hub/multi_turn.py
+++ b/miles/rollout/generate_hub/multi_turn.py
@@ -57,7 +57,9 @@ async def generate(input: GenerateFnInput) -> GenerateFnOutput:
             break
 
         gen_t0 = time.time()
-        output = await post(url, payload, headers=compute_routing_headers(args, sample))
+        # /generate is non-idempotent: a retry after the request reached the
+        # server would re-issue generation. Only pre-send errors are retried.
+        output = await post(url, payload, headers=compute_routing_headers(args, sample), idempotent=False)
         sink = None if input.evaluation else TrajectoryLifecycle().sink
         if sink is not None:
             tokens = output.get("meta_info", {}).get("completion_tokens", "")

--- a/miles/rollout/generate_hub/single_turn.py
+++ b/miles/rollout/generate_hub/single_turn.py
@@ -41,7 +41,9 @@ async def generate(input: GenerateFnInput) -> GenerateFnOutput:
         sample.status = halt_status
         return GenerateFnOutput(samples=sample)
 
-    output = await post(url, payload, headers=compute_routing_headers(args, sample))
+    # /generate is non-idempotent: a retry after the request reached the server
+    # would re-issue generation. Only pre-send connection errors are retried.
+    output = await post(url, payload, headers=compute_routing_headers(args, sample), idempotent=False)
     await update_sample_from_response(args, sample, payload=payload, output=output)
 
     return GenerateFnOutput(samples=sample)

--- a/miles/rollout/generate_utils/prefill_logprobs.py
+++ b/miles/rollout/generate_utils/prefill_logprobs.py
@@ -129,7 +129,7 @@ async def recompute_rollout_logprobs_via_prefill(
         return
 
     payload = _build_prefill_scoring_payload(args, sample, sampling_params)
-    output = await post(url, payload, headers=headers)
+    output = await post(url, payload, headers=headers, idempotent=False)
     sample.rollout_log_probs = _extract_response_logprobs(sample, output["meta_info"])
     sample.metadata["rollout_log_probs_source"] = "sglang_prefill_recompute"
 
@@ -164,7 +164,7 @@ async def recompute_samples_rollout_logprobs_via_prefill(
             # each scoring group so every group uses the same clean-prefill path.
             await post(flush_url, {})
             payload = _build_batch_prefill_scoring_payload(args, batch_samples, sampling_params)
-            outputs = await post(url, payload)
+            outputs = await post(url, payload, idempotent=False)
             if not isinstance(outputs, list):
                 raise ValueError(f"SGLang batch prefill scoring returned {type(outputs).__name__}, expected list")
             if len(outputs) != len(batch_samples):

--- a/miles/rollout/sglang_rollout.py
+++ b/miles/rollout/sglang_rollout.py
@@ -55,7 +55,7 @@ def get_model_url(args: Namespace, model_name: str, endpoint: str = "/generate")
     model when multiple models are deployed via ``--sglang-config``::
 
         url = get_model_url(args, "ref", "/generate")
-        resp = await post(url, json=payload)
+        resp = await post(url, payload, idempotent=False)
 
     Falls back to the default router if *model_name* is not found or
     ``sglang_model_routers`` is not set.
@@ -225,7 +225,9 @@ async def generate(args: Namespace, sample: Sample, sampling_params: dict[str, A
 
     headers = compute_routing_headers(args, sample)
 
-    output = await post(url, payload, headers=headers)
+    # /generate is non-idempotent: a retry after the request reached the server
+    # would re-issue generation. Only pre-send connection errors are retried.
+    output = await post(url, payload, headers=headers, idempotent=False)
     if getattr(args, "use_opd", False) and opd_top_k > 0 and opd_top_k_strategy != "only-teacher":
         output_top_logprobs = output.get("meta_info", {}).get("output_top_logprobs")
         if output_top_logprobs is not None:

--- a/miles/utils/http_utils.py
+++ b/miles/utils/http_utils.py
@@ -201,7 +201,21 @@ def _next_actor():
     return actor
 
 
-async def _post(client, url, payload, max_retries=60, action="post", headers=None):
+# Errors raised while *establishing* the TCP/TLS connection, i.e. strictly
+# before any request bytes reach the server. These are the only failures that
+# are always safe to retry for a non-idempotent request: the server never saw
+# the request, so retrying cannot duplicate side effects.
+_CONNECT_ERRORS = (httpx.ConnectError, httpx.ConnectTimeout)
+
+
+async def _post(client, url, payload, max_retries=60, action="post", headers=None, idempotent=True):
+    """POST/GET/DELETE with retries.
+
+    When ``idempotent`` is False (e.g. ``/generate``), retry only pre-send
+    connection-setup errors. Any failure after the request has been sent is
+    re-raised immediately: the server may already be processing it, and a blind
+    retry would re-issue the work (double-generate).
+    """
     retry_count = 0
     while retry_count < max_retries:
         try:
@@ -216,12 +230,23 @@ async def _post(client, url, payload, max_retries=60, action="post", headers=Non
             except json.JSONDecodeError:
                 output = response.text
         except Exception as e:
+            # Only retry HTTP/network errors; programming errors (AssertionError,
+            # AttributeError, ...) should fail immediately rather than retry max_retries times.
+            if not isinstance(e, httpx.HTTPError):
+                raise
             retry_count += 1
 
             if isinstance(e, httpx.HTTPStatusError):
                 response_text = e.response.text
             else:
                 response_text = None
+
+            # Non-idempotent calls must not retry once the request may have been
+            # sent; only connection-setup failures (request never left us) are
+            # safe to retry.
+            if not idempotent and not isinstance(e, _CONNECT_ERRORS):
+                logger.info(f"Error: {e}, not retrying non-idempotent request (url={url}, response={response_text})")
+                raise e
 
             logger.info(
                 f"Error: {e}, retrying... (attempt {retry_count}/{max_retries}, url={url}, response={response_text})"
@@ -320,8 +345,10 @@ def _init_ray_distributed_post(args):
                 timeout=httpx.Timeout(None),
             )
 
-        async def do_post(self, url, payload, max_retries=60, action="post", headers=None):
-            return await _post(self._client, url, payload, max_retries, action=action, headers=headers)
+        async def do_post(self, url, payload, max_retries=60, action="post", headers=None, idempotent=True):
+            return await _post(
+                self._client, url, payload, max_retries, action=action, headers=headers, idempotent=idempotent
+            )
 
     # Create actors per node
     created = []
@@ -346,18 +373,20 @@ def _init_ray_distributed_post(args):
 
 
 # TODO may generalize the name since it now contains http DELETE/GET etc (with retries and remote-execution)
-async def post(url, payload, max_retries=60, action="post", headers=None):
+async def post(url, payload, max_retries=60, action="post", headers=None, idempotent=True):
     # If distributed mode is enabled and actors exist, dispatch via Ray.
     if _distributed_post_enabled and _post_actors:
         try:
             actor = _next_actor()
             if actor is not None:
-                return await actor.do_post.remote(url, payload, max_retries, action=action, headers=headers)
+                return await actor.do_post.remote(
+                    url, payload, max_retries, action=action, headers=headers, idempotent=idempotent
+                )
         except Exception as e:
             logger.info(f"[http_utils] Distributed POST failed, falling back to local: {e} (url={url})")
             # fall through to local
 
-    return await _post(_http_client, url, payload, max_retries, action=action, headers=headers)
+    return await _post(_http_client, url, payload, max_retries, action=action, headers=headers, idempotent=idempotent)
 
 
 # TODO unify w/ `post` to add retries and remote-execution

--- a/tests/fast/utils/test_http_utils.py
+++ b/tests/fast/utils/test_http_utils.py
@@ -27,9 +27,10 @@ import threading
 import time
 from unittest.mock import patch
 
+import httpx
 import pytest
 
-from miles.utils.http_utils import wait_for_server_ready
+from miles.utils.http_utils import _post, wait_for_server_ready
 
 
 def _find_free_port() -> int:
@@ -194,3 +195,68 @@ class TestWaitForServerReadySimulatedDelays:
 
         # The fake clock should have advanced past the timeout
         assert fake_time[0] >= timeout
+
+
+class _FakeResponse:
+    """Minimal stand-in for an httpx.Response that always succeeds."""
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return {"ok": True}
+
+
+class _FakeClient:
+    """Async httpx-like client whose POST raises a configured error N times."""
+
+    def __init__(self, error, fail_times):
+        self._error = error
+        self._fail_times = fail_times
+        self.calls = 0
+
+    async def post(self, url, json=None, headers=None):
+        self.calls += 1
+        if self.calls <= self._fail_times:
+            raise self._error
+        return _FakeResponse()
+
+
+@pytest.mark.asyncio
+async def test_non_idempotent_does_not_retry_post_send_error():
+    """A post-send error on a non-idempotent call must not retry (no double-generate)."""
+    client = _FakeClient(httpx.ReadTimeout("server still generating"), fail_times=99)
+    with patch("miles.utils.http_utils.asyncio.sleep"):
+        with pytest.raises(httpx.ReadTimeout):
+            await _post(client, "http://x/generate", {"input_ids": [1]}, max_retries=60, idempotent=False)
+    assert client.calls == 1, "non-idempotent /generate must not re-send after a post-send error"
+
+
+@pytest.mark.asyncio
+async def test_non_idempotent_still_retries_connect_error():
+    """A pre-send connection error is safe to retry even for non-idempotent calls."""
+    client = _FakeClient(httpx.ConnectError("connection refused"), fail_times=3)
+    with patch("miles.utils.http_utils.asyncio.sleep"):
+        out = await _post(client, "http://x/generate", {"input_ids": [1]}, max_retries=60, idempotent=False)
+    assert out == {"ok": True}
+    assert client.calls == 4, "should retry the 3 connect failures then succeed"
+
+
+@pytest.mark.asyncio
+async def test_idempotent_retries_post_send_error():
+    """Idempotent calls keep the original behaviour: retry any HTTP error."""
+    client = _FakeClient(httpx.ReadTimeout("transient"), fail_times=2)
+    with patch("miles.utils.http_utils.asyncio.sleep"):
+        out = await _post(client, "http://x/health", {}, max_retries=60, idempotent=True)
+    assert out == {"ok": True}
+    assert client.calls == 3, "idempotent path should retry the 2 failures then succeed"
+
+
+@pytest.mark.asyncio
+async def test_programming_error_is_not_retried():
+    """Non-HTTP errors (e.g. a bug) must fail fast, not retry max_retries times."""
+    client = _FakeClient(ValueError("bug"), fail_times=99)
+    with patch("miles.utils.http_utils.asyncio.sleep"):
+        with pytest.raises(ValueError):
+            await _post(client, "http://x/health", {}, max_retries=60, idempotent=True)
+    assert client.calls == 1, "a programming error must not be retried"


### PR DESCRIPTION
> Draft: scope needs maintainer clarification. Training-step latency is larger than a wasted retry, so a blanket “never retry /generate after send” may be the wrong tradeoff. Tool-call / generate-hub call sites need a separate discussion. Not ready to merge.

## What

`http_utils._post` retries *any* exception up to `max_retries` (~60). For `/generate` that's unsafe: a failure that happens **after** the request reached the server (while generation is already running) gets retried, and since `/generate` carries no request id to abort the orphan, the retry re-issues generation — a double-generate.

## Fix

Thread an `idempotent` flag through `post`/`_post` (and the Ray `do_post` actor). Non-idempotent calls — the three `/generate` call sites — retry **only** pre-send connection-setup errors (`httpx.ConnectError` / `ConnectTimeout`, where the server never saw the request) and re-raise anything raised after the request was sent. Idempotent GET/DELETE/health/scoring calls are unchanged (default `idempotent=True`).

Adds CPU tests for the three cases (non-idempotent: no retry post-send, still retries connect errors; idempotent: retries post-send).

Fixes #1334
