### PR TITLE
feat(optimizer): NVMe optimizer-state streaming as a miles plugin

### DIFF
--- a/docs/advanced/disk-offload.md
+++ b/docs/advanced/disk-offload.md
@@ -77,9 +77,12 @@ dtypes it was written with and a resume verifies them, so bytes written as bf16 
 be read back as fp32. The fp8 options work but are not recommended: `exp_avg_sq` needs
 per-block scaling to survive 8-bit storage, which this does not implement.
 
-Two limits to know about. Resume is same-topology only — the on-disk layout follows this
+Three limits to know about. Resume is same-topology only — the on-disk layout follows this
 rank's DP shard, so changing TP/PP/DP/EP fails the layout assert rather than resharding.
-And the optimizer state is copied to the checkpoint directory synchronously, outside
+A checkpoint written before streaming was enabled cannot be resumed with it: the streamed
+state is the only optimizer state read, so miles refuses rather than silently restarting
+Adam from zero — pass `--no-load-optim` to accept a fresh optimizer state. And the
+optimizer state is copied to the checkpoint directory synchronously, outside
 `--async-save`, so expect checkpoint saves to take noticeably longer.
 
 The two also help each other. With the optimizer state already on disk there is that much

--- a/docs/advanced/disk-offload.md
+++ b/docs/advanced/disk-offload.md
@@ -38,12 +38,75 @@ matching `TMS_DISK_BACKUP_*` environment, and reclaiming the files at startup an
 Because pause and resume happen at phase boundaries, everything is resident again by the
 time the optimizer step runs. If the binding constraint is instead that the optimizer
 state does not fit the GPU *during* the step, actor offload cannot help; that case is what
-Megatron's `--optimizer-state-nvme-dir` addresses (see
-[radixark/Megatron-LM#63](https://github.com/radixark/Megatron-LM/pull/63)), and the two
-compose.
+`--stream-optimizer-state-to-disk` addresses, and the two compose.
+
+## Streaming the optimizer state
+
+```bash
+--offload-train --offload-train-target disk \
+--stream-optimizer-state-to-disk \
+--offload-train-disk-dir /scratch/miles_offload
+```
+
+The two together are what this is for. Actor offload gets the paused actor out of HBM for
+the whole rollout window; streaming keeps the largest part of it — 12 bytes per parameter
+of fp32 main params and Adam moments — from being in HBM in the first place, including
+while the step runs, which offload cannot do. Data parallelism divides the optimizer state,
+so a run with GPUs to spare shards it small enough to stay resident and needs neither; the
+runs that need both are the ones tight enough to sit at DP=1. GLM-5.2 744B on 8 GB300 nodes
+is the shape of it: 279 GB of state per rank against 276.6 GB of HBM, on half the nodes the
+run would otherwise need.
+
+The fp32 main params and Adam moments live in per-bucket files instead of on the GPU.
+Each step brings in one bucket, updates it, and writes it back, so peak residency is one
+bucket rather than the whole state. Buckets are capped at 200M elements independently of
+DDP's bucket sizes, which reach tens of GB at DP=1. Native-fp32 model params (a router's
+`expert_bias`, a GDN/Mamba `A_log`) stay GPU-resident under a small separate Adam: they
+are tiny, and unlike the bf16 path their optimizer shards alias the model params directly.
+
+`fp32` storage is bit-identical to keeping the state on GPU, so turning this on does not
+change results — it trades step time for memory. The step is I/O bound and the moments
+tolerate less precision than the master copy, so they can be stored narrower:
+
+```bash
+--stream-optimizer-state-moment-dtype bf16
+```
+
+That cuts streaming volume by a third (12 bytes per param to 8). A checkpoint records the
+dtypes it was written with and a resume verifies them, so bytes written as bf16 can never
+be read back as fp32. The fp8 options work but are not recommended: `exp_avg_sq` needs
+per-block scaling to survive 8-bit storage, which this does not implement.
+
+Two limits to know about. Resume is same-topology only — the on-disk layout follows this
+rank's DP shard, so changing TP/PP/DP/EP fails the layout assert rather than resharding.
+And the optimizer state is copied to the checkpoint directory synchronously, outside
+`--async-save`, so expect checkpoint saves to take noticeably longer.
+
+The two also help each other. With the optimizer state already on disk there is that much
+less to move when the actor is paused: on Qwen3-30B-A3B, sleep/wake went from 24s/8.9s to
+5.2s/1.3s once the paused actor no longer carried the state.
 
 ## Choosing
 
-- Host RAM holds the paused actor: keep the default `--offload-train-target=cpu`. It is
-  faster and needs no scratch space.
-- Host RAM does not hold it: switch to `--offload-train-target=disk`.
+`--offload-train` is the base mechanism, and it is not tied to colocation: the actor is
+resident only during `train()` and sleeps for the whole rollout window either way. What
+changes is who takes the freed HBM. Colocated, it is the engine on the same GPUs, so
+offload is mandatory and defaults on. Disaggregated, it is whatever else you fit on the
+training GPUs, which is the point when you are sizing engines against a fixed cluster.
+
+- Paused actor fits in host RAM: keep `--offload-train-target=cpu` (default). Fastest, no
+  scratch space.
+- It does not fit: `--offload-train-target=disk`.
+- On top of that, the optimizer state does not fit the GPU *during the step*, which offload
+  cannot help with: add `--stream-optimizer-state-to-disk`, and consider
+  `--stream-optimizer-state-moment-dtype bf16` to claw back some of the I/O cost.
+
+Streaming requires `--offload-train-target=disk`; miles asserts it. The two answer the same
+pressure and are only deployed as a pair, so that is the only combination covered.
+Streaming on its own does run — it is the one case where offload has nothing to do, because
+nothing else wants the training GPUs during rollout — but nothing validates it.
+
+Both mechanisms share `--offload-train-disk-dir` and `--offload-train-disk-chunk-mb`. Point the
+directory at real node-local NVMe: a tmpfs mount, which `/tmp` is on many systems, keeps
+the data in RAM and defeats both. The chunk is a pinned host staging buffer and each
+mechanism allocates its own, so enabling both costs 2x that per rank.

--- a/miles/backends/megatron_utils/model.py
+++ b/miles/backends/megatron_utils/model.py
@@ -181,6 +181,12 @@ def setup_model_and_optimizer(
             model_chunks=model,
             use_gloo_process_groups=args.enable_gloo_process_groups,
         )
+
+    if args.stream_optimizer_state_to_disk:
+        from miles_plugins.optimizers.nvme_stream import setup_optimizer_state_streaming
+
+        setup_optimizer_state_streaming(args, optimizer)
+
     opt_param_scheduler = get_optimizer_param_scheduler(args, optimizer)
     return model, optimizer, opt_param_scheduler
 

--- a/miles/ray/train/actor_factory.py
+++ b/miles/ray/train/actor_factory.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 
 import ray
 from ray.util.placement_group import PlacementGroup
