### PR TITLE
[fsdp] Add NemotronH/Mamba post-load clobber-reload fixup helpers

### DIFF
--- a/miles/backends/experimental/fsdp_utils/adaptations/post_load_fixups.py
+++ b/miles/backends/experimental/fsdp_utils/adaptations/post_load_fixups.py
@@ -33,3 +33,54 @@ def apply_post_load_fixups(model, hf_config, ckpt_path) -> list[str]:
         if f.applies_to(hf_config) and f.apply(model, ckpt_path):
             fired.append(f.name)
     return fired
+
+
+def _is_mamba_hybrid(hf_config) -> bool:
+    """True for Mamba/SSM-hybrid archs whose HF `_init_weights` clobbers loaded weights post-load."""
+    model_type = str(getattr(hf_config, "model_type", "") or "").lower()
+    if "nemotron_h" in model_type or "mamba" in model_type:
+        return True
+    tc = getattr(hf_config, "get_text_config", lambda: hf_config)()
+    layer_types = getattr(tc, "layer_types", None) or getattr(hf_config, "layer_types", None)
+    return bool(layer_types) and any("mamba" in str(t).lower() for t in layer_types)
+
+
+def _reload_clobbered_from_disk(model, ckpt_path, tol=1e-3) -> int:
+    """Reload params differing from the on-disk checkpoint by > ``tol`` (meta ranks skipped); return count."""
+    try:
+        from safetensors import safe_open
+    except Exception:  # pragma: no cover
+        return 0
+    files = sorted(glob.glob(os.path.join(ckpt_path, "*.safetensors")))
+    if not files:
+        return 0
+    index = os.path.join(ckpt_path, "model.safetensors.index.json")
+    shard_of = json.load(open(index))["weight_map"] if os.path.exists(index) else {}
+
+    reloaded = 0
+    with torch.no_grad():
+        for name, param in model.named_parameters():
+            if param.device.type == "meta":
+                continue
+            shards = [os.path.join(ckpt_path, shard_of[name])] if name in shard_of else files
+            for f in shards:
+                try:
+                    with safe_open(f, framework="pt") as sf:
+                        if name not in sf.keys():
+                            continue
+                        disk = sf.get_tensor(name)
+                except Exception:
+                    continue
+                if disk.shape == param.shape:
+                    disk = disk.to(param.dtype)
+                    if (param.detach() - disk).abs().max().item() > tol:
+                        param.copy_(disk)
+                        reloaded += 1
+                break
+    if reloaded:
+        logger.info(
+            "[fsdp post_load] re-asserted %d checkpoint param(s) that from_pretrained clobbered "
+            "post-load (Mamba _init_weights)",
+            reloaded,
+        )
+    return reloaded

--- a/tests/fast/backends/test_fsdp_hf_compat.py
+++ b/tests/fast/backends/test_fsdp_hf_compat.py
@@ -48,6 +48,23 @@ def test_split_down_proj():
         torch.testing.assert_close(d, full[e])
 
 
+def test_is_mamba_hybrid_gating():
+    # The clobber-reload only runs for Mamba/SSM-hybrid archs (NemotronH _init_weights
+    # re-inits dt_bias + out_proj post-load); it must be a no-op gate for everything else.
+    from types import SimpleNamespace
+
+    from miles.backends.experimental.fsdp_utils.adaptations.post_load_fixups import _is_mamba_hybrid
+
+    assert _is_mamba_hybrid(SimpleNamespace(model_type="nemotron_h"))
+    assert _is_mamba_hybrid(SimpleNamespace(model_type="mamba2"))
+    # detected via layer_types even when model_type doesn't say "mamba"
+    assert _is_mamba_hybrid(SimpleNamespace(model_type="hybrid", layer_types=["mamba", "attention"]))
+    # dense / non-mamba archs must NOT trigger the reload
+    assert not _is_mamba_hybrid(SimpleNamespace(model_type="qwen3"))
+    assert not _is_mamba_hybrid(SimpleNamespace(model_type="qwen3_moe"))
+    assert not _is_mamba_hybrid(SimpleNamespace(model_type="llama", layer_types=["attention"]))
+
+
 def test_packed_seq_context_boundaries():
     # The shared boundary derivation (formerly duplicated verbatim in nemotron_h.py + qwen3_5_moe.py).
     from miles.backends.experimental.fsdp_utils.adaptations.packing.boundaries import packed_seq_context


### PR DESCRIPTION
Adds helpers that detect Mamba hybrid models and reload the mixer params that NemotronH _init_weights overwrites after loading. The nemotron_h spec registers them later in the chain.