### PR TITLE
fix(megatron): propagate training-infra args to bridge model config

### DIFF
--- a/miles/backends/megatron_utils/model_provider.py
+++ b/miles/backends/megatron_utils/model_provider.py
@@ -23,41 +23,73 @@ from miles.utils.replay_base import routing_replay_manager
 logger = logging.getLogger(__name__)
 
 
-# Args-owned knobs to re-inject onto a bridge-built provider, which skips
-# core_transformer_config_from_args. NOT a blind args->provider copy -- architecture, dtype, and
-# provider-set fields stay HF-checkpoint-authoritative; overriding them would silently corrupt the model.
-_BRIDGE_RUNTIME_OVERRIDE_FIELDS = (
+def _apply_bridge_runtime_config(provider, args: argparse.Namespace) -> None:
+    """Re-inject args-owned runtime config onto a bridge-built provider.
+
+    Bridge mode builds the model from the HF checkpoint and skips
+    core_transformer_config_from_args, so CLI args never reach the provider. We
+    hand-pick fields here instead of blind-copying every arg: on this path the
+    provider is authoritative for what the HF checkpoint defines, and
+    architecture / dtype / provider-deliberate fields sit at mismatched defaults
+    in args. Overriding those would silently corrupt the model -- the bridge
+    weight mapping warns and continues, it does not raise -- so only the
+    training/parallelism/memory/numerics knobs that args legitimately owns are
+    propagated. Add new training-infra flags here, not as scattered assignments.
+    """
     # parallelism / sharding
-    "tensor_model_parallel_size",
-    "pipeline_model_parallel_size",
-    "expert_model_parallel_size",
-    "expert_tensor_parallel_size",
-    "sequence_parallel",
-    "context_parallel_size",
+    provider.tensor_model_parallel_size = args.tensor_model_parallel_size
+    provider.pipeline_model_parallel_size = args.pipeline_model_parallel_size
+    provider.expert_model_parallel_size = args.expert_model_parallel_size
+    provider.expert_tensor_parallel_size = args.expert_tensor_parallel_size
+    provider.sequence_parallel = args.sequence_parallel
+    provider.context_parallel_size = args.context_parallel_size
+
     # loss / sequence handling
-    "calculate_per_token_loss",  # CP>1 VL models assert this
-    "variable_seq_lengths",
+    provider.calculate_per_token_loss = args.calculate_per_token_loss  # CP>1 VL models assert this
+    provider.variable_seq_lengths = args.variable_seq_lengths
+
     # numerics (training infra, not model-defining)
-    "attention_softmax_in_fp32",
-    "fp32_residual_connection",
-    "deterministic_mode",
+    provider.attention_softmax_in_fp32 = args.attention_softmax_in_fp32
+    provider.fp32_residual_connection = args.fp32_residual_connection
+    provider.deterministic_mode = args.deterministic_mode
+
     # activation recompute (silently dropped before -> no checkpointing -> OOM at long context)
-    "recompute_granularity",
-    "recompute_method",
-    "recompute_num_layers",
-    "recompute_modules",
+    provider.recompute_granularity = args.recompute_granularity
+    provider.recompute_method = args.recompute_method
+    provider.recompute_num_layers = args.recompute_num_layers
+    provider.recompute_modules = args.recompute_modules
+
     # activation / memory offload
-    "cpu_offloading",
-    "cpu_offloading_num_layers",
-    "distribute_saved_activations",
+    provider.cpu_offloading_num_layers = args.cpu_offloading_num_layers
+    provider.distribute_saved_activations = args.distribute_saved_activations
+    # cpu_offloading is derived, set only when cpu_offloading_num_layers>0; guard its presence.
+    if hasattr(args, "cpu_offloading"):
+        provider.cpu_offloading = args.cpu_offloading
+
     # communication overlap
-    "tp_comm_overlap",
+    provider.tp_comm_overlap = args.tp_comm_overlap
+
     # fp8
-    "fp8",
-    "fp8_recipe",
+    provider.fp8 = args.fp8
+    provider.fp8_recipe = args.fp8_recipe
+
     # attention kernel selection
-    "attention_backend",
-)
+    provider.attention_backend = args.attention_backend
+
+    # MoE token dispatcher (same-name, always present)
+    provider.moe_token_dispatcher_type = args.moe_token_dispatcher_type
+
+    # arg name != provider field; arg default None, so propagate only when the user set it
+    if getattr(args, "decoder_first_pipeline_num_layers", None) is not None:
+        provider.num_layers_in_first_pipeline_stage = args.decoder_first_pipeline_num_layers
+    if getattr(args, "decoder_last_pipeline_num_layers", None) is not None:
+        provider.num_layers_in_last_pipeline_stage = args.decoder_last_pipeline_num_layers
+
+    # MoE training knobs: override only when explicitly set, else keep the provider's value
+    if getattr(args, "moe_router_bias_update_rate", None) is not None:
+        provider.moe_router_bias_update_rate = args.moe_router_bias_update_rate
+    if getattr(args, "moe_aux_loss_coeff", None) is not None:
+        provider.moe_aux_loss_coeff = args.moe_aux_loss_coeff
 
 
 # Adapt from https://github.com/volcengine/verl/blob/c3b20575d2bc815fcccd84bddb4c0401fc4b632b/verl/models/llama/megatron/layers/parallel_linear.py#L82
