### PR TITLE
fix(lora): honor --attention-backend in the bridge LoRA path

### DIFF
--- a/miles/backends/megatron_utils/bridge_lora_helpers.py
+++ b/miles/backends/megatron_utils/bridge_lora_helpers.py
@@ -101,6 +101,7 @@ def _setup_lora_model_via_bridge(args: Namespace) -> list:
     provider.recompute_num_layers = args.recompute_num_layers
     provider.recompute_modules = args.recompute_modules
     provider.distribute_saved_activations = args.distribute_saved_activations
+    provider.attention_backend = args.attention_backend
     provider.variable_seq_lengths = True
     provider.moe_token_dispatcher_type = "alltoall"
     provider.moe_router_load_balancing_type = "none"

--- a/tests/e2e/megatron/model_scripts/test_gpt_oss_20b_moe_lora_ci.py
+++ b/tests/e2e/megatron/model_scripts/test_gpt_oss_20b_moe_lora_ci.py
@@ -94,7 +94,7 @@ def execute(shared_outer: bool, virtual_experts: bool):
         "--attention-dropout 0.0 "
         "--hidden-dropout 0.0 "
         "--qkv-format bshd "
-        "--attention-backend fused "
+        "--attention-backend auto "
         "--update-weight-buffer-size 536870912 "
         "--actor-num-nodes 1 "
         f"--actor-num-gpus-per-node {NUM_GPUS} "


### PR DESCRIPTION
LoRA runs silently ignore `--attention-backend`: `_setup_lora_model_via_bridge` never copies it onto the provider, unlike `model_provider.py:78`. Megatron maps that field to the `NVTE_*_ATTN` vars, so the dropped value let TE pick a backend the caller had opted out of — which is why `test_lora_qwen2.5_0.5B.py` dies in the fused-attention backward on `main` nightly.

Honoring it makes one previously inert request take effect. gpt-oss runs with `--softmax-type learnable`, where TE 2.17 disables FlashAttention outright and reports no fused kernel, leaving `UnfusedDotProductAttention` as the only option; its CI test asked for `fused`, so it now asks for `auto`.
