### PR TITLE
fix(ci): partition 8-GPU H200 stage across two runners

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -165,12 +165,17 @@ jobs:
       (needs.stage-a-cpu.result == 'success' ||
         (needs.stage-a-cpu.result == 'failure' && (contains(github.event.pull_request.labels.*.name, 'bypass-fastfail') || (github.event_name == 'schedule' || contains(github.event.pull_request.labels.*.name, 'nightly'))))) &&
       ((github.event_name == 'workflow_dispatch') || ((github.event_name == 'schedule' || contains(github.event.pull_request.labels.*.name, 'nightly'))) || (github.event.pull_request))
+    strategy:
+      fail-fast: false
+      matrix:
+        partition_id: [0, 1]
     uses: ./.github/workflows/_run-ci.yml
     with:
       runs_on: '["h200", "8gpu"]'
       container_image: ${{ needs.resolve-ci-image.outputs.container_image }}
       execute_command: >-
         python tests/ci/run_suite.py --hw cuda --suite stage-c-8-gpu-h200
+        --auto-partition-id ${{ matrix.partition_id }} --auto-partition-size 2
         --labels ${{ join(github.event.pull_request.labels.*.name, ' ') }}
         ${{ (github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'run-ci-image') || contains(github.event.pull_request.labels.*.name, 'run-ci-all') || (github.event_name == 'schedule' || contains(github.event.pull_request.labels.*.name, 'nightly'))) && '--match-all-labels' || '' }}
         ${{ (contains(github.event.pull_request.labels.*.name, 'bypass-fastfail') || (github.event_name == 'schedule' || contains(github.event.pull_request.labels.*.name, 'nightly'))) && '--continue-on-error' || '' }}

--- a/docs/ci/00-stage.md
+++ b/docs/ci/00-stage.md
@@ -27,7 +27,7 @@ Stage names follow `stage-<tier>-<gpus>-<hw>` (or `stage-<tier>-<hw>` for CPU, e
 | `stage-c-2-gpu-h200` | 2× H200 | `["h200","2gpu"]` | 2 | `resolve-ci-image`, `stage-a-cpu` |
 | `stage-c-4-gpu-h200` | 4× H200 | `["h200","4gpu"]` | 3 | `resolve-ci-image`, `stage-a-cpu` |
 | `stage-c-8-gpu-h100` | 8× H100 | `["h100","8gpu"]` | 2 | `resolve-ci-image`, `stage-a-cpu` |
-| `stage-c-8-gpu-h200` | 8× H200 | `["h200","8gpu"]` | 1 | `resolve-ci-image`, `stage-a-cpu` |
+| `stage-c-8-gpu-h200` | 8× H200 | `["h200","8gpu"]` | 2 | `resolve-ci-image`, `stage-a-cpu` |
 
 `tier a` (CPU fast) gates the GPU fleet after `resolve-ci-image`; the GPU stages (`b` / `c`) all depend on `resolve-ci-image` and `stage-a-cpu`, and run concurrently with each other — the `b` / `c` letters classify role, they are not a sequential pipeline.
 


### PR DESCRIPTION
## Summary
Partition the 8-GPU H200 CI stage across both matching runners.

## Symptom & Reproduction
- **Symptom:** `stage-c-8-gpu-h200` launches one job although the fleet has two matching runners.
- **Reproduction:** `origin/main` defines no matrix or `--auto-partition-*` arguments for this stage.

## Root Cause
1. `stage-c-8-gpu-h200` was introduced without a matrix because its suite was empty.
2. `.github/workflows/pr-test.yml` therefore schedules one job even though two matching runners exist.

## Fix
Define `partition_id: [0, 1]` and pass each id to `run_suite.py` with partition size 2. Update `docs/ci/00-stage.md` first so the documented shard contract matches the workflow.

## Verification
- **Focused tests:** `pytest -q tests/ci/test/test_run_suite.py` passes 23 tests.
- **Partition 0:** The CI-equivalent `--list-only` command reports `Partition: 1/2`.
- **Partition 1:** The CI-equivalent `--list-only` command reports `Partition: 2/2`.
- **Workflow validation:** The repository YAML hook passes.
- **Matrix assertion:** PyYAML verifies both partition ids.
- **Command assertion:** PyYAML verifies the partition arguments.
- **Documentation assertion:** The stage roster records two shards.

## Review Focus
- Scrutinize `stage-c-8-gpu-h200` in `.github/workflows/pr-test.yml` for exact two-shard configuration.
- Scrutinize `docs/ci/00-stage.md` for the two-shard roster entry.
