### PR TITLE
fix(session): drop upstream Server/Date so aiohttp clients can read replies

### DIFF
--- a/miles/rollout/session/core.py
+++ b/miles/rollout/session/core.py
@@ -28,8 +28,11 @@ logger = logging.getLogger(__name__)
 JSON_MEDIA_TYPE = "application/json"
 
 # Hop-by-hop / length-framing headers dropped from the upstream response so the
-# transport layer recomputes them from the body we actually send.
-_DROP_RESPONSE_HEADERS = ("content-length", "transfer-encoding", "content-encoding")
+# transport layer recomputes them from the body we actually send. "server" and
+# "date" are dropped because our own ASGI server always emits them, so echoing
+# upstream's copy puts two of each on the wire; aiohttp's parser rejects that
+# outright with "Duplicate 'Server' header found" instead of reading the body.
+_DROP_RESPONSE_HEADERS = ("content-length", "transfer-encoding", "content-encoding", "server", "date")
 
 
 @dataclass

--- a/miles/router/router.py
+++ b/miles/router/router.py
@@ -166,7 +166,11 @@ class MilesRouter:
         content = result["response_body"]
         status_code = result["status_code"]
         headers = result["headers"]
-        headers = {k: v for k, v in headers.items() if k.lower() not in ("content-length", "transfer-encoding")}
+        headers = {
+            k: v
+            for k, v in headers.items()
+            if k.lower() not in ("content-length", "transfer-encoding", "server", "date")
+        }
         content_type = headers.get("content-type", "")
         try:
             data = json.loads(content)

--- a/tests/fast/router/test_sessions.py
+++ b/tests/fast/router/test_sessions.py
@@ -3,6 +3,7 @@
 import asyncio
 import json
 import re
+import socket
 import uuid
 from types import SimpleNamespace
 from unittest.mock import patch
@@ -161,6 +162,36 @@ class TestSessionProxy:
         record = records[0]
         assert record["path"] == "/v1/chat/completions"
         assert record["status_code"] == 200
+
+    def test_proxy_chat_response_has_no_duplicate_server_or_date_header(self, router_env):
+        # Both the backend and this server run under uvicorn, so each emits its own
+        # server/date. Echoing upstream's copy puts two of each on the wire, and
+        # aiohttp (the transport litellm uses) then refuses to read the body at all.
+        session_id = requests.post(f"{router_env.url}/sessions", timeout=5.0).json()["session_id"]
+        host, port = router_env.url.removeprefix("http://").split(":")
+        body = json.dumps({"messages": [{"role": "user", "content": "hi"}], "return_logprob": True})
+        request = (
+            f"POST /sessions/{session_id}/v1/chat/completions HTTP/1.1\r\n"
+            f"Host: {host}:{port}\r\n"
+            "Content-Type: application/json\r\n"
+            f"Content-Length: {len(body)}\r\n"
+            "Connection: close\r\n\r\n"
+            f"{body}"
+        )
+
+        with socket.create_connection((host, int(port)), timeout=10.0) as sock:
+            sock.sendall(request.encode())
+            raw = b""
+            while b"\r\n\r\n" not in raw:
+                chunk = sock.recv(4096)
+                assert chunk, "connection closed before response headers were complete"
+                raw += chunk
+
+        head = raw.split(b"\r\n\r\n", 1)[0].decode()
+        assert head.splitlines()[0].endswith("200 OK")
+        names = [line.split(":", 1)[0].lower() for line in head.splitlines()[1:]]
+        assert names.count("server") == 1
+        assert names.count("date") == 1
 
     def test_chat_malformed_json_body_returns_400(self, router_env):
         session_id = requests.post(f"{router_env.url}/sessions", timeout=5.0).json()["session_id"]


### PR DESCRIPTION
## What's wrong

`miles/rollout/session/core.py` and `miles/router/router.py` are both HTTP proxies: they forward a request to SGLang, then rebuild the client-facing response from the upstream response's headers. They drop only framing headers, so upstream's `Server: uvicorn` and `Date:` survive the copy — and then our own ASGI server adds its `Server`/`Date` again. **Two of each go on the wire.**

`httpx`/`h11` tolerates duplicates, which is why the session server's own logs show a cheerful `HTTP/1.1 200 OK`. But `aiohttp`'s strict C parser (llhttp) rejects a duplicate `Server` outright, *before* reading the body:

```
aiohttp.http_exceptions.BadHttpMessage: 400, message="Duplicate 'Server' header found."
```

litellm's `aiohttp_transport` maps that to `httpx.RequestError` -> `openai.APIConnectionError: Connection error.` -> `litellm.InternalServerError`. Any litellm-based agent talking to the session server therefore **cannot read a single response**.

## Impact observed

On a GLM-4.7-Flash / Terminal-Bench-2 agentic RL run with harbor + terminus-2 (which uses litellm's aiohttp transport):

- 27/27 finished trials wrote an `exception.txt` with the duplicate-header error.
- Every `trajectory.json` had exactly **one** step (`source: "user"`), `total_completion_tokens: 0`.
- The agent retried the identical turn-1 request (3x LiteLLM retries nested under 3x terminus-2 retries = ~12 re-sends per session), producing a storm of ~776 session rollbacks across 32 sessions.
- `rollout/raw_reward = 0.0`, with no way for it to ever be anything else.

Confirmed with an isolated repro against the real transport — a starlette+uvicorn app echoing `{"server": "uvicorn", "date": ...}` from a fake upstream, probed with aiohttp:

```
/old (current drop set):  ClientResponseError: 400, message="Duplicate 'Server' header found."
/new (drop set + server/date):  HTTP 200 body={"ok":true}
```

## The fix

Add `server` and `date` to the dropped-response-header sets in both proxies. Our own ASGI server always emits them, so forwarding upstream's copy can only ever duplicate.

Note `router.py` has two visually identical comprehensions; only the **response** filter in `build_proxy_response` is changed. The one at line 150 filters the *outbound request* and is left alone.

## Verification

Same run relaunched with only this patch applied, everything else identical:

| | before | after |
|---|---|---|
| trials with `exception.txt` | 27/27 | **0** |
| trajectory step counts | all `1` | `3`-`20` (31 trajectories) |
| session rollbacks | ~776 | **0** |
| non-200 upstream calls | storm | **0** |

## Test

`test_proxy_chat_response_has_no_duplicate_server_or_date_header` asserts at the wire level. The existing `router_env` fixture already runs both `MockSGLangServer` and the `SessionServer` under test through uvicorn, so it reproduces the production duplication exactly — a raw socket read observes it directly, which a `requests`/`httpx` client cannot (both silently fold duplicates).

Validated both ways on a real devbox: passes with the fix, and with the tuple reverted in a throwaway copy it fails with the duplication visible in the assertion output:

```
E       AssertionError: assert 2 == 1
E        +    where [...] = ['date', 'server', 'date', 'server', 'content-type', 'content-length', ...].count
```