### PR TITLE
fix: inject PPO terminal rewards after CP gather

### DIFF
--- a/miles/backends/training_utils/loss_hub/advantages.py
+++ b/miles/backends/training_utils/loss_hub/advantages.py
@@ -25,8 +25,27 @@ def compute_advantages(
 ) -> tuple[list[torch.Tensor], list[torch.Tensor]]:
     """Dispatch to the configured advantage estimator.
 
+    Shape symbols:
+        `B`: Number of samples in the current local batch.
+        `T_i`: Prompt-plus-response length of sample `i`, excluding BSHD padding.
+        `R_i`: Full response length of sample `i` before CP splitting.
+        `C_i`: Number of response-aligned positions of sample `i` stored on this CP rank; prompt and padding positions are excluded.
+
+    Args:
+        args: `Namespace`; no tensor shape.
+        kl: List length `B`; `kl[i]` has shape `[C_i]`.
+        rewards: List length `B`; `rewards[i]` is a scalar.
+        log_probs: `None` or list length `B`; `log_probs[i]` has shape `[C_i]`.
+        loss_masks: List length `B`; `loss_masks[i]` has shape `[R_i]`.
+        total_lengths: List length `B`; `total_lengths[i] = T_i`.
+        response_lengths: List length `B`; `response_lengths[i] = R_i`.
+        values: `None` or list length `B`; `values[i]` has shape `[C_i]`. PPO requires this input.
+
+    `C_i = R_i` when CP size is 1. With CP size greater than 1, `0 <= C_i <= R_i`; `C_i` can be zero and can differ across ranks. THD partitions a sequence of length `T_i`, while BSHD partitions the padded maximum sequence length, so the two formats do not guarantee the same `C_i`.
+
     Returns:
-        (advantages, returns) — both lists of tensors, one per sample.
+        `advantages`: List length `B`; `advantages[i]` has shape `[C_i]`.
+        `returns`: List length `B`; `returns[i]` has shape `[C_i]`.
     """
     if args.advantage_estimator in ["grpo", "gspo"]:
         rewards = torch.tensor(rewards, dtype=torch.float32, device=kl[0].device)
