### PR TITLE
docker: install transformer_engine_torch runtime deps

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -105,6 +105,10 @@ RUN if ls /tmp/wheels/causal_conv1d-*.whl 2>/dev/null | grep -q . && \
     fi
 
 # transformer_engine
+# --no-deps pins the three TE dists to exactly the wheels above, so pip cannot
+# pull a conflicting core dist. That also drops transformer_engine_torch's own
+# runtime deps, which still have to be installed: transformer_engine.pytorch
+# imports onnxscript unconditionally (module/_common -> export -> onnx_extensions).
 RUN --mount=type=bind,source=docker/verify_transformer_engine.py,target=/tmp/verify_transformer_engine.py \
     if [ "${ENABLE_CUDA_13}" = "1" ]; then \
       TE_CORE_DIST=transformer_engine_cu13; \
@@ -120,6 +124,7 @@ RUN --mount=type=bind,source=docker/verify_transformer_engine.py,target=/tmp/ver
     fi && \
     pip uninstall -y transformer-engine transformer-engine-cu12 transformer-engine-cu13 transformer-engine-torch && \
     pip install --force-reinstall --no-deps "$@" && \
+    pip install einops onnx onnxscript pydantic nvdlfw-inspect && \
     python3 /tmp/verify_transformer_engine.py "${TE_CORE_DIST}"
 
 # TE patches (cu13): B300/GB300 FA2 and backward override fixes

--- a/docker/verify_transformer_engine.py
+++ b/docker/verify_transformer_engine.py
@@ -2,10 +2,16 @@
 
 import importlib.metadata as metadata
 import importlib.util
+import re
 import sys
 
 
 VERSION = "2.17.0"
+
+
+def _dist_name(requirement: str) -> str:
+    """'onnxscript', 'torch>=2.1', 'foo; extra == \"bar\"' -> normalised dist name."""
+    return re.split(r"[<>=!~;\[ ]", requirement.strip(), maxsplit=1)[0].lower().replace("_", "-")
 
 
 def verify(core_dist: str) -> None:
@@ -16,14 +22,27 @@ def verify(core_dist: str) -> None:
         "transformer-engine-torch": VERSION,
     }
     actual = {name: metadata.version(name) for name in expected}
-    requires = {
-        requirement.lower().replace("_", "-").replace(" ", "")
-        for requirement in (metadata.requires("transformer-engine-torch") or [])
-    }
+    raw_requires = metadata.requires("transformer-engine-torch") or []
+    requires = {requirement.lower().replace("_", "-").replace(" ", "") for requirement in raw_requires}
 
     assert actual == expected, f"unexpected TransformerEngine versions: {actual}"
     assert f"{core}=={VERSION}" in requires, f"unexpected TransformerEngine torch requirements: {requires}"
     assert importlib.util.find_spec("transformer_engine") is not None, "transformer_engine package not found"
+
+    # The triplet is installed with --no-deps, so nothing makes transformer_engine_torch's
+    # own runtime deps present. Missing ones do not surface until something imports
+    # transformer_engine.pytorch, which is far too late -- a missing onnxscript shipped
+    # a green image that failed every GPU test.
+    missing = []
+    for requirement in raw_requires:
+        name = _dist_name(requirement)
+        if name.startswith("transformer-engine"):
+            continue  # pinned above
+        try:
+            metadata.version(name)
+        except metadata.PackageNotFoundError:
+            missing.append(name)
+    assert not missing, f"transformer_engine_torch runtime deps not installed: {missing}"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

#1796 switched TransformerEngine to the rolling wheels, installed with
`--no-deps`. Pinning the three TE dists to exactly those wheels is the point of
that flag, but it also drops `transformer_engine_torch`'s own runtime
requirements:

```
torch>=2.1, einops, onnxscript, onnx, packaging, pydantic,
nvdlfw-inspect, transformer_engine_cu13==2.17.0
```

`transformer_engine.pytorch` imports `onnxscript` unconditionally on its core
import path:

```
transformer_engine/pytorch/__init__.py:21   -> module/__init__.py
  module/layernorm_linear.py:21 -> module/base.py:23 -> module/_common.py:15
    export.py:61 -> onnx_extensions.py:26 -> import onnxscript
```

so every image built since #1796 dies as soon as anything touches TE — which is
every GPU test:

```
File ".../transformer_engine/pytorch/onnx_extensions.py", line 26, in <module>
    import onnxscript
ModuleNotFoundError: No module named 'onnxscript'
```

Seen on #1795's `stage-c-*-gpu-h200` jobs (run 30190570673), where it takes out
the run before any test body executes. It is not specific to that PR — it
reproduces on any image built from current main.

## Why the build stayed green

`verify_transformer_engine.py` compared versions and metadata and then called

```python
importlib.util.find_spec("transformer_engine")
```

`find_spec` resolves the package directory without importing it, so it succeeds
against an installation that cannot actually be imported. The verifier passed,
the image was pushed, and the failure surfaced hours later in GPU tests.

## Change

- Install the non-TE runtime deps after the pinned `--no-deps` triplet.
- Have the verifier assert that every non-TE requirement of
  `transformer_engine_torch` resolves, so a future `--no-deps` gap fails at the
  layer that introduced it rather than shipping a green image.

Deliberately not dropping `--no-deps`: letting pip resolve the triplet is what
that flag exists to prevent.

## Verification

Ran the new verifier inside a miles image that has the deps, then hid
`onnxscript`'s dist-info to reproduce exactly the state #1796 produces:

```
--- deps present (expect PASS) ---
PASS
--- simulate the #1796 state: hide onnxscript ---
AssertionError: transformer_engine_torch runtime deps not installed: ['onnxscript']
--- restored ---
PASS again
```