### PR TITLE
[fsdp] Add glm4_moe_lite adaptation spec

### DIFF
--- a/miles/backends/experimental/fsdp_utils/adaptations/specs/glm4_moe_lite.py
+++ b/miles/backends/experimental/fsdp_utils/adaptations/specs/glm4_moe_lite.py
@@ -1,0 +1,7 @@
+"""glm4_moe_lite (GLM-4.7-Flash) adaptations: reuse qwen3_moe expert-split weight transform plus an fp32 master."""
+
+from ..precision import register_fp32_master_type
+from ..weight_bridge import _qwen3_moe_expand, _qwen3_moe_matches, register_param_transform
+
+register_param_transform("glm4_moe_lite", _qwen3_moe_matches, _qwen3_moe_expand)
+register_fp32_master_type("glm4_moe_lite")


### PR DESCRIPTION
Adds the glm4_moe_lite spec, which reuses the qwen3_moe expert split and opts into an fp32 master. Needed for bit exact GLM 4.7 Flash weight sync.