### PR TITLE
[fsdp] Skip legacy qwen3_moe MoE-block patch on transformers>=5.6

### DIFF
--- a/miles/backends/experimental/fsdp_utils/models/qwen3_moe_hf.py
+++ b/miles/backends/experimental/fsdp_utils/models/qwen3_moe_hf.py
@@ -1,10 +1,19 @@
+import logging
+
 import torch
 import torch.nn.functional as F
+
+logger = logging.getLogger(__name__)
 
 
 def apply_fsdp_moe_patch():
 
     from transformers.models.qwen3_moe import modeling_qwen3_moe
+
+    # transformers>=5.6 batches experts; the legacy graph-forcing patch is unneeded and crashes, so skip it.
+    if hasattr(modeling_qwen3_moe, "Qwen3MoeTopKRouter") or hasattr(modeling_qwen3_moe, "Qwen3MoeExperts"):
+        logger.info("[fsdp] qwen3_moe uses batched experts (transformers>=5.6); skipping legacy MoE patch")
+        return
 
     def _forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
         batch_size, sequence_length, hidden_dim = hidden_states.shape
@@ -23,7 +32,6 @@ def apply_fsdp_moe_patch():
 
         expert_mask = torch.nn.functional.one_hot(selected_experts, num_classes=self.num_experts).permute(2, 1, 0)
 
-        # Loop over all experts
         for expert_idx in range(self.num_experts):
             expert_layer = self.experts[expert_idx]
             idx, top_x = torch.where(expert_mask[expert_idx])

--- a/tests/fast/backends/test_fsdp_hf_compat.py
+++ b/tests/fast/backends/test_fsdp_hf_compat.py
@@ -48,6 +48,18 @@ def test_split_down_proj():
         torch.testing.assert_close(d, full[e])
 
 
+def test_qwen3_moe_patch_noops_on_batched_structure():
+    # On transformers>=5.6 the patch must not replace the forward (batched experts).
+    from transformers.models.qwen3_moe import modeling_qwen3_moe
+
+    from miles.backends.experimental.fsdp_utils.models.qwen3_moe_hf import apply_fsdp_moe_patch
+
+    original_forward = modeling_qwen3_moe.Qwen3MoeSparseMoeBlock.forward
+    apply_fsdp_moe_patch()  # must not raise
+    if hasattr(modeling_qwen3_moe, "Qwen3MoeExperts") or hasattr(modeling_qwen3_moe, "Qwen3MoeTopKRouter"):
+        assert modeling_qwen3_moe.Qwen3MoeSparseMoeBlock.forward is original_forward
+
+
 def test_is_mamba_hybrid_gating():
     # The clobber-reload only runs for Mamba/SSM-hybrid archs (NemotronH _init_weights
     # re-inits dt_bias + out_proj post-load); it must be a no-op gate for everything else.


### PR DESCRIPTION
Makes the legacy qwen3_moe MoE block patch a no op on transformers 5.6 and later, where experts are already batched. This prevents double patching the new expert layout.