### PR TITLE
Fix megatron `use_distributed_optimizer` arg

### DIFF
--- a/miles/backends/megatron_utils/arguments.py
+++ b/miles/backends/megatron_utils/arguments.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 def set_default_megatron_args(args):
     # Muon currently owns its sharding path, and Megatron's distributed optimizer
     # only supports Adam-family optimizers.
-    args.use_distributed_optimizer = args.optimizer in [None, "adam"]
+    args.use_distributed_optimizer = args.optimizer is None or args.optimizer.lower() == "adam"
     # TODO: maybe change this after megatron has good fp8 support
     args.bf16 = not args.fp16
     # placeholders

--- a/miles/backends/megatron_utils/arguments.py
+++ b/miles/backends/megatron_utils/arguments.py
@@ -9,14 +9,10 @@ __all__ = ["validate_args", "parse_args", "set_default_megatron_args"]
 logger = logging.getLogger(__name__)
 
 
-def _is_muon_optimizer(optimizer: str | None) -> bool:
-    return optimizer is not None and "muon" in optimizer.lower()
-
-
 def set_default_megatron_args(args):
-    # Muon currently owns its sharding path and is incompatible with Megatron's
-    # distributed optimizer, while Adam/SGD keep the historical ZeRO default.
-    args.use_distributed_optimizer = not _is_muon_optimizer(args.optimizer)
+    # Muon currently owns its sharding path, and Megatron's distributed optimizer
+    # only supports Adam-family optimizers.
+    args.use_distributed_optimizer = args.optimizer in [None, "adam"]
     # TODO: maybe change this after megatron has good fp8 support
     args.bf16 = not args.fp16
     # placeholders


### PR DESCRIPTION
@humansand

Megatron `use_distributed_optimizer` only works with `adam`:
https://github.com/radixark/Megatron-LM/blob/87d1155be008e09ae667dac91020bb7b87238c22/megatron/core/optimizer/distrib_optimizer.py#L531-L537

Megatron optimizer choices are only `['adam', 'sgd', 'muon', 'dist_muon']`:
https://github.com/radixark/Megatron-LM/blob/87d1155be008e09ae667dac91020bb7b87238c22/megatron/training/arguments.py#L2086-L2088

The previous implementation sets `use_distributed_optimizer = True` for `sgd`, which is rejected by Megatron.