### PR TITLE
(2/N) feat(session): scale out as N session-server instances on a port range

### DIFF
--- a/miles/ray/rollout/router_manager.py
+++ b/miles/ray/rollout/router_manager.py
@@ -77,12 +77,31 @@ def start_router(args, *, has_pd_disaggregation: bool = False, force_new: bool =
     return router_ip, router_port
 
 
-def start_session_server(args):
-    """Start a standalone session server when ``--use-session-server`` is set.
+def _resolve_session_server_ports(raw: list[int] | None) -> list[int]:
+    """Resolve the ``--session-server-port`` value into the ports to serve on.
 
-    The session server runs as a separate process with its own port and proxies
-    inference requests directly to SGLang worker engines.  It is always started
-    as a standalone process regardless of whether ``--use-miles-router`` is active.
+    None: one auto-allocated port. One value: a single server on that port.
+    Two values: the half-open range [start, end), one server per port.
+    """
+    if raw is None:
+        return [find_available_port(random.randint(5000, 6000))]
+    if len(raw) == 1:
+        return raw
+    if len(raw) == 2:
+        start, end = raw
+        if start >= end:
+            raise ValueError(f"--session-server-port range [{start}, {end}) is empty.")
+        return list(range(start, end))
+    raise ValueError(f"--session-server-port takes one port or a start/end range, got {len(raw)} values: {raw}")
+
+
+def start_session_server(args):
+    """Start the standalone session servers when ``--use-session-server`` is set.
+
+    One independent single-process server per resolved port; the rollout side
+    picks one per session and its URL carries the affinity from then on.
+    Always started standalone regardless of whether ``--use-miles-router`` is
+    active.
     """
     if not getattr(args, "use_session_server", False):
         return
@@ -93,23 +112,34 @@ def start_session_server(args):
 
     if getattr(args, "session_server_ip", None) is None:
         args.session_server_ip = args.sglang_router_ip
-    if getattr(args, "session_server_port", None) is None:
-        args.session_server_port = find_available_port(random.randint(5000, 6000))
-    if getattr(args, "session_server_instance_id", None) is None:
-        args.session_server_instance_id = uuid.uuid4().hex
 
-    ip, port = args.session_server_ip, args.session_server_port
-    if not is_port_available(port):
-        raise RuntimeError(
-            f"Port {port} is already in use — a stale session server may still be running. "
-            f"Run 'pkill -9 python' to kill it, then retry."
-        )
+    ip = args.session_server_ip
+    ports = _resolve_session_server_ports(getattr(args, "session_server_port", None))
+    for port in ports:
+        if not is_port_available(port):
+            raise RuntimeError(
+                f"Port {port} is already in use — a stale session server may still be running. "
+                f"Run 'pkill -9 python' to kill it, then retry."
+            )
+    # The canonical driver-side value; rollout code picks from this list.
+    args.session_server_ports = ports
 
     router_url = f"http://{args.sglang_router_ip}:{args.sglang_router_port}"
 
+    # Spawn all children before waiting on any: each child pays the ~10s
+    # transformers import, so N servers start in ~one import of wall-time.
     # spawn (not fork): see start_router for rationale.
-    process = multiprocessing.get_context("spawn").Process(target=run_session_server, args=(args, router_url))
-    process.daemon = True
-    process.start()
-    wait_for_server_ready(ip, port, process, timeout=30)
-    logger.info(f"Session server launched at {ip}:{port}")
+    processes = []
+    for port in ports:
+        child_args = copy.copy(args)
+        child_args.session_server_port = port
+        child_args.session_server_instance_id = uuid.uuid4().hex
+        process = multiprocessing.get_context("spawn").Process(
+            target=run_session_server, args=(child_args, router_url)
+        )
+        process.daemon = True
+        process.start()
+        processes.append((port, process))
+    for port, process in processes:
+        wait_for_server_ready(ip, port, process, timeout=30)
+    logger.info(f"Session servers launched at {ip}, ports {ports} ({len(ports)} instances)")

--- a/miles/rollout/generate_hub/agentic_tool_call.py
+++ b/miles/rollout/generate_hub/agentic_tool_call.py
@@ -45,8 +45,8 @@ logger = logging.getLogger(__name__)
 
 
 async def generate(input: GenerateFnInput) -> GenerateFnOutput:
-    assert getattr(input.args, "session_server_ip", None) and getattr(input.args, "session_server_port", None), (
-        "agentic_tool_call.generate requires session_server_ip/session_server_port. "
+    assert getattr(input.args, "session_server_ip", None) and getattr(input.args, "session_server_ports", None), (
+        "agentic_tool_call.generate requires session_server_ip/session_server_ports. "
         "Pass --use-session-server to start the session server."
     )
     tracer = await OpenAIEndpointTracer.create(input.args)
@@ -66,10 +66,8 @@ async def generate(input: GenerateFnInput) -> GenerateFnOutput:
 
     log_prefix = f"[session={tracer.session_id}]"
 
-    session_ip = getattr(input.args, "session_server_ip", None)
-    session_port = getattr(input.args, "session_server_port", None)
-    if session_ip and session_port:
-        metadata = {**metadata, "session_server_id": f"{session_ip}:{session_port}"}
+    # From the tracer, not args: with multiple instances the owning ip:port is per-session.
+    metadata = {**metadata, "session_server_id": tracer.session_server_id}
 
     agent_metadata = None
     t_start = time.monotonic()

--- a/miles/rollout/generate_utils/openai_endpoint_utils.py
+++ b/miles/rollout/generate_utils/openai_endpoint_utils.py
@@ -4,6 +4,7 @@ Utilities for the OpenAI endpoint
 
 import asyncio
 import logging
+import random
 from argparse import Namespace
 from copy import deepcopy
 
@@ -27,23 +28,29 @@ class OpenAIEndpointTracer:
         self.base_url = f"{router_url}/sessions/{session_id}"
         self.session_server_instance_id = session_server_instance_id
 
+    @property
+    def session_server_id(self) -> str:
+        """``ip:port`` of the instance owning this session, as recorded in sample metadata."""
+        return self.router_url.removeprefix("http://")
+
     @staticmethod
     async def create(args: Namespace):
         session_ip = getattr(args, "session_server_ip", None)
-        session_port = getattr(args, "session_server_port", None)
-        if not session_ip or not session_port:
+        session_ports = getattr(args, "session_server_ports", None)
+        if not session_ip or not session_ports:
             raise RuntimeError(
-                "session_server_ip/session_server_port are not set. "
+                "session_server_ip/session_server_ports are not set. "
                 "Pass --use-session-server to start the session server."
             )
+        # The only routing decision in the system: pick the owning instance once
+        # per session; every later touch of the session reuses this URL.
+        session_port = random.choice(session_ports)
         session_url = f"http://{session_ip}:{session_port}"
         session_server_instance_id = None
         try:
             health = await post(f"{session_url}/health", {}, action="get")
             if isinstance(health, dict):
                 session_server_instance_id = health.get("session_server_instance_id")
-                if session_server_instance_id is not None:
-                    args.session_server_instance_id = session_server_instance_id
         except Exception as e:
             logger.warning("Failed to get session server health from %s: %s", session_url, e)
         response = await post(f"{session_url}/sessions", {}, action="post")

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -2030,8 +2030,11 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
             parser.add_argument(
                 "--session-server-port",
                 type=int,
+                nargs="+",
                 default=None,
-                help="Port of the standalone session server. Auto-allocated if not set.",
+                help="Port(s) of the standalone session servers. One value: a single server on "
+                "that port. Two values: a half-open range [start, end), one server per port. "
+                "Auto-allocates a single port if not set.",
             )
             parser.add_argument(
                 "--tito-model",

--- a/tests/fast/fixtures/generation_fixtures.py
+++ b/tests/fast/fixtures/generation_fixtures.py
@@ -295,9 +295,10 @@ def generation_env(request, variant):
 
         with cm:
             if is_agentic:
-                # Point session server address to the SessionServer we just started
+                # Point session server address to the SessionServer we just started,
+                # mirroring the driver-side contract set by start_session_server.
                 args.session_server_ip = "127.0.0.1"
-                args.session_server_port = server_port
+                args.session_server_ports = [server_port]
                 mock_tools.AGENTIC_MAX_TURNS = args_kwargs.get("generate_max_turns")
                 mock_tools.AGENTIC_RETURN_METADATA = args_kwargs.get("agentic_return_metadata")
             yield GenerateEnv(args=args, mock_server=mock_server)

--- a/tests/fast/fixtures/rollout_fixtures.py
+++ b/tests/fast/fixtures/rollout_fixtures.py
@@ -117,7 +117,7 @@ def _with_session_server(args: Namespace, backend_url: str) -> Iterator[UvicornT
     try:
         server.start()
         args.session_server_ip = "127.0.0.1"
-        args.session_server_port = port
+        args.session_server_ports = [port]
         yield server
     finally:
         server.stop()

--- a/tests/fast/ray/rollout/test_router_manager.py
+++ b/tests/fast/ray/rollout/test_router_manager.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 import pytest
 from tests.fast.ray.rollout.conftest import make_args
 
-from miles.ray.rollout.router_manager import start_router, start_session_server
+from miles.ray.rollout.router_manager import _resolve_session_server_ports, start_router, start_session_server
 
 
 class TestStartRouter:
@@ -52,7 +52,7 @@ class TestStartSessionServer:
             start_session_server(args)
 
     def test_enabled_port_conflict_raises_runtime_error(self):
-        """When the configured ``session_server_port`` is already bound, fail
+        """When a configured ``session_server_port`` is already bound, fail
         loud rather than silently re-using the stale process."""
         args = make_args(
             use_session_server=True,
@@ -60,8 +60,28 @@ class TestStartSessionServer:
             sglang_router_ip="127.0.0.1",
             sglang_router_port=20000,
             session_server_ip="127.0.0.1",
-            session_server_port=20001,
+            session_server_port=[20001],
         )
         with patch("miles.ray.rollout.router_manager.is_port_available", return_value=False):
             with pytest.raises(RuntimeError, match="already in use"):
                 start_session_server(args)
+
+
+class TestResolveSessionServerPorts:
+    def test_none_auto_allocates_one_port(self):
+        with patch("miles.ray.rollout.router_manager.find_available_port", return_value=20002):
+            assert _resolve_session_server_ports(None) == [20002]
+
+    def test_single_value_is_a_single_server(self):
+        assert _resolve_session_server_ports([30000]) == [30000]
+
+    def test_two_values_expand_to_half_open_range(self):
+        assert _resolve_session_server_ports([30000, 30004]) == [30000, 30001, 30002, 30003]
+
+    def test_empty_range_raises(self):
+        with pytest.raises(ValueError, match="empty"):
+            _resolve_session_server_ports([30004, 30000])
+
+    def test_more_than_two_values_raises(self):
+        with pytest.raises(ValueError, match="one port or a start/end range"):
+            _resolve_session_server_ports([30000, 30001, 30002])

--- a/tests/fast/rollout/generate_hub/test_multi_turn.py
+++ b/tests/fast/rollout/generate_hub/test_multi_turn.py
@@ -714,7 +714,8 @@ class TestAgentMetadata:
             mock_tools.AGENTIC_RETURN_METADATA = None
 
         samples = listify(result.sample)
-        expected_session_server_id = f"127.0.0.1:{generation_env.args.session_server_port}"
+        (session_server_port,) = generation_env.args.session_server_ports
+        expected_session_server_id = f"127.0.0.1:{session_server_port}"
         for s in samples:
             assert s.metadata["session_server_id"] == expected_session_server_id
             assert re.fullmatch(r"[0-9a-f]{32}", s.metadata["session_server_instance_id"])
@@ -753,7 +754,7 @@ class TestAgentNoRecords:
             )
             with with_session_server(mock_server.url, args, port=session_port):
                 args.session_server_ip = "127.0.0.1"
