### PR TITLE
Add stage-c-8-gpu-h200 CI stage for full-node 8-GPU H200 runners

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -157,6 +157,25 @@ jobs:
         ${{ (contains(github.event.pull_request.labels.*.name, 'bypass-fastfail') || (github.event_name == 'schedule' || contains(github.event.pull_request.labels.*.name, 'nightly'))) && '--continue-on-error' || '' }}
     secrets: inherit
 
+  stage-c-8-gpu-h200:
+    needs: [resolve-ci-image, stage-a-cpu]
+    if: |
+      always() && !cancelled() &&
+      needs.resolve-ci-image.result == 'success' &&
+      (needs.stage-a-cpu.result == 'success' ||
+        (needs.stage-a-cpu.result == 'failure' && (contains(github.event.pull_request.labels.*.name, 'bypass-fastfail') || (github.event_name == 'schedule' || contains(github.event.pull_request.labels.*.name, 'nightly'))))) &&
+      ((github.event_name == 'workflow_dispatch') || ((github.event_name == 'schedule' || contains(github.event.pull_request.labels.*.name, 'nightly'))) || (github.event.pull_request))
+    uses: ./.github/workflows/_run-ci.yml
+    with:
+      runs_on: '["h200", "8gpu"]'
+      container_image: ${{ needs.resolve-ci-image.outputs.container_image }}
+      execute_command: >-
+        python tests/ci/run_suite.py --hw cuda --suite stage-c-8-gpu-h200
+        --labels ${{ join(github.event.pull_request.labels.*.name, ' ') }}
+        ${{ (github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'run-ci-image') || contains(github.event.pull_request.labels.*.name, 'run-ci-all') || (github.event_name == 'schedule' || contains(github.event.pull_request.labels.*.name, 'nightly'))) && '--match-all-labels' || '' }}
+        ${{ (contains(github.event.pull_request.labels.*.name, 'bypass-fastfail') || (github.event_name == 'schedule' || contains(github.event.pull_request.labels.*.name, 'nightly'))) && '--continue-on-error' || '' }}
+    secrets: inherit
+
   stage-c-4-gpu-h200:
     needs: [resolve-ci-image, stage-a-cpu]
     if: |

--- a/docs/ci/00-stage.md
+++ b/docs/ci/00-stage.md
@@ -27,6 +27,7 @@ Stage names follow `stage-<tier>-<gpus>-<hw>` (or `stage-<tier>-<hw>` for CPU, e
 | `stage-c-2-gpu-h200` | 2× H200 | `["h200","2gpu"]` | 2 | `resolve-ci-image`, `stage-a-cpu` |
 | `stage-c-4-gpu-h200` | 4× H200 | `["h200","4gpu"]` | 3 | `resolve-ci-image`, `stage-a-cpu` |
 | `stage-c-8-gpu-h100` | 8× H100 | `["h100","8gpu"]` | 2 | `resolve-ci-image`, `stage-a-cpu` |
+| `stage-c-8-gpu-h200` | 8× H200 | `["h200","8gpu"]` | 1 | `resolve-ci-image`, `stage-a-cpu` |
 
 `tier a` (CPU fast) gates the GPU fleet after `resolve-ci-image`; the GPU stages (`b` / `c`) all depend on `resolve-ci-image` and `stage-a-cpu`, and run concurrently with each other — the `b` / `c` letters classify role, they are not a sequential pipeline.
 

--- a/tests/ci/run_suite.py
+++ b/tests/ci/run_suite.py
@@ -22,10 +22,10 @@ _RUN_CI_PREFIX = "run-ci-"
 # runtime by `filter_tests` via the `--labels` arg, not via per-suite jobs).
 #
 # CUDA suites: each is served by a matching workflow job in
-# .github/workflows/pr-test.yml. `stage-c-8-gpu-h100` runs on the full-node
-# 8-GPU H100 host; the H200 fleet is one 8-GPU node split into 2+2+4 workers
-# via per-runner CUDA_VISIBLE_DEVICES (see pr-test.yml stage-c-4-gpu-h200 /
-# stage-b-2-gpu-h200 / stage-c-2-gpu-h200 job comments).
+# .github/workflows/pr-test.yml. `stage-c-8-gpu-h100` and `stage-c-8-gpu-h200`
+# run on full-node 8-GPU hosts; the split H200 fleet is one 8-GPU node divided
+# into 2+2+4 workers via per-runner CUDA_VISIBLE_DEVICES (see pr-test.yml
+# stage-c-4-gpu-h200 / stage-b-2-gpu-h200 / stage-c-2-gpu-h200 job comments).
 PER_COMMIT_SUITES = {
     HWBackend.CPU: [
         "stage-a-cpu",
@@ -34,6 +34,7 @@ PER_COMMIT_SUITES = {
     HWBackend.CUDA: [
         "stage-b-2-gpu-h200",
         "stage-c-8-gpu-h100",
+        "stage-c-8-gpu-h200",
         "stage-c-4-gpu-h200",
         "stage-c-2-gpu-h200",
     ],

--- a/tests/ci/test/test_run_suite.py
+++ b/tests/ci/test/test_run_suite.py
@@ -79,6 +79,7 @@ class TestPerCommitSuites:
         assert PER_COMMIT_SUITES[HWBackend.CUDA] == [
             "stage-b-2-gpu-h200",
             "stage-c-8-gpu-h100",
+            "stage-c-8-gpu-h200",
             "stage-c-4-gpu-h200",
             "stage-c-2-gpu-h200",
         ]


### PR DESCRIPTION
## Summary
Add a `stage-c-8-gpu-h200` CI stage targeting runners that carry both the `h200` and `8gpu` labels.

## Motivation
The CI fleet now has full-node 8-GPU H200 runners, but no suite could target them: the existing H200 stages only cover the 2/4-GPU split workers and the only 8-GPU stage is pinned to h100 runner labels.

## Usage
Register a test with the new suite:

```python
register_cuda_ci(est_time=600, suite="stage-c-8-gpu-h200", labels=[])
```

The `stage-c-8-gpu-h200` job then runs it on an 8-GPU H200 runner via:

```bash
python tests/ci/run_suite.py --hw cuda --suite stage-c-8-gpu-h200
```

## Design Notes
- **Key choices:**
  - `runs_on: '["h200", "8gpu"]'` requires a runner carrying both labels, matching the label scheme of the existing GPU stages.
  - The job's gating (`resolve-ci-image` + `stage-a-cpu`, `bypass-fastfail` / nightly handling) is identical to the other GPU c-stages.
  - No partition matrix: the suite has no registered tests yet, so it runs as a single shard and exits 0 (the documented empty-suite semantics).
  - The suite is added to `PER_COMMIT_SUITES` and to the stage roster in `docs/ci/00-stage.md`, keeping the suite-to-stage mapping 1:1 on all three sides.

## Verification
- `yaml.safe_load` parses the workflow; all 8 jobs enumerate, including `stage-c-8-gpu-h200`.
- `python tests/ci/run_suite.py --hw cuda --suite stage-c-8-gpu-h200 --list-only` exits 0 with the empty-suite message, no unknown-suite warning emitted.

## Review Focus
- Scrutinize the `stage-c-8-gpu-h200` job in `.github/workflows/pr-test.yml` for exact `if`/`execute_command` parity with `stage-c-2-gpu-h200`.
- Scrutinize the fleet-topology comment above `PER_COMMIT_SUITES` in `tests/ci/run_suite.py` for accuracy against the live runner fleet.
