### PR TITLE
rocm: fix hipBLASLt BGRADB wgrad failure on gfx950

### DIFF
--- a/miles/backends/megatron_utils/model_provider.py
+++ b/miles/backends/megatron_utils/model_provider.py
@@ -104,6 +104,7 @@ def _apply_bridge_runtime_config(provider, args: argparse.Namespace) -> None:
             args, "gradient_accumulation_fusion", provider.gradient_accumulation_fusion
         )
 
+
 # Adapt from https://github.com/volcengine/verl/blob/c3b20575d2bc815fcccd84bddb4c0401fc4b632b/verl/models/llama/megatron/layers/parallel_linear.py#L82
 class LinearForLastLayer(torch.nn.Linear):
     def __init__(

--- a/miles/backends/megatron_utils/model_provider.py
+++ b/miles/backends/megatron_utils/model_provider.py
@@ -99,9 +99,10 @@ def _apply_bridge_runtime_config(provider, args: argparse.Namespace) -> None:
     # with bf16 inputs → fp32 output + HIPBLASLT_EPILOGUE_BGRADB + accumulate,
     # for which hipBLASLt has no algorithm. Honor the Megatron CLI flag so
     # that --no-gradient-accumulation-fusion actually takes effect.
-    provider.gradient_accumulation_fusion = getattr(
-        args, "gradient_accumulation_fusion", provider.gradient_accumulation_fusion
-    )
+    if hasattr(provider, "gradient_accumulation_fusion"):
+        provider.gradient_accumulation_fusion = getattr(
+            args, "gradient_accumulation_fusion", provider.gradient_accumulation_fusion
+        )
 
 # Adapt from https://github.com/volcengine/verl/blob/c3b20575d2bc815fcccd84bddb4c0401fc4b632b/verl/models/llama/megatron/layers/parallel_linear.py#L82
 class LinearForLastLayer(torch.nn.Linear):

--- a/miles/backends/megatron_utils/model_provider.py
+++ b/miles/backends/megatron_utils/model_provider.py
@@ -93,7 +93,15 @@ def _apply_bridge_runtime_config(provider, args: argparse.Namespace) -> None:
 
     if hasattr(provider, "dsa_attention_backend"):
         provider.dsa_attention_backend = getattr(args, "dsa_attention_backend", "megatron")
-
+    # The bridge provider defaults gradient_accumulation_fusion=True
+    # (via fusions.can_enable_gradient_accumulation_fusion). On ROCm/gfx950,
+    # this makes TE's LayerNormLinear backward issue a bias-fused wgrad GEMM
+    # with bf16 inputs → fp32 output + HIPBLASLT_EPILOGUE_BGRADB + accumulate,
+    # for which hipBLASLt has no algorithm. Honor the Megatron CLI flag so
+    # that --no-gradient-accumulation-fusion actually takes effect.
+    provider.gradient_accumulation_fusion = getattr(
+        args, "gradient_accumulation_fusion", provider.gradient_accumulation_fusion
+    )
 
 # Adapt from https://github.com/volcengine/verl/blob/c3b20575d2bc815fcccd84bddb4c0401fc4b632b/verl/models/llama/megatron/layers/parallel_linear.py#L82
 class LinearForLastLayer(torch.nn.Linear):

--- a/tests/ci/rocm_utils.py
+++ b/tests/ci/rocm_utils.py
@@ -1,0 +1,5 @@
+"""Shared ROCm detection for CI tests."""
+
+import torch
+
+IS_ROCM = getattr(torch.version, "hip", None) is not None


### PR DESCRIPTION
The bridge provider defaults gradient_accumulation_fusion to True (via can_enable_gradient_accumulation_fusion) and ignores --no-gradient-accumulation-fusion from the CLI. The fix propagates the flag from Megatron args to the bridge provider.

Context:
hipBLASLt on gfx950 (MI350/MI355) has no algorithm for the triple combination of bf16 output with fp32 accumulate + HIPBLASLT_EPILOGUE_BGRADB epilogue + accumulate=True. This fires during TE's LayerNormLinear backward when gradient_accumulation_fusion=True and the layer has bias. So we don't use gradient_accumulation_fusion and need this change for that to take effect.

Supersedes #1153