### PR TITLE
(4/7) feat(session): multi-process session-server data plane (routing + IPC + worker + thin router)

### DIFF
--- a/docs/developer/multi-process-session-server.md
+++ b/docs/developer/multi-process-session-server.md
@@ -1,0 +1,97 @@
+---
+title: Multi-process session server — requirements
+description: What the opt-in multi-process session server must do and must not break. The central doc-dev spec for the session modules; per-file mechanics live in each file's header docstring.
+---
+
+# Multi-process session server — requirements
+
+This is the demands-and-targets spec for the opt-in multi-process session server. The multi-process session modules (`core.py`, `sharding.py`, `ipc.py`, `router.py`, `worker.py`, and `supervisor.py`, which lands with the control plane) carry `# doc-dev: docs/developer/multi-process-session-server.md` and must conform to it; their per-file mechanics live in their header docstrings. Enforcement points outside the flagged set: `linear_trajectory.py` (the collision guard in `SessionRegistry.create_session`, the per-session lock / `closing` gate), the `rollout_manager` `check()` call sites, and `--session-server-workers` in `arguments.py`.
+
+## Goal
+
+Multi-turn agent rollouts must not be bottlenecked by the session server. Under R3 (`routed_experts` / `indexer_topk`) every chat turn returns a 100+ MiB body, and its `json.loads` + validation is pure-Python, GIL-bound work — a single process serializes every session's parse on one event loop, and threads add no parse throughput under the GIL. What we want is session throughput that scales with CPU cores; the only lever is more interpreters. So: shard sessions across worker processes, one GIL each — strictly opt-in, with the single-process server staying the unchanged default.
+
+Measured at the production shape (32 sessions × 50 turns, final-turn body ≈ 134 MiB): 16 workers give **7.2–7.6×** wall-time/throughput over single-process, with the workers pegged (~94% CPU, the intended bottleneck) and the router at ~5% (`tests/benchmark/bench_session_server_overhead.py`, landing separately).
+
+## Functional requirements
+
+- **Default path unchanged.** `--session-server-workers=1` keeps today's single-process server, behavior-identical; multi-process is strictly opt-in.
+- **Process-stable sticky routing.** Sessions are stateful (the TITO trajectory accumulates across turns), so every turn of a session must reach the same worker; router and workers must agree on the owner of a `session_id` without coordination — a stable hash modulo worker count, never the builtin `hash()` (salted per process by `PYTHONHASHSEED`).
+- **TITO correctness under concurrency preserved exactly.** The per-session `asyncio.Lock`, the `closing` re-checks, and the `num_assistant`-mismatch skip path in `SessionCore.chat_completions` must remain.
+- **Worker death is a hard, fast error.** A dead worker owns a hash shard, so an undetected death turns every request to that shard into a black hole; the supervisor's `check()` must be called at the start of **both** `generate()` and `eval()` so either phase fails loudly instead of hanging.
+- **No orphan processes** on crash or teardown.
+- **The router only moves bytes.** It never `json.loads` a body; it hash-routes to the owning worker and relays the response bytes verbatim — parsing in the router would re-incur the exact cost being escaped.
+- **R3 never reaches the client.** `routed_experts` / `indexer_topk` are replay-only training inputs, consumed from the session records via `GET /sessions/{id}` — never from the live chat reply — so the core strips them from client-facing chat responses (landed just below this stack as its own PR). Without the strip every relaying hop pays for the blobs: the single router process measured 100% CPU and capped 16-worker scaling at ~4.6×.
+
+## Required decomposition
+
+- **`SessionCore` (`core.py`) — the logic.** Request primitives in, session mutation + upstream proxy, Starlette `Response` out; knows nothing about processes, sockets, IPC, or HTTP servers; reused unchanged by both chassis.
+- **worker (`worker.py`) — one process, one shard.** Exactly one `SessionCore` plus its own httpx proxy backend; speaks IPC only: decode a request, call the core, serialize the `Response` back.
+- **router (`router.py`) — the single client-facing HTTP listener.** Hash-routes each request to the owning worker and forwards the reply back unchanged, without ever parsing it; imports neither core nor worker, so the router process stays tokenizer-free.
+- **supervisor (`supervisor.py`) — process lifecycle.** Spawns N workers + 1 router, waits for readiness, monitors and fail-fasts on any child death, tears the group down without orphans.
+- Support: `sharding.py` (stdlib-only owner function + id minting, importable without FastAPI), `ipc.py` (framed, multiplexed request/reply over one socket per worker), and `SessionRegistry.create_session(session_id=None)` (mints when None; a router-supplied id is created under exactly that id, with a loud collision guard — the single-process path never passes one).
+
+The per-turn chat path — the load the sharding exists for:
+
+```mermaid
+flowchart TD
+    client["client (rollout harness)"]
+    router["router — the single HTTP listener<br/>tokenizer-free, only moves bytes"]
+    worker["worker i = blake2b(session_id) mod N<br/>SessionCore + tokenizer, one GIL each"]
+    upstream["inference backend"]
+
+    client -->|"① chat turn (small request)"| router
+    router -->|"② one IPC frame"| worker
+    worker -->|"③ httpx proxy"| upstream
+    upstream -->|"④ R3 response body<br/>(~134 MiB/turn at prod shape)"| worker
+    worker -->|"⑤ parse + validate + record under this worker's GIL —<br/>the cost being sharded; client reply as one IPC frame<br/>(small — R3-stripped by the core; full R3 stays in this worker's records)"| router
+    router -->|"⑥ forwards the reply to the client unchanged<br/>(never parses or re-encodes it)"| client
+```
+
+The end-of-rollout full-records fetch — same topology, very different byte profile:
+
+```mermaid
+flowchart TD
+    client["client (rollout harness)"]
+    router["router"]
+    worker["worker owning the session"]
+
+    client -->|"① GET /sessions/:id (full records)"| router
+    router -->|"② IPC request (tiny)"| worker
+    worker -->|"③ records dump = ONE u64 IPC frame (~3.15 GiB at prod shape);<br/>FIFO writes queue sibling chat replies behind it"| router
+    router -->|"④ relays the multi-GiB body over HTTP"| client
+```
+
+The supervisor spawns and monitors the router and every worker and fail-fasts on any death; it is never on a data path.
+
+Sessions are sticky-by-hash, so the chat path only ever carries a single turn's request/response over IPC — never accumulated session state. The records path is the exception: session records are never pruned (the training data path consumes R3 from them), so its reply is the full accumulated dump as one frame — see "Open decisions" for the measured consequences.
+
+## Behavior parity
+
+`workers=N` must match the single-process server's observable behavior, with exactly two known deltas (introduced by the `SessionCore` extraction and inherent to multi-process, where the worker receives already-read bytes over IPC):
+
+- **Body-read timing / lock scope.** The route reads the body before entering `SessionCore.chat_completions` instead of inside `session.lock`; JSON parsing, TITO mutation, and record writes remain under the lock, proxying remains outside it. Consequences: a chat to a missing/closing session consumes the full body before the error returns, and a DELETE-vs-chat race during upload more likely rejects the chat (the outcome was already non-deterministic; the race-condition tests pass).
+- **Per-request debug logging removed** (the `debug_request_logger` middleware and two DELETE-path `debug` lines). Logging-only; no contract impact.
+
+## Design targets
+
+- **Observational equivalence.** To a client, `workers=N` is indistinguishable from `workers=1` — statuses, headers, body bytes, and TITO session metadata — on success and error paths alike (the two known deltas above excepted).
+- **Deterministic ownership.** Every operation of a session resolves to the same worker for the session's entire lifetime; ownership never depends on process identity, timing, or load.
+- **Loud failure.** A dead child never degrades into hangs or partial service: the rollout path fails fast, and teardown leaves no orphans.
+
+## Open decisions and accepted risks
+
+Deliberately cut — reintroduce only with evidence: IPC chunking / round-robin writer / send-buffer budget / configurable frame limits (single-frame bodies instead; reopen rule below); per-worker 503 backpressure, `asyncio.shield` on client disconnect, and the router task-tracking set (cancel-safe request + late-reply drop instead); worker-side `max_inflight` / `max_queued_bytes` admission and the parse-gate semaphore; the prototype's 409 in-flight gate, 500 invariant, and stricter response validation (behavior changes, not part of the mechanism).
+
+- **Records-path head-of-line and router relay ceiling (accepted for now).** Measured with 32 concurrent full-records `GET /sessions/{id}` overlapping chats (w16, production shape): chat reply p99 collapses ~33× (1.6 s → 52 s) and a ~3.15 GiB GET averages ~103 s — the giant reply frame queues sibling chat replies behind it on the IPC channel (FIFO whole frames) and every byte re-serializes through the single router process. The chat path itself never sends large bodies over IPC (the large body is parsed inside the worker); benchmark provenance in "Goal". Accepted for this stack; the fix is decided and lands as a follow-up records-path PR (see "Not covered").
+- **Single-frame large bodies.** A full-records `GET /sessions/{id}` reply crosses IPC as one in-memory frame — measured ~3.15 GiB per session at the production shape (records are never pruned, so it grows with turns × body size). This is why frame lengths are u64 with a 64 GiB cap enforced at send time: `_MAX_FRAME` is a corruption guard, not a size feature, and an oversized frame must fail only its own request — if it reached the peer's reader it would be indistinguishable from a corrupt length and tear down the channel, silently poisoning every other session on the shard.
+- **No client-disconnect shielding.** A cancelled client request drops only the router-side await (cancel-safe `request()` + late-reply drop); the worker handler runs as a separate task and still commits consistent state — pinned by a deterministic cancel test.
+- **No per-request dispatch timeout.** A dead worker surfaces as EOF → 503, but a live-but-hung worker leaves requests pending until the channel closes. Deliberate: `chat`/`proxy` legitimately run long (LLM generation), so a fixed timeout would false-positive on slow chats.
+- **Silent session mis-routing is the biggest correctness risk.** If the owner were computed differently at create vs. chat vs. get, sessions would intermittently land on the wrong worker — load-dependent and invisible at `workers=1`; the routing-determinism and equivalence tests exist to catch exactly this.
+
+## Not covered
+
+- Consistent-hashing / rebalanceable routing — v1 is modulo over a stable hash; resizing the worker count at runtime is unsupported.
+- A delta / incremental-R3 protocol (would need SGLang/trainer coordination).
+- General backpressure / admission control / rate limiting.
+- TODO (decided, follow-up records-path PR): worker-direct bulk replies — the router 307-redirects the records GET to the owning worker's own listener, so the multi-GiB records body never crosses IPC or the router. Design and flowchart land with that PR.

