### PR TITLE
refactor(utils): make loss mask generation strategy-based

### DIFF
--- a/docs/user-guide/argument-groups.md
+++ b/docs/user-guide/argument-groups.md
@@ -68,6 +68,7 @@ produces.
 | Rollout volume | `--rollout-batch-size`, `--n-samples-per-prompt`, `--num-rollout` |
 | Training consumption | `--global-batch-size`, `--num-steps-per-rollout` |
 | Sampling | `--rollout-temperature`, `--rollout-top-p`, `--rollout-max-response-len` |
+| Loss mask | `--loss-mask-type` |
 | Reward | `--rm-type`, `--custom-rm-path` |
 | Filtering | `--over-sampling-batch-size`, `--dynamic-sampling-filter-path` |
 

--- a/docs/user-guide/customization.md
+++ b/docs/user-guide/customization.md
@@ -13,6 +13,7 @@ and the default it replaces.
 | **Rollout** | `--rollout-function-path` | The whole rollout loop |
 | | `--custom-generate-function-path` | A single sample's generation |
 | | `--data-source-path` | How prompts are loaded |
+| | `--loss-mask-type` | How chat prompts become token IDs and loss masks |
 | | `--eval-function-path` | The eval rollout |
 | **Reward** | `--custom-rm-path` | Reward computation |
 | | `--custom-reward-post-process-path` | Reward normalization |
@@ -82,6 +83,56 @@ class CustomDataSource(DataSource):
 
 Same signature as `--rollout-function-path`. Defaults to whatever rollout function is
 configured.
+
+### `--loss-mask-type`
+
+Select or override the strategy that converts chat-formatted prompts into token IDs
+and a 0/1 loss mask. Built-in registered names are `qwen`, `qwen3`, and
+`distill_qwen` (auto-detected when `qwen` tokenizers contain `<｜Assistant｜>`).
+
+The value can be either a registered strategy name or a fully-qualified
+`LossMaskStrategy` subclass path.
+
+Implement a custom strategy by subclassing `LossMaskStrategy`:
+
+```python
+from miles.utils.mask_utils import LossMaskStrategy
+
+class MyCustomLossMask(LossMaskStrategy):
+    def get_loss_mask(
+        self, messages: list[dict], tools: list[dict] | None = None
+    ) -> tuple[list[int], list[int]]:
+        # token_ids and loss_mask must have the same length
+        token_ids = []
+        loss_mask = []
+        ...
+        return token_ids, loss_mask
+```
+
+Use it directly by class path:
+
+```bash
+--loss-mask-type my_package.my_module.MyCustomLossMask
+```
+
+Or register it under a short name so callers do not need the full path:
+
+```python
+from miles.utils.mask_utils import register_loss_mask
+
+@register_loss_mask("my_custom")
+class MyCustomLossMask(LossMaskStrategy):
+    ...
+```
+
+Import the module before the strategy is resolved (e.g., in the same process that
+launches training) and then use the short name:
+
+```bash
+python -c "import my_package.my_module" && python train.py --loss-mask-type my_custom
+```
+
+**Default:** `qwen`.
 
 ---
 

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -1875,8 +1875,10 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 "--loss-mask-type",
                 type=str,
                 default="qwen",
