### PR TITLE
fix(rollout): stop merge_samples at routing-replay gap from aborted turns

### DIFF
--- a/miles/rollout/generate_utils/sample_utils.py
+++ b/miles/rollout/generate_utils/sample_utils.py
@@ -6,6 +6,9 @@ from miles.utils.types import Sample
 _OPD_STUDENT_TOP_LOGPROBS_KEY = "opd_student_top_logprobs"
 
 
+_REPLAY_FIELDS = ("rollout_routed_experts", "rollout_indexer_topk")
+
+
 def merge_samples(samples: list[Sample], tokenizer) -> Sample:
     acc = samples[0]
     for sample in samples[1:]:
@@ -14,8 +17,18 @@ def merge_samples(samples: list[Sample], tokenizer) -> Sample:
         # TODO (shi.dong): figure out how in-turn truncation should be handled.
         if acc.status != Sample.Status.COMPLETED:
             break
+        # An aborted/truncated turn omits the routing-replay payloads
+        # (routed_experts / indexer_topk). Replay requires every training sample
+        # to carry these end-to-end, so stop at the last fully-captured turn
+        # instead of extending into a turn with a routing gap.
+        if _introduces_replay_gap(acc, sample):
+            break
         acc = _merge_sample_pair(acc, sample, tokenizer=tokenizer)
     return acc
+
+
+def _introduces_replay_gap(a: Sample, b: Sample) -> bool:
+    return any(getattr(a, field) is not None and getattr(b, field) is None for field in _REPLAY_FIELDS)
 
 
 def _merge_sample_pair(a: Sample, b: Sample, tokenizer) -> Sample:
@@ -98,8 +111,12 @@ def _merge_sample_pair(a: Sample, b: Sample, tokenizer) -> Sample:
         assert _startswith(short=a.tokens, long=b.tokens), "b.tokens must start with a.tokens"
         assert obs_len > 0, f"obs_len must be > 0, got {obs_len}"
         if a.rollout_routed_experts is not None:
+            assert (
+                b.rollout_routed_experts is not None
+            ), "cannot merge: a has rollout_routed_experts but b does not"
             assert a.rollout_routed_experts.shape[0] <= b.rollout_routed_experts.shape[0]
         if a.rollout_indexer_topk is not None:
+            assert b.rollout_indexer_topk is not None, "cannot merge: a has rollout_indexer_topk but b does not"
             assert a.rollout_indexer_topk.shape[0] <= b.rollout_indexer_topk.shape[0]
         assert a.status == Sample.Status.COMPLETED, f"a.status must be COMPLETED, got {a.status}"
 

--- a/miles/rollout/generate_utils/sample_utils.py
+++ b/miles/rollout/generate_utils/sample_utils.py
@@ -111,9 +111,7 @@ def _merge_sample_pair(a: Sample, b: Sample, tokenizer) -> Sample:
         assert _startswith(short=a.tokens, long=b.tokens), "b.tokens must start with a.tokens"
         assert obs_len > 0, f"obs_len must be > 0, got {obs_len}"
         if a.rollout_routed_experts is not None:
-            assert (
-                b.rollout_routed_experts is not None
-            ), "cannot merge: a has rollout_routed_experts but b does not"
+            assert b.rollout_routed_experts is not None, "cannot merge: a has rollout_routed_experts but b does not"
             assert a.rollout_routed_experts.shape[0] <= b.rollout_routed_experts.shape[0]
         if a.rollout_indexer_topk is not None:
             assert b.rollout_indexer_topk is not None, "cannot merge: a has rollout_indexer_topk but b does not"

--- a/tests/fast/rollout/generate_utils/test_sample_utils.py
+++ b/tests/fast/rollout/generate_utils/test_sample_utils.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock
 import numpy
 import pytest
 
-from miles.rollout.generate_utils.sample_utils import _merge_sample_pair
+from miles.rollout.generate_utils.sample_utils import _merge_sample_pair, merge_samples
 from miles.utils.types import Sample
 
 
@@ -175,3 +175,33 @@ class TestMergeSamples:
 
         with pytest.raises(AssertionError, match="loss_mask length"):
             _merge_sample_pair(a, b, mock_tokenizer)
