### PR TITLE
[fsdp] Actor: apply HF-compat class_patches before model construction

### DIFF
--- a/miles/backends/experimental/fsdp_utils/actor.py
+++ b/miles/backends/experimental/fsdp_utils/actor.py
@@ -43,17 +43,7 @@ logger = logging.getLogger(__name__)
 
 
 class FSDPTrainRayActor(TrainRayActor):
-    """Simplified TrainRayActor for pure HF+FSDP training.
-
-    Responsibilities:
-      * Initialize model/tokenizer on rank0 sequentially to avoid race on cache
-      * Wrap model with FSDP
-      * Provide minimal train / save / update_weights hooks compatible with existing RayTrainGroup
-
-    Weight update strategy:
-      * Rank0 gathers state_dict (full) and broadcasts tensor-by-tensor.
-      * For small models this is fine; for larger models consider sharded state_dict type.
-    """
+    """Simplified TrainRayActor for pure HF+FSDP2 training (rank0 loads, others meta; weight sync via rank0 broadcast)."""
 
     @with_defer(lambda: Timer().start("train_wait"))
     def init(self, args: Namespace, role: str, with_ref: bool = False, with_opd_teacher: bool = False) -> int:  # type: ignore[override]
@@ -64,7 +54,6 @@ class FSDPTrainRayActor(TrainRayActor):
 
             dumper.apply_source_patches()
 
-        # Setup ParallelState for both CP and non-CP cases
         set_parallel_state(create_fsdp_parallel_state(args))
 
         torch.manual_seed(args.seed)
@@ -77,11 +66,10 @@ class FSDPTrainRayActor(TrainRayActor):
             return 0
 
         self.fsdp_cpu_offload = getattr(self.args, "fsdp_cpu_offload", False)
-        # Offload train and fsdp cpu offload cannot be used together, fsdp_cpu_offload is more aggressive
+        # offload_train and fsdp_cpu_offload are mutually exclusive; fsdp_cpu_offload wins
         if self.args.offload_train and self.fsdp_cpu_offload:
             self.args.offload_train = False
 
-        self._enable_true_on_policy_optimizations(args)
         if dist.get_rank() == 0:
             init_tracking(args, primary=False)
 
@@ -96,10 +84,16 @@ class FSDPTrainRayActor(TrainRayActor):
                 self.tokenizer = load_tokenizer(
                     self.args.hf_checkpoint, chat_template_path=self.args.chat_template_path, trust_remote_code=True
                 )
-                # Vision models have `vision_config` in the config
                 if hasattr(self.hf_config, "vision_config"):
                     self.processor = load_processor(self.args.hf_checkpoint, trust_remote_code=True)
             dist.barrier(group=get_gloo_group())
+
+        # HF-compat patches before construction
+        from .adaptations.class_patches import apply_class_patches
+
+        apply_class_patches(self.hf_config, self.args)
+
+        self._enable_true_on_policy_optimizations(args)
 
         init_context = self._get_init_weight_context_manager()
 
@@ -138,7 +132,6 @@ class FSDPTrainRayActor(TrainRayActor):
         else:
             raise ValueError(f"Unsupported optimizer: {args.optimizer}. Supported options: 'adam'")
 
-        # Initialize LR scheduler
         self.lr_scheduler = get_lr_scheduler(args, self.optimizer)
 
         self.global_step = 0
@@ -146,7 +139,6 @@ class FSDPTrainRayActor(TrainRayActor):
 
         checkpoint_payload = checkpoint.load(self)
 
-        # Create separate ref model if needed (kept in CPU until needed)
         self.ref_model = None
         if with_ref:
             self.ref_model = self._create_ref_model(args.ref_load)
@@ -159,8 +151,7 @@ class FSDPTrainRayActor(TrainRayActor):
 
         checkpoint.finalize_load(self, checkpoint_payload)
 
-        # Initialize data packing parameters
-        self.max_tokens_per_gpu = args.max_tokens_per_gpu  # From main arguments
+        self.max_tokens_per_gpu = args.max_tokens_per_gpu
 
         if self.args.offload_train:
             self.sleep()
