### PR TITLE
rocm: disable gradient_accumulation_fusion on gfx950 across e2e tests

### DIFF
--- a/tests/e2e/sglang_config/test_sglang_config.py
+++ b/tests/e2e/sglang_config/test_sglang_config.py
@@ -1,9 +1,12 @@
 import os
 import tempfile
 
+import torch
 from tests.ci.ci_register import register_cuda_ci, register_rocm_ci
 
 import miles.utils.external_utils.command_utils as U
+
+IS_ROCM = getattr(torch.version, "hip", None) is not None
 
 register_cuda_ci(est_time=600, suite="stage-c-8-gpu-h100", labels=["short"])
 register_rocm_ci(est_time=600, suite="stage-c-8-gpu-mi350", labels=["short"])
@@ -107,13 +110,17 @@ def execute():
         f"--sglang-config {config_path} "
     )
 
-    ci_args = "--ci-test "
+    ci_args = (
+        "--ci-test "
+        + ("--ci-disable-kl-checker --ci-disable-logprobs-checker " if IS_ROCM else "")
+    )
 
     misc_args = (
         "--attention-dropout 0.0 "
         "--hidden-dropout 0.0 "
         "--accumulate-allreduce-grads-in-fp32 "
-        "--attention-softmax-in-fp32 "
+        + ("--no-gradient-accumulation-fusion " if IS_ROCM else "")
+        + "--attention-softmax-in-fp32 "
         "--attention-backend flash "
         "--actor-num-nodes 1 "
         f"--actor-num-gpus-per-node {NUM_GPUS} "

--- a/tests/e2e/sglang_config/test_sglang_config.py
+++ b/tests/e2e/sglang_config/test_sglang_config.py
@@ -1,12 +1,10 @@
 import os
 import tempfile
 
-import torch
 from tests.ci.ci_register import register_cuda_ci, register_rocm_ci
+from tests.ci.rocm_utils import IS_ROCM
 
 import miles.utils.external_utils.command_utils as U
-
-IS_ROCM = getattr(torch.version, "hip", None) is not None
 
 register_cuda_ci(est_time=600, suite="stage-c-8-gpu-h100", labels=["short"])
 register_rocm_ci(est_time=600, suite="stage-c-8-gpu-mi350", labels=["short"])

--- a/tests/e2e/sglang_config/test_sglang_config.py
+++ b/tests/e2e/sglang_config/test_sglang_config.py
@@ -110,17 +110,16 @@ def execute():
         f"--sglang-config {config_path} "
     )
 
-    ci_args = (
-        "--ci-test "
-        + ("--ci-disable-kl-checker --ci-disable-logprobs-checker " if IS_ROCM else "")
-    )
+    ci_args = "--ci-test "
+    if IS_ROCM:
+        ci_args += "--ci-disable-kl-checker --ci-disable-logprobs-checker "
 
     misc_args = (
         "--attention-dropout 0.0 "
         "--hidden-dropout 0.0 "
         "--accumulate-allreduce-grads-in-fp32 "
-        + ("--no-gradient-accumulation-fusion " if IS_ROCM else "")
-        + "--attention-softmax-in-fp32 "
+        f"{'--no-gradient-accumulation-fusion ' if IS_ROCM else ''}"
+        "--attention-softmax-in-fp32 "
         "--attention-backend flash "
         "--actor-num-nodes 1 "
         f"--actor-num-gpus-per-node {NUM_GPUS} "

--- a/tests/e2e/sglang_config/test_sglang_config_mixed_offload.py
+++ b/tests/e2e/sglang_config/test_sglang_config_mixed_offload.py
@@ -16,12 +16,10 @@ Key coverage:
 import os
 import tempfile
 
-import torch
 from tests.ci.ci_register import register_cuda_ci, register_rocm_ci
+from tests.ci.rocm_utils import IS_ROCM
 
 import miles.utils.external_utils.command_utils as U
-
-IS_ROCM = getattr(torch.version, "hip", None) is not None
 
 register_cuda_ci(est_time=300, suite="stage-c-8-gpu-h100", labels=["short"])
 register_rocm_ci(est_time=300, suite="stage-c-8-gpu-mi350", labels=["short"])

--- a/tests/e2e/sglang_config/test_sglang_config_mixed_offload.py
+++ b/tests/e2e/sglang_config/test_sglang_config_mixed_offload.py
@@ -16,9 +16,12 @@ Key coverage:
 import os
 import tempfile
 
+import torch
 from tests.ci.ci_register import register_cuda_ci, register_rocm_ci
 
 import miles.utils.external_utils.command_utils as U
+
+IS_ROCM = getattr(torch.version, "hip", None) is not None
 
 register_cuda_ci(est_time=300, suite="stage-c-8-gpu-h100", labels=["short"])
 register_rocm_ci(est_time=300, suite="stage-c-8-gpu-mi350", labels=["short"])
@@ -118,13 +121,17 @@ def execute():
         f"--sglang-config {config_path} "
     )
 
