### PR TITLE
[fsdp] Add adaptations facade: specs/__init__ + adaptations/__init__

### DIFF
--- a/miles/backends/experimental/fsdp_utils/adaptations/__init__.py
+++ b/miles/backends/experimental/fsdp_utils/adaptations/__init__.py
@@ -1,0 +1,30 @@
+"""Per-arch adaptation layer for the FSDP backend (mechanism registries + arch-centric ``specs/``)."""
+
+from .class_patches import ModelPatchHook, apply_class_patches, register_model_patch
+from .packing import PackingPatch, apply_packing, get_packing_patches, register_packing_patch
+from .post_load_fixups import PostLoadFixup, apply_post_load_fixups, register_post_load_fixup
+from .precision import PrecisionPolicy, apply_fp32_master, register_fp32_master_type, resolve_precision_policy
+from .weight_bridge import ParamTransform, get_param_transform, register_param_transform
+
+# MUST be last: importing the specs registers each arch's hooks into the mechanism registries above.
+from . import specs  # noqa: F401,E402  # isort: skip
+
+__all__ = [
+    "ModelPatchHook",
+    "apply_class_patches",
+    "register_model_patch",
+    "PackingPatch",
+    "apply_packing",
+    "get_packing_patches",
+    "register_packing_patch",
+    "PostLoadFixup",
+    "apply_post_load_fixups",
+    "register_post_load_fixup",
+    "PrecisionPolicy",
+    "apply_fp32_master",
+    "register_fp32_master_type",
+    "resolve_precision_policy",
+    "ParamTransform",
+    "get_param_transform",
+    "register_param_transform",
+]

--- a/miles/backends/experimental/fsdp_utils/adaptations/specs/__init__.py
+++ b/miles/backends/experimental/fsdp_utils/adaptations/specs/__init__.py
@@ -1,0 +1,13 @@
+"""Per-arch adaptation specs — the one place a new architecture plugs into the FSDP backend.
+
+Importing this package registers every arch's hooks. To add an arch, create ``specs/<arch>.py`` registering
+only the hooks it needs and add it to the import below:
+
+  * register_param_transform    [weight_bridge]    — train->rollout param rename/reshape at weight sync
+  * register_model_patch        [class_patches]    — config-time patch of transformers classes
+  * register_packing_patch      [packing.registry] — per-document state reset under THD packing
+  * register_post_load_fixup    [post_load_fixups] — correct weights from_pretrained clobbered
+  * register_fp32_master_type   [precision]        — keep an fp32 master for a bit-exact reshard
+"""
+
+from . import glm4_moe_lite, nemotron_h, qwen3_5_moe, qwen3_moe  # noqa: F401  (imports trigger registration)

--- a/tests/fast/backends/test_fsdp_precision.py
+++ b/tests/fast/backends/test_fsdp_precision.py
@@ -1,8 +1,25 @@
 """Unit tests for the FSDP precision policy (CPU-only)."""
 
+from types import SimpleNamespace
+
 import torch
 
-from miles.backends.experimental.fsdp_utils.adaptations.precision import apply_fp32_master
+from miles.backends.experimental.fsdp_utils.adaptations.precision import apply_fp32_master, resolve_precision_policy
+
+
+def test_resolve_precision_policy_gating_and_dtypes():
+    dense = SimpleNamespace(model_type="qwen3")
+    bf16_args = SimpleNamespace(fp16=False)
+
+    # fp32 master only for glm4_moe_lite; reduce is always fp32; param follows args.fp16
+    assert resolve_precision_policy(SimpleNamespace(model_type="glm4_moe_lite"), bf16_args).keep_fp32_master
+    p = resolve_precision_policy(dense, bf16_args)
+    assert not p.keep_fp32_master
+    assert p.param_dtype == torch.bfloat16 and p.reduce_dtype == torch.float32
+    assert resolve_precision_policy(dense, SimpleNamespace(fp16=True)).param_dtype == torch.float16
+    # nemotron_h keeps an fp32 master (mixed-dtype mamba checkpoint); qwen3_moe must not
+    assert resolve_precision_policy(SimpleNamespace(model_type="nemotron_h"), bf16_args).keep_fp32_master
+    assert not resolve_precision_policy(SimpleNamespace(model_type="qwen3_moe"), bf16_args).keep_fp32_master
 
 
 def test_apply_fp32_master_records_on_disk_dtypes_before_cast():


### PR DESCRIPTION
specs/__init__ imports every arch spec and adaptations/__init__ re exports the five mechanisms, so importing the package activates all registrations. This is the point where the full adaptation system becomes live, and it moves the precision policy gating test here since it needs every spec registered.