### PR TITLE
rocm: disable gradient_accumulation_fusion on gfx950 in test_qwen2.5_0.5B_gsm8k_async

### DIFF
--- a/tests/e2e/long/test_qwen2.5_0.5B_gsm8k_async.py
+++ b/tests/e2e/long/test_qwen2.5_0.5B_gsm8k_async.py
@@ -83,8 +83,6 @@ def execute():
     ci_args = (
         "--ci-test "
         "--ci-disable-kl-checker "
-        # ROCm (gfx950): the unfused bf16 wgrad path (needed to avoid a
-        # hipBLASLt BGRADB catalog gap) has ~1e-9 numerical drift.
         f"{'--ci-disable-logprobs-checker ' if IS_ROCM else ''}"
         "--ci-metric-checker-key eval/gsm8k "
         "--ci-metric-checker-threshold 0.55 "  # loose threshold at 250 step

--- a/tests/e2e/long/test_qwen2.5_0.5B_gsm8k_async.py
+++ b/tests/e2e/long/test_qwen2.5_0.5B_gsm8k_async.py
@@ -6,6 +6,7 @@ import miles.utils.external_utils.command_utils as U
 
 register_cuda_ci(est_time=5000, suite="stage-c-2-gpu-h200", labels=["long"])
 register_rocm_ci(est_time=5000, suite="stage-c-2-gpu-mi350", labels=["long"])
+IS_ROCM = torch.version.hip is not None
 
 MODEL_NAME = "Qwen2.5-0.5B-Instruct"
 MODEL_TYPE = "qwen2.5-0.5B"
@@ -82,7 +83,10 @@ def execute():
     ci_args = (
         "--ci-test "
         "--ci-disable-kl-checker "
-        "--ci-metric-checker-key eval/gsm8k "
+        # ROCm (gfx950): the unfused bf16 wgrad path (needed to avoid a
+        # hipBLASLt BGRADB catalog gap) has ~1e-9 numerical drift.
+        + ("--ci-disable-logprobs-checker " if IS_ROCM else "")
+        + "--ci-metric-checker-key eval/gsm8k "
         "--ci-metric-checker-threshold 0.55 "  # loose threshold at 250 step
     )
 
@@ -92,7 +96,8 @@ def execute():
         "--hidden-dropout 0.0 "
         # should be good for model performance
         "--accumulate-allreduce-grads-in-fp32 "
-        "--attention-softmax-in-fp32 "
+        + ("--no-gradient-accumulation-fusion " if IS_ROCM else "")
+        + "--attention-softmax-in-fp32 "
         # need to comment this when using model with MLA
         "--attention-backend flash "
         "--actor-num-nodes 1 "

--- a/tests/e2e/long/test_qwen2.5_0.5B_gsm8k_async.py
+++ b/tests/e2e/long/test_qwen2.5_0.5B_gsm8k_async.py
@@ -1,12 +1,12 @@
 import os
 
 from tests.ci.ci_register import register_cuda_ci, register_rocm_ci
+from tests.ci.rocm_utils import IS_ROCM
 
 import miles.utils.external_utils.command_utils as U
 
 register_cuda_ci(est_time=5000, suite="stage-c-2-gpu-h200", labels=["long"])
 register_rocm_ci(est_time=5000, suite="stage-c-2-gpu-mi350", labels=["long"])
-IS_ROCM = getattr(torch.version, "hip", None) is not None
 
 MODEL_NAME = "Qwen2.5-0.5B-Instruct"
 MODEL_TYPE = "qwen2.5-0.5B"

--- a/tests/e2e/long/test_qwen2.5_0.5B_gsm8k_async.py
+++ b/tests/e2e/long/test_qwen2.5_0.5B_gsm8k_async.py
@@ -6,7 +6,7 @@ import miles.utils.external_utils.command_utils as U
 
 register_cuda_ci(est_time=5000, suite="stage-c-2-gpu-h200", labels=["long"])
 register_rocm_ci(est_time=5000, suite="stage-c-2-gpu-mi350", labels=["long"])
-IS_ROCM = torch.version.hip is not None
+IS_ROCM = getattr(torch.version, "hip", None) is not None
 
 MODEL_NAME = "Qwen2.5-0.5B-Instruct"
 MODEL_TYPE = "qwen2.5-0.5B"
@@ -85,8 +85,8 @@ def execute():
         "--ci-disable-kl-checker "
         # ROCm (gfx950): the unfused bf16 wgrad path (needed to avoid a
         # hipBLASLt BGRADB catalog gap) has ~1e-9 numerical drift.
-        + ("--ci-disable-logprobs-checker " if IS_ROCM else "")
-        + "--ci-metric-checker-key eval/gsm8k "
+        f"{'--ci-disable-logprobs-checker ' if IS_ROCM else ''}"
+        "--ci-metric-checker-key eval/gsm8k "
         "--ci-metric-checker-threshold 0.55 "  # loose threshold at 250 step
     )
 
@@ -96,8 +96,8 @@ def execute():
         "--hidden-dropout 0.0 "
         # should be good for model performance
         "--accumulate-allreduce-grads-in-fp32 "
-        + ("--no-gradient-accumulation-fusion " if IS_ROCM else "")
-        + "--attention-softmax-in-fp32 "
+        f"{'--no-gradient-accumulation-fusion ' if IS_ROCM else ''}"
+        "--attention-softmax-in-fp32 "
         # need to comment this when using model with MLA
         "--attention-backend flash "
         "--actor-num-nodes 1 "


### PR DESCRIPTION
Depends on #1153. Related to #1105 (Miles CI gap between ROCm & CUDA).
hipBLASLt on gfx950 has no algorithm for TE's bias-fused wgrad GEMM (bf16→fp32 + BGRADB + accumulate). This conditionally disables gradient_accumulation_fusion and relaxes CI numerical checkers on ROCm. CUDA is unaffected.

Supersedes #1160
