### PR TITLE
feat(docs): add Megatron parameter tuning guide

### DIFF
--- a/docs/advanced/index.md
+++ b/docs/advanced/index.md
@@ -2,11 +2,15 @@
 title: Advanced Features
 description: Systems-level features for large-scale and long-running RL.
 ---
-This section covers the Miles features that the Core-features section of the
-homepage points at: low-precision training (FP8 / MXFP8 / INT4 QAT), Rollout
-Routing Replay for MoE, speculative decoding, and LoRA training and serving.
+This section covers Megatron capacity planning and the Miles features that the Core-features section of the homepage points at: low-precision training (FP8 / MXFP8 / INT4 QAT), Rollout Routing Replay for MoE, speculative decoding, and LoRA training and serving.
 
 <CardGroup cols={2}>
+
+  <Card title="Megatron Parameter Tuning" icon="calculator" href="/advanced/megatron_param_tuning">
+
+    Size parallel groups, static training state, host backups, and activation headroom before launching a full run.
+
+  </Card>
 
   <Card title="Low Precision RL" icon="bolt" href="/advanced/fp8-low-precision">
 

--- a/docs/advanced/megatron_param_tuning.md
+++ b/docs/advanced/megatron_param_tuning.md
@@ -3,51 +3,59 @@ title: Megatron Parameter Tuning
 description: Quickly estimate model-state memory, host memory, and token capacity for Megatron training in Miles.
 ---
 
-Use this guide to answer two questions before launching a Megatron job: whether the trainer state fits, and how to choose `--max-tokens-per-gpu`. The formulas are first-order estimates; the final decision must use the maximum observed rank from a complete training step.
+Use the largest trainer rank for every estimate. The formulas below are first-order planning numbers; the final configuration must pass a complete measured training step.
 
-## 1. Get three numbers
+<Note>
+This guide covers full-parameter fine-tuning only. LoRA and other partial-parameter fine-tuning methods are outside its calculation scope.
+</Note>
 
-Use these values for the most heavily loaded trainer rank:
+## Quick estimate
 
-| Symbol | Meaning |
-|---|---|
-| `N` | All resident model parameter elements on the rank |
-| `N_t` | Trainable parameter elements on the rank; equal to `N` for full-parameter training |
-| `Q` | Trainable parameter elements owned by the rank's distributed optimizer shard |
+### Inputs
 
-For full-parameter training with one optimizer shard group of size `S`, use `N_t = N` and `Q = N / S`. MoE models can have different dense and expert shard groups; in that case use `Q = N_dense / S_dense + N_expert / S_expert`.
+| Symbol | What to use | How to get it |
+|---|---|---|
+| `N` | All resident model parameter elements on the heaviest rank | Take the largest Megatron startup `COUNT` |
+| `Q` | Parameter elements in that rank's distributed-optimizer shard | For one shard group of size `S`, use `N / S`; for MoE, use `N_dense / S_dense + N_expert / S_expert` |
 
-Megatron prints the constructed parameter count for every TP/PP rank at startup:
+Under this full-parameter fine-tuning scope, every model parameter is trainable, so `N_t = N`. A recipe that deliberately freezes any parameters needs a separate trainable-parameter count and is outside the formulas below.
+
+Megatron prints `N` at startup:
 
 ```text
 > number of parameters on (tensor, pipeline) model parallel rank (T_RANK, P_RANK): COUNT
 ```
 
-Use the largest `COUNT` as `N`. A rough dense-model estimate is `total_parameters / (TP × PP)`, but it can miss embeddings, output heads, uneven pipeline stages, and replicated modules. Do not use a MoE model's advertised active-parameter count for weight memory.
+Use the largest `COUNT`. Before startup, `total_parameters / (TP × PP)` is only a rough dense-model estimate; it misses uneven stages and replicated modules. Never use a MoE model's advertised active-parameter count for weight memory. TODO: Add a dedicated parallel-group sizing guide and link it here.
 
