### PR TITLE
fix(ci): exclude long tests from image scope

### DIFF
--- a/docs/ci/00-stage.md
+++ b/docs/ci/00-stage.md
@@ -33,7 +33,7 @@ Stage names follow `stage-<tier>-<gpus>-<hw>` (or `stage-<tier>-<hw>` for CPU, e
 
 ## What each stage does
 
-**Image resolution (`resolve-ci-image`).** Before the GPU stages, a small `ubuntu-latest` job resolves the container image: it reads `ci-image-tag:` from the PR description (or the `ci_image_tag` dispatch input), defaults to `dev`, validates it is a bare tag, and outputs `radixark/miles:<tag>`. Every GPU stage uses this as its `container_image`. Distinct from this, the **`run-ci-image` label** selects the image scope — every enabled tag except `ft-short`/`ft-long` — which is how you validate a PR that bumps the image without scheduling FT tests.
+**Image resolution (`resolve-ci-image`).** Before the GPU stages, a small `ubuntu-latest` job resolves the container image: it reads `ci-image-tag:` from the PR description (or the `ci_image_tag` dispatch input), defaults to `dev`, validates it is a bare tag, and outputs `radixark/miles:<tag>`. Every GPU stage uses this as its `container_image`. Distinct from this, the **`run-ci-image` label** selects the image scope — every enabled tag except `long`, `ft-short`, and `ft-long` — which validates an image bump without selecting those domains implicitly.
 
 **Policy resolution (`resolve-ci-policy`).**
 
@@ -45,7 +45,7 @@ Stage names follow `stage-<tier>-<gpus>-<hw>` (or `stage-<tier>-<hw>` for CPU, e
 
 A **nightly** policy selects every enabled tag except `ft-long`, admits both regular and `nightly=True` registrations, and disables fast-fail. Regular cadence admits only regular registrations. Both cadences use the same stage inventory.
 
-`run-ci-all` selects the full domain-tag set without changing cadence. `run-ci-image` selects every enabled non-FT tag. If scope signals overlap, the precedence is `run-ci-all` > nightly > `run-ci-image`. The resolved cadence and raw/synthetic labels are passed to `run_suite.py`, which computes one run policy (see docs/ci/01-label.md for the subtraction semantics).
+`run-ci-all` selects the full domain-tag set without changing cadence. `run-ci-image` selects every enabled tag except `long`, `ft-short`, and `ft-long`. If scope signals overlap, the precedence is `run-ci-all` > nightly > `run-ci-image`. The resolved cadence and raw/synthetic labels are passed to `run_suite.py`, which computes one run policy (see docs/ci/01-label.md for the subtraction semantics).
 
 **Dependencies / gating.** Both CPU stages require both resolvers. GPU stages also require both resolvers and, by default, a successful `stage-a-cpu`, so a CPU-test failure short-circuits the expensive GPU fleet. Resolved nightly cadence and the `bypass-fastfail` PR label relax only the `stage-a-cpu` failure gate and make each suite continue after a test failure; neither bypasses resolver failure.
 

--- a/docs/ci/01-label.md
+++ b/docs/ci/01-label.md
@@ -10,7 +10,7 @@ A label is a GitHub PR label that changes what CI runs or how it fails. Three ki
 | Kind | Example | Effect |
 |---|---|---|
 | Domain label | `run-ci-megatron` | selects which tests run |
-| Scope label | `run-ci-image` | run every enabled non-FT tag |
+| Scope label | `run-ci-image` | run every enabled tag except `long`, `ft-short`, and `ft-long` |
 | Cadence/scope label | `nightly` | select nightly cadence and every enabled tag except `ft-long`, with fast-fail disabled |
 | Scope label | `run-ci-all` | run every enabled tag |
 | Behavior label | `bypass-fastfail` | opt out of fast-fail; one run surfaces every failure |
@@ -50,7 +50,7 @@ The workflow's `resolve-ci-policy` job forwards trigger-specific facts to `tests
 |---|---|---|---|---|
 | all | `run-ci-all` label | every enabled tag | — | determined by cadence |
 | nightly | resolved nightly cadence from the PR label, exact nightly cron, or local `--nightly` | every enabled tag incl. `ft-short` | `ft-long` | disabled on both levels (within-stage only for local runs) |
-| image | `run-ci-image` label | every enabled non-FT tag | `ft-short`, `ft-long` | determined by cadence |
+| image | `run-ci-image` label | every enabled tag except `long` and FT tags | `long`, `ft-short`, `ft-long` | determined by cadence |
 
 Rows are in precedence order: when scope signals overlap, the higher row wins (`run-ci-all` > nightly > `run-ci-image`, the branch order of `resolve_policy`). `run-ci-all` widens only the domain scope; without nightly cadence it does not admit nightly-only registrations.
 
@@ -58,7 +58,7 @@ The generic triggers carry no policy. The current nightly schedule is identified
 
 A subtraction is not a per-test veto — it only stops that label from granting inclusion. A test carrying a subtracted label still runs when another of its labels is in the set, so a test that must never run at nightly must carry only FT labels.
 
-A domain label explicitly requested on the PR wins over a scope subtraction: `run-ci-image` plus `run-ci-ft-short` runs the image scope *and* the ft-short tests, rather than silently dropping the explicit request.
+A domain label explicitly requested on the PR wins over a scope subtraction: `run-ci-image` plus `run-ci-long` or `run-ci-ft-short` runs the image scope *and* the explicitly requested tests, rather than silently dropping the request.
 
 ## Registration and scan scope
 

--- a/tests/ci/ci_policy.py
+++ b/tests/ci/ci_policy.py
@@ -79,8 +79,8 @@ def resolve_policy(cadence: str, raw_labels: set[str]) -> RunPolicy:
 
     Broad scopes are large include sets: `run-ci-all` includes every registered
     label, nightly cadence everything except `ft-long`, and `run-ci-image`
-    everything except `ft-short` and `ft-long`. Branch order encodes the
-    precedence `run-ci-all` > nightly > `run-ci-image`.
+    everything except `long`, `ft-short`, and `ft-long`. Branch order encodes
+    the precedence `run-ci-all` > nightly > `run-ci-image`.
 
     Explicitly requested `run-ci-<x>` labels are unioned in last, so an
     explicit request always wins over a scope subtraction. A subtraction is
@@ -98,7 +98,7 @@ def resolve_policy(cadence: str, raw_labels: set[str]) -> RunPolicy:
     elif cadence == NIGHTLY_CADENCE:
         scope = set(KNOWN_LABELS) - {"ft-long"}
     elif "run-ci-image" in raw_labels:
-        scope = set(KNOWN_LABELS) - {"ft-short", "ft-long"}
+        scope = set(KNOWN_LABELS) - {"long", "ft-short", "ft-long"}
     else:
         scope = set()
     return RunPolicy(

--- a/tests/ci/test/test_run_suite.py
+++ b/tests/ci/test/test_run_suite.py
@@ -176,7 +176,7 @@ class TestResolvePolicy:
             (REGULAR_CADENCE, set(), set(), False),
             (REGULAR_CADENCE, {"run-ci-megatron"}, {"megatron"}, False),
             (REGULAR_CADENCE, {"bypass-fastfail"}, set(), True),
-            (REGULAR_CADENCE, {"run-ci-image"}, _ALL - {"ft-short", "ft-long"}, False),
+            (REGULAR_CADENCE, {"run-ci-image"}, _ALL - {"long", "ft-short", "ft-long"}, False),
             (REGULAR_CADENCE, {"run-ci-all"}, _ALL, False),
             (REGULAR_CADENCE, {"run-ci-image", "run-ci-all"}, _ALL, False),
             (NIGHTLY_CADENCE, set(), _ALL - {"ft-long"}, True),
@@ -206,14 +206,15 @@ class TestResolvePolicy:
     @pytest.mark.parametrize(
         ("cadence", "labels", "expected"),
         [
-            (REGULAR_CADENCE, {"run-ci-image", "run-ci-ft-short"}, _ALL - {"ft-long"}),
+            (REGULAR_CADENCE, {"run-ci-image", "run-ci-long"}, _ALL - {"ft-short", "ft-long"}),
+            (REGULAR_CADENCE, {"run-ci-image", "run-ci-ft-short"}, _ALL - {"long", "ft-long"}),
             (NIGHTLY_CADENCE, {"nightly", "run-ci-ft-long"}, _ALL),
-            (REGULAR_CADENCE, {"run-ci-image", "run-ci-ft-short", "run-ci-ft-long"}, _ALL),
+            (REGULAR_CADENCE, {"run-ci-image", "run-ci-ft-short", "run-ci-ft-long"}, _ALL - {"long"}),
             (NIGHTLY_CADENCE, {"run-ci-ft-long"}, _ALL),
         ],
     )
     def test_explicit_domain_label_wins_over_scope_subtraction(self, cadence, labels, expected):
-        # Asking for FT coverage on an image bump must not be silently
+        # Asking for long or FT coverage on an image bump must not be silently
         # dropped: explicit requests are unioned in after the subtraction.
         assert resolve_policy(cadence, labels).include_labels == expected
 
@@ -575,25 +576,23 @@ def broad_scope_tests():
     return [
         _make("tests/e2e/always.py", labels=[]),
         _make("tests/e2e/megatron.py", labels=["megatron"]),
+        _make("tests/e2e/long.py", labels=["long"]),
         _make("tests/e2e/ft/short.py", labels=["ft-short"]),
         _make("tests/e2e/ft/long.py", labels=["ft-long", "long"]),
     ]
 
 
 class TestFilterTestsBroadScopes:
-    def test_image_scope_selects_no_ft_only_tests(self, broad_scope_tests):
+    def test_image_scope_excludes_long_and_ft_tests(self, broad_scope_tests):
         enabled, _ = filter_tests(
             broad_scope_tests,
             HWBackend.CUDA,
             "stage-c-8-gpu-h100",
             labels=set(resolve_policy(REGULAR_CADENCE, {"run-ci-image"}).include_labels),
         )
-        # ft/long.py still runs: its `long` label is in the include set. A
-        # subtraction is not a per-test veto (maintainer-decided semantics).
         assert _names(enabled) == {
             "tests/e2e/always.py",
             "tests/e2e/megatron.py",
-            "tests/e2e/ft/long.py",
         }
 
     def test_nightly_scope_selects_ft_short_but_not_ft_only_soak(self, broad_scope_tests):
@@ -609,6 +608,7 @@ class TestFilterTestsBroadScopes:
         assert _names(enabled) == {
             "tests/e2e/always.py",
             "tests/e2e/megatron.py",
+            "tests/e2e/long.py",
             "tests/e2e/ft/short.py",
             "tests/e2e/ft/long.py",
         }


### PR DESCRIPTION
> **Depends on:** #1671
> Stacked on the parent PR's branch. Review / merge the parent first.

## Summary
Exclude long-running tests from image validation while preserving explicit opt-in.

## Symptom & Reproduction
- **Symptom:** `run-ci-image` selects two `labels=["long"]` tests with a combined estimate of 12,400 seconds; the image scope is defined to exclude implicit long coverage.
- **Reproduction:** `PYTHONPATH=. python tests/ci/run_suite.py --hw cuda --suite stage-c-2-gpu-h200 --labels run-ci-image --list-only`

## Root Cause
1. `KNOWN_LABELS` registers `long` as an ordinary domain label.
2. `resolve_policy` subtracted only `ft-short` and `ft-long` from the image scope.

## Fix
Subtract `long` alongside the fault-tolerance labels when resolving `run-ci-image`. Keep the existing `scope | requested` union so an explicit `run-ci-long` still restores those tests, and synchronize both CI policy documents with the new scope.

## Verification
- **Updated test:** `TestResolvePolicy.test_selection_and_fastfail` covers the reduced image scope.
- **Updated test:** `TestResolvePolicy.test_explicit_domain_label_wins_over_scope_subtraction` covers the explicit `run-ci-long` override.
- **Updated test:** `TestFilterTestsBroadScopes.test_image_scope_excludes_long_and_ft_tests` covers selection of a long-only registration.
- **Registry check:** Image-only selection omits both real `tests/e2e/long` files; adding `run-ci-long` restores them.

## Review Focus
- Scrutinize the `resolve_policy` subtraction and explicit-label union semantics.
- Compare `docs/ci/00-stage.md` and `docs/ci/01-label.md` against the tested include set.
