### PR TITLE
[AMD] Restore Python 3.10 StrEnum compatibility

### DIFF
--- a/miles/backends/megatron_utils/ft/types.py
+++ b/miles/backends/megatron_utils/ft/types.py
@@ -1,4 +1,9 @@
-from enum import StrEnum, auto
+from enum import auto
+
+try:
+    from enum import StrEnum
+except ImportError:
+    from backports.strenum import StrEnum
 
 
 class TrainStepOutcome(StrEnum):

--- a/miles/backends/training_utils/parallel.py
+++ b/miles/backends/training_utils/parallel.py
@@ -1,5 +1,10 @@
 from dataclasses import dataclass
-from enum import StrEnum, auto
+from enum import auto
+
+try:
+    from enum import StrEnum
+except ImportError:
+    from backports.strenum import StrEnum
 
 
 from miles.utils.ft_utils.process_group_utils import GroupInfo, GroupsInfo

--- a/miles/utils/ft_utils/control_server/models.py
+++ b/miles/utils/ft_utils/control_server/models.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
-from enum import StrEnum
+try:
+    from enum import StrEnum
+except ImportError:
+    from backports.strenum import StrEnum
 from typing import Literal
 
 from miles.utils.pydantic_utils import StrictBaseModel


### PR DESCRIPTION
## Summary

The ROCm Docker image uses Python 3.10, where `enum.StrEnum` is unavailable. Unconditional imports in three fault-tolerance modules therefore block Miles from starting.

Use `backports.strenum` on Python 3.10 while retaining the standard-library implementation on Python 3.11+.

## Validation

Verified that all affected modules import successfully on Python 3.10.12.