-                choices=["qwen", "qwen3", "distill_qwen"],
-                help="Loss mask type",
+                help=(
+                    "Loss mask strategy. A registered name (e.g., qwen, qwen3, distill_qwen) "
+                    "or a fully-qualified LossMaskStrategy subclass path (e.g., my_module.MyStrategy)."
+                ),
             )
             parser.add_argument(
                 "--data-pad-size-multiplier",

--- a/miles/utils/mask_utils.py
+++ b/miles/utils/mask_utils.py
@@ -1,8 +1,17 @@
-import importlib
+"""Loss-mask strategies for SFT training.
+
+Follows the same ABC + registry + dispatcher pattern as
+``miles/utils/tracking_utils/base.py`` (TrackingBackend / BACKEND_REGISTRY /
+TrackingManager).  Strategies may hold per-run cached state (e.g.
+system_message_length) computed once at construction and reused across samples.
+"""
+
 from abc import ABC, abstractmethod
 from typing import Any
 
 from transformers import AutoTokenizer
+
+from miles.utils.misc import load_function
 
 
 def get_response_lengths(loss_masks: list[list[int]]) -> list[int]:
@@ -209,13 +218,11 @@ class MultiTurnLossMaskGenerator:
         # Allow fully-qualified class paths for custom strategies without registration.
         if "." in strategy_name:
             try:
-                module_path, class_name = strategy_name.rsplit(".", 1)
-                module = importlib.import_module(module_path)
-                cls = getattr(module, class_name)
+                cls = load_function(strategy_name)
                 if not isinstance(cls, type) or not issubclass(cls, LossMaskStrategy):
                     raise TypeError(f"{strategy_name} is not a LossMaskStrategy subclass")
                 return cls(tokenizer)
-            except (ImportError, AttributeError, ValueError, TypeError) as exc:
+            except (ImportError, AttributeError, TypeError) as exc:
                 raise ValueError(
                     f"Unable to load loss mask strategy {strategy_name!r}. "
                     f"Ensure it is a registered name or a fully-qualified LossMaskStrategy subclass."

--- a/miles/utils/mask_utils.py
+++ b/miles/utils/mask_utils.py
@@ -1,3 +1,7 @@
+import importlib
+from abc import ABC, abstractmethod
+from typing import Any
+
 from transformers import AutoTokenizer
 
 
@@ -6,16 +10,57 @@ def get_response_lengths(loss_masks: list[list[int]]) -> list[int]:
     return [len(mask[mask.index(1) :]) if 1 in mask else 0 for mask in loss_masks]
 
 
-class MultiTurnLossMaskGenerator:
-    def __init__(self, tokenizer: AutoTokenizer, tokenizer_type: str = "qwen"):
+LOSS_MASK_REGISTRY: dict[str, type["LossMaskStrategy"]] = {}
+
+
+def register_loss_mask(name: str):
+    """Register a loss mask strategy under one or more names.
+
+    Examples:
+        @register_loss_mask("my_custom")
+        class MyCustomStrategy(LossMaskStrategy):
+            ...
+    """
+    if not isinstance(name, str):
+        raise TypeError(f"Loss mask strategy name must be a string, got {name}")
+
+    def decorator(cls: Any) -> type["LossMaskStrategy"]:
+        if not isinstance(cls, type) or not issubclass(cls, LossMaskStrategy):
+            raise TypeError(f"Only LossMaskStrategy subclasses can be registered, got {cls}")
+        # protect from cases of module reload
+        if name in LOSS_MASK_REGISTRY and LOSS_MASK_REGISTRY[name] is not cls:
+            raise ValueError(f"Loss mask strategy {name!r} is already registered by a different class")
+        LOSS_MASK_REGISTRY[name] = cls
+        return cls
+
+    return decorator
+
+
+class LossMaskStrategy(ABC):
+    """Contract for generating a loss mask for a chat-formatted conversation."""
+
+    def __init__(self, tokenizer: AutoTokenizer):
         self.tokenizer = tokenizer
-        self.system_message_length, self.gen_token_length = self.get_system_message_length()
-        self.tokenizer_type = tokenizer_type
 
-    def get_response_lengths(self, loss_masks: list[list[int]]) -> list[int]:
-        return get_response_lengths(loss_masks)
+    @abstractmethod
+    def get_loss_mask(self, messages: list[dict], tools: list[dict] | None = None) -> tuple[list[int], list[int]]:
+        """Return (token_ids, loss_mask) for the given messages.
 
-    def find_all_sublist_indices(self, main_list, sublist):
+        The loss mask should have the same length as token_ids and contain 0/1
+        values indicating which tokens participate in loss calculation.
+        """
+        ...
+
+
+class BasePerMessageLossMaskStrategy(LossMaskStrategy):
+    """Shared machinery for strategies that build masks message-by-message."""
+
+    def __init__(self, tokenizer: AutoTokenizer):
+        super().__init__(tokenizer)
+        self.system_message_length, self.gen_token_length = self._get_system_message_length()
+
+    @staticmethod
+    def _find_all_sublist_indices(main_list, sublist):
         sublist_len = len(sublist)
         indices = []
         for i in range(len(main_list) - sublist_len + 1):
@@ -23,7 +68,7 @@ class MultiTurnLossMaskGenerator:
                 indices.append(i)
         return indices
 
-    def get_system_message_length(self) -> tuple[int, int]:
+    def _get_system_message_length(self) -> tuple[int, int]:
         test_string = "FOR TESTING ONLY"
         test_messages = [
             {"role": "user", "content": test_string},
@@ -34,7 +79,14 @@ class MultiTurnLossMaskGenerator:
             test_messages, add_special_tokens=False, tokenize=False
         )
         chat_template_token_ids = self.tokenizer(chat_template_token, add_special_tokens=False)["input_ids"]
-        idx_1, idx_2 = self.find_all_sublist_indices(chat_template_token_ids, raw_token_ids)
+        indices = self._find_all_sublist_indices(chat_template_token_ids, raw_token_ids)
+        if len(indices) != 2:
+            raise ValueError(
+                f"Expected to find raw token IDs exactly twice in the chat template, "
+                f"but found {len(indices)} occurrences. This can happen if the chat template "
+                f"or tokenizer behavior is incompatible with the system message length detection."
+            )
+        idx_1, idx_2 = indices[0], indices[1]
         end_interval = len(chat_template_token_ids) - len(raw_token_ids) - idx_2
         gen_token_length = len(
             self.tokenizer.apply_chat_template(
@@ -45,9 +97,15 @@ class MultiTurnLossMaskGenerator:
         system_message_length = idx_1 - ((idx_2 - idx_1) - end_interval - len(raw_token_ids))
         return system_message_length, gen_token_length
 
-    def gen_multi_turn_loss_mask_qwen(
-        self, messages: list[dict], tools: list[dict] = None
-    ) -> tuple[list[int], list[int]]:
+    def _apply_step_loss_mask(self, message: dict, loss_mask: list[int]) -> list[int]:
+        if message.get("step_loss_mask", 1) != 1:
+            return [0] * len(loss_mask)
+        return loss_mask
+
+
+@register_loss_mask("qwen")
+class QwenLossMaskStrategy(BasePerMessageLossMaskStrategy):
+    def get_loss_mask(self, messages: list[dict], tools: list[dict] | None = None) -> tuple[list[int], list[int]]:
         all_loss_masks = []
         all_token_ids = []
 
@@ -67,17 +125,17 @@ class MultiTurnLossMaskGenerator:
             else:
                 loss_mask = [0] * len(message_ids)
 
-            if message.get("step_loss_mask", 1) != 1:
-                loss_mask = [0] * len(message_ids)
+            loss_mask = self._apply_step_loss_mask(message, loss_mask)
 
             all_loss_masks.extend(loss_mask)
             all_token_ids.extend(message_ids)
 
         return all_token_ids, all_loss_masks
 
-    def gen_multi_turn_loss_mask_qwen3(
-        self, messages: list[dict], tools: list[dict] = None
-    ) -> tuple[list[int], list[int]]:
+
+@register_loss_mask("qwen3")
+class Qwen3LossMaskStrategy(BasePerMessageLossMaskStrategy):
+    def get_loss_mask(self, messages: list[dict], tools: list[dict] | None = None) -> tuple[list[int], list[int]]:
         all_loss_masks = []
         all_token_ids = []
 
@@ -104,17 +162,17 @@ class MultiTurnLossMaskGenerator:
             else:
                 loss_mask = [0] * len(message_ids)
 
-            if message.get("step_loss_mask", 1) != 1:
-                loss_mask = [0] * len(message_ids)
+            loss_mask = self._apply_step_loss_mask(message, loss_mask)
 
             all_loss_masks.extend(loss_mask)
             all_token_ids.extend(message_ids)
 
         return all_token_ids, all_loss_masks
 
-    def gen_multi_turn_loss_mask_distill_qwen(
-        self, messages: list[dict], tools: list[dict] = None
-    ) -> tuple[list[int], list[int]]:
+
+@register_loss_mask("distill_qwen")
+class DistillQwenLossMaskStrategy(LossMaskStrategy):
+    def get_loss_mask(self, messages: list[dict], tools: list[dict] | None = None) -> tuple[list[int], list[int]]:
         prompt = self.tokenizer.apply_chat_template(
             messages[:1], tokenize=False, add_generation_prompt=True, tools=tools
         )
@@ -130,21 +188,51 @@ class MultiTurnLossMaskGenerator:
             loss_mask = [0] * len(token_ids)
         return token_ids, loss_mask
 
-    def get_loss_mask(self, messages: list[dict], tools: list[dict] = None) -> tuple[list[int], list[int]]:
-        if self.tokenizer_type == "qwen":
-            if "<｜Assistant｜>" in self.tokenizer.get_added_vocab():
-                return self.gen_multi_turn_loss_mask_distill_qwen(messages, tools)
 
-            return self.gen_multi_turn_loss_mask_qwen(messages, tools)
-        elif self.tokenizer_type == "qwen3":
-            return self.gen_multi_turn_loss_mask_qwen3(messages, tools)
-        elif self.tokenizer_type == "distill_qwen":
-            return self.gen_multi_turn_loss_mask_distill_qwen(messages, tools)
-        else:
-            raise ValueError(f"Unsupported tokenizer type: {self.tokenizer_type}")
+class MultiTurnLossMaskGenerator:
+    """Dispatcher that selects and delegates to a LossMaskStrategy."""
+
+    def __init__(self, tokenizer: AutoTokenizer, tokenizer_type: str = "qwen"):
+        self.tokenizer = tokenizer
+        self.loss_mask_type = tokenizer_type
+        self.tokenizer_type = tokenizer_type  # historical alias
+        self.strategy = self._resolve_strategy(tokenizer, tokenizer_type)
+
+    def _resolve_strategy(self, tokenizer: AutoTokenizer, strategy_name: str) -> LossMaskStrategy:
+        # Auto-detect distillation variants for the qwen family.
+        if strategy_name == "qwen" and "<｜Assistant｜>" in tokenizer.get_added_vocab():
+            strategy_name = "distill_qwen"
+
+        if strategy_name in LOSS_MASK_REGISTRY:
+            return LOSS_MASK_REGISTRY[strategy_name](tokenizer)
+
+        # Allow fully-qualified class paths for custom strategies without registration.
+        if "." in strategy_name:
+            try:
+                module_path, class_name = strategy_name.rsplit(".", 1)
+                module = importlib.import_module(module_path)
+                cls = getattr(module, class_name)
+                if not isinstance(cls, type) or not issubclass(cls, LossMaskStrategy):
+                    raise TypeError(f"{strategy_name} is not a LossMaskStrategy subclass")
+                return cls(tokenizer)
+            except (ImportError, AttributeError, ValueError, TypeError) as exc:
+                raise ValueError(
+                    f"Unable to load loss mask strategy {strategy_name!r}. "
+                    f"Ensure it is a registered name or a fully-qualified LossMaskStrategy subclass."
+                ) from exc
+
+        raise ValueError(
+            f"Unsupported loss mask type: {strategy_name!r}. " f"Registered types: {sorted(LOSS_MASK_REGISTRY)}"
+        )
+
+    def get_response_lengths(self, loss_masks: list[list[int]]) -> list[int]:
+        return get_response_lengths(loss_masks)
+
+    def get_loss_mask(self, messages: list[dict], tools: list[dict] | None = None) -> tuple[list[int], list[int]]:
+        return self.strategy.get_loss_mask(messages, tools=tools)
 
     def get_loss_mask_with_multimodal_alignment(
-        self, messages: list[dict], input_ids: list[int], tools: list[dict] = None
+        self, messages: list[dict], input_ids: list[int], tools: list[dict] | None = None
     ) -> tuple[list[int], list[int]]:
         text = []
         for msg in messages:

--- a/tests/fast/utils/test_mask_utils.py
+++ b/tests/fast/utils/test_mask_utils.py
@@ -1,4 +1,4 @@
-from miles.utils.mask_utils import MultiTurnLossMaskGenerator
+from miles.utils.mask_utils import LOSS_MASK_REGISTRY, MultiTurnLossMaskGenerator
 from miles.utils.processing_utils import load_tokenizer
 
 
@@ -10,7 +10,7 @@ def test_loss_mask_qwen3_simple(model_name: str = "Qwen/Qwen3-8B"):
         {"role": "user", "content": "USER CONTENT FOR TESTING ONLY"},
         {"role": "assistant", "content": "ASSISTANT RESPONSE FOR TESTING ONLY"},
     ]
-    all_token_ids, all_loss_masks = mask_generator.gen_multi_turn_loss_mask_qwen3(messages)
+    all_token_ids, all_loss_masks = mask_generator.get_loss_mask(messages)
     assert len(all_token_ids) == len(all_loss_masks), f"{len(all_token_ids)} != {len(all_loss_masks)}"
     selected_texts = mask_generator.get_text_from_loss_mask(all_token_ids, all_loss_masks)
     assert len(selected_texts) == 1, f"Expected 1 text, got {len(selected_texts)}"
@@ -81,7 +81,7 @@ def test_loss_mask_qwen3_tools(model_name: str = "Qwen/Qwen3-8B"):
         },
     ]
 
-    all_token_ids, all_loss_masks = mask_generator.gen_multi_turn_loss_mask_qwen3(messages, tools)
+    all_token_ids, all_loss_masks = mask_generator.get_loss_mask(messages, tools=tools)
     assert len(all_token_ids) == len(all_loss_masks), f"{len(all_token_ids)} != {len(all_loss_masks)}"
     selected_texts = mask_generator.get_text_from_loss_mask(all_token_ids, all_loss_masks)
     assert len(selected_texts) == 2, f"Expected 2 texts, got {len(selected_texts)}"
@@ -93,6 +93,31 @@ def test_loss_mask_qwen3_tools(model_name: str = "Qwen/Qwen3-8B"):
     print("selected_texts = ", selected_texts)
 
 
+def test_loss_mask_registry_contains_builtins():
+    assert "qwen" in LOSS_MASK_REGISTRY
+    assert "qwen3" in LOSS_MASK_REGISTRY
+    assert "distill_qwen" in LOSS_MASK_REGISTRY
+
+
+def test_loss_mask_custom_class_path(model_name: str = "Qwen/Qwen3-8B"):
+    tokenizer = load_tokenizer(model_name)
+    mask_generator = MultiTurnLossMaskGenerator(
+        tokenizer,
+        tokenizer_type="miles.utils.mask_utils.Qwen3LossMaskStrategy",
+    )
+    messages = [
+        {"role": "system", "content": "SYSTEM MESSAGE FOR TESTING ONLY"},
+        {"role": "user", "content": "USER CONTENT FOR TESTING ONLY"},
+        {"role": "assistant", "content": "ASSISTANT RESPONSE FOR TESTING ONLY"},
+    ]
+    all_token_ids, all_loss_masks = mask_generator.get_loss_mask(messages)
+    assert len(all_token_ids) == len(all_loss_masks)
+    selected_texts = mask_generator.get_text_from_loss_mask(all_token_ids, all_loss_masks)
+    assert len(selected_texts) == 1, f"Expected 1 text, got {len(selected_texts)}"
+
+
 if __name__ == "__main__":
     test_loss_mask_qwen3_simple("Qwen/Qwen3-Coder-30B-A3B-Instruct")
     test_loss_mask_qwen3_tools("Qwen/Qwen3-Coder-30B-A3B-Instruct")
+    test_loss_mask_registry_contains_builtins()
+    test_loss_mask_custom_class_path("Qwen/Qwen3-Coder-30B-A3B-Instruct")


### PR DESCRIPTION
This refactors the loss mask path from a hardcoded tokenizer_type if/else into an interface/contract-based design, making it easier to add custom loss masks without modifying core code.

Changes:
- Introduce `LossMaskStrategy` ABC and a `register_loss_mask` decorator / `LOSS_MASK_REGISTRY`.
- Convert the existing Qwen family masks (`qwen`, `qwen3`, `distill_qwen`) into registered strategy classes.
- Make `MultiTurnLossMaskGenerator` a dispatcher that resolves the strategy by registered name or fully-qualified class path.
- Update `--loss-mask-type` in `arguments.py` to accept any registered name or class path.
- Update `tests/fast/utils/test_mask_utils.py` for the new contract and add registry/class-path tests.
- Document the new hook in `docs/user-guide/customization.md` and `docs/user-guide/argument-groups.md`.

Custom usage:

```python
from miles.utils.mask_utils import LossMaskStrategy

class MyMask(LossMaskStrategy):
    def get_loss_mask(self, messages, tools=None):
        ...
        return token_ids, loss_mask
```

Then pass `--loss-mask-type my_pkg.module.MyMask`, or register it with `@register_loss_mask("my_mask")` and use `--loss-mask-type my_mask`.

Related to the discussion in #1522 about a more extensible loss mask implementation.