### PR TITLE
ci: re-enable GLM-4.7-Flash ckpt save/load e2e test

### DIFF
--- a/miles/backends/megatron_utils/arguments.py
+++ b/miles/backends/megatron_utils/arguments.py
@@ -1,12 +1,29 @@
 import logging
 import os
 
-from megatron.training.arguments import parse_args, validate_args
+import torch
+from megatron.training.arguments import parse_args
+from megatron.training.arguments import validate_args as _megatron_validate_args
 from megatron.training.tokenizer.tokenizer import _vocab_size_with_padding
 
 __all__ = ["validate_args", "parse_args", "set_default_megatron_args"]
 
 logger = logging.getLogger(__name__)
+
+
+def validate_args(args):
+    args = _megatron_validate_args(args)
+
+    optimizer_state_dtypes = (args.main_params_dtype, args.exp_avg_dtype, args.exp_avg_sq_dtype)
+    if args.optimizer_cpu_offload and any(dtype != torch.float32 for dtype in optimizer_state_dtypes):
+        # HybridDeviceOptimizer currently creates FP32 master parameters and Adam states
+        # regardless of the precision-aware optimizer dtype settings.
+        raise ValueError(
+            "--optimizer-cpu-offload does not honor lower-precision --main-params-dtype, "
+            "--exp-avg-dtype, or --exp-avg-sq-dtype; remove these dtype overrides"
+        )
+
+    return args
 
 
 def set_default_megatron_args(args):

--- a/tests/e2e/ckpt/test_glm47_flash_ckpt.py
+++ b/tests/e2e/ckpt/test_glm47_flash_ckpt.py
@@ -43,9 +43,9 @@ def prepare():
 def execute(mode: str = "", ckpt_step: int | None = None):
     ckpt_args = f"--hf-checkpoint /root/models/{MODEL_NAME}/ " f"--ref-load /root/models/{MODEL_NAME}_torch_dist "
     # dp_reshardable keys optimizer param_state by position per PP rank; PP0/PP1
-    # hold 23/24 MoE layers here (uneven PP + MTP), so its common.pt never merges
-    # on load. fully_reshardable is model-space (name-keyed), PP-heterogeneity-safe.
-    ckpt_args += "--dist-ckpt-optim-fully-reshardable "
+    # hold 23/24 MoE layers here (uneven PP + MTP), so its common.pt never merges on
+    # load. fully_reshardable is name-keyed; mem-efficient = Gloo/CPU (NCCL gather OOMs).
+    ckpt_args += "--dist-ckpt-optim-fully-reshardable --distrib-optim-fully-reshardable-mem-efficient "
     if mode == "save":
         ckpt_args += f"--save /root/models/{MODEL_NAME}_miles "
         ckpt_args += "--save-interval 2 "

--- a/tests/e2e/ckpt/test_glm47_flash_ckpt.py
+++ b/tests/e2e/ckpt/test_glm47_flash_ckpt.py
@@ -9,7 +9,7 @@ register_cuda_ci(est_time=2400, suite="stage-c-8-gpu-h200", labels=["ckpt"])
 ENABLE_EVAL = 0
 USE_DEEPEP = 0
 
-TIGHT_HOST_MEMORY = bool(int(os.environ.get("MILES_TEST_TIGHT_HOST_MEMORY", "1")))
+TIGHT_HOST_MEMORY = bool(int(os.environ.get("MILES_TEST_TIGHT_HOST_MEMORY", "0")))
 
 MODEL_NAME = "GLM-4.7-Flash"
 MODEL_TYPE = "glm4.7-flash"
@@ -42,10 +42,6 @@ def prepare():
 
 def execute(mode: str = "", ckpt_step: int | None = None):
     ckpt_args = f"--hf-checkpoint /root/models/{MODEL_NAME}/ " f"--ref-load /root/models/{MODEL_NAME}_torch_dist "
-    # dp_reshardable keys optimizer param_state by position per PP rank; PP0/PP1
-    # hold 23/24 MoE layers here (uneven PP + MTP), so its common.pt never merges on
-    # load. fully_reshardable is name-keyed; mem-efficient = Gloo/CPU (NCCL gather OOMs).
-    ckpt_args += "--dist-ckpt-optim-fully-reshardable --distrib-optim-fully-reshardable-mem-efficient "
     if mode == "save":
         ckpt_args += f"--save /root/models/{MODEL_NAME}_miles "
         ckpt_args += "--save-interval 2 "

