### PR TITLE
Point SGLANG_BRANCH back to sglang-miles

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,7 +15,7 @@ FROM lmsysorg/sglang:${SGLANG_IMAGE_TAG} AS sglang
 
 # ======================================== Arguments =============================================
 
-ARG SGLANG_BRANCH=sglang-miles-v0.5.15
+ARG SGLANG_BRANCH=sglang-miles
 ARG SGLANG_COMMIT=""
 
 ARG MEGATRON_REPO=radixark/Megatron-LM


### PR DESCRIPTION
sglang-miles has been repointed to the v0.5.15 stack (same commit as sglang-miles-v0.5.15, `5bca6f8`). Restore the default branch reference before the transitional `sglang-miles-v0.5.15` branch is deleted.