### PR TITLE
feat(session): serve stream:true chat completions as fake streaming

### DIFF
--- a/miles/rollout/session/core.py
+++ b/miles/rollout/session/core.py
@@ -4,6 +4,7 @@ HTTP-agnostic: the FastAPI adapter (``sessions.py`` + ``server.py``) turns each 
 
 - ``chat_completions`` strips the R3 replay payloads (``routed_experts`` / ``indexer_topk``) from the client reply copy-on-write; the ``SessionRecord`` keeps the full response for the training path (``GET /sessions/{id}``).
 - ``chat_completions`` holds the per-session lock for prep and state update but not across the proxy call; ``closing`` re-checks and the ``num_assistant`` check gate concurrent DELETE/chat.
+- ``stream: true`` is served as fake streaming: the backend call stays non-streaming (TITO needs the complete message + meta_info) and the full response is re-rendered as a single SSE chunk plus ``data: [DONE]``. Errors all happen before the SSE body is built, so they keep their real status codes as JSON.
 """
 
 import json
@@ -58,7 +59,47 @@ def _strip_replay_payloads(response: dict) -> dict:
     return {**response, "choices": stripped_choices}
 
 
-def _chat_client_response(result: dict, response: dict) -> Response:
+def _response_to_stream_chunk(response: dict) -> dict:
+    """Synthesize the single ``chat.completion.chunk`` for a fake stream.
+
+    Adapted from NVIDIA-NeMo/ProRL-Agent-Server (``gateway/server.py::_response_to_stream_chunk``)
+    and THUDM/slime (``agent/adapters/openai.py::_render_stream``).
+
+    One big delta is protocol-legal (streaming deltas concatenate). All
+    tool_calls ride in this one chunk with their ``index`` set: some clients
+    mis-assemble arguments fragmented across chunks. The chunk carries no
+    ``meta_info``; the training path reads ``GET /sessions/{id}`` instead.
+    """
+    choice = response.get("choices", [{}])[0]
+    message = choice.get("message") or {}
+    delta = {"role": message.get("role", "assistant"), "content": message.get("content")}
+    if message.get("reasoning_content") is not None:
+        delta["reasoning_content"] = message["reasoning_content"]
+    if message.get("tool_calls"):
+        delta["tool_calls"] = [{**tool_call, "index": i} for i, tool_call in enumerate(message["tool_calls"])]
+    chunk = {
+        "id": response.get("id"),
+        "object": "chat.completion.chunk",
+        "created": response.get("created"),
+        "model": response.get("model"),
+        "choices": [{"index": 0, "delta": delta, "finish_reason": choice.get("finish_reason")}],
+    }
+    if response.get("usage") is not None:
+        chunk["usage"] = response["usage"]
+    return chunk
+
+
+def _chat_client_response(result: dict, response: dict, client_stream: bool) -> Response:
+    if client_stream:
+        sse = b"data: " + _render_json(_response_to_stream_chunk(response)) + b"\n\ndata: [DONE]\n\n"
+        # Fresh headers: upstream's headers describe its JSON body, not this SSE body.
+        # X-Accel-Buffering keeps reverse proxies from buffering the stream.
+        return Response(
+            content=sse,
+            status_code=result["status_code"],
+            headers={"cache-control": "no-cache", "x-accel-buffering": "no"},
+            media_type="text/event-stream",
+        )
     headers = {k: v for k, v in result["headers"].items() if k.lower() not in _DROP_RESPONSE_HEADERS}
     return Response(
         content=_render_json(_strip_replay_payloads(response)),
@@ -161,6 +202,13 @@ class SessionCore:
             except json.JSONDecodeError as e:
                 raise MessageValidationError(f"invalid JSON body: {e}") from e
 
+            # Fake streaming: the backend must stay non-streaming (TITO needs the
+            # complete message + meta_info, and sglang rejects return_meta_info
+            # with stream=true), so pop the client's intent here and honor it
+            # when rendering the client response.
+            client_stream = bool(request_body.pop("stream", False))
+            request_body.pop("stream_options", None)
+
             # TITO token tracking needs Miles-owned input_ids plus SGLang output
             # metadata: logprobs=True populates meta_info.output_token_logprobs and
             # return_meta_info wraps it in choice.meta_info. Hardcoded (not
@@ -240,7 +288,7 @@ class SessionCore:
         async with session.lock:
             if session.closing:
                 logger.warning(f"Session {session_id} closed during proxy, skipping state update")
-                return _chat_client_response(result, response)
+                return _chat_client_response(result, response, client_stream)
 
             if session.num_assistant != expected_num_assistant:
                 logger.warning(
@@ -248,7 +296,7 @@ class SessionCore:
                     f"(expected num_assistant={expected_num_assistant}, "
                     f"got {session.num_assistant}), skipping state update"
                 )
-                return _chat_client_response(result, response)
+                return _chat_client_response(result, response, client_stream)
 
             session.update_pretokenized_state(
                 request_messages,
@@ -269,7 +317,7 @@ class SessionCore:
             session.append_record(record)
         # --- lock released ---
 
-        return _chat_client_response(result, response)
+        return _chat_client_response(result, response, client_stream)
 
     async def proxy(
         self, session_id: str, path: str, *, method: str, query: str, headers: dict, body: bytes

--- a/miles/utils/chat_template_utils/template.py
+++ b/miles/utils/chat_template_utils/template.py
@@ -134,13 +134,8 @@ def apply_chat_template_from_str(
 
 _TEMPLATE_RELEVANT_KEYS = ("role", "content", "reasoning_content", "tool_calls")
 
-# Wire-only tool_call keys ignored when matching a stored message against a
-# client replay.  The OpenAI non-streaming message shape has no ``index`` on
-# tool_calls — it is an sglang extension (ToolCall.index, the tool's position
-# in the tools list, int or null) — so protocol-faithful clients (SSE
-# accumulators rebuilding the message from deltas) legitimately replay
-# tool_calls without it, or with a renumbered value.  No chat template reads
-# it either way.
+# SGLang serializes `index` on non-streaming tool calls, while accumulated
+# streaming messages may omit or renumber it; no chat template reads it.
 _WIRE_ONLY_TOOL_CALL_KEYS = ("index",)
 
 
@@ -163,9 +158,7 @@ def _normalize_value(value: Any) -> Any:
 def _normalize_tool_calls(value: Any) -> Any:
     """Project tool_calls down to template-relevant content for comparison.
 
