### PR TITLE
Add backend-aware MUSA support to Miles

### DIFF
--- a/miles/__init__.py
+++ b/miles/__init__.py
@@ -1,0 +1,1 @@
+from miles.utils import accelerator as _accelerator

--- a/miles/backends/experimental/fsdp_utils/actor.py
+++ b/miles/backends/experimental/fsdp_utils/actor.py
@@ -10,7 +10,7 @@ import torch.distributed as dist
 from tqdm import tqdm
 
 from miles.ray.train_actor import TrainRayActor
-from miles.utils import train_dump_utils, train_metric_utils
+from miles.utils import accelerator, train_dump_utils, train_metric_utils
 from miles.utils.context_utils import with_defer
 from miles.utils.distributed_utils import get_gloo_group
 from miles.utils.ft_utils.indep_dp import IndepDPInfo
@@ -257,10 +257,10 @@ class FSDPTrainRayActor(TrainRayActor):
 
         # Rank 0: move with weights, others: allocate empty tensors on device
         if dist.get_rank() == 0:
-            model = model.to(device=torch.cuda.current_device(), non_blocking=True)
+            model = model.to(device=accelerator.device(), non_blocking=True)
         else:
             # to_empty creates tensors on device without initializing memory
-            model = model.to_empty(device=torch.cuda.current_device())
+            model = model.to_empty(device=accelerator.device())
 
         is_cpu_offload = cpu_offload is not None
         options = StateDictOptions(full_state_dict=True, cpu_offload=is_cpu_offload, broadcast_from_rank0=True)
@@ -274,7 +274,7 @@ class FSDPTrainRayActor(TrainRayActor):
         if is_cpu_offload:
             model.to("cpu", non_blocking=True)
             for buf in model.buffers():
-                buf.data = buf.data.to(torch.cuda.current_device())
+                buf.data = buf.data.to(accelerator.device())
 
         return model
 
@@ -298,8 +298,8 @@ class FSDPTrainRayActor(TrainRayActor):
         if not self.args.offload_train:
             return
 
-        self.model.cuda()
-        move_torch_optimizer(self.optimizer, "cuda")
+        self.model.to(accelerator.device())
+        move_torch_optimizer(self.optimizer, accelerator.device())
         dist.barrier(group=get_gloo_group())
         print_memory("after wake_up model")
 
@@ -337,7 +337,7 @@ class FSDPTrainRayActor(TrainRayActor):
         if model_tag == "ref" and self.ref_model is not None:
             if not self.fsdp_cpu_offload:
                 self.model.cpu()
-                torch.cuda.empty_cache()
+                accelerator.empty_cache()
                 dist.barrier(group=get_gloo_group())
 
             active_model = self.ref_model
@@ -402,11 +402,11 @@ class FSDPTrainRayActor(TrainRayActor):
         finally:
             # Restore actor model if it was offloaded
             if model_tag == "ref" and self.ref_model is not None:
-                torch.cuda.empty_cache()
+                accelerator.empty_cache()
                 dist.barrier(group=get_gloo_group())
 
                 if not self.fsdp_cpu_offload:
