### PR TITLE
fix(ci): align model-script jobs with GPU allocation

### DIFF
--- a/scripts/run_glm5_1_744b_a40b_lora.py
+++ b/scripts/run_glm5_1_744b_a40b_lora.py
@@ -262,7 +262,7 @@ def _train(args: ScriptArgs):
 
     save_args = f"--save-interval 1 --save {load_save_path} "
 
-    misc_args = f"--attention-dropout 0.0 --hidden-dropout 0.0 --accumulate-allreduce-grads-in-fp32 --attention-softmax-in-fp32 --attention-backend flash --calculate-per-token-loss --use-miles-router --actor-num-nodes 1 --actor-num-gpus-per-node {args.num_gpus_per_node} --colocate "
+    misc_args = f"--attention-dropout 0.0 --hidden-dropout 0.0 --accumulate-allreduce-grads-in-fp32 --attention-softmax-in-fp32 --attention-backend flash --calculate-per-token-loss --use-miles-router --actor-num-nodes 1 --actor-num-gpus-per-node {args.num_gpus_per_node} --num-gpus-per-node {args.num_gpus_per_node} --colocate "
 
     wandb_args = U.get_default_wandb_args(__file__, run_id=args.run_id) if args.enable_wandb else ""
 

--- a/scripts/run_glm5_2_744b_a40b_lora.py
+++ b/scripts/run_glm5_2_744b_a40b_lora.py
@@ -262,7 +262,7 @@ def _train(args: ScriptArgs):
 
     save_args = f"--save-interval 1 --save {load_save_path} "
 
-    misc_args = f"--attention-dropout 0.0 --hidden-dropout 0.0 --accumulate-allreduce-grads-in-fp32 --attention-softmax-in-fp32 --attention-backend flash --calculate-per-token-loss --use-miles-router --actor-num-nodes 1 --actor-num-gpus-per-node {args.num_gpus_per_node} --colocate "
+    misc_args = f"--attention-dropout 0.0 --hidden-dropout 0.0 --accumulate-allreduce-grads-in-fp32 --attention-softmax-in-fp32 --attention-backend flash --calculate-per-token-loss --use-miles-router --actor-num-nodes 1 --actor-num-gpus-per-node {args.num_gpus_per_node} --num-gpus-per-node {args.num_gpus_per_node} --colocate "
 
     wandb_args = U.get_default_wandb_args(__file__, run_id=args.run_id) if args.enable_wandb else ""
 

--- a/scripts/run_kimi_k25.py
+++ b/scripts/run_kimi_k25.py
@@ -141,11 +141,11 @@ def _execute_train(args: ScriptArgs):
 
     if args.num_nodes == 1:  # single-node 2-layer minimal test
         perf_args = (
-            "--tensor-model-parallel-size 8 "
+            f"--tensor-model-parallel-size {args.num_gpus_per_node} "
             "--sequence-parallel "
             "--pipeline-model-parallel-size 1 "
             "--context-parallel-size 1 "
-            "--expert-model-parallel-size 8 "
+            f"--expert-model-parallel-size {args.num_gpus_per_node} "
             "--expert-tensor-parallel-size 1 "
         )
         max_tokens_per_gpu = 2048

--- a/tests/e2e/megatron/model_scripts/test_deepseek_v32_5layer_fp8.py
+++ b/tests/e2e/megatron/model_scripts/test_deepseek_v32_5layer_fp8.py
@@ -15,7 +15,7 @@ from scripts.run_deepseek_v32 import (
 )
 from tests.ci.ci_register import register_cuda_ci
 
-register_cuda_ci(est_time=1900, suite="stage-c-8-gpu-h200", labels=["megatron", "model-scripts"])
+register_cuda_ci(est_time=1700, suite="stage-c-8-gpu-h200", labels=["megatron", "model-scripts"])
 
 
 def _args() -> ScriptArgs:

--- a/tests/e2e/megatron/model_scripts/test_deepseek_v32_5layer_fp8.py
+++ b/tests/e2e/megatron/model_scripts/test_deepseek_v32_5layer_fp8.py
@@ -1,4 +1,4 @@
-"""DeepSeek V3.2 5-layer CI smoke test on H100.
+"""DeepSeek V3.2 5-layer CI smoke test on H200.
 
 FP8 rollout using the raw DeepSeek FP8 checkpoint (no re-quantization).
 BF16 training via Megatron. Thin wrapper around scripts/run_deepseek_v32.py.
