### PR TITLE
[5/5] fix(session): validate published rollout weights

### DIFF
--- a/miles/backends/sglang_utils/router_worker_client.py
+++ b/miles/backends/sglang_utils/router_worker_client.py
@@ -1,0 +1,618 @@
+import logging
+import time
+from enum import StrEnum
+from typing import NamedTuple, TypeVar
+from urllib.parse import quote
+from uuid import UUID
+
+import requests
+from pydantic import BaseModel, ConfigDict, ValidationError
+
+logger = logging.getLogger(__name__)
+
+ROUTER_REQUEST_TIMEOUT_SECONDS = 10.0
+ROUTER_OPERATION_TIMEOUT_SECONDS = 240.0
+ROUTER_POLL_INTERVAL_SECONDS = 1.0
+
+
+class _AcceptedStatus(StrEnum):
+    ACCEPTED = "accepted"
+
+
+class _JobState(StrEnum):
+    PENDING = "pending"
+    PROCESSING = "processing"
+    FAILED = "failed"
+
+
+class RouterWorkerType(StrEnum):
+    """Worker roles accepted by the SGLang router worker API."""
+
+    REGULAR = "regular"
+    PREFILL = "prefill"
+    DECODE = "decode"
+
+
+class RouterWorkerApi(StrEnum):
+    """Worker identity formats used by supported router APIs."""
+
+    URL = "url"
+    UUID = "uuid"
+
+
+class RouterWorkerJobType(StrEnum):
+    """Worker lifecycle jobs reported by the router."""
+
+    ADD = "AddWorker"
+    REMOVE = "RemoveWorker"
+
+
+class RouterWorkerSubmissionRejected(RuntimeError):
+    """The router definitively rejected a worker registration request."""
+
+
+class RouterWorkerSubmissionUnknown(RuntimeError):
+    """The router may have accepted a registration whose response was lost."""
+
+
+class RouterWorkerRegistrationFailed(RuntimeError):
+    """The router's accepted worker registration job failed."""
+
+
+class _RouterModel(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+
+_RouterModelT = TypeVar("_RouterModelT", bound=_RouterModel)
+
+
+class _CreateWorkerRequest(_RouterModel):
+    url: str
+    worker_type: RouterWorkerType
+    bootstrap_port: int | None
+
+
+class _CreateWorkerResponseV02(_RouterModel):
+    status: _AcceptedStatus
+    worker_id: str
+
+
+class _CreateWorkerResponseV03(_RouterModel):
+    status: _AcceptedStatus
+    worker_id: UUID
+    url: str
+    location: str
+
+
+class _DeleteWorkerResponse(_RouterModel):
+    status: _AcceptedStatus
+    worker_id: str
+
+
+class _JobStatus(_RouterModel):
+    job_type: RouterWorkerJobType
+    worker_url: str
+    status: _JobState
+    message: str | None
+
+
+class _WorkerInfo(_RouterModel):
+    id: str
+    url: str
+    is_healthy: bool
+    job_status: _JobStatus | None = None
+
+
+class _ListedWorkerV03(_RouterModel):
+    id: UUID
+    url: str
+
+
+class _ListWorkersResponseV03(_RouterModel):
+    workers: list[_ListedWorkerV03]
+
+
+class RouterWorkerRegistration(NamedTuple):
+    """Identity of one worker accepted by the router.
+
+    Args:
+        worker_id: Worker URL for Router 0.2.x or router-assigned UUID for
+            Router 0.3.x.
+        url: Canonical worker URL supplied during registration.
+    """
+
+    worker_id: str
+    url: str
+
+
+class _RemovalReconciliation(NamedTuple):
+    is_absent: bool
+    registration_observed: bool
+
+
+class RouterWorkerClient:
+    """Manage the asynchronous SGLang Router 0.2.2+ worker lifecycle.
+
+    Args:
+        router_url: Base HTTP URL of the router.
+        worker_api: Worker identity format used by the router.
+        request_timeout_seconds: Timeout for each HTTP request.
+        operation_timeout_seconds: Overall deadline for one add or remove operation.
+        poll_interval_seconds: Delay between worker-state observations.
+    """
+
+    def __init__(
+        self,
+        *,
+        router_url: str,
+        worker_api: RouterWorkerApi,
+        request_timeout_seconds: float,
+        operation_timeout_seconds: float,
+        poll_interval_seconds: float,
+    ) -> None:
+        if request_timeout_seconds <= 0:
+            raise ValueError("request_timeout_seconds must be positive")
+        if operation_timeout_seconds <= 0:
+            raise ValueError("operation_timeout_seconds must be positive")
+        if poll_interval_seconds < 0:
+            raise ValueError("poll_interval_seconds must be nonnegative")
+
+        self._router_url = router_url.rstrip("/")
+        self._worker_api = worker_api
+        self._request_timeout_seconds = request_timeout_seconds
+        self._operation_timeout_seconds = operation_timeout_seconds
+        self._poll_interval_seconds = poll_interval_seconds
+
+    def submit_registration(
+        self,
+        *,
+        worker_url: str,
+        worker_type: RouterWorkerType,
+        bootstrap_port: int | None,
+    ) -> RouterWorkerRegistration:
+        """Submit one worker registration operation.
+
+        Args:
+            worker_url: HTTP URL of the initialized worker.
+            worker_type: SGLang worker type.
+            bootstrap_port: Prefill bootstrap port, or None for other worker types.
+
+        Returns:
+            The accepted router worker identity.
+
+        Raises:
+            RuntimeError: The router rejects the operation or reports invalid state.
+            TimeoutError: Submission exceeds the operation deadline.
+            requests.RequestException: The submission request fails.
+        """
+        request = _CreateWorkerRequest(
+            url=worker_url,
+            worker_type=worker_type,
+            bootstrap_port=bootstrap_port,
+        )
+        deadline = time.monotonic() + self._operation_timeout_seconds
+
+        with requests.Session() as session:
+            response = session.post(
+                f"{self._router_url}/workers",
+                json=request.model_dump(mode="json", exclude_none=True),
+                timeout=self._request_timeout(deadline=deadline, operation="register worker"),
+            )
+            if 400 <= response.status_code < 500 and response.status_code not in {408, 429}:
+                try:
+                    self._require_status(response, expected_status=202, operation="register worker")
+                except (requests.HTTPError, RuntimeError) as error:
+                    raise RouterWorkerSubmissionRejected("Router rejected worker registration") from error
+            self._require_status(response, expected_status=202, operation="register worker")
+
+            if self._worker_api is RouterWorkerApi.URL:
+                accepted_v02 = self._parse_model(
+                    model_type=_CreateWorkerResponseV02,
+                    response=response,
+                    operation="register worker",
+                )
+                if accepted_v02.worker_id != worker_url:
+                    raise RuntimeError(
+                        f"Router accepted worker identity {accepted_v02.worker_id!r}, expected {worker_url!r}"
+                    )
+                return RouterWorkerRegistration(worker_id=accepted_v02.worker_id, url=worker_url)
+
+            accepted_v03 = self._parse_model(
+                model_type=_CreateWorkerResponseV03,
+                response=response,
+                operation="register worker",
+            )
+            if accepted_v03.url != worker_url:
+                raise RuntimeError(f"Router accepted worker URL {accepted_v03.url!r}, expected {worker_url!r}")
+
+            worker_id = str(accepted_v03.worker_id)
+            expected_location = f"/workers/{worker_id}"
+            if accepted_v03.location != expected_location:
+                raise RuntimeError(
+                    f"Router returned worker location {accepted_v03.location!r}, expected {expected_location!r}"
+                )
+
+            return RouterWorkerRegistration(worker_id=worker_id, url=worker_url)
+
+    def wait_until_active(self, *, registration: RouterWorkerRegistration) -> None:
+        """Wait until an accepted worker becomes healthy and routable.
+
+        Args:
+            registration: Accepted worker identity to observe.
+
+        Raises:
+            RuntimeError: The router reports failure or a different worker.
+            TimeoutError: Publication is not confirmed before the deadline.
+        """
+        deadline = time.monotonic() + self._operation_timeout_seconds
+        with requests.Session() as session:
+            self._wait_until_active(
+                session=session,
+                location=self._worker_location(registration=registration),
+                registration=registration,
+                deadline=deadline,
+            )
+
+    def find_registration_by_url(self, *, worker_url: str) -> RouterWorkerRegistration | None:
+        """Wait for a worker URL to become observable in the router registry.
+
+        This reconciles an accepted Router 0.3 registration when the POST
+        response, including its UUID, was lost.
+
+        Args:
+            worker_url: Canonical worker URL supplied during registration.
+
+        Returns:
+            The observed worker identity, or None if it remains absent through
+            the operation deadline.
+        """
+        deadline = time.monotonic() + self._operation_timeout_seconds
+        with requests.Session() as session:
+            while True:
+                response = self._get_router_response(
+                    session=session,
+                    location="/workers",
+                    deadline=deadline,
+                    operation="list workers",
+                )
+                self._require_status(response, expected_status=200, operation="list workers")
+                workers = self._parse_model(
+                    model_type=_ListWorkersResponseV03,
+                    response=response,
+                    operation="list workers",
+                )
+                matches = [worker for worker in workers.workers if worker.url == worker_url]
+                if len(matches) > 1:
+                    raise RuntimeError(f"Router returned multiple workers for URL {worker_url!r}")
+                if matches:
+                    return RouterWorkerRegistration(worker_id=str(matches[0].id), url=worker_url)
+
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    logger.warning("Router worker URL %s did not become observable during cleanup", worker_url)
+                    return None
+                time.sleep(min(self._poll_interval_seconds, remaining))
+
+    def remove(
+        self,
+        *,
+        registration: RouterWorkerRegistration,
+        registration_may_be_pending: bool,
+    ) -> None:
+        """Remove a worker and wait until the router no longer exposes it.
+
+        Args:
+            registration: Accepted worker identity to remove.
+            registration_may_be_pending: Whether registration was accepted but
+                has not yet been observed as active.
+
+        Raises:
+            RuntimeError: The router rejects the operation or reports invalid state.
+            TimeoutError: The router does not confirm removal before the deadline.
+            requests.RequestException: The removal request fails.
+        """
+        location = self._worker_location(registration=registration)
+        deadline = time.monotonic() + self._operation_timeout_seconds
+        with requests.Session() as session:
+            while True:
+                try:
+                    response = session.delete(
+                        f"{self._router_url}{location}",
+                        timeout=self._request_timeout(deadline=deadline, operation="remove worker"),
+                    )
+                except requests.RequestException as error:
+                    logger.warning("Ambiguous router worker removal submission: %s", error)
+                else:
+                    if response.status_code == 404:
+                        if not registration_may_be_pending:
+                            return
+                        logger.warning(
+                            "Router worker %s is not observable while registration may still be pending",
+                            registration.worker_id,
+                        )
+                    elif response.status_code in {408, 429} or response.status_code >= 500:
+                        logger.warning(
+                            "Ambiguous router worker removal response: status=%s",
+                            response.status_code,
+                        )
+                    else:
+                        self._require_status(response, expected_status=202, operation="remove worker")
+                        accepted = self._parse_model(
+                            model_type=_DeleteWorkerResponse,
+                            response=response,
+                            operation="remove worker",
+                        )
+                        if accepted.worker_id != registration.worker_id:
+                            raise RuntimeError(
+                                f"Router accepted removal for worker {accepted.worker_id}, "
+                                f"expected {registration.worker_id}"
+                            )
+                        self._wait_until_absent(
+                            session=session,
+                            location=location,
+                            registration=registration,
+                            deadline=deadline,
+                        )
+                        return
+
+                reconciliation = self._reconcile_ambiguous_removal(
+                    session=session,
+                    location=location,
+                    registration=registration,
+                    registration_may_be_pending=registration_may_be_pending,
+                    deadline=deadline,
+                )
+                if reconciliation.is_absent:
+                    return
+                if reconciliation.registration_observed:
+                    registration_may_be_pending = False
+                self._sleep_or_timeout(deadline=deadline, operation="remove worker")
+
+    def _wait_until_active(
+        self,
+        *,
+        session: requests.Session,
+        location: str,
+        registration: RouterWorkerRegistration,
+        deadline: float,
+    ) -> None:
+        while True:
+            response = self._get_router_response(
+                session=session,
+                location=location,
+                deadline=deadline,
+                operation="observe worker",
+            )
+            if response.status_code == 404:
+                self._sleep_or_timeout(deadline=deadline, operation="register worker")
+                continue
+
+            self._require_status(response, expected_status=200, operation="observe registered worker")
+            worker = self._parse_model(
+                model_type=_WorkerInfo,
+                response=response,
+                operation="observe registered worker",
+            )
+            self._validate_worker(worker=worker, registration=registration)
+
+            if worker.job_status is not None:
+                self._validate_job(
+                    job_status=worker.job_status,
+                    expected_job_type=RouterWorkerJobType.ADD,
+                    registration=registration,
+                )
+                if worker.job_status.status is _JobState.FAILED:
+                    detail = worker.job_status.message or "no failure message"
+                    raise RouterWorkerRegistrationFailed(
+                        f"Router failed to register worker {registration.worker_id}: {detail}"
+                    )
+            elif worker.is_healthy:
+                return
+
+            self._sleep_or_timeout(deadline=deadline, operation="register worker")
+
+    def _wait_until_absent(
+        self,
+        *,
+        session: requests.Session,
+        location: str,
+        registration: RouterWorkerRegistration,
+        deadline: float,
+    ) -> None:
+        while True:
+            response = self._get_router_response(
+                session=session,
+                location=location,
+                deadline=deadline,
+                operation="observe worker",
+            )
+            if response.status_code == 404:
+                return
+
+            self._require_status(response, expected_status=200, operation="observe removed worker")
+            worker = self._parse_model(
+                model_type=_WorkerInfo,
+                response=response,
+                operation="observe removed worker",
+            )
+            self._validate_worker(worker=worker, registration=registration)
+            if worker.job_status is not None:
+                if worker.job_status.job_type is RouterWorkerJobType.ADD:
+                    self._validate_job(
+                        job_status=worker.job_status,
+                        expected_job_type=RouterWorkerJobType.ADD,
+                        registration=registration,
+                    )
+                    self._sleep_or_timeout(deadline=deadline, operation="remove worker")
+                    continue
+                self._validate_job(
+                    job_status=worker.job_status,
+                    expected_job_type=RouterWorkerJobType.REMOVE,
+                    registration=registration,
+                )
+                if worker.job_status.status is _JobState.FAILED:
+                    detail = worker.job_status.message or "no failure message"
+                    raise RuntimeError(f"Router failed to remove worker {registration.worker_id}: {detail}")
+
+            self._sleep_or_timeout(deadline=deadline, operation="remove worker")
+
+    def _reconcile_ambiguous_removal(
+        self,
+        *,
+        session: requests.Session,
+        location: str,
+        registration: RouterWorkerRegistration,
+        registration_may_be_pending: bool,
+        deadline: float,
+    ) -> _RemovalReconciliation:
+        registration_observed = False
+        while True:
+            response = self._get_router_response(
+                session=session,
+                location=location,
+                deadline=deadline,
+                operation="observe worker",
+            )
+            if response.status_code == 404:
+                return _RemovalReconciliation(
+                    is_absent=registration_observed or not registration_may_be_pending,
+                    registration_observed=registration_observed,
+                )
+
+            self._require_status(response, expected_status=200, operation="reconcile removed worker")
+            worker = self._parse_model(
+                model_type=_WorkerInfo,
+                response=response,
+                operation="reconcile removed worker",
+            )
+            self._validate_worker(worker=worker, registration=registration)
+            registration_observed = True
+            if worker.job_status is None:
+                return _RemovalReconciliation(is_absent=False, registration_observed=True)
+
+            if worker.job_status.job_type is RouterWorkerJobType.ADD:
+                if worker.job_status.worker_url != registration.url:
+                    raise RuntimeError(
+                        f"Router reported a job for worker URL "
+                        f"{worker.job_status.worker_url!r}, expected "
+                        f"{registration.url!r}"
+                    )
+                if worker.job_status.status is _JobState.FAILED:
+                    return _RemovalReconciliation(is_absent=False, registration_observed=True)
+                self._sleep_or_timeout(deadline=deadline, operation="remove worker")
+                continue
+
+            self._validate_job(
+                job_status=worker.job_status,
+                expected_job_type=RouterWorkerJobType.REMOVE,
+                registration=registration,
+            )
+            if worker.job_status.status is _JobState.FAILED:
+                detail = worker.job_status.message or "no failure message"
+                raise RuntimeError(f"Router failed to remove worker {registration.worker_id}: {detail}")
+            self._sleep_or_timeout(deadline=deadline, operation="remove worker")
+
+    def _get_router_response(
+        self,
+        *,
+        session: requests.Session,
+        location: str,
+        deadline: float,
+        operation: str,
+    ) -> requests.Response:
+        last_error: requests.RequestException | None = None
+        while time.monotonic() < deadline:
+            try:
+                response = session.get(
+                    f"{self._router_url}{location}",
+                    timeout=self._request_timeout(deadline=deadline, operation=operation),
+                )
+                if response.status_code in {408, 429} or response.status_code >= 500:
+                    self._raise_for_status(response=response, operation=operation)
+                return response
+            except requests.RequestException as error:
+                last_error = error
+                logger.warning("Transient router %s failure: %s", operation, error)
+                self._sleep_or_timeout(deadline=deadline, operation=operation)
+
+        raise TimeoutError(f"Timed out while attempting to {operation}") from last_error
+
+    def _sleep_or_timeout(self, *, deadline: float, operation: str) -> None:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise TimeoutError(f"Timed out after {self._operation_timeout_seconds}s while attempting to {operation}")
+        time.sleep(min(self._poll_interval_seconds, remaining))
+
+    def _request_timeout(self, *, deadline: float, operation: str) -> float:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise TimeoutError(f"Timed out after {self._operation_timeout_seconds}s while attempting to {operation}")
+        return min(self._request_timeout_seconds, remaining)
+
+    def _worker_location(self, *, registration: RouterWorkerRegistration) -> str:
+        if self._worker_api is RouterWorkerApi.URL:
+            return f"/workers/{quote(registration.worker_id, safe='')}"
+        return f"/workers/{registration.worker_id}"
+
+    @staticmethod
+    def _validate_worker(
+        *,
+        worker: _WorkerInfo,
+        registration: RouterWorkerRegistration,
+    ) -> None:
+        if worker.id != registration.worker_id:
+            raise RuntimeError(f"Router returned worker {worker.id}, expected {registration.worker_id}")
+        if worker.url != registration.url:
+            raise RuntimeError(f"Router returned worker URL {worker.url!r}, expected {registration.url!r}")
+
+    @staticmethod
+    def _validate_job(
+        *,
+        job_status: _JobStatus,
+        expected_job_type: RouterWorkerJobType,
+        registration: RouterWorkerRegistration,
+    ) -> None:
+        if job_status.job_type is not expected_job_type:
+            raise RuntimeError(f"Router reported {job_status.job_type} while waiting for {expected_job_type}")
+        if job_status.worker_url != registration.url:
+            raise RuntimeError(
+                f"Router reported a job for worker URL {job_status.worker_url!r}, " f"expected {registration.url!r}"
+            )
+
+    @staticmethod
+    def _parse_model(
+        *,
+        model_type: type[_RouterModelT],
+        response: requests.Response,
+        operation: str,
+    ) -> _RouterModelT:
+        try:
+            return model_type.model_validate_json(response.text)
+        except ValidationError as error:
+            raise RuntimeError(
+                f"Router returned an invalid response while attempting to {operation}: {response.text}"
+            ) from error
+
+    @classmethod
+    def _require_status(
+        cls,
+        response: requests.Response,
+        *,
+        expected_status: int,
+        operation: str,
+    ) -> None:
+        if response.status_code == expected_status:
+            return
+        cls._raise_for_status(response=response, operation=operation)
+        raise RuntimeError(
+            f"Router returned HTTP {response.status_code} while attempting to {operation}; "
+            f"expected HTTP {expected_status}: {response.text}"
+        )
+
+    @staticmethod
+    def _raise_for_status(*, response: requests.Response, operation: str) -> None:
+        try:
+            response.raise_for_status()
+        except requests.HTTPError as error:
+            error.add_note(f"Router response while attempting to {operation}: {response.text}")
+            raise

--- a/miles/backends/sglang_utils/sglang_engine.py
+++ b/miles/backends/sglang_utils/sglang_engine.py
@@ -4,7 +4,6 @@ import logging
 import multiprocessing
 import os
 import time
-from urllib.parse import quote
 
 import requests
 import sglang_router
@@ -14,6 +13,18 @@ from sglang.srt.utils import kill_process_tree
 from urllib3.exceptions import NewConnectionError
 
 from miles.backends.megatron_utils.lora_utils import convert_target_modules_to_hf, lora_base_cpu_backup_enabled
+from miles.backends.sglang_utils.router_worker_client import (
+    ROUTER_OPERATION_TIMEOUT_SECONDS,
+    ROUTER_POLL_INTERVAL_SECONDS,
+    ROUTER_REQUEST_TIMEOUT_SECONDS,
+    RouterWorkerApi,
+    RouterWorkerClient,
+    RouterWorkerRegistration,
+    RouterWorkerRegistrationFailed,
+    RouterWorkerSubmissionRejected,
+    RouterWorkerSubmissionUnknown,
+    RouterWorkerType,
+)
 from miles.ray.ray_actor import RayActor
 from miles.utils.env_report import collect_and_print_node_env_report
 from miles.utils.http_utils import get_host_info
@@ -138,6 +149,10 @@ class SGLangEngine(RayActor):
         self.base_gpu_id = base_gpu_id
         self.sglang_overrides = sglang_overrides or {}
         self.num_gpus_per_engine = num_gpus_per_engine
+        self._is_registered_with_router = False
+        self._router_worker_id: str | None = None
+        self._router_registration_failed = False
+        self._router_registration_submission_unknown = False
 
     def get_topology_info(self) -> dict:
         """Placement facts for the dashboard timeline. ``base_gpu_id`` is
@@ -168,7 +183,23 @@ class SGLangEngine(RayActor):
         router_ip=None,
         router_port=None,
         engine_info_bootstrap_port=None,
+        *,
+        register_with_router: bool,
     ):
+        """Initialize an SGLang server actor.
+
+        Args:
+            dist_init_addr: Distributed initialization address for the engine.
+            port: HTTP server port.
+            nccl_port: NCCL communication port.
+            host: HTTP server host, or None to use the current node address.
+            disaggregation_bootstrap_port: Bootstrap port for a prefill worker.
+            router_ip: Router address, or None to use the configured address.
+            router_port: Router port, or None to use the configured port.
+            engine_info_bootstrap_port: Port used to exchange engine metadata.
+            register_with_router: Whether the initialized engine can be routed
+                immediately.
+        """
         if env_report := self.args.env_report:
             collect_and_print_node_env_report(
                 role="rollout",
@@ -213,11 +244,12 @@ class SGLangEngine(RayActor):
         self.node_rank = server_args_dict["node_rank"]
         self.server_host = server_args_dict["host"]  # with [] if ipv6
         self.server_port = server_args_dict["port"]
+        self.disaggregation_bootstrap_port = server_args_dict.get("disaggregation_bootstrap_port")
 
         if self.args.rollout_external:
             self._init_external(server_args_dict, external_engine_need_check_fields=external_engine_need_check_fields)
         else:
-            self._init_normal(server_args_dict)
+            self._init_normal(server_args_dict, register_with_router=register_with_router)
 
     def _init_external(self, expect_server_args, external_engine_need_check_fields):
         logger.info(f"Use external SGLang engine (rank={self.rank}, expect_server_args={expect_server_args})")
@@ -243,30 +275,104 @@ class SGLangEngine(RayActor):
         actual_server_args = _get_actual_server_args()
         _sanity_check_server_args(actual_server_args, expect_server_args)
 
-    def _init_normal(self, server_args_dict):
+    def _init_normal(self, server_args_dict, *, register_with_router: bool):
         logger.info(f"Launch HttpServerEngineAdapter at: {self.server_host}:{self.server_port}")
         self.process = launch_server_process(ServerArgs(**server_args_dict))
+        if register_with_router:
+            self.register_with_router()
 
-        if self.node_rank == 0 and self.router_ip and self.router_port:
-            if parse(sglang_router.__version__) <= parse("0.2.1") or self.args.use_miles_router:
-                assert (
-                    self.worker_type == "regular"
-                ), "pd disaggregation is not supported in old router or miles router."
-                response = requests.post(
-                    f"http://{self.router_ip}:{self.router_port}/add_worker?url=http://{self.server_host}:{self.server_port}"
+    def register_with_router(self):
+        """Register this initialized engine as an available router worker.
+
+        Recovery can defer this call until current actor weights have been
+        installed, preventing checkpoint-backed replacements from serving.
+        """
+        if (
+            self.args.rollout_external
+            or self.node_rank != 0
+            or not self.router_ip
+            or not self.router_port
+            or self._is_registered_with_router
+        ):
+            return
+
+        worker_url = f"http://{self.server_host}:{self.server_port}"
+        if parse(sglang_router.__version__) <= parse("0.2.1") or self.args.use_miles_router:
+            assert self.worker_type == "regular", "pd disaggregation is not supported in old router or miles router."
+            if self._router_registration_submission_unknown:
+                raise RouterWorkerSubmissionUnknown(
+                    "The router registration submission result is unknown; "
+                    "the engine generation must be replaced before retrying"
                 )
+            self._router_worker_id = worker_url
+            self._router_registration_submission_unknown = True
+            try:
+                response = requests.post(
+                    f"http://{self.router_ip}:{self.router_port}/add_worker?url={worker_url}",
+                    timeout=ROUTER_REQUEST_TIMEOUT_SECONDS,
+                )
+                response.raise_for_status()
+            except requests.HTTPError as error:
+                status_code = error.response.status_code if error.response is not None else None
+                if status_code is not None and 400 <= status_code < 500 and status_code not in {408, 429}:
+                    self._router_worker_id = None
+                    self._router_registration_submission_unknown = False
+                    raise
+                raise RouterWorkerSubmissionUnknown(
+                    "The router registration submission result is unknown; "
+                    "the engine generation must be replaced before retrying"
+                ) from error
+            except requests.RequestException as error:
+                raise RouterWorkerSubmissionUnknown(
+                    "The router registration submission result is unknown; "
+                    "the engine generation must be replaced before retrying"
+                ) from error
+            self._router_registration_submission_unknown = False
+        else:
+            if self._router_registration_submission_unknown:
+                raise RouterWorkerSubmissionUnknown(
+                    "The router registration submission result is unknown; "
+                    "the engine generation must be replaced before retrying"
+                )
+            bootstrap_port = None
+            if self.worker_type == "prefill":
+                if self.disaggregation_bootstrap_port is None:
+                    raise RuntimeError("Prefill worker requires disaggregation_bootstrap_port")
+                bootstrap_port = self.disaggregation_bootstrap_port
+            client = self._router_worker_client()
+            if self._router_worker_id is None:
+                if parse(sglang_router.__version__) < parse("0.3.0"):
+                    self._router_worker_id = worker_url
+                self._router_registration_submission_unknown = True
+                try:
+                    registration = client.submit_registration(
+                        worker_url=worker_url,
+                        worker_type=RouterWorkerType(self.worker_type),
+                        bootstrap_port=bootstrap_port,
+                    )
+                except RouterWorkerSubmissionRejected:
+                    self._router_worker_id = None
+                    self._router_registration_submission_unknown = False
+                    raise
+                except Exception as error:
+                    raise RouterWorkerSubmissionUnknown(
+                        "The router registration submission result is unknown; "
+                        "the engine generation must be replaced before retrying"
+                    ) from error
+                self._router_worker_id = registration.worker_id
+                self._router_registration_submission_unknown = False
             else:
-                payload = {
-                    "url": f"http://{self.server_host}:{self.server_port}",
-                    "worker_type": self.worker_type,
-                }
-                if self.worker_type == "prefill":
-                    payload["bootstrap_port"] = server_args_dict["disaggregation_bootstrap_port"]
-                response = requests.post(
-                    f"http://{self.router_ip}:{self.router_port}/workers",
-                    json=payload,
+                registration = RouterWorkerRegistration(
+                    worker_id=self._router_worker_id,
+                    url=worker_url,
                 )
-            response.raise_for_status()
+            try:
+                client.wait_until_active(registration=registration)
+            except RouterWorkerRegistrationFailed:
+                self._router_registration_failed = True
+                raise
+            self._router_registration_failed = False
+        self._is_registered_with_router = True
 
     def _make_request(self, endpoint: str, payload: dict | None = None):
         """Make a POST request to the specified endpoint with the given payload.
@@ -455,34 +561,59 @@ class SGLangEngine(RayActor):
             return
 
         logger.info(f"Shutdown engine {self.server_host}:{self.server_port}...")
-        if self.node_rank == 0:
-            worker_url = f"http://{self.server_host}:{self.server_port}"
-            response = None
-            if parse(sglang_router.__version__) <= parse("0.2.1") or self.args.use_miles_router:
-                response = requests.post(
-                    f"http://{self.router_ip}:{self.router_port}/remove_worker?url=http://{self.server_host}:{self.server_port}"
-                )
-            elif parse(sglang_router.__version__) < parse("0.3.0"):
-                worker_url = quote(worker_url, safe="")
-                response = requests.delete(f"http://{self.router_ip}:{self.router_port}/workers/{worker_url}")
-            else:
-                try:
-                    all_workers = requests.get(f"http://{self.router_ip}:{self.router_port}/workers").json()["workers"]
-                    for worker in all_workers:
-                        if worker["url"] == worker_url:
-                            worker_id = worker["id"]
-                            response = requests.delete(
-                                f"http://{self.router_ip}:{self.router_port}/workers/{worker_id}"
-                            )
-                            break
-                    else:
-                        logger.warning(f"Worker {worker_url} not found in router during shutdown.")
-                except Exception as e:
-                    logger.warning(f"Failed to fetch workers list or remove worker: {e}")
+        try:
+            if self.node_rank == 0 and (
+                self._is_registered_with_router
+                or self._router_worker_id is not None
+                or self._router_registration_submission_unknown
+            ):
+                worker_url = f"http://{self.server_host}:{self.server_port}"
+                response = None
+                if parse(sglang_router.__version__) <= parse("0.2.1") or self.args.use_miles_router:
+                    response = requests.post(
+                        f"http://{self.router_ip}:{self.router_port}/remove_worker?url={worker_url}",
+                        timeout=ROUTER_REQUEST_TIMEOUT_SECONDS,
+                    )
+                else:
+                    client = self._router_worker_client()
+                    registration_may_be_pending = (
+                        not self._is_registered_with_router
+                        and not self._router_registration_failed
+                        and (self._router_worker_id is not None or self._router_registration_submission_unknown)
+                    )
+                    registration = (
+                        client.find_registration_by_url(worker_url=worker_url)
+                        if self._router_worker_id is None
+                        else RouterWorkerRegistration(
+                            worker_id=self._router_worker_id,
+                            url=worker_url,
+                        )
+                    )
+                    if registration is not None:
+                        client.remove(
+                            registration=registration,
+                            registration_may_be_pending=registration_may_be_pending,
+                        )
+                        self._router_registration_submission_unknown = False
 
-            if response is not None:
-                response.raise_for_status()
-        kill_process_tree(self.process.pid)
+                if response is not None:
+                    response.raise_for_status()
+                    self._router_registration_submission_unknown = False
+                self._is_registered_with_router = False
+                self._router_worker_id = None
+                self._router_registration_failed = False
+        finally:
+            kill_process_tree(self.process.pid)
+
+    def _router_worker_client(self) -> RouterWorkerClient:
+        worker_api = RouterWorkerApi.URL if parse(sglang_router.__version__) < parse("0.3.0") else RouterWorkerApi.UUID
+        return RouterWorkerClient(
+            router_url=f"http://{self.router_ip}:{self.router_port}",
+            worker_api=worker_api,
+            request_timeout_seconds=ROUTER_REQUEST_TIMEOUT_SECONDS,
+            operation_timeout_seconds=ROUTER_OPERATION_TIMEOUT_SECONDS,
+            poll_interval_seconds=ROUTER_POLL_INTERVAL_SECONDS,
+        )
 
     def get_weight_version(self):
         if self.node_rank != 0:

--- a/miles/ray/actor_group.py
+++ b/miles/ray/actor_group.py
@@ -100,6 +100,9 @@ class RayTrainGroup:
         await self.rollout_manager.health_monitoring_pause.remote()
 
         await self._broadcast("update_weights", info=info)
+        await self.rollout_manager.register_recovered_updatable_engines.remote(
+            rollout_engine_generation_ids=info.rollout_engine_generation_ids
+        )
 
     async def reconcile_adapters(self) -> None:
         """Multi-LoRA: reconcile loaded adapters with the controller's active set

--- a/miles/ray/rollout/rollout_manager.py
+++ b/miles/ray/rollout/rollout_manager.py
@@ -7,7 +7,6 @@ import ray
 from sglang.srt.constants import GPU_MEMORY_TYPE_CUDA_GRAPH, GPU_MEMORY_TYPE_KV_CACHE, GPU_MEMORY_TYPE_WEIGHTS
 
 from miles.dashboard import hooks as dashboard_hooks
-from miles.ray.rollout.addr_allocator import PortCursors
 from miles.ray.rollout.debug_data import RolloutDataInjectionUtil, load_debug_rollout_data, save_debug_rollout_data
 from miles.ray.rollout.metrics import log_eval_rollout_data, log_rollout_data
 from miles.ray.rollout.rollout_data_conversion import postprocess_rollout_data
@@ -232,6 +231,7 @@ class RolloutManager:
         if not srv:
             return EnginesAndLock(
                 rollout_engines=[],
+                rollout_engine_generation_ids=[],
                 rollout_engine_lock=self.rollout_engine_lock,
                 has_new_engines=False,
                 engine_gpu_counts=[],
@@ -241,6 +241,7 @@ class RolloutManager:
         await srv.wait_all_engines_alive()
         return EnginesAndLock(
             rollout_engines=[e.actor_handle for e in srv.engines],
+            rollout_engine_generation_ids=[e.generation_id for e in srv.engines],
             rollout_engine_lock=self.rollout_engine_lock,
             has_new_engines=srv.has_new_engines,
             engine_gpu_counts=srv.engine_gpu_counts,
@@ -264,7 +265,22 @@ class RolloutManager:
         if self.rollout_id == -1 or srv is None:
             return
 
-        await srv.recover()
+        await srv.recover(register_with_router=False)
+
+    async def register_recovered_updatable_engines(
+        self,
+        rollout_engine_generation_ids: list[str],
+    ) -> None:
+        """Expose recovered engines included in a successful weight transfer.
+
+        Args:
+            rollout_engine_generation_ids: IDs of the node-0 engine generations
+                that received the completed weight update.
+        """
+        srv = self._get_updatable_server()
+        if srv is not None:
+            await srv.register_pending_engines_with_router(rollout_engine_generation_ids=rollout_engine_generation_ids)
+            self.args._sglang_published_model_names.add(srv.model_name)
 
     def _get_updatable_server(self) -> RolloutServer | None:
         updatable = [srv for srv in self.servers.values() if srv.update_weights]
@@ -282,10 +298,13 @@ class RolloutManager:
     # -------------------------- external start/stop -----------------------------
 
     async def start_cell(self, cell_id: int):
-        port_cursors = PortCursors.empty()
         idx = get_cell_indexer_of_id_map(self.servers)[cell_id]
-        group = self.servers[idx.srv_key].server_groups[idx.group_index]
-        await group.recover(port_cursors=port_cursors, filter_indices=idx.engine_indices)
+        server = self.servers[idx.srv_key]
+        await server.recover_group(
+            group_index=idx.group_index,
+            register_with_router=not server.update_weights,
+            filter_indices=idx.engine_indices,
+        )
 
     async def stop_cell(self, cell_id: int):
         idx = get_cell_indexer_of_id_map(self.servers)[cell_id]
@@ -359,6 +378,7 @@ class RolloutManager:
 @dataclass(frozen=True)
 class EnginesAndLock:
     rollout_engines: list[ray.actor.ActorHandle]
+    rollout_engine_generation_ids: list[str]
     rollout_engine_lock: ray.actor.ActorHandle
     has_new_engines: bool
     engine_gpu_counts: list[int]

--- a/miles/ray/rollout/rollout_server.py
+++ b/miles/ray/rollout/rollout_server.py
@@ -19,10 +19,13 @@ def start_rollout_servers(args, pg) -> dict[str, "RolloutServer"]:
     Returns a dict mapping model name -> ``RolloutServer``.
     """
     config = _resolve_sglang_config(args)
+    args._sglang_default_model_name = config.models[0].name
+    args._sglang_published_model_names = set()
 
     servers: dict[str, RolloutServer] = {}
     gpu_offset = 0
     engine_offset = 0
+    port_cursors = PortCursors.empty()
 
     rollout_pg_offset = _compute_rollout_offset(args)
     megatron_num_gpus = _compute_megatron_num_gpus(args)
@@ -40,7 +43,6 @@ def start_rollout_servers(args, pg) -> dict[str, "RolloutServer"]:
         server_groups: list[ServerGroup] = []
         all_init_handles: list = []
         new_engine_indices_per_group: list[list[int]] = []
-        port_cursors = PortCursors.empty()
 
         for group_cfg in model_cfg.server_groups:
             gpus_per_engine = group_cfg.num_gpus_per_engine
@@ -75,7 +77,7 @@ def start_rollout_servers(args, pg) -> dict[str, "RolloutServer"]:
                 router_port=router_port,
                 update_weights=model_cfg.update_weights,
             )