@@ -170,7 +161,6 @@ class FSDPTrainRayActor(TrainRayActor):
         return int(getattr(self.args, "start_rollout_id", 0))
 
     def get_model_cls(self):
-        # Vision models have `vision_config` in the config
         if hasattr(self.hf_config, "vision_config"):
             from transformers import AutoModelForImageTextToText
 
@@ -181,70 +171,38 @@ class FSDPTrainRayActor(TrainRayActor):
             return AutoModelForCausalLM
 
     def _enable_true_on_policy_optimizations(self, args):
+        """Backend-level true-on-policy setup (batch-invariant ops), gated on the run mode."""
         if args.true_on_policy_mode:
             from sglang.srt.batch_invariant_ops import enable_batch_invariant_mode
 
-            from .models.qwen3_moe import apply_true_on_policy_patch_for_qwen3_moe
-
             logger.info("FSDPTrainRayActor call enable_batch_invariant_mode for true-on-policy")
             enable_batch_invariant_mode(
-                # In Qwen3, rope `inv_freq_expanded.float() @ position_ids_expanded.float()` uses bmm
-                # and disabling it will make it aligned
+                # Qwen3 rope bmm; disabling it aligns
                 enable_bmm=False,
             )
 
-            apply_true_on_policy_patch_for_qwen3_moe()
-        else:
-            from .models.qwen3_moe_hf import apply_fsdp_moe_patch
-
-            apply_fsdp_moe_patch()
-
     def _get_init_weight_context_manager(self):
-        """Get context manager for model initialization.
-
-        Returns a callable that creates a context manager.
-        Uses meta device (no memory allocation) for non-rank-0 processes,
-        UNLESS tie_word_embeddings=True (which causes hangs with meta tensors).
-
-        Ref: verl/utils/fsdp_utils.py::get_init_weight_context_manager
-        NOTE: tie_word_embedding causes meta_tensor init to hang
-        """
+        """Init context: meta device on non-rank-0, except tie_word_embeddings=True forces CPU load on all ranks."""
         from accelerate import init_empty_weights
 
-        # Check if model uses tied word embeddings (which doesn't work with meta tensors)
         use_meta_tensor = not self.hf_config.tie_word_embeddings
 
         def cpu_init_weights():
             return torch.device("cpu")
 
         if use_meta_tensor:
-            # Rank 0: CPU, others: meta device (memory efficient for large models)
             return init_empty_weights if dist.get_rank() != 0 else cpu_init_weights
         else:
             logger.info(f"[Rank {dist.get_rank()}] tie_word_embeddings=True, loading full model to CPU on all ranks")
             return cpu_init_weights
 
     def _fsdp2_load_full_state_dict(self, model, full_state, device_mesh, cpu_offload):
-        """Load full state dict into FSDP2 model with efficient broadcast from rank 0.
-
-        This function loads weights from rank 0 and broadcasts to all other ranks,
-        avoiding the need for each rank to load the full model from disk.
-
-        Args:
-            model: FSDP2-wrapped model
-            full_state: State dict (only rank 0 has real weights, others have empty dict)
-            device_mesh: Device mesh for FSDP
-            cpu_offload: If not None, enables StateDictOptions cpu_offload
-
-        Ref:verl/utils/fsdp_utils.py::fsdp2_load_full_state_dict
-        """
+        """Load full state dict into FSDP2 model, broadcasting rank-0 weights to all ranks (only rank0 reads disk)."""
         from torch.distributed.checkpoint.state_dict import StateDictOptions, set_model_state_dict
 
-        # Rank 0: move with weights, others: allocate empty tensors on device
         if dist.get_rank() == 0:
             model = model.to(device=torch.cuda.current_device(), non_blocking=True)
         else:
-            # to_empty creates tensors on device without initializing memory
             model = model.to_empty(device=torch.cuda.current_device())
 
         is_cpu_offload = cpu_offload is not None
@@ -252,7 +210,7 @@ class FSDPTrainRayActor(TrainRayActor):
 
         set_model_state_dict(model, full_state, options=options)
 
-        # set_model_state_dict will not broadcast buffers, so we need to broadcast them manually.
+        # set_model_state_dict does not broadcast buffers; do it manually
         for _name, buf in model.named_buffers():
             dist.broadcast(buf, src=0)
 
