### PR TITLE
(6/7) test(session): InloopSessionServer replaces the in-process SessionServer test harness

### DIFF
--- a/miles/utils/test_utils/inloop_session_server.py
+++ b/miles/utils/test_utils/inloop_session_server.py
@@ -1,7 +1,7 @@
 """In-thread session server for tests: the production router app over in-loop workers.
 
-Serves the SAME client-facing app production runs (``build_router_app``) on a real
-port, but wires the N ``SessionWorker`` shards as in-loop IPC handlers on the server
+Serves the SAME client-facing app production runs (`build_router_app`) on a real
+port, but wires the N `SessionWorker` shards as in-loop IPC handlers on the server
 thread's event loop instead of spawning OS processes — real socketpair framing and
 worker dispatch, none of the spawn cost. Process lifecycle (spawn, readiness,
 fail-fast, teardown) is the supervisor's job and is covered by its own tests.
@@ -21,7 +21,7 @@ from miles.rollout.session.worker import ProxyBackend, SessionWorker
 
 
 class InloopSessionServer:
-    """Router app + ``n_workers`` in-loop worker shards, served from one thread."""
+    """Router app + `n_workers` in-loop worker shards, served from one thread."""
 
     def __init__(self, args, backend_url: str, host: str, port: int, n_workers: int = 1):
         self.args = args

--- a/miles/utils/test_utils/inloop_session_server.py
+++ b/miles/utils/test_utils/inloop_session_server.py
@@ -1,0 +1,81 @@
+"""In-thread session server for tests: the production router app over in-loop workers.
+
+Serves the SAME client-facing app production runs (``build_router_app``) on a real
+port, but wires the N ``SessionWorker`` shards as in-loop IPC handlers on the server
+thread's event loop instead of spawning OS processes — real socketpair framing and
+worker dispatch, none of the spawn cost. Process lifecycle (spawn, readiness,
+fail-fast, teardown) is the supervisor's job and is covered by its own tests.
+"""
+
+import asyncio
+import socket
+import threading
+import time
+
+import uvicorn
+
+from miles.rollout.session.core import build_session_core
+from miles.rollout.session.ipc import open_unix_channel
+from miles.rollout.session.router import build_router_app
+from miles.rollout.session.worker import ProxyBackend, SessionWorker
+
+
+class InloopSessionServer:
+    """Router app + ``n_workers`` in-loop worker shards, served from one thread."""
+
+    def __init__(self, args, backend_url: str, host: str, port: int, n_workers: int = 1):
+        self.args = args
+        self.backend_url = backend_url
+        self.host = host
+        self.port = port
+        self.n_workers = n_workers
+        self._server: uvicorn.Server | None = None
+        self._thread: threading.Thread | None = None
+
+    @property
+    def url(self) -> str:
+        return f"http://{self.host}:{self.port}"
+
+    def start(self) -> None:
+        self._thread = threading.Thread(target=lambda: asyncio.run(self._serve()), daemon=True)
+        self._thread.start()
+        self._wait_for_port_open()
+
+    async def _serve(self) -> None:
+        # Channels (and the workers behind them) must live on the serving loop,
+        # so all wiring happens here, before the port opens. Both channel ends are
+        # kept referenced: asyncio holds tasks weakly, so an unreferenced channel
+        # (with its reader/writer tasks) would be garbage-collected mid-serve.
+        channels, worker_channels, backends = [], [], []
+        for _ in range(self.n_workers):
+            worker_end, router_end = socket.socketpair()
+            backend = ProxyBackend(self.backend_url, timeout=getattr(self.args, "miles_router_timeout", 600.0))
+            backends.append(backend)
+            worker = SessionWorker(build_session_core(backend, self.args))
+            worker_channels.append(await open_unix_channel(worker_end, request_handler=worker.handle))
+            channels.append(await open_unix_channel(router_end))
+        app = build_router_app(channels, getattr(self.args, "session_server_instance_id", None))
+        self._server = uvicorn.Server(uvicorn.Config(app, host=self.host, port=self.port, log_level="warning"))
+        try:
+            await self._server.serve()
+        finally:
+            for channel in worker_channels + channels:
+                await channel.aclose()
+            for backend in backends:
+                await backend.aclose()
+
+    def stop(self) -> None:
+        if self._server is not None:
+            self._server.should_exit = True
+        if self._thread is not None and self._thread.is_alive():
+            self._thread.join(timeout=5.0)
+
+    def _wait_for_port_open(self) -> None:
+        for _ in range(100):
+            if self._thread is not None and not self._thread.is_alive():
+                raise RuntimeError("InloopSessionServer thread died during startup")
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+                if sock.connect_ex((self.host, self.port)) == 0:
+                    return
+            time.sleep(0.1)
+        raise RuntimeError(f"Failed to start server on {self.url}")

--- a/tests/fast/fixtures/generation_fixtures.py
+++ b/tests/fast/fixtures/generation_fixtures.py
@@ -14,13 +14,12 @@ import pytest
 from miles.rollout.base_types import GenerateFnInput
 from miles.rollout.inference_rollout.compatibility import load_generate_function
 from miles.rollout.inference_rollout.inference_rollout_common import GenerateState
-from miles.rollout.session.server import SessionServer
 from miles.utils.async_utils import run
 from miles.utils.http_utils import find_available_port, init_http_client
 from miles.utils.misc import SingletonMeta
 from miles.utils.test_utils import mock_tools
+from miles.utils.test_utils.inloop_session_server import InloopSessionServer
 from miles.utils.test_utils.mock_sglang_server import ProcessResult, ProcessResultMetaInfo, with_mock_server
-from miles.utils.test_utils.uvicorn_thread_server import UvicornThreadServer
 from miles.utils.types import Sample
 
 MODEL_NAME = "Qwen/Qwen3-0.6B"
@@ -239,9 +238,7 @@ def with_session_server(
         use_rollout_routing_replay=args.use_rollout_routing_replay,
         session_server_instance_id=uuid.uuid4().hex,
     )
-    session_server = SessionServer(args, backend_url=backend_url)
-
-    server = UvicornThreadServer(session_server.app, host="127.0.0.1", port=port)
+    server = InloopSessionServer(args, backend_url, host="127.0.0.1", port=port)
     server.start()
 
     try:
@@ -287,13 +284,13 @@ def generation_env(request, variant):
             **other_args_kwargs,
         )
 
-        # Agentic variants need a SessionServer for TITO session tracking;
+        # Agentic variants need a session server for TITO session tracking;
         # non-agentic variants talk directly to the mock sglang server.
         cm = with_session_server(mock_server.url, args, port=server_port) if is_agentic else _noop_port(server_port)
 
         with cm:
             if is_agentic:
-                # Point session server address to the SessionServer we just started
+                # Point session server address to the server we just started
                 args.session_server_ip = "127.0.0.1"
                 args.session_server_port = server_port
                 mock_tools.AGENTIC_MAX_TURNS = args_kwargs.get("generate_max_turns")

--- a/tests/fast/fixtures/rollout_fixtures.py
+++ b/tests/fast/fixtures/rollout_fixtures.py
@@ -14,11 +14,11 @@ import pytest
 import requests
 
 from miles.rollout.data_source import DataSource, RolloutDataSourceWithBuffer
-from miles.rollout.session.server import SessionServer
 from miles.router.router import MilesRouter
 from miles.utils.arguments import parse_args
 from miles.utils.http_utils import find_available_port, init_http_client
 from miles.utils.misc import SingletonMeta
+from miles.utils.test_utils.inloop_session_server import InloopSessionServer
 from miles.utils.test_utils.mock_sglang_server import MockSGLangServer, with_mock_server
 from miles.utils.test_utils.uvicorn_thread_server import UvicornThreadServer
 
@@ -100,7 +100,7 @@ DEFAULT_DATA_ROWS = [{"input": "What is 1+7?", "label": "8"}]
 
 @contextmanager
 def _with_session_server(args: Namespace, backend_url: str) -> Iterator[UvicornThreadServer]:
-    """Start a SessionServer for agentic variants that need TITO session tracking."""
+    """Start an in-loop session server for agentic variants that need TITO session tracking."""
     from types import SimpleNamespace
 
     session_args = SimpleNamespace(
@@ -111,9 +111,8 @@ def _with_session_server(args: Namespace, backend_url: str) -> Iterator[UvicornT
         tito_allowed_append_roles=getattr(args, "tito_allowed_append_roles", ["tool"]),
         use_rollout_routing_replay=getattr(args, "use_rollout_routing_replay", False),
     )
-    session_server = SessionServer(session_args, backend_url=backend_url)
     port = find_available_port(31000)
-    server = UvicornThreadServer(session_server.app, host="127.0.0.1", port=port)
+    server = InloopSessionServer(session_args, backend_url, host="127.0.0.1", port=port)
     try:
         server.start()
         args.session_server_ip = "127.0.0.1"

--- a/tests/fast/fixtures/rollout_fixtures.py
+++ b/tests/fast/fixtures/rollout_fixtures.py
@@ -99,7 +99,7 @@ DEFAULT_DATA_ROWS = [{"input": "What is 1+7?", "label": "8"}]
 
 
 @contextmanager
-def _with_session_server(args: Namespace, backend_url: str) -> Iterator[UvicornThreadServer]:
+def _with_session_server(args: Namespace, backend_url: str) -> Iterator[InloopSessionServer]:
     """Start an in-loop session server for agentic variants that need TITO session tracking."""
     from types import SimpleNamespace
 

--- a/tests/fast/router/session_pretokenized_test_utils.py
+++ b/tests/fast/router/session_pretokenized_test_utils.py
@@ -8,10 +8,10 @@ import requests
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 
-from miles.rollout.session.server import SessionServer
 from miles.utils.chat_template_utils import MismatchType, apply_chat_template, get_tito_tokenizer
 from miles.utils.http_utils import find_available_port
 from miles.utils.processing_utils import load_tokenizer
+from miles.utils.test_utils.inloop_session_server import InloopSessionServer
 from miles.utils.test_utils.uvicorn_thread_server import UvicornThreadServer
 
 FORBIDDEN_MISMATCH_TYPES: frozenset[str] = frozenset(
@@ -53,14 +53,12 @@ def make_router_env(
         tito_allowed_append_roles=allowed_append_roles,
         use_rollout_routing_replay=False,
     )
-    session_server = SessionServer(args, backend_url=backend.url)
-
     port = find_available_port(31000)
-    server = UvicornThreadServer(session_server.app, host="127.0.0.1", port=port)
+    server = InloopSessionServer(args, backend.url, host="127.0.0.1", port=port)
     server.start()
 
     return SimpleNamespace(
-        url=f"http://127.0.0.1:{port}",
+        url=server.url,
         backend=backend,
         server=server,
     )

--- a/tests/fast/router/test_session_dataplane.py
+++ b/tests/fast/router/test_session_dataplane.py
@@ -3,10 +3,10 @@
 Wires the router to N `SessionWorker` shards (each its own `SessionRegistry`)
 over real `socket.socketpair` IPC channels in one event loop, and drives the
 router app via httpx ASGITransport. This exercises hash routing, IPC framing,
-worker dispatch, TITO state per shard, and equivalence with the single-process
-server — without OS-process spawning (that lifecycle is the supervisor's job,
-covered separately). Workers as in-loop IPC handlers still use distinct
-registries, so cross-shard routing is genuinely tested.
+worker dispatch, TITO state per shard, and workers=N == workers=1 equivalence
+(the same topology with one shard) — without OS-process spawning (that lifecycle
+is the supervisor's job, covered separately). Workers as in-loop IPC handlers
+still use distinct registries, so cross-shard routing is genuinely tested.
 """
 
 import json
