### PR TITLE
fix(deepseek_v4): disable aggressive smem merge in sparse-MLA backward (NaN dQ/dKV)

### DIFF
--- a/miles_plugins/models/deepseek_v4/ops/kernel/tilelang_sparse_mla_bwd.py
+++ b/miles_plugins/models/deepseek_v4/ops/kernel/tilelang_sparse_mla_bwd.py
@@ -81,7 +81,7 @@ def postprocess(
     pass_configs={
         tilelang.PassConfigKey.TL_DISABLE_TMA_LOWER: True,
         tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True,
-        tilelang.PassConfigKey.TL_ENABLE_AGGRESSIVE_SHARED_MEMORY_MERGE: True,
+        tilelang.PassConfigKey.TL_ENABLE_AGGRESSIVE_SHARED_MEMORY_MERGE: False,
     },
 )
 def bwd(


### PR DESCRIPTION
### Summary
Disable `TL_ENABLE_AGGRESSIVE_SHARED_MEMORY_MERGE` in the DeepSeek-V4 sparse-MLA backward kernel (`miles_plugins/models/deepseek_v4/ops/kernel/tilelang_sparse_mla_bwd.py`).

### Problem
DSV4-Flash RL training crashes at the **first grad-norm check** with:
```
RuntimeError: ... found NaN in local grad norm for bucket #0 in backward pass
before data-parallel communication collective
```
Forward/rollout are finite; the very first backward NaNs. Root cause: the `bwd` kernel is JIT-compiled with `TL_ENABLE_AGGRESSIVE_SHARED_MEMORY_MERGE: True`, and aggressive shared-memory merge **miscompiles this kernel** — shared-memory buffers alias while still live → **NaN dQ/dKV** → NaN parameter grads → the crash above.

### Relation to #1571
This is the same tilelang miscompile that #1571 fixed for the analogous **glm5** sparse-MLA backward kernel. However #1571 (a) only patched glm5's copy and never DSV4's, and (b) guarded the fix Blackwell-only (`torch.cuda.get_device_capability()[0] < 10`). **DSV4's kernel variant reproduces the NaN on Hopper (H200, cc 9.0) as well**, so the `< 10` guard would be a no-op here — the merge must be disabled unconditionally for DSV4.

### Validation (aime example, fp8, H200)
| config | grad_norm @ step 0 |
|---|---|
| unpatched (main / :latest / dev / pr1605) | **NaN** (crash) |
| **this fix** (dev image, 6 nodes) | 0.075, 0.056 finite |
| **this fix** (:latest + pr1605, 7 nodes) | 0.0753 finite |

Ruled out as red herrings by experiment: fp8-vs-bf16 (NaN in both), the DSA-indexer `--te-precision-config-file` (disabling it didn't help), and a suspected bad node (the NaN always reported on the node holding the last PP stage — excluding it just moved the NaN to the new last node).

Cost: ~2% on this kernel (per #1571's ablation), in exchange for correctness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
