### PR TITLE
Add GLM-4.7-Flash GSM8K reasoning RL launcher + example doc

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -225,6 +225,7 @@
        "examples/retool",
        "examples/multi-agent",
        "examples/reproducibility",
+       "examples/glm47-flash-gsm8k",
        "examples/openhermes-sft"
       ]
      }

--- a/docs/examples/glm47-flash-gsm8k.md
+++ b/docs/examples/glm47-flash-gsm8k.md
@@ -1,0 +1,171 @@
+---
+title: GLM-4.7-Flash on GSM8K
+description: Step-by-step recipe for non-agentic math RL — GRPO fine-tuning of GLM-4.7-Flash on GSM8K, single 8×H200 node.
+---
+**What you'll learn:** how to run **reasoning-only** RL (no agent server, no tools) on
+GLM-4.7-Flash using GSM8K. Rollouts are generated in-process by SGLang and scored by an
+exact-match math reward. The whole loop fits on a **single 8×H200 node**.
+
+This is the simplest useful RL setup in Miles: one dataset, one reward function, one
+node. It's a good first run to validate a fresh cluster or image before moving on to
+agentic training.
+
+## How it works
+
+Unlike agentic training (which needs an external environment/agent server), math RL is
+fully self-contained:
+
+1. **Rollout** — SGLang samples `n` completions per prompt, in-process.
+2. **Reward** — `--rm-type math` extracts the boxed answer and compares it to the label
+   with a sympy-based exact-match grader (`miles/rollout/rm_hub/math_utils.py`). Reward is
+   `1.0` for a correct final answer, `0.0` otherwise.
+3. **Advantage + update** — GRPO centers the reward within each prompt's sample group and
+   updates the policy.
+
+No agent server, no tools, no env server are involved.
+
+## Prerequisites
+
+- A single node with **8× H200** (80 GB+ per GPU).
+- Miles + Megatron-LM installed (the standard `radixark/miles` image).
+- `WANDB_API_KEY` exported if you want metric logging.
+
+## Quick start
+
+```bash
+export WANDB_API_KEY=<your-key>
+
+cd /root/miles
+python scripts/run_glm47_flash_gsm8k.py --wandb-project glm47-flash-gsm8k
+```
+
+That single command downloads the model + dataset, converts the checkpoint (if needed),
+and launches training. The steps below explain what it does, and how to point it at a
+pre-staged checkpoint to skip the download.
+
+### 1. Download model + dataset
+
+```bash
+hf download zai-org/GLM-4.7-Flash --local-dir /root/models/GLM-4.7-Flash
+hf download --repo-type dataset zhuzilin/gsm8k --local-dir /root/datasets/gsm8k
+```
+
+The GSM8K parquet has columns `question`, `answer`, `label`, `messages`. The launcher
+reads the chat-formatted `messages` column (`--input-key messages --apply-chat-template`)
+and grades against `label` (`--label-key label`).
+
+### 2. Convert HF → Megatron `torch_dist`
+
+```bash
+cd /root/miles
+source scripts/models/glm4.7-flash.sh
+PYTHONPATH=/root/Megatron-LM torchrun --nproc-per-node 8 \
+   tools/convert_hf_to_torch_dist.py \
+   ${MODEL_ARGS[@]} \
+   --hf-checkpoint /root/models/GLM-4.7-Flash \
+   --save          /root/models/GLM-4.7-Flash_torch_dist
+```
+
+The launcher does this automatically and skips it when the target already has a
+`latest_checkpointed_iteration.txt` of `release`.
+
+### 3. Launch
+
+```bash
+cd /root/miles
+python scripts/run_glm47_flash_gsm8k.py --wandb-project glm47-flash-gsm8k
+```
+
+If the model and dataset are already staged (e.g. a shared cache), skip the download +
+conversion entirely:
+
+```bash
+python scripts/run_glm47_flash_gsm8k.py \
+   --skip-prepare \
+   --model-dir /path/to/shared/models \
+   --wandb-project glm47-flash-gsm8k
+```
+
+`--skip-prepare` requires that `<model-dir>/GLM-4.7-Flash`,
+`<model-dir>/GLM-4.7-Flash_torch_dist`, and `/root/datasets/gsm8k/{train,test}.parquet`
+already exist.
+
+## Recipe configuration
+
+### Parallelism
+
+| TP | PP | CP | EP | expert-TP | `max_tokens_per_gpu` | GPUs |
+|---|---|---|---|---|---|---|
+| 4 | 1 | 1 | 8 | 1 | 32768 | 8 (1 × 8) |
+
+`--rollout-num-gpus-per-engine 4` — TP must divide the 20 attention heads, so TP=4.
+
+### Rollout & reward
+
+```bash
+--prompt-data /root/datasets/gsm8k/train.parquet
+--input-key messages --label-key label --apply-chat-template
+--rm-type math                 # exact-match math grader
+--num-rollout 300              # >= 300 GRPO steps
+--rollout-batch-size 32
+--n-samples-per-prompt 8
+--rollout-max-response-len 1024  # GSM8K answers are short
+--rollout-temperature 1
+--global-batch-size 256
+```
+
+`--rollout-max-response-len 1024` is deliberately short — GSM8K solutions are a few
+hundred tokens. If you see `train_rollout_logprob_abs_diff` climbing while `raw_reward`
+stays flat, responses are being truncated; raise this.
+
+### Algorithm & optimizer
+
+GRPO with `--eps-clip 0.2 --eps-clip-high 0.28 --use-kl-loss --kl-loss-coef 0.00`.
+CPU-offloaded Adam (`--optimizer-cpu-offload --overlap-cpu-optimizer-d2h-h2d
+--use-precision-aware-optimizer`), `lr 1e-6`, constant schedule.
+
+### SGLang
+
+```bash
+--rollout-num-gpus-per-engine 4
+--sglang-mem-fraction-static 0.7
+# EAGLE speculative decoding (MTP head)
+--sglang-speculative-algorithm EAGLE
+--sglang-speculative-num-steps 2
+--sglang-speculative-eagle-topk 1
+--sglang-speculative-num-draft-tokens 3
+# Rollout Routing Replay
+--use-rollout-routing-replay
+```
+
+Rollouts use the SGLang router. The Miles router (`--use-miles-router`) is intentionally
+**not** enabled.
+
+### Evaluation
+
+Every 20 rollouts, the launcher evaluates on the GSM8K test split:
+
+```bash
+--eval-interval 20
+--eval-prompt-data gsm8k /root/datasets/gsm8k/test.parquet
+--n-samples-per-eval-prompt 1
+--eval-max-response-len 1024
+--eval-top-k 1
+```
+
+## What to watch
+
+| Metric (W&B) | Meaning |
+|---|---|
+| `rollout/raw_reward` | Fraction of rollouts with a correct answer — the true solve rate. **Use this, not `rollout/rewards`.** |
+| `rollout/rewards` | GRPO-centered advantage (≈ 0 by construction). Not a solve-rate signal. |
+| `eval/gsm8k` | Held-out test accuracy, logged every 20 rollouts. |
+| `train_rollout_logprob_abs_diff` | Rollout/train logprob drift. A fast climb usually means responses are truncating. |
+
+A healthy run shows `rollout/raw_reward` rising over the first tens of steps and
+`eval/gsm8k` tracking upward.
+
+## Pairs well with
+
+- [GLM4.7 Flash model card](/models/glm/glm4-7-flash) — the dapo-math recipe and full flag reference.
+- [Reproducibility Recipe](/examples/reproducibility) — make this run bit-stable for A/B testing.

