### PR TITLE
feat(session): pass request chat_template_kwargs to apply_chat_template

### DIFF
--- a/miles/rollout/session/core.py
+++ b/miles/rollout/session/core.py
@@ -226,20 +226,46 @@ class SessionCore:
             # Must be False so stop-token text is trimmed from assistant content;
             # token IDs still come from logprobs below.
             request_body["no_stop_trim"] = False
-            # Chat template kwargs should also be forwarded to sglang to make sure
-            # parsers work correctly.
-            server_ctk = self.registry.tito_tokenizer.chat_template_kwargs
-            if server_ctk:
-                request_body["chat_template_kwargs"] = {
-                    **server_ctk,
-                    **(request_body.get("chat_template_kwargs") or {}),
-                }
+            # Keep request's chat_template_kwargs and override some key fields by tito tokenizer chat template kwargs.
+            # FIXME(session): 1) only the nested "chat_template_kwargs" object
+            # is read — top-level "reasoning"/"reasoning_effort" request fields
+            # (and the kwargs spelling SGLang promotes to top level) never
+            # reach the local render, so those spellings still diverge;
+            # 2) mid-session mode-change safety is a per-family property and
+            # is not guarded yet:
+            #    - DeepSeek V3.2/V4: unsafe — history think blocks and the
+            #      prompt-head reasoning_effort marker render under one mode,
+            #      so a flip strands old-mode prefix tokens and the history no
+            #      longer matches the requested mode;
+            #    - Nemotron 3: safe — the template writes the reasoning
+            #      setting into every turn, so history keeps each turn's own
+            #      value;
+            #    - Qwen3/Qwen3.5: safe — the toggle only affects the
+            #      generation prompt, never rendered history;
+            #    - newer models treat effort as a per-turn control (OpenAI /
+            #      Anthropic style), so the guard belongs on FixedTemplate,
+            #      defaulting to allow;
+            # 3) compute_session_mismatch still renders with the startup
+            # tokenizer, so non-default-mode sessions log spurious mismatches.
+            request_ctk = request_body.get("chat_template_kwargs")
+            if request_ctk is not None and not isinstance(request_ctk, dict):
+                raise MessageValidationError("chat_template_kwargs must be an object")
+            tito_tokenizer = self.registry.tito_tokenizer
+            if request_ctk:
+                try:
+                    tito_tokenizer = tito_tokenizer.clone_with_chat_template_kwargs(request_ctk)
+                except ValueError as e:
+                    raise MessageValidationError(str(e)) from e
+            if tito_tokenizer.chat_template_kwargs:
+                request_body["chat_template_kwargs"] = dict(tito_tokenizer.chat_template_kwargs)
+            else:
+                request_body.pop("chat_template_kwargs", None)
 
             request_messages = request_body.get("messages", [])
             prompt_token_ids = session.prepare_pretokenized(
                 request_messages,
                 tools=request_body.get("tools"),
-                tito_tokenizer=self.registry.tito_tokenizer,
+                tito_tokenizer=tito_tokenizer,
             )
             request_body["input_ids"] = prompt_token_ids
             logger.debug("Using TITO input_ids: %d tokens", len(prompt_token_ids))

--- a/miles/rollout/session/core.py
+++ b/miles/rollout/session/core.py
@@ -226,26 +226,8 @@ class SessionCore:
             # Must be False so stop-token text is trimmed from assistant content;
             # token IDs still come from logprobs below.
             request_body["no_stop_trim"] = False
-            # Keep request's chat_template_kwargs and override some key fields by tito tokenizer chat template kwargs.
-            # FIXME(session): 1) only nested "chat_template_kwargs" reach the
-            # local render; unlike upstream SGLang, top-level "reasoning" and
-            # "reasoning_effort" are not mapped into template kwargs;
-            # 2) mid-session mode-change safety is a per-family property and
-            # is not guarded yet:
-            #    - DeepSeek V3.2/V4: unsafe — history think blocks and the
-            #      prompt-head reasoning_effort marker render under one mode,
-            #      so a flip strands old-mode prefix tokens and the history no
-            #      longer matches the requested mode;
-            #    - Nemotron 3: safe — the template writes the reasoning
-            #      setting into every turn, so history keeps each turn's own
-            #      value;
-            #    - Qwen3/Qwen3.5: safe — the toggle only affects the
-            #      generation prompt, never rendered history;
-            #    - newer models treat effort as a per-turn control (OpenAI /
-            #      Anthropic style), so the guard belongs on FixedTemplate,
-            #      defaulting to allow;
-            # 3) compute_session_mismatch still renders with the startup
-            # tokenizer, so non-default-mode sessions log spurious mismatches.
+            # FIXME(session): Only nested `chat_template_kwargs` reach the local renderer;
+            # top-level `reasoning` and `reasoning_effort` are not mapped to template kwargs.
             request_ctk = request_body.get("chat_template_kwargs")
             if request_ctk is not None and not isinstance(request_ctk, dict):
                 raise MessageValidationError("chat_template_kwargs must be an object")

