### PR TITLE
feat(session): session server v2 — opt-in trajectory-tree serving; v1 preserved byte-exact

### DIFF
--- a/docs/user-guide/agentic-chat-template.md
+++ b/docs/user-guide/agentic-chat-template.md
@@ -1,9 +1,9 @@
 ---
-title: Agentic Chat Templates (TITO)
+title: Agentic Rollout (TITO)
 description: How to turn on and verify Token-In-Token-Out (TITO) for multi-turn agentic rollout.
 ---
 
-# Agentic Chat Templates (TITO)
+# Agentic Rollout (TITO)
 
 Multi-turn agentic rollout in Miles runs on **TITO** (Token-In-Token-Out): each turn's token sequence is a bit-perfect prefix of the next, so the trainer sees exactly the tokens the engine produced — no re-tokenization, no drift. The *why* is in the blog ([No Token Left Behind](https://lmsys.org/blog/2026-05-13-no-token-left-behind/)); this page is *how*.
 

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -12,7 +12,7 @@ description: Concepts, launch script walkthrough, customization hooks, and a com
 | [Customization](/user-guide/customization) | The 21 `--*-path` plug-points for custom Python — rollout, reward, filters, loss, hooks. |
 | [Rollout Endpoints](/user-guide/rollout-endpoints) | The `/generate` endpoint and the OpenAI chat endpoint for agentic sessions. |
 | [Fully Async Rollout](/user-guide/fully-async) | Queue-backed rollout production, tuning knobs, and when to use `train_async.py`. |
-| [Agentic Chat Templates](/user-guide/agentic-chat-template) | Turning on and verifying TITO so multi-turn agentic rollout stays append-only. |
+| [Agentic Rollout (TITO)](/user-guide/agentic-chat-template) | Turning on and verifying TITO so multi-turn agentic rollout stays append-only. |
 | [CLI Reference](/user-guide/cli-reference) | Every flag Miles accepts, grouped by subsystem. |
 | [Environments](/user-guide/environments) | Supplying an environment: dataset + reward, your own env via the plug points, or an external ecosystem. |
 

--- a/docs/user-guide/rollout-endpoints.md
+++ b/docs/user-guide/rollout-endpoints.md
@@ -181,6 +181,14 @@ remain a `messages` list. SGLang handles templating server-side.
 
 </Warning>
 
+<Warning>
+
+**Session server v2 output is a `list[Sample]`.** With `--use-session-server v2`, `agentic_tool_call.generate` returns one sample for each selected tree leaf. The v1 session server returns one scalar `Sample`.
+
+A custom reward model (`--custom-rm-path`) receives the v2 samples in batch form. `--group-rm`, `--partial-rollout`, and `--recompute-logprobs-via-prefill` are not supported with this v2 agentic output and are rejected explicitly.
+
+</Warning>
+
 ### Optional teardown: the `abort` hook
 
 The module named by `--custom-agent-function-path` may expose an optional `abort`

--- a/docs/user-guide/rollout-endpoints.md
+++ b/docs/user-guide/rollout-endpoints.md
@@ -256,6 +256,6 @@ inherited across turns. Each request is tokenized independently.
 ## Next
 
 - [Customization](/user-guide/customization): the full catalog of `--*-path` hooks.
-- [Agentic Chat Templates](/user-guide/agentic-chat-template): verifying that a template is
+- [Agentic Rollout (TITO)](/user-guide/agentic-chat-template): verifying that a template is
   append-only across turns.
 - [Multi-agent example](/examples/multi-agent): full agentic walkthrough.

--- a/miles/rollout/generate_hub/agentic_tool_call.py
+++ b/miles/rollout/generate_hub/agentic_tool_call.py
@@ -46,6 +46,7 @@ async def generate(input: GenerateFnInput) -> GenerateFnOutput:
         "agentic_tool_call.generate requires session_server_ip/session_server_ports. "
         "Pass --use-session-server to start the session server."
     )
+    use_v2 = getattr(input.args, "use_session_server", None) == "v2"
     tracer = await OpenAIEndpointTracer.create(input.args)
 
     custom_agent_function: Callable = load_function(input.args.custom_agent_function_path)
@@ -84,11 +85,11 @@ async def generate(input: GenerateFnInput) -> GenerateFnOutput:
     finally:
         # Collect even if the agent failed.
         logger.debug(f"{log_prefix} Calling collect_samples...")
+        collect_kwargs = {"max_seq_len": max_seq_len}
+        if use_v2:
+            collect_kwargs["agent_metadata"] = agent_metadata
         try:
-            result = await tracer.collect_samples(
-                input.sample,
-                max_seq_len=max_seq_len,
-            )
+            result = await tracer.collect_samples(input.sample, **collect_kwargs)
         except asyncio.TimeoutError:
             collect_timed_out = True
             logger.warning(f"{log_prefix} Timed out collecting samples", exc_info=True)
@@ -101,7 +102,7 @@ async def generate(input: GenerateFnInput) -> GenerateFnOutput:
     if collect_timed_out:
         sample = deepcopy(input.sample)
         sample.status = Sample.Status.ABORTED
-        return GenerateFnOutput(samples=sample)
+        return GenerateFnOutput(samples=[sample] if use_v2 else sample)
 
     if not result.samples:
         if result.empty_reason == "all_truncated":
@@ -110,11 +111,15 @@ async def generate(input: GenerateFnInput) -> GenerateFnOutput:
             logger.warning("No model calls recorded for sample")
         sample = deepcopy(input.sample)
         sample.status = Sample.Status.ABORTED
-        return GenerateFnOutput(samples=sample)
+        return GenerateFnOutput(samples=[sample] if use_v2 else sample)
 
     samples = result.samples
-    for s in samples:
-        s.metadata.update(agent_metadata or {})
+    if not use_v2:
+        # v1: the agent's metadata is applied driver-side. Under v2 it traveled
+        # through collect_samples and came back applied by the server-side
+        # merge (per-sample metadata/reward on the wire) — no overlay here.
+        for s in samples:
+            s.metadata.update(agent_metadata or {})
 
     # If the agent function reports wall-clock time spent outside policy generation
     # (env/tool steps), surface it on Sample.non_generation_time so throughput
@@ -123,6 +128,9 @@ async def generate(input: GenerateFnInput) -> GenerateFnOutput:
     if ngt is not None:
         for s in samples:
             s.non_generation_time = ngt
+
+    if use_v2:
+        return GenerateFnOutput(samples=samples)
 
     (sample,) = samples
     sample.metadata.update(result.session_metadata)

--- a/miles/rollout/generate_utils/openai_endpoint_utils.py
+++ b/miles/rollout/generate_utils/openai_endpoint_utils.py
@@ -7,7 +7,12 @@ import logging
 import random
 from argparse import Namespace
 
-from miles.rollout.session.samples.codec import SamplesReply, decode_samples_and_merge_input_sample
+from miles.rollout.session.samples.codec import (
+    COMPUTED_FIELDS,
+    COMPUTED_FIELDS_V2,
+    SamplesReply,
+    decode_samples_and_merge_input_sample,
+)
 from miles.utils.http_utils import post, post_bytes_no_retry
 from miles.utils.types import Sample
 
@@ -17,11 +22,21 @@ _SESSION_REQUEST_TIMEOUT = 120
 
 
 class OpenAIEndpointTracer:
-    def __init__(self, router_url: str, session_id: str, session_server_instance_id: str | None = None):
+    def __init__(
+        self,
+        router_url: str,
+        session_id: str,
+        session_server_instance_id: str | None = None,
+        samples_wire_fields: tuple[str, ...] = COMPUTED_FIELDS,
+    ):
         self.router_url = router_url
         self.session_id = session_id
         self.base_url = f"{router_url}/sessions/{session_id}"
         self.session_server_instance_id = session_server_instance_id
+        # The samples-wire allowlist must match the server's encode: v1 default,
+        # extended under --use-session-server v2 (create() selects from args;
+        # direct constructions keep v1).
+        self.samples_wire_fields = samples_wire_fields
 
     @property
     def session_server_id(self) -> str:
@@ -45,19 +60,26 @@ class OpenAIEndpointTracer:
         session_server_instance_id = instance_ids.get(session_port)
         response = await post(f"{session_url}/sessions", {}, action="post")
         session_id = response["session_id"]
+        use_v2 = getattr(args, "use_session_server", None) == "v2"
         return OpenAIEndpointTracer(
             router_url=session_url,
             session_id=session_id,
             session_server_instance_id=session_server_instance_id,
+            samples_wire_fields=COMPUTED_FIELDS_V2 if use_v2 else COMPUTED_FIELDS,
         )
 
-    async def collect_samples(self, input_sample: Sample, *, max_seq_len: int | None) -> SamplesReply:
+    async def collect_samples(
+        self, input_sample: Sample, *, max_seq_len: int | None, agent_metadata: dict | None = None
+    ) -> SamplesReply:
         """Fetch server-assembled training samples for this session."""
+        body: dict = {"max_seq_len": max_seq_len}
+        if agent_metadata is not None:
+            body["metadata"] = agent_metadata
         try:
             # `asyncio.TimeoutError` propagates after cleanup is attempted for `agentic_tool_call.generate` to handle.
             payload = await post_bytes_no_retry(
                 f"{self.base_url}/samples",
-                {"max_seq_len": max_seq_len},
+                body,
                 timeout=_SESSION_REQUEST_TIMEOUT,
             )
         finally:
@@ -69,4 +91,4 @@ class OpenAIEndpointTracer:
             except Exception as e:
                 logger.warning(f"Failed to delete session {self.session_id} after collecting samples: {e}")
 
-        return decode_samples_and_merge_input_sample(payload, input_sample)
+        return decode_samples_and_merge_input_sample(payload, input_sample, fields=self.samples_wire_fields)

--- a/miles/rollout/session/core.py
+++ b/miles/rollout/session/core.py
@@ -318,8 +318,8 @@ class SessionCore:
 
         Flow: prepare pretokenized input_ids (lock held briefly) → proxy to
         backend (NO lock) → validate response → update trajectory checkpoint and
-        append record (lock held briefly). The lock is NOT held during the slow
-        proxy call so DELETE/other ops are not blocked if the agent disconnects.
+        append record (lock held briefly). The lock is NOT held during the long
+        inference call so DELETE/other ops are not blocked if the agent disconnects.
         """
         request_timestamp = time.time()
         session = self.registry.get_session(session_id)

--- a/miles/rollout/session/core.py
+++ b/miles/rollout/session/core.py
@@ -142,6 +142,92 @@ def proxy_result_to_response(result: dict) -> Response:
     return Response(content=_render_json(data), status_code=status_code, headers=headers, media_type=JSON_MEDIA_TYPE)
 
 
+def prepare_chat_request(body: bytes, args, tito_tokenizer) -> tuple:
+    """Parse and normalize a chat request body — the session-independent half
+    of chat dispatch, shared verbatim by the v1 and v2 cores. Returns
+    ``(request_body, client_stream, tito_tokenizer)``; the tokenizer may be a
+    request-scoped clone.
+    """
+    try:
+        request_body = json.loads(body) if body else {}
+    except json.JSONDecodeError as e:
+        raise MessageValidationError(f"invalid JSON body: {e}") from e
+
+    # Fake streaming: the backend must stay non-streaming (TITO needs the
+    # complete message + meta_info, and sglang rejects return_meta_info
+    # with stream=true), so pop the client's intent here and honor it
+    # when rendering the client response.
+    client_stream = bool(request_body.pop("stream", False))
+    request_body.pop("stream_options", None)
+
+    # TITO token tracking needs Miles-owned input_ids plus SGLang output
+    # metadata: logprobs=True populates meta_info.output_token_logprobs and
+    # return_meta_info wraps it in choice.meta_info. Hardcoded (not
+    # setdefault) so agent-side overrides cannot break token accumulation.
+    request_body["logprobs"] = True
+    request_body["return_meta_info"] = True
+    if getattr(args, "use_rollout_routing_replay", False):
+        request_body["return_routed_experts"] = True
+    if getattr(args, "use_rollout_indexer_replay", False):
+        request_body["return_indexer_topk"] = True
+    # Must be False so stop-token text is trimmed from assistant content;
+    # token IDs still come from logprobs below.
+    request_body["no_stop_trim"] = False
+    # Serve the adapter being trained instead of the base weights.
+    if is_lora_enabled(args):
+        request_body["lora_path"] = LORA_ADAPTER_NAME
+    # FIXME(session): Only nested `chat_template_kwargs` reach the local renderer;
+    # top-level `reasoning` and `reasoning_effort` are not mapped to template kwargs.
+    request_ctk = request_body.get("chat_template_kwargs")
+    if request_ctk is not None and not isinstance(request_ctk, dict):
+        raise MessageValidationError("chat_template_kwargs must be an object")
+    if request_ctk:
+        try:
+            tito_tokenizer = tito_tokenizer.clone_with_chat_template_kwargs(request_ctk)
+        except ValueError as e:
+            raise MessageValidationError(str(e)) from e
+    if tito_tokenizer.chat_template_kwargs:
+        request_body["chat_template_kwargs"] = dict(tito_tokenizer.chat_template_kwargs)
+    else:
+        request_body.pop("chat_template_kwargs", None)
+    return request_body, client_stream, tito_tokenizer
+
+
+def extract_completion(result: dict) -> tuple:
+    """Decode and validate the backend chat response — shared verbatim by the
+    v1 and v2 cores. Returns ``(response, choice, assistant_message,
+    completion_token_ids)``; malformed upstream payloads raise
+    ``UpstreamResponseError``.
+    """
+    response = json.loads(result["response_body"])
+    choice = response.get("choices", [{}])[0]
+
+    meta_info = choice.get("meta_info")
+    if not isinstance(meta_info, dict) or "output_token_logprobs" not in meta_info:
+        raise UpstreamResponseError("meta_info and output_token_logprobs must be in choice (requires logprobs=True)")
+    assistant_message = choice.get("message") or {}
+    if assistant_message.get("content") is None:
+        raise UpstreamResponseError(
+            "assistant message content is None, when tool call parser failed SGLang should still return "
+            "an empty content rather than None. Please check your modified SGLang version."
+        )
+
+    output_token_logprobs = meta_info["output_token_logprobs"]
+    completion_tokens = meta_info["completion_tokens"]
+
+    actual_output_logprobs_len = len(output_token_logprobs)
+    if actual_output_logprobs_len != completion_tokens:
+        raise UpstreamResponseError(
+            "invalid chat completion response: "
+            f"len(output_token_logprobs)={actual_output_logprobs_len} "
+            f"!= completion_tokens={completion_tokens}. "
+            f"Please check whether you use the correct SGLang branch which has fix the tokenizer batch decode issue."
+        )
+
+    completion_token_ids = [t[1] for t in output_token_logprobs]
+    return response, choice, assistant_message, completion_token_ids
+
+
 class SessionCore:
     """HTTP session operations over one ``SessionRegistry``."""
 
@@ -245,50 +331,9 @@ class SessionCore:
             if session.closing:
                 raise SessionNotFoundError(f"session not found: session_id={session_id}")
 
-            try:
-                request_body = json.loads(body) if body else {}
-            except json.JSONDecodeError as e:
-                raise MessageValidationError(f"invalid JSON body: {e}") from e
-
-            # Fake streaming: the backend must stay non-streaming (TITO needs the
-            # complete message + meta_info, and sglang rejects return_meta_info
-            # with stream=true), so pop the client's intent here and honor it
-            # when rendering the client response.
-            client_stream = bool(request_body.pop("stream", False))
-            request_body.pop("stream_options", None)
-
-            # TITO token tracking needs Miles-owned input_ids plus SGLang output
-            # metadata: logprobs=True populates meta_info.output_token_logprobs and
-            # return_meta_info wraps it in choice.meta_info. Hardcoded (not
-            # setdefault) so agent-side overrides cannot break token accumulation.
-            request_body["logprobs"] = True
-            request_body["return_meta_info"] = True
-            if getattr(self.args, "use_rollout_routing_replay", False):
-                request_body["return_routed_experts"] = True
-            if getattr(self.args, "use_rollout_indexer_replay", False):
-                request_body["return_indexer_topk"] = True
-            # Must be False so stop-token text is trimmed from assistant content;
-            # token IDs still come from logprobs below.
-            request_body["no_stop_trim"] = False
-            # Without this the engine serves the base weights, so the adapter being
-            # trained would never shape the trajectories it is scored on.
-            if is_lora_enabled(self.args):
-                request_body["lora_path"] = LORA_ADAPTER_NAME
-            # FIXME(session): Only nested `chat_template_kwargs` reach the local renderer;
-            # top-level `reasoning` and `reasoning_effort` are not mapped to template kwargs.
-            request_ctk = request_body.get("chat_template_kwargs")
-            if request_ctk is not None and not isinstance(request_ctk, dict):
-                raise MessageValidationError("chat_template_kwargs must be an object")
-            tito_tokenizer = self.registry.tito_tokenizer
-            if request_ctk:
-                try:
-                    tito_tokenizer = tito_tokenizer.clone_with_chat_template_kwargs(request_ctk)
-                except ValueError as e:
-                    raise MessageValidationError(str(e)) from e
-            if tito_tokenizer.chat_template_kwargs:
-                request_body["chat_template_kwargs"] = dict(tito_tokenizer.chat_template_kwargs)
-            else:
-                request_body.pop("chat_template_kwargs", None)
+            request_body, client_stream, tito_tokenizer = prepare_chat_request(
+                body, self.args, self.registry.tito_tokenizer
+            )
 
             request_messages = request_body.get("messages", [])
             prompt_token_ids = session.prepare_pretokenized(
@@ -314,34 +359,7 @@ class SessionCore:
         if result["status_code"] != 200:
             return proxy_result_to_response(result)
 
-        response = json.loads(result["response_body"])
-        choice = response.get("choices", [{}])[0]
-
-        meta_info = choice.get("meta_info")
-        if not isinstance(meta_info, dict) or "output_token_logprobs" not in meta_info:
-            raise UpstreamResponseError(
-                "meta_info and output_token_logprobs must be in choice (requires logprobs=True)"
-            )
-        assistant_message = choice.get("message") or {}
-        if assistant_message.get("content") is None:
-            raise UpstreamResponseError(
-                "assistant message content is None, when tool call parser failed SGLang should still return "
-                "an empty content rather than None. Please check your modified SGLang version."
-            )
-
-        output_token_logprobs = meta_info["output_token_logprobs"]
-        completion_tokens = meta_info["completion_tokens"]
-
-        actual_output_logprobs_len = len(output_token_logprobs)
-        if actual_output_logprobs_len != completion_tokens:
-            raise UpstreamResponseError(
-                "invalid chat completion response: "
-                f"len(output_token_logprobs)={actual_output_logprobs_len} "
-                f"!= completion_tokens={completion_tokens}. "
-                f"Please check whether you use the correct SGLang branch which has fix the tokenizer batch decode issue."
-            )
-
-        completion_token_ids = [t[1] for t in output_token_logprobs]
+        response, _, assistant_message, completion_token_ids = extract_completion(result)
 
         # --- Phase 3: update state (lock held briefly) ---
         async with session.lock:

--- a/miles/rollout/session/errors.py
+++ b/miles/rollout/session/errors.py
@@ -5,6 +5,7 @@ Hierarchy
 SessionError (base)
 ├── SessionNotFoundError       → 404  session does not exist
 ├── MessageValidationError     → 400  messages structure/content invalid
+├── TruncatedGenerationError   → 409  extending a length-truncated generation (v2)
 ├── TokenizationError          → 500  TITO tokenizer / prefix mismatch
 └── UpstreamResponseError      → 502  SGLang response invalid or unexpected
 """
@@ -30,6 +31,14 @@ class MessageValidationError(SessionError):
     """
 
     status_code: int = 400
+
+
+class TruncatedGenerationError(SessionError):
+    """Raised when a request extends a generation that ended with
+    finish_reason='length'; only the v2 tree server raises it (v1 never
+    branches)."""
+
+    status_code: int = 409
 
 
 class TokenizationError(SessionError):

--- a/miles/rollout/session/linear_trajectory.py
+++ b/miles/rollout/session/linear_trajectory.py
@@ -17,6 +17,38 @@ logger = logging.getLogger(__name__)
 MAX_ASSISTANT_ROLLBACK_STEPS = 1
 
 
+def assert_pretokenized_prefix(
+    prev: list[int],
+    all_token_ids: list[int],
+    *,
+    max_trim_tokens: int,
+    request_messages: list[dict[str, Any]],
+    assistant_message: dict[str, Any],
+) -> None:
+    """Stored token_ids must be a prefix of the new checkpoint, tolerating up
+    to *max_trim_tokens* trailing differences. Pure token-level check, shared
+    verbatim by the v1 checkpoint update and the v2 commit."""
+    if not prev:
+        return
+    check_len = len(prev) - max_trim_tokens
+    if check_len > 0 and all_token_ids[:check_len] != prev[:check_len]:
+        first_mismatch = next(
+            (i for i, (a, b) in enumerate(zip(all_token_ids[:check_len], prev[:check_len], strict=True)) if a != b),
+            min(len(all_token_ids), check_len),
+        )
+        raise TokenizationError(
+            f"pretokenized prefix mismatch: "
+            f"stored {len(prev)} tokens (checking first {check_len}, "
+            f"allowing {max_trim_tokens} trailing) are not a prefix of "
+            f"prompt_token_ids + completion_token_ids "
+            f"({len(all_token_ids)} tokens), "
+            f"first mismatch at index {first_mismatch}, "
+            f"matched {first_mismatch}/{check_len} prefix tokens\n"
+            f"request_messages={request_messages}\n"
+            f"assistant_message={assistant_message}"
+        )
+
+
 @dataclass
 class LinearTrajectory:
     """State for a linear trajectory.
@@ -114,30 +146,13 @@ class LinearTrajectory:
         Must be called under ``self.lock``.
         """
         all_token_ids = prompt_token_ids + completion_token_ids
-
-        prev = self.token_ids
-        if prev:
-            check_len = len(prev) - max_trim_tokens
-            if check_len > 0 and all_token_ids[:check_len] != prev[:check_len]:
-                first_mismatch = next(
-                    (
-                        i
-                        for i, (a, b) in enumerate(zip(all_token_ids[:check_len], prev[:check_len], strict=True))
-                        if a != b
-                    ),
-                    min(len(all_token_ids), check_len),
-                )
-                raise TokenizationError(
-                    f"pretokenized prefix mismatch: "
-                    f"stored {len(prev)} tokens (checking first {check_len}, "
-                    f"allowing {max_trim_tokens} trailing) are not a prefix of "
-                    f"prompt_token_ids + completion_token_ids "
-                    f"({len(all_token_ids)} tokens), "
-                    f"first mismatch at index {first_mismatch}, "
-                    f"matched {first_mismatch}/{check_len} prefix tokens\n"
-                    f"request_messages={request_messages}\n"
-                    f"assistant_message={assistant_message}"
-                )
+        assert_pretokenized_prefix(
+            self.token_ids,
+            all_token_ids,
+            max_trim_tokens=max_trim_tokens,
+            request_messages=request_messages,
+            assistant_message=assistant_message,
+        )
 
         self.messages = list(request_messages) + [assistant_message]
         self.trajectory_token_ids.append(all_token_ids)

--- a/miles/rollout/session/samples/codec.py
+++ b/miles/rollout/session/samples/codec.py
@@ -3,6 +3,8 @@
 Only fields in `SAMPLES_VALUE_SPEC` cross the wire. `encode_samples` packs them
 into safetensors; `decode_samples_and_merge_input_sample` overlays them onto a
 deepcopy of the input sample and merges server metadata.
+
+Tree-serving v2 selects `SAMPLES_VALUE_SPEC_V2` to carry `Sample.reward`.
 """
 
 import dataclasses
@@ -41,14 +43,22 @@ SAMPLES_VALUE_SPEC: dict[str, ValueSpec] = {
     "metadata": ValueSpec("json"),
 }
 
-# The wire allowlist, derived: only table fields cross the samples wire.
+# Tree-serving v2 adds `Sample.reward` to the wire.
+SAMPLES_VALUE_SPEC_V2: dict[str, ValueSpec] = {
+    **SAMPLES_VALUE_SPEC,
+    "reward": ValueSpec("json"),
+}
+
+# The wire allowlists, derived: only table fields cross the samples wire.
 COMPUTED_FIELDS = tuple(SAMPLES_VALUE_SPEC)
+COMPUTED_FIELDS_V2 = tuple(SAMPLES_VALUE_SPEC_V2)
 
 assert all(
-    spec.codec in ("tensor", "tensor_list", "json") for spec in SAMPLES_VALUE_SPEC.values()
+    spec.codec in ("tensor", "tensor_list", "json") for spec in SAMPLES_VALUE_SPEC_V2.values()
 ), "unknown codec in SAMPLES_VALUE_SPEC"
 
-_TENSOR_FIELDS = frozenset(field for field, spec in SAMPLES_VALUE_SPEC.items() if spec.codec != "json")
+_TENSOR_FIELDS = frozenset(field for field, spec in SAMPLES_VALUE_SPEC_V2.items() if spec.codec != "json")
+assert _TENSOR_FIELDS <= set(COMPUTED_FIELDS), "every tensor field must be on the v1 wire too"
 
 _SAMPLES_META_KEY = "_samples_meta"
 _OPD_STUDENT_TOP_LOGPROBS_KEY = "opd_student_top_logprobs"
@@ -75,14 +85,26 @@ def _asarray_wire(field: str, value, dtype: np.dtype) -> np.ndarray:
     return converted
 
 
-def encode_samples(samples: list[Sample], session_metadata: dict, empty_reason: str | None = None) -> bytes:
-    """Server side: pack assembled samples into one safetensors payload."""
+def encode_samples(
+    samples: list[Sample],
+    session_metadata: dict,
+    empty_reason: str | None = None,
+    *,
+    fields: tuple[str, ...] = COMPUTED_FIELDS,
+) -> bytes:
+    """Server side: pack assembled samples into one safetensors payload.
+
+    ``fields`` selects the wire allowlist (v1 default; the v2 server passes
+    ``COMPUTED_FIELDS_V2``) — with the default, the payload is byte-identical
+    to the pre-parameterized codec.
+    """
     tensors: dict[str, np.ndarray] = {}
     sample_metas = []
     for sample_index, sample in enumerate(samples):
         sample_meta: dict = {}
         nulls: list[str] = []
-        for field, spec in SAMPLES_VALUE_SPEC.items():
+        for field in fields:
+            spec = SAMPLES_VALUE_SPEC_V2[field]
             value = getattr(sample, field)
             if spec.codec == "json":
                 if field == "status":
@@ -112,8 +134,15 @@ def encode_samples(samples: list[Sample], session_metadata: dict, empty_reason: 
     return safetensors.numpy.save(tensors)
 
 
-def decode_samples_and_merge_input_sample(payload: bytes, input_sample: Sample) -> SamplesReply:
-    """Driver side: overlay each wire sample's computed fields onto a deepcopy of `input_sample`."""
+def decode_samples_and_merge_input_sample(
+    payload: bytes, input_sample: Sample, *, fields: tuple[str, ...] = COMPUTED_FIELDS
+) -> SamplesReply:
+    """Driver side: overlay each wire sample's computed fields onto a deepcopy of `input_sample`.
+
+    ``fields`` must match the server's encode allowlist (v1 default); extra
+    keys a newer server sent are ignored, so a v1 decode of a v2 payload
+    keeps exactly the v1 overlay semantics.
+    """
     tensors = safetensors.numpy.load(payload)  # SafetensorError propagates: invalid container
     meta_arr = tensors.pop(_SAMPLES_META_KEY)  # KeyError propagates: missing meta is malformed
     if meta_arr.ndim != 1 or meta_arr.dtype != np.uint8:
@@ -129,7 +158,8 @@ def decode_samples_and_merge_input_sample(payload: bytes, input_sample: Sample) 
         nulls = set(sample_meta["nulls"])  # KeyError propagates: missing null markers are malformed
         if nulls - _TENSOR_FIELDS:
             raise ValueError(f"null markers reference non-tensor fields: {sorted(nulls - _TENSOR_FIELDS)}")
-        for field, spec in SAMPLES_VALUE_SPEC.items():
+        for field in fields:
+            spec = SAMPLES_VALUE_SPEC_V2[field]
             if spec.codec == "json":
                 value = sample_meta[field]
                 if field == "status":
@@ -138,6 +168,11 @@ def decode_samples_and_merge_input_sample(payload: bytes, input_sample: Sample) 
                     value = list(value)
                 elif field == "prefix_cache_info":
                     value = Sample.PrefixCacheInfo.from_dict(value)
+                elif field == "reward":
+                    # Server reward is authoritative only when assigned; a null
+                    # keeps the driver input's local reward.
+                    if value is None:
+                        continue
                 elif field == "metadata":
                     if not isinstance(value, dict):
                         raise ValueError(f"metadata must be a JSON object, got {type(value).__name__}")

--- a/miles/rollout/session/sessions.py
+++ b/miles/rollout/session/sessions.py
@@ -37,8 +37,16 @@ def setup_session_routes(app, backend, args):
         chat_template_kwargs=getattr(args, "apply_chat_template_kwargs", None),
     )
 
-    registry = SessionRegistry(args, tokenizer, tito_tokenizer=tito_tokenizer)
-    core = SessionCore(backend, registry, args, session_server_instance_id)
+    use_v2 = getattr(args, "use_session_server", None) == "v2"
+    if use_v2:
+        from miles.rollout.session.v2.core import SessionCoreV2
+        from miles.rollout.session.v2.session_state import SessionRegistryV2
+
+        registry = SessionRegistryV2(args, tokenizer, tito_tokenizer=tito_tokenizer)
+        core = SessionCoreV2(backend, registry, args, session_server_instance_id)
+    else:
+        registry = SessionRegistry(args, tokenizer, tito_tokenizer=tito_tokenizer)
+        core = SessionCore(backend, registry, args, session_server_instance_id)
 
     @app.exception_handler(SessionError)
     async def session_error_handler(request: Request, exc: SessionError):
@@ -77,10 +85,11 @@ def setup_session_routes(app, backend, args):
         # Parse here so malformed input is not reported as an assembly error (422).
         body = await request.body()
         params = json.loads(body) if body else {}
-        return await core.collect_samples(
-            session_id,
-            max_seq_len=params.get("max_seq_len"),
-        )
+        if use_v2:
+            return await core.collect_samples(
+                session_id, max_seq_len=params.get("max_seq_len"), agent_metadata=params.get("metadata")
+            )
+        return await core.collect_samples(session_id, max_seq_len=params.get("max_seq_len"))
 
     @app.api_route("/sessions/{session_id}/{path:path}", methods=["GET", "POST", "PUT", "DELETE", "PATCH"])
     async def session_proxy(request: Request, session_id: str, path: str):

