### PR TITLE
Support PP-free Megatron forward/backward warmup

### DIFF
--- a/docs/user-guide/cli-reference.md
+++ b/docs/user-guide/cli-reference.md
@@ -211,6 +211,7 @@ Sections mirror the launch-script argument groups.
 | `--context-parallel-size` | int | `1` | CP. |
 | `--expert-model-parallel-size` | int | `1` | EP (MoE). |
 | `--expert-tensor-parallel-size` | int | `1` | TP within experts. |
+| `--enable-pp-free-warmup` | flag | off | Megatron only: before the first actor step, run one PP-free forward/backward per stage and virtual chunk without an optimizer step or gradient synchronization. Skipped when PP size is 1. |
 | `--sequence-parallel` | flag | off | Enable Megatron sequence parallel. |
 | `--use-dynamic-batch-size` | flag | off | Pack varlen samples. Recommended for varlen workloads. |
 | `--max-tokens-per-gpu` | int | – | Token budget per micro-batch per GPU. Required when dynamic batching is on. |

--- a/miles/backends/megatron_utils/actor.py
+++ b/miles/backends/megatron_utils/actor.py
@@ -399,6 +399,10 @@ class MegatronTrainRayActor(TrainRayActor):
     ) -> TrainStepOutcome:
         # Create data iterator for log_probs and train.
         data_iterator, num_microbatches = get_data_iterator(self.args, self.model, rollout_data)
+        if self.args.enable_pp_free_warmup:
+            from .pp_free_warmup import run_pp_free_warmup
+
+            run_pp_free_warmup(self.args, rollout_id, self.model, self.optimizer, data_iterator)
 
         for m in all_replay_managers:
             if self._use_rollout_replay(m):

