### PR TITLE
fix(train): support eval-only mode (--num-rollout 0)

### DIFF
--- a/miles/backends/fsdp_utils/lr_scheduler.py
+++ b/miles/backends/fsdp_utils/lr_scheduler.py
@@ -9,6 +9,8 @@ import torch
 from torch.optim.lr_scheduler import LRScheduler
 from typing_extensions import override
 
+from miles.backends.training_utils.train_iters import compute_train_iters
+
 logger = logging.getLogger(__name__)
 
 
@@ -167,7 +169,7 @@ def get_lr_scheduler(args, optimizer: torch.optim.Optimizer) -> FSDPLRScheduler:
     Returns:
         FSDPLRScheduler: Initialized scheduler bound to ``optimizer``.
     """
-    args.train_iters = args.num_rollout * args.rollout_batch_size * args.n_samples_per_prompt // args.global_batch_size
+    args.train_iters = compute_train_iters(args)
     if args.lr_decay_iters is None:
         args.lr_decay_iters = args.train_iters
     lr_decay_steps = args.lr_decay_iters

--- a/miles/backends/megatron_utils/model.py
+++ b/miles/backends/megatron_utils/model.py
@@ -38,6 +38,7 @@ from miles.utils.tracking_utils.structured_log import log_structured
 
 from ...utils.misc import filter_keys
 from ..training_utils.ci_utils import check_grad_norm, check_kl
+from ..training_utils.train_iters import compute_train_iters
 from ..training_utils.data import DataIterator, get_batch
 from ..training_utils.log_utils import aggregate_forward_results, aggregate_train_losses, log_train_step
 from ..training_utils.loss import loss_function
@@ -79,7 +80,7 @@ def get_optimizer_param_scheduler(args: Namespace, optimizer: MegatronOptimizer)
         OptimizerParamScheduler: Initialized scheduler bound to ``optimizer``.
     """
     # Iteration-based training.
-    args.train_iters = args.num_rollout * args.rollout_batch_size * args.n_samples_per_prompt // args.global_batch_size
+    args.train_iters = compute_train_iters(args)
     if args.lr_decay_iters is None:
         args.lr_decay_iters = args.train_iters
     lr_decay_steps = args.lr_decay_iters * args.global_batch_size

--- a/miles/backends/training_utils/train_iters.py
+++ b/miles/backends/training_utils/train_iters.py
@@ -1,0 +1,21 @@
+"""Compute Megatron/FSDP scheduler `train_iters` from rollout settings."""
+
+from argparse import Namespace
+
+
+def compute_train_iters(args: Namespace) -> int:
+    """Return the iteration count used to size the LR/WD schedule.
+
+    Eval-only (`--num-rollout 0`) still constructs the scheduler, and Megatron
+    asserts `lr_decay_steps > 0`, so that case is 1 rather than 0.
+    """
+    if args.num_rollout == 0:
+        return 1
+    estimated = args.num_rollout * args.rollout_batch_size * args.n_samples_per_prompt // args.global_batch_size
+    if estimated <= 0:
+        total_samples = args.num_rollout * args.rollout_batch_size * args.n_samples_per_prompt
+        raise ValueError(
+            f"Invalid training configuration: total samples ({total_samples}) "
+            f"must be at least global_batch_size ({args.global_batch_size})."
+        )
+    return estimated

--- a/tests/fast/backends/training_utils/test_train_iters.py
+++ b/tests/fast/backends/training_utils/test_train_iters.py
@@ -1,0 +1,21 @@
+from argparse import Namespace
+
+import pytest
+
+from miles.backends.training_utils.train_iters import compute_train_iters
+
+
+def test_eval_only_num_rollout_zero_is_one_iter():
+    args = Namespace(num_rollout=0, rollout_batch_size=8, n_samples_per_prompt=8, global_batch_size=16)
+    assert compute_train_iters(args) == 1
+
+
+def test_normal_run_uses_integer_division():
+    args = Namespace(num_rollout=4, rollout_batch_size=8, n_samples_per_prompt=8, global_batch_size=16)
+    assert compute_train_iters(args) == 16
+
+
+def test_too_few_samples_raises():
+    args = Namespace(num_rollout=1, rollout_batch_size=1, n_samples_per_prompt=1, global_batch_size=16)
+    with pytest.raises(ValueError, match="global_batch_size"):
+        compute_train_iters(args)


### PR DESCRIPTION
Port of THUDM/slime#2109 for miles.

Summary:
- compute estimated train iterations once
- clamp the scheduler-visible `train_iters` to at least 1 so Megatron LR decay steps stay valid
- keep the training loop semantics controlled by `args.num_rollout`; eval-only still performs zero training rollouts
- reject positive-rollout configs with zero training iterations instead of silently papering over an inconsistent train setup

Validation:
- `uv run --with pytest --with torch pytest --confcutdir=tests/fast/backends/megatron_utils tests/fast/backends/megatron_utils/test_eval_only_optimizer_scheduler.py -q` -> 3 passed