--- a/miles/rollout/session/v2/__init__.py
+++ b/miles/rollout/session/v2/__init__.py
@@ -1,0 +1,5 @@
+"""Session server v2: tree-of-trajectories serving, opt-in via --use-session-server v2.
+
+v1 (linear_trajectory + core) stays the default and is untouched; this package
+holds the entire tree implementation.
+"""

--- a/miles/rollout/session/v2/core.py
+++ b/miles/rollout/session/v2/core.py
@@ -1,0 +1,210 @@
+import json
+import logging
+import time
+
+from starlette.responses import Response
+
+from miles.rollout.session.core import (
+    JSON_MEDIA_TYPE,
+    ProxyRequest,
+    SessionCore,
+    _chat_client_response,
+    _render_json,
+    _samples_response,
+    extract_completion,
+    prepare_chat_request,
+    proxy_result_to_response,
+)
+from miles.rollout.session.errors import SessionNotFoundError, TokenizationError
+from miles.rollout.session.samples.codec import COMPUTED_FIELDS_V2, encode_samples
+from miles.rollout.session.types import GetSessionResponse, SessionRecord
+from miles.rollout.session.v2.session_state import (
+    SessionRegistryV2,
+    commit_generation,
+    position_for_request,
+    prepare_pretokenized,
+)
+from miles.rollout.session.v2.utils import build_leaf_material, tree_metadata
+from miles.utils.misc import load_function
+
+logger = logging.getLogger(__name__)
+
+
+class SessionCoreV2(SessionCore):
+    """``SessionCore`` with tree serving: overrides the session-semantics
+    methods (positioning/commit, metadata, samples op), inherits the
+    transport shell (health, create/delete, raw proxy)."""
+
+    def __init__(self, backend, registry: SessionRegistryV2, args, session_server_instance_id=None):
+        super().__init__(backend, registry, args, session_server_instance_id)
+        # Import-path only in production: function_registry is process-local.
+        self.sample_picker = load_function(args.session_sample_picker_path, sync_required=True)
+        self.sample_postprocessor = load_function(args.session_sample_postprocessor_path, sync_required=True)
+
+    def _session_metadata(self, session_id: str, session) -> dict:
+        """Mirrors ``core.SessionCore._session_metadata``: token ids come from
+        the active path, plus the ``tree`` block."""
+        metadata: dict = {}
+        try:
+            mismatch = self.registry.compute_session_mismatch(session)
+        except TokenizationError:
+            logger.exception("Failed to compute tito_session_mismatch for session %s", session_id)
+            mismatch = None
+        if mismatch is not None:
+            metadata["tito_session_mismatch"] = mismatch
+        metadata["accumulated_token_ids"] = session.active_token_ids()
+        metadata["max_trim_tokens"] = self.registry.tito_tokenizer.max_trim_tokens
+        metadata["tree"] = tree_metadata(session)
+        return metadata
+
+    async def get_session(self, session_id: str) -> Response:
+        """Mirrors ``core.SessionCore.get_session``, serving ``active_records()``."""
+        session = self.registry.get_session(session_id)
+        metadata = self._session_metadata(session_id, session)
+        payload = GetSessionResponse(session_id=session_id, records=session.active_records(), metadata=metadata)
+        return Response(
+            content=_render_json(payload.model_dump(mode="json")), status_code=200, media_type=JSON_MEDIA_TYPE
+        )
+
+    async def collect_samples(
+        self, session_id: str, *, max_seq_len: int | None, agent_metadata: dict | None = None
+    ) -> Response:
+        """Samples op: assemble one raw sample per leaf, then run the
+        pick/post-process hook pipeline and encode the result.
+
+        Synchronous on the server loop (no await), so the session read cannot
+        interleave with chat commits. Deterministic assembly/hook failures map
+        to 422; unknown exceptions propagate.
+        """
+        session = self.registry.get_session(session_id)
+        metadata = self._session_metadata(session_id, session)
+        if agent_metadata is not None:
+            metadata["agent"] = agent_metadata
+        if not session.tree.nodes:
+            return _samples_response(
+                encode_samples([], metadata, empty_reason="no_records", fields=COMPUTED_FIELDS_V2)
+            )
+
+        try:
+            material = build_leaf_material(
+                self.args, session, self.registry, session_id=session_id, max_seq_len=max_seq_len
+            )
+        except (AssertionError, ValueError) as exc:
+            return Response(content=str(exc).encode(), status_code=422, media_type="text/plain")
+        if not material:
+            return _samples_response(
+                encode_samples([], metadata, empty_reason="all_truncated", fields=COMPUTED_FIELDS_V2)
+            )
+
+        # Hook lane: a policy bug is a deterministic 422 carrying the hook's
+        # identity, never a masked 500 (server death stays loud).
+        try:
+            picked = self.sample_picker(material, metadata)
+            picked_ids = [id(sample) for sample in picked]
+            allowed = {id(sample) for sample in material}
+            if any(sample_id not in allowed for sample_id in picked_ids) or len(picked_ids) != len(set(picked_ids)):
+                raise ValueError(
+                    "pick hook must return a subset of its input samples without duplicates (pure selection)"
+                )
+            samples = self.sample_postprocessor(picked, metadata)
+        except Exception as exc:
+            body = (
+                f"session sample hook failed (picker={self.args.session_sample_picker_path}, "
+                f"postprocessor={self.args.session_sample_postprocessor_path}): {exc}"
+            )
+            return Response(content=body.encode(), status_code=422, media_type="text/plain")
+        if not samples:
+            return _samples_response(
+                encode_samples([], metadata, empty_reason="all_truncated", fields=COMPUTED_FIELDS_V2)
+            )
+        return _samples_response(encode_samples(samples, metadata, fields=COMPUTED_FIELDS_V2))
+
+    async def chat_completions(
+        self, session_id: str, *, method: str, query: str, headers: dict, body: bytes
+    ) -> Response:
+        """Proxy a chat completion through the backend with TITO token tracking.
+
+        Flow: prepare pretokenized input_ids (lock held briefly) → proxy to
+        backend (NO lock) → validate response → update trajectory checkpoint and
+        append record (lock held briefly). The lock is NOT held during the long
+        inference call so DELETE/other ops are not blocked if the agent disconnects.
+        """
+        request_timestamp = time.time()
+        session = self.registry.get_session(session_id)
+        if session.closing:
+            raise SessionNotFoundError(f"session not found: session_id={session_id}")
+
+        # --- Phase 1: prepare request (lock held briefly) ---
+        async with session.lock:
+            if session.closing:
+                raise SessionNotFoundError(f"session not found: session_id={session_id}")
+
+            request_body, client_stream, tito_tokenizer = prepare_chat_request(
+                body, self.args, self.registry.tito_tokenizer
+            )
+
+            request_messages = request_body.get("messages", [])
+            position_for_request(session, request_messages)
+            prompt_token_ids = prepare_pretokenized(
+                session,
+                request_messages,
+                tools=request_body.get("tools"),
+                tito_tokenizer=tito_tokenizer,
+            )
+            request_body["input_ids"] = prompt_token_ids
+            logger.debug("Using TITO input_ids: %d tokens", len(prompt_token_ids))
+
+            proxy_body = json.dumps(request_body).encode()
+            attach_parent = session.active_leaf
+        # --- lock released ---
+
+        # --- Phase 2: proxy to backend (NO lock held) ---
+        headers = {**headers, "X-SMG-Routing-Key": session_id}
+        result = await self.backend.do_proxy(
+            ProxyRequest(method=method, query=query), "v1/chat/completions", body=proxy_body, headers=headers
+        )
+
+        # Non-200 (e.g. 400 context too long) passes through unrecorded so the
+        # agent can retry or handle the error.
+        if result["status_code"] != 200:
+            return proxy_result_to_response(result)
+
+        response, choice, assistant_message, completion_token_ids = extract_completion(result)
+
+        # --- Phase 3: update state (lock held briefly) ---
+        async with session.lock:
+            if session.closing:
+                logger.warning(f"Session {session_id} closed during proxy, skipping state update")
+                return _chat_client_response(result, response, client_stream)
+
+            if session.active_leaf is not attach_parent:
+                logger.warning(
+                    f"Session {session_id} state changed during proxy "
+                    f"(the active view moved), skipping state update"
+                )
+                return _chat_client_response(result, response, client_stream)
+
+            record = SessionRecord(
+                timestamp=time.time(),
+                request_timestamp=request_timestamp,
+                method=method,
+                path="/v1/chat/completions",
+                status_code=result["status_code"],
+                request=request_body,
+                response=response,
+            )
+            commit_generation(
+                session,
+                parent=attach_parent,
+                request_messages=request_messages,
+                assistant_message=assistant_message,
+                prompt_token_ids=prompt_token_ids,
+                completion_token_ids=completion_token_ids,
+                max_trim_tokens=tito_tokenizer.max_trim_tokens,
+                record=record,
+                response_id=response.get("id", ""),
+                finish_reason=choice.get("finish_reason") or "",
+            )
+        # --- lock released ---
+
+        return _chat_client_response(result, response, client_stream)

--- a/miles/rollout/session/v2/picker_hub/__init__.py
+++ b/miles/rollout/session/v2/picker_hub/__init__.py
@@ -1,0 +1,12 @@
+"""Pick hooks for the session samples op — this is the customization point.
+
+Point ``--session-sample-picker-path`` at any ``fn(leaf_samples,
+session_metadata) -> list[Sample]``: a pure selection over the per-leaf raw
+samples (drop or reorder, never rewrite). Public inputs are each sample's
+``metadata["leaf"]`` descriptor and the structural tree tables in
+``session_metadata``. Runs synchronously inside the session server process.
+"""
+
+from miles.rollout.session.v2.picker_hub.drop_retries import drop_retries
+
+__all__ = ["drop_retries"]

--- a/miles/rollout/session/v2/picker_hub/drop_retries.py
+++ b/miles/rollout/session/v2/picker_hub/drop_retries.py
@@ -1,0 +1,86 @@
+"""The default pick hook: trim retry-superseded leaves."""
+
+import logging
+
+from miles.utils.types import Sample
+
+logger = logging.getLogger(__name__)
+
+
+def drop_retries(leaf_samples: list[Sample], session_metadata: dict) -> list[Sample]:
+    """Drop the dead leaves that retries leave behind.
+
+    When a generation goes bad, the agent re-sends the same message and the
+    conversation continues on the new branch — but the abandoned attempt is
+    still a leaf in the tree, and it must not become a training sample.
+
+    The rule, leaf by leaf: a sibling branched off the same parent after it
+    -> this leaf is the abandoned attempt, superseded by the retry: trim it.
+    No later sibling -> keep (root leaves included). Survivors are ordered by
+    checkpoint count, then commit order, both descending.
+
+    Example — turn 2 hit the length cap and the agent re-sent it (``seq`` is
+    commit order):
+
+        seq=0  turn 1: user asks, assistant answers
+        ├── seq=1  turn 2 attempt: cut off at the length cap  (leaf) -> trim
+        └── seq=2  turn 2 retry: the same user message re-sent
+            └── seq=3  turn 3: the retry path continues       (leaf) -> keep
+    """
+    nodes = {n["id"]: n for n in session_metadata["tree"]["nodes"]}
+    children: dict[int, list[int]] = {}
+    for n in session_metadata["tree"]["nodes"]:
+        if n["parent"] is not None:
+            children.setdefault(n["parent"], []).append(n["id"])
+    leaf_rows = session_metadata["tree"]["leaves"]
+
+    kept: list[Sample] = []
+    for sample in leaf_samples:
+        descriptor = sample.metadata["leaf"]
+        leaf_id, parent = descriptor["node_id"], descriptor["parent"]
+        later = [] if parent is None else [sibling for sibling in children[parent] if sibling > leaf_id]
+        if not later:
+            kept.append(sample)
+            continue
+        # Wall-clock regressions are diagnostic; `seq` is the ordering contract.
+        clock_regressions = [
+            (sibling, nodes[sibling]["committed_at"])
+            for sibling in later
+            if nodes[sibling]["committed_at"] < nodes[leaf_id]["committed_at"]
+        ]
+        if clock_regressions:
+            logger.warning(
+                "Default picker detected wall-clock rollback for superseded leaf "
+                "(response_id=%r, seq=%d, committed_at=%s); "
+                "later siblings=%s; continuing by seq",
+                descriptor["response_id"],
+                leaf_id,
+                nodes[leaf_id]["committed_at"],
+                clock_regressions,
+            )
+
+        # Length is diagnostic only; temporal supersession is decided by `seq`.
+        survivors_max = max(
+            nodes[row["node_id"]]["num_tokens"]
+            for row in leaf_rows
+            if any(sibling in row["path_node_ids"] for sibling in later)
+        )
+        if nodes[leaf_id]["num_tokens"] > survivors_max:
+            logger.warning(
+                "Default picker trimming superseded leaf (response_id=%r, seq=%d) "
+                "even though it is longer than every later sibling's deepest leaf "
+                "(%d > %d tokens); continuing by seq; use a custom picker to keep it",
+                descriptor["response_id"],
+                leaf_id,
+                nodes[leaf_id]["num_tokens"],
+                survivors_max,
+            )
+        logger.info("Default picker trimmed superseded retry leaf seq=%d", leaf_id)
+    return sorted(
+        kept,
+        key=lambda sample: (
+            len(sample.metadata["leaf"]["path_node_ids"]),
+            sample.metadata["leaf"]["node_id"],
+        ),
+        reverse=True,
+    )

--- a/miles/rollout/session/v2/postprocessor_hub/__init__.py
+++ b/miles/rollout/session/v2/postprocessor_hub/__init__.py
@@ -1,0 +1,16 @@
+"""Post-process hooks for the session samples op — this is the customization point.
+
+Point ``--session-sample-postprocessor-path`` at any ``fn(leaf_samples,
+session_metadata) -> list[Sample]``. The post-process hook finalizes the
+surviving set into training samples; it runs strictly after pick,
+synchronously inside the session server process. It never drops samples —
+selection is the picker's job (see ``picker_hub``).
+
+One module per hook, file named after the function. Custom post-processor
+ideas: reassign shared-node mask ownership by reward, broadcast advantages
+across branches.
+"""
+
+from miles.rollout.session.v2.postprocessor_hub.default_postprocess import default_postprocess
+
+__all__ = ["default_postprocess"]

--- a/miles/rollout/session/v2/postprocessor_hub/default_postprocess.py
+++ b/miles/rollout/session/v2/postprocessor_hub/default_postprocess.py
@@ -1,0 +1,59 @@
+from miles.utils.types import Sample
+
+_SERVER_OWNED_METADATA_KEYS = ("accumulated_token_ids", "tito_session_mismatch", "leaf")
+
+
+def check_input_metadata(agent_metadata: dict) -> dict:
+    return {key: value for key, value in agent_metadata.items() if key not in _SERVER_OWNED_METADATA_KEYS}
+
+
+def assign_reward(samples: list[Sample], trajectory_reward: float) -> None:
+    for sample in samples:
+        sample.reward = trajectory_reward
+
+
+def default_postprocess(leaf_samples: list[Sample], session_metadata: dict) -> list[Sample]:
+    """Finalize the leaf samples kept by the picker.
+
+    A shared completion is trainable only in the earliest committed kept leaf.
+    Ownership is computed after picking, so a dropped leaf cannot own it.
+
+    Agent metadata cannot replace server-owned fields. A provided trajectory reward is assigned to every kept sample.
+
+    Mutates each `Sample` in place and preserves picker order.
+    """
+    nodes_by_id = {node["id"]: node for node in session_metadata["tree"]["nodes"]}
+    agent_metadata = session_metadata.get("agent") or {}
+    trajectory_reward = agent_metadata.get("reward")
+    agent_sample_metadata = check_input_metadata(agent_metadata)
+
+    # Picker order may change; `node_id` preserves commit order.
+    owner_by_node_id: dict[int, int] = {}
+    for sample in leaf_samples:
+        leaf = sample.metadata["leaf"]
+        leaf_id = leaf["node_id"]
+        for node_id in leaf["path_node_ids"]:
+            owner_by_node_id[node_id] = min(leaf_id, owner_by_node_id.get(node_id, leaf_id))
+
+    processed_samples: list[Sample] = []
+    for sample in leaf_samples:
+        leaf = sample.metadata["leaf"]
+        response_start = len(sample.tokens) - sample.response_length
+        # Spans index all tokens; `loss_mask` indexes only the response.
+        # Clamp when early-stop or truncation shortens the sample.
+        for node_id in leaf["path_node_ids"]:
+            if owner_by_node_id[node_id] == leaf["node_id"]:
+                continue
+            completion_start, completion_end = nodes_by_id[node_id]["completion_span"]
+            mask_start = max(completion_start - response_start, 0)
+            mask_end = min(completion_end - response_start, sample.response_length)
+            if mask_end > mask_start:
+                sample.loss_mask[mask_start:mask_end] = [0] * (mask_end - mask_start)
+        server_metadata = {key: sample.metadata[key] for key in _SERVER_OWNED_METADATA_KEYS if key in sample.metadata}
+        sample.metadata = {**sample.metadata, **agent_sample_metadata, **server_metadata}
+        processed_samples.append(sample)
+    # Skip `assign_reward` to score downstream, or replace the scalar
+    # `agent_metadata["reward"]` for finer-grained assignment.
+    if trajectory_reward is not None:
+        assign_reward(processed_samples, trajectory_reward)
+    return processed_samples

--- a/miles/rollout/session/v2/session_state.py
+++ b/miles/rollout/session/v2/session_state.py
@@ -1,0 +1,214 @@
+"""Session state over the trajectory tree: always-branch serving.
+
+This module is the serving policy on top. A request is never rejected for mismatching stored history and never
+destroys anything: it attaches at the deepest matching node, its unmatched
+suffix becomes the new branch's delta, and whatever is not a clean
+extension just grows a sibling or a new root. Whether a branch was a retry
+is decided later by the sample_picker, not here.
+
+Concurrency contract: single lock on the whole tree. A commit only appends a new
+node under the parent captured at positioning time, so concurrent
+generations from the same spot become sibling nodes instead of a conflict.
+"""
+
+import asyncio
+import logging
+import uuid
+from dataclasses import dataclass, field
+from typing import Any
+
+from miles.rollout.session.errors import MessageValidationError, TokenizationError, TruncatedGenerationError
+from miles.rollout.session.linear_trajectory import SessionRegistry, assert_pretokenized_prefix
+from miles.rollout.session.types import SessionRecord
+from miles.rollout.session.v2.tree_trajectory import SessionTree, TrajectoryNode
+from miles.utils.chat_template_utils.tito_tokenizer import TITOTokenizer
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class SessionStateV2:
+    """Per-session concurrency container plus the trajectory forest.
+
+    ``active_leaf`` is the head of the single-chain view: the path root ->
+    active_leaf is what GET /sessions, judgment, and sample assembly see.
+    ``None`` means no committed generation yet (empty view, first-turn
+    semantics — a failed first turn leaves the session fully retryable).
+    """
+
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock, repr=False, compare=False)
+    closing: bool = field(default=False, repr=False, compare=False)
+    tree: SessionTree = field(default_factory=SessionTree)
+    active_leaf: TrajectoryNode | None = None
+
+    def active_path(self) -> list[TrajectoryNode]:
+        return self.active_leaf.path_nodes() if self.active_leaf is not None else []
+
+    def active_messages(self) -> list[dict[str, Any]]:
+        return self.active_leaf.path_messages() if self.active_leaf is not None else []
+
+    def active_records(self) -> list[SessionRecord]:
+        return [node.record for node in self.active_path()]
+
+    def active_token_ids(self) -> list[int]:
+        return self.active_leaf.token_ids if self.active_leaf is not None else []
+
+
+def position_for_request(state: SessionStateV2, request_messages: list[dict[str, Any]]) -> None:
+    """Move the view (``active_leaf``) to the attach point for *request_messages*."""
+    attach = state.tree.find_attach_point(request_messages)
+
+    if attach.node is not None and attach.node.truncated:
+        raise TruncatedGenerationError(
+            "truncated generation cannot be extended: the matched node ended with "
+            "finish_reason='length' and truncation closes that path for good; "
+            "branch before the cut instead"
+        )
+
+    if attach.node is not state.active_leaf:
+        logger.info(
+            "Branching: request(%d msgs) attaches at node seq=%s "
+            "(matched %d msgs, best overlap %d), tree has %d nodes",
+            len(request_messages),
+            attach.node.seq if attach.node is not None else "<new root>",
+            attach.matched_messages,
+            attach.best_overlap,
+            len(state.tree.nodes),
+        )
+    state.active_leaf = attach.node
+
+
+def prepare_pretokenized(
+    state: SessionStateV2,
+    request_messages: list[dict[str, Any]],
+    *,
+    tools: list[dict[str, Any]] | None,
+    tito_tokenizer: TITOTokenizer,
+) -> list[int]:
+    """Pretokenized input_ids for the positioned view.
+
+    - No attach node: render the whole request from scratch.
+    - Otherwise: reuse the parent's token snapshot as-is and tokenize only
+      the new suffix on top — the shared prefix is never re-rendered.
+    """
+    parent = state.active_leaf
+    if parent is None:
+        return tito_tokenizer.apply_chat_template(
+            request_messages,
+            tools=tools,
+            add_generation_prompt=True,
+            tokenize=True,
+        )
+
+    stored = state.active_messages()
+    _validate_suffix_roles(request_messages[len(stored) :], tito_tokenizer, assistant_exempt=True)
+    return tito_tokenizer.merge_tokens(
+        old_messages=stored,
+        new_messages=request_messages,
+        pretokenized_token_ids=parent.token_ids,
+        tools=tools,
+    )
+
+
+def _validate_suffix_roles(
+    suffix: list[dict[str, Any]],
+    tito_tokenizer: TITOTokenizer,
+    *,
+    assistant_exempt: bool,
+) -> None:
+    """Carried assistants are prompt material for branches; ``assistant_exempt``
+    keeps them outside the template's append-role gate."""
+    allowed = set(tito_tokenizer.allowed_append_roles)
+    if assistant_exempt:
+        allowed |= {"assistant"}
+    for message in suffix:
+        role = message.get("role")
+        if role not in allowed:
+            raise MessageValidationError(
+                f"appended message role={role!r} not allowed "
+                f"(allowed={sorted(set(tito_tokenizer.allowed_append_roles))}); "
+                "the selected TITO fixed template does not support appending this role"
+            )
+
+
+def commit_generation(
+    state: SessionStateV2,
+    *,
+    parent: TrajectoryNode | None,
+    request_messages: list[dict[str, Any]],
+    assistant_message: dict[str, Any],
+    prompt_token_ids: list[int],
+    completion_token_ids: list[int],
+    max_trim_tokens: int,
+    record: SessionRecord,
+    response_id: str,
+    finish_reason: str,
+) -> TrajectoryNode:
+    """Validate and append one generation under *parent* (captured at
+    positioning time), then advance the view to the new node. Prefix
+    validation is byte-identical to the pre-tree checkpoint check."""
+    all_token_ids = prompt_token_ids + completion_token_ids
+    assert_pretokenized_prefix(
+        parent.token_ids if parent is not None else [],
+        all_token_ids,
+        max_trim_tokens=max_trim_tokens,
+        request_messages=request_messages,
+        assistant_message=assistant_message,
+    )
+
+    parent_messages = parent.path_messages() if parent is not None else []
+    delta = list(request_messages[len(parent_messages) :]) + [assistant_message]
+    node = state.tree.create_node(
+        parent,
+        delta_messages=delta,
+        token_ids=all_token_ids,
+        completion_span=(len(prompt_token_ids), len(all_token_ids)),
+        committed_at=record.timestamp,
+        response_id=response_id,
+        record=record,
+        finish_reason=finish_reason,
+    )
+    state.active_leaf = node
+    return node
+
+
+class SessionRegistryV2(SessionRegistry):
+    """Session ID -> session state mapping with shared tokenizer resources.
+
+    The v1 registry shell (CRUD + tokenizer resources) with the session type
+    swapped to ``SessionStateV2``; all session mutations go through the
+    module-level serving functions, called by the route handler under
+    ``SessionStateV2.lock``.
+    """
+
+    sessions: dict[str, SessionStateV2]
+
+    def create_session(self) -> str:
+        session_id = uuid.uuid4().hex
+        self.sessions[session_id] = SessionStateV2()
+        return session_id
+
+    def compute_mismatch(self, messages: list[dict[str, Any]], token_ids: list[int], tools: Any) -> list[dict] | None:
+        """Compare accumulated token IDs against canonical chat template
+        output for one path. Read-only."""
+        if not token_ids:
+            return None
+        try:
+            expected_ids = self.tito_tokenizer.apply_chat_template(
+                messages,
+                tools=tools,
+                add_generation_prompt=False,
+                tokenize=True,
+            )
+            mismatches = self.comparator.compare_sequences(expected_ids, token_ids)
+            return [m.to_dict() for m in mismatches]
+        except Exception as e:
+            raise TokenizationError(f"failed to compute tito_session_mismatch: {e}") from e
+
+    def compute_session_mismatch(self, state: SessionStateV2) -> list[dict] | None:
+        """The active-path view of ``compute_mismatch``."""
+        if state.active_leaf is None:
+            return None
+        records = state.active_records()
+        tools = records[-1].request.get("tools") if records else None
+        return self.compute_mismatch(state.active_messages(), state.active_token_ids(), tools)

--- a/miles/rollout/session/v2/tree_trajectory.py
+++ b/miles/rollout/session/v2/tree_trajectory.py
@@ -1,0 +1,139 @@
+"""Session-as-forest data model: trajectory nodes and attach-point search.
+
+The forest is append-only and ``seq`` (commit order) is the only ordering
+key. Everything here is synchronous pure data — serving policy,
+concurrency, and tokenization live one layer up in ``session_state``.
+"""
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from miles.rollout.session.types import SessionRecord
+from miles.utils.chat_template_utils import message_matches
+
+MAX_NODES = 1024
+
+
+@dataclass
+class TrajectoryNode:
+    """End of one model generation (SessionRecord is 1:1 with the node)."""
+
+    delta_messages: list[dict[str, Any]]
+    token_ids: list[int]  # full root->node snapshot
+    completion_span: tuple[int, int]  # this node's sampled completion within token_ids
+    seq: int  # per-session logical commit order — THE ordering key
+    committed_at: float  # wall clock, decoration only (NTP-unsafe; never order by this)
+    response_id: str  # upstream response id: the agent-branch <-> leaf join key
+    record: SessionRecord
+    finish_reason: str
+    parent: "TrajectoryNode | None" = None
+    children: list["TrajectoryNode"] = field(default_factory=list, repr=False)
+
+    @property
+    def truncated(self) -> bool:
+        return self.finish_reason == "length"
+
+    def path_nodes(self) -> list["TrajectoryNode"]:
+        nodes: list[TrajectoryNode] = []
+        node: TrajectoryNode | None = self
+        while node is not None:
+            nodes.append(node)
+            node = node.parent
+        nodes.reverse()
+        return nodes
+
+    def path_messages(self) -> list[dict[str, Any]]:
+        return [message for node in self.path_nodes() for message in node.delta_messages]
+
+
+@dataclass(frozen=True)
+class AttachPoint:
+    """Result of matching a request against the tree."""
+
+    node: "TrajectoryNode | None"  # None = new root
+    matched_messages: int  # request messages consumed by the attach node's path
+    best_overlap: int  # diagnostics only: deepest overlap seen, incl. partial deltas
+
+
+class SessionTree:
+    """Forest of trajectory nodes plus the append-only commit surface."""
+
+    def __init__(self) -> None:
+        self.roots: list[TrajectoryNode] = []
+        self.nodes: list[TrajectoryNode] = []  # creation (seq) order
+
+    def leaves(self) -> list[TrajectoryNode]:
+        return [node for node in self.nodes if not node.children]
+
+    def create_node(
+        self,
+        parent: TrajectoryNode | None,
+        *,
+        delta_messages: list[dict[str, Any]],
+        token_ids: list[int],
+        completion_span: tuple[int, int],
+        committed_at: float,
+        response_id: str,
+        record: SessionRecord,
+        finish_reason: str,
+    ) -> TrajectoryNode:
+        if len(self.nodes) >= MAX_NODES:
+            raise ValueError(
+                f"node cap reached ({MAX_NODES}): the session cannot branch or extend "
+                f"further — this almost always means the harness is not replaying "
+                f"history verbatim"
+            )
+        node = TrajectoryNode(
+            delta_messages=list(delta_messages),
+            token_ids=token_ids,
+            completion_span=completion_span,
+            seq=len(self.nodes),
+            committed_at=committed_at,
+            response_id=response_id,
+            record=record,
+            finish_reason=finish_reason,
+            parent=parent,
+        )
+        self.nodes.append(node)
+        if parent is None:
+            self.roots.append(node)
+        else:
+            parent.children.append(node)
+        return node
+
+    def find_attach_point(self, request_messages: list[dict[str, Any]]) -> AttachPoint:
+        """Deepest node whose full path messages are a prefix of the request.
+
+        A node is only entered after its parent's delta is fully consumed;
+        ties on depth (twins whose deltas both match) go to the latest ``seq``.
+        Pure judgment — never mutates the forest.
+        """
+        best: TrajectoryNode | None = None
+        best_matched = -1
+        best_overlap = 0
+
+        def visit(node: TrajectoryNode, offset: int) -> None:
+            nonlocal best, best_matched, best_overlap
+            delta = node.delta_messages
+            i = 0
+            while (
+                i < len(delta)
+                and offset + i < len(request_messages)
+                and message_matches(delta[i], request_messages[offset + i])
+            ):
+                i += 1
+            best_overlap = max(best_overlap, offset + i)
+            if i < len(delta):
+                return  # partial delta: this node (and its subtree) is not a candidate
+            matched = offset + len(delta)
+            if matched > best_matched or (matched == best_matched and best is not None and node.seq > best.seq):
+                best, best_matched = node, matched
+            for child in node.children:
+                visit(child, matched)
+
+        for root in self.roots:
+            visit(root, 0)
+
+        if best is None:
+            return AttachPoint(node=None, matched_messages=0, best_overlap=best_overlap)
+        return AttachPoint(node=best, matched_messages=best_matched, best_overlap=best_overlap)

