### PR TITLE
(1/4) feat(ci): metric-history gate foundation — storage contract + collection backend (M0+M1)

### DIFF
--- a/docs/ci/03-metric-history-gate.md
+++ b/docs/ci/03-metric-history-gate.md
@@ -1,44 +1,61 @@
 ---
-
-## title: Metric history & regression gate
-description: How CI keeps per-test training metrics across runs, runs a two-layer gate against that history, and how to add a gate spec or clean a bad data point.
+title: Metric history & regression gate
+description: How CI keeps per-test training metrics across runs, runs a historical gate against that history, and how to add a gate spec or clean a bad data point.
+---
 
 # Metric history & regression gate
 
-CI keeps each test's per-metric numbers from every run in our own store and runs a two-layer gate against that history — catching the slow drift that fixed `--ci-<metric>` thresholds miss. wandb stays a write-only sink; the gate never reads from it. The baseline lives in our DB.
+CI keeps each test's per-metric numbers from every run in our own store and runs a historical gate against that history — catching the slow drift a single run cannot see. wandb stays a write-only sink; the gate never reads from it. The baseline lives in our DB.
 
 ## Identity: what shares a baseline
 
+**Goal:** pin down exactly which past values a new number may be compared against — same test, same metric, same rule, same point — so baselines never mix across meanings.
+
 The gate compares a number only against earlier numbers of the same kind, from the same test. Two keys decide that:
 
-- **Run series** (the "same test"): `(test_path, backend, suite, test_file_hash)`. `test_file_hash` = sha256 of the test file's **contents**, so editing the test starts a fresh series. Runs differing on any field never share a baseline.
-- **Value within a run**: `(metric_key, steps_key, constraint_key, step)` — the declaring gate's literal content plus which point:
-  - `steps_key` / `constraint_key` are canonical JSON of the declaration's raw `steps` / `constraint` literals. The key is built from what the author wrote — never a normalized form — so a code-side default change can never silently re-key a series; any edit to the declaration already resets the series via `test_file_hash`.
+- **Run series** (the "same test"): `(test_path, backend, suite)`. Runs differing on any field never share a baseline. A test-file edit does not reset the series (see Notes).
+- **Value within a run**: `(metric_key, steps_key, constraint_key, step)` — the declaring gate's literal content plus which point. `steps_key` and `step` are not redundant: a fanned-out declaration (`steps=[0, 1]` / `steps="all"`) produces several values in one run — one per selected step — and each must be judged only against its own step's history, so the literals identify the spec while `step` identifies the point:
+  - `steps_key` / `constraint_key` are canonical JSON of the declaration's raw `steps` / `constraint` literals: no whitespace, dict keys sorted, list order kept as written, a string keyword stored with its JSON quotes — `steps=[0, 1]` → `[0,1]`, `steps="last"` → `"last"` (quotes included). Built from the raw literal, never the normalized form, so a code-side default change can never silently re-key a series; editing the declaration's literals changes these keys, so a declaration edit starts a fresh coordinate history by construction.
   - `step` is the point the value came from: step `k` for a per-step value, `-1` for a whole-series reduction (e.g. `steps="last"`) — a reduced value keys on a constant, never the step it happened to land on, or its history would fragment across runs of different lengths.
   - Step-0 `ppo_kl` is compared only against past step-0 `ppo_kl` — never against step 1 or `grad_norm`.
 
-The store's baseline query keys on exactly these (plus a `limit` for how many recent points to read): `recent_trusted_values(test_path, backend, suite, metric_key, steps_key, constraint_key, step, test_file_hash, limit)`.
+The store's baseline query keys on exactly these (plus a `limit` for how many recent points to read): `recent_trusted_values(test_path, backend, suite, metric_key, steps_key, constraint_key, step, limit)`.
 
-## The gate: two layers
+## The gate: drift against trusted history
 
-After a test passes, each comparison coordinate's value is checked with `|cur - ref| > max(rel * |ref|, abs_floor)` (`rel` default `0.20`; `abs_floor` only matters for metrics near zero, e.g. step-0 `ppo_kl`).
+**Goal:** judge every declared coordinate against its own trusted past, so slow drift gets caught while a fresh baseline can seed itself.
 
-- **Hard gate** — always on. `ref` = a hardcoded safety limit. Runs even with zero history; generalizes today's `--ci-<metric>` thresholds.
-- **Historical gate** — activates with ≥1 trusted point in the series. `ref` = mean of the series' trusted runs. Catches drift.
-- **Cold start** (0 trusted): historical gate is inactive, hard gate only — not an error.
+After a test passes, each comparison coordinate's value is judged by its spec's constraint against the coordinate's own history:
+
+- **Historical gate** — activates with ≥1 trusted point at the coordinate. `ref` = mean of the coordinate's trusted values. Catches drift.
+- **Cold start** (0 trusted): the gate is inactive — not an error. Zero active checks means the run is vacuously trusted: that is how a fresh baseline gets seeded (recover a poisoned seed via `mark_untrusted`).
 
 ## Storage: two backends, two tables
 
-- Backends: `SQLiteMetricHistoryStore` is the local/offline backend for unit tests and in-process development; `NeonMetricHistoryStore` is the hosted Postgres backend for CI/prod. Callers use only `MetricHistoryStore`: for the same inputs, both backends must persist the same run and metric fields, return the same trusted baseline rows in newest-first order, and revoke trust for the same runs via `mark_untrusted`.
-- `write_run(...)` stores one CI run, its identity/provenance, its run-level `trusted` flag, and all metric values from that run. It rejects (raises on) non-finite metric values before persisting anything: the DB is the write boundary where validity is enforced, so `NaN` / `±Inf` never enter a baseline — upstream they are gate-side ERROR evidence, not storable measurements.
-- `recent_trusted_values(...)` returns the newest trusted values for one exact run series and one exact metric coordinate; this is the historical-gate baseline read.
-- `mark_untrusted(...)` flips matching runs to `trusted = false` by `run_id`, `github_run_id`, or `commit_sha`, so the next baseline read excludes those runs without deleting rows.
+**Goal:** persist runs and metric values behind one `MetricHistoryStore` contract so gate code stays backend-agnostic (SQLite offline, Neon in CI), with the write boundary guaranteeing only finite values ever enter a baseline.
+
+**Backends** — one `MetricHistoryStore` contract, two implementations; callers see only the contract, and for the same inputs both backends must persist the same run and metric fields, return the same trusted baseline rows in newest-first order, and revoke trust for the same runs:
+
+- `SQLiteMetricHistoryStore` — the local/offline backend, for unit tests and in-process development.
+- `NeonMetricHistoryStore` — the hosted Postgres backend, for CI/prod.
+
+**Store API** — the whole contract is three calls:
+
+- `write_run(...)` — persists one CI run: its identity/provenance, its run-level `trusted` flag, and all metric values from that run. It rejects (raises on) non-finite metric values before persisting anything: the DB is the write boundary where validity is enforced, so `NaN` / `±Inf` never enter a baseline — upstream they are gate-side ERROR evidence, not storable measurements.
+- `recent_trusted_values(...)` — the historical-gate baseline read: the newest trusted values for one exact run series and one exact value coordinate.
+- `mark_untrusted(...)` — flips matching runs to `trusted = false` by `run_id`, `github_run_id`, or `commit_sha`, so the next baseline read excludes those runs without deleting rows.
+
+**Tables & read path**:
+
 - `runs` — one row per CI run of one series: the identity above + provenance (`commit_sha`, `pr_number`, `github_run_id`, `github_run_attempt`, `event_name`, `ref`) + `created_at` + `trusted` (run-level).
 - `metric_values` — one row per value: `run_id` FK + `(metric_key, steps_key, constraint_key, step)` + `value`.
-- Read path: composite index `runs(test_path, backend, suite, test_file_hash, trusted, created_at DESC)`.
-- Hosted Postgres setup is out-of-band in this round: when `NeonMetricHistoryStore` is implemented, provision the equivalent two tables and application role outside this repo, and keep runtime gate code DML-only. Old-row cleanup policy is a later operational concern, not part of the M0/M1 substrate.
+- The baseline read is served by the composite index `runs(test_path, backend, suite, trusted, created_at DESC)`.
+
+**Operations** — hosted Postgres setup is out-of-band in this round: when `NeonMetricHistoryStore` is implemented, provision the equivalent two tables and application role outside this repo, and keep runtime gate code DML-only. Old-row cleanup policy is a later operational concern, not part of the M0/M1 substrate.
 
 ## Trust, cleanup, who writes
+
+**Goal:** keep the baseline self-protecting — only nightly-marked runs (with recorded provenance) write at all, a nightly run whose metrics fail the gate is still persisted but flagged `trusted = false` so it never enters the baseline, and a point later found bad is revoked by one flag flip instead of deletion.
 
 - A run is `trusted` iff it passed **all** active gates. A drifting run is still recorded, with `trusted = false`, so it can't drag the baseline. A test that fails then passes on **retry** is gated on its passing attempt's metrics and trusted normally — needing a retry is not itself a trust penalty.
 - **Clean a bad point**: `mark_untrusted` = `UPDATE runs SET trusted = false` on the run. The next gate read excludes it immediately — no rebaseline, no row deletion.
