### PR TITLE
[AMD] Fix HF to torch_dist conversion segfault during checkpoint save

### DIFF
--- a/tools/convert_hf_to_torch_dist.py
+++ b/tools/convert_hf_to_torch_dist.py
@@ -80,10 +80,12 @@ def get_args():
 def main():
     if torch.version.hip:
         import megatron.core.dist_checkpointing.strategies.filesystem_async as filesystem_async_module
+        import megatron.core.dist_checkpointing.strategies.torch as torch_strategy_module
 
         from miles.utils.rocm_checkpoint_writer import ROCmFileSystemWriterAsync
 
         filesystem_async_module.FileSystemWriterAsync = ROCmFileSystemWriterAsync
+        torch_strategy_module.FileSystemWriterAsync = ROCmFileSystemWriterAsync
         print("[ROCm] Applied FileSystemWriterAsync patch for HIP compatibility")
 
     configure_logger()


### PR DESCRIPTION
Co-authored-with: @XinyuJiangCMU

## Problem

On ROCm, `convert_hf_to_torch_dist.py` segfaults during checkpoint save. Miles already has a workaround (`ROCmFileSystemWriterAsync`, which forces `non_blocking=False`), but it was only patched into the `filesystem_async` namespace, while the writer is actually instantiated in `strategies/torch.py`, which holds its own `from .filesystem_async import FileSystemWriterAsync` binding.

## Fix

Patch the `strategies/torch` namespace too, so the writer it instantiates uses `ROCmFileSystemWriterAsync`.