### PR TITLE
(2/4) feat(ci): metric-history gate — offline historical gate + register_ci_gate (M2)

### DIFF
--- a/docs/ci/03-metric-history-gate.md
+++ b/docs/ci/03-metric-history-gate.md
@@ -21,6 +21,32 @@ The gate compares a number only against earlier numbers of the same kind, from t
 
 The store's baseline query keys on exactly these (plus a `limit` for how many recent points to read): `recent_trusted_values(test_path, backend, suite, metric_key, steps_key, constraint_key, step, limit)`.
 
+## Steps & constraint: what is compared, and by which rule
+
+**Goal:** let a test declare, as literal data next to its CI registration, which values of a metric are judged and by what rule — validated at parse time, with missing or non-finite data always surfacing as ERROR rather than a silent skip.
+
+A gate declaration composes a step selection and a constraint, both validated at parse time:
+
+- `steps` — which value(s) of the metric's series to compare: `"last"` (the series' last point, a whole-series reduction), `"all"` (every step present), or a list of step indices. `"all"` and a step list fan out to one comparison per step, judged against that step's own history.
+- **Constraint** — whether one value passes against a reference: every constraint is two-sided — the value must land in the corridor `[ref − band_down, ref + band_up]`, each side's band written independently as `band = max(rel·|ref|, abs_floor)`; a literal dict of those params (`rel_up` / `abs_floor_up` / `rel_down` / `abs_floor_down`), at least one param per side written. Bands scale from the reference only, so a deviating value cannot widen its own tolerance. There is no unbounded side — a value far from baseline in the "improving" direction is usually a broken metric, and a trusted run's values become future baselines, so admitting it would drag the mean; a side meant to be lenient gets a wide band, not no band.
+
+The authoritative constraint params are the schema table beside the function; the doc does not duplicate them. A missing/empty series, a missing required step, or a non-finite value (`NaN` / `±Inf`) at a selected coordinate is an ERROR verdict, never a skip — non-finite is judged here, not silently dropped (capture records it faithfully as a strict-JSON string marker the gate-side reader decodes; `write_run` refuses it at the DB boundary).
+
+A declaration sits at top level of the test file, next to its CI registration — `register_*_ci` decides where the test runs, `register_ci_gate` what is judged after it passes. A gate declaration alone does nothing: an unregistered file is never collected.
+
+```python
+from tests.ci.ci_register import register_cuda_ci
+from tests.ci.metric_history import register_ci_gate
+
+register_cuda_ci(est_time=300, suite="stage-c-8-gpu-h100")
+
+register_ci_gate(
+    metric_key="train/ppo_kl",                     # must be a captured key (whitelist)
+    steps=[0, 1],                                  # judge steps 0 and 1, each against its own history
+    constraint={"abs_floor_up": 0.02, "rel_down": 0.8, "abs_floor_down": 0.02},
+)
+```
+
 ## The gate: drift against trusted history
 
 **Goal:** judge every declared coordinate against its own trusted past, so slow drift gets caught while a fresh baseline can seed itself.
@@ -29,6 +55,61 @@ After a test passes, each comparison coordinate's value is judged by its spec's 
 
 - **Historical gate** — activates with ≥1 trusted point at the coordinate. `ref` = mean of the coordinate's trusted values. Catches drift.
 - **Cold start** (0 trusted): the gate is inactive — not an error. Zero active checks means the run is vacuously trusted: that is how a fresh baseline gets seeded (recover a poisoned seed via `mark_untrusted`).
+
+A fanned-out spec (`steps="all"` or a step list) contributes one verdict per step; the run is trusted iff **every** coordinate's active checks pass.
+
+The gate's data input is the run's **merged per-run JSONL record**:
+
+- *Merged, per-run*: three processes (the `train.py` driver, the training actor's main rank, the rollout manager) call `init_tracking`, each snapshotting to its own record file. In practice no whitelisted key is logged by more than one of them (today the actor's main rank logs them all), so the merge is a plain union; a key that does appear in several files just gets its series concatenated and step-sorted.
+- *JSONL* (JSON Lines): one self-contained JSON line per metric — `{"metric": <key>, "series": [[step, value], ...]}` — each line stands alone, so a process killed mid-run still leaves a parseable record. Capture writes the per-process files, the merge produces this one, and the gate only reads it (`parse_merged_record`, decoding the non-finite string markers back to floats).
+
+How one spec flows from declaration to verdict:
+
+```mermaid
+flowchart TD
+    subgraph parse_sg["declare & parse — static, per test file"]
+        decl["the gate declaration — a marker in the test file, runtime no-op<br>register_ci_gate(metric_key, steps, constraint)"]
+        spec(["the parsed spec — what to judge, by which rule<br>CiGateSpec: steps literal + normalized constraint dict"])
+        decl -- "read the file's AST, never execute it<br>(hence literal-only args); per-name schema validation<br>parse_ci_gate_specs" --> spec
+    end
+
+    record(["the run's captured metrics (one file per run, parsed once)<br>merged per-run JSONL record: raw per-step log() values,<br>capture whitelist TARGET_METRIC_KEYS only<br>parse_merged_record → {metric_key: series}"])
+
+    subgraph eval_sg["evaluate — _evaluate_spec, once per spec"]
+        lookup["find the spec's metric in the record<br>series = by_metric.get(spec.metric_key)"]
+        pick["pick the value(s) to judge — ×N, one per selected step<br>select(series, steps) → list of Selection (value, step)"]
+        coord(["one comparison coordinate — the key this value's history<br>is stored under: (metric_key, steps_key, constraint_key, step) (see Identity)"])
+        err["outcome: ERROR — judged, never skipped<br>coordinate untrusted"]
+        histq{"does this coordinate have<br>any trusted history?<br>recent_trusted_values(run-series identity,<br>coordinate, limit = 20)"}
+        inactive["outcome: HISTORICAL = INACTIVE — cold start, not a failure"]
+        hist["HISTORICAL check — drift against this coordinate's own past<br>evaluate_constraint(constraint, value, ref = mean of n values) → PASS | FAIL"]
+        result(["one verdict per coordinate<br>MetricGateResult: historical status + reason"])
+        lookup -- "metric missing from the record" --> err
+        lookup --> pick
+        pick -- "SelectionError: empty series ·<br>required step missing · non-finite value" --> err
+        pick --> coord
+        coord --> histq
+        histq -- "0 rows" --> inactive
+        histq -- "n ≥ 1 rows" --> hist
+        hist --> result
+        inactive --> result
+        err --> result
+    end
+
+    spec --> lookup
+    record --> lookup
+
+    trust["run-level verdict — after all specs, once per run<br>run trusted ⇔ every coordinate: historical ∈ {PASS, INACTIVE}<br>(what the verdict triggers: see 'Trust, cleanup, who writes')"]
+    store[("this test's own metric history<br>MetricHistoryStore — SQLite offline · Neon hosted backend")]
+
+    result --> trust
+    store -- "baseline read" --> histq
+    trust -- "a trusted run's values are persisted (write_run) and become<br>future baselines — writer: the harness, on nightly-marked runs only" --> store
+```
+
+
+
+Chart key: rectangle = a step or check; rounded box = a data artifact; diamond = a branch; cylinder = the store. Each check yields one status per coordinate — PASS / FAIL / ERROR / INACTIVE — where INACTIVE arises from a historical cold start. *run-series identity* = `(test_path, backend, suite)`; it and the value coordinate `(metric_key, steps_key, constraint_key, step)` are defined in the Identity section above.
 
 ## Storage: two backends, two tables
 
@@ -80,3 +161,19 @@ Shadow-first: collect, store, and evaluate, but **never block a PR** initially �
 - A test-file edit does not reset the series: `test_file_hash` was dropped from the run-series identity because a tiny edit to a test kept wiping its whole history. A test change that genuinely shifts a metric's expected level surfaces as gate failures instead; the reset levers are manual — `mark_untrusted` the stale runs, or edit the declaration literals (new `steps_key` / `constraint_key` ⇒ fresh coordinate).
 - The nightly trigger (`schedule` cron + `nightly` label) already shipped (#1491); detection here is harness-side via `GITHUB_EVENT_NAME`, so this feature needs **no** `pr-test.yml` **edit**.
 - Open: should a brand-new test's first baselines need human confirmation before counting as trusted? (v1: no.)
+
+## TODO
+
+**Goal:** collect everything planned but not implemented in one place — a doc-first pass must not conform code to this section; current behavior is everything above it.
+
+- **Hard gate returns as a pure absolute bound.** The removed hard layer mixed two motivations that want different judging logic: a sanity check ("from experience this metric must stay below X" — a plain one-sided limit, no tolerance) and a backstop against implicit drift that the historical gate absorbs (e.g. a logp diff growing a little per PR: each run sits within band of a baseline that itself follows the drift). The old implementation fed `hard_ref` through the same band constraint as a reference value (`evaluate_constraint(constraint, value, ref=hard_ref)`), giving a sanity limit tolerance semantics it should not have. Target — two unmixed declaration flavors:
+  - `register_ci_gate(...)` without `hard_ref` — the relative check against trusted history, exactly as documented above.
+  - `register_ci_gate(..., hard_ref=X)` — a plain absolute bound: the selected value must stay on the right side of `X` (an upper or lower limit), no band, no history involved. `hard_ref` is a limit, never a pinned pseudo-history reference value — synthesizing a baseline from it was considered and rejected as hard to implement. **It will not read any historical data.**
+  - Baselines survive both the removal and the return: `hard_ref` was policy, never part of the value coordinate, so adding or dropping the absolute flavor never resets a series.
+- **One-line declaration for standard metrics (a separate PR, after this stack)** — today `register_ci_gate(metric_key="train/train_rollout_logprob_abs_diff")` alone is a parse error (steps and constraint are required); target: a per-`metric_key` defaults table beside the parser (`register.py`) supplies steps + constraint for the standard metrics (`grad_norm`, `ppo_kl`, logp-diff, …), filled at parse time through the same schema validation, so the one-liner is a complete minimal declaration.
+  - Every defaulted key must stay within the capture whitelist; the absolute flavor's `hard_ref` is never defaulted.
+  - Gates stay explicit per test (greppable, uniformly strict ERROR semantics); blanket coverage is the sweep PR below.
+- **Sweep PR (a separate PR, after the defaults table)** — declare the standard one-liners across the CUDA e2e tests in one pass, where each test owner tunes or vetoes their band (partial-model tests have different variance profiles).
+- **Capture set becomes** `TARGET_METRIC_KEYS` **∪ declared keys** — the harness parses specs pre-launch and injects the extras via env.
+- **Self-calibrating constraint** — band = k·std of the coordinate's own history, for heteroskedastic tests; and a `mean` (step-average) reduction.
+- **Enforcement** — the per-test allowlist + global kill-switch from Rollout; shadow mode is current behavior.

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -17,6 +17,7 @@ from miles.utils.hf_config import is_dsa, load_hf_config
 from miles.utils.logging_utils import configure_logger_raw
 from miles.utils.megatron_args_utils import compute_megatron_world_size_except_dp
 from miles.utils.misc import load_function
+from miles.utils.tracking_utils.ci_history import RECORD_DIR_ENV
 
 logger = logging.getLogger(__name__)
 
@@ -2170,6 +2171,10 @@ def parse_args(add_custom_arguments=None):
                 "It has been moved to miles.backends.experimental. "
                 "Contributions are welcome if you are interested in improving it."
             )
+
+    # On iff the CI harness injected MILES_CI_GATE_RECORD_DIR (the same env var
+    # locates the per-test record). No CLI flag: non-CI runs always stay False.
+    args.ci_enable_metrics_capture = bool(os.environ.get(RECORD_DIR_ENV))
 
     miles_validate_args(args)
 