-    Drops wire-only keys plus null-valued keys from each tool_call dict:
-    Jinja2 renders an absent key and a None-valued key identically, so
-    neither may distinguish a stored message from its replay.
+    Only keys in `_WIRE_ONLY_TOOL_CALL_KEYS` are removed; all other values remain part of history matching.
 
     Deliberately a comparison-time projection, NOT a repair of the incoming
     message from stored state.  Matching only decides whether a replay is
@@ -180,11 +173,7 @@ def _normalize_tool_calls(value: Any) -> Any:
     if not isinstance(value, list):
         return value
     return [
-        (
-            {k: v for k, v in call.items() if k not in _WIRE_ONLY_TOOL_CALL_KEYS and v is not None}
-            if isinstance(call, dict)
-            else call
-        )
+        ({k: v for k, v in call.items() if k not in _WIRE_ONLY_TOOL_CALL_KEYS} if isinstance(call, dict) else call)
         for call in value
     ]
 
@@ -196,8 +185,7 @@ def message_matches(stored: dict[str, Any], new: dict[str, Any]) -> bool:
     ``provider_specific_fields`` into messages.  These have no effect on
     the Jinja2 chat template output, so we only compare the keys that
     templates actually read: role, content, reasoning_content, tool_calls.
-    Within tool_calls, wire-only keys (``index``) and null-valued keys are
-    ignored for the same reason.
+    Within tool_calls, wire-only keys such as `index` are ignored for the same reason.
     """
     for key in _TEMPLATE_RELEVANT_KEYS:
         stored_value = _normalize_value(stored.get(key))

--- a/miles/utils/chat_template_utils/template.py
+++ b/miles/utils/chat_template_utils/template.py
@@ -134,10 +134,13 @@ def apply_chat_template_from_str(
 
 _TEMPLATE_RELEVANT_KEYS = ("role", "content", "reasoning_content", "tool_calls")
 
-# Wire-only tool_call keys that no chat template reads.  SGLang's non-streaming
-# responses always serialize ``index`` (int or null, from ToolCall.index), while
-# streaming clients that rebuild the message from deltas drop it per OpenAI
-# semantics — so it must not participate in matching.
+# Wire-only tool_call keys ignored when matching a stored message against a
+# client replay.  The OpenAI non-streaming message shape has no ``index`` on
+# tool_calls — it is an sglang extension (ToolCall.index, the tool's position
+# in the tools list, int or null) — so protocol-faithful clients (SSE
+# accumulators rebuilding the message from deltas) legitimately replay
+# tool_calls without it, or with a renumbered value.  No chat template reads
+# it either way.
 _WIRE_ONLY_TOOL_CALL_KEYS = ("index",)
 
 
@@ -158,11 +161,21 @@ def _normalize_value(value: Any) -> Any:
 
 
 def _normalize_tool_calls(value: Any) -> Any:
-    """Drop wire-only and null-valued keys from each tool_call dict.
+    """Project tool_calls down to template-relevant content for comparison.
 
-    Jinja2 templates render an absent key and a None-valued key identically,
-    and ``index`` is a streaming-accumulation artifact no template reads, so
+    Drops wire-only keys plus null-valued keys from each tool_call dict:
+    Jinja2 renders an absent key and a None-valued key identically, so
     neither may distinguish a stored message from its replay.
+
+    Deliberately a comparison-time projection, NOT a repair of the incoming
+    message from stored state.  Matching only decides whether a replay is
+    the same history: on a match the prefix tokens come from stored
+    checkpoints and records keep the raw backend response (``index``
+    intact), so nothing downstream reads the replayed keys.  Filling
+    missing keys from stored would also presuppose the per-call
+    correspondence this comparison is itself establishing, and cannot
+    handle a client that replays a different ``index`` value rather than
+    none.
     """
     if not isinstance(value, list):
         return value

