### PR TITLE
[feat] --check-lora-weight-equal LoRA adapter weight-sync checker

### DIFF
--- a/miles/backends/megatron_utils/update_weight/update_weight_from_tensor.py
+++ b/miles/backends/megatron_utils/update_weight/update_weight_from_tensor.py
@@ -299,6 +299,7 @@ class UpdateWeightFromTensor:
                 lora_config=self._lora_config,
                 lora_name=LORA_ADAPTER_NAME,
                 lora_loaded=self._lora_loaded,
+                check_equal=getattr(self.args, "check_lora_weight_equal", False),
             )
             self._lora_loaded = True
             return refs or [], long_lived_tensors
@@ -314,6 +315,7 @@ def _send_to_colocated_engine(
     lora_config: dict | None = None,
     lora_name: str | None = None,
     lora_loaded: bool = False,
+    check_equal: bool = False,
 ) -> tuple[list[ObjectRef], Any]:
     # Placeholder ranks (GPU slots reserved but no engine) have no gather group.
     # gather_object is only collective among group members, so we skip entirely.
@@ -363,6 +365,17 @@ def _send_to_colocated_engine(
             # Thus, we need to apply the same way as `ipc_engine.update_weights_from_tensor` in future
             # (Yusheng) to-do-2: need to add ci test acc here - now it will pass but fail to update lora weights
 
+            expected_checksums = None
+            if check_equal:
+                import hashlib
+
+                expected_checksums = {
+                    n: hashlib.sha256(
+                        t.detach().cpu().contiguous().flatten().view(torch.uint8).numpy().tobytes()
+                    ).hexdigest()
+                    for n, t in hf_named_tensors
+                }
+
             refs.append(
                 ipc_engine.load_lora_adapter_from_tensors.remote(
                     lora_name=lora_name,
@@ -371,6 +384,7 @@ def _send_to_colocated_engine(
                         per_rank[0] if per_rank else None for per_rank in serialized_named_tensors
                     ],
                     load_format="flattened_bucket",
+                    expected_checksums=expected_checksums,
                 )
             )
 

--- a/miles/backends/megatron_utils/update_weight/update_weight_from_tensor.py
+++ b/miles/backends/megatron_utils/update_weight/update_weight_from_tensor.py
@@ -1,3 +1,4 @@
+import hashlib
 import logging
 from argparse import Namespace
 from collections.abc import Callable, Mapping, Sequence
@@ -367,8 +368,6 @@ def _send_to_colocated_engine(
 
             expected_checksums = None
             if check_equal:
-                import hashlib
-
                 expected_checksums = {
                     n: hashlib.sha256(
                         t.detach().cpu().contiguous().flatten().view(torch.uint8).numpy().tobytes()

--- a/miles/backends/sglang_utils/sglang_engine.py
+++ b/miles/backends/sglang_utils/sglang_engine.py
@@ -343,12 +343,7 @@ class SGLangEngine(RayActor):
         added_tokens_config: dict | None = None,
         expected_checksums: dict | None = None,
     ):
-        """Load a LoRA adapter. ``serialized_named_tensors[tp_rank]`` is bytes for TP rank N.
-
-        ``expected_checksums`` (set when ``--check-lora-weight-equal`` is on) is a
-        per-tensor-name sha256 manifest of the adapter as sent; each engine hashes
-        the tensors it received after deserializing and asserts they match.
-        """
+        """Load a LoRA adapter. ``serialized_named_tensors[tp_rank]`` is bytes for TP rank N."""
         payload = {
             "lora_name": lora_name,
             "config_dict": config_dict,

--- a/miles/backends/sglang_utils/sglang_engine.py
+++ b/miles/backends/sglang_utils/sglang_engine.py
@@ -341,8 +341,14 @@ class SGLangEngine(RayActor):
         load_format: str | None = None,
         pinned: bool = False,
         added_tokens_config: dict | None = None,
+        expected_checksums: dict | None = None,
     ):
-        """Load a LoRA adapter. ``serialized_named_tensors[tp_rank]`` is bytes for TP rank N."""
+        """Load a LoRA adapter. ``serialized_named_tensors[tp_rank]`` is bytes for TP rank N.
+
+        ``expected_checksums`` (set when ``--check-lora-weight-equal`` is on) is a
+        per-tensor-name sha256 manifest of the adapter as sent; each engine hashes
+        the tensors it received after deserializing and asserts they match.
+        """
         payload = {
             "lora_name": lora_name,
             "config_dict": config_dict,
@@ -353,6 +359,8 @@ class SGLangEngine(RayActor):
             payload["load_format"] = load_format
         if added_tokens_config is not None:
             payload["added_tokens_config"] = added_tokens_config
+        if expected_checksums is not None:
+            payload["expected_checksums"] = expected_checksums
 
         return self._make_request(
             "load_lora_adapter_from_tensors",

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -1726,8 +1726,8 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                     "(from_tensors) path: on every sync the trainer ships a per-tensor sha256 "
                     "manifest of the adapter it sends, and each rollout engine hashes the "
                     "tensors it received and fails the load on any mismatch/missing/extra "
-                    "name. Requires sglang-miles with sgl-project/sglang#31831. The LoRA "
-                    "analogue of --check-weight-update-equal, which only covers base weights."
+                    "name. The LoRA analogue of --check-weight-update-equal, which only "
+                    "covers base weights."
                 ),
             )
             parser.add_argument(

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -1722,11 +1722,12 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 action="store_true",
                 default=False,
                 help=(
-                    "Verify the megatron->sglang LoRA adapter weight-sync: on every sync the "
-                    "trainer ships a per-tensor sha256 manifest of the adapter it sends, and "
-                    "each rollout engine hashes the tensors it received and asserts they match "
-                    "(raising on any mismatch/missing name). The LoRA analogue of "
-                    "--check-weight-update-equal, which only covers base weights."
+                    "Verify the megatron->sglang LoRA adapter weight-sync on the colocated "
+                    "(from_tensors) path: on every sync the trainer ships a per-tensor sha256 "
+                    "manifest of the adapter it sends, and each rollout engine hashes the "
+                    "tensors it received and fails the load on any mismatch/missing/extra "
+                    "name. Requires sglang-miles with sgl-project/sglang#31831. The LoRA "
+                    "analogue of --check-weight-update-equal, which only covers base weights."
                 ),
             )
             parser.add_argument(

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -1709,6 +1709,18 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 "by up to 1 ULP of the quantized dtype per side (compared in dequantized space).",
             )
             parser.add_argument(
+                "--check-lora-weight-equal",
+                action="store_true",
+                default=False,
+                help=(
+                    "Verify the megatron->sglang LoRA adapter weight-sync: on every sync the "
+                    "trainer ships a per-tensor sha256 manifest of the adapter it sends, and "
+                    "each rollout engine hashes the tensors it received and asserts they match "
+                    "(raising on any mismatch/missing name). The LoRA analogue of "
+                    "--check-weight-update-equal, which only covers base weights."
+                ),
+            )
+            parser.add_argument(
                 "--save-local-weight-checksum",
                 action="store_true",
                 help="Save per-rank local weight checksum per-step.",


### PR DESCRIPTION
## Summary
- Adds `--check-lora-weight-equal`, the LoRA analogue of the existing `--check-weight-update-equal` (base weights only).
- On every megatron->sglang LoRA sync, the trainer computes a per-tensor sha256 manifest of the adapter it's about to send and passes it as `expected_checksums` alongside the serialized tensors.
- Each rollout engine hashes the tensors it actually received after deserializing and asserts they match, raising on any mismatch/missing name.
- Sglang-side verification (`expected_checksums` handling in `tp_worker.py`/`lora_manager.py`) already exists in the sglang-miles fork https://github.com/sgl-project/sglang/pull/31831