### PR TITLE
docker: stop downgrading cuDNN below what torch ships

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -105,6 +105,10 @@ RUN if ls /tmp/wheels/causal_conv1d-*.whl 2>/dev/null | grep -q . && \
     fi
 
 # transformer_engine
+# --no-deps pins the three TE dists to exactly the wheels above, so pip cannot
+# pull a conflicting core dist. That also drops transformer_engine_torch's own
+# runtime deps, which still have to be installed: transformer_engine.pytorch
+# imports onnxscript unconditionally (module/_common -> export -> onnx_extensions).
 RUN --mount=type=bind,source=docker/verify_transformer_engine.py,target=/tmp/verify_transformer_engine.py \
     if [ "${ENABLE_CUDA_13}" = "1" ]; then \
       TE_CORE_DIST=transformer_engine_cu13; \
@@ -120,6 +124,7 @@ RUN --mount=type=bind,source=docker/verify_transformer_engine.py,target=/tmp/ver
     fi && \
     pip uninstall -y transformer-engine transformer-engine-cu12 transformer-engine-cu13 transformer-engine-torch && \
     pip install --force-reinstall --no-deps "$@" && \
+    pip install einops onnx onnxscript pydantic nvdlfw-inspect && \
     python3 /tmp/verify_transformer_engine.py "${TE_CORE_DIST}"
 
 # TE patches (cu13): B300/GB300 FA2 and backward override fixes

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -157,11 +157,16 @@ RUN pip install multi-storage-client --no-deps
 COPY requirements.txt /tmp/requirements.txt
 RUN rm -rf /usr/lib/python3/dist-packages/jwt /usr/lib/python3/dist-packages/PyJWT* && pip install -r /tmp/requirements.txt
 
-# https://github.com/pytorch/pytorch/issues/168167
+# transformer_engine 2.17's fused attention emits cudnn-frontend's
+# Reshape_attributes::set_reshape_mode, i.e. the backend attribute
+# CUDNN_ATTR_OPERATION_RESHAPE_MODE, which cuDNN only understands from 9.22.0.
+# torch 2.11 ships 9.19.0.56, so this has to raise it rather than just get out of
+# the way. pip reports a conflict against torch's exact ==9.19.0.56 pin and then
+# installs anyway; the previous pin here produced the same conflict downwards.
 RUN if [ "${ENABLE_CUDA_13}" = "1" ]; then \
-    pip install nvidia-cudnn-cu13==9.16.0.29; \
+    pip install nvidia-cudnn-cu13==9.22.0.52; \
   else \
-    pip install nvidia-cudnn-cu12==9.16.0.29; \
+    pip install nvidia-cudnn-cu12==9.22.0.52; \
   fi
 
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -162,12 +162,6 @@ RUN pip install multi-storage-client --no-deps
 COPY requirements.txt /tmp/requirements.txt
 RUN rm -rf /usr/lib/python3/dist-packages/jwt /usr/lib/python3/dist-packages/PyJWT* && pip install -r /tmp/requirements.txt
 
-# transformer_engine 2.17's fused attention emits cudnn-frontend's
-# Reshape_attributes::set_reshape_mode, i.e. the backend attribute
-# CUDNN_ATTR_OPERATION_RESHAPE_MODE, which cuDNN only understands from 9.22.0.
-# torch 2.11 ships 9.19.0.56, so this has to raise it rather than just get out of
-# the way. pip reports a conflict against torch's exact ==9.19.0.56 pin and then
-# installs anyway; the previous pin here produced the same conflict downwards.
 RUN if [ "${ENABLE_CUDA_13}" = "1" ]; then \
     pip install nvidia-cudnn-cu13==9.22.0.52; \
   else \

--- a/docker/verify_transformer_engine.py
+++ b/docker/verify_transformer_engine.py
@@ -2,10 +2,16 @@
 
 import importlib.metadata as metadata
 import importlib.util
+import re
 import sys
 
 
 VERSION = "2.17.0"
+
+
+def _dist_name(requirement: str) -> str:
+    """'onnxscript', 'torch>=2.1', 'foo; extra == \"bar\"' -> normalised dist name."""
+    return re.split(r"[<>=!~;\[ ]", requirement.strip(), maxsplit=1)[0].lower().replace("_", "-")
 
 
 def verify(core_dist: str) -> None:
@@ -16,14 +22,27 @@ def verify(core_dist: str) -> None:
         "transformer-engine-torch": VERSION,
     }
     actual = {name: metadata.version(name) for name in expected}
