### PR TITLE
perf(session): drop superseded routed_experts/indexer_topk blobs from…

### DIFF
--- a/miles/rollout/session/linear_trajectory.py
+++ b/miles/rollout/session/linear_trajectory.py
@@ -43,6 +43,14 @@ class LinearTrajectory:
 
     def append_record(self, record: SessionRecord) -> None:
         self.records.append(record)
+        # An older record's all-token routed_experts/indexer_topk blob is never
+        # read again (merge_samples is last-wins); drop it to keep retained size
+        # O(prefix). Keep the last rollback-depth + 1 so a rolled-back tail keeps its blob.
+        idx = len(self.records) - 1 - (MAX_ASSISTANT_ROLLBACK_STEPS + 1)
+        if idx >= 0:
+            meta_info = self.records[idx].response["choices"][0]["meta_info"]
+            meta_info.pop("routed_experts", None)
+            meta_info.pop("indexer_topk", None)
 
     def prepare_pretokenized(
         self,
@@ -243,6 +251,11 @@ class SessionRegistry:
     """
 
     def __init__(self, args, tokenizer: Any, *, tito_tokenizer: TITOTokenizer):
+        # Sessions collapse turns via merge_samples (last-wins), so per-turn
+        # multi-sample output is unsupported here.
+        assert not getattr(
+            args, "generate_multi_samples", False
+        ), "session server (linear_trajectory) requires generate_multi_samples=False"
         self.sessions: dict[str, LinearTrajectory] = {}
         self.args = args
         self.tokenizer = tokenizer

--- a/tests/fast/fixtures/generation_fixtures.py
+++ b/tests/fast/fixtures/generation_fixtures.py
@@ -35,7 +35,6 @@ VARIANT_TO_GENERATE_FN_PATH = {
     "multi_turn_single_sample": "miles.rollout.generate_hub.multi_turn.generate",
     "multi_turn_multi_samples": "miles.rollout.generate_hub.multi_turn.generate",
     "agentic_tool_call_single_sample": "miles.rollout.generate_hub.agentic_tool_call.generate",
-    "agentic_tool_call_multi_samples": "miles.rollout.generate_hub.agentic_tool_call.generate",
 }
 
 
@@ -66,11 +65,9 @@ def extra_argv_for_variant(
         argv += ["--generate-tool-call-parser", generate_tool_call_parser]
         if variant == "multi_turn_multi_samples":
             argv.append("--generate-multi-samples")
-    elif variant in ("agentic_tool_call_single_sample", "agentic_tool_call_multi_samples"):
+    elif variant == "agentic_tool_call_single_sample":
         argv += ["--custom-agent-function-path", custom_agent_function_path]
         argv += ["--use-session-server", "--tito-model", "qwen3", "--tito-allowed-append-roles", "tool"]
-        if variant == "agentic_tool_call_multi_samples":
-            argv.append("--generate-multi-samples")
 
     return argv
 

--- a/tests/fast/rollout/generate_hub/test_multi_turn.py
+++ b/tests/fast/rollout/generate_hub/test_multi_turn.py
@@ -22,7 +22,7 @@ _ = generation_env, SAMPLE_TOOLS, TwoTurnStub, ThreeTurnStub
 
 
 def is_agentic_variant(variant: str) -> bool:
-    return variant in ("agentic_tool_call_single_sample", "agentic_tool_call_multi_samples")
+    return variant in ("agentic_tool_call_single_sample",)
 
 
 # ------------------------------------ fixtures and consts ----------------------------------------
@@ -38,7 +38,6 @@ TOKENIZER = load_tokenizer(MODEL_NAME, trust_remote_code=True)
         "multi_turn_single_sample",
         "multi_turn_multi_samples",
         "agentic_tool_call_single_sample",
-        "agentic_tool_call_multi_samples",
     ]
 )
 def variant(request):
@@ -645,7 +644,7 @@ class TestRoutedExpertsMultiTurn:
         assert len(sample.tokens) - 1 == second_routed_experts.shape[0]
 
 
-_AGENTIC_VARIANTS = ["agentic_tool_call_single_sample", "agentic_tool_call_multi_samples"]
+_AGENTIC_VARIANTS = ["agentic_tool_call_single_sample"]
 _AGENT_METADATA = {"reward": 1.0, "exit_status": "Submitted", "eval_report": {"passed": True}}
 
 

--- a/tests/fast/rollout/generate_utils/test_openai_endpoint_utils.py
+++ b/tests/fast/rollout/generate_utils/test_openai_endpoint_utils.py
@@ -7,6 +7,8 @@ and merge_samples — the core of the TITO (Token In Token Out) pipeline.
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+import numpy as np
+import pybase64
 import pytest
 
 from miles.rollout.generate_utils.openai_endpoint_utils import (
@@ -719,3 +721,49 @@ class TestPrefixCacheInfo:
 
         assert samples[0].prefix_cache_info.cached_tokens == 0
         assert samples[0].prefix_cache_info.total_prompt_tokens == 0
+
+
+class TestRoutedExpertsStripContract:
+    """The session server drops superseded all-token routed_experts blobs from
+    older records (keeping only the last few). This must not change the merged
+    training sample, because merge_samples is last-wins and a stripped record
+    decodes to rollout_routed_experts=None, which merge skips."""
+
+    def test_stripping_superseded_records_preserves_merged_r3(self):
+        tok = _mock_tokenizer()
+        args = SimpleNamespace(num_layers=2, moe_router_topk=4)
+        # A 3-turn TITO prefix chain (same layout as test_three_turn_merge_succeeds).
+        layouts = [([1, 2], [10]), ([1, 2, 10, 20], [30]), ([1, 2, 10, 20, 30, 40], [50])]
+
+        def build_records():
+            recs = []
+            for turn, (prompt_ids, output_ids) in enumerate(layouts):
+                record = _make_record(
+                    prompt_token_ids=prompt_ids, output_token_ids=output_ids, output_log_probs=[-0.1 * (turn + 1)]
+                )
+                rows = len(prompt_ids) + len(output_ids) - 1  # all-token: len(sample.tokens) - 1
+                blob = (np.arange(rows * 2 * 4, dtype=np.int32) + turn * 1000).reshape(rows, 2, 4)
+                record.response["choices"][0]["meta_info"]["routed_experts"] = pybase64.b64encode(
+                    blob.tobytes()
+                ).decode("ascii")
+                recs.append(record)
+            return recs
+
+        baseline = merge_samples(
+            compute_samples_from_openai_records(args, _make_input_sample(), build_records(), tok), tok
+        )
+
+        # Simulate the keep-last-2 storage strip in a >=3-turn trajectory: the two
+        # oldest records no longer carry routed_experts.
+        stripped_records = build_records()
+        for i in (0, 1):
+            stripped_records[i].response["choices"][0]["meta_info"].pop("routed_experts", None)
+        stripped = merge_samples(
+            compute_samples_from_openai_records(args, _make_input_sample(), stripped_records, tok), tok
+        )
+
+        assert baseline.rollout_routed_experts is not None
+        # The merged r3 is the last turn's all-token blob, byte-identical with or
+        # without the earlier records' blobs.
+        assert stripped.rollout_routed_experts.shape == (6, 2, 4)
+        np.testing.assert_array_equal(stripped.rollout_routed_experts, baseline.rollout_routed_experts)

--- a/tests/fast/rollout/inference_rollout/integration/test_agent_metadata.py
+++ b/tests/fast/rollout/inference_rollout/integration/test_agent_metadata.py
@@ -9,7 +9,7 @@ from miles.utils.types import Sample
 
 TWO_TURN_DATA_ROWS = [{"input": [{"role": "user", "content": TwoTurnStub.USER_QUESTION}], "label": "2008"}]
 
-_AGENTIC_VARIANTS = ["agentic_tool_call_single_sample", "agentic_tool_call_multi_samples"]
+_AGENTIC_VARIANTS = ["agentic_tool_call_single_sample"]
 
 _METADATA_RM_EXTRA_ARGV = [
     "--rollout-batch-size",

--- a/tests/fast/rollout/inference_rollout/integration/test_multi_turn.py
+++ b/tests/fast/rollout/inference_rollout/integration/test_multi_turn.py
@@ -15,7 +15,6 @@ _VARIANT_NAMES = [
     "multi_turn_single_sample",
     "multi_turn_multi_samples",
     "agentic_tool_call_single_sample",
-    "agentic_tool_call_multi_samples",
 ]
 
 _BASE_EXTRA_ARGV = [
@@ -60,7 +59,7 @@ def test_rollout(rollout_env, variant, test_type):
 
 
 def _verify_samples(variant: str, samples: list[Any]):
-    is_multi_samples = variant in ("multi_turn_multi_samples", "agentic_tool_call_multi_samples")
+    is_multi_samples = variant == "multi_turn_multi_samples"
 
     if is_multi_samples:
         if len(samples) > 0 and isinstance(samples[0], list):

--- a/tests/fast/router/test_linear_trajectory.py
+++ b/tests/fast/router/test_linear_trajectory.py
@@ -752,3 +752,109 @@ class TestComputeSessionMismatch:
         _, kwargs = mock_tokenize.call_args
         assert kwargs["tools"] == tools
         assert kwargs["add_generation_prompt"] is False
+
+
+# ---------------------------------------------------------------------------
+# routed_experts / indexer_topk blob retention
+# ---------------------------------------------------------------------------
+
+
+def _record_with_blobs(turn: int) -> SessionRecord:
+    """A successful chat-completion record carrying the all-token blobs plus the
+    output-only logprobs, shaped like a real upstream response."""
+    return SessionRecord(
+        timestamp=0.0,
+        method="POST",
+        path="/v1/chat/completions",
+        status_code=200,
+        request={"messages": [], "input_ids": [turn]},
+        response={
+            "choices": [
+                {
+                    "message": {"role": "assistant", "content": f"turn{turn}"},
+                    "finish_reason": "stop",
+                    "meta_info": {
+                        "output_token_logprobs": [[-0.1, 100 + turn]],
+                        "completion_tokens": 1,
+                        "routed_experts": f"r3-blob-{turn}",
+                        "indexer_topk": f"idx-blob-{turn}",
+                    },
+                }
+            ]
+        },
+    )
+
+
+def _meta(record: SessionRecord) -> dict:
+    return record.response["choices"][0]["meta_info"]
+
+
+class TestTopkBlobRetention:
+    """LinearTrajectory drops superseded all-token routed_experts/indexer_topk
+    blobs to keep retained record size O(prefix), while never touching the
+    output-only logprobs and keeping the last (rollback-bound + 1) records."""
+
+    def test_keeps_last_two_and_preserves_logprobs(self, registry: SessionRegistry):
+        session = registry.get_session(registry.create_session())
+
+        for turn in range(4):
+            session.append_record(_record_with_blobs(turn))
+
+        # Superseded records (0, 1) lose only the two all-token blobs.
+        for i in (0, 1):
+            assert "routed_experts" not in _meta(session.records[i])
+            assert "indexer_topk" not in _meta(session.records[i])
+            assert "output_token_logprobs" in _meta(session.records[i])
+
+        # The last two records keep everything.
+        for i in (2, 3):
+            assert _meta(session.records[i])["routed_experts"] == f"r3-blob-{i}"
+            assert _meta(session.records[i])["indexer_topk"] == f"idx-blob-{i}"
+            assert "output_token_logprobs" in _meta(session.records[i])
+
+    def test_registry_rejects_generate_multi_samples(self):
+        """linear_trajectory collapses turns via merge_samples, so the session
+        server refuses generate_multi_samples=True up front."""
+        args = SimpleNamespace(generate_multi_samples=True)
+        mock_tito = _MockTITOTokenizer(
+            tokenizer=None, assistant_start_str="<|im_start|>assistant", allowed_append_roles=None
+        )
+        with pytest.raises(AssertionError, match="generate_multi_samples"):
+            SessionRegistry(args, tokenizer=None, tito_tokenizer=mock_tito)
+
+    def test_single_rollback_leaves_surviving_tail_with_blob(self, registry: SessionRegistry):
+        """Keeping the last two records (not one) means a single rollback — which
+        drops the last record and promotes the previous one to the tail — never
+        leaves the surviving tail without its blob, even if the retry never
+        appends. With keep-last-1 the promoted record would already be stripped."""
+        session = registry.get_session(registry.create_session())
+
+        # Turn 1 -> A1
+        session.update_pretokenized_state([SYS_MSG, USER_MSG], ASSISTANT_MSG_1, [1, 2, 3], [10, 11], max_trim_tokens=0)
+        session.append_record(_record_with_blobs(0))
+        # Turn 2 -> A2
+        t2 = [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1]
+        session.prepare_pretokenized(t2, tito_tokenizer=registry.tito_tokenizer)
+        session.update_pretokenized_state(t2, ASSISTANT_MSG_2, [1, 2, 3, 10, 11, 20, 21], [30, 31], max_trim_tokens=0)
+        session.append_record(_record_with_blobs(1))
+        # Turn 3 -> AFINAL (this append strips record 0, keeps records 1 and 2)
+        t3 = [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1, ASSISTANT_MSG_2, TOOL_MSG_2]
+        session.prepare_pretokenized(t3, tito_tokenizer=registry.tito_tokenizer)
+        session.update_pretokenized_state(
+            t3, ASSISTANT_MSG_FINAL, [1, 2, 3, 10, 11, 20, 21, 30, 31, 40], [50, 51], max_trim_tokens=0
+        )
+        session.append_record(_record_with_blobs(2))
+
+        assert "routed_experts" not in _meta(session.records[0])
+        assert _meta(session.records[1])["routed_experts"] == "r3-blob-1"
+
+        # Rollback to the A2 checkpoint by diverging at TOOL_MSG_2.
+        new_tool = {"role": "tool", "content": '{"temperature": 99}', "tool_call_id": "call_2"}
+        rollback_msgs = [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1, ASSISTANT_MSG_2, new_tool]
+        session.prepare_pretokenized(rollback_msgs, tito_tokenizer=registry.tito_tokenizer)
+
+        assert len(session.records) == 2
+        # The promoted tail still carries its blob; if the retry never appends,
+        # merge_samples (last-wins) still recovers the correct routed_experts.
+        assert _meta(session.records[-1])["routed_experts"] == "r3-blob-1"
+        assert _meta(session.records[-1])["indexer_topk"] == "idx-blob-1"


### PR DESCRIPTION
## Summary
Drop superseded routed_experts/indexer_topk blobs from linear-trajectory session records.

## Motivation
Each chat-completion turn stored the full upstream response in its `SessionRecord`, including the all-token `routed_experts`/`indexer_topk` blob (~1KB/token over the whole prompt+output). Every turn's prompt is the full accumulated prefix, so the blobs overlap and grow per turn — retained payload is O(turns × prefix). A 64-trajectory x 50-turn x ~50k-context run retained tens of GB; the all-token run failed with 502. The merged training sample and the per-turn `output_token_logprobs` stay unchanged.

## Before / After
- **Before / After:** before, every record kept its blob, so retained payload was O(turns × prefix); after, `append_record` drops the blob from records that can no longer be the merged tail, so retained payload is O(prefix).
- **What moved where:** the strip lives in `LinearTrajectory.append_record`, retaining the last `MAX_ASSISTANT_ROLLBACK_STEPS + 1` records' blobs.
- `SessionRegistry.__init__` gains a `generate_multi_samples is False` assert; the last-wins reasoning only holds when turns are merged.
- The `agentic_tool_call_multi_samples` test variant is removed accordingly.

## Behavior Preservation
- **How we know:** `test_stripping_superseded_records_preserves_merged_r3` replays a 3-turn chain, strips the first two records, then asserts the merged `rollout_routed_experts` is byte-identical to the all-present baseline.
- `test_keeps_last_two_and_preserves_logprobs` asserts `output_token_logprobs` survive every strip.
- `test_single_rollback_leaves_surviving_tail_with_blob` asserts a rolled-back tail still carries its blob.

## Verification
Existing suite (`test_linear_trajectory` + `test_openai_endpoint_utils` + `test_sessions` + `test_session_race_conditions`) → 82 passed.

Retention microbenchmark drives the real `append_record` with synthetic blobs sized to the workload profile (~1KB/token, ~1k tokens/turn, so context reaches ~50k at turn 50). Per trajectory, retained blob bytes grow with turns pre-fix but stay O(prefix) after:

```
 turns | keep-all (pre-fix) MB | fixed (this PR) MB | reduction
    10 |                  53.7 |               18.6 |     2.9x
    20 |                 205.1 |               38.1 |     5.4x
    30 |                 454.1 |               57.6 |     7.9x
    40 |                 800.8 |               77.1 |    10.4x
    50 |                1245.1 |               96.7 |    12.9x
```

The session server is a singleton process (`router_manager.py:116`), so all in-flight sessions' retained sets coexist in one process. Building 64 concurrent sessions x 50 turns in one process measures the aggregate directly (not extrapolated), via tracemalloc live Python heap:

```
                   live Python heap | retained blobs
keep-all (pre-fix)        77.83 GB  |   77.82 GB     (substantiates "tens of GB" -> 502)
fixed (this PR)            6.05 GB  |    6.04 GB
```

Live heap equals retained blobs in both runs, confirming the popped blobs are released rather than held by a lingering reference. tracemalloc is used instead of RSS because glibc keeps freed chunks resident, which would over-report the fixed run.

## Review Focus
- Scrutinize the `append_record` strip index `len(records) - 1 - (MAX_ASSISTANT_ROLLBACK_STEPS + 1)` against `_try_detect_and_rollback_to_assistant_checkpoint`, which truncates `records` on a single-step rollback.
- Scrutinize the `SessionRegistry.__init__` assert: confirm the session-server subprocess receives the same `args`, so `generate_multi_samples=True` is rejected before any session runs.