--- a/miles/utils/chat_template_utils/template.py
+++ b/miles/utils/chat_template_utils/template.py
@@ -134,6 +134,12 @@ def apply_chat_template_from_str(
 
 _TEMPLATE_RELEVANT_KEYS = ("role", "content", "reasoning_content", "tool_calls")
 
+# Wire-only tool_call keys that no chat template reads.  SGLang's non-streaming
+# responses always serialize ``index`` (int or null, from ToolCall.index), while
+# streaming clients that rebuild the message from deltas drop it per OpenAI
+# semantics — so it must not participate in matching.
+_WIRE_ONLY_TOOL_CALL_KEYS = ("index",)
+
 
 def _normalize_value(value: Any) -> Any:
     """Normalize falsy sentinels that produce identical Jinja2 output.
@@ -151,6 +157,25 @@ def _normalize_value(value: Any) -> Any:
     return value
 
 
+def _normalize_tool_calls(value: Any) -> Any:
+    """Drop wire-only and null-valued keys from each tool_call dict.
+
+    Jinja2 templates render an absent key and a None-valued key identically,
+    and ``index`` is a streaming-accumulation artifact no template reads, so
+    neither may distinguish a stored message from its replay.
+    """
+    if not isinstance(value, list):
+        return value
+    return [
+        (
+            {k: v for k, v in call.items() if k not in _WIRE_ONLY_TOOL_CALL_KEYS and v is not None}
+            if isinstance(call, dict)
+            else call
+        )
+        for call in value
+    ]
+
+
 def message_matches(stored: dict[str, Any], new: dict[str, Any]) -> bool:
     """Compare only the fields that affect chat-template tokenization.
 
@@ -158,9 +183,16 @@ def message_matches(stored: dict[str, Any], new: dict[str, Any]) -> bool:
     ``provider_specific_fields`` into messages.  These have no effect on
     the Jinja2 chat template output, so we only compare the keys that
     templates actually read: role, content, reasoning_content, tool_calls.
+    Within tool_calls, wire-only keys (``index``) and null-valued keys are
+    ignored for the same reason.
     """
     for key in _TEMPLATE_RELEVANT_KEYS:
-        if _normalize_value(stored.get(key)) != _normalize_value(new.get(key)):
+        stored_value = _normalize_value(stored.get(key))
+        new_value = _normalize_value(new.get(key))
+        if key == "tool_calls":
+            stored_value = _normalize_tool_calls(stored_value)
+            new_value = _normalize_tool_calls(new_value)
+        if stored_value != new_value:
             return False
     return True
 

--- a/miles/utils/test_utils/mock_sglang_server.py
+++ b/miles/utils/test_utils/mock_sglang_server.py
@@ -176,9 +176,13 @@ class MockSGLangServer:
             message_content, parsed_calls = parser.parse_non_stream(process_result.text)
             if parsed_calls:
                 finish_reason = "tool_calls"
+                # Mirror SGLang's non-streaming wire shape: ToolCall always
+                # serializes ``index`` (the tool's position in the tools list,
+                # via ToolCallItem.tool_index; -1 when unknown).
                 tool_calls = [
                     {
                         "id": f"call{i:05d}",
+                        "index": call.tool_index,
                         "type": "function",
                         "function": {"name": call.name, "arguments": call.parameters or "{}"},
                     }

--- a/miles/utils/test_utils/mock_tools.py
+++ b/miles/utils/test_utils/mock_tools.py
@@ -189,9 +189,17 @@ class TwoTurnStub:
             "type": "function",
         },
     ]
+    # What the mock backend serves on the wire: SGLang's non-streaming ToolCall
+    # additionally carries ``index`` (the tool's position in the tools list).
+    # Clients normalized to the OpenAI shape (above) legitimately drop it.
+    FIRST_TOOL_CALLS_SGLANG_WIRE = [
+        {**tool_call, "index": index} for index, tool_call in zip((0, 1), FIRST_TOOL_CALLS_OPENAI_FORMAT, strict=True)
+    ]
 
     OPENAI_MESSAGES_FIRST_TURN = [{"role": "user", "content": USER_QUESTION}]
 
+    # The openai SDK preserves unknown keys (extra="allow"), so a client replay
+    # echoes the wire shape — index included.
     OPENAI_MESSAGES_SECOND_TURN_FROM_CLIENT = OPENAI_MESSAGES_FIRST_TURN + [
         {
             "content": FIRST_RESPONSE_CONTENT,
@@ -200,7 +208,7 @@ class TwoTurnStub:
             "annotations": None,
             "audio": None,
             "function_call": None,
-            "tool_calls": FIRST_TOOL_CALLS_OPENAI_FORMAT,
+            "tool_calls": FIRST_TOOL_CALLS_SGLANG_WIRE,
         },
         {"role": "tool", "tool_call_id": "call00000", "content": '{"year": 2026}', "name": "get_year"},
         {"role": "tool", "tool_call_id": "call00001", "content": '{"temperature": -60}', "name": "get_temperature"},
@@ -283,6 +291,12 @@ class ThreeTurnStub:
         },
     ]
 
+    # SGLang wire shape: index is the tool's position in the tools list
+    # (get_year=0, get_temperature=1), not the call position.
+    FIRST_TOOL_CALLS_SGLANG_WIRE = [
+        {**tool_call, "index": index} for index, tool_call in zip((0, 1), FIRST_TOOL_CALLS_OPENAI_FORMAT, strict=True)
+    ]
+
     SECOND_RESPONSE_CONTENT = "Now let me get Earth temperature."
     SECOND_TOOL_CALLS_OPENAI_FORMAT = [
         {
@@ -291,9 +305,12 @@ class ThreeTurnStub:
             "type": "function",
         },
     ]
+    SECOND_TOOL_CALLS_SGLANG_WIRE = [{**SECOND_TOOL_CALLS_OPENAI_FORMAT[0], "index": 1}]
 
     OPENAI_MESSAGES_FIRST_TURN = [{"role": "user", "content": USER_QUESTION}]
 
+    # The openai SDK preserves unknown keys (extra="allow"), so a client replay
+    # echoes the wire shape — index included.
     OPENAI_MESSAGES_SECOND_TURN_FROM_CLIENT = OPENAI_MESSAGES_FIRST_TURN + [
         {
             "content": FIRST_RESPONSE_CONTENT,
@@ -302,7 +319,7 @@ class ThreeTurnStub:
             "annotations": None,
             "audio": None,
             "function_call": None,
-            "tool_calls": FIRST_TOOL_CALLS_OPENAI_FORMAT,
+            "tool_calls": FIRST_TOOL_CALLS_SGLANG_WIRE,
         },
         {"role": "tool", "tool_call_id": "call00000", "content": '{"year": 2026}', "name": "get_year"},
         {"role": "tool", "tool_call_id": "call00001", "content": '{"temperature": -60}', "name": "get_temperature"},
@@ -316,7 +333,7 @@ class ThreeTurnStub:
             "annotations": None,
             "audio": None,
             "function_call": None,
-            "tool_calls": SECOND_TOOL_CALLS_OPENAI_FORMAT,
+            "tool_calls": SECOND_TOOL_CALLS_SGLANG_WIRE,
         },
         {"role": "tool", "tool_call_id": "call00000", "content": '{"temperature": 15}', "name": "get_temperature"},
     ]

--- a/miles/utils/test_utils/openai_stream_client.py
+++ b/miles/utils/test_utils/openai_stream_client.py
@@ -1,0 +1,87 @@
+"""Black-box OpenAI streaming client for e2e agents.
+
+Consumes a ``stream: true`` chat completions response as SSE and rebuilds the
+non-streaming response shape, so agent code can stay wire-format agnostic.
+The accumulator follows the OpenAI delta semantics (fragments concatenate,
+tool_calls merge by ``index``) and therefore works for both the session
+server's single-chunk fake streaming and a real multi-chunk stream.
+
+The rebuilt assistant message must survive the session server's
+``message_matches`` prefix check on the next turn, so tool_call fragments
+keep every upstream key except the streaming-only ``index``.
+"""
+
+import json
+
+
+def accumulate_chat_chunks(chunks: list[dict], *, label: str = "") -> dict:
+    """Fold ``chat.completion.chunk`` dicts into a non-streaming response."""
+    assert chunks, f"{label}: SSE stream contained no chunks before [DONE]"
+    message: dict = {"role": "assistant", "content": None}
+    tool_calls_by_index: dict[int, dict] = {}
+    finish_reason = None
+    usage = None
+    for chunk in chunks:
+        assert chunk.get("object") == "chat.completion.chunk", f"{label}: unexpected SSE payload {chunk!r}"
+        [choice] = chunk["choices"]
+        delta = choice.get("delta") or {}
+        if delta.get("role"):
+            message["role"] = delta["role"]
+        if delta.get("content") is not None:
+            message["content"] = (message["content"] or "") + delta["content"]
+        if delta.get("reasoning_content") is not None:
+            message["reasoning_content"] = (message.get("reasoning_content") or "") + delta["reasoning_content"]
+        for fragment in delta.get("tool_calls") or []:
+            entry = tool_calls_by_index.setdefault(fragment["index"], {"function": {}})
+            for key, value in fragment.items():
+                if key in ("index", "function") or value is None:
+                    continue
+                entry[key] = value
+            function = fragment.get("function") or {}
+            if function.get("name") is not None:
+                entry["function"]["name"] = function["name"]
+            if function.get("arguments") is not None:
+                entry["function"]["arguments"] = entry["function"].get("arguments", "") + function["arguments"]
+        if choice.get("finish_reason"):
+            finish_reason = choice["finish_reason"]
+        if chunk.get("usage") is not None:
+            usage = chunk["usage"]
+    if tool_calls_by_index:
+        message["tool_calls"] = [tool_calls_by_index[i] for i in sorted(tool_calls_by_index)]
+    first = chunks[0]
+    response = {
+        "id": first.get("id"),
+        "object": "chat.completion",
+        "created": first.get("created"),
+        "model": first.get("model"),
+        "choices": [{"index": 0, "message": message, "finish_reason": finish_reason}],
+    }
+    if usage is not None:
+        response["usage"] = usage
+    return response
+
+
+async def stream_chat_completions(client, url: str, payload: dict, *, label: str = "") -> dict:
+    """POST *payload* with ``stream: true`` via httpx and rebuild the response."""
+    chunks: list[dict] = []
+    done = False
+    async with client.stream("POST", url, json={**payload, "stream": True}) as resp:
+        if resp.status_code != 200:
+            body = await resp.aread()
+            raise AssertionError(f"{label} failed ({resp.status_code}): {body.decode(errors='replace')}")
+        content_type = resp.headers.get("content-type", "")
+        assert content_type.startswith(
+            "text/event-stream"
+        ), f"{label}: expected SSE, got content-type {content_type!r}"
+        async for line in resp.aiter_lines():
+            if not line or line.startswith(":"):
+                continue
+            assert line.startswith("data: "), f"{label}: unexpected SSE line {line!r}"
+            assert not done, f"{label}: SSE event after [DONE]"
+            data = line[len("data: ") :]
+            if data == "[DONE]":
+                done = True
+                continue
+            chunks.append(json.loads(data))
+    assert done, f"{label}: stream ended without data: [DONE]"
+    return accumulate_chat_chunks(chunks, label=label)

--- a/miles/utils/test_utils/openai_stream_client.py
+++ b/miles/utils/test_utils/openai_stream_client.py
@@ -13,6 +13,8 @@ keep every upstream key except the streaming-only ``index``.
 
 import json
 
+import httpx
+
 
 def accumulate_chat_chunks(chunks: list[dict], *, label: str = "") -> dict:
     """Fold ``chat.completion.chunk`` dicts into a non-streaming response."""
@@ -61,7 +63,7 @@ def accumulate_chat_chunks(chunks: list[dict], *, label: str = "") -> dict:
     return response
 
 
-async def stream_chat_completions(client, url: str, payload: dict, *, label: str = "") -> dict:
+async def stream_chat_completions(client: httpx.AsyncClient, url: str, payload: dict, *, label: str = "") -> dict:
     """POST *payload* with ``stream: true`` via httpx and rebuild the response."""
     chunks: list[dict] = []
     done = False

--- a/miles/utils/test_utils/session_verify_agent.py
+++ b/miles/utils/test_utils/session_verify_agent.py
@@ -22,6 +22,7 @@ import httpx
 
 from miles.rollout.base_types import GenerateFnInput, GenerateFnOutput
 from miles.rollout.generate_hub.agentic_tool_call import generate as _base_generate
+from miles.utils.test_utils.openai_stream_client import stream_chat_completions
 
 logger = logging.getLogger(__name__)
 
@@ -178,6 +179,11 @@ def build_initial_messages() -> list[dict]:
 
 async def _chat(client, base_url, messages, request_kwargs, *, label):
     payload = {"messages": messages, "tools": TOOLS, **request_kwargs}
+    # Streaming is the e2e default: black-box agent harnesses mostly consume
+    # chat completions as SSE, so exercise the session server's fake-streaming
+    # path unless the caller opts out with stream=False in request_kwargs.
+    if payload.pop("stream", True):
+        return await stream_chat_completions(client, f"{base_url}/v1/chat/completions", payload, label=label)
     resp = await client.post(f"{base_url}/v1/chat/completions", json=payload)
     assert resp.status_code == 200, f"{label} failed ({resp.status_code}): {resp.text}"
     return resp.json()

--- a/tests/e2e/sglang/utils/session_tool_agent.py
+++ b/tests/e2e/sglang/utils/session_tool_agent.py
@@ -31,6 +31,8 @@ import random
 
 import httpx
 
+from miles.utils.test_utils.openai_stream_client import stream_chat_completions
+
 logger = logging.getLogger(__name__)
 
 MAX_TOOL_TURNS = 8
@@ -105,6 +107,11 @@ async def _chat(
     }
     if tool_choice is not None:
         payload["tool_choice"] = tool_choice
+    # Streaming is the e2e default: black-box agent harnesses mostly consume
+    # chat completions as SSE, so exercise the session server's fake-streaming
+    # path unless the caller opts out with stream=False in request_kwargs.
+    if payload.pop("stream", True):
+        return await stream_chat_completions(client, f"{url}/v1/chat/completions", payload, label=label)
     resp = await client.post(f"{url}/v1/chat/completions", json=payload)
     assert resp.status_code == 200, f"{label} failed ({resp.status_code}): {resp.text}"
     return resp.json()

--- a/tests/fast/router/test_sessions.py
+++ b/tests/fast/router/test_sessions.py
@@ -1,11 +1,13 @@
 """Integration tests for session HTTP routes (create / get / delete / proxy)."""
 
+import asyncio
 import json
 import re
 import uuid
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import httpx
 import pytest
 import requests
 from fastapi.responses import JSONResponse
@@ -13,6 +15,7 @@ from fastapi.responses import JSONResponse
 from miles.rollout.session.server import SessionServer
 from miles.utils.http_utils import find_available_port
 from miles.utils.test_utils.mock_sglang_server import MockSGLangServer, ProcessResult, with_mock_server
+from miles.utils.test_utils.openai_stream_client import stream_chat_completions
 from miles.utils.test_utils.uvicorn_thread_server import UvicornThreadServer
 
 
@@ -348,6 +351,73 @@ class TestChatFakeStreaming:
         assert resp.status_code == 200
         assert resp.headers["content-type"].startswith("application/json")
         assert resp.json()["choices"][0]["message"]["content"]
+
+    def test_streaming_client_multi_turn_passes_prefix_check(self, router_env):
+        """The rebuilt assistant message must survive the next turn's TITO prefix check."""
+        session_id = _create_session(router_env.url)
+        url = f"{router_env.url}/sessions/{session_id}/v1/chat/completions"
+
+        async def run():
+            async with httpx.AsyncClient(timeout=10) as client:
+                first = await stream_chat_completions(client, url, {"messages": self.MESSAGES}, label="turn 1")
+                messages = [
+                    *self.MESSAGES,
+                    first["choices"][0]["message"],
+                    {"role": "tool", "content": "ok", "tool_call_id": "t0"},
+                ]
+                second = await stream_chat_completions(client, url, {"messages": messages}, label="turn 2")
+                return first, second
+
+        first, second = asyncio.run(run())
+        assert first["choices"][0]["message"]["content"]
+        assert second["choices"][0]["message"]["content"]
+        # Turn 2 extended (not rolled back) the session: both records are kept.
+        records = requests.get(f"{router_env.url}/sessions/{session_id}", timeout=5.0).json()["records"]
+        assert len(records) == 2
+
+    def test_streaming_client_rebuilds_tool_calls_exactly(self, router_env):
+        """Rebuilt tool_calls must dict-equal the record's stored assistant tool_calls."""
+        session_id = _create_session(router_env.url)
+        url = f"{router_env.url}/sessions/{session_id}/v1/chat/completions"
+
+        def tool_call_process_fn(prompt: str) -> ProcessResult:
+            return ProcessResult(
+                text=(
+                    '<tool_call>\n{"name": "get_weather", "arguments": {"city": "Beijing"}}\n</tool_call>\n'
+                    '<tool_call>\n{"name": "get_time", "arguments": {"timezone": "UTC"}}\n</tool_call>'
+                )
+            )
+
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "parameters": {"type": "object", "properties": {"city": {"type": "string"}}},
+                },
+            },
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_time",
+                    "parameters": {"type": "object", "properties": {"timezone": {"type": "string"}}},
+                },
+            },
+        ]
+
+        async def run():
+            async with httpx.AsyncClient(timeout=10) as client:
+                return await stream_chat_completions(
+                    client, url, {"messages": self.MESSAGES, "tools": tools}, label="tool turn"
+                )
+
+        with patch.object(router_env.backend, "process_fn", new=tool_call_process_fn):
+            response = asyncio.run(run())
+
+        rebuilt = response["choices"][0]["message"]["tool_calls"]
+        record = requests.get(f"{router_env.url}/sessions/{session_id}", timeout=5.0).json()["records"][0]
+        stored = record["response"]["choices"][0]["message"]["tool_calls"]
+        assert rebuilt == stored
 
     def test_openai_sdk_accumulates_fake_stream(self, router_env):
         openai = pytest.importorskip("openai")

