### PR TITLE
Add an experimental DeepSeek-V4 TOP parity contract

### DIFF
--- a/miles/backends/megatron_utils/megatron_to_hf/processors/quantizer_fp8.py
+++ b/miles/backends/megatron_utils/megatron_to_hf/processors/quantizer_fp8.py
@@ -106,15 +106,24 @@ def _quantize_param(args, name, weight, weight_block_size):
     assert name.endswith(".weight"), f"Expected weight parameter, got {name}"
     FP8_MIN = torch.finfo(torch.float8_e4m3fn).min
     FP8_MAX = torch.finfo(torch.float8_e4m3fn).max
+    force_pow_2_scales = bool(getattr(args, "true_on_policy_mode", False))
     if weight_block_size is not None:
         if _get_scale_format(args, name, weight_block_size) == "ue8m0":
             qweight, scale = quant_weight_ue8m0(weight, weight_block_size=weight_block_size)
             scale = transform_scale_ue8m0(scale, mn=qweight.shape[-2])
         # TODO: this [128, 128] is hacky. need improve
-        elif per_block_cast_to_fp8 is not None and list(weight_block_size) == [128, 128]:
+        elif (
+            per_block_cast_to_fp8 is not None
+            and list(weight_block_size) == [128, 128]
+            and not force_pow_2_scales
+        ):
             qweight, scale = per_block_cast_to_fp8(weight)
         else:
-            qweight, scale = blockwise_cast_to_fp8_triton(weight, weight_block_size)
+            qweight, scale = blockwise_cast_to_fp8_triton(
+                weight,
+                weight_block_size,
+                force_pow_2_scales=force_pow_2_scales,
+            )
         scale_name = name.replace(".weight", ".weight_scale_inv")
     else:
         # per tensor quant

--- a/miles/backends/megatron_utils/megatron_to_hf/processors/quantizer_fp8.py
+++ b/miles/backends/megatron_utils/megatron_to_hf/processors/quantizer_fp8.py
@@ -12,6 +12,12 @@ from ...sglang import (
 )
 
 
+def _use_dsv4_top_pow2_scales(args) -> bool:
+    return bool(
+        getattr(args, "true_on_policy_mode", False) and getattr(args, "experimental_attention_variant", None) == "dsv4"
+    )
+
+
 def quantize_params_fp8(args, megatron_name, converted_named_params, quantization_config):
     assert quantization_config["quant_method"] == "fp8"
     fmt = quantization_config.get("fmt", "e4m3")
@@ -106,17 +112,15 @@ def _quantize_param(args, name, weight, weight_block_size):
     assert name.endswith(".weight"), f"Expected weight parameter, got {name}"
     FP8_MIN = torch.finfo(torch.float8_e4m3fn).min
     FP8_MAX = torch.finfo(torch.float8_e4m3fn).max
-    force_pow_2_scales = bool(getattr(args, "true_on_policy_mode", False))
+    # SGLang's DSV4 FP8 path uses UE8M0-compatible power-of-two scales.
+    # Keep other TOP models on their existing conversion path.
+    force_pow_2_scales = _use_dsv4_top_pow2_scales(args)
     if weight_block_size is not None:
         if _get_scale_format(args, name, weight_block_size) == "ue8m0":
             qweight, scale = quant_weight_ue8m0(weight, weight_block_size=weight_block_size)
             scale = transform_scale_ue8m0(scale, mn=qweight.shape[-2])
         # TODO: this [128, 128] is hacky. need improve
