### PR TITLE
Daytona pool self-healing: replace slots whose env server died instead of retrying forever

### DIFF
--- a/examples/experimental/openenv/openenv_agent_function.py
+++ b/examples/experimental/openenv/openenv_agent_function.py
@@ -40,6 +40,7 @@ from dataclasses import dataclass
 from typing import Any
 from urllib.parse import urlparse, urlunparse
 
+import websockets.exceptions
 from openai import AsyncOpenAI
 
 logger = logging.getLogger(__name__)
@@ -156,19 +157,11 @@ _POOL_PROVISION_BACKOFF_CAP_S = float(os.getenv("OPENENV_DAYTONA_PROVISION_BACKO
 
 
 def _is_connection_error(exc: BaseException) -> bool:
-    s = str(exc).lower()
-    return any(
-        k in s
-        for k in (
-            "rejected websocket",
-            "failed to connect",
-            "no close frame",
-            "connection refused",
-            "connectionclosederror",
-            "server rejected",
-            "502",
-        )
-    )
+    # OpenEnv's EnvClient.connect normalizes every handshake failure (refused,
+    # timeout, HTTP 502 / rejected websocket) to a builtin ConnectionError;
+    # a mid-stream drop surfaces as websockets' ConnectionClosedError from
+    # recv/send. ConnectionClosedOK (clean 1000 close) is deliberately excluded.
+    return isinstance(exc, (ConnectionError, websockets.exceptions.ConnectionClosedError))
 
 
 def _is_throttle_error(exc: BaseException) -> bool:

--- a/examples/experimental/openenv/openenv_agent_function.py
+++ b/examples/experimental/openenv/openenv_agent_function.py
@@ -155,6 +155,22 @@ _POOL_PROVISION_BACKOFF_BASE_S = float(os.getenv("OPENENV_DAYTONA_PROVISION_BACK
 _POOL_PROVISION_BACKOFF_CAP_S = float(os.getenv("OPENENV_DAYTONA_PROVISION_BACKOFF_CAP_S", "30.0"))
 
 
+def _is_connection_error(exc: BaseException) -> bool:
+    s = str(exc).lower()
+    return any(
+        k in s
+        for k in (
+            "rejected websocket",
+            "failed to connect",
+            "no close frame",
+            "connection refused",
+            "connectionclosederror",
+            "server rejected",
+            "502",
+        )
+    )
+
+
 def _is_throttle_error(exc: BaseException) -> bool:
     s = str(exc).lower()
     return "throttler" in s or "too many requests" in s or "429" in s
@@ -179,6 +195,7 @@ class _DaytonaPool:
         self._queue: asyncio.Queue[_DaytonaSlot] | None = None
         self._slots: list[_DaytonaSlot] = []
         self._init_lock = asyncio.Lock()
+        self._replace_tasks: set[asyncio.Task] = set()
 
     @classmethod
     def maybe(cls) -> "_DaytonaPool | None":
@@ -266,6 +283,26 @@ class _DaytonaPool:
         assert self._queue is not None
         self._queue.put_nowait(slot)
 
+    def replace_broken(self, slot: _DaytonaSlot) -> None:
+        logger.warning(f"Daytona slot {slot.url} marked broken; replacing in background")
+        task = asyncio.create_task(self._replace(slot))
+        self._replace_tasks.add(task)
+        task.add_done_callback(self._replace_tasks.discard)
+
+    async def _replace(self, slot: _DaytonaSlot) -> None:
+        try:
+            await asyncio.to_thread(slot.provider.stop_container)
+        except Exception as e:
+            logger.warning(f"Failed to stop broken sandbox {slot.url}: {e}")
+        try:
+            new_slot = await self._spawn_one(-1, asyncio.Semaphore(1))
+        except Exception as e:
+            logger.error(f"Failed to replace broken Daytona slot ({slot.url}): {e}")
+            return
+        assert self._queue is not None
+        self._queue.put_nowait(new_slot)
+        logger.info(f"Daytona slot replaced: {slot.url} -> {new_slot.url}")
+
     async def teardown(self) -> None:
         for slot in self._slots:
             try:
@@ -283,11 +320,18 @@ async def _with_env(env_cls: Any, env_url: str, body: Callable[[Any], Any]) -> A
     pool = _DaytonaPool.maybe()
     if pool is not None:
         slot = await pool.acquire()
+        broken = False
         try:
             async with env_cls(base_url=slot.url, message_timeout_s=_MESSAGE_TIMEOUT_S) as env:
                 return await body(env)
+        except BaseException as e:
+            broken = _is_connection_error(e)
+            raise
         finally:
-            await pool.release(slot)
+            if broken:
+                pool.replace_broken(slot)
+            else:
+                await pool.release(slot)
 
     deadline = asyncio.get_event_loop().time() + _CAPACITY_MAX_WAIT_S
     while True:

--- a/examples/experimental/openenv/openenv_agent_function.py
+++ b/examples/experimental/openenv/openenv_agent_function.py
@@ -294,21 +294,32 @@ class _DaytonaPool:
             await asyncio.to_thread(slot.provider.stop_container)
         except Exception as e:
             logger.warning(f"Failed to stop broken sandbox {slot.url}: {e}")
+        if slot in self._slots:
+            self._slots.remove(slot)
         try:
             new_slot = await self._spawn_one(-1, asyncio.Semaphore(1))
         except Exception as e:
             logger.error(f"Failed to replace broken Daytona slot ({slot.url}): {e}")
             return
+        self._slots.append(new_slot)
         assert self._queue is not None
         self._queue.put_nowait(new_slot)
         logger.info(f"Daytona slot replaced: {slot.url} -> {new_slot.url}")
 
     async def teardown(self) -> None:
-        for slot in self._slots:
-            try:
-                await asyncio.to_thread(slot.provider.stop_container)
-            except Exception as e:
-                logger.warning(f"Failed to stop sandbox {slot.url}: {e}")
+        # Cancel in-flight replacements first: a task still awaiting _spawn_one
+        # would otherwise enqueue a sandbox after teardown and leak it.
+        try:
+            for task in list(self._replace_tasks):
+                task.cancel()
+            if self._replace_tasks:
+                await asyncio.gather(*self._replace_tasks, return_exceptions=True)
+        finally:
+            for slot in self._slots:
+                try:
+                    await asyncio.to_thread(slot.provider.stop_container)
+                except Exception as e:
+                    logger.warning(f"Failed to stop sandbox {slot.url}: {e}")
 
 
 async def _with_env(env_cls: Any, env_url: str, body: Callable[[Any], Any]) -> Any:


### PR DESCRIPTION
Builds on #1487 (targets its branch). Fixes a failure mode found running the tbench2 + Daytona pool adapter in fully-async disaggregated training.

## Problem

When in-flight episodes are killed mid-run (e.g. every weight update aborts current generations), their env-server processes inside the Daytona sandboxes can crash on the client disconnect and never recover (subsequent connects get 502 / rejected websocket). The slot goes back into the pool anyway, so every episode that later acquires it fails and retries forever.

Observed at scale: one weight update killed ~30 in-flight episodes, all their sandboxes' env servers 502-crashed, and the rollout worker spun on thousands of doomed retries — the run was permanently stalled while all sandboxes were "alive" from Daytona's point of view.

## Fix

Classify connection-level failures (`_is_connection_error`) in `_with_env`'s pool branch and, instead of releasing the broken slot back into the queue, replace it in the background: stop the dead sandbox, provision a fresh one through the existing `_spawn_one` path (inherits the throttle/backoff handling), and enqueue the replacement. The episode's own exception still propagates unchanged, so episode-level retry/reward semantics are untouched.

Notes:
- Replacement is fire-and-forget (`asyncio.create_task` with a held reference) so neither the failing episode nor other episodes block on the ~30-60s provisioning.
- Classification is by error text; a false negative degrades to today's behavior (slot released, next user re-detects), a false positive costs one sandbox recycle. Cancellation (episode killed) does NOT mark the slot broken — only the next real connection failure does.
- If provisioning the replacement fails (e.g. org quota exhausted), the error is logged and the pool shrinks by one rather than crash-looping.

## Validation

GLM-5.2 744B fully-async run (8 train + 8 inference nodes, 64-episode batches): at a weight-update window one slot's env server died, was detected on next acquire, replaced in background, and the episode stream continued without stalling — vs. the pre-fix run which permanently stalled at the same point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
