### PR TITLE
fix(rl): gate REINFORCE++ KL by the loss mask in returns

### DIFF
--- a/miles/backends/training_utils/loss_hub/math_utils.py
+++ b/miles/backends/training_utils/loss_hub/math_utils.py
@@ -483,8 +483,11 @@ def get_reinforce_plus_plus_returns(
             full_kl_response = local_kl_chunk
 
         # Step 3: Compute returns on full response kl tensor.
-        token_level_rewards = -kl_coef * full_kl_response
         full_mask = loss_masks[i]
+        # Gate KL by the loss mask so masked-out tokens (e.g. multi-turn observation/tool
+        # tokens) don't leak their KL into earlier valid tokens via the discounted accumulation.
+        masked_kl = full_kl_response * full_mask.to(device=full_kl_response.device, dtype=full_kl_response.dtype)
+        token_level_rewards = -kl_coef * masked_kl
         assert full_mask.sum().item() > 0, f"Sequence at index {i} is fully masked."
         last_idx = full_mask.nonzero(as_tuple=True)[0][-1]
         token_level_rewards[last_idx] += rewards[i]

--- a/tests/fast/backends/training_utils/loss/test_reinforce_pp_returns.py
+++ b/tests/fast/backends/training_utils/loss/test_reinforce_pp_returns.py
@@ -1,0 +1,24 @@
+"""CPU regression test for KL loss-masking in REINFORCE++ returns."""
+
+import pytest
+import torch
+
+from miles.backends.training_utils.loss_hub.math_utils import get_reinforce_plus_plus_returns
+
+from .loss_test_utils import make_parallel_state
+
+
+def test_reinforce_pp_returns_gates_kl_by_loss_mask():
+    # Masked tokens (positions 1,2) carry KL; without gating their KL leaks backward
+    # into the valid leading token, giving G_0 == -3.439 instead of the gated -1.729.
+    make_parallel_state()
+    returns = get_reinforce_plus_plus_returns(
+        rewards=torch.tensor([0.0]),
+        kl=[torch.tensor([1.0, 1.0, 1.0, 1.0])],
+        loss_masks=[torch.tensor([1.0, 0.0, 0.0, 1.0])],
+        response_lengths=[4],
+        total_lengths=[4],
+        kl_coef=1.0,
+        gamma=0.9,
+    )
+    assert returns[0][0].item() == pytest.approx(-1.729)


### PR DESCRIPTION
## What

`get_reinforce_plus_plus_returns` builds the per-token reward as `-kl_coef * full_kl_response` over the **full** response without gating by the loss mask:

```python
token_level_rewards = -kl_coef * full_kl_response
```

The per-token KL is non-zero at masked-out positions (e.g. multi-turn observation/tool tokens), and the backward discounted accumulation (`running_return = token_level_rewards[t] + gamma * running_return`) leaks that masked-token KL penalty into the returns of earlier **valid** training tokens. The function only credits the terminal reward at the last *unmasked* index, so masked tokens are intended to carry no signal — yet their KL still propagates.

## Why / fix

slime's sibling `get_reinforce_plus_plus_returns` gates the KL by the mask — `masked_kl = full_kl_response * full_mask` — landed in slime PR [#1372](https://github.com/THUDM/slime/pull/1372). miles forked this file (now `loss_hub/math_utils.py`) and dropped the gate. This applies the same mask gate before discounting, preserving the terminal `token_level_rewards[last_idx] += rewards[i]`.

## Test

`tests/fast/...test_reinforce_pp_returns`: with `loss_masks=[1,0,0,1]`, `kl=[1,1,1,1]`, `kl_coef=1`, `gamma=0.9`, the return `G_0` is `-1.729` (masked tokens contribute 0) instead of `-3.439` (leaked KL). Fails on `main`, passes after the fix. CPU-only.
