### PR TITLE
Enable observe training entropy without computing entropy loss

### DIFF
--- a/docs/user-guide/argument-groups.md
+++ b/docs/user-guide/argument-groups.md
@@ -120,7 +120,7 @@ more than one dimension.
 | Algorithm | `--advantage-estimator` |
 | KL | `--use-kl-loss`, `--kl-loss-coef`, `--kl-loss-type` |
 | Clipping | `--eps-clip`, `--eps-clip-high` |
-| Entropy | `--entropy-coef` |
+| Entropy | `--entropy-coef`, `--observe-training-entropy` |
 | Loss reduction | `--calculate-per-token-loss` |
 | Precision/off-policy safety | `--use-tis` |
 

--- a/docs/user-guide/cli-reference.md
+++ b/docs/user-guide/cli-reference.md
@@ -70,6 +70,7 @@ then push up until you OOM.
 | `--kl-loss-coef` | `0.0` | Weight of KL in the loss (0 means monitor only). |
 | `--kl-loss-type` | `k1` | `k1`, `k2`, `k3`, `low_var_kl`. |
 | `--entropy-coef` | `0.0` | Entropy bonus weight. |
+| `--observe-training-entropy` | off | Log training entropy even when `--entropy-coef` is `0.0`; detached from backward when the coefficient is zero. |
 | `--eps-clip` | `0.2` | PPO/GRPO low clip. |
 | `--eps-clip-high` | `–` | Asymmetric high clip (DAPO-style). |
 | `--use-tis` | off | Truncated Importance Sampling for train/inference precision mismatch. |
@@ -229,6 +230,7 @@ Sections mirror the launch-script argument groups.
 | `--kl-loss-coef` | float | `0.0` | KL weight in loss (0 means monitor). |
 | `--kl-loss-type` | enum | `k1` | `k1`, `k2`, `k3`, `low_var_kl`. |
 | `--entropy-coef` | float | `0.0` | Entropy bonus weight. |
+| `--observe-training-entropy` | flag | off | Log detached training entropy when entropy bonus weight is zero. |
 | `--eps-clip` | float | `0.2` | PPO/GRPO low clip. |
 | `--eps-clip-high` | float | – | Asymmetric high clip. |
 | `--use-tis` | flag | off | Truncated Importance Sampling. |

--- a/miles/backends/training_utils/loss_hub/logit_processors.py
+++ b/miles/backends/training_utils/loss_hub/logit_processors.py
@@ -135,6 +135,7 @@ def get_log_probs_and_entropy(
     total_lengths: list[int],
     response_lengths: list[int],
     with_entropy: bool = False,
+    entropy_requires_grad: bool = True,
     non_loss_data: bool = True,
     max_seq_lens: list[int] | None = None,
 ) -> dict[str, list[torch.Tensor]]:
