### PR TITLE
fix(args): skip Megatron validate_args for external SGLang server

### DIFF
--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -21,6 +21,17 @@ from miles.utils.misc import load_function
 logger = logging.getLogger(__name__)
 
 
+def is_external_model_server(args) -> bool:
+    """Return whether rollout runs against an external SGLang model server.
+
+    In this mode ``sglang_router_ip`` points at a long-lived remote server and no
+    local rollout GPUs are allocated, so the framework should skip Megatron argument
+    validation (which reads CUDA device properties) to allow evals to run on
+    CPU-only pods with no NVIDIA driver.
+    """
+    return getattr(args, "sglang_router_ip", None) is not None and args.rollout_num_gpus == 0
+
+
 def reset_arg(parser, name, **kwargs):
     """
     Reset the default value of a Megatron argument.
@@ -2170,7 +2181,7 @@ def parse_args(add_custom_arguments=None):
 
     miles_validate_args(args)
 
-    if backend == "megatron":
+    if backend == "megatron" and not is_external_model_server(args):
         megatron_validate_args(args)
 
         # always use varlen


### PR DESCRIPTION
## Summary

- Add `is_external_model_server(args)` predicate that returns `True` when `--sglang-router-ip` is set and `--rollout-num-gpus == 0`.
- Gate `megatron_validate_args` (and the associated varlen / pipeline-parallel rewrites) on `not is_external_model_server(args)`.

## Why

When rollout runs against an external SGLang model server, no local rollout GPUs are allocated. `megatron_validate_args` reads CUDA device properties during `parse_args`, which crashes on CPU-only pods that have no NVIDIA driver — this fails eval jobs before any rollout starts.

Skipping the Megatron block for external-server mode is safe because local Megatron isn't initialized in that path. `miles_validate_args` and `sglang_validate_args` still run for external-server evals.

## Assumptions

- External-server mode is identified by the combination of `sglang_router_ip is not None` and `rollout_num_gpus == 0`. Setting only one of the two keeps the existing validation path.
- The skipped block (Megatron validation, `variable_seq_lengths = True`, `allgather → alltoall` rewrite, and the `pipeline_model_parallel_size == 1` decoder assertion) only applies when local Megatron is initialized, which does not happen for external-server rollouts.

## Risks

Low. Regular training and colocated-eval runs (both `sglang_router_ip is None` or `rollout_num_gpus > 0`) hit the unchanged code path.

## Validation

- `python3 train.py --sglang-router-ip <remote> --rollout-num-gpus 0 ...` no longer trips `megatron_validate_args` at `parse_args` time.
- Regular Megatron training runs unaffected (predicate returns `False`).
- `pre-commit run --files miles/utils/arguments.py` clean.