### PR TITLE
Adapt sglang args to v0.5.14 ServerArgs dataclass migration

### DIFF
--- a/docs/user-guide/cli-reference.md
+++ b/docs/user-guide/cli-reference.md
@@ -145,7 +145,7 @@ Sections mirror the launch-script argument groups.
 | `--actor-num-gpus-per-node` | int | `8` | GPUs per actor node. |
 | `--rollout-num-gpus` | int | derived | Ignored under `--colocate`. |
 | `--rollout-num-gpus-per-engine` | int | `1` | TP size of each SGLang engine. |
-| `--colocate` | flag | off | Share GPUs between actor and rollout. Implicitly enables `--offload-train`, `--offload-rollout`, and `--sglang-disable-piecewise-cuda-graph`. |
+| `--colocate` | flag | off | Share GPUs between actor and rollout. Implicitly enables `--offload-train`, `--offload-rollout`, and defaults `--sglang-cuda-graph-backend-prefill=disabled`. |
 
 ### Model and checkpoints
 
@@ -288,7 +288,7 @@ Common `--sglang-*` flags:
 --sglang-enable-dp-attention
 --sglang-enable-deepep
 --sglang-enable-overlap-schedule
---sglang-enforce-piecewise-cuda-graph     # off by default in colocate mode
+--sglang-cuda-graph-backend-prefill       # prefill graphs default to disabled in colocate mode
 ```
 
 ### MTP / speculative decoding

--- a/docs/user-guide/training-script-walkthrough.md
+++ b/docs/user-guide/training-script-walkthrough.md
@@ -347,7 +347,7 @@ collision produces an OOM before training ever starts. Drop
 
 - `--offload-train` — train state offloads to CPU between phases
 - `--offload-rollout` — rollout state offloads to CPU between phases
-- `--sglang-disable-piecewise-cuda-graph` — avoids NVLS OOM in colocate mode
+- `--sglang-cuda-graph-backend-prefill=disabled` — avoids NVLS OOM in colocate mode
 
 </Note>
 

--- a/miles/backends/sglang_utils/arguments.py
+++ b/miles/backends/sglang_utils/arguments.py
@@ -135,11 +135,9 @@ def add_sglang_arguments(parser):
 
 def validate_args(args):
     args.sglang_tp_size = args.rollout_num_gpus_per_engine
-    args.sglang_dp_size = args.sglang_data_parallel_size
-    args.sglang_pp_size = args.sglang_pipeline_parallel_size
-    args.sglang_ep_size = args.sglang_expert_parallel_size
-    if hasattr(args, "sglang_attention_context_parallel_size"):
-        args.sglang_attn_cp_size = args.sglang_attention_context_parallel_size
+    # sglang v0.5.14 renamed the ServerArgs fields to dp_size/pp_size/ep_size/
+    # attn_cp_size (the old long names remain as CLI aliases), so the prefixed
+    # argparse dests are sglang_dp_size etc. directly — no re-mapping needed.
 
     if args.true_on_policy_mode:
         args.sglang_enable_deterministic_inference = True

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -2321,13 +2321,16 @@ def miles_validate_args(args):
             args.offload_train = True
         if args.offload_rollout is None:
             args.offload_rollout = True
-        if args.sglang_enforce_piecewise_cuda_graph:
-            logger.warning("Warning: colocate mode with --sglang-enforce-piecewise-cuda-graph may trigger NVLS OOM.")
-        if not args.sglang_disable_piecewise_cuda_graph:
-            args.sglang_disable_piecewise_cuda_graph = True
+        if args.sglang_cuda_graph_backend_prefill is None:
+            args.sglang_cuda_graph_backend_prefill = "disabled"
             logger.info(
-                "Colocate mode: defaulting --sglang-disable-piecewise-cuda-graph to avoid NVLS OOM. "
-                "Use --sglang-enforce-piecewise-cuda-graph to override."
+                "Colocate mode: defaulting --sglang-cuda-graph-backend-prefill=disabled to avoid NVLS OOM. "
+                "Set --sglang-cuda-graph-backend-prefill explicitly to override."
+            )
+        elif args.sglang_cuda_graph_backend_prefill != "disabled":
+            logger.warning(
+                f"Warning: colocate mode with --sglang-cuda-graph-backend-prefill="
+                f"{args.sglang_cuda_graph_backend_prefill} may trigger NVLS OOM."
             )
         if args.rollout_num_gpus != args.actor_num_gpus_per_node * args.actor_num_nodes:
             logger.info(

--- a/scripts/tools/verify_session_tito_tokenizer.py
+++ b/scripts/tools/verify_session_tito_tokenizer.py
@@ -96,7 +96,7 @@ def main() -> int:
     print(f"sglang reasoning parser:{args.sglang_reasoning_parser}")
     print(f"sglang tool-call parser:{args.sglang_tool_call_parser or '(none)'}")
     print(f"Rollout GPUs per engine:{args.rollout_num_gpus_per_engine}")
-    print(f"sglang expert-parallel: {args.sglang_expert_parallel_size}")
+    print(f"sglang expert-parallel: {args.sglang_ep_size}")
     print(f"Actor nodes:            {args.actor_num_nodes}")
     print(f"Actor GPUs per node:    {args.actor_num_gpus_per_node}")
     print(f"Samples per prompt:     {args.n_samples_per_prompt}")


### PR DESCRIPTION
ci-image-tag: bump-v0.5.14-test-1
ci-sglang-pr: sglang-miles-v0.5.14

Fixes the stage-a/b-cpu failures on #1587: `AttributeError: 'Namespace' object has no attribute 'sglang_data_parallel_size'`.

sglang v0.5.14 migrated ServerArgs to dataclass-Annotated fields: the parallelism fields are now named `dp_size`/`pp_size`/`ep_size`/`attn_cp_size` (old long names remain as CLI aliases mapping to the same dest), and `{disable,enforce}_piecewise_cuda_graph` were replaced by `cuda_graph_backend_prefill` (old flags remain as deprecated aliases). User-facing `--sglang-*` CLI flags keep working unchanged; only attribute reads of the removed dests needed migration.