### PR TITLE
rocm: disable gradient_accumulation_fusion on gfx950 in test_qwen2.5_0.5B_gsm8k

### DIFF
--- a/tests/e2e/long/test_qwen2.5_0.5B_gsm8k.py
+++ b/tests/e2e/long/test_qwen2.5_0.5B_gsm8k.py
@@ -1,10 +1,12 @@
 import os
 
+import torch
 from tests.ci.ci_register import register_cuda_ci
 
 import miles.utils.external_utils.command_utils as U
 
 register_cuda_ci(est_time=6000, suite="stage-c-2-gpu-h200", labels=["long"])
+IS_ROCM = torch.version.hip is not None
 
 MODEL_NAME = "Qwen2.5-0.5B-Instruct"
 MODEL_TYPE = "qwen2.5-0.5B"
@@ -81,7 +83,10 @@ def execute():
     ci_args = (
         "--ci-test "
         "--ci-disable-kl-checker "
-        "--ci-metric-checker-key eval/gsm8k "
+        # ROCm (gfx950): the unfused bf16 wgrad path (needed to avoid a
+        # hipBLASLt BGRADB catalog gap) has ~1e-9 numerical drift.
+        + ("--ci-disable-logprobs-checker " if IS_ROCM else "")
+        + "--ci-metric-checker-key eval/gsm8k "
         "--ci-metric-checker-threshold 0.55 "  # loose threshold at 250 step
     )
 
@@ -91,7 +96,8 @@ def execute():
         "--hidden-dropout 0.0 "
         # should be good for model performance
         "--accumulate-allreduce-grads-in-fp32 "
-        "--attention-softmax-in-fp32 "
+        + ("--no-gradient-accumulation-fusion " if IS_ROCM else "")
+        + "--attention-softmax-in-fp32 "
         # need to comment this when using model with MLA
         "--attention-backend flash "
         "--actor-num-nodes 1 "


### PR DESCRIPTION
Depends on #1153. 
hipBLASLt on gfx950 has no algorithm for TE's bias-fused wgrad GEMM (bf16→fp32 + BGRADB + accumulate). This conditionally disables gradient_accumulation_fusion and relaxes CI numerical checkers on ROCm. CUDA is unaffected.

Supersedes #1159