### PR TITLE
fix(dist): preserve new_group options across reload

### DIFF
--- a/miles/utils/reloadable_process_group.py
+++ b/miles/utils/reloadable_process_group.py
@@ -12,6 +12,21 @@ logger = logging.getLogger(__name__)
 old_new_group_dict = {}
 
 
+def _is_gloo_group(args, kwargs):
+    backend = kwargs.get("backend")
+    if backend is None and len(args) >= 3:
+        backend = args[2]
+    return backend is not None and str(backend).lower() == "gloo"
+
+
+def _get_group_ranks(args, kwargs):
+    if len(args) >= 1 and args[0] is not None:
+        return args[0]
+    if "ranks" in kwargs and kwargs["ranks"] is not None:
+        return kwargs["ranks"]
+    return list(range(dist.get_world_size()))
+
+
 def monkey_patch_torch_dist():
     pid = os.getpid()
     if pid in old_new_group_dict:
@@ -27,22 +42,14 @@ def monkey_patch_torch_dist():
     def new_group(*args, **kwargs):
         group = old_new_group(*args, **kwargs)
         # skip none nccl group.
-        if len(args) >= 3 and args[2] == "gloo" or "backend" in kwargs and kwargs["backend"] == "gloo":
+        if _is_gloo_group(args, kwargs):
             return group
 
-        # Get ranks from arguments
-        if len(args) >= 1 and args[0] is not None:
-            ranks = args[0]
-        elif "ranks" in kwargs and kwargs["ranks"] is not None:
-            ranks = kwargs["ranks"]
-        else:
-            # If no ranks specified, use all ranks in world
-            ranks = list(range(dist.get_world_size()))
-
+        ranks = _get_group_ranks(args, kwargs)
         if len(ranks) == 1:
             return group
 
-        group = ReloadableProcessGroup(group, ranks)
+        group = ReloadableProcessGroup(group, ranks, args, kwargs)
         return group
 
     dist.new_group = new_group
@@ -112,7 +119,7 @@ def monkey_patch_torch_dist():
 class ReloadableProcessGroup(torch.distributed.ProcessGroup):
     GROUPS = {}
 