--- a/tests/ci/metric_history/__init__.py
+++ b/tests/ci/metric_history/__init__.py
@@ -1,12 +1,18 @@
-"""Metric-history storage layer for the CI regression gate.
+"""Metric-history subsystem for the CI regression gate.
 
 * One import surface for consumers, re-exporting the :class:`MetricHistoryStore`
   contract and its record types (:class:`MetricSample`, :class:`RunIdentity`,
   :class:`RunProvenance`).
 * The two backends: offline :class:`SQLiteMetricHistoryStore` and the deferred
   :class:`NeonMetricHistoryStore` placeholder, plus :data:`NEON_DATABASE_URL_ENV`.
+* The gate declaration marker :func:`register_ci_gate` and its parsed
+  :class:`CiGateSpec`.
+* Not re-exported: gate evaluation (:mod:`tests.ci.metric_history.gate`),
+  step selection (:mod:`tests.ci.metric_history.selection`), constraints
+  (:mod:`tests.ci.metric_history.constraints`) -- import those modules directly.
 """
 
+from tests.ci.metric_history.register import CiGateSpec, register_ci_gate
 from tests.ci.metric_history.storage.neon_store import NEON_DATABASE_URL_ENV, NeonMetricHistoryStore
 from tests.ci.metric_history.storage.sqlite_store import SQLiteMetricHistoryStore
 from tests.ci.metric_history.storage.store import MetricHistoryStore, MetricSample, RunIdentity, RunProvenance
@@ -19,4 +25,6 @@ __all__ = [
     "SQLiteMetricHistoryStore",
     "NeonMetricHistoryStore",
     "NEON_DATABASE_URL_ENV",
+    "CiGateSpec",
+    "register_ci_gate",
 ]

--- a/tests/ci/metric_history/constraints.py
+++ b/tests/ci/metric_history/constraints.py
@@ -1,0 +1,54 @@
+# doc-dev: docs/ci/03-metric-history-gate.md
+"""The band constraint for the CI regression gate.
+
+* A constraint decides whether one extracted scalar `cur` passes against a
+  reference `ref` -- the mean of the trusted baseline for the historical
+  gate.
+* Every constraint is two-sided: `cur` must land in the corridor
+  `[ref - band_down, ref + band_up]`. There is no unbounded side -- a value
+  far from baseline in the "improving" direction is usually a broken metric,
+  and a passing run's values become future baselines, so admitting it would
+  drag the mean. A side meant to be lenient gets a wide band, not no band.
+* Each side's band scales from the reference only:
+  `band = max(rel * |ref|, abs_floor)`, so `rel_up = 0.5` reads as "at most
+  50% above the baseline mean". Scaling from `cur` would let a deviating
+  value widen its own tolerance (at rel 0.5 the effective ceiling is 2x ref,
+  not 1.5x). `abs_floor` keeps metrics near zero from flagging on a
+  meaningless relative percentage.
+* The declaration literal is validated against :data:`CONSTRAINT_SCHEMA` at
+  parse time; `evaluate_constraint` expects the normalized dict (defaults
+  filled). The literal as written is the spec's `constraint_key`, part of the
+  stored value's identity (see register.py).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ConstraintOutcome:
+    """Whether `cur` passed, and the corridor `[lo, hi]` it was judged against."""
+
+    ok: bool
+    lo: float
+    hi: float
+
+
+# Parse-time param schema, consumed by register.py. Each entry:
+# param -> (validator_key, required, default). A declaration must write at
+# least one band param per side -- the parser enforces it, since an
+# all-default side has band 0 and fails on any deviation.
+CONSTRAINT_SCHEMA: dict[str, tuple[str, bool, object]] = {
+    "rel_up": ("float_nonneg", False, 0.0),
+    "abs_floor_up": ("float_nonneg", False, 0.0),
+    "rel_down": ("float_nonneg", False, 0.0),
+    "abs_floor_down": ("float_nonneg", False, 0.0),
+}
+
+
+def evaluate_constraint(constraint: dict, cur: float, ref: float) -> ConstraintOutcome:
+    """Apply a normalized constraint dict to `cur` vs `ref`."""
+    hi = ref + max(constraint["rel_up"] * abs(ref), constraint["abs_floor_up"])
+    lo = ref - max(constraint["rel_down"] * abs(ref), constraint["abs_floor_down"])
+    return ConstraintOutcome(lo <= cur <= hi, lo, hi)

