### PR TITLE
fix(weight-update): propagate background P2P failures

### DIFF
--- a/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/p2p_transfer_utils.py
+++ b/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/p2p_transfer_utils.py
@@ -172,14 +172,18 @@ class P2PTransferManager:
         return future
 
     def wait_transfers(self) -> None:
-        """Wait for all submitted tasks to complete."""
+        """Wait for all submitted tasks to complete and propagate failures."""
+        errors: list[Exception] = []
         for future in self.transfer_futures:
             try:
                 future.result(timeout=self.transfer_timeout)
             except Exception as e:
                 logger.error(f"[P2P] Transfer future failed: {e}")
+                errors.append(e)
 
         self.transfer_futures.clear()
+        if errors:
+            raise errors[0]
 
 
 def create_server_args_from_dict(data_dict: dict) -> ServerArgs:

--- a/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/p2p_transfer_utils.py
+++ b/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/p2p_transfer_utils.py
@@ -174,14 +174,16 @@ class P2PTransferManager:
     def wait_transfers(self) -> None:
         """Wait for all submitted tasks to complete and propagate failures."""
         errors: list[Exception] = []
-        for future in self.transfer_futures:
-            try:
-                future.result(timeout=self.transfer_timeout)
-            except Exception as e:
-                logger.error(f"[P2P] Transfer future failed: {e}")
-                errors.append(e)
+        try:
+            for future in self.transfer_futures:
+                try:
+                    future.result(timeout=self.transfer_timeout)
+                except Exception as e:
+                    logger.error(f"[P2P] Transfer future failed: {e}")
+                    errors.append(e)
+        finally:
+            self.transfer_futures.clear()
 
-        self.transfer_futures.clear()
         if errors:
             raise errors[0]
 


### PR DESCRIPTION
## Summary

Background P2P transfer failures were logged but not propagated, allowing an incomplete weight update to finalize.

Wait for all submitted transfers as before, then re-raise the first failure if any transfer failed.

## Validation

A/B tested successful, failed, and timed-out transfers.