--- a/tests/e2e/ckpt/test_glm47_flash_ckpt.py
+++ b/tests/e2e/ckpt/test_glm47_flash_ckpt.py
@@ -4,8 +4,7 @@ from tests.ci.ci_register import register_cuda_ci
 
 import miles.utils.external_utils.command_utils as U
 
-# FIXME: need to modify megatron, better fix later.
-register_cuda_ci(est_time=2400, suite="stage-c-8-gpu-h100", labels=["ckpt"], disabled="Disabled due to bugs.")
+register_cuda_ci(est_time=2400, suite="stage-c-8-gpu-h100", labels=["ckpt"])
 
 ENABLE_EVAL = 0
 USE_DEEPEP = 0

--- a/tests/e2e/ckpt/test_glm47_flash_ckpt.py
+++ b/tests/e2e/ckpt/test_glm47_flash_ckpt.py
@@ -4,12 +4,12 @@ from tests.ci.ci_register import register_cuda_ci
 
 import miles.utils.external_utils.command_utils as U
 
-register_cuda_ci(est_time=2400, suite="stage-c-8-gpu-h100", labels=["ckpt"])
+register_cuda_ci(est_time=2400, suite="stage-c-8-gpu-h200", labels=["ckpt"])
 
 ENABLE_EVAL = 0
 USE_DEEPEP = 0
 
-TIGHT_HOST_MEMORY = bool(int(os.environ.get("MILES_TEST_TIGHT_HOST_MEMORY", "0")))
+TIGHT_HOST_MEMORY = bool(int(os.environ.get("MILES_TEST_TIGHT_HOST_MEMORY", "1")))
 
 MODEL_NAME = "GLM-4.7-Flash"
 MODEL_TYPE = "glm4.7-flash"

--- a/tests/e2e/ckpt/test_glm47_flash_ckpt.py
+++ b/tests/e2e/ckpt/test_glm47_flash_ckpt.py
@@ -42,6 +42,10 @@ def prepare():
 
 def execute(mode: str = "", ckpt_step: int | None = None):
     ckpt_args = f"--hf-checkpoint /root/models/{MODEL_NAME}/ " f"--ref-load /root/models/{MODEL_NAME}_torch_dist "
+    # dp_reshardable keys optimizer param_state by position per PP rank; PP0/PP1
+    # hold 23/24 MoE layers here (uneven PP + MTP), so its common.pt never merges
+    # on load. fully_reshardable is model-space (name-keyed), PP-heterogeneity-safe.
+    ckpt_args += "--dist-ckpt-optim-fully-reshardable "
     if mode == "save":
         ckpt_args += f"--save /root/models/{MODEL_NAME}_miles "
         ckpt_args += "--save-interval 2 "

--- a/tests/e2e/megatron/test_glm47_flash/_common.py
+++ b/tests/e2e/megatron/test_glm47_flash/_common.py
@@ -6,8 +6,6 @@ import miles.utils.external_utils.command_utils as U
 MODEL_NAME = "GLM-4.7-Flash"
 MODEL_TYPE = "glm4.7-flash"
 
-TIGHT_HOST_MEMORY = bool(int(os.environ.get("MILES_TEST_TIGHT_HOST_MEMORY", "1")))
-
 
 @dataclass
 class CaseConfig:
@@ -87,11 +85,6 @@ def build_train_args(case: CaseConfig, *, wandb_file: str) -> str:
         "--use-dynamic-batch-size "
         f"--max-tokens-per-gpu {case.max_tokens_per_gpu} "
     )
-
-    if TIGHT_HOST_MEMORY:
-        perf_args += "--exp-avg-dtype fp16 "
-        perf_args += "--exp-avg-sq-dtype fp16 "
-        perf_args += "--main-params-dtype fp16 "
 
     grpo_args = (
         "--advantage-estimator grpo "

--- a/tests/e2e/megatron/test_qwen3_30B_A3B/_common.py
+++ b/tests/e2e/megatron/test_qwen3_30B_A3B/_common.py
@@ -6,8 +6,6 @@ import miles.utils.external_utils.command_utils as U
 MODEL_NAME = "Qwen3-30B-A3B"
 MODEL_TYPE = "qwen3-30B-A3B"
 
-TIGHT_HOST_MEMORY = bool(int(os.environ.get("MILES_TEST_TIGHT_HOST_MEMORY", "1")))
-
 
 @dataclass
 class CaseConfig:
@@ -130,11 +128,6 @@ def build_train_args(case: CaseConfig, *, wandb_file: str) -> str:
         "--use-dynamic-batch-size "
         f"--max-tokens-per-gpu {case.max_tokens_per_gpu} "
     )
