### PR TITLE
chore(codeowners): add Shi-Dong to megatron/sglang backends and rollout/session

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,10 +2,10 @@
 /.github/workflows/ @yushengsu-thu @guapisolo @yueming-yuan
 /miles/ @fzyzcjy @yueming-yuan
 /miles/backends/ @fzyzcjy @yueming-yuan @maocheng23 @Zhichenzzz @Shi-Dong
-/miles/backends/megatron_utils/ @fzyzcjy @yueming-yuan @maocheng23 @yushengsu-thu @Zhichenzzz
-/miles/backends/sglang_utils/ @fzyzcjy @yueming-yuan @maocheng23 @yushengsu-thu @Zhichenzzz
+/miles/backends/megatron_utils/ @fzyzcjy @yueming-yuan @maocheng23 @yushengsu-thu @Zhichenzzz @Shi-Dong
+/miles/backends/sglang_utils/ @fzyzcjy @yueming-yuan @maocheng23 @yushengsu-thu @Zhichenzzz @Shi-Dong
 /miles/ray/ @fzyzcjy @yueming-yuan @maocheng23
 /miles/rollout/ @fzyzcjy @yueming-yuan @guapisolo @Shi-Dong
-/miles/rollout/session/ @fzyzcjy @yueming-yuan @guapisolo @maocheng23 @jybsuper
+/miles/rollout/session/ @fzyzcjy @yueming-yuan @guapisolo @maocheng23 @jybsuper @Shi-Dong
 /miles/router/ @fzyzcjy @yueming-yuan @guapisolo
 /miles/utils/ @fzyzcjy @yueming-yuan @guapisolo @maocheng23 @jybsuper @Zhichenzzz @Shi-Dong


### PR DESCRIPTION
## Summary
Adds `@Shi-Dong` as a code owner for three paths in `.github/CODEOWNERS`:

- `/miles/backends/megatron_utils/`
- `/miles/backends/sglang_utils/`
- `/miles/rollout/session/`

`@Shi-Dong` is already an owner of the parent `/miles/backends/`, `/miles/rollout/`, and `/miles/utils/` entries, so this extends review coverage to these more specific subpaths.

## Changes
- `.github/CODEOWNERS`: appended `@Shi-Dong` to the three lines above (3 insertions, 3 deletions).

## Test plan
- [ ] CODEOWNERS syntax validated by GitHub (no unknown users; `@Shi-Dong` already used elsewhere in the file).