### PR TITLE
Multi-turn RL on CodeContests on AMD MI35x

### DIFF
--- a/examples/experimental/qwen3-codecontests/README.md
+++ b/examples/experimental/qwen3-codecontests/README.md
@@ -1,0 +1,103 @@
+# Multi-turn RL on CodeContests on AMD MI35x 
+
+Self-contained example that RL-trains a Qwen3-30B-A3B model on the **CodeContests**
+competitive-programming dataset. The model is the backend for the **mini-swe-agent**: each turn it
+writes/edits `/app/solution.py` in a sandbox, runs it, inspects the output, and
+iterates until it submits. Reward = whether the submitted program passes the hidden
+tests. Training is **GRPO** on **token-in/token-out (TITO)** trajectories, so the
+exact tokens the agent generated are the tokens trained on.
+
+Default target: **Qwen3-30B-A3B** (MoE) in disaggregated **async** mode
+(4 train + 4 rollout GPUs) on AMD-MI35x .
+
+## How it works
+
+Two containers share a Docker network (`swe-net`):
+
+```
+┌─ miles_swe (GPU) ──────────────────┐        ┌─ agent_env (Docker-in-Docker) ─┐
+│  Megatron trainer (GRPO)           │        │  Harbor server (:11000)         │
+│  SGLang rollout engine(s)          │        │   └ spawns 1 task container     │
+│  Miles router (:31000)             │◀──────▶│     per trial (cc_base:v1)      │
+│  TITO session server (:30000)      │  model │     mini-swe-agent runs there,  │
+└────────────────────────────────────┘  calls │     grades via tests/test.sh    │
+                                                └─────────────────────────────────┘
+```
+
+Per rollout step: Miles opens a TITO session → mini-swe-agent (inside a Harbor task
+sandbox) calls back through the session server for each turn → Harbor grades the
+final `/app/solution.py` → the reward + exact token trajectory become one training
+sample → Megatron does a GRPO update → weights sync back to SGLang.
+
+## Prerequisites
+
+- A host with idle GPU(s) and a healthy ROCm stack, plus Docker.
+- Two container images available to the host Docker daemon (override names via env):
+  - trainer image (`MILES_IMAGE`: `rlsys/miles:MI350-355-latest`)
+  - Harbor image (`AGENT_IMAGE`: `aigmkt/aai-2026-harbor:v1`)
+- This repo checked out on the host (both containers bind-mount it identity-mapped).
+
+## Run it
+
+```bash
+cd examples/experimental/qwen3-codecontests
+WANDB_KEY=<optional> bash run_training_amd.sh
+```
+
+Everything is derived from the repo root and overridable via env. Useful flags:
+
+```bash
+bash run_training_amd.sh --skip-setup   # reuse running containers + installed miles
+bash run_training_amd.sh --skip-data    # reuse prepared data + model
+bash run_training_amd.sh --fresh-data   # wipe extracted tasks + jsonls, rebuild
+bash run_training_amd.sh --reset        # restart the trainer between runs
+bash run_training_amd.sh --teardown     # remove containers + task sandboxes
+bash run_training_amd.sh -- --num-rollout 50 --save-interval 5   # passthrough to the launcher
+```
+
+Runtime data (tasks, trials, HF cache) lives under `$RUNTIME`
+(default `<this dir>/runtime`); point it at a big disk if you have one:
+`RUNTIME=/data/$USER/cc bash run_training_amd.sh`.
+
+Training streams to the terminal and to `$WORK_DIR/train.log`; tail that file in a
+second shell to watch progress.
+
+## What the run does (in order)
+
+1. **Host setup** — create `swe-net`, clean any stale containers.
+2. **Containers** — launch `miles_swe` (trainer/SGLang/router/session server) and
+   `agent_env` (Harbor), both bind-mounting this repo identity-mapped.
+3. **Install miles** — `pip install -e . --no-deps` inside `miles_swe`.
+4. **Harbor** — start `harbor/server.py`, wait for `/health`.
+5. **Data prep** — `extract_codecontests.py` downloads `open-thoughts/CodeContests`
+   into `$TASKS_DIR/<task_id>/`; `build_cc_jsonl.py` writes the per-difficulty JSONLs
+   and the combined **`cc_train_all_sorted.jsonl`** used as `--prompt-data`.
+6. **Fast spawn** — bake a tiny `cc_base:v1` (python3) once and rewrite each task
+   Dockerfile to `FROM` it, collapsing per-trial container spawn toward the ~5s floor.
+7. **Model prefetch** — pull the Qwen3 weights into the HF cache.
+8. **Train** — async GRPO loop via `run-qwen3-codecontests.py`.
+
+## Caveats
+
+- The script **does not build** the trainer/Harbor images — it `docker run`s them; build/pull first.
+- `cc_base:v1` is **local-only** (built on the host daemon Harbor uses); it must exist
+  before task containers spawn (the data-prep step builds it).
+- `--privileged --ipc host` is used for GPU access; ensure the host GPU stack is healthy.
+- W&B is driven by `WANDB_KEY`/`WANDB_API_KEY` from the environment; empty ⇒ disabled.
+  Never hard-code a key.
+
+## Layout
+
+| Path | What |
+|---|---|
+| `run_training_amd.sh` | **Entry point** — brings up both containers, installs miles, starts Harbor, preps data, and runs the async GRPO loop. ROCm/MI35x. |
+| `run-qwen3-codecontests.py` | Training launcher (Typer); maps args → `launcher_args.py` → `execute_train`. |
+| `launcher_args.py` | Dependency-free builder of the train-arg string (topology, GRPO, SGLang, session server). |
+| `data_prep/extract_codecontests.py` | Download the HF dataset → per-task Harbor dirs; optional task-Dockerfile rewrite for fast spawn. |
+| `data_prep/build_cc_jsonl.py` | Task dirs → per-difficulty JSONLs **and** the combined `cc_train_all_sorted.jsonl` (easy→hard). |
+| `harbor/server.py` | FastAPI `/run` server wrapping Harbor's Trial API; maps results → reward/metrics. |
+| `harbor/swe_agent_function.py` | Miles→Harbor bridge: dispatches a rollout to the Harbor server. |
+| `harbor/generate.py` | Reward function, agent-metric aggregation, and the rollout class. |
+| `harbor/codecontests.yaml` | mini-swe-agent config for the CodeContests contract (`/app/solution.py`, stdin→stdout). |
+| `harbor/swe_net_override.yaml` | Compose override so task containers join `swe-net` and can reach the router. |
+

