### PR TITLE
[fsdp] Route FSDP->rollout weight sync through gather_full_param + the WeightBridge transform registry

### DIFF
--- a/miles/backends/experimental/fsdp_utils/update_weight_utils.py
+++ b/miles/backends/experimental/fsdp_utils/update_weight_utils.py
@@ -8,7 +8,7 @@ import ray
 import torch
 import torch.distributed as dist
 from ray.actor import ActorHandle
-from torch.distributed.tensor import DTensor, Replicate
+from torch.distributed.tensor import DTensor
 
 try:
     from sglang.srt.utils.patch_torch import monkey_patch_torch_reductions  # type: ignore[import]
@@ -19,7 +19,6 @@ from sglang.srt.utils import MultiprocessingSerializer
 
 from miles.utils.distributed_utils import get_gloo_group, init_process_group
 
-
 try:
     from sglang.srt.weight_sync.tensor_bucket import FlattenedTensorBucket  # type: ignore[import]
 except ImportError:
@@ -27,6 +26,26 @@ except ImportError:
 
 
 logger = logging.getLogger(__name__)
+
+
+from .adaptations.weight_bridge import get_param_transform
+from .dtensor import gather_full_param
+
+
+def _iter_sync_named_params(name, param, model_type, orig_dtypes=None):
+    """Yield (name, tensor) pairs for the rollout engine, applying the registered WeightBridge transform."""
+    expand = get_param_transform(name, param, model_type)
+    if expand is None:
+        yield name, param
+        return
+
+    # Materialize the full (unsharded) tensor before the transform slices it.
+    full = gather_full_param(param)
+    if orig_dtypes is not None:
+        target = orig_dtypes.get(name)
+        if target is not None and full.dtype != target:
+            full = full.to(target)
+    yield from expand(name, full)
 
 
 class UpdateWeight(abc.ABC):
@@ -56,23 +75,23 @@ class UpdateWeight(abc.ABC):
 
         bucket = []
         bucket_size = 0
-        for name, param in self.model.state_dict().items():
-            param_size = param.numel() * param.element_size()
-            if bucket and bucket_size + param_size >= self.args.update_weight_buffer_size:
-                self.wait_and_update_bucket_weights(bucket)
-                del bucket
-                bucket = []
-                bucket_size = 0
+        model_type = getattr(getattr(self.model, "config", None), "model_type", "")
+        # fp32-master archs (glm4_moe_lite): restore each param's on-disk dtype before streaming
+        orig_dtypes = getattr(self.model, "_fsdp_sync_orig_dtypes", None)
+        for raw_name, raw_param in self.model.state_dict().items():
+            for name, param in _iter_sync_named_params(raw_name, raw_param, model_type, orig_dtypes):
+                param_size = param.numel() * param.element_size()
+                if bucket and bucket_size + param_size >= self.args.update_weight_buffer_size:
+                    self.wait_and_update_bucket_weights(bucket)
+                    del bucket
+                    bucket = []
+                    bucket_size = 0
 
-            param = param.cuda()
-            if isinstance(param, DTensor):
-                # async version of param.full_tensor
-                param = param.redistribute(
-                    placements=[Replicate()] * param.device_mesh.ndim,
-                    async_op=True,
-                ).to_local()
-            bucket.append((name, param))
-            bucket_size += param_size
+                # passthrough params only (split experts are pre-cast); target_dtype cast deferred to post-wait
+                target_dtype = orig_dtypes.get(name) if orig_dtypes is not None else None
+                param = gather_full_param(param, async_op=True)
+                bucket.append((name, param, target_dtype))
+                bucket_size += param_size
 
         if bucket:
             self.wait_and_update_bucket_weights(bucket)
@@ -86,8 +105,15 @@ class UpdateWeight(abc.ABC):
         dist.barrier(group=get_gloo_group())
 
     def wait_and_update_bucket_weights(self, bucket):
