### PR TITLE
[Lora] Fix bridge-LoRA path silently dropping recompute args

### DIFF
--- a/miles/backends/megatron_utils/bridge_lora_helpers.py
+++ b/miles/backends/megatron_utils/bridge_lora_helpers.py
@@ -95,6 +95,9 @@ def _setup_lora_model_via_bridge(args: Namespace) -> list:
     provider.virtual_pipeline_model_parallel_size = args.virtual_pipeline_model_parallel_size
     provider.context_parallel_size = args.context_parallel_size
     provider.gradient_accumulation_fusion = args.gradient_accumulation_fusion
+    provider.recompute_granularity = args.recompute_granularity
+    provider.recompute_method = args.recompute_method
+    provider.recompute_num_layers = args.recompute_num_layers
     provider.variable_seq_lengths = True
     provider.moe_token_dispatcher_type = "alltoall"
     provider.moe_router_load_balancing_type = "none"

--- a/miles/backends/megatron_utils/bridge_lora_helpers.py
+++ b/miles/backends/megatron_utils/bridge_lora_helpers.py
@@ -98,6 +98,8 @@ def _setup_lora_model_via_bridge(args: Namespace) -> list:
     provider.recompute_granularity = args.recompute_granularity
     provider.recompute_method = args.recompute_method
     provider.recompute_num_layers = args.recompute_num_layers
+    provider.recompute_modules = args.recompute_modules
+    provider.distribute_saved_activations = args.distribute_saved_activations
     provider.variable_seq_lengths = True
     provider.moe_token_dispatcher_type = "alltoall"
     provider.moe_router_load_balancing_type = "none"


### PR DESCRIPTION
## What

`_setup_lora_model_via_bridge` builds the Megatron model from a Megatron-Bridge provider and copies a hand-picked set of megatron args onto it before `finalize()`. The recompute settings were missing from that list, so `--recompute-granularity` / `--recompute-method` / `--recompute-num-layers` were silently dropped on the bridge-LoRA path and every layer's activations stayed resident during backward.

This PR forwards the three recompute fields to the provider.

## Measured effect

gpt-oss-20B MoE LoRA (`examples/lora/run-gpt-oss-20B-megatron-moe-lora.sh`, 4xH200 TP4), train peak allocator memory per GPU:

| | peak alloc / GPU |
|---|---|
| before (recompute args dropped) | 90.9 GB |
| after (recompute active) | **44.1 GB (-46.8 GB, -51%)** |

Runs that do not pass recompute flags are unaffected: `None` is forwarded, which matches the provider default.