--- a/miles/rollout/session/core.py
+++ b/miles/rollout/session/core.py
@@ -227,10 +227,9 @@ class SessionCore:
             # token IDs still come from logprobs below.
             request_body["no_stop_trim"] = False
             # Keep request's chat_template_kwargs and override some key fields by tito tokenizer chat template kwargs.
-            # FIXME(session): 1) only the nested "chat_template_kwargs" object
-            # is read — top-level "reasoning"/"reasoning_effort" request fields
-            # (and the kwargs spelling SGLang promotes to top level) never
-            # reach the local render, so those spellings still diverge;
+            # FIXME(session): 1) only nested "chat_template_kwargs" reach the
+            # local render; unlike upstream SGLang, top-level "reasoning" and
+            # "reasoning_effort" are not mapped into template kwargs;
             # 2) mid-session mode-change safety is a per-family property and
             # is not guarded yet:
             #    - DeepSeek V3.2/V4: unsafe — history think blocks and the

--- a/miles/utils/chat_template_utils/template.py
+++ b/miles/utils/chat_template_utils/template.py
@@ -93,6 +93,21 @@ def extract_tool_dicts(tools: list[dict] | None) -> list[dict] | None:
     return [tool.model_dump() for tool in validated]
 
 
+def merge_chat_template_kwargs(
+    base: dict[str, Any],
+    overrides: dict[str, Any],
+    *,
+    alias_keys: Collection[str] = (),
+) -> dict[str, Any]:
+    """Merge one config layer, replacing base aliases as a group."""
+    merged = dict(base)
+    if any(key in overrides for key in alias_keys):
+        for key in alias_keys:
+            merged.pop(key, None)
+    merged.update(overrides)
+    return merged
+
+
 def apply_chat_template_from_str(
     chat_template: str,
     messages: list[dict],

--- a/miles/utils/chat_template_utils/tito_tokenizer.py
+++ b/miles/utils/chat_template_utils/tito_tokenizer.py
@@ -115,16 +115,7 @@ class TITOTokenizer:
         self.special_token_ids: set[int] = special_token_ids
 
     def clone_with_chat_template_kwargs(self, request_kwargs: dict[str, Any]) -> TITOTokenizer:
-        """A request-scoped copy over the same HF tokenizer.
-
-        *request_kwargs* win over this instance's construction-time kwargs;
-        running the family constructor again re-validates fixed-template
-        conflicts (``ValueError``) and re-derives dependent kwargs such as
-        DeepSeek's effective ``thinking``, so a stale derived value never
-        survives the override.  Family-owned state (``special_token_ids``,
-        default ``assistant_start_str``) is re-pinned by the constructor,
-        mirroring ``get_tito_tokenizer`` construction.
-        """
+        """Create a request-scoped copy with negligible overhead."""
         return type(self)(
             self.tokenizer,
             chat_template_kwargs={**self.chat_template_kwargs, **request_kwargs},

--- a/miles/utils/chat_template_utils/tito_tokenizer.py
+++ b/miles/utils/chat_template_utils/tito_tokenizer.py
@@ -83,6 +83,7 @@ class TITOTokenizer:
 
     max_trim_tokens: int = 0
     trailing_token_ids: frozenset[int] = frozenset()
+    chat_template_kwarg_aliases: frozenset[str] = frozenset()
 
     # The family's fixed renderer contract.  DEFAULT uses the model's native
     # template with the maximal best-effort append surface.
@@ -118,7 +119,11 @@ class TITOTokenizer:
         """Create a request-scoped copy with negligible overhead."""
         return type(self)(
             self.tokenizer,
-            chat_template_kwargs={**self.chat_template_kwargs, **request_kwargs},
+            chat_template_kwargs=template.merge_chat_template_kwargs(
+                self.chat_template_kwargs,
+                request_kwargs,
+                alias_keys=self.chat_template_kwarg_aliases,
+            ),
             assistant_start_str=self._assistant_start_str,
         )
 
@@ -585,6 +590,8 @@ class MinimaxM27TITOTokenizer(MinimaxM25TITOTokenizer):
 # DeepSeek V3.2 implementation
 # ---------------------------------------------------------------------------
 
+_DEEPSEEK_MODE_KWARG_ALIASES = frozenset({"thinking_mode", "enable_thinking", "thinking"})
+
 
 class DeepSeekV32TITOTokenizer(TITOTokenizer):
     """DeepSeek V3.2 — miles' vendored copy of the official ``encoding_dsv32``.
@@ -605,6 +612,7 @@ class DeepSeekV32TITOTokenizer(TITOTokenizer):
 
     reasoning_parser = "deepseek-v3"
     tool_call_parser = "deepseekv32"
+    chat_template_kwarg_aliases = _DEEPSEEK_MODE_KWARG_ALIASES
 
     FIXED_TEMPLATE = FixedTemplate(
         template=None,
@@ -653,6 +661,7 @@ class DeepSeekV4TITOTokenizer(TITOTokenizer):
 
     reasoning_parser = "deepseek-v4"
     tool_call_parser = "deepseekv4"
+    chat_template_kwarg_aliases = _DEEPSEEK_MODE_KWARG_ALIASES
 
     FIXED_TEMPLATE = FixedTemplate(
         template=None,
@@ -685,11 +694,10 @@ class DeepSeekV4TITOTokenizer(TITOTokenizer):
         # sglang's dsv4 parser separates reasoning only when the request carries
         # `thinking` (DeepSeek-V3.1's template kwarg, kept for the V4 family);
         # make the effective render mode explicit so the session server forwards it.
-        if "thinking" not in self.chat_template_kwargs:
-            self.chat_template_kwargs = {
-                **self.chat_template_kwargs,
-                "thinking": deepseek.V4.render_thinking_enabled(self.chat_template_kwargs),
-            }
+        self.chat_template_kwargs = {
+            **self.chat_template_kwargs,
+            "thinking": deepseek.V4.render_thinking_enabled(self.chat_template_kwargs),
+        }
 
     def tokenize_additional_messages(
         self,

--- a/miles/utils/chat_template_utils/tito_tokenizer.py
+++ b/miles/utils/chat_template_utils/tito_tokenizer.py
@@ -114,6 +114,23 @@ class TITOTokenizer:
         self.allowed_append_roles = self.FIXED_TEMPLATE.allowed_append_roles
         self.special_token_ids: set[int] = special_token_ids
 
+    def clone_with_chat_template_kwargs(self, request_kwargs: dict[str, Any]) -> TITOTokenizer:
+        """A request-scoped copy over the same HF tokenizer.
+
+        *request_kwargs* win over this instance's construction-time kwargs;
+        running the family constructor again re-validates fixed-template
+        conflicts (``ValueError``) and re-derives dependent kwargs such as
+        DeepSeek's effective ``thinking``, so a stale derived value never
+        survives the override.  Family-owned state (``special_token_ids``,
+        default ``assistant_start_str``) is re-pinned by the constructor,
+        mirroring ``get_tito_tokenizer`` construction.
+        """
+        return type(self)(
+            self.tokenizer,
+            chat_template_kwargs={**self.chat_template_kwargs, **request_kwargs},
+            assistant_start_str=self._assistant_start_str,
+        )
+
     def create_comparator(self) -> TokenSeqComparator:
         """Create a :class:`TokenSeqComparator` configured with this
         tokenizer's model-specific settings."""

--- a/tests/fast/router/test_sessions.py
+++ b/tests/fast/router/test_sessions.py
@@ -204,6 +204,60 @@ class TestSessionProxy:
         assert resp.status_code == 400
         assert resp.json()["error"].startswith("invalid JSON body:")
 
+    def test_chat_rejects_non_object_template_kwargs(self, router_env):
+        session_id = requests.post(f"{router_env.url}/sessions", timeout=5.0).json()["session_id"]
+        resp = requests.post(
+            f"{router_env.url}/sessions/{session_id}/v1/chat/completions",
+            json={
+                "messages": [{"role": "user", "content": "hi"}],
+                "chat_template_kwargs": ["enable_thinking"],
+            },
+            timeout=10.0,
+        )
+        assert resp.status_code == 400
+        assert resp.json()["error"] == "chat_template_kwargs must be an object"
+
+    def test_chat_template_kwargs_override_reaches_render_and_backend(self, router_env):
+        """A request response-mode kwarg wins over the launch default in both
+        the locally rendered input_ids and the outbound backend request."""
+        default_session = requests.post(f"{router_env.url}/sessions", timeout=5.0).json()["session_id"]
+        resp = requests.post(
+            f"{router_env.url}/sessions/{default_session}/v1/chat/completions",
+            json={"messages": [{"role": "user", "content": "hi"}]},
+            timeout=10.0,
+        )
+        assert resp.status_code == 200
+        default_payload = router_env.backend.request_log[-1]
+        assert default_payload["chat_template_kwargs"] == {"enable_thinking": False}
+
+        override_session = requests.post(f"{router_env.url}/sessions", timeout=5.0).json()["session_id"]
+        resp = requests.post(
+            f"{router_env.url}/sessions/{override_session}/v1/chat/completions",
+            json={
+                "messages": [{"role": "user", "content": "hi"}],
+                "chat_template_kwargs": {"enable_thinking": True},
+            },
+            timeout=10.0,
+        )
+        assert resp.status_code == 200
+        override_payload = router_env.backend.request_log[-1]
+        assert override_payload["chat_template_kwargs"] == {"enable_thinking": True}
+        assert override_payload["input_ids"] != default_payload["input_ids"]
+
+    def test_chat_unknown_template_kwarg_passes_through(self, router_env):
+        session_id = requests.post(f"{router_env.url}/sessions", timeout=5.0).json()["session_id"]
+        resp = requests.post(
+            f"{router_env.url}/sessions/{session_id}/v1/chat/completions",
+            json={
+                "messages": [{"role": "user", "content": "hi"}],
+                "chat_template_kwargs": {"unknown": False},
+            },
+            timeout=10.0,
+        )
+        assert resp.status_code == 200
+        payload = router_env.backend.request_log[-1]
+        assert payload["chat_template_kwargs"] == {"enable_thinking": False, "unknown": False}
+
     def test_chat_upstream_null_message_returns_502(self, router_env):
         session_id = requests.post(f"{router_env.url}/sessions", timeout=5.0).json()["session_id"]
 

--- a/tests/fast/router/test_sessions.py
+++ b/tests/fast/router/test_sessions.py
@@ -204,19 +204,6 @@ class TestSessionProxy:
         assert resp.status_code == 400
         assert resp.json()["error"].startswith("invalid JSON body:")
 
-    def test_chat_rejects_non_object_template_kwargs(self, router_env):
-        session_id = requests.post(f"{router_env.url}/sessions", timeout=5.0).json()["session_id"]
-        resp = requests.post(
-            f"{router_env.url}/sessions/{session_id}/v1/chat/completions",
-            json={
-                "messages": [{"role": "user", "content": "hi"}],
-                "chat_template_kwargs": ["enable_thinking"],
-            },
-            timeout=10.0,
-        )
-        assert resp.status_code == 400
-        assert resp.json()["error"] == "chat_template_kwargs must be an object"
-
     def test_chat_template_kwargs_override_reaches_render_and_backend(self, router_env):
         """A request response-mode kwarg wins over the launch default in both
         the locally rendered input_ids and the outbound backend request."""
@@ -243,20 +230,6 @@ class TestSessionProxy:
         override_payload = router_env.backend.request_log[-1]
         assert override_payload["chat_template_kwargs"] == {"enable_thinking": True}
         assert override_payload["input_ids"] != default_payload["input_ids"]
-
-    def test_chat_unknown_template_kwarg_passes_through(self, router_env):
-        session_id = requests.post(f"{router_env.url}/sessions", timeout=5.0).json()["session_id"]
-        resp = requests.post(
-            f"{router_env.url}/sessions/{session_id}/v1/chat/completions",
-            json={
-                "messages": [{"role": "user", "content": "hi"}],
-                "chat_template_kwargs": {"unknown": False},
-            },
-            timeout=10.0,
-        )
-        assert resp.status_code == 200
-        payload = router_env.backend.request_log[-1]
-        assert payload["chat_template_kwargs"] == {"enable_thinking": False, "unknown": False}
 
     def test_chat_upstream_null_message_returns_502(self, router_env):
         session_id = requests.post(f"{router_env.url}/sessions", timeout=5.0).json()["session_id"]

--- a/tests/fast/utils/chat_template_utils/test_tito_tokenizer.py
+++ b/tests/fast/utils/chat_template_utils/test_tito_tokenizer.py
@@ -53,6 +53,7 @@ from transformers import AutoTokenizer
 from miles.utils.chat_template_utils import MismatchType, apply_chat_template, resolve_fixed_chat_template
 from miles.utils.chat_template_utils.tito_tokenizer import (
     ALL_APPEND_ROLES,
+    DeepSeekV4TITOTokenizer,
     DeepSeekV32TITOTokenizer,
     FixedTemplate,
     GLM47TITOTokenizer,
@@ -251,6 +252,16 @@ class TestConfig:
         tito = DeepSeekV32TITOTokenizer(tokenizer, chat_template_kwargs=chat_template_kwargs)
 
         assert tito.chat_template_kwargs["thinking"] is expected
+
+    @pytest.mark.parametrize("tito_cls", [DeepSeekV32TITOTokenizer, DeepSeekV4TITOTokenizer])
+    def test_deepseek_request_thinking_overrides_startup_mode(self, tito_cls):
+        tokenizer = MagicMock()
+        tokenizer.convert_tokens_to_ids.return_value = 1
+        startup_tito = tito_cls(tokenizer, chat_template_kwargs={"enable_thinking": False})
+
+        request_tito = startup_tito.clone_with_chat_template_kwargs({"thinking": True})
+
+        assert request_tito.chat_template_kwargs == {"drop_thinking": False, "thinking": True}
 
     def test_comparator_inherits_trailing_ids(self, qwen3_tito: Qwen3TITOTokenizer):
         """create_comparator propagates trailing_token_ids to the comparator's trim set."""

--- a/tests/fast/utils/chat_template_utils/test_tito_tokenizer.py
+++ b/tests/fast/utils/chat_template_utils/test_tito_tokenizer.py
@@ -258,47 +258,6 @@ class TestConfig:
         assert comp._trim_trailing_ids == set(qwen3_tito.trailing_token_ids)
 
 
-class TestCloneWithChatTemplateKwargs:
-    """clone_with_chat_template_kwargs builds a request-scoped tokenizer:
-    request kwargs win over construction-time kwargs, fixed-template
-    conflicts re-validate, derived kwargs recompute, and the shared instance
-    never absorbs request state."""
-
-    def test_request_kwargs_win_and_share_hf_tokenizer(self, qwen3_tito: Qwen3TITOTokenizer):
-        clone = qwen3_tito.clone_with_chat_template_kwargs({"enable_thinking": True})
-
-        assert clone.tokenizer is qwen3_tito.tokenizer
-        assert clone.chat_template_kwargs["enable_thinking"] is True
-        # Construction-time kwargs the request did not touch survive.
-        assert clone.chat_template_kwargs["clear_thinking"] is False
-        # The shared instance never absorbs request state.
-        assert "enable_thinking" not in qwen3_tito.chat_template_kwargs
-
-    def test_fixed_template_conflict_revalidates(self, qwen3_tito: Qwen3TITOTokenizer):
-        class _PinnedQwen3TITOTokenizer(Qwen3TITOTokenizer):
-            FIXED_TEMPLATE = FixedTemplate(
-                template=Qwen3TITOTokenizer.FIXED_TEMPLATE.template,
-                extra_kwargs={"drop_thinking": False},
-            )
-
-        pinned = _PinnedQwen3TITOTokenizer(qwen3_tito.tokenizer)
-        with pytest.raises(ValueError, match="drop_thinking"):
-            pinned.clone_with_chat_template_kwargs({"drop_thinking": True})
-
-    def test_deepseek_v32_rederives_effective_thinking(self):
-        tokenizer = MagicMock()
-        tokenizer.convert_tokens_to_ids.side_effect = [1, 2, 1, 2]
-
-        tito = DeepSeekV32TITOTokenizer(tokenizer, chat_template_kwargs={})
-        assert tito.chat_template_kwargs["thinking"] is True
-
-        clone = tito.clone_with_chat_template_kwargs({"enable_thinking": False})
-        # The stale derived value does not survive the override: the clone's
-        # constructor recomputes ``thinking`` from the merged kwargs.
-        assert clone.chat_template_kwargs["thinking"] is False
-        assert tito.chat_template_kwargs["thinking"] is True
-
-
 class TestDeepSeekV32IncrementalAppend:
     """V3.2 rides the default synthetic-prefix suffix diff; with the family's
     pinned ``drop_thinking=False`` the vendored encoder renders every turn

--- a/tests/fast/utils/chat_template_utils/test_tito_tokenizer.py
+++ b/tests/fast/utils/chat_template_utils/test_tito_tokenizer.py
@@ -258,6 +258,47 @@ class TestConfig:
         assert comp._trim_trailing_ids == set(qwen3_tito.trailing_token_ids)
 
 
+class TestCloneWithChatTemplateKwargs:
+    """clone_with_chat_template_kwargs builds a request-scoped tokenizer:
+    request kwargs win over construction-time kwargs, fixed-template
+    conflicts re-validate, derived kwargs recompute, and the shared instance
+    never absorbs request state."""
+
+    def test_request_kwargs_win_and_share_hf_tokenizer(self, qwen3_tito: Qwen3TITOTokenizer):
+        clone = qwen3_tito.clone_with_chat_template_kwargs({"enable_thinking": True})
+
+        assert clone.tokenizer is qwen3_tito.tokenizer
+        assert clone.chat_template_kwargs["enable_thinking"] is True
+        # Construction-time kwargs the request did not touch survive.
+        assert clone.chat_template_kwargs["clear_thinking"] is False
+        # The shared instance never absorbs request state.
+        assert "enable_thinking" not in qwen3_tito.chat_template_kwargs
+
+    def test_fixed_template_conflict_revalidates(self, qwen3_tito: Qwen3TITOTokenizer):
+        class _PinnedQwen3TITOTokenizer(Qwen3TITOTokenizer):
+            FIXED_TEMPLATE = FixedTemplate(
+                template=Qwen3TITOTokenizer.FIXED_TEMPLATE.template,
+                extra_kwargs={"drop_thinking": False},
+            )
+
+        pinned = _PinnedQwen3TITOTokenizer(qwen3_tito.tokenizer)
+        with pytest.raises(ValueError, match="drop_thinking"):
+            pinned.clone_with_chat_template_kwargs({"drop_thinking": True})
+
+    def test_deepseek_v32_rederives_effective_thinking(self):
+        tokenizer = MagicMock()
+        tokenizer.convert_tokens_to_ids.side_effect = [1, 2, 1, 2]
+
+        tito = DeepSeekV32TITOTokenizer(tokenizer, chat_template_kwargs={})
+        assert tito.chat_template_kwargs["thinking"] is True
+
+        clone = tito.clone_with_chat_template_kwargs({"enable_thinking": False})
+        # The stale derived value does not survive the override: the clone's
+        # constructor recomputes ``thinking`` from the merged kwargs.
+        assert clone.chat_template_kwargs["thinking"] is False
+        assert tito.chat_template_kwargs["thinking"] is True
+
+
 class TestDeepSeekV32IncrementalAppend:
     """V3.2 rides the default synthetic-prefix suffix diff; with the family's
     pinned ``drop_thinking=False`` the vendored encoder renders every turn


### PR DESCRIPTION
## Summary
Pass request `chat_template_kwargs` to `apply_chat_template` when rendering session `input_ids`.

## Motivation
Session requests accepted `chat_template_kwargs`, but local `apply_chat_template` calls did not receive them.

## Usage
```http
POST /sessions/{session_id}/v1/chat/completions
Content-Type: application/json

{"messages": [{"role": "user", "content": "Hi"}], "chat_template_kwargs": {"enable_thinking": false}}
```

For this request, Miles passes `enable_thinking=false` to `apply_chat_template` while rendering `input_ids`.

Request values replace matching startup `chat_template_kwargs` for this render.

A request value that conflicts with a model family's fixed value returns HTTP 400.

## Design Notes
- **Key choices:** `SessionCore.chat_completions` merges request values over startup `chat_template_kwargs`.
- `TITOTokenizer.clone_with_chat_template_kwargs` creates a request-scoped tokenizer over the same HF tokenizer.
- `TITOTokenizer.apply_chat_template` passes the merged values to `template.apply_chat_template`.
- The request-scoped clone has negligible overhead.

## Verification
- **Tests added:** `test_chat_template_kwargs_override_reaches_render_and_backend` verifies a request override changes locally rendered `input_ids`.

## Review Focus
- Scrutinize the merge order in `SessionCore.chat_completions`.
- Scrutinize whether `TITOTokenizer.clone_with_chat_template_kwargs` preserves required model-family state.
