### PR TITLE
[AMD] Use legacy HSA IPC to avoid the ROCm 7.2 dma-buf leak

### DIFF
--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -203,6 +203,8 @@ RUN rm -rf /tmp/wheels
 
 # Runtime knobs consumed by the current SGLang/PyTorch stack.
 ENV HIP_FORCE_DEV_KERNARG=1
+# ROCm 7.2 switched IPC to dma-buf, which leaks exported VRAM in colocate; force legacy IPC to avoid it.
+ENV HSA_ENABLE_IPC_MODE_LEGACY=1
 ENV HSA_NO_SCRATCH_RECLAIM=1
 ENV SGLANG_USE_AITER=1
 ENV SGLANG_ALLOW_OVERWRITE_LONGER_CONTEXT_LEN=1


### PR DESCRIPTION
Co-authored-with: @JessicaJiang-123

**Problem.** On ROCm 7.2.x, miles colocate (training + inference on the same GPUs) leaks GPU memory. Training is supposed to hand memory back after each step so inference can reuse it, but the low-water mark creeps up ~6–7 GB per step and the job OOMs after roughly 8–10 steps.

**Root cause — a ROCm runtime regression, not miles or SGLang.** When one process shares a GPU buffer with another, ROCm hands out an IPC handle for it. On 7.2 the "Make IPC Handles Unique" change (first shipped in 7.2.0) takes extra references to that memory on export and never releases them, so `hipFree` reports the buffer as freed while the driver keeps the pages alive. A small HIP test — allocate GPU memory, share it with another process via IPC, free it, in a loop — leaks ~256 MB per iteration on 7.2 and stays flat on 7.0/7.1. ROCm 7.2.0–7.2.4 are all affected; 7.0 and 7.1 are clean. It is already fixed on `rocm-systems` develop but has not shipped in any released 7.2.x.

**Solution (this PR).** Set `HSA_ENABLE_IPC_MODE_LEGACY=1`. ROCm 7.2 switched the default IPC path from the pre-7.2 legacy mode to dma-buf, and only the dma-buf path takes the leaking unique-handle references. Forcing legacy mode routes IPC the old way and avoids the leak entirely — no runtime rebuild and no ROCm downgrade. It is harmless on ROCm 7.0 (legacy is already the default there), so it is set unconditionally on the ROCm image. Remove once a released ROCm 7.2.x ships the fix.

- Cause: https://github.com/ROCm/rocm-systems/commit/c23c320b4d96ad2d36abd7d8dec5ccc7e30337e9
- Fix (not yet in a released 7.2.x): https://github.com/ROCm/rocm-systems/pull/1912
