### PR TITLE
fix: preserve conversation prompts when skipping length filter

### DIFF
--- a/miles/utils/data.py
+++ b/miles/utils/data.py
@@ -91,7 +91,7 @@ def filter_long_prompt(origin_samples: list[Sample], tokenizer, processor, max_l
         logger.warning(
             "Skipping max_length check for list prompt. Set apply_chat_template=True to enable length filtering."
         )
-        return False
+        return origin_samples
 
     if processor:
         filtered_samples = []

--- a/tests/fast/utils/test_data.py
+++ b/tests/fast/utils/test_data.py
@@ -1,0 +1,15 @@
+from miles.utils.data import filter_long_prompt
+from miles.utils.types import Sample
+
+
+def test_filter_long_prompt_preserves_conversation_prompts() -> None:
+    samples = [Sample(prompt=[{"role": "user", "content": "How much?"}])]
+
+    filtered = filter_long_prompt(
+        samples,
+        tokenizer=None,
+        processor=None,
+        max_length=2048,
+    )
+
+    assert filtered is samples


### PR DESCRIPTION
## Summary

- preserve list-form conversation prompts when max-length filtering is skipped
- add a regression test covering conversation-form datasets

## Root cause

`filter_long_prompt()` returned the boolean `False` for list-form prompts. `Dataset` assigned that value to `self.samples`, causing `TypeError: object of type 'bool' has no len()` when rollout began.\n\n## Verification\n\n- reproduced the assertion failure against the affected runtime image\n- verified the focused assertion passes with this patch\n- `python -m compileall -q miles/utils/data.py tests/fast/utils/test_data.py`