### PR TITLE
fix(deps): cap transformers<5.13 — 5.13.0 breaks all CPU CI via qwen3_asr collision

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,5 +20,5 @@ sglang-router>=0.2.3
 tensorboard
 torchft-nightly==2026.4.3; platform_system == "Linux" and platform_machine == "x86_64"
 tqdm
-transformers
+transformers<5.13  # 5.13.0 registers qwen3_asr natively, colliding with sglang's AutoConfig.register (exist_ok=False); lift once sglang registers with exist_ok=True
 wandb


### PR DESCRIPTION
## Motivation

Every CPU CI shard on every PR has been red since 2026-07-04. All fail identically at pytest collection:

```
ImportError while loading conftest 'tests/conftest.py'.
...
sglang/python/sglang/srt/configs/qwen3_asr.py:167: in <module>
    AutoConfig.register("qwen3_asr", Qwen3ASRConfig)
E   ValueError: 'qwen3_asr' is already used by a Transformers config, pick another name.
```

Confirmed on unrelated branches (`refactor/session-core-extract`, `exp/search-r1-length-penalty`), so this is an environment break, not any PR's code.

## Root cause

- `requirements.txt` declared a bare, unpinned `transformers` (unchanged since #282, 2025-09).
- transformers **5.13.0** was published on PyPI 2026-07-03 16:05 UTC — 24 minutes *after* the last green main nightly (which resolved **5.12.1**).
- 5.13.0 ships a native `qwen3_asr` config. sglang's `qwen3_asr.py` (unchanged since May) registers the same name with `exist_ok=False` → `ValueError` on import.
- Only the CPU path breaks immediately: `run-cpu` resolves `requirements.txt` fresh from PyPI every run (`uv pip install -r requirements.txt`, `.github/workflows/_run-ci.yml`). GPU stages are shielded for now because docker images bake deps at build time — the next image rebuild would hit the same collision.
- sglang is installed `--no-deps` everywhere in CI/docker, so sglang's own transformers pin is never enforced; `requirements.txt` is the de facto resolver.

## Fix

Cap `transformers<5.13`:

- today this resolves to **5.12.1** — the exact version the last green CI actually ran (green for ~3 weeks) and the exact pin upstream `sgl-project/sglang` main declares;
- still allows 5.12.x patch releases, so the cap is the minimal constraint that excludes the breaking line.

`requirements.txt` feeds `setup.py:install_requires`, so this one line fixes the CPU runtime resolve, future docker image builds, and developer installs at once.

## Verification

- CI on this PR is the verification: CPU shards fail at collection on 5.13.0 and are expected green on <5.13 (matching the 07-03 green nightly environment).

## Follow-up (out of scope)

Long-term fix belongs in sglang: register `qwen3_asr` with `exist_ok=True` (or version-guard) so newer transformers doesn't collide. Lift the cap once that lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)