### PR TITLE
Fix: Remove trailing comma from help attribute causing tuple bug

### DIFF
--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -1330,7 +1330,7 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 default=None,
                 help=(
                     "Log statistics of the category of reward, such as why the reward function considers it as failed. "
-                    "Specify the key in the reward dict using this argument.",
+                    "Specify the key in the reward dict using this argument."
                 ),
             )
             parser.add_argument(


### PR DESCRIPTION
## Problem
Running `train_async.py --help` crashed with:
```
AttributeError: 'tuple' object has no attribute 'strip'
```

## Root Cause
The `--log-reward-category` argument had a trailing comma in its help attribute:
```python
help=(
    "Log statistics... "
    "Specify the key...",
),  # <- Trailing comma creates a tuple
```

In Python, `("text",)` is a tuple with one element, not a string. This caused argparse to fail when it tried to call `.strip()` on the tuple.

## Fix
Removed the trailing comma to make it a proper string:
```python
help=(
    "Log statistics... "
    "Specify the key..."
),
```

## Verification
- AST parsing confirms no tuple/list help attributes remain
- `train_async.py --help` now fails with expected module import error instead of tuple error