### PR TITLE
refactor(tito): remove --tito-allowed-append-roles and derive append surfaces from fixed templates

### DIFF
--- a/docs/user-guide/agentic-chat-template.md
+++ b/docs/user-guide/agentic-chat-template.md
@@ -14,50 +14,51 @@ Your harness only ever sends and receives **OpenAI chat messages**, never tokens
 Your rollout loop must keep two invariants, or TITO is rejected at runtime:
 
 - **Append-only messages.** Each turn = previous messages + new ones on the tail; past turns are never edited. The only exception is retrying the latest turn — a single-step rollback to the last assistant checkpoint. Diverging earlier, or rolling back more than one turn, is rejected.
-- **Declared roles match the flag.** `--tito-allowed-append-roles` must list exactly the roles your harness appends after the first assistant turn (`tool` is always implied) — Miles resolves a prefix-stable template for that exact set, and appending any role outside it is rejected at runtime.
+- **Appended roles follow the chat template.** After the first assistant message, the selected model's chat template determines which roles may be appended; users do not configure this separately.
 
 ## Pick your `--tito-model`
 
-No auto-detection — pick the family matching your model. Miles then auto-resolves the fixed template from `(--tito-model, --tito-allowed-append-roles)`; pass `--chat-template-path` only to override. The table below lists common models; the full set and verified role surfaces live in [issue #712](https://github.com/radixark/miles/issues/712).
+No auto-detection — pick the family matching your model. For every family, Miles resolves one `FIXED_TEMPLATE` registration from `--tito-model` alone. The registration owns the bundled Jinja template (or HuggingFace-native template) and fixed kwargs. A non-default family rejects `--chat-template-path` overrides and conflicting fixed kwargs; use `--tito-model default` for a custom renderer.
 
-| Your model | `--tito-model` | Max `--tito-allowed-append-roles` |
-|---|---|---|
-| Qwen3 | `qwen3` | `tool user` |
-| Qwen3.5 | `qwen35` | `tool user` |
-| GLM-4.7 / GLM-5 | `glm47` | `tool user system` |
-| NVIDIA Nemotron 3 Super / Ultra | `nemotron3` | `tool user system` |
-| Kimi K2.5 / K2.6 | `kimi25` / `kimi26` | `tool user` |
-| DeepSeek-V3.2 / V4 | `deepseekv32` / `deepseekv4` | `tool` |
-| anything else | `default` | `tool` |
+| Your model | `--tito-model` |
+|---|---|
+| Qwen3 | `qwen3` |
+| Qwen3.5 | `qwen35` |
+| Qwen3-Next | `qwennext` |
+| GLM-4.7 / GLM-5 | `glm47` |
+| NVIDIA Nemotron 3 Super / Ultra | `nemotron3` |
+| Kimi K2.5 / K2.6 | `kimi25` / `kimi26` |
+| MiniMax M2.5 / M2.7 | `minimax_m25` / `minimax_m27` |
+| DeepSeek-V3.2 / V4 | `deepseekv32` / `deepseekv4` |
+| anything else | `default` |
 
-More models: [issue #712](https://github.com/radixark/miles/issues/712).
+More models and verification history live in [issue #712](https://github.com/radixark/miles/issues/712).
 
 ## Turn it on
 
 ```bash
 ROLLOUT_ARGS+=(
-   --use-session-server          # entry point; required for the two flags below
+   --use-session-server          # entry point for TITO session tracking
    --hf-checkpoint Qwen/Qwen3-4B
    --tito-model qwen3
-   --tito-allowed-append-roles tool user
 )
 ```
 
 ## Example
 
-A full multi-turn agentic setup on the session-server TITO path lives in [`examples/experimental/swe-agent-v2`](https://github.com/radixark/miles/tree/main/examples/experimental/swe-agent-v2): its launchers wire `--use-session-server` + `--tito-model glm47` + `--tito-allowed-append-roles user tool` against a real SWE agent.
+A full multi-turn agentic setup on the session-server TITO path lives in [`examples/experimental/swe-agent-v2`](https://github.com/radixark/miles/tree/main/examples/experimental/swe-agent-v2): its launchers wire `--use-session-server` + `--tito-model glm47` against a real SWE agent.
 
 ## Add a new model
 
-Models in the table are verified by Miles maintainers — just pick the family. To support a new model (or a new append-role surface), register a `TITOTokenizer` subclass plus its fixed Jinja template (or HF-native + kwargs) and `SUPPORTED_TEMPLATES` rows in [`tito_tokenizer.py`](https://github.com/radixark/miles/blob/main/miles/utils/chat_template_utils/tito_tokenizer.py), then verify with both scripts — either failing blocks it. Each prints `Verdict: PASS/FAIL`.
+Models in the table are verified by Miles maintainers. To support a new model, register its `TITOTokenizer` and `FIXED_TEMPLATE` in [`tito_tokenizer.py`](https://github.com/radixark/miles/blob/main/miles/utils/chat_template_utils/tito_tokenizer.py), then run both checks below; either failure blocks support.
 
 ```bash
 # CPU / fast — rendered token sequence is append-only
 python scripts/tools/verify_chat_template.py \
-    --model <hf-id> --tito-model <family> --tito-allowed-append-roles tool user
+    --model <hf-id> --tito-model <family>
 
 # GPU / e2e — still holds under real model inference
 python scripts/tools/verify_session_tito_tokenizer.py \
-    --hf-checkpoint <hf-id> --tito-model <family> --tito-allowed-append-roles tool user \
+    --hf-checkpoint <hf-id> --tito-model <family> \
     --sglang-reasoning-parser <rp> --sglang-tool-call-parser <tcp> --rollout-num-gpus-per-engine 1
 ```

--- a/examples/experimental/openenv/openenv_launch_common.py
+++ b/examples/experimental/openenv/openenv_launch_common.py
@@ -114,7 +114,6 @@ def agent_args(tito_model: str, daytona_sandboxes: bool = False) -> str:
         f"--tito-model {tito_model} "
         "--use-session-server "
         "--session-server-port 30000 "
-        "--tito-allowed-append-roles user tool "
     )
 
 

--- a/examples/experimental/swe-agent-v2-amd/run.py
+++ b/examples/experimental/swe-agent-v2-amd/run.py
@@ -179,8 +179,6 @@ def execute(args: ScriptArgs):
         f"--tito-model {args.tito_model} "
         "--use-session-server "
         "--session-server-port 30000 "
-        # This is required by terminus-2 harness
-        "--tito-allowed-append-roles user tool "
     )
 
     misc_args = (

--- a/examples/experimental/swe-agent-v2/run-glm47-flash-agentic-async.py
+++ b/examples/experimental/swe-agent-v2/run-glm47-flash-agentic-async.py
@@ -282,7 +282,6 @@ def execute(args: ScriptArgs):
         "--tito-model glm47 "
         "--use-session-server "
         "--session-server-port 30000 "
-        "--tito-allowed-append-roles user tool "
     )
 
     misc_args = (

--- a/examples/experimental/swe-agent-v2/run.py
+++ b/examples/experimental/swe-agent-v2/run.py
@@ -173,8 +173,6 @@ def execute(args: ScriptArgs):
         "--tito-model glm47 "
         "--use-session-server "
         "--session-server-port 30000 "
-        # This is required by terminus-2 harness
-        "--tito-allowed-append-roles user tool "
     )
 
     misc_args = (

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -2191,14 +2191,6 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 "Controls how token IDs are computed for messages appended after "
                 "the pretokenized prefix in multi-turn agentic sessions.",
             )
-            parser.add_argument(
-                "--tito-allowed-append-roles",
-                nargs="+",
-                default=["tool"],
-                choices=["tool", "user", "system"],
-                help="Message roles allowed to be appended after the pretokenized "
-                "assistant prefix in TITO sessions (default: tool).",
-            )
             return parser
 
         def add_user_provided_function_arguments(parser):
@@ -2450,25 +2442,18 @@ def miles_validate_args(args):
     if args.recompute_logprobs_via_prefill:
         assert args.true_on_policy_mode, "--recompute-logprobs-via-prefill requires --true-on-policy-mode"
 
-    # Normalize --tito-allowed-append-roles: lowercase + deduplicate.
-    raw_roles = getattr(args, "tito_allowed_append_roles", ["tool"])
-    args.tito_allowed_append_roles = sorted(set(r.lower() for r in raw_roles))
+    if not args.use_session_server and args.tito_model != TITOTokenizerType.DEFAULT.value:
+        raise ValueError(
+            f"--tito-model={args.tito_model} requires --use-session-server; "
+            "this flag only configures the session-server TITO middleware."
+        )
 
-    if not args.use_session_server:
-        misconfigured = []
-        if args.tito_model != TITOTokenizerType.DEFAULT.value:
-            misconfigured.append(f"--tito-model={args.tito_model}")
-        if args.tito_allowed_append_roles != ["tool"]:
-            misconfigured.append(f"--tito-allowed-append-roles={args.tito_allowed_append_roles}")
-        if misconfigured:
-            raise ValueError(
-                f"{', '.join(misconfigured)} require --use-session-server; "
-                "these flags only configure the session-server TITO middleware."
-            )
-
-    if "user" in args.tito_allowed_append_roles:
+    # DEFAULT uses the checkpoint's native or caller-provided template.  Its
+    # maximal four-role surface is best-effort rather than a Miles-verified
+    # FixedTemplate contract.
+    if args.use_session_server and args.tito_model == TITOTokenizerType.DEFAULT.value:
         logger.warning(
-            "--tito-allowed-append-roles includes 'user'. "
+            "--tito-model=default uses a best-effort four-role append surface. "
             "Incremental tokenization assumes appended messages do not change how "
             "earlier turns render, which may not hold for user messages on "
             "context-sensitive chat templates (e.g. last_query_index logic, "
@@ -2485,7 +2470,7 @@ def miles_validate_args(args):
     if args.chat_template_path == "autofix":
         logger.warning(
             "--chat-template-path=autofix is deprecated; remove the flag and rely "
-            "on --tito-model + --tito-allowed-append-roles to auto-resolve. The "
+            "on --tito-model to auto-resolve. The "
             "alias will be removed in a future release."
         )
         args.chat_template_path = None

--- a/miles/utils/test_utils/session_verify_agent.py
+++ b/miles/utils/test_utils/session_verify_agent.py
@@ -22,6 +22,7 @@ import httpx
 
 from miles.rollout.base_types import GenerateFnInput, GenerateFnOutput
 from miles.rollout.generate_hub.agentic_tool_call import generate as _base_generate
+from miles.utils.chat_template_utils.tito_tokenizer import VALID_APPEND_ROLES, TITOTokenizerType
 from miles.utils.test_utils.openai_stream_client import stream_chat_completions
 
 logger = logging.getLogger(__name__)
@@ -31,6 +32,7 @@ class DriverAction(Enum):
     TOOL_RESULT = "tool_result"
     USER_FOLLOWUP = "user_followup"
     SYSTEM_REMINDER = "system_reminder"
+    ASSISTANT_INPUT = "assistant_input"
     ROLLBACK = "rollback"
     FORCE_FINAL = "force_final"
 
@@ -38,6 +40,7 @@ class DriverAction(Enum):
 _T = DriverAction.TOOL_RESULT
 _U = DriverAction.USER_FOLLOWUP
 _S = DriverAction.SYSTEM_REMINDER
+_A = DriverAction.ASSISTANT_INPUT
 _R = DriverAction.ROLLBACK
 _F = DriverAction.FORCE_FINAL
 
@@ -50,9 +53,8 @@ class ToolCallFailureMode(StrEnum):
                    ``tool`` role must follow an assistant with ``tool_calls``
                    (e.g. MiniMax-M2.7) will reject the next request at server-side.
     APPEND_USER  : Splice a ``user`` message carrying the same failure text as
-                   APPEND_TOOL.  Requires "user" in ``allowed_append_roles`` —
-                   raises ValueError at agent start otherwise, so misconfig is
-                   immediately visible instead of silently downgrading.
+                   APPEND_TOOL.  Requires the selected family's fixed template
+                   to support "user"; raises ValueError at agent start otherwise.
     ROLLBACK     : Pop the offending assistant and let the loop's chat call at
                    the bottom re-inference.  Universal — no role-surface
                    dependency — and the default.
@@ -90,11 +92,12 @@ _FORBIDDEN_MISMATCH_TYPES: frozenset[str] = frozenset(
 # response budget should drop to 2 to avoid context overflow.
 DEFAULT_CYCLES = 3
 
-_SUPPORTED_ROLE_SURFACES: tuple[frozenset[str], ...] = (
-    frozenset({"tool"}),
-    frozenset({"tool", "user"}),
-    frozenset({"tool", "user", "system"}),
-)
+
+def _fixed_template_append_roles(tito_model: TITOTokenizerType | str) -> tuple[str, ...]:
+    """Return the selected family's fixed append capability in canonical order."""
+    tokenizer_type = TITOTokenizerType(tito_model)
+    supported = TITOTokenizerType.get_tokenizer_class(tokenizer_type).FIXED_TEMPLATE.allowed_append_roles
+    return tuple(role for role in VALID_APPEND_ROLES if role in supported)
 
 
 def _build_cycle(role_surface: frozenset[str]) -> list[DriverAction]:
@@ -112,6 +115,11 @@ def _build_cycle(role_surface: frozenset[str]) -> list[DriverAction]:
 # and tool-call parsing are tuned against.
 USER_FOLLOWUP_TEXT = "Now check the weather in Shanghai."
 SYSTEM_REMINDER_TEXT = "Note: from now on, answer in a single sentence; skip all pleasantries."
+ASSISTANT_INPUT_TEXTS = (
+    "The earlier Beijing weather result was 22 degrees Celsius and sunny.",
+    "The earlier Shanghai weather result was 30 degrees Celsius and rainy.",
+)
+ASSISTANT_INPUT_FOLLOWUP_TEXT = "Summarize the two weather results above in one sentence without calling a tool."
 FORCE_FINAL_TEXT = "Please summarize all results inside <final_answer>...</final_answer> tags."
 
 TOOLS = [
@@ -153,11 +161,13 @@ INITIAL_USER_PROMPT = "What's the weather in Beijing?"
 
 
 def select_schedule(allowed_roles, *, cycles: int = DEFAULT_CYCLES) -> list[DriverAction]:
-    """Pick the schedule for ``frozenset(allowed_roles)``; raises on unregistered."""
+    """Build a schedule from the selected FixedTemplate capability."""
     key = frozenset(allowed_roles)
-    if key not in _SUPPORTED_ROLE_SURFACES:
-        registered = sorted(sorted(k) for k in _SUPPORTED_ROLE_SURFACES)
-        raise ValueError(f"No schedule registered for allowed_roles={sorted(key)}. Registered: {registered}")
+    invalid = key - set(VALID_APPEND_ROLES)
+    if invalid:
+        raise ValueError(f"Unknown append roles: {sorted(invalid)}")
+    if "tool" not in key:
+        raise ValueError(f"The session verifier requires 'tool' capability, got {sorted(key)}")
     if cycles < 1:
         raise ValueError(f"cycles must be >= 1, got {cycles}")
     cycle = _build_cycle(key)
@@ -166,6 +176,10 @@ def select_schedule(allowed_roles, *, cycles: int = DEFAULT_CYCLES) -> list[Driv
     schedule = list(cycle) + [_R] + cycle * (cycles - 1)
     if "user" in key:
         schedule.append(_F)
+    # Keep injected assistants after every rollback: they are prompt messages,
+    # not generated checkpoints, so rollback across them is a separate contract.
+    if "assistant" in key:
+        schedule.append(_A)
     return schedule
 
 
@@ -192,27 +206,26 @@ async def _chat(client, base_url, messages, request_kwargs, *, label):
 async def run_agent(base_url, prompt, request_kwargs, metadata, **kwargs):
     """Custom-agent entry point.  Returns ``{"driver_events": [...], **counters}``.
 
-    ``allowed_append_roles`` must be present in ``metadata`` (the ``generate``
-    wrapper below injects it from ``args.tito_allowed_append_roles``).
+    ``tito_model`` must be present in ``metadata`` (the ``generate`` wrapper
+    below injects it from ``args.tito_model``).  The driver schedule is derived
+    from that family's ``FixedTemplate.allowed_append_roles``.
     ``prompt`` is ignored — the driver synthesizes its own initial conversation
     from ``build_initial_messages`` so runs are reproducible.
     """
-    allowed_roles = metadata.get("allowed_append_roles")
-    if allowed_roles is None:
-        raise ValueError(
-            "session_verify_agent.run_agent requires allowed_append_roles in metadata; "
-            "the generate wrapper should inject it from args.tito_allowed_append_roles."
-        )
+    tito_model = metadata.get("tito_model")
+    if tito_model is None:
+        raise ValueError("session_verify_agent.run_agent requires tito_model in metadata")
+    allowed_roles = _fixed_template_append_roles(tito_model)
     cycles = metadata.get("session_verify_cycles", DEFAULT_CYCLES)
     schedule = select_schedule(allowed_roles, cycles=cycles)
 
     failure_mode = ToolCallFailureMode(metadata.get("tool_call_failure_mode", DEFAULT_TOOL_CALL_FAILURE_MODE))
-    # APPEND_USER injects a user message — only valid if 'user' is in
-    # allowed_append_roles.  Refuse up front instead of silently downgrading.
+    # APPEND_USER injects a user message, so the fixed template must support it.
+    # Refuse up front instead of silently downgrading.
     if failure_mode is ToolCallFailureMode.APPEND_USER and "user" not in allowed_roles:
         raise ValueError(
-            f"tool_call_failure_mode=APPEND_USER requires 'user' in allowed_append_roles, "
-            f"got {sorted(allowed_roles)}.  Pick ROLLBACK (universal) or APPEND_TOOL "
+            f"tool_call_failure_mode=APPEND_USER requires the {tito_model!r} fixed template "
+            f"to support 'user', got {sorted(allowed_roles)}. Pick ROLLBACK (universal) or APPEND_TOOL "
             "(lenient-template) for tool-only surfaces."
         )
 
@@ -223,6 +236,7 @@ async def run_agent(base_url, prompt, request_kwargs, metadata, **kwargs):
         "rollback_count": 0,
         "user_count": 0,
         "system_count": 0,
+        "assistant_input_count": 0,
         "tool_result_count": 0,
         "tool_call_count": 0,
     }
@@ -313,6 +327,13 @@ async def run_agent(base_url, prompt, request_kwargs, metadata, **kwargs):
                 counters["system_count"] += 1
                 events.append("append_system")
 
+            elif action is DriverAction.ASSISTANT_INPUT:
+                messages.extend({"role": "assistant", "content": text} for text in ASSISTANT_INPUT_TEXTS)
+                messages.append({"role": "user", "content": ASSISTANT_INPUT_FOLLOWUP_TEXT})
+                counters["assistant_input_count"] += len(ASSISTANT_INPUT_TEXTS)
+                counters["user_count"] += 1
+                events.append("append_assistant")
+
             elif action is DriverAction.ROLLBACK:
                 # Pop the last assistant from our local copy.  The next
                 # request therefore has one fewer message than what the
@@ -349,15 +370,16 @@ async def generate(input: GenerateFnInput) -> GenerateFnOutput:
     """Custom-generate wrapper that asserts driver-action coverage.
 
     - Per-sample: every sample must contain ``rollback``, plus ``append_user``
-      / ``append_system`` when those roles are allowed.
+      / ``append_system`` / ``append_assistant`` when those roles are allowed.
     - Cross-sample: at least one sample must contain ``append_tool``
       (model-dependent on emitting a tool_call).
     """
-    allowed_roles = list(input.args.tito_allowed_append_roles)
+    tito_model = input.args.tito_model
+    allowed_roles = list(_fixed_template_append_roles(tito_model))
     cycles = getattr(input.args, "session_verify_cycles", DEFAULT_CYCLES)
     failure_mode = getattr(input.args, "tool_call_failure_mode", DEFAULT_TOOL_CALL_FAILURE_MODE)
     # Sample.metadata is mutable even when the outer dataclass is frozen.
-    input.sample.metadata["allowed_append_roles"] = allowed_roles
+    input.sample.metadata["tito_model"] = tito_model
     input.sample.metadata["session_verify_cycles"] = cycles
     input.sample.metadata["tool_call_failure_mode"] = failure_mode
 
@@ -372,6 +394,8 @@ async def generate(input: GenerateFnInput) -> GenerateFnOutput:
         required_per_sample.append("append_user")
     if "system" in allowed_roles:
         required_per_sample.append("append_system")
+    if "assistant" in allowed_roles:
+        required_per_sample.append("append_assistant")
 
     for i, events in enumerate(events_per_sample):
         missing = [req for req in required_per_sample if req not in events]
@@ -445,10 +469,11 @@ def _add_arguments(parser):
         type=int,
         default=DEFAULT_CYCLES,
         help="Number of driver schedule cycles per sample for session-server "
-        "TITO verification.  Each cycle exercises every action in the role "
-        "surface plus a rollback; more cycles stress the TITO accumulator "
-        "longer but expand context length.  Drop to 2 on tighter-context "
-        "models (e.g. Qwen3 32K with 4K response budget).",
+        "TITO verification.  Each cycle exercises recurrent role actions plus "
+        "a rollback; assistant input is exercised once as the terminal action. "
+        "More cycles stress the TITO accumulator longer but expand context "
+        "length.  Drop to 2 on tighter-context models (e.g. Qwen3 32K with 4K "
+        "response budget).",
     )
     parser.add_argument(
         "--tool-call-failure-mode",
@@ -459,7 +484,7 @@ def _add_arguments(parser):
         "assistant.  'rollback' (default, universal) pops the assistant and "
         "re-inferences.  'append_tool' splices a sentinel tool message (only "
         "works on lenient templates).  'append_user' splices a user message "
-        "with the same failure text — requires 'user' in allowed_append_roles.",
+        "with the same failure text — requires the fixed template to support 'user'.",
     )
 
 

--- a/miles/utils/test_utils/session_verify_agent.py
+++ b/miles/utils/test_utils/session_verify_agent.py
@@ -93,7 +93,7 @@ _FORBIDDEN_MISMATCH_TYPES: frozenset[str] = frozenset(
 DEFAULT_CYCLES = 3
 
 
-def _fixed_template_append_roles(tito_model: TITOTokenizerType | str) -> tuple[str, ...]:
+def fixed_template_append_roles(tito_model: TITOTokenizerType | str) -> tuple[str, ...]:
     """Return the selected family's fixed append capability in canonical order."""
     tokenizer_type = TITOTokenizerType(tito_model)
     supported = TITOTokenizerType.get_tokenizer_class(tokenizer_type).FIXED_TEMPLATE.allowed_append_roles
@@ -215,7 +215,7 @@ async def run_agent(base_url, prompt, request_kwargs, metadata, **kwargs):
     tito_model = metadata.get("tito_model")
     if tito_model is None:
         raise ValueError("session_verify_agent.run_agent requires tito_model in metadata")
-    allowed_roles = _fixed_template_append_roles(tito_model)
+    allowed_roles = fixed_template_append_roles(tito_model)
     cycles = metadata.get("session_verify_cycles", DEFAULT_CYCLES)
     schedule = select_schedule(allowed_roles, cycles=cycles)
 
@@ -375,7 +375,7 @@ async def generate(input: GenerateFnInput) -> GenerateFnOutput:
       (model-dependent on emitting a tool_call).
     """
     tito_model = input.args.tito_model
-    allowed_roles = list(_fixed_template_append_roles(tito_model))
+    allowed_roles = list(fixed_template_append_roles(tito_model))
     cycles = getattr(input.args, "session_verify_cycles", DEFAULT_CYCLES)
     failure_mode = getattr(input.args, "tool_call_failure_mode", DEFAULT_TOOL_CALL_FAILURE_MODE)
     # Sample.metadata is mutable even when the outer dataclass is frozen.

--- a/miles/utils/test_utils/session_verify_runner.py
+++ b/miles/utils/test_utils/session_verify_runner.py
@@ -138,7 +138,6 @@ def namespace_to_train_args(ns: argparse.Namespace) -> str:
     level) so the runner stays pinned to whatever the caller's Namespace
     declared, regardless of any drift in miles' upstream default.
     """
-    allowed_roles_arg = " ".join(ns.tito_allowed_append_roles)
     parts: list[str] = [
         f"--hf-checkpoint {ns.hf_checkpoint}",
         f"--prompt-data {ns.prompt_data}",
@@ -154,7 +153,6 @@ def namespace_to_train_args(ns: argparse.Namespace) -> str:
         f"--session-verify-cycles {ns.session_verify_cycles}",
         f"--tool-call-failure-mode {ns.tool_call_failure_mode}",
         f"--tito-model {ns.tito_model}",
-        f"--tito-allowed-append-roles {allowed_roles_arg}",
         f"--rollout-num-gpus-per-engine {ns.rollout_num_gpus_per_engine}",
         f"--sglang-reasoning-parser {ns.sglang_reasoning_parser}",
         f"--rm-type {ns.rm_type}",
@@ -203,7 +201,7 @@ def run_session_verify(args: argparse.Namespace) -> None:
     path or by spreading ``SESSION_VERIFY_INVARIANT_ARGS`` into
     ``argparse.Namespace(...)`` for tests.
 
-    Mutates ``args`` in three places before composing train_args:
+    Mutates ``args`` in two places before composing train_args:
     - ``args.sglang_reasoning_parser`` / ``args.sglang_tool_call_parser`` are
       resolved against the TITO subclass's bound values via
       ``resolve_reasoning_and_tool_call_parser`` — caller-passed values that
@@ -211,15 +209,10 @@ def run_session_verify(args: argparse.Namespace) -> None:
       GPU work starts.
     - ``args.hf_checkpoint`` is replaced with the local download path so the
       composed train_args points at the downloaded model, not the HF id.
-    - ``args.tito_allowed_append_roles`` is normalized (lowercase, dedup,
-      ensure ``'tool'`` is in) to match the schedule contract in
-      ``session_verify_agent._SUPPORTED_ROLE_SURFACES``.
     """
     args.sglang_reasoning_parser, args.sglang_tool_call_parser = resolve_reasoning_and_tool_call_parser(
         args.tito_model, args.sglang_reasoning_parser, args.sglang_tool_call_parser
     )
-    args.tito_allowed_append_roles = sorted(set(r.lower() for r in args.tito_allowed_append_roles) | {"tool"})
-
     _ensure_prompt_data()
     _clear_proxy_env()
     args.hf_checkpoint = _ensure_model_downloaded(args.hf_checkpoint)

--- a/scripts/tools/verify_chat_template.py
+++ b/scripts/tools/verify_chat_template.py
@@ -1,6 +1,10 @@
 #!/usr/bin/env python3
 """One-click verification: is a chat template append-only after last user message?
 
+The shared CLI trajectory matrix covers tool, user, and system appends.
+Injected assistant input is covered by dedicated per-family CPU tests and the
+session verifier.
+
 Usage examples::
 
     # Verify a local .jinja template file at raw template-string level
@@ -11,15 +15,11 @@ Usage examples::
 
     # Verify through the registered TITO tokenizer family
     python scripts/tools/verify_chat_template.py --model Qwen/Qwen3-0.6B \\
-        --tito-model qwen3 --tito-allowed-append-roles tool
+        --tito-model qwen3
 
     # Verify through TITO while testing a local template override
     python scripts/tools/verify_chat_template.py --model Qwen/Qwen3-0.6B \\
         --tito-model qwen3 --template miles/utils/chat_template_utils/templates/qwen3_fixed.jinja
-
-    # Restrict which append roles the session is allowed to use (tool is implicit)
-    python scripts/tools/verify_chat_template.py --model Qwen/Qwen3-0.6B \\
-        --tito-allowed-append-roles user
 
     # Run thinking cases: off (default) / on / both
     python scripts/tools/verify_chat_template.py --model Qwen/Qwen3.5-0.8B --thinking both
@@ -31,7 +31,7 @@ import argparse
 import json
 import sys
 
-from miles.utils.chat_template_utils.tito_tokenizer import TITOTokenizerType
+from miles.utils.chat_template_utils.tito_tokenizer import VALID_APPEND_ROLES, TITOTokenizerType
 
 
 def _load_template_from_file(path: str) -> str:
@@ -75,22 +75,10 @@ def main() -> int:
         choices=[t.value for t in TITOTokenizerType],
         default=None,
         help=(
-            "Verify through the registered TITO tokenizer family under the given "
-            "--tito-allowed-append-roles surface. Requires --model and exercises "
-            "the production-shape TITO merge/tokenize path instead of the raw "
-            "template-string verifier."
-        ),
-    )
-    parser.add_argument(
-        "--tito-allowed-append-roles",
-        nargs="+",
-        default=["tool"],
-        choices=["tool", "user", "system"],
-        metavar="ROLE",
-        help=(
-            "Roles the session may append after an assistant turn.  'tool' is "
-            "implicitly always allowed (listing it is fine).  Trajectories that "
-            "require roles outside this set are skipped.  Default: tool."
+            "Verify through the registered TITO tokenizer family. Template resolution "
+            "and append capability both come from --tito-model. Requires --model and "
+            "exercises the production-shape TITO merge/tokenize path instead of the "
+            "raw template-string verifier."
         ),
     )
     parser.add_argument(
@@ -124,20 +112,20 @@ def main() -> int:
         parser.error("--tito-model requires --model so the TITO verifier can load the tokenizer")
 
     extra_template_kwargs = dict(args.chat_template_kwargs or {})
-
-    # ``--tito-allowed-append-roles`` lists the *optional* extra roles; ``tool``
-    # is implicit for tool-capable agentic workflows and unioned in here so both
-    # the fixed-template lookup and the trajectory filter see the same surface.
-    allowed_roles = set(args.tito_allowed_append_roles) | {"tool"}
-
     use_tito_instance = args.tito_model is not None
+    if use_tito_instance:
+        tokenizer_type = TITOTokenizerType(args.tito_model)
+        fixed_template = TITOTokenizerType.get_tokenizer_class(tokenizer_type).FIXED_TEMPLATE
+        allowed_roles = set(fixed_template.allowed_append_roles)
+    else:
+        allowed_roles = set(VALID_APPEND_ROLES)
 
     # ── Load template/tokenizer ────────────────────────────────────────
     if use_tito_instance:
         from miles.utils.chat_template_utils import resolve_fixed_chat_template
         from miles.utils.processing_utils import load_tokenizer
 
-        fixed_path, resolved_kwargs = resolve_fixed_chat_template(args.tito_model, sorted(allowed_roles))
+        fixed_path, resolved_kwargs = resolve_fixed_chat_template(args.tito_model)
         for key, value in resolved_kwargs.items():
             if key in extra_template_kwargs:
                 continue
@@ -172,7 +160,7 @@ def main() -> int:
     selected = select_cases(allowed_append_roles=allowed_roles, is_thinking=is_thinking_filter)
 
     print(f"Template source:       {source_desc}")
-    print(f"Allowed append roles:  {sorted(allowed_roles)}")
+    print(f"Append capability:     {sorted(allowed_roles)}")
     print(f"Thinking mode:         {args.thinking}")
     if extra_template_kwargs:
         print(f"Template kwargs:       {extra_template_kwargs}")
@@ -197,7 +185,6 @@ def main() -> int:
         results = run_all_checks_via_tito(
             tokenizer,
             args.tito_model,
-            allowed_append_roles=allowed_roles,
             thinking=args.thinking,
             extra_template_kwargs=extra_template_kwargs,
         )

--- a/scripts/tools/verify_session_tito_tokenizer.py
+++ b/scripts/tools/verify_session_tito_tokenizer.py
@@ -2,8 +2,8 @@
 """CLI: run the multi-role TITO session-server verifier against a real model.
 
 Boots the miles rollout pipeline (sglang + miles-router) under
-``--debug-rollout-only`` and drives the schedule registered for the requested
-``--tito-allowed-append-roles`` surface (see
+``--debug-rollout-only`` and drives the schedule registered for the selected
+family's ``FixedTemplate.allowed_append_roles`` capability (see
 ``miles.utils.test_utils.session_verify_agent``).  PASS iff every sample
 completes without HTTP error from the server-side prefix check and the
 custom-generate coverage assertion is satisfied.
@@ -21,7 +21,6 @@ Usage examples::
     python scripts/tools/verify_session_tito_tokenizer.py \\
         --hf-checkpoint zai-org/GLM-4.7-Flash \\
         --tito-model glm47 \\
-        --tito-allowed-append-roles tool user system \\
         --sglang-reasoning-parser glm45 \\
         --sglang-tool-call-parser glm47 \\
         --rollout-num-gpus-per-engine 4
@@ -30,7 +29,6 @@ Usage examples::
     python scripts/tools/verify_session_tito_tokenizer.py \\
         --hf-checkpoint Qwen/Qwen3-4B \\
         --tito-model qwen3 \\
-        --tito-allowed-append-roles tool user \\
         --sglang-reasoning-parser qwen3 \\
         --sglang-tool-call-parser qwen25 \\
         --rollout-num-gpus-per-engine 1
@@ -42,7 +40,6 @@ Usage examples::
     python scripts/tools/verify_session_tito_tokenizer.py \\
         --hf-checkpoint zai-org/GLM-4.7-Flash \\
         --tito-model glm47 \\
-        --tito-allowed-append-roles tool user system \\
         --sglang-reasoning-parser glm45 \\
         --sglang-tool-call-parser glm47 \\
         --rollout-num-gpus-per-engine 4 \\
@@ -55,7 +52,7 @@ import logging
 import sys
 
 from miles.utils.arguments import parse_args
-from miles.utils.test_utils.session_verify_agent import select_schedule
+from miles.utils.test_utils.session_verify_agent import _fixed_template_append_roles, select_schedule
 from miles.utils.test_utils.session_verify_runner import run_session_verify, session_verify_extras
 
 
@@ -71,6 +68,8 @@ def _print_action_table(allowed_roles: list[str]) -> None:
         print("  - append_user      (deterministic; required because 'user' in roles)")
     if "system" in allowed_roles:
         print("  - append_system    (deterministic; required because 'system' in roles)")
+    if "assistant" in allowed_roles:
+        print("  - append_assistant (deterministic; required because 'assistant' in roles)")
     print()
     print("Required cross-sample driver events (asserted in generate wrapper):")
     print("  - append_tool      (model-dependent; >=1 sample must emit a tool_call)")
@@ -85,14 +84,13 @@ def main() -> int:
 
     args = parse_args(add_custom_arguments=session_verify_extras)
 
-    # Normalize role surface up-front for the printed summary.  ``run_session_verify``
-    # also normalizes internally (lowercase + dedup + ensure 'tool'), but doing it
-    # here lets ``select_schedule`` validate the surface before any GPU work starts.
-    allowed_roles = sorted(set(r.lower() for r in args.tito_allowed_append_roles) | {"tool"})
+    # Resolve the family-owned capability before any GPU work starts so an
+    # unsupported verifier schedule fails immediately.
+    allowed_roles = list(_fixed_template_append_roles(args.tito_model))
 
     print(f"Model:                  {args.hf_checkpoint}")
     print(f"TITO model family:      {args.tito_model}")
-    print(f"Allowed append roles:   {allowed_roles}")
+    print(f"Template append roles:  {allowed_roles}")
     print(f"sglang reasoning parser:{args.sglang_reasoning_parser}")
     print(f"sglang tool-call parser:{args.sglang_tool_call_parser or '(none)'}")
     print(f"Rollout GPUs per engine:{args.rollout_num_gpus_per_engine}")

--- a/scripts/tools/verify_session_tito_tokenizer.py
+++ b/scripts/tools/verify_session_tito_tokenizer.py
@@ -52,7 +52,7 @@ import logging
 import sys
 
 from miles.utils.arguments import parse_args
-from miles.utils.test_utils.session_verify_agent import _fixed_template_append_roles, select_schedule
+from miles.utils.test_utils.session_verify_agent import fixed_template_append_roles, select_schedule
 from miles.utils.test_utils.session_verify_runner import run_session_verify, session_verify_extras
 
 
@@ -86,7 +86,7 @@ def main() -> int:
 
     # Resolve the family-owned capability before any GPU work starts so an
     # unsupported verifier schedule fails immediately.
-    allowed_roles = list(_fixed_template_append_roles(args.tito_model))
+    allowed_roles = list(fixed_template_append_roles(args.tito_model))
 
     print(f"Model:                  {args.hf_checkpoint}")
     print(f"TITO model family:      {args.tito_model}")

--- a/tests/e2e/sglang/test_session_server_multi_role/_common.py
+++ b/tests/e2e/sglang/test_session_server_multi_role/_common.py
@@ -22,7 +22,6 @@ class ModelConfig:
     reasoning_parser: str
     tool_call_parser: str | None
     tito_model: str
-    allowed_append_roles: tuple[str, ...]
     num_gpus: int = 4
     tp_size: int = 1
     # sglang expert-parallel size.  MoE archs like DeepSeek V4 hit a fused-moe
@@ -50,7 +49,6 @@ def run_one(cfg: ModelConfig) -> None:
     args = argparse.Namespace(
         hf_checkpoint=cfg.model_name,
         tito_model=cfg.tito_model,
-        tito_allowed_append_roles=list(cfg.allowed_append_roles),
         sglang_reasoning_parser=cfg.reasoning_parser,
         sglang_tool_call_parser=cfg.tool_call_parser,
         rollout_num_gpus_per_engine=cfg.tp_size,

--- a/tests/e2e/sglang/test_session_server_multi_role/test_deepseekv4.py
+++ b/tests/e2e/sglang/test_session_server_multi_role/test_deepseekv4.py
@@ -12,7 +12,6 @@ CONFIG = ModelConfig(
     reasoning_parser="deepseek-v4",
     tool_call_parser="deepseekv4",
     tito_model="deepseekv4",
-    allowed_append_roles=("tool", "user"),
     tp_size=4,
     # V4-Flash serving recipe (scripts/run_deepseek_v4.py): tp=4, ep=4.
     ep_size=4,

--- a/tests/e2e/sglang/test_session_server_multi_role/test_glm47.py
+++ b/tests/e2e/sglang/test_session_server_multi_role/test_glm47.py
@@ -9,7 +9,6 @@ CONFIG = ModelConfig(
     reasoning_parser="glm45",
     tool_call_parser="glm47",
     tito_model="glm47",
-    allowed_append_roles=("tool", "user", "system"),
     tp_size=4,
     # Lenient template: tool message is rendered without validating that the
     # preceding assistant carries a matching tool_call.id, so the APPEND_TOOL

--- a/tests/e2e/sglang/test_session_server_multi_role/test_minimax_m27.py
+++ b/tests/e2e/sglang/test_session_server_multi_role/test_minimax_m27.py
@@ -18,11 +18,9 @@ register_cuda_ci(est_time=600, suite="stage-c-4-gpu-h200", labels=["sglang"])
 # weights, so use tp=4.  cycles=2 to keep wall-time bounded given the 192K
 # context budget.
 #
-# Surface is {tool, user}: M2.7's chat template gates reasoning_content on
-# last_user_index, so a scheduled USER_FOLLOWUP step strips prior <think>
-# blocks — that's a documented template behavior; the fixed jinja
-# (clear_thinking=False) preserves history reasoning across user turns to
-# keep append-only.
+# M2.7's chat template gates reasoning_content on last_user_index, so a
+# scheduled USER_FOLLOWUP step strips prior <think> blocks; the fixed jinja
+# (clear_thinking=False) preserves history reasoning across user turns.
 #
 # tool_call_failure_mode="append_user": M2.7's strict template hard-asserts
 # that any ``tool`` role MUST follow an assistant with non-empty
@@ -38,7 +36,6 @@ CONFIG = ModelConfig(
     reasoning_parser="minimax-append-think",
     tool_call_parser="minimax-m2",
     tito_model="minimax_m27",
-    allowed_append_roles=("tool", "user"),
     tp_size=4,
     cycles=2,
     assistant_text_threshold=0.1,

--- a/tests/e2e/sglang/test_session_server_multi_role/test_nemotron3.py
+++ b/tests/e2e/sglang/test_session_server_multi_role/test_nemotron3.py
@@ -23,7 +23,6 @@ CONFIG = ModelConfig(
     reasoning_parser="nemotron_3",
     tool_call_parser="qwen3_coder",
     tito_model="nemotron3",
-    allowed_append_roles=("tool", "user"),
     tp_size=4,
     cycles=2,
     assistant_text_threshold=1.0,

--- a/tests/e2e/sglang/test_session_server_multi_role/test_qwen3.py
+++ b/tests/e2e/sglang/test_session_server_multi_role/test_qwen3.py
@@ -9,7 +9,6 @@ CONFIG = ModelConfig(
     reasoning_parser="qwen3",
     tool_call_parser="qwen25",
     tito_model="qwen3",
-    allowed_append_roles=("tool", "user"),
     tp_size=2,
     cycles=2,
     tool_call_failure_mode="append_tool",

--- a/tests/e2e/sglang/test_session_server_multi_role/test_qwen35.py
+++ b/tests/e2e/sglang/test_session_server_multi_role/test_qwen35.py
@@ -9,7 +9,6 @@ CONFIG = ModelConfig(
     reasoning_parser="qwen3",
     tool_call_parser="qwen3_coder",
     tito_model="qwen35",
-    allowed_append_roles=("tool", "user"),
     tp_size=2,
     cycles=2,
     tool_call_failure_mode="append_tool",

--- a/tests/e2e/sglang/test_session_server_multi_role/test_qwennext.py
+++ b/tests/e2e/sglang/test_session_server_multi_role/test_qwennext.py
@@ -14,7 +14,6 @@ CONFIG = ModelConfig(
     reasoning_parser="qwen3",
     tool_call_parser="qwen25",
     tito_model="qwennext",
-    allowed_append_roles=("tool", "user"),
     tp_size=4,
     cycles=2,
     n_samples_per_prompt=1,

--- a/tests/fast/fixtures/generation_fixtures.py
+++ b/tests/fast/fixtures/generation_fixtures.py
@@ -67,7 +67,7 @@ def extra_argv_for_variant(
             argv.append("--generate-multi-samples")
     elif variant in ("agentic_tool_call_single_sample", "agentic_tool_call_multi_samples"):
         argv += ["--custom-agent-function-path", custom_agent_function_path]
-        argv += ["--use-session-server", "--tito-model", "qwen3", "--tito-allowed-append-roles", "tool"]
+        argv += ["--use-session-server", "--tito-model", "qwen3"]
         if variant == "agentic_tool_call_multi_samples":
             argv.append("--generate-multi-samples")
 
@@ -238,7 +238,6 @@ def with_session_server(
         hf_checkpoint=args.hf_checkpoint,
         chat_template_path=args.chat_template_path,
         tito_model=args.tito_model,
-        tito_allowed_append_roles=args.tito_allowed_append_roles,
         use_rollout_routing_replay=args.use_rollout_routing_replay,
         session_server_instance_id=instance_id,
     )

--- a/tests/fast/fixtures/rollout_fixtures.py
+++ b/tests/fast/fixtures/rollout_fixtures.py
@@ -108,7 +108,6 @@ def _with_session_server(args: Namespace, backend_url: str) -> Iterator[UvicornT
         hf_checkpoint=args.hf_checkpoint,
         chat_template_path=getattr(args, "chat_template_path", None),
         tito_model=getattr(args, "tito_model", "default"),
-        tito_allowed_append_roles=getattr(args, "tito_allowed_append_roles", ["tool"]),
         use_rollout_routing_replay=getattr(args, "use_rollout_routing_replay", False),
     )
     session_server = SessionServer(session_args, backend_url=backend_url)

--- a/tests/fast/router/test_session_race_conditions.py
+++ b/tests/fast/router/test_session_race_conditions.py
@@ -64,7 +64,6 @@ def _router_env(process_fn, *, latency: float = 0.0):
                 hf_checkpoint=HF_CHECKPOINT,
                 chat_template_path=None,
                 trajectory_manager="linear_trajectory",
-                tito_allowed_append_roles=["tool", "system"],
             )
             server_obj = SessionServer(args, backend_url=backend.url)
 

--- a/tests/fast/router/test_sessions.py
+++ b/tests/fast/router/test_sessions.py
@@ -67,7 +67,6 @@ def router_env():
                 chat_template_path=None,
                 apply_chat_template_kwargs={"enable_thinking": False},
                 tito_model="default",
-                tito_allowed_append_roles=["tool"],
                 trajectory_manager="linear_trajectory",
                 session_server_instance_id=uuid.uuid4().hex,
             )

--- a/tests/fast/utils/test_arguments.py
+++ b/tests/fast/utils/test_arguments.py
@@ -174,6 +174,91 @@ def test_custom_megatron_post_save_hook_path_requires_save():
         miles_validate_args(args)
 
 
+class TestTitoFixedTemplateConfiguration:
+    def _parse(self, extra):
+        parser = argparse.ArgumentParser()
+        get_miles_extra_args_provider()(parser)
+        return parser.parse_args(extra + ["--num-rollout", "1"] + REQUIRED_ARGS)
+
+    def test_removed_role_flag_is_rejected(self):
+        with pytest.raises(SystemExit):
+            self._parse(["--tito-allowed-append-roles", "tool"])
+
+    @pytest.mark.parametrize(
+        ("extra", "expect_warning"),
+        [
+            (["--use-session-server"], True),
+            ([], False),
+            (["--use-session-server", "--tito-model", "qwen3"], False),
+        ],
+    )
+    def test_warns_only_for_default_model_session(self, caplog, extra, expect_warning):
+        args = self._parse(extra)
+
+        with caplog.at_level(logging.WARNING, logger="miles.utils.arguments"):
+            miles_validate_args(args)
+
+        target_records = [
+            record
+            for record in caplog.records
+            if record.getMessage().startswith("--tito-model=default uses a best-effort four-role append surface.")
+        ]
+        assert len(target_records) == int(expect_warning)
+
+    def test_named_family_requires_session_server(self):
+        args = self._parse(["--tito-model", "qwen3"])
+        with pytest.raises(ValueError, match="--tito-model=qwen3 requires --use-session-server"):
+            miles_validate_args(args)
+
+    def test_named_family_resolves_registered_template_and_kwargs(self):
+        args = self._parse(["--use-session-server", "--tito-model", "qwen3"])
+        miles_validate_args(args)
+        assert args.chat_template_path.endswith("/qwen3_fixed.jinja")
+        assert args.apply_chat_template_kwargs == {"clear_thinking": False}
+
+    def test_named_family_rejects_custom_template(self):
+        args = self._parse(
+            [
+                "--use-session-server",
+                "--tito-model",
+                "qwen3",
+                "--chat-template-path",
+                "/tmp/custom.jinja",
+            ]
+        )
+        with pytest.raises(ValueError, match="cannot override the template registered"):
+            miles_validate_args(args)
+
+    def test_named_family_rejects_conflicting_registered_kwarg(self):
+        args = self._parse(
+            [
+                "--use-session-server",
+                "--tito-model",
+                "qwen3",
+                "--apply-chat-template-kwargs",
+                '{"clear_thinking": true}',
+            ]
+        )
+        with pytest.raises(ValueError, match="clear_thinking=True conflicts"):
+            miles_validate_args(args)
+
+    def test_named_family_accepts_same_registered_and_additional_kwargs(self):
+        args = self._parse(
+            [
+                "--use-session-server",
+                "--tito-model",
+                "qwen3",
+                "--apply-chat-template-kwargs",
+                '{"clear_thinking": false, "enable_thinking": true}',
+            ]
+        )
+        miles_validate_args(args)
+        assert args.apply_chat_template_kwargs == {
+            "clear_thinking": False,
+            "enable_thinking": True,
+        }
+
+
 class TestMultiLoRAValidation:
     def _parse(self, extra):
         parser = argparse.ArgumentParser()

--- a/tests/fast/utils/test_utils/test_session_verify_agent.py
+++ b/tests/fast/utils/test_utils/test_session_verify_agent.py
@@ -1,0 +1,171 @@
+import asyncio
+from copy import deepcopy
+
+from tests.e2e.sglang.test_session_server_multi_role._common import ModelConfig
+
+from miles.utils.chat_template_utils.tito_tokenizer import VALID_APPEND_ROLES
+from miles.utils.test_utils import session_verify_agent
+from miles.utils.test_utils.session_verify_agent import (
+    ASSISTANT_INPUT_FOLLOWUP_TEXT,
+    ASSISTANT_INPUT_TEXTS,
+    DriverAction,
+    _fixed_template_append_roles,
+    run_agent,
+    select_schedule,
+)
+
+
+def test_all_role_schedule_places_assistant_input_last():
+    schedule = select_schedule(VALID_APPEND_ROLES, cycles=2)
+
+    assert schedule[-1] is DriverAction.ASSISTANT_INPUT
+    assert schedule.count(DriverAction.ASSISTANT_INPUT) == 1
+    assert DriverAction.ROLLBACK in schedule[:-1]
+
+
+def test_model_config_uses_family_fixed_template_capability():
+    cfg = ModelConfig(
+        model_name="model",
+        reasoning_parser="reasoning",
+        tool_call_parser="tool",
+        tito_model="qwen3",
+    )
+
+    assert _fixed_template_append_roles(cfg.tito_model) == VALID_APPEND_ROLES
+
+
+def test_assistant_input_appends_two_text_messages_then_user(monkeypatch):
+    calls = []
+
+    class FakeAsyncClient:
+        def __init__(self, *, timeout):
+            self.timeout = timeout
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+    async def fake_chat(client, base_url, messages, request_kwargs, *, label):
+        calls.append(deepcopy(messages))
+        return {
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": f"generated response {len(calls)}",
+                        "tool_calls": [],
+                    }
+                }
+            ]
+        }
+
+    monkeypatch.setattr(session_verify_agent.httpx, "AsyncClient", FakeAsyncClient)
+    monkeypatch.setattr(session_verify_agent, "_chat", fake_chat)
+    monkeypatch.setattr(
+        session_verify_agent,
+        "select_schedule",
+        lambda allowed_roles, *, cycles: [DriverAction.ASSISTANT_INPUT],
+    )
+
+    result = asyncio.run(
+        run_agent(
+            "http://session",
+            prompt=None,
+            request_kwargs={},
+            metadata={"tito_model": "qwen3"},
+        )
+    )
+
+    assert [message["role"] for message in calls[1]] == [
+        "system",
+        "user",
+        "assistant",
+        "assistant",
+        "assistant",
+        "user",
+    ]
+    assert [message["content"] for message in calls[1][-3:-1]] == list(ASSISTANT_INPUT_TEXTS)
+    assert calls[1][-1] == {"role": "user", "content": ASSISTANT_INPUT_FOLLOWUP_TEXT}
+    assert result["driver_events"] == ["initial", "append_assistant"]
+    assert result["assistant_input_count"] == 2
+    assert result["user_count"] == 1
+
+
+def test_minimax_schedule_excludes_system_and_keeps_assistant_rollback():
+    roles = _fixed_template_append_roles("minimax_m27")
+    schedule = select_schedule(roles, cycles=1)
+
+    assert roles == ("tool", "user", "assistant")
+    assert DriverAction.SYSTEM_REMINDER not in schedule
+    assert schedule[-1] is DriverAction.ASSISTANT_INPUT
+    assert DriverAction.ROLLBACK in schedule[:-1]
+
+
+def test_qwen35_schedule_excludes_system_and_keeps_assistant_rollback():
+    roles = _fixed_template_append_roles("qwen35")
+    schedule = select_schedule(roles, cycles=1)
+
+    assert roles == ("tool", "user", "assistant")
+    assert DriverAction.SYSTEM_REMINDER not in schedule
+    assert schedule[-1] is DriverAction.ASSISTANT_INPUT
+    assert DriverAction.ROLLBACK in schedule[:-1]
+
+
+def test_assistant_input_generated_response_is_rolled_back_and_regenerated(monkeypatch):
+    calls = []
+
+    class FakeAsyncClient:
+        def __init__(self, *, timeout):
+            self.timeout = timeout
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+    async def fake_chat(client, base_url, messages, request_kwargs, *, label):
+        calls.append(deepcopy(messages))
+        return {
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": f"generated response {len(calls)}",
+                        "tool_calls": [],
+                    }
+                }
+            ]
+        }
+
+    monkeypatch.setattr(session_verify_agent.httpx, "AsyncClient", FakeAsyncClient)
+    monkeypatch.setattr(session_verify_agent, "_chat", fake_chat)
+    monkeypatch.setattr(
+        session_verify_agent,
+        "select_schedule",
+        lambda allowed_roles, *, cycles: [DriverAction.ASSISTANT_INPUT, DriverAction.ROLLBACK],
+    )
+
+    result = asyncio.run(
+        run_agent(
+            "http://session",
+            prompt=None,
+            request_kwargs={},
+            metadata={"tito_model": "qwen3"},
+        )
+    )
+
+    injected_request = calls[1]
+    rollback_request = calls[2]
+
+    assert injected_request[-1] == {"role": "user", "content": ASSISTANT_INPUT_FOLLOWUP_TEXT}
+    # The rollback retries the exact injected request: the popped generated
+    # response is gone, the injected assistants stay as prompt history.
+    assert rollback_request == injected_request
+    assert all(message.get("content") != "generated response 2" for message in rollback_request)
+    assert result["driver_events"] == ["initial", "append_assistant", "rollback"]
+    assert result["assistant_input_count"] == 2
+    assert result["user_count"] == 1
+    assert result["rollback_count"] == 1

--- a/tests/fast/utils/test_utils/test_session_verify_agent.py
+++ b/tests/fast/utils/test_utils/test_session_verify_agent.py
@@ -9,7 +9,7 @@ from miles.utils.test_utils.session_verify_agent import (
     ASSISTANT_INPUT_FOLLOWUP_TEXT,
     ASSISTANT_INPUT_TEXTS,
     DriverAction,
-    _fixed_template_append_roles,
+    fixed_template_append_roles,
     run_agent,
     select_schedule,
 )
@@ -31,7 +31,7 @@ def test_model_config_uses_family_fixed_template_capability():
         tito_model="qwen3",
     )
 
-    assert _fixed_template_append_roles(cfg.tito_model) == VALID_APPEND_ROLES
+    assert fixed_template_append_roles(cfg.tito_model) == VALID_APPEND_ROLES
 
 
 def test_assistant_input_appends_two_text_messages_then_user(monkeypatch):
@@ -94,7 +94,7 @@ def test_assistant_input_appends_two_text_messages_then_user(monkeypatch):
 
 
 def test_minimax_schedule_excludes_system_and_keeps_assistant_rollback():
-    roles = _fixed_template_append_roles("minimax_m27")
+    roles = fixed_template_append_roles("minimax_m27")
     schedule = select_schedule(roles, cycles=1)
 
     assert roles == ("tool", "user", "assistant")
@@ -104,7 +104,7 @@ def test_minimax_schedule_excludes_system_and_keeps_assistant_rollback():
 
 
 def test_qwen35_schedule_excludes_system_and_keeps_assistant_rollback():
-    roles = _fixed_template_append_roles("qwen35")
+    roles = fixed_template_append_roles("qwen35")
     schedule = select_schedule(roles, cycles=1)
 
     assert roles == ("tool", "user", "assistant")

--- a/tests/fast/utils/test_utils/test_session_verify_runner.py
+++ b/tests/fast/utils/test_utils/test_session_verify_runner.py
@@ -15,7 +15,6 @@ def _build_args(**overrides) -> str:
         **SESSION_VERIFY_INVARIANT_ARGS,
         "hf_checkpoint": "/root/models/test-model",
         "tito_model": "qwen3",
-        "tito_allowed_append_roles": ["tool", "user"],
         "rollout_num_gpus_per_engine": 2,
         "actor_num_nodes": 1,
         "actor_num_gpus_per_node": 8,
@@ -46,6 +45,12 @@ def test_namespace_to_train_args_keeps_ci_test_enabled_for_fsdp_debug_rollout():
 
     assert "--train-backend fsdp" in train_args
     assert "--ci-test" in train_args
+
+
+def test_namespace_to_train_args_has_no_append_role_policy_flag():
+    train_args = _build_args()
+
+    assert "allowed-append-roles" not in train_args
 
 
 def test_namespace_to_train_args_omits_expert_parallel_for_single_expert():

--- a/tests/manual/session/bench_session_server_overhead.py
+++ b/tests/manual/session/bench_session_server_overhead.py
@@ -19,9 +19,9 @@ Run it directly:
 Add `--incremental-r3` to mock a backend that returns only the new per-turn
 `routed_experts` payload instead of the full accumulated sequence payload;
 add `--get-records` to also exercise the full-records GET (read path).
-With `--allowed-append-roles tool` (no `user`), turns after the first append
-tool responses to assistant tool calls instead of user messages, matching
-tool-only TITO surfaces such as DeepSeek V4.
+Use `--append-role tool` to make turns after the first append tool responses
+to assistant tool calls instead of user messages. This selects the benchmark
+traffic shape; the TITO family's fixed template owns the allowed role surface.
 """
 
 from __future__ import annotations
@@ -47,7 +47,7 @@ from typing import Any
 
 DEFAULT_HF_CHECKPOINT = "Qwen/Qwen3-0.6B"
 DEFAULT_TITO_MODEL = "qwen3"
-DEFAULT_ALLOWED_APPEND_ROLES = ["user"]
+DEFAULT_APPEND_ROLE = "user"
 
 # Tool-append turns declare this in every request: some encoders (DeepSeek V4)
 # render assistant history differently when no tools are declared, which breaks
@@ -337,7 +337,6 @@ def _build_server_args(
         chat_template_path=chat_template_path,
         apply_chat_template_kwargs=chat_template_kwargs,
         tito_model=bench_args.tito_model,
-        tito_allowed_append_roles=bench_args.allowed_append_roles,
         generate_multi_samples=False,
         use_rollout_routing_replay=True,
         use_rollout_indexer_replay=False,
@@ -541,9 +540,7 @@ def run_http_bench(args) -> dict[str, Any]:
         chat_template_path = None
         chat_template_kwargs = None
     else:
-        chat_template_path, chat_template_kwargs = resolve_fixed_chat_template(
-            args.tito_model, args.allowed_append_roles
-        )
+        chat_template_path, chat_template_kwargs = resolve_fixed_chat_template(args.tito_model)
 
     # Build the synthetic per-turn request/response bodies once (CPU, off the clock).
     tokenizer = load_tokenizer(args.hf_checkpoint, chat_template_path=chat_template_path, trust_remote_code=True)
@@ -551,7 +548,6 @@ def run_http_bench(args) -> dict[str, Any]:
         tokenizer,
         tokenizer_type=args.tito_model,
         chat_template_kwargs=chat_template_kwargs,
-        allowed_append_roles=args.allowed_append_roles,
     )
     specs = _build_turn_specs(
         tokenizer,
@@ -561,7 +557,7 @@ def run_http_bench(args) -> dict[str, Any]:
         output_tokens=args.output_tokens,
         r3_scale=args.r3_scale,
         incremental_r3=args.incremental_r3,
-        tool_appends="user" not in args.allowed_append_roles,
+        tool_appends=args.append_role == "tool",
     )
     response_bodies = [spec.response_body for spec in specs]
 
@@ -667,7 +663,7 @@ def run_http_bench(args) -> dict[str, Any]:
         "r3_scale_raw_bytes_per_token": args.r3_scale,
         "hf_checkpoint": args.hf_checkpoint,
         "tito_model": args.tito_model,
-        "allowed_append_roles": args.allowed_append_roles,
+        "append_role": args.append_role,
         "chat_template_path": chat_template_path,
         "chat_template_kwargs": chat_template_kwargs,
         "wall_s": wall_s,
@@ -788,11 +784,10 @@ def main() -> None:
     parser.add_argument("--hf-checkpoint", default=DEFAULT_HF_CHECKPOINT, help="tokenizer checkpoint or local path")
     parser.add_argument("--tito-model", default=DEFAULT_TITO_MODEL, help="TITO tokenizer family")
     parser.add_argument(
-        "--allowed-append-roles",
-        nargs="+",
-        default=DEFAULT_ALLOWED_APPEND_ROLES,
-        help="roles allowed after the pretokenized prefix; without 'user' the bench appends "
-        "tool responses to assistant tool calls instead of user turns (tool-only TITO surfaces)",
+        "--append-role",
+        choices=["user", "tool"],
+        default=DEFAULT_APPEND_ROLE,
+        help="role used for benchmark turns after the first; selects traffic shape only",
     )
     parser.add_argument("--chat-template-path", default=None, help="explicit chat template path")
     parser.add_argument("--json-out", default=None, help="persist the run as a JSON artifact")

--- a/tests/manual/tito/deepseek_v32.py
+++ b/tests/manual/tito/deepseek_v32.py
@@ -7,7 +7,6 @@ CONFIG = ModelConfig(
     reasoning_parser="deepseek-v3",
     tool_call_parser="deepseekv32",
     tito_model="deepseekv32",
-    allowed_append_roles=("tool",),
     num_gpus=8,
     tp_size=8,
     ep_size=8,


### PR DESCRIPTION
## Summary
Remove `--tito-allowed-append-roles`; verify surfaces derive schedules from `FIXED_TEMPLATE`.

## Motivation
With append roles bound to the family template, the flag is dead caller policy: remove it from argparse, validation, examples, fixtures, the verify runner, bench, and docs. The verify surface (GPU harness, e2e configs, verify scripts) now derives its role schedule from FIXED_TEMPLATE, and injected-assistant driving becomes a terminal verify action. Flag removal and surface derivation are one contract move; separating them leaves the GPU session-verify chain reading a removed argument in between.

## Before / After
- **Before / After:** callers passed `--tito-allowed-append-roles`; the session-verify harness read the roles from args.
- Now the harness derives append surfaces from the family's `FIXED_TEMPLATE`; injected-assistant input becomes a terminal schedule action.
- **What moved where:** schedule derivation lives in `session_verify_agent.py` (`fixed_template_append_roles`, `select_schedule`); flag plumbing is deleted from `arguments.py`, examples, fixtures, runner, bench, docs; the ownership wording in `agentic-chat-template.md` follows; 27 files, +392/−169.

## Behavior Preservation
- **How we know:** with the flag unset (the only configuration consistent with the parent PR's binding), derived surfaces equal the previous defaults.
- `TestTitoFixedTemplateConfiguration` pins the per-family derived configuration; the harness tests pin the schedules.

## Verification
- **Existing test suite:** `pytest tests/fast/utils/test_arguments.py tests/fast/utils/test_utils` — 148 passed at this commit.
- **New tests:** `test_session_verify_agent.py` covers restricted-family schedules (`test_minimax_schedule_excludes_system_and_keeps_assistant_rollback`, Qwen3.5 variant) plus injected-assistant rollback (`test_assistant_input_generated_response_is_rolled_back_and_regenerated`).

## Review Focus
- Scrutinize the schedule derivation in `session_verify_agent.py` for families whose templates restrict append roles.
- Scrutinize the misconfiguration gate rework in `arguments.py` for configurations the removed flag used to reject.
