### PR TITLE
fix: preserve BSHD layout in PPO CP advantages

### DIFF
--- a/miles/backends/training_utils/loss.py
+++ b/miles/backends/training_utils/loss.py
@@ -73,6 +73,7 @@ def compute_advantages_and_returns(args: Namespace, rollout_data: RolloutBatch) 
         loss_masks=loss_masks,
         total_lengths=total_lengths,
         response_lengths=response_lengths,
+        max_seq_lens=max_seq_lens,
         values=values,
     )
 

--- a/miles/backends/training_utils/loss_hub/advantages.py
+++ b/miles/backends/training_utils/loss_hub/advantages.py
@@ -22,6 +22,7 @@ def compute_advantages(
     total_lengths: list[int],
     response_lengths: list[int],
     values: list[torch.Tensor] | None = None,
+    max_seq_lens: list[int] | None = None,
 ) -> tuple[list[torch.Tensor], list[torch.Tensor]]:
     """Dispatch to the configured advantage estimator.
 
@@ -30,6 +31,7 @@ def compute_advantages(
         `T_i`: Prompt-plus-response length of sample `i`, excluding BSHD padding.
         `R_i`: Full response length of sample `i` before CP splitting.
         `C_i`: Number of response-aligned positions of sample `i` stored on this CP rank; prompt and padding positions are excluded.
+        `P_i`: Padded sequence length of sample `i` used by BSHD CP splitting.
 
     Args:
         args: `Namespace`; no tensor shape.
@@ -40,6 +42,7 @@ def compute_advantages(
         total_lengths: List length `B`; `total_lengths[i] = T_i`.
         response_lengths: List length `B`; `response_lengths[i] = R_i`.
         values: `None` or list length `B`; `values[i]` has shape `[C_i]`. PPO requires this input.
+        max_seq_lens: `None` or list length `B`; `max_seq_lens[i] = P_i`. Required for BSHD with CP.
 
     `C_i = R_i` when CP size is 1. With CP size greater than 1, `0 <= C_i <= R_i`; `C_i` can be zero and can differ across ranks. THD partitions a sequence of length `T_i`, while BSHD partitions the padded maximum sequence length, so the two formats do not guarantee the same `C_i`.
 
@@ -66,6 +69,8 @@ def compute_advantages(
             values_list=values,
             rewards_list=token_rewards,
             terminal_rewards=terminal_rewards,
+            qkv_format=args.qkv_format,
+            max_seq_lens=max_seq_lens,
             gamma=args.gamma,
             lambd=args.lambd,
         )

--- a/miles/backends/training_utils/loss_hub/math_utils.py
+++ b/miles/backends/training_utils/loss_hub/math_utils.py
@@ -8,7 +8,11 @@ import torch
 import torch.distributed as dist
 import torch.nn.functional as F
 
-from miles.backends.training_utils.cp_utils import slice_loss_masks_for_local_cp
+from miles.backends.training_utils.cp_utils import (
+    all_gather_with_cp,
+    slice_log_prob_with_cp,
+    slice_loss_masks_for_local_cp,
+)
 from miles.backends.training_utils.parallel import get_parallel_state
 
 _LOG_RATIO_EXP_CLAMP = 20.0
@@ -474,8 +478,6 @@ def get_reinforce_plus_plus_returns(
 
         if cp_size > 1:
             # Step 1,2:Gather all chunks and token_offsets from all ranks and reconstruct the full response tensor by splitting and placing each part
-            from miles.backends.training_utils.cp_utils import all_gather_with_cp
-
             full_kl_response = all_gather_with_cp(local_kl_chunk, total_len, response_len)
         else:
             full_kl_response = local_kl_chunk
@@ -496,8 +498,6 @@ def get_reinforce_plus_plus_returns(
 
         # Step 4: Pick up the results corresponding to our local chunk's parts.
         if cp_size > 1:
-            from miles.backends.training_utils.cp_utils import slice_log_prob_with_cp
-
             local_returns_chunk = slice_log_prob_with_cp(returns_for_seq, total_len, response_len)
         else:
             local_returns_chunk = returns_for_seq
@@ -568,8 +568,6 @@ def get_advantages_and_returns(
 
     cp_size = get_parallel_state().cp.size
     if cp_size > 1:
-        from miles.backends.training_utils.cp_utils import all_gather_with_cp
-
         full_rewards = all_gather_with_cp(rewards, total_len, response_len)
         full_values = all_gather_with_cp(values, total_len, response_len)
     else:
@@ -588,8 +586,6 @@ def get_advantages_and_returns(
     full_returns = full_advantages + full_values
 
     if cp_size > 1:
-        from miles.backends.training_utils.cp_utils import slice_log_prob_with_cp
-
         advantages = slice_log_prob_with_cp(full_advantages, total_len, response_len)
         returns = slice_log_prob_with_cp(full_returns, total_len, response_len)
     else:
@@ -620,7 +616,7 @@ def get_advantages_and_returns_batch(
         values_list:       list[Tensor], each current-CP-rank tensor has shape [C_i]
         rewards_list:      list[Tensor], same shape as values_list
         terminal_rewards:  list[float], one scalar sequence reward per sample
-        qkv_format:        sequence layout used to split tensors across CP ranks
+        qkv_format:        str, sequence layout used to split tensors across CP ranks
         max_seq_lens:      list[int] of BSHD padded lengths, or None for THD
     Output:
         advantages_list:   list[Tensor], each current-CP-rank tensor has shape [C_i]
@@ -638,15 +634,13 @@ def get_advantages_and_returns_batch(
             assert max_seq_lens is not None, "max_seq_lens is required for BSHD with CP"
             assert B == len(max_seq_lens)
             max_seq_lens_per_sample = max_seq_lens
-        else:
+        else:  # qkv_format == "thd" or cp_size == 1
             max_seq_lens_per_sample = [None] * B
 
         device = values_list[0].device
         dtype = values_list[0].dtype
 
         if cp_size > 1:
-            from miles.backends.training_utils.cp_utils import all_gather_with_cp
-
             full_values_list = []
             full_rewards_list = []
 
@@ -700,8 +694,6 @@ def get_advantages_and_returns_batch(
         returns_list = []
 
         if cp_size > 1:
-            from miles.backends.training_utils.cp_utils import slice_log_prob_with_cp
-
             for total_len, resp_len, adv_row, ret_row, max_seq_len in zip(
                 total_lengths,
                 response_lengths,

--- a/miles/backends/training_utils/loss_hub/math_utils.py
+++ b/miles/backends/training_utils/loss_hub/math_utils.py
@@ -605,6 +605,8 @@ def get_advantages_and_returns_batch(
     values_list,
     rewards_list,
     terminal_rewards,
+    qkv_format,
+    max_seq_lens,
     gamma,
     lambd,
     chunked: bool = True,
@@ -618,6 +620,8 @@ def get_advantages_and_returns_batch(
         values_list:       list[Tensor], each current-CP-rank tensor has shape [C_i]
         rewards_list:      list[Tensor], same shape as values_list
         terminal_rewards:  list[float], one scalar sequence reward per sample
+        qkv_format:        sequence layout used to split tensors across CP ranks
+        max_seq_lens:      list[int] of BSHD padded lengths, or None for THD
     Output:
         advantages_list:   list[Tensor], each current-CP-rank tensor has shape [C_i]
         returns_list:      list[Tensor], same shape
@@ -630,6 +634,13 @@ def get_advantages_and_returns_batch(
         assert B == len(terminal_rewards)
 
         cp_size = get_parallel_state().cp.size
+        if cp_size > 1 and qkv_format == "bshd":
+            assert max_seq_lens is not None, "max_seq_lens is required for BSHD with CP"
+            assert B == len(max_seq_lens)
+            max_seq_lens_per_sample = max_seq_lens
+        else:
+            max_seq_lens_per_sample = [None] * B
+
         device = values_list[0].device
         dtype = values_list[0].dtype
 
@@ -639,11 +650,16 @@ def get_advantages_and_returns_batch(
             full_values_list = []
             full_rewards_list = []
 
-            for total_len, resp_len, v, r in zip(
-                total_lengths, response_lengths, values_list, rewards_list, strict=False
+            for total_len, resp_len, v, r, max_seq_len in zip(
+                total_lengths,
+                response_lengths,
+                values_list,
+                rewards_list,
+                max_seq_lens_per_sample,
+                strict=False,
             ):
-                full_v = all_gather_with_cp(v, total_len, resp_len)
-                full_r = all_gather_with_cp(r, total_len, resp_len)
+                full_v = all_gather_with_cp(v, total_len, resp_len, qkv_format=qkv_format, max_seq_len=max_seq_len)
+                full_r = all_gather_with_cp(r, total_len, resp_len, qkv_format=qkv_format, max_seq_len=max_seq_len)
                 full_values_list.append(full_v)
                 full_rewards_list.append(full_r)
 
@@ -686,18 +702,31 @@ def get_advantages_and_returns_batch(
         if cp_size > 1:
             from miles.backends.training_utils.cp_utils import slice_log_prob_with_cp
 
-            for total_len, resp_len, adv_row, ret_row in zip(
+            for total_len, resp_len, adv_row, ret_row, max_seq_len in zip(
                 total_lengths,
                 response_lengths,
                 full_advantages,
                 full_returns,
+                max_seq_lens_per_sample,
                 strict=False,
             ):
                 adv_full = adv_row  # shape = [resp_len_i padded to max_len]
                 ret_full = ret_row
 
-                adv_sliced = slice_log_prob_with_cp(adv_full[:resp_len], total_len, resp_len)
-                ret_sliced = slice_log_prob_with_cp(ret_full[:resp_len], total_len, resp_len)
+                adv_sliced = slice_log_prob_with_cp(
+                    adv_full[:resp_len],
+                    total_len,
+                    resp_len,
+                    qkv_format=qkv_format,
+                    max_token_len=max_seq_len,
+                )
+                ret_sliced = slice_log_prob_with_cp(
+                    ret_full[:resp_len],
+                    total_len,
+                    resp_len,
+                    qkv_format=qkv_format,
+                    max_token_len=max_seq_len,
+                )
 
                 advantages_list.append(adv_sliced)
                 returns_list.append(ret_sliced)

--- a/tests/fast/backends/training_utils/test_ppo_cp_advantages.py
+++ b/tests/fast/backends/training_utils/test_ppo_cp_advantages.py
@@ -5,6 +5,7 @@ import torch.distributed as dist
 from tests.fast.dist_utils import init_gloo, run_multiprocess
 
 from miles.backends.training_utils.cp_utils import all_gather_with_cp, slice_log_prob_with_cp
+from miles.backends.training_utils.loss import compute_advantages_and_returns
 from miles.backends.training_utils.loss_hub.advantages import compute_advantages
 from miles.backends.training_utils.parallel import GroupInfo, ParallelState, set_parallel_state
 
@@ -25,7 +26,7 @@ def _parallel_state(rank: int = 0, world_size: int = 1) -> ParallelState:
 
 
 def _run_ppo_case(rank: int, total_length: int, response_length: int, expected_local_sizes: list[int]) -> None:
-    args = Namespace(advantage_estimator="ppo", kl_coef=0.1, gamma=0.0, lambd=0.0)
+    args = Namespace(advantage_estimator="ppo", kl_coef=0.1, gamma=0.0, lambd=0.0, qkv_format="thd")
     full_kl = torch.arange(1, response_length + 1, dtype=torch.float32)
     full_values = torch.zeros(response_length)
 
@@ -42,6 +43,7 @@ def _run_ppo_case(rank: int, total_length: int, response_length: int, expected_l
         loss_masks=[torch.ones(response_length)],
         total_lengths=[total_length],
         response_lengths=[response_length],
+        max_seq_lens=None,
         values=[local_values],
     )
     cp_advantages = all_gather_with_cp(advantages[0], total_length, response_length)
@@ -56,6 +58,7 @@ def _run_ppo_case(rank: int, total_length: int, response_length: int, expected_l
         loss_masks=[torch.ones(response_length)],
         total_lengths=[total_length],
         response_lengths=[response_length],
+        max_seq_lens=None,
         values=[full_values],
     )
 
@@ -83,9 +86,99 @@ def _worker_empty_rank_zero(rank: int, world_size: int, port: int) -> None:
         dist.destroy_process_group()
 
 
+def _worker_bshd_layout_metadata(rank: int, world_size: int, port: int) -> None:
+    init_gloo(rank, world_size, port=port)
+    try:
+        args = Namespace(
+            advantage_estimator="ppo",
+            use_rollout_logprobs=False,
+            kl_coef=0.1,
+            kl_loss_type="k1",
+            gamma=0.0,
+            lambd=0.0,
+            qkv_format="bshd",
+            use_opd=False,
+            normalize_advantages=False,
+        )
+        total_lengths = [8, 11]
+        response_lengths = [5, 6]
+        max_seq_lens = [12, 12]
+        rewards = [10.0, 20.0]
+        full_log_probs = [
+            torch.arange(1, response_length + 1, dtype=torch.float32) for response_length in response_lengths
+        ]
+        full_ref_log_probs = [torch.zeros_like(log_probs) for log_probs in full_log_probs]
+        full_values = [torch.zeros_like(log_probs) for log_probs in full_log_probs]
+
+        set_parallel_state(_parallel_state(rank=rank, world_size=world_size))
+        local_log_probs = [
+            slice_log_prob_with_cp(log_probs, total_length, response_length, "bshd", max_seq_len)
+            for log_probs, total_length, response_length, max_seq_len in zip(
+                full_log_probs, total_lengths, response_lengths, max_seq_lens, strict=True
+            )
+        ]
+        local_ref_log_probs = [torch.zeros_like(log_probs) for log_probs in local_log_probs]
+        local_values = [torch.zeros_like(log_probs) for log_probs in local_log_probs]
+        expected_local_sizes = [[1, 1], [4, 5]][rank]
+        assert [tensor.numel() for tensor in local_log_probs] == expected_local_sizes
+
+        rollout_data = {
+            "log_probs": local_log_probs,
+            "ref_log_probs": local_ref_log_probs,
+            "rewards": rewards,
+            "values": local_values,
+            "response_lengths": response_lengths,
+            "loss_masks": [torch.ones(response_length) for response_length in response_lengths],
+            "total_lengths": total_lengths,
+            "max_seq_lens": max_seq_lens,
+        }
+        compute_advantages_and_returns(args, rollout_data)
+        cp_advantages = [
+            all_gather_with_cp(advantage, total_length, response_length, "bshd", max_seq_len)
+            for advantage, total_length, response_length, max_seq_len in zip(
+                rollout_data["advantages"], total_lengths, response_lengths, max_seq_lens, strict=True
+            )
+        ]
+        cp_returns = [
+            all_gather_with_cp(ret, total_length, response_length, "bshd", max_seq_len)
+            for ret, total_length, response_length, max_seq_len in zip(
+                rollout_data["returns"], total_lengths, response_lengths, max_seq_lens, strict=True
+            )
+        ]
+
+        set_parallel_state(_parallel_state())
+        baseline_data = {
+            "log_probs": [tensor.clone() for tensor in full_log_probs],
+            "ref_log_probs": [tensor.clone() for tensor in full_ref_log_probs],
+            "rewards": rewards,
+            "values": [tensor.clone() for tensor in full_values],
+            "response_lengths": response_lengths,
+            "loss_masks": [torch.ones(response_length) for response_length in response_lengths],
+            "total_lengths": total_lengths,
+            "max_seq_lens": max_seq_lens,
+        }
+        compute_advantages_and_returns(args, baseline_data)
+
+        for cp_advantage, cp_return, baseline_advantage, baseline_return in zip(
+            cp_advantages,
+            cp_returns,
+            baseline_data["advantages"],
+            baseline_data["returns"],
+            strict=True,
+        ):
+            torch.testing.assert_close(cp_advantage, baseline_advantage)
+            torch.testing.assert_close(cp_return, baseline_return)
+    finally:
+        dist.destroy_process_group()
+
+
 def test_ppo_terminal_reward_is_added_to_global_response_tail() -> None:
     run_multiprocess(_worker_tail_on_rank_one)
 
 
 def test_ppo_terminal_reward_handles_empty_rank_zero_shard() -> None:
     run_multiprocess(_worker_empty_rank_zero)
+
+
+def test_ppo_bshd_cp_uses_padded_layout_metadata() -> None:
+    run_multiprocess(_worker_bshd_layout_metadata)


### PR DESCRIPTION
## Summary

Preserve BSHD token ownership while computing PPO advantages with context parallelism.

## Symptom & Reproduction

- **Symptom:** BSHD PPO with CP > 1 returned response-aligned outputs in THD token order.
- **Reproduction:** `pytest -q -p no:cacheprovider tests/fast/backends/training_utils/test_ppo_cp_advantages.py::test_ppo_bshd_cp_uses_padded_layout_metadata`

## Root Cause

1. `compute_advantages` did not forward `qkv_format` or `max_seq_lens`.
2. `get_advantages_and_returns_batch` used THD defaults for gather and re-slice.

## Fix

Propagate `max_seq_lens` from rollout data and pair it with `args.qkv_format` throughout PPO GAE. Both CP gather and re-slice now call the existing layout-aware helpers with identical per-sample metadata, while THD and CP=1 keep their previous behavior.

## Verification

- **New / updated test:** `test_ppo_bshd_cp_uses_padded_layout_metadata` compares reconstructed CP=2 BSHD outputs with CP=1 baselines.
- **Existing test suite:** `tests/fast/backends/training_utils/test_ppo_cp_advantages.py` passes all three cases.

## Review Focus

- Scrutinize metadata propagation from `compute_advantages_and_returns` to `get_advantages_and_returns_batch`.
- Scrutinize per-sample `max_seq_lens` pairing in both CP gather and re-slice.
