### PR TITLE
[AMD][DeepSeek V4][1/N] Fit TP=1 sparse MLA kernels in MI35x LDS

### DIFF
--- a/miles_plugins/models/deepseek_v4/ops/kernel/tilelang_sparse_mla_bwd.py
+++ b/miles_plugins/models/deepseek_v4/ops/kernel/tilelang_sparse_mla_bwd.py
@@ -116,9 +116,13 @@ def bwd(
     attn_sink_shape = [H]
 
     padded_H = max(tilelang.math.next_power_of_2(H), 16)
-    # Split large HIP head tiles to reduce LDS use.
-    use_reduced_lds_tile = torch.version.hip is not None and padded_H >= 64
-    block_H = min(32 if use_reduced_lds_tile else 64, padded_H)
+    is_hip = getattr(torch.version, "hip", None)
+    if is_hip:
+        # Split large HIP head tiles to reduce LDS use.
+        max_block_H = 32 if padded_H >= 64 else 64
+    else:
+        max_block_H = 64
+    block_H = min(max_block_H, padded_H)
     assert padded_H % block_H == 0
     NH = padded_H // block_H
     BS = block_size

--- a/miles_plugins/models/deepseek_v4/ops/kernel/tilelang_sparse_mla_bwd.py
+++ b/miles_plugins/models/deepseek_v4/ops/kernel/tilelang_sparse_mla_bwd.py
@@ -116,7 +116,9 @@ def bwd(
     attn_sink_shape = [H]
 
     padded_H = max(tilelang.math.next_power_of_2(H), 16)
-    block_H = min(64, padded_H)
+    # Split large HIP head tiles to reduce LDS use.
+    use_reduced_lds_tile = torch.version.hip is not None and padded_H >= 64
+    block_H = min(32 if use_reduced_lds_tile else 64, padded_H)
     assert padded_H % block_H == 0
     NH = padded_H // block_H
     BS = block_size

--- a/miles_plugins/models/deepseek_v4/ops/kernel/tilelang_sparse_mla_fwd.py
+++ b/miles_plugins/models/deepseek_v4/ops/kernel/tilelang_sparse_mla_fwd.py
@@ -61,9 +61,12 @@ def sparse_mqa_fwd(
 
     H_per_block = padded_H if REPLICATE_H == 1 else 64
 
-    # Limit pipeline buffering for 64-head HIP tiles to reduce LDS use.
-    if torch.version.hip is not None and H_per_block == 64:
-        num_stages = min(num_stages, 1)
+    is_hip = getattr(torch.version, "hip", None)
+    if is_hip:
+        # Limit pipeline buffering for 64-head HIP tiles to reduce LDS use.
+        kernel_num_stages = min(num_stages, 1) if H_per_block == 64 else num_stages
+    else:
+        kernel_num_stages = num_stages
 
     @T.prim_func
     def main(
@@ -102,7 +105,7 @@ def sparse_mqa_fwd(
 
             T.copy(Q[b_i, s_i, H0:H1, :D], Q_shared)
 
-            for i_i in T.Pipelined(NI, num_stages=num_stages):
+            for i_i in T.Pipelined(NI, num_stages=kernel_num_stages):
                 for bi_i in T.Parallel(BI):
                     mask[bi_i] = Indices[b_i, s_i, i_i * BI + bi_i] != -1
 

--- a/miles_plugins/models/deepseek_v4/ops/kernel/tilelang_sparse_mla_fwd.py
+++ b/miles_plugins/models/deepseek_v4/ops/kernel/tilelang_sparse_mla_fwd.py
@@ -61,6 +61,10 @@ def sparse_mqa_fwd(
 
     H_per_block = padded_H if REPLICATE_H == 1 else 64
 
+    # Limit pipeline buffering for 64-head HIP tiles to reduce LDS use.
+    if torch.version.hip is not None and H_per_block == 64:
+        num_stages = min(num_stages, 1)
+
     @T.prim_func
     def main(
         Q: T.Tensor(q_shape, dtype),  # type: ignore


### PR DESCRIPTION
## Summary

Reduce sparse-MLA LDS usage for the DeepSeek V4 TP=1 configuration on MI35x.

DeepSeek V4 has 64 attention heads, so TP=1 produces a 64-head local tile. On MI355X, the existing kernels exceed the 163,840-byte LDS limit:

- Forward: 206,848 bytes
- Backward: 204,800 bytes

This change:

- limits forward pipeline buffering to one stage for 64-head HIP tiles;
- uses 32-head backward tiles for large HIP head configurations.

The resulting kernels use 141,312 bytes and 135,168 bytes respectively. NVIDIA tuning and smaller-head HIP configurations are unchanged.

## Context

This is 1/N in a series of focused AMD DeepSeek V4 follow-ups. The TP=1 fix was originally developed in #1300. Following maintainer feedback, we are splitting that work into small, directly reviewable changes against the current codebase.

## Validation

Validated on AMD Instinct MI355X:

- Reproduced the TP=1 (`H=64`) compilation failures: forward and backward requested 206,848 and 204,800 bytes of LDS, exceeding the 163,840-byte device limit.
- After this change, the kernels use 141,312 and 135,168 bytes respectively.
- All 23 cases in `tests/manual/models/deepseek_v4/test_v4_tilelang_sparse_mla.py` passed, including TP=1 forward outputs and backward gradients compared against the PyTorch reference.