### PR TITLE
[multi-lora] Fix slice_lora_to_rank for 3D expert tensors; guard MoE expert multi-LoRA

### DIFF
--- a/miles/backends/megatron_utils/multi_lora_utils.py
+++ b/miles/backends/megatron_utils/multi_lora_utils.py
@@ -116,21 +116,34 @@ def zero_optimizer_state_for_adapter(optimizer, model, idx: int) -> None:
 
 
 def slice_lora_to_rank(hf_name: str, tensor: torch.Tensor, adapter_rank: int) -> torch.Tensor:
-    if "lora_A" in hf_name and adapter_rank < tensor.shape[0]:
-        remainder = tensor[adapter_rank:]
-        assert remainder.abs().max() == 0, (
-            f"lora_A padded dims are non-zero: {hf_name}, "
-            f"max={remainder.abs().max().item():.6e}, shape={tensor.shape}, rank={adapter_rank}"
-        )
-        return tensor[:adapter_rank]
-    if "lora_B" in hf_name and adapter_rank < tensor.shape[1]:
-        remainder = tensor[:, adapter_rank:]
-        assert remainder.abs().max() == 0, (
-            f"lora_B padded dims are non-zero: {hf_name}, "
-            f"max={remainder.abs().max().item():.6e}, shape={tensor.shape}, rank={adapter_rank}"
-        )
-        return tensor[:, :adapter_rank]
-    return tensor
+    """Trim a max-rank-padded LoRA weight down to an adapter's real rank.
+
+    LoRA weights are allocated at the shared ``--lora-rank`` (max rank) with the unused
+    rank slots zero-padded; this slices them to ``adapter_rank`` to match the adapter's
+    ``adapter_config`` ``r``. The rank axis is the second-to-last for ``lora_A``
+    (``[..., rank, in]``) and the last for ``lora_B`` (``[..., out, rank]``). Selecting
+    the axis by position handles both the 2-D dense layout (``[rank, in]`` /
+    ``[out, rank]``) and the 3-D grouped MoE-expert layout (``[num_experts, rank, in]`` /
+    ``[num_experts, out, rank]``) — the previous hard-coded ``shape[0]`` / ``shape[1]``
+    sliced the wrong (expert) axis on 3-D expert tensors and silently corrupted them.
+    Asserts the trimmed-away slots are exactly zero so a mis-sliced adapter fails loudly.
+    """
+    if "lora_A" in hf_name:
+        axis = tensor.ndim - 2
+    elif "lora_B" in hf_name:
+        axis = tensor.ndim - 1
+    else:
+        return tensor
+    if adapter_rank >= tensor.shape[axis]:
+        return tensor
+    remainder = tensor.narrow(axis, adapter_rank, tensor.shape[axis] - adapter_rank)
+    max_abs = remainder.abs().max()
+    assert max_abs == 0, (
+        f"{'lora_A' if 'lora_A' in hf_name else 'lora_B'} padded rank slots are non-zero: "
+        f"{hf_name}, max={max_abs.item():.6e}, shape={tuple(tensor.shape)}, "
+        f"rank={adapter_rank}, axis={axis}"
+    )
+    return tensor.narrow(axis, 0, adapter_rank)
 
 
 def save_multi_lora_checkpoints(

--- a/miles/utils/multi_lora.py
+++ b/miles/utils/multi_lora.py
@@ -67,6 +67,19 @@ def validate_multi_lora_args(args: Any) -> None:
     args.rollout_global_dataset = True
     assert args.lora_rank > 0, "--lora-rank must be set when --multi-lora-n-adapters > 0"
     assert args.target_modules is not None, "--target-modules must be set when --multi-lora-n-adapters > 0"
+    # MoE expert multi-LoRA is not yet wired end-to-end: the training-side per-token
+    # slot-id threading through the MoE dispatcher (Megatron-LM) and the bridge
+    # grouped-expert multi-adapter layer land in later PRs. Until then, targeting expert
+    # modules would silently drop the expert adapters at train time, so fail loudly.
+    # (Detects explicit expert targets like '*.mlp.experts.linear_fc1'; bare leaf names
+    # such as 'linear_fc1' cannot be disambiguated here without the model.)
+    _expert_targets = [tm for tm in args.target_modules if "experts" in str(tm)]
+    assert not _expert_targets, (
+        "Multi-LoRA does not yet support MoE expert target modules "
+        f"(got {_expert_targets}). Expert multi-LoRA is under development; for now remove "
+        "expert target modules (e.g. '*.mlp.experts.linear_fc1'). Non-expert "
+        "(attention/dense) target modules are supported."
+    )
     assert args.train_backend == "megatron", "Multi-LoRA currently requires --train-backend megatron"
     assert "muon" not in str(getattr(args, "optimizer", "")).lower(), (
         "Multi-LoRA does not support Muon: per-adapter decoupled stepping is only "

--- a/tests/fast/backends/megatron_utils/test_multi_lora_moe_support.py
+++ b/tests/fast/backends/megatron_utils/test_multi_lora_moe_support.py
@@ -1,0 +1,73 @@
+"""MoE multi-LoRA support guards (CI-registered):
+
+* ``slice_lora_to_rank`` trims the rank axis correctly for the 3-D grouped MoE-expert
+  layout (the previous hard-coded axis sliced the expert axis and corrupted the tensor).
+  The 2-D dense layout is covered canonically in ``test_slice_lora_to_rank.py``.
+* ``validate_multi_lora_args`` loudly rejects expert target modules until MoE expert
+  multi-LoRA is wired end-to-end, instead of silently dropping the expert adapters.
+"""
+
+from argparse import Namespace
+
+import pytest
+import torch
+
+from tests.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=30, suite="stage-a-cpu")
+
+from miles.backends.megatron_utils.multi_lora_utils import slice_lora_to_rank
+from miles.utils.multi_lora import validate_multi_lora_args
+
+
+MAXR, R, IN, OUT, E = 8, 5, 6, 7, 3
+
+
+def test_slice_3d_expert_lora_a_slices_rank_not_expert_axis():
+    # [num_experts, rank, in]: rank axis is dim 1; the expert axis must be preserved.
+    t = torch.randn(E, MAXR, IN)
+    t[:, R:, :] = 0
+    out = slice_lora_to_rank("x.experts.gate_proj.lora_A.weight", t, R)
+    assert out.shape == (E, R, IN)
+    assert torch.equal(out, t[:, :R, :])
+
+
+def test_slice_3d_expert_lora_b_slices_rank_not_expert_axis():
+    # [num_experts, out, rank]: rank axis is dim 2.
+    t = torch.randn(E, OUT, MAXR)
+    t[:, :, R:] = 0
+    out = slice_lora_to_rank("x.experts.down_proj.lora_B.weight", t, R)
+    assert out.shape == (E, OUT, R)
+    assert torch.equal(out, t[:, :, :R])
+
+
+def test_slice_3d_nonzero_padding_raises():
+    t = torch.randn(E, MAXR, IN)  # padded rank slots NOT zeroed -> corruption guard fires
+    with pytest.raises(AssertionError, match="padded rank slots are non-zero"):
+        slice_lora_to_rank("x.experts.gate_proj.lora_A.weight", t, R)
+
+
+def _guard_ns(target_modules):
+    # Only the attributes touched up to the MoE guard are required.
+    return Namespace(
+        multi_lora_n_adapters=2,
+        rollout_function_path="custom.fn",
+        data_source_path="custom.ds",
+        lora_rank=8,
+        target_modules=target_modules,
+    )
+
+
+def test_validate_rejects_expert_target_modules():
+    with pytest.raises(AssertionError, match="MoE expert target modules"):
+        validate_multi_lora_args(_guard_ns(["*.mlp.experts.linear_fc1", "linear_qkv"]))
+
+
+def test_validate_allows_non_expert_target_modules_past_guard():
+    # A dense/attention target must pass the MoE guard (it may still trip a later,
+    # unrelated check on this minimal Namespace — we only assert the guard did not
+    # false-positive on non-expert names).
+    try:
+        validate_multi_lora_args(_guard_ns(["linear_qkv", "linear_proj"]))
+    except (AssertionError, AttributeError) as exc:
+        assert "MoE expert target modules" not in str(exc)

--- a/tests/fast/backends/megatron_utils/test_slice_lora_to_rank.py
+++ b/tests/fast/backends/megatron_utils/test_slice_lora_to_rank.py
@@ -34,7 +34,7 @@ def test_nonzero_padding_is_rejected():
     # Live values beyond the adapter's rank mean the pad rows were trained —
     # slicing would silently drop signal, so it must hard-fail instead.
     tensor = torch.ones(32, 8)
-    with pytest.raises(AssertionError, match="padded dims are non-zero"):
+    with pytest.raises(AssertionError, match="padded rank slots are non-zero"):
         slice_lora_to_rank("x.lora_A.weight", tensor, 16)
 
 


### PR DESCRIPTION
## What

Two MoE multi-LoRA support fixes on the miles side:

1. **Fix `slice_lora_to_rank` for 3-D expert tensors (latent corruption).**
   It sliced hard-coded `shape[0]` (lora_A) / `shape[1]` (lora_B), which is the
   **expert** axis for the 3-D grouped-expert layout (`[num_experts, rank, in]` /
   `[num_experts, out, rank]`). On the weight-sync / HF-export path this silently
   sliced the wrong axis and corrupted expert adapters. It now slices the **rank**
   axis by position (lora_A: dim `-2`, lora_B: dim `-1`), which is **byte-identical
   for the 2-D dense layout** and correct for 3-D.

2. **Guard `validate_multi_lora_args` against expert target modules.**
   MoE expert multi-LoRA is not yet wired end-to-end (the dispatcher slot-id
   threading in Megatron-LM and the bridge grouped-expert layer are separate PRs).
   Until then, targeting expert modules (e.g. `*.mlp.experts.linear_fc1`) would
   silently drop the expert adapters at train time, so this now fails loudly with a
   clear message. (Detects explicit `experts` targets; bare leaf names like
   `linear_fc1` can't be disambiguated here without the model — a documented
   false-negative.)

## Non-regression

- `slice_lora_to_rank`: for existing 2-D inputs the new axis logic
  (`ndim-2` / `ndim-1`) equals the old `shape[0]` / `shape[1]` slicing exactly,
  including the `adapter_rank >= size` no-op and the zero-remainder assertion. No
  2-D caller sees a different result.
- The guard runs only after the `if not args.multi_lora: return` early-out, so
  non-multi-LoRA and non-MoE multi-LoRA runs are unaffected. None of the standard
  non-expert module names contain the substring `experts`, so no false positives.

## Verification

- **CPU-verified locally**: `slice_lora_to_rank` for 2-D and 3-D lora_A/lora_B
  (shape + content), the no-op path, the corruption assertion, and non-lora
  passthrough; the guard fires on expert targets and lets non-expert targets past.
  New CI-registered coverage in
  `tests/fast/backends/megatron_utils/test_multi_lora_moe_support.py`; the
  pre-existing `test_slice_lora_to_rank.py` is updated for the new assertion message.

## Related

Pairs with the Megatron-Bridge PR adding `MultiLoRAGroupedExpertLinear`
(opt-in grouped-expert multi-adapter LoRA). The guard in (2) is relaxed once the
end-to-end MoE expert path (Megatron-LM companion channel + bridge layer) lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
