### PR TITLE
openenv: make grading command configurable via OPENENV_EVAL_CMD

### DIFF
--- a/examples/experimental/openenv/openenv_agent_function.py
+++ b/examples/experimental/openenv/openenv_agent_function.py
@@ -88,7 +88,12 @@ _TESTSH_RC_MARKER = "__TB2_TESTSH_RC__:"
 # Honor an empty _TASK_WORKDIR (workdir prefix disabled) the same way
 # _apply_workdir does, instead of silently forcing /app.
 _EVAL_CD_CMD = f"cd {_TASK_WORKDIR} && " if _TASK_WORKDIR else ""
-_CANONICAL_EVAL_CMD = (
+# The default grades canonical TB2 tasks. Override with OPENENV_EVAL_CMD to grade
+# any other task family (e.g. swebench-style test.sh + exit-code scoring) without
+# touching this adapter or the OpenEnv server: the custom command just has to end
+# by printing "<_REWARD_MARKER><float>" on stdout (its own line). The marker string
+# itself stays fixed as _REWARD_MARKER; only the command that produces it varies.
+_CANONICAL_EVAL_CMD = os.getenv("OPENENV_EVAL_CMD") or (
     # rm the reward file first so a stale one can never be read back if test.sh
     # fails to run (e.g. in a reused sandbox where /logs survives across episodes).
     "mkdir -p /tests /logs/verifier && rm -f /logs/verifier/reward.txt && "


### PR DESCRIPTION
## Summary
- Makes the OpenEnv rollout adapter's grading command overridable via a single new env var `OPENENV_EVAL_CMD`, defaulting to the existing canonical TB2 command so current behavior is unchanged.
- Lets other task families (e.g. swebench-style `test.sh` + exit-code scoring) plug in their own harness **without** patching this adapter or the OpenEnv env server.

## Why
The env server is a generic pull-image + copy-task-dir + `exec` harness; the adapter already does its own grading via an `exec` step rather than the env's built-in pytest `evaluate`. The only thing hardcoding us to TB2 was the grading command itself. Exposing it as one env var keeps the interface general (any family supplies a command that prints \`<_REWARD_MARKER><float>\` as its last stdout line) while the reward-parsing contract stays fixed.

## Change
One wrap: \`_CANONICAL_EVAL_CMD = os.getenv("OPENENV_EVAL_CMD") or ( <current default> )\` plus a comment documenting the contract. Net +6/-1 lines.

## Test plan
- [ ] Canonical TB2 run unaffected (env var unset -> identical command).
- [ ] Set \`OPENENV_EVAL_CMD\` to a swebench-style command that emits the reward marker and confirm reward parses back through \`_parse_reward_marker\`.