-        bucket = [(name, param.wait()) if hasattr(param, "wait") else (name, param) for name, param in bucket]
-        self.update_bucket_weights(bucket, weight_version=self.weight_version)
+        resolved = []
+        for name, param, target_dtype in bucket:
+            if hasattr(param, "wait"):
+                param = param.wait()
+            # downcast the fp32 master to its on-disk dtype; None = no cast
+            if target_dtype is not None and param.dtype != target_dtype:
+                param = param.to(target_dtype)
+            resolved.append((name, param))
+        self.update_bucket_weights(resolved, weight_version=self.weight_version)
 
     @abc.abstractmethod
     def update_bucket_weights(self, named_tensors, weight_version=None) -> None:
@@ -95,12 +121,7 @@ class UpdateWeight(abc.ABC):
 
 
 class UpdateWeightFromTensor(UpdateWeight):
-    """Push model weights to rollout engines using tensors.
-
-    Streams parameters in size-bounded buckets; optionally groups tensors by dtype
-    and flattens per dtype, gathers per-rank blobs to the source, and issues one
-    RPC per dtype per bucket (or one per bucket if not flattened).
-    """
+    """Push model weights to rollout engines as tensors, streamed in size-bounded buckets (flattened per dtype)."""
 
     def connect_rollout_engines(
         self,
@@ -109,11 +130,7 @@ class UpdateWeightFromTensor(UpdateWeight):
         engine_gpu_counts: Sequence[int] | None = None,
         engine_gpu_offsets: Sequence[int] | None = None,
     ) -> None:
-        """Attach rollout engines and create per-engine IPC (Gloo) groups.
-
-        Sets the gather source rank, engine handle, and `tp_rank` within the
-        engine's local group.
-        """
+        """Attach rollout engines and create per-engine IPC (Gloo) groups."""
         self.rollout_engines = rollout_engines
 
         # Here we assume the gpu id of rollout engines and train actors are the same.
@@ -129,14 +146,11 @@ class UpdateWeightFromTensor(UpdateWeight):
                 self._ipc_gather_src = start_rank
                 self._ipc_gather_group = new_group
                 self._ipc_engine = engine
-                # Calculate TP rank within this SGLang engine group
                 self.tp_rank = dist.get_rank() - start_rank
 
     def update_bucket_weights(self, named_tensors, weight_version=None) -> None:
         monkey_patch_torch_reductions()
-        # Use flattened bucket approach similar to Megatron
         logger.info("Using flattened tensor bucket")
-        # Group tensors by dtype (same as Megatron)
         named_tensors_by_dtypes = {}
         for name, tensor in named_tensors:
             dtype = tensor.dtype
@@ -144,7 +158,6 @@ class UpdateWeightFromTensor(UpdateWeight):
                 named_tensors_by_dtypes[dtype] = []
             named_tensors_by_dtypes[dtype].append((name, tensor))
 
-        # Create flattened bucket for each dtype group
         serialized_tensors = []
         for _dtype, named_tensors in named_tensors_by_dtypes.items():
             flattened_tensor_bucket = FlattenedTensorBucket(named_tensors=named_tensors)
@@ -170,9 +183,7 @@ class UpdateWeightFromTensor(UpdateWeight):
         )
 
         if dist.get_rank() == self._ipc_gather_src:
-            # Handle flattened bucket format (same as Megatron approach)
-            # Each rank may have multiple dtype buckets
-            # TODO: here we assume all ranks have the same number of dtypes
+            # TODO: assumes all ranks have the same number of dtype buckets
             num_dtypes = len(gathered_serialized_batches[0])
             assert num_dtypes > 0
             for i in range(num_dtypes):
@@ -214,9 +225,7 @@ class UpdateWeightFromDistributed(UpdateWeight):
         self.rollout_engines = rollout_engines
         self.rollout_engine_lock = rollout_engine_lock
 
