### PR TITLE
fix(ppo): preserve raw KL metric tensor

### DIFF
--- a/miles/backends/training_utils/loss_hub/advantages.py
+++ b/miles/backends/training_utils/loss_hub/advantages.py
@@ -60,9 +60,8 @@ def compute_advantages(
         terminal_rewards = rewards
         token_rewards = []
         kl_coef = -args.kl_coef
-        for k in kl:
-            k *= kl_coef
-            token_rewards.append(k)
+        for per_token_kl in kl:
+            token_rewards.append(per_token_kl * kl_coef)
         advantages, returns = get_advantages_and_returns_batch(
             total_lengths=total_lengths,
             response_lengths=response_lengths,

--- a/tests/fast/backends/training_utils/loss/test_ppo_kl_metric.py
+++ b/tests/fast/backends/training_utils/loss/test_ppo_kl_metric.py
@@ -1,0 +1,24 @@
+import torch
+
+from miles.backends.training_utils.loss_hub.advantages import compute_advantages
+
+from .loss_test_utils import make_args, make_parallel_state
+
+
+def test_ppo_advantages_preserve_raw_kl_metric():
+    make_parallel_state()
+    raw_kl = torch.tensor([0.2, -0.1, 0.4], dtype=torch.float32)
+    kl = [raw_kl.clone()]
+
+    compute_advantages(
+        args=make_args(advantage_estimator="ppo", kl_coef=0.05),
+        kl=kl,
+        rewards=[1.5],
+        log_probs=[torch.zeros_like(raw_kl)],
+        loss_masks=[torch.ones_like(raw_kl)],
+        total_lengths=[5],
+        response_lengths=[3],
+        values=[torch.zeros_like(raw_kl)],
+    )
+
+    assert torch.equal(kl[0], raw_kl)


### PR DESCRIPTION
Port of THUDM/slime#2114 for miles' refactored advantage helper. Recut onto current `main`.

Summary:
- build PPO token-level rewards out of place instead of mutating the `kl` tensor list
- preserve the raw approximate KL tensor used by rollout/kl logging
- add a CPU test directly on `compute_advantages`

Validation:
- test fails on the old `k *= kl_coef` in-place loop
- test passes after the out-of-place multiply