--- a/miles/rollout/session/v2/utils.py
+++ b/miles/rollout/session/v2/utils.py
@@ -1,0 +1,87 @@
+import logging
+from argparse import Namespace
+from typing import Any
+
+from miles.rollout.generate_utils.sample_utils import merge_samples
+from miles.rollout.session.errors import TokenizationError
+from miles.rollout.session.samples.merge import compute_samples_from_openai_records, truncate_samples_by_total_tokens
+from miles.rollout.session.v2.session_state import SessionRegistryV2, SessionStateV2
+from miles.utils.types import Sample
+
+logger = logging.getLogger(__name__)
+
+
+def tree_metadata(state: SessionStateV2) -> dict:
+    """The structural layer: node and leaf tables, index-aligned with commits.
+
+    ``response_id`` is the branch<->leaf join key — the agent saw the same id
+    in each chat response, so the semantic layer can key per-branch data on it.
+    """
+    nodes = [
+        {
+            "id": node.seq,
+            "parent": node.parent.seq if node.parent is not None else None,
+            "seq": node.seq,
+            "truncated": node.truncated,
+            "committed_at": node.committed_at,
+            "completion_span": list(node.completion_span),
+            "num_tokens": len(node.token_ids),
+            "response_id": node.response_id,
+        }
+        for node in state.tree.nodes
+    ]
+    leaves = [
+        {"node_id": leaf.seq, "path_node_ids": [n.seq for n in leaf.path_nodes()]} for leaf in state.tree.leaves()
+    ]
+    return {"nodes": nodes, "leaves": leaves}
+
+
+def build_leaf_material(
+    args: Namespace,
+    state: SessionStateV2,
+    registry: SessionRegistryV2,
+    *,
+    session_id: str,
+    max_seq_len: int | None,
+) -> list[Sample]:
+    """Merge each leaf's root-to-leaf node records into one raw sample, in commit order.
+
+    Leaves whose turns all truncate away are dropped. Each sample's metadata
+    carries the ``leaf`` descriptor plus the flat TITO bookkeeping keys for
+    the downstream pick/post-process hooks.
+    """
+    material: list[Sample] = []
+    for leaf in state.tree.leaves():
+        path = leaf.path_nodes()
+        turns = compute_samples_from_openai_records(
+            args,
+            [node.record for node in path],
+            registry.tokenizer,
+            accumulated_token_ids=leaf.token_ids,
+            max_trim_tokens=registry.tito_tokenizer.max_trim_tokens,
+        )
+        if max_seq_len is not None:
+            turns = truncate_samples_by_total_tokens(turns, max_seq_len, registry.tokenizer)
+        if not turns:
+            continue
+        sample = merge_samples(turns, registry.tokenizer)
+        tools = path[-1].record.request.get("tools")
+        flat: dict[str, Any] = {
+            "accumulated_token_ids": list(leaf.token_ids),
+            "leaf": {
+                "node_id": leaf.seq,
+                "parent": leaf.parent.seq if leaf.parent is not None else None,
+                "path_node_ids": [n.seq for n in path],
+                "response_id": leaf.response_id,
+            },
+        }
+        try:
+            mismatch = registry.compute_mismatch(leaf.path_messages(), leaf.token_ids, tools)
+        except TokenizationError:
+            logger.exception("Failed to compute tito_session_mismatch for session %s", session_id)
+            mismatch = None
+        if mismatch is not None:
+            flat["tito_session_mismatch"] = mismatch
+        sample.metadata = {**(sample.metadata or {}), **flat}
+        material.append(sample)
+    return material

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -2628,6 +2628,21 @@ def miles_validate_args(args):
             "tree serving."
         )
 
