### PR TITLE
Add packed SFT rollout for pretokenized blocks

### DIFF
--- a/docs/packed_sft_rollout.md
+++ b/docs/packed_sft_rollout.md
@@ -1,0 +1,63 @@
+# Packed SFT Rollout
+
+Miles can train pre-packed SFT blocks by using a custom data source and rollout
+function. This path is useful when samples are pre-tokenized offline into long
+blocks, for example near-128K DeepSeek-V4 SFT blocks.
+
+Each JSONL row is one training sample:
+
+```json
+{"tokens":[0,128803,42,43],"loss_mask":[0,0,1,1],"metadata":{"source":"example"}}
+```
+
+The required fields are:
+
+- `tokens`: full token ids for one packed block.
+- `loss_mask`: either a full-length 0/1 mask aligned to `tokens`, or a tail mask
+  when `response_length` is also provided. Full-length masks may be sparse, so
+  one packed block can contain multiple conversations and multiple assistant
+  spans.
+- `response_length`: optional. When omitted with a full-length mask, Miles keeps
+  token 0 as the prefix token and uses `tokens[1:]` as the response window.
+
+The first trainable token cannot be token position 0. Miles shifts the response
+mask into next-token prediction positions during training, so every packed block
+needs at least one prefix/context token before the first trainable token.
+
+Use:
+
+```bash
+--data-source-path miles.rollout.packed_sft_rollout.PackedSFTDataSource \
+--rollout-function-path miles.rollout.packed_sft_rollout.generate_rollout \
+--prompt-data /path/to/packed.jsonl \
+--input-key ignored \
+--rollout-batch-size 64 \
+--global-batch-size 64 \
+--loss-type sft_loss \
+--calculate-per-token-loss \
+--disable-compute-advantages-and-returns \
+--debug-train-only
+```
+
+For DeepSeek-V4 BSHD long-context training, this is compatible with fixed
+`--micro-batch-size 1`, `--qkv-format bshd`, CP, and `--allgather-cp`.
+
+This is offline packing, not native multi-sample THD sequence packing. Tokens in
+one JSONL row form one continuous autoregressive context, so add separators in
+the offline packer if document boundaries matter.
+
+To build a packed JSONL from an OpenAI-style SFT JSONL:
+
+```bash
+python scripts/tools/pack_sft_jsonl.py \
+  --input /path/to/train.shuffle.max131073.jsonl \
+  --output /path/to/train.shuffle.max131073.packed128k.jsonl \
+  --hf-checkpoint /path/to/DeepSeek-V4-Flash-bf16 \
+  --loss-mask-type deepseek_v4 \
+  --block-size 131072
+```
+
+The packer emits `response_length = len(tokens) - 1` and `loss_mask[1:]`, so
+the first token in each packed block is context only. This matches Miles'
+next-token loss alignment while still allowing sparse loss over multiple
+assistant spans inside the block.

