### PR TITLE
fix(ci): calibrate CUDA E2E estimates from run 29198133159

### DIFF
--- a/tests/e2e/ckpt/test_qwen3_4B_ckpt.py
+++ b/tests/e2e/ckpt/test_qwen3_4B_ckpt.py
@@ -4,7 +4,7 @@ from tests.ci.ci_register import register_cuda_ci, register_rocm_ci
 
 import miles.utils.external_utils.command_utils as U
 
-register_cuda_ci(est_time=1200, suite="stage-c-8-gpu-h100", labels=["ckpt"])
+register_cuda_ci(est_time=1400, suite="stage-c-8-gpu-h100", labels=["ckpt"])
 register_rocm_ci(est_time=1200, suite="stage-c-8-gpu-mi350", labels=["ckpt"])
 
 ENABLE_EVAL = bool(int(os.environ.get("MILES_TEST_ENABLE_EVAL", "1")))

--- a/tests/e2e/long/test_qwen2.5_0.5B_gsm8k.py
+++ b/tests/e2e/long/test_qwen2.5_0.5B_gsm8k.py
@@ -4,7 +4,7 @@ from tests.ci.ci_register import register_cuda_ci
 
 import miles.utils.external_utils.command_utils as U
 
-register_cuda_ci(est_time=6000, suite="stage-c-2-gpu-h200", labels=["long"])
+register_cuda_ci(est_time=7000, suite="stage-c-2-gpu-h200", labels=["long"])
 
 MODEL_NAME = "Qwen2.5-0.5B-Instruct"
 MODEL_TYPE = "qwen2.5-0.5B"

--- a/tests/e2e/long/test_qwen2.5_0.5B_gsm8k_async.py
+++ b/tests/e2e/long/test_qwen2.5_0.5B_gsm8k_async.py
@@ -4,7 +4,7 @@ from tests.ci.ci_register import register_cuda_ci, register_rocm_ci
 
 import miles.utils.external_utils.command_utils as U
 
-register_cuda_ci(est_time=5000, suite="stage-c-2-gpu-h200", labels=["long"])
+register_cuda_ci(est_time=5400, suite="stage-c-2-gpu-h200", labels=["long"])
 register_rocm_ci(est_time=5000, suite="stage-c-2-gpu-mi350", labels=["long"])
 
 MODEL_NAME = "Qwen2.5-0.5B-Instruct"

--- a/tests/e2e/lora/test_lora_qwen2.5_0.5B.py
+++ b/tests/e2e/lora/test_lora_qwen2.5_0.5B.py
@@ -17,7 +17,7 @@ from tests.ci.ci_register import register_cuda_ci, register_rocm_ci
 
 import miles.utils.external_utils.command_utils as U
 
-register_cuda_ci(est_time=300, suite="stage-c-4-gpu-h200", labels=["lora"])
+register_cuda_ci(est_time=400, suite="stage-c-4-gpu-h200", labels=["lora"])
 register_rocm_ci(est_time=300, suite="stage-c-4-gpu-mi350", labels=["lora"])
 
 

--- a/tests/e2e/megatron/test_deepseek_v32_5layer_fp8.py
+++ b/tests/e2e/megatron/test_deepseek_v32_5layer_fp8.py
@@ -15,7 +15,7 @@ from scripts.run_deepseek_v32 import (
 )
 from tests.ci.ci_register import register_cuda_ci
 
-register_cuda_ci(est_time=1800, suite="stage-c-8-gpu-h100", labels=["model-scripts"])
+register_cuda_ci(est_time=1900, suite="stage-c-8-gpu-h100", labels=["model-scripts"])
 
 
 def _args() -> ScriptArgs:

--- a/tests/e2e/megatron/test_deepseek_v4_flash_4layer_ci.py
+++ b/tests/e2e/megatron/test_deepseek_v4_flash_4layer_ci.py
@@ -3,7 +3,7 @@ import os
 from scripts.run_deepseek_v4 import ScriptArgs, _prepare_download, _prepare_single, _prepare_spmd, _train
 from tests.ci.ci_register import register_cuda_ci
 
