### PR TITLE
(5/7) feat(session): process-lifecycle layer — supervisor spawns N session workers + router

### DIFF
--- a/miles/rollout/session/core.py
+++ b/miles/rollout/session/core.py
@@ -1,11 +1,11 @@
 # doc-dev: docs/developer/multi-process-session-server.md
-"""Logic layer of the session server: ``SessionCore``.
+"""Logic layer of the session server: `SessionCore`.
 
-HTTP-agnostic: the FastAPI adapter (``sessions.py`` + ``server.py``) turns each request into primitives and calls these methods. Owns one ``SessionRegistry`` (per-session TITO/trajectory state) and one proxy ``backend``. Reused unchanged by both chassis — the single-process adapter and the multi-process worker (``worker.py``, primitives decoded off IPC); ``build_session_core`` and ``error_response`` are the single source for core construction and the client error shape so those contracts cannot drift between modes.
+HTTP-agnostic: the FastAPI adapter (`sessions.py` + `server.py`) turns each request into primitives and calls these methods. Owns one `SessionRegistry` (per-session TITO/trajectory state) and one proxy `backend`. Reused unchanged by both chassis — the single-process adapter and the multi-process worker (`worker.py`, primitives decoded off IPC); `build_session_core` and `error_response` are the single source for core construction and the client error shape so those contracts cannot drift between modes.
 
-- ``create_session(session_id=None)``: the single-process path passes None (the registry mints); the multi-process router mints the id and passes it so the owning worker creates the trajectory under it.
-- ``chat_completions`` strips the R3 replay payloads (``routed_experts`` / ``indexer_topk``) from the client reply copy-on-write; the ``SessionRecord`` keeps the full response for the training path (``GET /sessions/{id}``).
-- ``chat_completions`` holds the per-session lock for prep and state update but not across the proxy call; ``closing`` re-checks and the ``num_assistant`` check gate concurrent DELETE/chat.
+- `create_session(session_id=None)`: the single-process path passes None (the registry mints); the multi-process router mints the id and passes it so the owning worker creates the trajectory under it.
+- `chat_completions` strips the R3 replay payloads (`routed_experts` / `indexer_topk`) from the client reply copy-on-write; the `SessionRecord` keeps the full response for the training path (`GET /sessions/{id}`).
+- `chat_completions` holds the per-session lock for prep and state update but not across the proxy call; `closing` re-checks and the `num_assistant` check gate concurrent DELETE/chat.
 """
 
 import json
@@ -96,7 +96,7 @@ def _chat_client_response(result: dict, response: dict) -> Response:
 def proxy_result_to_response(result: dict) -> Response:
     """Build the client response from a proxy result.
 
-    Mirrors the previous ``SessionServer.build_proxy_response``: re-emit JSON
+    Mirrors the previous `SessionServer.build_proxy_response`: re-emit JSON
     bodies as compact JSON (application/json), pass non-JSON bodies through
     unchanged, and drop wire-level framing headers from upstream.
     """
@@ -114,7 +114,7 @@ def proxy_result_to_response(result: dict) -> Response:
 
 
 class SessionCore:
-    """HTTP session operations over one ``SessionRegistry``."""
+    """HTTP session operations over one `SessionRegistry`."""
 
     def __init__(self, backend, registry: SessionRegistry, args, session_server_instance_id=None):
         self.backend = backend
@@ -171,12 +171,12 @@ class SessionCore:
 
         Three phases around the per-session lock: (1) under the lock, parse the
         body, inject the TITO-required request fields, and prepare pretokenized
-        ``input_ids`` from the accumulated trajectory; (2) release the lock and
+        `input_ids` from the accumulated trajectory; (2) release the lock and
         proxy to the backend — the slow LLM call runs unlocked so DELETE/other
         ops are not blocked if the agent disconnects; (3) re-acquire the lock,
         validate the response, and update the trajectory checkpoint + append the
-        record. ``closing`` is re-checked at each lock entry and, together with
-        the ``num_assistant`` mismatch check in phase 3, forms the concurrency
+        record. `closing` is re-checked at each lock entry and, together with
+        the `num_assistant` mismatch check in phase 3, forms the concurrency
         gate that drops a state update whose session was deleted or advanced
         during the unlocked proxy.
         """

--- a/miles/rollout/session/ipc.py
+++ b/miles/rollout/session/ipc.py
@@ -19,12 +19,31 @@ Deliberately minimal — no round-robin scheduling across requests, no configura
 from __future__ import annotations
 
 import asyncio
+import ctypes
 import json
 import logging
+import signal
 import struct
+import sys
 from collections.abc import Awaitable, Callable
 
 logger = logging.getLogger(__name__)
+
+
+def set_pdeathsig() -> None:
+    """Ask the kernel to SIGKILL this process if its parent dies (Linux only).
+
+    Shared by the worker and router child entry points; lives here (stdlib-only)
+    so the router process can call it without importing the worker/core stack.
+    """
+    if sys.platform != "linux":
+        return
+    try:
+        libc = ctypes.CDLL("libc.so.6", use_errno=True)
+        libc.prctl(1, signal.SIGKILL)  # PR_SET_PDEATHSIG
+    except Exception:
+        logger.warning("Failed to set PR_SET_PDEATHSIG; child may outlive a crashed parent")
+
 
 _LEN = struct.Struct(">Q")  # frame length / envelope meta_len prefix (u64)
 _HDR = struct.Struct(">QB")  # request_id (u64) + type (u8)

--- a/miles/rollout/session/ipc.py
+++ b/miles/rollout/session/ipc.py
@@ -1,19 +1,19 @@
 # doc-dev: docs/developer/multi-process-session-server.md
 """Minimal framed, multiplexed RPC between the session router and one session worker.
 
-- One :class:`IpcChannel` wraps one connected stream socket (a ``socket.socketpair`` end); the router side is the client (:meth:`IpcChannel.request`), the worker side is the server (a ``request_handler`` coroutine).
-- Concurrent requests over the one socket are multiplexed by ``request_id``: replies are matched by id, not arrival order, so a reply never waits for an earlier request to finish *processing*. Writes are FIFO whole frames, so it can still queue behind a large frame already being sent (see the trailing note).
+- One :class:`IpcChannel` wraps one connected stream socket (a `socket.socketpair` end); the router side is the client (:meth:`IpcChannel.request`), the worker side is the server (a `request_handler` coroutine).
+- Concurrent requests over the one socket are multiplexed by `request_id`: replies are matched by id, not arrival order, so a reply never waits for an earlier request to finish *processing*. Writes are FIFO whole frames, so it can still queue behind a large frame already being sent (see the trailing note).
 - Wire format — one whole message per frame, no chunking:
 
     frame: u64 length | u64 request_id | u8 type | payload bytes
            └ length counts everything after it (the 9-byte header + payload) ┘
 
-- ``type`` is REQUEST / REPLY / ERROR; a REPLY carries the handler's return bytes, an ERROR a UTF-8 error message.
-- The payload is opaque to the channel; the worker/router layer packs it with :func:`encode_envelope` as ``u64 meta_len | meta_json | raw_body`` (raw body, no base64).
-- The shared ``OP_*`` session-op protocol and the request/envelope codecs live here so neither the router nor the worker imports the other's module.
-- Teardown (EOF / read-write error / ``aclose``) fails every pending ``request()`` with ``IpcChannelClosed``, so a peer death surfaces as an exception, never a hang; ``request()`` is cancel-safe (a late reply is dropped, not mis-delivered).
+- `type` is REQUEST / REPLY / ERROR; a REPLY carries the handler's return bytes, an ERROR a UTF-8 error message.
+- The payload is opaque to the channel; the worker/router layer packs it with :func:`encode_envelope` as `u64 meta_len | meta_json | raw_body` (raw body, no base64).
+- The shared `OP_*` session-op protocol and the request/envelope codecs live here so neither the router nor the worker imports the other's module.
+- Teardown (EOF / read-write error / `aclose`) fails every pending `request()` with `IpcChannelClosed`, so a peer death surfaces as an exception, never a hang; `request()` is cancel-safe (a late reply is dropped, not mis-delivered).
 
-Deliberately minimal — no round-robin scheduling across requests, no configurable frame/body size limit; the single ``_MAX_FRAME`` cap is a corruption guard (rejects a garbage length before allocating), not a size feature, so a large body (e.g. a multi-GiB ``GET /sessions`` records dump) crosses as one frame. A frame that would exceed the cap is refused at send time as a per-request failure (ERROR frame / ``IpcError``) — it must never reach the peer's reader, where an oversized length is indistinguishable from corruption and tears down the whole channel.
+Deliberately minimal — no round-robin scheduling across requests, no configurable frame/body size limit; the single `_MAX_FRAME` cap is a corruption guard (rejects a garbage length before allocating), not a size feature, so a large body (e.g. a multi-GiB `GET /sessions` records dump) crosses as one frame. A frame that would exceed the cap is refused at send time as a per-request failure (ERROR frame / `IpcError`) — it must never reach the peer's reader, where an oversized length is indistinguishable from corruption and tears down the whole channel.
 """
 
 from __future__ import annotations
@@ -70,7 +70,7 @@ class IpcChannelClosed(Exception):
 
 
 def encode_envelope(meta: dict, body: bytes) -> bytes:
-    """Pack ``meta`` (JSON) + raw ``body`` (no base64) into one buffer."""
+    """Pack `meta` (JSON) + raw `body` (no base64) into one buffer."""
     meta_bytes = json.dumps(meta, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
     return _LEN.pack(len(meta_bytes)) + meta_bytes + body
 
@@ -118,10 +118,10 @@ def encode_request(
 class IpcChannel:
     """Framed multiplexed RPC over one connected stream socket.
 
-    Role is set by ``request_handler``: None ⇒ client (calls ``request()``; a
+    Role is set by `request_handler`: None ⇒ client (calls `request()`; a
     stray inbound REQUEST is logged and dropped); else ⇒ server (runs the handler
     per REQUEST; a stray REPLY for an unknown id is dropped). Teardown (EOF /
-    error / ``aclose()``) fails every pending ``request()`` with IpcChannelClosed,
+    error / `aclose()`) fails every pending `request()` with IpcChannelClosed,
     so a peer death surfaces as that exception, never a hang.
     """
 
@@ -153,7 +153,7 @@ class IpcChannel:
         """Send a request and await the peer's reply bytes.
 
         Cancel-safe: if the awaiting coroutine is cancelled, the pending future
-        is removed in ``finally`` so a late reply is dropped, not mis-delivered.
+        is removed in `finally` so a late reply is dropped, not mis-delivered.
 
         Raises IpcChannelClosed if the channel is/goes down, IpcError if the peer
         handler raised.
@@ -285,7 +285,7 @@ async def open_unix_channel(
     request_handler: Callable[[bytes], Awaitable[bytes]] | None = None,
     on_close: Callable[[], None] | None = None,
 ) -> IpcChannel:
-    """Wrap a connected socket (e.g. a ``socket.socketpair`` end) in an IpcChannel."""
+    """Wrap a connected socket (e.g. a `socket.socketpair` end) in an IpcChannel."""
     reader, writer = await asyncio.open_connection(sock=sock)
     channel = IpcChannel(reader, writer, request_handler=request_handler, on_close=on_close)
     channel.start()

--- a/miles/rollout/session/linear_trajectory.py
+++ b/miles/rollout/session/linear_trajectory.py
@@ -26,7 +26,7 @@ class LinearTrajectory:
     but the agent may retry from an earlier point (e.g. re-running a tool call),
     in which case the session is rolled back at most one assistant step.
 
-    Concurrency contract: all mutating methods must be called under ``self.lock``.
+    Concurrency contract: all mutating methods must be called under `self.lock`.
     """
 
     lock: asyncio.Lock = field(default_factory=asyncio.Lock, repr=False, compare=False)
@@ -59,7 +59,7 @@ class LinearTrajectory:
         most one assistant step on agent retries) and reuses the stored
         token_ids as the pretokenized prefix.
 
-        Must be called under ``self.lock``.
+        Must be called under `self.lock`.
         """
         if not self.token_ids:
             return tito_tokenizer.render_messages(
@@ -97,10 +97,10 @@ class LinearTrajectory:
     ) -> None:
         """Store raw token IDs after a successful response.
 
-        Appends ``prompt_token_ids + completion_token_ids`` as a new checkpoint.
+        Appends `prompt_token_ids + completion_token_ids` as a new checkpoint.
         Validates that the previously stored token_ids are a prefix of the new
-        checkpoint (tolerating up to ``max_trim_tokens`` trailing differences).
-        Must be called under ``self.lock``.
+        checkpoint (tolerating up to `max_trim_tokens` trailing differences).
+        Must be called under `self.lock`.
         """
         all_token_ids = prompt_token_ids + completion_token_ids
 
@@ -145,13 +145,13 @@ class LinearTrajectory:
         to the last assistant checkpoint within the matching prefix.
 
         Only a single-step rollback is allowed (controlled by
-        ``MAX_ASSISTANT_ROLLBACK_STEPS``).  Discarding exactly one assistant
+        `MAX_ASSISTANT_ROLLBACK_STEPS`).  Discarding exactly one assistant
         message means the agent is retrying from the preceding checkpoint —
         the request shares the stored prefix up to that assistant and then
         continues with whatever the agent chooses (same or different tool
         result, additional messages, etc.).  Any request that would need to
         discard more than one assistant (i.e. jump back across multiple
-        turns) is rejected with ``MessageValidationError`` and no state is
+        turns) is rejected with `MessageValidationError` and no state is
         modified.
 
         Example — agent retries after the first tool call::
@@ -176,7 +176,7 @@ class LinearTrajectory:
         No rollback occurs when:
         - The stored history is empty.
         - *request_messages* is a strict extension of stored messages
-          (``match_len >= len(stored)``).
+          (`match_len >= len(stored)`).
         """
         stored = self.messages
         if not stored or not self.trajectory_token_ids:

--- a/miles/rollout/session/router.py
+++ b/miles/rollout/session/router.py
@@ -17,6 +17,8 @@ import asyncio
 import json
 import uuid
 
+import setproctitle
+import uvicorn
 from fastapi import FastAPI, Request
 from starlette.responses import Response
 
@@ -31,6 +33,8 @@ from miles.rollout.session.ipc import (
     IpcError,
     decode_envelope,
     encode_request,
+    open_unix_channel,
+    set_pdeathsig,
 )
 from miles.rollout.session.sharding import worker_index_for_session
 
@@ -155,3 +159,20 @@ def build_router_app(channels: list, session_server_instance_id=None) -> FastAPI
         return await router.dispatch(router.channel_for(session_id), payload)
 
     return app
+
+
+async def _serve_router(args, router_ends: list, ip: str, port: int) -> None:
+    channels = [await open_unix_channel(sock) for sock in router_ends]
+    app = build_router_app(channels, getattr(args, "session_server_instance_id", None))
+    await uvicorn.Server(uvicorn.Config(app, host=ip, port=port, log_level="info")).serve()
+
+
+def run_router(args, router_ends: list, ip: str, port: int) -> None:
+    """``multiprocessing.Process`` target: serve the router app over the worker sockets.
+
+    Imports nothing from core/worker, so the router process never loads
+    the tokenizer/transformers stack — it only moves bytes between clients and workers.
+    """
+    setproctitle.setproctitle("miles-session-router")
+    set_pdeathsig()
+    asyncio.run(_serve_router(args, router_ends, ip, port))

--- a/miles/rollout/session/router.py
+++ b/miles/rollout/session/router.py
@@ -1,14 +1,14 @@
 # doc-dev: docs/developer/multi-process-session-server.md
 """Thin client-facing router for the multi-process session server.
 
-- The sole HTTP listener: a FastAPI app over N ``IpcChannel``s, one per worker.
-- Routes every op of a session through ``SessionRouter.channel_for`` — a stable hash of ``session_id`` (``worker_index_for_session``) — so create/get/chat/delete land on the same worker.
+- The sole HTTP listener: a FastAPI app over N `IpcChannel`s, one per worker.
+- Routes every op of a session through `SessionRouter.channel_for` — a stable hash of `session_id` (`worker_index_for_session`) — so create/get/chat/delete land on the same worker.
 - Relays the worker's response bytes back verbatim; it never parses a body.
-- ``POST /sessions`` mints the id first (uuid4 hex) so it can route by it, then dispatches the create to the owning worker.
-- Error mapping in ``dispatch``: channel down → 503, worker handler raised → 502, malformed reply envelope → uncaught 500 (a worker protocol violation).
-- ``GET /health`` pings every worker and reports 503 unless all reply healthy within the timeout.
+- `POST /sessions` mints the id first (uuid4 hex) so it can route by it, then dispatches the create to the owning worker.
+- Error mapping in `dispatch`: channel down → 503, worker handler raised → 502, malformed reply envelope → uncaught 500 (a worker protocol violation).
+- `GET /health` pings every worker and reports 503 unless all reply healthy within the timeout.
 
-Imports neither ``core`` nor ``worker``, so the router process never loads the tokenizer/transformers stack — it only moves bytes.
+Imports neither `core` nor `worker`, so the router process never loads the tokenizer/transformers stack — it only moves bytes.
 """
 
 from __future__ import annotations
@@ -49,10 +49,10 @@ def _err(status_code: int, message: str) -> Response:
 def _reply_to_response(reply: bytes) -> Response:
     """Relay a worker REPLY envelope as an HTTP Response verbatim.
 
-    ``meta`` must carry ``status`` + ``headers`` (worker contract); ``body`` is
+    `meta` must carry `status` + `headers` (worker contract); `body` is
     passed through unparsed, and a missing key raises KeyError (= worker protocol
-    violation, deliberately a 500). ``headers`` already carries content-type, so
-    no ``media_type`` is passed — that would duplicate content-length/-type.
+    violation, deliberately a 500). `headers` already carries content-type, so
+    no `media_type` is passed — that would duplicate content-length/-type.
     """
     meta, body = decode_envelope(reply)
     return Response(content=body, status_code=meta["status"], headers=meta["headers"])
@@ -69,7 +69,7 @@ class SessionRouter:
         self.instance_id = session_server_instance_id
 
     def channel_for(self, session_id: str):
-        """The sole routing point: the worker channel owning ``session_id``.
+        """The sole routing point: the worker channel owning `session_id`.
 
         Every op for a session must resolve here so create/get/chat/delete land
         on one worker; divergent hashing would silently mis-route.
@@ -77,7 +77,7 @@ class SessionRouter:
         return self.channels[worker_index_for_session(session_id, self.n_worker)]
 
     async def dispatch(self, channel, payload: bytes) -> Response:
-        """Send one request to ``channel`` and map the outcome to a Response.
+        """Send one request to `channel` and map the outcome to a Response.
 
         Channel down (IpcChannelClosed) → 503; worker handler raised (IpcError)
         → 502; a malformed reply envelope is not caught → 500. No per-request
@@ -168,7 +168,7 @@ async def _serve_router(args, router_ends: list, ip: str, port: int) -> None:
 
 
 def run_router(args, router_ends: list, ip: str, port: int) -> None:
-    """``multiprocessing.Process`` target: serve the router app over the worker sockets.
+    """`multiprocessing.Process` target: serve the router app over the worker sockets.
 
     Imports nothing from core/worker, so the router process never loads
     the tokenizer/transformers stack — it only moves bytes between clients and workers.

--- a/miles/rollout/session/server.py
+++ b/miles/rollout/session/server.py
@@ -1,9 +1,9 @@
 """Standalone session-server process: HTTP chassis + upstream proxy transport.
 
-- ``SessionServer`` is a FastAPI app plus one shared httpx client; ``do_proxy`` forwards a request to the inference router (sglang or miles) — which does the load balancing to worker engines — and returns the raw result, or a 502 JSON error on transport failure.
-- Session/TITO logic lives in ``core.SessionCore``; ``setup_session_routes`` (``sessions.py``) wires the HTTP routes to it.
+- `SessionServer` is a FastAPI app plus one shared httpx client; `do_proxy` forwards a request to the inference router (sglang or miles) — which does the load balancing to worker engines — and returns the raw result, or a 502 JSON error on transport failure.
+- Session/TITO logic lives in `core.SessionCore`; `setup_session_routes` (`sessions.py`) wires the HTTP routes to it.
 - Standalone (own process, own event loop) so sessions also work with the SGLang Rust Router or any other backend, decoupled from the Miles Router.
-- ``run_session_server`` is the subprocess entry point: fresh interpreter, so it configures logging and the process title itself, then serves uvicorn.
+- `run_session_server` is the subprocess entry point: fresh interpreter, so it configures logging and the process title itself, then serves uvicorn.
 """
 
 import json

--- a/miles/rollout/session/sessions.py
+++ b/miles/rollout/session/sessions.py
@@ -1,7 +1,7 @@
 """Single-process FastAPI adapter for the session server.
 
 Thin layer: converts each HTTP request to primitive inputs, calls
-``SessionCore``. All session/TITO logic lives in ``core``.
+`SessionCore`. All session/TITO logic lives in `core`.
 """
 
 import logging

--- a/miles/rollout/session/sharding.py
+++ b/miles/rollout/session/sharding.py
@@ -1,11 +1,11 @@
 # doc-dev: docs/developer/multi-process-session-server.md
 """Process-stable session→owner mapping for the multi-process session server.
 
-Decides which worker owns a ``session_id`` (see ``worker_index_for_session``
+Decides which worker owns a `session_id` (see `worker_index_for_session`
 for the hash choice), so the router and every worker agree on each session's
 owner with no coordination between them.
 
-Stdlib only (``hashlib``), so a headless worker or router can import it
+Stdlib only (`hashlib`), so a headless worker or router can import it
 without pulling in FastAPI.
 """
 
@@ -15,9 +15,9 @@ import hashlib
 
 
 def worker_index_for_session(session_id: str, n_worker: int) -> int:
-    """Map *session_id* to a worker index in ``range(n_worker)``.
+    """Map *session_id* to a worker index in `range(n_worker)`.
 
-    Uses blake2b (not the builtin ``hash()``, which PYTHONHASHSEED salts per
+    Uses blake2b (not the builtin `hash()`, which PYTHONHASHSEED salts per
     process) so the router and every worker derive the same owner.
     """
     if n_worker < 1:

--- a/miles/rollout/session/supervisor.py
+++ b/miles/rollout/session/supervisor.py
@@ -3,10 +3,10 @@
 
 - Runs in the rollout process and is the only way the session server runs; ``--session-server-workers=1`` (the default) is simply N=1, not a separate chassis.
 - ``start()`` spawns (``"spawn"`` context) N workers + 1 router, one ``socket.socketpair`` per worker, then closes every socket end the parent holds — so a child death is observable as EOF on the surviving peer.
-- Readiness: waits until the router's ``/health`` reports all workers healthy, raising early if a child dies during startup (e.g. while loading its tokenizer) or the deadline elapses.
+- Readiness: waits until the router's ``/health`` reports all workers healthy, raising early if a child dies during startup (e.g. while loading its tokenizer) or the deadline elapses; a failed ``start()`` tears down whatever it already spawned.
 - A monitor thread records the first child death and tears the whole group down (fail-fast).
 - ``check()``, called on the rollout path, re-raises that recorded failure so a dead worker fails the rollout loudly instead of hanging requests routed to its shard.
-- ``shutdown()`` is idempotent — SIGTERM, a short grace period, then SIGKILL — and is also registered via ``atexit``, so no orphan processes survive.
+- ``shutdown()`` is idempotent and thread-safe (a concurrent caller blocks until teardown completes) — SIGTERM, a short grace period, then SIGKILL — and is also registered via ``atexit``, so no orphan processes survive.
 """
 
 from __future__ import annotations
@@ -48,6 +48,7 @@ class SessionServerSupervisor:
         self._router = None
         self._failure: str | None = None
         self._shutdown_done = False
+        self._shutdown_lock = threading.Lock()
         self._monitor: threading.Thread | None = None
 
     def start(self) -> None:
@@ -57,23 +58,26 @@ class SessionServerSupervisor:
             worker_ends.append(worker_end)
             router_ends.append(router_end)
 
-        workers = []
-        for i in range(self.n_worker):
-            p = self._ctx.Process(
-                target=run_worker, args=(self.args, self.backend_url, worker_ends[i], i), daemon=False
-            )
-            p.start()
-            workers.append(p)
-        router = self._ctx.Process(target=run_router, args=(self.args, router_ends, self.ip, self.port), daemon=False)
-        router.start()
-
-        # Parent closes every socket end so a child death is observable as EOF on its peer.
-        for s in worker_ends + router_ends:
-            s.close()
-
-        self._procs = workers + [router]
-        self._router = router
+        # Each child lands in _procs before anything else can fail, so the except
+        # path below reaps every process a partially failed start() has spawned.
         try:
+            for i in range(self.n_worker):
+                p = self._ctx.Process(
+                    target=run_worker, args=(self.args, self.backend_url, worker_ends[i], i), daemon=False
+                )
+                p.start()
+                self._procs.append(p)
+            router = self._ctx.Process(
+                target=run_router, args=(self.args, router_ends, self.ip, self.port), daemon=False
+            )
+            router.start()
+            self._procs.append(router)
+            self._router = router
+
+            # Parent closes every socket end so a child death is observable as EOF on its peer.
+            for s in worker_ends + router_ends:
+                s.close()
+
             self._await_ready()
         except Exception:
             self.shutdown()
@@ -109,6 +113,10 @@ class SessionServerSupervisor:
         while not self._shutdown_done:
             for p in self._procs:
                 if not p.is_alive():
+                    # shutdown() flips _shutdown_done before terminate(), so a death seen
+                    # while the flag is still False cannot be shutdown-caused.
+                    if self._shutdown_done:
+                        return
                     self._failure = f"session server child pid={p.pid} died (exitcode={p.exitcode})"
                     logger.error("%s; tearing down session server", self._failure)
                     self.shutdown()
@@ -121,18 +129,21 @@ class SessionServerSupervisor:
             raise RuntimeError(f"session server failed: {self._failure}")
 
     def shutdown(self) -> None:
-        if self._shutdown_done:
-            return
-        self._shutdown_done = True
-        for p in self._procs:
-            if p.is_alive():
-                p.terminate()
-        deadline = time.monotonic() + _TERM_GRACE
-        for p in self._procs:
-            p.join(timeout=max(0.0, deadline - time.monotonic()))
-        for p in self._procs:
-            if p.is_alive():
-                try:
-                    os.kill(p.pid, signal.SIGKILL)
-                except ProcessLookupError:
-                    pass
+        # The lock makes a concurrent caller block until teardown completes instead of
+        # returning while children are still being reaped.
+        with self._shutdown_lock:
+            if self._shutdown_done:
+                return
+            self._shutdown_done = True
+            for p in self._procs:
+                if p.is_alive():
+                    p.terminate()
+            deadline = time.monotonic() + _TERM_GRACE
+            for p in self._procs:
+                p.join(timeout=max(0.0, deadline - time.monotonic()))
+            for p in self._procs:
+                if p.is_alive():
+                    try:
+                        os.kill(p.pid, signal.SIGKILL)
+                    except ProcessLookupError:
+                        pass

--- a/miles/rollout/session/supervisor.py
+++ b/miles/rollout/session/supervisor.py
@@ -1,0 +1,138 @@
+# doc-dev: docs/developer/multi-process-session-server.md
+"""Supervisor for the multi-process session server — the process-lifecycle layer.
+
+- Runs in the rollout process and is the only way the session server runs; ``--session-server-workers=1`` (the default) is simply N=1, not a separate chassis.
+- ``start()`` spawns (``"spawn"`` context) N workers + 1 router, one ``socket.socketpair`` per worker, then closes every socket end the parent holds — so a child death is observable as EOF on the surviving peer.
+- Readiness: waits until the router's ``/health`` reports all workers healthy, raising early if a child dies during startup (e.g. while loading its tokenizer) or the deadline elapses.
+- A monitor thread records the first child death and tears the whole group down (fail-fast).
+- ``check()``, called on the rollout path, re-raises that recorded failure so a dead worker fails the rollout loudly instead of hanging requests routed to its shard.
+- ``shutdown()`` is idempotent — SIGTERM, a short grace period, then SIGKILL — and is also registered via ``atexit``, so no orphan processes survive.
+"""
+
+from __future__ import annotations
+
+import atexit
+import logging
+import multiprocessing
+import os
+import signal
+import socket
+import threading
+import time
+
+import httpx
+
+from miles.rollout.session.router import run_router
+from miles.rollout.session.worker import run_worker
+from miles.utils.http_utils import wait_for_server_ready
+
+logger = logging.getLogger(__name__)
+
+_READINESS_TIMEOUT = 120.0
+_HEALTH_POLL_INTERVAL = 0.5
+_MONITOR_INTERVAL = 0.5
+_TERM_GRACE = 5.0
+
+
+class SessionServerSupervisor:
+    """Spawns and supervises N session workers + 1 router; fail-fast on any death."""
+
+    def __init__(self, args, backend_url: str, ip: str, port: int):
+        self.args = args
+        self.backend_url = backend_url
+        self.ip = ip
+        self.port = port
+        self.n_worker = int(getattr(args, "session_server_workers", 1))
+        self._ctx = multiprocessing.get_context("spawn")
+        self._procs: list = []
+        self._router = None
+        self._failure: str | None = None
+        self._shutdown_done = False
+        self._monitor: threading.Thread | None = None
+
+    def start(self) -> None:
+        worker_ends, router_ends = [], []
+        for _ in range(self.n_worker):
+            worker_end, router_end = socket.socketpair()
+            worker_ends.append(worker_end)
+            router_ends.append(router_end)
+
+        workers = []
+        for i in range(self.n_worker):
+            p = self._ctx.Process(
+                target=run_worker, args=(self.args, self.backend_url, worker_ends[i], i), daemon=False
+            )
+            p.start()
+            workers.append(p)
+        router = self._ctx.Process(target=run_router, args=(self.args, router_ends, self.ip, self.port), daemon=False)
+        router.start()
+
+        # Parent closes every socket end so a child death is observable as EOF on its peer.
+        for s in worker_ends + router_ends:
+            s.close()
+
+        self._procs = workers + [router]
+        self._router = router
+        try:
+            self._await_ready()
+        except Exception:
+            self.shutdown()
+            raise
+        self._monitor = threading.Thread(target=self._monitor_loop, name="session-supervisor", daemon=True)
+        self._monitor.start()
+        atexit.register(self.shutdown)
+        logger.info("Session server ready: %d workers + router at %s:%s", self.n_worker, self.ip, self.port)
+
+    def _await_ready(self) -> None:
+        # Router opens the TCP port quickly; this also watches the router process liveness.
+        wait_for_server_ready(self.ip, self.port, self._router, timeout=_READINESS_TIMEOUT)
+        deadline = time.monotonic() + _READINESS_TIMEOUT
+        while time.monotonic() < deadline:
+            self._raise_if_child_dead()  # a worker may die while loading its tokenizer
+            if self._health_ok():
+                return
+            time.sleep(_HEALTH_POLL_INTERVAL)
+        raise RuntimeError(f"session server not healthy within {_READINESS_TIMEOUT}s")
+
+    def _health_ok(self) -> bool:
+        try:
+            return httpx.get(f"http://{self.ip}:{self.port}/health", timeout=10.0).status_code == 200
+        except httpx.HTTPError:
+            return False
+
+    def _raise_if_child_dead(self) -> None:
+        for p in self._procs:
+            if not p.is_alive():
+                raise RuntimeError(f"session server child pid={p.pid} died during startup (exitcode={p.exitcode})")
+
+    def _monitor_loop(self) -> None:
+        while not self._shutdown_done:
+            for p in self._procs:
+                if not p.is_alive():
+                    self._failure = f"session server child pid={p.pid} died (exitcode={p.exitcode})"
+                    logger.error("%s; tearing down session server", self._failure)
+                    self.shutdown()
+                    return
+            time.sleep(_MONITOR_INTERVAL)
+
+    def check(self) -> None:
+        """Raise on the rollout path if any session-server child has died (no silent hang)."""
+        if self._failure is not None:
+            raise RuntimeError(f"session server failed: {self._failure}")
+
+    def shutdown(self) -> None:
+        if self._shutdown_done:
+            return
+        self._shutdown_done = True
+        for p in self._procs:
+            if p.is_alive():
+                p.terminate()
+        deadline = time.monotonic() + _TERM_GRACE
+        for p in self._procs:
+            p.join(timeout=max(0.0, deadline - time.monotonic()))
+        for p in self._procs:
+            if p.is_alive():
+                try:
+                    os.kill(p.pid, signal.SIGKILL)
+                except ProcessLookupError:
+                    pass

--- a/miles/rollout/session/supervisor.py
+++ b/miles/rollout/session/supervisor.py
@@ -1,12 +1,12 @@
 # doc-dev: docs/developer/multi-process-session-server.md
 """Supervisor for the multi-process session server — the process-lifecycle layer.
 
-- Runs in the rollout process and is the only way the session server runs; ``--session-server-workers=1`` (the default) is simply N=1, not a separate chassis.
-- ``start()`` spawns (``"spawn"`` context) N workers + 1 router, one ``socket.socketpair`` per worker, then closes every socket end the parent holds — so a child death is observable as EOF on the surviving peer.
-- Readiness: waits until the router's ``/health`` reports all workers healthy, raising early if a child dies during startup (e.g. while loading its tokenizer) or the deadline elapses; a failed ``start()`` tears down whatever it already spawned.
+- Runs in the rollout process and is the only way the session server runs; `--session-server-workers=1` (the default) is simply N=1, not a separate chassis.
+- `start()` spawns (`"spawn"` context) N workers + 1 router, one `socket.socketpair` per worker, then closes every socket end the parent holds — so a child death is observable as EOF on the surviving peer.
+- Readiness: waits until the router's `/health` reports all workers healthy, raising early if a child dies during startup (e.g. while loading its tokenizer) or the deadline elapses; a failed `start()` tears down whatever it already spawned.
 - A monitor thread records the first child death and tears the whole group down (fail-fast).
-- ``check()``, called on the rollout path, re-raises that recorded failure so a dead worker fails the rollout loudly instead of hanging requests routed to its shard.
-- ``shutdown()`` is idempotent and thread-safe (a concurrent caller blocks until teardown completes) — SIGTERM, a short grace period, then SIGKILL — and is also registered via ``atexit``, so no orphan processes survive.
+- `check()`, called on the rollout path, re-raises that recorded failure so a dead worker fails the rollout loudly instead of hanging requests routed to its shard.
+- `shutdown()` is idempotent and thread-safe (a concurrent caller blocks until teardown completes) — SIGTERM, a short grace period, then SIGKILL — and is also registered via `atexit`, so no orphan processes survive.
 """
 
 from __future__ import annotations

--- a/miles/rollout/session/worker.py
+++ b/miles/rollout/session/worker.py
@@ -1,11 +1,11 @@
 # doc-dev: docs/developer/multi-process-session-server.md
 """Headless session worker process — owns one shard of the multi-process data plane.
 
-- Owns one shard's session state: its own ``SessionCore`` (registry + tokenizer) plus its own httpx ``ProxyBackend``.
-- Speaks IPC, not HTTP: ``SessionWorker.handle`` decodes a request envelope, drives the matching ``SessionCore`` op, and encodes the returned Starlette ``Response`` (status + headers + body bytes) back.
-- A ``SessionError`` from the core becomes the same ``error_response`` the single-process FastAPI handler produces, so the workers=N and workers=1 error paths stay byte-identical.
-- ``ProxyBackend.do_proxy`` filters the same request headers as ``SessionServer.do_proxy`` (exercised by the equivalence tests) and turns a transport failure into a 502 result.
-- ``run_worker`` is the ``multiprocessing.Process`` target: names the process, arms PR_SET_PDEATHSIG, then serves the socket until the channel closes.
+- Owns one shard's session state: its own `SessionCore` (registry + tokenizer) plus its own httpx `ProxyBackend`.
+- Speaks IPC, not HTTP: `SessionWorker.handle` decodes a request envelope, drives the matching `SessionCore` op, and encodes the returned Starlette `Response` (status + headers + body bytes) back.
+- A `SessionError` from the core becomes the same `error_response` the single-process FastAPI handler produces, so the workers=N and workers=1 error paths stay byte-identical.
+- `ProxyBackend.do_proxy` filters the same request headers as `SessionServer.do_proxy` (exercised by the equivalence tests) and turns a transport failure into a 502 result.
+- `run_worker` is the `multiprocessing.Process` target: names the process, arms PR_SET_PDEATHSIG, then serves the socket until the channel closes.
 
 The worker trusts the router's stable-hash routing and does not re-derive ownership.
 """
@@ -135,7 +135,7 @@ async def _serve(args, backend_url: str, sock) -> None:
 
 
 def run_worker(args, backend_url: str, sock, worker_index: int) -> None:
-    """``multiprocessing.Process`` target: serve one session shard over ``sock``."""
+    """`multiprocessing.Process` target: serve one session shard over `sock`."""
     setproctitle.setproctitle(f"miles-session-worker-{worker_index}")
     set_pdeathsig()
     asyncio.run(_serve(args, backend_url, sock))

--- a/miles/rollout/session/worker.py
+++ b/miles/rollout/session/worker.py
@@ -13,11 +13,8 @@ The worker trusts the router's stable-hash routing and does not re-derive owners
 from __future__ import annotations
 
 import asyncio
-import ctypes
 import json
 import logging
-import signal
-import sys
 
 import httpx
 import setproctitle
@@ -35,6 +32,7 @@ from miles.rollout.session.ipc import (
     decode_envelope,
     encode_envelope,
     open_unix_channel,
+    set_pdeathsig,
 )
 
 logger = logging.getLogger(__name__)
@@ -125,17 +123,6 @@ class SessionWorker:
         raise ValueError(f"unknown op: {op!r}")
 
 
-def _set_pdeathsig() -> None:
-    """Ask the kernel to SIGKILL this worker if the parent (supervisor) dies (Linux)."""
-    if sys.platform != "linux":
-        return
-    try:
-        libc = ctypes.CDLL("libc.so.6", use_errno=True)
-        libc.prctl(1, signal.SIGKILL)  # PR_SET_PDEATHSIG
-    except Exception:
-        logger.warning("Failed to set PR_SET_PDEATHSIG; worker may outlive a crashed parent")
-
-
 async def _serve(args, backend_url: str, sock) -> None:
     backend = ProxyBackend(backend_url, timeout=getattr(args, "miles_router_timeout", 600.0))
     worker = SessionWorker(build_session_core(backend, args))
@@ -150,5 +137,5 @@ async def _serve(args, backend_url: str, sock) -> None:
 def run_worker(args, backend_url: str, sock, worker_index: int) -> None:
     """``multiprocessing.Process`` target: serve one session shard over ``sock``."""
     setproctitle.setproctitle(f"miles-session-worker-{worker_index}")
-    _set_pdeathsig()
+    set_pdeathsig()
     asyncio.run(_serve(args, backend_url, sock))

--- a/miles/utils/test_utils/chat_template_verify.py
+++ b/miles/utils/test_utils/chat_template_verify.py
@@ -6,8 +6,8 @@ all messages (with generation prompt).  This is required by sglang's
 pretokenized prefix mechanism for agentic workflows.
 
 Core functions are used by both the CLI script
-(``scripts/tools/verify_chat_template.py``) and the test suite
-(``tests/fast/utils/chat_template_utils/test_pretokenized_chat.py``).
+(`scripts/tools/verify_chat_template.py`) and the test suite
+(`tests/fast/utils/chat_template_utils/test_pretokenized_chat.py`).
 """
 
 from __future__ import annotations
@@ -36,7 +36,7 @@ def simulate_pretokenized_path(
     2. Render ALL messages (with generation prompt) -> full_text
     3. Verify prefix_text is a prefix of full_text
 
-    Raises ``ValueError`` on prefix mismatch.
+    Raises `ValueError` on prefix mismatch.
     """
     prefix_text = apply_chat_template_from_str(
         chat_template,
@@ -111,7 +111,7 @@ def verify_append_only(
 ) -> VerifyResult:
     """Check that the template satisfies the append-only invariant.
 
-    Returns a ``VerifyResult`` instead of raising, making it suitable for
+    Returns a `VerifyResult` instead of raising, making it suitable for
     batch verification in CLI scripts.
     """
     try:
@@ -136,13 +136,13 @@ def verify_append_only(
 #
 # Trajectories expose two class attributes used for verify-layer filtering:
 #
-#   * ``APPEND_ROLES: frozenset[str]`` — non-assistant roles that appear after
-#     the first assistant message.  Drives ``--tito-allowed-append-roles``.
-#   * ``IS_THINKING: bool`` — any assistant carries ``reasoning_content``.
-#     Drives ``--thinking`` and whether ``enable_thinking`` kwarg is passed.
+#   * `APPEND_ROLES: frozenset[str]` — non-assistant roles that appear after
+#     the first assistant message.  Drives `--tito-allowed-append-roles`.
+#   * `IS_THINKING: bool` — any assistant carries `reasoning_content`.
+#     Drives `--thinking` and whether `enable_thinking` kwarg is passed.
 #
 # Both are declared on the trajectory class (mock_trajectories.py), alongside
-# ``TOOLS`` / ``PRETOKENIZE_POSITIONS`` / ``MESSAGES``.  This file only lists
+# `TOOLS` / `PRETOKENIZE_POSITIONS` / `MESSAGES`.  This file only lists
 # which trajectories to exercise and expands them into concrete cases.
 
 import re  # noqa: E402
@@ -173,7 +173,7 @@ def _short_name(cls: type) -> str:
     return re.sub(r"(?<!^)(?=[A-Z])", "_", name).lower()
 
 
-# Trajectories exercised by ``run_all_checks`` / the CLI.  Must be a subset of
+# Trajectories exercised by `run_all_checks` / the CLI.  Must be a subset of
 # the classes defined in mock_trajectories.py.  Callers (CLI, tests) pick the
 # applicable subset via :func:`select_cases` based on each template's supported
 # append roles and thinking mode; there is no global "exclude" list here.
@@ -238,11 +238,11 @@ def select_cases(
 ) -> list[CaseSpec]:
     """Select trajectory cases by append-role surface and (optionally) thinking flag.
 
-    A case is included iff ``case.append_roles`` is a subset of
-    *allowed_append_roles*, and (when *is_thinking* is not ``None``)
-    ``case.is_thinking`` matches.
+    A case is included iff `case.append_roles` is a subset of
+    *allowed_append_roles*, and (when *is_thinking* is not `None`)
+    `case.is_thinking` matches.
 
-    The caller is responsible for including ``"tool"`` in *allowed_append_roles*
+    The caller is responsible for including `"tool"` in *allowed_append_roles*
     when the session is tool-capable; this function does not silently union it.
     """
     allowed = frozenset(allowed_append_roles)
@@ -257,14 +257,14 @@ def select_cases(
 
 
 def enable_thinking_variants(thinking: str) -> list[dict]:
-    """Return the list of ``enable_thinking`` kwarg variants to apply per case.
+    """Return the list of `enable_thinking` kwarg variants to apply per case.
 
-    * ``"off"`` → ``[{}]`` (no ``enable_thinking`` kwarg).
-    * ``"on"``  → ``[{"enable_thinking": True}]``.
-    * ``"both"`` → ``[{"enable_thinking": True}, {"enable_thinking": False}]``.
+    * `"off"` → `[{}]` (no `enable_thinking` kwarg).
+    * `"on"`  → `[{"enable_thinking": True}]`.
+    * `"both"` → `[{"enable_thinking": True}, {"enable_thinking": False}]`.
 
     Both CLI (:func:`run_all_checks`) and pytest parametrize callers use this
-    to avoid drifting in how the ``enable_thinking`` knob is exercised.
+    to avoid drifting in how the `enable_thinking` knob is exercised.
     """
     if thinking == "off":
         return [{}]
@@ -276,14 +276,14 @@ def enable_thinking_variants(thinking: str) -> list[dict]:
 
 
 def format_case_id(case: CaseSpec, kwargs: dict) -> str:
-    """Human-readable label for a ``(case, template_kwargs)`` tuple.
+    """Human-readable label for a `(case, template_kwargs)` tuple.
 
-    Used for both CLI ``VerifyResult.case_name`` and pytest test ids so the
+    Used for both CLI `VerifyResult.case_name` and pytest test ids so the
     same tuple is identified the same way in both surfaces.  Format:
 
-    * empty kwargs → ``case.case_name``.
-    * otherwise → ``<case.case_name>-<k1>_on/off-<k2>=val`` (keys sorted;
-      bool values emit ``key_on`` / ``key_off``; other values ``key=val``).
+    * empty kwargs → `case.case_name`.
+    * otherwise → `<case.case_name>-<k1>_on/off-<k2>=val` (keys sorted;
+      bool values emit `key_on` / `key_off`; other values `key=val`).
     """
     if not kwargs:
         return case.case_name
@@ -298,10 +298,10 @@ def format_case_id(case: CaseSpec, kwargs: dict) -> str:
 
 @dataclass
 class CoverageReport:
-    """Coverage of cases across ``(is_thinking, append_roles \\ {tool})``.
+    """Coverage of cases across `(is_thinking, append_roles \\ {tool})`.
 
-    ``covered`` maps each combination to the case names that fall in it;
-    ``missing`` lists combinations with no case.  ``tool`` is excluded from
+    `covered` maps each combination to the case names that fall in it;
+    `missing` lists combinations with no case.  `tool` is excluded from
     the role axis because it is implicitly always allowed.
     """
 
@@ -314,10 +314,10 @@ def check_coverage(
     *,
     role_universe: set[str] | None = None,
 ) -> CoverageReport:
-    """Enumerate ``thinking × append-role-subset`` combinations and report gaps.
+    """Enumerate `thinking × append-role-subset` combinations and report gaps.
 
     Used as a sanity check that every meaningful combination of
-    ``--tito-allowed-append-roles`` and ``--thinking`` is backed by at least
+    `--tito-allowed-append-roles` and `--thinking` is backed by at least
     one trajectory — otherwise certain CLI settings would be no-ops.
     """
     if cases is None:
@@ -355,20 +355,20 @@ def run_all_checks(
 ) -> list[VerifyResult]:
     """Run verification cases filtered by *allowed_append_roles* and *thinking*.
 
-    ``allowed_append_roles`` is the role surface the session may append after
-    an assistant turn; defaults to ``{"tool"}`` for the agentic baseline.
-    Trajectories whose ``append_roles`` are not a subset are skipped.  Caller
-    must include ``"tool"`` explicitly when relevant — there is no implicit
+    `allowed_append_roles` is the role surface the session may append after
+    an assistant turn; defaults to `{"tool"}` for the agentic baseline.
+    Trajectories whose `append_roles` are not a subset are skipped.  Caller
+    must include `"tool"` explicitly when relevant — there is no implicit
     union.
 
-    ``thinking`` selects which ``enable_thinking`` variants are exercised —
-    see :func:`enable_thinking_variants`.  When ``"both"``, **every** selected
-    trajectory (thinking or not) is rerun with ``enable_thinking=True`` and
-    ``enable_thinking=False``, so templates that branch on the flag are
+    `thinking` selects which `enable_thinking` variants are exercised —
+    see :func:`enable_thinking_variants`.  When `"both"`, **every** selected
+    trajectory (thinking or not) is rerun with `enable_thinking=True` and
+    `enable_thinking=False`, so templates that branch on the flag are
     validated against non-reasoning input too.
 
-    ``extra_template_kwargs`` is merged into every invocation — use it to
-    thread template-specific kwargs (e.g. GLM's ``clear_thinking=False``)
+    `extra_template_kwargs` is merged into every invocation — use it to
+    thread template-specific kwargs (e.g. GLM's `clear_thinking=False`)
     through the CLI.
     """
     if allowed_append_roles is None:
@@ -405,13 +405,13 @@ def run_all_checks(
 #
 # The string-based primitive above asserts text-prefix at the chat-template
 # layer.  This is necessary but not sufficient for production correctness —
-# production runs ``get_tito_tokenizer(...)`` and exercises ``merge_tokens``
+# production runs `get_tito_tokenizer(...)` and exercises `merge_tokens`
 # (model-specific token-level boundary patches) plus
-# ``tokenize_additional_non_assistant`` (renders appended segments under a
-# synthetic ``[_DUMMY_SYSTEM, ...]`` context, not the real history).
+# `tokenize_additional_non_assistant` (renders appended segments under a
+# synthetic `[_DUMMY_SYSTEM, ...]` context, not the real history).
 #
 # The primitive below mirrors the production path: it instantiates the actual
-# TITO subclass + HF tokenizer, runs ``merge_tokens`` against the encoded
+# TITO subclass + HF tokenizer, runs `merge_tokens` against the encoded
 # prefix, decodes, and asserts text equality with the canonical full render.
 
 
@@ -426,10 +426,10 @@ def verify_append_only_via_tito_instance(
 ) -> VerifyResult:
     """Decode-roundtrip verify with a pre-built TITO instance.
 
-    Asserts ``decode(tito.merge_tokens(prefix_msgs, full_msgs, encode(prefix_text)))
-    == full_text`` where ``prefix_text`` and ``full_text`` come from running the
-    chat template through ``tokenizer`` with the same kwargs ``tito`` was built
-    with.  The test-only path (e.g. ``BuggyQwen3TITOTokenizer``) uses this
+    Asserts `decode(tito.merge_tokens(prefix_msgs, full_msgs, encode(prefix_text)))
+    == full_text` where `prefix_text` and `full_text` come from running the
+    chat template through `tokenizer` with the same kwargs `tito` was built
+    with.  The test-only path (e.g. `BuggyQwen3TITOTokenizer`) uses this
     instance form directly; production-shape callers go through
     :func:`verify_append_only_via_tito`.
     """
@@ -468,12 +468,12 @@ def verify_append_only_via_tito_instance(
         )
 
         prefix_ids = tokenizer.encode(prefix_text, add_special_tokens=False)
-        # Simulate production's model-stop: in production, ``pretokenized_token_ids``
+        # Simulate production's model-stop: in production, `pretokenized_token_ids`
         # ends where the model actually stopped — typically before the trailing
-        # tokens the chat template would otherwise emit (Qwen's ``\n`` after
-        # ``<|im_end|>``, GLM's ambiguous ``<|user|>``/``<|observation|>`` boundary).
-        # The TITO subclass declares those as ``trailing_token_ids``.  Trim them
-        # here so ``merge_tokens``'s boundary patches see the prefix in its
+        # tokens the chat template would otherwise emit (Qwen's `\n` after
+        # `<|im_end|>`, GLM's ambiguous `<|user|>`/`<|observation|>` boundary).
+        # The TITO subclass declares those as `trailing_token_ids`.  Trim them
+        # here so `merge_tokens`'s boundary patches see the prefix in its
         # production shape so the verifier sees the same prefix the
         # subclass merge_tokens / trailing trim path operates on.
         trailing = tito.trailing_token_ids
@@ -518,9 +518,9 @@ def verify_append_only_via_tito(
 ) -> VerifyResult:
     """Decode-roundtrip verify, building TITO from the registered family.
 
-    Matches the production wiring at ``miles/rollout/session/sessions.py:35`` —
-    the same ``get_tito_tokenizer`` factory call, with ``chat_template_kwargs``
-    threaded through so ``merge_tokens`` and the dummy-context segment renders
+    Matches the production wiring at `miles/rollout/session/sessions.py:35` —
+    the same `get_tito_tokenizer` factory call, with `chat_template_kwargs`
+    threaded through so `merge_tokens` and the dummy-context segment renders
     use the same kwargs as the reference full render.
     """
     from miles.utils.chat_template_utils import get_tito_tokenizer
@@ -552,15 +552,15 @@ def run_all_checks_via_tito(
 ) -> list[VerifyResult]:
     """Same shape as :func:`run_all_checks` but routes through TITO + tokenizer.
 
-    Per-case TITO rebuild: each (case, ``enable_thinking`` variant) gets a fresh
+    Per-case TITO rebuild: each (case, `enable_thinking` variant) gets a fresh
     TITO instance constructed with the merged kwargs, so the dummy-context
-    segment renders inside ``tokenize_additional_non_assistant`` see the same
-    ``enable_thinking`` value as the reference render.  Construction is
+    segment renders inside `tokenize_additional_non_assistant` see the same
+    `enable_thinking` value as the reference render.  Construction is
     millisecond-level and runs ~50 times per CLI invocation; cheap.
 
-    The caller is responsible for setting ``tokenizer.chat_template`` (e.g. via
-    ``resolve_fixed_chat_template`` lookup or ``--template`` override) before
-    calling this — this function does not consult ``SUPPORTED_TEMPLATES``.
+    The caller is responsible for setting `tokenizer.chat_template` (e.g. via
+    `resolve_fixed_chat_template` lookup or `--template` override) before
+    calling this — this function does not consult `SUPPORTED_TEMPLATES`.
     """
     if allowed_append_roles is None:
         allowed_append_roles = {"tool"}
@@ -577,7 +577,7 @@ def run_all_checks_via_tito(
     for case in selected:
         # TITO incremental requires a non-empty non-assistant appendix at the
         # boundary.  Trajectories that end at the assistant turn (e.g. plain
-        # ``[sys, user, assistant]``) have no appendix to verify and are
+        # `[sys, user, assistant]`) have no appendix to verify and are
         # silently skipped here — the string-based primitive still covers
         # them at the text-prefix layer.
         msgs = case.traj_cls.MESSAGES

--- a/miles/utils/test_utils/mock_sglang_engine.py
+++ b/miles/utils/test_utils/mock_sglang_engine.py
@@ -1,4 +1,4 @@
-"""In-memory stand-in for ``SGLangEngine`` (no CUDA, no sglang, no model)."""
+"""In-memory stand-in for `SGLangEngine` (no CUDA, no sglang, no model)."""
 
 from __future__ import annotations
 
@@ -12,7 +12,7 @@ import ray
 logger = logging.getLogger(__name__)
 
 
-# Methods that just ``_record + _maybe_fault + return X``. The value is the
+# Methods that just `_record + _maybe_fault + return X`. The value is the
 # return value (no test asserts on its shape — sentinels keep the mock close
 # to what the real method's HTTP response shape returns).
 _RECORDING_METHODS: dict[str, Any] = {
@@ -53,8 +53,8 @@ def _make_recorder(name: str, return_value: Any) -> Callable:
 
 
 class MockSGLangEngine:
-    """Records every call into ``self.calls`` so tests can assert sequence and
-    arguments. Fault injection is set via ``set_fault(method, exception)``."""
+    """Records every call into `self.calls` so tests can assert sequence and
+    arguments. Fault injection is set via `set_fault(method, exception)`."""
 
     def __init__(
         self,

--- a/miles/utils/test_utils/mock_trajectories.py
+++ b/miles/utils/test_utils/mock_trajectories.py
@@ -7,13 +7,13 @@ Used by:
 
 Class attributes consumed by chat_template_verify:
 
-- ``APPEND_ROLES: frozenset[str]`` — non-assistant roles that appear *after*
-  the first assistant message (``tool`` / ``user`` / ``system``).  These are
+- `APPEND_ROLES: frozenset[str]` — non-assistant roles that appear *after*
+  the first assistant message (`tool` / `user` / `system`).  These are
   the roles the session must allow to be appended on top of an assistant-
-  stopped prefix; drives ``--tito-allowed-append-roles`` filtering.
-- ``IS_THINKING: bool`` — ``True`` iff at least one assistant message carries
-  ``reasoning_content``.  Drives ``--thinking`` filtering and whether the
-  ``enable_thinking`` chat-template kwarg is passed.
+  stopped prefix; drives `--tito-allowed-append-roles` filtering.
+- `IS_THINKING: bool` — `True` iff at least one assistant message carries
+  `reasoning_content`.  Drives `--thinking` filtering and whether the
+  `enable_thinking` chat-template kwarg is passed.
 
 Both are declared explicitly on each class so readers can see a trajectory's
 verify-layer classification without having to execute the module.
@@ -431,7 +431,7 @@ class MultiUserToolChainTrajectory:
     """sys, user1, ass(tool), tool, ass, user2, ass(tool), tool, ass(tool:date), tool
 
     NOTE: LinearTrajectory can carry multiple user messages when
-    ``allowed_append_roles`` includes ``"user"``; this trajectory exercises
+    `allowed_append_roles` includes `"user"`; this trajectory exercises
     that path.  The distribution may still deviate from the chat template
     behavior, causing high tito_session_mismatch_rate.
     """

--- a/miles/utils/test_utils/session_verify_agent.py
+++ b/miles/utils/test_utils/session_verify_agent.py
@@ -1,9 +1,9 @@
 """Custom-generate / custom-agent driver for TITO session-server verification.
 
-Wired through ``--custom-generate-function-path`` /
-``--custom-agent-function-path``; consumed by
-``tests/e2e/sglang/test_session_server_multi_role/`` (one test file per
-model family) and ``scripts/tools/verify_session_tito_tokenizer.py``.
+Wired through `--custom-generate-function-path` /
+`--custom-agent-function-path`; consumed by
+`tests/e2e/sglang/test_session_server_multi_role/` (one test file per
+model family) and `scripts/tools/verify_session_tito_tokenizer.py`.
 """
 
 from __future__ import annotations
@@ -44,12 +44,12 @@ _F = DriverAction.FORCE_FINAL
 class ToolCallFailureMode(StrEnum):
     """Recovery strategy when a TOOL_RESULT step finds the assistant emitted no tool_calls.
 
-    APPEND_TOOL  : Splice a sentinel ``tool`` message and continue.  Works on
+    APPEND_TOOL  : Splice a sentinel `tool` message and continue.  Works on
                    lenient templates; strict templates that hard-assert any
-                   ``tool`` role must follow an assistant with ``tool_calls``
+                   `tool` role must follow an assistant with `tool_calls`
                    (e.g. MiniMax-M2.7) will reject the next request at server-side.
-    APPEND_USER  : Splice a ``user`` message carrying the same failure text as
-                   APPEND_TOOL.  Requires "user" in ``allowed_append_roles`` —
+    APPEND_USER  : Splice a `user` message carrying the same failure text as
+                   APPEND_TOOL.  Requires "user" in `allowed_append_roles` —
                    raises ValueError at agent start otherwise, so misconfig is
                    immediately visible instead of silently downgrading.
     ROLLBACK     : Pop the offending assistant and let the loop's chat call at
@@ -84,8 +84,8 @@ _FORBIDDEN_MISMATCH_TYPES: frozenset[str] = frozenset(
     {"special_token_count", "special_token_type", "non_assistant_text"}
 )
 
-# Override per call: ``--session-verify-cycles N`` (CLI) or ``cycles=N``
-# (pytest via ``run_session_verify``).  Smaller-context models with a 4K
+# Override per call: `--session-verify-cycles N` (CLI) or `cycles=N`
+# (pytest via `run_session_verify`).  Smaller-context models with a 4K
 # response budget should drop to 2 to avoid context overflow.
 DEFAULT_CYCLES = 3
 
@@ -152,7 +152,7 @@ INITIAL_USER_PROMPT = "What's the weather in Beijing?"
 
 
 def select_schedule(allowed_roles, *, cycles: int = DEFAULT_CYCLES) -> list[DriverAction]:
-    """Pick the schedule for ``frozenset(allowed_roles)``; raises on unregistered."""
+    """Pick the schedule for `frozenset(allowed_roles)`; raises on unregistered."""
     key = frozenset(allowed_roles)
     if key not in _SUPPORTED_ROLE_SURFACES:
         registered = sorted(sorted(k) for k in _SUPPORTED_ROLE_SURFACES)
@@ -184,12 +184,12 @@ async def _chat(client, base_url, messages, request_kwargs, *, label):
 
 
 async def run_agent(base_url, prompt, request_kwargs, metadata, **kwargs):
-    """Custom-agent entry point.  Returns ``{"driver_events": [...], **counters}``.
+    """Custom-agent entry point.  Returns `{"driver_events": [...], **counters}`.
 
-    ``allowed_append_roles`` must be present in ``metadata`` (the ``generate``
-    wrapper below injects it from ``args.tito_allowed_append_roles``).
-    ``prompt`` is ignored — the driver synthesizes its own initial conversation
-    from ``build_initial_messages`` so runs are reproducible.
+    `allowed_append_roles` must be present in `metadata` (the `generate`
+    wrapper below injects it from `args.tito_allowed_append_roles`).
+    `prompt` is ignored — the driver synthesizes its own initial conversation
+    from `build_initial_messages` so runs are reproducible.
     """
     allowed_roles = metadata.get("allowed_append_roles")
     if allowed_roles is None:
@@ -311,7 +311,7 @@ async def run_agent(base_url, prompt, request_kwargs, metadata, **kwargs):
                 # Pop the last assistant from our local copy.  The next
                 # request therefore has one fewer message than what the
                 # server has stored, which is the trigger for its
-                # ``_detect_and_rollback`` path — the server rewinds its
+                # `_detect_and_rollback` path — the server rewinds its
                 # state, then re-inferences.
                 if not messages or messages[-1]["role"] != "assistant":
                     raise AssertionError(
@@ -342,9 +342,9 @@ async def run_agent(base_url, prompt, request_kwargs, metadata, **kwargs):
 async def generate(input: GenerateFnInput) -> GenerateFnOutput:
     """Custom-generate wrapper that asserts driver-action coverage.
 
-    - Per-sample: every sample must contain ``rollback``, plus ``append_user``
-      / ``append_system`` when those roles are allowed.
-    - Cross-sample: at least one sample must contain ``append_tool``
+    - Per-sample: every sample must contain `rollback`, plus `append_user`
+      / `append_system` when those roles are allowed.
+    - Cross-sample: at least one sample must contain `append_tool`
       (model-dependent on emitting a tool_call).
     """
     allowed_roles = list(input.args.tito_allowed_append_roles)

--- a/miles/utils/test_utils/session_verify_runner.py
+++ b/miles/utils/test_utils/session_verify_runner.py
@@ -1,23 +1,23 @@
-"""Boot a real ``miles`` rollout pipeline + run the multi-role TITO driver.
+"""Boot a real `miles` rollout pipeline + run the multi-role TITO driver.
 
 Used by both consumers:
 
-- pytest e2e: ``tests/e2e/sglang/test_session_server_multi_role/`` (one test
+- pytest e2e: `tests/e2e/sglang/test_session_server_multi_role/` (one test
   file per model family)
-- CLI: ``scripts/tools/verify_session_tito_tokenizer.py``
+- CLI: `scripts/tools/verify_session_tito_tokenizer.py`
 
-Both forms run the same ``execute_train(--debug-rollout-only)`` path: full miles
-pipeline (sglang + miles-router with session support) is launched, ``train`` is
-skipped, and the rollout drives ``session_verify_agent.run_agent`` against the
+Both forms run the same `execute_train(--debug-rollout-only)` path: full miles
+pipeline (sglang + miles-router with session support) is launched, `train` is
+skipped, and the rollout drives `session_verify_agent.run_agent` against the
 session server.
 
-Args flow through miles' canonical ``parse_args`` Namespace.
+Args flow through miles' canonical `parse_args` Namespace.
 
 # Backend choice
 
-``execute_train`` asserts ``("--train-backend fsdp" in train_args) == (megatron_model_type is None)``,
-so the ``fsdp`` + ``None`` pair is the only consistent way to skip megatron init
-in ``--debug-rollout-only`` mode.  We use that.
+`execute_train` asserts `("--train-backend fsdp" in train_args) == (megatron_model_type is None)`,
+so the `fsdp` + `None` pair is the only consistent way to skip megatron init
+in `--debug-rollout-only` mode.  We use that.
 """
 
 from __future__ import annotations
@@ -75,10 +75,10 @@ SESSION_VERIFY_INVARIANT_ARGS: dict[str, Any] = {
 
 
 def session_verify_extras(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
-    """``add_custom_arguments`` hook for ``miles.utils.arguments.parse_args``.
+    """`add_custom_arguments` hook for `miles.utils.arguments.parse_args`.
 
-    Adds the wrapper-only ``--assistant-text-threshold`` knob (a post-process
-    gate on the per-sample metrics JSONL, NOT in ``train_args``) and applies
+    Adds the wrapper-only `--assistant-text-threshold` knob (a post-process
+    gate on the per-sample metrics JSONL, NOT in `train_args`) and applies
     session-verify invariants as parser defaults — user CLI still overrides
     these via the canonical miles flags.
     """
@@ -92,7 +92,7 @@ def session_verify_extras(parser: argparse.ArgumentParser) -> argparse.ArgumentP
             "is known to roundtrip imperfectly (e.g. nemotron_3 keeps a "
             "trailing newline in reasoning_content) — hard mismatches still "
             "gate.  Post-process gate on per-sample JSONL metrics; not "
-            "forwarded to ``train_args``."
+            "forwarded to `train_args`."
         ),
     )
     parser.set_defaults(**SESSION_VERIFY_INVARIANT_ARGS)
@@ -110,7 +110,7 @@ def _ensure_model_downloaded(hf_checkpoint: str) -> str:
     """Return a local model path, downloading HF repos when needed.
 
     Lets callers pass either a HuggingFace repo id (downloaded under
-    ``/root/models/<short-name>``) or an existing local checkpoint path
+    `/root/models/<short-name>`) or an existing local checkpoint path
     (returned as-is, no download).
     """
     if os.path.exists(hf_checkpoint):
@@ -129,11 +129,11 @@ def _clear_proxy_env() -> None:
 
 
 def namespace_to_train_args(ns: argparse.Namespace) -> str:
-    """Serialize a fully-shaped Namespace into the ``train_args`` string.
+    """Serialize a fully-shaped Namespace into the `train_args` string.
 
-    Reads miles-canonical field names off ``ns``; emits the exact flag set
-    ``execute_train`` re-parses downstream.  ``actor_num_nodes`` is written
-    explicitly from ``ns.actor_num_nodes`` (NOT defaulted at the serializer
+    Reads miles-canonical field names off `ns`; emits the exact flag set
+    `execute_train` re-parses downstream.  `actor_num_nodes` is written
+    explicitly from `ns.actor_num_nodes` (NOT defaulted at the serializer
     level) so the runner stays pinned to whatever the caller's Namespace
     declared, regardless of any drift in miles' upstream default.
     """
@@ -180,30 +180,30 @@ def namespace_to_train_args(ns: argparse.Namespace) -> str:
 
 
 def run_session_verify(args: argparse.Namespace) -> None:
-    """Boot ``miles`` rollout pipeline and run the multi-role driver.
+    """Boot `miles` rollout pipeline and run the multi-role driver.
 
-    Returns nothing on success; raises ``AssertionError`` on TITO mismatch
+    Returns nothing on success; raises `AssertionError` on TITO mismatch
     (HTTP 500 from server-side prefix check) or coverage shortfall (raised by
-    ``session_verify_agent.generate``).
+    `session_verify_agent.generate`).
 
-    ``args`` MUST be a fully-shaped Namespace carrying miles-canonical field
-    names plus the session-verify-specific fields (``session_verify_cycles``,
-    ``tool_call_failure_mode``, ``assistant_text_threshold``).  Build it via
-    ``parse_args(add_custom_arguments=session_verify_extras)`` for the CLI
-    path or by spreading ``SESSION_VERIFY_INVARIANT_ARGS`` into
-    ``argparse.Namespace(...)`` for tests.
+    `args` MUST be a fully-shaped Namespace carrying miles-canonical field
+    names plus the session-verify-specific fields (`session_verify_cycles`,
+    `tool_call_failure_mode`, `assistant_text_threshold`).  Build it via
+    `parse_args(add_custom_arguments=session_verify_extras)` for the CLI
+    path or by spreading `SESSION_VERIFY_INVARIANT_ARGS` into
+    `argparse.Namespace(...)` for tests.
 
-    Mutates ``args`` in three places before composing train_args:
-    - ``args.sglang_reasoning_parser`` / ``args.sglang_tool_call_parser`` are
+    Mutates `args` in three places before composing train_args:
+    - `args.sglang_reasoning_parser` / `args.sglang_tool_call_parser` are
       resolved against the TITO subclass's bound values via
-      ``resolve_reasoning_and_tool_call_parser`` — caller-passed values that
-      disagree with the bound values raise ``ValueError`` here, before any
+      `resolve_reasoning_and_tool_call_parser` — caller-passed values that
+      disagree with the bound values raise `ValueError` here, before any
       GPU work starts.
-    - ``args.hf_checkpoint`` is replaced with the local download path so the
+    - `args.hf_checkpoint` is replaced with the local download path so the
       composed train_args points at the downloaded model, not the HF id.
-    - ``args.tito_allowed_append_roles`` is normalized (lowercase, dedup,
-      ensure ``'tool'`` is in) to match the schedule contract in
-      ``session_verify_agent._SUPPORTED_ROLE_SURFACES``.
+    - `args.tito_allowed_append_roles` is normalized (lowercase, dedup,
+      ensure `'tool'` is in) to match the schedule contract in
+      `session_verify_agent._SUPPORTED_ROLE_SURFACES`.
     """
     args.sglang_reasoning_parser, args.sglang_tool_call_parser = resolve_reasoning_and_tool_call_parser(
         args.tito_model, args.sglang_reasoning_parser, args.sglang_tool_call_parser
@@ -255,8 +255,8 @@ def assert_session_verify_metrics(metrics_path: str, *, assistant_text_threshold
     per-sample in the agent wrapper and would have already raised by now.
     Here we only cross-check the soft assistant_text rate against the
     caller-provided threshold (per-model: some upstream sglang reasoning
-    parsers — notably ``nemotron_3`` — leave a trailing ``\\n`` in
-    ``reasoning_content`` that breaks the canonical roundtrip until the
+    parsers — notably `nemotron_3` — leave a trailing `\\n` in
+    `reasoning_content` that breaks the canonical roundtrip until the
     parser is patched, so those families ride at threshold=1.0).
     """
     samples_with_mismatch = 0

--- a/tests/fast/router/test_session_dataplane.py
+++ b/tests/fast/router/test_session_dataplane.py
@@ -1,7 +1,7 @@
 """Data-plane integration: router + N worker shards over real socketpair IPC.
 
-Wires the router to N ``SessionWorker`` shards (each its own ``SessionRegistry``)
-over real ``socket.socketpair`` IPC channels in one event loop, and drives the
+Wires the router to N `SessionWorker` shards (each its own `SessionRegistry`)
+over real `socket.socketpair` IPC channels in one event loop, and drives the
 router app via httpx ASGITransport. This exercises hash routing, IPC framing,
 worker dispatch, TITO state per shard, and equivalence with the single-process
 server — without OS-process spawning (that lifecycle is the supervisor's job,

--- a/tests/fast/router/test_session_pretokenized_e2e.py
+++ b/tests/fast/router/test_session_pretokenized_e2e.py
@@ -7,7 +7,7 @@ These tests intentionally stay narrow:
 - only session/TITO plumbing + mismatch taxonomy checks
 
 Detailed template correctness remains covered by the lower-level chat-template
-tests in ``tests/fast/utils/chat_template_utils/``.
+tests in `tests/fast/utils/chat_template_utils/`.
 """
 
 from __future__ import annotations

--- a/tests/fast/router/test_session_supervisor.py
+++ b/tests/fast/router/test_session_supervisor.py
@@ -1,0 +1,92 @@
+"""Real-process supervisor: spawns worker+router processes, serves end-to-end over IPC,
+and fail-fasts when a worker dies (so the rollout path raises instead of hanging).
+
+Unlike test_session_dataplane (in-loop channels), this spawns actual OS processes via the
+supervisor — the control-plane path that PR-C adds.
+"""
+
+import time
+import uuid
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from miles.rollout.session.supervisor import SessionServerSupervisor
+from miles.utils.http_utils import find_available_port
+from miles.utils.test_utils.mock_sglang_server import MockSGLangServer, ProcessResult, with_mock_server
+
+
+def _process_fn(prompt: str) -> ProcessResult:
+    return ProcessResult(text=f"echo: {prompt}", finish_reason="stop")
+
+
+def _patched_chat_response():
+    original = MockSGLangServer._compute_chat_completions_response
+
+    def patched(self, payload: dict) -> dict:
+        response = original(self, payload)
+        choice = response["choices"][0]
+        otl = [
+            (it["logprob"], self.tokenizer.convert_tokens_to_ids(it["token"])) for it in choice["logprobs"]["content"]
+        ]
+        choice["meta_info"] = {"output_token_logprobs": otl, "completion_tokens": len(otl)}
+        return response
+
+    return patched
+
+
+def _args():
+    return SimpleNamespace(
+        miles_router_timeout=30,
+        hf_checkpoint="Qwen/Qwen3-0.6B",
+        chat_template_path=None,
+        apply_chat_template_kwargs={"enable_thinking": False},
+        tito_model="default",
+        tito_allowed_append_roles=["tool"],
+        session_server_instance_id=uuid.uuid4().hex,
+        session_server_workers=2,
+    )
+
+
+def test_supervisor_serves_then_fails_fast_on_worker_death():
+    with patch.object(MockSGLangServer, "_compute_chat_completions_response", new=_patched_chat_response()):
+        with with_mock_server(process_fn=_process_fn) as backend:
+            ip, port = "127.0.0.1", find_available_port(45000)
+            sup = SessionServerSupervisor(_args(), backend.url, ip, port)
+            sup.start()
+            base = f"http://{ip}:{port}"
+            try:
+                # End-to-end through real router + worker processes.
+                assert httpx.get(f"{base}/health", timeout=10).status_code == 200
+                sup.check()  # healthy → no raise
+
+                sid = httpx.post(f"{base}/sessions", timeout=10).json()["session_id"]
+                chat = httpx.post(
+                    f"{base}/sessions/{sid}/v1/chat/completions",
+                    json={"messages": [{"role": "user", "content": "hi"}]},
+                    timeout=30,
+                )
+                assert chat.status_code == 200, chat.text
+                assert len(httpx.get(f"{base}/sessions/{sid}", timeout=10).json()["records"]) == 1
+
+                # Kill a worker → the monitor must record it and check() must raise.
+                sup._procs[0].kill()
+                deadline = time.monotonic() + 10
+                while time.monotonic() < deadline:
+                    try:
+                        sup.check()
+                    except RuntimeError:
+                        break
+                    time.sleep(0.2)
+                with pytest.raises(RuntimeError, match="session server failed"):
+                    sup.check()
+            finally:
+                sup.shutdown()
+            # No orphans. Teardown may be running in the monitor thread (SIGTERM + grace +
+            # SIGKILL), so wait for the children to be reaped before asserting.
+            deadline = time.monotonic() + 15
+            while time.monotonic() < deadline and any(p.is_alive() for p in sup._procs):
+                time.sleep(0.2)
+            assert all(not p.is_alive() for p in sup._procs)

--- a/tests/fast/router/test_session_worker.py
+++ b/tests/fast/router/test_session_worker.py
@@ -1,6 +1,6 @@
 """Unit tests for the session worker's op dispatch / reply encoding (no process spawn).
 
-Drives ``SessionWorker.handle`` in-process against a real ``SessionCore`` (real
+Drives `SessionWorker.handle` in-process against a real `SessionCore` (real
 tokenizer) and a mock backend. The full chat-through-a-spawned-worker path is
 covered by the multi-process equivalence tests.
 """


### PR DESCRIPTION
## Summary
The process-lifecycle layer of the multi-process session server, split out of #1519 for reviewability: `SessionServerSupervisor` spawns (`"spawn"` context) N session workers + 1 thin router over socketpairs, gates readiness on the router's `/health` reporting every worker healthy, fail-fasts on any child death, and tears the whole group down with no orphans. **Nothing calls the supervisor yet** — launch wiring and the removal of the single-process chassis land in the follow-up PRs.

> Stacked on #1569 → #1510 → #1563 → #1518. Base = `refactor/session-mp-dataplane`. Review/merge after #1518; merge order within the split: **this → test-harness PR → #1519**.

## What's here
- `supervisor.py` — spawn-context children (a forked child would inherit this Ray actor's threads/finalizers, e.g. wandb's service thread, and deadlock); the parent closes every socket end it holds so a child death is observable as EOF; readiness raises early if a child dies while loading its tokenizer; a monitor thread records the first death and tears the group down (SIGTERM → grace → SIGKILL, `atexit`-registered); `check()` re-raises the recorded failure for the rollout path.
- `router.run_router` — the router process entry point; imports nothing from `core`/`worker`, so the router process never loads the tokenizer/transformers stack.
- `ipc.set_pdeathsig` — the PR_SET_PDEATHSIG helper moves here (stdlib-only) so the router can use it too; the worker's private copy is replaced by the shared helper.
- `tests/fast/router/test_session_supervisor.py` — spawns real worker+router processes, drives create/chat/get end-to-end over IPC, then kills a worker and asserts `check()` raises and no child is orphaned.

## Testing
- `pytest tests/fast/router` — **96 passed** at this commit (the in-process chassis is untouched here; the suite is green on this PR standing alone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

