### PR TITLE
feat(trainer): defer multimodal CUDA transfer for VLM training

### DIFF
--- a/docs/models/qwen/qwen3-6.md
+++ b/docs/models/qwen/qwen3-6.md
@@ -117,6 +117,10 @@ From `scripts/models/qwen3.6-27B.sh`:
 - `--apply-layernorm-1p`, `--qk-layernorm`, `--group-query-attention`.
 - `--attention-output-gate`.
 
+If the trainer OOMs on image-heavy batches, add `--defer-multimodal-cuda-transfer`:
+image tensors stay on pinned CPU memory and only the active micro-batch is moved to
+the GPU during collation. See [CLI Reference: Memory and throughput](/user-guide/cli-reference#memory-and-throughput).
+
 See [Backends Beyond Megatron](/advanced/architecture-support) for how miles
 preserves FP32 parameters like `A_log` through Megatron's mixed-precision pipeline.
 

--- a/docs/user-guide/cli-reference.md
+++ b/docs/user-guide/cli-reference.md
@@ -57,9 +57,15 @@ rollout_batch_size × n_samples_per_prompt
 | `--recompute-granularity` | Megatron default | `full` or `selective`. |
 | `--recompute-method` | Megatron default | `uniform` or `block`. |
 | `--recompute-num-layers` | Megatron default | Layers per recompute chunk. |
+| `--defer-multimodal-cuda-transfer` | off | VLM only: keep image tensors on CPU, move each micro-batch to GPU on demand. Cuts peak GPU memory. |
 
 Rule of thumb: start with `max_tokens_per_gpu = rollout_max_response_len / cp_size`,
 then push up until you OOM.
+
+For vision-language runs that OOM in the trainer, `--defer-multimodal-cuda-transfer`
+keeps the whole rollout's image features (`pixel_values`, `image_grid_thw`, ...) on
+pinned host memory and copies only the active micro-batch to the GPU during
+collation, trading a per-micro-batch host→device copy for lower peak memory.
 
 ### RL algorithm
 
@@ -217,6 +223,7 @@ Sections mirror the launch-script argument groups.
 | `--recompute-granularity` | enum | Megatron default | `full` or `selective`. |
 | `--recompute-method` | enum | Megatron default | `uniform` or `block`. |
 | `--recompute-num-layers` | int | Megatron default | Recompute chunk size. |
+| `--defer-multimodal-cuda-transfer` | flag | off | VLM only: hold multimodal tensors on pinned CPU, move each micro-batch to GPU during collation. Lowers peak GPU memory at the cost of a per-micro-batch host→device copy. |
 | `--gradient-checkpointing` | flag | off | FSDP equivalent of recompute flags. |
 | `--fsdp-cpu-offload` | flag | off | FSDP: offload params, grads, optimizer state to CPU. |
 | `--fsdp-cpu-backend` | str | `gloo` | FSDP: CPU backend for hybrid offload. |

--- a/miles/backends/training_utils/data.py
+++ b/miles/backends/training_utils/data.py
@@ -68,7 +68,11 @@ def get_rollout_data(
         # GPU in advance; with --defer-multimodal-cuda-transfer they stay on
         # pinned CPU memory and only the active microbatch is moved to CUDA
         # during collation (see collate_multimodal_train_inputs).
-        target_device = torch.device("cpu") if args.defer_multimodal_cuda_transfer else torch.cuda.current_device()
+        target_device = (
+            torch.device("cpu")
+            if getattr(args, "defer_multimodal_cuda_transfer", False)
+            else torch.cuda.current_device()
+        )
         rollout_data["multimodal_train_inputs"] = materialize_multimodal_inputs(
             rollout_data["multimodal_train_inputs"],
             target_device,

--- a/miles/backends/training_utils/data.py
+++ b/miles/backends/training_utils/data.py
@@ -15,7 +15,11 @@ from miles.utils.types import RolloutBatch
 from ...utils.data import process_rollout_data
 from ...utils.ray_utils import Box
 from .cp_utils import slice_log_prob_with_cp, slice_with_cp
-from .mm_data import expand_multimodal_rollout_data_in_place
+from .mm_data import (
+    collate_multimodal_train_inputs,
+    expand_multimodal_rollout_data_in_place,
+    materialize_multimodal_inputs,
+)
 from .parallel import get_parallel_state
 
 logger = logging.getLogger(__name__)
@@ -60,15 +64,15 @@ def get_rollout_data(
         ]
 
     if "multimodal_train_inputs" in rollout_data:
-        # Move multimodal training tensors to GPU in advance
-        rollout_data["multimodal_train_inputs"] = [
-            (
-                {key: tensor.to(device=torch.cuda.current_device()) for key, tensor in mm_dict.items()}
-                if mm_dict is not None
-                else None
-            )
-            for mm_dict in rollout_data["multimodal_train_inputs"]
-        ]
+        # Materialize multimodal training tensors. By default they are moved to
+        # GPU in advance; with --defer-multimodal-cuda-transfer they stay on
+        # pinned CPU memory and only the active microbatch is moved to CUDA
+        # during collation (see collate_multimodal_train_inputs).
+        target_device = torch.device("cpu") if args.defer_multimodal_cuda_transfer else torch.cuda.current_device()
+        rollout_data["multimodal_train_inputs"] = materialize_multimodal_inputs(
+            rollout_data["multimodal_train_inputs"],
+            target_device,
+        )
 
     if args.qkv_format == "bshd":
         # TODO: micro-batch wise dynamic, possibly move to @data.py:get_data_iterator
@@ -294,20 +298,14 @@ def get_batch(
     assert loss_masks.shape == tokens.shape, f"loss_masks.shape: {loss_masks.shape}, tokens.shape: {tokens.shape}"
     batch["full_loss_masks"] = loss_masks
 
-    # Process multimodal training tensors if present
-    multimodal_train_inputs = batch.get("multimodal_train_inputs", None)
-    if multimodal_train_inputs is not None:
-        multimodal_data = {}  # key -> concatenated tensor
-        multimodal_num_items = {}  # key -> list of item counts per sequence
-        for mm_input_dict in multimodal_train_inputs:
-            if mm_input_dict is not None:
-                for key, mm_tensor in mm_input_dict.items():
-                    if key not in multimodal_data:
-                        multimodal_data[key] = mm_tensor
-                        multimodal_num_items[key] = [mm_tensor.size(0)]
-                    else:
-                        multimodal_data[key] = torch.cat([multimodal_data[key], mm_tensor], dim=0)
-                        multimodal_num_items[key].append(mm_tensor.size(0))
+    # Process multimodal training tensors if present. Only the active
+    # microbatch is collated here, and its tensors are placed on CUDA — moving
+    # deferred (pinned CPU) payloads over just before the model forward.
+    if (multimodal_train_inputs := batch.get("multimodal_train_inputs")) is not None:
+        multimodal_data, multimodal_num_items = collate_multimodal_train_inputs(
+            multimodal_train_inputs,
+            torch.cuda.current_device(),
+        )
         batch["multimodal_train_inputs"] = multimodal_data
         batch["multimodal_num_items"] = multimodal_num_items
 

--- a/miles/backends/training_utils/mm_data.py
+++ b/miles/backends/training_utils/mm_data.py
@@ -1,15 +1,23 @@
-"""Multimodal-specific preprocessing for rollout data.
+"""Multimodal-specific preprocessing and tensor movement for rollout data.
 
-Currently Kimi-VL / Kimi-K2.5-only: the rollout side emits one media
-placeholder token per image, and training expands it to grid-derived token
-counts so the LM sees a position per vision patch.  Kept separate from
-data.py (generic batching / CP slicing) so additional VL models can land
-without inflating that module.
+Two concerns live here, kept out of data.py (generic batching / CP slicing)
+so additional VL models can land without inflating that module:
+
+1. Token expansion (currently Kimi-VL / Kimi-K2.5-only): the rollout side
+   emits one media placeholder token per image, and training expands it to
+   grid-derived token counts so the LM sees a position per vision patch.
+2. Multimodal tensor materialization and per-microbatch collation
+   (model-agnostic): moves image payloads (``pixel_values``, ``image_grid_thw``,
+   ...) between host and device. When ``--defer-multimodal-cuda-transfer`` is
+   set these tensors stay on pinned CPU memory after the rollout fetch and only
+   the active microbatch is copied to CUDA during collation, which avoids
+   holding a whole minibatch of vision features in GPU memory at once.
 """
 
 import logging
 from collections.abc import Sequence
 
+import numpy as np
 import torch
 
 from miles.utils.types import RolloutBatch
@@ -18,6 +26,9 @@ from .cp_utils import all_gather_with_cp, slice_log_prob_with_cp
 from .parallel import get_parallel_state
 
 logger = logging.getLogger(__name__)
+
+MultimodalValue = np.ndarray | torch.Tensor
+MultimodalInput = dict[str, MultimodalValue] | None
 
 # Kimi-K2.5 / Kimi-VL media placeholder token id.
 KIMI_VL_MEDIA_TOKEN_ID = 163605
@@ -197,3 +208,94 @@ def expand_multimodal_rollout_data_in_place(
             f"total_lengths_changed={expanded_total_lengths != old_total_lengths}, "
             f"response_lengths_changed={expanded_response_lengths != old_response_lengths}"
         )
+
+
+def _as_multimodal_tensor(value: MultimodalValue, device: torch.device | int | None) -> torch.Tensor:
+    """Convert one multimodal array-like value to a tensor on the requested device."""
+    if isinstance(value, np.ndarray):
+        tensor = torch.from_numpy(value.copy())
+    elif isinstance(value, torch.Tensor):
+        # Tensor inputs are already trainer-owned; cloning would duplicate large
+        # image payloads, including CUDA tensors in preload mode.
+        tensor = value
+    else:
+        raise TypeError(f"Expected multimodal value to be a tensor or ndarray, got {type(value).__name__}")
+    return tensor.to(device=device)
+
+
+def materialize_multimodal_inputs(
+    multimodal_inputs: Sequence[MultimodalInput],
+    device: torch.device | int,
+) -> list[dict[str, torch.Tensor] | None]:
+    """Resolve per-sequence multimodal sample dicts to tensors on ``device``.
+
+    Called once per rollout fetch. With ``device`` set to the CUDA device this
+    preloads every image payload (legacy behavior); with ``device`` set to CPU
+    (deferred mode) the tensors stay on pinned host memory so the later
+    non_blocking CPU->CUDA copy in :func:`collate_multimodal_train_inputs` can
+    overlap with compute.
+    """
+    materialized: list[dict[str, torch.Tensor] | None] = []
+    for multimodal_input in multimodal_inputs:
+        if multimodal_input is None:
+            materialized.append(None)
+            continue
+
+        materialized_input: dict[str, torch.Tensor] = {}
+        for key, value in multimodal_input.items():
+            tensor = _as_multimodal_tensor(value, device)
+            if isinstance(device, torch.device) and device.type == "cpu":
+                # Deferred tensors stay on CPU here; pin host memory so the
+                # later non_blocking CPU->CUDA copy can overlap with compute.
+                tensor = tensor.pin_memory() if torch.cuda.is_available() else tensor
+            materialized_input[key] = tensor
+        materialized.append(materialized_input)
+    return materialized
+
+
+def _cat_multimodal_tensors_for_forward(values: list[MultimodalValue], device: torch.device | int) -> torch.Tensor:
+    """Concatenate one multimodal field and place only the active microbatch on CUDA."""
+    tensors = [_as_multimodal_tensor(value, None) for value in values]
+    if any(tensor.is_cuda for tensor in tensors):
+        # Expected steady states are all-CPU in deferred mode and all-CUDA in
+        # preload mode. Mixed placement is still normalized before concatenation.
+        # non_blocking only avoids synchronization for CPU tensors backed by
+        # pinned host memory; CUDA tensors are already on the target path.
+        tensors = [tensor.to(device=device, non_blocking=True) for tensor in tensors]
+        return torch.cat(tensors, dim=0)
+    return torch.cat(tensors, dim=0).to(device=device, non_blocking=True)
+
+
+def collate_multimodal_train_inputs(
+    multimodal_train_inputs: Sequence[MultimodalInput],
+    device: torch.device | int,
+) -> tuple[dict[str, torch.Tensor], dict[str, list[int]]]:
+    """Collate the already-sliced microbatch multimodal payload for model forward.
+
+    Args:
+        multimodal_train_inputs: Per-sequence multimodal dicts selected by
+            ``DataIterator`` for the active microbatch.
+        device: CUDA device used by the current Megatron rank.
+
+    Returns:
+        A tuple of ``(multimodal_data, multimodal_num_items)``. Tensor values are
+        concatenated across the active microbatch and placed on ``device``.
+    """
+    values_by_key: dict[str, list[MultimodalValue]] = {}
+    multimodal_num_items: dict[str, list[int]] = {}
+    for mm_input_dict in multimodal_train_inputs:
+        if mm_input_dict is None:
+            continue
+        if not isinstance(mm_input_dict, dict):
+            raise TypeError(
+                f"Expected multimodal_train_inputs entries to be dict or None, got {type(mm_input_dict).__name__}"
+            )
+        for key, value in mm_input_dict.items():
+            tensor = _as_multimodal_tensor(value, None)
+            values_by_key.setdefault(key, []).append(tensor)
+            multimodal_num_items.setdefault(key, []).append(tensor.size(0))
+
+    multimodal_data = {
+        key: _cat_multimodal_tensors_for_forward(values, device) for key, values in values_by_key.items()
+    }
+    return multimodal_data, multimodal_num_items

--- a/miles/backends/training_utils/mm_data.py
+++ b/miles/backends/training_utils/mm_data.py
@@ -247,23 +247,26 @@ def materialize_multimodal_inputs(
             if isinstance(device, torch.device) and device.type == "cpu":
                 # Deferred tensors stay on CPU here; pin host memory so the
                 # later non_blocking CPU->CUDA copy can overlap with compute.
+                # pinning makes sure that the memory doesn't get paged out to disk
+                # which would make the copy synchronous.
                 tensor = tensor.pin_memory() if torch.cuda.is_available() else tensor
             materialized_input[key] = tensor
         materialized.append(materialized_input)
     return materialized
 
 
-def _cat_multimodal_tensors_for_forward(values: list[MultimodalValue], device: torch.device | int) -> torch.Tensor:
-    """Concatenate one multimodal field and place only the active microbatch on CUDA."""
-    tensors = [_as_multimodal_tensor(value, None) for value in values]
-    if any(tensor.is_cuda for tensor in tensors):
-        # Expected steady states are all-CPU in deferred mode and all-CUDA in
-        # preload mode. Mixed placement is still normalized before concatenation.
-        # non_blocking only avoids synchronization for CPU tensors backed by
-        # pinned host memory; CUDA tensors are already on the target path.
-        tensors = [tensor.to(device=device, non_blocking=True) for tensor in tensors]
-        return torch.cat(tensors, dim=0)
-    return torch.cat(tensors, dim=0).to(device=device, non_blocking=True)
+def _cat_multimodal_tensors_for_forward(tensors: list[torch.Tensor], device: torch.device | int) -> torch.Tensor:
+    """Concatenate one multimodal field and place only the active microbatch on CUDA.
+
+    The per-tensor ``.to()`` runs *before* the concat on purpose: ``torch.cat``
+    on CPU allocates a fresh *pageable* output tensor, dropping the pinning that
+    :func:`materialize_multimodal_inputs` applied. Concatenating first would
+    therefore force a synchronous host->device copy. Moving each (pinned) tensor
+    over first keeps the copy ``non_blocking`` so it overlaps with compute;
+    already-CUDA tensors (preload mode) make ``.to()`` a no-op.
+    """
+    tensors = [tensor.to(device=device, non_blocking=True) for tensor in tensors]
+    return torch.cat(tensors, dim=0)
 
 
 def collate_multimodal_train_inputs(
@@ -281,7 +284,7 @@ def collate_multimodal_train_inputs(
         A tuple of ``(multimodal_data, multimodal_num_items)``. Tensor values are
         concatenated across the active microbatch and placed on ``device``.
     """
-    values_by_key: dict[str, list[MultimodalValue]] = {}
+    values_by_key: dict[str, list[torch.Tensor]] = {}
     multimodal_num_items: dict[str, list[int]] = {}
     for mm_input_dict in multimodal_train_inputs:
         if mm_input_dict is None:

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -821,6 +821,16 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                     'JSON string for multimodal data mapping media types to data keys. Example: \'{"image": "image_file"}\''
                 ),
             )
+            parser.add_argument(
+                "--defer-multimodal-cuda-transfer",
+                action="store_true",
+                default=False,
+                help=(
+                    "Keep multimodal training tensors on CPU after rollout fetch and move only the active "
+                    "microbatch to CUDA during batch collation. Reduces peak GPU memory for VLM training at "
+                    "the cost of a per-microbatch host->device copy."
+                ),
+            )
             parser.add_argument("--metadata-key", type=str, default="metadata", help="JSON dataset key")
             parser.add_argument(
                 "--tool-key",

--- a/tests/fast/backends/training_utils/test_multimodal_microbatch_transfer.py
+++ b/tests/fast/backends/training_utils/test_multimodal_microbatch_transfer.py
@@ -1,0 +1,110 @@
+"""Tests for per-microbatch multimodal tensor collation and deferred transfer."""
+
+from tests.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=60, suite="stage-a-cpu", labels=[])
+
+import numpy as np
+import pytest
+import torch
+
+from miles.backends.training_utils.mm_data import collate_multimodal_train_inputs, materialize_multimodal_inputs
+
+
+def test_collate_multimodal_train_inputs_uses_only_selected_microbatch() -> None:
+    """The active microbatch is the only multimodal payload collated for forward."""
+    full_payload = [
+        {
+            "pixel_values": torch.tensor([[1.0], [2.0]]),
+            "image_grid_thw": torch.tensor([[1, 1, 1], [1, 1, 1]]),
+        },
+        {
+            "pixel_values": torch.tensor([[99.0]]),
+            "image_grid_thw": torch.tensor([[9, 9, 9]]),
+        },
+        {
+            "pixel_values": torch.tensor([[3.0], [4.0], [5.0]]),
+            "image_grid_thw": torch.tensor([[2, 2, 2], [2, 2, 2], [2, 2, 2]]),
+        },
+    ]
+    selected_microbatch = [full_payload[0], full_payload[2]]
+
+    multimodal_data, multimodal_num_items = collate_multimodal_train_inputs(
+        selected_microbatch,
+        torch.device("cpu"),
+    )
+
+    torch.testing.assert_close(multimodal_data["pixel_values"], torch.tensor([[1.0], [2.0], [3.0], [4.0], [5.0]]))
+    torch.testing.assert_close(
+        multimodal_data["image_grid_thw"],
+        torch.tensor([[1, 1, 1], [1, 1, 1], [2, 2, 2], [2, 2, 2], [2, 2, 2]]),
+    )
+    assert multimodal_num_items == {"pixel_values": [2, 3], "image_grid_thw": [2, 3]}
+
+
+def test_collate_multimodal_train_inputs_handles_numpy_and_none_entries() -> None:
+    """Deferred CPU materialization can leave numpy arrays mixed with empty samples."""
+    microbatch = [
+        None,
+        {
+            "pixel_values": np.array([[1.0, 2.0]], dtype=np.float32),
+            "image_grid_thw": np.array([[1, 2, 3]], dtype=np.int64),
+        },
+        {
+            "pixel_values": torch.tensor([[3.0, 4.0]], dtype=torch.float32),
+            "image_grid_thw": torch.tensor([[4, 5, 6]], dtype=torch.int64),
+        },
+    ]
+
+    multimodal_data, multimodal_num_items = collate_multimodal_train_inputs(microbatch, torch.device("cpu"))
+
+    torch.testing.assert_close(multimodal_data["pixel_values"], torch.tensor([[1.0, 2.0], [3.0, 4.0]]))
+    torch.testing.assert_close(multimodal_data["image_grid_thw"], torch.tensor([[1, 2, 3], [4, 5, 6]]))
+    assert multimodal_num_items == {"pixel_values": [1, 1], "image_grid_thw": [1, 1]}
+
+
+def test_collate_multimodal_train_inputs_handles_text_only_microbatch() -> None:
+    """Text-only microbatches should not add multimodal model kwargs."""
+    multimodal_data, multimodal_num_items = collate_multimodal_train_inputs([None, None], torch.device("cpu"))
+
+    assert multimodal_data == {}
+    assert multimodal_num_items == {}
+
+
+def test_collate_multimodal_train_inputs_fails_loudly_on_bad_values() -> None:
+    """Unexpected multimodal value types should fail before model forward."""
+    with pytest.raises(TypeError, match="Expected multimodal value"):
+        collate_multimodal_train_inputs([{"pixel_values": [[1.0, 2.0]]}], torch.device("cpu"))
+
+
+def test_materialize_multimodal_inputs_keeps_deferred_tensors_on_cpu() -> None:
+    """Deferred actor materialization resolves arrays to CPU tensors without CUDA placement."""
+    materialized = materialize_multimodal_inputs(
+        [
+            {
+                "pixel_values": np.array([[1.0, 2.0]], dtype=np.float32),
+                "image_grid_thw": np.array([[1, 1, 1]], dtype=np.int64),
+            },
+            None,
+        ],
+        device=torch.device("cpu"),
+    )
+
+    assert len(materialized) == 2
+    assert materialized[1] is None
+    assert materialized[0] is not None
+    torch.testing.assert_close(materialized[0]["pixel_values"], torch.tensor([[1.0, 2.0]], dtype=torch.float32))
+    torch.testing.assert_close(materialized[0]["image_grid_thw"], torch.tensor([[1, 1, 1]], dtype=torch.int64))
+    assert materialized[0]["pixel_values"].device.type == "cpu"
+    assert materialized[0]["pixel_values"].is_pinned() is torch.cuda.is_available()
+
+
+def test_materialize_multimodal_inputs_copies_numpy_values() -> None:
+    """Resolved tensors should not alias mutable arrays owned by the rollout side."""
+    pixel_values = np.array([[1.0, 2.0]], dtype=np.float32)
+    materialized = materialize_multimodal_inputs([{"pixel_values": pixel_values}], device=torch.device("cpu"))
+
+    pixel_values[0, 0] = 99.0
+
+    assert materialized[0] is not None
+    torch.testing.assert_close(materialized[0]["pixel_values"], torch.tensor([[1.0, 2.0]], dtype=torch.float32))

--- a/tests/fast/backends/training_utils/test_multimodal_microbatch_transfer.py
+++ b/tests/fast/backends/training_utils/test_multimodal_microbatch_transfer.py
@@ -108,3 +108,36 @@ def test_materialize_multimodal_inputs_copies_numpy_values() -> None:
 
     assert materialized[0] is not None
     torch.testing.assert_close(materialized[0]["pixel_values"], torch.tensor([[1.0, 2.0]], dtype=torch.float32))
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA for the deferred host->device path")
+def test_deferred_materialize_then_collate_lands_on_cuda() -> None:
+    """End-to-end deferred path smoke test: pinned-CPU materialize, then collate onto CUDA.
+
+    No other test exercises the actual host->device path (the rest collate onto
+    CPU). This confirms the deferred pipeline — materialize on pinned CPU, then
+    collate onto CUDA — yields a correctly concatenated payload resident on the
+    device. It does not assert the copy is non_blocking (async vs sync is not
+    observable from the output); that property is guaranteed structurally by
+    moving each pinned tensor over before the concat in
+    ``_cat_multimodal_tensors_for_forward``.
+    """
+    device = torch.device("cuda", torch.cuda.current_device())
+    materialized = materialize_multimodal_inputs(
+        [
+            {"pixel_values": np.array([[1.0], [2.0]], dtype=np.float32)},
+            {"pixel_values": np.array([[3.0]], dtype=np.float32)},
+        ],
+        device=torch.device("cpu"),
+    )
+    # Deferred payload is pinned CPU before collation.
+    assert materialized[0] is not None and materialized[0]["pixel_values"].device.type == "cpu"
+
+    multimodal_data, multimodal_num_items = collate_multimodal_train_inputs(materialized, device)
+
+    assert multimodal_data["pixel_values"].device.type == "cuda"
+    torch.testing.assert_close(
+        multimodal_data["pixel_values"].cpu(),
+        torch.tensor([[1.0], [2.0], [3.0]], dtype=torch.float32),
+    )
+    assert multimodal_num_items == {"pixel_values": [2, 1]}


### PR DESCRIPTION
## What

Adds an opt-in `--defer-multimodal-cuda-transfer` flag that keeps multimodal image
tensors (`pixel_values`, `image_grid_thw`, ...) on **pinned CPU memory** after the
rollout fetch and moves only the **active micro-batch** to CUDA during batch collation.

## Why

Today `get_rollout_data()` moves an entire step's image tensors to the GPU upfront:

```python
# miles/backends/training_utils/data.py (before)
rollout_data["multimodal_train_inputs"] = [
    {key: tensor.to(device=torch.cuda.current_device()) for key, tensor in mm_dict.items()}
    if mm_dict is not None else None
    for mm_dict in rollout_data["multimodal_train_inputs"]
]
```

So every image for every sample in the minibatch is resident on the GPU for the whole
step. For image-heavy VLM runs — e.g. **Qwen3-VL-32B async RL with multi-turn image
trajectories on B200s** — this pushes peak trainer memory over the edge and OOMs on the
backward pass. Recompute helps but roughly doubles train step time (~450s → ~900s in the
original experiments); deferring the transfer fixes the memory pressure without that cost.

With the flag on, peak multimodal GPU memory drops from *"all images in the minibatch"*
to *"images in one micro-batch"*. The host→device copy is `non_blocking` over pinned
memory, so it overlaps with compute.

## How

- New helpers in `training_utils/mm_data.py` (next to the existing multimodal
  preprocessing), shared by both the **Megatron and FSDP** actors via
  `get_rollout_data` / `get_batch`:
  - `materialize_multimodal_inputs(inputs, device)` — resolves per-sequence dicts to
    tensors on `device`; CPU target pins host memory for overlap.
  - `collate_multimodal_train_inputs(inputs, device)` — collates only the active
    micro-batch and places it on CUDA.
- `get_rollout_data` picks `cpu` vs `cuda.current_device()` based on the flag.
- `get_batch` always collates the sliced micro-batch onto CUDA (this is where a deferred
  payload crosses to the GPU, just before the model forward).

## Safety / compatibility

- **Defaults off.** With the flag off, `target_device` is the CUDA device, so
  `materialize_*` preloads and `collate_*` simply concatenates already-resident tensors —
  **behaviorally identical to the previous code**. Pure opt-in, zero impact on existing
  runs.
- Text-only and mixed (text + multimodal) batches are handled (None entries pass through).
- Unexpected value types fail loudly (`TypeError`) before the model forward rather than
  silently mis-collating.

## Tests

`tests/fast/backends/training_utils/test_multimodal_microbatch_transfer.py` (CPU-only,
registered as `stage-a-cpu`), 6 cases:
- active micro-batch is the only payload collated
- numpy + None + tensor entries mixed
- text-only micro-batch adds no model kwargs
- bad value types raise `TypeError`
- deferred materialization keeps tensors on CPU (pinned iff CUDA is available)
- resolved tensors don't alias mutable rollout-side numpy arrays

```
6 passed in 1.3s
```

`pre-commit run --files ...` passes (ruff / black / isort / autoflake + the local
`ban-*` hooks).

## Notes for reviewers

- Ported from our internal `slime` tree (original: *"[trainer] feat: defer multimodal
  cuda transfer"*, PR #1400 there). Adapted to the current miles module layout: the
  slime version added a separate `megatron_utils/multimodal.py`, but miles has already
  consolidated multimodal helpers into `training_utils/mm_data.py`, so the helpers landed
  there instead.
- I intentionally **did not** port slime's `ray.get()` ObjectRef resolution — miles
  resolves refs earlier in `process_rollout_data`, and the pre-existing code confirms
  tensors already arrive materialized (bare `.to(device)`, no `ray.get`).
- Only `slime/*` source was carried over; the internal `autonomy/*` recipe YAMLs are not
  included. The equivalent knob for miles users is documented in the CLI reference and the
  Qwen3-VL doc instead.
- Verified in detail on the Megatron forward path. The FSDP actor shares the same
  `get_rollout_data` / `get_batch` and consumes the collated output the same way, so it
  rides along, but I was only able to run the CPU unit tests locally (no GPU box) — a GPU
  run on FSDP would be the final confirmation.
