### PR TITLE
refactor(fsdp): remove obsolete s_aux guard

### DIFF
--- a/miles/backends/experimental/fsdp_utils/adaptations/class_patches.py
+++ b/miles/backends/experimental/fsdp_utils/adaptations/class_patches.py
@@ -4,61 +4,9 @@ The FSDP backend trains the stock HF model, so it's sensitive to transformers-ve
 idempotent patches keep the training forward runnable and warn when it diverges from the SGLang rollout.
 """
 
-import inspect
 import logging
-import textwrap
 
 logger = logging.getLogger(__name__)
-
-
-def apply_flash_attn_saux_guard() -> bool:
-    """Guard ``s_aux`` (attention sink) against None in transformers 5.6.0 flash_attention_forward, which
-    does ``s_aux.to(query.dtype)`` unconditionally and crashes sink-less models (Qwen3). Returns True if patched."""
-    try:
-        import transformers.integrations.flash_attention as fa
-    except Exception:  # pragma: no cover
-        return False
-    try:
-        src = inspect.getsource(fa.flash_attention_forward)
-    except (OSError, TypeError):
-        return False
-
-    BUG = "s_aux=s_aux.to(query.dtype)"
-    if "if s_aux is not None" in src or BUG not in src:
-        return False  # already guarded, or an unrecognized layout
-
-    new_src = textwrap.dedent(src).replace(BUG, "s_aux=(s_aux.to(query.dtype) if s_aux is not None else None)")
-    ns = vars(fa)
-    try:
-        exec(compile(new_src, fa.__file__, "exec"), ns)  # noqa: S102 - controlled recompile
-    except Exception as e:  # pragma: no cover
-        logger.warning(f"[fsdp class_patches] s_aux guard compile failed: {e}")
-        return False
-    patched = ns["flash_attention_forward"]
-    patched._saux_guarded = True
-    fa.flash_attention_forward = patched
-
-    try:
-        from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS as A
-
-        for key in list(A.valid_keys()):
-            try:
-                cur = A[key]
-            except Exception:
-                continue
-            if getattr(cur, "__name__", None) == "flash_attention_forward":
-                try:
-                    A[key] = patched
-                except Exception:
-                    try:
-                        A.register(key, patched, exist_ok=True)
-                    except Exception:
-                        pass
-    except Exception as e:  # pragma: no cover
-        logger.warning(f"[fsdp class_patches] s_aux guard re-register skipped: {e}")
-
-    logger.info("[fsdp class_patches] applied flash-attention s_aux None-guard")
-    return True
 
 
 def check_train_infer_consistency(hf_config) -> None:
@@ -112,15 +60,10 @@ def register_model_patch(hook: ModelPatchHook) -> None:
     _MODEL_PATCH_HOOKS.append(hook)
 
 
-def _always(hf_config) -> bool:
-    return True
-
-
 def _has_config(hf_config) -> bool:
     return hf_config is not None
 
 
-register_model_patch(ModelPatchHook("flash_attn_saux_guard", _always, lambda cfg, args: apply_flash_attn_saux_guard()))
 register_model_patch(ModelPatchHook("fp8_checkpoint_guard", _has_config, lambda cfg, args: check_fp8_checkpoint(cfg)))
 register_model_patch(
     ModelPatchHook("dsa_train_infer_warn", _has_config, lambda cfg, args: check_train_infer_consistency(cfg))

--- a/tests/fast/backends/test_fsdp_hf_compat.py
+++ b/tests/fast/backends/test_fsdp_hf_compat.py
@@ -210,21 +210,18 @@ def test_weight_bridge_registry():
 
 def test_model_patch_registry_gating():
     # The ModelPatchHook registry replaces the hardcoded per-arch dispatch in apply_class_patches.
-    # Verify the predicates gate correctly (s_aux always; config-checks need a config). Packed-sequence
-    # layout patches (GDN, ...) moved out of this registry into the unified packing registry
-    # (test_packing_registry below); apply_class_patches now dispatches them via apply_packing.
+    # Verify the config-check predicates gate correctly. Packed-sequence layout patches (GDN, ...) moved
+    # out of this registry into the unified packing registry (test_packing_registry below);
+    # apply_class_patches now dispatches them via apply_packing.
     from miles.backends.experimental.fsdp_utils.adaptations.class_patches import _MODEL_PATCH_HOOKS
 
     by_name = {h.name: h for h in _MODEL_PATCH_HOOKS}
-    # the three expected hooks are registered, in order (GDN packing no longer a ModelPatchHook)
-    assert [h.name for h in _MODEL_PATCH_HOOKS][:3] == [
-        "flash_attn_saux_guard",
+    # the two expected generic hooks are registered, in order (GDN packing no longer a ModelPatchHook)
+    assert [h.name for h in _MODEL_PATCH_HOOKS][:2] == [
         "fp8_checkpoint_guard",
         "dsa_train_infer_warn",
     ]
     assert "gated_deltanet_packing" not in by_name
-    # s_aux guard runs even without a config; the others don't
-    assert by_name["flash_attn_saux_guard"].applies_to(None)
     assert not by_name["fp8_checkpoint_guard"].applies_to(None)
     # the qwen3_moe MoE-block patch is a hook now (moved out of _enable_true_on_policy_optimizations),
     # gated on model_type; the backend-level enable_batch_invariant_mode stays in the actor.


### PR DESCRIPTION
## Summary

- Remove the obsolete `flash_attn_saux_guard` runtime source patch.
- Update the FSDP compatibility-registry test to match the remaining hooks.

## Motivation

Miles pins `transformers==5.12.1`, whose `flash_attention_forward` already checks that `s_aux` is not `None` before casting it. The local compatibility hook therefore returns without changing anything and leaves an unnecessary source-inspection and `exec` path in the FSDP setup.

## Before / After

Before, the compatibility registry attempted to inspect and rewrite `flash_attention_forward` at startup for an older Transformers implementation.

After, Miles relies on the guarded implementation in its pinned Transformers version while preserving every other generic and architecture-specific compatibility hook.

## Behavior Preservation

The supported dependency already contains the same `s_aux` guard, so removing the no-op rewrite does not change current runtime behavior. The exact Transformers pin prevents silently falling back to an older unguarded implementation.

## Verification

- `python -m pytest tests/fast/backends/test_fsdp_hf_compat.py -q` — 12 passed.
- `pre-commit run --files miles/backends/experimental/fsdp_utils/adaptations/class_patches.py tests/fast/backends/test_fsdp_hf_compat.py` — passed.
- `git diff --check` — passed.
- Independent read-only review found no residual guard consumers or unrelated changes.

## Review Focus

- Confirm that the pinned Transformers implementation makes the deleted rewrite redundant.
- Confirm that the registry-test edits only remove expectations forced by deleting that hook.
