### PR TITLE
[fsdp] Add apply_fp32_master in-place fp32 master conversion

### DIFF
--- a/miles/backends/experimental/fsdp_utils/adaptations/precision.py
+++ b/miles/backends/experimental/fsdp_utils/adaptations/precision.py
@@ -26,3 +26,11 @@ def resolve_precision_policy(hf_config, args) -> PrecisionPolicy:
     model_type = str(getattr(hf_config, "model_type", "") or "").lower()
     keep_fp32_master = any(t in model_type for t in _FP32_MASTER_TYPES)
     return PrecisionPolicy(param_dtype=param_dtype, reduce_dtype=torch.float32, keep_fp32_master=keep_fp32_master)
+
+
+def apply_fp32_master(model):
+    """Convert model to an fp32 master in place, recording each param's on-disk dtype first (before the cast)."""
+    orig_dtypes = {name: p.dtype for name, p in model.state_dict().items()}
+    model = model.to(torch.float32)
+    model._fsdp_sync_orig_dtypes = orig_dtypes
+    return model

--- a/tests/fast/backends/test_fsdp_precision.py
+++ b/tests/fast/backends/test_fsdp_precision.py
@@ -1,0 +1,21 @@
+"""Unit tests for the FSDP precision policy (CPU-only)."""
+
+import torch
+
+from miles.backends.experimental.fsdp_utils.adaptations.precision import apply_fp32_master
+
+
+def test_apply_fp32_master_records_on_disk_dtypes_before_cast():
+    m = torch.nn.Linear(4, 4).to(torch.bfloat16)
+    # an fp32-on-disk param (e.g. glm's e_score_correction_bias) must be recorded as fp32 so the
+    # weight-sync downcast keeps it fp32 -- casting it to bf16 would flip MoE routing.
+    m.register_parameter("score_bias", torch.nn.Parameter(torch.zeros(4, dtype=torch.float32)))
+
+    m = apply_fp32_master(m)
+
+    # the master is fully fp32...
+    assert all(p.dtype == torch.float32 for p in m.parameters())
+    # ...but the recorded on-disk dtypes are the pre-cast ones (bf16 weight/bias, fp32 score_bias)
+    od = m._fsdp_sync_orig_dtypes
+    assert od["weight"] == torch.bfloat16 and od["bias"] == torch.bfloat16
+    assert od["score_bias"] == torch.float32


### PR DESCRIPTION
Adds `apply_fp32_master`, which converts a model to a uniform fp32 master in place after recording each param on disk dtype so the weight sync can downcast correctly. Needed for mixed dtype checkpoints whose routing or mixer params are stored in fp32.