### PR TITLE
TOP: one attention-backend flag for both engines, radix-off for flashinfer

### DIFF
--- a/miles/true_on_policy/config.py
+++ b/miles/true_on_policy/config.py
@@ -69,13 +69,30 @@ class TrueOnPolicyKernelPolicy:
     tp_invariant_row_linear: bool
     deterministic_tp_allreduce: bool
 
+    @property
+    def resolved_attention_backend(self) -> str:
+        """The one attention-backend flag, driving BOTH engines (no GPU arch-gate).
+
+        Default comes from the contract (dense = ``fa3``, the tested Hopper path);
+        ``TOP_ATTN_BACKEND`` overrides it so flashinfer can be exercised on Hopper for
+        e2e parity tests, or forced on Blackwell (where fa3 does not build)."""
+        return os.environ.get("TOP_ATTN_BACKEND", self.sglang_attention_backend)
+
     def build_sglang_args(self) -> TrueOnPolicyArgList:
+        backend = self.resolved_attention_backend
         values = [
             "--sglang-true-on-policy-contract",
             self.contract.name,
             "--sglang-attention-backend",
-            self.sglang_attention_backend,
+            backend,
         ]
+        if backend == "flashinfer":
+            # radix cache is NOT enabled with flashinfer: sglang excludes it from
+            # RADIX_SUPPORTED_DETERMINISTIC_ATTENTION_BACKEND and force-disables radix for it
+            # under deterministic inference anyway; set explicitly to document intent. Costs
+            # rollout-generation prefix reuse on Blackwell (throughput, not parity -- TOP's
+            # recompute prefill is radix-free regardless). fa3 keeps radix.
+            values.append("--sglang-disable-radix-cache")
         if self.deterministic_inference:
             values.insert(0, "--sglang-enable-deterministic-inference")
         return TrueOnPolicyArgList(tuple(values))
@@ -105,6 +122,9 @@ class TrueOnPolicyKernelPolicy:
             "NCCL_ALGO": os.environ.get("NCCL_ALGO", "Ring"),
             "NVTE_ALLOW_NONDETERMINISTIC_ALGO": "0",
             "CUBLAS_WORKSPACE_CONFIG": ":4096:8",
+            # Pin the Megatron plugin's attention backend to the SAME flag sglang uses,
+            # so both engines agree without any per-process GPU arch detection.
+            "TOP_ATTN_BACKEND": self.resolved_attention_backend,
         }
 
 


### PR DESCRIPTION
# TOP: one attention-backend flag for both engines, radix-off for flashinfer

## Summary

A single `TOP_ATTN_BACKEND` flag that both the training (Megatron) and rollout (SGLang) engines honor, so they always run the same attention backend under true-on-policy — no per-process GPU-arch detection. It defaults to the contract's backend (dense Qwen3 = `fa3`, the tested Hopper path) and can be overridden to `flashinfer` (required on Blackwell, where fa3 doesn't build; also usable on Hopper for parity tests). When the backend is `flashinfer`, the rollout also gets `--sglang-disable-radix-cache`, since flashinfer isn't a radix-supported deterministic attention backend.

## Change

`miles/true_on_policy/config.py`:
- `resolved_attention_backend` property = `os.environ.get("TOP_ATTN_BACKEND", self.sglang_attention_backend)` — the contract sets the default; the env var overrides.
- The SGLang launch args use the resolved backend, and export `TOP_ATTN_BACKEND` into the run env so the Megatron plugin selects the same one.
- `flashinfer` → append `--sglang-disable-radix-cache` (parity is unaffected — TOP's recompute prefill is radix-free regardless; the cost is rollout prefix reuse on Blackwell, i.e. throughput). `fa3` keeps radix.

## Testing

Verified on real TOP runs (Qwen3-0.6B GSM8K, Qwen3-4B DAPO), which log `train_rollout_logprob_abs_diff == 0` every step — that log line is the TOP gate.

Automated CI is deferred until GPU CI is set up: a `register_cuda_ci` e2e regression test and a fast unit test for `resolved_attention_backend` (default = contract, `TOP_ATTN_BACKEND` override, flashinfer → `--sglang-disable-radix-cache`).

## Reproduce / verify parity

```python
from scripts.run_qwen3_4b import ScriptArgs, prepare, execute
ARGS = ScriptArgs(model_name="Qwen3-0.6B", train_backend="megatron", true_on_policy=True)
prepare(ARGS); execute(ARGS)
```

The contract injects the TOP flags for both engines: `--true-on-policy-mode`, `--sglang-true-on-policy-contract qwen3_dense_true_on_policy_v1`, `--batch-invariant-mode`, `--no-rope-fusion`, `--sglang-enable-deterministic-inference`, `--deterministic-mode`, `--recompute-logprobs-via-prefill`, and `--sglang-attention-backend fa3` (Hopper; set `TOP_ATTN_BACKEND=flashinfer` on Blackwell). Verification: `train/train_rollout_logprob_abs_diff == 0` on every step in the training log — that's the parity gate (asserted under `--ci-test`).

## Not in scope (deferred follow-ups)

- Automated CI (e2e regression test + fast config test) — until GPU CI is set up.
- Example cleanup (`run_simple.py` → pointer, README). `run_simple.py` and the only existing e2e TOP test (`tests/e2e/fsdp/test_qwen3_4B_fsdp_true_on_policy.py`) are stale: both pass `--sglang-rl-on-policy-target fsdp`, a flag no longer defined in `miles/utils/arguments.py`, so either would fail with an unknown-argument error if run today. They pre-date the `miles/true_on_policy/` contract module (run_simple last changed 2026-01-07) and hand-write a TOP flag set the contract now generates; the FSDP test is additionally `disabled="FSDP backend has known issues, not actively maintained"`. Rewriting the example to point at the contract-driven path is a follow-up, gated on the CI test above so it can't silently rot again.
- FSDP weight-update begin/end sessions — separate change.
