### PR TITLE
E2B sandbox backend (E2B Cloud / self-hosted AgentENV) + dedicated AgentENV recipe

### DIFF
--- a/docs/user-guide/environments.md
+++ b/docs/user-guide/environments.md
@@ -16,20 +16,22 @@ where the environment itself comes from:
 - **An external ecosystem** — adopt a prebuilt connector from the table below;
   connectors occupy the same three layers.
 
-| Integration | Plugs in at |
-|---|---|
-| [Harbor](/user-guide/harbor) | agent function |
-| [OpenEnv](/user-guide/openenv) | agent function |
-| [NeMo-Gym](/user-guide/nemo-gym) | agent function |
-| [Strands Agents](https://github.com/radixark/miles/tree/main/examples/experimental/strands_sglang) | generate function |
-| [τ-bench](https://github.com/radixark/miles/tree/main/examples/experimental/tau-bench) | generate function |
+| Integration | Plugs in at | Guide |
+|---|---|---|
+| [Harbor](https://github.com/harbor-framework/harbor) | agent function | [guide](/user-guide/harbor) |
+| [OpenEnv](https://github.com/huggingface/openenv) | agent function | [guide](/user-guide/openenv) |
+| [NeMo-Gym](https://github.com/NVIDIA-NeMo/Gym) | agent function | [guide](/user-guide/nemo-gym) |
+| [Strands Agents](https://strandsagents.com/) | generate function | [example](https://github.com/radixark/miles/tree/main/examples/experimental/strands_sglang) |
+| [τ-bench](https://github.com/sierra-research/tau-bench) | generate function | [example](https://github.com/radixark/miles/tree/main/examples/experimental/tau-bench) |
 
 Sandbox providers are a different axis: they provision the task containers
 *inside* a connector rather than occupying a rollout layer.
 
-| Sandbox provider | Used within |
-|---|---|
-| [Daytona](https://www.daytona.io/) | OpenEnv, Harbor, NeMo-Gym |
+| Sandbox provider | Used within | Guide |
+|---|---|---|
+| [AgentENV](https://github.com/kvcache-ai/AgentENV) | OpenEnv | [example](https://github.com/radixark/miles/tree/main/examples/experimental/agentenv) |
+| [Daytona](https://www.daytona.io/) | OpenEnv, Harbor, NeMo-Gym | [example](https://github.com/radixark/miles/tree/main/examples/experimental/openenv) |
+| [E2B](https://e2b.dev/) | OpenEnv | [example](https://github.com/radixark/miles/tree/main/examples/experimental/openenv) |
 
 All external ecosystem support is experimental.
 

--- a/docs/user-guide/openenv.md
+++ b/docs/user-guide/openenv.md
@@ -20,8 +20,10 @@ hook.
 The maintained end-to-end recipe is **Terminal-Bench-2 GRPO** in
 [`examples/experimental/openenv`](https://github.com/radixark/miles/tree/main/examples/experimental/openenv).
 It runs against a shared Docker env server (full per-task image fidelity) or
-per-episode [Daytona](https://www.daytona.io/) cloud sandboxes built from each
-task's official image (no resident infrastructure). Follow the
+per-episode cloud sandboxes built from each task's official image (no resident
+infrastructure) on a choice of providers: [Daytona](https://www.daytona.io/),
+[E2B](https://e2b.dev/), or a self-hosted, E2B-compatible
+[AgentENV](https://github.com/kvcache-ai/AgentENV) deployment. Follow the
 [recipe README](https://github.com/radixark/miles/blob/main/examples/experimental/openenv/README.md)
 for prompt-data preparation, env-server modes, launcher flags, and operational
 notes.

--- a/examples/experimental/agentenv/README.md
+++ b/examples/experimental/agentenv/README.md
@@ -1,0 +1,95 @@
+# RL on AgentENV sandboxes
+
+[AgentENV](https://github.com/kvcache-ai/AgentENV) is a self-hosted platform
+for running agent environments at scale on Firecracker microVMs, built by the
+Kimi K3 team: snapshot-backed sandboxes boot or resume in well under a second,
+per-task OCI images load on demand, and its native API **is** the E2B API — so
+Miles drives it through the standard `e2b` SDK with no AgentENV-specific code.
+
+AgentENV plugs in wherever E2B does. This page covers what is specific to
+AgentENV — deploying a server and pointing the SDK at it — then trains
+Terminal-Bench-2 GRPO through the [OpenEnv](../openenv/README.md) recipe on
+AgentENV sandboxes.
+
+## 1. Deploy an AgentENV server
+
+Requirements: a Linux host with `/dev/kvm` (bare metal, or a VM with nested
+virtualization) and kernel 6.8+. We validated on an AWS `m7i.metal-24xl`
+running Ubuntu 22.04 with the 6.8 HWE kernel.
+
+```bash
+# ublk is in linux-modules-extra on stock cloud kernels
+sudo apt-get install -y linux-modules-extra-$(uname -r) && sudo modprobe ublk_drv
+
+# host prerequisites + server container (Ubuntu 24.04 hosts can use the
+# native install script instead; see the AgentENV README)
+curl -fsSL https://raw.githubusercontent.com/kvcache-ai/AgentENV/main/scripts/docker-setup.sh | sudo bash
+docker run -d --name aenv --privileged -v /dev:/dev -p 8000:8000 -p 80:8000 \
+  -e AENV_SANDBOX_PROXY_DOMAINS=<ip-with-dashes>.sslip.io \
+  ghcr.io/kvcache-ai/aenv-server:latest
+curl -sf http://127.0.0.1:8000/health
+```
+
+Three parts of that command are not defaults. They exist because a training
+run reaches the env server inside each episode's microVM over one path only:
+the per-sandbox URL AgentENV's gateway routes. Get these wrong and no episode
+can connect.
+
+* **`AENV_SANDBOX_PROXY_DOMAINS` turns those URLs on.** It is what makes the
+  SDK's `get_host(port)` return a routable host, shaped
+  `{port}-{sandboxID}.{domain}`.
+* **The domain has to wildcard-resolve to the server**, because every sandbox
+  id is new. [sslip.io](https://sslip.io) gives you that with no DNS setup of
+  your own — `203-0-113-10.sslip.io` resolves to 203.0.113.10 — and a
+  wildcard record on a domain you own does the same.
+* **Publish port 80 too** (`-p 80:8000`): those URLs carry no port, so they
+  arrive on 80. Fronting the server with a proxy on 80/443 works instead, as
+  long as it forwards WebSocket — episode I/O runs over `/ws`, and only the
+  health check is plain HTTP.
+
+AgentENV does not enforce API keys yet — run it only on a trusted network.
+Multi-node deployment (gateway + scheduler) is
+documented in the [AgentENV docs](https://kvcache-ai.github.io/AgentENV/).
+
+## 2. Point the E2B SDK at it
+
+```bash
+pip install e2b
+export E2B_API_URL=http://<server>:8000       # control plane
+export E2B_SANDBOX_URL=http://<server>:8000   # data plane (envd proxy)
+# plain-HTTP deployments only; the default is https
+export OPENENV_E2B_URL_SCHEME=http
+# required, but any well-formed key passes: AgentENV does not check it, while
+# recent SDKs do validate the format client-side
+export E2B_API_KEY=e2b_0000000000000000000000000000000000000000
+```
+
+## 3. Train
+
+One AgentENV microVM per episode, on the
+[OpenEnv tbench2 recipe](../openenv/README.md)'s training pipeline unchanged.
+Follow that recipe's [prompt-data preparation and tbench2_env
+install](../openenv/README.md), then select the backend at launch:
+
+```bash
+export OPENENV_TB2_TASKS_DIR=/workspace/terminal-bench-2
+OPENENV_SANDBOX_BACKEND=agentenv python ../openenv/run-openenv-tbench2.py
+```
+
+From here the e2b leg behaves as that recipe describes it, with each episode
+running in a microVM instead of a cloud sandbox: the same per-task templates,
+the same pre-baking step, the same GPU-free sanity checks. One caveat is
+specific to baking against a self-hosted server: the CLI builds tasks one
+after another, so `--all` over the full suite is a long single run — give it
+its own session, or bake in chunks with `--tasks`.
+
+We validated this path with a sustained GRPO run on 8×H200 (GLM-4.7-Flash,
+TP=4/EP=2) over the full task set: 55 rollouts, ~3,400 episodes, each in a
+fresh microVM warm-started from its pre-baked template, scored by the task's
+own tests, with every rollout's weights serving the next. One
+`m7i.metal-24xl` server sustained 64 concurrent microVMs throughout; episode
+failures (WebSocket drops with the host at saturation) stayed near one
+percent, each bounded to its own episode by the adapter's abort handling.
+Size from there: ~64 concurrent episodes saturate one such host, and
+`OPENENV_E2B_CREATE_CONCURRENCY` (default 4) paces creation bursts — we ran
+it at 16.

--- a/examples/experimental/openenv/README.md
+++ b/examples/experimental/openenv/README.md
@@ -54,54 +54,75 @@ The installed `tbench2_env` must be `>=` the #1012 merge (04d259ea6), same as
 step 2b below; the adapter drops every episode (with a warning) from a server
 that doesn't carry that contract.
 
-### 2b. Alternative: Daytona cloud sandboxes (no Docker host)
+### 2b. Alternative: per-episode cloud sandboxes — Daytona, E2B, or AgentENV
 
-Instead of one shared env server, the adapter can give **every episode its own
-[Daytona](https://www.daytona.io/) cloud sandbox**, built from the task's official
-image plus an env server layer and deleted when the episode ends. Same
-per-task image fidelity as docker mode, with zero resident infrastructure (no
-Docker socket, no shared server to size or babysit, no cross-episode state), at
-the cost of per-episode sandbox creation (~1 min warm; the first episode of each
-task builds its image in ~10 min, cached after that by definition hash).
+Instead of one shared env server, every episode can get its **own cloud
+sandbox**, built from the task's official image plus an env-server layer and
+deleted when the episode ends. This keeps docker mode's per-task image
+fidelity while leaving no resident infrastructure behind: no Docker socket,
+no shared server to size or babysit, no cross-episode state. It costs a
+sandbox creation per episode, plus one image or template build the first time
+each task runs, which the provider caches from then on.
 
-The image recipe lives in [`tb2_sandbox_recipe.py`](tb2_sandbox_recipe.py), its Daytona
-materialization in [`tb2_sandbox_daytona.py`](tb2_sandbox_daytona.py) (this
-directory). The recipe bakes the **installed** `tbench2_env` package — OpenEnv's
-Terminal-Bench-2 environment package, the same one step 2's shared server
-runs — into each task image, and in this mode the adapter scores via the
-standard `evaluate` action, so the install must carry the server-side fixes
-this leg relies on (canonical `tests/test.sh` scoring built into `evaluate`,
-per-task WORKDIR resolved server-side, `TB2_WITHHOLD_TESTS` verifier-asset
-withholding — all upstream since huggingface/OpenEnv#965 + #972; the launcher
-preflights the installed source and fails fast on an older install). Install
-from upstream main (editable: the recipe embeds the package source, which
-needs `pyproject.toml` present next to the package):
+Whichever provider you pick, install `tbench2_env` **editable**: the recipe
+bakes the installed source into each task image, so that install must carry
+the same `>=` #1012 server contract as step 2. The launcher preflights the
+installed source and fails fast on an older one.
 
 ```bash
 git clone https://github.com/huggingface/OpenEnv.git   # >= the #1012 merge (04d259ea6, the full canonical contract for both modes); pin that sha if you need frozen reward semantics across a long run
 pip install -e OpenEnv/envs/tbench2_env
 ```
 
-Skip step 2 entirely and set:
+Then skip step 2 and set two things: `OPENENV_TB2_TASKS_DIR`, the checkout to
+build task images from, and `OPENENV_SANDBOX_BACKEND`, the provider to build
+them on. Neither has a default — the provider decides whose quota a run
+spends and which credentials have to be present — so setting one without the
+other fails at launch.
+
+Both providers authenticate the same way: the key in the environment
+(`DAYTONA_API_KEY`, `E2B_API_KEY`), or else a file whose *path* the launcher
+forwards. It never forwards the value, which ray's `runtime_env` records in
+plaintext; the agent-function docstrings cover what that means on a
+multi-host cluster.
+
+**Daytona** builds each image declaratively per episode. A warm create takes
+about a minute, and the first episode of each task spends about ten minutes
+building its image, cached by definition hash after that.
 
 ```bash
-pip install daytona   # the SDK is imported lazily, not installed with tbench2_env
+pip install daytona
 mkdir -p ~/.config/daytona && echo dtn_... > ~/.config/daytona/api_key   # or export DAYTONA_API_KEY
 export OPENENV_TB2_TASKS_DIR=/workspace/terminal-bench-2   # the checkout from step 1
-python run-openenv-tbench2.py
+OPENENV_SANDBOX_BACKEND=daytona python run-openenv-tbench2.py
 ```
 
-Key supply on multi-host clusters (and why only a file *path* is ever
-forwarded) is documented in the `openenv_daytona_agent_function.py` docstring —
-this mode's own agent function, which the launcher selects automatically
-when `OPENENV_TB2_TASKS_DIR` is set.
+**E2B-compatible** providers (`e2b`, or `agentenv` as an alias for the same
+leg) build one named template per task, and every later episode warm-starts
+from it in seconds. The endpoint defaults to E2B Cloud; to drive a
+self-hosted [AgentENV](https://github.com/kvcache-ai/AgentENV) deployment
+instead, follow the [AgentENV recipe](../agentenv/README.md).
 
-Infra sanity checks without touching a GPU (both live beside the launcher):
-`scan_golden.py` replays each task's official solution through the full
-sandbox + scoring path (`--logs` captures failure evidence; 82/89 of the TB2
-suite pass, the rest have upstream-broken solutions), and
-`eval_tbench2_via_api.py` runs the identical agentic loop with any
-OpenAI-compatible API standing in for the policy.
+```bash
+pip install e2b
+export E2B_API_KEY=e2b_...     # or E2B_API_KEY_FILE (default ~/.config/e2b/api_key)
+export OPENENV_TB2_TASKS_DIR=/workspace/terminal-bench-2
+OPENENV_SANDBOX_BACKEND=e2b python run-openenv-tbench2.py
+```
+
+Because that template is a named artifact rather than a build cache, it can be
+built ahead of the run. Doing so is optional, since the first episode of a
+task builds it inline, but that inline build occupies a create-concurrency
+slot, so an unbaked first rollout spends most of its wall clock building
+images: `python tb2_sandbox_e2b.py --tasks-dir /workspace/terminal-bench-2 --all`.
+
+Two sanity checks run without a GPU, and both honor
+`OPENENV_SANDBOX_BACKEND`. [`scan_golden.py`](scan_golden.py) replays each
+task's official solution through the full sandbox and scoring path; expect
+82/89 to pass, since the rest have upstream-broken solutions, and pass
+`--logs` to capture the failure evidence.
+[`eval_tbench2_via_api.py`](eval_tbench2_via_api.py) runs the same agentic
+loop with any OpenAI-compatible API standing in for the policy.
 
 ## 3. Launch training
 
@@ -118,8 +139,13 @@ Common overrides:
 | `--num-rollout` | (launcher) | Number of GRPO steps |
 | `OPENENV_MAX_TURNS` | `30` | Max agent turns per episode |
 | `OPENENV_MAX_ROLLOUT_TIME_SECONDS` | `3600` | Per-episode wall-clock cap; a straggler that exceeds it is terminated and scored 0 |
-| `OPENENV_TB2_TASKS_DIR` + Daytona key | off | Daytona sandbox mode (section 2b); overrides `--openenv-env-url`. Key: `DAYTONA_API_KEY` in the env, else a key file (`~/.config/daytona/api_key`; `DAYTONA_API_KEY_FILE` overrides) |
-| `OPENENV_DAYTONA_CREATE_CONCURRENCY` | `4` | Max in-flight sandbox creates (Daytona rate-limits creation) |
+| `OPENENV_TB2_TASKS_DIR` | off | Switches on per-episode sandbox mode (section 2b) and overrides `--openenv-env-url`. Point it at the terminal-bench-2 checkout from step 1 |
+| `DAYTONA_API_KEY` / `DAYTONA_API_KEY_FILE` | — / `~/.config/daytona/api_key` | Daytona key supply: the env value wins, otherwise the key file is read |
+| `OPENENV_SANDBOX_BACKEND` | — | Required whenever `OPENENV_TB2_TASKS_DIR` is set: `daytona`, `e2b`, or `agentenv` (alias for `e2b`; section 2b). Only the selected leg's `OPENENV_*` settings below are read — the others are ignored silently |
+| `E2B_API_KEY` / `E2B_API_KEY_FILE` | — / `~/.config/e2b/api_key` | E2B key supply, same file-path-forwarding contract as Daytona's |
+| `E2B_API_URL`, `E2B_SANDBOX_URL` | E2B Cloud | Endpoint overrides — point both at a self-hosted AgentENV gateway |
+| `OPENENV_DAYTONA_CREATE_CONCURRENCY` | `4` | Max in-flight creates on the daytona leg. Raise it against Daytona's creation rate limit, which the leg also retries with backoff |
+| `OPENENV_E2B_CREATE_CONCURRENCY` | `4` | Max in-flight creates on the e2b leg. Size it to what the endpoint can host — one self-hosted AgentENV machine took 16 — and use `OPENENV_E2B_THROTTLE_PATTERNS` to name additional provider errors that should count as retryable capacity limits |
 | `--dump-details <dir>` | off | Dump per-episode tokens/logprobs/masks/reward for inspection |
 | `WANDB_KEY`, `--wandb-project`, `--wandb-team` | — | W&B logging |
 

--- a/examples/experimental/openenv/eval_tbench2_via_api.py
+++ b/examples/experimental/openenv/eval_tbench2_via_api.py
@@ -1,14 +1,14 @@
 """Standalone Terminal-Bench-2 eval: an OpenAI-compatible *API* as the policy,
-Daytona sandboxes as the env. No GPU, no miles training pipeline.
+per-episode sandboxes as the env. No GPU, no miles training pipeline.
 
 This reuses the exact agent-env loop miles runs during training
 (``openenv_agent_function._multi_turn``: reset -> {policy emits a shell command
 -> exec -> feed output back} -> canonical tests/test.sh -> binary reward) but
 swaps miles' session-server policy for a plain API client. The machine running
 this only orchestrates; the policy runs in the cloud (e.g. DeepSeek) and each
-episode runs in its own Daytona sandbox (the task's OFFICIAL image +
+episode runs in its own per-provider sandbox (the task's OFFICIAL image +
 env server layer — recipe in the sibling ``tb2_sandbox_recipe`` module,
-materialized by ``tb2_sandbox_daytona``), created
+materialized per provider), created
 before the episode and deleted after.
 
 Why a separate script and not ``run-openenv-tbench2.py``: those launchers always
@@ -22,8 +22,11 @@ Env vars:
   DEEPSEEK_API_KEY / POLICY_API_KEY   policy API key (required)
   POLICY_BASE_URL   OpenAI-compatible root (default https://api.deepseek.com)
   POLICY_MODEL      default deepseek-v4-flash
-  OPENENV_TB2_TASKS_DIR  Daytona sandbox mode (TB2 checkout path); with
-                    DAYTONA_API_KEY or a key file at ~/.config/daytona/api_key.
+  OPENENV_TB2_TASKS_DIR  per-episode sandbox mode (TB2 checkout path); with
+                    provider credentials go with it (Daytona: DAYTONA_API_KEY
+                    or ~/.config/daytona/api_key; e2b/agentenv likewise).
+  OPENENV_SANDBOX_BACKEND             required with the above: daytona / e2b /
+                    agentenv (an alias for e2b).
                     Otherwise OPENENV_ENV_URL is used.
   OPENENV_MAX_TURNS, OPENENV_MAX_ROLLOUT_TIME_SECONDS, ...   as in the adapter.
 
@@ -107,10 +110,19 @@ async def main() -> None:
     rows = _load_rows(args)
     tasks_dir = os.getenv("OPENENV_TB2_TASKS_DIR", "").strip()
     if tasks_dir:
-        import openenv_daytona_agent_function as odaf
+        import openenv_sandbox_common as sandbox_common
 
-        run_episode = odaf.run_episode
-        env_desc = f"daytona sandboxes (tasks_dir={tasks_dir})"
+        try:
+            backend = sandbox_common.resolve_backend(os.getenv("OPENENV_SANDBOX_BACKEND"))
+        except ValueError as e:
+            sys.exit(str(e))
+        if backend == "e2b":
+            import openenv_e2b_agent_function as sandbox_leg
+        else:
+            import openenv_daytona_agent_function as sandbox_leg
+
+        run_episode = sandbox_leg.run_episode
+        env_desc = f"{backend} sandboxes (tasks_dir={tasks_dir})"
     else:
         run_episode = oaf.run_episode
         env_desc = os.getenv("OPENENV_ENV_URL", oaf._DEFAULT_ENV_URL)

--- a/examples/experimental/openenv/openenv_daytona_agent_function.py
+++ b/examples/experimental/openenv/openenv_daytona_agent_function.py
@@ -40,16 +40,14 @@ Env vars (the agent-loop ones in ``openenv_agent_function`` apply too):
   TB2_COMMAND_TIMEOUT_S        per-exec timeout inside the sandbox (default 900).
 """
 
-import asyncio
 import logging
 import os
-import random
-import threading
 from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Any
 
 import openenv_agent_function as oaf
+import openenv_sandbox_common as common
 import tb2_sandbox_daytona
 
 logger = logging.getLogger(__name__)
@@ -75,7 +73,7 @@ _CREATE_BACKOFF_CAP_S = float(os.getenv("OPENENV_DAYTONA_CREATE_BACKOFF_CAP_S", 
 _READY_TIMEOUT_S = float(os.getenv("OPENENV_DAYTONA_READY_TIMEOUT_S", "300"))
 _COMMAND_TIMEOUT_S = int(os.getenv("TB2_COMMAND_TIMEOUT_S", "900"))
 
-_create_sem: asyncio.Semaphore | None = None
+_get_create_sem = common.lazy_semaphore(_CREATE_CONCURRENCY)
 
 
 def _is_throttle_error(exc: BaseException) -> bool:
@@ -99,13 +97,6 @@ def _is_throttle_error(exc: BaseException) -> bool:
     return "throttler" in s or "too many requests" in s or "429" in s
 
 
-def _get_create_sem() -> asyncio.Semaphore:
-    global _create_sem
-    if _create_sem is None:
-        _create_sem = asyncio.Semaphore(_CREATE_CONCURRENCY)
-    return _create_sem
-
-
 def _start_declarative(task_id: str, tasks_dir: str) -> tuple[Any, str]:
     daytona = tb2_sandbox_daytona.make_daytona()
     sandbox, url = tb2_sandbox_daytona.create_task_sandbox(
@@ -117,88 +108,34 @@ def _start_declarative(task_id: str, tasks_dir: str) -> tuple[Any, str]:
     return (lambda: daytona.delete(sandbox)), url
 
 
-async def _create_once(task_id: str, tasks_dir: str) -> tuple[Any, str]:
-    """One sandbox-create attempt, safe against cancellation mid-create.
-
-    asyncio.to_thread is not cancellable: when the episode's wall-clock cap
-    cancels this coroutine mid-create, the worker thread keeps running and its
-    (close_fn, url) result would be discarded — leaking a sandbox that would
-    otherwise run (and bill) until the recipe's TTL backstop reclaims it.
-    Record the result thread-side and, on cancellation, hand it to a reaper
-    that deletes the orphan promptly once the create finishes.
-    """
-    result: list[tuple[Any, str]] = []
-    done = threading.Event()
-
-    def _start() -> tuple[Any, str]:
-        try:
-            result.append(_start_declarative(task_id, tasks_dir))
-        finally:
-            done.set()
-        return result[0]
-
-    try:
-        return await asyncio.to_thread(_start)
-    except asyncio.CancelledError:
-
-        def _reap() -> None:
-            done.wait()
-            for close_fn, _url in result:
-                try:
-                    close_fn()
-                    logger.info(f"Deleted sandbox orphaned by cancelled episode: {task_id}")
-                except Exception as e:
-                    logger.warning(f"Failed to delete orphaned sandbox for {task_id}: {e}")
-
-        threading.Thread(target=_reap, name=f"tb2-sandbox-reap-{task_id}", daemon=True).start()
-        raise
-
-
 async def _start_task_sandbox(task_id: str) -> tuple[Any, str]:
     """Create one sandbox for *task_id* with the env server running.
 
-    Returns (close_fn, base_url); close_fn deletes the sandbox. Creation is
-    throttled process-wide and retried on Daytona rate limits.
+    Returns (close_fn, base_url); close_fn deletes the sandbox. The
+    orchestration — cancel-safe create, process-wide throttling, backoff on
+    Daytona rate limits — is the provider-blind skeleton in
+    ``openenv_sandbox_common``; this leg contributes only its start hook and
+    throttle classifier.
     """
-    tasks_dir = os.getenv("OPENENV_TB2_TASKS_DIR", "").strip()
-
-    attempt = 0
-    while True:
-        try:
-            # Hold the semaphore only for the create attempt; release it during
-            # backoff so other episodes keep the pipeline full.
-            async with _get_create_sem():
-                return await _create_once(task_id, tasks_dir)
-        except Exception as e:
-            if not _is_throttle_error(e) or attempt >= _CREATE_MAX_RETRIES:
-                raise
-            attempt += 1
-            delay = min(
-                _CREATE_BACKOFF_CAP_S,
-                _CREATE_BACKOFF_BASE_S * (2 ** (attempt - 1)),
-            ) * (0.5 + random.random())
-            logger.warning(
-                f"Daytona create throttled for {task_id} "
-                f"(attempt {attempt}/{_CREATE_MAX_RETRIES}); retrying in {delay:.1f}s"
-            )
-            await asyncio.sleep(delay)
+    return await common.start_task_sandbox(
+        task_id,
+        os.getenv("OPENENV_TB2_TASKS_DIR", "").strip(),
+        start_fn=lambda tid, tdir: _start_declarative(tid, tdir),
+        is_throttle=_is_throttle_error,
+        sem=_get_create_sem(),
+        max_retries=_CREATE_MAX_RETRIES,
+        backoff_base_s=_CREATE_BACKOFF_BASE_S,
+        backoff_cap_s=_CREATE_BACKOFF_CAP_S,
+        logger=logger,
+        provider="Daytona",
+    )
 
 
 @asynccontextmanager
 async def _episode_env(env_cls: Any, metadata: dict[str, Any]):
     """Yield a connected env client on a fresh sandbox; delete it after."""
-    task_id = metadata.get("task_id") or metadata.get("task_name")
-    if not task_id:
-        raise ValueError("the sandbox is built for one task: metadata['task_id'] is required")
-    close_fn, url = await _start_task_sandbox(str(task_id))
-    try:
-        async with env_cls(base_url=url, message_timeout_s=oaf._MESSAGE_TIMEOUT_S) as env:
-            yield env
-    finally:
-        try:
-            await asyncio.to_thread(close_fn)
-        except Exception as e:
-            logger.warning(f"Failed to delete sandbox for {task_id}: {e}")
+    async with common.episode_env(env_cls, metadata, start=_start_task_sandbox, logger=logger) as env:
+        yield env
 
 
 async def _sandbox_run_body(env_cls: Any, metadata: dict[str, Any], body: Any) -> Any:

--- a/examples/experimental/openenv/openenv_e2b_agent_function.py
+++ b/examples/experimental/openenv/openenv_e2b_agent_function.py
@@ -1,0 +1,176 @@
+"""E2B-sandbox variant of the OpenEnv tbench2 agent function.
+
+A drop-in alternative to ``openenv_agent_function.run`` for
+``--custom-agent-function-path``: instead of sharing one env server
+(OPENENV_ENV_URL), every episode gets its OWN sandbox on an E2B-compatible
+provider — built from the task's OFFICIAL image plus an env server layer,
+killed when the episode ends. The provider is whatever the E2B SDK is pointed
+at: E2B Cloud, or a self-hosted AgentENV deployment
+(https://github.com/kvcache-ai/AgentENV) via E2B_API_URL / E2B_SANDBOX_URL.
+
+The agent loop and training wrapper live in ``openenv_agent_function``
+(sibling module) and are reused unchanged; this module only supplies its own
+``run_episode`` — how an env comes into being (see the episode-wiring note
+there). The image recipe lives in ``tb2_sandbox_recipe`` and its E2B
+materialization in ``tb2_sandbox_e2b``; like the Daytona leg, this variant
+needs the pinned tbench2_env install from the README (canonical test.sh
+scoring and verifier-asset withholding built into the server).
+
+Env vars (the agent-loop ones in ``openenv_agent_function`` apply too):
+  OPENENV_TB2_TASKS_DIR       path to a terminal-bench-2 checkout. Templates
+                    are built once per task under a recipe-digest alias
+                    (first episode of a task pays the build; repeats
+                    warm-start), or pre-baked via the tb2_sandbox_e2b CLI.
+  E2B_API_KEY / E2B_API_KEY_FILE   key supply, mirroring the Daytona leg's
+                    DAYTONA_API_KEY / _FILE contract (file default
+                    ~/.config/e2b/api_key; launchers forward the PATH, never
+                    the value). AgentENV accepts any non-empty key today.
+  E2B_API_URL / E2B_SANDBOX_URL    endpoint overrides read by the SDK itself;
+                    set both to target a self-hosted AgentENV.
+  OPENENV_E2B_CREATE_CONCURRENCY   max in-flight sandbox creates (default 4).
+  OPENENV_E2B_READY_TIMEOUT_S      server-ready wait per sandbox (default 300).
+  OPENENV_E2B_THROTTLE_PATTERNS    extra comma-separated lowercase substrings
+                    classified as retryable throttling/capacity errors —
+                    self-hosted providers surface "at capacity" differently
+                    than E2B Cloud's 429s; extend without a code change.
+  TB2_COMMAND_TIMEOUT_S            per-exec timeout inside the sandbox (default 900).
+"""
+
+import logging
+import os
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import Any
+
+import openenv_agent_function as oaf
+import openenv_sandbox_common as common
+import tb2_sandbox_e2b
+
+logger = logging.getLogger(__name__)
+
+# The sandbox's env server is the tbench2_env baked by the recipe, installed
+# per the README (at or after the huggingface/OpenEnv#1012 merge): canonical
+# tests/test.sh scoring built into `evaluate`, task WORKDIR resolved
+# server-side, verifier assets withheld. The launcher preflight rejects an
+# older install outright, and the shared agent loop's harness-marker guard
+# backstops it per episode.
+#
+# Providers rate-limit or run out of capacity under a fanned-out rollout; cap
+# in-flight creates process-wide and retry throttled ones with jittered
+# exponential backoff.
+_CREATE_CONCURRENCY = int(os.getenv("OPENENV_E2B_CREATE_CONCURRENCY", "4"))
+_CREATE_MAX_RETRIES = int(os.getenv("OPENENV_E2B_CREATE_MAX_RETRIES", "8"))
+_CREATE_BACKOFF_BASE_S = float(os.getenv("OPENENV_E2B_CREATE_BACKOFF_BASE_S", "2.0"))
+_CREATE_BACKOFF_CAP_S = float(os.getenv("OPENENV_E2B_CREATE_BACKOFF_CAP_S", "30.0"))
+_READY_TIMEOUT_S = float(os.getenv("OPENENV_E2B_READY_TIMEOUT_S", "300"))
+_COMMAND_TIMEOUT_S = int(os.getenv("TB2_COMMAND_TIMEOUT_S", "900"))
+
+_get_create_sem = common.lazy_semaphore(_CREATE_CONCURRENCY)
+
+
+def _extra_throttle_patterns() -> tuple[str, ...]:
+    raw = os.getenv("OPENENV_E2B_THROTTLE_PATTERNS", "")
+    return tuple(p.strip().lower() for p in raw.split(",") if p.strip())
+
+
+def _is_throttle_error(exc: BaseException) -> bool:
+    """True when a sandbox create failed only because the provider throttled it.
+
+    The SDK types HTTP 429 as RateLimitException; the text match covers
+    proxies and self-hosted servers whose limits only surface as text, and
+    OPENENV_E2B_THROTTLE_PATTERNS extends the set for provider-specific
+    capacity errors (e.g. a full AgentENV node pool) without a code change.
+    """
+    # In-function import, deliberately: this is the class's only use site, it
+    # only runs on the failure path (where e2b is already in sys.modules,
+    # having just raised `exc`), and offline tests must not require the SDK.
+    try:
+        from e2b.exceptions import RateLimitException
+
+        if isinstance(exc, RateLimitException):
+            return True
+    except ImportError:  # pragma: no cover - only without the e2b SDK
+        pass
+    s = str(exc).lower()
+    if "too many requests" in s or "429" in s or "rate limit" in s:
+        return True
+    return any(p in s for p in _extra_throttle_patterns())
+
+
+def _start_sandbox(task_id: str, tasks_dir: str) -> tuple[Any, str]:
+    sandbox, url = tb2_sandbox_e2b.create_task_sandbox(
+        Path(tasks_dir) / task_id,
+        command_timeout_s=_COMMAND_TIMEOUT_S,
+        ready_timeout_s=_READY_TIMEOUT_S,
+    )
+    return (lambda: tb2_sandbox_e2b.kill_sandbox(sandbox)), url
+
+
+async def _start_task_sandbox(task_id: str) -> tuple[Any, str]:
+    """Create one sandbox for *task_id* with the env server running.
+
+    Returns (close_fn, base_url); close_fn kills the sandbox. The
+    orchestration — cancel-safe create, process-wide throttling, backoff on
+    provider rate limits — is the provider-blind skeleton in
+    ``openenv_sandbox_common``; this leg contributes only its start hook and
+    throttle classifier.
+    """
+    return await common.start_task_sandbox(
+        task_id,
+        os.getenv("OPENENV_TB2_TASKS_DIR", "").strip(),
+        start_fn=lambda tid, tdir: _start_sandbox(tid, tdir),
+        is_throttle=_is_throttle_error,
+        sem=_get_create_sem(),
+        max_retries=_CREATE_MAX_RETRIES,
+        backoff_base_s=_CREATE_BACKOFF_BASE_S,
+        backoff_cap_s=_CREATE_BACKOFF_CAP_S,
+        logger=logger,
+        provider="E2B",
+    )
+
+
+@asynccontextmanager
+async def _episode_env(env_cls: Any, metadata: dict[str, Any]):
+    """Yield a connected env client on a fresh sandbox; kill it after."""
+    async with common.episode_env(env_cls, metadata, start=_start_task_sandbox, logger=logger) as env:
+        yield env
+
+
+async def _sandbox_run_body(env_cls: Any, metadata: dict[str, Any], body: Any) -> Any:
+    """Run *body* on a fresh sandbox for the episode's task."""
+    async with _episode_env(env_cls, metadata) as env:
+        return await body(env)
+
+
+async def run_episode(
+    policy: Any,
+    model_name: str,
+    messages: list[dict[str, str]],
+    request_kwargs: dict[str, Any],
+    metadata: dict[str, Any],
+) -> tuple[float | None, dict[str, Any]]:
+    """One episode in its own E2B sandbox, with the caller's own policy.
+    Direct-drive entry, same contract as openenv_agent_function's.
+
+    No post-episode hygiene: the sandbox is killed when the episode ends.
+    """
+    return await oaf._multi_turn(
+        oaf._load_tbench2(),
+        policy,
+        model_name,
+        messages,
+        request_kwargs,
+        metadata,
+        run_body=_sandbox_run_body,
+    )
+
+
+async def run(
+    base_url: str,
+    prompt: Any,
+    request_kwargs: dict[str, Any] | None = None,
+    metadata: dict[str, Any] | None = None,
+    **kwargs,
+) -> dict[str, Any] | None:
+    """Run one OpenEnv tbench2 episode in its own E2B sandbox."""
+    return await oaf._run_for_training(base_url, prompt, request_kwargs, metadata, run_episode)

--- a/examples/experimental/openenv/openenv_launch_common.py
+++ b/examples/experimental/openenv/openenv_launch_common.py
@@ -9,11 +9,14 @@ those launchers cannot silently drift apart. Each launcher keeps only its own
 perf/sglang/misc profile and its ``ScriptArgs`` defaults.
 """
 
+import importlib
 import os
 import subprocess
 import time
 from pathlib import Path
 from typing import Protocol
+
+import openenv_sandbox_common as sandbox_common
 
 
 class LaunchArgs(Protocol):
@@ -30,7 +33,9 @@ class LaunchArgs(Protocol):
     openenv_max_turns: int
     openenv_max_rollout_time_seconds: int
     openenv_tb2_tasks_dir: str
+    openenv_sandbox_backend: str
     daytona_api_key_file: str
+    e2b_api_key_file: str
     router_external_host: str
     miles_host_ip: str
 
@@ -100,12 +105,42 @@ def optimizer_args() -> str:
     )
 
 
-def agent_args(tito_model: str, daytona_sandboxes: bool = False) -> str:
+def resolve_sandbox_backend(args: LaunchArgs) -> str:
+    """The per-episode sandbox backend in effect: "" (shared env server),
+    "daytona", or "e2b".
+
+    Names and aliases resolve through openenv_sandbox_common, the canonical
+    registry: "agentenv" is an accepted alias for "e2b", because AgentENV
+    (https://github.com/kvcache-ai/AgentENV) is a self-hosted Firecracker
+    microVM platform whose native API is the E2B API, so it runs on the e2b
+    leg with E2B_API_URL/E2B_SANDBOX_URL pointed at it.
+
+    The two settings that turn this mode on come as a pair — a task checkout
+    to build images from, and the provider to build them on — so naming one
+    without the other is an error rather than a guess.
+    """
+    raw = (getattr(args, "openenv_sandbox_backend", "") or "").strip()
+    tasks_dir = args.openenv_tb2_tasks_dir
+    if not raw and not tasks_dir:
+        return ""
+    if not tasks_dir:
+        raise ValueError(
+            "sandbox backends build per-task images: set openenv_tb2_tasks_dir to a terminal-bench-2 checkout"
+        )
+    if not raw:
+        raise ValueError(
+            "openenv_tb2_tasks_dir selects per-episode sandboxes: set openenv_sandbox_backend "
+            "(OPENENV_SANDBOX_BACKEND) to the provider to run them on"
+        )
+    return sandbox_common.resolve_backend(raw)
+
+
+def agent_args(tito_model: str, sandbox_backend: str = "") -> str:
     """Agentic-rollout wiring. The TITO surface differs across models; the
     agent function decides where episodes run — the shared env server by
-    default, Daytona sandboxes (openenv_daytona_agent_function)
-    when the launcher runs with openenv_tb2_tasks_dir set."""
-    agent_fn = "openenv_daytona_agent_function.run" if daytona_sandboxes else "openenv_agent_function.run"
+    default, per-episode sandboxes (Daytona or E2B/AgentENV) when the launcher
+    resolves a sandbox backend (see resolve_sandbox_backend)."""
+    agent_fn = sandbox_common.AGENT_FUNCTIONS.get(sandbox_backend, "openenv_agent_function.run")
     return (
         "--custom-generate-function-path miles.rollout.generate_hub.agentic_tool_call.generate "
         f"--custom-agent-function-path {agent_fn} "
@@ -158,69 +193,51 @@ def apply_optional_env_vars(env: dict[str, str], args: LaunchArgs) -> None:
         env["MILES_HOST_IP"] = args.miles_host_ip
     if args.router_external_host:
         env["MILES_ROUTER_EXTERNAL_HOST"] = args.router_external_host
-    if args.openenv_tb2_tasks_dir:
-        # Key-supply contract (kept deliberately general): rollout workers get
-        # the Daytona key from their OWN environment (DAYTONA_API_KEY, e.g.
-        # platform-injected) or from a file they can read (DAYTONA_API_KEY_FILE,
-        # default ~/.config/daytona/api_key — a dotfile, K8s Secret mount, or
-        # shared-FS path). The launcher forwards only the file PATH, never the
-        # value: worker env rides ray's runtime_env, which exec_command echoes
-        # into driver logs and ray persists in job metadata, all in plaintext.
-        key_file = Path(args.daytona_api_key_file or "~/.config/daytona/api_key").expanduser()
-        try:
-            key_present = bool(key_file.read_text(encoding="utf-8").strip())
-        except OSError:
-            key_present = False
-        # Either supply is fine; neither is fully verifiable from here (the
-        # launcher cannot probe worker nodes), so echo which one is in effect.
-        if key_present:
-            env["DAYTONA_API_KEY_FILE"] = str(key_file)
-            print(
-                f"openenv: Daytona key supply: file {key_file} "
-                "(readable here; forwarding the path, workers read it themselves)",
-                flush=True,
+    backend = resolve_sandbox_backend(args)
+    if backend:
+        if backend == "daytona":
+            _sandbox_key_supply(
+                env,
+                provider="Daytona",
+                key_env_var="DAYTONA_API_KEY",
+                file_env_var="DAYTONA_API_KEY_FILE",
+                arg_path=args.daytona_api_key_file,
+                default_path="~/.config/daytona/api_key",
+                provision_hint="mkdir -p ~/.config/daytona && echo dtn_... > ~/.config/daytona/api_key",
             )
-        elif args.daytona_api_key_file:
-            # An explicitly configured path that doesn't resolve on the launcher
-            # is a config error; failing every episode later is far worse.
-            raise ValueError(f"DAYTONA_API_KEY_FILE={args.daytona_api_key_file} is missing or empty")
-        elif os.environ.get("DAYTONA_API_KEY", "").strip():
-            print(
-                "openenv: Daytona key supply: worker environment (DAYTONA_API_KEY "
-                "is set here; workers are assumed to have it in their own env — "
-                "single-host inheritance or platform-injected pod env)",
-                flush=True,
+            _preflight_sdk("daytona", "pip install daytona (or pip install -e '<OpenEnv>/envs/tbench2_env[daytona]')")
+        else:  # e2b (E2B Cloud or a self-hosted AgentENV endpoint)
+            _sandbox_key_supply(
+                env,
+                provider="E2B",
+                key_env_var="E2B_API_KEY",
+                file_env_var="E2B_API_KEY_FILE",
+                arg_path=args.e2b_api_key_file,
+                default_path="~/.config/e2b/api_key",
+                provision_hint="mkdir -p ~/.config/e2b && echo <key> > ~/.config/e2b/api_key"
+                "  # AgentENV accepts any non-empty key today",
             )
-        else:
-            raise ValueError(
-                "the Daytona sandbox mode needs an API key: put it in a file "
-                f"({key_file}; DAYTONA_API_KEY_FILE overrides) or in the "
-                "environment as DAYTONA_API_KEY. Provision the file with:\n"
-                "  mkdir -p ~/.config/daytona && echo dtn_... > ~/.config/daytona/api_key"
-            )
-        # Preflight the lazily-imported SDK. Without this, a missing install only
-        # surfaces inside each episode's sandbox start, where the failed sample is
-        # aborted, the group dropped, and the rollout loop refills forever — a
-        # silent GPU-burning churn instead of a launch-time error.
-        try:
-            import daytona  # noqa: F401
-        except ImportError as e:
-            raise RuntimeError(
-                "the Daytona sandbox mode needs the daytona SDK in the rollout "
-                "process's environment: pip install daytona "
-                "(or pip install -e '<OpenEnv>/envs/tbench2_env[daytona]')"
-            ) from e
-        # Same preflight for the env package the recipe bakes into each task
-        # image. The import check catches a missing install; the source probe
-        # catches an install that imports fine but lacks the server features
-        # the sandbox leg scores through (canonical tests/test.sh evaluate,
-        # TB2_WITHHOLD_TESTS) — that one would not even fail per-episode, it
-        # would silently mis-score every episode.
+            _preflight_sdk("e2b", "pip install e2b")
+            # Endpoint overrides are read from the environment by the SDK on
+            # every worker; forward them (they are addresses, not secrets).
+            # E2B_API_URL unset means E2B Cloud; set, it usually points at a
+            # self-hosted AgentENV deployment.
+            for var in ("E2B_API_URL", "E2B_SANDBOX_URL", "E2B_DOMAIN", "OPENENV_E2B_URL_SCHEME"):
+                if os.environ.get(var, "").strip():
+                    env[var] = os.environ[var].strip()
+            endpoint = env.get("E2B_API_URL", "E2B Cloud (default)")
+            print(f"openenv: E2B endpoint: {endpoint}", flush=True)
+        # Preflight the env package the recipe bakes into each task image —
+        # shared by every sandbox backend. The import check catches a missing
+        # install; the source probe catches an install that imports fine but
+        # lacks the server features the sandbox legs score through (canonical
+        # tests/test.sh evaluate, TB2_WITHHOLD_TESTS) — that one would not
+        # even fail per-episode, it would silently mis-score every episode.
         try:
             import tbench2_env
         except ImportError as e:
             raise RuntimeError(
-                "the Daytona sandbox mode needs tbench2_env in the rollout "
+                "the sandbox modes need tbench2_env in the rollout "
                 "process's environment: pip install -e '<OpenEnv>/envs/tbench2_env' "
                 "from the checkout described in this directory's README"
             ) from e
@@ -234,3 +251,66 @@ def apply_optional_env_vars(env: dict[str, str], args: LaunchArgs) -> None:
                 "(04d259ea6) — see this directory's README"
             )
         env["OPENENV_TB2_TASKS_DIR"] = args.openenv_tb2_tasks_dir
+
+
+def _sandbox_key_supply(
+    env: dict[str, str],
+    *,
+    provider: str,
+    key_env_var: str,
+    file_env_var: str,
+    arg_path: str,
+    default_path: str,
+    provision_hint: str,
+) -> None:
+    """Key-supply contract, shared by the sandbox backends: rollout workers
+    get the provider key from their OWN environment (e.g. platform-injected)
+    or from a file they can read (a dotfile, K8s Secret mount, or shared-FS
+    path). The launcher forwards only the file PATH, never the value: worker
+    env rides ray's runtime_env, which exec_command echoes into driver logs
+    and ray persists in job metadata, all in plaintext."""
+    key_file = Path(arg_path or default_path).expanduser()
+    try:
+        key_present = bool(key_file.read_text(encoding="utf-8").strip())
+    except OSError:
+        key_present = False
+    # Either supply is fine; neither is fully verifiable from here (the
+    # launcher cannot probe worker nodes), so echo which one is in effect.
+    if key_present:
+        env[file_env_var] = str(key_file)
+        print(
+            f"openenv: {provider} key supply: file {key_file} "
+            "(readable here; forwarding the path, workers read it themselves)",
+            flush=True,
+        )
+    elif arg_path:
+        # An explicitly configured path that doesn't resolve on the launcher
+        # is a config error; failing every episode later is far worse.
+        raise ValueError(f"{file_env_var}={arg_path} is missing or empty")
+    elif os.environ.get(key_env_var, "").strip():
+        print(
+            f"openenv: {provider} key supply: worker environment ({key_env_var} "
+            "is set here; workers are assumed to have it in their own env — "
+            "single-host inheritance or platform-injected pod env)",
+            flush=True,
+        )
+    else:
+        raise ValueError(
+            f"the {provider} sandbox mode needs an API key: put it in a file "
+            f"({key_file}; {file_env_var} overrides) or in the "
+            f"environment as {key_env_var}. Provision the file with:\n"
+            f"  {provision_hint}"
+        )
+
+
+def _preflight_sdk(module: str, install_hint: str) -> None:
+    """Preflight the lazily-imported provider SDK. Without this, a missing
+    install only surfaces inside each episode's sandbox start, where the
+    failed sample is aborted, the group dropped, and the rollout loop refills
+    forever — a silent GPU-burning churn instead of a launch-time error."""
+    try:
+        importlib.import_module(module)
+    except ImportError as e:
+        raise RuntimeError(
+            f"this sandbox mode needs the {module} SDK in the rollout process's environment: {install_hint}"
+        ) from e

--- a/examples/experimental/openenv/openenv_sandbox_common.py
+++ b/examples/experimental/openenv/openenv_sandbox_common.py
@@ -1,0 +1,173 @@
+"""Shared per-episode sandbox orchestration for the provider agent functions.
+
+A provider leg (``openenv_daytona_agent_function``, ``openenv_e2b_agent_function``)
+owns only what is genuinely provider-specific: how ONE sandbox with the env
+server comes into being (its ``tb2_sandbox_*`` materialization module), which
+errors count as retryable throttling, and its env-var knobs. Everything that
+makes per-episode sandboxes safe under a fanned-out rollout is provider-blind
+and lives here once:
+
+  ``create_once``          cancel-safe create. ``asyncio.to_thread`` is not
+                cancellable: when an episode's wall-clock cap cancels the
+                coroutine mid-create, the worker thread keeps running and its
+                (close_fn, url) result would be discarded — leaking a sandbox
+                until the provider-side TTL backstop reclaims it. The result
+                is recorded thread-side and, on cancellation, handed to a
+                reaper that closes the orphan promptly once the create
+                finishes.
+  ``lazy_semaphore``       the create-throttle semaphore each leg passes in,
+                built on first use rather than at import.
+  ``start_task_sandbox``   process-wide create throttling (the caller's
+                semaphore) plus jittered exponential backoff on the errors the
+                caller classifies as throttling; anything else propagates
+                immediately. The semaphore is held only for the create attempt
+                and released during backoff so other episodes keep the
+                pipeline full.
+  ``episode_env``          async context manager mirroring one episode's
+                lifetime: fresh sandbox -> connected env client -> close.
+"""
+
+import asyncio
+import logging
+import random
+import threading
+from collections.abc import Awaitable, Callable
+from contextlib import asynccontextmanager
+from typing import Any
+
+# A provider's "start one sandbox" hook: (task_id, tasks_dir) -> (close_fn, base_url).
+StartFn = Callable[[str, str], tuple[Callable[[], None], str]]
+
+# The canonical per-episode backend registry — the launcher and the sibling
+# tools (scan_golden, eval_tbench2_via_api) all resolve through here, so the
+# accepted names and the "agentenv is the e2b leg" aliasing cannot drift.
+AGENT_FUNCTIONS = {
+    "daytona": "openenv_daytona_agent_function.run",
+    "e2b": "openenv_e2b_agent_function.run",
+}
+_ALIASES = {"agentenv": "e2b"}
+
+
+def resolve_backend(name: str | None) -> str:
+    """Normalize a backend name; reject unknown and missing ones alike.
+
+    There is deliberately no default. Which provider runs decides whose quota
+    an entire rollout spends and which credentials must be present, so a name
+    left out is a question to answer rather than one to guess at.
+    """
+    backend = (name or "").strip().lower()
+    allowed = ", ".join(sorted([*AGENT_FUNCTIONS, *_ALIASES]))
+    if not backend:
+        raise ValueError(f"no sandbox backend named; choose one of: {allowed}")
+    backend = _ALIASES.get(backend, backend)
+    if backend not in AGENT_FUNCTIONS:
+        raise ValueError(f"unknown sandbox backend {name!r}; choose one of: {allowed}")
+    return backend
+
+
+def lazy_semaphore(limit: int) -> Callable[[], asyncio.Semaphore]:
+    """Return a getter for a *limit*-slot semaphore created on first call.
+
+    A leg reads its concurrency knob at import, but a semaphore constructed
+    then would belong to whatever loop happens to be current — the rollout
+    loop does not exist yet. Deferring construction to the first episode ties
+    it to the loop that actually awaits on it.
+    """
+    holder: list[asyncio.Semaphore] = []
+
+    def get() -> asyncio.Semaphore:
+        if not holder:
+            holder.append(asyncio.Semaphore(limit))
+        return holder[0]
+
+    return get
+
+
+async def create_once(start_fn: StartFn, task_id: str, tasks_dir: str, *, logger: logging.Logger) -> tuple[Any, str]:
+    """One sandbox-create attempt, safe against cancellation mid-create."""
+    result: list[tuple[Any, str]] = []
+    done = threading.Event()
+
+    def _start() -> tuple[Any, str]:
+        try:
+            result.append(start_fn(task_id, tasks_dir))
+        finally:
+            done.set()
+        return result[0]
+
+    try:
+        return await asyncio.to_thread(_start)
+    except asyncio.CancelledError:
+
+        def _reap() -> None:
+            done.wait()
+            for close_fn, _url in result:
+                try:
+                    close_fn()
+                    logger.info(f"Closed sandbox orphaned by cancelled episode: {task_id}")
+                except Exception as e:
+                    logger.warning(f"Failed to close orphaned sandbox for {task_id}: {e}")
+
+        threading.Thread(target=_reap, name=f"tb2-sandbox-reap-{task_id}", daemon=True).start()
+        raise
+
+
+async def start_task_sandbox(
+    task_id: str,
+    tasks_dir: str,
+    *,
+    start_fn: StartFn,
+    is_throttle: Callable[[BaseException], bool],
+    sem: asyncio.Semaphore,
+    max_retries: int,
+    backoff_base_s: float,
+    backoff_cap_s: float,
+    logger: logging.Logger,
+    provider: str,
+) -> tuple[Any, str]:
+    """Create one sandbox for *task_id* with the env server running.
+
+    Returns (close_fn, base_url). Creation is throttled process-wide and
+    retried with jittered exponential backoff on throttle errors.
+    """
+    attempt = 0
+    while True:
+        try:
+            async with sem:
+                return await create_once(start_fn, task_id, tasks_dir, logger=logger)
+        except Exception as e:
+            if not is_throttle(e) or attempt >= max_retries:
+                raise
+            attempt += 1
+            delay = min(backoff_cap_s, backoff_base_s * (2 ** (attempt - 1))) * (0.5 + random.random())
+            logger.warning(
+                f"{provider} create throttled for {task_id} (attempt {attempt}/{max_retries}); retrying in {delay:.1f}s"
+            )
+            await asyncio.sleep(delay)
+
+
+@asynccontextmanager
+async def episode_env(
+    env_cls: Any,
+    metadata: dict[str, Any],
+    *,
+    start: Callable[[str], Awaitable[tuple[Any, str]]],
+    logger: logging.Logger,
+):
+    """Yield a connected env client on a fresh sandbox; close it after."""
+    # Imported lazily so provider CLIs (bake) don't drag in the agent loop's
+    # dependencies (openai) just to reach this module's registry.
+    import openenv_agent_function as oaf
+
+    task_id = metadata.get("task_id") or metadata.get("task_name")
+    if not task_id:
+        raise ValueError("the sandbox is built for one task: metadata['task_id'] is required")
+    close_fn, url = await start(str(task_id))
+    try:
+        async with env_cls(base_url=url, message_timeout_s=oaf._MESSAGE_TIMEOUT_S) as env:
+            yield env
+    finally:
+        try:
+            await asyncio.to_thread(close_fn)
+        except Exception as e:
+            logger.warning(f"Failed to close sandbox for {task_id}: {e}")

--- a/examples/experimental/openenv/run-openenv-tbench2.py
+++ b/examples/experimental/openenv/run-openenv-tbench2.py
@@ -1,8 +1,9 @@
 """OpenEnv Terminal-Bench-2 (tbench2) learning launcher (GLM-4.7-Flash).
 
 Drives the OpenEnv tbench2 env via ``openenv_agent_function.run`` (shared env
-server) or ``openenv_daytona_agent_function.run`` (Daytona sandboxes;
-selected automatically when ``openenv_tb2_tasks_dir`` is set). tbench2 is
+server) or a per-episode sandbox agent function (set ``openenv_tb2_tasks_dir``
+plus ``--openenv-sandbox-backend daytona``, or ``e2b``/``agentenv`` for an
+E2B-compatible provider). tbench2 is
 *multi-turn*: the adapter runs an agentic loop (reset(task_id) -> {policy emits a
 shell command -> step(exec) -> feed output back} -> evaluate) and the reward is
 the binary pytest result (1.0 all tests pass, else 0.0).
@@ -89,7 +90,13 @@ class ScriptArgs(U.ExecuteTrainConfig):
     # path). Only the file PATH is ever forwarded — a key value in ray
     # runtime_env would be logged in plaintext.
     openenv_tb2_tasks_dir: str = os.environ.get("OPENENV_TB2_TASKS_DIR", "")
+    # Which per-episode sandbox provider runs the tasks_dir episodes:
+    # "daytona", "e2b" (E2B Cloud), or "agentenv" (alias for e2b — a
+    # self-hosted AgentENV deployment reached via E2B_API_URL/E2B_SANDBOX_URL).
+    # Required whenever openenv_tb2_tasks_dir is set; there is no default.
+    openenv_sandbox_backend: str = os.environ.get("OPENENV_SANDBOX_BACKEND", "")
     daytona_api_key_file: str = os.environ.get("DAYTONA_API_KEY_FILE", "")
+    e2b_api_key_file: str = os.environ.get("E2B_API_KEY_FILE", "")
     # When set, miles dumps full per-episode agent trajectories (tokens, logprobs,
     # loss masks, reward, multi-turn messages) to <dir>/rollout_data/{rollout_id}.pt
     # for post-hoc inspection via miles.utils.debug_utils.display_debug_rollout_data.
@@ -165,7 +172,7 @@ def execute(args: ScriptArgs):
         "--sglang-router-port 31000 "
     )
 
-    agent_args = C.agent_args("glm47", daytona_sandboxes=bool(args.openenv_tb2_tasks_dir))
+    agent_args = C.agent_args("glm47", sandbox_backend=C.resolve_sandbox_backend(args))
 
     misc_args = (
         "--attention-dropout 0.0 "

--- a/examples/experimental/openenv/scan_golden.py
+++ b/examples/experimental/openenv/scan_golden.py
@@ -1,5 +1,6 @@
 """Golden-patch sweep: for each TB2 task, run the OFFICIAL solution/solve.sh in
-its own Daytona sandbox and score with the standard evaluate action. Expected
+its own per-episode sandbox (OPENENV_SANDBOX_BACKEND selects the provider) and
+score with the standard evaluate action. Expected
 mostly 1.0 — this validates the infra (env + scoring) per task, no LLM involved.
 
 ``--logs`` additionally captures solve.log and test-log tails for every task
@@ -25,7 +26,19 @@ import tomllib
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import openenv_agent_function as oaf
-import openenv_daytona_agent_function as odaf
+
+# The sandbox leg to replay through — resolved by the same registry the
+# launcher uses, so a missing or unknown provider is an error here too.
+import openenv_sandbox_common as sandbox_common
+
+try:
+    _BACKEND = sandbox_common.resolve_backend(os.getenv("OPENENV_SANDBOX_BACKEND"))
+except ValueError as e:
+    sys.exit(str(e))
+if _BACKEND == "e2b":
+    import openenv_e2b_agent_function as sandbox_leg
+else:
+    import openenv_daytona_agent_function as sandbox_leg
 
 CAP_S = float(os.getenv("GOLDEN_TASK_CAP_S", "1800"))
 
@@ -62,7 +75,7 @@ async def golden_one(task_id: str, capture_logs: bool = False) -> tuple[str, flo
     try:
 
         async def run() -> dict:
-            async with odaf._episode_env(classes["env"], {"task_id": task_id}) as env:
+            async with sandbox_leg._episode_env(classes["env"], {"task_id": task_id}) as env:
                 await env.reset(task_id=task_id)
                 t = time.monotonic()
                 # Official oracle convention (harbor OracleAgent): solution dir
@@ -134,12 +147,12 @@ async def main() -> None:
     ap.add_argument("--out", default="")
     ap.add_argument("--logs", action="store_true", help="capture solve.log/test-log tails for tasks scoring <1.0")
     args = ap.parse_args()
-    # Golden replay only exists on the Daytona sandbox mode; fail fast so
+    # Golden replay only exists on the per-episode sandbox mode; fail fast so
     # golden_one can read OPENENV_TB2_TASKS_DIR unconditionally.
     if not os.getenv("OPENENV_TB2_TASKS_DIR", "").strip():
         sys.exit(
-            "scan_golden requires the Daytona sandbox mode: set OPENENV_TB2_TASKS_DIR "
-            "(+ DAYTONA_API_KEY or a key file at ~/.config/daytona/api_key)"
+            "scan_golden requires the per-episode sandbox mode: set OPENENV_TB2_TASKS_DIR "
+            "and OPENENV_SANDBOX_BACKEND (daytona/e2b/agentenv), plus that provider's credentials"
         )
     tasks = [t.strip() for t in args.tasks.split(",") if t.strip()]
     print(f"golden sweep | {len(tasks)} tasks | concurrency={args.concurrency}", flush=True)

--- a/examples/experimental/openenv/tb2_sandbox_daytona.py
+++ b/examples/experimental/openenv/tb2_sandbox_daytona.py
@@ -22,16 +22,15 @@ nothing a create passes can name a pre-registered snapshot — registering one
 per task would only spend the org quota the declarative path exists to avoid.
 """
 
-import getpass
 import os
 import shlex
-import threading
-import time
 from pathlib import Path
 
+import tb2_sandbox_recipe as recipe
 from tb2_sandbox_recipe import (
     read_task_config,
     resolve_docker_image,
+    sandbox_labels,
     server_cmd,
     server_layer_commands,
     wait_server_ready,
@@ -64,31 +63,6 @@ def task_resources(task_dir: Path):
     )
 
 
-def sandbox_labels(task_dir: Path) -> dict[str, str]:
-    """Labels for a per-task sandbox: what it runs, and who launched it.
-
-    The Daytona API records no creator, so in a shared org labels are the only
-    attribution. ``openenv-tbench2-task`` keys sweep/cleanup tooling to exactly
-    the sandboxes this recipe created (shared orgs run other workloads).
-    ``openenv-launcher`` is OPENENV_LAUNCHER when set — do set it on shared
-    hosts, where the unix user is a generic account — else the local unix
-    user. ``openenv-run-id`` (OPENENV_RUN_ID, optional) additionally groups
-    one run's sandboxes for targeted sweeps.
-    """
-    try:
-        user = getpass.getuser()
-    except Exception:  # no passwd entry / login env on minimal hosts
-        user = "unknown"
-    labels = {
-        "openenv-tbench2-task": task_dir.name,
-        "openenv-launcher": os.environ.get("OPENENV_LAUNCHER") or user,
-    }
-    run_id = os.environ.get("OPENENV_RUN_ID")
-    if run_id:
-        labels["openenv-run-id"] = run_id
-    return labels
-
-
 # Keepalive cadence: 6 beats per 30-minute auto-stop window, and up to 3
 # consecutive failed beats (15 minutes of API blips) tolerated before the
 # thread concludes the sandbox is gone and exits.
@@ -102,23 +76,14 @@ def _start_keepalive(sandbox, task_id: str) -> None:
     Daytona's auto-stop clock counts only SDK interactions — preview-proxy
     traffic, which is ALL of an episode's I/O, does not reset it — so without
     a heartbeat any healthy episode longer than the auto-stop interval would
-    be stopped mid-run. A daemon thread has exactly the right lifetime: it
-    dies with the process, which is what turns auto-stop into a dead-man's
-    switch for orphans. The thread exits once refreshes fail persistently
-    (the normal case: the episode ended and the caller deleted the sandbox).
-    """
-
-    def _beat() -> None:
-        failures = 0
-        while failures < _KEEPALIVE_MAX_CONSECUTIVE_FAILURES:
-            time.sleep(_KEEPALIVE_INTERVAL_S)
-            try:
-                sandbox.refresh_activity()
-                failures = 0
-            except Exception:
-                failures += 1
-
-    threading.Thread(target=_beat, name=f"tb2-sandbox-keepalive-{task_id}", daemon=True).start()
+    be stopped mid-run (see recipe.start_keepalive for the dead-man's-switch
+    lifetime contract)."""
+    recipe.start_keepalive(
+        sandbox.refresh_activity,
+        f"tb2-sandbox-keepalive-{task_id}",
+        interval_s=_KEEPALIVE_INTERVAL_S,
+        max_consecutive_failures=_KEEPALIVE_MAX_CONSECUTIVE_FAILURES,
+    )
 
 
 def create_task_sandbox(
@@ -175,27 +140,9 @@ _DEFAULT_API_KEY_FILE = "~/.config/daytona/api_key"
 
 
 def resolve_api_key() -> str:
-    """The Daytona API key: DAYTONA_API_KEY, else the key file.
-
-    The file indirection (DAYTONA_API_KEY_FILE, default
-    ``~/.config/daytona/api_key``) exists so launchers can hand rollout
-    workers a PATH instead of the secret itself: anything a launcher
-    forwards rides ray's runtime_env, which is echoed into driver logs and
-    persisted in job metadata in plaintext. Env vars the worker already has
-    (platform-injected, single-host inheritance) never pass through ray, so
-    DAYTONA_API_KEY is checked first.
-    """
-    key = os.environ.get("DAYTONA_API_KEY", "").strip()
-    if key:
-        return key
-    key_file = Path(os.environ.get("DAYTONA_API_KEY_FILE", "").strip() or _DEFAULT_API_KEY_FILE).expanduser()
-    try:
-        key = key_file.read_text(encoding="utf-8").strip()
-    except OSError:
-        key = ""
-    if not key:
-        raise RuntimeError(f"no Daytona API key: DAYTONA_API_KEY is unset and {key_file} is missing or empty")
-    return key
+    """The Daytona API key: DAYTONA_API_KEY, else the key file (see
+    recipe.resolve_api_key for the file-indirection rationale)."""
+    return recipe.resolve_api_key("DAYTONA_API_KEY", "DAYTONA_API_KEY_FILE", _DEFAULT_API_KEY_FILE)
 
 
 def make_daytona():

--- a/examples/experimental/openenv/tb2_sandbox_e2b.py
+++ b/examples/experimental/openenv/tb2_sandbox_e2b.py
@@ -1,0 +1,293 @@
+"""E2B materialization of the per-task Terminal-Bench-2 sandbox recipe.
+
+The recipe itself — the shell layers that turn a task's official image into a
+combined task+env-server image — lives in ``tb2_sandbox_recipe`` (sibling
+module) and is provider-agnostic. This module is everything E2B-specific about
+turning that recipe into a running cloud sandbox, and it works against any
+server speaking the E2B API:
+
+  * **E2B Cloud** (the default the SDK ships with), or
+  * **a self-hosted `AgentENV <https://github.com/kvcache-ai/AgentENV>`_
+    deployment** — the Firecracker microVM platform whose native API *is* the
+    E2B API. Point ``E2B_API_URL`` (and ``E2B_SANDBOX_URL``) at the AgentENV
+    server and this module needs no code changes; AgentENV currently accepts
+    any non-empty API key.
+
+Unlike Daytona's declarative per-episode image build, E2B separates the two
+halves of a create:
+
+  ``ensure_task_template(...)``  build the per-task template once, under a
+      deterministic alias derived from the task id AND a digest of the recipe
+      itself — so editing the recipe re-bakes automatically instead of
+      silently serving stale templates. Template counts are not quota-bound
+      (self-hosted AgentENV: bound only by snapshot-store capacity).
+  ``create_task_sandbox(...)``  per-episode: warm-start a sandbox from the
+      template, exec ``server_cmd()``, wait for /health, return
+      ``(sandbox, base_url)``. The sandbox carries ownership metadata and a
+      TTL armed as a dead-man's switch: a keepalive thread re-arms the
+      timeout while the creating process lives, so a hard-killed caller's
+      orphans are reclaimed instead of running forever.
+  bake CLI (``python tb2_sandbox_e2b.py ...``)  pre-build templates for a
+      task list so the first training episode doesn't pay the image build.
+
+All e2b imports are lazy (in-function), mirroring ``tb2_sandbox_daytona``:
+offline unit tests and non-sandbox launches must not require the SDK.
+"""
+
+import argparse
+import concurrent.futures
+import hashlib
+import os
+import re
+import shlex
+import sys
+import threading
+from pathlib import Path
+
+import tb2_sandbox_recipe as recipe
+from tb2_sandbox_recipe import (
+    read_task_config,
+    resolve_docker_image,
+    sandbox_labels,
+    server_cmd,
+    server_layer_commands,
+    wait_server_ready,
+)
+
+
+def template_alias(task_dir: Path) -> str:
+    """Deterministic template alias: ``tb2-<task-id>-<recipe digest>``.
+
+    The digest covers the base image, every build command (which embed the
+    tbench2_env source, deterministically tarred — see ``_dir_tar_b64``), and
+    the build resources (E2B sizes sandboxes at template-build time), so the
+    alias changes exactly when the baked artifact would: recipe edits,
+    env-package changes, or a task.toml resource bump re-bake; identical
+    inputs reuse the existing template.
+    """
+    task_dir = Path(task_dir)
+    base = resolve_docker_image(task_dir, None)
+    resources = task_build_resources(task_dir)
+    inputs = [base, *server_layer_commands(task_dir), repr(sorted(resources.items()))]
+    digest = hashlib.sha256("\n".join(inputs).encode()).hexdigest()[:10]
+    slug = re.sub(r"[^a-z0-9-]", "-", task_dir.name.lower())
+    return f"tb2-{slug}-{digest}"
+
+
+def task_build_resources(task_dir: Path) -> dict[str, int]:
+    """Template build resources from ``task.toml [environment]``.
+
+    E2B sizes sandboxes at template-build time (warm starts inherit the
+    template's spec), so the task's requirements go here, not on create.
+    """
+    env_cfg = read_task_config(task_dir).get("environment", {})
+    return {
+        "cpu_count": max(1, int(env_cfg.get("cpus", 1))),
+        "memory_mb": max(2048, int(env_cfg.get("memory_mb", 2048))),
+    }
+
+
+def _connection_opts() -> dict:
+    """Per-call connection kwargs. Only the key is passed explicitly (for the
+    file indirection); endpoint overrides (E2B_API_URL, E2B_SANDBOX_URL,
+    E2B_DOMAIN — e.g. a self-hosted AgentENV) are read from the environment
+    by the SDK itself."""
+    return {"api_key": resolve_api_key()}
+
+
+# One build per alias per process: a rollout fans out many episodes of the
+# same task at once, and every concurrent miss would otherwise start its own
+# multi-minute build. Cross-process dedup is the server's job (build cache).
+_build_locks: dict[str, threading.Lock] = {}
+_build_locks_guard = threading.Lock()
+
+
+def _build_lock(alias: str) -> threading.Lock:
+    with _build_locks_guard:
+        return _build_locks.setdefault(alias, threading.Lock())
+
+
+def ensure_task_template(
+    task_dir: Path,
+    *,
+    force: bool = False,
+    build_timeout_s: float = 1800.0,
+    on_logs=None,
+) -> str:
+    """Build the per-task template if its alias doesn't exist yet; return the alias.
+
+    *build_timeout_s* bounds the build's wall clock. ``Template.build`` blocks
+    across many requests (trigger + log polling), so the deadline is enforced
+    by running it on a scoped thread; on timeout the provider-side build keeps
+    cooking (and may finish), but this caller stops holding the alias lock and
+    the create-semaphore slot.
+    """
+    # In-function import, deliberately: the e2b SDK is an optional dependency
+    # of this recipe (the launcher preflights it), so importing the module
+    # must not require it — the offline tests import this file with a fake
+    # `e2b` in sys.modules, and the Daytona leg defers its SDK the same way.
+    from e2b import Template
+
+    task_dir = Path(task_dir)
+    alias = template_alias(task_dir)
+    with _build_lock(alias):
+        if not force and Template.alias_exists(alias, **_connection_opts()):
+            return alias
+        base = resolve_docker_image(task_dir, None)
+        template = Template().from_image(base)
+        for command in server_layer_commands(task_dir):
+            template = template.run_cmd(command)
+
+        def _build() -> None:
+            Template.build(
+                template,
+                alias,
+                **task_build_resources(task_dir),
+                skip_cache=force,
+                on_build_logs=on_logs,
+                **_connection_opts(),
+            )
+
+        # Not a `with` block: its __exit__ joins the worker, which would wait
+        # out the very build the timeout is meant to abandon.
+        pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+        try:
+            pool.submit(_build).result(timeout=build_timeout_s)
+        finally:
+            pool.shutdown(wait=False)
+    return alias
+
+
+def base_url(sandbox) -> str:
+    """The env server's externally reachable URL on port 8000.
+
+    ``get_host`` yields a per-port hostname routed by the provider's gateway
+    (E2B Cloud, or AgentENV's gateway ``{port}-{sandboxID}.{domain}`` routing
+    — the deployment must have a routing domain configured). The gateway must
+    proxy WebSocket as well as HTTP: OpenEnv's client health-checks over HTTP
+    but runs episode I/O over ``/ws``. OPENENV_E2B_URL_SCHEME (default https)
+    covers plain-HTTP self-hosted gateways.
+    """
+    scheme = os.getenv("OPENENV_E2B_URL_SCHEME", "https")
+    return f"{scheme}://{sandbox.get_host(8000)}"
+
+
+# TTL / keepalive: the sandbox is created with a bounded lifetime and the
+# keepalive thread re-arms it ahead of expiry for as long as THIS process
+# lives — the E2B timeout is kill-on-expiry, which is exactly a dead-man's
+# switch for orphans. 6 beats per window; up to 3 consecutive failed beats
+# (API blips) tolerated before the thread concludes the sandbox is gone.
+_SANDBOX_TTL_S = int(os.getenv("OPENENV_E2B_SANDBOX_TTL_S", "1800"))
+_KEEPALIVE_INTERVAL_S = _SANDBOX_TTL_S / 6.0
+_KEEPALIVE_MAX_CONSECUTIVE_FAILURES = 3
+
+
+def _start_keepalive(sandbox, task_id: str) -> None:
+    """Re-arm the sandbox TTL for as long as THIS process lives.
+
+    A live episode of any length keeps its sandbox; a hard-killed caller
+    (SIGKILL, OOM, node loss) stops beating and the provider kills the
+    sandbox within _SANDBOX_TTL_S of the last beat. The thread exits once
+    re-arms fail persistently (the normal case: the episode ended and the
+    caller killed the sandbox)."""
+    opts = _connection_opts()
+    recipe.start_keepalive(
+        lambda: sandbox.set_timeout(_SANDBOX_TTL_S, **opts),
+        f"tb2-sandbox-keepalive-{task_id}",
+        interval_s=_KEEPALIVE_INTERVAL_S,
+        max_consecutive_failures=_KEEPALIVE_MAX_CONSECUTIVE_FAILURES,
+    )
+
+
+def create_task_sandbox(
+    task_dir: Path,
+    *,
+    command_timeout_s: int = 900,
+    ready_timeout_s: float = 300.0,
+    ttl_s: int | None = None,
+):
+    """Create ONE per-episode sandbox for *task_dir* from its template.
+
+    Returns ``(sandbox, base_url)``. Caller must ``sandbox.kill()`` when the
+    episode ends. First create for a task pays the template build (via
+    ``ensure_task_template``); repeats warm-start from the built template.
+
+    The template deliberately carries no start command: the server is exec'd
+    here so runtime knobs (TB2_COMMAND_TIMEOUT_S) stay runtime — baking them
+    would silently pin them until the next re-bake.
+    """
+    from e2b import Sandbox
+
+    task_dir = Path(task_dir)
+    opts = _connection_opts()
+    alias = ensure_task_template(task_dir)
+    sandbox = Sandbox.create(
+        template=alias,
+        timeout=ttl_s if ttl_s is not None else _SANDBOX_TTL_S,
+        metadata=sandbox_labels(task_dir),
+        **opts,
+    )
+    try:
+        cmd = server_cmd(command_timeout_s, default_task_id=task_dir.name)
+        sandbox.commands.run(
+            f"bash -c {shlex.quote(cmd)} > /tmp/openenv-server.log 2>&1",
+            background=True,
+        )
+        url = base_url(sandbox)
+        wait_server_ready(url, timeout_s=ready_timeout_s)
+        _start_keepalive(sandbox, task_dir.name)
+        return sandbox, url
+    except Exception:
+        sandbox.kill(**opts)
+        raise
+
+
+def kill_sandbox(sandbox) -> None:
+    """Kill a sandbox created here.
+
+    The handle does not carry the endpoint and key its create used, so they
+    have to be supplied again — which is this module's business, not its
+    callers'.
+    """
+    sandbox.kill(**_connection_opts())
+
+
+_DEFAULT_API_KEY_FILE = "~/.config/e2b/api_key"
+
+
+def resolve_api_key() -> str:
+    """The E2B API key: E2B_API_KEY, else the key file (see
+    recipe.resolve_api_key for the file-indirection rationale). AgentENV does
+    not enforce keys today, but recent SDKs validate the format client-side —
+    provision a well-formed one (e2b_ + 40 hex chars)."""
+    return recipe.resolve_api_key("E2B_API_KEY", "E2B_API_KEY_FILE", _DEFAULT_API_KEY_FILE)
+
+
+def bake(tasks_dir: Path, task_id: str, force: bool) -> None:
+    """Pre-build the template for one task (optional warm cache)."""
+    task_dir = tasks_dir / task_id
+    alias = template_alias(task_dir)
+    resources = task_build_resources(task_dir)
+    print(f"[bake] {alias}  cpu={resources['cpu_count']} mem={resources['memory_mb']}MB")
+    ensure_task_template(
+        task_dir,
+        force=force,
+        on_logs=lambda entry: print(f"  | {entry}", flush=True),
+    )
+    print(f"[done] {alias}")
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    recipe.add_task_selection_args(ap)
+    ap.add_argument("--force", action="store_true", help="rebuild even when the alias exists")
+    args = ap.parse_args()
+
+    tasks_dir, task_ids = recipe.selected_task_ids(args)
+
+    for task_id in task_ids:
+        bake(tasks_dir, task_id, args.force)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/experimental/openenv/tb2_sandbox_recipe.py
+++ b/examples/experimental/openenv/tb2_sandbox_recipe.py
@@ -36,12 +36,15 @@ tampers with container binaries could still fake a pass.
 """
 
 import base64
+import getpass
 import gzip
 import io
+import os
 import re
 import shlex
 import subprocess
 import tarfile
+import threading
 import time
 from pathlib import Path
 
@@ -102,6 +105,95 @@ def read_task_config(task_dir: Path) -> dict:
     if not toml_path.is_file():
         raise FileNotFoundError(f"{task_dir}: no task.toml")
     return tomllib.loads(toml_path.read_text())
+
+
+def sandbox_labels(task_dir: Path) -> dict[str, str]:
+    """Ownership labels/metadata for a per-task sandbox: what it runs, and who
+    launched it. Provider-agnostic (Daytona labels, E2B metadata — same keys).
+
+    Sandbox APIs record no creator, so in a shared org/deployment these are
+    the only attribution. ``openenv-tbench2-task`` keys sweep/cleanup tooling
+    to exactly the sandboxes this recipe created (shared orgs run other
+    workloads). ``openenv-launcher`` is OPENENV_LAUNCHER when set — do set it
+    on shared hosts, where the unix user is a generic account — else the local
+    unix user. ``openenv-run-id`` (OPENENV_RUN_ID, optional) additionally
+    groups one run's sandboxes for targeted sweeps.
+    """
+    try:
+        user = getpass.getuser()
+    except Exception:  # no passwd entry / login env on minimal hosts
+        user = "unknown"
+    labels = {
+        "openenv-tbench2-task": task_dir.name,
+        "openenv-launcher": os.environ.get("OPENENV_LAUNCHER") or user,
+    }
+    run_id = os.environ.get("OPENENV_RUN_ID")
+    if run_id:
+        labels["openenv-run-id"] = run_id
+    return labels
+
+
+def resolve_api_key(env_var: str, file_env_var: str, default_path: str) -> str:
+    """A provider API key: *env_var*, else the key file.
+
+    The file indirection (*file_env_var*, default *default_path*) exists so
+    launchers can hand rollout workers a PATH instead of the secret itself:
+    anything a launcher forwards rides ray's runtime_env, which is echoed into
+    driver logs and persisted in job metadata in plaintext. Env vars the
+    worker already has (platform-injected, single-host inheritance) never pass
+    through ray, so *env_var* is checked first.
+    """
+    key = os.environ.get(env_var, "").strip()
+    if key:
+        return key
+    key_file = Path(os.environ.get(file_env_var, "").strip() or default_path).expanduser()
+    try:
+        key = key_file.read_text(encoding="utf-8").strip()
+    except OSError:
+        key = ""
+    if not key:
+        raise RuntimeError(f"no API key: {env_var} is unset and {key_file} is missing or empty")
+    return key
+
+
+def start_keepalive(beat, thread_name: str, *, interval_s: float, max_consecutive_failures: int) -> None:
+    """Run *beat* every *interval_s* for as long as THIS process lives.
+
+    A daemon thread has exactly the right lifetime for a sandbox keepalive: it
+    dies with the process, which is what turns the provider's idle/TTL timer
+    into a dead-man's switch for orphans. The thread exits once beats fail
+    *max_consecutive_failures* times in a row (the normal case: the episode
+    ended and the caller deleted the sandbox).
+    """
+
+    def _run() -> None:
+        failures = 0
+        while failures < max_consecutive_failures:
+            time.sleep(interval_s)
+            try:
+                beat()
+                failures = 0
+            except Exception:
+                failures += 1
+
+    threading.Thread(target=_run, name=thread_name, daemon=True).start()
+
+
+def add_task_selection_args(ap) -> None:
+    """The bake CLIs' shared task selection: --tasks-dir + (--tasks | --all)."""
+    ap.add_argument("--tasks-dir", required=True, help="local terminal-bench-2 checkout")
+    group = ap.add_mutually_exclusive_group(required=True)
+    group.add_argument("--tasks", help="comma-separated task_ids")
+    group.add_argument("--all", action="store_true", help="every dir with a task.toml")
+
+
+def selected_task_ids(args) -> tuple[Path, list[str]]:
+    tasks_dir = Path(args.tasks_dir).expanduser().resolve()
+    if args.all:
+        task_ids = sorted(p.name for p in tasks_dir.iterdir() if (p / "task.toml").is_file())
+    else:
+        task_ids = [t.strip() for t in args.tasks.split(",") if t.strip()]
+    return tasks_dir, task_ids
 
 
 def _tar_filter(tarinfo: tarfile.TarInfo) -> tarfile.TarInfo | None:

--- a/examples/experimental/openenv/tests/test_openenv_e2b_agent_function.py
+++ b/examples/experimental/openenv/tests/test_openenv_e2b_agent_function.py
@@ -1,0 +1,215 @@
+"""Offline unit tests for the E2B-sandbox agent function (no network, no GPU).
+
+Not collected by the repo-level pytest run (testpaths = ./tests); run manually
+when touching the adapter:
+
+    pytest examples/experimental/openenv/tests/ -q
+
+Covers what a live episode cannot cheaply prove:
+  - episode dispatch: this module's run_episode sends raw exec commands and
+    scores via the standard `evaluate` action;
+  - sandbox-create throttling: rate-limit errors (typed, textual, and the
+    OPENENV_E2B_THROTTLE_PATTERNS extension for self-hosted providers) are
+    retried with backoff and a bounded budget, anything else propagates
+    immediately; a cancel mid-create reaps the orphaned sandbox.
+"""
+
+import asyncio
+import sys
+import threading
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import openenv_agent_function as oaf  # noqa: E402
+import openenv_e2b_agent_function as oeaf  # noqa: E402
+from test_openenv_agent_function import _CLASSES, _FakeEnv, _FakePolicy, _FakeResult  # noqa: E402
+
+
+def run_async(coro):
+    """asyncio.run with the module's loop-bound state reset (fresh loop per test)."""
+    oeaf._create_sem = None
+    return asyncio.run(coro)
+
+
+# --- episode dispatch ------------------------------------------------------
+
+
+def test_e2b_leg_dispatch(monkeypatch):
+    """The e2b run_episode: exec raw (server resolves the workdir), scoring
+    via the standard `evaluate` action, no canonical exec, no rm-hack."""
+    monkeypatch.setattr(oaf, "_load_tbench2", lambda: _CLASSES)
+
+    @asynccontextmanager
+    async def fake_episode_env(env_cls, metadata):
+        yield env_cls()
+
+    monkeypatch.setattr(oeaf, "_episode_env", fake_episode_env)
+
+    reward, metrics = run_async(
+        oeaf.run_episode(_FakePolicy(), "m", [{"role": "system", "content": "s"}], {}, {"task_id": "t1"})
+    )
+    actions = _FakeEnv.last_actions
+    execs = [a for a in actions if a.action_type == "exec"]
+
+    assert reward == 1.0
+    assert execs[0].command == "echo hi"
+    assert any(a.action_type == "evaluate" for a in actions)
+    assert not any("test.sh" in (a.command or "") for a in execs)
+    assert not any("/tmp/tbench2_env_runs" in (a.command or "") for a in execs)
+    assert metrics["turns"] == 2 and metrics["tool_calls"] == 1
+
+
+def test_e2b_leg_eval_error_yields_no_verdict(monkeypatch):
+    """A server-side scoring failure (`evaluate` comes back with error set and
+    no reward) surfaces as reward=None -- dropped by the training wrapper --
+    not coerced into a false-negative 0.0."""
+
+    class _EvalErrorEnv(_FakeEnv):
+        async def step(self, action):
+            if action.action_type == "evaluate":
+                self.actions.append(action)
+                res = _FakeResult()
+                res.observation.error = "toolkit timeout"
+                return res
+            return await super().step(action)
+
+    monkeypatch.setattr(oaf, "_load_tbench2", lambda: {"env": _EvalErrorEnv, "action": _CLASSES["action"]})
+
+    @asynccontextmanager
+    async def fake_episode_env(env_cls, metadata):
+        yield env_cls()
+
+    monkeypatch.setattr(oeaf, "_episode_env", fake_episode_env)
+
+    reward, metrics = run_async(
+        oeaf.run_episode(_FakePolicy(), "m", [{"role": "system", "content": "s"}], {}, {"task_id": "t1"})
+    )
+    assert reward is None
+    assert metrics["turns"] == 2  # the episode itself completed; only scoring failed
+
+
+# --- sandbox-create throttling ----------------------------------------------
+
+
+class _Throttled(Exception):
+    def __str__(self):
+        return "rate limit exceeded, please retry"
+
+
+def _patch_fast_backoff(monkeypatch):
+    monkeypatch.setattr(oeaf, "_CREATE_BACKOFF_BASE_S", 0.001)
+    monkeypatch.setattr(oeaf, "_CREATE_BACKOFF_CAP_S", 0.001)
+
+
+def test_create_retries_through_throttling(monkeypatch):
+    """Throttle errors are retried (with backoff) until the create succeeds."""
+    _patch_fast_backoff(monkeypatch)
+    calls = {"n": 0}
+
+    def flaky_start(task_id, tasks_dir):
+        calls["n"] += 1
+        if calls["n"] <= 3:
+            raise _Throttled()
+        return (lambda: None), "http://sandbox:8000"
+
+    monkeypatch.setattr(oeaf, "_start_sandbox", flaky_start)
+    monkeypatch.setenv("OPENENV_TB2_TASKS_DIR", "/nonexistent")
+
+    close_fn, url = run_async(oeaf._start_task_sandbox("t1"))
+    assert url == "http://sandbox:8000"
+    assert calls["n"] == 4  # 3 throttled attempts + 1 success
+
+
+def test_create_gives_up_after_retry_budget(monkeypatch):
+    """A create that is throttled past _CREATE_MAX_RETRIES raises the error."""
+    _patch_fast_backoff(monkeypatch)
+    monkeypatch.setattr(oeaf, "_CREATE_MAX_RETRIES", 2)
+    calls = {"n": 0}
+
+    def always_throttled(task_id, tasks_dir):
+        calls["n"] += 1
+        raise _Throttled()
+
+    monkeypatch.setattr(oeaf, "_start_sandbox", always_throttled)
+    monkeypatch.setenv("OPENENV_TB2_TASKS_DIR", "/nonexistent")
+
+    with pytest.raises(_Throttled):
+        run_async(oeaf._start_task_sandbox("t1"))
+    assert calls["n"] == 3  # initial attempt + 2 retries
+
+
+def test_cancel_during_create_reaps_orphaned_sandbox(monkeypatch):
+    """Cancelling an episode mid-create must not leak the sandbox: the worker
+    thread finishes the create in the background and the reaper kills it."""
+    started = threading.Event()
+    release = threading.Event()
+    closed = threading.Event()
+
+    def slow_start(task_id, tasks_dir):
+        started.set()
+        assert release.wait(5)
+        return (lambda: closed.set()), "http://sandbox:8000"
+
+    monkeypatch.setattr(oeaf, "_start_sandbox", slow_start)
+    monkeypatch.setenv("OPENENV_TB2_TASKS_DIR", "/nonexistent")
+
+    async def scenario():
+        task = asyncio.create_task(oeaf._start_task_sandbox("t1"))
+        await asyncio.to_thread(started.wait, 5)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        # Only now does the in-flight create finish — after the awaiter is gone.
+        release.set()
+
+    run_async(scenario())
+    assert closed.wait(5)  # the reaper killed the orphan
+
+
+def test_create_non_throttle_error_propagates_immediately(monkeypatch):
+    """Anything that is not a rate-limit error must not be retried."""
+    _patch_fast_backoff(monkeypatch)
+    calls = {"n": 0}
+
+    def broken_start(task_id, tasks_dir):
+        calls["n"] += 1
+        raise RuntimeError("template build failed")
+
+    monkeypatch.setattr(oeaf, "_start_sandbox", broken_start)
+    monkeypatch.setenv("OPENENV_TB2_TASKS_DIR", "/nonexistent")
+
+    with pytest.raises(RuntimeError):
+        run_async(oeaf._start_task_sandbox("t1"))
+    assert calls["n"] == 1
+
+
+def test_is_throttle_error_classification(monkeypatch):
+    monkeypatch.delenv("OPENENV_E2B_THROTTLE_PATTERNS", raising=False)
+    assert oeaf._is_throttle_error(_Throttled())
+    assert oeaf._is_throttle_error(Exception("HTTP 429"))
+    assert oeaf._is_throttle_error(Exception("Too Many Requests"))
+    assert not oeaf._is_throttle_error(RuntimeError("template build failed"))
+
+
+def test_is_throttle_error_extra_patterns_env(monkeypatch):
+    """OPENENV_E2B_THROTTLE_PATTERNS extends the retryable set for
+    provider-specific capacity errors (e.g. a full self-hosted AgentENV pool)
+    without a code change."""
+    monkeypatch.delenv("OPENENV_E2B_THROTTLE_PATTERNS", raising=False)
+    assert not oeaf._is_throttle_error(Exception("no node with sufficient capacity"))
+    monkeypatch.setenv("OPENENV_E2B_THROTTLE_PATTERNS", "sufficient capacity, at capacity")
+    assert oeaf._is_throttle_error(Exception("no node with sufficient capacity"))
+    assert oeaf._is_throttle_error(Exception("cluster AT CAPACITY"))
+    assert not oeaf._is_throttle_error(RuntimeError("template build failed"))
+
+
+def test_is_throttle_error_typed_e2b_class():
+    """The SDK's typed rate-limit error is recognized even when its message
+    carries no throttle keywords; sibling error classes are not."""
+    ex = pytest.importorskip("e2b.exceptions")
+    assert oeaf._is_throttle_error(ex.RateLimitException("slow down"))
+    assert not oeaf._is_throttle_error(ex.AuthenticationException("bad key"))

--- a/examples/experimental/openenv/tests/test_openenv_sandbox_common.py
+++ b/examples/experimental/openenv/tests/test_openenv_sandbox_common.py
@@ -1,0 +1,46 @@
+"""Offline unit tests for the shared sandbox layer (no network, no GPU).
+
+Not collected by the repo-level pytest run (testpaths = ./tests); run manually
+when touching the adapter:
+
+    pytest examples/experimental/openenv/tests/ -q
+
+Covers the backend registry, whose whole job is to refuse to guess: which
+provider runs decides whose quota a rollout spends, so an unnamed or unknown
+one must fail at launch rather than resolve to whichever leg came first.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+import openenv_sandbox_common as common  # noqa: E402
+
+
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [("daytona", "daytona"), ("e2b", "e2b"), ("agentenv", "e2b"), ("  E2B  ", "e2b")],
+)
+def test_resolve_backend_normalizes_names_and_aliases(name, expected):
+    assert common.resolve_backend(name) == expected
+
+
+@pytest.mark.parametrize("name", [None, "", "   "])
+def test_resolve_backend_refuses_to_pick_for_you(name):
+    with pytest.raises(ValueError, match="no sandbox backend named"):
+        common.resolve_backend(name)
+
+
+def test_resolve_backend_rejects_unknown_names():
+    with pytest.raises(ValueError, match="unknown sandbox backend"):
+        common.resolve_backend("modal")
+
+
+def test_every_registered_backend_names_an_importable_target():
+    """The registry is what the launcher passes to --custom-agent-function-path."""
+    for backend, path in common.AGENT_FUNCTIONS.items():
+        module, _, func = path.rpartition(".")
+        assert func == "run", backend
+        assert (Path(__file__).resolve().parent.parent / f"{module}.py").is_file(), backend

--- a/examples/experimental/openenv/tests/test_tb2_sandbox_e2b.py
+++ b/examples/experimental/openenv/tests/test_tb2_sandbox_e2b.py
@@ -1,0 +1,285 @@
+"""Tests for the E2B sandbox half: template aliasing, key supply, and the
+orphan-TTL keepalive lifecycle.
+
+Not collected by the repo-level pytest run (testpaths = ./tests); run manually
+when touching the recipe:
+
+    pytest examples/experimental/openenv/tests/ -q
+"""
+
+import concurrent.futures
+import sys
+import threading
+import time
+import types
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+import tb2_sandbox_e2b as sandbox  # noqa: E402
+
+
+# --- template aliasing -------------------------------------------------------
+
+
+def _patch_recipe(
+    monkeypatch,
+    base="ghcr.io/laude/task:1.0",
+    commands=("apt-get install -y curl",),
+    resources=None,
+):
+    resources = resources or {"cpu_count": 1, "memory_mb": 2048}
+    monkeypatch.setattr(sandbox, "resolve_docker_image", lambda task_dir, override: base)
+    monkeypatch.setattr(sandbox, "server_layer_commands", lambda task_dir: list(commands))
+    monkeypatch.setattr(sandbox, "task_build_resources", lambda task_dir: dict(resources))
+
+
+def test_template_alias_is_deterministic_and_sanitized(monkeypatch):
+    _patch_recipe(monkeypatch)
+    a1 = sandbox.template_alias(Path("/tasks/Regex_Chess"))
+    a2 = sandbox.template_alias(Path("/tasks/Regex_Chess"))
+    assert a1 == a2
+    assert a1.startswith("tb2-regex-chess-")  # lowercased, non [a-z0-9-] mapped to '-'
+
+
+def test_template_alias_tracks_recipe_content(monkeypatch):
+    """The digest must cover base image AND build commands: editing either
+    re-bakes instead of silently serving a stale template."""
+    _patch_recipe(monkeypatch)
+    original = sandbox.template_alias(Path("/tasks/t"))
+    _patch_recipe(monkeypatch, commands=("apt-get install -y curl", "extra step"))
+    assert sandbox.template_alias(Path("/tasks/t")) != original
+    _patch_recipe(monkeypatch, base="ghcr.io/laude/task:2.0")
+    assert sandbox.template_alias(Path("/tasks/t")) != original
+
+
+def test_template_alias_tracks_build_resources(monkeypatch):
+    """E2B sizes sandboxes at template-build time, so a task.toml resource
+    bump must re-bake instead of warm-starting under-provisioned sandboxes."""
+    _patch_recipe(monkeypatch)
+    small = sandbox.template_alias(Path("/tasks/t"))
+    _patch_recipe(monkeypatch, resources={"cpu_count": 4, "memory_mb": 8192})
+    big = sandbox.template_alias(Path("/tasks/t"))
+    assert small != big
+
+
+class _FakeTemplateCls:
+    """Stands in for e2b.Template: records build calls, controls alias_exists."""
+
+    instances = None  # set per test
+
+    def __init__(self):
+        self.commands = []
+
+    def from_image(self, base):
+        self.base = base
+        return self
+
+    def run_cmd(self, cmd):
+        self.commands.append(cmd)
+        return self
+
+    @staticmethod
+    def alias_exists(alias, **kwargs):
+        return _FakeTemplateCls.exists
+
+    @staticmethod
+    def build(template, alias, **kwargs):
+        _FakeTemplateCls.builds.append((template, alias, kwargs))
+
+
+@pytest.fixture
+def fake_e2b(monkeypatch):
+    _FakeTemplateCls.exists = False
+    _FakeTemplateCls.builds = []
+    mod = types.ModuleType("e2b")
+    mod.Template = _FakeTemplateCls
+    monkeypatch.setitem(sys.modules, "e2b", mod)
+    monkeypatch.setattr(sandbox, "resolve_api_key", lambda: "e2b_" + "0" * 40)
+    return mod
+
+
+def test_ensure_template_short_circuits_on_existing_alias(monkeypatch, fake_e2b):
+    _patch_recipe(monkeypatch)
+    _FakeTemplateCls.exists = True
+    alias = sandbox.ensure_task_template(Path("/tasks/t"))
+    assert alias == sandbox.template_alias(Path("/tasks/t"))
+    assert _FakeTemplateCls.builds == []  # no rebuild when the alias exists
+
+
+def test_ensure_template_builds_with_recipe_and_resources(monkeypatch, fake_e2b):
+    _patch_recipe(monkeypatch, resources={"cpu_count": 3, "memory_mb": 4096})
+    alias = sandbox.ensure_task_template(Path("/tasks/t"))
+    ((template, built_alias, kwargs),) = _FakeTemplateCls.builds
+    assert built_alias == alias
+    assert template.base == "ghcr.io/laude/task:1.0"
+    assert template.commands == ["apt-get install -y curl"]
+    assert kwargs["cpu_count"] == 3 and kwargs["memory_mb"] == 4096
+    assert kwargs["skip_cache"] is False
+    assert kwargs["api_key"].startswith("e2b_")
+
+
+def test_ensure_template_force_rebuilds_skipping_cache(monkeypatch, fake_e2b):
+    _patch_recipe(monkeypatch)
+    _FakeTemplateCls.exists = True  # force must rebuild anyway
+    sandbox.ensure_task_template(Path("/tasks/t"), force=True)
+    ((_, _, kwargs),) = _FakeTemplateCls.builds
+    assert kwargs["skip_cache"] is True
+
+
+def test_ensure_template_enforces_build_wall_clock(monkeypatch, fake_e2b):
+    """build_timeout_s bounds the whole blocking build, not one HTTP request."""
+    _patch_recipe(monkeypatch)
+
+    def hanging_build(template, alias, **kwargs):
+        time.sleep(2)
+
+    monkeypatch.setattr(_FakeTemplateCls, "build", staticmethod(hanging_build))
+    with pytest.raises(concurrent.futures.TimeoutError):
+        sandbox.ensure_task_template(Path("/tasks/t"), build_timeout_s=0.05)
+
+
+class _FakeSandbox:
+    def __init__(self):
+        self.killed = False
+        self.commands = type("C", (), {"run": staticmethod(lambda *a, **k: None)})()
+
+    def get_host(self, port):
+        return f"{port}-id.example.test"
+
+    def kill(self, **kwargs):
+        self.killed = True
+
+
+def test_create_task_sandbox_kills_on_partial_failure(monkeypatch, fake_e2b):
+    """A sandbox whose server never becomes ready must not leak until TTL."""
+    created = _FakeSandbox()
+    fake_e2b.Sandbox = type("S", (), {"create": staticmethod(lambda **k: created)})
+    monkeypatch.setattr(sandbox, "ensure_task_template", lambda task_dir: "tb2-t-abc")
+    monkeypatch.setattr(sandbox, "sandbox_labels", lambda task_dir: {})
+    monkeypatch.setattr(sandbox, "server_cmd", lambda *a, **k: "serve")
+
+    def never_ready(url, timeout_s):
+        raise TimeoutError("server not ready")
+
+    monkeypatch.setattr(sandbox, "wait_server_ready", never_ready)
+    with pytest.raises(TimeoutError):
+        sandbox.create_task_sandbox(Path("/tasks/t"), ready_timeout_s=0.01)
+    assert created.killed
+
+
+def test_build_lock_is_per_alias():
+    lock_a1 = sandbox._build_lock("tb2-a-123")
+    lock_a2 = sandbox._build_lock("tb2-a-123")
+    lock_b = sandbox._build_lock("tb2-b-456")
+    assert lock_a1 is lock_a2
+    assert lock_a1 is not lock_b
+
+
+def test_task_build_resources_from_task_toml(tmp_path: Path):
+    (tmp_path / "task.toml").write_text("[environment]\ncpus = 4\nmemory_mb = 8192\n")
+    assert sandbox.task_build_resources(tmp_path) == {"cpu_count": 4, "memory_mb": 8192}
+
+
+def test_task_build_resources_floors(tmp_path: Path):
+    (tmp_path / "task.toml").write_text("[environment]\ncpus = 0\nmemory_mb = 128\n")
+    assert sandbox.task_build_resources(tmp_path) == {"cpu_count": 1, "memory_mb": 2048}
+
+
+# --- key supply --------------------------------------------------------------
+
+
+def test_resolve_api_key_env_value_wins(monkeypatch, tmp_path: Path):
+    key_file = tmp_path / "api_key"
+    key_file.write_text("e2b_from_file\n")
+    monkeypatch.setenv("E2B_API_KEY", "e2b_from_env")
+    monkeypatch.setenv("E2B_API_KEY_FILE", str(key_file))
+    assert sandbox.resolve_api_key() == "e2b_from_env"
+
+
+def test_resolve_api_key_falls_back_to_file(monkeypatch, tmp_path: Path):
+    # The launcher forwards only this path (never the value, which would be
+    # echoed into driver logs via ray runtime_env); workers must read it here.
+    key_file = tmp_path / "api_key"
+    key_file.write_text("e2b_from_file\n")
+    monkeypatch.delenv("E2B_API_KEY", raising=False)
+    monkeypatch.setenv("E2B_API_KEY_FILE", str(key_file))
+    assert sandbox.resolve_api_key() == "e2b_from_file"  # whitespace stripped
+
+
+def test_resolve_api_key_default_path_under_home(monkeypatch, tmp_path: Path):
+    monkeypatch.delenv("E2B_API_KEY", raising=False)
+    monkeypatch.delenv("E2B_API_KEY_FILE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg = tmp_path / ".config" / "e2b"
+    cfg.mkdir(parents=True)
+    (cfg / "api_key").write_text("e2b_default\n")
+    assert sandbox.resolve_api_key() == "e2b_default"
+
+
+def test_resolve_api_key_errors_when_absent(monkeypatch, tmp_path: Path):
+    monkeypatch.delenv("E2B_API_KEY", raising=False)
+    monkeypatch.setenv("E2B_API_KEY_FILE", str(tmp_path / "missing"))
+    with pytest.raises(RuntimeError, match="missing or empty"):
+        sandbox.resolve_api_key()
+
+
+# --- base_url ---------------------------------------------------------------
+
+
+class _HostStub:
+    def get_host(self, port):
+        return f"{port}-sbx123.example.dev"
+
+
+def test_base_url_default_https(monkeypatch):
+    monkeypatch.delenv("OPENENV_E2B_URL_SCHEME", raising=False)
+    assert sandbox.base_url(_HostStub()) == "https://8000-sbx123.example.dev"
+
+
+def test_base_url_scheme_override(monkeypatch):
+    # Self-hosted gateways (e.g. an AgentENV deployment inside the tailnet)
+    # may terminate plain HTTP.
+    monkeypatch.setenv("OPENENV_E2B_URL_SCHEME", "http")
+    assert sandbox.base_url(_HostStub()) == "http://8000-sbx123.example.dev"
+
+
+# --- TTL / keepalive ---------------------------------------------------------
+
+
+def test_sandbox_ttl_armed_by_default():
+    # The dead-man's-switch contract: sandboxes are created with a bounded
+    # lifetime, or a hard-killed caller's orphans run forever.
+    assert sandbox._SANDBOX_TTL_S > 0
+    assert sandbox._KEEPALIVE_INTERVAL_S < sandbox._SANDBOX_TTL_S  # beats within the window
+
+
+def test_keepalive_beats_then_exits_on_persistent_failure(monkeypatch):
+    monkeypatch.setattr(sandbox, "_KEEPALIVE_INTERVAL_S", 0.02)
+    monkeypatch.setattr(sandbox, "_connection_opts", lambda: {})
+
+    class Stub:
+        def __init__(self):
+            self.beats = 0
+            self.dead = False
+
+        def set_timeout(self, timeout, **opts):
+            if self.dead:
+                raise RuntimeError("sandbox killed")
+            self.beats += 1
+
+    stub = Stub()
+    sandbox._start_keepalive(stub, "regex-chess")
+    deadline = time.time() + 2.0
+    while stub.beats < 3 and time.time() < deadline:
+        time.sleep(0.01)
+    assert stub.beats >= 3  # beats while the sandbox is alive
+
+    stub.dead = True  # episode over, sandbox killed -> thread must exit
+    deadline = time.time() + 2.0
+    while time.time() < deadline:
+        if not any("keepalive" in t.name for t in threading.enumerate()):
+            break
+        time.sleep(0.01)
+    assert not any("keepalive" in t.name for t in threading.enumerate())


### PR DESCRIPTION
## What

A third materialization of the per-task sandbox model (after the shared docker-mode server and the Daytona leg, #1710/#1711/#1675): `OPENENV_SANDBOX_BACKEND=e2b` runs every episode in its own sandbox on **any provider speaking the E2B API**, driven through the official `e2b` SDK.

The backend this leg is built for is **[AgentENV](https://github.com/kvcache-ai/AgentENV)** — the Kimi K3 team's self-hosted Firecracker microVM platform, whose native API *is* the E2B API (`OPENENV_SANDBOX_BACKEND=agentenv` is an accepted alias). Pointing `E2B_API_URL`/`E2B_SANDBOX_URL` at an AgentENV gateway gives snapshot-backed sub-second sandbox starts and removes the two Daytona scaling walls we've measured (org snapshot quota; org memory quota at ~256 concurrent). E2B Cloud works unmodified as the zero-infra default.

## How

- `tb2_sandbox_e2b.py` — E2B materialization of the (unchanged, provider-agnostic) `tb2_sandbox_recipe`. E2B separates template build from sandbox create, so unlike Daytona's declarative per-episode build: templates build once per task under a **recipe-digest alias** (`tb2-<task>-<sha256[:10]>` over base image + build commands — recipe edits re-bake automatically, identical inputs reuse), episodes warm-start from the template, and a bake CLI (`python tb2_sandbox_e2b.py --tasks-dir ... --all`) pre-builds a suite. TTL dead-man's switch = E2B kill-on-expiry timeout re-armed by a keepalive thread.
- `openenv_e2b_agent_function.py` — episode-dispatch twin of the Daytona agent function: same `_multi_turn` loop, `native_evaluate=True` scoring, create semaphore + jittered backoff, cancel-safe orphan reaper. `OPENENV_E2B_THROTTLE_PATTERNS` extends retryable capacity errors per deployment without code changes.
- Launcher: implicit "tasks_dir ⇒ Daytona" becomes an explicit `resolve_sandbox_backend()` (**unchanged default**: tasks_dir alone still selects Daytona); key-supply + SDK-preflight blocks parameterized per provider (`E2B_API_KEY`/`E2B_API_KEY_FILE`, same file-path-forwarding contract).
- Seam tightened for the second provider: `sandbox_labels` moved into `tb2_sandbox_recipe` (ownership metadata is provider-agnostic; Daytona labels and E2B metadata take the same keys).

## Validation

- `pytest examples/experimental/openenv/tests/ -q` → **42 passed** (new suites mirror the Daytona ones: alias determinism/content-tracking, key supply, keepalive lifecycle, episode dispatch, throttle retry/give-up/cancel-reap; typed `RateLimitException` test verified against the real `e2b` SDK).
- SDK surface cross-checked against AgentENV's own E2B compatibility suite (`scripts/tests/e2e/e2b_python_sdk_compat.py` in their repo): `Template().from_image().run_cmd()` + `Template.build(cpu_count=, memory_mb=)`, `Sandbox.create(template=, timeout=, metadata=)`, `commands.run`, `kill` are all inside their tested surface.
- **Validated live against a self-hosted AgentENV server** (AWS `m7i.metal-24xl`): golden replay 1/1 (fix-git, reward 1.0, ~13 s warm end-to-end — sandbox create, WebSocket episode I/O through the provider's host-routing proxy, canonical evaluate, delete) and the full agentic loop with a cloud-API policy (14 turns, solved, zero infra errors). The two former unknowns both resolved: `get_host` port URLs route via `AENV_SANDBOX_PROXY_DOMAINS` + wildcard DNS (see the [AgentENV recipe](https://github.com/radixark/miles/tree/main/examples/experimental/agentenv)), and `/ws` proxies cleanly. Two AgentENV template-build gaps found on the Harbor path were fixed upstream ([AgentENV#66](https://github.com/kvcache-ai/AgentENV/pull/66), [AgentENV#67](https://github.com/kvcache-ai/AgentENV/pull/67)); the OpenEnv leg does not depend on them.
- **GRPO smoke closed the RL loop on this backend** (4×H200, GLM-4.7-Flash TP=2/EP=2, `OPENENV_SANDBOX_BACKEND=agentenv`): rollout 0 scored raw_reward 0.5 from per-episode AgentENV microVMs → `train_step outcome=NORMAL` → weight update broadcast to the inference engines (461 tensors, ~3.7 s) → subsequent rollouts generated on the updated weights (weight_version advancing in lockstep, raw_reward reaching 1.0), with on-policy fidelity intact (rollout vs ref logprobs −0.498/−0.507, TITO session mismatch 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