-register_cuda_ci(est_time=1800, suite="stage-c-8-gpu-h100", labels=["model-scripts"])
+register_cuda_ci(est_time=1500, suite="stage-c-8-gpu-h100", labels=["model-scripts"])
 
 
 def _args() -> ScriptArgs:

--- a/tests/e2e/megatron/test_glm5_1_744b_a40b_6layer_lora_ci.py
+++ b/tests/e2e/megatron/test_glm5_1_744b_a40b_6layer_lora_ci.py
@@ -11,7 +11,7 @@ import miles.utils.external_utils.command_utils as U
 # Functionality, not accuracy; 4 GPUs (TP=EP=4).
 
 
-register_cuda_ci(est_time=5400, suite="stage-c-8-gpu-h100", labels=["model-scripts"])
+register_cuda_ci(est_time=2200, suite="stage-c-8-gpu-h100", labels=["model-scripts"])
 
 # skip the engine-side stacked params a frozen-base LoRA run cannot re-ship
 # (they keep their correct checkpoint values; everything else is verified)

--- a/tests/e2e/megatron/test_glm5_2_744b_a40b_5layer_ci.py
+++ b/tests/e2e/megatron/test_glm5_2_744b_a40b_5layer_ci.py
@@ -17,7 +17,7 @@ import miles.utils.external_utils.command_utils as U
 # 0,1,2 + skip layers 3,4). Verifies the script is functional, not model accuracy.
 
 
-register_cuda_ci(est_time=1800, suite="stage-c-8-gpu-h100", labels=["model-scripts"])
+register_cuda_ci(est_time=1000, suite="stage-c-8-gpu-h100", labels=["model-scripts"])
 
 
 def _args() -> ScriptArgs:

--- a/tests/e2e/megatron/test_glm5_2_744b_a40b_5layer_lora_ci.py
+++ b/tests/e2e/megatron/test_glm5_2_744b_a40b_5layer_lora_ci.py
@@ -11,7 +11,7 @@ import miles.utils.external_utils.command_utils as U
 # combination must pass. Functionality, not accuracy; 4 GPUs (TP=EP=4).
 
 
-register_cuda_ci(est_time=5400, suite="stage-c-8-gpu-h100", labels=["model-scripts"])
+register_cuda_ci(est_time=2100, suite="stage-c-8-gpu-h100", labels=["model-scripts"])
 
 # skip the engine-side stacked params a frozen-base LoRA run cannot re-ship
 # (they keep their correct checkpoint values; everything else is verified)

--- a/tests/e2e/megatron/test_glm5_744b_a40b_4layer_ci.py
+++ b/tests/e2e/megatron/test_glm5_744b_a40b_4layer_ci.py
@@ -15,7 +15,7 @@ import miles.utils.external_utils.command_utils as U
 # This CI test is an example smoke test for the DSA model code path used by DeepSeek V3.2 and GLM-5. It only verifies that the training script is functional, not model accuracy.
 
 
-register_cuda_ci(est_time=1800, suite="stage-c-8-gpu-h100", labels=["model-scripts"])
+register_cuda_ci(est_time=800, suite="stage-c-8-gpu-h100", labels=["model-scripts"])
 
 
 def _args() -> ScriptArgs:

--- a/tests/e2e/megatron/test_glm5_744b_a40b_4layer_r3.py
+++ b/tests/e2e/megatron/test_glm5_744b_a40b_4layer_r3.py
@@ -16,7 +16,7 @@ import miles.utils.external_utils.command_utils as U
 # also forces --use-indexer-replay via miles_validate_args, so the training
 # side consumes the per-layer topk emitted by SGLang.
 
-register_cuda_ci(est_time=1100, suite="stage-c-8-gpu-h100", labels=["megatron", "replay"])
+register_cuda_ci(est_time=1200, suite="stage-c-8-gpu-h100", labels=["megatron", "replay"])
 
 
 def _args() -> ScriptArgs:

--- a/tests/e2e/megatron/test_gpt_oss_20b_moe_lora_ci.py
+++ b/tests/e2e/megatron/test_gpt_oss_20b_moe_lora_ci.py
@@ -10,7 +10,7 @@ import miles.utils.external_utils.command_utils as U
 # every combination must pass. Functionality, not accuracy; 4 GPUs (TP=4, EP=1).
 
 
