### PR TITLE
docker: use FA3 3.0.0 for transformer_engine 2.17

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -73,11 +73,11 @@ RUN case "${TARGETARCH}" in \
 RUN pip install /tmp/wheels/flash_attn-*.whl
 
 # flash-attn hopper (FA3): Hopper-only (sm_90a). Coexists with FA2.
-RUN pip install /tmp/wheels/flash_attn_3-*.whl && \
-    python_path=$(python -c "import site; print(site.getsitepackages()[0])") && \
-    mkdir -p $python_path/flash_attn_3 && \
-    curl -fSL https://raw.githubusercontent.com/Dao-AILab/flash-attention/fbf24f67cf7f6442c5cfb2c1057f4bfc57e72d89/hopper/flash_attn_interface.py \
-      -o $python_path/flash_attn_3/flash_attn_interface.py
+# The wheel ships flash_attn_interface top-level (what transformer_engine imports)
+# plus a flash_attn_3.flash_attn_interface re-export shim, so there is nothing to
+# fetch separately. Do not overwrite the shim with a copy of the full module: it
+# re-runs @torch.library.custom_op("flash_attn_3::...") and double-registers.
+RUN pip install /tmp/wheels/flash_attn_3-*.whl
 
 RUN pip install git+https://github.com/ISEEKYAN/mbridge.git@89eb10887887bc74853f89a4de258c0702932a1c --no-deps
 


### PR DESCRIPTION
## Problem

#1781 bumped transformer_engine to 2.17.0. TE 2.17 moved `use_flash_attn_3` out
of the `window_size`-tuple branch in `cp_p2p_fwd_flash_attn` /
`cp_p2p_bwd_flash_attn`:

```python
# TE 2.12
if use_flash_attn_3 or (v2_3_plus and not v2_7_0_plus):
    fa_forward_kwargs["window_size"] = (-1, -1)        # FA3 took the tuple
elif v2_7_0_plus:
    fa_forward_kwargs["window_size_left"] = -1

# TE 2.17
if v2_3_plus and not v2_7_0_plus:
    fa_forward_kwargs["window_size"] = (-1, -1)
elif use_flash_attn_3 or v2_7_0_plus:                  # FA3 moved here
    fa_forward_kwargs["window_size_left"] = -1
```

The `flash_attn_3` wheel we ship was `3.0.0b1`, whose `_flash_attn_forward` only
accepts a single `window_size` tuple, so every context-parallel path raises
`TypeError: got an unexpected keyword argument 'window_size_left'`. There are
eight such call sites in `context_parallel.py` (five forward, three backward).

TE has no FA3-only kill switch — `NVTE_FLASH_ATTN` disables FA2 and FA3
together. FA2 in the same image (`2.7.4.post1`) already takes the new kwargs, so
only the FA3 path is affected.

### Why this never broke before

TE's version gate is a silent capability gate that also guards the import. Under
TE 2.12 the tuple was correct, so nothing failed. The 2.17 bump is the first
time this pairing is exercised — and main's scheduled docker builds have been
failing since #1781 landed, so `:dev` still carries TE 2.12 and main looks green.

## Change

yueming-yuan/miles-wheels#10 rebuilt the wheel at flash-attention `00756db`
(version `3.0.0`) and replaced the `cu130-x86_64` release asset, so the existing
`pip install /tmp/wheels/flash_attn_3-*.whl` already resolves to it.

This PR only drops the separate `flash_attn_interface.py` fetch. That fetch was a
second revision pin that can drift from the one the extension module was built
at. It is now both unnecessary and harmful:

- the wheel ships `flash_attn_interface` top-level, which is what TE 2.17 imports;
- it also ships `flash_attn_3.flash_attn_interface` as a re-export shim;
- overwriting that shim with a copy of the full module re-runs
  `@torch.library.custom_op("flash_attn_3::_flash_attn_forward")` and
  double-registers the ops.

Nothing in miles or sglang imports `flash_attn_3.flash_attn_interface`.

## Verification

Built and installed on an h200-sci devbox running the miles image itself
(torch 2.11.0+cu130, CUDA 13.0), so the wheel matches the toolchain it ships with:

```
[INFO     | DotProductAttention]: Running with FlashAttention backend (version 3.0.0)
[PASS] all 5 symbols TE imports exist
[PASS] _flash_attn_forward schema takes window_size_left/right  ['SymInt window_size_left=-1', 'SymInt window_size_right=-1']
[PASS] _flash_attn_backward schema takes window_size_left/right  ['SymInt window_size_left=-1', 'SymInt window_size_right=-1']
[PASS] import transformer_engine.pytorch
[PASS] TE sees flash-attn-3 == 3.0.0  fa3_version=3.0.0 v3_0_0_beta=False
[PASS] fwd accepts window_size_left/right kwargs  out=(2, 512, 8, 128) lse=(2, 8, 512)
[PASS] returns (out, softmax_lse, ...) in the order TE indexes [0]/[1]
[PASS] TE DotProductAttention fwd+bwd on FlashAttention backend  grad_finite=True
[PASS] output matches SDPA reference  max_abs_err=0.001953
RESULT: ALL PASS
```

Checked so it is not rediscovered later:

- **Arch coverage is unchanged: `sm_80` + `sm_90a`**, confirmed with `cuobjdump`
  against both the old and new `_C.abi3.so`. `hopper/setup.py` derives arch from
  source-file suffixes and ignores `TORCH_CUDA_ARCH_LIST`, so FA3 has never had
  Blackwell kernels here.
- **`3.0.0b1` -> `3.0.0` is benign.** It flips `FlashAttentionUtils.v3_0_0_beta`
  to `False`; its only consumer appends an "update your flash-attn v3 beta" hint
  to an already-raised `TypeError`. No functional branch depends on it.
- **Return shape is compatible.** `3.0.0` returns
  `(out, softmax_lse, out_accum, softmax_lse_accum)`; TE reads `[0]` and `[1]`
  under `use_flash_attn_3`.

Full CP coverage runs in #1795, which cherry-picks this change.