### PR TITLE
Fix minor docs issues (plug-point count, R3 label, typo, MDX padding)

### DIFF
--- a/docs/models/deepseek/deepseek-v4-pro.md
+++ b/docs/models/deepseek/deepseek-v4-pro.md
@@ -95,9 +95,11 @@ Required env vars (the launcher sets these for you): `SGLANG_SKIP_CHECKPOINT_LOA
 Megatron side: `--qkv-format bshd` (V4 needs `bshd` with CP-aware data slicing). The DSA indexer additionally supports replay via `--use-rollout-indexer-replay` (off by default).
 
 <Warning title="Pro-specific rollout caveats">
+
 1. **Engine size ≥ 32 GPUs.** Pro needs a single SGLang engine spanning at least 32 GPUs — the launcher hard-codes `--rollout-num-gpus-per-engine 32`. Smaller engines do not leave enough memory after weights, KV cache, indexer state, and DeepEP buffers, and rollout will OOM under load.
 2. **EP is mandatory; pure TP will not shard the model.** 384 routed experts × `moe_ffn_hidden_size=3072` cannot be partitioned by tensor parallelism alone — the model must use expert parallelism (`--sglang-ep-size 32`) to spread the expert MLPs across ranks. `--sglang-tp-size 32` only covers the attention / embedding paths.
 3. **DeepEP normal-mode + CUDA graphs can hang at large batch sizes.** When `--sglang-moe-a2a-backend deepep` is on, an overly large `--sglang-cuda-graph-max-bs` makes SGLang hang during graph capture or replay. The launcher pins it to `8` for Pro — raise it only after verifying the engine doesn't deadlock at your target batch.
+
 </Warning>
 
 ### 5.4 Optimizer

--- a/docs/platforms/index.md
+++ b/docs/platforms/index.md
@@ -28,7 +28,7 @@ Miles runs on NVIDIA H/B-series and AMD MI300X with the same launch scripts. Eac
 | FP8 GEMM | ✅  | - | ✅  |
 | INT4 W4A16 QAT | ✅ | ✅ | ⚠️ |
 | Speculative decoding | ✅ | ✅ | ✅ |
-| Miles Router (R3) | ✅ | ✅ | ✅ |
+| Rollout Routing Replay (R3) | ✅ | ✅ | ✅ |
 | P2P weight transfer (RDMA) | ✅ IB / RoCEv2 | ✅ | ✅ Infinity Fabric |
 | Megatron CP | ✅ | ✅ | ✅ |
 | Deterministic inference | ✅ | ✅ | ⚠️ |

--- a/docs/user-guide/concepts.md
+++ b/docs/user-guide/concepts.md
@@ -88,4 +88,4 @@ Use this map when reading any launch script:
 - [Argument Groups](/user-guide/argument-groups) — where each launch-script array belongs.
 - [Training Script Walkthrough](/user-guide/training-script-walkthrough) — the launch script
   group by group, plus execution modes (colocation, sync/async, dynamic sampling, …).
-- [CLI Reference](/user-guide/cli-reference) — every flag, grouped and fully catalogd.
+- [CLI Reference](/user-guide/cli-reference) — every flag, grouped and fully cataloged.

--- a/docs/user-guide/customization.md
+++ b/docs/user-guide/customization.md
@@ -1,6 +1,6 @@
 ---
 title: Customization
-description: The 22 plug-points where you can drop in your own Python without forking Miles.
+description: The 21 plug-points where you can drop in your own Python without forking Miles.
 ---
 Most of Miles's behavior can be replaced with user-supplied Python by passing a
 `--*-path` flag. This page lists every such hook, the function signature it expects,

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -9,7 +9,7 @@ description: Concepts, launch script walkthrough, customization hooks, and a com
 | [Training Backend](/user-guide/usage) | Megatron-LM as the training backend — parallelism, checkpoints, and hooks. |
 | [Training Script Walkthrough](/user-guide/training-script-walkthrough) | The eight `XXX_ARGS` arrays in a launch script, plus the execution modes (sync/async, colocation, dynamic sampling, partial rollout, BF16+FP8). |
 | [Monitoring & Logging](/user-guide/monitoring) | wandb, structured logs, per-source breakdowns, profiling, router metrics. |
-| [Customization](/user-guide/customization) | The 22 `--*-path` plug-points for custom Python — rollout, reward, filters, loss, hooks. |
+| [Customization](/user-guide/customization) | The 21 `--*-path` plug-points for custom Python — rollout, reward, filters, loss, hooks. |
 | [Rollout Endpoints](/user-guide/rollout-endpoints) | The `/generate` endpoint and the OpenAI chat endpoint for agentic sessions. |
 | [Fully Async Rollout](/user-guide/fully-async) | Queue-backed rollout production, tuning knobs, and when to use `train_async.py`. |
 | [Agentic Chat Templates](/user-guide/agentic-chat-template) | Turning on and verifying TITO so multi-turn agentic rollout stays append-only. |


### PR DESCRIPTION
## Summary
Four small, independently-verified documentation fixes:

- **Plug-point count**: `customization.md` and `user-guide/index.md` said "22 plug-points" but the page documents 21 distinct `--*-path` hooks. Corrected to 21.
- **R3 label**: `platforms/index.md` support matrix labeled the R3 row "Miles Router (R3)", conflating the Miles router (`--use-miles-router`) with Rollout Routing Replay (`--use-rollout-routing-replay`). Relabeled to "Rollout Routing Replay (R3)" to match the canonical page title and every other reference.
- **Typo**: `concepts.md` "fully catalogd" → "cataloged".
- **MDX render fix**: added blank-line padding inside the `<Warning>` block in `deepseek-v4-pro.md` so the enclosed ordered list renders as markdown.

## Test plan
- [ ] Mintlify preview renders the DeepSeek-V4-Pro warning list correctly.