### PR TITLE
docs: fix incorrect GLM-5 conversion claim and FSDP2 backend path

### DIFF
--- a/docs/developer/experimental-features.md
+++ b/docs/developer/experimental-features.md
@@ -9,7 +9,7 @@ the long-running training jobs you'd publish results from.
 
 ## FSDP backend
 
-A PyTorch FSDP2 training backend lives at `miles/backends/fsdp_utils/`.
+A PyTorch FSDP2 training backend lives at `miles/backends/experimental/fsdp_utils/`.
 It trades maximum throughput for **zero conversion overhead**: there is no
 `torch_dist` step, Miles reads architecture information from the HuggingFace
 `config.json`, and weights load directly via `AutoModelForCausalLM.from_pretrained()`.

--- a/docs/models/glm/glm5.md
+++ b/docs/models/glm/glm5.md
@@ -32,7 +32,7 @@ python scripts/run_glm5_744b_a40b.py prepare --model-name GLM-5 --num-nodes 16
 
 ### 3.2 HF → Megatron `torch_dist` conversion
 
-Also handled by `prepare`. The launcher patches `config.json` to set `model_type=deepseek_v32` (`_process_glm_checkpoint`) before conversion — GLM-5 is loaded through the DeepseekV32 architecture path. Run `prepare-cp` afterwards on every node to copy the converted checkpoint from shared NFS to local disk.
+Also handled by `prepare`. Before conversion the launcher validates, via `_validate_glm_checkpoint`, that the checkpoint uses the native GLM-5 config (`model_type=glm_moe_dsa`, `architectures=[GlmMoeDsaForCausalLM]`) and fails fast if it does not, then converts it to the `glm5-744B-A40B` Megatron model type. Run `prepare-cp` afterwards on every node to copy the converted checkpoint from shared NFS to local disk.
 
 ## 4. Launch
 


### PR DESCRIPTION
## Summary

Two factual corrections found while auditing `docs/` against `origin/main`:

- **`docs/models/glm/glm5.md` (§3.2)** — The page said the launcher "patches `config.json` to set `model_type=deepseek_v32` (`_process_glm_checkpoint`)" and that "GLM-5 is loaded through the DeepseekV32 architecture path." None of that is in the code. `scripts/run_glm5_744b_a40b.py` has no `_process_glm_checkpoint` and no `deepseek_v32` reference. It instead calls `_validate_glm_checkpoint`, which **requires** the native GLM-5 config (`model_type=glm_moe_dsa`, `architectures=[GlmMoeDsaForCausalLM]`) and fails fast otherwise, then converts to the `glm5-744B-A40B` Megatron model type. Rewrote the sentence to match.
- **`docs/developer/experimental-features.md`** — The FSDP2 backend path was listed as `miles/backends/fsdp_utils/`, but the code lives at `miles/backends/experimental/fsdp_utils/`. Corrected the path.

## Test plan

- [ ] Docs-only change; verify the two edited pages render correctly in the docs build.