### PR TITLE
Rename RolloutExecutor.generate to get for future async and multi trainer scenarios

### DIFF
--- a/miles/dashboard/hooks.py
+++ b/miles/dashboard/hooks.py
@@ -344,7 +344,7 @@ def register_engines(servers) -> None:
 
 
 def report_data_buffer(length: int | None) -> None:
-    """Called at the top of every ``RolloutExecutor.generate()`` alongside
+    """Called at the top of every ``RolloutExecutor.get()`` alongside
     ``register_engines``, with ``getattr(data_source, "get_buffer_length",
     lambda: None)()``. A no-op for ``length is None`` — most data sources
     (plain ``RolloutDataSource``) never buffer samples across steps."""

--- a/miles/dashboard/store.py
+++ b/miles/dashboard/store.py
@@ -151,7 +151,7 @@ class TopologySnapshot(Record):
 class DataBufferSample(Record):
     """One report of ``RolloutDataSourceWithBuffer.get_buffer_length()``
     (design doc's "show the data status in databuffer" ask). Appended once
-    per ``RolloutExecutor.generate()`` call — a no-op for plain
+    per ``RolloutExecutor.get()`` call — a no-op for plain
     ``RolloutDataSource`` runs, which never buffer samples across steps.
     Low-rate and unpartitioned like ``TopologySnapshot``: only the latest
     value matters for display."""

--- a/miles/ray/rollout/rollout_executor.py
+++ b/miles/ray/rollout/rollout_executor.py
@@ -110,7 +110,7 @@ class RolloutExecutor:
 
     # -------------------------- data generation -----------------------------
 
-    async def generate(self, rollout_id):
+    async def get(self, rollout_id):
         start_time = time.time()
         self.rollout_id = rollout_id
         if (get_buffer_length := getattr(self.data_source, "get_buffer_length", None)) is not None:

--- a/miles/ray/rollout/rollout_executor.py
+++ b/miles/ray/rollout/rollout_executor.py
@@ -105,7 +105,7 @@ class RolloutExecutor:
 
     # -------------------------- data generation -----------------------------
 
-    async def generate(self, rollout_id):
+    async def get(self, rollout_id):
         start_time = time.time()
         self.rollout_id = rollout_id
         if (get_buffer_length := getattr(self.data_source, "get_buffer_length", None)) is not None:

--- a/tests/fast/ray/rollout/real_ray/test_rollout_executor.py
+++ b/tests/fast/ray/rollout/real_ray/test_rollout_executor.py
@@ -141,7 +141,7 @@ class TestGenerate:
 
         executor.generate_rollout = fake_rollout_fn
 
-        result = await executor.generate(rollout_id=42)
+        result = await executor.get(rollout_id=42)
 
         assert len(captured) == 1
         assert isinstance(captured[0], RolloutFnTrainInput)
@@ -167,7 +167,7 @@ class TestGenerate:
             samples=[make_samples_grouped(n_groups=1, group_size=4)], metrics={}
         )
 
-        await executor.generate(rollout_id=7)
+        await executor.get(rollout_id=7)
 
         assert not hasattr(executor, "servers")
         assert not hasattr(executor, "_health_monitors")

--- a/tests/fast/ray/rollout/real_ray/test_rollout_executor.py
+++ b/tests/fast/ray/rollout/real_ray/test_rollout_executor.py
@@ -85,7 +85,7 @@ class TestGenerate:
 
         executor.generate_rollout = fake_rollout_fn
 
-        result = await executor.generate(rollout_id=42)
+        result = await executor.get(rollout_id=42)
 
         assert len(captured) == 1
         assert isinstance(captured[0], RolloutFnTrainInput)
@@ -111,7 +111,7 @@ class TestGenerate:
             samples=[make_samples_grouped(n_groups=1, group_size=4)], metrics={}
         )
 
-        await executor.generate(rollout_id=7)
+        await executor.get(rollout_id=7)
 
         assert not hasattr(executor, "servers")
         assert not hasattr(executor, "_health_monitors")

--- a/train.py
+++ b/train.py
@@ -101,7 +101,7 @@ async def train(args):
             await rollout_executor.eval.remote(rollout_id)
 
         await inference_controller.prepare_rollout(rollout_id)
-        rollout_data_pack = await rollout_executor.generate.remote(rollout_id)
+        rollout_data_pack = await rollout_executor.get.remote(rollout_id)
 
         if args.offload_rollout:
             offload_tags = [GPU_MEMORY_TYPE_CUDA_GRAPH]

--- a/train.py
+++ b/train.py
@@ -110,7 +110,7 @@ async def train(args):
             await rollout_executor.eval.remote(rollout_id)
 
         await inference_controller.prepare_rollout(rollout_id)
-        rollout_data_pack = await rollout_executor.generate.remote(rollout_id)
+        rollout_data_pack = await rollout_executor.get.remote(rollout_id)
 
         if args.offload_rollout:
             if args.colocate_memory_peak_device == "gpu":

--- a/train_async.py
+++ b/train_async.py
@@ -75,7 +75,7 @@ async def train(args):
 
     async def prepare_and_generate(rollout_id):
         await inference_controller.prepare_rollout(rollout_id)
-        return await rollout_executor.generate.remote(rollout_id)
+        return await rollout_executor.get.remote(rollout_id)
 
     # async train loop.
     rollout_data_next_future = await eager_create_task(prepare_and_generate(args.start_rollout_id))

--- a/train_multi_lora_async.py
+++ b/train_multi_lora_async.py
@@ -84,7 +84,7 @@ async def main(args):
 
         try:
             await inference_controller.prepare_rollout(rollout_id)
-            rollout_data = await rollout_executor.generate.remote(rollout_id)
+            rollout_data = await rollout_executor.get.remote(rollout_id)
         except ray.exceptions.RayTaskError as e:
             if _is_empty_batch_timeout(e):
                 logger.warning(f"Generate timed out with no trainable groups; retrying reconcile/update. {e}")


### PR DESCRIPTION
Part of #1837