### PR TITLE
Add host memory monitoring to the dashboard

### DIFF
--- a/miles/backends/megatron_utils/actor.py
+++ b/miles/backends/megatron_utils/actor.py
@@ -354,7 +354,8 @@ class MegatronTrainRayActor(TrainRayActor):
                 return TrainStepOutcome.NORMAL
 
         if self.role == "critic":
-            return self.train_critic(rollout_id, rollout_data)
+            with timer("critic_train"):
+                return self.train_critic(rollout_id, rollout_data)
         else:
             return self.train_actor(rollout_id, rollout_data, witness_info=witness_info, attempt=attempt)
 

--- a/miles/dashboard/README.md
+++ b/miles/dashboard/README.md
@@ -13,10 +13,10 @@ python train.py ... \
 ```
 
 `--use-miles-dashboard` adds a named collector actor on the driver node, one
-NVML sampler per GPU node, per-rank phase interval sinks on the existing
-`Timer` instrumentation, and an sglang engine-metric scraper. Everything is
-appended under `{dump-details}/dashboard/` (append-only JSONL). Overhead on
-the training path is a few milliseconds per step; all pushes are
+NVML + host-memory sampler per GPU node, per-rank phase interval sinks on the
+existing `Timer` instrumentation, and an sglang engine-metric scraper.
+Everything is appended under `{dump-details}/dashboard/` (append-only JSONL).
+Overhead on the training path is a few milliseconds per step; all pushes are
 fire-and-forget and a dead collector never affects training.
 
 `--dump-details` alone (no `--use-miles-dashboard`) still writes the rollout
@@ -43,11 +43,12 @@ Views:
 - **Metrics** — a wandb-style category sidebar over every logged metric, plus
   an `sglang` category (scraped engine series) when present; hover for values,
   drag to zoom.
-- **Compute Utilization** — per-GPU lanes below 64 GPUs (phase band, NVML
-  utilization, sglang overlay, click-to-zoom bubble strip); above that, a
-  scale-invariant fleet overview (phase composition + utilization band) with a
-  lane-selection grammar (`g:` / `rank:` / `node:` / `every:`) and outlier
-  quick-picks.
+- **Compute Utilization** — one node-level CPU memory-pressure row plus per-GPU
+  lanes below 64 GPUs (phase band, NVML utilization, sglang overlay,
+  click-to-zoom bubble strip); hover CPU memory for used/available/total GiB.
+  Above that, a scale-invariant fleet overview (phase composition + utilization
+  band) with a lane-selection grammar (`g:` / `rank:` / `node:` / `every:`)
+  and outlier quick-picks.
 - **Rollouts** — per-step trajectory table and scatter, GRPO group degeneracy
   (`zero_std`), average weight-version staleness, eval tab.
 - **sample view** — a `conversation` tab (role-tagged turns with thinking /

--- a/miles/dashboard/args.py
+++ b/miles/dashboard/args.py
@@ -36,11 +36,17 @@ def add_dashboard_arguments(parser) -> None:
         "--use-miles-dashboard",
         action="store_true",
         default=False,
-        help="Collect dashboard telemetry (phases, GPU util, engine metrics) under {dump-details}/dashboard/. "
+        help="Collect dashboard telemetry (phases, GPU/CPU-memory util, engine metrics) under "
+        "{dump-details}/dashboard/. "
         "Requires --dump-details. View with `python -m miles.dashboard.serve`.",
     )
     group.add_argument("--dashboard-flush-interval", type=float, default=5.0, help="collector disk flush cadence (s)")
-    group.add_argument("--dashboard-gpu-sample-interval", type=float, default=1.0, help="NVML sampling cadence (s)")
+    group.add_argument(
+        "--dashboard-gpu-sample-interval",
+        type=float,
+        default=1.0,
+        help="Per-node NVML and CPU-memory sampling cadence (s)",
+    )
     group.add_argument("--dashboard-sglang-scrape-interval", type=float, default=2.0, help="engine scrape cadence (s)")
     group.add_argument(
         "--dashboard-sglang-scrape-mode",

--- a/miles/dashboard/collector.py
+++ b/miles/dashboard/collector.py
@@ -30,6 +30,7 @@ from typing import Any, ClassVar
 
 from miles.dashboard.sglang_scraper import DEFAULT_METRIC_WHITELIST, ScrapeMode, SglangScraper
 from miles.dashboard.store import (
+    CpuMemorySample,
     DataBufferSample,
     EngineInfo,
     EngineSample,
@@ -70,6 +71,14 @@ class _SelfGpuProcessPush:
         self._handle.push_gpu_processes.remote(node, batch)
 
 
+class _SelfCpuMemoryPush:
+    def __init__(self, handle):
+        self._handle = handle
+
+    def __call__(self, node: str, batch: list[CpuMemorySample]) -> None:
+        self._handle.push_cpu_memory_samples.remote(node, batch)
+
+
 def _default_list_gpu_nodes() -> list[tuple[str, str]]:
     # no initialized ray in this process = not running as the collector actor
     # (unit tests, tooling): nothing to reconcile, and never pay the import
@@ -91,6 +100,7 @@ def _default_spawn_sampler(node_id: str, node_ip: str, interval: float):
 
     from miles.dashboard.gpu_sampler import GpuSampler
 
+    collector_handle = ray.get_runtime_context().current_actor
     handle = (
         ray.remote(GpuSampler)
         .options(
@@ -98,10 +108,11 @@ def _default_spawn_sampler(node_id: str, node_ip: str, interval: float):
             scheduling_strategy=NodeAffinitySchedulingStrategy(node_id=node_id, soft=False),
         )
         .remote(
-            _SelfGpuPush(ray.get_runtime_context().current_actor),
+            _SelfGpuPush(collector_handle),
             node=node_ip,
             interval=interval,
-            push_processes=_SelfGpuProcessPush(ray.get_runtime_context().current_actor),
+            push_processes=_SelfGpuProcessPush(collector_handle),
+            cpu_push=_SelfCpuMemoryPush(collector_handle),
         )
     )
     if ray.get(handle.start.remote()):
@@ -160,6 +171,7 @@ class DashboardCollector:
         # latest-value caches for the Prometheus forwarding snapshot; kept
         # separately because store buffers empty out on every flush
         self._latest_gpu: dict[tuple[str, int], GpuSample] = {}
+        self._latest_cpu_memory: dict[str, CpuMemorySample] = {}
         self._latest_running_reqs: dict[str, float] = {}
         self._latest_phase_seconds: dict[str, float] = {}
         self._scraped_engine_addrs: set[str] = set()
@@ -217,6 +229,10 @@ class DashboardCollector:
 
     def push_data_buffer(self, sample: DataBufferSample) -> None:
         self._append(sample)
+
+    def push_cpu_memory_samples(self, node: str, batch: list[CpuMemorySample]) -> None:
+        for sample in batch:
+            self._append(sample)
 
     def update_topology(self, snapshot: TopologySnapshot) -> None:
         # an addr the actor path ever registered must not be resurrected as
@@ -303,6 +319,8 @@ class DashboardCollector:
     def _update_latest(self, record: Record) -> None:
         if isinstance(record, GpuSample):
             self._latest_gpu[(record.node, record.gpu)] = record
+        elif isinstance(record, CpuMemorySample):
+            self._latest_cpu_memory[record.node] = record
         elif isinstance(record, EngineSample):
             self._scraped_engine_addrs.add(record.addr)
             if record.metric == "sglang_num_running_reqs":
@@ -375,6 +393,14 @@ class DashboardCollector:
             snapshot |= {
                 f"dashboard/gpu_{safe(node)}_{gpu}_mem_mb": float(sample.mem_mb)
                 for (node, gpu), sample in self._latest_gpu.items()
+            }
+            snapshot |= {
+                f"dashboard/cpu_{safe(node)}_memory_percent": float(sample.percent)
+                for node, sample in self._latest_cpu_memory.items()
+            }
+            snapshot |= {
+                f"dashboard/cpu_{safe(node)}_memory_used_bytes": float(sample.used_bytes)
+                for node, sample in self._latest_cpu_memory.items()
             }
             snapshot |= {
                 f"dashboard/engine_{safe(addr)}_running_reqs": value

--- a/miles/dashboard/gpu_sampler.py
+++ b/miles/dashboard/gpu_sampler.py
@@ -24,7 +24,7 @@ from collections.abc import Callable
 from typing import ClassVar
 
 from miles.dashboard.logging_utils import RateLimitedWarner
-from miles.dashboard.store import GpuProcessSample, GpuSample
+from miles.dashboard.store import CpuMemorySample, GpuProcessSample, GpuSample
 
 logger = logging.getLogger(__name__)
 
@@ -44,6 +44,8 @@ class GpuSampler:
         interval: float = 1.0,
         nvml=None,
         push_processes: Callable[[str, list[GpuProcessSample]], None] | None = None,
+        cpu_push: Callable[[str, list[CpuMemorySample]], None] | None = None,
+        psutil_module=None,
     ):
         assert interval > 0, f"{interval=}"
         self._push = push
@@ -51,14 +53,21 @@ class GpuSampler:
         self.node = node
         self.interval = interval
         self._nvml = nvml
+        self._cpu_push = cpu_push
+        self._psutil = psutil_module
         self._handles: list = []
         self._uuids: list[str] = []
         self._buffer: list[GpuSample] = []
         self._process_buffer: list[GpuProcessSample] = []
+        self._cpu_buffer: list[CpuMemorySample] = []
         self._buffer_lock = threading.Lock()
         self._stop_event = threading.Event()
         self._thread: threading.Thread | None = None
         self._warner = RateLimitedWarner(logger)
+        if self._cpu_push is not None and self._psutil is None:
+            import psutil
+
+            self._psutil = psutil
         self.available = self._init_nvml()
 
     def _init_nvml(self) -> bool:
@@ -129,6 +138,7 @@ class GpuSampler:
                     GpuSample(ts=ts, node=self.node, gpu=gpu, util=util, mem_mb=mem_mb, power_w=power_w)
                 )
             count += 1
+        self._sample_cpu_memory(ts)
         return count
 
     def sample_processes_once(self, ts: float) -> int:
@@ -166,11 +176,38 @@ class GpuSampler:
         except Exception:
             return f"pid {pid}"  # process exited between enumeration and lookup, or name unavailable
 
+    def _sample_cpu_memory(self, ts: float) -> None:
+        if self._cpu_push is None:
+            return
+        try:
+            memory = self._psutil.virtual_memory()
+            total = int(memory.total)
+            available = int(memory.available)
+            used = max(0, total - available)
+            percent = 100.0 * used / total if total else 0.0
+        except Exception:
+            self._warner.warn(f"CPU memory read failed on {self.node}; skipping this tick")
+            return
+        with self._buffer_lock:
+            self._cpu_buffer.append(
+                CpuMemorySample(
+                    ts=ts,
+                    node=self.node,
+                    used_bytes=used,
+                    available_bytes=available,
+                    total_bytes=total,
+                    percent=percent,
+                )
+            )
+
     def flush(self) -> None:
         with self._buffer_lock:
             batch, self._buffer = self._buffer, []
             process_batch, self._process_buffer = self._process_buffer, []
+            cpu_batch, self._cpu_buffer = self._cpu_buffer, []
         if batch:
             self._push(self.node, batch)
         if process_batch and self._push_processes is not None:
             self._push_processes(self.node, process_batch)
+        if cpu_batch and self._cpu_push is not None:
+            self._cpu_push(self.node, cpu_batch)

--- a/miles/dashboard/hooks.py
+++ b/miles/dashboard/hooks.py
@@ -87,6 +87,9 @@ class PhaseSink:
                 if self._identity is None or (self._identity.rank < 0 and self.role == Role.TRAIN):
                     self._identity = _resolve_identity()
                 identity = self._identity
+                completed, self._buffer = self._buffer, []
+                if completed:
+                    self._last_flush = time.monotonic()
             event = PhaseEvent(
                 name=name,
                 t0=t0,
@@ -96,7 +99,7 @@ class PhaseSink:
                 rank=identity.rank,
                 role=self.role,
             )
-            self._handle.push_phases.remote([event])
+            self._handle.push_phases.remote([*completed, event])
         except Exception:
             self._warner.warn("dashboard phase sink failed; dropping events")
 

--- a/miles/dashboard/server.py
+++ b/miles/dashboard/server.py
@@ -101,7 +101,12 @@ def make_app(
             capabilities=dict(
                 has_metrics=store.has_stream(Stream.METRICS),
                 has_tokenizer=(reader.dump_dir / "tokenizer").is_dir(),
-                has_timeline=store.has_stream(Stream.PHASES) or store.has_stream(Stream.GPU_UTIL),
+                has_timeline=(
+                    store.has_stream(Stream.PHASES)
+                    or store.has_stream(Stream.GPU_UTIL)
+                    or store.has_stream(Stream.CPU_MEMORY)
+                ),
+                has_cpu_memory=store.has_stream(Stream.CPU_MEMORY),
                 has_engine_series=store.has_stream(Stream.ENGINE_SERIES),
                 max_window_s=MetricStore.MAX_WINDOW_S,
                 use_utilization_overview=use_utilization_overview,
@@ -175,6 +180,18 @@ def make_app(
         with _translate_errors():
             _check_window(t0, t1)
             return dict(advisories=[asdict(a) for a in compute_advisories(store, t0=t0, t1=t1)])
+
+    @app.get("/api/timeline/cpu_memory")
+    def timeline_cpu_memory(
+        t0: float | None = None, t1: float | None = None, max_points: int = 2000, lanes: str | None = None
+    ):
+        with _translate_errors():
+            _check_window(t0, t1)
+            if max_points < 2:
+                raise ValueError(f"{max_points=} must be >= 2")
+            resolved = store.resolve_lanes(lanes)
+            nodes = None if resolved is None else {node for node, _ in resolved}
+            return dict(nodes=store.cpu_memory_series(t0=t0, t1=t1, max_points=max_points, nodes=nodes))
 
     @app.get("/api/timeline/heatmap")
     def timeline_heatmap(

--- a/miles/dashboard/static/views_timeline.js
+++ b/miles/dashboard/static/views_timeline.js
@@ -14,6 +14,7 @@ const PHASE_COLORS = {
   rollout: "#d55816",
   eval_rollout: "#e8a683",
   actor_train: "#2a78d6",
+  critic_train: "#5f5aa8",
   train_log_probs: "#c3b8ec",
   log_probs: "#8b7bd8",
   ref_log_probs: "#4a3aa7",
@@ -34,6 +35,7 @@ const OVERLAY_METRICS = [
 ];
 const OVERLAY_COLOR = "#b84a12";
 const MEM_COLOR = "#1baf7a";
+const CPU_COLORS = ["#c2410c", "#b45309", "#a21caf", "#0f766e", "#4338ca", "#be123c"];
 const UTIL_STROKE = "rgba(42, 120, 214, 0.9)";
 const UTIL_FILL = "rgba(42, 120, 214, 0.14)";
 const TEXT = "#231f1c";
@@ -50,6 +52,8 @@ const QUICK_PICKS = [
 const QUICK_PICK_K = 8;
 
 const LANE_H = 66;
+const CPU_ROW_H = 58;
+const CPU_PLOT_H = 40;
 const PHASE_H = 14;
 const UTIL_H = 40;
 const M_LEFT = 96;
@@ -84,6 +88,8 @@ export async function renderTimeline(view, meta, route) {
   let advisories = [];
   let bubbles = [];
   let gpu = {};
+  let cpuMemory = {};
+  let cpuMemoryEnabled = Boolean(meta.capabilities.has_cpu_memory);
   let engineSeries = [];
   let T0 = 0;
   let T1 = 1;
@@ -131,6 +137,7 @@ export async function renderTimeline(view, meta, route) {
     if (!haveData) {
       lanes = [];
       gpu = {};
+      cpuMemory = {};
       phasesByLane = new Map();
       processesByLane = new Map();
       return;
@@ -155,10 +162,13 @@ export async function renderTimeline(view, meta, route) {
         history.replaceState(null, "", `#/timeline?lanes=${encodeURIComponent(selection)}`);
       }
     }
