### PR TITLE
[Bug Fix][OPD] Stop gradients through old-policy and teacher scores

### DIFF
--- a/miles/backends/training_utils/loss.py
+++ b/miles/backends/training_utils/loss.py
@@ -16,6 +16,16 @@ from miles.utils.multi_lora import is_multi_lora_enabled
 from miles.utils.types import RolloutBatch
 
 
+def _detach_rollout_tensor_list(rollout_data: RolloutBatch, key: str) -> list[torch.Tensor] | None:
+    tensors = rollout_data.get(key)
+    if tensors is None:
+        return None
+
+    detached_tensors = [tensor.detach() for tensor in tensors]
+    rollout_data[key] = detached_tensors
+    return detached_tensors
+
+
 def compute_advantages_and_returns(args: Namespace, rollout_data: RolloutBatch) -> None:
     """Compute advantages and returns in-place based on `args.advantage_estimator`.
 
@@ -38,7 +48,8 @@ def compute_advantages_and_returns(args: Namespace, rollout_data: RolloutBatch) 
             "total_lengths"). Modified in-place to add "advantages" and
             "returns" keys, each mapping to lists of tensors per sample.
     """
-    log_probs: list[torch.Tensor] = rollout_data.get("rollout_log_probs" if args.use_rollout_logprobs else "log_probs")
+    log_probs_key = "rollout_log_probs" if args.use_rollout_logprobs else "log_probs"
+    log_probs: list[torch.Tensor] = rollout_data.get(log_probs_key)
     ref_log_probs: list[torch.Tensor] = rollout_data.get("ref_log_probs")
     rewards: list[float] = rollout_data.get("rewards")
     values: None | list[torch.Tensor] = rollout_data.get("values")
@@ -50,6 +61,14 @@ def compute_advantages_and_returns(args: Namespace, rollout_data: RolloutBatch) 
     # return when not the last pp stage.
     if log_probs is None and values is None:
         return
+
+    # Scores produced before the policy update are fixed training data. Replace
+    # any live tensors in the persistent rollout container so neither advantage
+    # construction nor the later policy loss can retain or traverse their graph.
+    _detach_rollout_tensor_list(rollout_data, "log_probs")
+    _detach_rollout_tensor_list(rollout_data, "rollout_log_probs")
+    _detach_rollout_tensor_list(rollout_data, "teacher_log_probs")
+    log_probs = rollout_data.get(log_probs_key)
 
     if args.kl_coef == 0 or not log_probs:
         # when kl_coef is 0, we won't compute ref_log_prob