@@ -22,7 +22,6 @@ from miles.rollout.session.core import SessionCore
 from miles.rollout.session.ipc import open_unix_channel
 from miles.rollout.session.linear_trajectory import SessionRegistry
 from miles.rollout.session.router import build_router_app
-from miles.rollout.session.server import SessionServer
 from miles.rollout.session.sharding import worker_index_for_session
 from miles.rollout.session.worker import ProxyBackend, SessionWorker
 from miles.utils.chat_template_utils import get_tito_tokenizer
@@ -76,35 +75,42 @@ async def env():
                 chat_template_kwargs={"enable_thinking": False},
                 allowed_append_roles=["tool"],
             )
-            backends, worker_channels, router_channels = [], [], []
-            for _ in range(N_WORKERS):
-                a, b = socket.socketpair()
-                be = ProxyBackend(backend.url, timeout=30)
-                backends.append(be)
-                core = SessionCore(
-                    be, SessionRegistry(args, tokenizer, tito_tokenizer=tito), args, args.session_server_instance_id
-                )
-                worker = SessionWorker(core)
-                worker_channels.append(await open_unix_channel(b, request_handler=worker.handle))
-                router_channels.append(await open_unix_channel(a))
+            backends, channels = [], []
 
-            app = build_router_app(router_channels, args.session_server_instance_id)
+            async def make_shard_channels(n: int) -> list:
+                shard_channels = []
+                for _ in range(n):
+                    a, b = socket.socketpair()
+                    be = ProxyBackend(backend.url, timeout=30)
+                    backends.append(be)
+                    core = SessionCore(
+                        be,
+                        SessionRegistry(args, tokenizer, tito_tokenizer=tito),
+                        args,
+                        args.session_server_instance_id,
+                    )
+                    worker = SessionWorker(core)
+                    channels.append(await open_unix_channel(b, request_handler=worker.handle))
+                    shard_channels.append(await open_unix_channel(a))
+                    channels.append(shard_channels[-1])
+                return shard_channels
+
+            app = build_router_app(await make_shard_channels(N_WORKERS), args.session_server_instance_id)
             client = httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://router")
 
