### PR TITLE
feat(loss): support pg_loss aggregation modes

### DIFF
--- a/docs/user-guide/cli-reference.md
+++ b/docs/user-guide/cli-reference.md
@@ -237,7 +237,9 @@ Sections mirror the launch-script argument groups.
 | `--use-tis` | flag | off | Truncated Importance Sampling. |
 | `--use-routing-replay` | flag | off | Forward/backward routing consistency. |
 | `--use-rollout-routing-replay` | flag | off | R3 — capture inference-side expert routing and replay it during training. |
-| `--calculate-per-token-loss` | flag | off | Per-token loss reduction. |
+| `--calculate-per-token-loss` | flag | off | Legacy alias for `--loss-aggregation token_mean` (global per-token mean); kept for backward compatibility. Prefer `--loss-aggregation token_mean`. |
+| `--loss-aggregation` | enum | `sample_mean` | How pg_loss is aggregated (pg_loss only): `sample_mean` (GRPO), `prompt_mean` (DAPO), `token_mean` (= legacy `--calculate-per-token-loss`), `constant` (Dr.GRPO). See [customization](/user-guide/customization). |
+| `--loss-aggregation-divisor` | float | unset | Positive finite divisor `L` for `--loss-aggregation constant`; the final denominator is `L * global_batch_size`. |
 | `--no-check-for-nan-in-loss-and-grad` | flag | off | Skip NaN/Inf guard (Megatron flag, debug only). |
 | `--true-on-policy-mode` | flag | off | Strict on-policy: reject samples from a prior policy. |
 

--- a/docs/user-guide/customization.md
+++ b/docs/user-guide/customization.md
@@ -190,8 +190,54 @@ def get_pg_loss_reducer(
     ...
 ```
 
-Use case: Dr.GRPO divides by a constant instead of effective token count.
+Use case: a normalization not covered by `--loss-aggregation` below. The four
+standard modes are available first class; reach for this hook only for a custom
+reducer. When set, it takes precedence over `--loss-aggregation`.
 **Reference:** [`examples/DrGRPO/custom_reducer.py`](https://github.com/radixark/miles/blob/main/examples/DrGRPO/custom_reducer.py).
+
+### `--loss-aggregation`
+
+For one optimizer step, let `m_i` be the active-token count for sample `i`,
+`N` the sample count, `P` the prompt-group count, and `L` the configured
+constant divisor. The final policy-gradient scalar is:
+
+| Mode | Final scalar |
+| :--- | :--- |
+| `sample_mean` (default) | `(1 / N) * sum_i(sum_t loss_it * mask_it / max(m_i, 1))` |
+| `prompt_mean` | `(1 / P) * sum_g(sum_(i,t in g) loss_it * mask_it / max(sum_(i in g) m_i, 1))` |
+| `token_mean` | `sum_(i,t) loss_it * mask_it / sum_i m_i` |
+| `constant` | `sum_(i,t) loss_it * mask_it / (L * N)` |
+
+`sample_mean` preserves the previous default. `prompt_mean` is the DAPO-style
+prompt average, `token_mean` is a global active-token mean, and `constant` is
+the fixed-denominator form used by Dr.GRPO. `--loss-aggregation-divisor L`
+must be positive and finite and is accepted only for `constant`. `token_mean`
+rejects an optimizer step with no active tokens.
+
+`--calculate-per-token-loss` remains an alias for `--loss-aggregation
+token_mean`; new recipes should use the explicit mode. The legacy flag promotes
+`sample_mean` to `token_mean` and is rejected with `prompt_mean` or `constant`.
+When both keys appear in custom YAML, their values must agree. Both Megatron
+and FSDP apply the token denominator over the full data-parallel optimizer step.
+
+The mode changes `pg_loss`, not diagnostic metrics such as `pg_clipfrac` and
+`ppo_kl`, which remain sample means. In `token_mean`, the logged `loss`,
+`pg_loss`, and `ess_ratio` use the token denominator. Nonzero entropy or KL
+loss coefficients are rejected with `token_mean` because those auxiliary
+terms still use sample normalization.
+
+`prompt_mean` requires complete groups of exactly `n_samples_per_prompt`.
+Miles keeps groups within one optimizer step and validates custom converter
+metadata before training. A custom converter must emit one
+`prompt_group_indices` and one `prompt_mask_sums` value per sample; each
+`prompt_mask_sums` value is the total active-token count for that sample's
+group.
+
+The built-in TIS path preserves the loss mask and works with every mode. A
+custom TIS/RS function may change masks after data has been split into
+microbatches, so Miles rejects custom TIS with `prompt_mean` or `token_mean`
+rather than applying a stale step-level denominator. `sample_mean` and
+`constant` remain available with custom TIS/RS.
 
 ### `--custom-convert-samples-to-train-data-path`
 
@@ -212,6 +258,9 @@ def convert_samples_to_train_data(args, samples) -> dict:
         "metadata":                [...],
         "multimodal_train_inputs": [...],
         "teacher_log_probs":       [...],
+        # required when args.loss_aggregation == "prompt_mean"
+        "prompt_group_indices":    [...],
+        "prompt_mask_sums":        [...],
     }
 ```
 

--- a/miles/backends/experimental/fsdp_utils/actor.py
+++ b/miles/backends/experimental/fsdp_utils/actor.py
@@ -30,7 +30,13 @@ from ...training_utils.log_utils import (
     log_rollout_data,
     log_train_step,
 )
-from ...training_utils.loss import compute_advantages_and_returns, get_log_probs_and_entropy, loss_function
+from ...training_utils.loss import (
+    compute_advantages_and_returns,
+    get_log_probs_and_entropy,
+    get_token_counts_by_step,
+    loss_function,
+    scale_data_parallel_token_mean_loss,
+)
 from ...training_utils.parallel import get_parallel_state, set_parallel_state
 from . import checkpoint
 from .lr_scheduler import get_lr_scheduler
@@ -42,6 +48,16 @@ if TYPE_CHECKING:
     from miles.utils.audit_utils.witness.allocator import WitnessInfo
 
 logger = logging.getLogger(__name__)
+
+
+def _global_token_counts_by_step(loss_masks: list[torch.Tensor], num_steps: int) -> list[torch.Tensor]:
+    counts = get_token_counts_by_step(loss_masks, num_steps)
+    data_parallel = get_parallel_state().effective_dp
+    if data_parallel.size > 1:
+        dist.all_reduce(counts, op=dist.ReduceOp.SUM, group=data_parallel.group)
+    if torch.any(counts <= 0):
+        raise ValueError(f"token_mean requires at least one active token per optimizer step, got {counts.tolist()}.")
+    return list(counts)
 
 
 class FSDPTrainRayActor(TrainRayActor):
@@ -471,6 +487,11 @@ class FSDPTrainRayActor(TrainRayActor):
         with timer("actor_train"):
             data_iterator.reset()
             num_steps_per_rollout = len(num_microbatches)
+            token_counts = (
+                _global_token_counts_by_step(rollout_data["loss_masks"], num_steps_per_rollout)
+                if self.args.calculate_per_token_loss
+                else None
+            )
 
             for step_id in range(num_steps_per_rollout):
                 self.optimizer.zero_grad(set_to_none=True)
@@ -493,6 +514,7 @@ class FSDPTrainRayActor(TrainRayActor):
                             "returns",
                             "ref_log_probs",
                             "rollout_log_probs",
+                            "prompt_mask_sums",
                         ],
                         self.args.data_pad_size_multiplier,
                         self.args.qkv_format,
@@ -503,6 +525,7 @@ class FSDPTrainRayActor(TrainRayActor):
                         batch=batch,
                         step_id=step_id,
                         num_microbatches=num_microbatches[step_id],
+                        global_num_tokens=token_counts[step_id] if token_counts is not None else None,
                     )
                     losses_reduced.append(log_dict)
 
@@ -557,12 +580,12 @@ class FSDPTrainRayActor(TrainRayActor):
             self.ref_model.load_state_dict(actor_state)
             self.ref_model.cpu()
 
-    def _train_step(self, batch, step_id, num_microbatches):
+    def _train_step(self, batch, step_id, num_microbatches, global_num_tokens):
         # Prepare model inputs
         model_args = self._get_model_inputs_args(batch)
         logits = self.model(**model_args).logits.float()
 