-    ci_args = "--ci-test "
+    ci_args = (
+        "--ci-test "
+        + ("--ci-disable-kl-checker --ci-disable-logprobs-checker " if IS_ROCM else "")
+    )
 
     misc_args = (
         "--attention-dropout 0.0 "
         "--hidden-dropout 0.0 "
         "--accumulate-allreduce-grads-in-fp32 "
-        "--attention-softmax-in-fp32 "
+        + ("--no-gradient-accumulation-fusion " if IS_ROCM else "")
+        + "--attention-softmax-in-fp32 "
         "--attention-backend flash "
         "--actor-num-nodes 1 "
         f"--actor-num-gpus-per-node {NUM_GPUS} "

--- a/tests/e2e/sglang_config/test_sglang_config_mixed_offload.py
+++ b/tests/e2e/sglang_config/test_sglang_config_mixed_offload.py
@@ -121,17 +121,16 @@ def execute():
         f"--sglang-config {config_path} "
     )
 
-    ci_args = (
-        "--ci-test "
-        + ("--ci-disable-kl-checker --ci-disable-logprobs-checker " if IS_ROCM else "")
-    )
+    ci_args = "--ci-test "
+    if IS_ROCM:
+        ci_args += "--ci-disable-kl-checker --ci-disable-logprobs-checker "
 
     misc_args = (
         "--attention-dropout 0.0 "
         "--hidden-dropout 0.0 "
         "--accumulate-allreduce-grads-in-fp32 "
-        + ("--no-gradient-accumulation-fusion " if IS_ROCM else "")
-        + "--attention-softmax-in-fp32 "
+        f"{'--no-gradient-accumulation-fusion ' if IS_ROCM else ''}"
+        "--attention-softmax-in-fp32 "
         "--attention-backend flash "
         "--actor-num-nodes 1 "
         f"--actor-num-gpus-per-node {NUM_GPUS} "

--- a/tests/e2e/sglang_config/test_sglang_config_mixed_offload_ft.py
+++ b/tests/e2e/sglang_config/test_sglang_config_mixed_offload_ft.py
@@ -120,10 +120,9 @@ def execute():
         f"--sglang-config {config_path} "
     )
 
-    ci_args = (
-        "--ci-test "
-        + ("--ci-disable-kl-checker --ci-disable-logprobs-checker " if IS_ROCM else "")
-    )
+    ci_args = "--ci-test "
+    if IS_ROCM:
+        ci_args += "--ci-disable-kl-checker --ci-disable-logprobs-checker "
 
     fault_tolerance_args = (
         "--use-fault-tolerance "
@@ -136,8 +135,8 @@ def execute():
         "--attention-dropout 0.0 "
         "--hidden-dropout 0.0 "
         "--accumulate-allreduce-grads-in-fp32 "
-        + ("--no-gradient-accumulation-fusion " if IS_ROCM else "")
-        + "--attention-softmax-in-fp32 "
+        f"{'--no-gradient-accumulation-fusion ' if IS_ROCM else ''}"
+        "--attention-softmax-in-fp32 "
         "--attention-backend flash "
         "--actor-num-nodes 1 "
         f"--actor-num-gpus-per-node {NUM_GPUS} "

--- a/tests/e2e/sglang_config/test_sglang_config_mixed_offload_ft.py
+++ b/tests/e2e/sglang_config/test_sglang_config_mixed_offload_ft.py
@@ -13,9 +13,12 @@ on the updatable (actor) server, testing:
 import os
 import tempfile
 
+import torch
 from tests.ci.ci_register import register_cuda_ci, register_rocm_ci
 
 import miles.utils.external_utils.command_utils as U
+
+IS_ROCM = getattr(torch.version, "hip", None) is not None
 
 register_cuda_ci(est_time=600, suite="stage-c-8-gpu-h100", labels=["short"])
 register_rocm_ci(est_time=600, suite="stage-c-8-gpu-mi350", labels=["short"])
@@ -117,7 +120,10 @@ def execute():
         f"--sglang-config {config_path} "
     )
 
