### PR TITLE
Bump sglang to v0.5.14

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -139,8 +139,6 @@ RUN if [ "${ENABLE_CUDA_13}" = "1" ]; then \
     pip install nvidia-cudnn-cu12==9.16.0.29; \
   fi
 
-# reinstall numpy 1.x for megatron
-RUN pip install "numpy<2"
 
 RUN rm -rf /root/.cache/pip /root/flash-attention
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,7 +10,7 @@
 # release for the current arch picked from TARGETARCH — WHEELS_TAG_X86 on amd64,
 # WHEELS_TAG_ARM64 on arm64 (cu12-x86 overrides WHEELS_TAG_X86).
 
-ARG SGLANG_IMAGE_TAG=v0.5.13
+ARG SGLANG_IMAGE_TAG=v0.5.14
 FROM lmsysorg/sglang:${SGLANG_IMAGE_TAG} AS sglang
 
 # ======================================== Arguments =============================================

--- a/docs/user-guide/cli-reference.md
+++ b/docs/user-guide/cli-reference.md
@@ -145,7 +145,7 @@ Sections mirror the launch-script argument groups.
 | `--actor-num-gpus-per-node` | int | `8` | GPUs per actor node. |
 | `--rollout-num-gpus` | int | derived | Ignored under `--colocate`. |
 | `--rollout-num-gpus-per-engine` | int | `1` | TP size of each SGLang engine. |
-| `--colocate` | flag | off | Share GPUs between actor and rollout. Implicitly enables `--offload-train`, `--offload-rollout`, and `--sglang-disable-piecewise-cuda-graph`. |
+| `--colocate` | flag | off | Share GPUs between actor and rollout. Implicitly enables `--offload-train`, `--offload-rollout`, and defaults `--sglang-cuda-graph-backend-prefill=disabled`. |
 
 ### Model and checkpoints
 
@@ -288,7 +288,7 @@ Common `--sglang-*` flags:
 --sglang-enable-dp-attention
 --sglang-enable-deepep
 --sglang-enable-overlap-schedule
