### PR TITLE
fix(tests): defer tokenizer helper import during collection

### DIFF
--- a/tests/fast/fixtures/generation_fixtures.py
+++ b/tests/fast/fixtures/generation_fixtures.py
@@ -18,7 +18,6 @@ from miles.rollout.session.server import SessionServer
 from miles.utils.async_utils import run
 from miles.utils.http_utils import find_available_port, init_http_client
 from miles.utils.misc import SingletonMeta
-from miles.utils.test_utils import mock_tools
 from miles.utils.test_utils.mock_sglang_server import ProcessResult, ProcessResultMetaInfo, with_mock_server
 from miles.utils.test_utils.uvicorn_thread_server import UvicornThreadServer
 from miles.utils.types import Sample
@@ -252,6 +251,9 @@ def with_session_server(
 
 @pytest.fixture
 def generation_env(request, variant):
+    # tests/conftest.py imports this fixture for every test; load the tokenizer-backed helper only when it is used.
+    from miles.utils.test_utils import mock_tools
+
     SingletonMeta.clear_all_instances()
     params = getattr(request, "param", {})
     args_kwargs = params.get("args_kwargs", {})


### PR DESCRIPTION
## Summary
Stop unrelated tests from loading a Hugging Face tokenizer during pytest collection.

## Symptom & Reproduction
- **Symptom:** `tests/fast-gpu/test_det_process_group.py` exits 4 during collection when `Qwen/Qwen3-0.6B` is unavailable, before any process-group test runs.
- **Reproduction:** `HF_HUB_OFFLINE=1` with an empty Hugging Face cache makes `stage-c-4-gpu-h200` partition 0 exit during collection.

## Root Cause
1. `tests/conftest.py` registers `generation_env` for every test.
2. `generation_fixtures.py` imports `mock_tools` at module scope.
3. `mock_tools._TOKENIZER` loads `Qwen/Qwen3-0.6B` during collection.

## Fix
Import `mock_tools` inside `generation_env`, preserving fixture availability while deferring the tokenizer-backed helper until the fixture is instantiated.

## Verification
- **New / updated test:** Existing `stage-c-4-gpu-h200` partition 0 ran `test_det_process_group.py` with an empty offline Hugging Face cache; all 24 tests passed.

## Review Focus
- Scrutinize the deferred `mock_tools` import inside `generation_env`.