@@ -15,7 +15,7 @@ from scripts.run_deepseek_v32 import (
 )
 from tests.ci.ci_register import register_cuda_ci
 
-register_cuda_ci(est_time=1900, suite="stage-c-8-gpu-h100", labels=["megatron", "model-scripts"])
+register_cuda_ci(est_time=1900, suite="stage-c-8-gpu-h200", labels=["megatron", "model-scripts"])
 
 
 def _args() -> ScriptArgs:
@@ -23,7 +23,7 @@ def _args() -> ScriptArgs:
         model_org="Pinaster",
         model_name="DeepSeek-V3.2-5layer",
         megatron_model_type="deepseek-v32-5layer",
-        hardware="H100",
+        hardware="H200",
         use_single_node=True,
         from_bf16_ckpt=False,
         num_rollout=2,

--- a/tests/e2e/megatron/model_scripts/test_deepseek_v4_flash_4layer_ci.py
+++ b/tests/e2e/megatron/model_scripts/test_deepseek_v4_flash_4layer_ci.py
@@ -3,7 +3,7 @@ import os
 from scripts.run_deepseek_v4 import ScriptArgs, _prepare_download, _prepare_single, _prepare_spmd, _train
 from tests.ci.ci_register import register_cuda_ci
 
-register_cuda_ci(est_time=1500, suite="stage-c-8-gpu-h100", labels=["megatron", "model-scripts"])
+register_cuda_ci(est_time=1500, suite="stage-c-4-gpu-h200", labels=["megatron", "model-scripts"])
 
 
 def _args() -> ScriptArgs:
@@ -12,7 +12,7 @@ def _args() -> ScriptArgs:
         task="gsm8k",
         enable_eval=False,
         num_nodes=1,
