### PR TITLE
fix(weights): handle empty colocated tensor buckets

### DIFF
--- a/miles/backends/fsdp_utils/update_weight_utils.py
+++ b/miles/backends/fsdp_utils/update_weight_utils.py
@@ -17,6 +17,10 @@ except ImportError:
 
 from sglang.srt.utils import MultiprocessingSerializer
 
+from miles.backends.training_utils.serialized_buckets import (
+    align_serialized_bucket_columns,
+    empty_flattened_tensor_data,
+)
 from miles.utils.distributed_utils import get_gloo_group, init_process_group
 
 try:
@@ -187,12 +191,19 @@ class UpdateWeightFromTensor(UpdateWeight):
         )
 
         if dist.get_rank() == self._ipc_gather_src:
-            # TODO: assumes all ranks have the same number of dtype buckets
-            num_dtypes = len(gathered_serialized_batches[0])
-            assert num_dtypes > 0
-            for i in range(num_dtypes):
+            empty_serialized_tensor = None
+            _long_live_empty = []
+            for column in align_serialized_bucket_columns(gathered_serialized_batches):
+                if any(item is None for item in column):
+                    if empty_serialized_tensor is None:
+                        empty_tensor_data = empty_flattened_tensor_data(device=torch.cuda.current_device())
+                        _long_live_empty.append(empty_tensor_data)
+                        empty_serialized_tensor = MultiprocessingSerializer.serialize(
+                            empty_tensor_data, output_str=True
+                        )
+                    column = [item if item is not None else empty_serialized_tensor for item in column]
                 kwargs = {
-                    "serialized_named_tensors": [tensors[i] for tensors in gathered_serialized_batches],
+                    "serialized_named_tensors": column,
                     "load_format": "flattened_bucket",
                     "flush_cache": False,
                     "weight_version": str(weight_version),

--- a/miles/backends/megatron_utils/update_weight/update_weight_from_tensor.py
+++ b/miles/backends/megatron_utils/update_weight/update_weight_from_tensor.py
@@ -18,6 +18,10 @@ from miles.backends.megatron_utils.lora_utils import (
     lora_base_cpu_backup_enabled,
 )
 from miles.backends.training_utils.parallel import get_parallel_state
+from miles.backends.training_utils.serialized_buckets import (
+    align_serialized_bucket_columns,
+    empty_flattened_tensor_data,
+)
 from miles.utils.distributed_utils import get_gloo_group
 from miles.utils.lora import LORA_ADAPTER_NAME
 
@@ -324,10 +328,8 @@ class UpdateWeightFromTensor:
         """Frozen vision/audio tower tensors to append to every base sync (see
         __init__ comment). Returns None when the run has no MM towers. EVERY
         gather-group rank contributes the full tower set (read once from its local
-        HF checkpoint, the same bytes the engine loaded at boot): the colocated
-        send requires homogeneous per-rank bucket counts (num_dtypes is taken from
-        rank 0 and indexed into every rank's list), so a src-only contribution
-        breaks assembly. The duplicates are ~15MB/rank and load idempotently."""
+        HF checkpoint, the same bytes the engine loaded at boot). The duplicates
+        are ~15MB/rank and load idempotently."""
         provider = getattr(self.args, "custom_model_provider_path", None) or ""
         if "inkling_mm_model_provider" not in provider:
             return None
@@ -476,7 +478,7 @@ def _send_to_colocated_engine(
         converted_named_tensors_by_dtypes = {}
         serialized_lora = MultiprocessingSerializer.serialize(payload, output_str=True)
     elif getattr(FlattenedTensorBucket, "supports_multi_dtypes", False):
-        converted_named_tensors_by_dtypes = {"dtype": hf_named_tensors}
+        converted_named_tensors_by_dtypes = {"dtype": hf_named_tensors} if hf_named_tensors else {}
     else:
         converted_named_tensors_by_dtypes = {}
         for name, tensor in hf_named_tensors:
@@ -532,10 +534,18 @@ def _send_to_colocated_engine(
             )
 
         else:
-            num_dtypes = len(serialized_named_tensors[0])
-            for i in range(num_dtypes):
+            empty_serialized_tensor = None
+            for column in align_serialized_bucket_columns(serialized_named_tensors):
+                if any(item is None for item in column):
+                    if empty_serialized_tensor is None:
+                        empty_tensor_data = empty_flattened_tensor_data(device=torch.cuda.current_device())
+                        long_live_tensors.append(empty_tensor_data)
+                        empty_serialized_tensor = MultiprocessingSerializer.serialize(
+                            empty_tensor_data, output_str=True
+                        )
+                    column = [item if item is not None else empty_serialized_tensor for item in column]
                 kwargs = {
-                    "serialized_named_tensors": [tensors[i] for tensors in serialized_named_tensors],
+                    "serialized_named_tensors": column,
                     "load_format": "flattened_bucket",
                     "weight_version": str(weight_version),
                     "selector": selector,

--- a/miles/backends/training_utils/serialized_buckets.py
+++ b/miles/backends/training_utils/serialized_buckets.py
@@ -1,0 +1,25 @@
+"""Align per-rank serialized weight buckets after a colocated gather."""
+
+from collections.abc import Sequence
+
+import torch
+
+
+def align_serialized_bucket_columns(per_rank_buckets: Sequence[Sequence[object]]) -> list[list[object | None]]:
+    """Zip per-rank bucket lists into columns.
+
+    A short rank (including an empty one) contributes ``None`` so the gather
+    source can pad instead of indexing past the list.
+    """
+    if not per_rank_buckets:
+        return []
+    width = max(len(buckets) for buckets in per_rank_buckets)
+    return [[buckets[i] if i < len(buckets) else None for buckets in per_rank_buckets] for i in range(width)]
+
+
+def empty_flattened_tensor_data(*, device: torch.device | str | int) -> dict:
+    """Placeholder flattened bucket for a rank that contributed no tensors."""
+    return {
+        "flattened_tensor": torch.empty(0, dtype=torch.uint8, device=device),
+        "metadata": [],
+    }

--- a/tests/fast/backends/training_utils/test_serialized_buckets.py
+++ b/tests/fast/backends/training_utils/test_serialized_buckets.py
@@ -1,0 +1,154 @@
+from types import SimpleNamespace
+
+import torch
+
+from miles.backends.fsdp_utils import update_weight_utils as fsdp_update_weight
+from miles.backends.megatron_utils.update_weight import update_weight_from_tensor as megatron_update_weight
+from miles.backends.training_utils.serialized_buckets import (
+    align_serialized_bucket_columns,
+    empty_flattened_tensor_data,
+)
+
+
+class _RemoteMethod:
+    def __init__(self, result=None):
+        self.calls = []
+        self.result = result
+
+    def remote(self, **kwargs):
+        self.calls.append(kwargs)
+        return self.result
+
+
+class _Engine:
+    def __init__(self):
+        self.update_weights_from_tensor = _RemoteMethod({"success": True})
+        self.flush_cache = _RemoteMethod()
+
+
+class _RejectBucketConstruction:
+    supports_multi_dtypes = True
+
+    def __init__(self, **_kwargs):
+        raise AssertionError("an empty rank must not construct FlattenedTensorBucket")
+
+
+class _IdentitySerializer:
+    @staticmethod
+    def serialize(value, *, output_str):
+        assert output_str is True
+        return value
+
+
+def _source_dist(remote_buckets):
+    def gather_object(obj, object_gather_list, **_kwargs):
+        object_gather_list[:] = [obj, remote_buckets]
+
+    return SimpleNamespace(
+        get_rank=lambda: 0,
+        get_world_size=lambda _group=None: 2,
+        gather_object=gather_object,
+    )
+
+
+def _patch_transport(monkeypatch, module, remote_buckets):
+    empty_data = {"flattened_tensor": "empty", "metadata": []}
+    monkeypatch.setattr(module, "dist", _source_dist(remote_buckets))
+    monkeypatch.setattr(module, "FlattenedTensorBucket", _RejectBucketConstruction)
+    monkeypatch.setattr(module, "MultiprocessingSerializer", _IdentitySerializer)
+    monkeypatch.setattr(module, "empty_flattened_tensor_data", lambda *, device: empty_data)
+    monkeypatch.setattr(module.torch.cuda, "current_device", lambda: 0)
+    return empty_data
+
+
+def test_all_empty_ranks_yield_no_columns():
+    assert align_serialized_bucket_columns([[], []]) == []
+
+
+def test_short_rank_pads_with_none():
+    remote = {"flattened_tensor": ("remote",), "metadata": ("w",)}
+    assert align_serialized_bucket_columns([[], [remote]]) == [[None, remote]]
+
+
+def test_ragged_dtype_counts_pad_later_columns():
+    a0, a1, b0 = "a0", "a1", "b0"
+    assert align_serialized_bucket_columns([[a0, a1], [b0]]) == [[a0, b0], [a1, None]]
+
+
+def test_empty_flattened_tensor_data_is_zero_length_uint8_payload():
+    data = empty_flattened_tensor_data(device="cpu")
+
+    assert data["flattened_tensor"].dtype is torch.uint8
+    assert data["flattened_tensor"].numel() == 0
+    assert data["metadata"] == []
+
+
+def test_megatron_all_empty_gather_is_noop(monkeypatch):
+    _patch_transport(monkeypatch, megatron_update_weight, remote_buckets=[])
+    engine = _Engine()
+
+    refs, long_live_tensors = megatron_update_weight._send_to_colocated_engine(
+        [],
+        ipc_engine=engine,
+        ipc_gather_src=0,
+        ipc_gather_group=object(),
+        weight_version=7,
+    )
+
+    assert refs == []
+    assert long_live_tensors == []
+    assert engine.update_weights_from_tensor.calls == []
+
+
+def test_megatron_empty_source_is_padded_for_each_remote_bucket(monkeypatch):
+    remote_buckets = ["remote-0", "remote-1"]
+    empty_data = _patch_transport(monkeypatch, megatron_update_weight, remote_buckets=remote_buckets)
+    engine = _Engine()
+
+    refs, long_live_tensors = megatron_update_weight._send_to_colocated_engine(
+        [],
+        ipc_engine=engine,
+        ipc_gather_src=0,
+        ipc_gather_group=object(),
+        weight_version=7,
+    )
+
+    assert refs == [{"success": True}, {"success": True}]
+    assert long_live_tensors == [empty_data]
+    assert engine.update_weights_from_tensor.calls == [
+        {
+            "serialized_named_tensors": [empty_data, "remote-0"],
+            "load_format": "flattened_bucket",
+            "weight_version": "7",
+            "selector": "all",
+        },
+        {
+            "serialized_named_tensors": [empty_data, "remote-1"],
+            "load_format": "flattened_bucket",
+            "weight_version": "7",
+            "selector": "all",
+        },
+    ]
+
+
+def test_fsdp_empty_source_is_padded_for_remote_bucket(monkeypatch):
+    empty_data = _patch_transport(monkeypatch, fsdp_update_weight, remote_buckets=["remote"])
+    monkeypatch.setattr(fsdp_update_weight, "monkey_patch_torch_reductions", lambda: None)
+    monkeypatch.setattr(fsdp_update_weight.ray, "get", lambda ref: ref)
+    engine = _Engine()
+    updater = fsdp_update_weight.UpdateWeightFromTensor.__new__(fsdp_update_weight.UpdateWeightFromTensor)
+    updater._ipc_gather_src = 0
+    updater._ipc_gather_group = object()
+    updater._ipc_engine = engine
+
+    updater.update_bucket_weights([], weight_version=7)
+
+    assert engine.update_weights_from_tensor.calls == [
+        {
+            "serialized_named_tensors": [empty_data, "remote"],
+            "load_format": "flattened_bucket",
+            "flush_cache": False,
+            "weight_version": "7",
+        }
+    ]
+    assert engine.flush_cache.calls == [{}]


### PR DESCRIPTION
Twin of [THUDM/slime#2134](https://github.com/THUDM/slime/pull/2134), adapted to the current `radixark/miles` `main` and the shared Megatron/FSDP weight-sync paths.

## Problem

Colocated raw weight sync assumed every TP rank produced the same number of serialized dtype buckets. A rank with no tensors could either construct `FlattenedTensorBucket([])` before participating in the Gloo gather, or leave the gather source indexing a missing column when ranks had ragged bucket counts. Uneven PP/EP/MoE layouts can expose both cases.

## Fix

Empty local chunks now participate in `gather_object` with an empty list. After the gather, per-rank lists are aligned to the widest non-empty rank, and missing entries receive a lazily created, reusable zero-length serialized bucket. All-empty gathers remain no-ops. The alignment and placeholder construction live in one shared helper used by both Megatron and FSDP.

The SGLang receiver selects the serialized entry for its own TP rank and synchronizes once per update call. Padding therefore preserves equal call counts while giving ranks without tensors a valid no-op payload.

## Validation

- Changed-file pre-commit checks passed.
- Focused backend suite: 33 passed.
- Real CUDA IPC against the repository-pinned SGLang receiver: two spawned consumers each deserialized and reconstructed the same placeholder twice; every payload had zero elements and reconstructed to zero tensors.
- Full regular `stage-a-cpu` suite: 5,794 passed, 32 skipped.

GitHub-hosted exact-head workflows are awaiting maintainer approval; applying the `run-ci-weight-update` label will approve and run them.
