### PR TITLE
rollout: subtract agent-reported tool time from throughput accounting

### DIFF
--- a/miles/rollout/generate_hub/agentic_tool_call.py
+++ b/miles/rollout/generate_hub/agentic_tool_call.py
@@ -112,6 +112,15 @@ async def generate(input: GenerateFnInput) -> GenerateFnOutput:
     for s in samples:
         s.metadata.update(agent_metadata or {})
 
+    # If the agent function reports wall-clock time spent outside policy generation
+    # (env/tool steps), surface it on Sample.non_generation_time so throughput
+    # accounting subtracts it. Must be equal across all turn-samples: merge_samples
+    # collapses them with _merge_equal_value, which asserts the values match.
+    ngt = ((agent_metadata or {}).get("agent_metrics") or {}).get("total_tool_time")
+    if ngt is not None:
+        for s in samples:
+            s.non_generation_time = ngt
+
     if max_seq_len is not None:
         samples = truncate_samples_by_total_tokens(samples, max_seq_len, input.state.tokenizer)
 


### PR DESCRIPTION
## Summary

Adds a small, env-agnostic hook to the generic agentic generate function (`miles/rollout/generate_hub/agentic_tool_call.py`) so that wall-clock time an agent spends *outside* policy generation (environment steps, tool calls, sandbox exec/eval) is surfaced on `Sample.non_generation_time`.

## Why

`agentic_tool_call.generate` is the shared generate function used by every agent-environment RL path (Harbor/swe-agent-v2 and OpenEnv alike). The throughput/perf metrics in `miles/ray/rollout/metrics.py` derive per-sample tokens/sec from the total rollout wall-clock. In a multi-turn agentic rollout a large fraction of that wall-clock is env/tool latency, not decoding — so the reported tokens/sec is badly understated and not comparable across envs with different tool latencies. This hook lets the perf accounting subtract non-generation time and report a generation-only throughput.

## How

If the agent function returns `agent_metrics.total_tool_time`, that value is written to `non_generation_time` on every turn-sample of the episode. The value must be identical across turn-samples because `merge_samples` collapses them with `_merge_equal_value`, which asserts equality. Agent functions that don't report the metric are unaffected (`non_generation_time` stays at its `0.0` default).

## Notes

This was the only core-miles change previously bundled in #1487 (the OpenEnv tbench2 example). It is peeled out here as a standalone, generic change; #1487 now stacks on top of this branch.