-register_cuda_ci(est_time=5400, suite="stage-c-8-gpu-h100", labels=["model-scripts"])
+register_cuda_ci(est_time=1500, suite="stage-c-8-gpu-h100", labels=["model-scripts"])
 
 MODEL_NAME = "gpt-oss-20b-bf16"
 MODEL_TYPE = "gpt-oss-20b"

--- a/tests/e2e/megatron/test_kimi_k25_2layer_ci.py
+++ b/tests/e2e/megatron/test_kimi_k25_2layer_ci.py
@@ -10,7 +10,7 @@ import miles.utils.external_utils.command_utils as U
 # the training script is functional, not model accuracy.
 
 
-register_cuda_ci(est_time=1800, suite="stage-c-8-gpu-h100", labels=["model-scripts"])
+register_cuda_ci(est_time=1200, suite="stage-c-8-gpu-h100", labels=["model-scripts"])
 
 
 def _args() -> ScriptArgs:

--- a/tests/e2e/megatron/test_mimo_7B_mtp_only_grad.py
+++ b/tests/e2e/megatron/test_mimo_7B_mtp_only_grad.py
@@ -14,7 +14,7 @@ from tests.ci.ci_register import register_cuda_ci, register_rocm_ci
 
 import miles.utils.external_utils.command_utils as U
 
-register_cuda_ci(est_time=420, suite="stage-c-4-gpu-h200", labels=["megatron"])
+register_cuda_ci(est_time=400, suite="stage-c-4-gpu-h200", labels=["megatron"])
 register_rocm_ci(est_time=420, suite="stage-c-4-gpu-mi350", labels=["megatron"])
 
 MODEL_NAME = "MiMo-7B-RL"

--- a/tests/e2e/megatron/test_qwen3_30B_A3B/test_deepep_fp8.py
+++ b/tests/e2e/megatron/test_qwen3_30B_A3B/test_deepep_fp8.py
@@ -3,7 +3,7 @@ import os
 from tests.ci.ci_register import register_cuda_ci
 from tests.e2e.megatron.test_qwen3_30B_A3B._common import CaseConfig, execute, prepare
 
