### PR TITLE
[fix] honor --accumulate-allreduce-grads-in-fp32 on the bridge LoRA DDP path

### DIFF
--- a/miles/backends/megatron_utils/bridge_lora_helpers.py
+++ b/miles/backends/megatron_utils/bridge_lora_helpers.py
@@ -129,7 +129,12 @@ def _setup_lora_model_via_bridge(args: Namespace) -> list:
         provider.register_pre_wrap_hook(_make_value_model_hook(hidden_size, provider.sequence_parallel))
 
     use_distributed_optimizer = "muon" not in (args.optimizer or "").lower()
-    ddp_config = DistributedDataParallelConfig(use_distributed_optimizer=use_distributed_optimizer)
+    ddp_config = DistributedDataParallelConfig(
+        use_distributed_optimizer=use_distributed_optimizer,
+        # This path builds its own DDP config, so the flag has to be wired
+        # through explicitly; leaving it out silently reduces grads in bf16.
+        grad_reduce_in_fp32=args.accumulate_allreduce_grads_in_fp32,
+    )
     ddp_config.finalize()
 
     if args.offload_train:

--- a/miles/backends/megatron_utils/bridge_lora_helpers.py
+++ b/miles/backends/megatron_utils/bridge_lora_helpers.py
@@ -131,8 +131,6 @@ def _setup_lora_model_via_bridge(args: Namespace) -> list:
     use_distributed_optimizer = "muon" not in (args.optimizer or "").lower()
     ddp_config = DistributedDataParallelConfig(
         use_distributed_optimizer=use_distributed_optimizer,
-        # This path builds its own DDP config, so the flag has to be wired
-        # through explicitly; leaving it out silently reduces grads in bf16.
         grad_reduce_in_fp32=args.accumulate_allreduce_grads_in_fp32,
     )
     ddp_config.finalize()


### PR DESCRIPTION
The bridge LoRA path builds its own DDP config and only sets use_distributed_optimizer, so --accumulate-allreduce-grads-in-fp32 gets silently dropped and grad all-reduce runs in bf16. Wire the flag through.