### PR TITLE
[fsdp] Keep fp32 master for nemotron_h

### DIFF
--- a/miles/backends/experimental/fsdp_utils/adaptations/specs/nemotron_h.py
+++ b/miles/backends/experimental/fsdp_utils/adaptations/specs/nemotron_h.py
@@ -2,6 +2,7 @@
 
 from ..packing.registry import PackingPatch, register_packing_patch
 from ..post_load_fixups import PostLoadFixup, _is_mamba_hybrid, _reload_clobbered_from_disk, register_post_load_fixup
+from ..precision import register_fp32_master_type
 
 
 def _packing_applies(hf_config) -> bool:
@@ -16,3 +17,5 @@ def _packing_apply(model):
 
 register_packing_patch(PackingPatch("nemotron_h_packing", _packing_applies, "post_load", _packing_apply))
 register_post_load_fixup(PostLoadFixup("mamba_clobber_reload", _is_mamba_hybrid, _reload_clobbered_from_disk))
+# mixed-dtype checkpoint (mamba A_log/D/dt_bias are fp32) -> uniform fp32 master so FSDP2 wrapping accepts it
+register_fp32_master_type("nemotron_h")


### PR DESCRIPTION
Registers nemotron_h for an fp32 master because its mamba A_log, D and dt_bias are stored in fp32 and the checkpoint is mixed dtype. Without it FSDP2 wrapping fails the uniform dtype assertion, so this also updates the precision test to match.