### PR TITLE
fix(deepseek_v4): size rope freqs_cis table dynamically for high CP

### DIFF
--- a/miles_plugins/models/deepseek_v4/deepseek_v4.py
+++ b/miles_plugins/models/deepseek_v4/deepseek_v4.py
@@ -34,7 +34,7 @@ from miles_plugins.models.deepseek_v4.ops.cp_utils import (
 )
 from miles_plugins.models.deepseek_v4.ops.kernel.tilelang_sparse_mla import sparse_attn_tilelang
 from miles_plugins.models.deepseek_v4.ops.qat import fp8_simulate_qat
-from miles_plugins.models.deepseek_v4.ops.rope import apply_rotary_emb, ensure_freqs_cis, wrapped_precompute_freqs_cis
+from miles_plugins.models.deepseek_v4.ops.rope import apply_rotary_emb, wrapped_precompute_freqs_cis
 from miles_plugins.models.deepseek_v4.ops.v4_indexer import V4Indexer
 
 
@@ -182,13 +182,6 @@ class DeepSeekV4Attention(MegatronModule):
             else:
                 self.indexer = None
 
-        rope_base = config.dsv4_compress_rope_theta if self.compress_ratio else config.rotary_base
-        yarn_disabled = not self.compress_ratio
-        freqs_cis = wrapped_precompute_freqs_cis(
-            config, rope_head_dim=self.rope_head_dim, base=rope_base, yarn_disabled=yarn_disabled
-        )
-        self.register_buffer("freqs_cis", freqs_cis, persistent=False)
-
     def sharded_state_dict(
         self,
         prefix: str = "",
@@ -229,12 +222,11 @@ class DeepSeekV4Attention(MegatronModule):
         x = einops.rearrange(hidden_states, "s b d -> b s d")
 
         bsz, seqlen_local, _ = x.size()
-        # A long packed sample can exceed the budgeted table length; grow on demand.
         rope_base = self.config.dsv4_compress_rope_theta if self.compress_ratio else self.config.rotary_base
-        ensure_freqs_cis(
-            self, self.config, self.rope_head_dim, rope_base, not self.compress_ratio, seqlen_local * self.cp_size
+        freqs_cis = wrapped_precompute_freqs_cis(
+            self.config, self.rope_head_dim, rope_base, not self.compress_ratio, seqlen_local * self.cp_size, x.device
         )
-        freqs_cis = get_freqs_cis_for_cp(self.freqs_cis, seqlen_local, self.cp_size, self.cp_group)
+        freqs_cis = get_freqs_cis_for_cp(freqs_cis, seqlen_local, self.cp_size, self.cp_group)
         win = self.window_size
         ratio = self.compress_ratio
         rd = self.rope_head_dim

--- a/miles_plugins/models/deepseek_v4/deepseek_v4.py
+++ b/miles_plugins/models/deepseek_v4/deepseek_v4.py
@@ -34,7 +34,7 @@ from miles_plugins.models.deepseek_v4.ops.cp_utils import (
 )
 from miles_plugins.models.deepseek_v4.ops.kernel.tilelang_sparse_mla import sparse_attn_tilelang
 from miles_plugins.models.deepseek_v4.ops.qat import fp8_simulate_qat
-from miles_plugins.models.deepseek_v4.ops.rope import apply_rotary_emb, wrapped_precompute_freqs_cis
+from miles_plugins.models.deepseek_v4.ops.rope import apply_rotary_emb, ensure_freqs_cis, wrapped_precompute_freqs_cis
 from miles_plugins.models.deepseek_v4.ops.v4_indexer import V4Indexer
 
 
@@ -229,6 +229,11 @@ class DeepSeekV4Attention(MegatronModule):
         x = einops.rearrange(hidden_states, "s b d -> b s d")
 
         bsz, seqlen_local, _ = x.size()
+        # A long packed sample can exceed the budgeted table length; grow on demand.
+        rope_base = self.config.dsv4_compress_rope_theta if self.compress_ratio else self.config.rotary_base
+        ensure_freqs_cis(
+            self, self.config, self.rope_head_dim, rope_base, not self.compress_ratio, seqlen_local * self.cp_size
+        )
         freqs_cis = get_freqs_cis_for_cp(self.freqs_cis, seqlen_local, self.cp_size, self.cp_group)
         win = self.window_size
         ratio = self.compress_ratio

--- a/miles_plugins/models/deepseek_v4/ops/compressor.py
+++ b/miles_plugins/models/deepseek_v4/ops/compressor.py
@@ -7,7 +7,7 @@ from torch.nn import Linear
 from miles_plugins.models.deepseek_v4.ops.cp_utils import all_gather_cp, get_freqs_cis_for_cp
 from miles_plugins.models.deepseek_v4.ops.kernel.precision_aligned_ops import linear_bf16_fp32
 from miles_plugins.models.deepseek_v4.ops.qat import fp8_simulate_qat
-from miles_plugins.models.deepseek_v4.ops.rope import apply_rotary_emb, ensure_freqs_cis, wrapped_precompute_freqs_cis
+from miles_plugins.models.deepseek_v4.ops.rope import apply_rotary_emb, wrapped_precompute_freqs_cis
 from miles_plugins.models.deepseek_v4.ops.utils import rotate_activation
 
 
@@ -92,8 +92,6 @@ class DeepSeekV4Compressor(nn.Module):
         base = config.dsv4_compress_rope_theta
         assert rope_head_dim == 64
         assert base == 160000
-        freqs_cis = wrapped_precompute_freqs_cis(config, rope_head_dim=rope_head_dim, base=base)
-        self.register_buffer("freqs_cis", freqs_cis, persistent=False)
 
     def overlap_transform_raw(self, tensor: torch.Tensor, value=0):
         """Raw overlap transform without CP handling."""
@@ -149,11 +147,15 @@ class DeepSeekV4Compressor(nn.Module):
 
         kv = self.norm(kv.to(dtype))
 
-        # Grow the rope table on demand for samples longer than the budgeted length.
-        ensure_freqs_cis(
-            self, self.config, self.rope_head_dim, self.config.dsv4_compress_rope_theta, False, seqlen_local * self.cp_size
+        freqs_cis = wrapped_precompute_freqs_cis(
+            self.config,
+            self.rope_head_dim,
+            self.config.dsv4_compress_rope_theta,
+            False,
+            seqlen_local * self.cp_size,
+            x.device,
         )
-        freqs_cis = get_freqs_cis_for_cp(self.freqs_cis, seqlen_local, self.cp_size, self.cp_group, stride=ratio)
+        freqs_cis = get_freqs_cis_for_cp(freqs_cis, seqlen_local, self.cp_size, self.cp_group, stride=ratio)
 
         apply_rotary_emb(kv[..., -self.rope_head_dim :], freqs_cis)
 

--- a/miles_plugins/models/deepseek_v4/ops/compressor.py
+++ b/miles_plugins/models/deepseek_v4/ops/compressor.py
@@ -7,7 +7,7 @@ from torch.nn import Linear
 from miles_plugins.models.deepseek_v4.ops.cp_utils import all_gather_cp, get_freqs_cis_for_cp
 from miles_plugins.models.deepseek_v4.ops.kernel.precision_aligned_ops import linear_bf16_fp32
 from miles_plugins.models.deepseek_v4.ops.qat import fp8_simulate_qat
-from miles_plugins.models.deepseek_v4.ops.rope import apply_rotary_emb, wrapped_precompute_freqs_cis
+from miles_plugins.models.deepseek_v4.ops.rope import apply_rotary_emb, ensure_freqs_cis, wrapped_precompute_freqs_cis
 from miles_plugins.models.deepseek_v4.ops.utils import rotate_activation
 
 
@@ -149,6 +149,10 @@ class DeepSeekV4Compressor(nn.Module):
 
         kv = self.norm(kv.to(dtype))
 
+        # Grow the rope table on demand for samples longer than the budgeted length.
+        ensure_freqs_cis(
+            self, self.config, self.rope_head_dim, self.config.dsv4_compress_rope_theta, False, seqlen_local * self.cp_size
+        )
         freqs_cis = get_freqs_cis_for_cp(self.freqs_cis, seqlen_local, self.cp_size, self.cp_group, stride=ratio)
 
         apply_rotary_emb(kv[..., -self.rope_head_dim :], freqs_cis)

--- a/miles_plugins/models/deepseek_v4/ops/rope.py
+++ b/miles_plugins/models/deepseek_v4/ops/rope.py
@@ -3,11 +3,12 @@ from functools import lru_cache
 
 import torch
 from megatron.core.transformer import TransformerConfig
-from megatron.training.global_vars import get_args
 
 
-@lru_cache(2)
-def precompute_freqs_cis(dim, seqlen, original_seq_len, base, factor, beta_fast, beta_slow) -> torch.Tensor:
+@lru_cache(maxsize=32)
+def precompute_freqs_cis(
+    dim, seqlen, original_seq_len, base, factor, beta_fast, beta_slow, device=None
+) -> torch.Tensor:
     """Precompute the complex rotary frequencies for RoPE, with optional YaRN smoothing.
 
     When ``original_seq_len > 0``, applies YaRN factor rescaling interpolated
@@ -39,7 +40,8 @@ def precompute_freqs_cis(dim, seqlen, original_seq_len, base, factor, beta_fast,
     t = torch.arange(seqlen)
     freqs = torch.outer(t, freqs)
     freqs_cis = torch.polar(torch.ones_like(freqs), freqs)
-    return freqs_cis
+    # Cache on `device` so repeated lengths are GPU cache hits; values bit-identical to CPU build.
+    return freqs_cis.to(device) if device is not None else freqs_cis
 
 
 def apply_rotary_emb(x: torch.Tensor, freqs_cis: torch.Tensor, inverse: bool = False) -> torch.Tensor:
@@ -63,22 +65,9 @@ def apply_rotary_emb(x: torch.Tensor, freqs_cis: torch.Tensor, inverse: bool = F
 
 
 def wrapped_precompute_freqs_cis(
-    config: TransformerConfig, rope_head_dim: int, base: float, yarn_disabled: bool = False, min_seq_len: int = 0
+    config: TransformerConfig, rope_head_dim: int, base: float, yarn_disabled: bool, max_seq_len: int, device
 ):
-    # The freqs_cis table must cover the global sequence length that
-    # get_freqs_cis_for_cp slices (positions up to cp_size * seqlen_local). In
-    # packed-THD dynamic-batch mode the real maximum is max_tokens_per_gpu *
-    # cp_size (args.seq_length does not reflect the packed length), so derive it
-    # from the run config rather than hardcoding. min_seq_len lets the forward
-    # pass grow the table on demand (see ensure_freqs_cis).
-    args = get_args()
-    cp_size = getattr(args, "context_parallel_size", 1) or 1
-    if getattr(args, "max_tokens_per_gpu", None):
-        budget = args.max_tokens_per_gpu * cp_size
-    else:
-        budget = args.seq_length
-    max_seq_len = max(budget, config.original_max_position_embeddings, min_seq_len)
-
+    # max_seq_len = global length (cp_size * seqlen_local); table rebuilt per call, lru-cached.
     # yarn_disabled=True → original_seq_len=0, which makes precompute_freqs_cis skip the YaRN
     # correction-range interpolation. Used by 0415 for pure-window (compress_ratio==0) layers.
     original_seq_len = 0 if yarn_disabled else config.original_max_position_embeddings
@@ -105,15 +94,4 @@ def wrapped_precompute_freqs_cis(
         beta_slow=1,
     )
 
-    return precompute_freqs_cis(**inputs)
-
-
-def ensure_freqs_cis(module, config, rope_head_dim, base, yarn_disabled, seqlen_global):
-    # A single packed sample may exceed the max_tokens_per_gpu * cp_size budget
-    # (while still fitting in memory), so the table built at init can be too
-    # short. Grow module.freqs_cis monotonically to cover seqlen_global.
-    if seqlen_global > module.freqs_cis.size(0):
-        grown = wrapped_precompute_freqs_cis(
-            config, rope_head_dim=rope_head_dim, base=base, yarn_disabled=yarn_disabled, min_seq_len=seqlen_global
-        )
-        module.freqs_cis = grown.to(device=module.freqs_cis.device, dtype=module.freqs_cis.dtype)
+    return precompute_freqs_cis(**inputs, device=device)

--- a/miles_plugins/models/deepseek_v4/ops/rope.py
+++ b/miles_plugins/models/deepseek_v4/ops/rope.py
@@ -3,6 +3,7 @@ from functools import lru_cache
 
 import torch
 from megatron.core.transformer import TransformerConfig
+from megatron.training.global_vars import get_args
 
 
 @lru_cache(2)
@@ -62,9 +63,21 @@ def apply_rotary_emb(x: torch.Tensor, freqs_cis: torch.Tensor, inverse: bool = F
 
 
 def wrapped_precompute_freqs_cis(
-    config: TransformerConfig, rope_head_dim: int, base: float, yarn_disabled: bool = False
+    config: TransformerConfig, rope_head_dim: int, base: float, yarn_disabled: bool = False, min_seq_len: int = 0
 ):
-    max_seq_len = 65536
+    # The freqs_cis table must cover the global sequence length that
+    # get_freqs_cis_for_cp slices (positions up to cp_size * seqlen_local). In
+    # packed-THD dynamic-batch mode the real maximum is max_tokens_per_gpu *
+    # cp_size (args.seq_length does not reflect the packed length), so derive it
+    # from the run config rather than hardcoding. min_seq_len lets the forward
+    # pass grow the table on demand (see ensure_freqs_cis).
+    args = get_args()
+    cp_size = getattr(args, "context_parallel_size", 1) or 1
+    if getattr(args, "max_tokens_per_gpu", None):
+        budget = args.max_tokens_per_gpu * cp_size
+    else:
+        budget = args.seq_length
+    max_seq_len = max(budget, config.original_max_position_embeddings, min_seq_len)
 
     # yarn_disabled=True → original_seq_len=0, which makes precompute_freqs_cis skip the YaRN
     # correction-range interpolation. Used by 0415 for pure-window (compress_ratio==0) layers.
@@ -93,3 +106,14 @@ def wrapped_precompute_freqs_cis(
     )
 
     return precompute_freqs_cis(**inputs)
+
+
+def ensure_freqs_cis(module, config, rope_head_dim, base, yarn_disabled, seqlen_global):
+    # A single packed sample may exceed the max_tokens_per_gpu * cp_size budget
+    # (while still fitting in memory), so the table built at init can be too
+    # short. Grow module.freqs_cis monotonically to cover seqlen_global.
+    if seqlen_global > module.freqs_cis.size(0):
+        grown = wrapped_precompute_freqs_cis(
+            config, rope_head_dim=rope_head_dim, base=base, yarn_disabled=yarn_disabled, min_seq_len=seqlen_global
+        )
+        module.freqs_cis = grown.to(device=module.freqs_cis.device, dtype=module.freqs_cis.dtype)

--- a/miles_plugins/models/deepseek_v4/ops/v4_indexer.py
+++ b/miles_plugins/models/deepseek_v4/ops/v4_indexer.py
@@ -14,7 +14,7 @@ from miles_plugins.models.deepseek_v4.ops.kernel.tilelang_indexer_fwd import (
     batched_indexer_fwd,
 )
 from miles_plugins.models.deepseek_v4.ops.qat import fp8_simulate_qat
-from miles_plugins.models.deepseek_v4.ops.rope import apply_rotary_emb, ensure_freqs_cis, wrapped_precompute_freqs_cis
+from miles_plugins.models.deepseek_v4.ops.rope import apply_rotary_emb, wrapped_precompute_freqs_cis
 from miles_plugins.models.deepseek_v4.ops.utils import rotate_activation
 
 
@@ -67,10 +67,6 @@ class V4Indexer(MegatronModule):
             cp_group=pg_collection.cp,
         )
 
-        rope_base = config.dsv4_compress_rope_theta if self.compress_ratio else config.rotary_base
-        freqs_cis = wrapped_precompute_freqs_cis(config, rope_head_dim=self.rope_head_dim, base=rope_base)
-        self.register_buffer("freqs_cis", freqs_cis, persistent=False)
-
     def forward(self, x: torch.Tensor, qr: torch.Tensor, mask=None, packed_seq_params=None):
         """Forward pass.
 
@@ -99,10 +95,11 @@ class V4Indexer(MegatronModule):
         rd = self.rope_head_dim
         cp_size = parallel_state.get_context_parallel_world_size()
         cp_group = self.pg_collection.cp if hasattr(self.pg_collection, "cp") else None
-        # Grow the rope table on demand for samples longer than the budgeted length.
         rope_base = self.config.dsv4_compress_rope_theta if self.compress_ratio else self.config.rotary_base
-        ensure_freqs_cis(self, self.config, self.rope_head_dim, rope_base, False, seqlen * cp_size)
-        freqs_cis = get_freqs_cis_for_cp(self.freqs_cis, seqlen, cp_size, cp_group, stride=1)
+        freqs_cis = wrapped_precompute_freqs_cis(
+            self.config, self.rope_head_dim, rope_base, False, seqlen * cp_size, x.device
+        )
+        freqs_cis = get_freqs_cis_for_cp(freqs_cis, seqlen, cp_size, cp_group, stride=1)
         q = q.clone()
         q = einops.rearrange(q, "s b ... -> b s ...")
         apply_rotary_emb(q[..., -rd:], freqs_cis)

--- a/miles_plugins/models/deepseek_v4/ops/v4_indexer.py
+++ b/miles_plugins/models/deepseek_v4/ops/v4_indexer.py
@@ -14,7 +14,7 @@ from miles_plugins.models.deepseek_v4.ops.kernel.tilelang_indexer_fwd import (
     batched_indexer_fwd,
 )
 from miles_plugins.models.deepseek_v4.ops.qat import fp8_simulate_qat
-from miles_plugins.models.deepseek_v4.ops.rope import apply_rotary_emb, wrapped_precompute_freqs_cis
+from miles_plugins.models.deepseek_v4.ops.rope import apply_rotary_emb, ensure_freqs_cis, wrapped_precompute_freqs_cis
 from miles_plugins.models.deepseek_v4.ops.utils import rotate_activation
 
 
@@ -99,6 +99,9 @@ class V4Indexer(MegatronModule):
         rd = self.rope_head_dim
         cp_size = parallel_state.get_context_parallel_world_size()
         cp_group = self.pg_collection.cp if hasattr(self.pg_collection, "cp") else None
+        # Grow the rope table on demand for samples longer than the budgeted length.
+        rope_base = self.config.dsv4_compress_rope_theta if self.compress_ratio else self.config.rotary_base
+        ensure_freqs_cis(self, self.config, self.rope_head_dim, rope_base, False, seqlen * cp_size)
         freqs_cis = get_freqs_cis_for_cp(self.freqs_cis, seqlen, cp_size, cp_group, stride=1)
         q = q.clone()
         q = einops.rearrange(q, "s b ... -> b s ...")


### PR DESCRIPTION
## Problem

`wrapped_precompute_freqs_cis` in `miles_plugins/models/deepseek_v4/ops/rope.py` hardcodes the rope frequency table to `max_seq_len = 65536`. But `get_freqs_cis_for_cp` slices that table by **global** position:

```python
return freqs_cis[cp_rank * seqlen_local : (cp_rank + 1) * seqlen_local]
```

so the highest CP rank needs entries up to `seqlen_global - 1 = cp_size * seqlen_local - 1`. Whenever `seqlen_global = cp_size * seqlen_local > 65536`, the high ranks get a truncated/empty slice and the forward crashes in `apply_rotary_emb`:

```
RuntimeError: shape '[1, S, 1, 32]' is invalid for input of size 0
```

In packed-THD dynamic-batch SFT, `--max-tokens-per-gpu` is a **per-rank** budget, so `seqlen_global = max_tokens_per_gpu * cp_size` grows with CP. This trips long-context CP training (e.g. CP8 packing past 64K); a typical CP2 / <=64K-packed setup never hits it.

The failing shapes match the arithmetic exactly:
- CP4, `seqlen_local=24576`: rank 2 slices `[49152:65536]` -> 16384 rows -> input `size 524288` (= 16384 x 32).
- CP8, `seqlen_local=27904`: rank 3 start `83712 > 65536` -> empty slice -> input `size 0`.

## Root cause

`65536` is the model's `original_max_position_embeddings` (the pre-YaRN reference length). The frequencies are YaRN-rescaled (`rotary_scaling_factor=16`), so the model supports positions far beyond 65536 — only the **table length** was left at the pre-extension value, while the slicing indexes global positions that CP x packing easily pushes past 64K.

## Fix

1. Derive `max_seq_len` from the run config instead of hardcoding: `max_tokens_per_gpu * cp_size` (the real packed length in THD dynamic-batch mode; `args.seq_length` does not reflect it and defaults to 4096), floored at `original_max_position_embeddings`.
2. Grow the table on demand in `forward` via `ensure_freqs_cis`, because a single packed sample can exceed the `max_tokens_per_gpu * cp_size` budget while still fitting in memory. The table grows monotonically to the actual global length.

Applied to all three `freqs_cis` buffers: main MLA attention, the KV compressor, and the DSA indexer.

The YaRN frequency rescaling is unchanged, so positions <= 65535 stay bit-identical; positions beyond use the already-rescaled (factor 16) frequencies, which is within the model's designed YaRN range. Memory is unaffected for runs that stay within 64K (the table is still 65536) and scales with the actual context otherwise.

## Validation

8xH20 (64 GPU, TP2/PP4/CP8/EP8, packed SFT): the table inits at 65536 and grows to 106496 on demand when an over-budget sample appears; training runs clean across steps — no rope overflow, no OOM.
