### PR TITLE
Add --async-max-concurrent-samples to decouple fully-async generation concurrency from batch size

### DIFF
--- a/examples/fully_async/fully_async_rollout.py
+++ b/examples/fully_async/fully_async_rollout.py
@@ -82,10 +82,14 @@ class AsyncRolloutWorker:
 
     def __init__(self, args, data_buffer: DataSource):
         if args.async_max_concurrent_samples is not None:
-            assert args.async_max_concurrent_samples <= args.sglang_server_concurrency, (
-                f"--async-max-concurrent-samples ({args.async_max_concurrent_samples}) must not exceed "
-                f"--sglang-server-concurrency ({args.sglang_server_concurrency})"
+            client_capacity = (
+                args.sglang_server_concurrency * args.rollout_num_gpus // args.rollout_num_gpus_per_engine
             )
+            if args.async_max_concurrent_samples > client_capacity:
+                print(
+                    f"--async-max-concurrent-samples ({args.async_max_concurrent_samples}) exceeds the "
+                    f"client concurrency cap ({client_capacity}); the excess queues on the semaphore"
+                )
         self.args = args
         self.data_buffer = data_buffer  # Directly save data_buffer reference
         self.running = True

--- a/examples/fully_async/fully_async_rollout.py
+++ b/examples/fully_async/fully_async_rollout.py
@@ -94,7 +94,12 @@ class AsyncRolloutWorker:
         print("Continuous async rollout worker started")
 
         active_tasks = set()
-        max_concurrent_tasks = self.args.rollout_batch_size
+        # Concurrency is counted in trajectories; each in-flight group holds
+        # n_samples_per_prompt of them.
+        if self.args.async_max_concurrent_tasks is not None:
+            max_concurrent_tasks = max(1, self.args.async_max_concurrent_tasks // self.args.n_samples_per_prompt)
+        else:
+            max_concurrent_tasks = self.args.rollout_batch_size
         group_id_counter = 0
 
         while self.running:

--- a/examples/fully_async/fully_async_rollout.py
+++ b/examples/fully_async/fully_async_rollout.py
@@ -60,7 +60,7 @@ def get_global_worker(args, data_buffer: DataSource):
     with _worker_lock:
         if _global_worker is None or not _global_worker.worker_thread.is_alive():
             print("Creating new global async worker...")
-            _global_worker = AsyncRolloutWorker(args, data_buffer, concurrency=args.sglang_server_concurrency)
+            _global_worker = AsyncRolloutWorker(args, data_buffer)
             _global_worker.start()
         return _global_worker
 
@@ -80,10 +80,14 @@ class AsyncRolloutWorker:
     Supports continuous running, independent of rollout function lifecycle
     """
 
-    def __init__(self, args, data_buffer: DataSource, concurrency=10):
+    def __init__(self, args, data_buffer: DataSource):
+        if args.async_max_concurrent_samples is not None:
+            assert args.async_max_concurrent_samples <= args.sglang_server_concurrency, (
+                f"--async-max-concurrent-samples ({args.async_max_concurrent_samples}) must not exceed "
+                f"--sglang-server-concurrency ({args.sglang_server_concurrency})"
+            )
         self.args = args
         self.data_buffer = data_buffer  # Directly save data_buffer reference
-        self.concurrency = concurrency
         self.running = True
         self.output_queue = queue.Queue(maxsize=1000)  # Continuous output queue
         self.worker_thread = None
@@ -94,10 +98,8 @@ class AsyncRolloutWorker:
         print("Continuous async rollout worker started")
 
         active_tasks = set()
-        # Concurrency is counted in trajectories; each in-flight group holds
-        # n_samples_per_prompt of them.
-        if self.args.async_max_concurrent_tasks is not None:
-            max_concurrent_tasks = max(1, self.args.async_max_concurrent_tasks // self.args.n_samples_per_prompt)
+        if self.args.async_max_concurrent_samples is not None:
+            max_concurrent_tasks = max(1, self.args.async_max_concurrent_samples // self.args.n_samples_per_prompt)
         else:
             max_concurrent_tasks = self.args.rollout_batch_size
         group_id_counter = 0

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -491,6 +491,17 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 ),
             )
             parser.add_argument(
+                "--async-max-concurrent-tasks",
+                type=int,
+                default=None,
+                help=(
+                    "Maximum number of concurrently generating trajectories in fully async mode, "
+                    "decoupling generation concurrency from the training batch size. None (default) "
+                    "keeps the legacy bound of one training batch worth of trajectories "
+                    "(rollout_batch_size groups, i.e. rollout_batch_size * n_samples_per_prompt)."
+                ),
+            )
+            parser.add_argument(
                 "--custom-generate-function-path",
                 type=str,
                 default=None,

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -2665,6 +2665,13 @@ def miles_validate_args(args):
         args.disable_grad_buffers_cpu_backup = True
         args.disable_param_buffers_cpu_backup = args.enable_weights_backuper
 
+    if args.async_max_concurrent_samples is not None:
+        assert args.async_max_concurrent_samples >= args.n_samples_per_prompt, (
+            f"--async-max-concurrent-samples ({args.async_max_concurrent_samples}) must be at least "
+            f"--n-samples-per-prompt ({args.n_samples_per_prompt}): the worker submits whole groups, "
+            f"so one group already puts n_samples_per_prompt trajectories in flight"
+        )
+
     if args.eval_function_path is None:
         args.eval_function_path = args.rollout_function_path
 

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -491,7 +491,7 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 ),
             )
             parser.add_argument(
-                "--async-max-concurrent-tasks",
+                "--async-max-concurrent-samples",
                 type=int,
                 default=None,
                 help=(


### PR DESCRIPTION
## Problem

In fully async mode the generation concurrency is hard-wired to the training batch: `AsyncRolloutWorker` keeps at most `rollout_batch_size` groups in flight, i.e. exactly one training batch worth of trajectories. There is no way to run the generation side ahead of consumption (e.g. to keep a larger engine fleet or a larger sandbox pool saturated) without also inflating the training batch.

## Change

- New `--async-max-concurrent-samples` (default `None`): maximum number of concurrently generating **trajectories** in fully async mode. The worker converts it to in-flight groups (`value // n_samples_per_prompt`). Unset keeps the legacy bound (`rollout_batch_size` groups), so existing runs are unaffected.
- Validated in `miles_validate_args`: at least `--n-samples-per-prompt` (the worker submits whole groups, so one group already puts that many trajectories in flight). Values beyond the fleet-wide client cap (`sglang_server_concurrency x num_engines`) just queue on the client semaphore, so the worker logs a warning instead of failing.
- Dropped the dead `AsyncRolloutWorker(concurrency=...)` constructor parameter — it was stored and never read; the real bound is the one above.

Consumption is intentionally untouched: each train step still collects `rollout_batch_size` groups. The new knob only controls how far generation runs ahead, trading higher engine/sandbox utilization for higher average weight staleness (combine with `--max-weight-staleness` to bound the tail).

## Validation

GLM-5.2 744B fully-async disaggregated run (8 train + 8 inference nodes, agentic tbench2 episodes): `--rollout-batch-size 8 --n-samples-per-prompt 8 --async-max-concurrent-samples 128` doubles in-flight trajectories from 64 to 128 (16 groups); unset falls back to the previous behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