-        # For TP:
-        #   1. AllGather parameters to rank 0
-        #   2. Broadcast parameters from rank 0 to all sglang engines
+        # TP weight sync: AllGather params to rank 0, then broadcast from rank 0 to all sglang engines
         self._is_src_rank = dist.get_rank() == 0
         if self._is_src_rank:
             self._group_name = "miles"
@@ -224,7 +233,7 @@ class UpdateWeightFromDistributed(UpdateWeight):
             with socket.socket() as sock:
                 sock.bind(("", 0))
                 master_port = sock.getsockname()[1]
-            ## TODO: why +1?
+            # +1 for the trainer's source rank (rank 0); rollout engine ranks start at 1
             world_size = self.args.rollout_num_gpus + 1
 
             refs = [
@@ -248,11 +257,7 @@ class UpdateWeightFromDistributed(UpdateWeight):
             ray.get(refs)
 
     def update_bucket_weights(self, named_tensors, weight_version=None) -> None:
-        """Send names/dtypes/shapes metadata to engines, then broadcast tensors.
-
-        Ensures tensors are contiguous; when `world_size == 1`, converts DTensors
-        to full tensors prior to `dist.broadcast`.
-        """
+        """Send metadata to engines, then broadcast the tensors (DTensors materialized when world_size == 1)."""
         if not self._is_src_rank or not named_tensors:
             return
 
@@ -270,16 +275,13 @@ class UpdateWeightFromDistributed(UpdateWeight):
         handles = []
         # free cached blocks once before the batch (per-param empty_cache was a costly CUDA sync and ineffective)
         torch.cuda.empty_cache()
-        # Broadcast parameters one by one with memory management
         for _name, param in named_tensors:
-            # Ensure tensor is contiguous and on the right device
             param_data = param.data.contiguous()
 
             # avoid `DTensor._op_dispatcher.dispatch` has `assert compute_mesh is not None` error
             if dist.get_world_size() == 1 and isinstance(param_data, DTensor):
                 param_data = param_data.full_tensor()
 
-            # Synchronous broadcast to avoid memory buildup
             handles.append(dist.broadcast(param_data, 0, group=self._model_update_groups, async_op=True))
 
         for handle in handles:

--- a/tests/fast/backends/test_fsdp_hf_compat.py
+++ b/tests/fast/backends/test_fsdp_hf_compat.py
@@ -11,6 +11,7 @@ Covers:
 import torch
 
 from miles.backends.experimental.fsdp_utils.adaptations.weight_bridge import _qwen3_moe_expand
+from miles.backends.experimental.fsdp_utils.update_weight_utils import _iter_sync_named_params
 
 
 def test_split_gate_up_proj_rows_and_names():
@@ -46,6 +47,16 @@ def test_split_down_proj():
         d = out[f"model.layers.5.mlp.experts.{e}.down_proj.weight"]
         assert d.shape == (H, inter)
         torch.testing.assert_close(d, full[e])
+
+
+def test_iter_passthrough_for_non_expert():
+    p = torch.zeros(4, 4)
+    out = list(_iter_sync_named_params("model.embed_tokens.weight", p, "qwen3_moe"))
+    assert len(out) == 1 and out[0][0] == "model.embed_tokens.weight" and out[0][1] is p
+    # expert-named param under a model type that consumes batched layout -> passthrough
+    g = torch.zeros(2, 6, 4)
+    out = list(_iter_sync_named_params("model.layers.0.mlp.experts.gate_up_proj", g, "qwen3_5_moe"))
+    assert len(out) == 1 and out[0][1] is g
 
 
 def test_qwen3_moe_patch_noops_on_batched_structure():


### PR DESCRIPTION
Rewrites the weight sync loop to materialize full params via gather_full_param and apply the WeightBridge transforms, with the fp32 master downcast back to the on disk dtype. Adds the passthrough test and moves the expert split path onto the registry.