--- a/examples/experimental/qwen3-codecontests/data_prep/build_cc_jsonl.py
+++ b/examples/experimental/qwen3-codecontests/data_prep/build_cc_jsonl.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Build Miles prompt JSONLs from extracted CodeContests Harbor task dirs.
+
+Walks ``<tasks>/`` (output of extract_codecontests.py), reading each task's
+``instruction.md`` as the prompt, and emits BOTH:
+
+  1. Per-difficulty files ``cc_train_<bucket>.jsonl`` (one per difficulty bucket).
+  2. A single combined file (default ``cc_train_all_sorted.jsonl``) containing
+     every task ordered by INCREASING difficulty (Codeforces rating ascending),
+     with unrated tasks last. This is the curriculum file the training run
+     consumes as ``--prompt-data``.
+
+Difficulty comes from the Codeforces ``Rating`` field in each task's
+``instruction.md`` (the only real per-problem difficulty signal; the
+``difficulty`` field in task.toml is a constant "medium" and is ignored).
+
+Each output line is a Miles sample:
+    {"prompt": <instruction.md>,
+     "metadata": {"instance_id": <dir>, "agent_name": "mini-swe-agent",
+                  "split": "train", "rating": <int|null>, "difficulty": <bucket>}}
+
+CRITICAL: ``metadata.instance_id`` MUST equal the task directory name, because
+``server.py`` resolves the task under ``HARBOR_TASKS_DIR`` by that id. A mismatch
+yields ``TaskNotFound`` and silent 0.0 rewards.
+
+Buckets (by Codeforces rating):
+    easy        : rating <  1200
+    easy_medium : 1200 <= rating < 1600
+    medium      : 1600 <= rating < 2000
+    hard        : 2000 <= rating < 2400
+    very_hard   : rating >= 2400
+    unrated     : no Rating / Rating == 0
+
+Usage:
+    # emit per-difficulty files + the combined ascending-difficulty file
+    python build_cc_jsonl.py --tasks ~/harbor_tasks_cc --out-dir ./data
+
+    # quick validation on the first 20 tasks
+    python build_cc_jsonl.py --tasks ~/harbor_tasks_cc --out-dir ./data --limit 20
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+from pathlib import Path
+
+# Ordered easiest -> hardest; the combined file follows this order (unrated last).
+BUCKETS = ["easy", "easy_medium", "medium", "hard", "very_hard", "unrated"]
+_RATING_RE = re.compile(r"\*\*Rating\*\*:\s*(\d+)")
+
+
+def bucket_for(rating: int | None) -> str:
+    if not rating:  # None or 0
+        return "unrated"
+    if rating < 1200:
+        return "easy"
+    if rating < 1600:
+        return "easy_medium"
+    if rating < 2000:
+        return "medium"
+    if rating < 2400:
+        return "hard"
+    return "very_hard"
+
+
+def parse_rating(instruction_text: str) -> int | None:
+    m = _RATING_RE.search(instruction_text)
+    if not m:
+        return None
+    r = int(m.group(1))
+    return r if r > 0 else None
+
+
+def build(
+    tasks_dir: str,
+    out_dir: str,
+    *,
+    agent_name: str = "mini-swe-agent",
+    split: str = "train",
+    limit: int | None = None,
+    combined_name: str = "cc_train_all_sorted.jsonl",
+) -> dict[str, int]:
+    tasks = Path(os.path.expanduser(tasks_dir))
+    if not tasks.is_dir():
+        raise FileNotFoundError(f"tasks dir not found: {tasks}")
+    out = Path(os.path.expanduser(out_dir))
+    out.mkdir(parents=True, exist_ok=True)
+
+    samples: list[dict] = []
+    for d in sorted(p for p in tasks.iterdir() if p.is_dir()):
+        instr = d / "instruction.md"
+        if not instr.is_file():
+            continue
+        text = instr.read_text(errors="replace")
+        prompt = text.strip()
+        if not prompt:
+            continue
+        rating = parse_rating(text)
+        samples.append(
+            {
+                "prompt": prompt,
+                "metadata": {
+                    "instance_id": d.name,  # MUST match the task dir name
+                    "agent_name": agent_name,
+                    "split": split,
+                    "rating": rating,
+                    "difficulty": bucket_for(rating),
+                },
+            }
+        )
+        if limit is not None and len(samples) >= limit:
+            break
+
+    # Increasing difficulty: rated tasks by ascending rating, then unrated last.
+    # (rating is None) sorts True > False, so unrated lands at the end; ties broken
+    # by instance_id for determinism.
+    samples.sort(key=lambda s: (s["metadata"]["rating"] is None, s["metadata"]["rating"] or 0, s["metadata"]["instance_id"]))
+
+    counts = {b: 0 for b in BUCKETS}
+    bucket_files = {b: open(out / f"cc_train_{b}.jsonl", "w") for b in BUCKETS}
+    combined_path = out / combined_name
+    try:
+        with open(combined_path, "w") as combined:
+            for s in samples:
+                line = json.dumps(s) + "\n"
+                combined.write(line)
+                b = s["metadata"]["difficulty"]
+                bucket_files[b].write(line)
+                counts[b] += 1
+    finally:
+        for f in bucket_files.values():
+            f.close()
+
+    total = sum(counts.values())
+    print(f"wrote {total} samples -> {out}")
+    for b in BUCKETS:
+        print(f"  cc_train_{b}.jsonl : {counts[b]}")
+    print(f"combined (increasing difficulty): {total} lines -> {combined_path.name}")
+    return counts
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(
+        description="CodeContests task dirs -> per-difficulty JSONLs + a combined ascending-difficulty JSONL"
+    )
+    ap.add_argument("--tasks", default=os.path.expanduser("~/harbor_tasks_cc"))
+    ap.add_argument("--out-dir", default=str(Path(__file__).resolve().parent.parent / "data"))
+    ap.add_argument("--agent-name", default="mini-swe-agent")
+    ap.add_argument("--split", default="train")
+    ap.add_argument("--limit", type=int, default=None)
+    ap.add_argument("--combined-name", default="cc_train_all_sorted.jsonl",
+                    help="filename for the combined increasing-difficulty JSONL (written under --out-dir)")
+    args = ap.parse_args()
+    build(
+        args.tasks,
+        args.out_dir,
+        agent_name=args.agent_name,
+        split=args.split,
+        limit=args.limit,
+        combined_name=args.combined_name,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/experimental/qwen3-codecontests/data_prep/build_cc_jsonl.py
+++ b/examples/experimental/qwen3-codecontests/data_prep/build_cc_jsonl.py
@@ -120,9 +120,13 @@ def build(
     samples.sort(key=lambda s: (s["metadata"]["rating"] is None, s["metadata"]["rating"] or 0, s["metadata"]["instance_id"]))
 
     counts = {b: 0 for b in BUCKETS}
-    bucket_files = {b: open(out / f"cc_train_{b}.jsonl", "w") for b in BUCKETS}
     combined_path = out / combined_name
-    try:
+    from contextlib import ExitStack
+    with ExitStack() as stack:
+        bucket_files = {
+            b: stack.enter_context(open(out / f"cc_train_{b}.jsonl", "w"))
+            for b in BUCKETS
+        }
         with open(combined_path, "w") as combined:
             for s in samples:
                 line = json.dumps(s) + "\n"
@@ -130,9 +134,6 @@ def build(
                 b = s["metadata"]["difficulty"]
                 bucket_files[b].write(line)
                 counts[b] += 1
-    finally:
-        for f in bucket_files.values():
-            f.close()
 
     total = sum(counts.values())
     print(f"wrote {total} samples -> {out}")

--- a/examples/experimental/qwen3-codecontests/data_prep/extract_codecontests.py
+++ b/examples/experimental/qwen3-codecontests/data_prep/extract_codecontests.py
@@ -191,8 +191,11 @@ def prepare(
 
     total = 0
     for p in pqs:
+        if limit is not None and total >= limit:
+            break
         print(f"extracting {p.name} ...")
-        total += extract_parquet(p, out_dir, limit=limit, workers=workers)
+        remaining_limit = limit - total if limit is not None else None
+        total += extract_parquet(p, out_dir, limit=remaining_limit, workers=workers)
     print(f"done: {total} task dirs under {out_dir}")
     if base_image:
         n = rewrite_dockerfiles(str(out_dir), base_image)

--- a/examples/experimental/qwen3-codecontests/data_prep/extract_codecontests.py
+++ b/examples/experimental/qwen3-codecontests/data_prep/extract_codecontests.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""Extract CodeContests (or any Harbor-packaged HF dataset) into task dirs.
+
+The dataset ``open-thoughts/CodeContests`` ships parquet files with two columns:
+``path`` (task id, e.g. ``code_contests-0000``) and ``task_binary`` (a gzip tar
+archive of that task's Harbor directory: instruction.md, environment/Dockerfile,
+tests/, ...). This script downloads the dataset and extracts every task into
+
+    <out>/<task_id>/...
+
+It depends ONLY on ``pyarrow`` + ``tarfile`` (+ ``huggingface_hub`` for download).
+No SkyRL, no Harbor adapter. Logic mirrors the dataset's own
+``extract_parquet_tasks.py`` with hardened (path-traversal-safe) extraction.
+
+Usage:
+    # download from HF then extract
+    python extract_codecontests.py --dataset open-thoughts/CodeContests --out ~/harbor_tasks_cc
+
+    # extract from a parquet you already have (offline)
+    python extract_codecontests.py --parquet /path/tasks.parquet --out ~/harbor_tasks_cc
+
+    # only the first N tasks (quick validation)
+    python extract_codecontests.py --dataset open-thoughts/CodeContests --out ~/harbor_tasks_cc --limit 20
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import os
+import tarfile
+from concurrent.futures import ProcessPoolExecutor
+from pathlib import Path, PurePosixPath
+
+
+def _is_within(base: Path, target: Path) -> bool:
+    try:
+        return os.path.commonpath([str(base.resolve()), str(target.resolve())]) == str(
+            base.resolve()
+        )
+    except Exception:
+        return False
+
+
+def _sanitize_member_name(name: str) -> str:
+    parts = [p for p in PurePosixPath(name).parts if p not in ("..", ".", "", "/")]
+    return str(PurePosixPath(*parts)) if parts else ""
+
+
+def _safe_extract_tar(archive_bytes: bytes, dest_dir: Path) -> None:
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    with tarfile.open(fileobj=io.BytesIO(archive_bytes), mode="r:*") as tf:
+        for member in tf.getmembers():
+            name = _sanitize_member_name(member.name)
+            if not name:
+                continue
+            if ".snapshot" in PurePosixPath(name).parts:
+                continue
+            target = (dest_dir / name).resolve()
+            if not _is_within(dest_dir, target):
+                raise RuntimeError(f"unsafe path in archive: {member.name!r}")
+            if member.isdir():
+                target.mkdir(parents=True, exist_ok=True)
+            elif member.isfile():
+                target.parent.mkdir(parents=True, exist_ok=True)
+                src = tf.extractfile(member)
+                if src is None:
+                    continue
+                with src, open(target, "wb") as dst:
+                    dst.write(src.read())
+
+
+def _extract_one(args: tuple) -> bool:
+    rel_path, data, out_dir_str = args
+    if not isinstance(rel_path, str) or not isinstance(data, (bytes, bytearray, memoryview)):
+        return False
+    out_dir = Path(out_dir_str)
+    parts = [p for p in PurePosixPath(rel_path).parts if p not in ("..", "")]
+    target = (out_dir / Path(*parts)).resolve() if parts else (out_dir / "task_unknown")
+    if not _is_within(out_dir, target):
+        return False
+    if target.exists() and (target / "instruction.md").exists():
+        return True  # idempotent: already extracted
+    try:
+        _safe_extract_tar(bytes(data), target)
+        return True
+    except Exception as e:  # noqa: BLE001
+        print(f"  WARN failed to extract {rel_path}: {e}")
+        return False
+
+
+def _find_task_parquets(root: Path) -> list[Path]:
+    import pyarrow.parquet as pq
+
+    found = []
+    for f in sorted(root.glob("**/*.parquet")):
+        try:
+            names = pq.read_schema(f).names
+        except Exception:  # noqa: BLE001
+            continue
+        if "path" in names and "task_binary" in names:
+            found.append(f)
+    return found
+
+
+def extract_parquet(parquet_path: Path, out_dir: Path, limit: int | None = None, workers: int = 8) -> int:
+    import pyarrow.parquet as pq
+
+    table = pq.read_table(parquet_path, columns=["path", "task_binary"])
+    paths = table.column("path").to_pylist()
+    data = table.column("task_binary").to_pylist()
+    if limit is not None:
+        paths, data = paths[:limit], data[:limit]
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    jobs = [(p, d, str(out_dir)) for p, d in zip(paths, data)]
+    with ProcessPoolExecutor(max_workers=workers) as pool:
+        results = list(pool.map(_extract_one, jobs, chunksize=32))
+    return sum(results)
+
+
+def rewrite_dockerfiles(tasks_dir: str, base_image: str) -> int:
+    """Point every task's ``environment/Dockerfile`` at a prebuilt ``base_image`` and drop
+    the per-task ``apt-get install python3`` line.
+
+    All CodeContests tasks ship the SAME Dockerfile (``FROM ubuntu:24.04`` + an apt
+    python install). Harbor builds a separate image per task, so that ~40s apt fetch is
+    paid on almost every sandbox spawn. If Python is baked once into ``base_image`` and
+    each task Dockerfile just ``FROM``s it (no apt), the per-task build becomes ~instant
+    (all heavy layers cached) and spawn collapses toward the ~5s container-create floor.
+
+    Idempotent: a Dockerfile already pointing at ``base_image`` is left unchanged.
+    Returns the number of Dockerfiles actually modified.
+    """
+    root = Path(os.path.expanduser(tasks_dir)).resolve()
+    changed = 0
+    for df in sorted(root.glob("*/environment/Dockerfile")):
+        try:
+            original = df.read_text()
+        except Exception:  # noqa: BLE001
+            continue
+        out_lines = []
+        for ln in original.splitlines():
+            low = ln.strip().lower()
+            if low.startswith("from "):
+                out_lines.append(f"FROM {base_image}")
+                continue
+            # the expensive line — python is baked into base_image now, so drop it
+            if low.startswith("run ") and "apt-get" in low and "python3" in low:
+                continue
+            out_lines.append(ln)
+        new = "\n".join(out_lines) + "\n"
+        if new != original:
+            df.write_text(new)
+            changed += 1
+    return changed
+
+
+def prepare(
+    *,
+    dataset: str | None,
+    parquet: str | None,
+    out: str,
+    limit: int | None = None,
+    workers: int = 8,
+    base_image: str | None = None,
+    rewrite_only: bool = False,
+) -> str:
+    out_dir = Path(os.path.expanduser(out)).resolve()
+
+    if rewrite_only:
+        if not base_image:
+            raise ValueError("--rewrite-only requires --base-image")
+        n = rewrite_dockerfiles(str(out_dir), base_image)
+        print(f"rewrote {n} task Dockerfiles -> FROM {base_image}  (under {out_dir})")
+        return str(out_dir)
+
+    if parquet:
+        pqs = [Path(os.path.expanduser(parquet))]
+    else:
+        if not dataset:
+            raise ValueError("either --dataset or --parquet is required")
+        from huggingface_hub import snapshot_download
+
+        print(f"downloading {dataset} ...")
+        snap = Path(snapshot_download(repo_id=dataset, repo_type="dataset"))
+        print(f"  -> {snap}")
+        pqs = _find_task_parquets(snap)
+        if not pqs:
+            raise RuntimeError(f"no parquet with (path, task_binary) columns found under {snap}")
+
+    total = 0
+    for p in pqs:
+        print(f"extracting {p.name} ...")
+        total += extract_parquet(p, out_dir, limit=limit, workers=workers)
+    print(f"done: {total} task dirs under {out_dir}")
+    if base_image:
+        n = rewrite_dockerfiles(str(out_dir), base_image)
+        print(f"rewrote {n} task Dockerfiles -> FROM {base_image}")
+    return str(out_dir)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Extract Harbor CodeContests tasks (no SkyRL).")
+    ap.add_argument("--dataset", default="open-thoughts/CodeContests", help="HF dataset id")
+    ap.add_argument("--parquet", default=None, help="extract from a local parquet instead of downloading")
+    ap.add_argument("--out", default=os.path.expanduser("~/harbor_tasks_cc"))
+    ap.add_argument("--limit", type=int, default=None, help="only first N tasks")
+    ap.add_argument("--workers", type=int, default=8)
+    ap.add_argument("--base-image", default=None,
+                    help="if set, rewrite each task Dockerfile to FROM this prebuilt image "
+                         "and drop the per-task apt python install (faster sandbox spawn)")
+    ap.add_argument("--rewrite-only", action="store_true",
+                    help="skip download/extract; only rewrite Dockerfiles in --out to use --base-image")
+    args = ap.parse_args()
+    prepare(
+        dataset=None if args.parquet else args.dataset,
+        parquet=args.parquet,
+        out=args.out,
+        limit=args.limit,
+        workers=args.workers,
+        base_image=args.base_image,
+        rewrite_only=args.rewrite_only,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/experimental/qwen3-codecontests/harbor/codecontests.yaml
+++ b/examples/experimental/qwen3-codecontests/harbor/codecontests.yaml
@@ -1,0 +1,169 @@
+# mini-swe-agent config for the CodeContests Harbor dataset (Qwen3-8B / Miles).
+#
+# Modeled on minisweagent v2.3.0 config/benchmarks/swebench.yaml, but adapted for
+# competitive-programming tasks instead of SWE-bench repo bug-fixing:
+#   * submission target is a single file /app/solution.py (NOT a git diff)
+#   * working dir is /app (NOT /testbed); there is no repo
+#   * environment_class: local (the agent already runs inside the Harbor-spawned
+#     task container; `local` runs commands in that container, `docker`/`shell`
+#     are wrong here)
+#
+# The task instruction.md already states the contract ("Write your Python
+# solution to /app/solution.py", stdin->stdout); this template reinforces it and
+# defines the finish signal mini-swe-agent/Harbor recognizes.
+#
+# mini-swe-agent keeps an append-only message history (system, user, assistant,
+# tool, assistant, ...) and resends it each turn, so it is compatible with the
+# Miles TITO session server (assistant messages anchor the token checkpoints).
+#
+# Wire it in via:  MSWEA_CONFIG_FILE=/root/miles_qwen/examples/experimental/qwen3-codecontests/codecontests.yaml
+
+agent:
+  system_template: |
+    You are an AI assistant tasked with solving command-line tasks in a Linux
+    environment. You are given a task description and the output from previously
+    executed commands, and you solve the task by issuing shell commands.
+
+    For every response, reason in three steps before acting:
+    - Analysis: analyze the current state from the latest command output - what do
+      you see, what has been accomplished, and what still needs to be done?
+    - Plan: describe the next step(s) and what you expect each command to do.
+    - Act: issue the command(s) via the bash tool.
+
+    Concretely, you solve competitive-programming problems by writing a Python
+    program, testing it on the provided example(s), and submitting once correct.
+  instance_template: |
+    <problem>
+    {{task}}
+    </problem>
+
+    <instructions>
+    # Task Instructions
+
+    ## Goal
+    Solve the competitive-programming problem above by writing a **Python 3**
+    program and saving it to **/app/solution.py**. The program must:
+    1. Read all input from standard input (stdin).
+    2. Write the answer to standard output (stdout).
+    3. Match the required output format exactly (whitespace/newlines/case).
+    4. Run within time/memory limits and handle the stated constraints/edge cases.
+
+    The grader runs `python3 /app/solution.py`, feeds it each hidden test input on
+    stdin, and compares stdout. Only the file at /app/solution.py is graded.
+
+    ## How you operate
+    You are given the task and the output of previously executed commands, and you
+    proceed step-by-step. Each response MUST contain, in order:
+    1. **Analysis** - what the latest output shows: what is done, what remains.
+    2. **Plan** - the next command(s) and what you expect each to accomplish.
+    3. **At least one bash tool call** to execute your planned command(s).
+
+    Execution notes:
+    - The system runs each command in a FRESH subshell and returns the result;
+      directory/env changes do NOT persist across commands. Prefix with
+      `cd /app && ...` or write/load env from files as needed.
+    - Prefer small, verifiable steps so you can iterate on each result.
+
+    ## Recommended workflow
+    1. Re-read the problem; note input/output format and constraints.
+    2. Write your solution to /app/solution.py (use a heredoc, see example).
+    3. Test it against the sample input shown in the problem and verify the
+       sample output matches exactly.
+    4. Fix and re-test until the sample passes (and consider edge cases).
+    5. Submit (see below).
+
+    ## Creating /app/solution.py
+    ```bash
+    mkdir -p /app && cat <<'EOF' > /app/solution.py
+    import sys
+    def main():
+        data = sys.stdin.read().split()
+        # ... your solution ...
+    if __name__ == "__main__":
+        main()
+    EOF
+    ```
+
+    ## Testing against the sample
+    ```bash
+    printf '3\n((()))\n(())()\n()((\n' | python3 /app/solution.py
+    ```
+
+    ## Submission
+    When /app/solution.py is correct, submit by issuing EXACTLY this command on
+    its own (do NOT combine it with other commands):
+
+    ```bash
+    echo COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT
+    ```
+
+    <important>
+    - /app/solution.py MUST exist at submission time; it is the only graded file.
+    - You CANNOT continue working after submitting.
+    </important>
+    </instructions>
+
+    <system_information>
+    {{system}} {{release}} {{version}} {{machine}}
+    </system_information>
+  # Contest problems need far fewer steps than SWE-bench repos; generous but bounded.
+  step_limit: 100
+  cost_limit: 0.
+
+environment:
+  # The agent runs inside the Harbor-spawned task container; run commands there.
+  environment_class: local
+  cwd: "/app"
+  timeout: 60
+  interpreter: ["bash", "-c"]
+  env:
+    PAGER: cat
+    MANPAGER: cat
+    LESS: -R
+    PIP_PROGRESS_BAR: "off"
+    TQDM_DISABLE: "1"
+
+model:
+  # model_name is injected at runtime by the Harbor adapter / Miles (openai/model
+  # served by the SGLang router), so it is intentionally not pinned here.
+  observation_template: |
+    {% if output.exception_info -%}
+    <exception>{{output.exception_info}}</exception>
+    {% endif -%}
+    <returncode>{{output.returncode}}</returncode>
+    {% if output.output | length < 10000 -%}
+    <output>
+    {{ output.output -}}
+    </output>
+    {%- else -%}
+    <warning>
+    The output of your last command was too long; show less (head/tail/sed) or
+    redirect to a file and search it.
+    </warning>
+    <output_head>
+    {{ output.output[:5000] }}
+    </output_head>
+    <elided_chars>
+    {{ output.output | length - 10000 }} characters elided
+    </elided_chars>
+    <output_tail>
+    {{ output.output[-5000:] }}
+    </output_tail>
+    {%- endif -%}
+  format_error_template: |
+    Tool call error:
+
+    <error>
+    {{error}}
+    </error>
+
+    Every response must call the 'bash' tool at least once:
+    - Tool: bash
+    - Arguments: {"command": "your_command_here"}
+
+    When finished, submit with exactly: `echo COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT`
+    on its own (not combined with other commands).
+  model_kwargs:
+    drop_params: true
+    # Single command per turn keeps the trajectory linear and TITO-friendly.
+    parallel_tool_calls: false

--- a/examples/experimental/qwen3-codecontests/harbor/generate.py
+++ b/examples/experimental/qwen3-codecontests/harbor/generate.py
@@ -1,0 +1,121 @@
+"""
+Agent V2: reward, metrics, and rollout class.
+
+The generate function is provided by:
+    miles.rollout.generate_hub.agentic_tool_call.generate
+with --custom-agent-function-path pointing to swe_agent_function.run
+
+Task-type agnostic — reward is pre-computed by the Harbor environment
+and stored in sample.metadata["reward"] regardless of task type.
+
+Dynamic filter uses the general-purpose ``check_no_aborted`` from
+``miles.rollout.filter_hub.dynamic_sampling_filters``.
+
+Components:
+  - reward_func: reads pre-computed reward from sample metadata
+  - aggregate_agent_metrics: aggregates agent timing/count metrics
+  - RolloutFn: InferenceRolloutFn subclass that logs agent metrics
+"""
+
+import logging
+import os
+
+from miles.rollout.base_types import RolloutFnTrainInput, RolloutFnTrainOutput
+from miles.rollout.inference_rollout.inference_rollout_common import InferenceRolloutFn
+from miles.utils.types import Sample
+
+logger = logging.getLogger(__name__)
+
+
+# -- Reward --
+
+
+async def reward_func(args, samples: Sample | list[Sample], **kwargs) -> float | list[float]:
+    """Reward is pre-computed by the agent environment during generate().
+
+    Handles both single-sample calls (from ``async_rm``) and batched calls
+    (from ``batched_async_rm`` when ``--custom-rm-path`` is set).
+    """
+    if isinstance(samples, list):
+        return [s.metadata.get("reward", 0.0) for s in samples]
+    return samples.metadata.get("reward", 0.0)
+
+
+# -- Agent Metrics Aggregation --
+
+
+def _collect_values(all_metrics: list[dict], key: str) -> list[float]:
+    return [m.get(key, 0) for m in all_metrics]
+
+
+def _agg_mean(metrics: dict, all_metrics: list[dict], keys: list[str], prefix: str = "agent/", suffix: str = "_mean"):
+    for key in keys:
+        values = _collect_values(all_metrics, key)
+        if values:
+            metrics[f"{prefix}{key}{suffix}"] = sum(values) / len(values)
+
+
+def aggregate_agent_metrics(samples: list[Sample]) -> dict:
+    """Aggregate agent metrics across samples for logging."""
+    all_metrics = [
+        s.metadata.get("agent_metrics", {})
+        for s in samples
+        if hasattr(s, "metadata") and s.metadata and s.metadata.get("agent_metrics")
+    ]
+    if not all_metrics:
+        return {}
+
+    metrics = {}
+
+    for key in ["turns", "tool_calls"]:
+        values = _collect_values(all_metrics, key)
+        if values:
+            metrics[f"agent/{key}_mean"] = sum(values) / len(values)
+            metrics[f"agent/{key}_sum"] = sum(values)
+
+    _agg_mean(metrics, all_metrics, ["model_query_time_sum", "env_execution_time_sum", "eval_time", "agent_run_time"])
+    _agg_mean(metrics, all_metrics, ["time_per_turn", "model_query_time_avg", "env_execution_time_avg"], suffix="")
+    _agg_mean(metrics, all_metrics, ["model_time_ratio", "env_time_ratio", "eval_time_ratio"], suffix="")
+    # End-to-end Harbor trial phase timings (from server.py _extract_metrics):
+    # sandbox spawn, agent install, and the teardown+overhead residual. reward/agent-run
+    # already covered above via eval_time / agent_run_time.
+    _agg_mean(metrics, all_metrics, ["spawn_time", "agent_setup_time", "teardown_overhead_time"])
+
+    values = _collect_values(all_metrics, "total_time")
+    if values:
+        metrics["agent/total_time_mean"] = sum(values) / len(values)
+        metrics["agent/total_time_max"] = max(values)
+        metrics["agent/total_time_min"] = min(values)
+
+    return metrics
+
+
+# -- Rollout Function --
+
+
+class RolloutFn(InferenceRolloutFn):
+    """Rollout function with agent metrics aggregation."""
+
+    async def _call_train(self, input: RolloutFnTrainInput) -> RolloutFnTrainOutput:
+        # Tag every trial spawned during this rollout with its rollout_id. Rollouts
+        # generate one at a time in this process, so a process env var is a safe,
+        # race-free channel: swe_agent_function.run reads it and forwards it in the
+        # /run request, and server.py writes it into each trial dir.
+        os.environ["MILES_ROLLOUT_ID"] = str(input.rollout_id)
+        output = await super()._call_train(input)
+
+        all_samples = []
+        for group in output.samples:
+            if isinstance(group, list):
+                all_samples.extend(group)
+            else:
+                all_samples.append(group)
+
+        agent_metrics = aggregate_agent_metrics(all_samples)
+        if agent_metrics:
+            metrics = output.metrics or {}
+            metrics.update(agent_metrics)
+            output.metrics = metrics
+            logger.info(f"Agent metrics for rollout {input.rollout_id}: {agent_metrics}")
+
+        return output

--- a/examples/experimental/qwen3-codecontests/harbor/server.py
+++ b/examples/experimental/qwen3-codecontests/harbor/server.py
@@ -1,0 +1,484 @@
+"""
+FastAPI server wrapping Harbor for generalized agent-environment orchestration.
+
+Provides a single ``/run`` endpoint that handles any task type (SWE-bench,
+Terminal-Bench, custom datasets, etc.) through Harbor's unified Trial API.
+Harbor handles Docker orchestration, agent execution, and grading — the
+server is task-type agnostic.
+
+Requires:
+    - Harbor installed: pip install harbor-framework
+    - Prepared task dirs under HARBOR_TASKS_DIR (via adapters or prepare_harbor_tasks.py)
+
+Usage:
+    python server.py --port 11000 --max-concurrent 8
+"""
+
+import argparse
+import asyncio
+import logging
+import os
+import re
+import traceback
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import Any
+
+import uvicorn
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
+
+
+_semaphore: asyncio.Semaphore | None = None
+
+# Strong refs to in-flight background teardown tasks (see _install_async_teardown), so the
+# event loop doesn't garbage-collect them mid-flight.
+_bg_stops: set[asyncio.Task] = set()
+
+
+def _install_async_teardown() -> None:
+    """Opt-in (``HARBOR_ASYNC_TEARDOWN=1``): delete the task container in the BACKGROUND
+    instead of blocking each trial on it.
+
+    By default Harbor's ``Trial._finalize()`` ``await``s ``_stop_agent_environment()`` — a
+    synchronous ``docker compose down`` — BEFORE it writes ``result.json`` / returns the
+    trial, so container teardown sits on every sample's critical path (tens of seconds).
+    This monkey-patch makes ``_stop_agent_environment`` schedule the stop as a
+    fire-and-forget task and return immediately, so the sample is handed back to the
+    rollout without waiting for teardown.
+
+    Safe by construction: only Harbor schedules the stop, and only at the point it would
+    have deleted synchronously (trajectory + verifier already done) — so there is NO
+    create->start race like an external ``docker rm`` reaper. Trade-off: the concurrency
+    semaphore is released before the container is actually gone, so peak container count
+    can briefly exceed ``--max-concurrent`` while background deletes drain.
+    """
+    if os.getenv("HARBOR_ASYNC_TEARDOWN", "").lower() not in ("1", "true", "t", "yes"):
+        return
+    try:
+        from harbor.trial.trial import Trial
+    except Exception as e:  # noqa: BLE001
+        logger.warning(f"HARBOR_ASYNC_TEARDOWN requested but Harbor Trial import failed: {e}")
+        return
+
+    async def _guarded_stop(env: Any, delete: bool, name: str) -> None:
+        try:
+            await env.stop(delete=delete)
+        except Exception as e:  # noqa: BLE001
+            logger.debug(f"async teardown failed for {name}: {e}")
+
+    async def _async_stop(self) -> None:
+        # Preserve Harbor's idempotency guard: only the first call schedules the stop.
+        if getattr(self, "_is_agent_environment_stopped", False):
+            return
+        self._is_agent_environment_stopped = True
+        task = asyncio.create_task(
+            _guarded_stop(self.agent_environment, self.config.environment.delete, self.config.trial_name)
+        )
+        _bg_stops.add(task)
+        task.add_done_callback(_bg_stops.discard)
+
+    Trial._stop_agent_environment = _async_stop
+    logger.info("HARBOR_ASYNC_TEARDOWN enabled: task-container teardown runs in the background")
+
+
+@asynccontextmanager
+async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
+    global _semaphore
+    max_concurrent = int(os.getenv("AGENT_MAX_CONCURRENT", os.getenv("SWE_AGENT_MAX_CONCURRENT", "8")))
+    _semaphore = asyncio.Semaphore(max_concurrent)
+    logger.info(f"Initialized semaphore with max_concurrent={max_concurrent}")
+    _install_async_teardown()
+    yield
+
+
+app = FastAPI(title="Agent Environment Server (Harbor)", lifespan=_lifespan)
+
+
+class RunRequest(BaseModel):
+    base_url: str
+    model: str
+    sampling_params: dict[str, Any] = {}
+    api_key: str = "dummy"
+
+    instance_id: str = ""
+    agent_name: str = "mini-swe-agent"
+    max_seq_len: int | None = None
+    rollout_id: int | None = None
+
+    model_config = {"extra": "allow"}
+
+
+class RunResponse(BaseModel):
+    reward: float = 0.0
+    exit_status: str = ""
+    agent_metrics: dict[str, Any] = {}
+    eval_report: dict[str, Any] = {}
+
+
+def get_semaphore() -> asyncio.Semaphore:
+    assert _semaphore is not None, "Semaphore not initialized — server not started?"
+    return _semaphore
+
+
+_TIMEOUT_EXCEPTIONS = {"AgentTimeoutError", "VerifierTimeoutError", "EnvironmentStartTimeoutError"}
+_OUTPUT_LIMIT_EXCEPTIONS = {"MaxSeqLenExceededError"}
+
+_HOST_PROCESS_AGENTS = {"terminus-2", "terminus-1", "terminus"}
+
+_SAFE_INSTANCE_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+
+
+def _extract_exit_status(result) -> str:
+    """Derive exit status from Harbor TrialResult."""
+    exc = getattr(result, "exception_info", None)
+    if exc is not None:
+        exc_type = getattr(exc, "exception_type", "")
+        if exc_type in _TIMEOUT_EXCEPTIONS:
+            return "TimeLimitExceeded"
+        if exc_type in _OUTPUT_LIMIT_EXCEPTIONS:
+            return "SequenceLengthLimitExceeded"
+        return "AgentError"
+    if getattr(result, "verifier_result", None) is not None:
+        return "Submitted"
+    return "Unknown"
+
+
+def _timing_duration_sec(timing) -> float | None:
+    started = getattr(timing, "started_at", None)
+    finished = getattr(timing, "finished_at", None)
+    if started and finished:
+        return (finished - started).total_seconds()
+    return None
+
+
+def _extract_reward(result) -> tuple[float, dict[str, Any]]:
+    """Extract scalar reward and full eval report from Harbor TrialResult.
+
+    Looks for the ``"reward"`` key first, then falls back to the first value
+    in the rewards dict. Works with both ``reward.txt`` and ``reward.json``.
+    """
+    vr = getattr(result, "verifier_result", None)
+    if vr is None:
+        return 0.0, {}
+    rewards = getattr(vr, "rewards", None) or {}
+    reward = float(rewards.get("reward", next(iter(rewards.values()), 0.0)))
+    return reward, dict(rewards)
+
+
+def _count_turns(result) -> int | None:
+    """Number of agent turns from the ATIF trajectory Harbor writes per trial.
+
+    The mini-swe-agent Harbor adapter only records token/cost fields on the
+    ``AgentContext`` (no turn count, no ``rollout_details``), so derive turns
+    from ``<trial_dir>/agent/trajectory.json``: each ``source == "agent"`` step
+    is one model response (tool observations are merged into the preceding agent
+    step), so counting them gives the number of turns. Returns ``None`` if the
+    trajectory can't be read (leaving ``turns`` unset rather than a bogus 0).
+    """
+    import json
+    from urllib.parse import urlparse
+    from urllib.request import url2pathname
+
+    try:
+        uri = getattr(result, "trial_uri", None)
+        if not uri:
+            return None
+        traj = Path(url2pathname(urlparse(uri).path)) / "agent" / "trajectory.json"
+        if not traj.exists():
+            return None
+        steps = json.loads(traj.read_text()).get("steps", [])
+        return sum(1 for s in steps if isinstance(s, dict) and s.get("source") == "agent")
+    except Exception as e:
+        logger.warning(f"Failed to count agent turns: {e}", exc_info=True)
+        return None
+
+
+def _extract_metrics(result) -> dict[str, Any]:
+    """Extract agent metrics from Harbor TrialResult."""
+    metrics: dict[str, Any] = {}
+    try:
+        ar = getattr(result, "agent_result", None)
+        if ar is not None:
+            for field in ("n_input_tokens", "n_output_tokens", "cost_usd"):
+                val = getattr(ar, field, None)
+                if val is not None:
+                    metrics[field] = val
+            agent_meta = getattr(ar, "metadata", None)
+            if isinstance(agent_meta, dict):
+                metrics.update(agent_meta)
+
+        # mini-swe-agent doesn't report a turn count on the AgentContext, so
+        # derive it from the trajectory. codecontests.yaml sets
+        # parallel_tool_calls: false (one command per turn), so tool_calls == turns.
+        turns = _count_turns(result)
+        if turns is not None:
+            metrics.setdefault("turns", turns)
+            metrics.setdefault("tool_calls", turns)
+
+        # Per-phase Harbor timings (all TimingInfo objects on the TrialResult):
+        #   environment_setup -> sandbox spawn (docker compose build/up of the task container)
+        #   agent_setup       -> agent install inside the sandbox (uv tool install mini-swe-agent)
+        #   agent_execution   -> agent.run()  (the rollout itself)
+        #   verifier          -> reward/grading (test.sh)
+        for attr, key in (
+            ("environment_setup", "spawn_time"),
+            ("agent_setup", "agent_setup_time"),
+            ("agent_execution", "agent_run_time"),
+            ("verifier", "eval_time"),
+        ):
+            timing = getattr(result, attr, None)
+            if timing is not None:
+                dur = _timing_duration_sec(timing)
+                if dur is not None:
+                    metrics[key] = dur
+
+        # End-to-end trial wall-clock (TrialResult itself carries started_at/finished_at),
+        # spanning spawn -> ... -> teardown. Harbor does NOT time teardown separately, so
+        # expose the residual (total minus the measured phases) as the teardown+overhead
+        # bucket (dominated by sandbox teardown; also covers healthcheck + artifact/log I/O).
+        total = _timing_duration_sec(result)
+        if total is not None:
+            metrics["total_time"] = total
+            measured = sum(
+                float(metrics.get(k, 0.0))
+                for k in ("spawn_time", "agent_setup_time", "agent_run_time", "eval_time")
+            )
+            metrics["teardown_overhead_time"] = max(total - measured, 0.0)
+    except Exception as e:
+        logger.warning(f"Failed to extract metrics: {e}", exc_info=True)
+    return metrics
+
+
+def _error_response(exit_status: str) -> dict[str, Any]:
+    return {"reward": 0.0, "exit_status": exit_status, "agent_metrics": {}, "eval_report": {}}
+
+
+def _write_trial_meta(result, meta: dict) -> None:
+    """Write per-trial correlation metadata into the trial dir (``miles_rollout_id.json``).
+
+    Contains:
+      * ``rollout_id``  — the owning rollout step (native association, no wall-clock guess).
+      * ``session_id``  — the TITO session this trial's model calls used. This lets
+        build_timeline_data.py correlate the trial to the session server's per-call
+        ``gen_time`` logs (GPU generation time), giving an EXACT per-trial GPU split
+        (GPU = Σ gen_time; container-CPU = agent_execution − Σ gen_time).
+    """
+    import json
+    from urllib.parse import urlparse
+    from urllib.request import url2pathname
+
+    try:
+        uri = getattr(result, "trial_uri", None)
+        if not uri:
+            return
+        tdir = Path(url2pathname(urlparse(uri).path))
+        if tdir.exists():
+            (tdir / "miles_rollout_id.json").write_text(json.dumps(meta))
+    except Exception as e:
+        logger.warning(f"Failed to write trial meta sidecar: {e}")
+
+
+def _extract_session_id(base_url: str | None) -> str | None:
+    """The TITO session_id is the path segment in .../sessions/<id>/v1 (agent base_url)."""
+    if not base_url:
+        return None
+    m = re.search(r"/sessions/([^/]+)", base_url)
+    return m.group(1) if m else None
+
+
+async def _run_trial(request: RunRequest) -> dict[str, Any]:
+    """Run a Harbor trial for a single task instance.
+
+    Task-type agnostic — all differentiation (environment, grading harness)
+    is encoded in the Harbor task directory's 4 files.
+    """
+    try:
+        from harbor.models.trial.config import AgentConfig, EnvironmentConfig, TaskConfig, TrialConfig
+        # Harbor v0.13.x: ``Trial`` is an abstract base; use the concrete
+        # SingleStepTrial and the async ``create`` factory instead of direct
+        # construction.
+        from harbor.trial.single_step import SingleStepTrial
+    except ImportError:
+        logger.error("Harbor not installed. Install with: pip install harbor")
+        return _error_response("ImportError")
+
+    try:
+        tasks_dir = Path(
+            os.getenv("HARBOR_TASKS_DIR", "/root/harbor_tasks"),
+        ).resolve()
+
+        if not request.instance_id:
+            logger.error("Empty instance_id")
+            return _error_response("InvalidInstanceId")
+
+        raw_id = request.instance_id
+        if not _SAFE_INSTANCE_ID.match(raw_id):
+            logger.error(f"Invalid instance_id rejected: {raw_id!r}")
+            return _error_response("InvalidInstanceId")
+
+        # Normalize and verify the path stays within tasks_dir.
+        # Uses the pattern recommended by CodeQL (py/path-injection):
+        #   normpath(join(base, user_input)) + startswith(base)
+        tasks_dir_str = str(tasks_dir)
+        task_path = os.path.normpath(os.path.join(tasks_dir_str, raw_id))
+        if not task_path.startswith(tasks_dir_str):
+            logger.error(f"Path traversal blocked: {raw_id!r}")
+            return _error_response("InvalidInstanceId")
+
+        # Case-insensitive fallback: the SWE-Gym adapter lowercases task dir names
+        # (Docker repo names must be lowercase), but dataset instance_ids keep the
+        # original case (e.g. Project-MONAI__MONAI-1030). Try the lowercased dir if
+        # the exact-case one is absent so those instances aren't TaskNotFound.
+        if not os.path.exists(task_path) and raw_id != raw_id.lower():
+            lower_path = os.path.normpath(os.path.join(tasks_dir_str, raw_id.lower()))
+            if lower_path.startswith(tasks_dir_str) and os.path.exists(lower_path):
+                logger.info(f"Resolved {raw_id!r} -> lowercase task dir {raw_id.lower()!r}")
+                task_path = lower_path
+
+        if not os.path.exists(task_path):
+            logger.error(f"Task directory not found: {task_path}")
+            return _error_response("TaskNotFound")
+
+        task_path = Path(task_path)
+        agent_kwargs: dict[str, Any] = {}
+        agent_env: dict[str, str] = {}
+
+        is_host_agent = request.agent_name in _HOST_PROCESS_AGENTS
+
+        if "hosted_vllm" in request.model or "openai" in request.model:
+            agent_kwargs["model_info"] = {
+                "max_input_tokens": int(os.getenv("AGENT_MAX_INPUT_TOKENS", "32768")),
+                "max_output_tokens": int(os.getenv("AGENT_MAX_OUTPUT_TOKENS", "8192")),
+                "input_cost_per_token": 0.0,
+                "output_cost_per_token": 0.0,
+            }
+
+        if request.max_seq_len is not None:
+            agent_kwargs["max_seq_len"] = request.max_seq_len
+
+        # Optional: point mini-swe-agent at a specific config file (e.g. the
+        # merged swebench_local.yaml with environment_class=local). Gowtham 8b
+        # equivalent, routed through the Harbor adapter kwargs.
+        config_file = os.getenv("MSWEA_CONFIG_FILE")
+        if config_file:
+            agent_kwargs["config_file"] = config_file
+
+        if is_host_agent:
+            agent_kwargs["api_base"] = request.base_url
+            agent_kwargs["api_key"] = request.api_key or "dummy"
+            agent_kwargs["enable_summarize"] = False
+            agent_env = {
+                "OPENAI_API_KEY": request.api_key or "dummy",
+                "OPENAI_API_BASE": request.base_url,
+            }
+        else:
+            agent_env = {
+                "OPENAI_API_BASE": request.base_url,
+                "OPENAI_API_KEY": request.api_key,
+                "HOSTED_VLLM_API_BASE": request.base_url,
+                "HOSTED_VLLM_API_KEY": request.api_key,
+                "MSWEA_COST_TRACKING": "ignore_errors",
+            }
+
+        env_config_kwargs: dict[str, Any] = {
+            "type": "docker",
+            "delete": os.getenv("HARBOR_DELETE_CONTAINERS", "false").lower() in ("true", "1", "t"),
+        }
+        # Optional: extra docker-compose override(s) so Harbor task containers
+        # join swe-net (and can reach the Miles router/session server).
+        extra_compose_env = os.getenv("HARBOR_EXTRA_DOCKER_COMPOSE")
+        if extra_compose_env:
+            extra_compose = [Path(p) for p in extra_compose_env.split(os.pathsep) if p]
+            if extra_compose:
+                env_config_kwargs["extra_docker_compose"] = extra_compose
+
+        config = TrialConfig(
+            task=TaskConfig(path=task_path),
+            agent=AgentConfig(
+                name=request.agent_name,
+                model_name=request.model,
+                env=agent_env,
+                kwargs=agent_kwargs,
+            ),
+            environment=EnvironmentConfig(**env_config_kwargs),
+            # Trials must live on a path that resolves identically inside agent_env
+            # and on the host, else the host Docker daemon can't bind-mount the
+            # verifier/agent dirs (DinD path mismatch). Default to the identity mount.
+            trials_dir=Path(os.environ.get("HARBOR_TRIALS_DIR", "trials")),
+        )
+
+        trial = await SingleStepTrial.create(config)
+        result = await trial.run()
+
+        reward, eval_report = _extract_reward(result)
+        exit_status = _extract_exit_status(result)
+        agent_metrics = _extract_metrics(result)
+
+        # Native correlation sidecar: rollout_id (owning step, forwarded by
+        # swe_agent_function) + session_id (from the agent base_url) so the trial's
+        # model calls can be matched to the session server's per-call gen_time logs.
+        meta: dict[str, Any] = {}
+        if request.rollout_id is not None:
+            agent_metrics["rollout_id"] = request.rollout_id
+            meta["rollout_id"] = request.rollout_id
+        session_id = _extract_session_id(request.base_url)
+        if session_id is not None:
+            agent_metrics["session_id"] = session_id
+            meta["session_id"] = session_id
+        if meta:
+            _write_trial_meta(result, meta)
+
+        return {
+            "reward": reward,
+            "exit_status": exit_status,
+            "agent_metrics": agent_metrics,
+            "eval_report": eval_report,
+        }
+
+    except Exception as e:
+        logger.error(f"Harbor trial failed: {e}\n{traceback.format_exc()}")
+        return _error_response(f"Error: {type(e).__name__}")
+
+
+@app.post("/run")
+async def run_instance(request: RunRequest) -> RunResponse:
+    """Run an agent on a single task instance via Harbor."""
+    logger.info(f"Running instance: {request.instance_id}")
+    async with get_semaphore():
+        result = await _run_trial(request)
+    logger.info(
+        f"Instance {request.instance_id} finished: exit_status={result['exit_status']}, reward={result['reward']}"
+    )
+    return RunResponse(**result)
+
+
+@app.get("/health")
+async def health():
+    return {"status": "ok"}
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Agent Environment Server (Harbor)")
+    parser.add_argument("--host", type=str, default="0.0.0.0")
+    parser.add_argument("--port", type=int, default=11000)
+    parser.add_argument("--max-concurrent", type=int, default=8)
+    args = parser.parse_args()
+
+    os.environ["AGENT_MAX_CONCURRENT"] = str(args.max_concurrent)
+
+    os.environ.setdefault("MSWEA_API_KEY", "dummy")
+    os.environ.setdefault("HOSTED_VLLM_API_KEY", "dummy")
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(name)s %(levelname)s %(message)s",
+    )
+    uvicorn.run(app, host=args.host, port=args.port)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/experimental/qwen3-codecontests/harbor/server.py
+++ b/examples/experimental/qwen3-codecontests/harbor/server.py
@@ -320,12 +320,15 @@ async def _run_trial(request: RunRequest) -> dict[str, Any]:
             logger.error(f"Invalid instance_id rejected: {raw_id!r}")
             return _error_response("InvalidInstanceId")
 
-        # Normalize and verify the path stays within tasks_dir.
-        # Uses the pattern recommended by CodeQL (py/path-injection):
-        #   normpath(join(base, user_input)) + startswith(base)
-        tasks_dir_str = str(tasks_dir)
-        task_path = os.path.normpath(os.path.join(tasks_dir_str, raw_id))
-        if not task_path.startswith(tasks_dir_str):
+        # Resolve and verify the path stays within tasks_dir. Using
+        # os.path.commonpath is robust against sibling-prefix bypasses that a
+        # plain str.startswith check would allow (e.g. /root/harbor_tasks_cc
+        # starts with /root/harbor_tasks).
+        task_path = (tasks_dir / raw_id).resolve()
+        try:
+            if os.path.commonpath([tasks_dir, task_path]) != str(tasks_dir):
+                raise ValueError
+        except Exception:
             logger.error(f"Path traversal blocked: {raw_id!r}")
             return _error_response("InvalidInstanceId")
 
@@ -333,17 +336,18 @@ async def _run_trial(request: RunRequest) -> dict[str, Any]:
         # (Docker repo names must be lowercase), but dataset instance_ids keep the
         # original case (e.g. Project-MONAI__MONAI-1030). Try the lowercased dir if
         # the exact-case one is absent so those instances aren't TaskNotFound.
-        if not os.path.exists(task_path) and raw_id != raw_id.lower():
-            lower_path = os.path.normpath(os.path.join(tasks_dir_str, raw_id.lower()))
-            if lower_path.startswith(tasks_dir_str) and os.path.exists(lower_path):
-                logger.info(f"Resolved {raw_id!r} -> lowercase task dir {raw_id.lower()!r}")
-                task_path = lower_path
+        if not task_path.exists() and raw_id != raw_id.lower():
+            lower_path = (tasks_dir / raw_id.lower()).resolve()
+            try:
+                if os.path.commonpath([tasks_dir, lower_path]) == str(tasks_dir) and lower_path.exists():
+                    logger.info(f"Resolved {raw_id!r} -> lowercase task dir {raw_id.lower()!r}")
+                    task_path = lower_path
+            except Exception:
+                pass
 
-        if not os.path.exists(task_path):
+        if not task_path.exists():
             logger.error(f"Task directory not found: {task_path}")
             return _error_response("TaskNotFound")
-
-        task_path = Path(task_path)
         agent_kwargs: dict[str, Any] = {}
         agent_env: dict[str, str] = {}
 

--- a/examples/experimental/qwen3-codecontests/harbor/swe_agent_function.py
+++ b/examples/experimental/qwen3-codecontests/harbor/swe_agent_function.py
@@ -84,13 +84,23 @@ async def run(
         )
     except asyncio.TimeoutError:
         logger.error("Agent server call timed out after 3600s")
-        return None
+        return {
+            "reward": 0.0,
+            "exit_status": "Timeout",
+            "eval_report": {},
+            "agent_metrics": {},
+        }
     except asyncio.CancelledError:
         logger.warning("Agent server call cancelled (sibling task failure?)")
-        return None
+        raise
     except Exception as e:
         logger.error(f"Agent server call failed: {e}")
-        return None
+        return {
+            "reward": 0.0,
+            "exit_status": "Error",
+            "eval_report": {},
+            "agent_metrics": {},
+        }
 
     return {
         "reward": response.get("reward", 0.0),

--- a/examples/experimental/qwen3-codecontests/harbor/swe_agent_function.py
+++ b/examples/experimental/qwen3-codecontests/harbor/swe_agent_function.py
@@ -1,0 +1,100 @@
+"""
+Custom agent function for agentic_tool_call.generate.
+
+Dispatches to a Harbor-based agent server and returns env metadata
+as a plain dict. The generate layer merges this into sample.metadata so
+downstream reward models (--custom-rm-path) can extract reward, eval
+reports, etc.
+
+Task-type agnostic — the server + Harbor task directory handle all
+differentiation (environment, grading harness, agent selection).
+"""
+
+import asyncio
+import logging
+import os
+from typing import Any
+from urllib.parse import urlparse, urlsplit, urlunparse
+
+from miles.utils.http_utils import post
+
+logger = logging.getLogger(__name__)
+
+
+async def run(
+    base_url: str,
+    prompt: Any,
+    request_kwargs: dict[str, Any] | None = None,
+    metadata: dict[str, Any] | None = None,
+    **kwargs,
+) -> dict[str, Any] | None:
+    """Run a single task instance via the Harbor agent server."""
+    metadata = metadata or {}
+    request_kwargs = request_kwargs or {}
+
+    agent_server_url = os.getenv(
+        "AGENT_SERVER_URL",
+        os.getenv("SWE_AGENT_URL", "http://localhost:11000"),
+    )
+    model_name = os.getenv(
+        "AGENT_MODEL_NAME",
+        os.getenv("SWE_AGENT_MODEL_NAME", "model"),
+    )
+
+    session_url = f"{base_url}/v1"
+    external_host = os.getenv("MILES_ROUTER_EXTERNAL_HOST")
+    if external_host:
+        parsed = urlparse(session_url)
+        port = parsed.port
+        netloc = f"{external_host}:{port}" if port else external_host
+        session_url = urlunparse(parsed._replace(netloc=netloc))
+
+    request: dict[str, Any] = {
+        **metadata,
+        "base_url": session_url,
+        "model": f"openai/{model_name}",
+        "sampling_params": request_kwargs,
+    }
+
+    max_seq_len = metadata.get("max_seq_len")
+    if max_seq_len is not None:
+        request["max_seq_len"] = int(max_seq_len)
+
+    session_server_id = metadata.get("session_server_id")
+    if session_server_id is not None:
+        if external_host:
+            port = urlsplit(f"http://{session_server_id}").port
+            session_server_id = f"{external_host}:{port}"
+        request["session_server_id"] = session_server_id
+
+    session_server_instance_id = metadata.get("session_server_instance_id")
+    if session_server_instance_id is not None:
+        request["session_server_instance_id"] = session_server_instance_id
+
+    # Native rollout_id tagging (set by harbor/generate.py per rollout) so the server
+    # can stamp each trial with the step it belongs to — no wall-clock inference needed.
+    rollout_id = os.getenv("MILES_ROLLOUT_ID")
+    if rollout_id is not None:
+        request["rollout_id"] = rollout_id
+
+    try:
+        response = await asyncio.wait_for(
+            post(f"{agent_server_url}/run", request),
+            timeout=3600,  # 1 hour max per trial
+        )
+    except asyncio.TimeoutError:
+        logger.error("Agent server call timed out after 3600s")
+        return None
+    except asyncio.CancelledError:
+        logger.warning("Agent server call cancelled (sibling task failure?)")
+        return None
+    except Exception as e:
+        logger.error(f"Agent server call failed: {e}")
+        return None
+
+    return {
+        "reward": response.get("reward", 0.0),
+        "exit_status": response.get("exit_status", ""),
+        "eval_report": response.get("eval_report", {}),
+        "agent_metrics": response.get("agent_metrics", {}),
+    }

--- a/examples/experimental/qwen3-codecontests/harbor/swe_net_override.yaml
+++ b/examples/experimental/qwen3-codecontests/harbor/swe_net_override.yaml
@@ -1,0 +1,12 @@
+# Harbor extra-compose override: attach each task's `main` service to the
+# miles `swe-net` network so the in-container mini-swe-agent can reach the
+# Miles session server / router (172.18.0.2:30000/31000).
+# Wired via HARBOR_EXTRA_DOCKER_COMPOSE on the agent_env Harbor server.
+services:
+  main:
+    networks:
+      - default
+      - swe-net
+networks:
+  swe-net:
+    external: true

--- a/examples/experimental/qwen3-codecontests/launcher_args.py
+++ b/examples/experimental/qwen3-codecontests/launcher_args.py
@@ -1,0 +1,301 @@
+"""Dependency-free builder for the Qwen3-30B-A3B / CodeContests train args.
+
+This is the single source of truth for the command-line flags emitted by
+``run-qwen3-codecontests.py``. It has NO ``miles``/``typer`` imports so it can be
+unit-tested on a bare host (``test_launcher_args.py``), while the launcher maps
+its ``ScriptArgs`` into ``CCArgs`` and calls :func:`build_train_args`.
+
+Configured for Qwen3-30B-A3B (MoE, 128 experts) in disaggregated async mode,
+borrowing the topology from ``scripts/run_qwen3_30b_a3b.py``:
+  * SGLang parsers qwen25 / qwen3, --tito-model qwen3
+  * MoE expert parallelism (EP=4 async / EP=8 colocate) plus the triton
+    grouped-GEMM MoE runner (the aiter Composable-Kernel device_gemm path
+    crashes on MI35x)
+  * async: TP=2 * EP=4 over the training GPUs, a single SGLang engine spanning
+    the rollout GPUs, and <=1-step-stale weight sync (broadcast, in_place pause)
+  * the SGLANG_ROCM_FUSED_DECODE_MLA=0 workaround is NOT emitted (Qwen3 = GQA,
+    not MLA) -- see :func:`rocm_env_vars`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class CCArgs:
+    # mode / topology
+    mode: str = "normal"  # "normal" | "debug_rollout_only"
+    async_mode: bool = True
+    train_num_gpus: int = 4
+    num_gpus_per_node: int = 8
+    num_nodes: int = 1
+
+    # checkpoints / data
+    hf_checkpoint: str = "Qwen/Qwen3-30B-A3B"
+    ref_load: str = "/root/Qwen3-30B-A3B_torch_dist"
+    save_dir: str = "/root/Qwen3-30B-A3B_codecontests/"
+    save_interval: int = 9999
+    prompt_data: str = "/root/cc_train.jsonl"
+    # Optional resume: when set, miles loads the latest checkpoint here and
+    # continues the step count. Empty = fresh training from ref_load/hf_checkpoint.
+    load: str = ""
+
+    # rollout / batch
+    max_seq_len: int = 16384
+    rollout_batch_size: int = 4
+    n_samples_per_prompt: int = 8
+    global_batch_size: int = 8
+    # num_rollout: explicit number of rollout steps. num_epoch: run for whole-
+    # dataset epochs instead -- miles computes num_rollout = num_epoch *
+    # (dataset_size // rollout_batch_size). When num_epoch is set it takes
+    # precedence and --num-rollout is omitted (miles ignores num_rollout if
+    # num_epoch is given). Requires the global dataset (on by default).
+    num_rollout: int = 3
+    num_epoch: int | None = None
+    over_sampling_batch_size: int = 0
+
+    # qwen3 / codecontests fixed knobs
+    tito_model: str = "qwen3"
+    tool_call_parser: str = "qwen25"
+    reasoning_parser: str = "qwen3"
+
+    # logging
+    wandb_key: str = ""
+    wandb_project: str = "qwen3-30b-a3b-codecontests"
+    wandb_run_name: str = "qwen3-30b-a3b-codecontests"
+    wandb_team: str = ""
+    use_prometheus: bool = True
+    prometheus_port: int = 9090
+    prometheus_run_name: str = "qwen3-30b-a3b-codecontests"
+
+
+def build_train_args(a: CCArgs) -> str:
+    async_mode = a.async_mode
+
+    roll_temp = 0.7 if async_mode else 0.8
+    roll_max_resp = 8192
+    # Qwen3-30B-A3B has max_position_embeddings=40960 and no rope_scaling/YaRN,
+    # so cap seq/context length at the model's native window. Going past 40960
+    # would extrapolate RoPE beyond training and degrade quality.
+    seq_len = 40960 if async_mode else a.max_seq_len
+    roll_ctx = 40960 if async_mode else a.max_seq_len
+    max_tok_per_gpu = 32768 if async_mode else 16384
+
+    ckpt_args = (
+        f"--hf-checkpoint {a.hf_checkpoint} "
+        f"--ref-load {a.ref_load} "
+        f"--save {a.save_dir} "
+        f"--save-interval {a.save_interval} "
+    )
+    if a.load:
+        # Resume policy weights + dataset consumption state, but skip the saved
+        # optimizer/RNG state: restoring the precision-aware Adam state from a
+        # distributed-optimizer checkpoint hits an incompatibility
+        # (`unscaled_state.dtype` on a bool). Adam moments restart fresh; at
+        # constant lr 1e-6 the impact is minor. Step count + data position are
+        # still restored from --load, so no seen data is replayed.
+        ckpt_args += f"--load {a.load} --no-load-optim --no-load-rng "
+
+    # Run length: whole-dataset epochs (num_epoch) or an explicit rollout-step
+    # count. num_epoch wins when set (miles derives num_rollout from it).
+    run_len_arg = f"--num-epoch {a.num_epoch} " if a.num_epoch is not None else f"--num-rollout {a.num_rollout} "
+
+    rollout_args = (
+        f"--prompt-data {a.prompt_data} "
+        "--input-key prompt "
+        "--metadata-key metadata "
+        f"{run_len_arg}"
+        f"--rollout-batch-size {a.rollout_batch_size} "
+        f"--n-samples-per-prompt {a.n_samples_per_prompt} "
+        f"--rollout-temperature {roll_temp} "
+        f"--rollout-max-response-len {roll_max_resp} "
+        f"--max-seq-len {seq_len} "
+        f"--rollout-max-context-len {roll_ctx} "
+        f"--global-batch-size {a.global_batch_size} "
+        "--balance-data "
+    )
+    if a.over_sampling_batch_size:
+        rollout_args += f"--over-sampling-batch-size {a.over_sampling_batch_size} "
+
+    # Qwen3-30B-A3B is MoE (128 experts): EP shards the experts that hold the
+    # bulk of the 30B params; TP splits the modest dense attention/router path.
+    # Async uses the reference disaggregated topology (TP=2 * EP=4 over 4 train
+    # GPUs -> implied DP=2 shards optimizer state); colocate spreads experts
+    # across all training GPUs (TP=4 / EP=8 on an 8-GPU node). ETP=1 keeps whole
+    # experts per GPU so the grouped-GEMM MoE path stays efficient.
+    n_gpus = a.num_gpus_per_node
+    train_gpus = a.train_num_gpus if async_mode else n_gpus
+    rollout_gpus = (n_gpus - a.train_num_gpus) if async_mode else n_gpus
+    if async_mode:
+        tp_size = 2
+        ep_size = 4
+    else:
+        tp_size = min(4, train_gpus)
+        ep_size = min(8, train_gpus)
+
+    perf_args = (
+        f"--tensor-model-parallel-size {tp_size} "
+        f"{'--sequence-parallel ' if tp_size > 1 else ''}"
+        "--pipeline-model-parallel-size 1 "
+        "--context-parallel-size 1 "
+        f"--expert-model-parallel-size {ep_size} "
+        "--expert-tensor-parallel-size 1 "
+        "--recompute-granularity full "
+        "--recompute-method uniform "
+        "--recompute-num-layers 1 "
+        "--use-dynamic-batch-size "
+        f"--max-tokens-per-gpu {max_tok_per_gpu} "
+        "--use-precision-aware-optimizer "
+    )
+
+    grpo_args = (
+        "--advantage-estimator grpo "
+        "--use-kl-loss "
+        "--kl-loss-coef 0.01 "
+        "--kl-loss-type low_var_kl "
+        "--entropy-coef 0.0 "
+        "--eps-clip 0.2 "
+        "--eps-clip-high 0.28 "
+    )
+
+    optimizer_args = (
+        "--optimizer adam "
+        "--lr 1e-6 "
+        "--lr-decay-style constant "
+        "--weight-decay 0.1 "
+        "--adam-beta1 0.9 "
+        "--adam-beta2 0.98 "
+    )
+
+    # Qwen3-30B-A3B uses GQA + standard parsers (NOT glm47/glm45). MoE decode
+    # runs on the triton grouped-GEMM runner (aiter Composable-Kernel
+    # device_gemm crashes on MI35x). Async runs one SGLang engine spanning all
+    # rollout GPUs -> a single weight-broadcast target for fast per-step sync,
+    # and the dedicated (non-colocate) rollout GPUs afford a higher mem
+    # fraction; colocate shares the node so it stays at 0.7.
+    if async_mode:
+        rollout_gpus_per_engine = rollout_gpus
+        sglang_mem_fraction = 0.8
+        sglang_cuda_graph_max_bs = 256
+    else:
+        rollout_gpus_per_engine = n_gpus
+        sglang_mem_fraction = 0.7
+        sglang_cuda_graph_max_bs = 512
+    sglang_args = (
+        f"--rollout-num-gpus-per-engine {rollout_gpus_per_engine} "
+        f"--sglang-mem-fraction-static {sglang_mem_fraction} "
+        f"--sglang-cuda-graph-max-bs {sglang_cuda_graph_max_bs} "
+        "--sglang-moe-runner-backend triton "
+        f"--sglang-tool-call-parser {a.tool_call_parser} "
+        f"--sglang-reasoning-parser {a.reasoning_parser} "
+        "--use-miles-router "
+        "--sglang-router-port 31000 "
+    )
+    if async_mode:
+        sglang_args += f"--sglang-context-length {roll_ctx} "
+        sglang_args += "--sglang-allow-auto-truncate "
+
+    agent_args = (
+        "--custom-generate-function-path miles.rollout.generate_hub.agentic_tool_call.generate "
+        "--custom-agent-function-path harbor.swe_agent_function.run "
+        "--custom-rm-path harbor.generate.reward_func "
+        "--rollout-function-path harbor.generate.RolloutFn "
+        "--dynamic-sampling-filter-path miles.rollout.filter_hub.dynamic_sampling_filters.check_no_aborted "
+        f"--tito-model {a.tito_model} "
+        "--use-session-server "
+        "--session-server-port 30000 "
+        # required by the mini-swe-agent harness
+        "--tito-allowed-append-roles user tool "
+    )
+
+    misc_args = (
+        "--attention-dropout 0.0 "
+        "--hidden-dropout 0.0 "
+        "--attention-softmax-in-fp32 "
+    )
+    if async_mode:
+        misc_args += (
+            "--attention-backend flash "
+            "--accumulate-allreduce-grads-in-fp32 "
+            # Push weights every optimizer step so the rollout policy is at most
+            # one step stale (train_async.py overlaps generate(N+1)/train(N)).
+            "--update-weights-interval 1 "
+            "--update-weight-transfer-mode broadcast "
+            f"--update-weight-buffer-size {2 * 1024 ** 3} "
+            "--pause-generation-mode in_place "
+            "--use-fault-tolerance "
+            "--rollout-health-check-first-wait 1800 "
+            "--actor-num-nodes 1 "
+            f"--actor-num-gpus-per-node {train_gpus} "
+            f"--num-gpus-per-node {n_gpus} "
+            f"--rollout-num-gpus {rollout_gpus} "
+        )
+    else:
+        misc_args += (
+            "--accumulate-allreduce-grads-in-fp32 "
+            "--attention-backend flash "
+            "--colocate "
+        )
+        # Multi-GPU colocate keeps the rollout engine resident to avoid
+        # offload/reload latency. On a single GPU there isn't room for both the
+        # SGLang KV-cache pool and the Megatron training step, so let
+        # offload-rollout (default level: kv_cache + weight) free the GPU during
+        # training to avoid OOM.
+        if train_gpus > 1:
+            misc_args += "--no-offload-rollout "
+        misc_args += (
+            f"--actor-num-nodes {a.num_nodes} "
+            f"--actor-num-gpus-per-node {a.num_gpus_per_node} "
+            f"--rollout-num-gpus {a.num_gpus_per_node} "
+        )
+
+    debug_args = "--debug-rollout-only " if a.mode == "debug_rollout_only" else ""
+
+    wandb_args = ""
+    if a.wandb_key:
+        wandb_args = (
+            "--use-wandb "
+            f"--wandb-project {a.wandb_project} "
+            f"--wandb-group {a.wandb_run_name} "
+            f"--wandb-key {a.wandb_key} "
+        )
+        if a.wandb_team:
+            wandb_args += f"--wandb-team {a.wandb_team} "
+
+    prometheus_args = ""
+    if a.use_prometheus:
+        prometheus_args = (
+            "--use-prometheus "
+            f"--prometheus-port {a.prometheus_port} "
+            f"--prometheus-run-name {a.prometheus_run_name} "
+        )
+
+    return (
+        f"{ckpt_args}"
+        f"{rollout_args}"
+        f"{optimizer_args}"
+        f"{grpo_args}"
+        f"{wandb_args}"
+        f"{prometheus_args}"
+        f"{perf_args}"
+        f"{sglang_args}"
+        f"{agent_args}"
+        f"{misc_args}"
+        f"{debug_args}"
+    )
+
+
+def rocm_env_vars(num_gpus_per_node: int) -> dict:
+    """ROCm GPU-visibility env for Ray (per radixark/miles#1118).
+
+    Deliberately does NOT set ``SGLANG_ROCM_FUSED_DECODE_MLA`` -- that workaround is
+    only needed for the GLM MLA decode path; Qwen3 uses standard GQA attention.
+    """
+    all_gpus = ",".join(str(i) for i in range(num_gpus_per_node))
+    return {
+        "RAY_EXPERIMENTAL_NOSET_HIP_VISIBLE_DEVICES": "1",
+        "RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES": "1",
+        "HIP_VISIBLE_DEVICES": all_gpus,
+        "SGLANG_SET_CPU_AFFINITY": "0",
+    }

--- a/examples/experimental/qwen3-codecontests/run-qwen3-codecontests.py
+++ b/examples/experimental/qwen3-codecontests/run-qwen3-codecontests.py
@@ -1,0 +1,211 @@
+"""Agent V2 launcher (Qwen3-30B-A3B / CodeContests): Miles <-> Harbor (mini-swe-agent).
+
+Thin wrapper: maps ScriptArgs into the
+dependency-free arg builder in launcher_args.py (the single source of truth,
+unit-tested by tests/test_launcher_args.py), then calls U.execute_train.
+
+  * model = Qwen3-30B-A3B (MoE, 128 experts) -> megatron_model_type qwen3-30B-A3B
+  * SGLang parsers qwen25 / qwen3, triton MoE runner
+  * --tito-model qwen3
+  * agent = mini-swe-agent, dataset = CodeContests prompt jsonl
+  * async (disaggregated) on 8 GPUs: 4 train (TP2 * EP4) + 4 rollout via
+    train_async.py, <=1-step-stale weight sync
+
+Usage:
+    python run-qwen3-codecontests.py --skip-prepare
+    python run-qwen3-codecontests.py --mode debug_rollout_only
+    python run-qwen3-codecontests.py --no-async-mode   # colocate on one node
+"""
+
+import os
+import socket
+from dataclasses import dataclass
+
+import typer
+
+import miles.utils.external_utils.command_utils as U
+
+# launcher_args lives in this dir and the Harbor glue is the `harbor/` subpackage
+# (harbor.generate / harbor.swe_agent_function); put SCRIPT_DIR on sys.path so both
+# `import launcher_args` and `import harbor.*` resolve.
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+FULLY_ASYNC_DIR = (SCRIPT_DIR.parent.parent / "fully_async").resolve()
+sys.path.insert(0, str(SCRIPT_DIR))
+
+import launcher_args as LA  # noqa: E402
+
+
+@dataclass
+class ScriptArgs(U.ExecuteTrainConfig):
+    mode: str = "normal"  # "normal" | "debug_rollout_only"
+    run_id: str = U.create_run_id()
+    megatron_model_type: str = "qwen3-30B-A3B"
+    num_gpus_per_node: int = 8
+    megatron_path: str = "/root/Megatron-LM"
+
+    # Paths
+    skip_prepare: bool = False
+    base_dir: str = "/root"
+    model_name: str = "Qwen3-30B-A3B"
+    hf_checkpoint: str = "Qwen/Qwen3-30B-A3B"
+    ref_load: str = "/root/Qwen3-30B-A3B_torch_dist"
+    save_dir: str = "/root/Qwen3-30B-A3B_codecontests/"
+    load: str = ""  # set to a checkpoint dir to resume (continues step count); empty = fresh
+    prompt_data: str = "/root/miles_qwen/examples/experimental/qwen3-codecontests/data/cc_train_easy.jsonl"
+
+    # Training settings
+    max_seq_len: int = 16384
+    rollout_batch_size: int = 16
+    n_samples_per_prompt: int = 8
+    global_batch_size: int = 128
+    num_rollout: int = 64
+    # Set num_epoch to run for whole-dataset epochs instead of a fixed step
+    # count; when set it overrides num_rollout (miles computes
+    # num_rollout = num_epoch * dataset_size // rollout_batch_size).
+    num_epoch: int | None = None
+    over_sampling_batch_size: int = 0
+    save_interval: int = 10
+
+    # Async (disaggregated) mode: 4 train + 4 rollout GPUs via train_async.py.
+    async_mode: bool = True
+    train_num_gpus: int = 4
+
+    # Agent settings (mini-swe-agent)
+    agent_server_url: str = os.environ.get(
+        "AGENT_SERVER_URL", os.environ.get("SWE_AGENT_URL", "http://agent_env:11000")
+    )
+    agent_model_name: str = os.environ.get("AGENT_MODEL_NAME", "model")
+    harbor_tasks_dir: str = os.environ.get("HARBOR_TASKS_DIR", "/root/harbor_tasks_cc")
+    router_external_host: str = os.environ.get("MILES_ROUTER_EXTERNAL_HOST", socket.gethostname())
+    miles_host_ip: str = os.environ.get("MILES_HOST_IP", socket.gethostname())
+
+    # W&B settings
+    wandb_key: str = os.environ.get("WANDB_KEY", os.environ.get("WANDB_API_KEY", ""))
+    wandb_project: str = os.environ.get("WANDB_PROJECT", "qwen3-30b-a3b-codecontests")
+    wandb_team: str = os.environ.get("WANDB_TEAM", "")
+    wandb_run_name: str = os.environ.get("WANDB_RUN_NAME", "qwen3-30b-a3b-codecontests")
+
+    # Prometheus settings
+    use_prometheus: bool = True
+    prometheus_port: int = 9090
+    prometheus_run_name: str = "qwen3-30b-a3b-codecontests"
+
+
+def _to_ccargs(args: ScriptArgs) -> "LA.CCArgs":
+    return LA.CCArgs(
+        mode=args.mode,
+        async_mode=args.async_mode,
+        train_num_gpus=args.train_num_gpus,
+        num_gpus_per_node=args.num_gpus_per_node,
+        num_nodes=args.num_nodes,
+        hf_checkpoint=args.hf_checkpoint,
+        ref_load=args.ref_load,
+        save_dir=args.save_dir,
+        load=args.load,
+        save_interval=args.save_interval,
+        prompt_data=args.prompt_data,
+        max_seq_len=args.max_seq_len,
+        rollout_batch_size=args.rollout_batch_size,
+        n_samples_per_prompt=args.n_samples_per_prompt,
+        global_batch_size=args.global_batch_size,
+        num_rollout=args.num_rollout,
+        num_epoch=args.num_epoch,
+        over_sampling_batch_size=args.over_sampling_batch_size,
+        wandb_key=args.wandb_key,
+        wandb_project=args.wandb_project,
+        wandb_run_name=args.wandb_run_name,
+        wandb_team=args.wandb_team,
+        use_prometheus=args.use_prometheus,
+        prometheus_port=args.prometheus_port,
+        prometheus_run_name=args.prometheus_run_name,
+    )
+
+
+def cleanup():
+    import subprocess
+    import time
+
+    my_pid = os.getpid()
+    ppid = os.getppid()
+    print(f"Cleanup starting (pid={my_pid}, ppid={ppid})")
+    targets = ["sglang", "train.py", "train_async.py", "MegatronTrain"]
+    exclude = f"grep -v '^{my_pid}$' | grep -v '^{ppid}$'"
+    for t in targets:
+        subprocess.run(
+            f"pgrep -f '{t}' | {exclude} | xargs -r kill 2>/dev/null || true",
+            shell=True,
+        )
+    time.sleep(5)
+    print(f"Cleanup complete (pid={my_pid}).")
+
+
+def prepare(args: ScriptArgs):
+    U.convert_checkpoint(
+        model_name=args.model_name,
+        megatron_model_type=args.megatron_model_type,
+        num_gpus_per_node=args.num_gpus_per_node,
+        dir_dst=args.base_dir,
+        hf_checkpoint=args.hf_checkpoint,
+        megatron_path=args.megatron_path,
+    )
+
+
+def execute(args: ScriptArgs):
+    train_args = LA.build_train_args(_to_ccargs(args))
+
+    miles_root = U.repo_base_dir
+    pythonpath = f"{args.megatron_path}:{SCRIPT_DIR}:{miles_root}"
+    if args.async_mode:
+        pythonpath = f"{args.megatron_path}:{SCRIPT_DIR}:{FULLY_ASYNC_DIR}:{miles_root}"
+
+    extra_env_vars = {
+        "PYTHONPATH": pythonpath,
+        "MILES_EXPERIMENTAL_ROLLOUT_REFACTOR": "1",
+        "AGENT_SERVER_URL": args.agent_server_url,
+        "AGENT_MODEL_NAME": args.agent_model_name,
+        "MILES_ROUTER_EXTERNAL_HOST": args.router_external_host,
+        "HARBOR_TASKS_DIR": args.harbor_tasks_dir,
+        "MILES_HOST_IP": args.miles_host_ip,
+        # Keep wandb's run-log dir OUTSIDE any PYTHONPATH entry, otherwise a
+        # ./wandb dir at the repo root / SCRIPT_DIR shadows the real `wandb`
+        # package as a namespace package (import wandb -> no `login`).
+        "WANDB_DIR": os.environ.get("WANDB_DIR", "/root/work/wandb"),
+    }
+
+    # ROCm GPU visibility for Ray.
+    if os.path.exists("/opt/rocm"):
+        rocm_env = LA.rocm_env_vars(args.num_gpus_per_node)
+        # Optional: pin to a specific physical GPU id (e.g. CC_HIP_VISIBLE_DEVICES=7)
+        # for debugging on a known-idle device. Ray on ROCm requires
+        # HIP_VISIBLE_DEVICES (NOT ROCR_VISIBLE_DEVICES), so override here.
+        _gpu_override = os.environ.get("CC_HIP_VISIBLE_DEVICES")
+        if _gpu_override:
+            rocm_env["HIP_VISIBLE_DEVICES"] = _gpu_override
+        for k, v in rocm_env.items():
+            os.environ.setdefault(k, v)
+        extra_env_vars.update(rocm_env)
+
+    U.execute_train(
+        train_args=train_args,
+        config=args,
+        num_gpus_per_node=args.num_gpus_per_node,
+        megatron_model_type=args.megatron_model_type,
+        train_script="train_async.py" if args.async_mode else "train.py",
+        megatron_path=args.megatron_path,
+        extra_env_vars=extra_env_vars,
+    )
+
+
+@U.dataclass_cli
+def main(args: ScriptArgs):
+    cleanup()
+    if not args.skip_prepare:
+        prepare(args)
+    execute(args)
+
+
+if __name__ == "__main__":
+    typer.run(main)

--- a/examples/experimental/qwen3-codecontests/run_training_amd.sh
+++ b/examples/experimental/qwen3-codecontests/run_training_amd.sh
@@ -177,7 +177,7 @@ else
       cd $EX && PYTHONPATH=$REPO_DIR python3 harbor/server.py --port 11000 --max-concurrent '"$MAX_CONCURRENT"' > $WORK_DIR/harbor.log 2>&1'
 
   # health check runs from inside miles_swe (host can't reach swe-net directly)
-  if $DOCKER exec miles_swe bash -lc 'for i in $(seq 1 30); do curl -sf http://agent_env:11000/health && exit 0; sleep 2; done; exit 1'; then
+  if $DOCKER exec miles_swe bash -lc 'for i in $(seq 1 30); do python3 -c "import urllib.request; urllib.request.urlopen(\"http://agent_env:11000/health\")" && exit 0; sleep 2; done; exit 1'; then
     echo " <- harbor up"
   else
     echo "harbor NOT up; last 15 lines of harbor.log:"; tail -n 15 "$WORK_DIR/harbor.log" 2>/dev/null || true

--- a/examples/experimental/qwen3-codecontests/run_training_amd.sh
+++ b/examples/experimental/qwen3-codecontests/run_training_amd.sh
@@ -1,0 +1,265 @@
+#!/usr/bin/env bash
+#
+# Usage:
+#   bash run_training_amd.sh                  # full flow end-to-end
+#   WANDB_KEY=xxx bash run_training_amd.sh
+#   RUNTIME=/data/$USER/cc bash run_training_amd.sh   # runtime data on a big disk
+#   bash run_training_amd.sh --fresh-data     # wipe extracted tasks + jsonls, rebuild
+#   bash run_training_amd.sh --skip-setup     # reuse running containers / installed miles
+#   bash run_training_amd.sh --skip-data      # reuse prepared data + model
+#   bash run_training_amd.sh --reset          # restart the trainer between runs, then exit
+#   bash run_training_amd.sh --teardown       # remove containers + task sandboxes, then exit
+#   bash run_training_amd.sh --help
+#
+# Any flags after `--` pass straight through to run-qwen3-codecontests.py, e.g.:
+#   bash run_training_amd.sh -- --num-rollout 50 --save-interval 5
+set -euo pipefail
+
+# --------------------------------------------------------------------------- #
+# 0. Config — all paths derived from the repo; every value overridable via env.
+# --------------------------------------------------------------------------- #
+REPO_DIR="${REPO_DIR:-$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)}"
+EX="${EX:-$REPO_DIR/examples/experimental/qwen3-codecontests}"
+# Runtime data (extracted tasks, Harbor trials, HF cache). Keep it OFF the repo so
+# growing data never bloats a checkout; override with a big-disk path when available.
+RUNTIME="${RUNTIME:-$EX/runtime}"
+WORK_DIR="${WORK_DIR:-$RUNTIME/work}"                 # logs + Harbor trials (cc_trials/)
+TASKS_DIR="${TASKS_DIR:-$RUNTIME/harbor_tasks_cc}"    # extracted Harbor task dirs
+HF_CACHE="${HF_CACHE:-$RUNTIME/cache/hf}"             # HuggingFace cache (can be large)
+
+# Container images (mirror the notebook; override for your registry/tags).
+MILES_IMAGE="${MILES_IMAGE:-rlsys/miles:MI350-355-latest}"
+AGENT_IMAGE="${AGENT_IMAGE:-aigmkt/aai-2026-harbor:v1}"
+CC_BASE_IMAGE="${CC_BASE_IMAGE:-cc_base:v1}"          # shared task-sandbox base (fast spawn)
+
+# ROCm device groups on the host (video/render). Override if your host differs.
+VIDEO_GID="${VIDEO_GID:-44}"
+RENDER_GID="${RENDER_GID:-109}"
+
+# W&B: from the environment only — never hard-code a key. Empty => W&B disabled.
+WANDB_KEY="${WANDB_KEY:-${WANDB_API_KEY:-}}"
+
+# Model + training hyperparameters (match the notebook's async run; override via env
+# or passthrough flags after --).
+HF_CHECKPOINT="${HF_CHECKPOINT:-Qwen/Qwen3-30B-A3B}"
+PROMPT_DATA="${PROMPT_DATA:-$EX/data/cc_train_all_sorted.jsonl}"  # full curriculum, easy->hard
+NUM_GPUS_PER_NODE="${NUM_GPUS_PER_NODE:-8}"
+TRAIN_NUM_GPUS="${TRAIN_NUM_GPUS:-4}"
+NUM_EPOCH="${NUM_EPOCH:-1}"
+ROLLOUT_BATCH_SIZE="${ROLLOUT_BATCH_SIZE:-8}"
+N_SAMPLES_PER_PROMPT="${N_SAMPLES_PER_PROMPT:-8}"
+GLOBAL_BATCH_SIZE="${GLOBAL_BATCH_SIZE:-64}"
+SAVE_INTERVAL="${SAVE_INTERVAL:-3999}"
+MAX_CONCURRENT="${MAX_CONCURRENT:-128}"               # Harbor trial concurrency
+
+DOCKER="${DOCKER:-docker}"                            # set to "sudo docker" if needed
+
+SKIP_SETUP=0
+SKIP_DATA=0
+FRESH_DATA=0
+RESET_ONLY=0
+TEARDOWN_ONLY=0
+PASSTHRU=()
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --skip-setup) SKIP_SETUP=1; shift ;;
+    --skip-data)  SKIP_DATA=1; shift ;;
+    --fresh-data) FRESH_DATA=1; shift ;;
+    --reset)      RESET_ONLY=1; shift ;;
+    --teardown)   TEARDOWN_ONLY=1; shift ;;
+    -h|--help)    sed -n '2,30p' "${BASH_SOURCE[0]}"; exit 0 ;;
+    --) shift; PASSTHRU=("$@"); break ;;
+    *) echo "unknown arg: $1 (use --help)"; exit 2 ;;
+  esac
+done
+
+log()  { printf '\n\033[1;36m=== %s ===\033[0m\n' "$*"; }
+note() { printf '\033[2m%s\033[0m\n' "$*"; }
+
+# --------------------------------------------------------------------------- #
+# reset / teardown (notebook cells 27 / 28)
+# --------------------------------------------------------------------------- #
+reset_trainer() {
+  log "Reset trainer (restart miles_swe)"
+  $DOCKER restart miles_swe
+  $DOCKER exec miles_swe bash -lc 'rm -rf /tmp/ray/session_* 2>/dev/null; rm -f /app/aiter/aiter/jit/build/lock_* 2>/dev/null' || true
+  echo "miles_swe reset; live ray/sglang: $($DOCKER exec miles_swe bash -lc 'pgrep -fc "raylet|sglang|train.py" 2>/dev/null' || echo 0)"
+}
+
+teardown() {
+  log "Teardown (remove containers + task sandboxes)"
+  $DOCKER rm -f miles_swe agent_env 2>/dev/null || true
+  $DOCKER rm -f "$($DOCKER ps -aq --filter 'name=code_contests-')" 2>/dev/null || true
+}
+
+if [ "$RESET_ONLY" = 1 ]; then reset_trainer; exit 0; fi
+if [ "$TEARDOWN_ONLY" = 1 ]; then teardown; exit 0; fi
+
+export REPO_DIR EX RUNTIME WORK_DIR TASKS_DIR HF_CACHE WANDB_KEY
+mkdir -p "$WORK_DIR" "$TASKS_DIR" "$HF_CACHE"
+
+log "Config"
+printf '%-12s= %s\n' REPO_DIR "$REPO_DIR" EX "$EX" RUNTIME "$RUNTIME" \
+  WORK_DIR "$WORK_DIR" TASKS_DIR "$TASKS_DIR" HF_CACHE "$HF_CACHE" \
+  MILES_IMAGE "$MILES_IMAGE" AGENT_IMAGE "$AGENT_IMAGE" PROMPT_DATA "$PROMPT_DATA"
+echo "WANDB_KEY   = $([ -n "$WANDB_KEY" ] && echo set || echo '(empty -> W&B disabled)')"
+
+# --------------------------------------------------------------------------- #
+# 1+2+3. Host setup, launch containers, install miles (notebook cells 4, 6, 7, 9)
+# --------------------------------------------------------------------------- #
+if [ "$SKIP_SETUP" = 0 ]; then
+  log "1. Host setup & clean slate"
+  $DOCKER rm -f miles_swe agent_env 2>/dev/null || true
+  $DOCKER rm -f "$($DOCKER ps -aq --filter 'name=code_contests-')" 2>/dev/null || true
+  $DOCKER network create swe-net 2>/dev/null || echo "swe-net exists"
+
+  log "2. Launch containers (miles_swe + agent_env)"
+  # Repo AND $RUNTIME are IDENTITY-mounted (host path == container path) so work/
+  # tasks/trials resolve in the sibling task containers Harbor spawns. All caches
+  # live under $RUNTIME so growing data never fills '/'.
+  $DOCKER run -d \
+    --name miles_swe \
+    --network swe-net \
+    --hostname miles_swe \
+    --device=/dev/kfd \
+    --device=/dev/dri \
+    --security-opt seccomp=unconfined \
+    --group-add "$VIDEO_GID" \
+    --group-add "$RENDER_GID" \
+    --cap-add=SYS_PTRACE \
+    --ipc=host \
+    --shm-size=32g \
+    --ulimit memlock=-1 \
+    --ulimit stack=67108864 \
+    --memory=0 \
+    --memory-swap=0 \
+    --privileged \
+    --ulimit nofile=65535:65535 \
+    -e WANDB_API_KEY="$WANDB_KEY" \
+    -e HF_HOME="$HF_CACHE" \
+    -v "$REPO_DIR":"$REPO_DIR" \
+    -v "$RUNTIME":"$RUNTIME" \
+    "$MILES_IMAGE" sleep infinity
+
+  $DOCKER run -d --name agent_env --hostname agent_env \
+    --network swe-net \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    -v "$REPO_DIR":"$REPO_DIR" \
+    -v "$RUNTIME":"$RUNTIME" \
+    "$AGENT_IMAGE" sleep infinity
+
+  $DOCKER ps --format '{{.Names}}\t{{.Image}}\t{{.Status}}' | grep -E 'miles_swe|agent_env'
+
+  log "3. Install miles in miles_swe"
+  $DOCKER exec -e REPO_DIR="$REPO_DIR" miles_swe bash -lc 'cd "$REPO_DIR" && pip install -e . --no-deps --no-build-isolation'
+  $DOCKER exec miles_swe bash -lc 'python3 -c "import miles, miles_plugins.mbridge"' && echo "miles import ok"
+else
+  note "--skip-setup: reusing running containers + installed miles"
+fi
+
+# --------------------------------------------------------------------------- #
+# 4. Start Harbor (detached background service); wait for /health (cell 11)
+# --------------------------------------------------------------------------- #
+log "4. Start Harbor (background)"
+if $DOCKER exec miles_swe bash -lc 'curl -sf http://agent_env:11000/health' >/dev/null 2>&1; then
+  note "Harbor already responding; not relaunching"
+else
+  $DOCKER exec -d -e EX="$EX" -e REPO_DIR="$REPO_DIR" -e WORK_DIR="$WORK_DIR" -e TASKS_DIR="$TASKS_DIR" agent_env bash -lc ' \
+      export OPENAI_API_KEY=dummy \
+      MSWEA_API_KEY=dummy \
+      MSWEA_CONFIG_FILE=$EX/harbor/codecontests.yaml \
+      HARBOR_EXTRA_DOCKER_COMPOSE=$EX/harbor/swe_net_override.yaml \
+      HARBOR_DELETE_CONTAINERS=false \
+      HARBOR_ASYNC_TEARDOWN=1 \
+      HARBOR_TASKS_DIR=$TASKS_DIR \
+      HARBOR_TRIALS_DIR=$WORK_DIR/cc_trials; \
+      cd $EX && PYTHONPATH=$REPO_DIR python3 harbor/server.py --port 11000 --max-concurrent '"$MAX_CONCURRENT"' > $WORK_DIR/harbor.log 2>&1'
+
+  # health check runs from inside miles_swe (host can't reach swe-net directly)
+  if $DOCKER exec miles_swe bash -lc 'for i in $(seq 1 30); do curl -sf http://agent_env:11000/health && exit 0; sleep 2; done; exit 1'; then
+    echo " <- harbor up"
+  else
+    echo "harbor NOT up; last 15 lines of harbor.log:"; tail -n 15 "$WORK_DIR/harbor.log" 2>/dev/null || true
+    exit 1
+  fi
+fi
+
+# --------------------------------------------------------------------------- #
+# 5+6. Data prep, task base image, model pre-fetch (cells 13/14/16/21; guarded)
+# --------------------------------------------------------------------------- #
+if [ "$SKIP_DATA" = 0 ]; then
+  if [ "$FRESH_DATA" = 1 ]; then
+    log "5.0 Fresh data prep: wiping extracted tasks + jsonls + HF dataset cache"
+    $DOCKER exec -e EX="$EX" -e TASKS_DIR="$TASKS_DIR" -e HF_CACHE="$HF_CACHE" miles_swe bash -lc '
+      rm -rf "$TASKS_DIR"/code_contests-*
+      rm -f  "$EX"/data/cc_train_*.jsonl
+      rm -rf "$HF_CACHE"/hub/datasets--open-thoughts--CodeContests*
+      echo "after clean: tasks=$(ls "$TASKS_DIR" 2>/dev/null | wc -l)  jsonls=$(ls "$EX"/data/cc_train_*.jsonl 2>/dev/null | wc -l)"
+    '
+  fi
+
+  log "5. Data preparation (download + extract + build jsonls; guarded)"
+  $DOCKER exec -e EX="$EX" -e TASKS_DIR="$TASKS_DIR" -e HF_CACHE="$HF_CACHE" -e HF_HOME="$HF_CACHE" miles_swe bash -lc '
+    [ -d "$TASKS_DIR"/code_contests-0000 ] || \
+      python3 "$EX"/data_prep/extract_codecontests.py --dataset open-thoughts/CodeContests --out "$TASKS_DIR"
+    # build_cc_jsonl.py emits the per-difficulty splits AND the combined
+    # cc_train_all_sorted.jsonl (increasing difficulty, unrated last) in one pass.
+    [ -f "$EX"/data/cc_train_all_sorted.jsonl ] || \
+      python3 "$EX"/data_prep/build_cc_jsonl.py --tasks "$TASKS_DIR" --out-dir "$EX"/data
+  '
+
+  log "5b. Faster sandbox spawn: build task base image $CC_BASE_IMAGE + rewrite task Dockerfiles"
+  # Bake python3/pip once into a shared base image on the HOST docker daemon (the one
+  # Harbor uses via the mounted socket), then rewrite each task Dockerfile to FROM it
+  # (no per-task apt) so environment_setup drops toward the ~5s container-create floor.
+  if ! $DOCKER image inspect "$CC_BASE_IMAGE" >/dev/null 2>&1; then
+    $DOCKER build -t "$CC_BASE_IMAGE" - <<'EOF'
+FROM ubuntu:24.04
+RUN apt-get update && apt-get install -y python3 python3-pip && rm -rf /var/lib/apt/lists/*
+EOF
+  else
+    note "task base image $CC_BASE_IMAGE already present"
+  fi
+  $DOCKER exec -e EX="$EX" -e TASKS_DIR="$TASKS_DIR" -e CC_BASE_IMAGE="$CC_BASE_IMAGE" miles_swe bash -lc \
+    'python3 "$EX"/data_prep/extract_codecontests.py --rewrite-only --out "$TASKS_DIR" --base-image "$CC_BASE_IMAGE"'
+
+  log "6. Pre-fetch $HF_CHECKPOINT into HF cache"
+  $DOCKER exec -e HF_HOME="$HF_CACHE" -e HF_CHECKPOINT="$HF_CHECKPOINT" miles_swe bash -lc \
+    'python3 -c "import os; from huggingface_hub import snapshot_download; snapshot_download(os.environ[\"HF_CHECKPOINT\"])"'
+else
+  note "--skip-data: reusing prepared data + model"
+fi
+
+# --------------------------------------------------------------------------- #
+# 7. Training run (disaggregated async GRPO, 4 train + 4 rollout GPUs) — cell 23.
+# Foreground, streamed to terminal + $WORK_DIR/train.log. Use `--reset` between runs.
+# --------------------------------------------------------------------------- #
+log "7. Training run (foreground; also logging to $WORK_DIR/train.log)"
+$DOCKER exec -e EX="$EX" -e REPO_DIR="$REPO_DIR" -e WORK_DIR="$WORK_DIR" -e TASKS_DIR="$TASKS_DIR" \
+  -e HF_CACHE="$HF_CACHE" -e HF_HOME="$HF_CACHE" -e WANDB_KEY="$WANDB_KEY" \
+  -e HF_CHECKPOINT="$HF_CHECKPOINT" -e PROMPT_DATA="$PROMPT_DATA" \
+  -e NUM_GPUS_PER_NODE="$NUM_GPUS_PER_NODE" -e TRAIN_NUM_GPUS="$TRAIN_NUM_GPUS" \
+  -e NUM_EPOCH="$NUM_EPOCH" -e ROLLOUT_BATCH_SIZE="$ROLLOUT_BATCH_SIZE" \
+  -e N_SAMPLES_PER_PROMPT="$N_SAMPLES_PER_PROMPT" -e GLOBAL_BATCH_SIZE="$GLOBAL_BATCH_SIZE" \
+  -e SAVE_INTERVAL="$SAVE_INTERVAL" \
+  miles_swe bash -lc 'cd "$EX"; \
+    export WANDB_KEY=$WANDB_KEY \
+    MILES_ROUTER_EXTERNAL_HOST=miles_swe \
+    AGENT_SERVER_URL=http://agent_env:11000 \
+    HARBOR_TASKS_DIR=$TASKS_DIR \
+    WANDB_DIR=$WORK_DIR/wandb; \
+    PYTHONPATH=$REPO_DIR python3 run-qwen3-codecontests.py \
+    --async-mode \
+    --num-gpus-per-node "$NUM_GPUS_PER_NODE" \
+    --train-num-gpus "$TRAIN_NUM_GPUS" \
+    --hf-checkpoint "$HF_CHECKPOINT" \
+    --prompt-data "$PROMPT_DATA" \
+    --num-epoch "$NUM_EPOCH" \
+    --rollout-batch-size "$ROLLOUT_BATCH_SIZE" \
+    --n-samples-per-prompt "$N_SAMPLES_PER_PROMPT" \
+    --global-batch-size "$GLOBAL_BATCH_SIZE" \
+    --save-interval "$SAVE_INTERVAL" '"${PASSTHRU[*]:-}"' 2>&1' \
+  | tee "$WORK_DIR/train.log"
+
+log "Training finished. Trials under $WORK_DIR/cc_trials  |  log: $WORK_DIR/train.log"

--- a/miles/rollout/session/core.py
+++ b/miles/rollout/session/core.py
@@ -222,8 +222,19 @@ class SessionCore:
         # --- lock released ---
 
         # --- Phase 2: proxy to backend (NO lock held) ---
+        # Measure server-side generation time: the backend call duration as seen by
+        # the session server (≈ GPU generation + scheduler queue), which EXCLUDES the
+        # agent<->session-server network round-trip. The agent-observed per-turn time
+        # (model_query_time) minus this gen_time isolates that network/comm latency.
+        # Logged per session_id so GPU-vs-network can be separated downstream.
+        _gen_t0 = time.perf_counter()
         result = await self.backend.do_proxy(
             ProxyRequest(method=method, query=query), "v1/chat/completions", body=proxy_body, headers=headers
+        )
+        _gen_time = time.perf_counter() - _gen_t0
+        logger.info(
+            f"[session-server] GEN session_id={session_id} gen_time={_gen_time:.3f}s "
+            f"status={result['status_code']}"
         )
 
         # Non-200 (e.g. 400 context too long) passes through unrecorded so the
@@ -241,10 +252,11 @@ class SessionCore:
             )
         assistant_message = choice.get("message") or {}
         if assistant_message.get("content") is None:
-            raise UpstreamResponseError(
-                "assistant message content is None, when tool call parser failed SGLang should still return "
-                "an empty content rather than None. Please check your modified SGLang version."
-            )
+            # A tool-call-only turn (no natural-language text) legitimately yields
+            # content=None; coerce to "" so the turn records normally instead of
+            # aborting the sample. Token ids/logprobs come from meta_info, not this
+            # string, so training signal is unaffected.
+            assistant_message["content"] = ""
 
         output_token_logprobs = meta_info["output_token_logprobs"]
         completion_tokens = meta_info["completion_tokens"]


### PR DESCRIPTION
Self-contained Multi-turn RL example that trains a Qwen3-30B-A3B model on the CodeContests
competitive-programming dataset. The model is the backend for the mini-swe-agent: each turn it
writes/edits /app/solution.py in a sandbox, runs it, inspects the output, and
iterates until it submits. Reward = whether the submitted program passes the hidden
tests. Training is GRPO on token-in/token-out (TITO) trajectories.

Default target: Qwen3-30B-A3B (MoE) in disaggregated async mode
(4 train + 4 rollout GPUs) on AMD-MI35x .

