### PR TITLE
[fix] gate LoRA checkpoint writers on dp and cp, not dp alone

### DIFF
--- a/miles/backends/megatron_utils/lora_utils.py
+++ b/miles/backends/megatron_utils/lora_utils.py
@@ -383,9 +383,12 @@ def save_lora_checkpoint(
     from miles.utils import megatron_bridge_utils
 
     save_path = Path(save_dir)
-    is_dp_rank_0 = get_parallel_state().effective_dp.rank == 0
-    tp_rank = get_parallel_state().tp.rank
-    pp_rank = get_parallel_state().pp.rank
+    # Adapter weights are replicated across CP ranks, so the writer gate must
+    # include CP: on DP alone, every CP rank writes the same file concurrently.
+    parallel_state = get_parallel_state()
+    is_dp_rank_0 = parallel_state.effective_dp.rank == 0 and parallel_state.cp.rank == 0
+    tp_rank = parallel_state.tp.rank
+    pp_rank = parallel_state.pp.rank
 
     # Create directory on dp_rank=0, then synchronize
     if is_dp_rank_0:

--- a/miles/backends/megatron_utils/lora_utils.py
+++ b/miles/backends/megatron_utils/lora_utils.py
@@ -383,21 +383,19 @@ def save_lora_checkpoint(
     from miles.utils import megatron_bridge_utils
 
     save_path = Path(save_dir)
-    # Adapter weights are replicated across CP ranks, so the writer gate must
-    # include CP: on DP alone, every CP rank writes the same file concurrently.
     parallel_state = get_parallel_state()
-    is_dp_rank_0 = parallel_state.effective_dp.rank == 0 and parallel_state.cp.rank == 0
+    is_dp_cp_rank_0 = parallel_state.effective_dp.rank == 0 and parallel_state.cp.rank == 0
     tp_rank = parallel_state.tp.rank
     pp_rank = parallel_state.pp.rank
 
     # Create directory on dp_rank=0, then synchronize
-    if is_dp_rank_0:
+    if is_dp_cp_rank_0:
         save_path.mkdir(parents=True, exist_ok=True)
     if dist.is_initialized():
         dist.barrier()
 
     # ---- Megatron-native format (per TP/PP rank, fast resume) ----
-    if is_dp_rank_0:
+    if is_dp_cp_rank_0:
         adapter_state: dict[str, torch.Tensor] = {}
         for model_chunk in model:
             for name, param in model_chunk.named_parameters():
@@ -422,8 +420,8 @@ def save_lora_checkpoint(
         ):
             lora_state_dict[hf_name] = weight
 
-    # Only one rank writes the HF PEFT files (bridge already gathered across TP)
-    if is_dp_rank_0 and tp_rank == 0:
+    # Only one rank writes the HF PEFT files (bridge already gathered across TP/PP)
+    if is_dp_cp_rank_0 and tp_rank == 0 and pp_rank == 0:
         torch.save(lora_state_dict, save_path / "adapter_model.bin")
 
         target_modules_hf = (


### PR DESCRIPTION
save_lora_checkpoint gates its writers on effective_dp.rank == 0, but adapter weights are replicated across CP ranks — with context-parallel-size > 1 every CP rank on dp rank 0 writes the same adapter_megatron_tp{t}_pp{p}.pt and adapter_model.bin concurrently. Add cp.rank == 0 to the gate.