@@ -52,25 +69,14 @@ Capture is runtime behavior inside the training process, so it never blocks the 
 
 ## Rollout
 
+**Goal:** land the gate observe-only first, so it accumulates history and proves its verdicts on real runs before any PR can be blocked; enforcement is a later, reversible switch.
+
 Shadow-first: collect, store, and evaluate, but **never block a PR** initially — a historical-gate failure lands as an untrusted row and is surfaced, not enforced. Enforcement arrives later behind a per-test **allowlist** + a global **kill-switch**.
-
-## Map: files & knobs
-
-
-| Thing                    | Where                                                                                  |
-| ------------------------ | -------------------------------------------------------------------------------------- |
-| Enable capture           | set `MILES_CI_GATE_RECORD_DIR` (injected by the CI harness; no CLI flag)               |
-| DB connection            | `NEON_DATABASE_URL` (CI secret)                                                        |
-| Storage contract         | `tests/ci/metric_history/storage/store.py` (+ `storage/sqlite_store.py` offline, `storage/neon_store.py` prod) |
-| Gate logic               | `tests/ci/history_gate.py`                                                             |
-| Collection backend       | `miles/utils/tracking_utils/ci_history.py`                                             |
-| Declare a gate on a test | `register_ci_gate(...)` in the test file                                               |
-
-
-
 
 ## Notes
 
