### PR TITLE
fix(opd): align response signals with context parallelism

### DIFF
--- a/miles/backends/training_utils/data.py
+++ b/miles/backends/training_utils/data.py
@@ -84,29 +84,31 @@ def get_rollout_data(
 
         rollout_data["max_seq_lens"] = [max_seq_len] * len(rollout_data["tokens"])
 
-    if "rollout_log_probs" in rollout_data:
-        rollout_logprob_dtype = _rollout_logprob_dtype(args)
-        rollout_data["rollout_log_probs"] = [
-            torch.tensor(
-                slice_log_prob_with_cp(
-                    log_prob,
-                    total_length,
-                    response_length,
-                    args.qkv_format,
-                    rollout_data["max_seq_lens"][i] if args.qkv_format == "bshd" else None,
-                ),
-                device=torch.cuda.current_device(),
-                dtype=rollout_logprob_dtype,
-            )
-            for i, (log_prob, total_length, response_length) in enumerate(
-                zip(
-                    rollout_data["rollout_log_probs"],
-                    rollout_data["total_lengths"],
-                    rollout_data["response_lengths"],
-                    strict=False,
+    # Full-response SGLang OPD fields share rollout CP slicing but retain float32 precision.
+    for key in ("rollout_log_probs", "teacher_log_probs", "opd_reverse_kl"):
+        if key in rollout_data:
+            dtype = _rollout_logprob_dtype(args) if key == "rollout_log_probs" else torch.float32
+            rollout_data[key] = [
+                torch.as_tensor(
+                    slice_log_prob_with_cp(
+                        value,
+                        total_length,
+                        response_length,
+                        args.qkv_format,
+                        rollout_data["max_seq_lens"][i] if args.qkv_format == "bshd" else None,
+                    ),
+                    device=torch.cuda.current_device(),
+                    dtype=dtype,
                 )
-            )
-        ]
+                for i, (value, total_length, response_length) in enumerate(
+                    zip(
+                        rollout_data[key],
+                        rollout_data["total_lengths"],
+                        rollout_data["response_lengths"],
+                        strict=False,
+                    )
+                )
+            ]
     if "rollout_routed_experts" in rollout_data:
         rollout_data["rollout_routed_experts"] = [torch.from_numpy(r) for r in rollout_data["rollout_routed_experts"]]
     if "rollout_indexer_topk" in rollout_data:

--- a/miles/backends/training_utils/mm_data.py
+++ b/miles/backends/training_utils/mm_data.py
@@ -171,7 +171,7 @@ def expand_multimodal_rollout_data_in_place(
         parallel_state = get_parallel_state()
         cp_size = parallel_state.cp.size
         if cp_size > 1 and qkv_format == "thd":
-            for key in ("rollout_log_probs", "teacher_log_probs"):
+            for key in ("rollout_log_probs", "teacher_log_probs", "opd_reverse_kl"):
                 values = rollout_data.get(key)
                 if not values:
                     continue

--- a/tests/fast/backends/training_utils/test_opd_cp_data.py
+++ b/tests/fast/backends/training_utils/test_opd_cp_data.py
@@ -1,0 +1,148 @@
+from argparse import Namespace
+
+import pytest
+import torch
+
+from miles.backends.training_utils import cp_utils
+from miles.backends.training_utils import data as data_utils
+from miles.backends.training_utils import mm_data
+from miles.backends.training_utils.loss_hub.opd import apply_opd_kl_to_advantages
+from miles.backends.training_utils.parallel import GroupInfo, ParallelState
+
+_ROLLOUT_LOG_PROBS = torch.tensor([-0.2, -1.3, -0.7, -2.1, -0.4, -3.2, -1.8])
+_OPD_VALUES = torch.tensor([0.1, 0.9, -0.3, 1.7, -1.1, 0.4, 2.3])
+
+
+def _parallel_state(*, cp_size: int, cp_rank: int = 0) -> ParallelState:
+    trivial_group = GroupInfo(rank=0, size=1, group=None)
+    return ParallelState(
+        intra_dp=trivial_group,
+        intra_dp_cp=GroupInfo(rank=cp_rank, size=cp_size, group=None),
+        cp=GroupInfo(rank=cp_rank, size=cp_size, group=None),
+        tp=trivial_group,
+        pp=trivial_group,
+        ep=trivial_group,
+        etp=trivial_group,
+        indep_dp=trivial_group,
+    )
+
+
+def _args(qkv_format: str) -> Namespace:
+    return Namespace(
+        enable_witness=False,
+        qkv_format=qkv_format,
+        data_pad_size_multiplier=16,
+        compress_ratios=[],
+        true_on_policy_mode=False,
+        bf16=False,
+        fp16=False,
+    )
+
+
+def _load_rollout_data(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    qkv_format: str,
+    cp_size: int,
+    cp_rank: int,
+    opd_key: str,
+) -> dict:
+    parallel_state = _parallel_state(cp_size=cp_size, cp_rank=cp_rank)
+    rollout_data = {
+        "tokens": [list(range(11))],
+        "loss_masks": [[1] * 7],
+        "total_lengths": [11],
+        "response_lengths": [7],
+        "rollout_log_probs": [_ROLLOUT_LOG_PROBS.tolist()],
+        opd_key: [_OPD_VALUES.clone()],
+    }
+
+    monkeypatch.setattr(data_utils, "process_rollout_data", lambda *args, **kwargs: rollout_data)
+    monkeypatch.setattr(data_utils, "get_parallel_state", lambda: parallel_state)
+    monkeypatch.setattr(cp_utils, "get_parallel_state", lambda: parallel_state)
+    monkeypatch.setattr(torch.cuda, "current_device", lambda: torch.device("cpu"))
+
+    return data_utils.get_rollout_data(_args(qkv_format), object())
+
+
+@pytest.mark.parametrize("opd_key", ["teacher_log_probs", "opd_reverse_kl"])
+@pytest.mark.parametrize(
+    ("qkv_format", "cp_size", "cp_rank", "expected_indices"),
+    [
+        ("thd", 1, 0, [0, 1, 2, 3, 4, 5, 6]),
+        ("thd", 2, 0, [6]),
+        ("thd", 2, 1, [0, 1, 2, 3, 4, 5]),
+        ("bshd", 2, 0, [0]),
+        ("bshd", 2, 1, [1, 2, 3, 4, 5, 6]),
+    ],
+)
+def test_sglang_opd_response_fields_follow_rollout_log_prob_cp_slice(
+    monkeypatch: pytest.MonkeyPatch,
+    opd_key: str,
+    qkv_format: str,
+    cp_size: int,
+    cp_rank: int,
+    expected_indices: list[int],
+) -> None:
+    rollout_data = _load_rollout_data(
+        monkeypatch,
+        qkv_format=qkv_format,
+        cp_size=cp_size,
+        cp_rank=cp_rank,
+        opd_key=opd_key,
+    )
+
+    expected_indices_tensor = torch.tensor(expected_indices)
+    torch.testing.assert_close(
+        rollout_data["rollout_log_probs"][0],
+        _ROLLOUT_LOG_PROBS[expected_indices_tensor],
+    )
+    torch.testing.assert_close(
+        rollout_data[opd_key][0],
+        _OPD_VALUES[expected_indices_tensor],
+    )
+    assert rollout_data[opd_key][0].dtype == torch.float32
+    assert rollout_data[opd_key][0].device.type == "cpu"
+
+    advantages = [torch.ones(len(expected_indices), dtype=torch.float32)]
+    student_log_probs = [rollout_data[opd_key][0] + 0.25]
+    apply_opd_kl_to_advantages(
+        Namespace(opd_type="sglang", opd_kl_coef=0.5),
+        rollout_data,
+        advantages,
+        student_log_probs,
+    )
+
+    if opd_key == "teacher_log_probs":
+        torch.testing.assert_close(advantages[0], torch.full_like(advantages[0], 0.875))
+    else:
+        torch.testing.assert_close(
+            advantages[0],
+            1.0 - 0.5 * rollout_data[opd_key][0],
+        )
+
+
+def test_multimodal_cp_reslices_precomputed_opd_reverse_kl(monkeypatch: pytest.MonkeyPatch) -> None:
+    rollout_data = {
+        "tokens": [torch.tensor([mm_data.KIMI_VL_MEDIA_TOKEN_ID, 1, 2])],
+        "loss_masks": [torch.ones(2, dtype=torch.int)],
+        "total_lengths": [3],
+        "response_lengths": [2],
+        "multimodal_train_inputs": [{"grid_thws": torch.tensor([[1, 4, 4]])}],
+        "opd_reverse_kl": [torch.tensor([0.1, 0.2])],
+    }
+    gathered_keys = []
+
+    monkeypatch.setattr(mm_data, "get_parallel_state", lambda: _parallel_state(cp_size=2))
+
+    def _all_gather(value: torch.Tensor, *args, **kwargs) -> torch.Tensor:
+        gathered_keys.append(value)
+        return value
+
+    monkeypatch.setattr(mm_data, "all_gather_with_cp", _all_gather)
+    monkeypatch.setattr(mm_data, "slice_log_prob_with_cp", lambda value, *args, **kwargs: value)
+
+    mm_data.expand_multimodal_rollout_data_in_place(rollout_data)
+
+    assert len(gathered_keys) == 1
+    assert gathered_keys[0] is rollout_data["opd_reverse_kl"][0]


### PR DESCRIPTION
## Summary
Align SGLang OPD response signals with CP-local training tensors.

## Symptom & Reproduction
- **Symptom:** With context parallelism enabled, full-response OPD signals are compared against CP-local training tensors, producing a shape mismatch.
- **Reproduction:** A `T=11`/`R=7`/`CP=2` rank-0 case yields local shape `(1,)` versus OPD shape `(7,)`.

## Root Cause
1. `get_rollout_data` sliced only `rollout_log_probs` at trainer ingress.
2. `apply_opd_kl_to_advantages` consumed unsliced OPD fields with CP-local tensors.

## Fix
`get_rollout_data` now applies the existing response-aware CP ownership mapping to `rollout_log_probs`, `teacher_log_probs`, and `opd_reverse_kl`, while preserving the rollout precision policy and float32 OPD signals. `expand_multimodal_rollout_data_in_place` also re-slices precomputed reverse KL after multimodal token expansion changes sequence ownership.

## Verification
- **New test:** `test_sglang_opd_response_fields_follow_rollout_log_prob_cp_slice` covers the sampled/precomputed × CP=1/2 × THD/BSHD matrix.
- **New test:** `test_multimodal_cp_reslices_precomputed_opd_reverse_kl` covers the Kimi-VL metadata-adjustment path.
- **Focused suite:** The OPD/CP command completed with 23 passed.
- **Pre-commit:** Hooks completed successfully for the three changed files.

## Review Focus
- Scrutinize the field-specific dtype selection in `get_rollout_data`.
- Scrutinize the shared `slice_log_prob_with_cp` call in `get_rollout_data`.
- Scrutinize `opd_reverse_kl` re-slicing after multimodal response metadata changes.
