### PR TITLE
chore(ci): pin docker build to 2-GPU H200 runners

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -144,7 +144,7 @@ jobs:
     if: |
       always() &&
       (github.event_name != 'schedule' || needs.check-upstream.outputs.should_build == 'true')
-    runs-on: self-hosted
+    runs-on: ["h200", "2gpu"]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
Pin the docker build job to 2-GPU H200 runners instead of any self-hosted machine. These runners are usually idle.

## Motivation
The docker build-and-push job ran on any `self-hosted` runner. Target the `["h200", "2gpu"]` runner class instead, matching the runner-label convention the CI fleet already uses in pr-test.yml.

## Usage
Trigger a build as before, e.g. `gh workflow run docker-build.yml -f variant=cu13 -f image_tag=dev`; the `build-and-push` job now schedules only on a runner carrying both the `h200` and `2gpu` labels.

## Design Notes
- **Key choices:** reuse the exact label pair `["h200", "2gpu"]` that `pr-test.yml` already targets for its 2-GPU H200 stages.
- **Alternatives considered:** keeping `self-hosted` alongside the new labels was dropped because the fleet convention in `_run-ci.yml` matches GPU runners by hardware labels alone.

## Verification
- **Tests added:** none — the change is one `runs-on` label line.
- The `check yaml` pre-commit hook passed at commit time.

## Review Focus
- Scrutinize the `runs-on` label pair in `.github/workflows/docker-build.yml`: confirm the runners meant to build docker images carry the full `h200` + `2gpu` label pair.
