### PR TITLE
[fsdp] Extract packed-document boundary derivation primitive

### DIFF
--- a/miles/backends/experimental/fsdp_utils/adaptations/packing/boundaries.py
+++ b/miles/backends/experimental/fsdp_utils/adaptations/packing/boundaries.py
@@ -1,0 +1,27 @@
+"""Shared packed-document boundary derivation for the FSDP backend."""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class PackedSeqContext:
+    cu_seqlens: "object"  # torch.Tensor int32 [num_docs+1]
+    seq_idx: "object"  # torch.Tensor int32 [1, T]
+    max_seqlen: int
+
+
+def packed_seq_context(position_ids):
+    """Derive per-document boundaries from packed ``position_ids``, or ``None`` when not packing."""
+    import torch
+
+    if position_ids is None or position_ids.dim() != 2 or position_ids.shape[0] != 1:
+        return None
+    pos = position_ids.reshape(-1)
+    starts = (pos == 0).nonzero(as_tuple=True)[0]
+    if starts.numel() <= 1:
+        return None  # single document -> packing is a no-op
+    total = torch.tensor([pos.numel()], device=pos.device, dtype=starts.dtype)
+    cu_seqlens = torch.cat([starts, total]).to(torch.int32)
+    seq_idx = (torch.cumsum((pos == 0).to(torch.int32), dim=0) - 1).to(torch.int32).unsqueeze(0).contiguous()
+    max_seqlen = int((cu_seqlens[1:] - cu_seqlens[:-1]).max())
+    return PackedSeqContext(cu_seqlens=cu_seqlens, seq_idx=seq_idx, max_seqlen=max_seqlen)

--- a/tests/fast/backends/test_fsdp_hf_compat.py
+++ b/tests/fast/backends/test_fsdp_hf_compat.py
@@ -46,3 +46,25 @@ def test_split_down_proj():
         d = out[f"model.layers.5.mlp.experts.{e}.down_proj.weight"]
         assert d.shape == (H, inter)
         torch.testing.assert_close(d, full[e])
+
+
+def test_packed_seq_context_boundaries():
+    # The shared boundary derivation (formerly duplicated verbatim in nemotron_h.py + qwen3_5_moe.py).
+    from miles.backends.experimental.fsdp_utils.adaptations.packing.boundaries import packed_seq_context
+
+    # single document / non-packed / wrong shape -> None (packing is a no-op)
+    assert packed_seq_context(None) is None
+    assert packed_seq_context(torch.arange(8).view(1, 8)) is None  # one doc, never resets to 0
+    assert packed_seq_context(torch.arange(8)) is None  # not [1, T]
+    assert packed_seq_context(torch.zeros(2, 4, dtype=torch.long)) is None  # batch > 1
+
+    # three packed docs of length 3, 2, 4 -> position_ids reset to 0 at each start
+    pos = torch.tensor([[0, 1, 2, 0, 1, 0, 1, 2, 3]])
+    ctx = packed_seq_context(pos)
+    assert ctx is not None
+    assert ctx.cu_seqlens.tolist() == [0, 3, 5, 9]
+    assert ctx.cu_seqlens.dtype == torch.int32
+    assert ctx.seq_idx.tolist() == [[0, 0, 0, 1, 1, 2, 2, 2, 2]]
+    assert ctx.seq_idx.dtype == torch.int32
+    assert ctx.seq_idx.shape == (1, 9)
+    assert ctx.max_seqlen == 4


### PR DESCRIPTION
Adds `packed_seq_context`, which derives cu_seqlens and seq_idx from position_ids so packed document boundaries can be injected into kernels. Pure helper with unit tests; no arch uses it yet.