### PR TITLE
[fsdp] Add gather_full_param DTensor materialization primitive

### DIFF
--- a/miles/backends/experimental/fsdp_utils/dtensor.py
+++ b/miles/backends/experimental/fsdp_utils/dtensor.py
@@ -1,0 +1,19 @@
+"""DTensor materialization for FSDP2 weight export: move sharded params to CUDA, then all-gather to full."""
+
+import torch
+import torch.distributed as dist
+from torch.distributed.tensor import DTensor, Replicate
+
+
+def gather_full_param(param: torch.Tensor, *, async_op: bool = False) -> torch.Tensor:
+    """Materialize a (possibly FSDP2-sharded) param to a full local tensor on CUDA; async_op returns a .wait()-able."""
+    full = param.cuda()
+    if not isinstance(full, DTensor):
+        return full
+    if dist.get_world_size() == 1:
+        # redistribute on a 1-rank mesh trips `assert compute_mesh is not None`
+        return full.full_tensor()
+    return full.redistribute(
+        placements=[Replicate()] * full.device_mesh.ndim,
+        async_op=async_op,
+    ).to_local()

--- a/tests/fast/backends/test_fsdp_dtensor.py
+++ b/tests/fast/backends/test_fsdp_dtensor.py
@@ -1,0 +1,29 @@
+"""Unit tests for the FSDP2 DTensor materialization primitive.
+
+``gather_full_param`` always moves to CUDA first (a CPU DTensor picks the wrong collective
+backend), so these are GPU-gated. The sharded-DTensor all-gather path is exercised end to
+end by the per-model weight-export (lp_diff) runs; here we pin the non-DTensor contract.
+"""
+
+import pytest
+import torch
+
+from miles.backends.experimental.fsdp_utils.dtensor import gather_full_param
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="gather_full_param moves to CUDA")
+def test_non_dtensor_passthrough_to_cuda():
+    p = torch.arange(12, dtype=torch.float32).reshape(3, 4)
+    out = gather_full_param(p)
+    assert not isinstance(out, torch.distributed.tensor.DTensor)
+    assert out.is_cuda
+    torch.testing.assert_close(out.cpu(), p)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="gather_full_param moves to CUDA")
+def test_async_passthrough_is_noop_for_non_dtensor():
+    # A plain tensor has no async handle to drain; async_op must not change the result.
+    p = torch.ones(2, 2)
+    out = gather_full_param(p, async_op=True)
+    assert not hasattr(out, "wait")
+    torch.testing.assert_close(out.cpu(), p)


### PR DESCRIPTION
Adds `gather_full_param`, which gathers a possibly sharded FSDP2 DTensor param into one full local CUDA tensor, with a fast path when world_size is 1. It extracts an idiom that was previously inlined in the weight sync loop and changes no behavior.