### PR TITLE
Fix pre-train eval trigger when start_rollout_id != 0

### DIFF
--- a/train.py
+++ b/train.py
@@ -72,7 +72,7 @@ async def train(args):
     # train loop.
     # note that for async training, one can change the position of the sync operation(ray.get).
     for rollout_id in range(args.start_rollout_id, args.num_rollout):
-        if args.eval_interval is not None and rollout_id == 0 and not args.skip_eval_before_train:
+        if args.eval_interval is not None and rollout_id == args.start_rollout_id and not args.skip_eval_before_train:
             await rollout_manager.eval.remote(rollout_id)
 
         rollout_data_ref = await rollout_manager.generate.remote(rollout_id)


### PR DESCRIPTION
## Summary
- The train loop's pre-train eval check compared `rollout_id == 0`, but the first iteration's `rollout_id` is `args.start_rollout_id`, not always 0.
- On resumed runs (start_rollout_id > 0), the pre-train eval never fired even without `--skip-eval-before-train`.
- Fix: compare against `args.start_rollout_id` instead.

## Test plan
- [ ] Resume a run with `--start-rollout-id > 0` and `--eval-interval` set, confirm eval fires on the first loop iteration