### PR TITLE
test: add offload_train_target to the actor-factory args stub

### DIFF
--- a/tests/fast/ray/test_actor_factory.py
+++ b/tests/fast/ray/test_actor_factory.py
@@ -38,6 +38,7 @@ def test_megatron_offload_uses_torch_memory_saver_preload_resolver(monkeypatch):
     args = SimpleNamespace(
         dumper_source_patcher_config_train=None,
         offload_train=True,
+        offload_train_target="cpu",
         train_backend="megatron",
         train_env_vars={},
         use_fault_tolerance=False,


### PR DESCRIPTION
## Summary

`test_megatron_offload_uses_torch_memory_saver_preload_resolver` fails on any branch cut from current main:

```
AttributeError: 'types.SimpleNamespace' object has no attribute 'offload_train_target'
```

The test arrived in #1469 with a `SimpleNamespace` args stub that lacks `offload_train_target`, which the megatron offload path of `allocate_gpus_for_actor` has read since #1575. Post-merge main does not run the test matrix, so this only surfaces on new PRs (first seen on #1833, a docs-only change).

One-line fix: set `offload_train_target="cpu"` (the CLI default), which matches the `TMS_INIT_ENABLE_CPU_BACKUP == "1"` assertion the test already makes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)