### PR TITLE
refactor(tito): bind append roles to fixed templates

### DIFF
--- a/miles/rollout/session/linear_trajectory.py
+++ b/miles/rollout/session/linear_trajectory.py
@@ -78,7 +78,9 @@ class LinearTrajectory:
                 self.messages, request_messages, tito_tokenizer.allowed_append_roles
             )
         except ValueError as e:
-            raise MessageValidationError(f"{e}; to allow more roles use --tito-allowed-append-roles") from e
+            raise MessageValidationError(
+                f"{e}; the selected TITO fixed template does not support appending this role"
+            ) from e
 
         return tito_tokenizer.merge_tokens(
             old_messages=self.messages,

--- a/miles/rollout/session/sessions.py
+++ b/miles/rollout/session/sessions.py
@@ -34,7 +34,6 @@ def setup_session_routes(app, backend, args):
         tokenizer,
         tokenizer_type=getattr(args, "tito_model", "default"),
         chat_template_kwargs=getattr(args, "apply_chat_template_kwargs", None),
-        allowed_append_roles=getattr(args, "tito_allowed_append_roles", None),
     )
 
     registry = SessionRegistry(args, tokenizer, tito_tokenizer=tito_tokenizer)

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -838,8 +838,8 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 "Sets tokenizer.chat_template when loading via load_tokenizer, "
                 "and also sets --sglang-chat-template so the sglang server uses the same template. "
                 "For Miles-maintained fixed templates, leave this unset and pass "
-                "--tito-model plus --tito-allowed-append-roles so Miles can auto-resolve "
-                "the registered template. The literal value 'autofix' is kept only as a "
+                "--tito-model so Miles can auto-resolve the registered template. "
+                "The literal value 'autofix' is kept only as a "
                 "deprecated compatibility alias for that auto-resolve path. "
                 "The path must be accessible on all Ray worker nodes "
                 "(e.g. a path inside the miles repo, or a shared filesystem like NFS).",
@@ -2490,41 +2490,31 @@ def miles_validate_args(args):
         )
         args.chat_template_path = None
 
-    # Auto-resolve a bundled fixed chat-template only when:
-    #   1. the caller did NOT pass --chat-template-path (an explicit path always
-    #      wins and is never overridden)
-    #   2. the caller chose a non-default --tito-model family (DEFAULT means
-    #      "use the model's native HF chat template", which is loaded by
-    #      load_tokenizer — no override needed here)
-    should_auto_resolve = args.chat_template_path is None and args.tito_model != TITOTokenizerType.DEFAULT.value
-
-    if should_auto_resolve:
+    # A named family is one fixed renderer contract.  Letting a custom path or
+    # conflicting required kwarg through would detach its declared role
+    # capability from the renderer that actually runs.
+    if args.tito_model != TITOTokenizerType.DEFAULT.value:
         tito_model = TITOTokenizerType(args.tito_model)
         from miles.utils.chat_template_utils import resolve_fixed_chat_template
 
-        resolved_path, resolved_kwargs = resolve_fixed_chat_template(
-            tito_model,
-            allowed_append_roles=args.tito_allowed_append_roles,
-        )
+        if args.chat_template_path is not None:
+            raise ValueError(
+                f"--chat-template-path cannot override the template registered for "
+                f"--tito-model={tito_model.value}; use --tito-model=default for a custom template"
+            )
+
+        resolved_path, resolved_kwargs = resolve_fixed_chat_template(tito_model)
         if resolved_path is not None:
             args.chat_template_path = resolved_path