-            handles, new_engine_indices = group.start_engines(port_cursors)
+            handles, new_engine_indices = group.start_engines(port_cursors, register_with_router=True)
             all_init_handles.extend(handles)
             server_groups.append(group)
             new_engine_indices_per_group.append(new_engine_indices)
@@ -95,6 +97,7 @@ def start_rollout_servers(args, pg) -> dict[str, "RolloutServer"]:
             router_port=router_port,
             model_name=model_cfg.name,
             update_weights=model_cfg.update_weights,
+            _port_cursors=port_cursors,
         )
 
     args.sglang_model_routers = {name: (srv.router_ip, srv.router_port) for name, srv in servers.items()}
@@ -160,6 +163,7 @@ class RolloutServer:
     router_port: int | None = None
     model_name: str = "default"
     update_weights: bool = True
+    _port_cursors: PortCursors = dataclasses.field(default_factory=PortCursors.empty)
 
     @property
     def engines(self) -> list[ServerEngine]:
@@ -194,10 +198,64 @@ class RolloutServer:
             raise ValueError(f"Heterogeneous nodes_per_engine across groups: {values}")
         return values.pop()
 
-    async def recover(self):
-        """Recover dead engines across all active groups, overlapping init."""
-        port_cursors = PortCursors.empty()
-        await asyncio.gather(*[g.recover(port_cursors=port_cursors) for g in self.server_groups])
+    async def recover(self, *, register_with_router: bool) -> None:
+        """Recover dead engines across all active groups.
+
+        Args:
+            register_with_router: Whether each replacement can be routed as
+                soon as initialization completes.
+        """
+        await asyncio.gather(
+            *[
+                g.recover(
+                    port_cursors=self._port_cursors,
+                    register_with_router=register_with_router,
+                )
+                for g in self.server_groups
+            ]
+        )
+
+    async def recover_group(
+        self,
+        *,
+        group_index: int,
+        register_with_router: bool,
+        filter_indices: list[int] | None,
+    ) -> None:
+        """Recover selected slots in one server group.
+
+        Args:
+            group_index: Index of the server group to recover.
+            register_with_router: Whether replacements can be routed as soon
+                as initialization completes.
+            filter_indices: Actor ranks to inspect, or None to inspect all
+                ranks in the group.
+        """
+        await self.server_groups[group_index].recover(
+            port_cursors=self._port_cursors,
+            register_with_router=register_with_router,
+            filter_indices=filter_indices,
+        )
+
+    async def register_pending_engines_with_router(
+        self,
+        *,
+        rollout_engine_generation_ids: list[str],
+    ) -> None:
+        """Register recovered engines that received the completed weight update.
+
+        Args:
+            rollout_engine_generation_ids: IDs of the node-0 engine generations
+                included in the weight publication.
+        """
+        await asyncio.gather(
+            *[
+                group.register_pending_engines_with_router(
+                    rollout_engine_generation_ids=rollout_engine_generation_ids,
+                )
+                for group in self.server_groups
+            ]
+        )
 
     async def offload(self, tags: list[str] | None = None):
         handles = []

