### PR TITLE
fix: bracket IPv6 hosts in distributed init methods

### DIFF
--- a/miles/backends/fsdp_utils/update_weight_utils.py
+++ b/miles/backends/fsdp_utils/update_weight_utils.py
@@ -18,6 +18,7 @@ except ImportError:
 from sglang.srt.utils import MultiprocessingSerializer
 
 from miles.utils.distributed_utils import get_gloo_group, init_process_group
+from miles.utils.http_utils import _wrap_ipv6
 
 try:
     from sglang.srt.weight_sync.tensor_bucket import FlattenedTensorBucket  # type: ignore[import]
@@ -253,7 +254,7 @@ class UpdateWeightFromDistributed(UpdateWeight):
             ]
             self._model_update_groups = init_process_group(
                 backend="nccl",
-                init_method=f"tcp://{master_address}:{master_port}",
+                init_method=f"tcp://{_wrap_ipv6(master_address)}:{master_port}",
                 world_size=world_size,
                 rank=0,
                 group_name=self._group_name,

--- a/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/broadcast.py
+++ b/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/broadcast.py
@@ -12,6 +12,7 @@ from tqdm import tqdm
 
 from miles.backends.training_utils.parallel import get_parallel_state
 from miles.utils.distributed_utils import init_process_group
+from miles.utils.http_utils import _wrap_ipv6
 
 from miles.utils.lora import LORA_ADAPTER_NAME
 from ..common import _check_weight_sync_results
@@ -235,7 +236,7 @@ def connect_rollout_engines_from_distributed(
         rank_cursor += engine_gpu_counts[i]
     model_update_groups = init_process_group(
         backend="nccl",
-        init_method=f"tcp://{master_address}:{master_port}",
+        init_method=f"tcp://{_wrap_ipv6(master_address)}:{master_port}",
         world_size=world_size,
         rank=0,
         group_name=group_name,

--- a/tests/fast/backends/megatron_utils/test_ipv6_init_method.py
+++ b/tests/fast/backends/megatron_utils/test_ipv6_init_method.py
@@ -1,0 +1,29 @@
+from argparse import Namespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from miles.backends.megatron_utils.update_weight.update_weight_from_distributed import broadcast
+
+
+@pytest.mark.parametrize(
+    "ip,expected_prefix",
+    [
+        ("::1", "tcp://[::1]:"),
+        ("127.0.0.1", "tcp://127.0.0.1:"),
+    ],
+)
+def test_connect_rollout_engines_builds_valid_init_method(ip, expected_prefix):
+    engine = MagicMock()
+    with (
+        patch.object(broadcast, "ray") as mock_ray,
+        patch.object(broadcast, "init_process_group") as mock_init_pg,
+    ):
+        mock_ray._private.services.get_node_ip_address.return_value = ip
+        broadcast.connect_rollout_engines_from_distributed(
+            Namespace(rollout_num_gpus_per_engine=1),
+            group_name="test",
+            rollout_engines=[engine],
+        )
+
+    assert mock_init_pg.call_args.kwargs["init_method"].startswith(expected_prefix)


### PR DESCRIPTION
## Summary

Use the existing IPv6 wrapper for all actor/critic and weight-update tcp init methods.

## Why

Bare IPv6 node addresses make torch.distributed rendezvous URLs ambiguous. This extends the Slime fix from THUDM/slime#2151 to the additional Miles call sites while leaving IPv4 and hostnames unchanged.

## Testing

`pytest -q tests/fast/backends/test_ipv6_init_method.py`