--- a/tests/fast/router/test_sessions.py
+++ b/tests/fast/router/test_sessions.py
@@ -13,6 +13,7 @@ import requests
 from fastapi.responses import JSONResponse
 
 from miles.rollout.session.server import SessionServer
+from miles.utils.chat_template_utils import message_matches
 from miles.utils.http_utils import find_available_port
 from miles.utils.test_utils.mock_sglang_server import MockSGLangServer, ProcessResult, with_mock_server
 from miles.utils.test_utils.openai_stream_client import stream_chat_completions
@@ -375,8 +376,14 @@ class TestChatFakeStreaming:
         records = requests.get(f"{router_env.url}/sessions/{session_id}", timeout=5.0).json()["records"]
         assert len(records) == 2
 
-    def test_streaming_client_rebuilds_tool_calls_exactly(self, router_env):
-        """Rebuilt tool_calls must dict-equal the record's stored assistant tool_calls."""
+    def test_streaming_client_rebuilt_tool_calls_match_stored(self, router_env):
+        """Rebuilt tool_calls must match the stored assistant under message_matches.
+
+        The stored message keeps SGLang's wire shape (tool_calls carry
+        ``index``); a protocol-faithful streaming client drops that
+        streaming-only key when rebuilding.  The server's own comparison
+        (``message_matches``) must treat the two as equal — dict equality is
+        deliberately NOT the contract."""
         session_id = _create_session(router_env.url)
         url = f"{router_env.url}/sessions/{session_id}/v1/chat/completions"
 