--- a/miles/ray/rollout/server_engine.py
+++ b/miles/ray/rollout/server_engine.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from uuid import uuid4
 
 import ray
 from pydantic import BaseModel, ConfigDict
@@ -23,11 +24,17 @@ class ServerEngine:
         self._state = _StateStopped()
 
     def mark_allocated_uninitialized(self, actor_handle: ray.actor.ActorHandle):
-        self._change_state("mark_allocated", _StateStopped, _StateAllocatedUninitialized(actor_handle=actor_handle))
+        self._change_state(
+            "mark_allocated",
+            _StateStopped,
+            _StateAllocatedUninitialized(actor_handle=actor_handle, generation_id=uuid4().hex),
+        )
 
     def mark_alive(self):
         self._change_state(
-            "mark_alive", _StateAllocatedUninitialized, _StateAllocatedAlive(actor_handle=self.actor_handle)
+            "mark_alive",
+            _StateAllocatedUninitialized,
+            _StateAllocatedAlive(actor_handle=self.actor_handle, generation_id=self.generation_id),
         )
 
     def mark_stopped(self):
@@ -37,6 +44,11 @@ class ServerEngine:
     def actor_handle(self) -> ray.actor.ActorHandle:
         assert isinstance(self._state, _StateAllocatedBase)
         return self._state.actor_handle
+
+    @property
+    def generation_id(self) -> str:
+        assert isinstance(self._state, _StateAllocatedBase)
+        return self._state.generation_id
 
     @property
     def is_allocated(self) -> bool:
@@ -72,6 +84,7 @@ class _StateStopped(_StateBase):
 
 class _StateAllocatedBase(_StateBase):
     actor_handle: ray.actor.ActorHandle
+    generation_id: str
 
 
 class _StateAllocatedUninitialized(_StateAllocatedBase):

--- a/miles/ray/rollout/server_group.py
+++ b/miles/ray/rollout/server_group.py
@@ -164,6 +164,7 @@ class ServerGroup:
                 **addr_and_ports[index],
                 router_ip=self.router_ip,
                 router_port=self.router_port,
+                register_with_router=True,
             )
             for index, engine in new_engines
         ]

--- a/miles/ray/rollout/server_group.py
+++ b/miles/ray/rollout/server_group.py
@@ -8,6 +8,10 @@ import ray
 from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 from sglang.srt.constants import GPU_MEMORY_TYPE_WEIGHTS
 
