### PR TITLE
ci: cancel unfinished PR runs when the PR closes

### DIFF
--- a/.github/workflows/cancel-pr-workflows-on-close.yml
+++ b/.github/workflows/cancel-pr-workflows-on-close.yml
@@ -1,0 +1,108 @@
+# doc-dev: docs/ci/03-cancellation.md
+name: Cancel PR Workflows on Close
+
+# Cancels every unfinished run on a PR's head branch when the PR closes
+# (merged or not). Ported from sgl-project/sglang. Runs are listed repo-wide
+# by branch, not per workflow file, so workflows added later are covered
+# without editing this file.
+#
+# `pull_request_target` (not `pull_request`): the closed event must run with
+# base-repo credentials to get `actions: write` on fork PRs. Safe here — the
+# job never checks out or executes PR code.
+
+on:
+  pull_request_target:
+    types:
+      - closed
+
+permissions:
+  actions: write
+
+jobs:
+  cancel:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel unfinished runs of this PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          HEAD_BRANCH: ${{ github.event.pull_request.head.ref }}
+          HEAD_REPO_ID: ${{ github.event.pull_request.head.repo.id }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ -z "$HEAD_REPO_ID" ]; then
+            echo "Head repo no longer exists (fork deleted), nothing to match"
+            exit 0
+          fi
+
+          FAILURES=0
+
+          # `branch=` matches run.head_branch, shared with same-named
+          # branches of other forks -- filter by head repo id. Exclude this
+          # run itself: pull_request_target runs also carry the head branch.
+          # The status filter takes one value per request, so sweep every
+          # non-terminal state (pending/waiting/action_required runs would
+          # otherwise start after the PR is closed). Pass 2 catches runs
+          # still materializing during pass 1.
+          for pass in 1 2; do
+            run_ids=""
+            for status in queued in_progress waiting pending requested action_required; do
+              ids=""
+              for attempt in 1 2 3; do
+                if ids=$(gh api -X GET "repos/$REPO/actions/runs" \
+                  --paginate \
+                  -f branch="$HEAD_BRANCH" \
+                  -f status="$status" \
+                  -F per_page=100 \
+                  --jq ".workflow_runs[]
+                        | select(.head_repository.id == $HEAD_REPO_ID and .id != $GITHUB_RUN_ID)
+                        | .id"); then
+                  break
+                fi
+                ids=""
+                if [ "$attempt" -eq 3 ]; then
+                  echo "::error::Listing $status runs failed after 3 attempts"
+                  FAILURES=1
+                else
+                  sleep 5
+                fi
+              done
+              run_ids="$run_ids"$'\n'"$ids"
+            done
+            run_ids=$(echo "$run_ids" | sed '/^$/d' | sort -u)
+
+            if [ -z "$run_ids" ]; then
+              echo "Pass $pass: no unfinished runs found"
+              break
+            fi
+            echo "Pass $pass: cancelling $(echo "$run_ids" | wc -l | tr -d ' ') run(s)"
+
+            for run_id in $run_ids; do
+              echo "Cancelling https://github.com/$REPO/actions/runs/$run_id"
+              if gh run cancel "$run_id" --repo "$REPO" 2>/dev/null; then
+                continue
+              fi
+              # Plain cancel fails for runs stuck behind approval /
+              # deployment protection rules; force-cancel handles those.
+              if gh api -X POST "repos/$REPO/actions/runs/$run_id/force-cancel" >/dev/null 2>&1; then
+                echo "  force-cancelled"
+                continue
+              fi
+              # Finished between listing and cancelling is fine.
+              state=$(gh api "repos/$REPO/actions/runs/$run_id" --jq '.status' 2>/dev/null || echo "unknown")
+              if [ "$state" = "completed" ]; then
+                echo "  already finished, nothing to cancel"
+              else
+                echo "::error::Failed to cancel run $run_id (status: $state)"
+                FAILURES=1
+              fi
+            done
+
+            if [ "$pass" -eq 1 ]; then
+              sleep 20
+            fi
+          done
+
+          exit "$FAILURES"

--- a/docs/ci/03-cancellation.md
+++ b/docs/ci/03-cancellation.md
@@ -1,0 +1,25 @@
+---
+title: Run cancellation
+description: When an in-flight CI run is cancelled automatically — superseded within an open PR, or swept when the PR closes.
+---
+
+# Run cancellation
+
+Two mechanisms stop CI runs that no longer matter. Within an open PR, a new run supersedes the old one; when the PR closes, everything still in flight is swept. GPU stages hold self-hosted H100/H200 runners for up to hours, so a stale run is not just noise — it delays every queued PR behind it.
+
+## Within an open PR: supersede
+
+`pr-test.yml` declares a `concurrency` group keyed by PR number with `cancel-in-progress: true`. A new run on the same PR (push, reopen, `run-ci-*` label) cancels the previous one. Distinct nightly schedules and manual dispatches on the default branch use different group keys and never cancel one another.
+
+## On PR close: sweep
+
+Merging or closing a PR does not, by itself, stop anything: GitHub cancels an in-progress run only when a *new* run enters its concurrency group, and `closed` is not a `pr-test.yml` trigger. Without a sweeper, a run started just before merge keeps occupying GPU runners to completion.
+
+`cancel-pr-workflows-on-close.yml` (ported from sgl-project/sglang) closes that gap. On `pull_request_target: closed` — merged and unmerged alike — it lists every unfinished run on the PR's head branch **repo-wide** and cancels each one:
+
+- Listing is by branch, not by workflow file, so workflows added later are covered automatically.
+- Runs are matched against the PR's head repository id, so same-named branches in other forks are untouched.
+- Every non-terminal status is swept (`queued`, `in_progress`, `waiting`, `pending`, `requested`, `action_required`), and a second pass 20 s later catches runs that were still materializing during the first.
+- A run that rejects a plain cancel (stuck behind an approval or deployment protection rule) is force-cancelled via the API.
+
+The sweep never touches runs on `main` (nightly cron, `workflow_dispatch`) or on branches without a closing PR. It uses `pull_request_target` so the job has `actions: write` even when the PR comes from a fork; the job never checks out PR code.


### PR DESCRIPTION
## Summary
Cancel every unfinished CI run on a PR's head branch the moment the PR closes, merged or not.

## Motivation
Merging or closing a PR does not stop its in-flight CI: GitHub cancels a run only when a new run enters the same concurrency group, and `closed` is not a `pr-test.yml` trigger. A run started just before merge keeps occupying self-hosted GPU runners to completion — [run 29863936642](https://github.com/radixark/miles/actions/runs/29863936642) kept running the full GPU fleet for PR #1584 after it was already merged, delaying every queued PR behind it.

## Design
Port `cancel-pr-workflows-on-close.yml` from sgl-project/sglang, which solved the same problem on the same runner-scarcity grounds:

1. Trigger on `pull_request_target: closed` so the job holds `actions: write` even for fork PRs; the job never checks out PR code.
2. List unfinished runs **repo-wide by head branch** (not per workflow file), so workflows added later are covered without editing this file.
3. Filter by head repository id to spare same-named branches of other forks, and exclude the cancel run itself.
4. Sweep every non-terminal status (`queued`, `in_progress`, `waiting`, `pending`, `requested`, `action_required`), retry listing up to 3 times, force-cancel runs stuck behind approval rules, and run a second pass 20 s later for runs still materializing.

`docs/ci/03-cancellation.md` (bound via the workflow's `doc-dev` sentinel) documents the full cancellation model: per-PR supersede in `pr-test.yml` plus this on-close sweep.

## Verification
- **Syntax:** `pre-commit run` (`check-yaml`) passes on both files.
- **Logic provenance:** the shell step is byte-identical to sglang's production workflow except for the header comments; sglang runs it on every PR close.
- **Post-merge check (this trigger only takes effect once the file is on `main`):** push a trivial PR, wait for `PR Test` to start its GPU stages, merge, then confirm within ~1 min that the leftover run flips to `cancelled` and a green `Cancel PR Workflows on Close` run appears for the PR.

## Review Focus
- Scrutinize the `pull_request_target` trigger and the `actions: write`-only permission block.
- Scrutinize the head-repo-id filter against fork branches named identically to internal ones.
- Scrutinize whether any miles run on a PR head branch must survive PR close (e.g. manually dispatched debugging runs on that branch — they are swept too).

🤖 Generated with [Claude Code](https://claude.com/claude-code)