### PR TITLE
fix(docker): set TMS_CUDA_MAJOR for torch_memory_saver source build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -128,7 +128,9 @@ RUN git clone https://github.com/${MEGATRON_REPO}.git --recursive -b ${MEGATRON_
 # git source Megatron-LM itself pins in pyproject.toml.
 RUN pip install "git+https://github.com/NVIDIA-NeMo/Emerging-Optimizers.git@v0.1.0"
 
-RUN pip install git+https://github.com/fzyzcjy/torch_memory_saver.git --no-cache-dir --force-reinstall
+# torch_memory_saver's source build needs TMS_CUDA_MAJOR; take it from torch.
+RUN TMS_CUDA_MAJOR=$(python3 -c "import torch; print(torch.version.cuda.split('.')[0])") \
+    pip install git+https://github.com/fzyzcjy/torch_memory_saver.git --no-cache-dir --force-reinstall
 RUN pip install "nvidia-modelopt[torch]>=0.37.0" --no-build-isolation
 RUN pip install git+https://github.com/radixark/Megatron-Bridge.git@bridge --no-deps --no-build-isolation
 RUN pip install megatron-energon --no-deps


### PR DESCRIPTION
## Problem
#1773 unpinned `torch_memory_saver` (`@d64a639` → master), which crossed the multi-cuda-wheel change. Its `setup.py` now aborts a CUDA source build unless `TMS_CUDA_MAJOR` is set:

```
RuntimeError: TMS_CUDA_MAJOR env var must be set for CUDA builds
```

so the Docker Build & Push on main fails at the `pip install git+...torch_memory_saver.git` step ([failing run](https://github.com/radixark/miles/actions/runs/30033598982/job/89295870022)).

## Fix
Set `TMS_CUDA_MAJOR` for that build, derived from the image's own torch (`torch.version.cuda`), so the cu12 and cu13 variants each build the matching wheel with no hardcoding.

## Notes
- Verified the command form (`TMS_CUDA_MAJOR=<n> pip install git+...torch_memory_saver.git`) builds cleanly against current TMS master on an 8×H200 CUDA-13 box.
- `Dockerfile.rocm` left unpinned as #1773 set it — `TMS_CUDA_MAJOR` is a CUDA-only requirement; the ROCm build detects hip and does not need it.