### PR TITLE
Fix torch_memory_saver LD_PRELOAD path for CUDA-suffixed binaries

### DIFF
--- a/miles/ray/train/actor_factory.py
+++ b/miles/ray/train/actor_factory.py
@@ -41,13 +41,9 @@ def allocate_gpus_for_actor(
         env_vars["DUMPER_SOURCE_PATCHER_CONFIG"] = source_patcher_config
 
     if args.offload_train and args.train_backend == "megatron":
-        import torch_memory_saver
+        from torch_memory_saver.utils import get_binary_path_from_package
 
-        dynlib_path = os.path.join(
-            os.path.dirname(os.path.dirname(torch_memory_saver.__file__)),
-            "torch_memory_saver_hook_mode_preload.abi3.so",
-        )
-        assert os.path.exists(dynlib_path), f"LD_PRELOAD so file {dynlib_path} does not exist."
+        dynlib_path = str(get_binary_path_from_package("torch_memory_saver_hook_mode_preload"))
 
         env_vars["LD_PRELOAD"] = dynlib_path
         env_vars["TMS_INIT_ENABLE"] = "1"


### PR DESCRIPTION
## Problem

Since torch_memory_saver was upgraded to 0.0.9.post1 (#1773, #1774), the package ships **CUDA-major-suffixed** preload binaries (e.g. `torch_memory_saver_hook_mode_preload_cu13.abi3.so`) instead of the old unsuffixed `torch_memory_saver_hook_mode_preload.abi3.so`.

`miles/ray/train/actor_factory.py` still hardcodes the old unsuffixed filename and asserts it exists, so **every `offload_train` megatron run on the current `:dev` image dies at startup**:

```
AssertionError: LD_PRELOAD so file .../torch_memory_saver_hook_mode_preload.abi3.so does not exist.
```

This is currently red on main's own offload_train megatron path and blocks unrelated PRs (surfaced while monitoring #1261's stage-c-8-gpu CI).

## Fix

Use the package-provided `get_binary_path_from_package("torch_memory_saver_hook_mode_preload")` helper, which resolves the correct CUDA-suffixed variant (and raises a clear error itself if none is found, so the hand-written assert is no longer needed).

## Validation

On a `radixark/miles:dev` B300 devbox (torch_memory_saver 0.0.9.post1):
```
>>> from torch_memory_saver.utils import get_binary_path_from_package
>>> get_binary_path_from_package("torch_memory_saver_hook_mode_preload")
/usr/local/lib/python3.12/dist-packages/torch_memory_saver_hook_mode_preload_cu13.abi3.so   # exists
```
pre-commit passes.