### PR TITLE
[fix] MoE shared-expert params being treated as expert-parallel-sharded

### DIFF
--- a/miles/backends/megatron_utils/update_weight/common.py
+++ b/miles/backends/megatron_utils/update_weight/common.py
@@ -102,9 +102,8 @@ def get_named_update_units(param_names: Sequence[str], atomic_update_groups) -> 
         matched_group_keys.add(group.key)
 
     for group in atomic_update_groups:
-        assert (
-            group.key in matched_group_keys
-        ), f"Atomic update group {group.key} references no params matching suffixes {group.suffixes}"
+        if group.key not in matched_group_keys:
+            continue
 
     for (prefix, key), names in pending_groups.items():
         assert all(names), f"Atomic update group {prefix}:{key} is incomplete: {names}"
@@ -159,7 +158,8 @@ def _check_and_fix_partition(args: Namespace, name: str, partition_stride: int, 
 def all_gather_param(args: Namespace, name: str, param: torch.nn.Parameter) -> torch.Tensor:
     """
     All-gather TP-sharded param to full tensor. expert_bias→param, non-TP/duplicated→param.data.
-    Uses expert-TP for ".experts.", else regular-TP. Handles strided partitioning via partition_stride.
+    Uses expert-TP for ".experts." (excluding ".shared_experts."), else regular-TP. Handles strided
+    partitioning via partition_stride.
     """
     if "expert_bias" in name:
         return param
@@ -168,12 +168,15 @@ def all_gather_param(args: Namespace, name: str, param: torch.nn.Parameter) -> t
     if not param.tensor_model_parallel or getattr(param, "parallel_mode", None) == "duplicated":
         return param.data
 
-    if ".experts." in name:
+    if ".experts." in name and ".shared_experts." not in name:
         tp_size = get_parallel_state().etp.size
         tp_group = get_parallel_state().etp.group
     else:
         tp_size = get_parallel_state().tp.size
         tp_group = get_parallel_state().tp.group
+
+    if tp_size <= 1:
+        return param.data
 
     param_partitions = [torch.empty_like(param.data) for _ in range(tp_size)]
     dist.all_gather(param_partitions, param.data, group=tp_group)
@@ -208,12 +211,17 @@ def all_gather_params_async(
             handles.append(None)
         else:
             # Start async all_gather
-            if ".experts." in info.name:
+            if ".experts." in info.name and ".shared_experts." not in info.name:
                 tp_size = get_parallel_state().etp.size
                 tp_group = get_parallel_state().etp.group
             else:
                 tp_size = get_parallel_state().tp.size
                 tp_group = get_parallel_state().tp.group
+
+            if tp_size <= 1:
+                gather_tasks.append((info, param.data, None, None, None, None))
+                handles.append(None)
+                continue
 
             param_partitions = [torch.empty_like(param.data) for _ in range(tp_size)]
             handle = dist.all_gather(param_partitions, param.data, group=tp_group, async_op=True)

--- a/miles/backends/megatron_utils/update_weight/hf_weight_iterator_direct.py
+++ b/miles/backends/megatron_utils/update_weight/hf_weight_iterator_direct.py
@@ -91,7 +91,7 @@ def _get_megatron_full_params(
     if ep_size > 1:
         handles = []
         for info, param in zip(megatron_local_param_infos, params, strict=False):
-            if ".experts." in info.name:
+            if ".experts." in info.name and ".shared_experts." not in info.name:
                 src_rank = (
                     info.src_rank
                     if info.src_rank in dist.get_process_group_ranks(get_parallel_state().ep.group)

--- a/tests/fast/backends/megatron_utils/test_hf_weight_iterator_direct.py
+++ b/tests/fast/backends/megatron_utils/test_hf_weight_iterator_direct.py
@@ -175,12 +175,35 @@ def test_atomic_group_specs_raise_explicit_errors(direct_module, monkeypatch):
         with pytest.raises(AssertionError, match=error):
             direct_module.get_named_update_units([param.name for param in params], groups)
 
-    # A group with no matching params is skipped, not an error (e.g. a PP rank
-    # holding no layer needing it); the params are still returned as ungrouped units.
-    units = direct_module.get_named_update_units(
-        [param.name for param in params], [AtomicUpdateGroup("missing", (".c",))]
+
+def test_deepseekv4_atomic_group_skipped_when_layer_has_no_indexer(direct_module):
+    from miles.backends.megatron_utils.update_weight.common import get_atomic_update_groups
+
+    # A dense (non-DSA-indexer) layer's params -- no ".self_attention.indexer.*" names,
+    # since the indexer is only present on some layers (see --use-indexer-replay help).
+    param_names = [
+        "module.module.decoder.layers.0.input_layernorm.weight",
+        "module.module.decoder.layers.0.self_attention.wq_a.weight",
+        "module.module.decoder.layers.0.self_attention.wkv.weight",
+        "module.module.decoder.layers.0.self_attention.compressor.wkv.weight",
+        "module.module.decoder.layers.0.self_attention.compressor.wgate.weight",
+    ]
+
+    update_units = direct_module.get_named_update_units(
+        param_names, get_atomic_update_groups(Namespace(q_lora_rank=1024), "deepseekv4")
     )
-    assert {unit.names for unit in units} == {(param.name,) for param in params}
+
+    assert [unit.names for unit in update_units] == [
+        ("module.module.decoder.layers.0.input_layernorm.weight",),
+        (
+            "module.module.decoder.layers.0.self_attention.wq_a.weight",
+            "module.module.decoder.layers.0.self_attention.wkv.weight",
+        ),
+        (
+            "module.module.decoder.layers.0.self_attention.compressor.wkv.weight",
+            "module.module.decoder.layers.0.self_attention.compressor.wgate.weight",
+        ),
+    ]
 
 
 def _tensor(size: int) -> torch.Tensor:

--- a/tests/fast/backends/megatron_utils/test_hf_weight_iterator_direct.py
+++ b/tests/fast/backends/megatron_utils/test_hf_weight_iterator_direct.py
@@ -161,7 +161,6 @@ def test_atomic_group_specs_raise_explicit_errors(direct_module, monkeypatch):
 
     invalid_groups = [
         ([AtomicUpdateGroup("empty", ())], "Atomic update group empty has no suffixes"),
-        ([AtomicUpdateGroup("missing", (".c",))], "Atomic update group missing references no params"),
         (
             [AtomicUpdateGroup("left", (".a",)), AtomicUpdateGroup("right", (".a",))],
             "Param layer.a matches multiple atomic update groups",
@@ -175,6 +174,13 @@ def test_atomic_group_specs_raise_explicit_errors(direct_module, monkeypatch):
     for groups, error in invalid_groups:
         with pytest.raises(AssertionError, match=error):
             direct_module.get_named_update_units([param.name for param in params], groups)
+
+    # A group with no matching params is skipped, not an error (e.g. a PP rank
+    # holding no layer needing it); the params are still returned as ungrouped units.
+    units = direct_module.get_named_update_units(
+        [param.name for param in params], [AtomicUpdateGroup("missing", (".c",))]
+    )
+    assert {unit.names for unit in units} == {(param.name,) for param in params}
 
 
 def _tensor(size: int) -> torch.Tensor:


### PR DESCRIPTION
## Summary
Shared experts (`.shared_experts.`) are replicated across expert-parallel ranks, not routed/sharded like regular experts, but every `.experts.` substring check in the weight-sync path treated them identically:

- `all_gather_param`/`all_gather_params_async` used the expert-TP group (`etp`) instead of the regular TP group to reassemble them — wrong tensors whenever `etp_size != tp_size`.
- `_get_megatron_full_params` broadcasts them over the EP group using `info.src_rank`, which is only valid for actually EP-sharded params. For a replicated shared-expert param this can point at a rank outside the group, **deadlocking the broadcast**.

Also:
- Skip the all-gather entirely when the resolved `tp_size` is 1 — a no-op gather that can deadlock when interleaved with the EP broadcast above.
- Relax an atomic-update-group `assert` to a skip: a given PP rank legitimately may hold no layer needing a particular group (previously this hard-failed).
