### PR TITLE
Port keep sampling mask support

### DIFF
--- a/miles/backends/megatron_utils/model.py
+++ b/miles/backends/megatron_utils/model.py
@@ -264,6 +264,7 @@ def forward_only(
                 "multimodal_train_inputs",
                 "total_lengths",
                 "response_lengths",
+                "rollout_sampling_masks",
                 "max_seq_lens",
             ],
             args.data_pad_size_multiplier,
@@ -292,6 +293,7 @@ def forward_only(
             total_lengths=total_lengths,
             response_lengths=response_lengths,
             with_entropy=args.use_rollout_entropy,
+            sampling_masks=batch.get("rollout_sampling_masks"),
             max_seq_lens=batch.get("max_seq_lens", None),
         )
 
@@ -415,6 +417,7 @@ def train_one_step(
                 "advantages",
                 "returns",
                 "rollout_log_probs",
+                "rollout_sampling_masks",
                 "max_seq_lens",
                 "opd_reverse_kl",
             ],

--- a/miles/backends/training_utils/data.py
+++ b/miles/backends/training_utils/data.py
@@ -28,6 +28,93 @@ def _rollout_logprob_dtype(args: Namespace) -> torch.dtype:
     return torch.float32
 
 
+def _normalize_keep_sampling_masks_for_loss(
+    *,
+    token_ids: list[int],
+    loss_mask: list[int],
+    response_length: int,
+    log_probs: list[float],
+    masks: list[list[int] | None],
+    sample_index: int,
+) -> tuple[list[float], list[list[int]]]:
+    """Validate response-aligned sampling masks and neutralize non-loss tokens.
+
+    Tokens excluded from loss are replaced with singleton masks/logprob 0 so
+    downstream masked-logprob code can process every response position.
+    """
+    if len(masks) != response_length:
+        raise ValueError(
+            f"Sample {sample_index} rollout_sampling_masks length {len(masks)} != response_length {response_length}"
+        )
+    if len(log_probs) != response_length:
+        raise ValueError(
+            f"Sample {sample_index} rollout_log_probs length {len(log_probs)} != response_length {response_length}"
+        )
+
+    if len(loss_mask) == response_length:
+        response_loss_mask = loss_mask
+    elif len(loss_mask) >= response_length:
+        response_loss_mask = loss_mask[-response_length:] if response_length else []
+    else:
+        raise ValueError(
+            f"Sample {sample_index} loss_mask length {len(loss_mask)} is shorter than response_length {response_length}"
+        )
+
+    response_tokens = token_ids[-response_length:] if response_length else []
+    normalized_masks: list[list[int]] = []
+    normalized_log_probs = [float(x) for x in log_probs]
+    for token_index, (token_id, mask_value, loss_value) in enumerate(
+        zip(response_tokens, masks, response_loss_mask, strict=True)
+    ):
+        token_id = int(token_id)
+        if not int(loss_value):
+            normalized_masks.append([token_id])
+            normalized_log_probs[token_index] = 0.0
+            continue
+
+        if mask_value is None or len(mask_value) == 0:
+            raise ValueError(f"Sample {sample_index} token {token_index} with loss_mask=1 has no sampling mask")
+        mask = [int(mask_token) for mask_token in mask_value]
+        if token_id not in mask:
+            raise ValueError(f"Sample {sample_index} token {token_index} id {token_id} is not in its sampling mask")
+        normalized_masks.append(mask)
+
+    return normalized_log_probs, normalized_masks
+
+
+def _normalize_rollout_sampling_masks_for_loss(args: Namespace, rollout_data: RolloutBatch) -> None:
+    """Apply keep-sampling-mask normalization to each sample in a rollout batch."""
+    if not getattr(args, "keep_sampling_mask", False):
+        return
+    if "rollout_sampling_masks" not in rollout_data:
+        raise ValueError("keep_sampling_mask is enabled but rollout_sampling_masks is missing from rollout_data")
+    if "rollout_log_probs" not in rollout_data:
+        raise ValueError("keep_sampling_mask is enabled but rollout_log_probs is missing from rollout_data")
+
+    for i, (token_ids, loss_mask, masks, log_probs, response_length) in enumerate(
+        zip(
+            rollout_data["tokens"],
+            rollout_data["loss_masks"],
+            rollout_data["rollout_sampling_masks"],
+            rollout_data["rollout_log_probs"],
+            rollout_data["response_lengths"],
+            strict=True,
+        )
+    ):
+        if masks is None:
+            raise ValueError(f"Sample {i} is missing rollout_sampling_masks")
+        log_probs, masks = _normalize_keep_sampling_masks_for_loss(
+            token_ids=list(token_ids),
+            loss_mask=list(loss_mask),
+            response_length=int(response_length),
+            log_probs=list(log_probs),
+            masks=masks,
+            sample_index=i,
+        )
+        rollout_data["rollout_log_probs"][i] = log_probs
+        rollout_data["rollout_sampling_masks"][i] = masks
+
+
 def get_rollout_data(args: Namespace, rollout_data_ref: Box) -> RolloutBatch:
     parallel_state = get_parallel_state()
     # Fetch data through ray on CPU, not sure if this will be performance bottleneck.
