### PR TITLE
fix(docker): install emerging_optimizers for Muon optimizer support

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -123,6 +123,11 @@ RUN git clone https://github.com/${MEGATRON_REPO}.git --recursive -b ${MEGATRON_
     cd Megatron-LM && \
     pip install -e .
 
+# Muon optimizer support: megatron/core/optimizer/muon.py requires this for Newton-Schulz
+# orthogonalization; not on PyPI (only a dependency-confusion stub), so install from the
+# git source Megatron-LM itself pins in pyproject.toml.
+RUN pip install "git+https://github.com/NVIDIA-NeMo/Emerging-Optimizers.git@v0.1.0"
+
 RUN pip install git+https://github.com/fzyzcjy/torch_memory_saver.git@d64a639 --no-cache-dir --force-reinstall
 RUN pip install "nvidia-modelopt[torch]>=0.37.0" --no-build-isolation
 RUN pip install git+https://github.com/radixark/Megatron-Bridge.git@bridge --no-deps --no-build-isolation


### PR DESCRIPTION
Fixes `--optimizer muon` failing at optimizer construction:

```
AssertionError: Emerging Optimizers is not installed.
```

`megatron/core/optimizer/muon.py` gates its Newton-Schulz orthogonalization behind `HAVE_EMERGING_OPTIMIZERS`, which requires the `emerging_optimizers` package. It is not on PyPI (that name is squatted by a dependency-confusion stub — `pip install emerging_optimizers` fails with `Installation terminated! This is stub package to mitigate risks of Dependency Confusion attacks.`).

The real source is exactly what Megatron-LM itself pins in its own `pyproject.toml`:
```
emerging_optimizers = { git = "https://github.com/NVIDIA-NeMo/Emerging-Optimizers.git", rev = "v0.1.0" }
```

This adds one `pip install` of that pinned git source right after the Megatron-LM install step in the Dockerfile.

## Testing
Hit this while validating disk-offload (#1575) works with the Muon optimizer end-to-end on a real model (Qwen3-30B-A3B, 4xH200, RL). Confirmed `from emerging_optimizers.orthogonalized_optimizers.muon_utils import newton_schulz_tp` imports and `--optimizer muon` proceeds past optimizer construction after installing this package.