### PR TITLE
fix GLM 5 & 5.2 on blackwell

### DIFF
--- a/scripts/run_glm5_2_744b_a40b.py
+++ b/scripts/run_glm5_2_744b_a40b.py
@@ -359,6 +359,12 @@ def _execute_train(args: ScriptArgs):
         f"--sglang-chunked-prefill-size {2048 * sglang_world_size} "
         "--sglang-watchdog-timeout 3600 "
     )
+    if args.hardware in ("B200", "GB300") and not (args.fp8_rollout and args.use_deepep):
+        # TODO: fix bf16 trtllm weight update
+        if args.fp8_rollout:
+            sglang_args += "--sglang-moe-runner-backend flashinfer_trtllm_routed "
+        else:
+            sglang_args += "--sglang-moe-runner-backend triton "
     sglang_extra_env_vars = {
         "SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK": f"{64 if args.enable_pd else 256}",
         "SGLANG_NSA_FORCE_MLA": "1",

--- a/scripts/run_glm5_744b_a40b.py
+++ b/scripts/run_glm5_744b_a40b.py
@@ -344,6 +344,7 @@ def _execute_train(args: ScriptArgs):
         # use flashmla backend for better precision
         "--sglang-nsa-decode-backend flashmla_sparse "
         "--sglang-nsa-prefill-backend flashmla_sparse "
+        "--sglang-kv-cache-dtype bf16 "
         "--sglang-attention-backend nsa "
         "--sglang-page-size 64 "
         f"--sglang-cuda-graph-max-bs {sglang_decode_max_bs} "
@@ -352,6 +353,12 @@ def _execute_train(args: ScriptArgs):
         f"--sglang-chunked-prefill-size {2048 * sglang_world_size} "
         "--sglang-watchdog-timeout 3600 "
     )
+    if args.hardware in ("B200", "GB300") and not (args.fp8_rollout and args.use_deepep):
+        # TODO: fix bf16 trtllm weight update
+        if args.fp8_rollout:
+            sglang_args += "--sglang-moe-runner-backend flashinfer_trtllm_routed "
+        else:
+            sglang_args += "--sglang-moe-runner-backend triton "
     sglang_extra_env_vars = {
         "SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK": f"{32 if args.enable_pd else 256}",
         "SGLANG_NSA_FORCE_MLA": "1",


### PR DESCRIPTION
ci-sglang-pr: #29339

Make GLM-5 and GLM-5.2 RL run correctly on Blackwell (B200/GB300).

## Changes

**Both scripts** — on Blackwell, select the SGLang MoE runner backend by rollout dtype:
- **bf16 → `triton`**
- **fp8 → `flashinfer_trtllm_routed`** (separate block-quant weight path)

**GLM-5 only** — add `--sglang-kv-cache-dtype bf16`: the `flashmla_sparse` decode kernel requires a bf16 KV cache on sm100, but DSA auto-selects fp8 and crashes. (GLM-5.2 already runs fp8 KV + `flashmla_kv`, so it's unaffected.)

## Why triton for bf16

With `flashinfer_trtllm_routed`, the **bf16** MoE expert weights are silently **corrupted during `update_weights`** on Blackwell. Verified on GLM-5.2 with `--check-weight-update-equal`:

| backend | `experts.w13/w2` max_abs_err | train↔rollout logprob abs_diff | rollout KL |
|---|---|---|---|
| `flashinfer_trtllm_routed` | up to **1.22** | **~0.21** | ~0.047 |
| `triton` | **0** (bit-exact) | **~0.017** | ~4e-4 |
| H100 CI (`test_glm5_2_744b_a40b_5layer_ci`) | — | ~0.017 | ~4e-4 |

Root cause is in SGLang's trtllm **bf16** `process_weights_after_loading` block transform: on the hot `update_weights` re-block it is **not idempotent** — given byte-identical canonical input it produces a value-preserving reorder at initial load but a value-corrupting output on the second pass (the shape-keyed `_cache_permute_indices` entry from the initial load is reused, yielding a non-bijective gather). `triton` has no block layout, so its weight update is a plain copy and round-trips correctly. This restores GB300 train↔rollout consistency to H100 parity.

## TODO

The underlying SGLang trtllm bf16 weight-update bug is marked `# TODO: fix bf16 trtllm weight update`. A candidate fix (clearing the permute-index cache before the re-block) was confirmed to make the routed path round-trip bit-exactly; it belongs in SGLang. Once fixed upstream, the bf16 path can return to `flashinfer_trtllm_routed` for performance.