@@ -303,22 +261,7 @@ class FSDPTrainRayActor(TrainRayActor):
         num_microbatches: list[int],
         store_prefix: str = "",
     ) -> dict[str, list[torch.Tensor]]:
-        """Compute token log-probabilities using data iterator.
-
-        Parameters:
-            model_tag: Which parameters to use, e.g. "actor" or "ref".
-            data_iterator: DataIterator providing micro-batches.
-            num_microbatches: List of number of microbatches per step.
-            store_prefix: Prefix to use for keys in outputs (e.g., "ref_").
-
-        Returns:
-            A lightweight dictionary keyed by f"{store_prefix}log_probs".
-
-        Note:
-            Uses separate ref model when model_tag == "ref". The ref model is
-            loaded from CPU to GPU on-demand and offloaded back after use.
-        """
-        # Select which model to use
+        """Compute token log-probs over the data iterator; uses the separate ref model when model_tag==\"ref\"."""
         if model_tag == "ref" and self.ref_model is not None:
             if not self.fsdp_cpu_offload:
                 self.model.cpu()
@@ -385,7 +328,6 @@ class FSDPTrainRayActor(TrainRayActor):
             return rollout_data
 
         finally:
-            # Restore actor model if it was offloaded
             if model_tag == "ref" and self.ref_model is not None:
                 torch.cuda.empty_cache()
                 dist.barrier(group=get_gloo_group())
@@ -395,16 +337,7 @@ class FSDPTrainRayActor(TrainRayActor):
                     dist.barrier(group=get_gloo_group())
 
     def train(self, rollout_id: int, rollout_data_ref: Box) -> None:
-        """Run one training update over a rollout batch.
-
-        Parameters:
-            rollout_id: Monotonic id for logging.
-            rollout_data_ref: A Box handle wrapping a Ray object reference to a
-                dictionary with rollout tensors and metadata (e.g., `tokens`,
-                `loss_masks`, `rewards`, `response_lengths`, optional
-                `rollout_log_probs`, etc.). It will be fetched and partitioned
-                by `process_rollout_data` based on data-parallel rank/size.
-        """
+        """Run one training update over a rollout batch (rollout_data_ref is a Box handle to the Ray object ref)."""
         if self.args.offload_train:
             self.wake_up()
 
@@ -516,7 +449,6 @@ class FSDPTrainRayActor(TrainRayActor):
         if self.args.save_debug_train_data is not None:
             train_dump_utils.save_debug_train_data(self.args, rollout_id=rollout_id, rollout_data=rollout_data)
 
-        # Update ref model if needed (copy actor weights to ref)
         if (
             self.args.ref_update_interval is not None
             and (rollout_id + 1) % self.args.ref_update_interval == 0
@@ -524,13 +456,11 @@ class FSDPTrainRayActor(TrainRayActor):
         ):
             if dist.get_rank() == 0:
                 logger.info(f"Updating ref model at rollout_id {rollout_id}")
-            # Copy actor model state to ref model
             actor_state = self.model.state_dict()
             self.ref_model.load_state_dict(actor_state)
             self.ref_model.cpu()
 
     def _train_step(self, batch, step_id, num_microbatches):
-        # Prepare model inputs
         model_args = self._get_model_inputs_args(batch)
         logits = self.model(**model_args).logits.float()
 
@@ -548,11 +478,7 @@ class FSDPTrainRayActor(TrainRayActor):
 
     @timer
     def update_weights(self, info: "EnginesAndLock") -> None:  # type: ignore[override]
-        """Synchronize actor weights to rollout engines.
-
-        Handles both colocated and distributed update modes. In offload mode,
-        wakes up parameters as needed to perform the update.
-        """
+        """Synchronize actor weights to rollout engines (colocated or distributed; wakes params in offload mode)."""
         if self.args.debug_train_only or self.args.debug_rollout_only:
             return
 
@@ -587,20 +513,7 @@ class FSDPTrainRayActor(TrainRayActor):
         clear_memory()
 
     def _create_ref_model(self, ref_load_path: str | None):