--- a/scripts/run_glm47_flash_gsm8k.py
+++ b/scripts/run_glm47_flash_gsm8k.py
@@ -1,0 +1,213 @@
+"""GLM-4.7-Flash reasoning RL on GSM8K (single 8xH200 node).
+
+Non-agentic math GRPO: rollouts are generated in-process by SGLang and scored
+by the exact-match math reward (`--rm-type math`). No env server / agent server.
+
+Usage (single node, 8 GPUs):
+    python scripts/run_glm47_flash_gsm8k.py
+
+Reuse a pre-staged checkpoint / dataset (skips download + conversion):
+    python scripts/run_glm47_flash_gsm8k.py \
+        --model-dir /shared/models --skip-prepare \
+        --wandb-project glm47-flash-gsm8k
+"""
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+import typer
+
+import miles.utils.external_utils.command_utils as U
+
+
+@dataclass
+class ScriptArgs(U.ExecuteTrainConfig):
+    mode: Literal["normal", "debug_minimal"] = "normal"
+    run_id: str = U.create_run_id()
+    model_org: str = "zai-org"
+    model_name: str = "GLM-4.7-Flash"
+    megatron_model_type: str = "glm4.7-flash"
+    num_gpus_per_node: int = 8
+    hardware: Literal["H200"] = "H200"
+    enable_eval: bool = True
+    skip_prepare: bool = False
+    extra_args: str = ""
+    data_dir: str = "/root/datasets"
+    model_dir: str = "/root/models"
+    megatron_path: str = "/root/Megatron-LM"
+    wandb_project: str = "glm47-flash-gsm8k"
+
+
+def prepare(args: ScriptArgs):
+    if args.skip_prepare:
+        print("prepare: --skip-prepare set, skipping model/dataset download + conversion")
+        return
+
+    U.exec_command(f"mkdir -p {args.model_dir} {args.data_dir}")
+
+    hf_checkpoint = f"{args.model_dir}/{args.model_name}"
+    if Path(hf_checkpoint).exists():
+        print(f"prepare: {hf_checkpoint} already exists, skipping HF download")
+    else:
+        U.exec_command(
+            f"hf download {args.model_org}/{args.model_name} " f"--local-dir {hf_checkpoint}"
+        )
+
+    U.hf_download_dataset("zhuzilin/gsm8k", data_dir=args.data_dir)
+
+    U.convert_checkpoint(
+        model_name=args.model_name,
+        megatron_model_type=args.megatron_model_type,
+        num_gpus_per_node=args.num_gpus_per_node,
+        dir_dst=args.model_dir,
+        hf_checkpoint=hf_checkpoint,
+        megatron_path=args.megatron_path,
+    )
+
+
+def wandb_args(args: ScriptArgs) -> str:
+    wandb_key = os.environ.get("WANDB_API_KEY")
+    if not wandb_key:
+        print("Skip wandb configuration since WANDB_API_KEY is not found")
+        return ""
+    return (
+        "--use-wandb "
+        f"--wandb-project {args.wandb_project} "
+        f"--wandb-group {args.run_id} "
+        f"--wandb-key '{wandb_key}' "
+        "--disable-wandb-random-suffix "
+    )
+
+
+def execute(args: ScriptArgs):
+    ref_load_path = f"{args.model_dir}/{args.model_name}_torch_dist"
+    load_save_path = f"{args.output_dir}/{args.run_id}/checkpoints"
+
+    ckpt_args = (
+        f"--hf-checkpoint {args.model_dir}/{args.model_name} "
+        f"--ref-load {ref_load_path} "
+        f"--load {load_save_path} "
+        f"--save {load_save_path} "
+        f"--save-interval {2 if args.mode == 'debug_minimal' else 50} "
+        f"--save-retain-interval {2 if args.mode == 'debug_minimal' else 50} "
+    )
+
+    rollout_args = (
+        f"--prompt-data {args.data_dir}/gsm8k/train.parquet "
+        "--input-key messages "
+        "--label-key label "
+        "--apply-chat-template "
+        "--rollout-shuffle "
+        "--rm-type math "
+        f"--num-rollout {5 if args.mode == 'debug_minimal' else 300} "
+        "--rollout-batch-size 32 "
+        "--n-samples-per-prompt 8 "
+        f"--rollout-max-response-len {256 if args.mode == 'debug_minimal' else 1024} "
+        "--rollout-temperature 1 "
+        "--global-batch-size 256 "
+    )
+
+    eval_args = ""
+    if (args.mode != "debug_minimal") and args.enable_eval:
+        eval_args += (
+            "--eval-interval 20 "
+            f"--eval-prompt-data gsm8k {args.data_dir}/gsm8k/test.parquet "
+            "--n-samples-per-eval-prompt 1 "
+            "--eval-max-response-len 1024 "
+            "--eval-top-k 1 "
+        )
+
+    perf_args = (
+        "--tensor-model-parallel-size 4 "
+        "--sequence-parallel "
+        "--pipeline-model-parallel-size 1 "
+        "--context-parallel-size 1 "
+        "--expert-model-parallel-size 8 "
+        "--expert-tensor-parallel-size 1 "
+        "--recompute-granularity full "
+        "--recompute-method uniform "
+        "--recompute-num-layers 1 "
+        "--use-dynamic-batch-size "
+        "--max-tokens-per-gpu 32768 "
+    )
+
+    grpo_args = (
+        "--advantage-estimator grpo "
+        "--use-kl-loss "
+        "--kl-loss-coef 0.00 "
+        "--kl-loss-type low_var_kl "
+        "--entropy-coef 0.00 "
+        "--eps-clip 0.2 "
+        "--eps-clip-high 0.28 "
+    )
+
+    optimizer_args = (
+        "--optimizer adam "
+        "--lr 1e-6 "
+        "--lr-decay-style constant "
+        "--weight-decay 0.1 "
+        "--adam-beta1 0.9 "
+        "--adam-beta2 0.98 "
+        "--optimizer-cpu-offload "
+        "--overlap-cpu-optimizer-d2h-h2d "
+        "--use-precision-aware-optimizer "
+    )
+
+    # tp=4 because GLM-4.7-Flash has 20 attention heads (tp must divide num_heads)
+    sglang_args = (
+        "--rollout-num-gpus-per-engine 4 "
+        "--sglang-mem-fraction-static 0.7 "
+        # EAGLE speculative decoding (MTP)
+        "--sglang-speculative-algorithm EAGLE "
+        "--sglang-speculative-num-steps 2 "
+        "--sglang-speculative-eagle-topk 1 "
+        "--sglang-speculative-num-draft-tokens 3 "
+        # rollout routing replay (kept); NOTE: miles router intentionally NOT used
+        "--use-rollout-routing-replay "
+    )
+
+    misc_args = (
+        "--attention-dropout 0.0 "
+        "--hidden-dropout 0.0 "
+        "--accumulate-allreduce-grads-in-fp32 "
+        "--attention-softmax-in-fp32 "
+        "--attention-backend flash "
+        f"--actor-num-nodes {args.num_nodes} "
+        f"--actor-num-gpus-per-node {args.num_gpus_per_node} "
+        f"--num-gpus-per-node {args.num_gpus_per_node} "
+        "--colocate "
+        "--use-fault-tolerance "
+    )
+
+    train_args = (
+        f"{ckpt_args} "
+        f"{rollout_args} "
+        f"{optimizer_args} "
+        f"{grpo_args} "
+        f"{wandb_args(args)} "
+        f"{perf_args} "
+        f"{eval_args} "
+        f"{sglang_args} "
+        f"{misc_args} "
+        f"{args.extra_args} "
+    )
+
+    U.execute_train(
+        train_args=train_args,
+        config=args,
+        num_gpus_per_node=args.num_gpus_per_node,
+        megatron_model_type=args.megatron_model_type,
+        megatron_path=args.megatron_path,
+    )
+
+
+@U.dataclass_cli
+def main(args: ScriptArgs):
+    prepare(args)
+    execute(args)
+
+
+if __name__ == "__main__":
+    typer.run(main)


### PR DESCRIPTION
## Summary
- New single-node (8×H200) launcher `scripts/run_glm47_flash_gsm8k.py` for non-agentic math GRPO of GLM-4.7-Flash on GSM8K. Rollouts are generated in-process by SGLang and scored by the exact-match math reward (`--rm-type math`) — no env/agent server.
- New example doc `docs/examples/glm47-flash-gsm8k.md` (registered in the Examples nav) with a step-by-step launch guide, config walkthrough, and which W&B metrics to watch.

## Details
Adapted from `scripts/run_glm47_flash.py`: swaps dapo-math for GSM8K, 1024 response length, 300 rollouts, GSM8K eval, an explicit `--wandb-project`, and a `--skip-prepare` fast path for pre-staged checkpoints. Uses the SGLang router (the Miles router is intentionally omitted).

## Test plan
- [x] Launcher syntax-checks and parses CLI args.
- [x] Launched a live run on a single 8×H200 node from the vanilla GLM-4.7-Flash checkpoint (W&B project `glm47-flash-gsm8k`). Baseline `eval/gsm8k = 0.862`; GRPO training advancing with `rollout/raw_reward` ~0.69-0.79.