--- a/tests/ci/metric_history/gate.py
+++ b/tests/ci/metric_history/gate.py
@@ -1,0 +1,277 @@
+# doc-dev: docs/ci/03-metric-history-gate.md
+"""Offline regression gate for the CI metric-history system.
+
+* Consumes one merged per-run JSONL record plus the `register_ci_gate` specs
+  declared in the test file, and decides whether the run is *trusted*.
+* The record is the passed attempt's merged JSONL; a later round picks which
+  attempt.
+* Each spec pairs a STEPS selection (which value(s) to pull: `"last"` /
+  `"all"` / a step list) with a CONSTRAINT (the pass/fail rule). `"all"` and a
+  step list fan out to one comparison coordinate per step, each judged only
+  against that same step's history.
+* One check runs per coordinate, using the spec's constraint: the HISTORICAL
+  gate. It is active only when the store returns >=1 trusted baseline value
+  for the (identity, coordinate), and compares against the mean of those
+  values. Zero trusted values means INACTIVE -- a cold start, not a failure.
+* The run is trusted iff every *active* check passed for every coordinate.
+* The gate is pure and read-only: the store is injected via
+  :class:`MetricHistoryStore` and the only store call is
+  `store.recent_trusted_values` -- no connection opened, no wandb read, no
+  rows written.
+
+Caveats:
+
+* Do not add store writes here. Persistence is a later round; the gate stays
+  read-only.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import dataclass, field
+from enum import Enum
+
+from tests.ci.ci_register import CIRegistry, HWBackend, ut_parse_one_file
+from tests.ci.metric_history.constraints import evaluate_constraint
+from tests.ci.metric_history.register import CiGateSpec, parse_ci_gate_specs
+from tests.ci.metric_history.selection import SelectionError, select
+from tests.ci.metric_history.storage import MetricHistoryStore
+
+# Maps the parsed HWBackend enum to the lowercase backend string the store keys
+# on. The store's identity tuple is all strings; CIRegistry.backend is the enum.
+_BACKEND_STR: dict[HWBackend, str] = {
+    HWBackend.CPU: "cpu",
+    HWBackend.CUDA: "cuda",
+    HWBackend.ROCM: "rocm",
+}
+
+
+class GateStatus(Enum):
+    """Outcome of the historical check for one coordinate."""
+
+    PASS = "pass"
+    FAIL = "fail"
+    INACTIVE = "inactive"  # check not applicable: historical cold start
+    ERROR = "error"  # the metric could not be selected (missing/empty series, bad step)
+
+
+@dataclass(frozen=True)
+class MetricGateResult:
+    """Per-coordinate verdict.
+
+    `(metric_key, steps_key, constraint_key, step)` is the baseline coordinate;
+    `step` is None only when selection errored (there is no coordinate to
+    name), `-1` for a whole-series reduction like `steps="last"`. `at_step` is the
+    step the value actually came from, for reporting. `current` is the
+    extracted scalar, or None when selection errored. `baseline_mean` is the
+    mean of trusted history when the historical gate is active, else None.
+    `trusted` is True iff the check here passed or was inactive.
+    """
+
+    metric_key: str
+    steps_key: str
+    constraint_key: str
+    step: int | None
+    at_step: int | None
+    current: float | None
+    historical_status: GateStatus
+    baseline_n: int
+    baseline_mean: float | None
+    reason: str
+
+    @property
+    def trusted(self) -> bool:
+        return self.historical_status in (GateStatus.PASS, GateStatus.INACTIVE)
+
+
+@dataclass(frozen=True)
+class GateResult:
+    """Run-level verdict over every gate spec for one test file."""
+
+    test_path: str
+    backend: str
+    suite: str
+    metrics: list[MetricGateResult] = field(default_factory=list)
+
+    @property
+    def trusted(self) -> bool:
+        """The run is trusted iff every per-coordinate verdict is trusted.
+
+        An empty metrics list (no gate specs) is vacuously trusted: a file that
+        declares no gate cannot regress. One failing step of a fanned-out spec
+        untrusts the whole run.
+        """
+        return all(m.trusted for m in self.metrics)
+
+
+# Capture serializes non-finite floats as these markers so record lines stay
+# strict JSON; decode them back before extraction judges the values.
+_NONFINITE_MARKERS: dict[str, float] = {"NaN": math.nan, "Infinity": math.inf, "-Infinity": -math.inf}
+
+
+def _decode_value(value: object) -> object:
+    if isinstance(value, str) and value in _NONFINITE_MARKERS:
+        return _NONFINITE_MARKERS[value]
+    return value
+
+
+def parse_merged_record(record_path: str) -> dict[str, list]:
+    """Read a merged JSONL record into `{metric_key: series}`.
+
+    Each line is `{"metric": key, "series": [[step, value], ...]}`. Non-finite
+    values arrive as the capture-side string markers and are decoded back to
+    floats here. A repeated metric key (should not happen post-merge) keeps the
+    last line's series.
+    """
+    by_metric: dict[str, list] = {}
+    with open(record_path, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            rec = json.loads(line)
+            by_metric[rec["metric"]] = [
+                [point[0], _decode_value(point[1])] if isinstance(point, list) and len(point) >= 2 else point
+                for point in rec["series"]
+            ]
+    return by_metric
+
+
+def _registry_for(filename: str) -> CIRegistry:
+    """The single CIRegistry governing this test file.
+
+    A gate needs exactly one (backend, suite) identity. A file with no register
+    call, or more than one, is an authoring error the gate refuses rather than
+    guessing which suite a metric belongs to.
+    """
+    registries = ut_parse_one_file(filename)
+    if not registries:
+        raise ValueError(f"{filename}: no register_*_ci() call; gate identity is undefined")
+    if len(registries) > 1:
+        raise ValueError(f"{filename}: {len(registries)} register_*_ci() calls; gate identity is ambiguous")
+    return registries[0]
+
+
+def _error_result(spec: CiGateSpec, reason: str) -> MetricGateResult:
+    return MetricGateResult(
+        metric_key=spec.metric_key,
+        steps_key=spec.steps_key,
+        constraint_key=spec.constraint_key,
+        step=None,
+        at_step=None,
+        current=None,
+        historical_status=GateStatus.ERROR,
+        baseline_n=0,
+        baseline_mean=None,
+        reason=reason,
+    )
+
+
+def _evaluate_spec(
+    spec: CiGateSpec,
+    by_metric: dict[str, list],
+    store: MetricHistoryStore,
+    *,
+    test_path: str,
+    backend: str,
+    suite: str,
+    history_limit: int,
+) -> list[MetricGateResult]:
+    series = by_metric.get(spec.metric_key)
+    if series is None:
+        return [_error_result(spec, f"required metric {spec.metric_key!r} missing from record")]
+
+    try:
+        selections = select(series, spec.steps)
+    except SelectionError as e:
+        return [_error_result(spec, f"metric {spec.metric_key!r} (steps={spec.steps!r}): {e}")]
+
+    results: list[MetricGateResult] = []
+    for ex in selections:
+        reasons: list[str] = []
+        trusted_values = store.recent_trusted_values(
+            test_path,
+            backend,
+            suite,
+            spec.metric_key,
+            spec.steps_key,
+            spec.constraint_key,
+            ex.step,
+            history_limit,
+        )
+        if not trusted_values:
+            historical_status = GateStatus.INACTIVE
+            baseline_mean = None
+            reasons.append("historical: cold start (0 trusted baselines)")
+        else:
+            baseline_mean = sum(trusted_values) / len(trusted_values)
+            hist = evaluate_constraint(spec.constraint, ex.value, baseline_mean)
+            historical_status = GateStatus.PASS if hist.ok else GateStatus.FAIL
+            if not hist.ok:
+                reasons.append(
+                    f"historical: cur={ex.value:.6g} vs mean={baseline_mean:.6g} "
+                    f"(n={len(trusted_values)}) outside [{hist.lo:.6g}, {hist.hi:.6g}]"
+                )
+
+        if historical_status in (GateStatus.PASS, GateStatus.INACTIVE):
+            reasons.insert(0, "ok")
+
+        results.append(
+            MetricGateResult(
+                metric_key=spec.metric_key,
+                steps_key=spec.steps_key,
+                constraint_key=spec.constraint_key,
+                step=ex.step,
+                at_step=ex.at_step,
+                current=ex.value,
+                historical_status=historical_status,
+                baseline_n=len(trusted_values),
+                baseline_mean=baseline_mean,
+                reason="; ".join(reasons),
+            )
+        )
+    return results
+
+
+def evaluate_gate(
+    test_filename: str,
+    merged_record_path: str,
+    store: MetricHistoryStore,
+    *,
+    history_limit: int = 20,
+) -> GateResult:
+    """Evaluate every `register_ci_gate` spec in `test_filename` against a record.
+
+    `test_filename` is the repo-relative test path; its CIRegistry supplies the
+    (backend, suite) identity.
+    `merged_record_path` is the merged per-run JSONL of the passed attempt --
+    the gate never globs a base directory to find it. `store` answers the
+    baseline query and nothing else (no writes, no connection opened here). A
+    fanned-out spec contributes one MetricGateResult per step.
+    """
+    specs = parse_ci_gate_specs(test_filename)
+    registry = _registry_for(test_filename)
+    backend = _BACKEND_STR[registry.backend]
+    by_metric = parse_merged_record(merged_record_path)
+
+    results: list[MetricGateResult] = []
+    for spec in specs:
+        results.extend(
+            _evaluate_spec(
+                spec,
+                by_metric,
+                store,
+                test_path=registry.filename,
+                backend=backend,
+                suite=registry.suite,
+                history_limit=history_limit,
+            )
+        )
+
+    return GateResult(
+        test_path=registry.filename,
+        backend=backend,
+        suite=registry.suite,
+        metrics=results,
+    )

--- a/tests/ci/metric_history/register.py
+++ b/tests/ci/metric_history/register.py
@@ -1,0 +1,292 @@
+# doc-dev: docs/ci/03-metric-history-gate.md
+"""Declare and parse metric-history regression gates.
+
+* `register_ci_gate(...)` is the marker a test file uses to declare a gate.
+* Like `register_cuda_ci` it is a runtime no-op, parsed out of the file's AST
+  rather than executed.
+* A gate composes `steps` (which value(s) to pull from a metric's series:
+  `"last"` | `"all"` | a non-empty list of step indices) and a `constraint`
+  (the pass/fail rule).
+* `constraint` is a literal dict of the two-sided band params (`rel_up` /
+  `abs_floor_up` / `rel_down` / `abs_floor_down`), validated against the
+  schema in :mod:`constraints`.
+* A spec also carries `steps_key` / `constraint_key` -- canonical JSON of the
+  raw `steps` / `constraint` literals (see :func:`_canonical_key` for the
+  exact serialization) -- which, plus the selection's `step`, form the
+  identity a stored value's history is keyed under.
+* `parse_ci_gate_specs` extracts every declaration as a :class:`CiGateSpec`.
+
+Caveats:
+
+* `register_ci_gate`'s Python signature does NOT validate calls -- the parser
+  here does, at parse time.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import math
+from dataclasses import dataclass
+
+from tests.ci.metric_history.constraints import CONSTRAINT_SCHEMA
+
+
+def register_ci_gate(
+    *,
+    metric_key: str,
+    steps: str | list[int],
+    constraint: dict,
+    enforce: bool = False,
+    allowlist_reason: str | None = None,
+):
+    """Declare one history-gate spec for the test file it sits in.
+
+    Parsed via AST (like `register_cuda_ci`); a runtime no-op. Every argument
+    is keyword-only and must be a literal. `metric_key` names the target
+    metric. `steps` picks the
+    comparison value(s): `"last"` (the series' last point), `"all"` (every
+    step present, fanned out), or a non-empty list of step indices.
+    `constraint` is a literal dict of the two-sided band params -- see
+    :data:`constraints.CONSTRAINT_SCHEMA`; each side needs at least one of its
+    `rel` / `abs_floor` written. `enforce` and `allowlist_reason` are policy metadata the
+    gate carries without acting on (the verdict is informational this round).
+    """
+    return None
+
+
+_REGISTER_NAME = "register_ci_gate"
+_REQUIRED = object()
+
+# Top-level register_ci_gate fields: name -> (required, default).
+_FIELDS: dict[str, tuple[bool, object]] = {
+    "metric_key": (True, _REQUIRED),
+    "steps": (True, _REQUIRED),
+    "constraint": (True, _REQUIRED),
+    "enforce": (False, False),
+    "allowlist_reason": (False, None),
+}
+
+
+@dataclass(frozen=True)
+class CiGateSpec:
+    """One parsed `register_ci_gate` declaration.
+
+    `steps` is the validated selection literal (`"last"` | `"all"` | a list of
+    step indices); `constraint` is a normalized dict (name + validated params
+    + filled defaults); both drive execution. `steps_key` / `constraint_key` are
+    canonical JSON of the same literals as written and, with the extraction's
+    `step`, form the stored value's identity. `filename` is the test file the
+    spec governs; run identity comes from its CIRegistry.
+    """
+
+    filename: str
+    metric_key: str
+    steps: str | list[int]
+    constraint: dict
+    steps_key: str
+    constraint_key: str
+    enforce: bool = False
+    allowlist_reason: str | None = None
+
+
+class _ParseError(Exception):
+    """Internal: a bare message the caller wraps with file + field context."""
+
+
+def _literal(node: ast.AST) -> object:
+    """A Python literal from an AST node: a constant, a negative number, or a
+    list / dict of the same. Rejects any non-literal (name, call, expression).
+
+    Negative numbers matter because `-1.0` is an `ast.UnaryOp`, not an
+    `ast.Constant`; a plain constant check would wrongly reject them. Dict keys
+    must be string literals and duplicates are rejected (a plain dict would
+    silently keep the last).
+    """
+    if isinstance(node, ast.Constant):
+        return node.value
+    if (
+        isinstance(node, ast.UnaryOp)
+        and isinstance(node.op, ast.USub)
+        and isinstance(node.operand, ast.Constant)
+        and isinstance(node.operand.value, (int, float))
+        and not isinstance(node.operand.value, bool)
+    ):
+        return -node.operand.value
+    if isinstance(node, ast.List):
+        return [_literal(e) for e in node.elts]
+    if isinstance(node, ast.Dict):
+        out: dict = {}
+        for key_node, value_node in zip(node.keys, node.values, strict=True):
+            if key_node is None:
+                raise _ParseError("dict unpacking (**) is not allowed")
+            key = _literal(key_node)
+            if not isinstance(key, str):
+                raise _ParseError("dict keys must be string literals")
+            if key in out:
+                raise _ParseError(f"duplicate key {key!r}")
+            out[key] = _literal(value_node)
+        return out
+    raise _ParseError(f"must be a literal (got {type(node).__name__})")
+
+
+def _validate_param(validator: str, value: object) -> object:
+    """Validate one schema param (also the flat `steps` list); return it
+    (normalized)."""
+    if validator == "float_nonneg":
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise _ParseError("must be a number")
+        if not math.isfinite(value) or value < 0:
+            raise _ParseError("must be a finite number >= 0")
+        return float(value)
+    if validator == "step_list":
+        if not isinstance(value, list) or not value:
+            raise _ParseError("must be a non-empty list of step indices")
+        seen: set[int] = set()
+        for s in value:
+            if isinstance(s, bool) or not isinstance(s, int):
+                raise _ParseError("step indices must be integers")
+            if s < 0:
+                raise _ParseError("step indices must be >= 0")
+            if s in seen:
+                raise _ParseError(f"duplicate step {s}")
+            seen.add(s)
+        return list(value)
+    raise _ParseError(f"internal: unknown validator {validator!r}")
+
+
+def _normalize_constraint(raw: object) -> dict:
+    """Validate the constraint literal against `CONSTRAINT_SCHEMA` and return
+    a normalized dict (validated params + filled defaults). Each side needs at
+    least one written band param -- an all-default side has band 0 and would
+    fail on any deviation."""
+    if not isinstance(raw, dict):
+        raise _ParseError("constraint must be a dict")
+    for key in raw:
+        if key not in CONSTRAINT_SCHEMA:
+            raise _ParseError(f"unknown key {key!r} for constraint; valid: {sorted(CONSTRAINT_SCHEMA)}")
+    if "rel_up" not in raw and "abs_floor_up" not in raw:
+        raise _ParseError("constraint requires at least one upper band param ('rel_up' or 'abs_floor_up')")
+    if "rel_down" not in raw and "abs_floor_down" not in raw:
+        raise _ParseError("constraint requires at least one lower band param ('rel_down' or 'abs_floor_down')")
+    normalized: dict = {}
+    for param, (validator, required, default) in CONSTRAINT_SCHEMA.items():
+        if param in raw:
+            try:
+                normalized[param] = _validate_param(validator, raw[param])
+            except _ParseError as e:
+                raise _ParseError(f"constraint param {param!r}: {e}") from None
+        elif required:
+            raise _ParseError(f"constraint requires {param!r}")
+        else:
+            normalized[param] = default
+    return normalized
+
+
+def _validate_steps(value: object) -> str | list[int]:
+    """The declaration's `steps` literal: `"last"`, `"all"`, or a step list."""
+    if value == "last" or value == "all":
+        return value
+    if isinstance(value, list):
+        try:
+            return _validate_param("step_list", value)
+        except _ParseError as e:
+            raise _ParseError(f"steps: {e}") from None
+    raise _ParseError('steps must be "last", "all", or a non-empty list of step indices')
+
+
+def _require_str(value: object, field: str) -> str:
+    if not isinstance(value, str):
+        raise _ParseError(f"{field} must be a string")
+    return value
+
+
+def _require_bool(value: object, field: str) -> bool:
+    if not isinstance(value, bool):
+        raise _ParseError(f"{field} must be a boolean")
+    return value
+
+
+def _require_opt_str(value: object, field: str) -> str | None:
+    if value is not None and not isinstance(value, str):
+        raise _ParseError(f"{field} must be a string or None")
+    return value
+
+
+def _canonical_key(raw: object) -> str:
+    """Canonical JSON of a declaration literal (the `steps` string/list or
+    the `constraint` dict), as the stored identity key: no whitespace, dict
+    keys sorted, list order kept as written, a bare string keyword
+    serialized with its JSON quotes (`"last"` -> `'"last"'`).
+
+    Deliberately built from the literal as written in the test file, NOT the
+    normalized form: filled-in defaults live in code, so a code-side default
+    change would silently rewrite normalized keys and reset every series. The
+    raw literal changes only with an edit to the declaration itself -- the
+    intended reset lever for that coordinate's history.
+    """
+    return json.dumps(raw, sort_keys=True, separators=(",", ":"))
+
+
+def _parse_ci_gate_call(call: ast.Call, filename: str) -> CiGateSpec:
+    prefix = f"{filename}: {_REGISTER_NAME}()"
+    if call.args:
+        raise ValueError(f"{prefix} takes only keyword arguments (got {len(call.args)} positional)")
+
+    raw: dict[str, object] = {}
+    for kw in call.keywords:
+        if kw.arg is None:
+            raise ValueError(f"{prefix}: **kwargs are not supported")
+        if kw.arg not in _FIELDS:
+            raise ValueError(f"{prefix}: unknown argument {kw.arg!r}; valid: {sorted(_FIELDS)}")
+        if kw.arg in raw:
+            raise ValueError(f"{prefix}: duplicated argument {kw.arg!r}")
+        try:
+            raw[kw.arg] = _literal(kw.value)
+        except _ParseError as e:
+            raise ValueError(f"{prefix}: {kw.arg} {e}") from None
+
+    for field, (required, default) in _FIELDS.items():
+        if field not in raw:
+            if required:
+                raise ValueError(f"{prefix}: {field} is required")
+            raw[field] = default
+
+    try:
+        return CiGateSpec(
+            filename=filename,
+            metric_key=_require_str(raw["metric_key"], "metric_key"),
+            steps=_validate_steps(raw["steps"]),
+            constraint=_normalize_constraint(raw["constraint"]),
+            steps_key=_canonical_key(raw["steps"]),
+            constraint_key=_canonical_key(raw["constraint"]),
+            enforce=_require_bool(raw["enforce"], "enforce"),
+            allowlist_reason=_require_opt_str(raw["allowlist_reason"], "allowlist_reason"),
+        )
+    except _ParseError as e:
+        raise ValueError(f"{prefix}: {e}") from None
+
+
+def parse_ci_gate_specs(filename: str) -> list[CiGateSpec]:
+    """Return every `register_ci_gate` spec declared at top level in `filename`.
+
+    Parsed the same way as `register_cuda_ci`: top-level `Expr(Call)` whose
+    callee is the bare name `register_ci_gate`. Non-literal / invalid args raise
+    ValueError naming the file and field.
+
+    Note for the future writer: two specs may still map to the same baseline
+    coordinate (identical steps + constraint literals, differing only in
+    policy metadata). The writer must dedupe metric_values by coordinate so
+    one run contributes one row per coordinate.
+    """
+    with open(filename) as f:
+        tree = ast.parse(f.read(), filename=filename)
+    specs: list[CiGateSpec] = []
+    for stmt in tree.body:
+        if not isinstance(stmt, ast.Expr) or not isinstance(stmt.value, ast.Call):
+            continue
+        call = stmt.value
+        if not isinstance(call.func, ast.Name) or call.func.id != _REGISTER_NAME:
+            continue
+        specs.append(_parse_ci_gate_call(call, filename))
+    return specs

