### PR TITLE
fix(tools): upcast FP8 tensors missing scale_inv instead of passing them through

### DIFF
--- a/tools/fp8_cast_bf16.py
+++ b/tools/fp8_cast_bf16.py
@@ -100,8 +100,10 @@ def main(fp8_path, bf16_path):
                     fp8_weight_names.append(weight_name)
                     new_state_dict[weight_name] = weight_dequant(weight, scale_inv)
                 except KeyError:
-                    print(f"Warning: Missing scale_inv tensor for {weight_name}, skipping conversion")
-                    new_state_dict[weight_name] = weight
+                    # No scale_inv means the tensor is unscaled (scale 1.0); upcast so the
+                    # output checkpoint contains no FP8 tensors, which break dist-ckpt serialization.
+                    print(f"Warning: Missing scale_inv tensor for {weight_name}, upcasting to {torch.get_default_dtype()}")
+                    new_state_dict[weight_name] = weight.to(torch.get_default_dtype())
             else:
                 new_state_dict[weight_name] = weight
 


### PR DESCRIPTION
## Summary

`tools/fp8_cast_bf16.py` currently handles an FP8 tensor with no matching `*_scale_inv` by warning and copying the tensor through **still in `float8_e4m3fn`**. The resulting "bf16" checkpoint is mixed-dtype, and downstream torch dist-ckpt serialization fails with `inline_container.cc: ... unexpected pos`.

This is hit in practice by the public `sgl-project/DeepSeek-V4-Flash-FP8` checkpoint, where `mtp.0.e_proj.weight` / `mtp.0.h_proj.weight` carry no `scale_inv` — reported in the "Minor" section of #1583.

## Fix

On a missing `scale_inv`, upcast the tensor to the default dtype (bf16, matching `weight_dequant`'s output dtype) instead of passing it through as FP8 — i.e. treat the missing scale as 1.0. This makes the public checkpoint convert out of the box.

```
Warning: Missing scale_inv tensor for mtp.0.e_proj.weight, upcasting to torch.bfloat16
```

## Notes

- No index/weight_map changes needed: tensors without `scale_inv` were never added to `fp8_weight_names`, and they have no `*_scale_inv` entry to drop.
- @hvgazula reported in #1583 that exactly this upcast fixes the dist-ckpt failure and offered to test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)