--- a/miles/rollout/packed_sft_rollout.py
+++ b/miles/rollout/packed_sft_rollout.py
@@ -1,0 +1,334 @@
+import argparse
+import json
+import logging
+import os
+import random
+from dataclasses import dataclass
+from typing import Any
+
+from miles.utils.types import Sample
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class PackedSFTRecord:
+    tokens: list[int]
+    response_length: int
+    loss_mask: list[int]
+    metadata: dict[str, Any]
+
+
+class PackedSFTDataset:
+    def __init__(self, args):
+        self.args = args
+        self.seed = args.rollout_seed
+        self.epoch_id = -1
+        self.origin_samples = [
+            self._record_to_sample(row_id, row) for row_id, row in enumerate(_read_jsonl(args.prompt_data))
+        ]
+        if not self.origin_samples:
+            raise ValueError(f"Packed SFT dataset is empty: {args.prompt_data}")
+        self.samples = self.origin_samples
+
+    def _record_to_sample(self, row_id: int, row: dict[str, Any]) -> Sample:
+        record = _parse_record(
+            row,
+            row_id=row_id,
+            tokens_key=self.args.packed_sft_tokens_key,
+            loss_mask_key=self.args.packed_sft_loss_mask_key,
+            response_length_key=self.args.packed_sft_response_length_key,
+            metadata_key=self.args.metadata_key,
+            max_length=self.args.rollout_max_context_len,
+            allow_empty_loss=self.args.packed_sft_allow_empty_loss,
+        )
+        return Sample(
+            group_index=row_id,
+            index=row_id,
+            prompt="",
+            tokens=record.tokens,
+            response_length=record.response_length,
+            reward=0,
+            loss_mask=record.loss_mask,
+            status=Sample.Status.COMPLETED,
+            metadata=record.metadata,
+        )
+
+    def shuffle(self, new_epoch_id: int) -> None:
+        if self.epoch_id == new_epoch_id:
+            return
+
+        random.seed(self.seed + new_epoch_id)
+        permutation = list(range(len(self.samples)))
+        random.shuffle(permutation)
+        self.samples = [self.origin_samples[i] for i in permutation]
+        self.epoch_id = new_epoch_id
+
+    def __getitem__(self, idx: int) -> Sample:
+        return self.samples[idx]
+
+    def __len__(self) -> int:
+        return len(self.samples)
+
+
+class PackedSFTDataSource:
+    """Data source for already-tokenized packed SFT blocks.
+
+    Each JSONL row is one training sample. The row must contain token ids and a
+    loss mask. The mask may be full-length and sparse, which is required when a
+    block contains multiple packed conversations, or a tail response-window mask
+    when an explicit response_length is supplied.
+    """
+
+    def __init__(self, args):
+        self.args = args
+        self.epoch_id = 0
+        self.sample_offset = 0
+        self.sample_group_index = 0
+        self.sample_index = 0
+        self.metadata = {}
+        self.dataset = PackedSFTDataset(args)
+        if self.args.rollout_shuffle:
+            self.dataset.shuffle(self.epoch_id)
+
+    def get_samples(self, num_samples: int) -> list[list[Sample]]:
+        if self.sample_offset + num_samples <= len(self.dataset):
+            prompt_samples = self.dataset.samples[self.sample_offset : self.sample_offset + num_samples]
+            self.sample_offset += num_samples
+        else:
+            prompt_samples = self.dataset.samples[self.sample_offset :]
+            num_samples -= len(prompt_samples)
+            self.epoch_id += 1
+            if self.args.rollout_shuffle:
+                self.dataset.shuffle(self.epoch_id)
+            prompt_samples += self.dataset.samples[:num_samples]
+            self.sample_offset = num_samples
+
+        samples = []
+        for prompt_sample in prompt_samples:
+            group = []
+            for _ in range(self.args.n_samples_per_prompt):
+                sample = _clone_packed_sample(
+                    prompt_sample,
+                    group_index=self.sample_group_index,
+                    index=self.sample_index,
+                )
+                self.sample_index += 1
+                group.append(sample)
+            self.sample_group_index += 1
+            samples.append(group)
+        return samples
+
+    def add_samples(self, samples: list[list[Sample]]) -> None:
+        raise RuntimeError(f"Cannot add samples to {self.__class__.__name__}. This is a read-only data source.")
+
+    def save(self, rollout_id: int) -> None:
+        state_dict = {
+            "sample_offset": self.sample_offset,
+            "epoch_id": self.epoch_id,
+            "sample_group_index": self.sample_group_index,
+            "sample_index": self.sample_index,
+            "metadata": self.metadata,
+        }
+        path = os.path.join(self.args.save, f"rollout/global_dataset_state_dict_{rollout_id}.pt")
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        import torch
+
+        torch.save(state_dict, path)
+
+    def load(self, rollout_id: int | None = None) -> None:
+        if self.args.load is None:
+            return
+
+        path = os.path.join(self.args.load, f"rollout/global_dataset_state_dict_{rollout_id}.pt")
+        if not os.path.exists(path):
+            logger.info(f"Checkpoint {path} does not exist.")
+            return
+
+        logger.info(f"load metadata from {path}")
+        import torch
+
+        state_dict = torch.load(path)
+        self.sample_offset = state_dict.get("sample_offset", 0)
+        self.epoch_id = state_dict.get("epoch_id", 0)
+        self.sample_group_index = state_dict.get("sample_group_index", 0)
+        self.sample_index = state_dict.get("sample_index", 0)
+        self.metadata = state_dict.get("metadata", {})
+
+        if self.args.rollout_shuffle:
+            self.dataset.shuffle(self.epoch_id)
+
+
+def generate_rollout(args, rollout_id, data_buffer, evaluation=False):
+    assert not evaluation
+    groups = data_buffer.get_samples(args.rollout_batch_size)
+    flat = [sample for group in groups for sample in group]
+    total_tokens = sum(len(sample.tokens) for sample in flat)
+    loss_tokens = sum(sum(sample.loss_mask or []) for sample in flat)
+    logger.info(
+        "packed_sft_rollout::generate_rollout rollout_id=%s samples=%s total_tokens=%s loss_tokens=%s",
+        rollout_id,
+        len(flat),
+        total_tokens,
+        loss_tokens,
+    )
+    metrics = {
+        "packed_sft/total_tokens": total_tokens,
+        "packed_sft/loss_tokens": loss_tokens,
+        "packed_sft/avg_tokens_per_sample": total_tokens / max(len(flat), 1),
+        "packed_sft/avg_loss_tokens_per_sample": loss_tokens / max(len(flat), 1),
+    }
+    try:
+        from miles.rollout.base_types import RolloutFnTrainOutput
+    except ModuleNotFoundError:
+        return groups
+    return RolloutFnTrainOutput(samples=groups, metrics=metrics)
+
+
+def _add_arguments(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
+    parser.add_argument("--packed-sft-tokens-key", type=str, default="tokens")
+    parser.add_argument("--packed-sft-loss-mask-key", type=str, default="loss_mask")
+    parser.add_argument("--packed-sft-response-length-key", type=str, default="response_length")
+    parser.add_argument(
+        "--packed-sft-allow-empty-loss",
+        action="store_true",
+        default=False,
+        help="Allow packed blocks whose loss mask has no positive token. Disabled by default to catch bad packing.",
+    )
+    return parser
+
+
+generate_rollout.add_arguments = _add_arguments
+
+
+def _parse_record(
+    row: dict[str, Any],
+    *,
+    row_id: int,
+    tokens_key: str,
+    loss_mask_key: str,
+    response_length_key: str,
+    metadata_key: str,
+    max_length: int,
+    allow_empty_loss: bool,
+) -> PackedSFTRecord:
+    tokens = _parse_int_list(row.get(tokens_key), key=tokens_key, row_id=row_id)
+    if not tokens:
+        raise ValueError(f"row {row_id}: {tokens_key} must not be empty")
+    if len(tokens) > max_length:
+        raise ValueError(f"row {row_id}: packed token length {len(tokens)} exceeds max_length={max_length}")
+
+    loss_mask = _parse_int_list(row.get(loss_mask_key), key=loss_mask_key, row_id=row_id)
+    if any(x not in (0, 1) for x in loss_mask):
+        raise ValueError(f"row {row_id}: {loss_mask_key} must contain only 0/1 values")
+    if not allow_empty_loss and 1 not in loss_mask:
+        raise ValueError(f"row {row_id}: {loss_mask_key} contains no trainable token")
+
+    response_length = row.get(response_length_key)
+    if response_length is None:
+        if len(loss_mask) != len(tokens):
+            raise ValueError(
+                f"row {row_id}: full-length {loss_mask_key} must match tokens length "
+                f"when {response_length_key} is absent "
+                f"({len(loss_mask)} != {len(tokens)})"
+            )
+        if loss_mask[0]:
+            raise ValueError(
+                f"row {row_id}: first trainable token is at position 0; packed SFT blocks need at least "
+                "one prefix token before the first loss token"
+            )
+        response_length = len(tokens) - 1
+        loss_mask = loss_mask[1:]
+    else:
+        response_length = _parse_non_negative_int(response_length, key=response_length_key, row_id=row_id)
+        if response_length > len(tokens):
+            raise ValueError(
+                f"row {row_id}: {response_length_key}={response_length} exceeds tokens length={len(tokens)}"
+            )
+        if response_length == len(tokens):
+            raise ValueError(
+                f"row {row_id}: {response_length_key} equals tokens length; packed SFT blocks need at least "
+                "one prefix token before the response window"
+            )
+        elif len(loss_mask) == len(tokens):
+            prefix_mask = loss_mask[:-response_length] if response_length > 0 else loss_mask
+            if any(prefix_mask):
+                raise ValueError(
+                    f"row {row_id}: full-length {loss_mask_key} has trainable tokens outside the explicit "
+                    f"{response_length_key} tail window"
+                )
+            loss_mask = loss_mask[-response_length:] if response_length > 0 else []
+        elif len(loss_mask) != response_length:
+            raise ValueError(
+                f"row {row_id}: {loss_mask_key} length must equal tokens length or {response_length_key} "
+                f"({len(loss_mask)} not in {{{len(tokens)}, {response_length}}})"
+            )
+
+    if len(loss_mask) != response_length:
+        raise ValueError(
+            f"row {row_id}: normalized {loss_mask_key} length {len(loss_mask)} "
+            f"!= {response_length_key} {response_length}"
+        )
+    if not allow_empty_loss and 1 not in loss_mask:
+        raise ValueError(f"row {row_id}: normalized {loss_mask_key} contains no trainable token")
+
+    metadata = row.get(metadata_key) or {}
+    if not isinstance(metadata, dict):
+        raise ValueError(f"row {row_id}: {metadata_key} must be an object when provided")
+    metadata = dict(metadata)
+    metadata.setdefault("packed_sft_row_id", row_id)
+    metadata["packed_sft_total_length"] = len(tokens)
+    metadata["packed_sft_loss_tokens"] = sum(loss_mask)
+
+    return PackedSFTRecord(tokens=tokens, response_length=response_length, loss_mask=loss_mask, metadata=metadata)
+
+
+def _parse_int_list(value: Any, *, key: str, row_id: int) -> list[int]:
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"row {row_id}: {key} is not valid JSON") from exc
+    if not isinstance(value, list):
+        raise ValueError(f"row {row_id}: {key} must be a list of integers")
+    if not all(isinstance(x, int) for x in value):
+        raise ValueError(f"row {row_id}: {key} must be a list of integers")
+    return value
+
+
+def _parse_non_negative_int(value: Any, *, key: str, row_id: int) -> int:
+    if not isinstance(value, int) or value < 0:
+        raise ValueError(f"row {row_id}: {key} must be a non-negative integer")
+    return value
+
+
+def _read_jsonl(path: str):
+    if not os.path.exists(path):
+        raise FileNotFoundError(f"Packed SFT dataset path '{path}' does not exist.")
+    if not path.endswith(".jsonl"):
+        raise ValueError(f"Packed SFT dataset path '{path}' must be a .jsonl file.")
+
+    with open(path, encoding="utf-8") as f:
+        for line_num, line in enumerate(f):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                yield json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"JSON decode error at line {line_num} in {path}: {exc}") from exc
+
+
+def _clone_packed_sample(sample: Sample, *, group_index: int, index: int) -> Sample:
+    return Sample(
+        group_index=group_index,
+        index=index,
+        prompt=sample.prompt,
+        tokens=list(sample.tokens),
+        response=sample.response,
+        response_length=sample.response_length,
+        reward=sample.reward,
+        loss_mask=list(sample.loss_mask) if sample.loss_mask is not None else None,
+        status=sample.status,
+        metadata=dict(sample.metadata),
+    )