@@ -414,10 +421,77 @@ class TestChatFakeStreaming:
         with patch.object(router_env.backend, "process_fn", new=tool_call_process_fn):
             response = asyncio.run(run())
 
-        rebuilt = response["choices"][0]["message"]["tool_calls"]
+        rebuilt_message = response["choices"][0]["message"]
         record = requests.get(f"{router_env.url}/sessions/{session_id}", timeout=5.0).json()["records"][0]
-        stored = record["response"]["choices"][0]["message"]["tool_calls"]
-        assert rebuilt == stored
+        stored_message = record["response"]["choices"][0]["message"]
+        # Mock fidelity guard: the stored wire shape carries index, the rebuilt drops it.
+        assert all("index" in tool_call for tool_call in stored_message["tool_calls"])
+        assert all("index" not in tool_call for tool_call in rebuilt_message["tool_calls"])
+        assert message_matches(stored_message, rebuilt_message)
+        # Template-relevant substance survives the round-trip exactly.
+        assert [tool_call["function"] for tool_call in rebuilt_message["tool_calls"]] == [
+            tool_call["function"] for tool_call in stored_message["tool_calls"]
+        ]
+        assert [tool_call["id"] for tool_call in rebuilt_message["tool_calls"]] == [
+            tool_call["id"] for tool_call in stored_message["tool_calls"]
+        ]
+
+    def test_streaming_client_tool_call_turn_then_tool_result_continues(self, router_env):
+        """Regression: a streamed tool-call turn must not roll back the next turn.
+
+        This is the CPU incarnation of the stage-c multi-role e2e failure: the
+        stored assistant carries SGLang-shaped tool_calls (with ``index``), the
+        client replays the SSE-rebuilt message (without it), and the follow-up
+        tool_result request must extend the session instead of dying with
+        HTTP 400 ``rollback failed``."""
+        session_id = _create_session(router_env.url)
+        url = f"{router_env.url}/sessions/{session_id}/v1/chat/completions"
+
+        def tool_then_text_process_fn(prompt: str) -> ProcessResult:
+            if "TOOL_SENTINEL_42" in prompt:
+                return ProcessResult(text="Final answer after tool.")
+            return ProcessResult(
+                text='<tool_call>\n{"name": "get_weather", "arguments": {"city": "Beijing"}}\n</tool_call>'
+            )
+
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "parameters": {"type": "object", "properties": {"city": {"type": "string"}}},
+                },
+            },
+        ]
+
+        async def run():
+            async with httpx.AsyncClient(timeout=10) as client:
+                first = await stream_chat_completions(
+                    client, url, {"messages": self.MESSAGES, "tools": tools}, label="tool turn"
+                )
+                assistant = first["choices"][0]["message"]
+                messages = [
+                    *self.MESSAGES,
+                    assistant,
+                    {
+                        "role": "tool",
+                        "content": "TOOL_SENTINEL_42",
+                        "tool_call_id": assistant["tool_calls"][0]["id"],
+                    },
+                ]
+                second = await stream_chat_completions(
+                    client, url, {"messages": messages, "tools": tools}, label="tool_result turn"
+                )
+                return first, second
+
+        with patch.object(router_env.backend, "process_fn", new=tool_then_text_process_fn):
+            first, second = asyncio.run(run())
+
+        assert first["choices"][0]["finish_reason"] == "tool_calls"
+        assert second["choices"][0]["message"]["content"] == "Final answer after tool."
+        # Turn 2 extended (not rolled back) the session: both records are kept.
+        records = requests.get(f"{router_env.url}/sessions/{session_id}", timeout=5.0).json()["records"]
+        assert len(records) == 2
 
     def test_openai_sdk_accumulates_fake_stream(self, router_env):
         openai = pytest.importorskip("openai")

