### PR TITLE
fix(megatron): serialize Hugging Face metadata loads per node

### DIFF
--- a/miles/backends/megatron_utils/actor.py
+++ b/miles/backends/megatron_utils/actor.py
@@ -118,8 +118,8 @@ class MegatronTrainRayActor(TrainRayActor):
         self.prof = TrainProfiler(args)
 
         # read config and tokenizer serialized to prevent concurrent writing bug.
-        for i in range(dist.get_world_size()):
-            if i == dist.get_rank():
+        for i in range(args.num_gpus_per_node):
+            if i == dist.get_rank() % args.num_gpus_per_node:
                 self.hf_config = load_hf_config(args.hf_checkpoint)
                 self.tokenizer = load_tokenizer(
                     self.args.hf_checkpoint, chat_template_path=self.args.chat_template_path, trust_remote_code=True


### PR DESCRIPTION
## Summary

- limit serialized Hugging Face config/tokenizer loading to one wave per GPU position within a node
- allow matching rank positions on different nodes to load concurrently

## Why

The existing loop performs one metadata-loading wave per global rank. Trainer ranks are ordered contiguously by node and GPU, so `global_rank % num_gpus_per_node` remains unique within each node while allowing the same position on different nodes to run concurrently. This reduces startup serialization from world size to GPUs per node.

In a 64-rank, 8-node benchmark, metadata-loading critical-path time decreased from 118.39s to 28.12s (4.21x faster; 90.27s / 76.3% reduction). All 64 ranks completed one config and tokenizer load.

The existing global barrier after each wave is preserved. The optimization assumes the Hugging Face cache state being protected is node-local.

## Validation

- `pre-commit run --files miles/backends/megatron_utils/actor.py`
- `python -m py_compile miles/backends/megatron_utils/actor.py`
- 64-rank, 8-node baseline and optimized startup runs completed successfully