### PR TITLE
run_megatron: dump parameter grads, fix CP loss normalisation, skip DDP on forward-only runs

### DIFF
--- a/miles/utils/debug_utils/run_megatron/worker/batch.py
+++ b/miles/utils/debug_utils/run_megatron/worker/batch.py
@@ -4,6 +4,9 @@ from types import SimpleNamespace
 from typing import Any
 
 import torch
+import torch.distributed as dist
+
+from miles.backends.training_utils.parallel import get_parallel_state
 
 
 def prepare_batch(
@@ -95,17 +98,32 @@ def loss_func(
     labels: torch.Tensor,
     output_tensor: torch.Tensor,
 ) -> tuple[torch.Tensor, dict[str, Any]]:
-    """Cross-entropy loss for forward-backward pipeline schedule.
+    """Cross-entropy loss, normalised by the *global* valid-token count.
 
-    Uses ignore_index=-100 to handle CP-aware label masking.
+    A local ``reduction="mean"`` is wrong under context parallelism: the labels are
+    sharded, so each rank divides by its own valid count rather than the global
+    one, and every activation gradient comes out scaled by global/local -- about 2x
+    at CP=2, which shows up as a ~0.5 relative difference against the CP=1 run and
+    swamps any real discrepancy.
+
+    Summing locally and dividing by the CP-reduced count instead makes each rank
+    contribute its true share of the global mean: the per-rank losses add up to the
+    CP=1 loss, and the gradients match position for position.
     """
     logits: torch.Tensor = output_tensor.float()
     vocab_size: int = logits.size(-1)
+    flat_labels: torch.Tensor = labels.view(-1)
 
-    loss: torch.Tensor = torch.nn.functional.cross_entropy(
+    loss_sum: torch.Tensor = torch.nn.functional.cross_entropy(
         logits.view(-1, vocab_size),
-        labels.view(-1),
+        flat_labels,
         ignore_index=-100,
-        reduction="mean",
+        reduction="sum",
     )
+    num_valid: torch.Tensor = (flat_labels != -100).sum()
+    cp = get_parallel_state().cp
+    if cp.size > 1:
+        dist.all_reduce(num_valid, group=cp.group)
+
+    loss: torch.Tensor = loss_sum / num_valid.clamp(min=1)
     return loss, {"loss": loss.detach()}

--- a/miles/utils/debug_utils/run_megatron/worker/main.py
+++ b/miles/utils/debug_utils/run_megatron/worker/main.py
@@ -97,6 +97,7 @@ def main() -> None:
         )
 
     save_replay_data(script, rank=rank)
+    _dump_model_params_and_grads(model)
     _finalize_dumper()
 
     if rank == 0:
@@ -127,13 +128,20 @@ def _initialize_megatron(args: argparse.Namespace) -> None:
     args.__dict__.setdefault("debug_deterministic_collective", False)
     set_default_megatron_args(args)
     validate_args(args)
+    # Megatron's validate_args unconditionally resets this to False; the miles
+    # backend always runs with variable_seq_lengths (miles/utils/arguments.py),
+    # so mirror it here to keep the worker consistent with the training path.
+    args.variable_seq_lengths = True
 
     init(args)
 
 
 def _build_and_load_model(args: argparse.Namespace, script: WorkerScriptArgs) -> list[Any]:
     model_provider: Callable[..., Any] = get_model_provider_func(args, role=script.role)
-    model: list[Any] = get_model(model_provider, ModelType.encoder_or_decoder)
+    # Forward-only runs never call backward, so skip the DDP wrapper and its
+    # per-parameter grad buffers (which otherwise OOM for large models even
+    # when only logits/logprobs are needed).
+    model: list[Any] = get_model(model_provider, ModelType.encoder_or_decoder, wrap_with_ddp=script.run_backward)
 
     if args.load is not None:
         load_checkpoint(
@@ -145,7 +153,7 @@ def _build_and_load_model(args: argparse.Namespace, script: WorkerScriptArgs) ->
         )
 
     for m in model:
-        m.train()
+        m.train(script.run_backward)
     return model
 
 
@@ -208,6 +216,33 @@ def _print_config(args: argparse.Namespace, script: WorkerScriptArgs) -> None:
         flush=True,
     )
     print(f"[worker] run_backward={script.run_backward}, role={script.role}", flush=True)
+
+
+def _dump_model_params_and_grads(model: list[Any]) -> None:
+    """Dump parameter gradients so runs can be diffed per parameter.
+
+    ``DUMPER_ENABLE_MODEL_GRAD`` only takes effect inside ``dump_model``, which
+    the training path reaches through ``DumperMegatronUtil.finalize`` but this
+    standalone worker never called -- so ``--run-backward`` produced no
+    parameter gradients at all.
+
+    ``get_grad`` is not optional here. The dumper's default is a bare
+    ``param.grad`` read, and under Megatron DDP the gradient lives in
+    ``param.main_grad`` with ``param.grad`` left as None, so omitting it yields a
+    silently empty dump. The heavier distributed-optimizer shard gather in
+    ``dumper_utils`` is only needed for the FT trainer, whose reduce-scatter
+    leaves each rank holding a partial buffer.
+    """
+    if os.environ.get("DUMPER_ENABLE", "0") != "1":
+        return
+    if os.environ.get("DUMPER_ENABLE_MODEL_GRAD", "0") != "1":
+        return
+    assert len(model) == 1, f"model dump does not support virtual pipeline parallelism ({len(model)} chunks)"
+
+    def get_grad(param: torch.nn.Parameter) -> torch.Tensor | None:
+        return param.grad if param.grad is not None else getattr(param, "main_grad", None)
+
+    dumper.dump_model(model[0], get_grad=get_grad)
 
 
 def _finalize_dumper() -> None:


### PR DESCRIPTION
Three model-agnostic fixes to the standalone `run_megatron` worker, found while
using it for cross-stack forward/backward alignment.

### 1. `--run-backward` produced no parameter gradients at all

The worker called `dumper.register_non_intrusive_dumper(m)` (activations) and
`_finalize_dumper()` (`step()` + `configure(enable=False)`), but never
`dump_model`. `DUMPER_ENABLE_MODEL_GRAD` is only consumed *inside* `dump_model`
(`enable_curr_grad=self._config.enable_model_grad`), so setting it produced
activations and zero parameter gradients — no error, no warning, empty dump.

The training path reaches `dump_model` through `DumperMegatronUtil.finalize`
(`miles/utils/dumper_utils.py`); the standalone worker had no equivalent.

`get_grad` is required alongside, not optional. On `sglang-miles`,
`dumper.py:509` reads:

```python
g = get_grad(value) if get_grad is not None else value.grad
```

a bare `.grad` with no `main_grad` fallback. Under Megatron DDP the gradient
lives in `param.main_grad` with `param.grad` left `None`, so calling
`dump_model` *without* a getter still yields a silently empty dump. The heavier
distributed-optimizer shard gather in `dumper_utils._build_full_grad_getter` is
only needed for the FT trainer, whose reduce-scatter leaves each rank holding a
partial buffer — the standalone worker has no reduce-scatter, so the cheap
`.grad or main_grad` read is sufficient.

`step=` is deliberately not passed: `dump_model` on `sglang-miles` has no `step`
parameter, so it lands in `**kwargs` → `extra_kwargs` → `tags`, and
`_dump_single` then does `dict(step=..., rank=..., **tags)` → `TypeError: dict()
got multiple values for keyword argument 'step'`.

### 2. `loss_func` normalised by the local valid-token count under CP

`reduction="mean"` divides by each rank's own valid count, but under context
parallelism the labels are sharded. Every activation gradient comes out scaled
by global/local — about 2x at CP=2 — so a CP run compared against CP=1 shows a
spurious ~0.5 relative difference that swamps any real discrepancy.

Summing locally and dividing by the CP-reduced count makes each rank contribute
its true share of the global mean: the per-rank losses add up to the CP=1 loss
and the gradients match position for position.

### 3. Forward-only runs still allocated DDP grad buffers

`get_model` was always called with the default `wrap_with_ddp=True`, so a
forward-only run paid for per-parameter grad buffers it never used, OOMing on
large models when only logits/logprobs were wanted. Now keyed off
`script.run_backward`, with `m.train(script.run_backward)` to match.

Also mirrors the miles backend's `variable_seq_lengths`, which Megatron's
`validate_args` unconditionally resets to `False`.

### Adjacent issue, not fixed here

By the same `step=` mechanism, `miles/utils/dumper_utils.py` calling
`dumper.dump_model(extracted_model, get_grad=get_grad, step=0)` would raise
`TypeError` against `sglang-miles`. Left alone since it is a different code
path; flagging it because anyone enabling `DUMPER_ENABLE_MODEL_GRAD` on the
*training* path will hit it. Happy to fix in a follow-up.

Note also that `dumper_utils.finalize` only builds a `get_grad` when
`enable_experimental_ft_trainer()` is true and passes `None` otherwise — which,
per the bare-`.grad` default above, means non-FT Megatron DDP runs dump empty
gradients there too. `_log_model_grad_coverage` uses the correct
`.grad or main_grad` read, so the two disagree.

### Testing

`pre-commit` and `py_compile` pass. I could not run the fast tests locally — no
`sglang` / `megatron` on this host — so CI is the first real exercise.