-                args.session_server_port = session_port
+                args.session_server_ports = [session_port]
                 env = GenerateEnv(args=args, mock_server=mock_server)
                 result = _run_generate(agentic_variant, env, make_sample(prompt=TwoTurnStub.PROMPT))
 

--- a/tests/fast/rollout/generate_utils/test_openai_endpoint_utils.py
+++ b/tests/fast/rollout/generate_utils/test_openai_endpoint_utils.py
@@ -106,16 +106,58 @@ async def test_create_fetches_session_server_instance_id(monkeypatch):
 
     monkeypatch.setattr("miles.rollout.generate_utils.openai_endpoint_utils.post", fake_post)
 
-    args = SimpleNamespace(session_server_ip="127.0.0.1", session_server_port=12345)
+    args = SimpleNamespace(session_server_ip="127.0.0.1", session_server_ports=[12345])
     tracer = await OpenAIEndpointTracer.create(args)
 
     assert tracer.base_url == "http://127.0.0.1:12345/sessions/session-123"
+    assert tracer.session_server_id == "127.0.0.1:12345"
     assert tracer.session_server_instance_id == "server-instance-123"
-    assert args.session_server_instance_id == "server-instance-123"
     assert calls == [
         ("get", "http://127.0.0.1:12345/health"),
         ("post", "http://127.0.0.1:12345/sessions"),
     ]
