### PR TITLE
[AMD][DeepSeek V4][2/N] Enable decode CUDA graphs on MI355X

### DIFF
--- a/scripts/amd/run_deepseek_v4.py
+++ b/scripts/amd/run_deepseek_v4.py
@@ -406,9 +406,12 @@ def _train(args: ScriptArgs):
         "--router-health-success-threshold 1 "
         "--router-health-check-interval-secs 15 "
         "--router-health-failure-threshold 40 "  # TODO improve
-        # gfx950: DSv4 sgl-kernel topk_v2 is CUDA-only -> route DSA topk through torch + disable cuda-graph.
-        "--sglang-disable-cuda-graph "
+        # gfx950: DSv4 sgl-kernel topk_v2 is CUDA-only; route DSA top-k through torch.
         "--sglang-dsa-topk-backend torch "
+        # Capture the default per-engine rollout batch (32 * 8 / 8 = 32).
+        "--sglang-cuda-graph-max-bs-decode 32 "
+        # AITER graph registration fails through HIP IPC on gfx950; use RCCL.
+        "--sglang-disable-custom-all-reduce "
     )
     extra_env_vars = {
         "SGLANG_SKIP_CHECKPOINT_LOAD_CHECK": "1",

--- a/scripts/amd/run_deepseek_v4.py
+++ b/scripts/amd/run_deepseek_v4.py
@@ -408,8 +408,6 @@ def _train(args: ScriptArgs):
         "--router-health-failure-threshold 40 "  # TODO improve
         # gfx950: DSv4 sgl-kernel topk_v2 is CUDA-only; route DSA top-k through torch.
         "--sglang-dsa-topk-backend torch "
-        # Capture the default per-engine rollout batch (32 * 8 / 8 = 32).
-        "--sglang-cuda-graph-max-bs-decode 32 "
         # AITER graph registration fails through HIP IPC on gfx950; use RCCL.
         "--sglang-disable-custom-all-reduce "
     )


### PR DESCRIPTION
## Summary

Enable decode CUDA graphs for the AMD DeepSeek V4 runner.

The Torch DSA top-k fallback is graph-capturable. The observed failure came from AITER custom all-reduce graph registration through HIP IPC, so this change:

- enables decode CUDA graphs;
- uses RCCL instead of AITER custom all-reduce to avoid the HIP IPC registration failure;
- leaves decode graph capture sizing and prefill graph behavior to SGLang.

## Correctness

Validated with the full DeepSeek-V4-Flash-FP8 model using TP4/EP4 on MI355X:

- SGLang's default policy captured all 36 decode graph shapes through batch 256;
- a 256-request batch replayed successfully;
- memory offload, checkpoint reload, and graph reconstruction completed successfully;
- numerical variation remained within the existing eager ROCm FP8 execution variability.

## Performance

Decode graph replay removes repeated per-token kernel-launch overhead.