### PR TITLE
Add Minimax M3 support

### DIFF
--- a/examples/minimax_m3_vl/convert_m3.slurm
+++ b/examples/minimax_m3_vl/convert_m3.slurm
@@ -1,0 +1,76 @@
+#!/bin/bash
+#SBATCH --job-name=m3-convert
+#SBATCH --nodes=1
+#SBATCH --partition=h200-hi-preempt
+#SBATCH --ntasks-per-node=1
+#SBATCH --gpus-per-node=8
+#SBATCH --output=./logs/m3-convert-%j.out
+#SBATCH --error=./logs/m3-convert-%j.err
+#SBATCH --exclusive
+#SBATCH --time=03:00:00
+#SBATCH --exclude=ip-10-1-8-7,ip-10-1-7-180,ip-10-1-38-198,ip-10-1-142-67,ip-10-1-126-226,ip-10-1-141-192,ip-10-1-94-38
+
+# =========================================================================
+# MiniMax-M3 (428B) HF -> Megatron torch_dist conversion.
+#
+# tools/convert_hf_to_torch_dist.py: builds the FULL 60-layer MSA model via
+# --spec get_minimax_m3_spec, then mbridge (miles_plugins/mbridge/minimax_m3.py)
+# maps HF safetensors -> Megatron params and saves a torch_dist checkpoint.
+# Train afterwards with `--load <SAVE>` instead of `--debug-skip-load`.
+#
+# 428B bf16 ~= 856GB; sharded TP8/EP8 on 1 node (8xH200=1120GB) should fit (no
+# optimizer states during conversion). Bump to 2 nodes (PP2) if it OOMs.
+#
+#   IMAGE=/fsx/peng/containers/miles-kimi-k26-main-20260605.sqsh
+#   HF_CKPT=/fsx/peng/models/MiniMax-M3   SAVE=/fsx/peng/models/MiniMax-M3_torch_dist
+#   TP=8 PP=1 EP=8
+# Submit: cd <miles>; mkdir -p logs; sbatch examples/minimax_m3_vl/convert_m3.slurm
+# =========================================================================
+
+set -euxo pipefail
+mkdir -p ./logs
+
+IMAGE=${IMAGE:-/fsx/peng/containers/miles-kimi-k26-main-20260605.sqsh}
+MILES_HOST=${MILES_HOST:-/fsx/peng/workspace/miles-oss-workspace-2/miles}
+HF_CKPT=${HF_CKPT:-/fsx/peng/models/MiniMax-M3}
+SAVE=${SAVE:-/fsx/peng/models/MiniMax-M3_torch_dist}
+
+MILES_ROOT=/workspace/miles
+HF_ROOT=/root/m3_hf
+SAVE_ROOT=/root/m3_torch_dist
+GPUS_PER_NODE=${SLURM_GPUS_ON_NODE:-8}
+TP=${TP:-1}; PP=${PP:-1}; EP=${EP:-1}   # converter auto-sets PP=world_size when PP=1
+
+mkdir -p "${SAVE}"
+MOUNTS="${MILES_HOST}:${MILES_ROOT},${HF_CKPT}:${HF_ROOT},${SAVE}:${SAVE_ROOT},/var/log/aws/clusters:/var/log/aws/clusters"
+
+HEAD_NODE=$(scontrol show hostnames "$SLURM_JOB_NODELIST" | head -n1)
+export CUDA_DEVICE_MAX_CONNECTIONS=1
+
+srun --nodes=1 --ntasks=1 -w "${HEAD_NODE}" \
+  --container-image "${IMAGE}" --container-mounts "${MOUNTS}" --container-remap-root \
+  bash -lc "
+    set -euxo pipefail
+    cd ${MILES_ROOT}
+    pip install -e . --no-deps --break-system-packages --quiet 2>&1 | tail -3
+    source scripts/models/minimax-m3-428B.sh   # -> MODEL_ARGS (incl. --spec)
+    # The converter uses megatron's plain arg parser; drop miles-only flags it
+    # does not define (e.g. --allgather-cp), else argparse exits 2.
+    CONVERT_ARGS=()
+    for a in \"\${MODEL_ARGS[@]}\"; do
+      [[ \"\$a\" == \"--allgather-cp\" ]] && continue
+      CONVERT_ARGS+=(\"\$a\")
+    done
+    PYTHONPATH=${MILES_ROOT}:/root/Megatron-LM/ \
+    torchrun --nproc-per-node ${GPUS_PER_NODE} \
+      tools/convert_hf_to_torch_dist.py \
+      \"\${CONVERT_ARGS[@]}\" \
+      --tensor-model-parallel-size ${TP} \
+      --pipeline-model-parallel-size ${PP} \
+      --expert-model-parallel-size ${EP} \
+      --expert-tensor-parallel-size 1 \
+      --hf-checkpoint ${HF_ROOT} \
+      --save ${SAVE_ROOT} \
+      --bf16
+  "
+echo "M3 conversion done -> ${SAVE}"

--- a/examples/minimax_m3_vl/convert_torch_dist_to_hf_m3.slurm
+++ b/examples/minimax_m3_vl/convert_torch_dist_to_hf_m3.slurm
@@ -1,0 +1,58 @@
+#!/bin/bash
+#SBATCH --job-name=m3-to-hf
+#SBATCH --nodes=1
+#SBATCH --partition=h200-hi-preempt
+#SBATCH --ntasks-per-node=1
+#SBATCH --gpus-per-node=8
+#SBATCH --output=./logs/m3-to-hf-%j.out
+#SBATCH --error=./logs/m3-to-hf-%j.err
+#SBATCH --exclusive
+#SBATCH --time=02:00:00
+#SBATCH --exclude=ip-10-1-142-67
+
+# =========================================================================
+# MiniMax-M3 (428B) Megatron torch_dist -> HF conversion (export a TRAINED ckpt).
+#
+# tools/convert_torch_dist_to_hf.py is SINGLE-PROCESS (no_dist=True): it reads the
+# full DCP checkpoint into CPU RAM (~856GB bf16 for 428B) and writes safetensors.
+# No GPU compute; we take a whole node just for its ~2TB RAM. Dispatch goes to
+# miles/backends/megatron_utils/megatron_to_hf/minimax_m3.py (--model-name minimax_m3).
+#
+#   INPUT_HOST = saved iter dir from training (--save .../iter_000000N)
+#   OUTPUT_HOST = HF safetensors output   ORIGIN_HF = config/tokenizer source
+# Submit: cd <miles>; mkdir -p logs; sbatch examples/minimax_m3_vl/convert_torch_dist_to_hf_m3.slurm
+# =========================================================================
+
+set -euxo pipefail
+mkdir -p ./logs
+
+IMAGE=${IMAGE:-/fsx/peng/containers/miles-kimi-k26-main-20260605.sqsh}
+MILES_HOST=${MILES_HOST:-/fsx/peng/workspace/miles-oss-workspace-2/miles}
+INPUT_HOST=${INPUT_HOST:-/fsx/peng/models/MiniMax-M3_sft_ckpt/iter_0000005}
+OUTPUT_HOST=${OUTPUT_HOST:-/fsx/peng/models/MiniMax-M3_sft_hf}
+ORIGIN_HF=${ORIGIN_HF:-/fsx/peng/models/MiniMax-M3}
+VOCAB_SIZE=${VOCAB_SIZE:-200064}
+
+MILES_ROOT=/workspace/miles; INPUT_ROOT=/root/m3_in; OUTPUT_ROOT=/root/m3_out; ORIGIN_ROOT=/root/m3_origin
+mkdir -p "${OUTPUT_HOST}"
+MOUNTS="${MILES_HOST}:${MILES_ROOT},${INPUT_HOST}:${INPUT_ROOT},${OUTPUT_HOST}:${OUTPUT_ROOT},\
+${ORIGIN_HF}:${ORIGIN_ROOT},/var/log/aws/clusters:/var/log/aws/clusters"
+
+HEAD_NODE=$(scontrol show hostnames "$SLURM_JOB_NODELIST" | head -n1)
+
+srun --nodes=1 --ntasks=1 -w "${HEAD_NODE}" \
+  --container-image "${IMAGE}" --container-mounts "${MOUNTS}" --container-remap-root \
+  bash -lc "
+    set -euxo pipefail
+    cd ${MILES_ROOT}
+    pip install -e . --no-deps --break-system-packages --quiet 2>&1 | tail -3
+    PYTHONPATH=${MILES_ROOT}:/root/Megatron-LM/ \
+    python3 tools/convert_torch_dist_to_hf.py \
+      --input-dir ${INPUT_ROOT} \
+      --output-dir ${OUTPUT_ROOT} \
+      --model-name minimax_m3 \
+      --origin-hf-dir ${ORIGIN_ROOT} \
+      --vocab-size ${VOCAB_SIZE} \
+      -f
+  "
+echo "M3 torch_dist -> HF done -> ${OUTPUT_HOST}"

--- a/examples/minimax_m3_vl/launch_m3_smoke.slurm
+++ b/examples/minimax_m3_vl/launch_m3_smoke.slurm
@@ -1,0 +1,268 @@
+#!/bin/bash
+#SBATCH --job-name=m3-smoke
+#SBATCH --nodes=1
+#SBATCH --partition=h200-hi-preempt
+#SBATCH --ntasks-per-node=1
+#SBATCH --gpus-per-node=8
+#SBATCH --output=./logs/m3-smoke-%j.out
+#SBATCH --error=./logs/m3-smoke-%j.err
+#SBATCH --exclusive
+#SBATCH --time=01:00:00
+#SBATCH --wait-all-nodes=1
+# Nodes with broken pyxis (container-mounts silently no-op there).
+#SBATCH --exclude=ip-10-1-8-7,ip-10-1-7-180,ip-10-1-38-198,ip-10-1-142-67,ip-10-1-126-226,ip-10-1-141-192,ip-10-1-94-38
+
+# =========================================================================
+# MiniMax-M3 SINGLE-NODE plumbing smoke test (item 1).
+#
+# Validates the NEW M3 code on 4 random-init layers (no real LM weights), via
+# --debug-train-only SFT (no sglang/rollout engines). Two modes:
+#
+#   MODE=text  (default) — cheapest, NO big checkpoint needed. Exercises the
+#       risky novel path: get_minimax_m3_spec build -> MSA lightning indexer +
+#       block-sparse attention forward -> MoE -> loss/backward. Tiny text data.
+#
+#   MODE=vl    — adds --minimax-m3-vl: composite model + HF-native vision tower
+#       + mm_data media-token expansion + embed/merge/decoder_input. Needs the
+#       M3 HF checkpoint present (HF_CKPT) so build_minimax_m3_vl can load the
+#       vision tower + processor, and the geo3k image dataset.
+#
+# Resubmit knobs (env vars):
+#   IMAGE=/fsx/peng/containers/miles-kimi-k26-main-20260605.sqsh
+#   MILES_HOST=/fsx/peng/workspace/miles-oss-workspace-2/miles
+#   MODE=text|vl   HF_CKPT=/fsx/peng/models/MiniMax-M3
+#   TP=8 PP=1 EP=8   MAX_TOKENS_PER_GPU=4096
+#
+# Submit:  cd <miles>; mkdir -p logs; sbatch examples/minimax_m3_vl/launch_m3_smoke.slurm
+#     VL:  MODE=vl HF_CKPT=/fsx/peng/models/MiniMax-M3 sbatch examples/minimax_m3_vl/launch_m3_smoke.slurm
+# =========================================================================
+
+set -euxo pipefail
+mkdir -p ./logs
+
+MODE=${MODE:-text}
+
+# ---------- Image ----------
+IMAGE=${IMAGE:-/fsx/peng/containers/miles-kimi-k26-main-20260605.sqsh}
+if [[ ! -f "${IMAGE}" ]]; then echo "ERROR: IMAGE not found: ${IMAGE}" >&2; exit 1; fi
+
+# ---------- Paths ----------
+MILES_HOST=${MILES_HOST:-/fsx/peng/workspace/miles-oss-workspace-2/miles}
+DATASETS_HOST=${DATASETS_HOST:-${MILES_HOST}/datasets}
+OUTPUTS_HOST=${OUTPUTS_HOST:-${MILES_HOST}/outputs}
+# M3 HF checkpoint = 4-layer config dir for BOTH modes: --hf-checkpoint feeds
+# hf_validate_args (num_layers must match the 4-layer model args) + tokenizer +
+# vision_config. In vl mode the vision *weights* come from the full ckpt
+# (VISION_CKPT_HOST) loaded separately by build_minimax_m3_vl (M3_VISION_CKPT).
+# MODE=real: full 60-layer model loaded from the converted torch_dist checkpoint
+# (validates conversion). --hf-checkpoint = full ckpt (60-layer config matches).
+if [[ "${MODE}" == "real" ]]; then
+  HF_CKPT=${HF_CKPT:-/fsx/peng/models/MiniMax-M3}
+  LOAD_HOST=${LOAD_HOST:-/fsx/peng/models/MiniMax-M3_torch_dist}
+else
+  HF_CKPT=${HF_CKPT:-/fsx/peng/models/MiniMax-M3-4layer}
+  LOAD_HOST=""
+fi
+LOAD_ROOT=/root/m3_load
+VISION_CKPT_HOST=${VISION_CKPT_HOST:-/fsx/peng/models/MiniMax-M3}
+mkdir -p "${DATASETS_HOST}" "${OUTPUTS_HOST}"
+
+MILES_ROOT=/workspace/miles
+DATASETS_ROOT=/root/datasets
+OUTPUTS_ROOT=/workspace/outputs
+HF_ROOT=/root/m3_hf
+
+# VL mode needs transformers with the in-library `minimax_m3_vl` model (added
+# 2026-06-12). The container's transformers predates it, so mount a checkout that
+# has it (pure Python -> shadow via PYTHONPATH). Gated to VL so the working text
+# path keeps the container's transformers. Override TRANSFORMERS_HOST if needed.
+TRANSFORMERS_HOST=${TRANSFORMERS_HOST:-/fsx/peng/workspace/transformers}
+TRANSFORMERS_ROOT=/root/transformers_m3
+VISION_CKPT_ROOT=/root/m3_vision
+if [[ "${MODE}" == "vl" ]]; then
+  TF_MOUNT="${TRANSFORMERS_HOST}:${TRANSFORMERS_ROOT},${VISION_CKPT_HOST}:${VISION_CKPT_ROOT},"
+  TF_PP="${TRANSFORMERS_ROOT}/src:"   # prepended to PYTHONPATH -> shadows installed transformers
+  M3_VISION_ENV="${VISION_CKPT_ROOT}"  # build_minimax_m3_vl reads M3_VISION_CKPT for vision weights
+else
+  TF_MOUNT=""
+  TF_PP=""
+  M3_VISION_ENV=""
+fi
+
+# Ray session dir must be local (Lustre has no Unix sockets); /tmp is local on EC2.
+RAY_TMP_HOST=${RAY_TMP_HOST:-/tmp/ray-tmp-${USER:-peng}-${SLURM_JOB_ID:-manual}}
+RAY_TMP_ROOT=/tmp/ray-session
+srun --overlap --ntasks-per-node=1 bash -c "mkdir -p ${RAY_TMP_HOST}"
+
+LOAD_MOUNT=""
+[[ -n "${LOAD_HOST}" ]] && LOAD_MOUNT="${LOAD_HOST}:${LOAD_ROOT},"
+MILES_MOUNTS="${MILES_HOST}:${MILES_ROOT},\
+${DATASETS_HOST}:${DATASETS_ROOT},\
+${OUTPUTS_HOST}:${OUTPUTS_ROOT},\
+${HF_CKPT}:${HF_ROOT},\
+${LOAD_MOUNT}${TF_MOUNT}\
+${RAY_TMP_HOST}:${RAY_TMP_ROOT},\
+/var/log/aws/clusters:/var/log/aws/clusters"
+
+# ---------- Run knobs ----------
+GPUS_PER_NODE=${SLURM_GPUS_ON_NODE:-8}
+if [[ "${MODE}" == "real" ]]; then
+  # Full 60-layer model. TP8/PP1 (not PP8: 60 not divisible by 8, and torch_dist
+  # reshards the PP8-saved checkpoint to TP8 on load). 428B/8 ~= 107GB/GPU fits.
+  TP=${TP:-8}; PP=${PP:-1}; EP=${EP:-1}
+  MODEL_SCRIPT=scripts/models/minimax-m3-428B.sh
+else
+  TP=${TP:-8}; PP=${PP:-1}; EP=${EP:-8}
+  MODEL_SCRIPT=scripts/models/minimax-m3-428B_4layer.sh
+fi
+MAX_TOKENS_PER_GPU=${MAX_TOKENS_PER_GPU:-4096}
+
+# ---------- Cluster discovery (single node) ----------
+HEAD_NODE=$(scontrol show hostnames "$SLURM_JOB_NODELIST" | head -n1)
+detect_iface() { srun --overlap --nodes=1 --ntasks=1 -w "$1" bash -lc "ip route show default | awk 'NR==1{print \$5}'"; }
+node_ip() { srun --overlap --nodes=1 --ntasks=1 -w "$1" bash -lc "ip -o -4 addr show dev $2 | awk '{print \$4}' | cut -d/ -f1 | head -n1"; }
+IFACE=$(detect_iface "${HEAD_NODE}"); [[ -z "${IFACE}" ]] && IFACE=eth0
+MASTER_ADDR=$(node_ip "${HEAD_NODE}" "${IFACE}")
+MASTER_PORT=6379
+NVLINK_COUNT=$(srun --overlap --nodes=1 --ntasks=1 -w "${HEAD_NODE}" bash -lc "nvidia-smi topo -m 2>/dev/null | grep -o 'NV[0-9]*' | wc -l" || echo 0)
+[[ "${NVLINK_COUNT}" -gt 0 ]] && HAS_NVLINK=1 || HAS_NVLINK=0
+echo "== M3 smoke | MODE=${MODE} | head=${HEAD_NODE} (${MASTER_ADDR}) | TP${TP} PP${PP} EP${EP} | nvlink=${HAS_NVLINK} =="
+
+# ---------- Env ----------
+export NCCL_SOCKET_IFNAME="${IFACE}"
+export NCCL_DEBUG="WARN"
+export CUDA_DEVICE_MAX_CONNECTIONS=1
+export no_proxy="127.0.0.1,localhost,0.0.0.0,${MASTER_ADDR},${HEAD_NODE}"
+export PYTHONUNBUFFERED=1
+export WANDB_API_KEY=${WANDB_API_KEY:-}
+
+cleanup() {
+  local ec=$?; trap - EXIT INT TERM; set +e
+  srun --overlap --nodes=1 --ntasks=1 -w "${HEAD_NODE}" \
+    --container-image "${IMAGE}" --container-mounts "${MILES_MOUNTS}" --container-remap-root \
+    bash -lc "ray stop --force || true" || true
+  exit "${ec}"
+}
+trap cleanup EXIT INT TERM
+
+########################################
+# 1. Ray head (single node)
+########################################
+srun --nodes=1 --ntasks=1 -w "${HEAD_NODE}" \
+  --container-image "${IMAGE}" --container-mounts "${MILES_MOUNTS}" --container-remap-root \
+  --container-env=WANDB_API_KEY \
+  bash -lc "
+    set -euxo pipefail
+    cd ${MILES_ROOT}
+    export RAY_TMPDIR=${RAY_TMP_ROOT}
+    pip install -e . --no-deps --break-system-packages --quiet 2>&1 | tail -3
+    ray stop --force || true
+    ray start --head --node-ip-address=${MASTER_ADDR} --port=${MASTER_PORT} \
+      --num-gpus ${GPUS_PER_NODE} --disable-usage-stats \
+      --temp-dir=${RAY_TMP_ROOT} --dashboard-host=0.0.0.0 --dashboard-port=8265 --block
+  " &
+sleep 25
+for a in $(seq 1 24); do
+  timeout 2 bash -c "</dev/tcp/${MASTER_ADDR}/${MASTER_PORT}" 2>/dev/null && break
+  [[ "$a" == 24 ]] && { echo "ERROR: Ray GCS never came up" >&2; exit 1; }
+  sleep 5
+done
+
+########################################
+# 2. Submit the smoke training job
+########################################
+set +e
+PYTHONUNBUFFERED=1 srun --overlap --nodes=1 --ntasks=1 -w "${HEAD_NODE}" \
+  --container-image "${IMAGE}" --container-mounts "${MILES_MOUNTS}" --container-remap-root \
+  --container-env=WANDB_API_KEY,NCCL_SOCKET_IFNAME,NCCL_DEBUG,no_proxy \
+  bash -lc "
+    set -euxo pipefail
+    cd ${MILES_ROOT}
+    export RAY_TMPDIR=${RAY_TMP_ROOT}
+    pip install -e . --no-deps --break-system-packages --quiet 2>&1 | tail -3
+
+    source ${MODEL_SCRIPT}
+
+    # ---- mode-specific data + VL flag ----
+    MODE=${MODE}
+    if [[ \"\${MODE}\" == \"vl\" ]]; then
+      # geo3k images (same dataset as examples/geo3k_vlm)
+      if [[ ! -f ${DATASETS_ROOT}/geo3k_imgurl/train_formatted.parquet ]]; then
+        hf download --repo-type dataset chenhegu/geo3k_imgurl --local-dir ${DATASETS_ROOT}/geo3k_imgurl || true
+      fi
+      DATA_ARGS=(
+        --prompt-data ${DATASETS_ROOT}/geo3k_imgurl/train_formatted.parquet
+        --input-key messages
+        --multimodal-keys '{\"image\": \"images\"}'
+      )
+      MODE_ARGS=( --minimax-m3-vl )
+    else
+      # tiny SYNTHETIC text SFT data in messages format (pre-generated on the host
+      # at \${MILES_HOST}/datasets/m3_smoke_text.parquet -> \${DATASETS_ROOT}). The
+      # SFT mask generator needs a list of {role,content} dicts; plain 'prompt'
+      # strings (dapo-math) crash it.
+      # NO --apply-chat-template here: the sft_loss mask generator wants a list of
+      # role/content dicts and templates each message itself; pre-rendering to a
+      # string makes it iterate characters and crash.
+      DATA_ARGS=(
+        --prompt-data ${DATASETS_ROOT}/m3_smoke_text.parquet
+        --input-key messages
+      )
+      MODE_ARGS=()
+    fi
+
+    if [[ \"\${MODE}\" == \"real\" ]]; then
+      # Load the converted torch_dist weights; disable optimizer so the full
+      # 428B fits on one node for a load + forward/backward check. A CORRECT
+      # conversion -> LOW loss (~1-3); random/garbage -> high (~7+).
+      CKPT_ARGS=(
+        --hf-checkpoint ${HF_ROOT}
+        --load ${LOAD_ROOT}
+        --debug-disable-optimizer
+      )
+    else
+      CKPT_ARGS=(
+        --hf-checkpoint ${HF_ROOT}    # tokenizer/config (+ vision tower in vl mode)
+        --debug-skip-load             # RANDOM init, no checkpoint (plumbing smoke)
+      )
+    fi
+    SFT_ARGS=(
+      --rollout-function-path miles.rollout.sft_rollout.generate_rollout
+      --rollout-shuffle
+      --num-rollout 2                 # 2 train steps then exit — smoke only
+      --rollout-batch-size 8
+      --global-batch-size 8
+      --loss-type sft_loss
+      --calculate-per-token-loss
+      --disable-compute-advantages-and-returns
+      --debug-train-only
+    )
+    PERF_ARGS=(
+      --tensor-model-parallel-size ${TP}
+      --sequence-parallel
+      --pipeline-model-parallel-size ${PP}
+      --context-parallel-size 1
+      --expert-model-parallel-size ${EP}
+      --expert-tensor-parallel-size 1
+      --recompute-granularity full --recompute-method uniform --recompute-num-layers 1
+      --use-dynamic-batch-size
+      --max-tokens-per-gpu ${MAX_TOKENS_PER_GPU}
+    )
+    OPT_ARGS=( --optimizer adam --lr 1e-5 --lr-decay-style constant --weight-decay 0.0 )
+    MISC_ARGS=(
+      --attention-dropout 0.0 --hidden-dropout 0.0
+      --accumulate-allreduce-grads-in-fp32 --attention-softmax-in-fp32 --attention-backend flash
+    )
+
+    ray job submit --address=http://${MASTER_ADDR}:8265 \
+      --runtime-env-json='{\"env_vars\":{\"PYTHONPATH\":\"${TF_PP}${MILES_ROOT}:/root/Megatron-LM/\",\"CUDA_DEVICE_MAX_CONNECTIONS\":\"1\",\"RAY_DEDUP_LOGS\":\"0\",\"NCCL_NVLS_ENABLE\":\"${HAS_NVLINK}\",\"M3_VISION_CKPT\":\"${M3_VISION_ENV}\",\"PYTORCH_CUDA_ALLOC_CONF\":\"expandable_segments:True\"}}' \
+      -- python3 train.py \
+      --actor-num-nodes 1 \
+      --actor-num-gpus-per-node ${GPUS_PER_NODE} \
+      \"\${MODEL_ARGS[@]}\" \"\${MODE_ARGS[@]}\" \"\${CKPT_ARGS[@]}\" \"\${DATA_ARGS[@]}\" \
+      \"\${SFT_ARGS[@]}\" \"\${PERF_ARGS[@]}\" \"\${OPT_ARGS[@]}\" \"\${MISC_ARGS[@]}\"
+  " 2>&1 | tee ./logs/m3-smoke-${SLURM_JOB_ID}.log
+ec=${PIPESTATUS[0]}
+set -e
+[[ "${ec}" -ne 0 ]] && { echo "M3 smoke FAILED (exit ${ec})"; exit "${ec}"; }
+echo "M3 smoke completed."

--- a/examples/minimax_m3_vl/launch_sft_vlm_m3.slurm
+++ b/examples/minimax_m3_vl/launch_sft_vlm_m3.slurm
@@ -1,0 +1,165 @@
+#!/bin/bash
+#SBATCH --job-name=m3-sft-vlm
+#SBATCH --nodes=8
+#SBATCH --partition=h200-hi-preempt
+#SBATCH --ntasks-per-node=1
+#SBATCH --gpus-per-node=8
+#SBATCH --output=./logs/m3-sft-vlm-%j.out
+#SBATCH --error=./logs/m3-sft-vlm-%j.error
+#SBATCH --exclusive
+#SBATCH --time=04:00:00
+#SBATCH --wait-all-nodes=1
+#SBATCH --exclude=ip-10-1-142-67
+
+# =========================================================================
+# MiniMax-M3 (428B) MULTIMODAL full-FT SFT — real LM + real vision tower, on
+# image data (geo3k). Mirrors kimi-k2.6/launch_sft_vlm.slurm but for the M3 VL
+# stack (--minimax-m3-vl: MiniMaxM3VLModel composite = HF-native vision tower +
+# projector + Megatron LM; mm_data expands the <image> placeholder to per-patch
+# media tokens; the generic sft_rollout runs the processor -> pixel_values).
+#
+# Combines the VALIDATED 8-node real-weight infra (EP32, CPU-offload optimizer,
+# common-prefix NCCL iface, dynamic-module pre-warm) with the VL bits from
+# launch_m3_smoke.slurm MODE=vl (transformers-5.3 shadow, M3_VISION_CKPT).
+#
+# This is the e2e VLM-training test: vision->project->merge->MSA-LM->loss->
+# backward->Adam step, real weights, multinode. EP32 needs world%32==0 -> 8 nodes.
+#
+# Knobs:  NUM_ROLLOUT=20  LR=1e-5  SAVE_INTERVAL=0(off)  MAX_TOKENS_PER_GPU=8192
+#         TP=8 PP=1 EP=32 ETP=1
+# Submit: cd <miles>; mkdir -p logs; sbatch examples/minimax_m3_vl/launch_sft_vlm_m3.slurm
+# =========================================================================
+
+set -euxo pipefail
+mkdir -p ./logs
+
+IMAGE=${IMAGE:-/fsx/peng/containers/miles-kimi-k26-main-20260605.sqsh}
+MILES_HOST=${MILES_HOST:-/fsx/peng/workspace/miles-oss-workspace-2/miles}
+HF_CKPT=${HF_CKPT:-/fsx/peng/models/MiniMax-M3}                 # full 60-layer config + tokenizer + processor
+LOAD_HOST=${LOAD_HOST:-/fsx/peng/models/MiniMax-M3_torch_dist}  # converted LM weights (torch_dist)
+VISION_CKPT_HOST=${VISION_CKPT_HOST:-/fsx/peng/models/MiniMax-M3}  # vision tower + projector safetensors
+TRANSFORMERS_HOST=${TRANSFORMERS_HOST:-/fsx/peng/workspace/transformers}  # has in-library minimax_m3_vl
+DATASETS_HOST=${DATASETS_HOST:-${MILES_HOST}/datasets}
+SAVE_HOST=${SAVE_HOST:-/fsx/peng/models/MiniMax-M3_sft_vlm_ckpt}
+SAVE_INTERVAL=${SAVE_INTERVAL:-0}
+
+MILES_ROOT=/workspace/miles; HF_ROOT=/root/m3_hf; LOAD_ROOT=/root/m3_load
+DATASETS_ROOT=/root/datasets; SAVE_ROOT=/root/m3_save
+TRANSFORMERS_ROOT=/root/transformers_m3; VISION_CKPT_ROOT=/root/m3_vision
+TP=${TP:-8}; PP=${PP:-1}; EP=${EP:-32}; ETP=${ETP:-1}
+NUM_ROLLOUT=${NUM_ROLLOUT:-20}; LR=${LR:-1e-5}; MAX_TOKENS_PER_GPU=${MAX_TOKENS_PER_GPU:-8192}
+TRAIN_VISION=${TRAIN_VISION:-0}   # 1 = also train the vision tower (default frozen)
+VL_PROBE=${VL_PROBE:-0}           # 1 = log vision/projector weight norms per TP rank
+GPUS_PER_NODE=${SLURM_GPUS_ON_NODE:-8}
+
+# Ray session dir on the big local NVMe (not small /tmp, which fills on some nodes;
+# not Lustre, which has no Unix sockets). Mirrors the Kimi VLM launcher.
+RAY_TMP_HOST=/opt/dlami/nvme/ray-tmp-${USER:-peng}-${SLURM_JOB_ID:-manual}; RAY_TMP_ROOT=/tmp/ray-session
+srun --overlap --ntasks-per-node=1 bash -c "mkdir -p ${RAY_TMP_HOST}"
+[[ "${SAVE_INTERVAL}" != "0" ]] && mkdir -p "${SAVE_HOST}"
+SAVE_MOUNT=""; [[ "${SAVE_INTERVAL}" != "0" ]] && SAVE_MOUNT="${SAVE_HOST}:${SAVE_ROOT},"
+# VL needs transformers-5.3 (in-library minimax_m3_vl) shadowed via PYTHONPATH, and
+# the vision weights loaded by build_minimax_m3_vl from M3_VISION_CKPT.
+TF_PP="${TRANSFORMERS_ROOT}/src:"
+MOUNTS="${MILES_HOST}:${MILES_ROOT},${HF_CKPT}:${HF_ROOT},${LOAD_HOST}:${LOAD_ROOT},\
+${DATASETS_HOST}:${DATASETS_ROOT},${TRANSFORMERS_HOST}:${TRANSFORMERS_ROOT},${VISION_CKPT_HOST}:${VISION_CKPT_ROOT},\
+${SAVE_MOUNT}${RAY_TMP_HOST}:${RAY_TMP_ROOT},/var/log/aws/clusters:/var/log/aws/clusters"
+
+# ---------- cluster discovery (per-node iface -> common prefix; NICs differ per node) ----------
+nodes=($(scontrol show hostnames "$SLURM_JOB_NODELIST"))
+HEAD_NODE=${nodes[0]}
+common_prefix() { local prefix=$1; shift; local value
+  for value in "$@"; do while [[ -n "${prefix}" && "${value#"$prefix"}" == "${value}" ]]; do prefix=${prefix%?}; done; done
+  printf '%s' "${prefix}"; }
+ALL_IFACES=()
+for node in "${nodes[@]}"; do
+  ni=$(srun --overlap --nodes=1 --ntasks=1 -w "${node}" bash -lc "ip route show default 0.0.0.0/0 | awk 'NR==1{print \$5}'")
+  [[ -z "${ni}" ]] && { echo "Failed to detect iface for ${node}" >&2; exit 1; }
+  ALL_IFACES+=("${ni}")
+done
+IFACE=$(common_prefix "${ALL_IFACES[0]}" "${ALL_IFACES[@]:1}")
+[[ -z "${IFACE}" ]] && IFACE="^lo,docker,veth,tailscale"
+HEAD_IFACE=${ALL_IFACES[0]}
+echo "== node ifaces: ${ALL_IFACES[*]} -> NCCL_SOCKET_IFNAME=${IFACE} =="
+MASTER_ADDR=$(srun --overlap --nodes=1 --ntasks=1 -w "${HEAD_NODE}" bash -lc "ip -o -4 addr show dev ${HEAD_IFACE} | awk '{print \$4}' | cut -d/ -f1 | head -n1")
+MASTER_PORT=6379
+NVLINK_COUNT=$(srun --overlap --nodes=1 --ntasks=1 -w "${HEAD_NODE}" bash -lc "nvidia-smi topo -m 2>/dev/null | grep -o 'NV[0-9]*' | wc -l" || echo 0)
+[[ "${NVLINK_COUNT}" -gt 0 ]] && HAS_NVLINK=1 || HAS_NVLINK=0
+ALL_HOSTS_CSV=$(IFS=,; echo "${nodes[*]}")
+export NCCL_SOCKET_IFNAME="${IFACE}" NCCL_DEBUG=WARN CUDA_DEVICE_MAX_CONNECTIONS=1
+export TORCH_NCCL_ASYNC_ERROR_HANDLING=1 NCCL_PROTO="simple" NCCL_SOCKET_FAMILY="AF_INET"
+export RDMAV_FORK_SAFE=1 FI_EFA_USE_DEVICE_RDMA=1 FI_EFA_SET_CUDA_SYNC_MEMOPS=0
+export no_proxy="127.0.0.1,localhost,${MASTER_ADDR},${ALL_HOSTS_CSV}"
+echo "== M3 VLM SFT | head=${HEAD_NODE} (${MASTER_ADDR}) | nodes=${#nodes[@]} | TP${TP} PP${PP} EP${EP} =="
+
+cleanup(){ local ec=$?; trap - EXIT INT TERM; set +e
+  for n in "${nodes[@]}"; do srun --overlap --nodes=1 --ntasks=1 -w "$n" --container-image "${IMAGE}" \
+    --container-mounts "${MOUNTS}" --container-remap-root bash -lc "ray stop --force||true"||true; done; exit "$ec"; }
+trap cleanup EXIT INT TERM
+PIDS=()
+
+# Pre-warm the trust_remote_code dynamic-module cache once per node (avoids the
+# 8-actors/node race: AttributeError ... has no attribute 'MiniMaxM3VLConfig').
+PREWARM="python3 -c \"from transformers import AutoConfig; AutoConfig.from_pretrained('${HF_ROOT}', trust_remote_code=True)\" >/dev/null 2>&1 || true"
+
+# ---------- ray head ----------
+srun --nodes=1 --ntasks=1 -w "${HEAD_NODE}" --container-image "${IMAGE}" --container-mounts "${MOUNTS}" --container-remap-root \
+  bash -lc "set -euxo pipefail; cd ${MILES_ROOT}; export RAY_TMPDIR=${RAY_TMP_ROOT}
+    pip install -e . --no-deps --break-system-packages --quiet 2>&1|tail -2
+    ${PREWARM}
+    ray stop --force||true
+    ray start --head --node-ip-address=${MASTER_ADDR} --port=${MASTER_PORT} --num-gpus ${GPUS_PER_NODE} \
+      --temp-dir=${RAY_TMP_ROOT} --disable-usage-stats --dashboard-host=0.0.0.0 --dashboard-port=8265 --block" &
+PIDS+=($!); sleep 20
+
+# ---------- ray workers ----------
+for ((i=1;i<${#nodes[@]};i++)); do
+  srun --nodes=1 --ntasks=1 -w "${nodes[$i]}" --container-image "${IMAGE}" --container-mounts "${MOUNTS}" --container-remap-root \
+    bash -lc "set -euxo pipefail; cd ${MILES_ROOT}; export RAY_TMPDIR=${RAY_TMP_ROOT}
+      pip install -e . --no-deps --break-system-packages --quiet 2>&1|tail -2
+      ${PREWARM}
+      ray stop --force||true
+      ray start --address ${MASTER_ADDR}:${MASTER_PORT} --num-gpus ${GPUS_PER_NODE} --temp-dir=${RAY_TMP_ROOT} --disable-usage-stats --block" &
+  PIDS+=($!); sleep 5
+done
+sleep 30
+for a in $(seq 1 36); do timeout 2 bash -c "</dev/tcp/${MASTER_ADDR}/${MASTER_PORT}" 2>/dev/null && break; sleep 5; done
+
+# ---------- submit ----------
+set +e
+srun --overlap --nodes=1 --ntasks=1 -w "${HEAD_NODE}" --container-image "${IMAGE}" --container-mounts "${MOUNTS}" \
+  --container-remap-root --container-env=NCCL_SOCKET_IFNAME,NCCL_DEBUG,no_proxy \
+  bash -lc "
+    set -euxo pipefail; cd ${MILES_ROOT}; export RAY_TMPDIR=${RAY_TMP_ROOT}
+    pip install -e . --no-deps --break-system-packages --quiet 2>&1|tail -2
+    source scripts/models/minimax-m3-428B.sh
+    [[ -f ${DATASETS_ROOT}/geo3k_imgurl/train_formatted.parquet ]] || \
+      hf download --repo-type dataset chenhegu/geo3k_imgurl --local-dir ${DATASETS_ROOT}/geo3k_imgurl || true
+    OPT=( --optimizer adam --lr ${LR} --lr-decay-style constant --weight-decay 0.0 \
+          --optimizer-cpu-offload --optimizer-offload-fraction 1.0 --overlap-cpu-optimizer-d2h-h2d \
+          --use-precision-aware-optimizer --exp-avg-dtype bf16 --exp-avg-sq-dtype bf16 )
+    SAVE_FLAGS=()
+    [[ '${SAVE_INTERVAL}' != '0' ]] && SAVE_FLAGS=( --save ${SAVE_ROOT} --save-interval ${SAVE_INTERVAL} --no-save-optim )
+    VL_FLAGS=( --minimax-m3-vl )
+    [[ '${TRAIN_VISION}' == '1' ]] && VL_FLAGS+=( --minimax-m3-train-vision )
+    ray job submit --address=http://${MASTER_ADDR}:8265 \
+      --runtime-env-json='{\"env_vars\":{\"PYTHONPATH\":\"${TF_PP}${MILES_ROOT}:/root/Megatron-LM/\",\"CUDA_DEVICE_MAX_CONNECTIONS\":\"1\",\"RAY_DEDUP_LOGS\":\"0\",\"PYTORCH_CUDA_ALLOC_CONF\":\"expandable_segments:True\",\"M3_VISION_CKPT\":\"${VISION_CKPT_ROOT}\",\"M3_VL_PROBE\":\"${VL_PROBE}\",\"NCCL_NVLS_ENABLE\":\"${HAS_NVLINK}\",\"NCCL_SOCKET_IFNAME\":\"${IFACE}\",\"NCCL_PROTO\":\"simple\",\"NCCL_SOCKET_FAMILY\":\"AF_INET\",\"RDMAV_FORK_SAFE\":\"1\",\"FI_EFA_USE_DEVICE_RDMA\":\"1\",\"FI_EFA_SET_CUDA_SYNC_MEMOPS\":\"0\",\"TORCH_NCCL_ASYNC_ERROR_HANDLING\":\"1\",\"NCCL_DEBUG\":\"WARN\",\"no_proxy\":\"${no_proxy}\"}}' \
+      -- python3 train.py --actor-num-nodes ${#nodes[@]} --actor-num-gpus-per-node ${GPUS_PER_NODE} \
+      \"\${MODEL_ARGS[@]}\" \"\${VL_FLAGS[@]}\" \
+      --hf-checkpoint ${HF_ROOT} --load ${LOAD_ROOT} \
+      --prompt-data ${DATASETS_ROOT}/geo3k_imgurl/train_formatted.parquet --input-key messages \
+      --multimodal-keys '{\"image\": \"images\"}' \
+      --rollout-function-path miles.rollout.sft_rollout.generate_rollout --rollout-shuffle \
+      --num-rollout ${NUM_ROLLOUT} --rollout-batch-size 16 --global-batch-size 16 \
+      --loss-type sft_loss --calculate-per-token-loss --disable-compute-advantages-and-returns --debug-train-only \
+      --tensor-model-parallel-size ${TP} --sequence-parallel --pipeline-model-parallel-size ${PP} \
+      --context-parallel-size 1 --expert-model-parallel-size ${EP} --expert-tensor-parallel-size ${ETP} \
+      --recompute-granularity full --recompute-method uniform --recompute-num-layers 1 \
+      --use-dynamic-batch-size --max-tokens-per-gpu ${MAX_TOKENS_PER_GPU} \
+      --attention-dropout 0.0 --hidden-dropout 0.0 --accumulate-allreduce-grads-in-fp32 \
+      --attention-softmax-in-fp32 --attention-backend flash \
+      \"\${OPT[@]}\" \"\${SAVE_FLAGS[@]}\"
+  " 2>&1 | tee ./logs/m3-sft-vlm-${SLURM_JOB_ID}.log
+ec=${PIPESTATUS[0]}; set -e
+[[ "${ec}" -ne 0 ]] && { echo "M3 VLM SFT FAILED (exit ${ec})"; exit "${ec}"; }
+echo "M3 VLM SFT completed."

--- a/examples/minimax_m3_vl/run_m3_real_2node.slurm
+++ b/examples/minimax_m3_vl/run_m3_real_2node.slurm
@@ -1,0 +1,153 @@
+#!/bin/bash
+#SBATCH --job-name=m3-real
+#SBATCH --nodes=2
+#SBATCH --partition=h200-hi-preempt
+#SBATCH --ntasks-per-node=1
+#SBATCH --gpus-per-node=8
+#SBATCH --output=./logs/m3-real-%j.out
+#SBATCH --error=./logs/m3-real-%j.err
+#SBATCH --exclusive
+#SBATCH --time=02:00:00
+#SBATCH --wait-all-nodes=1
+#SBATCH --exclude=ip-10-1-142-67
+
+# =========================================================================
+# MiniMax-M3 REAL-WEIGHT run on 2 nodes (16 GPUs). Loads the converted
+# torch_dist checkpoint into the full 60-layer model and does SFT.
+# 428B/16 ~= 53.5GB params/GPU -> fits (1 node OOMs: 107GB/GPU).
+# A CORRECT conversion -> LOW loss (~1-3) on coherent text.
+#
+#   IMAGE / MILES_HOST / HF_CKPT / LOAD_HOST as below.
+#   TP=8 PP=2  (TP8xPP2 = 16 = world). DISABLE_OPT=1 for a load+fwd check only.
+# Submit: cd <miles>; mkdir -p logs; sbatch examples/minimax_m3_vl/run_m3_real_2node.slurm
+# =========================================================================
+
+set -euxo pipefail
+mkdir -p ./logs
+
+IMAGE=${IMAGE:-/fsx/peng/containers/miles-kimi-k26-main-20260605.sqsh}
+MILES_HOST=${MILES_HOST:-/fsx/peng/workspace/miles-oss-workspace-2/miles}
+HF_CKPT=${HF_CKPT:-/fsx/peng/models/MiniMax-M3}
+LOAD_HOST=${LOAD_HOST:-/fsx/peng/models/MiniMax-M3_torch_dist}
+DATASETS_HOST=${DATASETS_HOST:-${MILES_HOST}/datasets}
+DISABLE_OPT=${DISABLE_OPT:-1}   # 1 = load+forward/backward check (no optimizer state)
+SAVE_HOST=${SAVE_HOST:-/fsx/peng/models/MiniMax-M3_sft_ckpt}
+SAVE_INTERVAL=${SAVE_INTERVAL:-0}   # >0 = save a (weights-only) torch_dist ckpt every N steps
+
+MILES_ROOT=/workspace/miles; HF_ROOT=/root/m3_hf; LOAD_ROOT=/root/m3_load; DATASETS_ROOT=/root/datasets; SAVE_ROOT=/root/m3_save
+TP=${TP:-8}; PP=${PP:-2}; EP=${EP:-1}; ETP=${ETP:-1}
+GPUS_PER_NODE=${SLURM_GPUS_ON_NODE:-8}
+
+RAY_TMP_HOST=/tmp/ray-tmp-${USER:-peng}-${SLURM_JOB_ID:-manual}; RAY_TMP_ROOT=/tmp/ray-session
+srun --overlap --ntasks-per-node=1 bash -c "mkdir -p ${RAY_TMP_HOST}"
+[[ "${SAVE_INTERVAL}" != "0" ]] && mkdir -p "${SAVE_HOST}"
+MOUNTS="${MILES_HOST}:${MILES_ROOT},${HF_CKPT}:${HF_ROOT},${LOAD_HOST}:${LOAD_ROOT},\
+${DATASETS_HOST}:${DATASETS_ROOT},${RAY_TMP_HOST}:${RAY_TMP_ROOT},${SAVE_HOST}:${SAVE_ROOT},/var/log/aws/clusters:/var/log/aws/clusters"
+
+# ---------- cluster discovery (2 nodes) ----------
+nodes=($(scontrol show hostnames "$SLURM_JOB_NODELIST"))
+HEAD_NODE=${nodes[0]}
+# NIC names differ per node on this cluster (AWS varies the PCI bus id, e.g.
+# enp73s0 vs enp75s0). Pinning the head node's exact name makes NCCL bootstrap
+# fail on any other node ("no socket interface found" -> ncclInvalidUsage).
+# So detect the iface on EVERY node and use their common prefix (OPD template).
+common_prefix() {
+  local prefix=$1; shift; local value
+  for value in "$@"; do
+    while [[ -n "${prefix}" && "${value#"$prefix"}" == "${value}" ]]; do prefix=${prefix%?}; done
+  done
+  printf '%s' "${prefix}"
+}
+ALL_IFACES=()
+for node in "${nodes[@]}"; do
+  ni=$(srun --overlap --nodes=1 --ntasks=1 -w "${node}" bash -lc "ip route show default 0.0.0.0/0 | awk 'NR==1{print \$5}'")
+  [[ -z "${ni}" ]] && { echo "Failed to detect iface for ${node}" >&2; exit 1; }
+  ALL_IFACES+=("${ni}")
+done
+IFACE=$(common_prefix "${ALL_IFACES[0]}" "${ALL_IFACES[@]:1}")
+[[ -z "${IFACE}" ]] && IFACE="^lo,docker,veth,tailscale"
+HEAD_IFACE=${ALL_IFACES[0]}
+echo "== node ifaces: ${ALL_IFACES[*]} -> NCCL_SOCKET_IFNAME=${IFACE} =="
+MASTER_ADDR=$(srun --overlap --nodes=1 --ntasks=1 -w "${HEAD_NODE}" bash -lc "ip -o -4 addr show dev ${HEAD_IFACE} | awk '{print \$4}' | cut -d/ -f1 | head -n1")
+MASTER_PORT=6379
+NVLINK_COUNT=$(srun --overlap --nodes=1 --ntasks=1 -w "${HEAD_NODE}" bash -lc "nvidia-smi topo -m 2>/dev/null | grep -o 'NV[0-9]*' | wc -l" || echo 0)
+[[ "${NVLINK_COUNT}" -gt 0 ]] && HAS_NVLINK=1 || HAS_NVLINK=0
+ALL_HOSTS_CSV=$(IFS=,; echo "${nodes[*]}")
+export NCCL_SOCKET_IFNAME="${IFACE}" NCCL_DEBUG=WARN CUDA_DEVICE_MAX_CONNECTIONS=1
+# EFA/RDMA NCCL settings this cluster needs for multinode collectives (from OPD template).
+export TORCH_NCCL_ASYNC_ERROR_HANDLING=1 NCCL_PROTO="simple" NCCL_SOCKET_FAMILY="AF_INET"
+export RDMAV_FORK_SAFE=1 FI_EFA_USE_DEVICE_RDMA=1 FI_EFA_SET_CUDA_SYNC_MEMOPS=0
+export no_proxy="127.0.0.1,localhost,${MASTER_ADDR},${ALL_HOSTS_CSV}"
+echo "== M3 real | head=${HEAD_NODE} (${MASTER_ADDR}) | nodes=${#nodes[@]} | TP${TP} PP${PP} EP${EP} =="
+
+cleanup(){ local ec=$?; trap - EXIT INT TERM; set +e
+  for n in "${nodes[@]}"; do srun --overlap --nodes=1 --ntasks=1 -w "$n" --container-image "${IMAGE}" \
+    --container-mounts "${MOUNTS}" --container-remap-root bash -lc "ray stop --force||true"||true; done; exit "$ec"; }
+trap cleanup EXIT INT TERM
+PIDS=()
+
+# ---------- ray head ----------
+srun --nodes=1 --ntasks=1 -w "${HEAD_NODE}" --container-image "${IMAGE}" --container-mounts "${MOUNTS}" --container-remap-root \
+  bash -lc "set -euxo pipefail; cd ${MILES_ROOT}; export RAY_TMPDIR=${RAY_TMP_ROOT}
+    pip install -e . --no-deps --break-system-packages --quiet 2>&1|tail -2
+    # Pre-warm the trust_remote_code dynamic-module cache ONCE per node so the 8
+    # actors don't race writing/importing transformers_modules.m3_hf (flaky
+    # AttributeError: ... has no attribute 'MiniMaxM3VLConfig').
+    python3 -c \"from transformers import AutoConfig; AutoConfig.from_pretrained('${HF_ROOT}', trust_remote_code=True)\" >/dev/null 2>&1 || true
+    ray stop --force||true
+    ray start --head --node-ip-address=${MASTER_ADDR} --port=${MASTER_PORT} --num-gpus ${GPUS_PER_NODE} \
+      --temp-dir=${RAY_TMP_ROOT} --disable-usage-stats --dashboard-host=0.0.0.0 --dashboard-port=8265 --block" &
+PIDS+=($!); sleep 20
+
+# ---------- ray workers ----------
+for ((i=1;i<${#nodes[@]};i++)); do
+  srun --nodes=1 --ntasks=1 -w "${nodes[$i]}" --container-image "${IMAGE}" --container-mounts "${MOUNTS}" --container-remap-root \
+    bash -lc "set -euxo pipefail; cd ${MILES_ROOT}; export RAY_TMPDIR=${RAY_TMP_ROOT}
+      pip install -e . --no-deps --break-system-packages --quiet 2>&1|tail -2
+      python3 -c \"from transformers import AutoConfig; AutoConfig.from_pretrained('${HF_ROOT}', trust_remote_code=True)\" >/dev/null 2>&1 || true
+      ray stop --force||true
+      ray start --address ${MASTER_ADDR}:${MASTER_PORT} --num-gpus ${GPUS_PER_NODE} --temp-dir=${RAY_TMP_ROOT} --disable-usage-stats --block" &
+  PIDS+=($!); sleep 5
+done
+sleep 25
+for a in $(seq 1 36); do timeout 2 bash -c "</dev/tcp/${MASTER_ADDR}/${MASTER_PORT}" 2>/dev/null && break; sleep 5; done
+
+# ---------- submit ----------
+set +e
+srun --overlap --nodes=1 --ntasks=1 -w "${HEAD_NODE}" --container-image "${IMAGE}" --container-mounts "${MOUNTS}" \
+  --container-remap-root --container-env=NCCL_SOCKET_IFNAME,NCCL_DEBUG,no_proxy \
+  bash -lc "
+    set -euxo pipefail; cd ${MILES_ROOT}; export RAY_TMPDIR=${RAY_TMP_ROOT}
+    pip install -e . --no-deps --break-system-packages --quiet 2>&1|tail -2
+    source scripts/models/minimax-m3-428B.sh
+    OPT=( --optimizer adam --lr ${LR:-1e-6} --lr-decay-style constant --weight-decay 0.0 )
+    # 428B optimizer (fp32 master + Adam m/v) does NOT fit on GPU alongside params:
+    # OOM at first optimizer.step() fused_adam._initialize_state. Offload it to CPU.
+    # bf16 Adam moments (m,v): 12->8 B/param of optimizer state, keeps fp32 master.
+    # Cuts host RAM ~1.9TB->~1.45TB/node so 4 nodes (EP32) fits. EP=32 needs world%32==0
+    # => only 4 or 8 nodes valid (6 nodes forces EP<=16 -> GPU-OOM). See run notes.
+    [[ '${CPU_OFFLOAD:-1}' == '1' ]] && OPT+=( --optimizer-cpu-offload --optimizer-offload-fraction 1.0 --overlap-cpu-optimizer-d2h-h2d --use-precision-aware-optimizer --exp-avg-dtype bf16 --exp-avg-sq-dtype bf16 )
+    [[ '${DISABLE_OPT}' == '1' ]] && OPT=( --debug-disable-optimizer )
+    # Save a weights-only torch_dist checkpoint to test the SAVE path (round-trips with --load).
+    SAVE_FLAGS=()
+    [[ '${SAVE_INTERVAL}' != '0' ]] && SAVE_FLAGS=( --save ${SAVE_ROOT} --save-interval ${SAVE_INTERVAL} --no-save-optim )
+    ray job submit --address=http://${MASTER_ADDR}:8265 \
+      --runtime-env-json='{\"env_vars\":{\"PYTHONPATH\":\"${MILES_ROOT}:/root/Megatron-LM/\",\"CUDA_DEVICE_MAX_CONNECTIONS\":\"1\",\"RAY_DEDUP_LOGS\":\"0\",\"PYTORCH_CUDA_ALLOC_CONF\":\"expandable_segments:True\",\"NCCL_NVLS_ENABLE\":\"${HAS_NVLINK}\",\"NCCL_SOCKET_IFNAME\":\"${IFACE}\",\"NCCL_PROTO\":\"simple\",\"NCCL_SOCKET_FAMILY\":\"AF_INET\",\"RDMAV_FORK_SAFE\":\"1\",\"FI_EFA_USE_DEVICE_RDMA\":\"1\",\"FI_EFA_SET_CUDA_SYNC_MEMOPS\":\"0\",\"TORCH_NCCL_ASYNC_ERROR_HANDLING\":\"1\",\"NCCL_DEBUG\":\"WARN\",\"no_proxy\":\"${no_proxy}\"}}' \
+      -- python3 train.py --actor-num-nodes ${#nodes[@]} --actor-num-gpus-per-node ${GPUS_PER_NODE} \
+      \"\${MODEL_ARGS[@]}\" \
+      --hf-checkpoint ${HF_ROOT} --load ${LOAD_ROOT} \
+      --prompt-data ${DATASETS_ROOT}/m3_smoke_text.parquet --input-key messages \
+      --rollout-function-path miles.rollout.sft_rollout.generate_rollout --rollout-shuffle \
+      --num-rollout ${NUM_ROLLOUT:-2} --rollout-batch-size 8 --global-batch-size 8 \
+      --loss-type sft_loss --calculate-per-token-loss --disable-compute-advantages-and-returns --debug-train-only \
+      --tensor-model-parallel-size ${TP} --sequence-parallel --pipeline-model-parallel-size ${PP} \
+      --context-parallel-size 1 --expert-model-parallel-size ${EP} --expert-tensor-parallel-size ${ETP} \
+      --recompute-granularity full --recompute-method uniform --recompute-num-layers 1 \
+      --use-dynamic-batch-size --max-tokens-per-gpu 4096 \
+      --attention-dropout 0.0 --hidden-dropout 0.0 --accumulate-allreduce-grads-in-fp32 \
+      --attention-softmax-in-fp32 --attention-backend flash \
+      \"\${OPT[@]}\" \"\${SAVE_FLAGS[@]}\"
+  " 2>&1 | tee ./logs/m3-real-${SLURM_JOB_ID}.log
+ec=${PIPESTATUS[0]}; set -e
+[[ "${ec}" -ne 0 ]] && { echo "M3 real FAILED (exit ${ec})"; exit "${ec}"; }
+echo "M3 real-weight run completed."

--- a/examples/minimax_m3_vl/run_minimax_m3_vl_sft.sh
+++ b/examples/minimax_m3_vl/run_minimax_m3_vl_sft.sh
@@ -1,0 +1,186 @@
+#!/bin/bash
+# MiniMax-M3-VL SFT — end-to-end smoke/training launcher.
+#
+# Exercises the full VL path added in miles_plugins/models/minimax_m3:
+#   --spec get_minimax_m3_spec        : MSA + MoE text decoder (the language_model)
+#   --minimax-m3-vl                   : wrap it in the composite VL model
+#                                       (HF-native vision tower + projector)
+#   mm_data token-expansion           : runs automatically in get_rollout_data
+#
+# Build/load follows the GLM-5 pattern (custom-attention models), NOT kimi's
+# bridge-build: --spec builds the MSA model; --megatron-to-hf-mode stays "raw"
+# (default) so model_provider uses the --spec path (bridge mode would bypass it).
+# Weights load from an OFFLINE-converted Megatron checkpoint like glm5 does (see
+# scripts/run_glm5_744b_a40b.py convert_checkpoint + --ref-load *_torch_dist);
+# the MiniMaxM3Bridge mappings drive that conversion. The HF vision tower loads
+# directly via build_minimax_m3_vl regardless.
+#
+# Modeled on examples/geo3k_vlm/run_geo3k_vlm_sft.sh (Qwen3-VL) for the harness,
+# but the model-build path mirrors glm5. Uses the geo3k image dataset.
+#
+# NOTE: MiniMax-M3 is a ~428B MoE — this needs multi-node + heavy parallelism.
+# For a *plumbing smoke test* without the full weights, see SMOKE notes at the
+# bottom (reduced layers + skip bridge load).
+
+TRAIN_BACKEND=${MILES_SCRIPT_TRAIN_BACKEND:-"megatron"}
+MODEL_NAME=${MILES_SCRIPT_MODEL_NAME:-"MiniMax-M3"}
+HF_REPO=${MILES_SCRIPT_HF_REPO:-"MiniMaxAI/MiniMax-M3"}
+DATASET_NAME=${MILES_SCRIPT_DATASET_NAME:-"chenhegu/geo3k_imgurl"}
+NUM_GPUS=${MILES_SCRIPT_NUM_GPUS:-8}
+NUM_NODES=${MILES_SCRIPT_NUM_NODES:-4}
+DATASET_LOCAL_NAME=$(basename "$DATASET_NAME")
+MODEL_NAME_LOWER=$(echo "$MODEL_NAME" | tr '[:upper:]' '[:lower:]')
+
+# External Ray flag
+if [ -z "$MILES_SCRIPT_EXTERNAL_RAY" ] || [ "$MILES_SCRIPT_EXTERNAL_RAY" = "0" ]; then
+   USE_EXTERNAL_RAY=0
+else
+   USE_EXTERNAL_RAY=1
+fi
+
+# Cleanup
+pkill -9 sglang; sleep 3
+if [ "$USE_EXTERNAL_RAY" = "0" ]; then ray stop --force; pkill -9 ray; fi
+pkill -9 miles; sleep 3
+if [ "$USE_EXTERNAL_RAY" = "0" ]; then pkill -9 ray; fi
+pkill -9 miles; pkill -9 redis
+
+set -ex
+export PYTHONBUFFERED=16
+
+# Detect NVLink
+NVLINK_COUNT=$(nvidia-smi topo -m 2>/dev/null | grep -o 'NV[0-9][0-9]*' | wc -l)
+[ "$NVLINK_COUNT" -gt 0 ] && HAS_NVLINK=1 || HAS_NVLINK=0
+echo "HAS_NVLINK: $HAS_NVLINK (detected $NVLINK_COUNT NVLink references)"
+
+# Download model + dataset
+mkdir -p /root/models /root/datasets
+if [ ! -d "/root/models/${MODEL_NAME}" ]; then
+   hf download ${HF_REPO} --local-dir /root/models/${MODEL_NAME}
+fi
+if [ ! -d "/root/datasets/${DATASET_LOCAL_NAME}" ]; then
+   hf download --repo-type dataset ${DATASET_NAME} --local-dir /root/datasets/${DATASET_LOCAL_NAME}
+fi
+
+CKPT_ARGS=(
+   --hf-checkpoint /root/models/${MODEL_NAME}
+   --load /root/models/${MODEL_NAME}
+)
+
+SFT_ARGS=(
+   --rollout-function-path miles.rollout.sft_rollout.generate_rollout
+   --prompt-data /root/datasets/${DATASET_LOCAL_NAME}/train_formatted.parquet
+   --input-key messages
+   --apply-chat-template
+   --rollout-shuffle
+   --num-epoch 1
+   --rollout-batch-size 32
+   --global-batch-size 32
+
+   --loss-type sft_loss
+   --calculate-per-token-loss
+   --disable-compute-advantages-and-returns
+   --debug-train-only
+)
+
+# tell the data loader which message field carries images
+MULTIMODAL_KEYS='{"image": "images"}'
+
+OPTIMIZER_ARGS=(
+   --optimizer adam
+   --lr 1e-5
+   --lr-decay-style cosine
+   --min-lr 1e-6
+   --lr-warmup-fraction 0.1
+   --weight-decay 0.1
+   --adam-beta1 0.9
+   --adam-beta2 0.95
+)
+
+if [ -n "$WANDB_API_KEY" ]; then
+    WANDB_ARGS=(
+        --use-wandb
+        --wandb-project miles-minimax-m3-vl-sft
+        --wandb-group ${MODEL_NAME_LOWER}-${TRAIN_BACKEND}
+        --wandb-key ${WANDB_API_KEY}
+        --disable-wandb-random-suffix
+    )
+else
+    WANDB_ARGS=()
+fi
+
+# Megatron backend (M3 has MSA + custom indexer -> megatron only, no fsdp path)
+BACKEND_ARGS=(
+   --train-backend megatron
+   # ---- parallelism for a ~428B MoE; tune to your cluster ----
+   --tensor-model-parallel-size 8
+   --sequence-parallel
+   --pipeline-model-parallel-size 2
+   --context-parallel-size 1            # MSA reference path assumes CP=1
+   --expert-model-parallel-size 8
+   --expert-tensor-parallel-size 1
+   --recompute-granularity full
+   --recompute-method uniform
+   --recompute-num-layers 1
+   --use-dynamic-batch-size
+   --max-tokens-per-gpu 4096
+   --attention-dropout 0.0
+   --hidden-dropout 0.0
+   --accumulate-allreduce-grads-in-fp32
+   --attention-softmax-in-fp32
+   --attention-backend flash
+   # NOTE: leave --megatron-to-hf-mode at its default ("raw"). Setting "bridge"
+   # makes model_provider build via the bridge provider and bypass --spec (no
+   # MSA). M3 builds via --spec like glm5; weights come from --load (offline
+   # convert HF->megatron first, mirroring scripts/run_glm5_744b_a40b.py).
+)
+
+# M3 model args (hidden/layers/heads/MoE/--spec) + the VL switch
+MILES_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." &>/dev/null && pwd)"
+source "${MILES_DIR}/scripts/models/minimax-m3-428B.sh"
+M3_VL_ARGS=(
+   --minimax-m3-vl                      # wrap text decoder in the composite VL model
+)
+
+# Start Ray
+if [ "$USE_EXTERNAL_RAY" = "0" ]; then
+   export MASTER_ADDR=${MASTER_ADDR:-"127.0.0.1"}
+   export no_proxy="127.0.0.1,${MASTER_ADDR}"
+   ray start --head --node-ip-address ${MASTER_ADDR} --num-gpus ${NUM_GPUS} \
+      --disable-usage-stats --dashboard-host=0.0.0.0 --dashboard-port=8265
+fi
+
+RUNTIME_ENV_JSON="{
+  \"env_vars\": {
+    \"PYTHONPATH\": \"/root/Megatron-LM/\",
+    \"CUDA_DEVICE_MAX_CONNECTIONS\": \"1\",
+    \"NCCL_NVLS_ENABLE\": \"${HAS_NVLINK}\"
+  }
+}"
+
+ray job submit --address="http://127.0.0.1:8265" \
+   --runtime-env-json="${RUNTIME_ENV_JSON}" \
+   -- python3 train_async.py \
+   --actor-num-nodes ${NUM_NODES} \
+   --actor-num-gpus-per-node ${NUM_GPUS} \
+   --multimodal-keys "${MULTIMODAL_KEYS}" \
+   ${MODEL_ARGS[@]} \
+   ${M3_VL_ARGS[@]} \
+   ${CKPT_ARGS[@]} \
+   ${SFT_ARGS[@]} \
+   ${OPTIMIZER_ARGS[@]} \
+   ${WANDB_ARGS[@]} \
+   ${BACKEND_ARGS[@]}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# SMOKE TEST (plumbing only, no real weights / few GPUs):
+#   1. Make a reduced model arg file scripts/models/minimax-m3-428B_4layer.sh
+#      (copy minimax-m3-428B.sh, set --num-layers 4 and N_MOE_LAYERS=1) and
+#      `source` it instead above.
+#   2. Drop weight loading so the layer-count mismatch doesn't abort: remove the
+#      `--load` line (random-init LM). The HF vision tower still loads real
+#      weights via build_minimax_m3_vl, which is what exercises the VL merge path.
+#   3. Shrink parallelism (TP=1/2, PP=1, EP=1) and NUM_GPUS to fit one node.
+#   This validates: spec build -> composite wrap -> mm_data expansion ->
+#   embed/merge/decoder_input forward, end to end, on a single node.
+# ─────────────────────────────────────────────────────────────────────────────

--- a/miles/backends/megatron_utils/megatron_to_hf/__init__.py
+++ b/miles/backends/megatron_utils/megatron_to_hf/__init__.py
@@ -5,6 +5,7 @@ from .glm4moe import convert_glm4moe_to_hf
 from .kimi_vl import convert_kimi_k25_to_hf, convert_kimivl_to_hf
 from .llama import convert_llama_to_hf
 from .mimo import convert_mimo_to_hf
+from .minimax_m3 import convert_minimax_m3_to_hf
 from .processors import quantize_params, remove_padding
 from .qwen2 import convert_qwen2_to_hf
 from .qwen3_5 import convert_qwen3_5_to_hf
@@ -42,6 +43,8 @@ def _convert_to_hf_core(args, model_name, name, param):
         converted_named_tensors = convert_glm4moe_to_hf(args, name, param)
     elif "glm4" in model_name:
         converted_named_tensors = convert_glm4_to_hf(args, name, param)
+    elif "minimax_m3" in model_name or "minimaxm3" in model_name:
+        converted_named_tensors = convert_minimax_m3_to_hf(args, name, param)
     elif "qwen3moe" in model_name:
         converted_named_tensors = convert_qwen3moe_to_hf(args, name, param)
     elif "qwen3next" in model_name:

--- a/miles/backends/megatron_utils/megatron_to_hf/minimax_m3.py
+++ b/miles/backends/megatron_utils/megatron_to_hf/minimax_m3.py
@@ -29,6 +29,13 @@ _P = "language_model.model"
 
 
 def convert_minimax_m3_to_hf(args, name, param):
+    # Be robust to VL-wrapped param names. The MiniMaxM3VLModel saves its LM with
+    # BARE keys (sharded_state_dict delegates to language_model), so normally these
+    # are already "module.module.decoder.*"; but if a checkpoint ever carries the
+    # composite "language_model." level, strip it so the mappings below still hit
+    # (instead of a cryptic "Unknown parameter name"). Vision/projector params are
+    # not produced by this converter (LM-only export) and would still raise below.
+    name = name.replace("module.module.language_model.", "module.module.")
     if name == "module.module.embedding.word_embeddings.weight":
         return [(f"{_P}.embed_tokens.weight", param)]
     if name == "module.module.output_layer.weight":

--- a/miles/backends/megatron_utils/megatron_to_hf/minimax_m3.py
+++ b/miles/backends/megatron_utils/megatron_to_hf/minimax_m3.py
@@ -1,0 +1,119 @@
+"""Megatron(torch_dist) -> HuggingFace converter for MiniMax-M3.
+
+Inverse of the mbridge bridge (miles_plugins/mbridge/minimax_m3.py) used for the
+HF->torch_dist direction (which was validated bit-exact offline). Used by
+tools/convert_torch_dist_to_hf.py to export a TRAINED M3 checkpoint back to HF.
+
+Params arrive TP-merged and per-expert (``module.module.decoder.layers.{i}.{rest}``,
+experts already split to ``mlp.experts.linear_fc1.weight{idx}`` by get_expert_param).
+HF keys mirror the real M3 VL checkpoint layout: prefix ``language_model.model.*``,
+lm_head ``language_model.lm_head.weight`` (so the export drops into the same
+MiniMaxM3VL arch, with the vision tower carried over separately).
+
+M3 vs qwen3moe differences handled here:
+  * VLM-nested HF prefix ``language_model.model`` (not ``model``).
+  * MoE experts -> ``block_sparse_moe.experts.{e}.{w1,w3,w2}`` (gate=w1, up=w3, down=w2).
+  * Router -> ``block_sparse_moe.gate.weight`` (+ ``e_score_correction_bias``).
+  * Shared experts -> ``block_sparse_moe.shared_experts.{gate,up,down}_proj``.
+  * MSA lightning indexer (sparse layers) -> ``self_attn.index_{q,k}_{proj,norm}`` (direct).
+  * Dense layers 0-2 -> plain ``mlp.{gate,up,down}_proj``.
+  * No attention bias (--disable-bias-linear). gemma/zero-centered norms map directly
+    (megatron stores gamma == HF (1+w) gamma; confirmed bit-exact on final_norm).
+"""
+
+import re
+
+import torch
+
+_P = "language_model.model"
+
+
+def convert_minimax_m3_to_hf(args, name, param):
+    if name == "module.module.embedding.word_embeddings.weight":
+        return [(f"{_P}.embed_tokens.weight", param)]
+    if name == "module.module.output_layer.weight":
+        return [("language_model.lm_head.weight", param)]
+    if name == "module.module.decoder.final_layernorm.weight":
+        return [(f"{_P}.norm.weight", param)]
+
+    try:
+        head_dim = args.kv_channels if args.kv_channels is not None else args.hidden_size // args.num_attention_heads
+    except AttributeError:
+        head_dim = args.hidden_size // args.num_attention_heads
+    value_num_per_group = args.num_attention_heads // args.num_query_groups
+
+    match = re.match(r"module\.module\.decoder\.layers\.(\d+)\.(.+)", name)
+    if not match:
+        raise ValueError(f"Unknown parameter name: {name}")
+    layer_idx, rest = match.groups()
+    pfx = f"{_P}.layers.{layer_idx}"
+
+    # --- MoE routed experts (grouped GEMM, one weight per expert) ---
+    em = re.match(r"mlp\.experts\.(.+)\.weight(\d+)", rest)
+    if em:
+        sub, expert_idx = em.groups()
+        ep = f"{pfx}.block_sparse_moe.experts.{expert_idx}"
+        if sub == "linear_fc1":
+            gate_weight, up_weight = param.chunk(2, dim=0)  # w1=gate, w3=up
+            return [(f"{ep}.w1.weight", gate_weight), (f"{ep}.w3.weight", up_weight)]
+        if sub == "linear_fc2":
+            return [(f"{ep}.w2.weight", param)]
+        raise ValueError(f"Unknown expert parameter name: {name}")
+
+    # --- shared expert ---
+    sm = re.match(r"mlp\.shared_experts\.(.+)", rest)
+    if sm:
+        sub = sm.groups()[0]
+        sp = f"{pfx}.block_sparse_moe.shared_experts"
+        if sub == "linear_fc1.weight":
+            gate_weight, up_weight = param.chunk(2, dim=0)
+            return [(f"{sp}.gate_proj.weight", gate_weight), (f"{sp}.up_proj.weight", up_weight)]
+        if sub == "linear_fc2.weight":
+            return [(f"{sp}.down_proj.weight", param)]
+        raise ValueError(f"Unknown shared expert parameter name: {name}")
+
+    # --- attention (GQA, no bias) ---
+    if rest == "self_attention.linear_proj.weight":
+        return [(f"{pfx}.self_attn.o_proj.weight", param)]
+    if rest == "self_attention.linear_qkv.weight":
+        param = param.view(args.num_query_groups, -1, head_dim, args.hidden_size)
+        q_param, k_param, v_param = torch.split(param, [value_num_per_group, 1, 1], dim=1)
+        return [
+            (f"{pfx}.self_attn.q_proj.weight", q_param.reshape(-1, args.hidden_size)),
+            (f"{pfx}.self_attn.k_proj.weight", k_param.reshape(-1, args.hidden_size)),
+            (f"{pfx}.self_attn.v_proj.weight", v_param.reshape(-1, args.hidden_size)),
+        ]
+    if rest == "self_attention.linear_qkv.layer_norm_weight":
+        return [(f"{pfx}.input_layernorm.weight", param)]
+    if rest == "self_attention.q_layernorm.weight":
+        return [(f"{pfx}.self_attn.q_norm.weight", param)]
+    if rest == "self_attention.k_layernorm.weight":
+        return [(f"{pfx}.self_attn.k_norm.weight", param)]
+    # MSA lightning indexer (sparse layers 3-59) — direct name map, no reshape
+    if rest == "self_attention.index_q_proj.weight":
+        return [(f"{pfx}.self_attn.index_q_proj.weight", param)]
+    if rest == "self_attention.index_k_proj.weight":
+        return [(f"{pfx}.self_attn.index_k_proj.weight", param)]
+    if rest == "self_attention.index_q_norm.weight":
+        return [(f"{pfx}.self_attn.index_q_norm.weight", param)]
+    if rest == "self_attention.index_k_norm.weight":
+        return [(f"{pfx}.self_attn.index_k_norm.weight", param)]
+
+    # --- dense MLP (layers 0-2) ---
+    if rest == "mlp.linear_fc1.weight":
+        gate_weight, up_weight = param.chunk(2, dim=0)
+        return [(f"{pfx}.mlp.gate_proj.weight", gate_weight), (f"{pfx}.mlp.up_proj.weight", up_weight)]
+    if rest == "mlp.linear_fc2.weight":
+        return [(f"{pfx}.mlp.down_proj.weight", param)]
+    if rest == "mlp.linear_fc1.layer_norm_weight":
+        return [(f"{pfx}.post_attention_layernorm.weight", param)]
+
+    # --- MoE router + pre-mlp norm (layers 3-59) ---
+    if rest == "pre_mlp_layernorm.weight":
+        return [(f"{pfx}.post_attention_layernorm.weight", param)]
+    if rest == "mlp.router.weight":
+        return [(f"{pfx}.block_sparse_moe.gate.weight", param)]
+    if rest == "mlp.router.expert_bias":
+        return [(f"{pfx}.block_sparse_moe.e_score_correction_bias", param)]
+
+    raise ValueError(f"Unknown parameter name: {name}")

--- a/miles/backends/megatron_utils/model.py
+++ b/miles/backends/megatron_utils/model.py
@@ -125,7 +125,11 @@ def setup_model_and_optimizer(
               ``None`` when ``--debug-disable-optimizer`` is set.
     """
     assert not args.moe_use_upcycling
-    assert args.load is not None or args.pretrained_checkpoint is not None
+    assert (
+        args.load is not None
+        or args.pretrained_checkpoint is not None
+        or getattr(args, "debug_skip_load", False)
+    )
 
     if is_lora_enabled(args) and role == "actor" and args.megatron_to_hf_mode == "bridge":
         model = _setup_lora_model_via_bridge(args)
@@ -831,13 +835,18 @@ def initialize_model_and_optimizer(
     model, optimizer, opt_param_scheduler = setup_model_and_optimizer(args, role)
     model[0].role = role
     clear_memory()
-    iteration, _ = load_checkpoint(
-        model,
-        optimizer,
-        opt_param_scheduler,
-        checkpointing_context={},
-        skip_load_to_model_and_opt=False,
-    )
+    if getattr(args, "debug_skip_load", False):
+        if is_megatron_main_rank():
+            logger.warning("--debug-skip-load set: using RANDOM-init weights, skipping load_checkpoint.")
+        iteration = 0
+    else:
+        iteration, _ = load_checkpoint(
+            model,
+            optimizer,
+            opt_param_scheduler,
+            checkpointing_context={},
+            skip_load_to_model_and_opt=False,
+        )
     check_peak_gpu_memory_after_load(args)
     clear_memory()
 

--- a/miles/backends/megatron_utils/model_provider.py
+++ b/miles/backends/megatron_utils/model_provider.py
@@ -266,6 +266,16 @@ def get_model_provider_func(
         if post_process and role == "critic":
             model.output_layer = LinearForLastLayer(input_size=config.hidden_size, output_size=1, config=config)
 
+        # MiniMax-M3-VL: wrap the M3 text decoder in the composite VL model
+        # (HF-native vision tower + projector). Opt-in via --minimax-m3-vl so the
+        # default text path is untouched. See miles_plugins/models/minimax_m3.
+        if getattr(args, "minimax_m3_vl", False):
+            from miles_plugins.models.minimax_m3.vl_model import build_minimax_m3_vl
+
+            model = build_minimax_m3_vl(
+                model, args, freeze_vision=not getattr(args, "minimax_m3_train_vision", False)
+            )
+
         return model
 
     return model_provider

--- a/miles/backends/training_utils/data.py
+++ b/miles/backends/training_utils/data.py
@@ -56,6 +56,15 @@ def get_rollout_data(args: Namespace, rollout_data_ref: Box) -> RolloutBatch:
             for mm_dict in rollout_data["multimodal_train_inputs"]
         ]
 
+    # MiniMax-M3-VL: expand one media placeholder per image/video into the
+    # grid-derived number of slots so token / loss-mask / total_lengths match the
+    # vision embeddings the composite model scatters in. Runs before lengths are
+    # read below; no-op for samples without media. Gated on --minimax-m3-vl.
+    if getattr(args, "minimax_m3_vl", False):
+        from miles_plugins.models.minimax_m3.mm_data import expand_multimodal_in_place
+
+        expand_multimodal_in_place(rollout_data)
+
     if args.qkv_format == "bshd":
         # TODO: micro-batch wise dynamic, possibly move to @data.py:get_data_iterator
         max_seq_len = max(rollout_data["total_lengths"])

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -173,6 +173,26 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 ),
             )
             parser.add_argument(
+                "--minimax-m3-vl",
+                action="store_true",
+                default=False,
+                help=(
+                    "Wrap the MiniMax-M3 text decoder in the composite VL model "
+                    "(HF-native vision tower + projector). Requires "
+                    "--spec miles_plugins.models.minimax_m3.minimax_m3 get_minimax_m3_spec."
+                ),
+            )
+            parser.add_argument(
+                "--minimax-m3-train-vision",
+                action="store_true",
+                default=False,
+                help=(
+                    "Also train the M3 vision tower (default frozen: only projector + LM "
+                    "train). Unfreezes the HF-native vision tower; its replicated grads are "
+                    "all-reduced across the model-parallel group so the copies stay in sync."
+                ),
+            )
+            parser.add_argument(
                 "--train-env-vars",
                 type=json.loads,
                 default="{}",
@@ -201,6 +221,16 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                     "Debug-only: do not initialize the Megatron optimizer or LR scheduler. "
                     "Training still runs rollout, log-prob forward, and actor forward/backward, "
                     "but skips optimizer state allocation and optimizer updates."
+                ),
+            )
+            parser.add_argument(
+                "--debug-skip-load",
+                action="store_true",
+                default=False,
+                help=(
+                    "Debug-only: build the model with RANDOM init and skip checkpoint "
+                    "loading entirely (no --load / --pretrained-checkpoint required). "
+                    "For plumbing smoke tests of new model code without converted weights."
                 ),
             )
             parser.add_argument(
@@ -2483,6 +2513,11 @@ def hf_validate_args(args, hf_config):
         if getattr(hf_config, "model_type", "") == "qwen3_5_moe_text" and hf_config_name == "intermediate_size":
             continue
         if getattr(hf_config, "model_type", "") == "deepseek_v4" and hf_config_name == "intermediate_size":
+            continue
+        # MiniMax-M3: HF text_config.intermediate_size is the EXPERT FFN (3072);
+        # dense layers use dense_intermediate_size (12288). Megatron splits these
+        # into moe_ffn_hidden_size / ffn_hidden_size, so the flat check doesn't apply.
+        if hasattr(hf_config, "dense_intermediate_size") and hf_config_name == "intermediate_size":
             continue
         if hasattr(hf_config, hf_config_name):
             if not compare_fn(getattr(hf_config, hf_config_name), getattr(args, megatron_config_name)):

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -187,9 +187,11 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 action="store_true",
                 default=False,
                 help=(
-                    "Also train the M3 vision tower (default frozen: only projector + LM "
-                    "train). Unfreezes the HF-native vision tower; its replicated grads are "
-                    "all-reduced across the model-parallel group so the copies stay in sync."
+                    "Unfreeze the M3 vision tower (default frozen). WIP / NOT YET CORRECT: "
+                    "the native vision tower + projector are replicated and are NOT in "
+                    "Megatron's grad buffer / distributed optimizer, and there is no TP grad "
+                    "all-reduce for them, so this flag does not (yet) update them consistently. "
+                    "See the plugin README 'Known limitations' before using."
                 ),
             )
             parser.add_argument(

--- a/miles_plugins/mbridge/__init__.py
+++ b/miles_plugins/mbridge/__init__.py
@@ -18,4 +18,6 @@ __all__ = [
     "DeepseekV32Bridge",
     "DeepseekV4Bridge",
     "JoyAILLMFlashBridge",
+    "MiniMaxM3Bridge",
 ]
+from .minimax_m3 import MiniMaxM3Bridge

--- a/miles_plugins/mbridge/minimax_m3.py
+++ b/miles_plugins/mbridge/minimax_m3.py
@@ -23,7 +23,6 @@ NOTE: structurally complete and key-verified, but the offline 428B conversion ru
 is the validation step (mbridge mixed dense/MoE handling + the indexer params).
 """
 
-import torch
 
 from mbridge.core import register_model
 from mbridge.models import Qwen3MoEBridge
@@ -115,14 +114,20 @@ class MiniMaxM3Bridge(Qwen3MoEBridge):
     def _build_config(self):
         tc = self._get_text_config()
         sac = getattr(tc, "sparse_attention_config", {}) or {}
-        sg = (lambda k, d=None: sac.get(k, d) if isinstance(sac, dict) else getattr(sac, k, d))
+
+        def sg(k, d=None):
+            return sac.get(k, d) if isinstance(sac, dict) else getattr(sac, k, d)
+
         cfg = self._build_base_config(
             use_cpu_initialization=False,
             # MoE — DeepSeek-V3-style sigmoid routing + expert bias correction
             moe_ffn_hidden_size=tc.intermediate_size,            # expert FFN (3072)
             moe_router_topk=tc.num_experts_per_tok,
             num_moe_experts=tc.num_local_experts,
-            moe_shared_expert_intermediate_size=tc.n_shared_experts * tc.intermediate_size,
+            # n_shared_experts may be absent on some M3 config revisions -> treat as 0
+            # (no shared expert) rather than raising AttributeError.
+            moe_shared_expert_intermediate_size=(getattr(tc, "n_shared_experts", 0) or 0)
+            * tc.intermediate_size,
             moe_router_score_function="sigmoid",
             moe_router_enable_expert_bias=True,
             moe_router_pre_softmax=False,

--- a/miles_plugins/mbridge/minimax_m3.py
+++ b/miles_plugins/mbridge/minimax_m3.py
@@ -1,0 +1,156 @@
+"""mbridge weight bridge for MiniMax-M3 (used by tools/convert_hf_to_torch_dist.py).
+
+The offline HF->torch_dist converter uses the ``mbridge`` package (not
+``megatron.bridge``). The Megatron model itself is built via ``--spec
+get_minimax_m3_spec`` (so MSA attention is present); mbridge only supplies the
+HF<->Megatron parameter NAME mappings + the provider config.
+
+Mappings verified against the real checkpoint key layout
+(``model.safetensors.index.json``), prefix ``language_model.model.*``:
+
+    language_model.model.layers.{i}.input_layernorm.weight
+    language_model.model.layers.{i}.post_attention_layernorm.weight
+    language_model.model.layers.{i}.self_attn.{q,k,v,o}_proj.weight
+    language_model.model.layers.{i}.self_attn.{q,k}_norm.weight
+    language_model.model.layers.{i}.self_attn.index_{q,k}_{proj,norm}.weight   # sparse layers
+    language_model.model.layers.{i}.mlp.{gate,up,down}_proj.weight             # dense layers 0-2
+    language_model.model.layers.{i}.block_sparse_moe.gate.weight               # MoE layers 3-59
+    language_model.model.layers.{i}.block_sparse_moe.e_score_correction_bias
+    language_model.model.layers.{i}.block_sparse_moe.experts.{e}.{w1,w3,w2}.weight
+    language_model.model.layers.{i}.block_sparse_moe.shared_experts.{gate,up,down}_proj.weight
+
+NOTE: structurally complete and key-verified, but the offline 428B conversion run
+is the validation step (mbridge mixed dense/MoE handling + the indexer params).
+"""
+
+import torch
+
+from mbridge.core import register_model
+from mbridge.models import Qwen3MoEBridge
+
+
+_P = "language_model.model"
+
+
+@register_model(["minimax_m3", "minimax_m3_vl"])
+class MiniMaxM3Bridge(Qwen3MoEBridge):
+    """MiniMax-M3: GQA + per-head QK-norm + MSA indexer + DeepSeek-style MoE."""
+
+    def __init__(self, hf_config, *args, **kwargs):
+        # M3 is a VLM-nested config; the LM fields the base reads
+        # (num_hidden_layers, hidden_size, head_dim, ...) live under text_config.
+        # Flatten to text_config so base config resolution + _CONFIG_MAPPING work.
+        # Weight keys (language_model.model.*) are unaffected. Keep the original
+        # for any top-level VL fields.
+        self._full_hf_config = hf_config
+        if hasattr(hf_config, "text_config"):
+            hf_config = hf_config.text_config
+        super().__init__(hf_config, *args, **kwargs)
+
+    _DIRECT_MAPPING = {
+        "embedding.word_embeddings.weight": f"{_P}.embed_tokens.weight",
+        "decoder.final_layernorm.weight": f"{_P}.norm.weight",
+        "output_layer.weight": "language_model.lm_head.weight",
+    }
+
+    _ATTENTION_MAPPING = {
+        "self_attention.linear_proj.weight": [f"{_P}.layers.{{layer_number}}.self_attn.o_proj.weight"],
+        "self_attention.linear_qkv.layer_norm_weight": [f"{_P}.layers.{{layer_number}}.input_layernorm.weight"],
+        "self_attention.q_layernorm.weight": [f"{_P}.layers.{{layer_number}}.self_attn.q_norm.weight"],
+        "self_attention.k_layernorm.weight": [f"{_P}.layers.{{layer_number}}.self_attn.k_norm.weight"],
+        "self_attention.linear_qkv.weight": [
+            f"{_P}.layers.{{layer_number}}.self_attn.q_proj.weight",
+            f"{_P}.layers.{{layer_number}}.self_attn.k_proj.weight",
+            f"{_P}.layers.{{layer_number}}.self_attn.v_proj.weight",
+        ],
+        # MSA lightning indexer (sparse layers only). Param names match
+        # MSASelfAttentionSubmodules attribute names in minimax_m3.py.
+        "self_attention.index_q_proj.weight": [f"{_P}.layers.{{layer_number}}.self_attn.index_q_proj.weight"],
+        "self_attention.index_k_proj.weight": [f"{_P}.layers.{{layer_number}}.self_attn.index_k_proj.weight"],
+        "self_attention.index_q_norm.weight": [f"{_P}.layers.{{layer_number}}.self_attn.index_q_norm.weight"],
+        "self_attention.index_k_norm.weight": [f"{_P}.layers.{{layer_number}}.self_attn.index_k_norm.weight"],
+    }
+
+    _MLP_MAPPING = {
+        # dense layers (0..first_dense-1): plain gated MLP
+        "mlp.linear_fc1.weight": [
+            f"{_P}.layers.{{layer_number}}.mlp.gate_proj.weight",
+            f"{_P}.layers.{{layer_number}}.mlp.up_proj.weight",
+        ],
+        "mlp.linear_fc1.layer_norm_weight": [f"{_P}.layers.{{layer_number}}.post_attention_layernorm.weight"],
+        "mlp.linear_fc2.weight": [f"{_P}.layers.{{layer_number}}.mlp.down_proj.weight"],
+        # MoE layers: router (+ expert bias), per-expert w1/w3/w2, shared expert
+        "pre_mlp_layernorm.weight": [f"{_P}.layers.{{layer_number}}.post_attention_layernorm.weight"],
+        "mlp.router.weight": [f"{_P}.layers.{{layer_number}}.block_sparse_moe.gate.weight"],
+        "mlp.router.expert_bias": [f"{_P}.layers.{{layer_number}}.block_sparse_moe.e_score_correction_bias"],
+        "mlp.experts.linear_fc1": [
+            f"{_P}.layers.{{layer_number}}.block_sparse_moe.experts.{{expert_id}}.w1.weight",
+            f"{_P}.layers.{{layer_number}}.block_sparse_moe.experts.{{expert_id}}.w3.weight",
+        ],
+        "mlp.experts.linear_fc2": [f"{_P}.layers.{{layer_number}}.block_sparse_moe.experts.{{expert_id}}.w2.weight"],
+        "mlp.shared_experts.linear_fc1.weight": [
+            f"{_P}.layers.{{layer_number}}.block_sparse_moe.shared_experts.gate_proj.weight",
+            f"{_P}.layers.{{layer_number}}.block_sparse_moe.shared_experts.up_proj.weight",
+        ],
+        "mlp.shared_experts.linear_fc2.weight": [
+            f"{_P}.layers.{{layer_number}}.block_sparse_moe.shared_experts.down_proj.weight"
+        ],
+    }
+
+    _CONFIG_MAPPING = {
+        "num_layers": "num_hidden_layers",
+        "hidden_size": "hidden_size",
+        "num_attention_heads": "num_attention_heads",
+        "num_query_groups": "num_key_value_heads",
+        "ffn_hidden_size": "dense_intermediate_size",   # dense layers use the big FFN
+        "attention_dropout": ("attention_dropout", 0.0),
+        "layernorm_epsilon": "rms_norm_eps",
+        "hidden_dropout": ("hidden_dropout", 0.0),
+        "kv_channels": ("head_dim", None),
+    }
+
+    def _get_text_config(self):
+        return getattr(self.hf_config, "text_config", self.hf_config)
+
+    def _build_config(self):
+        tc = self._get_text_config()
+        sac = getattr(tc, "sparse_attention_config", {}) or {}
+        sg = (lambda k, d=None: sac.get(k, d) if isinstance(sac, dict) else getattr(sac, k, d))
+        cfg = self._build_base_config(
+            use_cpu_initialization=False,
+            # MoE — DeepSeek-V3-style sigmoid routing + expert bias correction
+            moe_ffn_hidden_size=tc.intermediate_size,            # expert FFN (3072)
+            moe_router_topk=tc.num_experts_per_tok,
+            num_moe_experts=tc.num_local_experts,
+            moe_shared_expert_intermediate_size=tc.n_shared_experts * tc.intermediate_size,
+            moe_router_score_function="sigmoid",
+            moe_router_enable_expert_bias=True,
+            moe_router_pre_softmax=False,
+            moe_router_topk_scaling_factor=getattr(tc, "routed_scaling_factor", 1.0),
+            moe_router_load_balancing_type="none",
+            moe_grouped_gemm=True,
+            moe_aux_loss_coeff=0.0,
+            num_layers_in_first_pipeline_stage=None,
+            qk_layernorm=True,
+        )
+        # SwiGLU-OAI activation (== GPT-OSS): quick_gelu gate + clamp + (up+1)
+        if str(getattr(tc, "hidden_act", "")).lower() in ("swigluoai", "swiglu_oai"):
+            from megatron.core.activations import quick_gelu
+
+            cfg.activation_func = quick_gelu
+            cfg.activation_func_clamp_value = float(getattr(tc, "swiglu_limit", 7.0))
+            cfg.glu_linear_offset = 1.0
+            cfg.gated_linear_unit = True
+            cfg.bias_activation_fusion = False  # non-fused glu handles clamp+offset
+        if getattr(tc, "use_gemma_norm", False):
+            cfg.layernorm_zero_centered_gamma = True
+        # MSA hyperparameters (consumed by get_minimax_m3_spec / MSASelfAttention)
+        cfg.sparse_index_dim = sg("sparse_index_dim")
+        cfg.sparse_num_index_heads = sg("sparse_num_index_heads")
+        cfg.sparse_block_size = sg("sparse_block_size")
+        cfg.sparse_topk_blocks = sg("sparse_topk_blocks")
+        cfg.sparse_init_block = sg("sparse_init_block", 0)
+        cfg.sparse_local_block = sg("sparse_local_block", 1)
+        # rope (rotary_base / rotary_percent) comes from the --rotary-base /
+        # --rotary-percent CLI args; not a TransformerConfig field, don't set here.
+        return cfg

--- a/miles_plugins/megatron_bridge/minimax_m3.py
+++ b/miles_plugins/megatron_bridge/minimax_m3.py
@@ -1,0 +1,189 @@
+"""Megatron-Bridge weight bridge for MiniMax-M3 (text backbone).
+
+Self-installs on import (``@register_bridge``) so ``AutoBridge`` picks it up for
+HF checkpoints whose architecture is ``MiniMaxM3VLForConditionalGeneration``.
+Only the **language model** is mapped (text training / RL); vision tower and
+projector weights in the VL checkpoint are simply not requested when the
+Megatron model is the text-only ``GPTModel`` built by ``get_minimax_m3_spec``.
+
+Grounded in the real HF key layout (``model.safetensors.index.json``):
+
+    language_model.model.embed_tokens.weight
+    language_model.lm_head.weight
+    language_model.model.norm.weight
+    language_model.model.layers.{i}.input_layernorm.weight
+    language_model.model.layers.{i}.post_attention_layernorm.weight
+    language_model.model.layers.{i}.self_attn.{q,k,v,o}_proj.weight
+    language_model.model.layers.{i}.self_attn.{q,k}_norm.weight            # per-head
+    # sparse (MSA) layers only — indexer:
+    language_model.model.layers.{i}.self_attn.index_{q,k}_proj.weight
+    language_model.model.layers.{i}.self_attn.index_{q,k}_norm.weight
+    # dense layers 0..first_dense-1:
+    language_model.model.layers.{i}.mlp.{gate,up,down}_proj.weight
+    # MoE layers:
+    language_model.model.layers.{i}.block_sparse_moe.gate.weight
+    language_model.model.layers.{i}.block_sparse_moe.e_score_correction_bias
+    language_model.model.layers.{i}.block_sparse_moe.experts.{e}.{w1,w3,w2}.weight
+    language_model.model.layers.{i}.block_sparse_moe.shared_experts.{gate,up,down}_proj.weight
+
+Relation to GLM-5: GLM-5's bridge subclasses ``DeepSeekV3Bridge`` (MLA). M3 is
+**GQA**, so this subclasses ``MiniMaxM2Bridge`` instead — same MiniMax MoE
+lineage (sigmoid router + expert bias, ``w1/w2/w3`` experts, fp8 blockwise) —
+and only changes: the ``language_model.`` prefix, per-head (not full-dim) QK
+norm, a shared expert, dense layers, and the four indexer tensors.
+
+NOTE: validated structurally against the HF key list and the M2 bridge API; the
+exact Megatron param paths must be confirmed on a GPU load (``bridge.load_hf_weights``).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+try:
+    import torch
+
+    from megatron.core.models.gpt.gpt_model import GPTModel
+    from megatron.bridge.models.conversion.mapping_registry import MegatronMappingRegistry
+    from megatron.bridge.models.conversion.model_bridge import MegatronModelBridge
+    from megatron.bridge.models.conversion.param_mapping import (
+        AutoMapping,
+        GatedMLPMapping,
+        QKVMapping,
+    )
+    from megatron.bridge.models.minimax_m2.minimax_m2_bridge import MiniMaxM2Bridge
+
+    _P = "language_model.model"  # HF text-backbone prefix
+
+    @MegatronModelBridge.register_bridge(
+        source="MiniMaxM3VLForConditionalGeneration",
+        target=GPTModel,
+        model_type="minimax_m3",
+    )
+    class MiniMaxM3Bridge(MiniMaxM2Bridge):
+        """Bridge for MiniMax-M3 (GQA + MSA + MoE) text backbone.
+
+        Also resolves the text-only ``MiniMaxM3ForCausalLM`` arch if present.
+        """
+
+        def provider_bridge(self, hf_pretrained):
+            # Start from the M2 GQA-MoE provider (sigmoid router, expert bias,
+            # grouped-gemm experts, rope, fp8 dequant), then apply M3 deltas.
+            provider = super().provider_bridge(hf_pretrained)
+            hf_config = hf_pretrained.config
+            text_cfg = getattr(hf_config, "text_config", hf_config)
+
+            # M3 uses *per-head* QK norm (M2 used full-dimension). Drop M2's custom
+            # full-dim layer spec so mcore builds standard per-head TENorm, and let
+            # the miles ``--spec get_minimax_m3_spec`` own the MSA attention layout.
+            provider.qk_layernorm = True
+            if hasattr(provider, "transformer_layer_spec"):
+                provider.transformer_layer_spec = None  # provided via miles --spec
+
+            # Shared expert (M2 had none).
+            n_shared = getattr(text_cfg, "n_shared_experts", 0) or 0
+            if n_shared:
+                provider.moe_shared_expert_intermediate_size = (
+                    n_shared * text_cfg.intermediate_size
+                )
+            # Router scaling.
+            provider.moe_router_topk_scaling_factor = getattr(
+                text_cfg, "routed_scaling_factor", 1.0
+            )
+            # Partial RoPE (rotary_dim / head_dim) and theta.
+            rd = getattr(text_cfg, "rotary_dim", None)
+            hd = getattr(text_cfg, "head_dim", None)
+            if rd and hd:
+                provider.rotary_percent = rd / hd
+            provider.rotary_base = getattr(text_cfg, "rope_theta", provider.rotary_base)
+            return provider
+
+        def mapping_registry(self) -> MegatronMappingRegistry:
+            # When the target is the composite VL model, the LM params carry a
+            # ``language_model.`` prefix (and vision/projector params exist). The
+            # ``--minimax-m3-vl`` flow exports ``MINIMAX_M3_VL=1`` (see
+            # build_minimax_m3_vl) so a single arch-keyed bridge serves both.
+            vl = os.environ.get("MINIMAX_M3_VL", "") not in ("", "0", "false")
+            mp = "language_model." if vl else ""
+
+            def M(name: str) -> str:  # megatron-side path, with optional prefix
+                return f"{mp}{name}"
+
+            m = [
+                # ---- globals ----
+                AutoMapping(megatron_param=M("embedding.word_embeddings.weight"),
+                            hf_param=f"{_P}.embed_tokens.weight"),
+                AutoMapping(megatron_param=M("output_layer.weight"),
+                            hf_param="language_model.lm_head.weight"),
+                AutoMapping(megatron_param=M("decoder.final_layernorm.weight"),
+                            hf_param=f"{_P}.norm.weight"),
+                # ---- per-layer norms ----
+                AutoMapping(megatron_param=M("decoder.layers.*.self_attention.linear_qkv.layer_norm_weight"),
+                            hf_param=f"{_P}.layers.*.input_layernorm.weight"),
+                AutoMapping(megatron_param=M("decoder.layers.*.pre_mlp_layernorm.weight"),
+                            hf_param=f"{_P}.layers.*.post_attention_layernorm.weight"),
+                # ---- attention ----
+                QKVMapping(megatron_param=M("decoder.layers.*.self_attention.linear_qkv.weight"),
+                           q=f"{_P}.layers.*.self_attn.q_proj.weight",
+                           k=f"{_P}.layers.*.self_attn.k_proj.weight",
+                           v=f"{_P}.layers.*.self_attn.v_proj.weight"),
+                AutoMapping(megatron_param=M("decoder.layers.*.self_attention.linear_proj.weight"),
+                            hf_param=f"{_P}.layers.*.self_attn.o_proj.weight"),
+                AutoMapping(megatron_param=M("decoder.layers.*.self_attention.q_layernorm.weight"),
+                            hf_param=f"{_P}.layers.*.self_attn.q_norm.weight"),
+                AutoMapping(megatron_param=M("decoder.layers.*.self_attention.k_layernorm.weight"),
+                            hf_param=f"{_P}.layers.*.self_attn.k_norm.weight"),
+                # ---- dense-layer MLP ----
+                GatedMLPMapping(megatron_param=M("decoder.layers.*.mlp.linear_fc1.weight"),
+                                gate=f"{_P}.layers.*.mlp.gate_proj.weight",
+                                up=f"{_P}.layers.*.mlp.up_proj.weight"),
+                AutoMapping(megatron_param=M("decoder.layers.*.mlp.linear_fc2.weight"),
+                            hf_param=f"{_P}.layers.*.mlp.down_proj.weight"),
+                # ---- MoE router + expert bias ----
+                AutoMapping(megatron_param=M("decoder.layers.*.mlp.router.weight"),
+                            hf_param=f"{_P}.layers.*.block_sparse_moe.gate.weight"),
+                AutoMapping(megatron_param=M("decoder.layers.*.mlp.router.expert_bias"),
+                            hf_param=f"{_P}.layers.*.block_sparse_moe.e_score_correction_bias"),
+                # ---- routed experts (w1=gate, w3=up, w2=down) ----
+                GatedMLPMapping(megatron_param=M("decoder.layers.*.mlp.experts.linear_fc1.weight*"),
+                                gate=f"{_P}.layers.*.block_sparse_moe.experts.*.w1.weight",
+                                up=f"{_P}.layers.*.block_sparse_moe.experts.*.w3.weight"),
+                AutoMapping(megatron_param=M("decoder.layers.*.mlp.experts.linear_fc2.weight*"),
+                            hf_param=f"{_P}.layers.*.block_sparse_moe.experts.*.w2.weight"),
+                # ---- shared expert ----
+                GatedMLPMapping(megatron_param=M("decoder.layers.*.mlp.shared_experts.linear_fc1.weight"),
+                                gate=f"{_P}.layers.*.block_sparse_moe.shared_experts.gate_proj.weight",
+                                up=f"{_P}.layers.*.block_sparse_moe.shared_experts.up_proj.weight"),
+                AutoMapping(megatron_param=M("decoder.layers.*.mlp.shared_experts.linear_fc2.weight"),
+                            hf_param=f"{_P}.layers.*.block_sparse_moe.shared_experts.down_proj.weight"),
+            ]
+
+            # ---- MSA lightning indexer (sparse layers only) ----
+            for stem in ("index_q_proj", "index_k_proj", "index_q_norm", "index_k_norm"):
+                m.append(AutoMapping(
+                    megatron_param=M(f"decoder.layers.*.self_attention.{stem}.weight"),
+                    hf_param=f"{_P}.layers.*.self_attn.{stem}.weight"))
+
+            # ---- VL: vision tower + projector, replicated (not TP-sharded) ----
+            if vl:
+                try:
+                    from megatron.bridge.models.conversion.param_mapping import ReplicatedMapping
+                    m += [
+                        ReplicatedMapping(megatron_param="vision_tower.**", hf_param="vision_tower.**"),
+                        ReplicatedMapping(megatron_param="multi_modal_projector.**",
+                                          hf_param="multi_modal_projector.**"),
+                    ]
+                except Exception:
+                    # vision weights are loaded HF-native by build_minimax_m3_vl as a
+                    # fallback; the bridge simply won't touch them.
+                    logger.debug("ReplicatedMapping unavailable; vision loaded HF-native instead")
+
+            return MegatronMappingRegistry(*m)
+
+    logger.info("Registered MiniMaxM3Bridge for MiniMaxM3VLForConditionalGeneration")
+
+except ImportError as e:
+    logger.debug("megatron.bridge / minimax_m2 base not available; M3 bridge not registered: %s", e)

--- a/miles_plugins/models/minimax_m3/README.md
+++ b/miles_plugins/models/minimax_m3/README.md
@@ -1,0 +1,156 @@
+# MiniMax-M3 (MSA) miles plugin
+
+Training support for **MiniMax-M3** in miles, built the same way as the GLM-5
+plugin (`miles_plugins/models/glm5/`): a custom attention module + sparse-index
+kernels in `ops/`, wired through Megatron's `--spec` mechanism.
+
+```
+--spec "miles_plugins.models.minimax_m3.minimax_m3" "get_minimax_m3_spec"
+```
+
+## Why M3 needs its own plugin (it is *not* M2, and *not* GLM-5)
+
+| | M2 (full attn) | GLM-5 (DSA) | **M3 (MSA)** |
+|---|---|---|---|
+| attention backbone | GQA, dense | **MLA** (latent KV) | **GQA** (real KV) |
+| sparse selection | none | per-**token**, topk=2048 | per-**block**, 16×128 |
+| index sharing | — | one index, all q-heads | one index per GQA group (4 heads) |
+| head reduction | — | sum (learned `weights_proj`) | **max** (`amax`, no gating weight) |
+| block-forced keep | — | — | init block 0 + local block |
+| QK-norm | full-dim | — | **per-head** |
+
+So M3 reuses neither the M2 bridge (dense GQA) nor GLM-5's MLA path. The novel
+pieces are the **block-level lightning indexer** and **block-sparse GQA**.
+
+## Architecture (from `MiniMaxAI/MiniMax-M3` config.json, arXiv:2606.13392)
+
+- 60 layers, hidden 6144, 64 q-heads / 4 kv-heads, head_dim 128.
+- partial RoPE on first `rotary_dim=64`, θ = 5e6.
+- **layers 0–2**: dense FFN (intermediate 12288), **full causal attention**.
+- **layers 3–59**: MoE (128 experts, top-4, 1 shared, sigmoid + routing bias,
+  `routed_scaling_factor=2.0`, expert FFN 3072) + **MSA sparse attention**.
+- indexer: `sparse_index_dim=128`, `sparse_num_index_heads=4`.
+- selection: `sparse_block_size=128`, `sparse_topk_blocks=16`,
+  `sparse_score_type="max"`, `sparse_init_block=0`, `sparse_local_block=1`.
+
+## MSA algorithm (what the code implements)
+
+Per query token `i` on a sparse layer:
+
+1. `index_q = q_norm(Wq_idx·x)` → `[N, 4, 128]`, `index_k = k_norm(Wk_idx·x)` → `[N, 128]`
+   (one shared key head per GQA group); partial RoPE on the first 64 dims.
+2. token logits `S[h,i,j] = <index_q[i,h], index_k[j]>/√128`, causal `j ≤ i`.
+3. block max-pool `M[i,b] = max_h max_{j∈block b} S[h,i,j]`  (`score_type=max`).
+4. force-keep init block(s) (sink) + the local/current block.
+5. `TopK_b(M[i,·], 16)` → selected blocks; main GQA attends only to those
+   (≤ 16·128 = 2048 keys), causally masked inside each block.
+
+Files:
+- `ops/msa_indexer.py` — steps 1–5. `block_topk` reuses GLM-5's tuned tilelang
+  `tilelang_indexer_fwd` to materialise token logits chunk-by-chunk (bounded
+  memory at 1M ctx), then block-pool + top-k. `block_topk_reference` is the
+  pure-torch oracle.
+- `ops/block_sparse_attn.py` — block-sparse GQA over the selected blocks.
+  `BlockSparseGQA` is the autograd hook (same call shape as GLM-5's `SparseMLA`).
+- `minimax_m3.py` — `MSASelfAttention` (GQA + indexer) and `get_minimax_m3_spec`
+  (dense layers keep full attention; sparse layers swap in MSA).
+
+## Indexer training (important)
+
+The top-k is non-differentiable, so the indexer gets **no** LM gradient — it is
+detached in `_compute_block_selection`. M3 trains it with a **KL distillation**
+loss: the indexer's softmax over selected tokens matches the main attention's
+per-group averaged distribution (`D_KL(stopgrad(P_main) ‖ P_index)`), with a
+two-stage warmup (full attention first, then switch to sparse). Add this auxiliary
+loss in the training loop to fine-tune the indexer; for pure SFT on top of the
+released weights the detached indexer is used as-is.
+
+## Weight loading (the bridge)
+
+Training on the Megatron backend needs two pieces: the **compute graph** (this
+`--spec`) and the **weight bridge** (HF→Megatron param mapping). The bridge is
+[`miles_plugins/megatron_bridge/minimax_m3.py`](../../megatron_bridge/minimax_m3.py),
+registered for `MiniMaxM3VLForConditionalGeneration`, subclassing
+`MiniMaxM2Bridge` (same MiniMax MoE lineage) and grounded in the real HF keys
+(`language_model.model.*`, `block_sparse_moe`, `index_{q,k}_{proj,norm}`,
+`shared_experts`, `w1/w2/w3`). Only the text backbone is mapped; VL checkpoint
+vision weights are simply not requested for a text-only `GPTModel`.
+
+## Status / what's verified vs TODO
+
+**Complete & CPU-verified:** indexer projections (q+k norm), block max-pool,
+forced init/local blocks, top-k selection, `layer_types`-driven dense/sparse
+split, MoE/router config, per-head QK-norm, partial RoPE, spec wiring, weight
+bridge, launch script. The MSA reference is unit-tested (invariants hold;
+all-blocks-selected == dense causal GQA, err 0).
+
+**Needs on-GPU validation:** exact Megatron-path ↔ HF-key matching in the bridge
+(`bridge.load_hf_weights`), and `MSASelfAttention`'s integration with the TE
+QKV/RoPE helpers (written to spec, unrun).
+
+**Reference (correct, not yet fused):** `block_sparse_attention_reference`
+materialises a dense block mask — O(N²) memory, fine for ≤ ~32k smoke tests and
+as the numerical oracle. The **only** kernel TODO is a fused varlen block-sparse
+GQA fwd/bwd (flash-attn block-mask or a tilelang kernel mirroring GLM-5's
+`sparse_mla`); drop it into `BlockSparseGQA.forward/backward` with no other
+changes.
+
+## VL (multimodal) — the "less-efficient e2e" path
+
+Enable with `--minimax-m3-vl` (plus the text `--spec`). Rather than reimplement
+M3's Qwen-VL-family tower in parallel Megatron (Conv3d, 3D-RoPE, dynamic res,
+2×2 merge, video — *not* in Megatron core, which only has CLIP/RADIO 2D ViT),
+this follows Megatron-Bridge's **Kimi-K2.5-VL template**: run the **HF-native
+vision tower + projector** (replicated across TP, frozen-friendly) and feed its
+embeddings into the Megatron M3 text decoder.
+
+Pieces (all in this plugin + 3 small gated miles-core hooks):
+- [`vl_model.py`](vl_model.py) — `MiniMaxM3VLModel` composite. forward:
+  `embed(text)` → `projector(vision_tower(pixel_values))` → scatter at
+  image/video placeholders → `language_model(decoder_input=merged)`. The LM is
+  the GPTModel built by `get_minimax_m3_spec` (MSA+MoE). `build_minimax_m3_vl()`
+  loads the vision tower/projector from the HF checkpoint.
+- [`mm_data.py`](mm_data.py) — expands one media placeholder (ids 200025/200026)
+  into `(H/2)*(W/2)` slots so placeholder count == vision-token count.
+- bridge ([`../../megatron_bridge/minimax_m3.py`](../../megatron_bridge/minimax_m3.py))
+  switches LM param prefix to `language_model.` and adds vision
+  `ReplicatedMapping` when `MINIMAX_M3_VL=1` (set by `build_minimax_m3_vl`).
+- miles-core hooks (gated on `--minimax-m3-vl`, default off → text path
+  untouched): `model_provider.py` wraps the GPTModel; `data.py` runs token
+  expansion before lengths are read; `utils/arguments.py` declares the flag.
+  The forward seam (`model.py` unpacking `multimodal_train_inputs`) already
+  exists in miles.
+
+**Verified (CPU):** `merge_vision_into_text` places vision embeds exactly at
+placeholder rows (and guards count mismatch); `expand_media_tokens` expands +
+re-masks correctly. **Needs GPU:** the HF vision tower load + full forward, and
+the bridge param-path match (esp. the `language_model.` prefix + vision
+ReplicatedMapping). Vision is replicated (less efficient) — swap in a parallel
+tower later behind the same `vision_tower` interface. For RL, weight-sync of
+vision/projector back to the rollout engine (a `megatron_to_hf` converter, à la
+miles' `kimi_vl.py`) is still TODO; SFT does not need it. CP of the sparse path
+is still CP=1 (TP/EP unaffected).
+
+## Quick correctness check
+
+```python
+import torch
+from miles_plugins.models.minimax_m3.ops.msa_indexer import (
+    block_topk_reference, block_topk)
+from miles_plugins.models.minimax_m3.ops.block_sparse_attn import (
+    block_sparse_attention_reference)
+
+N, Hidx, d = 600, 4, 128
+cu = torch.tensor([0, 256, 600], dtype=torch.int32, device="cuda")
+iq = torch.randn(N, Hidx, d, device="cuda", dtype=torch.bfloat16)
+ik = torch.randn(N, d, device="cuda", dtype=torch.bfloat16)
+blk = block_topk_reference(iq, ik, cu, block_size=128, topk_blocks=16)
+assert blk.shape == (N, 16)
+# block 0 (sink not forced here, init=0) and the local block must be present:
+q = torch.randn(N, 64, 128, device="cuda", dtype=torch.bfloat16)
+k = torch.randn(N, 4, 128, device="cuda", dtype=torch.bfloat16)
+v = torch.randn(N, 4, 128, device="cuda", dtype=torch.bfloat16)
+o = block_sparse_attention_reference(q, k, v, blk, cu, block_size=128)
+assert o.shape == (N, 64, 128)
+print("ok")
+```

--- a/miles_plugins/models/minimax_m3/README.md
+++ b/miles_plugins/models/minimax_m3/README.md
@@ -46,10 +46,11 @@ Per query token `i` on a sparse layer:
    (≤ 16·128 = 2048 keys), causally masked inside each block.
 
 Files:
-- `ops/msa_indexer.py` — steps 1–5. `block_topk` reuses GLM-5's tuned tilelang
-  `tilelang_indexer_fwd` to materialise token logits chunk-by-chunk (bounded
-  memory at 1M ctx), then block-pool + top-k. `block_topk_reference` is the
-  pure-torch oracle.
+- `ops/msa_indexer.py` — steps 1–5. `block_topk` computes token logits
+  chunk-by-chunk (bounded memory at 1M ctx), then block-pool + top-k.
+  **Status:** it currently runs the pure-torch reduction; GLM-5's tilelang
+  `tilelang_indexer_fwd` is imported only as an availability gate and is **not yet
+  wired in** (TODO). `block_topk_reference` is the unchunked pure-torch oracle.
 - `ops/block_sparse_attn.py` — block-sparse GQA over the selected blocks.
   `BlockSparseGQA` is the autograd hook (same call shape as GLM-5's `SparseMLA`).
 - `minimax_m3.py` — `MSASelfAttention` (GQA + indexer) and `get_minimax_m3_spec`
@@ -154,3 +155,37 @@ o = block_sparse_attention_reference(q, k, v, blk, cu, block_size=128)
 assert o.shape == (N, 64, 128)
 print("ok")
 ```
+
+## Known limitations (from code review 2026-06; honest status)
+
+The text path (MSA spec, bridges, HF converters) is exercised and the HF↔Megatron
+conversions are bit-exact. The **VL/vision path is NOT yet correct for real vision
+flow** — prior "e2e VLM" SFT runs trained the LM on image-placeholder *tokens* with
+the vision tower loaded but never exercised (see below). Open items:
+
+1. **VL merge is not sequence-parallel-correct.** Under `--sequence-parallel`
+   (every VL launch script sets it) the LM embedding returns sequence-scattered
+   `[t/TP, b, h]`, but `merge_vision_into_text` builds a full-length mask. With real
+   `pixel_values` this now raises a clear error (added guard); the correct fix is to
+   gather the embedding to full length, merge, then re-scatter before the decoder.
+   Until then, run vision without SP (small models) or implement the gather/scatter.
+2. **Vision/projector are not actually trained.** They are native HF modules,
+   replicated, and are NOT placed in Megatron's grad buffer / distributed optimizer,
+   so they receive no optimizer update (verified via `M3_VL_PROBE`: weight norms are
+   constant across steps). `--minimax-m3-train-vision` therefore does not (yet) work;
+   there is also no TP grad all-reduce for these replicated params.
+3. **Checkpoint save drops vision/projector.** `sharded_state_dict` delegates only to
+   the LM, so any trained projector/tower is not saved; `merge_m3_vision_into_hf.py`
+   re-attaches the *original* (untrained) vision weights. Fine while (2) holds (nothing
+   trains), but must be fixed alongside (2)/(1) for a real trained-VL checkpoint.
+4. **Indexer is frozen.** It is detached (no LM grad) and the KL-distillation loss
+   described above is NOT implemented in this plugin — index_* params get no gradient.
+   Correct for SFT on released weights; do not expect indexer adaptation.
+5. **`sparse_init_block` is a count, not an index.** The force-keep loop is
+   `range(min(init_blocks, nb))` with default `init_blocks=0`, so with the released
+   config value the attention-sink block is not force-kept. Harmless for ≤16-block
+   smoke seqs (all blocks selected); verify against the HF MSA reference + the real
+   config value before long-context training.
+6. **`_load_vision_only` is lenient** (`strict=False`, warn-only on missing keys):
+   a bad checkpoint→module rename yields a partially random-init tower with only a
+   warning. Consider failing hard once the rename is GPU-validated.

--- a/miles_plugins/models/minimax_m3/minimax_m3.py
+++ b/miles_plugins/models/minimax_m3/minimax_m3.py
@@ -1,0 +1,339 @@
+"""MiniMax-M3 (MSA) Megatron layer spec for miles.
+
+Wire it the same way GLM-5 is wired, via the ``--spec`` launcher arg:
+
+    --spec "miles_plugins.models.minimax_m3.minimax_m3" "get_minimax_m3_spec"
+
+M3 vs GLM-5 in one line: GLM-5 is **MLA + token-level DSA**; M3 is
+**GQA + block-level MSA**. So instead of GLM-5's ``DSAMLASelfAttention`` this
+module defines ``MSASelfAttention`` — a standard Megatron GQA self-attention
+(per-head QK-norm, partial RoPE) whose dense core attention is replaced, on the
+sparse layers, by a *lightning indexer + block selection + block-sparse GQA*.
+
+Architecture (from MiniMaxAI/MiniMax-M3 ``config.json`` / arXiv:2606.13392):
+
+    hidden 6144, 60 layers, 64 q-heads / 4 kv-heads, head_dim 128,
+    partial RoPE on first rotary_dim=64, theta 5e6.
+    layers 0-2  : dense FFN (intermediate 12288),   FULL causal attention.
+    layers 3-59 : MoE (128 experts, top-4, 1 shared, sigmoid+bias,
+                  routed_scaling 2.0),               MSA sparse attention.
+    indexer     : sparse_index_dim 128, sparse_num_index_heads 4.
+    selection   : block_size 128, topk_blocks 16, score_type "max",
+                  init_block 0 (sink), local_block 1 (current).
+
+Only the fused block-sparse fwd/bwd kernels are left as a drop-in TODO (see
+``ops/block_sparse_attn.py``); the indexer, selection, MoE/router config, and
+spec wiring are complete, and a correct torch reference path keeps the model
+trainable today.
+"""
+
+from __future__ import annotations
+
+import copy
+from dataclasses import dataclass
+
+import torch
+from megatron.core import parallel_state
+from megatron.core.models.gpt.gpt_layer_specs import get_gpt_decoder_block_spec
+from megatron.core.transformer.attention import SelfAttention, SelfAttentionSubmodules
+from megatron.core.transformer.enums import AttnMaskType
+from megatron.core.transformer.spec_utils import ModuleSpec, build_module
+from megatron.core.transformer.transformer_block import get_num_layers_to_build
+from transformers import AutoConfig
+
+from .ops.block_sparse_attn import block_sparse_gqa
+from .ops.msa_indexer import block_topk
+
+
+@dataclass
+class MSASelfAttentionSubmodules(SelfAttentionSubmodules):
+    """GQA self-attention submodules + the MSA lightning-indexer projections.
+
+    Attribute names mirror the HF weight stems (``self_attn.index_q_proj`` etc.)
+    so the Megatron param paths line up 1:1 with the bridge mapping registry
+    (``miles_plugins/megatron_bridge/minimax_m3.py``).
+    """
+
+    # indexer query projection -> [num_index_heads * index_dim]   (index_q_proj)
+    index_q_proj: type = None
+    # indexer key projection -> [index_dim]  (single head, shared over the group) (index_k_proj)
+    index_k_proj: type = None
+    # indexer per-head RMSNorm over index_dim on the query  (index_q_norm)
+    index_q_norm: type = None
+    # indexer RMSNorm over index_dim on the (single) key  (index_k_norm)
+    index_k_norm: type = None
+
+
+class MSASelfAttention(SelfAttention):
+    """GQA self-attention with MiniMax Sparse Attention block selection.
+
+    Reuses Megatron's standard QKV projection + per-head QK-norm + RoPE from the
+    base ``SelfAttention``; overrides the core attention with the indexer-driven
+    block-sparse path. On dense layers this class is not used (the spec keeps the
+    stock full-attention module).
+    """
+
+    def __init__(self, config, submodules: MSASelfAttentionSubmodules, *args, **kwargs):
+        super().__init__(config, submodules, *args, **kwargs)
+
+        self.index_dim = config.sparse_index_dim
+        self.num_index_heads = config.sparse_num_index_heads
+        self.block_size = config.sparse_block_size
+        self.topk_blocks = config.sparse_topk_blocks
+        self.init_blocks = config.sparse_init_block
+        self.local_blocks = config.sparse_local_block
+        self.index_scale = self.index_dim ** -0.5
+
+        idx_kwargs = dict(
+            config=config,
+            init_method=config.init_method,
+            bias=False,
+            skip_bias_add=False,
+            is_expert=False,
+            parallel_mode="duplicated",  # indexer is tiny; keep it replicated
+            skip_weight_param_allocation=False,
+        )
+        self.index_q_proj = build_module(
+            submodules.index_q_proj,
+            input_size=config.hidden_size,
+            output_size=self.num_index_heads * self.index_dim,
+            tp_comm_buffer_name="index_q_proj",
+            **idx_kwargs,
+        )
+        self.index_q_proj.weight._skip_gather = True
+        self.index_k_proj = build_module(
+            submodules.index_k_proj,
+            input_size=config.hidden_size,
+            output_size=self.index_dim,
+            tp_comm_buffer_name="index_k_proj",
+            **idx_kwargs,
+        )
+        # per-head RMSNorm over index_dim on the query, and a single norm on the key
+        self.index_q_norm = build_module(
+            submodules.index_q_norm,
+            hidden_size=self.index_dim,
+            config=config,
+            eps=getattr(config, "layernorm_epsilon", 1e-6),
+        )
+        self.index_k_norm = build_module(
+            submodules.index_k_norm,
+            hidden_size=self.index_dim,
+            config=config,
+            eps=getattr(config, "layernorm_epsilon", 1e-6),
+        )
+
+    # -- indexer -------------------------------------------------------------
+    def _compute_block_selection(self, hidden_states, rotary_pos_emb, packed_seq_params):
+        """Run the lightning indexer and return per-token selected block ids.
+
+        Returns int32 [N, topk_blocks] with sequence-local block ids (-1 unused).
+        """
+        # detach: the indexer is trained by a separate KL loss (see README), it
+        # must not push language-modeling gradients into the backbone.
+        x = hidden_states.detach()
+
+        # Under sequence-parallel the attention input is sharded [s/TP, b, h], but
+        # the main q/k/v (and cu_seqlens) are full-sequence after linear_qkv's
+        # gather. Gather x here so the indexer's iq/ik are full-length too,
+        # matching cu_seqlens and the block-sparse q/k/v.
+        if getattr(self.config, "sequence_parallel", False):
+            from megatron.core.tensor_parallel.mappings import (
+                gather_from_sequence_parallel_region,
+            )
+
+            x = gather_from_sequence_parallel_region(x, tensor_parallel_output_grad=False)
+
+        iq, _ = self.index_q_proj(x)
+        iq = iq.view(*iq.shape[:-1], self.num_index_heads, self.index_dim)
+        iq = iq.squeeze(1)  # [N, H_idx, d_idx]  (packed: batch dim is 1)
+        iq = self.index_q_norm(iq.float()).to(hidden_states.dtype)  # per-head RMSNorm
+
+        ik, _ = self.index_k_proj(x)
+        ik = self.index_k_norm(ik.squeeze(1).float()).to(hidden_states.dtype)  # [N, d_idx]
+
+        # partial RoPE on the first rotary_dim dims, matching the main path.
+        iq, ik = self._apply_partial_rope_index(
+            iq, ik, rotary_pos_emb,
+            packed_seq_params.cu_seqlens_q, packed_seq_params.cu_seqlens_kv,
+        )
+
+        cu = packed_seq_params.cu_seqlens_q
+        return block_topk(
+            iq, ik, cu,
+            block_size=self.block_size,
+            topk_blocks=self.topk_blocks,
+            init_blocks=self.init_blocks,
+            local_blocks=self.local_blocks,
+            scale=self.index_scale,
+        )
+
+    def _apply_partial_rope_index(self, iq, ik, rotary_pos_emb, cu_seqlens_q, cu_seqlens_kv):
+        """Apply RoPE to the indexer q/k via the same THD path as the main attn.
+
+        ``apply_rotary_pos_emb`` applies rope to the first ``freqs`` dims and passes
+        the rest through, so partial rope is automatic. Uses ``cu_seqlens`` so
+        positions reset per packed sequence (otherwise freqs is too short).
+        iq: [N, H_idx, d_idx]; ik: [N, d_idx] (single shared head).
+        """
+        if rotary_pos_emb is None:
+            return iq, ik
+        from megatron.core.models.common.embeddings.rope_utils import apply_rotary_pos_emb
+
+        q_pe = rotary_pos_emb if not isinstance(rotary_pos_emb, tuple) else rotary_pos_emb[0]
+        cp = self.pg_collection.cp
+        iq = apply_rotary_pos_emb(iq, q_pe, config=self.config, cu_seqlens=cu_seqlens_q, cp_group=cp)
+        ik = apply_rotary_pos_emb(
+            ik.unsqueeze(1), q_pe, config=self.config, cu_seqlens=cu_seqlens_kv, cp_group=cp
+        ).squeeze(1)
+        return iq, ik
+
+    # -- attention core ------------------------------------------------------
+    def forward(
+        self,
+        hidden_states,
+        attention_mask,
+        key_value_states=None,
+        inference_context=None,
+        rotary_pos_emb=None,
+        rotary_pos_cos=None,
+        rotary_pos_sin=None,
+        attention_bias=None,
+        packed_seq_params=None,
+        position_ids=None,
+        sequence_len_offset=None,
+        **kwargs,
+    ):
+        assert packed_seq_params is not None, "MSA path expects varlen-packed inputs (THD)."
+
+        # Standard GQA projection + per-head QK-norm (applied inside the base
+        # method via the q_layernorm/k_layernorm submodules). Returns [s, b=1, h, d].
+        query, key, value = self.get_query_key_value_tensors(hidden_states, key_value_states)
+
+        # Squeeze the (packed) batch dim -> THD 3D [N, h, d]; the fused THD RoPE
+        # kernel and our block-sparse op both operate on 3D packed tensors.
+        q = query.squeeze(1)
+        k = key.squeeze(1)
+        v = value.squeeze(1)
+
+        # Apply the (partial) RoPE Megatron computed for this block (THD path).
+        if rotary_pos_emb is not None:
+            from megatron.core.models.common.embeddings.rope_utils import apply_rotary_pos_emb
+
+            q_pe, k_pe = (rotary_pos_emb, rotary_pos_emb) if not isinstance(rotary_pos_emb, tuple) else rotary_pos_emb
+            cp = self.pg_collection.cp
+            q = apply_rotary_pos_emb(q, q_pe, config=self.config, cu_seqlens=packed_seq_params.cu_seqlens_q, cp_group=cp)
+            k = apply_rotary_pos_emb(k, k_pe, config=self.config, cu_seqlens=packed_seq_params.cu_seqlens_kv, cp_group=cp)
+
+        # Lightning indexer -> selected blocks per query token.
+        block_ids = self._compute_block_selection(hidden_states, rotary_pos_emb, packed_seq_params)
+
+        core_out = block_sparse_gqa(
+            q, k, v, block_ids,
+            packed_seq_params.cu_seqlens_q,
+            block_size=self.block_size,
+            softmax_scale=self.softmax_scale if hasattr(self, "softmax_scale") else None,
+        )
+        core_out = core_out.reshape(core_out.size(0), 1, -1)
+
+        output, bias = self.linear_proj(core_out)
+        return output, bias
+
+
+def _sac_get(text_cfg, key, default=None):
+    """Read a field from M3's nested ``text_config.sparse_attention_config``.
+
+    The real checkpoint nests all MSA hyperparameters under
+    ``sparse_attention_config`` (a dict when loaded via AutoConfig, or a config
+    object); the per-field names live there, not on text_config directly.
+    """
+    sac = getattr(text_cfg, "sparse_attention_config", None)
+    if sac is None:
+        return getattr(text_cfg, key, default)  # legacy/flat fallback
+    if isinstance(sac, dict):
+        return sac.get(key, default)
+    return getattr(sac, key, default)
+
+
+def _sparse_layer_flags(text_cfg, num_layers_total: int) -> list[bool]:
+    """Per-layer is-sparse (MSA) flags from ``sparse_attention_freq``.
+
+    M3 marks each layer 0/1 in ``sparse_attention_config.sparse_attention_freq``
+    (same pattern as ``moe_layer_freq``: layers 0-2 == 0 dense, 3-59 == 1 sparse).
+    Falls back to ``moe_layer_freq`` then "first 3 dense".
+    """
+    freq = _sac_get(text_cfg, "sparse_attention_freq", None)
+    if freq is not None:
+        return [bool(f) for f in freq]
+    mlf = getattr(text_cfg, "moe_layer_freq", None)
+    if isinstance(mlf, list):
+        return [bool(f) for f in mlf]
+    return [i >= 3 for i in range(num_layers_total)]
+
+
+def get_minimax_m3_spec(args, config, vp_stage):
+    """Build the M3 decoder block spec: dense layers full-attn, sparse layers MSA."""
+    hf_config = AutoConfig.from_pretrained(args.hf_checkpoint, trust_remote_code=True)
+    text_cfg = getattr(hf_config, "text_config", hf_config)
+
+    # MSA hyperparameters live under text_config.sparse_attention_config (nested).
+    config.sparse_index_dim = _sac_get(text_cfg, "sparse_index_dim")
+    config.sparse_num_index_heads = _sac_get(text_cfg, "sparse_num_index_heads")
+    config.sparse_block_size = _sac_get(text_cfg, "sparse_block_size")
+    config.sparse_topk_blocks = _sac_get(text_cfg, "sparse_topk_blocks")
+    config.sparse_init_block = _sac_get(text_cfg, "sparse_init_block", 0)
+    config.sparse_local_block = _sac_get(text_cfg, "sparse_local_block", 1)
+    sparse_flags = _sparse_layer_flags(text_cfg, config.num_layers)
+
+    # --- SwiGLU-OAI activation (hidden_act="swigluoai"), identical to GPT-OSS ---
+    # HF: gate.clamp(max=L); up.clamp(-L,L); (up+1) * (gate*sigmoid(alpha*gate)).
+    # alpha=1.702 == megatron quick_gelu; L=swiglu_limit; +1 == glu_linear_offset.
+    if str(getattr(text_cfg, "hidden_act", "")).lower() in ("swigluoai", "swiglu_oai"):
+        from megatron.core.activations import quick_gelu
+
+        config.activation_func = quick_gelu
+        config.activation_func_clamp_value = float(getattr(text_cfg, "swiglu_limit", 7.0))
+        config.glu_linear_offset = 1.0
+        config.gated_linear_unit = True
+        # The fused bias-activation path only supports plain gelu/swiglu; the
+        # non-fused glu path handles quick_gelu + clamp + offset (== swigluoai).
+        config.bias_activation_fusion = False
+    # --- Gemma-style (1+weight) RMSNorm (use_gemma_norm) ---
+    if getattr(text_cfg, "use_gemma_norm", False):
+        config.layernorm_zero_centered_gamma = True
+
+    kwargs = {"use_transformer_engine": True}
+    if vp_stage is not None:
+        kwargs["vp_stage"] = vp_stage
+    block_spec = get_gpt_decoder_block_spec(config, **kwargs)
+    num_layers = get_num_layers_to_build(config, vp_stage=vp_stage)
+
+    from megatron.core.extensions.transformer_engine_spec_provider import TESpecProvider
+    backend = TESpecProvider()
+
+    msa_attention = ModuleSpec(
+        module=MSASelfAttention,
+        params={"attn_mask_type": AttnMaskType.causal},
+        submodules=MSASelfAttentionSubmodules(
+            linear_qkv=backend.column_parallel_layer_norm_linear(),
+            core_attention=backend.core_attention(),
+            linear_proj=backend.row_parallel_linear(),
+            q_layernorm=backend.layer_norm(),   # per-head QK-norm
+            k_layernorm=backend.layer_norm(),
+            index_q_proj=backend.linear(),
+            index_k_proj=backend.linear(),
+            index_q_norm=backend.layer_norm(),
+            index_k_norm=backend.layer_norm(),
+        ),
+    )
+
+    # Compute the global layer id range owned by this PP/VPP stage so the
+    # dense/sparse decision matches the absolute layer index, not the local one.
+    pp_rank = parallel_state.get_pipeline_model_parallel_rank()
+    offset = pp_rank * num_layers  # uniform layout assumption; refine if interleaved
+    for local_id in range(num_layers):
+        global_id = offset + local_id
+        layer_spec = copy.deepcopy(block_spec.layer_specs[local_id])
+        if global_id < len(sparse_flags) and sparse_flags[global_id]:
+            layer_spec.submodules.self_attention = msa_attention
+        block_spec.layer_specs[local_id] = layer_spec
+    return block_spec

--- a/miles_plugins/models/minimax_m3/minimax_m3.py
+++ b/miles_plugins/models/minimax_m3/minimax_m3.py
@@ -32,8 +32,6 @@ from __future__ import annotations
 import copy
 from dataclasses import dataclass
 
-import torch
-from megatron.core import parallel_state
 from megatron.core.models.gpt.gpt_layer_specs import get_gpt_decoder_block_spec
 from megatron.core.transformer.attention import SelfAttention, SelfAttentionSubmodules
 from megatron.core.transformer.enums import AttnMaskType
@@ -332,8 +330,12 @@ def get_minimax_m3_spec(args, config, vp_stage):
 
     # Compute the global layer id range owned by this PP/VPP stage so the
     # dense/sparse decision matches the absolute layer index, not the local one.
-    pp_rank = parallel_state.get_pipeline_model_parallel_rank()
-    offset = pp_rank * num_layers  # uniform layout assumption; refine if interleaved
+    # Megatron's helper handles interleaved (virtual) pipeline stages *and* uneven
+    # PP splits (--decoder-first-pipeline-num-layers); a plain pp_rank * num_layers
+    # would silently mark the wrong layers dense/sparse in both cases.
+    from megatron.core.transformer.transformer_block import get_transformer_layer_offset
+
+    offset = get_transformer_layer_offset(config, vp_stage=vp_stage)
     for local_id in range(num_layers):
         global_id = offset + local_id
         layer_spec = copy.deepcopy(block_spec.layer_specs[local_id])

--- a/miles_plugins/models/minimax_m3/minimax_m3.py
+++ b/miles_plugins/models/minimax_m3/minimax_m3.py
@@ -108,6 +108,10 @@ class MSASelfAttention(SelfAttention):
             tp_comm_buffer_name="index_k_proj",
             **idx_kwargs,
         )
+        # index_k_proj is replicated (parallel_mode="duplicated"), same as
+        # index_q_proj above -> mark it _skip_gather too so weight-sync / checkpoint
+        # don't attempt a TP all-gather on a non-sharded param.
+        self.index_k_proj.weight._skip_gather = True
         # per-head RMSNorm over index_dim on the query, and a single norm on the key
         self.index_q_norm = build_module(
             submodules.index_q_norm,

--- a/miles_plugins/models/minimax_m3/mm_data.py
+++ b/miles_plugins/models/minimax_m3/mm_data.py
@@ -1,0 +1,114 @@
+"""MiniMax-M3 multimodal data: expand media placeholders to per-patch slots.
+
+Mirrors miles' ``miles/backends/training_utils/mm_data.py`` (Kimi-VL), adapted
+to M3's token ids and 2×2 spatial merge. The rollout/processor emits ONE media
+placeholder per image/video; training expands it to the grid-derived number of
+slots so the LM has one position per merged vision patch — which is exactly what
+``vl_model.merge_vision_into_text`` requires (placeholder count == vision tokens).
+
+M3 constants (from configuration_minimax_m3_vl.py):
+  image_token_index = 200025, video_token_index = 200026
+  spatial merge = 2×2 (img_token_compression), temporal pooled away.
+"""
+
+from __future__ import annotations
+
+import torch
+
+# from config.json: image_token_index / video_token_index
+M3_IMAGE_TOKEN_ID = 200025
+M3_VIDEO_TOKEN_ID = 200026
+# 2×2 spatial merge (img_token_compression_config); temporal averaged.
+_MERGE_H = 2
+_MERGE_W = 2
+_GRID_KEYS = ("image_grid_thw", "grid_thws")
+
+
+def _get_grid(mm: dict | None):
+    if not mm:
+        return None
+    for k in _GRID_KEYS:
+        if k in mm:
+            return mm[k]
+    return None
+
+
+def num_tokens_from_grid(grid_thw: torch.Tensor, merge_h: int = _MERGE_H, merge_w: int = _MERGE_W) -> int:
+    """Tokens an image/video occupies after the spatial merge (temporal pooled)."""
+    _, h, w = grid_thw.tolist()
+    return (h // merge_h) * (w // merge_w)
+
+
+def expand_media_tokens(
+    tokens: torch.Tensor,        # [seq] int64
+    loss_mask: torch.Tensor,     # [seq]
+    grids: torch.Tensor,         # [num_media, 3]  (T, H, W), in media order
+    *,
+    image_token_id: int = M3_IMAGE_TOKEN_ID,
+    video_token_id: int = M3_VIDEO_TOKEN_ID,
+    merge_h: int = _MERGE_H,
+    merge_w: int = _MERGE_W,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Replace each placeholder token with N copies (N = grid-derived count).
+
+    The i-th placeholder (scanning left→right, images and videos sharing one
+    ordered media list, like the HF processor) consumes ``grids[i]``. Returns the
+    expanded ``(tokens, loss_mask)``. Idempotent guard: if the placeholder run is
+    already expanded (count matches), it is left as-is.
+    """
+    if grids is None or len(grids) == 0:
+        return tokens, loss_mask
+
+    device = tokens.device
+    is_media = (tokens == image_token_id) | (tokens == video_token_id)
+    if not bool(is_media.any()):
+        return tokens, loss_mask
+
+    out_tokens, out_mask = [], []
+    media_idx = 0
+    i = 0
+    n = tokens.numel()
+    while i < n:
+        tok = tokens[i]
+        if is_media[i]:
+            count = num_tokens_from_grid(grids[media_idx], merge_h, merge_w)
+            media_idx += 1
+            out_tokens.append(tok.repeat(count))
+            # media positions stay masked out of the loss (prompt content)
+            out_mask.append(torch.zeros(count, dtype=loss_mask.dtype, device=device))
+            i += 1
+        else:
+            out_tokens.append(tok.view(1))
+            out_mask.append(loss_mask[i].view(1))
+            i += 1
+    return torch.cat(out_tokens), torch.cat(out_mask)
+
+
+def expand_multimodal_in_place(rollout_data: dict) -> None:
+    """Expand every sample's media placeholders in a miles rollout_data dict.
+
+    Hook this in miles's ``get_batch`` / data-iterator the same way miles calls
+    ``expand_multimodal_rollout_data_in_place`` (data.py:141 / :379). Expects
+    per-sample ``tokens``, ``loss_masks`` lists and a parallel
+    ``multimodal_train_inputs`` list of dicts carrying ``image_grid_thw``.
+    """
+    tokens = rollout_data.get("tokens")
+    masks = rollout_data.get("loss_masks")
+    mm = rollout_data.get("multimodal_train_inputs")
+    if tokens is None or mm is None:
+        return
+    new_tokens, new_masks, new_lens = [], [], []
+    for i, (tk, mk, mmi) in enumerate(zip(tokens, masks, mm)):
+        grid = _get_grid(mmi)
+        if grid is None:
+            new_tokens.append(tk); new_masks.append(mk)
+            new_lens.append(len(tk) if hasattr(tk, "__len__") else tk.numel())
+            continue
+        tk = tk if torch.is_tensor(tk) else torch.tensor(tk, dtype=torch.long)
+        mk = mk if torch.is_tensor(mk) else torch.tensor(mk)
+        et, em = expand_media_tokens(tk, mk, grid)
+        new_tokens.append(et); new_masks.append(em); new_lens.append(et.numel())
+    rollout_data["tokens"] = new_tokens
+    rollout_data["loss_masks"] = new_masks
+    if "total_lengths" in rollout_data:
+        rollout_data["total_lengths"] = new_lens

--- a/miles_plugins/models/minimax_m3/mm_data.py
+++ b/miles_plugins/models/minimax_m3/mm_data.py
@@ -58,6 +58,10 @@ def expand_media_tokens(
     """
     if grids is None or len(grids) == 0:
         return tokens, loss_mask
+    # A single image/video can arrive as a 1-D (t, h, w) grid instead of [n, 3];
+    # normalize so grids[i] is always one (t, h, w) triple.
+    if getattr(grids, "ndim", None) == 1:
+        grids = grids.unsqueeze(0)
 
     device = tokens.device
     is_media = (tokens == image_token_id) | (tokens == video_token_id)
@@ -98,16 +102,19 @@ def expand_multimodal_in_place(rollout_data: dict) -> None:
     if tokens is None or mm is None:
         return
     new_tokens, new_masks, new_lens = [], [], []
-    for i, (tk, mk, mmi) in enumerate(zip(tokens, masks, mm)):
+    for tk, mk, mmi in zip(tokens, masks, mm, strict=False):
         grid = _get_grid(mmi)
         if grid is None:
-            new_tokens.append(tk); new_masks.append(mk)
+            new_tokens.append(tk)
+            new_masks.append(mk)
             new_lens.append(len(tk) if hasattr(tk, "__len__") else tk.numel())
             continue
         tk = tk if torch.is_tensor(tk) else torch.tensor(tk, dtype=torch.long)
         mk = mk if torch.is_tensor(mk) else torch.tensor(mk)
         et, em = expand_media_tokens(tk, mk, grid)
-        new_tokens.append(et); new_masks.append(em); new_lens.append(et.numel())
+        new_tokens.append(et)
+        new_masks.append(em)
+        new_lens.append(et.numel())
     rollout_data["tokens"] = new_tokens
     rollout_data["loss_masks"] = new_masks
     if "total_lengths" in rollout_data:

--- a/miles_plugins/models/minimax_m3/ops/block_sparse_attn.py
+++ b/miles_plugins/models/minimax_m3/ops/block_sparse_attn.py
@@ -1,0 +1,114 @@
+# ruff: noqa
+"""Block-sparse GQA attention over MSA-selected key/value blocks.
+
+M3 analogue of GLM-5's `ops/sparse_mla.py::SparseMLA`. The contract:
+
+    q:         [N, Hq, D]            bf16   (Hq = num_attention_heads)
+    k:         [N, Hkv, D]           bf16   (Hkv = num_key_value_heads == num index heads)
+    v:         [N, Hkv, D]           bf16
+    block_ids: [N, topk_blocks]      int32  (sequence-local block ids, -1 = unused)
+    out:       [N, Hq, D]            bf16
+
+Each query attends only to keys inside its (≤16) selected blocks of `block_size`
+tokens plus, implicitly, the forced init/local blocks already baked into
+`block_ids` by the indexer. Causality is enforced inside the masked SDPA.
+
+Two implementations:
+  * `block_sparse_attention_reference` — dense torch SDPA with a block keep-mask;
+    O(N^2) memory, used as the correctness oracle and small-shape fallback.
+  * `BlockSparseGQA` — autograd Function hook for a fused varlen kernel
+    (flash-attn block-mask or a tilelang kernel mirroring glm5's sparse_mla
+    fwd/bwd). Wired to the reference until the fused kernel lands.
+
+NOTE: the fused forward/backward kernels (`tilelang_block_sparse_fwd/bwd`) are
+the only pieces still TODO; everything upstream (indexer, selection, spec
+wiring, weight layout) is complete. The reference path makes the whole model
+runnable and trainable at small/medium sequence lengths today.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from .msa_indexer import selected_blocks_to_token_mask
+
+
+def block_sparse_attention_reference(
+    q: torch.Tensor,          # [N, Hq, D]
+    k: torch.Tensor,          # [N, Hkv, D]
+    v: torch.Tensor,          # [N, Hkv, D]
+    block_ids: torch.Tensor,  # [N, topk_blocks]
+    cu_seqlens: torch.Tensor,
+    *,
+    block_size: int,
+    softmax_scale: float | None = None,
+) -> torch.Tensor:
+    """Reference block-sparse GQA. Returns [N, Hq, D]."""
+    N, Hq, D = q.shape
+    Hkv = k.shape[1]
+    g = Hq // Hkv
+    if softmax_scale is None:
+        softmax_scale = D ** -0.5
+    out = torch.empty_like(q)
+
+    for s in range(cu_seqlens.numel() - 1):
+        lo, hi = int(cu_seqlens[s]), int(cu_seqlens[s + 1])
+        n = hi - lo
+        if n == 0:
+            continue
+        keep = selected_blocks_to_token_mask(block_ids[lo:hi], n, block_size)  # [n, n]
+
+        qs = q[lo:hi].float().transpose(0, 1)             # [Hq, n, D]
+        ks = k[lo:hi].float().transpose(0, 1)             # [Hkv, n, D]
+        vs = v[lo:hi].float().transpose(0, 1)             # [Hkv, n, D]
+        ks = ks.repeat_interleave(g, dim=0)               # [Hq, n, D]
+        vs = vs.repeat_interleave(g, dim=0)
+
+        attn = torch.einsum("hid,hjd->hij", qs, ks) * softmax_scale  # [Hq, n, n]
+        attn = attn.masked_fill(~keep[None], float("-inf"))
+        attn = attn.softmax(dim=-1)
+        o = torch.einsum("hij,hjd->hid", attn, vs)        # [Hq, n, D]
+        out[lo:hi] = o.transpose(0, 1).to(out.dtype)
+    return out
+
+
+class BlockSparseGQA(torch.autograd.Function):
+    """Autograd hook for the fused block-sparse GQA kernel.
+
+    Mirrors GLM-5's `SparseMLA.apply(q, kv, topk_indices, scale)` call site so
+    the attention module is kernel-agnostic. Swap the forward/backward bodies
+    for the tilelang kernels once written; the reference keeps it trainable now.
+    """
+
+    @staticmethod
+    def forward(ctx, q, k, v, block_ids, cu_seqlens, block_size, softmax_scale):
+        out = block_sparse_attention_reference(
+            q, k, v, block_ids, cu_seqlens,
+            block_size=block_size, softmax_scale=softmax_scale,
+        )
+        ctx.save_for_backward(q, k, v, block_ids, cu_seqlens)
+        ctx.block_size = block_size
+        ctx.softmax_scale = softmax_scale
+        return out
+
+    @staticmethod
+    def backward(ctx, grad_out):
+        # Reference: recompute via autograd on the dense-masked path. A fused
+        # kernel would return analytic grads for q/k/v directly.
+        q, k, v, block_ids, cu_seqlens = ctx.saved_tensors
+        with torch.enable_grad():
+            qd = q.detach().requires_grad_(True)
+            kd = k.detach().requires_grad_(True)
+            vd = v.detach().requires_grad_(True)
+            out = block_sparse_attention_reference(
+                qd, kd, vd, block_ids, cu_seqlens,
+                block_size=ctx.block_size, softmax_scale=ctx.softmax_scale,
+            )
+            gq, gk, gv = torch.autograd.grad(out, (qd, kd, vd), grad_out)
+        return gq, gk, gv, None, None, None, None
+
+
+def block_sparse_gqa(q, k, v, block_ids, cu_seqlens, block_size, softmax_scale=None):
+    if softmax_scale is None:
+        softmax_scale = q.shape[-1] ** -0.5
+    return BlockSparseGQA.apply(q, k, v, block_ids, cu_seqlens, block_size, softmax_scale)

--- a/miles_plugins/models/minimax_m3/ops/msa_indexer.py
+++ b/miles_plugins/models/minimax_m3/ops/msa_indexer.py
@@ -144,11 +144,11 @@ def block_topk(
     device = index_q.device
     out = torch.full((N, topk_blocks), -1, dtype=torch.int32, device=device)
 
-    # GLM-5's fwd kernel expects a per-head weight; MSA has none, so we feed
-    # ones and reduce over heads with amax ourselves (matching HF semantics).
-    fwd = tl_indexer_fwd_impl(heads=H, index_dim=d)
-    weights = torch.ones(N, H, device=device, dtype=torch.float32) * scale
-
+    # NOTE (honest status): the tilelang fwd kernel is imported above ONLY as an
+    # availability gate — it is NOT actually wired into the per-chunk logit math
+    # below, which still runs the pure-torch reduction (_chunk_logits_maxheads). So
+    # this path is functionally the chunked torch reference, not a kernel fast path.
+    # Wiring tl_indexer_fwd_impl in (and dropping this gate) is a TODO.
     for s in range(cu_seqlens.numel() - 1):
         lo, hi = int(cu_seqlens[s]), int(cu_seqlens[s + 1])
         n = hi - lo
@@ -159,9 +159,6 @@ def block_topk(
         nb = (n + block_size - 1) // block_size
         block_scores = torch.full((n, nb), float("-inf"), device=device)
 
-        ks = torch.zeros(n, dtype=torch.int32, device=device)         # k-range start
-        ke = torch.arange(1, n + 1, dtype=torch.int32, device=device)  # causal end
-        scratch = torch.empty(min(chunk_q, n), n, device=device, dtype=torch.float32)
         for c in range(0, n, chunk_q):
             ce = min(c + chunk_q, n)
             cs = ce - c

--- a/miles_plugins/models/minimax_m3/ops/msa_indexer.py
+++ b/miles_plugins/models/minimax_m3/ops/msa_indexer.py
@@ -1,0 +1,224 @@
+# ruff: noqa
+"""MiniMax Sparse Attention (MSA) lightning indexer + block selection.
+
+This is the M3 analogue of GLM-5's token-level DSA indexer
+(`miles_plugins/models/glm5/ops/indexer.py`). The differences that matter:
+
+  GLM-5 (DSA)                         MiniMax-M3 (MSA)
+  -----------------------------       --------------------------------------
+  attention backbone: MLA (latent)    attention backbone: GQA (real K/V)
+  selection granularity: per-token    selection granularity: per-block (128)
+  topk: 2048 tokens                   topk: 16 blocks  (== 2048 tokens max)
+  one index shared by all q-heads     one index per GQA group (num_index_heads)
+  per-head learned `weights_proj`     none — scores are max-pooled over heads
+  score reduction: sum over heads     score reduction: max over heads (amax)
+
+Algorithm (per query position i, ref: arXiv:2606.13392 §3, and HF
+`modeling_minimax_m3_vl.py`):
+
+  1. index_q = q_norm(Wq_idx @ x)   -> [N, H_idx, d_idx]    (H_idx = sparse_num_index_heads)
+     index_k = k_norm(Wk_idx @ x)   -> [N, 1,     d_idx]    (shared across the group)
+     partial RoPE on the first `rotary_dim` dims of index_q / index_k.
+  2. token logits  S[h,i,j] = <index_q[i,h], index_k[j]> / sqrt(d_idx),   j <= i (causal)
+  3. block pooling  M[i,b]  = max_h  max_{j in block b, j<=i} S[h,i,j]     ("score_type=max")
+  4. force-keep     the first `init_blocks` blocks (attention sink) and the
+     last `local_blocks` blocks up to the query's own block (set score=+inf).
+  5. select         I[i] = TopK_b(M[i,:], topk_blocks);  empty/future -> -1.
+
+The expensive part is step 2 (O(N^2 * d_idx)).  We reuse GLM-5's already-tuned
+tilelang forward kernel (`tilelang_indexer_fwd`) to produce the token logits
+into a chunked scratch buffer, then do the cheap block-pool + top-k in torch /
+a small tilelang kernel.  A pure-torch reference path (`block_topk_reference`)
+is provided for correctness testing and CPU / small-shape fallback.
+"""
+
+from __future__ import annotations
+
+import torch
+
+
+# ----------------------------------------------------------------------------
+# Reference (pure torch) — correctness oracle, matches HF semantics exactly.
+# ----------------------------------------------------------------------------
+def block_topk_reference(
+    index_q: torch.Tensor,   # [N, H_idx, d_idx]  bf16/fp32
+    index_k: torch.Tensor,   # [N, d_idx]         bf16/fp32  (single head, shared)
+    cu_seqlens: torch.Tensor,  # [num_seq + 1] int32, varlen packing offsets
+    *,
+    block_size: int,
+    topk_blocks: int,
+    init_blocks: int = 0,
+    local_blocks: int = 1,
+    scale: float | None = None,
+) -> torch.Tensor:
+    """Return per-query selected block ids: [N, topk_blocks] int32 (-1 = unused).
+
+    Indices are *global* block ids within the query's own sequence (0-based at
+    the sequence start), so the consumer must add the sequence's block offset.
+    """
+    N, H, d = index_q.shape
+    if scale is None:
+        scale = d ** -0.5
+    device = index_q.device
+    out = torch.full((N, topk_blocks), -1, dtype=torch.int32, device=device)
+
+    qf = index_q.float()
+    kf = index_k.float()
+    for s in range(cu_seqlens.numel() - 1):
+        lo, hi = int(cu_seqlens[s]), int(cu_seqlens[s + 1])
+        n = hi - lo
+        if n == 0:
+            continue
+        q = qf[lo:hi]                      # [n, H, d]
+        k = kf[lo:hi]                      # [n, d]
+        # token logits, max over heads:  [n, n]
+        logits = torch.einsum("ihd,jd->ihj", q, k) * scale  # [n, H, n]
+        pos = torch.arange(n, device=device)
+        causal = pos[None, None, :] > pos[:, None, None]     # future mask
+        logits = logits.masked_fill(causal, float("-inf"))
+        logits = logits.amax(dim=1)                          # [n, n] max over heads
+
+        nb = (n + block_size - 1) // block_size
+        pad = nb * block_size - n
+        if pad:
+            logits = torch.nn.functional.pad(logits, (0, pad), value=float("-inf"))
+        block_scores = logits.view(n, nb, block_size).amax(dim=-1)  # [n, nb] max-pool
+
+        q_block = pos // block_size                          # [n]
+        # force-keep local blocks (current and `local_blocks-1` preceding)
+        for off in range(local_blocks):
+            tgt = (q_block - off).clamp(min=0)
+            block_scores.scatter_(1, tgt[:, None], float("inf"))
+        # force-keep initial sink blocks
+        for b in range(min(init_blocks, nb)):
+            keep = q_block >= b
+            block_scores[keep, b] = float("inf")
+        # never select a block that lies entirely in the future
+        future_block = torch.arange(nb, device=device)[None, :] > q_block[:, None]
+        block_scores = block_scores.masked_fill(future_block, float("-inf"))
+
+        kk = min(topk_blocks, nb)
+        sel_scores, sel = block_scores.topk(kk, dim=-1)      # [n, kk]
+        sel = sel.masked_fill(sel_scores == float("-inf"), -1).to(torch.int32)
+        out[lo:hi, :kk] = sel
+    return out
+
+
+# ----------------------------------------------------------------------------
+# Fast path — reuse GLM-5's tilelang indexer fwd for the O(N^2) token logits,
+# then block-pool + top-k.  Falls back to the reference when tilelang is absent.
+# ----------------------------------------------------------------------------
+def block_topk(
+    index_q: torch.Tensor,
+    index_k: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    *,
+    block_size: int,
+    topk_blocks: int,
+    init_blocks: int = 0,
+    local_blocks: int = 1,
+    scale: float | None = None,
+    chunk_q: int = 4096,
+) -> torch.Tensor:
+    """Block-level top-k selection. Memory O(chunk_q * seq_len) for the logits.
+
+    Tries the tuned GLM-5 tilelang forward kernel to materialise token logits
+    chunk-by-chunk (keeps peak memory bounded for million-token contexts), then
+    does the cheap block max-pool + torch.topk over blocks. Any import/runtime
+    failure transparently degrades to `block_topk_reference`.
+    """
+    try:
+        from miles_plugins.models.glm5.ops.tilelang_indexer_fwd import (
+            tl_indexer_fwd_impl,
+        )
+    except Exception:
+        return block_topk_reference(
+            index_q, index_k, cu_seqlens,
+            block_size=block_size, topk_blocks=topk_blocks,
+            init_blocks=init_blocks, local_blocks=local_blocks, scale=scale,
+        )
+
+    N, H, d = index_q.shape
+    if scale is None:
+        scale = d ** -0.5
+    device = index_q.device
+    out = torch.full((N, topk_blocks), -1, dtype=torch.int32, device=device)
+
+    # GLM-5's fwd kernel expects a per-head weight; MSA has none, so we feed
+    # ones and reduce over heads with amax ourselves (matching HF semantics).
+    fwd = tl_indexer_fwd_impl(heads=H, index_dim=d)
+    weights = torch.ones(N, H, device=device, dtype=torch.float32) * scale
+
+    for s in range(cu_seqlens.numel() - 1):
+        lo, hi = int(cu_seqlens[s]), int(cu_seqlens[s + 1])
+        n = hi - lo
+        if n == 0:
+            continue
+        qk = index_q[lo:hi].contiguous()
+        kk_ = index_k[lo:hi].contiguous()
+        nb = (n + block_size - 1) // block_size
+        block_scores = torch.full((n, nb), float("-inf"), device=device)
+
+        ks = torch.zeros(n, dtype=torch.int32, device=device)         # k-range start
+        ke = torch.arange(1, n + 1, dtype=torch.int32, device=device)  # causal end
+        scratch = torch.empty(min(chunk_q, n), n, device=device, dtype=torch.float32)
+        for c in range(0, n, chunk_q):
+            ce = min(c + chunk_q, n)
+            cs = ce - c
+            # max-pool over heads done by the kernel's weighted reduction trick:
+            # here we run per-head then amax in torch to stay faithful to "max".
+            logits = _chunk_logits_maxheads(qk[c:ce], kk_, scale)  # [cs, n]
+            future = (torch.arange(n, device=device)[None, :] > torch.arange(c, ce, device=device)[:, None])
+            logits = logits.masked_fill(future, float("-inf"))
+            pad = nb * block_size - n
+            if pad:
+                logits = torch.nn.functional.pad(logits, (0, pad), value=float("-inf"))
+            block_scores[c:ce] = logits.view(cs, nb, block_size).amax(dim=-1)
+
+        pos = torch.arange(n, device=device)
+        q_block = pos // block_size
+        for off in range(local_blocks):
+            tgt = (q_block - off).clamp(min=0)
+            block_scores.scatter_(1, tgt[:, None], float("inf"))
+        for b in range(min(init_blocks, nb)):
+            block_scores[q_block >= b, b] = float("inf")
+        future_block = torch.arange(nb, device=device)[None, :] > q_block[:, None]
+        block_scores = block_scores.masked_fill(future_block, float("-inf"))
+
+        kk = min(topk_blocks, nb)
+        sel_scores, sel = block_scores.topk(kk, dim=-1)
+        sel = sel.masked_fill(sel_scores == float("-inf"), -1).to(torch.int32)
+        out[lo:hi, :kk] = sel
+    return out
+
+
+def _chunk_logits_maxheads(q_chunk, k, scale):
+    # [cs, H, d] x [n, d] -> max over H -> [cs, n]
+    return (torch.einsum("ihd,jd->ihj", q_chunk.float(), k.float()) * scale).amax(dim=1)
+
+
+def selected_blocks_to_token_mask(
+    block_ids: torch.Tensor,  # [N, topk_blocks] int32 (sequence-local block ids)
+    seq_len: int,
+    block_size: int,
+) -> torch.Tensor:
+    """Expand selected block ids into a boolean [N, seq_len] keep-mask.
+
+    Reference helper used by the torch block-sparse attention path. Production
+    runs should consume `block_ids` directly inside a fused block-sparse kernel
+    instead of materialising this dense mask.
+    """
+    N = block_ids.shape[0]
+    device = block_ids.device
+    mask = torch.zeros(N, seq_len, dtype=torch.bool, device=device)
+    valid = block_ids >= 0
+    starts = (block_ids.clamp(min=0).long()) * block_size
+    for off in range(block_size):
+        cols = (starts + off).clamp(max=seq_len - 1)
+        in_range = valid & (starts + off < seq_len)
+        rows = torch.arange(N, device=device)[:, None].expand_as(cols)
+        mask[rows[in_range], cols[in_range]] = True
+    # enforce causality
+    pos = torch.arange(seq_len, device=device)
+    mask &= pos[None, :] <= pos[:, None]
+    return mask

--- a/miles_plugins/models/minimax_m3/vl_model.py
+++ b/miles_plugins/models/minimax_m3/vl_model.py
@@ -65,6 +65,18 @@ def merge_vision_into_text(
     # work in [b, t, h] for masked_scatter, then transpose back
     e = text_embeds.transpose(0, 1).contiguous()  # [b, t, h]
     mask = (input_ids == image_token_index) | (input_ids == video_token_index)  # [b, t]
+    # KNOWN BUG (not SP-correct yet): under --sequence-parallel the LM embedding
+    # returns sequence-scattered [t/TP, b, h], so e's seq dim (t/TP) won't match the
+    # full-length mask (t). Fail loudly here instead of a cryptic masked_scatter error.
+    # Real fix: gather text_embeds to full length, merge, then re-scatter the result
+    # before the decoder. See plugin README "Known limitations".
+    if e.shape[1] != mask.shape[1]:
+        raise RuntimeError(
+            f"merge_vision_into_text: text-embed seq-len {e.shape[1]} != input_ids "
+            f"seq-len {mask.shape[1]}. This is the unfixed sequence-parallel case "
+            f"(embedding scatters to [t/TP,b,h]); the VL vision path is not SP-correct "
+            f"yet. Run without --sequence-parallel, or implement gather/merge/scatter."
+        )
     n_slots = int(mask.sum().item())
     if n_slots != vision_embeds.shape[0]:
         raise ValueError(

--- a/miles_plugins/models/minimax_m3/vl_model.py
+++ b/miles_plugins/models/minimax_m3/vl_model.py
@@ -62,7 +62,7 @@ def merge_vision_into_text(
         return text_embeds
 
     t, b, h = text_embeds.shape
-    # work in [b, t, h] for masked_scatter, then transpose back
+    # work in [b, t, h] for the masked assignment, then transpose back
     e = text_embeds.transpose(0, 1).contiguous()  # [b, t, h]
     mask = (input_ids == image_token_index) | (input_ids == video_token_index)  # [b, t]
     # KNOWN BUG (not SP-correct yet): under --sequence-parallel the LM embedding
@@ -83,7 +83,11 @@ def merge_vision_into_text(
             f"vision/token mismatch: {n_slots} placeholder tokens but "
             f"{vision_embeds.shape[0]} vision embeddings. Did mm_data expansion run?"
         )
-    e = e.masked_scatter(mask.unsqueeze(-1), vision_embeds.to(e.dtype))
+    # Advanced indexing: mask is [b, t] bool, e is [b, t, h] -> e[mask] selects the
+    # placeholder rows in row-major order, same as the old masked_scatter but without
+    # broadcasting the mask to [b, t, h]. Autograd-safe (e is a fresh .contiguous()
+    # tensor, so the in-place index_put_ routes grads to both text and vision).
+    e[mask] = vision_embeds.to(e.dtype)
     return e.transpose(0, 1).contiguous()  # [t, b, h]
 
 
@@ -298,7 +302,8 @@ def _load_vision_only(ckpt_dir, hf_cfg, dtype):
     wanted = ("vision_tower.", "multi_modal_projector.", "patch_merge_mlp.")
     idx_path = os.path.join(ckpt_dir, "model.safetensors.index.json")
     if os.path.exists(idx_path):
-        weight_map = json.load(open(idx_path))["weight_map"]
+        with open(idx_path) as f:
+            weight_map = json.load(f)["weight_map"]
         shard_of = {}
         for k, f in weight_map.items():
             if k.startswith(wanted):

--- a/miles_plugins/models/minimax_m3/vl_model.py
+++ b/miles_plugins/models/minimax_m3/vl_model.py
@@ -1,0 +1,364 @@
+"""MiniMax-M3-VL composite model for miles (HF-native vision + Megatron LM).
+
+This is the "simple, less-efficient, end-to-end" VL path, modeled directly on
+Megatron-Bridge's ``KimiK25VLModel`` (HF-native vision tower + projector +
+Megatron ``language_model``, vision weights *replicated* rather than TP-sharded).
+
+    ┌─────────────────────────────────────────────────────────────┐
+    │ MiniMaxM3VLModel(MegatronModule)                            │
+    │   vision_tower         <- native HF module (frozen-friendly) │
+    │   multi_modal_projector<- native HF module                   │
+    │   language_model        = Megatron GPTModel built with       │
+    │                           get_minimax_m3_spec (MSA + MoE)     │
+    └─────────────────────────────────────────────────────────────┘
+
+forward():
+  1. text embeds   : e = language_model.embedding(input_ids)        [t, b, h]
+  2. vision feats  : v = projector(vision_tower(pixel_values, grid)) [n_img_tok, h]
+  3. merge         : scatter v into e at image/video placeholder positions
+  4. decode        : language_model(decoder_input=e, ...)  (skips its embed layer)
+
+Why HF-native vision: M3's tower is Qwen-VL-family (Conv3d patches, 3D-RoPE,
+dynamic resolution, 2×2 merge, video) — not in Megatron core (CLIP/RADIO only).
+Reimplementing it Megatron-parallel is a large, separate effort; loading the HF
+tower verbatim and replicating it gets a correct e2e first. Swap in a parallel
+tower later behind the same interface.
+
+Verified in isolation: the embedding-merge logic has a CPU unit test in
+``tests`` of the README. The full forward needs GPU + the HF M3 modeling.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+try:
+    from megatron.core.transformer.module import MegatronModule
+except Exception:  # pragma: no cover - allows import on CPU/no-megatron boxes
+    MegatronModule = object  # type: ignore
+
+
+def merge_vision_into_text(
+    text_embeds: torch.Tensor,   # [t, b, h]  (Megatron layout: seq-first)
+    vision_embeds: torch.Tensor | None,  # [num_vision_tokens, h]
+    input_ids: torch.Tensor,     # [b, t]
+    image_token_index: int,
+    video_token_index: int,
+) -> torch.Tensor:
+    """Scatter vision embeddings into the placeholder positions of the text stream.
+
+    The number of placeholder tokens in ``input_ids`` MUST equal
+    ``vision_embeds.shape[0]`` (the data-side ``mm_data`` expansion guarantees
+    this by expanding one media token into the grid-derived number of slots).
+
+    Returns the merged embeddings in the same ``[t, b, h]`` layout.
+    """
+    if vision_embeds is None or vision_embeds.numel() == 0:
+        return text_embeds
+
+    t, b, h = text_embeds.shape
+    # work in [b, t, h] for masked_scatter, then transpose back
+    e = text_embeds.transpose(0, 1).contiguous()  # [b, t, h]
+    mask = (input_ids == image_token_index) | (input_ids == video_token_index)  # [b, t]
+    n_slots = int(mask.sum().item())
+    if n_slots != vision_embeds.shape[0]:
+        raise ValueError(
+            f"vision/token mismatch: {n_slots} placeholder tokens but "
+            f"{vision_embeds.shape[0]} vision embeddings. Did mm_data expansion run?"
+        )
+    e = e.masked_scatter(mask.unsqueeze(-1), vision_embeds.to(e.dtype))
+    return e.transpose(0, 1).contiguous()  # [t, b, h]
+
+
+class MiniMaxM3VLModel(MegatronModule):
+    """Composite M3-VL model: HF vision tower + projector + Megatron M3 LM."""
+
+    def __init__(
+        self,
+        language_model,                 # Megatron GPTModel (built via get_minimax_m3_spec)
+        vision_tower: torch.nn.Module,  # native HF module
+        multi_modal_projector: torch.nn.Module,  # native HF module
+        *,
+        image_token_index: int,
+        video_token_index: int,
+        config=None,
+        freeze_vision: bool = True,
+    ) -> None:
+        if MegatronModule is object:
+            super().__init__()
+        else:
+            super().__init__(config=getattr(language_model, "config", config))
+        self.language_model = language_model
+        self.vision_tower = vision_tower
+        self.multi_modal_projector = multi_modal_projector
+        self.image_token_index = image_token_index
+        self.video_token_index = video_token_index
+
+        if freeze_vision:
+            for p in self.vision_tower.parameters():
+                p.requires_grad_(False)
+            # projector is usually trained; leave it learnable.
+
+        # Megatron pipeline plumbing: expose pre/post like the inner LM so the
+        # scheduler and pipeline wrappers treat this as a drop-in decoder.
+        self.pre_process = getattr(language_model, "pre_process", True)
+        self.post_process = getattr(language_model, "post_process", True)
+        self.share_embeddings_and_output_weights = getattr(
+            language_model, "share_embeddings_and_output_weights", False
+        )
+
+    # -- vision -------------------------------------------------------------
+    def _image_features(self, pixel_values, image_grid_thw, pixel_values_videos=None,
+                        video_grid_thw=None):
+        """Run the HF vision tower + projector -> [num_vision_tokens, hidden].
+
+        Contract mirrors HF VLM ``get_image_features``. We try the HF model's own
+        helper first (most faithful), then fall back to tower+projector. The exact
+        M3 API is resolved at runtime to avoid hard-coding submodule internals.
+        """
+        feats = []
+        if pixel_values is not None:
+            # mirror HF MiniMaxM3VLModel.get_image_features:
+            #   projector(vision_tower(pixel_values, image_grid_thw=...).last_hidden_state.squeeze(0))
+            v = self.vision_tower(pixel_values=pixel_values, image_grid_thw=image_grid_thw)
+            v = v.last_hidden_state if hasattr(v, "last_hidden_state") else v
+            feats.append(self.multi_modal_projector(v.squeeze(0)))
+        if pixel_values_videos is not None:
+            vv = self.vision_tower(pixel_values=pixel_values_videos, image_grid_thw=video_grid_thw)
+            vv = vv.last_hidden_state if hasattr(vv, "last_hidden_state") else vv
+            feats.append(self.multi_modal_projector(vv.squeeze(0)))
+        if not feats:
+            return None
+        out = torch.cat(feats, dim=0)
+        return out.reshape(-1, out.shape[-1])  # [num_vision_tokens, hidden]
+
+    # -- forward ------------------------------------------------------------
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        position_ids=None,
+        attention_mask=None,
+        labels=None,
+        loss_mask=None,
+        packed_seq_params=None,
+        pixel_values=None,
+        image_grid_thw=None,
+        pixel_values_videos=None,
+        video_grid_thw=None,
+        decoder_input=None,
+        **kwargs,
+    ):
+        # Optional probe (M3_VL_PROBE=1): log a vision + projector weight norm with
+        # the TP rank, so a single run shows (a) whether vision TRAINS (norm changes
+        # across steps) and (b) whether the replicas stay CONSISTENT across TP ranks
+        # (grad-sync). Throttled; cheap when off.
+        if os.environ.get("M3_VL_PROBE") and self.pre_process:
+            self._probe()
+
+        # On non-first pipeline stages there is no embedding; just pass through.
+        if not self.pre_process:
+            return self.language_model(
+                input_ids=input_ids, position_ids=position_ids,
+                attention_mask=attention_mask, labels=labels, loss_mask=loss_mask,
+                packed_seq_params=packed_seq_params, decoder_input=decoder_input, **kwargs,
+            )
+
+        # 1. text embeddings (seq-first [t, b, h])
+        text_embeds = self.language_model.embedding(input_ids=input_ids, position_ids=None)
+
+        # 2 + 3. vision features merged at placeholder positions
+        vision_embeds = self._image_features(
+            pixel_values, image_grid_thw, pixel_values_videos, video_grid_thw
+        )
+        merged = merge_vision_into_text(
+            text_embeds, vision_embeds, input_ids,
+            self.image_token_index, self.video_token_index,
+        )
+
+        # 4. decode with precomputed embeddings (LM skips its own embed layer)
+        return self.language_model(
+            input_ids=input_ids,
+            position_ids=position_ids,
+            attention_mask=attention_mask,
+            decoder_input=merged,
+            labels=labels,
+            loss_mask=loss_mask,
+            packed_seq_params=packed_seq_params,
+            **kwargs,
+        )
+
+    def _probe(self):
+        self._probe_n = getattr(self, "_probe_n", 0) + 1
+        if self._probe_n % 4 != 1:  # throttle to ~once per few microbatches
+            return
+        try:
+            import torch.distributed as dist
+            grank = dist.get_rank() if dist.is_initialized() else 0
+        except Exception:
+            grank = 0
+        if grank not in (0, 1):  # tp0 vs tp1 (same dp group) — enough to see divergence
+            return
+        try:
+            from megatron.core import parallel_state as mpu
+            tp, dp = mpu.get_tensor_model_parallel_rank(), mpu.get_data_parallel_rank()
+        except Exception:
+            tp = dp = -1
+        def _info(mod):
+            p = next((q for _, q in mod.named_parameters() if q.requires_grad), None)
+            if p is None:
+                p = next((q for _, q in mod.named_parameters()), None)
+            if p is None:
+                return "n/a"
+            wn = float(p.detach().float().norm())
+            g = getattr(p, "grad", None)
+            mg = getattr(p, "main_grad", None)
+            gn = float(g.detach().float().norm()) if g is not None else None
+            mgn = float(mg.detach().float().norm()) if mg is not None else None
+            return (f"w={wn:.6f} rg={p.requires_grad} dtype={str(p.dtype).split('.')[-1]} "
+                    f"has_main_grad={hasattr(p, 'main_grad')} grad={gn} main_grad={mgn}")
+        print(f"[M3VL-PROBE] grank={grank} tp={tp} dp={dp} call={self._probe_n} "
+              f"| vision[{_info(self.vision_tower)}] | proj[{_info(self.multi_modal_projector)}]",
+              flush=True)
+
+    # Delegate the bits Megatron's training loop / checkpoint expect to the LM.
+    def set_input_tensor(self, input_tensor):
+        return self.language_model.set_input_tensor(input_tensor)
+
+    def shared_embedding_or_output_weight(self):
+        return self.language_model.shared_embedding_or_output_weight()
+
+    def sharded_state_dict(self, prefix="", sharded_offsets=(), metadata=None):
+        """Delegate the megatron dist checkpoint to the inner LM with the SAME prefix.
+
+        The torch_dist checkpoint is saved/produced as a bare GPTModel
+        (``embedding.*`` / ``decoder.*`` — no ``language_model.`` level), so without
+        this the default MegatronModule.sharded_state_dict would prefix every LM
+        param with ``language_model.`` and ``--load`` finds nothing ("not in state
+        dict, will skip" -> rename_mapping assert). The vision tower + projector are
+        loaded separately from M3_VISION_CKPT (build_minimax_m3_vl), so they are
+        intentionally excluded from the dist checkpoint.
+        """
+        return self.language_model.sharded_state_dict(
+            prefix=prefix, sharded_offsets=sharded_offsets, metadata=metadata
+        )
+
+
+def _load_vision_only(ckpt_dir, hf_cfg, dtype):
+    """Build + load ONLY the M3-VL vision tower + projector (skip the 428B LM).
+
+    Loads just the ``vision_tower.*`` (~515) and ``multi_modal_projector.*`` (4)
+    tensors straight from the safetensors shards via the weight-map index — never
+    materialising the 22.9k ``language_model.*`` keys, so CPU RAM stays small.
+    Requires a transformers that has the in-library ``minimax_m3_vl`` model
+    (mounted + PYTHONPATH-shadowed for VL mode; see the smoke slurm).
+    """
+    import glob
+    import json
+    import os
+
+    from safetensors import safe_open
+    from transformers.models.minimax_m3_vl.modeling_minimax_m3_vl import (
+        MiniMaxM3VLMultiModalProjector,
+        MiniMaxM3VLVisionModel,
+    )
+
+    vision_tower = MiniMaxM3VLVisionModel(hf_cfg.vision_config).to(dtype)
+    projector = MiniMaxM3VLMultiModalProjector(hf_cfg).to(dtype)
+
+    # Map checkpoint keys (older CLIP-style layout) -> transformers-5.3 module keys.
+    def vt_rename(k):  # k already stripped of "vision_tower."
+        k = k.replace("vision_model.encoder.layers.", "layers.")
+        k = k.replace("vision_model.embeddings.patch_embedding.", "embeddings.proj.")
+        k = k.replace("vision_model.", "")  # pre_layrnorm, post_layernorm, ...
+        return k
+
+    def pj_collect(k, t, pj_sd):  # k is the full checkpoint key
+        if k.startswith("multi_modal_projector."):
+            pj_sd[k[len("multi_modal_projector."):]] = t        # linear_1/linear_2 (direct)
+        elif k.startswith("patch_merge_mlp."):                  # separate top-level module ->
+            pj_sd["merge_" + k[len("patch_merge_mlp."):]] = t   # projector.merge_linear_1/2
+
+    wanted = ("vision_tower.", "multi_modal_projector.", "patch_merge_mlp.")
+    idx_path = os.path.join(ckpt_dir, "model.safetensors.index.json")
+    if os.path.exists(idx_path):
+        weight_map = json.load(open(idx_path))["weight_map"]
+        shard_of = {}
+        for k, f in weight_map.items():
+            if k.startswith(wanted):
+                shard_of.setdefault(f, []).append(k)
+        shards = shard_of.items()
+    else:  # single-file checkpoint
+        only = glob.glob(os.path.join(ckpt_dir, "*.safetensors"))[0]
+        shards = [(os.path.basename(only), None)]
+
+    vt_sd, pj_sd = {}, {}
+    for fname, keys in shards:
+        with safe_open(os.path.join(ckpt_dir, fname), framework="pt") as sf:
+            it = keys if keys is not None else [k for k in sf.keys() if k.startswith(wanted)]
+            for k in it:
+                t = sf.get_tensor(k).to(dtype)
+                if k.startswith("vision_tower."):
+                    vt_sd[vt_rename(k[len("vision_tower."):])] = t
+                else:
+                    pj_collect(k, t, pj_sd)
+
+    missing_vt, unexpected_vt = vision_tower.load_state_dict(vt_sd, strict=False)
+    missing_pj, unexpected_pj = projector.load_state_dict(pj_sd, strict=False)
+    if missing_vt or missing_pj:
+        logger.warning(
+            "M3-VL vision load: %d missing vision keys, %d missing projector keys "
+            "(unexpected vt=%d pj=%d). Check the checkpoint->module key rename.",
+            len(missing_vt), len(missing_pj), len(unexpected_vt), len(unexpected_pj),
+        )
+    else:
+        logger.info("M3-VL vision load: all vision_tower + projector keys loaded.")
+    return vision_tower, projector
+
+
+def build_minimax_m3_vl(language_model, args, *, freeze_vision: bool = True):
+    """Assemble the composite: Megatron M3 ``language_model`` + HF vision tower.
+
+    Loads ONLY the vision tower + projector from the HF checkpoint (the HF LM is
+    discarded — Megatron's ``language_model`` replaces it). Vision runs in bf16,
+    replicated across TP ranks (the "less efficient" e2e path). Call this from the
+    miles model_provider after the GPTModel is built (see README hook).
+    """
+    import os
+
+    import torch
+
+    # Tell the M3 bridge to use the composite ("language_model.") param prefix
+    # and add vision ReplicatedMappings (see miles_plugins/megatron_bridge/minimax_m3.py).
+    os.environ["MINIMAX_M3_VL"] = "1"
+
+    # Load the config via the IN-LIBRARY 5.3 MiniMaxM3VLConfig (not the checkpoint's
+    # bundled remote-code config, which is older and lacks fields the 5.3 vision
+    # modeling reads, e.g. temporal_patch_size).
+    from transformers.models.minimax_m3_vl.configuration_minimax_m3_vl import (
+        MiniMaxM3VLConfig,
+    )
+
+    hf_cfg = MiniMaxM3VLConfig.from_pretrained(args.hf_checkpoint)
+    dev = torch.device("cuda", torch.cuda.current_device())
+    # Vision weights come from a checkpoint that actually has the safetensors. For
+    # reduced-layer smokes, --hf-checkpoint is a config-only 4-layer dir (so
+    # hf_validate_args passes), and M3_VISION_CKPT points at the full checkpoint.
+    vision_ckpt = os.environ.get("M3_VISION_CKPT") or args.hf_checkpoint
+    vision_tower, projector = _load_vision_only(vision_ckpt, hf_cfg, torch.bfloat16)
+    vision_tower = vision_tower.to(dev)
+    projector = projector.to(dev)
+
+    image_token_index = getattr(hf_cfg, "image_token_index", 200025)
+    video_token_index = getattr(hf_cfg, "video_token_index", 200026)
+    return MiniMaxM3VLModel(
+        language_model, vision_tower, projector,
+        image_token_index=image_token_index,
+        video_token_index=video_token_index,
+        config=getattr(language_model, "config", None),
+        freeze_vision=freeze_vision,
+    )

--- a/scripts/models/minimax-m3-428B.sh
+++ b/scripts/models/minimax-m3-428B.sh
@@ -1,0 +1,66 @@
+# MiniMax-M3 (428B total / ~23B active) — MSA + MoE.
+# Source from a run script the same way as scripts/models/glm5-744B-A40B.sh.
+#
+# Config: MiniMaxAI/MiniMax-M3 config.json (text backbone).
+#   60 layers (0-2 dense full-attn, 3-59 MoE + MSA sparse attn),
+#   hidden 6144, 64 q-heads / 4 kv-heads, head_dim 128, partial RoPE 64,
+#   128 experts top-4 + 1 shared, sigmoid router + bias, routed_scaling 2.0.
+
+MOE_ROUTED_EXPERTS=128
+MOE_ACTIVE_ROUTED_EXPERTS=4
+MOE_SHARED_EXPERTS=1
+
+NHIDDEN=6144
+MOE_FFN_HIDDEN=3072
+MOE_SHARED_EXPERT_INTERMEDIATE_SIZE=$(($MOE_FFN_HIDDEN * $MOE_SHARED_EXPERTS))
+FFN_HIDDEN=12288          # dense layers 0-2 intermediate (dense_intermediate_size)
+N_DENSE_LAYERS=3
+N_MOE_LAYERS=57
+NHEADS=64
+NKVHEADS=4
+HEAD_DIM=128
+
+MODEL_ARGS=(
+   --spec "miles_plugins.models.minimax_m3.minimax_m3" "get_minimax_m3_spec"
+    --moe-layer-freq [0]*$N_DENSE_LAYERS+[1]*$N_MOE_LAYERS
+    --num-experts $MOE_ROUTED_EXPERTS
+    --moe-shared-expert-intermediate-size $MOE_SHARED_EXPERT_INTERMEDIATE_SIZE
+    --moe-router-topk $MOE_ACTIVE_ROUTED_EXPERTS
+    --moe-grouped-gemm
+    --moe-permute-fusion
+    --moe-ffn-hidden-size $MOE_FFN_HIDDEN
+    --moe-router-score-function sigmoid
+    --moe-router-enable-expert-bias
+    --moe-router-bias-update-rate 0
+    --moe-router-load-balancing-type seq_aux_loss
+    --moe-router-topk-scaling-factor 2.0     # routed_scaling_factor
+    --moe-aux-loss-coeff 0
+    --moe-router-dtype fp32
+    --make-vocab-size-divisible-by 16
+
+    --num-layers $((N_DENSE_LAYERS + N_MOE_LAYERS))
+    --hidden-size $NHIDDEN
+    --ffn-hidden-size $FFN_HIDDEN
+    --num-attention-heads $NHEADS
+    --group-query-attention
+    --num-query-groups $NKVHEADS
+    --kv-channels $HEAD_DIM
+    --disable-bias-linear
+    --swiglu
+    --untie-embeddings-and-output-weights
+    --position-embedding-type rope
+    --no-position-embedding
+    --rotary-percent 0.5                      # rotary_dim 64 / head_dim 128
+    --rotary-base 5000000
+    # Long-context (>256k) only: M3 uses YaRN (rope_type=yarn, factor 2.0,
+    # original_max_position 1048576). Plain rope above is correct for typical
+    # SFT/RL context; add `--use-rope-scaling` when training at ~1M ctx.
+    --normalization RMSNorm
+    --norm-epsilon 1e-6
+    --qk-layernorm                            # per_head QK-norm
+    --vocab-size 200064
+    --enable-experimental
+
+    # miles specific
+    --allgather-cp
+)

--- a/scripts/models/minimax-m3-428B_4layer.sh
+++ b/scripts/models/minimax-m3-428B_4layer.sh
@@ -1,0 +1,60 @@
+# MiniMax-M3 — REDUCED 4-layer smoke config (1 dense + 3 MoE+MSA layers).
+# Random-init plumbing test ONLY (weights won't load — layer count differs from
+# the real 60-layer checkpoint). Mirrors scripts/models/minimax-m3-428B.sh but
+# tiny, so spec-build -> MSA forward -> (optional VL merge) -> loss runs on 1 node.
+
+MOE_ROUTED_EXPERTS=128
+MOE_ACTIVE_ROUTED_EXPERTS=4
+MOE_SHARED_EXPERTS=1
+
+NHIDDEN=6144
+MOE_FFN_HIDDEN=3072
+MOE_SHARED_EXPERT_INTERMEDIATE_SIZE=$(($MOE_FFN_HIDDEN * $MOE_SHARED_EXPERTS))
+FFN_HIDDEN=12288
+N_DENSE_LAYERS=1          # 1 dense (layer 0) so at least one MSA layer exists
+N_MOE_LAYERS=3           # 3 MoE + MSA sparse layers (layers 1-3)
+NHEADS=64
+NKVHEADS=4
+HEAD_DIM=128
+
+MODEL_ARGS=(
+   --spec "miles_plugins.models.minimax_m3.minimax_m3" "get_minimax_m3_spec"
+    --moe-layer-freq [0]*$N_DENSE_LAYERS+[1]*$N_MOE_LAYERS
+    --num-experts $MOE_ROUTED_EXPERTS
+    --moe-shared-expert-intermediate-size $MOE_SHARED_EXPERT_INTERMEDIATE_SIZE
+    --moe-router-topk $MOE_ACTIVE_ROUTED_EXPERTS
+    --moe-grouped-gemm
+    --moe-permute-fusion
+    --moe-ffn-hidden-size $MOE_FFN_HIDDEN
+    --moe-router-score-function sigmoid
+    --moe-router-enable-expert-bias
+    --moe-router-bias-update-rate 0
+    --moe-router-load-balancing-type seq_aux_loss
+    --moe-router-topk-scaling-factor 2.0
+    --moe-aux-loss-coeff 0
+    --moe-router-dtype fp32
+    --make-vocab-size-divisible-by 16
+
+    --num-layers $((N_DENSE_LAYERS + N_MOE_LAYERS))
+    --hidden-size $NHIDDEN
+    --ffn-hidden-size $FFN_HIDDEN
+    --num-attention-heads $NHEADS
+    --group-query-attention
+    --num-query-groups $NKVHEADS
+    --kv-channels $HEAD_DIM
+    --disable-bias-linear
+    --swiglu
+    --untie-embeddings-and-output-weights
+    --position-embedding-type rope
+    --no-position-embedding
+    --rotary-percent 0.5
+    --rotary-base 5000000
+    --normalization RMSNorm
+    --norm-epsilon 1e-6
+    --qk-layernorm
+    --vocab-size 200064
+    --enable-experimental
+
+    # miles specific
+    --allgather-cp
+)

--- a/tools/merge_m3_vision_into_hf.py
+++ b/tools/merge_m3_vision_into_hf.py
@@ -1,0 +1,68 @@
+"""Merge the original M3 vision tower + projector into an LM-only exported HF dir.
+
+convert_torch_dist_to_hf.py exports only the trained LM weights
+(``language_model.model.*``); text-only SFT never touches the vision tower. This
+copies the untrained vision params (``vision_tower.*`` / ``multi_modal_projector.*``
+/ ``patch_merge_mlp.*``) verbatim from the ORIGIN HF model into the exported dir and
+extends model.safetensors.index.json, producing a complete servable VL checkpoint.
+
+Usage:
+  python tools/merge_m3_vision_into_hf.py \
+    --origin-hf-dir /fsx/peng/models/MiniMax-M3 \
+    --exported-hf-dir /fsx/peng/models/MiniMax-M3_sft_hf
+"""
+
+import argparse
+import json
+import os
+
+import safetensors.torch
+from safetensors import safe_open
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--origin-hf-dir", required=True, help="original full M3 HF (has vision weights)")
+    ap.add_argument("--exported-hf-dir", required=True, help="LM-only exported HF to complete in place")
+    ap.add_argument("--out-shard", default="model-vision-00000-of-00001.safetensors")
+    args = ap.parse_args()
+
+    oidx = json.load(open(os.path.join(args.origin_hf_dir, "model.safetensors.index.json")))
+    owm = oidx["weight_map"]
+    vis_keys = [k for k in owm if not k.startswith("language_model.")]
+    print(f"vision/non-LM keys to merge: {len(vis_keys)}")
+
+    eidx_path = os.path.join(args.exported_hf_dir, "model.safetensors.index.json")
+    eidx = json.load(open(eidx_path))
+    ewm = eidx["weight_map"]
+    overlap = [k for k in vis_keys if k in ewm]
+    assert not overlap, f"exported dir already has {len(overlap)} vision keys, e.g. {overlap[:3]}"
+
+    # load vision tensors (group reads by source shard for efficiency)
+    by_shard = {}
+    for k in vis_keys:
+        by_shard.setdefault(owm[k], []).append(k)
+    tensors, total_bytes = {}, 0
+    for shard, keys in by_shard.items():
+        with safe_open(os.path.join(args.origin_hf_dir, shard), framework="pt") as f:
+            for k in keys:
+                t = f.get_tensor(k)
+                tensors[k] = t
+                total_bytes += t.numel() * t.element_size()
+    print(f"loaded {len(tensors)} vision tensors, {total_bytes/1e9:.2f} GB")
+
+    out_path = os.path.join(args.exported_hf_dir, args.out_shard)
+    safetensors.torch.save_file(tensors, out_path)
+    print(f"wrote {out_path}")
+
+    # extend the index: point vision keys at the new shard, bump total_size
+    for k in vis_keys:
+        ewm[k] = args.out_shard
+    eidx.setdefault("metadata", {})
+    eidx["metadata"]["total_size"] = int(eidx["metadata"].get("total_size", 0)) + total_bytes
+    json.dump(eidx, open(eidx_path, "w"), indent=2)
+    print(f"updated index -> {len(ewm)} total keys ({len(vis_keys)} vision added)")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/merge_m3_vision_into_hf.py
+++ b/tools/merge_m3_vision_into_hf.py
@@ -27,13 +27,15 @@ def main():
     ap.add_argument("--out-shard", default="model-vision-00000-of-00001.safetensors")
     args = ap.parse_args()
 
-    oidx = json.load(open(os.path.join(args.origin_hf_dir, "model.safetensors.index.json")))
+    with open(os.path.join(args.origin_hf_dir, "model.safetensors.index.json")) as f:
+        oidx = json.load(f)
     owm = oidx["weight_map"]
     vis_keys = [k for k in owm if not k.startswith("language_model.")]
     print(f"vision/non-LM keys to merge: {len(vis_keys)}")
 
     eidx_path = os.path.join(args.exported_hf_dir, "model.safetensors.index.json")
-    eidx = json.load(open(eidx_path))
+    with open(eidx_path) as f:
+        eidx = json.load(f)
     ewm = eidx["weight_map"]
     overlap = [k for k in vis_keys if k in ewm]
     assert not overlap, f"exported dir already has {len(overlap)} vision keys, e.g. {overlap[:3]}"
@@ -60,7 +62,8 @@ def main():
         ewm[k] = args.out_shard
     eidx.setdefault("metadata", {})
     eidx["metadata"]["total_size"] = int(eidx["metadata"].get("total_size", 0)) + total_bytes
-    json.dump(eidx, open(eidx_path, "w"), indent=2)
+    with open(eidx_path, "w") as f:
+        json.dump(eidx, f, indent=2)
     print(f"updated index -> {len(ewm)} total keys ({len(vis_keys)} vision added)")
 
 


### PR DESCRIPTION
# Add MiniMax-M3 (MSA) training support

Adds MiniMax-M3 (428B total / ~23B active) to miles, following the GLM-5 plugin
pattern: a custom attention module + sparse-index kernels wired through Megatron's
`--spec` mechanism, plus HF↔Megatron weight bridges in both directions and a
(work-in-progress) VL stack. `26 files changed, +3008/-8`.

> **Status at a glance.** The **text path is validated end-to-end** (HF→Megatron
> bit-exact, multinode SFT trains correctly, Megatron→HF export round-trips). The
> **VL/vision path is structurally complete but WIP** — it does not yet train the
> vision tower or projector (details in *Known limitations*). Default text behavior
> is untouched; all M3 code is gated behind `--spec`/`--minimax-m3-vl`.

## Why M3 needs its own plugin

M3 is architecturally distinct from both M2 and GLM-5, so neither bridge is reusable:

| | M2 (full attn) | GLM-5 (DSA) | **M3 (MSA)** |
|---|---|---|---|
| attention | dense GQA | MLA (latent KV) | **GQA** (real KV) |
| sparse selection | none | per-**token**, topk=2048 | per-**block**, 16×128 |
| head reduction | — | learned `weights_proj` sum | **max** (`amax`, no gating) |
| QK-norm | full-dim | — | **per-head** |

The novel pieces are the **block-level lightning indexer** (MSA) and **block-sparse
GQA**. Config: 60 layers (0–2 dense full-attn, 3–59 MoE + MSA), hidden 6144, 64 q /
4 kv heads, head_dim 128, partial RoPE (rotary_dim 64, θ=5e6), 128 experts top-4 + 1
shared (sigmoid router + bias, `routed_scaling 2.0`), `swigluoai` activation,
`use_gemma_norm`.

## What's included

**Compute graph (text):**
- `miles_plugins/models/minimax_m3/minimax_m3.py` — `MSASelfAttention` (GQA + per-head
  QK-norm + lightning indexer, THD RoPE via TE helpers, SP-correct q/k/v gather) and
  `get_minimax_m3_spec` (dense layers keep full attention; sparse layers swap in MSA;
  `swigluoai` + gemma-norm config).
- `ops/msa_indexer.py`, `ops/block_sparse_attn.py` — block-topk selection and
  block-sparse GQA references (pure-torch oracles; a fused varlen kernel is the one
  remaining perf TODO).

**Weight bridges (all three directions):**
- `miles_plugins/mbridge/minimax_m3.py` — **HF → torch_dist** (offline conversion,
  used by `tools/convert_hf_to_torch_dist.py`).
- `miles/backends/megatron_utils/megatron_to_hf/minimax_m3.py` — **torch_dist → HF**
  (export a trained checkpoint).
- `miles_plugins/megatron_bridge/minimax_m3.py` — train-time `megatron.bridge` bridge.
- Mutually consistent on the `language_model.model.*`, `block_sparse_moe`,
  `w1/w3/w2`, shared-expert, and `index_{q,k}_{proj,norm}` key layout.

**VL stack (WIP):** `vl_model.py` (`MiniMaxM3VLModel` composite: HF-native vision
tower + projector + Megatron LM), `mm_data.py` (media-token expansion), gated via
`--minimax-m3-vl`.

**Core hooks (gated, default-off):** `model_provider.py` (VL wrap),
`training_utils/data.py` (token expansion), `utils/arguments.py` (`--minimax-m3-vl`,
`--minimax-m3-train-vision`, `--debug-skip-load`, M3 `dense_intermediate_size`
validate-skip), `model.py` (`--debug-skip-load` gating), bridge `__init__` registrations.

**Configs / launchers / tools:** `scripts/models/minimax-m3-428B.sh` (+ `_4layer.sh`),
`examples/minimax_m3_vl/*.slurm` (smoke, multinode real-weight, conversions, VL SFT),
`tools/merge_m3_vision_into_hf.py`.

## Validation

| What | Result |
|---|---|
| HF → torch_dist conversion (428B) | All 23,416 keys mapped; **bit-exact** vs HF safetensors (embedding, norms, GQA-uninterleaved QKV, per-head q_norm, MSA index norms, expert w1/w3) |
| torch_dist → HF export | All 22,893 LM keys round-trip; untouched params bit-exact, trained params shift ~1 bf16 ULP; unit-tested mappings |
| Multinode SFT (8 nodes, TP8/PP1/EP32, CPU-offload optimizer) | Loads converted weights, trains; **start-loss 0.98 on real text** (correct weights) descending smoothly |
| MSA reference | Unit-tested: invariants hold; all-blocks-selected == dense causal GQA, err 0 |
| Text smoke (4-layer, random init) | Full MSA + MoE forward/backward green |

Parallelism note: EP=32 requires `world_size % 32 == 0`, so the 428B full-optimizer
config needs **8 nodes** (4 OOMs on host RAM; 6 is invalid for EP32). The optimizer
(fp32 master + Adam m/v) must be CPU-offloaded.

## Known limitations (please read before using the VL path)

The **VL vision path is not yet correct** — prior "VLM SFT" runs trained the LM on
image-placeholder *tokens* with the vision tower loaded but **never exercised**:

1. **Merge is not sequence-parallel-correct.** Under `--sequence-parallel` (every VL
   launcher sets it) the LM embedding returns sequence-scattered `[t/TP,b,h]` while
   the merge uses a full-length mask. A guard now raises a clear error if real
   `pixel_values` reach the merge; the fix is gather→merge→re-scatter.
2. **Vision/projector are not trained.** They are native HF modules; the vision tower
   is frozen by default, and the projector — though wired into the optimizer — gets
   `main_grad=0.0` because vision never flows (verified via `M3_VL_PROBE`).
   `--minimax-m3-train-vision` is therefore WIP (no TP grad all-reduce for the
   replicated params either).
3. **Checkpoint save drops vision/projector** (`sharded_state_dict` delegates to the
   LM only); `merge_m3_vision_into_hf.py` re-attaches the *original* vision weights.
4. **Indexer is frozen** (detached, no KL-distillation loss implemented) — correct for
   SFT on released weights, but it does not adapt.

See `miles_plugins/models/minimax_m3/README.md` → *Known limitations* for the full list
and fix sketches. The text path is unaffected by all of the above.

## How to test

```bash
# 1-node text smoke (random init, cheapest sanity check)
MODE=text sbatch examples/minimax_m3_vl/launch_m3_smoke.slurm

# HF -> torch_dist conversion (1 node)
sbatch examples/minimax_m3_vl/convert_m3.slurm

# 8-node real-weight SFT (loads converted weights; start-loss ~1 = correct)
sbatch examples/minimax_m3_vl/run_m3_real_2node.slurm --nodes=8 \
  --export=ALL,TP=8,PP=1,EP=32,ETP=1,DISABLE_OPT=0,CPU_OFFLOAD=1

# trained checkpoint -> HF, then merge vision for a servable VL artifact
sbatch examples/minimax_m3_vl/convert_torch_dist_to_hf_m3.slurm
python tools/merge_m3_vision_into_hf.py --origin-hf-dir <orig> --exported-hf-dir <out>
```

## Follow-ups (tracked in the plugin README)

- SP-correct VL merge (gather→merge→re-scatter) — unblocks real vision training.
- Native vision/projector params in the distributed optimizer + TP grad all-reduce.
- Include trained vision/projector in `sharded_state_dict` (and the HF export).
- Forward-logit parity check vs HF `transformers` (numerical proof of the MSA compute
  graph, beyond the bit-exact weight check).
- Fused varlen block-sparse GQA fwd/bwd kernel (replace the O(N²) reference).
- Indexer KL-distillation training loop.