-                    self.model.cuda()
+                    self.model.to(accelerator.device())
                     dist.barrier(group=get_gloo_group())
 
     def train(
@@ -667,8 +667,8 @@ class FSDPTrainRayActor(TrainRayActor):
 
             if "cu_seqlens" in batch:
                 cu_seqlens = batch["cu_seqlens"]
-                if not cu_seqlens.is_cuda:
-                    cu_seqlens = cu_seqlens.cuda()
+                if cu_seqlens.device.type != accelerator.device_type():
+                    cu_seqlens = cu_seqlens.to(accelerator.device())
                 update_ring_flash_attn_params(cu_seqlens, self.cp_group)
 
             input_ids = torch.chunk(input_ids, get_parallel_state().cp.size, dim=1)[get_parallel_state().cp.rank]
@@ -699,7 +699,7 @@ def move_torch_optimizer(optimizer, device):
                 if isinstance(value, torch.Tensor):
                     state[key] = value.to(device, non_blocking=True)
 
-    torch.cuda.synchronize()
+    accelerator.synchronize()
 
 
 def apply_fsdp2(model, mesh=None, cpu_offload=False, args=None):

--- a/miles/backends/experimental/fsdp_utils/checkpoint.py
+++ b/miles/backends/experimental/fsdp_utils/checkpoint.py
@@ -12,6 +12,8 @@ import torch.distributed.checkpoint as dcp
 from torch.distributed.checkpoint.state_dict import get_state_dict, set_state_dict
 from torch.distributed.checkpoint.stateful import Stateful
 
+from miles.utils import accelerator
+
 logger = logging.getLogger(__name__)
 
 
@@ -168,7 +170,11 @@ def finalize_load(actor: Any, checkpoint_payload: dict[str, Any] | None) -> None
         rng_state = checkpoint_payload["rng"]
         if "torch" in rng_state:
             torch.set_rng_state(rng_state["torch"])
-        if torch.cuda.is_available() and "cuda" in rng_state:
+        rng_key = accelerator.device_type()
+        accelerator_module = accelerator.accelerator_module()
+        if rng_key in rng_state and hasattr(accelerator_module, "set_rng_state_all"):
+            accelerator_module.set_rng_state_all(rng_state[rng_key])
+        elif "cuda" in rng_state and accelerator.is_cuda_available():
             torch.cuda.set_rng_state_all(rng_state["cuda"])
 
     metadata = checkpoint_payload.get("metadata") or {}
@@ -183,7 +189,7 @@ def finalize_load(actor: Any, checkpoint_payload: dict[str, Any] | None) -> None
         if getattr(actor.args, "start_rollout_id", None) is None:
             actor.args.start_rollout_id = iteration
 
-    torch.cuda.synchronize()
+    accelerator.synchronize()
     dist.barrier()
 
 
@@ -193,7 +199,7 @@ def save(actor: Any, iteration: int) -> None:
     Saves model weights and optimizer state to separate directories.
     This allows loading weights without optimizer or deleting optimizer before loading.
     """
-    torch.cuda.synchronize()
+    accelerator.synchronize()
 
     base_dir = Path(actor.args.save).expanduser()
     step_id = iteration + 1
@@ -229,7 +235,9 @@ def save(actor: Any, iteration: int) -> None:
 
     if dist.get_rank() == 0:
         rng_state = {"torch": torch.get_rng_state()}
-        rng_state["cuda"] = torch.cuda.get_rng_state_all()
+        accelerator_module = accelerator.accelerator_module()
+        if hasattr(accelerator_module, "get_rng_state_all"):
+            rng_state[accelerator.device_type()] = accelerator_module.get_rng_state_all()
         torch.save(rng_state, checkpoint_dir / "rng.pt")
 
         metadata = {

--- a/miles/backends/experimental/fsdp_utils/update_weight_utils.py
+++ b/miles/backends/experimental/fsdp_utils/update_weight_utils.py
@@ -10,6 +10,9 @@ import torch.distributed as dist
 from ray.actor import ActorHandle
 from torch.distributed.tensor import DTensor, Replicate
 
+from miles.utils import accelerator
+
+
 try:
     from sglang.srt.utils.patch_torch import monkey_patch_torch_reductions  # type: ignore[import]
 except ImportError:
@@ -64,7 +67,7 @@ class UpdateWeight(abc.ABC):
                 bucket = []
                 bucket_size = 0
 
-            param = param.cuda()
+            param = param.to(accelerator.device())
             if isinstance(param, DTensor):
                 # async version of param.full_tensor
                 param = param.redistribute(
@@ -234,12 +237,12 @@ class UpdateWeightFromDistributed(UpdateWeight):
                     i * self.args.rollout_num_gpus_per_engine + 1,
                     world_size,
                     self._group_name,
-                    backend="nccl",
+                    backend=accelerator.process_group_backend("nccl"),
                 )
                 for i, engine in enumerate(self.rollout_engines)
             ]
             self._model_update_groups = init_process_group(
-                backend="nccl",
+                backend=accelerator.process_group_backend("nccl"),
                 init_method=f"tcp://{master_address}:{master_port}",
                 world_size=world_size,
                 rank=0,
@@ -270,7 +273,7 @@ class UpdateWeightFromDistributed(UpdateWeight):
         handles = []
         # Broadcast parameters one by one with memory management
         for _name, param in named_tensors:
-            torch.cuda.empty_cache()
+            accelerator.empty_cache()
             # Ensure tensor is contiguous and on the right device
             param_data = param.data.contiguous()
 

--- a/miles/backends/megatron_utils/__init__.py
+++ b/miles/backends/megatron_utils/__init__.py
@@ -1,6 +1,7 @@
 import logging
 
 import torch
+from miles.utils import accelerator
 
 try:
     import deep_ep
@@ -12,7 +13,7 @@ try:
         if torch_memory_saver._impl is not None:
             torch_memory_saver._impl._binary_wrapper.cdll.tms_set_interesting_region(False)
         old_init(self, *args, **kwargs)
-        torch.cuda.synchronize()
+        accelerator.synchronize()
         if torch_memory_saver._impl is not None:
             torch_memory_saver._impl._binary_wrapper.cdll.tms_set_interesting_region(True)
 

--- a/miles/backends/megatron_utils/actor.py
+++ b/miles/backends/megatron_utils/actor.py
@@ -58,7 +58,6 @@ from .parallel import verify_megatron_parallel_state
 from .replay_utils import register_replay_list_moe
 from .update_weight.common import named_params_and_buffers
 from .update_weight.update_weight_from_distributed.broadcast import UpdateWeightFromDistributed
-from .update_weight.update_weight_from_distributed.p2p import UpdateWeightP2P
 from .update_weight.update_weight_from_tensor import UpdateWeightFromTensor
 
 if TYPE_CHECKING:
@@ -230,6 +229,14 @@ class MegatronTrainRayActor(TrainRayActor):
 
                 update_weight_cls = UpdateWeightFromDiskDelta
             else:
+                try:
+                    from .update_weight.update_weight_from_distributed.p2p import UpdateWeightP2P
+                except ImportError as exc:
+                    raise ImportError(
+                        "P2P weight transfer is not available with the current SGLang installation. "
+                        "Use --update-weight-transfer-mode broadcast, or switch to an SGLang version "
+                        "that provides the P2P update dependencies."
+                    ) from exc
                 update_weight_cls = UpdateWeightP2P
         self.weight_updater = update_weight_cls(
             self.args,

--- a/miles/backends/megatron_utils/actor.py
+++ b/miles/backends/megatron_utils/actor.py
@@ -13,6 +13,7 @@ from torch_memory_saver import torch_memory_saver
 
 from miles.dashboard import hooks as dashboard_hooks
 from miles.ray.train_actor import TrainRayActor
+from miles.utils import accelerator
 from miles.utils import train_dump_utils
 from miles.utils.argparse_utils import inplace_modify_args
 from miles.utils.audit_utils.event_logger.logger import event_logger_context
@@ -510,7 +511,7 @@ class MegatronTrainRayActor(TrainRayActor):
             if self._enable_weight_backup:
                 self.weights_backuper.backup("actor")
             else:
-                torch.cuda.synchronize()
+                accelerator.synchronize()
 
             # Update ref model if needed
             if (
@@ -765,7 +766,7 @@ class MegatronTrainRayActor(TrainRayActor):
         group_name = "actor_critic"
         world_size = 2
         self._actor_critic_groups = init_process_group(
-            backend="nccl",
+            backend=accelerator.process_group_backend("nccl"),
             init_method=f"tcp://{master_address}:{master_port}",
             world_size=world_size,
             rank=0 if self.role == "actor" else 1,

--- a/miles/backends/megatron_utils/ci_utils.py
+++ b/miles/backends/megatron_utils/ci_utils.py
@@ -11,6 +11,7 @@ import torch
 from megatron.core.distributed import DistributedDataParallel as DDP
 
 from miles.backends.training_utils.parallel import get_parallel_state
+from miles.utils import accelerator
 
 logger = logging.getLogger(__name__)
 
@@ -169,7 +170,7 @@ def check_peak_gpu_memory_after_load(args) -> None:
         return
 
     # Threshold 20 GB is midpoint between ~16.9 GB (with) and ~22.4 GB (without) on 8xH200.
-    peak_gpu_gb = torch.cuda.max_memory_allocated() / (1024**3)
+    peak_gpu_gb = accelerator.max_memory_allocated() / (1024**3)
     rank = torch.distributed.get_rank() if torch.distributed.is_initialized() else 0
     logger.info(f"[CI low-memory-resume] Rank {rank} peak GPU memory: {peak_gpu_gb:.2f} GB")
 

--- a/miles/backends/megatron_utils/ft/checkpoint_transfer.py
+++ b/miles/backends/megatron_utils/ft/checkpoint_transfer.py
@@ -12,6 +12,7 @@ except ImportError:
 from megatron.core.dist_checkpointing.tensor_aware_state_dict import MCoreTensorAwareStateDict
 
 from miles.backends.megatron_utils.ft.in_memory_checkpoint import InMemoryCheckpointManager, save_to_memory
+from miles.utils import accelerator
 from miles.utils.ft_utils.process_group_utils import GroupInfo
 from miles.utils.tracking_utils.structured_log import log_structured
 
@@ -216,5 +217,5 @@ def _create_transport(indep_dp: GroupInfo, timeout: timedelta) -> PGTransport:
     return PGTransport(
         pg=indep_dp.group,
         timeout=timeout,
-        device=torch.device("cuda"),
+        device=accelerator.device(),
     )

--- a/miles/backends/megatron_utils/megatron_to_hf/processors/quantizer_compressed_tensors.py
+++ b/miles/backends/megatron_utils/megatron_to_hf/processors/quantizer_compressed_tensors.py
@@ -5,6 +5,8 @@ import re
 import torch
 import torch.nn as nn
 
+from miles.utils import accelerator
+
 try:
     import fake_int4_quant_cuda
 except ImportError:
@@ -90,7 +92,7 @@ class WQLinear_GEMM(nn.Module):
             awq_linear.bias = linear.bias.clone().half()
 
         pack_num = 32 // awq_linear.w_bit
-        device = torch.device(f"cuda:{torch.cuda.current_device()}")
+        device = accelerator.device()
 
         repeat_scales = scales.to(device).t().repeat_interleave(group_size, 1)
         if isinstance(zeros, torch.Tensor):

--- a/miles/backends/megatron_utils/megatron_to_hf/processors/quantizer_mxfp8.py
+++ b/miles/backends/megatron_utils/megatron_to_hf/processors/quantizer_mxfp8.py
@@ -9,10 +9,17 @@ try:
     mxfp8_quantize = partial(flashinfer_mxfp8_quantize, is_sf_swizzled_layout=False)
 except ImportError:
     logger = logging.getLogger(__name__)
-    logger.warning("FlashInfer mxfp8_quantize not available; falling back to Triton.")
-    from sglang.srt.layers.quantization.fp8_utils import mxfp8_group_quantize
+    try:
+        from sglang.srt.layers.quantization.fp8_utils import mxfp8_group_quantize
 
-    mxfp8_quantize = mxfp8_group_quantize
+        logger.warning("FlashInfer mxfp8_quantize not available; falling back to SGLang mxfp8_group_quantize.")
+        mxfp8_quantize = mxfp8_group_quantize
+    except ImportError:
+        logger.warning(
+            "MXFP8 quantization kernels are not available in this SGLang/FlashInfer environment; "
+            "imports will continue, but MXFP8 conversion will fail if used."
+        )
+        mxfp8_quantize = None
 
 
 def quantize_params_mxfp8(args, megatron_name, converted_named_params, quantization_config):
@@ -112,6 +119,11 @@ def quantize_params_mxfp8(args, megatron_name, converted_named_params, quantizat
 
 
 def _quantize_param(name, weight):
+    if mxfp8_quantize is None:
+        raise RuntimeError(
+            "MXFP8 quantization requested, but neither flashinfer.mxfp8_quantize nor "
+            "sglang.srt.layers.quantization.fp8_utils.mxfp8_group_quantize is available."
+        )
     assert name.endswith(".weight"), f"Expected weight parameter, got {name}"
     weight = weight.contiguous()
     k = weight.shape[-1]

--- a/miles/backends/megatron_utils/model.py
+++ b/miles/backends/megatron_utils/model.py
@@ -19,7 +19,6 @@ from megatron.core.distributed import finalize_model_grads
 from megatron.core.enums import ModelType
 from megatron.core.models.gpt import GPTModel
 from megatron.core.optimizer import OptimizerConfig, get_megatron_optimizer
-from megatron.core.optimizer.muon import get_megatron_muon_optimizer
 from megatron.core.optimizer.optimizer import MegatronOptimizer
 from megatron.core.optimizer_param_scheduler import OptimizerParamScheduler
 from megatron.core.pipeline_parallel import get_forward_backward_func
@@ -57,6 +56,11 @@ from .model_provider import get_model_provider_func
 from .parallel import get_packed_seq_params
 
 logger = logging.getLogger(__name__)
+
+try:
+    from megatron.core.optimizer.muon import get_megatron_muon_optimizer
+except ModuleNotFoundError:
+    get_megatron_muon_optimizer = None
 
 
 from .bridge_lora_helpers import _ensure_model_list, _setup_lora_model_via_bridge  # noqa: F401
@@ -167,6 +171,12 @@ def setup_model_and_optimizer(
     config.timers = None
 
     if _is_muon_optimizer(config.optimizer):
+        if get_megatron_muon_optimizer is None:
+            raise ModuleNotFoundError(
+                "Megatron Muon optimizer is not available in the current MEGATRON_PATH. "
+                "Use --optimizer adam/sgd, or switch MEGATRON_PATH to a Megatron version "
+                "that provides megatron.core.optimizer.muon."
+            )
         optimizer = get_megatron_muon_optimizer(
             config=config,
             model_chunks=model,

--- a/miles/backends/megatron_utils/model.py
+++ b/miles/backends/megatron_utils/model.py
@@ -11,6 +11,8 @@ from functools import partial
 from pathlib import Path
 
 import torch
+from miles.utils import accelerator
+
 from megatron.core import mpu
 from megatron.core.distributed import DistributedDataParallel as DDP
 from megatron.core.distributed import finalize_model_grads
@@ -622,8 +624,8 @@ def train_one_step(
 
 def finalize_model_grads_with_empty_cache(*args, **kwargs):
     # TODO: this is an ad-hoc method and we should figure out why the oom happens in the first place.
-    device = torch.cuda.current_device()
-    free, total = torch.cuda.mem_get_info(device)
+    device = accelerator.current_device()
+    free, total = accelerator.mem_get_info(device)
     if free / total < 0.1:
         clear_memory()
     return finalize_model_grads(*args, **kwargs)

--- a/miles/backends/megatron_utils/update_weight/hf_weight_iterator_bridge.py
+++ b/miles/backends/megatron_utils/update_weight/hf_weight_iterator_bridge.py
@@ -3,6 +3,7 @@ import json
 import os
 
 from miles.backends.megatron_utils.lora_utils import is_lora_weight_name
+from miles.utils import accelerator
 from miles.utils import megatron_bridge_utils
 
 from ..megatron_to_hf import postprocess_hf_param
@@ -157,7 +158,7 @@ def _process_conversion_tasks(vanilla_conversion_tasks, new_weight_dict):
             # buffer-like params (Gemma-4 layer_scalar/scale) aren't in optimizer state; keep as-is
             return task
         new_param_weight = new_weight_dict[weight_dict_key]
-        new_param_weight = new_param_weight.cuda()
+        new_param_weight = new_param_weight.to(accelerator.device())
         return dataclasses.replace(task, param_weight=new_param_weight)
 
     return _MapWithLen(_handle_one, vanilla_conversion_tasks)

--- a/miles/backends/megatron_utils/update_weight/hf_weight_iterator_direct.py
+++ b/miles/backends/megatron_utils/update_weight/hf_weight_iterator_direct.py
@@ -7,6 +7,7 @@ import torch.distributed as dist
 from tqdm import tqdm
 
 from miles.backends.training_utils.parallel import get_parallel_state
+from miles.utils import accelerator
 from miles.utils.distributed_utils import get_gloo_group
 from miles.utils.types import ParamInfo
 
@@ -66,13 +67,13 @@ def _get_megatron_full_params(
         if dist.get_rank() == info.src_rank:
             params.append(
                 torch.nn.Parameter(
-                    megatron_local_weights[info.name].to(device=torch.cuda.current_device(), non_blocking=True),
+                    megatron_local_weights[info.name].to(device=accelerator.device(), non_blocking=True),
                     requires_grad=False,
                 )
             )
         else:
-            params.append(torch.empty(info.shape, dtype=info.dtype, device=torch.cuda.current_device()))
-    torch.cuda.synchronize()
+            params.append(torch.empty(info.shape, dtype=info.dtype, device=accelerator.device()))
+    accelerator.synchronize()
 
     # broadcast params across pp ranks
     if pp_size > 1:

--- a/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/broadcast.py
+++ b/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/broadcast.py
@@ -1,4 +1,4 @@
-import socket
+import os
 import time
 from argparse import Namespace
 from collections.abc import Callable, Mapping, Sequence
@@ -11,11 +11,49 @@ from ray.actor import ActorHandle
 from tqdm import tqdm
 
 from miles.backends.training_utils.parallel import get_parallel_state
+from miles.utils import accelerator
 from miles.utils.distributed_utils import init_process_group
+from miles.utils.http_utils import is_port_available
 
 from miles.utils.lora import LORA_ADAPTER_NAME
 from ..common import _check_weight_sync_results
 from .mixin import DistBucketedWeightUpdateMixin
+
+
+def _get_update_weight_group_index(group_name: str) -> int:
+    prefix = "miles-pp_"
+    if group_name.startswith(prefix):
+        suffix = group_name[len(prefix) :]
+        if suffix.isdigit():
+            return int(suffix)
+        if "-engine_" in suffix:
+            pp_rank, engine_rank = suffix.split("-engine_", maxsplit=1)
+            if pp_rank.isdigit() and engine_rank.isdigit():
+                return int(pp_rank) * 32 + int(engine_rank)
+    return sum(ord(char) for char in group_name) % 32
+
+
+def _get_update_weight_master_port(args: Namespace, group_name: str, consecutive: int = 8) -> int:
+    base = args.update_weight_master_port_base
+    stride = args.update_weight_master_port_stride
+    retries = args.update_weight_master_port_retries
+    group_index = _get_update_weight_group_index(group_name)
+    start_port = base + group_index * stride
+    scan_window = min(retries, stride)
+    if scan_window < consecutive:
+        raise RuntimeError(
+            f"Invalid update-weight port config for {group_name}: "
+            f"base={base}, stride={stride}, retries={retries}, consecutive={consecutive}"
+        )
+
+    for master_port in range(start_port, start_port + scan_window - consecutive + 1):
+        if all(is_port_available(master_port + offset) for offset in range(consecutive)):
+            return master_port
+    raise RuntimeError(
+        f"Failed to find update-weight master port for {group_name}: "
+        f"base={base}, stride={stride}, retries={retries}, start_port={start_port}, "
+        f"scan_window={scan_window}, consecutive={consecutive}"
+    )
 
 
 class UpdateWeightFromDistributed(DistBucketedWeightUpdateMixin):
@@ -43,6 +81,7 @@ class UpdateWeightFromDistributed(DistBucketedWeightUpdateMixin):
         self.quantization_config = quantization_config
         self.weight_version = 0
         self._model_update_groups = None
+        self._weight_update_connections: list[tuple[str, dist.ProcessGroup, Sequence[ActorHandle]]] = []
         self.rollout_engines: Sequence[ActorHandle] | None = None
         self._connection_stale: bool = False
         self._init_lora(
@@ -83,12 +122,42 @@ class UpdateWeightFromDistributed(DistBucketedWeightUpdateMixin):
             self._group_name = f"miles-pp_{pp_rank}"
 
         if self._is_source:
-            disconnect_rollout_engines_from_distributed(
-                self.args, self._group_name, self._model_update_groups, self.rollout_engines
+            for group_name, process_group, engines in self._weight_update_connections:
+                disconnect_rollout_engines_from_distributed(self.args, group_name, process_group, engines)
+
+            if engine_gpu_counts is None:
+                engine_gpu_counts = [self.args.rollout_num_gpus_per_engine] * len(rollout_engines)
+            if len(engine_gpu_counts) != len(rollout_engines):
+                raise ValueError(
+                    f"engine_gpu_counts has {len(engine_gpu_counts)} entries for {len(rollout_engines)} engines"
+                )
+
+            update_mode = os.environ.get("UPDATE_MODE", "broadcast")
+            split_engines = update_mode in {"p2p-broadcast", "gloo-broadcast"} or (
+                accelerator.is_musa_environment() and update_mode == "sync-broadcast"
             )
-            self._model_update_groups = connect_rollout_engines_from_distributed(
-                self.args, self._group_name, rollout_engines
-            )
+            if split_engines and len(rollout_engines) > 1 and not self.is_lora:
+                self._weight_update_connections = []
+                for engine_index, (engine, gpu_count) in enumerate(zip(rollout_engines, engine_gpu_counts)):
+                    group_name = f"{self._group_name}-engine_{engine_index}"
+                    process_group = connect_rollout_engines_from_distributed(
+                        self.args,
+                        group_name,
+                        [engine],
+                        engine_gpu_counts=[gpu_count],
+                    )
+                    self._weight_update_connections.append((group_name, process_group, [engine]))
+            else:
+                process_group = connect_rollout_engines_from_distributed(
+                    self.args,
+                    self._group_name,
+                    rollout_engines,
+                    engine_gpu_counts=engine_gpu_counts,
+                )
+                self._weight_update_connections = [(self._group_name, process_group, rollout_engines)]
+
+            groups = [connection[1] for connection in self._weight_update_connections]
+            self._model_update_groups = groups[0] if len(groups) == 1 else groups
 
     @property
     def _is_source(self):
@@ -109,16 +178,19 @@ class UpdateWeightFromDistributed(DistBucketedWeightUpdateMixin):
         # lock the rollout engines to prevent dead lock on broadcast.
         while not ray.get(self.rollout_engine_lock.acquire.remote()):
             time.sleep(0.1)
-        refs = update_weights_from_distributed(
-            self._group_name,
-            self._model_update_groups,
-            self.weight_version,
-            self.rollout_engines,
-            converted_named_tensors,
-        )
-        ray.get(refs)
-        converted_named_tensors.clear()
-        ray.get(self.rollout_engine_lock.release.remote())
+        try:
+            for group_name, process_group, engines in self._weight_update_connections:
+                refs = update_weights_from_distributed(
+                    group_name,
+                    process_group,
+                    self.weight_version,
+                    engines,
+                    converted_named_tensors,
+                )
+                ray.get(refs)
+            converted_named_tensors.clear()
+        finally:
+            ray.get(self.rollout_engine_lock.release.remote())
         if pbar:
             pbar.update(1)
 
@@ -135,27 +207,26 @@ class UpdateWeightFromDistributed(DistBucketedWeightUpdateMixin):
         dtypes = [param.dtype for _, param in named_tensors]
         shapes = [list(param.shape) for _, param in named_tensors]
 
-        refs = [
-            engine.load_lora_adapter_from_distributed.remote(
-                lora_name=LORA_ADAPTER_NAME,
-                config_dict=self._lora_config,
-                names=names,
-                dtypes=dtypes,
-                shapes=shapes,
-                group_name=self._group_name,
-            )
-            for engine in self.rollout_engines
-        ]
         contiguous_tensors = [
             param.data if param.data.is_contiguous() else param.data.contiguous() for _, param in named_tensors
         ]
-        handles = [
-            dist.broadcast(tensor, 0, group=self._model_update_groups, async_op=True) for tensor in contiguous_tensors
-        ]
-        for handle in handles:
-            handle.wait()
+        for group_name, process_group, engines in self._weight_update_connections:
+            refs = [
+                engine.load_lora_adapter_from_distributed.remote(
+                    lora_name=LORA_ADAPTER_NAME,
+                    config_dict=self._lora_config,
+                    names=names,
+                    dtypes=dtypes,
+                    shapes=shapes,
+                    group_name=group_name,
+                )
+                for engine in engines
+            ]
+            handles = [dist.broadcast(tensor, 0, group=process_group, async_op=True) for tensor in contiguous_tensors]
+            for handle in handles:
+                handle.wait()
 
-        _check_weight_sync_results(ray.get(refs), is_lora=True)
+            _check_weight_sync_results(ray.get(refs), is_lora=True)
 
     def _update_multi_lora_weight_implementation(
         self,
@@ -170,28 +241,27 @@ class UpdateWeightFromDistributed(DistBucketedWeightUpdateMixin):
         dtypes = [param.dtype for _, param in named_tensors]
         shapes = [list(param.shape) for _, param in named_tensors]
 
-        refs = [
-            engine.load_lora_adapter_from_distributed.remote(
-                lora_name=lora_name,
-                config_dict=lora_config,
-                names=names,
-                dtypes=dtypes,
-                shapes=shapes,
-                group_name=self._group_name,
-                upsert=True,
-            )
-            for engine in self.rollout_engines
-        ]
         # NCCL needs contiguous buffers (lora_B slices are strided); the list keeps them alive
         # until the async broadcasts complete.
         broadcast_tensors = [param.data.contiguous() for _, param in named_tensors]
-        handles = [
-            dist.broadcast(tensor, 0, group=self._model_update_groups, async_op=True) for tensor in broadcast_tensors
-        ]
-        for handle in handles:
-            handle.wait()
+        for group_name, process_group, engines in self._weight_update_connections:
+            refs = [
+                engine.load_lora_adapter_from_distributed.remote(
+                    lora_name=lora_name,
+                    config_dict=lora_config,
+                    names=names,
+                    dtypes=dtypes,
+                    shapes=shapes,
+                    group_name=group_name,
+                    upsert=True,
+                )
+                for engine in engines
+            ]
+            handles = [dist.broadcast(tensor, 0, group=process_group, async_op=True) for tensor in broadcast_tensors]
+            for handle in handles:
+                handle.wait()
 
-        _check_weight_sync_results(ray.get(refs), is_lora=True)
+            _check_weight_sync_results(ray.get(refs), is_lora=True)
 
 
 def connect_rollout_engines_from_distributed(
@@ -210,10 +280,9 @@ def connect_rollout_engines_from_distributed(
     if engine_gpu_counts is None:
         engine_gpu_counts = [args.rollout_num_gpus_per_engine] * len(rollout_engines)
     master_address = ray._private.services.get_node_ip_address()
-    with socket.socket() as sock:
-        sock.bind(("", 0))
-        master_port = sock.getsockname()[1]
+    master_port = _get_update_weight_master_port(args, group_name)
     world_size = sum(engine_gpu_counts) + 1
+    backend = accelerator.weight_update_backend()
 
     refs = []
     rank_cursor = 1
@@ -225,12 +294,12 @@ def connect_rollout_engines_from_distributed(
                 rank_cursor,
                 world_size,
                 group_name,
-                backend="nccl",
+                backend=backend,
             )
         )
         rank_cursor += engine_gpu_counts[i]
     model_update_groups = init_process_group(
-        backend="nccl",
+        backend=backend,
         init_method=f"tcp://{master_address}:{master_port}",
         world_size=world_size,
         rank=0,
@@ -260,8 +329,9 @@ def update_weights_from_distributed(
     converted_named_tensors: Sequence[tuple[str, torch.Tensor]],
 ) -> list[ObjectRef]:
     """
-    Send metadata (Ray), broadcast tensors (NCCL rank 0 → engines).
+    Send metadata over Ray, then transfer tensors according to UPDATE_MODE.
     """
+    update_mode = os.environ.get("UPDATE_MODE", "broadcast")
     refs = [
         engine.update_weights_from_distributed.remote(
             names=[name for name, _ in converted_named_tensors],
@@ -272,14 +342,24 @@ def update_weights_from_distributed(
         )
         for engine in rollout_engines
     ]
-
-    contiguous_tensors = [
-        param.data if param.data.is_contiguous() else param.data.contiguous() for _, param in converted_named_tensors
-    ]
-    handles = []
-    for tensor in contiguous_tensors:
-        handles.append(dist.broadcast(tensor, 0, group=group, async_op=True))
-    for handle in handles:
-        handle.wait()
+    if update_mode == "p2p-broadcast":
+        for i, (_, param) in enumerate(converted_named_tensors):
+            dist.send(param.data, dst=1, group=group, tag=i)
+    elif update_mode == "gloo-broadcast":
+        for _, param in converted_named_tensors:
+            dist.broadcast(param.data.cpu(), 0, group=group, async_op=False)
+    elif update_mode == "sync-broadcast":
+        for _, param in converted_named_tensors:
+            dist.broadcast(param.data, 0, group=group, async_op=False)
+    else:
+        contiguous_tensors = [
+            param.data if param.data.is_contiguous() else param.data.contiguous()
+            for _, param in converted_named_tensors
+        ]
+        handles = []
+        for tensor in contiguous_tensors:
+            handles.append(dist.broadcast(tensor, 0, group=group, async_op=True))
+        for handle in handles:
+            handle.wait()
 
     return refs

--- a/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/delta.py
+++ b/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/delta.py
@@ -20,6 +20,7 @@ from ray.actor import ActorHandle
 from tqdm import tqdm
 
 from miles.backends.training_utils.parallel import get_parallel_state
+from miles.utils import accelerator
 from miles.utils.disk_delta import NUM_WORKERS, checksum, make_tensor_reader, overwrite_encode
 from miles.utils.distributed_utils import get_gloo_group
 
@@ -330,7 +331,7 @@ class UpdateWeightFromDiskDelta(DistBucketedWeightUpdateMixin):
                 if use_pinned and nbytes <= max_bytes:
                     buf = free_q.get()  # blocks when all buffers are in flight -> backpressures the gather
                     buf[:nbytes].copy_(flat, non_blocking=True)
-                    torch.cuda.current_stream().synchronize()
+                    accelerator.current_stream().synchronize()
                     payload, pinned = buf, True
                 else:
                     payload, pinned = flat.cpu().numpy(), False
@@ -352,7 +353,7 @@ class UpdateWeightFromDiskDelta(DistBucketedWeightUpdateMixin):
         counts = torch.tensor(
             [self.changed_bytes, self.total_bytes, self.wire_bytes],
             dtype=torch.int64,
-            device=torch.cuda.current_device(),
+            device=accelerator.device(),
         )
         dist.all_reduce(counts)
         changed, total, wire = counts.tolist()

--- a/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/mixin.py
+++ b/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/mixin.py
@@ -8,6 +8,7 @@ import torch.distributed as dist
 from tqdm import tqdm
 
 from miles.backends.training_utils.parallel import get_parallel_state
+from miles.utils import accelerator
 from miles.utils.distributed_utils import get_gloo_group
 from miles.utils.lora import LORA_ADAPTER_NAME
 from miles.utils.timer import timer
@@ -201,8 +202,7 @@ class DistBucketedWeightUpdateMixin:
         handles = []
         for i, (_name, param) in enumerate(named_tensors):
             params = [
-                torch.empty_like(param.data, device=torch.cuda.current_device())
-                for _ in range(get_parallel_state().ep.size)
+                torch.empty_like(param.data, device=accelerator.device()) for _ in range(get_parallel_state().ep.size)
             ]
             handle = dist.all_gather(params, param.data, group=get_parallel_state().ep.group, async_op=True)
             handles.append(handle)

--- a/miles/backends/sglang_utils/arguments.py
+++ b/miles/backends/sglang_utils/arguments.py
@@ -136,6 +136,11 @@ def add_sglang_arguments(parser):
 
 def validate_args(args):
     args.sglang_tp_size = args.rollout_num_gpus_per_engine
+    args.sglang_dp_size = getattr(args, "sglang_data_parallel_size", getattr(args, "sglang_dp_size", 1))
+    args.sglang_pp_size = getattr(args, "sglang_pipeline_parallel_size", getattr(args, "sglang_pp_size", 1))
+    args.sglang_ep_size = getattr(args, "sglang_expert_parallel_size", getattr(args, "sglang_ep_size", 1))
+    if hasattr(args, "sglang_attention_context_parallel_size"):
+        args.sglang_attn_cp_size = args.sglang_attention_context_parallel_size
 
     if args.true_on_policy_mode:
         args.sglang_enable_deterministic_inference = True

--- a/miles/backends/sglang_utils/sglang_engine.py
+++ b/miles/backends/sglang_utils/sglang_engine.py
@@ -7,6 +7,8 @@ import time
 from urllib.parse import quote
 
 import requests
+from miles.utils import accelerator
+
 import sglang_router
 from packaging.version import parse
 from sglang.srt.server_args import ServerArgs
@@ -37,7 +39,7 @@ def get_base_gpu_id(args, rank):
 
 
 def _to_local_gpu_id(physical_gpu_id: int) -> int:
-    cvd = os.environ.get("CUDA_VISIBLE_DEVICES") or os.environ.get("HIP_VISIBLE_DEVICES")
+    cvd = os.environ.get(accelerator.visible_devices_env_key()) or os.environ.get("HIP_VISIBLE_DEVICES")
     if not cvd:
         return physical_gpu_id  # no remapping
     # CUDA_VISIBLE_DEVICES can be like "4,5,6,7"
@@ -49,7 +51,7 @@ def _to_local_gpu_id(physical_gpu_id: int) -> int:
     if 0 <= physical_gpu_id < len(visible):
         return physical_gpu_id
     raise RuntimeError(
-        f"GPU id {physical_gpu_id} is not valid under CUDA_VISIBLE_DEVICES={cvd}. "
+        f"GPU id {physical_gpu_id} is not valid under {accelerator.visible_devices_env_key()}={cvd}. "
         f"Expected one of {visible} (physical) or 0..{len(visible)-1} (local)."
     )
 

--- a/miles/backends/sglang_utils/sglang_engine.py
+++ b/miles/backends/sglang_utils/sglang_engine.py
@@ -25,6 +25,21 @@ from miles.utils.multi_lora import is_multi_lora_enabled
 logger = logging.getLogger(__name__)
 
 
+def _sglang_http_route_exists(endpoint: str) -> bool | None:
+    """Return whether the imported SGLang HTTP app declares an endpoint.
+
+    ``None`` means the route table could not be inspected, so callers should
+    fall back to probing the HTTP server.
+    """
+    try:
+        from sglang.srt.entrypoints.http_server import app
+    except Exception:
+        return None
+
+    path = f"/{endpoint.lstrip('/')}"
+    return any(getattr(route, "path", None) == path for route in getattr(app, "routes", []))
+
+
 def get_base_gpu_id(args, rank):
     num_gpus = min(args.num_gpus_per_node, args.rollout_num_gpus_per_engine)
     if args.colocate:
@@ -285,6 +300,41 @@ class SGLangEngine(RayActor):
 
         url = f"http://{self.server_host}:{self.server_port}/{endpoint}"
         response = requests.post(url, json=payload or {})
+        try:
+            response.raise_for_status()
+        except requests.exceptions.HTTPError as e:
+            if hasattr(e, "add_note"):
+                e.add_note(f"{response.text=}")
+            raise
+        return response.json()
+
+    def _make_optional_request(self, endpoint: str, payload: dict | None = None):
+        """Make a POST request to an optional SGLang endpoint.
+
+        Some SGLang versions do not expose weight-update lifecycle hooks such
+        as /begin_weight_update and /end_weight_update. Treat 404 as a
+        capability miss and keep all other HTTP failures strict.
+        """
+        if self.node_rank != 0:
+            return
+
+        if _sglang_http_route_exists(endpoint) is False:
+            logger.warning(
+                "SGLang endpoint /%s is not declared by the installed SGLang HTTP app; skipping optional request.",
+                endpoint,
+            )
+            return {"success": True, "skipped": True, "endpoint": endpoint}
+
+        url = f"http://{self.server_host}:{self.server_port}/{endpoint}"
+        response = requests.post(url, json=payload or {})
+        if response.status_code == 404:
+            logger.warning(
+                "SGLang endpoint /%s is not available at %s; skipping optional request.",
+                endpoint,
+                url,
+            )
+            return {"success": True, "skipped": True, "endpoint": endpoint}
+
         try:
             response.raise_for_status()
         except requests.exceptions.HTTPError as e:
@@ -617,11 +667,11 @@ class SGLangEngine(RayActor):
 
     def begin_weight_update(self):
         """Open a weight-update session on the engine (restores packed weights for loading)."""
-        return self._make_request("begin_weight_update", {})
+        return self._make_optional_request("begin_weight_update", {})
 
     def end_weight_update(self):
         """Close the weight-update session (post-load + quant post-process on the full model)."""
-        return self._make_request("end_weight_update", {})
+        return self._make_optional_request("end_weight_update", {})
 
     def update_weight_version(self, weight_version: str):
         return self._make_request(

--- a/miles/backends/training_utils/data.py
+++ b/miles/backends/training_utils/data.py
@@ -6,6 +6,7 @@ import torch
 import torch.distributed as dist
 import torch.nn.functional as F
 
+from miles.utils import accelerator
 from miles.utils.audit_utils.witness.allocator import WitnessInfo
 from miles.utils.data import get_minimum_num_micro_batch_size
 from miles.utils.ft_utils.process_group_utils import GeneralPGUtil
@@ -47,15 +48,15 @@ def get_rollout_data(
     )
     # move tokens to GPU in advance
     rollout_data["tokens"] = [
-        torch.tensor(t, dtype=torch.long, device=torch.cuda.current_device()) for t in rollout_data["tokens"]
+        torch.tensor(t, dtype=torch.long, device=accelerator.device()) for t in rollout_data["tokens"]
     ]
     rollout_data["loss_masks"] = [
-        torch.tensor(t, dtype=torch.int, device=torch.cuda.current_device()) for t in rollout_data["loss_masks"]
+        torch.tensor(t, dtype=torch.int, device=accelerator.device()) for t in rollout_data["loss_masks"]
     ]
     if args.enable_witness:
         seq_witness_ids = rollout_data.pop("seq_witness_ids")
         rollout_data["witness_ids"] = [
-            torch.full((len(t),), fill_value=sid, dtype=torch.long, device=torch.cuda.current_device())
+            torch.full((len(t),), fill_value=sid, dtype=torch.long, device=accelerator.device())
             for t, sid in zip(rollout_data["tokens"], seq_witness_ids, strict=True)
         ]
 
@@ -63,7 +64,7 @@ def get_rollout_data(
         # Move multimodal training tensors to GPU in advance
         rollout_data["multimodal_train_inputs"] = [
             (
-                {key: tensor.to(device=torch.cuda.current_device()) for key, tensor in mm_dict.items()}
+                {key: tensor.to(device=accelerator.device()) for key, tensor in mm_dict.items()}
                 if mm_dict is not None
                 else None
             )
@@ -97,7 +98,7 @@ def get_rollout_data(
                         args.qkv_format,
                         rollout_data["max_seq_lens"][i] if args.qkv_format == "bshd" else None,
                     ),
-                    device=torch.cuda.current_device(),
+                    device=accelerator.device(),
                     dtype=dtype,
                 )
                 for i, (value, total_length, response_length) in enumerate(
@@ -208,7 +209,7 @@ def get_batch(
                 tokens = F.pad(tokens, (0, pad), value=pad_token_id)
                 cu_seqlens_list.append(cu_seqlens_list[-1] + pad)
 
-            cu_seqlens = torch.tensor(cu_seqlens_list, dtype=torch.int, device=torch.cuda.current_device())
+            cu_seqlens = torch.tensor(cu_seqlens_list, dtype=torch.int, device=accelerator.device())
             tokens = tokens.chunk(cp_size, dim=0)[cp_rank]
         else:
             tokens = [slice_with_cp(t, pad_token_id, qkv_format) for t in tokens]
@@ -227,7 +228,7 @@ def get_batch(
                 cu_seqlens.append(cu_seqlens[-1] + pad)
 
             # thd requires the cu_seqlens to be of the origin length
-            cu_seqlens = torch.tensor(cu_seqlens, dtype=torch.int).cuda() * cp_size
+            cu_seqlens = torch.tensor(cu_seqlens, dtype=torch.int, device=accelerator.device()) * cp_size
 
         max_seqlen = (cu_seqlens[1:] - cu_seqlens[:-1]).max().item()
 
@@ -247,7 +248,7 @@ def get_batch(
         ), f"adapter_slots not sorted in micro-batch: {adapter_slots}"
         n_adapters = data_iterator.rollout_data["n_adapters"]
         total_tokens = tokens.numel()
-        counts = torch.zeros(n_adapters, dtype=torch.int32, device=torch.cuda.current_device())
+        counts = torch.zeros(n_adapters, dtype=torch.int32, device=accelerator.device())
         for slot, length in zip(adapter_slots, sample_token_lengths, strict=True):
             counts[slot] += length
         counts[adapter_slots[-1]] += total_tokens - counts.sum().item()
@@ -472,7 +473,7 @@ def get_data_iterator(
                 get_minimum_num_micro_batch_size(samples[start:end], args.max_tokens_per_gpu * cp_size)
             )
 
-        num_microbatches = torch.tensor(num_microbatches, dtype=torch.int, device=torch.cuda.current_device())
+        num_microbatches = torch.tensor(num_microbatches, dtype=torch.int, device=accelerator.device())
         GeneralPGUtil.create(dp_group).all_reduce(num_microbatches, dp_group, op=dist.ReduceOp.MAX)
 
         if vpp_size > 1:

--- a/miles/ray/train_actor.py
+++ b/miles/ray/train_actor.py
@@ -11,6 +11,7 @@ import torch.distributed as dist
 
 import miles.utils.eval_config
 from miles.ray.ray_actor import RayActor
+from miles.utils import accelerator
 from miles.utils.audit_utils.process_identity import TrainProcessIdentity
 from miles.utils.distributed_utils import init_gloo_group
 from miles.utils.env_report import collect_and_print_node_env_report
@@ -28,11 +29,7 @@ logger = logging.getLogger(__name__)
 
 
 def get_local_gpu_id():
-    cvd = os.environ.get("CUDA_VISIBLE_DEVICES") or os.environ.get("HIP_VISIBLE_DEVICES")
-    if not cvd:
-        return ray.get_gpu_ids()[0]
-    else:
-        return cvd.split(",").index(str(ray.get_gpu_ids()[0]))
+    return accelerator.resolve_visible_device_id(ray.get_gpu_ids()[0])
 
 
 class TrainRayActor(RayActor):
@@ -89,7 +86,7 @@ class TrainRayActor(RayActor):
         torch.serialization.add_safe_globals([miles.utils.eval_config.EvalDatasetConfig])
 
         local_rank = int(os.environ.get("LOCAL_RANK", 0))
-        torch.cuda.set_device(f"cuda:{local_rank}")
+        accelerator.set_device(accelerator.device_name(local_rank))
 
         if args.debug_deterministic_collective:
             register_det_nccl_backend()
@@ -97,10 +94,11 @@ class TrainRayActor(RayActor):
             logger.info("Deterministic collectives: training world uses the det_nccl backend")
 
         # Use hybrid backend when FSDP CPU offload is enabled with a CPU backend
-        backend = args.distributed_backend
+        backend = accelerator.process_group_backend(args.distributed_backend)
         if getattr(args, "fsdp_cpu_offload", False) and getattr(args, "fsdp_cpu_backend", None):
             cpu_backend = args.fsdp_cpu_backend
-            backend = f"cpu:{cpu_backend},cuda:{args.distributed_backend}"
+            device_backend = accelerator.process_group_backend(args.distributed_backend)
+            backend = f"cpu:{cpu_backend},{accelerator.device_type()}:{device_backend}"
             logger.info(f"FSDP CPU offload enabled, using hybrid backend: {backend}")
 
         dist.init_process_group(

--- a/miles/ray/utils.py
+++ b/miles/ray/utils.py
@@ -4,6 +4,7 @@ import os
 import ray
 import torch
 from miles.ray.ray_actor import RayActor
+from miles.utils import accelerator
 
 
 # Refer to
@@ -16,6 +17,7 @@ from miles.ray.ray_actor import RayActor
 # https://github.com/ray-project/ray/blob/161849364a784442cc659fb9780f1a6adee85fce/python/ray/_private/accelerators/intel_gpu.py#L97-L98
 NOSET_VISIBLE_DEVICES_ENV_VARS_LIST = [
     "RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES",
+    "RAY_EXPERIMENTAL_NOSET_MUSA_VISIBLE_DEVICES",
     "RAY_EXPERIMENTAL_NOSET_HIP_VISIBLE_DEVICES",
     "RAY_EXPERIMENTAL_NOSET_ASCEND_RT_VISIBLE_DEVICES",
     "RAY_EXPERIMENTAL_NOSET_HABANA_VISIBLE_MODULES",
@@ -30,9 +32,9 @@ def ray_noset_visible_devices(env_vars=os.environ):
 
 
 def get_physical_gpu_id():
-    device = torch.cuda.current_device()
-    props = torch.cuda.get_device_properties(device)
-    return str(props.uuid)
+    device = accelerator.current_device()
+    props = accelerator.get_device_properties(device)
+    return str(getattr(props, "uuid", device))
 
 
 @ray.remote

--- a/miles/utils/accelerator.py
+++ b/miles/utils/accelerator.py
@@ -1,0 +1,266 @@
+import importlib
+import logging
+import os
+import sys
+from contextlib import nullcontext
+from types import ModuleType
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_MUSA_PATCH_IMPORTED = False
+
+
+def _append_musa_patch_path() -> None:
+    patch_path = os.environ.get("MUSA_PATCH_PATH")
+    if patch_path and patch_path not in sys.path:
+        sys.path.append(patch_path)
+
+
+def _try_import_musa_patch_once() -> bool:
+    _append_musa_patch_path()
+    try:
+        importlib.import_module("musa_patch")
+    except ImportError:
+        return False
+    except Exception as exc:
+        logger.warning("Failed to import musa_patch: %s", exc)
+        return False
+    return True
+
+
+import torch
+
+_MUSA_PATCH_IMPORTED = _try_import_musa_patch_once()
+
+
+def _musa() -> ModuleType | None:
+    return getattr(torch, "musa", None)
+
+
+def is_musa_available() -> bool:
+    musa = _musa()
+    return bool(musa is not None and getattr(musa, "is_available", lambda: False)())
+
+
+def is_musa_environment() -> bool:
+    return is_musa_available() or "MUSA_VISIBLE_DEVICES" in os.environ or bool(os.environ.get("MUSA_PATCH_PATH"))
+
+
+def _musa_requested() -> bool:
+    return "MUSA_VISIBLE_DEVICES" in os.environ or bool(os.environ.get("MUSA_PATCH_PATH"))
+
+
+def _require_musa_available() -> None:
+    if _musa_requested() and not is_musa_available():
+        raise RuntimeError(
+            "MUSA environment was requested via MUSA_VISIBLE_DEVICES or MUSA_PATCH_PATH, "
+            "but torch.musa is unavailable. Check that musa_patch imports before torch and that MUSA runtime is installed."
+        )
+
+
+def is_cuda_available() -> bool:
+    return bool(torch.cuda.is_available())
+
+
+def device_type() -> str:
+    if is_musa_available():
+        return "musa"
+    if is_cuda_available():
+        return "cuda"
+    return "cpu"
+
+
+def device_name(index: int | None = None) -> str:
+    current_type = device_type()
+    if current_type == "cpu":
+        return "cpu"
+    if index is None:
+        index = current_device()
+    return f"{current_type}:{index}"
+
+
+def device(index: int | None = None) -> torch.device:
+    return torch.device(device_name(index))
+
+
+def accelerator_module() -> Any:
+    if is_musa_available():
+        return _musa()
+    return torch.cuda
+
+
+def set_device(index: int | str | torch.device) -> None:
+    if device_type() == "cpu":
+        return
+    accelerator_module().set_device(index)
+
+
+def current_device() -> int | str:
+    if device_type() == "cpu":
+        return "cpu"
+    return accelerator_module().current_device()
+
+
+def synchronize(device_arg: int | str | torch.device | None = None) -> None:
+    if device_type() == "cpu":
+        return
+    module = accelerator_module()
+    if hasattr(module, "synchronize"):
+        if device_arg is None:
+            module.synchronize()
+        else:
+            module.synchronize(device_arg)
+
+
+def empty_cache() -> None:
+    if device_type() == "cpu":
+        return
+    module = accelerator_module()
+    if hasattr(module, "empty_cache"):
+        module.empty_cache()
+
+
+def ipc_collect() -> None:
+    if device_type() == "cpu":
+        return
+    module = accelerator_module()
+    if hasattr(module, "ipc_collect"):
+        module.ipc_collect()
+
+
+def mem_get_info(device_arg: int | str | torch.device | None = None) -> tuple[int, int]:
+    if device_type() == "cpu":
+        raise RuntimeError("accelerator memory info is unavailable on CPU")
+    module = accelerator_module()
+    if device_arg is None:
+        device_arg = current_device()
+    return module.mem_get_info(device_arg)
+
+
+def memory_allocated(device_arg: int | str | torch.device | None = None) -> int:
+    if device_type() == "cpu":
+        return 0
+    return accelerator_module().memory_allocated(device_arg)
+
+
+def memory_reserved(device_arg: int | str | torch.device | None = None) -> int:
+    if device_type() == "cpu":
+        return 0
+    return accelerator_module().memory_reserved(device_arg)
+
+
+def max_memory_allocated(device_arg: int | str | torch.device | None = None) -> int:
+    if device_type() == "cpu":
+        return 0
+    module = accelerator_module()
+    if hasattr(module, "max_memory_allocated"):
+        return module.max_memory_allocated(device_arg)
+    return 0
+
+
+def get_device_properties(device_arg: int | str | torch.device | None = None) -> Any:
+    if device_type() == "cpu":
+        return None
+    module = accelerator_module()
+    if device_arg is None:
+        device_arg = current_device()
+    return module.get_device_properties(device_arg)
+
+
+def visible_devices_env_key() -> str:
+    if "MUSA_VISIBLE_DEVICES" in os.environ:
+        return "MUSA_VISIBLE_DEVICES"
+    return "MUSA_VISIBLE_DEVICES" if is_musa_available() else "CUDA_VISIBLE_DEVICES"
+
+
+def resolve_visible_device_id(physical_device_id: int | float | str) -> int:
+    visible_devices = os.environ.get(visible_devices_env_key())
+    physical_device_id = int(float(physical_device_id))
+    if not visible_devices:
+        return physical_device_id
+    visible = [int(x) for x in visible_devices.split(",") if x.strip()]
+    if physical_device_id in visible:
+        return visible.index(physical_device_id)
+    if 0 <= physical_device_id < len(visible):
+        return physical_device_id
+    raise RuntimeError(
+        f"Device id {physical_device_id} is not valid under {visible_devices_env_key()}={visible_devices}. "
+        f"Expected one of {visible} (physical) or 0..{len(visible) - 1} (local)."
+    )
+
+
+def process_group_backend(default: str = "nccl") -> str:
+    if default == "nccl":
+        if is_musa_available():
+            return "mccl"
+        _require_musa_available()
+    return default
+
+
+def weight_update_backend(default: str = "nccl") -> str:
+    if default == "nccl":
+        if is_musa_available():
+            return "cpu:gloo,musa:mccl"
+        _require_musa_available()
+    return default
+
+
+def stream_context(stream: Any):
+    if stream is None or device_type() == "cpu":
+        return nullcontext()
+    module = accelerator_module()
+    if hasattr(module, "stream"):
+        return module.stream(stream)
+    return nullcontext()
+
+
+def Stream(*args, **kwargs):
+    if device_type() == "cpu":
+        return None
+    module = accelerator_module()
+    stream_cls = getattr(module, "Stream", None)
+    if stream_cls is None:
+        return None
+    return stream_cls(*args, **kwargs)
+
+
+def Event(*args, **kwargs):
+    if device_type() == "cpu":
+        return None
+    module = accelerator_module()
+    event_cls = getattr(module, "Event", None)
+    if event_cls is None:
+        return None
+    return event_cls(*args, **kwargs)
+
+
+def current_stream():
+    if device_type() == "cpu":
+        return None
+    module = accelerator_module()
+    if hasattr(module, "current_stream"):
+        return module.current_stream()
+    return None
+
+
+def try_import_musa_patch() -> bool:
+    global _MUSA_PATCH_IMPORTED
+    if _MUSA_PATCH_IMPORTED:
+        return True
+
+    _append_musa_patch_path()
+
+    try:
+        importlib.import_module("musa_patch")
+    except ImportError:
+        if os.environ.get("MUSA_PATCH_PATH") or is_musa_available():
+            logger.warning("musa_patch is not importable; continuing without it")
+        return False
+    except Exception as exc:
+        logger.warning("Failed to import musa_patch: %s", exc)
+        return False
+
+    _MUSA_PATCH_IMPORTED = True
+    logger.info("Imported musa_patch")
+    return True

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -5,6 +5,7 @@ import os
 from typing import Any
 
 import yaml
+
 from sglang_router.launch_router import RouterArgs
 
 from miles.backends.sglang_utils.arguments import add_sglang_arguments
@@ -2948,6 +2949,13 @@ def hf_validate_args(args, hf_config):
     def equal(x, y):
         return x == y
 
+    def get_megatron_config_value(name):
+        if hasattr(args, name):
+            return getattr(args, name)
+        if name == "layernorm_epsilon" and hasattr(args, "norm_epsilon"):
+            return getattr(args, "norm_epsilon")
+        return getattr(args, name)
+
     errors = []
 
     # multimodal models have different config structure
@@ -2988,10 +2996,11 @@ def hf_validate_args(args, hf_config):
         if getattr(hf_config, "model_type", "") == "deepseek_v4" and hf_config_name == "intermediate_size":
             continue
         if hasattr(hf_config, hf_config_name):
-            if not compare_fn(getattr(hf_config, hf_config_name), getattr(args, megatron_config_name)):
+            megatron_config_value = get_megatron_config_value(megatron_config_name)
+            if not compare_fn(getattr(hf_config, hf_config_name), megatron_config_value):
                 errors.append(
                     f"{hf_config_name} in hf config {getattr(hf_config, hf_config_name)} is not equal to "
-                    f"{megatron_config_name} {getattr(args, megatron_config_name)}, please check the config."
+                    f"{megatron_config_name} {megatron_config_value}, please check the config."
                 )
 
     if len(errors) > 0:

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -560,6 +560,24 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 help="Interval for updating the weights",
             )
             parser.add_argument(
+                "--update-weight-master-port-base",
+                type=int,
+                default=23000,
+                help="Base port for update-weight distributed rendezvous. Use a non-ephemeral range.",
+            )
+            parser.add_argument(
+                "--update-weight-master-port-stride",
+                type=int,
+                default=100,
+                help="Port range stride reserved for each update-weight process group.",
+            )
+            parser.add_argument(
+                "--update-weight-master-port-retries",
+                type=int,
+                default=100,
+                help="Maximum number of update-weight rendezvous ports to scan per process group.",
+            )
+            parser.add_argument(
                 "--pause-generation-mode",
                 type=str,
                 choices=["abort", "retract", "in_place"],

--- a/miles/utils/chat_template_utils/deepseek.py
+++ b/miles/utils/chat_template_utils/deepseek.py
@@ -12,11 +12,11 @@ from __future__ import annotations
 
 import copy
 import functools
+import importlib
 import json
 import os
 from typing import Any
 
-from sglang.srt.entrypoints.openai import encoding_dsv4, encoding_dsv32
 from sglang.srt.entrypoints.openai.protocol import Tool
 
 _ASSISTANT_SP_TOKEN = "<｜Assistant｜>"
@@ -57,7 +57,18 @@ def _inject_tools_into_system(messages: list[dict[str, Any]], tools: list[dict[s
 class DeepSeekFamily:
     """Shared behavior for the DeepSeek official-encoder families."""
 
-    template: Any
+    encoder_module: str
+
+    @functools.cached_property
+    def template(self) -> Any:
+        module_name = f"sglang.srt.entrypoints.openai.{self.encoder_module}"
+        try:
+            return importlib.import_module(module_name)
+        except ImportError as exc:
+            raise ImportError(
+                f"{self.encoder_module} is required only for {self.encoder_module.removeprefix('encoding_')} "
+                f"chat rendering, but is unavailable in the installed SGLang version"
+            ) from exc
 
     def _build_encode_config(self, kwargs: dict) -> dict:
         kwargs = dict(kwargs)
@@ -112,7 +123,7 @@ class DeepSeekFamily:
 
 
 class DeepSeekV32Family(DeepSeekFamily):
-    template = encoding_dsv32
+    encoder_module = "encoding_dsv32"
 
     def _generation_prompt_suffix(self, tail_role: str | None, thinking_token: str) -> str | None:
         if tail_role in {"user", "developer"}:
@@ -123,7 +134,7 @@ class DeepSeekV32Family(DeepSeekFamily):
 
 
 class DeepSeekV4Family(DeepSeekFamily):
-    template = encoding_dsv4
+    encoder_module = "encoding_dsv4"
 
     def _generation_prompt_suffix(self, tail_role: str | None, thinking_token: str) -> str | None:
         if tail_role in {"user", "developer", "tool"}:

--- a/miles/utils/debug_utils/run_megatron/worker/main.py
+++ b/miles/utils/debug_utils/run_megatron/worker/main.py
@@ -17,6 +17,8 @@ from typing import Any
 
 import torch
 import torch.distributed as dist
+from miles.utils import accelerator
+
 from megatron.core import mpu
 from megatron.core.enums import ModelType
 from megatron.core.pipeline_parallel import get_forward_backward_func
@@ -117,9 +119,9 @@ def _parse_args() -> tuple[argparse.Namespace, WorkerScriptArgs]:
 
 
 def _initialize_megatron(args: argparse.Namespace) -> None:
-    torch.distributed.init_process_group(backend="nccl")
+    torch.distributed.init_process_group(backend=accelerator.process_group_backend("nccl"))
     local_rank: int = int(os.environ.get("LOCAL_RANK", 0))
-    torch.cuda.set_device(local_rank)
+    accelerator.set_device(local_rank)
 
     args.hf_checkpoint = str(args.script_hf_checkpoint)
     args.__dict__.setdefault("megatron_to_hf_mode", "raw")

--- a/miles/utils/dumper_utils.py
+++ b/miles/utils/dumper_utils.py
@@ -12,7 +12,7 @@ from typing import Any
 
 import torch
 import torch.distributed as dist
-from sglang.srt.debug_utils.dumper import DumperConfig, _get_rank, dumper
+import yaml
 
 from miles.backends.training_utils.parallel import get_parallel_state
 from miles.utils.environ import enable_experimental_ft_trainer
@@ -26,6 +26,55 @@ class DumperPhase(enum.Enum):
     INFERENCE = "inference"
     FWD_ONLY = "fwd_only"
     FWD_BWD = "fwd_bwd"
+
+
+def _get_sglang_dumper_module():
+    try:
+        from sglang.srt.debug_utils import dumper as dumper_module
+    except ImportError as exc:
+        raise ImportError("SGLang dumper support requires sglang.srt.debug_utils.dumper.") from exc
+    return dumper_module
+
+
+def _get_rank() -> int:
+    try:
+        return _get_sglang_dumper_module()._get_rank()
+    except ImportError:
+        if dist.is_available() and dist.is_initialized():
+            return dist.get_rank()
+        return 0
+
+
+def _kv_pairs_to_dict(raw: Sequence[str] | None) -> dict[str, Any]:
+    if not raw:
+        return {}
+
+    dumper_config = getattr(_get_sglang_dumper_module(), "DumperConfig", None)
+    if dumper_config is not None and hasattr(dumper_config, "_kv_pairs_to_dict"):
+        return dumper_config._kv_pairs_to_dict(raw)
+
+    parsed = {}
+    for item in raw:
+        if "=" not in item:
+            parsed[item] = True
+            continue
+        key, value = item.split("=", 1)
+        parsed[key] = yaml.safe_load(value)
+    return parsed
+
+
+def _require_modern_dumper():
+    dumper_module = _get_sglang_dumper_module()
+    dumper_config = getattr(dumper_module, "DumperConfig", None)
+    dumper_obj = getattr(dumper_module, "dumper", None)
+    required_methods = ("configure", "reset", "register_non_intrusive_dumper", "dump_model", "step")
+    if dumper_config is None or dumper_obj is None or any(not hasattr(dumper_obj, name) for name in required_methods):
+        raise RuntimeError(
+            "Dumper mode requires a SGLang dumper implementation with DumperConfig and "
+            "configure/reset/register_non_intrusive_dumper/dump_model/step APIs. "
+            "The SGLang source currently on PYTHONPATH provides an older lightweight dumper."
+        )
+    return dumper_config, dumper_obj
 
 
 # ------------------------------- SGLang -------------------------------------
@@ -101,6 +150,7 @@ class DumperMegatronUtil:
             args, phase=phase, rollout_id=rollout_id, store_prefix=store_prefix, overrides=self.overrides
         )
         if self.enabled:
+            _, dumper = _require_modern_dumper()
             dumper.register_non_intrusive_dumper(self._extract_model(model))
 
     def wrap_forward_step(self, forward_step_func: Callable) -> Callable:
@@ -123,6 +173,7 @@ class DumperMegatronUtil:
         # Weights/grads are a once-per-rollout end-state, so pin them to step 0 instead of
         # the running per-microbatch step. _configure already cleaned the scoped paths;
         # disable lazy cleanup after reset to preserve activations from this rollout.
+        _, dumper = _require_modern_dumper()
         dumper.reset()
         dumper.configure(cleanup_previous=False)
         dumper.dump_model(extracted_model, get_grad=get_grad)
@@ -167,6 +218,7 @@ class DumperMegatronUtil:
             merged["enable_output_file"] = False
             merged["enable_output_console"] = False
 
+        DumperConfig, dumper = _require_modern_dumper()
         full_config = DumperConfig(**merged)
         dumper.reset()
         # Wipe the whole phase dir only at run start (rollout 0). Gating on a
@@ -262,6 +314,7 @@ def _wrap_forward_step_with_stepping(forward_step_func: Callable) -> Callable:
     def _wrapped(*args: Any, **kwargs: Any) -> Any:
         nonlocal is_first_call
         if not is_first_call:
+            _, dumper = _require_modern_dumper()
             dumper.step()
         is_first_call = False
         return forward_step_func(*args, **kwargs)
@@ -332,7 +385,7 @@ def _barrier_after_dump_dir_cleanup() -> None:
 
 def _get_phase_override_configs(args: Namespace, phase: DumperPhase) -> dict[str, Any]:
     raw = getattr(args, f"dumper_{phase.value}")
-    return {"enable": args.dumper_enable, **DumperConfig._kv_pairs_to_dict(raw)}
+    return {"enable": args.dumper_enable, **_kv_pairs_to_dict(raw)}
 
 
 def _is_phase_enabled(args: Namespace, phase: DumperPhase) -> bool:

--- a/miles/utils/environ.py
+++ b/miles/utils/environ.py
@@ -1,5 +1,7 @@
 import os
 
+from miles.utils import accelerator
+
 _printed_experimental_rollout_refactor = False
 
 
@@ -20,11 +22,9 @@ def default_fp8_block_scaling_fp32_scales() -> str:
     On Blackwell (SM100+), TE emulates the blockwise FP8 recipe with MXFP8,
     which requires power-of-two scales, so FP32 scales must stay disabled.
     """
-    import torch
-
-    if not torch.cuda.is_available():
+    if not accelerator.is_cuda_available() or accelerator.is_musa_available():
         return "1"
-    major, _minor = torch.cuda.get_device_capability()
+    major, _minor = accelerator.accelerator_module().get_device_capability()
     return "0" if major >= 10 else "1"
 
 

--- a/miles/utils/memory_utils.py
+++ b/miles/utils/memory_utils.py
@@ -4,27 +4,29 @@ import logging
 import torch
 import torch.distributed as dist
 
+from miles.utils import accelerator
+
 logger = logging.getLogger(__name__)
 
 
 def clear_memory(clear_host_memory: bool = False):
-    torch.cuda.synchronize()
+    accelerator.synchronize()
     gc.collect()
-    torch.cuda.empty_cache()
+    accelerator.empty_cache()
     if clear_host_memory:
         torch._C._host_emptyCache()
 
 
 def available_memory():
-    device = torch.cuda.current_device()
-    free, total = torch.cuda.mem_get_info(device)
+    device = accelerator.current_device()
+    free, total = accelerator.mem_get_info(device)
     return {
         "gpu": str(device),
         "total_GB": _byte_to_gb(total),
         "free_GB": _byte_to_gb(free),
         "used_GB": _byte_to_gb(total - free),
-        "allocated_GB": _byte_to_gb(torch.cuda.memory_allocated(device)),
-        "reserved_GB": _byte_to_gb(torch.cuda.memory_reserved(device)),
+        "allocated_GB": _byte_to_gb(accelerator.memory_allocated(device)),
+        "reserved_GB": _byte_to_gb(accelerator.memory_reserved(device)),
     }
 
 

--- a/miles/utils/misc.py
+++ b/miles/utils/misc.py
@@ -131,7 +131,7 @@ def exec_command(cmd: str, capture_output: bool = False) -> str | None:
 
 @ray.remote(num_cpus=0.001)
 def _exec_command_on_node(cmd: str, capture_output: bool) -> str | None:
-    return exec_command(f"unset CUDA_VISIBLE_DEVICES; {cmd}", capture_output=capture_output)
+    return exec_command(f"unset CUDA_VISIBLE_DEVICES MUSA_VISIBLE_DEVICES; {cmd}", capture_output=capture_output)
 
 
 def exec_command_all_ray_node(

--- a/miles/utils/profile_utils.py
+++ b/miles/utils/profile_utils.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import torch
 
+from miles.utils import accelerator
 from miles.utils.memory_utils import print_memory
 
 logger = logging.getLogger(__name__)
@@ -58,7 +59,13 @@ def _profile_simple_loop(iterator, args, name):
 
 
 def _create_torch_profiler(args, name):
+    activities = [torch.profiler.ProfilerActivity.CPU]
+    activity_name = accelerator.device_type().upper()
+    if hasattr(torch.profiler.ProfilerActivity, activity_name):
+        activities.append(getattr(torch.profiler.ProfilerActivity, activity_name))
+
     return torch.profiler.profile(
+        activities=activities,
         schedule=torch.profiler.schedule(
             # TODO the train_actor and train_log_probs ones may need to have different args to control step
             wait=max(args.profile_step_start - 1, 0),
@@ -101,30 +108,61 @@ class _BaseMemoryProfiler:
 
 
 class _TorchMemoryProfiler(_BaseMemoryProfiler):
+    def __init__(self, args):
+        super().__init__(args)
+        self._recording = False
+
+    def _memory_module(self):
+        module = accelerator.accelerator_module()
+        return getattr(module, "memory", None)
+
     def start(self):
         logger.info("Attach OOM dump memory history.")
 
-        torch.cuda.memory._record_memory_history(
+        memory_module = self._memory_module()
+        if memory_module is None or not hasattr(memory_module, "_record_memory_history"):
+            logger.warning("Accelerator memory history is unavailable; skip torch memory profiler.")
+            return
+        if not hasattr(memory_module, "_dump_snapshot"):
+            logger.warning("Accelerator memory snapshot is unavailable; skip torch memory profiler.")
+            return
+
+        memory_module._record_memory_history(
             max_entries=1000000,
-            # record stack information for the trace events
-            # trace_alloc_record_context=True,
             stacks="all",
         )
+        self._recording = True
 
         def oom_observer(device, alloc, device_alloc, device_free):
             logger.info(
                 f"Observe OOM, will dump snapshot to {self._path_dump}. ({device=} {alloc=} {device_alloc=} {device_free=}; stacktrace is as follows)"
             )
             traceback.print_stack()
-            torch.cuda.memory._dump_snapshot(self._path_dump)
+            memory_module._dump_snapshot(str(self._path_dump))
             print_memory("when oom")
 
-        torch._C._cuda_attach_out_of_memory_observer(oom_observer)
+        if accelerator.is_musa_available():
+            musa_c = getattr(torch.musa, "_MUSAC", None)
+            attach_oom_observer = getattr(musa_c, "_musa_attach_out_of_memory_observer", None)
+        else:
+            attach_oom_observer = getattr(torch._C, "_cuda_attach_out_of_memory_observer", None)
+        if attach_oom_observer is not None:
+            attach_oom_observer(oom_observer)
+        else:
+            logger.warning("Accelerator OOM observer is unavailable; memory snapshot on OOM is disabled.")
 
     def stop(self):
+        if not self._recording:
+            return
         logger.info(f"Dump memory snapshot to: {self._path_dump}")
-        torch.cuda.memory._dump_snapshot(self._path_dump)
-        torch.cuda.memory._record_memory_history(enabled=None)
+        memory_module = self._memory_module()
+        if memory_module is None or not hasattr(memory_module, "_dump_snapshot"):
+            logger.warning("Accelerator memory snapshot is unavailable; skip dump.")
+            return
+        memory_module._dump_snapshot(str(self._path_dump))
+        if hasattr(memory_module, "_record_memory_history"):
+            memory_module._record_memory_history(enabled=None)
+        self._recording = False
 
 
 class _MemrayMemoryProfiler(_BaseMemoryProfiler):

--- a/miles/utils/reloadable_process_group.py
+++ b/miles/utils/reloadable_process_group.py
@@ -5,6 +5,7 @@ from contextlib import contextmanager
 import torch
 import torch.distributed as dist
 
+from miles.utils import accelerator
 from miles.utils.memory_utils import print_memory
 
 logger = logging.getLogger(__name__)
@@ -25,9 +26,17 @@ def monkey_patch_torch_dist():
     dist.old_new_group = old_new_group
 
     def new_group(*args, **kwargs):
+        backend = args[2] if len(args) >= 3 else kwargs.get("backend")
+        normalized_backend = accelerator.process_group_backend(backend) if backend is not None else backend
+        if normalized_backend != backend:
+            if len(args) >= 3:
+                args = (*args[:2], normalized_backend, *args[3:])
+            else:
+                kwargs = {**kwargs, "backend": normalized_backend}
+
         group = old_new_group(*args, **kwargs)
-        # skip none nccl group.
-        if len(args) >= 3 and args[2] == "gloo" or "backend" in kwargs and kwargs["backend"] == "gloo":
+        # skip non-accelerator group.
+        if normalized_backend == "gloo":
             return group
 
         # Get ranks from arguments
@@ -41,12 +50,20 @@ def monkey_patch_torch_dist():
         if len(ranks) == 1:
             return group
 
-        group = ReloadableProcessGroup(group, inner_args=args, inner_kwargs=kwargs)
+        group = ReloadableProcessGroup(group, inner_args=args, inner_kwargs=kwargs, backend=normalized_backend)
         return group
 
     dist.new_group = new_group
 
-    def get_new_function(func):
+    def get_new_query_function(func):
+        def new_function(*args, **kwargs):
+            args = tuple(arg.group if isinstance(arg, ReloadableProcessGroup) else arg for arg in args)
+            kwargs = {k: (v.group if isinstance(v, ReloadableProcessGroup) else v) for k, v in kwargs.items()}
+            return func(*args, **kwargs)
+
+        return new_function
+
+    def get_new_comm_function(func):
         def new_function(*args, **kwargs):
             args = tuple([arg.group if isinstance(arg, ReloadableProcessGroup) else arg for arg in args])
             kwargs = {k: (v.group if isinstance(v, ReloadableProcessGroup) else v) for k, v in kwargs.items()}
@@ -55,37 +72,37 @@ def monkey_patch_torch_dist():
 
         return new_function
 
-    dist.get_rank = get_new_function(dist.get_rank)
-    dist.get_world_size = get_new_function(dist.get_world_size)
-    dist.get_backend = get_new_function(dist.get_backend)
-    dist.get_global_rank = get_new_function(dist.get_global_rank)
-    dist.get_group_rank = get_new_function(dist.get_group_rank)
-    dist.get_process_group_ranks = get_new_function(dist.get_process_group_ranks)
+    dist.get_rank = get_new_query_function(dist.get_rank)
+    dist.get_world_size = get_new_query_function(dist.get_world_size)
+    dist.get_backend = get_new_query_function(dist.get_backend)
+    dist.get_global_rank = get_new_query_function(dist.get_global_rank)
+    dist.get_group_rank = get_new_query_function(dist.get_group_rank)
+    dist.get_process_group_ranks = get_new_query_function(dist.get_process_group_ranks)
 
-    dist.all_reduce = get_new_function(dist.all_reduce)
-    dist.all_gather = get_new_function(dist.all_gather)
-    dist.all_gather_into_tensor = get_new_function(dist.all_gather_into_tensor)
-    dist.all_gather_object = get_new_function(dist.all_gather_object)
-    dist.all_to_all = get_new_function(dist.all_to_all)
-    dist.all_to_all_single = get_new_function(dist.all_to_all_single)
-    dist.broadcast = get_new_function(dist.broadcast)
-    dist.broadcast_object_list = get_new_function(dist.broadcast_object_list)
-    dist.reduce = get_new_function(dist.reduce)
-    dist.reduce_scatter = get_new_function(dist.reduce_scatter)
-    dist.reduce_scatter_tensor = get_new_function(dist.reduce_scatter_tensor)
-    dist.scatter = get_new_function(dist.scatter)
-    dist.gather = get_new_function(dist.gather)
-    dist.barrier = get_new_function(dist.barrier)
-    dist.send = get_new_function(dist.send)
-    dist.recv = get_new_function(dist.recv)
-    dist._coalescing_manager = get_new_function(dist._coalescing_manager)
+    dist.all_reduce = get_new_comm_function(dist.all_reduce)
+    dist.all_gather = get_new_comm_function(dist.all_gather)
+    dist.all_gather_into_tensor = get_new_comm_function(dist.all_gather_into_tensor)
+    dist.all_gather_object = get_new_comm_function(dist.all_gather_object)
+    dist.all_to_all = get_new_comm_function(dist.all_to_all)
+    dist.all_to_all_single = get_new_comm_function(dist.all_to_all_single)
+    dist.broadcast = get_new_comm_function(dist.broadcast)
+    dist.broadcast_object_list = get_new_comm_function(dist.broadcast_object_list)
+    dist.reduce = get_new_comm_function(dist.reduce)
+    dist.reduce_scatter = get_new_comm_function(dist.reduce_scatter)
+    dist.reduce_scatter_tensor = get_new_comm_function(dist.reduce_scatter_tensor)
+    dist.scatter = get_new_comm_function(dist.scatter)
+    dist.gather = get_new_comm_function(dist.gather)
+    dist.barrier = get_new_comm_function(dist.barrier)
+    dist.send = get_new_comm_function(dist.send)
+    dist.recv = get_new_comm_function(dist.recv)
+    dist._coalescing_manager = get_new_comm_function(dist._coalescing_manager)
 
     # p2p
     old_isend = dist.isend
     old_irecv = dist.irecv
 
-    dist.isend = get_new_function(dist.isend)
-    dist.irecv = get_new_function(dist.irecv)
+    dist.isend = get_new_comm_function(dist.isend)
+    dist.irecv = get_new_comm_function(dist.irecv)
 
     def get_new_p2pop_function(func):
         def new_function(*args, **kwargs):
@@ -111,7 +128,7 @@ def monkey_patch_torch_dist():
 class ReloadableProcessGroup(torch.distributed.ProcessGroup):
     GROUPS = {}
 
-    def __init__(self, group, inner_args, inner_kwargs):
+    def __init__(self, group, inner_args, inner_kwargs, backend=None):
         super().__init__(
             rank=dist.get_rank(group),
             size=dist.get_world_size(group),
@@ -119,6 +136,7 @@ class ReloadableProcessGroup(torch.distributed.ProcessGroup):
         self.group = group
         self.inner_args = inner_args
         self.inner_kwargs = inner_kwargs
+        self.backend = backend
         pid = os.getpid()
         if pid not in ReloadableProcessGroup.GROUPS:
             ReloadableProcessGroup.GROUPS[pid] = []
@@ -153,7 +171,17 @@ class ReloadableProcessGroup(torch.distributed.ProcessGroup):
         for reloadable_group in reloadable_groups:
             if reloadable_group.group is not None:
                 continue
-            group = old_new_group(*reloadable_group.inner_args, **reloadable_group.inner_kwargs)
+            inner_kwargs = dict(reloadable_group.inner_kwargs)
+            backend = reloadable_group.backend
+            if backend is not None:
+                if len(reloadable_group.inner_args) >= 3:
+                    args = (*reloadable_group.inner_args[:2], backend, *reloadable_group.inner_args[3:])
+                    group = old_new_group(*args, **inner_kwargs)
+                else:
+                    inner_kwargs["backend"] = backend
+                    group = old_new_group(*reloadable_group.inner_args, **inner_kwargs)
+            else:
+                group = old_new_group(*reloadable_group.inner_args, **inner_kwargs)
             reloadable_group.group = group
 
     def rank(self) -> int:

--- a/miles/utils/replay_base.py
+++ b/miles/utils/replay_base.py
@@ -4,6 +4,8 @@ import os
 import torch
 import torch.distributed as dist
 
+from miles.utils import accelerator
+
 logger = logging.getLogger(__name__)
 
 
@@ -34,12 +36,12 @@ class Replay:
             )
         top_indices = self.top_indices_list[self.forward_index]
         self.forward_index += 1
-        return top_indices.to(torch.cuda.current_device())
+        return top_indices.to(accelerator.device())
 
     def pop_backward(self) -> torch.Tensor:
         top_indices = self.top_indices_list[self.backward_index]
         self.backward_index += 1
-        return top_indices.to(torch.cuda.current_device())
+        return top_indices.to(accelerator.device())
 
     def clear(self):
         self.forward_index = 0

--- a/miles/utils/tensor_backper.py
+++ b/miles/utils/tensor_backper.py
@@ -4,6 +4,8 @@ from collections.abc import Callable, Iterable
 
 import torch
 
+from miles.utils import accelerator
+
 _SourceGetter = Callable[[], Iterable[tuple[str, torch.Tensor]]]
 
 
@@ -58,7 +60,7 @@ class _TensorBackuperNormal(TensorBackuper):
             if name not in backup_dict:
                 backup_dict[name] = torch.empty_like(param, device=torch.device("cpu"), pin_memory=True)
             backup_dict[name].copy_(param.detach(), non_blocking=True)
-        torch.cuda.synchronize()
+        accelerator.synchronize()
 
     @torch.no_grad()
     def copy(self, *, src_tag: str, dst_tag: str):
@@ -71,7 +73,7 @@ class _TensorBackuperNormal(TensorBackuper):
         for name, param in self._source_getter():
             assert name in backup_dict
             param.copy_(backup_dict[name], non_blocking=True)
-        torch.cuda.synchronize()
+        accelerator.synchronize()
 
 
 class _TensorBackuperNoop(TensorBackuper):
@@ -94,12 +96,12 @@ class _TensorBackuperNoop(TensorBackuper):
     def backup(self, tag: str) -> None:
         assert tag == self._single_tag
         self._backup_hash_dict = _compute_hash_dict(dict(self._source_getter()))
-        torch.cuda.synchronize()
+        accelerator.synchronize()
 
     def restore(self, tag: str) -> None:
         assert tag == self._single_tag
         assert _compute_hash_dict(dict(self._source_getter())) == self._backup_hash_dict
-        torch.cuda.synchronize()
+        accelerator.synchronize()
 
 
 def _compute_hash_dict(tensors: dict[str, torch.Tensor]):

--- a/miles/utils/test_utils/det_process_group.py
+++ b/miles/utils/test_utils/det_process_group.py
@@ -20,6 +20,8 @@ from torch.distributed import ProcessGroup as BaseProcessGroup
 from torch.distributed import Work
 from torch.distributed.distributed_c10d import AllgatherOptions
 
+from miles.utils import accelerator
+
 logger = logging.getLogger(__name__)
 
 
@@ -40,6 +42,8 @@ def register_det_nccl_backend() -> None:
     deterministic fold. Idempotent.
     """
     global _backend_registered
+    if accelerator.is_musa_available():
+        raise RuntimeError("The deterministic NCCL debug backend is CUDA-only and is not supported on MUSA.")
     if _backend_registered:
         return
     dist.Backend.register_backend(DET_NCCL_BACKEND_NAME, _create_det_nccl_backend, extended_api=True, devices=["cuda"])

--- a/miles_plugins/__init__.py
+++ b/miles_plugins/__init__.py
@@ -1,0 +1,1 @@
+from miles.utils import accelerator as _accelerator

--- a/miles_plugins/models/deepseek_v4/ops/cp_utils.py
+++ b/miles_plugins/models/deepseek_v4/ops/cp_utils.py
@@ -8,6 +8,8 @@ import torch
 import torch.nn.functional as F
 from torch import Tensor
 
+from miles.utils import accelerator
+
 
 @lru_cache(1)
 def _get_window_topk_idxs_ref(window_size: int, bsz: int, seqlen: int, start_pos: int):
@@ -26,7 +28,7 @@ def _get_window_topk_idxs_ref(window_size: int, bsz: int, seqlen: int, start_pos
             matrix = torch.where(matrix > base, -1, matrix)
             return matrix
 
-    return _inner().unsqueeze(0).expand(bsz, -1, -1).cuda()
+    return _inner().unsqueeze(0).expand(bsz, -1, -1).to(accelerator.device())
 
 
 @lru_cache(2)
@@ -44,7 +46,7 @@ def _get_compress_topk_idxs_ref(ratio: int, bsz: int, seqlen: int, start_pos: in
             matrix = torch.where(mask, -1, matrix + offset)
             return matrix
 
-    return _inner().unsqueeze(0).expand(bsz, -1, -1).cuda()
+    return _inner().unsqueeze(0).expand(bsz, -1, -1).to(accelerator.device())
 
 
 def all_gather_cp(tensor: Tensor, dim: int, cp_group: torch.distributed.ProcessGroup) -> Tensor:

--- a/miles_plugins/models/qwen3_5.py
+++ b/miles_plugins/models/qwen3_5.py
@@ -3,6 +3,8 @@ import copy
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+from miles.utils import accelerator
+
 from megatron.core.models.gpt.gpt_layer_specs import get_gpt_decoder_block_spec
 from megatron.core.transformer.spec_utils import ModuleSpec
 from megatron.core.transformer.transformer_block import get_num_layers_to_build
@@ -89,7 +91,7 @@ class Qwen3_5GatedDeltaNet(nn.Module):
             self.head_v_dim,
             eps=self.layer_norm_epsilon,
             activation=self.activation,
-            device=torch.cuda.current_device(),
+            device=accelerator.device(),
             dtype=config.dtype if config.dtype is not None else torch.get_current_dtype(),
         )
 

--- a/miles_plugins/models/qwen3_next.py
+++ b/miles_plugins/models/qwen3_next.py
@@ -3,6 +3,8 @@ import copy
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+from miles.utils import accelerator
+
 from megatron.core.models.gpt.gpt_layer_specs import get_gpt_decoder_block_spec
 from megatron.core.transformer.spec_utils import ModuleSpec
 from megatron.core.transformer.transformer_block import get_num_layers_to_build
@@ -71,7 +73,7 @@ class Qwen3NextGatedDeltaNet(nn.Module):
             self.head_v_dim,
             eps=self.layer_norm_epsilon,
             activation=self.activation,
-            device=torch.cuda.current_device(),
+            device=accelerator.device(),
             dtype=config.dtype if config.dtype is not None else torch.get_current_dtype(),
         )
 

--- a/tests/fast/backends/training_utils/test_opd_cp_data.py
+++ b/tests/fast/backends/training_utils/test_opd_cp_data.py
@@ -60,7 +60,7 @@ def _load_rollout_data(
     monkeypatch.setattr(data_utils, "process_rollout_data", lambda *args, **kwargs: rollout_data)
     monkeypatch.setattr(data_utils, "get_parallel_state", lambda: parallel_state)
     monkeypatch.setattr(cp_utils, "get_parallel_state", lambda: parallel_state)
-    monkeypatch.setattr(torch.cuda, "current_device", lambda: torch.device("cpu"))
+    monkeypatch.setattr(data_utils.accelerator, "device", lambda: torch.device("cpu"))
 
     return data_utils.get_rollout_data(_args(qkv_format), object())
 

--- a/tools/convert_hf_to_mxfp8.py
+++ b/tools/convert_hf_to_mxfp8.py
@@ -24,6 +24,8 @@ import torch
 from sglang.srt.layers.quantization.fp8_utils import block_quant_dequant
 from tqdm import tqdm
 
+from miles.utils import accelerator
+
 try:
     from flashinfer import mxfp8_quantize as flashinfer_mxfp8_quantize
 
@@ -350,8 +352,7 @@ def convert_mxfp8(
             source_scale_index,
         )
         gc.collect()
-        if torch.cuda.is_available():
-            torch.cuda.empty_cache()
+        accelerator.empty_cache()
 
     quantization_config = {
         "activation_scheme": "dynamic",
@@ -382,8 +383,7 @@ def convert_mxfp8(
     json.dump(index_dict, open(os.path.join(output_path, "model.safetensors.index.json"), "w"), indent=2)
 
     gc.collect()
-    if torch.cuda.is_available():
-        torch.cuda.empty_cache()
+    accelerator.empty_cache()
 
 
 def main() -> None:
@@ -393,8 +393,8 @@ def main() -> None:
     parser.add_argument(
         "--device",
         type=str,
-        default="cuda",
-        help="Torch device to run quantization on (default: cuda).",
+        default=accelerator.device_name(0),
+        help="Torch device to run quantization on (default: current accelerator).",
     )
     parser.add_argument(
         "--num-layers-at-start-in-bf16",
@@ -417,20 +417,20 @@ def main() -> None:
     )
     args, _ = parser.parse_known_args()
 
-    if not torch.cuda.is_available():
-        raise RuntimeError("CUDA is not available, cannot run MXFP8 quantization.")
+    if accelerator.device_type() == "cpu":
+        raise RuntimeError("No accelerator is available, cannot run MXFP8 quantization.")
 
     if isinstance(args.device, str) and args.device.isdigit():
-        device = torch.device(f"cuda:{args.device}")
+        device = accelerator.device(int(args.device))
     else:
         device = torch.device(args.device)
 
-    if device.type != "cuda":
-        raise RuntimeError("MXFP8 quantization requires a CUDA device.")
+    if device.type != accelerator.device_type():
+        raise RuntimeError(f"MXFP8 quantization requires a {accelerator.device_type()} device.")
     if device.index is None:
-        device = torch.device("cuda:0")
+        device = accelerator.device(0)
 
-    torch.cuda.set_device(device)
+    accelerator.set_device(device)
 
     if not os.path.exists(args.save_dir):
         print(f"Creating directory {args.save_dir}")

--- a/tools/convert_hf_to_torch_dist.py
+++ b/tools/convert_hf_to_torch_dist.py
@@ -4,6 +4,8 @@ import shutil
 
 import torch
 import torch.distributed as dist
+from miles.utils import accelerator
+
 from megatron.core.enums import ModelType
 from megatron.training.arguments import parse_args, validate_args
 from megatron.training.checkpointing import get_checkpoint_name, get_checkpoint_tracker_filename, save_checkpoint
@@ -98,20 +100,22 @@ def main():
     local_rank = int(os.getenv("LOCAL_RANK") or os.getenv("SLURM_LOCALID") or 0)
     global_rank = int(os.getenv("RANK") or os.getenv("SLURM_PROCID") or 0)
 
-    torch.cuda.set_device(local_rank)
+    accelerator.set_device(local_rank)
     os.environ.setdefault("WORLD_SIZE", str(world_size))
     os.environ.setdefault("RANK", str(global_rank))
     os.environ.setdefault("LOCAL_RANK", str(local_rank))
     os.environ.setdefault("MASTER_ADDR", "localhost")
     os.environ.setdefault("MASTER_PORT", "12355")
     dist.init_process_group(
-        backend="nccl",
+        backend=accelerator.process_group_backend(),
         world_size=world_size,
         rank=global_rank,
-        device_id=torch.device(f"cuda:{local_rank}"),
+        device_id=None if accelerator.is_musa_available() else torch.device(accelerator.device_name(local_rank)),
     )
     args = get_args()
     init(args)
+    if accelerator.is_musa_available():
+        assert args.use_cpu_initialization, "MUSA requires --use_cpu_initialization=True"
     model = get_model(get_model_provider_func(args), ModelType.encoder_or_decoder, wrap_with_ddp=False)
 
     # Load model
@@ -122,9 +126,9 @@ def main():
     print(f"Model loaded: {hf_model_path}")
 
     print_memory("after loading model")
-    torch.cuda.synchronize()
+    accelerator.synchronize()
     gc.collect()
-    torch.cuda.empty_cache()
+    accelerator.empty_cache()
 
     save_checkpoint(1, model, None, None, 0)
 

--- a/tools/convert_to_hf.py
+++ b/tools/convert_to_hf.py
@@ -1,5 +1,7 @@
 import torch
 import torch.distributed as dist
+from miles.utils import accelerator
+
 from megatron.core import mpu
 from transformers import AutoModelForCausalLM
 
@@ -65,7 +67,7 @@ def main(args):
                     param = param_
                     break
         else:
-            param = torch.empty(info.shape, dtype=info.dtype, device=torch.cuda.current_device())
+            param = torch.empty(info.shape, dtype=info.dtype, device=accelerator.device())
 
         if pp_size > 1:
             if info.src_rank in dist.get_process_group_ranks(mpu.get_pipeline_model_parallel_group()):

--- a/train.py
+++ b/train.py
@@ -2,6 +2,8 @@ import asyncio
 import logging
 import os
 
+from miles.utils import accelerator as _accelerator
+
 from sglang.srt.constants import GPU_MEMORY_TYPE_CUDA_GRAPH, GPU_MEMORY_TYPE_KV_CACHE, GPU_MEMORY_TYPE_WEIGHTS
 
 from miles.ray.placement_group import create_placement_groups, create_rollout_manager, create_training_models

--- a/train_multi_lora_async.py
+++ b/train_multi_lora_async.py
@@ -4,6 +4,8 @@ import asyncio
 import logging
 from pathlib import Path
 
+from miles.utils import accelerator as _accelerator
+
 import ray
 
 from miles.ray.multi_lora.controller import create_multilora_controller, get_multi_lora_controller


### PR DESCRIPTION
# Add backend-aware MUSA support to Miles

## Summary

This PR adds backend-aware MUSA (Moore Threads GPU) support to Miles while preserving the existing CUDA execution path.

The implementation is based on the device, distributed-runtime, Megatron-LM, and SGLang adaptations required to run Miles post-training workloads in the current MUSA software stack. Instead of adding scattered MUSA-specific branches, it introduces a centralized accelerator abstraction and routes device-sensitive code through it.

The PR is based on upstream Miles commit `54ed128f8a38a2bb70d6948a2a9ec9b3aaff8167` and is organized into four commits:

- `feat(musa): add accelerator abstraction and bootstrap` adds the common accelerator API and initializes the optional MUSA compatibility patch before Megatron-LM and SGLang imports.
- `refactor(musa): route device operations through accelerator` replaces CUDA-bound device, memory, stream, profiling, Ray, model, and conversion-tool operations with backend-aware helpers.
- `feat(musa): support MCCL distributed weight updates` adds MCCL-aware process groups, reloadable group handling, rendezvous-port isolation, and MUSA-compatible distributed weight synchronization.
- `fix(musa): support MUSA runtime dependency versions` adds narrowly scoped compatibility handling for the Megatron-LM, SGLang, FlashInfer, and MXFP8 APIs available in the current MUSA environment.

## Motivation

Miles currently assumes CUDA/NCCL in several training, checkpoint, profiling, Ray, SGLang, and weight-update paths. In a MUSA environment, these assumptions can cause the following failures:

- Device creation, synchronization, cache management, and memory queries call `torch.cuda` directly.
- NCCL is selected where MCCL is required.
- Ray and SGLang local device IDs are resolved from `CUDA_VISIBLE_DEVICES` without recognizing `MUSA_VISIBLE_DEVICES`.
- CUDA-only profiler and memory-snapshot APIs are invoked on MUSA.
- Distributed weight-update groups do not select the composite CPU/MUSA backend required for metadata and tensor communication.
- The `p2p-broadcast` sender protocol does not match the MUSA-capable SGLang receiver topology.
- The MUSA compatibility patch must be loaded before Megatron-LM or SGLang initializes CUDA-bound modules.
- The Megatron-LM and SGLang versions currently used by the MUSA stack do not expose every API imported unconditionally by the latest Miles code.

## What Changed

### 1. Accelerator abstraction and bootstrap

- Add `miles/utils/accelerator.py` with backend-aware helpers for:
  - accelerator detection and device construction;
  - current-device resolution and device selection;
  - synchronization, streams, events, and cache management;
  - IPC collection and memory statistics;
  - visible-device environment handling;
  - process-group and weight-update backend selection.
- Attempt to import the optional `musa_patch` package centrally and idempotently before importing PyTorch, using `MUSA_PATCH_PATH` when it is configured.
- Initialize the accelerator layer before Megatron-LM and SGLang imports in the Miles package, plugins, and training entry points.
- Keep the patch path configurable through `MUSA_PATCH_PATH`.

### 2. Backend-aware device operations

- Replace direct `.cuda()`, `torch.cuda.current_device()`, CUDA synchronization, stream, cache, and memory calls across:
  - FSDP actor and checkpoint paths;
  - Megatron actor, model, checkpoint-transfer, conversion, and weight-iterator paths;
  - training data preparation and context-parallel slicing;
  - Ray actor device-ID handling;
  - profiling, memory dumping, replay, and tensor-backup utilities;
  - model plugins and checkpoint-conversion tools.
- Resolve Ray-assigned physical device IDs through `MUSA_VISIBLE_DEVICES` or `CUDA_VISIBLE_DEVICES` as appropriate.
- Keep CUDA-only diagnostics explicitly CUDA-only instead of silently redirecting them to unsupported MUSA implementations.
- Use CPU initialization where required by MUSA checkpoint-conversion flows.

### 3. MCCL process groups and distributed weight updates

- Map the default accelerator process-group backend from NCCL to MCCL when MUSA is active.
- Use `cpu:gloo,musa:mccl` for weight-update groups so CPU metadata and MUSA tensors use their corresponding backends.
- Preserve existing asynchronous broadcast behavior and support the configured `sync-broadcast`, `gloo-broadcast`, and `p2p-broadcast` modes.
- Implement the `p2p-broadcast` trainer sender protocol expected by SGLang: the trainer sends each tensor to rank 1 in the trainer/engine group, and SGLang performs the intra-engine broadcast.
- Create separate update groups for rollout engines when required by the selected transport mode.
- Add deterministic, per-group rendezvous-port ranges and bounded port scanning to reduce collisions in multi-engine and multi-node runs.
- Extend reloadable process-group wrappers to preserve MCCL/composite backends and unwrap wrapped groups for distributed query and communication APIs.

### 4. Profiling and memory support

- Select profiler activities according to the active accelerator.
- Route memory history, snapshots, OOM observers, synchronization, and memory statistics through backend-aware helpers.
- Gracefully disable unsupported MUSA memory-snapshot hooks instead of failing unrelated training paths.

### 5. Runtime dependency compatibility

- Delay imports of optional Megatron Muon optimizer, SGLang chat-template encoder, P2P weight-transfer, and MXFP8 components until those features are actually requested.
- Provide actionable errors when an optional feature is requested but unavailable in the installed dependency versions.
- Accept the SGLang parallel-size attribute names exposed by the current MUSA SGLang stack.
- Treat missing SGLang weight-update lifecycle endpoints as optional capabilities while keeping other HTTP errors strict.
- Support the `norm_epsilon`/`layernorm_epsilon` naming difference when validating Hugging Face and Megatron configurations.

## CUDA Compatibility

The CUDA path remains the default when `torch.musa` is unavailable:

- `accelerator.device_type()` resolves to `cuda` when CUDA is available and MUSA is not requested.
- Default process-group and weight-update backends remain NCCL.
- `CUDA_VISIBLE_DEVICES` resolution remains supported.
- Existing CUDA profiler, memory, synchronization, checkpoint, and model behavior is preserved.

A MUSA environment is recognized when `torch.musa` is available or when `MUSA_VISIBLE_DEVICES` or `MUSA_PATCH_PATH` is explicitly configured.

## Testing

The following targeted tests pass in the MUSA environment. `MUSA_PATCH_PATH` and `MEGATRON_PATH` point to the corresponding local installations:

```text
PYTHONPATH=$MUSA_PATCH_PATH:$MEGATRON_PATH:$PYTHONPATH \
pytest -q tests/fast/backends/training_utils/test_opd_cp_data.py

11 passed
```

```text
PYTHONPATH=$MUSA_PATCH_PATH:$MEGATRON_PATH:$PYTHONPATH \
pytest -q tests/test_fsdp_import.py \
  tests/fast/backends/megatron_utils/test_lora_update_weight.py

7 passed
```

Additional validation passes:

- Python bytecode compilation with `python -m compileall` for `miles`, `miles_plugins`, tools, and training entry points.
- Patch whitespace validation with `git diff --check`.

### End-to-end MUSA validation

The integration has also been validated with the `Qwen3-30B-A3B` post-training workload in the MUSA environment. The job runs through rollout, reward computation, distributed weight synchronization, and Megatron training stages successfully, confirming that the adapted Miles execution path works end to end.

## Scope and Non-Goals

- This PR does not modify CUDA or MUSA kernels, compiler toolchains, or kernel-launch syntax.
- Local example scripts, runtime environment files, logs, and ignore-file changes are not included.
- Optional features that are unavailable in the current MUSA dependency stack are not silently emulated; they fail with explicit errors when requested.
- The external `musa_patch` package remains an environment prerequisite for the current MUSA Megatron-LM/SGLang stack.
