### PR TITLE
feat(utils): allow custom loss mask module paths

### DIFF
--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -2,6 +2,7 @@ import argparse
 import json
 import logging
 import os
+import re
 from typing import Any
 
 import yaml
@@ -17,6 +18,18 @@ from miles.utils.logging_utils import configure_logger
 from miles.utils.misc import load_function
 
 logger = logging.getLogger(__name__)
+
+
+_LOSS_MASK_BUILTINS = {"qwen", "qwen3", "distill_qwen"}
+
+
+def _loss_mask_type(value: str) -> str:
+    """Validate --loss-mask-type values."""
+    if value in _LOSS_MASK_BUILTINS or re.fullmatch(r"[a-zA-Z_]\w*(\.[a-zA-Z_]\w*)+", value):
+        return value
+    raise argparse.ArgumentTypeError(
+        f"invalid loss_mask_type: {value!r}. Must be one of {sorted(_LOSS_MASK_BUILTINS)} or a dotted module path."
+    )
 
 
 def reset_arg(parser, name, **kwargs):
@@ -1639,10 +1652,10 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
             )
             parser.add_argument(
                 "--loss-mask-type",
-                type=str,
+                type=_loss_mask_type,
                 default="qwen",
-                choices=["qwen", "qwen3", "distill_qwen"],
-                help="Loss mask type",
+                help="Loss mask type. Built-in: qwen, qwen3, distill_qwen. "
+                "Custom: dotted module path (e.g. my_project.loss_masks.custom).",
             )
             parser.add_argument(
                 "--data-pad-size-multiplier",

--- a/tests/fast/utils/test_arguments.py
+++ b/tests/fast/utils/test_arguments.py
@@ -141,3 +141,22 @@ def test_recompute_logprobs_via_prefill_flag_is_parsed():
     args = parser.parse_args(["--recompute-logprobs-via-prefill"] + REQUIRED_ARGS)
 
     assert args.recompute_logprobs_via_prefill is True
+
+
+@pytest.mark.parametrize("loss_mask_type", ["qwen", "qwen3", "distill_qwen", "my_project.loss_masks.custom"])
+def test_loss_mask_type_accepts_builtins_and_module_paths(loss_mask_type: str) -> None:
+    parser = argparse.ArgumentParser()
+    get_miles_extra_args_provider()(parser)
+
+    args = parser.parse_args(["--loss-mask-type", loss_mask_type] + REQUIRED_ARGS)
+
+    assert args.loss_mask_type == loss_mask_type
+
+
+@pytest.mark.parametrize("loss_mask_type", ["custom_mask", ".foo", "foo.", "...", "foo..bar", "foo-bar.mask"])
+def test_loss_mask_type_rejects_invalid_values(loss_mask_type: str) -> None:
+    parser = argparse.ArgumentParser()
+    get_miles_extra_args_provider()(parser)
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--loss-mask-type", loss_mask_type] + REQUIRED_ARGS)


### PR DESCRIPTION
## Summary

- Allow --loss-mask-type to accept existing built-in names or a dotted module path.
- Validate dotted module paths during argument parsing so malformed values fail early.

## Why

This lets users plug in custom loss mask implementations without adding each implementation name to the argument parser.

## Validation

- python -m py_compile miles/utils/arguments.py tests/fast/utils/test_arguments.py
- ruff check miles/utils/arguments.py tests/fast/utils/test_arguments.py
- git diff --check
- isolated argparse validation for accepted built-ins, accepted module paths, and rejected malformed values

## Local notes

- pytest tests/fast/utils/test_arguments.py -q was blocked locally during test setup by a dependency mismatch in the local environment.
- pre-commit run --files miles/utils/arguments.py tests/fast/utils/test_arguments.py passed through ruff, autoflake, and isort; the Black hook did not complete locally.