### PR TITLE
Rewrite fully-async rollout as FullyAsyncRolloutFn on the class-based rollout API

### DIFF
--- a/docs/developer/architecture.md
+++ b/docs/developer/architecture.md
@@ -87,7 +87,7 @@ sequenceDiagram
 ```
 
 This is the sync path. Async (`train_async.py` + `--rollout-function-path
-miles.rollout.fully_async_rollout.generate_rollout_fully_async`) breaks the request from the trainer
+miles.rollout.fully_async_rollout.FullyAsyncRolloutFn`) breaks the request from the trainer
 loop and uses a continuously-running worker.
 
 ## Where common changes go

--- a/docs/developer/architecture.md
+++ b/docs/developer/architecture.md
@@ -86,9 +86,8 @@ sequenceDiagram
     T->>SG: weight_sync(p2p)
 ```
 
-This is the sync path. Async (`train_async.py` + `--rollout-function-path
-miles.rollout.fully_async_rollout.FullyAsyncRolloutFn`) breaks the request from the trainer
-loop and uses a continuously-running worker.
+This is the sync path. Fully async (`train_async.py --fully-async`) breaks the request
+from the trainer loop and uses a continuously-running worker.
 
 ## Where common changes go
 

--- a/docs/examples/fully-async.md
+++ b/docs/examples/fully-async.md
@@ -31,7 +31,7 @@ instead of the sum.
 ## Files
 
 ```text
-miles/rollout/fully_async_rollout.py # AsyncRolloutWorker + entry function
+miles/rollout/fully_async_rollout.py # FullyAsyncRolloutFn (worker + drain)
 examples/fully_async/
 ├── run-qwen3-4b-fully_async.sh     # launch script (Qwen3-4B)
 └── run_qwen3_30b_a3b_fully_async.py # MoE variant
@@ -47,9 +47,8 @@ bash examples/fully_async/run-qwen3-4b-fully_async.sh
 You should see:
 
 ```text
-Creating new global async worker...
-Continuous async rollout worker started
-[trainer] iter 1/3000 | drained 32 samples (queued: 18)
+Started fully-async rollout worker
+First rollout sample: ...
 ```
 
 ## What changes vs. the default recipe
@@ -59,62 +58,65 @@ Just two flags:
 ```diff
 - python3 train.py ...
 + python3 train_async.py ...
-+   --rollout-function-path miles.rollout.fully_async_rollout.generate_rollout_fully_async
++   --rollout-function-path miles.rollout.fully_async_rollout.FullyAsyncRolloutFn
 ```
 
 Everything else — model args, optimizer, GRPO config — stays the same.
 
 ## Walkthrough
 
-The interesting code is small. Here's the global worker manager:
+The interesting code is small. `FullyAsyncRolloutFn` is a class-based rollout
+function: the constructor receives the args and data source once, and the worker is a
+long-lived task on the shared rollout event loop, started lazily on the first train
+call:
 
 ```python miles/rollout/fully_async_rollout.py
-_global_worker = None
-_worker_lock = threading.Lock()
-
-def get_global_worker(args, data_buffer):
-    global _global_worker
-    with _worker_lock:
-        if _global_worker is None or not _global_worker.worker_thread.is_alive():
-            print("Creating new global async worker...")
-            _global_worker = AsyncRolloutWorker(args, data_buffer,
-                                                concurrency=args.sglang_server_concurrency)
-            _global_worker.start()
-        return _global_worker
+class FullyAsyncRolloutFn:
+    async def __call__(self, input):
+        if input.evaluation:
+            raise ValueError(...)
+        if self._worker is None:
+            self._output = asyncio.Queue(maxsize=OUTPUT_QUEUE_MAX_GROUPS)
+            self._worker = asyncio.create_task(self._worker_loop())
+        return await self._drain(input.rollout_id)
 ```
 
 Key points:
 
-* **Singleton.** One worker per process — multiple `train.py` calls share it.
-* **Thread + asyncio loop.** Cheaper than a subprocess; SGLang HTTP calls are I/O-bound,
-  so an asyncio loop in a single thread saturates them.
-* **`atexit` hook.** Worker is torn down when the process exits — no orphaned
-  generation tasks.
+* **Instance state, no globals.** The worker, queue, and `GenerateState` live on the
+  rollout-fn instance that `RolloutManager` holds for the process lifetime.
+* **One event loop.** Worker, drain, and eval coroutines all run on the shared rollout
+  loop — plain `asyncio.Queue`, no threads, no locks, no `atexit`.
+* **Errors are loud.** A failed generation task kills the worker, and the next drain
+  raises instead of hanging.
 
-The worker itself keeps `--rollout-batch-size` tasks in flight using
+The worker keeps `--rollout-batch-size` groups in flight using
 `generate_and_rm_group`:
 
 ```python
-async def _producer(self):
-    while not self._stop:
-        if len(self._inflight) < self.target_inflight:
-            self._inflight.add(asyncio.create_task(self._launch_one()))
-        done, self._inflight = await asyncio.wait(
-            self._inflight, return_when=asyncio.FIRST_COMPLETED
-        )
+async def _worker_loop(self):
+    active = set()
+    while True:
+        while len(active) < self._max_in_flight_groups():
+            active.add(self._submit_one_group())
+        done, active = await asyncio.wait(active, return_when=asyncio.FIRST_COMPLETED)
         for task in done:
-            self._output_queue.put(task.result())
+            await self._output.put(task.result())
 ```
 
-And the trainer-side entry simply drains:
+And each training step simply drains, recycling aborted or stale groups back into the
+data source:
 
 ```python
-async def generate_rollout_fully_async(args, rollout_id, *, evaluation=False):
-    worker = get_global_worker(args, data_buffer)
-    samples = []
-    while len(samples) < args.global_batch_size:
-        samples.append(worker._output_queue.get(timeout=600))
-    return RolloutFnTrainOutput(samples=samples)
+async def _drain(self, rollout_id):
+    data = []
+    while len(data) < self.args.rollout_batch_size:
+        group = await self._next_group()
+        if any(s.status == Sample.Status.ABORTED for s in _iter_samples(group)):
+            self._recycle(group)
+            continue
+        data.append(group)
+    return RolloutFnTrainOutput(samples=data, metrics=...)
 ```
 
 ## What's happening underneath
@@ -122,7 +124,7 @@ async def generate_rollout_fully_async(args, rollout_id, *, evaluation=False):
 ```mermaid
 sequenceDiagram
     participant T as train_async.py
-    participant W as AsyncRolloutWorker
+    participant W as FullyAsyncRolloutFn worker
     participant S as SGLang engines
 
     par Background
@@ -172,13 +174,13 @@ check GPU utilization.
 
 ## Limitations
 
-* **No evaluation mode in this example.** Eval still runs through the synchronous path
-  in `train_async.py`. Adding async eval is straightforward — copy the worker pattern
-  and use `evaluation=True`.
+* **No evaluation mode.** `FullyAsyncRolloutFn` raises on eval; set
+  `--eval-function-path` to the standard
+  `miles.rollout.inference_rollout.inference_rollout_common.InferenceRolloutFn`.
+* **Requires `MILES_EXPERIMENTAL_ROLLOUT_REFACTOR=1`.** Class-based rollout functions
+  only load on the new rollout API.
 * **Best-effort ordering.** Samples are sorted by index at drain time, but exact-order
   guarantees aren't provided.
-* **Minimal error handling.** If a generate task throws, it's logged but the worker
-  keeps going. Production users wire in [fault tolerance](/advanced/fault-tolerance).
 
 ## Variations
 

--- a/docs/examples/fully-async.md
+++ b/docs/examples/fully-async.md
@@ -53,12 +53,12 @@ First rollout sample: ...
 
 ## What changes vs. the default recipe
 
-Just two flags:
+Just two changes:
 
 ```diff
 - python3 train.py ...
-+ python3 train_async.py ...
-+   --rollout-function-path miles.rollout.fully_async_rollout.FullyAsyncRolloutFn
++ MILES_EXPERIMENTAL_ROLLOUT_REFACTOR=1 python3 train_async.py ...
++   --fully-async
 ```
 
 Everything else — model args, optimizer, GRPO config — stays the same.
@@ -174,9 +174,9 @@ check GPU utilization.
 
 ## Limitations
 
-* **No evaluation mode.** `FullyAsyncRolloutFn` raises on eval; set
-  `--eval-function-path` to the standard
-  `miles.rollout.inference_rollout.inference_rollout_common.InferenceRolloutFn`.
+* **No evaluation mode.** `FullyAsyncRolloutFn` raises on eval; `--fully-async`
+  therefore points `--eval-function-path` at the standard inference rollout unless you
+  set it yourself.
 * **Requires `MILES_EXPERIMENTAL_ROLLOUT_REFACTOR=1`.** Class-based rollout functions
   only load on the new rollout API.
 * **Best-effort ordering.** Samples are sorted by index at drain time, but exact-order

--- a/docs/user-guide/fully-async.md
+++ b/docs/user-guide/fully-async.md
@@ -26,13 +26,13 @@ where generation dominates the iteration.
 
 ## Enable it
 
-Switch the entrypoint from `train.py` to `train_async.py` and provide a rollout
-function that owns the background worker:
+Switch the entrypoint from `train.py` to `train_async.py`, enable the class-based
+rollout API, and select the rollout function that owns the background worker:
 
 ```diff
 - python3 train.py ...
-+ python3 train_async.py ...
-+   --rollout-function-path miles.rollout.fully_async_rollout.generate_rollout_fully_async
++ MILES_EXPERIMENTAL_ROLLOUT_REFACTOR=1 python3 train_async.py ...
++   --rollout-function-path miles.rollout.fully_async_rollout.FullyAsyncRolloutFn
 ```
 
 Everything else belongs in the same [argument groups](/user-guide/argument-groups) as a
@@ -75,20 +75,25 @@ generation. If it is empty, rollout is still the bottleneck and async cannot hid
 | `--num-steps-per-rollout` | Number of optimizer steps per queue drain cycle |
 | `--max-weight-staleness` | When the rollout engine's weight version lags the trainer's by more than this, the worker recycles the stale group instead of feeding it to the loss |
 
-The reference worker caps its output queue at 1000 groups, so if training is slower
-than rollout the producer eventually blocks rather than growing the queue without
+The worker caps its output queue at 1000 groups, so if training is slower than
+rollout the producer eventually blocks rather than growing the queue without
 bound. If the queue stays at zero, rollout is the bottleneck — scale rollout capacity
 or lower per-sample generation cost.
 
 ## What to monitor
 
-The reference worker logs progress to stdout, not wandb. Useful lines to grep for:
+The worker reports per-step metrics to wandb/dashboard alongside the standard rollout
+metrics:
 
 ```text
-Global worker queue size: <N>
-Staleness stats: recycled=<N>, avg_staleness=<f>, max_staleness=<N>
-Warning: No progress for <N>s. Queue size: <N>, Collected: <N>/<N>
+rollout/fully_async/queue_size
+rollout/fully_async/aborted_groups_recycled
+rollout/fully_async/stale_groups_recycled
+rollout/fully_async/avg_staleness, rollout/fully_async/max_staleness
 ```
+
+A `No completed rollout groups for <N>s` warning in the logs means the drain is
+starved — rollout is the bottleneck.
 
 Treat large staleness windows as a training-quality signal, not just a performance
 signal. Fast [P2P weight transfer](/advanced/p2p-weight-transfer) keeps the

--- a/docs/user-guide/fully-async.md
+++ b/docs/user-guide/fully-async.md
@@ -27,13 +27,18 @@ where generation dominates the iteration.
 ## Enable it
 
 Switch the entrypoint from `train.py` to `train_async.py`, enable the class-based
-rollout API, and select the rollout function that owns the background worker:
+rollout API, and pass `--fully-async`:
 
 ```diff
 - python3 train.py ...
 + MILES_EXPERIMENTAL_ROLLOUT_REFACTOR=1 python3 train_async.py ...
