### PR TITLE
(1/2) refactor(rollout): drop --generate-multi-samples and its per-turn sample semantics

### DIFF
--- a/docs/user-guide/rollout-endpoints.md
+++ b/docs/user-guide/rollout-endpoints.md
@@ -86,14 +86,14 @@ Helpers:
 
 - `compute_prompt_ids_from_sample` and `compute_request_payload` from
   `miles/rollout/generate_utils/generate_endpoint_utils.py` build `/generate` requests.
-- For multi-sample outputs, set `--generate-multi-samples` and return a list.
+- Returning a `list[Sample]` from a generate function is supported natively; no flag is needed.
 
 ### Reference generators
 
 - **`single_turn.py`**: single-turn generation via `/generate`. Text or multimodal prompts.
 - **`multi_turn.py`**: multi-turn tool calling via `/generate`. Adds CLI flags
   `--generate-max-turns`, `--generate-tool-specs-path`, `--generate-tool-call-parser`,
-  `--generate-execute-tool-function-path`, `--generate-multi-samples`.
+  `--generate-execute-tool-function-path`.
 - **`benchmarkers.py`**: forces random output sequence length for benchmarking.
 
 ---
@@ -178,6 +178,18 @@ CUSTOM_ARGS=(
 
 **Don't apply chat template.** For OpenAI format, do **not** pass `--apply-chat-template`. The prompt must
 remain a `messages` list. SGLang handles templating server-side.
+
+</Warning>
+
+<Warning>
+
+**Agentic output is a `list[Sample]`.** `agentic_tool_call.generate` always returns a list
+(one merged TITO sample per linear run today). Consequences:
+
+- A custom reward model (`--custom-rm-path`) is called in batch form with a
+  `list[Sample]` argument; it must handle that shape.
+- `--group-rm`, `--partial-rollout`, and `--recompute-logprobs-via-prefill` are not
+  supported in combination with the agentic generator.
 
 </Warning>
 

--- a/docs/user-guide/rollout-endpoints.md
+++ b/docs/user-guide/rollout-endpoints.md
@@ -86,7 +86,7 @@ Helpers:
 
 - `compute_prompt_ids_from_sample` and `compute_request_payload` from
   `miles/rollout/generate_utils/generate_endpoint_utils.py` build `/generate` requests.
-- Returning a `list[Sample]` from a generate function is supported natively; no flag is needed.
+- A generate function can set `GenerateFnOutput.samples` to a `Sample` or `list[Sample]`.
 
 ### Reference generators
 
@@ -178,18 +178,6 @@ CUSTOM_ARGS=(
 
 **Don't apply chat template.** For OpenAI format, do **not** pass `--apply-chat-template`. The prompt must
 remain a `messages` list. SGLang handles templating server-side.
-
-</Warning>
-
-<Warning>
-
-**Agentic output is a `list[Sample]`.** `agentic_tool_call.generate` always returns a list
-(one merged TITO sample per linear run today). Consequences:
-
-- A custom reward model (`--custom-rm-path`) is called in batch form with a
-  `list[Sample]` argument; it must handle that shape.
-- `--group-rm`, `--partial-rollout`, and `--recompute-logprobs-via-prefill` are not
-  supported in combination with the agentic generator.
 
 </Warning>
 

--- a/examples/experimental/swe-agent-v2/README.md
+++ b/examples/experimental/swe-agent-v2/README.md
@@ -289,8 +289,6 @@ merge_samples() ->
   logprobs:  -------- [real]  [0.0] [real]
 ```
 
-Without TITO, use `--generate-multi-samples` to skip merge and train on per-turn samples instead (current default in `run.sh`).
-
 ## Troubleshooting
 
 ### Harbor containers can't reach Miles Router
@@ -312,7 +310,9 @@ The task directory for the given `instance_id` doesn't exist under `HARBOR_TASKS
 
 ### `b.tokens must start with a.tokens` assertion error
 
-Multi-turn merge fails due to BPE re-tokenization inconsistency. Use `--generate-multi-samples` (already default in `run.sh`) to skip merge and train on per-turn samples.
+Multi-turn merge fails due to BPE re-tokenization inconsistency. The session-server TITO path
+(pretokenized `input_ids`) avoids the re-tokenization entirely; check that the run goes through
+`--use-session-server` and that the chat template round-trips (see the TITO docs).
 
 ### Trace-viewer shows no trajectories
 

--- a/examples/experimental/swe-agent-v2/README.md
+++ b/examples/experimental/swe-agent-v2/README.md
@@ -289,6 +289,8 @@ merge_samples() ->
   logprobs:  -------- [real]  [0.0] [real]
 ```
 
+Without TITO, use `--generate-multi-samples` to skip merge and train on per-turn samples instead (current default in `run.sh`).
+
 ## Troubleshooting
 
 ### Harbor containers can't reach Miles Router
@@ -310,9 +312,7 @@ The task directory for the given `instance_id` doesn't exist under `HARBOR_TASKS
 
 ### `b.tokens must start with a.tokens` assertion error
 
-Multi-turn merge fails due to BPE re-tokenization inconsistency. The session-server TITO path
-(pretokenized `input_ids`) avoids the re-tokenization entirely; check that the run goes through
-`--use-session-server` and that the chat template round-trips (see the TITO docs).
+Multi-turn merge fails due to BPE re-tokenization inconsistency. Use `--generate-multi-samples` (already default in `run.sh`) to skip merge and train on per-turn samples.
 
 ### Trace-viewer shows no trajectories
 

--- a/miles/rollout/filter_hub/dynamic_sampling_filters.py
+++ b/miles/rollout/filter_hub/dynamic_sampling_filters.py
@@ -6,8 +6,8 @@ from miles.utils.types import Sample
 __all__ = ["check_reward_nonzero_std", "check_no_aborted"]
 
 
-def _flatten_samples(samples):
-    """Flatten samples that may contain nested lists (generate functions may return list[Sample])."""
+def _flatten_samples(samples: list[Sample | list[Sample]]):
+    """Flatten a group whose elements are `Sample` or `list[Sample]` (generate-function dependent)."""
     for s in samples:
         if isinstance(s, list):
             yield from s
@@ -15,7 +15,7 @@ def _flatten_samples(samples):
             yield s
 
 
-def check_reward_nonzero_std(args, samples: list[Sample], **kwargs):
+def check_reward_nonzero_std(args, samples: list[Sample | list[Sample]], **kwargs):
     rewards = [sample.get_reward_value(args) for sample in _flatten_samples(samples)]
     keep = torch.tensor(rewards, dtype=torch.float64).std() > 1e-8
     return DynamicFilterOutput(
@@ -24,7 +24,7 @@ def check_reward_nonzero_std(args, samples: list[Sample], **kwargs):
     )
 
 
-def check_no_aborted(args, samples: list[Sample], **kwargs):
+def check_no_aborted(args, samples: list[Sample | list[Sample]], **kwargs):
     """Reject entire group if any sample was aborted (e.g. env timeout, Docker crash)."""
     if any(s.status == Sample.Status.ABORTED for s in _flatten_samples(samples)):
         return DynamicFilterOutput(keep=False, reason="group_has_aborted")

--- a/miles/rollout/filter_hub/dynamic_sampling_filters.py
+++ b/miles/rollout/filter_hub/dynamic_sampling_filters.py
@@ -6,22 +6,22 @@ from miles.utils.types import Sample
 __all__ = ["check_reward_nonzero_std", "check_no_aborted"]
 
 
-def check_reward_nonzero_std(args, samples: list[Sample], **kwargs):
-    rewards = [sample.get_reward_value(args) for sample in samples]
-    keep = torch.tensor(rewards, dtype=torch.float64).std() > 1e-8
-    return DynamicFilterOutput(
-        keep=keep,
-        reason=None if keep else f"zero_std_{round(rewards[0], 1)}",
-    )
-
-
 def _flatten_samples(samples):
-    """Flatten samples that may contain nested lists (from --generate-multi-samples)."""
+    """Flatten samples that may contain nested lists (generate functions may return list[Sample])."""
     for s in samples:
         if isinstance(s, list):
             yield from s
         else:
             yield s
+
+
+def check_reward_nonzero_std(args, samples: list[Sample], **kwargs):
+    rewards = [sample.get_reward_value(args) for sample in _flatten_samples(samples)]
+    keep = torch.tensor(rewards, dtype=torch.float64).std() > 1e-8
+    return DynamicFilterOutput(
+        keep=keep,
+        reason=None if keep else f"zero_std_{round(rewards[0], 1)}",
+    )
 
 
 def check_no_aborted(args, samples: list[Sample], **kwargs):

--- a/miles/rollout/generate_hub/agentic_tool_call.py
+++ b/miles/rollout/generate_hub/agentic_tool_call.py
@@ -89,7 +89,7 @@ async def generate(input: GenerateFnInput) -> GenerateFnOutput:
         logger.warning("No model calls recorded for sample")
         sample = deepcopy(input.sample)
         sample.status = Sample.Status.ABORTED
-        return GenerateFnOutput(samples=sample)
+        return GenerateFnOutput(samples=[sample])
 
     logger.debug(f"{log_prefix} Computing samples from {len(records)} records...")
     samples = compute_samples_from_openai_records(
@@ -123,19 +123,15 @@ async def generate(input: GenerateFnInput) -> GenerateFnOutput:
         logger.warning("All samples truncated (prompt already exceeds max_seq_len)")
         sample = deepcopy(input.sample)
         sample.status = Sample.Status.ABORTED
-        return GenerateFnOutput(samples=sample)
+        return GenerateFnOutput(samples=[sample])
 
-    if not input.args.generate_multi_samples:
-        samples = merge_samples(samples, input.state.tokenizer)
-        samples.metadata.update(session_metadata)
-    else:
-        samples[-1].metadata.update(session_metadata)
-    return GenerateFnOutput(samples=samples)
+    sample = merge_samples(samples, input.state.tokenizer)
+    sample.metadata.update(session_metadata)
+    return GenerateFnOutput(samples=[sample])
 
 
 def _add_arguments(parser: argparse.ArgumentParser):
     parser.add_argument("--custom-agent-function-path", type=str)
-    parser.add_argument("--generate-multi-samples", action="store_true", default=False)
     parser.add_argument(
         "--max-seq-len",
         type=int,

--- a/miles/rollout/generate_hub/agentic_tool_call.py
+++ b/miles/rollout/generate_hub/agentic_tool_call.py
@@ -89,7 +89,7 @@ async def generate(input: GenerateFnInput) -> GenerateFnOutput:
         logger.warning("No model calls recorded for sample")
         sample = deepcopy(input.sample)
         sample.status = Sample.Status.ABORTED
-        return GenerateFnOutput(samples=[sample])
+        return GenerateFnOutput(samples=sample)
 
     logger.debug(f"{log_prefix} Computing samples from {len(records)} records...")
     samples = compute_samples_from_openai_records(
@@ -123,11 +123,11 @@ async def generate(input: GenerateFnInput) -> GenerateFnOutput:
         logger.warning("All samples truncated (prompt already exceeds max_seq_len)")
         sample = deepcopy(input.sample)
         sample.status = Sample.Status.ABORTED
-        return GenerateFnOutput(samples=[sample])
+        return GenerateFnOutput(samples=sample)
 
     sample = merge_samples(samples, input.state.tokenizer)
     sample.metadata.update(session_metadata)
-    return GenerateFnOutput(samples=[sample])
+    return GenerateFnOutput(samples=sample)
 
 
 def _add_arguments(parser: argparse.ArgumentParser):

--- a/miles/rollout/generate_hub/multi_turn.py
+++ b/miles/rollout/generate_hub/multi_turn.py
@@ -38,8 +38,6 @@ async def generate(input: GenerateFnInput) -> GenerateFnOutput:
     tool_specs = load_function(args.generate_tool_specs_path)
     tool_call_parser = create_tool_call_parser(tool_specs, args.generate_tool_call_parser)
 
-    multi_samples = []
-
     # tool-call markup stays inline in the assistant text (what the model emitted)
     record_trajectory = args.save_debug_trajectory_data is not None
     trajectory = (list(sample.prompt) if isinstance(sample.prompt, list) else []) if record_trajectory else None
@@ -56,12 +54,7 @@ async def generate(input: GenerateFnInput) -> GenerateFnOutput:
         payload, halt_status = compute_request_payload(args, sample.tokens, input.sampling_params)
         if payload is None:
             sample.status = halt_status
-            if args.generate_multi_samples and multi_samples:
-                multi_samples[-1].status = halt_status
             break
-
-        if args.generate_multi_samples:
-            sample = deepcopy(input.sample)
 
         gen_t0 = time.time()
         output = await post(url, payload, headers=compute_routing_headers(args, sample))
@@ -72,10 +65,7 @@ async def generate(input: GenerateFnInput) -> GenerateFnOutput:
         await update_sample_from_response(args, sample, payload=payload, output=output, update_loss_mask=True)
         if record_trajectory:
             trajectory.append({"role": "assistant", "content": output["text"]})
-            sample.metadata["messages"] = list(trajectory)  # snapshot: multi_samples deepcopies per turn
-
-        if args.generate_multi_samples:
-            multi_samples.append(deepcopy(sample))
+            sample.metadata["messages"] = list(trajectory)  # snapshot: trajectory keeps growing in later turns
 
         if output["meta_info"]["finish_reason"]["type"] in ("abort", "length"):
             break
@@ -95,7 +85,7 @@ async def generate(input: GenerateFnInput) -> GenerateFnOutput:
             trajectory.extend(tool_messages)
             sample.metadata["messages"] = list(trajectory)
 
-    return GenerateFnOutput(samples=multi_samples if args.generate_multi_samples else sample)
+    return GenerateFnOutput(samples=sample)
 
 
 def _add_arguments(parser: argparse.ArgumentParser):
@@ -103,7 +93,6 @@ def _add_arguments(parser: argparse.ArgumentParser):
     parser.add_argument("--generate-tool-specs-path", type=str)
     parser.add_argument("--generate-tool-call-parser", type=str)
     parser.add_argument("--generate-execute-tool-function-path", type=str)
-    parser.add_argument("--generate-multi-samples", action="store_true")
 
 
 generate.add_arguments = _add_arguments

--- a/tests/fast/fixtures/generation_fixtures.py
+++ b/tests/fast/fixtures/generation_fixtures.py
@@ -31,10 +31,8 @@ DEFAULT_SAMPLING_PARAMS = {"max_new_tokens": 64, "temperature": 0.7}
 VARIANT_TO_GENERATE_FN_PATH = {
     "old_sglang_rollout": "miles.rollout.sglang_rollout.generate",
     "single_turn": "miles.rollout.generate_hub.single_turn.generate",
-    "multi_turn_single_sample": "miles.rollout.generate_hub.multi_turn.generate",
-    "multi_turn_multi_samples": "miles.rollout.generate_hub.multi_turn.generate",
-    "agentic_tool_call_single_sample": "miles.rollout.generate_hub.agentic_tool_call.generate",
-    "agentic_tool_call_multi_samples": "miles.rollout.generate_hub.agentic_tool_call.generate",
+    "multi_turn": "miles.rollout.generate_hub.multi_turn.generate",
+    "agentic_tool_call": "miles.rollout.generate_hub.agentic_tool_call.generate",
 }
 
 
@@ -53,7 +51,7 @@ def extra_argv_for_variant(
         custom_generate_function_path or VARIANT_TO_GENERATE_FN_PATH[variant],
     ]
 
-    if variant in ("multi_turn_single_sample", "multi_turn_multi_samples"):
+    if variant == "multi_turn":
         argv += [
             "--generate-max-turns",
             str(generate_max_turns),
@@ -63,13 +61,9 @@ def extra_argv_for_variant(
             generate_execute_tool_function_path,
         ]
         argv += ["--generate-tool-call-parser", generate_tool_call_parser]
-        if variant == "multi_turn_multi_samples":
-            argv.append("--generate-multi-samples")
-    elif variant in ("agentic_tool_call_single_sample", "agentic_tool_call_multi_samples"):
+    elif variant == "agentic_tool_call":
         argv += ["--custom-agent-function-path", custom_agent_function_path]
         argv += ["--use-session-server", "--tito-model", "qwen3"]
-        if variant == "agentic_tool_call_multi_samples":
-            argv.append("--generate-multi-samples")
 
     return argv
 

--- a/tests/fast/rollout/generate_hub/test_multi_turn.py
+++ b/tests/fast/rollout/generate_hub/test_multi_turn.py
@@ -22,7 +22,7 @@ _ = generation_env, SAMPLE_TOOLS, TwoTurnStub, ThreeTurnStub
 
 
 def is_agentic_variant(variant: str) -> bool:
-    return variant in ("agentic_tool_call_single_sample", "agentic_tool_call_multi_samples")
+    return variant == "agentic_tool_call"
 
 
 # ------------------------------------ fixtures and consts ----------------------------------------
@@ -33,14 +33,7 @@ DEFAULT_SAMPLING_PARAMS = {"max_new_tokens": 64, "temperature": 0.7}
 TOKENIZER = load_tokenizer(MODEL_NAME, trust_remote_code=True)
 
 
-@pytest.fixture(
-    params=[
-        "multi_turn_single_sample",
-        "multi_turn_multi_samples",
-        "agentic_tool_call_single_sample",
-        "agentic_tool_call_multi_samples",
-    ]
-)
+@pytest.fixture(params=["multi_turn", "agentic_tool_call"])
 def variant(request):
     return request.param
 
@@ -234,41 +227,21 @@ class TestBasicMultiTurn:
                 expected_request(S.FIRST_PROMPT_TOKEN_IDS),
                 expected_request(S.SECOND_PROMPT_TOKEN_IDS),
             ]
-        if variant in ("multi_turn_single_sample", "agentic_tool_call_single_sample"):
-            full_response = S.FIRST_RESPONSE + S.FIRST_TOOL_RESPONSE + S.SECOND_RESPONSE
-            expected = [
-                ExpectedSampleInfo(
-                    chunks=[
-                        expected_chunk(S.FIRST_RESPONSE, 1),
-                        expected_chunk(S.FIRST_TOOL_RESPONSE, 0),
-                        expected_chunk(S.SECOND_RESPONSE, 1),
-                    ],
-                    partial_sample=expected_partial_sample(
-                        prompt=S.PROMPT,
-                        response=full_response,
-                        response_length=token_len(full_response),
-                    ),
+        full_response = S.FIRST_RESPONSE + S.FIRST_TOOL_RESPONSE + S.SECOND_RESPONSE
+        expected = [
+            ExpectedSampleInfo(
+                chunks=[
+                    expected_chunk(S.FIRST_RESPONSE, 1),
+                    expected_chunk(S.FIRST_TOOL_RESPONSE, 0),
+                    expected_chunk(S.SECOND_RESPONSE, 1),
+                ],
+                partial_sample=expected_partial_sample(
+                    prompt=S.PROMPT,
+                    response=full_response,
+                    response_length=token_len(full_response),
                 ),
-            ]
-        else:
-            expected = [
-                ExpectedSampleInfo(
-                    chunks=[expected_chunk(S.FIRST_RESPONSE, 1)],
-                    partial_sample=expected_partial_sample(
-                        prompt=S.PROMPT,
-                        response=S.FIRST_RESPONSE,
-                        response_length=token_len(S.FIRST_RESPONSE),
-                    ),
-                ),
-                ExpectedSampleInfo(
-                    chunks=[expected_chunk(S.SECOND_RESPONSE, 1)],
-                    partial_sample=expected_partial_sample(
-                        prompt=S.PROMPT,
-                        response=S.SECOND_RESPONSE,
-                        response_length=token_len(S.SECOND_RESPONSE),
-                    ),
-                ),
-            ]
+            ),
+        ]
         verify_samples(result.sample, expected)
 
 
@@ -279,7 +252,7 @@ class TestExitConditions:
         indirect=True,
     )
     def test_conversation_metadata_records_turns(self, variant, generation_env):
-        if variant != "multi_turn_single_sample":
+        if variant != "multi_turn":
             pytest.skip("conversation recording asserted once, on the engine multi-turn path")
         generation_env.mock_server.process_fn = TwoTurnStub.process_fn
 
@@ -368,7 +341,7 @@ class TestExitConditions:
             assert _strip_pretokenized(result.requests) == [expected_openai_request(S.OPENAI_MESSAGES_FIRST_TURN)]
         else:
             assert result.requests == [expected_request(S.FIRST_PROMPT_TOKEN_IDS)]
-        if variant == "multi_turn_single_sample":
+        if variant == "multi_turn":
             expected = [
                 ExpectedSampleInfo(
                     chunks=[
@@ -405,17 +378,14 @@ class TestRespectMaxContextLen:
             pytest.skip("TODO: implement")
         result = _run_generate(variant, generation_env, make_sample(prompt=SINGLE_TURN_PROMPT))
         assert result.requests == []
-        if variant == "multi_turn_single_sample":
-            expected = [
-                ExpectedSampleInfo(
-                    chunks=[],
-                    partial_sample=expected_partial_sample(
-                        prompt=SINGLE_TURN_PROMPT, response="", response_length=0, status=Sample.Status.TRUNCATED
-                    ),
-                )
-            ]
-        else:
-            expected = []
+        expected = [
+            ExpectedSampleInfo(
+                chunks=[],
+                partial_sample=expected_partial_sample(
+                    prompt=SINGLE_TURN_PROMPT, response="", response_length=0, status=Sample.Status.TRUNCATED
+                ),
+            )
+        ]
         verify_samples(result.sample, expected)
 
     @pytest.mark.parametrize(
@@ -440,34 +410,21 @@ class TestRespectMaxContextLen:
         result = _run_generate(variant, generation_env, make_sample(prompt=S.PROMPT))
 
         assert result.requests == [expected_request(S.FIRST_PROMPT_TOKEN_IDS)]
-        if variant == "multi_turn_single_sample":
-            partial_response = S.FIRST_RESPONSE + S.FIRST_TOOL_RESPONSE
-            expected = [
-                ExpectedSampleInfo(
-                    chunks=[
-                        expected_chunk(S.FIRST_RESPONSE, 1),
-                        expected_chunk(S.FIRST_TOOL_RESPONSE, 0),
-                    ],
-                    partial_sample=expected_partial_sample(
-                        prompt=S.PROMPT,
-                        response=partial_response,
-                        response_length=token_len(partial_response),
-                        status=Sample.Status.TRUNCATED,
-                    ),
+        partial_response = S.FIRST_RESPONSE + S.FIRST_TOOL_RESPONSE
+        expected = [
+            ExpectedSampleInfo(
+                chunks=[
+                    expected_chunk(S.FIRST_RESPONSE, 1),
+                    expected_chunk(S.FIRST_TOOL_RESPONSE, 0),
+                ],
+                partial_sample=expected_partial_sample(
+                    prompt=S.PROMPT,
+                    response=partial_response,
+                    response_length=token_len(partial_response),
+                    status=Sample.Status.TRUNCATED,
                 ),
-            ]
-        else:
-            expected = [
-                ExpectedSampleInfo(
-                    chunks=[expected_chunk(S.FIRST_RESPONSE, 1)],
-                    partial_sample=expected_partial_sample(
-                        prompt=S.PROMPT,
-                        response=S.FIRST_RESPONSE,
-                        response_length=token_len(S.FIRST_RESPONSE),
-                        status=Sample.Status.TRUNCATED,
-                    ),
-                ),
-            ]
+            ),
+        ]
         verify_samples(result.sample, expected)
 
     @pytest.mark.parametrize(
@@ -518,57 +475,25 @@ class TestThreeTurn:
                 expected_request(S.SECOND_PROMPT_TOKEN_IDS),
                 expected_request(S.THIRD_PROMPT_TOKEN_IDS),
             ]
-        if variant in ("multi_turn_single_sample", "agentic_tool_call_single_sample"):
-            full_response = (
-                S.FIRST_RESPONSE
-                + S.FIRST_TOOL_RESPONSE
-                + S.SECOND_RESPONSE
-                + S.SECOND_TOOL_RESPONSE
-                + S.THIRD_RESPONSE
-            )
-            expected = [
-                ExpectedSampleInfo(
-                    chunks=[
-                        expected_chunk(S.FIRST_RESPONSE, 1),
-                        expected_chunk(S.FIRST_TOOL_RESPONSE, 0),
-                        expected_chunk(S.SECOND_RESPONSE, 1),
-                        expected_chunk(S.SECOND_TOOL_RESPONSE, 0),
-                        expected_chunk(S.THIRD_RESPONSE, 1),
-                    ],
-                    partial_sample=expected_partial_sample(
-                        prompt=S.PROMPT,
-                        response=full_response,
-                        response_length=token_len(full_response),
-                    ),
+        full_response = (
+            S.FIRST_RESPONSE + S.FIRST_TOOL_RESPONSE + S.SECOND_RESPONSE + S.SECOND_TOOL_RESPONSE + S.THIRD_RESPONSE
+        )
+        expected = [
+            ExpectedSampleInfo(
+                chunks=[
+                    expected_chunk(S.FIRST_RESPONSE, 1),
+                    expected_chunk(S.FIRST_TOOL_RESPONSE, 0),
+                    expected_chunk(S.SECOND_RESPONSE, 1),
+                    expected_chunk(S.SECOND_TOOL_RESPONSE, 0),
+                    expected_chunk(S.THIRD_RESPONSE, 1),
+                ],
+                partial_sample=expected_partial_sample(
+                    prompt=S.PROMPT,
+                    response=full_response,
+                    response_length=token_len(full_response),
                 ),
-            ]
-        else:
-            expected = [
-                ExpectedSampleInfo(
-                    chunks=[expected_chunk(S.FIRST_RESPONSE, 1)],
-                    partial_sample=expected_partial_sample(
-                        prompt=S.PROMPT,
-                        response=S.FIRST_RESPONSE,
-                        response_length=token_len(S.FIRST_RESPONSE),
-                    ),
-                ),
-                ExpectedSampleInfo(
-                    chunks=[expected_chunk(S.SECOND_RESPONSE, 1)],
-                    partial_sample=expected_partial_sample(
-                        prompt=S.PROMPT,
-                        response=S.SECOND_RESPONSE,
-                        response_length=token_len(S.SECOND_RESPONSE),
-                    ),
-                ),
-                ExpectedSampleInfo(
-                    chunks=[expected_chunk(S.THIRD_RESPONSE, 1)],
-                    partial_sample=expected_partial_sample(
-                        prompt=S.PROMPT,
-                        response=S.THIRD_RESPONSE,
-                        response_length=token_len(S.THIRD_RESPONSE),
-                    ),
-                ),
-            ]
+            ),
+        ]
         verify_samples(result.sample, expected)
 
 
@@ -665,7 +590,7 @@ class TestRoutedExpertsMultiTurn:
         assert len(sample.tokens) - 1 == second_routed_experts.shape[0]
 
 
-_AGENTIC_VARIANTS = ["agentic_tool_call_single_sample", "agentic_tool_call_multi_samples"]
+_AGENTIC_VARIANTS = ["agentic_tool_call"]
 _AGENT_METADATA = {"reward": 1.0, "exit_status": "Submitted", "eval_report": {"passed": True}}
 
 
@@ -780,6 +705,7 @@ class TestAgentNoRecords:
 
         SingletonMeta.clear_all_instances()
 
+        assert isinstance(result.sample, list)
         samples = listify(result.sample)
         assert len(samples) == 1
         assert samples[0].status == Sample.Status.ABORTED

--- a/tests/fast/rollout/generate_hub/test_multi_turn.py
+++ b/tests/fast/rollout/generate_hub/test_multi_turn.py
@@ -705,7 +705,5 @@ class TestAgentNoRecords:
 
         SingletonMeta.clear_all_instances()
 
-        assert isinstance(result.sample, list)
-        samples = listify(result.sample)
-        assert len(samples) == 1
-        assert samples[0].status == Sample.Status.ABORTED
+        assert isinstance(result.sample, Sample)
+        assert result.sample.status == Sample.Status.ABORTED

--- a/tests/fast/rollout/generate_hub/test_single_turn.py
+++ b/tests/fast/rollout/generate_hub/test_single_turn.py
@@ -30,7 +30,7 @@ SAMPLING_PARAMS = {"max_new_tokens": 16, "temperature": 0.7}
 DEFAULT_MAX_NEW_TOKENS = SAMPLING_PARAMS["max_new_tokens"]
 
 
-@pytest.fixture(params=["old_sglang_rollout", "single_turn", "multi_turn_single_sample", "multi_turn_multi_samples"])
+@pytest.fixture(params=["old_sglang_rollout", "single_turn", "multi_turn"])
 def variant(request):
     return request.param
 
@@ -49,9 +49,9 @@ def expected_request(
         "sampling_params": sampling_params or SAMPLING_PARAMS,
         "return_logprob": True,
     }
-    if variant in ("single_turn", "multi_turn_single_sample", "multi_turn_multi_samples") or return_routed_experts:
+    if variant in ("single_turn", "multi_turn") or return_routed_experts:
         result["return_routed_experts"] = return_routed_experts
-    if variant in ("single_turn", "multi_turn_single_sample", "multi_turn_multi_samples") or return_indexer_topk:
+    if variant in ("single_turn", "multi_turn") or return_indexer_topk:
         result["return_indexer_topk"] = return_indexer_topk
     if image_data is not None:
         result["image_data"] = image_data
@@ -85,11 +85,7 @@ def expected_sample(
 ) -> Sample:
     actual_response_length = response_length if response_length is not None else len(RESPONSE_TOKENS)
     if isinstance(loss_mask, _Unset):
-        loss_mask = (
-            [1] * actual_response_length
-            if variant in ("multi_turn_single_sample", "multi_turn_multi_samples")
-            else None
-        )
+        loss_mask = [1] * actual_response_length if variant == "multi_turn" else None
 
     return Sample(
         group_index=None,
@@ -143,7 +139,7 @@ class TestBasicGeneration:
 
 class TestResumedSingleTurn:
     def test_two_consecutive_calls_on_same_sample(self, variant, generation_env):
-        if variant in ("multi_turn_single_sample", "multi_turn_multi_samples"):
+        if variant == "multi_turn":
             pytest.skip("not tested yet")
         partial_text = "\\boxed"
         partial_tokens = [59, 79075]
@@ -279,7 +275,7 @@ class TestInputStatusValidation:
 
     @pytest.mark.parametrize("status", [Sample.Status.COMPLETED, Sample.Status.TRUNCATED])
     def test_rejected_statuses(self, variant, generation_env, status):
-        if variant in ("multi_turn_single_sample", "multi_turn_multi_samples"):
+        if variant == "multi_turn":
             pytest.skip("not tested yet")
         with pytest.raises(AssertionError):
             _run_generate(variant, generation_env, _make_sample(status=status))
@@ -298,7 +294,7 @@ class TestPayloadStructure:
 
 class TestBoundaryConditions:
     def test_max_new_tokens_zero_returns_truncated(self, variant, generation_env):
-        if variant in ("multi_turn_single_sample", "multi_turn_multi_samples"):
+        if variant == "multi_turn":
             pytest.skip("not tested yet")
         existing_tokens = [1, 2, 3, 4, 5, 6, 7] + list(range(100, 110))
         sample = _make_sample(tokens=existing_tokens, response="x" * 10, response_length=10)
@@ -319,11 +315,9 @@ class TestBoundaryConditions:
     def test_prompt_exceeds_max_context_len_returns_truncated(self, variant, generation_env):
         if variant == "old_sglang_rollout":
             pytest.skip("old_sglang_rollout does not support rollout_max_context_len")
-        if variant == "multi_turn_multi_samples":
-            pytest.skip("multi_turn_multi_samples returns empty list when first turn fails")
         result = _run_generate(variant, generation_env)
         assert result.requests == []
-        tokens = PROMPT_TOKENS if variant in ("multi_turn_single_sample", "multi_turn_multi_samples") else []
+        tokens = PROMPT_TOKENS if variant == "multi_turn" else []
         assert listify(result.sample) == [
             expected_sample(
                 variant,
@@ -333,7 +327,7 @@ class TestBoundaryConditions:
                 rollout_log_probs=None,
                 status=Sample.Status.TRUNCATED,
                 prompt_tokens=0,
-                loss_mask=None if variant == "multi_turn_single_sample" else _UNSET,
+                loss_mask=None if variant == "multi_turn" else _UNSET,
             )
         ]
 
@@ -363,11 +357,9 @@ class TestBoundaryConditions:
     def test_adjusted_max_new_tokens_zero_returns_truncated(self, variant, generation_env):
         if variant == "old_sglang_rollout":
             pytest.skip("old_sglang_rollout does not support rollout_max_context_len")
-        if variant == "multi_turn_multi_samples":
-            pytest.skip("multi_turn_multi_samples returns empty list when first turn fails")
         result = _run_generate(variant, generation_env)
         assert result.requests == []
-        tokens = PROMPT_TOKENS if variant == "multi_turn_single_sample" else []
+        tokens = PROMPT_TOKENS if variant == "multi_turn" else []
         assert listify(result.sample) == [
             expected_sample(
                 variant,
@@ -377,7 +369,7 @@ class TestBoundaryConditions:
                 rollout_log_probs=None,
                 status=Sample.Status.TRUNCATED,
                 prompt_tokens=0,
-                loss_mask=None if variant == "multi_turn_single_sample" else _UNSET,
+                loss_mask=None if variant == "multi_turn" else _UNSET,
             )
         ]
 
@@ -398,7 +390,7 @@ VLM_MODEL_NAME = "Qwen/Qwen2-VL-2B-Instruct"
 class TestMultimodal:
     @pytest.mark.parametrize("generation_env", [{"args_kwargs": {"model_name": VLM_MODEL_NAME}}], indirect=True)
     def test_multimodal_inputs_processed(self, variant, generation_env):
-        if variant in ("multi_turn_single_sample", "multi_turn_multi_samples"):
+        if variant == "multi_turn":
             pytest.skip("not tested yet")
         test_image = Image.new("RGB", (64, 64), color="red")
         multimodal_inputs = {"images": [test_image]}

--- a/tests/fast/rollout/inference_rollout/integration/test_agent_metadata.py
+++ b/tests/fast/rollout/inference_rollout/integration/test_agent_metadata.py
@@ -9,7 +9,7 @@ from miles.utils.types import Sample
 
 TWO_TURN_DATA_ROWS = [{"input": [{"role": "user", "content": TwoTurnStub.USER_QUESTION}], "label": "2008"}]
 
-_AGENTIC_VARIANTS = ["agentic_tool_call_single_sample", "agentic_tool_call_multi_samples"]
+_AGENTIC_VARIANTS = ["agentic_tool_call"]
 
 _METADATA_RM_EXTRA_ARGV = [
     "--rollout-batch-size",

--- a/tests/fast/rollout/inference_rollout/integration/test_multi_turn.py
+++ b/tests/fast/rollout/inference_rollout/integration/test_multi_turn.py
@@ -11,12 +11,7 @@ from miles.utils.types import Sample
 
 TWO_TURN_DATA_ROWS = [{"input": [{"role": "user", "content": TwoTurnStub.USER_QUESTION}], "label": "2008"}]
 
-_VARIANT_NAMES = [
-    "multi_turn_single_sample",
-    "multi_turn_multi_samples",
-    "agentic_tool_call_single_sample",
-    "agentic_tool_call_multi_samples",
-]
+_VARIANT_NAMES = ["multi_turn", "agentic_tool_call"]
 
 _BASE_EXTRA_ARGV = [
     "--rollout-batch-size",
@@ -60,36 +55,24 @@ def test_rollout(rollout_env, variant, test_type):
 
 
 def _verify_samples(variant: str, samples: list[Any]):
-    is_multi_samples = variant in ("multi_turn_multi_samples", "agentic_tool_call_multi_samples")
-
-    if is_multi_samples:
+    if variant == "agentic_tool_call":
         if len(samples) > 0 and isinstance(samples[0], list):
-            # Train mode: list[list[Sample]], grouped by prompt
+            # Train mode: list[list[Sample]] — one singleton list (merged TITO sample) per generate
             assert len(samples) == 2, f"n_samples_per_prompt=2, so group should have 2 samples, got {len(samples)}"
             for group_sample in samples:
-                assert isinstance(group_sample, list), "multi_samples variant should return list[Sample] per generate"
-                _verify_group_samples(group_sample)
+                assert isinstance(group_sample, list), "agentic_tool_call returns list[Sample] per generate"
+                assert len(group_sample) == 1, "linear trajectory merges into exactly one sample"
+                _verify_sample(group_sample[0])
         else:
-            # Eval mode: list[Sample], flattened
-            # n_samples_per_eval_prompt=2, and each generate returns 2 turns, so 2*2=4 samples
-            assert (
-                len(samples) == 4
-            ), f"n_samples_per_eval_prompt=2, each generate returns 2 turns, so should have 4 samples, got {len(samples)}"
-            # Group samples by prompt (every 2 samples form a group)
-            group_samples_list = [samples[i : i + 2] for i in range(0, len(samples), 2)]
-            for group_samples in group_samples_list:
-                _verify_group_samples(group_samples)
+            # Eval mode: list[Sample], flattened (one merged sample per generate)
+            assert len(samples) == 2, f"n_samples_per_eval_prompt=2, so should have 2 samples, got {len(samples)}"
+            for sample in samples:
+                _verify_sample(sample)
     else:
         assert len(samples) == 2, f"n_samples_per_prompt=2, so group should have 2 samples, got {len(samples)}"
         for sample in samples:
-            assert isinstance(sample, Sample), "single_sample variant should return Sample, not list"
+            assert isinstance(sample, Sample), "multi_turn returns a scalar Sample per generate"
             _verify_sample(sample)
-
-
-def _verify_group_samples(group_samples: list[Sample], expected_count: int = 2):
-    assert len(group_samples) == expected_count, f"Group should have {expected_count} samples (one per turn)"
-    for i, sample in enumerate(group_samples):
-        _verify_sample(sample, expect_answer=(i == len(group_samples) - 1))
 
 
 def _verify_sample(sample: Sample, expected_reward: float = 1.0, expect_answer: bool = True):
@@ -101,13 +84,8 @@ def _verify_sample(sample: Sample, expected_reward: float = 1.0, expect_answer: 
 
 async def _simple_reward_function(args, samples: Sample | list[Sample]) -> float | list[float]:
     if isinstance(samples, list):
-        # For multi_samples variants, use the last sample's reward
-        if getattr(args, "generate_multi_samples", False):
-            return [_check_reward(samples[-1])] * len(samples)
-        else:
-            return [_check_reward(sample) for sample in samples]
-    else:
-        return _check_reward(samples)
+        return [_check_reward(sample) for sample in samples]
+    return _check_reward(samples)
 
 
 def _check_reward(sample: Sample) -> float:

--- a/tests/fast/rollout/inference_rollout/integration/test_multi_turn.py
+++ b/tests/fast/rollout/inference_rollout/integration/test_multi_turn.py
@@ -55,24 +55,10 @@ def test_rollout(rollout_env, variant, test_type):
 
 
 def _verify_samples(variant: str, samples: list[Any]):
-    if variant == "agentic_tool_call":
-        if len(samples) > 0 and isinstance(samples[0], list):
-            # Train mode: list[list[Sample]] — one singleton list (merged TITO sample) per generate
-            assert len(samples) == 2, f"n_samples_per_prompt=2, so group should have 2 samples, got {len(samples)}"
-            for group_sample in samples:
-                assert isinstance(group_sample, list), "agentic_tool_call returns list[Sample] per generate"
-                assert len(group_sample) == 1, "linear trajectory merges into exactly one sample"
-                _verify_sample(group_sample[0])
-        else:
-            # Eval mode: list[Sample], flattened (one merged sample per generate)
-            assert len(samples) == 2, f"n_samples_per_eval_prompt=2, so should have 2 samples, got {len(samples)}"
-            for sample in samples:
-                _verify_sample(sample)
-    else:
-        assert len(samples) == 2, f"n_samples_per_prompt=2, so group should have 2 samples, got {len(samples)}"
-        for sample in samples:
-            assert isinstance(sample, Sample), "multi_turn returns a scalar Sample per generate"
-            _verify_sample(sample)
+    assert len(samples) == 2, f"n_samples_per_prompt=2, so group should have 2 samples, got {len(samples)}"
+    for sample in samples:
+        assert isinstance(sample, Sample), f"{variant} returns a scalar Sample per generate"
+        _verify_sample(sample)
 
 
 def _verify_sample(sample: Sample, expected_reward: float = 1.0, expect_answer: bool = True):

--- a/tests/manual/session/bench_session_server_overhead.py
+++ b/tests/manual/session/bench_session_server_overhead.py
@@ -337,7 +337,6 @@ def _build_server_args(
         chat_template_path=chat_template_path,
         apply_chat_template_kwargs=chat_template_kwargs,
         tito_model=bench_args.tito_model,
-        generate_multi_samples=False,
         use_rollout_routing_replay=True,
         use_rollout_indexer_replay=False,
         miles_router_timeout=600.0,


### PR DESCRIPTION
## Summary

Remove `--generate-multi-samples` without narrowing the generate output contract.

## Motivation

The flag made every turn a separate full-context sample by skipping the TITO merge. Sample boundaries belong to trajectory topology, not a CLI switch; treating turns as siblings gives them one `group_index` and pollutes group baselines.

Removing the flag does not make `GenerateFnOutput.samples` list-only. The contract remains `Sample | list[Sample]`: 
- Current built-in linear generators return one merged scalar sample, while custom generators may return lists for multi-agent or tree trajectories.
- TODO: add tree like trajectory support, returning `list[Sample]`.

## Before / After

- **Before / After:** Flag-selected output shape → scalar output from built-in linear generators.
- **What moved where:** Both built-in generators lose flag-controlled branches, while dynamic filters continue to accept scalar or list elements under the existing union contract.
- The deprecated `examples/experimental/swe-agent-v2/README.md` remains unchanged.

## Behavior Preservation

- **How we know:** Generate-hub tests compare merged trajectory values for both built-in generators.
- Generate-hub tests assert scalar aborted paths.
- Train/eval integration tests cover scalar output from both built-in generators.
- Agent metadata integration covers the scalar custom reward path.
- Multi-sample integration covers custom `list[Sample]` output.

## Verification

- **Existing test suite:** `test_multi_turn.py` passed 24 tests with 7 expected skips.
- **Rollout integration:** Train/eval coverage passed 4 tests.
- **Metadata integration:** The agent metadata test passed.
- **Multi-sample integration:** The custom list-output test passed.
- **Pre-commit:** All hooks passed on the four corrected files.

## Review Focus

- Scrutinize the built-in linear generators for removal of only the flag-controlled per-turn branches.
- Confirm `GenerateFnOutput.samples` remains `Sample | list[Sample]` even though the built-in linear generators return scalar samples.
- Confirm this diff contains no `/samples` endpoint, codec, or HTTP transport change.
