### PR TITLE
feat: lora GLM-5.2 FP8 rollout support

### DIFF
--- a/scripts/run_glm5_2_744b_a40b_lora.py
+++ b/scripts/run_glm5_2_744b_a40b_lora.py
@@ -323,11 +323,11 @@ def _train(args: ScriptArgs):
             "INDEXER_ROPE_NEOX_STYLE": "0",
             "SGLANG_NSA_FORCE_MLA": "1",
             # PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True breaks torch_memory_saver
-            # fp8 + LoRA: the quantized load path builds mlp.shared_experts TP-sharded while
-            # the LoRA B buffer is sized from the global gate_up dim, so set_lora_info fails
-            # at engine init (e.g. B 4096 vs partition prefix 2048). TP1 shared experts match
-            # the bf16 layout the LoRA buffers assume.
-            **({"SGLANG_SHARED_EXPERT_TP1": "1"} if args.fp8_rollout else {}),
+            # Do NOT set SGLANG_SHARED_EXPERT_TP1 here: TP1-replicated shared experts get
+            # double-counted under dp-attention/EP topologies that skip the in-layer
+            # all-reduce (garbage rollouts). The fp8 LoRA-init crash it papered over is
+            # fixed in sglang lora/mem_pool.py (column-parallel output-axis shard probe);
+            # fp8_rollout requires an sglang build with that fix.
         },
         megatron_path=args.megatron_path,
     )

--- a/scripts/run_glm5_2_744b_a40b_lora.py
+++ b/scripts/run_glm5_2_744b_a40b_lora.py
@@ -252,12 +252,8 @@ def _train(args: ScriptArgs):
 
     if _is_full:
         # mirrors run_glm5_744b_a40b.py; bf16 ~1488GB needs >=~22 GPUs/engine while fp8
-        # fits engine=min(8, ngpu) on one node.
-        # The big-engine fp8 profile is FULL-MODEL ONLY: on the 5-layer toy the ep8/dp8
-        # engine gives a large rollout<->train deviation (abs_diff 2.19 / kl 1.64 vs
-        # 0.27 / 0.06 at ep2/dp2; bisected: not the kv dtype, not the decode backend,
-        # not the LoRA layout), so the toy keeps the small-engine bf16-style serving
-        # profile and only swaps the weights to fp8.
+        # fits engine=min(8, ngpu) on one node. Big-engine fp8 profile is full-model only:
+        # the toy at ep8/dp8 shows a large rollout<->train deviation (abs_diff 2.19 vs 0.27).
         _fp8_full = args.fp8_rollout and args.model_name == "GLM-5.2"
         _eng = min(8, args.num_gpus_per_node) if _fp8_full else args.rollout_num_gpus_per_engine
         _decode = "flashmla_kv" if _fp8_full else "flashmla_sparse"

--- a/scripts/run_glm5_2_744b_a40b_lora.py
+++ b/scripts/run_glm5_2_744b_a40b_lora.py
@@ -280,12 +280,8 @@ def _train(args: ScriptArgs):
         sglang_args = f"--rollout-num-gpus-per-engine {args.rollout_num_gpus_per_engine} --sglang-mem-fraction-static {args.sglang_mem_fraction_static} --sglang-cuda-graph-max-bs 64 --sglang-moe-runner-backend triton --sglang-disable-shared-experts-fusion --sglang-lora-backend {args.sglang_lora_backend} --sglang-reasoning-parser glm45 --sglang-tool-call-parser glm47 "
 
     if args.fp8_rollout:
-        # Point the sglang engines at the pre-converted fp8 checkpoint via the --sglang-config
-        # YAML (model_path override). update_weights must stay ON so the per-step LoRA adapter
-        # sync still reaches the engine (a model_path != hf_checkpoint otherwise auto-disables
-        # it); the base-weight sync is already skipped under --lora-base-cpu-backup +
-        # --colocate (skip_base_sync in update_weight_from_tensor.py), so the quantized base
-        # on the engine is never overwritten by bf16 training weights.
+        # Serve the fp8 ckpt via --sglang-config; update_weights stays on so the per-step LoRA
+        # sync reaches the engine (the bf16 base sync is already skipped under colocate + backup).
         sglang_config_path = f"{load_save_path}/sglang_fp8_rollout.yaml"
         os.makedirs(load_save_path, exist_ok=True)
         with open(sglang_config_path, "w") as f:
@@ -323,11 +319,8 @@ def _train(args: ScriptArgs):
             "INDEXER_ROPE_NEOX_STYLE": "0",
             "SGLANG_NSA_FORCE_MLA": "1",
             # PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True breaks torch_memory_saver