-- Any test-file edit is an intentional baseline reset for that series (the hash changes).
+**Goal:** record accepted caveats and open questions beside the behavior they qualify; planned-but-unimplemented work lives in TODO below.
+
+- A test-file edit does not reset the series: `test_file_hash` was dropped from the run-series identity because a tiny edit to a test kept wiping its whole history. A test change that genuinely shifts a metric's expected level surfaces as gate failures instead; the reset levers are manual — `mark_untrusted` the stale runs, or edit the declaration literals (new `steps_key` / `constraint_key` ⇒ fresh coordinate).
 - The nightly trigger (`schedule` cron + `nightly` label) already shipped (#1491); detection here is harness-side via `GITHUB_EVENT_NAME`, so this feature needs **no** `pr-test.yml` **edit**.
-- Open: should a brand-new test's first baselines need human confirmation before counting as trusted? (v1: no.) Per-series `rel` / `abs_floor` overrides beyond the global defaults.
+- Open: should a brand-new test's first baselines need human confirmation before counting as trusted? (v1: no.)

--- a/docs/ci/03-metric-history-gate.md
+++ b/docs/ci/03-metric-history-gate.md
@@ -1,0 +1,76 @@
+---
+
+## title: Metric history & regression gate
+description: How CI keeps per-test training metrics across runs, runs a two-layer gate against that history, and how to add a gate spec or clean a bad data point.
+
+# Metric history & regression gate
+
+CI keeps each test's per-metric numbers from every run in our own store and runs a two-layer gate against that history — catching the slow drift that fixed `--ci-<metric>` thresholds miss. wandb stays a write-only sink; the gate never reads from it. The baseline lives in our DB.
+
+## Identity: what shares a baseline
+
+The gate compares a number only against earlier numbers of the same kind, from the same test. Two keys decide that:
+
+- **Run series** (the "same test"): `(test_path, backend, suite, test_file_hash)`. `test_file_hash` = sha256 of the test file's **contents**, so editing the test starts a fresh series. Runs differing on any field never share a baseline.
+- **Value within a run**: `(metric_key, steps_key, constraint_key, step)` — the declaring gate's literal content plus which point:
+  - `steps_key` / `constraint_key` are canonical JSON of the declaration's raw `steps` / `constraint` literals. The key is built from what the author wrote — never a normalized form — so a code-side default change can never silently re-key a series; any edit to the declaration already resets the series via `test_file_hash`.
+  - `step` is the point the value came from: step `k` for a per-step value, `-1` for a whole-series reduction (e.g. `steps="last"`) — a reduced value keys on a constant, never the step it happened to land on, or its history would fragment across runs of different lengths.
+  - Step-0 `ppo_kl` is compared only against past step-0 `ppo_kl` — never against step 1 or `grad_norm`.
+
+The store's baseline query keys on exactly these (plus a `limit` for how many recent points to read): `recent_trusted_values(test_path, backend, suite, metric_key, steps_key, constraint_key, step, test_file_hash, limit)`.
+
+## The gate: two layers
+
+After a test passes, each comparison coordinate's value is checked with `|cur - ref| > max(rel * |ref|, abs_floor)` (`rel` default `0.20`; `abs_floor` only matters for metrics near zero, e.g. step-0 `ppo_kl`).
+
+- **Hard gate** — always on. `ref` = a hardcoded safety limit. Runs even with zero history; generalizes today's `--ci-<metric>` thresholds.
+- **Historical gate** — activates with ≥1 trusted point in the series. `ref` = mean of the series' trusted runs. Catches drift.
+- **Cold start** (0 trusted): historical gate is inactive, hard gate only — not an error.
+
+## Storage: two backends, two tables
+
+- Backends: `SQLiteMetricHistoryStore` is the local/offline backend for unit tests and in-process development; `NeonMetricHistoryStore` is the hosted Postgres backend for CI/prod. Callers use only `MetricHistoryStore`: for the same inputs, both backends must persist the same run and metric fields, return the same trusted baseline rows in newest-first order, and revoke trust for the same runs via `mark_untrusted`.
+- `write_run(...)` stores one CI run, its identity/provenance, its run-level `trusted` flag, and all metric values from that run. It rejects (raises on) non-finite metric values before persisting anything: the DB is the write boundary where validity is enforced, so `NaN` / `±Inf` never enter a baseline — upstream they are gate-side ERROR evidence, not storable measurements.
+- `recent_trusted_values(...)` returns the newest trusted values for one exact run series and one exact metric coordinate; this is the historical-gate baseline read.
+- `mark_untrusted(...)` flips matching runs to `trusted = false` by `run_id`, `github_run_id`, or `commit_sha`, so the next baseline read excludes those runs without deleting rows.
+- `runs` — one row per CI run of one series: the identity above + provenance (`commit_sha`, `pr_number`, `github_run_id`, `github_run_attempt`, `event_name`, `ref`) + `created_at` + `trusted` (run-level).
+- `metric_values` — one row per value: `run_id` FK + `(metric_key, steps_key, constraint_key, step)` + `value`.
+- Read path: composite index `runs(test_path, backend, suite, test_file_hash, trusted, created_at DESC)`.
+- Hosted Postgres setup is out-of-band in this round: when `NeonMetricHistoryStore` is implemented, provision the equivalent two tables and application role outside this repo, and keep runtime gate code DML-only. Old-row cleanup policy is a later operational concern, not part of the M0/M1 substrate.
+
+## Trust, cleanup, who writes
+
+- A run is `trusted` iff it passed **all** active gates. A drifting run is still recorded, with `trusted = false`, so it can't drag the baseline. A test that fails then passes on **retry** is gated on its passing attempt's metrics and trusted normally — needing a retry is not itself a trust penalty.
+- **Clean a bad point**: `mark_untrusted` = `UPDATE runs SET trusted = false` on the run. The next gate read excludes it immediately — no rebaseline, no row deletion.
+- **Nightly-marked runs write baselines** — either the `schedule` cron (on `main`, post-merge) **or** a PR carrying the `nightly` label (the PR's own pre-merge code). Provenance (`event_name`, `pr_number`) records which, so a label-PR baseline is distinguishable from a post-merge one and can be `mark_untrusted`'d if it turns out bad. Ordinary (unlabeled) PR runs are read-only and only shadow.
+
+## Collection
+
+`CiHistoryBackend` runs alongside `WandbBackend` on the same `log()` fan-out and writes JSONL snapshots under the harness-assigned per-test attempt directory. After the test passes, the later gate/finalizer consumes those records, assigns identity + provenance, runs the gate, and (on a nightly-marked run only) writes the rows. Nothing is read back from wandb.
+
+Capture is runtime behavior inside the training process, so it never blocks the run on metric *content*: a non-finite value (`NaN` / `±Inf`) is real evidence of the run and is recorded faithfully, encoded in the JSONL as the string marker `"NaN"` / `"Infinity"` / `"-Infinity"` so every line stays strict JSON (the gate-side reader decodes markers back to floats). Judging non-finite values is the gate's job, not the recorder's. A wrong *type* (non-int/float) is an authoring bug, not run evidence, and still fails loud at capture.
+
+## Rollout
+
+Shadow-first: collect, store, and evaluate, but **never block a PR** initially — a historical-gate failure lands as an untrusted row and is surfaced, not enforced. Enforcement arrives later behind a per-test **allowlist** + a global **kill-switch**.
+
+## Map: files & knobs
+
+
+| Thing                    | Where                                                                                  |
+| ------------------------ | -------------------------------------------------------------------------------------- |
+| Enable capture           | set `MILES_CI_GATE_RECORD_DIR` (injected by the CI harness; no CLI flag)               |
+| DB connection            | `NEON_DATABASE_URL` (CI secret)                                                        |
+| Storage contract         | `tests/ci/metric_history/storage/store.py` (+ `storage/sqlite_store.py` offline, `storage/neon_store.py` prod) |
+| Gate logic               | `tests/ci/history_gate.py`                                                             |
+| Collection backend       | `miles/utils/tracking_utils/ci_history.py`                                             |
+| Declare a gate on a test | `register_ci_gate(...)` in the test file                                               |
+
+
+
+
+## Notes
+
+- Any test-file edit is an intentional baseline reset for that series (the hash changes).
+- The nightly trigger (`schedule` cron + `nightly` label) already shipped (#1491); detection here is harness-side via `GITHUB_EVENT_NAME`, so this feature needs **no** `pr-test.yml` **edit**.
+- Open: should a brand-new test's first baselines need human confirmation before counting as trusted? (v1: no.) Per-series `rel` / `abs_floor` overrides beyond the global defaults.

--- a/miles/utils/tracking_utils/base.py
+++ b/miles/utils/tracking_utils/base.py
@@ -7,7 +7,8 @@ calls to every active backend.
 To add a new backend:
 --------------------
 1. Subclass :class:`TrackingBackend`.
-2. Register it in :data:`BACKEND_REGISTRY`.
+2. Add it to ``BACKEND_REGISTRY`` in ``tracking.py`` (not base --
+   importing a backend module into base would be circular).
 3. Add a corresponding ``--use-<name>`` CLI flag in ``arguments.py``.
 """
 
@@ -120,24 +121,15 @@ class PrometheusBackend(TrackingBackend):
         return
 
 
-# Registry that maps backend name → (class, args-flag attribute)
-
-BACKEND_REGISTRY: dict[str, tuple[type[TrackingBackend], str]] = {
-    "wandb": (WandbBackend, "use_wandb"),
-    "tensorboard": (TensorboardBackend, "use_tensorboard"),
-    "mlflow": (MlflowBackend, "use_mlflow"),
-    "prometheus": (PrometheusBackend, "use_prometheus"),
-}
-
-
 class TrackingManager:
     # Initializes and logs to every enabled backend; used internally by ``tracking_utils``.
 
-    def __init__(self) -> None:
+    def __init__(self, registry: dict[str, tuple[type[TrackingBackend], str]]) -> None:
         self._backends: list[TrackingBackend] = []
+        self._registry = registry
 
     def init(self, args, *, primary: bool = True, **kwargs) -> None:
-        for name, (cls, flag) in BACKEND_REGISTRY.items():
+        for name, (cls, flag) in self._registry.items():
             if getattr(args, flag, False):
                 logger.info("Initialising tracking backend: %s", name)
                 backend = cls()

--- a/miles/utils/tracking_utils/ci_history.py
+++ b/miles/utils/tracking_utils/ci_history.py
@@ -1,0 +1,137 @@
+"""CI metric-history collection backend.
+
+* Captures the fixed :data:`TARGET_METRIC_KEYS` whitelist of training/rollout
+  metrics from the live process into one JSONL record file; keys outside the
+  whitelist are never recorded.
+* Collection is on only when the harness sets :data:`RECORD_DIR_ENV`
+  (`MILES_CI_GATE_RECORD_DIR`); without it `init()` leaves the backend a
+  no-op.
+* The record is a pure process-to-harness handoff: raw unreduced
+  `{"metric": key, "series": [[step, value], ...]}` lines, no identity (no
+  test path), nothing read from wandb, nothing written to any cloud. Reduction
+  and gating happen in a later step that consumes these records.
+* Every `log()` atomically rewrites the whole file as a fresh snapshot (temp
+  file + rename), not an append; a process that never calls `finish()` still
+  leaves a complete record.
+* Each backend instance owns a distinct file keyed by pid + a fresh uuid, so
+  concurrent processes never clobber each other's records.
+
+Caveats:
+
+* Capture never blocks the run on metric content: non-finite values (NaN/±Inf)
+  are recorded faithfully, serialized as the string markers `"NaN"` /
+  `"Infinity"` / `"-Infinity"` so every line stays strict JSON (the
+  gate-side reader decodes them).
+* A non-numeric value (bool/str/...) at a whitelisted key raises `TypeError`
+  in the logging process -- an authoring error fails loudly instead of being
+  dropped.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+import os
+import threading
+import uuid
+from typing import Any
+
+from .base import TrackingBackend
+
+logger = logging.getLogger(__name__)
+
+# Metric keys captured for the history gate, plus the step key carried alongside
+# each. The training keys are logged from the Ray training actor with step_key
+# "train/step"; rollout/raw_reward is logged with step_key "rollout/step". Keys
+# are the actor (role="actor") form with no role prefix.
+TARGET_METRIC_KEYS: tuple[str, ...] = (
+    "train/grad_norm",
+    "train/ppo_kl",
+    "train/train_rollout_logprob_abs_diff",
+    "train/train_rollout_kl",
+    "rollout/raw_reward",
+)
+
+# Env var naming the directory the harness assigns for this run's records.
+RECORD_DIR_ENV = "MILES_CI_GATE_RECORD_DIR"
+
+
+def _encode_value(value: float) -> float | str:
+    # Bare NaN/Infinity from json.dumps is not strict JSON; markers keep the
+    # record parseable by any reader.
+    if math.isfinite(value):
+        return value
+    if math.isnan(value):
+        return "NaN"
+    return "Infinity" if value > 0 else "-Infinity"
+
+
+class CiHistoryBackend(TrackingBackend):
+    """Accumulate target metrics in-process and persist the raw series to disk.
+
+    Each initialized backend instance owns a distinct JSONL file keyed by a
+    fresh process-local id, so separate instances do not clobber each other.
+
+    Some logging processes may not call `finish()`, so every `log()` persists
+    a fresh snapshot of the full accumulated series. The file is the latest
+    snapshot regardless of whether `finish()` ever fires.
+    """
+
+    def __init__(self) -> None:
+        self._series: dict[str, list[tuple[int | None, float]]] = {}
+        self._lock = threading.Lock()
+        self._record_dir: str | None = None
+        self._record_path: str | None = None
+
+    def init(self, args, *, primary: bool = True, **kwargs) -> None:
+        record_dir = os.environ.get(RECORD_DIR_ENV)
+        if not record_dir:
+            # No harness-assigned directory: nothing to collect into. Leaving
+            # _record_dir None makes log()/finish() no-ops.
+            logger.info("%s not set; CI history collection disabled.", RECORD_DIR_ENV)
+            return
+        os.makedirs(record_dir, exist_ok=True)
+        self._record_dir = record_dir
+        process_id = f"{os.getpid()}-{uuid.uuid4().hex}"
+        self._record_path = os.path.join(record_dir, f"{process_id}.jsonl")
+
+    def log(self, metrics: dict[str, Any], step: int | None = None, **kwargs) -> None:
+        if self._record_dir is None:
+            return
+        with self._lock:
+            captured: list[tuple[str, float]] = []
+            for key in TARGET_METRIC_KEYS:
+                if key not in metrics:
+                    continue
+                value = metrics[key]
+                if not isinstance(value, (int, float)) or isinstance(value, bool):
+                    message = f"CI history metric {key!r} must be int or float, got {type(value).__name__}"
+                    logger.error("%s", message)
+                    raise TypeError(message)
+                captured.append((key, float(value)))
+            for key, value in captured:
+                self._series.setdefault(key, []).append((step, value))
+            if captured:
+                self._write_snapshot_locked()
+
+    def finish(self) -> None:
+        if self._record_dir is None:
+            return
+        with self._lock:
+            self._write_snapshot_locked()
+
+    def _write_snapshot_locked(self) -> None:
+        # Rewrite the whole record file with the current series. Writing to a
+        # temp file and renaming makes each snapshot atomic, so a concurrent reader
+        # never sees a half-written record.
+        assert self._record_path is not None
+        tmp_path = f"{self._record_path}.tmp"
+        with open(tmp_path, "w", encoding="utf-8") as f:
+            for key, points in self._series.items():
+                line = {
+                    "metric": key,
+                    "series": [[step, _encode_value(value)] for step, value in points],
+                }
+                f.write(json.dumps(line, allow_nan=False) + "\n")
+        os.replace(tmp_path, self._record_path)

--- a/miles/utils/tracking_utils/tracking.py
+++ b/miles/utils/tracking_utils/tracking.py
@@ -5,10 +5,23 @@ import torch
 from miles.utils.audit_utils.event_logger.logger import get_event_logger, is_event_logger_initialized
 from miles.utils.audit_utils.event_logger.models import MetricEvent
 
-from .base import TrackingManager
+from .base import MlflowBackend, PrometheusBackend, TensorboardBackend, TrackingBackend, TrackingManager, WandbBackend
+from .ci_history import CiHistoryBackend
+
+# The full registry lives here, not base.py: base must never import a backend
+# module (ci_history imports TrackingBackend from base -> circular). This
+# module is the tracking entry point and the one place that imports every
+# backend, so it owns the registry.
+BACKEND_REGISTRY: dict[str, tuple[type[TrackingBackend], str]] = {
+    "wandb": (WandbBackend, "use_wandb"),
+    "tensorboard": (TensorboardBackend, "use_tensorboard"),
+    "mlflow": (MlflowBackend, "use_mlflow"),
+    "prometheus": (PrometheusBackend, "use_prometheus"),
+    "ci_history": (CiHistoryBackend, "ci_enable_metrics_capture"),
+}
 
 logger = logging.getLogger(__name__)
-_manager = TrackingManager()
+_manager = TrackingManager(BACKEND_REGISTRY)
 
 
 def init_tracking(args, primary: bool = True, **kwargs):

--- a/tests/ci/ci_utils.py
+++ b/tests/ci/ci_utils.py
@@ -1,3 +1,4 @@
+import hashlib
 import logging
 import os
 import re
@@ -9,6 +10,21 @@ from collections.abc import Callable
 from dataclasses import dataclass
 
 from tests.ci.ci_register import CIRegistry
+
+# Env var the training process reads to find the per-attempt record directory; kept
+# in sync with miles.utils.tracking_utils.ci_history.RECORD_DIR_ENV.
+CI_GATE_RECORD_DIR_ENV = "MILES_CI_GATE_RECORD_DIR"
+
+
+def _sanitize_for_path(name: str) -> str:
+    return re.sub(r"[^A-Za-z0-9._-]", "_", name)
+
+
+def _attempt_record_dir(base_dir: str, filename: str, attempt: int) -> str:
+    """Per-test, per-attempt subdir for CI metric-history records."""
+    record_key = f"{_sanitize_for_path(filename)}-{hashlib.sha1(filename.encode()).hexdigest()[:10]}"
+    return os.path.join(base_dir, record_key, f"attempt-{attempt}")
+
 
 # Configure logger to output to stdout
 logging.basicConfig(level=logging.INFO, format="%(message)s")
@@ -200,12 +216,19 @@ def run_unittest_files(
         process = None
         output_lines = []
 
-        def run_one_file(filename, capture_output=False, _i=i, _estimated_time=estimated_time):
+        def run_one_file(filename, capture_output=False, record_dir=None, _i=i, _estimated_time=estimated_time):
             nonlocal process, output_lines
 
             full_path = os.path.join(os.getcwd(), filename)
             logger.info(f".\n.\nBegin ({_i}/{len(files) - 1}):\npython3 {full_path}\n.\n.\n")
             file_tic = time.perf_counter()
+
+            child_env = None
+            if record_dir is not None:
+                # Point the training process at this attempt's own record dir.
+                os.makedirs(record_dir, exist_ok=True)
+                child_env = os.environ.copy()
+                child_env[CI_GATE_RECORD_DIR_ENV] = record_dir
 
             if capture_output:
                 # Capture output for retry decision
@@ -216,6 +239,7 @@ def run_unittest_files(
                     text=True,
                     errors="ignore",
                     start_new_session=True,
+                    env=child_env,
                 )
                 output_lines = []
                 for line in process.stdout:
@@ -228,6 +252,7 @@ def run_unittest_files(
                     stdout=None,
                     stderr=None,
                     start_new_session=True,
+                    env=child_env,
                 )
                 process.wait()
 
@@ -255,12 +280,17 @@ def run_unittest_files(
             attempt_timeout_after: float | None = None
             attempt_elapsed: float = 0.0
 
+            gate_base_dir = os.environ.get(CI_GATE_RECORD_DIR_ENV)
+            attempt_record_dir = (
+                _attempt_record_dir(gate_base_dir, filename, current_attempt) if gate_base_dir else None
+            )
+
             try:
                 try:
                     ret_code = run_with_timeout(
                         run_one_file,
                         args=(filename,),
-                        kwargs={"capture_output": enable_retry},
+                        kwargs={"capture_output": enable_retry, "record_dir": attempt_record_dir},
                         timeout=effective_timeout,
                     )
                     attempt_elapsed = time.perf_counter() - attempt_tic

--- a/tests/ci/metric_history/__init__.py
+++ b/tests/ci/metric_history/__init__.py
@@ -1,0 +1,22 @@
+"""Metric-history storage layer for the CI regression gate.
+
+* One import surface for consumers, re-exporting the :class:`MetricHistoryStore`
+  contract and its record types (:class:`MetricSample`, :class:`RunIdentity`,
+  :class:`RunProvenance`).
+* The two backends: offline :class:`SQLiteMetricHistoryStore` and the deferred
+  :class:`NeonMetricHistoryStore` placeholder, plus :data:`NEON_DATABASE_URL_ENV`.
+"""
+
+from tests.ci.metric_history.storage.neon_store import NEON_DATABASE_URL_ENV, NeonMetricHistoryStore
+from tests.ci.metric_history.storage.sqlite_store import SQLiteMetricHistoryStore
+from tests.ci.metric_history.storage.store import MetricHistoryStore, MetricSample, RunIdentity, RunProvenance
+
+__all__ = [
+    "MetricHistoryStore",
+    "MetricSample",
+    "RunIdentity",
+    "RunProvenance",
+    "SQLiteMetricHistoryStore",
+    "NeonMetricHistoryStore",
+    "NEON_DATABASE_URL_ENV",
+]

--- a/tests/ci/metric_history/storage/__init__.py
+++ b/tests/ci/metric_history/storage/__init__.py
@@ -1,0 +1,22 @@
+"""Storage layer for the CI metric-history regression gate.
+
+* Re-exports the :class:`MetricHistoryStore` contract and its record types
+  (:class:`MetricSample`, :class:`RunIdentity`, :class:`RunProvenance`).
+* Re-exports the two backends -- offline :class:`SQLiteMetricHistoryStore` and
+  the deferred :class:`NeonMetricHistoryStore` placeholder -- plus
+  :data:`NEON_DATABASE_URL_ENV`.
+"""
+
+from tests.ci.metric_history.storage.neon_store import NEON_DATABASE_URL_ENV, NeonMetricHistoryStore
+from tests.ci.metric_history.storage.sqlite_store import SQLiteMetricHistoryStore
+from tests.ci.metric_history.storage.store import MetricHistoryStore, MetricSample, RunIdentity, RunProvenance
+
+__all__ = [
+    "MetricHistoryStore",
+    "MetricSample",
+    "RunIdentity",
+    "RunProvenance",
+    "SQLiteMetricHistoryStore",
+    "NeonMetricHistoryStore",
+    "NEON_DATABASE_URL_ENV",
+]

--- a/tests/ci/metric_history/storage/neon_store.py
+++ b/tests/ci/metric_history/storage/neon_store.py
@@ -1,0 +1,72 @@
+# doc-dev: docs/ci/03-metric-history-gate.md
+"""Deferred Neon (hosted Postgres) backend for the metric-history store.
+
+* An intentional placeholder: the hosted backend is not wired this round -- no
+  Postgres driver is added to `requirements.txt` and nothing here opens a
+  connection.
+* The class exists so the gate can name its production backend and so the
+  connection contract (the `NEON_DATABASE_URL` env var, provisioned
+  out-of-band) is documented in one place.
+
+Implementation notes for whoever lands the real driver:
+
+* Add a driver (`psycopg[binary]` or `asyncpg`) to `requirements.txt`
+  only when this is implemented -- not before.
+* Read the DSN from the `NEON_DATABASE_URL` environment variable. Do not
+  embed credentials and do not hardcode the host.
+* Provision the schema and connection role out-of-band for now. The store's
+  read/write path must remain DML-only: insert runs, read baselines, and mark
+  runs untrusted.
+* `recent_trusted_values` must use the authoritative baseline query verbatim
+  (plain equality on `metric_key` / `steps_key` / `constraint_key` / `step`), so
+  its results match
+  :class:`~tests.ci.metric_history.storage.sqlite_store.SQLiteMetricHistoryStore`.
+"""
+
+from __future__ import annotations
+
+from tests.ci.metric_history.storage.store import MetricHistoryStore, MetricSample, RunIdentity, RunProvenance
+
+#: Name of the environment variable carrying the Neon Postgres DSN. The value
+#: is provisioned out-of-band as a CI secret and is NOT wired into any workflow
+#: in this round.
+NEON_DATABASE_URL_ENV = "NEON_DATABASE_URL"
+
+_NOT_IMPLEMENTED = "NeonMetricHistoryStore is not implemented yet; use SQLiteMetricHistoryStore offline."
+
+
+class NeonMetricHistoryStore(MetricHistoryStore):
+    def __init__(self, dsn: str | None = None):
+        raise NotImplementedError(_NOT_IMPLEMENTED)
+
+    def write_run(
+        self,
+        identity: RunIdentity,
+        provenance: RunProvenance,
+        created_at: str,
+        trusted: bool,
+        values: list[MetricSample],
+    ) -> str:
+        raise NotImplementedError(_NOT_IMPLEMENTED)
+
+    def recent_trusted_values(
+        self,
+        test_path: str,
+        backend: str,
+        suite: str,
+        metric_key: str,
+        steps_key: str,
+        constraint_key: str,
+        step: int,
+        limit: int,
+    ) -> list[float]:
+        raise NotImplementedError(_NOT_IMPLEMENTED)
+
+    def mark_untrusted(
+        self,
+        *,
+        run_id: str | None = None,
+        github_run_id: int | None = None,
+        commit_sha: str | None = None,
+    ) -> int:
+        raise NotImplementedError(_NOT_IMPLEMENTED)

--- a/tests/ci/metric_history/storage/sqlite_store.py
+++ b/tests/ci/metric_history/storage/sqlite_store.py
@@ -1,0 +1,178 @@
+# doc-dev: docs/ci/03-metric-history-gate.md
+"""SQLite-backed :class:`MetricHistoryStore` for offline use and tests.
+
+* No network dependency; the store runs entirely in-process. An in-memory
+  database (`:memory:`) makes it a drop-in fixture for unit tests.
+* Query and write semantics mirror the hosted Postgres backend, so tests
+  exercising this implementation validate the contract the gate relies on in
+  production — including the authoritative baseline query's plain-equality
+  match on the `(metric_key, steps_key, constraint_key, step)` coordinate.
+* This module owns a small local schema literal for tests; production Postgres
+  setup is out-of-band until the hosted backend is implemented.
+* Schema is applied at construction (`apply_schema`), never on the
+  read/write path.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import uuid
+
+from tests.ci.metric_history.storage.store import (
+    MetricHistoryStore,
+    MetricSample,
+    RunIdentity,
+    RunProvenance,
+    validate_finite_values,
+)
+
+# The local/offline schema: the two tables and the composite baseline index.
+# SQLite stores the same logical columns with its dynamic typing.
+_SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS runs (
+    run_id              TEXT PRIMARY KEY,
+    test_path           TEXT NOT NULL,
+    backend             TEXT NOT NULL,
+    suite               TEXT NOT NULL,
+    commit_sha          TEXT NOT NULL,
+    pr_number           INTEGER,
+    github_run_id       INTEGER,
+    github_run_attempt  INTEGER,
+    event_name          TEXT,
+    ref                 TEXT,
+    created_at          TEXT NOT NULL,
+    trusted             INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS metric_values (
+    run_id          TEXT NOT NULL REFERENCES runs(run_id),
+    metric_key      TEXT NOT NULL,
+    steps_key       TEXT NOT NULL,
+    constraint_key  TEXT NOT NULL,
+    step            INTEGER NOT NULL,
+    value           REAL NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS runs_baseline_idx
+    ON runs (test_path, backend, suite, trusted, created_at DESC);
+"""
+
+# Mirrors the authoritative baseline query: every coordinate column is
+# NOT NULL, so the whole match is plain equality.
+_BASELINE_SQL = """
+SELECT mv.value
+FROM metric_values mv
+JOIN runs r USING (run_id)
+WHERE r.test_path = ?
+  AND r.backend = ?
+  AND r.suite = ?
+  AND mv.metric_key = ?
+  AND mv.steps_key = ?
+  AND mv.constraint_key = ?
+  AND mv.step = ?
+  AND r.trusted = 1
+ORDER BY r.created_at DESC
+LIMIT ?
+"""
+
+
+class SQLiteMetricHistoryStore(MetricHistoryStore):
+    def __init__(self, database: str = ":memory:"):
+        # check_same_thread is left at its default; the store is meant for the
+        # single-threaded CI gate process and the test suite.
+        self._conn = sqlite3.connect(database)
+        self._conn.execute("PRAGMA foreign_keys = ON")
+        self.apply_schema()
+
+    def apply_schema(self) -> None:
+        """Create the tables and index if absent.
+
+        This runs once at construction (or when a caller resets a database),
+        never on the read/write path. This method keeps the SQLite fixture
+        self-contained.
+        """
+        self._conn.executescript(_SCHEMA_SQL)
+        self._conn.commit()
+
+    def write_run(
+        self,
+        identity: RunIdentity,
+        provenance: RunProvenance,
+        created_at: str,
+        trusted: bool,
+        values: list[MetricSample],
+    ) -> str:
+        validate_finite_values(values)
+        run_id = uuid.uuid4().hex
+        with self._conn:
+            self._conn.execute(
+                """
+                INSERT INTO runs (
+                    run_id, test_path, backend, suite,
+                    commit_sha, pr_number, github_run_id, github_run_attempt,
+                    event_name, ref, created_at, trusted
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    run_id,
+                    identity.test_path,
+                    identity.backend,
+                    identity.suite,
+                    provenance.commit_sha,
+                    provenance.pr_number,
+                    provenance.github_run_id,
+                    provenance.github_run_attempt,
+                    provenance.event_name,
+                    provenance.ref,
+                    created_at,
+                    1 if trusted else 0,
+                ),
+            )
+            self._conn.executemany(
+                "INSERT INTO metric_values (run_id, metric_key, steps_key, constraint_key, step, value)"
+                " VALUES (?, ?, ?, ?, ?, ?)",
+                [(run_id, s.metric_key, s.steps_key, s.constraint_key, s.step, s.value) for s in values],
+            )
+        return run_id
+
+    def recent_trusted_values(
+        self,
+        test_path: str,
+        backend: str,
+        suite: str,
+        metric_key: str,
+        steps_key: str,
+        constraint_key: str,
+        step: int,
+        limit: int,
+    ) -> list[float]:
+        rows = self._conn.execute(
+            _BASELINE_SQL,
+            (test_path, backend, suite, metric_key, steps_key, constraint_key, step, limit),
+        ).fetchall()
+        return [row[0] for row in rows]
+
+    def mark_untrusted(
+        self,
+        *,
+        run_id: str | None = None,
+        github_run_id: int | None = None,
+        commit_sha: str | None = None,
+    ) -> int:
+        keys = {"run_id": run_id, "github_run_id": github_run_id, "commit_sha": commit_sha}
+        provided = {name: value for name, value in keys.items() if value is not None}
+        if len(provided) != 1:
+            raise ValueError(
+                "mark_untrusted requires exactly one of run_id / github_run_id / commit_sha; "
+                f"got {sorted(provided)}"
+            )
+        column, value = next(iter(provided.items()))
+        with self._conn:
+            cursor = self._conn.execute(
+                f"UPDATE runs SET trusted = 0 WHERE {column} = ? AND trusted = 1",
+                (value,),
+            )
+            return cursor.rowcount
+
+    def close(self) -> None:
+        self._conn.close()

--- a/tests/ci/metric_history/storage/store.py
+++ b/tests/ci/metric_history/storage/store.py
@@ -1,0 +1,153 @@
+# doc-dev: docs/ci/03-metric-history-gate.md
+"""Storage contract for the CI metric-history regression gate.
+
+* The gate compares a candidate run's metrics against a baseline assembled
+  from the most recent *trusted* runs that share the same test identity.
+* Two normalized tables back the contract. `runs` -- one row per CI
+  execution of a test, holding identity (test_path, backend, suite),
+  provenance (commit_sha, pr_number, github_run_id, github_run_attempt,
+  event_name, ref), the `created_at` timestamp, and the run-level
+  `trusted` flag.
+* `metric_values` -- one row per comparison-coordinate value a run produced:
+  `(metric_key, steps_key, constraint_key, step, value)`, keyed back to `runs`
+  by `run_id`.
+* `trusted` lives on the run, not on the metric: a run is trusted as a
+  whole or not at all, so revoking trust drops every metric the run
+  contributed in one operation.
+* This module defines that storage contract and nothing else: it does not
+  decide what counts as a regression, does not read the candidate run, and
+  does not talk to CI.
+"""
+
+from __future__ import annotations
+
+import abc
+import math
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class MetricSample:
+    """One comparison-coordinate value a run contributed.
+
+    The coordinate is the declaring gate's literal content plus the point:
+    `steps_key` / `constraint_key` are canonical JSON of the declaration's
+    raw `steps` / `constraint` literals; `step` is the point the value came
+    from -- step `k`, or `-1` for a whole-series reduction (e.g.
+    `steps="last"`), which must key on a constant rather than the step it
+    happened to land on, or its history would fragment across runs of
+    different lengths.
+    """
+
+    metric_key: str
+    steps_key: str
+    constraint_key: str
+    step: int
+    value: float
+
+
+@dataclass(frozen=True)
+class RunIdentity:
+    """The fields that decide whether two runs share a baseline.
+
+    A baseline query is scoped to an exact (test_path, backend, suite)
+    tuple, so any difference here isolates one test's history from
+    another's. A test-file edit does not reset the series.
+    """
+
+    test_path: str
+    backend: str
+    suite: str
+
+
+@dataclass(frozen=True)
+class RunProvenance:
+    """Where a run came from. Recorded for audit and for `mark_untrusted`
+    targeting; never used to assemble a baseline."""
+
+    commit_sha: str
+    pr_number: int | None
+    github_run_id: int | None
+    github_run_attempt: int | None
+    event_name: str | None
+    ref: str | None
+
+
+def validate_finite_values(values: list[MetricSample]) -> None:
+    """Reject non-finite sample values before a backend persists anything."""
+    for sample in values:
+        if not math.isfinite(sample.value):
+            raise ValueError(
+                f"non-finite metric value {sample.value!r} for {sample.metric_key!r} "
+                f"(step={sample.step}); non-finite values never enter the store"
+            )
+
+
+class MetricHistoryStore(abc.ABC):
+    """Abstract metric-history store.
+
+    Implementations persist runs and their metric values and answer the
+    baseline query. The query and write surface are deliberately narrow: the
+    gate logic depends only on this interface, so swapping the SQLite test
+    backend for a hosted Postgres backend changes no caller.
+    """
+
+    @abc.abstractmethod
+    def write_run(
+        self,
+        identity: RunIdentity,
+        provenance: RunProvenance,
+        created_at: str,
+        trusted: bool,
+        values: list[MetricSample],
+    ) -> str:
+        """Persist one run and its metric values; return the new `run_id`.
+
+        `created_at` is an ISO-8601 timestamp string (timestamptz on the
+        server). The store assigns and returns the `run_id`; callers do not
+        supply it.
+
+        Raises `ValueError` if any sample's value is non-finite (NaN/±Inf),
+        before anything is persisted: the store is the write boundary where
+        validity is enforced, so non-finite values never enter a baseline.
+        Implementations enforce this via :func:`validate_finite_values`.
+        """
+
+    @abc.abstractmethod
+    def recent_trusted_values(
+        self,
+        test_path: str,
+        backend: str,
+        suite: str,
+        metric_key: str,
+        steps_key: str,
+        constraint_key: str,
+        step: int,
+        limit: int,
+    ) -> list[float]:
+        """Return up to `limit` baseline values, newest run first.
+
+        Only trusted runs matching the exact identity tuple and the exact
+        value coordinate `(metric_key, steps_key, constraint_key, step)`
+        contribute. Every coordinate column is NOT NULL, so matching is plain
+        equality -- no NULL-equality semantics anywhere in the query.
+        """
+
+    @abc.abstractmethod
+    def mark_untrusted(
+        self,
+        *,
+        run_id: str | None = None,
+        github_run_id: int | None = None,
+        commit_sha: str | None = None,
+    ) -> int:
+        """Revoke trust on the runs matching exactly one of the given keys.
+
+        Returns the number of run rows whose `trusted` flag changed from true
+        to false. Already-untrusted matches do not count. Revocation takes
+        effect immediately for subsequent `recent_trusted_values` calls; no
+        rebaseline step is required.
+
+        Exactly one of `run_id` / `github_run_id` / `commit_sha` must be
+        provided.
+        """

--- a/tests/ci/test/test_ci_history.py
+++ b/tests/ci/test/test_ci_history.py
@@ -1,0 +1,245 @@
+"""Tests for the CI metric-history collection backend and harness handoff.
+
+Covers the record structure produced by `CiHistoryBackend` (target keys present,
+JSONL parseable, raw unreduced series) and the harness per-attempt record-dir
+handoff in `tests.ci.ci_utils`.
+"""
+
+import json
+import logging
+import os
+from pathlib import Path
+
+import pytest
+from tests.ci.ci_register import register_cpu_ci
+from tests.ci.ci_utils import TestFile, _attempt_record_dir, run_unittest_files
+
+from miles.utils.tracking_utils.ci_history import RECORD_DIR_ENV, TARGET_METRIC_KEYS, CiHistoryBackend
+
+register_cpu_ci(est_time=1, suite="stage-a-cpu", labels=[])
+
+
+def test_all_backends_registered():
+    # The full registry lives in tracking_utils/tracking.py (the entry point),
+    # not base.py (base must not back-import a backend -> circular). Guard
+    # against the silent-drop failure mode: if a registry entry is removed or an
+    # import is pruned, the backend vanishes with no error. Assert the full set.
+    from miles.utils.tracking_utils.tracking import BACKEND_REGISTRY
+
+    assert set(BACKEND_REGISTRY) == {"wandb", "tensorboard", "mlflow", "prometheus", "ci_history"}
+    cls, flag = BACKEND_REGISTRY["ci_history"]
+    assert cls is CiHistoryBackend
+    assert flag == "ci_enable_metrics_capture"
+
+
+def _read_jsonl(path):
+    with open(path, encoding="utf-8") as f:
+        return [json.loads(line) for line in f if line.strip()]
+
+
+def test_record_has_target_keys_and_is_parseable(tmp_path, monkeypatch):
+    monkeypatch.setenv(RECORD_DIR_ENV, str(tmp_path))
+    backend = CiHistoryBackend()
+    backend.init(object(), primary=False)
+
+    backend.log({"train/grad_norm": 1.5, "train/ppo_kl": 0.0, "train/step": 0}, step=0)
+    backend.log({"train/grad_norm": 2.5, "train/ppo_kl": 0.1, "train/step": 1}, step=1)
+    backend.log({"rollout/raw_reward": 0.3, "rollout/step": 0}, step=0)
+    backend.finish()
+
+    files = [f for f in os.listdir(tmp_path) if f.endswith(".jsonl")]
+    assert len(files) == 1, f"expected one record file, got {files}"
+
+    records = _read_jsonl(os.path.join(tmp_path, files[0]))
+    by_metric = {r["metric"]: r["series"] for r in records}
+
+    assert set(by_metric) == {"train/grad_norm", "train/ppo_kl", "rollout/raw_reward"}
+    # Raw series are preserved unreduced: both grad_norm points are present.
+    assert by_metric["train/grad_norm"] == [[0, 1.5], [1, 2.5]]
+    assert by_metric["train/ppo_kl"] == [[0, 0.0], [1, 0.1]]
+    assert by_metric["rollout/raw_reward"] == [[0, 0.3]]
+
+
+def test_only_target_keys_captured(tmp_path, monkeypatch):
+    monkeypatch.setenv(RECORD_DIR_ENV, str(tmp_path))
+    backend = CiHistoryBackend()
+    backend.init(object(), primary=False)
+
+    backend.log({"train/grad_norm": 1.0, "train/pg_loss": 9.0, "train/step": 0}, step=0)
+    backend.finish()
+
+    records = _read_jsonl(os.path.join(tmp_path, os.listdir(tmp_path)[0]))
+    metrics = {r["metric"] for r in records}
+    assert metrics == {"train/grad_norm"}
+    assert metrics <= set(TARGET_METRIC_KEYS)
+
+
+def test_non_numeric_target_metric_errors_without_partial_capture(tmp_path, monkeypatch, caplog):
+    monkeypatch.setenv(RECORD_DIR_ENV, str(tmp_path))
+    backend = CiHistoryBackend()
+    backend.init(object(), primary=False)
+
+    with caplog.at_level(logging.ERROR, logger="miles.utils.tracking_utils.ci_history"):
+        with pytest.raises(TypeError, match="train/ppo_kl"):
+            backend.log({"train/grad_norm": 1.0, "train/ppo_kl": [0.1], "train/step": 0}, step=0)
+
+    assert "CI history metric 'train/ppo_kl' must be int or float, got list" in caplog.text
+
+    backend.log({"train/grad_norm": 2.0, "train/step": 1}, step=1)
+    backend.finish()
+
+    records = _read_jsonl(os.path.join(tmp_path, os.listdir(tmp_path)[0]))
+    by_metric = {r["metric"]: r["series"] for r in records}
+    assert by_metric["train/grad_norm"] == [[1, 2.0]]
+
+
+def _reject_bare_constant(name):
+    raise AssertionError(f"bare {name} token in record; non-finite must be a string marker")
+
+
+def test_non_finite_values_recorded_as_strict_json_markers(tmp_path, monkeypatch):
+    monkeypatch.setenv(RECORD_DIR_ENV, str(tmp_path))
+    backend = CiHistoryBackend()
+    backend.init(object(), primary=False)
+
+    backend.log({"train/grad_norm": 1.5, "train/step": 0}, step=0)
+    backend.log({"train/grad_norm": float("nan"), "train/step": 1}, step=1)
+    backend.log({"train/ppo_kl": float("inf"), "train/step": 1}, step=1)
+    backend.log({"rollout/raw_reward": float("-inf"), "rollout/step": 0}, step=0)
+    backend.finish()
+
+    path = os.path.join(tmp_path, os.listdir(tmp_path)[0])
+    # Strict JSON: parse_constant fires only on bare NaN/Infinity tokens.
+    with open(path, encoding="utf-8") as f:
+        for line in f:
+            if line.strip():
+                json.loads(line, parse_constant=_reject_bare_constant)
+
+    by_metric = {r["metric"]: r["series"] for r in _read_jsonl(path)}
+    assert by_metric["train/grad_norm"] == [[0, 1.5], [1, "NaN"]]
+    assert by_metric["train/ppo_kl"] == [[1, "Infinity"]]
+    assert by_metric["rollout/raw_reward"] == [[0, "-Infinity"]]
+
+
+def test_record_carries_no_identity(tmp_path, monkeypatch):
+    monkeypatch.setenv(RECORD_DIR_ENV, str(tmp_path))
+    backend = CiHistoryBackend()
+    backend.init(object(), primary=False)
+    backend.log({"train/grad_norm": 1.0}, step=0)
+    backend.finish()
+
+    raw = open(os.path.join(tmp_path, os.listdir(tmp_path)[0]), encoding="utf-8").read()
+    for forbidden in ("test_path", "test_", ".py", "filename"):
+        assert forbidden not in raw, f"record leaked identity token {forbidden!r}: {raw}"
+
+
+def test_disabled_when_env_unset(tmp_path, monkeypatch):
+    monkeypatch.delenv(RECORD_DIR_ENV, raising=False)
+    backend = CiHistoryBackend()
+    backend.init(object(), primary=False)
+    backend.log({"train/grad_norm": 1.0}, step=0)
+    backend.finish()
+    # No directory env => nothing written anywhere under tmp_path.
+    assert not list(tmp_path.iterdir())
+
+
+def test_flush_survives_without_finish(tmp_path, monkeypatch):
+    # Actor processes never call finish(); each log() must persist a snapshot.
+    monkeypatch.setenv(RECORD_DIR_ENV, str(tmp_path))
+    backend = CiHistoryBackend()
+    backend.init(object(), primary=False)
+    backend.log({"train/grad_norm": 1.0, "train/step": 0}, step=0)
+    backend.log({"train/grad_norm": 2.0, "train/step": 1}, step=1)
+    # Deliberately no finish().
+
+    records = _read_jsonl(os.path.join(tmp_path, os.listdir(tmp_path)[0]))
+    by_metric = {r["metric"]: r["series"] for r in records}
+    assert by_metric["train/grad_norm"] == [[0, 1.0], [1, 2.0]]
+
+
+def test_distinct_backend_instances_do_not_clobber_current_record_files(tmp_path, monkeypatch):
+    # This covers the backend's current file naming detail, not a CI harness
+    # contract to merge multiple writer outputs.
+    monkeypatch.setenv(RECORD_DIR_ENV, str(tmp_path))
+    b1 = CiHistoryBackend()
+    b1.init(object(), primary=False)
+    b2 = CiHistoryBackend()
+    b2.init(object(), primary=False)
+
+    b1.log({"train/grad_norm": 1.0}, step=0)
+    b2.log({"rollout/raw_reward": 0.5}, step=0)
+    b1.finish()
+    b2.finish()
+
+    files = [f for f in os.listdir(tmp_path) if f.endswith(".jsonl")]
+    assert len(files) == 2, f"expected one file per backend instance, got {files}"
+
+
+def test_attempt_isolation(tmp_path):
+    base = str(tmp_path)
+    filename = "nested dir/test bar.py"
+
+    d1 = _attempt_record_dir(base, filename, attempt=1)
+    d2 = _attempt_record_dir(base, filename, attempt=2)
+    assert d1 != d2, "attempts must not share a record directory"
+    assert os.path.dirname(d1) == os.path.dirname(d2)
+    assert os.path.basename(os.path.dirname(d1)).startswith("nested_dir_test_bar.py-")
+    assert d1.endswith(os.path.join("attempt-1"))
+    assert d2.endswith(os.path.join("attempt-2"))
+
+
+def test_attempt_record_dir_disambiguates_test_filenames(tmp_path):
+    base = str(tmp_path)
+
+    same_basename_a = _attempt_record_dir(base, "suite_a/test_a.py", attempt=1)
+    same_basename_b = _attempt_record_dir(base, "suite_b/test_a.py", attempt=1)
+    assert same_basename_a != same_basename_b
+
+    sanitized_collision_a = _attempt_record_dir(base, "foo/bar.py", attempt=1)
+    sanitized_collision_b = _attempt_record_dir(base, "foo_bar.py", attempt=1)
+    assert os.path.basename(os.path.dirname(sanitized_collision_a)).startswith("foo_bar.py-")
+    assert os.path.basename(os.path.dirname(sanitized_collision_b)).startswith("foo_bar.py-")
+    assert sanitized_collision_a != sanitized_collision_b
+
+
+def test_run_unittest_files_hands_off_attempt_record_dir(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    record_base = tmp_path / "records"
+    monkeypatch.setenv(RECORD_DIR_ENV, str(record_base))
+
+    state_file = tmp_path / "retry_state.txt"
+    child = tmp_path / "t retry.py"
+    child.write_text(
+        f"""
+import os
+import pathlib
+import sys
+
+record_dir = os.environ[{RECORD_DIR_ENV!r}]
+pathlib.Path(record_dir).mkdir(parents=True, exist_ok=True)
+pathlib.Path(record_dir, "seen.txt").write_text(record_dir)
+
+state_file = {str(state_file)!r}
+if os.path.exists(state_file):
+    sys.exit(0)
+
+pathlib.Path(state_file).write_text("1")
+print("accuracy retry", flush=True)
+sys.exit(1)
+"""
+    )
+
+    rc = run_unittest_files(
+        [TestFile(name=child.name, estimated_time=1)],
+        timeout_per_file=10,
+        enable_retry=True,
+        max_attempts=2,
+        retry_wait_seconds=0,
+    )
+
+    assert rc == 0
+    attempt_1 = Path(_attempt_record_dir(str(record_base), child.name, attempt=1))
+    attempt_2 = Path(_attempt_record_dir(str(record_base), child.name, attempt=2))
+    assert (attempt_1 / "seen.txt").read_text() == str(attempt_1)
+    assert (attempt_2 / "seen.txt").read_text() == str(attempt_2)
+    assert not list(record_base.glob("**/*.merged.jsonl"))

--- a/tests/ci/test/test_metric_history_store.py
+++ b/tests/ci/test/test_metric_history_store.py
@@ -1,0 +1,249 @@
+"""Offline unit tests for the metric-history store contract.
+
+These run against :class:`SQLiteMetricHistoryStore` with an in-memory database:
+no network, no driver install, no live Postgres. The SQLite backend mirrors the
+authoritative baseline query, so passing here means the contract the gate
+depends on holds.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+from tests.ci.ci_register import register_cpu_ci
+from tests.ci.metric_history import (
+    MetricSample,
+    NeonMetricHistoryStore,
+    RunIdentity,
+    RunProvenance,
+    SQLiteMetricHistoryStore,
+)
+
+register_cpu_ci(est_time=1, suite="stage-a-cpu", labels=[])
+
+IDENTITY = RunIdentity(
+    test_path="tests/e2e/test_grpo.py",
+    backend="megatron",
+    suite="stage-c-8-gpu-h100",
+)
+
+PROVENANCE = RunProvenance(
+    commit_sha="deadbeef",
+    pr_number=42,
+    github_run_id=1001,
+    github_run_attempt=1,
+    event_name="pull_request",
+    ref="refs/pull/42/merge",
+)
+
+# Canonical-JSON declaration keys, as the parser would derive them from a
+# test file's literal steps / constraint values.
+LAST_STEPS_KEY = '"last"'
+STEP_LIST_KEY = "[0,1]"
+REL_CONSTRAINT_KEY = '{"rel":0.2}'
+ABS_CONSTRAINT_KEY = '{"abs_floor":0.02}'
+
+
+def _sample(metric_key, value, *, steps_key=LAST_STEPS_KEY, constraint_key=REL_CONSTRAINT_KEY, step=-1):
+    return MetricSample(metric_key, steps_key, constraint_key, step, value)
+
+
+def _recent(
+    store,
+    metric_key,
+    *,
+    steps_key=LAST_STEPS_KEY,
+    constraint_key=REL_CONSTRAINT_KEY,
+    step=-1,
+    identity=IDENTITY,
+    limit=10,
+):
+    return store.recent_trusted_values(
+        identity.test_path,
+        identity.backend,
+        identity.suite,
+        metric_key,
+        steps_key,
+        constraint_key,
+        step,
+        limit,
+    )
+
+
+@pytest.fixture
+def store():
+    s = SQLiteMetricHistoryStore(":memory:")
+    yield s
+    s.close()
+
+
+def _write(
+    store,
+    *,
+    identity=IDENTITY,
+    provenance=PROVENANCE,
+    created_at,
+    trusted=True,
+    values,
+):
+    return store.write_run(identity, provenance, created_at, trusted, values)
+
+
+def test_write_then_recent_returns_written_values(store):
+    _write(
+        store,
+        created_at="2026-06-01T00:00:00+00:00",
+        values=[_sample("reward_mean", 0.81)],
+    )
+    _write(
+        store,
+        created_at="2026-06-02T00:00:00+00:00",
+        values=[_sample("reward_mean", 0.83)],
+    )
+
+    # Newest run first.
+    assert _recent(store, "reward_mean") == [0.83, 0.81]
+
+
+def test_write_run_rejects_non_finite_before_persisting(store):
+    for bad in (float("nan"), float("inf"), float("-inf")):
+        with pytest.raises(ValueError, match="non-finite"):
+            _write(
+                store,
+                created_at="2026-06-01T00:00:00+00:00",
+                values=[_sample("reward_mean", 0.5), _sample("reward_mean", bad, step=0)],
+            )
+
+    # Validation runs before any insert: the finite sibling sample must not
+    # have leaked in as a trusted row.
+    assert _recent(store, "reward_mean") == []
+
+
+def test_limit_caps_and_orders_newest_first(store):
+    for i, created in enumerate(
+        ["2026-06-01T00:00:00+00:00", "2026-06-02T00:00:00+00:00", "2026-06-03T00:00:00+00:00"]
+    ):
+        _write(store, created_at=created, values=[_sample("reward_mean", float(i))])
+
+    assert _recent(store, "reward_mean", limit=2) == [2.0, 1.0]
+
+
+def test_identity_isolation(store):
+    # Reference run under the canonical identity.
+    _write(store, created_at="2026-06-01T00:00:00+00:00", values=[_sample("reward_mean", 0.5)])
+
+    # Same metric, but each of these differs in exactly one identity field.
+    other_backend = RunIdentity(IDENTITY.test_path, "fsdp", IDENTITY.suite)
+    other_suite = RunIdentity(IDENTITY.test_path, IDENTITY.backend, "stage-b-2-gpu-h200")
+    other_path = RunIdentity("tests/e2e/test_other.py", IDENTITY.backend, IDENTITY.suite)
+    for ident in (other_backend, other_suite, other_path):
+        _write(
+            store,
+            identity=ident,
+            created_at="2026-06-02T00:00:00+00:00",
+            values=[_sample("reward_mean", 9.9)],
+        )
+
+    # Baseline for the canonical identity sees only its own single value.
+    assert _recent(store, "reward_mean") == [0.5]
+
+
+def test_coordinate_isolation(store):
+    # Four values under one metric_key; each non-base row differs from the
+    # base coordinate in exactly one coordinate column.
+    _write(
+        store,
+        created_at="2026-06-01T00:00:00+00:00",
+        values=[
+            _sample("pass_rate", 0.70),
+            _sample("pass_rate", 0.60, steps_key=STEP_LIST_KEY, step=0),
+            _sample("pass_rate", 0.80, constraint_key=ABS_CONSTRAINT_KEY),
+            _sample("pass_rate", 0.90, step=0),
+        ],
+    )
+
+    # Each exact coordinate matches only its own row: plain equality on every
+    # column, no cross-matching.
+    assert _recent(store, "pass_rate") == [0.70]
+    assert _recent(store, "pass_rate", steps_key=STEP_LIST_KEY, step=0) == [0.60]
+    assert _recent(store, "pass_rate", constraint_key=ABS_CONSTRAINT_KEY) == [0.80]
+    assert _recent(store, "pass_rate", step=0) == [0.90]
+
+
+def test_mark_untrusted_by_run_id_excludes_immediately(store):
+    keep = _write(store, created_at="2026-06-01T00:00:00+00:00", values=[_sample("reward_mean", 0.5)])
+    drop = _write(store, created_at="2026-06-02T00:00:00+00:00", values=[_sample("reward_mean", 0.9)])
+
+    affected = store.mark_untrusted(run_id=drop)
+    assert affected == 1
+
+    # No rebaseline step: the dropped run is gone from the baseline on the very
+    # next query, the kept run remains.
+    assert _recent(store, "reward_mean") == [0.5]
+    assert keep != drop
+
+
+def test_mark_untrusted_by_github_run_id(store):
+    prov = RunProvenance("c1", None, 7777, 1, "push", "refs/heads/main")
+    _write(store, provenance=prov, created_at="2026-06-01T00:00:00+00:00", values=[_sample("m", 1.0)])
+    _write(store, provenance=prov, created_at="2026-06-02T00:00:00+00:00", values=[_sample("m", 2.0)])
+
+    affected = store.mark_untrusted(github_run_id=7777)
+    assert affected == 2
+    assert _recent(store, "m") == []
+
+
+def test_mark_untrusted_by_commit_sha(store):
+    prov = RunProvenance("badc0de", 5, 1, 1, "pull_request", "refs/pull/5/merge")
+    _write(store, provenance=prov, created_at="2026-06-01T00:00:00+00:00", values=[_sample("m", 1.0)])
+    affected = store.mark_untrusted(commit_sha="badc0de")
+    assert affected == 1
+
+
+def test_mark_untrusted_is_idempotent(store):
+    rid = _write(store, created_at="2026-06-01T00:00:00+00:00", values=[_sample("m", 1.0)])
+    assert store.mark_untrusted(run_id=rid) == 1
+    # Already untrusted -> no rows change.
+    assert store.mark_untrusted(run_id=rid) == 0
+
+
+def test_mark_untrusted_requires_exactly_one_key(store):
+    with pytest.raises(ValueError):
+        store.mark_untrusted()
+    with pytest.raises(ValueError):
+        store.mark_untrusted(run_id="x", commit_sha="y")
+
+
+def test_untrusted_run_never_in_baseline(store):
+    _write(store, created_at="2026-06-01T00:00:00+00:00", trusted=False, values=[_sample("m", 5.0)])
+    assert _recent(store, "m") == []
+
+
+def test_baseline_sql_matches_authoritative_shape():
+    # Guard against drift from the authoritative query: identity predicates,
+    # plain equality on every coordinate column, trusted filter,
+    # created_at DESC, LIMIT.
+    from tests.ci.metric_history.storage.sqlite_store import _BASELINE_SQL
+
+    sql = re.sub(r"\s+", " ", _BASELINE_SQL).strip().lower()
+    for fragment in (
+        "from metric_values mv",
+        "join runs r using (run_id)",
+        "r.test_path = ?",
+        "r.backend = ?",
+        "r.suite = ?",
+        "mv.metric_key = ?",
+        "mv.steps_key = ?",
+        "mv.constraint_key = ?",
+        "mv.step = ?",
+        "r.trusted = 1",
+        "order by r.created_at desc",
+        "limit ?",
+    ):
+        assert fragment in sql, f"baseline query missing: {fragment!r}"
+
+
+def test_neon_store_is_deferred():
+    with pytest.raises(NotImplementedError):
+        NeonMetricHistoryStore()


### PR DESCRIPTION
## Summary
Storage contract + training-side metric capture for the CI history gate (M0+M1).

## Motivation
A per-run threshold cannot see a metric drifting a little on every PR. The gate needs its own store of per-test metric history to judge against; wandb stays a write-only sink and is never read back.

## Usage
When the CI harness sets `MILES_CI_GATE_RECORD_DIR`, `CiHistoryBackend` snapshots the whitelisted train/rollout metrics into per-process JSONL records under that dir; without the env nothing is written and behavior is unchanged.

## Design Notes
- **Key choices:** one narrow `MetricHistoryStore` contract (`write_run` / `recent_trusted_values` / `mark_untrusted`); the run-series identity is `(test_path, backend, suite)`; `trusted` lives on the run.
- `SQLiteMetricHistoryStore` mirrors the production baseline query offline; `NeonMetricHistoryStore` stays a deferred stub in this PR; `write_run` rejects non-finite values at the write boundary.
- Capture never blocks training: non-finite values are recorded as strict-JSON string markers; a wrong-typed metric fails loud at capture.
- Governing doc: `docs/ci/03-metric-history-gate.md`; its final form (single-layer gate, slim identity, consolidated TODO) lives on the m3 tree (#1517).

## Verification
- **Tests added:** `tests/ci/test/test_metric_history_store.py` — baseline ordering, identity/coordinate isolation, `mark_untrusted`, non-finite rejection.
- **Offline suite:** `pytest tests/ci/` is green.

## Review Focus
- Scrutinize the baseline query in `storage/sqlite_store.py` — every later milestone keys on its shape.
- Scrutinize the atomic snapshot rewrite and non-finite markers in `tracking_utils/ci_history.py`.