--- a/tests/fast/router/test_sessions.py
+++ b/tests/fast/router/test_sessions.py
@@ -1,5 +1,6 @@
 """Integration tests for session HTTP routes (create / get / delete / proxy)."""
 
+import json
 import re
 import uuid
 from types import SimpleNamespace
@@ -7,11 +8,25 @@ from unittest.mock import patch
 
 import pytest
 import requests
+from fastapi.responses import JSONResponse
 
 from miles.rollout.session.server import SessionServer
 from miles.utils.http_utils import find_available_port
 from miles.utils.test_utils.mock_sglang_server import MockSGLangServer, ProcessResult, with_mock_server
 from miles.utils.test_utils.uvicorn_thread_server import UvicornThreadServer
+
+
+def _create_session(url: str) -> str:
+    return requests.post(f"{url}/sessions", timeout=5.0).json()["session_id"]
+
+
+def _post_chat(url: str, session_id: str, payload: dict) -> requests.Response:
+    return requests.post(f"{url}/sessions/{session_id}/v1/chat/completions", json=payload, timeout=10.0)
+
+
+def _parse_sse(body: str) -> list[str]:
+    """Return the data payload of each SSE event, in order."""
+    return [block[len("data: ") :] for block in body.split("\n\n") if block.startswith("data: ")]
 
 
 @pytest.fixture(scope="class")
@@ -197,3 +212,163 @@ class TestSessionProxy:
         record_meta = record["response"]["choices"][0]["meta_info"]
         assert record_meta["routed_experts"] == [[0, 1], [2, 3]]
         assert record_meta["indexer_topk"] == [[4], [5]]
