### PR TITLE
[fix] fix session server `hash_consistent` mode

### DIFF
--- a/miles/rollout/session/core.py
+++ b/miles/rollout/session/core.py
@@ -222,6 +222,7 @@ class SessionCore:
         # --- lock released ---
 
         # --- Phase 2: proxy to backend (NO lock held) ---
+        headers = {**headers, "X-SMG-Routing-Key": session_id}
         result = await self.backend.do_proxy(
             ProxyRequest(method=method, query=query), "v1/chat/completions", body=proxy_body, headers=headers
         )
@@ -298,6 +299,7 @@ class SessionCore:
     async def proxy(
         self, session_id: str, path: str, *, method: str, query: str, headers: dict, body: bytes
     ) -> Response:
+        headers = {**headers, "X-SMG-Routing-Key": session_id}
         result = await self.backend.do_proxy(
             ProxyRequest(method=method, query=query), path, body=body, headers=headers
         )


### PR DESCRIPTION
## Problem

The session server forwards the client's headers to the engine router verbatim. External agent clients (OpenAI SDK etc.) never set `X-SMG-Routing-Key`, so with `--sglang-router-policy consistent_hashing` the router hashes an absent key — a constant — and pins **every session to a single engine**.

Observed on a 16-node disaggregated run (4x TP8 engines, `--use-session-server`, agentic tbench2 episodes): one engine had 2116 prefill/decode batches with 27 concurrent requests while the other three engines each logged exactly 1 (their own warmup). Rollout ran on 1/4 of provisioned inference capacity.

This never surfaced before because the two halves are individually fine: miles' own direct rollout path sets the header itself (`sglang_rollout.py`), and existing session-server users run the default `cache_aware` policy, which doesn't read the key. The combination — session server x consistent_hashing x multiple engines — was silently broken.

## Fix

`SessionCore` stamps `X-SMG-Routing-Key: session_id` on upstream requests (both `chat_completions` and the generic `proxy` path). Session ids are minted per episode (uuid), so sessions spread evenly across engines while each session stays pinned to one engine — which is also what keeps its prefix cache hot across turns.

No effect on `cache_aware` deployments (that policy ignores the header).

## Validation

Same 16-node run after the fix: all engines serve traffic (per-engine batch logs balanced), rollout-side GPU utilization visible on all inference nodes instead of one engine's pair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