--- a/miles/backends/megatron_utils/pp_free_warmup.py
+++ b/miles/backends/megatron_utils/pp_free_warmup.py
@@ -1,0 +1,240 @@
+"""One-time, pipeline-free Megatron forward/backward warmup."""
+
+import logging
+from contextlib import nullcontext
+
+import torch
+import torch.distributed as dist
+from megatron.core import mpu
+from megatron.core.distributed.finalize_model_grads import reset_model_temporary_tensors
+from megatron.core.fp8_utils import get_fp8_recipe
+from megatron.core.pipeline_parallel.p2p_communication import P2PCommunicator
+from megatron.core.tensor_parallel.random import _fork_rng
+from megatron.core.transformer.moe.moe_utils import clear_aux_losses_tracker
+from megatron.core.utils import get_attr_wrapped_model, get_model_config
+from transformer_engine.pytorch.graph import restore_fp8_tensors, save_fp8_tensors
+
+from miles.backends.megatron_utils.parallel import get_packed_seq_params
+from miles.backends.training_utils.data import get_batch
+
+logger = logging.getLogger(__name__)
+
+_WARMED_ATTR = "_miles_pp_free_warmed"
+_BATCH_KEYS = [
+    "tokens",
+    "multimodal_train_inputs",
+    "total_lengths",
+    "response_lengths",
+    "loss_masks",
+    "max_seq_lens",
+    "witness_ids",
+]
+
+
+def _zero_grad(model, optimizer):
+    for model_chunk in model:
+        model_chunk.zero_grad_buffer()
+    if optimizer is not None:
+        optimizer.zero_grad()
+
+
+def _clear_deferred_embedding_buffers(config, model_chunk):
+    if not getattr(config, "defer_embedding_wgrad_compute", False):
+        return
+
+    output_model = get_attr_wrapped_model(model_chunk, "post_process", return_model_obj=True)
+    if output_model.post_process:
+        output_model.embedding_activation_buffer.clear()
+        output_model.grad_output_buffer.clear()
+
+
+def _clear_loss_trackers(args):
+    clear_aux_losses_tracker()
+    if args.enable_mtp_training:
+        from megatron.core.transformer.multi_token_prediction import MTPLossLoggingHelper
+
+        if "values" in MTPLossLoggingHelper.tracker:
+            MTPLossLoggingHelper.clean_loss_in_tracker()
+
+    try:
+        from megatron.core.transformer.experimental_attention_variant.dsa import DSAIndexerLossLoggingHelper
+    except ImportError:
+        pass
+    else:
+        DSAIndexerLossLoggingHelper.clean_loss_in_tracker()
+
+
+def _tensor_leaves(value):
+    if torch.is_tensor(value):
+        yield value
+    elif isinstance(value, dict):
+        for item in value.values():
+            yield from _tensor_leaves(item)
+    elif isinstance(value, (list, tuple)):
+        for item in value:
+            yield from _tensor_leaves(item)
+
+
+def _zero_backward_seed(value):
+    tensors = [tensor for tensor in _tensor_leaves(value) if tensor.requires_grad]
+    if not tensors:
+        raise RuntimeError("The PP-free warmup model output has no differentiable tensors")
+    loss = tensors[0].float().sum() * 0.0
+    for tensor in tensors[1:]:
+        loss = loss + tensor.float().sum() * 0.0
+    return loss
+
+
+def _get_local_input_shape(tokens, config):
+    # Miles uses variable sequence lengths, so MCore's pipeline shape helper returns ().
+    # The batch tokens are already CP-local; only sequence parallelism further shards them.
+    seq_length = tokens.shape[-1]
+    if config.sequence_parallel:
+        tp_size = mpu.get_tensor_model_parallel_world_size()
+        if seq_length % tp_size != 0:
+            raise RuntimeError(f"Local sequence length {seq_length} is not divisible by TP size {tp_size}")
+        seq_length //= tp_size
+    if getattr(config, "dsv4_mode", False):
+        return (seq_length, tokens.shape[0], config.dsv4_hc_mult, config.hidden_size)
+    return (seq_length, tokens.shape[0], config.hidden_size)
+
+
+def run_pp_free_warmup(args, rollout_id, model, optimizer, data_iterator):
+    """Run one PP-free forward/backward on every pipeline stage."""
+    if len(model) != len(data_iterator):
+        raise RuntimeError(
+            f"The PP-free warmup needs one data iterator per model chunk; got {len(data_iterator)} "
+            f"iterators for {len(model)} chunks"
+        )
+
+    if all(getattr(model_chunk, _WARMED_ATTR, False) for model_chunk in model):
+        return
+
+    pp_group = mpu.get_pipeline_model_parallel_group()
+    if pp_group.size() == 1:
+        if dist.get_rank() == 0:
+            logger.info("Skipping PP-free warmup because pipeline parallelism is disabled (PP size is 1)")
+        for model_chunk in model:
+            setattr(model_chunk, _WARMED_ATTR, True)
+        return
+
+    config = get_model_config(model[0])
+    vpp_enabled = len(model) > 1
+    if dist.get_rank() == 0:
+        logger.info("Starting PP-free warmup before rollout %s", rollout_id)
+
+    training = [model_chunk.training for model_chunk in model]
+    local_inputs = [None] * len(model)
+    buffer_state = [
+        (buffer, buffer.detach().clone())
+        for model_chunk in model
+        for _, buffer in model_chunk.named_buffers()
+    ]
+    fp8_state = (
+        save_fp8_tensors(model, get_fp8_recipe(config))
+        if getattr(config, "fp8", None) is not None
+        else None
+    )
+    virtual_rank = mpu.get_virtual_pipeline_model_parallel_rank() if vpp_enabled else None
+
+    try:
+        if args.use_distributed_optimizer and args.overlap_param_gather:
+            for model_chunk in model:
+                model_chunk.disable_forward_pre_hook(param_sync=False)
+
+        for vp_stage, (model_chunk, iterator) in enumerate(zip(model, data_iterator, strict=True)):
+            if vpp_enabled:
+                mpu.set_virtual_pipeline_model_parallel_rank(vp_stage)
+
+            chunk_config = get_model_config(model_chunk)
+            batch = get_batch(
+                iterator,
+                _BATCH_KEYS,
+                args.data_pad_size_multiplier,
+                args.qkv_format,
+                allgather_cp=args.allgather_cp,
+            )
+            tokens = batch["tokens"]
+
+            if not get_attr_wrapped_model(model_chunk, "pre_process"):
+                local_inputs[vp_stage] = torch.zeros(
+                    _get_local_input_shape(tokens, chunk_config),
+                    dtype=chunk_config.pipeline_dtype or chunk_config.params_dtype,
+                    device=torch.cuda.current_device(),
+                    requires_grad=True,
+                )
+
+            forward_kwargs = {
+                "input_ids": tokens,
+                "position_ids": None,
+                "attention_mask": None,
+                "labels": None,
+                "packed_seq_params": get_packed_seq_params(batch, args),
+                "loss_mask": batch["full_loss_masks"],
+            }
+            if args.enable_witness:
+                forward_kwargs["witness_ids"] = batch["witness_ids"]
+            if args.enable_mtp_training:
+                forward_kwargs["mtp_kwargs"] = {"mtp_labels": tokens}
+            if batch["multimodal_train_inputs"] is not None:
+                forward_kwargs.update(batch["multimodal_train_inputs"])
+
+            model_chunk.train()
+            if hasattr(model_chunk, "set_is_first_microbatch"):
+                model_chunk.set_is_first_microbatch()
+            if local_inputs[vp_stage] is not None:
+                get_attr_wrapped_model(model_chunk, "set_input_tensor")([local_inputs[vp_stage]])
+
+            autocast = (
+                torch.autocast("cuda", dtype=chunk_config.autocast_dtype)
+                if chunk_config.enable_autocast
+                else nullcontext()
+            )
+            with _fork_rng(), torch.enable_grad(), model_chunk.no_sync(), autocast:
+                # Warmup JIT kernels concurrently without PP serialization.
+                output = model_chunk(**forward_kwargs)
+                _zero_backward_seed(output).backward()
+
+        p2p = P2PCommunicator(pp_group=pp_group, config=config)
+        is_pp_first_stage = mpu.is_pipeline_first_stage() and not vpp_enabled
+        is_pp_last_stage = mpu.is_pipeline_last_stage() and not vpp_enabled
+        p2p_buffer_shape = _get_local_input_shape(tokens, config)
+        p2p_buffer = torch.empty(
+            p2p_buffer_shape, dtype=config.pipeline_dtype, device=torch.cuda.current_device()
+        )
+
+        # Setup transport channels (NCCL lazily creates them)
+        # Warmup respects VPP mapping if enabled.
+        _, _ = p2p.send_forward_backward_recv_forward_backward(
+            output_tensor=None if is_pp_last_stage else p2p_buffer,
+            input_tensor_grad=None if is_pp_first_stage else p2p_buffer,
+            recv_prev=not is_pp_first_stage,
+            recv_next=not is_pp_last_stage,
+            tensor_shape=p2p_buffer_shape,
+        )
+        torch.cuda.synchronize()
+    finally:
+        if vpp_enabled:
+            mpu.set_virtual_pipeline_model_parallel_rank(virtual_rank)
+        if fp8_state is not None:
+            restore_fp8_tensors(model, fp8_state)
+        for iterator in data_iterator:
+            iterator.reset()
+        for vp_stage, model_chunk in enumerate(model):
+            model_chunk.train(training[vp_stage])
+            if local_inputs[vp_stage] is not None:
+                get_attr_wrapped_model(model_chunk, "set_input_tensor")([None])
+            _clear_deferred_embedding_buffers(get_model_config(model_chunk), model_chunk)
+            if args.use_distributed_optimizer and args.overlap_param_gather:
+                model_chunk.enable_forward_pre_hook()
+        _clear_loss_trackers(args)
+        reset_model_temporary_tensors(config, model)
+        _zero_grad(model, optimizer)
+        for buffer, saved_buffer in buffer_state:
+            buffer.detach().copy_(saved_buffer)
+
+    torch.cuda.synchronize()
+    for model_chunk in model:
+        setattr(model_chunk, _WARMED_ATTR, True)
+    if dist.get_rank() == 0:
+        logger.info("PP-free warmup complete on every stage")

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -179,6 +179,16 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 ),
             )
             parser.add_argument(
+                "--enable-pp-free-warmup",
+                action="store_true",
+                default=False,
+                help=(
+                    "Megatron only: run one PP-free forward/backward on every pipeline stage before the "
+                    "first actor step, without an optimizer step or gradient synchronization. "
+                    "Virtual pipeline stages are warmed one chunk at a time; skipped when PP size is 1."
+                ),
+            )
+            parser.add_argument(
                 "--train-env-vars",
                 type=json.loads,
                 default="{}",

--- a/tests/fast/utils/test_arguments.py
+++ b/tests/fast/utils/test_arguments.py
@@ -149,6 +149,16 @@ def test_recompute_logprobs_via_prefill_flag_is_parsed():
     assert args.recompute_logprobs_via_prefill is True
 
 
+@pytest.mark.parametrize(("extra_args", "expected"), [([], False), (["--enable-pp-free-warmup"], True)])
+def test_enable_pp_free_warmup_flag_is_parsed(extra_args, expected):
+    parser = argparse.ArgumentParser()
+    get_miles_extra_args_provider()(parser)
+
+    args = parser.parse_args(extra_args + REQUIRED_ARGS)
+
+    assert args.enable_pp_free_warmup is expected
+
+
 def test_custom_megatron_post_save_hook_path_is_parsed():
     parser = argparse.ArgumentParser()
     get_miles_extra_args_provider()(parser)


### PR DESCRIPTION
# Add PP-free Megatron forward/backward warmup

## Summary

Add an opt-in `--enable-pp-free-warmup` option for Megatron actors.

Before the first actor step, every pipeline stage performs one local forward and backward pass concurrently. This initializes JIT kernels without pipeline dependencies, then initializes the bidirectional NCCL pipeline channels before the first real pipeline execution.

**The warmup pass shaves ~20min on 1st step of DSV4+GB300 RL training (~4x speedup).**

The warmup:

- Performs no optimizer step.
- Disables gradient synchronization.
- Supports virtual pipeline chunks.
- Restores RNG, FP8, registered buffers, gradients, iterator position, model state, and temporary trackers.
- Runs once and is skipped when pipeline parallelism is disabled.

## Motivation

During the first normal pipeline execution, a stage cannot compile its kernels until it receives activations from the preceding stage. Forward compilation therefore propagates from the first stage to the last. Backward compilation then propagates in reverse.

The first use of each pipeline communication path also triggers lazy NCCL setup.

### Before: serialized pipeline warmup

```mermaid
flowchart LR
    R0F["Rank 0<br/>JIT compile FWD kernels"]
    C0F["NCCL PP<br/>comm setup"]
    MF["..."]
    RNF["Rank N<br/>JIT compile FWD kernels"]
    RNB["Rank N<br/>JIT compile BWD kernels"]
    CNB["NCCL PP<br/>comm setup"]
    MB["..."]
    R0B["Rank 0<br/>JIT compile BWD kernels"]

    R0F --> C0F --> MF --> RNF --> RNB
    RNB --> CNB --> MB --> R0B
```

### After: PP-free warmup on all ranks concurrently

```mermaid
flowchart TB
    subgraph S0["Rank 0"]
        direction LR
        R0F["JIT compile<br/>FWD kernels"] --> R0B["JIT compile<br/>BWD kernels"] --> R0C["PP comm setup"]
    end

    DOTS["..."]

    subgraph SN["Rank N"]
        direction LR
        RNF["JIT compile<br/>FWD kernels"] --> RNB["JIT compile<br/>BWD kernels"] --> RNC["PP comm setup"]
    end

    S0 ~~~ DOTS
    DOTS ~~~ SN
```

## Performance

Measured on 16 GB300 nodes:

- 8 actor nodes and 8 rollout nodes, 4 GPUs per node
- TP=2, PP=8, CP=2, EP=4
- The no-warmup control used `--distributed-timeout-minutes 60` so the serialized first pass could complete

First-step phase | Without warmup | With warmup | Time saved
-- | -- | -- | --
Local F/B warmup | — | 3m 14.6s | −3m 14.6s
Log-probs | 13m 28.9s | 48.0s | 12m 40.9s
Actor train | 14m 06.9s | 2m 55.5s | 11m 11.4s
Warmup + first training | 27m 35.9s | 6m 58.2s | 20m 37.6s

## Validation

Activations and gradients were dumped with and without warmup flag to validate that warmup did not impact training. The raw reward and KL were also compared.