### PR TITLE
[fsdp] Gate the true-on-policy log_probs==rollout_log_probs CI assert on ci_disable_logprobs_checker

### DIFF
--- a/miles/backends/training_utils/log_utils.py
+++ b/miles/backends/training_utils/log_utils.py
@@ -203,7 +203,7 @@ def log_rollout_data(rollout_id: int, args: Namespace, rollout_data: RolloutBatc
             if "rollout/entropy" in reduced_log_dict:
                 assert 0 < reduced_log_dict["rollout/entropy"] < 0.7
 
-        if args.ci_test and args.true_on_policy_mode:
+        if args.ci_test and args.true_on_policy_mode and not args.ci_disable_logprobs_checker:
             assert log_dict["log_probs"] == log_dict["rollout_log_probs"], (
                 f"CI check failed: true_on_policy_mode is enabled, but log_probs "
                 f"({log_dict['log_probs']}) != rollout_log_probs "


### PR DESCRIPTION
Gates the strict train vs rollout logprob equality assert behind the ci_disable_logprobs_checker flag. This lets runs that expect a small gap proceed while still logging the metric.