-    def __init__(self, group, ranks):
+    def __init__(self, group, ranks, group_args=(), group_kwargs=None):
         super().__init__(
             rank=dist.get_rank(group),
             size=dist.get_world_size(group),
@@ -120,6 +127,8 @@ class ReloadableProcessGroup(torch.distributed.ProcessGroup):
         self.group = group
         self.group_info = {
             "ranks": ranks,
+            "args": tuple(group_args),
+            "kwargs": dict(group_kwargs or {}),
         }
         pid = os.getpid()
         if pid not in ReloadableProcessGroup.GROUPS:
@@ -155,7 +164,10 @@ class ReloadableProcessGroup(torch.distributed.ProcessGroup):
         for reloadable_group in reloadable_groups:
             if reloadable_group.group is not None:
                 continue
-            group = old_new_group(ranks=reloadable_group.group_info["ranks"], backend="nccl")
+            group = old_new_group(
+                *reloadable_group.group_info["args"],
+                **reloadable_group.group_info["kwargs"],
+            )
             reloadable_group.group = group
 
     def rank(self) -> int:

--- a/miles/utils/reloadable_process_group.py
+++ b/miles/utils/reloadable_process_group.py
@@ -127,7 +127,7 @@ class ReloadableProcessGroup(torch.distributed.ProcessGroup):
         self.group = group
         self.group_info = {
             "ranks": ranks,
-            "args": tuple(group_args),
+            "args": tuple(group_args or ()),
             "kwargs": dict(group_kwargs or {}),
         }
         pid = os.getpid()
@@ -164,6 +164,8 @@ class ReloadableProcessGroup(torch.distributed.ProcessGroup):
         for reloadable_group in reloadable_groups:
             if reloadable_group.group is not None:
                 continue
+            if old_new_group is None:
+                raise RuntimeError(f"monkey_patch_torch_dist has not been called for pid {pid}")
             group = old_new_group(
                 *reloadable_group.group_info["args"],
                 **reloadable_group.group_info["kwargs"],

--- a/tests/fast/utils/test_reloadable_process_group.py
+++ b/tests/fast/utils/test_reloadable_process_group.py
@@ -1,0 +1,94 @@
+from datetime import timedelta
+from types import SimpleNamespace
+
+from miles.utils import reloadable_process_group as rpg
+
+
+class _FakeP2POp:
+    def __new__(cls, *args, **kwargs):
+        return object.__new__(cls)
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+
+class _FakeGroup:
+    pass
+
+
+def _noop(*args, **kwargs):
+    return None
+
+
+def _fake_dist(new_group, destroyed):
+    def get_rank(group=None):
+        return 0
+
+    def get_world_size(group=None):
+        return 2
+
+    return SimpleNamespace(
+        new_group=new_group,
+        get_rank=get_rank,
+        get_world_size=get_world_size,
+        get_backend=_noop,
+        get_global_rank=_noop,
+        get_group_rank=_noop,
+        get_process_group_ranks=_noop,
+        all_reduce=_noop,
+        all_gather=_noop,
+        all_gather_object=_noop,
+        all_gather_into_tensor=_noop,
+        all_to_all=_noop,
+        all_to_all_single=_noop,
+        broadcast=_noop,
+        broadcast_object_list=_noop,
+        reduce=_noop,
+        reduce_scatter=_noop,
+        reduce_scatter_tensor=_noop,
+        scatter=_noop,
+        gather=_noop,
+        barrier=_noop,
+        send=_noop,
+        recv=_noop,
+        _coalescing_manager=_noop,
+        isend=_noop,
+        irecv=_noop,
+        P2POp=_FakeP2POp,
+        destroy_process_group=lambda group: destroyed.append(group),
+    )
+
+
+def test_reload_process_groups_preserves_new_group_options(monkeypatch):
+    pid = 12345
+    calls = []
+    destroyed = []
+    timeout = timedelta(minutes=120)
+    pg_options = object()
+
+    def fake_new_group(*args, **kwargs):
+        group = _FakeGroup()
+        calls.append((args, dict(kwargs), group))
+        return group
+
+    monkeypatch.setattr(rpg, "dist", _fake_dist(fake_new_group, destroyed))
+    monkeypatch.setattr(rpg, "old_new_group_dict", {})
+    monkeypatch.setattr(rpg.ReloadableProcessGroup, "GROUPS", {})
+    monkeypatch.setattr(rpg.os, "getpid", lambda: pid)
+
+    rpg.monkey_patch_torch_dist()
+
+    group = rpg.dist.new_group([0, 1], backend="nccl", timeout=timeout, pg_options=pg_options)
+    first_inner_group = calls[-1][2]
+    assert group.group is first_inner_group
+
+    rpg.ReloadableProcessGroup.destroy_process_groups()
+    assert group.group is None
+    assert destroyed == [first_inner_group]
+
+    rpg.ReloadableProcessGroup.reload_process_groups()
+    assert group.group is calls[-1][2]
+    assert calls[-1][0] == ([0, 1],)
+    assert calls[-1][1]["backend"] == "nccl"
+    assert calls[-1][1]["timeout"] is timeout
+    assert calls[-1][1]["pg_options"] is pg_options


### PR DESCRIPTION
Port of THUDM/slime#2095 for miles.

Summary:
- capture original `torch.distributed.new_group` positional args and kwargs
- replay that exact constructor contract when reloadable process groups are rebuilt
- preserve timeout, pg_options, and future new_group options instead of hardcoding `{ranks, backend=nccl}`

Validation:
- `uv run --with pytest --with torch --with psutil --with numpy pytest --confcutdir=tests/fast/utils tests/fast/utils/test_reloadable_process_group.py -q` -> 1 passed