-
-    if TIGHT_HOST_MEMORY:
-        perf_args += "--exp-avg-dtype fp16 "
-        perf_args += "--exp-avg-sq-dtype fp16 "
-        perf_args += "--main-params-dtype fp16 "
 
     # r3 path uses --use-rollout-routing-replay; non-r3 uses --use-routing-replay.
     routing_flag = "--use-rollout-routing-replay" if case.use_r3 else "--use-routing-replay"

--- a/tests/fast/test_megatron_cli_flags.py
+++ b/tests/fast/test_megatron_cli_flags.py
@@ -1,4 +1,5 @@
 import sys
+from types import SimpleNamespace
 
 import pytest
 
@@ -54,3 +55,21 @@ def test_post_layernorm_flags_propagate_to_megatron(monkeypatch):
 
     assert config.post_self_attn_layernorm is True
     assert config.post_mlp_layernorm is True
+
+
+def test_optimizer_cpu_offload_rejects_lower_precision_state_dtypes(monkeypatch):
+    torch = pytest.importorskip("torch")
+    pytest.importorskip("megatron.training.arguments")
+
+    import miles.backends.megatron_utils.arguments as megatron_arguments
+
+    args = SimpleNamespace(
+        optimizer_cpu_offload=True,
+        main_params_dtype=torch.float16,
+        exp_avg_dtype=torch.float16,
+        exp_avg_sq_dtype=torch.float16,
+    )
+    monkeypatch.setattr(megatron_arguments, "_megatron_validate_args", lambda args: args)
+
+    with pytest.raises(ValueError, match="--optimizer-cpu-offload does not honor lower-precision"):
+        megatron_arguments.validate_args(args)


### PR DESCRIPTION
## Summary
Re-enable GLM-4.7-Flash checkpoint CI without unsupported optimizer-memory settings.

## Symptom & Reproduction
- **Symptom:** `tests/e2e/ckpt/test_glm47_flash_ckpt.py` was disabled, leaving the save → load → async-save → load roundtrip without CI coverage.
- **Reproduction:** `python tests/ci/run_suite.py --hw cuda --suite stage-c-8-gpu-h200 --labels run-ci-ckpt --list-only` omitted the disabled test before this PR.
- **Observed save failure:** `fully_reshardable` triggered host OOM through 103–116 GiB of additional FP32 buffers per actor.

## Root Cause
1. `register_cuda_ci` kept the checkpoint roundtrip disabled after its original Megatron blocker was fixed.
2. `dp_reshardable` keys `param_state` positionally, so uneven PP + MTP produced unmergeable optimizer lists.
3. `fully_reshardable` uses name-keyed state but gathers every optimizer shard through FP32 buffers.
4. `HybridDeviceOptimizer` ignores the three low-precision state dtypes, so `TIGHT_HOST_MEMORY` cannot shrink those buffers.

## Fix
Re-enable the test in `stage-c-8-gpu-h200` and remove the `fully_reshardable` save path, eliminating the profiled host-OOM allocation. Remove the ineffective FP16 optimizer-state overrides from CPU-offload E2E recipes and reject any non-FP32 optimizer-state dtype after Megatron argument normalization.

This fixes the observed host OOM only. The branch returns to `dp_reshardable`; the uneven-PP optimizer-list load mismatch remains unverified until the H200 checkpoint roundtrip completes.

## Verification
- **Updated E2E:** `test_glm47_flash_ckpt.py` is registered in `stage-c-8-gpu-h200` under `run-ci-ckpt`; the remote checkpoint job has not completed yet.
- **New test:** `test_optimizer_cpu_offload_rejects_lower_precision_state_dtypes` passes and verifies the fail-fast boundary.
- **Argument-path check:** A real Megatron parse normalized all three requested dtypes to `torch.float16`, then Miles rejected the CPU-offload combination.
- **Recipe check:** Shared Qwen3-30B-A3B/GLM-4.7-Flash recipes emit `--optimizer-cpu-offload` without the three low-precision dtype flags.

## Review Focus
- Scrutinize `miles/backends/megatron_utils/arguments.py::validate_args` for the CPU-offload dtype boundary.
- Treat the H200 checkpoint roundtrip as the arbiter for the unresolved uneven-PP `dp_reshardable` load behavior.
