### PR TITLE
[fsdp] PERF: empty_cache once per bucket instead of per param in distributed weight sync

### DIFF
--- a/miles/backends/experimental/fsdp_utils/update_weight_utils.py
+++ b/miles/backends/experimental/fsdp_utils/update_weight_utils.py
@@ -268,9 +268,10 @@ class UpdateWeightFromDistributed(UpdateWeight):
         ]
 
         handles = []
+        # free cached blocks once before the batch (per-param empty_cache was a costly CUDA sync and ineffective)
+        torch.cuda.empty_cache()
         # Broadcast parameters one by one with memory management
         for _name, param in named_tensors:
-            torch.cuda.empty_cache()
             # Ensure tensor is contiguous and on the right device
             param_data = param.data.contiguous()
 


### PR DESCRIPTION
Calls empty_cache once per bucket instead of once per param during distributed weight sync. The per param call was a costly CUDA sync that did little, so this speeds up weight sync.