### PR TITLE
[fsdp] Add packing package facade re-exporting boundaries + registry

### DIFF
--- a/miles/backends/experimental/fsdp_utils/adaptations/packing/__init__.py
+++ b/miles/backends/experimental/fsdp_utils/adaptations/packing/__init__.py
@@ -1,0 +1,13 @@
+"""Unified packed-sequence layout handling for the FSDP backend (one registry + one boundary derivation)."""
+
+from .boundaries import PackedSeqContext, packed_seq_context
+from .registry import PackingPatch, apply_packing, get_packing_patches, register_packing_patch
+
+__all__ = [
+    "PackedSeqContext",
+    "packed_seq_context",
+    "PackingPatch",
+    "register_packing_patch",
+    "get_packing_patches",
+    "apply_packing",
+]


### PR DESCRIPTION
Adds the packing package init that re exports the boundary helper and the registry API. A small convenience surface so callers import from one place.