-            # Single-process server for equivalence comparison (same mock backend).
-            sp = SessionServer(args, backend_url=backend.url)
-            sp_client = httpx.AsyncClient(transport=httpx.ASGITransport(app=sp.app), base_url="http://sp")
+            # workers=1 (same topology, one shard) for equivalence comparison.
+            sp_app = build_router_app(await make_shard_channels(1), args.session_server_instance_id)
+            sp_client = httpx.AsyncClient(transport=httpx.ASGITransport(app=sp_app), base_url="http://sp")
 
             try:
                 yield SimpleNamespace(client=client, sp_client=sp_client, n=N_WORKERS)
             finally:
                 await client.aclose()
                 await sp_client.aclose()
-                for ch in worker_channels + router_channels:
+                for ch in channels:
                     await ch.aclose()
                 for be in backends:
                     await be.aclose()
-                await sp.client.aclose()
 
 
 async def test_health_ok(env):
@@ -177,24 +183,18 @@ async def test_equivalence_with_single_process(env):
     assert rd.content == sd.content == b""
 
 
-async def test_transport_error_502_equivalence():
-    """A dead backend maps to the same 502 in workers=N (ProxyBackend) and workers=1
-    (SessionServer.do_proxy) — pins the two do_proxy implementations against drift."""
+async def test_transport_error_maps_to_502():
+    """A dead backend maps to a 502 proxy result with the error shape clients rely on."""
     from miles.rollout.session.core import ProxyRequest
     from miles.utils.http_utils import find_available_port
 
     dead = f"http://127.0.0.1:{find_available_port(42000)}"  # nothing listening → connection refused