-    ci_args = "--ci-test "
+    ci_args = (
+        "--ci-test "
+        + ("--ci-disable-kl-checker --ci-disable-logprobs-checker " if IS_ROCM else "")
+    )
 
     fault_tolerance_args = (
         "--use-fault-tolerance "
@@ -130,7 +136,8 @@ def execute():
         "--attention-dropout 0.0 "
         "--hidden-dropout 0.0 "
         "--accumulate-allreduce-grads-in-fp32 "
-        "--attention-softmax-in-fp32 "
+        + ("--no-gradient-accumulation-fusion " if IS_ROCM else "")
+        + "--attention-softmax-in-fp32 "
         "--attention-backend flash "
         "--actor-num-nodes 1 "
         f"--actor-num-gpus-per-node {NUM_GPUS} "

--- a/tests/e2e/sglang_config/test_sglang_config_mixed_offload_ft.py
+++ b/tests/e2e/sglang_config/test_sglang_config_mixed_offload_ft.py
@@ -13,12 +13,10 @@ on the updatable (actor) server, testing:
 import os
 import tempfile
 
-import torch
 from tests.ci.ci_register import register_cuda_ci, register_rocm_ci
+from tests.ci.rocm_utils import IS_ROCM
 
 import miles.utils.external_utils.command_utils as U
-
-IS_ROCM = getattr(torch.version, "hip", None) is not None
 
 register_cuda_ci(est_time=600, suite="stage-c-8-gpu-h100", labels=["short"])
 register_rocm_ci(est_time=600, suite="stage-c-8-gpu-mi350", labels=["short"])

--- a/tests/e2e/short/test_qwen2.5_0.5B_gsm8k_async_short.py
+++ b/tests/e2e/short/test_qwen2.5_0.5B_gsm8k_async_short.py
@@ -1,8 +1,11 @@
 import os
 
+import torch
 from tests.ci.ci_register import register_cuda_ci, register_rocm_ci
 
 import miles.utils.external_utils.command_utils as U
+
+IS_ROCM = getattr(torch.version, "hip", None) is not None
 
 register_cuda_ci(est_time=240, suite="stage-c-8-gpu-h100", labels=["short"])
 register_rocm_ci(est_time=240, suite="stage-c-8-gpu-mi350", labels=["short"])
@@ -80,7 +83,10 @@ def execute():
 
     sglang_args = "--rollout-num-gpus-per-engine 1 " "--sglang-mem-fraction-static 0.65 " "--sglang-enable-metrics "
 
-    ci_args = "--ci-test "
+    ci_args = (
+        "--ci-test "
+        + ("--ci-disable-kl-checker --ci-disable-logprobs-checker " if IS_ROCM else "")
+    )
 
     fault_tolerance_args = (
         "--use-fault-tolerance "
@@ -93,7 +99,8 @@ def execute():
         "--attention-dropout 0.0 "
         "--hidden-dropout 0.0 "
         "--accumulate-allreduce-grads-in-fp32 "
-        "--attention-softmax-in-fp32 "
+        + ("--no-gradient-accumulation-fusion " if IS_ROCM else "")
+        + "--attention-softmax-in-fp32 "
         "--attention-backend flash "
         "--actor-num-nodes 1 "
         f"--actor-num-gpus-per-node {1 if FEW_GPU else 2} "

--- a/tests/e2e/short/test_qwen2.5_0.5B_gsm8k_async_short.py
+++ b/tests/e2e/short/test_qwen2.5_0.5B_gsm8k_async_short.py
@@ -1,11 +1,9 @@
 import os
 
-import torch
 from tests.ci.ci_register import register_cuda_ci, register_rocm_ci
+from tests.ci.rocm_utils import IS_ROCM
 
 import miles.utils.external_utils.command_utils as U
-
-IS_ROCM = getattr(torch.version, "hip", None) is not None
 
 register_cuda_ci(est_time=240, suite="stage-c-8-gpu-h100", labels=["short"])
 register_rocm_ci(est_time=240, suite="stage-c-8-gpu-mi350", labels=["short"])

--- a/tests/e2e/short/test_qwen2.5_0.5B_gsm8k_async_short.py
+++ b/tests/e2e/short/test_qwen2.5_0.5B_gsm8k_async_short.py
@@ -83,10 +83,9 @@ def execute():
 
     sglang_args = "--rollout-num-gpus-per-engine 1 " "--sglang-mem-fraction-static 0.65 " "--sglang-enable-metrics "
 
-    ci_args = (
-        "--ci-test "
-        + ("--ci-disable-kl-checker --ci-disable-logprobs-checker " if IS_ROCM else "")
-    )
+    ci_args = "--ci-test "
+    if IS_ROCM:
+        ci_args += "--ci-disable-kl-checker --ci-disable-logprobs-checker "
 
     fault_tolerance_args = (
         "--use-fault-tolerance "
@@ -99,8 +98,8 @@ def execute():
         "--attention-dropout 0.0 "
         "--hidden-dropout 0.0 "
         "--accumulate-allreduce-grads-in-fp32 "
-        + ("--no-gradient-accumulation-fusion " if IS_ROCM else "")
-        + "--attention-softmax-in-fp32 "
+        f"{'--no-gradient-accumulation-fusion ' if IS_ROCM else ''}"
+        "--attention-softmax-in-fp32 "
         "--attention-backend flash "
         "--actor-num-nodes 1 "
         f"--actor-num-gpus-per-node {1 if FEW_GPU else 2} "

--- a/tests/e2e/short/test_qwen2.5_0.5B_gsm8k_short.py
+++ b/tests/e2e/short/test_qwen2.5_0.5B_gsm8k_short.py
@@ -83,13 +83,12 @@ def execute():
 
     sglang_args = "--rollout-num-gpus-per-engine 1 " "--sglang-mem-fraction-static 0.7 " "--sglang-enable-metrics "
 
-    ci_args = (
-        "--ci-test "
-        # ROCm (gfx950): the unfused bf16 wgrad path (needed to avoid a
-        # hipBLASLt BGRADB catalog gap) has numerical drift vs the
-        # fused fp32 path, exceeding the strict CI thresholds.
-        + ("--ci-disable-kl-checker --ci-disable-logprobs-checker " if IS_ROCM else "")
-    )
+    ci_args = "--ci-test "
+    # ROCm (gfx950): the unfused bf16 wgrad path (needed to avoid a
+    # hipBLASLt BGRADB catalog gap) has numerical drift vs the
+    # fused fp32 path, exceeding the strict CI thresholds.
+    if IS_ROCM:
+        ci_args += "--ci-disable-kl-checker --ci-disable-logprobs-checker "
 
     fault_tolerance_args = (
         "--use-fault-tolerance "
@@ -105,8 +104,8 @@ def execute():
         # ROCm (gfx950): hipBLASLt has no algorithm for bf16→fp32 +
         # HIPBLASLT_EPILOGUE_BGRADB + accumulate in TE's LayerNormLinear
         # backward when gradient_accumulation_fusion=True and bias=True.
-        + ("--no-gradient-accumulation-fusion " if IS_ROCM else "")
-        + "--attention-softmax-in-fp32 "
+        f"{'--no-gradient-accumulation-fusion ' if IS_ROCM else ''}"
+        "--attention-softmax-in-fp32 "
         "--attention-backend flash "
         "--actor-num-nodes 1 "
         f"--actor-num-gpus-per-node {NUM_GPUS} "

--- a/tests/e2e/short/test_qwen2.5_0.5B_gsm8k_short.py
+++ b/tests/e2e/short/test_qwen2.5_0.5B_gsm8k_short.py
@@ -82,9 +82,6 @@ def execute():
     sglang_args = "--rollout-num-gpus-per-engine 1 " "--sglang-mem-fraction-static 0.7 " "--sglang-enable-metrics "
 
     ci_args = "--ci-test "
-    # ROCm (gfx950): the unfused bf16 wgrad path (needed to avoid a
-    # hipBLASLt BGRADB catalog gap) has numerical drift vs the
-    # fused fp32 path, exceeding the strict CI thresholds.
     if IS_ROCM:
         ci_args += "--ci-disable-kl-checker --ci-disable-logprobs-checker "
 

--- a/tests/e2e/short/test_qwen2.5_0.5B_gsm8k_short.py
+++ b/tests/e2e/short/test_qwen2.5_0.5B_gsm8k_short.py
@@ -1,11 +1,9 @@
 import os
 
-import torch
 from tests.ci.ci_register import register_cuda_ci, register_rocm_ci
+from tests.ci.rocm_utils import IS_ROCM
 
 import miles.utils.external_utils.command_utils as U
-
-IS_ROCM = getattr(torch.version, "hip", None) is not None
 
 register_cuda_ci(est_time=360, suite="stage-c-8-gpu-h100", labels=["short"])
 register_rocm_ci(est_time=360, suite="stage-c-8-gpu-mi350", labels=["short"])

--- a/tests/e2e/short/test_qwen2.5_0.5B_gsm8k_short.py
+++ b/tests/e2e/short/test_qwen2.5_0.5B_gsm8k_short.py
@@ -1,8 +1,11 @@
 import os
 
+import torch
 from tests.ci.ci_register import register_cuda_ci, register_rocm_ci
 
 import miles.utils.external_utils.command_utils as U
+
+IS_ROCM = getattr(torch.version, "hip", None) is not None
 
 register_cuda_ci(est_time=360, suite="stage-c-8-gpu-h100", labels=["short"])
 register_rocm_ci(est_time=360, suite="stage-c-8-gpu-mi350", labels=["short"])
@@ -80,7 +83,13 @@ def execute():
 
     sglang_args = "--rollout-num-gpus-per-engine 1 " "--sglang-mem-fraction-static 0.7 " "--sglang-enable-metrics "
 
-    ci_args = "--ci-test "
+    ci_args = (
+        "--ci-test "
+        # ROCm (gfx950): the unfused bf16 wgrad path (needed to avoid a
+        # hipBLASLt BGRADB catalog gap) has numerical drift vs the
+        # fused fp32 path, exceeding the strict CI thresholds.
+        + ("--ci-disable-kl-checker --ci-disable-logprobs-checker " if IS_ROCM else "")
+    )
 
     fault_tolerance_args = (
         "--use-fault-tolerance "
@@ -93,7 +102,11 @@ def execute():
         "--attention-dropout 0.0 "
         "--hidden-dropout 0.0 "
         "--accumulate-allreduce-grads-in-fp32 "
-        "--attention-softmax-in-fp32 "
+        # ROCm (gfx950): hipBLASLt has no algorithm for bf16→fp32 +
+        # HIPBLASLT_EPILOGUE_BGRADB + accumulate in TE's LayerNormLinear
+        # backward when gradient_accumulation_fusion=True and bias=True.
+        + ("--no-gradient-accumulation-fusion " if IS_ROCM else "")
+        + "--attention-softmax-in-fp32 "
         "--attention-backend flash "
         "--actor-num-nodes 1 "
         f"--actor-num-gpus-per-node {NUM_GPUS} "


### PR DESCRIPTION
Consolidates #1154, #1155, #1156, #1157, #1158 into one PR.
hipBLASLt on gfx950 has no algorithm for TE's bias-fused wgrad GEMM
(bf16→fp32 + BGRADB + accumulate). This propagates --no-gradient-accumulation-fusion
from the Megatron CLI to the bridge provider, and conditionally disables the fusion
and relaxes CI numerical checkers on ROCm across the five e2e tests. CUDA is unaffected.
Supersedes #1489 which inturn superseded #1154, #1155, #1156, #1157, #1158.

Depends on #1618 