### PR TITLE
openenv/tbench2: DeepSeek-V4-Flash launcher variant

### DIFF
--- a/examples/experimental/openenv/README.md
+++ b/examples/experimental/openenv/README.md
@@ -1,0 +1,80 @@
+# OpenEnv Terminal-Bench-2 GRPO (GLM-4.7-Flash, single node)
+
+Train GLM-4.7-Flash with GRPO on the HuggingFace [OpenEnv](https://github.com/huggingface/openenv)
+**Terminal-Bench-2 (tbench2)** environment. A miles-side adapter runs the multi-turn
+agentic loop (`reset(task_id)` → { policy emits one shell command → `step(exec)` →
+feed output back } → `evaluate`) against an unmodified OpenEnv env server; the reward
+is the binary pytest result (1.0 = all tests pass, else 0.0).
+
+This guide targets a **single H200 node with 8 GPUs**. The run is colocated
+(training + rollout on the same 8 GPUs): TP=4, EP=2, one SGLang engine per GPU.
+
+## Prerequisites
+
+- The node has Docker available (the env server launches one container per task).
+- miles is installed and GLM-4.7-Flash weights are reachable (the launcher pulls
+  `zai-org/GLM-4.7-Flash` from HF and converts it to `torch_dist` on first run).
+- Install the OpenEnv tbench2 env client (isolate it if its deps clash with the
+  miles image):
+
+  ```bash
+  pip install -e <OpenEnv>/envs/tbench2_env
+  ```
+
+## 1. Build the prompt data
+
+Clone the TB2 suite and emit one prompt row per `task_id`:
+
+```bash
+git clone --depth 1 https://github.com/laude-institute/terminal-bench-2.git /workspace/terminal-bench-2
+python make_tbench2_data.py --tasks_dir /workspace/terminal-bench-2 --output /root/tbench2_train.jsonl
+# add --n 8 for a small smoke subset
+```
+
+## 2. Start the env server
+
+Run it in a separate shell (or off-node — see note). Docker mode gives real TB2
+fidelity; it needs the Docker socket and pulls the per-task images on first use:
+
+```bash
+TB2_MODE=docker TB2_TASKS_DIR=/workspace/terminal-bench-2 MAX_CONCURRENT_ENVS=32 \
+    python -m tbench2_env.server.app --port 8003
+```
+
+`MAX_CONCURRENT_ENVS` caps live sandboxes; keep it at or below the rollout batch
+concurrency. Per-task containers are heavy on disk — if you'd rather not colocate
+them with the GPU workload, run the env server on a separate Docker host and point
+the launcher at it via `--openenv-env-url http://<env-host>:8003`.
+
+## 3. Launch training
+
+```bash
+python run-openenv-tbench2.py --openenv-env-url http://localhost:8003
+```
+
+Common overrides:
+
+| Flag / env var | Default | Purpose |
+| --- | --- | --- |
+| `--openenv-env-url` | `http://localhost:8003` | Env server URL |
+| `--prompt-data` | `/root/tbench2_train.jsonl` | Prompt set from step 1 |
+| `--num-rollout` | (launcher) | Number of GRPO steps |
+| `OPENENV_MAX_TURNS` | `30` | Max agent turns per episode |
+| `OPENENV_MAX_ROLLOUT_TIME_SECONDS` | `3600` | Per-episode wall-clock cap; a straggler that exceeds it is terminated and scored 0 |
+| `--dump-details <dir>` | off | Dump per-episode tokens/logprobs/masks/reward for inspection |
+| `WANDB_KEY`, `--wandb-project`, `--wandb-team` | — | W&B logging |
+
+## Notes
+
+- **Reward signal.** The binary sparse reward needs a task subset where the base
+  policy *sometimes* succeeds (advantage variance). On the full TB2 suite,
+  GLM-4.7-Flash's low base solve-rate yields a near-flat GRPO signal — use a
+  variance-band subset (or a stronger base) to see a learning climb.
+- **`_step` vs. rollout.** W&B `_step` is an internal log-call index that advances
+  several times per rollout; it is **not** the training step. Read the driver log's
+  `rollout N:` counter for true progress.
+- **Sandbox leakage.** Upstream OpenEnv creates task containers with `remove=False`
+  and only tears them down on a clean session close (the idle reaper is off by
+  default), so an unclean disconnect (trainer crash) can orphan containers. Sweep
+  stale TB2 containers between runs, e.g. `docker rm -f` of any older than the
+  episode wall-cap.

--- a/examples/experimental/openenv/README.md
+++ b/examples/experimental/openenv/README.md
@@ -37,6 +37,10 @@ Run it in a separate shell (or off-node — see note). Docker mode gives real TB
 fidelity; it needs the Docker socket and pulls the per-task images on first use:
 
 ```bash
+# Raise the open-file limit first (see Notes): the WebSocket env server holds an
+# FD per live session + Docker connection and leaks sockets on unclean
+# disconnects, so the default 1024 soft limit is exhausted on a long run.
+ulimit -n 1048576
 TB2_MODE=docker TB2_TASKS_DIR=/workspace/terminal-bench-2 MAX_CONCURRENT_ENVS=32 \
     python -m tbench2_env.server.app --port 8003
 ```
@@ -78,3 +82,9 @@ Common overrides:
   default), so an unclean disconnect (trainer crash) can orphan containers. Sweep
   stale TB2 containers between runs, e.g. `docker rm -f` of any older than the
   episode wall-cap.
+- **Open-file limit.** The same unclean disconnects also leak socket FDs in the
+  env server process. On a long run under the default 1024 soft limit the accept
+  loop eventually fails every connection with `OSError: [Errno 24] Too many open
+  files`, silently throttling rollouts. Start the server with a raised limit
+  (`ulimit -n 1048576`, as in step 2); if a running server is already saturated,
+  restart it with the higher limit.