--- a/miles/rollout/session/core.py
+++ b/miles/rollout/session/core.py
@@ -1,7 +1,9 @@
+# doc-dev: docs/developer/multi-process-session-server.md
 """Logic layer of the session server: ``SessionCore``.
 
-HTTP-agnostic: the FastAPI adapter (``sessions.py`` + ``server.py``) turns each request into primitives and calls these methods. Owns one ``SessionRegistry`` (per-session TITO/trajectory state) and one proxy ``backend``.
+HTTP-agnostic: the FastAPI adapter (``sessions.py`` + ``server.py``) turns each request into primitives and calls these methods. Owns one ``SessionRegistry`` (per-session TITO/trajectory state) and one proxy ``backend``. Reused unchanged by both chassis — the single-process adapter and the multi-process worker (``worker.py``, primitives decoded off IPC); ``build_session_core`` and ``error_response`` are the single source for core construction and the client error shape so those contracts cannot drift between modes.
 
+- ``create_session(session_id=None)``: the single-process path passes None (the registry mints); the multi-process router mints the id and passes it so the owning worker creates the trajectory under it.
 - ``chat_completions`` strips the R3 replay payloads (``routed_experts`` / ``indexer_topk``) from the client reply copy-on-write; the ``SessionRecord`` keeps the full response for the training path (``GET /sessions/{id}``).
 - ``chat_completions`` holds the per-session lock for prep and state update but not across the proxy call; ``closing`` re-checks and the ``num_assistant`` check gate concurrent DELETE/chat.
 """
@@ -15,12 +17,15 @@ from starlette.responses import Response
 
 from miles.rollout.session.errors import (
     MessageValidationError,
+    SessionError,
     SessionNotFoundError,
     TokenizationError,
     UpstreamResponseError,
 )
 from miles.rollout.session.linear_trajectory import SessionRegistry
 from miles.rollout.session.types import GetSessionResponse, SessionRecord
+from miles.utils.chat_template_utils import get_tito_tokenizer
+from miles.utils.processing_utils import load_tokenizer
 
 logger = logging.getLogger(__name__)
 
@@ -42,6 +47,26 @@ class ProxyRequest:
 def _render_json(payload) -> bytes:
     """Encode like Starlette's JSONResponse (compact, non-ASCII preserved)."""
     return json.dumps(payload, ensure_ascii=False, allow_nan=False, separators=(",", ":")).encode("utf-8")
+
+
+def error_response(exc: SessionError) -> Response:
+    """Render a SessionError as the client response."""
+    return Response(content=_render_json({"error": str(exc)}), status_code=exc.status_code, media_type=JSON_MEDIA_TYPE)
+
+
+def build_session_core(backend, args) -> "SessionCore":
+    """Construct a SessionCore (tokenizer + registry) from args."""
+    tokenizer = load_tokenizer(
+        args.hf_checkpoint, chat_template_path=getattr(args, "chat_template_path", None), trust_remote_code=True
+    )
+    tito_tokenizer = get_tito_tokenizer(
+        tokenizer,
+        tokenizer_type=getattr(args, "tito_model", "default"),
+        chat_template_kwargs=getattr(args, "apply_chat_template_kwargs", None),
+        allowed_append_roles=getattr(args, "tito_allowed_append_roles", None),
+    )
+    registry = SessionRegistry(args, tokenizer, tito_tokenizer=tito_tokenizer)
+    return SessionCore(backend, registry, args, getattr(args, "session_server_instance_id", None))
 
 
 _CLIENT_STRIPPED_META_KEYS = ("routed_experts", "indexer_topk")
@@ -103,8 +128,10 @@ class SessionCore:
             body["session_server_instance_id"] = self.instance_id
         return Response(content=_render_json(body), status_code=200, media_type=JSON_MEDIA_TYPE)
 
-    async def create_session(self) -> Response:
-        session_id = self.registry.create_session()
+    async def create_session(self, session_id: str | None = None) -> Response:
+        # None in single-process (the registry mints); the multi-process router
+        # mints the id (to route by it) and passes it so the owning worker creates under it.
+        session_id = self.registry.create_session(session_id)
         return Response(content=_render_json({"session_id": session_id}), status_code=200, media_type=JSON_MEDIA_TYPE)
 
     async def get_session(self, session_id: str) -> Response:
@@ -142,10 +169,16 @@ class SessionCore:
     ) -> Response:
         """Proxy a chat completion through the backend with TITO token tracking.
 
-        Flow: prepare pretokenized input_ids (lock held briefly) → proxy to
-        backend (NO lock) → validate response → update trajectory checkpoint and
-        append record (lock held briefly). The lock is NOT held during the slow
-        proxy call so DELETE/other ops are not blocked if the agent disconnects.
+        Three phases around the per-session lock: (1) under the lock, parse the
+        body, inject the TITO-required request fields, and prepare pretokenized
+        ``input_ids`` from the accumulated trajectory; (2) release the lock and
+        proxy to the backend — the slow LLM call runs unlocked so DELETE/other
+        ops are not blocked if the agent disconnects; (3) re-acquire the lock,
+        validate the response, and update the trajectory checkpoint + append the
+        record. ``closing`` is re-checked at each lock entry and, together with
+        the ``num_assistant`` mismatch check in phase 3, forms the concurrency
+        gate that drops a state update whose session was deleted or advanced
+        during the unlocked proxy.
         """
         session = self.registry.get_session(session_id)
         if session.closing:

--- a/miles/rollout/session/ipc.py
+++ b/miles/rollout/session/ipc.py
@@ -165,6 +165,10 @@ class IpcChannel:
         self._send_q.put_nowait(_LEN.pack(len(frame)) + frame)
 
     async def _writer_loop(self) -> None:
+        # finally-teardown: however this loop exits (expected socket error or an
+        # unexpected bug), the channel must be torn down so pending futures fail
+        # instead of hanging. The exit reason is carried into IpcChannelClosed.
+        reason = "writer loop exited"
         try:
             while True:
                 frame = await self._send_q.get()
@@ -173,9 +177,14 @@ class IpcChannel:
         except asyncio.CancelledError:
             raise
         except (ConnectionError, OSError) as exc:
-            self._teardown(IpcChannelClosed(f"write failed: {exc!r}"))
+            reason = f"write failed: {exc!r}"
+        except Exception as exc:
+            reason = f"writer loop crashed: {exc!r}"
+        finally:
+            self._teardown(IpcChannelClosed(reason))
 
     async def _reader_loop(self) -> None:
+        reason = "reader loop exited"
         try:
             while True:
                 (length,) = _LEN.unpack(await self._reader.readexactly(_LEN.size))
@@ -187,9 +196,13 @@ class IpcChannel:
         except asyncio.CancelledError:
             raise
         except asyncio.IncompleteReadError:
-            self._teardown(IpcChannelClosed("peer closed connection"))
+            reason = "peer closed connection"
         except (IpcError, ConnectionError, OSError) as exc:
