### PR TITLE
ci: restore the image's cuDNN pin after reconciling requirements

### DIFF
--- a/.github/workflows/_run-ci.yml
+++ b/.github/workflows/_run-ci.yml
@@ -143,7 +143,7 @@ jobs:
           pinned=""
           for pkg in nvidia-cudnn-cu13 nvidia-cudnn-cu12; do
             v=$(python -m pip show "$pkg" 2>/dev/null | awk '/^Version:/{print $2}')
-            [ -n "$v" ] && pinned="$pinned $pkg==$v"
+            if [ -n "$v" ]; then pinned="$pinned $pkg==$v"; fi
           done
           python -m pip install -r "$GITHUB_WORKSPACE/requirements.txt" --break-system-packages
           for spec in $pinned; do

--- a/.github/workflows/_run-ci.yml
+++ b/.github/workflows/_run-ci.yml
@@ -142,14 +142,14 @@ jobs:
           # back afterwards; --no-deps so nothing else in the resolved set moves.
           pinned=""
           for pkg in nvidia-cudnn-cu13 nvidia-cudnn-cu12; do
-            v=$(python -m pip show "$pkg" 2>/dev/null | awk '/^Version:/{print $2}')
+            v=$(python -m pip show "$pkg" 2>/dev/null | awk '/^Version:/{print $2}' || true)
             if [ -n "$v" ]; then pinned="$pinned $pkg==$v"; fi
           done
           python -m pip install -r "$GITHUB_WORKSPACE/requirements.txt" --break-system-packages
           for spec in $pinned; do
             pkg=${spec%%==*}
             want=${spec##*==}
-            got=$(python -m pip show "$pkg" 2>/dev/null | awk '/^Version:/{print $2}')
+            got=$(python -m pip show "$pkg" 2>/dev/null | awk '/^Version:/{print $2}' || true)
             if [ -n "$got" ] && [ "$got" != "$want" ]; then
               echo "Restoring image pin: $pkg $got -> $want"
               python -m pip install --no-deps --break-system-packages "$spec"

--- a/.github/workflows/_run-ci.yml
+++ b/.github/workflows/_run-ci.yml
@@ -134,7 +134,27 @@ jobs:
 
       - name: Reconcile Miles dependencies
         shell: bash
-        run: python -m pip install -r "$GITHUB_WORKSPACE/requirements.txt" --break-system-packages
+        run: |
+          # The image pins cuDNN deliberately: transformer_engine's fused attention needs a
+          # newer build than torch's own exact pin, so the Dockerfile installs it last. This
+          # resolve drags it back down to whatever torch asks for, which makes fused attention
+          # backward fail with CUDNN_STATUS_BAD_PARAM. Record what the image shipped and put it
+          # back afterwards; --no-deps so nothing else in the resolved set moves.
+          pinned=""
+          for pkg in nvidia-cudnn-cu13 nvidia-cudnn-cu12; do
+            v=$(python -m pip show "$pkg" 2>/dev/null | awk '/^Version:/{print $2}')
+            [ -n "$v" ] && pinned="$pinned $pkg==$v"
+          done
+          python -m pip install -r "$GITHUB_WORKSPACE/requirements.txt" --break-system-packages
+          for spec in $pinned; do
+            pkg=${spec%%==*}
+            want=${spec##*==}
+            got=$(python -m pip show "$pkg" 2>/dev/null | awk '/^Version:/{print $2}')
+            if [ -n "$got" ] && [ "$got" != "$want" ]; then
+              echo "Restoring image pin: $pkg $got -> $want"
+              python -m pip install --no-deps --break-system-packages "$spec"
+            fi
+          done
 
       - name: Sync dependency sources
         if: ${{ !inputs.skip_dependency_install }}


### PR DESCRIPTION
## What breaks

Every GPU job runs `pip install -r requirements.txt` inside the test container
("Reconcile Miles dependencies"). `torchft-nightly` pulls `torch`, `torch` pins
`nvidia-cudnn-cu13` **exactly**, and the resolve therefore uninstalls the cuDNN the
image deliberately installed last:

```
Collecting nvidia-cudnn-cu13==9.19.0.56 (from torch>=2.7->torchft-nightly==2026.4.3->-r requirements.txt)
Downloading nvidia_cudnn_cu13-9.19.0.56-py3-none-manylinux_2_27_x86_64.whl (366.1 MB)
Uninstalling nvidia-cudnn-cu13-9.22.0.52:
Successfully installed nvidia-cudnn-cu13-9.19.0.56
```

`transformer_engine` 2.17's fused attention backward then fails:

```
fused_attn_f16_arbitrary_seqlen.cu:934 ... cuDNN Error: detail::set_attribute(
  reshape_operation.get_raw_desc(), CUDNN_ATTR_OPERATION_RESHAPE_MODE, ...)
  failed ... CUDNN_STATUS_BAD_PARAM
```

This is what has been failing `test_lora_qwen2.5_0.5B`,
`test_gpt_oss_20b_moe_lora_ci` and `test_qwen3_5_35b_a3b_lora_ci` on
radixark/miles#1795. The Dockerfile's pin was never wrong — it was being undone at
test time, which is why moving it had no effect.

## How this fixes it

Record the cuDNN version the image shipped, run the resolve, and reinstall that
version if the resolve moved it. `--no-deps` keeps the rest of the resolved set
untouched, and reading the version from the image rather than hardcoding it keeps the
Dockerfile the single place it is chosen.

## Why not declare the pin in requirements.txt

Tried it. pip resolves the conflict against torch's exact pin by **downgrading torch
itself**:

```
Successfully installed ... nvidia-cudnn-cu12-9.10.2.21 ... torch-2.10.0
```

torch 2.11.0+cu130 → 2.10.0 with the whole CUDA stack swapped to cu12. Strictly worse
than the bug.

## Measurements

On an H200 devbox running the exact CI image digest
(`radixark/miles@sha256:4d94f611…`):

| step | nvidia-cudnn-cu13 | torch |
|---|---|---|
| image as built | 9.22.0.52 | 2.11.0+cu130 |
| after `pip install -r requirements.txt` | **9.19.0.56** | 2.11.0+cu130 |
| after the restore added here | **9.22.0.52** | 2.11.0+cu130 |

TE fused attention backward, 8 configs (d=64/128 × MHA/GQA × sbhd/bshd, bf16, causal,
`NVTE_FUSED_ATTN=1`): **8/8 fail at 9.19.0.56, 8/8 pass at 9.22.0.52.**

The same devbox runs the full `test_lora_qwen2.5_0.5B` to completion with
`Selected backend = FusedAttention (sub-backend 1)` — the exact path and sub-backend
that fails in CI — once cuDNN is 9.22.0.52.

## Related

Depends on radixark/miles#1824, which removes the base image's apt cuDNN. Both are
required: the apt copy shadowed the pip one at load time (mixed sub-libraries,
`undefined symbol _ZTVN5cudnn7backend12OperationSetE`), and this PR keeps the pip copy
at the version the image chose.