### PR TITLE
[AMD] Enable R3 CI and add the rocm700-mi35x image variant

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -22,8 +22,9 @@ on:
           - cu13-x86
           - cu13-aarch64
           - cu12-x86
-          - rocm-mi300
-          - rocm-mi350
+          - rocm700-mi35x
+          - rocm700-mi30x
+          - rocm720-mi35x
       image_tag:
         description: 'Tag mode: latest, dev (rolling + timestamped), or custom'
         required: true

--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -149,6 +149,24 @@ RUN git clone https://github.com/radixark/miles.git /root/miles && \
     cp -r /tmp/amd_patch/sglang_attn_bridge/. miles/backends/experimental/fsdp_utils/sglang_attn_bridge/ && \
     pip install -e . --no-deps
 
+# ====================================== Install sgl-model-gateway ============================================
+ARG SGL_ROUTER_REPO=https://github.com/radixark/sgl-router-for-miles.git
+ARG SGL_ROUTER_BRANCH=main
+
+RUN --mount=type=cache,target=/root/.cache/pip \
+    set -eux; \
+    export PATH="/root/.cargo/bin:${PATH}"; \
+    git clone --branch "${SGL_ROUTER_BRANCH}" --depth 1 "${SGL_ROUTER_REPO}" /build/sgl-model-gateway && \
+    cd /build/sgl-model-gateway/bindings/python && \
+    ulimit -n 65536 && \
+    maturin build --release --features vendored-openssl --out /build/gateway_wheels && \
+    cd /build/sgl-model-gateway && \
+    cargo build --release --bin sgl-model-gateway --features vendored-openssl && \
+    cp target/release/sgl-model-gateway /usr/local/bin/sgl-model-gateway && \
+    chmod +x /usr/local/bin/sgl-model-gateway && \
+    pip install --force-reinstall --no-deps /build/gateway_wheels/sglang_router-*.whl && \
+    rm -rf /build/sgl-model-gateway /build/gateway_wheels
+
 # ====================================== Runtime knobs ==========================================
 
 # Runtime knobs consumed by the current SGLang/PyTorch stack.

--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -96,25 +96,14 @@ RUN rm -rf /root/Megatron-LM && \
     git apply /tmp/amd_patch/megatron.patch && \
     pip install -e .
 
-RUN pip uninstall -y sgl_kernel sglang || true
 RUN cd /sgl-workspace/sglang && \
     git reset --hard && \
-    git clean -fdx && \
     git fetch origin ${SGLANG_BRANCH} && \
     if [ -n "${SGLANG_COMMIT}" ]; then \
       git checkout ${SGLANG_COMMIT}; \
     else \
       git checkout FETCH_HEAD; \
     fi && \
-    git submodule sync --recursive && \
-    git submodule update --init --recursive && \
-    cd sgl-kernel && \
-    rm -f pyproject.toml && \
-    mv pyproject_rocm.toml pyproject.toml && \
-    AMDGPU_TARGET=${GPU_ARCH} python setup_rocm.py install && \
-    cd .. && \
-    rm -rf python/pyproject.toml && \
-    mv python/pyproject_other.toml python/pyproject.toml && \
     pip install -e "python[all_hip]" --no-deps
 
 RUN python -c "import sglang; import sgl_kernel; print('SGLang + sgl_kernel: OK')"

--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -1,15 +1,18 @@
 # doc-dev: docs/ci/02-docker-build.md
 # Multi-arch ROCm image for Miles (built on a prebuilt sglang base):
 #
-# 1. rocm/sgl-dev:MI350-355-latest  (gfx950, ROCm 7.2 / MI350 / MI355X)
-#    use default settings
+# 1. rocm700-mi35x  (gfx950, ROCm 7.0 / MI350 / MI355X)
+#    build-arg:SGLANG_IMAGE_REPO=rocm/sgl-dev  SGLANG_IMAGE_TAG=v0.5.14-rocm700-mi35x-20260627
 #
-# 2. rocm/sgl-dev:MI300-latest  (gfx942, ROCm 7.0 / MI300 / MI325)
-#    build-arg:GPU_ARCH=gfx942
-#    build-arg:SGLANG_IMAGE_TAG=v0.5.10-rocm700-mi30x
+# 2. rocm700-mi30x  (gfx942, ROCm 7.0 / MI300 / MI325)
+#    build-arg:GPU_ARCH=gfx942  SGLANG_IMAGE_TAG=v0.5.10-rocm700-mi30x
+#
+# 3. rocm720-mi35x  (gfx950, ROCm 7.2 / MI350 / MI355X)
+#    build-arg:SGLANG_IMAGE_TAG=v0.5.10-rocm720-mi35x
 
-ARG SGLANG_IMAGE_TAG=v0.5.10-rocm720-mi35x
-FROM lmsysorg/sglang:${SGLANG_IMAGE_TAG} AS sglang
+ARG SGLANG_IMAGE_REPO=lmsysorg/sglang
+ARG SGLANG_IMAGE_TAG=v0.5.10-rocm700-mi35x
+FROM ${SGLANG_IMAGE_REPO}:${SGLANG_IMAGE_TAG} AS sglang
 
 SHELL ["/bin/bash", "-ceuxo", "pipefail"]
 
