### PR TITLE
tito(dsv4): allow {tool,user} append surface for terminus-2

### DIFF
--- a/miles/utils/chat_template_utils/tito_tokenizer.py
+++ b/miles/utils/chat_template_utils/tito_tokenizer.py
@@ -793,6 +793,11 @@ class DeepSeekV4TITOTokenizer(TITOTokenizer):
             allowed_roles=frozenset({"tool"}),
             template=None,
         ),
+        FixedTemplateRow(
+            allowed_roles=frozenset({"tool", "user"}),
+            template=None,
+            extra_kwargs={"drop_thinking": False},
+        ),
     )
 
     _DEFAULT_ASSISTANT_START = "<｜Assistant｜>"


### PR DESCRIPTION
**What** — Registers a second `{tool, user}` append surface on `DeepSeekV4TITOTokenizer` (with `drop_thinking=False`), so terminus-2 user-role terminal observations can be appended incrementally.

**Why it stays append-only / byte-stable** — `encoding_dsv4` drops an earlier turn thinking block only when `drop_thinking=True` **and** `index <= last_user` (`encoding_dsv4.py:386`: keep iff `not drop_thinking or index > last_user_idx`). With `drop_thinking=False` all thinking is retained regardless of position, so appending a user turn does **not** rewrite prior assistants -> append-only and byte-stable.

**Serving requirement** — the runtime must match: pass `--apply-chat-template-kwargs '{"drop_thinking": false}'`.
