### PR TITLE
feat: support DeepSeek V4 THD packing

### DIFF
--- a/miles/backends/experimental/fsdp_utils/actor.py
+++ b/miles/backends/experimental/fsdp_utils/actor.py
@@ -386,6 +386,7 @@ class FSDPTrainRayActor(TrainRayActor):
                             response_lengths=batch["response_lengths"],
                             with_entropy=(store_prefix == ""),
                             max_seq_lens=batch.get("max_seq_lens", None),
+                            padded_total_lengths=batch.get("padded_total_lengths", None),
                         )
 
                         batch_result = {

--- a/miles/backends/megatron_utils/parallel.py
+++ b/miles/backends/megatron_utils/parallel.py
@@ -98,6 +98,7 @@ def get_packed_seq_params(batch: dict[str, torch.Tensor], args: Namespace) -> Pa
             max_seqlen_kv=batch["max_seqlen"],
             qkv_format="thd",
         )
+        packed_seq_params.miles_allgather_cp = bool(getattr(args, "allgather_cp", False))
         batch["packed_seq_params"] = packed_seq_params
         return packed_seq_params
     else:

--- a/miles/backends/sglang_utils/arguments.py
+++ b/miles/backends/sglang_utils/arguments.py
@@ -136,6 +136,11 @@ def add_sglang_arguments(parser):
 
 def validate_args(args):
     args.sglang_tp_size = args.rollout_num_gpus_per_engine
+    args.sglang_dp_size = args.sglang_data_parallel_size
+    args.sglang_pp_size = args.sglang_pipeline_parallel_size
+    args.sglang_ep_size = args.sglang_expert_parallel_size
+    if hasattr(args, "sglang_attention_context_parallel_size"):
+        args.sglang_attn_cp_size = args.sglang_attention_context_parallel_size
 
     if args.true_on_policy_mode:
         args.sglang_enable_deterministic_inference = True

--- a/miles/backends/training_utils/cp_utils.py
+++ b/miles/backends/training_utils/cp_utils.py
@@ -21,6 +21,7 @@ def get_logits_and_tokens_offset_with_cp(
     response_length: int,
     qkv_format: str = "thd",
     max_seq_len: int | None = None,
+    padded_total_length: int | None = None,
 ):
     """
     All offsets start from the begining of the prompt.
@@ -31,8 +32,10 @@ def get_logits_and_tokens_offset_with_cp(
     assert cp_size > 1
 
     prompt_length = total_length - response_length
+    effective_total_length = padded_total_length if padded_total_length is not None else total_length
+
     if qkv_format == "thd":
-        chunk_size = (total_length + 2 * cp_size - 1) // (2 * cp_size)
+        chunk_size = (effective_total_length + 2 * cp_size - 1) // (2 * cp_size)
     else:
         assert max_seq_len is not None, "max_seq_len must be provided for qkv_format=bshd"
         chunk_size = (max_seq_len + 2 * cp_size - 1) // (2 * cp_size)
@@ -67,11 +70,12 @@ def _slice_loss_mask_for_local_cp(
     loss_mask: torch.Tensor,
     qkv_format: str,
     max_seq_len: int | None,
+    padded_total_length: int | None = None,
 ) -> torch.Tensor:
     """Slice a per-sample response loss mask into this CP rank's local zigzag layout."""
     prompt_length = total_length - response_length
     _, _, _, tokens_offset = get_logits_and_tokens_offset_with_cp(
-        total_length, response_length, qkv_format, max_seq_len
+        total_length, response_length, qkv_format, max_seq_len, padded_total_length
     )
     mask_0 = loss_mask[tokens_offset[0][0] - prompt_length : tokens_offset[0][1] - prompt_length]
     mask_1 = loss_mask[tokens_offset[1][0] - prompt_length : tokens_offset[1][1] - prompt_length]
@@ -84,9 +88,12 @@ def slice_loss_masks_for_local_cp(
     response_lengths: list[int],
     qkv_format: str = "thd",
     max_seq_lens: list[int] | None = None,
+    padded_total_lengths: list[int] | None = None,
 ) -> list[torch.Tensor]:
     """Backward-compatible wrapper for local CP response mask slicing."""
