### PR TITLE
codeowners: add Zhichenzzz to /miles/ and a /miles/dashboard/ rule

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,10 @@
 /.github/CODEOWNERS @fzyzcjy @Ying1123
 /.github/workflows/ @yushengsu-thu @guapisolo @yueming-yuan
-/miles/ @fzyzcjy @yueming-yuan
+/miles/ @fzyzcjy @yueming-yuan @Zhichenzzz
 /miles/backends/ @fzyzcjy @yueming-yuan @maocheng23 @Zhichenzzz @Shi-Dong
 /miles/backends/megatron_utils/ @fzyzcjy @yueming-yuan @maocheng23 @yushengsu-thu @Zhichenzzz @Shi-Dong
 /miles/backends/sglang_utils/ @fzyzcjy @yueming-yuan @maocheng23 @yushengsu-thu @Zhichenzzz @Shi-Dong
+/miles/dashboard/ @fzyzcjy @yueming-yuan @Zhichenzzz @guapisolo @Shi-Dong @maocheng23
 /miles/ray/ @fzyzcjy @yueming-yuan @maocheng23
 /miles/rollout/ @fzyzcjy @yueming-yuan @guapisolo @Shi-Dong
 /miles/rollout/session/ @fzyzcjy @yueming-yuan @guapisolo @maocheng23 @jybsuper @Shi-Dong


### PR DESCRIPTION
Two CODEOWNERS updates:

1. Add `@Zhichenzzz` to `/miles/`.
2. Add a `/miles/dashboard/` rule: `@fzyzcjy @yueming-yuan @Zhichenzzz @guapisolo @Shi-Dong @maocheng23`.

Previously `miles/dashboard/*` had no dedicated rule, so it fell through to `/miles/` (`@fzyzcjy @yueming-yuan` only). This gives the dashboard its own owner set.