-        # Merge inferred kwargs.  User-explicit values win on conflict; only
-        # keys the user did not set are auto-filled.
-        if resolved_kwargs:
-            user_kwargs = args.apply_chat_template_kwargs or {}
-            for key, value in resolved_kwargs.items():
-                if key in user_kwargs:
-                    continue
-                user_kwargs[key] = value
-                logger.warning(
-                    "Auto-set --apply-chat-template-kwargs %s=%r for tito_model=%s "
-                    "(allowed_append_roles=%s); pass an explicit value to override.",
-                    key,
-                    value,
-                    tito_model.value,
-                    sorted(args.tito_allowed_append_roles),
+        user_kwargs = dict(args.apply_chat_template_kwargs or {})
+        for key, value in resolved_kwargs.items():
+            if key in user_kwargs and user_kwargs[key] != value:
+                raise ValueError(
+                    f"--apply-chat-template-kwargs {key}={user_kwargs[key]!r} conflicts "
+                    f"with the value registered for --tito-model={tito_model.value}: {value!r}"
                 )
-            args.apply_chat_template_kwargs = user_kwargs
+            user_kwargs[key] = value
+        args.apply_chat_template_kwargs = user_kwargs
 
     if args.chat_template_path is not None:
         if not os.path.isfile(args.chat_template_path):

--- a/miles/utils/chat_template_utils/template.py
+++ b/miles/utils/chat_template_utils/template.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import copy
 import json
+from collections.abc import Collection
 from typing import Any, Literal
 
 from huggingface_hub import hf_hub_download
@@ -198,19 +199,15 @@ def message_matches(stored: dict[str, Any], new: dict[str, Any]) -> bool:
     return True
 
 
-_DEFAULT_APPEND_ROLES: list[str] = ["tool"]
-
-
 def assert_messages_append_only_with_allowed_role(
     stored_messages: list[dict[str, Any]],
     new_messages: list[dict[str, Any]],
-    allowed_append_roles: list[str] = _DEFAULT_APPEND_ROLES,
+    allowed_append_roles: Collection[str],
 ) -> None:
     """Assert *new_messages* is an append-only extension of *stored_messages*.
 
     The stored prefix must match exactly (compared by template-relevant keys),
-    and any appended messages must have a role in *allowed_append_roles*
-    (default: ``{'tool'}``).
+    and any appended messages must have a role in *allowed_append_roles*.
     """
     if not stored_messages:
         return

--- a/miles/utils/chat_template_utils/tito_tokenizer.py
+++ b/miles/utils/chat_template_utils/tito_tokenizer.py
@@ -8,7 +8,6 @@ The default implementation renders the complete appended suffix and the next gen
 from __future__ import annotations
 
 import logging
-from collections.abc import Iterable
 from dataclasses import dataclass, field
 
 try:
@@ -24,29 +23,43 @@ from miles.utils.chat_template_utils.token_seq_comparator import TokenSeqCompara
 
 logger = logging.getLogger(__name__)
 
-# Bundled fixed-template files live under this directory; ``FixedTemplateRow.template``
+# Bundled fixed-template files live under this directory; ``FixedTemplate.template``
 # values are filenames relative to it.
 TEMPLATE_DIR = Path(__file__).parent / "templates"
 
-# Roles the TITO merge logic understands; passing anything else is a typo.
-_VALID_ROLES = frozenset({"tool", "user", "system"})
+# Roles that a fixed template may support after the pretokenized assistant
+# prefix.  A family narrows this set only when its registered renderer cannot
+# preserve every role append-only.
+VALID_APPEND_ROLES: tuple[str, ...] = ("tool", "user", "system", "assistant")
+ALL_APPEND_ROLES: frozenset[str] = frozenset(VALID_APPEND_ROLES)
 
 _DUMMY_SYSTEM: dict[str, Any] = {"role": "system", "content": "dummy system"}
 
 
 @dataclass(frozen=True)
-class FixedTemplateRow:
-    """A ``(roles, template, extra_kwargs)`` row owned by a TITO tokenizer family.
+class FixedTemplate:
+    """A family's fixed chat template, required kwargs, and append surface.
 
-    Each row says: when the session is configured for ``allowed_roles``, this
-    family expects the given chat template plus the given extra kwargs.
     ``template`` is a path relative to ``TEMPLATE_DIR`` for a bundled fixed
     template, or ``None`` to keep the HF-native template (kwargs-only fix).
+    ``extra_kwargs`` carry the family's preserve-think constants, so renders
+    stay append-only.  ``allowed_append_roles`` defaults to the maximal
+    four-role surface; a known restricted template must narrow it explicitly.
     """
 
-    allowed_roles: frozenset[str]
     template: str | None = None
     extra_kwargs: dict[str, Any] = field(default_factory=dict)
+    allowed_append_roles: frozenset[str] = ALL_APPEND_ROLES
+
+    def __post_init__(self) -> None:
+        roles = frozenset(self.allowed_append_roles)
+        invalid = roles - ALL_APPEND_ROLES
+        if invalid:
+            raise ValueError(
+                f"Unknown FixedTemplate allowed_append_roles: {sorted(invalid)}; "
+                f"supported roles are {sorted(ALL_APPEND_ROLES)}"
+            )
+        object.__setattr__(self, "allowed_append_roles", roles)
 
 
 def _build_dummy_assistant(stored_assistant: dict[str, Any]) -> dict[str, Any]:
@@ -71,10 +84,9 @@ class TITOTokenizer:
     max_trim_tokens: int = 0
     trailing_token_ids: frozenset[int] = frozenset()
 
-    # ``(roles, template, extra_kwargs)`` rows this family supports.  Resolved
-    # by ``resolve_fixed_chat_template`` via smallest-superset match against
-    # the caller's ``allowed_append_roles``.
-    SUPPORTED_TEMPLATES: tuple[FixedTemplateRow, ...] = ()
+    # The family's fixed renderer contract.  DEFAULT uses the model's native
+    # template with the maximal best-effort append surface.
+    FIXED_TEMPLATE: FixedTemplate = FixedTemplate()
 
     # sglang ``--reasoning-parser`` and ``--tool-call-parser`` values bound to
     # this family.
@@ -87,12 +99,19 @@ class TITOTokenizer:
         chat_template_kwargs: dict[str, Any] | None = None,
         assistant_start_str: str | None = None,
         special_token_ids: set[int] | None = None,
-        allowed_append_roles: list[str] | None = None,
     ):
         self.tokenizer = tokenizer
-        self.chat_template_kwargs = chat_template_kwargs or {}
+        provided_kwargs = dict(chat_template_kwargs or {})
+        for key, value in self.FIXED_TEMPLATE.extra_kwargs.items():
+            if key in provided_kwargs and provided_kwargs[key] != value:
+                raise ValueError(
+                    f"chat template kwarg {key}={provided_kwargs[key]!r} conflicts with "
+                    f"the value registered for {type(self).__name__}: {value!r}"
+                )
+            provided_kwargs[key] = value
+        self.chat_template_kwargs = provided_kwargs
         self._assistant_start_str = assistant_start_str
-        self.allowed_append_roles: list[str] = allowed_append_roles if allowed_append_roles is not None else ["tool"]
+        self.allowed_append_roles = self.FIXED_TEMPLATE.allowed_append_roles
         self.special_token_ids: set[int] = special_token_ids
 
     def create_comparator(self) -> TokenSeqComparator:
@@ -215,16 +234,9 @@ class Qwen3TITOTokenizer(TITOTokenizer):
     reasoning_parser = "qwen3"
     tool_call_parser = "qwen25"
 
-    SUPPORTED_TEMPLATES = (
-        FixedTemplateRow(
-            allowed_roles=frozenset({"tool"}),
-            template="qwen3_fixed.jinja",
-        ),
-        FixedTemplateRow(
-            allowed_roles=frozenset({"tool", "user"}),
-            template="qwen3_fixed.jinja",
-            extra_kwargs={"clear_thinking": False},
-        ),
+    FIXED_TEMPLATE = FixedTemplate(
+        template="qwen3_fixed.jinja",
+        extra_kwargs={"clear_thinking": False},
     )
 
     _default_assistant_start_str: str = "<|im_start|>assistant"
@@ -234,13 +246,11 @@ class Qwen3TITOTokenizer(TITOTokenizer):
         tokenizer: Any,
         chat_template_kwargs: dict[str, Any] | None = None,
         assistant_start_str: str | None = None,
-        allowed_append_roles: list[str] | None = None,
     ):
         super().__init__(
             tokenizer,
             chat_template_kwargs,
             assistant_start_str or self._default_assistant_start_str,
-            allowed_append_roles=allowed_append_roles,
         )
         nl_ids = tokenizer.encode("\n", add_special_tokens=False)
         assert len(nl_ids) == 1, f"Expected single newline token, got {nl_ids}"
@@ -265,7 +275,7 @@ class Qwen3TITOTokenizer(TITOTokenizer):
 # Qwen3.5 and Qwen3-Next-Thinking share the ``<|im_end|>`` boundary handling
 # with Qwen3, so they reuse Qwen3TITOTokenizer's token-level logic via plain
 # inheritance.  They are still split into named subclasses because each owns
-# its own ``SUPPORTED_TEMPLATES`` row pointing to a distinct fixed jinja, even
+# its own ``FIXED_TEMPLATE`` pointing to a distinct fixed jinja, even
 # though their boundary behavior is identical.
 
 
@@ -274,16 +284,10 @@ class Qwen35TITOTokenizer(Qwen3TITOTokenizer):
 
     tool_call_parser = "qwen3_coder"
 
-    SUPPORTED_TEMPLATES = (
-        FixedTemplateRow(
-            allowed_roles=frozenset({"tool"}),
-            template="qwen3.5_fixed.jinja",
-        ),
-        FixedTemplateRow(
-            allowed_roles=frozenset({"tool", "user"}),
-            template="qwen3.5_fixed.jinja",
-            extra_kwargs={"clear_thinking": False},
-        ),
+    FIXED_TEMPLATE = FixedTemplate(
+        template="qwen3.5_fixed.jinja",
+        extra_kwargs={"clear_thinking": False},
+        allowed_append_roles=frozenset({"tool", "user", "assistant"}),
     )
 
 
@@ -291,16 +295,9 @@ class QwenNextTITOTokenizer(Qwen3TITOTokenizer):
     """Qwen3-Thinking-2507 / Qwen3-Next-Thinking — same boundary behavior as
     Qwen3, distinct (shared) fixed template."""
 
-    SUPPORTED_TEMPLATES = (
-        FixedTemplateRow(
-            allowed_roles=frozenset({"tool"}),
-            template="qwen3_thinking_2507_and_next_fixed.jinja",
-        ),
-        FixedTemplateRow(
-            allowed_roles=frozenset({"tool", "user"}),
-            template="qwen3_thinking_2507_and_next_fixed.jinja",
-            extra_kwargs={"clear_thinking": False},
-        ),
+    FIXED_TEMPLATE = FixedTemplate(
+        template="qwen3_thinking_2507_and_next_fixed.jinja",
+        extra_kwargs={"clear_thinking": False},
     )
 
 
@@ -326,21 +323,9 @@ class GLM47TITOTokenizer(TITOTokenizer):
 
     # GLM's HF-native chat template already exposes a ``clear_thinking`` kwarg,
     # so no fixed-jinja patch is needed for either append surface.
-    SUPPORTED_TEMPLATES = (
-        FixedTemplateRow(
-            allowed_roles=frozenset({"tool"}),
-            template=None,
-        ),
-        FixedTemplateRow(
-            allowed_roles=frozenset({"tool", "user"}),
-            template=None,
-            extra_kwargs={"clear_thinking": False},
-        ),
-        FixedTemplateRow(
-            allowed_roles=frozenset({"tool", "user", "system"}),
-            template=None,
-            extra_kwargs={"clear_thinking": False},
-        ),
+    FIXED_TEMPLATE = FixedTemplate(
+        template=None,
+        extra_kwargs={"clear_thinking": False},
     )
 
     max_trim_tokens: int = 1
@@ -351,13 +336,11 @@ class GLM47TITOTokenizer(TITOTokenizer):
         tokenizer: Any,
         chat_template_kwargs: dict[str, Any] | None = None,
         assistant_start_str: str | None = None,
-        allowed_append_roles: list[str] | None = None,
     ):
         super().__init__(
             tokenizer,
             chat_template_kwargs,
             assistant_start_str or self._default_assistant_start_str,
-            allowed_append_roles=allowed_append_roles,
         )
         self._observation_id: int = tokenizer.convert_tokens_to_ids("<|observation|>")
         self._user_id: int = tokenizer.convert_tokens_to_ids("<|user|>")
@@ -405,21 +388,9 @@ class Nemotron3TITOTokenizer(Qwen3TITOTokenizer):
     reasoning_parser = "nemotron_3"
     tool_call_parser = "qwen3_coder"
 
-    SUPPORTED_TEMPLATES = (
-        FixedTemplateRow(
-            allowed_roles=frozenset({"tool"}),
-            template=None,
-        ),
-        FixedTemplateRow(
-            allowed_roles=frozenset({"tool", "user"}),
-            template=None,
-            extra_kwargs={"truncate_history_thinking": False},
-        ),
-        FixedTemplateRow(
-            allowed_roles=frozenset({"tool", "user", "system"}),
-            template=None,
-            extra_kwargs={"truncate_history_thinking": False},
-        ),
+    FIXED_TEMPLATE = FixedTemplate(
+        template=None,
+        extra_kwargs={"truncate_history_thinking": False},
     )
 
     _default_assistant_start_str: str = "<|im_start|>assistant\n"
@@ -429,13 +400,11 @@ class Nemotron3TITOTokenizer(Qwen3TITOTokenizer):
         tokenizer: Any,
         chat_template_kwargs: dict[str, Any] | None = None,
         assistant_start_str: str | None = None,
-        allowed_append_roles: list[str] | None = None,
     ):
         super().__init__(
             tokenizer,
             chat_template_kwargs,
             assistant_start_str or self._default_assistant_start_str,
-            allowed_append_roles=allowed_append_roles,
         )
 
 
@@ -461,12 +430,9 @@ class Kimi25TITOTokenizer(TITOTokenizer):
     ``{tool, user}`` surface is registered (per current onboarding scope).
     """
 
-    SUPPORTED_TEMPLATES = (
-        FixedTemplateRow(
-            allowed_roles=frozenset({"tool", "user"}),
-            template="kimi_k25_fixed.jinja",
-            extra_kwargs={"preserve_thinking": True},
-        ),
+    FIXED_TEMPLATE = FixedTemplate(
+        template="kimi_k25_fixed.jinja",
+        extra_kwargs={"preserve_thinking": True},
     )
 
     _default_assistant_start_str: str = "<|im_assistant|>"
@@ -476,14 +442,12 @@ class Kimi25TITOTokenizer(TITOTokenizer):
         tokenizer: Any,
         chat_template_kwargs: dict[str, Any] | None = None,
         assistant_start_str: str | None = None,
-        allowed_append_roles: list[str] | None = None,
     ):
         super().__init__(
             tokenizer,
             chat_template_kwargs,
             assistant_start_str or self._default_assistant_start_str,
             special_token_ids=_kimi_segment_special_token_ids(tokenizer),
-            allowed_append_roles=allowed_append_roles,
         )
 
 
@@ -504,12 +468,9 @@ class Kimi26TITOTokenizer(TITOTokenizer):
     reasoning_parser = "kimi_k2"
     tool_call_parser = "kimi_k2_raw_id"
 
-    SUPPORTED_TEMPLATES = (
-        FixedTemplateRow(
-            allowed_roles=frozenset({"tool", "user"}),
-            template=None,
-            extra_kwargs={"preserve_thinking": True},
-        ),
+    FIXED_TEMPLATE = FixedTemplate(
+        template=None,
+        extra_kwargs={"preserve_thinking": True},
     )
 
     _default_assistant_start_str: str = "<|im_assistant|>"
@@ -519,14 +480,12 @@ class Kimi26TITOTokenizer(TITOTokenizer):
         tokenizer: Any,
         chat_template_kwargs: dict[str, Any] | None = None,
         assistant_start_str: str | None = None,
-        allowed_append_roles: list[str] | None = None,
     ):
         super().__init__(
             tokenizer,
             chat_template_kwargs,
             assistant_start_str or self._default_assistant_start_str,
             special_token_ids=_kimi_segment_special_token_ids(tokenizer),
-            allowed_append_roles=allowed_append_roles,
         )
 
 
@@ -550,22 +509,18 @@ class MinimaxM25TITOTokenizer(TITOTokenizer):
     ``<think>`` blocks and breaks append-only.  Only ``{tool}`` surface is
     registered on HF-native template for that reason; multi-user-turn
     requires the fixed jinja with ``clear_thinking=False`` to always
-    preserve history reasoning.
+    preserve history reasoning.  The fixed Jinja renders tool, user, and
+    assistant appends, but ignores mid-session system messages, so that role
+    is excluded from its capability.
     """
 
     reasoning_parser = "minimax-append-think"
     tool_call_parser = "minimax-m2"
 
-    SUPPORTED_TEMPLATES = (
-        FixedTemplateRow(
-            allowed_roles=frozenset({"tool"}),
-            template=None,
-        ),
-        FixedTemplateRow(
-            allowed_roles=frozenset({"tool", "user"}),
-            template="minimax_m25_fixed.jinja",
-            extra_kwargs={"clear_thinking": False},
-        ),
+    FIXED_TEMPLATE = FixedTemplate(
+        template="minimax_m25_fixed.jinja",
+        extra_kwargs={"clear_thinking": False},
+        allowed_append_roles=frozenset({"tool", "user", "assistant"}),
     )
 
     _default_assistant_start_str: str = "]~b]ai"
@@ -575,13 +530,11 @@ class MinimaxM25TITOTokenizer(TITOTokenizer):
         tokenizer: Any,
         chat_template_kwargs: dict[str, Any] | None = None,
         assistant_start_str: str | None = None,
-        allowed_append_roles: list[str] | None = None,
     ):
         super().__init__(
             tokenizer,
             chat_template_kwargs,
             assistant_start_str or self._default_assistant_start_str,
-            allowed_append_roles=allowed_append_roles,
         )
         nl_ids = tokenizer.encode("\n", add_special_tokens=False)
         assert len(nl_ids) == 1, f"Expected single newline token, got {nl_ids}"
@@ -608,21 +561,15 @@ class MinimaxM27TITOTokenizer(MinimaxM25TITOTokenizer):
     to M2.5; the chat template only differs by default system identity string.
 
     Inherits parsers, ``__init__``, ``merge_tokens``, and
-    ``_default_assistant_start_str`` from M2.5; only ``SUPPORTED_TEMPLATES``
+    ``_default_assistant_start_str`` from M2.5; only ``FIXED_TEMPLATE``
     is rebound to ``minimax_m27_fixed.jinja`` so the fixed-template lookup
     points at the M2.7-derived jinja.
     """
 
-    SUPPORTED_TEMPLATES = (
-        FixedTemplateRow(
-            allowed_roles=frozenset({"tool"}),
-            template=None,
-        ),
-        FixedTemplateRow(
-            allowed_roles=frozenset({"tool", "user"}),
-            template="minimax_m27_fixed.jinja",
-            extra_kwargs={"clear_thinking": False},
-        ),
+    FIXED_TEMPLATE = FixedTemplate(
+        template="minimax_m27_fixed.jinja",
+        extra_kwargs={"clear_thinking": False},
+        allowed_append_roles=frozenset({"tool", "user", "assistant"}),
     )
 
 
@@ -651,17 +598,9 @@ class DeepSeekV32TITOTokenizer(TITOTokenizer):
     reasoning_parser = "deepseek-v3"
     tool_call_parser = "deepseekv32"
 
-    SUPPORTED_TEMPLATES = (
-        FixedTemplateRow(
-            allowed_roles=frozenset({"tool"}),
-            template=None,
-            extra_kwargs={"drop_thinking": False},
-        ),
-        FixedTemplateRow(
-            allowed_roles=frozenset({"tool", "user"}),
-            template=None,
-            extra_kwargs={"drop_thinking": False},
-        ),
+    FIXED_TEMPLATE = FixedTemplate(
+        template=None,
+        extra_kwargs={"drop_thinking": False},
     )
 
     _DEFAULT_ASSISTANT_START = "<｜Assistant｜>"
@@ -671,7 +610,6 @@ class DeepSeekV32TITOTokenizer(TITOTokenizer):
         tokenizer: Any,
         chat_template_kwargs: dict[str, Any] | None = None,
         assistant_start_str: str | None = None,
-        allowed_append_roles: list[str] | None = None,
     ):
         # V3.2 has no jinja template, so assistant_start_str can't be sniffed
         # from one; pin it explicitly.  The comparator keys off the User /
@@ -684,7 +622,6 @@ class DeepSeekV32TITOTokenizer(TITOTokenizer):
                 tokenizer.convert_tokens_to_ids("<｜User｜>"),
                 tokenizer.convert_tokens_to_ids("<｜Assistant｜>"),
             },
-            allowed_append_roles=allowed_append_roles,
         )
         self.chat_template_kwargs = {
             **self.chat_template_kwargs,
@@ -709,16 +646,9 @@ class DeepSeekV4TITOTokenizer(TITOTokenizer):
     reasoning_parser = "deepseek-v4"
     tool_call_parser = "deepseekv4"
 
-    SUPPORTED_TEMPLATES = (
-        FixedTemplateRow(
-            allowed_roles=frozenset({"tool"}),
-            template=None,
-        ),
-        FixedTemplateRow(
-            allowed_roles=frozenset({"tool", "user"}),
-            template=None,
-            extra_kwargs={"drop_thinking": False},
-        ),
+    FIXED_TEMPLATE = FixedTemplate(
+        template=None,
+        extra_kwargs={"drop_thinking": False},
     )
 
     _DEFAULT_ASSISTANT_START = "<｜Assistant｜>"
@@ -728,7 +658,6 @@ class DeepSeekV4TITOTokenizer(TITOTokenizer):
         tokenizer: Any,
         chat_template_kwargs: dict[str, Any] | None = None,
         assistant_start_str: str | None = None,
-        allowed_append_roles: list[str] | None = None,
     ):
         super().__init__(
             tokenizer,
@@ -738,7 +667,6 @@ class DeepSeekV4TITOTokenizer(TITOTokenizer):
                 tokenizer.convert_tokens_to_ids("<｜User｜>"),
                 tokenizer.convert_tokens_to_ids("<｜Assistant｜>"),
             },
-            allowed_append_roles=allowed_append_roles,
         )
         self._assistant_id: int = tokenizer.convert_tokens_to_ids("<｜Assistant｜>")
         self._think_bracket_ids: set[int] = {
@@ -829,7 +757,6 @@ def get_tito_tokenizer(
     tokenizer_type: TITOTokenizerType | str = TITOTokenizerType.DEFAULT,
     chat_template_kwargs: dict[str, Any] | None = None,
     assistant_start_str: str | None = None,
-    allowed_append_roles: list[str] | None = None,
 ) -> TITOTokenizer:
     """Create a ``TITOTokenizer`` instance.
 
@@ -841,9 +768,6 @@ def get_tito_tokenizer(
         assistant_start_str: Decoded text prefix identifying assistant content
             segments (e.g. ``"<|im_start|>assistant"``).  Auto-detected from
             the chat template by default; pass explicitly to override.
-        allowed_append_roles: Roles allowed in appended messages.  Defaults to
-            ``["tool"]``.  Passed to
-            ``assert_messages_append_only_with_allowed_role``.
     """
     if tokenizer is None:
         raise ValueError("tokenizer must not be None")
@@ -853,75 +777,44 @@ def get_tito_tokenizer(
     kwargs: dict[str, Any] = {"chat_template_kwargs": chat_template_kwargs}
     if assistant_start_str is not None:
         kwargs["assistant_start_str"] = assistant_start_str
-    if allowed_append_roles is not None:
-        kwargs["allowed_append_roles"] = allowed_append_roles
     return cls(tokenizer, **kwargs)
 
 
 # ---------------------------------------------------------------------------
-# Fixed-template resolution (smallest-superset over SUPPORTED_TEMPLATES)
+# Fixed-template resolution (one template per family)
 # ---------------------------------------------------------------------------
 
 
 def resolve_fixed_chat_template(
     tito_model: TITOTokenizerType | str,
-    allowed_append_roles: Iterable[str],
 ) -> tuple[str | None, dict[str, Any]]:
-    """Smallest-superset lookup over the requested family's ``SUPPORTED_TEMPLATES``.
+    """The family's fixed chat template and required kwargs.
 
     Returns ``(template_path, extra_kwargs)``:
 
     - ``template_path``: absolute path to a bundled ``.jinja`` file, or ``None``
-      when the matched row registers HF-native (kwargs-only fix) or when no
-      row matches at all.
-    - ``extra_kwargs``: kwargs the caller should merge into
-      ``template.apply_chat_template`` (caller's explicit user kwargs win on conflict).
-      Empty when no row matches or the matched row needs none.
+      when the family registers HF-native (kwargs-only fix).
+    - ``extra_kwargs``: kwargs owned by the registration and merged into
+      ``template.apply_chat_template``.  Conflicting caller values are invalid.
 
-    Raises ``ValueError`` on equally-minimal supersets — register a stricter
-    row to disambiguate.
+    Template resolution depends only on ``tito_model``.  The DEFAULT family
+    resolves to its native template (``None``) with no fixed kwargs.
     """
     if isinstance(tito_model, str):
         tito_model = TITOTokenizerType(tito_model)
 
-    requested = frozenset(allowed_append_roles)
-    invalid = requested - _VALID_ROLES
-    if invalid:
-        raise ValueError(
-            f"Unknown roles in allowed_append_roles: {sorted(invalid)}. " f"Supported: {sorted(_VALID_ROLES)}."
-        )
-
     cls = TITOTokenizerType.get_tokenizer_class(tito_model)
-    candidates = [row for row in cls.SUPPORTED_TEMPLATES if requested.issubset(row.allowed_roles)]
-    if not candidates:
-        raise ValueError(
-            f"No SUPPORTED_TEMPLATES row registered for tito_model={tito_model.value} "
-            f"with allowed_append_roles={sorted(requested)}. Register a row in "
-            f"{cls.__name__}.SUPPORTED_TEMPLATES (template=None for HF-native models)."
-        )
+    fixed = cls.FIXED_TEMPLATE
 
-    # Pick the most specific superset. Ties surface registration mistakes
-    # immediately rather than depending on iteration order.
-    min_size = min(len(row.allowed_roles) for row in candidates)
-    minimal = [row for row in candidates if len(row.allowed_roles) == min_size]
-    if len(minimal) > 1:
-        raise ValueError(
-            f"Ambiguous fixed-template registration for tito_model={tito_model.value}, "
-            f"requested_roles={sorted(requested)}: multiple equally-minimal supersets "
-            f"{[sorted(row.allowed_roles) for row in minimal]}. Register a stricter row to disambiguate."
-        )
-    row = minimal[0]
-
-    path = str(TEMPLATE_DIR / row.template) if row.template else None
+    path = str(TEMPLATE_DIR / fixed.template) if fixed.template else None
     logger.info(
-        "tito_model=%s requested_roles=%s -> matched registered_roles=%s -> template=%s kwargs=%s",
+        "tito_model=%s -> template=%s kwargs=%s allowed_append_roles=%s",
         tito_model.value,
-        sorted(requested),
-        sorted(row.allowed_roles),
         path,
-        row.extra_kwargs,
+        fixed.extra_kwargs,
+        sorted(fixed.allowed_append_roles),
     )
-    return path, dict(row.extra_kwargs)
+    return path, dict(fixed.extra_kwargs)
 
 
 # ---------------------------------------------------------------------------

--- a/miles/utils/test_utils/chat_template_verify.py
+++ b/miles/utils/test_utils/chat_template_verify.py
@@ -137,9 +137,12 @@ def verify_append_only(
 # Trajectories expose two class attributes used for verify-layer filtering:
 #
 #   * ``APPEND_ROLES: frozenset[str]`` — non-assistant roles that appear after
-#     the first assistant message.  Drives ``--tito-allowed-append-roles``.
+#     the first assistant message.  Compared with FixedTemplate capability.
 #   * ``IS_THINKING: bool`` — any assistant carries ``reasoning_content``.
 #     Drives ``--thinking`` and whether ``enable_thinking`` kwarg is passed.
+#
+# This shared verifier intentionally covers only non-assistant append trajectories;
+# dedicated family CPU tests and the session verifier cover injected assistant input.
 #
 # Both are declared on the trajectory class (mock_trajectories.py), alongside
 # ``TOOLS`` / ``PRETOKENIZE_POSITIONS`` / ``MESSAGES``.  This file only lists
@@ -316,9 +319,8 @@ def check_coverage(
 ) -> CoverageReport:
     """Enumerate ``thinking × append-role-subset`` combinations and report gaps.
 
-    Used as a sanity check that every meaningful combination of
-    ``--tito-allowed-append-roles`` and ``--thinking`` is backed by at least
-    one trajectory — otherwise certain CLI settings would be no-ops.
+    Used as a sanity check that every meaningful append-role and thinking
+    combination is backed by at least one trajectory.
     """
     if cases is None:
         cases = ALL_CASES
@@ -355,8 +357,8 @@ def run_all_checks(
 ) -> list[VerifyResult]:
     """Run verification cases filtered by *allowed_append_roles* and *thinking*.
 
-    ``allowed_append_roles`` is the role surface the session may append after
-    an assistant turn; defaults to ``{"tool"}`` for the agentic baseline.
+    ``allowed_append_roles`` is the role surface the template may append after
+    an assistant turn; defaults to the maximal four-role surface.
     Trajectories whose ``append_roles`` are not a subset are skipped.  Caller
     must include ``"tool"`` explicitly when relevant — there is no implicit
     union.
@@ -372,7 +374,9 @@ def run_all_checks(
     through the CLI.
     """
     if allowed_append_roles is None:
-        allowed_append_roles = {"tool"}
+        from miles.utils.chat_template_utils.tito_tokenizer import ALL_APPEND_ROLES
+
+        allowed_append_roles = ALL_APPEND_ROLES
     if thinking not in THINKING_MODES:
         raise ValueError(f"thinking must be one of {THINKING_MODES}; got {thinking!r}")
     extra = extra_template_kwargs or {}
@@ -434,10 +438,9 @@ def verify_append_only_via_tito_instance(
     :func:`verify_append_only_via_tito`.
     """
     try:
-        # TITO's incremental path requires the appendix to be all non-assistant.
-        # From the pretokenized boundary N, greedily extend M forward over the
-        # maximal non-assistant run — that's the chunk production would call
-        # merge_tokens for (between two assistant generations, or up to end).
+        # This shared verifier checks the maximal non-assistant run after boundary N.
+        # Production also accepts injected assistant input; dedicated family CPU
+        # tests and the session verifier cover that surface.
         n = pretokenized_num_message
         m = n
         while m < len(messages) and messages[m].get("role") != "assistant":
@@ -509,7 +512,6 @@ def verify_append_only_via_tito_instance(
 def verify_append_only_via_tito(
     tokenizer: Any,
     tito_model: TITOTokenizerType | str,
-    allowed_append_roles: list[str],
     messages: list[dict],
     pretokenized_num_message: int,
     tools: list[dict] | None = None,
@@ -529,7 +531,6 @@ def verify_append_only_via_tito(
         tokenizer,
         tokenizer_type=tito_model,
         chat_template_kwargs=dict(template_kwargs),
-        allowed_append_roles=list(allowed_append_roles),
     )
     return verify_append_only_via_tito_instance(
         tito,
@@ -546,7 +547,6 @@ def run_all_checks_via_tito(
     tokenizer: Any,
     tito_model: TITOTokenizerType | str,
     *,
-    allowed_append_roles: set[str] | frozenset[str] | None = None,
     thinking: str = "off",
     extra_template_kwargs: dict | None = None,
 ) -> list[VerifyResult]:
@@ -560,26 +560,29 @@ def run_all_checks_via_tito(
 
     The caller is responsible for setting ``tokenizer.chat_template`` (e.g. via
     ``resolve_fixed_chat_template`` lookup or ``--template`` override) before
-    calling this — this function does not consult ``SUPPORTED_TEMPLATES``.
+    calling this — this function does not consult ``FIXED_TEMPLATE``.
     """
-    if allowed_append_roles is None:
-        allowed_append_roles = {"tool"}
     if thinking not in THINKING_MODES:
         raise ValueError(f"thinking must be one of {THINKING_MODES}; got {thinking!r}")
     extra = extra_template_kwargs or {}
 
+    from miles.utils.chat_template_utils import TITOTokenizerType
+
+    if isinstance(tito_model, str):
+        tito_model = TITOTokenizerType(tito_model)
+    fixed_template = TITOTokenizerType.get_tokenizer_class(tito_model).FIXED_TEMPLATE
     is_thinking_filter = {"off": False, "on": True, "both": None}[thinking]
-    selected = select_cases(allowed_append_roles=allowed_append_roles, is_thinking=is_thinking_filter)
+    selected = select_cases(
+        allowed_append_roles=fixed_template.allowed_append_roles,
+        is_thinking=is_thinking_filter,
+    )
     variants = enable_thinking_variants(thinking)
-    roles_list = sorted(allowed_append_roles)
 
     results: list[VerifyResult] = []
     for case in selected:
-        # TITO incremental requires a non-empty non-assistant appendix at the
-        # boundary.  Trajectories that end at the assistant turn (e.g. plain
-        # ``[sys, user, assistant]``) have no appendix to verify and are
-        # silently skipped here — the string-based primitive still covers
-        # them at the text-prefix layer.
+        # This shared verifier requires a non-empty non-assistant appendix. Cases
+        # ending at an assistant remain covered at the text-prefix layer; dedicated
+        # family CPU tests and the session verifier cover injected assistant input.
         msgs = case.traj_cls.MESSAGES
         n = case.pretokenize_n
         if n >= len(msgs) or msgs[n].get("role") == "assistant":
@@ -590,7 +593,6 @@ def run_all_checks_via_tito(
                 verify_append_only_via_tito(
                     tokenizer,
                     tito_model,
-                    roles_list,
                     deepcopy(case.traj_cls.MESSAGES),
                     case.pretokenize_n,
                     tools=case.tools,

--- a/miles/utils/test_utils/chat_template_verify.py
+++ b/miles/utils/test_utils/chat_template_verify.py
@@ -17,10 +17,12 @@ from copy import deepcopy
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
+from miles.utils.chat_template_utils import TITOTokenizerType
 from miles.utils.chat_template_utils.template import apply_chat_template_from_str
+from miles.utils.chat_template_utils.tito_tokenizer import ALL_APPEND_ROLES
 
 if TYPE_CHECKING:
-    from miles.utils.chat_template_utils.tito_tokenizer import TITOTokenizer, TITOTokenizerType
+    from miles.utils.chat_template_utils.tito_tokenizer import TITOTokenizer
 
 
 def simulate_pretokenized_path(
@@ -374,8 +376,6 @@ def run_all_checks(
     through the CLI.
     """
     if allowed_append_roles is None:
-        from miles.utils.chat_template_utils.tito_tokenizer import ALL_APPEND_ROLES
-
         allowed_append_roles = ALL_APPEND_ROLES
     if thinking not in THINKING_MODES:
         raise ValueError(f"thinking must be one of {THINKING_MODES}; got {thinking!r}")
@@ -565,8 +565,6 @@ def run_all_checks_via_tito(
     if thinking not in THINKING_MODES:
         raise ValueError(f"thinking must be one of {THINKING_MODES}; got {thinking!r}")
     extra = extra_template_kwargs or {}
-
-    from miles.utils.chat_template_utils import TITOTokenizerType
 
     if isinstance(tito_model, str):
         tito_model = TITOTokenizerType(tito_model)

--- a/miles/utils/test_utils/mock_trajectories.py
+++ b/miles/utils/test_utils/mock_trajectories.py
@@ -9,8 +9,7 @@ Class attributes consumed by chat_template_verify:
 
 - ``APPEND_ROLES: frozenset[str]`` — non-assistant roles that appear *after*
   the first assistant message (``tool`` / ``user`` / ``system``).  These are
-  the roles the session must allow to be appended on top of an assistant-
-  stopped prefix; drives ``--tito-allowed-append-roles`` filtering.
+  compared with the selected FixedTemplate's append capability.
 - ``IS_THINKING: bool`` — ``True`` iff at least one assistant message carries
   ``reasoning_content``.  Drives ``--thinking`` filtering and whether the
   ``enable_thinking`` chat-template kwarg is passed.
@@ -430,9 +429,8 @@ class RetrySystemTrajectory:
 class MultiUserToolChainTrajectory:
     """sys, user1, ass(tool), tool, ass, user2, ass(tool), tool, ass(tool:date), tool
 
-    NOTE: LinearTrajectory can carry multiple user messages when
-    ``allowed_append_roles`` includes ``"user"``; this trajectory exercises
-    that path.  The distribution may still deviate from the chat template
+    NOTE: This trajectory exercises multiple user messages after a generated
+    assistant.  The distribution may still deviate from the chat template
     behavior, causing high tito_session_mismatch_rate.
     """
 
@@ -982,7 +980,7 @@ class MultiRoleSequenceTrajectory:
     """sys, user, asst+tool, tool, user2, asst+tool, system_reminder, tool, asst-final.
 
     Fills the {thinking=False, append_roles={tool, user, system}} matrix cell
-    that GLM47's tool+user+system SUPPORTED_TEMPLATES row otherwise has no
+    that GLM47's tool+user+system append configuration otherwise has no
     fixture for. Cuts exercise three boundaries: tool-append (N=3), user-after-tool
     (N=4), system-after-asst (N=6). Cuts at N=5/N=7/N=8 are intentionally not
     listed — they only exercise generation-prompt-only or repeat tool-append

--- a/tests/fast/rollout/generate_hub/test_multi_turn.py
+++ b/tests/fast/rollout/generate_hub/test_multi_turn.py
@@ -163,6 +163,7 @@ def expected_openai_request(messages: list[dict], **extra) -> dict:
         "logprobs": True,
         "return_meta_info": True,
         "no_stop_trim": False,
+        "chat_template_kwargs": {"clear_thinking": False},
         **extra,
     }
 
@@ -593,7 +594,6 @@ class TestRoutedExpertsMultiTurn:
                 TOKENIZER,
                 # Note: tokenizer_type needs to match MODEL_NAME
                 tokenizer_type=TITOTokenizerType.QWEN3,
-                allowed_append_roles=["tool"],
             )
             first_prompt_token_ids = tito.apply_chat_template(
                 S.OPENAI_MESSAGES_FIRST_TURN,

--- a/tests/fast/router/session_pretokenized_test_utils.py
+++ b/tests/fast/router/session_pretokenized_test_utils.py
@@ -43,14 +43,12 @@ def make_router_env(
     hf_checkpoint: str,
     chat_template_path: str | None,
     tito_model: str,
-    allowed_append_roles: list[str],
 ):
     args = SimpleNamespace(
         miles_router_timeout=30,
         hf_checkpoint=hf_checkpoint,
         chat_template_path=chat_template_path,
         tito_model=tito_model,
-        tito_allowed_append_roles=allowed_append_roles,
         use_rollout_routing_replay=False,
     )
     session_server = SessionServer(args, backend_url=backend.url)
@@ -81,7 +79,6 @@ def compute_local_session_mismatch(
     tokenizer,
     *,
     tito_model: str,
-    allowed_append_roles: list[str],
     messages: list[dict[str, Any]],
     accumulated_token_ids: list[int],
     tools: list[dict[str, Any]] | None,
@@ -89,7 +86,6 @@ def compute_local_session_mismatch(
     comparator = get_tito_tokenizer(
         tokenizer,
         tokenizer_type=tito_model,
-        allowed_append_roles=allowed_append_roles,
     ).create_comparator()
     expected_ids = apply_chat_template(
         messages,

--- a/tests/fast/router/test_linear_trajectory.py
+++ b/tests/fast/router/test_linear_trajectory.py
@@ -14,7 +14,7 @@ import pytest
 from miles.rollout.session.errors import MessageValidationError, SessionNotFoundError, TokenizationError
 from miles.rollout.session.linear_trajectory import SessionRegistry
 from miles.rollout.session.types import SessionRecord
-from miles.utils.chat_template_utils.tito_tokenizer import TITOTokenizer
+from miles.utils.chat_template_utils.tito_tokenizer import ALL_APPEND_ROLES, FixedTemplate, TITOTokenizer
 
 _MOCK_FIRST_TURN_TOKENS = [0]
 
@@ -56,30 +56,45 @@ class _MockTITOTokenizer(TITOTokenizer):
         return list(pretokenized_token_ids)
 
 
-def _make_registry(allowed_append_roles: list[str] | None = None) -> SessionRegistry:
+def _make_registry(allowed_append_roles: frozenset[str] = ALL_APPEND_ROLES) -> SessionRegistry:
     args = SimpleNamespace()
-    mock_tito = _MockTITOTokenizer(
-        tokenizer=None, assistant_start_str="<|im_start|>assistant", allowed_append_roles=allowed_append_roles
+    configured_mock_type = type(
+        "_ConfiguredMockTITOTokenizer",
+        (_MockTITOTokenizer,),
+        {"FIXED_TEMPLATE": FixedTemplate(allowed_append_roles=allowed_append_roles)},
     )
+    mock_tito = configured_mock_type(tokenizer=None, assistant_start_str="<|im_start|>assistant")
     return SessionRegistry(args, tokenizer=None, tito_tokenizer=mock_tito)
 
 
 @pytest.fixture
 def registry():
-    """Default registry: only tool messages allowed after assistant."""
+    """Default FixedTemplate supports the maximal four-role surface."""
     return _make_registry()
 
 
 @pytest.fixture
+def registry_tool_only():
+    """Registry whose test FixedTemplate is restricted to tool messages."""
+    return _make_registry(frozenset({"tool"}))
+
+
+@pytest.fixture
 def registry_with_system():
-    """Registry that allows both tool and system in appended messages."""
-    return _make_registry(allowed_append_roles=["tool", "system"])
+    """Registry whose test FixedTemplate supports tool and system."""
+    return _make_registry(frozenset({"tool", "system"}))
 
 
 @pytest.fixture
 def registry_with_user():
-    """Registry that allows tool and user in appended messages."""
-    return _make_registry(allowed_append_roles=["tool", "user"])
+    """Registry whose test FixedTemplate supports tool and user."""
+    return _make_registry(frozenset({"tool", "user"}))
+
+
+@pytest.fixture
+def registry_with_assistant():
+    """Registry whose test FixedTemplate supports injected assistant input."""
+    return _make_registry(frozenset({"tool", "user", "assistant"}))
 
 
 class TestSessionCRUD:
@@ -244,14 +259,14 @@ class TestSingleUserTurnPretokenized:
                 max_trim_tokens=0,
             )
 
-    def test_not_append_only_raises(self, registry: SessionRegistry):
+    def test_modified_prefix_raises(self, registry: SessionRegistry):
         """prepare raises when new messages modify stored prefix."""
         sid = registry.create_session()
         session = registry.get_session(sid)
         session.update_pretokenized_state([SYS_MSG, USER_MSG], ASSISTANT_MSG_1, [1, 2, 3], [10], max_trim_tokens=0)
 
-        bad_messages = [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, {"role": "assistant", "content": "oops"}]
-        with pytest.raises(MessageValidationError, match="role=.assistant.*allowed="):
+        bad_messages = [SYS_MSG, {"role": "user", "content": "different"}]
+        with pytest.raises(MessageValidationError, match="rollback failed"):
             session.prepare_pretokenized(bad_messages, tito_tokenizer=registry.tito_tokenizer)
 
     def test_session_not_found_raises(self, registry: SessionRegistry):
@@ -287,47 +302,91 @@ class TestSingleUserTurnPretokenized:
 
 
 # ---------------------------------------------------------------------------
-# TestAppendRole* — allowed_append_roles policy tests
+# TestAppendRole* — FixedTemplate capability tests
 #
-# Each class tests one configuration: tool-only (default), tool+system,
-# tool+user.  Tests verify which appended roles are accepted or rejected
-# under each allowed_append_roles setting.
+# Each class exercises an actual append behavior against either the default
+# four-role template capability or a synthetic restricted template.
 # ---------------------------------------------------------------------------
 
 
-class TestAppendRoleToolOnly:
-    """Default config: allowed_append_roles=['tool']."""
+class TestAppendRoleDefault:
+    """The default FixedTemplate supports all four roles."""
 
-    def test_tool_append_allowed(self, registry: SessionRegistry):
-        sid = registry.create_session()
-        session = registry.get_session(sid)
-        session.update_pretokenized_state([SYS_MSG, USER_MSG], ASSISTANT_MSG_1, [1, 2, 3], [10], max_trim_tokens=0)
-
-        messages = [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1]
-        result = session.prepare_pretokenized(messages, tito_tokenizer=registry.tito_tokenizer)
-        assert isinstance(result, list)
-
-    def test_system_append_rejected(self, registry: SessionRegistry):
-        sid = registry.create_session()
-        session = registry.get_session(sid)
-        session.update_pretokenized_state([SYS_MSG, USER_MSG], ASSISTANT_MSG_1, [1, 2, 3], [10, 11], max_trim_tokens=0)
-
-        messages = [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1, RETRY_SYS_MSG]
-        with pytest.raises(MessageValidationError, match="role='system'.*allowed="):
-            session.prepare_pretokenized(messages, tito_tokenizer=registry.tito_tokenizer)
-
-    def test_user_append_rejected(self, registry: SessionRegistry):
+    def test_default_template_allows_user_append(self, registry: SessionRegistry):
         sid = registry.create_session()
         session = registry.get_session(sid)
         session.update_pretokenized_state([SYS_MSG, USER_MSG], ASSISTANT_MSG_1, [1, 2, 3], [10], max_trim_tokens=0)
 
         messages = [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1, {"role": "user", "content": "extra"}]
+        result = session.prepare_pretokenized(messages, tito_tokenizer=registry.tito_tokenizer)
+        assert isinstance(result, list)
+
+    def test_default_template_allows_assistant_append(self, registry: SessionRegistry):
+        sid = registry.create_session()
+        session = registry.get_session(sid)
+        session.update_pretokenized_state([SYS_MSG, USER_MSG], ASSISTANT_MSG_1, [1, 2, 3], [10], max_trim_tokens=0)
+
+        messages = [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1, {"role": "assistant", "content": "injected"}]
+        result = session.prepare_pretokenized(messages, tito_tokenizer=registry.tito_tokenizer)
+        assert isinstance(result, list)
+
+
+class TestAppendRoleToolOnly:
+    """A template explicitly restricted to tool appends."""
+
+    def test_tool_append_allowed(self, registry_tool_only: SessionRegistry):
+        sid = registry_tool_only.create_session()
+        session = registry_tool_only.get_session(sid)
+        session.update_pretokenized_state([SYS_MSG, USER_MSG], ASSISTANT_MSG_1, [1, 2, 3], [10], max_trim_tokens=0)
+
+        messages = [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1]
+        result = session.prepare_pretokenized(messages, tito_tokenizer=registry_tool_only.tito_tokenizer)
+        assert isinstance(result, list)
+
+    def test_system_append_rejected(self, registry_tool_only: SessionRegistry):
+        sid = registry_tool_only.create_session()
+        session = registry_tool_only.get_session(sid)
+        session.update_pretokenized_state([SYS_MSG, USER_MSG], ASSISTANT_MSG_1, [1, 2, 3], [10, 11], max_trim_tokens=0)
+
+        messages = [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1, RETRY_SYS_MSG]
+        with pytest.raises(MessageValidationError, match="role='system'.*allowed="):
+            session.prepare_pretokenized(messages, tito_tokenizer=registry_tool_only.tito_tokenizer)
+
+    def test_user_append_rejected(self, registry_tool_only: SessionRegistry):
+        sid = registry_tool_only.create_session()
+        session = registry_tool_only.get_session(sid)
+        session.update_pretokenized_state([SYS_MSG, USER_MSG], ASSISTANT_MSG_1, [1, 2, 3], [10], max_trim_tokens=0)
+
+        messages = [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1, {"role": "user", "content": "extra"}]
         with pytest.raises(MessageValidationError, match="role='user'.*allowed="):
-            session.prepare_pretokenized(messages, tito_tokenizer=registry.tito_tokenizer)
+            session.prepare_pretokenized(messages, tito_tokenizer=registry_tool_only.tito_tokenizer)
+
+
+class TestAppendRoleAssistant:
+    """A template supporting tool, user, and injected assistant appends.
+
+    Injected assistant input joins the prompt region of the next sample (the
+    loss mask only ever covers generated response tokens)."""
+
+    def test_assistant_append_allowed(self, registry_with_assistant: SessionRegistry):
+        sid = registry_with_assistant.create_session()
+        session = registry_with_assistant.get_session(sid)
+        session.update_pretokenized_state([SYS_MSG, USER_MSG], ASSISTANT_MSG_1, [1, 2, 3], [10], max_trim_tokens=0)
+
+        messages = [
+            SYS_MSG,
+            USER_MSG,
+            ASSISTANT_MSG_1,
+            TOOL_MSG_1,
+            {"role": "assistant", "content": "injected"},
+            {"role": "user", "content": "next"},
+        ]
+        result = session.prepare_pretokenized(messages, tito_tokenizer=registry_with_assistant.tito_tokenizer)
+        assert isinstance(result, list)
 
 
 class TestAppendRoleToolSystem:
-    """Config: allowed_append_roles=['tool', 'system']."""
+    """A template supporting tool and system appends."""
 
     def test_tool_append_allowed(self, registry_with_system: SessionRegistry):
         sid = registry_with_system.create_session()
@@ -379,7 +438,7 @@ class TestAppendRoleToolSystem:
 
 
 class TestAppendRoleToolUser:
-    """Config: allowed_append_roles=['tool', 'user']; user follow-ups are allowed here."""
+    """A template supporting tool and user appends."""
 
     def test_tool_append_allowed(self, registry_with_user: SessionRegistry):
         sid = registry_with_user.create_session()

--- a/tests/fast/router/test_session_pretokenized_e2e.py
+++ b/tests/fast/router/test_session_pretokenized_e2e.py
@@ -43,25 +43,25 @@ FIXED_TEMPLATE_SMOKE_CONFIGS: tuple[FixedTemplateSmokeConfig, ...] = (
     FixedTemplateSmokeConfig(
         name="qwen3-fixed",
         hf_checkpoint="Qwen/Qwen3-0.6B",
-        chat_template_path=resolve_fixed_chat_template(TITOTokenizerType.QWEN3, ["tool"])[0],
+        chat_template_path=resolve_fixed_chat_template(TITOTokenizerType.QWEN3)[0],
         tito_model=TITOTokenizerType.QWEN3.value,
     ),
     FixedTemplateSmokeConfig(
         name="qwen3.5-fixed",
         hf_checkpoint="Qwen/Qwen3.5-0.8B",
-        chat_template_path=resolve_fixed_chat_template(TITOTokenizerType.QWEN35, ["tool"])[0],
+        chat_template_path=resolve_fixed_chat_template(TITOTokenizerType.QWEN35)[0],
         tito_model=TITOTokenizerType.QWEN35.value,
     ),
     FixedTemplateSmokeConfig(
         name="qwen3-thinking2507-fixed",
         hf_checkpoint="Qwen/Qwen3-4B-Thinking-2507",
-        chat_template_path=resolve_fixed_chat_template(TITOTokenizerType.QWENNEXT, ["tool"])[0],
+        chat_template_path=resolve_fixed_chat_template(TITOTokenizerType.QWENNEXT)[0],
         tito_model=TITOTokenizerType.QWENNEXT.value,
     ),
     FixedTemplateSmokeConfig(
         name="qwen3-next-thinking-fixed",
         hf_checkpoint="Qwen/Qwen3-Next-80B-A3B-Thinking",
-        chat_template_path=resolve_fixed_chat_template(TITOTokenizerType.QWENNEXT, ["tool"])[0],
+        chat_template_path=resolve_fixed_chat_template(TITOTokenizerType.QWENNEXT)[0],
         tito_model=TITOTokenizerType.QWENNEXT.value,
     ),
 )
@@ -113,7 +113,6 @@ def test_bundled_fixed_template_session_smoke(config: FixedTemplateSmokeConfig):
         hf_checkpoint=config.hf_checkpoint,
         chat_template_path=config.chat_template_path,
         tito_model=config.tito_model,
-        allowed_append_roles=["tool"],
     )
 
     try:
@@ -149,7 +148,6 @@ def test_bundled_fixed_template_session_smoke(config: FixedTemplateSmokeConfig):
             local_mismatch = compute_local_session_mismatch(
                 tokenizer,
                 tito_model=config.tito_model,
-                allowed_append_roles=["tool"],
                 messages=session_messages,
                 accumulated_token_ids=metadata["accumulated_token_ids"],
                 tools=trajectory.tools,

--- a/tests/fast/utils/chat_template_utils/test_fixed_templates.py
+++ b/tests/fast/utils/chat_template_utils/test_fixed_templates.py
@@ -1,8 +1,7 @@
-"""Unit tests for ``resolve_fixed_chat_template`` smallest-superset lookup.
+"""Unit tests for ``resolve_fixed_chat_template`` — one template per family.
 
-Rows live as ``SUPPORTED_TEMPLATES`` class attributes on each
-``TITOTokenizer`` subclass; the resolver picks the smallest superset of the
-caller's ``allowed_append_roles`` and returns ``(template_path, extra_kwargs)``.
+Each ``TITOTokenizer`` subclass registers a single ``FIXED_TEMPLATE``:
+template path, required kwargs, and the role surface that renderer supports.
 """
 
 import os
@@ -10,180 +9,92 @@ import os
 import pytest
 
 from miles.utils.chat_template_utils import TEMPLATE_DIR, TITOTokenizerType, resolve_fixed_chat_template
-from miles.utils.chat_template_utils.tito_tokenizer import FixedTemplateRow, Qwen3TITOTokenizer, Qwen35TITOTokenizer
+from miles.utils.chat_template_utils.tito_tokenizer import (
+    ALL_APPEND_ROLES,
+    FixedTemplate,
+    MinimaxM25TITOTokenizer,
+    MinimaxM27TITOTokenizer,
+    Qwen3TITOTokenizer,
+    Qwen35TITOTokenizer,
+    TITOTokenizer,
+)
 
-_QWEN3_FIXED = str(TEMPLATE_DIR / "qwen3_fixed.jinja")
-_QWEN35_FIXED = str(TEMPLATE_DIR / "qwen3.5_fixed.jinja")
-_THINKING_FIXED = str(TEMPLATE_DIR / "qwen3_thinking_2507_and_next_fixed.jinja")
+_EXPECTED_FIXED_TEMPLATES = {
+    TITOTokenizerType.QWEN3: ("qwen3_fixed.jinja", {"clear_thinking": False}),
+    TITOTokenizerType.QWEN35: ("qwen3.5_fixed.jinja", {"clear_thinking": False}),
+    TITOTokenizerType.QWENNEXT: ("qwen3_thinking_2507_and_next_fixed.jinja", {"clear_thinking": False}),
+    TITOTokenizerType.GLM47: (None, {"clear_thinking": False}),
+    TITOTokenizerType.NEMOTRON3: (None, {"truncate_history_thinking": False}),
+    TITOTokenizerType.KIMI25: ("kimi_k25_fixed.jinja", {"preserve_thinking": True}),
+    TITOTokenizerType.KIMI26: (None, {"preserve_thinking": True}),
+    TITOTokenizerType.MINIMAX_M25: ("minimax_m25_fixed.jinja", {"clear_thinking": False}),
+    TITOTokenizerType.MINIMAX_M27: ("minimax_m27_fixed.jinja", {"clear_thinking": False}),
+    TITOTokenizerType.DEEPSEEKV32: (None, {"drop_thinking": False}),
+    TITOTokenizerType.DEEPSEEKV4: (None, {"drop_thinking": False}),
+}
+
+
+def test_every_non_default_family_is_covered():
+    # New families must register a FIXED_TEMPLATE and take a row here.
+    assert set(_EXPECTED_FIXED_TEMPLATES) == set(TITOTokenizerType) - {TITOTokenizerType.DEFAULT}
 
 
 @pytest.mark.parametrize(
-    "tito_model, expected_path",
-    [
-        (TITOTokenizerType.QWEN3, _QWEN3_FIXED),
-        (TITOTokenizerType.QWEN35, _QWEN35_FIXED),
-        (TITOTokenizerType.QWENNEXT, _THINKING_FIXED),
-    ],
+    "tito_model", list(_EXPECTED_FIXED_TEMPLATES), ids=[t.value for t in _EXPECTED_FIXED_TEMPLATES]
 )
-def test_tool_only_resolution_matches_registered_template(tito_model, expected_path):
-    path, kwargs = resolve_fixed_chat_template(tito_model, ["tool"])
-    assert path == expected_path
-    assert kwargs == {}
-    assert os.path.isfile(path)
+def test_family_resolves_template_and_preserve_think_kwargs(tito_model):
+    # Every family pins its preserve-think kwargs unconditionally, so renders
+    # stay append-only regardless of which roles the harness appends.
+    expected_template, expected_kwargs = _EXPECTED_FIXED_TEMPLATES[tito_model]
+    path, kwargs = resolve_fixed_chat_template(tito_model)
+    if expected_template is None:
+        assert path is None
+    else:
+        assert path == str(TEMPLATE_DIR / expected_template)
+        assert os.path.isfile(path)
+    assert kwargs == expected_kwargs
 
 
-def test_deepseek_v4_tool_only_is_hf_native_no_kwargs():
-    # The native tool-calling surface keeps the HF-native dsv4 bridge with no
-    # kwargs override; the encoder itself forces drop_thinking=False whenever
-    # `tools` are present, so this surface is already append-only.
-    path, kwargs = resolve_fixed_chat_template(TITOTokenizerType.DEEPSEEKV4, ["tool"])
-    assert path is None
-    assert kwargs == {}
+def test_default_family_uses_native_template():
+    assert resolve_fixed_chat_template(TITOTokenizerType.DEFAULT) == (None, {})
 
 
-def test_deepseek_v4_tool_user_pins_drop_thinking_false():
-    # OpenEnv-style text-protocol scaffolds append env output as plain `user`
-    # turns and pass no `tools`. Without drop_thinking=False the encoder strips
-    # prior assistants' thinking once a new user turn advances last_user_index —
-    # a non-append-only mutation that corrupts the pretokenized prefix and NaNs
-    # the first backward. This row must pin drop_thinking=False.
-    path, kwargs = resolve_fixed_chat_template(TITOTokenizerType.DEEPSEEKV4, ["tool", "user"])
-    assert path is None
-    assert kwargs == {"drop_thinking": False}
+def test_fixed_template_defaults_to_all_roles():
+    fixed = FixedTemplate()
+    assert fixed.allowed_append_roles == ALL_APPEND_ROLES
+    assert isinstance(fixed.allowed_append_roles, frozenset)
+    assert TITOTokenizer.FIXED_TEMPLATE == fixed
 
 
-@pytest.mark.parametrize("roles", [["tool"], ["tool", "user"]])
-def test_deepseek_v32_pins_drop_thinking_false_on_every_surface(roles):
-    # The vendored encoding_dsv32 honors drop_thinking=False at the render
-    # level (unlike upstream, which strips historical thinking whenever a new
-    # user turn advances last_user_index).  Every V3.2 surface pins it so
-    # renders stay append-only for both tool and user appends.
-    path, kwargs = resolve_fixed_chat_template(TITOTokenizerType.DEEPSEEKV32, roles)
-    assert path is None
-    assert kwargs == {"drop_thinking": False}
+def test_fixed_template_rejects_unknown_role():
+    with pytest.raises(ValueError, match="Unknown FixedTemplate allowed_append_roles"):
+        FixedTemplate(allowed_append_roles=frozenset({"developer"}))
 
 
 @pytest.mark.parametrize(
-    "tito_model",
-    [TITOTokenizerType.QWEN3, TITOTokenizerType.QWEN35, TITOTokenizerType.QWENNEXT],
+    "tokenizer_cls",
+    [Qwen35TITOTokenizer, MinimaxM25TITOTokenizer, MinimaxM27TITOTokenizer],
 )
-def test_no_superset_raises(tito_model):
-    # ``{"tool", "system"}`` has no superset registered for the Qwen fixed
-    # families (which register ``{"tool"}`` and ``{"tool", "user"}``).  The
-    # resolver must surface this as a hard error so the caller cannot silently
-    # fall through to a non-append-only HF render.
-    with pytest.raises(ValueError) as excinfo:
-        resolve_fixed_chat_template(tito_model, ["tool", "system"])
-    msg = str(excinfo.value)
-    assert f"tito_model={tito_model.value}" in msg
-    assert "allowed_append_roles=['system', 'tool']" in msg
-    assert "SUPPORTED_TEMPLATES" in msg
+def test_restricted_fixed_template_excludes_mid_session_system(tokenizer_cls):
+    assert tokenizer_cls.FIXED_TEMPLATE.allowed_append_roles == frozenset({"tool", "user", "assistant"})
 
 
-# ---------------------------------------------------------------------------
-# Smallest-superset semantics — covered with monkeypatched class attributes
-# so the behavior is pinned independently of which rows happen to be
-# registered today.
-# ---------------------------------------------------------------------------
+def test_string_tito_model_accepted():
+    assert resolve_fixed_chat_template("qwen3") == resolve_fixed_chat_template(TITOTokenizerType.QWEN3)
 
 
-def test_subset_caller_falls_through_to_multi_role_row(monkeypatch):
-    # Only a multi-role row is registered; a strict-subset caller resolves to it.
+def test_kwargs_are_copied_not_shared(monkeypatch):
+    # Mutating the returned kwargs must not leak into the registration.
     monkeypatch.setattr(
         Qwen3TITOTokenizer,
-        "SUPPORTED_TEMPLATES",
-        (
-            FixedTemplateRow(
-                allowed_roles=frozenset({"tool", "user"}),
-                template="fake.jinja",
-            ),
-        ),
+        "FIXED_TEMPLATE",
+        FixedTemplate(template=None, extra_kwargs={"clear_thinking": False}),
     )
-    path, kwargs = resolve_fixed_chat_template(TITOTokenizerType.QWEN3, ["tool"])
-    assert path == str(TEMPLATE_DIR / "fake.jinja")
-    assert kwargs == {}
+    _path, kwargs = resolve_fixed_chat_template(TITOTokenizerType.QWEN3)
+    kwargs["clear_thinking"] = True
+    assert Qwen3TITOTokenizer.FIXED_TEMPLATE.extra_kwargs == {"clear_thinking": False}
 
 
-def test_exact_match_wins_over_strict_superset(monkeypatch):
-    # Both an exact ``{tool}`` row and a multi-role ``{tool, user}`` row exist.
-    # Smallest-cardinality wins, so caller ``["tool"]`` gets the exact row.
-    monkeypatch.setattr(
-        Qwen3TITOTokenizer,
-        "SUPPORTED_TEMPLATES",
-        (
-            FixedTemplateRow(
-                allowed_roles=frozenset({"tool"}),
-                template="exact.jinja",
-            ),
-            FixedTemplateRow(
-                allowed_roles=frozenset({"tool", "user"}),
-                template="multi.jinja",
-            ),
-        ),
-    )
-    path, kwargs = resolve_fixed_chat_template(TITOTokenizerType.QWEN3, ["tool"])
-    assert path == str(TEMPLATE_DIR / "exact.jinja")
-    assert kwargs == {}
-
-
-def test_ambiguous_minimal_supersets_raise(monkeypatch):
-    # Two rows of equal cardinality both ⊇ caller's roles → ambiguous.
-    monkeypatch.setattr(
-        Qwen3TITOTokenizer,
-        "SUPPORTED_TEMPLATES",
-        (
-            FixedTemplateRow(
-                allowed_roles=frozenset({"tool", "user"}),
-                template="a.jinja",
-            ),
-            FixedTemplateRow(
-                allowed_roles=frozenset({"tool", "system"}),
-                template="b.jinja",
-            ),
-        ),
-    )
-    with pytest.raises(ValueError, match="Ambiguous fixed-template registration"):
-        resolve_fixed_chat_template(TITOTokenizerType.QWEN3, ["tool"])
-
-
-def test_other_tito_model_rows_ignored(monkeypatch):
-    # Rows for a different tito_model never participate in the match — when
-    # the requested family has nothing registered, the resolver must throw.
-    monkeypatch.setattr(Qwen3TITOTokenizer, "SUPPORTED_TEMPLATES", ())
-    monkeypatch.setattr(
-        Qwen35TITOTokenizer,
-        "SUPPORTED_TEMPLATES",
-        (
-            FixedTemplateRow(
-                allowed_roles=frozenset({"tool"}),
-                template="qwen35.jinja",
-            ),
-        ),
-    )
-    with pytest.raises(ValueError, match="No SUPPORTED_TEMPLATES row registered"):
-        resolve_fixed_chat_template(TITOTokenizerType.QWEN3, ["tool"])
-
-
-def test_kwargs_only_row_returns_none_path_and_kwargs(monkeypatch):
-    # A row with template=None registers a kwargs-only fix (HF native + kwargs
-    # override).  Resolver returns (None, kwargs) so caller can keep the HF
-    # template and merge the kwargs.
-    monkeypatch.setattr(
-        Qwen3TITOTokenizer,
-        "SUPPORTED_TEMPLATES",
-        (
-            FixedTemplateRow(
-                allowed_roles=frozenset({"tool", "user"}),
-                template=None,
-                extra_kwargs={"clear_thinking": False},
-            ),
-        ),
-    )
-    path, kwargs = resolve_fixed_chat_template(TITOTokenizerType.QWEN3, ["tool", "user"])
-    assert path is None
-    assert kwargs == {"clear_thinking": False}
-
-
-def test_invalid_role_raises():
-    with pytest.raises(ValueError, match="Unknown roles"):
-        resolve_fixed_chat_template(TITOTokenizerType.QWEN3, ["tool", "users"])
+def test_registered_kwargs_cannot_be_overridden():
+    with pytest.raises(ValueError, match="conflicts with the value registered"):
+        Qwen3TITOTokenizer(object(), chat_template_kwargs={"clear_thinking": True})

--- a/tests/fast/utils/chat_template_utils/test_pretokenized_chat.py
+++ b/tests/fast/utils/chat_template_utils/test_pretokenized_chat.py
@@ -12,7 +12,7 @@ from copy import deepcopy
 import pytest
 
 from miles.utils.chat_template_utils import TITOTokenizerType, resolve_fixed_chat_template
-from miles.utils.chat_template_utils.template import load_hf_chat_template
+from miles.utils.chat_template_utils.template import apply_chat_template_from_str, load_hf_chat_template
 from miles.utils.test_utils.chat_template_verify import (
     CaseSpec,
     assert_pretokenized_equals_standard,
@@ -30,15 +30,8 @@ from miles.utils.test_utils.mock_trajectories import (
 
 
 def _load_fixed(tito_model: TITOTokenizerType) -> str:
-    path, _kwargs = resolve_fixed_chat_template(tito_model, ["tool"])
+    path, _kwargs = resolve_fixed_chat_template(tito_model)
     assert path is not None, f"resolve_fixed_chat_template should resolve {tito_model.value}"
-    with open(path) as f:
-        return f.read()
-
-
-def _load_fixed_for_roles(tito_model: TITOTokenizerType, roles: list[str]) -> str:
-    path, _kwargs = resolve_fixed_chat_template(tito_model, roles)
-    assert path is not None, f"resolve_fixed_chat_template should resolve {tito_model.value} for roles={roles}"
     with open(path) as f:
         return f.read()
 
@@ -49,22 +42,12 @@ def _load_fixed_for_roles(tito_model: TITOTokenizerType, roles: list[str]) -> st
 #
 # Each entry: (name, content, supports_thinking, allowed_append_roles, extra_template_kwargs)
 #
-# Design:
-# * fixed templates default to {tool} only.  When a fixed template carries a
-#   clear_thinking kwarg gate (Qwen3 today), a *_clear_thinking_off entry with
-#   {tool, user} + clear_thinking=False covers the multi-user-append surface
-#   the same way GLM does on its HF-native template.
-# * GLM thinking templates are covered twice: a default entry (tool only, no
-#   kwargs) matching production behavior, and a *_clear_thinking_off entry that
-#   adds {user} to allowed roles with clear_thinking=False to preserve
-#   reasoning across user turns (GLM's canonical pattern for session reset).
-# * Other non-thinking HF native templates only test {tool} — scope aligned
-#   with fixed.
-# * system role is never tested here; those trajectories remain in ALL_CASES
-#   for CLI use but are filtered out of this test by the above role sets.
+# Role sets only filter this test's shared non-assistant trajectories; template
+# resolution is role-independent. Rows without preserve-think kwargs are comparison
+# baselines, and system trajectories run only for rows that include ``system``.
 
 _TEMPLATES: list[tuple[str, str, bool, frozenset[str], dict]] = [
-    # fixed templates: tool only
+    # Qwen fixed-template comparison rows
     ("qwen3_fixed", _load_fixed(TITOTokenizerType.QWEN3), True, frozenset({"tool"}), {}),
     (
         "qwen3_fixed_clear_thinking_off",
@@ -117,7 +100,7 @@ _TEMPLATES: list[tuple[str, str, bool, frozenset[str], dict]] = [
     # Kimi K2: K2.5 needs patched jinja gating the "drop reasoning of prior
     # assistants once a non-tool-call assistant arrives" loop on
     # preserve_thinking=True; K2.6 already exposes that gate natively.
-    # Only {tool, user} surface registered per current onboarding.
+    # This matrix covers their tool/user trajectories.
     (
         "kimi_k25_fixed_preserve_thinking",
         _load_fixed(TITOTokenizerType.KIMI25),
@@ -132,15 +115,13 @@ _TEMPLATES: list[tuple[str, str, bool, frozenset[str], dict]] = [
         frozenset({"tool", "user"}),
         {"preserve_thinking": True},
     ),
-    # MiniMax-M2 family (M2.5, M2.7): thinking via reasoning_content; reasoning
-    # is rendered only for assistant turns after the last user (last_user_index
-    # gate), so appending a new user would strip prior <think> blocks.  {tool}
-    # uses HF-native template; {tool, user} requires the fixed jinja with
-    # clear_thinking=False to preserve history reasoning across user turns.
+    # MiniMax reasoning is gated by last_user_index, so user appends can strip
+    # prior thinking. The matrix keeps HF-native tool-only baselines for comparison;
+    # family auto-resolution uses FIXED_TEMPLATE with clear_thinking=False.
     ("minimax_m25", load_hf_chat_template("MiniMaxAI/MiniMax-M2.5"), True, frozenset({"tool"}), {}),
     (
         "minimax_m25_fixed_clear_thinking_off",
-        _load_fixed_for_roles(TITOTokenizerType.MINIMAX_M25, ["tool", "user"]),
+        _load_fixed(TITOTokenizerType.MINIMAX_M25),
         True,
         frozenset({"tool", "user"}),
         {"clear_thinking": False},
@@ -148,15 +129,13 @@ _TEMPLATES: list[tuple[str, str, bool, frozenset[str], dict]] = [
     ("minimax_m27", load_hf_chat_template("MiniMaxAI/MiniMax-M2.7"), True, frozenset({"tool"}), {}),
     (
         "minimax_m27_fixed_clear_thinking_off",
-        _load_fixed_for_roles(TITOTokenizerType.MINIMAX_M27, ["tool", "user"]),
+        _load_fixed(TITOTokenizerType.MINIMAX_M27),
         True,
         frozenset({"tool", "user"}),
         {"clear_thinking": False},
     ),
-    # Nemotron 3 Super: HF-native template is append-only.  No fixed jinja is
-    # shipped (SUPPORTED_TEMPLATES.template=None on all surfaces); multi-user
-    # surfaces require truncate_history_thinking=False to preserve reasoning
-    # across user turns, while {tool}-only does not.
+    # Nemotron uses its HF-native template with fixed kwargs. Family auto-resolution
+    # pins truncate_history_thinking=False; the matrix keeps a native tool baseline.
     (
         "nemotron3",
         load_hf_chat_template("nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16"),
@@ -178,7 +157,7 @@ _TEMPLATES: list[tuple[str, str, bool, frozenset[str], dict]] = [
         frozenset({"tool", "user", "system"}),
         {"truncate_history_thinking": False},
     ),
-    # other HF native non-thinking: tool only
+    # Other HF-native comparison rows: tool-only trajectories
     ("qwen3_instruct_2507", load_hf_chat_template("Qwen/Qwen3-4B-Instruct-2507"), False, frozenset({"tool"}), {}),
     ("qwen3_next_instruct", load_hf_chat_template("Qwen/Qwen3-Next-80B-A3B-Instruct"), False, frozenset({"tool"}), {}),
     ("qwen3_coder_next", load_hf_chat_template("Qwen/Qwen3-Coder-Next"), False, frozenset({"tool"}), {}),
@@ -301,3 +280,69 @@ def test_cross_user_turn_thinking_prefix_mismatch(chat_template, enable_thinking
             tools=MultiUserTurnThinkingTrajectory.TOOLS,
             enable_thinking=enable_thinking,
         )
+
+
+# ---------------------------------------------------------------------------
+# Intermediate system / injected-assistant appends — role-independent surface
+# ---------------------------------------------------------------------------
+#
+# allowed_append_roles no longer participates in template resolution. Each
+# family/shape cell must either remain append-only or match its fixed-template
+# rejection contract.
+# DeepSeek V3.2/V4 ride the encoder bridge and are covered in their own files.
+
+_APPEND_ROLE_FAMILIES = [
+    (TITOTokenizerType.QWEN3, None),
+    (TITOTokenizerType.QWEN35, None),
+    (TITOTokenizerType.QWENNEXT, None),
+    (TITOTokenizerType.GLM47, "zai-org/GLM-4.7-Flash"),
+    (TITOTokenizerType.KIMI25, None),
+    (TITOTokenizerType.KIMI26, "moonshotai/Kimi-K2.6"),
+    (TITOTokenizerType.MINIMAX_M25, None),
+    (TITOTokenizerType.MINIMAX_M27, None),
+    (TITOTokenizerType.NEMOTRON3, "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16"),
+]
+
+_APPEND_SHAPES = {
+    "system": [{"role": "system", "content": "mid-session system"}],
+    "assistant": [{"role": "assistant", "content": "injected", "reasoning_content": ""}],
+    "assistant_then_user": [
+        {"role": "assistant", "content": "injected", "reasoning_content": ""},
+        {"role": "user", "content": "next question"},
+    ],
+    "consecutive_assistants_then_user": [
+        {"role": "assistant", "content": "first injected"},
+        {"role": "assistant", "content": "second injected"},
+        {"role": "user", "content": "next question"},
+    ],
+}
+
+
+@pytest.mark.parametrize("shape", list(_APPEND_SHAPES), ids=list(_APPEND_SHAPES))
+@pytest.mark.parametrize("family, hf_model_id", _APPEND_ROLE_FAMILIES, ids=[f.value for f, _ in _APPEND_ROLE_FAMILIES])
+def test_appends_are_append_only_on_family_template(family, hf_model_id, shape):
+    path, kwargs = resolve_fixed_chat_template(family)
+    if path is not None:
+        with open(path, encoding="utf-8") as f:
+            template = f.read()
+    else:
+        template = load_hf_chat_template(hf_model_id)
+    history = [
+        {"role": "user", "content": "q1"},
+        {"role": "assistant", "content": "a1", "reasoning_content": "r1"},
+    ]
+
+    base = apply_chat_template_from_str(template, history, add_generation_prompt=False, **kwargs)
+    if family is TITOTokenizerType.QWEN35 and shape == "system":
+        with pytest.raises(ValueError, match="System message must be at the beginning"):
+            apply_chat_template_from_str(
+                template,
+                history + _APPEND_SHAPES[shape],
+                add_generation_prompt=False,
+                **kwargs,
+            )
+        return
+    full = apply_chat_template_from_str(
+        template, history + _APPEND_SHAPES[shape], add_generation_prompt=False, **kwargs
+    )
+    assert full.startswith(base)

--- a/tests/fast/utils/chat_template_utils/test_pretokenized_via_tito.py
+++ b/tests/fast/utils/chat_template_utils/test_pretokenized_via_tito.py
@@ -27,19 +27,18 @@ from miles.utils.test_utils.mock_trajectories import SingleToolTrajectory
 def _setup_tokenizer_with_registered_template(
     model_id: str,
     family: TITOTokenizerType,
-    roles: list[str],
 ):
     """Mirror what production wiring does at startup.
 
-    Loads tokenizer, looks up the registered ``SUPPORTED_TEMPLATES`` row for
-    ``(family, roles)``, and applies the resolved fixed template (if any) onto
+    Loads tokenizer, resolves the family's ``FIXED_TEMPLATE`` (resolution is
+    role-independent), and applies the fixed template (if any) onto
     ``tokenizer.chat_template``. Returns ``(tokenizer, extra_kwargs)``.
 
     A fresh tokenizer instance per call avoids state-mutation hazards from
     overwriting ``chat_template``.
     """
     tokenizer = AutoTokenizer.from_pretrained(model_id)
-    fixed_path, extra_kwargs = resolve_fixed_chat_template(family, roles)
+    fixed_path, extra_kwargs = resolve_fixed_chat_template(family)
     if fixed_path is not None:
         with open(fixed_path) as f:
             tokenizer.chat_template = f.read()
@@ -47,47 +46,31 @@ def _setup_tokenizer_with_registered_template(
 
 
 # ---------------------------------------------------------------------------
-# (1) PASS on registered families × role surfaces
+# (1) PASS on registered families
 # ---------------------------------------------------------------------------
 
 
 _PASS_PARAMS = [
-    pytest.param(TITOTokenizerType.QWEN3, "Qwen/Qwen3-0.6B", frozenset({"tool"}), id="qwen3-tool"),
-    pytest.param(TITOTokenizerType.QWEN3, "Qwen/Qwen3-0.6B", frozenset({"tool", "user"}), id="qwen3-tool_user"),
-    pytest.param(TITOTokenizerType.QWEN35, "Qwen/Qwen3.5-0.8B", frozenset({"tool"}), id="qwen35-tool"),
-    pytest.param(TITOTokenizerType.QWEN35, "Qwen/Qwen3.5-0.8B", frozenset({"tool", "user"}), id="qwen35-tool_user"),
-    pytest.param(TITOTokenizerType.QWENNEXT, "Qwen/Qwen3-4B-Thinking-2507", frozenset({"tool"}), id="qwennext-tool"),
-    pytest.param(
-        TITOTokenizerType.QWENNEXT,
-        "Qwen/Qwen3-4B-Thinking-2507",
-        frozenset({"tool", "user"}),
-        id="qwennext-tool_user",
-    ),
-    pytest.param(TITOTokenizerType.GLM47, "zai-org/GLM-4.7-Flash", frozenset({"tool"}), id="glm47-tool"),
-    pytest.param(TITOTokenizerType.GLM47, "zai-org/GLM-4.7-Flash", frozenset({"tool", "user"}), id="glm47-tool_user"),
-    pytest.param(
-        TITOTokenizerType.GLM47,
-        "zai-org/GLM-4.7-Flash",
-        frozenset({"tool", "user", "system"}),
-        id="glm47-tool_user_system",
-    ),
+    pytest.param(TITOTokenizerType.QWEN3, "Qwen/Qwen3-0.6B", id="qwen3"),
+    pytest.param(TITOTokenizerType.QWEN35, "Qwen/Qwen3.5-0.8B", id="qwen35"),
+    pytest.param(TITOTokenizerType.QWENNEXT, "Qwen/Qwen3-4B-Thinking-2507", id="qwennext"),
+    pytest.param(TITOTokenizerType.GLM47, "zai-org/GLM-4.7-Flash", id="glm47"),
 ]
 
 
-@pytest.mark.parametrize("family,model_id,roles", _PASS_PARAMS)
-def test_via_tito_pass_on_registered_families(family, model_id, roles):
+@pytest.mark.parametrize("family,model_id", _PASS_PARAMS)
+def test_via_tito_pass_on_registered_families(family, model_id):
     """All 4 registered TITO families round-trip cleanly via decode-roundtrip."""
-    tokenizer, extra_kwargs = _setup_tokenizer_with_registered_template(model_id, family, sorted(roles))
+    tokenizer, extra_kwargs = _setup_tokenizer_with_registered_template(model_id, family)
     results = run_all_checks_via_tito(
         tokenizer,
         family,
-        allowed_append_roles=set(roles),
         thinking="both",
         extra_template_kwargs=extra_kwargs,
     )
     failures = [r for r in results if not r.passed]
     assert not failures, (
-        f"Expected all PASS for {family.value} × {sorted(roles)} via TITO primitive; "
+        f"Expected all PASS for {family.value} via TITO primitive; "
         f"got {len(failures)} FAIL(s) out of {len(results)}:\n"
         + "\n".join(f"  [{r.case_name}] {r.error}" for r in failures[:5])
     )
@@ -101,14 +84,7 @@ def test_via_tito_pass_on_registered_families(family, model_id, roles):
 _DEEPSEEK_V4_MODEL = "/cluster-storage/models/deepseek-ai/DeepSeek-V4-Flash"
 
 
-@pytest.mark.parametrize(
-    "roles",
-    [
-        pytest.param(frozenset({"tool"}), id="deepseekv4-tool"),
-        pytest.param(frozenset({"tool", "user"}), id="deepseekv4-tool_user"),
-    ],
-)
-def test_via_tito_pass_on_deepseek_v4(roles):
+def test_via_tito_pass_on_deepseek_v4():
     """DSv4's encoder folds contiguous tool/user turns into one ``<｜User｜>``
     block and auto-appends the assistant opener after a user tail; the
     subclass's real-history diff + opener strip must round-trip on both
@@ -117,17 +93,16 @@ def test_via_tito_pass_on_deepseek_v4(roles):
     if not Path(_DEEPSEEK_V4_MODEL).exists():
         pytest.skip(f"DeepSeek V4 tokenizer not found: {_DEEPSEEK_V4_MODEL}")
     tokenizer = AutoTokenizer.from_pretrained(_DEEPSEEK_V4_MODEL, trust_remote_code=True)
-    _fixed_path, extra_kwargs = resolve_fixed_chat_template(TITOTokenizerType.DEEPSEEKV4, sorted(roles))
+    _fixed_path, extra_kwargs = resolve_fixed_chat_template(TITOTokenizerType.DEEPSEEKV4)
     results = run_all_checks_via_tito(
         tokenizer,
         TITOTokenizerType.DEEPSEEKV4,
-        allowed_append_roles=set(roles),
         thinking="both",
         extra_template_kwargs=dict(extra_kwargs),
     )
     failures = [r for r in results if not r.passed]
     assert not failures, (
-        f"Expected all PASS for deepseekv4 × {sorted(roles)} via TITO primitive; "
+        f"Expected all PASS for deepseekv4 via TITO primitive; "
         f"got {len(failures)} FAIL(s) out of {len(results)}:\n"
         + "\n".join(f"  [{r.case_name}] {r.error}" for r in failures[:5])
     )
@@ -155,7 +130,6 @@ def test_via_tito_fail_on_original_qwen3_template():
     results = run_all_checks_via_tito(
         tokenizer,
         TITOTokenizerType.QWEN3,
-        allowed_append_roles={"tool", "user"},
         thinking="both",
     )
     failures = [r for r in results if not r.passed]
@@ -185,8 +159,8 @@ class _BuggyQwen3TITOTokenizer(Qwen3TITOTokenizer):
 
 def test_via_tito_fail_on_buggy_qwen3_subclass():
     """A buggy ``merge_tokens`` produces a junction-level diff that the verifier surfaces."""
-    tokenizer, _ = _setup_tokenizer_with_registered_template("Qwen/Qwen3-0.6B", TITOTokenizerType.QWEN3, ["tool"])
-    buggy = _BuggyQwen3TITOTokenizer(tokenizer, allowed_append_roles=["tool"])
+    tokenizer, _ = _setup_tokenizer_with_registered_template("Qwen/Qwen3-0.6B", TITOTokenizerType.QWEN3)
+    buggy = _BuggyQwen3TITOTokenizer(tokenizer)
 
     result = verify_append_only_via_tito_instance(
         buggy,

--- a/tests/fast/utils/chat_template_utils/test_template.py
+++ b/tests/fast/utils/chat_template_utils/test_template.py
@@ -180,7 +180,7 @@ def _load_fixed_or_none(tito_model: TITOTokenizerType | None) -> str | None:
     """Return the bundled fixed chat-template content for *tito_model*, or ``None``."""
     if tito_model is None:
         return None
-    path, _kwargs = resolve_fixed_chat_template(tito_model, ["tool"])
+    path, _kwargs = resolve_fixed_chat_template(tito_model)
     if path is None:
         return None
     with open(path) as f:

--- a/tests/fast/utils/chat_template_utils/test_tito_tokenizer.py
+++ b/tests/fast/utils/chat_template_utils/test_tito_tokenizer.py
@@ -54,7 +54,9 @@ from transformers import AutoTokenizer
 
 from miles.utils.chat_template_utils import MismatchType, apply_chat_template, resolve_fixed_chat_template
 from miles.utils.chat_template_utils.tito_tokenizer import (
+    ALL_APPEND_ROLES,
     DeepSeekV32TITOTokenizer,
+    FixedTemplate,
     GLM47TITOTokenizer,
     Qwen3TITOTokenizer,
     Qwen35TITOTokenizer,
@@ -84,7 +86,7 @@ _TOK_CACHE: dict[tuple[str, str | None], AutoTokenizer] = {}
 
 
 def _get_tokenizer(model_id: str, tito_type: TITOTokenizerType | None = None) -> AutoTokenizer:
-    chat_template_path = resolve_fixed_chat_template(tito_type, ["tool"])[0] if tito_type is not None else None
+    chat_template_path = resolve_fixed_chat_template(tito_type)[0] if tito_type is not None else None
     cache_key = (model_id, chat_template_path)
     if cache_key not in _TOK_CACHE:
         _TOK_CACHE[cache_key] = load_tokenizer(
@@ -108,8 +110,6 @@ _TITO_MODELS: dict[str, tuple[str, type[TITOTokenizer], TITOTokenizerType]] = {
     "glm47": ("zai-org/GLM-4.7-Flash", GLM47TITOTokenizer, TITOTokenizerType.GLM47),
 }
 
-_ALLOWED_APPEND_ROLES = ["tool", "user", "system"]
-
 
 @pytest.fixture(params=list(_TITO_MODELS.keys()))
 def tito(request) -> TITOTokenizer:
@@ -117,7 +117,6 @@ def tito(request) -> TITOTokenizer:
     return cls(
         _get_tokenizer(model_id, tito_type),
         chat_template_kwargs={"clear_thinking": False},
-        allowed_append_roles=_ALLOWED_APPEND_ROLES,
     )
 
 
@@ -126,7 +125,6 @@ def qwen3_tito() -> Qwen3TITOTokenizer:
     return Qwen3TITOTokenizer(
         _get_tokenizer("Qwen/Qwen3-4B", TITOTokenizerType.QWEN3),
         chat_template_kwargs={"clear_thinking": False},
-        allowed_append_roles=_ALLOWED_APPEND_ROLES,
     )
 
 
@@ -135,13 +133,12 @@ def glm47_tito() -> GLM47TITOTokenizer:
     return GLM47TITOTokenizer(
         _get_tokenizer("zai-org/GLM-4.7-Flash", TITOTokenizerType.GLM47),
         chat_template_kwargs={"clear_thinking": False},
-        allowed_append_roles=_ALLOWED_APPEND_ROLES,
     )
 
 
 @pytest.fixture
 def default_tito() -> TITOTokenizer:
-    return TITOTokenizer(_get_tokenizer("Qwen/Qwen3-4B"), allowed_append_roles=_ALLOWED_APPEND_ROLES)
+    return TITOTokenizer(_get_tokenizer("Qwen/Qwen3-4B"))
 
 
 # ---------------------------------------------------------------------------
@@ -285,8 +282,14 @@ class TestDeepSeekV32IncrementalAppend:
         [
             [{"role": "user", "content": "next question"}],
             [{"role": "tool", "content": "out", "tool_call_id": "c0"}],
+            [{"role": "assistant", "content": "injected"}, {"role": "user", "content": "next"}],
+            [
+                {"role": "assistant", "content": "first injected"},
+                {"role": "assistant", "content": "second injected"},
+                {"role": "user", "content": "next"},
+            ],
         ],
-        ids=["user", "tool"],
+        ids=["user", "tool", "assistant_then_user", "consecutive_assistants_then_user"],
     )
     def test_incremental_equals_real_history_suffix(self, tmp_path, appended):
         (tmp_path / "config.json").write_text(json.dumps({"model_type": "deepseek_v32"}), encoding="utf-8")
@@ -294,7 +297,6 @@ class TestDeepSeekV32IncrementalAppend:
         tito = DeepSeekV32TITOTokenizer(
             tokenizer,
             chat_template_kwargs={"drop_thinking": False},
-            allowed_append_roles=["tool", "user"],
         )
         old = [
             {"role": "user", "content": "q"},
@@ -514,12 +516,24 @@ class TestTokenizeAdditional:
         with pytest.raises(ValueError, match="fewer"):
             qwen3_tito.tokenize_additional_messages(old_msgs, old_msgs[:1])
 
-    def test_rejects_assistant_append(self, qwen3_tito: Qwen3TITOTokenizer):
-        """Appending an assistant message (not tool/system) raises ValueError."""
+    def test_restricted_template_rejects_unsupported_role(self, qwen3_tito: Qwen3TITOTokenizer):
+        """A template with an explicit narrow capability rejects other roles."""
+
+        class _ToolOnlyQwen3TITOTokenizer(Qwen3TITOTokenizer):
+            FIXED_TEMPLATE = FixedTemplate(
+                template=Qwen3TITOTokenizer.FIXED_TEMPLATE.template,
+                extra_kwargs=dict(Qwen3TITOTokenizer.FIXED_TEMPLATE.extra_kwargs),
+                allowed_append_roles=frozenset({"tool"}),
+            )
+
+        restricted = _ToolOnlyQwen3TITOTokenizer(
+            qwen3_tito.tokenizer,
+            chat_template_kwargs={"clear_thinking": False},
+        )
         old_msgs = SingleToolTrajectory.MESSAGES[:3]
         bad_new = list(old_msgs) + [{"role": "assistant", "content": "hi"}]
         with pytest.raises(ValueError, match="role"):
-            qwen3_tito.tokenize_additional_messages(old_msgs, bad_new)
+            restricted.tokenize_additional_messages(old_msgs, bad_new)
 
 
 # ---------------------------------------------------------------------------
@@ -548,6 +562,7 @@ class TestFactory:
         """Enum values work the same as string values."""
         tito = get_tito_tokenizer(_get_tokenizer("Qwen/Qwen3-4B"), tokenizer_type=TITOTokenizerType.QWEN3)
         assert isinstance(tito, Qwen3TITOTokenizer)
+        assert tito.allowed_append_roles == ALL_APPEND_ROLES
 
     @pytest.mark.parametrize(
         "type_str, cls",
@@ -555,8 +570,8 @@ class TestFactory:
     )
     def test_qwen_variant_inherits_qwen3_boundary_logic(self, type_str, cls):
         """Qwen3.5 / Qwen3-Next reuse Qwen3's boundary handling via inheritance.
-        The named subclass exists so fixed_templates can key on (tito_model,
-        surface) — but token-level merge behavior is identical to Qwen3."""
+        The named subclass owns its FixedTemplate contract, while token-level
+        merge behavior remains identical to Qwen3."""
         tito = get_tito_tokenizer(_get_tokenizer("Qwen/Qwen3-4B"), tokenizer_type=type_str)
         assert isinstance(tito, cls)
         assert isinstance(tito, Qwen3TITOTokenizer)

--- a/tests/fast/utils/chat_template_utils/test_tito_tokenizer.py
+++ b/tests/fast/utils/chat_template_utils/test_tito_tokenizer.py
@@ -26,9 +26,7 @@ TestMergeTokensBoundary
     - Default: plain concatenation (no boundary handling).
 
 TestTokenizeAdditional
-    Behavioral tests for tokenize_additional_messages — the single
-    synthetic-prefix diff that computes incremental token IDs for the complete
-    appended non-assistant suffix.
+    Behavioral tests for tokenize_additional_messages — the single synthetic-prefix diff that computes incremental token IDs for the complete appended suffix.
 
     ``test_produces_nonempty_incremental`` is parametrized over:
       _TOOL_TRAJECTORIES (trajectory classes) × _TITO_MODELS (qwen3, glm47)


### PR DESCRIPTION
## Summary
Each TITO model binds to one fixed chat template; multi-template selection is removed.

## Motivation
`--tito-allowed-append-roles` was an overdesign: it treated chat-template behavior as caller policy and let one model pair with multiple `SUPPORTED_TEMPLATES` rows. Each family now binds its model to exactly one `FixedTemplate` owning the template path, fixed kwargs, and allowed_append_roles (restricted families record the template's real capability); the one-model-multiple-templates implementation is removed, resolution keys on `--tito-model` alone, and conflicting caller values fail loud. Shrinking the customization space makes the TITO tokenizer easier to reason about. The CLI flag still parses here and is removed in the follow-up commit; until then `scripts/tools/verify_chat_template.py` and `tests/manual/session/bench_session_server_overhead.py` still call the two-argument resolver.

## Before / After
- **Before / After:** one model could select among multiple `SUPPORTED_TEMPLATES` rows, keyed by model plus caller-supplied roles.
- Now each family binds one `FIXED_TEMPLATE`; resolution keys on `--tito-model` alone.
- **What moved where:** append-role policy moved from CLI/session configuration into the family classes in `tito_tokenizer.py`; the `FixedTemplate` type lives in `template.py`; 16 files, +449/−569.

## Behavior Changes and Verification
- **Intentional behavior change:** `--tito-model=default` keeps the model's native template, while each named family now unconditionally uses its registered template path, required kwargs, and append-role surface; custom template paths and conflicting required kwargs fail loud.
- **How we know:** migrated assertions in `test_fixed_templates.py` plus `test_tito_tokenizer.py` pin the expected template paths, kwargs, and role sets for every family.

## Verification
- **Existing test suite:** `pytest tests/fast/utils/chat_template_utils tests/fast/router` — 1625 passed at this commit.

## Review Focus
- Scrutinize each family's `FIXED_TEMPLATE` registration in `tito_tokenizer.py` against the `SUPPORTED_TEMPLATES` rows it replaces.
- Scrutinize the fail-loud path for caller role values that previously selected a different row.
