### PR TITLE
refactor(tito): rename render_messages to apply_chat_template

### DIFF
--- a/miles/rollout/session/linear_trajectory.py
+++ b/miles/rollout/session/linear_trajectory.py
@@ -62,7 +62,7 @@ class LinearTrajectory:
         Must be called under ``self.lock``.
         """
         if not self.token_ids:
-            return tito_tokenizer.render_messages(
+            return tito_tokenizer.apply_chat_template(
                 request_messages,
                 tools=tools,
                 add_generation_prompt=True,
@@ -273,7 +273,7 @@ class SessionRegistry:
             return None
         try:
             tools = session.records[-1].request.get("tools") if session.records else None
-            expected_ids = self.tito_tokenizer.render_messages(
+            expected_ids = self.tito_tokenizer.apply_chat_template(
                 session.messages,
                 tools=tools,
                 add_generation_prompt=False,

--- a/miles/utils/chat_template_utils/tito_tokenizer.py
+++ b/miles/utils/chat_template_utils/tito_tokenizer.py
@@ -24,8 +24,8 @@ except ImportError:
 from pathlib import Path
 from typing import Any
 
-from miles.utils.chat_template_utils import deepseek
-from miles.utils.chat_template_utils.template import apply_chat_template, assert_messages_append_only_with_allowed_role
+from miles.utils.chat_template_utils import deepseek, template
+from miles.utils.chat_template_utils.template import assert_messages_append_only_with_allowed_role
 from miles.utils.chat_template_utils.token_seq_comparator import TokenSeqComparator
 
 logger = logging.getLogger(__name__)
@@ -111,7 +111,7 @@ class TITOTokenizer:
             trim_trailing_ids=self.trailing_token_ids or None,
         )
 
-    def render_messages(
+    def apply_chat_template(
         self,
         messages: list[dict[str, Any]],
         *,
@@ -119,7 +119,7 @@ class TITOTokenizer:
         tools: list[dict[str, Any]] | None = None,
         tokenize: bool = False,
     ) -> str | list[int]:
-        return apply_chat_template(
+        return template.apply_chat_template(
             messages,
             tokenizer=self.tokenizer,
             tokenize=tokenize,
@@ -145,8 +145,8 @@ class TITOTokenizer:
         When *add_generation_prompt* is True and *appended_messages* is empty,
         this computes the generation-prompt suffix (the assistant opener tokens).
         """