-            self._teardown(IpcChannelClosed(f"read failed: {exc!r}"))
+            reason = f"read failed: {exc!r}"
+        except Exception as exc:
+            reason = f"reader loop crashed: {exc!r}"
+        finally:
+            self._teardown(IpcChannelClosed(reason))
 
     def _dispatch(self, mtype: int, request_id: int, payload: bytes) -> None:
         if mtype == _TYPE_REPLY:

--- a/miles/rollout/session/ipc.py
+++ b/miles/rollout/session/ipc.py
@@ -1,0 +1,260 @@
+# doc-dev: docs/developer/multi-process-session-server.md
+"""Minimal framed, multiplexed RPC between the session router and one session worker.
+
+- One :class:`IpcChannel` wraps one connected stream socket (a ``socket.socketpair`` end); the router side is the client (:meth:`IpcChannel.request`), the worker side is the server (a ``request_handler`` coroutine).
+- Concurrent requests over the one socket are multiplexed by ``request_id``: replies are matched by id, not arrival order, so a reply never waits for an earlier request to finish *processing*. Writes are FIFO whole frames, so it can still queue behind a large frame already being sent (see the trailing note).
+- Wire format — one whole message per frame, no chunking:
+
+    frame: u64 length | u64 request_id | u8 type | payload bytes
+           └ length counts everything after it (the 9-byte header + payload) ┘
+
+- ``type`` is REQUEST / REPLY / ERROR; a REPLY carries the handler's return bytes, an ERROR a UTF-8 error message.
+- The payload is opaque to the channel; the worker/router layer packs it with :func:`encode_envelope` as ``u64 meta_len | meta_json | raw_body`` (raw body, no base64).
+- The shared ``OP_*`` session-op protocol and the request/envelope codecs live here so neither the router nor the worker imports the other's module.
+- Teardown (EOF / read-write error / ``aclose``) fails every pending ``request()`` with ``IpcChannelClosed``, so a peer death surfaces as an exception, never a hang; ``request()`` is cancel-safe (a late reply is dropped, not mis-delivered).
+
+Deliberately minimal — no round-robin scheduling across requests, no configurable frame/body size limit; the single ``_MAX_FRAME`` cap is a corruption guard (rejects a garbage length before allocating), not a size feature, so a large body (e.g. a multi-GiB ``GET /sessions`` records dump) crosses as one frame. A frame that would exceed the cap is refused at send time as a per-request failure (ERROR frame / ``IpcError``) — it must never reach the peer's reader, where an oversized length is indistinguishable from corruption and tears down the whole channel.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import struct
+from collections.abc import Awaitable, Callable
+
+logger = logging.getLogger(__name__)
+
+_LEN = struct.Struct(">Q")  # frame length / envelope meta_len prefix (u64)
+_HDR = struct.Struct(">QB")  # request_id (u64) + type (u8)
+_HDR_LEN = _HDR.size
+
+# Reject a frame whose declared length exceeds this before allocating, so a
+# corrupt/garbage u64 length cannot trigger an absurd readexactly. Generous vs
+# the largest real body: a full-records GET measures ~3.15 GiB per session at
+# the production shape (50 turns x ~64 MiB avg accumulated-R3 responses) and
+# grows with turns x body size.
+_MAX_FRAME = 64 * 1024 * 1024 * 1024  # 64 GiB
+
+_TYPE_REQUEST = 1
+_TYPE_REPLY = 2
+_TYPE_ERROR = 3
+
+
+class IpcError(Exception):
+    """A peer request handler raised; surfaced on the caller's request()."""
+
+
+class IpcChannelClosed(Exception):
+    """The channel was torn down (EOF / connection error / aclose)."""
+
+
+def encode_envelope(meta: dict, body: bytes) -> bytes:
+    """Pack ``meta`` (JSON) + raw ``body`` (no base64) into one buffer."""
+    meta_bytes = json.dumps(meta, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+    return _LEN.pack(len(meta_bytes)) + meta_bytes + body
+
+
+def decode_envelope(buf: bytes) -> tuple[dict, bytes]:
+    """Inverse of :func:`encode_envelope`."""
+    (meta_len,) = _LEN.unpack_from(buf, 0)
+    start = _LEN.size
+    meta = json.loads(buf[start : start + meta_len])
+    return meta, buf[start + meta_len :]
+
+
+# Session op protocol shared by the router (encodes requests) and the worker
+# (decodes them). Kept here so neither side imports the other's heavy module.
+OP_HEALTH = "health"
+OP_CREATE = "create"
+OP_GET = "get"
+OP_DELETE = "delete"
+OP_CHAT = "chat"
+OP_PROXY = "proxy"
+
+
+def encode_request(
+    op: str,
+    *,
+    session_id: str = "",
+    path: str = "",
+    method: str = "",
+    query: str = "",
+    headers: dict | None = None,
+    body: bytes = b"",
+) -> bytes:
+    """Encode a session request for the worker (op + routing/HTTP metadata + raw body)."""
+    meta = {
+        "op": op,
+        "session_id": session_id,
+        "path": path,
+        "method": method,
+        "query": query,
+        "headers": headers or {},
+    }
+    return encode_envelope(meta, body)
+
+
+class IpcChannel:
+    """Framed multiplexed RPC over one connected stream socket.
+
+    Role is set by ``request_handler``: None ⇒ client (calls ``request()``; a
+    stray inbound REQUEST is logged and dropped); else ⇒ server (runs the handler
+    per REQUEST; a stray REPLY for an unknown id is dropped). Teardown (EOF /
+    error / ``aclose()``) fails every pending ``request()`` with IpcChannelClosed,
+    so a peer death surfaces as that exception, never a hang.
+    """
+
+    def __init__(
+        self,
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+        *,
+        request_handler: Callable[[bytes], Awaitable[bytes]] | None = None,
+        on_close: Callable[[], None] | None = None,
+    ):
+        self._reader = reader
+        self._writer = writer
+        self._request_handler = request_handler
+        self._on_close = on_close
+        self._next_id = 0
+        self._pending: dict[int, asyncio.Future] = {}
+        self._send_q: asyncio.Queue[bytes] = asyncio.Queue()
+        self._handler_tasks: set[asyncio.Task] = set()
+        self._reader_task: asyncio.Task | None = None
+        self._writer_task: asyncio.Task | None = None
+        self._closed = False
+
+    def start(self) -> None:
+        self._reader_task = asyncio.ensure_future(self._reader_loop())
+        self._writer_task = asyncio.ensure_future(self._writer_loop())
+
+    async def request(self, payload: bytes) -> bytes:
+        """Send a request and await the peer's reply bytes.
+
+        Cancel-safe: if the awaiting coroutine is cancelled, the pending future
+        is removed in ``finally`` so a late reply is dropped, not mis-delivered.
+
+        Raises IpcChannelClosed if the channel is/goes down, IpcError if the peer
+        handler raised.
+        """
+        if self._closed:
+            raise IpcChannelClosed("channel is closed")
+        request_id = self._next_id
+        self._next_id += 1
+        fut = asyncio.get_running_loop().create_future()
+        self._pending[request_id] = fut
+        try:
+            self._enqueue(_TYPE_REQUEST, request_id, payload)
+            return await fut
+        finally:
+            self._pending.pop(request_id, None)
+
+    def _enqueue(self, mtype: int, request_id: int, payload: bytes) -> None:
+        if self._closed:
+            return
+        # Refuse an oversized frame HERE, as a per-request failure: on the send
+        # side this raises to the caller (client request()) or becomes an ERROR
+        # frame (server handler). If it were sent, the peer's reader could not
+        # tell it from a corrupt length and would tear down the whole channel —
+        # silently poisoning every other session on this worker.
+        if _HDR_LEN + len(payload) > _MAX_FRAME:
+            raise IpcError(f"frame too large: {_HDR_LEN + len(payload)} bytes > _MAX_FRAME={_MAX_FRAME}")
+        frame = _HDR.pack(request_id, mtype) + payload
+        self._send_q.put_nowait(_LEN.pack(len(frame)) + frame)
+
+    async def _writer_loop(self) -> None:
+        try:
+            while True:
+                frame = await self._send_q.get()
+                self._writer.write(frame)
+                await self._writer.drain()
+        except asyncio.CancelledError:
+            raise
+        except (ConnectionError, OSError) as exc:
+            self._teardown(IpcChannelClosed(f"write failed: {exc!r}"))
+
+    async def _reader_loop(self) -> None:
+        try:
+            while True:
+                (length,) = _LEN.unpack(await self._reader.readexactly(_LEN.size))
+                if length < _HDR_LEN or length > _MAX_FRAME:
+                    raise IpcError(f"invalid frame length {length}")
+                frame = await self._reader.readexactly(length)
+                request_id, mtype = _HDR.unpack_from(frame, 0)
+                self._dispatch(mtype, request_id, frame[_HDR_LEN:])
+        except asyncio.CancelledError:
+            raise
+        except asyncio.IncompleteReadError:
+            self._teardown(IpcChannelClosed("peer closed connection"))
+        except (IpcError, ConnectionError, OSError) as exc:
+            self._teardown(IpcChannelClosed(f"read failed: {exc!r}"))
+
+    def _dispatch(self, mtype: int, request_id: int, payload: bytes) -> None:
+        if mtype == _TYPE_REPLY:
+            fut = self._pending.get(request_id)
+            if fut is not None and not fut.done():
+                fut.set_result(payload)
+        elif mtype == _TYPE_ERROR:
+            fut = self._pending.get(request_id)
+            if fut is not None and not fut.done():
+                fut.set_exception(IpcError(payload.decode("utf-8", "replace")))
+        elif mtype == _TYPE_REQUEST:
+            if self._request_handler is None:
+                logger.error("IpcChannel received a request but has no handler; dropping")
+                return
+            task = asyncio.ensure_future(self._run_handler(request_id, payload))
+            self._handler_tasks.add(task)
+            task.add_done_callback(self._handler_tasks.discard)
+        else:
+            logger.error("IpcChannel received unknown frame type %d; dropping", mtype)
+
+    async def _run_handler(self, request_id: int, payload: bytes) -> None:
+        try:
+            result = await self._request_handler(payload)
+            self._enqueue(_TYPE_REPLY, request_id, result)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:  # handler error → ERROR frame back to caller
+            logger.exception("IpcChannel request handler failed")
+            self._enqueue(_TYPE_ERROR, request_id, f"{type(exc).__name__}: {exc}".encode())
+
+    def _teardown(self, exc: Exception) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        for fut in self._pending.values():
+            if not fut.done():
+                fut.set_exception(exc)
+        self._pending.clear()
+        for task in (self._reader_task, self._writer_task):
+            if task is not None and task is not asyncio.current_task():
+                task.cancel()
+        for task in list(self._handler_tasks):
+            task.cancel()
+        try:
+            self._writer.close()
+        except Exception:
+            pass
+        if self._on_close is not None:
+            try:
+                self._on_close()
+            except Exception:
+                logger.exception("IpcChannel on_close callback failed")
+
+    async def aclose(self) -> None:
+        self._teardown(IpcChannelClosed("channel closed by aclose()"))
+
+
+async def open_unix_channel(
+    sock,
+    *,
+    request_handler: Callable[[bytes], Awaitable[bytes]] | None = None,
+    on_close: Callable[[], None] | None = None,
+) -> IpcChannel:
+    """Wrap a connected socket (e.g. a ``socket.socketpair`` end) in an IpcChannel."""
+    reader, writer = await asyncio.open_connection(sock=sock)
+    channel = IpcChannel(reader, writer, request_handler=request_handler, on_close=on_close)
+    channel.start()
+    return channel

--- a/miles/rollout/session/linear_trajectory.py
+++ b/miles/rollout/session/linear_trajectory.py
@@ -249,8 +249,19 @@ class SessionRegistry:
         self.tito_tokenizer = tito_tokenizer
         self.comparator = tito_tokenizer.create_comparator()
 
-    def create_session(self) -> str:
-        session_id = uuid.uuid4().hex
+    def create_session(self, session_id: str | None = None) -> str:
+        """Create a session; mint a fresh uuid4-hex id when none is given.
+
+        A caller-supplied id comes from the multi-process router, which mints the
+        id and routes by it, so the owning worker must create under that exact id.
+        Reject a collision so a duplicate CREATE surfaces loudly instead of
+        silently clobbering a live session. The id's shape is deliberately not
+        validated: supplied ids always come from the router (uuid4 hex).
+        """
+        if session_id is None:
+            session_id = uuid.uuid4().hex
+        elif session_id in self.sessions:
+            raise ValueError(f"session_id already exists: {session_id}")
         self.sessions[session_id] = LinearTrajectory()
         return session_id
 

--- a/miles/rollout/session/router.py
+++ b/miles/rollout/session/router.py
@@ -1,0 +1,157 @@
+# doc-dev: docs/developer/multi-process-session-server.md
+"""Thin client-facing router for the multi-process session server.
+
+- The sole HTTP listener: a FastAPI app over N ``IpcChannel``s, one per worker.
+- Routes every op of a session through ``SessionRouter.channel_for`` — a stable hash of ``session_id`` (``worker_index_for_session``) — so create/get/chat/delete land on the same worker.
+- Relays the worker's response bytes back verbatim; it never parses a body.
+- ``POST /sessions`` mints the id first (uuid4 hex) so it can route by it, then dispatches the create to the owning worker.
+- Error mapping in ``dispatch``: channel down → 503, worker handler raised → 502, malformed reply envelope → uncaught 500 (a worker protocol violation).
+- ``GET /health`` pings every worker and reports 503 unless all reply healthy within the timeout.
+
+Imports neither ``core`` nor ``worker``, so the router process never loads the tokenizer/transformers stack — it only moves bytes.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import uuid
+
+from fastapi import FastAPI, Request
+from starlette.responses import Response
+
+from miles.rollout.session.ipc import (
+    OP_CHAT,
+    OP_CREATE,
+    OP_DELETE,
+    OP_GET,
+    OP_HEALTH,
+    OP_PROXY,
+    IpcChannelClosed,
+    IpcError,
+    decode_envelope,
+    encode_request,
+)
+from miles.rollout.session.sharding import worker_index_for_session
+
+_JSON = "application/json"
+_HEALTH_TIMEOUT = 5.0
+
+
+def _err(status_code: int, message: str) -> Response:
+    return Response(content=json.dumps({"error": message}).encode(), status_code=status_code, media_type=_JSON)
+
+
+def _reply_to_response(reply: bytes) -> Response:
+    """Relay a worker REPLY envelope as an HTTP Response verbatim.
+
+    ``meta`` must carry ``status`` + ``headers`` (worker contract); ``body`` is
+    passed through unparsed, and a missing key raises KeyError (= worker protocol
+    violation, deliberately a 500). ``headers`` already carries content-type, so
+    no ``media_type`` is passed — that would duplicate content-length/-type.
+    """
+    meta, body = decode_envelope(reply)
+    return Response(content=body, status_code=meta["status"], headers=meta["headers"])
+
+
+class SessionRouter:
+    """Routes requests to per-worker IPC channels by stable hash of session_id."""
+
+    def __init__(self, channels: list, session_server_instance_id=None):
+        if not channels:
+            raise ValueError("SessionRouter requires at least one worker channel")
+        self.channels = channels
+        self.n_worker = len(channels)
+        self.instance_id = session_server_instance_id
+
+    def channel_for(self, session_id: str):
+        """The sole routing point: the worker channel owning ``session_id``.
+
+        Every op for a session must resolve here so create/get/chat/delete land
+        on one worker; divergent hashing would silently mis-route.
+        """
+        return self.channels[worker_index_for_session(session_id, self.n_worker)]
+
+    async def dispatch(self, channel, payload: bytes) -> Response:
+        """Send one request to ``channel`` and map the outcome to a Response.
+
+        Channel down (IpcChannelClosed) → 503; worker handler raised (IpcError)
+        → 502; a malformed reply envelope is not caught → 500. No per-request
+        timeout: covers worker death, not a live-but-hung worker.
+        """
+        try:
+            reply = await channel.request(payload)
+        except IpcChannelClosed:
+            return _err(503, "session worker unavailable")
+        except IpcError as exc:
+            return _err(502, f"session worker error: {exc}")
+        return _reply_to_response(reply)
+
+    async def healthy(self) -> bool:
+        async def ping(channel) -> bool:
+            meta, _ = decode_envelope(await channel.request(encode_request(OP_HEALTH)))
+            return meta["status"] == 200
+
+        try:
+            results = await asyncio.wait_for(
+                asyncio.gather(*(ping(ch) for ch in self.channels)), timeout=_HEALTH_TIMEOUT
+            )
+        except (asyncio.TimeoutError, IpcChannelClosed, IpcError):
+            return False
+        return all(results)
+
+
+def build_router_app(channels: list, session_server_instance_id=None) -> FastAPI:
+    router = SessionRouter(channels, session_server_instance_id)
+    app = FastAPI()
+
+    @app.get("/health")
+    async def health():
+        if not await router.healthy():
+            return _err(503, "one or more session workers unhealthy")
+        body = {"status": "ok"}
+        if router.instance_id is not None:
+            body["session_server_instance_id"] = router.instance_id
+        return Response(content=json.dumps(body).encode(), status_code=200, media_type=_JSON)
+
+    @app.post("/sessions")
+    async def create_session():
+        session_id = uuid.uuid4().hex
+        return await router.dispatch(router.channel_for(session_id), encode_request(OP_CREATE, session_id=session_id))
+
+    @app.get("/sessions/{session_id}")
+    async def get_session(session_id: str):
+        return await router.dispatch(router.channel_for(session_id), encode_request(OP_GET, session_id=session_id))
+
+    @app.delete("/sessions/{session_id}")
+    async def delete_session(session_id: str):
+        return await router.dispatch(router.channel_for(session_id), encode_request(OP_DELETE, session_id=session_id))
+
+    @app.post("/sessions/{session_id}/v1/chat/completions")
+    async def chat_completions(request: Request, session_id: str):
+        body = await request.body()
+        payload = encode_request(
+            OP_CHAT,
+            session_id=session_id,
+            method=request.method,
+            query=request.url.query,
+            headers=dict(request.headers),
+            body=body,
+        )
+        return await router.dispatch(router.channel_for(session_id), payload)
+
+    @app.api_route("/sessions/{session_id}/{path:path}", methods=["GET", "POST", "PUT", "DELETE", "PATCH"])
+    async def session_proxy(request: Request, session_id: str, path: str):
+        body = await request.body()
+        payload = encode_request(
+            OP_PROXY,
+            session_id=session_id,
+            path=path,
+            method=request.method,
+            query=request.url.query,
+            headers=dict(request.headers),
+            body=body,
+        )
+        return await router.dispatch(router.channel_for(session_id), payload)
+
+    return app

--- a/miles/rollout/session/sessions.py
+++ b/miles/rollout/session/sessions.py
@@ -7,13 +7,9 @@ Thin layer: converts each HTTP request to primitive inputs, calls
 import logging
 
 from fastapi import Request
-from fastapi.responses import JSONResponse
 
-from miles.rollout.session.core import SessionCore
+from miles.rollout.session.core import build_session_core, error_response
 from miles.rollout.session.errors import SessionError
-from miles.rollout.session.linear_trajectory import SessionRegistry
-from miles.utils.chat_template_utils import get_tito_tokenizer
-from miles.utils.processing_utils import load_tokenizer
 
 logger = logging.getLogger(__name__)
 
@@ -24,25 +20,11 @@ def setup_session_routes(app, backend, args):
         logger.info("[session] Skipping session routes (hf_checkpoint not set).")
         return
 
-    session_server_instance_id = getattr(args, "session_server_instance_id", None)
-
-    tokenizer = load_tokenizer(
-        hf_checkpoint, chat_template_path=getattr(args, "chat_template_path", None), trust_remote_code=True
-    )
-
-    tito_tokenizer = get_tito_tokenizer(
-        tokenizer,
-        tokenizer_type=getattr(args, "tito_model", "default"),
-        chat_template_kwargs=getattr(args, "apply_chat_template_kwargs", None),
-        allowed_append_roles=getattr(args, "tito_allowed_append_roles", None),
-    )
-
-    registry = SessionRegistry(args, tokenizer, tito_tokenizer=tito_tokenizer)
-    core = SessionCore(backend, registry, args, session_server_instance_id)
+    core = build_session_core(backend, args)
 
     @app.exception_handler(SessionError)
     async def session_error_handler(request: Request, exc: SessionError):
-        return JSONResponse(status_code=exc.status_code, content={"error": str(exc)})
+        return error_response(exc)
 
     @app.get("/health")
     async def health():

--- a/miles/rollout/session/sharding.py
+++ b/miles/rollout/session/sharding.py
@@ -1,0 +1,26 @@
+# doc-dev: docs/developer/multi-process-session-server.md
+"""Process-stable session→owner mapping for the multi-process session server.
+
+Decides which worker owns a ``session_id`` (see ``worker_index_for_session``
+for the hash choice), so the router and every worker agree on each session's
+owner with no coordination between them.
+
+Stdlib only (``hashlib``), so a headless worker or router can import it
+without pulling in FastAPI.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+
+def worker_index_for_session(session_id: str, n_worker: int) -> int:
+    """Map *session_id* to a worker index in ``range(n_worker)``.
+
+    Uses blake2b (not the builtin ``hash()``, which PYTHONHASHSEED salts per
+    process) so the router and every worker derive the same owner.
+    """
+    if n_worker < 1:
+        raise ValueError(f"n_worker must be >= 1, got {n_worker}")
+    digest = hashlib.blake2b(session_id.encode("utf-8"), digest_size=8).digest()
+    return int.from_bytes(digest, "big") % n_worker

--- a/miles/rollout/session/worker.py
+++ b/miles/rollout/session/worker.py
@@ -1,0 +1,154 @@
+# doc-dev: docs/developer/multi-process-session-server.md
+"""Headless session worker process — owns one shard of the multi-process data plane.
+
+- Owns one shard's session state: its own ``SessionCore`` (registry + tokenizer) plus its own httpx ``ProxyBackend``.
+- Speaks IPC, not HTTP: ``SessionWorker.handle`` decodes a request envelope, drives the matching ``SessionCore`` op, and encodes the returned Starlette ``Response`` (status + headers + body bytes) back.
+- A ``SessionError`` from the core becomes the same ``error_response`` the single-process FastAPI handler produces, so the workers=N and workers=1 error paths stay byte-identical.
+- ``ProxyBackend.do_proxy`` filters the same request headers as ``SessionServer.do_proxy`` (exercised by the equivalence tests) and turns a transport failure into a 502 result.
+- ``run_worker`` is the ``multiprocessing.Process`` target: names the process, arms PR_SET_PDEATHSIG, then serves the socket until the channel closes.
+
+The worker trusts the router's stable-hash routing and does not re-derive ownership.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import ctypes
+import json
+import logging
+import signal
+import sys
+
+import httpx
+import setproctitle
+from starlette.responses import Response
+
+from miles.rollout.session.core import ProxyRequest, build_session_core, error_response
+from miles.rollout.session.errors import SessionError
+from miles.rollout.session.ipc import (
+    OP_CHAT,
+    OP_CREATE,
+    OP_DELETE,
+    OP_GET,
+    OP_HEALTH,
+    OP_PROXY,
+    decode_envelope,
+    encode_envelope,
+    open_unix_channel,
+)
+
+logger = logging.getLogger(__name__)
+
+# Request headers not forwarded verbatim upstream (mirrors SessionServer.do_proxy;
+# the workers=N and workers=1 paths must filter identically — pinned by the
+# multi-process equivalence tests).
+_DROP_REQUEST_HEADERS = ("content-length", "transfer-encoding", "host")
+
+
+class ProxyBackend:
+    """Minimal httpx-only proxy backend for a worker (no FastAPI app)."""
+
+    def __init__(self, backend_url: str, *, timeout: float = 600.0, max_connections: int = 1024):
+        self.backend_url = backend_url
+        self.client = httpx.AsyncClient(
+            limits=httpx.Limits(max_connections=max_connections),
+            timeout=httpx.Timeout(timeout),
+        )
+
+    async def do_proxy(self, request: ProxyRequest, path: str, *, body: bytes, headers: dict) -> dict:
+        url = f"{self.backend_url}/{path}"
+        if request.query:
+            url = f"{url}?{request.query}"
+        headers = {k: v for k, v in headers.items() if k.lower() not in _DROP_REQUEST_HEADERS}
+        try:
+            response = await self.client.request(request.method, url, content=body, headers=headers)
+        except httpx.TransportError as exc:
+            logger.warning("Proxy transport error for %s %s: %s", request.method, path, exc)
+            error_body = json.dumps({"error": f"backend transport error: {type(exc).__name__}: {exc}"}).encode()
+            return {
+                "request_body": body,
+                "response_body": error_body,
+                "status_code": 502,
+                "headers": {"content-type": "application/json"},
+            }
+        content = await response.aread()
+        return {
+            "request_body": body,
+            "response_body": content,
+            "status_code": response.status_code,
+            "headers": dict(response.headers),
+        }
+
+    async def aclose(self) -> None:
+        await self.client.aclose()
+
+
+class SessionWorker:
+    """Decodes IPC request envelopes, drives a SessionCore, encodes replies."""
+
+    def __init__(self, core):
+        self.core = core
+
+    async def handle(self, payload: bytes) -> bytes:
+        meta, body = decode_envelope(payload)
+        try:
+            response = await self._dispatch(meta, body)
+        except SessionError as exc:
+            response = error_response(exc)
+        return encode_envelope(
+            {"status": response.status_code, "headers": dict(response.headers)}, response.body or b""
+        )
+
+    async def _dispatch(self, meta: dict, body: bytes) -> Response:
+        op = meta["op"]
+        if op == OP_HEALTH:
+            return await self.core.health()
+        if op == OP_CREATE:
+            return await self.core.create_session(meta["session_id"])
+        if op == OP_GET:
+            return await self.core.get_session(meta["session_id"])
+        if op == OP_DELETE:
+            return await self.core.delete_session(meta["session_id"])
+        if op == OP_CHAT:
+            return await self.core.chat_completions(
+                meta["session_id"], method=meta["method"], query=meta["query"], headers=meta["headers"], body=body
+            )
+        if op == OP_PROXY:
+            return await self.core.proxy(
+                meta["session_id"],
+                meta["path"],
+                method=meta["method"],
+                query=meta["query"],
+                headers=meta["headers"],
+                body=body,
+            )
+        raise ValueError(f"unknown op: {op!r}")
+
+
+def _set_pdeathsig() -> None:
+    """Ask the kernel to SIGKILL this worker if the parent (supervisor) dies (Linux)."""
+    if sys.platform != "linux":
+        return
+    try:
+        libc = ctypes.CDLL("libc.so.6", use_errno=True)
+        libc.prctl(1, signal.SIGKILL)  # PR_SET_PDEATHSIG
+    except Exception:
+        logger.warning("Failed to set PR_SET_PDEATHSIG; worker may outlive a crashed parent")
+
+
+async def _serve(args, backend_url: str, sock) -> None:
+    backend = ProxyBackend(backend_url, timeout=getattr(args, "miles_router_timeout", 600.0))
+    worker = SessionWorker(build_session_core(backend, args))
+    closed = asyncio.Event()
+    await open_unix_channel(sock, request_handler=worker.handle, on_close=closed.set)
+    try:
+        await closed.wait()
+    finally:
+        await backend.aclose()
+
+
+def run_worker(args, backend_url: str, sock, worker_index: int) -> None:
+    """``multiprocessing.Process`` target: serve one session shard over ``sock``."""
+    setproctitle.setproctitle(f"miles-session-worker-{worker_index}")
+    _set_pdeathsig()
+    asyncio.run(_serve(args, backend_url, sock))

--- a/tests/fast/router/test_session_dataplane.py
+++ b/tests/fast/router/test_session_dataplane.py
@@ -1,0 +1,200 @@
+"""Data-plane integration: router + N worker shards over real socketpair IPC.
+
+Wires the router to N ``SessionWorker`` shards (each its own ``SessionRegistry``)
+over real ``socket.socketpair`` IPC channels in one event loop, and drives the
+router app via httpx ASGITransport. This exercises hash routing, IPC framing,
+worker dispatch, TITO state per shard, and equivalence with the single-process
+server — without OS-process spawning (that lifecycle is the supervisor's job,
+covered separately). Workers as in-loop IPC handlers still use distinct
+registries, so cross-shard routing is genuinely tested.
+"""
+
+import json
+import socket
+import uuid
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from miles.rollout.session.core import SessionCore
+from miles.rollout.session.ipc import open_unix_channel
+from miles.rollout.session.linear_trajectory import SessionRegistry
+from miles.rollout.session.router import build_router_app
+from miles.rollout.session.server import SessionServer
+from miles.rollout.session.sharding import worker_index_for_session
+from miles.rollout.session.worker import ProxyBackend, SessionWorker
+from miles.utils.chat_template_utils import get_tito_tokenizer
+from miles.utils.processing_utils import load_tokenizer
+from miles.utils.test_utils.mock_sglang_server import MockSGLangServer, ProcessResult, with_mock_server
+
+N_WORKERS = 3
+
+
+def _process_fn(prompt: str) -> ProcessResult:
+    return ProcessResult(text=f"echo: {prompt}", finish_reason="stop")
+
+
+def _make_patched_chat_response():
+    # Add meta_info.output_token_logprobs the session core requires (same as test_sessions).
+    original = MockSGLangServer._compute_chat_completions_response
+
+    def patched(self, payload: dict) -> dict:
+        response = original(self, payload)
+        choice = response["choices"][0]
+        logprobs_content = choice["logprobs"]["content"]
+        otl = [(item["logprob"], self.tokenizer.convert_tokens_to_ids(item["token"])) for item in logprobs_content]
+        choice["meta_info"] = {"output_token_logprobs": otl, "completion_tokens": len(otl)}
+        return response
+
+    return patched
+
+
+def _make_args():
+    return SimpleNamespace(
+        miles_router_timeout=30,
+        hf_checkpoint="Qwen/Qwen3-0.6B",
+        chat_template_path=None,
+        apply_chat_template_kwargs={"enable_thinking": False},
+        tito_model="default",
+        tito_allowed_append_roles=["tool"],
+        session_server_instance_id=uuid.uuid4().hex,
+    )
+
+
+@pytest.fixture
+async def env():
+    with patch.object(MockSGLangServer, "_compute_chat_completions_response", new=_make_patched_chat_response()):
+        with with_mock_server(process_fn=_process_fn) as backend:
+            args = _make_args()
+            # One shared tokenizer for the N worker shards (fast); each shard gets its own registry.
+            tokenizer = load_tokenizer(args.hf_checkpoint, chat_template_path=None, trust_remote_code=True)
+            tito = get_tito_tokenizer(
+                tokenizer,
+                tokenizer_type="default",
+                chat_template_kwargs={"enable_thinking": False},
+                allowed_append_roles=["tool"],
+            )
+            backends, worker_channels, router_channels = [], [], []
+            for _ in range(N_WORKERS):
+                a, b = socket.socketpair()
+                be = ProxyBackend(backend.url, timeout=30)
+                backends.append(be)
+                core = SessionCore(
+                    be, SessionRegistry(args, tokenizer, tito_tokenizer=tito), args, args.session_server_instance_id
+                )
+                worker = SessionWorker(core)
+                worker_channels.append(await open_unix_channel(b, request_handler=worker.handle))
+                router_channels.append(await open_unix_channel(a))
+
+            app = build_router_app(router_channels, args.session_server_instance_id)
+            client = httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://router")
+
+            # Single-process server for equivalence comparison (same mock backend).
+            sp = SessionServer(args, backend_url=backend.url)
+            sp_client = httpx.AsyncClient(transport=httpx.ASGITransport(app=sp.app), base_url="http://sp")
+
+            try:
+                yield SimpleNamespace(client=client, sp_client=sp_client, n=N_WORKERS)
+            finally:
+                await client.aclose()
+                await sp_client.aclose()
+                for ch in worker_channels + router_channels:
+                    await ch.aclose()
+                for be in backends:
+                    await be.aclose()
+                await sp.client.aclose()
+
+
+async def test_health_ok(env):
+    r = await env.client.get("/health")
+    assert r.status_code == 200
+    assert r.json()["status"] == "ok"
+
+
+async def test_lifecycle_and_routing_determinism(env):
+    """create -> chat -> get -> delete for many ids; get/delete succeeding proves
+    every id-bearing op routes to the same shard that holds the session."""
+    ids = [(await env.client.post("/sessions")).json()["session_id"] for _ in range(8)]
+    assert len({worker_index_for_session(sid, env.n) for sid in ids}) >= 2  # >=2 distinct shards exercised
+
+    for sid in ids:
+        chat = await env.client.post(
+            f"/sessions/{sid}/v1/chat/completions", json={"messages": [{"role": "user", "content": "hi"}]}
+        )
+        assert chat.status_code == 200, chat.text
+
+        got = await env.client.get(f"/sessions/{sid}")
+        assert got.status_code == 200  # routed to the owning shard; 404 here would mean mis-routing
+        assert len(got.json()["records"]) == 1
+
+        assert (await env.client.delete(f"/sessions/{sid}")).status_code == 204
+        assert (await env.client.get(f"/sessions/{sid}")).status_code == 404
+
+
+async def test_get_missing_session_404(env):
+    r = await env.client.get(f"/sessions/{'0' * 32}")
+    assert r.status_code == 404
+    assert "not found" in r.json()["error"]
+
+
+async def test_equivalence_with_single_process(env):
+    """Router (workers=N) and the single-process server produce identical chat/get/delete
+    results (status + raw body bytes + content-type) for the same request."""
+    messages = {"messages": [{"role": "user", "content": "What is 1+2?"}]}
+
+    rid = (await env.client.post("/sessions")).json()["session_id"]
+    sid = (await env.sp_client.post("/sessions")).json()["session_id"]
+
+    rc = await env.client.post(f"/sessions/{rid}/v1/chat/completions", json=messages)
+    sc = await env.sp_client.post(f"/sessions/{sid}/v1/chat/completions", json=messages)
+    assert rc.status_code == sc.status_code == 200
+    # Bodies match except the mock's per-call volatile fields (id/created), which differ
+    # even between two calls to the same server. Equal-modulo-volatile proves the router
+    # relays the worker's response the same way the single-process server renders it.
+    rcb, scb = json.loads(rc.content), json.loads(sc.content)
+    for volatile in ("id", "created"):
+        rcb.pop(volatile, None)
+        scb.pop(volatile, None)
+    assert rcb == scb
+    assert rc.headers.get("content-type") == sc.headers.get("content-type")
+    assert rc.headers.get("content-length") == str(len(rc.content))  # router relayed framing intact
+
+    # GET records: same shape (TITO metadata present and consistent across the spawn boundary)
+    rg = await env.client.get(f"/sessions/{rid}")
+    sg = await env.sp_client.get(f"/sessions/{sid}")
+    assert rg.status_code == sg.status_code == 200
+    rgj, sgj = rg.json(), sg.json()
+    assert len(rgj["records"]) == len(sgj["records"]) == 1
+    assert set(rgj["metadata"]) == set(sgj["metadata"])
+    assert rgj["metadata"]["accumulated_token_ids"] == sgj["metadata"]["accumulated_token_ids"]
+
+    # DELETE: identical 204 + empty body
+    rd = await env.client.delete(f"/sessions/{rid}")
+    sd = await env.sp_client.delete(f"/sessions/{sid}")
+    assert rd.status_code == sd.status_code == 204
+    assert rd.content == sd.content == b""
+
+
+async def test_transport_error_502_equivalence():
+    """A dead backend maps to the same 502 in workers=N (ProxyBackend) and workers=1
+    (SessionServer.do_proxy) — pins the two do_proxy implementations against drift."""
+    from miles.rollout.session.core import ProxyRequest
+    from miles.utils.http_utils import find_available_port
+
+    dead = f"http://127.0.0.1:{find_available_port(42000)}"  # nothing listening → connection refused
+    args = _make_args()
+    pb = ProxyBackend(dead, timeout=2)
+    sp = SessionServer(args, backend_url=dead)
+    try:
+        req = ProxyRequest(method="POST", query="")
+        r_pb = await pb.do_proxy(req, "v1/chat/completions", body=b"{}", headers={})
+        r_sp = await sp.do_proxy(req, "v1/chat/completions", body=b"{}", headers={})
+        assert r_pb["status_code"] == r_sp["status_code"] == 502
+        assert r_pb["headers"] == r_sp["headers"]
+        assert json.loads(r_pb["response_body"])["error"].startswith("backend transport error")
+        assert json.loads(r_sp["response_body"])["error"].startswith("backend transport error")
+    finally:
+        await pb.aclose()
+        await sp.client.aclose()

--- a/tests/fast/router/test_session_ipc.py
+++ b/tests/fast/router/test_session_ipc.py
@@ -1,0 +1,140 @@
+"""Unit tests for the minimal IPC channel (miles/rollout/session/ipc.py)."""
+
+import asyncio
+import socket
+
+import pytest
+
+from miles.rollout.session.ipc import (
+    _LEN,
+    _MAX_FRAME,
+    IpcChannelClosed,
+    IpcError,
+    decode_envelope,
+    encode_envelope,
+    open_unix_channel,
+)
+
+
+async def _make_pair(handler=None, *, client_on_close=None):
+    """A connected (client, server) channel pair over a socketpair."""
+    s_client, s_server = socket.socketpair()
+    server = await open_unix_channel(s_server, request_handler=handler)
+    client = await open_unix_channel(s_client, on_close=client_on_close)
+    return client, server
+
+
+async def _close(*channels):
+    for ch in channels:
+        await ch.aclose()
+
+
+def test_envelope_roundtrip():
+    meta = {"op": "chat", "status": 200, "headers": {"content-type": "application/json"}}
+    body = b'{"x":1}\x00\xff'
+    m2, b2 = decode_envelope(encode_envelope(meta, body))
+    assert m2 == meta
+    assert b2 == body
+    m3, b3 = decode_envelope(encode_envelope({}, b""))
+    assert m3 == {}
+    assert b3 == b""
+
+
+async def test_request_reply_roundtrip():
+    async def echo(payload):
+        return payload
+
+    client, server = await _make_pair(echo)
+    try:
+        assert await asyncio.wait_for(client.request(b"hello"), 2) == b"hello"
+        assert await asyncio.wait_for(client.request(b""), 2) == b""
+        assert await asyncio.wait_for(client.request(b"\x00\xff\x01"), 2) == b"\x00\xff\x01"
+    finally:
+        await _close(client, server)
+
+
+async def test_multiplexing_replies_match_requests():
+    async def echo_after(payload):
+        # payload = b"<delay_ms>:<token>"; later-sent requests use shorter delays
+        delay_ms, _, token = payload.partition(b":")
+        await asyncio.sleep(int(delay_ms) / 1000)
+        return token
+
+    client, server = await _make_pair(echo_after)
+    try:
+        # decreasing delays → out-of-order completion; each future must still get ITS reply
+        reqs = [f"{(10 - i) * 10}:token-{i}".encode() for i in range(10)]
+        results = await asyncio.wait_for(asyncio.gather(*(client.request(r) for r in reqs)), 5)
+        assert results == [f"token-{i}".encode() for i in range(10)]
+    finally:
+        await _close(client, server)
+
+
+async def test_handler_error_becomes_ipc_error_and_channel_survives():
+    async def maybe_boom(payload):
+        if payload == b"x":
+            raise ValueError("kaboom")
+        return payload
+
+    client, server = await _make_pair(maybe_boom)
+    try:
+        with pytest.raises(IpcError, match="kaboom"):
+            await asyncio.wait_for(client.request(b"x"), 2)
+        # a handler error must not kill the channel
+        assert await asyncio.wait_for(client.request(b"ok"), 2) == b"ok"
+    finally:
+        await _close(client, server)
+
+
+async def test_peer_close_fails_pending_and_calls_on_close():
+    closed = asyncio.Event()
+
+    async def never(payload):
+        await asyncio.sleep(60)
+
+    client, server = await _make_pair(never, client_on_close=closed.set)
+    try:
+        task = asyncio.ensure_future(client.request(b"x"))
+        await asyncio.sleep(0.05)
+        await server.aclose()  # peer closes → client reader hits EOF
+        with pytest.raises(IpcChannelClosed):
+            await asyncio.wait_for(task, 2)
+        await asyncio.wait_for(closed.wait(), 2)
+        # a request on a closed channel fails fast
+        with pytest.raises(IpcChannelClosed):
+            await client.request(b"y")
+    finally:
+        await _close(client, server)
+
+
+async def test_cancel_then_reuse_drops_late_reply():
+    async def slow_echo(payload):
+        await asyncio.sleep(0.2)
+        return payload
+
+    client, server = await _make_pair(slow_echo)
+    try:
+        task = asyncio.ensure_future(client.request(b"first"))
+        await asyncio.sleep(0.02)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        # the cancelled request's late reply must be dropped, not delivered to the next request
+        assert await asyncio.wait_for(client.request(b"second"), 2) == b"second"
+    finally:
+        await _close(client, server)
+
+
+async def test_oversized_frame_length_tears_down():
+    s_client, s_peer = socket.socketpair()
+    closed = asyncio.Event()
+    client = await open_unix_channel(s_client, on_close=closed.set)
+    try:
+        # peer declares a frame length beyond the sanity cap → tear down, never allocate it
+        s_peer.sendall(_LEN.pack(_MAX_FRAME + 1))
+        await asyncio.wait_for(closed.wait(), 2)
+        with pytest.raises(IpcChannelClosed):
+            await client.request(b"x")
+    finally:
+        await client.aclose()
+        s_peer.close()

--- a/tests/fast/router/test_session_routing.py
+++ b/tests/fast/router/test_session_routing.py
@@ -1,0 +1,49 @@
+"""Unit tests for process-stable session routing (miles/rollout/session/sharding.py)."""
+
+import os
+import subprocess
+import sys
+import uuid
+
+import pytest
+
+from miles.rollout.session.sharding import worker_index_for_session
+
+
+def test_worker_index_in_range_and_deterministic():
+    sid = uuid.uuid4().hex
+    for n in (1, 2, 4, 16):
+        idx = worker_index_for_session(sid, n)
+        assert 0 <= idx < n
+        # deterministic: repeated calls agree
+        assert worker_index_for_session(sid, n) == idx
+
+
+def test_worker_index_distributes_across_workers():
+    n = 8
+    seen = {worker_index_for_session(uuid.uuid4().hex, n) for _ in range(2000)}
+    # with 2000 ids over 8 workers, every worker should be hit
+    assert seen == set(range(n))
+
+
+def test_worker_index_rejects_bad_n():
+    with pytest.raises(ValueError):
+        worker_index_for_session(uuid.uuid4().hex, 0)
+
+
+def test_mapping_is_process_stable_across_pythonhashseed():
+    """The mapping must not depend on PYTHONHASHSEED (i.e. must not use builtin hash())."""
+    sid = "0123456789abcdef0123456789abcdef"
+    n = 7
+    expected = worker_index_for_session(sid, n)
+
+    def index_in_subproc(seed: str) -> int:
+        code = (
+            "from miles.rollout.session.sharding import worker_index_for_session;"
+            f"print(worker_index_for_session({sid!r}, {n}))"
+        )
+        out = subprocess.check_output([sys.executable, "-c", code], env={**os.environ, "PYTHONHASHSEED": seed})
+        return int(out.strip())
+
+    assert index_in_subproc("0") == expected
+    assert index_in_subproc("12345") == expected

--- a/tests/fast/router/test_session_worker.py
+++ b/tests/fast/router/test_session_worker.py
@@ -1,0 +1,107 @@
+"""Unit tests for the session worker's op dispatch / reply encoding (no process spawn).
+
+Drives ``SessionWorker.handle`` in-process against a real ``SessionCore`` (real
+tokenizer) and a mock backend. The full chat-through-a-spawned-worker path is
+covered by the multi-process equivalence tests.
+"""
+
+import json
+import uuid
+from types import SimpleNamespace
+
+import pytest
+
+from miles.rollout.session.core import build_session_core
+from miles.rollout.session.ipc import (
+    OP_CREATE,
+    OP_DELETE,
+    OP_GET,
+    OP_HEALTH,
+    OP_PROXY,
+    decode_envelope,
+    encode_request,
+)
+from miles.rollout.session.worker import SessionWorker
+
+
+class _MockBackend:
+    """Returns a canned JSON response for the proxy op; never called by CRUD ops."""
+
+    async def do_proxy(self, request, path, *, body, headers):
+        return {
+            "request_body": body,
+            "response_body": b'{"proxied":true}',
+            "status_code": 200,
+            "headers": {"content-type": "application/json"},
+        }
+
+
+@pytest.fixture(scope="module")
+def worker():
+    args = SimpleNamespace(
+        miles_router_timeout=30,
+        hf_checkpoint="Qwen/Qwen3-0.6B",
+        chat_template_path=None,
+        apply_chat_template_kwargs={"enable_thinking": False},
+        tito_model="default",
+        tito_allowed_append_roles=["tool"],
+        session_server_instance_id=uuid.uuid4().hex,
+    )
+    return SessionWorker(build_session_core(_MockBackend(), args))
+
+
+def _reply(payload):
+    meta, body = decode_envelope(payload)
+    return meta["status"], meta["headers"], body
+
+
+async def test_health(worker):
+    status, _, body = _reply(await worker.handle(encode_request(OP_HEALTH)))
+    assert status == 200
+    assert json.loads(body)["status"] == "ok"
+
+
+async def test_create_get_delete_lifecycle(worker):
+    sid = uuid.uuid4().hex
+
+    status, _, body = _reply(await worker.handle(encode_request(OP_CREATE, session_id=sid)))
+    assert status == 200
+    assert json.loads(body)["session_id"] == sid
+
+    status, _, body = _reply(await worker.handle(encode_request(OP_GET, session_id=sid)))
+    assert status == 200
+    assert json.loads(body)["session_id"] == sid
+    assert json.loads(body)["records"] == []
+
+    status, _, body = _reply(await worker.handle(encode_request(OP_DELETE, session_id=sid)))
+    assert status == 204
+    assert body == b""
+
+    # get after delete → SessionNotFoundError mapped to a 404 error envelope
+    status, _, body = _reply(await worker.handle(encode_request(OP_GET, session_id=sid)))
+    assert status == 404
+    assert "not found" in json.loads(body)["error"]
+
+
+async def test_get_missing_session_returns_404(worker):
+    status, _, body = _reply(await worker.handle(encode_request(OP_GET, session_id=uuid.uuid4().hex)))
+    assert status == 404
+    assert "not found" in json.loads(body)["error"]
+
+
+async def test_proxy_passthrough(worker):
+    status, headers, body = _reply(
+        await worker.handle(encode_request(OP_PROXY, session_id=uuid.uuid4().hex, path="v1/models", method="GET"))
+    )
+    assert status == 200
+    assert json.loads(body) == {"proxied": True}
+    assert headers.get("content-type") == "application/json"
+
+
+async def test_create_duplicate_id_raises(worker):
+    # The collision guard makes a routing bug loud (becomes a 502 over IPC), rather
+    # than silently clobbering an existing session.
+    sid = uuid.uuid4().hex
+    await worker.handle(encode_request(OP_CREATE, session_id=sid))
+    with pytest.raises(ValueError):
+        await worker.handle(encode_request(OP_CREATE, session_id=sid))


### PR DESCRIPTION
## Summary
Opt-in multi-process session-server **data plane**, stacked on the `SessionCore` extraction (#1510) and the R3 client-strip (#1563). This PR adds the mechanism (routing + IPC + worker + thin router) but **does not wire it into launch** — the supervisor, the `--session-server-workers` flag, and the `router_manager`/`rollout_manager` wiring land in the follow-up control-plane PR. So this PR changes **no runtime behavior**: the default single-process path is untouched and nothing yet activates the multi-process path.

> Stacked on #1569 → #1510 → #1563. Base = `refactor/session-r3-client-strip`. Review/merge after #1563.

## What's here
- `sharding.py` — process-stable `blake2b(session_id) % N` sharding (router and every worker agree without coordination).
- `ipc.py` — minimal framed, multiplexed RPC over a UNIX socket: one frame per message, `request_id` multiplexing, cancel-safe `request()`, u64 frame lengths with a single 64 GiB sanity frame cap enforced at **send time** (an oversized frame is a per-request `IpcError` / ERROR-frame failure, never a channel teardown). No chunking / round-robin / send-budget / backpressure.
- `worker.py` — headless worker: one `SessionCore` + an httpx `ProxyBackend`, driven over IPC. No per-worker backpressure / parse-gate.
- `router.py` — thin client-facing router app: hash-routes to the owning worker and relays the opaque response body (never parses it); imports neither `core` nor `worker`, so the router process never loads the tokenizer/transformers stack.

## Single-sourced across single- and multi-process (no drift)
- `SessionCore.create_session(session_id=None)` → `SessionRegistry.create_session(session_id=None)` — the router mints the id (uuid4 hex, so it can route by it) and the owning worker creates under exactly that id, with a loud collision guard; the single-process path passes None and the registry mints.
- `core.error_response` / `build_session_core` — used by both the FastAPI adapter and the worker, so the error/response/tokenizer contracts can't diverge between modes.

## Cut vs. the original prototype (kept minimal)
Cut: IPC chunking/round-robin/send-budget, configurable size limits, router 503 backpressure, `asyncio.shield`, the router task-tracking set, worker backpressure + parse-gate, the 409/500 additions. Kept (load-bearing): `request_id` multiplexing, the sanity frame cap, cancel-safe `request()`. Rationale in `docs/developer/multi-process-session-server.md`.

## Why u64 frame lengths (measured)
Session records are never pruned (the training data path consumes R3 from them via `GET /sessions/{id}`), so a full-records GET reply grows with `turns × response size`. At the production shape from the design doc (50 turns × ~64 MiB avg accumulated-R3 response) one session's GET reply measures **~3.15 GiB — already past a u32/2 GiB frame limit**. With u32 the failure mode was the worst kind: the reply frame reached the router's reader, was indistinguishable from a corrupt length, and tore down the whole IPC channel — **silently poisoning every other session on that shard** (worker still alive, so the supervisor's `is_alive()` fail-fast can't see it; observed as 9/32 sessions failing with 503s and 0/32 GETs succeeding). With u64 + the 64 GiB send-side cap the same workload passes: 32/32 sessions, 1600/1600 turns, 0 chat errors, 30/32 GETs OK (2 client-side `ReadTimeout`s in the bench harness, not server failures) — each ~3.15 GiB reply crosses as one frame and an oversized frame can only fail its own request, never the channel.

## Tests (`tests/fast/router/`)
- `test_session_ipc` — framing, out-of-order multiplexing, handler-error → `IpcError`, EOF teardown, cancel-safety, oversized-frame rejection.
- `test_session_routing` — determinism, distribution, and **cross-process hash stability** (independent of `PYTHONHASHSEED`).
- `test_session_worker` — op dispatch, create/get/delete lifecycle, missing→404, proxy passthrough, duplicate-id guard.
- `test_session_dataplane` — router ↔ N=3 workers over real socketpair IPC: routing determinism (≥2 shards; mis-route would 404), **`workers=N` == `workers=1`** equivalence (status + body + content-type + content-length + 204 + 502 + TITO `accumulated_token_ids` across the spawn boundary).

`python -m pytest tests/fast/router/` → 95 passed. black / isort / ruff clean.

## Docs
`docs/developer/multi-process-session-server.md` — goal, functional requirements, module decomposition with data-path flowcharts (per-turn chat vs end-of-rollout full-records fetch), behavior parity, design targets, open decisions (incl. the measured records-GET head-of-line finding — accepted for this stack, fix decided and deferred to a follow-up records-path PR — and the kept-vs-cut rationale), and the not-covered list.


