### PR TITLE
Remove deprecated --use-miles-router flag from launch scripts

### DIFF
--- a/scripts/run-glm4-9B-4xgpu-radixtree.sh
+++ b/scripts/run-glm4-9B-4xgpu-radixtree.sh
@@ -108,7 +108,6 @@ WANDB_ARGS=(
 
 SGLANG_ARGS=(
    --rollout-num-gpus-per-engine 2
-   # --use-miles-router
 )
 
 MISC_ARGS=(

--- a/scripts/run-glm4.7-flash.sh
+++ b/scripts/run-glm4.7-flash.sh
@@ -125,7 +125,6 @@ SGLANG_ARGS=(
    # --sglang-max-running-requests 512
 
    # use rollout routing replay
-   --use-miles-router
    --use-rollout-routing-replay
 )
 

--- a/scripts/run-kimi-k25.sh
+++ b/scripts/run-kimi-k25.sh
@@ -150,7 +150,6 @@ ray job submit --address="http://127.0.0.1:8265" \
    --actor-num-nodes 32 \
    --actor-num-gpus-per-node 8 \
    --colocate \
-   --use-miles-router \
    --update-weight-buffer-size $(( 4 * 512 * 1024 * 1024 )) \
    ${MODEL_ARGS[@]} \
    ${CKPT_ARGS[@]} \

--- a/scripts/run-nemotron-3-nano-30b-a3b.sh
+++ b/scripts/run-nemotron-3-nano-30b-a3b.sh
@@ -91,7 +91,6 @@ SGLANG_ARGS=(
    --sglang-mem-fraction-static 0.7
    # Replay the exact rollout routing during training forward so
    # train logprobs match rollout logprobs (needed for MoE).
-   --use-miles-router
    --use-rollout-routing-replay
 )
 

--- a/scripts/run-nemotron-3-super-120b-a12b.sh
+++ b/scripts/run-nemotron-3-super-120b-a12b.sh
@@ -131,7 +131,6 @@ SGLANG_ARGS=(
    --sglang-mem-fraction-static 0.7
    # Replay the exact rollout routing during training forward so
    # train logprobs match rollout logprobs (needed for MoE).
-   --use-miles-router
    --use-rollout-routing-replay
 )
 

--- a/scripts/run-qwen3-4B_4xgpu.sh
+++ b/scripts/run-qwen3-4B_4xgpu.sh
@@ -109,7 +109,6 @@ WANDB_ARGS=(
 
 SGLANG_ARGS=(
    --rollout-num-gpus-per-engine 2
-   --use-miles-router
 )
 
 MISC_ARGS=(

--- a/scripts/run_gemma_4_26b_a4b.py
+++ b/scripts/run_gemma_4_26b_a4b.py
@@ -132,7 +132,6 @@ def _execute_train(args: ScriptArgs):
         "--sglang-disable-radix-cache "
         "--no-offload-train "
         "--no-offload-rollout "
-        "--use-miles-router "
         "--use-rollout-routing-replay "
     )
 

--- a/scripts/run_glm47_flash.py
+++ b/scripts/run_glm47_flash.py
@@ -124,8 +124,7 @@ def execute(args: ScriptArgs):
         "--sglang-speculative-num-steps 2 "
         "--sglang-speculative-eagle-topk 1 "
         "--sglang-speculative-num-draft-tokens 3 "
-        # miles router with rollout routing replay
-        "--use-miles-router "
+        # rollout routing replay
         "--use-rollout-routing-replay "
     )
 

--- a/scripts/run_joy_ai_llm_flash.py
+++ b/scripts/run_joy_ai_llm_flash.py
@@ -241,7 +241,6 @@ def execute(args: ScriptArgs, *, wandb_file: str = __file__):
                 )
                 misc_args += (
                     "--use-rollout-routing-replay "
-                    "--use-miles-router "
                     "--sglang-disable-shared-experts-fusion "
                     f"--extra-high-precision-layers-hf {MXFP8_HIGH_PRECISION_LAYERS_HF} "
                     f"--extra-high-precision-layers-megatron {MXFP8_HIGH_PRECISION_LAYERS_MEGATRON} "

--- a/scripts/run_kimi_k25.py
+++ b/scripts/run_kimi_k25.py
@@ -209,7 +209,6 @@ def _execute_train(args: ScriptArgs):
         "--attention-backend flash "
         "--no-check-for-nan-in-loss-and-grad "
         "--colocate "
-        "--use-miles-router "
         f"--update-weight-buffer-size {4 * 512 * 1024 * 1024} "
         f"--actor-num-nodes {args.num_nodes} "
         f"--actor-num-gpus-per-node {args.num_gpus_per_node} "


### PR DESCRIPTION
## Summary
The `--use-miles-router` flag is deprecated (sgl-router is the default rollout router). This removes the flag from every launch script under `scripts/` that still passed it. Where the flag was paired with `--use-rollout-routing-replay` (R3), R3 is kept — it is a separate, still-valid feature.

Scripts updated (10):
- Shell: `run-glm4.7-flash.sh`, `run-kimi-k25.sh`, `run-nemotron-3-nano-30b-a3b.sh`, `run-nemotron-3-super-120b-a12b.sh`, `run-qwen3-4B_4xgpu.sh`, `run-glm4-9B-4xgpu-radixtree.sh` (the last was already commented out).
- Python: `run_glm47_flash.py`, `run_kimi_k25.py`, `run_gemma_4_26b_a4b.py`, `run_joy_ai_llm_flash.py`.

## Scope
- `scripts/` only. `miles/utils/arguments.py` (where the flag is defined) is intentionally left untouched, as requested.
- A lone prose mention "sglang + miles-router" in `scripts/tools/verify_session_tito_tokenizer.py`'s docstring is left as-is — it is a pipeline description, not the flag.
- Pairs with the docs-only removal in #1479.

## Test plan
- [x] `bash -n` passes for all 6 shell scripts.
- [x] `python -m py_compile` passes for all 4 Python launchers.