-        """Create and initialize a separate reference model with FSDP2 CPUOffloadPolicy.
-
-        Parameters:
-            ref_load_path: Path to a directory containing a HF checkpoint. If
-                None, a ValueError is raised.
-
-        Returns:
-            FSDP2-wrapped ref model with CPU offload enabled
-
-        Note:
-            Creates a separate FSDP2 model instance for the reference model.
-            ALWAYS uses CPUOffloadPolicy for the reference model to save memory,
-            regardless of the actor model's CPU offload setting.
-        """
+        """Create a separate FSDP2 ref model (always CPUOffloadPolicy); raises if ref_load_path is None or not a dir."""
         if ref_load_path is None:
             raise ValueError("ref_load_path must be provided when loading reference model")
 
@@ -618,7 +531,7 @@ class FSDPTrainRayActor(TrainRayActor):
 
             full_state = ref_model.state_dict()
 
-            # Always use CPUOffloadPolicy for reference, let FSDP2 handle the offload. It is faster than model.cpu().
+            # always CPUOffloadPolicy for reference; faster than model.cpu()
             ref_model = apply_fsdp2(ref_model, mesh=get_parallel_state().dp_mesh, cpu_offload=True, args=self.args)
             ref_model = self._fsdp2_load_full_state_dict(
                 ref_model, full_state, get_parallel_state().dp_mesh, cpu_offload=True
@@ -634,7 +547,7 @@ class FSDPTrainRayActor(TrainRayActor):
         position_ids = batch["position_ids"]
 
         if get_parallel_state().cp.size > 1:
-            # TODO: Pin ring_flash_attn for torch 2.11+ compatibility; keep this local import to unblock non-FSDP+CP paths.
+            # TODO: Pin ring_flash_attn for torch 2.11+; local import to unblock non-FSDP+CP paths
             from ring_flash_attn import update_ring_flash_attn_params
 
             if "cu_seqlens" in batch:
@@ -675,17 +588,7 @@ def move_torch_optimizer(optimizer, device):
 
 
 def apply_fsdp2(model, mesh=None, cpu_offload=False, args=None):
-    """Apply FSDP v2 to the model.
-
-    Args:
-        model: The model to wrap with FSDP
-        mesh: Optional DeviceMesh for FSDP. If None, uses all ranks.
-        cpu_offload: If True, offload parameters, gradients, and optimizer states
-            to CPU. The optimizer step will run on CPU. (Default: False)
-        args: Arguments containing precision settings (fp16/bf16)
-
-    Ref: https://github.com/volcengine/verl/blob/main/verl/utils/fsdp_utils.py
-    """
+    """Apply FSDP2 (fully_shard) to the model; ref: https://github.com/volcengine/verl/blob/main/verl/utils/fsdp_utils.py"""
     from torch.distributed.fsdp import CPUOffloadPolicy, MixedPrecisionPolicy, fully_shard
 
     offload_policy = CPUOffloadPolicy() if cpu_offload else None
@@ -700,12 +603,8 @@ def apply_fsdp2(model, mesh=None, cpu_offload=False, args=None):
         or (isinstance(module, torch.nn.Embedding) and not model.config.tie_word_embeddings)
     ]
 
-    # Determine precision policy based on args
-    param_dtype = torch.bfloat16  # Default to bf16 as before
+    param_dtype = torch.float16 if args.fp16 else torch.bfloat16
     reduce_dtype = torch.float32
-
-    if args.fp16:
-        param_dtype = torch.float16
 
     logger.info(f"FSDP MixedPrecision Policy: param_dtype={param_dtype}, reduce_dtype={reduce_dtype}")
 
@@ -718,11 +617,9 @@ def apply_fsdp2(model, mesh=None, cpu_offload=False, args=None):
         "mesh": mesh,
     }
 
-    # Apply FSDP to each module (offload_policy=None is equivalent to not passing it)
+    # fully_shard each layer first, then the root model
     for module in modules:
         fully_shard(module, **fsdp_kwargs)
-
-    # Apply FSDP to the top-level model
     fully_shard(model, **fsdp_kwargs)
 
     return model


### PR DESCRIPTION
Has the actor apply the class patch hooks before building the model, replacing the old inline patching. It consumes the ModelPatchHook registry from earlier in the chain.