-    const [phasesRes, gpuRes, processesRes] = await Promise.all([
+    const [phasesRes, gpuRes, processesRes, cpuRes] = await Promise.all([
       api("/api/timeline/phases", { t0: f0, t1: f1, lanes: selection }),
       api("/api/timeline/gpu", { t0: f0, t1: f1, max_points: 4000, lanes: selection }),
       api("/api/timeline/gpu_processes", { t0: f0, t1: f1, lanes: selection }),
+      cpuMemoryEnabled
+        ? api("/api/timeline/cpu_memory", { t0: f0, t1: f1, max_points: 4000, lanes: selection })
+        : Promise.resolve({ nodes: {} }),
     ]);
     engineSeries = overlayMetric
       ? (await api("/api/timeline/engine_series", { metric: overlayMetric, t0: f0, t1: f1, max_points: 4000 }))
@@ -178,6 +188,7 @@ export async function renderTimeline(view, meta, route) {
     if (lanes.length > LANE_CAP) lanes = lanes.slice(0, LANE_CAP);
     capped = Math.max(0, total - lanes.length);
     gpu = gpuRes.lanes;
+    cpuMemory = cpuRes.nodes;
     multiNode = new Set(lanes.map((l) => l.node)).size > 1;
     phasesByLane = new Map(lanes.map((l) => [laneKey(l), []]));
     for (const p of phasesRes.phases) phasesByLane.get(`${p.node}:${p.gpu}`)?.push(p);
@@ -419,9 +430,12 @@ export async function renderTimeline(view, meta, route) {
   const canvas = el("canvas", { class: "timeline" });
   const overlayMax = () => Math.max(...engineSeries.flatMap((s) => s.value), 1e-9);
   const memMax = () => Math.max(...Object.values(gpu).flatMap((s) => s.mem_mb), 1);
+  const cpuNodes = () => Object.keys(cpuMemory).sort();
+  const cpuOffset = () => (cpuNodes().length ? CPU_ROW_H : 0);
 
   function draw() {
-    canvas.style.height = `${M_TOP + Math.max(lanes.length, 1) * LANE_H + 8}px`;
+    const cpuH = cpuOffset();
+    canvas.style.height = `${M_TOP + cpuH + Math.max(lanes.length, 1) * LANE_H + 8}px`;
     const dpr = window.devicePixelRatio || 1;
     const rect = canvas.getBoundingClientRect();
     canvas.width = rect.width * dpr;
@@ -448,13 +462,44 @@ export async function renderTimeline(view, meta, route) {
       ctx.fillText(label, X(t) - Math.min(30, label.length * 3.2), 12);
       ctx.beginPath();
       ctx.moveTo(X(t), M_TOP - 6);
-      ctx.lineTo(X(t), M_TOP + lanes.length * LANE_H);
+      ctx.lineTo(X(t), M_TOP + cpuH + lanes.length * LANE_H);
       ctx.stroke();
+    }
+
+    if (cpuH) {
+      const nodes = cpuNodes();
+      const yTop = M_TOP + 4;
+      const yBot = yTop + CPU_PLOT_H;
+      ctx.fillStyle = TEXT;
+      ctx.fillText("CPU mem", 8, yTop + 8);
+      ctx.fillStyle = MUTED;
+      ctx.fillText("0–100%", 8, yTop + 22);
+      ctx.strokeStyle = GRID;
+      ctx.beginPath();
+      ctx.moveTo(M_LEFT, yBot);
+      ctx.lineTo(width - M_RIGHT, yBot);
+      ctx.stroke();
+      nodes.forEach((node, nodeIndex) => {
+        const series = cpuMemory[node];
+        ctx.beginPath();
+        let started = false;
+        for (let j = 0; j < series.ts.length; j++) {
+          const t = series.ts[j];
+          if (t < v0 || t > v1) continue;
+          const y = yBot - (series.percent[j] / 100) * CPU_PLOT_H;
+          started ? ctx.lineTo(X(t), y) : ctx.moveTo(X(t), y);
+          started = true;
+        }
+        ctx.strokeStyle = CPU_COLORS[nodeIndex % CPU_COLORS.length];
+        ctx.lineWidth = 1.6;
+        ctx.stroke();
+        ctx.lineWidth = 1;
+      });
     }
 
     lanes.forEach((lane, i) => {
       const key = laneKey(lane);
-      const yPhase = M_TOP + i * LANE_H + 4;
+      const yPhase = M_TOP + cpuH + i * LANE_H + 4;
       const yUtilTop = yPhase + PHASE_H + 4;
       const yUtilBot = yUtilTop + UTIL_H;
 
@@ -616,7 +661,29 @@ export async function renderTimeline(view, meta, route) {
       return;
     }
     const rect = canvas.getBoundingClientRect();
-    const laneIdx = Math.floor((ev.clientY - rect.top - M_TOP) / LANE_H);
+    const localY = ev.clientY - rect.top - M_TOP;
+    const cpuH = cpuOffset();
+    if (cpuH && localY >= 0 && localY < cpuH && ev.clientX - rect.left >= M_LEFT) {
+      const t = timeAt(ev.clientX);
+      const lines = [`CPU memory  +${fmtNum(t - T0)}s`];
+      cpuNodes().forEach((node) => {
+        const series = cpuMemory[node];
+        if (!series.ts.length) return;
+        let best = 0;
+        for (let j = 1; j < series.ts.length; j++) {
+          if (Math.abs(series.ts[j] - t) < Math.abs(series.ts[best] - t)) best = j;
+        }
+        const gib = 1024 ** 3;
+        lines.push(
+          `${node}: ${fmtNum(series.percent[best])}%`,
+          `  used ${fmtNum(series.used_bytes[best] / gib)} / ${fmtNum(series.total_bytes[best] / gib)} GiB` +
+            ` · available ${fmtNum(series.available_bytes[best] / gib)} GiB`,
+        );
+      });
+      showTooltip(ev.clientX, ev.clientY, lines.join("\n"));
+      return;
+    }
+    const laneIdx = Math.floor((localY - cpuH) / LANE_H);
     if (laneIdx < 0 || laneIdx >= lanes.length || ev.clientX - rect.left < M_LEFT) {
       hideTooltip();
       return;
@@ -677,6 +744,9 @@ export async function renderTimeline(view, meta, route) {
         }),
         el("span", { style: `color: ${OVERLAY_COLOR}` }, ["— engine overlay"]),
         el("span", { style: `color: ${UTIL_STROKE}` }, ["— gpu util"]),
+        ...cpuNodes().map((node, i) =>
+          el("span", { style: `color: ${CPU_COLORS[i % CPU_COLORS.length]}` }, [`— cpu memory ${node}`]),
+        ),
       ]),
     );
   };
@@ -727,7 +797,9 @@ export async function renderTimeline(view, meta, route) {
       refreshing = true;
       try {
         // fresh global range (cheap edge-stamp read); getMeta() is cached
-        applyRange((await api("/api/meta")).time_range);
+        const latestMeta = await api("/api/meta");
+        applyRange(latestMeta.time_range);
+        cpuMemoryEnabled = Boolean(latestMeta.capabilities.has_cpu_memory);
         await Promise.all([loadData(), loadAdvisories()]);
         renderAll();
         await carpet.refresh(carpetRange());

--- a/miles/dashboard/store.py
+++ b/miles/dashboard/store.py
@@ -49,6 +49,7 @@ class Stream(StrEnum):
     PHASES = "phases"
     TOPOLOGY = "topology"
     GPU_UTIL = "gpu_util"
+    CPU_MEMORY = "cpu_memory"
     ENGINE_SERIES = "engine_series"
     TRAJECTORIES = "trajectories"
     GPU_PROCESSES = "gpu_processes"
@@ -203,6 +204,17 @@ class GpuSample(Record):
 
 
 @dataclass
+class CpuMemorySample(Record):
+    stream: ClassVar[Stream] = Stream.CPU_MEMORY
+    ts: float
+    node: str
+    used_bytes: int
+    available_bytes: int
+    total_bytes: int
+    percent: float
+
+
+@dataclass
 class EngineSample(Record):
     """One scraped sglang engine metric value."""
 
@@ -237,6 +249,7 @@ _RECORD_TYPE_OF_STREAM: dict[Stream, type[Record]] = {
         PhaseEvent,
         TopologySnapshot,
         GpuSample,
+        CpuMemorySample,
         EngineSample,
         TrajectoryEvent,
         GpuProcessSample,
@@ -378,9 +391,14 @@ class _PartitionReader:
 
 
 class MetricStore:
-    COLUMNAR_STREAMS: ClassVar[tuple[Stream, ...]] = (Stream.GPU_UTIL, Stream.ENGINE_SERIES)
+    COLUMNAR_STREAMS: ClassVar[tuple[Stream, ...]] = (
+        Stream.GPU_UTIL,
+        Stream.CPU_MEMORY,
+        Stream.ENGINE_SERIES,
+    )
     PARTITIONED_STREAMS: ClassVar[tuple[Stream, ...]] = (
         Stream.GPU_UTIL,
+        Stream.CPU_MEMORY,
         Stream.ENGINE_SERIES,
         Stream.PHASES,
         Stream.TRAJECTORIES,
@@ -392,6 +410,14 @@ class MetricStore:
     FRAME_SCHEMAS: ClassVar[dict[Stream, dict[str, Any]]] = {
         Stream.GPU_UTIL: dict(
             ts=pl.Float64, node=pl.String, gpu=pl.Int64, util=pl.Int64, mem_mb=pl.Int64, power_w=pl.Int64
+        ),
+        Stream.CPU_MEMORY: dict(
+            ts=pl.Float64,
+            node=pl.String,
+            used_bytes=pl.Int64,
+            available_bytes=pl.Int64,
+            total_bytes=pl.Int64,
+            percent=pl.Float64,
         ),
         # labels dicts are canonicalized to a JSON string column at parse time
         Stream.ENGINE_SERIES: dict(
@@ -737,6 +763,9 @@ class MetricStore:
         if stream is Stream.GPU_UTIL:
             frame = self._readers[stream].window(None, None)
             return [GpuSample(**row) for row in frame.iter_rows(named=True)]
+        if stream is Stream.CPU_MEMORY:
+            frame = self._readers[stream].window(None, None)
+            return [CpuMemorySample(**row) for row in frame.iter_rows(named=True)]
         if stream is Stream.ENGINE_SERIES:
             return [
                 EngineSample(
@@ -961,6 +990,32 @@ class MetricStore:
             for e in events
             if lanes is None or (e.node, e.gpu) in lanes
         ]
+
+    def cpu_memory_series(
+        self,
+        *,
+        t0: float | None = None,
+        t1: float | None = None,
+        max_points: int = 2000,
+        nodes: set[str] | None = None,
+    ) -> dict[str, dict]:
+        frame = self._window(self._readers[Stream.CPU_MEMORY].window(t0, t1), t0, t1)
+        out = {}
+        for key, part in sorted(frame.partition_by("node", as_dict=True).items()):
+            node = key[0] if isinstance(key, tuple) else key
+            if nodes is not None and node not in nodes:
+                continue
+            part = part.sort("ts")
+            percent = part["percent"].to_numpy()
+            indices, _ = minmax_downsample(np.arange(part.height), percent, max_points)
+            out[node] = dict(
+                ts=part["ts"].to_numpy()[indices].tolist(),
+                percent=percent[indices].tolist(),
+                used_bytes=part["used_bytes"].to_numpy()[indices].tolist(),
+                available_bytes=part["available_bytes"].to_numpy()[indices].tolist(),
+                total_bytes=part["total_bytes"].to_numpy()[indices].tolist(),
+            )
+        return out
 
     # cumulative engine families are stored raw; the catalog exposes them as
     # per-interval derived series instead

--- a/tests/fast/dashboard/dummy_telemetry.py
+++ b/tests/fast/dashboard/dummy_telemetry.py
@@ -30,6 +30,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from miles.dashboard.store import (
+    CpuMemorySample,
     EngineInfo,
     EngineSample,
     GpuSample,
@@ -147,7 +148,23 @@ def dump_dummy_telemetry(
     def engine_b_addr(ts: float) -> str:
         return ENGINE_B_OLD if ts < truth.restart_ts else ENGINE_B_NEW
 
+    total_memory = 2 * 1024**4
+
+    def append_cpu_memory(ts: float, percent: float) -> None:
+        used = int(total_memory * percent / 100)
+        store.append(
+            CpuMemorySample(
+                ts=ts,
+                node=GPU_NODE,
+                used_bytes=used,
+                available_bytes=total_memory - used,
+                total_bytes=total_memory,
+                percent=percent,
+            )
+        )
+
     for offset in range(INIT_SECONDS):
+        append_cpu_memory(BASE_TS + offset, 25.0)
         for gpu in range(gpus):
             store.append(GpuSample(ts=BASE_TS + offset, node=GPU_NODE, gpu=gpu, util=20, mem_mb=30_000, power_w=300))
 
@@ -210,6 +227,7 @@ def dump_dummy_telemetry(
 
         for offset in range(STEP_SECONDS):
             ts = t + offset
+            append_cpu_memory(ts, 35.0 if offset < ROLLOUT_SECONDS else 70.0)
             for gpu in range(gpus):
                 drain = DRAIN_A if gpu < 2 else DRAIN_B
                 if offset < ROLLOUT_SECONDS:

--- a/tests/fast/dashboard/test_collector.py
+++ b/tests/fast/dashboard/test_collector.py
@@ -7,6 +7,7 @@ from tests.fast.dashboard.dummy_telemetry import BASE_TS, dump_dummy_telemetry
 from miles.dashboard.collector import CollectorConfig, DashboardCollector
 from miles.dashboard.sglang_scraper import ScrapeMode
 from miles.dashboard.store import (
+    CpuMemorySample,
     DataBufferSample,
     EngineInfo,
     GpuProcessSample,
@@ -55,6 +56,11 @@ def test_collector_satisfies_dummy_telemetry_contract(tmp_path):
         by_node.setdefault(sample.node, []).append(sample)
     for node, batch in by_node.items():
         collector.push_gpu_samples(node, batch)
+    by_node_cpu: dict[str, list[CpuMemorySample]] = {}
+    for sample in reference.iter_records(Stream.CPU_MEMORY):
+        by_node_cpu.setdefault(sample.node, []).append(sample)
+    for node, batch in by_node_cpu.items():
+        collector.push_cpu_memory_samples(node, batch)
     for sample in reference.iter_records(Stream.ENGINE_SERIES):
         collector._append(sample)  # the scraper sink path
     collector.flush()
@@ -64,6 +70,7 @@ def test_collector_satisfies_dummy_telemetry_contract(tmp_path):
     assert replayed.topology_windows() == reference.topology_windows()
     assert replayed.phases_by_lane() == reference.phases_by_lane()
     assert replayed.gpu_series() == reference.gpu_series()
+    assert replayed.cpu_memory_series() == reference.cpu_memory_series()
     assert replayed.engine_series("sglang_num_running_reqs") == reference.engine_series("sglang_num_running_reqs")
     assert replayed.bubbles() == reference.bubbles()
     assert replayed.meta.run_name == reference.meta.run_name
@@ -193,6 +200,19 @@ def test_prometheus_forwarding_snapshot(tmp_path):
     collector.push_gpu_samples(
         "10.0.0.1", [GpuSample(ts=1.0, node="10.0.0.1", gpu=0, util=87, mem_mb=1000, power_w=600)]
     )
+    collector.push_cpu_memory_samples(
+        "10.0.0.1",
+        [
+            CpuMemorySample(
+                ts=1.0,
+                node="10.0.0.1",
+                used_bytes=300,
+                available_bytes=700,
+                total_bytes=1000,
+                percent=30.0,
+            )
+        ],
+    )
     collector.push_phases(
         [PhaseEvent(name="actor_train", t0=1.0, t1=61.0, node="10.0.0.1", gpus=[0], rank=0, role=Role.TRAIN)]
     )
@@ -202,6 +222,8 @@ def test_prometheus_forwarding_snapshot(tmp_path):
     assert len(updates) == 2
     snapshot = updates[-1]
     assert snapshot["dashboard/gpu_10_0_0_1_0_util"] == 87.0
+    assert snapshot["dashboard/cpu_10_0_0_1_memory_percent"] == 30.0
+    assert snapshot["dashboard/cpu_10_0_0_1_memory_used_bytes"] == 300.0
     assert snapshot["dashboard/phase_actor_train_seconds"] == 60.0
     assert all("." not in k and ":" not in k for k in snapshot)
 

--- a/tests/fast/dashboard/test_gpu_sampler.py
+++ b/tests/fast/dashboard/test_gpu_sampler.py
@@ -4,7 +4,7 @@ import time
 import pytest
 
 from miles.dashboard.gpu_sampler import GpuSampler
-from miles.dashboard.store import GpuProcessSample, GpuSample
+from miles.dashboard.store import CpuMemorySample, GpuProcessSample, GpuSample
 
 
 class FakeNvml:
@@ -64,6 +64,15 @@ class ProcessPushSpy:
         self.calls.append((node, batch))
 
 
+class FakePsutil:
+    calls = 0
+
+    @classmethod
+    def virtual_memory(cls):
+        cls.calls += 1
+        return type("Memory", (), {"total": 1000, "available": 250})()
+
+
 def test_sample_once_converts_units():
     push = PushSpy()
     sampler = GpuSampler(push, node="10.0.0.1", nvml=FakeNvml(count=2))
@@ -90,6 +99,35 @@ def test_flush_clears_buffer_and_skips_empty():
     sampler.flush()
     sampler.flush()  # cleared: no duplicate push
     assert len(push.calls) == 1
+
+
+def test_cpu_memory_sampled_once_per_node_tick_and_flushed_separately():
+    gpu_push = PushSpy()
+    cpu_push = PushSpy()
+    FakePsutil.calls = 0
+    sampler = GpuSampler(
+        gpu_push,
+        node="n",
+        nvml=FakeNvml(count=4),
+        cpu_push=cpu_push,
+        psutil_module=FakePsutil,
+    )
+
+    assert sampler.sample_once(ts=7.0) == 4
+    assert FakePsutil.calls == 1
+    sampler.flush()
+    [(node, batch)] = cpu_push.calls
+    assert node == "n"
+    assert batch == [
+        CpuMemorySample(
+            ts=7.0,
+            node="n",
+            used_bytes=750,
+            available_bytes=250,
+            total_bytes=1000,
+            percent=75.0,
+        )
+    ]
 
 
 def test_nvml_init_failure_disables_sampler(caplog):

--- a/tests/fast/dashboard/test_hooks.py
+++ b/tests/fast/dashboard/test_hooks.py
@@ -299,3 +299,20 @@ def test_phase_sink_begin_pushes_open_event_immediately():
     assert event.name == "rollout" and event.t0 == 100.0
     assert event.open and event.t1 == PhaseEvent.OPEN_T1
     assert (event.node, event.rank) == ("10.0.0.3", 7)
+
+
+def test_phase_sink_begin_flushes_previous_completion_before_open_event():
+    from miles.dashboard.store import PhaseEvent
+
+    handle = FakeHandle()
+    hooks.attach_phase_sink(handle, Role.TRAIN)
+    [sink] = Timer().event_sinks
+
+    sink("data_preprocess", 100.0, 100.4)
+    assert handle.push_phases.calls == []
+
+    sink.begin("critic_train", 100.4)
+    [(args, _)] = handle.push_phases.calls
+    completed, opened = args[0]
+    assert (completed.name, completed.t0, completed.t1) == ("data_preprocess", 100.0, 100.4)
+    assert (opened.name, opened.t0, opened.t1) == ("critic_train", 100.4, PhaseEvent.OPEN_T1)

--- a/tests/fast/dashboard/test_store.py
+++ b/tests/fast/dashboard/test_store.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 
 from miles.dashboard.store import (
+    CpuMemorySample,
     DataBufferSample,
     EngineInfo,
     EngineSample,
@@ -37,6 +38,14 @@ def _one_of_each() -> list:
             ],
         ),
         GpuSample(ts=10.5, node="10.0.0.2", gpu=0, util=87, mem_mb=61234, power_w=612),
+        CpuMemorySample(
+            ts=10.55,
+            node="10.0.0.2",
+            used_bytes=300,
+            available_bytes=700,
+            total_bytes=1000,
+            percent=30.0,
+        ),
         TrajectoryEvent(
             ts=10.7,
             kind=TrajectoryEventKind.GEN_START,

--- a/tests/fast/dashboard/test_timeline.py
+++ b/tests/fast/dashboard/test_timeline.py
@@ -96,6 +96,23 @@ def test_gpu_series_time_filter(loaded):
         assert all(t0 <= ts <= t1 for ts in series["ts"])
 
 
+def test_cpu_memory_series_is_node_level_aligned_and_downsampled(loaded):
+    store, truth = loaded
+    nodes = store.cpu_memory_series(max_points=40)
+    assert set(nodes) == {GPU_NODE}
+    series = nodes[GPU_NODE]
+    assert len(series["ts"]) <= 40
+    assert len(series["ts"]) == len(series["percent"]) == len(series["used_bytes"])
+    assert len(series["ts"]) == len(series["available_bytes"]) == len(series["total_bytes"])
+    assert min(series["percent"]) == 25.0
+    assert max(series["percent"]) == 70.0
+    assert series["ts"] == sorted(series["ts"])
+
+    t0, t1 = truth.rollout_interval(0)
+    window = store.cpu_memory_series(t0=t0, t1=t1)[GPU_NODE]
+    assert all(t0 <= ts <= t1 for ts in window["ts"])
+
+
 def test_engine_series_split_on_restart(loaded):
     store, truth = loaded
     series = store.engine_series("sglang_num_running_reqs")
@@ -168,6 +185,7 @@ def test_timeline_endpoints(tmp_path):
     meta = client.get("/api/meta").json()
     assert meta["capabilities"]["has_timeline"] is True
     assert meta["capabilities"]["has_engine_series"] is True
+    assert meta["capabilities"]["has_cpu_memory"] is True
 
     topology = client.get("/api/timeline/topology").json()
     assert len(topology["lanes"]) == truth.gpus
@@ -179,6 +197,10 @@ def test_timeline_endpoints(tmp_path):
     gpu = client.get("/api/timeline/gpu", params={"max_points": 50}).json()
     assert set(gpu["lanes"]) == {f"{GPU_NODE}:{g}" for g in range(truth.gpus)}
     assert client.get("/api/timeline/gpu", params={"max_points": 1}).status_code == 400
+
+    cpu = client.get("/api/timeline/cpu_memory", params={"max_points": 50}).json()
+    assert set(cpu["nodes"]) == {GPU_NODE}
+    assert client.get("/api/timeline/cpu_memory", params={"max_points": 1}).status_code == 400
 
     engines = client.get("/api/timeline/engine_series", params={"metric": "sglang_gen_throughput"}).json()
     assert {s["addr"] for s in engines["series"]} == {ENGINE_A, ENGINE_B_OLD, ENGINE_B_NEW}


### PR DESCRIPTION
## Summary

- Collect node-level host memory samples alongside GPU telemetry.
- Persist and expose CPU memory series through the dashboard APIs.
- Render host memory pressure in the Compute Utilization view and add test coverage.

## Why

Training jobs can experience host memory pressure even when GPU utilization looks healthy. Showing node memory in the same timeline makes those failures easier to diagnose.

## Impact

This adds lightweight host-memory sampling and a node-level memory row to the dashboard. Existing GPU telemetry and training behavior remain unchanged.

## Related
https://github.com/radixark/miles/pull/1736
https://github.com/radixark/miles/pull/1735

## Validation

- `python -m pytest --confcutdir=tests/fast/dashboard tests/fast/dashboard/ -q` — 186 passed, 4 skipped
- `ruff check` on all changed Python files
- `git diff --check`
