### PR TITLE
(2/7) refactor: extract session core with direct HTTP responses

### DIFF
--- a/miles/rollout/session/core.py
+++ b/miles/rollout/session/core.py
@@ -185,7 +185,7 @@ class SessionCore:
             raise UpstreamResponseError(
                 "meta_info and output_token_logprobs must be in choice (requires logprobs=True)"
             )
-        assistant_message = choice.get("message", {})
+        assistant_message = choice.get("message") or {}
         if assistant_message.get("content") is None:
             raise UpstreamResponseError(
                 "assistant message content is None, when tool call parser failed SGLang should still return "

--- a/miles/rollout/session/core.py
+++ b/miles/rollout/session/core.py
@@ -16,7 +16,12 @@ from dataclasses import dataclass
 
 from starlette.responses import Response
 
-from miles.rollout.session.errors import SessionNotFoundError, TokenizationError, UpstreamResponseError
+from miles.rollout.session.errors import (
+    MessageValidationError,
+    SessionNotFoundError,
+    TokenizationError,
+    UpstreamResponseError,
+)
 from miles.rollout.session.linear_trajectory import SessionRegistry
 from miles.rollout.session.types import GetSessionResponse, SessionRecord
 
@@ -130,7 +135,10 @@ class SessionCore:
             if session.closing:
                 raise SessionNotFoundError(f"session not found: session_id={session_id}")
 
-            request_body = json.loads(body) if body else {}
+            try:
+                request_body = json.loads(body) if body else {}
+            except json.JSONDecodeError as e:
+                raise MessageValidationError(f"invalid JSON body: {e}") from e
 
             # TITO token tracking needs Miles-owned input_ids plus SGLang output
             # metadata: logprobs=True populates meta_info.output_token_logprobs and

--- a/miles/rollout/session/core.py
+++ b/miles/rollout/session/core.py
@@ -1,0 +1,242 @@
+"""Logic layer of the session server: ``SessionCore``.
+
+- Each operation takes a request's primitives (HTTP method, query string, headers, already-read body bytes), mutates session state and/or proxies upstream via the injected ``backend``, and returns a Starlette ``Response``.
+- Knows nothing about HTTP servers or routing; the FastAPI adapter (``sessions.py`` + ``server.py``) reads each request and calls these methods.
+- One ``SessionCore`` owns exactly one ``SessionRegistry`` (the per-session TITO/trajectory state) and one proxy ``backend``.
+- Operations: ``health``, ``create_session``, ``get_session``, ``delete_session``, ``chat_completions``, and a generic ``proxy``.
+- Correctness-critical path: ``chat_completions`` — the per-session lock is held for request prep and state update but never during the proxy call; the ``closing`` re-checks and the ``num_assistant`` mismatch check gate concurrent DELETE/chat.
+
+Structural extraction of the previous single-process route handlers; the observable behavior (status codes, parsed response content, error shapes, recorded trajectory) is unchanged.
+"""
+
+import json
+import logging
+import time
+from dataclasses import dataclass
+
+from starlette.responses import Response
+
+from miles.rollout.session.errors import SessionNotFoundError, TokenizationError, UpstreamResponseError
+from miles.rollout.session.linear_trajectory import SessionRegistry
+from miles.rollout.session.types import GetSessionResponse, SessionRecord
+
+logger = logging.getLogger(__name__)
+
+JSON_MEDIA_TYPE = "application/json"
+
+# Hop-by-hop / length-framing headers dropped from the upstream response so the
+# transport layer recomputes them from the body we actually send.
+_DROP_RESPONSE_HEADERS = ("content-length", "transfer-encoding", "content-encoding")
+
+
+@dataclass
+class ProxyRequest:
+    """Primitive carrier for the proxy backend (replaces fastapi.Request)."""
+
+    method: str
+    query: str = ""
+
+
+def _render_json(payload) -> bytes:
+    """Encode like Starlette's JSONResponse (compact, non-ASCII preserved)."""
+    return json.dumps(payload, ensure_ascii=False, allow_nan=False, separators=(",", ":")).encode("utf-8")
+
+
+def proxy_result_to_response(result: dict) -> Response:
+    """Build the client response from a proxy result.
+
+    Mirrors the previous ``SessionServer.build_proxy_response``: re-emit JSON
+    bodies as compact JSON (application/json), pass non-JSON bodies through
+    unchanged, and drop wire-level framing headers from upstream.
+    """
+    content = result["response_body"]
+    status_code = result["status_code"]
+    headers = {k: v for k, v in result["headers"].items() if k.lower() not in _DROP_RESPONSE_HEADERS}
+    content_type = headers.get("content-type", "")
+    try:
+        data = json.loads(content)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        # Match the old Response(media_type=content_type): pass it through verbatim
+        # (incl. "" when upstream sent no content-type) so the wire bytes are identical.
+        return Response(content=content, status_code=status_code, headers=headers, media_type=content_type)
+    return Response(content=_render_json(data), status_code=status_code, headers=headers, media_type=JSON_MEDIA_TYPE)
+
+
+class SessionCore:
+    """HTTP session operations over one ``SessionRegistry``."""
+
+    def __init__(self, backend, registry: SessionRegistry, args, session_server_instance_id=None):
+        self.backend = backend
+        self.registry = registry
+        self.args = args
+        self.instance_id = session_server_instance_id
+
+    async def health(self) -> Response:
+        body = {"status": "ok"}
+        if self.instance_id is not None:
+            body["session_server_instance_id"] = self.instance_id
+        return Response(content=_render_json(body), status_code=200, media_type=JSON_MEDIA_TYPE)
+
+    async def create_session(self) -> Response:
+        session_id = self.registry.create_session()
+        return Response(content=_render_json({"session_id": session_id}), status_code=200, media_type=JSON_MEDIA_TYPE)
+
+    async def get_session(self, session_id: str) -> Response:
+        session = self.registry.get_session(session_id)
+        metadata: dict = {}
+        try:
+            mismatch = self.registry.compute_session_mismatch(session)
+        except TokenizationError:
+            logger.exception("Failed to compute tito_session_mismatch for session %s", session_id)
+            mismatch = None
+        if mismatch is not None:
+            metadata["tito_session_mismatch"] = mismatch
+        metadata["accumulated_token_ids"] = session.token_ids
+        metadata["max_trim_tokens"] = self.registry.tito_tokenizer.max_trim_tokens
+        payload = GetSessionResponse(session_id=session_id, records=session.records, metadata=metadata)
+        return Response(
+            content=_render_json(payload.model_dump(mode="json")), status_code=200, media_type=JSON_MEDIA_TYPE
+        )
+
+    async def delete_session(self, session_id: str) -> Response:
+        session = self.registry.get_session(session_id)
+        if session.closing:
+            raise SessionNotFoundError(f"session not found: session_id={session_id}")
+        session.closing = True
+        # Acquire the lock so an in-flight chat finishes before we drop the session.
+        await session.lock.acquire()
+        try:
+            self.registry.remove_session(session_id)
+        finally:
+            session.lock.release()
+        return Response(status_code=204)
+
+    async def chat_completions(
+        self, session_id: str, *, method: str, query: str, headers: dict, body: bytes
+    ) -> Response:
+        """Proxy a chat completion through the backend with TITO token tracking.
+
+        Flow: prepare pretokenized input_ids (lock held briefly) → proxy to
+        backend (NO lock) → validate response → update trajectory checkpoint and
+        append record (lock held briefly). The lock is NOT held during the slow
+        proxy call so DELETE/other ops are not blocked if the agent disconnects.
+        """
+        session = self.registry.get_session(session_id)
+        if session.closing:
+            raise SessionNotFoundError(f"session not found: session_id={session_id}")
+
+        # --- Phase 1: prepare request (lock held briefly) ---
+        async with session.lock:
+            if session.closing:
+                raise SessionNotFoundError(f"session not found: session_id={session_id}")
+
+            request_body = json.loads(body) if body else {}
+
+            # TITO token tracking needs Miles-owned input_ids plus SGLang output
+            # metadata: logprobs=True populates meta_info.output_token_logprobs and
+            # return_meta_info wraps it in choice.meta_info. Hardcoded (not
+            # setdefault) so agent-side overrides cannot break token accumulation.
+            request_body["logprobs"] = True
+            request_body["return_meta_info"] = True
+            if getattr(self.args, "use_rollout_routing_replay", False):
+                request_body["return_routed_experts"] = True
+            if getattr(self.args, "use_rollout_indexer_replay", False):
+                request_body["return_indexer_topk"] = True
+            # Must be False so stop-token text is trimmed from assistant content;
+            # token IDs still come from logprobs below.
+            request_body["no_stop_trim"] = False
+
+            request_messages = request_body.get("messages", [])
+            prompt_token_ids = session.prepare_pretokenized(
+                request_messages,
+                tools=request_body.get("tools"),
+                tito_tokenizer=self.registry.tito_tokenizer,
+            )
+            request_body["input_ids"] = prompt_token_ids
+            logger.debug("Using TITO input_ids: %d tokens", len(prompt_token_ids))
+
+            proxy_body = json.dumps(request_body).encode()
+            expected_num_assistant = session.num_assistant
+        # --- lock released ---
+
+        # --- Phase 2: proxy to backend (NO lock held) ---
+        result = await self.backend.do_proxy(
+            ProxyRequest(method=method, query=query), "v1/chat/completions", body=proxy_body, headers=headers
+        )
+
+        # Non-200 (e.g. 400 context too long) passes through unrecorded so the
+        # agent can retry or handle the error.
+        if result["status_code"] != 200:
+            return proxy_result_to_response(result)
+
+        response = json.loads(result["response_body"])
+        choice = response.get("choices", [{}])[0]
+
+        meta_info = choice.get("meta_info")
+        if not isinstance(meta_info, dict) or "output_token_logprobs" not in meta_info:
+            raise UpstreamResponseError(
+                "meta_info and output_token_logprobs must be in choice (requires logprobs=True)"
+            )
+        assistant_message = choice.get("message", {})
+        if assistant_message.get("content") is None:
+            raise UpstreamResponseError(
+                "assistant message content is None, when tool call parser failed SGLang should still return "
+                "an empty content rather than None. Please check your modified SGLang version."
+            )
+
+        output_token_logprobs = meta_info["output_token_logprobs"]
+        completion_tokens = meta_info["completion_tokens"]
+
+        actual_output_logprobs_len = len(output_token_logprobs)
+        if actual_output_logprobs_len != completion_tokens:
+            raise UpstreamResponseError(
+                "invalid chat completion response: "
+                f"len(output_token_logprobs)={actual_output_logprobs_len} "
+                f"!= completion_tokens={completion_tokens}. "
+                f"Please check whether you use the correct SGLang branch which has fix the tokenizer batch decode issue."
+            )
+
+        completion_token_ids = [t[1] for t in output_token_logprobs]
+
+        # --- Phase 3: update state (lock held briefly) ---
+        async with session.lock:
+            if session.closing:
+                logger.warning(f"Session {session_id} closed during proxy, skipping state update")
+                return proxy_result_to_response(result)
+
+            if session.num_assistant != expected_num_assistant:
+                logger.warning(
+                    f"Session {session_id} state changed during proxy "
+                    f"(expected num_assistant={expected_num_assistant}, "
+                    f"got {session.num_assistant}), skipping state update"
+                )
+                return proxy_result_to_response(result)
+
+            session.update_pretokenized_state(
+                request_messages,
+                assistant_message,
+                prompt_token_ids=prompt_token_ids,
+                completion_token_ids=completion_token_ids,
+                max_trim_tokens=self.registry.tito_tokenizer.max_trim_tokens,
+            )
+
+            record = SessionRecord(
+                timestamp=time.time(),
+                method=method,
+                path="/v1/chat/completions",
+                status_code=result["status_code"],
+                request=request_body,
+                response=response,
+            )
+            session.append_record(record)
+        # --- lock released ---
+
+        return proxy_result_to_response(result)
+
+    async def proxy(
+        self, session_id: str, path: str, *, method: str, query: str, headers: dict, body: bytes
+    ) -> Response:
+        result = await self.backend.do_proxy(
+            ProxyRequest(method=method, query=query), path, body=body, headers=headers
+        )
+        return proxy_result_to_response(result)

--- a/miles/rollout/session/server.py
+++ b/miles/rollout/session/server.py
@@ -1,9 +1,9 @@
-"""Standalone Session Server that proxies through the inference router.
+"""Standalone session-server process: HTTP chassis + upstream proxy transport.
 
-This decouples session/TITO logic from the Miles Router, allowing sessions
-to work with the SGLang Rust Router or any other backend.  Inference
-requests are proxied through the router (sglang or miles), which handles
-load balancing and forwarding to worker engines.
+- ``SessionServer`` is a FastAPI app plus one shared httpx client; ``do_proxy`` forwards a request to the inference router (sglang or miles) — which does the load balancing to worker engines — and returns the raw result, or a 502 JSON error on transport failure.
+- Session/TITO logic lives in ``core.SessionCore``; ``setup_session_routes`` (``sessions.py``) wires the HTTP routes to it.
+- Standalone (own process, own event loop) so sessions also work with the SGLang Rust Router or any other backend, decoupled from the Miles Router.
+- ``run_session_server`` is the subprocess entry point: fresh interpreter, so it configures logging and the process title itself, then serves uvicorn.
 """
 
 import json
@@ -12,14 +12,16 @@ import logging
 import httpx
 import setproctitle
 import uvicorn
-from fastapi import FastAPI, Request
-from fastapi.responses import JSONResponse
-from starlette.responses import Response
+from fastapi import FastAPI
 
+from miles.rollout.session.core import ProxyRequest
 from miles.rollout.session.sessions import setup_session_routes
 from miles.utils.logging_utils import configure_logger
 
 logger = logging.getLogger(__name__)
+
+# Request headers that must not be forwarded verbatim to the upstream backend.
+_DROP_REQUEST_HEADERS = ("content-length", "transfer-encoding", "host")
 
 
 class SessionServer:
@@ -41,24 +43,12 @@ class SessionServer:
 
         setup_session_routes(self.app, self, args)
 
-    async def do_proxy(
-        self,
-        request: Request,
-        path: str,
-        body: bytes | None = None,
-        headers: dict | None = None,
-    ) -> dict:
+    async def do_proxy(self, request: ProxyRequest, path: str, *, body: bytes, headers: dict) -> dict:
         url = f"{self.backend_url}/{path}"
-        if request.url.query:
-            url = f"{url}?{request.url.query}"
+        if request.query:
+            url = f"{url}?{request.query}"
 
-        if body is None:
-            body = await request.body()
-        if headers is None:
-            headers = dict(request.headers)
-        headers = {
-            k: v for k, v in headers.items() if k.lower() not in ("content-length", "transfer-encoding", "host")
-        }
+        headers = {k: v for k, v in headers.items() if k.lower() not in _DROP_REQUEST_HEADERS}
 
         try:
             response = await self.client.request(request.method, url, content=body, headers=headers)
@@ -78,23 +68,6 @@ class SessionServer:
             "status_code": response.status_code,
             "headers": dict(response.headers),
         }
-
-    def build_proxy_response(self, result: dict) -> Response:
-        content = result["response_body"]
-        status_code = result["status_code"]
-        # Drop wire-level framing headers from upstream so Starlette rebuilds them
-        # from the body we actually send: transfer-encoding is hop-by-hop
-        headers = {
-            k: v
-            for k, v in result["headers"].items()
-            if k.lower() not in ("content-length", "transfer-encoding", "content-encoding")
-        }
-        content_type = headers.get("content-type", "")
-        try:
-            data = json.loads(content)
-            return JSONResponse(content=data, status_code=status_code, headers=headers)
-        except (json.JSONDecodeError, UnicodeDecodeError):
-            return Response(content=content, status_code=status_code, headers=headers, media_type=content_type)
 
 
 def run_session_server(args, backend_url: str):

--- a/miles/rollout/session/sessions.py
+++ b/miles/rollout/session/sessions.py
@@ -1,14 +1,17 @@
-import json
+"""Single-process FastAPI adapter for the session server.
+
+Thin layer: converts each HTTP request to primitive inputs, calls
+``SessionCore``. All session/TITO logic lives in ``core``.
+"""
+
 import logging
-import time
 
 from fastapi import Request
 from fastapi.responses import JSONResponse
-from starlette.responses import Response
 
-from miles.rollout.session.errors import SessionError, SessionNotFoundError, TokenizationError, UpstreamResponseError
+from miles.rollout.session.core import SessionCore
+from miles.rollout.session.errors import SessionError
 from miles.rollout.session.linear_trajectory import SessionRegistry
-from miles.rollout.session.types import GetSessionResponse, SessionRecord
 from miles.utils.chat_template_utils import get_tito_tokenizer
 from miles.utils.processing_utils import load_tokenizer
 
@@ -35,212 +38,47 @@ def setup_session_routes(app, backend, args):
     )
 
     registry = SessionRegistry(args, tokenizer, tito_tokenizer=tito_tokenizer)
-
-    @app.get("/health")
-    async def health():
-        body = {"status": "ok"}
-        if session_server_instance_id is not None:
-            body["session_server_instance_id"] = session_server_instance_id
-        return body
-
-    # --- DEBUG: track in-flight chat_completions ---
-    _inflight_chat = {"count": 0}
-
-    @app.middleware("http")
-    async def debug_request_logger(request: Request, call_next):
-        client = request.client
-        client_info = f"{client.host}:{client.port}" if client else "unknown"
-        logger.info(
-            f"[session-server] REQUEST ARRIVED: {request.method} {request.url.path} from={client_info} inflight_chat={_inflight_chat['count']}"
-        )
-        t0 = time.time()
-        response = await call_next(request)
-        elapsed = time.time() - t0
-        logger.info(
-            f"[session-server] REQUEST DONE: {request.method} {request.url.path} status={response.status_code} elapsed={elapsed:.3f}s from={client_info}"
-        )
-        return response
+    core = SessionCore(backend, registry, args, session_server_instance_id)
 
     @app.exception_handler(SessionError)
     async def session_error_handler(request: Request, exc: SessionError):
         return JSONResponse(status_code=exc.status_code, content={"error": str(exc)})
 
+    @app.get("/health")
+    async def health():
+        return await core.health()
+
     @app.post("/sessions")
     async def create_session():
-        session_id = registry.create_session()
-        return {"session_id": session_id}
+        return await core.create_session()
 
     @app.get("/sessions/{session_id}")
     async def get_session(session_id: str):
-        session = registry.get_session(session_id)
-        metadata = {}
-        try:
-            mismatch = registry.compute_session_mismatch(session)
-        except TokenizationError:
-            logger.exception("Failed to compute tito_session_mismatch for session %s", session_id)
-            mismatch = None
-        if mismatch is not None:
-            metadata["tito_session_mismatch"] = mismatch
-        metadata["accumulated_token_ids"] = session.token_ids
-        metadata["max_trim_tokens"] = registry.tito_tokenizer.max_trim_tokens
-        return GetSessionResponse(
-            session_id=session_id,
-            records=session.records,
-            metadata=metadata,
-        )
+        return await core.get_session(session_id)
 
     @app.delete("/sessions/{session_id}")
     async def delete_session(session_id: str):
-        session = registry.get_session(session_id)
-        if session.closing:
-            raise SessionNotFoundError(f"session not found: session_id={session_id}")
-        session.closing = True
-        logger.debug(
-            f"[session-server] DELETE waiting for lock: session={session_id} lock_locked={session.lock.locked()}"
-        )
-        await session.lock.acquire()
-        logger.debug(f"[session-server] DELETE acquired lock: session={session_id}")
-        try:
-            registry.remove_session(session_id)
-        finally:
-            session.lock.release()
-        return Response(status_code=204)
+        return await core.delete_session(session_id)
 
     @app.post("/sessions/{session_id}/v1/chat/completions")
     async def chat_completions(request: Request, session_id: str):
-        """Proxy a chat completion through SGLang with TITO token tracking.
-
-        Flow: prepare pretokenized input_ids (lock held briefly) → inject
-        SGLang flags → proxy to backend (NO lock) → validate response →
-        update trajectory checkpoint (lock held briefly) → append session record.
-
-        The lock is NOT held during the slow proxy call to avoid blocking
-        DELETE/other operations when the agent disconnects mid-request.
-        """
-        _inflight_chat["count"] += 1
-        try:
-            session = registry.get_session(session_id)
-            if session.closing:
-                raise SessionNotFoundError(f"session not found: session_id={session_id}")
-
-            # --- Phase 1: prepare request (lock held briefly) ---
-            async with session.lock:
-                # Double-check: session may have been marked closing while waiting for lock.
-                if session.closing:
-                    raise SessionNotFoundError(f"session not found: session_id={session_id}")
-
-                body = await request.body()
-                request_body = json.loads(body) if body else {}
-
-                # TITO token tracking requires Miles-owned input_ids plus SGLang
-                # output-token metadata:
-                #   logprobs=True     → populates meta_info.output_token_logprobs
-                #   return_meta_info  → wraps the above in choice.meta_info
-                # Both flags are hardcoded (not set default) to prevent agent-side
-                # overrides from breaking the token accumulation invariants.
-                request_body["logprobs"] = True
-                request_body["return_meta_info"] = True
-                if getattr(args, "use_rollout_routing_replay", False):
-                    request_body["return_routed_experts"] = True
-                if getattr(args, "use_rollout_indexer_replay", False):
-                    request_body["return_indexer_topk"] = True
-                # Must be False so stop-token text is trimmed from assistant
-                # message content; token IDs are still taken from logprobs below.
-                request_body["no_stop_trim"] = False
-
-                request_messages = request_body.get("messages", [])
-                prompt_token_ids = session.prepare_pretokenized(
-                    request_messages,
-                    tools=request_body.get("tools"),
-                    tito_tokenizer=registry.tito_tokenizer,
-                )
-                request_body["input_ids"] = prompt_token_ids
-                logger.debug(
-                    "Using TITO input_ids: %d tokens",
-                    len(prompt_token_ids),
-                )
-
-                body = json.dumps(request_body).encode()
-                expected_num_assistant = session.num_assistant
-            # --- lock released here ---
-
-            # --- Phase 2: proxy to SGLang (NO lock held) ---
-            result = await backend.do_proxy(request, "v1/chat/completions", body=body)
-
-            # If SGLang returned a non-200 error (e.g. 400 for context too long),
-            # pass it through to the agent without recording — the agent can retry
-            # or handle the error.
-            if result["status_code"] != 200:
-                return backend.build_proxy_response(result)
-
-            response = json.loads(result["response_body"])
-
-            choice = response.get("choices", [{}])[0]
-
-            meta_info = choice.get("meta_info")
-            if not isinstance(meta_info, dict) or "output_token_logprobs" not in meta_info:
-                raise UpstreamResponseError(
-                    "meta_info and output_token_logprobs must be in choice (requires logprobs=True)"
-                )
-            assistant_message = choice.get("message", {})
-            if assistant_message.get("content") is None:
-                raise UpstreamResponseError(
-                    "assistant message content is None, when tool call parser failed SGLang should still return "
-                    "an empty content rather than None. Please check your modified SGLang version."
-                )
-
-            output_token_logprobs = meta_info["output_token_logprobs"]
-            completion_tokens = meta_info["completion_tokens"]
-
-            actual_output_logprobs_len = len(output_token_logprobs)
-            if actual_output_logprobs_len != completion_tokens:
-                raise UpstreamResponseError(
-                    "invalid chat completion response: "
-                    f"len(output_token_logprobs)={actual_output_logprobs_len} "
-                    f"!= completion_tokens={completion_tokens}. "
-                    f"Please check whether you use the correct SGLang branch which has fix the tokenizer batch decode issue."
-                )
-
-            completion_token_ids = [t[1] for t in output_token_logprobs]
-
-            # --- Phase 3: update state (lock held briefly) ---
-            async with session.lock:
-                if session.closing:
-                    logger.warning(f"Session {session_id} closed during proxy, skipping state update")
-                    return backend.build_proxy_response(result)
-
-                if session.num_assistant != expected_num_assistant:
-                    logger.warning(
-                        f"Session {session_id} state changed during proxy "
-                        f"(expected num_assistant={expected_num_assistant}, "
-                        f"got {session.num_assistant}), skipping state update"
-                    )
-                    return backend.build_proxy_response(result)
-
-                session.update_pretokenized_state(
-                    request_messages,
-                    assistant_message,
-                    prompt_token_ids=prompt_token_ids,
-                    completion_token_ids=completion_token_ids,
-                    max_trim_tokens=registry.tito_tokenizer.max_trim_tokens,
-                )
-
-                record = SessionRecord(
-                    timestamp=time.time(),
-                    method=request.method,
-                    path="/v1/chat/completions",
-                    status_code=result["status_code"],
-                    request=request_body,
-                    response=response,
-                )
-                session.append_record(record)
-            # --- lock released here ---
-
-            return backend.build_proxy_response(result)
-        finally:
-            _inflight_chat["count"] -= 1
+        body = await request.body()
+        return await core.chat_completions(
+            session_id,
+            method=request.method,
+            query=request.url.query,
+            headers=dict(request.headers),
+            body=body,
+        )
 
     @app.api_route("/sessions/{session_id}/{path:path}", methods=["GET", "POST", "PUT", "DELETE", "PATCH"])
     async def session_proxy(request: Request, session_id: str, path: str):
-        result = await backend.do_proxy(request, path)
-        return backend.build_proxy_response(result)
+        body = await request.body()
+        return await core.proxy(
+            session_id,
+            path,
+            method=request.method,
+            query=request.url.query,
+            headers=dict(request.headers),
+            body=body,
+        )

--- a/tests/fast/router/test_sessions.py
+++ b/tests/fast/router/test_sessions.py
@@ -138,3 +138,15 @@ class TestSessionProxy:
         record = records[0]
         assert record["path"] == "/v1/chat/completions"
         assert record["status_code"] == 200
+
+    def test_chat_malformed_json_body_returns_400(self, router_env):
+        session_id = requests.post(f"{router_env.url}/sessions", timeout=5.0).json()["session_id"]
+
+        resp = requests.post(
+            f"{router_env.url}/sessions/{session_id}/v1/chat/completions",
+            data=b"{not json",
+            headers={"Content-Type": "application/json"},
+            timeout=10.0,
+        )
+        assert resp.status_code == 400
+        assert resp.json()["error"].startswith("invalid JSON body:")

--- a/tests/fast/router/test_sessions.py
+++ b/tests/fast/router/test_sessions.py
@@ -150,3 +150,22 @@ class TestSessionProxy:
         )
         assert resp.status_code == 400
         assert resp.json()["error"].startswith("invalid JSON body:")
+
+    def test_chat_upstream_null_message_returns_502(self, router_env):
+        session_id = requests.post(f"{router_env.url}/sessions", timeout=5.0).json()["session_id"]
+
+        fixture_response = MockSGLangServer._compute_chat_completions_response
+
+        def null_message_response(self, payload: dict) -> dict:
+            response = fixture_response(self, payload)
+            response["choices"][0]["message"] = None
+            return response
+
+        with patch.object(MockSGLangServer, "_compute_chat_completions_response", new=null_message_response):
+            resp = requests.post(
+                f"{router_env.url}/sessions/{session_id}/v1/chat/completions",
+                json={"messages": [{"role": "user", "content": "hi"}]},
+                timeout=10.0,
+            )
+        assert resp.status_code == 502
+        assert "assistant message content is None" in resp.json()["error"]


### PR DESCRIPTION
> Stacked on #1569 (the session_ prefix rename). Base = `refactor/session-pkg-rename`.

## Summary
Extract session route behavior into `SessionCore`. Pure extraction; behavior preserved. The R3 client-strip stacks on this as its own PR (#1563).

## Motivation
`sessions.py` mixed FastAPI request adaptation with session/TITO state transitions. This PR makes the route layer thin while keeping Starlette `Response` as the HTTP return contract.

## Before / After
| Area | Before | After |
|---|---|---|
| Route layer | `sessions.py` owned FastAPI adaptation and session flow. | `sessions.py` reads `Request` data and calls `SessionCore`. |
| Core layer | Session behavior lived in route handlers. | `SessionCore` owns session CRUD, chat/TITO state transitions, and proxy response rendering. |
| Backend proxy | `do_proxy` accepted FastAPI `Request`. | `do_proxy` accepts `ProxyRequest`. |

## Behavior Preservation
Functional behavior is preserved: HTTP status codes, parsed response content, request/response header filtering, the hardcoded upstream flags (`logprobs`/`return_meta_info`/`no_stop_trim`/conditional R3 flags/`input_ids`), the three chat lock phases, every upstream-response validation check and its order, the `num_assistant`-mismatch handling (warn + skip state update + return the upstream 200), the `SessionRecord` fields, and non-200 passthrough. Existing session route and race-condition tests pass.

Two intended **non-functional** changes:
1. **Body-read timing / lock scope.** The FastAPI route now reads `await request.body()` before entering `SessionCore.chat_completions` (previously the body was read inside `session.lock`, after the session lookup). JSON parsing, TITO mutation, and record writes remain under `session.lock`; backend proxying remains outside it. Consequences: a chat to a missing/closing session consumes the full request body before returning the error; in a DELETE-vs-chat race during body upload the chat is more likely to be rejected (404). The race outcome was already non-deterministic and the race-condition tests pass.
2. **Debug request-logging removed.** The per-request `debug_request_logger` middleware (the `[session-server] REQUEST ARRIVED/DONE …` INFO lines and the `_inflight_chat` counter) and the two DELETE lock `debug` lines are removed. Logging-only; no contract impact.

## Verification
- `python -m pytest tests/fast/router/test_sessions.py -q` → 7 passed.
- `python -m pytest tests/fast/router/test_session_race_conditions.py -q` → 9 passed.
- `python -m pytest tests/fast/router/` → 73 passed.
- `python -m black --check miles/rollout/session/core.py miles/rollout/session/sessions.py miles/rollout/session/server.py` passed.

## Review Focus
- `SessionCore.chat_completions`: TITO record updates and accepted body-read timing.
- `proxy_result_to_response`: backend response rendering.
- `SessionServer.do_proxy`: request forwarding with `ProxyRequest`.



