### PR TITLE
(3/4) feat(ci): wire metric-history gate into harness + psycopg NeonStore (M3)

### DIFF
--- a/.github/workflows/_run-ci.yml
+++ b/.github/workflows/_run-ci.yml
@@ -57,6 +57,7 @@ jobs:
       MEGATRON_SOURCE_ROOT: /root/Megatron-LM
       GITHUB_COMMIT_NAME: ${{ github.sha }}_${{ github.event.pull_request.number || 'non-pr' }}
       WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}
+      NEON_DATABASE_URL: ${{ secrets.NEON_DATABASE_URL }}
       MILES_TEST_ENABLE_INFINITE_RUN: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.infinite_run) || 'false' }}
     steps:
       - name: Checkout repository

--- a/docs/ci/03-metric-history-gate.md
+++ b/docs/ci/03-metric-history-gate.md
@@ -47,6 +47,48 @@ register_ci_gate(
 )
 ```
 
+
+
+## Roles & data flow
+
+**Goal:** split the pipeline into three decoupled roles — collector, harness, gate library — connected only by JSONL files and one store, so the training process never blocks on gating and the gate stays a pure, read-only library.
+
+Three roles, connected only by JSONL files and one DB — there is no long-lived "metrics manager"; the pipeline is per-test, driven by the harness:
+
+- **Collector (training process)** — `miles.utils.tracking_utils.TrackingManager` fans every `log()` out to all enabled backends; `WandbBackend` and `CiHistoryBackend` are parallel siblings in that registry, so wandb receives the same data independently and nothing downstream ever reads it back. `CiHistoryBackend` snapshots the fixed metric whitelist into per-process JSONL files under the harness-assigned record dir (`MILES_CI_GATE_RECORD_DIR`, injected by the CI harness; no CLI flag).
+- **Harness / finalizer (CI runner)** — `run_suite.py` builds the store from env (`NEON_DATABASE_URL`, a CI secret), resolves the nightly signal + provenance, and allocates the record dir (CUDA suites only); `ci_utils.run_unittest_files` hands each attempt its own record subdir and merges the PASSING attempt's per-process records into the merged per-run JSONL record (a metric key appearing in several processes gets its series concatenated and sorted by step); `ci_utils.run_gate_hook` then assigns identity, runs the gate, and acts on the verdict.
+- **Gate library (pure functions, read-only against storage)** — `register.py` parses `register_ci_gate` declarations out of the test file's AST at evaluation time (the call itself is a runtime no-op; nothing registers at runtime), `selection.py` picks comparison coordinates, `constraints.py` judges pass/fail, `gate.py:evaluate_gate` composes them over the store's baseline read.
+
+One CUDA test run, end to end:
+
+```mermaid
+flowchart TD
+    subgraph training_process["training process (miles core)"]
+        training_code["training code"] -- "log()" --> tracking_manager["TrackingManager"]
+        tracking_manager -- "fan-out (parallel)" --> wandb_backend["WandbBackend<br>write-only sink, never read back"]
+        tracking_manager --> ci_history_backend["CiHistoryBackend"]
+    end
+    ci_history_backend -- "per-process JSONL snapshots<br>(whitelist only; non-finite → string markers)" --> run_unittest_files
+    subgraph ci_harness["CI harness (tests/ci)"]
+        run_suite["run_suite.py<br>store from env · nightly signal · provenance · record dir"] --> run_unittest_files["run_unittest_files<br>per-attempt record subdir; merge the PASSING attempt"]
+        run_unittest_files --> run_gate_hook["run_gate_hook<br>assign identity → run the gate → act on the verdict"]
+    end
+    gate_specs["register_ci_gate specs in the test file<br>(runtime no-op)"] -. "AST parse" .-> evaluate_gate
+    run_gate_hook --> evaluate_gate
+    subgraph gate_library["gate library (pure, read-only against storage)"]
+        evaluate_gate["register → selection → constraints → evaluate_gate"]
+    end
+    evaluate_gate -- "recent_trusted_values (baseline read)" --> metric_store
+    run_gate_hook -- "nightly: write_run(values + trusted)<br>ordinary PR: shadow verdict → log + GITHUB_STEP_SUMMARY, no write" --> metric_store
+    subgraph storage
+        metric_store[("MetricHistoryStore<br>SQLite offline · Neon CI/prod")]
+    end
+```
+
+
+
+Capture is runtime behavior inside the training process, so it never blocks the run on metric *content*: a non-finite value (`NaN` / `±Inf`) is real evidence of the run and is recorded faithfully, encoded in the JSONL as the string marker `"NaN"` / `"Infinity"` / `"-Infinity"` so every line stays strict JSON (the gate-side reader decodes markers back to floats). Judging non-finite values is the gate's job, not the recorder's. A wrong *type* (non-int/float) is an authoring bug, not run evidence, and still fails loud at capture.
+
 ## The gate: drift against trusted history
 
 **Goal:** judge every declared coordinate against its own trusted past, so slow drift gets caught while a fresh baseline can seed itself.
@@ -73,6 +115,16 @@ flowchart TD
         decl -- "read the file's AST, never execute it<br>(hence literal-only args); per-name schema validation<br>parse_ci_gate_specs" --> spec
     end
 
+    subgraph capture_sg["capture & merge — per attempt, harness-side"]
+        snaps(["per-process JSONL snapshots (one record subdir per attempt)<br>atomically rewritten during the run; non-finite → string markers"])
+        passq{"did the test attempt pass?"}
+        drop["outcome: records discarded — no merge, no gate, no write;<br>a retried test is judged on its passing attempt's own records"]
+        merge["merge the PASSING attempt's files into the merged per-run record<br>same metric key in several processes: series are concatenated, then sorted by step<br>ci_utils.run_unittest_files"]
+        snaps --> passq
+        passq -- "failed" --> drop
+        passq -- "passed" --> merge
+    end
+
     record(["the run's captured metrics (one file per run, parsed once)<br>merged per-run JSONL record: raw per-step log() values,<br>capture whitelist TARGET_METRIC_KEYS only<br>parse_merged_record → {metric_key: series}"])
 
     subgraph eval_sg["evaluate — _evaluate_spec, once per spec"]
@@ -97,6 +149,7 @@ flowchart TD
     end
 
     spec --> lookup
+    merge --> record
     record --> lookup
 
     trust["run-level verdict — after all specs, once per run<br>run trusted ⇔ every coordinate: historical ∈ {PASS, INACTIVE}<br>(what the verdict triggers: see 'Trust, cleanup, who writes')"]
@@ -132,7 +185,7 @@ Chart key: rectangle = a step or check; rounded box = a data artifact; diamond =
 - `metric_values` — one row per value: `run_id` FK + `(metric_key, steps_key, constraint_key, step)` + `value`.
 - The baseline read is served by the composite index `runs(test_path, backend, suite, trusted, created_at DESC)`.
 
-**Operations** — hosted Postgres setup is out-of-band in this round: when `NeonMetricHistoryStore` is implemented, provision the equivalent two tables and application role outside this repo, and keep runtime gate code DML-only. Old-row cleanup policy is a later operational concern, not part of the M0/M1 substrate.
+**Operations** — hosted Postgres setup is out-of-band: the two tables and application role are provisioned outside this repo, and runtime gate code stays DML-only (`NeonMetricHistoryStore` never issues DDL). Old-row cleanup policy is a later operational concern, not part of the M0/M1 substrate.
 
 ## Trust, cleanup, who writes
 
@@ -141,12 +194,9 @@ Chart key: rectangle = a step or check; rounded box = a data artifact; diamond =
 - A run is `trusted` iff it passed **all** active gates. A drifting run is still recorded, with `trusted = false`, so it can't drag the baseline. A test that fails then passes on **retry** is gated on its passing attempt's metrics and trusted normally — needing a retry is not itself a trust penalty.
 - **Clean a bad point**: `mark_untrusted` = `UPDATE runs SET trusted = false` on the run. The next gate read excludes it immediately — no rebaseline, no row deletion.
 - **Nightly-marked runs write baselines** — either the `schedule` cron (on `main`, post-merge) **or** a PR carrying the `nightly` label (the PR's own pre-merge code). Provenance (`event_name`, `pr_number`) records which, so a label-PR baseline is distinguishable from a post-merge one and can be `mark_untrusted`'d if it turns out bad. Ordinary (unlabeled) PR runs are read-only and only shadow.
+- **What one nightly run writes** — one `runs` row plus one `metric_values` row per value coordinate: two specs sharing a coordinate (identical `steps` + `constraint` literals, differing only in policy metadata) collapse to a single row, so a duplicated declaration cannot double-weight the baseline mean; and a file that declares no gate writes nothing at all — `run_gate_hook` skips the write instead of leaving an empty `runs` row.
 
-## Collection
 
-`CiHistoryBackend` runs alongside `WandbBackend` on the same `log()` fan-out and writes JSONL snapshots under the harness-assigned per-test attempt directory. After the test passes, the later gate/finalizer consumes those records, assigns identity + provenance, runs the gate, and (on a nightly-marked run only) writes the rows. Nothing is read back from wandb.
-
-Capture is runtime behavior inside the training process, so it never blocks the run on metric *content*: a non-finite value (`NaN` / `±Inf`) is real evidence of the run and is recorded faithfully, encoded in the JSONL as the string marker `"NaN"` / `"Infinity"` / `"-Infinity"` so every line stays strict JSON (the gate-side reader decodes markers back to floats). Judging non-finite values is the gate's job, not the recorder's. A wrong *type* (non-int/float) is an authoring bug, not run evidence, and still fails loud at capture.
 
 ## Rollout
 
@@ -161,6 +211,8 @@ Shadow-first: collect, store, and evaluate, but **never block a PR** initially �
 - A test-file edit does not reset the series: `test_file_hash` was dropped from the run-series identity because a tiny edit to a test kept wiping its whole history. A test change that genuinely shifts a metric's expected level surfaces as gate failures instead; the reset levers are manual — `mark_untrusted` the stale runs, or edit the declaration literals (new `steps_key` / `constraint_key` ⇒ fresh coordinate).
 - The nightly trigger (`schedule` cron + `nightly` label) already shipped (#1491); detection here is harness-side via `GITHUB_EVENT_NAME`, so this feature needs **no** `pr-test.yml` **edit**.
 - Open: should a brand-new test's first baselines need human confirmation before counting as trusted? (v1: no.)
+
+
 
 ## TODO
 
@@ -177,3 +229,4 @@ Shadow-first: collect, store, and evaluate, but **never block a PR** initially �
 - **Capture set becomes** `TARGET_METRIC_KEYS` **∪ declared keys** — the harness parses specs pre-launch and injects the extras via env.
 - **Self-calibrating constraint** — band = k·std of the coordinate's own history, for heteroskedastic tests; and a `mean` (step-average) reduction.
 - **Enforcement** — the per-test allowlist + global kill-switch from Rollout; shadow mode is current behavior.
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ nvidia-resiliency-ext~=0.6.0; platform_system == "Linux"
 omegaconf
 pillow
 polars==1.42.1
+psycopg[binary]  # metric-history gate store (Neon Postgres driver)
 pybase64
 pylatexenc
 pytest-asyncio

--- a/tests/ci/ci_utils.py
+++ b/tests/ci/ci_utils.py
@@ -1,4 +1,6 @@
+import datetime
 import hashlib
+import json
 import logging
 import os
 import re
@@ -9,7 +11,15 @@ import time
 from collections.abc import Callable
 from dataclasses import dataclass
 
-from tests.ci.ci_register import CIRegistry
+from tests.ci.ci_register import CIRegistry, HWBackend
+from tests.ci.metric_history import (
+    NEON_DATABASE_URL_ENV,
+    MetricSample,
+    NeonMetricHistoryStore,
+    RunIdentity,
+    RunProvenance,
+)
+from tests.ci.metric_history.gate import evaluate_gate
 
 # Env var the training process reads to find the per-attempt record directory; kept
 # in sync with miles.utils.tracking_utils.ci_history.RECORD_DIR_ENV.
@@ -24,6 +34,36 @@ def _attempt_record_dir(base_dir: str, filename: str, attempt: int) -> str:
     """Per-test, per-attempt subdir for CI metric-history records."""
     record_key = f"{_sanitize_for_path(filename)}-{hashlib.sha1(filename.encode()).hexdigest()[:10]}"
     return os.path.join(base_dir, record_key, f"attempt-{attempt}")
+
+
+def _merge_attempt_records(attempt_dir: str, merged_path: str) -> None:
+    """Merge every per-process JSONL file under `attempt_dir` into one record.
+
+    Each per-process file holds lines of `{"metric": key, "series": [[step, value], ...]}`.
+    The same metric key may appear in more than one file; concatenate
+    their series and sort by step so the merged per-run record is coherent. Runs
+    only for the PASSING attempt, right before the gate hook consumes the result.
+    """
+    if not os.path.isdir(attempt_dir):
+        return
+    merged: dict[str, list[list]] = {}
+    for fname in sorted(os.listdir(attempt_dir)):
+        if not fname.endswith(".jsonl"):
+            continue
+        with open(os.path.join(attempt_dir, fname), encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                rec = json.loads(line)
+                merged.setdefault(rec["metric"], []).extend(rec["series"])
+
+    for points in merged.values():
+        points.sort(key=lambda p: (p[0] is None, p[0]))
+
+    with open(merged_path, "w", encoding="utf-8") as f:
+        for metric, points in merged.items():
+            f.write(json.dumps({"metric": metric, "series": points}) + "\n")
 
 
 # Configure logger to output to stdout
@@ -142,6 +182,168 @@ def write_github_step_summary(content: str):
             f.write(content)
 
 
+def _gate_pr_number_from_env() -> int | None:
+    """Parse the PR number out of `GITHUB_COMMIT_NAME` (`{sha}_{pr|non-pr}`).
+
+    The workflow sets `GITHUB_COMMIT_NAME = {github.sha}_{pr_number||'non-pr'}`.
+    A push / schedule run carries the `non-pr` sentinel and yields None.
+    """
+    commit_name = os.environ.get("GITHUB_COMMIT_NAME")
+    if not commit_name or "_" not in commit_name:
+        return None
+    tail = commit_name.rsplit("_", 1)[1]
+    if tail == "non-pr":
+        return None
+    try:
+        return int(tail)
+    except ValueError:
+        return None
+
+
+def _gate_commit_sha_from_env() -> str:
+    """The run's commit sha: prefer `GITHUB_SHA`; fall back to the sha encoded
+    in `GITHUB_COMMIT_NAME` (`{sha}_{pr|non-pr}`); else empty string."""
+    sha = os.environ.get("GITHUB_SHA")
+    if sha:
+        return sha
+    commit_name = os.environ.get("GITHUB_COMMIT_NAME")
+    if commit_name and "_" in commit_name:
+        return commit_name.rsplit("_", 1)[0]
+    return commit_name or ""
+
+
+def _gate_int_env(name: str) -> int | None:
+    raw = os.environ.get(name)
+    if raw is None or raw == "":
+        return None
+    try:
+        return int(raw)
+    except ValueError:
+        return None
+
+
+def gate_provenance_from_env() -> RunProvenance:
+    """Build a :class:`RunProvenance` from the GitHub Actions environment.
+
+    Reads `GITHUB_SHA` (or the sha embedded in `GITHUB_COMMIT_NAME`),
+    `GITHUB_RUN_ID`, `GITHUB_RUN_ATTEMPT`, `GITHUB_EVENT_NAME`,
+    `GITHUB_REF`, and the PR number embedded in `GITHUB_COMMIT_NAME`. Missing
+    values become `None` (run_id / attempt / pr_number) or an empty string
+    (commit_sha) rather than raising -- provenance is audit metadata, never part
+    of the baseline key.
+    """
+    return RunProvenance(
+        commit_sha=_gate_commit_sha_from_env(),
+        pr_number=_gate_pr_number_from_env(),
+        github_run_id=_gate_int_env("GITHUB_RUN_ID"),
+        github_run_attempt=_gate_int_env("GITHUB_RUN_ATTEMPT"),
+        event_name=os.environ.get("GITHUB_EVENT_NAME"),
+        ref=os.environ.get("GITHUB_REF"),
+    )
+
+
+def build_store_from_env():
+    """Return the metric-history store for this environment, or None.
+
+    A hosted store is used only when `NEON_DATABASE_URL` is set (CI with the
+    secret inherited). Locally / in dev the var is unset and this returns None,
+    which disables the gate hook entirely -- no store, no evaluation, no writes.
+
+    Construction opens a DB connection eagerly. That happens outside the gate
+    hook's try/except, so a missing driver / bad DSN / DB outage is caught here
+    and degraded to None -- the gate must never fail a CI job (CUDA or ROCm)
+    before any test runs.
+    """
+    if os.environ.get(NEON_DATABASE_URL_ENV):
+        try:
+            return NeonMetricHistoryStore()
+        except Exception as e:  # noqa: BLE001 -- never let store setup fail CI
+            logger.warning("[CI Gate] store unavailable (%s: %s); gate disabled.", type(e).__name__, e)
+    return None
+
+
+def _shadow_verdict_line(filename: str, result) -> str:
+    """One-line human-readable shadow verdict for a PR run.
+
+    Shadow runs never write a row and never change pass/fail; this is the only
+    artifact they emit besides the per-metric detail.
+    """
+    verdict = "TRUSTED" if result.trusted else "NOT-TRUSTED"
+    return f"[CI Gate][shadow] {filename}: {verdict} ({len(result.metrics)} metric(s))"
+
+
+def run_gate_hook(
+    filename: str,
+    merged_record_path: str,
+    *,
+    store,
+    registry: CIRegistry,
+    nightly: bool,
+    provenance: RunProvenance,
+    now_iso: str | None = None,
+) -> None:
+    """Evaluate the history gate for one passed CUDA test and act on the verdict.
+
+    NIGHTLY-marked run -> persist the run as a trusted/untrusted baseline via
+    `store.write_run`, one `metric_values` row per coordinate (specs sharing a
+    coordinate collapse to one row); a file that declares no gate writes
+    nothing at all. ORDINARY PR run -> never write; log a shadow verdict and
+    append it to `GITHUB_STEP_SUMMARY`.
+
+    The entire body is wrapped: any gate or store error is caught and logged and
+    NEVER propagates, so the gate verdict can never change the test's pass/fail
+    this round.
+    """
+    try:
+        result = evaluate_gate(filename, merged_record_path, store, registry=registry)
+
+        if nightly:
+            if not result.metrics:
+                # Every spec yields at least one per-coordinate result, so an
+                # empty list means the file declares no gate: an empty runs row
+                # is nothing a baseline can use, so write nothing.
+                logger.info(f"[CI Gate][nightly] {filename}: no gate declared; skipping write")
+                return
+            identity = RunIdentity(
+                test_path=result.test_path,
+                backend=result.backend,
+                suite=result.suite,
+            )
+            created_at = now_iso or datetime.datetime.now(datetime.timezone.utc).isoformat()
+            # Specs sharing a coordinate (identical declaration literals,
+            # differing only in policy metadata) select the same value; writing
+            # one row per spec would double-weight that baseline mean.
+            seen_coords: set[tuple[str, str, str, int]] = set()
+            values: list[MetricSample] = []
+            for m in result.metrics:
+                if m.current is None:
+                    continue
+                coord = (m.metric_key, m.steps_key, m.constraint_key, m.step)
+                if coord in seen_coords:
+                    continue
+                seen_coords.add(coord)
+                values.append(MetricSample(m.metric_key, m.steps_key, m.constraint_key, m.step, m.current))
+            store.write_run(
+                identity,
+                provenance,
+                created_at,
+                trusted=result.trusted,
+                values=values,
+            )
+            logger.info(
+                f"[CI Gate][nightly] {filename}: wrote baseline " f"(trusted={result.trusted}, {len(values)} value(s))"
+            )
+        else:
+            line = _shadow_verdict_line(filename, result)
+            logger.info(line)
+            detail = "\n".join(f"  - {m.metric_key} (step={m.step}): {m.reason}" for m in result.metrics)
+            write_github_step_summary(line + ("\n" + detail if detail else "") + "\n")
+    except Exception as e:
+        # The gate is informational this round: a gate error, a missing record,
+        # or a DB error must never fail the test or CI.
+        logger.warning(f"[CI Gate] hook failed for {filename}: {type(e).__name__}: {e}")
+
+
 def _gha_emit_group(title: str) -> None:
     if os.environ.get("GITHUB_ACTIONS") != "true":
         return
@@ -185,6 +387,9 @@ def run_unittest_files(
     enable_retry: bool = False,
     max_attempts: int = 2,
     retry_wait_seconds: int = 60,
+    gate_store=None,
+    gate_nightly: bool = False,
+    gate_provenance: RunProvenance | None = None,
 ):
     """
     Run a list of test files.
@@ -198,6 +403,12 @@ def run_unittest_files(
                      assertion failures (not code errors).
         max_attempts: Maximum number of attempts per file including initial run (default: 2).
         retry_wait_seconds: Seconds to wait between retries (default: 60).
+        gate_store: Metric-history store for the regression gate, or None to skip
+                    the gate hook entirely. Built by `build_store_from_env`.
+        gate_nightly: True when this run writes trusted baselines (nightly);
+                    False for an ordinary PR run, which only logs a shadow verdict.
+        gate_provenance: RunProvenance for the gate write; defaults to
+                    `gate_provenance_from_env()` when None.
     """
     tic = time.perf_counter()
     success = True
@@ -265,6 +476,9 @@ def run_unittest_files(
         attempt = 1
         file_passed = False
         was_retried = False
+        # Merged record path of the PASSING attempt only. Failed attempts keep
+        # their per-process records on disk but are never merged or gated.
+        passing_record_path: str | None = None
 
         while attempt <= (max_attempts if enable_retry else 1):
             if attempt > 1:
@@ -298,6 +512,22 @@ def run_unittest_files(
                     if ret_code == 0:
                         attempt_status = "PASS"
                         file_passed = True
+                        if attempt_record_dir is not None:
+                            # The training process has exited, so its per-process
+                            # JSONL records are complete. Merge the passing
+                            # attempt's records into the one per-run record the
+                            # gate consumes. Gate infrastructure: a merge I/O
+                            # error must never propagate and change the test's
+                            # pass/fail, so it is caught and logged and only
+                            # skips the gate hook.
+                            merged_path = f"{attempt_record_dir}.merged.jsonl"
+                            try:
+                                _merge_attempt_records(attempt_record_dir, merged_path)
+                                passing_record_path = merged_path
+                            except Exception as e:  # noqa: BLE001 -- gate infra must not affect pass/fail
+                                logger.warning(
+                                    "[CI Gate] record merge failed for %s: %s: %s", filename, type(e).__name__, e
+                                )
                         if was_retried:
                             logger.info(f"\nPASSED on retry (attempt {attempt}): {filename}\n")
                             retried_tests.append((filename, attempt, "passed"))
@@ -355,6 +585,26 @@ def run_unittest_files(
                         timeout_after=attempt_timeout_after,
                         retry_of=(current_attempt - 1) if current_attempt >= 2 else None,
                     )
+
+        # Gate hook (CUDA path only): only run_unittest_files dispatches CUDA
+        # suites; CPU suites go through pytest in run_a_suite and never reach
+        # here. Fire only on a PASS with a selected passing-attempt record and a
+        # configured store. The hook never affects file_passed / success.
+        if (
+            file_passed
+            and gate_store is not None
+            and passing_record_path is not None
+            and isinstance(file, CIRegistry)
+            and file.backend == HWBackend.CUDA
+        ):
+            run_gate_hook(
+                filename,
+                passing_record_path,
+                store=gate_store,
+                registry=file,
+                nightly=gate_nightly,
+                provenance=gate_provenance or gate_provenance_from_env(),
+            )
 
         if not file_passed:
             success = False

--- a/tests/ci/metric_history/__init__.py
+++ b/tests/ci/metric_history/__init__.py
@@ -3,8 +3,8 @@
 * One import surface for consumers, re-exporting the :class:`MetricHistoryStore`
   contract and its record types (:class:`MetricSample`, :class:`RunIdentity`,
   :class:`RunProvenance`).
-* The two backends: offline :class:`SQLiteMetricHistoryStore` and the deferred
-  :class:`NeonMetricHistoryStore` placeholder, plus :data:`NEON_DATABASE_URL_ENV`.
+* The two backends: offline :class:`SQLiteMetricHistoryStore` and hosted
+  :class:`NeonMetricHistoryStore`, plus :data:`NEON_DATABASE_URL_ENV`.
 * The gate declaration marker :func:`register_ci_gate` and its parsed
   :class:`CiGateSpec`.
 * Not re-exported: gate evaluation (:mod:`tests.ci.metric_history.gate`),

--- a/tests/ci/metric_history/gate.py
+++ b/tests/ci/metric_history/gate.py
@@ -3,8 +3,8 @@
 
 * Consumes one merged per-run JSONL record plus the `register_ci_gate` specs
   declared in the test file, and decides whether the run is *trusted*.
-* The record is the passed attempt's merged JSONL; a later round picks which
-  attempt.
+* The record is the passing attempt's merged JSONL, selected and merged by the
+  harness caller (`tests.ci.ci_utils`) before the gate is invoked.
 * Each spec pairs a STEPS selection (which value(s) to pull: `"last"` /
   `"all"` / a step list) with a CONSTRAINT (the pass/fail rule). `"all"` and a
   step list fan out to one comparison coordinate per step, each judged only
@@ -21,8 +21,9 @@
 
 Caveats:
 
-* Do not add store writes here. Persistence is a later round; the gate stays
-  read-only.
+* Do not add store writes here. Persistence is the caller's job --
+  :func:`tests.ci.ci_utils.run_gate_hook` writes rows on nightly-marked runs --
+  and the gate itself stays read-only.
 """
 
 from __future__ import annotations
@@ -239,19 +240,54 @@ def evaluate_gate(
     merged_record_path: str,
     store: MetricHistoryStore,
     *,
+    registry: CIRegistry | None = None,
     history_limit: int = 20,
 ) -> GateResult:
     """Evaluate every `register_ci_gate` spec in `test_filename` against a record.
 
-    `test_filename` is the repo-relative test path; its CIRegistry supplies the
-    (backend, suite) identity.
+    `test_filename` is the repo-relative test path. Gate identity
+    (test_path/backend/suite) comes from `registry` when the real harness
+    passes one -- it has already chosen which `register_*_ci()` call applies,
+    so a file with several (e.g. `register_cuda_ci` + `register_rocm_ci`)
+    is handled without reparsing. When `registry` is None and the file has
+    gate specs, identity is reparsed via `_registry_for` (the isolated
+    unit-test convenience, which still refuses a no-register or ambiguous file).
+
+    A file with no gate specs is vacuously trusted and does NOT require a unique
+    registry: identity is taken from `registry` if given, else filled
+    best-effort from `test_filename` without raising on a dual-register or
+    no-register file.
+
     `merged_record_path` is the merged per-run JSONL of the passed attempt --
     the gate never globs a base directory to find it. `store` answers the
     baseline query and nothing else (no writes, no connection opened here). A
     fanned-out spec contributes one MetricGateResult per step.
     """
     specs = parse_ci_gate_specs(test_filename)
-    registry = _registry_for(test_filename)
+    if not specs:
+        # No gate spec can regress, so identity is informational here and must
+        # never raise on a dual-register / no-register file. Use the harness's
+        # registry if it gave one, otherwise fill best-effort from the filename.
+        if registry is not None:
+            return GateResult(
+                test_path=registry.filename,
+                backend=_BACKEND_STR[registry.backend],
+                suite=registry.suite,
+                metrics=[],
+            )
+        return GateResult(
+            test_path=test_filename,
+            backend="",
+            suite="",
+            metrics=[],
+        )
+
+    # The harness already selected one register_*_ci() call; use it directly and
+    # do not reparse (the file may carry several register calls). With no registry
+    # this is the isolated-unit-test path, which reparses and may still raise on
+    # an ambiguous (multi-register) or no-register file.
+    if registry is None:
+        registry = _registry_for(test_filename)
     backend = _BACKEND_STR[registry.backend]
     by_metric = parse_merged_record(merged_record_path)
 

--- a/tests/ci/metric_history/register.py
+++ b/tests/ci/metric_history/register.py
@@ -274,10 +274,10 @@ def parse_ci_gate_specs(filename: str) -> list[CiGateSpec]:
     callee is the bare name `register_ci_gate`. Non-literal / invalid args raise
     ValueError naming the file and field.
 
-    Note for the future writer: two specs may still map to the same baseline
-    coordinate (identical steps + constraint literals, differing only in
-    policy metadata). The writer must dedupe metric_values by coordinate so
-    one run contributes one row per coordinate.
+    Two specs may still map to the same baseline coordinate (identical
+    steps + constraint literals, differing only in policy metadata); the
+    harness writer (`tests.ci.ci_utils.run_gate_hook`) collapses such
+    duplicates to one `metric_values` row per coordinate.
     """
     with open(filename) as f:
         tree = ast.parse(f.read(), filename=filename)

--- a/tests/ci/metric_history/storage/__init__.py
+++ b/tests/ci/metric_history/storage/__init__.py
@@ -3,8 +3,7 @@
 * Re-exports the :class:`MetricHistoryStore` contract and its record types
   (:class:`MetricSample`, :class:`RunIdentity`, :class:`RunProvenance`).
 * Re-exports the two backends -- offline :class:`SQLiteMetricHistoryStore` and
-  the deferred :class:`NeonMetricHistoryStore` placeholder -- plus
-  :data:`NEON_DATABASE_URL_ENV`.
+  hosted :class:`NeonMetricHistoryStore` -- plus :data:`NEON_DATABASE_URL_ENV`.
 """
 
 from tests.ci.metric_history.storage.neon_store import NEON_DATABASE_URL_ENV, NeonMetricHistoryStore

--- a/tests/ci/metric_history/storage/neon_store.py
+++ b/tests/ci/metric_history/storage/neon_store.py
@@ -12,6 +12,11 @@
 * The DSN comes from the `NEON_DATABASE_URL` environment variable (a CI
   secret, provisioned out-of-band) unless one is passed explicitly. Credentials
   are never embedded and the host is never hardcoded.
+* Every operation opens a fresh connection and closes it before returning;
+  construction only resolves the DSN. The store lives for a whole CI suite
+  while individual e2e tests run tens of minutes, so a connection cached at
+  construction would outlive Neon's pooler idle timeout / compute autosuspend
+  and every write after the first idle gap would fail on a dead socket.
 * The schema (the two tables and the application role) is provisioned
   out-of-band, outside this repo. This module stays DML-only -- insert runs,
   read baselines, mark runs untrusted -- and never issues DDL on the
@@ -87,15 +92,13 @@ class NeonMetricHistoryStore(MetricHistoryStore):
                     "Set the environment variable to the Neon Postgres DSN, or pass dsn= explicitly."
                 )
         self._dsn = dsn
-        self._conn = self._connect(dsn)
 
-    @staticmethod
-    def _connect(dsn: str):
+    def _connect(self):
         # Lazy import: see module docstring. autocommit stays off so write_run
         # controls its own transaction boundary explicitly.
         import psycopg
 
-        return psycopg.connect(dsn)
+        return psycopg.connect(self._dsn)
 
     def write_run(
         self,
@@ -107,8 +110,9 @@ class NeonMetricHistoryStore(MetricHistoryStore):
     ) -> str:
         validate_finite_values(values)
         run_id = uuid.uuid4().hex
+        conn = self._connect()
         try:
-            with self._conn.cursor() as cur:
+            with conn.cursor() as cur:
                 cur.execute(
                     _INSERT_RUN_SQL,
                     (
@@ -130,10 +134,12 @@ class NeonMetricHistoryStore(MetricHistoryStore):
                     _INSERT_METRIC_SQL,
                     [(run_id, s.metric_key, s.steps_key, s.constraint_key, s.step, s.value) for s in values],
                 )
-            self._conn.commit()
+            conn.commit()
         except Exception:
-            self._conn.rollback()
+            conn.rollback()
             raise
+        finally:
+            conn.close()
         return run_id
 
     def recent_trusted_values(
@@ -147,12 +153,16 @@ class NeonMetricHistoryStore(MetricHistoryStore):
         step: int,
         limit: int,
     ) -> list[float]:
-        with self._conn.cursor() as cur:
-            cur.execute(
-                _BASELINE_SQL,
-                (test_path, backend, suite, metric_key, steps_key, constraint_key, step, limit),
-            )
-            rows = cur.fetchall()
+        conn = self._connect()
+        try:
+            with conn.cursor() as cur:
+                cur.execute(
+                    _BASELINE_SQL,
+                    (test_path, backend, suite, metric_key, steps_key, constraint_key, step, limit),
+                )
+                rows = cur.fetchall()
+        finally:
+            conn.close()
         return [row[0] for row in rows]
 
     def mark_untrusted(
@@ -170,18 +180,23 @@ class NeonMetricHistoryStore(MetricHistoryStore):
                 f"got {sorted(provided)}"
             )
         column, value = next(iter(provided.items()))
+        conn = self._connect()
         try:
-            with self._conn.cursor() as cur:
+            with conn.cursor() as cur:
                 cur.execute(
                     f"UPDATE runs SET trusted = false WHERE {column} = %s AND trusted = true",
                     (value,),
                 )
                 affected = cur.rowcount
-            self._conn.commit()
+            conn.commit()
         except Exception:
-            self._conn.rollback()
+            conn.rollback()
             raise
+        finally:
+            conn.close()
         return affected
 
     def close(self) -> None:
-        self._conn.close()
+        # No connection outlives an operation; kept for interface symmetry
+        # with the SQLite store so callers can close either unconditionally.
+        pass

--- a/tests/ci/metric_history/storage/neon_store.py
+++ b/tests/ci/metric_history/storage/neon_store.py
@@ -1,43 +1,101 @@
 # doc-dev: docs/ci/03-metric-history-gate.md
-"""Deferred Neon (hosted Postgres) backend for the metric-history store.
+"""Neon (hosted Postgres) backend for the metric-history store.
 
-* An intentional placeholder: the hosted backend is not wired this round -- no
-  Postgres driver is added to `requirements.txt` and nothing here opens a
-  connection.
-* The class exists so the gate can name its production backend and so the
-  connection contract (the `NEON_DATABASE_URL` env var, provisioned
-  out-of-band) is documented in one place.
+* The production backend: the CI regression gate writes runs here and reads its
+  baselines from here.
+* Mirrors :class:`~tests.ci.metric_history.storage.sqlite_store.SQLiteMetricHistoryStore`
+  semantics exactly -- same write surface, same authoritative baseline query --
+  so swapping backends changes no gate logic.
+* `recent_trusted_values` uses the authoritative baseline query verbatim
+  (plain equality on `metric_key` / `steps_key` / `constraint_key` / `step`),
+  so its results match the SQLite backend's.
+* The DSN comes from the `NEON_DATABASE_URL` environment variable (a CI
+  secret, provisioned out-of-band) unless one is passed explicitly. Credentials
+  are never embedded and the host is never hardcoded.
+* The schema (the two tables and the application role) is provisioned
+  out-of-band, outside this repo. This module stays DML-only -- insert runs,
+  read baselines, mark runs untrusted -- and never issues DDL on the
+  read/write path.
 
-Implementation notes for whoever lands the real driver:
+Caveats:
 
-* Add a driver (`psycopg[binary]` or `asyncpg`) to `requirements.txt`
-  only when this is implemented -- not before.
-* Read the DSN from the `NEON_DATABASE_URL` environment variable. Do not
-  embed credentials and do not hardcode the host.
-* Provision the schema and connection role out-of-band for now. The store's
-  read/write path must remain DML-only: insert runs, read baselines, and mark
-  runs untrusted.
-* `recent_trusted_values` must use the authoritative baseline query verbatim
-  (plain equality on `metric_key` / `steps_key` / `constraint_key` / `step`), so
-  its results match
-  :class:`~tests.ci.metric_history.storage.sqlite_store.SQLiteMetricHistoryStore`.
+* Keep the `psycopg` import lazy inside :meth:`_connect`, never at module
+  load. The package `__init__` imports this module unconditionally, so a
+  top-level driver import would make the whole metric-history package
+  un-importable where the driver is not installed (offline test runs, the
+  SQLite-only path); deferring it also lets the live-Postgres smoke test skip
+  cleanly when the driver/DSN are absent.
 """
 
 from __future__ import annotations
 
-from tests.ci.metric_history.storage.store import MetricHistoryStore, MetricSample, RunIdentity, RunProvenance
+import os
+import uuid
+
+from tests.ci.metric_history.storage.store import (
+    MetricHistoryStore,
+    MetricSample,
+    RunIdentity,
+    RunProvenance,
+    validate_finite_values,
+)
 
 #: Name of the environment variable carrying the Neon Postgres DSN. The value
-#: is provisioned out-of-band as a CI secret and is NOT wired into any workflow
-#: in this round.
+#: is provisioned out-of-band as a CI secret.
 NEON_DATABASE_URL_ENV = "NEON_DATABASE_URL"
 
-_NOT_IMPLEMENTED = "NeonMetricHistoryStore is not implemented yet; use SQLiteMetricHistoryStore offline."
+# Mirrors the authoritative baseline query (see sqlite_store._BASELINE_SQL),
+# translated to psycopg's %s placeholders and Postgres' boolean literal.
+# Every coordinate column is NOT NULL, so the whole match is plain equality.
+_BASELINE_SQL = """
+SELECT mv.value
+FROM metric_values mv
+JOIN runs r USING (run_id)
+WHERE r.test_path = %s
+  AND r.backend = %s
+  AND r.suite = %s
+  AND mv.metric_key = %s
+  AND mv.steps_key = %s
+  AND mv.constraint_key = %s
+  AND mv.step = %s
+  AND r.trusted = true
+ORDER BY r.created_at DESC
+LIMIT %s
+"""
+
+_INSERT_RUN_SQL = """
+INSERT INTO runs (
+    run_id, test_path, backend, suite,
+    commit_sha, pr_number, github_run_id, github_run_attempt,
+    event_name, ref, created_at, trusted
+) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+"""
+
+_INSERT_METRIC_SQL = (
+    "INSERT INTO metric_values (run_id, metric_key, steps_key, constraint_key, step, value)"
+    " VALUES (%s, %s, %s, %s, %s, %s)"
+)
 
 
 class NeonMetricHistoryStore(MetricHistoryStore):
     def __init__(self, dsn: str | None = None):
-        raise NotImplementedError(_NOT_IMPLEMENTED)
+        if dsn is None:
+            dsn = os.environ.get(NEON_DATABASE_URL_ENV)
+            if not dsn:
+                raise RuntimeError(
+                    f"No DSN passed and {NEON_DATABASE_URL_ENV} is unset; cannot connect to Neon. "
+                    "Set the environment variable to the Neon Postgres DSN, or pass dsn= explicitly."
+                )
+        self._dsn = dsn
+        self._conn = self._connect(dsn)
+
+    @staticmethod
+    def _connect(dsn: str):
+        # Lazy import: see module docstring. autocommit stays off so write_run
+        # controls its own transaction boundary explicitly.
+        import psycopg
+
+        return psycopg.connect(dsn)
 
     def write_run(
         self,
@@ -47,7 +105,36 @@ class NeonMetricHistoryStore(MetricHistoryStore):
         trusted: bool,
         values: list[MetricSample],
     ) -> str:
-        raise NotImplementedError(_NOT_IMPLEMENTED)
+        validate_finite_values(values)
+        run_id = uuid.uuid4().hex
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    _INSERT_RUN_SQL,
+                    (
+                        run_id,
+                        identity.test_path,
+                        identity.backend,
+                        identity.suite,
+                        provenance.commit_sha,
+                        provenance.pr_number,
+                        provenance.github_run_id,
+                        provenance.github_run_attempt,
+                        provenance.event_name,
+                        provenance.ref,
+                        created_at,
+                        trusted,
+                    ),
+                )
+                cur.executemany(
+                    _INSERT_METRIC_SQL,
+                    [(run_id, s.metric_key, s.steps_key, s.constraint_key, s.step, s.value) for s in values],
+                )
+            self._conn.commit()
+        except Exception:
+            self._conn.rollback()
+            raise
+        return run_id
 
     def recent_trusted_values(
         self,
@@ -60,7 +147,13 @@ class NeonMetricHistoryStore(MetricHistoryStore):
         step: int,
         limit: int,
     ) -> list[float]:
-        raise NotImplementedError(_NOT_IMPLEMENTED)
+        with self._conn.cursor() as cur:
+            cur.execute(
+                _BASELINE_SQL,
+                (test_path, backend, suite, metric_key, steps_key, constraint_key, step, limit),
+            )
+            rows = cur.fetchall()
+        return [row[0] for row in rows]
 
     def mark_untrusted(
         self,
@@ -69,4 +162,26 @@ class NeonMetricHistoryStore(MetricHistoryStore):
         github_run_id: int | None = None,
         commit_sha: str | None = None,
     ) -> int:
-        raise NotImplementedError(_NOT_IMPLEMENTED)
+        keys = {"run_id": run_id, "github_run_id": github_run_id, "commit_sha": commit_sha}
+        provided = {name: value for name, value in keys.items() if value is not None}
+        if len(provided) != 1:
+            raise ValueError(
+                "mark_untrusted requires exactly one of run_id / github_run_id / commit_sha; "
+                f"got {sorted(provided)}"
+            )
+        column, value = next(iter(provided.items()))
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    f"UPDATE runs SET trusted = false WHERE {column} = %s AND trusted = true",
+                    (value,),
+                )
+                affected = cur.rowcount
+            self._conn.commit()
+        except Exception:
+            self._conn.rollback()
+            raise
+        return affected
+
+    def close(self) -> None:
+        self._conn.close()

--- a/tests/ci/metric_history/storage/sqlite_store.py
+++ b/tests/ci/metric_history/storage/sqlite_store.py
@@ -3,12 +3,13 @@
 
 * No network dependency; the store runs entirely in-process. An in-memory
   database (`:memory:`) makes it a drop-in fixture for unit tests.
-* Query and write semantics mirror the hosted Postgres backend, so tests
-  exercising this implementation validate the contract the gate relies on in
-  production — including the authoritative baseline query's plain-equality
-  match on the `(metric_key, steps_key, constraint_key, step)` coordinate.
+* Query and write semantics mirror the hosted Postgres backend
+  (:class:`NeonMetricHistoryStore` in neon_store.py), so tests exercising this
+  implementation validate the contract the gate relies on in production —
+  including the authoritative baseline query's plain-equality match on the
+  `(metric_key, steps_key, constraint_key, step)` coordinate.
 * This module owns a small local schema literal for tests; production Postgres
-  setup is out-of-band until the hosted backend is implemented.
+  schema setup is out-of-band (provisioned outside the repo).
 * Schema is applied at construction (`apply_schema`), never on the
   read/write path.
 """

--- a/tests/ci/run_suite.py
+++ b/tests/ci/run_suite.py
@@ -1,10 +1,17 @@
 import argparse
+import os
 import subprocess
 import sys
+import tempfile
 
 from tests.ci.ci_policy import CI_CADENCES, NIGHTLY_CADENCE, REGULAR_CADENCE, RunPolicy, resolve_policy
 from tests.ci.ci_register import CIRegistry, HWBackend, collect_tests, discover_ci_files
-from tests.ci.ci_utils import run_unittest_files
+from tests.ci.ci_utils import (
+    CI_GATE_RECORD_DIR_ENV,
+    build_store_from_env,
+    gate_provenance_from_env,
+    run_unittest_files,
+)
 from tests.ci.labels import KNOWN_LABELS
 
 HW_MAPPING = {
@@ -207,6 +214,20 @@ def run_a_suite(args):
     if args.enable_retry:
         timeout += args.retry_timeout_increase
 
+    # Regression-gate wiring: the store exists only when NEON_DATABASE_URL is
+    # set (CI), so the gate hook is a no-op locally. The resolved cadence is
+    # also the baseline-writing signal. Provenance comes from the GitHub env.
+    gate_store = build_store_from_env()
+    gate_nightly = policy.is_nightly
+    gate_provenance = gate_provenance_from_env()
+
+    # The gate collects only when a record directory exists. CI does not set
+    # MILES_CI_GATE_RECORD_DIR, so allocate a job-local one whenever a store is
+    # configured (CUDA suites only -- the gate is CUDA-only). The training
+    # subprocesses' CiHistoryBackend and the merge/gate steps read it from env.
+    if gate_store is not None and hw == HWBackend.CUDA and not os.environ.get(CI_GATE_RECORD_DIR_ENV):
+        os.environ[CI_GATE_RECORD_DIR_ENV] = tempfile.mkdtemp(prefix="miles-ci-gate-")
+
     return run_unittest_files(
         ci_tests,
         timeout_per_file=timeout,
@@ -214,6 +235,9 @@ def run_a_suite(args):
         enable_retry=args.enable_retry,
         max_attempts=args.max_attempts,
         retry_wait_seconds=args.retry_wait_seconds,
+        gate_store=gate_store,
+        gate_nightly=gate_nightly,
+        gate_provenance=gate_provenance,
     )
 
 

--- a/tests/ci/test/test_ci_history.py
+++ b/tests/ci/test/test_ci_history.py
@@ -242,4 +242,7 @@ sys.exit(1)
     attempt_2 = Path(_attempt_record_dir(str(record_base), child.name, attempt=2))
     assert (attempt_1 / "seen.txt").read_text() == str(attempt_1)
     assert (attempt_2 / "seen.txt").read_text() == str(attempt_2)
-    assert not list(record_base.glob("**/*.merged.jsonl"))
+    # Only the PASSING attempt's records are merged for the gate hook; the
+    # failed attempt keeps its per-process records unmerged.
+    assert not Path(f"{attempt_1}.merged.jsonl").exists()
+    assert Path(f"{attempt_2}.merged.jsonl").exists()

--- a/tests/ci/test/test_gate_integration.py
+++ b/tests/ci/test/test_gate_integration.py
@@ -1,0 +1,548 @@
+"""Integration tests for wiring the regression gate into the CI harness.
+
+These exercise the helpers and the gate hook extracted into
+`tests.ci.ci_utils` directly -- no real DB, no real CUDA run. The store is an
+in-memory :class:`SQLiteMetricHistoryStore`; the GitHub environment is
+monkeypatched.
+
+Covered:
+
+* passing-attempt selection: only the PASSED attempt's record feeds the gate.
+* nightly write: a `schedule` event makes the hook persist a baseline row
+  whose `trusted` flag comes from the verdict; specs sharing a coordinate
+  collapse to one `metric_values` row; a no-spec file writes nothing.
+* PR no-write: a `pull_request` event writes no row and emits a shadow
+  verdict string.
+* never-blocks: a not-trusted verdict, and a gate that raises, both leave the
+  test's pass/fail untouched.
+"""
+
+from __future__ import annotations
+
+import json
+import textwrap
+from pathlib import Path
+
+import pytest
+from tests.ci.ci_register import HWBackend, register_cpu_ci, ut_parse_one_file
+from tests.ci.ci_utils import build_store_from_env, gate_provenance_from_env, run_gate_hook
+from tests.ci.metric_history import MetricSample, RunIdentity, RunProvenance, SQLiteMetricHistoryStore
+
+register_cpu_ci(est_time=1, suite="stage-a-cpu", labels=[])
+
+# Canonical declaration keys for the `last` + rel-0.20 fixtures below.
+LAST_KEY = json.dumps("last", sort_keys=True, separators=(",", ":"))
+REL20_KEY = json.dumps({"rel_up": 0.20, "rel_down": 0.20}, sort_keys=True, separators=(",", ":"))
+
+_GITHUB_ENV_VARS = (
+    "GITHUB_EVENT_NAME",
+    "GITHUB_SHA",
+    "GITHUB_COMMIT_NAME",
+    "GITHUB_RUN_ID",
+    "GITHUB_RUN_ATTEMPT",
+    "GITHUB_REF",
+    "GITHUB_STEP_SUMMARY",
+    "NEON_DATABASE_URL",
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_github_env(monkeypatch):
+    """Each test starts from a clean GitHub environment so leftovers from the
+    real CI runner (or a prior test) cannot leak in."""
+    for var in _GITHUB_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+
+
+@pytest.fixture
+def store():
+    s = SQLiteMetricHistoryStore(":memory:")
+    yield s
+    s.close()
+
+
+def _write_test_file(tmp_path: Path, gate_lines: str, *, name: str = "test_e2e_gate_fixture.py") -> str:
+    # Concatenate instead of interpolating into an indented f-string: a
+    # multi-line gate block would otherwise defeat the outer dedent.
+    body = (
+        "from tests.ci.ci_register import register_cuda_ci\n"
+        "from tests.ci.metric_history import register_ci_gate\n"
+        'register_cuda_ci(est_time=600, suite="stage-c-8-gpu-h100")\n' + textwrap.dedent(gate_lines).strip() + "\n"
+    )
+    p = tmp_path / name
+    p.write_text(body)
+    return str(p)
+
+
+def _write_record(tmp_path: Path, by_metric: dict[str, list], *, name: str) -> str:
+    p = tmp_path / name
+    with open(p, "w", encoding="utf-8") as f:
+        for metric, series in by_metric.items():
+            f.write(json.dumps({"metric": metric, "series": series}) + "\n")
+    return str(p)
+
+
+def _registry(test_file: str):
+    return ut_parse_one_file(test_file)[0]
+
+
+PROVENANCE = RunProvenance(
+    commit_sha="deadbeef",
+    pr_number=7,
+    github_run_id=100,
+    github_run_attempt=1,
+    event_name="schedule",
+    ref="refs/heads/main",
+)
+
+
+def _count_runs(store) -> int:
+    return store._conn.execute("SELECT COUNT(*) FROM runs").fetchone()[0]
+
+
+# --- gate_provenance_from_env -----------------------------------------------
+
+
+class TestGateProvenanceFromEnv:
+    def test_full_env_parsed(self, monkeypatch):
+        monkeypatch.setenv("GITHUB_SHA", "cafef00d")
+        monkeypatch.setenv("GITHUB_RUN_ID", "555")
+        monkeypatch.setenv("GITHUB_RUN_ATTEMPT", "2")
+        monkeypatch.setenv("GITHUB_EVENT_NAME", "pull_request")
+        monkeypatch.setenv("GITHUB_REF", "refs/pull/42/merge")
+        monkeypatch.setenv("GITHUB_COMMIT_NAME", "cafef00d_42")
+
+        prov = gate_provenance_from_env()
+        assert prov.commit_sha == "cafef00d"
+        assert prov.pr_number == 42
+        assert prov.github_run_id == 555
+        assert prov.github_run_attempt == 2
+        assert prov.event_name == "pull_request"
+        assert prov.ref == "refs/pull/42/merge"
+
+    def test_non_pr_commit_name_yields_none_pr(self, monkeypatch):
+        monkeypatch.setenv("GITHUB_COMMIT_NAME", "cafef00d_non-pr")
+        prov = gate_provenance_from_env()
+        assert prov.pr_number is None
+        # sha falls back to the GITHUB_COMMIT_NAME prefix when GITHUB_SHA unset.
+        assert prov.commit_sha == "cafef00d"
+
+    def test_empty_env_does_not_raise(self):
+        prov = gate_provenance_from_env()
+        assert prov.commit_sha == ""
+        assert prov.pr_number is None
+        assert prov.github_run_id is None
+        assert prov.github_run_attempt is None
+
+
+# --- build_store_from_env ---------------------------------------------------
+
+
+class TestBuildStoreFromEnv:
+    def test_no_neon_url_returns_none(self):
+        assert build_store_from_env() is None
+
+    def test_neon_url_routes_to_neon_store(self, monkeypatch):
+        # With the env var set the factory must construct the Neon backend
+        # rather than return None. The real NeonMetricHistoryStore.__init__
+        # eagerly opens a psycopg connection, so we patch the symbol *as imported
+        # by ci_utils* with a non-connecting fake that records its construction.
+        # This pins the factory's only job -- routing to NeonMetricHistoryStore --
+        # without depending on psycopg or a reachable DSN.
+        constructed = []
+
+        class _FakeNeonStore:
+            def __init__(self, dsn=None):
+                constructed.append(dsn)
+
+        monkeypatch.setattr("tests.ci.ci_utils.NeonMetricHistoryStore", _FakeNeonStore)
+        monkeypatch.setenv("NEON_DATABASE_URL", "postgres://example/db")
+
+        store = build_store_from_env()
+        assert isinstance(store, _FakeNeonStore), "NEON_DATABASE_URL must route to NeonMetricHistoryStore"
+        assert constructed == [None], "the factory constructs the store with no explicit DSN"
+
+    def test_store_construction_failure_degrades_to_none(self, monkeypatch):
+        # NeonMetricHistoryStore.__init__ connects eagerly, so a bad DSN / DB
+        # outage raises here -- OUTSIDE the gate hook's try/except. The factory
+        # must swallow it and return None: the gate may never fail a CI job
+        # (CUDA or ROCm) before a single test has run.
+        class _ExplodingStore:
+            def __init__(self, dsn=None):
+                raise RuntimeError("connection refused")
+
+        monkeypatch.setattr("tests.ci.ci_utils.NeonMetricHistoryStore", _ExplodingStore)
+        monkeypatch.setenv("NEON_DATABASE_URL", "postgres://unreachable/db")
+
+        assert build_store_from_env() is None
+
+
+# --- passing-attempt selection ----------------------------------------------
+
+
+class TestPassingAttemptSelection:
+    def test_only_passing_attempt_record_is_evaluated_and_written(self, tmp_path, store, monkeypatch):
+        # Nightly so the hook writes; assert the persisted value comes from the
+        # PASSING attempt's good record, never the failed attempt's bad one.
+        monkeypatch.setenv("GITHUB_EVENT_NAME", "schedule")
+        test_file = _write_test_file(
+            tmp_path,
+            """
+            register_ci_gate(metric_key="rollout/raw_reward",
+                             steps="last", constraint={"rel_up": 0.20, "rel_down": 0.20})
+            """,
+        )
+        registry = _registry(test_file)
+
+        # Attempt 1 "failed" with a bad metric (0.10), attempt 2 "passed" (0.80).
+        bad_record = _write_record(tmp_path, {"rollout/raw_reward": [[0, 0.10]]}, name="attempt-1.merged.jsonl")
+        good_record = _write_record(tmp_path, {"rollout/raw_reward": [[0, 0.80]]}, name="attempt-2.merged.jsonl")
+
+        # Only the passing attempt's record path is handed to the hook -- this
+        # is exactly what run_unittest_files selects (it captures the merged
+        # path only inside the ret_code==0 branch).
+        _ = bad_record
+        run_gate_hook(
+            test_file,
+            good_record,
+            store=store,
+            registry=registry,
+            nightly=True,
+            provenance=PROVENANCE,
+        )
+
+        rows = store._conn.execute("SELECT mv.value FROM metric_values mv JOIN runs r USING (run_id)").fetchall()
+        assert rows == [(0.80,)], "only the passing attempt's value must be written"
+
+
+# --- nightly write ----------------------------------------------------------
+
+
+class TestNightlyWrite:
+    def test_nightly_writes_trusted_row_with_provenance(self, tmp_path, store, monkeypatch):
+        monkeypatch.setenv("GITHUB_EVENT_NAME", "schedule")
+        test_file = _write_test_file(
+            tmp_path,
+            """
+            register_ci_gate(metric_key="rollout/raw_reward",
+                             steps="last", constraint={"rel_up": 0.20, "rel_down": 0.20})
+            """,
+        )
+        registry = _registry(test_file)
+        record = _write_record(tmp_path, {"rollout/raw_reward": [[0, 0.81]]}, name="m.jsonl")
+
+        assert _count_runs(store) == 0
+        run_gate_hook(
+            test_file,
+            record,
+            store=store,
+            registry=registry,
+            nightly=True,
+            provenance=PROVENANCE,
+            now_iso="2026-06-29T00:00:00+00:00",
+        )
+
+        row = store._conn.execute(
+            "SELECT test_path, backend, suite, commit_sha, pr_number, "
+            "github_run_id, event_name, created_at, trusted FROM runs"
+        ).fetchone()
+        assert row is not None
+        assert row[0] == registry.filename
+        assert row[1] == "cuda"
+        assert row[2] == "stage-c-8-gpu-h100"
+        assert row[3] == "deadbeef"
+        assert row[4] == 7
+        assert row[5] == 100
+        assert row[6] == "schedule"
+        assert row[7] == "2026-06-29T00:00:00+00:00"
+        # Cold-start (no prior baseline) -> historical inactive -> trusted verdict.
+        assert row[8] == 1
+
+        # The persisted value feeds future baselines.
+        vals = store.recent_trusted_values(
+            registry.filename,
+            "cuda",
+            "stage-c-8-gpu-h100",
+            "rollout/raw_reward",
+            LAST_KEY,
+            REL20_KEY,
+            -1,
+            20,
+        )
+        assert vals == [0.81]
+
+    def test_nightly_writes_untrusted_when_verdict_not_trusted(self, tmp_path, store):
+        # A historical failure makes the verdict not-trusted; the row is still
+        # written (nightly always writes) but flagged untrusted, so it never
+        # pollutes a future baseline.
+        test_file = _write_test_file(
+            tmp_path,
+            """
+            register_ci_gate(metric_key="rollout/raw_reward",
+                             steps="last", constraint={"rel_up": 0.20, "rel_down": 0.20})
+            """,
+        )
+        registry = _registry(test_file)
+        # Seed a trusted baseline at 0.30 under the gated coordinate.
+        store.write_run(
+            RunIdentity(test_path=registry.filename, backend="cuda", suite="stage-c-8-gpu-h100"),
+            PROVENANCE,
+            created_at="2026-06-01T00:00:00+00:00",
+            trusted=True,
+            values=[MetricSample("rollout/raw_reward", LAST_KEY, REL20_KEY, -1, 0.30)],
+        )
+        # 0.90 vs baseline mean 0.30, band 0.06 -> historical fails -> not trusted.
+        record = _write_record(tmp_path, {"rollout/raw_reward": [[0, 0.90]]}, name="m.jsonl")
+
+        run_gate_hook(
+            test_file,
+            record,
+            store=store,
+            registry=registry,
+            nightly=True,
+            provenance=PROVENANCE,
+            now_iso="2026-06-29T00:00:00+00:00",
+        )
+        trusted = store._conn.execute("SELECT trusted FROM runs ORDER BY created_at DESC").fetchone()[0]
+        assert trusted == 0
+        # Untrusted rows are invisible to the baseline query: only the seeded
+        # trusted baseline comes back, never the hook's 0.90 row.
+        vals = store.recent_trusted_values(
+            registry.filename,
+            "cuda",
+            "stage-c-8-gpu-h100",
+            "rollout/raw_reward",
+            LAST_KEY,
+            REL20_KEY,
+            -1,
+            20,
+        )
+        assert vals == [0.30]
+
+    def test_nightly_no_spec_file_writes_nothing(self, tmp_path, store, monkeypatch):
+        # A file with no register_ci_gate call has nothing a baseline can use:
+        # the hook must skip the write entirely, not leave an empty runs row.
+        monkeypatch.setenv("GITHUB_EVENT_NAME", "schedule")
+        test_file = _write_test_file(tmp_path, "")
+        registry = _registry(test_file)
+        record = _write_record(tmp_path, {"rollout/raw_reward": [[0, 0.81]]}, name="m.jsonl")
+
+        run_gate_hook(
+            test_file,
+            record,
+            store=store,
+            registry=registry,
+            nightly=True,
+            provenance=PROVENANCE,
+        )
+        assert _count_runs(store) == 0
+
+    def test_nightly_dedupes_values_by_coordinate(self, tmp_path, store, monkeypatch):
+        # Two specs with identical steps + constraint literals share one
+        # coordinate even though their policy metadata differs; the selected
+        # value is identical, so writing one row per spec would double-weight
+        # this run in the baseline mean.
+        monkeypatch.setenv("GITHUB_EVENT_NAME", "schedule")
+        test_file = _write_test_file(
+            tmp_path,
+            """
+            register_ci_gate(metric_key="rollout/raw_reward",
+                             steps="last", constraint={"rel_up": 0.20, "rel_down": 0.20})
+            register_ci_gate(metric_key="rollout/raw_reward",
+                             steps="last", constraint={"rel_up": 0.20, "rel_down": 0.20},
+                             enforce=True)
+            """,
+        )
+        registry = _registry(test_file)
+        record = _write_record(tmp_path, {"rollout/raw_reward": [[0, 0.81]]}, name="m.jsonl")
+
+        run_gate_hook(
+            test_file,
+            record,
+            store=store,
+            registry=registry,
+            nightly=True,
+            provenance=PROVENANCE,
+        )
+        assert _count_runs(store) == 1
+        rows = store._conn.execute(
+            "SELECT metric_key, steps_key, constraint_key, step, value FROM metric_values"
+        ).fetchall()
+        assert rows == [("rollout/raw_reward", LAST_KEY, REL20_KEY, -1, 0.81)]
+
+
+# --- PR no-write + shadow verdict -------------------------------------------
+
+
+class TestPrShadow:
+    def test_pr_writes_no_row_and_emits_shadow_verdict(self, tmp_path, store, monkeypatch, caplog):
+        monkeypatch.setenv("GITHUB_EVENT_NAME", "pull_request")
+        summary = tmp_path / "step_summary.md"
+        monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary))
+
+        test_file = _write_test_file(
+            tmp_path,
+            """
+            register_ci_gate(metric_key="rollout/raw_reward",
+                             steps="last", constraint={"rel_up": 0.20, "rel_down": 0.20})
+            """,
+        )
+        registry = _registry(test_file)
+        record = _write_record(tmp_path, {"rollout/raw_reward": [[0, 0.81]]}, name="m.jsonl")
+
+        with caplog.at_level("INFO"):
+            run_gate_hook(
+                test_file,
+                record,
+                store=store,
+                registry=registry,
+                nightly=False,
+                provenance=PROVENANCE,
+            )
+
+        # No row written for a PR run.
+        assert _count_runs(store) == 0
+        # A readable shadow verdict line was logged and appended to the summary.
+        assert "[CI Gate][shadow]" in caplog.text
+        assert "TRUSTED" in caplog.text
+        assert summary.exists()
+        summary_text = summary.read_text()
+        assert "[CI Gate][shadow]" in summary_text
+        assert "rollout/raw_reward" in summary_text
+
+
+# --- never-blocks -----------------------------------------------------------
+
+
+class TestNeverBlocks:
+    def test_not_trusted_verdict_does_not_raise_in_pr(self, tmp_path, store, monkeypatch):
+        # A clearly-not-trusted PR run still completes the hook normally (no
+        # exception, no new row). The caller's file_passed is computed
+        # independently of run_gate_hook, which returns None either way.
+        monkeypatch.setenv("GITHUB_EVENT_NAME", "pull_request")
+        test_file = _write_test_file(
+            tmp_path,
+            """
+            register_ci_gate(metric_key="rollout/raw_reward",
+                             steps="last", constraint={"rel_up": 0.20, "rel_down": 0.20})
+            """,
+        )
+        registry = _registry(test_file)
+        # Seed a trusted baseline at 0.30 so 0.95 fails the historical check.
+        store.write_run(
+            RunIdentity(test_path=registry.filename, backend="cuda", suite="stage-c-8-gpu-h100"),
+            PROVENANCE,
+            created_at="2026-06-01T00:00:00+00:00",
+            trusted=True,
+            values=[MetricSample("rollout/raw_reward", LAST_KEY, REL20_KEY, -1, 0.30)],
+        )
+        record = _write_record(tmp_path, {"rollout/raw_reward": [[0, 0.95]]}, name="m.jsonl")
+
+        result = run_gate_hook(
+            test_file,
+            record,
+            store=store,
+            registry=registry,
+            nightly=False,
+            provenance=PROVENANCE,
+        )
+        assert result is None
+        # Only the seeded baseline row: the PR run wrote nothing.
+        assert _count_runs(store) == 1
+
+    def test_gate_error_is_swallowed(self, tmp_path, store, monkeypatch, caplog):
+        # A missing record path makes evaluate_gate raise; the hook must catch,
+        # log, and return None rather than propagate -- CI stays green.
+        monkeypatch.setenv("GITHUB_EVENT_NAME", "schedule")
+        test_file = _write_test_file(
+            tmp_path,
+            """
+            register_ci_gate(metric_key="rollout/raw_reward",
+                             steps="last", constraint={"rel_up": 0.20, "rel_down": 0.20})
+            """,
+        )
+        registry = _registry(test_file)
+        missing_record = str(tmp_path / "does_not_exist.jsonl")
+
+        with caplog.at_level("WARNING"):
+            result = run_gate_hook(
+                test_file,
+                missing_record,
+                store=store,
+                registry=registry,
+                nightly=True,
+                provenance=PROVENANCE,
+            )
+        assert result is None
+        assert _count_runs(store) == 0
+        assert "[CI Gate] hook failed" in caplog.text
+
+    def test_store_error_never_blocks(self, tmp_path, monkeypatch):
+        # A store whose write_run raises (mirrors a real DB error, e.g. the Neon
+        # backend's connection dropping mid-write) must not propagate out of the
+        # hook.
+        monkeypatch.setenv("GITHUB_EVENT_NAME", "schedule")
+        test_file = _write_test_file(
+            tmp_path,
+            """
+            register_ci_gate(metric_key="rollout/raw_reward",
+                             steps="last", constraint={"rel_up": 0.20, "rel_down": 0.20})
+            """,
+        )
+        registry = _registry(test_file)
+        record = _write_record(tmp_path, {"rollout/raw_reward": [[0, 0.81]]}, name="m.jsonl")
+
+        class _ExplodingStore(SQLiteMetricHistoryStore):
+            def write_run(self, *a, **k):
+                raise RuntimeError("DB down")
+
+        store = _ExplodingStore(":memory:")
+        try:
+            result = run_gate_hook(
+                test_file,
+                record,
+                store=store,
+                registry=registry,
+                nightly=True,
+                provenance=PROVENANCE,
+            )
+            assert result is None
+        finally:
+            store.close()
+
+
+# --- backend gating: hook never fires off the CUDA path ----------------------
+
+
+def test_hook_signature_matches_metric_sample_contract(tmp_path, store, monkeypatch):
+    # Regression guard: nightly values must be built as
+    # MetricSample(metric_key, steps_key, constraint_key, step, current) and only
+    # for metrics whose current is not None. A spec on a missing metric
+    # (current None) yields a written run with zero values.
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "schedule")
+    test_file = _write_test_file(
+        tmp_path,
+        """
+        register_ci_gate(metric_key="rollout/raw_reward",
+                         steps="last", constraint={"rel_up": 0.20, "rel_down": 0.20})
+        """,
+    )
+    registry = _registry(test_file)
+    # Record has a different metric; rollout/raw_reward is missing -> current None.
+    record = _write_record(tmp_path, {"train/grad_norm": [[0, 1.0]]}, name="m.jsonl")
+
+    run_gate_hook(
+        test_file,
+        record,
+        store=store,
+        registry=registry,
+        nightly=True,
+        provenance=PROVENANCE,
+    )
+    assert _count_runs(store) == 1
+    n_values = store._conn.execute("SELECT COUNT(*) FROM metric_values").fetchone()[0]
+    assert n_values == 0
+    # The MetricSample type is the contract the hook builds from; assert it imports.
+    assert MetricSample("k", LAST_KEY, REL20_KEY, -1, 1.0).value == 1.0
+    assert HWBackend.CUDA is not None
+    assert RunIdentity("p", "cuda", "s").backend == "cuda"

--- a/tests/ci/test/test_history_gate.py
+++ b/tests/ci/test/test_history_gate.py
@@ -13,7 +13,7 @@ import textwrap
 from pathlib import Path
 
 import pytest
-from tests.ci.ci_register import register_cpu_ci
+from tests.ci.ci_register import CIRegistry, HWBackend, register_cpu_ci
 from tests.ci.metric_history import MetricSample, RunIdentity, RunProvenance, SQLiteMetricHistoryStore
 from tests.ci.metric_history.gate import GateStatus, evaluate_gate, parse_merged_record
 
@@ -606,3 +606,99 @@ def test_gate_writes_no_rows(tmp_path, store):
 
     n = store._conn.execute("SELECT COUNT(*) FROM runs").fetchone()[0]
     assert n == 0
+
+
+# --- dual-register files + harness-supplied registry ------------------------
+
+
+def _write_dual_register_file(tmp_path: Path, gate_lines: str, *, name: str = "test_dual_fixture.py") -> str:
+    """A real-shaped e2e file: BOTH register_cuda_ci and register_rocm_ci.
+
+    Mirrors tests/e2e/short/test_qwen2.5_0.5B_gsm8k_short.py, which trips the
+    single-registry reparse (two register_*_ci calls). The harness passes the
+    chosen registry in.
+    """
+    body = (
+        "from tests.ci.ci_register import register_cuda_ci, register_rocm_ci\n"
+        "from tests.ci.metric_history import register_ci_gate\n"
+        'register_cuda_ci(est_time=360, suite="stage-c-8-gpu-h100", labels=["short"])\n'
+        'register_rocm_ci(est_time=360, suite="stage-c-8-gpu-mi350", labels=["short"])\n'
+        + textwrap.dedent(gate_lines).strip()
+        + "\n"
+    )
+    p = tmp_path / name
+    p.write_text(body)
+    return str(p)
+
+
+def test_dual_register_with_gate_uses_supplied_registry(tmp_path, store):
+    # A file with BOTH register_cuda_ci and register_rocm_ci would make the
+    # single-registry reparse raise (ambiguous). With the harness passing the
+    # CUDA registry explicitly, the gate uses that identity and does not raise.
+    test_file = _write_dual_register_file(
+        tmp_path,
+        """
+        register_ci_gate(metric_key="rollout/raw_reward",
+                         steps="last", constraint={"rel_up": 0.20, "rel_down": 0.20})
+        """,
+    )
+    record = _write_record(tmp_path, {"rollout/raw_reward": [[0, 0.31]]})
+    cuda_registry = CIRegistry(
+        backend=HWBackend.CUDA,
+        filename=test_file,
+        est_time=360,
+        suite="stage-c-8-gpu-h100",
+        labels=["short"],
+    )
+
+    result = evaluate_gate(test_file, record, store, registry=cuda_registry)
+
+    assert len(result.metrics) == 1
+    assert result.metrics[0].historical_status == GateStatus.INACTIVE
+    # Identity is the supplied CUDA registry, not the ROCm one.
+    assert result.backend == "cuda"
+    assert result.suite == "stage-c-8-gpu-h100"
+    assert result.test_path == test_file
+
+
+def test_dual_register_no_spec_registry_none_vacuously_trusted(tmp_path, store):
+    # A dual-registered file with NO register_ci_gate spec, evaluated with
+    # registry=None, must be vacuously trusted -- it must NOT raise on the
+    # ambiguous (two register_*_ci) file because no gate identity is needed.
+    body = textwrap.dedent(
+        """
+        from tests.ci.ci_register import register_cuda_ci, register_rocm_ci
+        register_cuda_ci(est_time=360, suite="stage-c-8-gpu-h100", labels=["short"])
+        register_rocm_ci(est_time=360, suite="stage-c-8-gpu-mi350", labels=["short"])
+        """
+    ).lstrip("\n")
+    p = tmp_path / "test_dual_nogate.py"
+    p.write_text(body)
+    record = _write_record(tmp_path, {"rollout/raw_reward": [[0, 0.3]]})
+
+    result = evaluate_gate(str(p), record, store, registry=None)
+
+    assert result.metrics == []
+    assert result.trusted is True
+    assert result.test_path == str(p)
+
+
+def test_single_register_gate_registry_none_still_reparses(tmp_path, store):
+    # The isolated unit-test convenience path: a single-register file with a
+    # gate spec and registry=None still reparses identity via _registry_for.
+    test_file = _write_test_file(
+        tmp_path,
+        """
+        register_ci_gate(metric_key="rollout/raw_reward",
+                         steps="last", constraint={"rel_up": 0.20, "rel_down": 0.20})
+        """,
+    )
+    record = _write_record(tmp_path, {"rollout/raw_reward": [[0, 0.31]]})
+
+    result = evaluate_gate(test_file, record, store, registry=None)
+
+    assert len(result.metrics) == 1
+    assert result.metrics[0].historical_status == GateStatus.INACTIVE
+    assert result.backend == "cuda"
+    assert result.suite == "stage-c-8-gpu-h100"
+    assert result.trusted is True

--- a/tests/ci/test/test_metric_history_store.py
+++ b/tests/ci/test/test_metric_history_store.py
@@ -244,6 +244,12 @@ def test_baseline_sql_matches_authoritative_shape():
         assert fragment in sql, f"baseline query missing: {fragment!r}"
 
 
-def test_neon_store_is_deferred():
-    with pytest.raises(NotImplementedError):
+def test_neon_store_requires_dsn(monkeypatch):
+    # No DSN passed and the env var unset: construction fails with a clear error
+    # (not NotImplementedError -- the backend is implemented now). It must not
+    # attempt a connection, so the failure is purely about the missing DSN.
+    from tests.ci.metric_history import NEON_DATABASE_URL_ENV
+
+    monkeypatch.delenv(NEON_DATABASE_URL_ENV, raising=False)
+    with pytest.raises(RuntimeError, match=NEON_DATABASE_URL_ENV):
         NeonMetricHistoryStore()

--- a/tests/ci/test/test_neon_store.py
+++ b/tests/ci/test/test_neon_store.py
@@ -1,0 +1,434 @@
+"""Tests for :class:`NeonMetricHistoryStore`.
+
+Two layers:
+
+* SQL/transaction unit tests that run WITHOUT a live database. They monkeypatch
+  `psycopg.connect` with a fake connection/cursor that records the executed
+  SQL and params plus commit/rollback calls, then assert the store issues the
+  right statements within a single transaction.
+* A live-Postgres smoke test, guarded by `@pytest.mark.skipif` on the
+  `MILES_TEST_POSTGRES_DSN` env var. It provisions the two tables and round-trips
+  write_run -> recent_trusted_values -> mark_untrusted against a real server. It
+  skips cleanly offline (no network, no import of an absent driver, no failure).
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+import types
+
+import pytest
+from tests.ci.ci_register import register_cpu_ci
+from tests.ci.metric_history import (
+    NEON_DATABASE_URL_ENV,
+    MetricSample,
+    NeonMetricHistoryStore,
+    RunIdentity,
+    RunProvenance,
+)
+
+register_cpu_ci(est_time=1, suite="stage-a-cpu", labels=[])
+
+IDENTITY = RunIdentity(
+    test_path="tests/e2e/test_grpo.py",
+    backend="megatron",
+    suite="stage-c-8-gpu-h100",
+)
+
+PROVENANCE = RunProvenance(
+    commit_sha="deadbeef",
+    pr_number=42,
+    github_run_id=1001,
+    github_run_attempt=1,
+    event_name="pull_request",
+    ref="refs/pull/42/merge",
+)
+
+# Canonical-JSON declaration keys, as the parser derives them.
+LAST_STEPS_KEY = '"last"'
+REL_CONSTRAINT_KEY = '{"rel_down":0.2,"rel_up":0.2}'
+
+
+def _sample(metric_key, value, *, steps_key=LAST_STEPS_KEY, constraint_key=REL_CONSTRAINT_KEY, step=-1):
+    return MetricSample(metric_key, steps_key, constraint_key, step, value)
+
+
+# --------------------------------------------------------------------------- #
+# Fake psycopg: records executed SQL + params and commit/rollback ordering.
+# --------------------------------------------------------------------------- #
+
+
+def _norm(sql: str) -> str:
+    return re.sub(r"\s+", " ", sql).strip().lower()
+
+
+class _FakeCursor:
+    def __init__(self, conn: _FakeConn):
+        self._conn = conn
+        self.rowcount = -1
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def execute(self, sql, params=None):
+        self._conn.events.append(("execute", _norm(sql), params))
+        if self._conn.fail_on_execute:
+            raise RuntimeError("boom: simulated db error")
+        # Let a test pin a rowcount for the next UPDATE/SELECT.
+        if self._conn.next_rowcount is not None:
+            self.rowcount = self._conn.next_rowcount
+        return self
+
+    def executemany(self, sql, seq):
+        seq = list(seq)
+        self._conn.events.append(("executemany", _norm(sql), seq))
+        if self._conn.fail_on_execute:
+            raise RuntimeError("boom: simulated db error")
+        return self
+
+    def fetchall(self):
+        return list(self._conn.fetch_rows)
+
+
+class _FakeConn:
+    def __init__(self):
+        self.events: list = []
+        self.commit_count = 0
+        self.rollback_count = 0
+        self.closed = False
+        self.fail_on_execute = False
+        self.fetch_rows: list = []
+        self.next_rowcount: int | None = None
+
+    def cursor(self):
+        return _FakeCursor(self)
+
+    def commit(self):
+        self.commit_count += 1
+        self.events.append(("commit", None, None))
+
+    def rollback(self):
+        self.rollback_count += 1
+        self.events.append(("rollback", None, None))
+
+    def close(self):
+        self.closed = True
+
+
+@pytest.fixture
+def fake_conn(monkeypatch):
+    """Install a fake `psycopg` module whose `connect` returns one shared
+    fake connection, and hand that connection to the test."""
+    conn = _FakeConn()
+    fake_psycopg = types.ModuleType("psycopg")
+    fake_psycopg.connect = lambda dsn: conn  # noqa: ARG005
+    monkeypatch.setitem(sys.modules, "psycopg", fake_psycopg)
+    return conn
+
+
+@pytest.fixture
+def store(fake_conn):
+    return NeonMetricHistoryStore(dsn="postgresql://fake/db")
+
+
+# --------------------------------------------------------------------------- #
+# Construction / DSN resolution.
+# --------------------------------------------------------------------------- #
+
+
+def test_requires_dsn_when_env_unset(monkeypatch):
+    monkeypatch.delenv(NEON_DATABASE_URL_ENV, raising=False)
+    with pytest.raises(RuntimeError, match=NEON_DATABASE_URL_ENV):
+        NeonMetricHistoryStore()
+
+
+def test_reads_dsn_from_env(monkeypatch, fake_conn):
+    monkeypatch.setenv(NEON_DATABASE_URL_ENV, "postgresql://env/db")
+    s = NeonMetricHistoryStore()
+    assert s._conn is fake_conn
+
+
+def test_explicit_dsn_takes_precedence(monkeypatch, fake_conn):
+    monkeypatch.delenv(NEON_DATABASE_URL_ENV, raising=False)
+    s = NeonMetricHistoryStore(dsn="postgresql://explicit/db")
+    assert s._conn is fake_conn
+
+
+def test_no_ddl_at_construction(store, fake_conn):
+    # Construction must not issue any statement -- schema is provisioned out-of-band.
+    assert fake_conn.events == []
+
+
+# --------------------------------------------------------------------------- #
+# write_run: one runs INSERT + N metric INSERTs, single commit, rollback on error.
+# --------------------------------------------------------------------------- #
+
+
+def test_write_run_single_transaction_one_commit(store, fake_conn):
+    values = [
+        _sample("reward_mean", 0.83),
+        _sample("pass_rate", 0.6, step=0),
+        _sample("pass_rate", 0.8, step=1),
+    ]
+    run_id = store.write_run(IDENTITY, PROVENANCE, "2026-06-02T00:00:00+00:00", True, values)
+
+    assert isinstance(run_id, str) and len(run_id) == 32  # uuid4().hex
+
+    kinds = [e[0] for e in fake_conn.events]
+    # Exactly: one execute (runs INSERT), one executemany (metric_values), one commit.
+    assert kinds == ["execute", "executemany", "commit"]
+    assert fake_conn.commit_count == 1
+    assert fake_conn.rollback_count == 0
+
+    run_kind, run_sql, run_params = fake_conn.events[0]
+    assert "insert into runs" in run_sql
+    # run_id is generated by the store and is the first bound param.
+    assert run_params[0] == run_id
+    assert run_params[1:4] == (
+        IDENTITY.test_path,
+        IDENTITY.backend,
+        IDENTITY.suite,
+    )
+    # trusted is bound as a native bool, not 0/1.
+    assert run_params[-1] is True
+
+    mv_kind, mv_sql, mv_seq = fake_conn.events[1]
+    assert "insert into metric_values" in mv_sql
+    assert mv_seq == [
+        (run_id, "reward_mean", LAST_STEPS_KEY, REL_CONSTRAINT_KEY, -1, 0.83),
+        (run_id, "pass_rate", LAST_STEPS_KEY, REL_CONSTRAINT_KEY, 0, 0.6),
+        (run_id, "pass_rate", LAST_STEPS_KEY, REL_CONSTRAINT_KEY, 1, 0.8),
+    ]
+
+
+def test_write_run_rolls_back_on_error(store, fake_conn):
+    fake_conn.fail_on_execute = True
+    with pytest.raises(RuntimeError, match="boom"):
+        store.write_run(IDENTITY, PROVENANCE, "2026-06-02T00:00:00+00:00", True, [_sample("m", 1.0)])
+    assert fake_conn.commit_count == 0
+    assert fake_conn.rollback_count == 1
+    assert ("rollback", None, None) in fake_conn.events
+
+
+def test_write_run_rejects_non_finite_before_any_statement(store, fake_conn):
+    # The DB is the write boundary where validity is enforced (store contract:
+    # validate_finite_values); the raise must land before any SQL is issued.
+    for bad in (float("nan"), float("inf"), float("-inf")):
+        with pytest.raises(ValueError, match="non-finite"):
+            store.write_run(
+                IDENTITY,
+                PROVENANCE,
+                "2026-06-02T00:00:00+00:00",
+                True,
+                [_sample("m", 0.5), _sample("m", bad, step=0)],
+            )
+    assert fake_conn.events == []
+    assert fake_conn.commit_count == 0
+    assert fake_conn.rollback_count == 0
+
+
+# --------------------------------------------------------------------------- #
+# recent_trusted_values: the parameterized authoritative baseline JOIN.
+# --------------------------------------------------------------------------- #
+
+
+def test_recent_trusted_values_issues_baseline_join(store, fake_conn):
+    fake_conn.fetch_rows = [(0.83,), (0.81,)]
+    got = store.recent_trusted_values(
+        IDENTITY.test_path,
+        IDENTITY.backend,
+        IDENTITY.suite,
+        "reward_mean",
+        LAST_STEPS_KEY,
+        REL_CONSTRAINT_KEY,
+        -1,
+        limit=10,
+    )
+    assert got == [0.83, 0.81]  # newest-first, passed straight through
+
+    assert len(fake_conn.events) == 1
+    kind, sql, params = fake_conn.events[0]
+    assert kind == "execute"
+    # The authoritative shape, with %s placeholders and Postgres boolean literal.
+    for fragment in (
+        "from metric_values mv",
+        "join runs r using (run_id)",
+        "r.test_path = %s",
+        "r.backend = %s",
+        "r.suite = %s",
+        "mv.metric_key = %s",
+        "mv.steps_key = %s",
+        "mv.constraint_key = %s",
+        "mv.step = %s",
+        "r.trusted = true",
+        "order by r.created_at desc",
+        "limit %s",
+    ):
+        assert fragment in sql, f"baseline query missing: {fragment!r}"
+    # Params in the exact positional order the placeholders expect.
+    assert params == (
+        IDENTITY.test_path,
+        IDENTITY.backend,
+        IDENTITY.suite,
+        "reward_mean",
+        LAST_STEPS_KEY,
+        REL_CONSTRAINT_KEY,
+        -1,
+        10,
+    )
+    # No commit/rollback on a read.
+    assert fake_conn.commit_count == 0
+    assert fake_conn.rollback_count == 0
+
+
+# --------------------------------------------------------------------------- #
+# mark_untrusted: exactly-one-key guard + parameterized UPDATE.
+# --------------------------------------------------------------------------- #
+
+
+def test_mark_untrusted_requires_exactly_one_key(store, fake_conn):
+    with pytest.raises(ValueError):
+        store.mark_untrusted()
+    with pytest.raises(ValueError):
+        store.mark_untrusted(run_id="x", commit_sha="y")
+    # The guard fires before any statement is issued.
+    assert fake_conn.events == []
+
+
+@pytest.mark.parametrize(
+    "kwargs,column,value",
+    [
+        ({"run_id": "abc"}, "run_id", "abc"),
+        ({"github_run_id": 7777}, "github_run_id", 7777),
+        ({"commit_sha": "badc0de"}, "commit_sha", "badc0de"),
+    ],
+)
+def test_mark_untrusted_issues_parameterized_update(store, fake_conn, kwargs, column, value):
+    fake_conn.next_rowcount = 2
+    affected = store.mark_untrusted(**kwargs)
+    assert affected == 2
+
+    update = [e for e in fake_conn.events if e[0] == "execute"]
+    assert len(update) == 1
+    _, sql, params = update[0]
+    assert f"update runs set trusted = false where {column} = %s and trusted = true" in sql
+    assert params == (value,)
+    assert fake_conn.commit_count == 1
+    assert fake_conn.rollback_count == 0
+
+
+def test_mark_untrusted_rolls_back_on_error(store, fake_conn):
+    fake_conn.fail_on_execute = True
+    with pytest.raises(RuntimeError, match="boom"):
+        store.mark_untrusted(run_id="abc")
+    assert fake_conn.commit_count == 0
+    assert fake_conn.rollback_count == 1
+
+
+# --------------------------------------------------------------------------- #
+# Live-Postgres smoke test. Skips cleanly when no DSN env var is set.
+# --------------------------------------------------------------------------- #
+
+_LIVE_DSN_ENV = "MILES_TEST_POSTGRES_DSN"
+
+
+# Test-local provisioning DDL, mirroring the out-of-band schema (docs/ci/03:
+# the two tables are provisioned outside this repo; the store itself stays
+# DML-only). Only the live smoke test ever executes this, as an admin role.
+_PROVISION_SQL = """
+CREATE TABLE IF NOT EXISTS runs (
+    run_id              TEXT PRIMARY KEY,
+    test_path           TEXT NOT NULL,
+    backend             TEXT NOT NULL,
+    suite               TEXT NOT NULL,
+    commit_sha          TEXT NOT NULL,
+    pr_number           INTEGER,
+    github_run_id       BIGINT,
+    github_run_attempt  INTEGER,
+    event_name          TEXT,
+    ref                 TEXT,
+    created_at          TIMESTAMPTZ NOT NULL,
+    trusted             BOOLEAN NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS metric_values (
+    run_id         TEXT NOT NULL REFERENCES runs(run_id),
+    metric_key     TEXT NOT NULL,
+    steps_key  TEXT NOT NULL,
+    constraint_key       TEXT NOT NULL,
+    step           INTEGER NOT NULL,
+    value          DOUBLE PRECISION NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS runs_baseline_idx
+    ON runs (test_path, backend, suite, trusted, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS metric_values_run_id_idx
+    ON metric_values (run_id);
+"""
+
+
+@pytest.mark.skipif(
+    not os.environ.get(_LIVE_DSN_ENV),
+    reason=f"{_LIVE_DSN_ENV} not set; skipping live-Postgres round-trip",
+)
+def test_live_postgres_round_trip():
+    # Only reached when a real DSN is configured; imports the driver, provisions
+    # the two tables on that server, then round-trips the contract.
+    import psycopg
+
+    dsn = os.environ[_LIVE_DSN_ENV]
+
+    # Provision as a privileged role (the DSN here is a provisioning DSN, not
+    # the least-privilege app role).
+    with psycopg.connect(dsn) as admin:
+        with admin.cursor() as cur:
+            # Clean slate so the round-trip is deterministic across reruns.
+            cur.execute("DROP TABLE IF EXISTS metric_values")
+            cur.execute("DROP TABLE IF EXISTS runs")
+            cur.execute(_PROVISION_SQL)
+        admin.commit()
+
+    identity = RunIdentity("tests/e2e/test_smoke.py", "megatron", "stage-x")
+    prov = RunProvenance("smoke-sha", 1, 9001, 1, "push", "refs/heads/main")
+
+    store = NeonMetricHistoryStore(dsn=dsn)
+    try:
+        keep = store.write_run(identity, prov, "2026-06-01T00:00:00+00:00", True, [_sample("m", 0.5)])
+        drop = store.write_run(identity, prov, "2026-06-02T00:00:00+00:00", True, [_sample("m", 0.9)])
+        assert keep != drop
+
+        got = store.recent_trusted_values(
+            identity.test_path,
+            identity.backend,
+            identity.suite,
+            "m",
+            LAST_STEPS_KEY,
+            REL_CONSTRAINT_KEY,
+            -1,
+            limit=10,
+        )
+        assert got == [0.9, 0.5]  # newest-first
+
+        assert store.mark_untrusted(run_id=drop) == 1
+        # No rebaseline: the dropped run is gone on the next query.
+        got2 = store.recent_trusted_values(
+            identity.test_path,
+            identity.backend,
+            identity.suite,
+            "m",
+            LAST_STEPS_KEY,
+            REL_CONSTRAINT_KEY,
+            -1,
+            limit=10,
+        )
+        assert got2 == [0.5]
+        # Idempotent.
+        assert store.mark_untrusted(run_id=drop) == 0
+    finally:
+        store.close()

--- a/tests/ci/test/test_neon_store.py
+++ b/tests/ci/test/test_neon_store.py
@@ -100,7 +100,9 @@ class _FakeConn:
         self.events: list = []
         self.commit_count = 0
         self.rollback_count = 0
-        self.closed = False
+        self.connect_count = 0
+        self.connected_dsns: list = []
+        self.close_count = 0
         self.fail_on_execute = False
         self.fetch_rows: list = []
         self.next_rowcount: int | None = None
@@ -117,16 +119,22 @@ class _FakeConn:
         self.events.append(("rollback", None, None))
 
     def close(self):
-        self.closed = True
+        self.close_count += 1
 
 
 @pytest.fixture
 def fake_conn(monkeypatch):
-    """Install a fake `psycopg` module whose `connect` returns one shared
-    fake connection, and hand that connection to the test."""
+    """Install a fake `psycopg` module whose `connect` hands out one shared
+    fake connection while recording every connect call and its DSN."""
     conn = _FakeConn()
     fake_psycopg = types.ModuleType("psycopg")
-    fake_psycopg.connect = lambda dsn: conn  # noqa: ARG005
+
+    def _connect(dsn):
+        conn.connect_count += 1
+        conn.connected_dsns.append(dsn)
+        return conn
+
+    fake_psycopg.connect = _connect
     monkeypatch.setitem(sys.modules, "psycopg", fake_psycopg)
     return conn
 
@@ -150,17 +158,21 @@ def test_requires_dsn_when_env_unset(monkeypatch):
 def test_reads_dsn_from_env(monkeypatch, fake_conn):
     monkeypatch.setenv(NEON_DATABASE_URL_ENV, "postgresql://env/db")
     s = NeonMetricHistoryStore()
-    assert s._conn is fake_conn
+    s.recent_trusted_values("t", "b", "s", "m", LAST_STEPS_KEY, REL_CONSTRAINT_KEY, -1, limit=1)
+    assert fake_conn.connected_dsns == ["postgresql://env/db"]
 
 
 def test_explicit_dsn_takes_precedence(monkeypatch, fake_conn):
     monkeypatch.delenv(NEON_DATABASE_URL_ENV, raising=False)
     s = NeonMetricHistoryStore(dsn="postgresql://explicit/db")
-    assert s._conn is fake_conn
+    s.recent_trusted_values("t", "b", "s", "m", LAST_STEPS_KEY, REL_CONSTRAINT_KEY, -1, limit=1)
+    assert fake_conn.connected_dsns == ["postgresql://explicit/db"]
 
 
 def test_no_ddl_at_construction(store, fake_conn):
-    # Construction must not issue any statement -- schema is provisioned out-of-band.
+    # Construction must not connect nor issue any statement -- schema is
+    # provisioned out-of-band and connections are per-operation.
+    assert fake_conn.connect_count == 0
     assert fake_conn.events == []
 
 
@@ -320,6 +332,23 @@ def test_mark_untrusted_issues_parameterized_update(store, fake_conn, kwargs, co
     assert params == (value,)
     assert fake_conn.commit_count == 1
     assert fake_conn.rollback_count == 0
+
+
+def test_each_operation_opens_and_closes_its_own_connection(store, fake_conn):
+    # A store built at suite start must not cache a connection across the
+    # minutes-long gaps between e2e tests (Neon kills idle sockets); every
+    # operation gets a fresh connection and releases it before returning.
+    store.write_run(IDENTITY, PROVENANCE, "2026-06-02T00:00:00+00:00", True, [_sample("m", 0.5)])
+    store.recent_trusted_values("t", "b", "s", "m", LAST_STEPS_KEY, REL_CONSTRAINT_KEY, -1, limit=1)
+    assert fake_conn.connect_count == 2
+    assert fake_conn.close_count == 2
+
+
+def test_connection_closed_even_when_operation_fails(store, fake_conn):
+    fake_conn.fail_on_execute = True
+    with pytest.raises(RuntimeError, match="boom"):
+        store.write_run(IDENTITY, PROVENANCE, "2026-06-02T00:00:00+00:00", True, [_sample("m", 1.0)])
+    assert fake_conn.close_count == 1
 
 
 def test_mark_untrusted_rolls_back_on_error(store, fake_conn):


### PR DESCRIPTION
> **Depends on:** #1516
> Stacked on the parent PR's branch. Review / merge the parent first.

## Summary
Wire the gate into the CUDA harness (nightly writes, PR shadow) + the psycopg Neon store.

## Motivation
The gate library is pure and read-only; the harness drives the pipeline per test — allocate record dirs, merge the passing attempt's records, judge, act on the verdict — without ever changing a test's pass/fail.

## Usage
Nightly-marked runs (the `schedule` cron on `main`, or a PR carrying the `nightly` label) persist `write_run(values + trusted)`. Ordinary PR runs only shadow: verdict in logs + `GITHUB_STEP_SUMMARY`, no write. The DSN comes from the `NEON_DATABASE_URL` CI secret (`_run-ci.yml`); `requirements.txt` adds `psycopg[binary]`.

## Design Notes
- **Key choices:** only the PASSING attempt's records reach the gate; a failed attempt's records are discarded before the merge.
- The merge concatenates a metric key appearing in several processes, then sorts by step.
- `run_gate_hook` assigns identity from the harness-selected `CIRegistry`; every gate/store error inside the hook is swallowed.
- `NeonMetricHistoryStore` (psycopg) mirrors the SQLite baseline query, DML-only.
- Out-of-band provisioning: the hosted table must be re-created to the current schema.
- This tree carries the governing doc's final form: `docs/ci/03-metric-history-gate.md` (single-layer gate, slim `(test_path, backend, suite)` identity, consolidated TODO).

## Verification
- **Tests added:** `test_gate_integration.py` (nightly trusted/untrusted writes, PR shadow, error swallowing), `test_neon_store.py` (SQL shape + DSN-gated live round-trip); offline suite: 239 passed, 1 skipped.

## Review Focus
- Scrutinize the wrap-all in `ci_utils.py:run_gate_hook` — it is the zero-blocking guarantee.
- Scrutinize passing-attempt selection in `run_unittest_files` — a failed attempt's records must never reach the gate.