@@ -142,8 +143,7 @@ def get_log_probs_and_entropy(
 
     For each sample, extracts response-aligned logits and tokens, then computes
     log-probabilities via softmax across the tensor-parallel group. Log-probs
-    are squeezed from `[R, 1]` to `[R]`. Entropy values are always appended
-    (even when `with_entropy=False`), but only included in the result dict
+    are squeezed from `[R, 1]` to `[R]`. Entropy is computed and returned only
     when requested.
 
     Args:
@@ -153,6 +153,8 @@ def get_log_probs_and_entropy(
         total_lengths: Total sequence lengths per sample.
         response_lengths: Response segment lengths per sample.
         with_entropy: If True, include "entropy" key in result.
+        entropy_requires_grad: If False, compute entropy as an observed metric
+            without attaching it to the autograd graph.
         non_loss_data: Unused; kept for API compatibility.
 
     Returns:
@@ -177,13 +179,15 @@ def get_log_probs_and_entropy(
             tokens_chunk,
             parallel_state.tp.group,
             with_entropy=with_entropy,
+            entropy_requires_grad=entropy_requires_grad,
             chunk_size=args.log_probs_chunk_size,
             true_on_policy=args.true_on_policy_mode,
             vocab_size=getattr(args, "vocab_size", None),
         )
 
         log_probs_list.append(log_prob.squeeze(-1))
-        entropy_list.append(entropy)
+        if with_entropy:
+            entropy_list.append(entropy)
 
     res = {
         "log_probs": log_probs_list,

--- a/miles/backends/training_utils/loss_hub/losses.py
+++ b/miles/backends/training_utils/loss_hub/losses.py
@@ -96,6 +96,7 @@ def policy_loss_function(
     response_lengths = batch["response_lengths"]
     total_lengths = batch["total_lengths"]
     max_seq_lens = batch.get("max_seq_lens", None)
+    calculate_entropy = args.entropy_coef != 0 or args.observe_training_entropy
 
     log_probs_and_entropy = get_log_probs_and_entropy(
         logits,
@@ -103,7 +104,8 @@ def policy_loss_function(
         unconcat_tokens=batch["unconcat_tokens"],
         total_lengths=total_lengths,
         response_lengths=response_lengths,
-        with_entropy=args.entropy_coef != 0,
+        with_entropy=calculate_entropy,
+        entropy_requires_grad=args.entropy_coef != 0,
         max_seq_lens=max_seq_lens,
     )
 
@@ -267,15 +269,16 @@ def policy_loss_function(
     pg_clipfrac = sum_of_sample_mean(pg_clipfrac)
     ppo_kl = sum_of_sample_mean(ppo_kl)
 
-    # entropy loss
-    if args.entropy_coef != 0:
+    entropy_loss = pg_loss.new_zeros(())
+    loss = pg_loss
+    if calculate_entropy:
         entropy = log_probs_and_entropy["entropy"]
         entropy = torch.cat(entropy, dim=0)
         entropy_loss = sum_of_sample_mean(entropy)
-        loss = pg_loss - args.entropy_coef * entropy_loss
-    else:
-        entropy_loss = pg_loss.new_zeros(())
-        loss = pg_loss
+        if args.entropy_coef != 0:
+            loss = pg_loss - args.entropy_coef * entropy_loss
+        else:
+            entropy_loss = entropy_loss.detach()
 
     if args.use_kl_loss:
         ref_log_probs = batch["ref_log_probs"]

--- a/miles/backends/training_utils/loss_hub/math_utils.py
+++ b/miles/backends/training_utils/loss_hub/math_utils.py
@@ -859,6 +859,7 @@ def calculate_log_probs_and_entropy(
     tokens,
     tp_group,
     with_entropy: bool = False,
+    entropy_requires_grad: bool = True,
     chunk_size: int = -1,
     true_on_policy: bool = False,
     vocab_size: int | None = None,
@@ -869,6 +870,7 @@ def calculate_log_probs_and_entropy(
             tokens,
             tp_group,
             with_entropy=with_entropy,
+            entropy_requires_grad=entropy_requires_grad,
             vocab_size=vocab_size,
         )
 
@@ -877,6 +879,13 @@ def calculate_log_probs_and_entropy(
     # Without the clone, the backward will trigger inplace edit error.
     # It seems that the function with tp will modify the logits inplace.
     entropy = None
+
+    def compute_entropy(logits_chunk: torch.Tensor) -> torch.Tensor:
+        if entropy_requires_grad:
+            return compute_entropy_from_logits(logits_chunk.clone(), tp_group)
+        with torch.no_grad():
+            return compute_entropy_from_logits(logits_chunk.detach().clone(), tp_group)
+
     if logits.size(0) != 0:
         if chunk_size > 0:
             num_chunks = (logits.size(0) - 1) // chunk_size + 1
@@ -890,13 +899,13 @@ def calculate_log_probs_and_entropy(
             if with_entropy:
                 entropys = []
                 for _, logits_chunk in zip(tokens_chunks, logits_chunks, strict=True):
-                    entropy = compute_entropy_from_logits(logits_chunk.clone(), tp_group)
+                    entropy = compute_entropy(logits_chunk)
                     entropys.append(entropy)
                 entropy = torch.cat(entropys, dim=0)
         else:
             log_prob = compute_log_probs(logits.clone(), tokens, tp_group)
             if with_entropy:
-                entropy = compute_entropy_from_logits(logits.clone(), tp_group)
+                entropy = compute_entropy(logits)
     else:
         log_prob = logits.new_zeros((0,))
         if with_entropy:
@@ -910,6 +919,7 @@ def _calculate_log_probs_and_entropy_true_on_policy(
     tokens: torch.Tensor,
     tp_group: dist.ProcessGroup | None,
     with_entropy: bool = False,
+    entropy_requires_grad: bool = True,
     vocab_size: int | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor | None]:
     """True-on-policy log-prob and entropy computation matching SGLang's scoring contract.
@@ -920,6 +930,8 @@ def _calculate_log_probs_and_entropy_true_on_policy(
         tokens: Target tokens of shape ``[R]``.
         tp_group: Tensor-parallel process group for vocab gather.
         with_entropy: If True, also compute entropy.
+        entropy_requires_grad: If False, compute entropy as an observed metric
+            without attaching it to the autograd graph.
         vocab_size: Real tokenizer vocab size. If provided, padded logits are
             truncated after the full-vocab gather and before ``log_softmax``.
 
@@ -941,7 +953,13 @@ def _calculate_log_probs_and_entropy_true_on_policy(
 
     entropy = None
     if with_entropy:
-        probs = log_probs_full.exp()
-        entropy = -(probs * log_probs_full).sum(dim=-1)
+        entropy_log_probs = log_probs_full if entropy_requires_grad else log_probs_full.detach()
+        if entropy_requires_grad:
+            probs = entropy_log_probs.exp()
+            entropy = -(probs * entropy_log_probs).sum(dim=-1)
+        else:
+            with torch.no_grad():
+                probs = entropy_log_probs.exp()
+                entropy = -(probs * entropy_log_probs).sum(dim=-1)
 
     return log_prob, entropy

--- a/miles/backends/training_utils/loss_hub/math_utils.py
+++ b/miles/backends/training_utils/loss_hub/math_utils.py
@@ -954,12 +954,7 @@ def _calculate_log_probs_and_entropy_true_on_policy(
     entropy = None
     if with_entropy:
         entropy_log_probs = log_probs_full if entropy_requires_grad else log_probs_full.detach()
-        if entropy_requires_grad:
-            probs = entropy_log_probs.exp()
-            entropy = -(probs * entropy_log_probs).sum(dim=-1)
-        else:
-            with torch.no_grad():
-                probs = entropy_log_probs.exp()
-                entropy = -(probs * entropy_log_probs).sum(dim=-1)
+        probs = entropy_log_probs.exp()
+        entropy = -(probs * entropy_log_probs).sum(dim=-1)
 
     return log_prob, entropy

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -1004,6 +1004,15 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 ),
             )
             parser.add_argument(
+                "--observe-training-entropy",
+                action="store_true",
+                default=False,
+                help=(
+                    "Compute training entropy as a logged metric even when --entropy-coef is 0. "
+                    "When the coefficient is 0, the observed entropy is detached and does not affect backward."
+                ),
+            )
+            parser.add_argument(
                 "--get-mismatch-metrics",
                 action="store_true",
                 default=False,

--- a/tests/fast/backends/training_utils/test_true_on_policy_loss_metrics.py
+++ b/tests/fast/backends/training_utils/test_true_on_policy_loss_metrics.py
@@ -29,6 +29,7 @@ def _make_args(*, use_rollout_logprobs: bool) -> Namespace:
         log_probs_chunk_size=-1,
         true_on_policy_mode=False,
         allgather_cp=False,
+        observe_training_entropy=False,
     )
 
 


### PR DESCRIPTION
## Motivation
Algorithm bros want to observe entropy from the training forward pass even when the entropy is not included in calculating loss. The previous `--entropy-coef 0.0` path skipped training entropy entirely, leaving only rollout-time entropy available for dashboards.

## Usage
```
--entropy-coef 0.0 --observe-training-entropy
```
This logs entropy_loss from the training logits as a detached metric. It does not add the entropy to the loss and does not attach the observed entropy to backward.