### PR TITLE
docker: fix main image build — install TransformerEngine from PyPI, drop stale wheel path

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -108,12 +108,9 @@ RUN if ls /tmp/wheels/causal_conv1d-*.whl 2>/dev/null | grep -q . && \
 RUN if [ "${ENABLE_CUDA_13}" = "1" ]; then \
       pip install --no-deps transformer_engine==2.17.0 && \
       pip install transformer_engine_cu13==2.17.0 && \
-      if ls /tmp/wheels/transformer_engine_torch-*.whl 2>/dev/null | grep -q .; then \
-        pip install /tmp/wheels/transformer_engine_torch-*.whl; \
-      else \
-        pip install nvidia-mathdx==25.6.0 && \
-        pip -v install --no-build-isolation transformer_engine_torch==2.17.0; \
-      fi; \
+      rm -f /tmp/wheels/transformer_engine*.whl && \
+      pip install nvidia-mathdx==25.6.0 && \
+      pip -v install --no-build-isolation transformer_engine_torch==2.17.0; \
     else \
       pip -v install --no-build-isolation "transformer_engine[pytorch]==2.17.0"; \
     fi


### PR DESCRIPTION
## Problem

`build-and-push` on `main` has been failing since the TE 2.17.0 bump (#1781):

```
AssertionError: Transformer Engine package version mismatch. Found transformer-engine v2.17.0 and transformer-engine-cu13 v2.12.0.
```

Root cause: the wheels release (`miles-wheels` / `cu130-x86_64`) still ships `transformer_engine_torch-2.12.0`, and the TE install block prefers any local wheel it finds. So the build first installs `transformer_engine==2.17.0` + `transformer_engine_cu13==2.17.0` from PyPI, then installs the stale 2.12.0 torch wheel — whose dependency pin silently **downgrades `transformer-engine-cu13` back to 2.12.0**. The TE patch step's `import transformer_engine` then trips the package sanity check and the image build dies.

## Change

TE is meant to come from PyPI now (per discussion with @yueming-yuan), so:

- Drop the prebuilt TE-torch wheel branch: always `pip install --no-build-isolation transformer_engine_torch==2.17.0` (the previous fallback path becomes the only path).
- `rm -f /tmp/wheels/transformer_engine*.whl` first, so the stale wheels can't be picked up by anything downstream.
- The wheels release no longer needs to track TE version bumps.

## Verification

- `build-and-push` on this PR exercises the changed path directly (the source build of `transformer_engine_torch` adds some build time; that cost only exists until a wheel for the pinned version exists upstream).