### PR TITLE
Make ServerGroup callers cell-aware and drop the all_engines property

### DIFF
--- a/miles/dashboard/hooks.py
+++ b/miles/dashboard/hooks.py
@@ -362,18 +362,15 @@ def report_data_buffer(length: int | None) -> None:
 
 
 def _alive_engine_chunks(servers) -> list[list]:
-    """Multi-node engines occupy ``nodes_per_engine`` consecutive entries of
-    ``group.all_engines``; only the first (master) owns the router-visible
-    URL. Chunks with any dead member are skipped until recovery completes."""
+    """A multi-node engine's cell holds ``nodes_per_engine`` entries; only the
+    first (master) owns the router-visible URL. Cells with any dead member are
+    skipped until recovery completes."""
     chunks = []
     for server in servers.values():
         for group in server.server_groups:
-            stride = group.nodes_per_engine
-            engines = group.all_engines
-            for i in range(0, len(engines), stride):
-                chunk = engines[i : i + stride]
-                if all(engine.is_allocated and engine.is_alive for engine in chunk):
-                    chunks.append(chunk)
+            for cell in group.cells:
+                if all(engine.is_allocated and engine.is_alive for engine in cell.engines):
+                    chunks.append(cell.engines)
     return chunks
 
 

--- a/miles/ray/rollout/rollout_server.py
+++ b/miles/ray/rollout/rollout_server.py
@@ -299,7 +299,7 @@ class RolloutServer:
         # picture of init/recovery upper bounds across model sizes
         sleep_time = 2
         for _ in range(int(timeout // sleep_time)):
-            if all(e.is_alive for g in self.server_groups for e in g.all_engines):
+            if all(e.is_alive for g in self.server_groups for cell in g.cells for e in cell.engines):
                 return
             await asyncio.sleep(sleep_time)
             logger.info("wait_all_engines_alive looping...")

--- a/miles/ray/rollout/server_cell.py
+++ b/miles/ray/rollout/server_cell.py
@@ -12,6 +12,10 @@ class ServerCell:
     engines: list[ServerEngine]
 
 
+def flatten_cells(cells: list[ServerCell]) -> list[ServerEngine]:
+    return [engine for cell in cells for engine in cell.engines]
+
+
 class CellIndexer(NamedTuple):
     srv_key: str
     group_index: int
@@ -21,23 +25,22 @@ class CellIndexer(NamedTuple):
 def get_cell_indexer_of_id_map(servers: dict[str, "RolloutServer"]) -> list[CellIndexer]:
     """Flatten ``servers`` into a list whose position is the cell id.
 
-    A cell is one node-0 engine; ``engine_indices`` covers its ``nodes_per_engine``
-    underlying entries in ``group.all_engines``. Order is sorted by ``srv_key``, so
-    cell ids are stable across calls when the topology is unchanged.
+    ``engine_indices`` covers the cell's entries in the group's flat engine
+    list. Order is sorted by ``srv_key``, so cell ids are stable across calls
+    when the topology is unchanged.
     """
     result: list[CellIndexer] = []
     for srv_key in sorted(servers):
         srv = servers[srv_key]
         for group_index, group in enumerate(srv.server_groups):
-            assert len(group.all_engines) == len(group.engines) * group.nodes_per_engine
-            for local_index in range(len(group.engines)):
+            engine_offset = 0
+            for cell in group.cells:
                 result.append(
                     CellIndexer(
                         srv_key=srv_key,
                         group_index=group_index,
-                        engine_indices=list(
-                            range(local_index * group.nodes_per_engine, (local_index + 1) * group.nodes_per_engine)
-                        ),
+                        engine_indices=list(range(engine_offset, engine_offset + len(cell.engines))),
                     )
                 )
+                engine_offset += len(cell.engines)
     return result

--- a/miles/ray/rollout/server_group.py
+++ b/miles/ray/rollout/server_group.py
@@ -15,7 +15,7 @@ from miles.ray.rollout.addr_allocator import (
     allocate_rollout_engine_addr_and_ports_external,
     allocate_rollout_engine_addr_and_ports_normal,
 )
-from miles.ray.rollout.server_cell import ServerCell
+from miles.ray.rollout.server_cell import ServerCell, flatten_cells
 from miles.ray.rollout.server_engine import AddrInfo, ServerEngine
 from miles.ray.utils import NOSET_VISIBLE_DEVICES_ENV_VARS_LIST
 from miles.utils import async_utils, dumper_utils
@@ -38,7 +38,7 @@ class ServerGroup:
     pg: Any  # (placement_group, reordered_bundle_indices, reordered_gpu_ids)
     cells: list[ServerCell]
     num_gpus_per_engine: int
-    # NOTE: this may have risk when recovering engines parallelly; may use source of truth (all_engines) later
+    # NOTE: this may have risk when recovering engines parallelly; may use source of truth (cells) later
     has_new_engines: bool
     worker_type: str = "regular"  # "regular", "prefill", or "decode"
     rank_offset: int = 0
@@ -52,12 +52,8 @@ class ServerGroup:
 
     def __post_init__(self):
         assert (
-            not self.all_engines or self.rank_offset % self.nodes_per_engine == 0
+            not self.cells or self.rank_offset % self.nodes_per_engine == 0
         ), f"{self.rank_offset=} must be a multiple of {self.nodes_per_engine=}"
-
-    @property
-    def all_engines(self) -> list[ServerEngine]:
-        return [engine for cell in self.cells for engine in cell.engines]
 
     @property
     def nodes_per_engine(self):
@@ -66,7 +62,7 @@ class ServerGroup:
     @property
     def engines(self) -> list[ServerEngine]:
         """Node-0 engines only (for multi-node serving)."""
-        return self.all_engines[:: self.nodes_per_engine]
+        return [cell.engines[0] for cell in self.cells]
 
     def start_engines(
         self, port_cursors: PortCursors, start_indices: list[int] | None = None
@@ -76,7 +72,7 @@ class ServerGroup:
         Mutates ``port_cursors`` in place to advance past any newly assigned ports.
         Returns ``(init_handles, new_engine_indices)`` where *init_handles* is a list
         of Ray ObjectRefs (one per newly created engine) and *new_engine_indices* is
-        the list of indices into ``self.all_engines`` that were just allocated.
+        the list of indices into the group's flat engine list that were just allocated.
         """
         assert not ({"host", "port"} & set(self.sglang_overrides)), (
             f"sglang_overrides must not override host/port ({self.sglang_overrides=}): the rollout process derives "
@@ -93,12 +89,14 @@ class ServerGroup:
 
         RolloutRayActor = ray.remote(SGLangEngine)
 
+        all_engines = flatten_cells(self.cells)
+
         new_engines = []
         new_engine_indices = []
-        for i in range(len(self.all_engines)):
+        for i in range(len(all_engines)):
             if (start_indices is not None) and (i not in start_indices):
                 continue
-            if self.all_engines[i].is_allocated:
+            if all_engines[i].is_allocated:
                 continue
 
             global_rank = self.rank_offset + i
@@ -153,7 +151,7 @@ class ServerGroup:
 
             new_engines.append((global_rank, rollout_engine))
             new_engine_indices.append(i)
-            self.all_engines[i].mark_allocated_uninitialized(rollout_engine)
+            all_engines[i].mark_allocated_uninitialized(rollout_engine)
 
         curr_num_new_engines = len(new_engines)
         self.has_new_engines |= curr_num_new_engines > 0
@@ -179,7 +177,7 @@ class ServerGroup:
 
         for index, _ in new_engines:
             engine_addr_and_ports = addr_and_ports[index]
-            self.all_engines[index - self.rank_offset].set_addressing(
+            all_engines[index - self.rank_offset].set_addressing(
                 AddrInfo(
                     server_url=build_server_url(
                         host=engine_addr_and_ports["host"], port=engine_addr_and_ports["port"]
@@ -220,10 +218,11 @@ class ServerGroup:
         )
 
     def _primary_engines_of(self, engine_indices: list[int]) -> list[ServerEngine]:
+        all_engines = flatten_cells(self.cells)
         return [
-            self.all_engines[index]
+            all_engines[index]
             for index in engine_indices
-            if index % self.nodes_per_engine == 0 and self.all_engines[index].is_allocated
+            if index % self.nodes_per_engine == 0 and all_engines[index].is_allocated
         ]
 
     @property
@@ -241,8 +240,9 @@ class ServerGroup:
             async_utils.run(asyncio.wait_for(self.unregister_workers(engine_indices), timeout=_SHUTDOWN_TIMEOUT))
         except Exception as e:
             logger.warning(f"Unregistering {engine_indices=} from the router failed, tearing down anyway (e: {e})")
+        all_engines = flatten_cells(self.cells)
         for i in engine_indices:
-            engine = self.all_engines[i]
+            engine = all_engines[i]
             if engine.is_allocated:
                 logger.info(f"Shutting down and killing engine at index {i}")
                 try:
@@ -256,12 +256,13 @@ class ServerGroup:
                     logger.warning(f"Fail to kill engine at index {i} (e: {e})")
             else:
                 logger.info(f"Engine at index {i} is already None")
-            self.all_engines[i].mark_stopped()
+            all_engines[i].mark_stopped()
 
     async def recover(self, port_cursors: PortCursors, filter_indices: list[int] | None = None):
+        all_engines = flatten_cells(self.cells)
         if filter_indices is None:
-            filter_indices = [i for i, engine in enumerate(self.all_engines) if not engine.is_allocated]
-        start_indices = [idx for idx in filter_indices if not self.all_engines[idx].is_allocated]
+            filter_indices = [i for i, engine in enumerate(all_engines) if not engine.is_allocated]
+        start_indices = [idx for idx in filter_indices if not all_engines[idx].is_allocated]
 
         handles, new_engine_indices = self.start_engines(port_cursors, start_indices=start_indices)
         await asyncio.gather(*handles)
@@ -273,7 +274,7 @@ class ServerGroup:
             start_indices
         ), "curr_num_new_engines does not match start_indices length"
         if self.needs_offload and start_indices:
-            new_primary_engines = [self.all_engines[i] for i in start_indices if i % self.nodes_per_engine == 0]
+            new_primary_engines = [all_engines[i] for i in start_indices if i % self.nodes_per_engine == 0]
             release_handles.extend(engine.api_client.release_memory_occupation() for engine in new_primary_engines)
             if self.update_weights or self.model_path:
                 all_resume_engines.extend(new_primary_engines)
@@ -292,8 +293,9 @@ class ServerGroup:
         await self.register_workers(new_engine_indices)
 
     def mark_alive(self, engine_indices: list[int]):
+        all_engines = flatten_cells(self.cells)
         for engine_index in engine_indices:
-            self.all_engines[engine_index].mark_alive()
+            all_engines[engine_index].mark_alive()
 
     async def offload(self, tags: list[str] | None = None):
         if not self.needs_offload:

--- a/tests/fast/dashboard/test_hooks.py
+++ b/tests/fast/dashboard/test_hooks.py
@@ -6,6 +6,7 @@ import pytest
 from miles.dashboard import backend, hooks
 from miles.dashboard.hooks import BATCH_MAX_EVENTS, BATCH_MAX_SECONDS, _Identity
 from miles.dashboard.store import Role
+from miles.ray.rollout.server_cell import ServerCell
 from miles.utils.timer import Timer
 
 
@@ -152,7 +153,9 @@ class FakeServerEngine:
 
 class FakeGroup:
     def __init__(self, engines, nodes_per_engine=1):
-        self.all_engines = engines
+        self.cells = [
+            ServerCell(engines=engines[i : i + nodes_per_engine]) for i in range(0, len(engines), nodes_per_engine)
+        ]
         self.nodes_per_engine = nodes_per_engine
 
 

--- a/tests/fast/ray/rollout/real_ray/test_fault_tolerance.py
+++ b/tests/fast/ray/rollout/real_ray/test_fault_tolerance.py
@@ -10,6 +10,7 @@ import ray
 from tests.fast.ray.rollout.conftest import chunk_engines_into_cells, make_args
 
 from miles.ray.rollout.addr_allocator import PortCursors
+from miles.ray.rollout.server_cell import flatten_cells
 from miles.ray.rollout.server_engine import ServerEngine
 from miles.ray.rollout.server_group import ServerGroup
 
@@ -44,7 +45,7 @@ def _start(group: ServerGroup) -> None:
 
 
 def _kill_all(group: ServerGroup) -> None:
-    for e in group.all_engines:
+    for e in flatten_cells(group.cells):
         if e.is_allocated:
             try:
                 ray.kill(e.actor_handle)
@@ -68,22 +69,22 @@ class TestKillAndRecover:
         group = _build_group(pg_tuple=pg, num_engines=2)
         _start(group)
 
-        original_handles = [e.actor_handle for e in group.all_engines]
+        original_handles = [e.actor_handle for e in flatten_cells(group.cells)]
         # Real fault: kill engine 0 + mark its slot stopped (production code's
         # health monitor would do this; here we simulate it directly).
         ray.kill(original_handles[0])
-        group.all_engines[0].mark_stopped()
+        flatten_cells(group.cells)[0].mark_stopped()
 
         try:
             await group.recover(port_cursors=PortCursors.empty(), filter_indices=[0])
             # New actor for slot 0
-            assert group.all_engines[0].is_allocated
-            assert group.all_engines[0].actor_handle is not original_handles[0]
-            calls = ray.get(group.all_engines[0].actor_handle.get_calls.remote())
+            assert flatten_cells(group.cells)[0].is_allocated
+            assert flatten_cells(group.cells)[0].actor_handle is not original_handles[0]
+            calls = ray.get(flatten_cells(group.cells)[0].actor_handle.get_calls.remote())
             assert "init" in [c[0] for c in calls]
 
             # Slot 1 untouched, still the same actor
-            assert group.all_engines[1].actor_handle is original_handles[1]
+            assert flatten_cells(group.cells)[1].actor_handle is original_handles[1]
         finally:
             _kill_all(group)
 
@@ -99,17 +100,17 @@ class TestKillAndRecover:
         group = _build_group(pg_tuple=pg, num_engines=3)
         _start(group)
 
-        old = [e.actor_handle for e in group.all_engines]
+        old = [e.actor_handle for e in flatten_cells(group.cells)]
         for i in (0, 2):
             ray.kill(old[i])
-            group.all_engines[i].mark_stopped()
+            flatten_cells(group.cells)[i].mark_stopped()
 
         try:
             await group.recover(port_cursors=PortCursors.empty())
             for i in (0, 2):
-                assert group.all_engines[i].is_allocated
-                assert group.all_engines[i].actor_handle is not old[i]
-            assert group.all_engines[1].actor_handle is old[1]
+                assert flatten_cells(group.cells)[i].is_allocated
+                assert flatten_cells(group.cells)[i].actor_handle is not old[i]
+            assert flatten_cells(group.cells)[1].actor_handle is old[1]
         finally:
             _kill_all(group)
 
@@ -137,15 +138,15 @@ class TestKillAndRecover:
         group = _build_group(pg_tuple=pg, num_engines=1)
         group.router_ip, group.router_port = "10.0.0.9", 9000
         _start(group)
-        ray.kill(group.all_engines[0].actor_handle)
-        group.all_engines[0].mark_stopped()
+        ray.kill(flatten_cells(group.cells)[0].actor_handle)
+        flatten_cells(group.cells)[0].mark_stopped()
 
         try:
             with patch.object(ServerGroup, "_router_api_client", property(lambda self: _Recorder())):
                 await group.recover(port_cursors=PortCursors.empty(), filter_indices=[0])
 
-            assert [event["worker_url"] for event in events] == [group.all_engines[0].addr_info.server_url]
-            assert group.all_engines[0].is_alive
+            assert [event["worker_url"] for event in events] == [flatten_cells(group.cells)[0].addr_info.server_url]
+            assert flatten_cells(group.cells)[0].is_alive
         finally:
             _kill_all(group)
 
@@ -161,14 +162,14 @@ class TestKillAndRecover:
         pg = placement_group_factory(2)
         group = _build_group(pg_tuple=pg, num_engines=2, needs_offload=True, update_weights=True)
         _start(group)
-        old = [e.actor_handle for e in group.all_engines]
+        old = [e.actor_handle for e in flatten_cells(group.cells)]
 
         ray.kill(old[0])
-        group.all_engines[0].mark_stopped()
+        flatten_cells(group.cells)[0].mark_stopped()
 
         try:
             await group.recover(port_cursors=PortCursors.empty(), filter_indices=[0])
-            calls = ray.get(group.all_engines[0].actor_handle.get_calls.remote())
+            calls = ray.get(flatten_cells(group.cells)[0].actor_handle.get_calls.remote())
             assert "init" in [c[0] for c in calls]
 
             server = mock_engine_http_servers.for_rank(0)
@@ -223,9 +224,9 @@ class TestConcurrentRecover:
 
         # Kill one engine in each group
         for g in (a, b):
-            old = g.all_engines[0].actor_handle
+            old = flatten_cells(g.cells)[0].actor_handle
             ray.kill(old)
-            g.all_engines[0].mark_stopped()
+            flatten_cells(g.cells)[0].mark_stopped()
 
         try:
             # Real concurrent recover via asyncio.gather
@@ -233,8 +234,8 @@ class TestConcurrentRecover:
                 a.recover(port_cursors=PortCursors.empty(), filter_indices=[0]),
                 b.recover(port_cursors=PortCursors.empty(), filter_indices=[0]),
             )
-            assert a.all_engines[0].is_allocated
-            assert b.all_engines[0].is_allocated
+            assert flatten_cells(a.cells)[0].is_allocated
+            assert flatten_cells(b.cells)[0].is_allocated
         finally:
             _kill_all(a)
             _kill_all(b)
@@ -258,7 +259,7 @@ class TestSimulateCrashKeepsActorReachable:
         pg = placement_group_factory(1)
         group = _build_group(pg_tuple=pg, num_engines=1)
         _start(group)
-        actor = group.all_engines[0].actor_handle
+        actor = flatten_cells(group.cells)[0].actor_handle
 
         try:
             ray.get(actor.simulate_crash.remote())

--- a/tests/fast/ray/rollout/real_ray/test_inference_controller.py
+++ b/tests/fast/ray/rollout/real_ray/test_inference_controller.py
@@ -10,6 +10,7 @@ from tests.fast.ray.rollout.conftest import make_args
 
 from miles.backends.sglang_utils.sglang_api_client import SGLangApiClient
 from miles.ray.rollout.inference_controller import InferenceController
+from miles.ray.rollout.server_cell import flatten_cells
 
 
 class _NoopRouterApiClient:
@@ -463,12 +464,12 @@ class TestRecoverUpdatableEngines:
         # Kill engine 0 directly + mark stopped (simulates a fault before any
         # rollout). recover_updatable_engines must not bring it back yet.
         ray.kill(actor0_before)
-        controller.servers["actor"].server_groups[0].all_engines[0].mark_stopped()
+        flatten_cells(controller.servers["actor"].server_groups[0].cells)[0].mark_stopped()
 
         await controller.recover_updatable_engines()
 
         # Slot 0 is still de-allocated; recovery skipped because rollout_id=-1.
-        assert not controller.servers["actor"].server_groups[0].all_engines[0].is_allocated
+        assert not flatten_cells(controller.servers["actor"].server_groups[0].cells)[0].is_allocated
 
     async def test_recovers_dead_engine_after_rollout_started(
         self,
@@ -487,12 +488,12 @@ class TestRecoverUpdatableEngines:
         actor0_before = _engine_slots(controller)[0].actor_handle
 
         ray.kill(actor0_before)
-        controller.servers["actor"].server_groups[0].all_engines[0].mark_stopped()
+        flatten_cells(controller.servers["actor"].server_groups[0].cells)[0].mark_stopped()
 
         await controller.prepare_rollout(0)
         await controller.recover_updatable_engines()
 
-        slot0 = controller.servers["actor"].server_groups[0].all_engines[0]
+        slot0 = flatten_cells(controller.servers["actor"].server_groups[0].cells)[0]
         assert slot0.is_allocated
         assert slot0.actor_handle is not actor0_before
         assert isinstance(ray.get(slot0.actor_handle.get_calls.remote()), list)

--- a/tests/fast/ray/rollout/real_ray/test_rollout_server.py
+++ b/tests/fast/ray/rollout/real_ray/test_rollout_server.py
@@ -6,6 +6,7 @@ from tests.fast.ray.rollout.conftest import chunk_engines_into_cells, make_args
 
 from miles.ray.rollout.addr_allocator import PortCursors
 from miles.ray.rollout.rollout_server import RolloutServer
+from miles.ray.rollout.server_cell import flatten_cells
 from miles.ray.rollout.server_engine import ServerEngine
 from miles.ray.rollout.server_group import ServerGroup
 
@@ -40,7 +41,7 @@ def _start_group(group: ServerGroup) -> None:
 
 
 def _kill_group(group: ServerGroup) -> None:
-    for e in group.all_engines:
+    for e in flatten_cells(group.cells):
         if e.is_allocated:
             ray.kill(e.actor_handle)
 
@@ -128,7 +129,7 @@ class TestOffloadOnloadAggregation:
                 assert server.payloads_of("/release_memory_occupation") == [{"tags": ["weights"]}]
                 assert server.payloads_of("/resume_memory_occupation") == [{"tags": ["weights"]}]
 
-            for engine in a.all_engines + b.all_engines:
+            for engine in flatten_cells(a.cells) + flatten_cells(b.cells):
                 method_names = {name for name, _args, _kwargs in ray.get(engine.actor_handle.get_calls.remote())}
                 assert not {"release_memory_occupation", "resume_memory_occupation"} & method_names
         finally:
@@ -172,7 +173,7 @@ class TestOffloadOnloadAggregation:
         group = _build_group(pg_tuple=pg, num_engines=2, needs_offload=True)
         _start_group(group)
         group.mark_alive([0, 1])
-        group.all_engines[1].mark_stopped()
+        flatten_cells(group.cells)[1].mark_stopped()
 
         srv = RolloutServer(server_groups=[group])
         try:

--- a/tests/fast/ray/rollout/real_ray/test_server_group.py
+++ b/tests/fast/ray/rollout/real_ray/test_server_group.py
@@ -5,6 +5,7 @@ import ray
 from tests.fast.ray.rollout.conftest import chunk_engines_into_cells, make_args
 
 from miles.ray.rollout.addr_allocator import PortCursors
+from miles.ray.rollout.server_cell import flatten_cells
 from miles.ray.rollout.server_engine import ServerEngine
 from miles.ray.rollout.server_group import ServerGroup
 
@@ -44,7 +45,7 @@ class TestStartEnginesShortCircuits:
         handles, indices = group.start_engines(PortCursors.empty())
         assert handles == [] and indices == []
         assert group.has_new_engines is False
-        for e in group.all_engines:
+        for e in flatten_cells(group.cells):
             assert not e.is_allocated
 
     def test_placeholder_worker_short_circuits(self, placement_group_factory):
@@ -73,7 +74,7 @@ class TestStartEnginesRealActors:
         # Wait for init.remote() to actually complete on each actor.
         ray.get(handles)
 
-        for i, e in enumerate(group.all_engines):
+        for i, e in enumerate(flatten_cells(group.cells)):
             assert e.is_allocated
             calls = ray.get(e.actor_handle.get_calls.remote())
             method_names = [name for name, _, _ in calls]
@@ -84,7 +85,7 @@ class TestStartEnginesRealActors:
             assert e.addr_info.server_url == mock_engine_http_servers.for_rank(i).url
 
         # Cleanup: kill the actors we created.
-        for e in group.all_engines:
+        for e in flatten_cells(group.cells):
             ray.kill(e.actor_handle)
 
     def test_start_indices_filters_to_subset(self, patched_sglang_engine, placement_group_factory):
@@ -95,13 +96,13 @@ class TestStartEnginesRealActors:
         assert sorted(indices) == [1, 3]
         ray.get(handles)
 
-        assert not group.all_engines[0].is_allocated
-        assert group.all_engines[1].is_allocated
-        assert not group.all_engines[2].is_allocated
-        assert group.all_engines[3].is_allocated
+        assert not flatten_cells(group.cells)[0].is_allocated
+        assert flatten_cells(group.cells)[1].is_allocated
+        assert not flatten_cells(group.cells)[2].is_allocated
+        assert flatten_cells(group.cells)[3].is_allocated
 
         for i in (1, 3):
-            ray.kill(group.all_engines[i].actor_handle)
+            ray.kill(flatten_cells(group.cells)[i].actor_handle)
 
     def test_already_allocated_slot_is_skipped(self, patched_sglang_engine, placement_group_factory):
         """A second start_engines() call must NOT replace an already-allocated
@@ -112,12 +113,12 @@ class TestStartEnginesRealActors:
         # First call: allocates both slots.
         handles, _ = group.start_engines(PortCursors.empty())
         ray.get(handles)
-        first_handles = [e.actor_handle for e in group.all_engines]
+        first_handles = [e.actor_handle for e in flatten_cells(group.cells)]
 
         # Second call with no start_indices: should skip both.
         handles2, indices2 = group.start_engines(PortCursors.empty())
         assert handles2 == [] and indices2 == []
-        for first, e in zip(first_handles, group.all_engines, strict=True):
+        for first, e in zip(first_handles, flatten_cells(group.cells), strict=True):
             assert e.actor_handle is first  # still the same actor
 
         for h in first_handles:
@@ -138,10 +139,10 @@ class TestStopEnginesRealKill:
         handles, _ = group.start_engines(PortCursors.empty())
         ray.get(handles)
 
-        actors = [e.actor_handle for e in group.all_engines]
+        actors = [e.actor_handle for e in flatten_cells(group.cells)]
         group.stop_engines(engine_indices=[0, 1])
 
-        for e in group.all_engines:
+        for e in flatten_cells(group.cells):
             assert not e.is_allocated, "engine should be stopped"
 
         # Real-Ray claim: a follow-up call on a killed actor must surface as
@@ -162,14 +163,14 @@ class TestStopEnginesRealKill:
 
         # Plant a one-shot shutdown failure on engine 1.
         ray.get(
-            group.all_engines[1].actor_handle.set_fault.remote(
+            flatten_cells(group.cells)[1].actor_handle.set_fault.remote(
                 "shutdown",
                 RuntimeError("boom"),
             )
         )
 
         group.stop_engines(engine_indices=[0, 1])
-        for e in group.all_engines:
+        for e in flatten_cells(group.cells):
             assert not e.is_allocated, "all engines must be stopped despite shutdown raise"
 
 
@@ -199,8 +200,8 @@ class TestStartEnginesRealAllocator:
         # init kwargs == the addr_and_ports map produced by the real allocator
         kwargs0, kwargs1 = ray.get(
             [
-                group.all_engines[0].actor_handle.get_init_kwargs.remote(),
-                group.all_engines[1].actor_handle.get_init_kwargs.remote(),
+                flatten_cells(group.cells)[0].actor_handle.get_init_kwargs.remote(),
+                flatten_cells(group.cells)[1].actor_handle.get_init_kwargs.remote(),
             ]
         )
 
@@ -225,13 +226,13 @@ class TestStartEnginesRealAllocator:
         # sees these calls — but engine 1's ports still come from those
         # results, so this assertion catches a regression where the allocator
         # silently fell back to a stub or swallowed the .remote() calls.
-        leader_calls = ray.get(group.all_engines[0].actor_handle.get_calls.remote())
+        leader_calls = ray.get(flatten_cells(group.cells)[0].actor_handle.get_calls.remote())
         leader_method_names = [name for name, _, _ in leader_calls]
         assert (
             "_get_current_node_ip_and_free_port" in leader_method_names
         ), f"allocator never called the port-finder; saw {leader_method_names}"
 
-        for e in group.all_engines:
+        for e in flatten_cells(group.cells):
             ray.kill(e.actor_handle)
 
     def test_real_allocator_advances_cursor_across_sequential_groups(
@@ -256,15 +257,15 @@ class TestStartEnginesRealAllocator:
         handles_b, _ = b.start_engines(cursors)
         ray.get(handles_b)
 
-        kwargs_a = ray.get([e.actor_handle.get_init_kwargs.remote() for e in a.all_engines])
-        kwargs_b = ray.get([e.actor_handle.get_init_kwargs.remote() for e in b.all_engines])
+        kwargs_a = ray.get([e.actor_handle.get_init_kwargs.remote() for e in flatten_cells(a.cells)])
+        kwargs_b = ray.get([e.actor_handle.get_init_kwargs.remote() for e in flatten_cells(b.cells)])
         ports_a = {p for kw in kwargs_a for p in (kw["port"], kw["nccl_port"])}
         ports_b = {p for kw in kwargs_b for p in (kw["port"], kw["nccl_port"])}
 
         assert ports_a.isdisjoint(ports_b), f"sequential groups overlapped on ports: a={ports_a} b={ports_b}"
 
         for g in (a, b):
-            for e in g.all_engines:
+            for e in flatten_cells(g.cells):
                 ray.kill(e.actor_handle)
 
 

--- a/tests/fast/ray/rollout/real_ray/test_server_group_teardown.py
+++ b/tests/fast/ray/rollout/real_ray/test_server_group_teardown.py
@@ -8,6 +8,7 @@ from tests.fast.ray.rollout.conftest import chunk_engines_into_cells, make_args
 
 import miles.ray.rollout.server_group as server_group_module
 from miles.ray.rollout.addr_allocator import PortCursors
+from miles.ray.rollout.server_cell import flatten_cells
 from miles.ray.rollout.server_engine import ServerEngine
 from miles.ray.rollout.server_group import ServerGroup
 
@@ -50,20 +51,20 @@ class TestTeardownIsTerminal:
         group = _build_group(pg_tuple=placement_group_factory(1))
         handles, _ = group.start_engines(PortCursors.empty())
         ray.get(handles)
-        actor_handle = group.all_engines[0].actor_handle
+        actor_handle = flatten_cells(group.cells)[0].actor_handle
         ray.get(actor_handle.set_fault.remote("shutdown", RuntimeError("shutdown blew up")))
 
         group.stop_engines(engine_indices=[0])
 
         assert _is_dead(actor_handle)
-        assert not group.all_engines[0].is_allocated
+        assert not flatten_cells(group.cells)[0].is_allocated
 
     def test_a_hanging_shutdown_does_not_block_teardown(self, monkeypatch, ray_local_mode):
         """A wedged engine must not stall teardown forever, since teardown is how a wedged engine is reclaimed."""
         monkeypatch.setattr(server_group_module, "_SHUTDOWN_TIMEOUT", 0.5)
         group = _build_group(pg_tuple=(None, [], []))
         actor_handle = _HangingEngine.remote()
-        group.all_engines[0].mark_allocated_uninitialized(actor_handle)
+        flatten_cells(group.cells)[0].mark_allocated_uninitialized(actor_handle)
 
         finished = threading.Event()
         thread = threading.Thread(target=lambda: (group.stop_engines(engine_indices=[0]), finished.set()), daemon=True)
@@ -72,4 +73,4 @@ class TestTeardownIsTerminal:
 
         assert finished.is_set(), "stop_engines waited on a shutdown that never returns"
         assert _is_dead(actor_handle)
-        assert not group.all_engines[0].is_allocated
+        assert not flatten_cells(group.cells)[0].is_allocated

--- a/tests/fast/ray/rollout/test_server_cell.py
+++ b/tests/fast/ray/rollout/test_server_cell.py
@@ -80,14 +80,10 @@ class TestGetCellIndexerOfIdMap:
         assert cells[0].engine_indices == [0, 1]
 
     def test_placeholder_group_with_zero_engines_emits_zero_cells(self):
-        """``placeholder`` worker_type groups have empty all_engines/engines.
-        The internal assertion ``len(all_engines) == len(engines) *
-        nodes_per_engine`` still holds (0 == 0 * N)."""
+        """``placeholder`` worker_type groups have no cells, so no cell ids are emitted."""
         srv = MagicMock()
         group = MagicMock()
-        group.all_engines = []
-        group.engines = []
-        group.nodes_per_engine = 2
+        group.cells = []
         srv.server_groups = [group]
         out = get_cell_indexer_of_id_map({"only": srv})
         assert out == []

--- a/tests/fast/ray/rollout/test_server_group_router_registration.py
+++ b/tests/fast/ray/rollout/test_server_group_router_registration.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 import pytest
 from tests.fast.ray.rollout.conftest import chunk_engines_into_cells, fake_actor_handle, make_args
 
+from miles.ray.rollout.server_cell import flatten_cells
 from miles.ray.rollout.server_engine import AddrInfo, ServerEngine
 from miles.ray.rollout.server_group import ServerGroup
 from miles.utils import async_utils
@@ -172,7 +173,7 @@ def test_a_router_that_rejects_the_unregister_still_kills_the_actor():
         group.stop_engines(engine_indices=[0])
 
     assert [name for name, _kwargs in events] == ["remove_worker", "shutdown", "kill"]
-    assert not group.all_engines[0].is_allocated
+    assert not flatten_cells(group.cells)[0].is_allocated
 
 
 def test_a_router_that_never_answers_the_unregister_does_not_block_teardown():
@@ -193,7 +194,7 @@ def test_a_router_that_never_answers_the_unregister_does_not_block_teardown():
         group.stop_engines(engine_indices=[0])
 
     assert [name for name, _kwargs in events] == ["remove_worker", "kill"]
-    assert not group.all_engines[0].is_allocated
+    assert not flatten_cells(group.cells)[0].is_allocated
 
 
 def test_use_miles_router_reaches_both_router_calls():


### PR DESCRIPTION
Part of #1837