### PR TITLE
fix(update_weight): skip flush_cache for retract pause mode

### DIFF
--- a/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/mixin.py
+++ b/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/mixin.py
@@ -267,7 +267,10 @@ class DistBucketedWeightUpdateMixin:
         if dist.get_rank() == 0:
             mode = self.args.pause_generation_mode
             ray.get([engine.pause_generation.remote(mode=mode) for engine in self.rollout_engines])
-            if mode not in ("in_place"):
+            # retract already frees the in-flight requests' KV (they sit in the waiting
+            # queue), so a prefix-cache flush is unneeded; skipping it also avoids SGLang's
+            # /flush_cache HTTP 400 ("pending requests") which times out under a paused engine.
+            if mode not in ("in_place", "retract"):
                 ray.get([engine.flush_cache.remote() for engine in self.rollout_engines])
 
             begin_weight_update(self.rollout_engines)


### PR DESCRIPTION
## Summary
- \`_pause_and_prepare_engines\` (broadcast weight-update path) skips the SGLang prefix-cache flush for \`retract\` pause mode, same as \`in_place\`.
- \`retract\` already moves in-flight requests to the waiting queue and frees their KV, so flushing the prefix/radix cache is unnecessary for correctness.
- Skipping it fixes a hard crash in fully-async + session-server runs: at the first weight update whose waiting queue is non-empty, SGLang \`/flush_cache\` returns HTTP 400 (\"pending requests\") and \`SGLangEngine.flush_cache\` retries 60x with no sleep, raising \`TimeoutError\` that cascades into \`update_weights()\` and kills the job.
- Also converts the \`(\"in_place\")\` string literal into a proper tuple (it previously matched only via substring membership).

## Why
DeepSeek-V4-Flash agentic RL (fully-async rollout + off-cluster session server) needs \`retract\` to avoid the in_place TP-broadcast deadlock, but \`retract\` then died at the step-5 weight update on this flush. Verified by py-spy + engine logs (#queue-req>0, #running-req:0).

## Test plan
- [ ] Relaunch dpsk-v4-flash async run with \`--pause-generation-mode retract\`; confirm it clears the step-5 weight update (previously the crash point).