--- a/miles/backends/training_utils/loss_hub/losses.py
+++ b/miles/backends/training_utils/loss_hub/losses.py
@@ -90,8 +90,24 @@ def policy_loss_function(
         are enabled.
     """
     parallel_state = get_parallel_state()
-    advantages = torch.cat(batch["advantages"], dim=0)
-    old_log_probs = batch["rollout_log_probs"] if args.use_rollout_logprobs else batch["log_probs"]
+    advantages_list = [advantage.detach() for advantage in batch["advantages"]]
+    advantages = torch.cat(advantages_list, dim=0)
+    scored_old_log_probs = (
+        [log_prob.detach() for log_prob in batch["log_probs"]] if batch.get("log_probs") is not None else None
+    )
+    rollout_old_log_probs = (
+        [log_prob.detach() for log_prob in batch["rollout_log_probs"]]
+        if batch.get("rollout_log_probs") is not None
+        else None
+    )
+    if args.use_rollout_logprobs:
+        assert (
+            rollout_old_log_probs is not None
+        ), "rollout_log_probs must be provided when --use-rollout-logprobs is set"
+        old_log_probs = rollout_old_log_probs
+    else:
+        assert scored_old_log_probs is not None, "log_probs must be provided for policy loss"
+        old_log_probs = scored_old_log_probs
 
     response_lengths = batch["response_lengths"]
     total_lengths = batch["total_lengths"]
@@ -138,7 +154,7 @@ def policy_loss_function(
             args=args,
             full_log_probs=full_log_probs,
             full_old_log_probs=full_old_log_probs,
-            advantages=batch["advantages"],
+            advantages=advantages_list,
             loss_masks=batch["loss_masks"],
         )
 
@@ -189,8 +205,8 @@ def policy_loss_function(
             batch=batch,
             train_log_probs=train_log_probs_list,
             old_log_probs=old_log_probs_list,
-            rollout_log_probs=batch.get("rollout_log_probs"),
-            advantages=batch["advantages"],
+            rollout_log_probs=rollout_old_log_probs,
+            advantages=advantages_list,
             local_loss_masks=local_loss_mask_list,
             ppo_kl=ppo_kl,
             pg_loss=pg_loss,
@@ -212,13 +228,15 @@ def policy_loss_function(
         sum_of_sample_mean_for_mismatch_metrics = sum_of_sample_mean
 
         assert "rollout_log_probs" in batch, "rollout_log_probs must be provided for TIS"
+        assert scored_old_log_probs is not None, "log_probs must be provided for TIS"
+        assert rollout_old_log_probs is not None, "rollout_log_probs must be provided for TIS"
 
         ois = (-ppo_kl).exp()
         tis_kwargs = {
             "args": args,
             "pg_loss": pg_loss,
-            "train_log_probs": batch["log_probs"],
-            "rollout_log_probs": batch["rollout_log_probs"],
+            "train_log_probs": scored_old_log_probs,
+            "rollout_log_probs": rollout_old_log_probs,
             "loss_masks": batch["loss_masks"],
             "total_lengths": total_lengths,
             "response_lengths": response_lengths,
@@ -311,8 +329,8 @@ def policy_loss_function(
     train_scored_log_probs = old_log_probs
     train_rollout_logprob_abs_diff = None
     train_rollout_kl = None
-    if "rollout_log_probs" in batch and batch["rollout_log_probs"]:
-        rollout_log_probs = torch.cat(batch["rollout_log_probs"], dim=0)
+    if rollout_old_log_probs:
+        rollout_log_probs = torch.cat(rollout_old_log_probs, dim=0)
         abs_diff = (train_scored_log_probs - rollout_log_probs).abs()
         abs_diff = torch.where(
             active_tokens,

--- a/miles/backends/training_utils/loss_hub/opd.py
+++ b/miles/backends/training_utils/loss_hub/opd.py
@@ -20,7 +20,8 @@ def apply_opd_kl_to_advantages(
         args: Configuration containing `use_opd` and `opd_kl_coef`.
         rollout_data: Dict containing "teacher_log_probs".
         advantages: List of advantage tensors to modify in-place.
-        student_log_probs: List of student log-probability tensors.
+        student_log_probs: List of old-student log-probability tensors. OPD
+            treats these as fixed scoring inputs.
 
     References:
         https://github.com/thinking-machines-lab/tinker-cookbook/blob/main/tinker_cookbook/distillation/train_on_policy.py
@@ -42,7 +43,9 @@ def apply_opd_kl_to_advantages(
             reverse_kl = precomputed_reverse_kls[i]
             if not torch.is_tensor(reverse_kl):
                 reverse_kl = torch.tensor(reverse_kl, dtype=torch.float32)
-            reverse_kl = reverse_kl.to(device=adv.device)
+            # OPD treats rollout-side scores as fixed inputs. Keep that boundary
+            # explicit even if a custom data path supplies autograd history.
+            reverse_kl = reverse_kl.detach().to(device=adv.device)
             if adv.shape != reverse_kl.shape:
                 raise ValueError(
                     f"OPD shape mismatch at sample {i}: advantages={tuple(adv.shape)}, "
@@ -65,7 +68,8 @@ def apply_opd_kl_to_advantages(
         )
 
     device = student_log_probs[0].device
-    teacher_log_probs = [t.to(device=device) for t in teacher_log_probs]
+    teacher_log_probs = [t.detach().to(device=device) for t in teacher_log_probs]
+    rollout_data["teacher_log_probs"] = teacher_log_probs
 
     reverse_kls = []
     for i, adv in enumerate(advantages):
@@ -80,9 +84,10 @@ def apply_opd_kl_to_advantages(
                 f"student_log_probs={tuple(student_log_probs[i].shape)}. "
                 "OPD expects per-token advantages; broadcast scalar advantages must be expanded before this call."
             )
-        reverse_kl = student_log_probs[i] - teacher_log_probs[i]
+        old_student_log_prob = student_log_probs[i].detach()
+        reverse_kl = old_student_log_prob - teacher_log_probs[i]
         advantages[i] = adv - args.opd_kl_coef * reverse_kl
         reverse_kls.append(reverse_kl)
 
-    # Store reverse KL for logging
+    # Store reverse KL for logging.
     rollout_data["opd_reverse_kl"] = reverse_kls

--- a/tests/fast/backends/training_utils/loss/test_opd.py
+++ b/tests/fast/backends/training_utils/loss/test_opd.py
@@ -11,6 +11,7 @@ from argparse import Namespace
 import pytest
 import torch
 
+from miles.backends.training_utils import loss as loss_utils
 from miles.backends.training_utils.loss_hub.opd import apply_opd_kl_to_advantages
 
 # This module intentionally has no explicit CI registration call: modules under
@@ -24,8 +25,8 @@ def _args(opd_kl_coef: float = 1.0) -> Namespace:
 
 def test_subtracts_weighted_reverse_kl_and_stores_metric():
     args = _args(opd_kl_coef=0.5)
-    student = [torch.tensor([0.0, 1.0])]
-    teacher = [torch.tensor([0.0, 0.0])]
+    student = [torch.tensor([0.0, 1.0], requires_grad=True)]
+    teacher = [torch.tensor([0.0, 0.0], requires_grad=True)]
     advantages = [torch.tensor([2.0, 2.0])]
     rollout_data = {"teacher_log_probs": teacher}
 
@@ -34,6 +35,73 @@ def test_subtracts_weighted_reverse_kl_and_stores_metric():
     # reverse_kl = student - teacher = [0, 1]; adv - 0.5 * reverse_kl = [2.0, 1.5]
     assert torch.allclose(advantages[0], torch.tensor([2.0, 1.5]))
     assert torch.allclose(rollout_data["opd_reverse_kl"][0], torch.tensor([0.0, 1.0]))
+    assert advantages[0].requires_grad is False
+    assert rollout_data["opd_reverse_kl"][0].requires_grad is False
+
+    current_student_log_probs = torch.tensor([0.2, -0.3], requires_grad=True)
+    (advantages[0] * current_student_log_probs).sum().backward()
+    torch.testing.assert_close(current_student_log_probs.grad, advantages[0])
+    assert student[0].grad is None
+    assert teacher[0].grad is None
+
+
+def test_precomputed_reverse_kl_is_detached_before_weighting_advantages():
+    args = _args(opd_kl_coef=0.25)
+    precomputed = torch.tensor([0.4, -0.2], requires_grad=True)
+    advantages = [torch.tensor([0.0, 0.0])]
+    rollout_data = {"opd_reverse_kl": [precomputed]}
+
+    apply_opd_kl_to_advantages(args, rollout_data, advantages, student_log_probs=[torch.zeros(2)])
+
+    torch.testing.assert_close(advantages[0], torch.tensor([-0.1, 0.05]))
+    assert advantages[0].requires_grad is False
+    assert rollout_data["opd_reverse_kl"][0].requires_grad is False
+
+    current_student_log_probs = torch.tensor([0.3, -0.1], requires_grad=True)
+    (advantages[0] * current_student_log_probs).sum().backward()
+    torch.testing.assert_close(current_student_log_probs.grad, advantages[0])
+    assert precomputed.grad is None
+
+
+def test_fixed_opd_inputs_are_detached_in_persistent_rollout_data(monkeypatch):
+    old_source = torch.tensor([0.2, 0.4], requires_grad=True)
+    rollout_source = torch.tensor([0.3, 0.5], requires_grad=True)
+    teacher_source = torch.tensor([0.1, 0.2], requires_grad=True)
+    rollout_data = {
+        "log_probs": [old_source.sin()],
+        "rollout_log_probs": [rollout_source.cos()],
+        "teacher_log_probs": [teacher_source.square()],
+        "rewards": [0.0],
+        "values": None,
+        "response_lengths": [2],
+        "loss_masks": [torch.ones(2)],
+        "total_lengths": [2],
+    }
+    args = Namespace(
+        use_rollout_logprobs=False,
+        kl_coef=0.0,
+        use_opd=True,
+        opd_type="sglang",
+        opd_kl_coef=0.5,
+        normalize_advantages=False,
+    )
+
+    def fake_compute_advantages(**kwargs):
+        assert kwargs["log_probs"][0].grad_fn is None
+        zeros = torch.zeros_like(kwargs["log_probs"][0])
+        return [zeros], [zeros.clone()]
+
+    monkeypatch.setattr(loss_utils, "compute_advantages", fake_compute_advantages)
+
+    loss_utils.compute_advantages_and_returns(args, rollout_data)
+
+    for key in ("log_probs", "rollout_log_probs", "teacher_log_probs", "opd_reverse_kl", "advantages"):
+        assert rollout_data[key][0].grad_fn is None
+        assert rollout_data[key][0].requires_grad is False
+
+    assert old_source.grad is None
+    assert rollout_source.grad is None
+    assert teacher_source.grad is None
 
 
 def test_noop_when_student_log_probs_none():

--- a/tests/fast/backends/training_utils/test_true_on_policy_loss_metrics.py
+++ b/tests/fast/backends/training_utils/test_true_on_policy_loss_metrics.py
@@ -122,6 +122,52 @@ def test_train_rollout_logprob_abs_diff_uses_policy_loss_reference_logprobs(
     torch.testing.assert_close(metrics["train_rollout_logprob_abs_diff"], torch.tensor(expected_abs_diff))
 
 
+@pytest.mark.parametrize("use_rollout_logprobs", [False, True])
+def test_policy_loss_only_backpropagates_through_current_policy(monkeypatch, use_rollout_logprobs: bool):
+    args = _make_args(use_rollout_logprobs=use_rollout_logprobs)
+    old_source = torch.tensor([0.10, 0.20], requires_grad=True)
+    rollout_source = torch.tensor([0.12, 0.22], requires_grad=True)
+    advantage_source = torch.tensor([1.0, 2.0], requires_grad=True)
+    current_logits = torch.tensor([[[0.15], [0.25], [0.0]]], requires_grad=True)
+    batch = _make_batch(
+        old_log_probs=old_source.sin(),
+        rollout_log_probs=rollout_source.sin(),
+    )
+    if use_rollout_logprobs:
+        batch.pop("log_probs")
+    batch["advantages"] = [advantage_source.square()]
+
+    monkeypatch.setattr(
+        loss_utils,
+        "get_parallel_state",
+        lambda: SimpleNamespace(tp=SimpleNamespace(group=None)),
+    )
+    _patch_single_rank_loss_helpers(monkeypatch)
+
+    def fake_get_log_probs_and_entropy(logits, *args, **kwargs):
+        return {"log_probs": [logits.flatten()[:2].sin()]}
+
+    monkeypatch.setattr(
+        loss_utils,
+        "get_log_probs_and_entropy",
+        fake_get_log_probs_and_entropy,
+    )
+
+    loss, _ = loss_utils.policy_loss_function(
+        args,
+        batch,
+        logits=current_logits,
+        sum_of_sample_mean=lambda tensor: tensor.float().mean(),
+    )
+    loss.backward()
+
+    assert current_logits.grad is not None
+    assert torch.count_nonzero(current_logits.grad) > 0
+    assert old_source.grad is None
+    assert rollout_source.grad is None
+    assert advantage_source.grad is None
+
+
 def test_zero_weighted_entropy_nan_does_not_poison_policy_loss(monkeypatch):
     args = _make_args(use_rollout_logprobs=False)
     batch = _make_batch(


### PR DESCRIPTION
## Motivation

OPD and PPO-style policy-gradient training treat teacher scores, pre-update
policy scores, rollout-policy scores, and advantages as fixed inputs. The
standard Megatron and FSDP scoring paths already produce these tensors under
`torch.no_grad()`, but the training boundaries did not enforce that invariant.

A custom or fused path could therefore retain an autograd graph in persistent
rollout data. The same live old-policy tensor could later enter the PPO/GSPO
importance ratio, sending gradients through both the current- and old-policy
branches.

## What's in this PR

- Replace live `log_probs`, `rollout_log_probs`, and `teacher_log_probs` tensors
  with detached tensors in persistent rollout data before advantage
  construction.
- Write the device-aligned detached teacher tensors back to the rollout
  container.
- Defensively detach advantages and all fixed old-policy score inputs at the
  policy-loss boundary.
- Reuse the detached score lists in OPSM, GSPO, TIS, debug dumps, and mismatch
  metrics.
- Preserve the rollout-only policy-loss path, where `log_probs` is legitimately
  absent when `--use-rollout-logprobs` is enabled.
- Add non-leaf graph-retention coverage and real `policy_loss_function`
  backward tests for trainer-scored and rollout-scored old policies.

Current-policy logits remain differentiable. Forward values, the existing OPD
reverse-KL calculation, clipping, and coefficients are unchanged.

## Validation

- Focused OPD and policy-loss tests: `14 passed`
- Pre-commit on all five changed files: all applicable hooks passed
- `git diff --check upstream/main...HEAD`: clean

## Notes for reviewers

- This is a gradient-ownership fix, not a new OPD objective.
- Default Megatron/FSDP behavior is numerically unchanged because their
  pre-update scoring forwards already run under `torch.no_grad()`.
- The added policy-loss test executes the real PPO ratio and verifies that only
  current-policy logits receive gradients.
- The branch contains one topic commit on top of `main` (`5b809d9d`).