@@ -35,17 +54,20 @@ def compute_advantages(
         advantages = [r for r in returns]
 
     elif args.advantage_estimator == "ppo":
-        old_rewards = rewards
-        rewards = []
+        terminal_rewards = rewards
+        token_rewards = []
         kl_coef = -args.kl_coef
-        cp_rank = get_parallel_state().cp.rank
-        for reward, k in zip(old_rewards, kl, strict=False):
+        for k in kl:
             k *= kl_coef
-            if cp_rank == 0:
-                k[-1] += reward
-            rewards.append(k)
+            token_rewards.append(k)
         advantages, returns = get_advantages_and_returns_batch(
-            total_lengths, response_lengths, values, rewards, args.gamma, args.lambd
+            total_lengths=total_lengths,
+            response_lengths=response_lengths,
+            values_list=values,
+            rewards_list=token_rewards,
+            terminal_rewards=terminal_rewards,
+            gamma=args.gamma,
+            lambd=args.lambd,
         )
 
     elif args.advantage_estimator == "reinforce_plus_plus":

--- a/miles/backends/training_utils/loss_hub/math_utils.py
+++ b/miles/backends/training_utils/loss_hub/math_utils.py
@@ -604,19 +604,22 @@ def get_advantages_and_returns_batch(
     response_lengths,
     values_list,
     rewards_list,
+    terminal_rewards,
     gamma,
     lambd,
     chunked: bool = True,
 ):
     """
     Batched GAE with CP support.
+    C_i is the length of values_list[i] and rewards_list[i] on the current CP rank.
     Input:
         total_lengths:     list[int], each sample's total_len
         response_lengths:  list[int], each sample's response_len
-        values_list:       list[Tensor], each shape = [resp_len_i]
-        rewards_list:      list[Tensor], same shape
+        values_list:       list[Tensor], each current-CP-rank tensor has shape [C_i]
+        rewards_list:      list[Tensor], same shape as values_list
+        terminal_rewards:  list[float], one scalar sequence reward per sample
     Output:
-        advantages_list:   list[Tensor], each shape = [resp_len_i]
+        advantages_list:   list[Tensor], each current-CP-rank tensor has shape [C_i]
         returns_list:      list[Tensor], same shape
     """
 
@@ -624,6 +627,7 @@ def get_advantages_and_returns_batch(
         B = len(response_lengths)
         assert B == len(values_list)
         assert B == len(rewards_list)
+        assert B == len(terminal_rewards)
 
         cp_size = get_parallel_state().cp.size
         device = values_list[0].device
@@ -658,6 +662,7 @@ def get_advantages_and_returns_batch(
             L = response_lengths[i]
             full_values[i, :L] = full_values_list[i][:L]
             full_rewards[i, :L] = full_rewards_list[i][:L]
+            full_rewards[i, L - 1] += terminal_rewards[i]
 
         if not chunked:
             full_advantages, full_returns = vanilla_gae(

--- a/miles/backends/training_utils/loss_hub/math_utils.py
+++ b/miles/backends/training_utils/loss_hub/math_utils.py
@@ -660,9 +660,10 @@ def get_advantages_and_returns_batch(
 
         for i in range(B):
             L = response_lengths[i]
-            full_values[i, :L] = full_values_list[i][:L]
-            full_rewards[i, :L] = full_rewards_list[i][:L]
-            full_rewards[i, L - 1] += terminal_rewards[i]
+            if L > 0:
+                full_values[i, :L] = full_values_list[i][:L]
+                full_rewards[i, :L] = full_rewards_list[i][:L]
+                full_rewards[i, L - 1] += terminal_rewards[i]
 
         if not chunked:
             full_advantages, full_returns = vanilla_gae(

--- a/tests/fast/backends/training_utils/test_ppo_cp_advantages.py
+++ b/tests/fast/backends/training_utils/test_ppo_cp_advantages.py
@@ -1,0 +1,91 @@
+from argparse import Namespace
+
+import torch
+import torch.distributed as dist
+from tests.fast.dist_utils import init_gloo, run_multiprocess
+
+from miles.backends.training_utils.cp_utils import all_gather_with_cp, slice_log_prob_with_cp
+from miles.backends.training_utils.loss_hub.advantages import compute_advantages
+from miles.backends.training_utils.parallel import GroupInfo, ParallelState, set_parallel_state
+
+
+def _parallel_state(rank: int = 0, world_size: int = 1) -> ParallelState:
+    trivial_group = GroupInfo(rank=0, size=1, group=None)
+    cp_group = dist.group.WORLD if world_size > 1 else None
+    return ParallelState(
+        intra_dp=trivial_group,
+        intra_dp_cp=GroupInfo(rank=rank, size=world_size, group=cp_group),
+        cp=GroupInfo(rank=rank, size=world_size, group=cp_group),
+        tp=trivial_group,
+        pp=trivial_group,
+        ep=trivial_group,
+        etp=trivial_group,
+        indep_dp=trivial_group,
+    )
+
+
+def _run_ppo_case(rank: int, total_length: int, response_length: int, expected_local_sizes: list[int]) -> None:
+    args = Namespace(advantage_estimator="ppo", kl_coef=0.1, gamma=0.0, lambd=0.0)
+    full_kl = torch.arange(1, response_length + 1, dtype=torch.float32)
+    full_values = torch.zeros(response_length)
+
+    set_parallel_state(_parallel_state(rank=rank, world_size=2))
+    local_kl = slice_log_prob_with_cp(full_kl, total_length, response_length)
+    local_values = slice_log_prob_with_cp(full_values, total_length, response_length)
+    assert local_kl.numel() == expected_local_sizes[rank]
+
+    advantages, returns = compute_advantages(
+        args=args,
+        kl=[local_kl],
+        rewards=[10.0],
+        log_probs=[torch.empty_like(local_kl)],
+        loss_masks=[torch.ones(response_length)],
+        total_lengths=[total_length],
+        response_lengths=[response_length],
+        values=[local_values],
+    )
+    cp_advantages = all_gather_with_cp(advantages[0], total_length, response_length)
+    cp_returns = all_gather_with_cp(returns[0], total_length, response_length)
+
+    set_parallel_state(_parallel_state())
+    baseline_advantages, baseline_returns = compute_advantages(
+        args=args,
+        kl=[full_kl.clone()],
+        rewards=[10.0],
+        log_probs=[torch.empty_like(full_kl)],
+        loss_masks=[torch.ones(response_length)],
+        total_lengths=[total_length],
+        response_lengths=[response_length],
+        values=[full_values],
+    )
+
+    expected = -0.1 * full_kl
+    expected[-1] += 10.0
+    torch.testing.assert_close(cp_advantages, expected)
+    torch.testing.assert_close(cp_returns, expected)
+    torch.testing.assert_close(cp_advantages, baseline_advantages[0])
+    torch.testing.assert_close(cp_returns, baseline_returns[0])
+
+
+def _worker_tail_on_rank_one(rank: int, world_size: int, port: int) -> None:
+    init_gloo(rank, world_size, port=port)
+    try:
+        _run_ppo_case(rank, total_length=7, response_length=6, expected_local_sizes=[2, 4])
+    finally:
+        dist.destroy_process_group()
+
+
+def _worker_empty_rank_zero(rank: int, world_size: int, port: int) -> None:
+    init_gloo(rank, world_size, port=port)
+    try:
+        _run_ppo_case(rank, total_length=7, response_length=2, expected_local_sizes=[0, 2])
+    finally:
+        dist.destroy_process_group()
+
+
+def test_ppo_terminal_reward_is_added_to_global_response_tail() -> None:
+    run_multiprocess(_worker_tail_on_rank_one)
+
+
+def test_ppo_terminal_reward_handles_empty_rank_zero_shard() -> None:
+    run_multiprocess(_worker_empty_rank_zero)


### PR DESCRIPTION
## Summary
Inject PPO terminal rewards at the global response tail after CP reconstruction.

## Symptom & Reproduction
- **Symptom:** With CP greater than one, PPO writes the sequence reward to rank zero's local tail, producing a wrong reward position or an empty-shard `IndexError`.
- **Reproduction:** Run `pytest -q tests/fast/backends/training_utils/test_ppo_cp_advantages.py` against the pre-fix implementation.

## Root Cause
1. `compute_advantages` writes the terminal reward to rank zero's local `k[-1]`.
2. `all_gather_with_cp` reconstructs the full response only after that write.

## Fix
Pass terminal rewards separately, reconstruct full token rewards and values, and inject each reward at `response_lengths[i] - 1` before GAE. This keeps terminal placement in global response coordinates without duplicating CP ownership logic or adding collectives.

## Verification
- **New test:** `test_ppo_terminal_reward_is_added_to_global_response_tail` verifies reward placement when rank one owns the final token.
- **New test:** `test_ppo_terminal_reward_handles_empty_rank_zero_shard` verifies an empty rank-zero response shard.

## Review Focus
- Scrutinize terminal-reward placement in `get_advantages_and_returns_batch` after CP reconstruction.
- Scrutinize the CP=2 versus CP=1 equivalence checks in `test_ppo_cp_advantages.py`.