@@ -48,6 +49,10 @@ def allocate_gpus_for_actor(
         env_vars["LD_PRELOAD"] = dynlib_path
         env_vars["TMS_INIT_ENABLE"] = "1"
         if args.offload_train_target == "disk":
+            assert b"TMS_INIT_ENABLE_DISK_BACKUP" in Path(dynlib_path).read_bytes(), (
+                f"{dynlib_path} has no disk backend; reinstall torch_memory_saver at the commit "
+                f"docker/Dockerfile pins."
+            )
             env_vars["TMS_INIT_ENABLE_CPU_BACKUP"] = "0"
             env_vars["TMS_INIT_ENABLE_DISK_BACKUP"] = "1"
             env_vars["TMS_DISK_BACKUP_CHUNK_MB"] = str(args.offload_train_disk_chunk_mb)

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -2869,13 +2869,6 @@ def miles_validate_args(args):
         args.disable_grad_buffers_cpu_backup = True
         args.disable_param_buffers_cpu_backup = args.enable_weights_backuper
 
-    if args.offload_train_target == "disk" or args.stream_optimizer_state_to_disk:
-        if args.offload_train_disk_dir is None:
-            uid = os.getuid() if hasattr(os, "getuid") else 0
-            args.offload_train_disk_dir = os.path.join(
-                os.environ.get("SCRATCH", "/scratch"), f"miles_train_offload_{uid}"
-            )
-
     if args.offload_train_target == "disk":
         assert args.offload_train, "--offload-train-target=disk requires --offload-train"
         assert (
@@ -2887,12 +2880,22 @@ def miles_validate_args(args):
             "not from a CPU backup."
         )
         assert args.offload_train_disk_chunk_mb > 0, "--offload-train-disk-chunk-mb must be positive"
+        if args.offload_train_disk_dir is None:
+            uid = os.getuid() if hasattr(os, "getuid") else 0
+            args.offload_train_disk_dir = os.path.join(
+                os.environ.get("SCRATCH", "/scratch"), f"miles_train_offload_{uid}"
+            )
         logger.info(
             f"Train offload target=disk, dir={args.offload_train_disk_dir}, "
             f"chunk={args.offload_train_disk_chunk_mb}MB"
         )
 
     if args.stream_optimizer_state_to_disk:
+        assert args.offload_train_target == "disk", (
+            "--stream-optimizer-state-to-disk requires --offload-train-target=disk. Both answer the "
+            "same pressure and are only ever deployed as a pair, so that is the only combination "
+            "validated; streaming alone runs but is untested."
+        )
         assert args.use_distributed_optimizer, "--stream-optimizer-state-to-disk requires the distributed optimizer"
         assert (
             args.optimizer == "adam"
@@ -2916,7 +2919,6 @@ def miles_validate_args(args):
         assert (
             not args.enable_witness
         ), "--enable-witness reads the master optimizer's per-param state, which the NVMe store owns"
-        assert args.offload_train_disk_chunk_mb > 0, "--offload-train-disk-chunk-mb must be positive"
         logger.info(
             f"Streaming optimizer state to disk, dir={args.offload_train_disk_dir}, "
             f"chunk={args.offload_train_disk_chunk_mb}MB, moments={args.stream_optimizer_state_moment_dtype}"

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -2911,12 +2911,11 @@ def miles_validate_args(args):
             "--save-local-weight-checksum reads param.main_param, whose storage the NVMe store "
             "resizes to 0 between steps"
         )
-        assert not args.enable_witness, (
-            "--enable-witness reads the master optimizer's per-param state, which the NVMe store owns"
-        )
+        assert (
+            not args.enable_witness
+        ), "--enable-witness reads the master optimizer's per-param state, which the NVMe store owns"
         assert args.offload_train_target == "disk", (
-            "--stream-optimizer-state-to-disk is only supported alongside "
-            "--offload-train-target=disk; pass both."
+            "--stream-optimizer-state-to-disk is only supported alongside " "--offload-train-target=disk; pass both."
         )
         logger.info(
             f"Streaming optimizer state to disk, dir={args.offload_train_disk_dir}, "

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -16,6 +16,7 @@ from miles.utils.eval_config import EvalDatasetConfig, build_eval_dataset_config
 from miles.utils.ft_utils.health_checker import SimpleHealthCheckerConfig
 from miles.utils.hf_config import is_dsa, load_hf_config
 from miles.utils.logging_utils import configure_logger_raw
+from miles.utils.lora import is_lora_enabled
 from miles.utils.megatron_args_utils import compute_megatron_world_size_except_dp
 from miles.utils.misc import load_function
 from miles.utils.object_store import ObjectStoreBackend
@@ -2900,7 +2901,11 @@ def miles_validate_args(args):
         assert (
             args.optimizer == "adam"
         ), f"--stream-optimizer-state-to-disk requires --optimizer adam, got {args.optimizer}"
-        assert not args.multi_lora, "--stream-optimizer-state-to-disk does not support multi-LoRA"
+        assert not (args.multi_lora or is_lora_enabled(args)), (
+            "--stream-optimizer-state-to-disk does not support LoRA: the LoRA checkpoint path "
+            "persists optimizer.state_dict(), which the store leaves empty, and restores the "
+            "adapter into the model params without refreshing the streamed main params"
+        )
         assert not args.optimizer_cpu_offload, "--stream-optimizer-state-to-disk excludes --optimizer-cpu-offload"
         assert (
             not args.offload_optimizer_states

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -2897,6 +2897,11 @@ def miles_validate_args(args):
             "same pressure and are only ever deployed as a pair, so that is the only combination "
             "validated; streaming alone runs but is untested."
         )
+        assert not args.indep_dp, (
+            "--stream-optimizer-state-to-disk does not support --indep-dp: each cell has its own "
+            "process group, so torch.distributed.get_rank() restarts at 0 per cell and two cells "
+            "on one node would share a store directory"
+        )
         assert args.use_distributed_optimizer, "--stream-optimizer-state-to-disk requires the distributed optimizer"
         assert (
             args.optimizer == "adam"

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -139,12 +139,47 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 ),
             )
             parser.add_argument(
+                "--stream-optimizer-state-to-disk",
+                action="store_true",
+                help=(
+                    "Stream the fp32 main params and Adam moments through per-bucket files on "
+                    "node-local NVMe during optimizer.step(), bounding GPU residency to one bucket. "
+                    "For when the optimizer state does not fit the GPU *while the step runs*: "
+                    "--offload-train-target=disk cannot help there, because pause/resume happen at "
+                    "phase boundaries and everything is resident again by the time Adam launches. "
+                    "Bit-identical to keeping the state on GPU, at the cost of disk traffic every "
+                    "step. Distinct from --offload-optimizer-states and --optimizer-cpu-offload, "
+                    "and mutually exclusive with both."
+                ),
+            )
+            parser.add_argument(
+                "--stream-optimizer-state-moment-dtype",
+                type=str,
+                default="fp32",
+                choices=["fp32", "bf16", "fp16", "fp8e4m3", "fp8e5m2"],
+                help=(
+                    "On-disk dtype for the streamed Adam moments; the fp32 master copy is always "
+                    "fp32. This is a serialization format, not a compute precision: the step still "
+                    "hands fp32 tensors to FusedAdam, and the cast happens on the way to and from "
+                    "disk. That makes it distinct from --exp-avg-dtype / --exp-avg-sq-dtype, which "
+                    "change what the optimizer holds and require --use-precision-aware-optimizer, "
+                    "so they cannot be combined with streaming at all. "
+                    "The step is I/O bound and the moments tolerate less precision than the master "
+                    "copy, so bf16 cuts streaming volume by a third (12 bytes per param to 8). "
+                    "fp32 is bit-identical to keeping the moments on GPU. The fp8 options need "
+                    "per-block scaling for exp_avg_sq to be sound, which this does not implement, "
+                    "and are not recommended."
+                ),
+            )
+            parser.add_argument(
                 "--offload-train-disk-dir",
                 type=str,
                 default=None,
                 help=(
-                    "Node-local directory for train disk-offload files when "
-                    "--offload-train-target=disk. Should be fast local NVMe (e.g. /scratch). "
+                    "Node-local directory for the disk-offload files, used by both "
+                    "--offload-train-target=disk and --stream-optimizer-state-to-disk (each under "
+                    "its own subdirectory). Should be fast local NVMe (e.g. /scratch); a tmpfs "
+                    "mount, which /tmp is on many systems, keeps the data in RAM and defeats both. "
                     "Files are per-process and overwritten in place every step (bounded size); "
                     "defaults to $SCRATCH/miles_train_offload_<uid>."
                 ),
@@ -154,8 +189,10 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 type=int,
                 default=256,
                 help=(
-                    "Chunk size (MiB) for streaming the training actor GPU<->disk in disk-offload "
-                    "mode. Bounds the pinned host staging buffer regardless of the total offloaded size."
+                    "Chunk size (MiB) for the GPU<->disk transfers, i.e. the pinned host staging "
+                    "buffer, which bounds host memory regardless of how much is moved. Used by both "
+                    "--offload-train-target=disk and --stream-optimizer-state-to-disk, and each "
+                    "allocates its own, so enabling both costs 2x this per rank."
                 ),
             )
 
@@ -2851,6 +2888,39 @@ def miles_validate_args(args):
         logger.info(
             f"Train offload target=disk, dir={args.offload_train_disk_dir}, "
             f"chunk={args.offload_train_disk_chunk_mb}MB"
+        )
+
+    if args.stream_optimizer_state_to_disk:
+        assert args.use_distributed_optimizer, "--stream-optimizer-state-to-disk requires the distributed optimizer"
+        assert (
+            args.optimizer == "adam"
+        ), f"--stream-optimizer-state-to-disk requires --optimizer adam, got {args.optimizer}"
+        assert not args.multi_lora, "--stream-optimizer-state-to-disk does not support multi-LoRA"
+        assert not args.optimizer_cpu_offload, "--stream-optimizer-state-to-disk excludes --optimizer-cpu-offload"
+        assert (
+            not args.offload_optimizer_states
+        ), "--stream-optimizer-state-to-disk excludes --offload-optimizer-states"
+        assert (
+            not args.use_precision_aware_optimizer
+        ), "--stream-optimizer-state-to-disk requires mcore to hold the fp32 main params"
+        assert not args.reset_optimizer_states, (
+            "--reset-optimizer-states walks the master optimizer's state, which the NVMe store "
+            "leaves empty, so the reset would silently do nothing"
+        )
+        assert not args.save_local_weight_checksum, (
+            "--save-local-weight-checksum reads param.main_param, whose storage the NVMe store "
+            "resizes to 0 between steps"
+        )
+        assert not args.enable_witness, (
+            "--enable-witness reads the master optimizer's per-param state, which the NVMe store owns"
+        )
+        assert args.offload_train_target == "disk", (
+            "--stream-optimizer-state-to-disk is only supported alongside "
+            "--offload-train-target=disk; pass both."
+        )
+        logger.info(
+            f"Streaming optimizer state to disk, dir={args.offload_train_disk_dir}, "
+            f"chunk={args.offload_train_disk_chunk_mb}MB, moments={args.stream_optimizer_state_moment_dtype}"
         )
 
     if args.async_max_concurrent_samples is not None:

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -2869,6 +2869,13 @@ def miles_validate_args(args):
         args.disable_grad_buffers_cpu_backup = True
         args.disable_param_buffers_cpu_backup = args.enable_weights_backuper
 
+    if args.offload_train_target == "disk" or args.stream_optimizer_state_to_disk:
+        if args.offload_train_disk_dir is None:
+            uid = os.getuid() if hasattr(os, "getuid") else 0
+            args.offload_train_disk_dir = os.path.join(
+                os.environ.get("SCRATCH", "/scratch"), f"miles_train_offload_{uid}"
+            )
+
     if args.offload_train_target == "disk":
         assert args.offload_train, "--offload-train-target=disk requires --offload-train"
         assert (
@@ -2880,11 +2887,6 @@ def miles_validate_args(args):
             "not from a CPU backup."
         )
         assert args.offload_train_disk_chunk_mb > 0, "--offload-train-disk-chunk-mb must be positive"
-        if args.offload_train_disk_dir is None:
-            uid = os.getuid() if hasattr(os, "getuid") else 0
-            args.offload_train_disk_dir = os.path.join(
-                os.environ.get("SCRATCH", "/scratch"), f"miles_train_offload_{uid}"
-            )
         logger.info(
             f"Train offload target=disk, dir={args.offload_train_disk_dir}, "
             f"chunk={args.offload_train_disk_chunk_mb}MB"
@@ -2914,9 +2916,7 @@ def miles_validate_args(args):
         assert (
             not args.enable_witness
         ), "--enable-witness reads the master optimizer's per-param state, which the NVMe store owns"
-        assert args.offload_train_target == "disk", (
-            "--stream-optimizer-state-to-disk is only supported alongside " "--offload-train-target=disk; pass both."
-        )
+        assert args.offload_train_disk_chunk_mb > 0, "--offload-train-disk-chunk-mb must be positive"
         logger.info(
             f"Streaming optimizer state to disk, dir={args.offload_train_disk_dir}, "
             f"chunk={args.offload_train_disk_chunk_mb}MB, moments={args.stream_optimizer_state_moment_dtype}"

--- a/miles_plugins/optimizers/nvme_stream.py
+++ b/miles_plugins/optimizers/nvme_stream.py
@@ -1,0 +1,490 @@
+"""NVMe streaming of Megatron's DistributedOptimizer state.
+
+The fp32 main params and Adam moments live in per-bucket files on node-local NVMe
+instead of on the GPU. ``step()`` walks the buckets one at a time -- materialize,
+load, per-bucket Adam step, copy the updated mains into the param buffer, write
+back, release -- so GPU residency is bounded by one bucket rather than the whole
+state. For runs where the state does not fit the GPU *while the step runs*, which
+sleep-window offload cannot help with.
+
+``setup_optimizer_state_streaming`` gives each ``DistributedOptimizer`` in the chain
+a store and routes the five entry points that touch optimizer state at it, so
+Megatron carries no NVMe-specific behaviour. The one piece that stays on Megatron's
+side is the pair of checkpoint hooks in ``megatron/training/checkpointing.py``, which
+have to be inside ``save_checkpoint`` / ``load_checkpoint`` to cover every call path;
+they reach this class through four methods:
+
+    step()
+    refresh_main_from_model_params(copy_fn)
+    save_to(base_dir)
+    load_from(base_dir) -> bool
+
+Both directory arguments are checkpoint *bases*; the per-rank layout underneath is
+this file's business, matching the layout of the live scratch directory.
+"""
+
+import atexit
+import errno
+import json
+import logging
+import os
+import shutil
+import time
+from types import MethodType
+from typing import TYPE_CHECKING, NamedTuple
+
+import torch
+from megatron.core.fp8_utils import is_float8tensor
+
+if TYPE_CHECKING:
+    from megatron.core.optimizer.distrib_optimizer import DistributedOptimizer
+
+logger = logging.getLogger(__name__)
+
+SEGMENTS = ("main", "exp_avg", "exp_avg_sq")
+DTYPES = {
+    "fp32": torch.float32,
+    "bf16": torch.bfloat16,
+    "fp16": torch.float16,
+    "fp8e4m3": torch.float8_e4m3fn,
+    "fp8e5m2": torch.float8_e5m2,
+}
+BUCKET_NUMEL_LIMIT = 200_000_000
+FP32_RESIDENT_WARN_MB = 256
+IO_ALIGN = 4096
+
+
+class _Entry(NamedTuple):
+    model_param: torch.nn.Parameter
+    main_param: torch.Tensor
+    group_index: int
+
+
+def _align(nbytes: int) -> int:
+    return (nbytes + IO_ALIGN - 1) // IO_ALIGN * IO_ALIGN
+
+
+def _resize(tensor: torch.Tensor, numel: int) -> None:
+    tensor.untyped_storage().resize_(numel * tensor.element_size())
+
+
+def _allocate_file(path: str, nbytes: int) -> int:
+    fd = os.open(path, os.O_RDWR | os.O_CREAT | os.O_CLOEXEC, 0o600)
+    try:
+        os.posix_fallocate(fd, 0, nbytes)
+    except OSError as e:
+        if e.errno not in (errno.EOPNOTSUPP, errno.ENOTSUP, errno.EINVAL):
+            raise
+        os.ftruncate(fd, nbytes)
+    return fd
+
+
+def _rw_full(op, fd: int, offset: int, buf) -> None:
+    mv = memoryview(buf).cast("B")
+    done = 0
+    while done < len(mv):
+        n = op(fd, [mv[done:]], offset + done)
+        if n <= 0:
+            raise OSError(f"short {op.__name__} ({n}) on optimizer state file at offset {offset + done}")
+        done += n
+
+
+def plan_buckets(entries_by_ddp_bucket: dict, limit: int = BUCKET_NUMEL_LIMIT) -> list[list[_Entry]]:
+    planned, current, numel = [], [], 0
+    for _, entries in sorted(entries_by_ddp_bucket.items(), key=lambda kv: kv[0]):
+        for entry in entries:
+            current.append(entry)
+            numel += entry.main_param.numel()
+            if numel >= limit:
+                planned.append(current)
+                current, numel = [], 0
+        if current:
+            planned.append(current)
+            current, numel = [], 0
+    return planned
+
+
+class _Stager:
+    def __init__(self, nbytes: int):
+        self._buf = torch.empty(nbytes, dtype=torch.uint8, pin_memory=True)
+        self._bytes = self._buf.numpy()
+        self._device_buf = None
+
+    def _device_staging(self, dtype: torch.dtype, numel: int, like: torch.Tensor) -> torch.Tensor:
+        # A cross-dtype copy between GPU and pinned host memory does not take the DMA
+        # path: casting on the device first and moving same-dtype bytes is ~40x faster
+        # for bf16 and ~100x for fp8.
+        size = self._buf.numel()
+        if self._device_buf is None or self._device_buf.device != like.device:
+            self._device_buf = torch.empty(size, dtype=torch.uint8, device=like.device)
+        return self._device_buf[: numel * dtype.itemsize].view(dtype)
+
+    def transfer(self, fd: int, offset: int, tensor: torch.Tensor, dtype: torch.dtype, *, to_disk: bool) -> int:
+        flat = tensor.view(-1)
+        cast = dtype != flat.dtype
+        chunk = self._buf.numel() // dtype.itemsize
+        pos = 0
+        while pos < flat.numel():
+            numel = min(chunk, flat.numel() - pos)
+            host = self._buf[: numel * dtype.itemsize].view(dtype)
+            at = offset + pos * dtype.itemsize
+            nbytes = numel * dtype.itemsize
+            if to_disk:
+                if cast:
+                    staged = self._device_staging(dtype, numel, flat)
+                    staged.copy_(flat[pos : pos + numel])
+                    host.copy_(staged)
+                else:
+                    host.copy_(flat[pos : pos + numel])
+                _rw_full(os.pwritev, fd, at, self._bytes[:nbytes])
+            else:
+                _rw_full(os.preadv, fd, at, self._bytes[:nbytes])
+                if cast:
+                    staged = self._device_staging(dtype, numel, flat)
+                    staged.copy_(host)
+                    flat[pos : pos + numel].copy_(staged)
+                else:
+                    flat[pos : pos + numel].copy_(host)
+            pos += numel
+        return flat.numel() * dtype.itemsize
+
+
+class _Bucket:
+    def __init__(self, path: str, entries: list[_Entry], adam, stager: _Stager, dtypes: dict):
+        self.path, self.entries, self.adam, self.dtypes = path, entries, adam, dtypes
+        self._stager = stager
+        self.group_indices = sorted({e.group_index for e in entries})
+        self.numel = sum(e.main_param.numel() for e in entries)
+
+        self.offsets: dict[str, list[int]] = {}
+        at = 0
+        for segment in SEGMENTS:
+            self.offsets[segment] = []
+            for entry in entries:
+                self.offsets[segment].append(at)
+                at += _align(entry.main_param.numel() * dtypes[segment].itemsize)
+        self.nbytes = at
+        self.fd = _allocate_file(path, at)
+        self.moments_ready = False
+
+    def _tensors(self, segment: str):
+        for index, entry in enumerate(self.entries):
+            tensor = entry.main_param if segment == "main" else self.adam.state[entry.main_param][segment]
+            yield tensor, self.offsets[segment][index]
+
+    def _move(self, segments, *, to_disk: bool) -> int:
+        moved = 0
+        for segment in segments:
+            for tensor, offset in self._tensors(segment):
+                if not to_disk:
+                    _resize(tensor, tensor.numel())
+                moved += self._stager.transfer(self.fd, offset, tensor, self.dtypes[segment], to_disk=to_disk)
+                if to_disk:
+                    _resize(tensor, 0)
+        return moved
+
+    def fetch(self) -> int:
+        return self._move(SEGMENTS if self.moments_ready else SEGMENTS[:1], to_disk=False)
+
+    def flush(self, segments=SEGMENTS) -> int:
+        moved = self._move(segments, to_disk=True)
+        self.moments_ready = self.moments_ready or tuple(segments) == SEGMENTS
+        return moved
+
+    def materialize_main(self) -> None:
+        for tensor, _ in self._tensors("main"):
+            _resize(tensor, tensor.numel())
+
+    def allocate_moments(self) -> None:
+        for entry in self.entries:
+            state = self.adam.state.setdefault(entry.main_param, {})
+            for segment in SEGMENTS[1:]:
+                if segment not in state:
+                    state[segment] = torch.empty_like(entry.main_param)
+                    _resize(state[segment], 0)
+        self.moments_ready = True
+
+
+class NVMeOptimizerStateStore:
+    _next_uid = 0
+
+    def __init__(
+        self, distrib_optimizer: "DistributedOptimizer", dir_root: str, chunk_mb: int, moment_dtype: str = "fp32"
+    ):
+        self.dist_opt = distrib_optimizer
+        self.uid = NVMeOptimizerStateStore._next_uid
+        NVMeOptimizerStateStore._next_uid += 1
+        config = distrib_optimizer.config
+
+        assert not config.use_precision_aware_optimizer, (
+            "NVMe state store requires the non-precision-aware optimizer " "(fp32 main params held by mcore)."
+        )
+        assert not config.optimizer_cpu_offload, "NVMe state store is mutually exclusive with CPU offload."
+        assert (
+            not config.offload_optimizer_states
+        ), "NVMe state store is mutually exclusive with --offload-optimizer-states."
+        assert not distrib_optimizer.ddp_config.use_megatron_fsdp
+        # See _copy_main_to_model_params for why fp8 params cannot be streamed.
+        assert not any(
+            is_float8tensor(p) for group in distrib_optimizer.model_float16_groups for p in group
+        ), "NVMe state store does not support fp8 params."
+        assert not config.reuse_grad_buf_for_mxfp8_param_ag, (
+            "NVMe state store does not support the MXFP8 param all-gather, which copies mains "
+            "into the param buffer through a different path."
+        )
+
+        moments = moment_dtype
+        assert moments in DTYPES, f"unknown moment dtype {moments!r}, expected one of {sorted(DTYPES)}"
+        if DTYPES[moments].itemsize == 1:
+            logger.warning(
+                f"Storing Adam moments as {moments} without per-block scaling is numerically risky "
+                "for exp_avg_sq; bf16 is the safe way to halve moment I/O."
+            )
+        self.dtypes = {"main": torch.float32, "exp_avg": DTYPES[moments], "exp_avg_sq": DTYPES[moments]}
+
+        self._rank = torch.distributed.get_rank()
+        self._instance = distrib_optimizer.distributed_optimizer_instance_id
+        self.dir = os.path.join(dir_root, self.relative_dir)
+        shutil.rmtree(self.dir, ignore_errors=True)
+        os.makedirs(self.dir, exist_ok=True)
+        atexit.register(shutil.rmtree, self.dir, ignore_errors=True)
+
+        self._stager = _Stager(chunk_mb * 1024 * 1024)
+        self.buckets = self._build_buckets()
+        self._fp32_group_indices, self._fp32_adam = self._build_fp32_optimizer()
+
+        for bucket in self.buckets:
+            bucket.flush(segments=("main",))
+
+        total_gb = sum(b.nbytes for b in self.buckets) / 1024**3
+        logger.info(
+            f"NVMe optimizer state store: {len(self.buckets)} buckets, {total_gb:.1f} GB at "
+            f"{self.dir} (moments stored as {moments})"
+        )
+
+    @property
+    def relative_dir(self) -> str:
+        """This store's location under any base directory -- scratch or checkpoint.
+
+        ``uid`` is what disambiguates the chained dense and expert optimizers, which can
+        share an instance id.
+        """
+        return os.path.join(f"rank{self._rank:05d}", f"opt{self._instance}_{self.uid}")
+
+    def _build_buckets(self) -> list[_Bucket]:
+        by_ddp_bucket: dict[tuple, list[_Entry]] = {}
+        groups = zip(self.dist_opt.model_float16_groups, self.dist_opt.shard_fp32_from_float16_groups, strict=True)
+        for group_index, (model_group, main_group) in enumerate(groups):
+            for model_param, main_param in zip(model_group, main_group, strict=True):
+                assert main_param is not None and main_param.dtype == torch.float32
+                key = self.dist_opt.model_param_gbuf_map[model_param]
+                by_ddp_bucket.setdefault(key, []).append(_Entry(model_param, main_param, group_index))
+
+        buckets = []
+        for index, entries in enumerate(plan_buckets(by_ddp_bucket)):
+            params: dict[int, list[torch.Tensor]] = {}
+            for entry in entries:
+                params.setdefault(entry.group_index, []).append(entry.main_param)
+            path = os.path.join(self.dir, f"bucket{index:05d}.bin")
+            buckets.append(_Bucket(path, entries, self._adam_for(params), self._stager, self.dtypes))
+        return buckets
+
+    def _build_fp32_optimizer(self):
+        params: dict[int, list[torch.Tensor]] = {}
+        total_bytes = 0
+        for group_index, (model_group, shard_group) in enumerate(
+            zip(self.dist_opt.model_fp32_groups, self.dist_opt.shard_fp32_groups, strict=True)
+        ):
+            if model_group:
+                params[group_index] = list(shard_group)
+                total_bytes += sum(p.numel() * p.element_size() for p in shard_group)
+        if not params:
+            return [], None
+
+        total_mb = total_bytes / 1024**2
+        log = logger.warning if total_mb > FP32_RESIDENT_WARN_MB else logger.info
+        log(f"NVMe optimizer state store: {total_mb:.1f} MB of native-fp32 params stay GPU-resident")
+        return sorted(params), self._adam_for(params)
+
+    def _adam_for(self, params_by_group: dict[int, list[torch.Tensor]]):
+        from megatron.core.optimizer import Adam
+
+        master_groups = self.dist_opt.optimizer.param_groups
+        groups = []
+        for group_index in sorted(params_by_group):
+            group = {k: v for k, v in master_groups[group_index].items() if k != "params"}
+            group["params"] = params_by_group[group_index]
+            groups.append(group)
+        return Adam(groups, adam_w_mode=self.dist_opt.config.decoupled_weight_decay)
+
+    def _sync_lr_wd(self, adam, group_indices) -> None:
+        master_groups = self.dist_opt.optimizer.param_groups
+        for group, group_index in zip(adam.param_groups, group_indices, strict=True):
+            group["lr"] = master_groups[group_index]["lr"]
+            group["weight_decay"] = master_groups[group_index]["weight_decay"]
+
+    # Adapted from DistributedOptimizer._copy_main_params_to_model_params, which walks every
+    # group at once, at
+    # https://github.com/radixark/Megatron-LM/blob/4716f75475c78e2fc2c6f0d3af095f1681b770b4/megatron/core/optimizer/distrib_optimizer.py#L2469-L2519
+    # Recheck against that revision when bumping Megatron. Its fp8 branch is absent because
+    # quantize_param_shard() is a DP collective over the whole fp8 param set and cannot be
+    # split per bucket; __init__ rejects fp8 params instead.
+    def _copy_main_to_model_params(self, entries: list[_Entry]) -> None:
+        dist_opt = self.dist_opt
+        for entry in entries:
+            param_range_map = dist_opt._get_model_param_range_map(entry.model_param)
+            world_range = param_range_map["gbuf_world_in_bucket"]
+            assert world_range.size == entry.main_param.nelement()
+            gbuf_index, _, bucket_id = dist_opt.model_param_gbuf_map[entry.model_param]
+            param_data = dist_opt.buffers[gbuf_index].buckets[bucket_id].param_data
+            param_data.view(-1)[world_range.start : world_range.end].copy_(entry.main_param)
+
+    @torch.no_grad()
+    def step(self) -> bool:
+        started = time.monotonic()
+        read = written = 0
+        for bucket in self.buckets:
+            read += bucket.fetch()
+            self._sync_lr_wd(bucket.adam, bucket.group_indices)
+            bucket.adam.step()
+            self._copy_main_to_model_params(bucket.entries)
+            written += bucket.flush()
+        if self._fp32_adam is not None:
+            self._sync_lr_wd(self._fp32_adam, self._fp32_group_indices)
+            self._fp32_adam.step()
+        logger.info(
+            f"NVMe streaming step: {len(self.buckets)} buckets, read {read / 1024**3:.1f} GB, "
+            f"wrote {written / 1024**3:.1f} GB in {time.monotonic() - started:.1f}s"
+        )
+        return True
+
+    @torch.no_grad()
+    def refresh_main_from_model_params(self, copy_fn) -> None:
+        for bucket in self.buckets:
+            bucket.materialize_main()
+        copy_fn()
+        for bucket in self.buckets:
+            bucket.flush(segments=("main",))
+
+    @torch.no_grad()
+    def save_to(self, base_dir: str) -> None:
+        dirpath = os.path.join(base_dir, self.relative_dir)
+        os.makedirs(dirpath, exist_ok=True)
+        manifest = {
+            "dtypes": {segment: str(dtype) for segment, dtype in self.dtypes.items()},
+            "buckets": [
+                {
+                    "numel": bucket.numel,
+                    "entry_numels": [e.main_param.numel() for e in bucket.entries],
+                    "steps": [g.get("step", 0) for g in bucket.adam.param_groups],
+                    "file": os.path.basename(bucket.path),
+                }
+                for bucket in self.buckets
+            ],
+        }
+        for bucket in self.buckets:
+            shutil.copyfile(bucket.path, os.path.join(dirpath, os.path.basename(bucket.path)))
+        if self._fp32_adam is not None:
+            torch.save(self._fp32_adam.state_dict(), os.path.join(dirpath, "fp32_resident_optimizer.pt"))
+        with open(os.path.join(dirpath, "manifest.json"), "w") as f:
+            json.dump(manifest, f)
+        logger.info(f"NVMe optimizer state saved: {len(self.buckets)} buckets -> {dirpath}")
+
+    @torch.no_grad()
+    def load_from(self, base_dir: str) -> bool:
+        """Restore this store from a checkpoint base, or report that there is nothing there.
+
+        Returns False for a checkpoint written without streaming, which keeps pre-streaming
+        checkpoints loadable; every other mismatch fails on the asserts below.
+        """
+        dirpath = os.path.join(base_dir, self.relative_dir)
+        if not os.path.isdir(dirpath):
+            logger.warning(f"no NVMe optimizer state at {dirpath}; starting from a fresh optimizer state")
+            return False
+
+        with open(os.path.join(dirpath, "manifest.json")) as f:
+            manifest = json.load(f)
+
+        saved = manifest.get("dtypes", {segment: str(torch.float32) for segment in SEGMENTS})
+        current = {segment: str(dtype) for segment, dtype in self.dtypes.items()}
+        assert saved == current, (
+            f"NVMe state dtype mismatch: checkpoint stores {saved}, this run stores {current} "
+            "-- the bytes would be misread"
+        )
+        assert len(manifest["buckets"]) == len(self.buckets), (
+            f"NVMe state layout mismatch: checkpoint has {len(manifest['buckets'])} buckets, "
+            f"current topology builds {len(self.buckets)} (same-topology resume only)"
+        )
+
+        for bucket, meta in zip(self.buckets, manifest["buckets"], strict=True):
+            assert meta["numel"] == bucket.numel
+            assert meta["entry_numels"] == [e.main_param.numel() for e in bucket.entries]
+            shutil.copyfile(os.path.join(dirpath, meta["file"]), bucket.path)
+            for group, step in zip(bucket.adam.param_groups, meta["steps"], strict=True):
+                if step:
+                    group["step"] = step
+            bucket.allocate_moments()
+        fp32_state = os.path.join(dirpath, "fp32_resident_optimizer.pt")
+        if self._fp32_adam is not None and os.path.isfile(fp32_state):
+            self._fp32_adam.load_state_dict(torch.load(fp32_state))
+        logger.info(f"NVMe optimizer state loaded: {len(self.buckets)} buckets <- {dirpath}")
+        return True
+
+
+def setup_optimizer_state_streaming(args, optimizer) -> None:
+    """Give every DistributedOptimizer in ``optimizer``'s chain a store and route it there.
+
+    Must run before load_checkpoint: the constructor evicts the fp32 main params, and the
+    bindings are what keep the load path from writing into the evicted storage.
+    """
+    from megatron.core.optimizer.distrib_optimizer import DistributedOptimizer
+
+    dir_root = os.path.join(args.offload_train_disk_dir, "optimizer_state")
+    for dist_opt in optimizer.chained_optimizers:
+        assert isinstance(
+            dist_opt, DistributedOptimizer
+        ), f"--stream-optimizer-state-to-disk requires the distributed optimizer, got {type(dist_opt).__name__}"
+        if dist_opt.is_stub_optimizer:
+            continue
+        store = NVMeOptimizerStateStore(
+            dist_opt, dir_root, args.offload_train_disk_chunk_mb, args.stream_optimizer_state_moment_dtype
+        )
+        _bind(dist_opt, store)
+
+
+def _bind(dist_opt: "DistributedOptimizer", store: NVMeOptimizerStateStore) -> None:
+    """Point the five DistributedOptimizer entry points that touch optimizer state at ``store``."""
+    from megatron.core.optimizer.distrib_optimizer import DistributedOptimizer
+
+    # The all-gather tail is copied from DistributedOptimizer.step_with_ready_grads and has
+    # to stay in sync with it; the timer calls around it are dropped, hence the assert.
+    def step_with_ready_grads(self) -> bool:
+        assert self.config.timers is None
+        update_successful = store.step()
+        if not self.ddp_config.overlap_param_gather:
+            for model_chunk in self.model_chunks:
+                model_chunk.start_param_sync()
+        return update_successful
+
+    def reload_model_params(self, state_dict=None) -> None:
+        store.refresh_main_from_model_params(
+            lambda: DistributedOptimizer.reload_model_params(self, state_dict=state_dict)
+        )
+
+    # save_to()/load_from() carry the real state; returning empties here rather than forcing
+    # --no-save-optim keeps opt_param_scheduler, saved under the same guard, working.
+    def state_dict(self):
+        return {"nvme_state_store": True}
+
+    def load_state_dict(self, state_dict) -> None:
+        return
+
+    def sharded_state_dict(self, model_sharded_state_dict, is_loading=False, sharding_type=None, metadata=None):
+        return {}
+
+    dist_opt.step_with_ready_grads = MethodType(step_with_ready_grads, dist_opt)
+    dist_opt.reload_model_params = MethodType(reload_model_params, dist_opt)
+    dist_opt.state_dict = MethodType(state_dict, dist_opt)
+    dist_opt.load_state_dict = MethodType(load_state_dict, dist_opt)
+    dist_opt.sharded_state_dict = MethodType(sharded_state_dict, dist_opt)
+    dist_opt._nvme_state_store = store  # how checkpointing.py finds it

--- a/miles_plugins/optimizers/nvme_stream.py
+++ b/miles_plugins/optimizers/nvme_stream.py
@@ -209,9 +209,15 @@ class NVMeOptimizerStateStore:
     _next_uid = 0
 
     def __init__(
-        self, distrib_optimizer: "DistributedOptimizer", dir_root: str, chunk_mb: int, moment_dtype: str = "fp32"
+        self,
+        distrib_optimizer: "DistributedOptimizer",
+        dir_root: str,
+        chunk_mb: int,
+        moment_dtype: str = "fp32",
+        allow_fresh_state: bool = False,
     ):
         self.dist_opt = distrib_optimizer
+        self._allow_fresh_state = allow_fresh_state
         self.uid = NVMeOptimizerStateStore._next_uid
         NVMeOptimizerStateStore._next_uid += 1
         config = distrib_optimizer.config
@@ -394,11 +400,16 @@ class NVMeOptimizerStateStore:
     def load_from(self, base_dir: str) -> bool:
         """Restore this store from a checkpoint base, or report that there is nothing there.
 
-        Returns False for a checkpoint written without streaming, which keeps pre-streaming
-        checkpoints loadable; every other mismatch fails on the asserts below.
+        Returns False only under --no-load-optim, which is what makes a pre-streaming
+        checkpoint loadable; every other mismatch fails on the asserts below.
         """
         dirpath = os.path.join(base_dir, self.relative_dir)
         if not os.path.isdir(dirpath):
+            assert self._allow_fresh_state, (
+                f"no NVMe optimizer state at {dirpath}; this checkpoint was written without "
+                "--stream-optimizer-state-to-disk and its optimizer state cannot be streamed, "
+                "so resuming would restart Adam from zero. Pass --no-load-optim to accept that."
+            )
             logger.warning(f"no NVMe optimizer state at {dirpath}; starting from a fresh optimizer state")
             return False
 
@@ -448,7 +459,11 @@ def setup_optimizer_state_streaming(args, optimizer) -> None:
         if dist_opt.is_stub_optimizer:
             continue
         store = NVMeOptimizerStateStore(
-            dist_opt, dir_root, args.offload_train_disk_chunk_mb, args.stream_optimizer_state_moment_dtype
+            dist_opt,
+            dir_root,
+            args.offload_train_disk_chunk_mb,
+            args.stream_optimizer_state_moment_dtype,
+            allow_fresh_state=args.no_load_optim,
         )
         _bind(dist_opt, store)
 

--- a/miles_plugins/optimizers/nvme_stream.py
+++ b/miles_plugins/optimizers/nvme_stream.py
@@ -440,6 +440,7 @@ def setup_optimizer_state_streaming(args, optimizer) -> None:
     from megatron.core.optimizer.distrib_optimizer import DistributedOptimizer
 
     dir_root = os.path.join(args.offload_train_disk_dir, "optimizer_state")
+    _purge_rank_dir(dir_root)
     for dist_opt in optimizer.chained_optimizers:
         assert isinstance(
             dist_opt, DistributedOptimizer
@@ -450,6 +451,22 @@ def setup_optimizer_state_streaming(args, optimizer) -> None:
             dist_opt, dir_root, args.offload_train_disk_chunk_mb, args.stream_optimizer_state_moment_dtype
         )
         _bind(dist_opt, store)
+
+
+def _purge_rank_dir(dir_root: str) -> None:
+    """Drop everything this rank left behind, before any store claims its own path.
+
+    A store only removes the exact path it is about to use, so state written under a
+    different layout -- another parallelism, a renamed directory scheme -- survives
+    forever, and a run killed by the scheduler never reaches its atexit cleanup either.
+    On a 744B DP1 model that is hundreds of GB per rank per stale run, and node-local
+    NVMe fills up until allocation fails. The rank subtree is exclusively this rank's,
+    so clearing it whole is safe, and it must happen before the chained dense and
+    expert stores are constructed, since they share it.
+    """
+    rank_dir = os.path.join(dir_root, f"rank{torch.distributed.get_rank():05d}")
+    shutil.rmtree(rank_dir, ignore_errors=True)
+    os.makedirs(rank_dir, exist_ok=True)
 
 
 def _bind(dist_opt: "DistributedOptimizer", store: NVMeOptimizerStateStore) -> None:

--- a/tests/ci/labels.py
+++ b/tests/ci/labels.py
@@ -33,4 +33,5 @@ KNOWN_LABELS: dict[str, str] = {
     "replay": "Routing / indexer replay tests",
     "qwen35": "Qwen3.5-35B-A3B MTP / spec-v2 e2e tests",
     "mooncake": "Mooncake object-store rollout transfer tests",
+    "miles-plugin": "miles_plugins extension tests (optimizers, model plugins)",
 }

--- a/tests/e2e/megatron/test_qwen3_4B_offload_disk_stream.py
+++ b/tests/e2e/megatron/test_qwen3_4B_offload_disk_stream.py
@@ -1,0 +1,180 @@
+"""E2E test for --stream-optimizer-state-to-disk (on top of --offload-train-target=disk).
+
+Same colocate RL loop as test_qwen3_4B_offload_disk.py, but the fp32 main params and
+Adam moments additionally live in per-bucket NVMe files and are streamed through the
+GPU bucket-by-bucket during each optimizer step. Completing the run is only half the
+check: a run where the store silently never engaged (flag lost on the way to the
+actor, plugin import failure swallowed) trains just as happily, so `execute` also
+asserts that every rank logged actual streaming steps, on top of the disk-offload
+armed assertion inherited from the base test.
+"""
+
+import glob
+import os
+
+from tests.ci.ci_register import register_cuda_ci
+from tests.ci.metric_history import register_ci_gate
+
+import miles.utils.external_utils.command_utils as U
+
+MODEL_NAME = "Qwen3-4B"
+MODEL_TYPE = "qwen3-4B"
+NUM_GPUS = 4
+OFFLOAD_DIR = "/root/train_offload_disk_stream"
+
+register_cuda_ci(
+    est_time=600,
+    suite="stage-c-4-gpu-h200",
+    labels=["miles-plugin"],
+)
+
+register_ci_gate(metric_key="train/grad_norm")
+register_ci_gate(metric_key="train/ppo_kl")
+register_ci_gate(metric_key="train/train_rollout_logprob_abs_diff")
+register_ci_gate(metric_key="train/train_rollout_kl")
+register_ci_gate(metric_key="rollout/raw_reward")
+
+
+def prepare():
+    U.exec_command("mkdir -p /root/models /root/datasets")
+    U.exec_command(f"hf download Qwen/{MODEL_NAME} --local-dir /root/models/{MODEL_NAME}")
+    U.hf_download_dataset("zhuzilin/dapo-math-17k")
+    U.convert_checkpoint(model_name=MODEL_NAME, megatron_model_type=MODEL_TYPE, num_gpus_per_node=NUM_GPUS)
+
+
+def _assert_offloaded_to_disk():
+    """Every rank must have armed disk offload under its own directory."""
+    logs = glob.glob("/tmp/ray/session_latest/logs/worker-*")
+    assert logs, "no Ray worker logs to check for the disk-offload path"
+
+    armed = set()
+    for path in logs:
+        with open(path, errors="ignore") as f:
+            for line in f:
+                if "Train disk-offload reclaim armed" in line:
+                    armed.add(line.split("reclaim armed for ")[1].split()[0])
+
+    expected = {os.path.join(OFFLOAD_DIR, f"cell0_rank{rank}") for rank in range(NUM_GPUS)}
+    assert armed == expected, f"expected disk offload armed for {sorted(expected)}, saw {sorted(armed)}"
+    print(f"disk offload armed for {len(armed)} ranks under {OFFLOAD_DIR}")
+
+
+def _assert_streamed():
+    """Every rank must have executed real streaming steps.
+
+    The store logs one `NVMe streaming step: ...` line per optimizer step from each
+    training actor process, so the number of distinct worker logs carrying it equals
+    the number of ranks. Reads Ray's post-job worker logs, same as the disk assertion.
+    """
+    logs = glob.glob("/tmp/ray/session_latest/logs/worker-*")
+    assert logs, "no Ray worker logs to check for the streaming path"
+
+    streamed = set()
+    for path in logs:
+        with open(path, errors="ignore") as f:
+            if any("NVMe streaming step:" in line for line in f):
+                streamed.add(path)
+
+    assert (
+        len(streamed) == NUM_GPUS
+    ), f"expected {NUM_GPUS} ranks to log streaming steps, saw {len(streamed)}: {sorted(streamed)}"
+    print(f"optimizer state streaming ran on {len(streamed)} ranks")
+
+
+def execute():
+    ckpt_args = f"--hf-checkpoint /root/models/{MODEL_NAME}/ " f"--ref-load /root/{MODEL_NAME}_torch_dist "
+
+    rollout_args = (
+        "--prompt-data /root/datasets/dapo-math-17k/dapo-math-17k.jsonl "
+        "--input-key prompt "
+        "--label-key label "
+        "--apply-chat-template "
+        "--rollout-shuffle "
+        "--rm-type deepscaler "
+        "--num-rollout 2 "
+        "--rollout-batch-size 4 "
+        "--n-samples-per-prompt 2 "
+        "--rollout-max-response-len 256 "
+        "--rollout-temperature 0.8 "
+        "--global-batch-size 8 "
+        "--balance-data "
+    )
+
+    perf_args = (
+        "--tensor-model-parallel-size 2 "
+        "--sequence-parallel "
+        "--pipeline-model-parallel-size 1 "
+        "--context-parallel-size 1 "
+        "--recompute-granularity full "
+        "--recompute-method uniform "
+        "--recompute-num-layers 1 "
+        "--use-dynamic-batch-size "
+        "--max-tokens-per-gpu 2048 "
+    )
+
+    grpo_args = (
+        "--advantage-estimator grpo "
+        "--use-kl-loss "
+        "--kl-loss-coef 0.00 "
+        "--kl-loss-type low_var_kl "
+        "--entropy-coef 0.00 "
+        "--eps-clip 0.2 "
+        "--eps-clip-high 0.28 "
+    )
+
+    optimizer_args = (
+        "--optimizer adam "
+        "--lr 1e-6 "
+        "--lr-decay-style constant "
+        "--weight-decay 0.1 "
+        "--adam-beta1 0.9 "
+        "--adam-beta2 0.98 "
+    )
+
+    # The feature under test: paused-actor disk offload plus NVMe optimizer-state
+    # streaming during the step.
+    offload_args = (
+        "--offload-train "
+        "--offload-train-target disk "
+        f"--offload-train-disk-dir {OFFLOAD_DIR} "
+        "--offload-train-disk-chunk-mb 64 "
+        "--stream-optimizer-state-to-disk "
+    )
+
+    sglang_args = "--rollout-num-gpus-per-engine 1 " "--sglang-mem-fraction-static 0.6 "
+
+    ci_args = "--ci-test "
+
+    misc_args = (
+        "--attention-dropout 0.0 "
+        "--hidden-dropout 0.0 "
+        "--accumulate-allreduce-grads-in-fp32 "
+        "--attention-softmax-in-fp32 "
+        "--attention-backend flash "
+        "--actor-num-nodes 1 "
+        f"--actor-num-gpus-per-node {NUM_GPUS} "
+        "--colocate "
+    )
+
+    train_args = (
+        f"{ckpt_args} "
+        f"{rollout_args} "
+        f"{optimizer_args} "
+        f"{grpo_args} "
+        f"{offload_args} "
+        f"{U.get_default_wandb_args(__file__)} "
+        f"{perf_args} "
+        f"{sglang_args} "
+        f"{ci_args} "
+        f"{misc_args} "
+    )
+
+    U.execute_train(train_args=train_args, num_gpus_per_node=NUM_GPUS, megatron_model_type=MODEL_TYPE)
+
+    _assert_offloaded_to_disk()
+    _assert_streamed()
+
+
+if __name__ == "__main__":
+    prepare()
+    execute()

--- a/tests/fast/backends/megatron_utils/test_lora_model_branches.py
+++ b/tests/fast/backends/megatron_utils/test_lora_model_branches.py
@@ -70,6 +70,7 @@ class TestSetupModelAndOptimizerLoraBranch:
             megatron_to_hf_mode=mode,
             moe_use_upcycling=False,
             debug_disable_optimizer=False,
+            stream_optimizer_state_to_disk=False,
             load="/some/path",
             pretrained_checkpoint=None,
             # optimizer fields


### PR DESCRIPTION
Targets `main`; #1575 has landed, so this is no longer stacked and the diff is just the two commits below. Pairs with [radixark/Megatron-LM#63](https://github.com/radixark/Megatron-LM/pull/63), which is updated alongside this.

## Why

`--offload-train-target=disk` (#1575) spills the paused actor at phase boundaries. That cannot help when the optimizer state does not fit the GPU *while the step runs* — by the time the Adam kernel launches, everything is resident again. Streaming solves that instead: the fp32 main params and Adam moments live in per-bucket files, and each step brings in one bucket, updates it, and writes it back.

The mechanism was written and validated in Megatron-LM#63 (GLM-5.2 744B on 8xGB300, Qwen3.5-35B-A3B on 8xH200). This PR moves the implementation into miles and shrinks what Megatron has to carry.

## What moves

`megatron/core/optimizer/nvme_state_store.py` -> `miles_plugins/optimizers/nvme_stream.py`, plus the wiring. The five `if self._nvme_state_store is not None` branches inside `DistributedOptimizer` become instance bindings in `_bind()`:

| entry point | binding |
|---|---|
| `step_with_ready_grads` | `store.step()` + the param all-gather tail |
| `reload_model_params` | routed through `store.refresh_main_from_model_params` |
| `state_dict` / `load_state_dict` / `sharded_state_dict` | empties; `save_to`/`load_from` carry the real bytes |

Megatron keeps one thing: the two checkpoint hooks in `checkpointing.py`, which have to be inside `save_checkpoint`/`load_checkpoint` because miles has two save call sites and a missed one shows up as a checkpoint with no optimizer state that silently resumes from zero. Its optimizer diff is empty — #63 is down to one file, +19 lines.

### The per-bucket copy is adapted here, not extracted there

`step()` has to get each bucket's updated mains into the param buffer before `flush()` releases their storage, so it needs a subset version of `_copy_main_params_to_model_params`. The first version of this work extracted one in Megatron and called it. That was wrong on two counts:

1. Its only live caller under streaming was the store. Once `step_with_ready_grads` is bound to `store.step()`, Megatron's own `_copy_main_params_to_model_params` is never reached, so the extracted method existed there purely to serve an out-of-repo caller.
2. It handed out a **partial** operation. The fp8 branch relies on `quantize_param_shard()` having already run over the *whole* fp8 param set, and that is a DP collective which cannot be hoisted into a per-subset method — `plan_buckets` cuts on each rank's own shard sizes, so bucket counts differ across ranks and the calls would not line up. A caller taking only the subset method therefore skips fp8 weight updates with no error. The `# quantized in the above quantize_param_shard function` comment also lost its referent the moment "above" became a different method.

So `_copy_main_to_model_params` lives here, pinned by commit and line range in a comment (`4716f754#L2469-L2519`), following the same convention as `miles/utils/seqlen_balancing.py` and the `miles_plugins/models/*` kernels. The precondition it cannot satisfy is enforced next to it: the constructor rejects fp8 params and the MXFP8 param all-gather. Drift on a Megatron bump is the cost — the pinned link makes it auditable, and the `assert world_range.size == shard_main_param.nelement()` is the tripwire.

miles' own coupling is two lazy imports; `grep -rn nvme_stream miles/` lists all of it.

## Arg surface: one new switch, nothing renamed

```bash
--offload-train --offload-train-target disk      # actor, from #1575
--stream-optimizer-state-to-disk                 # optimizer state, new
--offload-train-disk-dir DIR                     # from #1575, now used by both
--offload-train-disk-chunk-mb N                  # from #1575, now used by both
--stream-optimizer-state-moments {fp32,bf16,...} # advanced, default fp32
```

**Streaming requires `--offload-train-target=disk`, asserted at startup.** Both mechanisms answer the same pressure — not enough HBM for the model — and are only ever deployed as a pair, so that is the only combination covered. Streaming on its own does run (#63's matrix has a passing row for it) and it is the one case where offload has nothing to do, because nothing else wants the training GPUs during rollout; but nothing validates it, and failing at startup beats someone discovering that at 3am. Since the assert makes streaming imply disk offload, `--offload-train-disk-dir` and `--offload-train-disk-chunk-mb` are reused unchanged with each mechanism taking its own subdirectory of the shared root, and #1575's validation block is untouched — the diff against it is two help strings.

The one thing that does not carry over is Megatron's `--optimizer-state-nvme-dir`, where "enable" and "where" were the same knob, so there could be no default location. It also read too close to the three flags miles already inherits (`--offload-optimizer-states`, `--optimizer-cpu-offload`, `--rl-offload-optimizer-during-inference`), two of which are mutually exclusive with this. `stream` encodes the actual distinction: offload happens at phase boundaries, streaming happens inside `optimizer.step()`.

Moments default to `fp32`, so **enabling streaming does not change results** — it is bit-identical to GPU-resident state and only trades step time for memory. `bf16` stays an explicit perf opt-in. The fp8 options are kept (#63 measured fp8e4m3 at ~1.4x bf16's deviation, 6/6 steps NORMAL) but documented as not recommended. The dtype is a constructor argument now, so `getattr(config, "optimizer_state_nvme_moment_dtype", "fp32")` and its silent fallback are gone.

## Guards

Three miles-side readers go through the main params or the master optimizer's per-param state, both of which the store owns — mains have 0-sized storage between steps and the master Adam never holds state. They were unguarded and would have returned emptiness rather than failing:

- `--reset-optimizer-states` (walks `chained_optimizer.optimizer.state.values()`) — the reset would silently do nothing
- `--save-local-weight-checksum` (reads `param.main_param`)
- `--enable-witness` (writes `main_param.data[local_idx]`)

The disk-offload requirement above also subsumes the `--colocate` without `--offload-train` case, which #63 hit as an sglang `resume_memory_occupation` OOM mid-run. Plus the usual exclusions (`--optimizer-cpu-offload`, `--offload-optimizer-states`, precision-aware optimizer, multi-LoRA, non-Adam, non-distributed optimizer).

`_bind` also asserts `reuse_grad_buf_for_mxfp8_param_ag` is off: the bound `step_with_ready_grads` drops Megatron's branch to `_copy_main_params_to_param_buffer`.

## Checkpointing

`save_to`/`load_from` now take the checkpoint *base* and derive their own per-rank subdirectory from the same `relative_dir` the live scratch directory uses, so the layout is spelled once instead of once per repo (Megatron had `rank0000_opt0_0` flat while the store had `rank0/opt0_0` nested). Megatron no longer reads `store.dist_opt` or `store.uid`; the duck-typed contract is four methods. The "this checkpoint has no streamed state" case moves into `load_from`, which is a policy decision — it keeps pre-streaming checkpoints loadable — and now lives in one place.

## Known limits, documented in `docs/advanced/disk-offload.md`

- **Same-topology resume only.** The on-disk layout follows this rank's DP shard with no global parameter identity, so changing TP/PP/DP/EP fails the layout assert rather than resharding. This is a regression against the `torch_dist` path for runs that enable streaming; fixing it means emitting per-param `ShardedTensor`s, which `sharded_state_dict`'s build-the-whole-plan-up-front shape does not currently allow.
- **Checkpoint save is synchronous.** The hook sits before the `--async-save` block in Megatron, so the state copy blocks. Byte volume is unchanged from today (dist-ckpt writes the same 12 B/param, and `bf16` moments write less) — what is lost is the async parallel writer. Separate PR.

## Guard added

`--offload-train-target=disk` sets `TMS_INIT_ENABLE_CPU_BACKUP=0` alongside `TMS_INIT_ENABLE_DISK_BACKUP=1`. A torch_memory_saver built before [fzyzcjy/torch_memory_saver#80](https://github.com/fzyzcjy/torch_memory_saver/pull/80) ignores the disk variable but still honours the cpu one, so `pause()` frees the actor with no backup anywhere and `resume()` returns uninitialized memory. Nothing fails at that point — the weights are garbage and it surfaces a rollout later as `nan` log-probs and then `found NaN in local grad norm for bucket #0`, which reads like a model bug. `actor_factory` now asserts the LD_PRELOADed binary knows the env var (checked against the binary, not the Python API, since the binary is what reads it). `radixark/miles:dev` currently ships 0.0.9.post1 and trips it.

## Testing

Qwen3-30B-A3B RL on 8xH200 (h200-sci-k8s devbox), colocate, TP4/EP8/DP8, bf16, `--num-rollout 3`, dapo-math-17k, eval off. Both arms identical except for streaming. Because streaming is mutually exclusive with `--optimizer-cpu-offload` / `--use-precision-aware-optimizer`, which the launcher's `("H100", 1)` preset adds, those three flags were dropped from **both** arms — so the baseline holds the whole optimizer state on GPU, which is the intended contrast.

**3/3 train steps `outcome=NORMAL valid_step=true` on all 8 ranks in both arms.** Weights round-trip correctly: `train_rollout_logprob_abs_diff` 0.01803 / 0.01864 (baseline) vs 0.01804 / 0.01875 / 0.01896 (streaming).

Peak is `torch.cuda.max_memory_allocated()` bracketing the `actor_train` timer, max over the 8 ranks; steps 1-2 only, since step 0 is lower until Adam creates the moments.

| | baseline (disk offload only) | streaming, bf16 moments | delta |
|---|---|---|---|
| peak allocated | 81.14 / 80.84 GB | **38.86 / 38.64 GB** | **-42.3 GB (-52%)** |
| peak reserved | 95.08 / 95.16 GB | 54.00 / 52.64 GB | -41.8 GB |
| `actor_train` | 39.9 / 42.9 s | 55.6 / 59.4 s | **+16.1 s (+39%)** |
| sleep (offload) | 45.6 / 53.1 s | 8.9 / 8.3 s | -5.3x |
| wake_up | 27.4 s | 3.7 s | -7.4x |

Both numbers check out against what the store reports, so they are not coincidence:

- **Memory.** The store holds 28.5 GB/rank on disk (dense 1.5 + expert 27.0) at 8 B/param with bf16 moments, i.e. 3.56 G params/rank. GPU-resident at 12 B/param that is 42.8 GB; measured reduction 42.3 GB, within 1.2%.
- **Time.** Self-reported I/O per step is 0.9 s (dense) + ~14.3 s (expert) = ~15.2 s/rank against a +16.1 s train-time delta; the rest is the per-bucket Adam launches and the copy.

**The docs' "trades step time for memory" is too pessimistic for the colocated pairing.** With the state already on disk the paused actor has ~43 GB/rank less to spill, so sleep/wake collapse and the cycle gets *faster*:

```
per rollout (train + sleep + wake)   baseline: 41.4 + 49.4 + 27.4 = 118.2 s
                                    streaming: 57.5 +  8.6 +  3.7 =  69.8 s   (-41%)
```

The lazy-moments path is exercised rather than assumed: the expert store reads 13.5 GB on the first step (= 27.0 x 4/8, mains only) and 27.0 GB from the second on. Both ChainedOptimizer members get their own store (`opt0_0` dense / `opt0_1` expert), confirming the per-process uid disambiguation.

Not covered: fp32 moments (should be bit-identical, worth running as the correctness control); checkpoint save/load, since `--save-interval 20` never fires in 3 steps, so the synchronous copy noted above is still unmeasured. One streaming attempt lost its rollout engine at step 3 to sglang's own `couldn't get a response from detokenizer for last 20 s` liveness check; it did not recur on rerun and host RAM was never under pressure (103 of 2009 GB), so it is not attributed to streaming, but not ruled out either.

### Second arm: fp32 moments, 4xB300, fp8 rollout

Closes the fp32-moments control the arm above lists as not covered, on different hardware, topology and rollout precision: 4xB300, TP4/PP1/CP1/EP4, colocate, `--rollout-fp8` with bf16 training, `--offload-train-target disk`, `--num-rollout 3`, dapo-math-17k, 8192 response length, eval off. (This arm also dropped `--use-fault-tolerance` from the launcher, which turned out to be unnecessary: `_FT_DEFAULT_COMPONENTS` is `["rollout"]`, so `"train" not in ft_components` and the witness / weight-checksum auto-enables that streaming rejects never fire. The H200 arm above kept FT on and confirms it: `ft_components ['rollout']`, `enable_witness False`, `save_local_weight_checksum False`, no assert. Streaming is only incompatible with an explicit `--ft-components train`, where refusing is the intended behaviour. Both arms here were symmetric, so the comparison is unaffected.)

Three 3-step runs, `perf 0/1/2` in each, no NaN, no traceback:

| actor offload | streaming | `train_rollout_logprob_abs_diff` (steps 0/1/2) |
|---|---|---|
| cpu | off | 0.0329 / 0.0336 / 0.0350 |
| disk | off | 0.0325 / 0.0340 / 0.0349 |
| disk | **on, fp32 moments** | 0.0328 / 0.0336 / 0.0351 |

Agreement step by step across all three arms, so the fp32 path behaves as documented.

Metric here is the train actor's `allocated_GB` from miles' own `print_memory` at the end of the train phase, plus a 2 s `nvidia-smi` sampler windowed to `actor_train start..end`; steps 1-2 only.

| | baseline (disk offload only) | streaming, fp32 moments | delta |
|---|---|---|---|
| train-actor `allocated_GB` | 132.1 GB | **46.7 GB** | **-85.4 GB (-65%)** |
| device peak, train phases | 173.8-177.9 GiB | 85.4-88.5 GiB | ~-89 GiB |
| `actor_train` | 99.0 / 106.9 s (mean 103.0) | 139.3 / 148.9 s (mean 144.1) | **+41.1 s (+40%)** |

Both deltas check out against what the store reports:

- **Memory.** The store holds 85.4 GB/rank on disk (dense 4.4 + expert 81.0) at 12 B/param with fp32 moments; the measured reduction is 85.4 GB, exact.
- **Time.** Self-reported I/O is 2.4 s (dense) + 37.2 s (expert) = 39.6 s/rank against a +41.1 s train-time delta, so 96% of the added time is the synchronous streaming I/O.
- **Lazy moments, fp32 flavour.** The expert store reads 27.0 GB on the first step (= 81.0/3, mains only, three equal-sized fp32 segments) and 81.0 GB from the second on. With the bf16 arm's 4/8 ratio that pins the per-segment dtype accounting from both directions.

Two things this arm needed that the H200 arm did not. torch_memory_saver at [#80](https://github.com/fzyzcjy/torch_memory_saver/pull/80) — `radixark/miles:dev` ships 0.0.9.post1 and tripped exactly the silent-corruption failure described under Guards, surfacing as `found NaN in local grad norm` in step 0's backward until the matching build was installed. And a one-line sglang fix ([sgl-project/sglang#32385](https://github.com/sgl-project/sglang/pull/32385)) for an unrelated uninitialised-scale bug that makes fp8 rollout unusable for any model with `moe_intermediate / 128 % 4 != 0`, Qwen3-30B-A3B included.

Measurement note: the device-level peak taken over the whole run is ~197 GiB in both arms and shows nothing, because `--sglang-mem-fraction-static 0.7` dominates it. The numbers above window the sampler to the train phases, where the colocated engine is offloaded.

Checkpoint save/load is covered separately, below.

### Checkpoint save and resume

Run on the 8xH200 box, same arms as above, `--save-interval 1` over 2 rollouts to make the hook fire, then a resume from the produced checkpoint. This is the first exercise of `save_to` / `load_from` and therefore of the two `checkpointing.py` hooks in radixark/Megatron-LM#63.

**Save.** Both iterations got their state, and the layout is what `relative_dir` intends:

```
iter_0000001/nvme_opt_state/rank00000/opt0_0/{bucket00000.bin, manifest.json}
                                     /opt0_1/{bucket00000.bin .. bucket00017.bin, manifest.json}
                            rank00001/...   (8 ranks)
```

16 manifests, i.e. 8 ranks x 2 chained members, no collisions — the point of moving the subdirectory naming out of Megatron and into the store, where the live scratch directory already spelled it. Per rank the store is 1 bucket / 1.5 GB (dense) plus 18 buckets / 27.0 GB (expert) at 8 B/param, so 228 GB of optimizer state across the 8 ranks; the whole `iter_0000001` directory is 285 GB. Manifest contents check out: `dtypes` `{main: float32, exp_avg: bfloat16, exp_avg_sq: bfloat16}`, per-group Adam `steps [2, 2]`, and `numel 197,499,904` for the dense bucket, just under the 200M cap.

**Cost of the synchronous copy**, previously unmeasured: `Timer save_model` 57.0 s and 51.8 s. That covers the model dist-ckpt plus the 228 GB `shutil.copyfile` of the store, so it is an upper bound on the streaming part rather than an isolated figure.

**Resume.** Both members load, and the manifest dtype and layout asserts pass:

```
NVMe optimizer state loaded: 18 buckets <- .../iter_0000001/nvme_opt_state/...
NVMe optimizer state loaded:  1 buckets <- .../iter_0000001/nvme_opt_state/...
```

The restored state is actually used, not just copied back. On a cold start the first step reads only the mains — 4/8 of the total with bf16 moments — because Adam has not created the moments yet. After a resume `allocate_moments()` has pre-created them and `load_from` has filled them, so the very first step streams all three segments:

| | first step after | expert store read | wrote |
|---|---|---|---|
| cold start | — | 13.5 GB (= 27.0 x 4/8, mains only) | 27.0 GB |
| **resume** | `iter_0000001` | **27.0 GB (full)** | 27.0 GB |

Training continues normally from there: 2 x `outcome=NORMAL`, `train_rollout_logprob_abs_diff` 0.0186, in the same band as the arms above, job exits succeeded with no asserts and no NaN.