@@ -24,9 +27,6 @@ ARG MILES_COMMIT=main
 
 ARG GPU_ARCH=gfx950
 ARG MAX_JOBS=128
-
-ARG AITER_REPO=https://github.com/ROCm/aiter.git
-ARG AITER_COMMIT=v0.1.11.post1
 
 ARG RCCL_TESTS_REPO=https://github.com/ROCm/rocm-systems.git
 ARG RCCL_TESTS_BRANCH=develop
@@ -130,11 +130,11 @@ RUN pip install "nvidia-modelopt[torch]>=0.37.0" --no-build-isolation
 # still import it; re-pin to the base image's setuptools.
 RUN pip install "setuptools==79.0.1"
 
-# Pin the CLI stack (typer/click) for huggingface_hub / Ray compatibility.
-RUN pip install "typer==0.25.1" "click==8.2.1"
-
 RUN rm -rf /usr/lib/python3/dist-packages/jwt /usr/lib/python3/dist-packages/PyJWT* && \
     pip install -r /tmp/requirements.txt
+
+# Pin the CLI stack (typer/click) for huggingface_hub / Ray compatibility.
+RUN pip install "typer==0.25.1" "click==8.2.1"
 
 # Pin numpy 1.x for Megatron compatibility.
 RUN pip install "numpy<2"

--- a/docker/build.py
+++ b/docker/build.py
@@ -49,17 +49,18 @@ VARIANTS = {
             "WHEELS_TAG_X86": "cu129-x86_64-v0.5.12",
         },
     },
-    "rocm-mi350": {
+    "rocm700-mi35x": {
         "image": "rocm/sgl-dev",
-        "tag_postfix": "-rocm720-mi35x",
+        "tag_postfix": "-rocm700-mi35x",
         "tag_prefix": "miles",
         "dockerfile": "docker/Dockerfile.rocm",
         "build_args": {
             "GPU_ARCH": "gfx950",
-            "SGLANG_IMAGE_TAG": "v0.5.10-rocm720-mi35x",
+            "SGLANG_IMAGE_REPO": "rocm/sgl-dev",
+            "SGLANG_IMAGE_TAG": "v0.5.14-rocm700-mi35x-20260627",
         },
     },
-    "rocm-mi300": {
+    "rocm700-mi30x": {
         "image": "rocm/sgl-dev",
         "tag_postfix": "-rocm700-mi30x",
         "tag_prefix": "miles",
@@ -67,6 +68,16 @@ VARIANTS = {
         "build_args": {
             "GPU_ARCH": "gfx942",
             "SGLANG_IMAGE_TAG": "v0.5.10-rocm700-mi30x",
+        },
+    },
+    "rocm720-mi35x": {
+        "image": "rocm/sgl-dev",
+        "tag_postfix": "-rocm720-mi35x",
+        "tag_prefix": "miles",
+        "dockerfile": "docker/Dockerfile.rocm",
+        "build_args": {
+            "GPU_ARCH": "gfx950",
+            "SGLANG_IMAGE_TAG": "v0.5.10-rocm720-mi35x",
         },
     },
 }
@@ -143,8 +154,9 @@ class Variant(str, Enum):
     cu13_x86 = "cu13-x86"
     cu13_aarch64 = "cu13-aarch64"
     cu12_x86 = "cu12-x86"
-    rocm_mi350 = "rocm-mi350"
-    rocm_mi300 = "rocm-mi300"
+    rocm700_mi35x = "rocm700-mi35x"
+    rocm700_mi30x = "rocm700-mi30x"
+    rocm720_mi35x = "rocm720-mi35x"
 
 
 class ImageTag(str, Enum):

--- a/tests/e2e/megatron/test_qwen3_30B_A3B/test_r3_baseline.py
+++ b/tests/e2e/megatron/test_qwen3_30B_A3B/test_r3_baseline.py
@@ -1,9 +1,10 @@
 import os
 
-from tests.ci.ci_register import register_cuda_ci
+from tests.ci.ci_register import register_cuda_ci, register_rocm_ci
 from tests.e2e.megatron.test_qwen3_30B_A3B._common import CaseConfig, execute, prepare
 
 register_cuda_ci(est_time=1200, suite="stage-c-4-gpu-h200", labels=["megatron", "replay"])
+register_rocm_ci(est_time=1500, suite="stage-c-4-gpu-mi350", labels=["megatron", "replay"])
 
 CASE = CaseConfig(
     use_deepep=False,


### PR DESCRIPTION
Co-authored-with: @XinyuJiangCMU 

## What

1. Enable rollout routing replay (R3): Build sgl-router-for-miles and register `test_r3_baseline` on ROCm CI (`stage-c-4-gpu-mi350`).

2. Add the `rocm700-mi35x` image variant and standardize the ROCm variant naming to `rocm<version>-mi<arch>` (migrated from [#1474](https://github.com/radixark/miles/pull/1474)).

3. Bump the `rocm700-mi35x` base image to `rocm/sgl-dev:v0.5.14-rocm700-mi35x-20260627` (adapted from [#1506](https://github.com/radixark/miles/pull/1506)).

4. Cleanup: remove dead aiter build args and drop the redundant sgl-kernel rebuild.

## Test

Built the ROCm image and ran `test_r3_baseline` on MI355X successfully.