--- a/tests/ci/metric_history/selection.py
+++ b/tests/ci/metric_history/selection.py
@@ -1,0 +1,141 @@
+# doc-dev: docs/ci/03-metric-history-gate.md
+"""Step selection for the CI regression gate.
+
+* `select(series, steps)` pulls the comparison value(s) out of one metric's
+  per-run series `[[step, value], ...]`; step may be None.
+* `steps` is the declaration's flat literal, validated by the parser:
+  `"last"` | `"all"` | a non-empty list of step indices. There is no
+  name-keyed registry -- the selection space is a closed enum.
+* Selection is pure and returns a list of :class:`Selection` -- one entry per
+  comparison coordinate.
+* `"last"` -- the last numeric point (1 coordinate, `step = -1`).
+* `"all"` -- every step present in the series, fanned out (N coordinates).
+* `[k, ...]` -- the named steps, fanned out (`len(steps)` coordinates); a named
+  step missing from the series is an error, not a silent skip.
+* A fanned coordinate is identified by its step, so this run's step-0 value is
+  compared only against past runs' step-0 values.
+* Raising :class:`SelectionError` (rather than returning a sentinel) lets the
+  gate turn the failure into a clear per-coordinate verdict.
+
+Caveats:
+
+* A non-finite value (NaN/±Inf) at a coordinate the selection picks is an
+  SelectionError -- judged, never silently dropped. Points whose value is not a
+  number at all (bool/None/...) are ignored, as are points no selection picks.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+Point = Sequence  # [step, value]
+
+
+class SelectionError(ValueError):
+    """A required series is absent, empty, or ill-formed for this selection."""
+
+
+@dataclass(frozen=True)
+class Selection:
+    """One comparison value pulled from a series.
+
+    `step` is the identity role: step `k` for a per-step value, `-1` for a
+    whole-series reduction (`"last"`), which must key on a constant or its
+    history would fragment across runs of different lengths. `at_step` is the
+    step the value actually came from, carried for reporting only (None when
+    the series carries no step index).
+    """
+
+    step: int
+    at_step: int | None
+    value: float
+
+
+def _is_number(value: object) -> bool:
+    """A real int/float (not bool — it sneaks through `isinstance(x, int)`).
+
+    Finiteness is deliberately not checked here: non-finite values stay in the
+    series and error at selection time, never silently dropped.
+    """
+    return not isinstance(value, bool) and isinstance(value, (int, float))
+
+
+def _valid_step(step: object) -> bool:
+    return isinstance(step, int) and not isinstance(step, bool)
+
+
+def _numeric_points(series: Sequence[Point]) -> list[tuple[int | None, float]]:
+    """(step, value) for each point whose value is a number.
+
+    A non-int (or bool) step is normalized to None; the value is kept —
+    including non-finite floats, which selection rejects if picked. Points
+    with a non-numeric value are dropped.
+    """
+    out: list[tuple[int | None, float]] = []
+    for point in series:
+        if len(point) < 2:
+            continue
+        step, value = point[0], point[1]
+        if not _is_number(value):
+            continue
+        out.append((step if _valid_step(step) else None, float(value)))
+    return out
+
+
+def _select_last(series: Sequence[Point]) -> list[Selection]:
+    points = _numeric_points(series)
+    if not points:
+        raise SelectionError("series has no numeric point")
+    step, value = points[-1]
+    if not math.isfinite(value):
+        raise SelectionError(f"last: non-finite value {value!r} at the last point (step {step})")
+    return [Selection(step=-1, at_step=step, value=value)]
+
+
+def _select_all(series: Sequence[Point]) -> list[Selection]:
+    points = _numeric_points(series)
+    if not points:
+        raise SelectionError("series has no numeric point")
+    out: list[Selection] = []
+    seen: set[int] = set()
+    for step, value in points:
+        if step is None:
+            raise SelectionError("all: a numeric point carries no step index")
+        if step in seen:
+            raise SelectionError(f"all: duplicate step {step} in series")
+        if not math.isfinite(value):
+            raise SelectionError(f"all: non-finite value {value!r} at step {step}")
+        seen.add(step)
+        out.append(Selection(step=step, at_step=step, value=value))
+    return out
+
+
+def _select_steps(series: Sequence[Point], steps: Sequence[int]) -> list[Selection]:
+    by_step: dict[int, float] = {}
+    for step, value in _numeric_points(series):
+        if step is None:
+            continue
+        if step in by_step:
+            raise SelectionError(f"steps: duplicate step {step} in series")
+        by_step[step] = value
+    out: list[Selection] = []
+    for k in steps:
+        if k not in by_step:
+            raise SelectionError(f"steps: required step {k} missing from series")
+        if not math.isfinite(by_step[k]):
+            raise SelectionError(f"steps: non-finite value {by_step[k]!r} at required step {k}")
+        out.append(Selection(step=k, at_step=k, value=by_step[k]))
+    return out
+
+
+def select(series: Sequence[Point], steps: str | Sequence[int]) -> list[Selection]:
+    """Apply a validated `steps` literal to a series."""
+    if steps == "last":
+        return _select_last(series)
+    if steps == "all":
+        return _select_all(series)
+    if isinstance(steps, (list, tuple)):
+        return _select_steps(series, steps)
+    raise SelectionError(f'invalid steps {steps!r}; valid: "last", "all", or a list of step indices')

--- a/tests/ci/metric_history/storage/store.py
+++ b/tests/ci/metric_history/storage/store.py
@@ -31,12 +31,12 @@ class MetricSample:
     """One comparison-coordinate value a run contributed.
 
     The coordinate is the declaring gate's literal content plus the point:
-    `steps_key` / `constraint_key` are canonical JSON of the declaration's
-    raw `steps` / `constraint` literals; `step` is the point the value came
-    from -- step `k`, or `-1` for a whole-series reduction (e.g.
-    `steps="last"`), which must key on a constant rather than the step it
-    happened to land on, or its history would fragment across runs of
-    different lengths.
+    `steps_key` / `constraint_key` are canonical JSON of the declaration's raw
+    `steps` / `constraint` literals (serialization pinned by
+    `register._canonical_key`); `step` is the point the value came from -- step `k`, or `-1`
+    for a whole-series reduction (e.g. `steps="last"`), which must key on
+    a constant rather than the step it happened to land on, or its history
+    would fragment across runs of different lengths.
     """
 
     metric_key: str

--- a/tests/ci/test/test_ci_register.py
+++ b/tests/ci/test/test_ci_register.py
@@ -252,7 +252,7 @@ class TestRegisterNegative:
 # --- AST helpers (extraction-only, isolated from KNOWN_LABELS validation) ---
 
 
-class TestExtractionHelpers:
+class TestSelectionHelpers:
     def test_extract_constant_int(self):
         node = ast.parse("42", mode="eval").body
         assert _extract_constant(node) == 42

--- a/tests/ci/test/test_history_gate.py
+++ b/tests/ci/test/test_history_gate.py
@@ -1,0 +1,608 @@
+"""Offline tests for the metric-history regression gate.
+
+These run fully offline against an in-memory :class:`SQLiteMetricHistoryStore`
+and on-disk fixture files (a test file declaring register_ci_gate + a merged
+JSONL record). No network, no real DB connection opened by the gate, no wandb.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import textwrap
+from pathlib import Path
+
+import pytest
+from tests.ci.ci_register import register_cpu_ci
+from tests.ci.metric_history import MetricSample, RunIdentity, RunProvenance, SQLiteMetricHistoryStore
+from tests.ci.metric_history.gate import GateStatus, evaluate_gate, parse_merged_record
+
+register_cpu_ci(est_time=1, suite="stage-a-cpu", labels=[])
+
+PROVENANCE = RunProvenance(
+    commit_sha="deadbeef",
+    pr_number=1,
+    github_run_id=100,
+    github_run_attempt=1,
+    event_name="pull_request",
+    ref="refs/pull/1/merge",
+)
+
+
+def _key(literal: object) -> str:
+    """Canonical declaration key, matching register.py's `_canonical_key`."""
+    return json.dumps(literal, sort_keys=True, separators=(",", ":"))
+
+
+# Keys for the fixtures below: steps / constraint literals as written there.
+LAST_KEY = _key("last")
+
+
+@pytest.fixture
+def store():
+    s = SQLiteMetricHistoryStore(":memory:")
+    yield s
+    s.close()
+
+
+def _write_test_file(tmp_path: Path, gate_lines: str, *, name: str = "test_e2e_fixture.py") -> str:
+    # Concatenate instead of interpolating into an indented f-string: a
+    # multi-line gate block would otherwise defeat the outer dedent.
+    body = (
+        "from tests.ci.ci_register import register_cuda_ci\n"
+        "from tests.ci.metric_history import register_ci_gate\n"
+        'register_cuda_ci(est_time=600, suite="stage-c-8-gpu-h100")\n' + textwrap.dedent(gate_lines).strip() + "\n"
+    )
+    p = tmp_path / name
+    p.write_text(body)
+    return str(p)
+
+
+def _write_record(tmp_path: Path, by_metric: dict[str, list], *, name: str = "merged.jsonl") -> str:
+    p = tmp_path / name
+    with open(p, "w", encoding="utf-8") as f:
+        for metric, series in by_metric.items():
+            f.write(json.dumps({"metric": metric, "series": series}) + "\n")
+    return str(p)
+
+
+def _seed_baseline(
+    store, test_filename, *, metric_key, steps_key, constraint_key, step, values, suite="stage-c-8-gpu-h100"
+):
+    identity = RunIdentity(
+        test_path=test_filename,
+        backend="cuda",
+        suite=suite,
+    )
+    for i, v in enumerate(values):
+        store.write_run(
+            identity,
+            PROVENANCE,
+            created_at=f"2026-06-0{i + 1}T00:00:00+00:00",
+            trusted=True,
+            values=[MetricSample(metric_key, steps_key, constraint_key, step, v)],
+        )
+
+
+# --- parse_merged_record ----------------------------------------------------
+
+
+def test_parse_merged_record(tmp_path):
+    path = _write_record(tmp_path, {"train/grad_norm": [[0, 0.5], [1, 1.0]], "rollout/raw_reward": [[0, 0.3]]})
+    got = parse_merged_record(path)
+    assert got == {"train/grad_norm": [[0, 0.5], [1, 1.0]], "rollout/raw_reward": [[0, 0.3]]}
+
+
+def test_parse_merged_record_decodes_non_finite_markers(tmp_path):
+    path = _write_record(tmp_path, {"train/grad_norm": [[0, 0.5], [1, "NaN"], [2, "Infinity"], [3, "-Infinity"]]})
+    series = parse_merged_record(path)["train/grad_norm"]
+    assert series[0] == [0, 0.5]
+    assert math.isnan(series[1][1])
+    assert series[2][1] == math.inf
+    assert series[3][1] == -math.inf
+
+
+def test_non_finite_at_gated_coordinate_errors_and_untrusts(tmp_path, store):
+    test_file = _write_test_file(
+        tmp_path,
+        """
+        register_ci_gate(metric_key="train/grad_norm",
+                         steps="last", constraint={"rel_up": 0.20, "rel_down": 0.20})
+        """,
+    )
+    # Capture-side marker for a NaN at the last (gated) step: ERROR, not a
+    # silent fallback to the previous finite point.
+    record = _write_record(tmp_path, {"train/grad_norm": [[0, 0.9], [1, "NaN"]]})
+
+    result = evaluate_gate(test_file, record, store)
+
+    m = result.metrics[0]
+    assert m.historical_status == GateStatus.ERROR
+    assert "non-finite" in m.reason
+    assert result.trusted is False
+
+
+# --- cold start (no trusted history) ----------------------------------------
+
+
+def test_cold_start_vacuously_trusted(tmp_path, store):
+    test_file = _write_test_file(
+        tmp_path,
+        """
+        register_ci_gate(metric_key="train/grad_norm",
+                         steps="last", constraint={"rel_up": 0.20, "rel_down": 0.20})
+        """,
+    )
+    record = _write_record(tmp_path, {"train/grad_norm": [[0, 0.9]]})
+
+    result = evaluate_gate(test_file, record, store)
+
+    assert len(result.metrics) == 1
+    m = result.metrics[0]
+    # No baselines yet: historical gate inactive, NOT an error, NOT a failure.
+    assert m.historical_status == GateStatus.INACTIVE
+    assert "historical: cold start (0 trusted baselines)" in m.reason
+    assert m.baseline_n == 0
+    assert m.steps_key == LAST_KEY
+    assert m.step == -1
+    # Zero active checks: vacuously trusted -- this run seeds the baseline.
+    assert result.trusted is True
+
+
+# --- historical gate --------------------------------------------------------
+
+
+def test_historical_failure(tmp_path, store):
+    test_file = _write_test_file(
+        tmp_path,
+        """
+        register_ci_gate(metric_key="rollout/raw_reward",
+                         steps="last", constraint={"rel_up": 0.20, "rel_down": 0.20})
+        """,
+    )
+    # Seed a trusted baseline around 0.80 under the `last` coordinate.
+    _seed_baseline(
+        store,
+        test_file,
+        metric_key="rollout/raw_reward",
+        steps_key=LAST_KEY,
+        constraint_key=_key({"rel_up": 0.20, "rel_down": 0.20}),
+        step=-1,
+        values=[0.80, 0.82, 0.78],
+    )
+    # Current 0.55 vs mean 0.80, band = 0.16 -> |0.55-0.80|=0.25 fails historical.
+    record = _write_record(tmp_path, {"rollout/raw_reward": [[0, 0.55]]})
+
+    result = evaluate_gate(test_file, record, store)
+    m = result.metrics[0]
+    assert m.baseline_n == 3
+    assert m.baseline_mean == pytest.approx((0.80 + 0.82 + 0.78) / 3)
+    assert m.historical_status == GateStatus.FAIL
+    assert result.trusted is False
+
+
+def test_historical_pass_within_tolerance(tmp_path, store):
+    test_file = _write_test_file(
+        tmp_path,
+        """
+        register_ci_gate(metric_key="rollout/raw_reward",
+                         steps="last", constraint={"rel_up": 0.20, "rel_down": 0.20})
+        """,
+    )
+    _seed_baseline(
+        store,
+        test_file,
+        metric_key="rollout/raw_reward",
+        steps_key=LAST_KEY,
+        constraint_key=_key({"rel_up": 0.20, "rel_down": 0.20}),
+        step=-1,
+        values=[0.80, 0.82, 0.78],
+    )
+    record = _write_record(tmp_path, {"rollout/raw_reward": [[0, 0.79]]})
+
+    result = evaluate_gate(test_file, record, store)
+    m = result.metrics[0]
+    assert m.historical_status == GateStatus.PASS
+    assert result.trusted is True
+
+
+def test_drift_beyond_historical_band_not_trusted(tmp_path, store):
+    test_file = _write_test_file(
+        tmp_path,
+        """
+        register_ci_gate(metric_key="train/grad_norm",
+                         steps="last", constraint={"rel_up": 0.50, "rel_down": 0.50})
+        """,
+    )
+    _seed_baseline(
+        store,
+        test_file,
+        metric_key="train/grad_norm",
+        steps_key=LAST_KEY,
+        constraint_key=_key({"rel_up": 0.50, "rel_down": 0.50}),
+        step=-1,
+        values=[1.0, 1.0, 1.0],
+    )
+    # current 1.8: historical |1.8-1.0|=0.8 > 0.5 fail.
+    record = _write_record(tmp_path, {"train/grad_norm": [[0, 1.8]]})
+
+    result = evaluate_gate(test_file, record, store)
+    m = result.metrics[0]
+    assert m.historical_status == GateStatus.FAIL
+    assert m.baseline_mean == pytest.approx(1.0)
+    assert result.trusted is False
+
+
+# --- per-step fan-out ---------------------------------------------------------
+
+
+def test_all_fans_out_one_result_per_step(tmp_path, store):
+    test_file = _write_test_file(
+        tmp_path,
+        """
+        register_ci_gate(metric_key="train/grad_norm",
+                         steps="all", constraint={"rel_up": 0.50, "rel_down": 0.50})
+        """,
+    )
+    record = _write_record(tmp_path, {"train/grad_norm": [[0, 0.9], [1, 1.1]]})
+
+    result = evaluate_gate(test_file, record, store)
+    assert len(result.metrics) == 2
+    assert [(m.step, m.at_step, m.current) for m in result.metrics] == [
+        (0, 0, 0.9),
+        (1, 1, 1.1),
+    ]
+    assert result.trusted is True
+
+
+def test_all_reads_per_step_baselines(tmp_path, store):
+    # Step 0's history and step 1's history must never cross-contaminate.
+    test_file = _write_test_file(
+        tmp_path,
+        """
+        register_ci_gate(metric_key="train/ppo_kl",
+                         steps="all", constraint={"rel_up": 0.90, "rel_down": 0.90})
+        """,
+    )
+    kl_rule = _key({"rel_up": 0.90, "rel_down": 0.90})
+    _seed_baseline(
+        store,
+        test_file,
+        metric_key="train/ppo_kl",
+        steps_key=_key("all"),
+        constraint_key=kl_rule,
+        step=0,
+        values=[0.1, 0.1],
+    )
+    _seed_baseline(
+        store,
+        test_file,
+        metric_key="train/ppo_kl",
+        steps_key=_key("all"),
+        constraint_key=kl_rule,
+        step=1,
+        values=[0.9, 0.9],
+    )
+    record = _write_record(tmp_path, {"train/ppo_kl": [[0, 0.1], [1, 0.9]]})
+
+    result = evaluate_gate(test_file, record, store)
+    by_step = {m.step: m for m in result.metrics}
+    assert by_step[0].baseline_mean == pytest.approx(0.1)
+    assert by_step[1].baseline_mean == pytest.approx(0.9)
+    assert by_step[0].historical_status == GateStatus.PASS
+    assert by_step[1].historical_status == GateStatus.PASS
+    assert result.trusted is True
+
+
+def test_all_one_bad_step_untrusts_run(tmp_path, store):
+    test_file = _write_test_file(
+        tmp_path,
+        """
+        register_ci_gate(metric_key="train/grad_norm",
+                         steps="all", constraint={"rel_up": 0.20, "rel_down": 0.20})
+        """,
+    )
+    _seed_baseline(
+        store,
+        test_file,
+        metric_key="train/grad_norm",
+        steps_key=_key("all"),
+        constraint_key=_key({"rel_up": 0.20, "rel_down": 0.20}),
+        step=0,
+        values=[1.0, 1.0],
+    )
+    _seed_baseline(
+        store,
+        test_file,
+        metric_key="train/grad_norm",
+        steps_key=_key("all"),
+        constraint_key=_key({"rel_up": 0.20, "rel_down": 0.20}),
+        step=1,
+        values=[1.0, 1.0],
+    )
+    # Step 0 within band 0.2; step 1 drifts past it.
+    record = _write_record(tmp_path, {"train/grad_norm": [[0, 1.1], [1, 1.5]]})
+
+    result = evaluate_gate(test_file, record, store)
+    by_step = {m.step: m for m in result.metrics}
+    assert by_step[0].historical_status == GateStatus.PASS
+    assert by_step[1].historical_status == GateStatus.FAIL
+    assert result.trusted is False
+
+
+def test_all_and_explicit_steps_have_separate_coordinates(tmp_path, store):
+    # The coordinate is the declaration's literal content: a steps="all" gate and
+    # a steps=[0] gate both judge step 0's value, but each owns its own series.
+    gate_lines = """
+        register_ci_gate(metric_key="train/ppo_kl",
+                         steps="all", constraint={"rel_up": 0.50, "rel_down": 0.50})
+        register_ci_gate(metric_key="train/ppo_kl",
+                         steps=[0], constraint={"rel_up": 0.50, "rel_down": 0.50})
+    """
+    test_file = _write_test_file(tmp_path, gate_lines)
+    _seed_baseline(
+        store,
+        test_file,
+        metric_key="train/ppo_kl",
+        steps_key=_key("all"),
+        constraint_key=_key({"rel_up": 0.50, "rel_down": 0.50}),
+        step=0,
+        values=[0.1, 0.1],
+    )
+    record = _write_record(tmp_path, {"train/ppo_kl": [[0, 0.1]]})
+
+    result = evaluate_gate(test_file, record, store)
+    assert len(result.metrics) == 2  # one per spec, both at step 0
+    all_m, steps_m = result.metrics
+    assert all_m.baseline_n == 2
+    assert steps_m.baseline_n == 0  # its own coordinate: cold start
+    assert steps_m.historical_status == GateStatus.INACTIVE
+
+
+def test_rule_is_part_of_coordinate(tmp_path, store):
+    # Two gates, same steps, different constraints: different constraint_key,
+    # so each judges against its own baseline series.
+    gate_lines = """
+        register_ci_gate(metric_key="rollout/raw_reward",
+                         steps="last", constraint={"rel_up": 0.50, "rel_down": 0.50})
+        register_ci_gate(metric_key="rollout/raw_reward",
+                         steps="last", constraint={"rel_up": 0.01, "rel_down": 0.01})
+    """
+    test_file = _write_test_file(tmp_path, gate_lines)
+    _seed_baseline(
+        store,
+        test_file,
+        metric_key="rollout/raw_reward",
+        steps_key=LAST_KEY,
+        constraint_key=_key({"rel_up": 0.50, "rel_down": 0.50}),
+        step=-1,
+        values=[1.0, 1.0, 1.0],
+    )
+    record = _write_record(tmp_path, {"rollout/raw_reward": [[0, 1.2]]})
+
+    result = evaluate_gate(test_file, record, store)
+    loose, tight = result.metrics
+    assert loose.constraint_key != tight.constraint_key
+    assert loose.baseline_n == 3
+    assert loose.historical_status == GateStatus.PASS  # band 0.5
+    # The tight rule's own series is unseeded: cold start, not a shared read.
+    assert tight.baseline_n == 0
+    assert tight.historical_status == GateStatus.INACTIVE
+
+
+# --- near-zero abs constraint -------------------------------------------------
+
+
+def test_near_zero_not_flagged_on_relative_pct(tmp_path, store):
+    # ppo_kl rides at ~1e-9. With a positive abs_floor, a tiny absolute
+    # deviation must NOT trip even though the *relative* change is huge.
+    test_file = _write_test_file(
+        tmp_path,
+        """
+        register_ci_gate(metric_key="train/ppo_kl",
+                         steps=[0],
+                         constraint={"rel_up": 0.20, "abs_floor_up": 1e-6, "rel_down": 0.20, "abs_floor_down": 1e-6})
+        """,
+    )
+    # Seed a near-zero baseline; current also near-zero but 100x in relative terms.
+    _seed_baseline(
+        store,
+        test_file,
+        metric_key="train/ppo_kl",
+        steps_key=_key([0]),
+        constraint_key=_key({"rel_up": 0.20, "abs_floor_up": 1e-6, "rel_down": 0.20, "abs_floor_down": 1e-6}),
+        step=0,
+        values=[1e-9, 2e-9, 1e-9],
+    )
+    record = _write_record(tmp_path, {"train/ppo_kl": [[0, 1e-7], [1, 5e-3]]})
+
+    result = evaluate_gate(test_file, record, store)
+    m = result.metrics[0]
+    # steps:[0] picks the step-0 value 1e-7.
+    assert m.current == pytest.approx(1e-7)
+    # historical mean ~1.33e-9; |1e-7 - 1.33e-9| ~ 9.9e-8 <= abs_floor 1e-6.
+    assert m.historical_status == GateStatus.PASS
+    assert result.trusted is True
+
+
+def test_near_zero_real_jump_is_flagged(tmp_path, store):
+    # Sanity counterpart: a ppo_kl that jumps well past abs_floor IS flagged.
+    test_file = _write_test_file(
+        tmp_path,
+        """
+        register_ci_gate(metric_key="train/ppo_kl",
+                         steps=[0],
+                         constraint={"rel_up": 0.20, "abs_floor_up": 1e-6, "rel_down": 0.20, "abs_floor_down": 1e-6})
+        """,
+    )
+    _seed_baseline(
+        store,
+        test_file,
+        metric_key="train/ppo_kl",
+        steps_key=_key([0]),
+        constraint_key=_key({"rel_up": 0.20, "abs_floor_up": 1e-6, "rel_down": 0.20, "abs_floor_down": 1e-6}),
+        step=0,
+        values=[1e-9, 2e-9, 1e-9],
+    )
+    record = _write_record(tmp_path, {"train/ppo_kl": [[0, 0.5]]})
+    result = evaluate_gate(test_file, record, store)
+    assert result.metrics[0].historical_status == GateStatus.FAIL
+    assert result.trusted is False
+
+
+# --- missing / empty / ill-formed required series -----------------------------
+
+
+def test_missing_required_series_verdict_not_crash(tmp_path, store):
+    test_file = _write_test_file(
+        tmp_path,
+        """
+        register_ci_gate(metric_key="rollout/raw_reward",
+                         steps="last", constraint={"rel_up": 0.20, "rel_down": 0.20})
+        """,
+    )
+    # Record carries a different metric only.
+    record = _write_record(tmp_path, {"train/grad_norm": [[0, 1.0]]})
+
+    result = evaluate_gate(test_file, record, store)
+    m = result.metrics[0]
+    assert m.historical_status == GateStatus.ERROR
+    assert m.current is None
+    assert "missing" in m.reason
+    assert result.trusted is False
+
+
+def test_empty_required_series_verdict(tmp_path, store):
+    test_file = _write_test_file(
+        tmp_path,
+        """
+        register_ci_gate(metric_key="rollout/raw_reward",
+                         steps="last", constraint={"rel_up": 0.20, "rel_down": 0.20})
+        """,
+    )
+    record = _write_record(tmp_path, {"rollout/raw_reward": []})
+
+    result = evaluate_gate(test_file, record, store)
+    m = result.metrics[0]
+    assert m.historical_status == GateStatus.ERROR
+    assert result.trusted is False
+
+
+def test_all_null_step_is_error_verdict(tmp_path, store):
+    # A steps="all" gate over a series with a step-less point yields one ERROR
+    # verdict for the spec, not a crash and not a silent skip.
+    test_file = _write_test_file(
+        tmp_path,
+        """
+        register_ci_gate(metric_key="train/grad_norm",
+                         steps="all", constraint={"rel_up": 0.20, "rel_down": 0.20})
+        """,
+    )
+    record = _write_record(tmp_path, {"train/grad_norm": [[0, 1.0], [None, 1.1]]})
+
+    result = evaluate_gate(test_file, record, store)
+    assert len(result.metrics) == 1
+    assert result.metrics[0].historical_status == GateStatus.ERROR
+    assert result.trusted is False
+
+
+# --- asymmetric corridor ------------------------------------------------------
+
+
+def test_asymmetric_corridor_tight_up_loose_down(tmp_path, store):
+    test_file = _write_test_file(
+        tmp_path,
+        """
+        register_ci_gate(metric_key="train/grad_norm",
+                         steps="last",
+                         constraint={"rel_up": 0.10, "rel_down": 0.80})
+        """,
+    )
+    _seed_baseline(
+        store,
+        test_file,
+        metric_key="train/grad_norm",
+        steps_key=LAST_KEY,
+        constraint_key=_key({"rel_up": 0.10, "rel_down": 0.80}),
+        step=-1,
+        values=[2.0, 2.0],
+    )
+    # Corridor [2.0 - 1.6, 2.0 + 0.2] = [0.4, 2.2]. A drop within the loose
+    # lower band passes.
+    low = _write_record(tmp_path, {"train/grad_norm": [[0, 0.5]]}, name="low.jsonl")
+    assert evaluate_gate(test_file, low, store).metrics[0].historical_status == GateStatus.PASS
+
+    # A rise beyond the tight upper band fails.
+    high = _write_record(tmp_path, {"train/grad_norm": [[0, 3.0]]}, name="high.jsonl")
+    assert evaluate_gate(test_file, high, store).metrics[0].historical_status == GateStatus.FAIL
+
+    # A collapse past the lower band fails too: a "too good" value is suspect
+    # and must not enter the baseline.
+    collapse = _write_record(tmp_path, {"train/grad_norm": [[0, 0.1]]}, name="collapse.jsonl")
+    assert evaluate_gate(test_file, collapse, store).metrics[0].historical_status == GateStatus.FAIL
+
+
+def test_reward_corridor_flags_drop_and_suspicious_jump(tmp_path, store):
+    # raw_reward regressing means DROPPING (tight lower band); a jump far
+    # above baseline smells of a broken env / reward hack (loose upper band).
+    test_file = _write_test_file(
+        tmp_path,
+        """
+        register_ci_gate(metric_key="rollout/raw_reward",
+                         steps="last",
+                         constraint={"rel_up": 0.50, "rel_down": 0.10})
+        """,
+    )
+    _seed_baseline(
+        store,
+        test_file,
+        metric_key="rollout/raw_reward",
+        steps_key=LAST_KEY,
+        constraint_key=_key({"rel_up": 0.50, "rel_down": 0.10}),
+        step=-1,
+        values=[0.60, 0.60],
+    )
+    # Corridor [0.54, 0.90]: a genuine improvement passes.
+    ok = _write_record(tmp_path, {"rollout/raw_reward": [[0, 0.85]]}, name="ok.jsonl")
+    assert evaluate_gate(test_file, ok, store).metrics[0].historical_status == GateStatus.PASS
+
+    low = _write_record(tmp_path, {"rollout/raw_reward": [[0, 0.50]]}, name="low.jsonl")
+    assert evaluate_gate(test_file, low, store).metrics[0].historical_status == GateStatus.FAIL
+
+    jump = _write_record(tmp_path, {"rollout/raw_reward": [[0, 0.95]]}, name="jump.jsonl")
+    assert evaluate_gate(test_file, jump, store).metrics[0].historical_status == GateStatus.FAIL
+
+
+# --- multiple specs, no specs ------------------------------------------------
+
+
+def test_no_gate_specs_is_vacuously_trusted(tmp_path, store):
+    body = textwrap.dedent(
+        """
+        from tests.ci.ci_register import register_cuda_ci
+        register_cuda_ci(est_time=600, suite="stage-c-8-gpu-h100")
+        """
+    ).lstrip("\n")
+    p = tmp_path / "test_nogate.py"
+    p.write_text(body)
+    record = _write_record(tmp_path, {"rollout/raw_reward": [[0, 0.3]]})
+
+    result = evaluate_gate(str(p), record, store)
+    assert result.metrics == []
+    assert result.trusted is True
+
+
+def test_gate_writes_no_rows(tmp_path, store):
+    # The gate must never persist: after evaluation the store has no runs.
+    test_file = _write_test_file(
+        tmp_path,
+        """
+        register_ci_gate(metric_key="rollout/raw_reward",
+                         steps="all", constraint={"rel_up": 0.20, "rel_down": 0.20})
+        """,
+    )
+    record = _write_record(tmp_path, {"rollout/raw_reward": [[0, 0.31]]})
+    evaluate_gate(test_file, record, store)
+
+    n = store._conn.execute("SELECT COUNT(*) FROM runs").fetchone()[0]
+    assert n == 0