-    requires = {
-        requirement.lower().replace("_", "-").replace(" ", "")
-        for requirement in (metadata.requires("transformer-engine-torch") or [])
-    }
+    raw_requires = metadata.requires("transformer-engine-torch") or []
+    requires = {requirement.lower().replace("_", "-").replace(" ", "") for requirement in raw_requires}
 
     assert actual == expected, f"unexpected TransformerEngine versions: {actual}"
     assert f"{core}=={VERSION}" in requires, f"unexpected TransformerEngine torch requirements: {requires}"
     assert importlib.util.find_spec("transformer_engine") is not None, "transformer_engine package not found"
+
+    # The triplet is installed with --no-deps, so nothing makes transformer_engine_torch's
+    # own runtime deps present. Missing ones do not surface until something imports
+    # transformer_engine.pytorch, which is far too late -- a missing onnxscript shipped
+    # a green image that failed every GPU test.
+    missing = []
+    for requirement in raw_requires:
+        name = _dist_name(requirement)
+        if name.startswith("transformer-engine"):
+            continue  # pinned above
+        try:
+            metadata.version(name)
+        except metadata.PackageNotFoundError:
+            missing.append(name)
+    assert not missing, f"transformer_engine_torch runtime deps not installed: {missing}"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
> **Status: do not merge yet.** The original premise of this PR — that cuDNN 9.22.0
> fixes TE 2.17's `CUDNN_ATTR_OPERATION_RESHAPE_MODE` failure — has been **disproven**.
> See "What this does not fix" below. The remaining change is still defensible on its
> own terms, but the root cause is unresolved and the final version is undecided.

## What is still true: the pin is an obsolete downgrade

`docker/Dockerfile` pins `nvidia-cudnn-cu13==9.16.0.29` under a bare link to
[pytorch/pytorch#168167](https://github.com/pytorch/pytorch/issues/168167) (Conv3D bf16
~40,000x slowdown on H200). Both of that pin's reasons have expired:

| original purpose | today |
|---|---|
| dodge the Conv3D regression | maintainer `nWEIdia`: *"wait for 2.10 for the fix"* — this image runs torch **2.11.0** |
| raise cuDNN to the workaround floor | maintainer `eqy`: *"manually install a **newer** version of cuDNN (**9.15+**)"* — torch 2.11 already ships **9.19.0.56** |

The pin was originally an *upgrade* (the base image sat below 9.15). Now that torch ships
9.19.0.56 it has inverted into a downgrade, visible in every build log:

```
Found existing installation: nvidia-cudnn-cu13 9.19.0.56
Uninstalling nvidia-cudnn-cu13-9.19.0.56
Successfully installed nvidia-cudnn-cu13-9.16.0.29
```

## What this does not fix

I claimed 9.22.0.52 resolves the `fused_attn_bwd` failure. It does not. With
9.22.0.52 installed (confirmed in the build log of radixark/miles#1795 run
30237617317), the identical error still fires:

```
cuDNN Error: detail::set_attribute(reshape_operation.get_raw_desc(),
             CUDNN_ATTR_OPERATION_RESHAPE_MODE, CUDNN_TYPE_RESHAPE_MODE, 1,
             &cudnn_reshape_mode) failed ... code: CUDNN_STATUS_BAD_PARAM
```

4 occurrences in `test_qwen3_5_35b_a3b_lora_ci` (h100), 6 in `test_lora_qwen2.5_0.5B`
(h200).

**Why this PR's own CI looked clean.** It branches off main, which does not carry
radixark/Megatron-Bridge#24. Both affected LoRA tests therefore died earlier, at
`ValueError: not enough values to unpack (expected 21, got 16)`, and never reached the
attention backward at all. Zero cuDNN errors here meant *the path was never executed*,
not that it was fixed. Only #1795 — which pins the merged Megatron-Bridge — gets far
enough to exercise it.

## Open

The real requirement is unknown. Candidates still to test: a higher cuDNN (9.23 / 9.24 /
9.25 are on PyPI); or that this is not a version floor at all — `transformer_engine_cu13`
ships as a prebuilt binary and may not be loading the pip-installed cuDNN it appears to.
Needs a minimal repro on a devbox and a bisect, not another inference from release notes.

Note that TE declares no cuDNN dependency whatsoever (`transformer-engine-cu13` requires
only pydantic / importlib-metadata / packaging), so whatever the constraint is, no
metadata check can enforce it.