@@ -38,6 +125,7 @@ def get_rollout_data(args: Namespace, rollout_data_ref: Box) -> RolloutBatch:
         parallel_state.intra_dp.rank,
         parallel_state.intra_dp.size,
     )
+    _normalize_rollout_sampling_masks_for_loss(args, rollout_data)
     # move tokens to GPU in advance
     rollout_data["tokens"] = [
         torch.tensor(t, dtype=torch.long, device=torch.cuda.current_device()) for t in rollout_data["tokens"]

--- a/miles/backends/training_utils/log_utils.py
+++ b/miles/backends/training_utils/log_utils.py
@@ -118,6 +118,7 @@ def log_rollout_data(rollout_id: int, args: Namespace, rollout_data: RolloutBatc
                 "multimodal_train_inputs",
                 "loss_masks",
                 "sample_indices",
+                "rollout_sampling_masks",
                 "rollout_routed_experts",
                 "rollout_indexer_topk",
                 "max_seq_lens",

--- a/miles/backends/training_utils/loss_hub/logit_processors.py
+++ b/miles/backends/training_utils/loss_hub/logit_processors.py
@@ -4,7 +4,10 @@ from collections.abc import Iterator
 import torch
 
 from miles.backends.training_utils.cp_utils import allgather_cp_redistribute, get_logits_and_tokens_offset_with_cp
-from miles.backends.training_utils.loss_hub.math_utils import calculate_log_probs_and_entropy
+from miles.backends.training_utils.loss_hub.math_utils import (
+    calculate_log_probs_and_entropy,
+    calculate_masked_log_probs_and_entropy,
+)
 from miles.backends.training_utils.parallel import get_parallel_state
 
 
@@ -127,6 +130,78 @@ def get_responses(
         yield logits_chunk, tokens_chunk
 
 
+def get_response_sampling_masks(
+    logits: torch.Tensor,
+    *,
+    args: Namespace,
+    sampling_masks: list[list[list[int] | None]] | None,
+    total_lengths: list[int],
+    response_lengths: list[int],
+    max_seq_lens: list[int] | None = None,
+) -> Iterator[list[list[int] | None]]:
+    """Yield saved sampling masks aligned with the local response tokens.
+
+    `get_responses` may return only the context-parallel slice owned by this
+    rank, so the full-response Python mask lists must be sliced the same way.
+    """
+    if sampling_masks is None:
+        raise ValueError("keep_sampling_mask is enabled but rollout_sampling_masks is missing from the batch")
+
+    qkv_format = args.qkv_format
+    if qkv_format == "thd":
+        assert logits.size(0) == 1, f"{logits.shape}"
+        local_token_count = logits.size(1)
+    else:
+        local_token_count = logits.view(-1, logits.size(-1)).size(0)
+
+    parallel_state = get_parallel_state()
+    cp_size = parallel_state.cp.size
+    cp_rank = parallel_state.cp.rank
+    seq_start = 0
+    for i, (masks, total_length, response_length) in enumerate(
+        zip(sampling_masks, total_lengths, response_lengths, strict=False)
+    ):
+        if masks is None:
+            raise ValueError(f"Sample {i} is missing rollout_sampling_masks")
+        if len(masks) != response_length:
+            raise ValueError(
+                f"Sample {i} rollout_sampling_masks length {len(masks)} != response_length {response_length}"
+            )
+
+        max_seq_len = max_seq_lens[i] if max_seq_lens is not None else None
+        prompt_length = total_length - response_length
+
+        if cp_size == 1:
+            masks_chunk = masks
+        elif args.allgather_cp:
+            chunk_start = cp_rank * local_token_count
+            chunk_end = chunk_start + local_token_count
+
+            resp_token_start = seq_start + prompt_length
+            resp_token_end = seq_start + total_length
+            logit_global_start = resp_token_start - 1
+            logit_global_end = resp_token_end - 1
+
+            s = max(logit_global_start, chunk_start)
+            e = min(logit_global_end, chunk_end)
+            if e <= s:
+                masks_chunk = []
+            else:
+                mask_start = s - logit_global_start
+                mask_end = e - logit_global_start
+                masks_chunk = masks[mask_start:mask_end]
+        else:
+            _, _, _, tokens_offset = get_logits_and_tokens_offset_with_cp(
+                total_length, response_length, qkv_format, max_seq_len
+            )
+            masks_0 = masks[tokens_offset[0][0] - prompt_length : tokens_offset[0][1] - prompt_length]
+            masks_1 = masks[tokens_offset[1][0] - prompt_length : tokens_offset[1][1] - prompt_length]
+            masks_chunk = masks_0 + masks_1
+
+        seq_start += total_length
+        yield masks_chunk
+
+
 def get_log_probs_and_entropy(
     logits: torch.Tensor,
     *,
@@ -134,6 +209,7 @@ def get_log_probs_and_entropy(
     unconcat_tokens: list[torch.Tensor],
     total_lengths: list[int],
     response_lengths: list[int],
+    sampling_masks: list[list[list[int] | None]] | None = None,
     with_entropy: bool = False,
     non_loss_data: bool = True,
     max_seq_lens: list[int] | None = None,
@@ -164,25 +240,55 @@ def get_log_probs_and_entropy(
     parallel_state = get_parallel_state()
     log_probs_list = []
     entropy_list = []
-    for logits_chunk, tokens_chunk in get_responses(
+    response_iter = get_responses(
         logits,
         args=args,
         unconcat_tokens=unconcat_tokens,
         total_lengths=total_lengths,
         response_lengths=response_lengths,
         max_seq_lens=max_seq_lens,
-    ):
-        log_prob, entropy = calculate_log_probs_and_entropy(
-            logits_chunk,
-            tokens_chunk,
-            parallel_state.tp.group,
-            with_entropy=with_entropy,
-            chunk_size=args.log_probs_chunk_size,
-            true_on_policy=args.true_on_policy_mode,
-            vocab_size=getattr(args, "vocab_size", None),
+    )
+    use_sampling_masks = getattr(args, "keep_sampling_mask", False)
+    if use_sampling_masks:
+        mask_iter = get_response_sampling_masks(
+            logits,
+            args=args,
+            sampling_masks=sampling_masks,
+            total_lengths=total_lengths,
+            response_lengths=response_lengths,
+            max_seq_lens=max_seq_lens,
         )
+    else:
+        mask_iter = None
 
-        log_probs_list.append(log_prob.squeeze(-1))
+    for idx, (logits_chunk, tokens_chunk) in enumerate(response_iter):
+        if not use_sampling_masks:
+            log_prob, entropy = calculate_log_probs_and_entropy(
+                logits_chunk,
+                tokens_chunk,
+                parallel_state.tp.group,
+                with_entropy=with_entropy,
+                chunk_size=args.log_probs_chunk_size,
+                true_on_policy=args.true_on_policy_mode,
+                vocab_size=getattr(args, "vocab_size", None),
+            )
+        else:
+            assert mask_iter is not None
+            masks_chunk = next(mask_iter)
+            if len(masks_chunk) != tokens_chunk.size(0):
+                raise ValueError(
+                    f"Sample {idx} mask chunk length {len(masks_chunk)} != token chunk length {tokens_chunk.size(0)}"
+                )
+            log_prob, entropy = calculate_masked_log_probs_and_entropy(
+                logits_chunk,
+                tokens_chunk,
+                masks_chunk,
+                parallel_state.tp.group,
+                with_entropy=with_entropy,
+                chunk_size=args.log_probs_chunk_size,
+            )
+
+        log_probs_list.append(log_prob.reshape(-1))
         entropy_list.append(entropy)
 
     res = {
@@ -212,6 +318,7 @@ def get_values(
     unconcat_tokens: list[torch.Tensor],
     total_lengths: list[int],
     response_lengths: list[int],
+    sampling_masks: list[list[list[int] | None]] | None = None,
     with_entropy: bool = False,
     non_loss_data: bool = True,
     max_seq_lens: list[int] | None = None,

--- a/miles/backends/training_utils/loss_hub/losses.py
+++ b/miles/backends/training_utils/loss_hub/losses.py
@@ -103,6 +103,7 @@ def policy_loss_function(
         unconcat_tokens=batch["unconcat_tokens"],
         total_lengths=total_lengths,
         response_lengths=response_lengths,
+        sampling_masks=batch.get("rollout_sampling_masks"),
         with_entropy=args.entropy_coef != 0,
         max_seq_lens=max_seq_lens,
     )
@@ -451,6 +452,7 @@ def sft_loss_function(
         unconcat_tokens=batch["unconcat_tokens"],
         total_lengths=total_lengths,
         response_lengths=response_lengths,
+        sampling_masks=batch.get("rollout_sampling_masks"),
         with_entropy=False,
         max_seq_lens=batch.get("max_seq_lens", None),
     )

--- a/miles/backends/training_utils/loss_hub/math_utils.py
+++ b/miles/backends/training_utils/loss_hub/math_utils.py
@@ -295,6 +295,145 @@ def compute_log_probs(
     return -fused_vocab_parallel_cross_entropy(logits, tokens, process_group)
 
 
+def _masked_log_probs_and_entropy_inner(
+    logits: torch.Tensor,
+    tokens: torch.Tensor,
+    masks: list[list[int] | None],
+    *,
+    process_group: dist.ProcessGroup | None,
+    with_entropy: bool,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    """Compute logprobs after restricting each row to its saved sampling mask.
+
+    `masks` must already be aligned 1:1 with `tokens` and `logits`. For each
+    row this computes ``log p(token | mask) = logit[token] - logsumexp(logits[mask])``
+    over the rollout sampler's saved support. Logits for token ids outside the
+    mask do not affect the denominator, so they get no gradient from this
+    computation. Non-loss response positions are normalized before this
+    function to singleton masks, which yields logprob 0 and zero gradient.
+    """
+    if logits.size(0) == 0:
+        entropy = logits.new_zeros((0,)) if with_entropy else None
+        return logits.new_zeros((0,)), entropy
+
+    if len(masks) != logits.size(0):
+        raise ValueError(f"Sampling-mask chunk length {len(masks)} != logits chunk length {logits.size(0)}")
+    if any(mask is None or len(mask) == 0 for mask in masks):
+        raise ValueError("Every generated token must have a non-empty sampling mask when keep_sampling_mask is enabled")
+
+    if process_group is None:
+        tp_size = 1
+        tp_rank = 0
+    else:
+        tp_size = dist.get_world_size(process_group)
+        tp_rank = dist.get_rank(process_group)
+
+    local_vocab_size = logits.size(-1)
+    vocab_start = tp_rank * local_vocab_size
+    vocab_end = vocab_start + local_vocab_size
+
+    max_mask_len = max(len(mask) for mask in masks if mask is not None)
+    mask_ids = torch.zeros((len(masks), max_mask_len), dtype=torch.long, device=logits.device)
+    valid = torch.zeros((len(masks), max_mask_len), dtype=torch.bool, device=logits.device)
+    sampled_in_mask = []
+    for row, (mask, token) in enumerate(zip(masks, tokens.tolist(), strict=True)):
+        assert mask is not None
+        sampled_in_mask.append(int(token) in mask)
+        ids = torch.tensor(mask, dtype=torch.long, device=logits.device)
+        mask_ids[row, : ids.numel()] = ids
+        valid[row, : ids.numel()] = True
+    if not all(sampled_in_mask):
+        bad_index = sampled_in_mask.index(False)
+        raise ValueError(f"Sampled token {int(tokens[bad_index])} is not in its saved sampling mask")
+
+    local_valid = valid & (mask_ids >= vocab_start) & (mask_ids < vocab_end)
+    local_offsets = (mask_ids - vocab_start).clamp(min=0, max=max(local_vocab_size - 1, 0))
+    local_mask_logits = logits.gather(dim=-1, index=local_offsets)
+    neg_inf = torch.finfo(logits.dtype).min
+    local_mask_logits = local_mask_logits.masked_fill(~local_valid, neg_inf)
+
+    local_max = local_mask_logits.max(dim=-1).values.detach()
+    if tp_size > 1:
+        global_max = local_max.clone()
+        dist.all_reduce(global_max, op=dist.ReduceOp.MAX, group=process_group)
+    else:
+        global_max = local_max
+
+    shifted = (local_mask_logits - global_max.unsqueeze(-1)).masked_fill(~local_valid, neg_inf)
+    local_exp = shifted.exp().masked_fill(~local_valid, 0.0)
+    local_sum = local_exp.sum(dim=-1)
+    if tp_size > 1:
+        global_sum = dist.nn.all_reduce(local_sum, group=process_group)
+    else:
+        global_sum = local_sum
+
+    token_local = (tokens >= vocab_start) & (tokens < vocab_end)
+    token_offsets = (tokens - vocab_start).clamp(min=0, max=max(local_vocab_size - 1, 0))
+    local_selected = logits.gather(dim=-1, index=token_offsets.unsqueeze(-1)).squeeze(-1)
+    local_selected = torch.where(token_local, local_selected, torch.zeros_like(local_selected))
+    if tp_size > 1:
+        selected = dist.nn.all_reduce(local_selected, group=process_group)
+    else:
+        selected = local_selected
+
+    log_den = global_max + global_sum.clamp_min(torch.finfo(global_sum.dtype).tiny).log()
+    log_probs = selected - log_den
+
+    entropy = None
+    if with_entropy:
+        local_weighted_logits = (local_exp * local_mask_logits.masked_fill(~local_valid, 0.0)).sum(dim=-1)
+        if tp_size > 1:
+            weighted_logits = dist.nn.all_reduce(local_weighted_logits, group=process_group)
+        else:
+            weighted_logits = local_weighted_logits
+        entropy = log_den - weighted_logits / global_sum.clamp_min(torch.finfo(global_sum.dtype).tiny)
+
+    return log_probs, entropy
+
+
+def calculate_masked_log_probs_and_entropy(
+    logits: torch.Tensor,
+    tokens: torch.Tensor,
+    masks: list[list[int] | None],
+    process_group: dist.ProcessGroup | None,
+    *,
+    with_entropy: bool = False,
+    chunk_size: int = -1,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    if logits.size(0) == 0:
+        entropy = logits.new_zeros((0,)) if with_entropy else None
+        return logits.new_zeros((0,)), entropy
+
+    logits = logits.contiguous()
+    if chunk_size <= 0 or logits.size(0) <= chunk_size:
+        return _masked_log_probs_and_entropy_inner(
+            logits,
+            tokens,
+            masks,
+            process_group=process_group,
+            with_entropy=with_entropy,
+        )
+
+    log_probs = []
+    entropies = []
+    for start in range(0, logits.size(0), chunk_size):
+        end = start + chunk_size
+        log_prob, entropy = _masked_log_probs_and_entropy_inner(
+            logits[start:end],
+            tokens[start:end],
+            masks[start:end],
+            process_group=process_group,
+            with_entropy=with_entropy,
+        )
+        log_probs.append(log_prob)
+        if with_entropy:
+            assert entropy is not None
+            entropies.append(entropy)
+
+    entropy = torch.cat(entropies, dim=0) if with_entropy else None
+    return torch.cat(log_probs, dim=0), entropy
+
+
 def _prepare_true_on_policy_full_logits(
     logits_or_shards: torch.Tensor | list[torch.Tensor] | tuple[torch.Tensor, ...],
     *,

--- a/miles/ray/rollout/train_data_conversion.py
+++ b/miles/ray/rollout/train_data_conversion.py
@@ -67,6 +67,9 @@ def convert_samples_to_train_data(
     if samples[0].rollout_log_probs is not None:
         train_data["rollout_log_probs"] = [sample.rollout_log_probs for sample in samples]
 
+    if samples[0].rollout_sampling_masks is not None:
+        train_data["rollout_sampling_masks"] = [sample.rollout_sampling_masks for sample in samples]
+
     if samples[0].rollout_routed_experts is not None:
         train_data["rollout_routed_experts"] = [sample.rollout_routed_experts for sample in samples]
 
@@ -152,6 +155,7 @@ def split_train_data_by_dp(args, data, dp_size):
             "round_number",
             "sample_indices",
             "rollout_log_probs",
+            "rollout_sampling_masks",
             "rollout_routed_experts",
             "rollout_indexer_topk",
             "prompt",

--- a/miles/rollout/generate_utils/generate_endpoint_utils.py
+++ b/miles/rollout/generate_utils/generate_endpoint_utils.py
@@ -55,10 +55,54 @@ def compute_request_payload(
         "return_routed_experts": args.use_rollout_routing_replay,
         "return_indexer_topk": args.use_rollout_indexer_replay,
     }
+    if getattr(args, "keep_sampling_mask", False):
+        payload["return_sampling_mask"] = True
     if image_data := (multimodal_inputs or {}).get("images"):
         payload["image_data"] = [encode_image_for_rollout_engine(image) for image in image_data]
 
     return payload, None
+
+
+def extract_response_tokens_and_log_probs(args, meta_info: dict) -> tuple[list[int], list[float]]:
+    output_token_logprobs = meta_info.get("output_token_logprobs")
+    if output_token_logprobs:
+        response_tokens = [int(item[1]) for item in output_token_logprobs]
+    else:
+        response_tokens = []
+
+    if getattr(args, "keep_sampling_mask", False):
+        sampling_logprobs = meta_info.get("output_token_sampling_logprobs")
+        if not isinstance(sampling_logprobs, list):
+            raise ValueError("SGLang response missing output_token_sampling_logprobs")
+        if len(sampling_logprobs) != len(response_tokens):
+            raise ValueError(
+                "SGLang output_token_sampling_logprobs length "
+                f"{len(sampling_logprobs)} != response token length {len(response_tokens)}"
+            )
+        if any(logprob is None for logprob in sampling_logprobs):
+            raise ValueError("SGLang response contained None output_token_sampling_logprobs")
+        return response_tokens, [float(logprob) for logprob in sampling_logprobs]
+
+    if output_token_logprobs:
+        return response_tokens, [float(item[0]) for item in output_token_logprobs]
+    return [], []
+
+
+def extract_response_sampling_masks(args, meta_info: dict, response_length: int) -> list[list[int]] | None:
+    if not getattr(args, "keep_sampling_mask", False):
+        return None
+
+    sampling_masks = meta_info.get("output_token_sampling_mask")
+    if not isinstance(sampling_masks, list):
+        raise ValueError("SGLang response missing output_token_sampling_mask")
+    if len(sampling_masks) != response_length:
+        raise ValueError(
+            "SGLang output_token_sampling_mask length "
+            f"{len(sampling_masks)} != response token length {response_length}"
+        )
+    if any(mask is None for mask in sampling_masks):
+        raise ValueError("SGLang response contained None output_token_sampling_mask")
+    return [[int(token_id) for token_id in mask] for mask in sampling_masks]
 
 
 async def update_sample_from_response(
@@ -68,11 +112,8 @@ async def update_sample_from_response(
     if (len(sample.response) == 0) and not sample.tokens:
         sample.tokens = payload["input_ids"]
 
-    if x := output["meta_info"].get("output_token_logprobs"):
-        new_response_tokens = [item[1] for item in x]
-        new_response_log_probs = [item[0] for item in x]
-    else:
-        new_response_tokens, new_response_log_probs = [], []
+    meta_info = output["meta_info"]
+    new_response_tokens, new_response_log_probs = extract_response_tokens_and_log_probs(args, meta_info)
 
     # Update sample with tokens directly - avoiding re-tokenization
     sample.tokens = sample.tokens + new_response_tokens
@@ -82,6 +123,11 @@ async def update_sample_from_response(
     if sample.rollout_log_probs is None:
         sample.rollout_log_probs = []
     sample.rollout_log_probs += new_response_log_probs
+    new_sampling_masks = extract_response_sampling_masks(args, meta_info, len(new_response_tokens))
+    if new_sampling_masks is not None:
+        if sample.rollout_sampling_masks is None:
+            sample.rollout_sampling_masks = []
+        sample.rollout_sampling_masks += new_sampling_masks
 
     if update_loss_mask:
         if sample.loss_mask is None:
@@ -93,7 +139,7 @@ async def update_sample_from_response(
     sample.rollout_indexer_topk = get_indexer_topk_from_response(args, output, sample)
 
     # TODO may unify (currently there are both methods inside Sample and separate functions)
-    sample.update_from_meta_info(args, output["meta_info"])
+    sample.update_from_meta_info(args, meta_info)
 
 
 def _decode_topk_buffer(info: str, num_tokens: int, num_layers: int, topk: int) -> np.ndarray:

--- a/miles/rollout/generate_utils/sample_utils.py
+++ b/miles/rollout/generate_utils/sample_utils.py
@@ -28,11 +28,16 @@ def _merge_sample_pair(a: Sample, b: Sample, tokenizer) -> Sample:
         assert x == y, f"{field} mismatch: a.{field}={x}, b.{field}={y}"
         return x
 
+    needs_sampling_masks = a.rollout_sampling_masks is not None or b.rollout_sampling_masks is not None
+
     def _fill_defaults(sample: Sample):
         if sample.loss_mask is None:
             sample.loss_mask = [1] * sample.response_length
         if sample.rollout_log_probs is None:
             sample.rollout_log_probs = [0.0] * sample.response_length
+        if needs_sampling_masks and sample.rollout_sampling_masks is None:
+            response_tokens = sample.tokens[-sample.response_length :] if sample.response_length else []
+            sample.rollout_sampling_masks = [[token_id] for token_id in response_tokens]
 
     def _merge_optional_per_token(field):
         # Optional OPD per-token lists (teacher_log_probs, opd_reverse_kl): merge like
@@ -118,6 +123,13 @@ def _merge_sample_pair(a: Sample, b: Sample, tokenizer) -> Sample:
             loss_mask=a.loss_mask + [0] * obs_len + b.loss_mask,
             weight_versions=a.weight_versions + b.weight_versions,
             rollout_log_probs=a.rollout_log_probs + [0.0] * obs_len + b.rollout_log_probs,
+            rollout_sampling_masks=(
+                a.rollout_sampling_masks
+                + [[token_id] for token_id in obs_tokens]
+                + b.rollout_sampling_masks
+            )
+            if needs_sampling_masks
+            else None,
             teacher_log_probs=_merge_optional_per_token("teacher_log_probs"),
             opd_reverse_kl=_merge_optional_per_token("opd_reverse_kl"),
             rollout_routed_experts=b.rollout_routed_experts,

--- a/miles/rollout/generate_utils/tool_call_utils.py
+++ b/miles/rollout/generate_utils/tool_call_utils.py
@@ -62,6 +62,8 @@ def update_sample_with_tool_responses(sample: Sample, tool_messages: list[dict[s
     sample.tokens += next_obs_tokens_ids
     sample.loss_mask += [0] * len(next_obs_tokens_ids)
     sample.rollout_log_probs += [0.0] * len(next_obs_tokens_ids)
+    if sample.rollout_sampling_masks is not None:
+        sample.rollout_sampling_masks += [[token_id] for token_id in next_obs_tokens_ids]
 
 
 # TODO: very naive implementation, need the to-be-implemented e2e test to validate.

--- a/miles/rollout/inference_rollout/inference_rollout_common.py
+++ b/miles/rollout/inference_rollout/inference_rollout_common.py
@@ -40,6 +40,7 @@ class GenerateState:
             temperature=args.rollout_temperature,
             top_p=args.rollout_top_p,
             top_k=args.rollout_top_k,
+            min_p=getattr(args, "rollout_min_p", 0.0),
             max_new_tokens=args.rollout_max_response_len,
         )
 
@@ -155,8 +156,9 @@ def compute_sampling_params(
     top_p,
     top_k,
     max_new_tokens,
+    min_p: float | None = None,
 ):
-    return dict(
+    sampling_params = dict(
         temperature=temperature,
         top_p=top_p,
         top_k=top_k,
@@ -167,6 +169,9 @@ def compute_sampling_params(
         no_stop_trim=True,
         spaces_between_special_tokens=False,
     )
+    if min_p is not None:
+        sampling_params["min_p"] = min_p
+    return sampling_params
 
 
 class InferenceRolloutFn:

--- a/miles/rollout/sglang_rollout.py
+++ b/miles/rollout/sglang_rollout.py
@@ -31,7 +31,11 @@ from miles.utils.processing_utils import (
 )
 from miles.utils.types import Sample
 
-from .generate_utils.generate_endpoint_utils import get_indexer_topk_from_response
+from .generate_utils.generate_endpoint_utils import (
+    extract_response_sampling_masks,
+    extract_response_tokens_and_log_probs,
+    get_indexer_topk_from_response,
+)
 from .generate_utils.prefill_logprobs import recompute_samples_rollout_logprobs_via_prefill
 from .rm_hub import async_rm, batched_async_rm
 
@@ -79,6 +83,7 @@ class GenerateState(metaclass=SingletonMeta):
             temperature=args.rollout_temperature,
             top_p=args.rollout_top_p,
             top_k=args.rollout_top_k,
+            min_p=getattr(args, "rollout_min_p", 0.0),
             max_new_tokens=args.rollout_max_response_len,
             stop=args.rollout_stop,
             stop_token_ids=args.rollout_stop_token_ids,
@@ -179,6 +184,8 @@ async def generate(args: Namespace, sample: Sample, sampling_params: dict[str, A
         payload["return_routed_experts"] = True
     if getattr(args, "use_rollout_indexer_replay", False):
         payload["return_indexer_topk"] = True
+    if getattr(args, "keep_sampling_mask", False):
+        payload["return_sampling_mask"] = True
 
     if sample.multimodal_inputs and sample.multimodal_inputs["images"]:
         image_data = sample.multimodal_inputs["images"]
@@ -204,11 +211,8 @@ async def generate(args: Namespace, sample: Sample, sampling_params: dict[str, A
             sample.metadata.setdefault("opd_student_top_logprobs", [])
             sample.metadata["opd_student_top_logprobs"].extend(output_top_logprobs)
 
-    if "output_token_logprobs" in output["meta_info"]:
-        new_response_tokens = [item[1] for item in output["meta_info"]["output_token_logprobs"]]
-        new_response_log_probs = [item[0] for item in output["meta_info"]["output_token_logprobs"]]
-    else:
-        new_response_tokens, new_response_log_probs = [], []
+    meta_info = output["meta_info"]
+    new_response_tokens, new_response_log_probs = extract_response_tokens_and_log_probs(args, meta_info)
 
     # Update sample with tokens directly - avoiding re-tokenization
     sample.tokens = sample.tokens + new_response_tokens
@@ -223,20 +227,25 @@ async def generate(args: Namespace, sample: Sample, sampling_params: dict[str, A
     if sample.rollout_log_probs is None:
         sample.rollout_log_probs = []
     sample.rollout_log_probs += new_response_log_probs
+    new_sampling_masks = extract_response_sampling_masks(args, meta_info, len(new_response_tokens))
+    if new_sampling_masks is not None:
+        if sample.rollout_sampling_masks is None:
+            sample.rollout_sampling_masks = []
+        sample.rollout_sampling_masks += new_sampling_masks
 
-    if "routed_experts" in output["meta_info"]:
+    if "routed_experts" in meta_info:
         sample.rollout_routed_experts = np.frombuffer(
-            pybase64.b64decode(output["meta_info"]["routed_experts"].encode("ascii")),
+            pybase64.b64decode(meta_info["routed_experts"].encode("ascii")),
             dtype=np.int32,
         ).reshape(
             len(sample.tokens) - 1,
             args.num_layers,
             args.moe_router_topk,
         )
-    if "indexer_topk" in output["meta_info"]:
+    if "indexer_topk" in meta_info:
         sample.rollout_indexer_topk = get_indexer_topk_from_response(args, output, sample)
 
-    sample.update_from_meta_info(args, output["meta_info"])
+    sample.update_from_meta_info(args, meta_info)
 
     return sample
 

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -331,6 +331,21 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 "--rollout-top-k", type=int, default=-1, help="the top-k for the inference engine during rollout."
             )
             parser.add_argument(
+                "--rollout-min-p",
+                type=float,
+                default=0.0,
+                help="min-p sampling threshold for the inference engine during rollout. 0.0 disables.",
+            )
+            parser.add_argument(
+                "--keep-sampling-mask",
+                action="store_true",
+                default=False,
+                help=(
+                    "Ask SGLang to return the sparse top-k/top-p/min-p sampling support for each generated token "
+                    "and train against the same truncated distribution in Megatron."
+                ),
+            )
+            parser.add_argument(
                 "--rollout-max-context-len",
                 type=int,
                 default=None,
@@ -2211,6 +2226,23 @@ def miles_validate_args(args):
 
     if args.use_rollout_logprobs:
         assert not args.use_tis, "use_rollout_logprobs and use_tis cannot be set at the same time."
+
+    if getattr(args, "keep_sampling_mask", False):
+        assert getattr(args, "train_backend", None) != "fsdp", (
+            "--keep-sampling-mask is not supported with --train-backend fsdp; "
+            "the sampling-mask training path is only wired for the Megatron backend."
+        )
+        assert not getattr(args, "recompute_logprobs_via_prefill", False), (
+            "--keep-sampling-mask requires --recompute-logprobs-via-prefill to be off because "
+            "SGLang prefill logprobs are full-vocab logprobs, not sampling-mask-renormalized logprobs."
+        )
+        top_k = getattr(args, "rollout_top_k", -1)
+        min_p = getattr(args, "rollout_min_p", 0.0)
+        if args.rollout_top_p >= 1.0 and (top_k is None or top_k <= 0) and min_p <= 0.0:
+            raise ValueError(
+                "--keep-sampling-mask requires a truncating rollout sampler "
+                "(for example --rollout-top-p 0.99)."
+            )
 
     if args.get_mismatch_metrics:
         assert (

--- a/miles/utils/types.py
+++ b/miles/utils/types.py
@@ -25,6 +25,7 @@ class Sample:
     loss_mask: list[int] | None = None
     weight_versions: list[str] = field(default_factory=list)
     rollout_log_probs: list[float] | None = None  # Log probabilities from rollout engine
+    rollout_sampling_masks: list[list[int] | None] | None = None
     rollout_routed_experts: numpy.ndarray | None = (
         None  # Routed experts from rollout engine. shape: (num_tokens-1, num_layers, moe_router_topk), dtype=int32
     )
@@ -171,6 +172,11 @@ class Sample:
             assert (
                 len(self.rollout_log_probs) == self.response_length
             ), f"rollout_log_probs length ({len(self.rollout_log_probs)}) != response_length ({self.response_length})"
+        if self.rollout_sampling_masks is not None:
+            assert len(self.rollout_sampling_masks) == self.response_length, (
+                f"rollout_sampling_masks length ({len(self.rollout_sampling_masks)}) "
+                f"!= response_length ({self.response_length})"
+            )
         if self.teacher_log_probs is not None:
             assert (
                 len(self.teacher_log_probs) == self.response_length
@@ -199,6 +205,8 @@ class Sample:
         self.response_length -= n
         if self.rollout_log_probs is not None:
             self.rollout_log_probs = self.rollout_log_probs[:-n]
+        if self.rollout_sampling_masks is not None:
+            self.rollout_sampling_masks = self.rollout_sampling_masks[:-n]
         if self.teacher_log_probs is not None:
             self.teacher_log_probs = self.teacher_log_probs[:-n]
         if self.opd_reverse_kl is not None:
@@ -228,6 +236,7 @@ class Sample:
         self.loss_mask = None
         self.weight_versions = []
         self.rollout_log_probs = None
+        self.rollout_sampling_masks = None
         self.rollout_routed_experts = None
         self.rollout_indexer_topk = None
         self.status = Sample.Status.ABORTED
@@ -280,7 +289,15 @@ class ParamInfo:
 # A dict-based batch produced along the rollout -> training path
 # In Megatron backend, several fields are converted to torch.Tensor lists on GPU
 # before being consumed by data iterators (see megatron_utils.actor._get_rollout_data).
-RolloutBatch = dict[str, list[torch.Tensor] | list[int] | list[float] | list[str]]
+RolloutBatch = dict[
+    str,
+    list[torch.Tensor]
+    | list[int]
+    | list[float]
+    | list[str]
+    | list[list[int] | None]
+    | list[list[list[int] | None]],
+]
 
 
 @dataclass


### PR DESCRIPTION
@guapisolo this is our trainer-side changes for top-p replay (see sglang_rollout.py for how we provide the return_sampling_mask flag to sglang, and grab the returned masks). Since it was originally an internal feature, it may not be very polished style-wise (and I haven't invested much time doing extra polish here -- primarily hope it can be useful to you to contextualize the SGLang PR https://github.com/sgl-project/sglang/pull/27408). We are quite confident in its correctness as it is used in all our RL runs now. We have directly ablated the feature and have found that RL runs with rollout top-p < 1 and/or finite top-k rapidly collapse without applying the sampling masks in training, which is consistent with what DeepSeek V3.2 and MAI-Thinking-1 found. 

By applying the top-p rollout masks in training, no token outside the rollout masks receive gradient. The SLIME implementation probably does something similar, setting the tokens outside the rollouts masks to have -inf logit could also work. 

It's also good practice to use the renormalized rollouts logprobs in any downstream train-inference mismatch techniques.