### PR TITLE
fix(megatron): serialize Hugging Face metadata loads per node

### DIFF
--- a/miles/backends/megatron_utils/actor.py
+++ b/miles/backends/megatron_utils/actor.py
@@ -17,7 +17,7 @@ from miles.utils.argparse_utils import inplace_modify_args
 from miles.utils.audit_utils.event_logger.logger import event_logger_context
 from miles.utils.audit_utils.witness.allocator import WitnessInfo
 from miles.utils.context_utils import with_defer
-from miles.utils.distributed_utils import get_gloo_group, init_process_group
+from miles.utils.distributed_utils import get_gloo_group, init_process_group, run_on_local_rank_serialized
 from miles.utils.ft_utils.indep_dp import IndepDPInfo
 from miles.utils.hf_config import load_hf_config
 from miles.utils.memory_utils import clear_memory, print_memory
@@ -117,14 +117,18 @@ class MegatronTrainRayActor(TrainRayActor):
             )
         self.prof = TrainProfiler(args)
 
-        # read config and tokenizer serialized to prevent concurrent writing bug.
-        for i in range(dist.get_world_size()):
-            if i == dist.get_rank():
-                self.hf_config = load_hf_config(args.hf_checkpoint)
-                self.tokenizer = load_tokenizer(
-                    self.args.hf_checkpoint, chat_template_path=self.args.chat_template_path, trust_remote_code=True
-                )
-            dist.barrier(group=get_gloo_group())
+        # Serialize config and tokenizer loads within each node to prevent concurrent cache writes.
+        self.hf_config, self.tokenizer = run_on_local_rank_serialized(
+            lambda: (
+                load_hf_config(args.hf_checkpoint),
+                load_tokenizer(
+                    self.args.hf_checkpoint,
+                    chat_template_path=self.args.chat_template_path,
+                    trust_remote_code=True,
+                ),
+            ),
+            num_local_ranks=args.num_gpus_per_node,
+        )
 
         self.train_parallel_config = {} if args.indep_dp else {"dp_size": get_parallel_state().intra_dp.size}
         dist.barrier(group=get_gloo_group())

--- a/miles/utils/distributed_utils.py
+++ b/miles/utils/distributed_utils.py
@@ -1,5 +1,7 @@
+import os
+from collections.abc import Callable
 from datetime import timedelta
-from typing import Any
+from typing import Any, TypeVar
 
 import torch
 import torch.distributed as dist
@@ -17,6 +19,7 @@ from torch.distributed.distributed_c10d import (
 from miles.utils.ft_utils.process_group_utils import GeneralPGUtil
 
 GLOO_GROUP = None
+_T = TypeVar("_T")
 
 
 def init_gloo_group():
@@ -33,6 +36,37 @@ def get_gloo_group():
     if GLOO_GROUP is None:
         raise RuntimeError("Gloo group has not been initialized. Call _init_gloo_group() first.")
     return GLOO_GROUP
+
+
+def run_on_local_rank_serialized(operation: Callable[[], _T], *, num_local_ranks: int) -> _T:
+    """Run an operation one local rank at a time across every node.
+
+    Ranks with the same local rank execute concurrently on different nodes. A
+    global barrier after each turn keeps operations serialized within each node.
+
+    Args:
+        operation: Operation to run on this process's local-rank turn.
+        num_local_ranks: Number of possible local ranks on each node.
+
+    Returns:
+        The value returned by ``operation``.
+
+    Raises:
+        ValueError: If the local rank is outside ``num_local_ranks``.
+    """
+    local_rank = int(os.environ["LOCAL_RANK"])
+    if not 0 <= local_rank < num_local_ranks:
+        raise ValueError(f"LOCAL_RANK {local_rank} must be in [0, {num_local_ranks})")
+
+    results: list[_T] = []
+    gloo_group = get_gloo_group()
+    for current_local_rank in range(num_local_ranks):
+        if current_local_rank == local_rank:
+            results.append(operation())
+        dist.barrier(group=gloo_group)
+
+    assert len(results) == 1
+    return results[0]
 
 
 # Copy from pytorch to allow creating multiple main groups.

--- a/tests/fast/utils/test_distributed_utils.py
+++ b/tests/fast/utils/test_distributed_utils.py
@@ -1,0 +1,40 @@
+import pytest
+
+from miles.utils import distributed_utils
+
+
+def test_run_on_local_rank_serialized_runs_on_local_turn(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LOCAL_RANK", "2")
+
+    gloo_group = object()
+    events: list[tuple[str, object | None]] = []
+    expected_value = object()
+
+    monkeypatch.setattr(distributed_utils, "get_gloo_group", lambda: gloo_group)
+    monkeypatch.setattr(
+        distributed_utils.dist,
+        "barrier",
+        lambda *, group: events.append(("barrier", group)),
+    )
+
+    def operation() -> object:
+        events.append(("operation", None))
+        return expected_value
+
+    result = distributed_utils.run_on_local_rank_serialized(operation, num_local_ranks=4)
+
+    assert result is expected_value
+    assert events == [
+        ("barrier", gloo_group),
+        ("barrier", gloo_group),
+        ("operation", None),
+        ("barrier", gloo_group),
+        ("barrier", gloo_group),
+    ]
+
+
+def test_run_on_local_rank_serialized_rejects_out_of_range_rank(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LOCAL_RANK", "4")
+
+    with pytest.raises(ValueError, match=r"LOCAL_RANK 4 must be in \[0, 4\)"):
+        distributed_utils.run_on_local_rank_serialized(lambda: None, num_local_ranks=4)


### PR DESCRIPTION
## Summary

- limit serialized Hugging Face config/tokenizer loading to one wave per GPU position within a node
- allow matching rank positions on different nodes to load concurrently

## Why

The existing loop performs one metadata-loading wave per global rank. Trainer ranks are ordered contiguously by node and GPU, so `global_rank % num_gpus_per_node` remains unique within each node while allowing the same position on different nodes to run concurrently. This reduces startup serialization from world size to GPUs per node.

In a 64-rank, 8-node benchmark, metadata-loading critical-path time decreased from 118.39s to 28.12s (4.21x faster; 90.27s / 76.3% reduction). All 64 ranks completed one config and tokenizer load.

The existing global barrier after each wave is preserved. The optimization assumes the Hugging Face cache state being protected is node-local.

## Validation

- `pre-commit run --files miles/backends/megatron_utils/actor.py`
- `python -m py_compile miles/backends/megatron_utils/actor.py`
- 64-rank, 8-node baseline and optimized startup runs completed successfully