### PR TITLE
fix(eval): guard eval reward aggregation against None rewards

### DIFF
--- a/miles/ray/rollout/metrics.py
+++ b/miles/ray/rollout/metrics.py
@@ -28,13 +28,14 @@ def log_eval_rollout_data(rollout_id, args, data, extra_metrics: dict[str, Any] 
     for key in data.keys():
         rewards = data[key]["rewards"]
         num_none = sum(1 for r in rewards if r is None)
+        log_dict[f"eval/{key}-none_reward_ratio"] = num_none / len(rewards) if len(rewards) > 0 else 0.0
         if num_none:
             logger.warning(
                 f"eval/{key}: {num_none}/{len(rewards)} samples have reward=None "
                 "(likely errored/aborted trials); treating as 0.0 for metrics."
             )
             rewards = [0.0 if r is None else r for r in rewards]
-        log_dict[f"eval/{key}"] = sum(rewards) / len(rewards) if rewards else 0.0
+        log_dict[f"eval/{key}"] = sum(rewards) / len(rewards) if len(rewards) > 0 else 0.0
         if (samples := data[key].get("samples")) is not None:
             log_dict |= dict_add_prefix(_compute_metrics_from_samples(args, samples), f"eval/{key}/")
         if "truncated" in data[key]:

--- a/miles/ray/rollout/metrics.py
+++ b/miles/ray/rollout/metrics.py
@@ -27,7 +27,14 @@ def log_eval_rollout_data(rollout_id, args, data, extra_metrics: dict[str, Any] 
     log_dict = extra_metrics or {}
     for key in data.keys():
         rewards = data[key]["rewards"]
-        log_dict[f"eval/{key}"] = sum(rewards) / len(rewards)
+        num_none = sum(1 for r in rewards if r is None)
+        if num_none:
+            logger.warning(
+                f"eval/{key}: {num_none}/{len(rewards)} samples have reward=None "
+                "(likely errored/aborted trials); treating as 0.0 for metrics."
+            )
+            rewards = [0.0 if r is None else r for r in rewards]
+        log_dict[f"eval/{key}"] = sum(rewards) / len(rewards) if rewards else 0.0
         if (samples := data[key].get("samples")) is not None:
             log_dict |= dict_add_prefix(_compute_metrics_from_samples(args, samples), f"eval/{key}/")
         if "truncated" in data[key]:


### PR DESCRIPTION
## Summary
- `log_eval_rollout_data` in `miles/ray/rollout/metrics.py` computed `sum(rewards) / len(rewards)` with no guard against `None` entries in `rewards`.
- Whenever an eval trial returned `reward=None` (e.g. an errored/aborted trial from a session-server TITO rollback desync), the aggregation raised `TypeError: unsupported operand type(s) for +: 'float' and 'NoneType'`. A **single** `None` reward crashed the **entire** eval, taking down `train.py` and orphaning every in-flight trial.
- Fix: coerce `None` rewards to `0.0` (treating errored/aborted trials as failures, matching how the agent server already logs `reward=0.0` for them), emit a `logger.warning` so the data loss is surfaced, and reuse the coerced list for the downstream `compute_pass_rate` call so metrics stay consistent. An empty-list guard avoids a `ZeroDivisionError`.

## Context
Observed on a 6-node DeepSeek-V4-Flash eval (85 tasks x 5 samples = 425 trials): the run reached 425/425 completion, then crashed at `metrics.py:31` during aggregation because ~43% of trials returned `None` rewards from session-server rollback failures. The crash orphaned in-flight trials (cascading `CancelledError` / `InternalServerError`). This change makes eval aggregation robust so partial infra failures degrade gracefully into reported 0.0 rewards instead of losing the whole eval.

## Test plan
- [ ] Eval with a mix of valid and `None` rewards logs the warning and completes without crashing.
- [ ] Eval with all-valid rewards produces identical metrics to before.