### PR TITLE
[fsdp] PERF: hand bf16 logits to the cross-entropy, drop the full-vocab fp32 buffer

### DIFF
--- a/miles/backends/experimental/fsdp_utils/actor.py
+++ b/miles/backends/experimental/fsdp_utils/actor.py
@@ -304,7 +304,8 @@ class FSDPTrainRayActor(TrainRayActor):
                         )
 
                         model_args = self._get_model_inputs_args(batch)
-                        logits = active_model(**model_args).logits.float()
+                        # keep logits in native bf16 (chunks upcast to fp32 downstream); avoids ~5GB full-vocab fp32 tensor
+                        logits = active_model(**model_args).logits
 
                         result = get_log_probs_and_entropy(
                             logits=logits,
@@ -462,7 +463,8 @@ class FSDPTrainRayActor(TrainRayActor):
 
     def _train_step(self, batch, step_id, num_microbatches):
         model_args = self._get_model_inputs_args(batch)
-        logits = self.model(**model_args).logits.float()
+        # bf16 logits (see log_probs phase); per-response chunks upcast to fp32 in the loss path
+        logits = self.model(**model_args).logits
 
         loss, normalizer, log_dict = loss_function(
             args=self.args,

--- a/miles/backends/training_utils/loss_hub/logit_processors.py
+++ b/miles/backends/training_utils/loss_hub/logit_processors.py
@@ -41,7 +41,8 @@ def get_responses(
     qkv_format = args.qkv_format
 
     if not args.true_on_policy_mode:
-        assert logits.dtype == torch.float32, f"{logits.dtype}"
+        # FSDP hands native bf16 here (no full-vocab fp32 buffer); chunks are upcast to fp32 downstream
+        assert logits.dtype in (torch.float32, torch.bfloat16), f"{logits.dtype}"
     assert len(logits.shape) == 3, f"{logits.shape}"
 
     if qkv_format == "thd":
@@ -51,8 +52,13 @@ def get_responses(
         assert max_seq_lens is not None
         logits = logits.view(-1, logits.size(-1))
 
+    defer_temperature_to_chunks = False
     if logits.size(-1) > 1 and args.rollout_temperature > 0 and args.rollout_temperature != 1.0:
-        logits = logits.div(args.rollout_temperature)
+        if args.true_on_policy_mode or logits.dtype == torch.float32:
+            logits = logits.div(args.rollout_temperature)
+        else:
+            # bf16 logits: dividing before the fp32 upcast rounds the quotient back to bf16; defer to the chunk
+            defer_temperature_to_chunks = True
     if args.true_on_policy_mode:
         if getattr(args, "bf16", False):
             logits = logits.to(torch.bfloat16)
@@ -124,6 +130,8 @@ def get_responses(
 
         seq_start += total_length
 
+        if defer_temperature_to_chunks:
+            logits_chunk = logits_chunk.to(torch.float32).div(args.rollout_temperature)
         yield logits_chunk, tokens_chunk
 
 
@@ -245,7 +253,8 @@ def get_values(
         max_seq_lens=max_seq_lens,
     ):
         assert logits_chunk.size(-1) == 1, f"{logits_chunk.shape}"
-        value_list.append(logits_chunk.squeeze(-1))
+        # upcast (no-op for fp32) so value-head outputs stay fp32 even when logits arrive bf16
+        value_list.append(logits_chunk.squeeze(-1).float())
 
     res = {
         "values": value_list,

--- a/miles/backends/training_utils/loss_hub/math_utils.py
+++ b/miles/backends/training_utils/loss_hub/math_utils.py
@@ -902,19 +902,19 @@ def calculate_log_probs_and_entropy(
             logits_chunks = logits.chunk(num_chunks, dim=0)
             log_probs = []
             for tokens_chunk, logits_chunk in zip(tokens_chunks, logits_chunks, strict=True):
-                log_prob = compute_log_probs(logits_chunk.clone(), tokens_chunk, tp_group)
+                log_prob = compute_log_probs(logits_chunk.to(torch.float32, copy=True), tokens_chunk, tp_group)
                 log_probs.append(log_prob)
             log_prob = torch.cat(log_probs, dim=0)
             if with_entropy:
                 entropys = []
                 for _, logits_chunk in zip(tokens_chunks, logits_chunks, strict=True):
-                    entropy = compute_entropy_from_logits(logits_chunk.clone(), tp_group)
+                    entropy = compute_entropy_from_logits(logits_chunk.to(torch.float32, copy=True), tp_group)
                     entropys.append(entropy)
                 entropy = torch.cat(entropys, dim=0)
         else:
-            log_prob = compute_log_probs(logits.clone(), tokens, tp_group)
+            log_prob = compute_log_probs(logits.to(torch.float32, copy=True), tokens, tp_group)
             if with_entropy:
-                entropy = compute_entropy_from_logits(logits.clone(), tp_group)
+                entropy = compute_entropy_from_logits(logits.to(torch.float32, copy=True), tp_group)
     else:
         log_prob = logits.new_zeros((0,))
         if with_entropy:


### PR DESCRIPTION
Keeps logits in bf16 and upcasts per chunk inside the loss instead of materializing a full vocab fp32 buffer, saving roughly 5GB on large vocab models. The rollout temperature division now happens after the fp32 upcast on the response chunk, since dividing in bf16 rounded the quotient and inflated the train vs rollout logprob gap when temperature is not 1.