-        elif (
-            per_block_cast_to_fp8 is not None
-            and list(weight_block_size) == [128, 128]
-            and not force_pow_2_scales
-        ):
+        elif per_block_cast_to_fp8 is not None and list(weight_block_size) == [128, 128] and not force_pow_2_scales:
             qweight, scale = per_block_cast_to_fp8(weight)
         else:
             qweight, scale = blockwise_cast_to_fp8_triton(

--- a/miles/backends/sglang_utils/arguments.py
+++ b/miles/backends/sglang_utils/arguments.py
@@ -1,3 +1,5 @@
+import warnings
+
 from sglang.srt.server_args import ServerArgs
 from miles.utils.http_utils import _wrap_ipv6
 
@@ -137,12 +139,27 @@ def add_sglang_arguments(parser):
 def validate_args(args):
     args.sglang_tp_size = args.rollout_num_gpus_per_engine
 
-    if args.true_on_policy_mode:
-        args.sglang_enable_deterministic_inference = True
+    recompute_via_prefill = getattr(args, "recompute_logprobs_via_prefill", False)
+    allow_nondeterministic_probe = getattr(args, "allow_nondeterministic_top_parity_probe", False)
 
-    if getattr(args, "recompute_logprobs_via_prefill", False):
-        args.sglang_enable_prefill_only_deterministic_inference = True
-        args.sglang_enable_deterministic_inference = True
+    if allow_nondeterministic_probe:
+        if not (args.true_on_policy_mode and recompute_via_prefill):
+            raise ValueError(
+                "--allow-nondeterministic-top-parity-probe requires both "
+                "--true-on-policy-mode and --recompute-logprobs-via-prefill"
+            )
+        warnings.warn(
+            "Running a nondeterministic TOP parity probe. This diagnostic mode does not certify "
+            "true on-policy behavior and must not be used for training.",
+            stacklevel=2,
+        )
+    else:
+        if args.true_on_policy_mode:
+            args.sglang_enable_deterministic_inference = True
+
+        if recompute_via_prefill:
+            args.sglang_enable_prefill_only_deterministic_inference = True
+            args.sglang_enable_deterministic_inference = True
 
     if args.sglang_dp_size > 1:
         assert args.sglang_enable_dp_attention

--- a/miles/backends/sglang_utils/arguments.py
+++ b/miles/backends/sglang_utils/arguments.py
@@ -1,5 +1,3 @@
-import warnings
-
 from sglang.srt.server_args import ServerArgs
 from miles.utils.http_utils import _wrap_ipv6
 
@@ -139,27 +137,12 @@ def add_sglang_arguments(parser):
 def validate_args(args):
     args.sglang_tp_size = args.rollout_num_gpus_per_engine
 
-    recompute_via_prefill = getattr(args, "recompute_logprobs_via_prefill", False)
-    allow_nondeterministic_probe = getattr(args, "allow_nondeterministic_top_parity_probe", False)
+    if args.true_on_policy_mode:
+        args.sglang_enable_deterministic_inference = True
 
-    if allow_nondeterministic_probe:
-        if not (args.true_on_policy_mode and recompute_via_prefill):
-            raise ValueError(
-                "--allow-nondeterministic-top-parity-probe requires both "
-                "--true-on-policy-mode and --recompute-logprobs-via-prefill"
-            )
-        warnings.warn(
-            "Running a nondeterministic TOP parity probe. This diagnostic mode does not certify "
-            "true on-policy behavior and must not be used for training.",
-            stacklevel=2,
-        )
-    else:
-        if args.true_on_policy_mode:
-            args.sglang_enable_deterministic_inference = True
-
-        if recompute_via_prefill:
-            args.sglang_enable_prefill_only_deterministic_inference = True
-            args.sglang_enable_deterministic_inference = True
+    if getattr(args, "recompute_logprobs_via_prefill", False):
+        args.sglang_enable_prefill_only_deterministic_inference = True
+        args.sglang_enable_deterministic_inference = True
 
     if args.sglang_dp_size > 1:
         assert args.sglang_enable_dp_attention

--- a/miles/backends/sglang_utils/dsv4_top_attention.py
+++ b/miles/backends/sglang_utils/dsv4_top_attention.py
@@ -1,0 +1,219 @@
+"""Inference-side sparse-attention arithmetic for the DSV4 TOP contract."""
+
+from __future__ import annotations
+
+import torch
+
+from miles_plugins.models.deepseek_v4.ops.kernel.tilelang_sparse_mla_fwd import (
+    sparse_mqa_fwd_interface,
+)
+
+_CONTRACT_TOKENS = 96
+_HEAD_DIM = 512
+_CONTRACT_LOCAL_HEADS = 8
+_QUERY_HEADS = 64
+_SWA_SLOTS = 128
+_COMPRESSED_SLOTS = 256
+_KERNEL_SLOTS = _SWA_SLOTS + _COMPRESSED_SLOTS
+
+
+def _validate_sparse_indices(
+    combined_indices: torch.Tensor,
+    combined_lens: torch.Tensor,
+) -> None:
+    if combined_lens.shape != (_CONTRACT_TOKENS,):
+        raise RuntimeError("DSV4 TOP sparse-attention length shape mismatch: " f"{tuple(combined_lens.shape)}")
+    if combined_indices.ndim != 2 or combined_indices.shape[0] != (_CONTRACT_TOKENS):
+        raise RuntimeError("DSV4 TOP sparse-attention index shape mismatch: " f"{tuple(combined_indices.shape)}")
+    if combined_indices.dtype != torch.int32:
+        raise RuntimeError("DSV4 TOP sparse-attention indices must be int32, got " f"{combined_indices.dtype}")
+    valid_counts = (combined_indices >= 0).sum(dim=-1).to(combined_lens.dtype)
+    if not torch.equal(valid_counts, combined_lens):
+        raise RuntimeError("DSV4 TOP sparse-attention lengths do not match valid indices")
+
+
+def _causal_indices(
+    *,
+    width: int,
+    device: torch.device,
+) -> torch.Tensor:
+    token_positions = torch.arange(
+        _CONTRACT_TOKENS,
+        dtype=torch.int32,
+        device=device,
+    )
+    indices = torch.full(
+        (_CONTRACT_TOKENS, width),
+        -1,
+        dtype=torch.int32,
+        device=device,
+    )
+    indices[:, :_CONTRACT_TOKENS] = torch.where(
+        token_positions.unsqueeze(0) <= token_positions.unsqueeze(1),
+        token_positions.unsqueeze(0),
+        -1,
+    )
+    return indices
+
+
+def maybe_dsv4_top_sparse_prefill(
+    *,
+    model_runner,
+    q_flat: torch.Tensor,
+    kv: torch.Tensor,
+    swa_slice: torch.Tensor,
+    combined_indices: torch.Tensor,
+    combined_lens: torch.Tensor,
+    compress_ratio: int,
+    layer_id: int,
+    attn_sink: torch.Tensor,
+    softmax_scale: float,
+) -> torch.Tensor | None:
+    """Return the TOP output for the pinned E2E shape, else ``None``."""
+    contract_layer = (
+        (compress_ratio == 0 and layer_id in (0, 1))
+        or (compress_ratio == 4 and layer_id == 2)
+        or (compress_ratio == 128 and layer_id == 3)
+    )
+    if not (
+        contract_layer and q_flat.shape[0] == _CONTRACT_TOKENS and kv.ndim == 3 and kv.shape[1:] == (1, _HEAD_DIM)
+    ):
+        return None
+
+    n_local_heads = model_runner.model_config.get_num_attention_heads(model_runner.tp_size)
+    if n_local_heads != _CONTRACT_LOCAL_HEADS:
+        raise RuntimeError(
+            "DSV4 TOP sparse attention expected " f"{_CONTRACT_LOCAL_HEADS} local heads, got {n_local_heads}"
+        )
+    expected_q_shape = (
+        _CONTRACT_TOKENS,
+        _QUERY_HEADS,
+        _HEAD_DIM,
+    )
+    if q_flat.shape != expected_q_shape:
+        raise RuntimeError(
+            "DSV4 TOP sparse-attention query shape mismatch: "
+            f"expected {expected_q_shape}, got {tuple(q_flat.shape)}"
+        )
+    _validate_sparse_indices(combined_indices, combined_lens)
+
+    if compress_ratio == 0:
+        expected_kv_shape = (_CONTRACT_TOKENS, 1, _HEAD_DIM)
+        if kv.shape != expected_kv_shape:
+            raise RuntimeError(
+                "DSV4 TOP C0 KV shape mismatch: " f"expected {expected_kv_shape}, got {tuple(kv.shape)}"
+            )
+        expected_indices = _causal_indices(
+            width=_SWA_SLOTS,
+            device=combined_indices.device,
+        )
+        expected_lens = torch.arange(
+            1,
+            _CONTRACT_TOKENS + 1,
+            dtype=torch.int32,
+            device=combined_lens.device,
+        )
+        if not torch.equal(combined_lens, expected_lens):
+            raise RuntimeError("DSV4 TOP C0 lengths are not causal")
+        if not torch.equal(combined_indices, expected_indices):
+            raise RuntimeError("DSV4 TOP C0 indices are not causal")
+        kv_for_miles = kv
+        kernel_indices = combined_indices
+    elif compress_ratio == 4:
+        expected_kv_shape = (120, 1, _HEAD_DIM)
+        if kv.shape != expected_kv_shape:
+            raise RuntimeError(
+                "DSV4 TOP C4 KV shape mismatch: " f"expected {expected_kv_shape}, got {tuple(kv.shape)}"
+            )
+        expected_index_shape = (_CONTRACT_TOKENS, 640)
+        if combined_indices.shape != expected_index_shape:
+            raise RuntimeError(
+                "DSV4 TOP C4 index shape mismatch: "
+                f"expected {expected_index_shape}, got "
+                f"{tuple(combined_indices.shape)}"
+            )
+
+        token_positions = torch.arange(
+            _CONTRACT_TOKENS,
+            dtype=torch.int32,
+            device=combined_indices.device,
+        )
+        compressed_lens = (token_positions + 1) // 4
+        window_lens = token_positions + 1
+        if not torch.equal(
+            combined_lens,
+            compressed_lens + window_lens,
+        ):
+            raise RuntimeError("DSV4 TOP C4 sparse lengths are invalid")
+
+        kernel_indices = torch.full(
+            (_CONTRACT_TOKENS, _KERNEL_SLOTS),
+            -1,
+            dtype=torch.int32,
+            device=combined_indices.device,
+        )
+        window_slots = torch.arange(
+            _SWA_SLOTS,
+            dtype=torch.int64,
+            device=combined_indices.device,
+        ).unsqueeze(0)
+        window_sources = compressed_lens.long().unsqueeze(1) + window_slots
+        window_values = combined_indices.gather(1, window_sources)
+        kernel_indices[:, :_SWA_SLOTS] = torch.where(
+            window_slots < window_lens.long().unsqueeze(1),
+            window_values,
+            -1,
+        )
+        compressed_slots = torch.arange(
+            _COMPRESSED_SLOTS,
+            dtype=torch.int64,
+            device=combined_indices.device,
+        ).unsqueeze(0)
+        kernel_indices[:, _SWA_SLOTS:] = torch.where(
+            compressed_slots < compressed_lens.long().unsqueeze(1),
+            combined_indices[:, :_COMPRESSED_SLOTS],
+            -1,
+        )
+        valid_kernel_indices = (kernel_indices == -1) | ((kernel_indices >= 0) & (kernel_indices < kv.shape[0]))
+        if not bool(torch.all(valid_kernel_indices).item()):
+            raise RuntimeError("DSV4 TOP C4 generated out-of-range sparse indices")
+        kv_for_miles = kv
+    else:
+        expected_swa_shape = (
+            _CONTRACT_TOKENS,
+            1,
+            _HEAD_DIM,
+        )
+        if swa_slice.shape != expected_swa_shape:
+            raise RuntimeError(
+                "DSV4 TOP C128 SWA shape mismatch: " f"expected {expected_swa_shape}, got " f"{tuple(swa_slice.shape)}"
+            )
+        expected_lens = torch.arange(
+            1,
+            _CONTRACT_TOKENS + 1,
+            dtype=torch.int32,
+            device=combined_lens.device,
+        )
+        if not torch.equal(combined_lens, expected_lens):
+            raise RuntimeError("DSV4 TOP C128 lengths are not causal")
+        kv_for_miles = swa_slice
+        kernel_indices = _causal_indices(
+            width=_KERNEL_SLOTS,
+            device=combined_indices.device,
+        )
+
+    q_miles = q_flat[:, :n_local_heads, :].unsqueeze(0).contiguous()
+    kv_miles = kv_for_miles.squeeze(1).unsqueeze(0).contiguous()
+    sink_miles = attn_sink[:n_local_heads].contiguous()
+    indices_miles = kernel_indices.unsqueeze(0).contiguous()
+    output, _ = sparse_mqa_fwd_interface(
+        q_miles,
+        kv_miles,
+        sink_miles,
+        indices_miles,
+        sm_scale=softmax_scale,
+    )
+
+    result = torch.zeros_like(q_flat)
+    result[:, :n_local_heads, :].copy_(output.squeeze(0))
+    return result

--- a/miles/backends/sglang_utils/dsv4_top_moe.py
+++ b/miles/backends/sglang_utils/dsv4_top_moe.py
@@ -1,0 +1,482 @@
+"""Inference-side MoE arithmetic used by the DSV4 TOP source contract."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass
+from typing import Iterator
+
+import torch
+
+_CONTRACT_TOKENS = 96
+_CONTRACT_TOPK = 6
+_CONTRACT_HIDDEN_SIZE = 4096
+_CONTRACT_NUM_EXPERTS = 32
+_FP8_BLOCK_SIZE = 128
+_GROUPED_GEMM_ALIGNMENT = 16
+
+
+@dataclass
+class Dsv4TopMoeContext:
+    """Request-local state shared with SGLang's fused-MoE call stack."""
+
+    active: bool
+    topk_ids: torch.Tensor | None = None
+    routed_unscaled: torch.Tensor | None = None
+
+
+_CURRENT_MOE_CONTEXT: ContextVar[Dsv4TopMoeContext | None] = ContextVar(
+    "miles_dsv4_top_moe_context",
+    default=None,
+)
+
+
+@contextmanager
+def dsv4_top_moe_context(
+    *,
+    layer_id: int,
+    hidden_states: torch.Tensor,
+    topk_ids: torch.Tensor,
+) -> Iterator[Dsv4TopMoeContext]:
+    """Activate the version-pinned four-layer/96-token MoE contract."""
+    active = layer_id in (0, 1, 2, 3) and hidden_states.shape == (_CONTRACT_TOKENS, _CONTRACT_HIDDEN_SIZE)
+    if active and topk_ids.shape != (
+        _CONTRACT_TOKENS,
+        _CONTRACT_TOPK,
+    ):
+        raise RuntimeError(
+            "DSV4 TOP MoE contract expected top-k ids with shape "
+            f"{(_CONTRACT_TOKENS, _CONTRACT_TOPK)}, got "
+            f"{tuple(topk_ids.shape)}"
+        )
+
+    context = Dsv4TopMoeContext(
+        active=active,
+        topk_ids=topk_ids.clone() if active else None,
+    )
+    token = _CURRENT_MOE_CONTEXT.set(context)
+    try:
+        yield context
+    finally:
+        _CURRENT_MOE_CONTEXT.reset(token)
+
+
+def get_dsv4_top_moe_context() -> Dsv4TopMoeContext | None:
+    return _CURRENT_MOE_CONTEXT.get()
+
+
+def _validate_expert_ids(
+    expert_ids: torch.Tensor,
+    *,
+    num_experts: int,
+) -> None:
+    valid = (expert_ids == -1) | ((expert_ids >= 0) & (expert_ids < num_experts))
+    if not bool(torch.all(valid).item()):
+        raise RuntimeError(
+            "DSV4 TOP MoE contract received invalid expert ids: "
+            f"min={expert_ids.min().item()}, max={expert_ids.max().item()}, "
+            f"num_experts={num_experts}"
+        )
+
+
+def _wrap_block_fp8(
+    data: torch.Tensor,
+    scale_inv: torch.Tensor,
+    quantizer,
+    *,
+    is_2d_scaled: bool,
+):
+    import transformer_engine_torch as tex
+    from transformer_engine.pytorch.tensor.float8_blockwise_tensor import (
+        Float8BlockwiseQTensor,
+    )
+
+    data = data.contiguous()
+    scale_inv = scale_inv.contiguous()
+    if data.dtype != torch.float8_e4m3fn:
+        raise RuntimeError(f"DSV4 TOP expected FP8 E4M3 data, got {data.dtype}")
+    if scale_inv.dtype != torch.float32:
+        raise RuntimeError("DSV4 TOP expected FP32 inverse scales, got " f"{scale_inv.dtype}")
+
+    expected_scale_shape = tuple(quantizer.get_scale_shape(data.shape, columnwise=False))
+    if tuple(scale_inv.shape) != expected_scale_shape:
+        raise RuntimeError(
+            "DSV4 TOP FP8 scale shape mismatch: "
+            f"data={tuple(data.shape)}, scale={tuple(scale_inv.shape)}, "
+            f"expected={expected_scale_shape}"
+        )
+
+    return Float8BlockwiseQTensor(
+        shape=tuple(data.shape),
+        dtype=torch.bfloat16,
+        device=data.device,
+        requires_grad=False,
+        rowwise_data=data.view(torch.uint8),
+        rowwise_scale_inv=scale_inv,
+        columnwise_data=None,
+        columnwise_scale_inv=None,
+        fp8_dtype=tex.DType.kFloat8E4M3,
+        quantizer=quantizer,
+        is_2D_scaled=is_2d_scaled,
+    )
+
+
+def _te_grouped_gemm_by_slot(
+    inputs: torch.Tensor,
+    expert_ids: torch.Tensor,
+    weights: torch.Tensor,
+    weight_scale: torch.Tensor,
+) -> torch.Tensor:
+    """Run trainer-compatible TE grouped GEMM and restore slot order."""
+    import transformer_engine_torch as tex
+    from transformer_engine.pytorch.cpp_extensions.gemm import (
+        general_grouped_gemm,
+    )
+    from transformer_engine.pytorch.tensor.float8_blockwise_tensor import (
+        Float8BlockQuantizer,
+    )
+    from sglang.srt.layers.quantization.fp8_kernel import (
+        sglang_per_token_group_quant_fp8,
+    )
+
+    if inputs.ndim != 2 or weights.ndim != 3:
+        raise RuntimeError(
+            "DSV4 TOP grouped GEMM expected 2D inputs and 3D weights, "
+            f"got {tuple(inputs.shape)} and {tuple(weights.shape)}"
+        )
+    num_slots, input_size = inputs.shape
+    num_experts, output_size, weight_input_size = weights.shape
+    if input_size != weight_input_size:
+        raise RuntimeError("DSV4 TOP grouped GEMM input/weight K mismatch: " f"{input_size} vs {weight_input_size}")
+    if num_experts != _CONTRACT_NUM_EXPERTS:
+        raise RuntimeError("DSV4 TOP grouped GEMM expected " f"{_CONTRACT_NUM_EXPERTS} experts, got {num_experts}")
+    if input_size % _FP8_BLOCK_SIZE or output_size % _FP8_BLOCK_SIZE:
+        raise RuntimeError(
+            "DSV4 TOP grouped GEMM dimensions must be divisible by "
+            f"{_FP8_BLOCK_SIZE}: input={input_size}, output={output_size}"
+        )
+    if expert_ids.shape != (num_slots,):
+        raise RuntimeError(
+            "DSV4 TOP grouped GEMM expert-id shape mismatch: "
+            f"expected {(num_slots,)}, got {tuple(expert_ids.shape)}"
+        )
+    if weights.dtype != torch.float8_e4m3fn:
+        raise RuntimeError(f"DSV4 TOP expected FP8 weights, got {weights.dtype}")
+    expected_weight_scale_shape = (
+        num_experts,
+        output_size // _FP8_BLOCK_SIZE,
+        input_size // _FP8_BLOCK_SIZE,
+    )
+    if weight_scale.shape != expected_weight_scale_shape:
+        raise RuntimeError(
+            "DSV4 TOP weight-scale shape mismatch: "
+            f"expected {expected_weight_scale_shape}, got "
+            f"{tuple(weight_scale.shape)}"
+        )
+    if weight_scale.dtype != torch.float32:
+        raise RuntimeError(f"DSV4 TOP expected FP32 weight scales, got {weight_scale.dtype}")
+    _validate_expert_ids(expert_ids, num_experts=num_experts)
+
+    quantized_inputs, input_scales = sglang_per_token_group_quant_fp8(
+        inputs.contiguous(),
+        _FP8_BLOCK_SIZE,
+        scale_ue8m0=True,
+    )
+    expected_input_scale_shape = (
+        num_slots,
+        input_size // _FP8_BLOCK_SIZE,
+    )
+    if input_scales.shape != expected_input_scale_shape:
+        raise RuntimeError(
+            "DSV4 TOP input-scale shape mismatch: "
+            f"expected {expected_input_scale_shape}, got "
+            f"{tuple(input_scales.shape)}"
+        )
+    if input_scales.dtype != torch.float32:
+        raise RuntimeError(f"DSV4 TOP expected FP32 input scales, got {input_scales.dtype}")
+
+    input_quantizer = Float8BlockQuantizer(
+        tex.DType.kFloat8E4M3,
+        rowwise=True,
+        columnwise=False,
+        force_pow_2_scales=True,
+        block_scaling_dim=1,
+    )
+    input_quantizer.internal = True
+    input_quantizer.optimize_for_gemm = True
+    weight_quantizer = Float8BlockQuantizer(
+        tex.DType.kFloat8E4M3,
+        rowwise=True,
+        columnwise=False,
+        force_pow_2_scales=True,
+        block_scaling_dim=2,
+    )
+    weight_quantizer.internal = True
+
+    input_qtensors = []
+    weight_qtensors = []
+    slot_indices_by_expert = []
+    counts = []
+    padded_counts = []
+    for expert in range(num_experts):
+        slot_indices = torch.nonzero(
+            expert_ids == expert,
+            as_tuple=False,
+        ).flatten()
+        count = int(slot_indices.numel())
+        padded_count = (count + _GROUPED_GEMM_ALIGNMENT - 1) // _GROUPED_GEMM_ALIGNMENT * _GROUPED_GEMM_ALIGNMENT
+        counts.append(count)
+        padded_counts.append(padded_count)
+        slot_indices_by_expert.append(slot_indices)
+
+        expert_inputs = torch.zeros(
+            (padded_count, input_size),
+            dtype=torch.float8_e4m3fn,
+            device=inputs.device,
+        )
+        expert_scale_shape = tuple(
+            input_quantizer.get_scale_shape(
+                expert_inputs.shape,
+                columnwise=False,
+            )
+        )
+        expected_expert_scale_shape = (
+            input_size // _FP8_BLOCK_SIZE,
+            padded_count,
+        )
+        if expert_scale_shape != expected_expert_scale_shape:
+            raise RuntimeError(
+                "DSV4 TOP padded input-scale shape mismatch: "
+                f"expected {expected_expert_scale_shape}, got "
+                f"{expert_scale_shape}"
+            )
+        expert_scales = torch.ones(
+            expert_scale_shape,
+            dtype=torch.float32,
+            device=inputs.device,
+        )
+        if count:
+            expert_inputs[:count].copy_(quantized_inputs.index_select(0, slot_indices))
+            expert_scales[:, :count].copy_(
+                input_scales.index_select(
+                    0,
+                    slot_indices,
+                ).transpose(0, 1)
+            )
+        input_qtensors.append(
+            _wrap_block_fp8(
+                expert_inputs,
+                expert_scales,
+                input_quantizer,
+                is_2d_scaled=False,
+            )
+        )
+        weight_qtensors.append(
+            _wrap_block_fp8(
+                weights[expert],
+                weight_scale[expert],
+                weight_quantizer,
+                is_2d_scaled=True,
+            )
+        )
+
+    if sum(counts) <= 0:
+        raise RuntimeError("DSV4 TOP grouped GEMM received no valid routes")
+
+    padded_output = torch.empty(
+        (sum(padded_counts), output_size),
+        dtype=torch.bfloat16,
+        device=inputs.device,
+    )
+    result = general_grouped_gemm(
+        A=weight_qtensors,
+        B=input_qtensors,
+        out=[padded_output],
+        quantization_params=[None] * num_experts,
+        out_dtype=torch.bfloat16,
+        layout="TN",
+        m_splits=padded_counts,
+        gelu=False,
+        grad=False,
+        accumulate=False,
+        bias=None,
+        use_bias=False,
+        use_split_accumulator=True,
+        D_dtype=None,
+        single_output=True,
+    )
+    if result[0][0].data_ptr() != padded_output.data_ptr():
+        raise RuntimeError("DSV4 TOP TE grouped GEMM did not write into the supplied output")
+
+    output_by_slot = torch.zeros(
+        (num_slots, output_size),
+        dtype=torch.bfloat16,
+        device=inputs.device,
+    )
+    cursor = 0
+    for count, padded_count, slot_indices in zip(
+        counts,
+        padded_counts,
+        slot_indices_by_expert,
+        strict=True,
+    ):
+        if count:
+            output_by_slot.index_copy_(
+                0,
+                slot_indices,
+                padded_output[cursor : cursor + count],
+            )
+        cursor += padded_count
+    if cursor != padded_output.shape[0]:
+        raise RuntimeError("DSV4 TOP grouped GEMM output cursor mismatch: " f"{cursor} vs {padded_output.shape[0]}")
+    return output_by_slot
+
+
+def replace_fused_moe_fc1(
+    *,
+    hidden_states: torch.Tensor,
+    topk_ids: torch.Tensor,
+    intermediate_cache1: torch.Tensor,
+    w1: torch.Tensor,
+    w1_scale: torch.Tensor,
+    use_fp8_w8a8: bool,
+    block_shape,
+    bias: torch.Tensor | None,
+) -> None:
+    """Replace SGLang FC1 with the trainer-compatible TE grouped GEMM."""
+    if not use_fp8_w8a8 or block_shape != [128, 128] or bias is not None:
+        raise RuntimeError("DSV4 TOP FC1 requires FP8 block scaling without bias")
+    if hidden_states.shape != (
+        _CONTRACT_TOKENS,
+        _CONTRACT_HIDDEN_SIZE,
+    ):
+        raise RuntimeError(f"DSV4 TOP FC1 hidden shape mismatch: {hidden_states.shape}")
+    if topk_ids.shape != (_CONTRACT_TOKENS, _CONTRACT_TOPK):
+        raise RuntimeError(f"DSV4 TOP FC1 top-k shape mismatch: {topk_ids.shape}")
+
+    num_slots = _CONTRACT_TOKENS * _CONTRACT_TOPK
+    flat_hidden = (
+        hidden_states.unsqueeze(1)
+        .expand(
+            _CONTRACT_TOKENS,
+            _CONTRACT_TOPK,
+            _CONTRACT_HIDDEN_SIZE,
+        )
+        .reshape(num_slots, _CONTRACT_HIDDEN_SIZE)
+        .contiguous()
+    )
+    output_by_slot = _te_grouped_gemm_by_slot(
+        flat_hidden,
+        topk_ids.reshape(-1).long(),
+        w1,
+        w1_scale,
+    )
+    if intermediate_cache1.shape[0] < num_slots:
+        raise RuntimeError("DSV4 TOP FC1 cache is too small: " f"{tuple(intermediate_cache1.shape)}")
+    intermediate_cache1[:num_slots].copy_(output_by_slot)
+
+
+def replace_fused_moe_fc2(
+    *,
+    topk_ids: torch.Tensor,
+    intermediate_cache2: torch.Tensor,
+    intermediate_cache3: torch.Tensor,
+    w2: torch.Tensor,
+    w2_scale: torch.Tensor,
+    use_fp8_w8a8: bool,
+    block_shape,
+    bias: torch.Tensor | None,
+) -> None:
+    """Replace SGLang FC2 with the trainer-compatible TE grouped GEMM."""
+    if not use_fp8_w8a8 or block_shape != [128, 128] or bias is not None:
+        raise RuntimeError("DSV4 TOP FC2 requires FP8 block scaling without bias")
+    if topk_ids.shape != (_CONTRACT_TOKENS, _CONTRACT_TOPK):
+        raise RuntimeError(f"DSV4 TOP FC2 top-k shape mismatch: {topk_ids.shape}")
+    expected_output_shape = (
+        _CONTRACT_TOKENS,
+        _CONTRACT_TOPK,
+        _CONTRACT_HIDDEN_SIZE,
+    )
+    if intermediate_cache3.shape != expected_output_shape:
+        raise RuntimeError(
+            "DSV4 TOP FC2 output-cache shape mismatch: "
+            f"expected {expected_output_shape}, got "
+            f"{tuple(intermediate_cache3.shape)}"
+        )
+
+    num_slots = _CONTRACT_TOKENS * _CONTRACT_TOPK
+    if intermediate_cache2.shape[0] < num_slots:
+        raise RuntimeError("DSV4 TOP FC2 input cache is too small: " f"{tuple(intermediate_cache2.shape)}")
+    output_by_slot = _te_grouped_gemm_by_slot(
+        intermediate_cache2[:num_slots].contiguous(),
+        topk_ids.reshape(-1).long(),
+        w2,
+        w2_scale,
+    )
+    intermediate_cache3.copy_(output_by_slot.view(expected_output_shape))
+
+
+def record_fused_moe_trainer_order(
+    intermediate_cache3: torch.Tensor,
+) -> None:
+    """Reduce TP slots and reproduce the trainer's stable expert ordering."""
+    from sglang.srt.distributed.parallel_state import get_tp_group
+    from sglang.srt.tp_invariant_ops import tree_all_reduce_sum
+
+    context = get_dsv4_top_moe_context()
+    if context is None or not context.active or context.topk_ids is None:
+        raise RuntimeError("DSV4 TOP routed combine ran without an active MoE context")
+    expected_shape = (
+        _CONTRACT_TOKENS,
+        _CONTRACT_TOPK,
+        _CONTRACT_HIDDEN_SIZE,
+    )
+    if intermediate_cache3.shape != expected_shape:
+        raise RuntimeError(
+            "DSV4 TOP routed combine shape mismatch: "
+            f"expected {expected_shape}, got "
+            f"{tuple(intermediate_cache3.shape)}"
+        )
+
+    global_weighted_by_slot = tree_all_reduce_sum(
+        intermediate_cache3,
+        device_group=get_tp_group().device_group,
+    )
+    token_ids = (
+        torch.arange(
+            _CONTRACT_TOKENS,
+            dtype=torch.long,
+            device=context.topk_ids.device,
+        )
+        .unsqueeze(1)
+        .expand(_CONTRACT_TOKENS, _CONTRACT_TOPK)
+        .reshape(-1)
+    )
+    expert_ids = context.topk_ids.reshape(-1).long()
+    order = torch.argsort(
+        expert_ids * _CONTRACT_TOKENS + token_ids,
+        stable=True,
+    )
+    sorted_tokens = token_ids[order]
+    sorted_weighted = global_weighted_by_slot.reshape(
+        _CONTRACT_TOKENS * _CONTRACT_TOPK,
+        _CONTRACT_HIDDEN_SIZE,
+    )[order]
+    trainer_order = torch.zeros(
+        (_CONTRACT_TOKENS, _CONTRACT_HIDDEN_SIZE),
+        dtype=sorted_weighted.dtype,
+        device=sorted_weighted.device,
+    )
+
+    previous_deterministic = torch.are_deterministic_algorithms_enabled()
+    torch.use_deterministic_algorithms(True)
+    try:
+        trainer_order.index_add_(
+            0,
+            sorted_tokens,
+            sorted_weighted,
+        )
+    finally:
+        torch.use_deterministic_algorithms(previous_deterministic)
+    context.routed_unscaled = trainer_order

--- a/miles/backends/sglang_utils/dsv4_top_patches.py
+++ b/miles/backends/sglang_utils/dsv4_top_patches.py
@@ -1,0 +1,93 @@
+"""Narrow SGLang compatibility patches required by the DSV4 TOP contract.
+
+These patches run in the spawned SGLang server process. Keep them small,
+version-tolerant, and guarded by an explicit Miles environment variable.
+"""
+
+from __future__ import annotations
+
+from functools import wraps
+import os
+from pathlib import Path
+
+
+def _patch_hash_topk_fp32_input() -> None:
+    """Feed the NVIDIA DSV4 hash-topk kernel its required FP32 logits.
+
+    SGLang's ``HashTopK.forward`` must retain the original router-logit tensor
+    in ``StandardTopKOutput``. Patching the imported JIT function, instead of
+    the module forward, preserves that behavior while fixing the kernel input.
+    """
+    import sglang.jit_kernel.dsv4 as dsv4_kernels
+
+    original = dsv4_kernels.hash_topk
+    if getattr(original, "_miles_dsv4_top_fp32_input", False):
+        return
+
+    @wraps(original)
+    def hash_topk_fp32_input(*args, **kwargs):
+        if "router_logits" in kwargs:
+            kwargs = dict(kwargs)
+            kwargs["router_logits"] = kwargs["router_logits"].float()
+        else:
+            args = list(args)
+            args[0] = args[0].float()
+        return original(*args, **kwargs)
+
+    hash_topk_fp32_input._miles_dsv4_top_fp32_input = True
+    dsv4_kernels.hash_topk = hash_topk_fp32_input
+
+
+def _activate_reference_source_patches() -> None:
+    """Load the version-pinned DSV4 TOP SGLang arithmetic contract.
+
+    SGLang normally enters its source-patcher path only when tensor dumping is
+    enabled. TOP needs the patcher without enabling tensor collection, so make
+    a configured source patch sufficient to enter that path. The patch engine
+    itself is fail-closed: any source mismatch raises during model startup.
+    """
+    config_path = Path(__file__).with_name("dsv4_top_sglang_reference.yaml")
+    if not config_path.is_file():
+        raise RuntimeError(f"Missing DSV4 TOP SGLang contract: {config_path}")
+
+    configured_path = os.environ.get("DUMPER_SOURCE_PATCHER_CONFIG")
+    if configured_path and Path(configured_path).resolve() != config_path.resolve():
+        if (
+            os.environ.get(
+                "MILES_DSV4_TOP_ALLOW_SOURCE_PATCH_OVERRIDE",
+                "0",
+            )
+            != "1"
+        ):
+            raise RuntimeError(
+                "DSV4 TOP cannot replace its inference contract with "
+                f"DUMPER_SOURCE_PATCHER_CONFIG={configured_path}; set "
+                "MILES_DSV4_TOP_ALLOW_SOURCE_PATCH_OVERRIDE=1 only for "
+                "controlled compatibility ablations"
+            )
+    else:
+        os.environ["DUMPER_SOURCE_PATCHER_CONFIG"] = str(config_path)
+
+    from sglang.srt.debug_utils.dumper import _Dumper
+
+    may_enable = _Dumper.may_enable
+    if getattr(may_enable.fget, "_miles_dsv4_top_source_patches", False):
+        return
+
+    original_getter = may_enable.fget
+
+    def may_enable_source_patches(self) -> bool:
+        return bool(original_getter(self) or self._config.source_patcher_config is not None)
+
+    may_enable_source_patches._miles_dsv4_top_source_patches = True
+    _Dumper.may_enable = property(may_enable_source_patches)
+
+
+def apply_dsv4_top_sglang_patches() -> None:
+    """Apply the inference-side compatibility portion of DSV4 TOP."""
+    source_contract = os.environ.get("MILES_DSV4_TOP_SOURCE_CONTRACT", "1")
+    if source_contract not in ("0", "1"):
+        raise RuntimeError("MILES_DSV4_TOP_SOURCE_CONTRACT must be 0 or 1, " f"got {source_contract!r}")
+    if source_contract == "1":
+        _activate_reference_source_patches()
+    _patch_hash_topk_fp32_input()

--- a/miles/backends/sglang_utils/dsv4_top_sglang_reference.yaml
+++ b/miles/backends/sglang_utils/dsv4_top_sglang_reference.yaml
@@ -1,0 +1,490 @@
+# Version-pinned SGLang arithmetic contract for the DSV4 TOP B200 E2E.
+#
+# Source matching is intentionally fail-closed: a different SGLang revision
+# must be revalidated instead of silently falling back to off-policy kernels.
+---
+patches:
+- target: sglang.srt.models.deepseek_v4.MQALayer.refresh_attn_sink_cache
+  preamble: |
+    if self.compress_ratio == 0:
+        from sglang.srt.layers.deepseek_v4_rope import precompute_freqs_cis
+        self.freqs_cis = precompute_freqs_cis(
+            dim=self.qk_rope_head_dim,
+            seqlen=self.freqs_cis.shape[0],
+            original_seq_len=0,
+            base=10000,
+            factor=16,
+            beta_fast=32,
+            beta_slow=1,
+        ).to(self.freqs_cis.device)
+  edits: []
+- target: sglang.srt.models.deepseek_v4.MQALayer._compute_kv_to_cache
+  edits:
+  - match: |
+      token_to_kv_pool.set_swa_key_buffer_radix_fused_norm_rope(
+          layer_id=self.layer_id,
+          swa_loc=attn_backend.get_swa_out_cache_loc(forward_batch),
+          kv=kv,
+          kv_weight=self.kv_norm.weight.data,
+          eps=self.eps,
+          freqs_cis=self.freqs_cis,
+          positions=positions,
+      )
+    replacement: |
+      kv = self.kv_norm(kv)
+      fused_rope_inplace(
+          kv[..., -self.qk_rope_head_dim :].unsqueeze(1),
+          None,
+          self.freqs_cis,
+          positions=positions,
+      )
+      token_to_kv_pool.set_swa_key_buffer_radix_fused(
+          layer_id=self.layer_id,
+          swa_loc=attn_backend.get_swa_out_cache_loc(forward_batch),
+          cache_k=kv,
+      )
+- target: sglang.srt.models.deepseek_v4.MQALayer._compute_q_b
+  preamble: |
+    from miles_plugins.models.deepseek_v4.ops.rope import apply_rotary_emb
+    from miles_plugins.models.deepseek_v4.ops.utils import fixed_tree_mean_last_dim
+  edits:
+  - match: |
+      q, _ = self.wq_b(q)
+      q = q.view(-1, self.n_local_heads, self.head_dim)
+      if q_out is None:
+          q_out = torch.empty_like(q)
+      # Fused warp-per-(token, head) rmsnorm-self + RoPE + write to q_out.
+      fused_q_norm_rope(q, q_out, self.eps, self.freqs_cis, positions)
+      return q_out
+    replacement: |
+      q, _ = self.wq_b(q)
+      q = q.view(-1, self.n_local_heads, self.head_dim)
+      q_fp32 = q.float()
+      q = (
+          q_fp32
+          * torch.rsqrt(fixed_tree_mean_last_dim(q_fp32.square()) + self.eps)
+      ).to(q.dtype)
+      q = q.clone()
+      apply_rotary_emb(
+          q.unsqueeze(0)[..., -self.qk_rope_head_dim :],
+          self.freqs_cis[positions],
+      )
+      if q_out is not None:
+          q_out.copy_(q)
+          q = q_out
+      return q
+- target: sglang.srt.layers.attention.deepseek_v4_backend.DeepseekV4AttnBackend._forward_prefill_sparse
+  edits:
+  - match: |
+      o, _, _ = flash_mla_sparse_fwd(
+          q=q_flat,
+          kv=kv,
+          indices=combined_indices.unsqueeze(1),
+          sm_scale=self.softmax_scale,
+          d_v=self.head_dim_v,
+          attn_sink=attn_sink,
+          topk_length=combined_lens,
+      )
+      return o
+    replacement: |
+      from miles.backends.sglang_utils.dsv4_top_attention import (
+          maybe_dsv4_top_sparse_prefill,
+      )
+
+      o = maybe_dsv4_top_sparse_prefill(
+          model_runner=self.model_runner,
+          q_flat=q_flat,
+          kv=kv,
+          swa_slice=swa_slice,
+          combined_indices=combined_indices,
+          combined_lens=combined_lens,
+          compress_ratio=compress_ratio,
+          layer_id=layer_id,
+          attn_sink=attn_sink,
+          softmax_scale=self.softmax_scale,
+      )
+      if o is not None:
+          return o
+
+      o, _, _ = flash_mla_sparse_fwd(
+          q=q_flat,
+          kv=kv,
+          indices=combined_indices.unsqueeze(1),
+          sm_scale=self.softmax_scale,
+          d_v=self.head_dim_v,
+          attn_sink=attn_sink,
+          topk_length=combined_lens,
+      )
+      return o
+- target: sglang.srt.models.deepseek_v4.MQALayer.forward
+  preamble: |
+    from sglang.srt.distributed.parallel_state import get_tp_group
+    from sglang.srt.tp_invariant_ops import tree_all_reduce_sum
+    from miles_plugins.models.deepseek_v4.ops.rope import apply_rotary_emb
+  edits:
+  - match: |
+      fused_rope_inplace(
+          o[..., -self.qk_rope_head_dim :],
+          None,
+          self.freqs_cis,
+          positions=positions,
+          inverse=True,
+      )
+    replacement: |
+      apply_rotary_emb(
+          o.unsqueeze(0)[..., -self.qk_rope_head_dim :],
+          self.freqs_cis[positions],
+          inverse=True,
+      )
+  - match: |
+      else:
+          wo_a = self.wo_a.weight.view(self.n_local_groups, self.o_lora_rank, -1)
+          o = torch.einsum("tgd,grd->tgr", o, wo_a)
+    replacement: |
+      else:
+          wo_a = self.wo_a.weight.view(self.n_local_groups, self.o_lora_rank, -1)
+          if self.n_local_groups == 1:
+              # DSV4 TOP: match the trainer's batch-invariant
+              # single-group value-reconstruction GEMM exactly.
+              o = torch.mm(
+                  o.reshape(-1, o.size(-1)),
+                  wo_a[0].transpose(0, 1),
+              ).view(o.size(0), 1, self.o_lora_rank)
+          else:
+              o = torch.einsum("tgd,grd->tgr", o, wo_a)
+  - match: 'o, _ = self.wo_b(o.flatten(1))
+
+'
+    replacement: |
+      o_flat = o.flatten(1)
+      is_clean_reprefill = (
+          forward_batch.forward_mode.is_extend()
+          and forward_batch.is_prefill_only
+          and forward_batch.batch_size == 1
+          and forward_batch.extend_num_tokens == 96
+          and forward_batch.seq_lens.numel() == 1
+          and int(forward_batch.seq_lens[0].item()) == 96
+          and o_flat.shape == (96, 1024)
+      )
+      if self.layer_id in (0, 1, 2, 3) and is_clean_reprefill:
+          assert self.tp_size == 8, self.tp_size
+          assert get_tensor_model_parallel_world_size() == 8
+          assert not self.dsa_enable_prefill_cp
+          o, _ = self.wo_b(o_flat, skip_all_reduce=True)
+          o = tree_all_reduce_sum(
+              o,
+              device_group=get_tp_group().device_group,
+          )
+      else:
+          o, _ = self.wo_b(o_flat)
+- target: sglang.srt.models.deepseek_v4.DeepseekV4DecoderLayer.hc_pre
+  edits:
+  - match: 'shape, dtype = x.size(), x.dtype
+
+'
+    replacement: |
+      shape, dtype = x.size(), x.dtype
+      if x.shape[0] > 0:
+          from tile_kernels.modeling.mhc.ops import mhc_pre_big_fuse
+
+          assert x.dtype == torch.bfloat16, x.dtype
+          assert hc_fn.dtype == torch.float32, hc_fn.dtype
+          assert hc_scale.dtype == torch.float32, hc_scale.dtype
+          assert hc_base.dtype == torch.float32, hc_base.dtype
+          post, comb, y = mhc_pre_big_fuse(
+              residual=x.contiguous(),
+              fn=hc_fn.contiguous(),
+              mhc_scale=hc_scale.contiguous(),
+              mhc_base=hc_base.contiguous(),
+              rms_eps=self.rms_norm_eps,
+              mhc_pre_eps=self.hc_eps,
+              mhc_sinkhorn_eps=self.hc_eps,
+              mhc_post_mult_value=_MHC_POST_MULT_VALUE,
+              sinkhorn_repeat=self.hc_sinkhorn_iters,
+              n_splits=16,
+          )
+          return y.to(dtype), post.squeeze(-1), comb, False
+- target: sglang.srt.models.deepseek_v4.DeepseekV4DecoderLayer.hc_post
+  edits:
+  - match: |
+      if _is_npu:
+          return torch.ops.custom.npu_hc_post(x, residual, post, comb)
+    replacement: |
+      if _is_npu:
+          return torch.ops.custom.npu_hc_post(x, residual, post, comb)
+
+      from tile_kernels.modeling.mhc.ops import mhc_post as tk_mhc_post
+
+      assert x.dtype == torch.bfloat16, x.dtype
+      assert residual.dtype == torch.bfloat16, residual.dtype
+      assert post.dtype == torch.float32, post.dtype
+      assert comb.dtype == torch.float32, comb.dtype
+      assert residual.shape == (x.shape[0], self.hc_mult, x.shape[-1])
+      assert post.shape in (
+          (x.shape[0], self.hc_mult),
+          (x.shape[0], self.hc_mult, 1),
+      )
+      assert comb.shape == (x.shape[0], self.hc_mult, self.hc_mult)
+      post_4d = post.unsqueeze(-1) if post.ndim == 2 else post
+      return tk_mhc_post(
+          x.unsqueeze(0).contiguous(),
+          residual.unsqueeze(0).contiguous(),
+          post_4d.unsqueeze(0).contiguous(),
+          comb.unsqueeze(0).contiguous(),
+      ).squeeze(0)
+- target: sglang.srt.models.deepseek_v2.DeepseekV2MoE.forward_normal
+  edits:
+  - match: |
+      final_hidden_states = self.experts(
+          hidden_states,
+          topk_output,
+      )
+    replacement: |
+      from miles.backends.sglang_utils.dsv4_top_moe import (
+          dsv4_top_moe_context,
+      )
+
+      with dsv4_top_moe_context(
+          layer_id=self.layer_id,
+          hidden_states=hidden_states,
+          topk_ids=topk_output.topk_ids,
+      ) as _miles_dsv4_top_context:
+          final_hidden_states = self.experts(
+              hidden_states,
+              topk_output,
+          )
+      if _miles_dsv4_top_context.active:
+          if _miles_dsv4_top_context.routed_unscaled is None:
+              raise RuntimeError(
+                  "DSV4 TOP fused MoE did not produce trainer-order output"
+              )
+          _miles_dsv4_top_routed_global_trainer_order = (
+              _miles_dsv4_top_context.routed_unscaled
+              * self.routed_scaling_factor
+          ).to(_miles_dsv4_top_context.routed_unscaled.dtype)
+  - match: |
+      final_hidden_states = maybe_fuse_routed_scale_and_shared_add(
+          self.experts,
+          final_hidden_states,
+          None if self._shared_expert_tp1 else shared_output,
+          self.routed_scaling_factor,
+      )
+    replacement: |
+      if _miles_dsv4_top_context.active:
+          if self._shared_expert_tp1 or shared_output is None:
+              raise RuntimeError(
+                  "DSV4 TOP requires TP-sharded shared experts"
+              )
+          from sglang.srt.distributed.parallel_state import get_tp_group
+          from sglang.srt.tp_invariant_ops import tree_all_reduce_sum
+
+          _miles_dsv4_top_shared_global = tree_all_reduce_sum(
+              shared_output,
+              device_group=get_tp_group().device_group,
+          )
+          final_hidden_states = (
+              _miles_dsv4_top_routed_global_trainer_order
+              + _miles_dsv4_top_shared_global
+          )
+      else:
+          final_hidden_states = maybe_fuse_routed_scale_and_shared_add(
+              self.experts,
+              final_hidden_states,
+              None if self._shared_expert_tp1 else shared_output,
+              self.routed_scaling_factor,
+          )
+  - match: |
+      if self.tp_size > 1 and not should_skip_post_experts_all_reduce(
+          is_tp_path=True,
+          use_reduce_scatter=use_reduce_scatter,
+          should_allreduce_fusion=should_allreduce_fusion,
+      ):
+          final_hidden_states = tensor_model_parallel_all_reduce(final_hidden_states)
+    replacement: |
+      if (
+          not _miles_dsv4_top_context.active
+          and self.tp_size > 1
+          and not should_skip_post_experts_all_reduce(
+              is_tp_path=True,
+              use_reduce_scatter=use_reduce_scatter,
+              should_allreduce_fusion=should_allreduce_fusion,
+          )
+      ):
+          final_hidden_states = tensor_model_parallel_all_reduce(
+              final_hidden_states
+          )
+- target: sglang.srt.layers.moe.moe_runner.triton_utils.fused_moe._fused_moe_kernel_sequence
+  edits:
+  - match: 'num_tokens = hidden_states.shape[0]
+
+'
+    replacement: |
+      num_tokens = hidden_states.shape[0]
+      from miles.backends.sglang_utils.dsv4_top_moe import (
+          get_dsv4_top_moe_context,
+      )
+
+      _miles_dsv4_top_context = get_dsv4_top_moe_context()
+  - match: 'if hooks and hooks.after_gate_up:
+
+'
+    replacement: |
+      if (
+          _miles_dsv4_top_context is not None
+          and _miles_dsv4_top_context.active
+      ):
+          from miles.backends.sglang_utils.dsv4_top_moe import (
+              replace_fused_moe_fc1,
+          )
+
+          replace_fused_moe_fc1(
+              hidden_states=hidden_states,
+              topk_ids=topk_ids,
+              intermediate_cache1=intermediate_cache1,
+              w1=w1,
+              w1_scale=w1_scale,
+              use_fp8_w8a8=use_fp8_w8a8,
+              block_shape=block_shape,
+              bias=b1,
+          )
+      if hooks and hooks.after_gate_up:
+  - match: |
+      not apply_router_weight_on_input and not no_combine,
+      1,
+    replacement: |
+      False,
+      1,
+  - match: 'if hooks and hooks.after_down:
+
+'
+    replacement: |
+      if (
+          _miles_dsv4_top_context is not None
+          and _miles_dsv4_top_context.active
+      ):
+          from miles.backends.sglang_utils.dsv4_top_moe import (
+              record_fused_moe_trainer_order,
+              replace_fused_moe_fc2,
+          )
+
+          replace_fused_moe_fc2(
+              topk_ids=topk_ids,
+              intermediate_cache2=intermediate_cache2,
+              intermediate_cache3=intermediate_cache3,
+              w2=w2,
+              w2_scale=w2_scale,
+              use_fp8_w8a8=use_fp8_w8a8,
+              block_shape=block_shape,
+              bias=b2,
+          )
+
+      # Match the trainer's FC2 ordering exactly. SGLang first stores
+      # BF16, then casts and applies routing weights separately.
+      if not apply_router_weight_on_input and not no_combine:
+          if use_fused_moe_sum_all_reduce:
+              raise RuntimeError(
+                  "DSV4 TOP does not support fused MoE sum/all-reduce"
+              )
+          intermediate_cache3.mul_(
+              topk_weights.to(
+                  dtype=intermediate_cache3.dtype
+              ).unsqueeze(-1)
+          )
+
+      if (
+          _miles_dsv4_top_context is not None
+          and _miles_dsv4_top_context.active
+      ):
+          if no_combine or use_fused_moe_sum_all_reduce:
+              raise RuntimeError(
+                  "DSV4 TOP requires the explicit routed combine path"
+              )
+          record_fused_moe_trainer_order(intermediate_cache3)
+      if hooks and hooks.after_down:
+- target: sglang.srt.layers.moe.moe_runner.triton_utils.fused_moe_triton_kernels.invoke_fused_moe_kernel
+  preamble: |
+    # Keep 128-wide FP8 scale groups while matching the trainer's K=32
+    # grouped-GEMM accumulation order.
+    if (
+        use_fp8_w8a8
+        and block_shape == [128, 128]
+        and B.shape[2] == 2048
+    ):
+        config = dict(config)
+        config["BLOCK_SIZE_K"] = 32
+  edits:
+  - match: 'A, A_scale = sglang_per_token_group_quant_fp8(A, block_k)
+
+'
+    replacement: |
+      # TE Float8BlockScaling uses 1x128 activation
+      # blocks with power-of-two (UE8M0-compatible) scales on Blackwell.
+      A, A_scale = sglang_per_token_group_quant_fp8(
+          A,
+          block_k,
+          scale_ue8m0=True,
+      )
+- target: sglang.srt.models.deepseek_v2.DeepseekV2MoE._forward_shared_experts
+  edits:
+  - match: |
+      if (hidden_states.shape[0] > 0) and (self.num_fused_shared_experts == 0):
+          return self.shared_experts(
+              hidden_states, gemm_output_zero_allocator=gemm_output_zero_allocator
+          )
+    replacement: |
+      if (hidden_states.shape[0] > 0) and (self.num_fused_shared_experts == 0):
+          # Keep the shared-expert FC2/activation arithmetic on the same
+          # common TOP path as the routed experts.
+          _miles_dsv4_top_contract_active = (
+              self.layer_id in (0, 1, 2, 3)
+              and hidden_states.shape == (96, 4096)
+          )
+          _miles_dsv4_top_previous_shared_contract = getattr(
+              self.shared_experts,
+              "_miles_dsv4_top_shared_contract_active",
+              False,
+          )
+          self.shared_experts._miles_dsv4_top_shared_contract_active = (
+              _miles_dsv4_top_contract_active
+          )
+          try:
+              return self.shared_experts(
+                  hidden_states,
+                  gemm_output_zero_allocator=gemm_output_zero_allocator,
+              )
+          finally:
+              self.shared_experts._miles_dsv4_top_shared_contract_active = (
+                  _miles_dsv4_top_previous_shared_contract
+              )
+- target: sglang.srt.models.deepseek_v2.DeepseekV2MLP.forward
+  edits:
+  - match: 'gate_up, _ = self.gate_up_proj(x)
+
+'
+    replacement: |
+      _miles_dsv4_top_shared_contract_active = bool(
+          getattr(self, "_miles_dsv4_top_shared_contract_active", False)
+      )
+      if _miles_dsv4_top_shared_contract_active:
+          assert isinstance(x, torch.Tensor) and x.shape == (96, 4096), type(x)
+      gate_up, _ = self.gate_up_proj(x)
+  - match: 'and self.down_proj.weight.dtype == torch.uint8
+
+'
+    replacement: |
+      and self.down_proj.weight.dtype == torch.uint8
+      and not _miles_dsv4_top_shared_contract_active
+  - match: |
+      x, _ = self.down_proj(
+          x,
+          skip_all_reduce=should_allreduce_fusion or use_reduce_scatter,
+      )
+    replacement: |
+      if _miles_dsv4_top_shared_contract_active:
+          # Recompute at an unambiguous boundary.  DeepSeek-V4's
+          # swiglu_limit branch bypasses the generic activation branch.
+          x = self.act_fn.forward_native(gate_up)
+      x, _ = self.down_proj(
+          x,
+          skip_all_reduce=should_allreduce_fusion or use_reduce_scatter,
+      )

--- a/miles/backends/sglang_utils/runtime_bootstrap/sitecustomize.py
+++ b/miles/backends/sglang_utils/runtime_bootstrap/sitecustomize.py
@@ -1,0 +1,12 @@
+"""Bootstrap Miles runtime patches in freshly spawned SGLang workers."""
+
+from __future__ import annotations
+
+import os
+
+if os.environ.get("MILES_DSV4_TOP_RUNTIME_PATCHES", "0") == "1":
+    from miles.backends.sglang_utils.dsv4_top_patches import (
+        apply_dsv4_top_sglang_patches,
+    )
+
+    apply_dsv4_top_sglang_patches()

--- a/miles/backends/sglang_utils/sglang_engine.py
+++ b/miles/backends/sglang_utils/sglang_engine.py
@@ -3,6 +3,7 @@ import ipaddress
 import logging
 import multiprocessing
 import os
+from pathlib import Path
 import time
 from urllib.parse import quote
 
@@ -20,6 +21,33 @@ from miles.utils.http_utils import get_host_info
 from miles.utils.lora import LORA_ADAPTER_NAME, is_lora_enabled
 
 logger = logging.getLogger(__name__)
+
+
+def _dsv4_top_runtime_patches_enabled() -> bool:
+    value = os.environ.get("MILES_DSV4_TOP_RUNTIME_PATCHES", "0")
+    if value not in ("0", "1"):
+        raise ValueError("MILES_DSV4_TOP_RUNTIME_PATCHES must be 0 or 1, " f"got {value!r}")
+    return value == "1"
+
+
+def _launch_server_with_miles_patches(server_args: ServerArgs) -> None:
+    if _dsv4_top_runtime_patches_enabled():
+        # SGLang starts scheduler workers in fresh Python interpreters. Make
+        # the narrowly scoped sitecustomize bootstrap visible to those
+        # children so they receive the same runtime patches as this process.
+        bootstrap_dir = Path(__file__).with_name("runtime_bootstrap")
+        pythonpath = os.environ.get("PYTHONPATH")
+        os.environ["PYTHONPATH"] = f"{bootstrap_dir}{os.pathsep}{pythonpath}" if pythonpath else str(bootstrap_dir)
+
+        from miles.backends.sglang_utils.dsv4_top_patches import (
+            apply_dsv4_top_sglang_patches,
+        )
+
+        apply_dsv4_top_sglang_patches()
+
+    from sglang.srt.entrypoints.http_server import launch_server
+
+    launch_server(server_args)
 
 
 def get_base_gpu_id(args, rank):
@@ -54,11 +82,12 @@ def _to_local_gpu_id(physical_gpu_id: int) -> int:
 
 
 def launch_server_process(server_args: ServerArgs) -> multiprocessing.Process:
-    from sglang.srt.entrypoints.http_server import launch_server
-
     multiprocessing.set_start_method("spawn", force=True)
     server_args.host = server_args.host.strip("[]")
-    p = multiprocessing.Process(target=launch_server, args=(server_args,))
+    p = multiprocessing.Process(
+        target=_launch_server_with_miles_patches,
+        args=(server_args,),
+    )
     p.start()
 
     if server_args.node_rank != 0:
@@ -213,30 +242,19 @@ class SGLangEngine(RayActor):
 
     def _init_normal(self, server_args_dict):
         logger.info(f"Launch HttpServerEngineAdapter at: {self.server_host}:{self.server_port}")
-        if os.environ.get("MILES_ALLOW_DSV4_DETERMINISTIC_BACKEND_PROBE", "0") == "1":
+        if _dsv4_top_runtime_patches_enabled():
             if not server_args_dict.get("enable_deterministic_inference", False):
-                raise ValueError(
-                    "MILES_ALLOW_DSV4_DETERMINISTIC_BACKEND_PROBE requires "
-                    "SGLang deterministic inference"
-                )
+                raise ValueError("MILES_DSV4_TOP_RUNTIME_PATCHES requires SGLang " "deterministic inference")
             import sglang.srt.server_args as sglang_server_args_module
 
             choices = sglang_server_args_module.DETERMINISTIC_ATTENTION_BACKEND_CHOICES
             if not isinstance(choices, list):
-                raise TypeError(
-                    "Expected mutable deterministic attention backend choices, "
-                    f"got {type(choices)!r}"
-                )
+                raise TypeError("Expected mutable deterministic attention backend choices, " f"got {type(choices)!r}")
             if "dsv4" not in choices:
-                sglang_server_args_module.DETERMINISTIC_ATTENTION_BACKEND_CHOICES = [
-                    *choices,
-                    "dsv4",
-                ]
-            logger.warning(
-                "Diagnostic-only: allowing the DSV4 attention backend through "
-                "SGLang's deterministic-inference validator. This compatibility "
-                "shim does not by itself certify the DSV4 backend as deterministic."
-            )
+                # SGLang's override validators import this list by reference. Mutate
+                # it in place so every already-imported validator observes DSV4.
+                choices.append("dsv4")
+            logger.info("Enabled the DSV4 attention backend for the explicit Miles TOP " "runtime contract.")
         self.process = launch_server_process(ServerArgs(**server_args_dict))
 
         if self.node_rank == 0 and self.router_ip and self.router_port:

--- a/miles/backends/sglang_utils/sglang_engine.py
+++ b/miles/backends/sglang_utils/sglang_engine.py
@@ -213,6 +213,30 @@ class SGLangEngine(RayActor):
 
     def _init_normal(self, server_args_dict):
         logger.info(f"Launch HttpServerEngineAdapter at: {self.server_host}:{self.server_port}")
+        if os.environ.get("MILES_ALLOW_DSV4_DETERMINISTIC_BACKEND_PROBE", "0") == "1":
+            if not server_args_dict.get("enable_deterministic_inference", False):
+                raise ValueError(
+                    "MILES_ALLOW_DSV4_DETERMINISTIC_BACKEND_PROBE requires "
+                    "SGLang deterministic inference"
+                )
+            import sglang.srt.server_args as sglang_server_args_module
+
+            choices = sglang_server_args_module.DETERMINISTIC_ATTENTION_BACKEND_CHOICES
+            if not isinstance(choices, list):
+                raise TypeError(
+                    "Expected mutable deterministic attention backend choices, "
+                    f"got {type(choices)!r}"
+                )
+            if "dsv4" not in choices:
+                sglang_server_args_module.DETERMINISTIC_ATTENTION_BACKEND_CHOICES = [
+                    *choices,
+                    "dsv4",
+                ]
+            logger.warning(
+                "Diagnostic-only: allowing the DSV4 attention backend through "
+                "SGLang's deterministic-inference validator. This compatibility "
+                "shim does not by itself certify the DSV4 backend as deterministic."
+            )
         self.process = launch_server_process(ServerArgs(**server_args_dict))
 
         if self.node_rank == 0 and self.router_ip and self.router_port:

--- a/miles/backends/training_utils/loss_hub/logit_processors.py
+++ b/miles/backends/training_utils/loss_hub/logit_processors.py
@@ -54,10 +54,16 @@ def get_responses(
     if logits.size(-1) > 1 and args.rollout_temperature > 0 and args.rollout_temperature != 1.0:
         logits = logits.div(args.rollout_temperature)
     if args.true_on_policy_mode:
-        if getattr(args, "bf16", False):
-            logits = logits.to(torch.bfloat16)
-        elif getattr(args, "fp16", False):
-            logits = logits.to(torch.float16)
+        logprob_dtype = getattr(args, "true_on_policy_logprob_dtype", "training")
+        if logprob_dtype == "training":
+            if getattr(args, "bf16", False):
+                logits = logits.to(torch.bfloat16)
+            elif getattr(args, "fp16", False):
+                logits = logits.to(torch.float16)
+        elif logprob_dtype == "fp32":
+            logits = logits.float()
+        else:
+            raise ValueError(f"Unsupported true-on-policy logprob dtype: {logprob_dtype}")
 
     parallel_state = get_parallel_state()
     cp_size = parallel_state.cp.size
@@ -184,6 +190,15 @@ def get_log_probs_and_entropy(
             true_on_policy=args.true_on_policy_mode,
             vocab_size=getattr(args, "vocab_size", None),
         )
+
+        if args.true_on_policy_mode and getattr(args, "true_on_policy_logprob_dtype", "training") == "fp32":
+            # SGLang prefill computes full-vocabulary log_softmax in FP32, then
+            # transports selected-token scalars which Miles stores in the
+            # training precision. Match that cast order exactly.
+            if getattr(args, "bf16", False):
+                log_prob = log_prob.to(torch.bfloat16)
+            elif getattr(args, "fp16", False):
+                log_prob = log_prob.to(torch.float16)
 
         log_probs_list.append(log_prob.squeeze(-1))
         if with_entropy:

--- a/miles/backends/training_utils/loss_hub/logit_processors.py
+++ b/miles/backends/training_utils/loss_hub/logit_processors.py
@@ -189,6 +189,7 @@ def get_log_probs_and_entropy(
             chunk_size=args.log_probs_chunk_size,
             true_on_policy=args.true_on_policy_mode,
             vocab_size=getattr(args, "vocab_size", None),
+            batch_invariant=getattr(args, "batch_invariant_mode", False),
         )
 
         if args.true_on_policy_mode and getattr(args, "true_on_policy_logprob_dtype", "training") == "fp32":

--- a/miles/backends/training_utils/loss_hub/math_utils.py
+++ b/miles/backends/training_utils/loss_hub/math_utils.py
@@ -881,6 +881,7 @@ def calculate_log_probs_and_entropy(
     chunk_size: int = -1,
     true_on_policy: bool = False,
     vocab_size: int | None = None,
+    batch_invariant: bool = False,
 ):
     if true_on_policy:
         return _calculate_log_probs_and_entropy_true_on_policy(
@@ -890,6 +891,7 @@ def calculate_log_probs_and_entropy(
             with_entropy=with_entropy,
             entropy_requires_grad=entropy_requires_grad,
             vocab_size=vocab_size,
+            batch_invariant=batch_invariant,
         )
 
     logits = logits.contiguous()
@@ -939,6 +941,7 @@ def _calculate_log_probs_and_entropy_true_on_policy(
     with_entropy: bool = False,
     entropy_requires_grad: bool = True,
     vocab_size: int | None = None,
+    batch_invariant: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor | None]:
     """True-on-policy log-prob and entropy computation matching SGLang's scoring contract.
 
@@ -952,6 +955,9 @@ def _calculate_log_probs_and_entropy_true_on_policy(
             without attaching it to the autograd graph.
         vocab_size: Real tokenizer vocab size. If provided, padded logits are
             truncated after the full-vocab gather and before ``log_softmax``.
+        batch_invariant: Use SGLang's deterministic full-vocabulary
+            ``log_softmax`` implementation. Other TOP models retain the
+            existing PyTorch implementation.
 
     Returns:
         Tuple of ``(log_probs, entropy)`` where *log_probs* has shape ``[R]``
@@ -964,7 +970,14 @@ def _calculate_log_probs_and_entropy_true_on_policy(
 
     full_logits = _gather_true_on_policy_full_logits(logits, tp_group, vocab_size=vocab_size)
     _maybe_dump_top_logprob_backward("full_logits", full_logits)
-    log_probs_full = torch.log_softmax(full_logits, dim=-1)
+    if batch_invariant:
+        from sglang.srt.batch_invariant_ops.batch_invariant_ops import (
+            log_softmax as batch_invariant_log_softmax,
+        )
+
+        log_probs_full = batch_invariant_log_softmax(full_logits, dim=-1)
+    else:
+        log_probs_full = torch.log_softmax(full_logits, dim=-1)
     _maybe_dump_top_logprob_backward("log_probs_full", log_probs_full)
     log_prob = torch.gather(log_probs_full, dim=-1, index=tokens.unsqueeze(-1)).squeeze(-1)
     _maybe_dump_top_logprob_backward("log_prob", log_prob)

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -169,12 +169,34 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 help="Whether to enable true-on-policy mode.",
             )
             parser.add_argument(
+                "--true-on-policy-logprob-dtype",
+                type=str,
+                choices=["training", "fp32"],
+                default="training",
+                help=(
+                    "Precision used by the full-vocabulary log_softmax in true-on-policy mode. "
+                    "'training' preserves the current behavior (BF16/FP16 according to the "
+                    "training precision); 'fp32' matches SGLang prefill scoring when no SGLang "
+                    "TOP contract forces a lower-precision LM-head/logprob path."
+                ),
+            )
+            parser.add_argument(
                 "--recompute-logprobs-via-prefill",
                 action="store_true",
                 default=False,
                 help=(
                     "Recompute rollout logprobs via SGLang prefill instead of decode kernels. "
                     "Only needed for models whose prefill and decode paths are not numerically identical."
+                ),
+            )
+            parser.add_argument(
+                "--allow-nondeterministic-top-parity-probe",
+                action="store_true",
+                default=False,
+                help=(
+                    "Diagnostic only: permit a true-on-policy prefill-logprob parity probe without "
+                    "enabling SGLang deterministic inference. This does not certify true on-policy "
+                    "behavior and must not be used for training."
                 ),
             )
             parser.add_argument(
@@ -2296,6 +2318,13 @@ def miles_validate_args(args):
 
     if args.recompute_logprobs_via_prefill:
         assert args.true_on_policy_mode, "--recompute-logprobs-via-prefill requires --true-on-policy-mode"
+        if getattr(args, "use_rollout_routing_replay", False):
+            raise ValueError(
+                "--recompute-logprobs-via-prefill is incompatible with "
+                "--use-rollout-routing-replay: the former defines the recomputed "
+                "prefill forward as the behavior-policy scoring path, while the latter "
+                "injects expert routes recorded by rollout/decode into the trainer."
+            )
 
     # Normalize --tito-allowed-append-roles: lowercase + deduplicate.
     raw_roles = getattr(args, "tito_allowed_append_roles", ["tool"])

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -190,16 +190,6 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 ),
             )
             parser.add_argument(
-                "--allow-nondeterministic-top-parity-probe",
-                action="store_true",
-                default=False,
-                help=(
-                    "Diagnostic only: permit a true-on-policy prefill-logprob parity probe without "
-                    "enabling SGLang deterministic inference. This does not certify true on-policy "
-                    "behavior and must not be used for training."
-                ),
-            )
-            parser.add_argument(
                 "--train-env-vars",
                 type=json.loads,
                 default="{}",
@@ -1998,6 +1988,15 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 action="store_true",
             )
             parser.add_argument(
+                "--ci-disable-weight-update-checker",
+                action="store_true",
+                help=(
+                    "Keep CI assertions enabled but skip the post-sync weight "
+                    "equality checker. Use this only when model-owned dynamic "
+                    "buffers cannot participate in the checker protocol."
+                ),
+            )
+            parser.add_argument(
                 "--ci-disable-kl-checker",
                 action="store_true",
             )
@@ -2615,7 +2614,12 @@ def miles_validate_args(args):
         "debug_rollout_only and debug_train_only cannot be set at the same time, " "please set only one of them."
     )
 
-    if args.ci_test and not args.debug_rollout_only and not args.debug_train_only:
+    if (
+        args.ci_test
+        and not args.ci_disable_weight_update_checker
+        and not args.debug_rollout_only
+        and not args.debug_train_only
+    ):
         args.check_weight_update_equal = True
 
     # always true on offload for colocate at the moment.

--- a/miles/utils/fp8_kernel.py
+++ b/miles/utils/fp8_kernel.py
@@ -37,6 +37,7 @@ def _blockwise_cast_to_fp8_triton(
     eps,
     fp8_min,
     fp8_max,
+    FORCE_POW_2_SCALES: tl.constexpr,
     BLOCK_M: tl.constexpr = 32,
     BLOCK_N: tl.constexpr = 128,
 ):
@@ -51,6 +52,8 @@ def _blockwise_cast_to_fp8_triton(
     x = tl.load(X + off_m[:, None] * stride_xm + off_n[None, :] * stride_xn, mask=mask, other=0.0).to(tl.float32)
     _absmax = tl.maximum(tl.max(tl.abs(x)), eps)
     x_s = _absmax / fp8_max
+    if FORCE_POW_2_SCALES:
+        x_s = tl.exp2(tl.ceil(tl.log2(tl.abs(x_s))))
     s_inv = 1.0 / x_s
     y_q = tl.clamp(x * s_inv, fp8_min, fp8_max).to(Y.dtype.element_ty)
 
@@ -58,7 +61,12 @@ def _blockwise_cast_to_fp8_triton(
     tl.store(S + pid_m * stride_sm + pid_n * stride_sn, x_s)
 
 
-def blockwise_cast_to_fp8_triton(x: torch.Tensor, block_size=None) -> tuple[torch.Tensor, torch.Tensor]:
+def blockwise_cast_to_fp8_triton(
+    x: torch.Tensor,
+    block_size=None,
+    *,
+    force_pow_2_scales: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor]:
     BLOCK_M, BLOCK_N = 128, 128
     if block_size:
         BLOCK_M, BLOCK_N = block_size[0], block_size[1]
@@ -74,6 +82,18 @@ def blockwise_cast_to_fp8_triton(x: torch.Tensor, block_size=None) -> tuple[torc
     else:
         kwargs = {"BLOCK_M": BLOCK_M, "BLOCK_N": BLOCK_N, "num_warps": 1, "num_stages": 4}
     _blockwise_cast_to_fp8_triton[grid](
-        x, y, s, *x.stride(), *y.stride(), *s.stride(), M, N, 1e-10, fp8_min, fp8_max, **kwargs
+        x,
+        y,
+        s,
+        *x.stride(),
+        *y.stride(),
+        *s.stride(),
+        M,
+        N,
+        1e-10,
+        fp8_min,
+        fp8_max,
+        FORCE_POW_2_SCALES=force_pow_2_scales,
+        **kwargs,
     )
     return y, s

--- a/miles_plugins/models/deepseek_v4/deepseek_v4.py
+++ b/miles_plugins/models/deepseek_v4/deepseek_v4.py
@@ -16,8 +16,12 @@ from megatron.core.tensor_parallel.layers import ColumnParallelLinear
 from megatron.core.tensor_parallel.mappings import (
     copy_to_tensor_model_parallel_region,
     gather_from_sequence_parallel_region,
+    reduce_from_tensor_model_parallel_region,
     scatter_to_sequence_parallel_region,
 )
+from megatron.core.transformer.identity_op import IdentityOp
+from megatron.core.transformer.moe.experts import TEGroupedMLP
+from megatron.core.transformer.moe.moe_layer import MoELayer
 from megatron.core.transformer.experimental_attention_variant.dsa import DSAIndexer, DSAIndexerSubmodules
 from megatron.core.transformer.module import MegatronModule
 from megatron.core.transformer.spec_utils import ModuleSpec
@@ -33,8 +37,20 @@ from miles_plugins.models.deepseek_v4.ops.cp_utils import (
     get_window_topk_idxs_cp,
 )
 from miles_plugins.models.deepseek_v4.ops.kernel.tilelang_sparse_mla import sparse_attn_tilelang
+from miles_plugins.models.deepseek_v4.ops.moe import (
+    DeepSeekV4TopKRouter,
+    DeepSeekV4TopMoELayer,
+    DeepSeekV4TopTEGroupedMLP,
+)
+from miles_plugins.models.deepseek_v4.ops.norm import (
+    DeepSeekV4BatchInvariantRMSNorm,
+)
 from miles_plugins.models.deepseek_v4.ops.qat import fp8_simulate_qat
-from miles_plugins.models.deepseek_v4.ops.rope import apply_rotary_emb, wrapped_precompute_freqs_cis
+from miles_plugins.models.deepseek_v4.ops.rope import (
+    apply_rotary_emb,
+    precompute_freqs_cis,
+    wrapped_precompute_freqs_cis,
+)
 from miles_plugins.models.deepseek_v4.ops.utils import fixed_tree_mean_last_dim
 from miles_plugins.models.deepseek_v4.ops.v4_indexer import V4Indexer
 
@@ -232,31 +248,66 @@ class DeepSeekV4Attention(MegatronModule):
 
         bsz, seqlen_local, _ = x.size()
         rope_base = self.config.dsv4_compress_rope_theta if self.compress_ratio else self.config.rotary_base
-        freqs_cis = wrapped_precompute_freqs_cis(
-            self.config, self.rope_head_dim, rope_base, not self.compress_ratio, seqlen_local * self.cp_size, x.device
-        )
+        if self.batch_invariant_mode and self.compress_ratio:
+            precompute_freqs_cis.cache_clear()
+            with torch.device(x.device):
+                freqs_cis = wrapped_precompute_freqs_cis(
+                    self.config,
+                    self.rope_head_dim,
+                    rope_base,
+                    not self.compress_ratio,
+                    seqlen_local * self.cp_size,
+                    x.device,
+                )
+            precompute_freqs_cis.cache_clear()
+        else:
+            freqs_cis = wrapped_precompute_freqs_cis(
+                self.config,
+                self.rope_head_dim,
+                rope_base,
+                not self.compress_ratio,
+                seqlen_local * self.cp_size,
+                x.device,
+            )
         freqs_cis = get_freqs_cis_for_cp(freqs_cis, seqlen_local, self.cp_size, self.cp_group)
         win = self.window_size
         ratio = self.compress_ratio
         rd = self.rope_head_dim
 
         q_after_wq_a = self.wq_a(x)[0]
-        qr = q = self.q_norm(q_after_wq_a)
+        if self.batch_invariant_mode:
+            from sglang.srt.batch_invariant_ops.batch_invariant_ops import (
+                rms_norm_batch_invariant,
+            )
+
+            q = rms_norm_batch_invariant(
+                q_after_wq_a,
+                self.q_norm.weight,
+                eps=self.eps,
+            )
+        else:
+            q = self.q_norm(q_after_wq_a)
+        qr = q
         q_after_wq_b = self.wq_b(q)[0]
         q = q_after_wq_b.unflatten(-1, (self.n_local_heads, self.head_dim))
         q_fp32 = q.float()
         q_square = q_fp32.square()
         q_square_mean = (
-            fixed_tree_mean_last_dim(q_square)
-            if self.batch_invariant_mode
-            else q_square.mean(-1, keepdim=True)
+            fixed_tree_mean_last_dim(q_square) if self.batch_invariant_mode else q_square.mean(-1, keepdim=True)
         )
         q = (q_fp32 * torch.rsqrt(q_square_mean + self.eps)).to(q.dtype)
         q = q.clone()
         apply_rotary_emb(q[..., -rd:], freqs_cis)
 
         kv_after_wkv = self.wkv(x)[0]
-        kv_vanilla = self.kv_norm(kv_after_wkv)
+        if self.batch_invariant_mode:
+            kv_vanilla = rms_norm_batch_invariant(
+                kv_after_wkv,
+                self.kv_norm.weight,
+                eps=self.eps,
+            )
+        else:
+            kv_vanilla = self.kv_norm(kv_after_wkv)
         kv_vanilla = kv_vanilla.clone()
         apply_rotary_emb(kv_vanilla[..., -rd:], freqs_cis)
         if self.use_fp8_qat:
@@ -330,7 +381,24 @@ class DeepSeekV4Attention(MegatronModule):
             )
         else:
             o = torch.einsum("bsgd,grd->bsgr", o, wo_a)
-        x, _ = self.wo_b(o.flatten(2))
+        o_flat = o.flatten(2)
+        if self.batch_invariant_mode:
+            old_tp_size = self.wo_b.tp_size
+            old_parallel_mode = self.wo_b.parallel_mode
+            self.wo_b.tp_size = 1
+            self.wo_b.parallel_mode = None
+            try:
+                x, _ = self.wo_b(o_flat)
+            finally:
+                self.wo_b.tp_size = old_tp_size
+                self.wo_b.parallel_mode = old_parallel_mode
+            x = reduce_from_tensor_model_parallel_region(
+                x,
+                group=self.tp_group,
+                deterministic=True,
+            )
+        else:
+            x, _ = self.wo_b(o_flat)
 
         output = einops.rearrange(x, "b s d -> s b d")
 
@@ -357,6 +425,33 @@ def _dsv4_attention_module_spec(config, backend=None):
     )
 
 
+def _apply_dsv4_batch_invariant_spec(block_spec):
+    for layer_spec in block_spec.layer_specs:
+        layer_submodules = layer_spec.submodules
+        if layer_submodules.input_layernorm is not IdentityOp:
+            layer_submodules.input_layernorm = DeepSeekV4BatchInvariantRMSNorm
+        if layer_submodules.pre_mlp_layernorm is not IdentityOp:
+            layer_submodules.pre_mlp_layernorm = DeepSeekV4BatchInvariantRMSNorm
+
+        mlp_spec = layer_submodules.mlp
+        if not isinstance(mlp_spec, ModuleSpec) or mlp_spec.module not in (
+            MoELayer,
+            DeepSeekV4TopMoELayer,
+        ):
+            raise RuntimeError("DeepSeek-V4 batch-invariant mode requires Megatron MoELayer")
+        if mlp_spec.submodules.experts.module not in (
+            TEGroupedMLP,
+            DeepSeekV4TopTEGroupedMLP,
+        ):
+            raise RuntimeError("DeepSeek-V4 batch-invariant mode requires TEGroupedMLP experts")
+        mlp_spec.module = DeepSeekV4TopMoELayer
+        mlp_spec.submodules.router = DeepSeekV4TopKRouter
+        mlp_spec.submodules.experts.module = DeepSeekV4TopTEGroupedMLP
+
+    block_spec.layer_norm = DeepSeekV4BatchInvariantRMSNorm
+    return block_spec
+
+
 def get_dsv4_spec(args, config, vp_stage):
     """
     Usage: --spec miles_plugins.models.deepseek_v4.deepseek_v4 get_dsv4_spec
@@ -371,6 +466,12 @@ def get_dsv4_spec(args, config, vp_stage):
 
     _eav_specs.get_experimental_attention_variant_module_spec = _patched_get_spec
     try:
-        return get_transformer_block_with_experimental_attention_variant_spec(config, vp_stage=vp_stage)
+        block_spec = get_transformer_block_with_experimental_attention_variant_spec(
+            config,
+            vp_stage=vp_stage,
+        )
+        if getattr(config, "batch_invariant_mode", False):
+            block_spec = _apply_dsv4_batch_invariant_spec(block_spec)
+        return block_spec
     finally:
         _eav_specs.get_experimental_attention_variant_module_spec = _orig_get_spec

--- a/miles_plugins/models/deepseek_v4/deepseek_v4.py
+++ b/miles_plugins/models/deepseek_v4/deepseek_v4.py
@@ -35,6 +35,7 @@ from miles_plugins.models.deepseek_v4.ops.cp_utils import (
 from miles_plugins.models.deepseek_v4.ops.kernel.tilelang_sparse_mla import sparse_attn_tilelang
 from miles_plugins.models.deepseek_v4.ops.qat import fp8_simulate_qat
 from miles_plugins.models.deepseek_v4.ops.rope import apply_rotary_emb, wrapped_precompute_freqs_cis
+from miles_plugins.models.deepseek_v4.ops.utils import fixed_tree_mean_last_dim
 from miles_plugins.models.deepseek_v4.ops.v4_indexer import V4Indexer
 
 
@@ -159,6 +160,7 @@ class DeepSeekV4Attention(MegatronModule):
         )
         self.softmax_scale = self.head_dim**-0.5
         self.sequence_parallel = config.sequence_parallel
+        self.batch_invariant_mode = getattr(config, "batch_invariant_mode", False)
 
         if self.compress_ratio:
             self.compressor = DeepSeekV4Compressor(
@@ -243,7 +245,13 @@ class DeepSeekV4Attention(MegatronModule):
         q_after_wq_b = self.wq_b(q)[0]
         q = q_after_wq_b.unflatten(-1, (self.n_local_heads, self.head_dim))
         q_fp32 = q.float()
-        q = (q_fp32 * torch.rsqrt(q_fp32.square().mean(-1, keepdim=True) + self.eps)).to(q.dtype)
+        q_square = q_fp32.square()
+        q_square_mean = (
+            fixed_tree_mean_last_dim(q_square)
+            if self.batch_invariant_mode
+            else q_square.mean(-1, keepdim=True)
+        )
+        q = (q_fp32 * torch.rsqrt(q_square_mean + self.eps)).to(q.dtype)
         q = q.clone()
         apply_rotary_emb(q[..., -rd:], freqs_cis)
 
@@ -311,7 +319,17 @@ class DeepSeekV4Attention(MegatronModule):
 
         o = o.view(bsz, seqlen_local, self.n_local_groups, -1)
         wo_a = self.wo_a.weight.view(self.n_local_groups, self.o_lora_rank, -1)
-        o = torch.einsum("bsgd,grd->bsgr", o, wo_a)
+        if self.batch_invariant_mode:
+            if self.n_local_groups != 1:
+                raise RuntimeError(
+                    "DeepSeek-V4 batch-invariant wo_a currently requires exactly one local output group, "
+                    f"got {self.n_local_groups}."
+                )
+            o = torch.mm(o.reshape(-1, o.size(-1)), wo_a[0].transpose(0, 1)).view(
+                bsz, seqlen_local, 1, self.o_lora_rank
+            )
+        else:
+            o = torch.einsum("bsgd,grd->bsgr", o, wo_a)
         x, _ = self.wo_b(o.flatten(2))
 
         output = einops.rearrange(x, "b s d -> s b d")

--- a/miles_plugins/models/deepseek_v4/ops/compressor.py
+++ b/miles_plugins/models/deepseek_v4/ops/compressor.py
@@ -47,6 +47,185 @@ def _overlap_transform(tensor: torch.Tensor, *, compress_ratio: int, head_dim: i
     return new_tensor
 
 
+def _compress_c4_reference(
+    x: torch.Tensor,
+    wkv_weight: torch.Tensor,
+    wgate_weight: torch.Tensor,
+    ape: torch.Tensor,
+    norm_weight: torch.Tensor,
+    freqs_cis: torch.Tensor,
+    *,
+    head_dim: int,
+    rope_head_dim: int,
+    norm_eps: float,
+) -> torch.Tensor:
+    """Differentiable C4 compressor used as the exact kernel's backward."""
+    ratio = 4
+    dtype = x.dtype
+
+    kv = linear_bf16_fp32(x, wkv_weight).to(torch.bfloat16).float()
+    score = linear_bf16_fp32(x, wgate_weight).to(torch.bfloat16).float()
+    kv = kv.unflatten(1, (-1, ratio))
+    score = score.unflatten(1, (-1, ratio)) + ape
+    kv = _overlap_transform(kv, compress_ratio=ratio, head_dim=head_dim, value=0)
+    score = _overlap_transform(
+        score,
+        compress_ratio=ratio,
+        head_dim=head_dim,
+        value=float("-inf"),
+    )
+    kv = (kv * score.softmax(dim=2)).sum(dim=2)
+
+    kv_fp32 = kv.float()
+    variance = kv_fp32.square().mean(-1, keepdim=True)
+    kv = (norm_weight * kv_fp32 * torch.rsqrt(variance + norm_eps)).to(dtype)
+    apply_rotary_emb(kv[..., -rope_head_dim:], freqs_cis[: x.shape[1] : ratio])
+    return kv
+
+
+def _compress_c4_sglang(
+    x: torch.Tensor,
+    wkv_weight: torch.Tensor,
+    wgate_weight: torch.Tensor,
+    ape: torch.Tensor,
+    norm_weight: torch.Tensor,
+    freqs_cis: torch.Tensor,
+    *,
+    head_dim: int,
+    norm_eps: float,
+) -> torch.Tensor:
+    """Run SGLang's exact C4 prefill compressor for a single sequence."""
+    from sglang.jit_kernel.dsv4 import (
+        CompressorPrefillPlan,
+        compress_forward,
+        compress_norm_rope_store,
+    )
+
+    kv = linear_bf16_fp32(x, wkv_weight).to(torch.bfloat16).float()
+    score = linear_bf16_fp32(x, wgate_weight).to(torch.bfloat16).float()
+    kernel_input = torch.cat((kv, score), dim=-1).squeeze(0).contiguous()
+    kernel_ape = ape.view(4, -1, head_dim).transpose(0, 1).reshape(-1, head_dim).contiguous()
+
+    plan = CompressorPrefillPlan.generate_legacy(
+        compress_ratio=4,
+        req_pool_indices=torch.tensor([0], dtype=torch.int64, device=x.device),
+        seq_lens=torch.tensor([kernel_input.shape[0]], dtype=torch.int64),
+        extend_lens=torch.tensor([kernel_input.shape[0]], dtype=torch.int64),
+        num_q_tokens=kernel_input.shape[0],
+        device=x.device,
+    )
+    plan_c = plan.plan_c.clone()
+    plan_raw = plan_c.view(torch.int32)
+    plan_raw[:, 1] &= 0xFFFF
+    plan_raw[:, 2:4] = 0
+    plan = CompressorPrefillPlan(
+        4,
+        plan_c,
+        torch.empty((0, 8), dtype=torch.uint8, device=x.device),
+        None,
+    )
+
+    buffer = torch.empty(
+        (1, 4, kernel_input.shape[-1]),
+        dtype=kernel_input.dtype,
+        device=x.device,
+    )
+    compressed = compress_forward(
+        buffer,
+        kernel_input,
+        kernel_ape,
+        plan,
+        head_dim=head_dim,
+        compress_ratio=4,
+    )
+    output = torch.empty(
+        (compressed.shape[0], head_dim),
+        dtype=torch.bfloat16,
+        device=x.device,
+    )
+    out_loc = (
+        torch.arange(
+            kernel_input.shape[0],
+            dtype=torch.int64,
+            device=x.device,
+        )
+        // 4
+    )
+    compress_norm_rope_store(
+        compressed,
+        plan,
+        norm_weight=norm_weight.to(compressed.dtype).contiguous(),
+        norm_eps=norm_eps,
+        freq_cis=freqs_cis,
+        out_loc=out_loc,
+        kvcache=output.view(torch.uint8),
+        page_size=1,
+        bf16_store=True,
+    )
+    return output.unsqueeze(0)
+
+
+class _DeepSeekV4C4CompressorFunction(torch.autograd.Function):
+    """Exact SGLang forward with a differentiable PyTorch backward."""
+
+    @staticmethod
+    def forward(
+        ctx,
+        x: torch.Tensor,
+        wkv_weight: torch.Tensor,
+        wgate_weight: torch.Tensor,
+        ape: torch.Tensor,
+        norm_weight: torch.Tensor,
+        freqs_cis: torch.Tensor,
+        head_dim: int,
+        rope_head_dim: int,
+        norm_eps: float,
+    ) -> torch.Tensor:
+        ctx.save_for_backward(
+            x,
+            wkv_weight,
+            wgate_weight,
+            ape,
+            norm_weight,
+            freqs_cis,
+        )
+        ctx.head_dim = head_dim
+        ctx.rope_head_dim = rope_head_dim
+        ctx.norm_eps = norm_eps
+        return _compress_c4_sglang(
+            x,
+            wkv_weight,
+            wgate_weight,
+            ape,
+            norm_weight,
+            freqs_cis,
+            head_dim=head_dim,
+            norm_eps=norm_eps,
+        )
+
+    @staticmethod
+    def backward(ctx, grad_output: torch.Tensor):
+        saved = ctx.saved_tensors
+        inputs = [tensor.detach().requires_grad_(True) for tensor in saved[:5]]
+        freqs_cis = saved[5]
+        with torch.enable_grad():
+            output = _compress_c4_reference(
+                *inputs,
+                freqs_cis,
+                head_dim=ctx.head_dim,
+                rope_head_dim=ctx.rope_head_dim,
+                norm_eps=ctx.norm_eps,
+            )
+        grads = torch.autograd.grad(
+            output,
+            inputs,
+            grad_output,
+            allow_unused=True,
+        )
+        grads = tuple(grad if needed else None for grad, needed in zip(grads, ctx.needs_input_grad[:5]))
+        return (*grads, None, None, None, None)
+
+
 class DeepSeekV4Compressor(nn.Module):
     def __init__(
         self,
@@ -131,6 +310,42 @@ class DeepSeekV4Compressor(nn.Module):
         assert (seqlen_local >= ratio) and (seqlen_local % ratio == 0), f"{seqlen_local=} {ratio=}"
         if self.cp_size > 1:
             assert seqlen_local % (ratio * 2) == 0
+
+        if getattr(self.config, "batch_invariant_mode", False) and ratio == 4 and self.head_dim == 512:
+            if self.cp_size != 1:
+                raise RuntimeError("DSV4 TOP exact C4 compressor currently requires context parallel size 1.")
+            if bsz != 1:
+                raise RuntimeError("DSV4 TOP exact C4 compressor currently requires micro-batch size 1.")
+            freqs_cis = wrapped_precompute_freqs_cis(
+                self.config,
+                self.rope_head_dim,
+                self.config.dsv4_compress_rope_theta,
+                False,
+                seqlen_local,
+                x.device,
+            )
+            kv = _DeepSeekV4C4CompressorFunction.apply(
+                x,
+                self.wkv.weight,
+                self.wgate.weight,
+                self.ape,
+                self.norm.weight,
+                freqs_cis,
+                self.head_dim,
+                self.rope_head_dim,
+                self.norm.eps,
+            )
+            if self.rotate:
+                kv = rotate_activation(kv)
+                if self.use_fp8_qat:
+                    kv = fp8_simulate_qat(kv, 128)
+            elif self.use_fp8_qat:
+                kv = kv.clone()
+                kv[..., : self.nope_head_dim] = fp8_simulate_qat(
+                    kv[..., : self.nope_head_dim],
+                    64,
+                )
+            return kv
 
         kv = linear_bf16_fp32(x, self.wkv.weight)
         score = linear_bf16_fp32(x, self.wgate.weight)

--- a/miles_plugins/models/deepseek_v4/ops/hyper_connection.py
+++ b/miles_plugins/models/deepseek_v4/ops/hyper_connection.py
@@ -41,9 +41,7 @@ def _top_fused_hc_head_enabled() -> bool:
         return False
     if value in ("1", "true", "yes", "on"):
         return True
-    raise ValueError(
-        f"{_TOP_FUSED_HC_HEAD_ENV} must be a boolean value, got {value!r}"
-    )
+    raise ValueError(f"{_TOP_FUSED_HC_HEAD_ENV} must be a boolean value, got {value!r}")
 
 
 def _hc_head_reference(
@@ -60,9 +58,7 @@ def _hc_head_reference(
     flat_shape = (batch * seq, hc_mult, hidden)
     x_flat = x.reshape(flat_shape)
     x_compute = x_flat.flatten(1).float()
-    rsqrt = torch.rsqrt(
-        x_compute.square().mean(-1, keepdim=True) + norm_eps
-    )
+    rsqrt = torch.rsqrt(x_compute.square().mean(-1, keepdim=True) + norm_eps)
     mixes = F.linear(x_compute, hc_fn) * rsqrt
     pre = torch.sigmoid(mixes * hc_scale + hc_base) + hc_eps
     output = torch.sum(

--- a/miles_plugins/models/deepseek_v4/ops/hyper_connection.py
+++ b/miles_plugins/models/deepseek_v4/ops/hyper_connection.py
@@ -10,6 +10,8 @@ both forward and backward kernels (the legacy in-tree implementation only had
 a no-grad forward path — see ``_HYPER_CONNECTION_MIXER_NO_GRAD = True``).
 """
 
+import os
+
 import einops
 import torch
 import torch.nn.functional as F
@@ -30,6 +32,115 @@ from torch import Tensor
 # (see the legacy ``hc_split_sinkhorn`` kernel). TileKernels lets us pass the
 # same factor through ``post_mult_value``.
 _HC_POST_MULT_VALUE = 2.0
+_TOP_FUSED_HC_HEAD_ENV = "MILES_DSV4_TOP_FUSED_HC_HEAD"
+
+
+def _top_fused_hc_head_enabled() -> bool:
+    value = os.environ.get(_TOP_FUSED_HC_HEAD_ENV, "0").strip().lower()
+    if value in ("0", "false", "no", "off"):
+        return False
+    if value in ("1", "true", "yes", "on"):
+        return True
+    raise ValueError(
+        f"{_TOP_FUSED_HC_HEAD_ENV} must be a boolean value, got {value!r}"
+    )
+
+
+def _hc_head_reference(
+    x: Tensor,
+    hc_fn: Tensor,
+    hc_scale: Tensor,
+    hc_base: Tensor,
+    norm_eps: float,
+    hc_eps: float,
+) -> Tensor:
+    """Differentiable reference used by the TOP fused kernel's backward."""
+    shape, dtype = x.shape, x.dtype
+    batch, seq, hc_mult, hidden = shape
+    flat_shape = (batch * seq, hc_mult, hidden)
+    x_flat = x.reshape(flat_shape)
+    x_compute = x_flat.flatten(1).float()
+    rsqrt = torch.rsqrt(
+        x_compute.square().mean(-1, keepdim=True) + norm_eps
+    )
+    mixes = F.linear(x_compute, hc_fn) * rsqrt
+    pre = torch.sigmoid(mixes * hc_scale + hc_base) + hc_eps
+    output = torch.sum(
+        pre.unsqueeze(-1) * x_compute.view(flat_shape),
+        dim=1,
+    )
+    return output.view(batch, seq, hidden).to(dtype)
+
+
+def _sglang_fused_hc_head_forward(
+    x: Tensor,
+    hc_fn: Tensor,
+    hc_scale: Tensor,
+    hc_base: Tensor,
+    norm_eps: float,
+    hc_eps: float,
+) -> Tensor:
+    from sglang.srt.layers.mhc_head import fused_hc_head
+
+    batch, seq, hc_mult, hidden = x.shape
+    return fused_hc_head(
+        x.reshape(-1, hc_mult, hidden).contiguous(),
+        hc_fn,
+        hc_scale,
+        hc_base,
+        norm_eps=norm_eps,
+        hc_eps=hc_eps,
+    ).view(batch, seq, hidden)
+
+
+class _SGLangFusedHCHead(torch.autograd.Function):
+    """SGLang-exact TOP forward with a differentiable reference backward."""
+
+    @staticmethod
+    def forward(
+        ctx,
+        x: Tensor,
+        hc_fn: Tensor,
+        hc_scale: Tensor,
+        hc_base: Tensor,
+        norm_eps: float,
+        hc_eps: float,
+    ) -> Tensor:
+        ctx.norm_eps = norm_eps
+        ctx.hc_eps = hc_eps
+        ctx.save_for_backward(x, hc_fn, hc_scale, hc_base)
+        return _sglang_fused_hc_head_forward(
+            x,
+            hc_fn,
+            hc_scale,
+            hc_base,
+            norm_eps,
+            hc_eps,
+        )
+
+    @staticmethod
+    def backward(ctx, grad_output: Tensor):
+        x_saved, fn_saved, scale_saved, base_saved = ctx.saved_tensors
+        with torch.enable_grad():
+            x_ref = x_saved.detach().requires_grad_(True)
+            fn_ref = fn_saved.detach().requires_grad_(True)
+            scale_ref = scale_saved.detach().requires_grad_(True)
+            base_ref = base_saved.detach().requires_grad_(True)
+            output_ref = _hc_head_reference(
+                x_ref,
+                fn_ref,
+                scale_ref,
+                base_ref,
+                ctx.norm_eps,
+                ctx.hc_eps,
+            )
+            grads = torch.autograd.grad(
+                output_ref,
+                (x_ref, fn_ref, scale_ref, base_ref),
+                grad_output,
+                allow_unused=False,
+            )
+        return (*grads, None, None)
 
 
 class HCHeadParams(MegatronModule):
@@ -143,6 +254,16 @@ class DeepSeekV4HyperConnectionUtil:
 
         dtype = x.dtype
         x_bf16 = (x if x.dtype == torch.bfloat16 else x.bfloat16()).contiguous()
+
+        if _top_fused_hc_head_enabled():
+            return _SGLangFusedHCHead.apply(
+                x_bf16,
+                hc_fn,
+                hc_scale,
+                hc_base,
+                self.norm_eps,
+                self.hc_eps,
+            ).to(dtype)
 
         # NOTE: TileKernels' ``mhc_head`` ends with ``mixes[..., :mhc_mult]``
         # which is a non-contiguous view that ``mhc_head_compute_mix_fwd_kernel``

--- a/miles_plugins/models/deepseek_v4/ops/moe.py
+++ b/miles_plugins/models/deepseek_v4/ops/moe.py
@@ -1,0 +1,199 @@
+"""DeepSeek-V4 MoE variants used by the batch-invariant TOP path."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+from megatron.core.transformer.moe.experts import TEGroupedMLP
+from megatron.core.transformer.moe.moe_layer import MoELayer
+from megatron.core.transformer.moe.moe_utils import (
+    apply_router_token_dropping,
+    compute_routing_scores_for_aux_loss,
+)
+from megatron.core.transformer.moe.router import TopKRouter
+
+from miles.utils.replay_base import routing_replay_manager
+
+
+def _sqrtsoftplus_routing_fp32(
+    logits: torch.Tensor,
+    *,
+    topk: int,
+    expert_bias: Optional[torch.Tensor],
+    tid2eid: Optional[torch.Tensor],
+    input_ids: Optional[torch.Tensor],
+    is_mtp: bool,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Match SGLang's DSV4 router normalization and deterministic scatter."""
+    num_tokens = logits.shape[0]
+    scores = torch.nn.functional.softplus(logits.float()).sqrt()
+
+    if tid2eid is not None:
+        if input_ids is None:
+            raise RuntimeError("DSV4 hash routing requires input_ids")
+        top_indices = tid2eid[input_ids]
+        if not torch.all(top_indices >= 0):
+            raise RuntimeError("DSV4 hash routing table contains uninitialized expert ids")
+    else:
+        if expert_bias is None:
+            raise RuntimeError("DSV4 non-hash routing requires expert_bias")
+
+        def compute_topk(
+            values: torch.Tensor,
+            requested_topk: int,
+            _num_groups=None,
+            _group_topk=None,
+        ):
+            return torch.topk(values, k=requested_topk, dim=1)
+
+        if is_mtp:
+            topk_fn = compute_topk
+        else:
+            topk_fn = routing_replay_manager.get_topk_fn(
+                compute_topk,
+                return_probs=True,
+            )
+        _, top_indices = topk_fn(scores + expert_bias, topk, None, None)
+
+    selected_scores = torch.gather(scores, dim=1, index=top_indices)
+    probs = selected_scores / (selected_scores.sum(dim=-1, keepdim=True) + 1e-20)
+    probs = probs.type_as(logits)
+
+    routing_probs = torch.zeros_like(logits)
+    rows = torch.arange(num_tokens, device=logits.device).unsqueeze(1)
+    routing_probs.index_put_((rows, top_indices), probs, accumulate=False)
+
+    routing_map = torch.zeros_like(logits, dtype=logits.dtype)
+    routing_map.index_put_(
+        (rows, top_indices),
+        torch.ones_like(probs, dtype=routing_map.dtype),
+        accumulate=False,
+    )
+    return routing_probs, routing_map.bool()
+
+
+class DeepSeekV4TopKRouter(TopKRouter):
+    """DSV4 router whose selected-weight normalization stays in FP32."""
+
+    def routing(
+        self,
+        logits: torch.Tensor,
+        padding_mask: Optional[torch.Tensor] = None,
+        input_ids: Optional[torch.Tensor] = None,
+    ):
+        if not self.config.dsv4_mode:
+            return super().routing(logits, padding_mask, input_ids)
+        if self.score_function != "sqrtsoftplus":
+            raise RuntimeError(
+                "DSV4 batch-invariant routing currently requires " f"sqrtsoftplus, got {self.score_function!r}"
+            )
+        if self.config.moe_router_fusion:
+            raise RuntimeError("DSV4 batch-invariant routing requires the unfused router")
+        if self.config.moe_router_num_groups is not None:
+            raise RuntimeError("DSV4 sqrtsoftplus routing does not support groups")
+        if self.config.moe_router_group_topk is not None:
+            raise RuntimeError("DSV4 sqrtsoftplus routing does not support group_topk")
+        if not self._routing_mode_initialized:
+            raise RuntimeError("DSV4 routing mode was not initialized")
+
+        seq_length, bsz = logits.shape[:2]
+        logits = logits.view(-1, self.config.num_moe_experts)
+        if padding_mask is not None:
+            padding_mask = padding_mask.reshape(-1)
+        logits = self.apply_z_loss(logits, padding_mask=padding_mask)
+
+        probs, routing_map = _sqrtsoftplus_routing_fp32(
+            logits,
+            topk=self.topk,
+            expert_bias=self.expert_bias,
+            tid2eid=self.tid2eid,
+            input_ids=(input_ids.view(-1) if self.tid2eid is not None and input_ids is not None else None),
+            is_mtp=self.is_mtp,
+        )
+
+        if self.config.moe_expert_capacity_factor is not None:
+            probs, routing_map = apply_router_token_dropping(
+                probs,
+                routing_map,
+                router_topk=self.topk,
+                capacity_factor=self.config.moe_expert_capacity_factor,
+                drop_policy=self.config.moe_token_drop_policy,
+                pad_to_capacity=self.config.moe_pad_expert_input_to_capacity,
+            )
+
+        if self.training and torch.is_grad_enabled() and self.is_aux_loss_enabled():
+            routing_map_for_aux_loss, scores_for_aux_loss = compute_routing_scores_for_aux_loss(
+                logits,
+                self.topk,
+                self.score_function,
+                fused=False,
+                padding_mask=padding_mask,
+            )
+            probs = self._apply_aux_loss(
+                probs,
+                scores_for_aux_loss,
+                routing_map_for_aux_loss,
+                with_padding_mask=padding_mask is not None,
+            )
+            probs = self._apply_seq_aux_loss(
+                probs,
+                scores_for_aux_loss,
+                routing_map_for_aux_loss,
+                seq_length,
+                bsz,
+                with_padding_mask=padding_mask is not None,
+            )
+            probs = self._apply_global_aux_loss(
+                probs,
+                scores_for_aux_loss,
+                routing_map_for_aux_loss,
+                with_padding_mask=padding_mask is not None,
+            )
+
+        self._apply_expert_bias(routing_map, padding_mask=padding_mask)
+        return probs, routing_map
+
+
+class DeepSeekV4TopTEGroupedMLP(TEGroupedMLP):
+    """Apply DSV4 routing weights after FC2, matching SGLang's FP8 path."""
+
+    def forward(
+        self,
+        permuted_local_hidden_states: torch.Tensor,
+        tokens_per_expert: torch.Tensor,
+        permuted_probs: torch.Tensor,
+    ):
+        if self.config.moe_apply_probs_on_input:
+            raise RuntimeError("DSV4 batch-invariant grouped experts require " "moe_apply_probs_on_input=False")
+
+        output, output_bias = super().forward(
+            permuted_local_hidden_states,
+            tokens_per_expert,
+            torch.ones_like(permuted_probs),
+        )
+        output_dtype = output.dtype
+        output = (output * permuted_probs.unsqueeze(-1)).to(output_dtype)
+        return output, output_bias
+
+
+class DeepSeekV4TopMoELayer(MoELayer):
+    """Apply DSV4 routed scaling after the EP/TP combine, before shared experts."""
+
+    def postprocess(
+        self,
+        output: torch.Tensor,
+        shared_expert_output: Optional[torch.Tensor],
+    ):
+        output = self.token_dispatcher.combine_postprocess(output)
+        if self.config.moe_latent_size:
+            output, _ = self.fc2_latent_proj(output)
+
+        scaling_factor = self.config.moe_router_topk_scaling_factor
+        if scaling_factor is None:
+            raise RuntimeError("DSV4 routing requires a top-k scaling factor")
+        output = (output * scaling_factor).to(output.dtype)
+
+        if shared_expert_output is not None:
+            output = output + shared_expert_output
+        return output

--- a/miles_plugins/models/deepseek_v4/ops/norm.py
+++ b/miles_plugins/models/deepseek_v4/ops/norm.py
@@ -1,0 +1,37 @@
+"""Batch-invariant normalization for DeepSeek-V4 TOP."""
+
+from __future__ import annotations
+
+import torch
+from megatron.core.transformer.module import MegatronModule
+from megatron.core.transformer.transformer_config import TransformerConfig
+
+
+class DeepSeekV4BatchInvariantRMSNorm(MegatronModule):
+    """RMSNorm with SGLang's fixed-block forward reduction."""
+
+    def __init__(
+        self,
+        config: TransformerConfig,
+        hidden_size: int,
+        eps: float = 1e-5,
+    ):
+        super().__init__(config=config)
+        if config.normalization != "RMSNorm":
+            raise RuntimeError("DeepSeek-V4 batch-invariant norm requires RMSNorm")
+        if config.layernorm_zero_centered_gamma:
+            raise RuntimeError("DeepSeek-V4 batch-invariant norm does not support " "zero-centered gamma")
+        self.weight = torch.nn.Parameter(torch.ones(hidden_size, dtype=config.params_dtype))
+        self.weight.sequence_parallel = config.sequence_parallel
+        self.eps = eps
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        from sglang.srt.batch_invariant_ops.batch_invariant_ops import (
+            rms_norm_batch_invariant,
+        )
+
+        return rms_norm_batch_invariant(
+            hidden_states,
+            self.weight,
+            eps=self.eps,
+        )

--- a/miles_plugins/models/deepseek_v4/ops/utils.py
+++ b/miles_plugins/models/deepseek_v4/ops/utils.py
@@ -15,16 +15,11 @@ def fixed_tree_mean_last_dim(x: torch.Tensor) -> torch.Tensor:
     """
     width = x.shape[-1]
     if width == 0 or width & (width - 1):
-        raise RuntimeError(
-            "fixed_tree_mean_last_dim requires a nonzero power-of-two last "
-            f"dimension, got {width}."
-        )
+        raise RuntimeError("fixed_tree_mean_last_dim requires a nonzero power-of-two last " f"dimension, got {width}.")
 
     reduced = x
     while reduced.shape[-1] > 1:
-        reduced = reduced.reshape(
-            *reduced.shape[:-1], reduced.shape[-1] // 2, 2
-        )
+        reduced = reduced.reshape(*reduced.shape[:-1], reduced.shape[-1] // 2, 2)
         reduced = reduced[..., 0] + reduced[..., 1]
     return reduced / width
 

--- a/miles_plugins/models/deepseek_v4/ops/utils.py
+++ b/miles_plugins/models/deepseek_v4/ops/utils.py
@@ -6,6 +6,29 @@ except ImportError:
     hadamard_transform = None
 
 
+def fixed_tree_mean_last_dim(x: torch.Tensor) -> torch.Tensor:
+    """Mean over the last dimension with a fixed binary reduction tree.
+
+    This keeps the floating-point association independent of all outer tensor
+    dimensions while remaining composed of ordinary autograd-aware PyTorch
+    operations. DeepSeek-V4 TOP currently uses it for the 512-wide query RMS.
+    """
+    width = x.shape[-1]
+    if width == 0 or width & (width - 1):
+        raise RuntimeError(
+            "fixed_tree_mean_last_dim requires a nonzero power-of-two last "
+            f"dimension, got {width}."
+        )
+
+    reduced = x
+    while reduced.shape[-1] > 1:
+        reduced = reduced.reshape(
+            *reduced.shape[:-1], reduced.shape[-1] // 2, 2
+        )
+        reduced = reduced[..., 0] + reduced[..., 1]
+    return reduced / width
+
+
 def rotate_activation(x: torch.Tensor) -> torch.Tensor:
     """Scaled Hadamard transform used to redistribute activation energy before
     QAT. Consumed by both the attention compressor and the DSA indexer.

--- a/tests/e2e/megatron/model_scripts/test_deepseek_v4_flash_4layer_top_parity.py
+++ b/tests/e2e/megatron/model_scripts/test_deepseek_v4_flash_4layer_top_parity.py
@@ -1,0 +1,345 @@
+"""Manual B200 bring-up test for DSV4 rollout-prefill/train parity.
+
+This is intentionally not enabled in CI yet. It performs one short rollout,
+recomputes rollout log-probabilities with SGLang prefill, and then requires
+exact per-token BF16 equality with the Megatron training forward pass.
+"""
+
+import math
+import os
+from pathlib import Path
+
+import torch
+
+from miles.rollout.generate_utils.prefill_logprobs import recompute_samples_rollout_logprobs_via_prefill
+from miles.rollout.sglang_rollout import (
+    GenerateState,
+    generate_rollout as _base_generate_rollout,
+    get_model_url,
+)
+from miles.utils.async_utils import run
+from scripts.run_deepseek_v4 import ScriptArgs, _prepare_download, _prepare_single, _prepare_spmd, _train
+from tests.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(
+    est_time=1900,
+    suite="stage-c-8-gpu-b200",
+    labels=["megatron", "model-scripts"],
+    disabled="Manual DSV4 TOP bring-up probe; enable after exact parity is green.",
+)
+
+_PREFILL_RECOMPUTE_PASSES = 5
+
+
+def generate_rollout_with_prefill_repeats(args, rollout_id, data_source, evaluation=False):
+    """Run the normal rollout, then repeat clean-cache scoring on the same engine."""
+    output = _base_generate_rollout(args, rollout_id, data_source, evaluation=evaluation)
+    if evaluation:
+        return output
+
+    samples = [sample for group in output.samples for sample in group]
+    token_snapshots = {id(sample): list(sample.tokens) for sample in samples}
+    logprob_passes = {id(sample): [list(sample.rollout_log_probs)] for sample in samples}
+    state = GenerateState(args)
+
+    for _ in range(_PREFILL_RECOMPUTE_PASSES - 1):
+        run(
+            recompute_samples_rollout_logprobs_via_prefill(
+                args,
+                samples,
+                url=get_model_url(args, "default"),
+                sampling_params=state.sampling_params,
+            )
+        )
+        for sample in samples:
+            if sample.tokens != token_snapshots[id(sample)]:
+                raise AssertionError("Repeated prefill scoring mutated the sample token sequence")
+            logprob_passes[id(sample)].append(list(sample.rollout_log_probs))
+
+    for sample in samples:
+        sample.metadata["prefill_recompute_logprob_passes"] = logprob_passes[id(sample)]
+        # Keep the value consumed by training anchored to the original recompute.
+        sample.rollout_log_probs = list(logprob_passes[id(sample)][0])
+
+    return output
+
+
+def _args() -> ScriptArgs:
+    storage_root = os.environ.get("MILES_DSV4_TOP_STORAGE_ROOT", "/scratch/models")
+    debug_root = os.environ.get(
+        "MILES_DSV4_TOP_DEBUG_ROOT",
+        f"{storage_root}/miles-top-dsv4-debug",
+    )
+    rollout_tp = int(os.environ.get("MILES_DSV4_ROLLOUT_TP", "8"))
+    if rollout_tp not in (4, 8):
+        raise ValueError(f"MILES_DSV4_ROLLOUT_TP must be 4 or 8, got {rollout_tp}")
+
+    return ScriptArgs(
+        model_name="DeepSeek-V4-Flash-FP8-4layer",
+        task="gsm8k",
+        enable_eval=False,
+        num_nodes=1,
+        num_gpus_per_node=8,
+        hardware="B200",
+        model_dir=storage_root,
+        model_local_dir=storage_root,
+        data_dir=storage_root,
+        save_dir=storage_root,
+        debug_data_root=debug_root,
+        dump_details=True,
+        skip_saving=True,
+        use_fault_tolerance=False,
+        optimizer_offload=False,
+        extra_env_vars=(
+            '{"SGLANG_DSA_FUSE_TOPK":"1",'
+            '"SGLANG_DSA_PREFILL_DENSE_ATTN_KV_LEN_THRESHOLD":"0",'
+            '"SGLANG_DSA_TOPK_FLASHINFER_DETERMINISTIC":"1",'
+            '"SGLANG_DSA_TOPK_FLASHINFER_TIE_BREAK":"large"}'
+        ),
+        extra_args=(
+            "--num-rollout 1 "
+            "--rollout-batch-size 1 "
+            "--n-samples-per-prompt 1 "
+            "--rollout-max-response-len 16 "
+            "--rollout-temperature 1 "
+            "--rollout-top-p 1 "
+            "--rollout-top-k -1 "
+            "--recompute-logprobs-via-prefill "
+            "--true-on-policy-mode "
+            "--allow-nondeterministic-top-parity-probe "
+            f"--rollout-num-gpus-per-engine {rollout_tp} "
+            f"--sglang-tp-size {rollout_tp} "
+            "--sglang-dp-size 1 "
+            f"--sglang-ep-size {rollout_tp} "
+            "--sglang-router-policy consistent_hashing "
+            "--rollout-function-path "
+            "tests.e2e.megatron.model_scripts."
+            "test_deepseek_v4_flash_4layer_top_parity."
+            "generate_rollout_with_prefill_repeats "
+            "--sglang-dsa-topk-backend flashinfer "
+            "--miles-dsa-topk-backend flashinfer "
+            "--disable-weights-backuper "
+            "--debug-disable-optimizer "
+        ),
+    )
+
+
+def prepare(args: ScriptArgs) -> None:
+    _prepare_download(args)
+
+    bf16_sentinel = Path(args.model_dir) / args.bf16_name / "model.safetensors.index.json"
+    if not bf16_sentinel.exists():
+        _prepare_single(args)
+    else:
+        print(f"Skipping FP8->BF16 conversion: {bf16_sentinel}")
+
+    torch_dist_sentinel = Path(args.model_dir) / args.torch_dist_name / "latest_checkpointed_iteration.txt"
+    if not torch_dist_sentinel.exists():
+        _prepare_spmd(args)
+    else:
+        print(f"Skipping torch_dist conversion: {torch_dist_sentinel}")
+
+    if args.hf_checkpoint is None:
+        args.hf_checkpoint = f"{args.model_local_dir}/{args.model_name}"
+
+
+def _bf16_bits_and_order(value: float) -> tuple[int, int]:
+    scalar = torch.tensor(value, dtype=torch.bfloat16)
+    bits = int(scalar.view(torch.int16).item()) & 0xFFFF
+    ordered = ((~bits) & 0xFFFF) if bits & 0x8000 else bits | 0x8000
+    return bits, ordered
+
+
+def _require_bf16_dump_values(*, name: str, values: torch.Tensor, dump_path: Path) -> None:
+    if not torch.isfinite(values).all():
+        raise AssertionError(f"{name} contains non-finite active values in {dump_path}")
+
+    round_trip = values.to(torch.bfloat16).float()
+    if not torch.equal(values, round_trip):
+        mismatch = torch.nonzero(values != round_trip, as_tuple=False)[0].item()
+        raise AssertionError(
+            f"{name} in {dump_path} was not BF16 before debug_dump's FP32 serialization; "
+            f"first offset={mismatch}, stored={values[mismatch].item()}, "
+            f"bf16_round_trip={round_trip[mismatch].item()}"
+        )
+
+
+def assert_prefill_repeatability(args: ScriptArgs) -> None:
+    dump_path = (
+        Path(args.debug_data_root)
+        / args.run_id
+        / "dump_details"
+        / "rollout_data"
+        / "0.pt"
+    )
+    if not dump_path.is_file():
+        raise AssertionError(f"No rollout debug dump found at {dump_path}")
+
+    payload = torch.load(dump_path, map_location="cpu", weights_only=False)
+    samples = payload.get("samples") or []
+    if not samples:
+        raise AssertionError(f"No samples found in {dump_path}")
+
+    checked_values = 0
+    for sample_index, sample in enumerate(samples):
+        passes = sample.get("metadata", {}).get("prefill_recompute_logprob_passes")
+        if passes is None:
+            raise AssertionError(
+                f"Sample {sample_index} in {dump_path} has no repeated-prefill snapshots"
+            )
+        if len(passes) != _PREFILL_RECOMPUTE_PASSES:
+            raise AssertionError(
+                f"Sample {sample_index} in {dump_path} has {len(passes)} prefill passes, "
+                f"expected {_PREFILL_RECOMPUTE_PASSES}"
+            )
+
+        baseline = torch.tensor(passes[0], dtype=torch.float32)
+        if not torch.isfinite(baseline).all():
+            raise AssertionError(f"Prefill pass 0 contains non-finite values in {dump_path}")
+
+        baseline_bits = baseline.view(torch.int32)
+        baseline_bf16_bits = baseline.to(torch.bfloat16).view(torch.int16)
+        checked_values += baseline.numel()
+
+        for pass_index, values in enumerate(passes[1:], start=1):
+            candidate = torch.tensor(values, dtype=torch.float32)
+            if candidate.shape != baseline.shape:
+                raise AssertionError(
+                    f"Prefill pass shape mismatch for sample {sample_index}: "
+                    f"pass0={tuple(baseline.shape)}, pass{pass_index}={tuple(candidate.shape)}"
+                )
+            if not torch.isfinite(candidate).all():
+                raise AssertionError(
+                    f"Prefill pass {pass_index} contains non-finite values in {dump_path}"
+                )
+
+            raw_bad = baseline_bits != candidate.view(torch.int32)
+            if raw_bad.any():
+                offset = int(torch.nonzero(raw_bad, as_tuple=False)[0].item())
+                bf16_bad = baseline_bf16_bits != candidate.to(torch.bfloat16).view(torch.int16)
+                abs_diff = (baseline - candidate).abs()
+                raise AssertionError(
+                    "DeepSeek-V4 repeated clean-prefill scoring is not bitwise deterministic: "
+                    f"sample={sample_index}, pass={pass_index}, "
+                    f"raw_mismatches={int(raw_bad.sum())}/{baseline.numel()}, "
+                    f"bf16_mismatches={int(bf16_bad.sum())}/{baseline.numel()}, "
+                    f"mean_abs_diff={abs_diff.mean().item():.8g}, "
+                    f"max_abs_diff={abs_diff.max().item():.8g}, "
+                    f"first_offset={offset}, pass0={baseline[offset].item():.10g}, "
+                    f"pass{pass_index}={candidate[offset].item():.10g}. "
+                    f"Dump={dump_path}"
+                )
+
+    print(
+        "PASS: exact FP32 bitwise repeatability across "
+        f"{_PREFILL_RECOMPUTE_PASSES} clean-cache same-engine DSV4 prefill passes "
+        f"for {checked_values} response-token logprobs; dump={dump_path}"
+    )
+
+
+def assert_prefill_train_parity(args: ScriptArgs) -> None:
+    dump_root = Path(args.debug_data_root) / args.run_id / "dump_details" / "policy_loss_debug"
+    dump_paths = sorted(dump_root.glob("rank_*_call_*.pt"))
+    if not dump_paths:
+        raise AssertionError(f"No policy-loss debug dumps found under {dump_root}")
+
+    active_count = 0
+    mismatch_count = 0
+    all_abs_diffs: list[torch.Tensor] = []
+    first_mismatch = None
+
+    for dump_path in dump_paths:
+        payload = torch.load(dump_path, map_location="cpu", weights_only=True)
+        rank = int(payload["rank"])
+
+        for sample in payload["samples"]:
+            if "rollout_log_probs" not in sample:
+                raise AssertionError(
+                    f"{dump_path} has no rollout_log_probs; "
+                    "--recompute-logprobs-via-prefill did not reach training"
+                )
+
+            train = sample["train_log_probs"].flatten()
+            prefill = sample["rollout_log_probs"].flatten()
+            mask = sample["local_loss_mask"].flatten().bool()
+
+            if train.shape != prefill.shape or train.shape != mask.shape:
+                raise AssertionError(
+                    f"Shape mismatch in {dump_path}, sample={sample['index']}: "
+                    f"train={tuple(train.shape)}, prefill={tuple(prefill.shape)}, "
+                    f"mask={tuple(mask.shape)}"
+                )
+
+            active_train = train[mask]
+            active_prefill = prefill[mask]
+            _require_bf16_dump_values(name="train_log_probs", values=active_train, dump_path=dump_path)
+            _require_bf16_dump_values(name="prefill_log_probs", values=active_prefill, dump_path=dump_path)
+
+            abs_diff = (active_train - active_prefill).abs()
+            all_abs_diffs.append(abs_diff)
+            active_count += int(mask.sum().item())
+
+            bad = mask & (train != prefill)
+            num_bad = int(bad.sum().item())
+            mismatch_count += num_bad
+
+            if num_bad and first_mismatch is None:
+                offset = int(torch.nonzero(bad, as_tuple=False)[0].item())
+                first_mismatch = {
+                    "rank": rank,
+                    "sample": int(sample["index"]),
+                    "offset": offset,
+                    "train": float(train[offset].item()),
+                    "prefill": float(prefill[offset].item()),
+                    "dump_path": str(dump_path),
+                }
+
+    if active_count == 0:
+        raise AssertionError(f"No active response tokens found under {dump_root}")
+
+    if first_mismatch is not None:
+        diffs = torch.cat(all_abs_diffs).float()
+        train_value = first_mismatch["train"]
+        prefill_value = first_mismatch["prefill"]
+        delta = train_value - prefill_value
+        ratio = math.exp(max(-80.0, min(80.0, delta)))
+
+        train_bits, train_order = _bf16_bits_and_order(train_value)
+        prefill_bits, prefill_order = _bf16_bits_and_order(prefill_value)
+        ulp = abs(train_order - prefill_order)
+
+        raise AssertionError(
+            "DeepSeek-V4 per-token prefill/train parity failed: "
+            f"{mismatch_count}/{active_count} active token/rank entries mismatched; "
+            f"mean_abs_diff={diffs.mean().item():.8g}, "
+            f"p99_abs_diff={torch.quantile(diffs, 0.99).item():.8g}, "
+            f"max_abs_diff={diffs.max().item():.8g}. "
+            f"First mismatch: rank={first_mismatch['rank']}, "
+            f"sample={first_mismatch['sample']}, "
+            f"response_offset={first_mismatch['offset']}, "
+            f"prefill={prefill_value:.10g} (bf16=0x{prefill_bits:04x}), "
+            f"train={train_value:.10g} (bf16=0x{train_bits:04x}), "
+            f"bf16_ulp_distance={ulp}, exp(train-prefill)={ratio:.10g}. "
+            f"First dump={first_mismatch['dump_path']}"
+        )
+
+    print(
+        "PASS: exact BF16 prefill/train log-prob parity for "
+        f"{active_count} active token/rank entries; dumps={dump_root}"
+    )
+
+
+def execute(args: ScriptArgs) -> None:
+    _train(args)
+    assert_prefill_repeatability(args)
+    if os.environ.get("MILES_DSV4_PREFILL_REPEATABILITY_ONLY") == "1":
+        return
+    assert_prefill_train_parity(args)
+
+
+if __name__ == "__main__":
+    args = _args()
+    prepare(args)
+    for proxy_var in ("http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY"):
+        os.environ.pop(proxy_var, None)
+    execute(args)

--- a/tests/e2e/megatron/model_scripts/test_deepseek_v4_flash_4layer_top_parity.py
+++ b/tests/e2e/megatron/model_scripts/test_deepseek_v4_flash_4layer_top_parity.py
@@ -1,10 +1,11 @@
-"""Manual B200 bring-up test for DSV4 rollout-prefill/train parity.
+"""B200 E2E test for DSV4 rollout-prefill/train true-on-policy parity.
 
-This is intentionally not enabled in CI yet. It performs one short rollout,
-recomputes rollout log-probabilities with SGLang prefill, and then requires
-exact per-token BF16 equality with the Megatron training forward pass.
+The test performs one short rollout, recomputes its log-probabilities with
+SGLang prefill, and requires exact per-token BF16 equality with the Megatron
+training forward pass. It also exercises Miles' standard TOP CI assertion.
 """
 
+import json
 import math
 import os
 from pathlib import Path
@@ -25,7 +26,6 @@ register_cuda_ci(
     est_time=1900,
     suite="stage-c-8-gpu-b200",
     labels=["megatron", "model-scripts"],
-    disabled="Manual DSV4 TOP bring-up probe; enable after exact parity is green.",
 )
 
 _PREFILL_RECOMPUTE_PASSES = 5
@@ -65,6 +65,11 @@ def generate_rollout_with_prefill_repeats(args, rollout_id, data_source, evaluat
 
 
 def _args() -> ScriptArgs:
+    # The trainer must use the same fused HC-head arithmetic as the SGLang
+    # prefill scorer. Keep the production default unchanged and opt in only
+    # for this exact-parity contract test.
+    os.environ.setdefault("MILES_DSV4_TOP_FUSED_HC_HEAD", "1")
+
     storage_root = os.environ.get("MILES_DSV4_TOP_STORAGE_ROOT", "/scratch/models")
     debug_root = os.environ.get(
         "MILES_DSV4_TOP_DEBUG_ROOT",
@@ -73,6 +78,12 @@ def _args() -> ScriptArgs:
     rollout_tp = int(os.environ.get("MILES_DSV4_ROLLOUT_TP", "8"))
     if rollout_tp not in (4, 8):
         raise ValueError(f"MILES_DSV4_ROLLOUT_TP must be 4 or 8, got {rollout_tp}")
+    runtime_patches = os.environ.get("MILES_DSV4_TOP_RUNTIME_PATCHES", "1")
+    if runtime_patches not in ("0", "1"):
+        raise ValueError("MILES_DSV4_TOP_RUNTIME_PATCHES must be 0 or 1, " f"got {runtime_patches!r}")
+    source_contract = os.environ.get("MILES_DSV4_TOP_SOURCE_CONTRACT", "1")
+    if source_contract not in ("0", "1"):
+        raise ValueError("MILES_DSV4_TOP_SOURCE_CONTRACT must be 0 or 1, " f"got {source_contract!r}")
 
     return ScriptArgs(
         model_name="DeepSeek-V4-Flash-FP8-4layer",
@@ -89,12 +100,19 @@ def _args() -> ScriptArgs:
         dump_details=True,
         skip_saving=True,
         use_fault_tolerance=False,
+        enable_r3=False,
         optimizer_offload=False,
-        extra_env_vars=(
-            '{"SGLANG_DSA_FUSE_TOPK":"1",'
-            '"SGLANG_DSA_PREFILL_DENSE_ATTN_KV_LEN_THRESHOLD":"0",'
-            '"SGLANG_DSA_TOPK_FLASHINFER_DETERMINISTIC":"1",'
-            '"SGLANG_DSA_TOPK_FLASHINFER_TIE_BREAK":"large"}'
+        extra_env_vars=json.dumps(
+            {
+                "MILES_DSV4_TOP_RUNTIME_PATCHES": runtime_patches,
+                "MILES_DSV4_TOP_SOURCE_CONTRACT": source_contract,
+                "MILES_DSV4_TOP_FUSED_HC_HEAD": "1",
+                "SGLANG_DSA_FUSE_TOPK": "1",
+                "SGLANG_DSA_PREFILL_DENSE_ATTN_KV_LEN_THRESHOLD": "0",
+                "SGLANG_DSA_TOPK_FLASHINFER_DETERMINISTIC": "1",
+                "SGLANG_DSA_TOPK_FLASHINFER_TIE_BREAK": "large",
+            },
+            separators=(",", ":"),
         ),
         extra_args=(
             "--num-rollout 1 "
@@ -106,7 +124,14 @@ def _args() -> ScriptArgs:
             "--rollout-top-k -1 "
             "--recompute-logprobs-via-prefill "
             "--true-on-policy-mode "
-            "--allow-nondeterministic-top-parity-probe "
+            "--ci-test "
+            "--ci-disable-weight-update-checker "
+            "--true-on-policy-logprob-dtype fp32 "
+            "--batch-invariant-mode "
+            "--attention-backend flash "
+            "--sglang-cuda-graph-backend-decode disabled "
+            "--sglang-cuda-graph-backend-prefill disabled "
+            "--debug-deterministic-collective "
             f"--rollout-num-gpus-per-engine {rollout_tp} "
             f"--sglang-tp-size {rollout_tp} "
             "--sglang-dp-size 1 "
@@ -125,7 +150,16 @@ def _args() -> ScriptArgs:
 
 
 def prepare(args: ScriptArgs) -> None:
-    _prepare_download(args)
+    hf_sentinel = Path(args.model_dir) / args.model_name / "config.json"
+    if args.hf_checkpoint is None and hf_sentinel.exists():
+        args.hf_checkpoint = str(hf_sentinel.parent)
+        print(f"Using existing HF checkpoint: {args.hf_checkpoint}")
+
+    dataset_sentinel = Path(args.data_dir) / "gsm8k" / "train.parquet"
+    if hf_sentinel.exists() and dataset_sentinel.exists():
+        print("Skipping checkpoint/dataset download: " f"{hf_sentinel}, {dataset_sentinel}")
+    else:
+        _prepare_download(args)
 
     bf16_sentinel = Path(args.model_dir) / args.bf16_name / "model.safetensors.index.json"
     if not bf16_sentinel.exists():
@@ -150,28 +184,13 @@ def _bf16_bits_and_order(value: float) -> tuple[int, int]:
     return bits, ordered
 
 
-def _require_bf16_dump_values(*, name: str, values: torch.Tensor, dump_path: Path) -> None:
+def _require_finite_dump_values(*, name: str, values: torch.Tensor, dump_path: Path) -> None:
     if not torch.isfinite(values).all():
         raise AssertionError(f"{name} contains non-finite active values in {dump_path}")
 
-    round_trip = values.to(torch.bfloat16).float()
-    if not torch.equal(values, round_trip):
-        mismatch = torch.nonzero(values != round_trip, as_tuple=False)[0].item()
-        raise AssertionError(
-            f"{name} in {dump_path} was not BF16 before debug_dump's FP32 serialization; "
-            f"first offset={mismatch}, stored={values[mismatch].item()}, "
-            f"bf16_round_trip={round_trip[mismatch].item()}"
-        )
-
 
 def assert_prefill_repeatability(args: ScriptArgs) -> None:
-    dump_path = (
-        Path(args.debug_data_root)
-        / args.run_id
-        / "dump_details"
-        / "rollout_data"
-        / "0.pt"
-    )
+    dump_path = Path(args.debug_data_root) / args.run_id / "dump_details" / "rollout_data" / "0.pt"
     if not dump_path.is_file():
         raise AssertionError(f"No rollout debug dump found at {dump_path}")
 
@@ -184,9 +203,7 @@ def assert_prefill_repeatability(args: ScriptArgs) -> None:
     for sample_index, sample in enumerate(samples):
         passes = sample.get("metadata", {}).get("prefill_recompute_logprob_passes")
         if passes is None:
-            raise AssertionError(
-                f"Sample {sample_index} in {dump_path} has no repeated-prefill snapshots"
-            )
+            raise AssertionError(f"Sample {sample_index} in {dump_path} has no repeated-prefill snapshots")
         if len(passes) != _PREFILL_RECOMPUTE_PASSES:
             raise AssertionError(
                 f"Sample {sample_index} in {dump_path} has {len(passes)} prefill passes, "
@@ -209,9 +226,7 @@ def assert_prefill_repeatability(args: ScriptArgs) -> None:
                     f"pass0={tuple(baseline.shape)}, pass{pass_index}={tuple(candidate.shape)}"
                 )
             if not torch.isfinite(candidate).all():
-                raise AssertionError(
-                    f"Prefill pass {pass_index} contains non-finite values in {dump_path}"
-                )
+                raise AssertionError(f"Prefill pass {pass_index} contains non-finite values in {dump_path}")
 
             raw_bad = baseline_bits != candidate.view(torch.int32)
             if raw_bad.any():
@@ -255,8 +270,7 @@ def assert_prefill_train_parity(args: ScriptArgs) -> None:
         for sample in payload["samples"]:
             if "rollout_log_probs" not in sample:
                 raise AssertionError(
-                    f"{dump_path} has no rollout_log_probs; "
-                    "--recompute-logprobs-via-prefill did not reach training"
+                    f"{dump_path} has no rollout_log_probs; " "--recompute-logprobs-via-prefill did not reach training"
                 )
 
             train = sample["train_log_probs"].flatten()
@@ -272,14 +286,28 @@ def assert_prefill_train_parity(args: ScriptArgs) -> None:
 
             active_train = train[mask]
             active_prefill = prefill[mask]
-            _require_bf16_dump_values(name="train_log_probs", values=active_train, dump_path=dump_path)
-            _require_bf16_dump_values(name="prefill_log_probs", values=active_prefill, dump_path=dump_path)
+            _require_finite_dump_values(
+                name="train_log_probs",
+                values=active_train,
+                dump_path=dump_path,
+            )
+            _require_finite_dump_values(
+                name="prefill_log_probs",
+                values=active_prefill,
+                dump_path=dump_path,
+            )
 
-            abs_diff = (active_train - active_prefill).abs()
+            # TOP's transport/training contract is BF16. The trainer scorer is
+            # intentionally computed in FP32, so compare the BF16 values that
+            # are actually consumed instead of requiring the raw FP32 result
+            # to have already landed on the BF16 grid.
+            train_bf16 = train.to(torch.bfloat16)
+            prefill_bf16 = prefill.to(torch.bfloat16)
+            abs_diff = (train_bf16[mask].float() - prefill_bf16[mask].float()).abs()
             all_abs_diffs.append(abs_diff)
             active_count += int(mask.sum().item())
 
-            bad = mask & (train != prefill)
+            bad = mask & (train_bf16.view(torch.int16) != prefill_bf16.view(torch.int16))
             num_bad = int(bad.sum().item())
             mismatch_count += num_bad
 
@@ -289,8 +317,10 @@ def assert_prefill_train_parity(args: ScriptArgs) -> None:
                     "rank": rank,
                     "sample": int(sample["index"]),
                     "offset": offset,
-                    "train": float(train[offset].item()),
-                    "prefill": float(prefill[offset].item()),
+                    "train": float(train_bf16[offset].item()),
+                    "prefill": float(prefill_bf16[offset].item()),
+                    "train_raw": float(train[offset].item()),
+                    "prefill_raw": float(prefill[offset].item()),
                     "dump_path": str(dump_path),
                 }
 
@@ -317,8 +347,10 @@ def assert_prefill_train_parity(args: ScriptArgs) -> None:
             f"First mismatch: rank={first_mismatch['rank']}, "
             f"sample={first_mismatch['sample']}, "
             f"response_offset={first_mismatch['offset']}, "
-            f"prefill={prefill_value:.10g} (bf16=0x{prefill_bits:04x}), "
-            f"train={train_value:.10g} (bf16=0x{train_bits:04x}), "
+            f"prefill_bf16={prefill_value:.10g} (bits=0x{prefill_bits:04x}, "
+            f"raw={first_mismatch['prefill_raw']:.10g}), "
+            f"train_bf16={train_value:.10g} (bits=0x{train_bits:04x}, "
+            f"raw={first_mismatch['train_raw']:.10g}), "
             f"bf16_ulp_distance={ulp}, exp(train-prefill)={ratio:.10g}. "
             f"First dump={first_mismatch['dump_path']}"
         )

--- a/tests/fast/backends/test_dsv4_top_patches.py
+++ b/tests/fast/backends/test_dsv4_top_patches.py
@@ -1,0 +1,135 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import torch
+import yaml
+
+from miles.backends.megatron_utils.megatron_to_hf.processors.quantizer_fp8 import (
+    _use_dsv4_top_pow2_scales,
+)
+from miles.backends.sglang_utils import dsv4_top_patches
+from miles.backends.sglang_utils.sglang_engine import (
+    _dsv4_top_runtime_patches_enabled,
+)
+from miles.backends.sglang_utils.dsv4_top_moe import (
+    dsv4_top_moe_context,
+    get_dsv4_top_moe_context,
+)
+
+_CONTRACT_PATH = Path(dsv4_top_patches.__file__).with_name("dsv4_top_sglang_reference.yaml")
+
+
+def test_dsv4_top_source_contract_is_reviewable_and_diagnostics_free():
+    text = _CONTRACT_PATH.read_text()
+    for forbidden in (
+        "_codex",
+        "dumper.dump",
+        "diagnostic",
+        "probe",
+    ):
+        assert forbidden not in text.lower()
+
+    contract = yaml.safe_load(text)
+    patches = contract["patches"]
+    assert len(patches) == 12
+    assert len({patch["target"] for patch in patches}) == len(patches)
+    assert sum(len(patch.get("edits", ())) for patch in patches) == 20
+
+    for patch in patches:
+        assert patch["target"].startswith("sglang.")
+        for edit in patch.get("edits", ()):
+            assert edit["match"].strip()
+            assert edit["replacement"].strip()
+
+
+@pytest.mark.parametrize(
+    ("source_contract", "activates_source_contract"),
+    (("0", False), ("1", True)),
+)
+def test_dsv4_top_source_contract_switch(
+    monkeypatch,
+    source_contract,
+    activates_source_contract,
+):
+    calls = []
+    monkeypatch.setenv("MILES_DSV4_TOP_SOURCE_CONTRACT", source_contract)
+    monkeypatch.setattr(
+        dsv4_top_patches,
+        "_activate_reference_source_patches",
+        lambda: calls.append("source"),
+    )
+    monkeypatch.setattr(
+        dsv4_top_patches,
+        "_patch_hash_topk_fp32_input",
+        lambda: calls.append("hash_topk"),
+    )
+
+    dsv4_top_patches.apply_dsv4_top_sglang_patches()
+
+    assert calls == (["source", "hash_topk"] if activates_source_contract else ["hash_topk"])
+
+
+def test_dsv4_top_source_contract_switch_rejects_unknown_value(monkeypatch):
+    monkeypatch.setenv("MILES_DSV4_TOP_SOURCE_CONTRACT", "true")
+
+    with pytest.raises(
+        RuntimeError,
+        match="MILES_DSV4_TOP_SOURCE_CONTRACT must be 0 or 1",
+    ):
+        dsv4_top_patches.apply_dsv4_top_sglang_patches()
+
+
+@pytest.mark.parametrize(
+    ("value", "enabled"),
+    (("0", False), ("1", True)),
+)
+def test_dsv4_top_runtime_patch_switch(monkeypatch, value, enabled):
+    monkeypatch.setenv("MILES_DSV4_TOP_RUNTIME_PATCHES", value)
+    assert _dsv4_top_runtime_patches_enabled() is enabled
+
+
+def test_dsv4_top_runtime_patch_switch_rejects_unknown_value(monkeypatch):
+    monkeypatch.setenv("MILES_DSV4_TOP_RUNTIME_PATCHES", "true")
+    with pytest.raises(
+        ValueError,
+        match="MILES_DSV4_TOP_RUNTIME_PATCHES must be 0 or 1",
+    ):
+        _dsv4_top_runtime_patches_enabled()
+
+
+@pytest.mark.parametrize(
+    ("true_on_policy", "attention_variant", "expected"),
+    (
+        (True, "dsv4", True),
+        (False, "dsv4", False),
+        (True, None, False),
+        (True, "mla", False),
+    ),
+)
+def test_pow2_weight_scales_are_scoped_to_dsv4_top(
+    true_on_policy,
+    attention_variant,
+    expected,
+):
+    args = SimpleNamespace(
+        true_on_policy_mode=true_on_policy,
+        experimental_attention_variant=attention_variant,
+    )
+    assert _use_dsv4_top_pow2_scales(args) is expected
+
+
+def test_dsv4_top_moe_context_is_request_local_and_restored():
+    hidden_states = torch.empty((96, 4096))
+    topk_ids = torch.zeros((96, 6), dtype=torch.int64)
+    assert get_dsv4_top_moe_context() is None
+
+    with dsv4_top_moe_context(
+        layer_id=0,
+        hidden_states=hidden_states,
+        topk_ids=topk_ids,
+    ) as context:
+        assert context.active is True
+        assert get_dsv4_top_moe_context() is context
+
+    assert get_dsv4_top_moe_context() is None

--- a/tests/fast/backends/training_utils/loss/test_true_on_policy_logsoftmax.py
+++ b/tests/fast/backends/training_utils/loss/test_true_on_policy_logsoftmax.py
@@ -1,0 +1,66 @@
+import sys
+import types
+
+import torch
+
+from miles.backends.training_utils.loss_hub.math_utils import (
+    calculate_log_probs_and_entropy,
+)
+
+
+def test_top_logsoftmax_keeps_pytorch_default(monkeypatch):
+    calls = []
+    original = torch.log_softmax
+
+    def tracked_log_softmax(*args, **kwargs):
+        calls.append("torch")
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(torch, "log_softmax", tracked_log_softmax)
+    logits = torch.tensor([[2.0, 1.0, -1.0]])
+    tokens = torch.tensor([1])
+
+    log_probs, _ = calculate_log_probs_and_entropy(
+        logits,
+        tokens,
+        None,
+        true_on_policy=True,
+    )
+
+    assert calls == ["torch"]
+    torch.testing.assert_close(
+        log_probs,
+        original(logits, dim=-1)[:, 1],
+    )
+
+
+def test_top_logsoftmax_uses_batch_invariant_kernel_only_when_requested(
+    monkeypatch,
+):
+    calls = []
+    original = torch.log_softmax
+    module_name = "sglang.srt.batch_invariant_ops.batch_invariant_ops"
+    fake_module = types.ModuleType(module_name)
+
+    def batch_invariant_log_softmax(*args, **kwargs):
+        calls.append("batch_invariant")
+        return original(*args, **kwargs)
+
+    fake_module.log_softmax = batch_invariant_log_softmax
+    monkeypatch.setitem(sys.modules, module_name, fake_module)
+    logits = torch.tensor([[2.0, 1.0, -1.0]])
+    tokens = torch.tensor([1])
+
+    log_probs, _ = calculate_log_probs_and_entropy(
+        logits,
+        tokens,
+        None,
+        true_on_policy=True,
+        batch_invariant=True,
+    )
+
+    assert calls == ["batch_invariant"]
+    torch.testing.assert_close(
+        log_probs,
+        original(logits, dim=-1)[:, 1],
+    )

--- a/tests/fast/models/deepseek_v4/test_hyper_connection_top.py
+++ b/tests/fast/models/deepseek_v4/test_hyper_connection_top.py
@@ -33,14 +33,8 @@ def test_top_fused_hc_head_flag_rejects_invalid_value(monkeypatch):
 
 def test_sglang_fused_hc_head_wrapper_uses_reference_backward(monkeypatch):
     x, hc_fn, hc_scale, hc_base = _inputs()
-    values = [
-        value.detach().requires_grad_(True)
-        for value in (x, hc_fn, hc_scale, hc_base)
-    ]
-    reference_values = [
-        value.detach().clone().requires_grad_(True)
-        for value in (x, hc_fn, hc_scale, hc_base)
-    ]
+    values = [value.detach().requires_grad_(True) for value in (x, hc_fn, hc_scale, hc_base)]
+    reference_values = [value.detach().clone().requires_grad_(True) for value in (x, hc_fn, hc_scale, hc_base)]
 
     def fake_fused_forward(
         x_value,

--- a/tests/fast/models/deepseek_v4/test_hyper_connection_top.py
+++ b/tests/fast/models/deepseek_v4/test_hyper_connection_top.py
@@ -1,0 +1,91 @@
+import pytest
+import torch
+
+from miles_plugins.models.deepseek_v4.ops import hyper_connection
+
+
+def _inputs():
+    torch.manual_seed(7)
+    x = torch.randn(2, 3, 4, 8, dtype=torch.bfloat16)
+    hc_fn = torch.randn(4, 32, dtype=torch.float32)
+    hc_scale = torch.randn(1, dtype=torch.float32)
+    hc_base = torch.randn(4, dtype=torch.float32)
+    return x, hc_fn, hc_scale, hc_base
+
+
+@pytest.mark.parametrize("value", ["1", "true", "yes", "on"])
+def test_top_fused_hc_head_flag_accepts_true_values(monkeypatch, value):
+    monkeypatch.setenv(hyper_connection._TOP_FUSED_HC_HEAD_ENV, value)
+    assert hyper_connection._top_fused_hc_head_enabled()
+
+
+@pytest.mark.parametrize("value", ["0", "false", "no", "off"])
+def test_top_fused_hc_head_flag_accepts_false_values(monkeypatch, value):
+    monkeypatch.setenv(hyper_connection._TOP_FUSED_HC_HEAD_ENV, value)
+    assert not hyper_connection._top_fused_hc_head_enabled()
+
+
+def test_top_fused_hc_head_flag_rejects_invalid_value(monkeypatch):
+    monkeypatch.setenv(hyper_connection._TOP_FUSED_HC_HEAD_ENV, "maybe")
+    with pytest.raises(ValueError, match="must be a boolean value"):
+        hyper_connection._top_fused_hc_head_enabled()
+
+
+def test_sglang_fused_hc_head_wrapper_uses_reference_backward(monkeypatch):
+    x, hc_fn, hc_scale, hc_base = _inputs()
+    values = [
+        value.detach().requires_grad_(True)
+        for value in (x, hc_fn, hc_scale, hc_base)
+    ]
+    reference_values = [
+        value.detach().clone().requires_grad_(True)
+        for value in (x, hc_fn, hc_scale, hc_base)
+    ]
+
+    def fake_fused_forward(
+        x_value,
+        fn_value,
+        scale_value,
+        base_value,
+        norm_eps,
+        hc_eps,
+    ):
+        return hyper_connection._hc_head_reference(
+            x_value,
+            fn_value,
+            scale_value,
+            base_value,
+            norm_eps,
+            hc_eps,
+        )
+
+    monkeypatch.setattr(
+        hyper_connection,
+        "_sglang_fused_hc_head_forward",
+        fake_fused_forward,
+    )
+
+    norm_eps = 1e-6
+    hc_eps = 1e-6
+    actual = hyper_connection._SGLangFusedHCHead.apply(
+        *values,
+        norm_eps,
+        hc_eps,
+    )
+    expected = hyper_connection._hc_head_reference(
+        *reference_values,
+        norm_eps,
+        hc_eps,
+    )
+    assert torch.equal(actual, expected)
+
+    grad = torch.randn_like(actual)
+    actual.backward(grad)
+    expected.backward(grad)
+    for actual_value, expected_value in zip(values, reference_values):
+        torch.testing.assert_close(
+            actual_value.grad,
+            expected_value.grad,
+            rtol=0,
+            atol=0,
+        )

--- a/tests/fast/utils/test_arguments.py
+++ b/tests/fast/utils/test_arguments.py
@@ -149,6 +149,27 @@ def test_recompute_logprobs_via_prefill_flag_is_parsed():
     assert args.recompute_logprobs_via_prefill is True
 
 
+def test_recompute_logprobs_via_prefill_rejects_rollout_routing_replay():
+    parser = argparse.ArgumentParser()
+    get_miles_extra_args_provider()(parser)
+    args = parser.parse_args(
+        [
+            "--true-on-policy-mode",
+            "--recompute-logprobs-via-prefill",
+            "--use-rollout-routing-replay",
+            "--num-rollout",
+            "1",
+        ]
+        + REQUIRED_ARGS
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="--recompute-logprobs-via-prefill is incompatible with --use-rollout-routing-replay",
+    ):
+        miles_validate_args(args)
+
+
 def test_custom_megatron_post_save_hook_path_is_parsed():
     parser = argparse.ArgumentParser()
     get_miles_extra_args_provider()(parser)

--- a/tests/fast/utils/test_arguments.py
+++ b/tests/fast/utils/test_arguments.py
@@ -149,6 +149,26 @@ def test_recompute_logprobs_via_prefill_flag_is_parsed():
     assert args.recompute_logprobs_via_prefill is True
 
 
+def test_ci_can_disable_only_weight_update_checker():
+    parser = argparse.ArgumentParser()
+    get_miles_extra_args_provider()(parser)
+    args = parser.parse_args(
+        [
+            "--ci-test",
+            "--ci-disable-weight-update-checker",
+            "--num-rollout",
+            "1",
+        ]
+        + REQUIRED_ARGS
+    )
+
+    miles_validate_args(args)
+
+    assert args.ci_test is True
+    assert args.ci_disable_weight_update_checker is True
+    assert args.check_weight_update_equal is False
+
+
 def test_recompute_logprobs_via_prefill_rejects_rollout_routing_replay():
     parser = argparse.ArgumentParser()
     get_miles_extra_args_provider()(parser)

--- a/tests/fast/utils/test_dsv4_fixed_tree_mean.py
+++ b/tests/fast/utils/test_dsv4_fixed_tree_mean.py
@@ -1,0 +1,41 @@
+import pytest
+import torch
+
+from miles_plugins.models.deepseek_v4.ops.utils import fixed_tree_mean_last_dim
+
+
+def test_fixed_tree_mean_has_explicit_association_and_keeps_dim():
+    x = torch.tensor(
+        [[1.0e20, 1.0, -1.0e20, 1.0], [1.0, 2.0, 3.0, 4.0]],
+        dtype=torch.float32,
+    )
+
+    actual = fixed_tree_mean_last_dim(x)
+    expected = ((x[..., 0] + x[..., 1]) + (x[..., 2] + x[..., 3])) / 4
+
+    assert actual.shape == (2, 1)
+    assert torch.equal(actual[..., 0], expected)
+
+
+def test_fixed_tree_mean_is_outer_shape_invariant():
+    torch.manual_seed(1234)
+    compact = torch.randn(3, 5, 512, dtype=torch.float32)
+    padded = torch.zeros(3, 17, 512, dtype=torch.float32)
+    padded[:, :5].copy_(compact)
+
+    compact_mean = fixed_tree_mean_last_dim(compact)
+    padded_mean = fixed_tree_mean_last_dim(padded)[:, :5]
+
+    assert torch.equal(compact_mean, padded_mean)
+
+
+@pytest.mark.parametrize("width", [0, 3, 6])
+def test_fixed_tree_mean_rejects_unsupported_width(width):
+    with pytest.raises(RuntimeError, match="nonzero power-of-two"):
+        fixed_tree_mean_last_dim(torch.zeros(2, width))
+
+
+def test_fixed_tree_mean_preserves_autograd():
+    x = torch.randn(2, 3, 8, dtype=torch.float64, requires_grad=True)
+
+    assert torch.autograd.gradcheck(fixed_tree_mean_last_dim, (x,))


### PR DESCRIPTION
## Summary

This draft adds a self-contained, experimental DeepSeek-V4 true-on-policy (TOP) numerical contract for the:

```text
rollout -> SGLang prefill recompute -> Megatron training forward
```

path.

The main acceptance criterion is exact equality between the behavior-policy log-probabilities recomputed by SGLang prefill and the log-probabilities consumed by the Megatron training forward pass.

This is intentionally a draft/reference implementation. The change is large and is expected to be split into smaller, independently reviewable follow-up PRs before upstreaming.

## Motivation

Matching the prefill scorer and trainer scorer requires more than synchronizing model weights or selecting nominally equivalent kernels. DeepSeek-V4's inference and training paths differed in floating-point association and implementation details across:

- RMS normalization and reduction trees
- attention reconstruction and TP reduction
- compressed attention and hyper-connections
- FP8 scale generation and grouped-GEMM accumulation
- routed and shared-expert MoE ordering
- full-vocabulary log-softmax precision and implementation

Small differences at these boundaries accumulate through the model and produce different per-token log-probabilities, even when both paths are individually deterministic.

## What changed

### Megatron/trainer path

- Added DeepSeek-V4 batch-invariant RMSNorm and fixed-tree reductions.
- Added deterministic TP reduction for the aligned attention path.
- Aligned query/KV normalization, value reconstruction, compressed attention, and hyper-connection arithmetic.
- Added trainer-compatible DeepSeek-V4 MoE routing, FP8 grouped-GEMM, routed scaling, combine ordering, and shared-expert accumulation.
- Scoped power-of-two FP8 scales to DeepSeek-V4 TOP.
- Added an FP32 true-on-policy full-vocabulary log-softmax option and batch-invariant log-softmax path, followed by the BF16 transport cast used by training.

### SGLang/prefill path

- Added deterministic sparse-attention and MoE compatibility helpers.
- Added a version-pinned, fail-closed SGLang source arithmetic contract.
- Added runtime bootstrap propagation to spawned SGLang workers.
- Added explicit runtime/source contract switches with strict value validation.
- Added deterministic backend validation and fixed reduction/accumulation ordering for the tested TP8 path.

### Contract and CI behavior

- Added argument validation for the new TOP log-probability contract.
- Kept the normal `--ci-test` TOP assertions enabled.
- Added a narrowly scoped option to disable only the unrelated post-sync weight checker, because DeepSeek-V4 has model-owned dynamic buffers that do not participate in that checker protocol.
- Rejected combining prefill recomputation with rollout routing replay because those options define conflicting scoring contracts.

## End-to-end evidence

Validated with `miles:latest` on one 8xB200 node using the pruned four-layer DeepSeek-V4 model and TP8 for both SGLang and Megatron.

The test uses neutral sampling transforms:

```text
temperature = 1
top_p = 1
top_k = -1
```

### Positive run

- Five clean-cache prefill recomputations on the same SGLang engine.
- All 16 response-token FP32 log-probabilities were bitwise identical across all five passes.
- Prefill recompute versus Megatron training forward:
  - 128/128 active token/rank BF16 log-probabilities were exactly equal.

### Contract-off negative run

The same branch and E2E were run with only the SGLang source numerical contract disabled. The workload still initialized successfully, completed rollout/prefill/training forward, and reached the intended parity assertion.

Result:

- 112/128 active token/rank entries mismatched.
- Mean absolute difference: `0.057136059`.
- Maximum absolute difference: `0.25`.

This distinguishes a real numerical-contract failure from a startup/configuration failure and demonstrates that the E2E does not pass without the alignment implementation.

## Tests

- DeepSeek-V4 TP8 TOP E2E:
  - five-pass bitwise prefill repeatability
  - per-token/per-TP-rank BF16 prefill-versus-trainer exact equality
- Fail-closed source/runtime contract tests.
- Batch-invariant log-softmax gating tests.
- DeepSeek-V4 FP8 scale scoping tests.
- MoE request-local state restoration tests.
- Fixed-tree reduction invariance and autograd tests.
- Fused hyper-connection tests.
- Argument and CI checker behavior tests.

Final validation:

- `49 passed`
- Black: 22 changed Python files clean
- `git diff --check`: clean

## What this E2E proves

Within the tested contract, this is the key integration evidence for DeepSeek-V4 TOP: the SGLang prefill recompute scorer and Megatron training-forward scorer produce the exact BF16 per-token log-probabilities consumed by training.

It is analogous to the existing Qwen TOP E2E, with the additional requirement that five repeated DeepSeek-V4 prefill recomputations are themselves bitwise deterministic.

## Current scope and limitations

This draft currently covers:

- the pruned four-layer DeepSeek-V4 checkpoint
- B200
- TP8
- the pinned SGLang version in `miles:latest`
- the tested 96-token E2E shape
- neutral sampling transforms
- forward/log-probability parity

It does not yet establish:

- arbitrary sequence lengths or batch sizes
- the full DeepSeek-V4 checkpoint
- other hardware or parallel configurations
- post-sampling behavior distributions for non-neutral temperature/top-k/top-p
- optimizer-update or full training-trajectory equivalence

## Proposed follow-up decomposition

After reviewing this reference PR, the implementation can be split into smaller PRs such as:

1. **Done:** trainer-side fixed-tree reduction and batch-invariant DSV4 query RMS ([#1912](https://github.com/radixark/miles/pull/1912)).
2. **No separate Miles runtime PR needed:** Megatron [`enable_batch_invariant_mode()`](https://github.com/NVIDIA/Megatron-LM/blob/main/megatron/core/transformer/custom_layers/batch_invariant_kernels.py#L1072-L1085) globally registers the accelerator implementation of `aten::_log_softmax`, so the existing Miles `torch.log_softmax` scorer automatically uses the batch-invariant kernel. The test-only split [#1964](https://github.com/radixark/miles/pull/1964) was closed.
3. **Partially implemented:** DeepSeek-V4 FP8 scale alignment. [Miles #1182](https://github.com/radixark/miles/pull/1182) already selects SGLang `per_block_cast_to_fp8` for `[128, 128]` trainer-to-rollout hot updates, producing FP32 power-of-two expert-weight scales. GB200 validation confirmed bitwise-equal logical scales and FP8 weight bytes against Trainer TE with `force_pow_2_scales=True` for representative weights. [SGLang #33005](https://github.com/sgl-project/sglang/pull/33005) supplies the remaining Triton-MoE activation-scale propagation.
4. **DSV4 attention preparation and reconstruction alignment:** add the SGLang rollout/prefill fixed-tree query RMS path—the inference-side counterpart of #1912—and align Q/KV normalization, RoPE generation and application, KV-cache writes, inverse RoPE, the single-group value-reconstruction GEMM, and deterministic `wo_b` TP reduction.
5. **DSV4 sparse-attention and indexer alignment:** use a supported common forward kernel for trainer and prefill, and replace the `hash_topk` FP32 runtime monkeypatch with a supported integration.
6. **DSV4 C4 compressor forward alignment:** make the trainer use the SGLang-compatible forward with correct autograd support.
7. **DSV4 hyper-connection alignment:** use common HC-head, HC-pre, and HC-post forward kernels with trainer backward support.
8. **Routed and shared MoE expert-compute alignment:** align FC1, activation, FC2, and FP8 GEMM accumulation through a supported SGLang-compatible trainer path, without rerunning TE grouped GEMM over Triton results.
9. **MoE routing, combine, and collective alignment:** align routing-weight cast and application timing, stable expert/token accumulation order, shared-expert TP reduction, and routed/shared addition order.
10. **Remove the diagnostic source-patcher plumbing:** delete the YAML/bootstrap path after every arithmetic boundary above has a supported integration, while retaining fail-closed runtime contract validation.
11. **Final DeepSeek-V4 TP8 E2E:** run the parity test without `DUMPER_SOURCE_PATCHER_CONFIG`.