--- a/scripts/tools/pack_sft_jsonl.py
+++ b/scripts/tools/pack_sft_jsonl.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""Pack OpenAI-style SFT JSONL into pretokenized Miles packed-SFT blocks."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+from sglang.srt.entrypoints.openai.protocol import Tool
+
+from miles.rollout.sft_rollout import MultiTurnLossMaskGenerator
+from miles.utils.processing_utils import load_tokenizer
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", required=True, help="Input SFT JSONL with messages/tools fields.")
+    parser.add_argument("--output", required=True, help="Output packed JSONL with tokens/loss_mask fields.")
+    parser.add_argument("--report", default=None, help="Optional JSON report path.")
+    parser.add_argument("--hf-checkpoint", required=True, help="HF tokenizer/checkpoint path.")
+    parser.add_argument("--input-key", default="messages")
+    parser.add_argument("--tool-key", default="tools")
+    parser.add_argument("--metadata-key", default="metadata")
+    parser.add_argument("--loss-mask-type", default="deepseek_v4")
+    parser.add_argument("--block-size", type=int, default=131072)
+    parser.add_argument("--min-fill-ratio", type=float, default=0.0)
+    parser.add_argument("--max-rows", type=int, default=None)
+    parser.add_argument("--num-shards", type=int, default=1)
+    parser.add_argument("--shard-id", type=int, default=0)
+    parser.add_argument("--trust-remote-code", action="store_true", default=True)
+    parser.add_argument("--log-interval", type=int, default=1000)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    if args.block_size <= 1:
+        raise ValueError("--block-size must be greater than 1")
+    if not 0.0 <= args.min_fill_ratio <= 1.0:
+        raise ValueError("--min-fill-ratio must be in [0, 1]")
+    if args.num_shards <= 0:
+        raise ValueError("--num-shards must be positive")
+    if args.shard_id < 0 or args.shard_id >= args.num_shards:
+        raise ValueError("--shard-id must satisfy 0 <= shard_id < num_shards")
+
+    output = Path(args.output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    report_path = Path(args.report) if args.report else output.with_suffix(output.suffix + ".report.json")
+
+    tokenizer = load_tokenizer(args.hf_checkpoint, trust_remote_code=args.trust_remote_code)
+    mask_generator = MultiTurnLossMaskGenerator(tokenizer, tokenizer_type=args.loss_mask_type)
+
+    stats = {
+        "input": args.input,
+        "output": str(output),
+        "hf_checkpoint": args.hf_checkpoint,
+        "loss_mask_type": args.loss_mask_type,
+        "block_size": args.block_size,
+        "min_fill_ratio": args.min_fill_ratio,
+        "num_shards": args.num_shards,
+        "shard_id": args.shard_id,
+        "rows_seen": 0,
+        "rows_selected": 0,
+        "rows_packed": 0,
+        "rows_dropped": 0,
+        "blocks_written": 0,
+        "total_tokens": 0,
+        "total_loss_tokens": 0,
+        "max_sample_tokens": 0,
+        "max_block_tokens": 0,
+        "min_block_tokens": None,
+        "tool_rows": 0,
+        "started_at": time.time(),
+        "dropped_examples": [],
+    }
+
+    current_tokens: list[int] = []
+    current_loss_mask: list[int] = []
+    current_rows: list[dict[str, Any]] = []
+
+    def flush_block(writer, *, force: bool = False) -> None:
+        if not current_tokens:
+            return
+        fill_ratio = len(current_tokens) / args.block_size
+        if not force and fill_ratio < args.min_fill_ratio:
+            return
+        metadata = {
+            "packed_source_rows": list(current_rows),
+            "packed_num_sequences": len(current_rows),
+            "packed_fill_ratio": fill_ratio,
+        }
+        writer.write(
+            json.dumps(
+                {
+                    "tokens": current_tokens,
+                    "response_length": len(current_tokens) - 1,
+                    "loss_mask": current_loss_mask[1:],
+                    "metadata": metadata,
+                },
+                ensure_ascii=False,
+                separators=(",", ":"),
+            )
+            + "\n"
+        )
+        stats["blocks_written"] += 1
+        stats["max_block_tokens"] = max(stats["max_block_tokens"], len(current_tokens))
+        stats["min_block_tokens"] = (
+            len(current_tokens)
+            if stats["min_block_tokens"] is None
+            else min(stats["min_block_tokens"], len(current_tokens))
+        )
+        current_tokens.clear()
+        current_loss_mask.clear()
+        current_rows.clear()
+
+    with open(args.input, encoding="utf-8") as reader, open(output, "w", encoding="utf-8") as writer:
+        for row_id, line in enumerate(reader):
+            if args.max_rows is not None and row_id >= args.max_rows:
+                break
+            line = line.strip()
+            if not line:
+                continue
+
+            stats["rows_seen"] += 1
+            if row_id % args.num_shards != args.shard_id:
+                continue
+            stats["rows_selected"] += 1
+            try:
+                row = json.loads(line)
+                messages = row[args.input_key]
+                tools = row.get(args.tool_key)
+                if tools:
+                    tools = [Tool.model_validate(t).model_dump() for t in tools]
+                    stats["tool_rows"] += 1
+                tokens, loss_mask = mask_generator.get_loss_mask(messages, tools=tools)
+            except Exception as exc:
+                _record_drop(stats, row_id, "parse_or_tokenize_error", str(exc))
+                continue
+
+            if len(tokens) != len(loss_mask):
+                _record_drop(stats, row_id, "mask_length_mismatch", f"{len(tokens)} != {len(loss_mask)}")
+                continue
+            if len(tokens) > args.block_size:
+                _record_drop(stats, row_id, "too_long", f"{len(tokens)} > {args.block_size}")
+                continue
+            if 1 not in loss_mask:
+                _record_drop(stats, row_id, "empty_loss_mask", "no trainable assistant tokens")
+                continue
+
+            if current_tokens and len(current_tokens) + len(tokens) > args.block_size:
+                flush_block(writer, force=True)
+
+            current_tokens.extend(tokens)
+            current_loss_mask.extend(loss_mask)
+            current_rows.append(
+                {
+                    "row_id": row_id,
+                    "tokens": len(tokens),
+                    "loss_tokens": sum(loss_mask),
+                    "metadata": row.get(args.metadata_key) or {},
+                }
+            )
+            stats["rows_packed"] += 1
+            stats["total_tokens"] += len(tokens)
+            stats["total_loss_tokens"] += sum(loss_mask)
+            stats["max_sample_tokens"] = max(stats["max_sample_tokens"], len(tokens))
+
+            if args.log_interval and stats["rows_seen"] % args.log_interval == 0:
+                elapsed = max(time.time() - stats["started_at"], 1e-6)
+                print(
+                    "PACK shard={shard_id}/{num_shards} rows_seen={rows_seen} rows_selected={rows_selected} "
+                    "rows_packed={rows_packed} blocks={blocks_written} total_tokens={total_tokens} "
+                    "tok_s={tok_s:.1f}".format(
+                        tok_s=stats["total_tokens"] / elapsed,
+                        **stats,
+                    ),
+                    flush=True,
+                )
+
+        flush_block(writer, force=True)
+
+    stats["finished_at"] = time.time()
+    stats["elapsed_seconds"] = stats["finished_at"] - stats["started_at"]
+    stats["avg_tokens_per_block"] = stats["total_tokens"] / max(stats["blocks_written"], 1)
+    stats["avg_loss_tokens_per_block"] = stats["total_loss_tokens"] / max(stats["blocks_written"], 1)
+    stats["packing_fill_ratio"] = stats["avg_tokens_per_block"] / args.block_size
+    with open(report_path, "w", encoding="utf-8") as f:
+        json.dump(stats, f, ensure_ascii=False, indent=2)
+        f.write("\n")
+
+    print(
+        "PACK DONE shard={shard_id}/{num_shards} rows_seen={rows_seen} rows_selected={rows_selected} "
+        "rows_packed={rows_packed} rows_dropped={rows_dropped} blocks={blocks_written} "
+        "avg_tokens_per_block={avg_tokens_per_block:.1f} fill={packing_fill_ratio:.4f} report={report}".format(
+            report=str(report_path), **stats
+        ),
+        flush=True,
+    )
+
+
+def _record_drop(stats: dict[str, Any], row_id: int, reason: str, detail: str) -> None:
+    stats["rows_dropped"] += 1
+    if len(stats["dropped_examples"]) < 20:
+        stats["dropped_examples"].append({"row_id": row_id, "reason": reason, "detail": detail})
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/fast/rollout/test_packed_sft_rollout.py
+++ b/tests/fast/rollout/test_packed_sft_rollout.py
@@ -1,0 +1,132 @@
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from miles.rollout.packed_sft_rollout import PackedSFTDataSource, generate_rollout
+
+
+def _write_jsonl(path, rows):
+    with open(path, "w", encoding="utf-8") as f:
+        for row in rows:
+            f.write(json.dumps(row) + "\n")
+
+
+def _args(path, **overrides):
+    args = SimpleNamespace(
+        prompt_data=str(path),
+        rollout_seed=123,
+        rollout_shuffle=False,
+        n_samples_per_prompt=1,
+        metadata_key="metadata",
+        rollout_max_context_len=16,
+        packed_sft_tokens_key="tokens",
+        packed_sft_loss_mask_key="loss_mask",
+        packed_sft_response_length_key="response_length",
+        packed_sft_allow_empty_loss=False,
+        rollout_batch_size=2,
+        save=str(path.parent / "ckpt"),
+        load=None,
+    )
+    for key, value in overrides.items():
+        setattr(args, key, value)
+    return args
+
+
+def test_full_length_sparse_loss_mask_uses_whole_block_response_window(tmp_path):
+    data = tmp_path / "packed.jsonl"
+    _write_jsonl(data, [{"tokens": [10, 11, 12, 13, 14], "loss_mask": [0, 1, 0, 1, 0]}])
+
+    source = PackedSFTDataSource(_args(data, rollout_batch_size=1))
+    sample = source.get_samples(1)[0][0]
+
+    assert sample.tokens == [10, 11, 12, 13, 14]
+    assert sample.response_length == 4
+    assert sample.loss_mask == [1, 0, 1, 0]
+    assert sample.reward == 0
+    assert sample.metadata["packed_sft_total_length"] == 5
+    assert sample.metadata["packed_sft_loss_tokens"] == 2
+
+
+def test_explicit_response_length_accepts_tail_loss_mask(tmp_path):
+    data = tmp_path / "packed.jsonl"
+    _write_jsonl(data, [{"tokens": [10, 11, 12, 13, 14], "response_length": 2, "loss_mask": [0, 1]}])
+
+    source = PackedSFTDataSource(_args(data, rollout_batch_size=1))
+    sample = source.get_samples(1)[0][0]
+
+    assert sample.response_length == 2
+    assert sample.loss_mask == [0, 1]
+
+
+def test_explicit_response_length_accepts_full_loss_mask_and_crops_tail(tmp_path):
+    data = tmp_path / "packed.jsonl"
+    _write_jsonl(data, [{"tokens": [10, 11, 12, 13, 14], "response_length": 2, "loss_mask": [0, 0, 0, 1, 1]}])
+
+    source = PackedSFTDataSource(_args(data, rollout_batch_size=1))
+    sample = source.get_samples(1)[0][0]
+
+    assert sample.response_length == 2
+    assert sample.loss_mask == [1, 1]
+
+
+def test_explicit_whole_block_response_length_is_rejected(tmp_path):
+    data = tmp_path / "packed.jsonl"
+    _write_jsonl(data, [{"tokens": [10, 11, 12, 13], "response_length": 4, "loss_mask": [0, 1, 0, 1]}])
+
+    with pytest.raises(ValueError, match="equals tokens length"):
+        PackedSFTDataSource(_args(data, rollout_batch_size=1))
+
+
+def test_rejects_overlength_block(tmp_path):
+    data = tmp_path / "packed.jsonl"
+    _write_jsonl(data, [{"tokens": list(range(17)), "loss_mask": [0] * 16 + [1]}])
+
+    with pytest.raises(ValueError, match="exceeds max_length=16"):
+        PackedSFTDataSource(_args(data))
+
+
+def test_rejects_empty_loss_by_default(tmp_path):
+    data = tmp_path / "packed.jsonl"
+    _write_jsonl(data, [{"tokens": [1, 2, 3], "loss_mask": [0, 0, 0]}])
+
+    with pytest.raises(ValueError, match="contains no trainable token"):
+        PackedSFTDataSource(_args(data))
+
+
+def test_rejects_loss_starting_at_first_token(tmp_path):
+    data = tmp_path / "packed.jsonl"
+    _write_jsonl(data, [{"tokens": [1, 2, 3], "loss_mask": [1, 1, 1]}])
+
+    with pytest.raises(ValueError, match="first trainable token is at position 0"):
+        PackedSFTDataSource(_args(data))
+
+
+def test_rejects_explicit_response_window_with_prefix_loss(tmp_path):
+    data = tmp_path / "packed.jsonl"
+    _write_jsonl(data, [{"tokens": [1, 2, 3, 4], "response_length": 2, "loss_mask": [0, 1, 1, 1]}])
+
+    with pytest.raises(ValueError, match="outside the explicit"):
+        PackedSFTDataSource(_args(data))
+
+
+def test_generate_rollout_returns_groups_and_metrics(tmp_path):
+    data = tmp_path / "packed.jsonl"
+    _write_jsonl(
+        data,
+        [
+            {"tokens": [1, 2, 3], "loss_mask": [0, 1, 1]},
+            {"tokens": [4, 5], "loss_mask": [0, 1]},
+        ],
+    )
+
+    args = _args(data, rollout_batch_size=2)
+    source = PackedSFTDataSource(args)
+    output = generate_rollout(args, rollout_id=0, data_buffer=source, evaluation=False)
+
+    samples = output.samples if hasattr(output, "samples") else output
+    assert len(samples) == 2
+    assert samples[0][0].tokens == [1, 2, 3]
+    if hasattr(output, "metrics"):
+        assert output.metrics["packed_sft/total_tokens"] == 5
+        assert output.metrics["packed_sft/loss_tokens"] == 3


### PR DESCRIPTION
This PR adds a custom packed SFT rollout path for pretokenized 128K training blocks.\n\nWhat changed:\n- Add `miles.rollout.packed_sft_rollout.PackedSFTDataSource` for JSONL rows with `tokens` and `loss_mask`.\n- Add `miles.rollout.packed_sft_rollout.generate_rollout` so Miles can train directly on pre-packed blocks without dynamic token batch packing.\n- Validate max context length, non-empty trainable tokens, binary loss masks, response-tail alignment, and first-token loss masking.\n- Document the JSONL contract and example launch flags.\n- Add fast unit tests for full-length masks, tail masks, invalid masks, overlength samples, and rollout output grouping.\n\nLocal checks:\n- `python3 -m py_compile miles/rollout/packed_sft_rollout.py tests/fast/rollout/test_packed_sft_rollout.py`\n- `git diff -- docs/packed_sft_rollout.md miles/rollout/packed_sft_rollout.py tests/fast/rollout/test_packed_sft_rollout.py --check`\n\n`pytest` was not available in this local environment, and the local environment also lacks the full torch/ray runtime, so runtime validation should run in the Miles training image.