### PR TITLE
test(gpt-oss): request auto attention backend instead of an unsatisfiable fused

### DIFF
--- a/tests/e2e/megatron/model_scripts/test_gpt_oss_20b_moe_lora_ci.py
+++ b/tests/e2e/megatron/model_scripts/test_gpt_oss_20b_moe_lora_ci.py
@@ -94,7 +94,7 @@ def execute(shared_outer: bool, virtual_experts: bool):
         "--attention-dropout 0.0 "
         "--hidden-dropout 0.0 "
         "--qkv-format bshd "
-        "--attention-backend fused "
+        "--attention-backend auto "
         "--update-weight-buffer-size 536870912 "
         "--actor-num-nodes 1 "
         f"--actor-num-gpus-per-node {NUM_GPUS} "


### PR DESCRIPTION
The gpt-oss LoRA CI test asks for `--attention-backend fused`, but that request cannot be satisfied for this model on the CI image, and it has never actually taken effect.

### Why fused cannot serve this model

gpt-oss runs with `--softmax-type learnable` (sink attention) and `--window-size 128,0`. In TE 2.17 (`dot_product_attention/utils.py`), the support matrix for a non-vanilla `softmax_type` without context parallelism is `FusedAttention, UnfusedDotProductAttention` — FlashAttention is disabled unconditionally:

```python
if softmax_type != "vanilla":
    logger.debug("Disabling FlashAttention for softmax_type = %s", softmax_type)
    use_flash_attention = False
```

Of the version- and feature-gates that could then drop FusedAttention, none apply to this run (`qkv_format = bshd`, `fp8 = None`, `context_parallel_size = 1`, `attention_dropout = 0.0`, and `deterministic = False` since `deterministic_mode` is off and `NVTE_ALLOW_NONDETERMINISTIC_ALGO` is unset). What remains is `tex.get_fused_attn_backend(...)` returning `No_Backend` for this shape, which leaves `UnfusedDotProductAttention` as the only viable backend.

### Why nobody noticed

`_setup_lora_model_via_bridge` does not copy `attention_backend` onto the provider, so on the LoRA path the value silently degrades to `auto`, all three `NVTE_*_ATTN` vars are set to 1, and TE selects the unfused path. The test has been passing on unfused attention all along; the `fused` in its args was never honored.

Once `attention_backend` is honored, `fused` restricts TE to a backend it cannot use and the run dies with `ValueError: No dot product attention backend is available for the provided inputs`. Requesting `auto` states the behaviour this test has actually had since it was added.

### Scope

Behaviourally a no-op on `main` today, since the value is discarded on this path either way.

Two related items, deliberately not in this PR:
- `scripts/run-gpt-oss-20b-bf16.sh:116` carries the same flag on the non-LoRA path, where it *is* honored. Only referenced from docs, not wired into CI.
- That this model trains on unfused attention is a performance question worth its own investigation.