### PR TITLE
[chore] Move ruff select/ignore under [tool.ruff.lint]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,8 @@ line_length = 119
 
 [tool.ruff]
 line-length = 320  # TODO
+
+[tool.ruff.lint]
 select = [
     "E",      # Pycodestyle Errors (Structural/Fundamental Errors like bad indentation)
     "F",      # Pyflakes (Core Errors: Unused imports, undefined names)


### PR DESCRIPTION
## Summary

Ruff deprecated top-level `select`/`ignore` in `[tool.ruff]` in favor of the
`[tool.ruff.lint]` section. With the currently pinned toolchain every ruff
invocation — local, pre-commit, and CI — emits:

    warning: The top-level linter settings are deprecated in favour of their
    counterparts in the `lint` section.

Since `.pre-commit-config.yaml` pins `ruff-pre-commit` and pre-commit.ci
autoupdates quarterly, this will keep resurfacing until the legacy path is
removed upstream, at which point the lint configuration would silently stop
applying.

## Change

Moves `select` and `ignore` into a new `[tool.ruff.lint]` section. `line-length`
stays at the top level, where it still belongs.

## Verification

The enabled rule set is unchanged — `ruff check --show-settings` produces an
identical `linter.rules.enabled` block before and after. `ruff check .` passes
with no findings and no deprecation warning.