--- a/tests/ci/test/test_metric_history_store.py
+++ b/tests/ci/test/test_metric_history_store.py
@@ -41,8 +41,8 @@ PROVENANCE = RunProvenance(
 # test file's literal steps / constraint values.
 LAST_STEPS_KEY = '"last"'
 STEP_LIST_KEY = "[0,1]"
-REL_CONSTRAINT_KEY = '{"rel":0.2}'
-ABS_CONSTRAINT_KEY = '{"abs_floor":0.02}'
+REL_CONSTRAINT_KEY = '{"rel_down":0.2,"rel_up":0.2}'
+ABS_CONSTRAINT_KEY = '{"abs_floor_down":0.02,"abs_floor_up":0.02}'
 
 
 def _sample(metric_key, value, *, steps_key=LAST_STEPS_KEY, constraint_key=REL_CONSTRAINT_KEY, step=-1):

--- a/tests/ci/test/test_metric_selection.py
+++ b/tests/ci/test/test_metric_selection.py
@@ -1,0 +1,525 @@
+"""Offline unit tests for step selection, constraints, and register_ci_gate
+parsing (including the canonical declaration keys)."""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+from tests.ci.ci_register import CIRegistry, HWBackend, register_cpu_ci, ut_parse_one_file
+from tests.ci.metric_history.constraints import evaluate_constraint
+from tests.ci.metric_history.register import parse_ci_gate_specs
+from tests.ci.metric_history.selection import SelectionError, select
+
+register_cpu_ci(est_time=1, suite="stage-a-cpu", labels=[])
+
+# --- step selection -----------------------------------------------------------
+
+
+def test_last_picks_last_numeric_point():
+    got = select([[0, 0.1], [1, 0.2], [2, 0.35]], "last")
+    assert len(got) == 1
+    # Identity step is the -1 reduction sentinel; the landing step is reporting.
+    assert got[0].step == -1
+    assert got[0].at_step == 2
+    assert got[0].value == pytest.approx(0.35)
+
+
+def test_selection_skips_bool_and_none_values():
+    # bool sneaks through isinstance(int); None is not a number. Non-numeric
+    # points are ignored -- only numeric points count toward selection.
+    series = [[0, True], [1, None], [2, 2.5]]
+    got = select(series, "last")
+    assert got[0].value == pytest.approx(2.5)
+
+
+def test_last_non_finite_at_selected_point_errors():
+    for bad in (float("nan"), float("inf")):
+        with pytest.raises(SelectionError, match="non-finite"):
+            select([[0, 1.0], [1, bad]], "last")
+
+
+def test_last_ignores_non_selected_non_finite():
+    # A mid-series NaN is not the selected coordinate: last gates the actual
+    # last point, which is finite here.
+    got = select([[0, float("nan")], [1, 2.5]], "last")
+    assert got[0].at_step == 1
+    assert got[0].value == pytest.approx(2.5)
+
+
+def test_all_non_finite_errors():
+    with pytest.raises(SelectionError, match="all: non-finite value nan at step 1"):
+        select([[0, 1.0], [1, float("nan")]], "all")
+
+
+def test_steps_non_finite_at_named_step_errors():
+    with pytest.raises(SelectionError, match="non-finite value -inf at required step 1"):
+        select([[0, 1.0], [1, float("-inf")]], [1])
+
+
+def test_empty_series_errors_clearly():
+    for steps in ("last", "all", [0]):
+        with pytest.raises(SelectionError):
+            select([], steps)
+
+
+def test_all_fans_out_one_extraction_per_step():
+    got = select([[0, 1.0], [1, 2.0], [2, 3.0]], "all")
+    assert [(e.step, e.at_step, e.value) for e in got] == [
+        (0, 0, 1.0),
+        (1, 1, 2.0),
+        (2, 2, 3.0),
+    ]
+
+
+def test_all_null_step_errors():
+    with pytest.raises(SelectionError, match="no step index"):
+        select([[0, 1.0], [None, 2.0]], "all")
+
+
+def test_all_duplicate_step_errors():
+    with pytest.raises(SelectionError, match="duplicate step"):
+        select([[0, 1.0], [0, 2.0]], "all")
+
+
+def test_steps_picks_named_steps():
+    got = select([[0, 0.001], [1, 0.5], [2, 0.9]], [0, 2])
+    assert [(e.step, e.value) for e in got] == [(0, 0.001), (2, 0.9)]
+
+
+def test_steps_missing_named_step_errors():
+    with pytest.raises(SelectionError, match="required step 3 missing"):
+        select([[0, 0.001], [1, 0.5]], [3])
+
+
+# --- constraints --------------------------------------------------------------
+
+
+def test_symmetric_corridor():
+    c = {"rel_up": 0.20, "abs_floor_up": 0.0, "rel_down": 0.20, "abs_floor_down": 0.0}
+    assert evaluate_constraint(c, 1.1, 1.0).ok
+    assert not evaluate_constraint(c, 1.3, 1.0).ok
+    assert not evaluate_constraint(c, 0.7, 1.0).ok
+
+
+def test_band_scales_from_ref_only():
+    # The tolerance is fixed by history: a deviating cur must not widen its
+    # own band (a max over both magnitudes would pass 0.99 here, an effective
+    # ceiling of 2x ref instead of the declared 1.5x).
+    c = {"rel_up": 0.50, "abs_floor_up": 0.0, "rel_down": 0.50, "abs_floor_down": 0.0}
+    assert evaluate_constraint(c, 0.74, 0.5).ok
+    assert not evaluate_constraint(c, 0.76, 0.5).ok
+    assert not evaluate_constraint(c, 0.99, 0.5).ok
+
+
+def test_abs_floor_covers_near_zero():
+    # A reference near zero makes the relative band vanish; the floor remains.
+    c = {"rel_up": 0.20, "abs_floor_up": 1e-6, "rel_down": 0.20, "abs_floor_down": 1e-6}
+    assert evaluate_constraint(c, 1e-7, 0.0).ok
+    assert not evaluate_constraint(c, 0.5, 0.0).ok
+
+
+def test_each_side_band_is_max_of_rel_and_floor():
+    c = {"rel_up": 0.30, "abs_floor_up": 0.1, "rel_down": 0.10, "abs_floor_down": 0.1}
+    out = evaluate_constraint(c, 0.5, 0.5)
+    assert out.hi == pytest.approx(0.65)  # rel side wins: 0.3*0.5 > 0.1
+    assert out.lo == pytest.approx(0.4)  # floor wins: 0.1*0.5 < 0.1
+
+
+def test_asymmetric_sides():
+    # Tight upper band, loose-but-finite lower band: a moderate drop passes,
+    # a rise beyond band and a collapse far below both fail.
+    c = {"rel_up": 0.10, "abs_floor_up": 0.0, "rel_down": 0.80, "abs_floor_down": 0.0}
+    assert evaluate_constraint(c, 2.1, 2.0).ok
+    assert not evaluate_constraint(c, 2.3, 2.0).ok
+    assert evaluate_constraint(c, 0.5, 2.0).ok
+    assert not evaluate_constraint(c, 0.3, 2.0).ok
+
+
+# --- register_ci_gate parsing -----------------------------------------------
+
+
+def _make_fixture(body: str, tmp_path: Path, name: str = "test_gatefix.py") -> str:
+    p = tmp_path / name
+    p.write_text(textwrap.dedent(body).lstrip("\n"))
+    return str(p)
+
+
+def test_parse_single_spec_with_defaults(tmp_path):
+    path = _make_fixture(
+        """
+        from tests.ci.ci_register import register_cuda_ci
+        from tests.ci.metric_history import register_ci_gate
+        register_cuda_ci(est_time=600, suite="stage-c-8-gpu-h100")
+        register_ci_gate(
+            metric_key="train/grad_norm",
+            steps="all",
+            constraint={"rel_up": 0.20, "rel_down": 0.20},
+        )
+        """,
+        tmp_path,
+    )
+    specs = parse_ci_gate_specs(path)
+    assert len(specs) == 1
+    s = specs[0]
+    assert s.metric_key == "train/grad_norm"
+    assert s.steps == "all"
+    assert s.constraint == {"rel_up": 0.20, "abs_floor_up": 0.0, "rel_down": 0.20, "abs_floor_down": 0.0}
+    assert s.enforce is False
+    assert s.allowlist_reason is None
+    assert s.filename == path
+
+
+def test_parse_all_fields(tmp_path):
+    path = _make_fixture(
+        """
+        from tests.ci.metric_history import register_ci_gate
+        register_ci_gate(
+            metric_key="train/ppo_kl",
+            steps=[0, 1],
+            constraint={"abs_floor_up": 1e-6, "rel_up": 0.5, "rel_down": 0.8},
+            enforce=True,
+            allowlist_reason="known noisy",
+        )
+        """,
+        tmp_path,
+    )
+    s = parse_ci_gate_specs(path)[0]
+    assert s.steps == [0, 1]
+    assert s.constraint == {"rel_up": 0.5, "abs_floor_up": 1e-6, "rel_down": 0.8, "abs_floor_down": 0.0}
+    assert s.enforce is True
+    assert s.allowlist_reason == "known noisy"
+
+
+def test_declaration_keys_are_canonical_json(tmp_path):
+    # Dict keys are sorted and every literal is whitespace-free regardless of
+    # how the author wrote it; this pins the exact stored-identity format.
+    path = _make_fixture(
+        """
+        from tests.ci.metric_history import register_ci_gate
+        register_ci_gate(metric_key="train/ppo_kl",
+                         steps=[0,  1],
+                         constraint={"abs_floor_up": 0.02, "abs_floor_down": 0.02})
+        register_ci_gate(metric_key="train/x", steps="last",
+                         constraint={"rel_up": 0.2, "rel_down": 0.2})
+        """,
+        tmp_path,
+    )
+    fanned, reduced = parse_ci_gate_specs(path)
+    assert fanned.steps_key == "[0,1]"
+    assert fanned.constraint_key == '{"abs_floor_down":0.02,"abs_floor_up":0.02}'
+    assert reduced.steps_key == '"last"'
+
+
+def test_declaration_keys_use_raw_literal_not_normalized(tmp_path):
+    # The normalized constraint fills the omitted params from code; the key
+    # must come from the literal as written, so a code-side default change
+    # can never silently rewrite keys and reset every series.
+    path = _make_fixture(
+        """
+        from tests.ci.metric_history import register_ci_gate
+        register_ci_gate(metric_key="train/x",
+                         steps="last", constraint={"rel_up": 0.2, "rel_down": 0.2})
+        """,
+        tmp_path,
+    )
+    s = parse_ci_gate_specs(path)[0]
+    assert s.constraint == {"rel_up": 0.2, "abs_floor_up": 0.0, "rel_down": 0.2, "abs_floor_down": 0.0}
+    assert s.constraint_key == '{"rel_down":0.2,"rel_up":0.2}'
+    assert "abs_floor" not in s.constraint_key
+
+
+def test_abs_optional_rel_defaults_to_zero(tmp_path):
+    path = _make_fixture(
+        """
+        from tests.ci.metric_history import register_ci_gate
+        register_ci_gate(
+            metric_key="train/ppo_kl",
+            steps="last",
+            constraint={"abs_floor_up": 1e-6, "abs_floor_down": 1e-6},
+        )
+        """,
+        tmp_path,
+    )
+    s = parse_ci_gate_specs(path)[0]
+    assert s.constraint == {"rel_up": 0.0, "abs_floor_up": 1e-6, "rel_down": 0.0, "abs_floor_down": 1e-6}
+
+
+def test_parse_multiple_specs(tmp_path):
+    path = _make_fixture(
+        """
+        from tests.ci.metric_history import register_ci_gate
+        register_ci_gate(metric_key="train/grad_norm",
+                         steps="all", constraint={"rel_up": 0.2, "rel_down": 0.2})
+        register_ci_gate(metric_key="rollout/raw_reward",
+                         steps="last",
+                         constraint={"rel_up": 0.5, "rel_down": 0.2})
+        """,
+        tmp_path,
+    )
+    specs = parse_ci_gate_specs(path)
+    assert [s.metric_key for s in specs] == ["train/grad_norm", "rollout/raw_reward"]
+
+
+def test_unknown_kwarg_rejected(tmp_path):
+    path = _make_fixture(
+        """
+        from tests.ci.metric_history import register_ci_gate
+        register_ci_gate(metric_key="train/x",
+                         steps="last", constraint={"rel_up": 0.2, "rel_down": 0.2}, bogus=3)
+        """,
+        tmp_path,
+    )
+    with pytest.raises(ValueError, match="unknown argument 'bogus'"):
+        parse_ci_gate_specs(path)
+
+
+def test_non_literal_arg_rejected(tmp_path):
+    path = _make_fixture(
+        """
+        from tests.ci.metric_history import register_ci_gate
+        X = "last"
+        register_ci_gate(metric_key="train/x", steps=X,
+                         constraint={"rel_up": 0.2, "rel_down": 0.2})
+        """,
+        tmp_path,
+    )
+    with pytest.raises(ValueError, match="must be a literal"):
+        parse_ci_gate_specs(path)
+
+
+def test_non_literal_inside_dict_rejected(tmp_path):
+    path = _make_fixture(
+        """
+        from tests.ci.metric_history import register_ci_gate
+        X = 0.2
+        register_ci_gate(metric_key="train/x",
+                         steps="last", constraint={"rel_up": X, "rel_down": 0.2})
+        """,
+        tmp_path,
+    )
+    with pytest.raises(ValueError, match="must be a literal"):
+        parse_ci_gate_specs(path)
+
+
+@pytest.mark.parametrize("missing", ["metric_key", "steps", "constraint"])
+def test_missing_required_field_rejected(tmp_path, missing):
+    fields = {
+        "metric_key": 'metric_key="train/x"',
+        "steps": 'steps="last"',
+        "constraint": 'constraint={"rel_up": 0.2, "rel_down": 0.2}',
+    }
+    del fields[missing]
+    call = f"register_ci_gate({', '.join(fields.values())})"
+    path = _make_fixture(
+        f"""
+        from tests.ci.metric_history import register_ci_gate
+        {call}
+        """,
+        tmp_path,
+    )
+    with pytest.raises(ValueError, match=f"{missing} is required"):
+        parse_ci_gate_specs(path)
+
+
+def test_positional_arg_rejected(tmp_path):
+    path = _make_fixture(
+        """
+        from tests.ci.metric_history import register_ci_gate
+        register_ci_gate("train/x", 1.0)
+        """,
+        tmp_path,
+    )
+    with pytest.raises(ValueError, match="only keyword arguments"):
+        parse_ci_gate_specs(path)
+
+
+def test_unknown_steps_keyword_rejected(tmp_path):
+    path = _make_fixture(
+        """
+        from tests.ci.metric_history import register_ci_gate
+        register_ci_gate(metric_key="train/x",
+                         steps="mean_last_9000", constraint={"rel_up": 0.2, "rel_down": 0.2})
+        """,
+        tmp_path,
+    )
+    with pytest.raises(ValueError, match='steps must be "last", "all"'):
+        parse_ci_gate_specs(path)
+
+
+def test_constraint_name_key_is_gone(tmp_path):
+    # The old name-keyed constraint registry was merged into one band family;
+    # a declaration still passing "name" must fail loud, not silently drop.
+    path = _make_fixture(
+        """
+        from tests.ci.metric_history import register_ci_gate
+        register_ci_gate(metric_key="train/x",
+                         steps="last", constraint={"name": "band", "rel_up": 0.2, "rel_down": 0.2})
+        """,
+        tmp_path,
+    )
+    with pytest.raises(ValueError, match="unknown key 'name' for constraint"):
+        parse_ci_gate_specs(path)
+
+
+@pytest.mark.parametrize(
+    "literal,match",
+    [
+        ('{"rel_down": 0.2}', "upper band param"),
+        ('{"rel_up": 0.2}', "lower band param"),
+    ],
+    ids=["missing-up", "missing-down"],
+)
+def test_constraint_missing_side_rejected(tmp_path, literal, match):
+    # An all-default side has band 0 and fails on any deviation; the parser
+    # demands at least one written band param per side.
+    path = _make_fixture(
+        f"""
+        from tests.ci.metric_history import register_ci_gate
+        register_ci_gate(metric_key="train/x",
+                         steps="last", constraint={literal})
+        """,
+        tmp_path,
+    )
+    with pytest.raises(ValueError, match=match):
+        parse_ci_gate_specs(path)
+
+
+def test_non_string_non_list_steps_rejected(tmp_path):
+    path = _make_fixture(
+        """
+        from tests.ci.metric_history import register_ci_gate
+        register_ci_gate(metric_key="train/x",
+                         steps=0, constraint={"rel_up": 0.2, "rel_down": 0.2})
+        """,
+        tmp_path,
+    )
+    with pytest.raises(ValueError, match='steps must be "last", "all"'):
+        parse_ci_gate_specs(path)
+
+
+@pytest.mark.parametrize(
+    "steps_literal",
+    ["[]", "[1.5]", "[True]", "[-1]", "[0, 0]"],
+    ids=["empty", "float", "bool", "negative", "duplicate"],
+)
+def test_bad_steps_list_rejected(tmp_path, steps_literal):
+    path = _make_fixture(
+        f"""
+        from tests.ci.metric_history import register_ci_gate
+        register_ci_gate(metric_key="train/x",
+                         steps={steps_literal},
+                         constraint={{"rel_up": 0.2, "rel_down": 0.2}})
+        """,
+        tmp_path,
+    )
+    with pytest.raises(ValueError, match="steps: "):
+        parse_ci_gate_specs(path)
+
+
+def test_direction_key_is_gone(tmp_path):
+    # The one-sided direction abstraction was removed: every constraint is
+    # two-sided, a lenient side gets a wide band. A stale declaration must
+    # fail loud, not silently drop its direction.
+    path = _make_fixture(
+        """
+        from tests.ci.metric_history import register_ci_gate
+        register_ci_gate(metric_key="train/x",
+                         steps="last",
+                         constraint={"rel_up": 0.2, "rel_down": 0.8, "direction": "higher_is_worse"})
+        """,
+        tmp_path,
+    )
+    with pytest.raises(ValueError, match="unknown key 'direction'"):
+        parse_ci_gate_specs(path)
+
+
+def test_negative_rel_rejected(tmp_path):
+    path = _make_fixture(
+        """
+        from tests.ci.metric_history import register_ci_gate
+        register_ci_gate(metric_key="train/x",
+                         steps="last", constraint={"rel_up": -0.2, "rel_down": 0.2})
+        """,
+        tmp_path,
+    )
+    with pytest.raises(ValueError, match="param 'rel_up'"):
+        parse_ci_gate_specs(path)
+
+
+def test_duplicate_dict_key_rejected(tmp_path):
+    # A plain dict would silently keep the last value; the parser must reject.
+    path = _make_fixture(
+        """
+        from tests.ci.metric_history import register_ci_gate
+        register_ci_gate(metric_key="train/x",
+                         steps="last",
+                         constraint={"rel_up": 0.2, "rel_up": 0.3, "rel_down": 0.2})
+        """,
+        tmp_path,
+    )
+    with pytest.raises(ValueError, match="duplicate key 'rel_up'"):
+        parse_ci_gate_specs(path)
+
+
+def test_sub_label_argument_is_gone(tmp_path):
+    # The old author-label argument was removed with the encoded-coordinate
+    # design; a declaration still passing it must fail loud, not silently drop.
+    path = _make_fixture(
+        """
+        from tests.ci.metric_history import register_ci_gate
+        register_ci_gate(metric_key="train/x",
+                         steps="last", constraint={"rel_up": 0.2, "rel_down": 0.2},
+                         sub_label="shard-0")
+        """,
+        tmp_path,
+    )
+    with pytest.raises(ValueError, match="unknown argument 'sub_label'"):
+        parse_ci_gate_specs(path)
+
+
+def test_non_bool_enforce_rejected(tmp_path):
+    path = _make_fixture(
+        """
+        from tests.ci.metric_history import register_ci_gate
+        register_ci_gate(metric_key="train/x",
+                         steps="last", constraint={"rel_up": 0.2, "rel_down": 0.2}, enforce=1)
+        """,
+        tmp_path,
+    )
+    with pytest.raises(ValueError, match="enforce must be a boolean"):
+        parse_ci_gate_specs(path)
+
+
+def test_register_ci_gate_does_not_disturb_suite_parsing(tmp_path):
+    # The suite RegistryVisitor must still find exactly the register_cuda_ci
+    # call and ignore the register_ci_gate calls beside it.
+    path = _make_fixture(
+        """
+        from tests.ci.ci_register import register_cuda_ci
+        from tests.ci.metric_history import register_ci_gate
+        register_cuda_ci(est_time=600, suite="stage-c-8-gpu-h100", labels=["megatron"])
+        register_ci_gate(metric_key="train/grad_norm",
+                         steps="all", constraint={"rel_up": 0.2, "rel_down": 0.2})
+        """,
+        tmp_path,
+    )
+    registries = ut_parse_one_file(path)
+    assert len(registries) == 1
+    assert isinstance(registries[0], CIRegistry)
+    assert registries[0].backend == HWBackend.CUDA
+    assert registries[0].suite == "stage-c-8-gpu-h100"
+
+
+def test_register_ci_gate_runtime_is_noop():
+    from tests.ci.metric_history import register_ci_gate
+
+    assert (
+        register_ci_gate(
+            metric_key="train/grad_norm",
+            steps="all",
+            constraint={"rel_up": 0.2, "rel_down": 0.2},
+        )
+        is None
+    )


### PR DESCRIPTION
> **Depends on:** #1523
> Stacked on the parent PR's branch. Review / merge the parent first.

## Summary
Offline gate library (M2): declaration parsing, step selection, and the historical check.

## Motivation
After a test passes, each declared metric coordinate is judged against its own trusted history — catching the slow drift a single run cannot see. Shadow-first: the verdict is informational, nothing blocks.

## Usage
```python
register_cuda_ci(est_time=300, suite="stage-c-8-gpu-h100")

register_ci_gate(
    metric_key="train/ppo_kl",
    steps=[0, 1],
    constraint={"abs_floor_up": 0.02, "rel_down": 0.8, "abs_floor_down": 0.02},
)
```
A runtime no-op, parsed from the test file's AST at evaluation time.

## Design Notes
- **Key choices:** flat declaration surface — `steps` (`"last"` / `"all"` / a step list) plus one two-sided band constraint — the value must land in `[ref - band_down, ref + band_up]`, each side written independently as `rel_up` / `abs_floor_up` / `rel_down` / `abs_floor_down` with `band = max(rel*|ref|, abs_floor)` (no unbounded side: a collapse far below baseline is a broken-metric smell and must not enter the baseline mean); the stored identity is `(metric_key, steps_key, constraint_key, step)` with keys as canonical JSON of the raw literals.
- Single layer: historical only. A cold start is INACTIVE (vacuously trusted); a selection failure is ERROR, never a silent skip.
- **Alternatives considered:** the earlier hard layer was removed — it mixed a sanity bound with anti-drift semantics; its successor (a pure absolute bound) is a doc TODO, not implemented.
- Governing doc final form lives on the m3 tree (#1517).

## Verification
- **Tests added:** `test_metric_selection.py` (parser + selection), `test_history_gate.py` (cold start, drift failure, fan-out, ERROR paths); 206 offline tests green on this branch.

## Review Focus
- Scrutinize `register.py:_canonical_key` — raw-literal serialization is the stored identity; changing it re-keys every series.
- Scrutinize ERROR semantics in `gate.py:_evaluate_spec` — a missing metric/step or non-finite value must land as ERROR / untrusted.


