### PR TITLE
[feat] Muon support for multi-LoRA per-slot optimizers

### DIFF
--- a/miles/backends/megatron_utils/model.py
+++ b/miles/backends/megatron_utils/model.py
@@ -164,17 +164,19 @@ def setup_model_and_optimizer(
     config = OptimizerConfig(**kwargs)
     config.timers = None
 
-    if _is_muon_optimizer(config.optimizer):
+    # Multi-LoRA wins over the plain Muon path: it builds per-slot optimizers of
+    # either family itself and applies LayerWise once over all slots.
+    if is_multi_lora_enabled(args):
+        from miles.backends.megatron_utils.multi_lora_optimizer import build_multi_lora_optimizer
+
+        optimizer = build_multi_lora_optimizer(args, config, model)
+    elif _is_muon_optimizer(config.optimizer):
         optimizer = get_megatron_muon_optimizer(
             config=config,
             model_chunks=model,
             use_gloo_process_groups=args.enable_gloo_process_groups,
             layer_wise_distributed_optimizer="dist" in config.optimizer.lower(),
         )
-    elif is_multi_lora_enabled(args):
-        from miles.backends.megatron_utils.multi_lora_optimizer import build_multi_lora_optimizer
-
-        optimizer = build_multi_lora_optimizer(args, config, model)
     else:
         optimizer = get_megatron_optimizer(
             config=config,

--- a/miles/backends/megatron_utils/multi_lora_optimizer.py
+++ b/miles/backends/megatron_utils/multi_lora_optimizer.py
@@ -1,5 +1,6 @@
-"""Per-slot decoupled Adam optimizers for multi-LoRA, chained under Megatron's LayerWiseDistributedOptimizer;
-requires plain DDP all-reduce (use_distributed_optimizer OFF) so cross-batch gradient retention stays idempotent."""
+"""Per-slot decoupled optimizers (Adam/AdamW or Muon) for multi-LoRA, chained under Megatron's
+LayerWiseDistributedOptimizer; requires plain DDP all-reduce (use_distributed_optimizer OFF) so
+cross-batch gradient retention stays idempotent."""
 
 import logging
 from argparse import Namespace
@@ -35,14 +36,6 @@ def adapter_slot_parameters(model, slot: int) -> list[torch.nn.Parameter]:
     return parameters
 
 
-def _adam_init_state_fn(opt, config=None):
-    for group in opt.param_groups:
-        for p in group["params"]:
-            if len(opt.state[p]) == 0:
-                opt.state[p]["exp_avg"] = torch.zeros_like(p.data)
-                opt.state[p]["exp_avg_sq"] = torch.zeros_like(p.data)
-
-
 @contextmanager
 def _only_slot_trainable(model_chunks, slot_params: list[torch.nn.Parameter]):
     """Temporarily freeze every trainable param outside ``slot_params`` so the
@@ -67,24 +60,33 @@ def build_multi_lora_optimizer(
     config: OptimizerConfig,
     model_chunks: Sequence,
 ) -> MegatronOptimizer:
-    """Build one Float16-wrapped Adam per adapter slot under a LayerWiseDistributedOptimizer (ChainedOptimizer);
-    each child's param groups are tagged with ``miles_multi_lora_slot`` and narrowed to this rank's shard."""
+    """Build one Float16-wrapped optimizer (Adam/AdamW or Muon) per adapter slot under a
+    LayerWiseDistributedOptimizer (ChainedOptimizer); each child's param groups are tagged with
+    ``miles_multi_lora_slot`` and narrowed to this rank's shard."""
     assert not config.use_distributed_optimizer, (
         "multi-LoRA per-slot optimizers require use_distributed_optimizer=False: "
         "gradient retention relies on all-reduce idempotency, and LayerWise "
         "sharding replaces byte-level ZeRO"
     )
     assert not config.fp16, "multi-LoRA per-slot optimizers require bf16 (no dynamic loss scaler)"
-    assert (config.optimizer or "").lower() == "adam", (
-        "multi-LoRA per-slot optimizers only implement Adam semantics (state init, "
-        f"slot retirement cleanup, step clocks); got optimizer={config.optimizer!r}"
+    assert (config.optimizer or "").lower() in ("adam", "muon", "dist_muon"), (
+        "multi-LoRA per-slot optimizers implement Adam/AdamW and Muon state layouts "
+        f"(state init, slot retirement cleanup); got optimizer={config.optimizer!r}"
     )
 
     pg_collection = ProcessGroupCollection.use_mpu_process_groups()
 
-    # Defer bf16 master-weight creation into LayerWise (post-sharding) so fp32 masters exist only for owned params.
+    # Defer bf16 master-weight creation into LayerWise (post-sharding) so fp32 masters exist only
+    # for owned params. Children must also come out raw (not layer-wise wrapped): multi-LoRA applies
+    # LayerWise ONCE over all slots below, so dist_muon collapses to plain muon here.
     reset_bf16 = config.bf16
+    reset_optimizer = config.optimizer
+    reset_layer_wise = getattr(config, "use_layer_wise_distributed_optimizer", False)
     config.bf16 = False
+    if (config.optimizer or "").lower() == "dist_muon":
+        config.optimizer = "muon"
+    if hasattr(config, "use_layer_wise_distributed_optimizer"):
+        config.use_layer_wise_distributed_optimizer = False
 
     base_optimizers: list = []
     init_fns: list = []
@@ -110,9 +112,14 @@ def build_multi_lora_optimizer(
                 for group in child.param_groups:
                     group["miles_multi_lora_slot"] = slot
                 base_optimizers.append(child)
-                init_fns.append(_adam_init_state_fn)
+                # Each child carries the stock init fn matching its own family
+                # (Adam moments, or Muon's _init_group momentum buffers).
+                init_fns.append(child.init_state_fn)
     finally:
         config.bf16 = reset_bf16
+        config.optimizer = reset_optimizer
+        if hasattr(config, "use_layer_wise_distributed_optimizer"):
+            config.use_layer_wise_distributed_optimizer = reset_layer_wise
 
     optimizer = LayerWiseDistributedOptimizer(base_optimizers, config, pg_collection, init_state_fn_list=init_fns)
 

--- a/miles/backends/megatron_utils/multi_lora_utils.py
+++ b/miles/backends/megatron_utils/multi_lora_utils.py
@@ -107,6 +107,9 @@ def zero_optimizer_state_for_adapter(optimizer, model, idx: int) -> None:
                 state["exp_avg"].zero_()
             if "exp_avg_sq" in state:
                 state["exp_avg_sq"].zero_()
+            # Muon (emerging-optimizers OrthogonalizedOptimizer) keeps its state here.
+            if "momentum_buffer" in state:
+                state["momentum_buffer"].zero_()
             # Bias correction restarts for the slot's next tenant.
             if "step" in state:
                 if isinstance(state["step"], torch.Tensor):

--- a/miles/utils/multi_lora.py
+++ b/miles/utils/multi_lora.py
@@ -68,10 +68,6 @@ def validate_multi_lora_args(args: Any) -> None:
     assert args.lora_rank > 0, "--lora-rank must be set when --multi-lora-n-adapters > 0"
     assert args.target_modules is not None, "--target-modules must be set when --multi-lora-n-adapters > 0"
     assert args.train_backend == "megatron", "Multi-LoRA currently requires --train-backend megatron"
-    assert "muon" not in str(getattr(args, "optimizer", "")).lower(), (
-        "Multi-LoRA does not support Muon: per-adapter decoupled stepping is only "
-        "implemented for Adam-family per-slot optimizers"
-    )
     assert not args.colocate, (
         "Multi-LoRA requires disaggregated rollout engines: weight sync is only "
         "implemented for the distributed path, not the colocated tensor path."
@@ -100,10 +96,9 @@ def validate_multi_lora_args(args: Any) -> None:
         "depend on batch contents. Drop --calculate-per-token-loss."
     )
     assert args.multi_lora_max_coalesce_wait_s >= 0, "--multi-lora-max-coalesce-wait-s must be non-negative"
-    assert (getattr(args, "optimizer", "adam") or "adam").lower() == "adam", (
-        "Multi-LoRA requires --optimizer adam: the per-slot optimizer isolation "
-        "(build_multi_lora_optimizer, slot retirement state cleanup) only implements "
-        f"Adam semantics; got --optimizer {args.optimizer}"
+    assert (getattr(args, "optimizer", "adam") or "adam").lower() in ("adam", "muon", "dist_muon"), (
+        "Multi-LoRA per-slot optimizers support adam (AdamW) and muon: state isolation and "
+        f"slot-retirement cleanup implement only those state layouts; got --optimizer {args.optimizer}"
     )
     from miles.utils.environ import enable_experimental_ft_trainer
 

--- a/tests/fast/backends/megatron_utils/test_multi_lora_slot_cleanup.py
+++ b/tests/fast/backends/megatron_utils/test_multi_lora_slot_cleanup.py
@@ -1,5 +1,5 @@
 """zero_optimizer_state_for_adapter must reset a retired slot's Adam moments and step clock
-(group-level FusedAdam or per-param torch AdamW) while leaving co-tenant slots untouched."""
+(group-level FusedAdam or per-param torch AdamW) — and Muon momentum buffers — while leaving co-tenant slots untouched."""
 
 import sys
 import types
@@ -89,3 +89,22 @@ def test_per_param_adamw_fallback_clock_resets(rig):
     zero_optimizer_state_for_adapter(optimizer, rig.model, 0)
 
     assert float(inner.state[rig.p0]["step"]) == 0.0
+
+
+def test_muon_momentum_buffer_resets_only_for_the_retired_slot(rig):
+    # Muon (emerging-optimizers) keeps a per-param momentum_buffer and no step clock.
+    inner, optimizer = make_optimizer(
+        groups=[
+            {"params": [rig.p0], "miles_multi_lora_slot": 0},
+            {"params": [rig.p1], "miles_multi_lora_slot": 1},
+        ],
+        state={
+            rig.p0: {"momentum_buffer": torch.ones(4)},
+            rig.p1: {"momentum_buffer": torch.ones(4)},
+        },
+    )
+
+    zero_optimizer_state_for_adapter(optimizer, rig.model, 0)
+
+    assert float(inner.state[rig.p0]["momentum_buffer"].abs().sum()) == 0.0
+    assert float(inner.state[rig.p1]["momentum_buffer"].abs().sum()) == 4.0  # co-tenant untouched

--- a/tests/fast/utils/test_arguments.py
+++ b/tests/fast/utils/test_arguments.py
@@ -229,18 +229,18 @@ class TestMultiLoRAValidation:
         assert self._parse([]).multi_lora_max_empty_wait_s == 30.0
         assert self._parse(["--multi-lora-max-empty-wait-s", "5"]).multi_lora_max_empty_wait_s == 5.0
 
-    def test_rejects_non_adam_optimizer(self):
-        # Per-slot optimizer isolation (state init, retirement cleanup, step
-        # clocks) only implements Adam semantics. Muon has its own dedicated
-        # rejection; anything else non-Adam trips the generic guard.
-        args = self._parse([])
-        args.optimizer = "muon"
-        with pytest.raises(AssertionError, match="does not support Muon"):
+    def test_optimizer_allowlist(self):
+        # Per-slot isolation implements the Adam/AdamW and Muon state layouts;
+        # anything else trips the guard.
+        for accepted in ("adam", "muon", "dist_muon"):
+            args = self._parse([])
+            args.optimizer = accepted
             miles_validate_args(args)
+            assert args.multi_lora is True
 
         args = self._parse([])
         args.optimizer = "sgd"
-        with pytest.raises(AssertionError, match="requires --optimizer adam"):
+        with pytest.raises(AssertionError, match="support adam \\(AdamW\\) and muon"):
             miles_validate_args(args)
 
     def test_rejects_experimental_ft_trainer(self, monkeypatch):


### PR DESCRIPTION
Multi-LoRA currently rejects `--optimizer muon` at launch. Since the per-slot construction already goes through the stock `get_megatron_optimizer`, this just opens the same factory to muon: `dist_muon` collapses to plain `muon` (multi-LoRA applies LayerWise once over all slots itself), each per-slot child now uses its own family-matched `init_state_fn`, and slot-retirement cleanup additionally zeroes muon's `momentum_buffer` so a reused slot doesn't inherit the previous adapter's momentum. The adam/AdamW path is unchanged, and the stepping machinery and per-adapter LR scheduler were already optimizer-agnostic. Selecting muon requires the `emerging-optimizers` package, same as the non-LoRA muon path.