### PR TITLE
Add a deterministic_random reward type

### DIFF
--- a/miles/rollout/rm_hub/__init__.py
+++ b/miles/rollout/rm_hub/__init__.py
@@ -1,4 +1,5 @@
 import asyncio
+import hashlib
 import random
 
 import aiohttp
@@ -62,6 +63,10 @@ async def async_rm(args, sample: Sample, **kwargs):
         return compute_ifbench_reward(response, label, metadata=metadata)
     elif rm_type == "random":
         return random.randint(0, 1)
+    elif rm_type == "deterministic_random":
+        content = str(sample.tokens) + response
+        content_hash = hashlib.sha256(content.encode()).digest()
+        return int(content_hash[0]) % 2
     elif rm_type:
         raise NotImplementedError(f"Rule-based RM for {rm_type} is not implemented.")
     else:

--- a/tests/fast/rollout/rm_hub/test_rm_hub.py
+++ b/tests/fast/rollout/rm_hub/test_rm_hub.py
@@ -51,6 +51,31 @@ class TestAsyncRm:
         reward = run(async_rm(mock_args, sample))
         assert reward in [0, 1]
 
+    def test_deterministic_random_rm_returns_binary(self, mock_args):
+        mock_args.rm_type = "deterministic_random"
+        sample = Sample(prompt="", response="hello", label="", tokens=[1, 2, 3])
+        reward = run(async_rm(mock_args, sample))
+        assert reward in [0, 1]
+
+    def test_deterministic_random_rm_is_deterministic(self, mock_args):
+        mock_args.rm_type = "deterministic_random"
+        sample = Sample(prompt="", response="hello world", label="", tokens=[10, 20])
+        rewards = [run(async_rm(mock_args, sample)) for _ in range(5)]
+        assert len(set(rewards)) == 1
+
+    def test_deterministic_random_rm_differs_by_response(self, mock_args):
+        mock_args.rm_type = "deterministic_random"
+        samples = [Sample(prompt="", response=f"response_{i}", label="", tokens=[1, 2, 3]) for i in range(20)]
+        rewards = [run(async_rm(mock_args, s)) for s in samples]
+        assert 0 in rewards and 1 in rewards
+
+    def test_deterministic_random_rm_differs_by_tokens(self, mock_args):
+        """Same response with different tokens yields both reward values across many samples."""
+        mock_args.rm_type = "deterministic_random"
+        samples = [Sample(prompt="", response="same", label="", tokens=[i, i + 1, i + 2]) for i in range(20)]
+        rewards = [run(async_rm(mock_args, s)) for s in samples]
+        assert 0 in rewards and 1 in rewards
+
     def test_rm_type_from_metadata(self, mock_args):
         mock_args.rm_type = None
         sample = Sample(prompt="", response=r"\boxed{42}", label="42", metadata={"rm_type": "math"})


### PR DESCRIPTION
Add a `deterministic_random` reward that hashes the sample tokens + response to
produce a stable pseudo-random 0/1 reward, used for reproducible
fault-tolerance / CI tests.

- rm_hub/__init__.py (+ test).