### PR TITLE
feat(rollout): dynamo.frontend launcher (round-robin) (2/N)

### DIFF
--- a/miles/backends/dynamo_utils/__init__.py
+++ b/miles/backends/dynamo_utils/__init__.py
@@ -1,5 +1,6 @@
 """NVIDIA Dynamo rollout backend — selected via ``--rollout-backend dynamo``."""
 
 from miles.backends.dynamo_utils.dynamo_engine import DynamoEngine
+from miles.backends.dynamo_utils.dynamo_router import start_dynamo_router
 
-__all__ = ["DynamoEngine"]
+__all__ = ["DynamoEngine", "start_dynamo_router"]

--- a/miles/backends/dynamo_utils/__init__.py
+++ b/miles/backends/dynamo_utils/__init__.py
@@ -1,0 +1,5 @@
+"""NVIDIA Dynamo rollout backend — selected via ``--rollout-backend dynamo``."""
+
+from miles.backends.dynamo_utils.dynamo_engine import DynamoEngine
+
+__all__ = ["DynamoEngine"]

--- a/miles/backends/dynamo_utils/dynamo_engine.py
+++ b/miles/backends/dynamo_utils/dynamo_engine.py
@@ -1,0 +1,37 @@
+"""Ray-actor wrapper around a ``dynamo.sglang`` worker subprocess.
+
+Selected when ``--rollout-backend dynamo``. Skeleton only in this PR.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from miles.ray.ray_actor import RayActor
+
+logger = logging.getLogger(__name__)
+
+
+class DynamoEngine(RayActor):
+    def __init__(
+        self,
+        args,
+        rank: int,
+        worker_type: str = "regular",
+        base_gpu_id: Optional[int] = None,
+        sglang_overrides: Optional[dict] = None,
+        num_gpus_per_engine: Optional[int] = None,
+    ):
+        self.args = args
+        self.rank = rank
+        self.worker_type = worker_type
+        self.base_gpu_id = base_gpu_id
+        self.sglang_overrides = sglang_overrides or {}
+        self.num_gpus_per_engine = num_gpus_per_engine
+
+    def init(self, *args, **kwargs):
+        raise NotImplementedError(
+            "DynamoEngine.init is stubbed; follow-up PRs land the "
+            "subprocess spawn, generation and weight-update paths."
+        )

--- a/miles/backends/dynamo_utils/dynamo_router.py
+++ b/miles/backends/dynamo_utils/dynamo_router.py
@@ -1,0 +1,100 @@
+"""Launch a Dynamo frontend in place of ``sgl_router`` (round-robin only)."""
+
+from __future__ import annotations
+
+import logging
+import os
+import random
+import subprocess
+import sys
+
+from miles.utils.http_utils import (
+    _wrap_ipv6,
+    find_available_port,
+    get_host_info,
+    is_port_available,
+    wait_for_server_ready,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def start_dynamo_router(
+    args,
+    *,
+    has_pd_disaggregation: bool = False,
+    force_new: bool = False,
+) -> tuple[str, int]:
+    """Drop-in replacement for :func:`miles.ray.rollout.router_manager.start_router`
+    when ``--rollout-backend dynamo`` is active.
+
+    Same signature, same return value (``(host, port)``). Cluster-wide
+    state (``args.sglang_router_ip`` / ``args.sglang_router_port``) is
+    read and written the same way.
+    """
+    if not force_new and args.sglang_router_ip is not None:
+        return args.sglang_router_ip, args.sglang_router_port
+
+    if has_pd_disaggregation:
+        raise NotImplementedError(
+            "PD-disaggregation is not yet wired into the Dynamo backend; "
+            "will land in a follow-up PR of this series."
+        )
+
+    router_ip = _wrap_ipv6(get_host_info()[1])
+    if force_new:
+        router_port = find_available_port(random.randint(3000, 4000))
+    else:
+        router_port = args.sglang_router_port
+        if router_port is None:
+            router_port = find_available_port(random.randint(3000, 4000))
+
+    if not is_port_available(router_port):
+        raise RuntimeError(
+            f"Port {router_port} already bound — stale Dynamo frontend? "
+            f"Run 'pkill -f dynamo.frontend' and retry."
+        )
+
+    argv: list[str] = [
+        sys.executable, "-m", "dynamo.frontend",
+        "--http-port", str(router_port),
+        "--router-mode", "round-robin",
+        "--discovery-backend", "file",
+    ]
+
+    env = os.environ.copy()
+    # Turn on Dynamo's RL mode on the frontend: forces token-id passthrough,
+    # sets logprobs=true, etc. Without it the request schema Miles expects
+    # gets rejected by the frontend's OpenAI validator.
+    env["DYN_ENABLE_RL"] = "true"
+
+    logger.info("Starting Dynamo frontend: %s", " ".join(argv))
+    proc = subprocess.Popen(argv, env=env)
+
+    # wait_for_server_ready expects .is_alive() (multiprocessing.Process API).
+    class _PopenAlive:
+        def __init__(self, p):
+            self._p = p
+
+        def is_alive(self):
+            return self._p.poll() is None
+
+        @property
+        def pid(self):
+            return self._p.pid
+
+    healthy = False
+    try:
+        wait_for_server_ready(router_ip, router_port, _PopenAlive(proc), timeout=60)
+        healthy = True
+    finally:
+        if not healthy and proc.poll() is None:
+            proc.terminate()
+            try:
+                proc.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait()
+
+    logger.info("Dynamo frontend healthy at %s:%d", router_ip, router_port)
+    return router_ip, router_port

--- a/miles/ray/rollout/router_manager.py
+++ b/miles/ray/rollout/router_manager.py
@@ -24,6 +24,18 @@ def start_router(args, *, has_pd_disaggregation: bool = False, force_new: bool =
     if not force_new and args.sglang_router_ip is not None:
         return args.sglang_router_ip, args.sglang_router_port
 
+    # Hand off to the Dynamo frontend launcher when that backend is active.
+    # It returns the same ``(ip, port)`` shape so the rest of this function
+    # never needs to know which router actually came up.
+    if getattr(args, "rollout_backend", "sglang") == "dynamo":
+        from miles.backends.dynamo_utils.dynamo_router import start_dynamo_router
+
+        return start_dynamo_router(
+            args,
+            has_pd_disaggregation=has_pd_disaggregation,
+            force_new=force_new,
+        )
+
     router_ip = _wrap_ipv6(get_host_info()[1])
     if force_new:
         router_port = find_available_port(random.randint(3000, 4000))

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -1394,6 +1394,16 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
 
         def add_router_arguments(parser):
             parser.add_argument(
+                "--rollout-backend",
+                choices=["sglang", "dynamo"],
+                default="sglang",
+                help=(
+                    "Rollout router / worker stack. 'sglang' keeps the existing "
+                    "miles-router + sglang path; 'dynamo' selects the Dynamo "
+                    "backend (currently stubbed — raises NotImplementedError)."
+                ),
+            )
+            parser.add_argument(
                 "--use-miles-router",
                 action="store_true",
                 default=False,
@@ -2262,6 +2272,12 @@ def _resolve_ft_components(args: argparse.Namespace) -> list[str]:
 def miles_validate_args(args):
     args.ft_components = _resolve_ft_components(args)
     args.eval_datasets = _resolve_eval_datasets(args)
+
+    if getattr(args, "rollout_backend", "sglang") == "dynamo":
+        raise NotImplementedError(
+            "--rollout-backend dynamo is stubbed; follow-up PRs land the "
+            "actual integration. Use --rollout-backend sglang for now."
+        )
 
     if args.mini_ft_controller_enable and args.control_server_port == 0:
         raise ValueError("--mini-ft-controller-enable requires --control-server-port to be set (non-zero)")


### PR DESCRIPTION
Tracking: #1648 (Dynamo KV router RFC)

> **Draft — 2/N of the Dynamo integration series.** Depends on #1646 (1/N). RFC will be linked in a follow-up comment.

## What this adds

- `miles/backends/dynamo_utils/dynamo_router.py::start_dynamo_router` — drop-in replacement for \`start_router\` when \`--rollout-backend dynamo\` is active. Same signature, same \`(ip, port)\` return shape. **Round-robin only**; KV-aware routing (etcd + NATS sidecars, KV events, predict-on-route) lands in a follow-up.
- \`miles/ray/rollout/router_manager.py\`: hand off to \`start_dynamo_router\` when \`args.rollout_backend == \"dynamo\"\`.

After this PR lands, \`--rollout-backend dynamo\` brings up \`dynamo.frontend\` as the router. **Generation dispatch is still not wired** (that's the next PR), so end-to-end rollouts don't work yet — but the router discovery / startup path is now visible for review.

## Depends on

#1646 — \`--rollout-backend\` flag + \`dynamo_utils\` scaffold