@@ -128,21 +160,7 @@ def get_model_provider_func(
 
         bridge = AutoBridge.from_hf_pretrained(args.hf_checkpoint, trust_remote_code=True)
         provider = bridge.to_megatron_provider(load_weights=False)
-        # Otherwise these knobs silently keep their TransformerConfig defaults.
-        for _field in _BRIDGE_RUNTIME_OVERRIDE_FIELDS:
-            if hasattr(args, _field) and hasattr(provider, _field):
-                setattr(provider, _field, getattr(args, _field))
-        # Translated arg name / only-when-explicitly-set fields (kept out of the blind loop).
-        if hasattr(args, "moe_token_dispatcher_type"):
-            provider.moe_token_dispatcher_type = args.moe_token_dispatcher_type
-        if getattr(args, "decoder_first_pipeline_num_layers", None) is not None:
-            provider.num_layers_in_first_pipeline_stage = args.decoder_first_pipeline_num_layers
-        if getattr(args, "decoder_last_pipeline_num_layers", None) is not None:
-            provider.num_layers_in_last_pipeline_stage = args.decoder_last_pipeline_num_layers
-        if getattr(args, "moe_router_bias_update_rate", None) is not None:
-            provider.moe_router_bias_update_rate = args.moe_router_bias_update_rate
-        if getattr(args, "moe_aux_loss_coeff", None) is not None:
-            provider.moe_aux_loss_coeff = args.moe_aux_loss_coeff
+        _apply_bridge_runtime_config(provider, args)
         provider.finalize()
 
         def wrapped_bridge_provider(

--- a/miles/backends/megatron_utils/model_provider.py
+++ b/miles/backends/megatron_utils/model_provider.py
@@ -23,11 +23,9 @@ from miles.utils.replay_base import routing_replay_manager
 logger = logging.getLogger(__name__)
 
 
-# TransformerConfig knobs that come from CLI args and that bridge model providers do NOT set
-# themselves (so they must be re-injected onto a bridge-built provider, which skips
-# core_transformer_config_from_args). See the bridge branch of get_model_provider_func for the
-# full rationale and what is deliberately excluded. Add new training-infra flags here, not as
-# one-off scattered assignments, so the silent-default class stays closed.
+# Args-owned knobs to re-inject onto a bridge-built provider, which skips
+# core_transformer_config_from_args. NOT a blind args->provider copy -- architecture, dtype, and
+# provider-set fields stay HF-checkpoint-authoritative; overriding them would silently corrupt the model.
 _BRIDGE_RUNTIME_OVERRIDE_FIELDS = (
     # parallelism / sharding
     "tensor_model_parallel_size",
@@ -130,17 +128,7 @@ def get_model_provider_func(
 
         bridge = AutoBridge.from_hf_pretrained(args.hf_checkpoint, trust_remote_code=True)
         provider = bridge.to_megatron_provider(load_weights=False)
-        # Bridge mode builds the model ARCHITECTURE from the HF config and skips Megatron's
-        # core_transformer_config_from_args, so CLI args never reach the provider config on their
-        # own. Re-inject the training/parallelism/memory/numerics knobs that come from args and that
-        # the provider does not set itself; otherwise they silently keep TransformerConfig defaults
-        # (e.g. recompute_granularity=None -> activation checkpointing never runs -> OOM at long ctx).
-        # This allow-list (_BRIDGE_RUNTIME_OVERRIDE_FIELDS) deliberately EXCLUDES:
-        #   - architecture fields (hidden_size/num_layers/...; the bridge sets these from HF);
-        #   - dtype (bf16/params_dtype; the bridge derives these from the checkpoint torch_dtype);
-        #   - provider-deliberate fields (apply_rope_fusion=False for mRoPE, fusion flags,
-        #     add_bias_linear, ...) the per-model provider sets on purpose -- overriding those would
-        #     reintroduce silent correctness bugs.
+        # Otherwise these knobs silently keep their TransformerConfig defaults.
         for _field in _BRIDGE_RUNTIME_OVERRIDE_FIELDS:
             if hasattr(args, _field) and hasattr(provider, _field):
                 setattr(provider, _field, getattr(args, _field))

--- a/miles/backends/megatron_utils/model_provider.py
+++ b/miles/backends/megatron_utils/model_provider.py
@@ -24,17 +24,17 @@ logger = logging.getLogger(__name__)
 
 
 def _apply_bridge_runtime_config(provider, args: argparse.Namespace) -> None:
-    """Re-inject args-owned runtime config onto a bridge-built provider.
+    """Copy the runtime config from args onto a bridge-built provider.
 
     Bridge mode builds the model from the HF checkpoint and skips
-    core_transformer_config_from_args, so CLI args never reach the provider. We
-    hand-pick fields here instead of blind-copying every arg: on this path the
-    provider is authoritative for what the HF checkpoint defines, and
-    architecture / dtype / provider-deliberate fields sit at mismatched defaults
-    in args. Overriding those would silently corrupt the model -- the bridge
-    weight mapping warns and continues, it does not raise -- so only the
-    training/parallelism/memory/numerics knobs that args legitimately owns are
-    propagated. Add new training-infra flags here, not as scattered assignments.
+    core_transformer_config_from_args, so command-line args never reach the
+    provider. We copy only some fields, not all of args: the provider already
+    holds the right values from the HF checkpoint, while args only has default
+    values for model shape, dtype, and fields the provider set on purpose.
+    Copying those would quietly break the model -- the bridge only logs a
+    warning and keeps going, it does not fail. So we copy just the training,
+    parallelism, memory, and numerics settings that really come from args. Put
+    new training flags here, not spread across the code.
     """
     # parallelism / sharding
     provider.tensor_model_parallel_size = args.tensor_model_parallel_size

--- a/miles/backends/megatron_utils/model_provider.py
+++ b/miles/backends/megatron_utils/model_provider.py
@@ -23,6 +23,45 @@ from miles.utils.replay_base import routing_replay_manager
 logger = logging.getLogger(__name__)
 
 
+# TransformerConfig knobs that come from CLI args and that bridge model providers do NOT set
+# themselves (so they must be re-injected onto a bridge-built provider, which skips
+# core_transformer_config_from_args). See the bridge branch of get_model_provider_func for the
+# full rationale and what is deliberately excluded. Add new training-infra flags here, not as
+# one-off scattered assignments, so the silent-default class stays closed.
+_BRIDGE_RUNTIME_OVERRIDE_FIELDS = (
+    # parallelism / sharding
+    "tensor_model_parallel_size",
+    "pipeline_model_parallel_size",
+    "expert_model_parallel_size",
+    "expert_tensor_parallel_size",
+    "sequence_parallel",
+    "context_parallel_size",
+    # loss / sequence handling
+    "calculate_per_token_loss",  # CP>1 VL models assert this
+    "variable_seq_lengths",
+    # numerics (training infra, not model-defining)
+    "attention_softmax_in_fp32",
+    "fp32_residual_connection",
+    "deterministic_mode",
+    # activation recompute (silently dropped before -> no checkpointing -> OOM at long context)
+    "recompute_granularity",
+    "recompute_method",
+    "recompute_num_layers",
+    "recompute_modules",
+    # activation / memory offload
+    "cpu_offloading",
+    "cpu_offloading_num_layers",
+    "distribute_saved_activations",
+    # communication overlap
+    "tp_comm_overlap",
+    # fp8
+    "fp8",
+    "fp8_recipe",
+    # attention kernel selection
+    "attention_backend",
+)
+
+
 # Adapt from https://github.com/volcengine/verl/blob/c3b20575d2bc815fcccd84bddb4c0401fc4b632b/verl/models/llama/megatron/layers/parallel_linear.py#L82
 class LinearForLastLayer(torch.nn.Linear):
     def __init__(
@@ -91,17 +130,21 @@ def get_model_provider_func(
 
         bridge = AutoBridge.from_hf_pretrained(args.hf_checkpoint, trust_remote_code=True)
         provider = bridge.to_megatron_provider(load_weights=False)
-        # TODO: we should not manually set this...
-        provider.tensor_model_parallel_size = args.tensor_model_parallel_size
-        provider.pipeline_model_parallel_size = args.pipeline_model_parallel_size
-        provider.expert_model_parallel_size = args.expert_model_parallel_size
-        provider.expert_tensor_parallel_size = args.expert_tensor_parallel_size
-        provider.sequence_parallel = args.sequence_parallel
-        provider.context_parallel_size = args.context_parallel_size
-        # CP>1 VL models assert this; bridge configs skip core_transformer_config_from_args.
-        provider.calculate_per_token_loss = args.calculate_per_token_loss
-        provider.attention_softmax_in_fp32 = args.attention_softmax_in_fp32
-        provider.variable_seq_lengths = args.variable_seq_lengths
+        # Bridge mode builds the model ARCHITECTURE from the HF config and skips Megatron's
+        # core_transformer_config_from_args, so CLI args never reach the provider config on their
+        # own. Re-inject the training/parallelism/memory/numerics knobs that come from args and that
+        # the provider does not set itself; otherwise they silently keep TransformerConfig defaults
+        # (e.g. recompute_granularity=None -> activation checkpointing never runs -> OOM at long ctx).
+        # This allow-list (_BRIDGE_RUNTIME_OVERRIDE_FIELDS) deliberately EXCLUDES:
+        #   - architecture fields (hidden_size/num_layers/...; the bridge sets these from HF);
+        #   - dtype (bf16/params_dtype; the bridge derives these from the checkpoint torch_dtype);
+        #   - provider-deliberate fields (apply_rope_fusion=False for mRoPE, fusion flags,
+        #     add_bias_linear, ...) the per-model provider sets on purpose -- overriding those would
+        #     reintroduce silent correctness bugs.
+        for _field in _BRIDGE_RUNTIME_OVERRIDE_FIELDS:
+            if hasattr(args, _field) and hasattr(provider, _field):
+                setattr(provider, _field, getattr(args, _field))
+        # Translated arg name / only-when-explicitly-set fields (kept out of the blind loop).
         if hasattr(args, "moe_token_dispatcher_type"):
             provider.moe_token_dispatcher_type = args.moe_token_dispatcher_type
         if getattr(args, "decoder_first_pipeline_num_layers", None) is not None:


### PR DESCRIPTION
## Summary
Bridge mode silently drops args-derived training config (recompute, offload, fp8, ...)

## Symptom & Reproduction
- **Symptom:** under `--megatron-to-hf-mode bridge`, args-derived knobs (`recompute_granularity`, `cpu_offloading`, `fp8`, `attention_backend`) silently keep their dataclass defaults.
- **Symptom:** Qwen3.6-27B VLM at 32k OOMs on the train step (~136 GiB/GPU) at TP4 because activation checkpointing never runs.
- **Reproduction:** run a bridge-mode job with `--recompute-granularity full`; the bridge `transformer_block` reads `self.config.recompute_granularity` as `None`.

## Root Cause
1. `get_model_provider_func` bridge branch builds the provider via `bridge.to_megatron_provider`, bypassing `core_transformer_config_from_args`.
2. It then hand-wires only ~9 fields, so any other args-derived knob keeps its `TransformerConfig` dataclass default.
3. `Qwen3VLTransformerBlock` gates checkpointing on `recompute_granularity == "full"`, so the `None` default makes `_checkpointed_forward` never run.
4. Every other such knob (`cpu_offloading`, `fp8`, `deterministic_mode`) is the same latent gap, surfacing only when it breaks.

## Fix
Give the bridge provider one place that re-injects the args-owned runtime config it would otherwise lose: `_apply_bridge_runtime_config(provider, args)`, so new training-infra flags land here instead of being rediscovered one OOM at a time. It is a curated include-list, not a blind copy of args: in bridge mode the HF checkpoint and the per-model provider own architecture, dtype, and model-specific config, and the bridge weight mapping only warns and continues, so copying those back would silently corrupt the model rather than fail.

## Verification
- **End-to-end:** `recompute_granularity` (the live casualty) reaches `will_checkpoint=True` on Qwen3.6-27B VLM at 32k; the train step completes with no OOM.
- **Field presence:** every propagated field was confirmed present at runtime before assignment, not assumed.
- **Selection audit:** the propagated set was checked against the full args-to-`TransformerConfig` overlap to confirm no runtime/infra knob is missing.

## Review Focus
- Scrutinize `_apply_bridge_runtime_config` membership: every assignment must be a runtime/infra knob, never an architecture or provider-set field (e.g. `cp_comm_type`, `moe_grouped_gemm`, `apply_rope_fusion` stay provider-owned).
- Confirm `bf16`/`params_dtype` stay HF-derived and are not propagated.
- Verify the guard on `cpu_offloading`, the only conditionally-set field among the propagated knobs.
