### PR TITLE
ci: compare PR merge commits with their current base

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -77,6 +77,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          fetch-depth: 2
           persist-credentials: false
       - id: diff
         shell: bash
@@ -88,9 +89,10 @@ jobs:
             echo "changed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          git fetch --depth 1 origin "$BASE_SHA"
+          # Compare the PR merge commit with its current base (HEAD^1) rather than
+          # the recorded base.sha, which can lag main and pull in unrelated changes.
           # Dockerfile.rocm doesn't feed the cu13 multi-arch build this pipeline produces.
-          if git diff --name-only "$BASE_SHA" HEAD \
+          if git diff --name-only HEAD^1 HEAD \
               | grep -qE '^(docker/(Dockerfile|build\.py|verify_transformer_engine\.py)|requirements\.txt)$|^docker/patch/'; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
           else


### PR DESCRIPTION
## What

- Diff the checked-out PR **merge commit** against its first parent (`HEAD^1`) instead of the recorded `github.event.pull_request.base.sha` when the `docker-paths` job decides whether Docker inputs changed.
- Deepen the checkout to `fetch-depth: 2` so `HEAD^1` is available, and drop the now-unneeded `git fetch --depth 1 origin "$BASE_SHA"`.

## Why

On a `pull_request` event `actions/checkout` checks out the **merge commit**, which already includes current `main`. Diffing that merge commit against `base.sha` (the commit `main` was at when the PR branched) folds in **unrelated changes that landed on `main` since** — e.g. an unrelated `docker/Dockerfile` or `requirements.txt` edit — so `docker-paths` reports `changed=true` and the pipeline rebuilds the multi-arch image on the GPU fleet for a PR that never touched Docker inputs.

Comparing `HEAD^1` (the merge commit's first parent = current base) with `HEAD` yields exactly the PR's own delta against today's `main`, so the Docker-input filter only fires when this PR actually changes a Docker input.

```
  main (base branch)              PR branch
  ──────────────────              ─────────
  B  ← base.sha  ...............  P   (this PR's commit, branched at B)
  │                               │
  C  (unrelated edit on main,     │
  │   e.g. docker/Dockerfile)     │
  │                               │
  D  ← current main tip ──────────┤
  │        (= HEAD^1)             │
  └───────────►  M  ◄─────────────┘
               HEAD = PR merge commit CI checks out
               (refs/pull/N/merge)  parents: ^1 = D, ^2 = P

  git diff base.sha(B)..HEAD  =  P + C + D   ✗  C/D unrelated → needless build
  git diff HEAD^1(D)..HEAD    =  P           ✓  exactly this PR's files
```

The merge commit `M` already contains `D` (current `main`), so diffing it against the older `base.sha` (`B`) re-surfaces everything that landed on `main` in between (`C`, `D`). Diffing against `HEAD^1` (`D`) cancels that out and leaves only `P`.

This is a straight port of radixark/miles_diffusion#73; miles carries the same `docker-paths` diff logic and therefore the same false-positive build trigger. The miles-specific cron/manual guard (`if [ -z "$BASE_SHA" ]` → `changed=false`) is preserved, since non-PR runs have no merge commit to diff.

## Files

- `.github/workflows/pr-test.yml` — `docker-paths` job: add `fetch-depth: 2`, remove the shallow base fetch, switch the change-detection diff from `"$BASE_SHA" HEAD` to `HEAD^1 HEAD`.

## Checklist

- [x] `pre-commit run --files .github/workflows/pr-test.yml` passes (`check yaml` green)
- [ ] `pre-commit run --all-files` — **not run** (single-file CI change; ran the targeted hook instead)
- [ ] Added/updated tests for new behaviour — **n/a** (CI workflow logic; no unit-testable surface)
- [ ] `pytest -x` is green — **not run** (no Python changed)
- [ ] If launch flags changed, `python3 train.py --help` still parses — **n/a** (no launch flags changed)
- [ ] If a public flag was added, it appears in the CLI reference docs — **n/a**
- [ ] If an example was added, it has a real walkthrough — **n/a**

### Suggested manual verification (mirrors [#73](https://github.com/radixark/miles_diffusion/pull/73)'s test plan)

Against a PR whose branch is behind a `main` that has since changed a Docker input, confirm `git diff --name-only HEAD^1 HEAD` on the merge commit **excludes** that unrelated file, whereas the old `git diff --name-only "$BASE_SHA" HEAD` **includes** it.
