### PR TITLE
Publish fp8 weight updates in plain HF layout (no UE8M0 pre-transform)

### DIFF
--- a/miles/backends/megatron_utils/megatron_to_hf/processors/quantizer_fp8.py
+++ b/miles/backends/megatron_utils/megatron_to_hf/processors/quantizer_fp8.py
@@ -5,12 +5,7 @@ import torch
 
 from miles.utils.fp8_kernel import blockwise_cast_to_fp8_triton
 
-from ...sglang import (
-    per_block_cast_to_fp8,
-    quant_weight_ue8m0,
-    should_deepgemm_weight_requant_ue8m0,
-    transform_scale_ue8m0,
-)
+from ...sglang import per_block_cast_to_fp8
 
 
 def quantize_params_fp8(args, megatron_name, converted_named_params, quantization_config):
@@ -49,7 +44,7 @@ def quantize_params_fp8(args, megatron_name, converted_named_params, quantizatio
                 # TODO: find a clearer way.
                 if converted_name.endswith("_scale"):
                     continue
-                quantize_named_params.extend(_quantize_param(args, converted_name, param, weight_block_size))
+                quantize_named_params.extend(_quantize_param(converted_name, param, weight_block_size))
 
             return quantize_named_params
 
@@ -64,7 +59,7 @@ def quantize_params_fp8(args, megatron_name, converted_named_params, quantizatio
         ]:
             quantize_named_params = []
             for converted_name, param in converted_named_params:
-                quantize_named_params.extend(_quantize_param(args, converted_name, param, weight_block_size))
+                quantize_named_params.extend(_quantize_param(converted_name, param, weight_block_size))
 
             return quantize_named_params
 
@@ -103,7 +98,7 @@ def quantize_params_fp8(args, megatron_name, converted_named_params, quantizatio
     if rest in fp8_param_names:
         quantize_named_params = []
         for converted_name, param in converted_named_params:
-            quantize_named_params.extend(_quantize_param(args, converted_name, param, weight_block_size))
+            quantize_named_params.extend(_quantize_param(converted_name, param, weight_block_size))
 
         return quantize_named_params
 
@@ -111,16 +106,13 @@ def quantize_params_fp8(args, megatron_name, converted_named_params, quantizatio
     return converted_named_params
 
 
-def _quantize_param(args, name, weight, weight_block_size):
+def _quantize_param(name, weight, weight_block_size):
     assert name.endswith(".weight"), f"Expected weight parameter, got {name}"
     FP8_MIN = torch.finfo(torch.float8_e4m3fn).min
     FP8_MAX = torch.finfo(torch.float8_e4m3fn).max
     if weight_block_size is not None:
-        if _get_scale_format(args, name, weight_block_size) == "ue8m0":
-            qweight, scale = quant_weight_ue8m0(weight, weight_block_size=weight_block_size)
-            scale = transform_scale_ue8m0(scale, mn=qweight.shape[-2])
         # TODO: this [128, 128] is hacky. need improve
-        elif (
+        if (
             os.environ["NVTE_FP8_BLOCK_SCALING_FP32_SCALES"] == "0"
             and per_block_cast_to_fp8 is not None
             and list(weight_block_size) == [128, 128]
@@ -136,21 +128,3 @@ def _quantize_param(args, name, weight, weight_block_size):
         scale = scale.view(1)
         scale_name = name.replace(".weight", ".weight_scale")
     return [(name, qweight), (scale_name, scale)]
-
-
-def _get_scale_format(args, name, weight_block_size):
-    if not (
-        should_deepgemm_weight_requant_ue8m0
-        and should_deepgemm_weight_requant_ue8m0(weight_block_size=weight_block_size)
-    ):
-        return None  # use default fp32 scale format
-
-    if ".experts." not in name:
-        # Non-MoE linear weights: ue8m0 when deepgemm is enabled
-        return "ue8m0"
-
-    # MoE expert weights: only ue8m0 when runner is deep_gemm
-    is_deepgemm_moe_backend = args.sglang_moe_runner_backend == "deep_gemm" or (
-        args.sglang_moe_runner_backend == "auto" and args.sglang_moe_a2a_backend in ["deepep", "mooncake"]
-    )
-    return "ue8m0" if is_deepgemm_moe_backend else None

--- a/miles/backends/megatron_utils/sglang.py
+++ b/miles/backends/megatron_utils/sglang.py
@@ -1,13 +1,5 @@
 # the file to manage all sglang deps in the megatron actor
 try:
-    from sglang.srt.layers.quantization.fp8_utils import quant_weight_ue8m0, transform_scale_ue8m0
-    from sglang.srt.model_loader.utils import should_deepgemm_weight_requant_ue8m0
-except ImportError:
-    quant_weight_ue8m0 = None
-    transform_scale_ue8m0 = None
-    should_deepgemm_weight_requant_ue8m0 = None
-
-try:
     from sglang.srt.layers.quantization.fp8_utils import per_block_cast_to_fp8
 except ImportError:
     per_block_cast_to_fp8 = None
@@ -26,9 +18,6 @@ except ImportError:
 
 __all__ = [
     "per_block_cast_to_fp8",
-    "quant_weight_ue8m0",
-    "transform_scale_ue8m0",
-    "should_deepgemm_weight_requant_ue8m0",
     "monkey_patch_torch_reductions",
     "MultiprocessingSerializer",
     "FlattenedTensorBucket",

--- a/tests/fast/backends/megatron_utils/test_hf_weight_iterator_direct.py
+++ b/tests/fast/backends/megatron_utils/test_hf_weight_iterator_direct.py
@@ -38,10 +38,6 @@ def _install_import_stubs(monkeypatch):
     sys.modules["sglang.srt.utils"].MultiprocessingSerializer = object
     sys.modules["sglang.srt.utils.patch_torch"].monkey_patch_torch_reductions = lambda: None
     sys.modules["sglang.srt.weight_sync.tensor_bucket"].FlattenedTensorBucket = object
-    fp8_utils = sys.modules["sglang.srt.layers.quantization.fp8_utils"]
-    fp8_utils.quant_weight_ue8m0 = lambda *args, **kwargs: None
-    fp8_utils.transform_scale_ue8m0 = lambda x, **kwargs: x
-
     ray = types.ModuleType("ray")
     ray_actor = types.ModuleType("ray.actor")
     ray_util = types.ModuleType("ray.util")


### PR DESCRIPTION
## Problem

Miles currently lets the FP8 weight publisher construct a kernel-specific SGLang runtime representation. The trainer inspects rollout backend settings, quantizes to UE8M0, and packs the scales into the DeepGEMM layout before transport.

That gives weight conversion two meanings:

- ordinary HF/checkpoint tensors for some models and backends
- live SGLang runtime tensors for others

The transport then determines tensor semantics. A published weight set may work for one live engine but not as a checkpoint for a new or differently configured engine. This is incompatible with disk-delta, elastic rollout replacement, and external rollout consumers.

## Miles contract

Miles should produce one transport-independent checkpoint/load representation:

1. Megatron-to-HF conversion establishes names and tensor layout.
2. Miles quantization emits checkpoint-format weights and scales.
3. Broadcast, P2P, and disk-delta only transport or encode those tensors.
4. The rollout runtime derives any kernel-specific representation while loading.

This PR implements the Miles side of that contract for FP8:

- publish FP8 weights with ordinary float32 block-scale tensors
- remove trainer-side `quant_weight_ue8m0` / `transform_scale_ue8m0` packing
- remove trainer-side inference of the SGLang MoE/runtime backend
- preserve the existing checkpoint-layout quantizer selection and all current DSA/indexer coverage

## Rollout-runtime requirement

The rollout consumer must accept the checkpoint/load representation repeatedly, not only during process startup. For SGLang this means that an online update must:

1. restore any destructively packed runtime state to a loadable checkpoint state
2. load the new checkpoint-format tensors
3. derive the active kernel layout again

This is a required consumer capability, not a dependency on one particular SGLang PR. sgl-project/sglang#30749 was an earlier implementation and validation of that lifecycle, but it was closed without merging. The currently supported SGLang versions do not yet provide the complete FP8 online-reload contract, so this PR remains draft until Miles pins a version that does.

Initial model loading already follows the desired contract; repeated online update is the missing capability. The Miles and rollout-runtime sides must ship together.

## Validation

- rebased onto current Miles `main` without dropping newer FP8 model handling
- changed Python files compile successfully
- targeted pytest could not run in the local checkout because its available Python environments do not contain both PyTorch and pytest
- once a compatible rollout runtime is available, validate with the same-base oracle: initial load → snapshot → poison tensors → online reload → per-tensor and logprob comparison
