### PR TITLE
fix: pass session-server chat responses through without re-parsing

### DIFF
--- a/miles/rollout/session/session_server.py
+++ b/miles/rollout/session/session_server.py
@@ -13,7 +13,6 @@ import httpx
 import setproctitle
 import uvicorn
 from fastapi import FastAPI, Request
-from fastapi.responses import JSONResponse
 from starlette.responses import Response
 
 from miles.rollout.session.sessions import setup_session_routes
@@ -79,21 +78,24 @@ class SessionServer:
         }
 
     def build_proxy_response(self, result: dict) -> Response:
-        content = result["response_body"]
-        status_code = result["status_code"]
+        """Forward the upstream result to the client verbatim.
+
+        This is a proxy: the chat-completion handler already parses and validates
+        the upstream JSON once for TITO token tracking, so re-parsing and
+        re-serializing it through JSONResponse would only double CPU on large
+        (multi-MB all-token routed-experts) responses. We return the original
+        bytes and let Starlette recompute framing from the body — this also makes
+        non-JSON upstream bodies (e.g. error pages) pass through unchanged.
+        """
         # Drop wire-level framing headers from upstream so Starlette rebuilds them
-        # from the body we actually send: transfer-encoding is hop-by-hop
+        # from the body we actually send: transfer-encoding is hop-by-hop, and
+        # httpx already decoded the body so content-encoding/length no longer match.
         headers = {
             k: v
             for k, v in result["headers"].items()
             if k.lower() not in ("content-length", "transfer-encoding", "content-encoding")
         }
-        content_type = headers.get("content-type", "")
-        try:
-            data = json.loads(content)
-            return JSONResponse(content=data, status_code=status_code, headers=headers)
-        except (json.JSONDecodeError, UnicodeDecodeError):
-            return Response(content=content, status_code=status_code, headers=headers, media_type=content_type)
+        return Response(content=result["response_body"], status_code=result["status_code"], headers=headers)
 
 
 def run_session_server(args, backend_url: str):

--- a/miles/rollout/session/session_server.py
+++ b/miles/rollout/session/session_server.py
@@ -78,18 +78,11 @@ class SessionServer:
         }
 
     def build_proxy_response(self, result: dict) -> Response:
-        """Forward the upstream result to the client verbatim.
-
-        This is a proxy: the chat-completion handler already parses and validates
-        the upstream JSON once for TITO token tracking, so re-parsing and
-        re-serializing it through JSONResponse would only double CPU on large
-        (multi-MB all-token routed-experts) responses. We return the original
-        bytes and let Starlette recompute framing from the body — this also makes
-        non-JSON upstream bodies (e.g. error pages) pass through unchanged.
-        """
-        # Drop wire-level framing headers from upstream so Starlette rebuilds them
-        # from the body we actually send: transfer-encoding is hop-by-hop, and
-        # httpx already decoded the body so content-encoding/length no longer match.
+        """Return the upstream body unchanged. The caller already parsed it once for
+        TITO tracking, so re-serializing here would double CPU on large responses;
+        raw bytes also pass non-JSON bodies (e.g. error pages) through."""
+        # Drop framing headers that no longer match the body we send: transfer-encoding
+        # is hop-by-hop, and httpx already decoded the body so content-length/encoding are stale.
         headers = {
             k: v
             for k, v in result["headers"].items()


### PR DESCRIPTION
<!-- lint: profile=evidence-heavy -->
## Summary
Session server no longer re-parses then re-serializes each chat-completion response

## Symptom & Reproduction
- **Symptom:** all-token routed-experts (`meta_info.routed_experts` ~1KB/token) make the final-turn chat response reach ~50MB.
- The success path then spends ~185ms/request of duplicate event-loop CPU.
- `/health` p99 rises to ~410ms under this load.
- The 64×50 workload fails with `502`.
- **Reproduction:** 64 trajectories × 50 turns, ~50k final-turn context, all-token routed-experts.
- Measured via a same-environment A/B with a fake SGLang backend at 8×50, reaching the same ~50MB final-turn response.

## Root Cause
1. `chat_completions` already parses the upstream response once (`response_json_load`) for TITO token tracking.
2. `build_proxy_response` runs `json.loads` on the same response bytes a second time.
3. `build_proxy_response` then re-encodes the dict through `JSONResponse`, a third full pass.
4. Steps 2-3 run on the event loop, ~185ms/request at ~50MB responses, starving `/health`.

## Fix
Make `build_proxy_response` a byte passthrough: return `result["response_body"]` verbatim via `Response`, letting Starlette recompute framing from the body. This removes the duplicate `json.loads` plus the `JSONResponse` re-encode at the source rather than masking them behind a cache or a thread pool. Non-JSON upstream bodies (e.g. error pages) now pass through unchanged instead of taking a re-encode round-trip.

## Verification
- **Existing tests:** `tests/fast/router/test_sessions.py` (7) plus `test_session_race_conditions.py` (9) pass — 16 passed.
- **A/B profile** (all-token routed, 8×50, 1KB/token, fake backend, same process):

| metric (ms unless noted) | OLD reparse+JSONResponse | NEW passthrough |
|---|---:|---:|
| `build_proxy_response`/req mean | 107.1 | 0.01 |
| `build_proxy_response`/req p99 | 314.5 | 0.02 |
| chat latency mean | 2162 | 1294 |
| chat latency p95 | 4450 | 2475 |
| `/health` p99 | 409.7 | 133.6 |
| wall time (s) | 109.3 | 65.2 |

- The required `response_json_load` parse stays ~70ms at the final turn, confirming only the duplicate work was removed.

## Review Focus
- Scrutinize the header filter in `build_proxy_response`: `content-length` / `transfer-encoding` / `content-encoding` are dropped so Starlette reframes from the verbatim body that httpx already decoded.
- Scrutinize the non-200 / non-JSON paths: upstream error bodies are now returned verbatim rather than re-encoded through `JSONResponse`.