-        text_without = self.render_messages(base_messages, add_generation_prompt=False, tools=tools)
-        text_with = self.render_messages(
+        text_without = self.apply_chat_template(base_messages, add_generation_prompt=False, tools=tools)
+        text_with = self.apply_chat_template(
             base_messages + appended_messages,
             add_generation_prompt=add_generation_prompt,
             tools=tools,
@@ -762,8 +762,8 @@ class DeepSeekV4TITOTokenizer(TITOTokenizer):
     ) -> list[int]:
         """Diff real-history renders because V4 folds adjacent ``tool``/``user`` turns."""
         assert_messages_append_only_with_allowed_role(old_messages, new_messages, self.allowed_append_roles)
-        text_old = self.render_messages(old_messages, add_generation_prompt=False, tools=tools)
-        text_new = self.render_messages(new_messages, add_generation_prompt=True, tools=tools)
+        text_old = self.apply_chat_template(old_messages, add_generation_prompt=False, tools=tools)
+        text_new = self.apply_chat_template(new_messages, add_generation_prompt=True, tools=tools)
         if not text_new.startswith(text_old):
             raise ValueError(
                 "deepseek_v4 render is not append-only for the appended messages "
@@ -836,7 +836,7 @@ def get_tito_tokenizer(
         tokenizer: HuggingFace tokenizer object.
         tokenizer_type: Explicit type (string or enum).  Corresponds to the
             ``--tito-model`` CLI argument.
-        chat_template_kwargs: Extra kwargs forwarded to ``apply_chat_template``.
+        chat_template_kwargs: Extra kwargs forwarded to ``template.apply_chat_template``.
         assistant_start_str: Decoded text prefix identifying assistant content
             segments (e.g. ``"<|im_start|>assistant"``).  Auto-detected from
             the chat template by default; pass explicitly to override.
@@ -874,7 +874,7 @@ def resolve_fixed_chat_template(
       when the matched row registers HF-native (kwargs-only fix) or when no
       row matches at all.
     - ``extra_kwargs``: kwargs the caller should merge into
-      ``apply_chat_template`` (caller's explicit user kwargs win on conflict).
+      ``template.apply_chat_template`` (caller's explicit user kwargs win on conflict).
       Empty when no row matches or the matched row needs none.
 
     Raises ``ValueError`` on equally-minimal supersets — register a stricter

--- a/miles/utils/chat_template_utils/tito_tokenizer.py
+++ b/miles/utils/chat_template_utils/tito_tokenizer.py
@@ -5,16 +5,10 @@
 assistant's generated token sequence, then merges them with the pretokenized
 prefix — handling model-specific boundary tokens at the junction.
 
-The default implementation incrementally tokenizes appended non-assistant turns
-with role-specific synthetic prefixes:
-
-- contiguous ``tool`` runs use ``[dummy_system, dummy_assistant]``
-- each ``user`` or ``system`` message uses ``[dummy_system]``
-
-The appended suffix is processed left-to-right, then the generation prompt for
-the next assistant turn is appended once at the end.  Model-specific
-subclasses only override ``merge_tokens`` for boundary quirks at the prefix
-junction.
+The default implementation renders the complete appended non-assistant suffix
+and the next generation prompt once under a synthetic
+``[dummy_system, dummy_assistant]`` prefix.  Model-specific subclasses only
+override ``merge_tokens`` for boundary quirks at the prefix junction.
 """
 
 from __future__ import annotations
@@ -61,24 +55,13 @@ class FixedTemplateRow:
     extra_kwargs: dict[str, Any] = field(default_factory=dict)
 
 
-def _build_dummy_assistant(tool_responses: list[dict[str, Any]]) -> dict[str, Any]:
-    """Build a dummy assistant message with tool_calls matching *tool_responses*,
-    so the template correctly renders the subsequent tool-response turn boundaries."""
+def _build_dummy_assistant(stored_assistant: dict[str, Any]) -> dict[str, Any]:
+    """Build a dummy assistant that preserves the stored turn's tool calls."""
     return {
         "role": "assistant",
         "content": "",
         "reasoning_content": " ",
-        "tool_calls": [
-            {
-                "id": resp.get("tool_call_id") or f"call0000{i}",
-                "type": "function",
-                "function": {
-                    "name": resp.get("name") or "dummy_func",
-                    "arguments": {},
-                },
-            }
-            for i, resp in enumerate(tool_responses)
-        ],
+        "tool_calls": stored_assistant.get("tool_calls") or [],
     }
 
 
@@ -148,28 +131,6 @@ class TITOTokenizer:
     def _encode_text(self, text: str) -> list[int]:
         return self.tokenizer.encode(text, add_special_tokens=False)
 
-    def _split_appended_segments(self, appended_messages: list[dict[str, Any]]) -> list[list[dict[str, Any]]]:
-        segments: list[list[dict[str, Any]]] = []
-        i = 0
-        while i < len(appended_messages):
-            role = appended_messages[i]["role"]
-            # Many templates wrap a contiguous tool-response run as one logical
-            # block, so tool messages are diffed together instead of one-by-one.
-            if role == "tool":
-                j = i + 1
-                while j < len(appended_messages) and appended_messages[j]["role"] == "tool":
-                    j += 1
-                segments.append(appended_messages[i:j])
-                i = j
-                continue
-            if role in {"user", "system"}:
-                segments.append([appended_messages[i]])
-                i += 1
-                continue
-            raise ValueError(f"unsupported appended role for TITO segmentation: {role}")
-
-        return segments
-
     def _tokenize_rendered_suffix(
         self,
         base_messages: list[dict[str, Any]],
@@ -194,30 +155,6 @@ class TITOTokenizer:
             roles = [msg["role"] for msg in appended_messages] if appended_messages else ["generation_prompt"]
             raise ValueError(f"rendered suffix diff failed for {roles}")
         return self._encode_text(text_with[len(text_without) :])
-
-    def _tokenize_tool_segment(
-        self,
-        appended_messages: list[dict[str, Any]],
-        tools: list[dict[str, Any]] | None = None,
-    ) -> list[int]:
-        # No dummy user to avoid cut think issues.
-        return self._tokenize_rendered_suffix(
-            [_DUMMY_SYSTEM, _build_dummy_assistant(appended_messages)],
-            appended_messages,
-            tools=tools,
-        )
-
-    def _tokenize_user_and_system_segment(
-        self,
-        appended_message: dict[str, Any],
-        tools: list[dict[str, Any]] | None = None,
-    ) -> list[int]:
-        # User/system single-message appends share one synthetic context.
-        return self._tokenize_rendered_suffix(
-            [_DUMMY_SYSTEM],
-            [appended_message],
-            tools=tools,
-        )
 
     def tokenize_additional_non_assistant(
         self,
@@ -246,25 +183,9 @@ class TITOTokenizer:
         """
         assert_messages_append_only_with_allowed_role(old_messages, new_messages, self.allowed_append_roles)
         appended_messages = new_messages[len(old_messages) :]
-        incremental: list[int] = []
-
-        # Incremental non-assistant content is assembled segment-by-segment
-        # using the smallest synthetic context that preserves each role's
-        # boundary tokens.
-        for segment in self._split_appended_segments(appended_messages):
-            role = segment[0]["role"]
-            if role == "tool":
-                incremental.extend(self._tokenize_tool_segment(segment, tools))
-            elif role == "user" or role == "system":
-                incremental.extend(self._tokenize_user_and_system_segment(segment[0], tools))
-            else:
-                raise ValueError(f"unsupported appended role for TITO tokenization: {role}")
-
-        # The next assistant opener depends on the full post-append history, so
-        # it is derived from the real messages once and appended only at the end.
-        return incremental + self._tokenize_rendered_suffix(
-            new_messages,
-            [],
+        return self._tokenize_rendered_suffix(
+            [_DUMMY_SYSTEM, _build_dummy_assistant(old_messages[-1])],
+            appended_messages,
             tools=tools,
             add_generation_prompt=True,
         )

--- a/miles/utils/test_utils/chat_template_verify.py
+++ b/miles/utils/test_utils/chat_template_verify.py
@@ -456,12 +456,12 @@ def verify_append_only_via_tito_instance(
         prefix_msgs = deepcopy(messages[:n])
         full_msgs = deepcopy(messages[:m])
 
-        prefix_text = tito.render_messages(
+        prefix_text = tito.apply_chat_template(
             prefix_msgs,
             tools=tools,
             add_generation_prompt=False,
         )
-        full_text = tito.render_messages(
+        full_text = tito.apply_chat_template(
             full_msgs,
             tools=tools,
             add_generation_prompt=True,

--- a/miles/utils/test_utils/chat_template_verify.py
+++ b/miles/utils/test_utils/chat_template_verify.py
@@ -407,8 +407,8 @@ def run_all_checks(
 # layer.  This is necessary but not sufficient for production correctness —
 # production runs ``get_tito_tokenizer(...)`` and exercises ``merge_tokens``
 # (model-specific token-level boundary patches) plus
-# ``tokenize_additional_non_assistant`` (renders appended segments under a
-# synthetic ``[_DUMMY_SYSTEM, ...]`` context, not the real history).
+# ``tokenize_additional_non_assistant`` (renders the complete appendix under a
+# synthetic ``[_DUMMY_SYSTEM, dummy_assistant]`` context, not the real history).
 #
 # The primitive below mirrors the production path: it instantiates the actual
 # TITO subclass + HF tokenizer, runs ``merge_tokens`` against the encoded
@@ -520,7 +520,7 @@ def verify_append_only_via_tito(
 
     Matches the production wiring at ``miles/rollout/session/sessions.py:35`` —
     the same ``get_tito_tokenizer`` factory call, with ``chat_template_kwargs``
-    threaded through so ``merge_tokens`` and the dummy-context segment renders
+    threaded through so ``merge_tokens`` and the dummy-context appendix render
     use the same kwargs as the reference full render.
     """
     from miles.utils.chat_template_utils import get_tito_tokenizer
@@ -554,7 +554,7 @@ def run_all_checks_via_tito(
 
     Per-case TITO rebuild: each (case, ``enable_thinking`` variant) gets a fresh
     TITO instance constructed with the merged kwargs, so the dummy-context
-    segment renders inside ``tokenize_additional_non_assistant`` see the same
+    appendix render inside ``tokenize_additional_non_assistant`` sees the same
     ``enable_thinking`` value as the reference render.  Construction is
     millisecond-level and runs ~50 times per CLI invocation; cheap.
 

--- a/tests/fast/rollout/generate_hub/test_multi_turn.py
+++ b/tests/fast/rollout/generate_hub/test_multi_turn.py
@@ -575,13 +575,13 @@ class TestRoutedExpertsMultiTurn:
                 tokenizer_type=TITOTokenizerType.QWEN3,
                 allowed_append_roles=["tool"],
             )
-            first_prompt_token_ids = tito.render_messages(
+            first_prompt_token_ids = tito.apply_chat_template(
                 S.OPENAI_MESSAGES_FIRST_TURN,
                 tools=SAMPLE_TOOLS,
                 add_generation_prompt=True,
                 tokenize=True,
             )
-            second_prompt_token_ids = tito.render_messages(
+            second_prompt_token_ids = tito.apply_chat_template(
                 S.OPENAI_MESSAGES_SECOND_TURN_FROM_CLIENT,
                 tools=SAMPLE_TOOLS,
                 add_generation_prompt=True,

--- a/tests/fast/router/test_linear_trajectory.py
+++ b/tests/fast/router/test_linear_trajectory.py
@@ -28,7 +28,7 @@ class _MockTITOTokenizer(TITOTokenizer):
     def create_comparator(self):
         return None
 
-    def render_messages(
+    def apply_chat_template(
         self,
         messages: list[dict[str, Any]],
         *,
@@ -676,7 +676,7 @@ class TestComputeSessionMismatch:
         session.update_pretokenized_state([SYS_MSG, USER_MSG], ASSISTANT_MSG_1, [1, 2, 3], [10, 11], max_trim_tokens=0)
 
         # Simulate: template returns same IDs as stored
-        registry.tito_tokenizer.render_messages = MagicMock(return_value=[1, 2, 3, 10, 11])
+        registry.tito_tokenizer.apply_chat_template = MagicMock(return_value=[1, 2, 3, 10, 11])
 
         # Need a real comparator; replace the None one
         mock_comparator = MagicMock()
@@ -686,7 +686,7 @@ class TestComputeSessionMismatch:
         result = registry.compute_session_mismatch(session)
         assert result == []
         mock_comparator.compare_sequences.assert_called_once_with([1, 2, 3, 10, 11], [1, 2, 3, 10, 11])
-        registry.tito_tokenizer.render_messages.assert_called_once_with(
+        registry.tito_tokenizer.apply_chat_template.assert_called_once_with(
             session.messages,
             tools=None,
             add_generation_prompt=False,
@@ -698,7 +698,7 @@ class TestComputeSessionMismatch:
         session = registry.get_session(sid)
         session.update_pretokenized_state([SYS_MSG, USER_MSG], ASSISTANT_MSG_1, [1, 2, 3], [10, 11], max_trim_tokens=0)
 
-        registry.tito_tokenizer.render_messages = MagicMock(return_value=[1, 2, 99, 10, 11])
+        registry.tito_tokenizer.apply_chat_template = MagicMock(return_value=[1, 2, 99, 10, 11])
 
         @dataclass
         class FakeMismatch:
@@ -719,7 +719,7 @@ class TestComputeSessionMismatch:
         session = registry.get_session(sid)
         session.update_pretokenized_state([SYS_MSG, USER_MSG], ASSISTANT_MSG_1, [1, 2, 3], [10, 11], max_trim_tokens=0)
 
-        registry.tito_tokenizer.render_messages = MagicMock(side_effect=RuntimeError("tokenizer failed"))
+        registry.tito_tokenizer.apply_chat_template = MagicMock(side_effect=RuntimeError("tokenizer failed"))
 
         with pytest.raises(TokenizationError, match="tokenizer failed"):
             registry.compute_session_mismatch(session)
@@ -741,7 +741,7 @@ class TestComputeSessionMismatch:
         session.append_record(record)
 
         mock_tokenize = MagicMock(return_value=[1, 2, 10])
-        registry.tito_tokenizer.render_messages = mock_tokenize
+        registry.tito_tokenizer.apply_chat_template = mock_tokenize
         mock_comparator = MagicMock()
         mock_comparator.compare_sequences.return_value = []
         registry.comparator = mock_comparator

--- a/tests/fast/utils/chat_template_utils/test_template.py
+++ b/tests/fast/utils/chat_template_utils/test_template.py
@@ -400,7 +400,7 @@ class TestDeepSeekV32TITOAlignWithSGLang:
     V3.2 ships no jinja chat_template; the ``DEEPSEEKV32`` TITO family rides
     miles' ``apply_chat_template`` -> ``chat_template_utils.deepseek`` bridge,
     which mirrors sglang's ``chat_encoding_spec == "dsv32"`` branch.  These pin
-    that ``get_tito_tokenizer(...).render_messages`` produces identical
+    that ``get_tito_tokenizer(...).apply_chat_template`` produces identical
     prompt_ids to sglang for the tool surface actually used in training, with
     thinking on/off.  ``thinking`` is the sglang request knob; ``enable_thinking``
     is the equivalent miles chat-template kwarg — both map to the encoder's
@@ -433,7 +433,7 @@ class TestDeepSeekV32TITOAlignWithSGLang:
             tokenizer_type=TITOTokenizerType.DEEPSEEKV32,
             chat_template_kwargs={"enable_thinking": thinking},
         )
-        actual = tito.render_messages(messages, add_generation_prompt=True, tools=self._TOOLS, tokenize=True)
+        actual = tito.apply_chat_template(messages, add_generation_prompt=True, tools=self._TOOLS, tokenize=True)
         assert actual == expected
 
     def test_absent_enable_thinking_defaults_to_thinking(self):
@@ -448,7 +448,7 @@ class TestDeepSeekV32TITOAlignWithSGLang:
             tokenizer_type=TITOTokenizerType.DEEPSEEKV32,
             chat_template_kwargs={},
         )
-        actual = tito.render_messages(messages, add_generation_prompt=True, tools=self._TOOLS, tokenize=True)
+        actual = tito.apply_chat_template(messages, add_generation_prompt=True, tools=self._TOOLS, tokenize=True)
         assert actual == expected
 
     @pytest.mark.parametrize("thinking", [False, True], ids=["chat", "thinking"])
@@ -476,7 +476,7 @@ class TestDeepSeekV32TITOAlignWithSGLang:
             tokenizer_type=TITOTokenizerType.DEEPSEEKV32,
             chat_template_kwargs={"enable_thinking": thinking},
         )
-        actual = tito.render_messages(messages, add_generation_prompt=True, tools=self._TOOLS, tokenize=True)
+        actual = tito.apply_chat_template(messages, add_generation_prompt=True, tools=self._TOOLS, tokenize=True)
         assert actual == expected
 
 
@@ -510,7 +510,7 @@ class TestDeepSeekV4TITOAlignWithSGLang:
             chat_template_kwargs={"enable_thinking": thinking},
         )
 
-        actual = tito.render_messages(messages, add_generation_prompt=True, tools=tools, tokenize=True)
+        actual = tito.apply_chat_template(messages, add_generation_prompt=True, tools=tools, tokenize=True)
         assert actual == expected
 
     @pytest.mark.parametrize("thinking", [False, True], ids=["chat", "thinking"])
@@ -557,5 +557,5 @@ class TestDeepSeekV4TITOAlignWithSGLang:
             chat_template_kwargs={"enable_thinking": thinking},
         )
 
-        actual = tito.render_messages(messages, add_generation_prompt=True, tools=tools, tokenize=True)
+        actual = tito.apply_chat_template(messages, add_generation_prompt=True, tools=tools, tokenize=True)
         assert actual == expected

--- a/tests/fast/utils/chat_template_utils/test_tito_tokenizer.py
+++ b/tests/fast/utils/chat_template_utils/test_tito_tokenizer.py
@@ -26,26 +26,25 @@ TestMergeTokensBoundary
     - Default: plain concatenation (no boundary handling).
 
 TestTokenizeAdditional
-    Behavioral tests for tokenize_additional_non_assistant — the role-segmented
-    synthetic-prefix diff that computes incremental token IDs for appended
-    non-assistant messages.
+    Behavioral tests for tokenize_additional_non_assistant — the single
+    synthetic-prefix diff that computes incremental token IDs for the complete
+    appended non-assistant suffix.
 
     ``test_produces_nonempty_incremental`` is parametrized over:
       _TOOL_TRAJECTORIES (trajectory classes) × _TITO_MODELS (qwen3, glm47)
     Split points are auto-detected by _find_tito_splits from message structure,
     so adding a trajectory to _TOOL_TRAJECTORIES automatically extends coverage.
 
-    Remaining tests cover segmentation logic, generation-prompt timing,
-    reasoning-content shape, merge structure preservation, and append-only
-    validation (reject prefix mutation, fewer messages, or forbidden roles).
+    Remaining tests cover complete-appendix rendering, generation-prompt
+    timing, stored tool-call preservation, merge structure preservation, and
+    append-only validation (reject prefix mutation, fewer messages, or
+    forbidden roles).
 
 TestFactory
     get_tito_tokenizer factory: string/enum dispatch, invalid input handling.
 """
 
 from __future__ import annotations
-
-from pathlib import Path
 
 import pytest
 from transformers import AutoTokenizer
@@ -111,13 +110,18 @@ _ALLOWED_APPEND_ROLES = ["tool", "user", "system"]
 @pytest.fixture(params=list(_TITO_MODELS.keys()))
 def tito(request) -> TITOTokenizer:
     model_id, cls, tito_type = _TITO_MODELS[request.param]
-    return cls(_get_tokenizer(model_id, tito_type), allowed_append_roles=_ALLOWED_APPEND_ROLES)
+    return cls(
+        _get_tokenizer(model_id, tito_type),
+        chat_template_kwargs={"clear_thinking": False},
+        allowed_append_roles=_ALLOWED_APPEND_ROLES,
+    )
 
 
 @pytest.fixture
 def qwen3_tito() -> Qwen3TITOTokenizer:
     return Qwen3TITOTokenizer(
         _get_tokenizer("Qwen/Qwen3-4B", TITOTokenizerType.QWEN3),
+        chat_template_kwargs={"clear_thinking": False},
         allowed_append_roles=_ALLOWED_APPEND_ROLES,
     )
 
@@ -126,6 +130,7 @@ def qwen3_tito() -> Qwen3TITOTokenizer:
 def glm47_tito() -> GLM47TITOTokenizer:
     return GLM47TITOTokenizer(
         _get_tokenizer("zai-org/GLM-4.7-Flash", TITOTokenizerType.GLM47),
+        chat_template_kwargs={"clear_thinking": False},
         allowed_append_roles=_ALLOWED_APPEND_ROLES,
     )
 
@@ -296,7 +301,7 @@ class TestMergeTokensBoundary:
 
 
 # ---------------------------------------------------------------------------
-# TestTokenizeAdditional — incremental tokenization via role-segmented synthetic diff
+# TestTokenizeAdditional — one synthetic diff for the complete appended suffix
 #
 # test_produces_nonempty_incremental is the scalable core: parametrized over
 # _TRAJ_CASES (trajectories × split points) × tito fixture (models).
@@ -321,35 +326,39 @@ class TestTokenizeAdditional:
         incremental = tito.tokenize_additional_non_assistant(old_msgs, new_msgs, tools)
         assert len(incremental) > 0
 
-    def test_contiguous_tool_segment_is_tokenized_together(self, qwen3_tito: Qwen3TITOTokenizer):
-        old_msgs, new_msgs, tools = _split_at(MultiToolSingleTurnTrajectory, 3)
-        appended = new_msgs[len(old_msgs) :]
-
-        segments = qwen3_tito._split_appended_segments(appended)
-        assert len(segments) == 1
-        assert [msg["role"] for msg in segments[0]] == ["tool", "tool"]
-
-        incremental = qwen3_tito.tokenize_additional_non_assistant(old_msgs, new_msgs, tools)
-        decoded = qwen3_tito.tokenizer.decode(incremental)
-        assert MultiToolSingleTurnTrajectory.MESSAGES[3]["content"] in decoded
-        assert MultiToolSingleTurnTrajectory.MESSAGES[4]["content"] in decoded
-
-    def test_user_and_system_segments_are_singletons(self, default_tito: TITOTokenizer):
+    def test_complete_appendix_reaches_renderer_and_its_error_propagates(
+        self, qwen3_tito: Qwen3TITOTokenizer, monkeypatch
+    ):
+        old_msgs = list(SingleToolTrajectory.MESSAGES[:3])
         appended = [
-            {"role": "system", "content": "Use JSON."},
-            {"role": "user", "content": "Hello"},
-            {"role": "tool", "tool_call_id": "call_1", "content": '{"ok": true}'},
-            {"role": "tool", "tool_call_id": "call_2", "content": '{"ok": false}'},
-            {"role": "user", "content": "Try again"},
+            SingleToolTrajectory.MESSAGES[3],
+            {"role": "user", "content": "Try another route."},
+            {"role": "tool", "tool_call_id": "call_1", "content": '{"ok": false}'},
         ]
+        calls = []
 
-        segments = default_tito._split_appended_segments(appended)
-        assert [[msg["role"] for msg in segment] for segment in segments] == [
-            ["system"],
-            ["user"],
-            ["tool", "tool"],
-            ["user"],
-        ]
+        def reject_invalid_order(base_messages, appended_messages, *, tools=None, add_generation_prompt=False):
+            calls.append((base_messages, appended_messages, tools, add_generation_prompt))
+            if [message["role"] for message in appended_messages] == ["tool", "user", "tool"]:
+                raise ValueError("invalid tool ordering")
+            return [1]
+
+        monkeypatch.setattr(qwen3_tito, "_tokenize_rendered_suffix", reject_invalid_order)
+
+        with pytest.raises(ValueError, match="invalid tool ordering"):
+            qwen3_tito.tokenize_additional_non_assistant(
+                old_msgs,
+                old_msgs + appended,
+                SingleToolTrajectory.TOOLS,
+            )
+
+        assert len(calls) == 1
+        base_messages, rendered_appendix, tools, add_generation_prompt = calls[0]
+        assert [message["role"] for message in base_messages] == ["system", "assistant"]
+        assert base_messages[-1]["tool_calls"] == old_msgs[-1]["tool_calls"]
+        assert rendered_appendix == appended
+        assert tools == SingleToolTrajectory.TOOLS
+        assert add_generation_prompt is True
 
     def test_generation_prompt_is_appended_once_for_full_suffix(self, qwen3_tito: Qwen3TITOTokenizer):
         old_msgs = list(SingleToolThinkingTrajectory.MESSAGES[:3])
@@ -368,31 +377,14 @@ class TestTokenizeAdditional:
             )
         )
 
-    def test_qwen3_tool_dummy_assistant_preserves_reasoning_shape(self):
-        thinking_template_path = (
-            Path(__file__).resolve().parents[4]
-            / "miles/utils/chat_template_utils/templates/qwen3_thinking_2507_and_next_fixed.jinja"
-        )
-        thinking_tito = Qwen3TITOTokenizer(
-            load_tokenizer(
-                "Qwen/Qwen3-4B-Instruct-2507",
-                chat_template_path=str(thinking_template_path),
-                trust_remote_code=True,
-            ),
-            allowed_append_roles=_ALLOWED_APPEND_ROLES,
-        )
-        tool_messages = [SingleToolThinkingTrajectory.MESSAGES[3]]
-        dummy_assistant = _build_dummy_assistant(tool_messages)
-        rendered = thinking_tito.render_messages(
-            [{"role": "system", "content": "dummy system"}, dummy_assistant],
-            add_generation_prompt=False,
-            tools=SingleToolThinkingTrajectory.TOOLS,
-        )
+    def test_dummy_assistant_preserves_parallel_tool_calls(self):
+        stored_assistant = MultiToolSingleTurnTrajectory.MESSAGES[2]
+        dummy_assistant = _build_dummy_assistant(stored_assistant)
 
+        assert dummy_assistant["content"] == ""
         assert dummy_assistant["reasoning_content"] == " "
-        assert rendered.endswith(
-            '<|im_start|>assistant\n<tool_call>\n{"name": "dummy_func", "arguments": {}}\n</tool_call><|im_end|>\n'
-        )
+        assert dummy_assistant["tool_calls"] == stored_assistant["tool_calls"]
+        assert [call["id"] for call in dummy_assistant["tool_calls"]] == ["call_1", "call_2"]
 
     @pytest.mark.parametrize(
         "traj_cls, pos",

--- a/tests/manual/session/bench_session_server_overhead.py
+++ b/tests/manual/session/bench_session_server_overhead.py
@@ -154,8 +154,8 @@ def _completion_token_ids(
     assistant_message: dict[str, Any],
     tools: list[dict[str, Any]] | None,
 ):
-    prompt_text = tito_tokenizer.render_messages(messages, add_generation_prompt=True, tokenize=False, tools=tools)
-    full_text = tito_tokenizer.render_messages(
+    prompt_text = tito_tokenizer.apply_chat_template(messages, add_generation_prompt=True, tokenize=False, tools=tools)
+    full_text = tito_tokenizer.apply_chat_template(
         messages + [assistant_message],
         add_generation_prompt=False,
         tokenize=False,
@@ -237,7 +237,7 @@ def _build_turn_specs(
         request_messages = [dict(message) for message in history] + [input_message]
         tools = [BENCH_TOOL] if tool_appends else None
 
-        prompt_token_ids = tito_tokenizer.render_messages(
+        prompt_token_ids = tito_tokenizer.apply_chat_template(
             request_messages,
             add_generation_prompt=True,
             tokenize=True,


### PR DESCRIPTION
> **Depends on:** #1712
> Stacked on the parent PR's branch. Review / merge the parent first.

## Summary
Rename `TITOTokenizer.render_messages` to `apply_chat_template` across its callers.

## Motivation
`TITOTokenizer.render_messages` was a one-line delegate to the module-level `apply_chat_template` that only binds `self.tokenizer` plus `self.chat_template_kwargs`; having two names for the same rendering operation split the vocabulary between the method and the function it wraps. Matching the instance method to the module function and the Hugging Face tokenizer convention removes that split vocabulary while keeping rendering behavior unchanged.

## Before / After
- **Before / After:** `TITOTokenizer` callers used `render_messages`; they now use `apply_chat_template`.
- **What moved where:** The wrapper remains on `TITOTokenizer`, with its delegate qualified as `template.apply_chat_template`.

## Behavior Preservation
- **How we know:** Existing TITO, trajectory, template, generate-hub tests cover the renamed call sites.

## Verification
- **Existing test suite:** 21 GitHub checks passed on exact head commit `99eeac2ba74323c5cf3a8cbe9a96154f15ec5286`.

## Review Focus
- Scrutinize `TITOTokenizer.apply_chat_template` for delegation through `template.apply_chat_template` without recursion.
- Scrutinize the seven updated files for complete `render_messages` call-site migration.