+
+
+class TestChatFakeStreaming:
+    """``stream: true`` is fake streaming: non-streaming backend call, single SSE chunk."""
+
+    MESSAGES = [{"role": "user", "content": "What is 1+2?"}]
+
+    def test_stream_single_chunk_matches_non_stream(self, router_env):
+        non_stream_sid = _create_session(router_env.url)
+        stream_sid = _create_session(router_env.url)
+
+        non_stream = _post_chat(router_env.url, non_stream_sid, {"messages": self.MESSAGES}).json()
+
+        resp = _post_chat(
+            router_env.url,
+            stream_sid,
+            {"messages": self.MESSAGES, "stream": True, "stream_options": {"include_usage": True}},
+        )
+        assert resp.status_code == 200
+        assert resp.headers["content-type"].startswith("text/event-stream")
+
+        events = _parse_sse(resp.text)
+        assert len(events) == 2
+        assert events[1] == "[DONE]"
+
+        chunk = json.loads(events[0])
+        assert chunk["object"] == "chat.completion.chunk"
+        assert chunk["model"] == "mock-model"
+        [chunk_choice] = chunk["choices"]
+        expected_choice = non_stream["choices"][0]
+        assert chunk_choice["delta"]["role"] == "assistant"
+        assert chunk_choice["delta"]["content"] == expected_choice["message"]["content"]
+        assert chunk_choice["finish_reason"] == expected_choice["finish_reason"] == "stop"
+        # Training payloads never reach the chunk; they live on the session record.
+        assert "meta_info" not in chunk_choice
+        assert "routed_experts" not in resp.text
+        assert "indexer_topk" not in resp.text
+
+        # Neither the backend nor the record sees the stream flags.
+        backend_payload = router_env.backend.request_log[-1]
+        assert "stream" not in backend_payload
+        assert "stream_options" not in backend_payload
+
+        stream_record = requests.get(f"{router_env.url}/sessions/{stream_sid}", timeout=5.0).json()["records"][0]
+        non_stream_record = requests.get(f"{router_env.url}/sessions/{non_stream_sid}", timeout=5.0).json()["records"][
+            0
+        ]
+        assert stream_record["request"] == non_stream_record["request"]
+        assert (
+            stream_record["response"]["choices"][0]["message"]
+            == non_stream_record["response"]["choices"][0]["message"]
+        )
+        assert (
+            stream_record["response"]["choices"][0]["meta_info"]
+            == non_stream_record["response"]["choices"][0]["meta_info"]
+        )
+
+    def test_stream_tool_calls_single_chunk_with_index(self, router_env):
+        session_id = _create_session(router_env.url)
+
+        def tool_call_process_fn(prompt: str) -> ProcessResult:
+            return ProcessResult(
+                text=(
+                    '<tool_call>\n{"name": "get_weather", "arguments": {"city": "Beijing"}}\n</tool_call>\n<tool_call>\n{"name": "get_time", "arguments": {"timezone": "UTC"}}\n</tool_call>'
+                )
+            )
+
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "parameters": {"type": "object", "properties": {"city": {"type": "string"}}},
+                },
+            },
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_time",
+                    "parameters": {"type": "object", "properties": {"timezone": {"type": "string"}}},
+                },
+            },
+        ]
+
+        with patch.object(router_env.backend, "process_fn", new=tool_call_process_fn):
+            resp = _post_chat(router_env.url, session_id, {"messages": self.MESSAGES, "tools": tools, "stream": True})
+
+        assert resp.status_code == 200
+        chunk = json.loads(_parse_sse(resp.text)[0])
+        [chunk_choice] = chunk["choices"]
+        assert chunk_choice["finish_reason"] == "tool_calls"
+        tool_calls = chunk_choice["delta"]["tool_calls"]
+        assert [tool_call["index"] for tool_call in tool_calls] == [0, 1]
+        assert [tool_call["function"]["name"] for tool_call in tool_calls] == ["get_weather", "get_time"]
+        for tool_call in tool_calls:
+            json.loads(tool_call["function"]["arguments"])
+
+    def test_stream_passes_through_usage_and_length_finish_reason(self, router_env):
+        session_id = _create_session(router_env.url)
+        fixture_response = MockSGLangServer._compute_chat_completions_response
+
+        def length_with_usage(self, payload: dict) -> dict:
+            response = fixture_response(self, payload)
+            response["choices"][0]["finish_reason"] = "length"
+            response["usage"] = {"prompt_tokens": 5, "completion_tokens": 7, "total_tokens": 12}
+            return response
+
+        with patch.object(MockSGLangServer, "_compute_chat_completions_response", new=length_with_usage):
+            resp = _post_chat(router_env.url, session_id, {"messages": self.MESSAGES, "stream": True})
+
+        assert resp.status_code == 200
+        chunk = json.loads(_parse_sse(resp.text)[0])
+        assert chunk["choices"][0]["finish_reason"] == "length"
+        assert chunk["usage"] == {"prompt_tokens": 5, "completion_tokens": 7, "total_tokens": 12}
+
+    def test_stream_backend_error_passes_through_json(self, router_env):
+        session_id = _create_session(router_env.url)
+
+        async def reject(self, request, compute_fn):
+            return JSONResponse(content={"error": "context too long"}, status_code=400)
+
+        with patch.object(MockSGLangServer, "_handle_generate_like_request", new=reject):
+            resp = _post_chat(router_env.url, session_id, {"messages": self.MESSAGES, "stream": True})
+
+        assert resp.status_code == 400
+        assert resp.headers["content-type"].startswith("application/json")
+        assert resp.json() == {"error": "context too long"}
+        records = requests.get(f"{router_env.url}/sessions/{session_id}", timeout=5.0).json()["records"]
+        assert records == []
+
+    def test_stream_false_keeps_json_response(self, router_env):
+        session_id = _create_session(router_env.url)
+        resp = _post_chat(router_env.url, session_id, {"messages": self.MESSAGES, "stream": False})
+        assert resp.status_code == 200
+        assert resp.headers["content-type"].startswith("application/json")
+        assert resp.json()["choices"][0]["message"]["content"]
+
+    def test_openai_sdk_accumulates_fake_stream(self, router_env):
+        openai = pytest.importorskip("openai")
+
+        non_stream_sid = _create_session(router_env.url)
+        stream_sid = _create_session(router_env.url)
+
+        expected = _post_chat(router_env.url, non_stream_sid, {"messages": self.MESSAGES}).json()
+        expected_content = expected["choices"][0]["message"]["content"]
+
+        client = openai.OpenAI(
+            base_url=f"{router_env.url}/sessions/{stream_sid}/v1", api_key="not-used", max_retries=0
+        )
+        stream = client.chat.completions.create(model="mock-model", messages=self.MESSAGES, stream=True)
+        content = ""
+        finish_reason = None
+        for chunk in stream:
+            [choice] = chunk.choices
+            if choice.delta.content:
+                content += choice.delta.content
+            if choice.finish_reason:
+                finish_reason = choice.finish_reason
+        assert content == expected_content
+        assert finish_reason == "stop"

--- a/tests/fast/utils/chat_template_utils/test_template.py
+++ b/tests/fast/utils/chat_template_utils/test_template.py
@@ -27,7 +27,12 @@ from sglang.srt.entrypoints.openai.protocol import ChatCompletionRequest
 from sglang.srt.entrypoints.openai.serving_chat import OpenAIServingChat
 from transformers import AutoTokenizer
 
