### PR TITLE
fix(opd): score teacher at rollout temperature

### DIFF
--- a/miles/rollout/on_policy_distillation.py
+++ b/miles/rollout/on_policy_distillation.py
@@ -277,8 +277,9 @@ def _compute_topk_reverse_kl(
 
 async def reward_func(args: Namespace, sample: Sample, **kwargs: Any) -> dict[str, Any]:
     top_k = _get_opd_top_k(args)
+    temperature = args.rollout_temperature
     if top_k == 0:
-        return await _post_json(args.rm_url, _score_payload(sample.tokens, temperature=args.rollout_temperature))
+        return await _post_json(args.rm_url, _score_payload(sample.tokens, temperature=temperature))
 
     strategy = _get_top_k_strategy(args)
 
@@ -291,7 +292,7 @@ async def reward_func(args: Namespace, sample: Sample, **kwargs: Any) -> dict[st
         sample.tokens,
         top_k=top_k if strategy in TEACHER_TOP_STRATEGIES else 0,
         token_ids=teacher_token_ids,
-        temperature=args.rollout_temperature,
+        temperature=temperature,
     )
     teacher_response = await _post_json(args.rm_url, teacher_payload)
 
@@ -301,7 +302,7 @@ async def reward_func(args: Namespace, sample: Sample, **kwargs: Any) -> dict[st
         student_token_ids = _unique_ids(teacher_top)
         reward_payload["student_on_teacher"] = await _post_json(
             _student_score_url(args),
-            _score_payload(sample.tokens, token_ids=student_token_ids, temperature=args.rollout_temperature),
+            _score_payload(sample.tokens, token_ids=student_token_ids, temperature=temperature),
         )
 
     return reward_payload

--- a/miles/rollout/on_policy_distillation.py
+++ b/miles/rollout/on_policy_distillation.py
@@ -38,11 +38,17 @@ def _get_reward_weight_mode(args: Namespace) -> str:
     return mode
 
 
-def _score_payload(input_ids: list[int], top_k: int = 0, token_ids: list[int] | None = None) -> dict[str, Any]:
+def _score_payload(
+    input_ids: list[int],
+    top_k: int = 0,
+    token_ids: list[int] | None = None,
+    *,
+    temperature: float = 0,
+) -> dict[str, Any]:
     payload = {
         "input_ids": input_ids,
         "sampling_params": {
-            "temperature": 0,
+            "temperature": temperature,
             "max_new_tokens": 0,
             "skip_special_tokens": False,
         },
@@ -272,7 +278,7 @@ def _compute_topk_reverse_kl(
 async def reward_func(args: Namespace, sample: Sample, **kwargs: Any) -> dict[str, Any]:
     top_k = _get_opd_top_k(args)
     if top_k == 0:
-        return await _post_json(args.rm_url, _score_payload(sample.tokens))
+        return await _post_json(args.rm_url, _score_payload(sample.tokens, temperature=args.rollout_temperature))
 
     strategy = _get_top_k_strategy(args)
 
@@ -285,6 +291,7 @@ async def reward_func(args: Namespace, sample: Sample, **kwargs: Any) -> dict[st
         sample.tokens,
         top_k=top_k if strategy in TEACHER_TOP_STRATEGIES else 0,
         token_ids=teacher_token_ids,
+        temperature=args.rollout_temperature,
     )
     teacher_response = await _post_json(args.rm_url, teacher_payload)
 
@@ -294,7 +301,7 @@ async def reward_func(args: Namespace, sample: Sample, **kwargs: Any) -> dict[st
         student_token_ids = _unique_ids(teacher_top)
         reward_payload["student_on_teacher"] = await _post_json(
             _student_score_url(args),
-            _score_payload(sample.tokens, token_ids=student_token_ids),
+            _score_payload(sample.tokens, token_ids=student_token_ids, temperature=args.rollout_temperature),
         )
 
     return reward_payload

--- a/tests/fast/rollout/test_on_policy_distillation.py
+++ b/tests/fast/rollout/test_on_policy_distillation.py
@@ -1,10 +1,11 @@
+import asyncio
 import math
 from argparse import Namespace
 
 import pytest
 from tests.ci.ci_register import register_cpu_ci
 
-from miles.rollout.on_policy_distillation import _compute_topk_reverse_kl
+from miles.rollout.on_policy_distillation import _compute_topk_reverse_kl, reward_func
 from miles.utils.types import Sample
 
 register_cpu_ci(est_time=60, suite="stage-a-cpu")
@@ -100,3 +101,22 @@ def test_topk_xor_uses_symmetric_difference_without_normalization():
     expected_1 = math.log(0.3 / 0.6) + math.log(0.1 / 0.2)
 
     assert reverse_kl.tolist() == pytest.approx([expected_0, expected_1])
+
+
+def test_reward_func_scores_teacher_at_rollout_temperature(monkeypatch):
+    calls = []
+
+    async def fake_post_json(url, payload):
+        calls.append((url, payload))
+        return {"meta_info": {"input_token_logprobs": [None, [0.0, 12]]}}
+
+    monkeypatch.setattr("miles.rollout.on_policy_distillation._post_json", fake_post_json)
+    args = Namespace(
+        rm_url="http://teacher/generate",
+        rollout_temperature=0.8,
+        opd_log_prob_top_k=0,
+    )
+
+    asyncio.run(reward_func(args, Sample(tokens=[10, 11, 12], response_length=1)))
+
+    assert calls[0][1]["sampling_params"]["temperature"] == 0.8


### PR DESCRIPTION
Port of THUDM/slime#2085 for miles' OPD rollout helper.

Summary:
- score OPD teacher logprobs with the configured `args.rollout_temperature` instead of hardcoded temperature 0
- apply the same scoring temperature through the top-k teacher and student-on-teacher paths
- keep `_score_payload`'s helper default for direct callers while `reward_func` uses the typed rollout config directly

Validation:
- `uv run --with pytest --with torch --with aiohttp --with numpy pytest --confcutdir=tests/fast/rollout tests/fast/rollout/test_on_policy_distillation.py -q` -> 5 passed