-    args = _make_args()
     pb = ProxyBackend(dead, timeout=2)
-    sp = SessionServer(args, backend_url=dead)
     try:
         req = ProxyRequest(method="POST", query="")
         r_pb = await pb.do_proxy(req, "v1/chat/completions", body=b"{}", headers={})
-        r_sp = await sp.do_proxy(req, "v1/chat/completions", body=b"{}", headers={})
-        assert r_pb["status_code"] == r_sp["status_code"] == 502
-        assert r_pb["headers"] == r_sp["headers"]
+        assert r_pb["status_code"] == 502
+        assert r_pb["headers"] == {"content-type": "application/json"}
         assert json.loads(r_pb["response_body"])["error"].startswith("backend transport error")
-        assert json.loads(r_sp["response_body"])["error"].startswith("backend transport error")
     finally:
         await pb.aclose()
-        await sp.client.aclose()

--- a/tests/fast/router/test_session_race_conditions.py
+++ b/tests/fast/router/test_session_race_conditions.py
@@ -67,9 +67,8 @@ def _router_env(process_fn, *, latency: float = 0.0):
             )
             port = find_available_port(31000)
             server = InloopSessionServer(args, backend.url, host="127.0.0.1", port=port)
-            server.start()
-
             try:
+                server.start()
                 yield SimpleNamespace(url=server.url, backend=backend, server=server)
             finally:
                 server.stop()

--- a/tests/fast/router/test_session_race_conditions.py
+++ b/tests/fast/router/test_session_race_conditions.py
@@ -27,10 +27,9 @@ from unittest.mock import patch
 
 import requests
 
-from miles.rollout.session.server import SessionServer
 from miles.utils.http_utils import find_available_port
+from miles.utils.test_utils.inloop_session_server import InloopSessionServer
 from miles.utils.test_utils.mock_sglang_server import MockSGLangServer, ProcessResult, with_mock_server
-from miles.utils.test_utils.uvicorn_thread_server import UvicornThreadServer
 
 HF_CHECKPOINT = "Qwen/Qwen3-0.6B"
 
