### PR TITLE
docs: document the optional agent abort hook

### DIFF
--- a/docs/user-guide/rollout-endpoints.md
+++ b/docs/user-guide/rollout-endpoints.md
@@ -181,6 +181,34 @@ remain a `messages` list. SGLang handles templating server-side.
 
 </Warning>
 
+### Optional teardown: the `abort` hook
+
+The module named by `--custom-agent-function-path` may expose an optional `abort`
+function alongside the agent entry point:
+
+```python
+async def abort(args) -> None:
+    ...  # tell this agent's backend to cancel its in-flight work
+```
+
+Miles calls it during **oversampling abort**. When dynamic sampling has collected
+enough groups, the rollout aborts in-flight SGLang generation (see
+[Partial rollout](/user-guide/training-script-walkthrough#partial-rollout-reclaim-aborted-work)).
+An external agent loop doesn't observe that abort on its own — it keeps issuing
+fresh completion requests until it hits its own `max_seq_len` or timeout. If your
+agent drives an external backend (e.g. a sandbox/agent server), define `abort` to
+tell that backend to tear down the trials tied to this rollout.
+
+The hook is **entirely optional and safe to omit**:
+
+- If the module defines no `abort`, nothing is called — existing plugins are
+  unaffected and their in-flight generations simply drain as before.
+- It only fires when `--custom-agent-function-path` is set, so non-agentic runs
+  never invoke it.
+
+See [`swe_agent_function.abort`](https://github.com/radixark/miles/blob/main/examples/experimental/swe-agent-v2/swe_agent_function.py)
+for a reference implementation that flushes the Harbor agent server.
+
 ### Customizing the wrapper
 
 [`agentic_tool_call.generate`](https://github.com/radixark/miles/blob/main/miles/rollout/generate_hub/agentic_tool_call.py)

--- a/docs/user-guide/training-script-walkthrough.md
+++ b/docs/user-guide/training-script-walkthrough.md
@@ -391,6 +391,16 @@ not a stuck trainer.
 Dynamic sampling implies that *some* in-flight generations will be abandoned. Without
 care, the compute invested in those half-finished trajectories is lost.
 
+<Note>
+
+**Agentic rollouts.** When an external agent drives generation, aborting SGLang
+doesn't stop the agent — it keeps issuing requests until its own limit. Define an
+optional [`abort` hook](/user-guide/rollout-endpoints#optional-teardown-the-abort-hook)
+in your `--custom-agent-function-path` module so Miles can tell the agent backend
+to tear down its in-flight trials at abort time.
+
+</Note>
+
 `--partial-rollout` flips on a buffer that retains partial samples and resumes their
 generation during the next rollout. The buffer dequeue policy is itself pluggable via
 `--buffer-filter-path`; the default is a first-in-first-out pop:


### PR DESCRIPTION
## Summary

Documents the optional `abort(args)` teardown hook added in #1639. Miles calls a sibling `abort` in the `--custom-agent-function-path` module during oversampling abort, but that contract was undocumented, so the call can surprise plugin authors (raised in #1639 review).

- `docs/user-guide/rollout-endpoints.md`: new "Optional teardown: the `abort` hook" section next to the existing agent wire-up — shows the signature, explains it fires on oversampling abort, and stresses it is optional / a no-op when absent, and only fires when an agent function is configured. Points at `swe_agent_function.abort` as the reference implementation.
- `docs/user-guide/training-script-walkthrough.md`: a Note in the "Partial rollout" section links the oversampling-abort mechanism to the agent hook.

The agentic workflow and the required agent entry point are already documented; this only fills the gap around the new `abort` hook.

## Test plan

- [ ] Docs-only change; verify the two new anchors/cross-links render in the docs site.
