### PR TITLE
[fix] make tensors contiguous before broadcast weight sync

### DIFF
--- a/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/broadcast.py
+++ b/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/broadcast.py
@@ -135,8 +135,11 @@ class UpdateWeightFromDistributed(DistBucketedWeightUpdateMixin):
             )
             for engine in self.rollout_engines
         ]
+        contiguous_tensors = [
+            param.data if param.data.is_contiguous() else param.data.contiguous() for _, param in named_tensors
+        ]
         handles = [
-            dist.broadcast(param.data, 0, group=self._model_update_groups, async_op=True) for _, param in named_tensors
+            dist.broadcast(tensor, 0, group=self._model_update_groups, async_op=True) for tensor in contiguous_tensors
         ]
         for handle in handles:
             handle.wait()
@@ -220,9 +223,12 @@ def update_weights_from_distributed(
         for engine in rollout_engines
     ]
 
+    contiguous_tensors = [
+        param.data if param.data.is_contiguous() else param.data.contiguous() for _, param in converted_named_tensors
+    ]
     handles = []
-    for _, param in converted_named_tensors:
-        handles.append(dist.broadcast(param.data, 0, group=group, async_op=True))
+    for tensor in contiguous_tensors:
+        handles.append(dist.broadcast(tensor, 0, group=group, async_op=True))
     for handle in handles:
         handle.wait()
 


### PR DESCRIPTION
## Problem

In `broadcast` weight-transfer mode, converted HF tensors are passed straight to `dist.broadcast(param.data, ...)`. When the rollout engines are served in FP8 with DeepGEMM ue8m0 scales (blockwise `[128, 128]`, e.g. GLM-5.2 / DeepSeek-style models on Blackwell with `--sglang-moe-a2a-backend deepep`), the converted `weight_scale_inv` tensors come out of `transform_scale_ue8m0` in MN-major TMA-aligned layout — **non-contiguous by design** (DeepGEMM asserts the strided layout). NCCL rejects them:

```
ValueError: Tensors must be contiguous
  File ".../update_weight_from_distributed/broadcast.py", line 225, in update_weights_from_distributed
    handles.append(dist.broadcast(param.data, 0, group=group, async_op=True))
```

This never surfaces in colocated mode because the tensor/IPC path flattens through `FlattenedTensorBucket`, which implicitly makes contiguous copies. The broadcast path has no such step, so disaggregated + FP8-ue8m0 crashes on the first weight sync.

## Fix

Make contiguous copies only where needed before broadcasting (both the bucketed implementation and the module-level `update_weights_from_distributed`, plus the LoRA path which shares the pattern). Contiguous tensors pass through untouched; the only copies are the packed ue8m0 scale tensors, which are ~1/16384 the size of their weights — overhead is negligible.

## Validation

GLM-5.2 744B fully-async disaggregated run (8 training + 8 inference nodes, GB300, `--update-weight-transfer-mode broadcast`): weight sync crashed on the first update before the fix; after it, multiple weight updates completed across RL steps with rewards and `train_rollout_logprob_abs_diff` in the normal band.

