### PR TITLE
fix(megatron): propagate recompute config to bridge model so checkpointing engages

### DIFF
--- a/miles/backends/megatron_utils/model_provider.py
+++ b/miles/backends/megatron_utils/model_provider.py
@@ -102,6 +102,14 @@ def get_model_provider_func(
         provider.calculate_per_token_loss = args.calculate_per_token_loss
         provider.attention_softmax_in_fp32 = args.attention_softmax_in_fp32
         provider.variable_seq_lengths = args.variable_seq_lengths
+        # Bridge configs skip core_transformer_config_from_args, so activation-recompute settings
+        # never reach the model config (the bridge transformer_block gates checkpointing on
+        # self.config.recompute_granularity, which stayed None). Without this the FULL backward
+        # activation stack is stored (~96GiB at 32k for Qwen3.6-27B) -> OOM. Propagate them so
+        # --recompute-granularity actually engages.
+        provider.recompute_granularity = args.recompute_granularity
+        provider.recompute_method = args.recompute_method
+        provider.recompute_num_layers = args.recompute_num_layers
         if hasattr(args, "moe_token_dispatcher_type"):
             provider.moe_token_dispatcher_type = args.moe_token_dispatcher_type
         if getattr(args, "decoder_first_pipeline_num_layers", None) is not None:


### PR DESCRIPTION
## Summary
Bridge-mode models never run activation recompute, OOMing long-context training

## Symptom & Reproduction
- **Symptom:** `--recompute-granularity full` never engages under `--megatron-to-hf-mode bridge`.
- **Symptom:** Qwen3.6-27B VLM at 32k OOMs on the train step (~136 GiB/GPU) at TP4 with the optimizer CPU-offloaded.
- **Reproduction:** run any bridge-mode job with `--recompute-granularity full`; the bridge `transformer_block` reads `self.config.recompute_granularity` as `None`.

## Root Cause
1. `get_model_provider_func` bridge branch wires `provider.X = args.X` per field but omits `recompute_granularity/method/num_layers`.
2. Bridge providers skip `core_transformer_config_from_args`, so `recompute_granularity` stays `None` on the model config.
3. `Qwen3VLTransformerBlock` gates checkpointing on `recompute_granularity == "full"`, so `_checkpointed_forward` never runs.
4. Without `_checkpointed_forward`, the full backward activation stack (~96 GiB at 32k) exhausts GPU memory on the train step.

## Fix
Set `provider.recompute_granularity/method/num_layers` from `args` alongside the adjacent `provider.X = args.X` fields, before `provider.finalize()`. This propagates the recompute config into the bridge `TransformerConfig` so checkpointing engages. Root-cause fix (the config never reached the model), not a memory-knob workaround.

## Verification
- **Gate probe:** with the fix, the bridge gate reads `recompute_granularity=full` → `will_checkpoint=True` (previously `None` → `False`).
- **End-to-end:** Qwen3.6-27B VLM (32k, TP4 colocate) completes the train step with no OOM.

## Review Focus
- Scrutinize that the three `recompute_*` assignments sit before `provider.finalize()`, inside the `megatron_to_hf_mode == "bridge"` branch.
- Confirm non-bridge paths stay untouched: they already set recompute through `core_transformer_config_from_args`.
