### PR TITLE
[tiny] Make NVTE_FP8_BLOCK_SCALING_FP32_SCALES overridable via env

### DIFF
--- a/miles/ray/train/actor_factory.py
+++ b/miles/ray/train/actor_factory.py
@@ -27,7 +27,7 @@ def allocate_gpus_for_actor(
         # because sglang will always set NCCL_CUMEM_ENABLE to 0
         # we need also set it to 0 to prevent nccl error.
         "NCCL_CUMEM_ENABLE": os.environ.get("NCCL_CUMEM_ENABLE", "0"),
-        "NVTE_FP8_BLOCK_SCALING_FP32_SCALES": "1",
+        "NVTE_FP8_BLOCK_SCALING_FP32_SCALES": os.environ.get("NVTE_FP8_BLOCK_SCALING_FP32_SCALES", "1"),
         # DeepEP/NVSHMEM's internal NCCL conflicts with our NCCL and hangs under CUDA graphs.
         "NVSHMEM_DISABLE_NCCL": os.environ.get("NVSHMEM_DISABLE_NCCL", "1"),
         **{name: "1" for name in NOSET_VISIBLE_DEVICES_ENV_VARS_LIST},


### PR DESCRIPTION
Co-author-with: @XinyuJiangCMU 

Make NVTE_FP8_BLOCK_SCALING_FP32_SCALES configurable via the environment in `allocate_gpus_for_actor`.