+
+    def test_merge_sample_pair_routed_experts_gap_raises_clear_error(self, mock_tokenizer):
+        # An aborted turn omits routed_experts; merging a routed turn into it must
+        # raise a clear assertion rather than an AttributeError on None.shape.
+        a = make_sample(tokens=[1, 2, 10], response_length=1, loss_mask=[1])
+        b = make_sample(tokens=[1, 2, 10, 20, 30], response_length=1, loss_mask=[1])
+        a.rollout_routed_experts = numpy.zeros((2, 2, 3), dtype=numpy.int32)
+        b.rollout_routed_experts = None
+
+        with pytest.raises(AssertionError, match="a has rollout_routed_experts but b does not"):
+            _merge_sample_pair(a, b, mock_tokenizer)
+
+    def test_merge_samples_stops_at_routing_gap(self, mock_tokenizer):
+        # merge_samples should keep the last fully-captured turn when a later turn
+        # lacks the replay payload, instead of crashing while extending into it.
+        t0 = make_sample(tokens=[1, 2, 10], response_length=1, loss_mask=[1])
+        t1 = make_sample(
+            tokens=[1, 2, 10, 20, 30],
+            response_length=1,
+            loss_mask=[1],
+            status=Sample.Status.TRUNCATED,
+        )
+        t0.rollout_routed_experts = numpy.zeros((2, 2, 3), dtype=numpy.int32)
+        t1.rollout_routed_experts = None
+
+        merged = merge_samples([t0, t1], mock_tokenizer)
+
+        assert merged is t0
+        assert merged.tokens == t0.tokens
+        assert merged.rollout_routed_experts is not None


### PR DESCRIPTION
## What

`merge_samples` folds a multi-turn agentic trajectory (one `Sample` per turn) into a single training `Sample`. This PR makes it stop at the last fully-captured turn when a later turn is missing its routing-replay payloads (`rollout_routed_experts` / `rollout_indexer_topk`), and turns the two crashing `.shape[0]` asserts in `_merge_sample_pair` into guards that check both operands with a clear message.

## Why

With routing replay enabled (`use_rollout_routing_replay=True`), each turn's inference response is expected to carry per-token top-k expert routing so training can replay the exact rollout routing. But a turn can legitimately come back with tokens + logprobs and **no** `routed_experts` / `indexer_topk`.

The reason is on the SGLang side. Per-token routing is captured into a buffer keyed by KV-cache slot and is only harvested at request completion (`maybe_collect_routed_experts`, gated on `req.finished()`). Two things break that:

1. **Retraction under KV-cache pressure.** When SGLang preempts/retracts a running request to free memory, `Req.reset_for_retract()` explicitly nulls the capture — the buffer is indexed by KV slots that retraction frees and reuses, so the routing is unrecoverable while the token ids survive (recomputed on resume): https://github.com/sgl-project/sglang/blob/5ab2cfe9a899d1d2dffae932fb0f6371014d0d71/python/sglang/srt/managers/schedule_batch.py#L1102
2. **Harvest can be skipped entirely** for a request torn down without a clean finish — e.g. the overlap-scheduler fast-path `if enable_overlap and (req.finished() or req.is_retracted): continue`, or an `agentic_abort` teardown of an in-flight turn.

This is exactly the high-concurrency agentic regime that triggers it: many long concurrent turns cause KV pressure (→ retraction), and the `agentic_abort` flush storm tears down in-flight turns — so some turns return tokens+logprobs with `routed_experts=None`.

When such a turn followed a completed (routed) one, `_merge_sample_pair` hit:

```python
if a.rollout_routed_experts is not None:
    assert a.rollout_routed_experts.shape[0] <= b.rollout_routed_experts.shape[0]
```

The guard only checks `a`, then unconditionally dereferences `b.rollout_routed_experts.shape[0]` → `AttributeError: 'NoneType' object has no attribute 'shape'`. That failed the samples handler and surfaced as a `502` on the session-server `/samples` POST, discarding the whole trajectory group.

Simply letting the merge succeed with `rollout_routed_experts=None` doesn't work: the training path requires the payload on **every** sample when replay is on — `fill_replay_data` in `actor.train_actor` runs unconditionally for enabled managers and raises `ValueError(f"{data_key} is required in rollout_data for replay.")` if the key is absent, and `data.py` would otherwise call `torch.from_numpy(None)`. So a routing gap cannot be carried into training at all.

## Fix

Stop the fold at the last turn that still has complete routing, mirroring the existing `break`-on-non-`COMPLETED` logic (and its `# TODO (shi.dong)` note about in-turn truncation). The returned sample stays fully routed, so nothing downstream sees a `None`, and we salvage the completed prefix instead of losing the whole group. The `.shape` asserts now also guard `b` explicitly so a direct `_merge_sample_pair` call fails loudly rather than with an opaque `AttributeError`.

## Test plan

- [x] `tests/fast/rollout/generate_utils/test_sample_utils.py` — 9 passed (7 existing + 2 new: `test_merge_sample_pair_routed_experts_gap_raises_clear_error`, `test_merge_samples_stops_at_routing_gap`)