-        num_gpus_per_node=8,
+        num_gpus_per_node=4,
         skip_saving=True,
         use_fault_tolerance=False,
         extra_args=(

--- a/tests/e2e/megatron/model_scripts/test_deepseek_v4_flash_4layer_ci.py
+++ b/tests/e2e/megatron/model_scripts/test_deepseek_v4_flash_4layer_ci.py
@@ -3,7 +3,7 @@ import os
 from scripts.run_deepseek_v4 import ScriptArgs, _prepare_download, _prepare_single, _prepare_spmd, _train
 from tests.ci.ci_register import register_cuda_ci
 
-register_cuda_ci(est_time=1500, suite="stage-c-4-gpu-h200", labels=["megatron", "model-scripts"])
+register_cuda_ci(est_time=1900, suite="stage-c-4-gpu-h200", labels=["megatron", "model-scripts"])
 
 
 def _args() -> ScriptArgs:

--- a/tests/e2e/megatron/model_scripts/test_glm5_1_744b_a40b_6layer_lora_ci.py
+++ b/tests/e2e/megatron/model_scripts/test_glm5_1_744b_a40b_6layer_lora_ci.py
@@ -11,7 +11,7 @@ import miles.utils.external_utils.command_utils as U
 # Functionality, not accuracy; 8 GPUs (TP=EP=8).
 
 
-register_cuda_ci(est_time=2200, suite="stage-c-8-gpu-h200", labels=["megatron", "model-scripts", "lora"])
+register_cuda_ci(est_time=2400, suite="stage-c-8-gpu-h200", labels=["megatron", "model-scripts", "lora"])
 
 # skip the engine-side stacked params a frozen-base LoRA run cannot re-ship
 # (they keep their correct checkpoint values; everything else is verified)

--- a/tests/e2e/megatron/model_scripts/test_glm5_1_744b_a40b_6layer_lora_ci.py
+++ b/tests/e2e/megatron/model_scripts/test_glm5_1_744b_a40b_6layer_lora_ci.py
@@ -8,10 +8,10 @@ import miles.utils.external_utils.command_utils as U
 # Smoke test for scripts/run_glm5_1_744b_a40b_lora.py on the 6-layer toy (full rollout ->
 # train -> save loop). Runs the MoE-expert LoRA matrix — {shared-outer + virtual-experts,
 # per-expert + no-virtual-experts} x {tilelang, megatron} — and every combination must pass.
-# Functionality, not accuracy; 4 GPUs (TP=EP=4).
+# Functionality, not accuracy; 8 GPUs (TP=EP=8).
 
 
-register_cuda_ci(est_time=2200, suite="stage-c-4-gpu-h200", labels=["megatron", "model-scripts", "lora"])
+register_cuda_ci(est_time=2200, suite="stage-c-8-gpu-h200", labels=["megatron", "model-scripts", "lora"])
 
 # skip the engine-side stacked params a frozen-base LoRA run cannot re-ship
 # (they keep their correct checkpoint values; everything else is verified)
@@ -35,7 +35,7 @@ def _args(dsa: str, shared_outer: bool, virtual_experts: bool) -> ScriptArgs:
     return ScriptArgs(
         model_name="GLM-5.1-6layer",
         num_nodes=1,
-        num_gpus_per_node=4,
+        num_gpus_per_node=8,
         num_rollout=1,
         enable_wandb=False,
         dsa_attention_backend=dsa,

--- a/tests/e2e/megatron/model_scripts/test_glm5_1_744b_a40b_6layer_lora_ci.py
+++ b/tests/e2e/megatron/model_scripts/test_glm5_1_744b_a40b_6layer_lora_ci.py
@@ -11,7 +11,7 @@ import miles.utils.external_utils.command_utils as U
 # Functionality, not accuracy; 4 GPUs (TP=EP=4).
 
 
-register_cuda_ci(est_time=2200, suite="stage-c-8-gpu-h100", labels=["megatron", "model-scripts", "lora"])
+register_cuda_ci(est_time=2200, suite="stage-c-4-gpu-h200", labels=["megatron", "model-scripts", "lora"])
 
 # skip the engine-side stacked params a frozen-base LoRA run cannot re-ship
 # (they keep their correct checkpoint values; everything else is verified)

--- a/tests/e2e/megatron/model_scripts/test_glm5_2_744b_a40b_5layer_ci.py
+++ b/tests/e2e/megatron/model_scripts/test_glm5_2_744b_a40b_5layer_ci.py
@@ -17,16 +17,22 @@ import miles.utils.external_utils.command_utils as U
 # 0,1,2 + skip layers 3,4). Verifies the script is functional, not model accuracy.
 
 
-register_cuda_ci(est_time=1000, suite="stage-c-8-gpu-h100", labels=["megatron", "model-scripts"])
+register_cuda_ci(est_time=1000, suite="stage-c-2-gpu-h200", labels=["megatron", "model-scripts"])
 
 
 def _args() -> ScriptArgs:
     return ScriptArgs(
         model_name="GLM-5.2_5layer",
         num_nodes=1,
-        num_gpus_per_node=8,
+        num_gpus_per_node=2,
         num_rollout=2,
-        extra_args=("--ci-test " "--ci-disable-logprobs-checker " "--disable-weights-backuper "),
+        enable_optimizer_offload=True,
+        extra_args=(
+            "--ci-test "
+            "--ci-disable-logprobs-checker "
+            "--disable-weights-backuper "
+            "--tensor-model-parallel-size 2 "
+        ),
     )
 
 

--- a/tests/e2e/megatron/model_scripts/test_glm5_2_744b_a40b_5layer_ci.py
+++ b/tests/e2e/megatron/model_scripts/test_glm5_2_744b_a40b_5layer_ci.py
@@ -17,22 +17,17 @@ import miles.utils.external_utils.command_utils as U
 # 0,1,2 + skip layers 3,4). Verifies the script is functional, not model accuracy.
 
 
-register_cuda_ci(est_time=1000, suite="stage-c-2-gpu-h200", labels=["megatron", "model-scripts"])
+register_cuda_ci(est_time=1000, suite="stage-c-4-gpu-h200", labels=["megatron", "model-scripts"])
 
 
 def _args() -> ScriptArgs:
     return ScriptArgs(
         model_name="GLM-5.2_5layer",
         num_nodes=1,
-        num_gpus_per_node=2,
+        num_gpus_per_node=4,
         num_rollout=2,
         enable_optimizer_offload=True,
-        extra_args=(
-            "--ci-test "
-            "--ci-disable-logprobs-checker "
-            "--disable-weights-backuper "
-            "--tensor-model-parallel-size 2 "
-        ),
+        extra_args=("--ci-test " "--ci-disable-logprobs-checker " "--disable-weights-backuper "),
     )
 
 

--- a/tests/e2e/megatron/model_scripts/test_glm5_2_744b_a40b_5layer_ci.py
+++ b/tests/e2e/megatron/model_scripts/test_glm5_2_744b_a40b_5layer_ci.py
@@ -17,7 +17,7 @@ import miles.utils.external_utils.command_utils as U
 # 0,1,2 + skip layers 3,4). Verifies the script is functional, not model accuracy.
 
 
-register_cuda_ci(est_time=1000, suite="stage-c-4-gpu-h200", labels=["megatron", "model-scripts"])
+register_cuda_ci(est_time=900, suite="stage-c-4-gpu-h200", labels=["megatron", "model-scripts"])
 
 
 def _args() -> ScriptArgs:

--- a/tests/e2e/megatron/model_scripts/test_glm5_2_744b_a40b_5layer_lora_ci.py
+++ b/tests/e2e/megatron/model_scripts/test_glm5_2_744b_a40b_5layer_lora_ci.py
@@ -11,7 +11,7 @@ import miles.utils.external_utils.command_utils as U
 # combination must pass. Functionality, not accuracy; 4 GPUs (TP=EP=4).
 
 
-register_cuda_ci(est_time=2100, suite="stage-c-4-gpu-h200", labels=["megatron", "model-scripts", "lora"])
+register_cuda_ci(est_time=2400, suite="stage-c-4-gpu-h200", labels=["megatron", "model-scripts", "lora"])
 
 # skip the engine-side stacked params a frozen-base LoRA run cannot re-ship
 # (they keep their correct checkpoint values; everything else is verified)

--- a/tests/e2e/megatron/model_scripts/test_glm5_2_744b_a40b_5layer_lora_ci.py
+++ b/tests/e2e/megatron/model_scripts/test_glm5_2_744b_a40b_5layer_lora_ci.py
@@ -11,7 +11,7 @@ import miles.utils.external_utils.command_utils as U
 # combination must pass. Functionality, not accuracy; 4 GPUs (TP=EP=4).
 
 
-register_cuda_ci(est_time=2100, suite="stage-c-8-gpu-h100", labels=["megatron", "model-scripts", "lora"])
+register_cuda_ci(est_time=2100, suite="stage-c-4-gpu-h200", labels=["megatron", "model-scripts", "lora"])
 
 # skip the engine-side stacked params a frozen-base LoRA run cannot re-ship
 # (they keep their correct checkpoint values; everything else is verified)

--- a/tests/e2e/megatron/model_scripts/test_glm5_2_744b_a40b_5layer_lora_ci.py
+++ b/tests/e2e/megatron/model_scripts/test_glm5_2_744b_a40b_5layer_lora_ci.py
@@ -8,10 +8,10 @@ import miles.utils.external_utils.command_utils as U
 # Smoke test for scripts/run_glm5_2_744b_a40b_lora.py on the 5-layer toy (DSA cross-layer
 # path, full rollout -> train -> save loop). Runs the MoE-expert LoRA matrix — {shared-outer +
 # virtual-experts, per-expert + no-virtual-experts} x {tilelang, megatron} — and every
-# combination must pass. Functionality, not accuracy; 4 GPUs (TP=EP=4).
+# combination must pass. Functionality, not accuracy; 2 GPUs (TP=EP=2).
 
 
-register_cuda_ci(est_time=2100, suite="stage-c-4-gpu-h200", labels=["megatron", "model-scripts", "lora"])
+register_cuda_ci(est_time=2100, suite="stage-c-2-gpu-h200", labels=["megatron", "model-scripts", "lora"])
 
 # skip the engine-side stacked params a frozen-base LoRA run cannot re-ship
 # (they keep their correct checkpoint values; everything else is verified)
@@ -35,7 +35,7 @@ def _args(dsa: str, shared_outer: bool, virtual_experts: bool) -> ScriptArgs:
     return ScriptArgs(
         model_name="GLM-5.2_5layer",
         num_nodes=1,
-        num_gpus_per_node=4,
+        num_gpus_per_node=2,
         num_rollout=2,
         enable_wandb=False,
         dsa_attention_backend=dsa,

--- a/tests/e2e/megatron/model_scripts/test_glm5_2_744b_a40b_5layer_lora_ci.py
+++ b/tests/e2e/megatron/model_scripts/test_glm5_2_744b_a40b_5layer_lora_ci.py
@@ -8,10 +8,10 @@ import miles.utils.external_utils.command_utils as U
 # Smoke test for scripts/run_glm5_2_744b_a40b_lora.py on the 5-layer toy (DSA cross-layer
 # path, full rollout -> train -> save loop). Runs the MoE-expert LoRA matrix — {shared-outer +
 # virtual-experts, per-expert + no-virtual-experts} x {tilelang, megatron} — and every
-# combination must pass. Functionality, not accuracy; 2 GPUs (TP=EP=2).
+# combination must pass. Functionality, not accuracy; 4 GPUs (TP=EP=4).
 
 
-register_cuda_ci(est_time=2100, suite="stage-c-2-gpu-h200", labels=["megatron", "model-scripts", "lora"])
+register_cuda_ci(est_time=2100, suite="stage-c-4-gpu-h200", labels=["megatron", "model-scripts", "lora"])
 
 # skip the engine-side stacked params a frozen-base LoRA run cannot re-ship
 # (they keep their correct checkpoint values; everything else is verified)
@@ -35,7 +35,7 @@ def _args(dsa: str, shared_outer: bool, virtual_experts: bool) -> ScriptArgs:
     return ScriptArgs(
         model_name="GLM-5.2_5layer",
         num_nodes=1,
-        num_gpus_per_node=2,
+        num_gpus_per_node=4,
         num_rollout=2,
         enable_wandb=False,
         dsa_attention_backend=dsa,

--- a/tests/e2e/megatron/model_scripts/test_glm5_744b_a40b_4layer_ci.py
+++ b/tests/e2e/megatron/model_scripts/test_glm5_744b_a40b_4layer_ci.py
@@ -15,16 +15,22 @@ import miles.utils.external_utils.command_utils as U
 # This CI test is an example smoke test for the DSA model code path used by DeepSeek V3.2 and GLM-5. It only verifies that the training script is functional, not model accuracy.
 
 
-register_cuda_ci(est_time=800, suite="stage-c-8-gpu-h100", labels=["megatron", "model-scripts"])
+register_cuda_ci(est_time=800, suite="stage-c-2-gpu-h200", labels=["megatron", "model-scripts"])
 
 
 def _args() -> ScriptArgs:
     return ScriptArgs(
         model_name="GLM-5_4layer",
         num_nodes=1,
-        num_gpus_per_node=8,
+        num_gpus_per_node=2,
         num_rollout=2,
-        extra_args=("--ci-test " "--ci-disable-logprobs-checker " "--disable-weights-backuper "),
+        enable_optimizer_offload=True,
+        extra_args=(
+            "--ci-test "
+            "--ci-disable-logprobs-checker "
+            "--disable-weights-backuper "
+            "--tensor-model-parallel-size 2 "
+        ),
     )
 
 

--- a/tests/e2e/megatron/model_scripts/test_glm5_744b_a40b_4layer_ci.py
+++ b/tests/e2e/megatron/model_scripts/test_glm5_744b_a40b_4layer_ci.py
@@ -15,7 +15,7 @@ import miles.utils.external_utils.command_utils as U
 # This CI test is an example smoke test for the DSA model code path used by DeepSeek V3.2 and GLM-5. It only verifies that the training script is functional, not model accuracy.
 
 
-register_cuda_ci(est_time=800, suite="stage-c-2-gpu-h200", labels=["megatron", "model-scripts"])
+register_cuda_ci(est_time=900, suite="stage-c-2-gpu-h200", labels=["megatron", "model-scripts"])
 
 
 def _args() -> ScriptArgs:

--- a/tests/e2e/megatron/model_scripts/test_glm5_744b_a40b_4layer_r3.py
+++ b/tests/e2e/megatron/model_scripts/test_glm5_744b_a40b_4layer_r3.py
@@ -17,7 +17,7 @@ import miles.utils.external_utils.command_utils as U
 # side consumes the per-layer topk emitted by SGLang.
 
 register_cuda_ci(
-    est_time=1200,
+    est_time=1400,
     suite="stage-c-2-gpu-h200",
     labels=["megatron", "model-scripts", "replay"],
 )

--- a/tests/e2e/megatron/model_scripts/test_glm5_744b_a40b_4layer_r3.py
+++ b/tests/e2e/megatron/model_scripts/test_glm5_744b_a40b_4layer_r3.py
@@ -16,14 +16,18 @@ import miles.utils.external_utils.command_utils as U
 # also forces --use-indexer-replay via miles_validate_args, so the training
 # side consumes the per-layer topk emitted by SGLang.
 
-register_cuda_ci(est_time=1200, suite="stage-c-4-gpu-h200", labels=["megatron", "replay"])
+register_cuda_ci(
+    est_time=1200,
+    suite="stage-c-2-gpu-h200",
+    labels=["megatron", "model-scripts", "replay"],
+)
 
 
 def _args() -> ScriptArgs:
     return ScriptArgs(
         model_name="GLM-5_4layer",
         num_nodes=1,
-        num_gpus_per_node=4,
+        num_gpus_per_node=2,
         num_rollout=2,
         enable_optimizer_offload=True,
         extra_env_vars="MILES_EXPERIMENTAL_ROLLOUT_REFACTOR=1",
@@ -35,10 +39,10 @@ def _args() -> ScriptArgs:
             "--rollout-max-response-len 4096 "
             # preserve to avoid CPU OOM
             "--sglang-max-total-tokens 1900000 "
-            # exercise indexer replay across PP stages
+            # exercise indexer replay with two-way tensor and expert parallelism
             "--tensor-model-parallel-size 2 "
-            "--pipeline-model-parallel-size 2 "
-            "--expert-model-parallel-size 4 "
+            "--pipeline-model-parallel-size 1 "
+            "--expert-model-parallel-size 2 "
         ),
     )
 

--- a/tests/e2e/megatron/model_scripts/test_glm5_744b_a40b_4layer_r3.py
+++ b/tests/e2e/megatron/model_scripts/test_glm5_744b_a40b_4layer_r3.py
@@ -16,14 +16,14 @@ import miles.utils.external_utils.command_utils as U
 # also forces --use-indexer-replay via miles_validate_args, so the training
 # side consumes the per-layer topk emitted by SGLang.
 
-register_cuda_ci(est_time=1200, suite="stage-c-8-gpu-h100", labels=["megatron", "replay"])
+register_cuda_ci(est_time=1200, suite="stage-c-4-gpu-h200", labels=["megatron", "replay"])
 
 
 def _args() -> ScriptArgs:
     return ScriptArgs(
         model_name="GLM-5_4layer",
         num_nodes=1,
-        num_gpus_per_node=8,
+        num_gpus_per_node=4,
         num_rollout=2,
         enable_optimizer_offload=True,
         extra_env_vars="MILES_EXPERIMENTAL_ROLLOUT_REFACTOR=1",

--- a/tests/e2e/megatron/model_scripts/test_gpt_oss_20b_moe_lora_ci.py
+++ b/tests/e2e/megatron/model_scripts/test_gpt_oss_20b_moe_lora_ci.py
@@ -7,14 +7,14 @@ import miles.utils.external_utils.command_utils as U
 # MoE-expert LoRA smoke test on gpt-oss-20b (expert-only targets, bridge mode; CI-sized
 # version of examples/lora/run-gpt-oss-20B-megatron-moe-lora.sh). Runs both serving
 # combinations — {shared-outer + virtual-experts, per-expert + no-virtual-experts} — and
-# every combination must pass. Functionality, not accuracy; 2 GPUs (TP=2, EP=1).
+# every combination must pass. Functionality, not accuracy; 4 GPUs (TP=4, EP=1).
 
 
-register_cuda_ci(est_time=1500, suite="stage-c-2-gpu-h200", labels=["megatron", "model-scripts", "lora"])
+register_cuda_ci(est_time=1500, suite="stage-c-4-gpu-h200", labels=["megatron", "model-scripts", "lora"])
 
 MODEL_NAME = "gpt-oss-20b-bf16"
 MODEL_TYPE = "gpt-oss-20b"
-NUM_GPUS = 2
+NUM_GPUS = 4
 
 # (name, experts_shared_outer_loras, virtual_experts_serving)
 _CONFIGS = [

--- a/tests/e2e/megatron/model_scripts/test_gpt_oss_20b_moe_lora_ci.py
+++ b/tests/e2e/megatron/model_scripts/test_gpt_oss_20b_moe_lora_ci.py
@@ -7,14 +7,14 @@ import miles.utils.external_utils.command_utils as U
 # MoE-expert LoRA smoke test on gpt-oss-20b (expert-only targets, bridge mode; CI-sized
 # version of examples/lora/run-gpt-oss-20B-megatron-moe-lora.sh). Runs both serving
 # combinations — {shared-outer + virtual-experts, per-expert + no-virtual-experts} — and
-# every combination must pass. Functionality, not accuracy; 4 GPUs (TP=4, EP=1).
+# every combination must pass. Functionality, not accuracy; 2 GPUs (TP=2, EP=1).
 
 
-register_cuda_ci(est_time=1500, suite="stage-c-4-gpu-h200", labels=["megatron", "model-scripts", "lora"])
+register_cuda_ci(est_time=1500, suite="stage-c-2-gpu-h200", labels=["megatron", "model-scripts", "lora"])
 
 MODEL_NAME = "gpt-oss-20b-bf16"
 MODEL_TYPE = "gpt-oss-20b"
-NUM_GPUS = 4
+NUM_GPUS = 2
 
 # (name, experts_shared_outer_loras, virtual_experts_serving)
 _CONFIGS = [
@@ -58,7 +58,7 @@ def execute(shared_outer: bool, virtual_experts: bool):
     )
 
     perf_args = (
-        "--tensor-model-parallel-size 4 "
+        f"--tensor-model-parallel-size {NUM_GPUS} "
         "--sequence-parallel "
         "--pipeline-model-parallel-size 1 "
         "--context-parallel-size 1 "
@@ -83,7 +83,7 @@ def execute(shared_outer: bool, virtual_experts: bool):
     grpo_args = "--advantage-estimator grpo --entropy-coef 0.00 --eps-clip 0.2 --eps-clip-high 0.28 "
 
     sglang_args = (
-        "--rollout-num-gpus-per-engine 4 "
+        f"--rollout-num-gpus-per-engine {NUM_GPUS} "
         "--sglang-dtype bfloat16 "
         "--sglang-mem-fraction-static 0.2 "
         "--sglang-moe-runner-backend triton "
@@ -98,6 +98,7 @@ def execute(shared_outer: bool, virtual_experts: bool):
         "--update-weight-buffer-size 536870912 "
         "--actor-num-nodes 1 "
         f"--actor-num-gpus-per-node {NUM_GPUS} "
+        f"--num-gpus-per-node {NUM_GPUS} "
         "--colocate "
         "--ci-test "
         "--ci-disable-logprobs-checker "

--- a/tests/e2e/megatron/model_scripts/test_gpt_oss_20b_moe_lora_ci.py
+++ b/tests/e2e/megatron/model_scripts/test_gpt_oss_20b_moe_lora_ci.py
@@ -10,7 +10,7 @@ import miles.utils.external_utils.command_utils as U
 # every combination must pass. Functionality, not accuracy; 4 GPUs (TP=4, EP=1).
 
 
-register_cuda_ci(est_time=1500, suite="stage-c-8-gpu-h100", labels=["megatron", "model-scripts", "lora"])
+register_cuda_ci(est_time=1500, suite="stage-c-4-gpu-h200", labels=["megatron", "model-scripts", "lora"])
 
 MODEL_NAME = "gpt-oss-20b-bf16"
 MODEL_TYPE = "gpt-oss-20b"

--- a/tests/e2e/megatron/model_scripts/test_gpt_oss_20b_moe_lora_ci.py
+++ b/tests/e2e/megatron/model_scripts/test_gpt_oss_20b_moe_lora_ci.py
@@ -10,7 +10,7 @@ import miles.utils.external_utils.command_utils as U
 # every combination must pass. Functionality, not accuracy; 4 GPUs (TP=4, EP=1).
 
 
-register_cuda_ci(est_time=1500, suite="stage-c-4-gpu-h200", labels=["megatron", "model-scripts", "lora"])
+register_cuda_ci(est_time=1600, suite="stage-c-4-gpu-h200", labels=["megatron", "model-scripts", "lora"])
 
 MODEL_NAME = "gpt-oss-20b-bf16"
 MODEL_TYPE = "gpt-oss-20b"

--- a/tests/e2e/megatron/model_scripts/test_kimi_k25_2layer_ci.py
+++ b/tests/e2e/megatron/model_scripts/test_kimi_k25_2layer_ci.py
@@ -6,18 +6,18 @@ from tests.ci.ci_register import register_cuda_ci
 import miles.utils.external_utils.command_utils as U
 
 # Smoke test for the Kimi-K2.5 (MoE + MLA, INT4 rollout + BF16 Megatron bridge) training
-# script. It runs the 2-layer pruned model on a single 8-GPU node and only verifies that
+# script. It runs the 2-layer pruned model on a single 2-GPU H200 node and only verifies that
 # the training script is functional, not model accuracy.
 
 
-register_cuda_ci(est_time=1200, suite="stage-c-8-gpu-h100", labels=["megatron", "model-scripts"])
+register_cuda_ci(est_time=2000, suite="stage-c-2-gpu-h200", labels=["megatron", "model-scripts"])
 
 
 def _args() -> ScriptArgs:
     return ScriptArgs(
         model_name="Kimi-K2.5-2layer",
         num_nodes=1,
-        num_gpus_per_node=8,
+        num_gpus_per_node=2,
         num_rollout=2,
         extra_args=("--ci-test " "--ci-disable-logprobs-checker " "--disable-weights-backuper "),
     )

--- a/tests/e2e/megatron/model_scripts/test_kimi_k25_2layer_ci.py
+++ b/tests/e2e/megatron/model_scripts/test_kimi_k25_2layer_ci.py
@@ -10,7 +10,7 @@ import miles.utils.external_utils.command_utils as U
 # the training script is functional, not model accuracy.
 
 
-register_cuda_ci(est_time=2000, suite="stage-c-4-gpu-h200", labels=["megatron", "model-scripts"])
+register_cuda_ci(est_time=1200, suite="stage-c-4-gpu-h200", labels=["megatron", "model-scripts"])
 
 
 def _args() -> ScriptArgs:

--- a/tests/e2e/megatron/model_scripts/test_kimi_k25_2layer_ci.py
+++ b/tests/e2e/megatron/model_scripts/test_kimi_k25_2layer_ci.py
@@ -6,18 +6,18 @@ from tests.ci.ci_register import register_cuda_ci
 import miles.utils.external_utils.command_utils as U
 
 # Smoke test for the Kimi-K2.5 (MoE + MLA, INT4 rollout + BF16 Megatron bridge) training
-# script. It runs the 2-layer pruned model on a single 2-GPU H200 node and only verifies that
+# script. It runs the 2-layer pruned model on a single 4-GPU H200 node and only verifies that
 # the training script is functional, not model accuracy.
 
 
-register_cuda_ci(est_time=2000, suite="stage-c-2-gpu-h200", labels=["megatron", "model-scripts"])
+register_cuda_ci(est_time=2000, suite="stage-c-4-gpu-h200", labels=["megatron", "model-scripts"])
 
 
 def _args() -> ScriptArgs:
     return ScriptArgs(
         model_name="Kimi-K2.5-2layer",
         num_nodes=1,
-        num_gpus_per_node=2,
+        num_gpus_per_node=4,
         num_rollout=2,
         extra_args=("--ci-test " "--ci-disable-logprobs-checker " "--disable-weights-backuper "),
     )


### PR DESCRIPTION
> **Depends on:** #1670
> Stacked on the parent PR's branch. Review / merge the parent first.

## Summary
Align model-script CI stages and runtime topology with allocated GPU counts.

## Symptom & Reproduction
- **Symptom:** Three four-GPU smoke tests reserve eight-GPU H100 jobs.
- **Symptom:** The Kimi two-GPU smoke test configures an eight-GPU topology.
- **Reproduction:** Inspect the four registrations plus their generated runtime arguments on the parent branch.

## Root Cause
1. `register_cuda_ci` assigns four smoke tests to eight-GPU H100 suites.
2. `_execute_train` fixes Kimi tensor and expert parallelism at eight.
3. `_train` omits `--num-gpus-per-node` from GLM train arguments.
4. `get_miles_extra_args_provider` defaults rollout GPUs per node to eight.

## Fix
Move GPT-OSS and GLM-5 LoRA tests to 4-GPU H200 stages and Kimi K2.5 to a 2-GPU H200 stage with a 2000-second estimate. Derive Kimi TP/EP and GLM runtime GPU capacity from the configured per-node count so colocated workloads match the allocated hardware.

## Verification
- **Two-GPU suite:** Full selection listed Kimi at 2000 seconds.
- **Four-GPU suite:** Full selection listed both GLM LoRA tests plus GPT-OSS LoRA.
- **Two-GPU labels:** `run-ci-model-scripts` selected Kimi.
- **Four-GPU labels:** `run-ci-model-scripts` selected the three moved LoRA tests.
- **Partition coverage:** Each target suite's partition union matched its full selection.
- **Runtime wiring:** Kimi TP/EP now derives from `num_gpus_per_node`.
- **Runtime wiring:** Both GLM commands now pass `--num-gpus-per-node`.
- **Patch hygiene:** `git diff --check ci/megatron-model-script-coverage..ci/model-script-gpu-allocation` exited 0.
- **GPU E2E:** Not run; stage selection was verified with `--list-only`.

## Review Focus
- Scrutinize the `register_cuda_ci` suite changes against each test's topology.
- Confirm `_execute_train` preserves Kimi's eight-GPU default path.
- Confirm `_train` forwards four-GPU capacity to the Miles runtime.