-            # Do NOT set SGLANG_SHARED_EXPERT_TP1 here: TP1-replicated shared experts get
-            # double-counted under dp-attention/EP topologies that skip the in-layer
-            # all-reduce (garbage rollouts). The fp8 LoRA-init crash it papered over is
-            # fixed in sglang lora/mem_pool.py (column-parallel output-axis shard probe);
-            # fp8_rollout requires an sglang build with that fix.
+            # No SGLANG_SHARED_EXPERT_TP1: it double-counts shared experts under dp-attention/EP;
+            # the fp8 LoRA-init crash it papered over is fixed in sglang lora/mem_pool.py.
         },
         megatron_path=args.megatron_path,
     )

--- a/scripts/run_glm5_2_744b_a40b_lora.py
+++ b/scripts/run_glm5_2_744b_a40b_lora.py
@@ -32,6 +32,15 @@ Usage:
   python scripts/run_glm5_2_744b_a40b_lora.py prepare --model-name GLM-5.2_5layer --task dapo-math
   python scripts/run_glm5_2_744b_a40b_lora.py train   --model-name GLM-5.2_5layer --task dapo-math \\
       --rollout-max-response-len 4096 --num-gpus-per-node 4
+
+fp8 rollout (train stays bf16; sglang serves <hf_checkpoint>_fp8 via --sglang-config; LoRA
+adapters still sync per step, only the base-weight sync is skipped). The rollout checkpoint
+(<hf_checkpoint>_fp8, e.g. the official GLM-5.2 fp8 release) must already exist:
+  python scripts/run_glm5_2_744b_a40b_lora.py train --model-name GLM-5.2_5layer \\
+      --fp8-rollout --num-gpus-per-node 4
+Expected parity on the toy (gsm8k, 5 rollouts): train_rollout_logprob_abs_diff ~0.27 /
+train_rollout_kl ~0.058, flat across steps (constant weight-quantization offset), vs
+~0.010 / ~1.2e-4 with the bf16 rollout.
 """
 
 import os
@@ -116,6 +125,8 @@ class ScriptArgs(U.ExecuteTrainConfig):
     sglang_lora_backend: str = "triton"
     # serve from a pre-converted _fp8 ckpt (fits engine=8 / 1 node); train stays bf16
     fp8_rollout: bool = False
+    # rollout-side fp8 checkpoint; defaults to <hf_checkpoint>_fp8 (e.g. GLM-5.2_fp8).
+    fp8_rollout_checkpoint: str | None = None
 
     enable_wandb: bool = True
     extra_args: str = ""
@@ -123,6 +134,8 @@ class ScriptArgs(U.ExecuteTrainConfig):
     def __post_init__(self):
         if self.hf_checkpoint is None:
             self.hf_checkpoint = f"{self.model_dir}/{self.model_name}"
+        if self.fp8_rollout and self.fp8_rollout_checkpoint is None:
+            self.fp8_rollout_checkpoint = f"{self.hf_checkpoint}_fp8"
         if self.rollout_max_response_len == 0:
             self.rollout_max_response_len = 4096 if self.task == "dapo-math" else 512
         if self.seq_window == 0 and self.task == "dapo-math":
@@ -239,11 +252,17 @@ def _train(args: ScriptArgs):
 
     if _is_full:
         # mirrors run_glm5_744b_a40b.py; bf16 ~1488GB needs >=~22 GPUs/engine while fp8
-        # fits engine=min(8, ngpu) on one node
-        _eng = min(8, args.num_gpus_per_node) if args.fp8_rollout else args.rollout_num_gpus_per_engine
-        _decode = "flashmla_kv" if args.fp8_rollout else "flashmla_sparse"
-        _cg = 256 if args.fp8_rollout else 64
-        _kv = "--sglang-kv-cache-dtype fp8_e4m3 " if args.fp8_rollout else ""
+        # fits engine=min(8, ngpu) on one node.
+        # The big-engine fp8 profile is FULL-MODEL ONLY: on the 5-layer toy the ep8/dp8
+        # engine gives a large rollout<->train deviation (abs_diff 2.19 / kl 1.64 vs
+        # 0.27 / 0.06 at ep2/dp2; bisected: not the kv dtype, not the decode backend,
+        # not the LoRA layout), so the toy keeps the small-engine bf16-style serving
+        # profile and only swaps the weights to fp8.
+        _fp8_full = args.fp8_rollout and args.model_name == "GLM-5.2"
+        _eng = min(8, args.num_gpus_per_node) if _fp8_full else args.rollout_num_gpus_per_engine
+        _decode = "flashmla_kv" if _fp8_full else "flashmla_sparse"
+        _cg = 256 if _fp8_full else 64
+        _kv = "--sglang-kv-cache-dtype fp8_e4m3 " if _fp8_full else ""
         sglang_args = (
             f"--rollout-num-gpus-per-engine {_eng} --sglang-mem-fraction-static {args.sglang_mem_fraction_static} "
             f"--sglang-enable-dp-attention --sglang-ep-size {_eng} --sglang-dp-size {_eng} "
@@ -259,6 +278,27 @@ def _train(args: ScriptArgs):
         )
     else:
         sglang_args = f"--rollout-num-gpus-per-engine {args.rollout_num_gpus_per_engine} --sglang-mem-fraction-static {args.sglang_mem_fraction_static} --sglang-cuda-graph-max-bs 64 --sglang-moe-runner-backend triton --sglang-disable-shared-experts-fusion --sglang-lora-backend {args.sglang_lora_backend} --sglang-reasoning-parser glm45 --sglang-tool-call-parser glm47 "
+
+    if args.fp8_rollout:
+        # Point the sglang engines at the pre-converted fp8 checkpoint via the --sglang-config
+        # YAML (model_path override). update_weights must stay ON so the per-step LoRA adapter
+        # sync still reaches the engine (a model_path != hf_checkpoint otherwise auto-disables
+        # it); the base-weight sync is already skipped under --lora-base-cpu-backup +
+        # --colocate (skip_base_sync in update_weight_from_tensor.py), so the quantized base
+        # on the engine is never overwritten by bf16 training weights.
+        sglang_config_path = f"{load_save_path}/sglang_fp8_rollout.yaml"
+        os.makedirs(load_save_path, exist_ok=True)
+        with open(sglang_config_path, "w") as f:
+            f.write(
+                "sglang:\n"
+                "  - name: default\n"
+                f"    model_path: {args.fp8_rollout_checkpoint}\n"
+                "    update_weights: true\n"
+                "    server_groups:\n"
+                "      - worker_type: regular\n"
+                f"        num_gpus: {args.num_gpus_per_node}\n"
+            )
+        sglang_args += f"--sglang-config {sglang_config_path} "
 
     save_args = f"--save-interval 1 --save {load_save_path} "
 
@@ -283,6 +323,11 @@ def _train(args: ScriptArgs):
             "INDEXER_ROPE_NEOX_STYLE": "0",
             "SGLANG_NSA_FORCE_MLA": "1",
             # PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True breaks torch_memory_saver
+            # fp8 + LoRA: the quantized load path builds mlp.shared_experts TP-sharded while
+            # the LoRA B buffer is sized from the global gate_up dim, so set_lora_info fails
+            # at engine init (e.g. B 4096 vs partition prefix 2048). TP1 shared experts match
+            # the bf16 layout the LoRA buffers assume.
+            **({"SGLANG_SHARED_EXPERT_TP1": "1"} if args.fp8_rollout else {}),
         },
         megatron_path=args.megatron_path,
     )

--- a/scripts/run_glm5_2_744b_a40b_lora.py
+++ b/scripts/run_glm5_2_744b_a40b_lora.py
@@ -252,8 +252,7 @@ def _train(args: ScriptArgs):
 
     if _is_full:
         # mirrors run_glm5_744b_a40b.py; bf16 ~1488GB needs >=~22 GPUs/engine while fp8
-        # fits engine=min(8, ngpu) on one node. Big-engine fp8 profile is full-model only:
-        # the toy at ep8/dp8 shows a large rollout<->train deviation (abs_diff 2.19 vs 0.27).
+        # fits engine=min(8, ngpu) on one node
         _fp8_full = args.fp8_rollout and args.model_name == "GLM-5.2"
         _eng = min(8, args.num_gpus_per_node) if _fp8_full else args.rollout_num_gpus_per_engine
         _decode = "flashmla_kv" if _fp8_full else "flashmla_sparse"
@@ -315,8 +314,6 @@ def _train(args: ScriptArgs):
             "INDEXER_ROPE_NEOX_STYLE": "0",
             "SGLANG_NSA_FORCE_MLA": "1",
             # PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True breaks torch_memory_saver
-            # No SGLANG_SHARED_EXPERT_TP1: it double-counts shared experts under dp-attention/EP;
-            # the fp8 LoRA-init crash it papered over is fixed in sglang lora/mem_pool.py.
         },
         megatron_path=args.megatron_path,
     )


### PR DESCRIPTION
## Summary

Development branch for GLM-5.2 FP8 support in miles (rollout + training integration). Opened as a draft to track the work; implementation commits will land on this branch.

Based on `main` @ 81d2f02.

Logprob diff:
<img width="1106" height="630" alt="image" src="https://github.com/user-attachments/assets/6510694d-3331-4dc4-8f74-9697033e1401" />

Reward:
<img width="1096" height="613" alt="image" src="https://github.com/user-attachments/assets/ae030533-62dc-4760-96bf-39606592989b" />


## Companion PRs

- sglang: https://github.com/sgl-project/sglang/pull/31251

## Test plan

- [ ] GLM-5.2 FP8 rollout smoke test
- [ ] Training E2E on H200 cluster