### PR TITLE
Bump TransformerEngine to 2.17.0

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -94,19 +94,21 @@ RUN pip install causal-conv1d==1.6.1 mamba-ssm==2.3.1 --no-build-isolation
 
 # transformer_engine
 RUN if [ "${ENABLE_CUDA_13}" = "1" ]; then \
-      pip install --no-deps transformer_engine==2.12.0 && \
-      pip install transformer_engine_cu13==2.12.0 && \
+      pip install --no-deps transformer_engine==2.17.0 && \
+      pip install transformer_engine_cu13==2.17.0 && \
       if ls /tmp/wheels/transformer_engine_torch-*.whl 2>/dev/null | grep -q .; then \
         pip install /tmp/wheels/transformer_engine_torch-*.whl; \
       else \
         pip install nvidia-mathdx==25.6.0 && \
-        pip -v install --no-build-isolation transformer_engine_torch==2.12.0; \
+        pip -v install --no-build-isolation transformer_engine_torch==2.17.0; \
       fi; \
     else \
-      pip -v install --no-build-isolation "transformer_engine[pytorch]==2.10.0"; \
+      pip -v install --no-build-isolation "transformer_engine[pytorch]==2.17.0"; \
     fi
 
-# TE patches (cu13): B300/GB300 sm103 FA2 whitelist fix
+# TE patches (cu13): B300/GB300 FA2 and backward override fixes
+# te_dequantized_backward_override.patch is a hot fix from
+# https://github.com/NVIDIA/TransformerEngine/pull/3141; drop it after TE v2.18.
 COPY docker/patch/ /tmp/patches/
 RUN if [ "${ENABLE_CUDA_13}" = "1" ] && [ -d /tmp/patches/cu13 ]; then \
       TE_DIR=$(python -c 'import transformer_engine; print(transformer_engine.__path__[0])') && \

--- a/docker/patch/cu13/te_dequantized_backward_override.patch
+++ b/docker/patch/cu13/te_dequantized_backward_override.patch
@@ -1,0 +1,22 @@
+--- a/pytorch/module/grouped_linear.py
++++ b/pytorch/module/grouped_linear.py
+@@ -431,6 +431,8 @@
+             backward_override = None
+         if backward_override == "high_precision":
+             save_original_input = True
++        elif backward_override == "dequantized":
++            save_original_input = False
+ 
+         num_gemms = len(m_splits)
+         weights = weights_and_biases[:num_gemms]
+--- a/pytorch/module/linear.py
++++ b/pytorch/module/linear.py
+@@ -285,6 +285,8 @@
+     is_fsdp2 = args.is_fsdp2
+     if backward_override == "high_precision":
+         save_original_input = True
++    elif backward_override == "dequantized":
++        save_original_input = False
+ 
+     # NVTX label for profiling
+     nvtx_label = "transformer_engine._Linear.forward"

--- a/docker/patch/cu13/te_fa2_sm103_whitelist.patch
+++ b/docker/patch/cu13/te_fa2_sm103_whitelist.patch
@@ -1,11 +1,19 @@
 --- a/pytorch/attention/dot_product_attention/utils.py
 +++ b/pytorch/attention/dot_product_attention/utils.py
-@@ -629,7 +629,7 @@
-         or head_dim_qk % 8 != 0
-         or (
-             head_dim_qk > 192
--            and device_compute_capability not in ((8, 0), (9, 0), (10, 0), (12, 0))
-+            and device_compute_capability not in ((8, 0), (9, 0), (10, 0), (10, 3), (12, 0))
+@@ -848,16 +848,11 @@
+         and (
+             fa2_padded_head_dim > 256
+             or fa2_padded_head_dim % 8 != 0
+-            or (
+-                fa2_padded_head_dim > 192
+-                and device_compute_capability not in ((8, 0), (9, 0), (10, 0), (12, 0))
+-            )
          )
      ):
-         if FlashAttentionUtils.is_installed:
+         logger.debug(
+             "Disabling FlashAttention 2 due to unsupported head_dim_qk and head_dim_v. "
+             "Supported after padding: padded head_dim %%8 = 0, padded head_dim <= 256 "
+-            "(>192 requires sm80/90/100+). "
+             "Found: head_dim_qk = %s, head_dim_v = %s, padded head_dim = %s, on sm%s.",
+             head_dim_qk,
+             head_dim_v,


### PR DESCRIPTION
## Summary

Bumps TransformerEngine 2.12.0 → 2.17.0 (cu13 trio: `transformer_engine` / `transformer_engine_cu13` / `transformer_engine_torch`; cu12 path 2.10.0 → 2.17.0). This is the dependency prerequisite for #1261 (NVFP4 RL), which constructs `transformer_engine.pytorch.tensor.nvfp4_tensor.NVFP4Quantizer` directly.

## TE patches

- `te_dequantized_backward_override.patch` (new): hot fix from NVIDIA/TransformerEngine#3141; drop after TE v2.18.
- `te_fa2_sm103_whitelist.patch`: updated for the TE 2.17 source layout.

Both patch files are regenerated from pristine pip-installed TE 2.17.0 sources so that they apply cleanly with **both** GNU `patch -p1` (fuzz 0) and `git apply`. The originals from the #1261 branch fail the Dockerfile's `patch -p1` step (the dequantized patch is rejected by GNU patch 2.7.6 even at default fuzz; the fa2 patch needs fuzz 2 and is rejected by `git apply` as corrupt), which would break the image build.

## Validation

- `tests/fast-gpu/test_nvfp4_quantizer.py`: **633 passed** on a B200 devbox with TE 2.17.0 + both patches.
- Qwen3-30B-A3B NVFP4 e2e (the #1261 branch merged with current main) on 4x B300 (actor 2 GPU TP2/EP2, rollout 2 GPU, `--rollout-nvfp4 --train-nvfp4`): NVFP4 checkpoint conversion, sglang `flashinfer_trtllm_routed` rollout, and bf16+fp4 Megatron training all run; steps 0-2 stable with `train_rollout_logprob_abs_diff` ≈ 0.054-0.056 and `train_rollout_kl` ≈ 0.012-0.013 (same order as the step-1 sanity numbers reported in #1261).
- `te.Linear` fwd/bwd and rowwise `NVFP4Quantizer` smoke-tested on GPU after upgrade.

Note for #1261: after this lands, rebase onto main and drop the branch's copies of the Dockerfile TE bump and the two patch files (this PR's regenerated patch bytes must win, or the docker build fails at the patch step).