### PR TITLE
docs: fix inaccuracies and expand explanations in Quick Start

### DIFF
--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -31,9 +31,9 @@ Steps 2–4 below all run inside the container.
 ## 2. Download model and data
 
 ```bash
-hf download Qwen/Qwen3-4B                          --local-dir /root/Qwen3-4B
+hf download Qwen/Qwen3-4B --local-dir /root/Qwen3-4B
 hf download --repo-type dataset BytedTsinghua-SIA/DAPO-Math-17K --local-dir /root/dapo-math-17k
-hf download --repo-type dataset zhuzilin/aime-2024     --local-dir /root/aime-2024
+hf download --repo-type dataset zhuzilin/aime-2024 --local-dir /root/aime-2024
 ```
 
 ## 3. Convert to Megatron format
@@ -47,7 +47,7 @@ source scripts/models/qwen3-4B.sh
 PYTHONPATH=/root/Megatron-LM python tools/convert_hf_to_torch_dist.py \
    ${MODEL_ARGS[@]} \
    --hf-checkpoint /root/Qwen3-4B \
-   --save          /root/Qwen3-4B_torch_dist
+   --save /root/Qwen3-4B_torch_dist
 ```
 
 For larger models, run the converter under `torchrun --nproc-per-node 8` (optionally
@@ -79,14 +79,14 @@ flowchart LR
     P[Prompt dataset] --> R[SGLang rollout]
     R --> RM[Reward fn]
     RM --> A[Megatron actor]
-    A == P2P weight sync ==> R
+    A == weight sync ==> R
     A -. KL .-> Ref[(Reference model)]
 ```
 
 1. Sample `rollout-batch-size` prompts and generate `n-samples-per-prompt` responses.
-2. Score responses with the reward model (`--rm-type deepscaler` in this recipe).
+2. Score responses with the reward function (`--rm-type deepscaler` in this recipe).
 3. Compute the GRPO objective and step the optimizer.
-4. Push updated weights back to the SGLang engines via P2P.
+4. Push the updated weights back to the SGLang engines. This recipe uses the default NCCL broadcast; you can switch to point-to-point RDMA transfer with `--update-weight-transfer-mode p2p`.
 
 The four batch-sizing knobs satisfy:
 
@@ -115,6 +115,6 @@ Miles fills in whichever side you leave unset.
   dynamic sampling, partial rollout, and BF16+FP8 inference.
 - [Training backends](/user-guide/usage) — Megatron vs FSDP.
 - [Customization](/user-guide/customization) — plug in custom rollout / reward.
-- [Models](/models/index) — recipes for Qwen3.5, GLM4.5, DeepSeek R1, Kimi K2, and more.
+- [Models](/models/index) — recipes for Qwen3.5, GLM4.5, DeepSeek V4, Kimi K2, and more.
 
 If you hit issues, the [FAQ](/faq) covers the common ones.

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -173,6 +173,6 @@ samples = 256 = one optimizer step at global batch size 256.
   dynamic sampling, partial rollout, and BF16+FP8 inference.
 - [Training backends](/user-guide/usage) — Megatron vs FSDP.
 - [Customization](/user-guide/customization) — plug in custom rollout / reward.
-- [Models](/models/index) — recipes for Qwen3.5, GLM4.5, DeepSeek V4, Kimi K2, and more.
+- [Models](/models/index) — recipes for Qwen3.5, GLM5.2, DeepSeek V4, Kimi K2.6, and more.
 
 If you hit issues, the [FAQ](/faq) covers the common ones.

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -5,6 +5,11 @@ description: A working RL training job on Qwen3-4B in under an hour.
 This page takes you from `docker pull` to a running GRPO training job on Qwen3-4B. It
 assumes an 8-GPU node (H100 / H200 / B-series) and roughly 200 GB of disk.
 
