### PR TITLE
rollout: use router base_url for direct worker HTTP calls

### DIFF
--- a/miles/rollout/inference_rollout/inference_rollout_train.py
+++ b/miles/rollout/inference_rollout/inference_rollout_train.py
@@ -57,7 +57,7 @@ async def get_worker_urls(args: Namespace):
         return response["urls"]
     else:
         response = await get(f"http://{args.sglang_router_ip}:{args.sglang_router_port}/workers")
-        return [worker["url"] for worker in response["workers"]]
+        return list(dict.fromkeys(worker.get("base_url", worker["url"]) for worker in response["workers"]))
 
 
 def submit_generate_tasks(state: GenerateState, samples: list[list[Sample]]):

--- a/miles/rollout/sglang_rollout.py
+++ b/miles/rollout/sglang_rollout.py
@@ -353,7 +353,7 @@ async def abort(args: Namespace, rollout_id: int) -> list[list[Sample]]:
         urls = response["urls"]
     else:
         response = await get(f"http://{args.sglang_router_ip}:{args.sglang_router_port}/workers")
-        urls = [worker["url"] for worker in response["workers"]]
+        urls = list(dict.fromkeys(worker.get("base_url", worker["url"]) for worker in response["workers"]))
 
     logger.info(f"Abort request for {urls}")
     abort_tasks = [post(f"{url}/abort_request", {"abort_all": True}) for url in urls]


### PR DESCRIPTION
## Summary
- The sgl-router `/workers` endpoint reports `url` as a worker's logical identity, which carries an `@rank` suffix for DP-aware workers (registered via `--router-dp-aware`) and is not a dispatchable network address.
- `abort()` (sglang_rollout.py) and `get_worker_urls()` (inference_rollout_train.py) both read `worker["url"]` directly and POST to it, which breaks under DP-aware routing (`http://host:port@0/abort_request` fails to connect).
- Switch both to `worker.get("base_url", worker["url"])` — `base_url` is the real dispatchable address, shared by every DP rank of one physical server. Falls back to `url` against routers too old to report `base_url`. Dedupe via `dict.fromkeys` so multiple ranks sharing one `base_url` don't get hit once per rank (e.g. `abort_request` firing N times against the same server).
- Companion fix on the router side: radixark/sgl-router-for-miles#9 (adds the `base_url`/`dp_rank` fields this depends on).

## Test plan
- [x] Verified end-to-end on 8xH200 with `--router-dp-aware` forced on (Qwen3-30B-A3B-5layer, PD disaggregation + DP-attention, dp_size=2): no connection errors, `abort_request` calls deduped correctly, full training run succeeded with real update_weights cycles.