-This document does not derive parallel groups. Start from a tested recipe and see [Parallelism compatibility](/user-guide/usage#parallelism-compatibility) when changing TP, PP, CP, EP, or expert TP.
+### Static memory
 
-## 2. Estimate static memory
+| Configuration | HBM per trainer rank | CPU memory per trainer rank |
+|---|---:|---:|
+| Default BF16 + distributed GPU Adam | `6N + 12Q` bytes | — |
+| BF16 + full CPU Adam offload | `6N` bytes | `16Q` bytes |
 
-Miles defaults to BF16 model parameters, FP32 gradients, distributed Adam, and FP32 optimizer state. The steady-state HBM estimate is:
+With one shard group, `Q = N/S`, so the default is `(6 + 12/S) × N`; full CPU offload uses `6N` HBM and `16N/S` CPU memory. Divide bytes by `2^30` for GiB.
 
-$$
-M_{HBM} \approx 2N + 4N_t + 12Q \quad \text{bytes}.
-$$
+The `16Q` CPU Adam total contains four FP32 buffers of `4Q` each: the main parameter, first moment, second moment, and persistent input-gradient buffer. The input-gradient buffer receives the optimizer-owned gradient shard before each Adam update; do not add it again under host-memory overhead.
 
-For full-parameter training with one shard group, this is `(6 + 12/S) × N` bytes. Divide by `2^30` for GiB.
-
-| State | Approximate memory | Default placement |
+| Planning limit | Initial target | Include in the total |
 |---|---:|---|
-| BF16 model parameters | `2N` | HBM |
-| FP32 gradients | `4N_t` | HBM |
-| FP32 main parameters and two Adam moments | `12Q` | HBM |
+| HBM | At most `80%` of physical HBM | Static state, activations, CUDA/NCCL buffers, workspaces, fragmentation, weight sync, and offload/onload transitions |
+| Host memory | At most `80%` of pre-launch `MemAvailable` | Every local trainer and rollout process, CPU Adam, backups, Ray, pinned buffers, dataloaders, and checkpoint staging |
 
-This estimate excludes activations, CUDA/NCCL buffers, allocator fragmentation, kernel workspaces, padding, and temporary weight-sync or offload peaks.
+`80%` is a starting policy, not a guarantee. Use a lower target for long contexts, large token caps, new kernels, or colocated transitions, and do not rely on swap.
 
-### CPU optimizer offload
+## Configuration choices
 
-For large production and capacity-oriented CI jobs, use CPU Adam when optimizer state would consume too much HBM:
+| Item | Default | Capacity option | Recommendation |
+|---|---|---|---|
+| Model parameters | BF16 in HBM, `2N` | Tested FP8 recipe | FP8 compute does not make every resident parameter `1 B`; measure the actual recipe |
+| Gradients | FP32 in HBM, `4N` | `--grad-reduce-in-bf16` | Avoid for production and convergence CI; use only after numerical validation |
+| Adam main parameter and moments | FP32 in HBM, `12Q` | CPU optimizer offload; or `--main-params-dtype fp16`, `--exp-avg-dtype fp16`, `--exp-avg-sq-dtype fp16` | Prefer CPU offload when HBM is tight; low-precision state requires `--use-precision-aware-optimizer` and numerical validation |
+| QAT | Disabled | Model-specific fake-quant recipe | Enable only for a target quantized rollout or deployment format; it is not triggered automatically by model size or FP8 |
+
+Recommended CPU Adam flags:
 
 ```bash
 --optimizer-cpu-offload
@@ -55,64 +63,53 @@ For large production and capacity-oriented CI jobs, use CPU Adam when optimizer 
 --use-precision-aware-optimizer
 ```
 
-With full CPU offload, estimate:
+CPU offload saves HBM but can reduce throughput. The current full CPU-offload path keeps FP32 Adam state on the host, so the FP16 optimizer-state flags do not reduce the `16Q` CPU estimate. See [Low Precision RL](advanced/fp8-low-precision) and [INT4 QAT](advanced/int4-qat) for format-specific setup.
 
-$$
-M_{HBM} \approx 2N + 4N_t, \qquad M_{CPU,optimizer} \approx 16Q \quad \text{bytes}.
-$$
+## Additional host memory
 
-The CPU estimate includes the FP32 main parameter, two Adam moments, and gradient staging. Sum it across every trainer rank on the node. CPU offload preserves HBM headroom but can reduce throughput, so benchmark GPU Adam when both configurations fit.
+| Source | Estimate | When to count it |
+|---|---:|---|
+| Other `torch_memory_saver` mirrors | Runtime-dependent | Count eligible allocations that are not explicitly excluded below when training offload is enabled |
+| Flat gradient-buffer TMS backup | `0` in current Miles Megatron paths, avoiding about `4N` with default FP32 gradients | `offload_train=True` sets `disable_grad_buffers_cpu_backup=True`; without training offload, Miles does not enable TMS |
+| Weight and parameter backups | About `2N` for the actor-sized copy, plus the tags below | Count the copy owner and every additional model-switching tag |
+| Runtime overhead | Measure per node | Count Ray object store, pinned transfers, dataloaders, page cache, and checkpoint transients |
 
-### Precision choices
+For default BF16 colocate with training offload, `--disable-weights-backuper` changes which subsystem owns the actor-sized CPU copy but does not remove that copy:
 
-| Choice | Recommendation |
-|---|---|
-| Default BF16 weights, FP32 gradients, FP32 Adam state | Use for production and convergence CI |
-| `--grad-reduce-in-bf16` | Avoid for production and convergence CI; use only for validated fit-only jobs |
-| `--main-params-dtype fp16`, `--exp-avg-dtype fp16`, `--exp-avg-sq-dtype fp16` | Require `--use-precision-aware-optimizer`; use only after numerical comparison |
-| FP8 training | Use a tested hardware/model recipe; FP8 compute does not make every resident parameter `1 B` |
-| QAT | Enable only for a target quantized rollout or deployment format; it is not triggered automatically by model size or FP8 |
+| Configuration | `TensorBackuper` `actor` copy | TMS `param_buffer` copy | Actor-sized CPU total |
+|---|---:|---:|---:|
+| Default | About `2N` | `0` | About `2N` |
+| `--disable-weights-backuper` | `0` | About `2N` | About `2N` |
 
-The current full CPU-offload path keeps its Adam state in FP32 host memory, so the FP16 optimizer-state flags do not reduce the `16Q` CPU estimate. See [Low Precision RL](/advanced/fp8-low-precision) and [INT4 QAT](/advanced/int4-qat) for format-specific setup.
+With explicit `--no-offload-train`, Miles does not enable TMS, so `--disable-weights-backuper` can remove the actor-sized CPU copy, but the trainer remains resident in HBM.
 
-## 3. Add host-memory overhead
+`MegatronTrainRayActor._enable_weight_backup` is true for colocate, reference-model KL, Megatron OPD teacher, or old-actor switching. With the default weight backuper enabled, each additional BF16 tag adds about `2N`:
 
-In addition to CPU Adam, include these consumers when enabled:
+| User configuration | Backup tag | Incremental CPU memory |
+|---|---|---:|
+| `--use-kl-loss` or nonzero `--kl-coef`; requires `--ref-load` | `ref` | `+2N` |
+| `--use-opd --opd-type megatron`; requires `--opd-teacher-load` | `teacher` | `+2N` |
+| `--keep-old-actor` | `old_actor` | `+2N` |
+| `--keep-old-actor --update-weights-interval 1` | `rollout_actor` | `+2N` |
 
-- `torch_memory_saver` mirrors eligible allocations when training is offloaded; Miles excludes the flat gradient buffer, but the remaining amount is runtime-dependent.
+For combined conditions, count the union of created tags. These additional tags require the default weight backuper; do not use `--disable-weights-backuper` with model-switching features.
 
-- Explicit weight backups can add approximately one local model shard per backup tag.
+Sum these values across all local processes before comparing with `MemAvailable`.
 
-- Standard full-model colocated SGLang does not automatically keep another full CPU model copy; LoRA with `--lora-base-cpu-backup` is an explicit exception.
+## Tune `--max-tokens-per-gpu`
 
-At the node level, add all trainer ranks, rollout processes, Ray object-store memory, pinned transfer buffers, dataloaders, and checkpoint staging. Use pre-launch `MemAvailable` from `/proc/meminfo`, not total installed RAM. Keeping planned usage below roughly `80%` of `MemAvailable` is a starting policy, not a universal safe limit, and the job should not rely on swap.
+Activation memory is configuration- and data-dependent. Measure it with the exact production recipe instead of deriving it from parameter count.
 
-## 4. Calibrate activation memory
-
-Activation memory depends on tokens, model shape, recomputation, attention kernels, pipeline scheduling, and MoE routing. It is more reliable to measure its slope than to derive it from parameter count.
-
-1. Set the planning budget to `B = 0.8 × physical_HBM`; use a lower fraction for long contexts, large token caps, new kernels, or colocated transitions.
-
-2. Run the exact recipe at two safe token caps `K1 < K2`. Include warmup, a full forward/backward/optimizer step, weight sync, and offload/onload transitions. Use separate runs or call `torch.cuda.reset_peak_memory_stats()` before each measurement.
-
-3. Record `torch.cuda.max_memory_reserved()` on every rank and use the largest rank. Estimate:
+| Step | Action |
+|---:|---|
+| 1 | Set the planning budget `B`, initially `0.8 × physical_HBM` |
+| 2 | Run two safe token caps `K1 < K2`; include warmup, forward, backward, optimizer step, weight sync, and offload/onload transitions |
+| 3 | Record `torch.cuda.max_memory_reserved()` on every rank; use separate runs or call `torch.cuda.reset_peak_memory_stats()` before each measurement |
+| 4 | Estimate the slope and candidate cap with the formulas below |
+| 5 | Round down, then validate the longest samples and representative packing patterns; use binary search if the peak is nonlinear |
 
 $$
 \alpha = \frac{M(K_2)-M(K_1)}{K_2-K_1}, \qquad K_{candidate} = K_1 + \frac{B-M(K_1)}{\alpha}.
 $$
 
-4. Round `K_candidate` down and validate it with representative longest samples and packing patterns. Use binary search when the measured peak is nonlinear.
-
-Miles packs a CP group against approximately `CP × max_tokens_per_gpu`; the flag remains a per-GPU target. Always validate the actual maximum rank rather than assuming perfectly balanced tokens.
-
-## Quick checklist
-
-- Take the largest startup parameter count, not the average rank or advertised active parameters.
-
-- Calculate default HBM with `2N + 4N_t + 12Q`.
-
-- With CPU Adam, calculate HBM with `2N + 4N_t` and host optimizer memory with `16Q`.
-
-- Add backup, Ray, rollout, checkpoint, activation, workspace, and transition peaks.
-
-- Keep initial HBM and host plans below roughly `80%`, then confirm them with a complete measured step.
+Miles packs a CP group against approximately `CP × max_tokens_per_gpu`, but the flag remains a per-GPU target. Always validate the maximum observed rank rather than assuming perfectly balanced tokens.

--- a/docs/advanced/megatron_param_tuning.md
+++ b/docs/advanced/megatron_param_tuning.md
@@ -1,0 +1,118 @@
+---
+title: Megatron Parameter Tuning
+description: Quickly estimate model-state memory, host memory, and token capacity for Megatron training in Miles.
+---
+
+Use this guide to answer two questions before launching a Megatron job: whether the trainer state fits, and how to choose `--max-tokens-per-gpu`. The formulas are first-order estimates; the final decision must use the maximum observed rank from a complete training step.
+
+## 1. Get three numbers
+
+Use these values for the most heavily loaded trainer rank:
+
+| Symbol | Meaning |
+|---|---|
+| `N` | All resident model parameter elements on the rank |
+| `N_t` | Trainable parameter elements on the rank; equal to `N` for full-parameter training |
+| `Q` | Trainable parameter elements owned by the rank's distributed optimizer shard |
+
+For full-parameter training with one optimizer shard group of size `S`, use `N_t = N` and `Q = N / S`. MoE models can have different dense and expert shard groups; in that case use `Q = N_dense / S_dense + N_expert / S_expert`.
+
+Megatron prints the constructed parameter count for every TP/PP rank at startup:
+
+```text
+> number of parameters on (tensor, pipeline) model parallel rank (T_RANK, P_RANK): COUNT
+```
+
+Use the largest `COUNT` as `N`. A rough dense-model estimate is `total_parameters / (TP × PP)`, but it can miss embeddings, output heads, uneven pipeline stages, and replicated modules. Do not use a MoE model's advertised active-parameter count for weight memory.
+
+This document does not derive parallel groups. Start from a tested recipe and see [Parallelism compatibility](/user-guide/usage#parallelism-compatibility) when changing TP, PP, CP, EP, or expert TP.
+
+## 2. Estimate static memory
+
+Miles defaults to BF16 model parameters, FP32 gradients, distributed Adam, and FP32 optimizer state. The steady-state HBM estimate is:
+
+$$
+M_{HBM} \approx 2N + 4N_t + 12Q \quad \text{bytes}.
+$$
+
+For full-parameter training with one shard group, this is `(6 + 12/S) × N` bytes. Divide by `2^30` for GiB.
+
+| State | Approximate memory | Default placement |
+|---|---:|---|
+| BF16 model parameters | `2N` | HBM |
+| FP32 gradients | `4N_t` | HBM |
+| FP32 main parameters and two Adam moments | `12Q` | HBM |
+
+This estimate excludes activations, CUDA/NCCL buffers, allocator fragmentation, kernel workspaces, padding, and temporary weight-sync or offload peaks.
+
+### CPU optimizer offload
+
+For large production and capacity-oriented CI jobs, use CPU Adam when optimizer state would consume too much HBM:
+
+```bash
+--optimizer-cpu-offload
+--overlap-cpu-optimizer-d2h-h2d
+--use-precision-aware-optimizer
+```
+
+With full CPU offload, estimate:
+
+$$
+M_{HBM} \approx 2N + 4N_t, \qquad M_{CPU,optimizer} \approx 16Q \quad \text{bytes}.
+$$
+
+The CPU estimate includes the FP32 main parameter, two Adam moments, and gradient staging. Sum it across every trainer rank on the node. CPU offload preserves HBM headroom but can reduce throughput, so benchmark GPU Adam when both configurations fit.
+
+### Precision choices
+
+| Choice | Recommendation |
+|---|---|
+| Default BF16 weights, FP32 gradients, FP32 Adam state | Use for production and convergence CI |
+| `--grad-reduce-in-bf16` | Avoid for production and convergence CI; use only for validated fit-only jobs |
+| `--main-params-dtype fp16`, `--exp-avg-dtype fp16`, `--exp-avg-sq-dtype fp16` | Require `--use-precision-aware-optimizer`; use only after numerical comparison |
+| FP8 training | Use a tested hardware/model recipe; FP8 compute does not make every resident parameter `1 B` |
+| QAT | Enable only for a target quantized rollout or deployment format; it is not triggered automatically by model size or FP8 |
+
+The current full CPU-offload path keeps its Adam state in FP32 host memory, so the FP16 optimizer-state flags do not reduce the `16Q` CPU estimate. See [Low Precision RL](/advanced/fp8-low-precision) and [INT4 QAT](/advanced/int4-qat) for format-specific setup.
+
+## 3. Add host-memory overhead
+
+In addition to CPU Adam, include these consumers when enabled:
+
+- `torch_memory_saver` mirrors eligible allocations when training is offloaded; Miles excludes the flat gradient buffer, but the remaining amount is runtime-dependent.
+
+- Explicit weight backups can add approximately one local model shard per backup tag.
+
+- Standard full-model colocated SGLang does not automatically keep another full CPU model copy; LoRA with `--lora-base-cpu-backup` is an explicit exception.
+
+At the node level, add all trainer ranks, rollout processes, Ray object-store memory, pinned transfer buffers, dataloaders, and checkpoint staging. Use pre-launch `MemAvailable` from `/proc/meminfo`, not total installed RAM. Keeping planned usage below roughly `80%` of `MemAvailable` is a starting policy, not a universal safe limit, and the job should not rely on swap.
+
+## 4. Calibrate activation memory
+
+Activation memory depends on tokens, model shape, recomputation, attention kernels, pipeline scheduling, and MoE routing. It is more reliable to measure its slope than to derive it from parameter count.
+
+1. Set the planning budget to `B = 0.8 × physical_HBM`; use a lower fraction for long contexts, large token caps, new kernels, or colocated transitions.
+
+2. Run the exact recipe at two safe token caps `K1 < K2`. Include warmup, a full forward/backward/optimizer step, weight sync, and offload/onload transitions. Use separate runs or call `torch.cuda.reset_peak_memory_stats()` before each measurement.
+
+3. Record `torch.cuda.max_memory_reserved()` on every rank and use the largest rank. Estimate:
+
+$$
+\alpha = \frac{M(K_2)-M(K_1)}{K_2-K_1}, \qquad K_{candidate} = K_1 + \frac{B-M(K_1)}{\alpha}.
+$$
+
+4. Round `K_candidate` down and validate it with representative longest samples and packing patterns. Use binary search when the measured peak is nonlinear.
+
+Miles packs a CP group against approximately `CP × max_tokens_per_gpu`; the flag remains a per-GPU target. Always validate the actual maximum rank rather than assuming perfectly balanced tokens.
+
+## Quick checklist
+
+- Take the largest startup parameter count, not the average rank or advertised active parameters.
+
+- Calculate default HBM with `2N + 4N_t + 12Q`.
+
+- With CPU Adam, calculate HBM with `2N + 4N_t` and host optimizer memory with `16Q`.
+
+- Add backup, Ray, rollout, checkpoint, activation, workspace, and transition peaks.
+
+- Keep initial HBM and host plans below roughly `80%`, then confirm them with a complete measured step.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -178,6 +178,7 @@
               {
                 "group": "Performance",
                 "pages": [
+                  "advanced/megatron_param_tuning",
                   "advanced/fp8-low-precision",
                   "advanced/int4-qat",
                   "advanced/speculative-decoding",


### PR DESCRIPTION
## Summary
Add a concise Megatron capacity-planning guide to the Advanced documentation.

## Motivation
Document practical HBM, host-memory, and token-capacity estimates for Megatron training, and expose the guide through the Advanced documentation navigation.

## Usage
Take `N`, `N_t`, and `Q` from the most heavily loaded Megatron rank, apply the documented HBM or CPU-offload formula, then calibrate `--max-tokens-per-gpu` with two measured training runs.

## Design Notes
- **Key choices:** Base estimates on three explicit input counts.
- **Key choices:** Put the memory formulas on the main path.
- **Key choices:** Defer supporting details to existing guides.

## Verification
- **Tests added:** None; this is a documentation-only change.
- **Build validation:** `npx --yes mintlify@latest validate` passed.
- **Link validation:** `npx --yes mintlify@latest broken-links` found no broken links.

## Review Focus
- Scrutinize the memory formulas in `docs/advanced/megatron_param_tuning.md` against the current Megatron defaults.
- Verify that `docs/advanced/index.md` and `docs/docs.json` expose the new page consistently.