+    if args.use_session_server == "v2":
+        unsupported = [
+            flag
+            for enabled, flag in (
+                (args.group_rm, "--group-rm"),
+                (args.partial_rollout, "--partial-rollout"),
+                (args.recompute_logprobs_via_prefill, "--recompute-logprobs-via-prefill"),
+            )
+            if enabled
+        ]
+        if unsupported:
+            raise ValueError(
+                f"--use-session-server v2 does not support {', '.join(unsupported)}; v2 returns list[Sample]"
+            )
+
     if not args.use_session_server and args.tito_model != TITOTokenizerType.DEFAULT.value:
         raise ValueError(
             f"--tito-model={args.tito_model} requires --use-session-server; "

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -2318,10 +2318,14 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
         def add_session_arguments(parser):
             parser.add_argument(
                 "--use-session-server",
-                action="store_true",
+                nargs="?",
+                const=True,
                 default=False,
                 help="Start a standalone session server for TITO/session support. "
-                "Requires --hf-checkpoint and --chat-template-path to also be set.",
+                "Requires --hf-checkpoint and --chat-template-path to also be set. "
+                "Bare flag (or 'v1') selects the append-only linear v1 server; "
+                "'--use-session-server v2' selects the tree-serving v2 "
+                "(multi-lineage trajectories, always-branch).",
             )
             parser.add_argument(
                 "--session-server-ip",
@@ -2346,6 +2350,28 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 help="TITO tokenizer type for pretokenized prefix reuse. "
                 "Controls how token IDs are computed for messages appended after "
                 "the pretokenized prefix in multi-turn agentic sessions.",
+            )
+            parser.add_argument(
+                "--session-sample-picker-path",
+                type=str,
+                default="miles.rollout.session.v2.picker_hub.drop_retries",
+                help="v2 only. Import path of the sample-pick hook for the "
+                "session samples op: fn(leaf_samples, session_metadata) -> "
+                "list[Sample], a pure selection over the per-leaf raw samples. "
+                "Runs synchronously inside the session server process; long CPU "
+                "work stalls every session on the instance. Default: the "
+                "temporal-supersession retry trim.",
+            )
+            parser.add_argument(
+                "--session-sample-postprocessor-path",
+                type=str,
+                default="miles.rollout.session.v2.postprocessor_hub.default_postprocess",
+                help="v2 only. Import path of the post-process hook for the "
+                "session samples op: fn(leaf_samples, session_metadata) -> "
+                "list[Sample], finalizing loss masks / rewards over the picked "
+                "samples. Runs synchronously inside the session server process. "
+                "Default: exactly-once completion masking + rewards keyed by "
+                "response id.",
             )
             return parser
 
@@ -2595,13 +2621,20 @@ def miles_validate_args(args):
     if args.recompute_logprobs_via_prefill:
         assert args.true_on_policy_mode, "--recompute-logprobs-via-prefill requires --true-on-policy-mode"
 
+    if args.use_session_server not in (False, True, "v1", "v2"):
+        raise ValueError(
+            f"--use-session-server={args.use_session_server!r} is not a known session server "
+            "version; pass it bare (or 'v1') for the append-only linear server, or 'v2' for "
+            "tree serving."
+        )
+
     if not args.use_session_server and args.tito_model != TITOTokenizerType.DEFAULT.value:
         raise ValueError(
             f"--tito-model={args.tito_model} requires --use-session-server; "
             "this flag only configures the session-server TITO middleware."
         )
 
-    # DEFAULT uses the checkpoint's native or caller-provided template.  Its
+    # DEFAULT uses the checkpoint's native or caller-provided template. Its
     # maximal four-role surface is best-effort rather than a Miles-verified
     # FixedTemplate contract.
     if args.use_session_server and args.tito_model == TITOTokenizerType.DEFAULT.value:

--- a/miles/utils/chat_template_utils/tito_tokenizer.py
+++ b/miles/utils/chat_template_utils/tito_tokenizer.py
@@ -85,7 +85,7 @@ class TITOTokenizer:
     trailing_token_ids: frozenset[int] = frozenset()
     chat_template_kwarg_aliases: frozenset[str] = frozenset()
 
-    # The family's fixed renderer contract.  DEFAULT uses the model's native
+    # The family's fixed renderer contract. DEFAULT uses the model's native
     # template with the maximal best-effort append surface.
     FIXED_TEMPLATE: FixedTemplate = FixedTemplate()
 
@@ -191,7 +191,9 @@ class TITOTokenizer:
         """Compute incremental token IDs for messages appended after the
         pretokenized prefix.
 
-        Appended roles must be listed in ``self.allowed_append_roles``.  The method validates that *new_messages* is an append-only extension of *old_messages* via ``assert_messages_append_only_with_allowed_role``.
+        Appended roles must be listed in ``self.allowed_append_roles``.  The
+        method validates that *new_messages* is an append-only extension of
+        *old_messages* via ``assert_messages_append_only_with_allowed_role``.
 
         Args:
             old_messages: Previously stored messages (prefix).

--- a/miles/utils/misc.py
+++ b/miles/utils/misc.py
@@ -1,5 +1,6 @@
 import asyncio
 import importlib
+import inspect
 import logging
 import re
 import subprocess
@@ -44,22 +45,28 @@ function_registry = FunctionRegistry()
 
 
 # TODO may rename to `load_object` since it can be used to load things like tool_specs
-def load_function(path):
+def load_function(path, *, sync_required=False):
     """
     Load a function from registry or module.
     :param path: The path to the function, e.g. "module.submodule.function".
+    :param sync_required: Reject coroutine functions, for callers that run the
+        loaded function synchronously on an event loop.
     :return: The function object.
     """
-    if path is None:
+    if not path:
         return None
 
-    registered = function_registry.get(path)
-    if registered is not None:
-        return registered
-
-    module_path, _, attr = path.rpartition(".")
-    module = importlib.import_module(module_path)
-    return getattr(module, attr)
+    fn = function_registry.get(path)
+    if fn is None:
+        module_path, _, attr = path.rpartition(".")
+        module = importlib.import_module(module_path)
+        fn = getattr(module, attr)
+    if sync_required:
+        if not callable(fn):
+            raise ValueError(f"load_function({path!r}) did not resolve to a callable")
+        if inspect.iscoroutinefunction(fn):
+            raise ValueError(f"load_function({path!r}) resolved to an async function; a synchronous one is required")
+    return fn
 
 
 async def call_agent_abort_hook(args) -> None:

--- a/miles/utils/test_utils/session_verify_runner.py
+++ b/miles/utils/test_utils/session_verify_runner.py
@@ -181,7 +181,11 @@ def namespace_to_train_args(ns: argparse.Namespace) -> str:
             ]
         )
     if ns.use_session_server:
-        parts.append("--use-session-server")
+        # Preserve an explicit version string ("v2"); a bare True stays the bare flag.
+        if isinstance(ns.use_session_server, str):
+            parts.append(f"--use-session-server {ns.use_session_server}")
+        else:
+            parts.append("--use-session-server")
     if ns.debug_rollout_only:
         parts.append("--debug-rollout-only")
     if ns.ci_test:

--- a/miles/utils/test_utils/session_verify_runner.py
+++ b/miles/utils/test_utils/session_verify_runner.py
@@ -65,7 +65,7 @@ SESSION_VERIFY_INVARIANT_ARGS: dict[str, Any] = {
     "rm_type": "random",
     "custom_generate_function_path": "miles.utils.test_utils.session_verify_agent.generate",
     "custom_agent_function_path": "miles.utils.test_utils.session_verify_agent.run_agent",
-    "use_session_server": True,
+    "use_session_server": "v2",
     "debug_rollout_only": True,
     "ci_test": True,
     "colocate": True,

--- a/tests/e2e/sglang/test_session_v1_v2_parity.py
+++ b/tests/e2e/sglang/test_session_v1_v2_parity.py
@@ -1,0 +1,84 @@
+import os
+
+import pytest
+import torch
+from huggingface_hub import snapshot_download
+from tests.ci.ci_register import register_cuda_ci
+from tests.e2e.sglang.utils.sglang_server import start_sglang_server
+from tests.session_parity_utils import V1, V2, assert_agentic_retry_trajectory_parity, run_agentic_retry_trajectories
+
+from miles.utils.test_utils.session_verify_agent import build_initial_messages
+from miles.utils.types import Sample
+
+register_cuda_ci(est_time=480, suite="stage-c-2-gpu-h200", labels=["sglang"])
+
+_MODEL_ID = "Qwen/Qwen3-8B"
+_MODEL_REVISION = "b968826d9c46dd6066d109eabc6255188de91218"
+_DEFAULT_MODEL_PATH = "/root/models/Qwen3-8B"
+_MODEL_PATH_OVERRIDE = os.environ.get("SGLANG_SESSION_PARITY_MODEL_PATH")
+_MODEL_PATH = _MODEL_PATH_OVERRIDE or _DEFAULT_MODEL_PATH
+_BATCH_SIZE = 16
+
+
+@pytest.fixture(scope="module")
+def sglang_server():
+    assert torch.cuda.is_available()
+    assert "H200" in torch.cuda.get_device_name(0)
+    if _MODEL_PATH_OVERRIDE is None:
+        snapshot_download(_MODEL_ID, revision=_MODEL_REVISION, local_dir=_DEFAULT_MODEL_PATH)
+
+    server = start_sglang_server(
+        model_path=_MODEL_PATH,
+        enable_deterministic_inference=True,
+        extra_args=[
+            "--attention-backend",
+            "fa3",
+            "--reasoning-parser",
+            "qwen3",
+            "--tool-call-parser",
+            "qwen25",
+            "--disable-radix-cache",
+            "--mem-fraction-static",
+            "0.5",
+        ],
+    )
+    try:
+        yield server
+    finally:
+        server.stop()
+
+
+def test_qwen3_8b_h200_fa3_agentic_v2_drop_retries_matches_v1_training_payload_bitwise(sglang_server):
+    v1_runs = run_agentic_retry_trajectories(
+        backend_url=sglang_server.base_url,
+        hf_checkpoint=_MODEL_PATH,
+        version=V1,
+        input_samples=_build_input_samples(),
+    )
+    v2_runs = run_agentic_retry_trajectories(
+        backend_url=sglang_server.base_url,
+        hf_checkpoint=_MODEL_PATH,
+        version=V2,
+        input_samples=_build_input_samples(),
+    )
+
+    assert len(v1_runs) == len(v2_runs) == _BATCH_SIZE
+    for index, (v1, v2) in enumerate(zip(v1_runs, v2_runs, strict=True)):
+        assert v1.samples[0].index == v2.samples[0].index == index
+        assert_agentic_retry_trajectory_parity(v1, v2)
+
+
+def _build_input_samples() -> list[Sample]:
+    return [
+        Sample(
+            index=index,
+            prompt=build_initial_messages(),
+            reward=0.25,
+            metadata={"source": "parity"},
+        )
+        for index in range(_BATCH_SIZE)
+    ]
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/fast/fixtures/generation_fixtures.py
+++ b/tests/fast/fixtures/generation_fixtures.py
@@ -2,11 +2,11 @@
 Fixtures to test custom-generate-function
 """
 
+import copy
 import uuid
 from argparse import Namespace
 from contextlib import contextmanager
 from dataclasses import dataclass
-from types import SimpleNamespace
 from typing import Any
 from unittest.mock import patch
 
@@ -63,7 +63,7 @@ def extra_argv_for_variant(
         argv += ["--generate-tool-call-parser", generate_tool_call_parser]
     elif variant == "agentic_tool_call":
         argv += ["--custom-agent-function-path", custom_agent_function_path]
-        argv += ["--use-session-server", "--tito-model", "qwen3"]
+        argv += ["--use-session-server", "v2", "--tito-model", "qwen3"]
 
     return argv
 
@@ -237,21 +237,9 @@ def with_session_server(
     # caller's per-port map, where OpenAIEndpointTracer.create reads it from.
     instance_id = uuid.uuid4().hex
     args.session_server_instance_ids = {port: instance_id}
-    server_args = SimpleNamespace(
-        miles_router_timeout=30,
-        hf_checkpoint=args.hf_checkpoint,
-        chat_template_path=args.chat_template_path,
-        tito_model=args.tito_model,
-        use_rollout_routing_replay=args.use_rollout_routing_replay,
-        sglang_speculative_algorithm=args.sglang_speculative_algorithm,
-        # Sample assembly runs inside the server, so the R3 decode shape args
-        # must reach the server namespace (set them via args_kwargs BEFORE the
-        # server starts; assigning to the driver args afterwards has no effect).
-        num_layers=getattr(args, "num_layers", None),
-        moe_router_topk=getattr(args, "moe_router_topk", None),
-        save_debug_trajectory_data=getattr(args, "save_debug_trajectory_data", None),
-        session_server_instance_id=instance_id,
-    )
+    server_args = copy.copy(args)
+    server_args.miles_router_timeout = 30
+    server_args.session_server_instance_id = instance_id
     session_server = SessionServer(server_args, backend_url=backend_url)
 
     server = UvicornThreadServer(session_server.app, host="127.0.0.1", port=port)

--- a/tests/fast/fixtures/rollout_fixtures.py
+++ b/tests/fast/fixtures/rollout_fixtures.py
@@ -2,6 +2,7 @@
 Fixtures to test rollout-function
 """
 
+import copy
 import json
 from argparse import Namespace
 from collections.abc import Iterator
@@ -101,17 +102,8 @@ DEFAULT_DATA_ROWS = [{"input": "What is 1+7?", "label": "8"}]
 @contextmanager
 def _with_session_server(args: Namespace, backend_url: str) -> Iterator[UvicornThreadServer]:
     """Start a SessionServer for agentic variants that need TITO session tracking."""
-    from types import SimpleNamespace
-
-    session_args = SimpleNamespace(
-        miles_router_timeout=30,
-        hf_checkpoint=args.hf_checkpoint,
-        chat_template_path=getattr(args, "chat_template_path", None),
-        tito_model=getattr(args, "tito_model", "default"),
-        use_rollout_routing_replay=getattr(args, "use_rollout_routing_replay", False),
-        save_debug_trajectory_data=getattr(args, "save_debug_trajectory_data", None),
-        sglang_speculative_algorithm=getattr(args, "sglang_speculative_algorithm", None),
-    )
+    session_args = copy.copy(args)
+    session_args.miles_router_timeout = 30
     session_server = SessionServer(session_args, backend_url=backend_url)
     port = find_available_port(31000)
     server = UvicornThreadServer(session_server.app, host="127.0.0.1", port=port)

--- a/tests/fast/rollout/generate_hub/test_agentic_v2.py
+++ b/tests/fast/rollout/generate_hub/test_agentic_v2.py
@@ -1,0 +1,94 @@
+from types import SimpleNamespace
+
+import pytest
+
+import miles.rollout.generate_hub.agentic_tool_call as agentic_tool_call
+from miles.rollout.base_types import GenerateFnInput
+from miles.rollout.session.samples.codec import SamplesReply
+from miles.utils.types import Sample
+
+
+class _Tracer:
+    session_id = "sid-1"
+    session_server_id = "127.0.0.1:12345"
+    session_server_instance_id = None
+    base_url = "http://127.0.0.1:12345/sessions/sid-1"
+
+    def __init__(self, reply=None, error=None):
+        self.reply = reply
+        self.error = error
+        self.agent_metadata = None
+
+    async def collect_samples(self, input_sample, *, max_seq_len, agent_metadata=None):
+        self.agent_metadata = agent_metadata
+        if self.error is not None:
+            raise self.error
+        return self.reply
+
+
+def _generate_input(**args_kwargs) -> GenerateFnInput:
+    args = SimpleNamespace(
+        session_server_ip="127.0.0.1",
+        session_server_ports=[12345],
+        custom_agent_function_path="test.fake_agent",
+        max_seq_len=None,
+        use_session_server="v2",
+        **args_kwargs,
+    )
+    state = SimpleNamespace(args=args)
+    sample = Sample(
+        group_index=3,
+        index=7,
+        prompt=[{"role": "user", "content": "hello"}],
+        label="label",
+        metadata={"source": "test"},
+    )
+    return GenerateFnInput(state=state, sample=sample, sampling_params={}, evaluation=False)
+
+
+async def _fake_agent(**kwargs):
+    return {"agent_result": "done"}
+
+
+def _patch_agent(monkeypatch, tracer):
+    async def fake_create(args):
+        return tracer
+
+    monkeypatch.setattr(agentic_tool_call.OpenAIEndpointTracer, "create", fake_create)
+    monkeypatch.setattr(agentic_tool_call, "load_function", lambda path: _fake_agent)
+
+
+@pytest.mark.asyncio
+async def test_success_returns_list_and_forwards_agent_metadata(monkeypatch):
+    sample = Sample(status=Sample.Status.COMPLETED, response="done", response_length=1, tokens=[1])
+    tracer = _Tracer(SamplesReply(samples=[sample], session_metadata={}, empty_reason=None))
+    _patch_agent(monkeypatch, tracer)
+
+    output = await agentic_tool_call.generate(_generate_input())
+
+    assert output.samples == [sample]
+    assert tracer.agent_metadata == {"agent_result": "done"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("empty_reason", ["no_records", "all_truncated"])
+async def test_empty_reply_returns_aborted_list(monkeypatch, empty_reason):
+    tracer = _Tracer(SamplesReply(samples=[], session_metadata={}, empty_reason=empty_reason))
+    _patch_agent(monkeypatch, tracer)
+    generate_input = _generate_input()
+
+    output = await agentic_tool_call.generate(generate_input)
+
+    assert isinstance(output.samples, list)
+    assert len(output.samples) == 1
+    assert output.samples[0] is not generate_input.sample
+    assert output.samples[0].status == Sample.Status.ABORTED
+
+
+@pytest.mark.asyncio
+async def test_collection_error_propagates(monkeypatch):
+    tracer = _Tracer(error=RuntimeError("samples unavailable"))
+    _patch_agent(monkeypatch, tracer)
+
+    with pytest.raises(RuntimeError, match="samples unavailable"):
+        await agentic_tool_call.generate(_generate_input())

--- a/tests/fast/rollout/generate_hub/test_multi_turn.py
+++ b/tests/fast/rollout/generate_hub/test_multi_turn.py
@@ -123,7 +123,7 @@ def verify_samples(actual: Sample | list[Sample], expected: list[ExpectedSampleI
         # Session server populates diagnostic metadata (token IDs,
         # trim config, mismatch analysis, dashboard lifecycle timing) that
         # varies with mock setup. Strip these before comparing structure.
-        for key in ("tito_session_mismatch", "accumulated_token_ids", "max_trim_tokens", "lifecycle"):
+        for key in ("tito_session_mismatch", "accumulated_token_ids", "max_trim_tokens", "lifecycle", "leaf"):
             actual_partial.metadata.pop(key, None)
         assert actual_partial == expected_item.partial_sample
 
@@ -679,7 +679,7 @@ class TestAgentCollectionFailure:
     ):
         collect_error = asyncio.TimeoutError()
 
-        async def fail_collect(_tracer, _input_sample, *, max_seq_len):
+        async def fail_collect(_tracer, _input_sample, *, max_seq_len, agent_metadata=None):
             raise collect_error
 
         monkeypatch.setattr(
@@ -690,8 +690,8 @@ class TestAgentCollectionFailure:
         with caplog.at_level(logging.WARNING):
             result = _run_generate(variant, generation_env, input_sample)
 
-        assert isinstance(result.sample, Sample)
-        assert result.sample.status == Sample.Status.ABORTED
+        [sample] = listify(result.sample)
+        assert sample.status == Sample.Status.ABORTED
         assert input_sample.status == Sample.Status.PENDING
         assert "Timed out collecting samples" in caplog.text
 
@@ -739,5 +739,5 @@ class TestAgentNoRecords:
 
         SingletonMeta.clear_all_instances()
 
-        assert isinstance(result.sample, Sample)
-        assert result.sample.status == Sample.Status.ABORTED
+        [sample] = listify(result.sample)
+        assert sample.status == Sample.Status.ABORTED

--- a/tests/fast/rollout/generate_utils/test_openai_endpoint_utils.py
+++ b/tests/fast/rollout/generate_utils/test_openai_endpoint_utils.py
@@ -233,3 +233,66 @@ async def test_post_bytes_no_retry_transport_error_propagates_once(monkeypatch):
     with pytest.raises(ConnectionError, match="boom"):
         await post_bytes_no_retry("http://x/samples", {}, timeout=5)
     assert client.post_count == 1
+
+
+# ── v2 wire (--use-session-server v2): metadata channel + extended fields ──
+
+
+@pytest.mark.asyncio
+async def test_collect_samples_v2_payload_carries_metadata_and_decodes_extras(monkeypatch):
+    """v2 pin: the collect body gains the "metadata" key only when the caller
+    passes agent metadata, and the v2 field tuple overlays reward + merged
+    metadata; the v1 pin above (`payload == {"max_seq_len": 7}`) stays."""
+    from miles.rollout.session.samples.codec import COMPUTED_FIELDS_V2
+
+    sample = Sample()
+    sample.tokens = [1, 2, 10]
+    sample.response = "r"
+    sample.response_length = 1
+    sample.loss_mask = [1]
+    sample.rollout_log_probs = [-0.5]
+    sample.status = Sample.Status.COMPLETED
+    sample.reward = 0.75
+    sample.metadata = {"leaf": {"node_id": 1}}
+    payload = encode_samples([sample], {"max_trim_tokens": 1}, None, fields=COMPUTED_FIELDS_V2)
+
+    seen = []
+
+    async def fake_post_bytes(url, body, *, timeout):
+        seen.append(body)
+        return payload
+
+    async def fake_post(url, body, action="post"):
+        assert action == "delete"
+        return {}
+
+    monkeypatch.setattr("miles.rollout.generate_utils.openai_endpoint_utils.post_bytes_no_retry", fake_post_bytes)
+    monkeypatch.setattr("miles.rollout.generate_utils.openai_endpoint_utils.post", fake_post)
+
+    tracer = OpenAIEndpointTracer(
+        router_url="http://127.0.0.1:12345", session_id="sid-1", samples_wire_fields=COMPUTED_FIELDS_V2
+    )
+    input_sample = Sample()
+    input_sample.metadata = {"env": "keep-me"}
+    result = await tracer.collect_samples(input_sample, max_seq_len=7, agent_metadata={"reward": 0.75})
+
+    assert seen == [{"max_seq_len": 7, "metadata": {"reward": 0.75}}]
+    (decoded,) = result.samples
+    assert decoded.reward == 0.75
+    assert decoded.metadata == {"env": "keep-me", "leaf": {"node_id": 1}}
+
+
+@pytest.mark.asyncio
+async def test_create_selects_wire_fields_by_session_server_version(monkeypatch):
+    from miles.rollout.session.samples.codec import COMPUTED_FIELDS, COMPUTED_FIELDS_V2
+
+    async def fake_post(url: str, payload: dict, action: str = "post"):
+        return {"session_id": "sid-x"}
+
+    monkeypatch.setattr("miles.rollout.generate_utils.openai_endpoint_utils.post", fake_post)
+
+    def args(version):
+        return SimpleNamespace(session_server_ip="127.0.0.1", session_server_ports=[7000], use_session_server=version)
+
+    assert (await OpenAIEndpointTracer.create(args(True))).samples_wire_fields == COMPUTED_FIELDS
+    assert (await OpenAIEndpointTracer.create(args("v2"))).samples_wire_fields == COMPUTED_FIELDS_V2

--- a/tests/fast/rollout/inference_rollout/integration/test_multi_turn.py
+++ b/tests/fast/rollout/inference_rollout/integration/test_multi_turn.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 import pytest
-from tests.fast.fixtures.generation_fixtures import extra_argv_for_variant
+from tests.fast.fixtures.generation_fixtures import extra_argv_for_variant, listify
 from tests.fast.fixtures.rollout_fixtures import RolloutEnvConfig
 from tests.fast.rollout.inference_rollout.integration.utils import MODULAR_ROLLOUT_BASE_ARGV, load_and_call_rollout
 
@@ -56,8 +56,11 @@ def test_rollout(rollout_env, variant, test_type):
 
 def _verify_samples(variant: str, samples: list[Any]):
     assert len(samples) == 2, f"n_samples_per_prompt=2, so group should have 2 samples, got {len(samples)}"
-    for sample in samples:
-        assert isinstance(sample, Sample), f"{variant} returns a scalar Sample per generate"
+    for generated in samples:
+        [sample] = listify(generated)
+        assert isinstance(sample, Sample), f"{variant} should return Sample trajectories"
+        if variant == "agentic_tool_call":
+            assert "leaf" in sample.metadata, "session server v2 should attach leaf metadata"
         _verify_sample(sample)
 
 

--- a/tests/fast/router/conftest.py
+++ b/tests/fast/router/conftest.py
@@ -1,0 +1,8 @@
+"""Shared fixtures for router tests.
+
+The class-scoped ``router_env`` (mock SGLang upstream + session server) is
+defined in test_sessions.py; re-exported here so additive test modules can
+depend on it without importing a name their own test signatures would shadow.
+"""
+
+from tests.fast.router.test_sessions import router_env  # noqa: F401

--- a/tests/fast/router/session_pretokenized_test_utils.py
+++ b/tests/fast/router/session_pretokenized_test_utils.py
@@ -49,8 +49,11 @@ def make_router_env(
         hf_checkpoint=hf_checkpoint,
         chat_template_path=chat_template_path,
         tito_model=tito_model,
+        use_session_server="v2",
         use_rollout_routing_replay=False,
         sglang_speculative_algorithm=None,
+        session_sample_picker_path="miles.rollout.session.v2.picker_hub.drop_retries",
+        session_sample_postprocessor_path="miles.rollout.session.v2.postprocessor_hub.default_postprocess",
     )
     session_server = SessionServer(args, backend_url=backend.url)
 

--- a/tests/fast/router/test_session_pretokenized_e2e.py
+++ b/tests/fast/router/test_session_pretokenized_e2e.py
@@ -144,6 +144,7 @@ def test_bundled_fixed_template_session_smoke(config: FixedTemplateSmokeConfig):
 
             session_payload = fetch_session_payload(env.url, session_id)
             metadata = session_payload["metadata"]
+            assert len(metadata["tree"]["nodes"]) == turn_idx + 1
             remote_mismatch = metadata.get("tito_session_mismatch", [])
             local_mismatch = compute_local_session_mismatch(
                 tokenizer,

--- a/tests/fast/router/test_session_samples_op_v2.py
+++ b/tests/fast/router/test_session_samples_op_v2.py
@@ -1,0 +1,685 @@
+"""Samples-op tests: golden assembled Samples plus the op-level error/route contracts.
+
+Drives `SessionCoreV2.collect_samples` in-process against a real tokenizer (the
+`test_sessions.py` precedent), with records injected via the registry — the
+broken-chain and R3 fixtures cannot be produced through the chat path. The
+HTTP surface (route registration order, 404 mapping) is exercised through the
+real `setup_session_routes` app with a `TestClient`.
+
+The golden tests assert the exact `Sample` field values derivable from the
+two-turn records fixture — through `collect_samples` → `decode_samples_and_merge_input_sample`
+overlay → the driver-side metadata application `agentic_tool_call.generate`
+performs — including the template-field overlay and the metadata application
+order (agent metadata overrides the input's keys; session metadata, applied
+last, overrides the agent's).
+"""
+
+import json
+import logging
+import uuid
+from copy import deepcopy
+from types import SimpleNamespace
+
+import numpy as np
+import pybase64
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from tests.fast.rollout.session.test_samples import _make_record
+
+from miles.rollout.session.errors import TokenizationError
+from miles.rollout.session.samples.codec import COMPUTED_FIELDS_V2, decode_samples_and_merge_input_sample
+from miles.rollout.session.sessions import setup_session_routes
+from miles.rollout.session.v2.core import SessionCoreV2
+from miles.rollout.session.v2.session_state import SessionRegistryV2
+from miles.utils.chat_template_utils import get_tito_tokenizer
+from miles.utils.misc import function_registry
+from miles.utils.processing_utils import load_tokenizer
+from miles.utils.types import Sample
+
+NUM_LAYERS = 3
+TOPK = 2
+
+_ARGS = SimpleNamespace(
+    use_session_server="v2",
+    miles_router_timeout=30,
+    hf_checkpoint="Qwen/Qwen3-0.6B",
+    chat_template_path=None,
+    apply_chat_template_kwargs={"enable_thinking": False},
+    tito_model="default",
+    sglang_speculative_algorithm=None,
+    session_server_instance_id=uuid.uuid4().hex,
+    save_debug_trajectory_data=None,
+    session_sample_picker_path="miles.rollout.session.v2.picker_hub.drop_retries",
+    session_sample_postprocessor_path="miles.rollout.session.v2.postprocessor_hub.default_postprocess",
+    num_layers=NUM_LAYERS,
+    moe_router_topk=TOPK,
+)
+
+
+class _UnusedBackend:
+    """collect_samples never proxies; any backend call is a test bug."""
+
+    async def do_proxy(self, *args, **kwargs):
+        raise AssertionError("collect_samples must not touch the proxy backend")
+
+
+def _build_core() -> SessionCoreV2:
+    # Mirrors setup_session_routes (sessions.py): tokenizer + registry + core.
+    tokenizer = load_tokenizer(
+        _ARGS.hf_checkpoint, chat_template_path=_ARGS.chat_template_path, trust_remote_code=True
+    )
+    tito_tokenizer = get_tito_tokenizer(
+        tokenizer,
+        tokenizer_type=_ARGS.tito_model,
+        chat_template_kwargs=_ARGS.apply_chat_template_kwargs,
+    )
+    registry = SessionRegistryV2(_ARGS, tokenizer, tito_tokenizer=tito_tokenizer)
+    return SessionCoreV2(_UnusedBackend(), registry, _ARGS, _ARGS.session_server_instance_id)
+
+
+@pytest.fixture(scope="module")
+def core():
+    return _build_core()
+
+
+# ── fixtures: a two-turn trajectory with R3 / cache stats / weight versions ──
+
+
+def _r3_b64(num_tokens: int, seed: int) -> str:
+    arr = np.arange(seed, seed + num_tokens * NUM_LAYERS * TOPK, dtype=np.int32)
+    return pybase64.b64encode(arr.tobytes()).decode("ascii")
+
+
+def _two_turn_records():
+    # R3 buffer length per record = (len(prompt) + len(output) - 1) * layers * topk.
+    return [
+        _make_record(
+            prompt_token_ids=[1, 2, 3],
+            output_token_ids=[10, 11],
+            output_log_probs=[-0.125, -0.25],
+            cached_tokens=0,
+            prompt_tokens=3,
+            weight_version="w1",
+            routed_experts=_r3_b64(4, seed=0),
+        ),
+        _make_record(
+            prompt_token_ids=[1, 2, 3, 10, 11, 20, 21],
+            output_token_ids=[30, 31],
+            output_log_probs=[-0.5, -1.0],
+            cached_tokens=5,
+            prompt_tokens=7,
+            weight_version="w2",
+            routed_experts=_r3_b64(8, seed=100),
+        ),
+    ]
+
+
+_ACCUMULATED = [1, 2, 3, 10, 11, 20, 21, 30, 31]
+
+
+def _input_sample() -> Sample:
+    return Sample(
+        group_index=4,
+        index=9,
+        prompt=[{"role": "user", "content": "hi"}],
+        label="lbl",
+        reward=2.5,
+        metadata={"task": "t1", "shared_key": "from-input"},
+        routing_key="routing-sid",
+        train_metadata={"loss": "ppo"},
+        generate_function_path="gen.fn",
+    )
+
+
+# Overlapping keys lock the application order: agent overrides the input's
+# shared_key; session_metadata (applied last) overrides the agent's
+# max_trim_tokens plant.
+_AGENT_METADATA = {"shared_key": "from-agent", "agent_only": 1, "accumulated_token_ids": "agent-plant"}
+
+
+async def _make_session(core, records, accumulated) -> str:
+    response = await core.create_session()
+    sid = json.loads(response.body)["session_id"]
+    state = core.registry.sessions[sid]
+    for i, record in enumerate(records):
+        last = i == len(records) - 1
+        state.active_leaf = state.tree.create_node(
+            state.active_leaf,
+            delta_messages=[],
+            token_ids=list(accumulated) if (last and accumulated is not None) else [],
+            completion_span=(0, 0),
+            committed_at=record.timestamp,
+            response_id="",
+            record=record,
+            finish_reason="",
+        )
+    return sid
+
+
+async def _collect_via_op(core, sid, *, max_seq_len=None, agent_metadata=None):
+    response = await core.collect_samples(sid, max_seq_len=max_seq_len, agent_metadata=agent_metadata)
+    return response.status_code, response.body
+
+
+def _new_pipeline(payload, input_sample):
+    """What the driver does with the reply: decode only — per-sample metadata
+    and rewards arrive already applied by the server-side post-process."""
+    reply = decode_samples_and_merge_input_sample(payload, input_sample, fields=COMPUTED_FIELDS_V2)
+    return reply.samples, reply
+
+
+# ── golden assembly: exact expected Samples for the two-turn fixture ──
+
+
+def _expected_r3(seed: int, num_tokens: int):
+    return np.arange(seed, seed + num_tokens * NUM_LAYERS * TOPK, dtype=np.int32).reshape(num_tokens, NUM_LAYERS, TOPK)
+
+
+async def test_assembled_samples_golden_merged(core):
+    """Turns merge into one trajectory Sample; the env tokens between turns
+    get zero loss/logprob; the last turn's R3 is kept."""
+    sid = await _make_session(core, _two_turn_records(), _ACCUMULATED)
+    status, payload = await _collect_via_op(core, sid, agent_metadata=_AGENT_METADATA)
+    assert status == 200
+    samples, reply = _new_pipeline(payload, _input_sample())
+    (m,) = samples
+    tokenizer = core.registry.tokenizer
+
+    assert m.tokens == _ACCUMULATED
+    assert m.response == tokenizer.decode([10, 11]) + tokenizer.decode([20, 21]) + tokenizer.decode([30, 31])
+    assert m.response_length == 6
+    assert m.loss_mask == [1, 1, 0, 0, 1, 1]
+    assert m.rollout_log_probs == [-0.125, -0.25, 0.0, 0.0, -0.5, -1.0]
+    assert m.status == Sample.Status.COMPLETED
+    assert m.weight_versions == ["w1", "w2"]
+    assert np.array_equal(m.rollout_routed_experts, _expected_r3(100, 8))
+    assert m.prefix_cache_info.to_dict() == {"cached_tokens": 5, "total_prompt_tokens": 10}
+    # Overlay: template fields are the driver's, untouched by the wire.
+    assert m.prompt == [{"role": "user", "content": "hi"}]
+    assert m.label == "lbl"
+    assert m.reward == 2.5
+    assert m.routing_key == "routing-sid"
+    assert m.train_metadata == {"loss": "ppo"}
+    assert m.metadata["task"] == "t1"
+    # Metadata layering (server-side post-process, wire-carried): the agent's
+    # semantic layer overrides the input's shared_key; the server's flat keys
+    # land last, so the agent's accumulated_token_ids plant cannot survive.
+    assert m.metadata["shared_key"] == "from-agent"
+    assert m.metadata["agent_only"] == 1
+    assert m.metadata["accumulated_token_ids"] == _ACCUMULATED
+    assert reply.session_metadata["agent"] == _AGENT_METADATA
+
+
+async def test_truncation_golden(core):
+    """max_seq_len=8 strips one output token off the second turn (a turn-level
+    budget applied before merge): the merged sample ends TRUNCATED at 8 tokens
+    with its per-token fields (including R3) trimmed in lockstep."""
+    sid = await _make_session(core, _two_turn_records(), _ACCUMULATED)
+    status, payload = await _collect_via_op(core, sid, max_seq_len=8)
+    assert status == 200
+    samples, _ = _new_pipeline(payload, _input_sample())
+
+    (last,) = samples
+    assert last.status == Sample.Status.TRUNCATED
+    assert last.tokens == _ACCUMULATED[:8]
+    assert last.loss_mask == [1, 1, 0, 0, 1]
+    assert last.rollout_log_probs == [-0.125, -0.25, 0.0, 0.0, -0.5]
+    assert np.array_equal(last.rollout_routed_experts, _expected_r3(100, 8)[:-1])
+
+
+async def test_session_metadata_matches_get_session(core):
+    """The samples reply and the records GET must expose the same metadata dict
+    (both are built by the extracted _session_metadata helper)."""
+    sid = await _make_session(core, _two_turn_records(), _ACCUMULATED)
+    _, payload = await _collect_via_op(core, sid)
+    reply = decode_samples_and_merge_input_sample(payload, Sample(), fields=COMPUTED_FIELDS_V2)
+
+    response = await core.get_session(sid)
+    assert response.status_code == 200
+    assert reply.session_metadata == json.loads(response.body)["metadata"]
+    assert reply.session_metadata["accumulated_token_ids"] == _ACCUMULATED
+
+
+# ── empty_reason discriminator ──
+
+
+async def test_no_records_reply(core):
+    sid = await _make_session(core, [], None)
+    status, payload = await _collect_via_op(core, sid)
+    assert status == 200
+    reply = decode_samples_and_merge_input_sample(payload, Sample(), fields=COMPUTED_FIELDS_V2)
+    assert reply.samples == [] and reply.empty_reason == "no_records"
+
+
+async def test_all_truncated_reply(core):
+    # max_seq_len=2 < the first turn's prompt+1: truncate_samples_by_total_tokens
+    # drops every turn -> empty samples with the all_truncated reason; the old
+    # pipeline returns [] on the same fixture (today's ABORTED path).
+    records = _two_turn_records()
+    sid = await _make_session(core, records, _ACCUMULATED)
+    status, payload = await _collect_via_op(core, sid, max_seq_len=2)
+    assert status == 200
+    reply = decode_samples_and_merge_input_sample(payload, Sample(), fields=COMPUTED_FIELDS_V2)
+    assert reply.samples == [] and reply.empty_reason == "all_truncated"
+
+
+# ── the 422 lane ──
+
+
+async def test_broken_chain_returns_422_and_server_survives(core):
+    # The accumulated sequence carries one token the records never produced ->
+    # the cursor consistency assert fires -> 422 with the assertion text, and
+    # the server keeps serving (the failure never escapes as an unhandled 500).
+    sid = await _make_session(core, _two_turn_records(), _ACCUMULATED + [99])
+    status, payload = await _collect_via_op(core, sid)
+    assert status == 422
+    assert "cursor" in payload.decode()
+
+    health = await core.health()
+    assert health.status_code == 200
+
+
+# ── the tree data plane: branches, trims, exactly-once, rewards ──
+
+
+def _single_turn_record(prompt_ids, output_ids, weight_version="w1"):
+    return _make_record(
+        prompt_token_ids=list(prompt_ids),
+        output_token_ids=list(output_ids),
+        output_log_probs=[-0.1] * len(output_ids),
+        cached_tokens=0,
+        prompt_tokens=len(prompt_ids),
+        weight_version=weight_version,
+        routed_experts=_r3_b64(len(prompt_ids) + len(output_ids) - 1, seed=0),
+    )
+
+
+def _fabricate_node(state, parent, record, token_ids, *, completion_span, response_id="", committed_at=None):
+    return state.tree.create_node(
+        parent,
+        delta_messages=[],
+        token_ids=list(token_ids),
+        completion_span=completion_span,
+        committed_at=float(len(state.tree.nodes)) if committed_at is None else committed_at,
+        response_id=response_id,
+        record=record,
+        finish_reason="stop",
+    )
+
+
+async def _fresh_state(core):
+    response = await core.create_session()
+    sid = json.loads(response.body)["session_id"]
+    return sid, core.registry.sessions[sid]
+
+
+async def test_superseded_retry_leaf_is_trimmed(core):
+    """A childless leaf with a later sibling is retry noise: one sample out."""
+    sid, state = await _fresh_state(core)
+    root = _fabricate_node(
+        state, None, _single_turn_record([1, 2, 3], [10, 11]), [1, 2, 3, 10, 11], completion_span=(3, 5)
+    )
+    _fabricate_node(  # abandoned attempt
+        state,
+        root,
+        _single_turn_record([1, 2, 3, 10, 11, 20], [30]),
+        [1, 2, 3, 10, 11, 20, 30],
+        completion_span=(6, 7),
+    )
+    retry = _fabricate_node(  # the retry that superseded it
+        state,
+        root,
+        _single_turn_record([1, 2, 3, 10, 11, 21], [31]),
+        [1, 2, 3, 10, 11, 21, 31],
+        completion_span=(6, 7),
+    )
+    state.active_leaf = retry
+
+    status, payload = await _collect_via_op(core, sid)
+    assert status == 200
+    reply = decode_samples_and_merge_input_sample(payload, Sample(), fields=COMPUTED_FIELDS_V2)
+    (m,) = reply.samples
+    assert m.tokens == [1, 2, 3, 10, 11, 21, 31]
+
+
+@pytest.mark.parametrize("trajectory_reward", [1.0, 0.0])
+async def test_deep_abandoned_branch_survives_and_masks_shared_prefix(core, trajectory_reward):
+    """A deep abandoned branch is data (subagent shape): two samples, and the
+    shared root completion trains exactly once (earliest leaf owns it)."""
+    sid, state = await _fresh_state(core)
+    root = _fabricate_node(
+        state, None, _single_turn_record([1, 2, 3], [10, 11]), [1, 2, 3, 10, 11], completion_span=(3, 5)
+    )
+    early_mid = _fabricate_node(
+        state,
+        root,
+        _single_turn_record([1, 2, 3, 10, 11, 20], [30]),
+        [1, 2, 3, 10, 11, 20, 30],
+        completion_span=(6, 7),
+    )
+    early_leaf = _fabricate_node(
+        state,
+        early_mid,
+        _single_turn_record([1, 2, 3, 10, 11, 20, 30, 40], [50]),
+        [1, 2, 3, 10, 11, 20, 30, 40, 50],
+        completion_span=(8, 9),
+        response_id="early",
+    )
+    late_leaf = _fabricate_node(
+        state,
+        root,
+        _single_turn_record([1, 2, 3, 10, 11, 21], [31]),
+        [1, 2, 3, 10, 11, 21, 31],
+        completion_span=(6, 7),
+        response_id="late",
+    )
+    state.active_leaf = late_leaf
+
+    status, payload = await _collect_via_op(core, sid, agent_metadata={"reward": trajectory_reward})
+    assert status == 200
+    reply = decode_samples_and_merge_input_sample(payload, Sample(), fields=COMPUTED_FIELDS_V2)
+    early_sample, late_sample = reply.samples
+    assert early_sample.tokens == early_leaf.token_ids
+    assert late_sample.tokens == late_leaf.token_ids
+    # The early leaf owns the shared root completion [3,5); the late leaf masks it.
+    assert early_sample.loss_mask[:2] == [1, 1]
+    assert late_sample.loss_mask[:2] == [0, 0]
+    assert late_sample.loss_mask[-1] == 1  # its own completion still trains
+    assert [sample.reward for sample in reply.samples] == [trajectory_reward, trajectory_reward]
+    assert [sample.metadata["reward"] for sample in reply.samples] == [trajectory_reward, trajectory_reward]
+
+
+async def test_picker_warns_and_trims_longer_superseded_leaf(core, caplog):
+    """A longer superseded leaf warns, then temporal order still trims it."""
+    sid, state = await _fresh_state(core)
+    root = _fabricate_node(
+        state, None, _single_turn_record([1, 2, 3], [10, 11]), [1, 2, 3, 10, 11], completion_span=(3, 5)
+    )
+    _fabricate_node(  # abandoned but LONGER than the retry
+        state,
+        root,
+        _single_turn_record([1, 2, 3, 10, 11, 20], [30, 31, 32]),
+        [1, 2, 3, 10, 11, 20, 30, 31, 32],
+        completion_span=(6, 9),
+    )
+    retry = _fabricate_node(
+        state,
+        root,
+        _single_turn_record([1, 2, 3, 10, 11, 21], [31]),
+        [1, 2, 3, 10, 11, 21, 31],
+        completion_span=(6, 7),
+    )
+    state.active_leaf = retry
+
+    with caplog.at_level(logging.WARNING, logger="miles.rollout.session.v2.picker_hub.drop_retries"):
+        status, payload = await _collect_via_op(core, sid)
+    assert status == 200
+    reply = decode_samples_and_merge_input_sample(payload, Sample(), fields=COMPUTED_FIELDS_V2)
+    (sample,) = reply.samples
+    assert sample.tokens == retry.token_ids
+    assert "longer than every later sibling's deepest leaf" in caplog.text
+    assert "continuing by seq" in caplog.text
+
+
+async def test_picker_warns_on_wall_clock_rollback_and_trims_by_seq(core, caplog):
+    """A later `seq` with an earlier wall clock warns without changing the trim."""
+    sid, state = await _fresh_state(core)
+    root = _fabricate_node(
+        state, None, _single_turn_record([1, 2, 3], [10, 11]), [1, 2, 3, 10, 11], completion_span=(3, 5)
+    )
+    _fabricate_node(
+        state,
+        root,
+        _single_turn_record([1, 2, 3, 10, 11, 20], [30]),
+        [1, 2, 3, 10, 11, 20, 30],
+        completion_span=(6, 7),
+        committed_at=10.0,
+    )
+    retry = _fabricate_node(
+        state,
+        root,
+        _single_turn_record([1, 2, 3, 10, 11, 21], [31]),
+        [1, 2, 3, 10, 11, 21, 31],
+        completion_span=(6, 7),
+        committed_at=5.0,
+    )
+    state.active_leaf = retry
+
+    with caplog.at_level(logging.WARNING, logger="miles.rollout.session.v2.picker_hub.drop_retries"):
+        status, payload = await _collect_via_op(core, sid)
+    assert status == 200
+    reply = decode_samples_and_merge_input_sample(payload, Sample(), fields=COMPUTED_FIELDS_V2)
+    (sample,) = reply.samples
+    assert sample.tokens == retry.token_ids
+    assert "wall-clock rollback" in caplog.text
+    assert "continuing by seq" in caplog.text
+    assert "longer than every later sibling" not in caplog.text
+
+
+async def test_two_roots_yield_two_samples(core):
+    """Zero-overlap branches (subagent forest) each assemble independently."""
+    sid, state = await _fresh_state(core)
+    main = _fabricate_node(
+        state, None, _single_turn_record([1, 2, 3], [10, 11]), [1, 2, 3, 10, 11], completion_span=(3, 5)
+    )
+    sub = _fabricate_node(state, None, _single_turn_record([7, 8], [70, 71]), [7, 8, 70, 71], completion_span=(2, 4))
+    state.active_leaf = sub
+
+    status, payload = await _collect_via_op(core, sid)
+    assert status == 200
+    reply = decode_samples_and_merge_input_sample(payload, Sample(), fields=COMPUTED_FIELDS_V2)
+    first, second = reply.samples
+    assert first.tokens == sub.token_ids
+    assert second.tokens == main.token_ids
+    tree = reply.session_metadata["tree"]
+    assert [n["parent"] for n in tree["nodes"]] == [None, None]
+    assert [leaf["node_id"] for leaf in tree["leaves"]] == [main.seq, sub.seq]
+    assert [first.reward, second.reward] == [None, None]
+
+
+async def test_picker_orders_by_checkpoint_count_then_latest_commit(core):
+    sid, state = await _fresh_state(core)
+    root = _fabricate_node(state, None, _single_turn_record([1], [10]), [1, 10], completion_span=(1, 2))
+    deep = _fabricate_node(
+        state,
+        root,
+        _single_turn_record([1, 10, 20], [30]),
+        [1, 10, 20, 30],
+        completion_span=(3, 4),
+    )
+    shallow_early = _fabricate_node(
+        state,
+        None,
+        _single_turn_record([100, 101, 102, 103], [104, 105, 106, 107]),
+        [100, 101, 102, 103, 104, 105, 106, 107],
+        completion_span=(4, 8),
+    )
+    shallow_late = _fabricate_node(
+        state,
+        None,
+        _single_turn_record([200, 201, 202, 203], [204, 205, 206]),
+        [200, 201, 202, 203, 204, 205, 206],
+        completion_span=(4, 7),
+    )
+    state.active_leaf = shallow_late
+
+    status, payload = await _collect_via_op(core, sid)
+    assert status == 200
+    reply = decode_samples_and_merge_input_sample(payload, Sample(), fields=COMPUTED_FIELDS_V2)
+    assert len(deep.path_nodes()) == 2
+    assert len(shallow_early.path_nodes()) == len(shallow_late.path_nodes()) == 1
+    assert len(deep.token_ids) < len(shallow_late.token_ids) < len(shallow_early.token_ids)
+    assert [sample.metadata["leaf"]["node_id"] for sample in reply.samples] == [
+        deep.seq,
+        shallow_late.seq,
+        shallow_early.seq,
+    ]
+
+
+# ── the hook layer: custom pick/post-process, contract enforcement ──
+
+
+def _keep_all_picker(leaf_samples, session_metadata):
+    return list(leaf_samples)
+
+
+def _reverse_picker(leaf_samples, session_metadata):
+    return list(reversed(leaf_samples))
+
+
+def _duplicate_picker(leaf_samples, session_metadata):
+    return [leaf_samples[0], leaf_samples[0]]
+
+
+def _exploding_picker(leaf_samples, session_metadata):
+    raise RuntimeError("policy bug")
+
+
+def _impure_picker(leaf_samples, session_metadata):
+    return [deepcopy(leaf_samples[0])]
+
+
+async def _exploding_async_picker(leaf_samples, session_metadata):
+    return leaf_samples
+
+
+def _build_core_with_hooks(**hook_args) -> SessionCoreV2:
+    args = SimpleNamespace(**{**vars(_ARGS), **hook_args})
+    tokenizer = load_tokenizer(args.hf_checkpoint, chat_template_path=args.chat_template_path, trust_remote_code=True)
+    tito_tokenizer = get_tito_tokenizer(
+        tokenizer,
+        tokenizer_type=args.tito_model,
+        chat_template_kwargs=args.apply_chat_template_kwargs,
+    )
+    registry = SessionRegistryV2(args, tokenizer, tito_tokenizer=tito_tokenizer)
+    return SessionCoreV2(_UnusedBackend(), registry, args, args.session_server_instance_id)
+
+
+async def _retry_shaped_session(core):
+    sid, state = await _fresh_state(core)
+    root = _fabricate_node(
+        state, None, _single_turn_record([1, 2, 3], [10, 11]), [1, 2, 3, 10, 11], completion_span=(3, 5)
+    )
+    _fabricate_node(
+        state,
+        root,
+        _single_turn_record([1, 2, 3, 10, 11, 20], [30]),
+        [1, 2, 3, 10, 11, 20, 30],
+        completion_span=(6, 7),
+    )
+    retry = _fabricate_node(
+        state,
+        root,
+        _single_turn_record([1, 2, 3, 10, 11, 21], [31]),
+        [1, 2, 3, 10, 11, 21, 31],
+        completion_span=(6, 7),
+    )
+    state.active_leaf = retry
+    return sid
+
+
+async def test_custom_picker_keeps_abandoned_leaf(core):
+    """A tree-RL style picker keeps everything: the abandoned retry leaf
+    becomes a second sample instead of being trimmed."""
+    with function_registry.temporary("test_hooks.keep_all", _keep_all_picker):
+        hooked = _build_core_with_hooks(session_sample_picker_path="test_hooks.keep_all")
+        sid = await _retry_shaped_session(hooked)
+        response = await hooked.collect_samples(sid, max_seq_len=None)
+        assert response.status_code == 200
+        reply = decode_samples_and_merge_input_sample(bytes(response.body), Sample(), fields=COMPUTED_FIELDS_V2)
+        abandoned, retry = reply.samples
+        assert abandoned.tokens == [1, 2, 3, 10, 11, 20, 30]
+        assert retry.tokens == [1, 2, 3, 10, 11, 21, 31]
+        # Exactly-once over the SURVIVING set: the abandoned (earlier) leaf now
+        # owns the shared root completion; the retry masks it.
+        assert abandoned.loss_mask[:2] == [1, 1]
+        assert retry.loss_mask[:2] == [0, 0]
+
+
+async def test_custom_picker_reorder_keeps_earliest_leaf_as_owner(core):
+    with function_registry.temporary("test_hooks.reverse", _reverse_picker):
+        hooked = _build_core_with_hooks(session_sample_picker_path="test_hooks.reverse")
+        sid = await _retry_shaped_session(hooked)
+        response = await hooked.collect_samples(sid, max_seq_len=None)
+        assert response.status_code == 200
+        reply = decode_samples_and_merge_input_sample(bytes(response.body), Sample(), fields=COMPUTED_FIELDS_V2)
+        retry, abandoned = reply.samples
+        assert retry.loss_mask[:2] == [0, 0]
+        assert abandoned.loss_mask[:2] == [1, 1]
+
+
+async def test_hook_exception_maps_to_422_with_identity(core):
+    with function_registry.temporary("test_hooks.exploding", _exploding_picker):
+        hooked = _build_core_with_hooks(session_sample_picker_path="test_hooks.exploding")
+        sid = await _retry_shaped_session(hooked)
+        response = await hooked.collect_samples(sid, max_seq_len=None)
+        assert response.status_code == 422
+        body = bytes(response.body).decode()
+        assert "test_hooks.exploding" in body and "policy bug" in body
+
+
+async def test_impure_picker_maps_to_422(core):
+    with function_registry.temporary("test_hooks.impure", _impure_picker):
+        hooked = _build_core_with_hooks(session_sample_picker_path="test_hooks.impure")
+        sid = await _retry_shaped_session(hooked)
+        response = await hooked.collect_samples(sid, max_seq_len=None)
+        assert response.status_code == 422
+        assert "subset" in bytes(response.body).decode()
+
+
+async def test_duplicate_picker_maps_to_422(core):
+    with function_registry.temporary("test_hooks.duplicate", _duplicate_picker):
+        hooked = _build_core_with_hooks(session_sample_picker_path="test_hooks.duplicate")
+        sid = await _retry_shaped_session(hooked)
+        response = await hooked.collect_samples(sid, max_seq_len=None)
+        assert response.status_code == 422
+        assert "duplicates" in bytes(response.body).decode()
+
+
+async def test_agent_cannot_fill_missing_server_metadata(core, monkeypatch):
+    def fail_mismatch(*args, **kwargs):
+        raise TokenizationError("test mismatch failure")
+
+    monkeypatch.setattr(core.registry, "compute_mismatch", fail_mismatch)
+    sid = await _make_session(core, _two_turn_records(), _ACCUMULATED)
+    status, payload = await _collect_via_op(core, sid, agent_metadata={"tito_session_mismatch": ["agent-plant"]})
+    assert status == 200
+    reply = decode_samples_and_merge_input_sample(payload, Sample(), fields=COMPUTED_FIELDS_V2)
+    (sample,) = reply.samples
+    assert "tito_session_mismatch" not in sample.metadata
+
+
+def test_async_hook_rejected_at_load():
+    with function_registry.temporary("test_hooks.async_picker", _exploding_async_picker):
+        with pytest.raises(ValueError, match="async"):
+            _build_core_with_hooks(session_sample_picker_path="test_hooks.async_picker")
+
+
+# ── the HTTP surface: route order and error mapping through the real app ──
+
+
+@pytest.fixture(scope="module")
+def app_client():
+    app = FastAPI()
+    setup_session_routes(app, _UnusedBackend(), _ARGS)
+    with TestClient(app) as client:
+        yield client
+
+
+def test_missing_session_returns_404(app_client):
+    response = app_client.post(f"/sessions/{uuid.uuid4().hex}/samples", content=b'{"max_seq_len":null}')
+    assert response.status_code == 404
+    assert "not found" in response.json()["error"]
+
+
+def test_samples_route_registered_before_catch_all_proxy(app_client):
+    # The catch-all session_proxy would forward the request to the inference
+    # backend (_UnusedBackend raises); the samples route must win instead and
+    # answer with a decodable empty reply for a fresh session.
+    sid = app_client.post("/sessions").json()["session_id"]
+    response = app_client.post(f"/sessions/{sid}/samples", content=b'{"max_seq_len":null}')
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "application/octet-stream"
+    reply = decode_samples_and_merge_input_sample(response.content, Sample(), fields=COMPUTED_FIELDS_V2)
+    assert reply.empty_reason == "no_records", "catch-all session_proxy swallowed the samples route"

--- a/tests/fast/router/test_session_state.py
+++ b/tests/fast/router/test_session_state.py
@@ -1,0 +1,934 @@
+"""Unit tests for SessionRegistryV2 and LinearTrajectory.
+
+Tests the session registry CRUD and the trajectory pretokenized state management
+logic in isolation (no HTTP server, no real tokenizer).
+"""
+
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from miles.rollout.session.errors import MessageValidationError, SessionNotFoundError, TokenizationError
+from miles.rollout.session.types import SessionRecord
+from miles.rollout.session.v2.session_state import (
+    SessionRegistryV2,
+    SessionStateV2,
+    commit_generation,
+    position_for_request,
+    prepare_pretokenized,
+)
+from miles.utils.chat_template_utils.tito_tokenizer import FixedTemplate, TITOTokenizer
+
+_MOCK_FIRST_TURN_TOKENS = [0]
+
+
+class _MockTITOTokenizer(TITOTokenizer):
+    """Stub for unit tests: returns pretokenized_token_ids unchanged (no
+    incremental tokens), renders first-turn prompts as a fixed sentinel, and
+    skips real tokenizer operations.
+    """
+
+    def create_comparator(self):
+        return None
+
+    def apply_chat_template(
+        self,
+        messages: list[dict[str, Any]],
+        *,
+        add_generation_prompt: bool,
+        tools: list[dict[str, Any]] | None = None,
+        tokenize: bool = False,
+    ) -> list[int]:
+        return list(_MOCK_FIRST_TURN_TOKENS)
+
+    def tokenize_additional_messages(
+        self,
+        old_messages: list[dict[str, Any]],
+        new_messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None = None,
+    ) -> list[int]:
+        return []
+
+    def merge_tokens(
+        self,
+        old_messages: list[dict[str, Any]],
+        new_messages: list[dict[str, Any]],
+        pretokenized_token_ids: list[int],
+        tools: list[dict[str, Any]] | None = None,
+    ) -> list[int]:
+        return list(pretokenized_token_ids)
+
+
+def _make_mock_tito(tito_cls, allowed_append_roles: list[str]) -> TITOTokenizer:
+    configured_tito_cls = type(
+        f"_Configured{tito_cls.__name__}",
+        (tito_cls,),
+        {"FIXED_TEMPLATE": FixedTemplate(allowed_append_roles=frozenset(allowed_append_roles))},
+    )
+    return configured_tito_cls(tokenizer=None, assistant_start_str="<|im_start|>assistant")
+
+
+def _make_registry(allowed_append_roles: list[str]) -> SessionRegistryV2:
+    args = SimpleNamespace()
+    mock_tito = _make_mock_tito(_MockTITOTokenizer, allowed_append_roles)
+    return SessionRegistryV2(args, tokenizer=None, tito_tokenizer=mock_tito)
+
+
+def _commit(
+    state: SessionStateV2, request_messages, assistant_message, prompt_ids, completion_ids, *, max_trim_tokens=0
+):
+    """Drive one committed generation through the serving surface (record stub)."""
+    record = SessionRecord(
+        timestamp=float(len(state.tree.nodes)),
+        method="POST",
+        path="/v1/chat/completions",
+        status_code=200,
+        request={"messages": list(request_messages)},
+        response={},
+    )
+    return commit_generation(
+        state,
+        parent=state.active_leaf,
+        request_messages=request_messages,
+        assistant_message=assistant_message,
+        prompt_token_ids=prompt_ids,
+        completion_token_ids=completion_ids,
+        max_trim_tokens=max_trim_tokens,
+        record=record,
+        response_id=f"resp-{len(state.tree.nodes)}",
+        finish_reason="stop",
+    )
+
+
+@pytest.fixture
+def registry():
+    """Tool-only registry (explicit: the ctor default is tool+user)."""
+    return _make_registry(allowed_append_roles=["tool"])
+
+
+@pytest.fixture
+def registry_with_system():
+    """Registry that allows both tool and system in appended messages."""
+    return _make_registry(allowed_append_roles=["tool", "system"])
+
+
+@pytest.fixture
+def registry_with_user():
+    """Registry that allows tool and user in appended messages."""
+    return _make_registry(allowed_append_roles=["tool", "user"])
+
+
+class TestSessionCRUD:
+    def test_create_session(self, registry: SessionRegistryV2):
+        session_id = registry.create_session()
+        assert session_id is not None
+        assert len(session_id) == 32
+        assert session_id in registry.sessions
+
+    def test_get_session(self, registry: SessionRegistryV2):
+        session_id = registry.create_session()
+        session = registry.get_session(session_id)
+        assert session.active_records() == []
+
+    def test_get_session_not_found(self, registry: SessionRegistryV2):
+        with pytest.raises(SessionNotFoundError):
+            registry.get_session("nonexistent")
+
+    def test_remove_session(self, registry: SessionRegistryV2):
+        session_id = registry.create_session()
+        registry.remove_session(session_id)  # no raise = success
+        assert session_id not in registry.sessions
+        with pytest.raises(SessionNotFoundError):
+            registry.remove_session(session_id)
+
+    def test_committed_generation_carries_its_record(self, registry: SessionRegistryV2):
+        session_id = registry.create_session()
+        session = registry.get_session(session_id)
+        node = _commit(session, [{"role": "user", "content": "hello"}], ASSISTANT_MSG_1, [1, 2], [10])
+
+        assert len(session.active_records()) == 1
+        assert session.active_records()[0] is node.record
+        assert session.active_records()[0].path == "/v1/chat/completions"
+
+    def test_append_record_missing_session(self, registry: SessionRegistryV2):
+        with pytest.raises(SessionNotFoundError):
+            registry.get_session("missing")
+
+
+# ---------------------------------------------------------------------------
+# Messages for multi-turn pretokenized tests
+# ---------------------------------------------------------------------------
+
+SYS_MSG = {"role": "system", "content": "You are a helpful assistant."}
+USER_MSG = {"role": "user", "content": "What's the weather in Beijing?"}
+ASSISTANT_MSG_1 = {
+    "role": "assistant",
+    "content": None,
+    "tool_calls": [
+        {"id": "call_1", "type": "function", "function": {"name": "get_weather", "arguments": '{"city": "Beijing"}'}}
+    ],
+}
+TOOL_MSG_1 = {"role": "tool", "content": '{"temperature": 25}', "tool_call_id": "call_1"}
+ASSISTANT_MSG_2 = {
+    "role": "assistant",
+    "content": "It's 25\u00b0C in Beijing. Let me also check Shanghai.",
+    "tool_calls": [
+        {"id": "call_2", "type": "function", "function": {"name": "get_weather", "arguments": '{"city": "Shanghai"}'}}
+    ],
+}
+TOOL_MSG_2 = {"role": "tool", "content": '{"temperature": 30}', "tool_call_id": "call_2"}
+ASSISTANT_MSG_FINAL = {"role": "assistant", "content": "Beijing is 25\u00b0C and Shanghai is 30\u00b0C."}
+RETRY_SYS_MSG = {"role": "system", "content": "Please try using the tools to answer."}
+
+
+class TestSingleUserTurnPretokenized:
+    """Test prepare_pretokenized and update_pretokenized_state across turns."""
+
+    def test_first_turn_renders_from_scratch(self, registry: SessionRegistryV2):
+        """First turn has no prior token_ids, so prepare renders from scratch."""
+        sid = registry.create_session()
+        session = registry.get_session(sid)
+        messages = [SYS_MSG, USER_MSG]
+        result = prepare_pretokenized(session, messages, tools=None, tito_tokenizer=registry.tito_tokenizer)
+        assert result == _MOCK_FIRST_TURN_TOKENS
+
+    def test_two_turn_trajectory(self, registry: SessionRegistryV2):
+        """Full 2-turn: user -> assistant(tool_call) -> tool -> final answer."""
+        sid = registry.create_session()
+        session = registry.get_session(sid)
+
+        # --- Turn 1: [sys, user] -> assistant with tool_call ---
+        turn1_messages = [SYS_MSG, USER_MSG]
+        assert (
+            prepare_pretokenized(session, turn1_messages, tools=None, tito_tokenizer=registry.tito_tokenizer)
+            == _MOCK_FIRST_TURN_TOKENS
+        )
+
+        turn1_prompt_ids = [1, 2, 3, 4, 5]
+        turn1_completion_ids = [10, 11, 12]
+        _commit(session, turn1_messages, ASSISTANT_MSG_1, turn1_prompt_ids, turn1_completion_ids, max_trim_tokens=0)
+
+        assert session.active_messages() == [SYS_MSG, USER_MSG, ASSISTANT_MSG_1]
+        assert session.active_token_ids() == [1, 2, 3, 4, 5, 10, 11, 12]
+
+        # --- Turn 2: [sys, user, assistant, tool] -> final answer ---
+        turn2_messages = [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1]
+        result = prepare_pretokenized(session, turn2_messages, tools=None, tito_tokenizer=registry.tito_tokenizer)
+        assert result == [1, 2, 3, 4, 5, 10, 11, 12]
+
+        turn2_prompt_ids = [1, 2, 3, 4, 5, 10, 11, 12, 20, 21]
+        turn2_completion_ids = [30, 31, 32]
+        _commit(
+            session, turn2_messages, ASSISTANT_MSG_FINAL, turn2_prompt_ids, turn2_completion_ids, max_trim_tokens=0
+        )
+
+        assert session.active_messages() == [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1, ASSISTANT_MSG_FINAL]
+        assert session.active_token_ids() == [1, 2, 3, 4, 5, 10, 11, 12, 20, 21, 30, 31, 32]
+
+    def test_three_turn_trajectory(self, registry: SessionRegistryV2):
+        """Full 3-turn: user -> ass(tool) -> tool -> ass(tool) -> tool -> final."""
+        sid = registry.create_session()
+        session = registry.get_session(sid)
+
+        # Turn 1
+        t1_msgs = [SYS_MSG, USER_MSG]
+        _commit(session, t1_msgs, ASSISTANT_MSG_1, [1, 2, 3], [10, 11], max_trim_tokens=0)
+
+        # Turn 2
+        t2_msgs = [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1]
+        result = prepare_pretokenized(session, t2_msgs, tools=None, tito_tokenizer=registry.tito_tokenizer)
+        assert result == [1, 2, 3, 10, 11]
+
+        _commit(session, t2_msgs, ASSISTANT_MSG_2, [1, 2, 3, 10, 11, 20, 21], [30, 31], max_trim_tokens=0)
+
+        # Turn 3
+        t3_msgs = [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1, ASSISTANT_MSG_2, TOOL_MSG_2]
+        result = prepare_pretokenized(session, t3_msgs, tools=None, tito_tokenizer=registry.tito_tokenizer)
+        assert result == [1, 2, 3, 10, 11, 20, 21, 30, 31]
+
+        _commit(
+            session, t3_msgs, ASSISTANT_MSG_FINAL, [1, 2, 3, 10, 11, 20, 21, 30, 31, 40], [50, 51], max_trim_tokens=0
+        )
+
+        assert len(session.active_messages()) == 7  # sys, user, ass1, tool1, ass2, tool2, final
+        assert session.active_token_ids() == [1, 2, 3, 10, 11, 20, 21, 30, 31, 40, 50, 51]
+
+    def test_prefix_mismatch_raises(self, registry: SessionRegistryV2):
+        """update_pretokenized_state asserts stored token_ids is prefix of new."""
+        sid = registry.create_session()
+        session = registry.get_session(sid)
+        _commit(session, [SYS_MSG, USER_MSG], ASSISTANT_MSG_1, [1, 2, 3], [10, 11], max_trim_tokens=0)
+
+        with pytest.raises(TokenizationError, match="pretokenized prefix mismatch"):
+            _commit(
+                session,
+                [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1],
+                ASSISTANT_MSG_FINAL,
+                [9, 9, 9, 20, 21],  # does NOT start with [1,2,3,10,11]
+                [30],
+                max_trim_tokens=0,
+            )
+
+    def test_disallowed_env_role_in_suffix_raises(self, registry: SessionRegistryV2):
+        """The append-role gate still guards env roles (assistants are exempt:
+        they are prompt material for compaction branches)."""
+        sid = registry.create_session()
+        session = registry.get_session(sid)
+        _commit(session, [SYS_MSG, USER_MSG], ASSISTANT_MSG_1, [1, 2, 3], [10], max_trim_tokens=0)
+
+        bad_messages = [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, {"role": "user", "content": "not allowed here"}]
+        position_for_request(session, bad_messages)
+        with pytest.raises(MessageValidationError, match="role=.user.*allowed="):
+            prepare_pretokenized(session, bad_messages, tools=None, tito_tokenizer=registry.tito_tokenizer)
+
+    def test_session_not_found_raises(self, registry: SessionRegistryV2):
+        with pytest.raises(SessionNotFoundError, match="session not found"):
+            registry.get_session("nonexistent")
+
+    def test_no_system_message(self, registry: SessionRegistryV2):
+        """Works without system message (system is optional)."""
+        sid = registry.create_session()
+        session = registry.get_session(sid)
+        msgs = [USER_MSG]
+        _commit(session, msgs, ASSISTANT_MSG_1, [1, 2], [10], max_trim_tokens=0)
+
+        t2_msgs = [USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1]
+        result = prepare_pretokenized(session, t2_msgs, tools=None, tito_tokenizer=registry.tito_tokenizer)
+        assert result == [1, 2, 10]
+
+    def test_multiple_system_messages_at_start(self, registry: SessionRegistryV2):
+        """Multiple system messages before the user message are allowed (part of stored prefix)."""
+        sid = registry.create_session()
+        session = registry.get_session(sid)
+        extra_sys = {"role": "system", "content": "Extra instructions."}
+        msgs = [SYS_MSG, extra_sys, USER_MSG]
+        result = prepare_pretokenized(session, msgs, tools=None, tito_tokenizer=registry.tito_tokenizer)
+        assert result == _MOCK_FIRST_TURN_TOKENS  # first turn, no prior tokens
+
+        _commit(session, msgs, ASSISTANT_MSG_1, [1, 2, 3, 4], [10, 11], max_trim_tokens=0)
+        assert session.active_messages() == [SYS_MSG, extra_sys, USER_MSG, ASSISTANT_MSG_1]
+
+        t2_msgs = [SYS_MSG, extra_sys, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1]
+        result = prepare_pretokenized(session, t2_msgs, tools=None, tito_tokenizer=registry.tito_tokenizer)
+        assert result == [1, 2, 3, 4, 10, 11]
+
+
+# ---------------------------------------------------------------------------
+# TestAppendRole* — allowed_append_roles policy tests
+#
+# Each class tests one configuration: tool-only, tool+system, tool+user
+# (the ctor default).  Tests verify which appended roles are accepted or
+# rejected under each allowed_append_roles setting.
+# ---------------------------------------------------------------------------
+
+
+class TestAppendRoleToolOnly:
+    """Config: allowed_append_roles=['tool']."""
+
+    def test_tool_append_allowed(self, registry: SessionRegistryV2):
+        sid = registry.create_session()
+        session = registry.get_session(sid)
+        _commit(session, [SYS_MSG, USER_MSG], ASSISTANT_MSG_1, [1, 2, 3], [10], max_trim_tokens=0)
+
+        messages = [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1]
+        result = prepare_pretokenized(session, messages, tools=None, tito_tokenizer=registry.tito_tokenizer)
+        assert isinstance(result, list)
+
+    def test_system_append_rejected(self, registry: SessionRegistryV2):
+        sid = registry.create_session()
+        session = registry.get_session(sid)
+        _commit(session, [SYS_MSG, USER_MSG], ASSISTANT_MSG_1, [1, 2, 3], [10, 11], max_trim_tokens=0)
+
+        messages = [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1, RETRY_SYS_MSG]
+        with pytest.raises(MessageValidationError, match="role='system'.*allowed="):
+            prepare_pretokenized(session, messages, tools=None, tito_tokenizer=registry.tito_tokenizer)
+
+    def test_user_append_rejected(self, registry: SessionRegistryV2):
+        sid = registry.create_session()
+        session = registry.get_session(sid)
+        _commit(session, [SYS_MSG, USER_MSG], ASSISTANT_MSG_1, [1, 2, 3], [10], max_trim_tokens=0)
+
+        messages = [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1, {"role": "user", "content": "extra"}]
+        with pytest.raises(MessageValidationError, match="role='user'.*allowed="):
+            prepare_pretokenized(session, messages, tools=None, tito_tokenizer=registry.tito_tokenizer)
+
+
+class TestAppendRoleToolSystem:
+    """Config: allowed_append_roles=['tool', 'system']."""
+
+    def test_tool_append_allowed(self, registry_with_system: SessionRegistryV2):
+        sid = registry_with_system.create_session()
+        session = registry_with_system.get_session(sid)
+        _commit(session, [SYS_MSG, USER_MSG], ASSISTANT_MSG_1, [1, 2, 3], [10], max_trim_tokens=0)
+
+        messages = [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1]
+        result = prepare_pretokenized(
+            session, messages, tools=None, tito_tokenizer=registry_with_system.tito_tokenizer
+        )
+        assert isinstance(result, list)
+
+    def test_system_append_allowed(self, registry_with_system: SessionRegistryV2):
+        sid = registry_with_system.create_session()
+        session = registry_with_system.get_session(sid)
+        _commit(session, [SYS_MSG, USER_MSG], ASSISTANT_MSG_1, [1, 2, 3], [10, 11], max_trim_tokens=0)
+
+        messages = [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1, RETRY_SYS_MSG]
+        result = prepare_pretokenized(
+            session, messages, tools=None, tito_tokenizer=registry_with_system.tito_tokenizer
+        )
+        assert result == [1, 2, 3, 10, 11]
+
+    def test_system_then_assistant_trajectory(self, registry_with_system: SessionRegistryV2):
+        """Full trajectory with a retry system message between tool-call turns."""
+        sid = registry_with_system.create_session()
+        session = registry_with_system.get_session(sid)
+
+        t1_msgs = [SYS_MSG, USER_MSG]
+        _commit(session, t1_msgs, ASSISTANT_MSG_1, [1, 2, 3], [10, 11], max_trim_tokens=0)
+
+        t2_msgs = [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1, RETRY_SYS_MSG]
+        result = prepare_pretokenized(session, t2_msgs, tools=None, tito_tokenizer=registry_with_system.tito_tokenizer)
+        assert isinstance(result, list)
+
+        _commit(session, t2_msgs, ASSISTANT_MSG_2, [1, 2, 3, 10, 11, 20, 21, 22], [30, 31], max_trim_tokens=0)
+        assert session.active_messages() == [
+            SYS_MSG,
+            USER_MSG,
+            ASSISTANT_MSG_1,
+            TOOL_MSG_1,
+            RETRY_SYS_MSG,
+            ASSISTANT_MSG_2,
+        ]
+
+        t3_msgs = [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1, RETRY_SYS_MSG, ASSISTANT_MSG_2, TOOL_MSG_2]
+        result = prepare_pretokenized(session, t3_msgs, tools=None, tito_tokenizer=registry_with_system.tito_tokenizer)
+        assert isinstance(result, list)
+
+    def test_user_append_rejected(self, registry_with_system: SessionRegistryV2):
+        sid = registry_with_system.create_session()
+        session = registry_with_system.get_session(sid)
+        _commit(session, [SYS_MSG, USER_MSG], ASSISTANT_MSG_1, [1, 2, 3], [10], max_trim_tokens=0)
+
+        messages = [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1, {"role": "user", "content": "extra"}]
+        with pytest.raises(MessageValidationError, match="role='user'.*allowed="):
+            prepare_pretokenized(session, messages, tools=None, tito_tokenizer=registry_with_system.tito_tokenizer)
+
+
+class TestAppendRoleToolUser:
+    """Config: allowed_append_roles=['tool', 'user']; user follow-ups are allowed here."""
+
+    def test_tool_append_allowed(self, registry_with_user: SessionRegistryV2):
+        sid = registry_with_user.create_session()
+        session = registry_with_user.get_session(sid)
+        _commit(session, [SYS_MSG, USER_MSG], ASSISTANT_MSG_1, [1, 2, 3], [10], max_trim_tokens=0)
+
+        messages = [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1]
+        result = prepare_pretokenized(session, messages, tools=None, tito_tokenizer=registry_with_user.tito_tokenizer)
+        assert isinstance(result, list)
+
+    def test_user_append_allowed(self, registry_with_user: SessionRegistryV2):
+        sid = registry_with_user.create_session()
+        session = registry_with_user.get_session(sid)
+        _commit(session, [SYS_MSG, USER_MSG], ASSISTANT_MSG_1, [1, 2, 3], [10], max_trim_tokens=0)
+
+        messages = [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1, {"role": "user", "content": "follow-up"}]
+        result = prepare_pretokenized(session, messages, tools=None, tito_tokenizer=registry_with_user.tito_tokenizer)
+        assert isinstance(result, list)
+
+    def test_user_then_assistant_trajectory(self, registry_with_user: SessionRegistryV2):
+        """Full trajectory: tool → user follow-up → assistant → tool → final."""
+        sid = registry_with_user.create_session()
+        session = registry_with_user.get_session(sid)
+
+        # Turn 1: [sys, user] -> assistant(tool_call)
+        t1_msgs = [SYS_MSG, USER_MSG]
+        _commit(session, t1_msgs, ASSISTANT_MSG_1, [1, 2, 3], [10, 11], max_trim_tokens=0)
+
+        # Turn 2: append tool + user follow-up -> assistant(tool_call)
+        follow_up = {"role": "user", "content": "Also check Shanghai."}
+        t2_msgs = [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1, follow_up]
+        result = prepare_pretokenized(session, t2_msgs, tools=None, tito_tokenizer=registry_with_user.tito_tokenizer)
+        assert isinstance(result, list)
+
+        _commit(session, t2_msgs, ASSISTANT_MSG_2, [1, 2, 3, 10, 11, 20, 21, 22], [30, 31], max_trim_tokens=0)
+        assert session.active_messages() == [
+            SYS_MSG,
+            USER_MSG,
+            ASSISTANT_MSG_1,
+            TOOL_MSG_1,
+            follow_up,
+            ASSISTANT_MSG_2,
+        ]
+
+        # Turn 3: append tool after the second assistant
+        t3_msgs = [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1, follow_up, ASSISTANT_MSG_2, TOOL_MSG_2]
+        result = prepare_pretokenized(session, t3_msgs, tools=None, tito_tokenizer=registry_with_user.tito_tokenizer)
+        assert isinstance(result, list)
+
+    def test_system_append_rejected(self, registry_with_user: SessionRegistryV2):
+        sid = registry_with_user.create_session()
+        session = registry_with_user.get_session(sid)
+        _commit(session, [SYS_MSG, USER_MSG], ASSISTANT_MSG_1, [1, 2, 3], [10, 11], max_trim_tokens=0)
+
+        messages = [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1, RETRY_SYS_MSG]
+        with pytest.raises(MessageValidationError, match="role='system'.*allowed="):
+            prepare_pretokenized(session, messages, tools=None, tito_tokenizer=registry_with_user.tito_tokenizer)
+
+
+class TestCarriedAssistant:
+    """Client-carried assistants in a branch suffix are prompt material and
+    inherit the attach node's snapshot like any other suffix."""
+
+    def test_carried_assistant_before_user_allowed(self):
+        mock_tito = _make_mock_tito(_MockTITOTokenizer, ["tool", "user"])
+        registry = SessionRegistryV2(SimpleNamespace(), tokenizer=None, tito_tokenizer=mock_tito)
+        sid = registry.create_session()
+        session = registry.get_session(sid)
+        _commit(session, [SYS_MSG, USER_MSG], ASSISTANT_MSG_1, [1, 2, 3], [10], max_trim_tokens=0)
+
+        carried = {"role": "assistant", "content": "carried summary"}
+        messages = [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1, carried, {"role": "user", "content": "next"}]
+        result = prepare_pretokenized(session, messages, tools=None, tito_tokenizer=registry.tito_tokenizer)
+        # The mock merge returns the pretokenized prefix unchanged: getting the
+        # snapshot back proves the merge path ran (a from-scratch render would
+        # return the first-turn sentinel) and the view stayed on the parent.
+        assert result == [1, 2, 3, 10]
+        assert session.active_leaf is session.tree.nodes[0]
+
+
+class TestRollback:
+    """Retry handling through the single-chain view over the tree.
+
+    ``judge_and_position`` never destroys anything: a legal one-step retry
+    moves ``active_leaf`` back to the anchor node (abandoned generations stay
+    in the tree, invisible to the view). Byte-level HTTP fidelity is pinned
+    by ``TestRollbackPins`` in ``test_sessions.py``; this suite covers the
+    mechanism."""
+
+    def _dispatch_and_apply(self, state, messages):
+        position_for_request(state, messages)
+
+    def test_rollback_to_first_assistant(self, registry: SessionRegistryV2):
+        """After 2 completions, a divergent retry rolls back to the first checkpoint."""
+        sid = registry.create_session()
+        state = registry.get_session(sid)
+        session = state
+
+        # Turn 1: [sys, user] -> assistant1
+        t1_msgs = [SYS_MSG, USER_MSG]
+        _commit(session, t1_msgs, ASSISTANT_MSG_1, [1, 2, 3], [10, 11], max_trim_tokens=0)
+
+        # Turn 2: [sys, user, asst1, tool1] -> assistant2
+        t2_msgs = [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1]
+        prepare_pretokenized(session, t2_msgs, tools=None, tito_tokenizer=registry.tito_tokenizer)
+        _commit(session, t2_msgs, ASSISTANT_MSG_2, [1, 2, 3, 10, 11, 20, 21], [30, 31], max_trim_tokens=0)
+
+        assert len(session.active_path()) == 2
+        assert len([n.token_ids for n in session.active_path()]) == 2
+
+        # Retry: send [sys, user, asst1, NEW_tool] - diverges after asst1
+        new_tool = {"role": "tool", "content": '{"temperature": 99}', "tool_call_id": "call_1"}
+        rollback_msgs = [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, new_tool]
+        self._dispatch_and_apply(state, rollback_msgs)
+        assert state.active_leaf is state.tree.nodes[0]
+        result = prepare_pretokenized(session, rollback_msgs, tools=None, tito_tokenizer=registry.tito_tokenizer)
+        assert isinstance(result, list)
+
+        # View rolled back to the first generation; the abandoned node stays in the tree
+        assert len(state.tree.nodes) == 2
+        assert len(session.active_path()) == 1
+        assert len([n.token_ids for n in session.active_path()]) == 1
+        assert session.active_token_ids() == [1, 2, 3, 10, 11]
+        assert session.active_messages() == [SYS_MSG, USER_MSG, ASSISTANT_MSG_1]
+
+    def test_multi_step_rollback_raises(self, registry: SessionRegistryV2):
+        """Rollback that discards >1 assistant raises MessageValidationError and leaves state unchanged."""
+        sid = registry.create_session()
+        state = registry.get_session(sid)
+        session = state
+
+        _commit(session, [SYS_MSG, USER_MSG], ASSISTANT_MSG_1, [1, 2, 3], [10, 11], max_trim_tokens=0)
+
+        t2_msgs = [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1]
+        prepare_pretokenized(session, t2_msgs, tools=None, tito_tokenizer=registry.tito_tokenizer)
+        _commit(session, t2_msgs, ASSISTANT_MSG_2, [1, 2, 3, 10, 11, 20, 21], [30, 31], max_trim_tokens=0)
+
+        t3_msgs = [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1, ASSISTANT_MSG_2, TOOL_MSG_2]
+        prepare_pretokenized(session, t3_msgs, tools=None, tito_tokenizer=registry.tito_tokenizer)
+        _commit(
+            session, t3_msgs, ASSISTANT_MSG_FINAL, [1, 2, 3, 10, 11, 20, 21, 30, 31, 40], [50, 51], max_trim_tokens=0
+        )
+
+        assert len(session.active_path()) == 3
+
+        # Snapshot state before attempted rollback
+        prev_messages = list(session.active_messages())
+        prev_token_ids = list([n.token_ids for n in session.active_path()])
+        prev_records = list(session.active_records())
+        prev_num_assistant = len(session.active_path())
+
+        # Deep divergence: the view positions at the deep anchor (node 0) and
+        # NOTHING is destroyed — the abandoned generations stay in the tree.
+        new_tool = {"role": "tool", "content": '{"alt": true}', "tool_call_id": "call_1"}
+        position_for_request(state, [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, new_tool])
+        assert state.active_leaf is state.tree.nodes[0]
+        assert len(state.tree.nodes) == prev_num_assistant  # nothing destroyed
+        assert [n.token_ids for n in state.tree.nodes] == prev_token_ids
+        assert [n.record for n in state.tree.nodes] == prev_records
+        assert state.tree.nodes[2].path_messages() == prev_messages
+
+    def test_rollback_then_continue_full_trajectory(self, registry: SessionRegistryV2):
+        """Rollback and then complete a full new trajectory from the checkpoint."""
+        sid = registry.create_session()
+        state = registry.get_session(sid)
+        session = state
+
+        # Turn 1
+        t1_msgs = [SYS_MSG, USER_MSG]
+        _commit(session, t1_msgs, ASSISTANT_MSG_1, [1, 2, 3], [10, 11], max_trim_tokens=0)
+
+        # Turn 2
+        t2_msgs = [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1]
+        prepare_pretokenized(session, t2_msgs, tools=None, tito_tokenizer=registry.tito_tokenizer)
+        _commit(session, t2_msgs, ASSISTANT_MSG_2, [1, 2, 3, 10, 11, 20], [30], max_trim_tokens=0)
+
+        # Rollback to asst1, send different tool
+        new_tool = {"role": "tool", "content": '{"retry": true}', "tool_call_id": "call_1"}
+        rollback_msgs = [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, new_tool]
+        self._dispatch_and_apply(state, rollback_msgs)
+        result = prepare_pretokenized(session, rollback_msgs, tools=None, tito_tokenizer=registry.tito_tokenizer)
+        assert isinstance(result, list)
+
+        # Continue: complete a new turn from the rolled-back state
+        _commit(session, rollback_msgs, ASSISTANT_MSG_FINAL, [1, 2, 3, 10, 11, 40, 41], [50, 51], max_trim_tokens=0)
+
+        assert len(session.active_path()) == 2
+        assert len([n.token_ids for n in session.active_path()]) == 2
+        assert session.active_token_ids() == [1, 2, 3, 10, 11, 40, 41, 50, 51]
+        assert session.active_messages() == [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, new_tool, ASSISTANT_MSG_FINAL]
+
+    def test_rollback_fewer_messages_than_stored(self, registry_with_system: SessionRegistryV2):
+        """Rollback triggered when request has strictly fewer messages than stored."""
+        sid = registry_with_system.create_session()
+        state = registry_with_system.get_session(sid)
+        session = state
+
+        # Turn 1: [sys, user] -> asst1
+        _commit(session, [SYS_MSG, USER_MSG], ASSISTANT_MSG_1, [1, 2], [10], max_trim_tokens=0)
+
+        # Turn 2: [sys, user, asst1, tool1] -> asst2
+        t2_msgs = [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1]
+        prepare_pretokenized(session, t2_msgs, tools=None, tito_tokenizer=registry_with_system.tito_tokenizer)
+        _commit(session, t2_msgs, ASSISTANT_MSG_2, [1, 2, 10, 20], [30], max_trim_tokens=0)
+        # stored messages: [sys, user, asst1, tool1, asst2] (5 messages)
+
+        # Agent retries with only [sys, user, asst1, sys_retry] (4 messages)
+        retry_msgs = [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, RETRY_SYS_MSG]
+        self._dispatch_and_apply(state, retry_msgs)
+        result = prepare_pretokenized(
+            session, retry_msgs, tools=None, tito_tokenizer=registry_with_system.tito_tokenizer
+        )
+        assert isinstance(result, list)
+
+        assert len(session.active_path()) == 1
+        assert session.active_messages() == [SYS_MSG, USER_MSG, ASSISTANT_MSG_1]
+
+    def test_rollback_to_second_assistant(self, registry: SessionRegistryV2):
+        """Rollback to the second checkpoint (skipping the third)."""
+        sid = registry.create_session()
+        state = registry.get_session(sid)
+        session = state
+
+        # 3 completions
+        _commit(session, [SYS_MSG, USER_MSG], ASSISTANT_MSG_1, [1, 2], [10], max_trim_tokens=0)
+
+        t2 = [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1]
+        prepare_pretokenized(session, t2, tools=None, tito_tokenizer=registry.tito_tokenizer)
+        _commit(session, t2, ASSISTANT_MSG_2, [1, 2, 10, 20], [30], max_trim_tokens=0)
+
+        t3 = [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1, ASSISTANT_MSG_2, TOOL_MSG_2]
+        prepare_pretokenized(session, t3, tools=None, tito_tokenizer=registry.tito_tokenizer)
+        _commit(session, t3, ASSISTANT_MSG_FINAL, [1, 2, 10, 20, 30, 40], [50], max_trim_tokens=0)
+
+        assert len(session.active_path()) == 3
+
+        # Rollback: keep up to asst2, diverge at tool2
+        new_tool = {"role": "tool", "content": '{"alt": 1}', "tool_call_id": "call_2"}
+        rollback_msgs = [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1, ASSISTANT_MSG_2, new_tool]
+        self._dispatch_and_apply(state, rollback_msgs)
+        assert state.active_leaf is state.tree.nodes[1]
+        result = prepare_pretokenized(session, rollback_msgs, tools=None, tito_tokenizer=registry.tito_tokenizer)
+        assert isinstance(result, list)
+
+        assert len(session.active_path()) == 2
+        assert len([n.token_ids for n in session.active_path()]) == 2
+        assert session.active_token_ids() == [1, 2, 10, 20, 30]
+        assert session.active_messages() == [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1, ASSISTANT_MSG_2]
+
+    def test_no_rollback_when_append_only(self, registry: SessionRegistryV2):
+        """Normal append-only flow classifies as EXTEND and mutates nothing."""
+        sid = registry.create_session()
+        state = registry.get_session(sid)
+        session = state
+
+        _commit(session, [SYS_MSG, USER_MSG], ASSISTANT_MSG_1, [1, 2], [10], max_trim_tokens=0)
+
+        # Append tool - not a rollback
+        t2_msgs = [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1]
+        position_for_request(state, t2_msgs)
+        assert state.active_leaf is state.tree.nodes[0]
+        result = prepare_pretokenized(session, t2_msgs, tools=None, tito_tokenizer=registry.tito_tokenizer)
+        assert isinstance(result, list)
+
+        # State should NOT have been rolled back
+        assert len(session.active_path()) == 1
+        assert len([n.token_ids for n in session.active_path()]) == 1
+        assert session.active_token_ids() == [1, 2, 10]
+
+    def test_rollback_no_assistant_in_prefix_raises(self, registry: SessionRegistryV2):
+        """Dispatch rejects when no assistant anchor exists in the matched prefix."""
+        sid = registry.create_session()
+        state = registry.get_session(sid)
+        session = state
+        _commit(session, [SYS_MSG, USER_MSG], ASSISTANT_MSG_1, [1, 2], [10], max_trim_tokens=0)
+
+        # Diverge inside the root delta: nothing fully matches, so the request
+        # opens a new root (the old chain stays intact in the tree).
+        bad_msgs = [SYS_MSG, {"role": "user", "content": "different question"}]
+        position_for_request(state, bad_msgs)
+        assert state.active_leaf is None
+        assert len(state.tree.nodes) == 1
+
+    def test_rollback_shrinks_record_view_in_sync(self, registry: SessionRegistryV2):
+        """The record view shrinks in sync with the token view on rollback."""
+        sid = registry.create_session()
+        state = registry.get_session(sid)
+        session = state
+
+        _commit(session, [SYS_MSG, USER_MSG], ASSISTANT_MSG_1, [1, 2], [10], max_trim_tokens=0)
+        t2 = [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1]
+        prepare_pretokenized(session, t2, tools=None, tito_tokenizer=registry.tito_tokenizer)
+        _commit(session, t2, ASSISTANT_MSG_2, [1, 2, 10, 20], [30], max_trim_tokens=0)
+
+        assert len(session.active_records()) == 2
+
+        new_tool = {"role": "tool", "content": '{"alt": 1}', "tool_call_id": "call_1"}
+        self._dispatch_and_apply(state, [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, new_tool])
+
+        assert len(session.active_records()) == 1
+        assert session.active_records()[0] is state.tree.nodes[0].record
+
+
+class TestJudgmentCountingMatrix:
+    """Counting matrix for the single-chain judgment: the step unit is the
+    GENERATION (tree node), not the message — client-carried foreign
+    assistants live inside a node's delta and are never anchors (the shape
+    the prompt-assistant fix pinned)."""
+
+    FS_USER_2 = {"role": "user", "content": "the real question"}
+
+    def _fresh(self, registry):
+        sid = registry.create_session()
+        state = registry.get_session(sid)
+        return state, state
+
+    def _two_turns(self, registry):
+        """stored: [sys, user, asst1, tool1, asst2]; 2 generations."""
+        state, session = self._fresh(registry)
+        _commit(session, [SYS_MSG, USER_MSG], ASSISTANT_MSG_1, [1, 2], [10], max_trim_tokens=0)
+        t2 = [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1]
+        prepare_pretokenized(session, t2, tools=None, tito_tokenizer=registry.tito_tokenizer)
+        _commit(session, t2, ASSISTANT_MSG_2, [1, 2, 10, 20], [30], max_trim_tokens=0)
+        return state, session
+
+    def test_empty_view_extends_anything(self, registry: SessionRegistryV2):
+        state, _ = self._fresh(registry)
+        position_for_request(state, [USER_MSG])
+        assert state.active_leaf is None
+
+    def test_strict_extension_leaves_view_alone(self, registry: SessionRegistryV2):
+        state, _ = self._two_turns(registry)
+        request = [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1, ASSISTANT_MSG_2, TOOL_MSG_2]
+        position_for_request(state, request)
+        assert state.active_leaf is state.tree.nodes[1]
+
+    def test_degenerate_equal_history_is_extend(self, registry: SessionRegistryV2):
+        state, _ = self._two_turns(registry)
+        request = [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1, ASSISTANT_MSG_2]
+        position_for_request(state, request)
+        assert state.active_leaf is state.tree.nodes[1]
+
+    def test_pure_drop_one_generation(self, registry: SessionRegistryV2):
+        """Dropping asst2 (and nothing else) is one step even though the
+        request also re-sends tool1: 2 messages beyond the anchor, 1 generation."""
+        state, _ = self._two_turns(registry)
+        position_for_request(state, [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1])
+        assert state.active_leaf is state.tree.nodes[0]
+
+    def test_divergent_one_generation(self, registry: SessionRegistryV2):
+        state, _ = self._two_turns(registry)
+        new_tool = {"role": "tool", "content": '{"alt": 1}', "tool_call_id": "call_1"}
+        position_for_request(state, [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, new_tool])
+        assert state.active_leaf is state.tree.nodes[0]
+        assert state.active_messages() == [SYS_MSG, USER_MSG, ASSISTANT_MSG_1]
+
+    def test_deep_divergence_two_generations_rejected(self, registry: SessionRegistryV2):
+        state, session = self._two_turns(registry)
+        t3 = [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1, ASSISTANT_MSG_2, TOOL_MSG_2]
+        prepare_pretokenized(session, t3, tools=None, tito_tokenizer=registry.tito_tokenizer)
+        _commit(session, t3, ASSISTANT_MSG_FINAL, [1, 2, 10, 20, 30, 40], [50], max_trim_tokens=0)
+
+        new_tool = {"role": "tool", "content": '{"alt": 1}', "tool_call_id": "call_1"}
+        position_for_request(state, [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, new_tool])
+        assert state.active_leaf is state.tree.nodes[0]  # deep anchor, no destruction
+
+    def test_no_anchor(self, registry: SessionRegistryV2):
+        state, session = self._fresh(registry)
+        _commit(session, [SYS_MSG, USER_MSG], ASSISTANT_MSG_1, [1, 2], [10], max_trim_tokens=0)
+        position_for_request(state, [SYS_MSG, {"role": "user", "content": "different"}])
+        assert state.active_leaf is None  # new root; old chain intact
+        assert len(state.tree.nodes) == 1
+
+    def test_prompt_assistant_is_not_an_anchor(self, registry: SessionRegistryV2):
+        """Few-shot first request: the anchor is the generation boundary, and
+        a divergent retry drops exactly one generation (historically this
+        computed discard_count=0 and kept a stale checkpoint)."""
+        state, session = self._fresh(registry)
+        few_shot = [USER_MSG, ASSISTANT_MSG_1, self.FS_USER_2]
+        _commit(session, few_shot, ASSISTANT_MSG_2, [1, 2], [10], max_trim_tokens=0)
+        t2 = [*few_shot, ASSISTANT_MSG_2, TOOL_MSG_2]
+        prepare_pretokenized(session, t2, tools=None, tito_tokenizer=registry.tito_tokenizer)
+        _commit(session, t2, ASSISTANT_MSG_FINAL, [1, 2, 10, 20], [30], max_trim_tokens=0)
+        # stored: [user, fs_asst, user2, asst2, tool2, final]; generations: asst2, final
+
+        new_tool = {"role": "tool", "content": '{"alt": 1}', "tool_call_id": "call_2"}
+        position_for_request(state, [*few_shot, ASSISTANT_MSG_2, new_tool])
+        assert state.active_leaf is state.tree.nodes[0]
+        assert state.active_messages() == [*few_shot, ASSISTANT_MSG_2]
+
+    def test_prefix_with_only_prompt_assistants_has_no_anchor(self, registry: SessionRegistryV2):
+        state, session = self._fresh(registry)
+        few_shot = [USER_MSG, ASSISTANT_MSG_1, self.FS_USER_2]
+        _commit(session, few_shot, ASSISTANT_MSG_2, [1, 2], [10], max_trim_tokens=0)
+
+        position_for_request(state, [USER_MSG, ASSISTANT_MSG_1, {"role": "user", "content": "changed"}])
+        assert state.active_leaf is None  # divergence inside the root delta opens a new root
+
+
+class TestUpdatePretokenizedStateMissingSession:
+    """update_pretokenized_state raises SessionNotFoundError for unknown session."""
+
+    def test_raises_on_missing_session(self, registry: SessionRegistryV2):
+        with pytest.raises(SessionNotFoundError, match="session not found"):
+            registry.get_session("nonexistent")
+
+
+class TestComputeSessionMismatch:
+    """Tests for compute_session_mismatch."""
+
+    def test_raises_for_missing_session(self, registry: SessionRegistryV2):
+        with pytest.raises(SessionNotFoundError):
+            registry.get_session("nonexistent")
+
+    def test_returns_none_for_empty_token_ids(self, registry: SessionRegistryV2):
+        sid = registry.create_session()
+        session = registry.get_session(sid)
+        assert registry.compute_session_mismatch(session) is None
+
+    def test_returns_empty_list_when_no_mismatch(self, registry: SessionRegistryV2):
+        sid = registry.create_session()
+        session = registry.get_session(sid)
+        _commit(session, [SYS_MSG, USER_MSG], ASSISTANT_MSG_1, [1, 2, 3], [10, 11], max_trim_tokens=0)
+
+        # Simulate: template returns same IDs as stored
+        registry.tito_tokenizer.apply_chat_template = MagicMock(return_value=[1, 2, 3, 10, 11])
+
+        # Need a real comparator; replace the None one
+        mock_comparator = MagicMock()
+        mock_comparator.compare_sequences.return_value = []
+        registry.comparator = mock_comparator
+
+        result = registry.compute_session_mismatch(session)
+        assert result == []
+        mock_comparator.compare_sequences.assert_called_once_with([1, 2, 3, 10, 11], [1, 2, 3, 10, 11])
+        registry.tito_tokenizer.apply_chat_template.assert_called_once_with(
+            session.active_messages(),
+            tools=None,
+            add_generation_prompt=False,
+            tokenize=True,
+        )
+
+    def test_returns_mismatch_dicts(self, registry: SessionRegistryV2):
+        sid = registry.create_session()
+        session = registry.get_session(sid)
+        _commit(session, [SYS_MSG, USER_MSG], ASSISTANT_MSG_1, [1, 2, 3], [10, 11], max_trim_tokens=0)
+
+        registry.tito_tokenizer.apply_chat_template = MagicMock(return_value=[1, 2, 99, 10, 11])
+
+        @dataclass
+        class FakeMismatch:
+            position: int
+
+            def to_dict(self):
+                return {"position": self.position, "detail": "mismatch"}
+
+        mock_comparator = MagicMock()
+        mock_comparator.compare_sequences.return_value = [FakeMismatch(position=2)]
+        registry.comparator = mock_comparator
+
+        result = registry.compute_session_mismatch(session)
+        assert result == [{"position": 2, "detail": "mismatch"}]
+
+    def test_raises_tokenization_error_on_exception(self, registry: SessionRegistryV2):
+        sid = registry.create_session()
+        session = registry.get_session(sid)
+        _commit(session, [SYS_MSG, USER_MSG], ASSISTANT_MSG_1, [1, 2, 3], [10, 11], max_trim_tokens=0)
+
+        registry.tito_tokenizer.apply_chat_template = MagicMock(side_effect=RuntimeError("tokenizer failed"))
+
+        with pytest.raises(TokenizationError, match="tokenizer failed"):
+            registry.compute_session_mismatch(session)
+
+    def test_uses_tools_from_last_record(self, registry: SessionRegistryV2):
+        sid = registry.create_session()
+        session = registry.get_session(sid)
+        _commit(session, [SYS_MSG, USER_MSG], ASSISTANT_MSG_1, [1, 2], [10], max_trim_tokens=0)
+
+        tools = [{"type": "function", "function": {"name": "get_weather"}}]
+        record = SessionRecord(
+            timestamp=1.0,
+            method="POST",
+            path="/v1/chat/completions",
+            status_code=200,
+            request={"tools": tools},
+            response={},
+        )
+        t2 = [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1]
+        commit_generation(
+            session,
+            parent=session.active_leaf,
+            request_messages=t2,
+            assistant_message=ASSISTANT_MSG_2,
+            prompt_token_ids=[1, 2, 10, 20],
+            completion_token_ids=[30],
+            max_trim_tokens=0,
+            record=record,
+            response_id="resp-tools",
+            finish_reason="stop",
+        )
+
+        mock_tokenize = MagicMock(return_value=[1, 2, 10])
+        registry.tito_tokenizer.apply_chat_template = mock_tokenize
+        mock_comparator = MagicMock()
+        mock_comparator.compare_sequences.return_value = []
+        registry.comparator = mock_comparator
+
+        registry.compute_session_mismatch(session)
+
+        # Verify tools were passed to the TITO renderer.
+        _, kwargs = mock_tokenize.call_args
+        assert kwargs["tools"] == tools
+        assert kwargs["add_generation_prompt"] is False

--- a/tests/fast/router/test_session_v1_v2_parity.py
+++ b/tests/fast/router/test_session_v1_v2_parity.py
@@ -1,0 +1,113 @@
+import pytest
+from tests.session_parity_utils import (
+    SESSION_PARITY_SEED,
+    V1,
+    V2,
+    assert_agentic_retry_trajectory_parity,
+    assert_sample_bitwise_equal,
+    run_agentic_retry_trajectories,
+)
+
+from miles.utils.test_utils.mock_sglang_server import ProcessResult, ProcessResultMetaInfo, with_mock_server
+from miles.utils.test_utils.session_verify_agent import (
+    ASSISTANT_INPUT_FOLLOWUP_TEXT,
+    FORCE_FINAL_TEXT,
+    MOCK_TOOL_RESULTS,
+    SYSTEM_REMINDER_TEXT,
+    USER_FOLLOWUP_TEXT,
+    build_initial_messages,
+)
+from miles.utils.types import Sample
+
+_MODEL = "Qwen/Qwen3-0.6B"
+_BATCH_SIZE = 16
+_REQUESTS_PER_TRAJECTORY = 9
+_AGENT_RESPONSES = {
+    "initial": ProcessResult(
+        'I will check Beijing.\n<tool_call>\n{"name": "get_weather", '
+        '"arguments": {"location": "Beijing"}}\n</tool_call>',
+        meta_info=ProcessResultMetaInfo(weight_version="w0"),
+    ),
+    "beijing_result": ProcessResult(
+        "Beijing is 22 degrees Celsius and sunny.",
+        meta_info=ProcessResultMetaInfo(weight_version="w1"),
+    ),
+    "shanghai_call": ProcessResult(
+        'I will check Shanghai.\n<tool_call>\n{"name": "get_weather", '
+        '"arguments": {"location": "Shanghai"}}\n</tool_call>',
+        meta_info=ProcessResultMetaInfo(weight_version="w2"),
+    ),
+    "shanghai_result": ProcessResult(
+        "Shanghai is 15 degrees Celsius and cloudy.",
+        meta_info=ProcessResultMetaInfo(weight_version="w3"),
+    ),
+    "rollback_retry": ProcessResult(
+        "I will answer in one sentence.",
+        meta_info=ProcessResultMetaInfo(weight_version="w4"),
+    ),
+    "force_final": ProcessResult(
+        "<final_answer>Beijing is sunny and Shanghai is cloudy.</final_answer>",
+        meta_info=ProcessResultMetaInfo(weight_version="w7"),
+    ),
+    "assistant_input": ProcessResult(
+        "<final_answer>Beijing was sunny and Shanghai was rainy.</final_answer>",
+        meta_info=ProcessResultMetaInfo(weight_version="w8"),
+    ),
+}
+_SELECTED_WEIGHT_VERSIONS = ["w0", "w1", "w2", "w3", "w4", "w7", "w8"]
+
+
+def test_agentic_v2_drop_retries_matches_v1_training_payload_bitwise():
+    v1_runs = _run_scripted_agents(V1)
+    v2_runs = _run_scripted_agents(V2)
+
+    assert len(v1_runs) == len(v2_runs) == _BATCH_SIZE
+    for index, (v1, v2) in enumerate(zip(v1_runs, v2_runs, strict=True)):
+        assert v1.samples[0].index == v2.samples[0].index == index
+        assert v1.samples[0].weight_versions == _SELECTED_WEIGHT_VERSIONS
+        assert v2.samples[0].weight_versions == _SELECTED_WEIGHT_VERSIONS
+        assert_agentic_retry_trajectory_parity(v1, v2)
+
+
+def test_sample_bitwise_comparator_distinguishes_signed_zero():
+    with pytest.raises(AssertionError, match="sample.reward is not bitwise equal"):
+        assert_sample_bitwise_equal(Sample(reward=0.0), Sample(reward=-0.0))
+
+
+def _run_scripted_agents(version: str):
+    input_samples = [
+        Sample(
+            index=index,
+            prompt=build_initial_messages(),
+            reward=0.25,
+            metadata={"source": "parity"},
+        )
+        for index in range(_BATCH_SIZE)
+    ]
+    with with_mock_server(model_name=_MODEL, process_fn=_process_agent_prompt, latency=0.05) as backend:
+        results = run_agentic_retry_trajectories(
+            backend_url=backend.url,
+            hf_checkpoint=_MODEL,
+            version=version,
+            input_samples=input_samples,
+        )
+        assert len(backend.request_log) == _BATCH_SIZE * _REQUESTS_PER_TRAJECTORY
+        assert {request["seed"] for request in backend.request_log} == {SESSION_PARITY_SEED}
+        assert backend.max_concurrent == _BATCH_SIZE
+    return results
+
+
+def _process_agent_prompt(prompt: str) -> ProcessResult:
+    if ASSISTANT_INPUT_FOLLOWUP_TEXT in prompt:
+        return _AGENT_RESPONSES["assistant_input"]
+    if FORCE_FINAL_TEXT in prompt:
+        return _AGENT_RESPONSES["force_final"]
+    if SYSTEM_REMINDER_TEXT in prompt:
+        return _AGENT_RESPONSES["rollback_retry"]
+    if MOCK_TOOL_RESULTS[1] in prompt:
+        return _AGENT_RESPONSES["shanghai_result"]
+    if USER_FOLLOWUP_TEXT in prompt:
+        return _AGENT_RESPONSES["shanghai_call"]
+    if MOCK_TOOL_RESULTS[0] in prompt:
+        return _AGENT_RESPONSES["beijing_result"]
+    return _AGENT_RESPONSES["initial"]

--- a/tests/fast/router/test_sessions.py
+++ b/tests/fast/router/test_sessions.py
@@ -68,8 +68,10 @@ def router_env():
                 chat_template_path=None,
                 apply_chat_template_kwargs={"enable_thinking": False},
                 tito_model="default",
+                sglang_speculative_algorithm=None,
                 trajectory_manager="linear_trajectory",
                 session_server_instance_id=uuid.uuid4().hex,
+                save_debug_trajectory_data=None,
             )
             server_obj = SessionServer(args, backend_url=backend.url)
 

--- a/tests/fast/router/test_sessions_v1_pins.py
+++ b/tests/fast/router/test_sessions_v1_pins.py
@@ -1,0 +1,193 @@
+"""HTTP-level pins for the v1 (linear trajectory) retry/rollback surface.
+
+v1 is the default session server; these pins lock its production behavior
+byte-exactly — every 400 text asserted including interpolated numbers — so
+the opt-in v2 tree server (--use-session-server v2) can never silently
+change the default path. Additive file: the v1 implementation and its
+original test modules stay untouched.
+"""
+
+from unittest.mock import patch
+
+import requests
+from fastapi.responses import JSONResponse
+from tests.fast.router.test_sessions import _create_session, _post_chat
+
+from miles.utils.test_utils.mock_sglang_server import MockSGLangServer
+
+
+class TestRollbackPins:
+    """Byte-exact pins for the rollback dispatch surface (retry semantics)."""
+
+    U1 = {"role": "user", "content": "What is 1+2?"}
+    T1 = {"role": "tool", "content": "tool-result-1", "tool_call_id": "t0"}
+    T1_DIFF = {"role": "tool", "content": "tool-result-DIFFERENT", "tool_call_id": "t0"}
+
+    def _turn(self, url: str, session_id: str, messages: list) -> dict:
+        resp = _post_chat(url, session_id, {"messages": messages})
+        assert resp.status_code == 200
+        return resp.json()["choices"][0]["message"]
+
+    def _get(self, url: str, session_id: str) -> dict:
+        return requests.get(f"{url}/sessions/{session_id}", timeout=5.0).json()
+
+    def _two_turn_session(self, env) -> tuple[str, dict, dict]:
+        """Stored history after this: [U1, a1, T1, a2] with 2 records."""
+        session_id = _create_session(env.url)
+        a1 = self._turn(env.url, session_id, [self.U1])
+        a2 = self._turn(env.url, session_id, [self.U1, a1, self.T1])
+        assert len(self._get(env.url, session_id)["records"]) == 2
+        return session_id, a1, a2
+
+    def test_pure_drop_retry_rolls_back_and_regenerates(self, router_env):
+        session_id, a1, _ = self._two_turn_session(router_env)
+
+        retry = _post_chat(router_env.url, session_id, {"messages": [self.U1, a1, self.T1]})
+
+        assert retry.status_code == 200
+        records = self._get(router_env.url, session_id)["records"]
+        assert len(records) == 2
+        assert records[-1]["request"]["messages"][-1] == self.T1
+
+    def test_divergent_retry_rolls_back_and_continues(self, router_env):
+        session_id, a1, _ = self._two_turn_session(router_env)
+
+        retry = _post_chat(router_env.url, session_id, {"messages": [self.U1, a1, self.T1_DIFF]})
+
+        assert retry.status_code == 200
+        records = self._get(router_env.url, session_id)["records"]
+        assert len(records) == 2
+        assert records[-1]["request"]["messages"][-1] == self.T1_DIFF
+
+    def test_deep_rollback_400_byte_exact_and_state_unchanged(self, router_env):
+        session_id, a1, a2 = self._two_turn_session(router_env)
+        t2 = {"role": "tool", "content": "tool-result-2", "tool_call_id": "t1"}
+        a3 = self._turn(router_env.url, session_id, [self.U1, a1, self.T1, a2, t2])
+        before = self._get(router_env.url, session_id)
+        assert len(before["records"]) == 3
+
+        resp = _post_chat(router_env.url, session_id, {"messages": [self.U1, a1, self.T1_DIFF]})
+
+        assert resp.status_code == 400
+        assert resp.json()["error"] == (
+            "rollback failed: discard_count=2 exceeds max_assistant_rollback_steps=1 "
+            "(stored has 6 messages, request has 3 messages)"
+        )
+        after = self._get(router_env.url, session_id)
+        assert after["records"] == before["records"]
+        assert after["metadata"]["accumulated_token_ids"] == before["metadata"]["accumulated_token_ids"]
+
+        t3 = {"role": "tool", "content": "tool-result-3", "tool_call_id": "t2"}
+        extend = _post_chat(router_env.url, session_id, {"messages": [self.U1, a1, self.T1, a2, t2, a3, t3]})
+        assert extend.status_code == 200
+
+    def test_first_turn_retry_rolls_back_to_empty_and_regenerates(self, router_env):
+        session_id = _create_session(router_env.url)
+        self._turn(router_env.url, session_id, [self.U1])
+
+        resp = _post_chat(router_env.url, session_id, {"messages": [self.U1]})
+
+        assert resp.status_code == 200
+        regenerated = resp.json()["choices"][0]["message"]
+        after = self._get(router_env.url, session_id)
+        assert len(after["records"]) == 1
+        assert after["records"][0]["request"]["messages"] == [self.U1]
+
+        extend = _post_chat(router_env.url, session_id, {"messages": [self.U1, regenerated, self.T1]})
+        assert extend.status_code == 200
+
+    def test_failed_first_turn_then_different_first_request_accepted(self, router_env):
+        """A failed first turn records nothing, so a completely different first
+        request is a fresh first turn and must be accepted — the empty-session
+        accept-anything semantics that later dispatch rewrites must preserve."""
+        session_id = _create_session(router_env.url)
+
+        async def reject(self, request, compute_fn):
+            return JSONResponse(content={"error": "context too long"}, status_code=400)
+
+        with patch.object(MockSGLangServer, "_handle_generate_like_request", new=reject):
+            failed = _post_chat(router_env.url, session_id, {"messages": [self.U1]})
+        assert failed.status_code == 400
+        assert self._get(router_env.url, session_id)["records"] == []
+
+        other_first = {"role": "user", "content": "a completely different opening"}
+        resp = _post_chat(router_env.url, session_id, {"messages": [other_first]})
+        assert resp.status_code == 200
+        records = self._get(router_env.url, session_id)["records"]
+        assert len(records) == 1
+        assert records[0]["request"]["messages"] == [other_first]
+
+    def test_degenerate_extension_resend_exact_history(self, router_env):
+        session_id = _create_session(router_env.url)
+        a1 = self._turn(router_env.url, session_id, [self.U1])
+
+        resend = _post_chat(router_env.url, session_id, {"messages": [self.U1, a1]})
+
+        assert resend.status_code == 200
+        assert len(self._get(router_env.url, session_id)["records"]) == 2
+
+    def test_disallowed_append_role_400_with_rollback_side_effect(self, router_env):
+        session_id, a1, _ = self._two_turn_session(router_env)
+
+        resp = _post_chat(
+            router_env.url, session_id, {"messages": [self.U1, a1, {"role": "developer", "content": "another"}]}
+        )
+
+        assert resp.status_code == 400
+        error = resp.json()["error"]
+        assert error.endswith("; the selected TITO fixed template does not support appending this role")
+        # Characterization: today the rollback mutates BEFORE the append-only
+        # check rejects, and the 400 leaves the rolled-back state behind. Any
+        # future rework of v1 must keep this order.
+        assert len(self._get(router_env.url, session_id)["records"]) == 1
+
+    def test_collect_samples_after_rollback_single_sample(self, router_env):
+        from miles.rollout.session.samples.codec import decode_samples_and_merge_input_sample
+        from miles.utils.types import Sample
+
+        # The class fixture plants fake R3 replay payloads that only the
+        # records path tolerates; assembly would try to decode them. This pin
+        # is about rollback x assembly, so run it with clean meta_info.
+        fixture_response = MockSGLangServer._compute_chat_completions_response
+
+        def clean_meta_response(mock_self, payload: dict) -> dict:
+            response = fixture_response(mock_self, payload)
+            meta = response["choices"][0]["meta_info"]
+            meta.pop("routed_experts", None)
+            meta.pop("indexer_topk", None)
+            return response
+
+        with patch.object(MockSGLangServer, "_compute_chat_completions_response", new=clean_meta_response):
+            session_id, a1, _ = self._two_turn_session(router_env)
+            retry = _post_chat(router_env.url, session_id, {"messages": [self.U1, a1, self.T1]})
+            assert retry.status_code == 200
+
+            resp = requests.post(f"{router_env.url}/sessions/{session_id}/samples", json={}, timeout=10.0)
+
+        assert resp.status_code == 200
+        reply = decode_samples_and_merge_input_sample(resp.content, Sample())
+        assert reply.empty_reason is None
+        assert len(reply.samples) == 1
+        [sample] = reply.samples
+        assert sample.response_length > 0
+        assert len(sample.loss_mask) == sample.response_length
+
+    def test_few_shot_first_request_divergent_retry_uses_generated_checkpoint(self, router_env):
+        """Client-carried assistants stay prompt history, so only the first
+        backend-generated response anchors the divergent retry."""
+        few_shot = [
+            {"role": "user", "content": "Q-few-shot"},
+            {"role": "assistant", "content": "A-few-shot"},
+            {"role": "user", "content": "Q-real"},
+        ]
+        session_id = _create_session(router_env.url)
+        a1 = self._turn(router_env.url, session_id, few_shot)
+        self._turn(router_env.url, session_id, [*few_shot, a1, self.T1])
+        assert len(self._get(router_env.url, session_id)["records"]) == 2
+
+        retry = _post_chat(router_env.url, session_id, {"messages": [*few_shot, a1, self.T1_DIFF]})
+
+        assert retry.status_code == 200
+        records = self._get(router_env.url, session_id)["records"]
+        assert len(records) == 2
+        assert records[-1]["request"]["messages"][-1] == self.T1_DIFF

--- a/tests/fast/router/test_sessions_v2.py
+++ b/tests/fast/router/test_sessions_v2.py
@@ -1,0 +1,395 @@
+"""HTTP tests for session server v2 (tree serving, --use-session-server v2).
+
+The v1 HTTP surface keeps its own modules (test_sessions.py untouched at
+base + test_sessions_v1_pins.py); everything here runs against a v2-flagged
+server. The rollback pin classes mirror test_sessions_v1_pins.py so v1/v2
+behavior stays byte-comparable.
+"""
+
+import json
+import uuid
+from contextlib import contextmanager
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+import requests
+import safetensors.numpy
+from fastapi.responses import JSONResponse
+from tests.fast.router.test_sessions import _create_session, _post_chat
+
+from miles.rollout.session.server import SessionServer
+from miles.utils.http_utils import find_available_port
+from miles.utils.lora import LORA_ADAPTER_NAME
+from miles.utils.test_utils.mock_sglang_server import MockSGLangServer, ProcessResult, with_mock_server
+from miles.utils.test_utils.uvicorn_thread_server import UvicornThreadServer
+
+
+@contextmanager
+def _serve_router(extra_args: dict | None = None):
+    """A standalone v2 SessionServer with arg overrides."""
+
+    def process_fn(prompt: str) -> ProcessResult:
+        return ProcessResult(text=f"echo: {prompt}", finish_reason="stop")
+
+    with with_mock_server(process_fn=process_fn) as backend:
+        args = SimpleNamespace(
+            miles_router_timeout=30,
+            hf_checkpoint="Qwen/Qwen3-0.6B",
+            chat_template_path=None,
+            apply_chat_template_kwargs={"enable_thinking": False},
+            tito_model="default",
+            sglang_speculative_algorithm=None,
+            use_session_server="v2",
+            session_server_instance_id=uuid.uuid4().hex,
+            save_debug_trajectory_data=None,
+            session_sample_picker_path="miles.rollout.session.v2.picker_hub.drop_retries",
+            session_sample_postprocessor_path="miles.rollout.session.v2.postprocessor_hub.default_postprocess",
+            **(extra_args or {}),
+        )
+        server_obj = SessionServer(args, backend_url=backend.url)
+        port = find_available_port(31000)
+        server = UvicornThreadServer(server_obj.app, host="127.0.0.1", port=port)
+        server.start()
+        try:
+            yield SimpleNamespace(url=f"http://127.0.0.1:{port}", backend=backend)
+        finally:
+            server.stop()
+
+
+@pytest.fixture(scope="class")
+def router_env():
+    """v2 twin of test_sessions.router_env: same mock backend + R3 payloads,
+    tree serving enabled."""
+
+    def process_fn(prompt: str) -> ProcessResult:
+        return ProcessResult(text=f"echo: {prompt}", finish_reason="stop")
+
+    original_chat_response = MockSGLangServer._compute_chat_completions_response
+
+    def patched_chat_response(self, payload: dict) -> dict:
+        response = original_chat_response(self, payload)
+        choice = response["choices"][0]
+        logprobs_content = choice["logprobs"]["content"]
+        output_token_logprobs = [
+            (item["logprob"], self.tokenizer.convert_tokens_to_ids(item["token"])) for item in logprobs_content
+        ]
+        choice["meta_info"] = {
+            "output_token_logprobs": output_token_logprobs,
+            "completion_tokens": len(output_token_logprobs),
+            # R3 replay payloads: must reach the session record but never the
+            # client-facing chat response (see _strip_replay_payloads).
+            "routed_experts": [[0, 1], [2, 3]],
+            "indexer_topk": [[4], [5]],
+        }
+        return response
+
+    with patch.object(MockSGLangServer, "_compute_chat_completions_response", new=patched_chat_response):
+        with _serve_router() as env:
+            yield env
+
+
+class TestRequestChatTemplateKwargs:
+    def test_override_reaches_render_and_backend(self, router_env):
+        default_session = _create_session(router_env.url)
+        resp = _post_chat(router_env.url, default_session, {"messages": [{"role": "user", "content": "hi"}]})
+        assert resp.status_code == 200
+        default_payload = router_env.backend.request_log[-1]
+        assert default_payload["chat_template_kwargs"] == {"enable_thinking": False}
+
+        override_session = _create_session(router_env.url)
+        resp = _post_chat(
+            router_env.url,
+            override_session,
+            {
+                "messages": [{"role": "user", "content": "hi"}],
+                "chat_template_kwargs": {"enable_thinking": True},
+            },
+        )
+        assert resp.status_code == 200
+        override_payload = router_env.backend.request_log[-1]
+        assert override_payload["chat_template_kwargs"] == {"enable_thinking": True}
+        assert override_payload["input_ids"] != default_payload["input_ids"]
+
+
+def test_lora_adapter_reaches_backend():
+    with _serve_router({"lora_rank": 8}) as env:
+        session_id = _create_session(env.url)
+        response = _post_chat(env.url, session_id, {"messages": [{"role": "user", "content": "hi"}]})
+
+        assert response.status_code == 200
+        assert env.backend.request_log[-1]["lora_path"] == LORA_ADAPTER_NAME
+
+
+class TestRollbackPins:
+    """HTTP-level pins for the rollback dispatch surface (retry semantics).
+
+    These lock today's behavior before the classify/apply split rewires the
+    internals: the unit-level TestRollback suite is legitimately rewritten by
+    that split, so byte-level fidelity must live at this layer. Every 400 text
+    is asserted exactly, including interpolated numbers.
+    """
+
+    U1 = {"role": "user", "content": "What is 1+2?"}
+    T1 = {"role": "tool", "content": "tool-result-1", "tool_call_id": "t0"}
+    T1_DIFF = {"role": "tool", "content": "tool-result-DIFFERENT", "tool_call_id": "t0"}
+
+    def _turn(self, url: str, session_id: str, messages: list) -> dict:
+        resp = _post_chat(url, session_id, {"messages": messages})
+        assert resp.status_code == 200
+        return resp.json()["choices"][0]["message"]
+
+    def _get(self, url: str, session_id: str) -> dict:
+        return requests.get(f"{url}/sessions/{session_id}", timeout=5.0).json()
+
+    def _two_turn_session(self, env) -> tuple[str, dict, dict]:
+        """Stored history after this: [U1, a1, T1, a2] with 2 records."""
+        session_id = _create_session(env.url)
+        a1 = self._turn(env.url, session_id, [self.U1])
+        a2 = self._turn(env.url, session_id, [self.U1, a1, self.T1])
+        assert len(self._get(env.url, session_id)["records"]) == 2
+        return session_id, a1, a2
+
+    def test_pure_drop_retry_rolls_back_and_regenerates(self, router_env):
+        session_id, a1, _ = self._two_turn_session(router_env)
+
+        retry = _post_chat(router_env.url, session_id, {"messages": [self.U1, a1, self.T1]})
+
+        assert retry.status_code == 200
+        records = self._get(router_env.url, session_id)["records"]
+        assert len(records) == 2
+        assert records[-1]["request"]["messages"][-1] == self.T1
+
+    def test_divergent_retry_rolls_back_and_continues(self, router_env):
+        session_id, a1, _ = self._two_turn_session(router_env)
+
+        retry = _post_chat(router_env.url, session_id, {"messages": [self.U1, a1, self.T1_DIFF]})
+
+        assert retry.status_code == 200
+        records = self._get(router_env.url, session_id)["records"]
+        assert len(records) == 2
+        assert records[-1]["request"]["messages"][-1] == self.T1_DIFF
+
+    def test_deep_divergence_branches_and_keeps_both_lines(self, router_env):
+        """Was the deep-rollback 400 pin: a divergence beyond one generation now
+        branches at the deep anchor (200), the abandoned deep line stays in the
+        tree, and the samples op emits BOTH lines (deep abandons are data)."""
+        with _clean_r3_meta():
+            session_id, a1, a2 = self._two_turn_session(router_env)
+            t2 = {"role": "tool", "content": "tool-result-2", "tool_call_id": "t1"}
+            self._turn(router_env.url, session_id, [self.U1, a1, self.T1, a2, t2])
+            assert len(self._get(router_env.url, session_id)["records"]) == 3
+
+            resp = _post_chat(router_env.url, session_id, {"messages": [self.U1, a1, self.T1_DIFF]})
+
+            assert resp.status_code == 200
+            after = self._get(router_env.url, session_id)
+            # The view follows the new branch: anchor turn + the fresh generation.
+            assert len(after["records"]) == 2
+            tree = after["metadata"]["tree"]
+            assert len(tree["nodes"]) == 4
+            assert sorted(len(leaf["path_node_ids"]) for leaf in tree["leaves"]) == [2, 3]
+
+            samples = requests.post(f"{router_env.url}/sessions/{session_id}/samples", json={}, timeout=10.0)
+            assert samples.status_code == 200
+            meta = _decode_samples_meta(samples.content)
+            assert len(meta["samples"]) == 2  # the deep abandoned line still trains
+            for wire_sample in meta["samples"]:
+                # v2 serving fills SessionRecord.request_timestamp like v1 does
+                # (folding collects per-turn segments into a list).
+                lifecycle = wire_sample["metadata"]["lifecycle"]
+                segments = lifecycle if isinstance(lifecycle, list) else [lifecycle]
+                assert segments and all(seg["req_ts"] is not None for seg in segments)
+
+    def test_root_divergence_opens_new_root(self, router_env):
+        """Was the no-anchor 400 pin: divergence inside the root delta now opens
+        a second root (200); both roots produce samples."""
+        with _clean_r3_meta():
+            session_id = _create_session(router_env.url)
+            self._turn(router_env.url, session_id, [self.U1])
+
+            resp = _post_chat(
+                router_env.url, session_id, {"messages": [{"role": "user", "content": "a different opening"}]}
+            )
+
+            assert resp.status_code == 200
+            after = self._get(router_env.url, session_id)
+            assert len(after["records"]) == 1  # view follows the new root
+            tree = after["metadata"]["tree"]
+            assert [n["parent"] for n in tree["nodes"]] == [None, None]
+
+            samples = requests.post(f"{router_env.url}/sessions/{session_id}/samples", json={}, timeout=10.0)
+            assert samples.status_code == 200
+            assert len(_decode_samples_meta(samples.content)["samples"]) == 2
+
+    def test_failed_first_turn_then_different_first_request_accepted(self, router_env):
+        """A failed first turn records nothing, so a completely different first
+        request is a fresh first turn and must be accepted — the empty-session
+        accept-anything semantics that later dispatch rewrites must preserve."""
+        session_id = _create_session(router_env.url)
+
+        async def reject(self, request, compute_fn):
+            return JSONResponse(content={"error": "context too long"}, status_code=400)
+
+        with patch.object(MockSGLangServer, "_handle_generate_like_request", new=reject):
+            failed = _post_chat(router_env.url, session_id, {"messages": [self.U1]})
+        assert failed.status_code == 400
+        assert self._get(router_env.url, session_id)["records"] == []
+
+        other_first = {"role": "user", "content": "a completely different opening"}
+        resp = _post_chat(router_env.url, session_id, {"messages": [other_first]})
+        assert resp.status_code == 200
+        records = self._get(router_env.url, session_id)["records"]
+        assert len(records) == 1
+        assert records[0]["request"]["messages"] == [other_first]
+
+    def test_degenerate_extension_resend_exact_history(self, router_env):
+        session_id = _create_session(router_env.url)
+        a1 = self._turn(router_env.url, session_id, [self.U1])
+
+        resend = _post_chat(router_env.url, session_id, {"messages": [self.U1, a1]})
+
+        assert resend.status_code == 200
+        assert len(self._get(router_env.url, session_id)["records"]) == 2
+
+    def test_disallowed_append_role_400_with_rollback_side_effect(self, router_env):
+        session_id, a1, _ = self._two_turn_session(router_env)
+
+        resp = _post_chat(
+            router_env.url, session_id, {"messages": [self.U1, a1, {"role": "developer", "content": "another"}]}
+        )
+
+        assert resp.status_code == 400
+        error = resp.json()["error"]
+        assert error.endswith("; the selected TITO fixed template does not support appending this role")
+        # Characterization: today the rollback mutates BEFORE the append-only
+        # check rejects, and the 400 leaves the rolled-back state behind. The
+        # classify/apply split must keep this order.
+        assert len(self._get(router_env.url, session_id)["records"]) == 1
+
+    def test_collect_samples_after_rollback_single_sample(self, router_env):
+        from miles.rollout.session.samples.codec import decode_samples_and_merge_input_sample
+        from miles.utils.types import Sample
+
+        # The class fixture plants fake R3 replay payloads that only the
+        # records path tolerates; assembly would try to decode them. This pin
+        # is about rollback x assembly, so run it with clean meta_info.
+        fixture_response = MockSGLangServer._compute_chat_completions_response
+
+        def clean_meta_response(mock_self, payload: dict) -> dict:
+            response = fixture_response(mock_self, payload)
+            meta = response["choices"][0]["meta_info"]
+            meta.pop("routed_experts", None)
+            meta.pop("indexer_topk", None)
+            return response
+
+        with patch.object(MockSGLangServer, "_compute_chat_completions_response", new=clean_meta_response):
+            session_id, a1, _ = self._two_turn_session(router_env)
+            retry = _post_chat(router_env.url, session_id, {"messages": [self.U1, a1, self.T1]})
+            assert retry.status_code == 200
+
+            resp = requests.post(f"{router_env.url}/sessions/{session_id}/samples", json={}, timeout=10.0)
+
+        assert resp.status_code == 200
+        reply = decode_samples_and_merge_input_sample(resp.content, Sample())
+        assert reply.empty_reason is None
+        assert len(reply.samples) == 1
+        [sample] = reply.samples
+        assert sample.response_length > 0
+        assert len(sample.loss_mask) == sample.response_length
+
+    def test_few_shot_first_request_divergent_retry_rolls_back_cleanly(self, router_env):
+        """Assistants carried by the first request are prompt, not checkpoints.
+
+        Historically the rollback anchor math counted the few-shot assistant
+        as a checkpoint, so this divergent retry computed discard_count=0,
+        kept the stale second checkpoint, and answered 200 with a corrupted
+        token stream (records grew to 3). With ``prompt_assistant_count`` the
+        anchor is the generated assistant: one-step rollback + regenerate,
+        records land at 2."""
+        few_shot = [
+            {"role": "user", "content": "Q-few-shot"},
+            {"role": "assistant", "content": "A-few-shot"},
+            {"role": "user", "content": "Q-real"},
+        ]
+        session_id = _create_session(router_env.url)
+        a1 = self._turn(router_env.url, session_id, few_shot)
+        self._turn(router_env.url, session_id, [*few_shot, a1, self.T1])
+        assert len(self._get(router_env.url, session_id)["records"]) == 2
+
+        retry = _post_chat(router_env.url, session_id, {"messages": [*few_shot, a1, self.T1_DIFF]})
+
+        assert retry.status_code == 200
+        assert len(self._get(router_env.url, session_id)["records"]) == 2
+
+
+@contextmanager
+def _clean_r3_meta():
+    """The class fixture plants fake R3 replay payloads that only the records
+    path tolerates; assembly would try to decode them. Samples-op tests run
+    with clean meta_info."""
+    fixture_response = MockSGLangServer._compute_chat_completions_response
+
+    def clean_meta_response(mock_self, payload: dict) -> dict:
+        response = fixture_response(mock_self, payload)
+        meta = response["choices"][0]["meta_info"]
+        meta.pop("routed_experts", None)
+        meta.pop("indexer_topk", None)
+        return response
+
+    with patch.object(MockSGLangServer, "_compute_chat_completions_response", new=clean_meta_response):
+        yield
+
+
+def _decode_samples_meta(payload: bytes) -> dict:
+    tensors = safetensors.numpy.load(payload)
+    return json.loads(tensors["_samples_meta"].tobytes().decode("utf-8"))
+
+
+class TestTruncationAndCompaction:
+    U1 = {"role": "user", "content": "What is 1+2?"}
+    T1 = {"role": "tool", "content": "tool-result-1", "tool_call_id": "t0"}
+
+    def test_extending_truncated_generation_is_409(self, router_env):
+        session_id = _create_session(router_env.url)
+        fixture_response = MockSGLangServer._compute_chat_completions_response
+
+        def length_finish(self, payload: dict) -> dict:
+            response = fixture_response(self, payload)
+            response["choices"][0]["finish_reason"] = "length"
+            return response
+
+        with patch.object(MockSGLangServer, "_compute_chat_completions_response", new=length_finish):
+            first = _post_chat(router_env.url, session_id, {"messages": [self.U1]})
+        assert first.status_code == 200
+        a1 = first.json()["choices"][0]["message"]
+
+        extend = _post_chat(router_env.url, session_id, {"messages": [self.U1, a1, self.T1]})
+        assert extend.status_code == 409
+        assert "truncated generation cannot be extended" in extend.json()["error"]
+
+        # Branching BEFORE the cut still works: a different opening opens a new root.
+        reroot = _post_chat(router_env.url, session_id, {"messages": [{"role": "user", "content": "fresh"}]})
+        assert reroot.status_code == 200
+
+    def test_compaction_branch_with_carried_assistant(self, router_env):
+        """A branch delta carrying a client assistant (compaction) is accepted:
+        the carried assistant is prompt (loss 0 comes from assembly), and the
+        suffix render appends onto the inherited snapshot."""
+        session_id = _create_session(router_env.url)
+        first = _post_chat(router_env.url, session_id, {"messages": [self.U1]})
+        a1 = first.json()["choices"][0]["message"]
+
+        carried = {"role": "assistant", "content": "compacted summary of earlier work"}
+        resp = _post_chat(
+            router_env.url,
+            session_id,
+            {"messages": [self.U1, a1, self.T1, carried, {"role": "tool", "content": "go", "tool_call_id": "t1"}]},
+        )
+        assert resp.status_code == 200
+        meta = requests.get(f"{router_env.url}/sessions/{session_id}", timeout=5.0).json()["metadata"]
+        # Snapshot inheritance is unconditional: the carried-assistant branch
+        # commits as a child of the first generation, never as a second root.
+        nodes = meta["tree"]["nodes"]
+        assert len(nodes) == 2
+        assert nodes[1]["parent"] == nodes[0]["id"]

--- a/tests/fast/router/test_tree_assembly_invariants.py
+++ b/tests/fast/router/test_tree_assembly_invariants.py
@@ -1,0 +1,312 @@
+"""Tree-merge invariants for randomized forests and targeted edges.
+
+The independent oracle checks:
+
+1. token fields match each possibly truncated leaf snapshot;
+2. every kept completion span is trainable in exactly one surviving leaf;
+3. temporal retry trimming accepts shorter replacements;
+4. one trajectory reward reaches every kept sample;
+5. samples sort by checkpoint count, then leaf seq, descending.
+"""
+
+import json
+import random
+import uuid
+from types import SimpleNamespace
+
+import pytest
+from tests.fast.rollout.session.test_samples import _make_record
+
+from miles.rollout.session.samples.codec import COMPUTED_FIELDS_V2, decode_samples_and_merge_input_sample
+from miles.rollout.session.v2.core import SessionCoreV2
+from miles.rollout.session.v2.session_state import SessionRegistryV2
+from miles.utils.chat_template_utils import get_tito_tokenizer
+from miles.utils.processing_utils import load_tokenizer
+from miles.utils.types import Sample
+
+_ARGS = SimpleNamespace(
+    miles_router_timeout=30,
+    hf_checkpoint="Qwen/Qwen3-0.6B",
+    chat_template_path=None,
+    apply_chat_template_kwargs={"enable_thinking": False},
+    tito_model="default",
+    sglang_speculative_algorithm=None,
+    session_server_instance_id=uuid.uuid4().hex,
+    save_debug_trajectory_data=None,
+    session_sample_picker_path="miles.rollout.session.v2.picker_hub.drop_retries",
+    session_sample_postprocessor_path="miles.rollout.session.v2.postprocessor_hub.default_postprocess",
+)
+
+
+class _UnusedBackend:
+    async def do_proxy(self, *args, **kwargs):
+        raise AssertionError("collect_samples must not touch the proxy backend")
+
+
+@pytest.fixture(scope="module")
+def core():
+    tokenizer = load_tokenizer(_ARGS.hf_checkpoint, chat_template_path=None, trust_remote_code=True)
+    tito_tokenizer = get_tito_tokenizer(
+        tokenizer,
+        tokenizer_type=_ARGS.tito_model,
+        chat_template_kwargs=_ARGS.apply_chat_template_kwargs,
+    )
+    registry = SessionRegistryV2(_ARGS, tokenizer, tito_tokenizer=tito_tokenizer)
+    return SessionCoreV2(_UnusedBackend(), registry, _ARGS, _ARGS.session_server_instance_id)
+
+
+class _Grower:
+    """Grows legal trees out of synthetic records with globally unique token ids."""
+
+    def __init__(self, state):
+        self.state = state
+        self.next_token = 1
+
+    def _fresh(self, n: int) -> list[int]:
+        ids = list(range(self.next_token, self.next_token + n))
+        self.next_token += n
+        return ids
+
+    def grow(self, parent, *, env_len: int, completion_len: int, finish_reason: str = "stop"):
+        prefix = parent.token_ids if parent is not None else []
+        prompt = prefix + self._fresh(env_len)
+        completion = self._fresh(completion_len)
+        record = _make_record(prompt_token_ids=prompt, output_token_ids=completion, finish_reason=finish_reason)
+        return self.state.tree.create_node(
+            parent,
+            delta_messages=[],
+            token_ids=prompt + completion,
+            completion_span=(len(prompt), len(prompt) + len(completion)),
+            committed_at=float(len(self.state.tree.nodes)),
+            response_id=f"resp-{len(self.state.tree.nodes)}",
+            record=record,
+            finish_reason=finish_reason,
+        )
+
+
+async def _fresh_grower(core):
+    response = await core.create_session()
+    sid = json.loads(response.body)["session_id"]
+    state = core.registry.sessions[sid]
+    return sid, state, _Grower(state)
+
+
+def _oracle_pick(state):
+    """Independent re-derivation of ruling F: (kept, trimmed)."""
+    kept, trimmed = [], []
+    for leaf in state.tree.leaves():
+        if leaf.parent is None:
+            kept.append(leaf)
+            continue
+        later = [s for s in leaf.parent.children if s.seq > leaf.seq]
+        if not later:
+            kept.append(leaf)
+            continue
+        trimmed.append(leaf)
+    kept.sort(key=lambda leaf: (len(leaf.path_nodes()), leaf.seq), reverse=True)
+    return kept, trimmed
+
+
+def _oracle_owner(kept):
+    owner = {}
+    for leaf in sorted(kept, key=lambda leaf: leaf.seq):
+        for node in leaf.path_nodes():
+            owner.setdefault(node.seq, leaf.seq)
+    return owner
+
+
+def _assert_sample_legality(sample: Sample, leaf, owner: dict[int, int]) -> None:
+    snapshot = leaf.token_ids
+    assert sample.tokens == snapshot[: len(sample.tokens)], "sample tokens must be a prefix of the leaf snapshot"
+    assert len(sample.loss_mask) == sample.response_length
+    assert len(sample.rollout_log_probs) == sample.response_length
+
+    response_start = len(sample.tokens) - sample.response_length
+    trained = {response_start + i for i, bit in enumerate(sample.loss_mask) if bit == 1}
+    expected = set()
+    for node in leaf.path_nodes():
+        if owner[node.seq] != leaf.seq:
+            continue
+        lo, hi = node.completion_span
+        expected |= set(range(lo, min(hi, len(sample.tokens))))
+    # Mid-path early-stop (a non-COMPLETED turn ends the fold) may keep the
+    # sample shorter than the snapshot; trained positions must then be the
+    # owned completions clipped to the kept range.
+    expected = {p for p in expected if response_start <= p < len(sample.tokens)}
+    assert trained == expected, f"exactly-once violated: trained={sorted(trained)} expected={sorted(expected)}"
+
+
+async def _collect(core, sid, *, max_seq_len=None, agent_metadata=None):
+    response = await core.collect_samples(sid, max_seq_len=max_seq_len, agent_metadata=agent_metadata)
+    return response.status_code, bytes(response.body)
+
+
+def _grow_random_tree(grower, rng: random.Random, *, allow_shorter_retries: bool = False):
+    """Grow a random forest, optionally allowing shorter retry branches."""
+    grower.grow(None, env_len=rng.randint(1, 3), completion_len=rng.randint(1, 4))
+    for _ in range(rng.randint(2, 9)):
+        state = grower.state
+        op = rng.random()
+        leaves = state.tree.leaves()
+        if op < 0.15:  # new root (subagent)
+            grower.grow(None, env_len=rng.randint(1, 3), completion_len=rng.randint(1, 4))
+        elif op < 0.45:  # retry: supersede a random childless leaf with a sibling
+            leaf = rng.choice(leaves)
+            if leaf.parent is None:
+                grower.grow(leaf, env_len=rng.randint(1, 2), completion_len=rng.randint(1, 3))
+                continue
+            abandoned_len = len(leaf.token_ids) - len(leaf.parent.token_ids)
+            floor = 1 if allow_shorter_retries else max(1, abandoned_len)
+            grower.grow(
+                leaf.parent,
+                env_len=rng.randint(1, 2),
+                completion_len=max(floor, rng.randint(1, abandoned_len + 2)),
+            )
+        else:  # extend a random leaf
+            grower.grow(rng.choice(leaves), env_len=rng.randint(1, 2), completion_len=rng.randint(1, 3))
+
+
+@pytest.mark.parametrize("seed", range(25))
+async def test_fuzz_forest_assembly_invariants(core, seed):
+    sid, state, grower = await _fresh_grower(core)
+    rng = random.Random(seed)
+    _grow_random_tree(grower, rng)
+    state.active_leaf = state.tree.leaves()[-1]
+
+    kept, trimmed = _oracle_pick(state)
+    trajectory_reward = round(rng.random(), 3)
+
+    status, payload = await _collect(core, sid, agent_metadata={"reward": trajectory_reward})
+    assert status == 200
+    reply = decode_samples_and_merge_input_sample(payload, Sample(), fields=COMPUTED_FIELDS_V2)
+    assert len(reply.samples) == len(kept)
+    owner = _oracle_owner(kept)
+    for sample, leaf in zip(reply.samples, kept, strict=True):
+        assert sample.metadata["leaf"]["node_id"] == leaf.seq
+        _assert_sample_legality(sample, leaf, owner)
+        assert sample.reward == trajectory_reward
+    emitted = {s.metadata["leaf"]["node_id"] for s in reply.samples}
+    assert emitted.isdisjoint({leaf.seq for leaf in trimmed})
+
+
+@pytest.mark.parametrize("seed", range(50, 70))
+async def test_fuzz_shorter_replacements_assemble_legally(core, seed):
+    """Shorter replacements still assemble under the temporal trim rule."""
+    sid, state, grower = await _fresh_grower(core)
+    rng = random.Random(seed)
+    _grow_random_tree(grower, rng, allow_shorter_retries=True)
+    state.active_leaf = state.tree.leaves()[-1]
+
+    kept, _ = _oracle_pick(state)
+    status, payload = await _collect(core, sid)
+    assert status == 200
+    reply = decode_samples_and_merge_input_sample(payload, Sample(), fields=COMPUTED_FIELDS_V2)
+    assert len(reply.samples) == len(kept)
+    owner = _oracle_owner(kept)
+    for sample, leaf in zip(reply.samples, kept, strict=True):
+        _assert_sample_legality(sample, leaf, owner)
+
+
+@pytest.mark.parametrize("seed", range(25, 35))
+async def test_fuzz_forest_invariants_under_truncation(core, seed):
+    sid, state, grower = await _fresh_grower(core)
+    rng = random.Random(seed)
+    _grow_random_tree(grower, rng)
+    state.active_leaf = state.tree.leaves()[-1]
+
+    kept, _ = _oracle_pick(state)
+    max_seq_len = rng.randint(4, 12)
+
+    status, payload = await _collect(core, sid, max_seq_len=max_seq_len)
+    assert status == 200
+    reply = decode_samples_and_merge_input_sample(payload, Sample(), fields=COMPUTED_FIELDS_V2)
+    if not reply.samples:
+        assert reply.empty_reason == "all_truncated"
+        return
+    # Leaves whose every turn truncated away drop from the material; the
+    # survivors' ownership is recomputed over what remains (no orphan spans).
+    emitted_ids = [s.metadata["leaf"]["node_id"] for s in reply.samples]
+    emitted_leaves = [next(leaf for leaf in kept if leaf.seq == node_id) for node_id in emitted_ids]
+    owner = _oracle_owner(emitted_leaves)
+    for sample, leaf in zip(reply.samples, emitted_leaves, strict=True):
+        assert len(sample.tokens) <= max_seq_len
+        _assert_sample_legality(sample, leaf, owner)
+
+
+class TestTargetedEdges:
+    async def test_chained_retries_single_survivor(self, core):
+        sid, state, grower = await _fresh_grower(core)
+        root = grower.grow(None, env_len=2, completion_len=2)
+        for _ in range(3):  # three abandoned attempts, each superseded
+            grower.grow(root, env_len=1, completion_len=2)
+        survivor = grower.grow(root, env_len=1, completion_len=2)
+        state.active_leaf = survivor
+
+        status, payload = await _collect(core, sid)
+        assert status == 200
+        reply = decode_samples_and_merge_input_sample(payload, Sample(), fields=COMPUTED_FIELDS_V2)
+        (sample,) = reply.samples
+        assert sample.metadata["leaf"]["node_id"] == survivor.seq
+
+    async def test_twins_equal_length_earlier_trimmed(self, core):
+        sid, state, grower = await _fresh_grower(core)
+        root = grower.grow(None, env_len=2, completion_len=2)
+        grower.grow(root, env_len=1, completion_len=2)
+        twin_b = grower.grow(root, env_len=1, completion_len=2)
+        state.active_leaf = twin_b
+
+        status, payload = await _collect(core, sid)
+        assert status == 200
+        reply = decode_samples_and_merge_input_sample(payload, Sample(), fields=COMPUTED_FIELDS_V2)
+        (sample,) = reply.samples  # temporal rule: the earlier equal-length twin is trimmed
+        assert sample.metadata["leaf"]["node_id"] == twin_b.seq
+
+    async def test_fork_below_fork_ownership_nesting(self, core):
+        """Two nested fork points: each shared span trains exactly once, in
+        the earliest surviving leaf that contains it."""
+        sid, state, grower = await _fresh_grower(core)
+        root = grower.grow(None, env_len=2, completion_len=2)
+        mid = grower.grow(root, env_len=1, completion_len=2)
+        deep_a = grower.grow(mid, env_len=1, completion_len=2)  # earliest leaf: owns root+mid+own
+        grower.grow(deep_a, env_len=1, completion_len=2)  # extend: deep_a no longer a leaf
+        grower.grow(mid, env_len=1, completion_len=3)  # later sibling below mid
+        side = grower.grow(root, env_len=1, completion_len=4)  # sibling below root
+        state.active_leaf = side
+
+        kept, _ = _oracle_pick(state)
+        status, payload = await _collect(core, sid)
+        assert status == 200
+        reply = decode_samples_and_merge_input_sample(payload, Sample(), fields=COMPUTED_FIELDS_V2)
+        assert len(reply.samples) == len(kept)
+        owner = _oracle_owner(kept)
+        for sample, leaf in zip(reply.samples, kept, strict=True):
+            _assert_sample_legality(sample, leaf, owner)
+        # Cross-check: the union of trained spans over all samples covers each
+        # surviving-path completion exactly once.
+        span_train_count: dict[int, int] = {}
+        for sample, leaf in zip(reply.samples, kept, strict=True):
+            response_start = len(sample.tokens) - sample.response_length
+            trained = {response_start + i for i, bit in enumerate(sample.loss_mask) if bit == 1}
+            for node in leaf.path_nodes():
+                lo, hi = node.completion_span
+                if set(range(lo, hi)) <= trained:
+                    span_train_count[node.seq] = span_train_count.get(node.seq, 0) + 1
+        surviving_nodes = {node.seq for leaf in kept for node in leaf.path_nodes()}
+        assert span_train_count == {seq: 1 for seq in surviving_nodes}
+
+    async def test_midpath_length_turn_early_stops_but_stays_legal(self, core):
+        """A non-COMPLETED mid-path turn ends the fold (documented early-stop):
+        the sample stops at that turn and every trained position still lies in
+        an owned completion span."""
+        sid, state, grower = await _fresh_grower(core)
+        root = grower.grow(None, env_len=2, completion_len=2)
+        cut = grower.grow(root, env_len=1, completion_len=2, finish_reason="length")
+        leaf = grower.grow(cut, env_len=1, completion_len=2)
+        state.active_leaf = leaf
+
+        status, payload = await _collect(core, sid)
+        assert status == 200
+        reply = decode_samples_and_merge_input_sample(payload, Sample(), fields=COMPUTED_FIELDS_V2)
+        (sample,) = reply.samples
+        assert len(sample.tokens) == len(cut.token_ids)  # fold stopped at the length turn
+        _assert_sample_legality(sample, leaf, _oracle_owner([leaf]))

--- a/tests/fast/router/test_tree_trajectory.py
+++ b/tests/fast/router/test_tree_trajectory.py
@@ -1,0 +1,180 @@
+"""Unit tests for the trajectory tree: data model + attach-point search.
+
+Pure model level (no serving wiring).
+"""
+
+import pytest
+
+from miles.rollout.session.types import SessionRecord
+from miles.rollout.session.v2 import tree_trajectory
+from miles.rollout.session.v2.tree_trajectory import SessionTree
+
+SYS = {"role": "system", "content": "sys"}
+U1 = {"role": "user", "content": "q1"}
+A1 = {"role": "assistant", "content": "a1"}
+T1 = {"role": "tool", "content": "t1", "tool_call_id": "c1"}
+A2 = {"role": "assistant", "content": "a2"}
+T2 = {"role": "tool", "content": "t2", "tool_call_id": "c2"}
+A3 = {"role": "assistant", "content": "a3"}
+
+
+def _commit(tree, parent, delta, *, finish_reason="stop", committed_at=None):
+    seq = len(tree.nodes)
+    prefix = parent.token_ids if parent is not None else []
+    tokens = prefix + [100 + seq]
+    record = SessionRecord(
+        timestamp=0.0, method="POST", path="/v1/chat/completions", request={}, response={}, status_code=200
+    )
+    return tree.create_node(
+        parent,
+        delta_messages=delta,
+        token_ids=tokens,
+        completion_span=(len(tokens) - 1, len(tokens)),
+        committed_at=committed_at if committed_at is not None else float(seq),
+        response_id=f"resp-{seq}",
+        record=record,
+        finish_reason=finish_reason,
+    )
+
+
+@pytest.fixture
+def linear_tree():
+    """root n0=[sys,u1,a1] -> n1=[t1,a2] -> n2=[t2,a3]"""
+    tree = SessionTree()
+    n0 = _commit(tree, None, [SYS, U1, A1])
+    n1 = _commit(tree, n0, [T1, A2])
+    n2 = _commit(tree, n1, [T2, A3])
+    return tree, n0, n1, n2
+
+
+class TestAttachPoint:
+    def test_case1_strict_leaf_extension(self, linear_tree):
+        tree, _, _, n2 = linear_tree
+        ap = tree.find_attach_point([SYS, U1, A1, T1, A2, T2, A3, {"role": "user", "content": "next"}])
+        assert ap.node is n2
+        assert ap.matched_messages == 7
+
+    def test_case2_degenerate_resend_of_full_path(self, linear_tree):
+        tree, _, _, n2 = linear_tree
+        ap = tree.find_attach_point([SYS, U1, A1, T1, A2, T2, A3])
+        assert ap.node is n2
+        assert ap.matched_messages == 7  # empty suffix: generate a new child of n2
+
+    def test_case3_internal_node_divergence(self, linear_tree):
+        tree, _, n1, _ = linear_tree
+        t2_diff = {"role": "tool", "content": "t2-DIFF", "tool_call_id": "c2"}
+        ap = tree.find_attach_point([SYS, U1, A1, T1, A2, t2_diff])
+        assert ap.node is n1
+        assert ap.matched_messages == 5
+        assert ap.best_overlap == 5
+
+    def test_case4_divergence_inside_child_delta_attaches_parent(self, linear_tree):
+        tree, n0, _, _ = linear_tree
+        t1_diff = {"role": "tool", "content": "t1-DIFF", "tool_call_id": "c1"}
+        ap = tree.find_attach_point([SYS, U1, A1, t1_diff])
+        assert ap.node is n0
+        assert ap.matched_messages == 3
+
+    def test_case4b_divergence_inside_root_delta_is_new_root(self, linear_tree):
+        tree, _, _, _ = linear_tree
+        ap = tree.find_attach_point([SYS, {"role": "user", "content": "other"}])
+        assert ap.node is None
+        assert ap.matched_messages == 0
+        assert ap.best_overlap == 1  # sys matched before the divergence
+
+    def test_case4b_pure_prefix_of_root_delta_is_new_root(self, linear_tree):
+        """Today's no-anchor shape: resend [sys, u1] against stored [sys, u1, a1, ...]."""
+        tree, _, _, _ = linear_tree
+        ap = tree.find_attach_point([SYS, U1])
+        assert ap.node is None
+        assert ap.best_overlap == 2
+
+    def test_case5_foreign_assistant_divergence_attaches_parent(self, linear_tree):
+        """Client rewrote a2 (compaction): the rewritten assistant lands in the
+        new branch's delta; matching just stops before it."""
+        tree, n0, _, _ = linear_tree
+        a2_rewritten = {"role": "assistant", "content": "a2-compacted"}
+        ap = tree.find_attach_point([SYS, U1, A1, T1, a2_rewritten, {"role": "user", "content": "go on"}])
+        assert ap.node is n0
+        assert ap.matched_messages == 3
+        assert ap.best_overlap == 4  # sys,u1,a1 + t1 inside n1's delta
+
+    def test_case6_zero_overlap_is_new_root(self, linear_tree):
+        tree, _, _, _ = linear_tree
+        ap = tree.find_attach_point([{"role": "system", "content": "subagent"}, {"role": "user", "content": "task"}])
+        assert ap.node is None
+        assert ap.best_overlap == 0
+
+    def test_case9_twin_tie_goes_to_latest_seq(self):
+        tree = SessionTree()
+        n0 = _commit(tree, None, [SYS, U1, A1])
+        twin_a = _commit(tree, n0, [T1, A2])
+        twin_b = _commit(tree, n0, [T1, A2])  # same delta text, later seq
+        assert twin_a.seq < twin_b.seq
+        ap = tree.find_attach_point([SYS, U1, A1, T1, A2, {"role": "user", "content": "next"}])
+        assert ap.node is twin_b
+
+    def test_deepest_match_wins_across_roots(self):
+        """Two roots where one's opening is a prefix of the other's history."""
+        tree = SessionTree()
+        r1 = _commit(tree, None, [SYS, U1, A1])
+        n1 = _commit(tree, r1, [T1, A2])
+        _commit(tree, None, [SYS, U1, {"role": "assistant", "content": "other-a1"}])
+        ap = tree.find_attach_point([SYS, U1, A1, T1, A2, T2])
+        assert ap.node is n1
+
+    def test_empty_request_is_new_root(self, linear_tree):
+        tree, _, _, _ = linear_tree
+        ap = tree.find_attach_point([])
+        assert ap.node is None
+        assert ap.best_overlap == 0
+
+    def test_search_never_mutates(self, linear_tree):
+        tree, _, _, _ = linear_tree
+        before = [(n.seq, len(n.children)) for n in tree.nodes]
+        tree.find_attach_point([SYS, U1, A1, T1, A2])
+        assert [(n.seq, len(n.children)) for n in tree.nodes] == before
+
+
+class TestModel:
+    def test_case10_concurrent_commits_become_siblings(self, linear_tree):
+        tree, n0, _, _ = linear_tree
+        s1 = _commit(tree, n0, [{"role": "user", "content": "sub A"}, A2])
+        s2 = _commit(tree, n0, [{"role": "user", "content": "sub B"}, A3])
+        assert s1 in n0.children and s2 in n0.children
+        assert s1.parent is n0 and s2.parent is n0
+
+    def test_full_snapshot_and_path_helpers(self, linear_tree):
+        _, n0, n1, n2 = linear_tree
+        assert n2.token_ids[: len(n1.token_ids)] == n1.token_ids  # snapshot inherits prefix
+        assert n2.path_nodes() == [n0, n1, n2]
+        assert n2.path_messages() == [SYS, U1, A1, T1, A2, T2, A3]
+
+    def test_case7_truncated_is_derived_from_finish_reason(self):
+        tree = SessionTree()
+        node = _commit(tree, None, [U1, A1], finish_reason="length")
+        assert node.truncated
+        assert not _commit(tree, node, [T1, A2]).truncated
+
+    def test_leaves_in_creation_order(self, linear_tree):
+        tree, n0, _, n2 = linear_tree
+        side = _commit(tree, n0, [T1, {"role": "assistant", "content": "retry"}])
+        assert tree.leaves() == [n2, side]
+
+    def test_case12_node_cap_fails_loud(self, monkeypatch):
+        monkeypatch.setattr(tree_trajectory, "MAX_NODES", 2)
+        tree = SessionTree()
+        n0 = _commit(tree, None, [U1, A1])
+        _commit(tree, n0, [T1, A2])
+        with pytest.raises(ValueError, match="node cap reached"):
+            _commit(tree, n0, [T1, A3])
+
+    def test_seq_is_creation_order_not_wall_clock(self):
+        """Wall clock is decoration: ordering must survive a clock step backwards."""
+        tree = SessionTree()
+        n0 = _commit(tree, None, [SYS, U1, A1], committed_at=100.0)
+        early_clock = _commit(tree, n0, [T1, A2], committed_at=50.0)
+        later = _commit(tree, n0, [T1, A2], committed_at=99.0)
+        assert early_clock.seq < later.seq
+        ap = tree.find_attach_point([SYS, U1, A1, T1, A2, T2])
+        assert ap.node is later

--- a/tests/fast/utils/test_arguments.py
+++ b/tests/fast/utils/test_arguments.py
@@ -205,6 +205,32 @@ def test_custom_megatron_post_save_hook_path_requires_save():
         miles_validate_args(args)
 
 
+class TestSessionServerV2Validation:
+    def _parse(self, extra):
+        parser = argparse.ArgumentParser()
+        get_miles_extra_args_provider()(parser)
+        return parser.parse_args(extra + ["--num-rollout", "1"] + REQUIRED_ARGS)
+
+    @pytest.mark.parametrize(
+        ("extra", "flag"),
+        [
+            (["--group-rm"], "--group-rm"),
+            (["--partial-rollout"], "--partial-rollout"),
+            (
+                ["--true-on-policy-mode", "--recompute-logprobs-via-prefill"],
+                "--recompute-logprobs-via-prefill",
+            ),
+        ],
+    )
+    def test_rejects_unsupported_list_consumers(self, extra, flag):
+        args = self._parse(["--use-session-server", "v2", *extra])
+
+        with pytest.raises(ValueError) as exc_info:
+            miles_validate_args(args)
+
+        assert str(exc_info.value) == (f"--use-session-server v2 does not support {flag}; v2 returns list[Sample]")
+
+
 class TestTitoFixedTemplateConfiguration:
     def _parse(self, extra):
         parser = argparse.ArgumentParser()

--- a/tests/fast/utils/test_utils/test_session_verify_runner.py
+++ b/tests/fast/utils/test_utils/test_session_verify_runner.py
@@ -50,6 +50,12 @@ def test_namespace_to_train_args_keeps_ci_test_enabled_for_fsdp_debug_rollout():
     assert "--ci-test" in train_args
 
 
+def test_namespace_to_train_args_uses_session_server_v2():
+    train_args = _build_args()
+
+    assert "--use-session-server v2" in train_args
+
+
 def test_namespace_to_train_args_has_no_append_role_policy_flag():
     train_args = _build_args()
 

--- a/tests/session_parity_utils.py
+++ b/tests/session_parity_utils.py
@@ -1,0 +1,343 @@
+"""Shared v1/v2 session sample parity helpers."""
+
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+import enum
+import json
+import math
+import struct
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from copy import deepcopy
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import patch
+
+import httpx
+import numpy as np
+
+from miles.rollout.base_types import GenerateFnInput
+from miles.rollout.generate_hub import agentic_tool_call
+from miles.rollout.generate_utils.openai_endpoint_utils import OpenAIEndpointTracer
+from miles.rollout.session.samples.codec import SamplesReply
+from miles.rollout.session.server import SessionServer
+from miles.utils import http_utils
+from miles.utils.http_utils import find_available_port
+from miles.utils.test_utils.uvicorn_thread_server import UvicornThreadServer
+from miles.utils.types import Sample
+
+V1 = "v1"
+V2 = "v2"
+SESSION_PARITY_SEED = 20260803
+
+_CHAT_TIMEOUT_SECS = 120.0
+_PICKER_PATH = "miles.rollout.session.v2.picker_hub.drop_retries"
+_POSTPROCESSOR_PATH = "miles.rollout.session.v2.postprocessor_hub.default_postprocess"
+_RUNTIME_LIFECYCLE_KEYS = frozenset({"t0", "t1", "req_ts", "prev_t1"})
+_EXPECTED_AGENT_METADATA = {
+    "driver_events": [
+        "initial",
+        "append_tool",
+        "append_user",
+        "append_tool",
+        "append_system",
+        "rollback",
+        "rollback",
+        "force_final",
+        "append_assistant",
+    ],
+    "rollback_count": 2,
+    "user_count": 2,
+    "system_count": 1,
+    "assistant_input_count": 2,
+    "tool_result_count": 2,
+    "tool_call_count": 2,
+}
+
+
+@dataclasses.dataclass(frozen=True)
+class SessionParityRun:
+    version: str
+    samples: list[Sample]
+    session_metadata: dict[str, Any]
+    pre_collect: dict[str, Any]
+    empty_reason: str | None
+
+
+def run_agentic_retry_trajectories(
+    *,
+    backend_url: str,
+    hf_checkpoint: str,
+    version: str,
+    input_samples: list[Sample],
+) -> list[SessionParityRun]:
+    """Run a concurrent weather-agent batch through one session version."""
+    if version not in (V1, V2):
+        raise ValueError(f"unknown session version: {version}")
+
+    with _serve_session(backend_url=backend_url, hf_checkpoint=hf_checkpoint, version=version) as args:
+        collected = asyncio.run(_run_and_collect(args=args, hf_checkpoint=hf_checkpoint, input_samples=input_samples))
+
+    return [
+        SessionParityRun(
+            version=version,
+            samples=samples,
+            session_metadata=reply.session_metadata,
+            pre_collect=pre_collect,
+            empty_reason=reply.empty_reason,
+        )
+        for pre_collect, reply, samples in collected
+    ]
+
+
+async def _run_and_collect(
+    *,
+    args: SimpleNamespace,
+    hf_checkpoint: str,
+    input_samples: list[Sample],
+) -> list[tuple[dict[str, Any], SamplesReply, list[Sample]]]:
+    async with httpx.AsyncClient(timeout=None) as client:
+        with patch.object(http_utils, "_http_client", client):
+            original_collect = OpenAIEndpointTracer.collect_samples
+            collected: dict[int, tuple[dict[str, Any], SamplesReply]] = {}
+
+            async def collect_with_snapshot(
+                tracer: OpenAIEndpointTracer,
+                collected_input_sample: Sample,
+                *,
+                max_seq_len: int | None,
+                agent_metadata: dict | None = None,
+            ) -> SamplesReply:
+                response = await client.get(tracer.base_url)
+                assert response.status_code == 200, response.text
+                reply = await original_collect(
+                    tracer,
+                    collected_input_sample,
+                    max_seq_len=max_seq_len,
+                    agent_metadata=agent_metadata,
+                )
+                collected[id(collected_input_sample)] = (response.json(), reply)
+                return reply
+
+            async def generate_one(input_sample: Sample):
+                input_sample.metadata.update(
+                    {
+                        "tito_model": args.tito_model,
+                        "session_verify_cycles": args.session_verify_cycles,
+                        "tool_call_failure_mode": args.tool_call_failure_mode,
+                    }
+                )
+                generate_input = GenerateFnInput(
+                    state=SimpleNamespace(args=args),
+                    sample=input_sample,
+                    sampling_params={
+                        "model": hf_checkpoint,
+                        "temperature": 0,
+                        "sampling_seed": SESSION_PARITY_SEED,
+                        "max_new_tokens": 128,
+                    },
+                    evaluation=False,
+                )
+                output = await agentic_tool_call.generate(generate_input)
+                return input_sample, output
+
+            with patch.object(OpenAIEndpointTracer, "collect_samples", collect_with_snapshot):
+                outputs = await asyncio.gather(*(generate_one(sample) for sample in input_samples))
+
+    results = []
+    for input_sample, output in outputs:
+        samples = output.samples if isinstance(output.samples, list) else [output.samples]
+        pre_collect, reply = collected[id(input_sample)]
+        results.append((pre_collect, reply, samples))
+    return results
+
+
+def assert_agentic_retry_trajectory_parity(v1: SessionParityRun, v2: SessionParityRun) -> None:
+    """Assert agent coverage, retry topology, and training-payload parity."""
+    assert v1.version == V1
+    assert v2.version == V2
+    assert v1.empty_reason is None
+    assert v2.empty_reason is None
+    assert len(v1.samples) == 1
+    assert len(v2.samples) == 1
+    assert len(v1.pre_collect["records"]) == 7
+    assert len(v2.pre_collect["records"]) == 7
+    _assert_weather_tool_round_trip(v1.pre_collect)
+    _assert_weather_tool_round_trip(v2.pre_collect)
+
+    tree = v2.pre_collect["metadata"]["tree"]
+    assert [(node["id"], node["parent"]) for node in tree["nodes"]] == [
+        (0, None),
+        (1, 0),
+        (2, 1),
+        (3, 2),
+        (4, 3),
+        (5, 3),
+        (6, 3),
+        (7, 6),
+        (8, 7),
+    ]
+    assert [(leaf["node_id"], leaf["path_node_ids"]) for leaf in tree["leaves"]] == [
+        (4, [0, 1, 2, 3, 4]),
+        (5, [0, 1, 2, 3, 5]),
+        (8, [0, 1, 2, 3, 6, 7, 8]),
+    ]
+
+    selected_leaf = v2.samples[0].metadata["leaf"]
+    assert selected_leaf["node_id"] == 8
+    assert selected_leaf["parent"] == 7
+    assert selected_leaf["path_node_ids"] == [0, 1, 2, 3, 6, 7, 8]
+    assert selected_leaf["response_id"] == tree["nodes"][8]["response_id"]
+    assert v2.session_metadata["agent"] == _EXPECTED_AGENT_METADATA
+    for key, value in _EXPECTED_AGENT_METADATA.items():
+        assert v1.samples[0].metadata[key] == value
+        assert v2.samples[0].metadata[key] == value
+    assert v1.samples[0].metadata["max_trim_tokens"] == v2.session_metadata["max_trim_tokens"]
+
+    v2_linear_metadata = {key: value for key, value in v2.session_metadata.items() if key not in ("agent", "tree")}
+    _assert_bits_equal(v1.session_metadata, v2_linear_metadata, path="session_metadata")
+    assert_sample_bitwise_equal(
+        v1.samples[0],
+        v2.samples[0],
+        metadata_projection=_training_metadata_projection,
+    )
+
+
+def assert_sample_bitwise_equal(
+    left: Sample,
+    right: Sample,
+    *,
+    metadata_projection: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
+) -> None:
+    """Compare every declared Sample field without float tolerance."""
+    assert type(left) is type(right)
+    left_extras = set(vars(left)) - {field.name for field in dataclasses.fields(left)}
+    right_extras = set(vars(right)) - {field.name for field in dataclasses.fields(right)}
+    assert left_extras == right_extras == set()
+
+    for field in dataclasses.fields(left):
+        left_value = getattr(left, field.name)
+        right_value = getattr(right, field.name)
+        if field.name == "metadata" and metadata_projection is not None:
+            left_value = metadata_projection(left_value)
+            right_value = metadata_projection(right_value)
+        _assert_bits_equal(left_value, right_value, path=f"sample.{field.name}")
+
+
+@contextmanager
+def _serve_session(*, backend_url: str, hf_checkpoint: str, version: str) -> Iterator[SimpleNamespace]:
+    port = find_available_port(31000)
+    instance_id = f"session-parity-{version}"
+    args = SimpleNamespace(
+        miles_router_timeout=_CHAT_TIMEOUT_SECS,
+        hf_checkpoint=hf_checkpoint,
+        chat_template_path=None,
+        apply_chat_template_kwargs={"enable_thinking": False},
+        tito_model="qwen3",
+        sglang_speculative_algorithm=None,
+        use_session_server=version,
+        use_rollout_routing_replay=False,
+        use_rollout_indexer_replay=False,
+        session_server_instance_id=instance_id,
+        session_server_ip="127.0.0.1",
+        session_server_ports=[port],
+        session_server_instance_ids={port: instance_id},
+        save_debug_trajectory_data=None,
+        custom_agent_function_path="miles.utils.test_utils.session_verify_agent.run_agent",
+        max_seq_len=None,
+        session_verify_cycles=1,
+        tool_call_failure_mode="rollback",
+        session_sample_picker_path=_PICKER_PATH,
+        session_sample_postprocessor_path=_POSTPROCESSOR_PATH,
+    )
+    app = SessionServer(args, backend_url=backend_url).app
+    server = UvicornThreadServer(app, host=args.session_server_ip, port=port)
+    server.start()
+    try:
+        yield args
+    finally:
+        server.stop()
+
+
+def _training_metadata_projection(metadata: dict[str, Any]) -> dict[str, Any]:
+    projected = deepcopy(metadata)
+    projected.pop("leaf", None)
+    projected.pop("max_trim_tokens", None)
+    lifecycle = projected.get("lifecycle")
+    if lifecycle is not None:
+        segments = lifecycle if isinstance(lifecycle, list) else [lifecycle]
+        projected["lifecycle"] = [_project_lifecycle_segment(segment) for segment in segments]
+    return projected
+
+
+def _assert_weather_tool_round_trip(snapshot: dict[str, Any]) -> None:
+    records = snapshot["records"]
+    for record in records:
+        assert [tool["function"]["name"] for tool in record["request"]["tools"]] == ["get_weather"]
+
+    for call_index, result_index, location in ((0, 1, "Beijing"), (2, 3, "Shanghai")):
+        [tool_call] = records[call_index]["response"]["choices"][0]["message"]["tool_calls"]
+        assert tool_call["function"]["name"] == "get_weather"
+        assert json.loads(tool_call["function"]["arguments"]) == {"location": location}
+
+        tool_result = records[result_index]["request"]["messages"][-1]
+        assert tool_result["role"] == "tool"
+        assert tool_result["tool_call_id"] == tool_call["id"]
+
+
+def _project_lifecycle_segment(segment: dict[str, Any]) -> dict[str, Any]:
+    projected = dict(segment)
+    for key in _RUNTIME_LIFECYCLE_KEYS & projected.keys():
+        if projected[key] is not None:
+            assert type(projected[key]) in (int, float)
+            assert math.isfinite(projected[key])
+            projected[key] = "<runtime>"
+    return projected
+
+
+def _assert_bits_equal(left: Any, right: Any, *, path: str) -> None:
+    left_bits = _bit_tree(left, path=path)
+    right_bits = _bit_tree(right, path=path)
+    if left_bits != right_bits:
+        raise AssertionError(f"{path} is not bitwise equal")
+
+
+def _bit_tree(value: Any, *, path: str) -> Any:
+    if dataclasses.is_dataclass(value):
+        declared = {field.name for field in dataclasses.fields(value)}
+        extras = set(vars(value)) - declared
+        if extras:
+            raise AssertionError(f"{path} has undeclared fields: {sorted(extras)}")
+        return (
+            "dataclass",
+            type(value),
+            tuple(
+                (field.name, _bit_tree(getattr(value, field.name), path=f"{path}.{field.name}"))
+                for field in dataclasses.fields(value)
+            ),
+        )
+    if isinstance(value, np.ndarray):
+        if value.dtype.hasobject:
+            raise AssertionError(f"{path} has object dtype")
+        if not value.flags.c_contiguous:
+            raise AssertionError(f"{path} is not C-contiguous")
+        return "ndarray", value.dtype.str, value.shape, value.tobytes(order="C")
+    if isinstance(value, np.generic):
+        return "numpy-scalar", value.dtype.str, value.tobytes()
+    if isinstance(value, enum.Enum):
+        return "enum", type(value), _bit_tree(value.value, path=f"{path}.value")
+    if isinstance(value, dict):
+        items = [
+            (_bit_tree(key, path=f"{path}.<key>"), _bit_tree(item, path=f"{path}[{key!r}]"))
+            for key, item in value.items()
+        ]
+        return "dict", tuple(sorted(items, key=lambda pair: repr(pair[0])))
+    if isinstance(value, (list, tuple)):
+        return type(value), tuple(_bit_tree(item, path=f"{path}[{index}]") for index, item in enumerate(value))
+    if isinstance(value, float):
+        return "float64", struct.pack(">d", value)
+    if value is None or type(value) in (bool, int, str, bytes):
+        return type(value), value
+    raise TypeError(f"unsupported value at {path}: {type(value).__name__}")


### PR DESCRIPTION
## Motivation

The session server needs multi-lineage trajectory support (retries, compaction with carried assistants, subagent forests). Earlier revisions of this branch replaced the linear implementation in place; that made a brand-new system look like an evolution of the old one and put the default production path at risk. This revision restructures the work so that:

- **v1 (linear trajectory) is preserved byte-exactly** and stays the default. `git diff` against the pre-branch base is empty for every v1 module and test file.
- **The tree implementation lands as an opt-in session server v2** (`--use-session-server v2`), fully contained in `miles/rollout/session/v2/`.

## Commit series (atop the stacked picks)

1. `test(session)`: nine byte-exact HTTP pins for the v1 retry/rollback surface, verified against the untouched tree — the default path can never move silently. Includes a characterization pin for v1's few-shot prompt-assistant anchoring quirk (out of v1's append-only + one-step-retry envelope; such flows belong to v2).
2. `fix(tito)`: preserve-think kwargs become family constants on every template surface ("never cut think"), plus `supports_midpath_assistant_rerender` marking DeepSeek-V3.2's structural exception. Spike-verified byte-identical on pure tool loops.
3. `feat(session)`: v2 trajectory tree — node = end of one model generation, full root→node token snapshots, pure deepest-prefix attach search, append-only commits under the session lock (`MAX_NODES=1024` backstop).
4. `feat(session)`: session server v2 — always-branch serving (mismatches grow siblings/new roots; retry semantics moves to the samples-op picker), `--session-strict-append-only` single-chain guard, compaction splice with zero-inheritance-root fallback, 409 on extending truncated generations, per-leaf assembly with default pick (temporal-supersession trim, roots never trimmed, non-retry-shaped trees 422) and default merge (exactly-once completion masking, rewards keyed by response id), both replaceable via `--session-sample-picker-path` / `--session-merge-function-path`. Version dispatch is a ~10-line seam in `sessions.py`; the codec is parameterized so the v1 wire stays byte-identical while v2 adds `reward`/`metadata`.
5. `feat(rollout)`: driver-side seam — the agent's semantic layer (per-branch rewards) travels through `collect_samples` under v2 and comes back applied by the server-side merge; the v1 driver path (metadata overlays, `{"max_seq_len": ...}` collect body) is byte-equal to before, pinned.
6. `test(session)`: tree-merge legality invariants — an independent oracle over randomized forests (seeded fuzz banks for retry shapes, truncation, guardrail-422 shapes) plus targeted edges (chained retries, equal-length twins, fork-below-fork ownership, mid-path length turns).

## Testing

- v1: restored suites pass unmodified; A-list byte-exactness proven by empty `git diff` against base; new v1 pins green against the pristine tree.
- v2: HTTP matrix (branching, strict, truncation/compaction), session-state unit matrix (49), samples-op suite (16, incl. hook lanes), tree model (18), invariants fuzz (59). Router + session + generate_utils: **326 passed**.
- chat-template suite: 1463 passed (1 pre-existing failure on upstream picks, unrelated).

## Follow-ups

- GPU e2e for v2 branching flows (`session_verify_runner` branching-harness variant) on 4×H200 CI.
- v2 twins of the race-condition / pretokenized e2e suites (v1-only today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NmYsBAGK6NDt1LzjA7VSqH
