### PR TITLE
docs: remove nonexistent --sglang-log-dir flag and /tmp/sglang log path

### DIFF
--- a/docs/developer/debug.md
+++ b/docs/developer/debug.md
@@ -99,7 +99,7 @@ Where to look:
 | Component | Path |
 |---|---|
 | Trainer stdout | wherever you redirected `ray job submit` |
-| SGLang | `/tmp/sglang/*.log` (or `--sglang-log-dir`) |
+| SGLang | inside the Ray worker logs (`~/.ray/session_latest/logs/worker-*.{out,err}`); control verbosity with `--sglang-log-level` |
 | Ray workers | `~/.ray/session_latest/logs/worker-*.{out,err}` |
 | NCCL | `NCCL_DEBUG=INFO NCCL_DEBUG_FILE=/tmp/nccl_%h_%p.log` |
 

--- a/docs/developer/debug.md
+++ b/docs/developer/debug.md
@@ -99,8 +99,8 @@ Where to look:
 | Component | Path |
 |---|---|
 | Trainer stdout | wherever you redirected `ray job submit` |
-| SGLang | inside the Ray worker logs (`~/.ray/session_latest/logs/worker-*.{out,err}`); control verbosity with `--sglang-log-level` |
 | Ray workers | `~/.ray/session_latest/logs/worker-*.{out,err}` |
+| SGLang | inside the Ray worker logs; control verbosity with `--sglang-log-level` |
 | NCCL | `NCCL_DEBUG=INFO NCCL_DEBUG_FILE=/tmp/nccl_%h_%p.log` |
 
 `grep` for these signal phrases:

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -126,7 +126,7 @@ then go investigate the data + model alignment that caused it.
 | What | Path |
 |---|---|
 | Trainer stdout | wherever you redirected `ray job submit` |
-| SGLang server | stdout/stderr captured by Ray under `~/.ray/session_latest/logs/`; pass `--sglang-log-dir <path>` to write to a chosen directory instead |
+| SGLang server | stdout/stderr captured by Ray under `~/.ray/session_latest/logs/`; control verbosity with `--sglang-log-level` |
 | Ray workers | `~/.ray/session_latest/logs/` |
 | wandb | `wandb/` in your run dir, plus the cloud UI |
 

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -104,7 +104,7 @@ Miles fills in whichever side you leave unset.
 | Is the policy learning? | `loss` and `reward` columns in stdout, or wandb |
 | Rollout or train bottleneck? | `rollout=` vs. `train=` timings per iteration |
 | Are GPUs saturated? | `nvidia-smi dmon -s u` |
-| SGLang internals? | `tail -f /tmp/sglang/*.log` |
+| SGLang internals? | Ray worker logs under `~/.ray/session_latest/logs/`; raise verbosity with `--sglang-log-level` |
 | Ranks crashing? | `~/.ray/session_latest/logs/worker-*.err` |
 
 ## Next steps


### PR DESCRIPTION
## Summary

Three docs pages tell users to find or redirect SGLang server logs via mechanisms that do not exist in the codebase:

- `docs/faq.md` ("Where do logs live?") said to pass `--sglang-log-dir <path>` to write SGLang logs to a chosen directory.
- `docs/developer/debug.md` ("Reading logs") pointed at `/tmp/sglang/*.log` (or `--sglang-log-dir`).
- `docs/getting-started/quick-start.md` ("Inspecting a run") suggested `tail -f /tmp/sglang/*.log`.

Neither `--sglang-log-dir` nor a `/tmp/sglang/*.log` default exists:

- The flag is not defined in `miles/utils/arguments.py`, cannot come from the auto-prefixed `--sglang-*` bridge (sglang's `ServerArgs` has no `log_dir` field), and is not among the router arguments in `miles/backends/sglang_utils/arguments.py`. A repo-wide search finds it only in these docs pages.
- The server is launched as a plain `multiprocessing.Process` inside a Ray actor (`launch_server_process` in `miles/backends/sglang_utils/sglang_engine.py`) with no stream redirection, so its output lands in Ray's worker logs under `~/.ray/session_latest/logs/`. The only `/tmp/sglang*` path in the code is a DeepGEMM cache directory (`miles/ray/rollout/server_group.py`), not logs.

All three spots now point at the Ray worker logs and mention the real verbosity knob `--sglang-log-level` (which the docs already use elsewhere, e.g. `user-guide/usage.md`).

## Test plan

- [ ] Docs-only change; verify the three edited pages render correctly in the docs build.