### PR TITLE
[fix] DeepSeek-V4 blockwise FP8: keep linear_weights_proj to bf16

### DIFF
--- a/miles_plugins/models/deepseek_v4/ops/qat.py
+++ b/miles_plugins/models/deepseek_v4/ops/qat.py
@@ -13,7 +13,9 @@ def fp8_simulate(x: torch.Tensor, block_size: int):
     the rest of the DeepSeek stack.
     """
     x_c = x.contiguous()
-    y, scale = act_quant(x_c, block_size, "ue8m0")
+    # Force fp32 scale storage: act_quant's auto dtype picks float8_e8m0fnu on
+    # Blackwell+DeepGEMM, but per_token_cast_back below only accepts int32/fp32 scales
+    y, scale = act_quant(x_c, block_size, "ue8m0", scale_dtype=torch.float32)
 
     N = x_c.size(-1)
     y_flat = y.view(-1, N)

--- a/miles_plugins/models/deepseek_v4/ops/qat.py
+++ b/miles_plugins/models/deepseek_v4/ops/qat.py
@@ -13,9 +13,7 @@ def fp8_simulate(x: torch.Tensor, block_size: int):
     the rest of the DeepSeek stack.
     """
     x_c = x.contiguous()
-    # Force fp32 scale storage: act_quant's auto dtype picks float8_e8m0fnu on
-    # Blackwell+DeepGEMM, but per_token_cast_back below only accepts int32/fp32 scales
-    y, scale = act_quant(x_c, block_size, "ue8m0", scale_dtype=torch.float32)
+    y, scale = act_quant(x_c, block_size, "ue8m0")
 
     N = x_c.size(-1)
     y_flat = y.view(-1, N)

--- a/scripts/run_deepseek_v4.py
+++ b/scripts/run_deepseek_v4.py
@@ -579,9 +579,7 @@ def _train(args: ScriptArgs):
         # Keep the DSA indexer weights_proj (a TELinear) in BF16 on the trainer: blockwise
         # fp8 on weights_proj is numerically unstable, so override it back to BF16 via TE.
         if "--te-precision-config-file" not in args.extra_args:
-            misc_args += (
-                f"--te-precision-config-file " f"{U.save_to_temp_file(_DSV4_TE_PRECISION_CONFIG, 'yaml')} "
-            )
+            misc_args += f"--te-precision-config-file " f"{U.save_to_temp_file(_DSV4_TE_PRECISION_CONFIG, 'yaml')} "
 
     train_args = (
         f"{ckpt_args} "

--- a/scripts/run_deepseek_v4.py
+++ b/scripts/run_deepseek_v4.py
@@ -56,6 +56,19 @@ _MEGATRON_MODEL_TYPE = {
 _PRO_MODEL_NAMES = ("DeepSeek-V4-Pro-FP8",)
 _BLACKWELL_HARDWARE = ("B200", "B300", "GB200", "GB300")
 
+_DSV4_TE_PRECISION_CONFIG = """
+configs:
+  bf16:
+    transformer_engine_config_type: "TEQuantizationParams"
+    training_recipe: {}
+matchers:
+  dsa_indexer_weights_proj_bf16:
+    type: "glob"
+    enabled: true
+    pattern: "*.self_attention.indexer.linear_weights_proj"
+    config: "bf16"
+""".strip()
+
 
 @dataclass
 class ScriptArgs(U.ExecuteTrainConfig):
@@ -563,6 +576,12 @@ def _train(args: ScriptArgs):
         # On Blackwell, TE emulates the blockwise recipe with MXFP8, which requires pow2 scales.
         fp32_scales = "0" if _is_blackwell(args) else "1"
         misc_args += f"""--train-env-vars '{{"NVTE_FP8_BLOCK_SCALING_FP32_SCALES":"{fp32_scales}"}}' """
+        # Keep the DSA indexer weights_proj (a TELinear) in BF16 on the trainer: blockwise
+        # fp8 on weights_proj is numerically unstable, so override it back to BF16 via TE.
+        if "--te-precision-config-file" not in args.extra_args:
+            misc_args += (
+                f"--te-precision-config-file " f"{U.save_to_temp_file(_DSV4_TE_PRECISION_CONFIG, 'yaml')} "
+            )
 
     train_args = (
         f"{ckpt_args} "

--- a/tools/convert_hf_to_fp8.py
+++ b/tools/convert_hf_to_fp8.py
@@ -137,6 +137,10 @@ def process_file(input_path, output_path, filename, strategy, block_size, result
             and "lm_head" not in key
             and "eh_proj" not in key
             and "weights_proj" not in key
+            and "head." not in key
+            and "wo_a" not in key
+            and "ffn.gate." not in key
+            and "compressor." not in key
             and "vision_tower" not in key
             and "mm_projector" not in key
         ):


### PR DESCRIPTION
## Changes

**`scripts/run_deepseek_v4.py` — keep the DSA indexer `weights_proj` in BF16 on the trainer**
- Add `_DSV4_TE_PRECISION_CONFIG`, a TE per-module precision override that matches
  `*.self_attention.indexer.linear_weights_proj` and forces it to BF16.
- Inject it via `--te-precision-config-file` in the `fp8_training` branch (skipped if the
  user already passes their own `--te-precision-config-file` through `--extra-args`).
  Blockwise FP8 on `weights_proj` is numerically unstable, so the trainer keeps it BF16.

**`tools/convert_hf_to_fp8.py` — keep more weights BF16 in the rollout checkpoint**
- Extend the skip list so `head.`, `wo_a`, `ffn.gate.`, and `compressor.` are left in BF16
  instead of being cast to FP8, matching the trainer's BF16 set. (In run_deepseek_v4, we do not need convert_hf_to_fp8 since the checkpoint already in fp8 format. Keep the change to avoid future bug.)

**`miles_plugins/models/deepseek_v4/ops/qat.py` — fix FP8 simulate scale dtype**
- Pass `scale_dtype=torch.float32` to `act_quant`. The auto dtype picks `float8_e8m0fnu`
  on Blackwell+DeepGEMM, but the downstream `per_token_cast_back` only accepts int32/fp32
  scales. `scale_fmt="ue8m0"` still rounds scale values to powers of two, so numerics are
  unchanged.

## Notes
- Scope is **blockwise FP8 only**
- The `--te-precision-config-file` injection is guarded so an explicit user-provided
  config in `--extra-args` takes precedence.

<img width="1164" height="31" alt="Screenshot 2026-06-29 at 11 08 14 AM" src="https://github.com/user-attachments/assets/6f993d72-679f-4055-ba19-7ff6e2e4b5c0" />
