### PR TITLE
[AMD] fix GPU memory release for TMS pause on ROCm 7.2

### DIFF
--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -26,6 +26,10 @@ ARG MEGATRON_BRANCH=miles-main
 ARG MILES_COMMIT=main
 
 ARG GPU_ARCH=gfx950
+# 1 on ROCm 7.2 to bake the ROCr VMM-pause fix; ROCm 7.0 has no such regression, leave 0.
+ARG APPLY_ROCR_VMMFIX=0
+ARG WHEELS_REPO=XinyuJiangCMU/miles-wheels-rocm
+ARG WHEELS_TAG_ROCM=rocm720-gfx950-v0.5.14
 ARG MAX_JOBS=128
 
 ARG RCCL_TESTS_REPO=https://github.com/ROCm/rocm-systems.git
@@ -119,6 +123,22 @@ RUN cd /sgl-workspace/sglang && \
 RUN python -c "import sglang; import sgl_kernel; print('SGLang + sgl_kernel: OK')"
 
 RUN pip install git+https://github.com/fzyzcjy/torch_memory_saver.git@d64a639 --no-cache-dir --force-reinstall
+
+# Fix the ROCm 7.2 ROCr VMM-pause leak.
+RUN if [ "$APPLY_ROCR_VMMFIX" = "1" ]; then \
+      asset="libhsa-runtime64.so.1.18.70200.vmmfix"; \
+      curl -fsSL -o "/tmp/$asset" "https://github.com/${WHEELS_REPO}/releases/download/${WHEELS_TAG_ROCM}/$asset"; \
+      dst="$(readlink -f /opt/rocm/lib/libhsa-runtime64.so.1)"; \
+      case "$dst" in \
+        *.1.18.70200) ;; \
+        *) echo "[vmmfix] ROCr soname mismatch: $dst (expected .1.18.70200 = ROCm 7.2.0); rebuild the .so" >&2; exit 1 ;; \
+      esac; \
+      cp -a "$dst" /opt/libhsa-runtime64.so.stock-prevmmfix.bak && \
+      install -m0644 "/tmp/$asset" "$dst" && rm -f "/tmp/$asset" && \
+      echo "[vmmfix] installed patched ROCr at $dst"; \
+    else \
+      echo "[vmmfix] skipped (APPLY_ROCR_VMMFIX=$APPLY_ROCR_VMMFIX; ROCm 7.0 has no VMM-pause regression)"; \
+    fi
 RUN pip install git+https://github.com/radixark/Megatron-Bridge.git@bridge --no-deps --no-build-isolation
 RUN pip install megatron-energon --no-deps
 RUN pip install multi-storage-client --no-deps

--- a/docker/build.py
+++ b/docker/build.py
@@ -78,6 +78,7 @@ VARIANTS = {
         "build_args": {
             "GPU_ARCH": "gfx950",
             "SGLANG_IMAGE_TAG": "v0.5.10-rocm720-mi35x",
+            "APPLY_ROCR_VMMFIX": "1",
         },
     },
 }

--- a/docs/ci/02-docker-build.md
+++ b/docs/ci/02-docker-build.md
@@ -34,7 +34,7 @@ The Dockerfile is the build recipe and nothing more: it knows no variants and no
 
 **Output** — one `radixark/miles` image for the platform buildx targets: the sglang base, then Megatron-LM (`radixark/Megatron-LM@miles-main`), miles, and the prebuilt wheels (`sgl-router` among them). A multi-arch build is one `buildx` run executed once per platform — `TARGETARCH` differs each time, so each arch installs its own wheels — and buildx pushes the two as a single manifest.
 
-`docker/Dockerfile.rocm` is the ROCm counterpart (build-args `GPU_ARCH` + a ROCm `SGLANG_IMAGE_TAG`).
+`docker/Dockerfile.rocm` is the ROCm counterpart (build-args `GPU_ARCH` + a ROCm `SGLANG_IMAGE_TAG`; the 7.2 variants also set `APPLY_ROCR_VMMFIX=1`, which downloads the ROCr VMM-pause fix `.so` from the `WHEELS_TAG_ROCM` release and installs it — ROCm 7.0 has no such regression and leaves it off).
 
 ## Build script
 


### PR DESCRIPTION
Co-authored-with: @JessicaJiang-123 

## What
Adds a build-arg-gated step to `docker/Dockerfile.rocm` that installs a rebuilt `libhsa-runtime64` fixing the ROCm 7.2 ROCr VMM-pause regression. `docker/build.py` turns it on for the `rocm720-mi35x` variant; the ROCm 7.0 variants leave it off.

## Why
On ROCm 7.2, ROCr's `~MappedHandleAllowedAgent()` CPU-agent branch early-returns without unmapping the imported dma-buf:

```cpp
Runtime::MappedHandleAllowedAgent::~MappedHandleAllowedAgent() {
  if (targetAgent->device_type() == kAmdCpuDevice) return;  // leaks the imported dma-buf FD
  hsa_status_t status = targetAgent->driver().ReleaseShareableHandle(shareable_handle);
  assert(status == HSA_STATUS_SUCCESS);
}
```

The leaked FD pins the physical GPU memory, so `hipMemUnmap` + `hipMemRelease` free nothing while the address range stays reserved (ROCm/ROCm#6021). `torch_memory_saver.pause()` then frees nothing and colocate RL OOMs handing memory back to the trainer, which is the ROCm 7.2 regression reported in fzyzcjy/torch_memory_saver#83. ROCm 7.0 is unaffected. The upstream one-function fix (ROCm/rocm-systems#4363) is only on `develop`, not in any released 7.2.x (checked through 7.2.4), so bumping the base ROCm does not help.

## How
- The rebuilt `.so` ships as a release asset in `miles-wheels-rocm` (`rocm720-gfx950-v0.5.14`), built by its `build_rocr_vmmfix.py`: clone ROCR-Runtime @ `rocm-7.2.0`, apply the same ROCm/rocm-systems#4363 fix rebased onto that tag, then cmake.
- `Dockerfile.rocm` downloads it and overwrites `libhsa-runtime64` in place.

## Verification (gfx950 / MI355X)
A minimal test that reserves memory, maps it, then unmaps and releases it (what `pause()` does), same GPU: stock ROCm 7.2.0 frees **0 MB**, while this fix frees the full **8192 MB**, matching ROCm 7.0.0. `torch_memory_saver` `pause()`/`resume()` then works end to end: frees on pause, restores on resume, tensor contents intact with cpu_backup. This is also the first confirmation the fix works on MI355X (gfx950); upstream had only tested it on consumer GPUs.

## Removal
Remove this step once a released ROCm version includes the fix.
