### PR TITLE
fix(docker): install onnxscript alongside the --no-deps TE 2.17 wheels

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -120,6 +120,9 @@ RUN --mount=type=bind,source=docker/verify_transformer_engine.py,target=/tmp/ver
     fi && \
     pip uninstall -y transformer-engine transformer-engine-cu12 transformer-engine-cu13 transformer-engine-torch && \
     pip install --force-reinstall --no-deps "$@" && \
+    # --no-deps skips TE 2.17's runtime deps; onnxscript is imported at
+    # transformer_engine.pytorch import time, so install it explicitly.
+    pip install onnxscript==0.7.1 && \
     python3 /tmp/verify_transformer_engine.py "${TE_CORE_DIST}"
 
 # TE patches (cu13): B300/GB300 FA2 and backward override fixes

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -120,8 +120,6 @@ RUN --mount=type=bind,source=docker/verify_transformer_engine.py,target=/tmp/ver
     fi && \
     pip uninstall -y transformer-engine transformer-engine-cu12 transformer-engine-cu13 transformer-engine-torch && \
     pip install --force-reinstall --no-deps "$@" && \
-    # --no-deps skips TE 2.17's runtime deps; onnxscript is imported at
-    # transformer_engine.pytorch import time, so install it explicitly.
     pip install onnxscript==0.7.1 && \
     python3 /tmp/verify_transformer_engine.py "${TE_CORE_DIST}"
 

--- a/docker/verify_transformer_engine.py
+++ b/docker/verify_transformer_engine.py
@@ -24,6 +24,9 @@ def verify(core_dist: str) -> None:
     assert actual == expected, f"unexpected TransformerEngine versions: {actual}"
     assert f"{core}=={VERSION}" in requires, f"unexpected TransformerEngine torch requirements: {requires}"
     assert importlib.util.find_spec("transformer_engine") is not None, "transformer_engine package not found"
+    # The TE wheels are installed with --no-deps; onnxscript is imported at
+    # transformer_engine.pytorch import time and must be present in the image.
+    assert importlib.util.find_spec("onnxscript") is not None, "onnxscript missing (TE imports it at runtime)"
 
 
 if __name__ == "__main__":

--- a/docker/verify_transformer_engine.py
+++ b/docker/verify_transformer_engine.py
@@ -24,8 +24,6 @@ def verify(core_dist: str) -> None:
     assert actual == expected, f"unexpected TransformerEngine versions: {actual}"
     assert f"{core}=={VERSION}" in requires, f"unexpected TransformerEngine torch requirements: {requires}"
     assert importlib.util.find_spec("transformer_engine") is not None, "transformer_engine package not found"
-    # The TE wheels are installed with --no-deps; onnxscript is imported at
-    # transformer_engine.pytorch import time and must be present in the image.
     assert importlib.util.find_spec("onnxscript") is not None, "onnxscript missing (TE imports it at runtime)"
 
 


### PR DESCRIPTION
## Why

Every stage-c GPU job on `main` (and on every PR that has merged current `main`) dies in ~45s at import time:
<img width="960" height="495" alt="Screenshot 2026-07-26 at 1 08 56 PM" src="https://github.com/user-attachments/assets/43466ac9-7388-471c-9d3b-3706fb3a48ec" />

```
ModuleNotFoundError: No module named 'onnxscript'
```

`main`'s scheduled PR Test went red between 07-25 (run 30163604872, green) and 07-26 (run 30208207783, red). The TE 2.17 wheels are installed with `--no-deps` (docker/Dockerfile:122), which skips TransformerEngine's runtime dependencies — and TE 2.17 imports `onnxscript` at `transformer_engine.pytorch` import time. `docker/verify_transformer_engine.py` only checks wheel versions/metadata, so the image build stayed green while every runtime import fails.

## What

- Install `onnxscript==0.7.1` in the same `RUN` as the TE wheels (right after the `--no-deps` install).
- Add a `find_spec("onnxscript")` assert to `verify_transformer_engine.py`, so a future missing runtime dep fails at image build instead of at the first GPU job.

## Validation

This PR's own CI is the verification: the PR-side image build (#1791) builds the image with this Dockerfile and runs the GPU matrix inside it — the stage-c jobs that currently fail at import should turn green.