+A Miles job combines two engines: [SGLang](https://github.com/sgl-project/sglang)
+generates responses from the current policy (the *rollout*), and
+[Megatron-LM](https://github.com/NVIDIA/Megatron-LM) updates the policy from those
+responses (the *training*). In this recipe both share the same 8 GPUs.
+
 For other models, see [Models](/models/index).
 
 ## 1. Start the container
@@ -20,7 +25,13 @@ docker run --rm \
   -it radixark/miles:latest /bin/bash
 ```
 
-That drops you into a shell inside the container. Refresh the editable install:
+The flags matter: `--gpus all` exposes the GPUs, `--ipc=host` and `--shm-size=32g`
+give NCCL and Ray the shared memory they need, and `--network=host` lets you reach
+the Ray dashboard from the host.
+
+That drops you into a shell inside the container. The image ships with Miles at
+`/root/miles` and Megatron-LM at `/root/Megatron-LM`. Refresh the editable install
+so you run the latest main:
 
 ```bash
 cd /root/miles && git pull && pip install -e . --no-deps
@@ -30,15 +41,26 @@ Steps 2–4 below all run inside the container.
 
 ## 2. Download model and data
 
+Three artifacts are needed: the model you will train, a training prompt set, and an
+evaluation set.
+
 ```bash
 hf download Qwen/Qwen3-4B --local-dir /root/Qwen3-4B
 hf download --repo-type dataset BytedTsinghua-SIA/DAPO-Math-17K --local-dir /root/dapo-math-17k
 hf download --repo-type dataset zhuzilin/aime-2024 --local-dir /root/aime-2024
 ```
 
+Qwen3-4B is the starting policy. DAPO-Math-17K supplies the training prompts — math
+problems whose ground-truth labels the reward function checks answers against.
+AIME-2024 is a small, harder benchmark used only for periodic evaluation, never for
+training.
+
 ## 3. Convert to Megatron format
 
-Megatron consumes a `torch_dist` checkpoint, not the raw HuggingFace directory.
+Megatron consumes a `torch_dist` checkpoint, not the raw HuggingFace directory. The
+`source` line below loads `MODEL_ARGS`, the Megatron-side description of the
+architecture (layer count, hidden sizes, attention layout); the converter uses it to
+map the HuggingFace weights into a sharded `torch_dist` checkpoint.
 
 ```bash
 cd /root/miles
@@ -50,6 +72,9 @@ PYTHONPATH=/root/Megatron-LM python tools/convert_hf_to_torch_dist.py \
    --save /root/Qwen3-4B_torch_dist
 ```
 
+Keep the original HuggingFace directory too — the launch script still points the
+SGLang engines at it (`--hf-checkpoint`).
+
 For larger models, run the converter under `torchrun --nproc-per-node 8` (optionally
 multi-node). See the [Models](/models/index) section for per-family conversion
 commands.
@@ -60,8 +85,23 @@ commands.
 bash scripts/run-qwen3-4B.sh
 ```
 
-The script starts Ray, launches SGLang engines, loads the Megatron actor, and runs the
-rollout / train loop. After a minute or two you should see iteration logs:
+The script is organized into named argument groups (`CKPT_ARGS`, `ROLLOUT_ARGS`,
+`GRPO_ARGS`, and so on) and is meant to be read and edited — it is the canonical
+place to change hyperparameters. When launched, it starts a local Ray cluster and
+submits `train.py` as a Ray job. The run is colocated (`--colocate`): the four
+SGLang engines (2 GPUs each) and the Megatron trainer share the same 8 GPUs,
+alternating between generation and training phases.
+
+A few defaults worth knowing on a first run:
+
+- Checkpoints are written to `/root/Qwen3-4B_miles/` every 20 rollouts
+  (`--save-interval 20`).
+- The policy is evaluated on AIME-2024 every 20 rollouts (`--eval-interval 20`).
+- If the run dies, relaunch the same script — `--load` points at the save
+  directory, so training resumes from the last checkpoint.
+- The Ray dashboard at `http://localhost:8265` shows per-worker logs and GPU usage.
+
+After a minute or two you should see iteration logs:
 
 ```text
 [ray]      starting cluster on 1 node, 8 gpus
@@ -83,9 +123,14 @@ flowchart LR
     A -. KL .-> Ref[(Reference model)]
 ```
 
-1. Sample `rollout-batch-size` prompts and generate `n-samples-per-prompt` responses.
-2. Score responses with the reward function (`--rm-type deepscaler` in this recipe).
-3. Compute the GRPO objective and step the optimizer.
+1. Sample `rollout-batch-size` prompts from the dataset and let the SGLang engines
+   generate `n-samples-per-prompt` candidate responses for each.
+2. Score every response with the reward function — `--rm-type deepscaler` in this
+   recipe, a rule-based verifier that compares the model's final answer against the
+   dataset label.
+3. Compute the GRPO objective from the scored responses and step the optimizer. The
+   frozen reference model provides the optional KL regularization term (this recipe
+   sets `--kl-loss-coef 0.00`, so the term is off).
 4. Push the updated weights back to the SGLang engines. This recipe uses the default NCCL broadcast; you can switch to point-to-point RDMA transfer with `--update-weight-transfer-mode p2p`.
 
 The four batch-sizing knobs satisfy:
@@ -95,7 +140,8 @@ rollout_batch_size × n_samples_per_prompt
   = global_batch_size × num_steps_per_rollout
 ```
 
-Miles fills in whichever side you leave unset.
+Miles fills in whichever side you leave unset. In this recipe, 32 prompts × 8
+samples = 256 = one optimizer step at global batch size 256.
 
 ## Inspecting a run
 

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -3,14 +3,13 @@ title: Quick Start
 description: A working RL training job on Qwen3-4B in under an hour.
 ---
 This page takes you from `docker pull` to a running GRPO training job on Qwen3-4B. It
-assumes an 8-GPU node (H100 / H200 / B-series) and roughly 200 GB of disk.
+assumes an 8-GPU node (H100 / H200 / B-series) and roughly 200 GB of disk. For other
+models, see [Models](/models/index).
 
 A Miles job combines two engines: [SGLang](https://github.com/sgl-project/sglang)
 generates responses from the current policy (the *rollout*), and
 [Megatron-LM](https://github.com/NVIDIA/Megatron-LM) updates the policy from those
 responses (the *training*). In this recipe both share the same 8 GPUs.
-
-For other models, see [Models](/models/index).
 
 ## 1. Start the container
 
@@ -50,10 +49,12 @@ hf download --repo-type dataset BytedTsinghua-SIA/DAPO-Math-17K --local-dir /roo
 hf download --repo-type dataset zhuzilin/aime-2024 --local-dir /root/aime-2024
 ```
 
-Qwen3-4B is the starting policy. DAPO-Math-17K supplies the training prompts — math
-problems whose ground-truth labels the reward function checks answers against.
-AIME-2024 is a small, harder benchmark used only for periodic evaluation, never for
-training.
+Qwen3-4B is the starting policy.
+[DAPO-Math-17K](https://huggingface.co/datasets/BytedTsinghua-SIA/DAPO-Math-17K)
+supplies the training prompts — math problems whose ground-truth labels the reward
+function checks answers against.
+[AIME-2024](https://huggingface.co/datasets/zhuzilin/aime-2024) is a small, harder
+benchmark used only for periodic evaluation, never for training.
 
 ## 3. Convert to Megatron format
 
@@ -74,10 +75,6 @@ PYTHONPATH=/root/Megatron-LM python tools/convert_hf_to_torch_dist.py \
 
 Keep the original HuggingFace directory too — the launch script still points the
 SGLang engines at it (`--hf-checkpoint`).
-
-For larger models, run the converter under `torchrun --nproc-per-node 8` (optionally
-multi-node). See the [Models](/models/index) section for per-family conversion
-commands.
 
 ## 4. Launch training
 
@@ -101,14 +98,22 @@ A few defaults worth knowing on a first run:
   directory, so training resumes from the last checkpoint.
 - The Ray dashboard at `http://localhost:8265` shows per-worker logs and GPU usage.
 
-After a minute or two you should see iteration logs:
+After the engines start up and the first rollout completes, the job log settles into
+per-rollout metric lines. The values below are illustrative, and each line carries
+more keys than shown:
 
 ```text
-[ray]      starting cluster on 1 node, 8 gpus
-[sglang]   launching 4 engines (tp=2 each)
-[megatron] loading dist checkpoint from /root/Qwen3-4B_torch_dist
-[trainer]  iter 1/3000 | loss=0.412 reward=0.61 rollout=18.4s train=22.1s
+perf 0: {'perf/rollout_time': 98.6, ...}
+rollout 0: {'rollout/raw_reward': 0.32, 'rollout/log_probs': -0.27, ...}
+step 0: {'train/loss': 0.0021, 'train/pg_loss': 0.0018, 'train/grad_norm': 0.62, ...}
+perf 0: {'perf/train_wait_time': 101.2, 'perf/actor_train_time': 41.3, ...}
 ```
+
+`rollout/raw_reward` is the mean reward of the freshly scored responses — the number
+to watch. The `step` line reports each optimizer step, and the two `perf` lines time
+the generation side (`perf/rollout_time`) and the training side
+(`perf/actor_train_time`) of the iteration. The same metrics go to wandb when
+`--use-wandb` is set.
 
 ## 5. What's happening
 
@@ -131,7 +136,14 @@ flowchart LR
 3. Compute the GRPO objective from the scored responses and step the optimizer. The
    frozen reference model provides the optional KL regularization term (this recipe
    sets `--kl-loss-coef 0.00`, so the term is off).
-4. Push the updated weights back to the SGLang engines. This recipe uses the default NCCL broadcast; you can switch to point-to-point RDMA transfer with `--update-weight-transfer-mode p2p`.
+4. Push the updated weights back to the SGLang engines. In this colocated recipe the
+   trainer and the engines share the same GPUs, so each rank gathers its weight shards
+   over NCCL, converts them to the HuggingFace layout, and hands them to its local
+   engine through IPC — no network transfer is involved. Disaggregated runs choose a
+   transport with `--update-weight-transfer-mode` instead: the default `broadcast`
+   sends the weights from the trainer to the engines over NCCL, while `p2p` writes
+   them point-to-point over RDMA (via the Mooncake transfer engine) rather than using
+   a collective; `p2p` cannot be combined with `--colocate`.
 
 The four batch-sizing knobs satisfy:
 
@@ -147,8 +159,8 @@ samples = 256 = one optimizer step at global batch size 256.
 
 | Question | Where to look |
 |---|---|
-| Is the policy learning? | `loss` and `reward` columns in stdout, or wandb |
-| Rollout or train bottleneck? | `rollout=` vs. `train=` timings per iteration |
+| Is the policy learning? | `rollout/raw_reward` in stdout, or wandb |
+| Rollout or train bottleneck? | `perf/rollout_time` vs. `perf/actor_train_time` |
 | Are GPUs saturated? | `nvidia-smi dmon -s u` |
 | SGLang internals? | `tail -f /tmp/sglang/*.log` |
 | Ranks crashing? | `~/.ray/session_latest/logs/worker-*.err` |


### PR DESCRIPTION
## Summary

Three passes over the Quick Start page (`docs/getting-started/quick-start.md`), checked against the actual recipe (`scripts/run-qwen3-4B.sh`, `scripts/models/qwen3-4B.sh`), `miles/utils/arguments.py`, and the weight-update / logging code.

### Pass 1: factual fixes

- **Weight sync is not P2P.** The mermaid diagram and step 4 claimed weights are pushed "via P2P", but `run-qwen3-4B.sh` never opts into P2P. Relabeled the diagram edge to "weight sync" and reworded step 4 (further refined in pass 3 below).
- **Stale model name.** The Next-steps model list mentioned "DeepSeek R1", but there is no R1 recipe under `docs/models/deepseek/` (recipes are DeepSeek V4 flash/pro). Changed to "DeepSeek V4".
- **Terminology.** Step 2 called `--rm-type deepscaler` "the reward model"; it is a rule-based reward function (the diagram already labels it `Reward fn`). Changed "reward model" to "reward function".
- **Whitespace alignment.** Removed padded column alignment in the `hf download` block and the converter's `--save` flag.

### Pass 2: explanatory pass for first-time users

- **Intro** now explains the two engines up front: SGLang generates the rollout, Megatron-LM trains on it, and in this recipe they share the same 8 GPUs.
- **Step 1** explains why each docker flag is needed and what ships in the image (`/root/miles`, `/root/Megatron-LM`), so the editable-install refresh makes sense.
- **Step 2** explains the role of each artifact: Qwen3-4B is the starting policy, DAPO-Math-17K supplies training prompts with checkable labels, AIME-2024 is eval-only.
- **Step 3** explains what `MODEL_ARGS` is and why conversion is needed, and warns to keep the HuggingFace directory because SGLang still loads it via `--hf-checkpoint`.
- **Step 4** describes the launch script as the canonical, editable home of hyperparameters, explains colocation (4 engines x 2 GPUs sharing the node with the trainer), and lists first-run defaults: checkpoint/eval every 20 rollouts, resume-by-relaunch via `--load`, and the Ray dashboard at `localhost:8265`.
- **Step 5** expands the loop description: deepscaler as a rule-based verifier, the KL term being off in this recipe (`--kl-loss-coef 0.00`), and a concrete instance of the batch equation (32 prompts x 8 samples = 256 = one optimizer step).

### Pass 3: review follow-ups

- Merged the "For other models" pointer into the opening paragraph.
- Added HuggingFace hyperlinks for the DAPO-Math-17K and AIME-2024 datasets.
- Removed the `torchrun` multi-node converter paragraph — not needed for this simple example.
- **Replaced the fabricated sample log block.** The `[ray]/[sglang]/[megatron]/[trainer]` lines do not exist in the codebase. The real per-rollout output is the `rollout N: {...}` / `step N: {...}` / `perf N: {...}` metric-dict lines emitted by `gather_log_data`, `log_train_step`, and the perf loggers (`miles/backends/training_utils/log_utils.py`, `miles/ray/rollout/metrics.py`), with real keys (`rollout/raw_reward`, `train/loss`, `train/pg_loss`, `perf/rollout_time`, `perf/actor_train_time`). Also updated the "Inspecting a run" table rows that referenced the fabricated fields.
- **Corrected and expanded the weight-sync bullet.** With `--colocate` (this recipe), the updater is `UpdateWeightFromTensor` (`megatron_utils/actor.py`): NCCL gather to HF layout, then an IPC handoff to the local engine — `--update-weight-transfer-mode` does not apply. The bullet now also compares the disaggregated transports: default `broadcast` (NCCL trainer-to-engines) vs `p2p` (point-to-point RDMA via the Mooncake transfer engine, incompatible with `--colocate` per the assert in `arguments.py`).

The "SGLang internals" row of the inspection table is intentionally untouched here — it is fixed by #1802.

## Test plan

- [ ] Docs-only change; verify the Quick Start page renders correctly (including the mermaid diagram) in the docs build.