### PR TITLE
fix: run PPO GAE over trainable tokens only

### DIFF
--- a/miles/backends/training_utils/loss_hub/advantages.py
+++ b/miles/backends/training_utils/loss_hub/advantages.py
@@ -71,6 +71,7 @@ def compute_advantages(
             terminal_rewards=terminal_rewards,
             qkv_format=args.qkv_format,
             max_seq_lens=max_seq_lens,
+            loss_masks=loss_masks,
             gamma=args.gamma,
             lambd=args.lambd,
         )

--- a/miles/backends/training_utils/loss_hub/math_utils.py
+++ b/miles/backends/training_utils/loss_hub/math_utils.py
@@ -611,7 +611,7 @@ def get_advantages_and_returns_batch(
     """
     Batched GAE with CP support, computed over trainable tokens only.
 
-    Semantics (PPO-002):
+    Semantics:
       - Masked tokens (`loss_mask == 0`, e.g. tool/env observations in
         multi-turn rollouts) are not MDP transitions. GAE runs on the
         subsequence of trainable tokens, so masked tokens carry no reward

--- a/miles/backends/training_utils/loss_hub/math_utils.py
+++ b/miles/backends/training_utils/loss_hub/math_utils.py
@@ -624,8 +624,15 @@ def get_advantages_and_returns_batch(
       - Truncated sequences use the same zero bootstrap as terminated ones:
         the value after the last trainable token is taken as 0 and the
         observed terminal reward is still applied.
-      - Advantages and returns at masked positions are 0; the policy and value
-        losses mask them out, so they are never trained.
+      - This function outputs zero advantages and returns at masked positions.
+        Downstream transforms may still shift these entries to nonzero values
+        (advantage whitening applies its affine transform to every position,
+        and the on-policy distillation KL penalty is added per token), but the
+        whitening statistics themselves are mask-weighted, so the injected
+        zeros do not bias them. Correctness relies on the policy and value
+        losses masking these positions out (the policy loss re-zeros
+        advantages at inactive tokens and all loss reducers weight by
+        `loss_mask`), so masked positions never receive gradient.
 
     C_i is the length of values_list[i] and rewards_list[i] on the current CP rank.
     Input:

--- a/miles/backends/training_utils/loss_hub/math_utils.py
+++ b/miles/backends/training_utils/loss_hub/math_utils.py
@@ -603,12 +603,30 @@ def get_advantages_and_returns_batch(
     terminal_rewards,
     qkv_format,
     max_seq_lens,
+    loss_masks,
     gamma,
     lambd,
     chunked: bool = True,
 ):
     """
-    Batched GAE with CP support.
+    Batched GAE with CP support, computed over trainable tokens only.
+
+    Semantics (PPO-002):
+      - Masked tokens (`loss_mask == 0`, e.g. tool/env observations in
+        multi-turn rollouts) are not MDP transitions. GAE runs on the
+        subsequence of trainable tokens, so masked tokens carry no reward
+        (including KL shaping), contribute no value delta, and the GAE carry
+        crosses them without extra `gamma * lambd` decay.
+      - The terminal reward is added at the last trainable token, not the last
+        response token.
+      - Fully masked samples get zero advantages and returns; their terminal
+        reward is dropped.
+      - Truncated sequences use the same zero bootstrap as terminated ones:
+        the value after the last trainable token is taken as 0 and the
+        observed terminal reward is still applied.
+      - Advantages and returns at masked positions are 0; the policy and value
+        losses mask them out, so they are never trained.
+
     C_i is the length of values_list[i] and rewards_list[i] on the current CP rank.
     Input:
         total_lengths:     list[int], each sample's total_len
@@ -618,6 +636,7 @@ def get_advantages_and_returns_batch(
         terminal_rewards:  list[float], one scalar sequence reward per sample
         qkv_format:        str, sequence layout used to split tensors across CP ranks
         max_seq_lens:      list[int] of BSHD padded lengths, or None for THD
+        loss_masks:        list[Tensor], full-response masks, each has shape [R_i]
     Output:
         advantages_list:   list[Tensor], each current-CP-rank tensor has shape [C_i]
         returns_list:      list[Tensor], same shape
@@ -628,6 +647,7 @@ def get_advantages_and_returns_batch(
         assert B == len(values_list)
         assert B == len(rewards_list)
         assert B == len(terminal_rewards)
+        assert B == len(loss_masks)
 
         cp_size = get_parallel_state().cp.size
         if cp_size > 1 and qkv_format == "bshd":
@@ -657,35 +677,46 @@ def get_advantages_and_returns_batch(
                 full_values_list.append(full_v)
                 full_rewards_list.append(full_r)
 
-            # full_values_list[i].shape = [total_len_i]
+            # full_values_list[i].shape = [resp_len_i]
         else:
             full_values_list = values_list
             full_rewards_list = rewards_list
 
-        # pad to max_len for batched GAE
-        max_len = max(response_lengths)
+        # Compress each sample to its trainable positions so that masked
+        # tokens do not act as MDP transitions in the GAE recursion.
+        trainable_indices = [
+            loss_masks[i][: response_lengths[i]].to(device).nonzero(as_tuple=True)[0] for i in range(B)
+        ]
+        trainable_lengths = [idx.numel() for idx in trainable_indices]
 
-        full_values = torch.zeros(B, max_len, device=device, dtype=dtype)
-        full_rewards = torch.zeros(B, max_len, device=device, dtype=dtype)
+        # pad to max_len for batched GAE
+        max_len = max(trainable_lengths)
+
+        packed_values = torch.zeros(B, max_len, device=device, dtype=dtype)
+        packed_rewards = torch.zeros(B, max_len, device=device, dtype=dtype)
 
         for i in range(B):
-            L = response_lengths[i]
-            if L > 0:
-                full_values[i, :L] = full_values_list[i][:L]
-                full_rewards[i, :L] = full_rewards_list[i][:L]
-                full_rewards[i, L - 1] += terminal_rewards[i]
+            K = trainable_lengths[i]
+            if K > 0:
+                idx = trainable_indices[i]
+                packed_values[i, :K] = full_values_list[i][idx]
+                packed_rewards[i, :K] = full_rewards_list[i][idx]
+                packed_rewards[i, K - 1] += terminal_rewards[i]
 
-        if not chunked:
-            full_advantages, full_returns = vanilla_gae(
-                rewards=full_rewards,
-                values=full_values,
+        if max_len == 0:
+            packed_advantages = torch.zeros(B, 0, device=device, dtype=dtype)
+            packed_returns = torch.zeros(B, 0, device=device, dtype=dtype)
+        elif not chunked:
+            packed_advantages, packed_returns = vanilla_gae(
+                rewards=packed_rewards,
+                values=packed_values,
                 gamma=gamma,
                 lambd=lambd,
             )
         else:
-            full_advantages, full_returns = chunked_gae(
-                rewards=full_rewards,
-                values=full_values,
+            packed_advantages, packed_returns = chunked_gae(
+                rewards=packed_rewards,
+                values=packed_values,
                 gamma=gamma,
                 lambd=lambd,
             )
@@ -693,41 +724,36 @@ def get_advantages_and_returns_batch(
         advantages_list = []
         returns_list = []
 
-        if cp_size > 1:
-            for total_len, resp_len, adv_row, ret_row, max_seq_len in zip(
-                total_lengths,
-                response_lengths,
-                full_advantages,
-                full_returns,
-                max_seq_lens_per_sample,
-                strict=False,
-            ):
-                adv_full = adv_row  # shape = [resp_len_i padded to max_len]
-                ret_full = ret_row
+        for i in range(B):
+            resp_len = response_lengths[i]
+            K = trainable_lengths[i]
 
-                adv_sliced = slice_log_prob_with_cp(
-                    adv_full[:resp_len],
-                    total_len,
+            adv_full = torch.zeros(resp_len, device=device, dtype=dtype)
+            ret_full = torch.zeros(resp_len, device=device, dtype=dtype)
+            if K > 0:
+                idx = trainable_indices[i]
+                adv_full[idx] = packed_advantages[i, :K]
+                ret_full[idx] = packed_returns[i, :K]
+
+            if cp_size > 1:
+                max_seq_len = max_seq_lens_per_sample[i]
+                adv_full = slice_log_prob_with_cp(
+                    adv_full,
+                    total_lengths[i],
                     resp_len,
                     qkv_format=qkv_format,
                     max_token_len=max_seq_len,
                 )
-                ret_sliced = slice_log_prob_with_cp(
-                    ret_full[:resp_len],
-                    total_len,
+                ret_full = slice_log_prob_with_cp(
+                    ret_full,
+                    total_lengths[i],
                     resp_len,
                     qkv_format=qkv_format,
                     max_token_len=max_seq_len,
                 )
 
-                advantages_list.append(adv_sliced)
-                returns_list.append(ret_sliced)
-
-        else:
-            for i in range(B):
-                L = response_lengths[i]
-                advantages_list.append(full_advantages[i, :L])
-                returns_list.append(full_returns[i, :L])
+            advantages_list.append(adv_full)
+            returns_list.append(ret_full)
 
     return advantages_list, returns_list
 

--- a/tests/fast/backends/training_utils/test_ppo_cp_advantages.py
+++ b/tests/fast/backends/training_utils/test_ppo_cp_advantages.py
@@ -70,6 +70,59 @@ def _run_ppo_case(rank: int, total_length: int, response_length: int, expected_l
     torch.testing.assert_close(cp_returns, baseline_returns[0])
 
 
+def _run_ppo_masked_case(rank: int) -> None:
+    total_length, response_length = 7, 6
+    loss_mask = torch.tensor([1.0, 1.0, 0.0, 0.0, 1.0, 0.0])
+
+    for gamma, lambd in [(0.0, 0.0), (0.9, 0.8)]:
+        args = Namespace(advantage_estimator="ppo", kl_coef=0.1, gamma=gamma, lambd=lambd, qkv_format="thd")
+        full_kl = torch.arange(1, response_length + 1, dtype=torch.float32)
+        full_values = torch.tensor([0.5, -0.3, 0.7, 0.1, -0.2, 0.4])
+
+        set_parallel_state(_parallel_state(rank=rank, world_size=2))
+        local_kl = slice_log_prob_with_cp(full_kl, total_length, response_length).clone()
+        local_values = slice_log_prob_with_cp(full_values, total_length, response_length).clone()
+
+        advantages, returns = compute_advantages(
+            args=args,
+            kl=[local_kl],
+            rewards=[10.0],
+            log_probs=[torch.empty_like(local_kl)],
+            loss_masks=[loss_mask.clone()],
+            total_lengths=[total_length],
+            response_lengths=[response_length],
+            values=[local_values],
+        )
+        cp_advantages = all_gather_with_cp(advantages[0], total_length, response_length)
+        cp_returns = all_gather_with_cp(returns[0], total_length, response_length)
+
+        set_parallel_state(_parallel_state())
+        baseline_advantages, baseline_returns = compute_advantages(
+            args=args,
+            kl=[full_kl.clone()],
+            rewards=[10.0],
+            log_probs=[torch.empty_like(full_kl)],
+            loss_masks=[loss_mask.clone()],
+            total_lengths=[total_length],
+            response_lengths=[response_length],
+            values=[full_values.clone()],
+        )
+
+        torch.testing.assert_close(cp_advantages, baseline_advantages[0])
+        torch.testing.assert_close(cp_returns, baseline_returns[0])
+        assert torch.all(cp_advantages[loss_mask == 0] == 0)
+        assert torch.all(cp_returns[loss_mask == 0] == 0)
+
+        if gamma == 0.0 and lambd == 0.0:
+            # Terminal reward lands on the last trainable token (index 4), and
+            # with gamma = 0 each trainable advantage is reward - value.
+            expected = torch.zeros(response_length)
+            expected[0] = -0.1 * 1.0 - 0.5
+            expected[1] = -0.1 * 2.0 - (-0.3)
+            expected[4] = -0.1 * 5.0 + 10.0 - (-0.2)
+            torch.testing.assert_close(cp_advantages, expected)
+
+
 def _worker_tail_on_rank_one(rank: int, world_size: int, port: int) -> None:
     init_gloo(rank, world_size, port=port)
     try:
@@ -172,6 +225,14 @@ def _worker_bshd_layout_metadata(rank: int, world_size: int, port: int) -> None:
         dist.destroy_process_group()
 
 
+def _worker_masked_case(rank: int, world_size: int, port: int) -> None:
+    init_gloo(rank, world_size, port=port)
+    try:
+        _run_ppo_masked_case(rank)
+    finally:
+        dist.destroy_process_group()
+
+
 def test_ppo_terminal_reward_is_added_to_global_response_tail() -> None:
     run_multiprocess(_worker_tail_on_rank_one)
 
@@ -182,3 +243,7 @@ def test_ppo_terminal_reward_handles_empty_rank_zero_shard() -> None:
 
 def test_ppo_bshd_cp_uses_padded_layout_metadata() -> None:
     run_multiprocess(_worker_bshd_layout_metadata)
+
+
+def test_ppo_masked_gae_matches_single_rank_baseline() -> None:
+    run_multiprocess(_worker_masked_case)

--- a/tests/fast/backends/training_utils/test_ppo_gae_masks.py
+++ b/tests/fast/backends/training_utils/test_ppo_gae_masks.py
@@ -1,0 +1,209 @@
+import pytest
+import torch
+
+from miles.backends.training_utils.loss_hub.math_utils import get_advantages_and_returns_batch, vanilla_gae
+from miles.backends.training_utils.parallel import GroupInfo, ParallelState, set_parallel_state
+
+
+@pytest.fixture(autouse=True)
+def _trivial_parallel_state() -> None:
+    trivial_group = GroupInfo(rank=0, size=1, group=None)
+    set_parallel_state(
+        ParallelState(
+            intra_dp=trivial_group,
+            intra_dp_cp=trivial_group,
+            cp=trivial_group,
+            tp=trivial_group,
+            pp=trivial_group,
+            ep=trivial_group,
+            etp=trivial_group,
+            indep_dp=trivial_group,
+        )
+    )
+
+
+def _reference_masked_gae(
+    values: torch.Tensor,
+    rewards: torch.Tensor,
+    mask: torch.Tensor,
+    terminal_reward: float,
+    gamma: float,
+    lambd: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Serial GAE over the compressed subsequence of trainable tokens."""
+    idx = mask.nonzero(as_tuple=True)[0]
+    advantages = torch.zeros_like(values)
+    returns = torch.zeros_like(values)
+    if idx.numel() == 0:
+        return advantages, returns
+
+    v = values[idx]
+    r = rewards[idx].clone()
+    r[-1] += terminal_reward
+
+    K = v.numel()
+    compressed_adv = torch.zeros_like(v)
+    lastgaelam = 0.0
+    for t in reversed(range(K)):
+        next_value = v[t + 1] if t < K - 1 else 0.0
+        delta = r[t] + gamma * next_value - v[t]
+        lastgaelam = delta + gamma * lambd * lastgaelam
+        compressed_adv[t] = lastgaelam
+
+    advantages[idx] = compressed_adv
+    returns[idx] = compressed_adv + v
+    return advantages, returns
+
+
+def _compute(
+    values: list[torch.Tensor],
+    rewards: list[torch.Tensor],
+    terminal_rewards: list[float],
+    loss_masks: list[torch.Tensor],
+    gamma: float,
+    lambd: float,
+    chunked: bool,
+) -> tuple[list[torch.Tensor], list[torch.Tensor]]:
+    response_lengths = [v.numel() for v in values]
+    return get_advantages_and_returns_batch(
+        total_lengths=[length + 1 for length in response_lengths],
+        response_lengths=response_lengths,
+        values_list=values,
+        rewards_list=rewards,
+        terminal_rewards=terminal_rewards,
+        qkv_format="thd",
+        max_seq_lens=None,
+        loss_masks=loss_masks,
+        gamma=gamma,
+        lambd=lambd,
+        chunked=chunked,
+    )
+
+
+@pytest.mark.parametrize("chunked", [False, True])
+def test_masked_gap_matches_compressed_reference(chunked: bool) -> None:
+    torch.manual_seed(0)
+    mask = torch.tensor([1.0, 1.0, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 0.0])
+    values = torch.randn(10)
+    rewards = torch.randn(10)
+    terminal_reward = 3.0
+    gamma, lambd = 0.9, 0.95
+
+    advantages, returns = _compute(
+        [values.clone()], [rewards.clone()], [terminal_reward], [mask.clone()], gamma, lambd, chunked
+    )
+    expected_adv, expected_ret = _reference_masked_gae(values, rewards, mask, terminal_reward, gamma, lambd)
+
+    torch.testing.assert_close(advantages[0], expected_adv)
+    torch.testing.assert_close(returns[0], expected_ret)
+    assert torch.all(advantages[0][mask == 0] == 0)
+    assert torch.all(returns[0][mask == 0] == 0)
+
+
+@pytest.mark.parametrize("chunked", [False, True])
+@pytest.mark.parametrize("gap_len", [1, 5])
+def test_gae_carry_crosses_mask_gap_undecayed(chunked: bool, gap_len: int) -> None:
+    # Two trainable tokens separated by a masked gap: the carry from the second
+    # to the first must decay by exactly one factor of gamma * lambd, no matter
+    # how long the gap is.
+    gamma, lambd = 0.9, 0.5
+    length = 2 + gap_len
+    mask = torch.zeros(length)
+    mask[0] = 1.0
+    mask[-1] = 1.0
+    values = torch.zeros(length)
+    rewards = torch.zeros(length)
+    rewards[-1] = 2.0
+
+    advantages, _ = _compute([values], [rewards], [0.0], [mask], gamma, lambd, chunked)
+
+    torch.testing.assert_close(advantages[0][-1], torch.tensor(2.0))
+    torch.testing.assert_close(advantages[0][0], torch.tensor(gamma * lambd * 2.0))
+    assert torch.all(advantages[0][1:-1] == 0)
+
+
+@pytest.mark.parametrize("chunked", [False, True])
+def test_terminal_reward_on_last_trainable_token(chunked: bool) -> None:
+    # Masked tail: with gamma = 0 the terminal reward would be lost entirely if
+    # it were injected at the last response token instead of the last trainable
+    # token.
+    mask = torch.tensor([1.0, 1.0, 1.0, 0.0, 0.0])
+    values = torch.tensor([0.5, -0.2, 0.3, 0.9, 0.9])
+    rewards = torch.tensor([0.1, 0.2, 0.3, 7.0, 7.0])
+    terminal_reward = 10.0
+
+    advantages, returns = _compute([values], [rewards], [terminal_reward], [mask], 0.0, 0.0, chunked)
+
+    expected = torch.tensor([0.1 - 0.5, 0.2 + 0.2, 0.3 + 10.0 - 0.3, 0.0, 0.0])
+    torch.testing.assert_close(advantages[0], expected)
+    torch.testing.assert_close(returns[0], expected + values * mask)
+
+
+@pytest.mark.parametrize("chunked", [False, True])
+def test_fully_masked_sample_yields_zeros(chunked: bool) -> None:
+    torch.manual_seed(1)
+    values = [torch.randn(4), torch.randn(6)]
+    rewards = [torch.randn(4), torch.randn(6)]
+    masks = [torch.zeros(4), torch.ones(6)]
+
+    advantages, returns = _compute(
+        [v.clone() for v in values], [r.clone() for r in rewards], [5.0, 2.0], masks, 0.9, 0.95, chunked
+    )
+
+    assert torch.all(advantages[0] == 0)
+    assert torch.all(returns[0] == 0)
+
+    expected_adv, expected_ret = _reference_masked_gae(values[1], rewards[1], masks[1], 2.0, 0.9, 0.95)
+    torch.testing.assert_close(advantages[1], expected_adv)
+    torch.testing.assert_close(returns[1], expected_ret)
+
+
+@pytest.mark.parametrize("chunked", [False, True])
+def test_all_ones_mask_preserves_unmasked_behavior(chunked: bool) -> None:
+    torch.manual_seed(2)
+    lengths = [5, 3]
+    values = [torch.randn(length) for length in lengths]
+    rewards = [torch.randn(length) for length in lengths]
+    terminal_rewards = [4.0, -1.0]
+    gamma, lambd = 0.99, 0.9
+
+    advantages, returns = _compute(
+        [v.clone() for v in values],
+        [r.clone() for r in rewards],
+        terminal_rewards,
+        [torch.ones(length) for length in lengths],
+        gamma,
+        lambd,
+        chunked,
+    )
+
+    max_len = max(lengths)
+    padded_values = torch.zeros(2, max_len)
+    padded_rewards = torch.zeros(2, max_len)
+    for i, length in enumerate(lengths):
+        padded_values[i, :length] = values[i]
+        padded_rewards[i, :length] = rewards[i]
+        padded_rewards[i, length - 1] += terminal_rewards[i]
+    expected_adv, expected_ret = vanilla_gae(padded_rewards, padded_values, gamma, lambd)
+
+    for i, length in enumerate(lengths):
+        torch.testing.assert_close(advantages[i], expected_adv[i, :length])
+        torch.testing.assert_close(returns[i], expected_ret[i, :length])
+
+
+@pytest.mark.parametrize("chunked", [False, True])
+def test_truncation_uses_zero_bootstrap(chunked: bool) -> None:
+    # Truncated rollouts are treated like terminated ones: with gamma = lambd
+    # = 1 the GAE telescopes to sum(rewards) + terminal - V_t, i.e. the value
+    # after the last trainable token is bootstrapped as exactly zero.
+    values = torch.tensor([0.4, -0.1, 0.25, 0.6])
+    rewards = torch.tensor([0.1, -0.2, 0.3, 0.05])
+    terminal_reward = 1.5
+
+    advantages, _ = _compute(
+        [values.clone()], [rewards.clone()], [terminal_reward], [torch.ones(4)], 1.0, 1.0, chunked
+    )
+
+    reward_tail_sums = torch.flip(torch.cumsum(torch.flip(rewards, dims=[0]), dim=0), dims=[0])
+    expected = reward_tail_sums + terminal_reward - values
+    torch.testing.assert_close(advantages[0], expected)


### PR DESCRIPTION
## Summary

PPO's GAE currently treats every response token as an MDP transition and injects the terminal reward at the last response token, regardless of the loss mask. In multi-turn / agentic rollouts, tool and environment observation tokens are masked (`loss_mask == 0`), which breaks GAE in three ways:

1. **Terminal reward can be attenuated or lost.** If the response ends with masked tokens (e.g. a final env observation), the scalar reward lands on a masked position. It only reaches trainable tokens after `(gamma * lambd)^gap` decay — and with `gamma = 0` it is lost entirely.
2. **Masked tokens leak signal into the recursion.** KL-shaped rewards and critic value deltas at masked positions (tokens the policy never produced) flow into the advantages of neighboring trainable tokens, and each masked token adds one step of `gamma * lambd` decay, diluting credit across long observation blocks.
3. **Truncation semantics were undefined.** Nothing documented or tested what happens when a rollout hits the length limit.

This PR defines and enforces the semantics in `get_advantages_and_returns_batch`:

- GAE runs on the compressed subsequence of trainable tokens; masked tokens carry no reward (including KL shaping), contribute no value delta, and the GAE carry crosses them with exactly one `gamma * lambd` decay per trainable transition (undecayed pass-through).
- The terminal reward is injected at the **last trainable token**.
- Fully masked samples get zero advantages/returns (their terminal reward is dropped) instead of training on garbage.
- Truncated sequences keep the existing zero-bootstrap treatment (value after the last trainable token taken as 0, observed reward still applied) — now documented and pinned by a test, no behavior change.
- The function outputs zero advantages/returns at masked positions. Downstream transforms can still shift these entries to nonzero values — advantage whitening applies its affine transform to every position, and the on-policy distillation KL penalty is added per token — but the whitening statistics are mask-weighted, so the injected zeros do not bias them. Correctness relies on the losses: the policy loss re-zeros advantages at inactive tokens and every loss reducer weights by `loss_mask`, so masked positions never receive gradient.

For fully unmasked responses the results are bit-identical to the previous implementation (covered by a regression test). The `vanilla_gae` / `chunked_gae` kernels are untouched — masking happens by compressing each sample before the batched scan, so the FLA-style chunked kernel keeps working as-is.

## Test plan

- [x] New `tests/fast/backends/training_utils/test_ppo_gae_masks.py` (all parametrized over `chunked` True/False):
  - internal mask gap matches a serial reference on the compressed subsequence; masked positions get 0
  - carry crosses a mask gap with exactly one `gamma * lambd` decay, independent of gap length
  - terminal reward lands on the last trainable token when the tail is masked (`gamma = 0` would previously lose it)
  - fully masked sample yields zeros without disturbing its batch neighbors
  - all-ones mask reproduces the previous unmasked behavior exactly
  - `gamma = lambd = 1` telescopes to `sum(rewards) + terminal - V_t`, pinning zero-bootstrap truncation semantics
- [x] New 2-rank Gloo CP test in `test_ppo_cp_advantages.py`: masked GAE under CP == single-rank baseline, masked positions zero, exact values for `gamma = lambd = 0`
- [x] Full CPU baseline suite green (64 passed): `tests/test_chunked_gae.py`, `test_ppo_gae_masks.py`, `test_ppo_cp_advantages.py`, `test_train_data_conversion.py`, `test_ppo_ratio_numerics.py`, `test_true_on_policy_loss_metrics.py`
- [x] Re-ran `test_ppo_gae_masks.py` + `test_ppo_cp_advantages.py` after merging `origin/main` (17 passed)
- [x] `ruff check` and `black --check` clean on all touched files
