### PR TITLE
fix: require explicit off-policy correction for async PPO training

### DIFF
--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -2928,6 +2928,27 @@ def miles_validate_args(args):
     _maybe_apply_dumper_overrides(args)
 
 
+def validate_async_off_policy_correction(args) -> None:
+    """Require an explicit behavior-policy choice for async PPO training.
+
+    In the async train loop the next rollout is generated before the current
+    weight update is published, so samples can come from a stale policy. With
+    the default flags the PPO ratio denominator (``log_probs``) is recomputed
+    by the *current* actor, silently anchoring clipping (and KL-shaped
+    advantages) to a policy that never generated the trajectory; the recorded
+    ``weight_versions`` are a metric, not an enforcement mechanism.
+    """
+    if not args.use_critic:
+        return
+    assert args.use_rollout_logprobs or args.use_tis or args.keep_old_actor, (
+        "Async PPO training requires an explicit behavior-policy correction, because rollouts are "
+        "generated before the current weight update while log probs are recomputed by the current "
+        "actor by default. Pass one of: --use-rollout-logprobs (use the rollout engine's log probs "
+        "as the ratio denominator), --use-tis (truncated importance sampling correction), or "
+        "--keep-old-actor (recompute the denominator with the weights the rollout engines used)."
+    )
+
+
 def _maybe_apply_dumper_overrides(args) -> None:
     if not args.dumper_enable:
         return

--- a/tests/fast/utils/test_arguments.py
+++ b/tests/fast/utils/test_arguments.py
@@ -13,6 +13,7 @@ from miles.utils.arguments import (
     _resolve_ft_components,
     get_miles_extra_args_provider,
     miles_validate_args,
+    validate_async_off_policy_correction,
 )
 from miles.utils.misc import function_registry
 
@@ -356,3 +357,27 @@ def test_sglang_parallel_size_aliases_keep_last_value():
     args = parser.parse_args(["--sglang-data-parallel-size", "2", "--sglang-dp-size", "3"])
 
     assert args.sglang_dp_size == 3
+
+
+def _make_async_ppo_args(**overrides) -> SimpleNamespace:
+    defaults = dict(
+        use_critic=True,
+        use_rollout_logprobs=False,
+        use_tis=False,
+        keep_old_actor=False,
+    )
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+class TestValidateAsyncOffPolicyCorrection:
+    def test_ppo_without_correction_is_rejected(self):
+        with pytest.raises(AssertionError, match="behavior-policy correction"):
+            validate_async_off_policy_correction(_make_async_ppo_args())
+
+    @pytest.mark.parametrize("flag", ["use_rollout_logprobs", "use_tis", "keep_old_actor"])
+    def test_ppo_with_any_correction_passes(self, flag):
+        validate_async_off_policy_correction(_make_async_ppo_args(**{flag: True}))
+
+    def test_non_ppo_estimators_are_unaffected(self):
+        validate_async_off_policy_correction(_make_async_ppo_args(use_critic=False))

--- a/train_async.py
+++ b/train_async.py
@@ -4,7 +4,7 @@ import os
 
 from miles.ray.placement_group import create_placement_groups, create_rollout_manager, create_training_models
 from miles.utils import object_store
-from miles.utils.arguments import parse_args
+from miles.utils.arguments import parse_args, validate_async_off_policy_correction
 from miles.utils.async_utils import eager_create_task
 from miles.utils.audit_utils.process_identity import MainProcessIdentity
 from miles.utils.data import remove_rollout_data_refs
@@ -21,6 +21,7 @@ logger = logging.getLogger(__name__)
 # The framework supports other asynchronous approaches such as fully async (which is shown in examples/full_async).
 async def train(args):
     assert not args.colocate, "Colocation is not supported for async training."
+    validate_async_off_policy_correction(args)
     configure_logger(args, source=MainProcessIdentity())
     maybe_start_periodic_pyspy_dump()
     # allocate the GPUs


### PR DESCRIPTION
## Summary

In the async train loop (`train_async.py`), the next rollout is launched before the actor trains on the current one, and new weights are only published at the end of each `update_weights_interval` window. Samples therefore come from a policy that is at least one update behind the actor doing the training.

With the default flags this staleness is silently ignored for PPO: `use_rollout_logprobs=False` makes the trainer recompute `log_probs` with the *current* actor and use them as the PPO ratio denominator. Clipping is then anchored to a policy that never generated the trajectory, and no behavior-to-proximal importance correction is applied (with KL reward shaping, the same mis-attributed log probs also leak into the advantages). The `weight_versions` recorded on samples are only a metric — nothing enforces consistency.

The framework already ships three explicit ways to handle this, but nothing requires picking one:

- `--use-rollout-logprobs` — use the rollout engine's log probs directly as the ratio denominator (true behavior policy).
- `--use-tis` — recompute the denominator but apply truncated importance sampling correction against the rollout log probs.
- `--keep-old-actor` — recompute the denominator with a retained copy of the weights the rollout engines actually used (the rollout_actor → old_actor queue keeps it version-aligned with the in-flight generation).

This PR adds `validate_async_off_policy_correction` to `miles/utils/arguments.py` and calls it at the top of `train_async.py::train`: async PPO training (`--advantage-estimator ppo`) now fails fast with an actionable error unless one of the three flags is set. Other estimators (e.g. GRPO) are unaffected, and the synchronous entrypoint (`train.py`) is untouched — there the rollout and the recomputed log probs use the same weights, so no contract is needed.

## Test plan

- [x] New tests in `tests/fast/utils/test_arguments.py`:
  - async PPO with none of the three flags is rejected with the actionable message
  - each of `--use-rollout-logprobs` / `--use-tis` / `--keep-old-actor` individually satisfies the contract
  - non-PPO estimators (`use_critic=False`) pass without any flag
- [x] `python -m py_compile` on all three touched files
- [x] `black --check`, `isort --check-only`, and `ruff check` clean on all touched files

Note: `tests/fast/utils/test_arguments.py` imports `miles.utils.arguments`, which requires sglang, so the new tests were verified on this branch by exercising the extracted function body directly (same cases as committed); CI runs the real test file.
