### PR TITLE
Add nvidia-resiliency-ext to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ httpx[http2]
 hypothesis>=5.40
 mcp[cli]
 memray  # needed for debugging (but is lightweight), we can put it to dev mode when using pyproject.toml
+nvidia-resiliency-ext; platform_system == "Linux"
 omegaconf
 pillow
 polars

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ httpx[http2]
 hypothesis>=5.40
 mcp[cli]
 memray  # needed for debugging (but is lightweight), we can put it to dev mode when using pyproject.toml
-nvidia-resiliency-ext; platform_system == "Linux"
+nvidia-resiliency-ext~=0.6.0; platform_system == "Linux"
 omegaconf
 pillow
 polars


### PR DESCRIPTION
## What

Add `nvidia-resiliency-ext` (Linux-only) to `requirements.txt`.

## Why

The fault-tolerance trainer auto-sets `non_persistent_ckpt_type="local"` whenever `train` is in `--ft-components` (`miles/utils/arguments.py`), and Megatron requires the `nvidia_resiliency_ext` module for local checkpointing. Without it, any FT training run crashes at init with:

```
RuntimeError: nvidia_resiliency_ext is required for local checkpointing
```

The dependency is already declared on the trainer-FT branch, but it needs to be on `main` first so the `radixark/miles:dev` CI image (which bakes deps at build time via `pip install -r requirements.txt`, built from `main`) ships the module. Landing this standalone unblocks the FT e2e tests: once merged and the `dev` image is rebuilt, the FT suite can run and pass in CI.

This is a pure dependency addition — no code changes.