+from miles.backends.sglang_utils.router_worker_client import (
+    RouterWorkerRegistrationFailed,
+    RouterWorkerSubmissionUnknown,
+)
 from miles.backends.sglang_utils.sglang_engine import SGLangEngine
 from miles.ray.rollout.addr_allocator import (
     PortCursors,
@@ -45,6 +49,7 @@ class ServerGroup:
     router_ip: str | None = None
     router_port: int | None = None
     update_weights: bool = True
+    pending_router_registration: set[int] = dataclasses.field(default_factory=set)
 
     @property
     def nodes_per_engine(self):
@@ -56,7 +61,11 @@ class ServerGroup:
         return self.all_engines[:: self.nodes_per_engine]
 
     def start_engines(
-        self, port_cursors: PortCursors, start_indices: list[int] | None = None
+        self,
+        port_cursors: PortCursors,
+        *,
+        register_with_router: bool,
+        start_indices: list[int] | None = None,
     ) -> tuple[list, list[int]]:
         """Create Ray actors, allocate ports, and fire ``engine.init()`` without waiting.
 
@@ -164,10 +173,12 @@ class ServerGroup:
                 **addr_and_ports[index],
                 router_ip=self.router_ip,
                 router_port=self.router_port,
-                register_with_router=True,
+                register_with_router=register_with_router,
             )
             for index, engine in new_engines
         ]
+        if not register_with_router:
+            self.pending_router_registration.update(self._logical_engine_root_indices(new_engine_indices))
         return init_handles, new_engine_indices
 
     # There are two callers, only one of them will exist in a running system
@@ -195,15 +206,47 @@ class ServerGroup:
                     logger.warning(f"Fail to kill engine at index {i} (e: {e})")
             else:
                 logger.info(f"Engine at index {i} is already None")
+            first_index = i - (i % self.nodes_per_engine)
+            self.pending_router_registration.discard(first_index)
             self.all_engines[i].mark_stopped()
 
-    async def recover(self, port_cursors: PortCursors, filter_indices: list[int] | None = None):
+    async def recover(
+        self,
+        port_cursors: PortCursors,
+        *,
+        register_with_router: bool,
+        filter_indices: list[int] | None = None,
+    ) -> None:
+        """Recover complete logical engines that contain stopped actor ranks.
+
+        Args:
+            port_cursors: Persistent per-node port allocation cursors.
+            register_with_router: Whether recovered engines can be routed as
+                soon as initialization completes.
+            filter_indices: Actor ranks to inspect, or None to inspect all
+                ranks.
+        """
         if filter_indices is None:
             filter_indices = [i for i, engine in enumerate(self.all_engines) if not engine.is_allocated]
-        start_indices = [idx for idx in filter_indices if not self.all_engines[idx].is_allocated]
+        stopped_indices = [idx for idx in filter_indices if not self.all_engines[idx].is_allocated]
+        start_indices = self._logical_engine_indices(stopped_indices)
 
-        handles, new_engine_indices = self.start_engines(port_cursors, start_indices=start_indices)
-        await asyncio.gather(*handles)
+        # One failed rank invalidates the distributed SGLang engine. Stop any
+        # surviving ranks so node 0 leaves the router before replacement.
+        allocated_peer_indices = [idx for idx in start_indices if self.all_engines[idx].is_allocated]
+        if allocated_peer_indices:
+            self.stop_engines(engine_indices=allocated_peer_indices)
+
+        handles, new_engine_indices = self.start_engines(
+            port_cursors,
+            register_with_router=register_with_router,
+            start_indices=start_indices,
+        )
+        try:
+            await asyncio.gather(*handles)
+        except BaseException:
+            self.stop_engines(engine_indices=new_engine_indices)
+            raise
 
         release_handles = []
         all_resume_engines = []
@@ -228,6 +271,64 @@ class ServerGroup:
                 )
 
         self.mark_alive(engine_indices=new_engine_indices)
+
+    async def register_pending_engines_with_router(
+        self,
+        *,
+        rollout_engine_generation_ids: list[str],
+    ) -> None:
+        """Expose replacements included in a completed weight publication.
+
+        Args:
+            rollout_engine_generation_ids: IDs of the node-0 engine generations
+                that received the completed weight update.
+        """
+        registrations = [
+            (i, self.all_engines[i].actor_handle, self.all_engines[i].generation_id)
+            for i in sorted(self.pending_router_registration)
+            if self.all_engines[i].is_alive and self.all_engines[i].generation_id in rollout_engine_generation_ids
+        ]
+        results = await asyncio.gather(
+            *[actor_handle.register_with_router.remote() for _, actor_handle, _ in registrations],
+            return_exceptions=True,
+        )
+        failures: list[BaseException] = []
+        quarantined_registrations: list[tuple[int, str]] = []
+        for (engine_index, _, generation_id), result in zip(registrations, results, strict=True):
+            if isinstance(result, BaseException):
+                failures.append(result)
+                error = result.as_instanceof_cause() if isinstance(result, ray.exceptions.RayTaskError) else result
+                if isinstance(error, (RouterWorkerRegistrationFailed, RouterWorkerSubmissionUnknown)):
+                    quarantined_registrations.append((engine_index, generation_id))
+            elif (
+                self.all_engines[engine_index].is_alive
+                and self.all_engines[engine_index].generation_id == generation_id
+            ):
+                self.pending_router_registration.discard(engine_index)
+        for engine_index, generation_id in quarantined_registrations:
+            if (
+                self.all_engines[engine_index].is_alive
+                and self.all_engines[engine_index].generation_id == generation_id
+            ):
+                self.stop_engines(engine_indices=self._logical_engine_indices([engine_index]))
+        if failures:
+            raise failures[0]
+
+    def _logical_engine_indices(self, engine_indices: list[int]) -> list[int]:
+        """Expand actor ranks to the complete logical engines they belong to."""
+        logical_engine_indices: set[int] = set()
+        for engine_index in engine_indices:
+            if not 0 <= engine_index < len(self.all_engines):
+                raise IndexError(f"Engine index {engine_index} is out of range")
+            first_index = engine_index - (engine_index % self.nodes_per_engine)
+            logical_engine_indices.update(
+                range(first_index, min(first_index + self.nodes_per_engine, len(self.all_engines)))
+            )
+        return sorted(logical_engine_indices)
+
+    def _logical_engine_root_indices(self, engine_indices: list[int]) -> list[int]:
+        """Return the node-0 actor index for each referenced logical engine."""
+        return sorted({engine_index - (engine_index % self.nodes_per_engine) for engine_index in engine_indices})
 
     def mark_alive(self, engine_indices: list[int]):
         for engine_index in engine_indices:

--- a/miles/ray/train/group.py
+++ b/miles/ray/train/group.py
@@ -255,6 +255,9 @@ class RayTrainGroup:
     async def update_weights(self, rollout_id: int | None = None):
         """Broadcast weights to rollout engines."""
         log_structured(logger.info, op="update_weights", phase="start", rollout=rollout_id)
+        if self.args.use_fault_tolerance:
+            await self._rollout_manager.recover_updatable_engines.remote()
+
         # TODO: allow using all cells to update weights (instead of first alive cell)
         # Fetch the updatable engines + lock once (like V1 RayActorGroup) so all
         # ranks observe a consistent engine set; the actor releases the lock itself.
@@ -264,6 +267,9 @@ class RayTrainGroup:
         await retry(
             lambda _: self._execute_first_alive("update_weights", info=info),
             max_attempts=_RETRY_MAX_ATTEMPTS,
+        )
+        await self._rollout_manager.register_recovered_updatable_engines.remote(
+            rollout_engine_generation_ids=info.rollout_engine_generation_ids
         )
 
         await self._maybe_log_inference_engine_weight_checksums(rollout_id=rollout_id)

--- a/miles/rollout/generate_utils/generate_endpoint_utils.py
+++ b/miles/rollout/generate_utils/generate_endpoint_utils.py
@@ -2,6 +2,7 @@
 Utils to integrate SGLang's `/generate` endpoint with RL things like Sample.
 """
 
+from argparse import Namespace
 from copy import deepcopy
 from typing import Any
 
@@ -11,6 +12,43 @@ import pybase64
 from miles.utils.lora import LORA_ADAPTER_NAME, is_lora_enabled
 from miles.utils.processing_utils import encode_image_for_rollout_engine
 from miles.utils.types import Sample
+
+
+_DEFAULT_MODEL_ROUTE = "default"
+_UNPUBLISHED_WEIGHT_VERSION = "default"
+
+
+def validate_weight_version(args: Namespace, meta_info: dict[str, Any], *, model_name: str | None) -> None:
+    """Reject an initial checkpoint version from a published, updatable route.
+
+    Args:
+        args: Rollout arguments containing model publication state.
+        meta_info: JSON metadata returned by the inference endpoint.
+        model_name: Explicit routed model, or None/"default" for the default route.
+
+    Raises:
+        RuntimeError: If a published model returns its initial weight version.
+    """
+    if meta_info.get("weight_version") != _UNPUBLISHED_WEIGHT_VERSION:
+        return
+    if (
+        getattr(args, "debug_rollout_only", False)
+        or getattr(args, "debug_skip_weight_update", False)
+        or is_lora_enabled(args)
+    ):
+        return
+
+    published_model_names = getattr(args, "_sglang_published_model_names", None)
+    if published_model_names is None:
+        return
+    route_model_name = (
+        getattr(args, "_sglang_default_model_name", None) if model_name in {None, _DEFAULT_MODEL_ROUTE} else model_name
+    )
+    if route_model_name in published_model_names:
+        raise RuntimeError(
+            f"Received weight_version='default' from updatable model '{route_model_name}' "
+            "after actor weights were published"
+        )
 
 
 # Make this an isolated function because users may want to compute their own
@@ -82,6 +120,8 @@ def compute_request_payload(
 async def update_sample_from_response(
     args, sample: Sample, payload: dict, output: dict, update_loss_mask: bool = False
 ):
+    validate_weight_version(args, output["meta_info"], model_name=None)
+
     # Initialize sample.tokens for the first turn
     if (len(sample.response) == 0) and not sample.tokens:
         sample.tokens = payload["input_ids"]

--- a/miles/rollout/session/samples/merge.py
+++ b/miles/rollout/session/samples/merge.py
@@ -21,6 +21,7 @@ from copy import deepcopy
 from miles.rollout.generate_utils.generate_endpoint_utils import (
     get_indexer_topk_from_response,
     get_routed_experts_from_response,
+    validate_weight_version,
 )
 from miles.rollout.session.types import SessionRecord
 from miles.utils.lifecycle import attach_lifecycle_metadata
@@ -105,6 +106,10 @@ def _compute_sample_from_openai_record(
     args: Namespace, input_sample: Sample, record: SessionRecord, tokenizer, trim_count: int = 0
 ) -> Sample:
     choice = record.response["choices"][0]
+    model_name = record.request.get("model")
+    if model_name is not None and not isinstance(model_name, str):
+        raise TypeError("Session request model must be a string")
+    validate_weight_version(args, choice["meta_info"], model_name=model_name)
 
     prompt_token_ids = record.request.get("input_ids")
     if prompt_token_ids is None:

--- a/miles/rollout/sglang_rollout.py
+++ b/miles/rollout/sglang_rollout.py
@@ -37,6 +37,7 @@ from .generate_utils.generate_endpoint_utils import (
     compute_routing_headers,
     get_indexer_topk_from_response,
     policy_uses_routing_key,
+    validate_weight_version,
 )
 from .generate_utils.prefill_logprobs import recompute_samples_rollout_logprobs_via_prefill
 from .rm_hub import async_rm, batched_async_rm
@@ -216,6 +217,7 @@ async def generate(args: Namespace, sample: Sample, sampling_params: dict[str, A
     headers = compute_routing_headers(args, sample)
 
     output = await post(url, payload, headers=headers)
+    validate_weight_version(args, output["meta_info"], model_name=None)
     if getattr(args, "use_opd", False) and opd_top_k > 0 and opd_top_k_strategy != "only-teacher":
         output_top_logprobs = output.get("meta_info", {}).get("output_top_logprobs")
         if output_top_logprobs is not None:

--- a/miles/utils/test_utils/mock_sglang_engine.py
+++ b/miles/utils/test_utils/mock_sglang_engine.py
@@ -39,6 +39,7 @@ _RECORDING_METHODS: dict[str, Any] = {
     "get_weight_version": "mock-v0",
     "get_parallelism_info": {"_mock": True},
     "get_remote_instance_transfer_engine_info": {"_mock": True},
+    "register_with_router": None,
 }
 
 
@@ -97,6 +98,8 @@ class MockSGLangEngine:
         self._record("init", (), kwargs)
         self._maybe_fault("init")
         self.initialized = True
+        if kwargs["register_with_router"]:
+            self.register_with_router()
         return None
 
     def shutdown(self):

--- a/tests/fast/backends/sglang_utils/test_router_worker_client.py
+++ b/tests/fast/backends/sglang_utils/test_router_worker_client.py
@@ -1,0 +1,751 @@
+import json
+import time
+from collections.abc import Iterator
+from unittest.mock import MagicMock
+from urllib.parse import quote
+
+import pytest
+import requests
+from tests.ci.ci_register import register_cpu_ci
+
+from miles.backends.sglang_utils.router_worker_client import (
+    RouterWorkerApi,
+    RouterWorkerClient,
+    RouterWorkerJobType,
+    RouterWorkerRegistration,
+    RouterWorkerSubmissionRejected,
+    RouterWorkerType,
+)
+
+register_cpu_ci(est_time=1, suite="stage-a-cpu", labels=[])
+
+_WORKER_ID = "12345678-1234-5678-1234-567812345678"
+_WORKER_URL = "http://127.0.0.1:30000"
+_LOCATION = f"/workers/{_WORKER_ID}"
+
+
+class _Response:
+    def __init__(self, status_code: int, payload: object) -> None:
+        self.status_code = status_code
+        self.text = json.dumps(payload)
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise requests.HTTPError(
+                f"HTTP {self.status_code}",
+                response=self,
+            )
+
+
+class _Session:
+    def __init__(
+        self,
+        *,
+        post_responses: list[_Response] | None = None,
+        get_responses: list[_Response] | None = None,
+        delete_responses: list[_Response | requests.RequestException] | None = None,
+    ) -> None:
+        self._post_responses: Iterator[_Response] = iter(post_responses or [])
+        self._get_responses: Iterator[_Response] = iter(get_responses or [])
+        self._delete_responses: Iterator[_Response | requests.RequestException] = iter(delete_responses or [])
+        self.calls: list[tuple[str, str, object | None, float]] = []
+
+    def __enter__(self) -> "_Session":
+        return self
+
+    def __exit__(self, exc_type: object, exc_value: object, traceback: object) -> None:
+        return None
+
+    def post(self, url: str, *, json: object, timeout: float) -> _Response:
+        self.calls.append(("POST", url, json, timeout))
+        return next(self._post_responses)
+
+    def get(self, url: str, *, timeout: float) -> _Response:
+        self.calls.append(("GET", url, None, timeout))
+        return next(self._get_responses)
+
+    def delete(self, url: str, *, timeout: float) -> _Response:
+        self.calls.append(("DELETE", url, None, timeout))
+        response = next(self._delete_responses)
+        if isinstance(response, requests.RequestException):
+            raise response
+        return response
+
+
+def _client(
+    *,
+    worker_api: RouterWorkerApi = RouterWorkerApi.UUID,
+    poll_interval_seconds: float = 0.0,
+) -> RouterWorkerClient:
+    return RouterWorkerClient(
+        router_url="http://router:3000",
+        worker_api=worker_api,
+        request_timeout_seconds=2.0,
+        operation_timeout_seconds=10.0,
+        poll_interval_seconds=poll_interval_seconds,
+    )
+
+
+def _create_response() -> _Response:
+    return _Response(
+        202,
+        {
+            "status": "accepted",
+            "worker_id": str(_WORKER_ID),
+            "url": _WORKER_URL,
+            "location": _LOCATION,
+            "message": "Worker addition queued for background processing",
+        },
+    )
+
+
+def _worker_response(
+    *,
+    is_healthy: bool,
+    job_status: dict[str, object] | None,
+    job_type: RouterWorkerJobType = RouterWorkerJobType.ADD,
+) -> _Response:
+    if job_status is not None:
+        job_status = {
+            "job_type": job_type,
+            "worker_url": _WORKER_URL,
+            **job_status,
+        }
+    return _Response(
+        200,
+        {
+            "id": str(_WORKER_ID),
+            "url": _WORKER_URL,
+            "is_healthy": is_healthy,
+            "job_status": job_status,
+        },
+    )
+
+
+def test_register_waits_for_confirmed_active_worker(monkeypatch: pytest.MonkeyPatch) -> None:
+    session = _Session(
+        post_responses=[_create_response()],
+        get_responses=[
+            _worker_response(
+                is_healthy=False,
+                job_status={"status": "pending", "message": None},
+            ),
+            _worker_response(
+                is_healthy=False,
+                job_status={"status": "processing", "message": None},
+            ),
+            _worker_response(is_healthy=True, job_status=None),
+        ],
+    )
+    monkeypatch.setattr(requests, "Session", lambda: session)
+
+    client = _client()
+    result = client.submit_registration(
+        worker_url=_WORKER_URL,
+        worker_type=RouterWorkerType.REGULAR,
+        bootstrap_port=None,
+    )
+    client.wait_until_active(registration=result)
+
+    assert result == RouterWorkerRegistration(worker_id=_WORKER_ID, url=_WORKER_URL)
+    assert session.calls == [
+        (
+            "POST",
+            "http://router:3000/workers",
+            {"url": _WORKER_URL, "worker_type": "regular"},
+            2.0,
+        ),
+        ("GET", f"http://router:3000{_LOCATION}", None, 2.0),
+        ("GET", f"http://router:3000{_LOCATION}", None, 2.0),
+        ("GET", f"http://router:3000{_LOCATION}", None, 2.0),
+    ]
+
+
+def test_register_reports_background_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    session = _Session(
+        post_responses=[_create_response()],
+        get_responses=[
+            _worker_response(
+                is_healthy=False,
+                job_status={"status": "failed", "message": "Worker already exists"},
+            )
+        ],
+    )
+    monkeypatch.setattr(requests, "Session", lambda: session)
+
+    with pytest.raises(RuntimeError, match="Worker already exists"):
+        client = _client()
+        registration = client.submit_registration(
+            worker_url=_WORKER_URL,
+            worker_type=RouterWorkerType.REGULAR,
+            bootstrap_port=None,
+        )
+        client.wait_until_active(registration=registration)
+
+
+def test_register_rejects_colliding_removal_job(monkeypatch: pytest.MonkeyPatch) -> None:
+    session = _Session(
+        post_responses=[_create_response()],
+        get_responses=[
+            _worker_response(
+                is_healthy=False,
+                job_status={"status": "processing", "message": None},
+                job_type=RouterWorkerJobType.REMOVE,
+            )
+        ],
+    )
+    monkeypatch.setattr(requests, "Session", lambda: session)
+
+    client = _client()
+    registration = client.submit_registration(
+        worker_url=_WORKER_URL,
+        worker_type=RouterWorkerType.REGULAR,
+        bootstrap_port=None,
+    )
+    with pytest.raises(RuntimeError, match="RemoveWorker.*AddWorker"):
+        client.wait_until_active(registration=registration)
+
+
+def test_register_rejects_malformed_acceptance(monkeypatch: pytest.MonkeyPatch) -> None:
+    session = _Session(
+        post_responses=[
+            _Response(
+                202,
+                {
+                    "status": "accepted",
+                    "worker_id": "not-a-uuid",
+                    "url": _WORKER_URL,
+                    "location": "/workers/not-a-uuid",
+                },
+            )
+        ]
+    )
+    monkeypatch.setattr(requests, "Session", lambda: session)
+
+    with pytest.raises(RuntimeError, match="invalid response"):
+        _client().submit_registration(
+            worker_url=_WORKER_URL,
+            worker_type=RouterWorkerType.REGULAR,
+            bootstrap_port=None,
+        )
+
+
+def test_register_marks_client_rejection_as_retryable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = _Session(
+        post_responses=[_Response(400, {"error": "invalid worker"})],
+    )
+    monkeypatch.setattr(requests, "Session", lambda: session)
+
+    with pytest.raises(RouterWorkerSubmissionRejected):
+        _client().submit_registration(
+            worker_url=_WORKER_URL,
+            worker_type=RouterWorkerType.REGULAR,
+            bootstrap_port=None,
+        )
+
+
+def test_register_preserves_ambiguous_server_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = _Session(
+        post_responses=[_Response(503, {"error": "temporarily unavailable"})],
+    )
+    monkeypatch.setattr(requests, "Session", lambda: session)
+
+    with pytest.raises(requests.HTTPError):
+        _client().submit_registration(
+            worker_url=_WORKER_URL,
+            worker_type=RouterWorkerType.REGULAR,
+            bootstrap_port=None,
+        )
+
+
+def test_register_reconciles_transient_not_found_without_second_post(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = _Session(
+        post_responses=[_create_response()],
+        get_responses=[
+            _Response(404, {"error": "not found"}),
+            _worker_response(is_healthy=True, job_status=None),
+        ],
+    )
+    monkeypatch.setattr(requests, "Session", lambda: session)
+
+    client = _client()
+    registration = client.submit_registration(
+        worker_url=_WORKER_URL,
+        worker_type=RouterWorkerType.REGULAR,
+        bootstrap_port=None,
+    )
+    client.wait_until_active(registration=registration)
+
+    assert [call[0] for call in session.calls] == ["POST", "GET", "GET"]
+
+
+@pytest.mark.parametrize("status_code", [408, 429, 503])
+def test_register_retries_transient_observation_error(
+    monkeypatch: pytest.MonkeyPatch,
+    status_code: int,
+) -> None:
+    session = _Session(
+        post_responses=[_create_response()],
+        get_responses=[
+            _Response(status_code, {"error": "temporarily unavailable"}),
+            _worker_response(is_healthy=True, job_status=None),
+        ],
+    )
+    monkeypatch.setattr(requests, "Session", lambda: session)
+
+    client = _client()
+    registration = client.submit_registration(
+        worker_url=_WORKER_URL,
+        worker_type=RouterWorkerType.REGULAR,
+        bootstrap_port=None,
+    )
+    client.wait_until_active(registration=registration)
+
+    assert [call[0] for call in session.calls] == ["POST", "GET", "GET"]
+
+
+def test_register_includes_prefill_bootstrap_port(monkeypatch: pytest.MonkeyPatch) -> None:
+    session = _Session(
+        post_responses=[_create_response()],
+        get_responses=[_worker_response(is_healthy=True, job_status=None)],
+    )
+    monkeypatch.setattr(requests, "Session", lambda: session)
+
+    client = _client()
+    registration = client.submit_registration(
+        worker_url=_WORKER_URL,
+        worker_type=RouterWorkerType.PREFILL,
+        bootstrap_port=40000,
+    )
+    client.wait_until_active(registration=registration)
+
+    assert session.calls[0] == (
+        "POST",
+        "http://router:3000/workers",
+        {
+            "url": _WORKER_URL,
+            "worker_type": "prefill",
+            "bootstrap_port": 40000,
+        },
+        2.0,
+    )
+
+
+def test_find_registration_by_url_waits_until_worker_is_observable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = _Session(
+        get_responses=[
+            _Response(200, {"workers": [], "total": 0}),
+            _Response(
+                200,
+                {
+                    "workers": [
+                        {
+                            "id": _WORKER_ID,
+                            "url": _WORKER_URL,
+                            "is_healthy": False,
+                            "job_status": None,
+                        }
+                    ],
+                    "total": 1,
+                },
+            ),
+        ],
+    )
+    monkeypatch.setattr(requests, "Session", lambda: session)
+
+    registration = _client().find_registration_by_url(worker_url=_WORKER_URL)
+
+    assert registration == RouterWorkerRegistration(worker_id=_WORKER_ID, url=_WORKER_URL)
+    assert session.calls == [
+        ("GET", "http://router:3000/workers", None, 2.0),
+        ("GET", "http://router:3000/workers", None, 2.0),
+    ]
+
+
+def test_remove_waits_until_worker_is_absent(monkeypatch: pytest.MonkeyPatch) -> None:
+    session = _Session(
+        delete_responses=[
+            _Response(
+                202,
+                {
+                    "status": "accepted",
+                    "worker_id": str(_WORKER_ID),
+                    "message": "Worker removal queued for background processing",
+                },
+            )
+        ],
+        get_responses=[
+            _worker_response(
+                is_healthy=False,
+                job_status={"status": "processing", "message": None},
+                job_type=RouterWorkerJobType.REMOVE,
+            ),
+            _Response(404, {"error": "not found"}),
+        ],
+    )
+    monkeypatch.setattr(requests, "Session", lambda: session)
+
+    _client().remove(
+        registration=RouterWorkerRegistration(worker_id=_WORKER_ID, url=_WORKER_URL),
+        registration_may_be_pending=False,
+    )
+
+    assert session.calls == [
+        ("DELETE", f"http://router:3000{_LOCATION}", None, 2.0),
+        ("GET", f"http://router:3000{_LOCATION}", None, 2.0),
+        ("GET", f"http://router:3000{_LOCATION}", None, 2.0),
+    ]
+
+
+def test_remove_waits_for_registration_job_to_yield_to_removal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = _Session(
+        delete_responses=[
+            _Response(
+                202,
+                {
+                    "status": "accepted",
+                    "worker_id": str(_WORKER_ID),
+                },
+            )
+        ],
+        get_responses=[
+            _worker_response(
+                is_healthy=False,
+                job_status={"status": "processing", "message": None},
+                job_type=RouterWorkerJobType.ADD,
+            ),
+            _worker_response(
+                is_healthy=False,
+                job_status={"status": "processing", "message": None},
+                job_type=RouterWorkerJobType.REMOVE,
+            ),
+            _Response(404, {"error": "not found"}),
+        ],
+    )
+    monkeypatch.setattr(requests, "Session", lambda: session)
+
+    _client().remove(
+        registration=RouterWorkerRegistration(worker_id=_WORKER_ID, url=_WORKER_URL),
+        registration_may_be_pending=True,
+    )
+
+    assert session.calls == [
+        ("DELETE", f"http://router:3000{_LOCATION}", None, 2.0),
+        ("GET", f"http://router:3000{_LOCATION}", None, 2.0),
+        ("GET", f"http://router:3000{_LOCATION}", None, 2.0),
+        ("GET", f"http://router:3000{_LOCATION}", None, 2.0),
+    ]
+
+
+def test_remove_retries_not_found_while_registration_is_pending(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = _Session(
+        delete_responses=[
+            _Response(404, {"error": "not found"}),
+            _Response(
+                202,
+                {
+                    "status": "accepted",
+                    "worker_id": str(_WORKER_ID),
+                },
+            ),
+        ],
+        get_responses=[
+            _Response(404, {"error": "not found"}),
+            _worker_response(
+                is_healthy=False,
+                job_status={"status": "processing", "message": None},
+                job_type=RouterWorkerJobType.ADD,
+            ),
+            _worker_response(
+                is_healthy=False,
+                job_status={"status": "processing", "message": None},
+                job_type=RouterWorkerJobType.REMOVE,
+            ),
+            _Response(404, {"error": "not found"}),
+        ],
+    )
+    monkeypatch.setattr(requests, "Session", lambda: session)
+
+    _client().remove(
+        registration=RouterWorkerRegistration(worker_id=_WORKER_ID, url=_WORKER_URL),
+        registration_may_be_pending=True,
+    )
+
+    assert session.calls == [
+        ("DELETE", f"http://router:3000{_LOCATION}", None, 2.0),
+        ("GET", f"http://router:3000{_LOCATION}", None, 2.0),
+        ("DELETE", f"http://router:3000{_LOCATION}", None, 2.0),
+        ("GET", f"http://router:3000{_LOCATION}", None, 2.0),
+        ("GET", f"http://router:3000{_LOCATION}", None, 2.0),
+        ("GET", f"http://router:3000{_LOCATION}", None, 2.0),
+    ]
+
+
+def test_remove_accepts_absence_after_observing_pending_registration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = _Session(
+        delete_responses=[_Response(404, {"error": "not found"})],
+        get_responses=[
+            _worker_response(
+                is_healthy=False,
+                job_status={"status": "processing", "message": None},
+                job_type=RouterWorkerJobType.ADD,
+            ),
+            _Response(404, {"error": "not found"}),
+        ],
+    )
+    monkeypatch.setattr(requests, "Session", lambda: session)
+
+    _client().remove(
+        registration=RouterWorkerRegistration(worker_id=_WORKER_ID, url=_WORKER_URL),
+        registration_may_be_pending=True,
+    )
+
+    assert session.calls == [
+        ("DELETE", f"http://router:3000{_LOCATION}", None, 2.0),
+        ("GET", f"http://router:3000{_LOCATION}", None, 2.0),
+        ("GET", f"http://router:3000{_LOCATION}", None, 2.0),
+    ]
+
+
+def test_remove_retries_delete_for_failed_registration_record(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = _Session(
+        delete_responses=[
+            requests.Timeout("response lost"),
+            _Response(
+                202,
+                {
+                    "status": "accepted",
+                    "worker_id": str(_WORKER_ID),
+                },
+            ),
+        ],
+        get_responses=[
+            _worker_response(
+                is_healthy=False,
+                job_status={"status": "failed", "message": "registration failed"},
+                job_type=RouterWorkerJobType.ADD,
+            ),
+            _Response(404, {"error": "not found"}),
+        ],
+    )
+    monkeypatch.setattr(requests, "Session", lambda: session)
+
+    _client().remove(
+        registration=RouterWorkerRegistration(worker_id=_WORKER_ID, url=_WORKER_URL),
+        registration_may_be_pending=True,
+    )
+
+    assert session.calls == [
+        ("DELETE", f"http://router:3000{_LOCATION}", None, 2.0),
+        ("GET", f"http://router:3000{_LOCATION}", None, 2.0),
+        ("DELETE", f"http://router:3000{_LOCATION}", None, 2.0),
+        ("GET", f"http://router:3000{_LOCATION}", None, 2.0),
+    ]
+
+
+def test_remove_reconciles_ambiguous_submission(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = _Session(
+        delete_responses=[requests.Timeout("response lost")],
+        get_responses=[
+            _worker_response(
+                is_healthy=False,
+                job_status={"status": "processing", "message": None},
+                job_type=RouterWorkerJobType.REMOVE,
+            ),
+            _Response(404, {"error": "not found"}),
+        ],
+    )
+    monkeypatch.setattr(requests, "Session", lambda: session)
+
+    _client().remove(
+        registration=RouterWorkerRegistration(
+            worker_id=_WORKER_ID,
+            url=_WORKER_URL,
+        ),
+        registration_may_be_pending=False,
+    )
+
+    assert session.calls == [
+        ("DELETE", f"http://router:3000{_LOCATION}", None, 2.0),
+        ("GET", f"http://router:3000{_LOCATION}", None, 2.0),
+        ("GET", f"http://router:3000{_LOCATION}", None, 2.0),
+    ]
+
+
+def test_remove_throttles_retry_after_transient_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = _Session(
+        delete_responses=[
+            _Response(503, {"error": "temporarily unavailable"}),
+            _Response(
+                202,
+                {
+                    "status": "accepted",
+                    "worker_id": str(_WORKER_ID),
+                },
+            ),
+        ],
+        get_responses=[
+            _worker_response(is_healthy=True, job_status=None),
+            _Response(404, {"error": "not found"}),
+        ],
+    )
+    monkeypatch.setattr(requests, "Session", lambda: session)
+    sleep = MagicMock()
+    monkeypatch.setattr(time, "sleep", sleep)
+
+    _client(poll_interval_seconds=1.0).remove(
+        registration=RouterWorkerRegistration(worker_id=_WORKER_ID, url=_WORKER_URL),
+        registration_may_be_pending=False,
+    )
+
+    assert session.calls == [
+        ("DELETE", f"http://router:3000{_LOCATION}", None, 2.0),
+        ("GET", f"http://router:3000{_LOCATION}", None, 2.0),
+        ("DELETE", f"http://router:3000{_LOCATION}", None, 2.0),
+        ("GET", f"http://router:3000{_LOCATION}", None, 2.0),
+    ]
+    sleep.assert_called_once_with(1.0)
+
+
+def test_remove_reports_background_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    session = _Session(
+        delete_responses=[
+            _Response(
+                202,
+                {
+                    "status": "accepted",
+                    "worker_id": str(_WORKER_ID),
+                },
+            )
+        ],
+        get_responses=[
+            _worker_response(
+                is_healthy=False,
+                job_status={"status": "failed", "message": "remove failed"},
+                job_type=RouterWorkerJobType.REMOVE,
+            )
+        ],
+    )
+    monkeypatch.setattr(requests, "Session", lambda: session)
+
+    with pytest.raises(RuntimeError, match="remove failed"):
+        _client().remove(
+            registration=RouterWorkerRegistration(worker_id=_WORKER_ID, url=_WORKER_URL),
+            registration_may_be_pending=False,
+        )
+
+
+def test_remove_is_idempotent_when_worker_is_already_absent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = _Session(delete_responses=[_Response(404, {"error": "not found"})])
+    monkeypatch.setattr(requests, "Session", lambda: session)
+
+    _client().remove(
+        registration=RouterWorkerRegistration(worker_id=_WORKER_ID, url=_WORKER_URL),
+        registration_may_be_pending=False,
+    )
+
+    assert session.calls == [
+        ("DELETE", f"http://router:3000{_LOCATION}", None, 2.0),
+    ]
+
+
+def test_remove_reports_definitive_client_rejection(monkeypatch: pytest.MonkeyPatch) -> None:
+    session = _Session(delete_responses=[_Response(400, {"error": "invalid worker"})])
+    monkeypatch.setattr(requests, "Session", lambda: session)
+
+    with pytest.raises(requests.HTTPError, match="400"):
+        _client().remove(
+            registration=RouterWorkerRegistration(worker_id=_WORKER_ID, url=_WORKER_URL),
+            registration_may_be_pending=False,
+        )
+
+    assert session.calls == [
+        ("DELETE", f"http://router:3000{_LOCATION}", None, 2.0),
+    ]
+
+
+def test_router_0_2_uses_encoded_worker_url_identity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    encoded_worker_url = quote(_WORKER_URL, safe="")
+    location = f"/workers/{encoded_worker_url}"
+    session = _Session(
+        post_responses=[
+            _Response(
+                202,
+                {
+                    "status": "accepted",
+                    "worker_id": _WORKER_URL,
+                },
+            )
+        ],
+        get_responses=[
+            _Response(
+                200,
+                {
+                    "id": _WORKER_URL,
+                    "url": _WORKER_URL,
+                    "is_healthy": True,
+                    "job_status": None,
+                },
+            ),
+            _Response(404, {"error": "not found"}),
+        ],
+        delete_responses=[
+            _Response(
+                202,
+                {
+                    "status": "accepted",
+                    "worker_id": _WORKER_URL,
+                },
+            )
+        ],
+    )
+    monkeypatch.setattr(requests, "Session", lambda: session)
+
+    client = _client(worker_api=RouterWorkerApi.URL)
+    registration = client.submit_registration(
+        worker_url=_WORKER_URL,
+        worker_type=RouterWorkerType.REGULAR,
+        bootstrap_port=None,
+    )
+    client.wait_until_active(registration=registration)
+    client.remove(registration=registration, registration_may_be_pending=False)
+
+    assert registration == RouterWorkerRegistration(
+        worker_id=_WORKER_URL,
+        url=_WORKER_URL,
+    )
+    assert session.calls == [
+        (
+            "POST",
+            "http://router:3000/workers",
+            {"url": _WORKER_URL, "worker_type": "regular"},
+            2.0,
+        ),
+        ("GET", f"http://router:3000{location}", None, 2.0),
+        ("DELETE", f"http://router:3000{location}", None, 2.0),
+        ("GET", f"http://router:3000{location}", None, 2.0),
+    ]

--- a/tests/fast/backends/sglang_utils/test_sglang_engine_router.py
+++ b/tests/fast/backends/sglang_utils/test_sglang_engine_router.py
@@ -1,0 +1,437 @@
+from argparse import Namespace
+from unittest.mock import MagicMock, call
+
+import pytest
+import requests
+import sglang_router
+from tests.ci.ci_register import register_cpu_ci
+
+import miles.backends.sglang_utils.sglang_engine as sglang_engine_module
+from miles.backends.sglang_utils.router_worker_client import (
+    RouterWorkerRegistration,
+    RouterWorkerRegistrationFailed,
+    RouterWorkerSubmissionRejected,
+    RouterWorkerSubmissionUnknown,
+    RouterWorkerType,
+)
+from miles.backends.sglang_utils.sglang_engine import SGLangEngine
+
+register_cpu_ci(est_time=1, suite="stage-a-cpu", labels=[])
+
+_WORKER_ID = "12345678-1234-5678-1234-567812345678"
+_WORKER_URL = "http://127.0.0.1:30000"
+
+
+def _engine() -> SGLangEngine:
+    engine = SGLangEngine.__new__(SGLangEngine)
+    engine.args = Namespace(rollout_external=False, use_miles_router=False)
+    engine.node_rank = 0
+    engine.router_ip = "127.0.0.1"
+    engine.router_port = 3000
+    engine.server_host = "127.0.0.1"
+    engine.server_port = 30000
+    engine.worker_type = "regular"
+    engine.disaggregation_bootstrap_port = None
+    engine._is_registered_with_router = False
+    engine._router_worker_id = None
+    engine._router_registration_failed = False
+    engine._router_registration_submission_unknown = False
+    return engine
+
+
+def test_registration_timeout_reconciles_same_worker_without_second_post(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(sglang_router, "__version__", "0.3.2")
+    client = MagicMock()
+    registration = RouterWorkerRegistration(worker_id=_WORKER_ID, url=_WORKER_URL)
+    client.submit_registration.return_value = registration
+    client.wait_until_active.side_effect = [TimeoutError("pending"), None]
+    engine = _engine()
+    monkeypatch.setattr(engine, "_router_worker_client", MagicMock(return_value=client))
+
+    with pytest.raises(TimeoutError, match="pending"):
+        engine.register_with_router()
+    assert engine._is_registered_with_router is False
+    assert engine._router_worker_id == _WORKER_ID
+
+    engine.register_with_router()
+
+    assert client.submit_registration.call_count == 1
+    assert client.wait_until_active.call_count == 2
+    assert engine._is_registered_with_router is True
+
+
+def test_unknown_submission_result_blocks_duplicate_post(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(sglang_router, "__version__", "0.3.2")
+    client = MagicMock()
+    client.submit_registration.side_effect = TimeoutError("response lost")
+    engine = _engine()
+    monkeypatch.setattr(engine, "_router_worker_client", MagicMock(return_value=client))
+
+    with pytest.raises(RouterWorkerSubmissionUnknown, match="generation must be replaced"):
+        engine.register_with_router()
+    with pytest.raises(RouterWorkerSubmissionUnknown, match="generation must be replaced"):
+        engine.register_with_router()
+
+    assert client.submit_registration.call_count == 1
+    assert engine._is_registered_with_router is False
+
+    registration = RouterWorkerRegistration(worker_id=_WORKER_ID, url=_WORKER_URL)
+    client.find_registration_by_url.return_value = registration
+    engine.process = Namespace(pid=123)
+    kill_process_tree = MagicMock()
+    monkeypatch.setattr(sglang_engine_module, "kill_process_tree", kill_process_tree)
+
+    engine.shutdown()
+
+    client.find_registration_by_url.assert_called_once_with(worker_url=_WORKER_URL)
+    client.remove.assert_called_once_with(
+        registration=registration,
+        registration_may_be_pending=True,
+    )
+    assert engine._router_registration_submission_unknown is False
+    kill_process_tree.assert_called_once_with(123)
+
+
+def test_router_0_2_unknown_submission_retains_url_identity_for_cleanup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(sglang_router, "__version__", "0.2.2")
+    client = MagicMock()
+    client.submit_registration.side_effect = TimeoutError("response lost")
+    engine = _engine()
+    engine.process = Namespace(pid=123)
+    monkeypatch.setattr(engine, "_router_worker_client", MagicMock(return_value=client))
+    kill_process_tree = MagicMock()
+    monkeypatch.setattr(sglang_engine_module, "kill_process_tree", kill_process_tree)
+
+    with pytest.raises(RouterWorkerSubmissionUnknown, match="generation must be replaced"):
+        engine.register_with_router()
+    with pytest.raises(RouterWorkerSubmissionUnknown, match="generation must be replaced"):
+        engine.register_with_router()
+
+    assert client.submit_registration.call_count == 1
+    assert engine._router_worker_id == _WORKER_URL
+
+    engine.shutdown()
+
+    client.find_registration_by_url.assert_not_called()
+    client.remove.assert_called_once_with(
+        registration=RouterWorkerRegistration(worker_id=_WORKER_URL, url=_WORKER_URL),
+        registration_may_be_pending=True,
+    )
+    kill_process_tree.assert_called_once_with(123)
+
+
+def test_external_wrapper_recovery_does_not_require_router_publication(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    engine = _engine()
+    engine.args.rollout_external = True
+    engine.args.env_report = None
+    engine.args.sglang_router_ip = "127.0.0.1"
+    engine.args.sglang_router_port = 3000
+    engine.rank = 0
+    engine.base_gpu_id = 0
+    engine.sglang_overrides = {}
+    engine.num_gpus_per_engine = 1
+    server_args = {
+        "node_rank": 0,
+        "host": "127.0.0.1",
+        "port": 30000,
+    }
+    compute_server_args = MagicMock(return_value=(server_args, ["host", "port"]))
+    monkeypatch.setattr(sglang_engine_module, "_compute_server_args", compute_server_args)
+    init_external = MagicMock()
+    monkeypatch.setattr(engine, "_init_external", init_external)
+
+    engine.init(
+        dist_init_addr="127.0.0.1:29500",
+        port=30000,
+        nccl_port=29501,
+        host="127.0.0.1",
+        register_with_router=False,
+    )
+
+    init_external.assert_called_once_with(
+        server_args,
+        external_engine_need_check_fields=["host", "port"],
+    )
+
+
+def test_normal_initialization_can_defer_router_registration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    engine = _engine()
+    process = object()
+    server_args = object()
+    server_args_factory = MagicMock(return_value=server_args)
+    launch_server_process = MagicMock(return_value=process)
+    register_with_router = MagicMock()
+    monkeypatch.setattr(sglang_engine_module, "ServerArgs", server_args_factory)
+    monkeypatch.setattr(sglang_engine_module, "launch_server_process", launch_server_process)
+    monkeypatch.setattr(engine, "register_with_router", register_with_router)
+
+    engine._init_normal({"model_path": "model"}, register_with_router=False)
+
+    server_args_factory.assert_called_once_with(model_path="model")
+    launch_server_process.assert_called_once_with(server_args)
+    register_with_router.assert_not_called()
+    assert engine.process is process
+
+
+def test_normal_initialization_registers_immediately(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    engine = _engine()
+    process = object()
+    server_args = object()
+    server_args_factory = MagicMock(return_value=server_args)
+    launch_server_process = MagicMock(return_value=process)
+    register_with_router = MagicMock()
+    monkeypatch.setattr(sglang_engine_module, "ServerArgs", server_args_factory)
+    monkeypatch.setattr(sglang_engine_module, "launch_server_process", launch_server_process)
+    monkeypatch.setattr(engine, "register_with_router", register_with_router)
+
+    engine._init_normal({"model_path": "model"}, register_with_router=True)
+
+    server_args_factory.assert_called_once_with(model_path="model")
+    launch_server_process.assert_called_once_with(server_args)
+    register_with_router.assert_called_once_with()
+    assert engine.process is process
+
+
+def test_router_0_2_registration_uses_async_worker_client(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(sglang_router, "__version__", "0.2.2")
+    client = MagicMock()
+    registration = RouterWorkerRegistration(worker_id=_WORKER_URL, url=_WORKER_URL)
+    client.submit_registration.return_value = registration
+    engine = _engine()
+    monkeypatch.setattr(engine, "_router_worker_client", MagicMock(return_value=client))
+
+    engine.register_with_router()
+
+    client.submit_registration.assert_called_once_with(
+        worker_url=_WORKER_URL,
+        worker_type=RouterWorkerType.REGULAR,
+        bootstrap_port=None,
+    )
+    client.wait_until_active.assert_called_once_with(registration=registration)
+    assert engine._is_registered_with_router is True
+
+
+def test_router_0_2_1_registration_keeps_synchronous_contract(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(sglang_router, "__version__", "0.2.1")
+    response = MagicMock()
+    post = MagicMock(return_value=response)
+    monkeypatch.setattr(requests, "post", post)
+    engine = _engine()
+    router_worker_client = MagicMock()
+    monkeypatch.setattr(engine, "_router_worker_client", router_worker_client)
+
+    engine.register_with_router()
+
+    post.assert_called_once_with(
+        "http://127.0.0.1:3000/add_worker?url=http://127.0.0.1:30000",
+        timeout=10.0,
+    )
+    response.raise_for_status.assert_called_once_with()
+    router_worker_client.assert_not_called()
+    assert engine._is_registered_with_router is True
+
+
+def test_router_0_2_1_unknown_submission_blocks_retry_and_allows_cleanup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(sglang_router, "__version__", "0.2.1")
+    remove_response = MagicMock()
+    post = MagicMock(side_effect=[requests.Timeout("response lost"), remove_response])
+    monkeypatch.setattr(requests, "post", post)
+    engine = _engine()
+    engine.process = Namespace(pid=123)
+    kill_process_tree = MagicMock()
+    monkeypatch.setattr(sglang_engine_module, "kill_process_tree", kill_process_tree)
+
+    with pytest.raises(RouterWorkerSubmissionUnknown, match="generation must be replaced"):
+        engine.register_with_router()
+    with pytest.raises(RouterWorkerSubmissionUnknown, match="generation must be replaced"):
+        engine.register_with_router()
+
+    assert engine._router_worker_id == _WORKER_URL
+    assert engine._is_registered_with_router is False
+
+    engine.shutdown()
+
+    assert post.call_args_list == [
+        call(
+            "http://127.0.0.1:3000/add_worker?url=http://127.0.0.1:30000",
+            timeout=10.0,
+        ),
+        call(
+            "http://127.0.0.1:3000/remove_worker?url=http://127.0.0.1:30000",
+            timeout=10.0,
+        ),
+    ]
+    remove_response.raise_for_status.assert_called_once_with()
+    assert engine._router_worker_id is None
+    kill_process_tree.assert_called_once_with(123)
+
+
+@pytest.mark.parametrize(
+    ("router_version", "worker_id"),
+    [
+        ("0.2.2", _WORKER_URL),
+        ("0.3.2", _WORKER_ID),
+    ],
+)
+def test_definitive_submission_rejection_remains_retryable(
+    monkeypatch: pytest.MonkeyPatch,
+    router_version: str,
+    worker_id: str,
+) -> None:
+    monkeypatch.setattr(sglang_router, "__version__", router_version)
+    client = MagicMock()
+    registration = RouterWorkerRegistration(worker_id=worker_id, url=_WORKER_URL)
+    client.submit_registration.side_effect = [
+        RouterWorkerSubmissionRejected("registration rejected"),
+        registration,
+    ]
+    engine = _engine()
+    monkeypatch.setattr(engine, "_router_worker_client", MagicMock(return_value=client))
+
+    with pytest.raises(RouterWorkerSubmissionRejected, match="registration rejected"):
+        engine.register_with_router()
+
+    assert engine._router_registration_submission_unknown is False
+    assert engine._router_worker_id is None
+
+    engine.register_with_router()
+
+    assert client.submit_registration.call_count == 2
+    client.wait_until_active.assert_called_once_with(registration=registration)
+    assert engine._is_registered_with_router is True
+
+
+def test_background_registration_failure_retains_identity_without_resubmission(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(sglang_router, "__version__", "0.3.2")
+    client = MagicMock()
+    registration = RouterWorkerRegistration(worker_id=_WORKER_ID, url=_WORKER_URL)
+    client.submit_registration.return_value = registration
+    client.wait_until_active.side_effect = [
+        RouterWorkerRegistrationFailed("registration failed"),
+        RouterWorkerRegistrationFailed("registration failed"),
+    ]
+    engine = _engine()
+    monkeypatch.setattr(engine, "_router_worker_client", MagicMock(return_value=client))
+
+    with pytest.raises(RouterWorkerRegistrationFailed, match="registration failed"):
+        engine.register_with_router()
+
+    assert engine._router_worker_id == _WORKER_ID
+    assert engine._is_registered_with_router is False
+    assert engine._router_registration_failed is True
+
+    with pytest.raises(RouterWorkerRegistrationFailed, match="registration failed"):
+        engine.register_with_router()
+
+    assert client.submit_registration.call_count == 1
+    assert client.wait_until_active.call_count == 2
+    assert engine._is_registered_with_router is False
+    assert engine._router_registration_failed is True
+
+    engine.process = Namespace(pid=123)
+    kill_process_tree = MagicMock()
+    monkeypatch.setattr(sglang_engine_module, "kill_process_tree", kill_process_tree)
+
+    engine.shutdown()
+
+    client.remove.assert_called_once_with(
+        registration=registration,
+        registration_may_be_pending=False,
+    )
+    kill_process_tree.assert_called_once_with(123)
+
+
+def test_router_0_2_1_registration_failure_remains_retryable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(sglang_router, "__version__", "0.2.1")
+    first_response = MagicMock()
+    first_response.status_code = 400
+    first_response.raise_for_status.side_effect = requests.HTTPError(
+        "registration failed",
+        response=first_response,
+    )
+    second_response = MagicMock()
+    post = MagicMock(side_effect=[first_response, second_response])
+    monkeypatch.setattr(requests, "post", post)
+    engine = _engine()
+
+    with pytest.raises(requests.HTTPError, match="registration failed"):
+        engine.register_with_router()
+
+    assert engine._is_registered_with_router is False
+
+    engine.register_with_router()
+
+    assert post.call_count == 2
+    assert second_response.raise_for_status.call_count == 1
+    assert engine._is_registered_with_router is True
+
+
+def test_shutdown_kills_process_when_router_removal_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(sglang_router, "__version__", "0.3.2")
+    client = MagicMock()
+    client.remove.side_effect = RuntimeError("remove failed")
+    engine = _engine()
+    engine._is_registered_with_router = True
+    engine._router_worker_id = _WORKER_ID
+    engine.process = Namespace(pid=123)
+    monkeypatch.setattr(engine, "_router_worker_client", MagicMock(return_value=client))
+    kill_process_tree = MagicMock()
+    monkeypatch.setattr(sglang_engine_module, "kill_process_tree", kill_process_tree)
+
+    with pytest.raises(RuntimeError, match="remove failed"):
+        engine.shutdown()
+
+    client.remove.assert_called_once_with(
+        registration=RouterWorkerRegistration(worker_id=_WORKER_ID, url=_WORKER_URL),
+        registration_may_be_pending=False,
+    )
+    kill_process_tree.assert_called_once_with(123)
+
+
+def test_shutdown_removes_accepted_worker_before_activation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(sglang_router, "__version__", "0.3.2")
+    client = MagicMock()
+    engine = _engine()
+    engine._router_worker_id = _WORKER_ID
+    engine.process = Namespace(pid=123)
+    monkeypatch.setattr(engine, "_router_worker_client", MagicMock(return_value=client))
+    kill_process_tree = MagicMock()
+    monkeypatch.setattr(sglang_engine_module, "kill_process_tree", kill_process_tree)
+
+    engine.shutdown()
+
+    client.remove.assert_called_once_with(
+        registration=RouterWorkerRegistration(
+            worker_id=_WORKER_ID,
+            url=_WORKER_URL,
+        ),
+        registration_may_be_pending=True,
+    )
+    assert engine._router_worker_id is None
+    kill_process_tree.assert_called_once_with(123)

--- a/tests/fast/ray/rollout/real_ray/test_fault_tolerance.py
+++ b/tests/fast/ray/rollout/real_ray/test_fault_tolerance.py
@@ -37,7 +37,7 @@ def _build_group(
 
 
 def _start(group: ServerGroup) -> None:
-    handles, indices = group.start_engines(PortCursors.empty())
+    handles, indices = group.start_engines(PortCursors.empty(), register_with_router=True)
     ray.get(handles)
     group.mark_alive(indices)
 
@@ -74,7 +74,11 @@ class TestKillAndRecover:
         group.all_engines[0].mark_stopped()
 
         try:
-            await group.recover(port_cursors=PortCursors.empty(), filter_indices=[0])
+            await group.recover(
+                port_cursors=PortCursors.empty(),
+                register_with_router=False,
+                filter_indices=[0],
+            )
             # New actor for slot 0
             assert group.all_engines[0].is_allocated
             assert group.all_engines[0].actor_handle is not original_handles[0]
@@ -104,7 +108,7 @@ class TestKillAndRecover:
             group.all_engines[i].mark_stopped()
 
         try:
-            await group.recover(port_cursors=PortCursors.empty())
+            await group.recover(port_cursors=PortCursors.empty(), register_with_router=False)
             for i in (0, 2):
                 assert group.all_engines[i].is_allocated
                 assert group.all_engines[i].actor_handle is not old[i]
@@ -129,7 +133,11 @@ class TestKillAndRecover:
         group.all_engines[0].mark_stopped()
 
         try:
-            await group.recover(port_cursors=PortCursors.empty(), filter_indices=[0])
+            await group.recover(
+                port_cursors=PortCursors.empty(),
+                register_with_router=False,
+                filter_indices=[0],
+            )
             calls = ray.get(group.all_engines[0].actor_handle.get_calls.remote())
             method_names = [c[0] for c in calls]
             # init → release → resume(tags=[WEIGHTS])
@@ -189,8 +197,16 @@ class TestConcurrentRecover:
         try:
             # Real concurrent recover via asyncio.gather
             await asyncio.gather(
-                a.recover(port_cursors=PortCursors.empty(), filter_indices=[0]),
-                b.recover(port_cursors=PortCursors.empty(), filter_indices=[0]),
+                a.recover(
+                    port_cursors=PortCursors.empty(),
+                    register_with_router=False,
+                    filter_indices=[0],
+                ),
+                b.recover(
+                    port_cursors=PortCursors.empty(),
+                    register_with_router=False,
+                    filter_indices=[0],
+                ),
             )
             assert a.all_engines[0].is_allocated
             assert b.all_engines[0].is_allocated

--- a/tests/fast/ray/rollout/real_ray/test_rollout_manager.py
+++ b/tests/fast/ray/rollout/real_ray/test_rollout_manager.py
@@ -188,12 +188,13 @@ class TestStartStopCell:
         tmp_path,
         patch_low_level,
     ):
-        """stop_cell(0) → start_cell(0) drives a real ``recover()`` that spawns
-        a fresh mock actor in place of the killed one."""
+        """start_cell() restores an updatable actor without routing it early."""
         args = _make_test_args(tmp_path, models=[("actor", True)])
         pg = placement_group_factory(2)
 
         manager = _make_manager(args, pg)
+        assert manager.args._sglang_default_model_name == "actor"
+        assert manager.args._sglang_published_model_names == set()
         eal_before = await manager.get_updatable_engines_and_lock()
         actor0_before = eal_before.rollout_engines[0]
 
@@ -205,6 +206,8 @@ class TestStartStopCell:
 
         assert actor0_after is not actor0_before, "start_cell must produce a fresh actor"
         assert ray.get(actor0_after.health_generate.remote(timeout=1.0)) is True
+        calls = ray.get(actor0_after.get_calls.remote())
+        assert [call[0] for call in calls] == ["init", "health_generate"]
 
     async def test_stop_cell_targets_high_id_correctly(
         self,
@@ -474,6 +477,20 @@ class TestRecoverUpdatableEngines:
         assert slot0.is_allocated
         assert slot0.actor_handle is not actor0_before
         assert ray.get(slot0.actor_handle.health_generate.remote(timeout=1.0)) is True
+        calls_before_registration = ray.get(slot0.actor_handle.get_calls.remote())
+        assert [call[0] for call in calls_before_registration] == ["init", "health_generate"]
+
+        await manager.register_recovered_updatable_engines(
+            rollout_engine_generation_ids=[slot0.generation_id],
+        )
+
+        assert manager.args._sglang_published_model_names == {"actor"}
+        calls_after_registration = ray.get(slot0.actor_handle.get_calls.remote())
+        assert [call[0] for call in calls_after_registration] == [
+            "init",
+            "health_generate",
+            "register_with_router",
+        ]
 
 
 @pytest.mark.asyncio

--- a/tests/fast/ray/rollout/real_ray/test_rollout_server.py
+++ b/tests/fast/ray/rollout/real_ray/test_rollout_server.py
@@ -33,7 +33,7 @@ def _build_group(
 
 
 def _start_group(group: ServerGroup) -> None:
-    handles, _ = group.start_engines(PortCursors.empty())
+    handles, _ = group.start_engines(PortCursors.empty(), register_with_router=True)
     ray.get(handles)
 
 

--- a/tests/fast/ray/rollout/real_ray/test_server_group.py
+++ b/tests/fast/ray/rollout/real_ray/test_server_group.py
@@ -41,7 +41,7 @@ class TestStartEnginesShortCircuits:
         # PG made but unused — start_engines should bail before scheduling.
         pg = placement_group_factory(2)
         group = _build_group(pg_tuple=pg, num_engines=2, debug_train_only=True)
-        handles, indices = group.start_engines(PortCursors.empty())
+        handles, indices = group.start_engines(PortCursors.empty(), register_with_router=True)
         assert handles == [] and indices == []
         assert group.has_new_engines is False
         for e in group.all_engines:
@@ -51,7 +51,7 @@ class TestStartEnginesShortCircuits:
         # PG is unused in this short-circuit path; min size 1 keeps Ray happy.
         pg = placement_group_factory(1)
         group = _build_group(pg_tuple=pg, num_engines=0, worker_type="placeholder")
-        handles, indices = group.start_engines(PortCursors.empty())
+        handles, indices = group.start_engines(PortCursors.empty(), register_with_router=True)
         assert handles == [] and indices == []
         assert group.has_new_engines is False
 
@@ -65,7 +65,7 @@ class TestStartEnginesRealActors:
         pg = placement_group_factory(2)
         group = _build_group(pg_tuple=pg, num_engines=2)
 
-        handles, indices = group.start_engines(PortCursors.empty())
+        handles, indices = group.start_engines(PortCursors.empty(), register_with_router=True)
         assert sorted(indices) == [0, 1]
         assert group.has_new_engines is True
         # Wait for init.remote() to actually complete on each actor.
@@ -88,7 +88,11 @@ class TestStartEnginesRealActors:
         pg = placement_group_factory(4)
         group = _build_group(pg_tuple=pg, num_engines=4)
 
-        handles, indices = group.start_engines(PortCursors.empty(), start_indices=[1, 3])
+        handles, indices = group.start_engines(
+            PortCursors.empty(),
+            register_with_router=True,
+            start_indices=[1, 3],
+        )
         assert sorted(indices) == [1, 3]
         ray.get(handles)
 
@@ -107,12 +111,12 @@ class TestStartEnginesRealActors:
         group = _build_group(pg_tuple=pg, num_engines=2)
 
         # First call: allocates both slots.
-        handles, _ = group.start_engines(PortCursors.empty())
+        handles, _ = group.start_engines(PortCursors.empty(), register_with_router=True)
         ray.get(handles)
         first_handles = [e.actor_handle for e in group.all_engines]
 
         # Second call with no start_indices: should skip both.
-        handles2, indices2 = group.start_engines(PortCursors.empty())
+        handles2, indices2 = group.start_engines(PortCursors.empty(), register_with_router=True)
         assert handles2 == [] and indices2 == []
         for first, e in zip(first_handles, group.all_engines, strict=True):
             assert e.actor_handle is first  # still the same actor
@@ -132,7 +136,7 @@ class TestStopEnginesRealKill:
     def test_stop_marks_engines_stopped_and_actor_truly_dies(self, patched_sglang_engine, placement_group_factory):
         pg = placement_group_factory(2)
         group = _build_group(pg_tuple=pg, num_engines=2)
-        handles, _ = group.start_engines(PortCursors.empty())
+        handles, _ = group.start_engines(PortCursors.empty(), register_with_router=True)
         ray.get(handles)
 
         actors = [e.actor_handle for e in group.all_engines]
@@ -154,7 +158,7 @@ class TestStopEnginesRealKill:
         We use ``set_fault`` to make shutdown raise on its next invocation."""
         pg = placement_group_factory(2)
         group = _build_group(pg_tuple=pg, num_engines=2)
-        handles, _ = group.start_engines(PortCursors.empty())
+        handles, _ = group.start_engines(PortCursors.empty(), register_with_router=True)
         ray.get(handles)
 
         # Plant a one-shot shutdown failure on engine 1.
@@ -189,7 +193,7 @@ class TestStartEnginesRealAllocator:
         pg = placement_group_factory(2)
         group = _build_group(pg_tuple=pg, num_engines=2)
 
-        handles, indices = group.start_engines(PortCursors.empty())
+        handles, indices = group.start_engines(PortCursors.empty(), register_with_router=True)
         assert sorted(indices) == [0, 1]
         ray.get(handles)
 
@@ -246,11 +250,11 @@ class TestStartEnginesRealAllocator:
         b = _build_group(pg_tuple=pg_b, num_engines=2)
 
         cursors = PortCursors.empty()
-        handles_a, _ = a.start_engines(cursors)
+        handles_a, _ = a.start_engines(cursors, register_with_router=True)
         ray.get(handles_a)
         # `cursors` now carries the next-free-port state from group A.
 
-        handles_b, _ = b.start_engines(cursors)
+        handles_b, _ = b.start_engines(cursors, register_with_router=True)
         ray.get(handles_b)
 
         kwargs_a = ray.get([e.actor_handle.get_init_kwargs.remote() for e in a.all_engines])

--- a/tests/fast/ray/rollout/test_addr_allocator.py
+++ b/tests/fast/ray/rollout/test_addr_allocator.py
@@ -237,6 +237,28 @@ class TestSharedPortCursorsAcrossGroups:
         ports_b = {addrs_b[r]["port"] for r in addrs_b} | {addrs_b[r]["nccl_port"] for r in addrs_b}
         assert ports_a.isdisjoint(ports_b), f"port overlap A={ports_a} B={ports_b}"
 
+    def test_recovery_cursor_does_not_reuse_previous_engine_url(self, patch_ray_get):
+        args = make_args(num_gpus_per_node=8, sglang_dp_size=1)
+        cursors = PortCursors.empty()
+        engines = [(0, fake_engine(port_seed=0))]
+
+        first_addrs, next_cursors = allocate_rollout_engine_addr_and_ports_normal(
+            args=args,
+            rollout_engines=engines,
+            num_gpus_per_engine=1,
+            base_port=cursors.next_base_port(),
+        )
+        cursors.assign(next_cursors)
+        second_addrs, _ = allocate_rollout_engine_addr_and_ports_normal(
+            args=args,
+            rollout_engines=engines,
+            num_gpus_per_engine=1,
+            base_port=cursors.next_base_port(),
+        )
+
+        assert first_addrs[0]["host"] == second_addrs[0]["host"]
+        assert first_addrs[0]["port"] != second_addrs[0]["port"]
+
 
 class TestRankPortConsistency:
     """rank ↔ addr_and_ports index consistency in ``ServerGroup.start_engines``.

--- a/tests/fast/ray/rollout/test_rollout_server.py
+++ b/tests/fast/ray/rollout/test_rollout_server.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+from unittest.mock import AsyncMock
+
 import pytest
 from tests.fast.ray.rollout.conftest import make_args, make_dataclass_group
 
+from miles.ray.rollout.addr_allocator import PortCursors
 from miles.ray.rollout.rollout_server import (
     RolloutServer,
     _compute_megatron_num_gpus,
@@ -107,6 +110,29 @@ class TestRolloutServerCrossGroupProperties:
         b = make_dataclass_group(num_engines=2, num_gpus_per_engine=2, gpu_offset=4)
         srv = RolloutServer(server_groups=[a, b])
         assert srv.engine_gpu_offsets == [0, 1, 4, 6]
+
+
+@pytest.mark.asyncio
+async def test_recovery_reuses_persistent_port_cursor() -> None:
+    observed_base_ports: list[int] = []
+
+    async def recover(*, port_cursors, register_with_router):
+        assert register_with_router is False
+        observed_base_ports.append(port_cursors.next_base_port())
+        port_cursors.assign(PortCursors(_values={0: port_cursors.next_base_port() + 100}))
+
+    group = make_dataclass_group(num_engines=1)
+    group.recover = AsyncMock(side_effect=recover)
+    server = RolloutServer(
+        server_groups=[group],
+        _port_cursors=PortCursors(_values={0: 20000}),
+    )
+
+    await server.recover(register_with_router=False)
+    await server.recover(register_with_router=False)
+
+    assert observed_base_ports == [20000, 20100]
+    assert server._port_cursors == PortCursors(_values={0: 20200})
 
 
 class TestRolloutServerNodesPerEngineHeterogeneity:

--- a/tests/fast/ray/rollout/test_server_engine.py
+++ b/tests/fast/ray/rollout/test_server_engine.py
@@ -1,0 +1,20 @@
+from unittest.mock import MagicMock
+
+from ray.actor import ActorHandle
+
+from miles.ray.rollout.server_engine import ServerEngine
+
+
+def test_generation_id_tracks_one_actor_allocation() -> None:
+    engine = ServerEngine()
+
+    engine.mark_allocated_uninitialized(MagicMock(spec=ActorHandle))
+    first_generation_id = engine.generation_id
+    engine.mark_alive()
+
+    assert engine.generation_id == first_generation_id
+
+    engine.mark_stopped()
+    engine.mark_allocated_uninitialized(MagicMock(spec=ActorHandle))
+
+    assert engine.generation_id != first_generation_id

--- a/tests/fast/ray/rollout/test_server_group_recovery.py
+++ b/tests/fast/ray/rollout/test_server_group_recovery.py
@@ -1,0 +1,261 @@
+from collections.abc import Callable
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from tests.ci.ci_register import register_cpu_ci
+from tests.fast.ray.rollout.conftest import make_args
+
+from miles.backends.sglang_utils.router_worker_client import (
+    RouterWorkerRegistrationFailed,
+    RouterWorkerSubmissionUnknown,
+)
+from miles.ray.rollout.addr_allocator import PortCursors
+from miles.ray.rollout.server_group import ServerGroup
+
+register_cpu_ci(est_time=1, suite="stage-a-cpu", labels=[])
+
+
+class _RemoteRegistration:
+    def __init__(
+        self,
+        failures: list[BaseException] | None = None,
+        on_call: Callable[[], None] | None = None,
+    ) -> None:
+        self.calls = 0
+        self._failures = iter(failures or [])
+        self._on_call = on_call
+
+    async def remote(self) -> None:
+        self.calls += 1
+        if self._on_call is not None:
+            self._on_call()
+        failure = next(self._failures, None)
+        if failure is not None:
+            raise failure
+
+
+def _actor(registration: _RemoteRegistration) -> SimpleNamespace:
+    return SimpleNamespace(
+        register_with_router=registration,
+    )
+
+
+def _group(*, all_engines: list[object], num_gpus_per_engine: int = 1) -> ServerGroup:
+    return ServerGroup(
+        args=make_args(num_gpus_per_node=8),
+        pg=None,
+        all_engines=all_engines,
+        num_gpus_per_engine=num_gpus_per_engine,
+        has_new_engines=False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_recover_replaces_complete_multinode_engine_when_one_rank_stops() -> None:
+    engines = [
+        SimpleNamespace(is_allocated=True, mark_alive=MagicMock()),
+        SimpleNamespace(is_allocated=False, mark_alive=MagicMock()),
+        SimpleNamespace(is_allocated=True, mark_alive=MagicMock()),
+        SimpleNamespace(is_allocated=True, mark_alive=MagicMock()),
+    ]
+    group = _group(all_engines=engines, num_gpus_per_engine=16)
+
+    def stop_engines(*, engine_indices: list[int]) -> None:
+        assert engine_indices == [0]
+        engines[0].is_allocated = False
+
+    group.stop_engines = MagicMock(side_effect=stop_engines)
+
+    def start_engines(
+        port_cursors: PortCursors,
+        *,
+        register_with_router: bool,
+        start_indices: list[int] | None,
+    ) -> tuple[list[object], list[int]]:
+        assert port_cursors == PortCursors.empty()
+        assert register_with_router is False
+        assert start_indices == [0, 1]
+        return [], [0, 1]
+
+    group.start_engines = MagicMock(side_effect=start_engines)
+
+    await group.recover(
+        port_cursors=PortCursors.empty(),
+        register_with_router=False,
+        filter_indices=[1],
+    )
+
+    assert group.stop_engines.call_count == 1
+    assert group.start_engines.call_count == 1
+    assert engines[0].mark_alive.call_count == 1
+    assert engines[1].mark_alive.call_count == 1
+    assert engines[2].mark_alive.call_count == 0
+    assert engines[3].mark_alive.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_recover_stops_new_engines_when_initialization_fails() -> None:
+    engines = [
+        SimpleNamespace(is_allocated=False, mark_alive=MagicMock()),
+        SimpleNamespace(is_allocated=False, mark_alive=MagicMock()),
+    ]
+    group = _group(all_engines=engines, num_gpus_per_engine=16)
+
+    async def failed_initialization() -> None:
+        raise RouterWorkerRegistrationFailed("registration failed")
+
+    group.start_engines = MagicMock(return_value=([failed_initialization()], [0, 1]))
+    group.stop_engines = MagicMock()
+
+    with pytest.raises(RouterWorkerRegistrationFailed, match="registration failed"):
+        await group.recover(
+            port_cursors=PortCursors.empty(),
+            register_with_router=True,
+            filter_indices=[0],
+        )
+
+    group.stop_engines.assert_called_once_with(engine_indices=[0, 1])
+    assert engines[0].mark_alive.call_count == 0
+    assert engines[1].mark_alive.call_count == 0
+
+
+def test_pending_registration_tracks_only_multinode_engine_roots() -> None:
+    engines = [SimpleNamespace() for _ in range(4)]
+    group = _group(all_engines=engines, num_gpus_per_engine=16)
+
+    assert group._logical_engine_root_indices([0, 1, 2, 3]) == [0, 2]
+
+
+@pytest.mark.asyncio
+async def test_pending_registration_retries_only_failed_engines() -> None:
+    first_registration = _RemoteRegistration()
+    second_registration = _RemoteRegistration([RuntimeError("registration failed")])
+    engines = [
+        SimpleNamespace(
+            is_alive=True,
+            generation_id="first",
+            actor_handle=_actor(first_registration),
+        ),
+        SimpleNamespace(
+            is_alive=True,
+            generation_id="second",
+            actor_handle=_actor(second_registration),
+        ),
+    ]
+    group = _group(all_engines=engines)
+    group.pending_router_registration = {0, 1}
+
+    with pytest.raises(RuntimeError, match="registration failed"):
+        await group.register_pending_engines_with_router(
+            rollout_engine_generation_ids=["first", "second"],
+        )
+
+    assert group.pending_router_registration == {1}
+
+    await group.register_pending_engines_with_router(
+        rollout_engine_generation_ids=["second"],
+    )
+
+    assert group.pending_router_registration == set()
+    assert first_registration.calls == 1
+    assert second_registration.calls == 2
+
+
+@pytest.mark.asyncio
+async def test_pending_registration_ignores_replacement_after_weight_snapshot() -> None:
+    updated_registration = _RemoteRegistration()
+    later_registration = _RemoteRegistration()
+    engines = [
+        SimpleNamespace(is_alive=True, generation_id="updated", actor_handle=_actor(updated_registration)),
+        SimpleNamespace(is_alive=True, generation_id="later", actor_handle=_actor(later_registration)),
+    ]
+    group = _group(all_engines=engines)
+    group.pending_router_registration = {0, 1}
+
+    await group.register_pending_engines_with_router(
+        rollout_engine_generation_ids=["updated"],
+    )
+
+    assert group.pending_router_registration == {1}
+    assert updated_registration.calls == 1
+    assert later_registration.calls == 0
+
+
+@pytest.mark.asyncio
+async def test_completed_registration_does_not_clear_newer_replacement() -> None:
+    engines: list[SimpleNamespace] = []
+    replacement_registration = _RemoteRegistration()
+    replacement_actor = _actor(replacement_registration)
+
+    def replace_actor() -> None:
+        engines[0].actor_handle = replacement_actor
+        engines[0].generation_id = "replacement"
+
+    original_registration = _RemoteRegistration(on_call=replace_actor)
+    engines.append(
+        SimpleNamespace(
+            is_alive=True,
+            generation_id="original",
+            actor_handle=_actor(original_registration),
+        )
+    )
+    group = _group(all_engines=engines)
+    group.pending_router_registration = {0}
+
+    await group.register_pending_engines_with_router(
+        rollout_engine_generation_ids=["original"],
+    )
+
+    assert group.pending_router_registration == {0}
+    assert original_registration.calls == 1
+    assert replacement_registration.calls == 0
+
+
+@pytest.mark.asyncio
+async def test_unknown_submission_quarantines_engine_generation() -> None:
+    registration = _RemoteRegistration([RouterWorkerSubmissionUnknown("submission outcome unknown")])
+    engines = [
+        SimpleNamespace(
+            is_alive=True,
+            generation_id="unknown",
+            actor_handle=_actor(registration),
+        )
+    ]
+    group = _group(all_engines=engines)
+    group.pending_router_registration = {0}
+    group.stop_engines = MagicMock()
+
+    with pytest.raises(RouterWorkerSubmissionUnknown, match="outcome unknown"):
+        await group.register_pending_engines_with_router(
+            rollout_engine_generation_ids=["unknown"],
+        )
+
+    group.stop_engines.assert_called_once_with(engine_indices=[0])
+
+
+@pytest.mark.asyncio
+async def test_failed_registration_quarantines_engine_generation() -> None:
+    registration = _RemoteRegistration([RouterWorkerRegistrationFailed("registration failed")])
+    engines = [
+        SimpleNamespace(
+            is_alive=True,
+            generation_id="failed",
+            actor_handle=_actor(registration),
+        ),
+        SimpleNamespace(
+            is_alive=True,
+            generation_id="failed-peer",
+            actor_handle=_actor(_RemoteRegistration()),
+        ),
+    ]
+    group = _group(all_engines=engines, num_gpus_per_engine=16)
+    group.pending_router_registration = {0}
+    group.stop_engines = MagicMock()
+
+    with pytest.raises(RouterWorkerRegistrationFailed, match="registration failed"):
+        await group.register_pending_engines_with_router(
+            rollout_engine_generation_ids=["failed"],
+        )
+
+    group.stop_engines.assert_called_once_with(engine_indices=[0, 1])

--- a/tests/fast/ray/test_actor_group_weight_update.py
+++ b/tests/fast/ray/test_actor_group_weight_update.py
@@ -1,0 +1,113 @@
+from argparse import Namespace
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from tests.ci.ci_register import register_cpu_ci
+
+from miles.ray.actor_group import RayTrainGroup
+
+register_cpu_ci(est_time=1, suite="stage-a-cpu", labels=[])
+
+
+class _RemoteCall:
+    def __init__(self, events: list[str], name: str, result: object = None) -> None:
+        self._events = events
+        self._name = name
+        self._result = result
+
+    async def remote(self, **kwargs: object) -> object:
+        self._events.append(self._name)
+        if self._name == "register":
+            assert kwargs == {"rollout_engine_generation_ids": ["engine-generation-id"]}
+        else:
+            assert kwargs == {}
+        return self._result
+
+
+class _RolloutManager:
+    def __init__(self, events: list[str]) -> None:
+        self.recover_updatable_engines = _RemoteCall(events, "recover")
+        self.get_updatable_engines_and_lock = _RemoteCall(
+            events,
+            "get_engines",
+            result=SimpleNamespace(
+                rollout_engines=["engine"],
+                rollout_engine_generation_ids=["engine-generation-id"],
+            ),
+        )
+        self.health_monitoring_pause = _RemoteCall(events, "pause")
+        self.register_recovered_updatable_engines = _RemoteCall(events, "register")
+
+
+@pytest.mark.asyncio
+async def test_update_weights_registers_recovered_engines_after_transfer() -> None:
+    events: list[str] = []
+    group = RayTrainGroup.__new__(RayTrainGroup)
+    group.args = Namespace(
+        debug_train_only=False,
+        debug_rollout_only=False,
+        debug_skip_weight_update=False,
+        use_fault_tolerance=True,
+    )
+    group.rollout_manager = _RolloutManager(events)
+
+    async def record_broadcast(method_name: str, *, info: object) -> None:
+        assert method_name == "update_weights"
+        assert info == SimpleNamespace(
+            rollout_engines=["engine"],
+            rollout_engine_generation_ids=["engine-generation-id"],
+        )
+        events.append("transfer")
+
+    group._broadcast = AsyncMock(side_effect=record_broadcast)
+
+    await group.update_weights()
+
+    assert events == ["recover", "get_engines", "pause", "transfer", "register"]
+
+
+@pytest.mark.asyncio
+async def test_update_weights_does_not_register_when_transfer_fails() -> None:
+    events: list[str] = []
+    group = RayTrainGroup.__new__(RayTrainGroup)
+    group.args = Namespace(
+        debug_train_only=False,
+        debug_rollout_only=False,
+        debug_skip_weight_update=False,
+        use_fault_tolerance=True,
+    )
+    group.rollout_manager = _RolloutManager(events)
+    group._broadcast = AsyncMock(side_effect=RuntimeError("transfer failed"))
+
+    with pytest.raises(RuntimeError, match="transfer failed"):
+        await group.update_weights()
+
+    assert events == ["recover", "get_engines", "pause"]
+
+
+@pytest.mark.asyncio
+async def test_update_weights_publishes_pending_manual_start_without_fault_tolerance() -> None:
+    events: list[str] = []
+    group = RayTrainGroup.__new__(RayTrainGroup)
+    group.args = Namespace(
+        debug_train_only=False,
+        debug_rollout_only=False,
+        debug_skip_weight_update=False,
+        use_fault_tolerance=False,
+    )
+    group.rollout_manager = _RolloutManager(events)
+
+    async def record_broadcast(method_name: str, *, info: object) -> None:
+        assert method_name == "update_weights"
+        assert info == SimpleNamespace(
+            rollout_engines=["engine"],
+            rollout_engine_generation_ids=["engine-generation-id"],
+        )
+        events.append("transfer")
+
+    group._broadcast = AsyncMock(side_effect=record_broadcast)
+
+    await group.update_weights()
+
+    assert events == ["get_engines", "pause", "transfer", "register"]

--- a/tests/fast/ray/train/test_group.py
+++ b/tests/fast/ray/train/test_group.py
@@ -193,6 +193,83 @@ class TestExecuteFirstAlive:
             assert any(c[0] == "update_weights" for c in calls)
 
 
+def _make_weight_update_group(*, events: list[str], use_fault_tolerance: bool) -> RayTrainGroup:
+    info = SimpleNamespace(rollout_engine_generation_ids=["engine-generation-id"])
+
+    def remote_call(name: str, result: object = None) -> MagicMock:
+        async def record(**kwargs: object) -> object:
+            events.append(name)
+            if name == "register":
+                assert kwargs == {"rollout_engine_generation_ids": ["engine-generation-id"]}
+            else:
+                assert kwargs == {}
+            return result
+
+        call = MagicMock()
+        call.remote = AsyncMock(side_effect=record)
+        return call
+
+    group = RayTrainGroup.__new__(RayTrainGroup)
+    group.args = SimpleNamespace(use_fault_tolerance=use_fault_tolerance)
+    group._rollout_manager = SimpleNamespace(
+        recover_updatable_engines=remote_call("recover"),
+        get_updatable_engines_and_lock=remote_call("get_engines", info),
+        health_monitoring_pause=remote_call("pause"),
+        register_recovered_updatable_engines=remote_call("register"),
+    )
+
+    async def transfer(method_name: str, *, info: object) -> None:
+        assert method_name == "update_weights"
+        assert info == SimpleNamespace(rollout_engine_generation_ids=["engine-generation-id"])
+        events.append("transfer")
+
+    async def checksum(*, rollout_id: int | None) -> None:
+        assert rollout_id == 7
+        events.append("checksum")
+
+    group._execute_first_alive = AsyncMock(side_effect=transfer)
+    group._maybe_log_inference_engine_weight_checksums = AsyncMock(side_effect=checksum)
+    return group
+
+
+class TestUpdateWeights:
+    async def test_recovers_before_transfer_and_registers_before_checksum(self):
+        events: list[str] = []
+        group = _make_weight_update_group(events=events, use_fault_tolerance=True)
+
+        await group.update_weights(rollout_id=7)
+
+        assert events == ["recover", "get_engines", "pause", "transfer", "register", "checksum"]
+
+    async def test_failed_transfer_does_not_register_or_checksum(self):
+        events: list[str] = []
+        group = _make_weight_update_group(events=events, use_fault_tolerance=True)
+
+        async def failed_transfer(method_name: str, *, info: object) -> None:
+            assert method_name == "update_weights"
+            assert info == SimpleNamespace(rollout_engine_generation_ids=["engine-generation-id"])
+            events.append("transfer")
+            raise RuntimeError("transfer failed")
+
+        group._execute_first_alive = AsyncMock(side_effect=failed_transfer)
+
+        with (
+            patch("miles.ray.train.group._RETRY_MAX_ATTEMPTS", 1),
+            pytest.raises(RuntimeError, match="transfer failed"),
+        ):
+            await group.update_weights(rollout_id=7)
+
+        assert events == ["recover", "get_engines", "pause", "transfer"]
+
+    async def test_non_fault_tolerant_transfer_still_publishes_pending_engines(self):
+        events: list[str] = []
+        group = _make_weight_update_group(events=events, use_fault_tolerance=False)
+
+        await group.update_weights(rollout_id=7)
+
+        assert events == ["get_engines", "pause", "transfer", "register", "checksum"]
+
+
 class TestComputeIndepDPInfo:
     def test_all_alive(self):
         group = _make_group(num_cells=3)

--- a/tests/fast/rollout/generate_hub/test_multi_turn.py
+++ b/tests/fast/rollout/generate_hub/test_multi_turn.py
@@ -669,6 +669,23 @@ _AGENTIC_VARIANTS = ["agentic_tool_call_single_sample", "agentic_tool_call_multi
 _AGENT_METADATA = {"reward": 1.0, "exit_status": "Submitted", "eval_report": {"passed": True}}
 
 
+class TestAgenticWeightVersion:
+    @pytest.fixture(params=_AGENTIC_VARIANTS)
+    def variant(self, request):
+        return request.param
+
+    @pytest.mark.parametrize("generation_env", [{"process_fn_kwargs": {"weight_version": "default"}}], indirect=True)
+    def test_default_weight_version_rejected_after_publication(self, variant, generation_env):
+        generation_env.args._sglang_default_model_name = "actor"
+        generation_env.args._sglang_published_model_names = {"actor"}
+
+        with pytest.raises(
+            RuntimeError,
+            match="Received weight_version='default' from updatable model 'actor' after actor weights were published",
+        ):
+            _run_generate(variant, generation_env, make_sample(prompt=TwoTurnStub.PROMPT))
+
+
 class TestAgentMetadata:
     """Tests specific to agentic_tool_call: agent function returning dict | None → metadata merge."""
 

--- a/tests/fast/rollout/generate_hub/test_single_turn.py
+++ b/tests/fast/rollout/generate_hub/test_single_turn.py
@@ -1,3 +1,5 @@
+from argparse import Namespace
+
 from tests.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=220, suite="stage-b-cpu", labels=[])
@@ -10,6 +12,7 @@ from PIL import Image
 from tests.fast.fixtures.generation_fixtures import GenerateEnv, generation_env, listify, make_sample, run_generate
 from transformers import AutoProcessor
 
+from miles.rollout.generate_utils.generate_endpoint_utils import validate_weight_version
 from miles.utils.processing_utils import encode_image_for_rollout_engine
 from miles.utils.test_utils.mock_sglang_server import ProcessResult, ProcessResultMetaInfo
 from miles.utils.types import Sample
@@ -239,6 +242,29 @@ class TestRoutedExperts:
 
 
 class TestMetaInfo:
+    def test_explicit_model_route_scopes_publication(self):
+        args = Namespace(
+            _sglang_default_model_name="actor",
+            _sglang_published_model_names={"actor"},
+            debug_rollout_only=False,
+            debug_skip_weight_update=False,
+            lora_rank=0,
+            lora_adapter_path=None,
+        )
+        meta_info = {"weight_version": "default"}
+
+        assert validate_weight_version(args, meta_info, model_name="ref") is None
+        with pytest.raises(
+            RuntimeError,
+            match="Received weight_version='default' from updatable model 'actor' after actor weights were published",
+        ):
+            validate_weight_version(args, meta_info, model_name="actor")
+        with pytest.raises(
+            RuntimeError,
+            match="Received weight_version='default' from updatable model 'actor' after actor weights were published",
+        ):
+            validate_weight_version(args, meta_info, model_name="default")
+
     @pytest.mark.parametrize(
         "generation_env", [{"process_fn_kwargs": {"cached_tokens": 3, "weight_version": "v1.0"}}], indirect=True
     )
@@ -246,6 +272,33 @@ class TestMetaInfo:
         result = _run_generate(variant, generation_env)
         assert result.requests == [expected_request(variant)]
         assert listify(result.sample) == [expected_sample(variant, cached_tokens=3, weight_versions=["v1.0"])]
+
+    @pytest.mark.parametrize("generation_env", [{"process_fn_kwargs": {"weight_version": "default"}}], indirect=True)
+    def test_default_weight_version_rejected_after_publication(self, variant, generation_env):
+        generation_env.args._sglang_default_model_name = "actor"
+        generation_env.args._sglang_published_model_names = {"actor"}
+
+        with pytest.raises(
+            RuntimeError,
+            match="Received weight_version='default' from updatable model 'actor' after actor weights were published",
+        ):
+            _run_generate(variant, generation_env)
+
+    @pytest.mark.parametrize("generation_env", [{"process_fn_kwargs": {"weight_version": "default"}}], indirect=True)
+    @pytest.mark.parametrize(
+        "mode", ["unpublished", "frozen-route", "debug-rollout-only", "debug-skip-weight-update", "lora"]
+    )
+    def test_default_weight_version_allowed_without_published_actor_contract(self, variant, generation_env, mode):
+        generation_env.args._sglang_default_model_name = "ref" if mode == "frozen-route" else "actor"
+        generation_env.args._sglang_published_model_names = set() if mode == "unpublished" else {"actor"}
+        generation_env.args.debug_rollout_only = mode == "debug-rollout-only"
+        generation_env.args.debug_skip_weight_update = mode == "debug-skip-weight-update"
+        if mode == "lora":
+            generation_env.args.lora_rank = 8
+
+        result = _run_generate(variant, generation_env)
+
+        assert listify(result.sample) == [expected_sample(variant, weight_versions=["default"])]
 
     @pytest.mark.parametrize(
         "generation_env",

--- a/tests/fast/rollout/session/test_samples.py
+++ b/tests/fast/rollout/session/test_samples.py
@@ -4,6 +4,7 @@ Validates the contract between session records, sample construction,
 and merge_samples — the core of the TITO (Token In Token Out) pipeline.
 """
 
+from argparse import Namespace
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -93,6 +94,55 @@ def _make_record(
 
 
 class TestComputeSamplesFromRecords:
+    def test_weight_version_validation_uses_serving_route(self):
+        tok = _mock_tokenizer()
+        record = _make_record(prompt_token_ids=[1, 2, 3], output_token_ids=[10, 11])
+        record.response["choices"][0]["meta_info"]["weight_version"] = "default"
+        args = Namespace(
+            _sglang_default_model_name="actor",
+            _sglang_published_model_names={"actor"},
+            debug_rollout_only=False,
+            debug_skip_weight_update=False,
+            lora_rank=0,
+            lora_adapter_path=None,
+            save_debug_trajectory_data=None,
+        )
+
+        record.request["model"] = "ref"
+        samples = compute_samples_from_openai_records(args, _make_input_sample(), [record], tok)
+
+        assert len(samples) == 1
+        assert samples[0].weight_versions == ["default"]
+
+        record.request["model"] = "actor"
+        with pytest.raises(
+            RuntimeError,
+            match="Received weight_version='default' from updatable model 'actor' after actor weights were published",
+        ):
+            compute_samples_from_openai_records(args, _make_input_sample(), [record], tok)
+
+        record.request["model"] = "default"
+        with pytest.raises(
+            RuntimeError,
+            match="Received weight_version='default' from updatable model 'actor' after actor weights were published",
+        ):
+            compute_samples_from_openai_records(args, _make_input_sample(), [record], tok)
+
+        del record.request["model"]
+        with pytest.raises(
+            RuntimeError,
+            match="Received weight_version='default' from updatable model 'actor' after actor weights were published",
+        ):
+            compute_samples_from_openai_records(args, _make_input_sample(), [record], tok)
+
+    def test_weight_version_validation_rejects_non_string_model(self):
+        tok = _mock_tokenizer()
+        record = _make_record(prompt_token_ids=[1, 2, 3], output_token_ids=[10, 11])
+        record.request["model"] = ["actor"]
+
+        with pytest.raises(TypeError, match="Session request model must be a string"):
+            compute_samples_from_openai_records(_ARGS, _make_input_sample(), [record], tok)
+
     def test_single_record_builds_correct_sample(self):
         tok = _mock_tokenizer()
         record = _make_record(

--- a/tests/fast/utils/test_utils/test_mock_sglang_engine.py
+++ b/tests/fast/utils/test_utils/test_mock_sglang_engine.py
@@ -107,7 +107,7 @@ class TestRealRayActorLifecycle:
             num_gpus_per_engine=1,
         )
         try:
-            ray.get(actor.init.remote(host="127.0.0.1", port=20000))
+            ray.get(actor.init.remote(host="127.0.0.1", port=20000, register_with_router=True))
             ray.get(actor.health_generate.remote(timeout=1.0))
             ray.get(actor.release_memory_occupation.remote(tags=[GPU_MEMORY_TYPE_WEIGHTS]))
             ray.get(actor.resume_memory_occupation.remote(tags=[GPU_MEMORY_TYPE_WEIGHTS]))
@@ -118,6 +118,7 @@ class TestRealRayActorLifecycle:
             method_names = [name for name, _, _ in calls]
             assert method_names == [
                 "init",
+                "register_with_router",
                 "health_generate",
                 "release_memory_occupation",
                 "resume_memory_occupation",


### PR DESCRIPTION
## Summary

- Applies the published-weight invariant when session response records are converted into rollout samples.
- Validates the recorded request model and resolves omitted or literal `default` routes before checking the response's weight version.
- Keeps reference and other unpublished routes valid while rejecting stale actor-route records before they can enter training data.

## Context

Session rollouts reconstruct samples from OpenAI-compatible response records instead of passing through the direct generation response helper changed in [PR #1806](https://github.com/radixark/miles/pull/1806). Without validation at this ingress, a checkpoint-backed actor response carrying `weight_version=default` after publication could bypass the direct rollout guard.

This final layer reuses the same route-aware validator during session sample conversion. It closes the alternate ingestion path without adding another publication state machine or changing recovery behavior.

Closes #1724.

**Stack goal:** This five-PR sequence addresses [issue #1724](https://github.com/radixark/miles/issues/1724): recovered updatable engines remain unroutable until actor-weight synchronization succeeds, and both rollout ingestion paths reject evidence that this invariant was violated.

| Layer | Upstream PR | Status | Contract |
| --- | --- | --- | --- |
| 1/5 | [#1801](https://github.com/radixark/miles/pull/1801) | Ready for review | Typed asynchronous Router lifecycle |
| 2/5 | [#1804](https://github.com/radixark/miles/pull/1804) | Ready for review | Confirmed SGLang worker activation and removal |
| 3/5 | [#1805](https://github.com/radixark/miles/pull/1805) | Ready for review | Recovered-engine publication after weight synchronization |
| 4/5 | [#1806](https://github.com/radixark/miles/pull/1806) | Ready for review | Direct rollout published-weight guard |
| 5/5 | [#1807](https://github.com/radixark/miles/pull/1807) | Ready for review | Session-ingress published-weight guard |

All public drafts target `main` because external-fork branches cannot be selected as base refs in this repository. This matches the existing Miles external-stack convention: descendants appear cumulative until their parents merge, then GitHub removes shared commits from later diffs. Merge in order. If a parent is squash- or rebase-merged and commit identities change, rebase the descendants onto the updated `main` before continuing.

## Description

- Validates each session response against the model recorded in its request before constructing a `Sample`.
- Rejects non-string request model values because route ownership cannot otherwise be determined safely.
- Resolves an omitted model or literal `default` route to the configured default model.
- Allows initial versions from reference and other unpublished routes while rejecting them from a published actor route.
- Reuses the direct rollout validator so direct responses and session records enforce one publication contract.

## Validation

### Layer checks

- The session sample suite passed 25 tests.
- Route-specific tests cover explicit reference, explicit actor, literal `default`, omitted model, and malformed model values.
- The complete five-layer stack passed 112 focused tests.
- Exact branch-head CPU CI passed all four Stage A shards and Stage B on `5fdef0252e`. Stage B reported 152 passed and 34 skipped.

### Stack-head confirmation

The final stack head was tested against baseline `52403d0e3b` with the same controlled asynchronous held-transfer witness:

- the baseline sent one of four pre-synchronization requests to the replacement and returned `default`;
- the fixed head sent none of those requests to the replacement and returned four current numeric versions;
- after synchronization, the replacement joined normally and served 8 of 32 requests in both runs;
- each job completed four production rollouts with 128 numeric responses.

Both GPU jobs completed successfully. Four separate failure-path checks confirmed that transfer and registration failures quarantine the affected replacement. [PR #1805](https://github.com/radixark/miles/pull/1805) contains the full setup, result table, interpretation, and proof boundary.

### Proof boundary

The paired GPU run proves the recovery publication invariant on the exact baseline and fixed commits. It is a focused recovery test, not a long-running or fully asynchronous trainer test.

## Risks and Follow-ups

Malformed session records with a non-string model now fail during sample conversion. This is intentional: accepting them would make route-specific publication validation ambiguous.