@@ -66,15 +65,12 @@ def _router_env(process_fn, *, latency: float = 0.0):
                 trajectory_manager="linear_trajectory",
                 tito_allowed_append_roles=["tool", "system"],
             )
-            server_obj = SessionServer(args, backend_url=backend.url)
-
             port = find_available_port(31000)
-            server = UvicornThreadServer(server_obj.app, host="127.0.0.1", port=port)
+            server = InloopSessionServer(args, backend.url, host="127.0.0.1", port=port)
             server.start()
-            url = f"http://127.0.0.1:{port}"
 
             try:
-                yield SimpleNamespace(url=url, backend=backend, server=server)
+                yield SimpleNamespace(url=server.url, backend=backend, server=server)
             finally:
                 server.stop()
 

--- a/tests/fast/router/test_sessions.py
+++ b/tests/fast/router/test_sessions.py
@@ -53,9 +53,8 @@ def router_env():
             )
             port = find_available_port(31000)
             server = InloopSessionServer(args, backend.url, host="127.0.0.1", port=port)
-            server.start()
-
             try:
+                server.start()
                 yield SimpleNamespace(url=server.url, backend=backend)
             finally:
                 server.stop()

--- a/tests/fast/router/test_sessions.py
+++ b/tests/fast/router/test_sessions.py
@@ -8,15 +8,14 @@ from unittest.mock import patch
 import pytest
 import requests
 
-from miles.rollout.session.server import SessionServer
 from miles.utils.http_utils import find_available_port
+from miles.utils.test_utils.inloop_session_server import InloopSessionServer
 from miles.utils.test_utils.mock_sglang_server import MockSGLangServer, ProcessResult, with_mock_server
-from miles.utils.test_utils.uvicorn_thread_server import UvicornThreadServer
 
 
 @pytest.fixture(scope="class")
 def router_env():
-    """Create a standalone SessionServer with session routes and a mock backend."""
+    """Create an in-loop session server (router app + one worker shard) with a mock backend."""
 
     def process_fn(prompt: str) -> ProcessResult:
         return ProcessResult(text=f"echo: {prompt}", finish_reason="stop")
@@ -52,16 +51,12 @@ def router_env():
                 trajectory_manager="linear_trajectory",
                 session_server_instance_id=uuid.uuid4().hex,
             )
-            server_obj = SessionServer(args, backend_url=backend.url)
-
             port = find_available_port(31000)
-            server = UvicornThreadServer(server_obj.app, host="127.0.0.1", port=port)
+            server = InloopSessionServer(args, backend.url, host="127.0.0.1", port=port)
             server.start()
 
-            url = f"http://127.0.0.1:{port}"
-
             try:
-                yield SimpleNamespace(url=url, backend=backend)
+                yield SimpleNamespace(url=server.url, backend=backend)
             finally:
                 server.stop()
 


### PR DESCRIPTION
## Summary
Migrates every test fixture off the in-process `SessionServer` app onto `InloopSessionServer` — the **production router app** (`build_router_app`) served on a real port, with N `SessionWorker` shards wired as in-loop IPC handlers on the server thread's event loop (real socketpair framing and worker dispatch, none of the OS-process spawn cost). **Assertions are unchanged across the migrated suites** — this PR is the migration-equivalence evidence that the router-app topology preserves the behavior the old harness pinned, which is what licenses deleting the single-process chassis in #1519.

> Stacked on #1569 → #1510 → #1563 → #1518 → #1565. Base = `refactor/session-mp-lifecycle`. Merge order within the split: **#1565 → this → #1519**.

## What's here
- `miles/utils/test_utils/inloop_session_server.py` — router app + `n_workers` in-loop worker shards served from one thread; process lifecycle (spawn, readiness, fail-fast, teardown) stays the supervisor's job, covered by its own test in #1565.
- `generation_fixtures.py` / `rollout_fixtures.py` / `session_pretokenized_test_utils.py` / `test_session_race_conditions.py` / `test_sessions.py` — harness swap only; assertions untouched.
- `test_session_dataplane.py` — the equivalence reference becomes the same topology with one shard, and the transport-error test asserts the 502 shape directly instead of comparing against `SessionServer.do_proxy`.

## Testing
- `pytest tests/fast/router` — **96 passed** at this commit, with the in-process chassis still present: proves no remaining coverage depends on it before #1519 deletes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