+
+
+@pytest.mark.asyncio
+async def test_create_distributes_sessions_across_port_range(monkeypatch):
+    """With a multi-port range, sessions land on more than one instance, and every
+    request of a session (health, create, chat, GET, DELETE) hits the port chosen
+    at create time — the URL is the router."""
+    calls: list[tuple[str, str]] = []
+
+    async def fake_post(url: str, payload: dict, action: str = "post"):
+        calls.append((action, url))
+        if action == "get" and url.endswith("/health"):
+            return {"status": "ok", "session_server_instance_id": "0" * 32}
+        if action == "post" and url.endswith("/sessions"):
+            return {"session_id": f"session-{len(calls)}"}
+        return {"session_id": url.rsplit("/", 1)[1], "records": [], "metadata": {}}
+
+    monkeypatch.setattr("miles.rollout.generate_utils.openai_endpoint_utils.post", fake_post)
+
+    ports = [12345, 12346, 12347, 12348]
+    args = SimpleNamespace(session_server_ip="127.0.0.1", session_server_ports=ports)
+
+    chosen_ports = set()
+    for _ in range(32):
+        calls.clear()
+        tracer = await OpenAIEndpointTracer.create(args)
+        port = int(tracer.session_server_id.rsplit(":", 1)[1])
+        assert port in ports
+        chosen_ports.add(port)
+
+        await tracer.collect_records()
+        prefix = f"http://127.0.0.1:{port}"
+        assert [url for _, url in calls] == [
+            f"{prefix}/health",
+            f"{prefix}/sessions",
+            tracer.base_url,
+            tracer.base_url,
+        ]
+        assert tracer.base_url.startswith(f"{prefix}/sessions/")
+
+    # 32 uniform picks over 4 ports miss a given port with p = (3/4)^32 ≈ 1e-4.
+    assert len(chosen_ports) > 1
 
 
 # ── test: compute_samples_from_openai_records ────────────────────────