--- a/examples/experimental/openenv/make_tbench2_data.py
+++ b/examples/experimental/openenv/make_tbench2_data.py
@@ -1,6 +1,6 @@
 """Generate a prompt dataset for the OpenEnv Terminal-Bench-2 (tbench2) run.
 
-Unlike the coding/echo examples, the *tasks* are not hand-written: they are the
+The *tasks* are not hand-written: they are the
 Terminal-Bench-2 suite shipped in the laude-institute/terminal-bench-2 repo. The
 env serves the per-task instruction at reset(), so each prompt-data row only
 needs the system prompt (how the agent should behave) plus the ``task_id`` in

--- a/examples/experimental/openenv/make_tbench2_data.py
+++ b/examples/experimental/openenv/make_tbench2_data.py
@@ -1,0 +1,78 @@
+"""Generate a prompt dataset for the OpenEnv Terminal-Bench-2 (tbench2) run.
+
+Unlike the coding/echo examples, the *tasks* are not hand-written: they are the
+Terminal-Bench-2 suite shipped in the laude-institute/terminal-bench-2 repo. The
+env serves the per-task instruction at reset(), so each prompt-data row only
+needs the system prompt (how the agent should behave) plus the ``task_id`` in
+metadata. ``openenv_agent_function`` drives the multi-turn loop and reads
+metadata["task_id"].
+
+task_ids are the top-level task directory names in the TB2 repo checkout
+(e.g. "chess-best-move"); a valid task dir contains a ``task.toml``.
+
+    # all 89 tasks
+    python make_tbench2_data.py --tasks_dir /workspace/terminal-bench-2 \
+        --output /root/tbench2_train.jsonl
+    # a small smoke subset
+    python make_tbench2_data.py --tasks_dir /workspace/terminal-bench-2 \
+        --output /root/tbench2_smoke.jsonl --n 8
+    # an explicit subset
+    python make_tbench2_data.py --tasks_dir /workspace/terminal-bench-2 \
+        --tasks chess-best-move,circuit-fibsqrt
+"""
+
+import json
+from pathlib import Path
+
+from tap import Tap
+
+# The agent contract must match openenv_agent_function._multi_turn: one shell
+# command per turn inside a single ```bash block; TASK_COMPLETE to stop.
+_SYSTEM = (
+    "You are an autonomous terminal agent solving a Terminal-Bench task. You will "
+    "be given the task instruction, then interact with a real Linux shell. On each "
+    "turn respond with EXACTLY ONE shell command inside a single ```bash code block "
+    "and nothing else. Inspect the environment, make the required changes, and "
+    "verify your work. When you are confident the task is fully complete, reply with "
+    "TASK_COMPLETE (with no code block)."
+)
+
+
+class Args(Tap):
+    tasks_dir: str = "/workspace/terminal-bench-2"  # TB2 repo checkout
+    output: str = "/root/tbench2_train.jsonl"
+    n: int = 0  # 0 = all discovered tasks
+    tasks: str = ""  # optional comma-separated explicit task_ids
+
+
+def _discover_task_ids(tasks_dir: Path) -> list[str]:
+    return sorted(p.name for p in tasks_dir.iterdir() if (p / "task.toml").is_file())
+
+
+def main() -> None:
+    args = Args().parse_args()
+    tasks_dir = Path(args.tasks_dir).expanduser().resolve()
+
+    if args.tasks:
+        task_ids = [t.strip() for t in args.tasks.split(",") if t.strip()]
+    else:
+        task_ids = _discover_task_ids(tasks_dir)
+        if args.n > 0:
+            task_ids = task_ids[: args.n]
+
+    missing = [t for t in task_ids if not (tasks_dir / t / "task.toml").is_file()]
+    if missing:
+        raise SystemExit(f"task_ids without a task.toml in {tasks_dir}: {missing}")
+
+    with open(args.output, "w") as f:
+        for tid in task_ids:
+            row = {
+                "prompt": [{"role": "system", "content": _SYSTEM}],
+                "metadata": {"task_id": tid},
+            }
+            f.write(json.dumps(row) + "\n")
+    print(f"Wrote {len(task_ids)} TB2 tasks to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/experimental/openenv/openenv_agent_function.py
+++ b/examples/experimental/openenv/openenv_agent_function.py
@@ -110,6 +110,7 @@ def _parse_reward_marker(output: str) -> float:
                 return 0.0
     return 0.0
 
+
 # Per-message WS recv timeout. Docker-mode tbench2 reset (container create),
 # exec, and evaluate (pytest) each routinely exceed the EnvClient default of 60s.
 _MESSAGE_TIMEOUT_S = float(os.getenv("OPENENV_MESSAGE_TIMEOUT_S", "600"))
@@ -254,9 +255,7 @@ async def _multi_turn(
                 break
 
             t0 = time.monotonic()
-            step_result = await env.step(
-                action_cls(action_type="exec", command=_apply_workdir(command))
-            )
+            step_result = await env.step(action_cls(action_type="exec", command=_apply_workdir(command)))
             tool_times.append(time.monotonic() - t0)
             output = _obs_field(step_result, "output")
             # Feed the command output back as a user turn, not a tool turn. GLM
@@ -272,9 +271,7 @@ async def _multi_turn(
             convo.append({"role": "user", "content": content})
 
         t0 = time.monotonic()
-        eval_result = await env.step(
-            action_cls(action_type="exec", command=_CANONICAL_EVAL_CMD)
-        )
+        eval_result = await env.step(action_cls(action_type="exec", command=_CANONICAL_EVAL_CMD))
         eval_time = time.monotonic() - t0
         reward = _parse_reward_marker(_obs_field(eval_result, "output"))
 
@@ -306,9 +303,7 @@ async def _multi_turn(
 
         return reward, turns, gen_times, tool_times, reset_time, eval_time
 
-    reward, turns, gen_times, tool_times, reset_time, eval_time = await _with_env(
-        classes["env"], env_url, body
-    )
+    reward, turns, gen_times, tool_times, reset_time, eval_time = await _with_env(classes["env"], env_url, body)
     total_gen_time = sum(gen_times)
     # non_generation_time = everything the rollout spent outside policy generation:
     # per-turn exec latency plus the one-off reset() and evaluate() env steps. Feeds
@@ -351,16 +346,11 @@ async def run(
         # is interrupted and the env session is closed by _with_env's async-with
         # during cancellation cleanup.
         reward, agent_metrics = await asyncio.wait_for(
-            _multi_turn(
-                classes, env_url, policy, model_name, messages, request_kwargs, metadata
-            ),
+            _multi_turn(classes, env_url, policy, model_name, messages, request_kwargs, metadata),
             timeout=_MAX_ROLLOUT_TIME_S,
         )
     except asyncio.TimeoutError:
-        logger.warning(
-            f"OpenEnv tbench2 episode exceeded {_MAX_ROLLOUT_TIME_S:.0f}s; "
-            "terminating with reward 0"
-        )
+        logger.warning(f"OpenEnv tbench2 episode exceeded {_MAX_ROLLOUT_TIME_S:.0f}s; " "terminating with reward 0")
         # eval_report empty: the episode was cancelled before the canonical
         # eval ever ran, so there is no pytest report to surface.
         return {

--- a/examples/experimental/openenv/openenv_agent_function.py
+++ b/examples/experimental/openenv/openenv_agent_function.py
@@ -1,0 +1,597 @@
+"""OpenEnv Terminal-Bench-2 <-> miles adapter.
+
+miles selects the policy and calls ``run`` once per episode via
+``--custom-agent-function-path openenv_agent_function.run``. The episode drives
+the OpenEnv tbench2 env through an agentic loop (reset -> {policy -> exec} ->
+evaluate).
+
+The policy is always reached at ``base_url/v1`` through miles' session server,
+so token ids + logprobs + loss masks are captured natively (no re-tokenization)
+on every turn of the multi-turn episode.
+
+Env vars:
+  OPENENV_ENV_URL    base_url of the env server (default: http://localhost:8003).
+                     Ignored when OPENENV_DAYTONA_SNAPSHOT is set.
+  OPENENV_MAX_TURNS  multi-turn cap (default: 30)
+  OPENENV_MESSAGE_TIMEOUT_S  per-message WS recv timeout (default: 600; docker-mode
+                     reset/exec/pytest routinely exceed the client default of 60)
+  OPENENV_MAX_ROLLOUT_TIME_SECONDS  hard wall-clock cap for one episode (default:
+                     3600). An episode that does not return within the limit is
+                     terminated and scored reward 0 (bounds long-trajectory
+                     stragglers that would otherwise stall the whole rollout batch).
+  AGENT_MODEL_NAME   model name sent to the policy (default: "model")
+  MILES_ROUTER_EXTERNAL_HOST  optional host rewrite for off-cluster agents
+  OPENENV_TASK_WORKDIR  container dir every agent command + eval runs in (default:
+                     /app, the TB2 task image WORKDIR). Empty string disables the
+                     prefix. Needed because upstream OpenEnv defaults to /task.
+  OPENENV_TB2_TESTS_SRC  where the upstream env stages the task's tests inside the
+                     container (default: /task/tests); copied to /tests for test.sh.
+
+Daytona pool (optional; takes precedence over OPENENV_ENV_URL when set):
+  OPENENV_DAYTONA_SNAPSHOT      Daytona snapshot name to provision sandboxes from
+  OPENENV_DAYTONA_POOL_SIZE     # of long-lived sandboxes to spawn (default: 8)
+  OPENENV_DAYTONA_PORT          server port inside the sandbox (default: 8000)
+  DAYTONA_API_KEY               Daytona API key (required when SNAPSHOT is set)
+"""
+
+import asyncio
+import logging
+import os
+import random
+import re
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import urlparse, urlunparse
+
+import websockets.exceptions
+from openai import AsyncOpenAI
+
+logger = logging.getLogger(__name__)
+
+# Env slots are finite: hosted spaces admit one session at a time
+# (CAPACITY_REACHED) and the docker-mode tbench2 server caps concurrent envs
+# (MAX_CONCURRENT_ENVS), closing the WebSocket cleanly (ConnectionClosedOK) once
+# full. Both are transient -- episodes hold a slot only for their rollout -- so
+# jittered backoff + retry serializes the surplus rather than failing it.
+#
+# A rollout fans out more episodes than the server has slots (e.g. ~32 episodes
+# vs a 16-session cap), so a queued episode must outwait a full episode ahead of
+# it -- minutes, not seconds. The wait deadline is sized for that; the backoff
+# ceiling is wide enough that 16 queued episodes don't hammer the server with
+# reconnects while they wait.
+_CAPACITY_MAX_WAIT_S = 1800.0
+_CAPACITY_BACKOFF_S = (1.0, 5.0)
+
+# Strip a single fenced block: ```python / ```bash / ``` ... ```.
+_FENCE_RE = re.compile(r"```(?:python|py|bash|sh)?\s*\n?(.*?)```", re.DOTALL | re.IGNORECASE)
+
+# Max chars of command output fed back to the policy per turn (keeps context bounded).
+_OBS_CHAR_CAP = 4000
+
+# --- Adapter-driven Terminal-Bench-2 fidelity --------------------------------
+# Upstream OpenEnv's Tbench2DockerEnvironment runs the task container with workdir
+# /task (a copy of the task *source*) and scores via bare `pytest tests/` there.
+# Real TB2 tasks live at /app (the task image's WORKDIR) and are scored by the
+# task's canonical tests/test.sh, which pins the pytest toolchain, copies test.py
+# into /app, runs test_outputs.py, and writes the binary result to
+# /logs/verifier/reward.txt. We reproduce that faithfully from the adapter --
+# without patching OpenEnv or vendoring it -- by (a) running every agent command
+# in _TASK_WORKDIR and (b) driving the canonical harness through a plain `exec`
+# step instead of the env's built-in (non-canonical) `evaluate` action.
+#
+# This assumes the env server is UNMODIFIED upstream, which copies the task dir
+# (tests included) into the container at _TB2_TESTS_SRC.
+_TASK_WORKDIR = os.getenv("OPENENV_TASK_WORKDIR", "/app")
+_TB2_TESTS_SRC = os.getenv("OPENENV_TB2_TESTS_SRC", "/task/tests")
+
+# The eval exec echoes reward.txt on this marker so we can parse it out of stdout.
+_REWARD_MARKER = "__TB2_REWARD__:"
+# Honor an empty _TASK_WORKDIR (workdir prefix disabled) the same way
+# _apply_workdir does, instead of silently forcing /app.
+_EVAL_CD_CMD = f"cd {_TASK_WORKDIR} && " if _TASK_WORKDIR else ""
+_CANONICAL_EVAL_CMD = (
+    # rm the reward file first so a stale one can never be read back if test.sh
+    # fails to run (e.g. in a reused sandbox where /logs survives across episodes).
+    "mkdir -p /tests /logs/verifier && rm -f /logs/verifier/reward.txt && "
+    f"cp -a {_TB2_TESTS_SRC}/. /tests/ 2>/dev/null || true; "
+    f"{_EVAL_CD_CMD}bash /tests/test.sh > /tmp/tb2_testsh.log 2>&1; "
+    f"echo {_REWARD_MARKER}$(cat /logs/verifier/reward.txt 2>/dev/null)"
+)
+
+
+def _apply_workdir(command: str) -> str:
+    """Prefix an agent command so it runs in the real task workdir (/app)."""
+    if not _TASK_WORKDIR:
+        return command
+    return f"cd {_TASK_WORKDIR} && {command}"
+
+
+def _parse_reward_marker(output: str) -> float:
+    """Parse the reward.txt value the canonical-eval exec echoed on its marker line."""
+    for line in output.splitlines()[::-1]:
+        if _REWARD_MARKER in line:
+            raw = line.split(_REWARD_MARKER, 1)[1].strip()
+            try:
+                return float(raw) if raw else 0.0
+            except ValueError:
+                return 0.0
+    return 0.0
+
+# Per-message WS recv timeout. Docker-mode tbench2 reset (container create),
+# exec, and evaluate (pytest) each routinely exceed the EnvClient default of 60s.
+_MESSAGE_TIMEOUT_S = float(os.getenv("OPENENV_MESSAGE_TIMEOUT_S", "600"))
+
+# Hard wall-clock cap for one episode. The per-message timeout above bounds a
+# single env op, and OPENENV_MAX_TURNS bounds the turn count, but neither bounds
+# total episode time: a long agentic trajectory can loop for turns * (long
+# generation) and stall the whole rollout batch (a step finishes only when the
+# slowest of all concurrent episodes returns). An episode exceeding this cap is
+# terminated (its coroutine cancelled) and scored reward 0.
+_MAX_ROLLOUT_TIME_S = float(os.getenv("OPENENV_MAX_ROLLOUT_TIME_SECONDS", "3600"))
+
+
+def _is_retryable_env_error(e: BaseException) -> bool:
+    """True when an env op failed only because no env slot was free (transient).
+
+    The docker-mode tbench2 server caps concurrent envs; over that cap it either
+    returns CAPACITY_REACHED or closes the WebSocket cleanly (ConnectionClosedOK).
+    Both mean "retry once a slot frees up", not a genuine episode failure. Match
+    the close exceptions by class name so the adapter need not import websockets.
+    """
+    if "CAPACITY_REACHED" in str(e):
+        return True
+    return type(e).__name__ in {"ConnectionClosedOK", "ConnectionClosedError", "ConnectionClosed"}
+
+
+def _resolve_session_url(base_url: str) -> str:
+    """Build the OpenAI-compatible policy URL, rewriting host for off-cluster agents."""
+    session_url = f"{base_url}/v1"
+    external_host = os.getenv("MILES_ROUTER_EXTERNAL_HOST")
+    if external_host:
+        parsed = urlparse(session_url)
+        netloc = f"{external_host}:{parsed.port}" if parsed.port else external_host
+        session_url = urlunparse(parsed._replace(netloc=netloc))
+    return session_url
+
+
+def _extract_messages(prompt: Any) -> list[dict[str, str]]:
+    """Accept either a chat-message list or a raw string prompt."""
+    if isinstance(prompt, list):
+        return list(prompt)
+    return [{"role": "user", "content": str(prompt)}]
+
+
+def _strip_fence(text: str) -> str:
+    """Return the contents of a single fenced block, else the stripped text."""
+    match = _FENCE_RE.search(text)
+    if match:
+        return match.group(1).strip()
+    return text.strip()
+
+
+def _obs_field(result: Any, name: str) -> str:
+    """Read an Observation field off a StepResult, tolerating shape differences."""
+    obs = getattr(result, "observation", result)
+    return str(getattr(obs, name, "") or "")
+
+
+# Lazy import so the file loads without the env client present at import time.
+def _load_tbench2() -> dict[str, Any]:
+    from tbench2_env import Tbench2Action, Tbench2Env
+
+    return {"env": Tbench2Env, "action": Tbench2Action}
+
+
+_DEFAULT_ENV_URL = "http://localhost:8003"
+
+
+# ---- Daytona sandbox pool (per-process singleton) ---------------------------
+#
+# When OPENENV_DAYTONA_SNAPSHOT is set, the adapter provisions a pool of N
+# long-lived Daytona sandboxes (one DaytonaProvider per sandbox) on first use
+# and rotates episodes across them through an asyncio.Queue. Episodes acquire a
+# slot, run reset() -> step() -> evaluate(), then release. Concurrency is capped
+# by the queue depth, so a rollout fan-out of 64 episodes onto a 64-slot pool
+# runs without queueing.
+#
+# When the env var is unset the legacy code path runs (single OPENENV_ENV_URL
+# host shared by all episodes), preserving the off-cluster manual-URL flow.
+_POOL_PROVISION_TIMEOUT_S = float(os.getenv("OPENENV_DAYTONA_PROVISION_TIMEOUT_S", "600"))
+_POOL_READY_TIMEOUT_S = float(os.getenv("OPENENV_DAYTONA_READY_TIMEOUT_S", "300"))
+# Daytona rate-limits sandbox creation (ThrottlerException: Too Many Requests).
+# Firing every create in a large pool at once trips it and, with no backoff,
+# fails the whole pool. Cap in-flight creates and retry throttled ones with
+# jittered exponential backoff so a wide (e.g. 64-slot) pool still comes up.
+_POOL_PROVISION_CONCURRENCY = int(os.getenv("OPENENV_DAYTONA_PROVISION_CONCURRENCY", "8"))
+_POOL_PROVISION_MAX_RETRIES = int(os.getenv("OPENENV_DAYTONA_PROVISION_MAX_RETRIES", "8"))
+_POOL_PROVISION_BACKOFF_BASE_S = float(os.getenv("OPENENV_DAYTONA_PROVISION_BACKOFF_BASE_S", "2.0"))
+_POOL_PROVISION_BACKOFF_CAP_S = float(os.getenv("OPENENV_DAYTONA_PROVISION_BACKOFF_CAP_S", "30.0"))
+
+
+def _is_connection_error(exc: BaseException) -> bool:
+    # OpenEnv's EnvClient.connect normalizes every handshake failure (refused,
+    # timeout, HTTP 502 / rejected websocket) to a builtin ConnectionError;
+    # a mid-stream drop surfaces as websockets' ConnectionClosedError from
+    # recv/send. ConnectionClosedOK (clean 1000 close) is deliberately excluded.
+    return isinstance(exc, (ConnectionError, websockets.exceptions.ConnectionClosedError))
+
+
+def _is_throttle_error(exc: BaseException) -> bool:
+    s = str(exc).lower()
+    return "throttler" in s or "too many requests" in s or "429" in s
+
+
+@dataclass
+class _DaytonaSlot:
+    provider: Any
+    url: str
+
+
+class _DaytonaPool:
+    """Process-wide pool of provisioned Daytona sandboxes."""
+
+    _instance: "_DaytonaPool | None" = None
+
+    def __init__(self, snapshot: str, api_key: str, size: int, port: int = 8000):
+        self._snapshot = snapshot
+        self._api_key = api_key
+        self._size = size
+        self._port = port
+        self._queue: asyncio.Queue[_DaytonaSlot] | None = None
+        self._slots: list[_DaytonaSlot] = []
+        self._init_lock = asyncio.Lock()
+        self._replace_tasks: set[asyncio.Task] = set()
+
+    @classmethod
+    def maybe(cls) -> "_DaytonaPool | None":
+        """Return the singleton pool if env vars say to use one, else None."""
+        snapshot = os.getenv("OPENENV_DAYTONA_SNAPSHOT", "").strip()
+        if not snapshot:
+            return None
+        if cls._instance is None:
+            api_key = os.environ["DAYTONA_API_KEY"]
+            size = int(os.getenv("OPENENV_DAYTONA_POOL_SIZE", "8"))
+            port = int(os.getenv("OPENENV_DAYTONA_PORT", "8000"))
+            cls._instance = cls(snapshot=snapshot, api_key=api_key, size=size, port=port)
+        return cls._instance
+
+    async def _ensure_provisioned(self) -> None:
+        if self._queue is not None:
+            return
+        async with self._init_lock:
+            if self._queue is not None:
+                return
+            logger.info(
+                f"Provisioning {self._size} Daytona sandboxes from snapshot:{self._snapshot} "
+                f"(concurrency={_POOL_PROVISION_CONCURRENCY})"
+            )
+            sem = asyncio.Semaphore(_POOL_PROVISION_CONCURRENCY)
+            results = await asyncio.gather(
+                *(self._spawn_one(i, sem) for i in range(self._size)),
+                return_exceptions=True,
+            )
+            slots: list[_DaytonaSlot] = []
+            for i, r in enumerate(results):
+                if isinstance(r, BaseException):
+                    logger.error(f"Daytona slot {i} failed to provision: {r}")
+                    continue
+                slots.append(r)
+            if not slots:
+                raise RuntimeError("Failed to provision any Daytona sandboxes")
+            queue: asyncio.Queue[_DaytonaSlot] = asyncio.Queue(maxsize=len(slots))
+            for slot in slots:
+                queue.put_nowait(slot)
+            self._queue = queue
+            self._slots = slots
+            logger.info(f"Daytona pool ready: {len(slots)} / {self._size} slots online")
+
+    async def _spawn_one(self, idx: int, sem: asyncio.Semaphore) -> _DaytonaSlot:
+        from openenv.core.containers.runtime.daytona_provider import DaytonaProvider
+
+        def _start() -> tuple[Any, str]:
+            provider = DaytonaProvider(api_key=self._api_key, auto_stop_interval=0)
+            url = provider.start_container(image=f"snapshot:{self._snapshot}", port=self._port)
+            provider.wait_for_ready(url, timeout_s=_POOL_READY_TIMEOUT_S)
+            return provider, url
+
+        attempt = 0
+        while True:
+            try:
+                # Hold the semaphore only for the create attempt; release it
+                # during backoff so other slots keep the pipeline full.
+                async with sem:
+                    provider, url = await asyncio.wait_for(
+                        asyncio.to_thread(_start), timeout=_POOL_PROVISION_TIMEOUT_S
+                    )
+                logger.info(f"Daytona slot {idx}: {url}")
+                return _DaytonaSlot(provider=provider, url=url)
+            except Exception as e:
+                if not _is_throttle_error(e) or attempt >= _POOL_PROVISION_MAX_RETRIES:
+                    raise
+                attempt += 1
+                delay = min(
+                    _POOL_PROVISION_BACKOFF_CAP_S,
+                    _POOL_PROVISION_BACKOFF_BASE_S * (2 ** (attempt - 1)),
+                ) * (0.5 + random.random())
+                logger.warning(
+                    f"Daytona slot {idx} throttled (attempt {attempt}/"
+                    f"{_POOL_PROVISION_MAX_RETRIES}); retrying in {delay:.1f}s"
+                )
+                await asyncio.sleep(delay)
+
+    async def acquire(self) -> _DaytonaSlot:
+        await self._ensure_provisioned()
+        assert self._queue is not None
+        return await self._queue.get()
+
+    async def release(self, slot: _DaytonaSlot) -> None:
+        assert self._queue is not None
+        self._queue.put_nowait(slot)
+
+    def replace_broken(self, slot: _DaytonaSlot) -> None:
+        logger.warning(f"Daytona slot {slot.url} marked broken; replacing in background")
+        task = asyncio.create_task(self._replace(slot))
+        self._replace_tasks.add(task)
+        task.add_done_callback(self._replace_tasks.discard)
+
+    async def _replace(self, slot: _DaytonaSlot) -> None:
+        try:
+            await asyncio.to_thread(slot.provider.stop_container)
+        except Exception as e:
+            logger.warning(f"Failed to stop broken sandbox {slot.url}: {e}")
+        if slot in self._slots:
+            self._slots.remove(slot)
+        try:
+            new_slot = await self._spawn_one(-1, asyncio.Semaphore(1))
+        except Exception as e:
+            logger.error(f"Failed to replace broken Daytona slot ({slot.url}): {e}")
+            return
+        self._slots.append(new_slot)
+        assert self._queue is not None
+        self._queue.put_nowait(new_slot)
+        logger.info(f"Daytona slot replaced: {slot.url} -> {new_slot.url}")
+
+    async def teardown(self) -> None:
+        # Cancel in-flight replacements first: a task still awaiting _spawn_one
+        # would otherwise enqueue a sandbox after teardown and leak it.
+        try:
+            for task in list(self._replace_tasks):
+                task.cancel()
+            if self._replace_tasks:
+                await asyncio.gather(*self._replace_tasks, return_exceptions=True)
+        finally:
+            for slot in self._slots:
+                try:
+                    await asyncio.to_thread(slot.provider.stop_container)
+                except Exception as e:
+                    logger.warning(f"Failed to stop sandbox {slot.url}: {e}")
+
+
+async def _with_env(env_cls: Any, env_url: str, body: Callable[[Any], Any]) -> Any:
+    """Open an env session and run ``body(env)``, retrying while a slot is busy.
+
+    If OPENENV_DAYTONA_SNAPSHOT is set, the sandbox URL is checked out from a
+    process-wide pool; otherwise the shared ``env_url`` is used directly.
+    """
+    pool = _DaytonaPool.maybe()
+    if pool is not None:
+        slot = await pool.acquire()
+        broken = False
+        try:
+            async with env_cls(base_url=slot.url, message_timeout_s=_MESSAGE_TIMEOUT_S) as env:
+                return await body(env)
+        except BaseException as e:
+            broken = _is_connection_error(e)
+            raise
+        finally:
+            if broken:
+                pool.replace_broken(slot)
+            else:
+                await pool.release(slot)
+
+    deadline = asyncio.get_event_loop().time() + _CAPACITY_MAX_WAIT_S
+    while True:
+        try:
+            async with env_cls(base_url=env_url, message_timeout_s=_MESSAGE_TIMEOUT_S) as env:
+                return await body(env)
+        except Exception as e:
+            if _is_retryable_env_error(e) and asyncio.get_event_loop().time() < deadline:
+                await asyncio.sleep(random.uniform(*_CAPACITY_BACKOFF_S))
+                continue
+            raise
+
+
+async def _multi_turn(
+    classes: dict[str, Any],
+    env_url: str,
+    policy: AsyncOpenAI,
+    model_name: str,
+    messages: list[dict[str, str]],
+    request_kwargs: dict[str, Any],
+    metadata: dict[str, Any],
+) -> tuple[float, dict[str, Any]]:
+    """Agentic loop: reset(task) -> {policy -> exec -> feed output back} -> evaluate (tbench2).
+
+    The policy emits one shell command per turn (a ```bash block or the bare
+    reply), executed in the real task workdir (_TASK_WORKDIR, /app); the loop ends
+    when the policy stops emitting a command, says TASK_COMPLETE, or hits
+    OPENENV_MAX_TURNS. Scoring runs the task's canonical tests/test.sh via an
+    ``exec`` step and parses /logs/verifier/reward.txt for the binary reward
+    (faithful to Terminal-Bench-2, and needs no OpenEnv-side changes).
+    """
+    action_cls = classes["action"]
+    task_id = metadata.get("task_id") or metadata.get("task_name")
+    max_turns = int(os.getenv("OPENENV_MAX_TURNS", "30"))
+
+    async def body(env: Any) -> tuple[float, int, list[float], list[float], float, float]:
+        # Per-turn wall-clock timings. gen_times[i] is turn i's policy generation
+        # latency; tool_times[i] is turn i's env.step(exec) latency. reset_time and
+        # eval_time bracket the one-off reset() and the final evaluate() env steps.
+        gen_times: list[float] = []
+        tool_times: list[float] = []
+
+        t0 = time.monotonic()
+        reset_result = await (env.reset(task_id=task_id) if task_id else env.reset())
+        reset_time = time.monotonic() - t0
+        instruction = _obs_field(reset_result, "instruction")
+        convo = list(messages)
+        if instruction:
+            convo.append({"role": "user", "content": instruction})
+
+        turns = 0
+        while turns < max_turns:
+            turns += 1
+            t0 = time.monotonic()
+            completion = await policy.chat.completions.create(
+                model=model_name, messages=convo, extra_body=request_kwargs
+            )
+            gen_times.append(time.monotonic() - t0)
+            message = completion.choices[0].message
+            reply = message.content or ""
+            # Echo the assistant turn back verbatim. The session server stores the
+            # message exactly as SGLang emitted it -- content plus reasoning_content
+            # and tool_calls split out by the reasoning/tool-call parsers -- and
+            # matches each later request against that stored prefix. A thin
+            # {role, content} dict drops reasoning_content/tool_calls, diverges at
+            # the assistant turn, and trips "rollback failed: no assistant message
+            # in matched prefix". model_dump round-trips whatever the SDK parsed
+            # (extras like reasoning_content included).
+            convo.append(message.model_dump(exclude_none=True))
+
+            command = _strip_fence(reply) if "```" in reply else reply.strip()
+            if not command or command.upper().startswith("TASK_COMPLETE"):
+                break
+
+            t0 = time.monotonic()
+            step_result = await env.step(
+                action_cls(action_type="exec", command=_apply_workdir(command))
+            )
+            tool_times.append(time.monotonic() - t0)
+            output = _obs_field(step_result, "output")
+            # Feed the command output back as a user turn, not a tool turn. GLM
+            # emits native tool_calls that we must echo verbatim (above) for the
+            # session server's prefix match; a role="tool" reply would then have
+            # to carry a matching tool_call_id and trips OpenAI tool-call
+            # validation. A plain user turn sidesteps the handshake -- the same
+            # text protocol the Harbor mini-swe-agent scaffold uses.
+            #
+            # Substitute a placeholder when a command produces no stdout: SGLang
+            # rejects an empty message content with "content cannot be empty".
+            content = output[:_OBS_CHAR_CAP] or "(no output)"
+            convo.append({"role": "user", "content": content})
+
+        t0 = time.monotonic()
+        eval_result = await env.step(
+            action_cls(action_type="exec", command=_CANONICAL_EVAL_CMD)
+        )
+        eval_time = time.monotonic() - t0
+        reward = _parse_reward_marker(_obs_field(eval_result, "output"))
+
+        # rm-hack: the tbench2 env server (TB2_OUTPUT_DIR=/tmp/tbench2_env_runs)
+        # leaves a per-episode trial dir under that path after every episode, which
+        # fills the sandbox overlay disk and trips ENOSPC. One episode holds the
+        # sandbox at a time, so it is safe to purge them here.
+        #
+        # BUT the same dir also holds repo_cache/ (TB2_CACHE_DIR defaults to
+        # output_dir/repo_cache) -- the shared terminal-bench-2 checkout that
+        # reset() clones once and every later episode reads its task from
+        # (repo_cache/terminal-bench-2-main/<task>). A blanket `rm -rf .../*` wiped
+        # repo_cache too, so on a pooled/reused sandbox every episode after the first
+        # either re-cloned the whole repo (huge) or raced into "Task path not found",
+        # collapsing effective concurrency and exploding step time. Preserve
+        # repo_cache; delete only the ephemeral per-trial dirs beside it.
+        try:
+            await env.step(
+                action_cls(
+                    action_type="exec",
+                    command=(
+                        "find /tmp/tbench2_env_runs -mindepth 1 -maxdepth 1 "
+                        "! -name repo_cache -exec rm -rf {} + 2>/dev/null || true"
+                    ),
+                )
+            )
+        except Exception:
+            pass
+
+        return reward, turns, gen_times, tool_times, reset_time, eval_time
+
+    reward, turns, gen_times, tool_times, reset_time, eval_time = await _with_env(
+        classes["env"], env_url, body
+    )
+    total_gen_time = sum(gen_times)
+    # non_generation_time = everything the rollout spent outside policy generation:
+    # per-turn exec latency plus the one-off reset() and evaluate() env steps. Feeds
+    # Sample.non_generation_time so miles' throughput accounting subtracts env time.
+    total_tool_time = sum(tool_times) + reset_time + eval_time
+    return reward, {
+        "turns": turns,
+        "tool_calls": len(tool_times),
+        "gen_times": gen_times,
+        "tool_times": tool_times,
+        "reset_time": reset_time,
+        "eval_time": eval_time,
+        "total_gen_time": total_gen_time,
+        "total_tool_time": total_tool_time,
+    }
+
+
+async def run(
+    base_url: str,
+    prompt: Any,
+    request_kwargs: dict[str, Any] | None = None,
+    metadata: dict[str, Any] | None = None,
+    **kwargs,
+) -> dict[str, Any] | None:
+    """Run one OpenEnv tbench2 episode via the trained policy."""
+    request_kwargs = request_kwargs or {}
+    metadata = metadata or {}
+
+    classes = _load_tbench2()
+    session_url = _resolve_session_url(base_url)
+    model_name = os.getenv("AGENT_MODEL_NAME", os.getenv("SWE_AGENT_MODEL_NAME", "model"))
+    env_url = os.getenv("OPENENV_ENV_URL", _DEFAULT_ENV_URL)
+
+    policy = AsyncOpenAI(base_url=session_url, api_key="EMPTY")
+    messages = _extract_messages(prompt)
+
+    try:
+        # Hard wall-clock cap: cancel the episode if it overruns and score it 0.
+        # wait_for cancels the coroutine, so any in-flight policy call / env.step
+        # is interrupted and the pooled sandbox slot is released by _with_env's
+        # finally block during cancellation cleanup.
+        reward, agent_metrics = await asyncio.wait_for(
+            _multi_turn(
+                classes, env_url, policy, model_name, messages, request_kwargs, metadata
+            ),
+            timeout=_MAX_ROLLOUT_TIME_S,
+        )
+    except asyncio.TimeoutError:
+        logger.warning(
+            f"OpenEnv tbench2 episode exceeded {_MAX_ROLLOUT_TIME_S:.0f}s; "
+            "terminating with reward 0"
+        )
+        # eval_report empty: the episode was cancelled before the canonical
+        # eval ever ran, so there is no pytest report to surface.
+        return {
+            "reward": 0.0,
+            "exit_status": "timeout",
+            "eval_report": {},
+            "agent_metrics": {"timed_out": 1},
+        }
+    except Exception as e:
+        logger.error(f"OpenEnv tbench2 episode failed: {e}", exc_info=True)
+        return None
+
+    # eval_report is intentionally empty: the canonical-eval marker protocol
+    # (see _REWARD_MARKER) echoes back only the scalar reward. The detailed
+    # pytest CTRF report is written inside the sandbox at
+    # /logs/verifier/ctrf.json and is deliberately not captured back to the
+    # trainer, which consumes only `reward`.
+    return {
+        "reward": reward,
+        "exit_status": "completed",
+        "eval_report": {},
+        "agent_metrics": agent_metrics,
+    }

--- a/examples/experimental/openenv/openenv_agent_function.py
+++ b/examples/experimental/openenv/openenv_agent_function.py
@@ -11,7 +11,6 @@ on every turn of the multi-turn episode.
 
 Env vars:
   OPENENV_ENV_URL    base_url of the env server (default: http://localhost:8003).
-                     Ignored when OPENENV_DAYTONA_SNAPSHOT is set.
   OPENENV_MAX_TURNS  multi-turn cap (default: 30)
   OPENENV_MESSAGE_TIMEOUT_S  per-message WS recv timeout (default: 600; docker-mode
                      reset/exec/pytest routinely exceed the client default of 60)
@@ -26,12 +25,6 @@ Env vars:
                      prefix. Needed because upstream OpenEnv defaults to /task.
   OPENENV_TB2_TESTS_SRC  where the upstream env stages the task's tests inside the
                      container (default: /task/tests); copied to /tests for test.sh.
-
-Daytona pool (optional; takes precedence over OPENENV_ENV_URL when set):
-  OPENENV_DAYTONA_SNAPSHOT      Daytona snapshot name to provision sandboxes from
-  OPENENV_DAYTONA_POOL_SIZE     # of long-lived sandboxes to spawn (default: 8)
-  OPENENV_DAYTONA_PORT          server port inside the sandbox (default: 8000)
-  DAYTONA_API_KEY               Daytona API key (required when SNAPSHOT is set)
 """
 
 import asyncio
@@ -41,11 +34,9 @@ import random
 import re
 import time
 from collections.abc import Callable
-from dataclasses import dataclass
 from typing import Any
 from urllib.parse import urlparse, urlunparse
 
-import websockets.exceptions
 from openai import AsyncOpenAI
 
 logger = logging.getLogger(__name__)
@@ -187,210 +178,8 @@ def _load_tbench2() -> dict[str, Any]:
 _DEFAULT_ENV_URL = "http://localhost:8003"
 
 
-# ---- Daytona sandbox pool (per-process singleton) ---------------------------
-#
-# When OPENENV_DAYTONA_SNAPSHOT is set, the adapter provisions a pool of N
-# long-lived Daytona sandboxes (one DaytonaProvider per sandbox) on first use
-# and rotates episodes across them through an asyncio.Queue. Episodes acquire a
-# slot, run reset() -> step() -> evaluate(), then release. Concurrency is capped
-# by the queue depth, so a rollout fan-out of 64 episodes onto a 64-slot pool
-# runs without queueing.
-#
-# When the env var is unset the legacy code path runs (single OPENENV_ENV_URL
-# host shared by all episodes), preserving the off-cluster manual-URL flow.
-_POOL_PROVISION_TIMEOUT_S = float(os.getenv("OPENENV_DAYTONA_PROVISION_TIMEOUT_S", "600"))
-_POOL_READY_TIMEOUT_S = float(os.getenv("OPENENV_DAYTONA_READY_TIMEOUT_S", "300"))
-# Daytona rate-limits sandbox creation (ThrottlerException: Too Many Requests).
-# Firing every create in a large pool at once trips it and, with no backoff,
-# fails the whole pool. Cap in-flight creates and retry throttled ones with
-# jittered exponential backoff so a wide (e.g. 64-slot) pool still comes up.
-_POOL_PROVISION_CONCURRENCY = int(os.getenv("OPENENV_DAYTONA_PROVISION_CONCURRENCY", "8"))
-_POOL_PROVISION_MAX_RETRIES = int(os.getenv("OPENENV_DAYTONA_PROVISION_MAX_RETRIES", "8"))
-_POOL_PROVISION_BACKOFF_BASE_S = float(os.getenv("OPENENV_DAYTONA_PROVISION_BACKOFF_BASE_S", "2.0"))
-_POOL_PROVISION_BACKOFF_CAP_S = float(os.getenv("OPENENV_DAYTONA_PROVISION_BACKOFF_CAP_S", "30.0"))
-
-
-def _is_connection_error(exc: BaseException) -> bool:
-    # OpenEnv's EnvClient.connect normalizes every handshake failure (refused,
-    # timeout, HTTP 502 / rejected websocket) to a builtin ConnectionError;
-    # a mid-stream drop surfaces as websockets' ConnectionClosedError from
-    # recv/send. ConnectionClosedOK (clean 1000 close) is deliberately excluded.
-    return isinstance(exc, (ConnectionError, websockets.exceptions.ConnectionClosedError))
-
-
-def _is_throttle_error(exc: BaseException) -> bool:
-    s = str(exc).lower()
-    return "throttler" in s or "too many requests" in s or "429" in s
-
-
-@dataclass
-class _DaytonaSlot:
-    provider: Any
-    url: str
-
-
-class _DaytonaPool:
-    """Process-wide pool of provisioned Daytona sandboxes."""
-
-    _instance: "_DaytonaPool | None" = None
-
-    def __init__(self, snapshot: str, api_key: str, size: int, port: int = 8000):
-        self._snapshot = snapshot
-        self._api_key = api_key
-        self._size = size
-        self._port = port
-        self._queue: asyncio.Queue[_DaytonaSlot] | None = None
-        self._slots: list[_DaytonaSlot] = []
-        self._init_lock = asyncio.Lock()
-        self._replace_tasks: set[asyncio.Task] = set()
-
-    @classmethod
-    def maybe(cls) -> "_DaytonaPool | None":
-        """Return the singleton pool if env vars say to use one, else None."""
-        snapshot = os.getenv("OPENENV_DAYTONA_SNAPSHOT", "").strip()
-        if not snapshot:
-            return None
-        if cls._instance is None:
-            api_key = os.environ["DAYTONA_API_KEY"]
-            size = int(os.getenv("OPENENV_DAYTONA_POOL_SIZE", "8"))
-            port = int(os.getenv("OPENENV_DAYTONA_PORT", "8000"))
-            cls._instance = cls(snapshot=snapshot, api_key=api_key, size=size, port=port)
-        return cls._instance
-
-    async def _ensure_provisioned(self) -> None:
-        if self._queue is not None:
-            return
-        async with self._init_lock:
-            if self._queue is not None:
-                return
-            logger.info(
-                f"Provisioning {self._size} Daytona sandboxes from snapshot:{self._snapshot} "
-                f"(concurrency={_POOL_PROVISION_CONCURRENCY})"
-            )
-            sem = asyncio.Semaphore(_POOL_PROVISION_CONCURRENCY)
-            results = await asyncio.gather(
-                *(self._spawn_one(i, sem) for i in range(self._size)),
-                return_exceptions=True,
-            )
-            slots: list[_DaytonaSlot] = []
-            for i, r in enumerate(results):
-                if isinstance(r, BaseException):
-                    logger.error(f"Daytona slot {i} failed to provision: {r}")
-                    continue
-                slots.append(r)
-            if not slots:
-                raise RuntimeError("Failed to provision any Daytona sandboxes")
-            queue: asyncio.Queue[_DaytonaSlot] = asyncio.Queue(maxsize=len(slots))
-            for slot in slots:
-                queue.put_nowait(slot)
-            self._queue = queue
-            self._slots = slots
-            logger.info(f"Daytona pool ready: {len(slots)} / {self._size} slots online")
-
-    async def _spawn_one(self, idx: int, sem: asyncio.Semaphore) -> _DaytonaSlot:
-        from openenv.core.containers.runtime.daytona_provider import DaytonaProvider
-
-        def _start() -> tuple[Any, str]:
-            provider = DaytonaProvider(api_key=self._api_key, auto_stop_interval=0)
-            url = provider.start_container(image=f"snapshot:{self._snapshot}", port=self._port)
-            provider.wait_for_ready(url, timeout_s=_POOL_READY_TIMEOUT_S)
-            return provider, url
-
-        attempt = 0
-        while True:
-            try:
-                # Hold the semaphore only for the create attempt; release it
-                # during backoff so other slots keep the pipeline full.
-                async with sem:
-                    provider, url = await asyncio.wait_for(
-                        asyncio.to_thread(_start), timeout=_POOL_PROVISION_TIMEOUT_S
-                    )
-                logger.info(f"Daytona slot {idx}: {url}")
-                return _DaytonaSlot(provider=provider, url=url)
-            except Exception as e:
-                if not _is_throttle_error(e) or attempt >= _POOL_PROVISION_MAX_RETRIES:
-                    raise
-                attempt += 1
-                delay = min(
-                    _POOL_PROVISION_BACKOFF_CAP_S,
-                    _POOL_PROVISION_BACKOFF_BASE_S * (2 ** (attempt - 1)),
-                ) * (0.5 + random.random())
-                logger.warning(
-                    f"Daytona slot {idx} throttled (attempt {attempt}/"
-                    f"{_POOL_PROVISION_MAX_RETRIES}); retrying in {delay:.1f}s"
-                )
-                await asyncio.sleep(delay)
-
-    async def acquire(self) -> _DaytonaSlot:
-        await self._ensure_provisioned()
-        assert self._queue is not None
-        return await self._queue.get()
-
-    async def release(self, slot: _DaytonaSlot) -> None:
-        assert self._queue is not None
-        self._queue.put_nowait(slot)
-
-    def replace_broken(self, slot: _DaytonaSlot) -> None:
-        logger.warning(f"Daytona slot {slot.url} marked broken; replacing in background")
-        task = asyncio.create_task(self._replace(slot))
-        self._replace_tasks.add(task)
-        task.add_done_callback(self._replace_tasks.discard)
-
-    async def _replace(self, slot: _DaytonaSlot) -> None:
-        try:
-            await asyncio.to_thread(slot.provider.stop_container)
-        except Exception as e:
-            logger.warning(f"Failed to stop broken sandbox {slot.url}: {e}")
-        if slot in self._slots:
-            self._slots.remove(slot)
-        try:
-            new_slot = await self._spawn_one(-1, asyncio.Semaphore(1))
-        except Exception as e:
-            logger.error(f"Failed to replace broken Daytona slot ({slot.url}): {e}")
-            return
-        self._slots.append(new_slot)
-        assert self._queue is not None
-        self._queue.put_nowait(new_slot)
-        logger.info(f"Daytona slot replaced: {slot.url} -> {new_slot.url}")
-
-    async def teardown(self) -> None:
-        # Cancel in-flight replacements first: a task still awaiting _spawn_one
-        # would otherwise enqueue a sandbox after teardown and leak it.
-        try:
-            for task in list(self._replace_tasks):
-                task.cancel()
-            if self._replace_tasks:
-                await asyncio.gather(*self._replace_tasks, return_exceptions=True)
-        finally:
-            for slot in self._slots:
-                try:
-                    await asyncio.to_thread(slot.provider.stop_container)
-                except Exception as e:
-                    logger.warning(f"Failed to stop sandbox {slot.url}: {e}")
-
-
 async def _with_env(env_cls: Any, env_url: str, body: Callable[[Any], Any]) -> Any:
-    """Open an env session and run ``body(env)``, retrying while a slot is busy.
-
-    If OPENENV_DAYTONA_SNAPSHOT is set, the sandbox URL is checked out from a
-    process-wide pool; otherwise the shared ``env_url`` is used directly.
-    """
-    pool = _DaytonaPool.maybe()
-    if pool is not None:
-        slot = await pool.acquire()
-        broken = False
-        try:
-            async with env_cls(base_url=slot.url, message_timeout_s=_MESSAGE_TIMEOUT_S) as env:
-                return await body(env)
-        except BaseException as e:
-            broken = _is_connection_error(e)
-            raise
-        finally:
-            if broken:
-                pool.replace_broken(slot)
-            else:
-                await pool.release(slot)
-
+    """Open an env session and run ``body(env)``, retrying while a slot is busy."""
     deadline = asyncio.get_event_loop().time() + _CAPACITY_MAX_WAIT_S
     while True:
         try:
@@ -559,8 +348,8 @@ async def run(
     try:
         # Hard wall-clock cap: cancel the episode if it overruns and score it 0.
         # wait_for cancels the coroutine, so any in-flight policy call / env.step
-        # is interrupted and the pooled sandbox slot is released by _with_env's
-        # finally block during cancellation cleanup.
+        # is interrupted and the env session is closed by _with_env's async-with
+        # during cancellation cleanup.
         reward, agent_metrics = await asyncio.wait_for(
             _multi_turn(
                 classes, env_url, policy, model_name, messages, request_kwargs, metadata

--- a/examples/experimental/openenv/openenv_agent_function.py
+++ b/examples/experimental/openenv/openenv_agent_function.py
@@ -583,6 +583,8 @@ async def run(
     except Exception as e:
         logger.error(f"OpenEnv tbench2 episode failed: {e}", exc_info=True)
         return None
+    finally:
+        await policy.close()
 
     # eval_report is intentionally empty: the canonical-eval marker protocol
     # (see _REWARD_MARKER) echoes back only the scalar reward. The detailed

--- a/examples/experimental/openenv/openenv_generate.py
+++ b/examples/experimental/openenv/openenv_generate.py
@@ -1,8 +1,9 @@
-"""Reward function for the OpenEnv Phase-1 smoke run.
+"""Reward function for the OpenEnv Terminal-Bench-2 (tbench2) run.
 
-Task-agnostic: the agent function (``openenv_echo_agent_function.run``) stores the
-env-provided reward in ``sample.metadata["reward"]``; this just reads it back.
-Mirrors ``swe-agent-v2/generate.py:reward_func`` so it works for both the
+Task-agnostic: the agent function (``openenv_agent_function.run``) stores the
+env-computed binary pytest reward in ``sample.metadata["reward"]``; this just
+reads it back. Wired via ``--custom-rm-path openenv_generate.reward_func`` and
+mirrors ``swe-agent-v2/generate.py:reward_func`` so it works for both the
 single-sample (``async_rm``) and batched (``--custom-rm-path``) call paths.
 """
 

--- a/examples/experimental/openenv/openenv_generate.py
+++ b/examples/experimental/openenv/openenv_generate.py
@@ -1,0 +1,15 @@
+"""Reward function for the OpenEnv Phase-1 smoke run.
+
+Task-agnostic: the agent function (``openenv_echo_agent_function.run``) stores the
+env-provided reward in ``sample.metadata["reward"]``; this just reads it back.
+Mirrors ``swe-agent-v2/generate.py:reward_func`` so it works for both the
+single-sample (``async_rm``) and batched (``--custom-rm-path``) call paths.
+"""
+
+from miles.utils.types import Sample
+
+
+async def reward_func(args, samples: Sample | list[Sample], **kwargs) -> float | list[float]:
+    if isinstance(samples, list):
+        return [s.metadata.get("reward", 0.0) for s in samples]
+    return samples.metadata.get("reward", 0.0)

--- a/examples/experimental/openenv/openenv_launch_common.py
+++ b/examples/experimental/openenv/openenv_launch_common.py
@@ -1,12 +1,12 @@
 """Shared launch helpers for the OpenEnv tbench2 learning launchers.
 
-``run-openenv-tbench2.py`` (GLM-4.7-Flash) and ``run-openenv-tbench2-dsv4.py``
-(DeepSeek-V4-Flash) drive the same agentic adapter and differ only in the
-model-family serving/training profile. The model-agnostic fragments (process
-cleanup, GRPO/optimizer/rollout/agent flags, W&B + Prometheus wiring, and the
-OpenEnv/Daytona env-var plumbing) live here so the two launchers cannot silently
-drift apart. Each launcher keeps only its own perf/sglang/misc profile and its
-``ScriptArgs`` defaults.
+``run-openenv-tbench2.py`` (GLM-4.7-Flash) is the launcher in this example;
+sibling per-model launchers (e.g. a DeepSeek-V4-Flash variant) reuse the same
+agentic adapter and differ only in the model-family serving/training profile.
+The model-agnostic fragments (process cleanup, GRPO/optimizer/rollout/agent
+flags, W&B + Prometheus wiring, and the OpenEnv/Daytona env-var plumbing) live
+here so those launchers cannot silently drift apart. Each launcher keeps only
+its own perf/sglang/misc profile and its ``ScriptArgs`` defaults.
 """
 
 import os

--- a/examples/experimental/openenv/openenv_launch_common.py
+++ b/examples/experimental/openenv/openenv_launch_common.py
@@ -4,9 +4,9 @@
 sibling per-model launchers (e.g. a DeepSeek-V4-Flash variant) reuse the same
 agentic adapter and differ only in the model-family serving/training profile.
 The model-agnostic fragments (process cleanup, GRPO/optimizer/rollout/agent
-flags, W&B + Prometheus wiring, and the OpenEnv/Daytona env-var plumbing) live
-here so those launchers cannot silently drift apart. Each launcher keeps only
-its own perf/sglang/misc profile and its ``ScriptArgs`` defaults.
+flags, W&B + Prometheus wiring, and the OpenEnv env-var plumbing) live here so
+those launchers cannot silently drift apart. Each launcher keeps only its own
+perf/sglang/misc profile and its ``ScriptArgs`` defaults.
 """
 
 import os
@@ -28,10 +28,6 @@ class LaunchArgs(Protocol):
     agent_model_name: str
     openenv_max_turns: int
     openenv_max_rollout_time_seconds: int
-    openenv_daytona_snapshot: str
-    openenv_daytona_pool_size: int
-    openenv_daytona_port: int
-    daytona_api_key: str
     router_external_host: str
     miles_host_ip: str
 
@@ -151,14 +147,8 @@ def base_env_vars(args: LaunchArgs, script_dir: str, megatron_path: str, miles_r
 
 
 def apply_optional_env_vars(env: dict[str, str], args: LaunchArgs) -> None:
-    """Add host-rewrite / Daytona-pool env vars when the args request them."""
+    """Add host-rewrite env vars when the args request them."""
     if args.miles_host_ip:
         env["MILES_HOST_IP"] = args.miles_host_ip
     if args.router_external_host:
         env["MILES_ROUTER_EXTERNAL_HOST"] = args.router_external_host
-    if args.openenv_daytona_snapshot:
-        assert args.daytona_api_key, "DAYTONA_API_KEY required when openenv_daytona_snapshot is set"
-        env["OPENENV_DAYTONA_SNAPSHOT"] = args.openenv_daytona_snapshot
-        env["OPENENV_DAYTONA_POOL_SIZE"] = str(args.openenv_daytona_pool_size)
-        env["OPENENV_DAYTONA_PORT"] = str(args.openenv_daytona_port)
-        env["DAYTONA_API_KEY"] = args.daytona_api_key

--- a/examples/experimental/openenv/openenv_launch_common.py
+++ b/examples/experimental/openenv/openenv_launch_common.py
@@ -1,0 +1,164 @@
+"""Shared launch helpers for the OpenEnv tbench2 learning launchers.
+
+``run-openenv-tbench2.py`` (GLM-4.7-Flash) and ``run-openenv-tbench2-dsv4.py``
+(DeepSeek-V4-Flash) drive the same agentic adapter and differ only in the
+model-family serving/training profile. The model-agnostic fragments (process
+cleanup, GRPO/optimizer/rollout/agent flags, W&B + Prometheus wiring, and the
+OpenEnv/Daytona env-var plumbing) live here so the two launchers cannot silently
+drift apart. Each launcher keeps only its own perf/sglang/misc profile and its
+``ScriptArgs`` defaults.
+"""
+
+import os
+import subprocess
+import time
+from typing import Protocol
+
+
+class LaunchArgs(Protocol):
+    """The config fields the shared helpers read (satisfied by each launcher's ScriptArgs)."""
+
+    prompt_data: str
+    rollout_batch_size: int
+    n_samples_per_prompt: int
+    max_seq_len: int
+    global_batch_size: int
+
+    openenv_env_url: str
+    agent_model_name: str
+    openenv_max_turns: int
+    openenv_max_rollout_time_seconds: int
+    openenv_daytona_snapshot: str
+    openenv_daytona_pool_size: int
+    openenv_daytona_port: int
+    daytona_api_key: str
+    router_external_host: str
+    miles_host_ip: str
+
+    wandb_key: str
+    wandb_project: str
+    wandb_team: str
+    wandb_run_name: str
+
+    use_prometheus: bool
+    prometheus_port: int
+    prometheus_run_name: str
+
+
+def cleanup() -> None:
+    """Kill old Ray jobs and stale processes to free GPU resources."""
+    my_pid = os.getpid()
+    ppid = os.getppid()
+    print(f"Cleanup starting (pid={my_pid}, ppid={ppid})")
+    targets = ["sglang", "train.py", "MegatronTrain"]
+    exclude = f"grep -v '^{my_pid}$' | grep -v '^{ppid}$'"
+    for t in targets:
+        subprocess.run(
+            f"pgrep -f '{t}' | {exclude} | xargs -r kill 2>/dev/null || true",
+            shell=True,
+        )
+    time.sleep(5)
+    print(f"Cleanup complete (pid={my_pid}) — old processes killed.")
+
+
+def rollout_args(args: LaunchArgs) -> str:
+    return (
+        f"--prompt-data {args.prompt_data} "
+        "--input-key prompt "
+        "--metadata-key metadata "
+        "--rollout-shuffle "
+        "--num-rollout 40 "
+        f"--rollout-batch-size {args.rollout_batch_size} "
+        f"--n-samples-per-prompt {args.n_samples_per_prompt} "
+        "--rollout-temperature 0.8 "
+        "--rollout-max-response-len 8192 "
+        f"--max-seq-len {args.max_seq_len} "
+        f"--global-batch-size {args.global_batch_size} "
+        "--balance-data "
+    )
+
+
+def grpo_args() -> str:
+    return (
+        "--advantage-estimator grpo "
+        "--use-kl-loss "
+        "--kl-loss-coef 0.01 "
+        "--kl-loss-type low_var_kl "
+        "--entropy-coef 0.0 "
+        "--eps-clip 0.2 "
+        "--eps-clip-high 0.28 "
+    )
+
+
+def optimizer_args() -> str:
+    return (
+        "--optimizer adam "
+        "--lr 1e-6 "
+        "--lr-decay-style constant "
+        "--weight-decay 0.1 "
+        "--adam-beta1 0.9 "
+        "--adam-beta2 0.98 "
+    )
+
+
+def agent_args(tito_model: str) -> str:
+    """Agentic-rollout wiring. Only the TITO surface differs across models."""
+    return (
+        "--custom-generate-function-path miles.rollout.generate_hub.agentic_tool_call.generate "
+        "--custom-agent-function-path openenv_agent_function.run "
+        "--custom-rm-path openenv_generate.reward_func "
+        "--dynamic-sampling-filter-path miles.rollout.filter_hub.dynamic_sampling_filters.check_no_aborted "
+        f"--tito-model {tito_model} "
+        "--use-session-server "
+        "--session-server-port 30000 "
+        "--tito-allowed-append-roles user tool "
+    )
+
+
+def wandb_args(args: LaunchArgs) -> str:
+    if not args.wandb_key:
+        return ""
+    out = (
+        "--use-wandb "
+        f"--wandb-project {args.wandb_project} "
+        f"--wandb-group {args.wandb_run_name} "
+        f"--wandb-key {args.wandb_key} "
+    )
+    if args.wandb_team:
+        out += f"--wandb-team {args.wandb_team} "
+    return out
+
+
+def prometheus_args(args: LaunchArgs) -> str:
+    if not args.use_prometheus:
+        return ""
+    return (
+        "--use-prometheus "
+        f"--prometheus-port {args.prometheus_port} "
+        f"--prometheus-run-name {args.prometheus_run_name} "
+    )
+
+
+def base_env_vars(args: LaunchArgs, script_dir: str, megatron_path: str, miles_root: str) -> dict[str, str]:
+    return {
+        "PYTHONPATH": f"{megatron_path}:{script_dir}:{miles_root}",
+        "MILES_EXPERIMENTAL_ROLLOUT_REFACTOR": "1",
+        "OPENENV_ENV_URL": args.openenv_env_url,
+        "OPENENV_MAX_TURNS": str(args.openenv_max_turns),
+        "OPENENV_MAX_ROLLOUT_TIME_SECONDS": str(args.openenv_max_rollout_time_seconds),
+        "AGENT_MODEL_NAME": args.agent_model_name,
+    }
+
+
+def apply_optional_env_vars(env: dict[str, str], args: LaunchArgs) -> None:
+    """Add host-rewrite / Daytona-pool env vars when the args request them."""
+    if args.miles_host_ip:
+        env["MILES_HOST_IP"] = args.miles_host_ip
+    if args.router_external_host:
+        env["MILES_ROUTER_EXTERNAL_HOST"] = args.router_external_host
+    if args.openenv_daytona_snapshot:
+        assert args.daytona_api_key, "DAYTONA_API_KEY required when openenv_daytona_snapshot is set"
+        env["OPENENV_DAYTONA_SNAPSHOT"] = args.openenv_daytona_snapshot
+        env["OPENENV_DAYTONA_POOL_SIZE"] = str(args.openenv_daytona_pool_size)
+        env["OPENENV_DAYTONA_PORT"] = str(args.openenv_daytona_port)
+        env["DAYTONA_API_KEY"] = args.daytona_api_key

--- a/examples/experimental/openenv/run-openenv-tbench2-dsv4.py
+++ b/examples/experimental/openenv/run-openenv-tbench2-dsv4.py
@@ -1,0 +1,287 @@
+"""OpenEnv Terminal-Bench-2 (tbench2) learning launcher for DeepSeek-V4-Flash.
+
+Sibling of ``run-openenv-tbench2.py`` (GLM-4.7-Flash). Same agentic adapter
+(``openenv_agent_function.run`` + ``openenv_generate.reward_func`` + the
+``make_tbench2_data.py`` prompt data); only the *model family* differs, so the
+serving/training flags below mirror the verified DeepSeek-V4-Flash profile in
+``scripts/run_deepseek_v4.py`` (the ``train`` command) rather than GLM's.
+
+Why a separate launcher (not a flag on the GLM one): dsv4 needs a materially
+different config — ``--qkv-format bshd`` + ``--micro-batch-size 1`` (NOT
+dynamic-batch-size), ``--model-name deepseekv4`` for the mbridge load, MoE gate
+freezing, the blockwise FP8 recipe, MTP/EAGLE speculative decoding, dsv4-specific
+SGLANG_* env vars, and tp4/dp1/ep4 rollout engines. Keeping it out of the GLM
+launcher guarantees GLM support is untouched.
+
+The append-only fix that makes dsv4 safe under the OpenEnv text protocol lives
+in ``miles/utils/chat_template_utils/tito_tokenizer.py``: the {tool, user}
+FixedTemplateRow for DeepSeekV4TITOTokenizer pins ``drop_thinking=False`` (see
+miles PR #1590). OpenEnv feeds env output back as plain ``user`` turns and passes
+no ``tools``; without that pin the encoder strips prior assistants' thinking once
+a new user turn advances last_user_index — a non-append-only mutation that
+corrupts the pretokenized prefix and NaNs the first backward. This launcher
+selects that surface via ``--tito-model deepseekv4`` +
+``--tito-allowed-append-roles user tool``.
+
+Prereqs (identical to the GLM launcher for env/data; model prep differs):
+    # 1. Install the env client where the rollout runs.
+    pip install -e <OpenEnv>/envs/tbench2_env
+    # 2. TB2 task suite + prompt data (task_ids).
+    git clone --depth 1 https://github.com/laude-institute/terminal-bench-2.git /workspace/terminal-bench-2
+    python make_tbench2_data.py --tasks_dir /workspace/terminal-bench-2 --output /root/tbench2_train.jsonl
+    # 3. Serve the env (docker mode for real TB2 fidelity), or use the Daytona pool.
+    TB2_MODE=docker TB2_TASKS_DIR=/workspace/terminal-bench-2 MAX_CONCURRENT_ENVS=32 \
+        python -m tbench2_env.server.app --port 8003
+    # 4. Prepare the dsv4 checkpoint (FP8 -> BF16 -> torch_dist). Use the canonical
+    #    pipeline, then point --hf-checkpoint / --ref-load at its outputs:
+    python scripts/run_deepseek_v4.py prepare-download --model-name DeepSeek-V4-Flash-FP8
+    python scripts/run_deepseek_v4.py prepare-single   --model-name DeepSeek-V4-Flash-FP8 \
+        --hf-checkpoint /root/models/DeepSeek-V4-Flash-FP8
+    python scripts/run_deepseek_v4.py prepare-spmd     --model-name DeepSeek-V4-Flash-FP8 \
+        --num-nodes 8 --num-gpus-per-node 8
+
+Usage:
+    python run-openenv-tbench2-dsv4.py --openenv-env-url http://<env-host>:8003 --num-nodes 8
+
+NOTE: this launcher assembles proven flags from two working scripts but the exact
+combination (dsv4 serving + OpenEnv text protocol + drop_thinking=False) still
+needs a short pod smoke run to confirm the first backward is NaN-free.
+"""
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+import openenv_launch_common as C
+import typer
+
+import miles.utils.external_utils.command_utils as U
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+
+
+@dataclass
+class ScriptArgs(U.ExecuteTrainConfig):
+    mode: Literal["normal", "debug_rollout_only"] = "normal"
+    run_id: str = U.create_run_id()
+    megatron_model_type: str = "deepseek-v4-flash"
+    num_gpus_per_node: int = 8
+    megatron_path: str = "/root/Megatron-LM"
+
+    # Paths (point at the outputs of scripts/run_deepseek_v4.py prepare-*).
+    skip_prepare: bool = True
+    base_dir: str = "/root"
+    model_name: str = "DeepSeek-V4-Flash-FP8"
+    hf_checkpoint: str = "/root/models/DeepSeek-V4-Flash-FP8"
+    ref_load: str = "/root/models/DeepSeek-V4-Flash-FP8_torch_dist"
+    save_dir: str = "/workspace/DeepSeek-V4-Flash_openenv_tbench2/"
+    prompt_data: str = "/root/tbench2_train.jsonl"
+
+    # Training settings (small; multi-turn so responses run long). max_seq_len
+    # MUST stay >= 65536: dsv4's RoPE buffer is sized to it and a shorter cap
+    # skips trajectory truncation, letting a long episode overflow rope.py.
+    max_seq_len: int = 65536
+    rollout_batch_size: int = 8
+    n_samples_per_prompt: int = 8
+    global_batch_size: int = 32
+
+    # dsv4 knobs
+    enable_mtp: bool = True
+    fp8_training: bool = True
+    enable_r3: bool = True
+    train_deterministic: bool = True
+
+    # OpenEnv settings
+    openenv_env_url: str = os.environ.get("OPENENV_ENV_URL", "http://localhost:8003")
+    agent_model_name: str = os.environ.get("AGENT_MODEL_NAME", "model")
+    openenv_max_turns: int = int(os.environ.get("OPENENV_MAX_TURNS", "30"))
+    openenv_max_rollout_time_seconds: int = int(os.environ.get("OPENENV_MAX_ROLLOUT_TIME_SECONDS", "3600"))
+    openenv_daytona_snapshot: str = os.environ.get("OPENENV_DAYTONA_SNAPSHOT", "")
+    openenv_daytona_pool_size: int = int(os.environ.get("OPENENV_DAYTONA_POOL_SIZE", "8"))
+    openenv_daytona_port: int = int(os.environ.get("OPENENV_DAYTONA_PORT", "8000"))
+    daytona_api_key: str = os.environ.get("DAYTONA_API_KEY", "")
+    dump_details: str = os.environ.get("OPENENV_DUMP_DETAILS", "")
+    router_external_host: str = os.environ.get("MILES_ROUTER_EXTERNAL_HOST", "")
+    miles_host_ip: str = os.environ.get("MILES_HOST_IP", "")
+
+    # W&B settings
+    wandb_key: str = os.environ.get("WANDB_KEY", os.environ.get("WANDB_API_KEY", ""))
+    wandb_project: str = os.environ.get("WANDB_PROJECT", "openenv-tbench2-learn")
+    wandb_team: str = os.environ.get("WANDB_TEAM", "")
+    wandb_run_name: str = "openenv-tbench2-learn-dsv4"
+
+    # Prometheus settings
+    use_prometheus: bool = True
+    prometheus_port: int = 9090
+    prometheus_run_name: str = "openenv-tbench2-learn-dsv4"
+
+
+def _parallel_config(num_nodes: int, num_gpus_per_node: int) -> str:
+    """DeepSeek-V4-Flash parallel config (mirrors scripts/run_deepseek_v4.py).
+
+    Only the verified profiles are wired up; anything else must be added
+    deliberately rather than guessed.
+    """
+    total_gpus = num_nodes * num_gpus_per_node
+    if num_nodes == 1:
+        return (
+            f"--tensor-model-parallel-size {num_gpus_per_node} "
+            "--sequence-parallel "
+            "--pipeline-model-parallel-size 1 "
+            "--context-parallel-size 1 "
+            f"--expert-model-parallel-size {num_gpus_per_node} "
+            "--expert-tensor-parallel-size 1 "
+        )
+    if total_gpus == 64:  # 8 nodes x 8 GPUs (H200)
+        return (
+            "--tensor-model-parallel-size 8 "
+            "--sequence-parallel "
+            "--pipeline-model-parallel-size 8 "
+            "--decoder-first-pipeline-num-layers 4 "
+            "--decoder-last-pipeline-num-layers 3 "
+            "--context-parallel-size 1 "
+            "--expert-model-parallel-size 8 "
+            "--expert-tensor-parallel-size 1 "
+        )
+    raise NotImplementedError(
+        f"No verified dsv4-flash parallel config for {total_gpus} GPUs "
+        f"({num_nodes} nodes x {num_gpus_per_node} GPUs/node). Add one here, "
+        "mirroring scripts/run_deepseek_v4.py:_get_parallel_config."
+    )
+
+
+def execute(args: ScriptArgs):
+    ckpt_args = (
+        f"--hf-checkpoint {args.hf_checkpoint} "
+        f"--ref-load {args.ref_load} "
+        f"--save {args.save_dir} "
+        "--save-interval 20 "
+    )
+
+    rollout_args = C.rollout_args(args)
+
+    # dsv4 perf: bshd + micro-batch-size 1 (NOT --use-dynamic-batch-size).
+    perf_args = _parallel_config(args.num_nodes, args.num_gpus_per_node)
+    perf_args += (
+        "--recompute-granularity full "
+        "--recompute-method uniform "
+        "--recompute-num-layers 1 "
+        "--micro-batch-size 1 "
+        "--max-tokens-per-gpu 2048 "
+        "--optimizer-cpu-offload "
+        "--overlap-cpu-optimizer-d2h-h2d "
+        "--use-precision-aware-optimizer "
+    )
+
+    grpo_args = C.grpo_args()
+
+    optimizer_args = C.optimizer_args()
+
+    # dsv4-flash rollout engines: tp4/dp1/ep4, 4 GPUs/engine. DP attention stays
+    # OFF for Flash. MTP/EAGLE per --enable-mtp.
+    sglang_args = (
+        "--rollout-num-gpus-per-engine 4 "
+        "--sglang-tp-size 4 "
+        "--sglang-dp-size 1 "
+        "--sglang-ep-size 4 "
+        "--sglang-mem-fraction-static 0.7 "
+        "--sglang-tool-call-parser deepseekv4 "
+        "--sglang-reasoning-parser deepseek-v4 "
+        "--sglang-router-port 31000 "
+        "--router-health-success-threshold 1 "
+        "--router-health-check-interval-secs 15 "
+        "--router-health-failure-threshold 40 "
+    )
+    if args.enable_mtp:
+        sglang_args += (
+            "--sglang-speculative-algorithm EAGLE "
+            "--sglang-speculative-num-steps 3 "
+            "--sglang-speculative-eagle-topk 1 "
+            "--sglang-speculative-num-draft-tokens 4 "
+        )
+
+    agent_args = C.agent_args("deepseekv4")
+
+    misc_args = (
+        "--attention-dropout 0.0 "
+        "--hidden-dropout 0.0 "
+        "--accumulate-allreduce-grads-in-fp32 "
+        "--attention-softmax-in-fp32 "
+        "--attention-backend flash "
+        "--model-name deepseekv4 "  # mbridge load
+        "--qkv-format bshd "
+        "--moe-router-freeze-gate "
+        "--freeze-e-score-correction-bias "
+        f"--update-weight-buffer-size {1 * 1024 ** 3} "
+        "--rollout-health-check-interval 300 "
+        "--rollout-health-check-timeout 300 "
+        "--colocate "
+        f"--actor-num-nodes {args.num_nodes} "
+        f"--actor-num-gpus-per-node {args.num_gpus_per_node} "
+        f"--rollout-num-gpus {args.num_nodes * args.num_gpus_per_node} "
+    )
+    if args.enable_r3:
+        misc_args += "--use-rollout-routing-replay "
+
+    extra_env_vars = C.base_env_vars(args, str(SCRIPT_DIR), args.megatron_path, U.repo_base_dir)
+    extra_env_vars |= {
+        "SGLANG_SKIP_CHECKPOINT_LOAD_CHECK": "1",
+        "SGLANG_DSV4_FP4_EXPERTS": "0",
+        "SGLANG_HEALTH_CHECK_TIMEOUT": "120",
+        "SGLANG_DG_CACHE_DIR_PER_PROCESS": "1",
+        "SGLANG_OPT_FP8_WO_A_GEMM": "0",
+    }
+    if args.train_deterministic:
+        misc_args += "--deterministic-mode "
+        extra_env_vars |= {
+            "NCCL_ALGO": "Ring",
+            "NVTE_ALLOW_NONDETERMINISTIC_ALGO": "0",
+            "CUBLAS_WORKSPACE_CONFIG": ":4096:8",
+        }
+    if args.fp8_training:
+        misc_args += "--transformer-impl transformer_engine --bf16 --fp8-format e4m3 --fp8-recipe blockwise "
+        misc_args += """--train-env-vars '{"NVTE_FP8_BLOCK_SCALING_FP32_SCALES":"1"}' """
+
+    debug_args = "--debug-rollout-only " if args.mode == "debug_rollout_only" else ""
+    dump_args = f"--dump-details {args.dump_details} " if args.dump_details else ""
+
+    wandb_args = C.wandb_args(args)
+
+    prometheus_args = C.prometheus_args(args)
+
+    train_args = (
+        f"{ckpt_args}"
+        f"{rollout_args}"
+        f"{optimizer_args}"
+        f"{grpo_args}"
+        f"{wandb_args}"
+        f"{prometheus_args}"
+        f"{perf_args}"
+        f"{sglang_args}"
+        f"{agent_args}"
+        f"{misc_args}"
+        f"{debug_args}"
+        f"{dump_args}"
+    )
+
+    C.apply_optional_env_vars(extra_env_vars, args)
+
+    U.execute_train(
+        train_args=train_args,
+        config=args,
+        num_gpus_per_node=args.num_gpus_per_node,
+        megatron_model_type=args.megatron_model_type,
+        megatron_path=args.megatron_path,
+        extra_env_vars=extra_env_vars,
+    )
+
+
+@U.dataclass_cli
+def main(args: ScriptArgs):
+    C.cleanup()
+    execute(args)
+
+
+if __name__ == "__main__":
+    typer.run(main)

--- a/examples/experimental/openenv/run-openenv-tbench2.py
+++ b/examples/experimental/openenv/run-openenv-tbench2.py
@@ -1,0 +1,221 @@
+"""OpenEnv Terminal-Bench-2 (tbench2) learning launcher (GLM-4.7-Flash).
+
+Drives the OpenEnv tbench2 env via ``openenv_agent_function.run``. tbench2 is
+*multi-turn*: the adapter runs an agentic loop (reset(task_id) -> {policy emits a
+shell command -> step(exec) -> feed output back} -> evaluate) and the reward is
+the binary pytest result (1.0 all tests pass, else 0.0).
+
+Prereqs:
+    # 1. Install the env client where the rollout runs (pulls camel-ai; isolate
+    #    from the training env if its deps clash with the miles image).
+    pip install -e <OpenEnv>/envs/tbench2_env
+    # 2. Get the TB2 task suite + build prompt-data (task_ids).
+    git clone --depth 1 https://github.com/laude-institute/terminal-bench-2.git /workspace/terminal-bench-2
+    python make_tbench2_data.py --tasks_dir /workspace/terminal-bench-2 --output /root/tbench2_train.jsonl
+    # 3. Serve the env. The tbench2 server supports concurrency natively via
+    #    MAX_CONCURRENT_ENVS (no wrapper needed). Choose execution mode:
+    #      TB2_MODE=docker  -> real TB2 fidelity (needs docker.sock + image pulls)
+    #      TB2_MODE=local   -> runs in-process, ignores task Dockerfiles (degraded)
+    TB2_MODE=docker TB2_TASKS_DIR=/workspace/terminal-bench-2 MAX_CONCURRENT_ENVS=32 \
+        python -m tbench2_env.server.app --port 8003
+
+    NOTE (open decisions before a real run): docker mode wants a Docker host with
+    disk + socket; colocating heavy per-task containers on the GPU pod is risky,
+    so the env server likely runs off-pod (use --openenv-env-url / the host
+    rewrite). The binary sparse reward also needs a task subset where the base
+    policy *sometimes* succeeds (advantage variance) -- e.g. the TB2 variance
+    band -- or GRPO sees a flat signal.
+
+Usage:
+    python run-openenv-tbench2.py --openenv-env-url http://<env-host>:8003
+"""
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+import typer
+
+import miles.utils.external_utils.command_utils as U
+import openenv_launch_common as C
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+
+
+@dataclass
+class ScriptArgs(U.ExecuteTrainConfig):
+    mode: Literal["normal", "debug_rollout_only"] = "normal"
+    run_id: str = U.create_run_id()
+    megatron_model_type: str = "glm4.7-flash"
+    num_gpus_per_node: int = 8
+    megatron_path: str = "/root/Megatron-LM"
+
+    # Paths
+    skip_prepare: bool = False
+    base_dir: str = "/root"
+    model_name: str = "GLM-4.7-Flash"
+    hf_checkpoint: str = "zai-org/GLM-4.7-Flash"
+    ref_load: str = "/root/GLM-4.7-Flash_torch_dist"
+    save_dir: str = "/workspace/GLM-4.7-Flash_openenv_tbench2/"
+    prompt_data: str = "/root/tbench2_train.jsonl"
+
+    # Training settings (small; multi-turn so responses run long)
+    max_seq_len: int = 16384
+    rollout_batch_size: int = 8
+    n_samples_per_prompt: int = 8
+    global_batch_size: int = 32
+
+    # OpenEnv settings
+    openenv_env_url: str = os.environ.get("OPENENV_ENV_URL", "http://localhost:8003")
+    agent_model_name: str = os.environ.get("AGENT_MODEL_NAME", "model")
+    openenv_max_turns: int = int(os.environ.get("OPENENV_MAX_TURNS", "30"))
+    # Hard wall-clock cap (seconds) per episode. An episode that does not return
+    # within the limit is terminated and scored reward 0, bounding long-trajectory
+    # stragglers that would otherwise stall the whole rollout batch.
+    openenv_max_rollout_time_seconds: int = int(
+        os.environ.get("OPENENV_MAX_ROLLOUT_TIME_SECONDS", "3600")
+    )
+    # When set, the adapter ignores --openenv-env-url and instead provisions a
+    # pool of Daytona sandboxes from this snapshot, rotating episodes across them.
+    openenv_daytona_snapshot: str = os.environ.get("OPENENV_DAYTONA_SNAPSHOT", "")
+    openenv_daytona_pool_size: int = int(os.environ.get("OPENENV_DAYTONA_POOL_SIZE", "8"))
+    openenv_daytona_port: int = int(os.environ.get("OPENENV_DAYTONA_PORT", "8000"))
+    daytona_api_key: str = os.environ.get("DAYTONA_API_KEY", "")
+    # When set, miles dumps full per-episode agent trajectories (tokens, logprobs,
+    # loss masks, reward, multi-turn messages) to <dir>/rollout_data/{rollout_id}.pt
+    # for post-hoc inspection via miles.utils.debug_utils.display_debug_rollout_data.
+    dump_details: str = os.environ.get("OPENENV_DUMP_DETAILS", "")
+    # Optional host rewrite for the policy URL (only needed if the in-process
+    # agent cannot reach the session server at its raw base_url host).
+    router_external_host: str = os.environ.get("MILES_ROUTER_EXTERNAL_HOST", "")
+    # Leave empty so miles resolves the numeric LAN IP itself. sgl-router's Rust
+    # binder rejects a hostname ("invalid socket address syntax"), and a numeric
+    # base_url host keeps the in-process policy client off hostname DNS too.
+    miles_host_ip: str = os.environ.get("MILES_HOST_IP", "")
+
+    # W&B settings
+    wandb_key: str = os.environ.get("WANDB_KEY", os.environ.get("WANDB_API_KEY", ""))
+    wandb_project: str = os.environ.get("WANDB_PROJECT", "openenv-tbench2-learn")
+    wandb_team: str = os.environ.get("WANDB_TEAM", "")
+    wandb_run_name: str = "openenv-tbench2-learn"
+
+    # Prometheus settings
+    use_prometheus: bool = True
+    prometheus_port: int = 9090
+    prometheus_run_name: str = "openenv-tbench2-learn"
+
+
+def prepare(args: ScriptArgs):
+    """Convert HF checkpoint to torch_dist format if not already done."""
+    U.convert_checkpoint(
+        model_name=args.model_name,
+        megatron_model_type=args.megatron_model_type,
+        num_gpus_per_node=args.num_gpus_per_node,
+        dir_dst=args.base_dir,
+        hf_checkpoint=args.hf_checkpoint,
+        megatron_path=args.megatron_path,
+    )
+
+
+def execute(args: ScriptArgs):
+    ckpt_args = (
+        f"--hf-checkpoint {args.hf_checkpoint} "
+        f"--ref-load {args.ref_load} "
+        f"--save {args.save_dir} "
+        "--save-interval 100 "
+    )
+
+    rollout_args = C.rollout_args(args)
+
+    perf_args = (
+        "--tensor-model-parallel-size 4 "
+        "--sequence-parallel "
+        "--pipeline-model-parallel-size 1 "
+        "--context-parallel-size 1 "
+        "--expert-model-parallel-size 2 "  # single 8-GPU node: TP=4 -> DP=2, so EP<=2
+        "--expert-tensor-parallel-size 1 "
+        "--recompute-granularity full "
+        "--recompute-method uniform "
+        "--recompute-num-layers 1 "
+        "--use-dynamic-batch-size "
+        "--max-tokens-per-gpu 16384 "
+        "--optimizer-cpu-offload "
+        "--overlap-cpu-optimizer-d2h-h2d "
+        "--use-precision-aware-optimizer "
+    )
+
+    grpo_args = C.grpo_args()
+
+    optimizer_args = C.optimizer_args()
+
+    sglang_args = (
+        "--rollout-num-gpus-per-engine 1 "
+        "--sglang-mem-fraction-static 0.7 "
+        "--sglang-tool-call-parser glm47 "
+        "--sglang-reasoning-parser glm45 "
+        "--sglang-router-port 31000 "
+    )
+
+    agent_args = C.agent_args("glm47")
+
+    misc_args = (
+        "--attention-dropout 0.0 "
+        "--hidden-dropout 0.0 "
+        "--accumulate-allreduce-grads-in-fp32 "
+        "--attention-softmax-in-fp32 "
+        "--attention-backend flash "
+        "--colocate "
+        f"--actor-num-nodes {args.num_nodes} "
+        f"--actor-num-gpus-per-node {args.num_gpus_per_node} "
+        f"--rollout-num-gpus {args.num_gpus_per_node} "
+    )
+
+    debug_args = "--debug-rollout-only " if args.mode == "debug_rollout_only" else ""
+
+    dump_args = f"--dump-details {args.dump_details} " if args.dump_details else ""
+
+    wandb_args = C.wandb_args(args)
+
+    prometheus_args = C.prometheus_args(args)
+
+    train_args = (
+        f"{ckpt_args}"
+        f"{rollout_args}"
+        f"{optimizer_args}"
+        f"{grpo_args}"
+        f"{wandb_args}"
+        f"{prometheus_args}"
+        f"{perf_args}"
+        f"{sglang_args}"
+        f"{agent_args}"
+        f"{misc_args}"
+        f"{debug_args}"
+        f"{dump_args}"
+    )
+
+    extra_env_vars = C.base_env_vars(
+        args, str(SCRIPT_DIR), args.megatron_path, U.repo_base_dir
+    )
+    C.apply_optional_env_vars(extra_env_vars, args)
+
+    U.execute_train(
+        train_args=train_args,
+        config=args,
+        num_gpus_per_node=args.num_gpus_per_node,
+        megatron_model_type=args.megatron_model_type,
+        megatron_path=args.megatron_path,
+        extra_env_vars=extra_env_vars,
+    )
+
+
+@U.dataclass_cli
+def main(args: ScriptArgs):
+    C.cleanup()
+    if not args.skip_prepare:
+        prepare(args)
+    execute(args)
+
+
+if __name__ == "__main__":
+    typer.run(main)

--- a/examples/experimental/openenv/run-openenv-tbench2.py
+++ b/examples/experimental/openenv/run-openenv-tbench2.py
@@ -73,9 +73,7 @@ class ScriptArgs(U.ExecuteTrainConfig):
     # Hard wall-clock cap (seconds) per episode. An episode that does not return
     # within the limit is terminated and scored reward 0, bounding long-trajectory
     # stragglers that would otherwise stall the whole rollout batch.
-    openenv_max_rollout_time_seconds: int = int(
-        os.environ.get("OPENENV_MAX_ROLLOUT_TIME_SECONDS", "3600")
-    )
+    openenv_max_rollout_time_seconds: int = int(os.environ.get("OPENENV_MAX_ROLLOUT_TIME_SECONDS", "3600"))
     # When set, miles dumps full per-episode agent trajectories (tokens, logprobs,
     # loss masks, reward, multi-turn messages) to <dir>/rollout_data/{rollout_id}.pt
     # for post-hoc inspection via miles.utils.debug_utils.display_debug_rollout_data.
@@ -188,9 +186,7 @@ def execute(args: ScriptArgs):
         f"{dump_args}"
     )
 
-    extra_env_vars = C.base_env_vars(
-        args, str(SCRIPT_DIR), args.megatron_path, U.repo_base_dir
-    )
+    extra_env_vars = C.base_env_vars(args, str(SCRIPT_DIR), args.megatron_path, U.repo_base_dir)
     C.apply_optional_env_vars(extra_env_vars, args)
 
     U.execute_train(

--- a/examples/experimental/openenv/run-openenv-tbench2.py
+++ b/examples/experimental/openenv/run-openenv-tbench2.py
@@ -35,10 +35,10 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
 
+import openenv_launch_common as C
 import typer
 
 import miles.utils.external_utils.command_utils as U
-import openenv_launch_common as C
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 

--- a/examples/experimental/openenv/run-openenv-tbench2.py
+++ b/examples/experimental/openenv/run-openenv-tbench2.py
@@ -76,12 +76,6 @@ class ScriptArgs(U.ExecuteTrainConfig):
     openenv_max_rollout_time_seconds: int = int(
         os.environ.get("OPENENV_MAX_ROLLOUT_TIME_SECONDS", "3600")
     )
-    # When set, the adapter ignores --openenv-env-url and instead provisions a
-    # pool of Daytona sandboxes from this snapshot, rotating episodes across them.
-    openenv_daytona_snapshot: str = os.environ.get("OPENENV_DAYTONA_SNAPSHOT", "")
-    openenv_daytona_pool_size: int = int(os.environ.get("OPENENV_DAYTONA_POOL_SIZE", "8"))
-    openenv_daytona_port: int = int(os.environ.get("OPENENV_DAYTONA_PORT", "8000"))
-    daytona_api_key: str = os.environ.get("DAYTONA_API_KEY", "")
     # When set, miles dumps full per-episode agent trajectories (tokens, logprobs,
     # loss masks, reward, multi-turn messages) to <dir>/rollout_data/{rollout_id}.pt
     # for post-hoc inspection via miles.utils.debug_utils.display_debug_rollout_data.

--- a/miles/rollout/generate_hub/agentic_tool_call.py
+++ b/miles/rollout/generate_hub/agentic_tool_call.py
@@ -112,6 +112,15 @@ async def generate(input: GenerateFnInput) -> GenerateFnOutput:
     for s in samples:
         s.metadata.update(agent_metadata or {})
 
+    # If the agent function reports wall-clock time spent outside policy generation
+    # (env/tool steps), surface it on Sample.non_generation_time so throughput
+    # accounting subtracts it. Must be equal across all turn-samples: merge_samples
+    # collapses them with _merge_equal_value, which asserts the values match.
+    ngt = ((agent_metadata or {}).get("agent_metrics") or {}).get("total_tool_time")
+    if ngt is not None:
+        for s in samples:
+            s.non_generation_time = ngt
+
     if max_seq_len is not None:
         samples = truncate_samples_by_total_tokens(samples, max_seq_len, input.state.tokenizer)
 


### PR DESCRIPTION
## Summary

Adds the DeepSeek-V4-Flash launcher variant `run-openenv-tbench2-dsv4.py` for the OpenEnv tbench2 agentic RL adapter. Stacked on #1487 (`shi/openenv-miles-adapter`), which carries the shared adapter, the GLM-4.7-Flash launcher, and the shared `openenv_launch_common.py` helpers.

## Why a separate PR

The DeepSeek-V4 launcher is not exercised by the GLM-4.7-Flash smoke run that validates #1487. Splitting it keeps #1487 scoped to the adapter plus one validated launcher, and isolates the DeepSeek-V4 serving/training profile so it can be reviewed on its own. The launcher reuses the shared GRPO/optimizer/rollout/agent/W&B flags from `openenv_launch_common.py`; it only overrides the DeepSeek-V4 perf/sglang/misc profile and its own `ScriptArgs` defaults.

## Test plan

- [ ] Launch a short DeepSeek-V4-Flash tbench2 run against an OpenEnv agent server and confirm rollouts produce non-zero `rollout/raw_reward` and GRPO steps advance.