-+   --rollout-function-path miles.rollout.fully_async_rollout.FullyAsyncRolloutFn
++   --fully-async
 ```
+
+`--fully-async` selects the built-in rollout worker and, unless you pass
+`--eval-function-path` yourself, points evaluation at the standard inference rollout
+(the fully async worker does not serve eval). When submitting through Ray, propagate
+`MILES_EXPERIMENTAL_ROLLOUT_REFACTOR=1` in the job's `runtime_env`.
 
 Everything else belongs in the same [argument groups](/user-guide/argument-groups) as a
 synchronous run.

--- a/docs/user-guide/training-script-walkthrough.md
+++ b/docs/user-guide/training-script-walkthrough.md
@@ -292,7 +292,7 @@ Enable it with two changes to the launch script:
 ```diff
 - python3 train.py ...
 + python3 train_async.py ...
-+   --rollout-function-path miles.rollout.fully_async_rollout.generate_rollout_fully_async
++   --rollout-function-path miles.rollout.fully_async_rollout.FullyAsyncRolloutFn
 ```
 
 | Mode | Per-iteration latency | Throughput | When to use |

--- a/docs/user-guide/training-script-walkthrough.md
+++ b/docs/user-guide/training-script-walkthrough.md
@@ -292,7 +292,7 @@ Enable it with two changes to the launch script:
 ```diff
 - python3 train.py ...
 + python3 train_async.py ...
-+   --rollout-function-path miles.rollout.fully_async_rollout.FullyAsyncRolloutFn
++   --fully-async
 ```
 
 | Mode | Per-iteration latency | Throughput | When to use |

--- a/docs/user-guide/training-script-walkthrough.md
+++ b/docs/user-guide/training-script-walkthrough.md
@@ -287,11 +287,11 @@ Async rollout turns the cadence into two concurrent loops. A background worker k
 into a queue; the trainer drains the queue, steps, and syncs weights. Per-iteration
 wall time drops to roughly `max(rollout_time, train_time)`.
 
-Enable it with two changes to the launch script:
+Enable it with three changes to the launch script:
 
 ```diff
 - python3 train.py ...
-+ python3 train_async.py ...
++ MILES_EXPERIMENTAL_ROLLOUT_REFACTOR=1 python3 train_async.py ...
 +   --fully-async
 ```
 

--- a/examples/fully_async/README.md
+++ b/examples/fully_async/README.md
@@ -2,7 +2,7 @@
 
 This example shows a simple way to make rollout generation **fully asynchronous**: a single global worker is created once and then keeps running in the background, continuously pulling prompts and launching generation tasks. Training only needs to fetch already finished results. This removes the per‑step wait that happens in the normal synchronous style.
 
-The implementation lives in the core library at `miles/rollout/fully_async_rollout.py` (global async worker + `generate_rollout_fully_async` entry).
+The implementation lives in the core library at `miles/rollout/fully_async_rollout.py` (`FullyAsyncRolloutFn`, a class-based rollout function that owns a persistent background worker). It requires `MILES_EXPERIMENTAL_ROLLOUT_REFACTOR=1`.
 
 ## Files
 * `run-qwen3-4b-fully_async.sh`: example launch script with Qwen3‑4B.
@@ -17,30 +17,29 @@ bash examples/fully_async/run-qwen3-4b-fully_async.sh
 ```
 You should see log lines like:
 ```
-Creating new global async worker...
-Continuous async rollout worker started
+Started fully-async rollout worker
 ```
 
 ## How It Works (Very Short)
-* First call: create `AsyncRolloutWorker` (thread + asyncio loop).
-* Loop keeps up to `--rollout-batch-size` tasks in flight using `generate_and_rm_group`.
-* Completed groups are pushed into a queue; caller drains until it has enough samples.
-* Worker is stopped automatically at process exit.
+* First train call: the rollout fn starts a persistent worker task on the shared rollout event loop.
+* The worker keeps up to `--rollout-batch-size` groups in flight using `generate_and_rm_group`.
+* Completed groups are pushed into a queue; each step drains until it has `--rollout-batch-size` groups.
+* Aborted or too-stale groups are recycled back into the data source.
 
 ## Limitations
-* No evaluation mode.
+* No evaluation mode (`--eval-function-path` must point at the standard `InferenceRolloutFn`).
 * Ordering is best effort (sorted at the end by index).
-* Minimal error handling.
 
-## Config Differences (2 Key Points)
-To enable the fully async pattern there are only two changes compared to a normal run:
+## Config Differences (3 Key Points)
+To enable the fully async pattern there are only three changes compared to a normal run:
 
 1. Use the async training driver: `train_async.py` (not `train.py`).
-2. Set the rollout function path:
+2. Enable the class-based rollout API: `MILES_EXPERIMENTAL_ROLLOUT_REFACTOR=1`.
+3. Set the rollout function path:
 	```bash
-	--rollout-function-path miles.rollout.fully_async_rollout.generate_rollout_fully_async
+	--rollout-function-path miles.rollout.fully_async_rollout.FullyAsyncRolloutFn
 	```
 
 Why is it still "fully" async although `train_async.py` itself schedules rollouts step‑by‑step?
 
-Because the real generation work is done by a **persistent background worker** created in `generate_rollout_fully_async`. Each call from `train_async.py` only drains already completed samples from the worker's output queue; the worker has been continuously generating since the first call. Thus rollout production (model inference) and training consume happen in parallel with minimal waiting.
+Because the real generation work is done by a **persistent background worker** owned by `FullyAsyncRolloutFn`. Each call from `train_async.py` only drains already completed samples from the worker's output queue; the worker has been continuously generating since the first call. Thus rollout production (model inference) and training consume happen in parallel with minimal waiting.

--- a/examples/fully_async/README.md
+++ b/examples/fully_async/README.md
@@ -27,7 +27,7 @@ Started fully-async rollout worker
 * Aborted or too-stale groups are recycled back into the data source.
 
 ## Limitations
-* No evaluation mode (`--eval-function-path` must point at the standard `InferenceRolloutFn`).
+* No evaluation mode (`--fully-async` points `--eval-function-path` at the standard `InferenceRolloutFn` unless you set it).
 * Ordering is best effort (sorted at the end by index).
 
 ## Config Differences (3 Key Points)
@@ -35,10 +35,7 @@ To enable the fully async pattern there are only three changes compared to a nor
 
 1. Use the async training driver: `train_async.py` (not `train.py`).
 2. Enable the class-based rollout API: `MILES_EXPERIMENTAL_ROLLOUT_REFACTOR=1`.
-3. Set the rollout function path:
-	```bash
-	--rollout-function-path miles.rollout.fully_async_rollout.FullyAsyncRolloutFn
-	```
+3. Pass `--fully-async`.
 
 Why is it still "fully" async although `train_async.py` itself schedules rollouts step‑by‑step?
 

