### PR TITLE
Remove deprecated --use-miles-router from recipe docs

### DIFF
--- a/docs/models/kimi/kimi-k2.5.md
+++ b/docs/models/kimi/kimi-k2.5.md
@@ -87,7 +87,7 @@ The launcher groups its flags into the arrays that are passed to `train.py`. The
 - **`GRPO_ARGS`** and **`OPTIMIZER_ARGS`** set the algorithm and CPU-offloaded Adam (§5.2, §5.4).
 - **`SGLANG_ARGS`** configures the colocated rollout engine (§5.3).
 
-The job runs colocated (`--colocate`) across 32 nodes (`--actor-num-nodes 32 --actor-num-gpus-per-node 8`) and uses the miles router (`--use-miles-router`) with `--update-weight-buffer-size $((4*512*1024*1024))`.
+The job runs colocated (`--colocate`) across 32 nodes (`--actor-num-nodes 32 --actor-num-gpus-per-node 8`) with `--update-weight-buffer-size $((4*512*1024*1024))`.
 
 ## 5. Example Recipe Configuration
 

--- a/docs/models/nemotron/nemotron-3-nano-moe.md
+++ b/docs/models/nemotron/nemotron-3-nano-moe.md
@@ -110,13 +110,12 @@ SGLANG_ARGS=(
    --sglang-mem-fraction-static 0.7
    # Replay the exact rollout routing during training forward so
    # train logprobs match rollout logprobs (needed for MoE).
-   --use-miles-router
    --use-rollout-routing-replay
 )
 ```
 
-`--use-miles-router --use-rollout-routing-replay` is what keeps train and rollout
-logprobs aligned for the sigmoid-routed MoE — drop them and you'll see the same
+The `--use-rollout-routing-replay` flag is what keeps train and rollout
+logprobs aligned for the sigmoid-routed MoE — drop it and you'll see the same
 ~0.28 drift the bridge shim was added to fix.
 
 ### 5.4 Optimizer

--- a/docs/models/nemotron/nemotron-3-super.md
+++ b/docs/models/nemotron/nemotron-3-super.md
@@ -112,12 +112,11 @@ SGLANG_ARGS=(
    --sglang-mem-fraction-static 0.7
    # Replay the exact rollout routing during training forward so
    # train logprobs match rollout logprobs (needed for sigmoid-routed MoE).
-   --use-miles-router
    --use-rollout-routing-replay
 )
 ```
 
-`--use-miles-router --use-rollout-routing-replay` keeps train and rollout
+The `--use-rollout-routing-replay` flag keeps train and rollout
 logprobs aligned for the sigmoid-routed MoE — the same routing-replay rule that
 Nano-MoE uses.
 


### PR DESCRIPTION
## Summary
The `--use-miles-router` flag is deprecated. This removes its remaining references from the model recipe pages, keeping the still-valid `--use-rollout-routing-replay` (R3) intact:

- `models/nemotron/nemotron-3-nano-moe.md` — dropped the flag from the `SGLANG_ARGS` block and reworded the prose so R3 alone is credited with keeping train/rollout logprobs aligned.
- `models/nemotron/nemotron-3-super.md` — same treatment.
- `models/kimi/kimi-k2.5.md` — dropped the "uses the miles router (`--use-miles-router`)" clause, kept the `--update-weight-buffer-size` detail.

## Notes / scope
- Docs-only. The flag is still defined in code (`miles/utils/arguments.py`) and several `scripts/run-*.sh` launchers still pass it; those are intentionally out of scope for this PR.
- The `/advanced/miles-router` page slug (titled "Rollout Routing Replay (R3)") and the developer/architecture descriptions of the router component are also left untouched here — separate follow-ups if desired.

## Test plan
- [ ] Mintlify preview: the three recipe pages render with R3 guidance intact and no dangling references.