### PR TITLE
fix(rollout): recover session rollback on router-timeout desync

### DIFF
--- a/miles/rollout/session/linear_trajectory.py
+++ b/miles/rollout/session/linear_trajectory.py
@@ -61,6 +61,10 @@ class LinearTrajectory:
 
         Must be called under ``self.lock``.
         """
+        # 1. Detect agent retries and roll back (at most one assistant step).
+        self._try_detect_and_rollback_to_assistant_checkpoint(request_messages)
+
+        # No stored prefix (first turn, or a rollback reset the trajectory): render fresh.
         if not self.token_ids:
             return tito_tokenizer.render_messages(
                 request_messages,
@@ -69,8 +73,6 @@ class LinearTrajectory:
                 tokenize=True,
             )
 
-        # 1. Detect agent retries and roll back (at most one assistant step).
-        self._try_detect_and_rollback_to_assistant_checkpoint(request_messages)
         # 2. Confirm the (possibly rolled-back) stored messages are a prefix of request,
         #    and that each appended message role is in tito_tokenizer.allowed_append_roles.
         try:
@@ -173,6 +175,14 @@ class LinearTrajectory:
               records              = [record_0]
               num_assistant        = 1
 
+        A retry that is a strict *prefix* of the stored history (no assistant in
+        the matched prefix) rolls back to zero assistant checkpoints — the
+        timeout-desync recovery for #955, where the engine committed an assistant
+        reply the client never received.  Bounded by
+        ``MAX_ASSISTANT_ROLLBACK_STEPS`` like any rollback, so a strict prefix
+        discarding two or more assistants, or a request that diverges *inside*
+        the matched prefix, is still rejected with ``MessageValidationError``.
+
         No rollback occurs when:
         - The stored history is empty.
         - *request_messages* is a strict extension of stored messages
@@ -193,7 +203,7 @@ class LinearTrajectory:
             return
 
         # Find the last assistant message within the matched prefix.
-        rollback_msg_end = None
+        rollback_msg_end = 0
         checkpoint_index = -1
         assistant_count = 0
         for i in range(match_len):
@@ -203,11 +213,15 @@ class LinearTrajectory:
                 assistant_count += 1
 
         if checkpoint_index < 0:
-            raise MessageValidationError(
-                f"rollback failed: no assistant message found in the first "
-                f"{match_len} matched messages (stored has {len(stored)} messages, "
-                f"request has {len(request_messages)} messages)"
-            )
+            # Reject a divergent or empty request; a strict prefix of stored
+            # history is the #955 timeout-desync retry -> roll back to zero.
+            if match_len == 0 or match_len < len(request_messages):
+                raise MessageValidationError(
+                    f"rollback failed: no assistant message found in the first "
+                    f"{match_len} matched messages (stored has {len(stored)} messages, "
+                    f"request has {len(request_messages)} messages)"
+                )
+            rollback_msg_end = match_len
 
         discard_count = self.num_assistant - (checkpoint_index + 1)
         if discard_count > MAX_ASSISTANT_ROLLBACK_STEPS:
@@ -227,7 +241,19 @@ class LinearTrajectory:
             rollback_msg_end,
             discard_count,
         )
+        if checkpoint_index < 0:
+            # Greppable signal so #955 timeout-desyncs are countable until a metric lands.
+            logger.warning(
+                "session rollback-to-zero: request is a strict prefix of stored "
+                "history (likely a router-timeout desync, #955); discarding the "
+                "orphaned assistant and resetting the trajectory "
+                "(stored=%d messages, request=%d messages)",
+                len(stored),
+                len(request_messages),
+            )
 
+        # On a zero rollback messages keeps the matched prefix while the rest reset;
+        # the next completion overwrites messages, so the brief asymmetry is expected.
         self.messages = stored[:rollback_msg_end]
         self.trajectory_token_ids = self.trajectory_token_ids[: checkpoint_index + 1]
         self.records = self.records[: checkpoint_index + 1]

--- a/tests/fast/router/test_linear_trajectory.py
+++ b/tests/fast/router/test_linear_trajectory.py
@@ -649,6 +649,84 @@ class TestRollback:
         assert len(session.records) == 1
         assert session.records[0].timestamp == 1.0
 
+    def test_rollback_to_zero_assistants_on_timeout_desync(self, registry: SessionRegistry):
+        """#955: a retry that is a strict prefix of stored history resets to zero.
+
+        After a router timeout the engine commits an assistant reply the client
+        never received; the client retries with its shorter (strict-prefix)
+        message list. The rollback should reset the whole trajectory to zero
+        assistant checkpoints and re-render from scratch, instead of raising a
+        non-recoverable MessageValidationError.
+        """
+        sid = registry.create_session()
+        session = registry.get_session(sid)
+
+        # Turn 1: [sys, user] -> asst1 (committed by the engine after the timeout).
+        session.update_pretokenized_state([SYS_MSG, USER_MSG], ASSISTANT_MSG_1, [1, 2], [10], max_trim_tokens=0)
+        session.append_record(
+            SessionRecord(
+                timestamp=1.0, method="POST", path="/v1/chat/completions", status_code=200, request={}, response={}
+            )
+        )
+        assert session.num_assistant == 1
+
+        # Client retries with only [sys, user] - a strict prefix of stored history.
+        result = session.prepare_pretokenized([SYS_MSG, USER_MSG], tito_tokenizer=registry.tito_tokenizer)
+
+        # Rolled back to zero checkpoints and re-rendered from scratch. The mock
+        # renders a first turn as _MOCK_FIRST_TURN_TOKENS; had we wrongly fallen
+        # through to merge_tokens with an empty prefix, the result would be [].
+        assert result == _MOCK_FIRST_TURN_TOKENS
+        assert session.num_assistant == 0
+        assert session.trajectory_token_ids == []
+        assert session.records == []
+        assert session.token_ids == []
+        assert session.messages == [SYS_MSG, USER_MSG]
+
+    def test_rollback_to_zero_then_continue(self, registry: SessionRegistry):
+        """After a reset to zero, a fresh completion rebuilds consistent state."""
+        sid = registry.create_session()
+        session = registry.get_session(sid)
+
+        session.update_pretokenized_state([SYS_MSG, USER_MSG], ASSISTANT_MSG_1, [1, 2], [10], max_trim_tokens=0)
+
+        # Strict-prefix retry resets to zero.
+        session.prepare_pretokenized([SYS_MSG, USER_MSG], tito_tokenizer=registry.tito_tokenizer)
+        assert session.num_assistant == 0
+
+        # Regenerate the first turn from the rolled-back state.
+        session.update_pretokenized_state([SYS_MSG, USER_MSG], ASSISTANT_MSG_2, [3, 4], [20], max_trim_tokens=0)
+
+        assert session.num_assistant == 1
+        assert len(session.trajectory_token_ids) == 1
+        assert session.token_ids == [3, 4, 20]
+        assert session.messages == [SYS_MSG, USER_MSG, ASSISTANT_MSG_2]
+
+    def test_rollback_to_zero_exceeding_max_steps_raises(self, registry: SessionRegistry):
+        """A strict-prefix retry that would discard two assistants is still rejected."""
+        sid = registry.create_session()
+        session = registry.get_session(sid)
+
+        # Two completed turns -> two assistant checkpoints.
+        session.update_pretokenized_state([SYS_MSG, USER_MSG], ASSISTANT_MSG_1, [1, 2], [10], max_trim_tokens=0)
+        t2 = [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1]
+        session.prepare_pretokenized(t2, tito_tokenizer=registry.tito_tokenizer)
+        session.update_pretokenized_state(t2, ASSISTANT_MSG_2, [1, 2, 10, 20], [30], max_trim_tokens=0)
+        assert session.num_assistant == 2
+
+        prev_messages = list(session.messages)
+        prev_token_ids = list(session.trajectory_token_ids)
+        prev_num_assistant = session.num_assistant
+
+        # Strict prefix [sys, user] would discard 2 assistants > MAX_ASSISTANT_ROLLBACK_STEPS.
+        with pytest.raises(MessageValidationError, match="exceeds max_assistant_rollback_steps"):
+            session.prepare_pretokenized([SYS_MSG, USER_MSG], tito_tokenizer=registry.tito_tokenizer)
+
+        # State must be unchanged.
+        assert session.messages == prev_messages
+        assert session.trajectory_token_ids == prev_token_ids
+        assert session.num_assistant == prev_num_assistant
+
 
 class TestUpdatePretokenizedStateMissingSession:
     """update_pretokenized_state raises SessionNotFoundError for unknown session."""


### PR DESCRIPTION
## Summary

Fixes #955.

A router timeout can leave the engine holding an assistant reply the client never received. The client then retries with a shorter message list (a strict prefix of stored history), and session rollback raised a non-recoverable **400**, abandoning the whole rollout trial and wasting GPU compute.

This makes rollback recover: on a strict-prefix retry it resets the trajectory to zero assistant checkpoints and re-renders, so the rollout continues. Recovery is GPU-cost-neutral (the re-sent prompt is a radix-cache hit — no re-prefill).

## Change

In `miles/rollout/session/linear_trajectory.py`:
- Reset to zero assistant checkpoints when the retry is a non-empty strict prefix with no assistant in the matched prefix. Still bounded by `MAX_ASSISTANT_ROLLBACK_STEPS`, so it only fires for the single orphaned turn — a genuine divergence, or a 2+-assistant rollback, still raises.
- Reorder `prepare_pretokenized` so a reset re-renders from scratch instead of an empty-prefix `merge_tokens`.

No error-hierarchy or HTTP-contract change. A distinct `WARNING` keeps these desyncs countable in logs.

## Why not the proposed 409

A 409 is a reasonable ergonomics layer, but insufficient alone: a retried 409 hits the same path and only succeeds *because of* this rollback. The server-side fix is the necessary core; a 409 can layer on later.

## Limitations

- Covers the single-orphaned-assistant case; deeper multi-turn desyncs stay rejected.
- Root cause is the timeout itself (#920) — this is a backstop, not the root fix.

## Tests

3 new tests (repro, reset-then-continue, 2-assistant guard) + existing suite green (43/43). Fast tests use a stub tokenizer; the real-tokenizer path after reset runs only in CI.

Related: #920