### PR DESCRIPTION
> **Depends on:** #1658
> Stacked on the parent PR's branch. Review / merge the parent first.

## Summary
`--session-server-port` accepts a port range; one independent session-server instance per port.

## Motivation
The session server does real CPU work on every chat turn (request/response JSON parse and serialize, TITO tokenization, record store) on one event loop under one GIL, and pegs a single core at production agentic load. The reverted #1518 scaled it with a router + IPC + worker data plane behind one URL; but the rollout side already mints each session's URL exactly once in `OpenAIEndpointTracer.create` and reuses it for every later touch, so affinity needs no server-side routing — N independent instances suffice, and the URL is the router.

## Usage
```
--use-session-server --session-server-port 5000 5016   # 16 instances on [5000, 5016)
--use-session-server --session-server-port 30000       # one instance on that port, unchanged
# flag absent: one auto-allocated port, unchanged
```

## Design Notes
- **Key choices:**
  - The only routing decision in the system is `random.choice(ports)`, once per session in `OpenAIEndpointTracer.create`.
  - `start_session_server` spawns every child before waiting on any, so N instances pay roughly one transformers import of wall-time.
  - Each child receives its own scalar `session_server_port` and instance id, leaving `server.py` / `sessions.py` / `core.py` untouched.
  - `session_server_id` sample metadata now comes from the tracer's chosen URL; the racy driver-global `session_server_instance_id` write-back is dropped.
- **Alternatives considered:** the #1518 data plane — every constraint it satisfies, N independent instances satisfy without the IPC / router layer.

## Verification
- **Tests added:** `TestResolveSessionServerPorts` — range expansion plus empty-range / more-than-two-values hard errors.
- `test_create_distributes_sessions_across_port_range` — sessions spread across a 4-port range; every request of a session hits its create-time port.
- `tests/fast/ray/rollout`, `tests/fast/rollout/generate_hub` (full), `tests/fast/rollout/inference_rollout/integration`, `tests/fast/router` all pass; the follow-up bench PR measures 8.2x throughput at 16 instances vs 1.

## Review Focus
- Scrutinize `_resolve_session_server_ports` boundary semantics: half-open `[start, end)`, single-value / flag-absent compatibility.
- Scrutinize the `args.session_server_ports` propagation: `start_session_server` mutates the same args object the rollout actor hands to generate functions.