--- a/examples/fully_async/run-qwen3-4b-fully_async.sh
+++ b/examples/fully_async/run-qwen3-4b-fully_async.sh
@@ -38,7 +38,7 @@ CKPT_ARGS=(
 PROMPT_SET=/path/to/dapo-math-17k.jsonl
 
 ROLLOUT_ARGS=(
-   --rollout-function-path miles.rollout.fully_async_rollout.generate_rollout_fully_async
+   --rollout-function-path miles.rollout.fully_async_rollout.FullyAsyncRolloutFn
    --prompt-data ${PROMPT_SET}
    --input-key prompt
    --label-key label
@@ -121,6 +121,7 @@ ray start --head --node-ip-address ${MASTER_ADDR} --num-gpus 8 --disable-usage-s
 RUNTIME_ENV_JSON="{
   \"env_vars\": {
     \"PYTHONPATH\": \"/root/Megatron-LM/\",
+    \"MILES_EXPERIMENTAL_ROLLOUT_REFACTOR\": \"1\",
     \"CUDA_DEVICE_MAX_CONNECTIONS\": \"1\",
     \"NCCL_NVLS_ENABLE\": \"${HAS_NVLINK}\"
   }

--- a/examples/fully_async/run-qwen3-4b-fully_async.sh
+++ b/examples/fully_async/run-qwen3-4b-fully_async.sh
@@ -38,7 +38,7 @@ CKPT_ARGS=(
 PROMPT_SET=/path/to/dapo-math-17k.jsonl
 
 ROLLOUT_ARGS=(
-   --rollout-function-path miles.rollout.fully_async_rollout.FullyAsyncRolloutFn
+   --fully-async
    --prompt-data ${PROMPT_SET}
    --input-key prompt
    --label-key label

--- a/examples/fully_async/run_qwen3_30b_a3b_fully_async.py
+++ b/examples/fully_async/run_qwen3_30b_a3b_fully_async.py
@@ -61,7 +61,7 @@ def execute(args: ScriptArgs):
     )
 
     rollout_args = (
-        "--rollout-function-path miles.rollout.fully_async_rollout.generate_rollout_fully_async "
+        "--rollout-function-path miles.rollout.fully_async_rollout.FullyAsyncRolloutFn "
         f"--prompt-data {args.data_dir}/dapo-math-17k/dapo-math-17k.jsonl "
         "--input-key prompt "
         "--label-key label "
@@ -158,6 +158,7 @@ def execute(args: ScriptArgs):
         megatron_path=args.megatron_path,
         extra_env_vars={
             "FLASHINFER_DISABLE_VERSION_CHECK": "1",
+            "MILES_EXPERIMENTAL_ROLLOUT_REFACTOR": "1",
             "PYTHONPATH": args.megatron_path,
         },
     )

--- a/examples/fully_async/run_qwen3_30b_a3b_fully_async.py
+++ b/examples/fully_async/run_qwen3_30b_a3b_fully_async.py
@@ -61,7 +61,7 @@ def execute(args: ScriptArgs):
     )
 
     rollout_args = (
-        "--rollout-function-path miles.rollout.fully_async_rollout.FullyAsyncRolloutFn "
+        "--fully-async "
         f"--prompt-data {args.data_dir}/dapo-math-17k/dapo-math-17k.jsonl "
         "--input-key prompt "
         "--label-key label "

--- a/examples/infra_features/random_async/random_async_rollout.py
+++ b/examples/infra_features/random_async/random_async_rollout.py
@@ -267,7 +267,7 @@ atexit.register(stop_global_worker)
 class AsyncRandomRolloutWorker:
     """Background asyncio loop that fills an output queue with random sample groups.
 
-    Mirrors ``miles.rollout.fully_async_rollout.AsyncRolloutWorker`` but
+    Mirrors the worker inside ``miles.rollout.fully_async_rollout.FullyAsyncRolloutFn`` but
     skips the data buffer and reward model entirely.
     """
 

--- a/examples/swe-agent/run-glm47-flash-agentic-async.py
+++ b/examples/swe-agent/run-glm47-flash-agentic-async.py
@@ -154,7 +154,7 @@ def execute(args: ScriptArgs):
     )
 
     rollout_args = (
-        "--rollout-function-path miles.rollout.fully_async_rollout.generate_rollout_fully_async "
+        "--rollout-function-path miles.rollout.fully_async_rollout.FullyAsyncRolloutFn "
         f"--prompt-data {args.prompt_data} "
         "--input-key prompt "
         "--metadata-key metadata "

--- a/examples/swe-agent/run-glm47-flash-agentic-async.py
+++ b/examples/swe-agent/run-glm47-flash-agentic-async.py
@@ -154,7 +154,7 @@ def execute(args: ScriptArgs):
     )
 
     rollout_args = (
-        "--rollout-function-path miles.rollout.fully_async_rollout.FullyAsyncRolloutFn "
+        "--fully-async "
         f"--prompt-data {args.prompt_data} "
         "--input-key prompt "
         "--metadata-key metadata "

--- a/miles/rollout/fully_async_rollout.py
+++ b/miles/rollout/fully_async_rollout.py
@@ -57,21 +57,23 @@ class _CachedWeightVersion:
     def __init__(self, ttl: float = 1.0):
         self._ttl = ttl
         self._value: int | None = None
-        self._last_query = 0.0
+        self._last_query = float("-inf")
 
     async def get(self, args) -> int | None:
-        now = time.monotonic()
-        if self._value is not None and (now - self._last_query) < self._ttl:
+        # Throttles failures too: the drain queries once per group, and an unreachable
+        # router would otherwise cost every one of them the full timeout.
+        if (time.monotonic() - self._last_query) < self._ttl:
             return self._value
         url = f"http://{args.sglang_router_ip}:{args.sglang_router_port}/model_info"
         try:
             data = await asyncio.wait_for(get(url), timeout=WEIGHT_VERSION_QUERY_TIMEOUT_SECS)
+            self._value = int(data["weight_version"])
         except (httpx.HTTPError, asyncio.TimeoutError) as e:
             # Transient router unavailability; the staleness filter is best-effort.
             logger.debug(f"Failed to query engine weight version: {e}")
-            return self._value
-        self._value = int(data["weight_version"])
-        self._last_query = now
+        finally:
+            # Stamped on completion, so a router slower than the TTL still gets throttled.
+            self._last_query = time.monotonic()
         return self._value
 
 

--- a/miles/rollout/fully_async_rollout.py
+++ b/miles/rollout/fully_async_rollout.py
@@ -6,12 +6,12 @@ worker's output queue. Rollout production and training consumption run in parall
 so per-iteration wall time moves from ``rollout_time + train_time`` toward
 ``max(rollout_time, train_time)``.
 
-Requires the class-based rollout API (``MILES_EXPERIMENTAL_ROLLOUT_REFACTOR=1``)::
+Selected by ``train_async.py --fully-async``, which also requires the class-based
+rollout API (``MILES_EXPERIMENTAL_ROLLOUT_REFACTOR=1``).
 
-    --rollout-function-path miles.rollout.fully_async_rollout.FullyAsyncRolloutFn
-
-Evaluation is not served by this function; point ``--eval-function-path`` at
-``miles.rollout.inference_rollout.inference_rollout_common.InferenceRolloutFn``.
+Evaluation is not served by this function; ``--fully-async`` therefore points
+``--eval-function-path`` at the standard inference rollout unless it is set
+explicitly.
 """
 
 import asyncio

--- a/miles/rollout/fully_async_rollout.py
+++ b/miles/rollout/fully_async_rollout.py
@@ -22,8 +22,10 @@ from collections.abc import Iterator
 import httpx
 
 from miles.rollout.base_types import RolloutFnConstructorInput, RolloutFnInput, RolloutFnOutput, RolloutFnTrainOutput
+from miles.rollout.filter_hub.base_types import MetricGatherer, call_dynamic_filter
 from miles.rollout.inference_rollout.inference_rollout_common import GenerateState, generate_and_rm_group
 from miles.utils.http_utils import get
+from miles.utils.misc import load_function
 from miles.utils.types import Sample
 
 logger = logging.getLogger(__name__)
@@ -90,6 +92,8 @@ class FullyAsyncRolloutFn:
         self.args = input.args
         self.data_source = input.data_source
         self.state = GenerateState(input.args)
+        self._dynamic_filter = load_function(input.args.dynamic_sampling_filter_path)
+        self._sample_filter = load_function(input.args.rollout_sample_filter_path)
         self._weight_version = _CachedWeightVersion()
         self._worker: asyncio.Task | None = None
         self._output: asyncio.Queue[tuple[list[Sample], Group]] | None = None
@@ -178,6 +182,7 @@ class FullyAsyncRolloutFn:
         aborted_groups_recycled = 0
         stale_groups_recycled = 0
         staleness_values: list[int] = []
+        metric_gatherer = MetricGatherer()
         do_print = True
 
         while len(data) < target_data_size:
@@ -205,6 +210,12 @@ class FullyAsyncRolloutFn:
                         )
                         continue
 
+            filter_output = call_dynamic_filter(self._dynamic_filter, args, group)
+            if not filter_output.keep:
+                # Dropped, not recycled: no usable gradient signal.
+                metric_gatherer.on_dynamic_filter_drop(reason=filter_output.reason)
+                continue
+
             if do_print:
                 sample = group[0][0] if isinstance(group[0], list) else group[0]
                 logger.info(
@@ -223,10 +234,14 @@ class FullyAsyncRolloutFn:
 
         data.sort(key=lambda group: group[0][0].index if isinstance(group[0], list) else group[0].index)
 
+        if self._sample_filter is not None:
+            self._sample_filter(args, data)
+
         metrics = {
             "rollout/fully_async/queue_size": self._output.qsize(),
             "rollout/fully_async/aborted_groups_recycled": aborted_groups_recycled,
             "rollout/fully_async/stale_groups_recycled": stale_groups_recycled,
+            **metric_gatherer.collect(),
         }
         if staleness_values:
             metrics["rollout/fully_async/avg_staleness"] = sum(staleness_values) / len(staleness_values)

--- a/miles/rollout/fully_async_rollout.py
+++ b/miles/rollout/fully_async_rollout.py
@@ -90,7 +90,7 @@ class FullyAsyncRolloutFn:
         self.state = GenerateState(input.args)
         self._weight_version = _CachedWeightVersion()
         self._worker: asyncio.Task | None = None
-        self._output: asyncio.Queue[Group] | None = None
+        self._output: asyncio.Queue[tuple[list[Sample], Group]] | None = None
 
     async def __call__(self, input: RolloutFnInput) -> RolloutFnOutput:
         if input.evaluation:
@@ -113,15 +113,23 @@ class FullyAsyncRolloutFn:
         return self.args.rollout_batch_size
 
     def _submit_one_group(self) -> asyncio.Task:
-        [group] = self.data_source.get_samples(1)
-        return asyncio.create_task(
-            generate_and_rm_group(
-                self.state,
-                group,
-                sampling_params=self.state.sampling_params.copy(),
-                evaluation=False,
-            )
+        [prompt_group] = self.data_source.get_samples(1)
+        return asyncio.create_task(self._generate_group(prompt_group))
+
+    async def _generate_group(self, prompt_group: list[Sample]) -> tuple[list[Sample], Group]:
+        """Return the submitted prompt group next to its result.
+
+        A retry has to resubmit the prompt group: a generate function may expand one
+        trajectory into several samples, and ``generate_and_rm_group`` does not accept
+        that shape back.
+        """
+        result = await generate_and_rm_group(
+            self.state,
+            prompt_group,
+            sampling_params=self.state.sampling_params.copy(),
+            evaluation=False,
         )
+        return prompt_group, result
 
     async def _worker_loop(self):
         active: set[asyncio.Task] = set()
@@ -136,7 +144,7 @@ class FullyAsyncRolloutFn:
 
     # -------------------------- consumer --------------------------
 
-    async def _next_group(self) -> Group:
+    async def _next_group(self) -> tuple[list[Sample], Group]:
         queue_get = asyncio.create_task(self._output.get())
         try:
             while True:
@@ -145,11 +153,13 @@ class FullyAsyncRolloutFn:
                     return_when=asyncio.FIRST_COMPLETED,
                     timeout=NO_PROGRESS_WARN_SECS,
                 )
-                if queue_get in done:
-                    return queue_get.result()
+                # Checked before the queue: the worker loop never returns normally, so a
+                # dead worker fails the step now instead of after its backlog drains.
                 if self._worker in done:
                     self._worker.result()
                     raise RuntimeError("fully-async rollout worker exited without an exception")
+                if queue_get in done:
+                    return queue_get.result()
                 logger.warning(
                     f"No completed rollout groups for {NO_PROGRESS_WARN_SECS}s (queued: {self._output.qsize()})"
                 )
@@ -169,12 +179,12 @@ class FullyAsyncRolloutFn:
         do_print = True
 
         while len(data) < target_data_size:
-            group = await self._next_group()
+            prompt_group, group = await self._next_group()
             assert len(group) == args.n_samples_per_prompt
 
             # A weight update paused generation mid-group: return it for re-sampling.
             if any(s.status == Sample.Status.ABORTED for s in _iter_samples(group)):
-                self._recycle(group)
+                self._recycle(prompt_group)
                 aborted_groups_recycled += 1
                 continue
 
@@ -185,7 +195,7 @@ class FullyAsyncRolloutFn:
                     staleness = current - oldest
                     staleness_values.append(staleness)
                     if staleness > args.max_weight_staleness:
-                        self._recycle(group)
+                        self._recycle(prompt_group)
                         stale_groups_recycled += 1
                         logger.info(
                             f"Recycled stale group (oldest_version={oldest}, current={current}, "
@@ -222,7 +232,7 @@ class FullyAsyncRolloutFn:
 
         return RolloutFnTrainOutput(samples=data, metrics=metrics)
 
-    def _recycle(self, group: Group) -> None:
-        for sample in _iter_samples(group):
+    def _recycle(self, prompt_group: list[Sample]) -> None:
+        for sample in prompt_group:
             sample.reset_for_retry()
-        self.data_source.add_samples([group])
+        self.data_source.add_samples([prompt_group])

--- a/miles/rollout/fully_async_rollout.py
+++ b/miles/rollout/fully_async_rollout.py
@@ -47,6 +47,10 @@ def _iter_samples(group: Group) -> Iterator[Sample]:
             yield item
 
 
+def _first_sample(group: Group) -> Sample:
+    return group[0][0] if isinstance(group[0], list) else group[0]
+
+
 def group_oldest_weight_version(group: Group) -> int | None:
     """Return the minimum weight version across all trajectories and turns in a group."""
     versions = [v for s in _iter_samples(group) if (v := s.oldest_weight_version) is not None]
@@ -217,7 +221,7 @@ class FullyAsyncRolloutFn:
                 continue
 
             if do_print:
-                sample = group[0][0] if isinstance(group[0], list) else group[0]
+                sample = _first_sample(group)
                 logger.info(
                     f"First rollout sample: {[str(sample.prompt) + sample.response]}, "
                     f"label: {sample.label}, reward: {sample.reward}"
@@ -226,13 +230,13 @@ class FullyAsyncRolloutFn:
 
             data.append(group)
 
-        sample = data[-1][0][0] if isinstance(data[-1][0], list) else data[-1][0]
+        sample = _first_sample(data[-1])
         logger.info(
             f"Finish rollout: {[str(sample.prompt) + sample.response]}, "
             f"label: {sample.label}, reward: {sample.reward}"
         )
 
-        data.sort(key=lambda group: group[0][0].index if isinstance(group[0], list) else group[0].index)
+        data.sort(key=lambda group: _first_sample(group).index)
 
         if self._sample_filter is not None:
             self._sample_filter(args, data)

--- a/miles/rollout/fully_async_rollout.py
+++ b/miles/rollout/fully_async_rollout.py
@@ -1,33 +1,63 @@
+"""Fully asynchronous rollout generation.
+
+A persistent background worker keeps up to ``rollout_batch_size`` prompt groups in
+flight at all times; each training step only drains already-completed groups from the
+worker's output queue. Rollout production and training consumption run in parallel,
+so per-iteration wall time moves from ``rollout_time + train_time`` toward
+``max(rollout_time, train_time)``.
+
+Requires the class-based rollout API (``MILES_EXPERIMENTAL_ROLLOUT_REFACTOR=1``)::
+
+    --rollout-function-path miles.rollout.fully_async_rollout.FullyAsyncRolloutFn
+
+Evaluation is not served by this function; point ``--eval-function-path`` at
+``miles.rollout.inference_rollout.inference_rollout_common.InferenceRolloutFn``.
+"""
+
 import asyncio
-import atexit
 import logging
-import queue
-import threading
 import time
+from collections.abc import Iterator
 
-import aiohttp
+import httpx
 
-from miles.rollout.data_source import DataSource
-from miles.rollout.sglang_rollout import GenerateState, generate_and_rm_group
-from miles.utils.async_utils import run
+from miles.rollout.base_types import RolloutFnConstructorInput, RolloutFnInput, RolloutFnOutput, RolloutFnTrainOutput
+from miles.rollout.inference_rollout.inference_rollout_common import GenerateState, generate_and_rm_group
+from miles.utils.http_utils import get
 from miles.utils.types import Sample
 
 logger = logging.getLogger(__name__)
 
+OUTPUT_QUEUE_MAX_GROUPS = 1000
+NO_PROGRESS_WARN_SECS = 30.0
+WEIGHT_VERSION_QUERY_TIMEOUT_SECS = 2.0
 
-def group_oldest_weight_version(group: list[Sample]) -> int | None:
+# A finished group is list[Sample], or list[list[Sample]] when a generate function
+# returns multiple samples per trajectory (e.g. multi-agent).
+Group = list[Sample | list[Sample]]
+
+
+def _iter_samples(group: Group) -> Iterator[Sample]:
+    for item in group:
+        if isinstance(item, list):
+            yield from item
+        else:
+            yield item
+
+
+def group_oldest_weight_version(group: Group) -> int | None:
     """Return the minimum weight version across all trajectories and turns in a group."""
-    versions = [s.oldest_weight_version for s in group if s.oldest_weight_version is not None]
+    versions = [v for s in _iter_samples(group) if (v := s.oldest_weight_version) is not None]
     return min(versions) if versions else None
 
 
 class _CachedWeightVersion:
-    """Throttled query for the current engine weight version via /model_info."""
+    """Throttled query of the current engine weight version via the router's /model_info."""
 
     def __init__(self, ttl: float = 1.0):
         self._ttl = ttl
         self._value: int | None = None
-        self._last_query: float = 0.0
+        self._last_query = 0.0
 
     async def get(self, args) -> int | None:
         now = time.monotonic()
@@ -35,320 +65,164 @@ class _CachedWeightVersion:
             return self._value
         url = f"http://{args.sglang_router_ip}:{args.sglang_router_port}/model_info"
         try:
-            async with aiohttp.ClientSession() as session:
-                async with session.get(url, timeout=aiohttp.ClientTimeout(total=2)) as resp:
-                    if resp.status == 200:
-                        data = await resp.json()
-                        self._value = int(data["weight_version"])
-                        self._last_query = now
-        except Exception as e:
+            data = await asyncio.wait_for(get(url), timeout=WEIGHT_VERSION_QUERY_TIMEOUT_SECS)
+        except (httpx.HTTPError, asyncio.TimeoutError) as e:
+            # Transient router unavailability; the staleness filter is best-effort.
             logger.debug(f"Failed to query engine weight version: {e}")
+            return self._value
+        self._value = int(data["weight_version"])
+        self._last_query = now
         return self._value
 
 
-_cached_version = _CachedWeightVersion()
+class FullyAsyncRolloutFn:
+    """Continuous rollout generation decoupled from training steps.
 
-
-# Global worker manager
-_global_worker = None
-_worker_lock = threading.Lock()
-
-
-def get_global_worker(args, data_buffer: DataSource):
-    """Get or create global worker"""
-    global _global_worker
-    with _worker_lock:
-        if _global_worker is None or not _global_worker.worker_thread.is_alive():
-            print("Creating new global async worker...")
-            _global_worker = AsyncRolloutWorker(args, data_buffer)
-            _global_worker.start()
-        return _global_worker
-
-
-def stop_global_worker():
-    """Stop global worker"""
-    global _global_worker
-    with _worker_lock:
-        if _global_worker is not None:
-            _global_worker.stop()
-            _global_worker = None
-
-
-class AsyncRolloutWorker:
-    """
-    Simplified asynchronous rollout worker, using threads instead of processes
-    Supports continuous running, independent of rollout function lifecycle
+    The worker runs as a long-lived task on the shared rollout event loop, created
+    lazily on the first train call. Groups whose samples were aborted (e.g. by a
+    weight update pausing generation) or whose weights are older than
+    ``--max-weight-staleness`` are recycled back into the data source.
     """
 
-    def __init__(self, args, data_buffer: DataSource):
-        if args.async_max_concurrent_samples is not None:
-            client_capacity = (
-                args.sglang_server_concurrency * args.rollout_num_gpus // args.rollout_num_gpus_per_engine
+    def __init__(self, input: RolloutFnConstructorInput):
+        self.args = input.args
+        self.data_source = input.data_source
+        self.state = GenerateState(input.args)
+        self._weight_version = _CachedWeightVersion()
+        self._worker: asyncio.Task | None = None
+        self._output: asyncio.Queue[Group] | None = None
+
+    async def __call__(self, input: RolloutFnInput) -> RolloutFnOutput:
+        if input.evaluation:
+            raise ValueError(
+                "FullyAsyncRolloutFn does not serve eval; set --eval-function-path to "
+                "miles.rollout.inference_rollout.inference_rollout_common.InferenceRolloutFn"
             )
-            if args.async_max_concurrent_samples > client_capacity:
-                print(
-                    f"--async-max-concurrent-samples ({args.async_max_concurrent_samples}) exceeds the "
-                    f"client concurrency cap ({client_capacity}); the excess queues on the semaphore"
-                )
-        self.args = args
-        self.data_buffer = data_buffer  # Directly save data_buffer reference
-        self.running = True
-        self.output_queue = queue.Queue(maxsize=1000)  # Continuous output queue
-        self.worker_thread = None
-        self.state = GenerateState(args)
+        if self._worker is None:
+            self._output = asyncio.Queue(maxsize=OUTPUT_QUEUE_MAX_GROUPS)
+            self._worker = asyncio.create_task(self._worker_loop())
+            logger.info("Started fully-async rollout worker")
+        return await self._drain(input.rollout_id)
 
-    async def continuous_worker_loop(self):
-        """Continuous work loop - constantly get data from data_buffer and process"""
-        print("Continuous async rollout worker started")
+    # -------------------------- producer --------------------------
 
-        active_tasks = set()
-        if self.args.async_max_concurrent_samples is not None:
-            max_concurrent_tasks = max(1, self.args.async_max_concurrent_samples // self.args.n_samples_per_prompt)
-        else:
-            max_concurrent_tasks = self.args.rollout_batch_size
-        group_id_counter = 0
+    def _max_in_flight_groups(self) -> int:
+        if (x := self.args.async_max_concurrent_samples) is not None:
+            # Whole groups are submitted, so the sample budget floors to a group count.
+            return max(1, x // self.args.n_samples_per_prompt)
+        return self.args.rollout_batch_size
 
-        while self.running:
-            try:
-                # Clean up completed tasks
-                if active_tasks:
-                    done_tasks = {task for task in active_tasks if task.done()}
-                    for task in done_tasks:
-                        try:
-                            task.result()  # Results are already handled in callbacks
-                        except Exception as e:
-                            print(f"Task failed with exception: {e}")
-                    active_tasks -= done_tasks
+    def _submit_one_group(self) -> asyncio.Task:
+        [group] = self.data_source.get_samples(1)
+        return asyncio.create_task(
+            generate_and_rm_group(
+                self.state,
+                group,
+                sampling_params=self.state.sampling_params.copy(),
+                evaluation=False,
+            )
+        )
 
-                # If active task count hasn't reached limit, try to get new data and start tasks
-                while len(active_tasks) < max_concurrent_tasks and self.running:
-                    samples = self.data_buffer.get_samples(1)
-
-                    for group in samples:
-                        group_id = group_id_counter
-                        group_id_counter += 1
-
-                        # Create new async task
-                        task = asyncio.create_task(
-                            generate_and_rm_group(
-                                self.args,
-                                group,
-                                sampling_params=self.state.sampling_params.copy(),
-                                evaluation=False,
-                            )
-                        )
-
-                        # Add completion callback
-                        def make_callback(gid):
-                            def task_done_callback(done_task):
-                                result = done_task.result()
-                                self.output_queue.put((gid, result))
-
-                            return task_done_callback
-
-                        task.add_done_callback(make_callback(group_id))
-                        active_tasks.add(task)
-                        break
-
-                # Brief sleep to avoid busy waiting
-                await asyncio.sleep(1)
-
-            except Exception as e:
-                print(f"Error in continuous worker loop: {e}")
-                await asyncio.sleep(1)
-
-        if active_tasks:
-            print(f"Waiting for {len(active_tasks)} continuous tasks to complete...")
-            await asyncio.wait(active_tasks)
-
-        print("Continuous async rollout worker stopped")
-
-    def worker_thread_func(self):
-        """Worker function running in independent thread"""
-        asyncio.run(self.continuous_worker_loop())
-
-    def start(self):
-        """Start continuous work mode"""
-        if self.worker_thread is None or not self.worker_thread.is_alive():
-            self.worker_thread = threading.Thread(target=self.worker_thread_func, daemon=True)
-            self.worker_thread.start()
-            print("Started continuous async worker thread")
-
-    def stop(self):
-        """Stop worker thread"""
-        self.running = False
-        if self.worker_thread and self.worker_thread.is_alive():
-            self.worker_thread.join(timeout=5)
-        print("Stopped async worker thread")
-
-    def get_completed_groups(self) -> list[tuple]:
-        """Get completed sample groups"""
-        completed = []
+    async def _worker_loop(self):
+        active: set[asyncio.Task] = set()
         while True:
-            try:
-                result = self.output_queue.get_nowait()
-                completed.append(result)
-            except queue.Empty:
-                break
-        return completed
+            while len(active) < self._max_in_flight_groups():
+                active.add(self._submit_one_group())
+            done, active = await asyncio.wait(active, return_when=asyncio.FIRST_COMPLETED)
+            for task in done:
+                # Blocks when the queue is full: training lagging behind rollout
+                # production pauses submission instead of growing the queue unboundedly.
+                await self._output.put(task.result())
 
-    def get_queue_size(self) -> int:
-        """Get current output queue size"""
-        return self.output_queue.qsize()
+    # -------------------------- consumer --------------------------
 
+    async def _next_group(self) -> Group:
+        queue_get = asyncio.create_task(self._output.get())
+        try:
+            while True:
+                done, _ = await asyncio.wait(
+                    {queue_get, self._worker},
+                    return_when=asyncio.FIRST_COMPLETED,
+                    timeout=NO_PROGRESS_WARN_SECS,
+                )
+                if queue_get in done:
+                    return queue_get.result()
+                if self._worker in done:
+                    self._worker.result()
+                    raise RuntimeError("fully-async rollout worker exited without an exception")
+                logger.warning(
+                    f"No completed rollout groups for {NO_PROGRESS_WARN_SECS}s (queued: {self._output.qsize()})"
+                )
+        finally:
+            if not queue_get.done():
+                queue_get.cancel()
 
-async def generate_rollout_async(args, rollout_id: int, data_buffer: DataSource) -> list[list[Sample]]:
-    """
-    Simplified asynchronous rollout generation - using global continuous worker
-    """
-    assert args.rollout_global_dataset
+    async def _drain(self, rollout_id: int) -> RolloutFnTrainOutput:
+        args = self.args
+        assert args.rollout_global_dataset
 
-    # Get global worker, which will run continuously
-    worker = get_global_worker(args, data_buffer)
+        target_data_size = args.rollout_batch_size
+        data: list[Group] = []
+        aborted_groups_recycled = 0
+        stale_groups_recycled = 0
+        staleness_values: list[int] = []
+        do_print = True
 
-    # Simplified: directly use rollout_batch_size as target
-    target_data_size = args.rollout_batch_size
+        while len(data) < target_data_size:
+            group = await self._next_group()
+            assert len(group) == args.n_samples_per_prompt
 
-    data = []
-    completed_groups = {}
-    do_print = True
-    stale_groups_recycled = 0
-    staleness_values = []
-
-    use_staleness_filter = getattr(args, "max_weight_staleness", None) is not None
-
-    print(f"Starting async rollout generation for {target_data_size} groups")
-    print(f"Global worker queue size: {worker.get_queue_size()}")
-    if use_staleness_filter:
-        print(f"Staleness filter enabled: max_weight_staleness={args.max_weight_staleness}")
-
-    # Main loop: collect results from global worker's output queue
-    start_time = time.time()
-    last_progress_time = start_time
-    no_progress_timeout = 30.0  # Warn if no progress for 30 seconds
-
-    while len(data) < target_data_size:
-        # Collect completed results
-        completed = worker.get_completed_groups()
-
-        made_progress = False
-        for group_id, group in completed:
-            completed_groups[group_id] = group
-            made_progress = True
-
-        if made_progress:
-            last_progress_time = time.time()
-
-        # Query current engine version once per collection batch (cached/throttled)
-        current_engine_version = None
-        if use_staleness_filter:
-            current_engine_version = await _cached_version.get(args)
-
-        # Process completed groups in order (try to maintain order, but not strict requirement)
-        processed_any = False
-
-        # Process all available completed groups
-        available_ids = list(completed_groups.keys())
-        for group_id in available_ids:
-            if len(data) >= target_data_size:
-                break
-
-            group = completed_groups.pop(group_id)
-
-            # If any sample in the group was aborted, return the whole group to the data buffer
-            # and do not forward it to the training engine.
-            try:
-                any_aborted = any([sample.status == Sample.Status.ABORTED for sample in group])
-            except Exception:
-                any_aborted = False
-
-            if any_aborted:
-                try:
-                    for s in group:
-                        s.reset_for_retry()
-                    data_buffer.add_samples([group])
-                    print(f"Returned aborted group {group_id} to data buffer", flush=True)
-                except Exception as e:
-                    print(f"Failed to return aborted group {group_id} to buffer: {e}", flush=True)
-                # don't count as processed for training
+            # A weight update paused generation mid-group: return it for re-sampling.
+            if any(s.status == Sample.Status.ABORTED for s in _iter_samples(group)):
+                self._recycle(group)
+                aborted_groups_recycled += 1
                 continue
 
-            # Staleness filter: discard groups whose oldest weight version is too far behind
-            oldest = group_oldest_weight_version(group)
-            if oldest is not None and current_engine_version is not None:
-                staleness = current_engine_version - oldest
-                staleness_values.append(staleness)
-                if staleness > args.max_weight_staleness:
-                    try:
-                        for s in group:
-                            s.reset_for_retry()
-                        data_buffer.add_samples([group])
-                    except Exception as e:
-                        logger.warning(f"Failed to recycle stale group {group_id}: {e}")
-                    stale_groups_recycled += 1
-                    logger.info(
-                        f"Recycled stale group {group_id} "
-                        f"(oldest_version={oldest}, current={current_engine_version}, "
-                        f"staleness={staleness} > max={args.max_weight_staleness})"
-                    )
-                    # don't count as processed for training
-                    continue
+            if args.max_weight_staleness is not None:
+                oldest = group_oldest_weight_version(group)
+                current = await self._weight_version.get(args)
+                if oldest is not None and current is not None:
+                    staleness = current - oldest
+                    staleness_values.append(staleness)
+                    if staleness > args.max_weight_staleness:
+                        self._recycle(group)
+                        stale_groups_recycled += 1
+                        logger.info(
+                            f"Recycled stale group (oldest_version={oldest}, current={current}, "
+                            f"staleness={staleness} > max={args.max_weight_staleness})"
+                        )
+                        continue
 
             if do_print:
-                print(
-                    f"First rollout sample: {[group[0].prompt + group[0].response]}, "
-                    f"label: {group[0].label}, reward: {group[0].reward}",
-                    flush=True,
+                sample = group[0][0] if isinstance(group[0], list) else group[0]
+                logger.info(
+                    f"First rollout sample: {[str(sample.prompt) + sample.response]}, "
+                    f"label: {sample.label}, reward: {sample.reward}"
                 )
                 do_print = False
 
-            # Simplified: directly add samples, no filters used
             data.append(group)
-            processed_any = True
 
-        # Check progress
-        current_time = time.time()
-        if current_time - last_progress_time > no_progress_timeout:
-            print(
-                f"Warning: No progress for {no_progress_timeout}s. "
-                f"Queue size: {worker.get_queue_size()}, "
-                f"Collected: {len(data)}/{target_data_size}"
-            )
-            last_progress_time = current_time
-
-        # If no results were processed, brief sleep to avoid busy waiting
-        if not processed_any:
-            await asyncio.sleep(0.01)
-
-    duration = time.time() - start_time
-    print(f"Rollout completed in {duration:.2f}s! Global worker queue size: {worker.get_queue_size()}")
-    if stale_groups_recycled > 0 or staleness_values:
-        avg_staleness = sum(staleness_values) / len(staleness_values) if staleness_values else 0
-        print(
-            f"Staleness stats: recycled={stale_groups_recycled}, "
-            f"avg_staleness={avg_staleness:.1f}, "
-            f"max_staleness={max(staleness_values) if staleness_values else 0}"
+        sample = data[-1][0][0] if isinstance(data[-1][0], list) else data[-1][0]
+        logger.info(
+            f"Finish rollout: {[str(sample.prompt) + sample.response]}, "
+            f"label: {sample.label}, reward: {sample.reward}"
         )
 
-    if data:
-        print(
-            f"Finish rollout: {[data[-1][0].prompt + data[-1][0].response]}, "
-            f"label: {data[-1][0].label}, reward: {data[-1][0].reward}",
-            flush=True,
-        )
+        data.sort(key=lambda group: group[0][0].index if isinstance(group[0], list) else group[0].index)
 
-    data = sorted(data, key=lambda group: group[0].index)
-    return data
+        metrics = {
+            "rollout/fully_async/queue_size": self._output.qsize(),
+            "rollout/fully_async/aborted_groups_recycled": aborted_groups_recycled,
+            "rollout/fully_async/stale_groups_recycled": stale_groups_recycled,
+        }
+        if staleness_values:
+            metrics["rollout/fully_async/avg_staleness"] = sum(staleness_values) / len(staleness_values)
+            metrics["rollout/fully_async/max_staleness"] = max(staleness_values)
 
+        return RolloutFnTrainOutput(samples=data, metrics=metrics)
 
-def generate_rollout_fully_async(args, rollout_id, data_buffer: DataSource, evaluation=False):
-    if evaluation:
-        raise ValueError("Evaluation mode not supported in simple async rollout")
-
-    completed_samples = run(generate_rollout_async(args, rollout_id, data_buffer))
-    return completed_samples
-
-
-# Register exit cleanup function
-
-atexit.register(stop_global_worker)
+    def _recycle(self, group: Group) -> None:
+        for sample in _iter_samples(group):
+            sample.reset_for_retry()
+        self.data_source.add_samples([group])

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -44,6 +44,8 @@ def _resolve_rollout_functions(args) -> None:
             "--fully-async needs the class-based rollout API: set MILES_EXPERIMENTAL_ROLLOUT_REFACTOR=1 "
             "(and propagate it through runtime_env when submitting via Ray)"
         )
+        # Runs after validate_multi_lora_args, which selects a rollout function of its own.
+        assert not args.multi_lora, "--fully-async and multi-LoRA select different rollout functions"
         assert (
             args.rollout_function_path is None
         ), "--fully-async and --rollout-function-path both select a rollout function; pass only one"

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -50,6 +50,13 @@ def _resolve_rollout_functions(args) -> None:
             args.rollout_function_path is None
         ), "--fully-async and --rollout-function-path both select a rollout function; pass only one"
         assert not args.colocate, "--fully-async cannot colocate: rollout must keep generating while training runs"
+        assert not args.partial_rollout, "--fully-async does not support --partial-rollout"
+        assert (
+            not args.recompute_logprobs_via_prefill
+        ), "--fully-async does not support --recompute-logprobs-via-prefill"
+        assert (
+            args.rollout_all_samples_process_path is None
+        ), "--fully-async does not support --rollout-all-samples-process-path"
 
     args.rollout_function_path = resolve_rollout_function_path(args)
 

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -24,18 +24,18 @@ from miles.utils.tracking_utils.ci_history import RECORD_DIR_ENV
 logger = logging.getLogger(__name__)
 
 
-def default_rollout_function_path() -> str:
-    """The standard rollout function, used when nothing selects another one."""
+def resolve_rollout_function_paths(args) -> tuple[str, str]:
+    """The (rollout, eval) function paths the arguments select."""
     if enable_experimental_rollout_refactor():
-        return "miles.rollout.inference_rollout.inference_rollout_common.InferenceRolloutFn"
-    return "miles.rollout.sglang_rollout.generate_rollout"
-
-
-def resolve_rollout_function_path(args) -> str:
-    """The rollout function the arguments select."""
+        standard_path = "miles.rollout.inference_rollout.inference_rollout_common.InferenceRolloutFn"
+    else:
+        standard_path = "miles.rollout.sglang_rollout.generate_rollout"
+    rollout_path = args.rollout_function_path or standard_path
+    # Resolved before the fully-async override: fully async does not serve eval.
+    eval_path = args.eval_function_path or rollout_path
     if args.fully_async:
-        return "miles.rollout.fully_async_rollout.FullyAsyncRolloutFn"
-    return args.rollout_function_path or default_rollout_function_path()
+        rollout_path = "miles.rollout.fully_async_rollout.FullyAsyncRolloutFn"
+    return rollout_path, eval_path
 
 
 def _resolve_rollout_functions(args) -> None:
@@ -58,11 +58,7 @@ def _resolve_rollout_functions(args) -> None:
             args.rollout_all_samples_process_path is None
         ), "--fully-async does not support --rollout-all-samples-process-path"
 
-    args.rollout_function_path = resolve_rollout_function_path(args)
-
-    if args.eval_function_path is None:
-        # Fully async does not serve eval, so eval keeps the standard rollout function.
-        args.eval_function_path = default_rollout_function_path() if args.fully_async else args.rollout_function_path
+    args.rollout_function_path, args.eval_function_path = resolve_rollout_function_paths(args)
 
 
 def reset_arg(parser, name, **kwargs):
@@ -2285,7 +2281,7 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
             except SystemExit:
                 return parser
             for path in [
-                resolve_rollout_function_path(args_partial),
+                resolve_rollout_function_paths(args_partial)[0],
                 args_partial.custom_generate_function_path,
             ]:
                 try:

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -24,6 +24,38 @@ from miles.utils.tracking_utils.ci_history import RECORD_DIR_ENV
 logger = logging.getLogger(__name__)
 
 
+def default_rollout_function_path() -> str:
+    """The standard rollout function, used when nothing selects another one."""
+    if enable_experimental_rollout_refactor():
+        return "miles.rollout.inference_rollout.inference_rollout_common.InferenceRolloutFn"
+    return "miles.rollout.sglang_rollout.generate_rollout"
+
+
+def resolve_rollout_function_path(args) -> str:
+    """The rollout function the arguments select."""
+    if args.fully_async:
+        return "miles.rollout.fully_async_rollout.FullyAsyncRolloutFn"
+    return args.rollout_function_path or default_rollout_function_path()
+
+
+def _resolve_rollout_functions(args) -> None:
+    if args.fully_async:
+        assert enable_experimental_rollout_refactor(), (
+            "--fully-async needs the class-based rollout API: set MILES_EXPERIMENTAL_ROLLOUT_REFACTOR=1 "
+            "(and propagate it through runtime_env when submitting via Ray)"
+        )
+        assert (
+            args.rollout_function_path is None
+        ), "--fully-async and --rollout-function-path both select a rollout function; pass only one"
+        assert not args.colocate, "--fully-async cannot colocate: rollout must keep generating while training runs"
+
+    args.rollout_function_path = resolve_rollout_function_path(args)
+
+    if args.eval_function_path is None:
+        # Fully async does not serve eval, so eval keeps the standard rollout function.
+        args.eval_function_path = default_rollout_function_path() if args.fully_async else args.rollout_function_path
+
+
 def reset_arg(parser, name, **kwargs):
     """
     Reset the default value of a Megatron argument.
@@ -365,11 +397,7 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
             parser.add_argument(
                 "--rollout-function-path",
                 type=str,
-                default=(
-                    "miles.rollout.inference_rollout.inference_rollout_common.InferenceRolloutFn"
-                    if enable_experimental_rollout_refactor()
-                    else "miles.rollout.sglang_rollout.generate_rollout"
-                ),
+                default=None,
                 help=(
                     "Path to the rollout generation function. "
                     "Use this to create your own custom rollout function and set this to its path. "
@@ -380,6 +408,17 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                     "(see `miles.rollout.sglang_rollout.generate_rollout` for the default impl). "
                     "Within each output sample, set at least `tokens`, `response_length`, `reward`, "
                     "and `truncated`."
+                ),
+            )
+            parser.add_argument(
+                "--fully-async",
+                action="store_true",
+                default=False,
+                help=(
+                    "Run fully async rollout: a persistent worker keeps generating while the trainer "
+                    "drains completed groups. Selects `FullyAsyncRolloutFn` as the rollout function; "
+                    "evaluation keeps the standard rollout function, which fully async does not serve. "
+                    "Requires train_async.py and MILES_EXPERIMENTAL_ROLLOUT_REFACTOR=1."
                 ),
             )
             parser.add_argument(
@@ -2237,7 +2276,7 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
             except SystemExit:
                 return parser
             for path in [
-                args_partial.rollout_function_path,
+                resolve_rollout_function_path(args_partial),
                 args_partial.custom_generate_function_path,
             ]:
                 try:
@@ -2881,8 +2920,7 @@ def miles_validate_args(args):
             f"so one group already puts n_samples_per_prompt trajectories in flight"
         )
 
-    if args.eval_function_path is None:
-        args.eval_function_path = args.rollout_function_path
+    _resolve_rollout_functions(args)
 
     if args.num_steps_per_rollout is not None:
         global_batch_size = args.rollout_batch_size * args.n_samples_per_prompt // args.num_steps_per_rollout

--- a/miles/utils/multi_lora.py
+++ b/miles/utils/multi_lora.py
@@ -72,7 +72,7 @@ def validate_multi_lora_args(args: Any) -> None:
 
     # Swap in the multi-LoRA rollout fn and data source unless the user pointed these flags elsewhere.
     # `rollout_function_path is None` means nothing has selected one yet; see
-    # `resolve_rollout_function_path`.
+    # `resolve_rollout_function_paths`.
     if args.rollout_function_path is None:
         args.rollout_function_path = "miles.rollout.multi_lora.async_rollout.generate_rollout_multi_lora"
     if args.data_source_path == "miles.rollout.data_source.RolloutDataSourceWithBuffer":

--- a/miles/utils/multi_lora.py
+++ b/miles/utils/multi_lora.py
@@ -71,8 +71,6 @@ def validate_multi_lora_args(args: Any) -> None:
         return
 
     # Swap in the multi-LoRA rollout fn and data source unless the user pointed these flags elsewhere.
-    # `rollout_function_path is None` means nothing has selected one yet; see
-    # `resolve_rollout_function_paths`.
     if args.rollout_function_path is None:
         args.rollout_function_path = "miles.rollout.multi_lora.async_rollout.generate_rollout_multi_lora"
     if args.data_source_path == "miles.rollout.data_source.RolloutDataSourceWithBuffer":

--- a/miles/utils/multi_lora.py
+++ b/miles/utils/multi_lora.py
@@ -71,11 +71,9 @@ def validate_multi_lora_args(args: Any) -> None:
         return
 
     # Swap in the multi-LoRA rollout fn and data source unless the user pointed these flags elsewhere.
-    standard_rollout_fns = (
-        "miles.rollout.inference_rollout.inference_rollout_common.InferenceRolloutFn",
-        "miles.rollout.sglang_rollout.generate_rollout",
-    )
-    if args.rollout_function_path in standard_rollout_fns:
+    # `rollout_function_path is None` means nothing has selected one yet; see
+    # `resolve_rollout_function_path`.
+    if args.rollout_function_path is None:
         args.rollout_function_path = "miles.rollout.multi_lora.async_rollout.generate_rollout_multi_lora"
     if args.data_source_path == "miles.rollout.data_source.RolloutDataSourceWithBuffer":
         args.data_source_path = "miles.rollout.multi_lora.data_source.MultiLoRAAsyncDataSource"

--- a/tests/ci/labels.py
+++ b/tests/ci/labels.py
@@ -30,6 +30,7 @@ KNOWN_LABELS: dict[str, str] = {
     "ft-short": "Fault-tolerance trainer comparison tests (no_failure / deterministic / with_failure)",
     "ft-long": "Fault-tolerance trainer soak tests (random-crash survival, realistic-gsm8k convergence)",
     "weight-update": "Weight update tests",
+    "fully-async": "Fully-async rollout tests",
     "replay": "Routing / indexer replay tests",
     "qwen35": "Qwen3.5-35B-A3B MTP / spec-v2 e2e tests",
     "mooncake": "Mooncake object-store rollout transfer tests",

--- a/tests/e2e/megatron/test_qwen3_30B_A3B/_common.py
+++ b/tests/e2e/megatron/test_qwen3_30B_A3B/_common.py
@@ -210,12 +210,7 @@ def build_train_args(case: CaseConfig, *, wandb_file: str) -> str:
         misc_args += "--megatron-to-hf-mode bridge "
 
     if case.fully_async:
-        misc_args += (
-            "--rollout-function-path miles.rollout.fully_async_rollout.FullyAsyncRolloutFn "
-            # FullyAsyncRolloutFn does not serve eval; it would otherwise be inherited
-            # from --rollout-function-path.
-            "--eval-function-path miles.rollout.inference_rollout.inference_rollout_common.InferenceRolloutFn "
-        )
+        misc_args += "--fully-async "
 
     if case.use_mooncake:
         misc_args += U.get_mooncake_object_store_args()

--- a/tests/e2e/megatron/test_qwen3_30B_A3B/_common.py
+++ b/tests/e2e/megatron/test_qwen3_30B_A3B/_common.py
@@ -31,8 +31,6 @@ class CaseConfig:
     rollout_num_gpus: int = None
     update_weight_transfer_mode: str = None
     num_rollout: int = 2
-    # Fully-async rollout: a persistent worker keeps generating while the trainer
-    # drains completed groups (train_async.py + FullyAsyncRolloutFn).
     fully_async: bool = False
 
     def __post_init__(self):

--- a/tests/e2e/megatron/test_qwen3_30B_A3B/_common.py
+++ b/tests/e2e/megatron/test_qwen3_30B_A3B/_common.py
@@ -30,9 +30,15 @@ class CaseConfig:
     colocate: bool = True
     rollout_num_gpus: int = None
     update_weight_transfer_mode: str = None
+    num_rollout: int = 2
+    # Fully-async rollout: a persistent worker keeps generating while the trainer
+    # drains completed groups (train_async.py + FullyAsyncRolloutFn).
+    fully_async: bool = False
 
     def __post_init__(self):
         # Validation only — topology values are passed explicitly, not inferred.
+        if self.fully_async and self.colocate:
+            raise ValueError("fully_async requires colocate=False: train_async.py rejects colocation")
         if self.num_gpus_per_node % (self.cp_size * self.pp_size) != 0:
             raise ValueError(
                 "num_gpus_per_node must be divisible by cp_size * pp_size: "
@@ -101,7 +107,7 @@ def build_train_args(case: CaseConfig, *, wandb_file: str) -> str:
         "--apply-chat-template "
         "--rollout-shuffle "
         "--rm-type deepscaler "
-        "--num-rollout 2 "
+        f"--num-rollout {case.num_rollout} "
         "--rollout-batch-size 8 "
         "--n-samples-per-prompt 8 "
         "--rollout-max-response-len 8192 "
@@ -203,6 +209,14 @@ def build_train_args(case: CaseConfig, *, wandb_file: str) -> str:
     if case.use_bridge:
         misc_args += "--megatron-to-hf-mode bridge "
 
+    if case.fully_async:
+        misc_args += (
+            "--rollout-function-path miles.rollout.fully_async_rollout.FullyAsyncRolloutFn "
+            # FullyAsyncRolloutFn does not serve eval; it would otherwise be inherited
+            # from --rollout-function-path.
+            "--eval-function-path miles.rollout.inference_rollout.inference_rollout_common.InferenceRolloutFn "
+        )
+
     if case.use_mooncake:
         misc_args += U.get_mooncake_object_store_args()
 
@@ -241,5 +255,6 @@ def execute(case: CaseConfig, *, wandb_file: str) -> None:
         num_gpus_per_node=case.num_gpus_per_node + (0 if case.colocate else case.rollout_num_gpus),
         megatron_model_type=MODEL_TYPE,
         before_ray_job_submit=U.start_mooncake_master if case.use_mooncake else None,
+        train_script="train_async.py" if case.fully_async else "train.py",
         extra_env_vars=extra_env_vars,
     )

--- a/tests/e2e/megatron/test_qwen3_30B_A3B/test_fully_async.py
+++ b/tests/e2e/megatron/test_qwen3_30B_A3B/test_fully_async.py
@@ -1,0 +1,43 @@
+import os
+
+from tests.ci.ci_register import register_cuda_ci
+from tests.ci.metric_history import register_ci_gate
+from tests.e2e.megatron.test_qwen3_30B_A3B._common import CaseConfig, execute, prepare
+
+register_cuda_ci(est_time=1500, suite="stage-c-8-gpu-h100", labels=["megatron", "weight-update"])
+
+register_ci_gate(metric_key="train/grad_norm")
+register_ci_gate(metric_key="train/ppo_kl")
+register_ci_gate(metric_key="train/train_rollout_logprob_abs_diff")
+register_ci_gate(metric_key="train/train_rollout_kl")
+register_ci_gate(metric_key="rollout/raw_reward")
+
+# Fully-async rollout on the disaggregated topology (it cannot colocate). Three
+# rollouts exercise the states that only exist with a persistent worker: a cold
+# start, a drain from an already-warm queue, and a drain across a weight update
+# (which pauses generation and makes the worker recycle aborted groups).
+CASE = CaseConfig(
+    use_deepep=False,
+    use_fp8_rollout=False,
+    use_int4_rollout=False,
+    use_bridge=False,
+    use_r3=False,
+    num_gpus_per_node=6,
+    cp_size=2,
+    pp_size=3,
+    tp_size=1,
+    ep_size=2,
+    colocate=False,
+    rollout_num_gpus=2,
+    rollout_num_gpus_per_engine=2,
+    update_weight_transfer_mode="broadcast",
+    num_rollout=3,
+    fully_async=True,
+)
+
+
+if __name__ == "__main__":
+    for proxy_var in ("http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY"):
+        os.environ.pop(proxy_var, None)
+    prepare(CASE, need_fp8=CASE.use_fp8_rollout, need_int4=CASE.use_int4_rollout, all_bridge=CASE.use_bridge)
+    execute(CASE, wandb_file=__file__)

--- a/tests/e2e/megatron/test_qwen3_30B_A3B/test_fully_async.py
+++ b/tests/e2e/megatron/test_qwen3_30B_A3B/test_fully_async.py
@@ -4,7 +4,7 @@ from tests.ci.ci_register import register_cuda_ci
 from tests.ci.metric_history import register_ci_gate
 from tests.e2e.megatron.test_qwen3_30B_A3B._common import CaseConfig, execute, prepare
 
-register_cuda_ci(est_time=1500, suite="stage-c-8-gpu-h100", labels=["megatron", "weight-update"])
+register_cuda_ci(est_time=1500, suite="stage-c-8-gpu-h100", labels=["megatron", "weight-update", "fully-async"])
 
 register_ci_gate(metric_key="train/grad_norm")
 register_ci_gate(metric_key="train/ppo_kl")

--- a/tests/fast/rollout/test_fully_async_rollout.py
+++ b/tests/fast/rollout/test_fully_async_rollout.py
@@ -7,6 +7,7 @@ from argparse import Namespace
 from collections import deque
 from dataclasses import replace
 
+import httpx
 import pytest
 
 import miles.rollout.fully_async_rollout as fully_async
@@ -252,3 +253,26 @@ async def test_nested_group_recycles_the_flat_prompt_group(monkeypatch):
     assert all(isinstance(sample, Sample) for sample in data_source.recycled[0])
     assert len(submitted) > 1
     assert len(output.samples) == 1
+
+
+async def test_weight_version_throttles_failed_queries(monkeypatch):
+    """A drain queries once per group, so an unreachable router must not cost one timeout each."""
+    calls = []
+
+    async def unreachable_router(url):
+        calls.append(url)
+        raise httpx.ConnectError("router down")
+
+    monkeypatch.setattr(fully_async, "get", unreachable_router)
+    args = make_args()
+
+    throttled = fully_async._CachedWeightVersion(ttl=60.0)
+    assert await throttled.get(args) is None
+    assert await throttled.get(args) is None
+    assert len(calls) == 1
+
+    calls.clear()
+    expired = fully_async._CachedWeightVersion(ttl=0.0)
+    assert await expired.get(args) is None
+    assert await expired.get(args) is None
+    assert len(calls) == 2

--- a/tests/fast/rollout/test_fully_async_rollout.py
+++ b/tests/fast/rollout/test_fully_async_rollout.py
@@ -1,0 +1,209 @@
+from tests.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=60, suite="stage-a-cpu", labels=[])
+
+import asyncio
+from argparse import Namespace
+from collections import deque
+
+import pytest
+
+import miles.rollout.fully_async_rollout as fully_async
+from miles.rollout.base_types import RolloutFnConstructorInput, RolloutFnEvalInput, RolloutFnTrainInput
+from miles.utils.types import Sample
+
+N_SAMPLES_PER_PROMPT = 2
+
+
+class FakeGenerateState:
+    def __init__(self, args):
+        self.args = args
+        self.sampling_params = {}
+        self.aborted = False
+
+
+class FakeDataSource:
+    """Serves scripted groups first, then manufactures completed groups forever."""
+
+    def __init__(self, scripted=None):
+        self.scripted = deque(scripted or [])
+        self.next_group_index = 1000
+        self.recycled = []
+        self.num_get_calls = 0
+
+    def get_samples(self, num_samples):
+        assert num_samples == 1
+        self.num_get_calls += 1
+        if self.scripted:
+            return [self.scripted.popleft()]
+        self.next_group_index += 1
+        return [make_group(self.next_group_index)]
+
+    def add_samples(self, groups):
+        self.recycled.extend(groups)
+
+
+def make_group(
+    group_index: int,
+    status: Sample.Status = Sample.Status.COMPLETED,
+    weight_versions: list[str] | None = None,
+) -> list[Sample]:
+    return [
+        Sample(
+            group_index=group_index,
+            index=group_index * 10 + i,
+            prompt=f"prompt {group_index}",
+            response="ok",
+            response_length=1,
+            label="ok",
+            reward=1,
+            status=status,
+            weight_versions=list(weight_versions or []),
+        )
+        for i in range(N_SAMPLES_PER_PROMPT)
+    ]
+
+
+def make_args(**overrides) -> Namespace:
+    defaults = dict(
+        rollout_global_dataset=True,
+        rollout_batch_size=2,
+        n_samples_per_prompt=N_SAMPLES_PER_PROMPT,
+        max_weight_staleness=None,
+        async_max_concurrent_samples=None,
+        sglang_router_ip="127.0.0.1",
+        sglang_router_port=30000,
+    )
+    defaults.update(overrides)
+    return Namespace(**defaults)
+
+
+def make_fn(monkeypatch, args, data_source, generate=None):
+    async def default_generate(state, group, sampling_params, evaluation=False):
+        await asyncio.sleep(0)
+        return group
+
+    monkeypatch.setattr(fully_async, "GenerateState", FakeGenerateState)
+    monkeypatch.setattr(fully_async, "generate_and_rm_group", generate or default_generate)
+    return fully_async.FullyAsyncRolloutFn(RolloutFnConstructorInput(args=args, data_source=data_source))
+
+
+async def test_drain_collects_batch_sorted_with_metrics(monkeypatch):
+    args = make_args(rollout_batch_size=3)
+    fn = make_fn(monkeypatch, args, FakeDataSource())
+
+    output = await fn(RolloutFnTrainInput(rollout_id=0))
+
+    assert len(output.samples) == 3
+    indices = [group[0].index for group in output.samples]
+    assert indices == sorted(indices)
+    assert all(len(group) == N_SAMPLES_PER_PROMPT for group in output.samples)
+    assert output.metrics["rollout/fully_async/aborted_groups_recycled"] == 0
+    assert output.metrics["rollout/fully_async/stale_groups_recycled"] == 0
+
+    # The worker persists across calls; a second drain works on the same instance.
+    output2 = await fn(RolloutFnTrainInput(rollout_id=1))
+    assert len(output2.samples) == 3
+
+
+async def test_eval_raises(monkeypatch):
+    fn = make_fn(monkeypatch, make_args(), FakeDataSource())
+    with pytest.raises(ValueError, match="does not serve eval"):
+        await fn(RolloutFnEvalInput(rollout_id=0))
+    assert fn._worker is None
+
+
+async def test_aborted_group_recycled(monkeypatch):
+    aborted = make_group(1, status=Sample.Status.ABORTED)
+    data_source = FakeDataSource(scripted=[aborted])
+    fn = make_fn(monkeypatch, make_args(rollout_batch_size=1), data_source)
+
+    output = await fn(RolloutFnTrainInput(rollout_id=0))
+
+    assert data_source.recycled == [aborted]
+    # reset_for_retry cleared generated outputs so the prompt can be re-sampled
+    assert all(sample.response == "" and sample.weight_versions == [] for sample in aborted)
+    assert output.samples[0][0].group_index != 1
+    assert output.metrics["rollout/fully_async/aborted_groups_recycled"] == 1
+
+
+async def test_stale_group_recycled(monkeypatch):
+    stale = make_group(1, weight_versions=["5"])
+    data_source = FakeDataSource(scripted=[stale])
+    data_source_fresh_versions = ["10"]
+
+    original_make = data_source.get_samples
+
+    def get_samples_with_fresh_versions(num_samples):
+        groups = original_make(num_samples)
+        for group in groups:
+            for sample in group:
+                if not sample.weight_versions:
+                    sample.weight_versions = list(data_source_fresh_versions)
+        return groups
+
+    data_source.get_samples = get_samples_with_fresh_versions
+
+    fn = make_fn(monkeypatch, make_args(rollout_batch_size=1, max_weight_staleness=2), data_source)
+
+    class FakeWeightVersion:
+        async def get(self, args):
+            return 10
+
+    fn._weight_version = FakeWeightVersion()
+
+    output = await fn(RolloutFnTrainInput(rollout_id=0))
+
+    assert data_source.recycled == [stale]
+    assert output.metrics["rollout/fully_async/stale_groups_recycled"] == 1
+    assert output.metrics["rollout/fully_async/max_staleness"] == 5
+
+
+async def test_worker_error_propagates(monkeypatch):
+    async def failing_generate(state, group, sampling_params, evaluation=False):
+        raise RuntimeError("generation exploded")
+
+    fn = make_fn(monkeypatch, make_args(), FakeDataSource(), generate=failing_generate)
+
+    with pytest.raises(RuntimeError, match="generation exploded"):
+        await fn(RolloutFnTrainInput(rollout_id=0))
+
+
+async def test_worker_bounds_in_flight_groups(monkeypatch):
+    release = asyncio.Event()
+
+    async def blocking_generate(state, group, sampling_params, evaluation=False):
+        await release.wait()
+        return group
+
+    data_source = FakeDataSource()
+    fn = make_fn(monkeypatch, make_args(rollout_batch_size=2), data_source, generate=blocking_generate)
+
+    drain = asyncio.create_task(fn(RolloutFnTrainInput(rollout_id=0)))
+    await asyncio.sleep(0.05)
+    assert data_source.num_get_calls == 2  # in-flight bound, not more
+
+    release.set()
+    output = await drain
+    assert len(output.samples) == 2
+
+
+async def test_async_max_concurrent_samples_caps_in_flight_groups(monkeypatch):
+    release = asyncio.Event()
+
+    async def blocking_generate(state, group, sampling_params, evaluation=False):
+        await release.wait()
+        return group
+
+    data_source = FakeDataSource()
+    # 3 samples // 2 per group -> 1 group in flight, below rollout_batch_size
+    args = make_args(rollout_batch_size=4, async_max_concurrent_samples=3)
+    fn = make_fn(monkeypatch, args, data_source, generate=blocking_generate)
+
+    drain = asyncio.create_task(fn(RolloutFnTrainInput(rollout_id=0)))
+    await asyncio.sleep(0.05)
+    assert data_source.num_get_calls == 1
+
+    release.set()
+    output = await drain
+    assert len(output.samples) == 4

--- a/tests/fast/rollout/test_fully_async_rollout.py
+++ b/tests/fast/rollout/test_fully_async_rollout.py
@@ -12,6 +12,7 @@ import pytest
 
 import miles.rollout.fully_async_rollout as fully_async
 from miles.rollout.base_types import RolloutFnConstructorInput, RolloutFnEvalInput, RolloutFnTrainInput
+from miles.rollout.filter_hub.base_types import DynamicFilterOutput
 from miles.utils.types import Sample
 
 N_SAMPLES_PER_PROMPT = 2
@@ -73,6 +74,8 @@ def make_args(**overrides) -> Namespace:
         n_samples_per_prompt=N_SAMPLES_PER_PROMPT,
         max_weight_staleness=None,
         async_max_concurrent_samples=None,
+        dynamic_sampling_filter_path=None,
+        rollout_sample_filter_path=None,
         sglang_router_ip="127.0.0.1",
         sglang_router_port=30000,
     )
@@ -253,6 +256,41 @@ async def test_nested_group_recycles_the_flat_prompt_group(monkeypatch):
     assert all(isinstance(sample, Sample) for sample in data_source.recycled[0])
     assert len(submitted) > 1
     assert len(output.samples) == 1
+
+
+async def test_dynamic_filter_drops_group_without_recycling(monkeypatch):
+    rejected = make_group(1)
+    data_source = FakeDataSource(scripted=[rejected])
+    fn = make_fn(monkeypatch, make_args(rollout_batch_size=1), data_source)
+
+    def reject_group_1(args, group, **kwargs):
+        keep = group[0].group_index != 1
+        return DynamicFilterOutput(keep=keep, reason=None if keep else "rejected")
+
+    fn._dynamic_filter = reject_group_1
+
+    output = await fn(RolloutFnTrainInput(rollout_id=0))
+
+    assert len(output.samples) == 1
+    assert output.samples[0][0].group_index != 1
+    # Unlike a recycle, a filtered group is not returned to the data source for re-sampling.
+    assert data_source.recycled == []
+    assert output.metrics["rollout/dynamic_filter/drop_rejected"] == 1
+
+
+async def test_sample_filter_marks_samples_without_shrinking_the_batch(monkeypatch):
+    fn = make_fn(monkeypatch, make_args(rollout_batch_size=2), FakeDataSource())
+
+    def mark_first_of_each_group(args, data):
+        for group in data:
+            group[0].remove_sample = True
+
+    fn._sample_filter = mark_first_of_each_group
+
+    output = await fn(RolloutFnTrainInput(rollout_id=0))
+
+    assert len(output.samples) == 2
+    assert [sample.remove_sample for sample in output.samples[0]] == [True, False]
 
 
 async def test_weight_version_throttles_failed_queries(monkeypatch):

--- a/tests/fast/rollout/test_fully_async_rollout.py
+++ b/tests/fast/rollout/test_fully_async_rollout.py
@@ -5,6 +5,7 @@ register_cpu_ci(est_time=60, suite="stage-a-cpu", labels=[])
 import asyncio
 from argparse import Namespace
 from collections import deque
+from dataclasses import replace
 
 import pytest
 
@@ -207,3 +208,47 @@ async def test_async_max_concurrent_samples_caps_in_flight_groups(monkeypatch):
     release.set()
     output = await drain
     assert len(output.samples) == 4
+
+
+async def test_worker_failure_beats_queued_groups(monkeypatch):
+    """A dead worker fails the step even when it left completed groups behind."""
+    fn = make_fn(monkeypatch, make_args(rollout_batch_size=1), FakeDataSource())
+
+    async def boom():
+        raise RuntimeError("generation exploded")
+
+    fn._output = asyncio.Queue(maxsize=fully_async.OUTPUT_QUEUE_MAX_GROUPS)
+    group = make_group(1)
+    await fn._output.put((group, group))
+    fn._worker = asyncio.create_task(boom())
+    await asyncio.sleep(0)
+
+    with pytest.raises(RuntimeError, match="generation exploded"):
+        await fn(RolloutFnTrainInput(rollout_id=0))
+
+
+async def test_nested_group_recycles_the_flat_prompt_group(monkeypatch):
+    """A generate function may expand one trajectory into several samples; the retry
+    must resubmit the flat prompt group the data source handed out."""
+    prompt_group = make_group(1)
+    data_source = FakeDataSource(scripted=[prompt_group])
+    submitted = []
+
+    async def multi_sample_generate(state, group, sampling_params, evaluation=False):
+        assert all(isinstance(sample, Sample) for sample in group), "resubmitted a nested group"
+        submitted.append(group)
+        if len(submitted) > 1:
+            return group
+        expanded = []
+        for sample in group:
+            aborted = replace(sample, status=Sample.Status.ABORTED)
+            expanded.append([aborted, replace(sample)])
+        return expanded
+
+    fn = make_fn(monkeypatch, make_args(rollout_batch_size=1), data_source, generate=multi_sample_generate)
+    output = await fn(RolloutFnTrainInput(rollout_id=0))
+
+    assert data_source.recycled == [prompt_group]
+    assert all(isinstance(sample, Sample) for sample in data_source.recycled[0])
+    assert len(submitted) > 1
+    assert len(output.samples) == 1

--- a/train.py
+++ b/train.py
@@ -20,6 +20,7 @@ logger = logging.getLogger(__name__)
 
 
 async def train(args):
+    assert not args.fully_async, "--fully-async requires the async driver: run train_async.py"
     configure_logger(args, source=MainProcessIdentity())
     maybe_start_periodic_pyspy_dump()
     # allocate the GPUs


### PR DESCRIPTION
## Motivation

#1716 moved `fully_async_rollout.py` from `examples/` into `miles/rollout/` unchanged. What landed was still example-quality code on the legacy stack: a module-global worker (`_global_worker` + `threading.Lock` + `atexit`), a private thread event loop, the `GenerateState` singleton from `sglang_rollout`, `print` everywhere, and broad `try/except` that silently drops data. The singleton's semaphore binds to the worker's private loop, which is why fully-async + eval was structurally impossible (cross-loop `RuntimeError`).

This PR rewrites it on the class-based rollout API and gives it a real flag.

## What this PR does

**`FullyAsyncRolloutFn`, selected by `train_async.py --fully-async`** (requires `MILES_EXPERIMENTAL_ROLLOUT_REFACTOR=1`):

- **Worker = long-lived task on the shared rollout event loop**, lazy-started on the first train call. No thread, no private loop, no globals, no `atexit`; `asyncio.Queue(maxsize=1000)` keeps the same backpressure (a full queue pauses submission).
- **New-stack primitives**: `inference_rollout_common.generate_and_rm_group` with an instance-owned `GenerateState`, so custom generate functions receive the state type `GenerateFnInput` declares.
- **Errors are loud**: a failed generation task kills the worker, and the next drain raises the original exception instead of hanging. The recycle paths no longer swallow. (`_iter_samples` also fixes a latent bug where multi-sample groups could never be abort-recycled — the old broad `except` hid an `AttributeError`.)
- **Behavior preserved**: in-flight bound = `rollout_batch_size` groups; ABORTED-group recycle on weight-update pauses; `--max-weight-staleness` filter; final sort by index. New: `assert len(group) == n_samples_per_prompt` and per-step metrics (`rollout/fully_async/queue_size`, recycle counts, staleness stats) via `RolloutFnTrainOutput.metrics`.

**Rollout features the drain used to silently ignore.** The drain reimplements the collection loop, so everything the standard path does around it was lost:

- `--dynamic-sampling-filter-path` and `--rollout-sample-filter-path` are now applied. A dynamic-filtered group is dropped rather than recycled, matching the standard path — continuous submission already replaces it, so no over-sampling machinery is needed. This mattered in practice: `examples/swe-agent/run-glm47-flash-agentic-async.py`, one of the scripts this PR migrates, passes `--dynamic-sampling-filter-path`.
- `--partial-rollout`, `--recompute-logprobs-via-prefill` and `--rollout-all-samples-process-path` now fail fast instead of being ignored. Partial rollout is actively defeated by the recycle path (`reset_for_retry()` drops the partial response), and a group can cross a weight update before it is drained, so a drain-time logprob recompute would score it under newer weights than generated it — the correct fix there is a per-group recompute at completion time, which is out of scope here.

**Argument resolution.** `--rollout-function-path` loses its string default in favor of `None`, so `resolve_rollout_function_paths()` is the single place that answers "which rollout and eval function did these arguments select". `--fully-async` asserts against the flags it conflicts with (colocate, multi-LoRA, an explicit `--rollout-function-path`, the missing refactor env var), and eval is resolved before the fully-async override, so "fully async does not serve eval" holds by construction — eval keeps the standard `InferenceRolloutFn` unless `--eval-function-path` is set. `train.py` rejects `--fully-async` outright (it needs the async driver).

**Weight-version cache.** `_CachedWeightVersion` only stamped `_last_query` on success, so an unreachable router made every group in the drain pay the full 2s timeout instead of one per TTL — silently, at `logger.debug`. Stamped in a `finally` on completion now, which also fixes a router slower than the TTL defeating the cache entirely.

Scripts and docs move to the `--fully-async` path; the qwen scripts gain the env flag. `_submit_one_group` is shaped to receive #1673's sample-completion backfill with minimal conflict.

## Testing

**New e2e case** — `tests/e2e/megatron/test_qwen3_30B_A3B/test_fully_async.py`, `stage-c-8-gpu-h100`. Fully-async on the disaggregated topology (it cannot colocate); three rollouts exercise the states that only exist with a persistent worker: a cold start, a drain from an already-warm queue, and a drain across a weight update (which pauses generation and makes the worker recycle aborted groups).

**New CPU tests** — `tests/fast/rollout/test_fully_async_rollout.py`, `stage-a-cpu`, 12 cases on a `FakeGenerateState` / `FakeDataSource` harness:

| | |
|---|---|
| `drain_collects_batch_sorted_with_metrics` | sorted batch + metrics, worker persists across calls |
| `eval_raises` | eval is rejected without starting a worker |
| `aborted_group_recycled` / `stale_group_recycled` | both recycle paths return the prompt group to the data source |
| `worker_error_propagates` / `worker_failure_beats_queued_groups` | a dead worker fails the step, even with a backlog queued |
| `worker_bounds_in_flight_groups` / `async_max_concurrent_samples_caps_in_flight_groups` | both in-flight bounds |
| `nested_group_recycles_the_flat_prompt_group` | multi-sample generate functions resubmit the flat prompt group |
| `dynamic_filter_drops_group_without_recycling` | dropped, *not* recycled; drop reason reaches metrics |
| `sample_filter_marks_samples_without_shrinking_the_batch` | `remove_sample` set, batch size unchanged |
| `weight_version_throttles_failed_queries` | one HTTP call per TTL when the router is down, not one per group |

`resolve_rollout_function_paths` was checked to be behavior-identical to the two functions it replaces across all 10 valid argument combinations. `pre-commit run --all-files` passes.