---sglang-enforce-piecewise-cuda-graph     # off by default in colocate mode
+--sglang-cuda-graph-backend-prefill       # prefill graphs default to disabled in colocate mode
 ```
 
 ### MTP / speculative decoding

--- a/docs/user-guide/training-script-walkthrough.md
+++ b/docs/user-guide/training-script-walkthrough.md
@@ -347,7 +347,7 @@ collision produces an OOM before training ever starts. Drop
 
 - `--offload-train` — train state offloads to CPU between phases
 - `--offload-rollout` — rollout state offloads to CPU between phases
-- `--sglang-disable-piecewise-cuda-graph` — avoids NVLS OOM in colocate mode
+- `--sglang-cuda-graph-backend-prefill=disabled` — avoids NVLS OOM in colocate mode
 
 </Note>
 

--- a/miles/backends/megatron_utils/initialize.py
+++ b/miles/backends/megatron_utils/initialize.py
@@ -69,9 +69,6 @@ def init(args):
 
     set_parallel_state(create_megatron_parallel_state())
 
-    # https://github.com/NVIDIA/Megatron-LM/issues/1563
-    assert np.__version__.startswith("1."), "Megatron does not support numpy 2.x"
-
     # Random seeds for reproducibility.
     if args.rank == 0:
         logger.info(f"> setting random seeds to {args.seed} ...")

--- a/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/p2p.py
+++ b/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/p2p.py
@@ -271,8 +271,8 @@ class UpdateWeightP2P(DistBucketedWeightUpdateMixin):
         # after RDMA transfer, at end_weight_update.
         from sglang.srt.model_loader import loader as model_loader_module
 
-        original_post_load_weights = model_loader_module._post_load_weights
-        model_loader_module._post_load_weights = lambda *args, **kwargs: None
+        original_post_load_weights = model_loader_module.post_load_weights
+        model_loader_module.post_load_weights = lambda *args, **kwargs: None
         try:
             with ParallelismContext(parallelism_config):
                 model = get_model(
@@ -281,7 +281,7 @@ class UpdateWeightP2P(DistBucketedWeightUpdateMixin):
                     device_config=DeviceConfig(device="cpu"),
                 )
         finally:
-            model_loader_module._post_load_weights = original_post_load_weights
+            model_loader_module.post_load_weights = original_post_load_weights
 
         # Also patch the instance method for subsequent load_weights() calls
         # (deepseek_weight_loader.py:342 calls self.post_load_weights() at the end).

--- a/miles/backends/sglang_utils/arguments.py
+++ b/miles/backends/sglang_utils/arguments.py
@@ -135,11 +135,9 @@ def add_sglang_arguments(parser):
 
 def validate_args(args):
     args.sglang_tp_size = args.rollout_num_gpus_per_engine
-    args.sglang_dp_size = args.sglang_data_parallel_size
-    args.sglang_pp_size = args.sglang_pipeline_parallel_size
-    args.sglang_ep_size = args.sglang_expert_parallel_size
-    if hasattr(args, "sglang_attention_context_parallel_size"):
-        args.sglang_attn_cp_size = args.sglang_attention_context_parallel_size
+    # sglang v0.5.14 renamed the ServerArgs fields to dp_size/pp_size/ep_size/
+    # attn_cp_size (the old long names remain as CLI aliases), so the prefixed
+    # argparse dests are sglang_dp_size etc. directly — no re-mapping needed.
 
     if args.true_on_policy_mode:
         args.sglang_enable_deterministic_inference = True

--- a/miles/backends/sglang_utils/arguments.py
+++ b/miles/backends/sglang_utils/arguments.py
@@ -135,9 +135,6 @@ def add_sglang_arguments(parser):
 
 def validate_args(args):
     args.sglang_tp_size = args.rollout_num_gpus_per_engine
-    # sglang v0.5.14 renamed the ServerArgs fields to dp_size/pp_size/ep_size/
-    # attn_cp_size (the old long names remain as CLI aliases), so the prefixed
-    # argparse dests are sglang_dp_size etc. directly — no re-mapping needed.
 
     if args.true_on_policy_mode:
         args.sglang_enable_deterministic_inference = True

--- a/miles/backends/sglang_utils/arguments.py
+++ b/miles/backends/sglang_utils/arguments.py
@@ -51,7 +51,8 @@ def add_sglang_arguments(parser):
         # memory
         "enable_memory_saver",
         # distributed
-        "tp_size",
+        # tp_size stays exposed: scripts pass --sglang-tp-size, but the value is
+        # overridden from --rollout-num-gpus-per-engine in validate_args below.
         "port",
         "nnodes",
         "node_rank",

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -1862,13 +1862,6 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                     fn.add_arguments(parser)
             return parser
 
-        def add_sglang_tp_size():
-            temp_parser = argparse.ArgumentParser(add_help=False)
-            temp_parser.add_argument("--rollout-num-gpus-per-engine", type=int, default=1)
-            temp_args, _ = temp_parser.parse_known_args()
-            sglang_tp_size = temp_args.rollout_num_gpus_per_engine
-            return sglang_tp_size
-
         # Add custom arguments in front to prevent overwritten some miles arguments.
         if add_custom_arguments is not None:
             parser = add_custom_arguments(parser)
@@ -1909,7 +1902,6 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
         )
         reset_arg(parser, "--padded-vocab-size", type=int, default=None)
 
-        parser.set_defaults(sglang_tensor_parallel_size=add_sglang_tp_size())
         return parser
 
     return add_miles_arguments

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -2321,13 +2321,16 @@ def miles_validate_args(args):
             args.offload_train = True
         if args.offload_rollout is None:
             args.offload_rollout = True
-        if args.sglang_enforce_piecewise_cuda_graph:
-            logger.warning("Warning: colocate mode with --sglang-enforce-piecewise-cuda-graph may trigger NVLS OOM.")
-        if not args.sglang_disable_piecewise_cuda_graph:
-            args.sglang_disable_piecewise_cuda_graph = True
+        if args.sglang_cuda_graph_backend_prefill is None:
+            args.sglang_cuda_graph_backend_prefill = "disabled"
             logger.info(
-                "Colocate mode: defaulting --sglang-disable-piecewise-cuda-graph to avoid NVLS OOM. "
-                "Use --sglang-enforce-piecewise-cuda-graph to override."
+                "Colocate mode: defaulting --sglang-cuda-graph-backend-prefill=disabled to avoid NVLS OOM. "
+                "Set --sglang-cuda-graph-backend-prefill explicitly to override."
+            )
+        elif args.sglang_cuda_graph_backend_prefill != "disabled":
+            logger.warning(
+                f"Warning: colocate mode with --sglang-cuda-graph-backend-prefill="
+                f"{args.sglang_cuda_graph_backend_prefill} may trigger NVLS OOM."
             )
         if args.rollout_num_gpus != args.actor_num_gpus_per_node * args.actor_num_nodes:
             logger.info(

--- a/scripts/tools/verify_session_tito_tokenizer.py
+++ b/scripts/tools/verify_session_tito_tokenizer.py
@@ -96,7 +96,7 @@ def main() -> int:
     print(f"sglang reasoning parser:{args.sglang_reasoning_parser}")
     print(f"sglang tool-call parser:{args.sglang_tool_call_parser or '(none)'}")
     print(f"Rollout GPUs per engine:{args.rollout_num_gpus_per_engine}")
-    print(f"sglang expert-parallel: {args.sglang_expert_parallel_size}")
+    print(f"sglang expert-parallel: {args.sglang_ep_size}")
     print(f"Actor nodes:            {args.actor_num_nodes}")
     print(f"Actor GPUs per node:    {args.actor_num_gpus_per_node}")
     print(f"Samples per prompt:     {args.n_samples_per_prompt}")


### PR DESCRIPTION
ci-image-tag: bump-v0.5.14-test-2
ci-sglang-pr: sglang-miles-v0.5.14

Bumps the sglang base from v0.5.13 → v0.5.14.

sglang-miles stack rebased onto v0.5.14: [sglang-miles-v0.5.14](https://github.com/sgl-project/sglang/tree/sglang-miles-v0.5.14) (22 commits; 6 dropped as already upstream, PostProcessWeights chain folded into its final begin/end_weight_update form).