-    return get_local_response_loss_masks(total_lengths, response_lengths, loss_masks, qkv_format, max_seq_lens)
+    return get_local_response_loss_masks(
+        total_lengths, response_lengths, loss_masks, qkv_format, max_seq_lens, padded_total_lengths
+    )
 
 
 def get_sum_of_sample_mean(
@@ -96,6 +103,7 @@ def get_sum_of_sample_mean(
     calculate_per_token_loss: bool = False,
     qkv_format: str = "thd",
     max_seq_lens: list[int] | None = None,
+    padded_total_lengths: list[int] | None = None,
 ) -> Callable[[torch.Tensor], torch.Tensor]:
     """
     Calculate correct sample mean for CP
@@ -127,8 +135,11 @@ def get_sum_of_sample_mean(
             zip(total_lengths, response_lengths, loss_masks, strict=True)
         ):
             max_seq_len = max_seq_lens[i] if max_seq_lens is not None else None
+            padded_total_length = padded_total_lengths[i] if padded_total_lengths is not None else None
             chunked_loss_masks.append(
-                _slice_loss_mask_for_local_cp(total_length, response_length, loss_mask, qkv_format, max_seq_len)
+                _slice_loss_mask_for_local_cp(
+                    total_length, response_length, loss_mask, qkv_format, max_seq_len, padded_total_length
+                )
             )
             cp_chunk_lengths.append(chunked_loss_masks[i].size(0))
 
@@ -161,6 +172,7 @@ def get_local_response_loss_masks(
     loss_masks: list[torch.Tensor],
     qkv_format: str = "thd",
     max_seq_lens: list[int] | None = None,
+    padded_total_lengths: list[int] | None = None,
 ) -> list[torch.Tensor]:
     """Return response loss masks aligned with this rank's local log-probs."""
     parallel_state = get_parallel_state()
@@ -172,8 +184,11 @@ def get_local_response_loss_masks(
         zip(total_lengths, response_lengths, loss_masks, strict=True)
     ):
         max_seq_len = max_seq_lens[i] if max_seq_lens is not None else None
+        padded_total_length = padded_total_lengths[i] if padded_total_lengths is not None else None
         local_masks.append(
-            _slice_loss_mask_for_local_cp(total_length, response_length, loss_mask, qkv_format, max_seq_len)
+            _slice_loss_mask_for_local_cp(
+                total_length, response_length, loss_mask, qkv_format, max_seq_len, padded_total_length
+            )
         )
 
     return local_masks
@@ -185,6 +200,7 @@ def all_gather_with_cp(
     response_length: int,
     qkv_format: str = "thd",
     max_seq_len: int | None = None,
+    padded_total_length: int | None = None,
 ) -> torch.Tensor:
     """
     Gather tensors across all ranks in the context parallel group.
@@ -198,7 +214,7 @@ def all_gather_with_cp(
         return tensor
 
     _, _, logits_offset, _ = get_logits_and_tokens_offset_with_cp(
-        total_length, response_length, qkv_format, max_seq_len
+        total_length, response_length, qkv_format, max_seq_len, padded_total_length
     )
 
     prompt_length = total_length - response_length
@@ -322,6 +338,7 @@ def allgather_cp_redistribute(
     total_lengths: list[int],
     response_lengths: list[int],
     max_seq_lens: list[int] | None = None,
+    padded_total_lengths: list[int] | None = None,
 ) -> None:
     """Redistribute response tensors from allgather-CP layout to zigzag ring-attn layout.
 
@@ -353,7 +370,9 @@ def allgather_cp_redistribute(
         # Reconstruct full response tensors with each rank's contiguous contribution
         full_resps = []
         seq_start = 0
-        for value, total_length, response_length in zip(values, total_lengths, response_lengths, strict=False):
+        for idx, (value, total_length, response_length) in enumerate(
+            zip(values, total_lengths, response_lengths, strict=False)
+        ):
             prompt_length = total_length - response_length
             logit_global_start = seq_start + prompt_length - 1
             logit_global_end = seq_start + total_length - 1
@@ -376,7 +395,7 @@ def allgather_cp_redistribute(
 
             assert full_resp.size(0) == response_length, f"Expected {response_length}, got {full_resp.size(0)}"
             full_resps.append(full_resp)
-            seq_start += total_length
+            seq_start += padded_total_lengths[idx] if padded_total_lengths is not None else total_length
 
         # Single differentiable all-reduce to gather full response from all CP ranks
         all_cat = torch.cat(full_resps, dim=0)
@@ -388,8 +407,11 @@ def allgather_cp_redistribute(
             zip(all_cat.split(response_lengths, dim=0), total_lengths, response_lengths, strict=False)
         ):
             max_seq_len = max_seq_lens[idx] if max_seq_lens is not None else None
+            padded_total_length = padded_total_lengths[idx] if padded_total_lengths is not None else None
             new_values.append(
-                slice_log_prob_with_cp(full_resp, total_length, response_length, args.qkv_format, max_seq_len)
+                slice_log_prob_with_cp(
+                    full_resp, total_length, response_length, args.qkv_format, max_seq_len, padded_total_length
+                )
             )
 
         res[key] = new_values
@@ -401,6 +423,7 @@ def slice_log_prob_with_cp(
     response_length: int,
     qkv_format: str = "thd",
     max_token_len: int | None = None,
+    padded_total_length: int | None = None,
 ) -> list[float] | torch.Tensor:
     assert len(log_prob) == response_length
 
@@ -412,7 +435,7 @@ def slice_log_prob_with_cp(
 
     prompt_length = total_length - response_length
     _, _, logits_offset, _ = get_logits_and_tokens_offset_with_cp(
-        total_length, response_length, qkv_format, max_token_len
+        total_length, response_length, qkv_format, max_token_len, padded_total_length
     )
 
     chunk_1 = log_prob[logits_offset[0][0] - (prompt_length - 1) : logits_offset[0][1] - (prompt_length - 1)]

--- a/miles/backends/training_utils/data.py
+++ b/miles/backends/training_utils/data.py
@@ -1,4 +1,5 @@
 import logging
+import math
 from argparse import Namespace
 from collections.abc import Sequence
 
@@ -19,6 +20,41 @@ from .mm_data import expand_multimodal_rollout_data_in_place
 from .parallel import get_parallel_state
 
 logger = logging.getLogger(__name__)
+
+
+def _get_thd_sample_pad_multiple(args: Namespace) -> int | None:
+    """Return per-sample padding multiple required by packed THD kernels."""
+    model_name = (getattr(args, "model_name", "") or "").lower().replace("-", "").replace("_", "")
+    is_deepseek_v4 = "deepseekv4" in model_name
+    if not is_deepseek_v4:
+        return None
+
+    compress_ratios = getattr(args, "compress_ratios", None)
+    active_ratios = [int(ratio) for ratio in (compress_ratios or []) if int(ratio) > 1]
+    if not active_ratios:
+        return None
+    return math.lcm(*active_ratios)
+
+
+def get_thd_padded_total_lengths(args: Namespace, total_lengths: Sequence[int]) -> list[int] | None:
+    """Return model-input lengths after DSV4 THD per-sample alignment."""
+    if getattr(args, "qkv_format", None) != "thd":
+        return None
+    multiple = _get_thd_sample_pad_multiple(args)
+    if multiple is None:
+        return None
+    return [((int(length) + multiple - 1) // multiple) * multiple for length in total_lengths]
+
+
+def _get_thd_allgather_pad_multiple(cp_size: int, pad_size: int, sample_pad_multiple: int | None) -> int:
+    """Return a global THD multiple that keeps every contiguous CP shard kernel-aligned."""
+    global_pad_multiple = cp_size * pad_size
+    if sample_pad_multiple is not None:
+        # DSV4 compressors require each CP-local shard to contain a whole
+        # pair of compression groups.  The global stream must therefore be
+        # divisible by 2 * cp_size * every active compression ratio.
+        global_pad_multiple = math.lcm(global_pad_multiple, 2 * cp_size * sample_pad_multiple)
+    return global_pad_multiple
 
 
 def _rollout_logprob_dtype(args: Namespace) -> torch.dtype:
@@ -84,6 +120,8 @@ def get_rollout_data(
 
         rollout_data["max_seq_lens"] = [max_seq_len] * len(rollout_data["tokens"])
 
+    padded_total_lengths = get_thd_padded_total_lengths(args, rollout_data["total_lengths"])
+
     # Full-response SGLang OPD fields share rollout CP slicing but retain float32 precision.
     for key in ("rollout_log_probs", "teacher_log_probs", "opd_reverse_kl"):
         if key in rollout_data:
@@ -96,6 +134,7 @@ def get_rollout_data(
                         response_length,
                         args.qkv_format,
                         rollout_data["max_seq_lens"][i] if args.qkv_format == "bshd" else None,
+                        padded_total_lengths[i] if padded_total_lengths is not None else None,
                     ),
                     device=torch.cuda.current_device(),
                     dtype=dtype,
@@ -164,6 +203,7 @@ def get_batch(
     # use 0 as the pad token id should be fine?
     pad_token_id = 0
     pad_size = parallel_state.tp.size * pad_multiplier
+    padded_total_lengths: list[int] | None = None
 
     # for cp, we need all tokens to calculate logprob
     batch["unconcat_tokens"] = tokens
@@ -189,20 +229,36 @@ def get_batch(
 
     elif qkv_format == "thd":
         cp_rank = parallel_state.cp.rank
+        sample_pad_multiple = _get_thd_sample_pad_multiple(data_iterator.args)
+        padded_total_lengths = [] if sample_pad_multiple is not None else None
+        if sample_pad_multiple is not None and cp_size > 1 and not allgather_cp:
+            raise NotImplementedError(
+                "DeepSeek-V4 THD packing with CP>1 requires --allgather-cp; "
+                "zigzag CP cannot preserve packed sample boundaries yet."
+            )
 
         if allgather_cp:
             assert batch.get("adapter_slots") is None, "allgather CP is currently not supported with multi-LoRA: "
             # DSA mode: concatenate all sequences first, then slice once with CP.
             # We also pad the *global* concatenated stream to make per-rank batches equal.
             cu_seqlens_list: list[int] = [0]
+            padded_tokens: list[torch.Tensor] = []
             for t in tokens:
+                if sample_pad_multiple is not None:
+                    sample_pad = (sample_pad_multiple - t.size(0) % sample_pad_multiple) % sample_pad_multiple
+                    if sample_pad:
+                        t = F.pad(t, (0, sample_pad), value=pad_token_id)
+                    assert padded_total_lengths is not None
+                    padded_total_lengths.append(t.size(0))
+                padded_tokens.append(t)
                 cu_seqlens_list.append(cu_seqlens_list[-1] + t.size(0))
+            tokens = padded_tokens
 
             tokens = torch.cat(tokens, dim=0)
 
             # Pad global stream so (1) divisible by cp_size (equal batches),
             # (2) divisible by pad_size (reduce fragmentation).
-            global_pad_size = cp_size * pad_size
+            global_pad_size = _get_thd_allgather_pad_multiple(cp_size, pad_size, sample_pad_multiple)
             pad = (global_pad_size - tokens.size(0) % global_pad_size) % global_pad_size
             if pad != 0:
                 tokens = F.pad(tokens, (0, pad), value=pad_token_id)
@@ -211,7 +267,16 @@ def get_batch(
             cu_seqlens = torch.tensor(cu_seqlens_list, dtype=torch.int, device=torch.cuda.current_device())
             tokens = tokens.chunk(cp_size, dim=0)[cp_rank]
         else:
-            tokens = [slice_with_cp(t, pad_token_id, qkv_format) for t in tokens]
+            padded_tokens: list[torch.Tensor] = []
+            for t in tokens:
+                if sample_pad_multiple is not None:
+                    sample_pad = (sample_pad_multiple - t.size(0) % sample_pad_multiple) % sample_pad_multiple
+                    if sample_pad:
+                        t = F.pad(t, (0, sample_pad), value=pad_token_id)
+                    assert padded_total_lengths is not None
+                    padded_total_lengths.append(t.size(0))
+                padded_tokens.append(t)
+            tokens = [slice_with_cp(t, pad_token_id, qkv_format) for t in padded_tokens]
             sample_token_lengths = [t.size(0) for t in tokens]
 
             cu_seqlens = [0]
@@ -221,7 +286,8 @@ def get_batch(
             tokens = torch.cat(tokens)
 
             # Always pad to reduce memory fragmentation and maybe make the computation faster
-            pad = (pad_size - tokens.size(0) % pad_size) % pad_size
+            final_pad_size = math.lcm(pad_size, sample_pad_multiple) if sample_pad_multiple is not None else pad_size
+            pad = (final_pad_size - tokens.size(0) % final_pad_size) % final_pad_size
             if pad != 0:
                 tokens = F.pad(tokens, (0, pad), value=pad_token_id)
                 cu_seqlens.append(cu_seqlens[-1] + pad)
@@ -235,6 +301,8 @@ def get_batch(
 
         batch["cu_seqlens"] = cu_seqlens
         batch["max_seqlen"] = max_seqlen
+        if padded_total_lengths is not None:
+            batch["padded_total_lengths"] = padded_total_lengths
     else:
         raise ValueError(f"Unsupported qkv_format: {qkv_format}")
 
@@ -261,6 +329,11 @@ def get_batch(
             ids = [slice_with_cp(p, 0, qkv_format, max_seqlen) for p in ids_list]
             ids = torch.stack(ids)
         elif qkv_format == "thd":
+            if padded_total_lengths is not None:
+                ids_list = [
+                    F.pad(p, (0, padded_total_length - p.size(0)), value=0)
+                    for p, padded_total_length in zip(ids_list, padded_total_lengths, strict=True)
+                ]
             ids = [slice_with_cp(p, 0, qkv_format) for p in ids_list]
             ids = torch.cat(ids)
             if pad != 0:
@@ -293,6 +366,11 @@ def get_batch(
         prompt_length = total_length - response_length
         # Align mask to token stream positions (prompt_length-1 left pad, 1 right pad)
         loss_mask = F.pad(loss_mask, (prompt_length - 1, 1), value=0)
+        if padded_total_lengths is not None:
+            padded_total_length = padded_total_lengths[len(loss_masks)]
+            sample_pad = padded_total_length - total_length
+            if sample_pad:
+                loss_mask = F.pad(loss_mask, (0, sample_pad), value=0)
         if allgather_cp:
             loss_masks.append(loss_mask)
             continue
@@ -352,6 +430,8 @@ class DataIterator:
         rollout_data: RolloutBatch,
         micro_batch_size: int | None = None,
         micro_batch_indices: list[list[int]] | None = None,
+        *,
+        args: Namespace | None = None,
     ) -> None:
         """Initialize an iterator over `rollout_data`.
 
@@ -360,7 +440,9 @@ class DataIterator:
             micro_batch_size: Fixed contiguous slice size when not using dynamic scheduling.
             micro_batch_indices: Explicit indices per micro-batch when using dynamic balancing.
                 Must be mutually exclusive with `micro_batch_size`.
+            args: Optional runtime args used for model-specific batch preparation.
         """
+        self.args = args or Namespace(model_name="", compress_ratios=None)
         self.rollout_data = rollout_data
         self.micro_batch_size = micro_batch_size
         self.micro_batch_indices = micro_batch_indices
@@ -448,7 +530,14 @@ def get_data_iterator(
     def _generate_data_iterator(rollout_data, micro_batch_size, micro_batch_indices=None):
         data_iterator = []
         for _ in range(vpp_size):
-            data_iterator.append(DataIterator(rollout_data, micro_batch_size, micro_batch_indices))
+            data_iterator.append(
+                DataIterator(
+                    rollout_data,
+                    micro_batch_size,
+                    micro_batch_indices,
+                    args=args,
+                )
+            )
         return data_iterator
 
     if not args.use_dynamic_batch_size:

--- a/miles/backends/training_utils/data.py
+++ b/miles/backends/training_utils/data.py
@@ -1,5 +1,8 @@
+import hashlib
+import json
 import logging
 import math
+import os
 from argparse import Namespace
 from collections.abc import Sequence
 
@@ -55,6 +58,216 @@ def _get_thd_allgather_pad_multiple(cp_size: int, pad_size: int, sample_pad_mult
         # divisible by 2 * cp_size * every active compression ratio.
         global_pad_multiple = math.lcm(global_pad_multiple, 2 * cp_size * sample_pad_multiple)
     return global_pad_multiple
+
+
+def _summarize_thd_packing(
+    total_lengths: Sequence[int],
+    partitions: Sequence[Sequence[int]],
+    *,
+    sample_pad_multiple: int | None,
+    global_pad_multiple: int,
+    seq_length: int,
+) -> dict[str, int | float]:
+    """Summarize real token utilization for a THD dynamic-batch schedule."""
+
+    def _round_up(value: int, multiple: int) -> int:
+        return ((value + multiple - 1) // multiple) * multiple
+
+    def _sample_aligned(length: int) -> int:
+        if sample_pad_multiple is None:
+            return length
+        return _round_up(length, sample_pad_multiple)
+
+    pack_actual_tokens = []
+    pack_padded_tokens = []
+    pack_sample_counts = []
+    for partition in partitions:
+        lengths = [int(total_lengths[index]) for index in partition]
+        actual_tokens = sum(lengths)
+        aligned_tokens = sum(_sample_aligned(length) for length in lengths)
+        pack_actual_tokens.append(actual_tokens)
+        pack_padded_tokens.append(_round_up(aligned_tokens, global_pad_multiple))
+        pack_sample_counts.append(len(lengths))
+
+    actual_tokens = sum(pack_actual_tokens)
+    padded_tokens = sum(pack_padded_tokens)
+    partition_indices = [index for partition in partitions for index in partition]
+    no_pack_padded_tokens = sum(_round_up(_sample_aligned(int(total_lengths[index])), global_pad_multiple) for index in partition_indices)
+    pack_count = len(partitions)
+    sample_count = sum(pack_sample_counts)
+    capacity_tokens = pack_count * seq_length
+
+    return {
+        "samples": sample_count,
+        "packs": pack_count,
+        "samples_per_pack": sample_count / pack_count if pack_count else 0.0,
+        "actual_tokens": actual_tokens,
+        "padded_tokens": padded_tokens,
+        "no_pack_padded_tokens": no_pack_padded_tokens,
+        "packing_efficiency": actual_tokens / padded_tokens if padded_tokens else 0.0,
+        "seq_capacity_fill": actual_tokens / capacity_tokens if capacity_tokens else 0.0,
+        "padding_reduction_vs_mbs1": (1.0 - padded_tokens / no_pack_padded_tokens if no_pack_padded_tokens else 0.0),
+        "max_samples_per_pack": max(pack_sample_counts, default=0),
+        "max_pack_actual_tokens": max(pack_actual_tokens, default=0),
+        "max_pack_padded_tokens": max(pack_padded_tokens, default=0),
+        "oversized_packs": sum(padded > seq_length for padded in pack_padded_tokens),
+    }
+
+
+def _get_capped_thd_partitions(
+    total_lengths: Sequence[int],
+    num_partitions: int,
+    *,
+    sample_pad_multiple: int | None,
+    global_pad_multiple: int,
+    max_padded_tokens: int,
+) -> list[list[int]]:
+    """Build non-empty THD packs whose aligned stream fits the hard limit.
+
+    ``get_seqlen_balanced_partitions`` minimizes length imbalance, but it does
+    not enforce a per-partition capacity.  This first-fit fallback is used only
+    when that balancing pass creates an invalid THD pack.  Costs include the
+    per-sample DSV4 alignment and the final all-gather padding, so a pack that
+    passes this helper also passes the actual ``cu_seqlens`` construction.
+    """
+
+    if num_partitions < 1:
+        raise ValueError(f"num_partitions must be positive, got {num_partitions}")
+    if num_partitions > len(total_lengths):
+        raise ValueError(f"Cannot build non-empty capped THD partitions because num_partitions exceeds sample count: num_partitions={num_partitions}, samples={len(total_lengths)}")
+
+    def round_up(value: int, multiple: int) -> int:
+        return ((value + multiple - 1) // multiple) * multiple
+
+    sample_multiple = sample_pad_multiple or 1
+
+    def sample_cost(length: int) -> int:
+        return round_up(int(length), sample_multiple)
+
+    def pack_cost(aligned_sum: int) -> int:
+        return round_up(aligned_sum, global_pad_multiple)
+
+    partitions: list[list[int]] = []
+    aligned_sums: list[int] = []
+    for index, raw_length in enumerate(total_lengths):
+        length = int(raw_length)
+        cost = sample_cost(length)
+        if pack_cost(cost) > max_padded_tokens:
+            raise ValueError(f"Cannot pack a sample into a THD sequence: sample_local_index={index}, sample_length={length}, sample_padded_length={cost}, max_padded_tokens={max_padded_tokens}")
+
+        for partition_index, aligned_sum in enumerate(aligned_sums):
+            if pack_cost(aligned_sum + cost) <= max_padded_tokens:
+                partitions[partition_index].append(index)
+                aligned_sums[partition_index] += cost
+                break
+        else:
+            partitions.append([index])
+            aligned_sums.append(cost)
+
+    if len(partitions) > num_partitions:
+        raise ValueError(f"Cannot fit THD samples under the hard sequence limit with the planned number of packs: required_packs={len(partitions)}, planned_packs={num_partitions}, max_padded_tokens={max_padded_tokens}, pack_padded_tokens={[pack_cost(total) for total in aligned_sums]}")
+
+    # Pipeline schedules require every planned micro-batch to be non-empty.
+    while len(partitions) < num_partitions:
+        split_index = max(range(len(partitions)), key=lambda i: len(partitions[i]))
+        if len(partitions[split_index]) <= 1:
+            raise ValueError(f"Cannot create non-empty THD packs for the planned schedule: planned_packs={num_partitions}, current_packs={len(partitions)}, samples={len(total_lengths)}")
+        moved_index = partitions[split_index].pop()
+        moved_cost = sample_cost(total_lengths[moved_index])
+        aligned_sums[split_index] -= moved_cost
+        partitions.append([moved_index])
+        aligned_sums.append(moved_cost)
+
+    return [sorted(partition) for partition in partitions]
+
+
+def _validate_dynamic_batch_schedule(
+    num_microbatches: Sequence[int],
+    micro_batch_indices: Sequence[Sequence[int]],
+    num_local_samples: int,
+) -> tuple[list[int], list[list[int]]]:
+    """Normalize and validate a dynamic micro-batch schedule."""
+    normalized_num_microbatches = [int(value) for value in num_microbatches]
+    normalized_indices = [[int(index) for index in partition] for partition in micro_batch_indices]
+
+    if not normalized_num_microbatches or any(value <= 0 for value in normalized_num_microbatches):
+        raise ValueError(f"Dynamic batch schedule requires positive micro-batch counts: {normalized_num_microbatches}")
+    if len(normalized_indices) != sum(normalized_num_microbatches):
+        raise ValueError(f"Dynamic batch schedule partition count mismatch: partitions={len(normalized_indices)}, expected={sum(normalized_num_microbatches)}")
+    if any(not partition for partition in normalized_indices):
+        raise ValueError("Dynamic batch schedule contains an empty micro-batch")
+
+    flat_indices = [index for partition in normalized_indices for index in partition]
+    expected_indices = list(range(num_local_samples))
+    if sorted(flat_indices) != expected_indices:
+        raise ValueError(f"Dynamic batch schedule must contain every local sample exactly once: scheduled={len(flat_indices)}, expected={num_local_samples}, unique={len(set(flat_indices))}")
+    return normalized_num_microbatches, normalized_indices
+
+
+def _dynamic_batch_schedule_fingerprint(num_microbatches: Sequence[int], micro_batch_indices: Sequence[Sequence[int]]) -> str:
+    payload = {
+        "num_microbatches": [int(value) for value in num_microbatches],
+        "micro_batch_indices": [[int(index) for index in partition] for partition in micro_batch_indices],
+    }
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()[:16]
+
+
+def _sync_thd_dynamic_batch_schedule(
+    parallel_state,
+    num_microbatches: Sequence[int],
+    micro_batch_indices: Sequence[Sequence[int]],
+    num_local_samples: int,
+) -> tuple[list[int], list[list[int]]]:
+    """Broadcast one canonical THD schedule inside each DP replica.
+
+    Every rank currently receives the rollout data and can build a schedule,
+    but independently derived partitions are unsafe for variable-shape PP/CP
+    collectives.  Propagating PP -> CP -> TP makes the rank-zero schedule for
+    each model replica authoritative without crossing the data-parallel axis.
+    """
+    local_num_microbatches, local_indices = _validate_dynamic_batch_schedule(num_microbatches, micro_batch_indices, num_local_samples)
+    payload = {
+        "num_microbatches": local_num_microbatches,
+        "micro_batch_indices": local_indices,
+        "num_local_samples": int(num_local_samples),
+    }
+    local_fingerprint = _dynamic_batch_schedule_fingerprint(local_num_microbatches, local_indices)
+
+    if dist.is_initialized():
+        for group_name in ("pp", "cp", "tp"):
+            group_info = getattr(parallel_state, group_name)
+            if group_info.size <= 1:
+                continue
+            if group_info.group is None:
+                raise RuntimeError(f"{group_name} process group is missing for schedule synchronization")
+            object_list = [payload if group_info.rank == 0 else None]
+            dist.broadcast_object_list(
+                object_list,
+                src=dist.get_global_rank(group_info.group, 0),
+                group=group_info.group,
+            )
+            payload = object_list[0]
+
+    if not isinstance(payload, dict) or int(payload.get("num_local_samples", -1)) != num_local_samples:
+        raise ValueError(f"Canonical THD schedule has incompatible sample count: payload={payload.get('num_local_samples') if isinstance(payload, dict) else type(payload).__name__}, local={num_local_samples}")
+    canonical_num_microbatches, canonical_indices = _validate_dynamic_batch_schedule(payload["num_microbatches"], payload["micro_batch_indices"], num_local_samples)
+    canonical_fingerprint = _dynamic_batch_schedule_fingerprint(canonical_num_microbatches, canonical_indices)
+    if local_fingerprint != canonical_fingerprint:
+        logger.warning(
+            "THD dynamic batch schedule differed from the canonical model-replica schedule; using canonical schedule: local=%s canonical=%s",
+            local_fingerprint,
+            canonical_fingerprint,
+        )
+    if not dist.is_initialized() or dist.get_rank() == 0:
+        logger.info(
+            "[schedule] samples=%d microbatches=%d fingerprint=%s synchronized=%s",
+            num_local_samples,
+            sum(canonical_num_microbatches),
+            canonical_fingerprint,
+            dist.is_initialized(),
+        )
+    return canonical_num_microbatches, canonical_indices
 
 
 def _rollout_logprob_dtype(args: Namespace) -> torch.dtype:
@@ -191,6 +404,8 @@ def get_batch(
     # fetch it here so callers don't have to know. None for non-multi-LoRA runs.
     if "adapter_slots" not in keys:
         keys = [*keys, "adapter_slots"]
+    microbatch_index = data_iterator.offset
+    scheduled_indices = list(data_iterator.micro_batch_indices[microbatch_index]) if data_iterator.micro_batch_indices is not None else None
     batch = data_iterator.get_next(keys)
 
     if "dynamic_global_batch_size" in data_iterator.rollout_data:
@@ -398,6 +613,20 @@ def get_batch(
     assert loss_masks.shape == tokens.shape, f"loss_masks.shape: {loss_masks.shape}, tokens.shape: {tokens.shape}"
     batch["full_loss_masks"] = loss_masks
 
+    if qkv_format == "thd" and os.environ.get("MILES_THD_MICROBATCH_PROGRESS", "").lower() in {"1", "true", "yes"} and parallel_state.effective_dp.rank == 0 and parallel_state.cp.rank == 0 and parallel_state.tp.rank == 0:
+        index_fingerprint = hashlib.sha256(json.dumps(scheduled_indices or [], separators=(",", ":")).encode("utf-8")).hexdigest()[:12]
+        logger.info(
+            "[thd-progress] pp_rank=%d microbatch=%d samples=%d actual_tokens=%d global_padded_tokens=%d local_tokens=%d max_seqlen=%d indices=%s",
+            parallel_state.pp.rank,
+            microbatch_index,
+            len(batch["total_lengths"]),
+            sum(int(length) for length in batch["total_lengths"]),
+            tokens.numel() * cp_size,
+            tokens.numel(),
+            int(max_seqlen),
+            index_fingerprint,
+        )
+
     # Process multimodal training tensors if present
     multimodal_train_inputs = batch.get("multimodal_train_inputs", None)
     if multimodal_train_inputs is not None:
@@ -581,6 +810,64 @@ def get_data_iterator(
             start, end = i * num_local_gbs, (i + 1) * num_local_gbs
             samples = rollout_data["total_lengths"][start:end]
             partitions = get_seqlen_balanced_partitions(samples, num_mbs, equal_size=False)
+
+            if args.qkv_format == "thd":
+                sample_pad_multiple = _get_thd_sample_pad_multiple(args)
+                global_pad_multiple = _get_thd_allgather_pad_multiple(
+                    cp_size,
+                    parallel_state.tp.size * args.data_pad_size_multiplier,
+                    sample_pad_multiple,
+                )
+                packing_stats = _summarize_thd_packing(
+                    samples,
+                    partitions,
+                    sample_pad_multiple=sample_pad_multiple,
+                    global_pad_multiple=global_pad_multiple,
+                    seq_length=args.seq_length,
+                )
+                if packing_stats["oversized_packs"]:
+                    logger.warning(
+                        "Dynamic THD balancing produced an oversized pack; falling back to cap-aware packing: step=%d max_pack_padded_tokens=%d seq_length=%d max_tokens_per_gpu=%d cp_size=%d",
+                        i,
+                        packing_stats["max_pack_padded_tokens"],
+                        args.seq_length,
+                        args.max_tokens_per_gpu,
+                        cp_size,
+                    )
+                    partitions = _get_capped_thd_partitions(
+                        samples,
+                        num_mbs,
+                        sample_pad_multiple=sample_pad_multiple,
+                        global_pad_multiple=global_pad_multiple,
+                        max_padded_tokens=args.seq_length,
+                    )
+                    packing_stats = _summarize_thd_packing(
+                        samples,
+                        partitions,
+                        sample_pad_multiple=sample_pad_multiple,
+                        global_pad_multiple=global_pad_multiple,
+                        seq_length=args.seq_length,
+                    )
+                    if packing_stats["oversized_packs"]:
+                        raise AssertionError(f"cap-aware THD packing returned an oversized pack: step={i}, max_pack_padded_tokens={packing_stats['max_pack_padded_tokens']}, seq_length={args.seq_length}")
+                if not dist.is_initialized() or dist.get_rank() == 0:
+                    logger.info(
+                        "[packing] step=%d samples=%d packs=%d samples_per_pack=%.4f actual_tokens=%d padded_tokens=%d packing_efficiency=%.6f seq_capacity_fill=%.6f no_pack_padded_tokens=%d padding_reduction_vs_mbs1=%.6f max_samples_per_pack=%d max_pack_actual_tokens=%d max_pack_padded_tokens=%d",
+                        i,
+                        packing_stats["samples"],
+                        packing_stats["packs"],
+                        packing_stats["samples_per_pack"],
+                        packing_stats["actual_tokens"],
+                        packing_stats["padded_tokens"],
+                        packing_stats["packing_efficiency"],
+                        packing_stats["seq_capacity_fill"],
+                        packing_stats["no_pack_padded_tokens"],
+                        packing_stats["padding_reduction_vs_mbs1"],
+                        packing_stats["max_samples_per_pack"],
+                        packing_stats["max_pack_actual_tokens"],
+                        packing_stats["max_pack_padded_tokens"],
+                    )
+
             for j in range(num_mbs):
                 for k in range(len(partitions[j])):
                     partitions[j][k] += start
@@ -590,7 +877,19 @@ def get_data_iterator(
                     partitions[j].sort(key=lambda index: rollout_data["adapter_slots"][index])
             micro_batch_indices.extend(partitions)
 
-        assert len(set(sum(micro_batch_indices, []))) == num_local_samples
+        if args.qkv_format == "thd":
+            num_microbatches, micro_batch_indices = _sync_thd_dynamic_batch_schedule(
+                parallel_state,
+                num_microbatches,
+                micro_batch_indices,
+                num_local_samples,
+            )
+        else:
+            num_microbatches, micro_batch_indices = _validate_dynamic_batch_schedule(
+                num_microbatches,
+                micro_batch_indices,
+                num_local_samples,
+            )
 
         data_iterator = _generate_data_iterator(rollout_data, None, micro_batch_indices)
 

--- a/miles/backends/training_utils/log_utils.py
+++ b/miles/backends/training_utils/log_utils.py
@@ -16,7 +16,7 @@ from miles.utils.types import RolloutBatch
 
 from ...utils.tracking_utils import tracking
 from .cp_utils import get_sum_of_sample_mean
-from .data import DataIterator
+from .data import DataIterator, get_thd_padded_total_lengths
 from .parallel import get_parallel_state
 
 logger = logging.getLogger(__name__)
@@ -123,6 +123,7 @@ def log_rollout_data(rollout_id: int, args: Namespace, rollout_data: RolloutBatc
         loss_masks = rollout_data["loss_masks"]
         total_lengths = rollout_data["total_lengths"]
         max_seq_lens = rollout_data.get("max_seq_lens", None)
+        padded_total_lengths = get_thd_padded_total_lengths(args, total_lengths)
 
         for key, val in rollout_data.items():
             if key in [
@@ -172,6 +173,7 @@ def log_rollout_data(rollout_id: int, args: Namespace, rollout_data: RolloutBatc
                             loss_masks,
                             qkv_format=args.qkv_format,
                             max_seq_lens=max_seq_lens,
+                            padded_total_lengths=padded_total_lengths,
                         )
                         val = cp_size * sum_of_sample_mean(val) / len(loss_masks)
                     else:
@@ -267,12 +269,15 @@ def log_rollout_data(rollout_id: int, args: Namespace, rollout_data: RolloutBatc
             correct_response_lengths = []
             correct_total_lengths = []
             correct_loss_masks = []
+            correct_max_seq_lens = []
             correct_entropy = []
             for i, raw_reward in enumerate(raw_rewards):
                 if raw_reward == 1:
                     correct_response_lengths.append(response_lengths[i])
                     correct_total_lengths.append(total_lengths[i])
                     correct_loss_masks.append(loss_masks[i])
+                    if max_seq_lens is not None:
+                        correct_max_seq_lens.append(max_seq_lens[i])
                     correct_entropy.append(-rollout_data["log_probs"][i])
             num_correct_responses = len(correct_total_lengths)
             rollout_data["correct_response_lengths"] = correct_response_lengths
@@ -282,8 +287,14 @@ def log_rollout_data(rollout_id: int, args: Namespace, rollout_data: RolloutBatc
             for p, val in correct_response_length_percentile.items():
                 rollout_data[f"correct_length/{p}"] = [val] * num_correct_responses
             if len(correct_entropy) > 0:
+                correct_padded_total_lengths = get_thd_padded_total_lengths(args, correct_total_lengths)
                 sum_of_sample_mean = get_sum_of_sample_mean(
-                    correct_total_lengths, correct_response_lengths, correct_loss_masks
+                    correct_total_lengths,
+                    correct_response_lengths,
+                    correct_loss_masks,
+                    qkv_format=args.qkv_format,
+                    max_seq_lens=correct_max_seq_lens if max_seq_lens is not None else None,
+                    padded_total_lengths=correct_padded_total_lengths,
                 )
                 correct_entropy = sum_of_sample_mean(torch.cat(correct_entropy, dim=0))
                 rollout_data["correct_entropy"] = [correct_entropy.item()] * num_correct_responses

--- a/miles/backends/training_utils/loss.py
+++ b/miles/backends/training_utils/loss.py
@@ -133,6 +133,7 @@ def loss_function(
         args.calculate_per_token_loss,
         args.qkv_format,
         batch.get("max_seq_lens", None),
+        batch.get("padded_total_lengths", None),
     )
 
     func = get_loss_function(args)

--- a/miles/backends/training_utils/loss_hub/logit_processors.py
+++ b/miles/backends/training_utils/loss_hub/logit_processors.py
@@ -16,6 +16,7 @@ def get_responses(
     total_lengths: list[int],
     response_lengths: list[int],
     max_seq_lens: list[int] | None = None,
+    padded_total_lengths: list[int] | None = None,
 ) -> Iterator[tuple[torch.Tensor, torch.Tensor]]:
     """Yield response-aligned `(logits_chunk, tokens_chunk)` pairs per sample.
 
@@ -61,12 +62,17 @@ def get_responses(
 
     parallel_state = get_parallel_state()
     cp_size = parallel_state.cp.size
+    if padded_total_lengths is not None and len(padded_total_lengths) != len(total_lengths):
+        raise ValueError(
+            f"padded_total_lengths has {len(padded_total_lengths)} entries for {len(total_lengths)} samples"
+        )
     end = 0
     seq_start = 0
     for i, (tokens, total_length, response_length) in enumerate(
         zip(unconcat_tokens, total_lengths, response_lengths, strict=False)
     ):
         max_seq_len = max_seq_lens[i] if max_seq_lens is not None else None
+        padded_total_length = padded_total_lengths[i] if padded_total_lengths is not None else total_length
 
         if cp_size == 1:
             if qkv_format == "bshd":
@@ -74,10 +80,12 @@ def get_responses(
                 start = end - response_length
                 logits_chunk = logits[start - 1 : end - 1]
             else:
-                end += total_length
-                start = end - response_length
-                logits_chunk = logits[start - 1 : end - 1]
-            tokens_chunk = tokens[-response_length:]
+                sample_start = end
+                end += padded_total_length
+                start = sample_start + total_length - response_length
+                sample_end = sample_start + total_length
+                logits_chunk = logits[start - 1 : sample_end - 1]
+            tokens_chunk = tokens[-response_length:] if response_length > 0 else tokens[:0]
         elif args.allgather_cp:
             # DSA: global concat then contiguous CP split. Each rank owns logits for
             # global positions [chunk_start, chunk_end).
@@ -104,7 +112,7 @@ def get_responses(
         else:
             # TODO: this is super ugly... do better abstraction.
             chunk_size, chunks_offset, logits_offset, tokens_offset = get_logits_and_tokens_offset_with_cp(
-                total_length, response_length, qkv_format, max_seq_len
+                total_length, response_length, qkv_format, max_seq_len, padded_total_length
             )
 
             logits_0, logits_1 = logits[end : end + chunk_size], logits[end + chunk_size : end + 2 * chunk_size]
@@ -122,7 +130,7 @@ def get_responses(
             logits_chunk = torch.cat([logits_0, logits_1], dim=0)
             tokens_chunk = torch.cat([tokens_0, tokens_1], dim=0)
 
-        seq_start += total_length
+        seq_start += padded_total_length
 
         yield logits_chunk, tokens_chunk
 
@@ -138,6 +146,7 @@ def get_log_probs_and_entropy(
     entropy_requires_grad: bool = True,
     non_loss_data: bool = True,
     max_seq_lens: list[int] | None = None,
+    padded_total_lengths: list[int] | None = None,
 ) -> dict[str, list[torch.Tensor]]:
     """Compute per-token log-probabilities (and optionally entropy) on responses.
 
@@ -173,6 +182,7 @@ def get_log_probs_and_entropy(
         total_lengths=total_lengths,
         response_lengths=response_lengths,
         max_seq_lens=max_seq_lens,
+        padded_total_lengths=padded_total_lengths,
     ):
         log_prob, entropy = calculate_log_probs_and_entropy(
             logits_chunk,
@@ -204,6 +214,7 @@ def get_log_probs_and_entropy(
             total_lengths=total_lengths,
             response_lengths=response_lengths,
             max_seq_lens=max_seq_lens,
+            padded_total_lengths=padded_total_lengths,
         )
 
     return res
@@ -219,6 +230,7 @@ def get_values(
     with_entropy: bool = False,
     non_loss_data: bool = True,
     max_seq_lens: list[int] | None = None,
+    padded_total_lengths: list[int] | None = None,
 ) -> dict[str, list[torch.Tensor]]:
     """Extract per-token value predictions over response tokens.
 
@@ -247,6 +259,7 @@ def get_values(
         total_lengths=total_lengths,
         response_lengths=response_lengths,
         max_seq_lens=max_seq_lens,
+        padded_total_lengths=padded_total_lengths,
     ):
         assert logits_chunk.size(-1) == 1, f"{logits_chunk.shape}"
         value_list.append(logits_chunk.squeeze(-1))
@@ -263,6 +276,7 @@ def get_values(
             total_lengths=total_lengths,
             response_lengths=response_lengths,
             max_seq_lens=max_seq_lens,
+            padded_total_lengths=padded_total_lengths,
         )
 
     return res

--- a/miles/backends/training_utils/loss_hub/losses.py
+++ b/miles/backends/training_utils/loss_hub/losses.py
@@ -97,6 +97,7 @@ def policy_loss_function(
     total_lengths = batch["total_lengths"]
     max_seq_lens = batch.get("max_seq_lens", None)
     calculate_entropy = args.entropy_coef != 0 or args.observe_training_entropy
+    padded_total_lengths = batch.get("padded_total_lengths", None)
 
     log_probs_and_entropy = get_log_probs_and_entropy(
         logits,
@@ -107,6 +108,7 @@ def policy_loss_function(
         with_entropy=calculate_entropy,
         entropy_requires_grad=args.entropy_coef != 0,
         max_seq_lens=max_seq_lens,
+        padded_total_lengths=padded_total_lengths,
     )
 
     log_probs = log_probs_and_entropy["log_probs"]
@@ -120,15 +122,23 @@ def policy_loss_function(
     full_old_log_probs = None
     if need_full_log_probs:
         full_log_probs = [
-            all_gather_with_cp(log_prob, total_length, response_length)
-            for log_prob, total_length, response_length in zip(
-                log_probs, total_lengths, response_lengths, strict=False
+            all_gather_with_cp(log_prob, total_length, response_length, padded_total_length=padded_total_length)
+            for log_prob, total_length, response_length, padded_total_length in zip(
+                log_probs,
+                total_lengths,
+                response_lengths,
+                padded_total_lengths or [None] * len(total_lengths),
+                strict=False,
             )
         ]
         full_old_log_probs = [
-            all_gather_with_cp(old_log_prob, total_length, response_length)
-            for old_log_prob, total_length, response_length in zip(
-                old_log_probs, total_lengths, response_lengths, strict=False
+            all_gather_with_cp(old_log_prob, total_length, response_length, padded_total_length=padded_total_length)
+            for old_log_prob, total_length, response_length, padded_total_length in zip(
+                old_log_probs,
+                total_lengths,
+                response_lengths,
+                padded_total_lengths or [None] * len(total_lengths),
+                strict=False,
             )
         ]
 
@@ -163,6 +173,7 @@ def policy_loss_function(
         batch["loss_masks"],
         args.qkv_format,
         max_seq_lens,
+        padded_total_lengths,
     )
     local_loss_masks = torch.cat(local_loss_mask_list, dim=0).to(device=ppo_kl.device)
     active_tokens = local_loss_masks.bool()
@@ -241,6 +252,7 @@ def policy_loss_function(
             args.calculate_per_token_loss,
             args.qkv_format,
             max_seq_lens,
+            padded_total_lengths,
         )
 
     # Determine pg_loss reducer: use custom if specified, otherwise default
@@ -265,6 +277,7 @@ def policy_loss_function(
         qkv_format=args.qkv_format,
         max_seq_lens=max_seq_lens,
         calculate_per_token_loss=args.calculate_per_token_loss,
+        padded_total_lengths=padded_total_lengths,
     )
 
     pg_loss = pg_loss_reducer(pg_loss)
@@ -399,6 +412,7 @@ def value_loss_function(
         total_lengths=batch["total_lengths"],
         response_lengths=batch["response_lengths"],
         max_seq_lens=batch.get("max_seq_lens", None),
+        padded_total_lengths=batch.get("padded_total_lengths", None),
     )
     values = torch.cat([value.flatten() for value in values["values"]], dim=0)
 
@@ -458,6 +472,7 @@ def sft_loss_function(
         response_lengths=response_lengths,
         with_entropy=False,
         max_seq_lens=batch.get("max_seq_lens", None),
+        padded_total_lengths=batch.get("padded_total_lengths", None),
     )
 
     log_probs = log_probs_and_entropy["log_probs"]

--- a/miles/backends/training_utils/loss_hub/math_utils.py
+++ b/miles/backends/training_utils/loss_hub/math_utils.py
@@ -36,6 +36,7 @@ def compute_ess_ratio_contribution(
     qkv_format: str,
     max_seq_lens: list[int] | None,
     calculate_per_token_loss: bool,
+    padded_total_lengths: list[int] | None = None,
 ) -> torch.Tensor:
     """Return an ESS contribution compatible with ``aggregate_train_losses``.
 
@@ -52,6 +53,7 @@ def compute_ess_ratio_contribution(
         response_lengths,
         qkv_format,
         max_seq_lens,
+        padded_total_lengths,
     )
     local_lengths = [mask.size(0) for mask in local_masks]
     is_weights_per_sample = _safe_exp_neg_ppo_kl(ppo_kl.detach()).split(local_lengths, dim=0)

--- a/miles/rollout/data_source.py
+++ b/miles/rollout/data_source.py
@@ -61,6 +61,17 @@ class RolloutDataSource(DataSource):
                 args.hf_checkpoint, chat_template_path=args.chat_template_path, trust_remote_code=True
             )
             processor = load_processor(args.hf_checkpoint, trust_remote_code=True)
+            skip_prompt_length_filter = os.environ.get("MILES_SKIP_PROMPT_LENGTH_FILTER", "").lower() in {
+                "1",
+                "true",
+                "yes",
+            }
+            max_prompt_length = None if skip_prompt_length_filter else args.rollout_max_prompt_len
+            if skip_prompt_length_filter:
+                logger.info(
+                    "MILES_SKIP_PROMPT_LENGTH_FILTER=1: skipping Dataset startup length filtering. "
+                    "Use only with pre-filtered prompt data."
+                )
 
             # TODO move (during the refactor)
             if (d := args.dump_details) is not None:
@@ -72,7 +83,7 @@ class RolloutDataSource(DataSource):
                 args.prompt_data,
                 tokenizer=tokenizer,
                 processor=processor,
-                max_length=args.rollout_max_prompt_len,
+                max_length=max_prompt_length,
                 prompt_key=args.input_key,
                 multimodal_keys=args.multimodal_keys,
                 label_key=args.label_key,

--- a/miles/rollout/sft_rollout.py
+++ b/miles/rollout/sft_rollout.py
@@ -55,7 +55,7 @@ def generate_rollout(args, rollout_id, data_buffer, evaluation=False):
         sample.tokens = token_ids
         sample.response_length = response_length
         sample.reward = 0
-        sample.loss_mask = loss_mask[-response_length:]
+        sample.loss_mask = loss_mask[-response_length:] if response_length > 0 else []
 
         if i == 0 and not SAMPLE_PRINTED:
             logger.info(

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -1997,7 +1997,7 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 "--loss-mask-type",
                 type=str,
                 default="qwen",
-                choices=["qwen", "qwen3", "distill_qwen", "deepseek_v4"],
+                choices=["qwen", "qwen3", "distill_qwen", "deepseek_v4", "deepseek_v4_jinja"],
                 help="Loss mask type",
             )
             parser.add_argument(

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -1997,7 +1997,7 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 "--loss-mask-type",
                 type=str,
                 default="qwen",
-                choices=["qwen", "qwen3", "distill_qwen"],
+                choices=["qwen", "qwen3", "distill_qwen", "deepseek_v4"],
                 help="Loss mask type",
             )
             parser.add_argument(

--- a/miles/utils/data.py
+++ b/miles/utils/data.py
@@ -85,11 +85,33 @@ def filter_long_prompt(origin_samples: list[Sample], tokenizer, processor, max_l
     if max_length is None:
         return origin_samples
 
-    if not isinstance(origin_samples[0].prompt, str):
-        logger.warning(
-            "Skipping max_length check for list prompt. Set apply_chat_template=True to enable length filtering."
-        )
+    if not origin_samples:
         return origin_samples
+
+    if not isinstance(origin_samples[0].prompt, str):
+        filtered_samples = []
+        for sample in origin_samples:
+            if processor:
+                from miles.utils.processing_utils import call_processor, process_vision_info
+
+                multimodal_inputs = process_vision_info(sample.prompt, processor)
+                processor_output = call_processor(processor, sample.prompt, multimodal_inputs)
+                input_ids = processor_output["input_ids"][0]
+            else:
+                input_ids = chat_template_utils.apply_chat_template(
+                    sample.prompt,
+                    tokenizer=tokenizer,
+                    tools=sample.metadata.get("tools") if sample.metadata else None,
+                    tokenize=True,
+                    add_generation_prompt=False,
+                )
+            if len(input_ids) <= max_length:
+                filtered_samples.append(sample)
+
+        logger.info(
+            f"Filtered {len(origin_samples) - len(filtered_samples)} samples longer than max_length={max_length}."
+        )
+        return filtered_samples
 
     if processor:
         # Use processor only for samples with actual multimodal content; use batched tokenizer for text-only.

--- a/miles/utils/mask_utils.py
+++ b/miles/utils/mask_utils.py
@@ -1,5 +1,7 @@
 from transformers import AutoTokenizer
 
+from miles.utils import chat_template_utils
+
 
 def get_response_lengths(loss_masks: list[list[int]]) -> list[int]:
     # return the lengths starting from the first occurrence of 1 to the end of each loss mask
@@ -9,8 +11,12 @@ def get_response_lengths(loss_masks: list[list[int]]) -> list[int]:
 class MultiTurnLossMaskGenerator:
     def __init__(self, tokenizer: AutoTokenizer, tokenizer_type: str = "qwen"):
         self.tokenizer = tokenizer
-        self.system_message_length, self.gen_token_length = self.get_system_message_length()
         self.tokenizer_type = tokenizer_type
+        if tokenizer_type == "deepseek_v4":
+            self.system_message_length = 0
+            self.gen_token_length = 0
+        else:
+            self.system_message_length, self.gen_token_length = self.get_system_message_length()
 
     def get_response_lengths(self, loss_masks: list[list[int]]) -> list[int]:
         return get_response_lengths(loss_masks)
@@ -130,6 +136,54 @@ class MultiTurnLossMaskGenerator:
             loss_mask = [0] * len(token_ids)
         return token_ids, loss_mask
 
+    def gen_multi_turn_loss_mask_deepseek_v4(
+        self, messages: list[dict], tools: list[dict] = None
+    ) -> tuple[list[int], list[int]]:
+        rendered = chat_template_utils.apply_chat_template(
+            messages,
+            tokenizer=self.tokenizer,
+            tools=tools,
+            tokenize=False,
+            add_generation_prompt=False,
+        )
+        encoded = self.tokenizer(rendered, add_special_tokens=False, return_offsets_mapping=True)
+        all_token_ids = encoded["input_ids"]
+        offset_mapping = encoded["offset_mapping"]
+        all_loss_masks = [0] * len(all_token_ids)
+
+        def eos_end(start: int) -> int:
+            candidates = []
+            eos_token = getattr(self.tokenizer, "eos_token", None)
+            if isinstance(eos_token, str) and eos_token:
+                candidates.append(eos_token)
+            candidates.append("<｜end▁of▁sentence｜>")
+            for eos in dict.fromkeys(candidates):
+                if rendered.startswith(eos, start):
+                    return start + len(eos)
+            return start
+
+        cursor = 0
+        for message in messages:
+            content = message.get("content") or ""
+            if not isinstance(content, str) or not content:
+                continue
+
+            content_start = rendered.find(content, cursor)
+            if content_start < 0:
+                continue
+            content_end = content_start + len(content)
+            cursor = content_end
+
+            if message["role"] != "assistant" or message.get("step_loss_mask", 1) != 1:
+                continue
+
+            content_end = eos_end(content_end)
+            for idx, (token_start, token_end) in enumerate(offset_mapping):
+                if token_end > content_start and token_start < content_end:
+                    all_loss_masks[idx] = 1
+
+        return all_token_ids, all_loss_masks
+
     def get_loss_mask(self, messages: list[dict], tools: list[dict] = None) -> tuple[list[int], list[int]]:
         if self.tokenizer_type == "qwen":
             if "<｜Assistant｜>" in self.tokenizer.get_added_vocab():
@@ -140,6 +194,8 @@ class MultiTurnLossMaskGenerator:
             return self.gen_multi_turn_loss_mask_qwen3(messages, tools)
         elif self.tokenizer_type == "distill_qwen":
             return self.gen_multi_turn_loss_mask_distill_qwen(messages, tools)
+        elif self.tokenizer_type == "deepseek_v4":
+            return self.gen_multi_turn_loss_mask_deepseek_v4(messages, tools)
         else:
             raise ValueError(f"Unsupported tokenizer type: {self.tokenizer_type}")
 

--- a/miles/utils/mask_utils.py
+++ b/miles/utils/mask_utils.py
@@ -12,7 +12,7 @@ class MultiTurnLossMaskGenerator:
     def __init__(self, tokenizer: AutoTokenizer, tokenizer_type: str = "qwen"):
         self.tokenizer = tokenizer
         self.tokenizer_type = tokenizer_type
-        if tokenizer_type == "deepseek_v4":
+        if tokenizer_type in {"deepseek_v4", "deepseek_v4_jinja"}:
             self.system_message_length = 0
             self.gen_token_length = 0
         else:
@@ -136,16 +136,11 @@ class MultiTurnLossMaskGenerator:
             loss_mask = [0] * len(token_ids)
         return token_ids, loss_mask
 
-    def gen_multi_turn_loss_mask_deepseek_v4(
-        self, messages: list[dict], tools: list[dict] = None
+    def _mask_deepseek_v4_assistant_spans(
+        self,
+        rendered: str,
+        messages: list[dict],
     ) -> tuple[list[int], list[int]]:
-        rendered = chat_template_utils.apply_chat_template(
-            messages,
-            tokenizer=self.tokenizer,
-            tools=tools,
-            tokenize=False,
-            add_generation_prompt=False,
-        )
         encoded = self.tokenizer(rendered, add_special_tokens=False, return_offsets_mapping=True)
         all_token_ids = encoded["input_ids"]
         offset_mapping = encoded["offset_mapping"]
@@ -184,6 +179,74 @@ class MultiTurnLossMaskGenerator:
 
         return all_token_ids, all_loss_masks
 
+    def gen_multi_turn_loss_mask_deepseek_v4(
+        self, messages: list[dict], tools: list[dict] = None
+    ) -> tuple[list[int], list[int]]:
+        rendered = chat_template_utils.apply_chat_template(
+            messages,
+            tokenizer=self.tokenizer,
+            tools=tools,
+            tokenize=False,
+            add_generation_prompt=False,
+        )
+        return self._mask_deepseek_v4_assistant_spans(rendered, messages)
+
+    def gen_multi_turn_loss_mask_deepseek_v4_jinja(
+        self, messages: list[dict], tools: list[dict] = None
+    ) -> tuple[list[int], list[int]]:
+        """Render with the tokenizer's explicit Jinja template.
+
+        DeepSeek V4 normally routes through the official SGLang encoder. This
+        opt-in mode deliberately bypasses that routing so an SFT run can match
+        a dataset prepared by Hugging Face ``apply_chat_template`` (for
+        example, Megatron-Bridge offline packing) token for token.
+        """
+        if not getattr(self.tokenizer, "chat_template", None):
+            raise ValueError("deepseek_v4_jinja requires a tokenizer chat_template")
+
+        tokenize_kwargs = {
+            "tokenize": True,
+            "add_generation_prompt": False,
+            "return_dict": True,
+            "return_assistant_tokens_mask": True,
+        }
+        if tools is not None:
+            tokenize_kwargs["tools"] = tools
+        tokenized = self.tokenizer.apply_chat_template(messages, **tokenize_kwargs)
+        if not hasattr(tokenized, "get"):
+            raise TypeError(
+                "deepseek_v4_jinja requires apply_chat_template(..., return_dict=True) "
+                f"to return a mapping, got {type(tokenized).__name__}"
+            )
+
+        def as_flat_int_list(values, field_name: str) -> list[int]:
+            if hasattr(values, "tolist"):
+                values = values.tolist()
+            if isinstance(values, tuple):
+                values = list(values)
+            if not isinstance(values, list):
+                raise TypeError(f"Expected {field_name} to be list-like, got {type(values).__name__}")
+            if values and isinstance(values[0], list):
+                if len(values) != 1:
+                    raise ValueError(f"Expected one unbatched {field_name} sequence, got {len(values)}")
+                values = values[0]
+            return [int(value) for value in values]
+
+        token_ids = as_flat_int_list(tokenized.get("input_ids"), "input_ids")
+        assistant_masks = tokenized.get("assistant_masks")
+        if assistant_masks is None:
+            raise ValueError(
+                "deepseek_v4_jinja requires a {% generation %} chat template and "
+                "return_assistant_tokens_mask support; assistant_masks was not returned"
+            )
+        loss_mask = as_flat_int_list(assistant_masks, "assistant_masks")
+        if len(token_ids) != len(loss_mask):
+            raise ValueError(
+                "deepseek_v4_jinja token/mask length mismatch: "
+                f"input_ids={len(token_ids)}, assistant_masks={len(loss_mask)}"
+            )
+        return token_ids, loss_mask
+
     def get_loss_mask(self, messages: list[dict], tools: list[dict] = None) -> tuple[list[int], list[int]]:
         if self.tokenizer_type == "qwen":
             if "<｜Assistant｜>" in self.tokenizer.get_added_vocab():
@@ -196,6 +259,8 @@ class MultiTurnLossMaskGenerator:
             return self.gen_multi_turn_loss_mask_distill_qwen(messages, tools)
         elif self.tokenizer_type == "deepseek_v4":
             return self.gen_multi_turn_loss_mask_deepseek_v4(messages, tools)
+        elif self.tokenizer_type == "deepseek_v4_jinja":
+            return self.gen_multi_turn_loss_mask_deepseek_v4_jinja(messages, tools)
         else:
             raise ValueError(f"Unsupported tokenizer type: {self.tokenizer_type}")
 

--- a/miles_plugins/mbridge/deepseekv4.py
+++ b/miles_plugins/mbridge/deepseekv4.py
@@ -78,11 +78,14 @@ class DeepseekV4Bridge(DeepseekV3Bridge):
 
     def _weight_to_mcore_format(self, mcore_weights_name: str, hf_weights: list[torch.Tensor]) -> torch.Tensor:
         # V4 keeps several params in fp32 (attn_sink, compressor.ape, and the
-        # hyper-connection hc_* params, all marked _keep_fp32). The base bridge
-        # downcasts every loaded weight to self.dtype (bf16), which would silently
-        # round these to bf16 before they reach the fp32 mcore params. Run the base
-        # reshaping but skip the dtype downcast for fp32-source weights.
-        if len(hf_weights) == 1 and hf_weights[0].dtype == torch.float32:
+        # hyper-connection hc_* params, all marked _keep_fp32). It also has
+        # integer hash-router tables such as tid2eid. The base bridge downcasts
+        # every loaded weight to self.dtype (bf16), which would silently round
+        # both fp32 params and integer ids before they reach the mcore params.
+        # Run the base reshaping but skip the dtype downcast for these tensors.
+        if len(hf_weights) == 1 and (
+            hf_weights[0].dtype == torch.float32 or not hf_weights[0].is_floating_point()
+        ):
             saved_dtype = getattr(self, "dtype", None)
             self.dtype = None
             try:

--- a/miles_plugins/models/deepseek_v4/deepseek_v4.py
+++ b/miles_plugins/models/deepseek_v4/deepseek_v4.py
@@ -27,10 +27,17 @@ from megatron.core.transformer.utils import make_sharded_tensors_for_checkpoint
 from miles_plugins.models.deepseek_v4.ops.compressor import DeepSeekV4Compressor
 from miles_plugins.models.deepseek_v4.ops.cp_utils import (
     all_gather_cp,
+    get_compress_cu_seqlens_for_packed,
+    get_compress_query_ranges_for_packed,
     get_compress_topk_idxs_cp,
+    get_compress_topk_idxs_packed,
     get_freqs_cis_for_cp,
+    get_q_positions_for_packed_cp,
     get_q_positions_for_cp,
+    get_seq_ids_and_offsets_from_cu_seqlens,
     get_window_topk_idxs_cp,
+    get_window_topk_idxs_packed,
+    is_packed_thd_contiguous_cp,
 )
 from miles_plugins.models.deepseek_v4.ops.kernel.tilelang_sparse_mla import sparse_attn_tilelang
 from miles_plugins.models.deepseek_v4.ops.qat import fp8_simulate_qat
@@ -229,11 +236,37 @@ class DeepSeekV4Attention(MegatronModule):
         x = einops.rearrange(hidden_states, "s b d -> b s d")
 
         bsz, seqlen_local, _ = x.size()
+        packed_seq = is_packed_thd_contiguous_cp(packed_seq_params, self.cp_size)
+        if packed_seq:
+            if bsz != 1:
+                raise ValueError(f"DeepSeek-V4 THD packing requires batch dimension 1, got {bsz=}")
+            cu_seqlens = packed_seq_params.cu_seqlens_q.to(device=x.device, dtype=torch.long)
+            seqlen_global = int(cu_seqlens[-1].item())
+            expected_global = seqlen_local * self.cp_size
+            if seqlen_global != expected_global:
+                raise ValueError(
+                    "DeepSeek-V4 THD packing requires contiguous allgather CP: "
+                    f"cu_seqlens[-1]={seqlen_global}, local={seqlen_local}, cp={self.cp_size}"
+                )
+            if self.compress_ratio:
+                get_compress_cu_seqlens_for_packed(cu_seqlens, ratio=self.compress_ratio)
+            max_rope_seq_len = int(packed_seq_params.max_seqlen_q)
+            q_positions = get_q_positions_for_packed_cp(seqlen_local, self.cp_size, self.cp_group, x.device)
+            _, q_offsets, _, _ = get_seq_ids_and_offsets_from_cu_seqlens(cu_seqlens, q_positions)
+        else:
+            max_rope_seq_len = seqlen_local * self.cp_size
+            q_positions = get_q_positions_for_cp(
+                seqlen_local, cp_size=self.cp_size, cp_group=self.cp_group, device=x.device
+            )
+
         rope_base = self.config.dsv4_compress_rope_theta if self.compress_ratio else self.config.rotary_base
         freqs_cis = wrapped_precompute_freqs_cis(
-            self.config, self.rope_head_dim, rope_base, not self.compress_ratio, seqlen_local * self.cp_size, x.device
+            self.config, self.rope_head_dim, rope_base, not self.compress_ratio, max_rope_seq_len, x.device
         )
-        freqs_cis = get_freqs_cis_for_cp(freqs_cis, seqlen_local, self.cp_size, self.cp_group)
+        if packed_seq:
+            freqs_cis = freqs_cis[q_offsets]
+        else:
+            freqs_cis = get_freqs_cis_for_cp(freqs_cis, seqlen_local, self.cp_size, self.cp_group)
         win = self.window_size
         ratio = self.compress_ratio
         rd = self.rope_head_dim
@@ -255,12 +288,13 @@ class DeepSeekV4Attention(MegatronModule):
             kv_vanilla = kv_vanilla.clone()
             kv_vanilla[..., : self.nope_head_dim] = fp8_simulate_qat(kv_vanilla[..., : self.nope_head_dim], 64)
 
-        seqlen_global = seqlen_local * self.cp_size
-        q_positions = get_q_positions_for_cp(
-            seqlen_local, cp_size=self.cp_size, cp_group=self.cp_group, device=x.device
-        )
+        if not packed_seq:
+            seqlen_global = seqlen_local * self.cp_size
 
-        topk_idxs = get_window_topk_idxs_cp(q_positions, window_size=win, cp_size=self.cp_size, bsz=bsz)
+        if packed_seq:
+            topk_idxs = get_window_topk_idxs_packed(q_positions, cu_seqlens, window_size=win, bsz=bsz)
+        else:
+            topk_idxs = get_window_topk_idxs_cp(q_positions, window_size=win, cp_size=self.cp_size, bsz=bsz)
 
         if self.compress_ratio:
             kv_compress_offset = seqlen_global
@@ -271,22 +305,48 @@ class DeepSeekV4Attention(MegatronModule):
                     x_sbd = scatter_to_sequence_parallel_region(x_sbd, group=self.tp_group)
                     qr_sbd = scatter_to_sequence_parallel_region(qr_sbd, group=self.tp_group)
                 if isinstance(self.indexer, V4Indexer):
-                    compress_topk_idxs = self.indexer(x_sbd, qr_sbd)
+                    compress_topk_idxs = self.indexer(x_sbd, qr_sbd, packed_seq_params=packed_seq_params)
                 else:
-                    indexer_mask = self._compute_indexer_mask(q_positions=q_positions, seqlen_global=seqlen_global)
-                    compress_topk_idxs = self.indexer(x_sbd, qr_sbd, mask=indexer_mask, packed_seq_params=None)
-                q_first_invalid_group = (q_positions + 1).unsqueeze(1) // ratio
+                    if packed_seq:
+                        raise NotImplementedError(
+                            "DeepSeek-V4 THD packing currently requires V4_INDEXER_IMPL=tilelang; "
+                            "the legacy Megatron DSAIndexer compressor is not packed-boundary aware."
+                        )
+                    indexer_mask = self._compute_indexer_mask(
+                        q_positions=q_positions,
+                        seqlen_global=seqlen_global,
+                        cu_seqlens=cu_seqlens if packed_seq else None,
+                    )
+                    compress_topk_idxs = self.indexer(
+                        x_sbd, qr_sbd, mask=indexer_mask, packed_seq_params=packed_seq_params
+                    )
+                if packed_seq:
+                    q_first_valid_group, q_first_invalid_group = get_compress_query_ranges_for_packed(
+                        q_positions, cu_seqlens, ratio=ratio
+                    )
+                    q_first_valid_group = q_first_valid_group.unsqueeze(1)
+                    q_first_invalid_group = q_first_invalid_group.unsqueeze(1)
+                else:
+                    q_first_valid_group = None
+                    q_first_invalid_group = (q_positions + 1).unsqueeze(1) // ratio
                 topk_idx_mask = (compress_topk_idxs >= q_first_invalid_group) | (compress_topk_idxs < 0)
+                if q_first_valid_group is not None:
+                    topk_idx_mask |= compress_topk_idxs < q_first_valid_group
                 compress_topk_idxs = torch.where(topk_idx_mask, -1, compress_topk_idxs + kv_compress_offset)
             else:
-                compress_topk_idxs = get_compress_topk_idxs_cp(q_positions, ratio=ratio, cp_size=self.cp_size, bsz=bsz)
+                if packed_seq:
+                    compress_topk_idxs = get_compress_topk_idxs_packed(q_positions, cu_seqlens, ratio=ratio, bsz=bsz)
+                else:
+                    compress_topk_idxs = get_compress_topk_idxs_cp(
+                        q_positions, ratio=ratio, cp_size=self.cp_size, bsz=bsz
+                    )
             topk_idxs = torch.cat([topk_idxs, compress_topk_idxs], dim=-1)
         topk_idxs = topk_idxs.int()
 
         kv_compress = None
         if self.compress_ratio:
             x_sbd = einops.rearrange(x, "b s d -> s b d")
-            kv_compress_sbd = self.compressor(x_sbd)
+            kv_compress_sbd = self.compressor(x_sbd, packed_seq_params=packed_seq_params)
             if kv_compress_sbd is not None:
                 kv_compress = einops.rearrange(kv_compress_sbd, "s b d -> b s d")
 
@@ -298,8 +358,8 @@ class DeepSeekV4Attention(MegatronModule):
                 kv_compress = all_gather_cp(kv_compress, dim=1, cp_group=self.cp_group)
 
         if kv_compress is not None:
-            kv = torch.cat([kv_vanilla, kv_compress], dim=1)
             assert kv_compress_offset == kv_vanilla.size(1)
+            kv = torch.cat([kv_vanilla, kv_compress], dim=1)
         else:
             kv = kv_vanilla
 
@@ -321,13 +381,24 @@ class DeepSeekV4Attention(MegatronModule):
 
         return output
 
-    def _compute_indexer_mask(self, *, q_positions: torch.Tensor, seqlen_global: int) -> torch.Tensor:
+    def _compute_indexer_mask(
+        self,
+        *,
+        q_positions: torch.Tensor,
+        seqlen_global: int,
+        cu_seqlens: torch.Tensor | None = None,
+    ) -> torch.Tensor:
         """Dense causal mask for legacy DSAIndexer path."""
         ratio = 4
         device = q_positions.device
         k_group_idx = torch.arange(seqlen_global // ratio, device=device).unsqueeze(0)
-        q_first_invalid_group = (q_positions.unsqueeze(1) + 1) // ratio
-        invalid_mask = k_group_idx >= q_first_invalid_group
+        if cu_seqlens is None:
+            invalid_mask = k_group_idx >= (q_positions.unsqueeze(1) + 1) // ratio
+        else:
+            valid_start, valid_end = get_compress_query_ranges_for_packed(q_positions, cu_seqlens, ratio=ratio)
+            valid_start = valid_start.unsqueeze(1)
+            valid_end = valid_end.unsqueeze(1)
+            invalid_mask = (k_group_idx < valid_start) | (k_group_idx >= valid_end)
         return torch.where(invalid_mask, float("-inf"), 0.0)
 
 

--- a/miles_plugins/models/deepseek_v4/ops/compressor.py
+++ b/miles_plugins/models/deepseek_v4/ops/compressor.py
@@ -4,7 +4,14 @@ import torch.nn as nn
 from megatron.core.transformer.transformer_config import TransformerConfig
 from torch.nn import Linear
 
-from miles_plugins.models.deepseek_v4.ops.cp_utils import all_gather_cp, get_freqs_cis_for_cp
+from miles_plugins.models.deepseek_v4.ops.cp_utils import (
+    all_gather_cp,
+    get_compress_cu_seqlens_for_packed,
+    get_freqs_cis_for_cp,
+    get_q_positions_for_packed_cp,
+    get_seq_ids_and_offsets_from_cu_seqlens,
+    is_packed_thd_contiguous_cp,
+)
 from miles_plugins.models.deepseek_v4.ops.kernel.precision_aligned_ops import linear_bf16_fp32
 from miles_plugins.models.deepseek_v4.ops.qat import fp8_simulate_qat
 from miles_plugins.models.deepseek_v4.ops.rope import apply_rotary_emb, wrapped_precompute_freqs_cis
@@ -119,7 +126,36 @@ class DeepSeekV4Compressor(nn.Module):
         start = self.cp_rank * G_local
         return tensor[:, start : start + G_local, :, :]
 
-    def forward_raw(self, x: torch.Tensor) -> torch.Tensor:
+    def overlap_transform_packed(self, tensor: torch.Tensor, cu_seqlens: torch.Tensor, value=0) -> torch.Tensor:
+        """Apply overlap transform independently inside each packed sample."""
+        if self.cp_size > 1:
+            tensor = all_gather_cp(tensor, dim=1, cp_group=self.cp_group)
+
+        comp_cu_seqlens = get_compress_cu_seqlens_for_packed(cu_seqlens, ratio=self.compress_ratio)
+        expected_groups = int(comp_cu_seqlens[-1].item())
+        if tensor.size(1) != expected_groups:
+            raise ValueError(
+                "Packed DeepSeek-V4 compressor group count mismatch: "
+                f"tensor={tensor.size(1)}, boundaries={expected_groups}"
+            )
+        group_boundaries = comp_cu_seqlens.tolist()
+        pieces = [
+            self.overlap_transform_raw(tensor[:, start:end], value)
+            for start, end in zip(group_boundaries[:-1], group_boundaries[1:], strict=True)
+        ]
+        tensor = torch.cat(pieces, dim=1) if pieces else tensor[:, :0]
+
+        if self.cp_size == 1:
+            return tensor
+        if tensor.shape[1] % self.cp_size != 0:
+            raise ValueError(
+                f"Packed compressed length {tensor.shape[1]} must be divisible by CP size {self.cp_size}"
+            )
+        G_local = tensor.shape[1] // self.cp_size
+        start = self.cp_rank * G_local
+        return tensor[:, start : start + G_local, :, :]
+
+    def forward_raw(self, x: torch.Tensor, packed_seq_params=None) -> torch.Tensor:
         assert self.ape.dtype == torch.float32
         assert self.wkv.weight.dtype == torch.bfloat16
         assert self.wgate.weight.dtype == torch.bfloat16
@@ -132,6 +168,18 @@ class DeepSeekV4Compressor(nn.Module):
         if self.cp_size > 1:
             assert seqlen_local % (ratio * 2) == 0
 
+        packed_seq = is_packed_thd_contiguous_cp(packed_seq_params, self.cp_size)
+        cu_seqlens = None
+        if packed_seq:
+            cu_seqlens = packed_seq_params.cu_seqlens_q.to(device=x.device, dtype=torch.long)
+            get_compress_cu_seqlens_for_packed(cu_seqlens, ratio=ratio)
+            expected_global = seqlen_local * self.cp_size
+            if int(cu_seqlens[-1].item()) != expected_global:
+                raise ValueError(
+                    "Packed DeepSeek-V4 compressor requires contiguous allgather CP: "
+                    f"cu_seqlens[-1]={int(cu_seqlens[-1].item())}, local={seqlen_local}, cp={self.cp_size}"
+                )
+
         kv = linear_bf16_fp32(x, self.wkv.weight)
         score = linear_bf16_fp32(x, self.wgate.weight)
 
@@ -139,23 +187,52 @@ class DeepSeekV4Compressor(nn.Module):
         score = score.unflatten(1, (-1, ratio)) + self.ape
 
         if overlap:
-            kv = self.overlap_transform_with_cp(kv, 0)
-            score = self.overlap_transform_with_cp(score, float("-inf"))
+            if packed_seq:
+                kv = self.overlap_transform_packed(kv, cu_seqlens, 0)
+                score = self.overlap_transform_packed(score, cu_seqlens, float("-inf"))
+            else:
+                kv = self.overlap_transform_with_cp(kv, 0)
+                score = self.overlap_transform_with_cp(score, float("-inf"))
 
         score_softmax = score.softmax(dim=2)
         kv = (kv * score_softmax).sum(dim=2)
 
         kv = self.norm(kv.to(dtype))
 
-        freqs_cis = wrapped_precompute_freqs_cis(
-            self.config,
-            self.rope_head_dim,
-            self.config.dsv4_compress_rope_theta,
-            False,
-            seqlen_local * self.cp_size,
-            x.device,
-        )
-        freqs_cis = get_freqs_cis_for_cp(freqs_cis, seqlen_local, self.cp_size, self.cp_group, stride=ratio)
+        if packed_seq:
+            max_seq_len = int(packed_seq_params.max_seqlen_q)
+            q_positions = get_q_positions_for_packed_cp(seqlen_local, self.cp_size, self.cp_group, x.device)
+            _, offsets, _, _ = get_seq_ids_and_offsets_from_cu_seqlens(cu_seqlens, q_positions)
+            if int(q_positions[0].item()) % ratio != 0:
+                raise ValueError(
+                    f"Packed CP chunk must start on a compression-group boundary: {q_positions[0].item()=}, {ratio=}"
+                )
+            group_offsets = offsets[::ratio] // ratio
+            if group_offsets.numel() != kv.size(1):
+                raise ValueError(
+                    "Packed DeepSeek-V4 compressor RoPE/group mismatch: "
+                    f"offsets={group_offsets.numel()}, compressed_kv={kv.size(1)}"
+                )
+            max_comp_seq_len = (max_seq_len + ratio - 1) // ratio
+            freqs_cis = wrapped_precompute_freqs_cis(
+                self.config,
+                self.rope_head_dim,
+                self.config.dsv4_compress_rope_theta,
+                False,
+                max_comp_seq_len * ratio,
+                x.device,
+            )
+            freqs_cis = freqs_cis[::ratio][group_offsets]
+        else:
+            freqs_cis = wrapped_precompute_freqs_cis(
+                self.config,
+                self.rope_head_dim,
+                self.config.dsv4_compress_rope_theta,
+                False,
+                seqlen_local * self.cp_size,
+                x.device,
+            )
+            freqs_cis = get_freqs_cis_for_cp(freqs_cis, seqlen_local, self.cp_size, self.cp_group, stride=ratio)
 
         apply_rotary_emb(kv[..., -self.rope_head_dim :], freqs_cis)
 
@@ -170,7 +247,7 @@ class DeepSeekV4Compressor(nn.Module):
 
         return kv
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
+    def forward(self, x: torch.Tensor, packed_seq_params=None) -> torch.Tensor:
         """
         Args:
             x: [seqlen, batch, dim] SBHD layout (Megatron standard)
@@ -178,6 +255,6 @@ class DeepSeekV4Compressor(nn.Module):
             k: [seqlen // compress_ratio, batch, head_dim] SBHD layout
         """
         x_bshd = einops.rearrange(x, "s b d -> b s d")
-        k_bshd = self.forward_raw(x_bshd)
+        k_bshd = self.forward_raw(x_bshd, packed_seq_params=packed_seq_params)
         k = einops.rearrange(k_bshd, "b sc d -> sc b d")
         return k

--- a/miles_plugins/models/deepseek_v4/ops/cp_utils.py
+++ b/miles_plugins/models/deepseek_v4/ops/cp_utils.py
@@ -67,6 +67,36 @@ def get_q_positions_for_cp(
     return torch.arange(start, start + seqlen_local, device=device)
 
 
+def get_q_positions_for_packed_cp(seqlen_local: int, cp_size: int, cp_group: torch.distributed.ProcessGroup, device):
+    """Return global packed-stream positions owned by this contiguous CP rank."""
+    return get_q_positions_for_cp(
+        seqlen_local,
+        cp_size=cp_size,
+        cp_group=cp_group,
+        device=device,
+    )
+
+
+def is_packed_thd_contiguous_cp(packed_seq_params, cp_size: int) -> bool:
+    """Return whether THD boundaries describe the contiguous CP layout used here."""
+    return (
+        packed_seq_params is not None
+        and getattr(packed_seq_params, "qkv_format", None) == "thd"
+        and (cp_size == 1 or bool(getattr(packed_seq_params, "miles_allgather_cp", False)))
+    )
+
+
+def get_seq_ids_and_offsets_from_cu_seqlens(cu_seqlens: Tensor, positions: Tensor) -> tuple[Tensor, Tensor, Tensor, Tensor]:
+    """Map packed global positions to sequence ids and in-sequence offsets."""
+    if cu_seqlens.ndim != 1 or cu_seqlens.numel() < 2:
+        raise ValueError(f"cu_seqlens must contain at least one packed sequence, got shape={tuple(cu_seqlens.shape)}")
+    seq_ids = torch.searchsorted(cu_seqlens, positions.to(cu_seqlens.dtype), right=True) - 1
+    seq_starts = cu_seqlens[seq_ids].to(positions.device)
+    seq_ends = cu_seqlens[seq_ids + 1].to(positions.device)
+    offsets = positions - seq_starts
+    return seq_ids, offsets, seq_starts, seq_ends
+
+
 def get_window_topk_idxs_cp(
     q_positions: Tensor,
     *,
@@ -88,6 +118,23 @@ def get_window_topk_idxs_cp(
         assert torch.equal(result.cpu(), ref_result.cpu()), "get_window_topk_idxs_cp mismatch with ref"
 
     return result
+
+
+def get_window_topk_idxs_packed(
+    q_positions: Tensor,
+    cu_seqlens: Tensor,
+    *,
+    window_size: int,
+    bsz: int,
+) -> Tensor:
+    """Get local-window indices for a packed stream without crossing sequence boundaries."""
+    device = q_positions.device
+    _, q_offsets, seq_starts, _ = get_seq_ids_and_offsets_from_cu_seqlens(cu_seqlens, q_positions)
+    width = min(int(window_size), int(cu_seqlens[-1].item()))
+    rel = (q_offsets.unsqueeze(1) - width + 1).clamp(min=0) + torch.arange(width, device=device)
+    k_pos = seq_starts.unsqueeze(1) + rel
+    topk_idxs = torch.where(rel > q_offsets.unsqueeze(1), -1, k_pos)
+    return topk_idxs.unsqueeze(0).expand(bsz, -1, -1)
 
 
 def get_compress_topk_idxs_cp(
@@ -113,6 +160,52 @@ def get_compress_topk_idxs_cp(
         assert torch.equal(result.cpu(), ref_result.cpu()), "get_compress_topk_idxs_cp mismatch with ref"
 
     return result
+
+
+def get_compress_topk_idxs_packed(
+    q_positions: Tensor,
+    cu_seqlens: Tensor,
+    *,
+    ratio: int,
+    bsz: int,
+) -> Tensor:
+    """Get compressed-KV topk indices for a packed stream without crossing boundaries."""
+    device = q_positions.device
+    comp_seq_starts, comp_seq_ends = get_compress_query_ranges_for_packed(q_positions, cu_seqlens, ratio=ratio)
+    comp_lengths = comp_seq_ends - comp_seq_starts
+    max_comp = int(comp_lengths.max().item()) if comp_lengths.numel() else 0
+    if max_comp == 0:
+        return torch.full((bsz, q_positions.numel(), 1), -1, device=device, dtype=torch.long)
+    rel_group = torch.arange(max_comp, device=device).unsqueeze(0)
+    valid = rel_group < comp_lengths.unsqueeze(1)
+    comp_idx = comp_seq_starts.unsqueeze(1) + rel_group
+    comp_offset = int(cu_seqlens[-1].item())
+    comp_idx = torch.where(valid, comp_idx + comp_offset, -1)
+    return comp_idx.unsqueeze(0).expand(bsz, -1, -1)
+
+
+def get_compress_cu_seqlens_for_packed(cu_seqlens: Tensor, *, ratio: int) -> Tensor:
+    """Return compressed packed boundaries. Requires per-sample lengths divisible by ratio."""
+    lengths = cu_seqlens[1:] - cu_seqlens[:-1]
+    if torch.any(lengths % ratio != 0):
+        raise AssertionError(f"Packed DeepSeek-V4 lengths must be divisible by compress ratio {ratio}: {lengths}")
+    comp_lengths = lengths // ratio
+    return torch.cat([cu_seqlens.new_zeros(1), comp_lengths.cumsum(dim=0)])
+
+
+def get_compress_query_ranges_for_packed(
+    q_positions: Tensor,
+    cu_seqlens: Tensor,
+    *,
+    ratio: int,
+) -> tuple[Tensor, Tensor]:
+    """Return the valid compressed-KV range for each packed query token."""
+    comp_cu_seqlens = get_compress_cu_seqlens_for_packed(cu_seqlens, ratio=ratio)
+    seq_ids, q_offsets, _, _ = get_seq_ids_and_offsets_from_cu_seqlens(cu_seqlens, q_positions)
+    starts = comp_cu_seqlens[seq_ids]
+    ends = starts + (q_offsets + 1) // ratio
+    ends = torch.minimum(ends, comp_cu_seqlens[seq_ids + 1])
+    return starts, ends
 
 
 def get_freqs_cis_for_cp(

--- a/miles_plugins/models/deepseek_v4/ops/kernel/tilelang_indexer_fwd.py
+++ b/miles_plugins/models/deepseek_v4/ops/kernel/tilelang_indexer_fwd.py
@@ -6,7 +6,29 @@
 #   - Supports compressed KV (seq_len_kv = seq_len_q / compress_ratio)
 import tilelang
 import torch
+import torch.nn.functional as F
 from tilelang import language as T
+
+
+_INDEXER_BLOCK_N = 256
+
+
+def _get_indexer_padded_lengths(seq_len, seq_len_kv, heads, block_n=_INDEXER_BLOCK_N):
+    """Return workspace lengths that keep every TileLang load inside its buffers.
+
+    The forward kernel loads a full ``block_n`` KV rows for its last range block,
+    while the cleanup kernel iterates in larger blocks and relies on a runtime
+    column guard. One extra KV tile is reserved as a scratch tail; callers still
+    receive the original logical shape.
+    """
+    if seq_len < 0 or seq_len_kv < 0:
+        raise ValueError(f"sequence lengths must be non-negative, got {seq_len=} {seq_len_kv=}")
+    if block_n <= 0:
+        raise ValueError(f"block_n must be positive, got {block_n=}")
+    block_q = max(1, 128 // heads)
+    padded_seq_len = ((seq_len + block_q - 1) // block_q) * block_q if seq_len else 0
+    padded_seq_len_kv = ((seq_len_kv + block_n - 1) // block_n + 1) * block_n if seq_len_kv else 0
+    return padded_seq_len, padded_seq_len_kv
 
 
 @tilelang.jit(
@@ -116,7 +138,7 @@ def clean_logits_(
             for n_i in T.Pipelined(T.ceildiv(seq_len_kv, block_K)):
                 for k_i in T.serial(block_K // threads):
                     idx = n_i * block_K + k_i * threads + tx
-                    if idx < cu_k_s or idx >= cu_k_e:
+                    if idx < seq_len_kv and (idx < cu_k_s or idx >= cu_k_e):
                         Logits[bx, idx] = -T.infinity(dtype)
 
     return clean_logits_kernel
@@ -148,13 +170,42 @@ def indexer_fwd_interface(q, kv, weights, cu_seqlen_ks, cu_seqlen_ke, clean_logi
     """
     seq_len, heads, index_dim = q.shape
     seq_len_kv = kv.shape[0]
+    logical_seq_len = seq_len
+    logical_seq_len_kv = seq_len_kv
+
+    padded_seq_len, padded_seq_len_kv = _get_indexer_padded_lengths(seq_len, seq_len_kv, heads)
+    if padded_seq_len == 0 or padded_seq_len_kv == 0:
+        return torch.empty([seq_len, seq_len_kv], device=q.device, dtype=torch.float32)
+
+    cu_seqlen_ks = cu_seqlen_ks.to(device=q.device, dtype=torch.int32).clamp(0, logical_seq_len_kv)
+    cu_seqlen_ke = cu_seqlen_ke.to(device=q.device, dtype=torch.int32).clamp(0, logical_seq_len_kv)
+
+    if padded_seq_len != logical_seq_len:
+        pad_len = padded_seq_len - logical_seq_len
+        q = torch.cat((q, q.new_zeros((pad_len, heads, index_dim))), dim=0).contiguous()
+        weights = torch.cat((weights, weights.new_zeros((pad_len, heads))), dim=0).contiguous()
+        pad_rows = torch.zeros(
+            padded_seq_len - logical_seq_len,
+            device=q.device,
+            dtype=cu_seqlen_ks.dtype,
+        ).fill_(logical_seq_len_kv)
+        cu_seqlen_ks = torch.cat((cu_seqlen_ks, pad_rows), dim=0)
+        cu_seqlen_ke = torch.cat((cu_seqlen_ke, pad_rows), dim=0)
+    else:
+        q = q.contiguous()
+        weights = weights.contiguous()
+
+    if padded_seq_len_kv != logical_seq_len_kv:
+        kv = F.pad(kv, (0, 0, 0, padded_seq_len_kv - logical_seq_len_kv), value=0).contiguous()
+    else:
+        kv = kv.contiguous()
 
     clean_logits_kernel = clean_logits_()
     tl_indexer_fwd_kernel = tl_indexer_fwd_impl(heads=heads, index_dim=index_dim)
 
-    logits = torch.empty([seq_len, seq_len_kv], device=q.device, dtype=torch.float32)
+    logits = torch.empty([padded_seq_len, padded_seq_len_kv], device=q.device, dtype=torch.float32)
     tl_indexer_fwd_kernel(
-        q.view(seq_len * heads, index_dim),
+        q.view(padded_seq_len * heads, index_dim),
         kv,
         logits,
         weights.float(),
@@ -163,7 +214,7 @@ def indexer_fwd_interface(q, kv, weights, cu_seqlen_ks, cu_seqlen_ke, clean_logi
     )
     if clean_logits:
         clean_logits_kernel(logits, cu_seqlen_ks, cu_seqlen_ke)
-    return logits
+    return logits[:logical_seq_len, :logical_seq_len_kv]
 
 
 def batched_indexer_fwd(q, k, weights, cu_seqlen_ks, cu_seqlen_ke):

--- a/miles_plugins/models/deepseek_v4/ops/kernel/tilelang_indexer_fwd.py
+++ b/miles_plugins/models/deepseek_v4/ops/kernel/tilelang_indexer_fwd.py
@@ -4,6 +4,8 @@
 #   - Operates on [seqlen, batch, heads, dim] (SBHD) layout, batch handled externally
 #   - Uses causal mask via cu_seqlens instead of variable-length packed sequences
 #   - Supports compressed KV (seq_len_kv = seq_len_q / compress_ratio)
+import os
+
 import tilelang
 import torch
 import torch.nn.functional as F
@@ -11,6 +13,8 @@ from tilelang import language as T
 
 
 _INDEXER_BLOCK_N = 256
+_DEFAULT_INDEXER_LOGITS_WORKSPACE_MB = 2048
+_INDEXER_LOGITS_WORKSPACE_MB_ENV = "MILES_DSV4_INDEXER_LOGITS_WORKSPACE_MB"
 
 
 def _get_indexer_padded_lengths(seq_len, seq_len_kv, heads, block_n=_INDEXER_BLOCK_N):
@@ -29,6 +33,45 @@ def _get_indexer_padded_lengths(seq_len, seq_len_kv, heads, block_n=_INDEXER_BLO
     padded_seq_len = ((seq_len + block_q - 1) // block_q) * block_q if seq_len else 0
     padded_seq_len_kv = ((seq_len_kv + block_n - 1) // block_n + 1) * block_n if seq_len_kv else 0
     return padded_seq_len, padded_seq_len_kv
+
+
+def _get_indexer_logits_workspace_bytes():
+    workspace_mb = os.environ.get(
+        _INDEXER_LOGITS_WORKSPACE_MB_ENV,
+        str(_DEFAULT_INDEXER_LOGITS_WORKSPACE_MB),
+    )
+    try:
+        workspace_mb = int(workspace_mb)
+    except ValueError as exc:
+        raise ValueError(
+            f"{_INDEXER_LOGITS_WORKSPACE_MB_ENV} must be an integer MiB value, got {workspace_mb!r}"
+        ) from exc
+    if workspace_mb <= 0:
+        raise ValueError(f"{_INDEXER_LOGITS_WORKSPACE_MB_ENV} must be positive, got {workspace_mb}")
+    return workspace_mb * 1024 * 1024
+
+
+def _get_indexer_query_chunk_size(seq_len, seq_len_kv, heads, max_workspace_bytes):
+    """Bound the FP32 logits workspace while preserving TileLang query tiles."""
+    if seq_len < 0 or seq_len_kv < 0:
+        raise ValueError(f"sequence lengths must be non-negative, got {seq_len=} {seq_len_kv=}")
+    if max_workspace_bytes <= 0:
+        raise ValueError(f"max_workspace_bytes must be positive, got {max_workspace_bytes}")
+    if seq_len == 0 or seq_len_kv == 0:
+        return seq_len
+
+    block_q = max(1, 128 // heads)
+    _, padded_seq_len_kv = _get_indexer_padded_lengths(1, seq_len_kv, heads)
+    bytes_per_query = padded_seq_len_kv * torch.float32.itemsize
+    minimum_workspace_bytes = block_q * bytes_per_query
+    if max_workspace_bytes < minimum_workspace_bytes:
+        raise ValueError(
+            "indexer logits workspace is smaller than one TileLang query tile: "
+            f"got {max_workspace_bytes} bytes, need at least {minimum_workspace_bytes}"
+        )
+    workspace_rows = max_workspace_bytes // bytes_per_query
+    chunk_size = (workspace_rows // block_q) * block_q
+    return min(seq_len, chunk_size)
 
 
 @tilelang.jit(
@@ -243,3 +286,51 @@ def batched_indexer_fwd(q, k, weights, cu_seqlen_ks, cu_seqlen_ke):
             cu_seqlen_ke,
         )
     return all_logits
+
+
+def batched_indexer_topk(
+    q,
+    k,
+    weights,
+    cu_seqlen_ks,
+    cu_seqlen_ke,
+    topk,
+    topk_fn,
+    max_workspace_bytes=None,
+):
+    """Compute exact per-query top-k indices without materializing full-sequence logits.
+
+    Chunking only the query dimension is exact because every query independently
+    scores the full compressed-KV dimension. The chunk size is aligned to the
+    TileLang query tile and caps the temporary FP32 logits allocation.
+    """
+    seqlen, batch, heads, _ = q.shape
+    seq_len_kv = k.shape[0]
+    topk_count = min(topk, seq_len_kv)
+    if seqlen == 0 or topk_count == 0:
+        return torch.empty((batch, seqlen, topk_count), device=q.device, dtype=torch.int32)
+
+    if max_workspace_bytes is None:
+        max_workspace_bytes = _get_indexer_logits_workspace_bytes()
+    query_chunk_size = _get_indexer_query_chunk_size(
+        seqlen,
+        seq_len_kv,
+        heads,
+        max_workspace_bytes,
+    )
+    topk_indices = torch.empty((batch, seqlen, topk_count), device=q.device, dtype=torch.int32)
+
+    for b in range(batch):
+        k_b = k[:, b, :].contiguous()
+        for start in range(0, seqlen, query_chunk_size):
+            end = min(start + query_chunk_size, seqlen)
+            chunk_logits = indexer_fwd_interface(
+                q[start:end, b, :, :].contiguous(),
+                k_b,
+                weights[start:end, b, :].contiguous(),
+                cu_seqlen_ks[start:end],
+                cu_seqlen_ke[start:end],
+            )
+            topk_indices[b, start:end].copy_(topk_fn(chunk_logits, topk_count))
+
+    return topk_indices

--- a/miles_plugins/models/deepseek_v4/ops/kernel/tilelang_sparse_mla_bwd.py
+++ b/miles_plugins/models/deepseek_v4/ops/kernel/tilelang_sparse_mla_bwd.py
@@ -172,7 +172,11 @@ def bwd(
                     acc_p[h_i, bi_i] = T.if_then_else(mask[bi_i], 0, -T.infinity(acc_p.dtype))
 
                 for bi_i, d_i in T.Parallel(BS, D):
-                    KV_shared[bi_i, d_i] = KV[by, Indices[by, s_i, i_i * BS + bi_i], d_i]
+                    # Keep invalid causal/window padding indices in bounds;
+                    # ``acc_p`` is masked to -inf immediately afterwards.
+                    index = Indices[by, s_i, i_i * BS + bi_i]
+                    safe_index = T.max(T.min(index, S_kv - 1), 0)
+                    KV_shared[bi_i, d_i] = KV[by, safe_index, d_i]
 
                 T.gemm(Q_shared, KV_shared, acc_p, transpose_B=True, policy=T.GemmWarpPolicy.FullCol)
 
@@ -217,14 +221,12 @@ def bwd(
                             acc_dkv_shared[bi_i, d_i] = acc_dkv[bi_i + s * (BS // split_store), d_i]
 
                     for bi_i, d_i in T.Parallel(BS // split_store, D // 4):
-                        T.atomic_addx4(
-                            dKV[
-                                by,
-                                Indices[by, s_i, i_i * BS + bi_i + s * (BS // split_store)],
-                                d_i * 4,
-                            ],
-                            acc_dkv_shared[bi_i, d_i * 4],
-                        )
+                        index = Indices[by, s_i, i_i * BS + bi_i + s * (BS // split_store)]
+                        if index >= 0 and index < S_kv:
+                            T.atomic_addx4(
+                                dKV[by, index, d_i * 4],
+                                acc_dkv_shared[bi_i, d_i * 4],
+                            )
 
             # Store dQ
             T.copy(acc_dq, dQ_shared)

--- a/miles_plugins/models/deepseek_v4/ops/kernel/tilelang_sparse_mla_fwd.py
+++ b/miles_plugins/models/deepseek_v4/ops/kernel/tilelang_sparse_mla_fwd.py
@@ -110,7 +110,11 @@ def sparse_mqa_fwd(
                     mask[bi_i] = Indices[b_i, s_i, i_i * BI + bi_i] != -1
 
                 for bi_i, d_i in T.Parallel(BI, D):
-                    KV_shared[bi_i, d_i] = KV[b_i, Indices[b_i, s_i, i_i * BI + bi_i], d_i]
+                    # Causal/window padding uses -1.  Keep the masked load in
+                    # bounds; the score mask below makes this value inert.
+                    index = Indices[b_i, s_i, i_i * BI + bi_i]
+                    safe_index = T.max(T.min(index, seq_len_kv - 1), 0)
+                    KV_shared[bi_i, d_i] = KV[b_i, safe_index, d_i]
 
                 for h_i, bi_i in T.Parallel(H_per_block, BI):
                     acc_s[h_i, bi_i] = T.if_then_else(mask[bi_i], 0, -T.infinity(acc_s.dtype))

--- a/miles_plugins/models/deepseek_v4/ops/v4_indexer.py
+++ b/miles_plugins/models/deepseek_v4/ops/v4_indexer.py
@@ -8,7 +8,14 @@ from megatron.core.transformer.module import MegatronModule
 from megatron.core.transformer.transformer_config import TransformerConfig
 
 from miles_plugins.models.deepseek_v4.ops.compressor import DeepSeekV4Compressor
-from miles_plugins.models.deepseek_v4.ops.cp_utils import all_gather_cp, get_freqs_cis_for_cp
+from miles_plugins.models.deepseek_v4.ops.cp_utils import (
+    all_gather_cp,
+    get_compress_query_ranges_for_packed,
+    get_freqs_cis_for_cp,
+    get_q_positions_for_packed_cp,
+    get_seq_ids_and_offsets_from_cu_seqlens,
+    is_packed_thd_contiguous_cp,
+)
 from miles_plugins.models.deepseek_v4.ops.kernel.tilelang_indexer_fwd import (
     _make_causal_cu_seqlens,
     batched_indexer_fwd,
@@ -76,7 +83,7 @@ class V4Indexer(MegatronModule):
             x:  hidden states [seqlen, batch, hidden_size]
             qr: low-rank query [seqlen, batch, q_lora_rank]
             mask: unused (causal mask generated internally via cu_seqlens)
-            packed_seq_params: unused
+            packed_seq_params: optional THD packed boundaries
 
         Returns:
             topk_indices: [batch, seqlen, index_topk] int64
@@ -98,10 +105,30 @@ class V4Indexer(MegatronModule):
         cp_size = parallel_state.get_context_parallel_world_size()
         cp_group = self.pg_collection.cp if hasattr(self.pg_collection, "cp") else None
         rope_base = self.config.dsv4_compress_rope_theta if self.compress_ratio else self.config.rotary_base
-        freqs_cis = wrapped_precompute_freqs_cis(
-            self.config, self.rope_head_dim, rope_base, False, seqlen * cp_size, x.device
-        )
-        freqs_cis = get_freqs_cis_for_cp(freqs_cis, seqlen, cp_size, cp_group, stride=1)
+        packed_seq = is_packed_thd_contiguous_cp(packed_seq_params, cp_size)
+        if packed_seq:
+            if bsz != 1:
+                raise ValueError(f"DeepSeek-V4 THD packing requires batch dimension 1, got {bsz=}")
+            cu_seqlens = packed_seq_params.cu_seqlens_q.to(device=x.device, dtype=torch.long)
+            seqlen_global = int(cu_seqlens[-1].item())
+            expected_global = seqlen * cp_size
+            if seqlen_global != expected_global:
+                raise ValueError(
+                    "DeepSeek-V4 THD packing requires contiguous allgather CP: "
+                    f"cu_seqlens[-1]={seqlen_global}, local={seqlen}, cp={cp_size}"
+                )
+            max_seqlen = int(packed_seq_params.max_seqlen_q)
+            q_positions = get_q_positions_for_packed_cp(seqlen, cp_size, cp_group, x.device)
+            _, q_offsets, _, _ = get_seq_ids_and_offsets_from_cu_seqlens(cu_seqlens, q_positions)
+            freqs_cis_all = wrapped_precompute_freqs_cis(
+                self.config, self.rope_head_dim, rope_base, False, max_seqlen, x.device
+            )
+            freqs_cis = freqs_cis_all[q_offsets]
+        else:
+            freqs_cis = wrapped_precompute_freqs_cis(
+                self.config, self.rope_head_dim, rope_base, False, seqlen * cp_size, x.device
+            )
+            freqs_cis = get_freqs_cis_for_cp(freqs_cis, seqlen, cp_size, cp_group, stride=1)
         q = q.clone()
         q = einops.rearrange(q, "s b ... -> b s ...")
         apply_rotary_emb(q[..., -rd:], freqs_cis)
@@ -111,7 +138,7 @@ class V4Indexer(MegatronModule):
         if self.use_fp8_qat:
             q = fp8_simulate_qat(q, 128)
 
-        k = self.compressor(x)
+        k = self.compressor(x, packed_seq_params=packed_seq_params)
 
         weights, _ = self.linear_weights_proj(x)
         softmax_scale = self.index_head_dim**-0.5
@@ -120,14 +147,24 @@ class V4Indexer(MegatronModule):
         if cp_size > 1 and cp_group is not None:
             k = all_gather_cp(k, dim=0, cp_group=cp_group)
 
-        seqlen_global = seqlen * cp_size
+        if not packed_seq:
+            seqlen_global = seqlen * cp_size
         seqlen_kv = k.shape[0]
-        cu_ks, cu_ke = _make_causal_cu_seqlens(seqlen_global, seqlen_kv, self.compress_ratio, q.device)
-        # cu_seqlens are for global positions; slice to local query positions
-        if cp_size > 1 and cp_group is not None:
-            cp_rank = cp_group.rank()
-            cu_ks = cu_ks[cp_rank * seqlen : (cp_rank + 1) * seqlen]
-            cu_ke = cu_ke[cp_rank * seqlen : (cp_rank + 1) * seqlen]
+        if seqlen_kv == 0:
+            return torch.empty((bsz, seqlen, 0), device=x.device, dtype=torch.int32)
+        if packed_seq:
+            cu_ks, cu_ke = get_compress_query_ranges_for_packed(
+                q_positions, cu_seqlens, ratio=self.compress_ratio
+            )
+            cu_ks = cu_ks.to(torch.int32)
+            cu_ke = cu_ke.to(torch.int32)
+        else:
+            cu_ks, cu_ke = _make_causal_cu_seqlens(seqlen_global, seqlen_kv, self.compress_ratio, q.device)
+            # cu_seqlens are for global positions; slice to local query positions
+            if cp_size > 1 and cp_group is not None:
+                cp_rank = cp_group.rank()
+                cu_ks = cu_ks[cp_rank * seqlen : (cp_rank + 1) * seqlen]
+                cu_ke = cu_ke[cp_rank * seqlen : (cp_rank + 1) * seqlen]
         index_scores = batched_indexer_fwd(q, k, weights.float(), cu_ks, cu_ke)
 
         topk_count = min(self.index_topk, index_scores.size(-1))

--- a/miles_plugins/models/deepseek_v4/ops/v4_indexer.py
+++ b/miles_plugins/models/deepseek_v4/ops/v4_indexer.py
@@ -18,7 +18,7 @@ from miles_plugins.models.deepseek_v4.ops.cp_utils import (
 )
 from miles_plugins.models.deepseek_v4.ops.kernel.tilelang_indexer_fwd import (
     _make_causal_cu_seqlens,
-    batched_indexer_fwd,
+    batched_indexer_topk,
 )
 from miles_plugins.models.deepseek_v4.ops.qat import fp8_simulate_qat
 from miles_plugins.models.deepseek_v4.ops.rope import apply_rotary_emb, wrapped_precompute_freqs_cis
@@ -165,9 +165,14 @@ class V4Indexer(MegatronModule):
                 cp_rank = cp_group.rank()
                 cu_ks = cu_ks[cp_rank * seqlen : (cp_rank + 1) * seqlen]
                 cu_ke = cu_ke[cp_rank * seqlen : (cp_rank + 1) * seqlen]
-        index_scores = batched_indexer_fwd(q, k, weights.float(), cu_ks, cu_ke)
-
-        topk_count = min(self.index_topk, index_scores.size(-1))
-        topk_indices = get_dsa_topk_fn(self.topk_backend)(index_scores, topk_count)
+        topk_indices = batched_indexer_topk(
+            q,
+            k,
+            weights.float(),
+            cu_ks,
+            cu_ke,
+            self.index_topk,
+            get_dsa_topk_fn(self.topk_backend),
+        )
 
         return topk_indices

--- a/tests/fast/backends/training_utils/test_true_on_policy_loss_metrics.py
+++ b/tests/fast/backends/training_utils/test_true_on_policy_loss_metrics.py
@@ -49,7 +49,12 @@ def _patch_single_rank_loss_helpers(monkeypatch):
     monkeypatch.setattr(
         loss_utils,
         "get_local_response_loss_masks",
-        lambda total_lengths, response_lengths, loss_masks, qkv_format="thd", max_seq_lens=None: loss_masks,
+        lambda total_lengths,
+        response_lengths,
+        loss_masks,
+        qkv_format="thd",
+        max_seq_lens=None,
+        padded_total_lengths=None: loss_masks,
     )
     monkeypatch.setattr(
         loss_utils,

--- a/tests/fast/models/test_deepseek_v4_bridge.py
+++ b/tests/fast/models/test_deepseek_v4_bridge.py
@@ -1,0 +1,25 @@
+import pytest
+import torch
+
+
+@pytest.fixture(scope="module")
+def bridge_stub():
+    pytest.importorskip("mbridge")
+    from miles_plugins.mbridge.deepseekv4 import DeepseekV4Bridge
+
+    bridge = DeepseekV4Bridge.__new__(DeepseekV4Bridge)
+    bridge.make_vocab_size_divisible_by = None
+    return bridge
+
+
+def test_tid2eid_preserves_integer_expert_indices(bridge_stub):
+    bridge_stub.dtype = torch.bfloat16
+    tid2eid = torch.tensor([[0, 257, 381, 382, 383]], dtype=torch.int64)
+
+    converted = bridge_stub._weight_to_mcore_format(
+        "decoder.layers.0.mlp.router.tid2eid", [tid2eid]
+    )
+
+    assert converted.dtype == torch.int64
+    assert torch.equal(converted, tid2eid)
+    assert converted.is_contiguous()

--- a/tests/fast/models/test_deepseek_v4_packing.py
+++ b/tests/fast/models/test_deepseek_v4_packing.py
@@ -1,0 +1,172 @@
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.nn as nn
+
+from miles.backends.training_utils.data import (
+    DataIterator,
+    _get_thd_allgather_pad_multiple,
+    get_thd_padded_total_lengths,
+)
+from miles.backends.training_utils.loss_hub import logit_processors
+from miles_plugins.models.deepseek_v4.ops.compressor import DeepSeekV4Compressor
+from miles_plugins.models.deepseek_v4.ops.cp_utils import (
+    get_compress_cu_seqlens_for_packed,
+    get_compress_query_ranges_for_packed,
+    get_compress_topk_idxs_packed,
+    get_seq_ids_and_offsets_from_cu_seqlens,
+    get_window_topk_idxs_packed,
+    is_packed_thd_contiguous_cp,
+)
+
+
+def test_packed_window_and_compressed_indices_do_not_cross_samples():
+    cu_seqlens = torch.tensor([0, 128, 384], dtype=torch.long)
+    q_positions = torch.arange(96, 192)
+
+    window = get_window_topk_idxs_packed(q_positions, cu_seqlens, window_size=128, bsz=1)[0]
+    seq_ids, _, seq_starts, _ = get_seq_ids_and_offsets_from_cu_seqlens(cu_seqlens, q_positions)
+    valid_window = window >= 0
+    assert torch.all(window[valid_window] >= seq_starts.unsqueeze(1).expand_as(window)[valid_window])
+    assert torch.all(window[valid_window] <= q_positions.unsqueeze(1).expand_as(window)[valid_window])
+
+    first_query_of_second_sample = (q_positions == 128).nonzero(as_tuple=True)[0].item()
+    assert window[first_query_of_second_sample, 0].item() == 128
+    assert torch.all(window[first_query_of_second_sample, 1:] == -1)
+    assert seq_ids[first_query_of_second_sample].item() == 1
+
+    compressed = get_compress_topk_idxs_packed(q_positions, cu_seqlens, ratio=128, bsz=1)[0]
+    assert compressed[(q_positions == 127).nonzero(as_tuple=True)[0].item(), 0].item() == 384
+    assert torch.all(compressed[first_query_of_second_sample] == -1)
+
+    starts, ends = get_compress_query_ranges_for_packed(q_positions, cu_seqlens, ratio=4)
+    assert starts[first_query_of_second_sample].item() == 32
+    assert ends[first_query_of_second_sample].item() == 32
+    assert torch.all(ends >= starts)
+
+
+def test_compressed_boundaries_require_per_sample_alignment():
+    assert torch.equal(
+        get_compress_cu_seqlens_for_packed(torch.tensor([0, 128, 384]), ratio=128),
+        torch.tensor([0, 1, 3]),
+    )
+    with pytest.raises(AssertionError, match="divisible"):
+        get_compress_cu_seqlens_for_packed(torch.tensor([0, 127, 384]), ratio=128)
+
+    packed = SimpleNamespace(qkv_format="thd", miles_allgather_cp=True)
+    zigzag = SimpleNamespace(qkv_format="thd", miles_allgather_cp=False)
+    assert is_packed_thd_contiguous_cp(packed, cp_size=4)
+    assert not is_packed_thd_contiguous_cp(zigzag, cp_size=4)
+    assert is_packed_thd_contiguous_cp(zigzag, cp_size=1)
+
+
+def test_c4_overlap_resets_at_each_packed_sample():
+    compressor = DeepSeekV4Compressor.__new__(DeepSeekV4Compressor)
+    nn.Module.__init__(compressor)
+    compressor.compress_ratio = 4
+    compressor.head_dim = 1
+    compressor.cp_size = 1
+
+    groups = torch.arange(1, 1 + 4 * 4 * 2, dtype=torch.float32).view(1, 4, 4, 2)
+    packed = compressor.overlap_transform_packed(groups, torch.tensor([0, 8, 16]), value=0)
+    unbounded = compressor.overlap_transform_raw(groups, value=0)
+
+    assert torch.all(packed[:, 2, :4] == 0)
+    assert torch.any(unbounded[:, 2, :4] != 0)
+    assert torch.equal(packed[:, 2:, 4:], unbounded[:, 2:, 4:])
+
+
+def test_thd_padding_and_response_logits_keep_original_alignment(monkeypatch):
+    args = SimpleNamespace(
+        model_name="deepseekv4",
+        compress_ratios=[0, 4, 128],
+        qkv_format="thd",
+        true_on_policy_mode=False,
+        rollout_temperature=1.0,
+    )
+    assert get_thd_padded_total_lengths(args, [3, 129]) == [128, 256]
+    assert _get_thd_allgather_pad_multiple(cp_size=4, pad_size=128, sample_pad_multiple=128) == 1024
+
+    rollout_data = {"tokens": [10, 20]}
+    iterator = DataIterator(rollout_data, 1, args=args)
+    assert iterator.get_next(["tokens"])["tokens"] == [10]
+
+    monkeypatch.setattr(
+        logit_processors,
+        "get_parallel_state",
+        lambda: SimpleNamespace(cp=SimpleNamespace(size=1, rank=0)),
+    )
+    logits = torch.arange(8 * 2, dtype=torch.float32).view(1, 8, 2)
+    chunks = list(
+        logit_processors.get_responses(
+            logits,
+            args=args,
+            unconcat_tokens=[torch.tensor([10, 11, 12]), torch.tensor([20, 21])],
+            total_lengths=[3, 2],
+            response_lengths=[2, 1],
+            padded_total_lengths=[4, 4],
+        )
+    )
+
+    assert torch.equal(chunks[0][0], logits[0, 0:2])
+    assert torch.equal(chunks[0][1], torch.tensor([11, 12]))
+    assert torch.equal(chunks[1][0], logits[0, 4:5])
+    assert torch.equal(chunks[1][1], torch.tensor([21]))
+
+
+def test_indexer_workspace_padding_keeps_logical_lengths():
+    tilelang_indexer_fwd = pytest.importorskip(
+        "miles_plugins.models.deepseek_v4.ops.kernel.tilelang_indexer_fwd"
+    )
+    get_lengths = tilelang_indexer_fwd._get_indexer_padded_lengths
+    assert get_lengths(seq_len=257, seq_len_kv=513, heads=64) == (258, 1024)
+    assert get_lengths(seq_len=256, seq_len_kv=256, heads=64) == (256, 512)
+    assert get_lengths(seq_len=0, seq_len_kv=0, heads=64) == (0, 0)
+
+
+def test_indexer_workspace_padding_restores_logical_shape(monkeypatch):
+    tilelang_indexer_fwd = pytest.importorskip(
+        "miles_plugins.models.deepseek_v4.ops.kernel.tilelang_indexer_fwd"
+    )
+    captured = {}
+
+    def fake_indexer_factory(*, heads, index_dim):
+        captured["heads"] = heads
+        captured["index_dim"] = index_dim
+
+        def fake_indexer(q, kv, logits, weights, cu_ks, cu_ke):
+            captured["q"] = q.clone()
+            captured["kv"] = kv.clone()
+            captured["weights"] = weights.clone()
+            captured["cu_ks"] = cu_ks.clone()
+            captured["cu_ke"] = cu_ke.clone()
+            logits.zero_()
+
+        return fake_indexer
+
+    def fake_clean_factory():
+        def fake_clean(logits, cu_ks, cu_ke):
+            captured["clean_shape"] = tuple(logits.shape)
+
+        return fake_clean
+
+    monkeypatch.setattr(tilelang_indexer_fwd, "tl_indexer_fwd_impl", fake_indexer_factory)
+    monkeypatch.setattr(tilelang_indexer_fwd, "clean_logits_", fake_clean_factory)
+
+    q = torch.ones(3, 64, 2, dtype=torch.bfloat16)
+    kv = torch.ones(257, 2, dtype=torch.bfloat16)
+    weights = torch.ones(3, 64, dtype=torch.float32)
+    cu_ks = torch.tensor([0, 1, 2], dtype=torch.int32)
+    cu_ke = torch.tensor([1, 2, 257], dtype=torch.int32)
+
+    logits = tilelang_indexer_fwd.indexer_fwd_interface(q, kv, weights, cu_ks, cu_ke)
+
+    assert logits.shape == (3, 257)
+    assert captured["q"].shape == (4 * 64, 2)
+    assert captured["kv"].shape == (768, 2)
+    assert captured["weights"].shape == (4, 64)
+    assert captured["clean_shape"] == (4, 768)
+    assert captured["cu_ks"][-1].item() == 257
+    assert captured["cu_ke"][-1].item() == 257
+    assert torch.count_nonzero(captured["kv"][257:]) == 0

--- a/tests/fast/models/test_deepseek_v4_packing.py
+++ b/tests/fast/models/test_deepseek_v4_packing.py
@@ -6,7 +6,12 @@ import torch.nn as nn
 
 from miles.backends.training_utils.data import (
     DataIterator,
+    _dynamic_batch_schedule_fingerprint,
     _get_thd_allgather_pad_multiple,
+    _get_capped_thd_partitions,
+    _summarize_thd_packing,
+    _sync_thd_dynamic_batch_schedule,
+    _validate_dynamic_batch_schedule,
     get_thd_padded_total_lengths,
 )
 from miles.backends.training_utils.loss_hub import logit_processors
@@ -113,6 +118,120 @@ def test_thd_padding_and_response_logits_keep_original_alignment(monkeypatch):
     assert torch.equal(chunks[0][1], torch.tensor([11, 12]))
     assert torch.equal(chunks[1][0], logits[0, 4:5])
     assert torch.equal(chunks[1][1], torch.tensor([21]))
+
+
+def test_thd_dynamic_packing_stats_measure_real_and_padded_tokens():
+    stats = _summarize_thd_packing(
+        [60000, 61000, 30000, 30000],
+        [[0, 1], [2, 3]],
+        sample_pad_multiple=128,
+        global_pad_multiple=4096,
+        seq_length=131072,
+    )
+
+    assert stats["samples"] == 4
+    assert stats["packs"] == 2
+    assert stats["samples_per_pack"] == 2
+    assert stats["actual_tokens"] == 181000
+    assert stats["padded_tokens"] == 184320
+    assert stats["no_pack_padded_tokens"] == 188416
+    assert stats["packing_efficiency"] == pytest.approx(181000 / 184320)
+    assert stats["seq_capacity_fill"] == pytest.approx(181000 / (2 * 131072))
+    assert stats["padding_reduction_vs_mbs1"] == pytest.approx(1 - 184320 / 188416)
+    assert stats["max_samples_per_pack"] == 2
+    assert stats["max_pack_actual_tokens"] == 121000
+    assert stats["max_pack_padded_tokens"] == 122880
+    assert stats["oversized_packs"] == 0
+
+
+def test_thd_dynamic_packing_stats_flag_pack_over_seq_length():
+    stats = _summarize_thd_packing(
+        [70000, 70000],
+        [[0, 1]],
+        sample_pad_multiple=128,
+        global_pad_multiple=4096,
+        seq_length=131072,
+    )
+
+    assert stats["max_pack_padded_tokens"] == 143360
+    assert stats["oversized_packs"] == 1
+
+
+def test_thd_capped_fallback_accounts_for_dsv4_alignment_and_global_padding():
+    partitions = _get_capped_thd_partitions(
+        [70000, 70000, 30000],
+        2,
+        sample_pad_multiple=128,
+        global_pad_multiple=2048,
+        max_padded_tokens=131072,
+    )
+
+    stats = _summarize_thd_packing(
+        [70000, 70000, 30000],
+        partitions,
+        sample_pad_multiple=128,
+        global_pad_multiple=2048,
+        seq_length=131072,
+    )
+    assert sorted(sum(partitions, [])) == [0, 1, 2]
+    assert stats["max_pack_padded_tokens"] <= 131072
+    assert stats["oversized_packs"] == 0
+
+
+def test_thd_capped_fallback_rejects_an_unplaceable_single_sample():
+    with pytest.raises(ValueError, match="sample into a THD sequence"):
+        _get_capped_thd_partitions(
+            [131073],
+            1,
+            sample_pad_multiple=128,
+            global_pad_multiple=2048,
+            max_padded_tokens=131072,
+        )
+
+
+def test_dynamic_batch_schedule_validation_rejects_duplicate_or_missing_samples():
+    with pytest.raises(ValueError, match="every local sample exactly once"):
+        _validate_dynamic_batch_schedule([2], [[0, 1], [1, 2]], num_local_samples=3)
+
+
+def test_thd_dynamic_batch_schedule_sync_uses_canonical_model_replica_schedule(monkeypatch):
+    local_indices = [[0, 2], [1]]
+    canonical_indices = [[0], [1, 2]]
+    canonical_payload = {
+        "num_microbatches": [2],
+        "micro_batch_indices": canonical_indices,
+        "num_local_samples": 3,
+    }
+    groups = [object(), object(), object()]
+    parallel = SimpleNamespace(
+        pp=SimpleNamespace(rank=1, size=2, group=groups[0]),
+        cp=SimpleNamespace(rank=1, size=2, group=groups[1]),
+        tp=SimpleNamespace(rank=1, size=2, group=groups[2]),
+    )
+    calls = []
+
+    monkeypatch.setattr("miles.backends.training_utils.data.dist.is_initialized", lambda: True)
+    monkeypatch.setattr("miles.backends.training_utils.data.dist.get_rank", lambda: 1)
+    monkeypatch.setattr(
+        "miles.backends.training_utils.data.dist.get_global_rank",
+        lambda group, rank: 100 + groups.index(group),
+    )
+
+    def fake_broadcast_object_list(object_list, *, src, group):
+        calls.append((src, group))
+        object_list[0] = canonical_payload
+
+    monkeypatch.setattr(
+        "miles.backends.training_utils.data.dist.broadcast_object_list",
+        fake_broadcast_object_list,
+    )
+
+    num_microbatches, indices = _sync_thd_dynamic_batch_schedule(parallel, [2], local_indices, 3)
+
+    assert num_microbatches == [2]
+    assert indices == canonical_indices
+    assert calls == [(100, groups[0]), (101, groups[1]), (102, groups[2])]
+    assert _dynamic_batch_schedule_fingerprint([2], local_indices) != _dynamic_batch_schedule_fingerprint([2], canonical_indices)
 
 
 def test_indexer_workspace_padding_keeps_logical_lengths():

--- a/tests/fast/models/test_deepseek_v4_packing.py
+++ b/tests/fast/models/test_deepseek_v4_packing.py
@@ -170,3 +170,108 @@ def test_indexer_workspace_padding_restores_logical_shape(monkeypatch):
     assert captured["cu_ks"][-1].item() == 257
     assert captured["cu_ke"][-1].item() == 257
     assert torch.count_nonzero(captured["kv"][257:]) == 0
+
+
+def test_indexer_query_chunk_size_bounds_fp32_workspace():
+    tilelang_indexer_fwd = pytest.importorskip(
+        "miles_plugins.models.deepseek_v4.ops.kernel.tilelang_indexer_fwd"
+    )
+    max_workspace_bytes = 8192
+    chunk_size = tilelang_indexer_fwd._get_indexer_query_chunk_size(
+        seq_len=17,
+        seq_len_kv=257,
+        heads=64,
+        max_workspace_bytes=max_workspace_bytes,
+    )
+    _, padded_seq_len_kv = tilelang_indexer_fwd._get_indexer_padded_lengths(1, 257, 64)
+
+    assert chunk_size == 2
+    assert chunk_size % 2 == 0
+    assert chunk_size * padded_seq_len_kv * torch.float32.itemsize <= max_workspace_bytes
+
+
+def test_indexer_query_chunk_size_rejects_workspace_smaller_than_one_tile():
+    tilelang_indexer_fwd = pytest.importorskip(
+        "miles_plugins.models.deepseek_v4.ops.kernel.tilelang_indexer_fwd"
+    )
+    _, padded_seq_len_kv = tilelang_indexer_fwd._get_indexer_padded_lengths(1, 257, 64)
+    minimum_workspace_bytes = 2 * padded_seq_len_kv * torch.float32.itemsize
+
+    with pytest.raises(ValueError, match="smaller than one TileLang query tile"):
+        tilelang_indexer_fwd._get_indexer_query_chunk_size(
+            seq_len=17,
+            seq_len_kv=257,
+            heads=64,
+            max_workspace_bytes=minimum_workspace_bytes - 1,
+        )
+
+
+def test_batched_indexer_topk_chunks_queries_without_full_logits(monkeypatch):
+    tilelang_indexer_fwd = pytest.importorskip(
+        "miles_plugins.models.deepseek_v4.ops.kernel.tilelang_indexer_fwd"
+    )
+    seen_chunk_sizes = []
+
+    def fake_indexer(q, kv, weights, cu_ks, cu_ke):
+        seen_chunk_sizes.append(q.shape[0])
+        scores = torch.arange(kv.shape[0], dtype=torch.float32).expand(q.shape[0], -1).clone()
+        positions = torch.arange(kv.shape[0]).unsqueeze(0)
+        valid = (positions >= cu_ks.unsqueeze(1)) & (positions < cu_ke.unsqueeze(1))
+        return scores.masked_fill(~valid, float("-inf"))
+
+    def torch_topk_indices(logits, topk):
+        scores, indices = torch.topk(logits, topk, dim=-1)
+        return indices.to(torch.int32).masked_fill(scores == -torch.inf, -1)
+
+    monkeypatch.setattr(tilelang_indexer_fwd, "indexer_fwd_interface", fake_indexer)
+    q = torch.zeros(5, 2, 64, 1, dtype=torch.bfloat16)
+    k = torch.zeros(5, 2, 1, dtype=torch.bfloat16)
+    weights = torch.ones(5, 2, 64, dtype=torch.float32)
+    cu_ks = torch.zeros(5, dtype=torch.int32)
+    cu_ke = torch.full((5,), 5, dtype=torch.int32)
+
+    indices = tilelang_indexer_fwd.batched_indexer_topk(
+        q,
+        k,
+        weights,
+        cu_ks,
+        cu_ke,
+        topk=2,
+        topk_fn=torch_topk_indices,
+        max_workspace_bytes=4096,
+    )
+
+    assert indices.shape == (2, 5, 2)
+    assert torch.equal(indices, torch.tensor([[[4, 3]] * 5] * 2, dtype=torch.int32))
+    assert seen_chunk_sizes == [2, 2, 1, 2, 2, 1]
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA TileLang kernel")
+def test_batched_indexer_topk_gpu_chunks_match_full_logits():
+    tilelang_indexer_fwd = pytest.importorskip(
+        "miles_plugins.models.deepseek_v4.ops.kernel.tilelang_indexer_fwd"
+    )
+    from miles_plugins.models.dsa_topk import torch_dsa_topk
+
+    torch.manual_seed(1234)
+    device = torch.device("cuda")
+    q = torch.randn(16, 1, 64, 128, device=device, dtype=torch.bfloat16)
+    k = torch.randn(8, 1, 128, device=device, dtype=torch.bfloat16)
+    weights = torch.randn(16, 1, 64, device=device, dtype=torch.float32)
+    cu_ks = torch.zeros(16, device=device, dtype=torch.int32)
+    cu_ke = torch.full((16,), 8, device=device, dtype=torch.int32)
+
+    full_logits = tilelang_indexer_fwd.batched_indexer_fwd(q, k, weights, cu_ks, cu_ke)
+    expected = torch_dsa_topk(full_logits, 4)
+    actual = tilelang_indexer_fwd.batched_indexer_topk(
+        q,
+        k,
+        weights,
+        cu_ks,
+        cu_ke,
+        topk=4,
+        topk_fn=torch_dsa_topk,
+        max_workspace_bytes=4096,
+    )
+
+    assert torch.equal(actual, expected)

--- a/tests/fast/utils/test_mask_utils.py
+++ b/tests/fast/utils/test_mask_utils.py
@@ -2,6 +2,21 @@ from miles.utils.mask_utils import MultiTurnLossMaskGenerator
 from miles.utils.processing_utils import load_tokenizer
 
 
+class _CharOffsetTokenizer:
+    name_or_path = ""
+    eos_token = "<｜end▁of▁sentence｜>"
+
+    def __call__(self, text, add_special_tokens=False, return_offsets_mapping=False):
+        assert add_special_tokens is False
+        output = {"input_ids": [ord(ch) for ch in text]}
+        if return_offsets_mapping:
+            output["offset_mapping"] = [(i, i + 1) for i in range(len(text))]
+        return output
+
+    def decode(self, token_ids):
+        return "".join(chr(token_id) for token_id in token_ids)
+
+
 def test_loss_mask_qwen3_simple(model_name: str = "Qwen/Qwen3-8B"):
     tokenizer = load_tokenizer(model_name)
     mask_generator = MultiTurnLossMaskGenerator(tokenizer, tokenizer_type="qwen3")
@@ -91,6 +106,34 @@ def test_loss_mask_qwen3_tools(model_name: str = "Qwen/Qwen3-8B"):
     print("token_ids = ", all_token_ids)
     print("loss_mask = ", all_loss_masks)
     print("selected_texts = ", selected_texts)
+
+
+def test_loss_mask_deepseek_v4_masks_full_assistant_content(monkeypatch):
+    assistant_content = '<function_calls>{"name":"terminal"}</function_calls>'
+    rendered = f"<user>show tool calls</user><assistant>{assistant_content}<｜end▁of▁sentence｜>"
+
+    def fake_apply_chat_template(messages, tokenizer, tools=None, tokenize=False, add_generation_prompt=False):
+        assert tokenize is False
+        assert add_generation_prompt is False
+        return rendered
+
+    monkeypatch.setattr(
+        "miles.utils.mask_utils.chat_template_utils.apply_chat_template",
+        fake_apply_chat_template,
+    )
+
+    mask_generator = MultiTurnLossMaskGenerator(_CharOffsetTokenizer(), tokenizer_type="deepseek_v4")
+    token_ids, loss_mask = mask_generator.get_loss_mask(
+        [
+            {"role": "user", "content": "show tool calls"},
+            {"role": "assistant", "content": assistant_content},
+        ]
+    )
+
+    assert len(token_ids) == len(loss_mask)
+    assert mask_generator.get_text_from_loss_mask(token_ids, loss_mask) == [
+        assistant_content + "<｜end▁of▁sentence｜>"
+    ]
 
 
 if __name__ == "__main__":

--- a/tests/fast/utils/test_mask_utils.py
+++ b/tests/fast/utils/test_mask_utils.py
@@ -17,6 +17,71 @@ class _CharOffsetTokenizer:
         return "".join(chr(token_id) for token_id in token_ids)
 
 
+class _BridgeJinjaTokenizer:
+    name_or_path = ""
+    chat_template = "bridge-jinja"
+    eos_token = "<EOS>"
+
+    rendered = "<BOS><USER>question<ASSISTANT></think>answer<EOS>"
+    token_spans = [
+        (0, "<BOS>"),
+        (100, "<USER>"),
+        (10, "question"),
+        (101, "<ASSISTANT>"),
+        (128822, "</think>"),
+        (20, "answer"),
+        (1, "<EOS>"),
+    ]
+
+    def apply_chat_template(
+        self,
+        messages,
+        *,
+        tokenize,
+        add_generation_prompt,
+        tools=None,
+        return_dict=False,
+        return_assistant_tokens_mask=False,
+    ):
+        assert messages == [
+            {"role": "user", "content": "question"},
+            {"role": "assistant", "content": "answer"},
+        ]
+        assert add_generation_prompt is False
+        assert tools is None
+        if tokenize:
+            assert return_dict is True
+            assert return_assistant_tokens_mask is True
+            return {
+                "input_ids": [token_id for token_id, _ in self.token_spans],
+                "assistant_masks": [0, 0, 0, 0, 0, 1, 1],
+            }
+        assert return_dict is False
+        assert return_assistant_tokens_mask is False
+        return self.rendered
+
+    def __call__(self, text, add_special_tokens=False, return_offsets_mapping=False):
+        assert text == self.rendered
+        assert add_special_tokens is False
+        cursor = 0
+        input_ids = []
+        offset_mapping = []
+        for token_id, token_text in self.token_spans:
+            start = self.rendered.index(token_text, cursor)
+            end = start + len(token_text)
+            input_ids.append(token_id)
+            offset_mapping.append((start, end))
+            cursor = end
+        output = {"input_ids": input_ids}
+        if return_offsets_mapping:
+            output["offset_mapping"] = offset_mapping
+        return output
+
+    def decode(self, token_ids):
+        pieces = {token_id: token_text for token_id, token_text in self.token_spans}
+        return "".join(pieces[token_id] for token_id in token_ids)
+
+
 def test_loss_mask_qwen3_simple(model_name: str = "Qwen/Qwen3-8B"):
     tokenizer = load_tokenizer(model_name)
     mask_generator = MultiTurnLossMaskGenerator(tokenizer, tokenizer_type="qwen3")
@@ -134,6 +199,83 @@ def test_loss_mask_deepseek_v4_masks_full_assistant_content(monkeypatch):
     assert mask_generator.get_text_from_loss_mask(token_ids, loss_mask) == [
         assistant_content + "<｜end▁of▁sentence｜>"
     ]
+
+
+def test_loss_mask_deepseek_v4_jinja_matches_bridge_shifted_semantics(monkeypatch):
+    def fail_official_encoder(*args, **kwargs):
+        raise AssertionError("deepseek_v4_jinja must bypass the official encoder")
+
+    monkeypatch.setattr(
+        "miles.utils.mask_utils.chat_template_utils.apply_chat_template",
+        fail_official_encoder,
+    )
+
+    mask_generator = MultiTurnLossMaskGenerator(_BridgeJinjaTokenizer(), tokenizer_type="deepseek_v4_jinja")
+    token_ids, target_mask = mask_generator.get_loss_mask(
+        [
+            {"role": "user", "content": "question"},
+            {"role": "assistant", "content": "answer"},
+        ]
+    )
+
+    assert token_ids == [0, 100, 10, 101, 128822, 20, 1]
+    assert target_mask == [0, 0, 0, 0, 0, 1, 1]
+
+    response_length = mask_generator.get_response_lengths([target_mask])[0]
+    prompt_length = len(token_ids) - response_length
+    effective_loss_mask = [0] * (prompt_length - 1) + target_mask[-response_length:] + [0]
+    assert effective_loss_mask == [0, 0, 0, 0, 1, 1, 0]
+    assert token_ids[4] == 128822  # </think> predicts the first assistant token.
+    assert token_ids[-1] == 1 and effective_loss_mask[-1] == 0  # EOS is a target, not an input loss position.
+
+
+def test_loss_mask_deepseek_v4_jinja_supervises_reasoning_and_empty_think_close():
+    class ThinkingTokenizer(_BridgeJinjaTokenizer):
+        chat_template = "bridge-thinking-jinja {% generation %}"
+
+        def apply_chat_template(
+            self,
+            messages,
+            *,
+            tokenize,
+            add_generation_prompt,
+            tools=None,
+            return_dict=False,
+            return_assistant_tokens_mask=False,
+        ):
+            assert tokenize is True
+            assert add_generation_prompt is False
+            assert tools is None
+            assert return_dict is True
+            assert return_assistant_tokens_mask is True
+            reasoning = messages[-1].get("reasoning_content") or ""
+            token_ids = [0, 100, 10, 101, 128821]
+            assistant_masks = [0, 0, 0, 0, 0]
+            if reasoning:
+                token_ids.append(30)
+                assistant_masks.append(1)
+            token_ids.extend([128822, 20, 1])
+            assistant_masks.extend([1, 1, 1])
+            return {"input_ids": token_ids, "assistant_masks": assistant_masks}
+
+    mask_generator = MultiTurnLossMaskGenerator(ThinkingTokenizer(), tokenizer_type="deepseek_v4_jinja")
+    reasoning_ids, reasoning_mask = mask_generator.get_loss_mask(
+        [
+            {"role": "user", "content": "question"},
+            {"role": "assistant", "reasoning_content": "reason", "content": "answer"},
+        ]
+    )
+    assert reasoning_ids == [0, 100, 10, 101, 128821, 30, 128822, 20, 1]
+    assert reasoning_mask == [0, 0, 0, 0, 0, 1, 1, 1, 1]
+
+    empty_ids, empty_mask = mask_generator.get_loss_mask(
+        [
+            {"role": "user", "content": "question"},
+            {"role": "assistant", "reasoning_content": "", "content": "answer"},
+        ]
+    )
+    assert empty_ids == [0, 100, 10, 101, 128821, 128822, 20, 1]
+    assert empty_mask == [0, 0, 0, 0, 0, 1, 1, 1]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Add true THD packing for DeepSeek-V4 with sample-local cu_seqlens boundaries across CP, DSV4 attention/indexer/compressor, response extraction, and loss computation.
- Add an opt-in DeepSeek-V4 Jinja assistant-mask path so Miles can reproduce explicit generation-span, </think>, and EOS supervision semantics.
- Bound the DSV4 indexer FP32 logits workspace by query-chunking while preserving exact full-KV top-k results.
- Preserve integer hash-router IDs during checkpoint mapping.

## Validation

- Targeted Miles tests in the release image: 13 passed, 1 skipped on the CPU host; the skipped real-GPU TileLang chunk-vs-full equality test passed separately in LTP.
- Real-GPU packing smoke in the release image: 12 passed.
- Formal DeepSeek-V4-Pro-Base run: zmm-dsv4pb-g128-t8p8-r54-0727-d6231f on train_p, 16 nodes / 128 B GPUs, TP8 / PP8 / CP2 / EP8, THD, sequence length 131072, MBS1, sequence-level GBS128.
- The run loaded the official Pro-Base distributed checkpoint, collected 128 samples, completed step 0, and reached terminal Succeeded.
- train/loss = 0.227968514690235; train/grad_norm = 1.0173206552758771; actor_train = 3957.8s.
- Throughput is about 33.1 nominal tokens/GPU/s at 128K capacity, or 14.6 effective tokens/GPU/s for the 7,385,297 non-padding tokens in this batch.
- No CUDA OOM, NCCL failure, actor death, or illegal-memory error occurred in the successful run.

## Review

- Explicit diff review, git diff --check, Python compilation, inline-secret scan, bounded-workspace edge-case test, and targeted Miles tests passed.
- Ruff was unavailable in both the host and release image; no Ruff result is claimed.