-from miles.utils.chat_template_utils import TITOTokenizerType, get_tito_tokenizer, resolve_fixed_chat_template
+from miles.utils.chat_template_utils import (
+    TITOTokenizerType,
+    get_tito_tokenizer,
+    message_matches,
+    resolve_fixed_chat_template,
+)
 from miles.utils.chat_template_utils.template import apply_chat_template
 from miles.utils.processing_utils import load_tokenizer
 from miles.utils.test_utils.chat_template_verify import (
@@ -559,3 +564,53 @@ class TestDeepSeekV4TITOAlignWithSGLang:
 
         actual = tito.render_messages(messages, add_generation_prompt=True, tools=tools, tokenize=True)
         assert actual == expected
+
+
+class TestMessageMatches:
+    """message_matches compares template-relevant content, not wire idiosyncrasies."""
+
+    STORED_SGLANG_WIRE = {
+        "role": "assistant",
+        "content": "",
+        "reasoning_content": None,
+        "tool_calls": [
+            {
+                "id": "call_abc",
+                "index": 0,
+                "type": "function",
+                "function": {"name": "get_weather", "arguments": '{"city": "Paris"}'},
+            }
+        ],
+    }
+
+    def _rebuilt(self, **tool_call_overrides):
+        tool_call = {
+            "id": "call_abc",
+            "type": "function",
+            "function": {"name": "get_weather", "arguments": '{"city": "Paris"}'},
+            **tool_call_overrides,
+        }
+        return {"role": "assistant", "content": "", "tool_calls": [tool_call]}
+
+    @pytest.mark.parametrize("index_value", [0, 7, None], ids=["int", "other-int", "null"])
+    def test_stream_rebuilt_replay_matches_sglang_wire(self, index_value):
+        stored = copy.deepcopy(self.STORED_SGLANG_WIRE)
+        stored["tool_calls"][0]["index"] = index_value
+        assert message_matches(stored, self._rebuilt())
+
+    def test_null_valued_tool_call_key_matches_absent_key(self):
+        assert message_matches(self.STORED_SGLANG_WIRE, self._rebuilt(index=None))
+
+    def test_different_arguments_still_mismatch(self):
+        rebuilt = self._rebuilt()
+        rebuilt["tool_calls"][0]["function"] = {"name": "get_weather", "arguments": '{"city": "Rome"}'}
+        assert not message_matches(self.STORED_SGLANG_WIRE, rebuilt)
+
+    def test_different_tool_call_id_still_mismatches(self):
+        rebuilt = self._rebuilt(id="call_zzz")
+        assert not message_matches(self.STORED_SGLANG_WIRE, rebuilt)
+
+    def test_content_mismatch_still_detected(self):
+        rebuilt = self._rebuilt()
+        rebuilt["content"] = "different"
+        assert not message_matches(self.STORED_SGLANG_WIRE, rebuilt)

--- a/tests/fast/utils/chat_template_utils/test_template.py
+++ b/tests/fast/utils/chat_template_utils/test_template.py
@@ -598,8 +598,15 @@ class TestMessageMatches:
         stored["tool_calls"][0]["index"] = index_value
         assert message_matches(stored, self._rebuilt())
 
-    def test_null_valued_tool_call_key_matches_absent_key(self):
+    def test_null_index_matches_absent_index(self):
         assert message_matches(self.STORED_SGLANG_WIRE, self._rebuilt(index=None))
+
+    def test_null_tool_call_id_does_not_match_absent_id(self):
+        stored = copy.deepcopy(self.STORED_SGLANG_WIRE)
+        stored["tool_calls"][0]["id"] = None
+        rebuilt = self._rebuilt()
+        del rebuilt["tool_calls"][0]["id"]
+        assert not message_matches(stored, rebuilt)
 
     def test_different_arguments_still_mismatch(self):
         rebuilt = self._rebuilt()

--- a/tests/fast/utils/test_utils/test_mock_sglang_server.py
+++ b/tests/fast/utils/test_utils/test_mock_sglang_server.py
@@ -299,7 +299,12 @@ class TestChatCompletionsEndpoint:
                     "role": "assistant",
                     "content": "Let me check for you.",
                     "tool_calls": [
-                        {"id": "call00000", "type": "function", "function": {"name": "get_year", "arguments": "{}"}}
+                        {
+                            "id": "call00000",
+                            "index": 0,
+                            "type": "function",
+                            "function": {"name": "get_year", "arguments": "{}"},
+                        }
                     ],
                 },
                 "logprobs": {"content": expected_logprobs(server.tokenizer, tool_call_response)},
@@ -375,9 +380,15 @@ class TestChatCompletionsEndpoint:
                     "role": "assistant",
                     "content": "I will get year and temperature.",
                     "tool_calls": [
-                        {"id": "call00000", "type": "function", "function": {"name": "get_year", "arguments": "{}"}},
+                        {
+                            "id": "call00000",
+                            "index": 0,
+                            "type": "function",
+                            "function": {"name": "get_year", "arguments": "{}"},
+                        },
                         {
                             "id": "call00001",
+                            "index": 1,
                             "type": "function",
                             "function": {"name": "get_temperature", "arguments": '{"location": "Shanghai"}'},
                         },
@@ -420,7 +431,7 @@ class TestMultiTurnToolCallProcessFn:
             pytest.param(
                 TwoTurnStub.OPENAI_MESSAGES_FIRST_TURN,
                 TwoTurnStub.FIRST_RESPONSE_CONTENT,
-                TwoTurnStub.FIRST_TOOL_CALLS_OPENAI_FORMAT,
+                TwoTurnStub.FIRST_TOOL_CALLS_SGLANG_WIRE,
                 "tool_calls",
                 id="first_turn",
             ),


### PR DESCRIPTION
## Summary
Serve `stream: true` chat completions from the session server as fake streaming (single SSE chunk).

## Motivation
Streaming clients hitting POST /sessions/{id}/v1/chat/completions got a
deterministic 400 today: the session server always injects
return_meta_info=True, and sglang rejects that combination with
stream=true. TITO also needs the complete non-streaming response
(choices[0].message + meta_info.output_token_logprobs), so real
streaming passthrough cannot work either.

## Usage
```bash
curl -N http://<router>/sessions/<id>/v1/chat/completions \
  -d '{"messages": [{"role": "user", "content": "hi"}], "stream": true}'
```
Returns `text/event-stream` with one `chat.completion.chunk` carrying the whole message as one delta, then `data: [DONE]`. TITO tracking, `SessionRecord`, `GET /sessions/{id}` all stay identical to a non-streaming request.

## Design Notes
- **Key choices:** `chat_completions` pops `stream`/`stream_options` in Phase 1, keeping the backend call plus the `SessionRecord` non-streaming.
- `_response_to_stream_chunk` (adapted from NVIDIA-NeMo/ProRL-Agent-Server & THUDM/slime) puts all tool_calls in the single chunk with `index` set because fragmented arguments across chunks break real clients.
- Streaming clients rebuilding the assistant message drop the wire-only tool_call `index` that sglang always serializes, so `message_matches` now ignores `index` plus null-valued keys inside tool_calls.
- `MockSGLangServer` now emits `index` like real sglang, making the fast suite exercise the true wire shape.
- Errors keep their real status codes as JSON because every failure occurs before the SSE body is built.
- **Alternatives considered:** real streaming passthrough — sglang rejects `return_meta_info` with `stream=true`; per-chunk responses break TITO validation.
- Heartbeat / token slicing commits HTTP 200 before the result exists, degrading upstream errors to in-stream events.

## Verification

| test | asserts |
|---|---|
| `TestChatFakeStreaming` (tests/fast/router/test_sessions.py) | single-chunk parity with non-streaming; stream flags never reach backend or record; tool_calls in one chunk with parseable arguments; usage and `finish_reason="length"` passthrough; backend 400 passes through as JSON without a record; `stream: false` regression; openai SDK accumulation; streamed tool-call turn then tool_result continuation extends the session without rollback |
| `TestMessageMatches` (tests/fast/utils/chat_template_utils/test_template.py) | tool_call `index` int/null/absent all match; real `id`/`arguments`/`content` diffs still mismatch |

- Affected fast suites (router, mock server, generate_hub, chat template): 457 passed.

## Review Focus
- Scrutinize `_normalize_tool_calls` in miles/utils/chat_template_utils/template.py: it must ignore only wire-only artifacts, never real tool_call differences.
- Scrutinize the `_response_to_stream_chunk` delta shape (role/content/reasoning_content/tool_calls with `index`) against real client accumulators.
- Scrutinize the three `_chat_client_response` call sites: the `closing` / `num_assistant` race paths must also honor `client_stream`.