-register_cuda_ci(est_time=1200, suite="stage-c-8-gpu-h100", labels=["megatron"])
+register_cuda_ci(est_time=900, suite="stage-c-8-gpu-h100", labels=["megatron"])
 
 CASE = CaseConfig(
     use_deepep=True,

--- a/tests/e2e/megatron/test_qwen3_30B_A3B/test_deepep_fp8_bridge.py
+++ b/tests/e2e/megatron/test_qwen3_30B_A3B/test_deepep_fp8_bridge.py
@@ -4,7 +4,7 @@ from tests.ci.ci_register import register_cuda_ci
 from tests.e2e.megatron.test_qwen3_30B_A3B._common import CaseConfig, execute, prepare
 
 # Limited by host memory
-register_cuda_ci(est_time=900, suite="stage-c-8-gpu-h100", labels=["megatron"])
+register_cuda_ci(est_time=800, suite="stage-c-8-gpu-h100", labels=["megatron"])
 
 CASE = CaseConfig(
     use_deepep=True,

--- a/tests/e2e/megatron/test_qwen3_30B_A3B/test_disagg_broadcast.py
+++ b/tests/e2e/megatron/test_qwen3_30B_A3B/test_disagg_broadcast.py
@@ -3,7 +3,7 @@ import os
 from tests.ci.ci_register import register_cuda_ci
 from tests.e2e.megatron.test_qwen3_30B_A3B._common import CaseConfig, execute, prepare
 
-register_cuda_ci(est_time=1100, suite="stage-c-8-gpu-h100", labels=["megatron", "weight-update"])
+register_cuda_ci(est_time=1300, suite="stage-c-8-gpu-h100", labels=["megatron", "weight-update"])
 
 CASE = CaseConfig(
     use_deepep=False,

--- a/tests/e2e/megatron/test_qwen3_30B_A3B/test_int4_rollout.py
+++ b/tests/e2e/megatron/test_qwen3_30B_A3B/test_int4_rollout.py
@@ -3,7 +3,7 @@ import os
 from tests.ci.ci_register import register_cuda_ci
 from tests.e2e.megatron.test_qwen3_30B_A3B._common import CaseConfig, execute, prepare
 
-register_cuda_ci(est_time=1800, suite="stage-c-4-gpu-h200", labels=["megatron"])
+register_cuda_ci(est_time=1700, suite="stage-c-4-gpu-h200", labels=["megatron"])
 
 CASE = CaseConfig(
     use_deepep=False,

--- a/tests/e2e/megatron/test_qwen3_30B_A3B_p2p.py
+++ b/tests/e2e/megatron/test_qwen3_30B_A3B_p2p.py
@@ -9,7 +9,7 @@ ROLLOUT_NUM_GPUS = 2  # inference engine pool
 ACTOR_NUM_GPUS = NUM_GPUS - ROLLOUT_NUM_GPUS  # 6: training actor pool (p2p keeps it disjoint from rollout)
 
 register_cuda_ci(
-    est_time=900,
+    est_time=700,
     suite="stage-c-8-gpu-h100",
     labels=["megatron", "weight-update"],
 )

--- a/tests/e2e/megatron/test_qwen3_5_35B_A3B_mtp/test_mtp0_spec_v2.py
+++ b/tests/e2e/megatron/test_qwen3_5_35B_A3B_mtp/test_mtp0_spec_v2.py
@@ -14,7 +14,7 @@ import os
 from tests.ci.ci_register import register_cuda_ci
 from tests.e2e.megatron.test_qwen3_5_35B_A3B_mtp._common import CaseConfig, execute, prepare
 
-register_cuda_ci(est_time=1200, suite="stage-c-8-gpu-h100", labels=["megatron", "qwen35"])
+register_cuda_ci(est_time=1800, suite="stage-c-8-gpu-h100", labels=["megatron", "qwen35"])
 
 CASE = CaseConfig(
     # tp2/cp2/pp2/ep4: TP=4 hits a Qwen3.5 attention-output-gate sharding bug, so stay at

--- a/tests/e2e/megatron/test_qwen3_5_35B_A3B_mtp/test_mtp1_spec_v2_r3.py
+++ b/tests/e2e/megatron/test_qwen3_5_35B_A3B_mtp/test_mtp1_spec_v2_r3.py
@@ -10,7 +10,7 @@ import os
 from tests.ci.ci_register import register_cuda_ci
 from tests.e2e.megatron.test_qwen3_5_35B_A3B_mtp._common import CaseConfig, execute, prepare
 
-register_cuda_ci(est_time=1200, suite="stage-c-8-gpu-h100", labels=["megatron", "qwen35"])
+register_cuda_ci(est_time=1600, suite="stage-c-8-gpu-h100", labels=["megatron", "qwen35"])
 
 CASE = CaseConfig(
     # tp2/pp2/cp1/ep4: TP=4 hits a Qwen3.5 attention-output-gate sharding bug, so stay at

--- a/tests/e2e/precision/test_hf_attention_cp_relayout.py
+++ b/tests/e2e/precision/test_hf_attention_cp_relayout.py
@@ -13,7 +13,7 @@ import torch.distributed as dist
 
 from tests.ci.ci_register import register_cuda_ci, register_rocm_ci
 
-register_cuda_ci(est_time=60, suite="stage-c-4-gpu-h200", labels=["precision"])
+register_cuda_ci(est_time=30, suite="stage-c-4-gpu-h200", labels=["precision"])
 register_rocm_ci(est_time=60, suite="stage-c-4-gpu-mi350", labels=["precision"])
 
 from miles_plugins.models.hf_attention import _packed_shard_to_zigzag, _zigzag_to_packed_shard

--- a/tests/e2e/precision/test_qwen3_5_cp_correctness.py
+++ b/tests/e2e/precision/test_qwen3_5_cp_correctness.py
@@ -16,7 +16,7 @@ import torch.distributed as dist
 
 from tests.ci.ci_register import register_cuda_ci, register_rocm_ci
 
-register_cuda_ci(est_time=120, suite="stage-c-4-gpu-h200", labels=["precision"])
+register_cuda_ci(est_time=300, suite="stage-c-4-gpu-h200", labels=["precision"])
 register_rocm_ci(est_time=120, suite="stage-c-4-gpu-mi350", labels=["precision"])
 
 

--- a/tests/e2e/sglang/test_r3_router_equivalence.py
+++ b/tests/e2e/sglang/test_r3_router_equivalence.py
@@ -2,7 +2,7 @@ from tests.ci.ci_register import register_cuda_ci
 
 # Two model families run sequentially in one job, so est_time is roughly 2x
 # of a single family.
-register_cuda_ci(est_time=900, suite="stage-c-4-gpu-h200", labels=["sglang"])
+register_cuda_ci(est_time=1000, suite="stage-c-4-gpu-h200", labels=["sglang"])
 
 """E2E test: verify sglang router and miles router produce identical rollout
 routing replay results across MoE models.

--- a/tests/e2e/sglang/test_session_server_multi_role/test_deepseekv4.py
+++ b/tests/e2e/sglang/test_session_server_multi_role/test_deepseekv4.py
@@ -1,7 +1,7 @@
 from tests.ci.ci_register import register_cuda_ci
 from tests.e2e.sglang.test_session_server_multi_role._common import ModelConfig, run_one
 
-register_cuda_ci(est_time=1700, suite="stage-c-4-gpu-h200", labels=["sglang"])
+register_cuda_ci(est_time=1000, suite="stage-c-4-gpu-h200", labels=["sglang"])
 
 
 CONFIG = ModelConfig(

--- a/tests/e2e/sglang/test_session_server_multi_role/test_glm47.py
+++ b/tests/e2e/sglang/test_session_server_multi_role/test_glm47.py
@@ -1,7 +1,7 @@
 from tests.ci.ci_register import register_cuda_ci
 from tests.e2e.sglang.test_session_server_multi_role._common import ModelConfig, run_one
 
-register_cuda_ci(est_time=400, suite="stage-c-4-gpu-h200", labels=["sglang"])
+register_cuda_ci(est_time=500, suite="stage-c-4-gpu-h200", labels=["sglang"])
 
 
 CONFIG = ModelConfig(

--- a/tests/e2e/sglang/test_session_server_multi_role/test_minimax_m27.py
+++ b/tests/e2e/sglang/test_session_server_multi_role/test_minimax_m27.py
@@ -10,7 +10,7 @@ tests/fast/utils/chat_template_utils/.
 from tests.ci.ci_register import register_cuda_ci
 from tests.e2e.sglang.test_session_server_multi_role._common import ModelConfig, run_one
 
-register_cuda_ci(est_time=900, suite="stage-c-4-gpu-h200", labels=["sglang"])
+register_cuda_ci(est_time=600, suite="stage-c-4-gpu-h200", labels=["sglang"])
 
 
 # MiniMax-M2.7 (MiniMaxM2ForCausalLM arch, 62 layers, 8 KV heads, ~215GB fp8).

--- a/tests/e2e/sglang/test_session_server_multi_role/test_nemotron3.py
+++ b/tests/e2e/sglang/test_session_server_multi_role/test_nemotron3.py
@@ -1,7 +1,7 @@
 from tests.ci.ci_register import register_cuda_ci
 from tests.e2e.sglang.test_session_server_multi_role._common import ModelConfig, run_one
 
-register_cuda_ci(est_time=1200, suite="stage-c-4-gpu-h200", labels=["sglang"])
+register_cuda_ci(est_time=800, suite="stage-c-4-gpu-h200", labels=["sglang"])
 
 
 # Nemotron-3-Super-120B-A12B-FP8 (~120GB fp8, A12B activated).

--- a/tests/e2e/sglang/test_session_server_multi_role/test_qwen3.py
+++ b/tests/e2e/sglang/test_session_server_multi_role/test_qwen3.py
@@ -1,7 +1,7 @@
 from tests.ci.ci_register import register_cuda_ci
 from tests.e2e.sglang.test_session_server_multi_role._common import ModelConfig, run_one
 
-register_cuda_ci(est_time=400, suite="stage-c-4-gpu-h200", labels=["sglang"])
+register_cuda_ci(est_time=600, suite="stage-c-4-gpu-h200", labels=["sglang"])
 
 
 CONFIG = ModelConfig(

--- a/tests/e2e/sglang/test_session_server_multi_role/test_qwen35.py
+++ b/tests/e2e/sglang/test_session_server_multi_role/test_qwen35.py
@@ -1,7 +1,7 @@
 from tests.ci.ci_register import register_cuda_ci
 from tests.e2e.sglang.test_session_server_multi_role._common import ModelConfig, run_one
 
-register_cuda_ci(est_time=400, suite="stage-c-4-gpu-h200", labels=["sglang"])
+register_cuda_ci(est_time=500, suite="stage-c-4-gpu-h200", labels=["sglang"])
 
 
 CONFIG = ModelConfig(

--- a/tests/e2e/sglang_config/test_sglang_config.py
+++ b/tests/e2e/sglang_config/test_sglang_config.py
@@ -5,7 +5,7 @@ from tests.ci.ci_register import register_cuda_ci, register_rocm_ci
 
 import miles.utils.external_utils.command_utils as U
 
-register_cuda_ci(est_time=600, suite="stage-c-8-gpu-h100", labels=["short"])
+register_cuda_ci(est_time=400, suite="stage-c-8-gpu-h100", labels=["short"])
 register_rocm_ci(est_time=600, suite="stage-c-8-gpu-mi350", labels=["short"])
 
 MODEL_NAME = "Qwen2.5-0.5B-Instruct"

--- a/tests/e2e/sglang_config/test_sglang_config_mixed_offload.py
+++ b/tests/e2e/sglang_config/test_sglang_config_mixed_offload.py
@@ -20,7 +20,7 @@ from tests.ci.ci_register import register_cuda_ci, register_rocm_ci
 
 import miles.utils.external_utils.command_utils as U
 
-register_cuda_ci(est_time=300, suite="stage-c-8-gpu-h100", labels=["short"])
+register_cuda_ci(est_time=400, suite="stage-c-8-gpu-h100", labels=["short"])
 register_rocm_ci(est_time=300, suite="stage-c-8-gpu-mi350", labels=["short"])
 
 MODEL_NAME = "Qwen2.5-0.5B-Instruct"

--- a/tests/e2e/sglang_config/test_sglang_config_mixed_offload_ft.py
+++ b/tests/e2e/sglang_config/test_sglang_config_mixed_offload_ft.py
@@ -17,7 +17,7 @@ from tests.ci.ci_register import register_cuda_ci, register_rocm_ci
 
 import miles.utils.external_utils.command_utils as U
 
-register_cuda_ci(est_time=600, suite="stage-c-8-gpu-h100", labels=["short"])
+register_cuda_ci(est_time=500, suite="stage-c-8-gpu-h100", labels=["short"])
 register_rocm_ci(est_time=600, suite="stage-c-8-gpu-mi350", labels=["short"])
 
 MODEL_NAME = "Qwen2.5-0.5B-Instruct"

--- a/tests/e2e/short/test_dumper.py
+++ b/tests/e2e/short/test_dumper.py
@@ -31,7 +31,7 @@ from tests.e2e.conftest_dumper import (
 
 import miles.utils.external_utils.command_utils as U
 
-register_cuda_ci(est_time=2000, suite="stage-c-8-gpu-h100", labels=["short"])
+register_cuda_ci(est_time=1100, suite="stage-c-8-gpu-h100", labels=["short"])
 
 
 app: typer.Typer = typer.Typer()

--- a/tests/e2e/short/test_qwen2.5_0.5B_gsm8k_async_short.py
+++ b/tests/e2e/short/test_qwen2.5_0.5B_gsm8k_async_short.py
@@ -4,7 +4,7 @@ from tests.ci.ci_register import register_cuda_ci, register_rocm_ci
 
 import miles.utils.external_utils.command_utils as U
 
-register_cuda_ci(est_time=240, suite="stage-c-8-gpu-h100", labels=["short"])
+register_cuda_ci(est_time=400, suite="stage-c-8-gpu-h100", labels=["short"])
 register_rocm_ci(est_time=240, suite="stage-c-8-gpu-mi350", labels=["short"])
 
 FEW_GPU = U.get_bool_env_var("MILES_TEST_FEW_GPU", "0")

--- a/tests/e2e/short/test_qwen2.5_0.5B_gsm8k_short.py
+++ b/tests/e2e/short/test_qwen2.5_0.5B_gsm8k_short.py
@@ -4,7 +4,7 @@ from tests.ci.ci_register import register_cuda_ci, register_rocm_ci
 
 import miles.utils.external_utils.command_utils as U
 
-register_cuda_ci(est_time=360, suite="stage-c-8-gpu-h100", labels=["short"])
+register_cuda_ci(est_time=400, suite="stage-c-8-gpu-h100", labels=["short"])
 register_rocm_ci(est_time=360, suite="stage-c-8-gpu-mi350", labels=["short"])
 
 FEW_GPU = U.get_bool_env_var("MILES_TEST_FEW_GPU", "0")

--- a/tests/e2e/short/test_qwen2.5_0.5B_opd_sglang.py
+++ b/tests/e2e/short/test_qwen2.5_0.5B_opd_sglang.py
@@ -7,7 +7,7 @@ from tests.ci.ci_register import register_cuda_ci
 
 import miles.utils.external_utils.command_utils as U
 
-register_cuda_ci(est_time=900, suite="stage-c-8-gpu-h100", labels=["short"])
+register_cuda_ci(est_time=400, suite="stage-c-8-gpu-h100", labels=["short"])
 
 TIGHT_DEVICE_MEMORY = U.get_bool_env_var("MILES_TEST_TIGHT_DEVICE_MEMORY", "1")
 

--- a/tests/e2e/short/test_run_megatron.py
+++ b/tests/e2e/short/test_run_megatron.py
@@ -35,7 +35,7 @@ NUM_LAYERS: int = 5
 
 _RUN_DIR: Path = Path(tempfile.mkdtemp(prefix="test_run_megatron_"))
 
-register_cuda_ci(est_time=2000, suite="stage-c-8-gpu-h100", labels=["short"])
+register_cuda_ci(est_time=200, suite="stage-c-8-gpu-h100", labels=["short"])
 register_rocm_ci(est_time=2000, suite="stage-c-8-gpu-mi350", labels=["short"])
 
 


### PR DESCRIPTION
## Summary
Calibrate CUDA E2E partition estimates from complete timings in run 29198133159.

## Symptom & Reproduction
- **Symptom:** 38 passed CUDA E2E files had estimates outside the run-based calibration result.
- **Reproduction:** Compare run 29198133159 canonical `End (i/n):` timings with each file's `register_cuda_ci` value.

## Root Cause
1. `register_cuda_ci` stored stale estimates for 38 passed E2E files.
2. `RegistryVisitor._parse_call_args` copies each estimate into `CIRegistry.est_time`.
3. `auto_partition` uses `CIRegistry.est_time` as its LPT cost.

## Fix
Calibrate 38 CUDA E2E estimates from complete passed-job timings with a 25% margin and bucket rounding. Skipped jobs and the failed disk-delta test remain unchanged. Each passed file uses `ceil(max_elapsed_s * 1.25)`, rounded up to a 10-second bucket through 200 seconds or a 100-second bucket above 200 seconds.

## Verification
- **Source run:** [Scheduled `PR Test` run 29198133159](https://github.com/radixark/miles/actions/runs/29198133159) ran on `main@5e392cf2`.
- **Timing evidence:** Independent parsing found 43 rows with 42 passes.
- **Failed evidence:** One failed row remains excluded from calibration.
- **Formula:** Independent recomputation found zero formula errors.
- **Scope:** AST validation found exactly 38 estimate-only file changes.
- **Convergence:** Recomputing from the same logs changed all 38 proposals to keep.
- **Patch hygiene:** `git diff --check origin/main..ci/e2e-estimates-29198133159` exited 0.
- **Suite selection:** Ten full or partitioned `run_suite.py --list-only` invocations exited 0.
- **Partition coverage:** Each affected suite's partition union matched its full selection.
- **GPU E2E:** Not rerun; run 29198133159 supplies the runtime evidence.

## Review Focus
- Scrutinize the single-run evidence behind lowered `register_cuda_ci` values.
- Confirm every diff changes only the `est_time` integer literal.
- Confirm `test_qwen3_4B_disk_delta.py` remains unchanged after its failed sample.
