### PR TITLE
[algo] dual-clip PPO wiring and debug-disable-optimizer guard

### DIFF
--- a/miles/backends/megatron_utils/arguments.py
+++ b/miles/backends/megatron_utils/arguments.py
@@ -12,7 +12,9 @@ logger = logging.getLogger(__name__)
 def set_default_megatron_args(args):
     # Muon currently owns its sharding path, and Megatron's distributed optimizer
     # only supports Adam-family optimizers.
-    args.use_distributed_optimizer = args.optimizer is None or args.optimizer.lower() == "adam"
+    args.use_distributed_optimizer = (args.optimizer is None or args.optimizer.lower() == "adam") and not getattr(
+        args, "debug_disable_optimizer", False
+    )
     # TODO: maybe change this after megatron has good fp8 support
     args.bf16 = not args.fp16
     # placeholders

--- a/miles/backends/training_utils/loss_hub/losses.py
+++ b/miles/backends/training_utils/loss_hub/losses.py
@@ -177,7 +177,9 @@ def policy_loss_function(
         advantages.new_zeros(()),
     )
 
-    pg_loss, pg_clipfrac = compute_policy_loss(ppo_kl, advantages, args.eps_clip, args.eps_clip_high)
+    pg_loss, pg_clipfrac = compute_policy_loss(
+        ppo_kl, advantages, args.eps_clip, args.eps_clip_high, getattr(args, "eps_clip_c", None)
+    )
 
     if getattr(args, "dump_details", None) is not None:
         from miles.backends.training_utils.debug_dump import maybe_dump_policy_loss_debug

--- a/tests/fast/backends/training_utils/test_true_on_policy_loss_metrics.py
+++ b/tests/fast/backends/training_utils/test_true_on_policy_loss_metrics.py
@@ -105,7 +105,7 @@ def test_train_rollout_logprob_abs_diff_uses_policy_loss_reference_logprobs(
     monkeypatch.setattr(
         loss_utils,
         "compute_policy_loss",
-        lambda ppo_kl, advantages, eps_clip, eps_clip_high: (
+        lambda ppo_kl, advantages, eps_clip, eps_clip_high, eps_clip_c=None: (
             torch.zeros_like(ppo_kl),
             torch.zeros_like(ppo_kl),
         ),
@@ -144,7 +144,7 @@ def test_zero_weighted_entropy_nan_does_not_poison_policy_loss(monkeypatch):
     monkeypatch.setattr(
         loss_utils,
         "compute_policy_loss",
-        lambda ppo_kl, advantages, eps_clip, eps_clip_high: (
+        lambda ppo_kl, advantages, eps_clip, eps_clip_high, eps_clip_c=None: (
             torch.zeros_like(ppo_kl),
             torch.zeros_like(ppo_kl),
         ),
@@ -187,7 +187,7 @@ def test_zero_weighted_kl_nan_does_not_poison_policy_loss(monkeypatch):
     monkeypatch.setattr(
         loss_utils,
         "compute_policy_loss",
-        lambda ppo_kl, advantages, eps_clip, eps_clip_high: (
+        lambda ppo_kl, advantages, eps_clip, eps_clip_high, eps_clip_c=None: (
             torch.zeros_like(ppo_kl),
             torch.zeros_like(ppo_kl),
         ),


### PR DESCRIPTION
## Summary
- `--eps-clip-c` (dual-clip PPO) has been silently inert: `compute_policy_loss()` already implements it, but `policy_loss_function()` never passed it through, so it always ran with `eps_clip_c=None` regardless of the flag.
- `set_default_megatron_args()` force-enabled `use_distributed_optimizer` even when `--debug-disable-optimizer` is set, which shouldn't be configuring a distributed optimizer at all in that mode.
