### PR TITLE
feat(rm): allow per-sample custom_rm_path override

### DIFF
--- a/miles/rollout/generate_utils/sample_utils.py
+++ b/miles/rollout/generate_utils/sample_utils.py
@@ -126,6 +126,7 @@ def _merge_sample_pair(a: Sample, b: Sample, tokenizer) -> Sample:
             status=b.status,
             metadata=_merge_metadata(),
             generate_function_path=_merge_equal_value("generate_function_path"),
+            custom_rm_path=_merge_equal_value("custom_rm_path"),
             train_metadata=_merge_equal_value("train_metadata"),
             session_id=_merge_equal_value("session_id"),
             non_generation_time=_merge_equal_value("non_generation_time"),

--- a/miles/rollout/rm_hub/__init__.py
+++ b/miles/rollout/rm_hub/__init__.py
@@ -92,10 +92,28 @@ async def batched_async_rm(
             sample.reward = reward
         return None
 
-    if args.custom_rm_path is not None:
+    samples_with_overrides = [(index, sample) for index, sample in enumerate(samples) if sample.custom_rm_path]
+    if not samples_with_overrides and args.custom_rm_path is not None:
         # Ensure the custom reward function is implemented in batch mode
         rm_function = load_function(args.custom_rm_path)
         return await rm_function(args, samples, **kwargs)
-    tasks = [async_rm(args, sample, **kwargs) for sample in samples]
-    rewards = await asyncio.gather(*tasks)
-    return rewards
+
+    samples_without_overrides = [(index, sample) for index, sample in enumerate(samples) if not sample.custom_rm_path]
+    override_rewards = asyncio.gather(*(async_rm(args, sample, **kwargs) for _, sample in samples_with_overrides))
+    if args.custom_rm_path is not None and samples_without_overrides:
+        rm_function = load_function(args.custom_rm_path)
+        default_rewards = rm_function(args, [sample for _, sample in samples_without_overrides], **kwargs)
+    else:
+        default_rewards = asyncio.gather(
+            *(async_rm(args, sample, **kwargs) for _, sample in samples_without_overrides)
+        )
+
+    override_rewards, default_rewards = await asyncio.gather(override_rewards, default_rewards)
+    rewards_by_index = dict(
+        zip(
+            [index for index, _ in samples_with_overrides] + [index for index, _ in samples_without_overrides],
+            [*override_rewards, *default_rewards],
+            strict=True,
+        )
+    )
+    return [rewards_by_index[index] for index in range(len(samples))]

--- a/miles/rollout/rm_hub/__init__.py
+++ b/miles/rollout/rm_hub/__init__.py
@@ -29,6 +29,10 @@ async def remote_rm(args, sample: Sample):
 
 
 async def async_rm(args, sample: Sample, **kwargs):
+    if sample.custom_rm_path:
+        rm_function = load_function(sample.custom_rm_path)
+        return await rm_function(args, sample, **kwargs)
+
     if args.custom_rm_path is not None:
         rm_function = load_function(args.custom_rm_path)
         return await rm_function(args, sample, **kwargs)

--- a/miles/rollout/sglang_rollout.py
+++ b/miles/rollout/sglang_rollout.py
@@ -561,6 +561,7 @@ async def eval_rollout_single_dataset(
             sample_index += 1
             sample.metadata = dataset_cfg.inject_metadata(getattr(sample, "metadata", None))
             sample.generate_function_path = getattr(dataset_cfg, "custom_generate_function_path", None)
+            sample.custom_rm_path = dataset_cfg.custom_rm_path
             sampling_params = base_sampling_params
             if getattr(args, "sglang_enable_deterministic_inference", False):
                 sampling_params = base_sampling_params.copy()

--- a/miles/utils/eval_config.py
+++ b/miles/utils/eval_config.py
@@ -118,6 +118,9 @@ class EvalDatasetConfig:
     # per-dataset custom generate function (e.g., for tool calling)
     custom_generate_function_path: str | None = None
 
+    # per-dataset custom reward function (overrides the global --custom-rm-path)
+    custom_rm_path: str | None = None
+
     metadata_overrides: dict[str, Any] = field(default_factory=dict)
 
     def __post_init__(self) -> None:

--- a/miles/utils/types.py
+++ b/miles/utils/types.py
@@ -49,6 +49,7 @@ class Sample:
 
     metadata: dict = field(default_factory=dict)
     generate_function_path: str | None = None
+    custom_rm_path: str | None = None
     # metadata used during training, e.g., what loss to use for this sample.
     train_metadata: dict | None = None
 

--- a/tests/fast/rollout/rm_hub/test_rm_hub.py
+++ b/tests/fast/rollout/rm_hub/test_rm_hub.py
@@ -4,7 +4,19 @@ import pytest
 
 from miles.rollout.rm_hub import async_rm, batched_async_rm
 from miles.utils.async_utils import run
+from miles.utils.misc import function_registry
 from miles.utils.types import Sample
+
+PER_SAMPLE_RM_PATH = "test.per_sample.rm"
+GLOBAL_RM_PATH = "test.global.rm"
+
+
+async def _per_sample_rm(args, sample, **kwargs):
+    return 111
+
+
+async def _global_rm(args, sample, **kwargs):
+    return 999
 
 
 @pytest.fixture
@@ -94,6 +106,22 @@ class TestAsyncRm:
         sample = Sample(prompt="", response="test", label="test")
         with pytest.raises(NotImplementedError, match=match):
             run(async_rm(mock_args, sample))
+
+    def test_per_sample_custom_rm_takes_priority(self, mock_args):
+        mock_args.custom_rm_path = GLOBAL_RM_PATH
+        sample = Sample(prompt="", response="", label="", custom_rm_path=PER_SAMPLE_RM_PATH)
+        with function_registry.temporary(PER_SAMPLE_RM_PATH, _per_sample_rm), function_registry.temporary(
+            GLOBAL_RM_PATH, _global_rm
+        ):
+            reward = run(async_rm(mock_args, sample))
+        assert reward == 111
+
+    def test_falls_back_to_global_custom_rm(self, mock_args):
+        mock_args.custom_rm_path = GLOBAL_RM_PATH
+        sample = Sample(prompt="", response="", label="")
+        with function_registry.temporary(GLOBAL_RM_PATH, _global_rm):
+            reward = run(async_rm(mock_args, sample))
+        assert reward == 999
 
 
 class TestBatchedAsyncRm:

--- a/tests/fast/rollout/rm_hub/test_rm_hub.py
+++ b/tests/fast/rollout/rm_hub/test_rm_hub.py
@@ -16,6 +16,8 @@ async def _per_sample_rm(args, sample, **kwargs):
 
 
 async def _global_rm(args, sample, **kwargs):
+    if isinstance(sample, list):
+        return [999] * len(sample)
     return 999
 
 
@@ -125,6 +127,18 @@ class TestAsyncRm:
 
 
 class TestBatchedAsyncRm:
+    def test_per_sample_custom_rm_takes_priority(self, mock_args):
+        mock_args.custom_rm_path = GLOBAL_RM_PATH
+        samples = [
+            Sample(prompt="", response="", label="", custom_rm_path=PER_SAMPLE_RM_PATH),
+            Sample(prompt="", response="", label=""),
+        ]
+        with function_registry.temporary(PER_SAMPLE_RM_PATH, _per_sample_rm), function_registry.temporary(
+            GLOBAL_RM_PATH, _global_rm
+        ):
+            rewards = run(batched_async_rm(mock_args, samples))
+        assert rewards == [111, 999]
+
     @pytest.mark.parametrize(
         "rm_type,samples_data,expected",
         [


### PR DESCRIPTION
## Summary

Allow each sample metadata record to override the configured custom reward function path, including batched reward dispatch.

## Why

Mixed-task batches need to route samples to different reward functions without splitting rollout jobs. Override samples use the single-sample reward contract; unoverridden samples remain batched through the configured global function. Samples without an override keep the existing behavior. This ports the Slime configuration behavior from THUDM/slime#2081.

## Testing

`pytest -q tests/fast/rollout/rm_hub/test_rm_hub.py`