### PR TITLE
feat(rollout): --rollout-backend flag + dynamo_utils scaffold (1/N)

### DIFF
--- a/miles/backends/dynamo_utils/__init__.py
+++ b/miles/backends/dynamo_utils/__init__.py
@@ -1,0 +1,5 @@
+"""NVIDIA Dynamo rollout backend — selected via ``--rollout-backend dynamo``."""
+
+from miles.backends.dynamo_utils.dynamo_engine import DynamoEngine
+
+__all__ = ["DynamoEngine"]

--- a/miles/backends/dynamo_utils/dynamo_engine.py
+++ b/miles/backends/dynamo_utils/dynamo_engine.py
@@ -1,0 +1,37 @@
+"""Ray-actor wrapper around a ``dynamo.sglang`` worker subprocess.
+
+Selected when ``--rollout-backend dynamo``. Skeleton only in this PR.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from miles.ray.ray_actor import RayActor
+
+logger = logging.getLogger(__name__)
+
+
+class DynamoEngine(RayActor):
+    def __init__(
+        self,
+        args,
+        rank: int,
+        worker_type: str = "regular",
+        base_gpu_id: Optional[int] = None,
+        sglang_overrides: Optional[dict] = None,
+        num_gpus_per_engine: Optional[int] = None,
+    ):
+        self.args = args
+        self.rank = rank
+        self.worker_type = worker_type
+        self.base_gpu_id = base_gpu_id
+        self.sglang_overrides = sglang_overrides or {}
+        self.num_gpus_per_engine = num_gpus_per_engine
+
+    def init(self, *args, **kwargs):
+        raise NotImplementedError(
+            "DynamoEngine.init is stubbed; follow-up PRs land the "
+            "subprocess spawn, generation and weight-update paths."
+        )

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -1394,6 +1394,16 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
 
         def add_router_arguments(parser):
             parser.add_argument(
+                "--rollout-backend",
+                choices=["sglang", "dynamo"],
+                default="sglang",
+                help=(
+                    "Rollout router / worker stack. 'sglang' keeps the existing "
+                    "miles-router + sglang path; 'dynamo' selects the Dynamo "
+                    "backend (currently stubbed — raises NotImplementedError)."
+                ),
+            )
+            parser.add_argument(
                 "--use-miles-router",
                 action="store_true",
                 default=False,
@@ -2262,6 +2272,12 @@ def _resolve_ft_components(args: argparse.Namespace) -> list[str]:
 def miles_validate_args(args):
     args.ft_components = _resolve_ft_components(args)
     args.eval_datasets = _resolve_eval_datasets(args)
+
+    if getattr(args, "rollout_backend", "sglang") == "dynamo":
+        raise NotImplementedError(
+            "--rollout-backend dynamo is stubbed; follow-up PRs land the "
+            "actual integration. Use --rollout-backend sglang for now."
+        )
 
     if args.mini_ft_controller_enable and args.control_server_port == 0:
         raise ValueError("--mini-ft-controller-enable requires --control-server-port to be set (non-zero)")

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -1397,11 +1397,7 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 "--rollout-backend",
                 choices=["sglang", "dynamo"],
                 default="sglang",
-                help=(
-                    "Rollout router / worker stack. 'sglang' keeps the existing "
-                    "miles-router + sglang path; 'dynamo' selects the Dynamo "
-                    "backend (currently stubbed — raises NotImplementedError)."
-                ),
+                help="Rollout backend stack (default: sglang). 'dynamo' is stubbed.",
             )
             parser.add_argument(
                 "--use-miles-router",


### PR DESCRIPTION
Tracking: #1648 (Dynamo KV router RFC)

> **Draft — 1/N of a series to integrate NVIDIA Dynamo as an alternative rollout backend.** Tracking RFC will be linked in a follow-up comment.

## What this adds

- `--rollout-backend {sglang,dynamo}` CLI flag (default `sglang`; existing users unaffected).
- `miles/backends/dynamo_utils/` package scaffold with a stubbed `DynamoEngine(RayActor)`.
- Selecting `dynamo` currently raises `NotImplementedError` from `DynamoEngine.init` — the subsequent PRs of the series wire everything up.