-        loss, normalizer, log_dict = loss_function(
+        loss, _, log_dict = loss_function(
             args=self.args,
             batch=batch,
             num_microbatches=num_microbatches,
@@ -570,6 +593,12 @@ class FSDPTrainRayActor(TrainRayActor):
             apply_megatron_loss_scaling=False,
         )
 
+        if global_num_tokens is not None:
+            loss = scale_data_parallel_token_mean_loss(
+                loss,
+                global_num_tokens=global_num_tokens,
+                data_parallel_size=get_parallel_state().effective_dp.size,
+            )
         loss.backward()
 
         return log_dict

--- a/miles/backends/megatron_utils/model.py
+++ b/miles/backends/megatron_utils/model.py
@@ -439,6 +439,7 @@ def train_one_step(
                 "max_seq_lens",
                 "witness_ids",
                 "opd_reverse_kl",
+                "prompt_mask_sums",
             ],
             args.data_pad_size_multiplier,
             args.qkv_format,

--- a/miles/backends/training_utils/cp_utils.py
+++ b/miles/backends/training_utils/cp_utils.py
@@ -1,4 +1,5 @@
 import logging
+import math
 from collections.abc import Callable
 
 import torch
@@ -96,10 +97,25 @@ def get_sum_of_sample_mean(
     calculate_per_token_loss: bool = False,
     qkv_format: str = "thd",
     max_seq_lens: list[int] | None = None,
+    sample_denoms: list[torch.Tensor] | None = None,
+    constant_divisor: float | None = None,
 ) -> Callable[[torch.Tensor], torch.Tensor]:
-    """
-    Calculate correct sample mean for CP
-    """
+    """Build a CP-aware reducer for masked token losses."""
+    configured_modes = sum((calculate_per_token_loss, sample_denoms is not None, constant_divisor is not None))
+    if configured_modes > 1:
+        raise ValueError(
+            "calculate_per_token_loss, sample_denoms, and constant_divisor select mutually exclusive reducers."
+        )
+    if sample_denoms is not None and len(sample_denoms) != len(loss_masks):
+        raise ValueError(f"Expected {len(loss_masks)} sample denominators, got {len(sample_denoms)}.")
+    if constant_divisor is not None and (
+        isinstance(constant_divisor, bool) or not math.isfinite(constant_divisor) or constant_divisor <= 0
+    ):
+        raise ValueError(f"constant_divisor must be positive and finite, got {constant_divisor!r}.")
+
+    if sample_denoms is None and constant_divisor is None and not calculate_per_token_loss:
+        sample_denoms = [loss_mask.sum() for loss_mask in loss_masks]
+
     parallel_state = get_parallel_state()
     cp_size = parallel_state.cp.size
     if cp_size == 1:
@@ -107,8 +123,10 @@ def get_sum_of_sample_mean(
         def sum_of_sample_mean(x: torch.Tensor) -> torch.Tensor:
             return sum(
                 [
-                    (x_i * loss_mask_i).sum() / torch.clamp_min(loss_mask_i.sum(), 1)
-                    for x_i, loss_mask_i in zip(x.split(response_lengths, dim=0), loss_masks, strict=True)
+                    (x_i * loss_mask_i).sum() / torch.clamp_min(denom, 1)
+                    for x_i, loss_mask_i, denom in zip(
+                        x.split(response_lengths, dim=0), loss_masks, sample_denoms, strict=True
+                    )
                 ]
             )
 
@@ -135,9 +153,9 @@ def get_sum_of_sample_mean(
         def sum_of_sample_mean(x: torch.Tensor) -> torch.Tensor:
             return sum(
                 [
-                    (x_i * chunked_loss_mask).sum() / torch.clamp_min(loss_mask.sum(), 1)
-                    for x_i, chunked_loss_mask, loss_mask in zip(
-                        x.split(cp_chunk_lengths, dim=0), chunked_loss_masks, loss_masks, strict=True
+                    (x_i * chunked_loss_mask).sum() / torch.clamp_min(denom, 1)
+                    for x_i, chunked_loss_mask, denom in zip(
+                        x.split(cp_chunk_lengths, dim=0), chunked_loss_masks, sample_denoms, strict=True
                     )
                 ]
             )
@@ -151,6 +169,13 @@ def get_sum_of_sample_mean(
                     )
                 ]
             )
+
+    if constant_divisor is not None:
+
+        def sum_of_constant(x: torch.Tensor) -> torch.Tensor:
+            return sum_of_token(x) / constant_divisor
+
+        return sum_of_constant
 
     return sum_of_sample_mean if not calculate_per_token_loss else sum_of_token
 

--- a/miles/backends/training_utils/data.py
+++ b/miles/backends/training_utils/data.py
@@ -59,6 +59,10 @@ def get_rollout_data(
             for t, sid in zip(rollout_data["tokens"], seq_witness_ids, strict=True)
         ]
 
+    if "prompt_mask_sums" in rollout_data:
+        rollout_data["prompt_mask_sums"] = list(
+            torch.tensor(rollout_data["prompt_mask_sums"], dtype=torch.float32, device=torch.cuda.current_device())
+        )
     if "multimodal_train_inputs" in rollout_data:
         # Move multimodal training tensors to GPU in advance
         rollout_data["multimodal_train_inputs"] = [

--- a/miles/backends/training_utils/log_utils.py
+++ b/miles/backends/training_utils/log_utils.py
@@ -404,24 +404,56 @@ def aggregate_train_losses(
         return {}
 
     keys = losses_reduced[0]["keys"]
+    has_normalizers = "normalizers" in losses_reduced[0]
 
     values = None
+    normalizers = None
     for log_dict in losses_reduced:
+        if log_dict["keys"] != keys:
+            raise ValueError(
+                "All train loss log_dict entries must have the same keys in the same order; "
+                f"got {log_dict['keys']} after {keys}."
+            )
+        if ("normalizers" in log_dict) != has_normalizers:
+            raise ValueError(
+                "Cannot aggregate a mix of train loss log_dict entries with and without explicit normalizers."
+            )
         if values is None:
             values = log_dict["values"].clone()
         else:
             values += log_dict["values"]
+        if "normalizers" in log_dict:
+            if normalizers is None:
+                normalizers = log_dict["normalizers"].clone()
+            else:
+                normalizers += log_dict["normalizers"]
 
-    assert len(keys) + 1 == values.numel(), f"Expected {len(keys) + 1} values, got {values.numel()}"
+    if normalizers is None:
+        if len(keys) + 1 != values.numel():
+            raise ValueError(f"Expected {len(keys) + 1} values, got {values.numel()}")
+    else:
+        if len(keys) != values.numel():
+            raise ValueError(f"Expected {len(keys)} values, got {values.numel()}")
+        if len(keys) != normalizers.numel():
+            raise ValueError(f"Expected {len(keys)} normalizers, got {normalizers.numel()}")
 
     for group in parallel_state.effective_dp_cp.groups_inner_to_outer:
         MultiPGUtil.all_reduce(values, [group], op=dist.ReduceOp.SUM)
+        if normalizers is not None:
+            MultiPGUtil.all_reduce(normalizers, [group], op=dist.ReduceOp.SUM)
 
     loss_reduced = {}
     values = values.tolist()
-    num_samples_or_tokens = values[0]
+    if normalizers is not None:
+        normalizers = normalizers.tolist()
+        for key, value, normalizer in zip(keys, values, normalizers, strict=True):
+            if normalizer <= 0:
+                raise ValueError(f"Train metric {key!r} has a non-positive normalizer: {normalizer}.")
+            loss_reduced[key] = value * parallel_state.cp.size / normalizer
+        return loss_reduced
 
-    for key, value in zip(keys, values[1:], strict=False):
+    num_samples_or_tokens = values[0]
+    for key, value in zip(keys, values[1:], strict=True):
         loss_reduced[key] = value * parallel_state.cp.size / num_samples_or_tokens
 
     return loss_reduced

--- a/miles/backends/training_utils/loss.py
+++ b/miles/backends/training_utils/loss.py
@@ -6,13 +6,82 @@ from torch.utils.checkpoint import checkpoint
 from miles.backends.training_utils.cp_utils import get_sum_of_sample_mean
 from miles.backends.training_utils.loss_hub.advantages import compute_advantages, normalize_advantages
 from miles.backends.training_utils.loss_hub.logit_processors import get_log_probs_and_entropy, get_values  # noqa: F401
-from miles.backends.training_utils.loss_hub.losses import get_loss_function
+from miles.backends.training_utils.loss_hub.losses import TOKEN_NORMALIZED_TRAIN_KEYS, get_loss_function
 from miles.backends.training_utils.loss_hub.math_utils import compute_approx_kl
 from miles.backends.training_utils.loss_hub.opd import apply_opd_kl_to_advantages
 from miles.backends.training_utils.parallel import get_parallel_state
 from miles.utils.audit_utils.event_logger.logger import get_event_logger, is_event_logger_initialized
 from miles.utils.audit_utils.event_logger.models import TrainAdvantageComputationEvent
 from miles.utils.types import RolloutBatch
+
+
+def get_active_token_count(loss_masks: list[torch.Tensor]) -> torch.Tensor:
+    """Count active tokens without inventing weight for fully masked samples."""
+    if not loss_masks:
+        raise ValueError("Cannot normalize a loss over an empty batch.")
+    return torch.stack([loss_mask.sum() for loss_mask in loss_masks]).sum()
+
+
+def get_token_counts_by_step(loss_masks: list[torch.Tensor], num_steps: int) -> torch.Tensor:
+    if num_steps <= 0 or len(loss_masks) < num_steps or len(loss_masks) % num_steps != 0:
+        raise ValueError(f"Cannot split {len(loss_masks)} loss masks across {num_steps} optimizer steps.")
+    samples_per_step = len(loss_masks) // num_steps
+    return torch.stack(
+        [
+            get_active_token_count(loss_masks[start : start + samples_per_step])
+            for start in range(0, len(loss_masks), samples_per_step)
+        ]
+    )
+
+
+def scale_data_parallel_token_mean_loss(
+    loss: torch.Tensor,
+    *,
+    global_num_tokens: torch.Tensor,
+    data_parallel_size: int,
+) -> torch.Tensor:
+    """Scale a local token numerator before FSDP averages gradients across DP."""
+    if global_num_tokens.numel() != 1:
+        raise ValueError(f"Expected one token normalizer, got shape {tuple(global_num_tokens.shape)}.")
+    return loss * data_parallel_size / global_num_tokens.to(device=loss.device)
+
+
+def _as_scalar_tensor(value, *, device: torch.device) -> torch.Tensor:
+    if isinstance(value, torch.Tensor):
+        return value.to(device=device).reshape(())
+    return torch.tensor(value, device=device)
+
+
+def _build_train_log_dict(
+    log: dict[str, torch.Tensor],
+    *,
+    num_samples: int,
+    num_tokens: torch.Tensor,
+    device: torch.device,
+    calculate_per_token_loss: bool,
+    metrics_token_reduced: bool,
+) -> dict[str, list[str] | torch.Tensor]:
+    keys = list(log.keys())
+    values = torch.stack([_as_scalar_tensor(value, device=device) for value in log.values()])
+    if not calculate_per_token_loss:
+        return {
+            "keys": keys,
+            "values": torch.cat([torch.tensor([num_samples], device=device), values]),
+        }
+
+    num_tokens_scalar = num_tokens.to(device=device).reshape(())
+    num_samples_scalar = torch.tensor(num_samples, device=device)
+    normalizers = torch.stack(
+        [
+            num_tokens_scalar if metrics_token_reduced or key in TOKEN_NORMALIZED_TRAIN_KEYS else num_samples_scalar
+            for key in keys
+        ]
+    )
+    return {
+        "keys": keys,
+        "values": values,
+        "normalizers": normalizers,
+    }
 
 
 def compute_advantages_and_returns(args: Namespace, rollout_data: RolloutBatch) -> None:
@@ -119,19 +188,26 @@ def loss_function(
         - `normalizer` is `num_tokens` (scalar tensor) if
           `args.calculate_per_token_loss` is True, else `1` (int).
         - `logging_dict` has keys "keys" (list of str metric names) and
-          "values" (1D tensor: [count, metric1, metric2, ...]).
+          "values". Without `calculate_per_token_loss`, "values" is a 1D
+          tensor `[num_samples, metric1, metric2, ...]`; with it, "values"
+          holds only the metrics and a "normalizers" tensor carries each
+          metric's denominator (`num_tokens` or `num_samples`).
     """
     parallel_state = get_parallel_state()
-    num_tokens = sum([torch.clamp_min(loss_mask.sum(), 1) for loss_mask in batch["loss_masks"]])
+    num_tokens = get_active_token_count(batch["loss_masks"])
     num_samples = len(batch["response_lengths"])
 
+    # Policy loss selects pg_loss aggregation separately; this shared reducer is
+    # for metrics and auxiliary terms. Non-policy losses use the legacy reducer
+    # axis directly.
+    reducer_per_token_loss = args.calculate_per_token_loss and args.loss_type != "policy_loss"
     sum_of_sample_mean = get_sum_of_sample_mean(
         batch["total_lengths"],
         batch["response_lengths"],
         batch["loss_masks"],
-        args.calculate_per_token_loss,
-        args.qkv_format,
-        batch.get("max_seq_lens", None),
+        calculate_per_token_loss=reducer_per_token_loss,
+        qkv_format=args.qkv_format,
+        max_seq_lens=batch.get("max_seq_lens", None),
     )
 
     func = get_loss_function(args)
@@ -168,19 +244,23 @@ def loss_function(
         if apply_megatron_loss_scaling:
             loss = loss * parallel_state.cp.size
 
+    log_dict = _build_train_log_dict(
+        log,
+        num_samples=num_samples,
+        num_tokens=num_tokens,
+        device=logits.device,
+        calculate_per_token_loss=args.calculate_per_token_loss,
+        metrics_token_reduced=reducer_per_token_loss,
+    )
+
     return (
         loss,
-        torch.tensor(num_tokens if args.calculate_per_token_loss else 1, device=logits.device),
-        {
-            "keys": list(log.keys()),
-            "values": torch.tensor(
-                [
-                    num_samples if not args.calculate_per_token_loss else num_tokens,
-                ]
-                + list(log.values()),
-                device=logits.device,
-            ),
-        },
+        (
+            num_tokens.to(device=logits.device)
+            if args.calculate_per_token_loss
+            else torch.tensor(1, device=logits.device)
+        ),
+        log_dict,
     )
 
 

--- a/miles/backends/training_utils/loss_hub/losses.py
+++ b/miles/backends/training_utils/loss_hub/losses.py
@@ -59,6 +59,75 @@ class LossFunction(Protocol):
         ...
 
 
+# Policy-loss log keys that track pg_loss's token normalization under
+# --loss-aggregation token_mean; every other policy-loss metric stays
+# sample-normalized. Non-policy losses reduce every metric with the token
+# reducer when the legacy per-token path is active, so their keys are
+# token-normalized wholesale instead of consulting this set.
+TOKEN_NORMALIZED_TRAIN_KEYS = frozenset({"loss", "pg_loss", "ess_ratio"})
+
+
+def get_pg_loss_reducer(
+    args: Namespace,
+    batch: RolloutBatch,
+    *,
+    total_lengths: list[int],
+    response_lengths: list[int],
+    pg_loss_masks: list[torch.Tensor],
+    max_seq_lens: list[int] | None,
+    default_reducer: Callable[[torch.Tensor], torch.Tensor],
+) -> Callable[[torch.Tensor], torch.Tensor]:
+    """Select the pg_loss reducer for ``--loss-aggregation``.
+
+    ``default_reducer`` must have been built from the same ``pg_loss_masks``;
+    ``sample_mean`` returns it unchanged.
+    """
+    mode = args.loss_aggregation
+    if mode == "sample_mean":
+        return default_reducer
+    if mode == "token_mean":
+        return get_sum_of_sample_mean(
+            total_lengths,
+            response_lengths,
+            pg_loss_masks,
+            calculate_per_token_loss=True,
+            qkv_format=args.qkv_format,
+            max_seq_lens=max_seq_lens,
+        )
+    if mode == "prompt_mean":
+        prompt_mask_sums = batch.get("prompt_mask_sums")
+        if prompt_mask_sums is None:
+            raise ValueError(
+                "--loss-aggregation prompt_mean requires per-prompt-group mask sums "
+                "(batch['prompt_mask_sums']), but they are missing. A custom "
+                "--custom-convert-samples-to-train-data-path must populate "
+                "'prompt_mask_sums' (grouped by Sample.group_index)."
+            )
+        reducer = get_sum_of_sample_mean(
+            total_lengths,
+            response_lengths,
+            pg_loss_masks,
+            qkv_format=args.qkv_format,
+            max_seq_lens=max_seq_lens,
+            sample_denoms=prompt_mask_sums,
+        )
+
+        def prompt_mean_reducer(x: torch.Tensor) -> torch.Tensor:
+            return reducer(x) * args.n_samples_per_prompt
+
+        return prompt_mean_reducer
+    if mode == "constant":
+        return get_sum_of_sample_mean(
+            total_lengths,
+            response_lengths,
+            pg_loss_masks,
+            qkv_format=args.qkv_format,
+            max_seq_lens=max_seq_lens,
+            constant_divisor=args.loss_aggregation_divisor,
+        )
+    raise ValueError(f"Unknown --loss-aggregation mode: {mode!r}")
+
+
 def policy_loss_function(
     args: Namespace,
     batch: RolloutBatch,
@@ -199,14 +268,7 @@ def policy_loss_function(
 
     # Apply off-policy correction using importance sampling if enabled
     if args.get_mismatch_metrics or args.use_tis:
-        # NOTE:
-        # `tis_func` may apply rejection-sampling style masking (RS) and return `modified_response_masks`.
-        # We rebuild `sum_of_sample_mean` with those masks to correct denominators for loss/backprop.
-        #
-        # However, mismatch/TIS/RS metrics (e.g., "truncate_fraction") are often defined over the
-        # *pre-RS* valid tokens. If we aggregate metrics with `modified_response_masks`, the rejected
-        # tokens are excluded from the denominator and the metric can be artificially driven to 0.
-        # Keep a copy of the original reducer (based on `batch["loss_masks"]`) for metric aggregation.
+        # TIS/RS can shrink the pg_loss mask; mismatch metrics stay on the original mask.
         sum_of_sample_mean_for_mismatch_metrics = sum_of_sample_mean
 
         assert "rollout_log_probs" in batch, "rollout_log_probs must be provided for TIS"
@@ -230,27 +292,32 @@ def policy_loss_function(
             tis_func = vanilla_tis_function
         pg_loss, modified_response_masks, tis_metrics = tis_func(**tis_kwargs)
 
-        # [decouple IS and rejection] Rebuild sum_of_sample_mean with modified_response_masks for denominator correction
-        # modified_response_masks will be sliced with cp in get_sum_of_sample_mean
         sum_of_sample_mean = get_sum_of_sample_mean(
             total_lengths,
             response_lengths,
             modified_response_masks,
-            args.calculate_per_token_loss,
-            args.qkv_format,
-            max_seq_lens,
+            calculate_per_token_loss=False,
+            qkv_format=args.qkv_format,
+            max_seq_lens=max_seq_lens,
         )
 
-    # Determine pg_loss reducer: use custom if specified, otherwise default
+    pg_loss_masks = modified_response_masks if (args.get_mismatch_metrics or args.use_tis) else batch["loss_masks"]
+
     if args.custom_pg_loss_reducer_function_path is not None:
         custom_pg_loss_reducer_func = load_function(args.custom_pg_loss_reducer_function_path)
-        # Determine which loss_masks to use for pg_loss reducer
-        pg_loss_masks = modified_response_masks if (args.get_mismatch_metrics or args.use_tis) else batch["loss_masks"]
         pg_loss_reducer = custom_pg_loss_reducer_func(
             total_lengths, response_lengths, pg_loss_masks, args.calculate_per_token_loss
         )
     else:
-        pg_loss_reducer = sum_of_sample_mean
+        pg_loss_reducer = get_pg_loss_reducer(
+            args,
+            batch,
+            total_lengths=total_lengths,
+            response_lengths=response_lengths,
+            pg_loss_masks=pg_loss_masks,
+            max_seq_lens=max_seq_lens,
+            default_reducer=sum_of_sample_mean,
+        )
 
     # ESS (Effective Sample Size) ratio from per-token IS weights
     # w = π_new/π_old = exp(-ppo_kl).  A value of 1.0 is on-policy; near 0

--- a/miles/ray/rollout/train_data_conversion.py
+++ b/miles/ray/rollout/train_data_conversion.py
@@ -1,8 +1,10 @@
+import math
 from typing import Any
 
 import ray
 import torch
 
+from miles.utils.iter_utils import group_by
 from miles.utils.ray_utils import Box
 from miles.utils.seqlen_balancing import get_seqlen_balanced_partitions
 from miles.utils.types import Sample
@@ -54,6 +56,27 @@ def convert_samples_to_train_data(
             sample.loss_mask = [0] * sample.response_length
         loss_masks.append(sample.loss_mask)
     train_data["loss_masks"] = loss_masks
+
+    if args.loss_aggregation == "prompt_mean":
+        prompt_group_indices = [sample.group_index for sample in samples]
+        if None in prompt_group_indices:
+            raise ValueError("--loss-aggregation prompt_mean requires every Sample.group_index to be set.")
+        prompt_groups = group_by(zip(prompt_group_indices, loss_masks, strict=True), key=lambda pair: pair[0])
+        partial_groups = {
+            group_index: len(group)
+            for group_index, group in prompt_groups.items()
+            if len(group) != args.n_samples_per_prompt
+        }
+        if partial_groups:
+            raise ValueError(
+                "--loss-aggregation prompt_mean requires complete prompt groups; "
+                f"expected {args.n_samples_per_prompt} samples per group, got {partial_groups}."
+            )
+        group_mask_totals = {
+            group_index: sum(sum(mask) for _, mask in group) for group_index, group in prompt_groups.items()
+        }
+        train_data["prompt_group_indices"] = prompt_group_indices
+        train_data["prompt_mask_sums"] = [group_mask_totals[group_index] for group_index in prompt_group_indices]
 
     # overwriting the raw reward
     if samples[0].metadata and "raw_reward" in samples[0].metadata:
@@ -121,6 +144,68 @@ def _post_process_rewards(args, samples: list[Sample] | list[list[Sample]], cust
     return raw_rewards, raw_rewards
 
 
+def _prompt_group_partitions(
+    prompt_group_indices: list[int],
+    prompt_mask_sums: list[float],
+    loss_masks: list[list[float]],
+    total_lengths: list[int],
+    dp_size: int,
+    *,
+    balance_data: bool,
+    expected_group_size: int,
+) -> list[list[int]]:
+    num_samples = len(total_lengths)
+    if len(prompt_group_indices) != num_samples:
+        raise ValueError(
+            "--loss-aggregation prompt_mean requires one prompt_group_indices entry per sample "
+            f"(got {len(prompt_group_indices)} for {num_samples} samples)."
+        )
+    if len(prompt_mask_sums) != num_samples:
+        raise ValueError(
+            "--loss-aggregation prompt_mean requires one prompt_mask_sums entry per sample "
+            f"(got {len(prompt_mask_sums)} for {num_samples} samples)."
+        )
+    if len(loss_masks) != num_samples:
+        raise ValueError(f"--loss-aggregation prompt_mean got {len(loss_masks)} loss masks for {num_samples} samples.")
+
+    group_to_indices = group_by(range(len(prompt_group_indices)), key=lambda i: prompt_group_indices[i])
+    partial_groups = {
+        group_index: len(indices)
+        for group_index, indices in group_to_indices.items()
+        if len(indices) != expected_group_size
+    }
+    if partial_groups:
+        raise ValueError(
+            "--loss-aggregation prompt_mean requires complete prompt groups; "
+            f"expected {expected_group_size} samples per group, got {partial_groups}."
+        )
+    for group_index, indices in group_to_indices.items():
+        expected_mask_sum = sum(sum(loss_masks[index]) for index in indices)
+        if any(not math.isclose(float(prompt_mask_sums[index]), expected_mask_sum) for index in indices):
+            raise ValueError(
+                "--loss-aggregation prompt_mean received inconsistent prompt_mask_sums for group "
+                f"{group_index!r}; expected {expected_mask_sum}."
+            )
+    group_keys = list(group_to_indices)
+
+    if len(group_keys) % dp_size != 0:
+        raise ValueError(
+            "--loss-aggregation prompt_mean requires the number of prompt groups in a train step "
+            f"to be divisible by dp_size (got {len(group_keys)} prompt groups, dp_size={dp_size})."
+        )
+
+    if balance_data:
+        group_lengths = [sum(total_lengths[index] for index in indices) for indices in group_to_indices.values()]
+        group_partitions = get_seqlen_balanced_partitions(group_lengths, dp_size, equal_size=True)
+    else:
+        group_partitions = [range(i, len(group_keys), dp_size) for i in range(dp_size)]
+
+    return [
+        [sample_index for group_pos in partition for sample_index in group_to_indices[group_keys[group_pos]]]
+        for partition in group_partitions
+    ]
+
+
 def split_train_data_by_dp(args, data, dp_size):
     """Split the train data by data parallel size."""
     rollout_data_list = split_train_data_by_dp_raw(args, data, dp_size=dp_size)
@@ -131,11 +216,69 @@ def split_train_data_by_dp_raw(args, data: dict[str, Any], *, dp_size: int) -> l
     """Split the train data by data parallel size."""
     total_lengths = [len(t) for t in data["tokens"]]
     data["total_lengths"] = total_lengths
+    loss_aggregation = args.loss_aggregation
 
-    if args.balance_data:
+    if loss_aggregation == "token_mean":
+        global_batch_size = data.get("dynamic_global_batch_size", args.global_batch_size)
+        if len(data["loss_masks"]) % global_batch_size != 0:
+            raise ValueError(
+                f"Cannot split {len(data['loss_masks'])} loss masks into token_mean steps of {global_batch_size}."
+            )
+
+    if loss_aggregation == "prompt_mean":
+        missing = {"prompt_group_indices", "prompt_mask_sums"} - data.keys()
+        if missing:
+            raise ValueError(
+                "--loss-aggregation prompt_mean requires custom train data to include "
+                f"{', '.join(sorted(missing))}."
+            )
+        # Each rank consumes contiguous global_batch_size // dp_size slices per
+        # optimizer step, so with multiple steps per rollout a prompt group stays
+        # within one step only if that per-rank slice is a multiple of the group
+        # size. Dynamic global batch size always trains one step per rollout.
+        if not args.use_dynamic_global_batch_size and len(total_lengths) > args.global_batch_size:
+            num_local_gbs = args.global_batch_size // dp_size
+            if num_local_gbs % args.n_samples_per_prompt != 0:
+                raise ValueError(
+                    "--loss-aggregation prompt_mean requires global_batch_size // dp_size "
+                    f"({args.global_batch_size} // {dp_size} = {num_local_gbs}) to be a multiple of "
+                    f"n_samples_per_prompt ({args.n_samples_per_prompt}) when a rollout spans multiple "
+                    "train steps; otherwise a prompt group would straddle an optimizer-step boundary."
+                )
+        partitions = _prompt_group_partitions(
+            data["prompt_group_indices"],
+            data["prompt_mask_sums"],
+            data["loss_masks"],
+            total_lengths,
+            dp_size,
+            balance_data=args.balance_data,
+            expected_group_size=args.n_samples_per_prompt,
+        )
+    elif args.balance_data:
         partitions = get_seqlen_balanced_partitions(total_lengths, dp_size, equal_size=True)
     else:
         partitions = [range(i, len(total_lengths), dp_size) for i in range(dp_size)]
+
+    if loss_aggregation == "token_mean":
+        if global_batch_size % dp_size != 0:
+            raise ValueError(
+                f"token_mean requires global_batch_size {global_batch_size} to be divisible by dp_size {dp_size}."
+            )
+        local_samples_per_step = global_batch_size // dp_size
+        num_steps = len(data["loss_masks"]) // global_batch_size
+        empty_steps = []
+        for step in range(num_steps):
+            step_masks = [
+                data["loss_masks"][sample_index]
+                for partition in partitions
+                for sample_index in partition[step * local_samples_per_step : (step + 1) * local_samples_per_step]
+            ]
+            if sum(sum(mask) for mask in step_masks) <= 0:
+                empty_steps.append(step)
+        if empty_steps:
+            raise ValueError(
+                f"token_mean requires at least one active token per optimizer step; empty: {empty_steps}."
+            )
 
     ans = []
 
@@ -160,6 +303,8 @@ def split_train_data_by_dp_raw(args, data: dict[str, Any], *, dp_size: int) -> l
             "opd_reverse_kl",
             "seq_witness_ids",
             "weight_versions",
+            "prompt_group_indices",
+            "prompt_mask_sums",
         ]:
             if key not in data:
                 continue

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -1,6 +1,7 @@
 import argparse
 import json
 import logging
+import math
 import os
 from typing import Any
 
@@ -19,6 +20,8 @@ from miles.utils.megatron_args_utils import compute_megatron_world_size_except_d
 from miles.utils.misc import load_function
 
 logger = logging.getLogger(__name__)
+
+_LOSS_AGGREGATION_MODES = ("sample_mean", "prompt_mean", "token_mean", "constant")
 
 
 def reset_arg(parser, name, **kwargs):
@@ -1213,6 +1216,25 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 default=None,
                 help="Path to a custom reducer function for pg_loss only. When set, pg_loss will use this custom reducer while other metrics (pg_clipfrac, ppo_kl, entropy_loss, etc.) still use the default sum_of_sample_mean. (e.g., examples/Dr.GRPO/custom_reducer.py:get_pg_loss_reducer).",
             )
+            parser.add_argument(
+                "--loss-aggregation",
+                type=str,
+                default="sample_mean",
+                choices=_LOSS_AGGREGATION_MODES,
+                help=(
+                    "How to aggregate pg_loss: per sample, per prompt group, per active token, or with a "
+                    "fixed divisor. --custom-pg-loss-reducer-function-path takes precedence."
+                ),
+            )
+            parser.add_argument(
+                "--loss-aggregation-divisor",
+                type=float,
+                default=None,
+                help=(
+                    "Positive finite divisor for --loss-aggregation constant. Required in constant mode "
+                    "and rejected for every other mode."
+                ),
+            )
 
             parser.add_argument(
                 "--use-routing-replay",
@@ -2259,6 +2281,105 @@ def _resolve_ft_components(args: argparse.Namespace) -> list[str]:
     return list(args.ft_components)
 
 
+def _validate_loss_aggregation_args(args):
+    """Reconcile --loss-aggregation with its legacy alias --calculate-per-token-loss and validate the mode."""
+    if not isinstance(args.loss_aggregation, str):
+        raise ValueError(f"--loss-aggregation must be a string, got {args.loss_aggregation!r}.")
+    if not isinstance(args.calculate_per_token_loss, bool):
+        raise ValueError("--calculate-per-token-loss must be a boolean, got " f"{args.calculate_per_token_loss!r}.")
+    if args.loss_aggregation not in _LOSS_AGGREGATION_MODES:
+        choices = ", ".join(sorted(_LOSS_AGGREGATION_MODES))
+        raise ValueError(f"Unknown --loss-aggregation mode {args.loss_aggregation!r}; expected one of: {choices}.")
+
+    if args.loss_aggregation == "constant":
+        divisor = args.loss_aggregation_divisor
+        if (
+            isinstance(divisor, bool)
+            or not isinstance(divisor, (int, float))
+            or not math.isfinite(divisor)
+            or divisor <= 0
+        ):
+            raise ValueError(
+                "--loss-aggregation constant requires --loss-aggregation-divisor <positive finite number> "
+                "(the model's max generation/context length, e.g. 40960), got "
+                f"{divisor!r}."
+            )
+    elif args.loss_aggregation_divisor is not None:
+        raise ValueError(
+            "--loss-aggregation-divisor is only used with --loss-aggregation constant, "
+            f"but --loss-aggregation={args.loss_aggregation!r}."
+        )
+
+    if args.loss_aggregation == "token_mean":
+        args.calculate_per_token_loss = True
+    elif args.calculate_per_token_loss:
+        if args.loss_aggregation == "sample_mean":
+            args.loss_aggregation = "token_mean"
+        else:
+            raise ValueError(
+                f"--loss-aggregation {args.loss_aggregation} is incompatible with --calculate-per-token-loss "
+                "(use --loss-aggregation token_mean for the per-token global mean)."
+            )
+
+    custom_tis_path = args.custom_tis_function_path
+    if (
+        args.loss_type == "policy_loss"
+        and custom_tis_path is not None
+        and args.loss_aggregation in {"prompt_mean", "token_mean"}
+    ):
+        raise ValueError(
+            f"--loss-aggregation {args.loss_aggregation} cannot be combined with --custom-tis-function-path. "
+            "A custom TIS/RS function may change the active loss mask after microbatching, but this mode's "
+            "normalizer is defined over the full optimizer step. Use sample_mean or constant, or omit the "
+            "custom TIS function."
+        )
+
+    if args.calculate_per_token_loss and args.indep_dp:
+        raise ValueError("token_mean is not supported with independent-DP training.")
+
+    # token_mean makes pg_loss token-normalized while entropy/KL auxiliary loss
+    # terms stay sample-normalized; reject the mix instead of training with an
+    # inconsistent objective.
+    if args.loss_type == "policy_loss" and args.loss_aggregation == "token_mean":
+        mixed_terms = []
+        if args.entropy_coef != 0:
+            mixed_terms.append("--entropy-coef")
+        if args.use_kl_loss and args.kl_loss_coef != 0:
+            mixed_terms.append("--kl-loss-coef")
+        if mixed_terms:
+            raise ValueError(
+                "--loss-aggregation token_mean cannot be combined with "
+                f"{', '.join(mixed_terms)} because the policy-gradient term is token-normalized "
+                "while auxiliary policy-loss terms are sample-normalized. Use sample_mean, "
+                "set the auxiliary coefficient to 0, or add explicit per-term loss normalizers."
+            )
+
+    if (
+        args.loss_aggregation == "prompt_mean"
+        and args.global_batch_size is not None
+        and args.global_batch_size % args.n_samples_per_prompt != 0
+    ):
+        raise ValueError(
+            "--loss-aggregation prompt_mean requires global_batch_size to be a multiple of "
+            "n_samples_per_prompt so each prompt group stays within one training step "
+            f"(got global_batch_size={args.global_batch_size}, n_samples_per_prompt={args.n_samples_per_prompt})."
+        )
+
+
+def _derive_global_batch_size_from_rollout(args, *, require_existing_match: bool = True) -> None:
+    if args.num_steps_per_rollout is None:
+        return
+    global_batch_size = args.rollout_batch_size * args.n_samples_per_prompt // args.num_steps_per_rollout
+    if require_existing_match and args.global_batch_size is not None:
+        if args.global_batch_size != global_batch_size:
+            raise ValueError(
+                f"global_batch_size {args.global_batch_size} is not equal to "
+                f"rollout_batch_size {args.rollout_batch_size} * n_samples_per_prompt {args.n_samples_per_prompt} "
+                f"// num_steps_per_rollout {args.num_steps_per_rollout}"
+            )
+    args.global_batch_size = global_batch_size
+
+
 def miles_validate_args(args):
     args.ft_components = _resolve_ft_components(args)
     args.eval_datasets = _resolve_eval_datasets(args)
@@ -2657,15 +2778,7 @@ def miles_validate_args(args):
     if args.eval_function_path is None:
         args.eval_function_path = args.rollout_function_path
 
-    if args.num_steps_per_rollout is not None:
-        global_batch_size = args.rollout_batch_size * args.n_samples_per_prompt // args.num_steps_per_rollout
-        if args.global_batch_size is not None:
-            assert args.global_batch_size == global_batch_size, (
-                f"global_batch_size {args.global_batch_size} is not equal to "
-                f"rollout_batch_size {args.rollout_batch_size} * n_samples_per_prompt {args.n_samples_per_prompt} "
-                f"// num_steps_per_rollout {args.num_steps_per_rollout}"
-            )
-        args.global_batch_size = global_batch_size
+    _derive_global_batch_size_from_rollout(args)
 
     if args.n_samples_per_prompt == 1:
         args.grpo_std_normalization = False
@@ -2706,6 +2819,28 @@ def miles_validate_args(args):
             if hasattr(args, k):
                 logger.info(f"Warning: Argument {k} is already set to {getattr(args, k)}, will override with {v}.")
             setattr(args, k, v)
+        # The legacy flag and the new mode are one logical setting. If a custom
+        # config overrides only one spelling, it replaces the CLI value from
+        # the other spelling as well.
+        if "loss_aggregation" in data and "calculate_per_token_loss" not in data:
+            args.calculate_per_token_loss = False
+        elif "calculate_per_token_loss" in data and "loss_aggregation" not in data:
+            args.loss_aggregation = "sample_mean"
+        elif "loss_aggregation" in data and "calculate_per_token_loss" in data:
+            if (
+                isinstance(args.loss_aggregation, str)
+                and isinstance(args.calculate_per_token_loss, bool)
+                and args.calculate_per_token_loss != (args.loss_aggregation == "token_mean")
+            ):
+                raise ValueError(
+                    "custom config gives conflicting values for loss_aggregation and " "calculate_per_token_loss."
+                )
+        _derive_global_batch_size_from_rollout(args, require_existing_match="global_batch_size" in data)
+
+    # Validate once on the merged config (CLI, then --custom-config-path
+    # overrides): reconciling the --calculate-per-token-loss alias mutates args,
+    # so an earlier pass would leak derived state into the override's view.
+    _validate_loss_aggregation_args(args)
 
     if args.use_rollout_indexer_replay:
         args.use_indexer_replay = True

--- a/tests/fast/backends/training_utils/conftest.py
+++ b/tests/fast/backends/training_utils/conftest.py
@@ -1,0 +1,109 @@
+import importlib
+import sys
+import types
+from enum import Enum
+from types import SimpleNamespace
+
+import pytest
+
+_MISSING = object()
+_MILES_MODULES = [
+    "miles.backends.sglang_utils.arguments",
+    "miles.backends.training_utils.cp_utils",
+    "miles.backends.training_utils.log_utils",
+    "miles.backends.training_utils.loss",
+    "miles.backends.training_utils.loss_hub.losses",
+    "miles.backends.training_utils.parallel",
+    "miles.ray.rollout.train_data_conversion",
+    "miles.utils.arguments",
+    "miles.utils.types",
+]
+
+
+def _install_import_stubs(monkeypatch):
+    for name in ["sglang", "sglang.srt", "sglang.srt.entrypoints", "sglang.srt.entrypoints.openai"]:
+        module = types.ModuleType(name)
+        module.__path__ = []
+        monkeypatch.setitem(sys.modules, name, module)
+
+    protocol = types.ModuleType("sglang.srt.entrypoints.openai.protocol")
+    protocol.Tool = object
+    monkeypatch.setitem(sys.modules, "sglang.srt.entrypoints.openai.protocol", protocol)
+
+    server_args = types.ModuleType("sglang.srt.server_args")
+
+    class _ServerArgs:
+        @staticmethod
+        def add_cli_args(parser):
+            return None
+
+    server_args.ServerArgs = _ServerArgs
+    monkeypatch.setitem(sys.modules, "sglang.srt.server_args", server_args)
+
+    chat_template_utils = types.ModuleType("miles.utils.chat_template_utils")
+    chat_template_utils.__path__ = []
+    chat_template_utils.resolve_fixed_chat_template = lambda *args, **kwargs: (None, {})
+    monkeypatch.setitem(sys.modules, "miles.utils.chat_template_utils", chat_template_utils)
+
+    tito_tokenizer = types.ModuleType("miles.utils.chat_template_utils.tito_tokenizer")
+
+    class _TITOTokenizerType(Enum):
+        DEFAULT = "default"
+
+    tito_tokenizer.TITOTokenizerType = _TITOTokenizerType
+    monkeypatch.setitem(sys.modules, "miles.utils.chat_template_utils.tito_tokenizer", tito_tokenizer)
+
+    sglang_router = types.ModuleType("sglang_router")
+    sglang_router.__path__ = []
+    monkeypatch.setitem(sys.modules, "sglang_router", sglang_router)
+
+    launch_router = types.ModuleType("sglang_router.launch_router")
+
+    class _RouterArgs:
+        @staticmethod
+        def add_cli_args(parser, *args, **kwargs):
+            return None
+
+    launch_router.RouterArgs = _RouterArgs
+    monkeypatch.setitem(sys.modules, "sglang_router.launch_router", launch_router)
+
+
+@pytest.fixture
+def miles(monkeypatch):
+    previous_modules = {name: sys.modules.get(name, _MISSING) for name in _MILES_MODULES}
+    for name in _MILES_MODULES:
+        sys.modules.pop(name, None)
+
+    _install_import_stubs(monkeypatch)
+
+    cp_utils = importlib.import_module("miles.backends.training_utils.cp_utils")
+    log_utils = importlib.import_module("miles.backends.training_utils.log_utils")
+    loss = importlib.import_module("miles.backends.training_utils.loss")
+    losses = importlib.import_module("miles.backends.training_utils.loss_hub.losses")
+    parallel = importlib.import_module("miles.backends.training_utils.parallel")
+    train_data_conversion = importlib.import_module("miles.ray.rollout.train_data_conversion")
+    arguments = importlib.import_module("miles.utils.arguments")
+    types_module = importlib.import_module("miles.utils.types")
+
+    try:
+        yield SimpleNamespace(
+            arguments=arguments,
+            convert_samples_to_train_data=train_data_conversion.convert_samples_to_train_data,
+            split_train_data_by_dp=train_data_conversion.split_train_data_by_dp,
+            train_data_conversion=train_data_conversion,
+            cp_utils=cp_utils,
+            log_utils=log_utils,
+            loss=loss,
+            get_pg_loss_reducer=losses.get_pg_loss_reducer,
+            get_sum_of_sample_mean=cp_utils.get_sum_of_sample_mean,
+            GroupInfo=parallel.GroupInfo,
+            ParallelState=parallel.ParallelState,
+            Sample=types_module.Sample,
+        )
+    finally:
+        for name in reversed(_MILES_MODULES):
+            previous = previous_modules[name]
+            if previous is _MISSING:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = previous

--- a/tests/fast/backends/training_utils/loss/loss_test_utils.py
+++ b/tests/fast/backends/training_utils/loss/loss_test_utils.py
@@ -98,6 +98,8 @@ _ARGS_DEFAULTS = dict(
     use_opsm=False,
     opsm_delta=0.1,
     calculate_per_token_loss=False,
+    loss_aggregation="sample_mean",
+    loss_aggregation_divisor=None,
     # value_loss_function
     value_clip=0.2,
     # loss_function dispatcher

--- a/tests/fast/backends/training_utils/loss/test_loss_snapshot.py
+++ b/tests/fast/backends/training_utils/loss/test_loss_snapshot.py
@@ -117,9 +117,9 @@ def _get_sum_of_sample_mean(batch, args, parallel_state):
         batch["total_lengths"],
         batch["response_lengths"],
         batch["loss_masks"],
-        args.calculate_per_token_loss,
-        args.qkv_format,
-        batch.get("max_seq_lens", None),
+        calculate_per_token_loss=args.calculate_per_token_loss,
+        qkv_format=args.qkv_format,
+        max_seq_lens=batch.get("max_seq_lens", None),
     )
 
 

--- a/tests/fast/backends/training_utils/test_loss_aggregation.py
+++ b/tests/fast/backends/training_utils/test_loss_aggregation.py
@@ -1,0 +1,435 @@
+"""Tests for the ``--loss-aggregation`` pg_loss modes."""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+
+def _parallel_state(miles, *, cp_size: int, cp_rank: int = 0):
+    return miles.ParallelState(
+        intra_dp=miles.GroupInfo(rank=0, size=1, group=None),
+        intra_dp_cp=miles.GroupInfo(rank=0, size=cp_size, group=None),
+        cp=miles.GroupInfo(rank=cp_rank, size=cp_size, group=None),
+        tp=miles.GroupInfo(rank=0, size=1, group=None),
+        pp=miles.GroupInfo(rank=0, size=1, group=None),
+        ep=miles.GroupInfo(rank=0, size=1, group=None),
+        etp=miles.GroupInfo(rank=0, size=1, group=None),
+        indep_dp=miles.GroupInfo(rank=0, size=1, group=None),
+        cp_comm_type=None,
+    )
+
+
+def _legacy_sum_of_sample_mean(response_lengths, loss_masks):
+    def reducer(x: torch.Tensor) -> torch.Tensor:
+        return sum(
+            (x_i * m_i).sum() / torch.clamp_min(m_i.sum(), 1)
+            for x_i, m_i in zip(x.split(response_lengths, dim=0), loss_masks, strict=True)
+        )
+
+    return reducer
+
+
+RESPONSE_LENGTHS = [3, 3, 4, 4]
+TOTAL_LENGTHS = [3, 3, 4, 4]
+LOSS_MASKS = [
+    torch.tensor([1.0, 1.0, 0.0]),
+    torch.tensor([1.0, 1.0, 1.0]),
+    torch.tensor([1.0, 0.0, 0.0, 0.0]),
+    torch.tensor([1.0, 1.0, 1.0, 1.0]),
+]
+PROMPT_GROUP_INDICES = [0, 0, 1, 1]
+X = torch.arange(1.0, 15.0)
+
+
+def test_default_is_byte_identical_to_legacy_reducer(miles, monkeypatch):
+    monkeypatch.setattr(miles.cp_utils, "get_parallel_state", lambda: _parallel_state(miles, cp_size=1))
+
+    new = miles.get_sum_of_sample_mean(TOTAL_LENGTHS, RESPONSE_LENGTHS, LOSS_MASKS)
+    legacy = _legacy_sum_of_sample_mean(RESPONSE_LENGTHS, LOSS_MASKS)
+
+    torch.testing.assert_close(new(X), legacy(X), rtol=0, atol=0)
+
+
+def test_prompt_mean_denominator_is_group_token_total(miles, monkeypatch):
+    monkeypatch.setattr(miles.cp_utils, "get_parallel_state", lambda: _parallel_state(miles, cp_size=1))
+
+    sample_denoms = [torch.tensor(5.0)] * 4
+    reducer = miles.get_sum_of_sample_mean(TOTAL_LENGTHS, RESPONSE_LENGTHS, LOSS_MASKS, sample_denoms=sample_denoms)
+    expected = (3 + 15) / 5 + (7 + 50) / 5
+    torch.testing.assert_close(reducer(X), torch.tensor(expected))
+
+
+def test_constant_divides_summed_token_loss_by_L(miles, monkeypatch):
+    monkeypatch.setattr(miles.cp_utils, "get_parallel_state", lambda: _parallel_state(miles, cp_size=1))
+
+    reducer = miles.get_sum_of_sample_mean(TOTAL_LENGTHS, RESPONSE_LENGTHS, LOSS_MASKS, constant_divisor=10.0)
+    torch.testing.assert_close(reducer(X), torch.tensor(7.5))
+
+
+def test_token_mean_is_unnormalized_global_token_sum(miles, monkeypatch):
+    monkeypatch.setattr(miles.cp_utils, "get_parallel_state", lambda: _parallel_state(miles, cp_size=1))
+
+    reducer = miles.get_sum_of_sample_mean(TOTAL_LENGTHS, RESPONSE_LENGTHS, LOSS_MASKS, calculate_per_token_loss=True)
+    torch.testing.assert_close(reducer(X), torch.tensor(75.0))
+
+
+def test_active_token_count_does_not_count_fully_masked_samples(miles):
+    count = miles.loss.get_active_token_count([torch.zeros(2, dtype=torch.int32), torch.ones(2, dtype=torch.int32)])
+
+    assert count.dtype == torch.int64
+    torch.testing.assert_close(count, torch.tensor(2))
+
+
+def test_token_counts_are_computed_at_optimizer_step_scope(miles):
+    counts = miles.loss.get_token_counts_by_step(
+        [torch.zeros(2), torch.ones(2), torch.ones(1), torch.ones(3)],
+        num_steps=2,
+    )
+
+    torch.testing.assert_close(counts, torch.tensor([2.0, 4.0]))
+
+
+def test_fsdp_scaling_converts_rank_local_numerators_to_global_token_mean(miles):
+    global_num_tokens = torch.tensor(5.0)
+    scaled_local_losses = [
+        miles.loss.scale_data_parallel_token_mean_loss(
+            loss,
+            global_num_tokens=global_num_tokens,
+            data_parallel_size=2,
+        )
+        for loss in (torch.tensor(6.0), torch.tensor(14.0))
+    ]
+
+    # FSDP averages gradients across DP ranks after each local loss is scaled.
+    torch.testing.assert_close(sum(scaled_local_losses) / 2, torch.tensor(4.0))
+
+
+def test_legacy_positional_per_token_loss_call_still_works(miles, monkeypatch):
+    monkeypatch.setattr(miles.cp_utils, "get_parallel_state", lambda: _parallel_state(miles, cp_size=1))
+
+    reducer = miles.get_sum_of_sample_mean(TOTAL_LENGTHS, RESPONSE_LENGTHS, LOSS_MASKS, True)
+    torch.testing.assert_close(reducer(X), torch.tensor(75.0))
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"calculate_per_token_loss": True, "sample_denoms": [torch.tensor(1.0)] * 4},
+        {"calculate_per_token_loss": True, "constant_divisor": 4.0},
+        {"sample_denoms": [torch.tensor(1.0)] * 4, "constant_divisor": 4.0},
+    ],
+)
+def test_reducer_rejects_multiple_normalization_modes(miles, kwargs):
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        miles.get_sum_of_sample_mean(TOTAL_LENGTHS, RESPONSE_LENGTHS, LOSS_MASKS, **kwargs)
+
+
+@pytest.mark.parametrize("constant_divisor", [None, 20.0])
+def test_cp_zigzag_rank_sum_matches_single_rank(miles, monkeypatch, constant_divisor):
+    total_length, response_length = 10, 8
+    loss_mask = torch.tensor([1.0, 1.0, 1.0, 1.0, 0.0, 1.0, 1.0, 1.0])
+    x_full = torch.arange(1.0, 9.0)
+    sample_denoms = None if constant_divisor is not None else [torch.tensor(20.0)]
+
+    def build():
+        return miles.get_sum_of_sample_mean(
+            [total_length],
+            [response_length],
+            [loss_mask],
+            constant_divisor=constant_divisor,
+            sample_denoms=sample_denoms,
+        )
+
+    monkeypatch.setattr(miles.cp_utils, "get_parallel_state", lambda: _parallel_state(miles, cp_size=1))
+    ref = build()(x_full)
+
+    total = torch.zeros(())
+    for rank in range(2):
+        monkeypatch.setattr(
+            miles.cp_utils,
+            "get_parallel_state",
+            lambda r=rank: _parallel_state(miles, cp_size=2, cp_rank=r),
+        )
+        x_local = miles.cp_utils._slice_loss_mask_for_local_cp(total_length, response_length, x_full, "thd", None)
+        total = total + build()(x_local)
+
+    torch.testing.assert_close(total, ref)
+
+
+def _args(**overrides):
+    base = dict(
+        loss_aggregation="sample_mean",
+        loss_aggregation_divisor=None,
+        calculate_per_token_loss=False,
+        loss_type="policy_loss",
+        n_samples_per_prompt=2,
+        qkv_format="thd",
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def _default_reducer(miles, *, calculate_per_token_loss=False):
+    return miles.get_sum_of_sample_mean(
+        TOTAL_LENGTHS,
+        RESPONSE_LENGTHS,
+        LOSS_MASKS,
+        calculate_per_token_loss=calculate_per_token_loss,
+    )
+
+
+def _select(miles, args, batch, *, default_reducer=None, pg_loss_masks=LOSS_MASKS):
+    batch = dict(batch)
+    batch.setdefault("loss_masks", LOSS_MASKS)
+    if default_reducer is None:
+        default_reducer = _default_reducer(miles)
+    return miles.get_pg_loss_reducer(
+        args,
+        batch,
+        total_lengths=TOTAL_LENGTHS,
+        response_lengths=RESPONSE_LENGTHS,
+        pg_loss_masks=pg_loss_masks,
+        max_seq_lens=None,
+        default_reducer=default_reducer,
+    )
+
+
+@pytest.mark.parametrize(
+    ("args", "batch", "expected"),
+    [
+        (_args(loss_aggregation="sample_mean"), {}, 26.0),
+        (_args(loss_aggregation="token_mean", calculate_per_token_loss=True), {}, 75.0),
+        (_args(loss_aggregation="constant", loss_aggregation_divisor=10.0), {}, 7.5),
+        (
+            _args(loss_aggregation="prompt_mean"),
+            {"prompt_group_indices": PROMPT_GROUP_INDICES, "prompt_mask_sums": [torch.tensor(5.0)] * 4},
+            30.0,
+        ),
+    ],
+)
+def test_pg_loss_reducer_modes_compute_expected_loss(miles, monkeypatch, args, batch, expected):
+    monkeypatch.setattr(miles.cp_utils, "get_parallel_state", lambda: _parallel_state(miles, cp_size=1))
+
+    reducer = _select(miles, args, batch)
+    torch.testing.assert_close(reducer(X), torch.tensor(expected))
+
+
+def test_prompt_mean_without_prompt_mask_sums_fails(miles):
+    with pytest.raises(ValueError, match="prompt_mask_sums"):
+        _select(miles, _args(loss_aggregation="prompt_mean"), {}, default_reducer=lambda x: x)
+
+
+def test_token_mean_log_aggregation_keeps_metric_sample_mean(miles, monkeypatch):
+    state = _parallel_state(miles, cp_size=1)
+    monkeypatch.setattr(miles.cp_utils, "get_parallel_state", lambda: state)
+    monkeypatch.setattr(miles.loss, "get_parallel_state", lambda: state)
+    monkeypatch.setattr(miles.log_utils, "get_parallel_state", lambda: state)
+    monkeypatch.setattr(miles.log_utils.MultiPGUtil, "all_reduce", lambda *args, **kwargs: None)
+
+    args = _args(loss_aggregation="token_mean", calculate_per_token_loss=True)
+    args.global_batch_size = 2
+    args.use_dynamic_global_batch_size = False
+    args.recompute_loss_function = False
+    args.true_on_policy_mode = False
+
+    batch = {
+        "loss_masks": [torch.ones(2), torch.ones(3)],
+        "total_lengths": [2, 3],
+        "response_lengths": [2, 3],
+    }
+
+    def fake_loss_function(args, batch, logits, sum_of_sample_mean):
+        per_token_metric = torch.arange(1.0, 6.0, device=logits.device)
+        return logits.sum() * 0, {
+            "pg_loss": per_token_metric.sum(),
+            "ppo_kl": sum_of_sample_mean(per_token_metric),
+        }
+
+    monkeypatch.setattr(miles.loss, "get_loss_function", lambda args: fake_loss_function)
+
+    _, _, log_dict = miles.loss.loss_function(args, batch, 1, torch.ones((), requires_grad=True))
+    loss_dict = miles.log_utils.aggregate_train_losses([log_dict])
+
+    torch.testing.assert_close(torch.tensor(loss_dict["pg_loss"]), torch.tensor(3.0))
+    torch.testing.assert_close(torch.tensor(loss_dict["ppo_kl"]), torch.tensor(2.75))
+
+
+def test_build_train_log_dict_carries_per_metric_normalizers(miles):
+    log_dict = miles.loss._build_train_log_dict(
+        {
+            "loss": torch.tensor(12.0),
+            "pg_loss": torch.tensor(15.0),
+            "ppo_kl": torch.tensor(5.5),
+        },
+        num_samples=2,
+        num_tokens=torch.tensor(5.0),
+        device=torch.device("cpu"),
+        calculate_per_token_loss=True,
+        metrics_token_reduced=False,
+    )
+
+    assert log_dict["keys"] == ["loss", "pg_loss", "ppo_kl"]
+    torch.testing.assert_close(log_dict["values"], torch.tensor([12.0, 15.0, 5.5]))
+    torch.testing.assert_close(log_dict["normalizers"], torch.tensor([5.0, 5.0, 2.0]))
+
+
+def test_non_policy_per_token_loss_uses_token_reducer(miles, monkeypatch):
+    state = _parallel_state(miles, cp_size=1)
+    monkeypatch.setattr(miles.cp_utils, "get_parallel_state", lambda: state)
+    monkeypatch.setattr(miles.loss, "get_parallel_state", lambda: state)
+
+    args = _args(loss_aggregation="token_mean", calculate_per_token_loss=True)
+    args.loss_type = "sft_loss"
+    args.global_batch_size = 2
+    args.use_dynamic_global_batch_size = False
+    args.recompute_loss_function = False
+    args.true_on_policy_mode = False
+
+    batch = {
+        "loss_masks": [torch.ones(2), torch.ones(3)],
+        "total_lengths": [2, 3],
+        "response_lengths": [2, 3],
+    }
+
+    def fake_loss_function(args, batch, logits, sum_of_sample_mean):
+        token_values = torch.arange(1.0, 6.0, device=logits.device)
+        loss = sum_of_sample_mean(token_values)
+        return loss, {"loss": loss.detach()}
+
+    monkeypatch.setattr(miles.loss, "get_loss_function", lambda args: fake_loss_function)
+
+    loss, normalizer, log_dict = miles.loss.loss_function(args, batch, 1, torch.ones((), requires_grad=True))
+
+    torch.testing.assert_close(loss, torch.tensor(15.0))
+    torch.testing.assert_close(normalizer, torch.tensor(5.0))
+    torch.testing.assert_close(log_dict["values"], torch.tensor([15.0]))
+    torch.testing.assert_close(log_dict["normalizers"], torch.tensor([5.0]))
+
+
+def test_value_loss_per_token_metrics_stay_token_normalized(miles, monkeypatch):
+    state = _parallel_state(miles, cp_size=1)
+    monkeypatch.setattr(miles.cp_utils, "get_parallel_state", lambda: state)
+    monkeypatch.setattr(miles.loss, "get_parallel_state", lambda: state)
+    monkeypatch.setattr(miles.log_utils, "get_parallel_state", lambda: state)
+    monkeypatch.setattr(miles.log_utils.MultiPGUtil, "all_reduce", lambda *args, **kwargs: None)
+
+    args = _args(loss_aggregation="token_mean", calculate_per_token_loss=True)
+    args.loss_type = "value_loss"
+    args.global_batch_size = 2
+    args.use_dynamic_global_batch_size = False
+    args.recompute_loss_function = False
+    args.true_on_policy_mode = False
+
+    batch = {
+        "loss_masks": [torch.ones(2), torch.ones(3)],
+        "total_lengths": [2, 3],
+        "response_lengths": [2, 3],
+    }
+
+    def fake_value_loss_function(args, batch, logits, sum_of_sample_mean):
+        # 3 of 5 tokens clipped: the logged fraction must be 0.6, not 3 / num_samples.
+        clipfrac = torch.tensor([1.0, 0.0, 1.0, 1.0, 0.0], device=logits.device)
+        loss = sum_of_sample_mean(clipfrac)
+        return loss, {
+            "value_loss": loss.detach(),
+            "value_clipfrac": sum_of_sample_mean(clipfrac).detach(),
+        }
+
+    monkeypatch.setattr(miles.loss, "get_loss_function", lambda args: fake_value_loss_function)
+
+    _, _, log_dict = miles.loss.loss_function(args, batch, 1, torch.ones((), requires_grad=True))
+    loss_dict = miles.log_utils.aggregate_train_losses([log_dict])
+
+    torch.testing.assert_close(torch.tensor(loss_dict["value_clipfrac"]), torch.tensor(0.6))
+
+
+def test_aggregate_train_losses_rejects_mixed_normalizer_contracts(miles, monkeypatch):
+    state = _parallel_state(miles, cp_size=1)
+    monkeypatch.setattr(miles.log_utils, "get_parallel_state", lambda: state)
+    monkeypatch.setattr(miles.log_utils.MultiPGUtil, "all_reduce", lambda *args, **kwargs: None)
+
+    with pytest.raises(ValueError, match="mix"):
+        miles.log_utils.aggregate_train_losses(
+            [
+                {
+                    "keys": ["pg_loss"],
+                    "values": torch.tensor([10.0]),
+                    "normalizers": torch.tensor([5.0]),
+                },
+                {
+                    "keys": ["pg_loss"],
+                    "values": torch.tensor([2.0, 6.0]),
+                },
+            ]
+        )
+
+
+def test_aggregate_train_losses_rejects_key_order_mismatch(miles, monkeypatch):
+    state = _parallel_state(miles, cp_size=1)
+    monkeypatch.setattr(miles.log_utils, "get_parallel_state", lambda: state)
+    monkeypatch.setattr(miles.log_utils.MultiPGUtil, "all_reduce", lambda *args, **kwargs: None)
+
+    with pytest.raises(ValueError, match="same keys"):
+        miles.log_utils.aggregate_train_losses(
+            [
+                {
+                    "keys": ["pg_loss", "ppo_kl"],
+                    "values": torch.tensor([10.0, 5.0]),
+                    "normalizers": torch.tensor([5.0, 2.0]),
+                },
+                {
+                    "keys": ["ppo_kl", "pg_loss"],
+                    "values": torch.tensor([5.0, 10.0]),
+                    "normalizers": torch.tensor([2.0, 5.0]),
+                },
+            ]
+        )
+
+
+def test_aggregate_train_losses_rejects_bad_legacy_value_count(miles, monkeypatch):
+    state = _parallel_state(miles, cp_size=1)
+    monkeypatch.setattr(miles.log_utils, "get_parallel_state", lambda: state)
+
+    with pytest.raises(ValueError, match="Expected 2 values"):
+        miles.log_utils.aggregate_train_losses(
+            [
+                {
+                    "keys": ["pg_loss"],
+                    "values": torch.tensor([10.0]),
+                },
+            ]
+        )
+
+
+def test_aggregate_train_losses_rejects_bad_normalizer_count(miles, monkeypatch):
+    state = _parallel_state(miles, cp_size=1)
+    monkeypatch.setattr(miles.log_utils, "get_parallel_state", lambda: state)
+
+    with pytest.raises(ValueError, match="Expected 2 normalizers"):
+        miles.log_utils.aggregate_train_losses(
+            [
+                {
+                    "keys": ["pg_loss", "ppo_kl"],
+                    "values": torch.tensor([10.0, 5.0]),
+                    "normalizers": torch.tensor([5.0]),
+                },
+            ]
+        )
+
+
+def test_aggregate_train_losses_rejects_zero_token_normalizer(miles, monkeypatch):
+    state = _parallel_state(miles, cp_size=1)
+    monkeypatch.setattr(miles.log_utils, "get_parallel_state", lambda: state)
+    monkeypatch.setattr(miles.log_utils.MultiPGUtil, "all_reduce", lambda *args, **kwargs: None)
+
+    with pytest.raises(ValueError, match="non-positive normalizer"):
+        miles.log_utils.aggregate_train_losses(
+            [
+                {
+                    "keys": ["pg_loss"],
+                    "values": torch.tensor([0.0]),
+                    "normalizers": torch.tensor([0.0]),
+                }
+            ]
+        )

--- a/tests/fast/backends/training_utils/test_loss_aggregation_args.py
+++ b/tests/fast/backends/training_utils/test_loss_aggregation_args.py
@@ -1,0 +1,229 @@
+import argparse
+from types import SimpleNamespace
+
+import pytest
+
+
+def _args(**overrides):
+    values = dict(
+        loss_aggregation="sample_mean",
+        loss_aggregation_divisor=None,
+        calculate_per_token_loss=False,
+        custom_tis_function_path=None,
+        indep_dp=False,
+        loss_type="policy_loss",
+        entropy_coef=0.0,
+        use_kl_loss=False,
+        kl_loss_coef=0.0,
+        global_batch_size=4,
+        n_samples_per_prompt=2,
+    )
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+@pytest.mark.parametrize("divisor", [None, 0.0, -1.0, float("nan"), float("inf"), float("-inf")])
+def test_constant_requires_positive_finite_divisor(miles, divisor):
+    with pytest.raises(ValueError, match="loss-aggregation-divisor"):
+        miles.arguments._validate_loss_aggregation_args(
+            _args(loss_aggregation="constant", loss_aggregation_divisor=divisor)
+        )
+
+
+def test_unknown_mode_from_custom_config_is_rejected(miles):
+    with pytest.raises(ValueError, match="Unknown --loss-aggregation mode"):
+        miles.arguments._validate_loss_aggregation_args(_args(loss_aggregation="typo"))
+
+
+@pytest.mark.parametrize(
+    ("overrides", "match"),
+    [
+        ({"loss_aggregation": ["token_mean"]}, "must be a string"),
+        ({"calculate_per_token_loss": "false"}, "must be a boolean"),
+    ],
+)
+def test_loss_aggregation_config_types_are_strict(miles, overrides, match):
+    with pytest.raises(ValueError, match=match):
+        miles.arguments._validate_loss_aggregation_args(_args(**overrides))
+
+
+@pytest.mark.parametrize("mode", ["prompt_mean", "token_mean"])
+def test_custom_tis_is_rejected_when_step_normalizer_can_change(miles, mode):
+    with pytest.raises(ValueError, match="custom-tis-function-path"):
+        miles.arguments._validate_loss_aggregation_args(
+            _args(loss_aggregation=mode, custom_tis_function_path="pkg.module:custom_tis")
+        )
+
+
+@pytest.mark.parametrize("mode", ["sample_mean", "constant"])
+def test_custom_tis_is_allowed_with_stable_step_normalizers(miles, mode):
+    miles.arguments._validate_loss_aggregation_args(
+        _args(
+            loss_aggregation=mode,
+            loss_aggregation_divisor=10.0 if mode == "constant" else None,
+            custom_tis_function_path="pkg.module:custom_tis",
+        )
+    )
+
+
+@pytest.mark.parametrize(
+    ("overrides", "expected_mode", "expected_per_token"),
+    [
+        ({}, "sample_mean", False),
+        ({"loss_aggregation": "token_mean"}, "token_mean", True),
+        ({"calculate_per_token_loss": True}, "token_mean", True),
+        ({"loss_aggregation": "constant", "loss_aggregation_divisor": 10.0}, "constant", False),
+    ],
+)
+def test_aliases_resolve_to_one_loss_aggregation_axis(miles, overrides, expected_mode, expected_per_token):
+    args = _args(**overrides)
+
+    miles.arguments._validate_loss_aggregation_args(args)
+
+    assert args.loss_aggregation == expected_mode
+    assert args.calculate_per_token_loss is expected_per_token
+
+
+@pytest.mark.parametrize("mode", ["constant", "prompt_mean"])
+def test_non_token_mode_rejects_calculate_per_token_loss(miles, mode):
+    args = _args(
+        loss_aggregation=mode,
+        loss_aggregation_divisor=10.0 if mode == "constant" else None,
+        calculate_per_token_loss=True,
+    )
+
+    with pytest.raises(ValueError, match="incompatible with --calculate-per-token-loss"):
+        miles.arguments._validate_loss_aggregation_args(args)
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"entropy_coef": 0.01},
+        {"use_kl_loss": True, "kl_loss_coef": 0.1},
+    ],
+)
+def test_token_mean_rejects_sample_normalized_auxiliary_losses(miles, overrides):
+    with pytest.raises(ValueError, match="auxiliary policy-loss terms are sample-normalized"):
+        miles.arguments._validate_loss_aggregation_args(_args(loss_aggregation="token_mean", **overrides))
+
+
+def test_token_mean_allows_zero_weight_auxiliary_metrics(miles):
+    miles.arguments._validate_loss_aggregation_args(
+        _args(loss_aggregation="token_mean", use_kl_loss=True, kl_loss_coef=0.0)
+    )
+
+
+@pytest.mark.parametrize(
+    ("mode", "global_batch_size", "should_pass"),
+    [
+        ("prompt_mean", 3, False),
+        ("prompt_mean", 6, True),
+        ("sample_mean", 3, True),
+    ],
+)
+def test_prompt_mean_requires_whole_groups_per_step(miles, mode, global_batch_size, should_pass):
+    args = _args(loss_aggregation=mode, global_batch_size=global_batch_size)
+    if should_pass:
+        miles.arguments._validate_loss_aggregation_args(args)
+    else:
+        with pytest.raises(ValueError, match="multiple of n_samples_per_prompt"):
+            miles.arguments._validate_loss_aggregation_args(args)
+
+
+_BASE_ARGV = [
+    "--rollout-batch-size",
+    "4",
+    "--n-samples-per-prompt",
+    "2",
+    "--num-steps-per-rollout",
+    "2",
+    "--num-rollout",
+    "1",
+]
+
+
+def _parse_and_validate(miles, *extra_args, config_text=None, tmp_path=None):
+    parser = argparse.ArgumentParser()
+    miles.arguments.get_miles_extra_args_provider()(parser)
+    argv = [*_BASE_ARGV, *extra_args]
+    if config_text is not None:
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(config_text)
+        argv.extend(["--custom-config-path", str(config_path)])
+    args = parser.parse_args(argv)
+    miles.arguments.miles_validate_args(args)
+    return args
+
+
+def test_validation_uses_derived_global_batch_size(miles):
+    argv = [
+        "--rollout-batch-size",
+        "3",
+        "--n-samples-per-prompt",
+        "2",
+        "--num-steps-per-rollout",
+        "2",
+        "--num-rollout",
+        "1",
+        "--loss-aggregation",
+        "prompt_mean",
+    ]
+    parser = argparse.ArgumentParser()
+    miles.arguments.get_miles_extra_args_provider()(parser)
+
+    with pytest.raises(ValueError, match="multiple of n_samples_per_prompt"):
+        miles.arguments.miles_validate_args(parser.parse_args(argv))
+
+
+def test_validation_runs_after_custom_config_overrides(miles, tmp_path):
+    config = "loss_aggregation: prompt_mean\nrollout_batch_size: 3\n"
+
+    with pytest.raises(ValueError, match="multiple of n_samples_per_prompt"):
+        _parse_and_validate(miles, config_text=config, tmp_path=tmp_path)
+
+
+def test_custom_global_batch_size_must_match_derived_value(miles, tmp_path):
+    config = "rollout_batch_size: 3\nglobal_batch_size: 4\n"
+
+    with pytest.raises(ValueError, match="global_batch_size 4 is not equal"):
+        _parse_and_validate(miles, config_text=config, tmp_path=tmp_path)
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        "loss_aggregation: sample_mean\ncalculate_per_token_loss: true\n",
+        "loss_aggregation: token_mean\ncalculate_per_token_loss: false\n",
+    ],
+)
+def test_custom_config_rejects_conflicting_alias_values(miles, tmp_path, config):
+    with pytest.raises(ValueError, match="conflicting values"):
+        _parse_and_validate(miles, config_text=config, tmp_path=tmp_path)
+
+
+@pytest.mark.parametrize(
+    ("cli_args", "config_mode", "expected_mode", "expected_per_token"),
+    [
+        ((), "token_mean", "token_mean", True),
+        (("--loss-aggregation", "token_mean"), "sample_mean", "sample_mean", False),
+        (("--calculate-per-token-loss",), "sample_mean", "sample_mean", False),
+    ],
+)
+def test_custom_config_overrides_both_cli_spellings(
+    miles,
+    tmp_path,
+    cli_args,
+    config_mode,
+    expected_mode,
+    expected_per_token,
+):
+    args = _parse_and_validate(
+        miles,
+        *cli_args,
+        config_text=f"loss_aggregation: {config_mode}\n",
+        tmp_path=tmp_path,
+    )
+
+    assert args.loss_aggregation == expected_mode
+    assert args.calculate_per_token_loss is expected_per_token

--- a/tests/fast/backends/training_utils/test_prompt_mean_data.py
+++ b/tests/fast/backends/training_utils/test_prompt_mean_data.py
@@ -1,0 +1,196 @@
+from types import SimpleNamespace
+
+import pytest
+
+
+def _sample(miles, group_index, index, response_length, loss_mask):
+    sample = miles.Sample(group_index=group_index, index=index, response_length=response_length, reward=1.0)
+    sample.tokens = [0] * response_length
+    sample.loss_mask = loss_mask
+    sample.status = miles.Sample.Status.COMPLETED
+    return sample
+
+
+def _args(**overrides):
+    values = dict(
+        advantage_estimator="grpo",
+        balance_data=False,
+        global_batch_size=4,
+        rewards_normalization=False,
+        reward_key=None,
+        use_dynamic_global_batch_size=False,
+        loss_aggregation="prompt_mean",
+        n_samples_per_prompt=2,
+        rollout_batch_size=2,
+        grpo_std_normalization=False,
+    )
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def _convert(miles, samples, args):
+    return miles.convert_samples_to_train_data(
+        args,
+        samples,
+        metadata={},
+        custom_convert_samples_to_train_data_func=None,
+        custom_reward_post_process_func=None,
+    )
+
+
+def test_conversion_computes_prompt_group_denominators(miles):
+    samples = [
+        _sample(miles, 0, 0, 3, [1, 1, 0]),
+        _sample(miles, 0, 1, 3, [1, 1, 1]),
+        _sample(miles, 1, 2, 4, [1, 0, 0, 0]),
+        _sample(miles, 1, 3, 4, [1, 1, 1, 1]),
+    ]
+
+    train_data = _convert(miles, samples, _args())
+
+    assert train_data["prompt_group_indices"] == [0, 0, 1, 1]
+    assert train_data["prompt_mask_sums"] == [5, 5, 5, 5]
+
+
+def test_conversion_rejects_incomplete_prompt_groups(miles):
+    samples = [
+        _sample(miles, 0, 0, 2, [1, 1]),
+        _sample(miles, 1, 1, 2, [1, 1]),
+    ]
+
+    with pytest.raises(ValueError, match="complete prompt groups"):
+        _convert(miles, samples, _args())
+
+
+def test_dp_split_keeps_prompt_groups_whole(miles, monkeypatch):
+    monkeypatch.setattr(miles.train_data_conversion.ray, "put", lambda value: value)
+    samples = [
+        _sample(miles, 0, 0, 3, [1, 1, 0]),
+        _sample(miles, 0, 1, 3, [1, 1, 1]),
+        _sample(miles, 1, 2, 4, [1, 0, 0, 0]),
+        _sample(miles, 1, 3, 4, [1, 1, 1, 1]),
+    ]
+    args = _args()
+
+    refs = miles.split_train_data_by_dp(args, _convert(miles, samples, args), dp_size=2)
+    parts = [ref.inner for ref in refs]
+
+    assert parts[0]["partition"] == [0, 1]
+    assert parts[1]["partition"] == [2, 3]
+    assert parts[0]["prompt_group_indices"] == [0, 0]
+    assert parts[1]["prompt_group_indices"] == [1, 1]
+    assert parts[0]["prompt_mask_sums"] == [5, 5]
+    assert parts[1]["prompt_mask_sums"] == [5, 5]
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "match"),
+    [
+        ("prompt_mask_sums", [4, 4, 4], "one prompt_mask_sums entry per sample"),
+        ("prompt_mask_sums", [99, 99, 4, 4], "inconsistent prompt_mask_sums"),
+        ("prompt_group_indices", [0, 1, 1, 1], "complete prompt groups"),
+    ],
+)
+def test_dp_split_rejects_malformed_prompt_metadata(miles, field, value, match):
+    samples = [
+        _sample(miles, 0, 0, 2, [1, 1]),
+        _sample(miles, 0, 1, 2, [1, 1]),
+        _sample(miles, 1, 2, 2, [1, 1]),
+        _sample(miles, 1, 3, 2, [1, 1]),
+    ]
+    args = _args()
+    train_data = _convert(miles, samples, args)
+    train_data[field] = value
+
+    with pytest.raises(ValueError, match=match):
+        miles.train_data_conversion.split_train_data_by_dp_raw(args, train_data, dp_size=2)
+
+
+def test_dp_split_rejects_undistributable_prompt_groups(miles, monkeypatch):
+    monkeypatch.setattr(miles.train_data_conversion.ray, "put", lambda value: value)
+    samples = [_sample(miles, group, 2 * group + sample, 2, [1, 1]) for group in range(3) for sample in range(2)]
+    args = _args()
+
+    with pytest.raises(ValueError, match="divisible by dp_size"):
+        miles.split_train_data_by_dp(args, _convert(miles, samples, args), dp_size=2)
+
+
+def test_dp_split_rejects_groups_that_straddle_steps(miles, monkeypatch):
+    monkeypatch.setattr(miles.train_data_conversion.ray, "put", lambda value: value)
+    samples = [_sample(miles, group, 4 * group + sample, 2, [1, 1]) for group in range(2) for sample in range(4)]
+    args = _args(n_samples_per_prompt=4, global_batch_size=4)
+
+    with pytest.raises(ValueError, match="straddle an optimizer-step boundary"):
+        miles.split_train_data_by_dp(args, _convert(miles, samples, args), dp_size=2)
+
+
+def test_dp_split_keeps_groups_aligned_across_multiple_steps(miles, monkeypatch):
+    monkeypatch.setattr(miles.train_data_conversion.ray, "put", lambda value: value)
+    samples = [_sample(miles, group, 4 * group + sample, 2, [1, 1]) for group in range(4) for sample in range(4)]
+    args = _args(n_samples_per_prompt=4, global_batch_size=8)
+
+    refs = miles.split_train_data_by_dp(args, _convert(miles, samples, args), dp_size=2)
+
+    for part in (ref.inner for ref in refs):
+        assert len(part["prompt_group_indices"]) == 8
+        for step_slice in (part["prompt_group_indices"][:4], part["prompt_group_indices"][4:]):
+            assert len(set(step_slice)) == 1
+
+
+def test_dp_split_requires_both_prompt_fields(miles):
+    with pytest.raises(ValueError, match="prompt_mask_sums"):
+        miles.train_data_conversion.split_train_data_by_dp_raw(
+            _args(),
+            {"tokens": [[0, 0]] * 4},
+            dp_size=2,
+        )
+
+
+def test_conversion_rejects_missing_group_index(miles):
+    samples = [
+        _sample(miles, None, 0, 2, [1, 1]),
+        _sample(miles, None, 1, 2, [1, 0]),
+    ]
+
+    with pytest.raises(ValueError, match="group_index"):
+        _convert(miles, samples, _args(rollout_batch_size=1))
+
+
+def test_default_mode_omits_prompt_metadata(miles):
+    samples = [
+        _sample(miles, 0, 0, 2, [1, 1]),
+        _sample(miles, 0, 1, 2, [1, 0]),
+    ]
+
+    train_data = _convert(miles, samples, _args(loss_aggregation="sample_mean", rollout_batch_size=1))
+
+    assert "prompt_group_indices" not in train_data
+    assert "prompt_mask_sums" not in train_data
+
+
+def test_token_mean_rejects_an_optimizer_step_without_active_tokens(miles):
+    data = {
+        "tokens": [[0, 0]] * 4,
+        "loss_masks": [[0, 0], [0, 0], [1, 0], [0, 1]],
+    }
+
+    with pytest.raises(ValueError, match="at least one active token"):
+        miles.train_data_conversion.split_train_data_by_dp_raw(
+            _args(loss_aggregation="token_mean", global_batch_size=2),
+            data,
+            dp_size=1,
+        )
+
+
+def test_token_mean_checks_steps_after_length_balancing(miles):
+    data = {
+        "tokens": [[0], [0, 0], [0], [0]],
+        "loss_masks": [[0], [1, 0], [0], [1]],
+    }
+
+    with pytest.raises(ValueError, match="at least one active token"):
+        miles.train_data_conversion.split_train_data_by_dp_raw(
+            _args(loss_aggregation="token_mean", global_batch_size=2, balance_data=True),
+            data,
+            dp_size=2,
+        )

--- a/tests/fast/backends/training_utils/test_true_on_policy_loss_metrics.py
+++ b/tests/fast/backends/training_utils/test_true_on_policy_loss_metrics.py
@@ -18,6 +18,8 @@ def _make_args(*, use_rollout_logprobs: bool) -> Namespace:
         eps_clip_high=0.2,
         custom_tis_function_path=None,
         custom_pg_loss_reducer_function_path=None,
+        loss_aggregation="sample_mean",
+        loss_aggregation_divisor=None,
         calculate_per_token_loss=False,
         qkv_format="thd",
         entropy_coef=0.0,

--- a/tests/fast/ray/rollout/conftest.py
+++ b/tests/fast/ray/rollout/conftest.py
@@ -45,6 +45,7 @@ def make_args(**overrides: Any) -> Namespace:
         disable_rollout_trim_samples=False,
         balance_data=False,
         delay_split_train_data_by_dp=False,
+        loss_aggregation="sample_mean",
         # advantage / reward
         advantage_estimator="grpo",
         rewards_normalization=True,

--- a/tests/fast/ray/rollout/test_train_data_conversion.py
+++ b/tests/fast/ray/rollout/test_train_data_conversion.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from unittest.mock import MagicMock
-
 import pytest
 import ray
 import torch
@@ -495,8 +493,7 @@ class TestSplitTrainDataRaw:
             "loss_masks": [[0, 0, 1], [0, 1], [0, 0, 0, 1], [0, 1]],
         }
 
-        args = MagicMock()
-        args.balance_data = False
+        args = make_args(balance_data=False)
 
         result = split_train_data_by_dp_raw(args, data, dp_size=2)
 
@@ -516,8 +513,7 @@ class TestSplitTrainDataRaw:
             "opd_reverse_kl": [[float(i)] for i in range(4)],
         }
 
-        args = MagicMock()
-        args.balance_data = False
+        args = make_args(balance_data=False)
 
         result = split_train_data_by_dp_raw(args, data, dp_size=2)
 
@@ -534,8 +530,7 @@ class TestSplitTrainDataRaw:
             "loss_masks": [[0, 1], [0, 1]],
         }
 
-        args = MagicMock()
-        args.balance_data = False
+        args = make_args(balance_data=False)
 
         result = split_train_data_by_dp_raw(args, data, dp_size=1)
         assert "seq_witness_ids" not in result[0]


### PR DESCRIPTION
## Description

Adds first-class policy-gradient loss aggregation modes while preserving the existing `sample_mean` default:

```text
--loss-aggregation {sample_mean,prompt_mean,token_mean,constant}
```

For one optimizer step, let `m_i` be the active-token count for sample `i`, `N` the sample count, `P` the prompt-group count, and `L` the configured constant divisor:

| Mode | Final policy-gradient scalar |
| --- | --- |
| `sample_mean` | `(1 / N) * sum_i(sum_t loss_it * mask_it / max(m_i, 1))` |
| `prompt_mean` | `(1 / P) * sum_g(sum_(i,t in g) loss_it * mask_it / max(sum_(i in g) m_i, 1))` |
| `token_mean` | `sum_(i,t) loss_it * mask_it / sum_i m_i` |
| `constant` | `sum_(i,t) loss_it * mask_it / (L * N)` |

`--calculate-per-token-loss` remains the backward-compatible spelling of `token_mean`. Custom pg-loss reducers still take precedence over the built-in modes.

## Design and constraints

- `token_mean` uses the global active-token count for the optimizer step on both Megatron and FSDP. Fully masked samples do not add phantom tokens, and an all-zero step is rejected before training.
- `prompt_mean` groups samples by `Sample.group_index`, validates complete groups and group token totals, and keeps groups within one DP shard and optimizer step.
- Train metrics carry per-key normalizers, so token-normalized loss metrics and sample-normalized diagnostics aggregate correctly across microbatches and DP/CP ranks.
- Nonzero entropy or KL-loss coefficients are rejected with policy `token_mean`, since those auxiliary terms retain sample normalization.
- Constant divisors must be positive and finite. Unknown YAML modes, invalid types, conflicting legacy/new settings, and malformed prompt metadata fail during configuration or data preparation.
- The built-in TIS path preserves masks and works with every mode. Custom TIS/RS remains supported with `sample_mean` and `constant`; it is rejected with `prompt_mean` and `token_mean` because a mask-changing custom reducer cannot supply a correct full-step denominator after microbatching.

Related implementations: THUDM/slime#2090 and areal-project/AReaL#1443.

## Validation

- 114 focused training/loss tests, including the pre-existing true-on-policy, CP, replay, and loss snapshot suites.
- 29 pre-existing rollout conversion and DP partitioning tests.
- Ruff and Black on every changed Python file.
- `python3 -m py_compile` on the changed runtime modules.
- `git diff --check origin/main`.

The focused coverage includes reducer algebra, CP slicing, FSDP token-scaling algebra, zero-mask handling, per-key log normalizers, config precedence, prompt metadata, and post-balancing optimizer-step validation.
