### PR TITLE
Kimi K3: --colocate-memory-peak-device — overlap the trainer/rollout handoff on the GPU

### DIFF
--- a/miles/backends/megatron_utils/actor.py
+++ b/miles/backends/megatron_utils/actor.py
@@ -253,10 +253,31 @@ class MegatronTrainRayActor(TrainRayActor):
 
         return start_rollout_id
 
+    # Make sleep()/wake_up() idempotent: gpu peak mode wakes the trainer early.
+    _train_offloaded = False
+    _grad_buffer_offloaded = False
+
+    @with_logs
+    @timer
+    def offload_grad_buffer(self) -> None:
+        """Release the no-backup grad buffers ahead of the engine weight
+        resume: free host-side, and the heavy PP stages need the bytes."""
+        assert self.args.offload_train
+        if self._train_offloaded or self._grad_buffer_offloaded:
+            return
+        if not is_lora_enabled(self.args):
+            return
+        print_memory("before offload grad_buffer")
+        torch_memory_saver.pause(tag="grad_buffer")
+        self._grad_buffer_offloaded = True
+        print_memory("after offload grad_buffer")
+
     @with_logs
     @timer
     def sleep(self) -> None:
         assert self.args.offload_train
+        if self._train_offloaded:
+            return
 
         clear_memory(clear_host_memory=True)
         print_memory("before offload model")
@@ -265,12 +286,15 @@ class MegatronTrainRayActor(TrainRayActor):
         destroy_process_groups()
 
         if is_lora_enabled(self.args):
-            torch_memory_saver.pause(tag="grad_buffer")
+            if not self._grad_buffer_offloaded:
+                torch_memory_saver.pause(tag="grad_buffer")
+                self._grad_buffer_offloaded = True
             torch_memory_saver.pause(tag="default")
         else:
             torch_memory_saver.pause(tag=None)
 
         print_memory("after offload model")
+        self._train_offloaded = True
 
         if should_log_cpu_memory:
             log_cpu_memory(self._last_rollout_id, self.args, "after_offload_train")
@@ -279,17 +303,21 @@ class MegatronTrainRayActor(TrainRayActor):
     @timer
     def wake_up(self) -> None:
         assert self.args.offload_train
+        if not self._train_offloaded:
+            return
         print_memory("before wake_up model")
 
         if is_lora_enabled(self.args):
             torch_memory_saver.resume(tag="default")
             torch_memory_saver.resume(tag="grad_buffer")
+            self._grad_buffer_offloaded = False
         else:
             torch_memory_saver.resume(tag=None)
 
         clear_memory()
         reload_process_groups()
         print_memory("after wake_up model")
+        self._train_offloaded = False
 
     @property
     def _enable_weight_backup(self) -> bool:

--- a/miles/backends/megatron_utils/actor.py
+++ b/miles/backends/megatron_utils/actor.py
@@ -55,7 +55,6 @@ from .parallel import verify_megatron_parallel_state
 from .replay_utils import register_replay_list_moe
 from .update_weight.common import named_params_and_buffers
 from .update_weight.update_weight_from_distributed.broadcast import UpdateWeightFromDistributed
-from .update_weight.update_weight_from_distributed.p2p import UpdateWeightP2P
 from .update_weight.update_weight_from_tensor import UpdateWeightFromTensor
 
 if TYPE_CHECKING:
@@ -225,6 +224,8 @@ class MegatronTrainRayActor(TrainRayActor):
 
                 update_weight_cls = UpdateWeightFromDiskDelta
             else:
+                from .update_weight.update_weight_from_distributed.p2p import UpdateWeightP2P
+
                 update_weight_cls = UpdateWeightP2P
         self.weight_updater = update_weight_cls(
             self.args,
@@ -263,8 +264,11 @@ class MegatronTrainRayActor(TrainRayActor):
 
         destroy_process_groups()
 
-        tag = "default" if is_lora_enabled(self.args) else None
-        torch_memory_saver.pause(tag=tag)
+        if is_lora_enabled(self.args):
+            torch_memory_saver.pause(tag="grad_buffer")
+            torch_memory_saver.pause(tag="default")
+        else:
+            torch_memory_saver.pause(tag=None)
 
         print_memory("after offload model")
 
@@ -277,8 +281,11 @@ class MegatronTrainRayActor(TrainRayActor):
         assert self.args.offload_train
         print_memory("before wake_up model")
 
-        tag = "default" if is_lora_enabled(self.args) else None
-        torch_memory_saver.resume(tag=tag)
+        if is_lora_enabled(self.args):
+            torch_memory_saver.resume(tag="default")
+            torch_memory_saver.resume(tag="grad_buffer")
+        else:
+            torch_memory_saver.resume(tag=None)
 
         clear_memory()
         reload_process_groups()
@@ -549,6 +556,7 @@ class MegatronTrainRayActor(TrainRayActor):
                 maybe_finalize_async_save(blocking=True)
 
             from megatron.training.checkpointing import get_checkpoint_name
+
             from miles.utils.misc import load_function
 
             checkpoint_dir = get_checkpoint_name(self.args.save, rollout_id, return_base_dir=True)
@@ -600,7 +608,11 @@ class MegatronTrainRayActor(TrainRayActor):
 
         with torch_memory_saver.disable() if self.args.offload_train else nullcontext():
             print_memory("before update_weights")
-            self.weight_updater.update_weights()
+            if self.args.colocate:
+                self.weight_updater.update_weights(resume_generation=not self.args.offload_train)
+            else:
+                self.weight_updater.update_weights()
+            torch.cuda.ipc_collect()
             print_memory("after update_weights")
 
             if self.args.ci_test and len(rollout_engines) > 0 and not is_lora_enabled(self.args):
@@ -624,6 +636,7 @@ class MegatronTrainRayActor(TrainRayActor):
 
         if self.args.offload_train:
             destroy_process_groups()
+            print_memory("after update_weights process-group cleanup")
 
     @with_logs
     def load_other_checkpoint(self, model_tag: str, path: str) -> None:

--- a/miles/backends/megatron_utils/actor.py
+++ b/miles/backends/megatron_utils/actor.py
@@ -168,7 +168,7 @@ class MegatronTrainRayActor(TrainRayActor):
 
         parallel_state = get_parallel_state()
         if parallel_state.cp.size > 1:
-            from miles_plugins.models.cp_utils import detect_and_setup_hybrid_cp
+            from miles_plugins.models.hf_attention import detect_and_setup_hybrid_cp
 
             for model_chunk in self.model:
                 detect_and_setup_hybrid_cp(

--- a/miles/backends/megatron_utils/checkpoint.py
+++ b/miles/backends/megatron_utils/checkpoint.py
@@ -1,9 +1,12 @@
 import logging
 import os
 import re
+import time
+from contextlib import contextmanager, nullcontext
 from pathlib import Path
 
 import torch.distributed as dist
+from megatron.core.utils import unwrap_model
 
 # TODO: may need to copy those 2 functions and do refactoring.
 from megatron.training.checkpointing import load_checkpoint as _load_checkpoint_megatron
@@ -12,7 +15,7 @@ from megatron.training.global_vars import get_args
 
 from miles.utils import megatron_bridge_utils
 
-from .lora_utils import is_lora_enabled, is_lora_model, load_lora_adapter, save_lora_checkpoint
+from .lora_utils import _is_adapter_param_name, is_lora_enabled, is_lora_model, load_lora_adapter, save_lora_checkpoint
 
 try:
     # Here we patch out the `validate_non_overlapping_shards_metadata` in both functions
@@ -97,11 +100,34 @@ logger = logging.getLogger(__name__)
 __all__ = ["save_checkpoint", "save_checkpoint_with_lora", "load_checkpoint"]
 
 
+@contextmanager
+def _exclude_adapter_params_from_sharded_state_dict(models):
+    originals = []
+    for model in unwrap_model(models):
+        original = model.sharded_state_dict
+        originals.append((model, original))
+
+        def sharded_state_dict(*args, _original=original, **kwargs):
+            state_dict = _original(*args, **kwargs)
+            return {name: value for name, value in state_dict.items() if not _is_adapter_param_name(name)}
+
+        model.sharded_state_dict = sharded_state_dict
+
+    try:
+        yield
+    finally:
+        for model, original in originals:
+            model.sharded_state_dict = original
+
+
 def load_checkpoint(ddp_model, optimizer, opt_param_scheduler, checkpointing_context, skip_load_to_model_and_opt):
     # ref: how megatron `load_checkpoint` gets directory
     args = get_args()
 
     load_path = args.load
+    load_started = time.perf_counter()
+    if dist.get_rank() == 0:
+        logger.info("Starting checkpoint load from %s", load_path)
 
     has_local_checkpoint_manager = "local_checkpoint_manager" in (checkpointing_context or {})
     if has_local_checkpoint_manager:
@@ -112,13 +138,17 @@ def load_checkpoint(ddp_model, optimizer, opt_param_scheduler, checkpointing_con
         ), f"{args.load=} does not exist or is an empty directory. Did you specify the wrong folder?"
 
     if has_local_checkpoint_manager or _is_megatron_checkpoint(load_path):
-        result = _load_checkpoint_megatron(
-            ddp_model=ddp_model,
-            optimizer=optimizer,
-            opt_param_scheduler=opt_param_scheduler,
-            checkpointing_context=checkpointing_context,
-            skip_load_to_model_and_opt=skip_load_to_model_and_opt,
+        sharded_state_dict_context = (
+            _exclude_adapter_params_from_sharded_state_dict(ddp_model) if is_lora_enabled(args) else nullcontext()
         )
+        with sharded_state_dict_context:
+            result = _load_checkpoint_megatron(
+                ddp_model=ddp_model,
+                optimizer=optimizer,
+                opt_param_scheduler=opt_param_scheduler,
+                checkpointing_context=checkpointing_context,
+                skip_load_to_model_and_opt=skip_load_to_model_and_opt,
+            )
     else:
         result = _load_checkpoint_hf(
             ddp_model=ddp_model,
@@ -148,6 +178,8 @@ def load_checkpoint(ddp_model, optimizer, opt_param_scheduler, checkpointing_con
                     f"Training will start with freshly initialized adapter weights."
                 )
 
+    if dist.get_rank() == 0:
+        logger.info("Checkpoint load from %s completed in %.2f seconds", load_path, time.perf_counter() - load_started)
     return result
 
 

--- a/miles/backends/megatron_utils/lora_utils.py
+++ b/miles/backends/megatron_utils/lora_utils.py
@@ -11,6 +11,7 @@ import torch
 import torch.distributed as dist
 
 from miles.backends.training_utils.parallel import get_parallel_state
+from miles.utils.distributed_utils import get_gloo_group
 from miles.utils.lora import is_lora_enabled
 
 logger = logging.getLogger(__name__)
@@ -115,6 +116,10 @@ def lora_base_cpu_backup_enabled(args: Namespace) -> bool:
     return is_lora_enabled(args) and getattr(args, "colocate", False) and getattr(args, "lora_base_cpu_backup", False)
 
 
+def lora_rollout_base_retained(args: Namespace) -> bool:
+    return not args.offload_rollout or "weight" not in args.offload_rollout_level
+
+
 def is_lora_model(model: Sequence[torch.nn.Module]) -> bool:
     """Check if model has LoRA layers applied."""
     for model_chunk in model:
@@ -131,6 +136,66 @@ def is_lora_weight_name(name: str) -> bool:
     return ".lora_A." in name or ".lora_B." in name
 
 
+_marked_lora_grad_params_cache: dict[int, list[torch.nn.Parameter]] = {}
+
+
+def reduce_marked_lora_grads(model: Sequence[torch.nn.Module]) -> None:
+    """Sum EP-replicated native-LoRA partial gradients over the expert-model-parallel domain.
+
+    The expert-shared adapter factors (one ``lora_A`` serving every expert under
+    ``--experts-shared-outer-loras``) are replicated on every EP rank but only
+    see their own rank's experts' tokens, so each rank holds a partial gradient.
+    Megatron has no EP-domain gradient reduction: it assumes expert parameters
+    are partitioned across EP and only ever reduces them over expert-DP, so this
+    sum has to be supplied here.
+
+    The TP-domain counterparts need no code here — they carry Megatron's own
+    ``sum_gradients_across_tp_domain`` flag (see ``_new_param`` in the Kimi K3
+    LoRA plugin) and are reduced inside ``finalize_model_grads``.
+    """
+    from megatron.core import parallel_state
+
+    if parallel_state.get_expert_model_parallel_world_size() <= 1:
+        return
+
+    key = id(model[0]) if model else 0
+    marked = _marked_lora_grad_params_cache.get(key)
+    if marked is None:
+        marked = []
+        for model_chunk in model:
+            for parameter in model_chunk.parameters():
+                group_name = getattr(parameter, "_lora_grad_sum_group", None)
+                if group_name is None or not parameter.requires_grad:
+                    continue
+                assert group_name == "ep", f"unsupported LoRA gradient sum group {group_name!r}"
+                marked.append(parameter)
+        _marked_lora_grad_params_cache[key] = marked
+
+    gradients = []
+    for parameter in marked:
+        gradient = getattr(parameter, "main_grad", None)
+        if gradient is None:
+            gradient = parameter.grad
+        if gradient is not None:
+            gradients.append(gradient)
+    if not gradients:
+        return
+
+    group = parallel_state.get_expert_model_parallel_group()
+    # Sort the dtypes: set iteration order follows object hashes, which are
+    # address-derived and so need not agree across ranks.
+    for dtype in sorted({gradient.dtype for gradient in gradients}, key=str):
+        same_dtype = [gradient for gradient in gradients if gradient.dtype == dtype]
+        flat = torch._utils._flatten_dense_tensors(same_dtype)
+        dist.all_reduce(flat, op=dist.ReduceOp.SUM, group=group)
+        for gradient, reduced in zip(
+            same_dtype,
+            torch._utils._unflatten_dense_tensors(flat, same_dtype),
+            strict=True,
+        ):
+            gradient.copy_(reduced)
+
+
 def _is_adapter_param_name(name: str) -> bool:
     """Check if a parameter name belongs to a LoRA adapter (Megatron internal naming)."""
     return "lora_" in name or (".adapter." in name and ("linear_in" in name or "linear_out" in name))
@@ -139,16 +204,21 @@ def _is_adapter_param_name(name: str) -> bool:
 _param_grad_buffer_patched = False
 
 
+def _configure_lora_buffer_cpu_backup(kwargs: dict) -> None:
+    kwargs["disable_grad_buffers_cpu_backup"] = True
+
+
 def patch_param_grad_buffer_for_colocate_mode_lora() -> None:
-    """Patch _ParamAndGradBuffer to use disable_param_buffers_cpu_backup=True.
+    """Patch _ParamAndGradBuffer to disable CPU backup for gradient buffers.
 
     In colocate mode with offload_train, torch_memory_saver.pause(tag="default")
     offloads default-region GPU memory.  During LoRA training, base weights are
     frozen (requires_grad=False) so DDP only creates buffers for adapter params.
 
-    This patch ensures those buffers are allocated in the "param_buffer" region
-    (enable_cpu_backup=False), making them invisible to pause(tag="default") —
-    eliminating the need for resume()/pause() around update_weights.
+    Adapter parameter buffers must remain in the default region so their CPU
+    backups are available to update_weights while the trainer sleeps. Gradient
+    buffers can be discarded and rebuilt, so they use a separate no-backup
+    region that sleep()/wake_up() pauses and resumes explicitly.
 
     The patch is idempotent and only takes effect once.
     """
@@ -162,12 +232,11 @@ def patch_param_grad_buffer_for_colocate_mode_lora() -> None:
     _original_init = _ParamAndGradBuffer.__init__
 
     def _patched_init(self, *args, **kwargs):
-        kwargs["disable_param_buffers_cpu_backup"] = True
-        kwargs["disable_grad_buffers_cpu_backup"] = True
+        _configure_lora_buffer_cpu_backup(kwargs)
         _original_init(self, *args, **kwargs)
 
     _ParamAndGradBuffer.__init__ = _patched_init
-    logger.info("Patched _ParamAndGradBuffer.__init__ for LoRA colocate mode (disable cpu backup)")
+    logger.info("Patched _ParamAndGradBuffer.__init__ for LoRA colocate mode (discard gradient buffers on sleep)")
 
 
 # ---------------------------------------------------------------------------
@@ -361,87 +430,111 @@ def save_lora_checkpoint(
 ) -> str:
     """Save LoRA adapter checkpoint to disk.
 
-    Saves in two formats:
-    1. **HF PEFT format** (``adapter_model.bin`` + ``adapter_config.json``) for
-       external tool compatibility. Uses Megatron-Bridge's ``export_adapter_weights``
-       which correctly handles fused QKV / gate-up weight splitting and TP gathering.
-    2. **Megatron-native format** (``adapter_megatron_tp{tp}_pp{pp}.pt``) for fast
-       checkpoint resume without name/weight conversion. Each TP/PP rank saves its
-       own shard with original parameter names.
+    Bridge LoRA saves both HF PEFT and Megatron-native formats. Native Kimi K3
+    LoRA saves one Megatron shard per global rank; materializing its full 896-expert
+    HF adapter on every rank is intentionally kept out of the training checkpoint
+    path.
 
     When ``optimizer`` is provided, training state (optimizer + LR scheduler) is
     also saved per-rank for checkpoint resume. Base model weights are frozen and
     never change, so they are not saved.
 
-    This function is collective: **all ranks must call it** because the bridge
-    export performs TP all-gather internally. Only ``dp_rank == 0`` writes files.
+    This function is collective: all ranks must call it.
     """
     import json
 
-    from megatron.bridge import AutoBridge
-
-    from miles.utils import megatron_bridge_utils
-
     save_path = Path(save_dir)
+    native_kimi_k3 = args.megatron_to_hf_mode == "raw" and "kimi_k3" in (args.model_name or "").lower()
     is_dp_rank_0 = get_parallel_state().effective_dp.rank == 0
     tp_rank = get_parallel_state().tp.rank
     pp_rank = get_parallel_state().pp.rank
+    global_rank = dist.get_rank() if dist.is_initialized() else 0
 
-    # Create directory on dp_rank=0, then synchronize
-    if is_dp_rank_0:
+    if is_dp_rank_0 or native_kimi_k3:
         save_path.mkdir(parents=True, exist_ok=True)
     if dist.is_initialized():
-        dist.barrier()
+        dist.barrier(group=get_gloo_group())
 
     # ---- Megatron-native format (per TP/PP rank, fast resume) ----
-    if is_dp_rank_0:
+    if is_dp_rank_0 or native_kimi_k3:
         adapter_state: dict[str, torch.Tensor] = {}
         for model_chunk in model:
             for name, param in model_chunk.named_parameters():
                 if _is_adapter_param_name(name):
                     adapter_state[name] = param.data.cpu()
 
-        native_path = save_path / f"adapter_megatron_tp{tp_rank}_pp{pp_rank}.pt"
+        if native_kimi_k3:
+            native_path = save_path / f"adapter_megatron_rank{global_rank}.pt"
+        else:
+            native_path = save_path / f"adapter_megatron_tp{tp_rank}_pp{pp_rank}.pt"
         torch.save(adapter_state, native_path)
         logger.info(f"Saved {len(adapter_state)} adapter tensors (native) to {native_path}")
 
-    # ---- HF PEFT format (uses bridge for correct name/weight conversion) ----
-    # Bridge export is collective: all TP ranks participate in the all-gather,
-    # so every rank must call export_adapter_weights.
-    bridge = AutoBridge.from_hf_pretrained(args.hf_checkpoint, trust_remote_code=True)
+    if native_kimi_k3:
+        if global_rank == 0:
+            target_modules_hf = convert_target_modules_to_hf(list(args.target_modules))
+            config = {
+                "peft_type": "LORA",
+                "r": args.lora_rank,
+                "lora_alpha": args.lora_alpha,
+                "target_modules": target_modules_hf,
+                "lora_dropout": args.lora_dropout,
+                "bias": "none",
+                "task_type": "CAUSAL_LM",
+                "experts_shared_outer_loras": True,
+                "format": "megatron_rank_sharded",
+            }
+            with open(save_path / "adapter_config.json", "w") as f:
+                json.dump(config, f, indent=2)
+    else:
+        from megatron.bridge import AutoBridge
 
-    lora_state_dict: dict[str, torch.Tensor] = {}
-    with megatron_bridge_utils.patch_megatron_model(model):
-        for hf_name, weight, _megatron_name in bridge.export_adapter_weights(
-            model,
-            cpu=True,
-            show_progress=False,
-        ):
-            lora_state_dict[hf_name] = weight
+        from miles.utils import megatron_bridge_utils
 
-    # Only one rank writes the HF PEFT files (bridge already gathered across TP)
-    if is_dp_rank_0 and tp_rank == 0:
-        torch.save(lora_state_dict, save_path / "adapter_model.bin")
+        bridge = AutoBridge.from_hf_pretrained(args.hf_checkpoint, trust_remote_code=True)
+        lora_state_dict: dict[str, torch.Tensor] = {}
+        with megatron_bridge_utils.patch_megatron_model(model):
+            for hf_name, weight, _megatron_name in bridge.export_adapter_weights(
+                model,
+                cpu=True,
+                show_progress=False,
+            ):
+                lora_state_dict[hf_name] = weight
 
-        target_modules_hf = (
-            convert_target_modules_to_hf(list(args.target_modules))
-            if args.target_modules
-            else ["q_proj", "k_proj", "v_proj", "o_proj", "gate_proj", "up_proj", "down_proj"]
-        )
-        config = {
-            "peft_type": "LORA",
-            "r": args.lora_rank,
-            "lora_alpha": args.lora_alpha,
-            "target_modules": target_modules_hf,
-            "lora_dropout": args.lora_dropout,
-            "bias": "none",
-            "task_type": "CAUSAL_LM",
-        }
-        with open(save_path / "adapter_config.json", "w") as f:
-            json.dump(config, f, indent=2)
+        if is_dp_rank_0 and tp_rank == 0:
+            torch.save(lora_state_dict, save_path / "adapter_model.bin")
 
+            target_modules_hf = (
+                convert_target_modules_to_hf(list(args.target_modules))
+                if args.target_modules
+                else [
+                    "q_proj",
+                    "k_proj",
+                    "v_proj",
+                    "o_proj",
+                    "gate_proj",
+                    "up_proj",
+                    "down_proj",
+                ]
+            )
+            config = {
+                "peft_type": "LORA",
+                "r": args.lora_rank,
+                "lora_alpha": args.lora_alpha,
+                "target_modules": target_modules_hf,
+                "lora_dropout": args.lora_dropout,
+                "bias": "none",
+                "task_type": "CAUSAL_LM",
+            }
+            with open(save_path / "adapter_config.json", "w") as f:
+                json.dump(config, f, indent=2)
+
+            os.sync()
+            logger.info(f"Saved HF PEFT adapter to {save_path} with " f"{len(lora_state_dict)} tensors")
+
+    if native_kimi_k3 and global_rank == 0:
         os.sync()
-        logger.info(f"Saved HF PEFT adapter to {save_path} with {len(lora_state_dict)} tensors")
+        logger.info(f"Saved rank-sharded Kimi K3 adapter to {save_path}")
 
     # ---- Training state (optimizer + scheduler) for resume ----
     if optimizer is not None:
@@ -457,7 +550,7 @@ def save_lora_checkpoint(
         logger.info(f"Saved optimizer/scheduler state to {save_path}")
 
     if dist.is_initialized():
-        dist.barrier()
+        dist.barrier(group=get_gloo_group())
 
     return str(save_path)
 
@@ -499,16 +592,40 @@ def load_lora_adapter(
     pp_rank = get_parallel_state().pp.rank
 
     # ---- Try Megatron-native format first (fast, no conversion needed) ----
-    native_path = adapter_dir / f"adapter_megatron_tp{tp_rank}_pp{pp_rank}.pt"
+    global_rank = dist.get_rank() if dist.is_initialized() else 0
+    native_path = adapter_dir / f"adapter_megatron_rank{global_rank}.pt"
+    if not native_path.exists():
+        config_path = adapter_dir / "adapter_config.json"
+        if config_path.exists():
+            import json
+
+            with open(config_path) as f:
+                adapter_config = json.load(f)
+            if adapter_config.get("format") == "megatron_rank_sharded":
+                raise FileNotFoundError(
+                    f"Missing Kimi K3 adapter shard for global rank {global_rank}: " f"{native_path}"
+                )
+        native_path = adapter_dir / f"adapter_megatron_tp{tp_rank}_pp{pp_rank}.pt"
     if native_path.exists():
         state_dict = torch.load(native_path, map_location="cpu", weights_only=True)
-        loaded = 0
+        adapter_params = {
+            name: param
+            for model_chunk in model
+            for name, param in model_chunk.named_parameters()
+            if _is_adapter_param_name(name)
+        }
+        missing = adapter_params.keys() - state_dict.keys()
+        unexpected = state_dict.keys() - adapter_params.keys()
+        if missing or unexpected:
+            raise RuntimeError(
+                f"Adapter checkpoint parameter mismatch: missing={sorted(missing)}, "
+                f"unexpected={sorted(unexpected)}"
+            )
         for model_chunk in model:
             for name, param in model_chunk.named_parameters():
                 if name in state_dict:
                     param.data.copy_(state_dict[name].to(device=param.device))
-                    loaded += 1
-        logger.info(f"Loaded {loaded} adapter tensors from Megatron-native checkpoint: {native_path}")
+        logger.info(f"Loaded {len(adapter_params)} adapter tensors from " f"Megatron-native checkpoint: {native_path}")
 
         iteration = _load_training_state(adapter_dir, optimizer, opt_param_scheduler)
         return True, iteration

--- a/miles/backends/megatron_utils/megatron_to_hf/__init__.py
+++ b/miles/backends/megatron_utils/megatron_to_hf/__init__.py
@@ -2,6 +2,7 @@ from .deepseekv3 import convert_deepseekv3_to_hf
 from .deepseekv4 import convert_deepseekv4_to_hf
 from .glm4 import convert_glm4_to_hf
 from .glm4moe import convert_glm4moe_to_hf
+from .kimi_k3 import convert_kimi_k3_to_hf
 from .kimi_vl import convert_kimi_k25_to_hf, convert_kimivl_to_hf
 from .llama import convert_llama_to_hf
 from .mimo import convert_mimo_to_hf
@@ -56,6 +57,8 @@ def _convert_to_hf_core(args, model_name, name, param):
         converted_named_tensors = convert_llama_to_hf(args, name, param)
     elif "mimo" in model_name:
         converted_named_tensors = convert_mimo_to_hf(args, name, param)
+    elif "kimi_k3" in model_name:
+        converted_named_tensors = convert_kimi_k3_to_hf(args, name, param)
     elif "kimivl" in model_name:
         converted_named_tensors = convert_kimivl_to_hf(args, name, param)
     elif "kimi_k25" in model_name:

--- a/miles/backends/megatron_utils/megatron_to_hf/kimi_k3.py
+++ b/miles/backends/megatron_utils/megatron_to_hf/kimi_k3.py
@@ -1,0 +1,109 @@
+import re
+
+from ..update_weight.common import AtomicUpdateGroup
+
+
+_PREFIX = "language_model.model"
+
+
+def get_kimi_k3_atomic_update_groups():
+    return [
+        AtomicUpdateGroup(
+            "qkv_a_proj",
+            (
+                ".self_attention.q_a_proj.weight",
+                ".self_attention.kv_a_proj_with_mqa.weight",
+            ),
+        )
+    ]
+
+
+def convert_kimi_k3_to_hf(args, name, param):
+    del args
+
+    direct = {
+        "module.module.embedding.word_embeddings.weight": f"{_PREFIX}.embed_tokens.weight",
+        "module.module.decoder.final_layernorm.weight": f"{_PREFIX}.norm.weight",
+        "module.module.output_layer.weight": "language_model.lm_head.weight",
+    }
+    if name in direct:
+        return [(direct[name], param)]
+
+    match = re.fullmatch(r"module\.module\.decoder\.layers\.(\d+)\.(.+)", name)
+    if match is None:
+        raise ValueError(f"Unknown Kimi K3 parameter name: {name}")
+    layer_idx, rest = match.groups()
+    layer_prefix = f"{_PREFIX}.layers.{layer_idx}"
+
+    expert_match = re.fullmatch(r"mlp\.experts\.(linear_fc[12])\.weight(\d+)", rest)
+    if expert_match is not None:
+        projection, expert_idx = expert_match.groups()
+        expert_prefix = f"{layer_prefix}.block_sparse_moe.experts.{expert_idx}"
+        if projection == "linear_fc1":
+            gate, up = param.chunk(2, dim=0)
+            return [
+                (f"{expert_prefix}.w1.weight", gate),
+                (f"{expert_prefix}.w3.weight", up),
+            ]
+        return [(f"{expert_prefix}.w2.weight", param)]
+
+    if rest == "mlp.linear_fc1.weight":
+        gate, up = param.chunk(2, dim=0)
+        return [
+            (f"{layer_prefix}.mlp.gate_proj.weight", gate),
+            (f"{layer_prefix}.mlp.up_proj.weight", up),
+        ]
+
+    if rest == "mlp.shared_experts.linear_fc1.weight":
+        gate, up = param.chunk(2, dim=0)
+        shared_prefix = f"{layer_prefix}.block_sparse_moe.shared_experts"
+        return [
+            (f"{shared_prefix}.gate_proj.weight", gate),
+            (f"{shared_prefix}.up_proj.weight", up),
+        ]
+
+    output_mapping = {
+        "output_attn_res_norm.weight": f"{_PREFIX}.output_attn_res_norm.weight",
+        "output_attn_res_proj.weight": f"{_PREFIX}.output_attn_res_proj.weight",
+    }
+    if rest in output_mapping:
+        return [(output_mapping[rest], param)]
+
+    mapping = {
+        "input_layernorm.weight": "input_layernorm.weight",
+        "pre_mlp_layernorm.weight": "post_attention_layernorm.weight",
+        "self_attention_res_norm.weight": "self_attention_res_norm.weight",
+        "self_attention_res_proj.weight": "self_attention_res_proj.weight",
+        "mlp_res_norm.weight": "mlp_res_norm.weight",
+        "mlp_res_proj.weight": "mlp_res_proj.weight",
+        "self_attention.q_proj.weight": "self_attn.q_proj.weight",
+        "self_attention.k_proj.weight": "self_attn.k_proj.weight",
+        "self_attention.v_proj.weight": "self_attn.v_proj.weight",
+        "self_attention.q_conv1d.weight": "self_attn.q_conv1d.weight",
+        "self_attention.k_conv1d.weight": "self_attn.k_conv1d.weight",
+        "self_attention.v_conv1d.weight": "self_attn.v_conv1d.weight",
+        "self_attention.A_log": "self_attn.A_log",
+        "self_attention.dt_bias": "self_attn.dt_bias",
+        "self_attention.f_a_proj.weight": "self_attn.f_a_proj.weight",
+        "self_attention.f_b_proj.weight": "self_attn.f_b_proj.weight",
+        "self_attention.b_proj.weight": "self_attn.b_proj.weight",
+        "self_attention.g_proj.weight": "self_attn.g_proj.weight",
+        "self_attention.o_norm.weight": "self_attn.o_norm.weight",
+        "self_attention.o_proj.weight": "self_attn.o_proj.weight",
+        "self_attention.q_a_proj.weight": "self_attn.q_a_proj.weight",
+        "self_attention.q_a_layernorm.weight": "self_attn.q_a_layernorm.weight",
+        "self_attention.q_b_proj.weight": "self_attn.q_b_proj.weight",
+        "self_attention.kv_a_proj_with_mqa.weight": "self_attn.kv_a_proj_with_mqa.weight",
+        "self_attention.kv_a_layernorm.weight": "self_attn.kv_a_layernorm.weight",
+        "self_attention.kv_b_proj.weight": "self_attn.kv_b_proj.weight",
+        "mlp.linear_fc2.weight": "mlp.down_proj.weight",
+        "mlp.router.weight": "block_sparse_moe.gate.weight",
+        "mlp.router.expert_bias": "block_sparse_moe.gate.e_score_correction_bias",
+        "mlp.fc1_latent_proj.weight": "block_sparse_moe.routed_expert_down_proj.weight",
+        "mlp.routed_expert_norm.weight": "block_sparse_moe.routed_expert_norm.weight",
+        "mlp.fc2_latent_proj.weight": "block_sparse_moe.routed_expert_up_proj.weight",
+        "mlp.shared_experts.linear_fc2.weight": "block_sparse_moe.shared_experts.down_proj.weight",
+    }
+    if rest not in mapping:
+        raise ValueError(f"Unknown Kimi K3 layer parameter name: {name}")
+    return [(f"{layer_prefix}.{mapping[rest]}", param)]

--- a/miles/backends/megatron_utils/megatron_to_hf/processors/quantizer_compressed_tensors.py
+++ b/miles/backends/megatron_utils/megatron_to_hf/processors/quantizer_compressed_tensors.py
@@ -5,6 +5,8 @@ import re
 import torch
 import torch.nn as nn
 
+from miles.utils.mxfp4 import quantize_mxfp4
+
 try:
     import fake_int4_quant_cuda
 except ImportError:
@@ -264,12 +266,19 @@ def pack_layer(weight, group_size, sym=True):
 
 
 def quantize_params_compressed_tensors(converted_named_params, quantization_config):
+    quant_format = quantization_config["format"]
     w_cfg = quantization_config["config_groups"]["group_0"]["weights"]
     group_size = w_cfg["group_size"]
     is_symmetric = w_cfg["symmetric"]
+    is_mxfp4 = quant_format == "mxfp4-pack-quantized"
+    if is_mxfp4:
+        assert w_cfg["type"] == "float"
+        assert w_cfg["num_bits"] == 4
+        assert w_cfg["scale_dtype"] == "torch.uint8"
+        assert is_symmetric
     ignore_rules = quantization_config.get("ignore", [])
     # Base names of params the checkpoint actually stores packed (see
-    # HfWeightIteratorBridge). The published ignore list of multimodal
+    # HfWeightIteratorBase). The published ignore list of multimodal
     # checkpoints (e.g. Kimi-K2.5 VL) only covers LLM submodules, so relying
     # on it alone would wrongly quantize the vision tower / projector.
     quantized_basenames = quantization_config.get("_miles_quantized_basenames")
@@ -290,16 +299,21 @@ def quantize_params_compressed_tensors(converted_named_params, quantization_conf
             results.append((name, param))
             continue
 
-        qw, s, zp = pack_layer(param, group_size, is_symmetric)
         qweight_name = name.replace(".weight", ".weight_packed")
         scale_name = name.replace(".weight", ".weight_scale")
-        weight_shape = torch.tensor(param.shape, dtype=torch.int32, device="cuda")
-        weight_shape_name = name.replace(".weight", ".weight_shape")
-        if zp is not None:
-            zp_name = name.replace(".weight", ".weight_zero_point")
-            results.append((zp_name, zp))
-        results.append((qweight_name, qw))
-        results.append((scale_name, s))
-        results.append((weight_shape_name, weight_shape))
+        if is_mxfp4:
+            qw, s = quantize_mxfp4(param, group_size)
+            results.append((qweight_name, qw))
+            results.append((scale_name, s))
+        else:
+            qw, s, zp = pack_layer(param, group_size, is_symmetric)
+            weight_shape = torch.tensor(param.shape, dtype=torch.int32, device="cuda")
+            weight_shape_name = name.replace(".weight", ".weight_shape")
+            if zp is not None:
+                zp_name = name.replace(".weight", ".weight_zero_point")
+                results.append((zp_name, zp))
+            results.append((qweight_name, qw))
+            results.append((scale_name, s))
+            results.append((weight_shape_name, weight_shape))
 
     return results

--- a/miles/backends/megatron_utils/model.py
+++ b/miles/backends/megatron_utils/model.py
@@ -56,6 +56,7 @@ logger = logging.getLogger(__name__)
 
 
 from .bridge_lora_helpers import _ensure_model_list, _setup_lora_model_via_bridge  # noqa: F401
+from .fp32_param_utils import enforce_marked_param_dtypes
 from .lora_utils import save_lora_checkpoint
 
 
@@ -139,8 +140,20 @@ def setup_model_and_optimizer(
 
     if is_lora_enabled(args) and role == "actor" and args.megatron_to_hf_mode == "bridge":
         model = _setup_lora_model_via_bridge(args)
+        enforce_marked_param_dtypes(model)
     else:
-        model = get_model(get_model_provider_func(args, role), ModelType.encoder_or_decoder)
+        provider_func = get_model_provider_func(args, role)
+        if is_lora_enabled(args) and role == "actor":
+            if "kimi_k3" not in (args.model_name or "").lower():
+                raise NotImplementedError("LoRA with --megatron-to-hf-mode raw is only implemented for Kimi K3")
+            from miles_plugins.models.kimi_k3.lora import wrap_model_provider_with_kimi_k3_lora
+
+            from .lora_utils import patch_param_grad_buffer_for_colocate_mode_lora
+
+            provider_func = wrap_model_provider_with_kimi_k3_lora(provider_func, args)
+            if args.offload_train:
+                patch_param_grad_buffer_for_colocate_mode_lora()
+        model = get_model(provider_func, ModelType.encoder_or_decoder)
 
     if args.debug_disable_optimizer:
         if is_first_replica_megatron_main_rank():
@@ -585,6 +598,9 @@ def finalize_model_grads_with_empty_cache(*args, **kwargs):
     free, total = torch.cuda.mem_get_info(device)
     if free / total < 0.1:
         clear_memory()
+    from .lora_utils import reduce_marked_lora_grads
+
+    reduce_marked_lora_grads(args[0])
     return finalize_model_grads(*args, **kwargs)
 
 

--- a/miles/backends/megatron_utils/update_weight/common.py
+++ b/miles/backends/megatron_utils/update_weight/common.py
@@ -52,6 +52,10 @@ def _get_model_atomic_update_groups(model_name) -> list[AtomicUpdateGroup]:
         from ..megatron_to_hf.deepseekv4 import get_deepseek_v4_atomic_update_groups
 
         return get_deepseek_v4_atomic_update_groups()
+    if "kimi_k3" in model_name:
+        from ..megatron_to_hf.kimi_k3 import get_kimi_k3_atomic_update_groups
+
+        return get_kimi_k3_atomic_update_groups()
     return []
 
 
@@ -263,7 +267,7 @@ def named_params_and_buffers(
 def _maybe_get_cpu_backup(x: torch.Tensor):
     from torch_memory_saver import torch_memory_saver
 
-    if (cpu_tensor := torch_memory_saver.get_cpu_backup(x)) is not None:
+    if (cpu_tensor := torch_memory_saver.get_cpu_backup(x, zero_copy=True)) is not None:
         return cpu_tensor
 
     return x

--- a/miles/backends/megatron_utils/update_weight/hf_weight_iterator_base.py
+++ b/miles/backends/megatron_utils/update_weight/hf_weight_iterator_base.py
@@ -1,3 +1,5 @@
+import json
+import os
 from abc import ABC, abstractmethod
 
 
@@ -18,7 +20,7 @@ class HfWeightIteratorBase(ABC):
         self.args = args
         self.model = model
         self.model_name = model_name
-        self.quantization_config = quantization_config
+        self.quantization_config = _with_checkpoint_quantized_param_basenames(quantization_config, args.hf_checkpoint)
 
     @abstractmethod
     def get_hf_weight_chunks(self, megatron_local_weights, weight_type="base"):
@@ -27,3 +29,20 @@ class HfWeightIteratorBase(ABC):
         megatron_model.to_hf_magically().named_parameters()
         """
         raise NotImplementedError
+
+
+def _with_checkpoint_quantized_param_basenames(quantization_config, hf_checkpoint):
+    if quantization_config is None or quantization_config.get("quant_method") != "compressed-tensors":
+        return quantization_config
+
+    index_path = os.path.join(hf_checkpoint, "model.safetensors.index.json")
+    if not os.path.exists(index_path):
+        return quantization_config
+    with open(index_path) as f:
+        names = json.load(f)["weight_map"]
+    return {
+        **quantization_config,
+        "_miles_quantized_basenames": {
+            name.removesuffix(".weight_packed") for name in names if name.endswith(".weight_packed")
+        },
+    }

--- a/miles/backends/megatron_utils/update_weight/hf_weight_iterator_bridge.py
+++ b/miles/backends/megatron_utils/update_weight/hf_weight_iterator_bridge.py
@@ -1,6 +1,4 @@
 import dataclasses
-import json
-import os
 
 from miles.backends.megatron_utils.lora_utils import is_lora_weight_name
 from miles.utils import megatron_bridge_utils
@@ -19,21 +17,6 @@ class HfWeightIteratorBridge(HfWeightIteratorBase):
         from megatron.bridge import AutoBridge
 
         self._bridge = AutoBridge.from_hf_pretrained(self.args.hf_checkpoint, trust_remote_code=True)
-
-        if (
-            self.quantization_config is not None
-            and self.quantization_config.get("quant_method") == "compressed-tensors"
-        ):
-            quantized_basenames = _load_quantized_param_basenames(self.args.hf_checkpoint)
-            if quantized_basenames is not None:
-                # Quantize exactly the params the checkpoint stores packed; the
-                # published ignore list of multimodal checkpoints (e.g.
-                # Kimi-K2.5 VL) omits vision_tower/mm_projector, so it cannot
-                # be trusted as the sole quantization criterion.
-                self.quantization_config = {
-                    **self.quantization_config,
-                    "_miles_quantized_basenames": quantized_basenames,
-                }
 
     def get_hf_weight_chunks(self, megatron_local_weights, weight_type: str = "base"):
         renamed_megatron_local_weights = {strip_param_name_prefix(k): v for k, v in megatron_local_weights.items()}
@@ -88,16 +71,6 @@ class HfWeightIteratorBridge(HfWeightIteratorBase):
                     yield q_hf_name, q_weight, megatron_param_name
             else:
                 yield hf_name, weight, megatron_param_name
-
-
-def _load_quantized_param_basenames(hf_checkpoint):
-    """Base names of params stored packed (`<base>.weight_packed`) in the checkpoint, or None if unknown."""
-    index_path = os.path.join(hf_checkpoint, "model.safetensors.index.json")
-    if not os.path.exists(index_path):
-        return None
-    with open(index_path) as f:
-        names = json.load(f)["weight_map"]
-    return {n.removesuffix(".weight_packed") for n in names if n.endswith(".weight_packed")}
 
 
 def _stream_atomic_units(items, atomic_update_groups):

--- a/miles/backends/megatron_utils/update_weight/hf_weight_iterator_direct.py
+++ b/miles/backends/megatron_utils/update_weight/hf_weight_iterator_direct.py
@@ -32,6 +32,68 @@ class HfWeightIteratorDirect(HfWeightIteratorBase):
     def get_hf_weight_chunks(self, megatron_local_weights, weight_type="base"):
         rank = dist.get_rank()
 
+        if weight_type == "lora":
+            if "kimi_k3" not in self.model_name.lower():
+                raise NotImplementedError(f"Raw LoRA export is not implemented for model {self.model_name!r}")
+            from miles.backends.megatron_utils.lora_utils import _is_adapter_param_name
+            from miles_plugins.models.kimi_k3.lora import export_kimi_k3_lora_hf_chunks
+
+            cpu_backup_by_parameter = {
+                id(parameter): megatron_local_weights[name]
+                for name, parameter in named_params_and_buffers(self.args, self.model)
+                if _is_adapter_param_name(name)
+            }
+            if not cpu_backup_by_parameter:
+                raise RuntimeError("Kimi K3 LoRA export found no adapter CPU backups")
+
+            def materialize_from_cpu_backup(parameter):
+                backup = cpu_backup_by_parameter.get(id(parameter))
+                if backup is None:
+                    raise RuntimeError("Kimi K3 LoRA parameter is missing from the CPU backup")
+                return backup.cuda()
+
+            pp = get_parallel_state().pp
+            if pp.size == 1:
+                yield from export_kimi_k3_lora_hf_chunks(
+                    self.model,
+                    materialize_parameter=materialize_from_cpu_backup,
+                )
+                return
+
+            # Each rank exports only its pipeline stage's adapters, but every
+            # engine feeder rank must carry the identical full adapter stream
+            # (engine TP groups can span pipeline stages). Replay each stage's
+            # chunk stream across the PP group in stage order, mirroring the
+            # base path's cross-PP broadcast.
+            pp_group_ranks = dist.get_process_group_ranks(pp.group)
+            for pp_src, src_rank in enumerate(pp_group_ranks):
+                if pp.rank == pp_src:
+                    for chunk in export_kimi_k3_lora_hf_chunks(
+                        self.model,
+                        materialize_parameter=materialize_from_cpu_backup,
+                    ):
+                        meta = [(name, tuple(tensor.shape), tensor.dtype) for name, tensor in chunk]
+                        dist.broadcast_object_list([meta], src=src_rank, group=pp.group)
+                        for _, tensor in chunk:
+                            dist.broadcast(tensor, src=src_rank, group=pp.group)
+                        yield chunk
+                    dist.broadcast_object_list([None], src=src_rank, group=pp.group)
+                else:
+                    while True:
+                        holder = [None]
+                        dist.broadcast_object_list(holder, src=src_rank, group=pp.group)
+                        meta = holder[0]
+                        if meta is None:
+                            break
+                        chunk = [
+                            (name, torch.empty(shape, dtype=dtype, device=torch.cuda.current_device()))
+                            for name, shape, dtype in meta
+                        ]
+                        for _, tensor in chunk:
+                            dist.broadcast(tensor, src=src_rank, group=pp.group)
+                        yield chunk
+            return
+
         for megatron_local_param_infos in tqdm(
             self.megatron_local_param_info_buckets, disable=rank != 0, desc="Update weights"
         ):
@@ -167,9 +229,13 @@ def _get_megatron_local_param_infos(args: Namespace, model: Sequence[torch.nn.Mo
     pp_size = get_parallel_state().pp.size
     ep_size = get_parallel_state().ep.size
 
+    from ..lora_utils import _is_adapter_param_name
+
     param_infos = {}
     rank = dist.get_rank()
     for name, param in named_params_and_buffers(args, model):
+        if _is_adapter_param_name(name):
+            continue
         param_infos[name] = ParamInfo(
             name=name,
             dtype=param.dtype,

--- a/miles/backends/megatron_utils/update_weight/update_weight_from_tensor.py
+++ b/miles/backends/megatron_utils/update_weight/update_weight_from_tensor.py
@@ -13,12 +13,13 @@ from miles.backends.megatron_utils.lora_utils import (
     build_lora_sync_config,
     is_lora_weight_name,
     lora_base_cpu_backup_enabled,
+    lora_rollout_base_retained,
 )
 from miles.backends.training_utils.parallel import get_parallel_state
 from miles.utils.distributed_utils import get_gloo_group
 from miles.utils.lora import LORA_ADAPTER_NAME
 
-from ..sglang import FlattenedTensorBucket, MultiprocessingSerializer
+from ..sglang import FlattenedTensorBucket, MultiprocessingSerializer, monkey_patch_torch_reductions
 from .common import _check_weight_sync_results, begin_weight_update, end_weight_update
 from .hf_weight_iterator_base import HfWeightIteratorBase
 from .update_weight_from_distributed.broadcast import (
@@ -28,6 +29,23 @@ from .update_weight_from_distributed.broadcast import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _wait_for_colocated_transfer(refs: Sequence[ObjectRef], ipc_gather_group, *, is_lora: bool) -> None:
+    results = ray.get(refs)
+    _check_weight_sync_results(results, is_lora=is_lora)
+    if ipc_gather_group is not None:
+        dist.barrier(group=ipc_gather_group)
+
+
+def _should_skip_lora_base_sync(
+    *,
+    is_lora: bool,
+    retains_rollout_base: bool,
+    check_weight_update_equal: bool,
+    lora_base_synced: bool,
+) -> bool:
+    return is_lora and retains_rollout_base and (not check_weight_update_equal or lora_base_synced)
 
 
 class UpdateWeightFromTensor:
@@ -70,9 +88,14 @@ class UpdateWeightFromTensor:
             self._lora_loaded = False
             self._lora_base_synced = False
 
-        # Create IPC gather groups within megatron.
-        for start_rank in range(0, dist.get_world_size(), self.args.rollout_num_gpus_per_engine):
-            end_rank = start_rank + self.args.rollout_num_gpus_per_engine
+        # Create IPC gather groups for complete colocated engines. A partial tail
+        # of trainer ranks can be reserved as placeholder GPU slots.
+        self._ipc_gather_group = None
+        self._ipc_gather_src = None
+        world_size = dist.get_world_size()
+        engine_size = self.args.rollout_num_gpus_per_engine
+        for start_rank in range(0, world_size - engine_size + 1, engine_size):
+            end_rank = start_rank + engine_size
             group_ranks = list(range(start_rank, end_rank))
             new_group = dist.new_group(ranks=group_ranks, backend="gloo")
             if dist.get_rank() in group_ranks:
@@ -189,7 +212,7 @@ class UpdateWeightFromTensor:
         return out
 
     @torch.no_grad()
-    def update_weights(self) -> None:
+    def update_weights(self, *, resume_generation: bool = True) -> None:
         """
         version++, flush caches, process buckets. Progress on rank 0.
         """
@@ -202,11 +225,13 @@ class UpdateWeightFromTensor:
         # a host mirror across pause/resume), we can skip the base sync entirely
         # and the surrounding restore_weights_before_load / post_process_quantization
         # calls that would otherwise prep / re-quantize fresh base bytes.
-        # TODO: implement lora weight checker
-        skip_base_sync = (
-            self.is_lora
-            and (self.use_distribute or lora_base_cpu_backup_enabled(self.args))
-            and not getattr(self.args, "check_weight_update_equal", False)
+        skip_base_sync = _should_skip_lora_base_sync(
+            is_lora=self.is_lora,
+            retains_rollout_base=(
+                self.use_distribute or lora_base_cpu_backup_enabled(self.args) or lora_rollout_base_retained(self.args)
+            ),
+            check_weight_update_equal=getattr(self.args, "check_weight_update_equal", False),
+            lora_base_synced=self._lora_base_synced if self.is_lora else False,
         )
 
         if rank == 0:
@@ -224,43 +249,79 @@ class UpdateWeightFromTensor:
                 megatron_local_weights, weight_type="base"
             ):
                 refs, long_lived_tensors = self._send_base_params(hf_named_tensors)
-                results = ray.get(refs)
-                _check_weight_sync_results(results, is_lora=False)
+                _wait_for_colocated_transfer(refs, self._ipc_gather_group, is_lora=False)
                 del long_lived_tensors
 
+            # SGLang restores packed base weights for the duration of a base
+            # update. Close that session before Bridge starts its TP/EP LoRA
+            # gathers; keeping both live exceeds colocated full-model memory.
+            if rank == 0:
+                end_weight_update(self.rollout_engines)
+            dist.barrier(group=get_gloo_group())
+            if self.is_lora:
+                torch.cuda.synchronize()
+                torch.cuda.empty_cache()
+
         if self.is_lora:
-            # SGLang's load_lora_adapter_from_tensors expects the full adapter in
-            # one call; drain the bridge's chunker so --update-weight-buffer-size
-            # only bounds the base path.
-            accumulated_named_tensors: list = []
-            for hf_named_tensors in self._hf_weight_iterator.get_hf_weight_chunks(
-                megatron_local_weights, weight_type="lora"
-            ):
-                accumulated_named_tensors.extend(hf_named_tensors)
-
-            if not accumulated_named_tensors:
+            chunks = iter(self._hf_weight_iterator.get_hf_weight_chunks(megatron_local_weights, weight_type="lora"))
+            try:
+                hf_named_tensors = next(chunks)
+            except StopIteration:
                 raise RuntimeError(
-                    "LoRA weight sync failed: the weight iterator produced zero chunks. "
-                    "No adapter weights were sent to the rollout engine. This usually means "
-                    "the Megatron-Bridge or SGLang version is incompatible."
-                )
+                    "LoRA weight sync failed: the weight iterator produced zero chunks. No adapter weights were sent to the rollout engine. This usually means the Megatron-Bridge or SGLang version is incompatible."
+                ) from None
 
-            refs, long_lived_tensors = self._send_lora_params(accumulated_named_tensors)
-            results = ray.get(refs)
-            _check_weight_sync_results(results, is_lora=True)
+            is_first_chunk = True
+            sent_chunks = 0
+            next_hf_named_tensors = None
+            for next_hf_named_tensors in chunks:
+                refs, long_lived_tensors = self._send_lora_params(
+                    hf_named_tensors,
+                    is_first_chunk=is_first_chunk,
+                    is_last_chunk=False,
+                )
+                _wait_for_colocated_transfer(refs, self._ipc_gather_group, is_lora=True)
+                del long_lived_tensors
+                # Reap this chunk's IPC storage. Only safe here: the receiver
+                # finished the chunk, every producer rank crossed the engine
+                # barrier, and the flattened bucket is deleted, so no handle is
+                # in flight. Collecting earlier double-unlinks shm files.
+                torch.cuda.ipc_collect()
+                sent_chunks += 1
+                hf_named_tensors = next_hf_named_tensors
+                is_first_chunk = False
+
+            refs, long_lived_tensors = self._send_lora_params(
+                hf_named_tensors,
+                is_first_chunk=is_first_chunk,
+                is_last_chunk=True,
+            )
+            _wait_for_colocated_transfer(refs, self._ipc_gather_group, is_lora=True)
             del long_lived_tensors
+            torch.cuda.ipc_collect()
+            sent_chunks += 1
+
+            del chunks, hf_named_tensors, next_hf_named_tensors
+            # Backstop for anything the per-chunk collections left behind.
+            torch.cuda.ipc_collect()
+            torch.cuda.empty_cache()
+
+            if rank == 0:
+                logger.info(
+                    "LoRA weight version %d sent in %d chunks",
+                    self.weight_version,
+                    sent_chunks,
+                )
 
             if not self._lora_base_synced:
                 self._lora_base_synced = True
 
         dist.barrier(group=get_gloo_group())
 
-        if rank == 0:
-            # Skip when no fresh base bytes landed (skip_base_sync).
-            if not skip_base_sync:
-                end_weight_update(self.rollout_engines)
-            ray.get([engine.continue_generation.remote() for engine in self.rollout_engines])
-        dist.barrier(group=get_gloo_group())
+        if resume_generation:
+            if rank == 0:
+                ray.get([engine.continue_generation.remote() for engine in self.rollout_engines])
+            dist.barrier(group=get_gloo_group())
 
     def _send_base_params(self, hf_named_tensors) -> tuple[list[ObjectRef], Any]:
         refs, long_lived_tensors = _send_to_colocated_engine(
@@ -282,11 +343,16 @@ class UpdateWeightFromTensor:
                 refs = (refs or []) + refs_distributed
         return refs or [], long_lived_tensors
 
-    def _send_lora_params(self, hf_named_tensors) -> tuple[list[ObjectRef], Any]:
+    def _send_lora_params(
+        self,
+        hf_named_tensors,
+        *,
+        is_first_chunk: bool = True,
+        is_last_chunk: bool = True,
+    ) -> tuple[list[ObjectRef], Any]:
         if not any(is_lora_weight_name(n) for n, _ in hf_named_tensors):
             raise RuntimeError(
-                "LoRA weight sync failed: chunk contains no LoRA weights "
-                "(no lora_A/lora_B names found). Check weight iterator configuration."
+                "LoRA weight sync failed: chunk contains no LoRA weights (no lora_A/lora_B names found). Check weight iterator configuration."
             )
         if self.use_distribute and self._is_distributed_src_rank:
             raise NotImplementedError("LoRA weight sync is not yet supported for distributed (non-colocated) engines")
@@ -296,11 +362,15 @@ class UpdateWeightFromTensor:
                 ipc_engine=self._ipc_engine,
                 ipc_gather_src=self._ipc_gather_src,
                 ipc_gather_group=self._ipc_gather_group,
+                weight_version=self.weight_version,
                 lora_config=self._lora_config,
                 lora_name=LORA_ADAPTER_NAME,
                 lora_loaded=self._lora_loaded,
+                lora_is_first_chunk=is_first_chunk,
+                lora_is_last_chunk=is_last_chunk,
             )
-            self._lora_loaded = True
+            if is_last_chunk:
+                self._lora_loaded = True
             return refs or [], long_lived_tensors
 
 
@@ -314,6 +384,8 @@ def _send_to_colocated_engine(
     lora_config: dict | None = None,
     lora_name: str | None = None,
     lora_loaded: bool = False,
+    lora_is_first_chunk: bool = True,
+    lora_is_last_chunk: bool = True,
 ) -> tuple[list[ObjectRef], Any]:
     # Placeholder ranks (GPU slots reserved but no engine) have no gather group.
     # gather_object is only collective among group members, so we skip entirely.
@@ -323,8 +395,23 @@ def _send_to_colocated_engine(
     is_lora = lora_config is not None
     is_gather_src = dist.get_rank() == ipc_gather_src
     long_live_tensors = []
+    monkey_patch_torch_reductions()
 
-    if getattr(FlattenedTensorBucket, "supports_multi_dtypes", False):
+    if is_lora:
+        assert weight_version is not None, "LoRA tensor sync requires a weight version"
+        names = [name for name, _ in hf_named_tensors]
+        assert len(set(names)) == len(names), "LoRA adapter contains duplicate HF tensor names"
+        # Use one CUDA IPC allocation per existing chunk. K3 exports thousands
+        # of tensors; serializing them individually overflows PyTorch's CUDA IPC
+        # limbo before the receiver-side references are reaped.
+        flattened_tensor_bucket = FlattenedTensorBucket(named_tensors=hf_named_tensors)
+        flattened_tensor_data = {
+            "flattened_tensor": flattened_tensor_bucket.get_flattened_tensor(),
+            "metadata": flattened_tensor_bucket.get_metadata(),
+        }
+        long_live_tensors.append(flattened_tensor_data)
+        serialized_tensors = [MultiprocessingSerializer.serialize(flattened_tensor_data, output_str=True)]
+    elif getattr(FlattenedTensorBucket, "supports_multi_dtypes", False):
         converted_named_tensors_by_dtypes = {"dtype": hf_named_tensors}
     else:
         converted_named_tensors_by_dtypes = {}
@@ -334,15 +421,16 @@ def _send_to_colocated_engine(
                 converted_named_tensors_by_dtypes[dtype] = []
             converted_named_tensors_by_dtypes[dtype].append((name, tensor))
 
-    serialized_tensors: list = []
-    for _dtype, named_tensors in converted_named_tensors_by_dtypes.items():
-        flattened_tensor_bucket = FlattenedTensorBucket(named_tensors=named_tensors)
-        flattened_tensor_data = {
-            "flattened_tensor": flattened_tensor_bucket.get_flattened_tensor(),
-            "metadata": flattened_tensor_bucket.get_metadata(),
-        }
-        long_live_tensors.append(flattened_tensor_data)
-        serialized_tensors.append(MultiprocessingSerializer.serialize(flattened_tensor_data, output_str=True))
+    if not is_lora:
+        serialized_tensors = []
+        for _dtype, named_tensors in converted_named_tensors_by_dtypes.items():
+            flattened_tensor_bucket = FlattenedTensorBucket(named_tensors=named_tensors)
+            flattened_tensor_data = {
+                "flattened_tensor": flattened_tensor_bucket.get_flattened_tensor(),
+                "metadata": flattened_tensor_bucket.get_metadata(),
+            }
+            long_live_tensors.append(flattened_tensor_data)
+            serialized_tensors.append(MultiprocessingSerializer.serialize(flattened_tensor_data, output_str=True))
 
     serialized_named_tensors = [None] * dist.get_world_size(ipc_gather_group) if is_gather_src else None
     dist.gather_object(
@@ -355,7 +443,7 @@ def _send_to_colocated_engine(
     refs = []
     if is_gather_src:
         if is_lora:
-            if lora_loaded:
+            if lora_is_first_chunk and lora_loaded:
                 ray.get(ipc_engine.unload_lora_adapter.remote(lora_name=lora_name))
 
             # (Yusheng) to-do-1: update lora weights from tensors should support multiple dtypes (bf16, fp8, fp16, fp32)
@@ -363,16 +451,22 @@ def _send_to_colocated_engine(
             # Thus, we need to apply the same way as `ipc_engine.update_weights_from_tensor` in future
             # (Yusheng) to-do-2: need to add ci test acc here - now it will pass but fail to update lora weights
 
+            assert all(
+                len(rank_payloads) == 1 for rank_payloads in serialized_named_tensors
+            ), "LoRA tensor sync requires one payload per engine rank"
+
             refs.append(
                 ipc_engine.load_lora_adapter_from_tensors.remote(
                     lora_name=lora_name,
                     config_dict=lora_config,
-                    serialized_named_tensors=[
-                        per_rank[0] if per_rank else None for per_rank in serialized_named_tensors
-                    ],
+                    serialized_tensors=[rank_payloads[0] for rank_payloads in serialized_named_tensors],
                     load_format="flattened_bucket",
+                    is_first_chunk=lora_is_first_chunk,
+                    is_last_chunk=lora_is_last_chunk,
                 )
             )
+            if lora_is_last_chunk:
+                refs.append(ipc_engine.update_weight_version.remote(weight_version=str(weight_version)))
 
         else:
             num_dtypes = len(serialized_named_tensors[0])

--- a/miles/backends/megatron_utils/update_weight/update_weight_from_tensor.py
+++ b/miles/backends/megatron_utils/update_weight/update_weight_from_tensor.py
@@ -282,11 +282,6 @@ class UpdateWeightFromTensor:
                 )
                 _wait_for_colocated_transfer(refs, self._ipc_gather_group, is_lora=True)
                 del long_lived_tensors
-                # Reap this chunk's IPC storage. Only safe here: the receiver
-                # finished the chunk, every producer rank crossed the engine
-                # barrier, and the flattened bucket is deleted, so no handle is
-                # in flight. Collecting earlier double-unlinks shm files.
-                torch.cuda.ipc_collect()
                 sent_chunks += 1
                 hf_named_tensors = next_hf_named_tensors
                 is_first_chunk = False
@@ -298,12 +293,9 @@ class UpdateWeightFromTensor:
             )
             _wait_for_colocated_transfer(refs, self._ipc_gather_group, is_lora=True)
             del long_lived_tensors
-            torch.cuda.ipc_collect()
             sent_chunks += 1
 
             del chunks, hf_named_tensors, next_hf_named_tensors
-            # Backstop for anything the per-chunk collections left behind.
-            torch.cuda.ipc_collect()
             torch.cuda.empty_cache()
 
             if rank == 0:

--- a/miles/backends/sglang_utils/sglang_engine.py
+++ b/miles/backends/sglang_utils/sglang_engine.py
@@ -57,7 +57,6 @@ def launch_server_process(server_args: ServerArgs) -> multiprocessing.Process:
     from sglang.srt.entrypoints.http_server import launch_server
 
     multiprocessing.set_start_method("spawn", force=True)
-    server_args.host = server_args.host.strip("[]")
     p = multiprocessing.Process(target=launch_server, args=(server_args,))
     p.start()
 
@@ -213,6 +212,7 @@ class SGLangEngine(RayActor):
 
     def _init_normal(self, server_args_dict):
         logger.info(f"Launch HttpServerEngineAdapter at: {self.server_host}:{self.server_port}")
+        server_args_dict = {**server_args_dict, "host": server_args_dict["host"].strip("[]")}
         self.process = launch_server_process(ServerArgs(**server_args_dict))
 
         if self.node_rank == 0 and self.router_ip and self.router_port:
@@ -337,17 +337,21 @@ class SGLangEngine(RayActor):
         self,
         lora_name: str,
         config_dict: dict,
-        serialized_named_tensors: list,
+        serialized_tensors: str | list[str],
         load_format: str | None = None,
         pinned: bool = False,
         added_tokens_config: dict | None = None,
+        is_first_chunk: bool = True,
+        is_last_chunk: bool = True,
     ):
-        """Load a LoRA adapter. ``serialized_named_tensors[tp_rank]`` is bytes for TP rank N."""
+        """Load a LoRA adapter chunk; SGLang applies TP/EP slicing internally."""
         payload = {
             "lora_name": lora_name,
             "config_dict": config_dict,
-            "serialized_named_tensors": serialized_named_tensors,
+            "serialized_tensors": serialized_tensors,
             "pinned": pinned,
+            "is_first_chunk": is_first_chunk,
+            "is_last_chunk": is_last_chunk,
         }
         if load_format is not None:
             payload["load_format"] = load_format

--- a/miles/backends/training_utils/cp_utils.py
+++ b/miles/backends/training_utils/cp_utils.py
@@ -3,15 +3,9 @@ from collections.abc import Callable
 
 import torch
 import torch.distributed as dist
-import torch.nn as nn
 import torch.nn.functional as F
 
 from .parallel import get_parallel_state
-
-try:
-    from fla.ops.cp import build_cp_context as _fla_build_cp_context
-except ImportError:
-    _fla_build_cp_context = None
 
 logger = logging.getLogger(__name__)
 
@@ -422,30 +416,3 @@ def slice_log_prob_with_cp(
         return chunk_1 + chunk_2
     else:
         return torch.cat([chunk_1, chunk_2], dim=0)
-
-
-def build_gdn_cp_context(module: nn.Module, cu_seqlens: torch.Tensor, device: torch.device):
-    """Build fla CP context for a GatedDeltaNet module from packed sequence boundaries.
-
-    Args:
-        module: GDN module with ``cp_group`` / ``cp_world_size`` / ``conv_kernel_size``.
-        cu_seqlens: Global packed sequence boundaries (e.g. ``packed_seq_params.cu_seqlens_q``).
-        device: Target device.
-
-    Returns ``None`` when CP is not configured on the module (``cp_group`` not set).
-    Raises ``RuntimeError`` if hybrid CP is configured but ``fla.ops.cp`` is missing.
-    """
-    cp_group = getattr(module, "cp_group", None)
-    if cp_group is None:
-        return None
-    if _fla_build_cp_context is None:
-        raise RuntimeError(
-            "Hybrid CP requires fla.ops.cp (flash-linear-attention >= 0.4.2) " "but it could not be imported."
-        )
-    if cu_seqlens is None or cu_seqlens.numel() < 2:
-        raise ValueError(f"Hybrid CP requires valid cu_seqlens (at least 2 elements) but got {cu_seqlens}")
-    return _fla_build_cp_context(
-        cu_seqlens=cu_seqlens.to(device=device, dtype=torch.int32),
-        group=cp_group,
-        conv1d_kernel_size=module.conv_kernel_size,
-    )

--- a/miles/ray/actor_group.py
+++ b/miles/ray/actor_group.py
@@ -100,6 +100,8 @@ class RayTrainGroup:
         await self.rollout_manager.health_monitoring_pause.remote()
 
         await self._broadcast("update_weights", info=info)
+        if self.args.colocate and self.args.offload_train and not self.args.debug_skip_weight_update:
+            await asyncio.gather(*(engine.continue_generation.remote() for engine in info.rollout_engines))
 
     async def onload(self):
         await self._broadcast("wake_up")

--- a/miles/ray/actor_group.py
+++ b/miles/ray/actor_group.py
@@ -112,6 +112,9 @@ class RayTrainGroup:
     async def clear_memory(self):
         await self._broadcast("clear_memory")
 
+    async def offload_grad_buffer(self):
+        await self._broadcast("offload_grad_buffer")
+
     async def connect(self, critic_group):
         refs = [
             actor.connect_actor_critic.remote(critic)

--- a/miles/ray/placement_group.py
+++ b/miles/ray/placement_group.py
@@ -214,6 +214,11 @@ def create_rollout_manager(args, pg):
         )
 
     if args.offload_rollout:
-        ray.get(rollout_manager.offload.remote(tags=get_rollout_offload_tags(args)))
+        if getattr(args, "colocate_memory_peak_device", "cpu") == "gpu":
+            # Keep the engine weights resident through trainer init: their host
+            # mirror cannot coexist with the checkpoint load's footprint.
+            ray.get(rollout_manager.offload_kv.remote())
+        else:
+            ray.get(rollout_manager.offload.remote(tags=get_rollout_offload_tags(args)))
 
     return rollout_manager, num_rollout_per_epoch

--- a/miles/ray/placement_group.py
+++ b/miles/ray/placement_group.py
@@ -9,7 +9,7 @@ from miles.utils.async_utils import eager_create_task
 from miles.utils.environ import enable_experimental_ft_trainer
 
 from ..utils.ray_utils import compute_ray_pin_head_options
-from .rollout.rollout_manager import RolloutManager
+from .rollout.rollout_manager import RolloutManager, get_rollout_offload_tags
 
 logger = logging.getLogger(__name__)
 
@@ -202,12 +202,18 @@ def create_rollout_manager(args, pg):
         assert args.num_rollout > 0
 
     if args.check_weight_update_equal:
-        ray.get(rollout_manager.check_weights.remote(action="snapshot"))
+        snapshot_action = "snapshot" if args.check_weight_update_allow_quant_error else "snapshot_checksum"
+        ray.get(
+            rollout_manager.check_weights.remote(
+                action=snapshot_action,
+                skip_list=args.check_weight_update_skip_list,
+            )
+        )
         ray.get(
             rollout_manager.check_weights.remote(action="reset_tensors", skip_list=args.check_weight_update_skip_list)
         )
 
     if args.offload_rollout:
-        ray.get(rollout_manager.offload.remote())
+        ray.get(rollout_manager.offload.remote(tags=get_rollout_offload_tags(args)))
 
     return rollout_manager, num_rollout_per_epoch

--- a/miles/ray/rollout/rollout_manager.py
+++ b/miles/ray/rollout/rollout_manager.py
@@ -211,12 +211,24 @@ class RolloutManager:
 
     async def onload_weights(self):
         if "weight" not in self.args.offload_rollout_level:
-            # Weights stayed resident on the GPU; only kv/graphs were offloaded.
             return
         await self.onload(tags=[GPU_MEMORY_TYPE_WEIGHTS])
 
     async def onload_kv(self):
         await self.onload(tags=[GPU_MEMORY_TYPE_KV_CACHE, GPU_MEMORY_TYPE_CUDA_GRAPH])
+
+    # Split offloads for --colocate-memory-peak-device gpu: kv/graphs are pure
+    # GPU memory, while releasing the weights builds their host mirror.
+    async def offload_kv(self):
+        tags = [GPU_MEMORY_TYPE_CUDA_GRAPH]
+        if "kv_cache" in self.args.offload_rollout_level:
+            tags.append(GPU_MEMORY_TYPE_KV_CACHE)
+        await self.offload(tags=tags)
+
+    async def offload_weights(self):
+        if "weight" not in self.args.offload_rollout_level:
+            return
+        await self.offload(tags=[GPU_MEMORY_TYPE_WEIGHTS])
 
     # -------------------------- engine management -----------------------------
 

--- a/miles/ray/rollout/rollout_manager.py
+++ b/miles/ray/rollout/rollout_manager.py
@@ -41,6 +41,15 @@ logging.getLogger("httpcore").setLevel(logging.WARNING)
 logger = logging.getLogger(__name__)
 
 
+def get_rollout_offload_tags(args) -> list[str]:
+    tags = [GPU_MEMORY_TYPE_CUDA_GRAPH]
+    if "kv_cache" in args.offload_rollout_level:
+        tags.append(GPU_MEMORY_TYPE_KV_CACHE)
+    if "weight" in args.offload_rollout_level:
+        tags.append(GPU_MEMORY_TYPE_WEIGHTS)
+    return tags
+
+
 @ray.remote
 class RolloutManager:
     """The class to run rollout and convert rollout data to training data."""
@@ -201,6 +210,9 @@ class RolloutManager:
             await srv.onload(tags)
 
     async def onload_weights(self):
+        if "weight" not in self.args.offload_rollout_level:
+            # Weights stayed resident on the GPU; only kv/graphs were offloaded.
+            return
         await self.onload(tags=[GPU_MEMORY_TYPE_WEIGHTS])
 
     async def onload_kv(self):

--- a/miles/ray/train/actor_factory.py
+++ b/miles/ray/train/actor_factory.py
@@ -38,12 +38,12 @@ def allocate_gpus_for_actor(
         env_vars["DUMPER_SOURCE_PATCHER_CONFIG"] = source_patcher_config
 
     if args.offload_train and args.train_backend == "megatron":
-        import torch_memory_saver
+        from torch_memory_saver.utils import get_binary_path_from_package
 
-        dynlib_path = os.path.join(
-            os.path.dirname(os.path.dirname(torch_memory_saver.__file__)),
-            "torch_memory_saver_hook_mode_preload.abi3.so",
-        )
+        # The packaged binary name carries a per-build suffix on recent
+        # torch_memory_saver (e.g. _hook_mode_preload_cu13.abi3.so), so resolve
+        # it through the package helper instead of hardcoding the filename.
+        dynlib_path = str(get_binary_path_from_package("torch_memory_saver_hook_mode_preload"))
         assert os.path.exists(dynlib_path), f"LD_PRELOAD so file {dynlib_path} does not exist."
 
         env_vars["LD_PRELOAD"] = dynlib_path

--- a/miles/ray/train/group.py
+++ b/miles/ray/train/group.py
@@ -265,6 +265,8 @@ class RayTrainGroup:
             lambda _: self._execute_first_alive("update_weights", info=info),
             max_attempts=_RETRY_MAX_ATTEMPTS,
         )
+        if self.args.colocate and self.args.offload_train and not self.args.debug_skip_weight_update:
+            await asyncio.gather(*(engine.continue_generation.remote() for engine in info.rollout_engines))
 
         await self._maybe_log_inference_engine_weight_checksums(rollout_id=rollout_id)
 

--- a/miles/ray/train/group.py
+++ b/miles/ray/train/group.py
@@ -299,6 +299,10 @@ class RayTrainGroup:
         # Catch *without* retry: cells w/ exceptions are auto marked errored, and will not be used
         await self._execute_all_alive_and_catch("clear_memory")
 
+    async def offload_grad_buffer(self):
+        # Catch *without* retry: cells w/ exceptions are auto marked errored, and will not be used
+        await self._execute_all_alive_and_catch("offload_grad_buffer")
+
     async def connect(self, critic_group: "RayTrainGroup"):
         assert len(self._cells) == len(critic_group._cells), (
             f"Actor and critic must have the same number of cells: "

--- a/miles/rollout/rm_hub/deepscaler.py
+++ b/miles/rollout/rm_hub/deepscaler.py
@@ -36,7 +36,12 @@ def _grade_boxed_solution(model_solution, label):
 
 
 def get_deepscaler_rule_based_reward(response, label):
-    if "</think>" in response:
+    if "<|open|>response<|sep|>" in response:
+        # Kimi K-series emits a thinking channel then a response channel
+        # (`…<|close|>think<|sep|><|open|>response<|sep|>…`) instead of </think>.
+        # Grade only the response channel, where the final \boxed answer lives.
+        model_solution = response.split("<|open|>response<|sep|>")[-1]
+    elif "</think>" in response:
         model_solution = response.split("</think>")[-1]
     elif "###Response" in response:
         model_solution = response.split("###Response")[1]

--- a/miles/router/router.py
+++ b/miles/router/router.py
@@ -76,7 +76,11 @@ class MilesRouter:
     async def _check_worker_health(self, url):
         """Encapsulated health check logic for better maintainability."""
         try:
-            response = await self.client.get(f"{url}/health", timeout=5.0)
+            # Colocate engines under long (multi-thousand-token) generations, or
+            # briefly paused during a weight-sync sleep, can be slow to answer
+            # /health while still alive. A 5s timeout falsely marks them dead; use
+            # a generous timeout so only truly-hung engines are quarantined.
+            response = await self.client.get(f"{url}/health", timeout=30.0)
             if response.status_code == 200:
                 return url, True
             logger.debug(f"[miles-router] Worker {url} is unhealthy (Status: {response.status_code})")

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -1379,7 +1379,10 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 help=(
                     "LoRA + colocate: keep SGLang-side CPU mirror of base weights "
                     "and skip per-step base sync. Trades host RAM for faster "
-                    "onload/offload. Ignored unless --colocate and LoRA are both on."
+                    "onload/offload. Ignored unless --colocate and LoRA are both on. "
+                    "Also needs 'weight' in --offload-rollout-level: SGLang populates "
+                    "the mirror during release_weights_occupation, so with the weights "
+                    "never released the mirror is never built and the flag does nothing."
                 ),
             )
             parser.add_argument(

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -124,6 +124,22 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 ),
             )
 
+            parser.add_argument(
+                "--colocate-memory-peak-device",
+                type=str,
+                choices=["cpu", "gpu"],
+                default="cpu",
+                help=(
+                    "Which device absorbs the trainer<->rollout handoff overlap. 'cpu' "
+                    "(default): each side offloads before the other onloads, so the "
+                    "engine's weight mirror and the trainer's backup briefly coexist in "
+                    "host memory. 'gpu': onload the other side first, so both sides "
+                    "briefly coexist in GPU memory instead and the two host copies never "
+                    "overlap. Use 'gpu' when host RAM is the tighter budget than the "
+                    "handoff headroom on the GPU."
+                ),
+            )
+
             reset_arg(parser, "--distributed-backend", type=str, default="nccl")
             reset_arg(parser, "--distributed-timeout-minutes", type=int, default=10)
 

--- a/miles/utils/http_utils.py
+++ b/miles/utils/http_utils.py
@@ -171,7 +171,7 @@ def terminate_process(process: multiprocessing.Process, timeout: float = 1.0) ->
         process.join()
 
 
-_http_client: httpx.AsyncClient | None = None
+_http_clients: dict[asyncio.AbstractEventLoop, tuple[int, httpx.AsyncClient]] = {}
 _client_concurrency: int = 0
 
 # Optional Ray-based distributed POST dispatch
@@ -226,16 +226,13 @@ async def _post(client, url, payload, max_retries=60, action="post", headers=Non
 
 def init_http_client(args):
     """Initialize HTTP client and optionally enable distributed POST via Ray."""
-    global _http_client, _client_concurrency, _distributed_post_enabled
+    global _client_concurrency, _distributed_post_enabled
     if not args.rollout_num_gpus:
         return
 
     _client_concurrency = args.sglang_server_concurrency * args.rollout_num_gpus // args.rollout_num_gpus_per_engine
-    if _http_client is None:
-        _http_client = httpx.AsyncClient(
-            limits=httpx.Limits(max_connections=_client_concurrency),
-            timeout=httpx.Timeout(None),
-        )
+    if _client_concurrency <= 0:
+        raise ValueError(f"HTTP client concurrency must be positive, got {_client_concurrency}")
 
     # Optionally initialize distributed POST via Ray without changing interfaces
     if args.use_distributed_post:
@@ -267,7 +264,7 @@ def _init_ray_distributed_post(args):
         def __init__(self, concurrency: int):
             # Lazy creation to this actor's event loop
             self._client = httpx.AsyncClient(
-                limits=httpx.Limits(max_connections=max(1, concurrency)),
+                limits=httpx.Limits(max_connections=max(1, concurrency), max_keepalive_connections=0),
                 timeout=httpx.Timeout(None),
             )
 
@@ -296,6 +293,25 @@ def _init_ray_distributed_post(args):
     _post_actors = created
 
 
+def _get_http_client() -> httpx.AsyncClient:
+    if _client_concurrency <= 0:
+        raise RuntimeError("HTTP client is not initialized; call init_http_client first")
+
+    loop = asyncio.get_running_loop()
+    entry = _http_clients.get(loop)
+    if entry is not None and entry[0] == _client_concurrency:
+        return entry[1]
+
+    if entry is not None:
+        loop.create_task(entry[1].aclose())
+    client = httpx.AsyncClient(
+        limits=httpx.Limits(max_connections=_client_concurrency, max_keepalive_connections=0),
+        timeout=httpx.Timeout(None),
+    )
+    _http_clients[loop] = (_client_concurrency, client)
+    return client
+
+
 # TODO may generalize the name since it now contains http DELETE/GET etc (with retries and remote-execution)
 async def post(url, payload, max_retries=60, action="post", headers=None):
     # If distributed mode is enabled and actors exist, dispatch via Ray.
@@ -308,12 +324,12 @@ async def post(url, payload, max_retries=60, action="post", headers=None):
             logger.info(f"[http_utils] Distributed POST failed, falling back to local: {e} (url={url})")
             # fall through to local
 
-    return await _post(_http_client, url, payload, max_retries, action=action, headers=headers)
+    return await _post(_get_http_client(), url, payload, max_retries, action=action, headers=headers)
 
 
 # TODO unify w/ `post` to add retries and remote-execution
 async def get(url):
-    response = await _http_client.get(url)
+    response = await _get_http_client().get(url)
     response.raise_for_status()
     output = response.json()
     return output

--- a/miles/utils/mxfp4.py
+++ b/miles/utils/mxfp4.py
@@ -1,0 +1,61 @@
+"""MXFP4 (E2M1 elements + E8M0 block scales) pack/unpack.
+
+Kept as a torch-only leaf module so checkpoint tooling can convert an
+``mxfp4-pack-quantized`` compressed-tensors checkpoint without importing
+Megatron, which ``megatron_to_hf.processors`` pulls in.
+"""
+
+import torch
+
+_E2M1_VALUES = (0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0)
+
+
+def quantize_mxfp4(weight, group_size):
+    assert weight.shape[-1] % group_size == 0
+    assert weight.shape[-1] % 2 == 0
+
+    blocks = weight.reshape(-1, group_size)
+    amax = blocks.abs().amax(dim=-1, keepdim=True).float()
+    scale_exp = torch.ceil(torch.log2(amax / 6.0)).clamp_(-127, 127)
+    normalized = blocks.float() * torch.exp2(-scale_exp)
+
+    magnitude = torch.zeros_like(normalized, dtype=torch.uint8)
+    for bound in (0.25, 0.75, 1.25, 1.75, 2.5, 3.5, 5.0):
+        magnitude.add_(normalized.abs() > bound)
+    encoded = magnitude | (torch.signbit(normalized).to(torch.uint8) << 3)
+
+    packed = encoded[:, 0::2] | (encoded[:, 1::2] << 4)
+    packed = packed.reshape(*weight.shape[:-1], weight.shape[-1] // 2).contiguous()
+    scale = (scale_exp + 127).to(torch.uint8)
+    scale = scale.reshape(*weight.shape[:-1], weight.shape[-1] // group_size).contiguous()
+    return packed, scale
+
+
+def dequantize_mxfp4(
+    weight_packed: torch.Tensor,
+    weight_scale: torch.Tensor,
+    group_size: int,
+) -> torch.Tensor:
+    assert weight_packed.dtype == torch.uint8
+    assert weight_scale.dtype == torch.uint8
+    assert group_size > 0
+
+    unpacked = torch.empty(
+        *weight_packed.shape[:-1],
+        weight_packed.shape[-1] * 2,
+        dtype=torch.uint8,
+        device=weight_packed.device,
+    )
+    unpacked[..., 0::2] = weight_packed & 0x0F
+    unpacked[..., 1::2] = (weight_packed >> 4) & 0x0F
+
+    signs = 1.0 - 2.0 * ((unpacked & 0b1000) >> 3).float()
+    magnitudes = unpacked & 0b0111
+    values = torch.tensor(_E2M1_VALUES, dtype=torch.float32, device=weight_packed.device)
+    dequantized = signs * values[magnitudes.long()]
+
+    assert dequantized.numel() % group_size == 0
+    assert weight_scale.numel() == dequantized.numel() // group_size
+    dequantized = dequantized.reshape(-1, group_size)
+    scales = torch.exp2(weight_scale.float().reshape(-1, 1) - 127.0)
+    return (dequantized * scales).reshape(unpacked.shape).to(torch.bfloat16).contiguous()

--- a/miles_plugins/mbridge/__init__.py
+++ b/miles_plugins/mbridge/__init__.py
@@ -4,6 +4,7 @@ from .glm4 import GLM4Bridge
 from .glm4moe import GLM4MoEBridge
 from .glm4moe_lite import GLM4MoELiteBridge
 from .joyai_llm_flash import JoyAILLMFlashBridge
+from .kimi_k3 import KimiK3Bridge
 from .mimo import MimoBridge
 from .qwen3_5 import Qwen3_5Bridge
 from .qwen3_next import Qwen3NextBridge
@@ -18,4 +19,5 @@ __all__ = [
     "DeepseekV32Bridge",
     "DeepseekV4Bridge",
     "JoyAILLMFlashBridge",
+    "KimiK3Bridge",
 ]

--- a/miles_plugins/mbridge/kimi_k3.py
+++ b/miles_plugins/mbridge/kimi_k3.py
@@ -1,0 +1,219 @@
+import inspect
+
+import torch
+from megatron.core.transformer import MLATransformerConfig
+from megatron.core.transformer.enums import AttnBackend
+
+from mbridge.core import register_model
+from mbridge.core.safetensor_io import SafeTensorIO
+from mbridge.models import DeepseekV3Bridge
+
+from miles_plugins.models.kimi_k3.model import build_kimi_k3_spec
+from miles_plugins.models.kimi_k3.ops import situ_and_mul
+
+
+@register_model("kimi_k3")
+class KimiK3Bridge(DeepseekV3Bridge):
+    TransformerConfigClass = MLATransformerConfig
+
+    _CONFIG_MAPPING = {
+        "num_layers": "num_hidden_layers",
+        "hidden_size": "hidden_size",
+        "num_attention_heads": "num_attention_heads",
+        "num_query_groups": "num_key_value_heads",
+        "ffn_hidden_size": "intermediate_size",
+        "attention_dropout": ("attention_dropout", 0.0),
+        "layernorm_epsilon": "rms_norm_eps",
+        "hidden_dropout": ("hidden_dropout", 0.0),
+        "kv_channels": "head_dim",
+    }
+
+    _DIRECT_MAPPING = {
+        "embedding.word_embeddings.weight": "language_model.model.embed_tokens.weight",
+        "decoder.final_layernorm.weight": "language_model.model.norm.weight",
+        "output_layer.weight": "language_model.lm_head.weight",
+    }
+
+    _ATTENTION_MAPPING = {
+        "input_layernorm.weight": ["language_model.model.layers.{layer_number}.input_layernorm.weight"],
+        "self_attention.q_proj.weight": ["language_model.model.layers.{layer_number}.self_attn.q_proj.weight"],
+        "self_attention.k_proj.weight": ["language_model.model.layers.{layer_number}.self_attn.k_proj.weight"],
+        "self_attention.v_proj.weight": ["language_model.model.layers.{layer_number}.self_attn.v_proj.weight"],
+        "self_attention.q_conv1d.weight": ["language_model.model.layers.{layer_number}.self_attn.q_conv1d.weight"],
+        "self_attention.k_conv1d.weight": ["language_model.model.layers.{layer_number}.self_attn.k_conv1d.weight"],
+        "self_attention.v_conv1d.weight": ["language_model.model.layers.{layer_number}.self_attn.v_conv1d.weight"],
+        "self_attention.A_log": ["language_model.model.layers.{layer_number}.self_attn.A_log"],
+        "self_attention.dt_bias": ["language_model.model.layers.{layer_number}.self_attn.dt_bias"],
+        "self_attention.f_a_proj.weight": ["language_model.model.layers.{layer_number}.self_attn.f_a_proj.weight"],
+        "self_attention.f_b_proj.weight": ["language_model.model.layers.{layer_number}.self_attn.f_b_proj.weight"],
+        "self_attention.b_proj.weight": ["language_model.model.layers.{layer_number}.self_attn.b_proj.weight"],
+        "self_attention.g_proj.weight": ["language_model.model.layers.{layer_number}.self_attn.g_proj.weight"],
+        "self_attention.o_norm.weight": ["language_model.model.layers.{layer_number}.self_attn.o_norm.weight"],
+        "self_attention.o_proj.weight": ["language_model.model.layers.{layer_number}.self_attn.o_proj.weight"],
+        "self_attention.q_a_proj.weight": ["language_model.model.layers.{layer_number}.self_attn.q_a_proj.weight"],
+        "self_attention.q_a_layernorm.weight": [
+            "language_model.model.layers.{layer_number}.self_attn.q_a_layernorm.weight"
+        ],
+        "self_attention.q_b_proj.weight": ["language_model.model.layers.{layer_number}.self_attn.q_b_proj.weight"],
+        "self_attention.kv_a_proj_with_mqa.weight": [
+            "language_model.model.layers.{layer_number}.self_attn.kv_a_proj_with_mqa.weight"
+        ],
+        "self_attention.kv_a_layernorm.weight": [
+            "language_model.model.layers.{layer_number}.self_attn.kv_a_layernorm.weight"
+        ],
+        "self_attention.kv_b_proj.weight": ["language_model.model.layers.{layer_number}.self_attn.kv_b_proj.weight"],
+        "self_attention_res_norm.weight": [
+            "language_model.model.layers.{layer_number}.self_attention_res_norm.weight"
+        ],
+        "self_attention_res_proj.weight": [
+            "language_model.model.layers.{layer_number}.self_attention_res_proj.weight"
+        ],
+    }
+
+    _MLP_MAPPING = {
+        "pre_mlp_layernorm.weight": ["language_model.model.layers.{layer_number}.post_attention_layernorm.weight"],
+        "mlp_res_norm.weight": ["language_model.model.layers.{layer_number}.mlp_res_norm.weight"],
+        "mlp_res_proj.weight": ["language_model.model.layers.{layer_number}.mlp_res_proj.weight"],
+        "mlp.linear_fc1.weight": [
+            "language_model.model.layers.{layer_number}.mlp.gate_proj.weight",
+            "language_model.model.layers.{layer_number}.mlp.up_proj.weight",
+        ],
+        "mlp.linear_fc2.weight": ["language_model.model.layers.{layer_number}.mlp.down_proj.weight"],
+        "mlp.router.weight": ["language_model.model.layers.{layer_number}.block_sparse_moe.gate.weight"],
+        "mlp.router.expert_bias": [
+            "language_model.model.layers.{layer_number}.block_sparse_moe.gate.e_score_correction_bias"
+        ],
+        "mlp.fc1_latent_proj.weight": [
+            "language_model.model.layers.{layer_number}.block_sparse_moe.routed_expert_down_proj.weight"
+        ],
+        "mlp.routed_expert_norm.weight": [
+            "language_model.model.layers.{layer_number}.block_sparse_moe.routed_expert_norm.weight"
+        ],
+        "mlp.fc2_latent_proj.weight": [
+            "language_model.model.layers.{layer_number}.block_sparse_moe.routed_expert_up_proj.weight"
+        ],
+        "mlp.shared_experts.linear_fc1.weight": [
+            "language_model.model.layers.{layer_number}.block_sparse_moe.shared_experts.gate_proj.weight",
+            "language_model.model.layers.{layer_number}.block_sparse_moe.shared_experts.up_proj.weight",
+        ],
+        "mlp.shared_experts.linear_fc2.weight": [
+            "language_model.model.layers.{layer_number}.block_sparse_moe.shared_experts.down_proj.weight"
+        ],
+        "mlp.experts.linear_fc1.weight": [
+            "language_model.model.layers.{layer_number}.block_sparse_moe.experts.{expert_id}.w1.weight",
+            "language_model.model.layers.{layer_number}.block_sparse_moe.experts.{expert_id}.w3.weight",
+        ],
+        "mlp.experts.linear_fc2.weight": [
+            "language_model.model.layers.{layer_number}.block_sparse_moe.experts.{expert_id}.w2.weight"
+        ],
+    }
+
+    _OTHER_MAPPING = {
+        "output_attn_res_norm.weight": ["language_model.model.output_attn_res_norm.weight"],
+        "output_attn_res_proj.weight": ["language_model.model.output_attn_res_proj.weight"],
+    }
+
+    @property
+    def text_config(self):
+        return self.hf_config.text_config
+
+    def _build_config(self):
+        hf_config = self.text_config
+        moe_layer_freq = [0] * hf_config.num_hidden_layers
+        for layer_idx in range(hf_config.first_k_dense_replace, hf_config.num_hidden_layers):
+            if layer_idx % hf_config.moe_layer_freq == 0:
+                moe_layer_freq[layer_idx] = 1
+
+        config = self._build_base_config(
+            text_config_key="text_config",
+            attention_backend=AttnBackend.auto,
+            multi_latent_attention=True,
+            qk_layernorm=True,
+            q_lora_rank=hf_config.q_lora_rank,
+            kv_lora_rank=hf_config.kv_lora_rank,
+            qk_head_dim=hf_config.qk_nope_head_dim,
+            qk_pos_emb_head_dim=hf_config.qk_rope_head_dim,
+            v_head_dim=hf_config.v_head_dim,
+            gated_activation_func=situ_and_mul,
+            bias_activation_fusion=False,
+            bias_dropout_fusion=False,
+            use_te_activation_func=False,
+            persist_layer_norm=True,
+            moe_ffn_hidden_size=hf_config.moe_intermediate_size,
+            moe_latent_size=hf_config.routed_expert_hidden_size,
+            moe_latent_use_norm=hf_config.latent_moe_use_norm,
+            num_moe_experts=hf_config.num_experts,
+            moe_router_topk=hf_config.num_experts_per_token,
+            moe_router_score_function=hf_config.moe_router_activation_func,
+            moe_router_pre_softmax=True,
+            moe_router_topk_scaling_factor=hf_config.routed_scaling_factor,
+            moe_router_enable_expert_bias=True,
+            freeze_e_score_correction_bias=True,
+            moe_router_bias_update_rate=0.0,
+            moe_router_dtype="fp32",
+            moe_router_load_balancing_type="none",
+            moe_aux_loss_coeff=0.0,
+            moe_grouped_gemm=True,
+            moe_shared_expert_intermediate_size=(hf_config.moe_intermediate_size * hf_config.num_shared_experts),
+            moe_shared_expert_overlap=False,
+            moe_layer_freq=moe_layer_freq,
+            disable_bf16_reduced_precision_matmul=True,
+        )
+        config.kimi_kda_layers = tuple(hf_config.linear_attn_config["kda_layers"])
+        config.kimi_linear_num_heads = hf_config.linear_attn_config["num_heads"]
+        config.kimi_linear_head_dim = hf_config.linear_attn_config["head_dim"]
+        config.kimi_linear_conv_kernel_size = hf_config.linear_attn_config["short_conv_kernel_size"]
+        config.kimi_kda_gate_lower_bound = hf_config.linear_attn_config["gate_lower_bound"]
+        config.kimi_attn_res_block_size = hf_config.attn_res_block_size
+        return config
+
+    def _get_gptmodel_args(self) -> dict:
+        return {
+            "vocab_size": self.text_config.vocab_size,
+            "max_sequence_length": self.text_config.max_position_embeddings,
+            "position_embedding_type": "none",
+        }
+
+    def _get_transformer_layer_spec(self, vp_stage=None):
+        self.has_vp_stage = "vp_stage" in inspect.signature(build_kimi_k3_spec).parameters
+        return build_kimi_k3_spec(self.config, vp_stage=vp_stage)
+
+    def _get_safetensor_io(self, weights_path: str):
+        safetensor_io = SafeTensorIO(self._get_actual_hf_path(weights_path))
+        assert not any(name.endswith(".weight_packed") for name in safetensor_io.index), (
+            "Kimi K3 Megatron loading requires the experts to be converted from MXFP4 "
+            "to standard BF16 safetensors first"
+        )
+        return safetensor_io
+
+    def _weight_name_mapping_mcore_to_hf(self, mcore_weights_name: str) -> list[str]:
+        assert "_extra_state" not in mcore_weights_name
+        if mcore_weights_name in self._DIRECT_MAPPING:
+            return [self._DIRECT_MAPPING[mcore_weights_name]]
+        if "self_attention" in mcore_weights_name or "input_layernorm" in mcore_weights_name:
+            return self._weight_name_mapping_attention(mcore_weights_name)
+        if "mlp" in mcore_weights_name:
+            return self._weight_name_mapping_mlp(mcore_weights_name)
+        return self._weight_name_mapping_other(mcore_weights_name)
+
+    def _weight_to_mcore_format(
+        self,
+        mcore_weights_name: str,
+        hf_weights: list[torch.Tensor],
+    ) -> torch.Tensor:
+        if mcore_weights_name.endswith(
+            (
+                "self_attention.q_conv1d.weight",
+                "self_attention.k_conv1d.weight",
+                "self_attention.v_conv1d.weight",
+            )
+        ):
+            assert len(hf_weights) == 1
+            return hf_weights[0].float().contiguous()
+        if mcore_weights_name.endswith("self_attention.A_log"):
+            assert len(hf_weights) == 1
+            return hf_weights[0][: self.config.kimi_linear_num_heads].float().contiguous()
+        if mcore_weights_name.endswith("self_attention.dt_bias"):
+            assert len(hf_weights) == 1
+            return hf_weights[0].float().contiguous()
+        return super()._weight_to_mcore_format(mcore_weights_name, hf_weights)

--- a/miles_plugins/models/cp_utils.py
+++ b/miles_plugins/models/cp_utils.py
@@ -1,26 +1,158 @@
-import logging
+"""CP token-layout helpers used inside model plugin ``forward`` implementations.
 
+Distinct from ``miles.backends.training_utils.cp_utils``, which owns the CP
+helpers the training backend applies *around* the model (slicing data, masks,
+logprobs and logits). Everything here runs inside a layer.
+
+Megatron CP stores each rank's tokens in the zigzag load-balanced order that
+ring attention wants, while fla's CP operators expect a contiguous rank-local
+chunk. Anything that hands a sequence to fla under CP therefore has to relayout
+first and undo it afterwards. Lives here rather than in one model plugin because
+three of them need it (qwen3_next, qwen3_5, kimi_k3).
+"""
+
+import torch
 import torch.distributed as dist
 import torch.nn as nn
 
-from miles_plugins.models.hf_attention import HuggingfaceAttention
+try:
+    from fla.ops.cp import build_cp_context as _fla_build_cp_context
+except ImportError:
+    _fla_build_cp_context = None
 
-logger = logging.getLogger(__name__)
+
+def build_gdn_cp_context(module: nn.Module, cu_seqlens: torch.Tensor, device: torch.device):
+    """Build fla CP context for a GatedDeltaNet module from packed sequence boundaries.
+
+    Args:
+        module: GDN module with ``cp_group`` / ``cp_world_size`` / ``conv_kernel_size``.
+        cu_seqlens: Global packed sequence boundaries (e.g. ``packed_seq_params.cu_seqlens_q``).
+        device: Target device.
+
+    Returns ``None`` when CP is not configured on the module (``cp_group`` not set).
+    Raises ``RuntimeError`` if hybrid CP is configured but ``fla.ops.cp`` is missing.
+    """
+    cp_group = getattr(module, "cp_group", None)
+    if cp_group is None:
+        return None
+    if _fla_build_cp_context is None:
+        raise RuntimeError(
+            "Hybrid CP requires fla.ops.cp (flash-linear-attention >= 0.4.2) " "but it could not be imported."
+        )
+    if cu_seqlens is None or cu_seqlens.numel() < 2:
+        raise ValueError(f"Hybrid CP requires valid cu_seqlens (at least 2 elements) but got {cu_seqlens}")
+    return _fla_build_cp_context(
+        cu_seqlens=cu_seqlens.to(device=device, dtype=torch.int32),
+        group=cp_group,
+        conv1d_kernel_size=module.conv_kernel_size,
+    )
 
 
-def detect_and_setup_hybrid_cp(model: nn.Module, cp_group: dist.ProcessGroup, cp_rank: int, cp_world_size: int) -> int:
-    """Scan for GatedDeltaNet modules and configure them for native fla CP."""
-    count = 0
-    for module in model.modules():
-        if isinstance(module, HuggingfaceAttention):
-            linear_attn = getattr(module, "linear_attn", None)
-            if linear_attn is not None:
-                linear_attn.cp_group = cp_group
-                linear_attn.cp_rank = cp_rank
-                linear_attn.cp_world_size = cp_world_size
-                module.hybrid_cp = True
-                count += 1
+def get_cp_sequence_lengths(cu_seqlens, cp_size, local_total_len=None):
+    global_seq_lengths = [(cu_seqlens[i + 1] - cu_seqlens[i]).item() for i in range(len(cu_seqlens) - 1)]
+    local_seq_lengths = []
+    for global_seq_len in global_seq_lengths:
+        if global_seq_len % cp_size != 0:
+            raise ValueError(f"Expected sequence length {global_seq_len} to be divisible by cp_size={cp_size}")
+        local_seq_lengths.append(global_seq_len // cp_size)
 
-    if count > 0:
-        logger.info(f"Configured hybrid CP on {count} GDN modules (fla native state passing)")
-    return count
+    if local_total_len is not None and sum(local_seq_lengths) != local_total_len:
+        raise ValueError(f"Expected local total length {local_total_len}, got {sum(local_seq_lengths)}")
+
+    return global_seq_lengths, local_seq_lengths
+
+
+def gather_cp_tensors(x, cp_group):
+    gathered = [torch.empty_like(x) for _ in range(dist.get_world_size(group=cp_group))]
+    dist.all_gather(gathered, x.contiguous(), group=cp_group)
+    return gathered
+
+
+def _zigzag_to_packed_shard_impl(hidden_states, cu_seqlens, cp_group, cp_rank, cp_size):
+    """Convert zigzag ring-attn layout to the contiguous packed shard expected by fla CP."""
+    global_seq_lengths, local_seq_lengths = get_cp_sequence_lengths(cu_seqlens, cp_size, hidden_states.size(0))
+    gathered_by_rank = [
+        gathered.split(local_seq_lengths, dim=0) for gathered in gather_cp_tensors(hidden_states, cp_group)
+    ]
+
+    full_sequences = []
+    for seq_idx, global_seq_len in enumerate(global_seq_lengths):
+        per_rank = [rank_seqs[seq_idx] for rank_seqs in gathered_by_rank]
+        if global_seq_len % (2 * cp_size) == 0:
+            subchunk_len = global_seq_len // (2 * cp_size)
+            full_seq = torch.cat(
+                [seq[:subchunk_len] for seq in per_rank] + [seq[subchunk_len:] for seq in per_rank][::-1],
+                dim=0,
+            )
+        else:
+            # Final local padding is appended contiguously on each rank, not in zigzag order.
+            full_seq = torch.cat(per_rank, dim=0)
+        full_sequences.append(full_seq)
+
+    full_stream = torch.cat(full_sequences, dim=0) if full_sequences else hidden_states[:0]
+    shard_len = hidden_states.size(0)
+    return full_stream[cp_rank * shard_len : (cp_rank + 1) * shard_len]
+
+
+def _packed_shard_to_zigzag_impl(hidden_states, cu_seqlens, cp_group, cp_rank, cp_size):
+    """Convert contiguous packed shard layout back to zigzag ring-attn layout."""
+    global_seq_lengths, local_seq_lengths = get_cp_sequence_lengths(cu_seqlens, cp_size, hidden_states.size(0))
+    full_stream = torch.cat(gather_cp_tensors(hidden_states, cp_group), dim=0)
+    full_sequences = full_stream.split(global_seq_lengths, dim=0)
+
+    local_sequences = []
+    for full_seq, global_seq_len, local_seq_len in zip(
+        full_sequences, global_seq_lengths, local_seq_lengths, strict=True
+    ):
+        if global_seq_len % (2 * cp_size) == 0:
+            subchunk_len = global_seq_len // (2 * cp_size)
+            parts = full_seq.split(subchunk_len, dim=0)
+            local_sequences.append(torch.cat([parts[cp_rank], parts[2 * cp_size - 1 - cp_rank]], dim=0))
+        else:
+            local_sequences.append(full_seq.split(local_seq_len, dim=0)[cp_rank])
+
+    return torch.cat(local_sequences, dim=0) if local_sequences else hidden_states[:0]
+
+
+class _ZigzagToPackedShard(torch.autograd.Function):
+    """Convert zigzag ring-attn layout to contiguous packed shards for native fla CP."""
+
+    @staticmethod
+    def forward(ctx, hidden_states, cu_seqlens, cp_group, cp_rank, cp_size):
+        ctx.cp_group = cp_group
+        ctx.cp_rank = cp_rank
+        ctx.cp_size = cp_size
+        ctx.save_for_backward(cu_seqlens)
+        return _zigzag_to_packed_shard_impl(hidden_states, cu_seqlens, cp_group, cp_rank, cp_size)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        (cu_seqlens,) = ctx.saved_tensors
+        result = _packed_shard_to_zigzag_impl(grad_output, cu_seqlens, ctx.cp_group, ctx.cp_rank, ctx.cp_size)
+        return result, None, None, None, None
+
+
+class _PackedShardToZigzag(torch.autograd.Function):
+    """Convert contiguous packed shards back to zigzag ring-attn layout."""
+
+    @staticmethod
+    def forward(ctx, hidden_states, cu_seqlens, cp_group, cp_rank, cp_size):
+        ctx.cp_group = cp_group
+        ctx.cp_rank = cp_rank
+        ctx.cp_size = cp_size
+        ctx.save_for_backward(cu_seqlens)
+        return _packed_shard_to_zigzag_impl(hidden_states, cu_seqlens, cp_group, cp_rank, cp_size)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        (cu_seqlens,) = ctx.saved_tensors
+        result = _zigzag_to_packed_shard_impl(grad_output, cu_seqlens, ctx.cp_group, ctx.cp_rank, ctx.cp_size)
+        return result, None, None, None, None
+
+
+def zigzag_to_packed_shard(hidden_states, cu_seqlens, cp_group, cp_rank, cp_size):
+    return _ZigzagToPackedShard.apply(hidden_states, cu_seqlens, cp_group, cp_rank, cp_size)
+
+
+def packed_shard_to_zigzag(hidden_states, cu_seqlens, cp_group, cp_rank, cp_size):
+    return _PackedShardToZigzag.apply(hidden_states, cu_seqlens, cp_group, cp_rank, cp_size)

--- a/miles_plugins/models/hf_attention.py
+++ b/miles_plugins/models/hf_attention.py
@@ -1,123 +1,18 @@
+import logging
 from abc import ABC, abstractmethod
 
 import torch
 import torch.distributed as dist
+import torch.nn as nn
 from megatron.core import mpu, tensor_parallel
 from megatron.core.inference.contexts import BaseInferenceContext
 from megatron.core.packed_seq_params import PackedSeqParams
 from megatron.core.transformer.module import MegatronModule
 
 from miles.utils.hf_config import load_hf_config
+from miles_plugins.models.cp_utils import packed_shard_to_zigzag, zigzag_to_packed_shard
 
-
-def _get_cp_sequence_lengths(cu_seqlens, cp_size, local_total_len=None):
-    global_seq_lengths = [(cu_seqlens[i + 1] - cu_seqlens[i]).item() for i in range(len(cu_seqlens) - 1)]
-    local_seq_lengths = []
-    for global_seq_len in global_seq_lengths:
-        if global_seq_len % cp_size != 0:
-            raise ValueError(f"Expected sequence length {global_seq_len} to be divisible by cp_size={cp_size}")
-        local_seq_lengths.append(global_seq_len // cp_size)
-
-    if local_total_len is not None and sum(local_seq_lengths) != local_total_len:
-        raise ValueError(f"Expected local total length {local_total_len}, got {sum(local_seq_lengths)}")
-
-    return global_seq_lengths, local_seq_lengths
-
-
-def _gather_cp_tensors(x, cp_group):
-    gathered = [torch.empty_like(x) for _ in range(dist.get_world_size(group=cp_group))]
-    dist.all_gather(gathered, x.contiguous(), group=cp_group)
-    return gathered
-
-
-def _zigzag_to_packed_shard_impl(hidden_states, cu_seqlens, cp_group, cp_rank, cp_size):
-    """Convert zigzag ring-attn layout to the contiguous packed shard expected by fla CP."""
-    global_seq_lengths, local_seq_lengths = _get_cp_sequence_lengths(cu_seqlens, cp_size, hidden_states.size(0))
-    gathered_by_rank = [
-        gathered.split(local_seq_lengths, dim=0) for gathered in _gather_cp_tensors(hidden_states, cp_group)
-    ]
-
-    full_sequences = []
-    for seq_idx, global_seq_len in enumerate(global_seq_lengths):
-        per_rank = [rank_seqs[seq_idx] for rank_seqs in gathered_by_rank]
-        if global_seq_len % (2 * cp_size) == 0:
-            subchunk_len = global_seq_len // (2 * cp_size)
-            full_seq = torch.cat(
-                [seq[:subchunk_len] for seq in per_rank] + [seq[subchunk_len:] for seq in per_rank][::-1],
-                dim=0,
-            )
-        else:
-            # Final local padding is appended contiguously on each rank, not in zigzag order.
-            full_seq = torch.cat(per_rank, dim=0)
-        full_sequences.append(full_seq)
-
-    full_stream = torch.cat(full_sequences, dim=0) if full_sequences else hidden_states[:0]
-    shard_len = hidden_states.size(0)
-    return full_stream[cp_rank * shard_len : (cp_rank + 1) * shard_len]
-
-
-def _packed_shard_to_zigzag_impl(hidden_states, cu_seqlens, cp_group, cp_rank, cp_size):
-    """Convert contiguous packed shard layout back to zigzag ring-attn layout."""
-    global_seq_lengths, local_seq_lengths = _get_cp_sequence_lengths(cu_seqlens, cp_size, hidden_states.size(0))
-    full_stream = torch.cat(_gather_cp_tensors(hidden_states, cp_group), dim=0)
-    full_sequences = full_stream.split(global_seq_lengths, dim=0)
-
-    local_sequences = []
-    for full_seq, global_seq_len, local_seq_len in zip(
-        full_sequences, global_seq_lengths, local_seq_lengths, strict=True
-    ):
-        if global_seq_len % (2 * cp_size) == 0:
-            subchunk_len = global_seq_len // (2 * cp_size)
-            parts = full_seq.split(subchunk_len, dim=0)
-            local_sequences.append(torch.cat([parts[cp_rank], parts[2 * cp_size - 1 - cp_rank]], dim=0))
-        else:
-            local_sequences.append(full_seq.split(local_seq_len, dim=0)[cp_rank])
-
-    return torch.cat(local_sequences, dim=0) if local_sequences else hidden_states[:0]
-
-
-class _ZigzagToPackedShard(torch.autograd.Function):
-    """Convert zigzag ring-attn layout to contiguous packed shards for native fla CP."""
-
-    @staticmethod
-    def forward(ctx, hidden_states, cu_seqlens, cp_group, cp_rank, cp_size):
-        ctx.cp_group = cp_group
-        ctx.cp_rank = cp_rank
-        ctx.cp_size = cp_size
-        ctx.save_for_backward(cu_seqlens)
-        return _zigzag_to_packed_shard_impl(hidden_states, cu_seqlens, cp_group, cp_rank, cp_size)
-
-    @staticmethod
-    def backward(ctx, grad_output):
-        (cu_seqlens,) = ctx.saved_tensors
-        result = _packed_shard_to_zigzag_impl(grad_output, cu_seqlens, ctx.cp_group, ctx.cp_rank, ctx.cp_size)
-        return result, None, None, None, None
-
-
-class _PackedShardToZigzag(torch.autograd.Function):
-    """Convert contiguous packed shards back to zigzag ring-attn layout."""
-
-    @staticmethod
-    def forward(ctx, hidden_states, cu_seqlens, cp_group, cp_rank, cp_size):
-        ctx.cp_group = cp_group
-        ctx.cp_rank = cp_rank
-        ctx.cp_size = cp_size
-        ctx.save_for_backward(cu_seqlens)
-        return _packed_shard_to_zigzag_impl(hidden_states, cu_seqlens, cp_group, cp_rank, cp_size)
-
-    @staticmethod
-    def backward(ctx, grad_output):
-        (cu_seqlens,) = ctx.saved_tensors
-        result = _zigzag_to_packed_shard_impl(grad_output, cu_seqlens, ctx.cp_group, ctx.cp_rank, ctx.cp_size)
-        return result, None, None, None, None
-
-
-def _zigzag_to_packed_shard(hidden_states, cu_seqlens, cp_group, cp_rank, cp_size):
-    return _ZigzagToPackedShard.apply(hidden_states, cu_seqlens, cp_group, cp_rank, cp_size)
-
-
-def _packed_shard_to_zigzag(hidden_states, cu_seqlens, cp_group, cp_rank, cp_size):
-    return _PackedShardToZigzag.apply(hidden_states, cu_seqlens, cp_group, cp_rank, cp_size)
+logger = logging.getLogger(__name__)
 
 
 class _AllGatherForDuplicatedComputation(torch.autograd.Function):
@@ -208,7 +103,7 @@ class HuggingfaceAttention(MegatronModule, ABC):
             # already provides that layout, so no extra relayout is
             # needed here.
             if not self.args.allgather_cp:
-                hidden_states = _zigzag_to_packed_shard(
+                hidden_states = zigzag_to_packed_shard(
                     hidden_states,
                     cu_seqlens,
                     mpu.get_context_parallel_group(),
@@ -253,7 +148,7 @@ class HuggingfaceAttention(MegatronModule, ABC):
 
         if mpu.get_context_parallel_world_size() > 1 and self.hybrid_cp:
             if not self.args.allgather_cp:
-                output = _packed_shard_to_zigzag(
+                output = packed_shard_to_zigzag(
                     output,
                     cu_seqlens,
                     mpu.get_context_parallel_group(),
@@ -283,3 +178,21 @@ class HuggingfaceAttention(MegatronModule, ABC):
     @abstractmethod
     def hf_forward(self, hidden_states, packed_seq_params):
         """Huggingface forward function"""
+
+
+def detect_and_setup_hybrid_cp(model: nn.Module, cp_group: dist.ProcessGroup, cp_rank: int, cp_world_size: int) -> int:
+    """Scan for GatedDeltaNet modules and configure them for native fla CP."""
+    count = 0
+    for module in model.modules():
+        if isinstance(module, HuggingfaceAttention):
+            linear_attn = getattr(module, "linear_attn", None)
+            if linear_attn is not None:
+                linear_attn.cp_group = cp_group
+                linear_attn.cp_rank = cp_rank
+                linear_attn.cp_world_size = cp_world_size
+                module.hybrid_cp = True
+                count += 1
+
+    if count > 0:
+        logger.info(f"Configured hybrid CP on {count} GDN modules (fla native state passing)")
+    return count

--- a/miles_plugins/models/kimi_k3/__init__.py
+++ b/miles_plugins/models/kimi_k3/__init__.py
@@ -1,0 +1,7 @@
+def get_kimi_k3_spec(*args, **kwargs):
+    from .model import get_kimi_k3_spec as get_spec
+
+    return get_spec(*args, **kwargs)
+
+
+__all__ = ["get_kimi_k3_spec"]

--- a/miles_plugins/models/kimi_k3/layers.py
+++ b/miles_plugins/models/kimi_k3/layers.py
@@ -1,0 +1,602 @@
+import copy
+
+import torch
+import torch.nn as nn
+from einops import rearrange
+from fla.modules import FusedRMSNormGated, ShortConvolution
+from megatron.core.dist_checkpointing.mapping import ShardedStateDict
+from megatron.core.extensions.transformer_engine import (
+    TEColumnParallelLinear,
+    TEDotProductAttention,
+    TELinear,
+    TERowParallelLinear,
+)
+from megatron.core.inference.contexts import BaseInferenceContext
+from megatron.core.packed_seq_params import PackedSeqParams
+from megatron.core.process_groups_config import ProcessGroupCollection
+from megatron.core.tensor_parallel.layers import set_tensor_model_parallel_attributes
+from megatron.core.tensor_parallel.mappings import (
+    copy_to_tensor_model_parallel_region,
+    gather_from_sequence_parallel_region,
+    scatter_to_sequence_parallel_region,
+)
+from megatron.core.transformer.enums import AttnMaskType
+from megatron.core.transformer.module import MegatronModule
+from megatron.core.transformer.transformer_layer import TransformerLayer, get_transformer_layer_offset
+from megatron.core.transformer.utils import ensure_metadata_has_dp_cp_group, make_sharded_tensors_for_checkpoint
+
+from miles.backends.megatron_utils.fp32_param_utils import mark_param_dtype
+from miles_plugins.models.cp_utils import build_gdn_cp_context, packed_shard_to_zigzag, zigzag_to_packed_shard
+from miles_plugins.models.kimi_k3.ops import KimiRMSNorm, attn_res_aggregate, kda
+from miles_plugins.models.kimi_k3.pipeline import bank_num_rows, pack_stage_boundary, unpack_stage_boundary
+
+
+def _mark_tp_replicated(module: nn.Module, *, reduction: str = "average") -> None:
+    assert reduction in ("average", "sum")
+    for parameter in module.parameters():
+        setattr(parameter, f"{reduction}_gradients_across_tp_domain", True)
+
+
+def _linear(module: nn.Module, inputs: torch.Tensor) -> torch.Tensor:
+    output, bias = module(inputs)
+    assert bias is None
+    return output
+
+
+class KimiK3ShortConvolution(ShortConvolution):
+    def __init__(self, *args, tp_group, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.tp_group = tp_group
+        mark_param_dtype(self.weight, torch.float32)
+        set_tensor_model_parallel_attributes(self.weight, True, 0, 1)
+
+    def sharded_state_dict(
+        self,
+        prefix: str = "",
+        sharded_offsets: tuple = (),
+        metadata: dict | None = None,
+    ) -> ShardedStateDict:
+        metadata = ensure_metadata_has_dp_cp_group(metadata)
+        return make_sharded_tensors_for_checkpoint(
+            self.state_dict(prefix="", keep_vars=True),
+            prefix,
+            {"weight": 0},
+            sharded_offsets,
+            tp_group=self.tp_group,
+            dp_cp_group=metadata["dp_cp_group"],
+        )
+
+
+class KimiK3Attention(MegatronModule):
+    def __init__(
+        self,
+        config,
+        layer_number: int,
+        cp_comm_type: str | None = None,
+        pg_collection=None,
+    ) -> None:
+        super().__init__(config=config)
+        self.cp_comm_type = cp_comm_type
+
+        if pg_collection is None:
+            pg_collection = ProcessGroupCollection.use_mpu_process_groups(required_pgs=["tp", "cp"])
+        else:
+            assert hasattr(pg_collection, "tp") and hasattr(pg_collection, "cp")
+        self.pg_collection = pg_collection
+        self.tp_group = pg_collection.tp
+        self.tp_size = self.tp_group.size()
+        self.cp_group = pg_collection.cp
+        self.cp_size = self.cp_group.size()
+        self.sequence_parallel = config.sequence_parallel
+        self.linear_config = copy.copy(config)
+        self.linear_config.sequence_parallel = False
+
+        self.layer_idx = layer_number - 1
+        self.is_kda = layer_number in config.kimi_kda_layers
+        if self.is_kda:
+            self._init_kda(config)
+        else:
+            self._init_mla(config)
+
+    def _duplicated_linear(self, input_size: int, output_size: int) -> TELinear:
+        return TELinear(
+            input_size,
+            output_size,
+            config=self.linear_config,
+            init_method=self.config.init_method,
+            bias=False,
+            skip_bias_add=False,
+            skip_weight_param_allocation=False,
+            parallel_mode="duplicated",
+        )
+
+    def _column_linear(self, input_size: int, output_size: int) -> TEColumnParallelLinear:
+        return TEColumnParallelLinear(
+            input_size,
+            output_size,
+            config=self.linear_config,
+            init_method=self.config.init_method,
+            bias=False,
+            gather_output=False,
+            skip_bias_add=False,
+            is_expert=False,
+            tp_group=self.tp_group,
+        )
+
+    def _row_linear(self, input_size: int, output_size: int) -> TERowParallelLinear:
+        return TERowParallelLinear(
+            input_size,
+            output_size,
+            config=self.linear_config,
+            init_method=self.config.init_method,
+            bias=False,
+            input_is_parallel=True,
+            skip_bias_add=False,
+            is_expert=False,
+            tp_group=self.tp_group,
+        )
+
+    def _init_kda(self, config) -> None:
+        hidden_size = config.hidden_size
+        device = torch.cuda.current_device()
+        dtype = config.params_dtype
+        self.num_heads = config.kimi_linear_num_heads
+        assert self.num_heads % self.tp_size == 0
+        self.local_num_heads = self.num_heads // self.tp_size
+        self.head_dim = config.kimi_linear_head_dim
+        # build_gdn_cp_context reads this off the module.
+        self.conv_kernel_size = config.kimi_linear_conv_kernel_size
+        self.projection_size = self.num_heads * self.head_dim
+        self.local_projection_size = self.local_num_heads * self.head_dim
+
+        self.q_proj = self._column_linear(hidden_size, self.projection_size)
+        self.k_proj = self._column_linear(hidden_size, self.projection_size)
+        self.v_proj = self._column_linear(hidden_size, self.projection_size)
+        self.q_conv1d = KimiK3ShortConvolution(
+            hidden_size=self.local_projection_size,
+            kernel_size=config.kimi_linear_conv_kernel_size,
+            activation="silu",
+            device=device,
+            dtype=dtype,
+            tp_group=self.tp_group,
+        )
+        self.k_conv1d = KimiK3ShortConvolution(
+            hidden_size=self.local_projection_size,
+            kernel_size=config.kimi_linear_conv_kernel_size,
+            activation="silu",
+            device=device,
+            dtype=dtype,
+            tp_group=self.tp_group,
+        )
+        self.v_conv1d = KimiK3ShortConvolution(
+            hidden_size=self.local_projection_size,
+            kernel_size=config.kimi_linear_conv_kernel_size,
+            activation="silu",
+            device=device,
+            dtype=dtype,
+            tp_group=self.tp_group,
+        )
+
+        self.f_a_proj = self._duplicated_linear(hidden_size, self.head_dim)
+        self.f_b_proj = self._column_linear(self.head_dim, self.projection_size)
+        self.b_proj = self._column_linear(hidden_size, self.num_heads)
+        self.g_proj = self._column_linear(hidden_size, self.projection_size)
+
+        self.A_log = nn.Parameter(torch.empty(self.local_num_heads, dtype=torch.float32, device=device))
+        self.dt_bias = nn.Parameter(torch.empty(self.local_projection_size, dtype=torch.float32, device=device))
+        mark_param_dtype(self.A_log, torch.float32)
+        mark_param_dtype(self.dt_bias, torch.float32)
+        set_tensor_model_parallel_attributes(self.A_log, True, 0, 1)
+        set_tensor_model_parallel_attributes(self.dt_bias, True, 0, 1)
+
+        self.o_norm = FusedRMSNormGated(
+            self.head_dim,
+            eps=config.layernorm_epsilon,
+            activation="sigmoid",
+            device=device,
+            dtype=dtype,
+        )
+        _mark_tp_replicated(self.o_norm, reduction="sum")
+        self.o_proj = self._row_linear(self.projection_size, hidden_size)
+        self.gate_lower_bound = config.kimi_kda_gate_lower_bound
+
+    def _init_mla(self, config) -> None:
+        hidden_size = config.hidden_size
+        device = torch.cuda.current_device()
+        dtype = config.params_dtype
+        self.num_heads = config.num_attention_heads
+        assert self.num_heads % self.tp_size == 0
+        self.local_num_heads = self.num_heads // self.tp_size
+        self.q_lora_rank = config.q_lora_rank
+        self.kv_lora_rank = config.kv_lora_rank
+        self.qk_nope_head_dim = config.qk_head_dim
+        self.qk_extra_head_dim = config.qk_pos_emb_head_dim
+        self.v_head_dim = config.v_head_dim
+        self.q_head_dim = self.qk_nope_head_dim + self.qk_extra_head_dim
+
+        self.q_a_proj = self._duplicated_linear(hidden_size, self.q_lora_rank)
+        self.q_a_layernorm = KimiRMSNorm(self.q_lora_rank, config.layernorm_epsilon, device=device, dtype=dtype)
+        self.q_b_proj = self._column_linear(self.q_lora_rank, self.num_heads * self.q_head_dim)
+        self.kv_a_proj_with_mqa = self._duplicated_linear(hidden_size, self.kv_lora_rank + self.qk_extra_head_dim)
+        self.kv_a_layernorm = KimiRMSNorm(self.kv_lora_rank, config.layernorm_epsilon, device=device, dtype=dtype)
+        self.kv_b_proj = self._column_linear(
+            self.kv_lora_rank,
+            self.num_heads * (self.qk_nope_head_dim + self.v_head_dim),
+        )
+        self.g_proj = self._column_linear(hidden_size, self.num_heads * self.v_head_dim)
+        self.o_proj = self._row_linear(self.num_heads * self.v_head_dim, hidden_size)
+
+        # K3 does not rotate the 64-wide field, so only Megatron's MLA *module* is
+        # unusable -- its attention *core* is not, and it is what carries CP
+        # (ring/a2a) and the varlen kernels. k_channels/v_channels express the
+        # unequal qk (128 nope + 64 extra) and v (128) widths; softmax_scale must be
+        # given explicitly because K3 has no YaRN mscale.
+        self.core_attention = TEDotProductAttention(
+            config=self.config,
+            layer_number=self.layer_idx + 1,
+            attn_mask_type=AttnMaskType.causal,
+            attention_type="self",
+            softmax_scale=self.q_head_dim**-0.5,
+            k_channels=self.q_head_dim,
+            v_channels=self.v_head_dim,
+            cp_comm_type=self.cp_comm_type,
+            pg_collection=self.pg_collection,
+        )
+
+    def sharded_state_dict(
+        self,
+        prefix: str = "",
+        sharded_offsets: tuple = (),
+        metadata: dict | None = None,
+    ) -> ShardedStateDict:
+        sharded_state_dict = super().sharded_state_dict(prefix, sharded_offsets, metadata)
+        if not self.is_kda:
+            return sharded_state_dict
+
+        metadata = ensure_metadata_has_dp_cp_group(metadata)
+        sharded_state_dict.update(
+            make_sharded_tensors_for_checkpoint(
+                {"A_log": self.A_log, "dt_bias": self.dt_bias},
+                prefix,
+                {"A_log": 0, "dt_bias": 0},
+                sharded_offsets,
+                tp_group=self.tp_group,
+                dp_cp_group=metadata["dp_cp_group"],
+            )
+        )
+        return sharded_state_dict
+
+    def _cp_global_cu_seqlens(
+        self,
+        hidden_states: torch.Tensor,
+        packed_seq_params: PackedSeqParams | None,
+    ) -> torch.Tensor:
+        """Global packed-sequence boundaries, which both the zigzag relayout and
+        fla's CP context are defined against.
+
+        Under THD they come straight from packed_seq_params. Under BSHD the tokens
+        are not packed -- dim 0 is the sequence and dim 1 the batch -- so the whole
+        sequence is a single segment whose global length is the local shard times
+        cp_size.
+        """
+        if packed_seq_params is not None and packed_seq_params.cu_seqlens_q is not None:
+            return packed_seq_params.cu_seqlens_q
+        total = hidden_states.shape[0] * self.cp_size
+        return torch.tensor([0, total], dtype=torch.int32, device=hidden_states.device)
+
+    def _forward_kda(
+        self,
+        hidden_states: torch.Tensor,
+        packed_seq_params: PackedSeqParams | None,
+    ) -> torch.Tensor:
+        core = self._kda_core(hidden_states, packed_seq_params)
+        return _linear(self.o_proj, core.to(hidden_states.dtype)).transpose(0, 1)
+
+    def _kda_core(
+        self,
+        hidden_states: torch.Tensor,
+        packed_seq_params: PackedSeqParams | None,
+    ) -> torch.Tensor:
+        """KDA delta-rule core: projections + conv + recurrence + gated norm,
+        returning the flattened pre-o_proj output."""
+        cp_context = (
+            build_gdn_cp_context(
+                self, self._cp_global_cu_seqlens(hidden_states, packed_seq_params), hidden_states.device
+            )
+            if self.cp_size > 1
+            else None
+        )
+        x = hidden_states.transpose(0, 1)
+        cu_seqlens = packed_seq_params.cu_seqlens_q if packed_seq_params is not None else None
+        if cp_context is not None:
+            # The context carries rank-local boundaries; the global ones only
+            # described where this shard sits in the full stream.
+            cu_seqlens = cp_context.cu_seqlens
+        # Packed input carrying neither channel would make the conv and the
+        # recurrence treat the whole microbatch as one sequence, silently
+        # leaking state across samples rather than failing.
+        assert (
+            packed_seq_params is None or cu_seqlens is not None or cp_context is not None
+        ), "packed (THD) input reached the KDA core without sequence boundaries"
+
+        conv_kwargs = {"output_final_state": False, "cu_seqlens": cu_seqlens, "cp_context": cp_context}
+        q, _ = self.q_conv1d(x=_linear(self.q_proj, x), **conv_kwargs)
+        k, _ = self.k_conv1d(x=_linear(self.k_proj, x), **conv_kwargs)
+        v, _ = self.v_conv1d(x=_linear(self.v_proj, x), **conv_kwargs)
+        q = rearrange(q, "b s (h d) -> b s h d", h=self.local_num_heads)
+        k = rearrange(k, "b s (h d) -> b s h d", h=self.local_num_heads)
+        v = rearrange(v, "b s (h d) -> b s h d", h=self.local_num_heads)
+        forget_gate = rearrange(
+            _linear(self.f_b_proj, _linear(self.f_a_proj, x)), "b s (h d) -> b s h d", h=self.local_num_heads
+        )
+        beta = _linear(self.b_proj, x).float().sigmoid()
+        output = kda(
+            q,
+            k,
+            v,
+            forget_gate,
+            beta,
+            self.A_log,
+            self.dt_bias,
+            self.gate_lower_bound,
+            cu_seqlens=cu_seqlens,
+            cp_context=cp_context,
+        )
+        gate = rearrange(_linear(self.g_proj, x), "b s (h d) -> b s h d", h=self.local_num_heads)
+
+        output = self.o_norm(output.reshape(-1, self.head_dim), gate.reshape(-1, self.head_dim))
+        return output.view(*gate.shape).flatten(-2)
+
+    def _forward_mla(
+        self,
+        hidden_states: torch.Tensor,
+        packed_seq_params: PackedSeqParams | None,
+    ) -> torch.Tensor:
+        # Stay in [s, b, ...] the whole way: that is TE's sbhd layout, so q/k/v need
+        # neither a transpose nor a copy to reach it. (KDA is the opposite -- its
+        # kernels want [b, s, ...] -- which is why _kda_core transposes and this does
+        # not.)
+        x = hidden_states
+        query = _linear(
+            self.q_b_proj,
+            self.q_a_layernorm(_linear(self.q_a_proj, x)),
+        )
+        query = query.view(*query.shape[:-1], self.local_num_heads, self.q_head_dim)
+
+        compressed_kv = _linear(self.kv_a_proj_with_mqa, x)
+        kv_latent, key_extra = torch.split(
+            compressed_kv,
+            [self.kv_lora_rank, self.qk_extra_head_dim],
+            dim=-1,
+        )
+        key_value = _linear(self.kv_b_proj, self.kv_a_layernorm(kv_latent))
+        key_value = key_value.view(
+            *key_value.shape[:-1],
+            self.local_num_heads,
+            self.qk_nope_head_dim + self.v_head_dim,
+        )
+        key_nope, value = torch.split(
+            key_value,
+            [self.qk_nope_head_dim, self.v_head_dim],
+            dim=-1,
+        )
+        # value is a slice, so it needs the copy; query is a view of a canonical
+        # linear output and key comes fresh out of the cat below. TE classifies the
+        # qkv layout from strides normalised by the last dim, so all three must have
+        # canonical ones or it rejects the layout outright.
+        value = value.contiguous()
+        key_extra = copy_to_tensor_model_parallel_region(key_extra, group=self.tp_group)
+        key_extra = key_extra.unsqueeze(-2).expand(*key_nope.shape[:-1], -1)
+        key = torch.cat((key_nope, key_extra), dim=-1)
+
+        # TE requires 3D [t, h, d] tensors under packed sequences (qkv_format
+        # "thd"), with the batch dim dropped; mirror Megatron's Attention.forward
+        # (attention.py: squeeze(1) before core_attention, reshape (t, 1, -1)
+        # after). The fixed-length run_megatron harness never takes this branch.
+        is_thd = packed_seq_params is not None and packed_seq_params.qkv_format == "thd"
+        if is_thd:
+            query = query.squeeze(1)
+            key = key.squeeze(1)
+            value = value.squeeze(1)
+        # TE returns the head dims already fused, so there is no flatten here.
+        output = self.core_attention(
+            query,
+            key,
+            value,
+            None,
+            packed_seq_params=packed_seq_params,
+            attn_mask_type=AttnMaskType.causal,
+        )
+        if is_thd:
+            output = output.reshape(output.size(0), 1, -1)
+        output = output * torch.sigmoid(_linear(self.g_proj, x))
+        return _linear(self.o_proj, output)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: torch.Tensor | None = None,
+        key_value_states: torch.Tensor | None = None,
+        inference_context: BaseInferenceContext | None = None,
+        rotary_pos_emb: torch.Tensor | None = None,
+        rotary_pos_cos: torch.Tensor | None = None,
+        rotary_pos_sin: torch.Tensor | None = None,
+        rotary_pos_cos_sin: torch.Tensor | None = None,
+        attention_bias: torch.Tensor | None = None,
+        packed_seq_params: PackedSeqParams | None = None,
+        sequence_len_offset: int | None = None,
+        **kwargs,
+    ) -> tuple[torch.Tensor, None]:
+        del (
+            attention_mask,
+            key_value_states,
+            inference_context,
+            rotary_pos_emb,
+            rotary_pos_cos,
+            rotary_pos_sin,
+            rotary_pos_cos_sin,
+            attention_bias,
+            sequence_len_offset,
+            kwargs,
+        )
+        if self.sequence_parallel:
+            hidden_states = gather_from_sequence_parallel_region(
+                hidden_states,
+                tensor_parallel_output_grad=False,
+                group=self.tp_group,
+            )
+        # Megatron CP stores each rank's tokens in the zigzag load-balanced order that
+        # ring attention wants; fla's CP operators want a contiguous rank-local chunk.
+        # Relayout only around KDA -- MLA's TE kernel consumes zigzag directly, which
+        # is the whole reason the global layout stays zigzag.
+        relayout = self.is_kda and self.cp_size > 1
+        if relayout:
+            cp_cu_seqlens = self._cp_global_cu_seqlens(hidden_states, packed_seq_params)
+            hidden_states = zigzag_to_packed_shard(
+                hidden_states, cp_cu_seqlens, self.cp_group, self.cp_group.rank(), self.cp_size
+            )
+        output = (
+            self._forward_kda(hidden_states, packed_seq_params)
+            if self.is_kda
+            else self._forward_mla(hidden_states, packed_seq_params)
+        )
+        if relayout:
+            output = packed_shard_to_zigzag(output, cp_cu_seqlens, self.cp_group, self.cp_group.rank(), self.cp_size)
+        if self.sequence_parallel:
+            output = scatter_to_sequence_parallel_region(output, group=self.tp_group)
+        return output, None
+
+
+class KimiK3TransformerLayer(TransformerLayer):
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        assert self.config.hidden_dropout == 0.0, "Kimi K3 requires hidden dropout 0"
+
+        hidden_size = self.config.hidden_size
+        eps = self.config.layernorm_epsilon
+        device = torch.cuda.current_device()
+        dtype = self.config.params_dtype
+        self.attn_res_block_size = self.config.kimi_attn_res_block_size
+        self.self_attention_res_norm = KimiRMSNorm(hidden_size, eps, device=device, dtype=dtype)
+        self.self_attention_res_proj = nn.Linear(hidden_size, 1, bias=False, device=device, dtype=dtype)
+        self.mlp_res_norm = KimiRMSNorm(hidden_size, eps, device=device, dtype=dtype)
+        self.mlp_res_proj = nn.Linear(hidden_size, 1, bias=False, device=device, dtype=dtype)
+        _mark_tp_replicated(self.self_attention_res_norm, reduction="sum")
+        _mark_tp_replicated(self.self_attention_res_proj, reduction="sum")
+        _mark_tp_replicated(self.mlp_res_norm, reduction="sum")
+        _mark_tp_replicated(self.mlp_res_proj, reduction="sum")
+
+        if self.layer_number == self.config.num_layers:
+            self.output_attn_res_norm = KimiRMSNorm(hidden_size, eps, device=device, dtype=dtype)
+            self.output_attn_res_proj = nn.Linear(hidden_size, 1, bias=False, device=device, dtype=dtype)
+            _mark_tp_replicated(self.output_attn_res_norm, reduction="sum")
+            _mark_tp_replicated(self.output_attn_res_proj, reduction="sum")
+
+        # Global layer indices where a pipeline stage begins. Derived from
+        # per-rank offsets (VPP is rejected in build_kimi_k3_spec, so vp_stage
+        # is always None); this handles uneven splits and avoids relying on a
+        # per-stage layer count. A layer is a stage entry if it starts a
+        # non-first stage, and a stage exit if the next layer starts a new
+        # stage (i.e. this is the last layer of a non-final stage).
+        pp_size = self.config.pipeline_model_parallel_size
+        stage_starts = {get_transformer_layer_offset(self.config, None, r) for r in range(pp_size)}
+        layer_idx = self.layer_number - 1
+        self.is_stage_entry = layer_idx in stage_starts and layer_idx > 0
+        self.is_stage_exit = (layer_idx + 1) in stage_starts and layer_idx + 1 < self.config.num_layers
+
+    @staticmethod
+    def _add_bias(output_with_bias: tuple[torch.Tensor, torch.Tensor | None]) -> torch.Tensor:
+        output, bias = output_with_bias
+        return output if bias is None else output + bias
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: torch.Tensor | None = None,
+        context: torch.Tensor | None = None,
+        context_mask: torch.Tensor | None = None,
+        rotary_pos_emb: torch.Tensor | None = None,
+        rotary_pos_cos: torch.Tensor | None = None,
+        rotary_pos_sin: torch.Tensor | None = None,
+        rotary_pos_cos_sin: torch.Tensor | None = None,
+        attention_bias: torch.Tensor | None = None,
+        inference_context: BaseInferenceContext | None = None,
+        packed_seq_params: PackedSeqParams | None = None,
+        sequence_len_offset: torch.Tensor | None = None,
+        padding_mask: torch.Tensor | None = None,
+        input_ids: torch.Tensor | None = None,
+        **kwargs,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        del context_mask, kwargs
+        layer_idx = self.layer_number - 1
+
+        if context is not None:
+            prefix_sum = hidden_states
+            block_residual = context
+        elif layer_idx == 0:
+            prefix_sum = hidden_states
+            block_residual = hidden_states.new_empty(*hidden_states.shape[:-1], 0, hidden_states.shape[-1])
+        else:
+            assert self.is_stage_entry, "Attention-residual snapshot bank is missing"
+            prefix_sum, block_residual = unpack_stage_boundary(
+                hidden_states,
+                self.config.hidden_size,
+                bank_num_rows(layer_idx, self.attn_res_block_size),
+            )
+
+        if block_residual.shape[-2] > 0:
+            attention_input = attn_res_aggregate(
+                prefix_sum,
+                block_residual,
+                self.self_attention_res_proj,
+                self.self_attention_res_norm,
+                self.input_layernorm,
+            )
+        else:
+            attention_input = self.input_layernorm(prefix_sum)
+
+        is_block_write_layer = layer_idx % self.attn_res_block_size == 0
+        if is_block_write_layer:
+            block_residual = torch.cat((block_residual, prefix_sum.unsqueeze(-2)), dim=-2)
+
+        attention_output = self._add_bias(
+            self.self_attention(
+                attention_input,
+                attention_mask=attention_mask,
+                inference_context=inference_context,
+                rotary_pos_emb=rotary_pos_emb,
+                rotary_pos_cos=rotary_pos_cos,
+                rotary_pos_sin=rotary_pos_sin,
+                rotary_pos_cos_sin=rotary_pos_cos_sin,
+                attention_bias=attention_bias,
+                packed_seq_params=packed_seq_params,
+                sequence_len_offset=sequence_len_offset,
+            )
+        )
+        prefix_sum = attention_output if is_block_write_layer else prefix_sum + attention_output
+
+        mlp_input = attn_res_aggregate(
+            prefix_sum,
+            block_residual,
+            self.mlp_res_proj,
+            self.mlp_res_norm,
+            self.pre_mlp_layernorm,
+        )
+        mlp_kwargs = {"padding_mask": padding_mask}
+        if self.is_moe_layer:
+            mlp_kwargs["input_ids"] = input_ids
+        mlp_output = self._add_bias(self.mlp(mlp_input, **mlp_kwargs))
+        prefix_sum = prefix_sum + mlp_output
+
+        if self.layer_number == self.config.num_layers:
+            prefix_sum = attn_res_aggregate(
+                prefix_sum,
+                block_residual,
+                self.output_attn_res_proj,
+                self.output_attn_res_norm,
+                nn.Identity(),
+            )
+
+        if self.is_stage_exit:
+            return pack_stage_boundary(prefix_sum, block_residual), block_residual
+        return prefix_sum, block_residual

--- a/miles_plugins/models/kimi_k3/lora.py
+++ b/miles_plugins/models/kimi_k3/lora.py
@@ -1,0 +1,697 @@
+from __future__ import annotations
+
+import logging
+from collections import Counter
+from collections.abc import Callable
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+logger = logging.getLogger(__name__)
+
+_SUPPORTED_TARGET_SUFFIXES = {
+    "self_attention.o_proj",
+    "self_attention.q_a_proj",
+    "self_attention.kv_a_proj_with_mqa",
+    "mlp.linear_fc1",
+    "mlp.linear_fc2",
+    "mlp.experts.linear_fc1",
+    "mlp.experts.linear_fc2",
+}
+
+# Targets that may be omitted: the routed-expert down-proj carries the
+# EP-shared w2_lora_B whose cross-expert gradient aggregation dominates
+# adapter growth (cf. miles PR 1559); dropping it must not trip validation.
+_OPTIONAL_TARGET_SUFFIXES = {"mlp.experts.linear_fc2"}
+
+
+class KimiK3LoRAAdapter(nn.Module):
+    def __init__(self, kind: str, hf_prefix: str) -> None:
+        super().__init__()
+        self.kind = kind
+        self.hf_prefix = hf_prefix
+        self.load_meta: dict[str, int] = {}
+        self.include_fc2 = True  # experts only: _apply_expert_lora overrides per target set
+
+    def sharded_state_dict(self, prefix="", sharded_offsets=(), metadata=None):
+        del prefix, sharded_offsets, metadata
+        return {}
+
+
+def _new_param(
+    ref_weight: torch.Tensor,
+    shape: tuple[int, ...],
+    *,
+    init: str,
+    grad_sum_group: str | None = None,
+    expert: bool = False,
+) -> nn.Parameter:
+    tensor = torch.empty(*shape, dtype=ref_weight.dtype, device=ref_weight.device)
+    if init == "zero":
+        tensor.zero_()
+    elif init == "xavier":
+        if tensor.ndim == 2:
+            nn.init.xavier_uniform_(tensor)
+        else:
+            for expert_tensor in tensor:
+                nn.init.xavier_uniform_(expert_tensor)
+    else:
+        raise ValueError(f"Unsupported Kimi K3 LoRA init method: {init}")
+
+    param = nn.Parameter(tensor)
+    param.tensor_model_parallel = False
+    param.partition_dim = -1
+    param.partition_stride = 1
+    if expert:
+        param.allreduce = False
+    if grad_sum_group == "tp":
+        # Megatron already reduces TP-replicated partial gradients in
+        # finalize_model_grads (_allreduce_non_tensor_model_parallel_grads) —
+        # the same path its own sequence-parallel LayerNorm grads take.
+        param.sum_gradients_across_tp_domain = True
+    elif grad_sum_group is not None:
+        # EP has no upstream equivalent: Megatron assumes expert parameters are
+        # partitioned across EP and only ever reduces them over expert-DP, so
+        # reduce_marked_lora_grads supplies this sum.
+        assert grad_sum_group == "ep", f"unsupported LoRA gradient sum group {grad_sum_group!r}"
+        param._lora_grad_sum_group = grad_sum_group
+    return param
+
+
+def _register_param(
+    adapter: KimiK3LoRAAdapter,
+    name: str,
+    ref_weight: torch.Tensor,
+    shape: tuple[int, ...],
+    *,
+    init: str,
+    grad_sum_group: str | None = None,
+    expert: bool = False,
+) -> None:
+    adapter.register_parameter(
+        name,
+        _new_param(
+            ref_weight,
+            shape,
+            init=init,
+            grad_sum_group=grad_sum_group,
+            expert=expert,
+        ),
+    )
+
+
+def _dropout(inputs: torch.Tensor, probability: float, training: bool) -> torch.Tensor:
+    if probability and training:
+        return F.dropout(inputs, p=probability, training=True)
+    return inputs
+
+
+def _grouped_linear(inputs: torch.Tensor, weights: torch.Tensor, tokens_per_expert: list[int]) -> torch.Tensor:
+    if inputs.is_cuda:
+        offsets = torch.as_tensor(tokens_per_expert, device=inputs.device, dtype=torch.int32).cumsum(
+            0, dtype=torch.int32
+        )
+        return F.grouped_mm(inputs, weights.transpose(1, 2), offs=offsets)
+    segments = torch.split(inputs, tokens_per_expert, dim=0)
+    return torch.cat([F.linear(segment, weights[idx]) for idx, segment in enumerate(segments)], dim=0)
+
+
+def _validate_targets(args) -> None:
+    targets = set(args.target_modules)
+    suffixes = {target.split("decoder.layers.*.", 1)[-1] for target in targets}
+    unsupported = suffixes - _SUPPORTED_TARGET_SUFFIXES
+    missing = _SUPPORTED_TARGET_SUFFIXES - suffixes - _OPTIONAL_TARGET_SUFFIXES
+    if unsupported or missing:
+        raise NotImplementedError(
+            "Kimi K3 native LoRA currently requires the verified target set; "
+            f"unsupported={sorted(unsupported)}, missing={sorted(missing)}"
+        )
+    if not args.experts_shared_outer_loras:
+        raise NotImplementedError("Kimi K3 native LoRA currently requires --experts-shared-outer-loras")
+
+
+def _enable_full_recompute_input_grads(model) -> None:
+    if model.config.recompute_granularity != "full" or not model.pre_process:
+        return
+
+    def enable_grad(module, _inputs, output):
+        if module.training:
+            if not isinstance(output, torch.Tensor):
+                raise TypeError(f"Kimi K3 embedding returned {type(output)}, expected torch.Tensor")
+            output.requires_grad_(True)
+        return output
+
+    model.embedding.register_forward_hook(enable_grad)
+
+
+def _apply_attention_lora(attention, args, layer_idx: int, scale: float, dropout: float, a_init: str) -> None:
+    from megatron.core.tensor_parallel.mappings import reduce_from_tensor_model_parallel_region
+
+    rank = int(args.lora_rank)
+    hidden_size = attention.config.hidden_size
+    adapter = KimiK3LoRAAdapter(
+        "kda_attention" if attention.is_kda else "mla_attention",
+        f"language_model.model.layers.{layer_idx}.self_attn.",
+    )
+
+    _register_param(
+        adapter,
+        "o_lora_A",
+        attention.o_proj.weight,
+        (rank, attention.o_proj.weight.shape[1]),
+        init=a_init,
+    )
+    _register_param(
+        adapter,
+        "o_lora_B",
+        attention.o_proj.weight,
+        (hidden_size, rank),
+        init="zero",
+    )
+
+    o_proj = attention.o_proj
+    original_o_proj = o_proj.forward
+
+    def o_proj_forward(inputs, *forward_args, **forward_kwargs):
+        output, bias = original_o_proj(inputs, *forward_args, **forward_kwargs)
+        local = F.linear(_dropout(inputs, dropout, o_proj.training), adapter.o_lora_A)
+        reduced = reduce_from_tensor_model_parallel_region(local, group=attention.tp_group)
+        delta = F.linear(reduced, adapter.o_lora_B)
+        return torch.add(output, delta, alpha=scale), bias
+
+    o_proj.forward = o_proj_forward
+
+    if not attention.is_kda:
+        for module_name, output_size in (
+            ("q_a_proj", attention.q_lora_rank),
+            ("kv_a_proj_with_mqa", attention.kv_lora_rank + attention.qk_extra_head_dim),
+        ):
+            module = getattr(attention, module_name)
+            prefix = "q_a" if module_name == "q_a_proj" else "kv_a"
+            _register_param(
+                adapter,
+                f"{prefix}_lora_A",
+                module.weight,
+                (rank, hidden_size),
+                init=a_init,
+            )
+            _register_param(
+                adapter,
+                f"{prefix}_lora_B",
+                module.weight,
+                (output_size, rank),
+                init="zero",
+            )
+            original_forward = module.forward
+            lora_a = getattr(adapter, f"{prefix}_lora_A")
+            lora_b = getattr(adapter, f"{prefix}_lora_B")
+
+            def duplicated_forward(
+                inputs,
+                *forward_args,
+                _module=module,
+                _original=original_forward,
+                _a=lora_a,
+                _b=lora_b,
+                **forward_kwargs,
+            ):
+                output, bias = _original(inputs, *forward_args, **forward_kwargs)
+                delta = F.linear(F.linear(_dropout(inputs, dropout, _module.training), _a), _b)
+                # q_b/kv_b TE column backward reduces latent dgrad over TP;
+                # the key-extra slice is reduced by KimiK3Attention itself.
+                return torch.add(output, delta, alpha=scale), bias
+
+            module.forward = duplicated_forward
+
+    attention.lora_adapter = adapter
+
+
+def _apply_dense_mlp_lora(
+    mlp,
+    args,
+    layer_idx: int,
+    scale: float,
+    dropout: float,
+    a_init: str,
+    *,
+    adapter_kind: str = "dense_mlp",
+    hf_prefix: str | None = None,
+) -> None:
+    from megatron.core.tensor_parallel.mappings import (
+        gather_from_sequence_parallel_region,
+        reduce_from_tensor_model_parallel_region,
+        reduce_scatter_to_sequence_parallel_region,
+    )
+
+    rank = int(args.lora_rank)
+    sequence_parallel = bool(mlp.config.sequence_parallel)
+    tp_group = mlp.tp_group
+    fc1 = mlp.linear_fc1
+    fc2 = mlp.linear_fc2
+    adapter = KimiK3LoRAAdapter(
+        adapter_kind,
+        hf_prefix or f"language_model.model.layers.{layer_idx}.mlp.",
+    )
+    _register_param(
+        adapter,
+        "fc1_lora_A",
+        fc1.weight,
+        (rank, mlp.config.hidden_size),
+        init=a_init,
+        grad_sum_group="tp",
+    )
+    _register_param(
+        adapter,
+        "fc1_lora_B",
+        fc1.weight,
+        (fc1.weight.shape[0], rank),
+        init="zero",
+    )
+    _register_param(
+        adapter,
+        "fc2_lora_A",
+        fc2.weight,
+        (rank, fc2.weight.shape[1]),
+        init=a_init,
+    )
+    _register_param(
+        adapter,
+        "fc2_lora_B",
+        fc2.weight,
+        (mlp.config.hidden_size, rank),
+        init="zero",
+        grad_sum_group="tp" if sequence_parallel else None,
+    )
+
+    original_fc1 = fc1.forward
+
+    def fc1_forward(inputs, *forward_args, **forward_kwargs):
+        output, bias = original_fc1(inputs, *forward_args, **forward_kwargs)
+        adapter_inputs = gather_from_sequence_parallel_region(inputs, group=tp_group) if sequence_parallel else inputs
+        delta = F.linear(
+            F.linear(_dropout(adapter_inputs, dropout, fc1.training), adapter.fc1_lora_A),
+            adapter.fc1_lora_B,
+        )
+        return torch.add(output, delta, alpha=scale), bias
+
+    fc1.forward = fc1_forward
+    original_fc2 = fc2.forward
+
+    def fc2_forward(inputs, *forward_args, **forward_kwargs):
+        output, bias = original_fc2(inputs, *forward_args, **forward_kwargs)
+        local = F.linear(_dropout(inputs, dropout, fc2.training), adapter.fc2_lora_A)
+        reduced = (
+            reduce_scatter_to_sequence_parallel_region(local, group=tp_group)
+            if sequence_parallel
+            else reduce_from_tensor_model_parallel_region(local, group=tp_group)
+        )
+        delta = F.linear(reduced, adapter.fc2_lora_B)
+        return torch.add(output, delta, alpha=scale), bias
+
+    fc2.forward = fc2_forward
+    mlp.lora_adapter = adapter
+
+
+def _apply_expert_lora(
+    moe,
+    args,
+    layer_idx: int,
+    scale: float,
+    dropout: float,
+    a_init: str,
+    *,
+    include_fc2: bool,
+) -> None:
+    experts = moe.experts
+    if (moe.config.expert_tensor_parallel_size or 1) != 1:
+        raise NotImplementedError("Kimi K3 native expert LoRA currently requires ETP=1")
+
+    rank = int(args.lora_rank)
+    num_local_experts = experts.num_local_experts
+    latent_size = moe.config.moe_latent_size
+    intermediate_size = moe.config.moe_ffn_hidden_size
+    ref_fc1 = experts.linear_fc1.weight0
+    ref_fc2 = experts.linear_fc2.weight0
+    adapter = KimiK3LoRAAdapter(
+        "experts",
+        f"language_model.model.layers.{layer_idx}.block_sparse_moe.experts.",
+    )
+    adapter.include_fc2 = include_fc2
+    _register_param(
+        adapter,
+        "w1_lora_A",
+        ref_fc1,
+        (rank, latent_size),
+        init=a_init,
+        expert=True,
+        grad_sum_group="ep",
+    )
+    _register_param(
+        adapter,
+        "w3_lora_A",
+        ref_fc1,
+        (rank, latent_size),
+        init=a_init,
+        expert=True,
+        grad_sum_group="ep",
+    )
+    _register_param(
+        adapter,
+        "w1_lora_B",
+        ref_fc1,
+        (num_local_experts, intermediate_size, rank),
+        init="zero",
+        expert=True,
+    )
+    _register_param(
+        adapter,
+        "w3_lora_B",
+        ref_fc1,
+        (num_local_experts, intermediate_size, rank),
+        init="zero",
+        expert=True,
+    )
+    if include_fc2:
+        _register_param(
+            adapter,
+            "w2_lora_A",
+            ref_fc2,
+            (num_local_experts, rank, intermediate_size),
+            init=a_init,
+            expert=True,
+        )
+        _register_param(
+            adapter,
+            "w2_lora_B",
+            ref_fc2,
+            (latent_size, rank),
+            init="zero",
+            grad_sum_group="ep",
+            expert=True,
+        )
+    adapter.load_meta = {"num_local_experts": num_local_experts}
+
+    fc1 = experts.linear_fc1
+    original_fc1 = fc1.forward
+
+    def expert_fc1_forward(inputs, tokens_per_expert, *forward_args, **forward_kwargs):
+        output, bias = original_fc1(inputs, tokens_per_expert, *forward_args, **forward_kwargs)
+        adapter_inputs = _dropout(inputs, dropout, fc1.training)
+        shared = F.linear(
+            adapter_inputs,
+            torch.cat((adapter.w1_lora_A, adapter.w3_lora_A), dim=0),
+        )
+        w1_shared, w3_shared = shared.chunk(2, dim=-1)
+        w1_delta = _grouped_linear(w1_shared.contiguous(), adapter.w1_lora_B, tokens_per_expert)
+        w3_delta = _grouped_linear(w3_shared.contiguous(), adapter.w3_lora_B, tokens_per_expert)
+        delta = torch.cat((w1_delta, w3_delta), dim=-1)
+        return torch.add(output, delta, alpha=scale), bias
+
+    fc1.forward = expert_fc1_forward
+    if include_fc2:
+        fc2 = experts.linear_fc2
+        original_fc2 = fc2.forward
+
+        def expert_fc2_forward(inputs, tokens_per_expert, *forward_args, **forward_kwargs):
+            output, bias = original_fc2(inputs, tokens_per_expert, *forward_args, **forward_kwargs)
+            inner = _grouped_linear(
+                _dropout(inputs, dropout, fc2.training),
+                adapter.w2_lora_A,
+                tokens_per_expert,
+            )
+            delta = F.linear(inner, adapter.w2_lora_B)
+            return torch.add(output, delta, alpha=scale), bias
+
+        fc2.forward = expert_fc2_forward
+    experts.lora_adapter = adapter
+
+
+def apply_kimi_k3_lora(model, args):
+    from megatron.core.transformer.mlp import MLP
+    from megatron.core.transformer.moe.moe_layer import MoELayer
+
+    from .layers import KimiK3Attention
+
+    _validate_targets(args)
+    rank = int(args.lora_rank)
+    if rank <= 0:
+        raise ValueError("apply_kimi_k3_lora requires --lora-rank > 0")
+    scale = float(args.lora_alpha) / rank
+    dropout = float(args.lora_dropout or 0.0)
+    a_init = "xavier"
+
+    for parameter in model.parameters():
+        parameter.requires_grad = False
+    _enable_full_recompute_input_grads(model)
+
+    for layer in model.decoder.layers:
+        layer_idx = layer.layer_number - 1
+        if not isinstance(layer.self_attention, KimiK3Attention):
+            raise TypeError(f"Kimi K3 layer {layer_idx} has unexpected attention type {type(layer.self_attention)}")
+        _apply_attention_lora(layer.self_attention, args, layer_idx, scale, dropout, a_init)
+
+        if isinstance(layer.mlp, MLP):
+            _apply_dense_mlp_lora(layer.mlp, args, layer_idx, scale, dropout, a_init)
+        elif isinstance(layer.mlp, MoELayer):
+            _apply_expert_lora(
+                layer.mlp,
+                args,
+                layer_idx,
+                scale,
+                dropout,
+                a_init,
+                include_fc2=any(target.endswith("mlp.experts.linear_fc2") for target in args.target_modules),
+            )
+            if layer.mlp.shared_experts is None:
+                raise RuntimeError(f"Kimi K3 MoE layer {layer_idx} is missing shared experts")
+            _apply_dense_mlp_lora(
+                layer.mlp.shared_experts,
+                args,
+                layer_idx,
+                scale,
+                dropout,
+                a_init,
+                adapter_kind="shared_experts",
+                hf_prefix=(f"language_model.model.layers.{layer_idx}.block_sparse_moe.shared_experts."),
+            )
+        else:
+            raise TypeError(f"Kimi K3 layer {layer_idx} has unexpected MLP type {type(layer.mlp)}")
+
+    trainable = sum(parameter.numel() for parameter in model.parameters() if parameter.requires_grad)
+    total = sum(parameter.numel() for parameter in model.parameters())
+    logger.info(
+        "Kimi K3 native LoRA applied: rank=%d alpha=%s trainable=%d total=%d ratio=%.6f%%",
+        rank,
+        args.lora_alpha,
+        trainable,
+        total,
+        100.0 * trainable / total,
+    )
+    return model
+
+
+def wrap_model_provider_with_kimi_k3_lora(provider_func, args):
+    def wrapped(*provider_args, **provider_kwargs):
+        return apply_kimi_k3_lora(provider_func(*provider_args, **provider_kwargs), args)
+
+    return wrapped
+
+
+class _GatherBatch:
+    class _Token:
+        def __init__(self, batch: _GatherBatch, kind: str, index: int) -> None:
+            self.batch = batch
+            self.kind = kind
+            self.index = index
+
+        def get(self) -> torch.Tensor:
+            return self.batch.resolved[self.kind][self.index]
+
+    def __init__(self) -> None:
+        self.requests: dict[str, list[tuple[torch.Tensor, int]]] = {"tp": [], "ep": []}
+        self.resolved: dict[str, list[torch.Tensor]] = {"tp": [], "ep": []}
+
+    def add(self, kind: str, local: torch.Tensor, dim: int) -> _Token:
+        self.requests[kind].append((local, dim))
+        return self._Token(self, kind, len(self.requests[kind]) - 1)
+
+    def flush(self) -> int:
+        from megatron.core import parallel_state
+
+        groups = {
+            "tp": (
+                parallel_state.get_tensor_model_parallel_group,
+                parallel_state.get_tensor_model_parallel_world_size(),
+            ),
+            "ep": (
+                parallel_state.get_expert_model_parallel_group,
+                parallel_state.get_expert_model_parallel_world_size(),
+            ),
+        }
+        calls = 0
+        for kind, requests in self.requests.items():
+            if not requests:
+                continue
+            get_group, world_size = groups[kind]
+            if world_size == 1:
+                self.resolved[kind] = [local for local, _dim in requests]
+                continue
+            group = get_group()
+            dtypes = {local.dtype for local, _dim in requests}
+            if len(dtypes) != 1:
+                raise TypeError(f"Kimi K3 LoRA {kind} gather has mixed dtypes: {dtypes}")
+            flat_parts = [local.detach().contiguous().view(-1) for local, _dim in requests]
+            sizes = [part.numel() for part in flat_parts]
+            flat_local = torch.cat(flat_parts)
+            gathered = flat_local.new_empty(world_size * flat_local.numel())
+            torch.distributed.all_gather_into_tensor(gathered, flat_local, group=group)
+            per_rank = gathered.view(world_size, flat_local.numel())
+            offset = 0
+            resolved = []
+            for (local, dim), size in zip(requests, sizes, strict=True):
+                partitions = [per_rank[rank, offset : offset + size].view(local.shape) for rank in range(world_size)]
+                resolved.append(torch.cat(partitions, dim=dim))
+                offset += size
+            self.resolved[kind] = resolved
+            calls += 1
+        return calls
+
+
+def _unwrap_model_chunks(model_chunks):
+    for chunk in model_chunks:
+        while hasattr(chunk, "module"):
+            chunk = chunk.module
+        yield chunk
+
+
+def _validate_adapter_layout(models, adapters: list[KimiK3LoRAAdapter]) -> None:
+    expected = []
+    for model in models:
+        for layer in model.decoder.layers:
+            layer_idx = layer.layer_number - 1
+            attention_kind = "kda_attention" if layer.self_attention.is_kda else "mla_attention"
+            expected.append(
+                (
+                    attention_kind,
+                    f"language_model.model.layers.{layer_idx}.self_attn.",
+                )
+            )
+            if hasattr(layer.mlp, "experts"):
+                expected.extend(
+                    (
+                        (
+                            "experts",
+                            f"language_model.model.layers.{layer_idx}.block_sparse_moe.experts.",
+                        ),
+                        (
+                            "shared_experts",
+                            f"language_model.model.layers.{layer_idx}.block_sparse_moe.shared_experts.",
+                        ),
+                    )
+                )
+            else:
+                expected.append(
+                    (
+                        "dense_mlp",
+                        f"language_model.model.layers.{layer_idx}.mlp.",
+                    )
+                )
+
+    expected_counts = Counter(expected)
+    actual_counts = Counter((adapter.kind, adapter.hf_prefix) for adapter in adapters)
+    if actual_counts != expected_counts:
+        missing = list((expected_counts - actual_counts).elements())
+        unexpected = list((actual_counts - expected_counts).elements())
+        raise RuntimeError(
+            "Kimi K3 LoRA adapter layout is incomplete: "
+            f"expected={sum(expected_counts.values())}, actual={sum(actual_counts.values())}, "
+            f"missing={missing[:5]}, unexpected={unexpected[:5]}"
+        )
+
+
+def _export_attention(adapter: KimiK3LoRAAdapter, materialize_parameter):
+    batch = _GatherBatch()
+    plans: list[tuple[str, torch.Tensor | Callable[[], torch.Tensor]]] = []
+    prefix = adapter.hf_prefix
+    if adapter.kind == "mla_attention":
+        for hf_name, parameter_a, parameter_b in (
+            ("q_a_proj", adapter.q_a_lora_A, adapter.q_a_lora_B),
+            ("kv_a_proj_with_mqa", adapter.kv_a_lora_A, adapter.kv_a_lora_B),
+        ):
+            local_a = materialize_parameter(parameter_a)
+            local_b = materialize_parameter(parameter_b)
+            plans.append((f"{prefix}{hf_name}.lora_A.weight", local_a))
+            plans.append((f"{prefix}{hf_name}.lora_B.weight", local_b))
+    o_a = batch.add("tp", materialize_parameter(adapter.o_lora_A), 1)
+    plans.append((f"{prefix}o_proj.lora_A.weight", o_a.get))
+    plans.append((f"{prefix}o_proj.lora_B.weight", materialize_parameter(adapter.o_lora_B)))
+    batch.flush()
+    return plans
+
+
+def _export_dense_mlp(adapter: KimiK3LoRAAdapter, materialize_parameter):
+    batch = _GatherBatch()
+    prefix = adapter.hf_prefix
+    fc1_a = materialize_parameter(adapter.fc1_lora_A)
+    gate_b_local, up_b_local = materialize_parameter(adapter.fc1_lora_B).chunk(2, dim=0)
+    gate_b = batch.add("tp", gate_b_local, 0)
+    up_b = batch.add("tp", up_b_local, 0)
+    down_a = batch.add("tp", materialize_parameter(adapter.fc2_lora_A), 1)
+    fc2_b = materialize_parameter(adapter.fc2_lora_B)
+    batch.flush()
+    return [
+        (f"{prefix}gate_proj.lora_A.weight", fc1_a),
+        (f"{prefix}gate_proj.lora_B.weight", gate_b.get),
+        (f"{prefix}up_proj.lora_A.weight", fc1_a),
+        (f"{prefix}up_proj.lora_B.weight", up_b.get),
+        (f"{prefix}down_proj.lora_A.weight", down_a.get),
+        (f"{prefix}down_proj.lora_B.weight", fc2_b),
+    ]
+
+
+def _export_experts(adapter: KimiK3LoRAAdapter, materialize_parameter):
+    batch = _GatherBatch()
+    prefix = adapter.hf_prefix
+    w1_a = materialize_parameter(adapter.w1_lora_A)
+    w3_a = materialize_parameter(adapter.w3_lora_A)
+    w1_b = batch.add("ep", materialize_parameter(adapter.w1_lora_B), 0)
+    w3_b = batch.add("ep", materialize_parameter(adapter.w3_lora_B), 0)
+    if adapter.include_fc2:
+        w2_a = batch.add("ep", materialize_parameter(adapter.w2_lora_A), 0)
+        w2_b = materialize_parameter(adapter.w2_lora_B)
+    batch.flush()
+    plans = [
+        (f"{prefix}w1.lora_A.weight", w1_a.unsqueeze(0)),
+        (f"{prefix}w1.lora_B.weight", w1_b.get),
+        (f"{prefix}w3.lora_A.weight", w3_a.unsqueeze(0)),
+        (f"{prefix}w3.lora_B.weight", w3_b.get),
+    ]
+    if adapter.include_fc2:
+        plans.append((f"{prefix}w2.lora_A.weight", w2_a.get))
+        plans.append((f"{prefix}w2.lora_B.weight", w2_b.unsqueeze(0)))
+    return plans
+
+
+def export_kimi_k3_lora_hf_chunks(model_chunks, materialize_parameter=lambda parameter: parameter):
+    models = list(_unwrap_model_chunks(model_chunks))
+    adapters: list[KimiK3LoRAAdapter] = []
+    for model in models:
+        adapters.extend(module for module in model.modules() if isinstance(module, KimiK3LoRAAdapter))
+    if not adapters:
+        raise RuntimeError("Kimi K3 native LoRA export found no adapters")
+    _validate_adapter_layout(models, adapters)
+
+    for adapter in adapters:
+        if adapter.kind in ("kda_attention", "mla_attention"):
+            plans = _export_attention(adapter, materialize_parameter)
+        elif adapter.kind in ("dense_mlp", "shared_experts"):
+            plans = _export_dense_mlp(adapter, materialize_parameter)
+        elif adapter.kind == "experts":
+            plans = _export_experts(adapter, materialize_parameter)
+        else:
+            raise ValueError(f"Unknown Kimi K3 LoRA adapter kind: {adapter.kind}")
+        yield [
+            (name, (value() if callable(value) else value).detach().to(torch.bfloat16).contiguous())
+            for name, value in plans
+        ]

--- a/miles_plugins/models/kimi_k3/model.py
+++ b/miles_plugins/models/kimi_k3/model.py
@@ -1,0 +1,66 @@
+import copy
+
+from megatron.core.extensions.transformer_engine import TEColumnParallelLinear, TENorm
+from megatron.core.models.gpt.gpt_layer_specs import get_gpt_decoder_block_spec
+from megatron.core.transformer.spec_utils import ModuleSpec
+from megatron.core.transformer.transformer_layer import get_transformer_layer_offset
+
+from .layers import KimiK3Attention, KimiK3TransformerLayer
+from .ops import situ_and_mul
+
+
+KIMI_K3_KDA_LAYERS = tuple(
+    layer_number for layer_number in range(1, 94) if layer_number % 4 != 0 and layer_number != 93
+)
+
+
+def configure_kimi_k3(config) -> None:
+    assert config.num_layers <= 93
+    assert config.num_attention_heads == 96
+    assert config.moe_latent_size == 3584
+    config.kimi_kda_layers = tuple(
+        layer_number for layer_number in KIMI_K3_KDA_LAYERS if layer_number <= config.num_layers
+    )
+    config.kimi_linear_num_heads = 96
+    config.kimi_linear_head_dim = 128
+    config.kimi_linear_conv_kernel_size = 4
+    config.kimi_kda_gate_lower_bound = -5.0
+    config.kimi_attn_res_block_size = 12
+    config.gated_activation_func = situ_and_mul
+    config.moe_latent_use_norm = True
+    config.bias_activation_fusion = False
+    config.use_te_activation_func = False
+
+
+def build_kimi_k3_spec(config, vp_stage=None):
+    assert config.virtual_pipeline_model_parallel_size is None, "Kimi K3 does not support VPP yet"
+
+    block_spec = get_gpt_decoder_block_spec(
+        config,
+        use_transformer_engine=True,
+        vp_stage=vp_stage,
+    )
+    # block_spec.layer_specs only holds this PP stage's layers, so index
+    # moe_layer_freq with the global layer offset of the stage.
+    layer_offset = get_transformer_layer_offset(config, vp_stage)
+    layer_specs = []
+    for layer_spec in block_spec.layer_specs:
+        layer_spec = copy.deepcopy(layer_spec)
+        layer_spec.module = KimiK3TransformerLayer
+        layer_spec.submodules.self_attention = ModuleSpec(module=KimiK3Attention)
+        layer_spec.submodules.input_layernorm = TENorm
+        layer_spec.submodules.pre_mlp_layernorm = TENorm
+
+        if not config.moe_layer_freq[layer_offset + len(layer_specs)]:
+            layer_spec.submodules.mlp.submodules.linear_fc1 = TEColumnParallelLinear
+
+        layer_specs.append(layer_spec)
+
+    block_spec.layer_specs = layer_specs
+    return block_spec
+
+
+def get_kimi_k3_spec(args, config, vp_stage):
+    del args
+    configure_kimi_k3(config)
+    return build_kimi_k3_spec(config, vp_stage=vp_stage)

--- a/miles_plugins/models/kimi_k3/ops.py
+++ b/miles_plugins/models/kimi_k3/ops.py
@@ -1,0 +1,117 @@
+import torch
+import torch.nn as nn
+
+
+def _patch_fla_kda_hopper_autotune() -> None:
+    from fla.ops.kda.chunk_bwd import chunk_kda_bwd_kernel_wy_dqkg_fused
+    from fla.utils import IS_NVIDIA_HOPPER
+
+    if not IS_NVIDIA_HOPPER:
+        return
+
+    autotuner = chunk_kda_bwd_kernel_wy_dqkg_fused.fn
+    if getattr(autotuner, "_kimi_k3_hopper_configs_patched", False):
+        return
+
+    assert len(autotuner.configs) == 24
+    autotuner.configs = [
+        config for config in autotuner.configs if not (config.kwargs["BK"] == 32 and config.num_warps == 4)
+    ]
+    assert len(autotuner.configs) == 18
+    autotuner._kimi_k3_hopper_configs_patched = True
+
+
+def kda(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    lower_bound: float,
+    *,
+    cu_seqlens: torch.Tensor | None = None,
+    cp_context=None,
+) -> torch.Tensor:
+    """Delta-rule core, fla in both directions.
+
+    Sequence boundaries reach fla through exactly one of two channels, never
+    both: ``cu_seqlens`` without CP, and ``cp_context`` under CP, where fla
+    derives the rank-local boundaries itself and the caller's ``cu_seqlens`` is
+    already a copy of the context's own. Passing both is a combination fla has
+    never been run with here, so the selection stays exclusive.
+
+    ``initial_state`` / ``output_final_state`` are unavailable under CP (fla
+    forbids them): the recurrent state crosses ranks through ``cp_context``,
+    not through an explicitly threaded tensor.
+    """
+    from fla.ops.kda import chunk_kda
+
+    _patch_fla_kda_hopper_autotune()
+    boundaries = {"cp_context": cp_context} if cp_context is not None else {"cu_seqlens": cu_seqlens}
+    output, _ = chunk_kda(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        A_log=A_log,
+        dt_bias=dt_bias,
+        initial_state=None,
+        output_final_state=False,
+        use_qk_l2norm_in_kernel=True,
+        use_gate_in_kernel=True,
+        safe_gate=True,
+        lower_bound=lower_bound,
+        transpose_state_layout=True,
+        **boundaries,
+    )
+    return output
+
+
+def situ_and_mul(
+    x: torch.Tensor,
+    beta: float = 4.0,
+    linear_beta: float = 25.0,
+) -> torch.Tensor:
+    gate, linear = torch.chunk(x.float(), 2, dim=-1)
+    gate = beta * torch.tanh(gate / beta) * torch.sigmoid(gate)
+    linear = linear_beta * torch.tanh(linear / linear_beta)
+    return (gate * linear).to(x.dtype)
+
+
+class KimiRMSNorm(nn.Module):
+    def __init__(
+        self,
+        hidden_size: int,
+        eps: float,
+        device: torch.device | int | None = None,
+        dtype: torch.dtype | None = None,
+    ) -> None:
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(hidden_size, device=device, dtype=dtype))
+        self.eps = eps
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        input_dtype = hidden_states.dtype
+        normalized = hidden_states.float()
+        normalized = normalized * torch.rsqrt(normalized.square().mean(dim=-1, keepdim=True) + self.eps)
+        return self.weight * normalized.to(input_dtype)
+
+
+def attn_res_aggregate(
+    prefix_sum: torch.Tensor,
+    block_residual: torch.Tensor,
+    score_proj: nn.Linear,
+    score_norm: KimiRMSNorm,
+    output_norm: nn.Module,
+) -> torch.Tensor:
+    rows = torch.cat((block_residual, prefix_sum.unsqueeze(-2)), dim=-2)
+    rows_float = rows.float()
+    normalized = rows_float * torch.rsqrt(rows_float.square().mean(dim=-1, keepdim=True) + score_norm.eps)
+    score_weight = score_norm.weight.float() * score_proj.weight.squeeze(0).float()
+    scores = (normalized * score_weight).sum(dim=-1)
+    probabilities = torch.softmax(scores, dim=-1)
+    mixed = (probabilities.unsqueeze(-1) * rows_float).sum(dim=-2).to(rows.dtype)
+    return output_norm(mixed)

--- a/miles_plugins/models/kimi_k3/pipeline.py
+++ b/miles_plugins/models/kimi_k3/pipeline.py
@@ -1,0 +1,33 @@
+"""Stage-boundary packing for pipeline-parallel Kimi K3.
+
+The attention-residual state (prefix_sum plus the snapshot bank) must cross
+pipeline stage boundaries, but Megatron's p2p carries a single hidden-states
+tensor. The stage-exit layer packs [prefix_sum, bank] along the hidden
+dimension into one 3-D tensor and the stage-entry layer unpacks it. Miles
+always runs the Megatron backend with variable_seq_lengths, so the receiver
+allocates its buffer from the sender's actual shape and any row-count
+disagreement fails loudly at unpack instead of corrupting silently.
+"""
+
+import torch
+
+
+def bank_num_rows(layer_idx: int, block_size: int) -> int:
+    """Snapshot rows present before global layer ``layer_idx`` executes."""
+    assert layer_idx > 0
+    return (layer_idx + block_size - 1) // block_size
+
+
+def pack_stage_boundary(prefix_sum: torch.Tensor, block_residual: torch.Tensor) -> torch.Tensor:
+    assert block_residual.shape[-2] > 0, "stage boundary before the first snapshot write"
+    return torch.cat((prefix_sum, block_residual.flatten(-2)), dim=-1)
+
+
+def unpack_stage_boundary(packed: torch.Tensor, hidden_size: int, num_rows: int) -> tuple[torch.Tensor, torch.Tensor]:
+    expected = (1 + num_rows) * hidden_size
+    assert (
+        packed.shape[-1] == expected
+    ), f"stage-boundary payload width {packed.shape[-1]} != (1 + {num_rows}) * {hidden_size}"
+    prefix_sum = packed[..., :hidden_size].contiguous()
+    block_residual = packed[..., hidden_size:].unflatten(-1, (num_rows, hidden_size)).contiguous()
+    return prefix_sum, block_residual

--- a/miles_plugins/models/qwen3_5.py
+++ b/miles_plugins/models/qwen3_5.py
@@ -16,7 +16,7 @@ except ImportError:
     pass
 
 from miles.backends.megatron_utils.fp32_param_utils import mark_param_dtype
-from miles.backends.training_utils.cp_utils import build_gdn_cp_context
+from miles_plugins.models.cp_utils import build_gdn_cp_context
 
 from .hf_attention import HuggingfaceAttention
 from .qwen_gdn_backend import get_chunk_gated_delta_rule

--- a/miles_plugins/models/qwen3_next.py
+++ b/miles_plugins/models/qwen3_next.py
@@ -16,7 +16,7 @@ try:
 except ImportError:
     pass
 
-from miles.backends.training_utils.cp_utils import build_gdn_cp_context
+from miles_plugins.models.cp_utils import build_gdn_cp_context
 
 from .hf_attention import HuggingfaceAttention
 from .qwen_gdn_backend import get_chunk_gated_delta_rule

--- a/scripts/models/kimi-k3-4layer.sh
+++ b/scripts/models/kimi-k3-4layer.sh
@@ -1,0 +1,52 @@
+NLAYERS=4
+MOE_LAYER_FREQ="[0,1,1,1]"
+
+MODEL_ARGS=(
+    --spec "miles_plugins.models.kimi_k3" "get_kimi_k3_spec"
+
+    --disable-bias-linear
+    --num-layers "$NLAYERS"
+    --hidden-size 7168
+    --ffn-hidden-size 33792
+    --num-attention-heads 96
+    --num-query-groups 96
+    --kv-channels 256
+    --normalization RMSNorm
+    --position-embedding-type none
+    --rotary-base 50000
+    --norm-epsilon 1e-5
+    --hidden-dropout 0
+    --attention-dropout 0
+    --disable-bf16-reduced-precision-matmul
+    --swiglu
+    --untie-embeddings-and-output-weights
+    --vocab-size 163840
+    --make-vocab-size-divisible-by 128
+
+    --multi-latent-attention
+    --q-lora-rank 1536
+    --kv-lora-rank 512
+    --qk-head-dim 128
+    --qk-pos-emb-head-dim 64
+    --v-head-dim 128
+    --qk-layernorm
+    --attention-softmax-in-fp32
+
+    --num-experts 896
+    --moe-layer-freq "$MOE_LAYER_FREQ"
+    --moe-ffn-hidden-size 3072
+    --moe-latent-size 3584
+    --moe-shared-expert-intermediate-size 6144
+    --moe-router-topk 16
+    --moe-router-score-function sigmoid
+    --moe-router-pre-softmax
+    --moe-router-enable-expert-bias
+    --moe-router-load-balancing-type none
+    --moe-token-dispatcher-type alltoall
+    --moe-router-bias-update-rate 0
+    --moe-aux-loss-coeff 0
+    --moe-router-topk-scaling-factor 1.0
+    --moe-router-dtype fp32
+    --moe-grouped-gemm
+    --moe-permute-fusion
+)

--- a/scripts/models/kimi-k3.sh
+++ b/scripts/models/kimi-k3.sh
@@ -1,0 +1,52 @@
+NLAYERS=93
+MOE_LAYER_FREQ="[0,$(printf '1,%.0s' {1..91})1]"
+
+MODEL_ARGS=(
+    --spec "miles_plugins.models.kimi_k3" "get_kimi_k3_spec"
+
+    --disable-bias-linear
+    --num-layers "$NLAYERS"
+    --hidden-size 7168
+    --ffn-hidden-size 33792
+    --num-attention-heads 96
+    --num-query-groups 96
+    --kv-channels 256
+    --normalization RMSNorm
+    --position-embedding-type none
+    --rotary-base 10000
+    --norm-epsilon 1e-5
+    --hidden-dropout 0
+    --attention-dropout 0
+    --disable-bf16-reduced-precision-matmul
+    --swiglu
+    --untie-embeddings-and-output-weights
+    --vocab-size 163840
+    --make-vocab-size-divisible-by 128
+
+    --multi-latent-attention
+    --q-lora-rank 1536
+    --kv-lora-rank 512
+    --qk-head-dim 128
+    --qk-pos-emb-head-dim 64
+    --v-head-dim 128
+    --qk-layernorm
+    --attention-softmax-in-fp32
+
+    --num-experts 896
+    --moe-layer-freq "$MOE_LAYER_FREQ"
+    --moe-ffn-hidden-size 3072
+    --moe-latent-size 3584
+    --moe-shared-expert-intermediate-size 6144
+    --moe-router-topk 16
+    --moe-router-score-function sigmoid
+    --moe-router-pre-softmax
+    --moe-router-enable-expert-bias
+    --moe-router-load-balancing-type none
+    --moe-token-dispatcher-type alltoall
+    --moe-router-bias-update-rate 0
+    --moe-aux-loss-coeff 0
+    --moe-router-topk-scaling-factor 1.0
+    --moe-router-dtype fp32
+    --moe-grouped-gemm
+    --moe-permute-fusion
+)

--- a/scripts/run_kimi_k3.py
+++ b/scripts/run_kimi_k3.py
@@ -1,0 +1,168 @@
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+import typer
+
+import miles.utils.external_utils.command_utils as U
+
+
+app = typer.Typer()
+
+
+@dataclass
+class ScriptArgs(U.ExecuteTrainConfig):
+    mode: Literal["normal", "debug_minimal"] = "debug_minimal"
+    run_id: str = U.create_run_id()
+    hf_checkpoint: str = "/root/models/Kimi-K3-4layer-bf16"
+    ref_load: str = "/root/models/Kimi-K3-4layer-torch-dist"
+    megatron_model_type: str = "kimi-k3-4layer"
+    num_gpus_per_node: int = 8
+    data_dir: str = "/root/datasets"
+    megatron_path: str = "/root/Megatron-LM"
+    sglang_path: str = "/root/sglang/python"
+    check_weight_update_equal: bool = False
+    extra_args: str = ""
+
+    def __post_init__(self):
+        if self.num_nodes != 1 or self.num_gpus_per_node != 8:
+            raise NotImplementedError("The verified Kimi K3 training configuration is one 8-GPU node")
+
+
+def _validate_paths(args: ScriptArgs) -> None:
+    for name, path in (("hf_checkpoint", args.hf_checkpoint), ("ref_load", args.ref_load)):
+        if not Path(path).exists():
+            raise FileNotFoundError(f"{name} does not exist: {path}")
+    if not Path(args.sglang_path, "sglang").is_dir():
+        raise FileNotFoundError(f"sglang package does not exist under sglang_path: {args.sglang_path}")
+
+
+@app.command()
+@U.dataclass_cli
+def prepare_data(args: ScriptArgs) -> None:
+    Path(args.data_dir).mkdir(parents=True, exist_ok=True)
+    U.hf_download_dataset("zhuzilin/dapo-math-17k", data_dir=args.data_dir)
+
+
+def _execute_train(args: ScriptArgs) -> None:
+    _validate_paths(args)
+    dataset = Path(args.data_dir) / "dapo-math-17k" / "dapo-math-17k.jsonl"
+    if not dataset.is_file():
+        raise FileNotFoundError(f"Dataset does not exist: {dataset}; run prepare-data first")
+
+    ckpt_args = (
+        f"--hf-checkpoint {args.hf_checkpoint} "
+        f"--ref-load {args.ref_load} "
+        "--megatron-to-hf-mode raw "
+        "--model-name kimi_k3 "
+    )
+
+    rollout_args = (
+        f"--prompt-data {dataset} "
+        "--input-key prompt "
+        "--label-key label "
+        "--apply-chat-template "
+        "--rollout-shuffle "
+        "--balance-data "
+        f"--rm-type {'deterministic_random' if args.mode == 'debug_minimal' else 'deepscaler'} "
+        f"--num-rollout {2 if args.mode == 'debug_minimal' else 3000} "
+        f"--rollout-batch-size {8 if args.mode == 'debug_minimal' else 32} "
+        f"--n-samples-per-prompt {2 if args.mode == 'debug_minimal' else 8} "
+        f"--rollout-max-response-len {32 if args.mode == 'debug_minimal' else 16384} "
+        "--rollout-temperature 1 "
+        f"--global-batch-size {16 if args.mode == 'debug_minimal' else 256} "
+        "--use-dynamic-global-batch-size "
+    )
+
+    perf_args = (
+        "--tensor-model-parallel-size 8 "
+        "--sequence-parallel "
+        "--pipeline-model-parallel-size 1 "
+        "--context-parallel-size 1 "
+        "--expert-model-parallel-size 8 "
+        "--expert-tensor-parallel-size 1 "
+        "--recompute-granularity full "
+        "--recompute-method uniform "
+        "--recompute-num-layers 1 "
+        "--use-dynamic-batch-size "
+        "--max-tokens-per-gpu 512 "
+        "--log-probs-chunk-size 512 "
+    )
+
+    optimizer_args = (
+        "--optimizer sgd --sgd-momentum 0 --lr 1e-6 --lr-decay-style constant "
+        "--weight-decay 0 --use-distributed-optimizer "
+        if args.mode == "debug_minimal"
+        else (
+            "--optimizer adam --lr 1e-6 --lr-decay-style constant "
+            "--weight-decay 0.1 --adam-beta1 0.9 --adam-beta2 0.98 "
+            "--optimizer-cpu-offload --optimizer-offload-fraction 0.8 "
+            "--overlap-cpu-optimizer-d2h-h2d "
+            "--use-precision-aware-optimizer --use-distributed-optimizer "
+        )
+    )
+
+    grpo_args = (
+        "--advantage-estimator grpo "
+        "--kl-loss-coef 0.0 "
+        "--kl-loss-type low_var_kl "
+        "--entropy-coef 0.0 "
+        "--eps-clip 0.2 "
+        "--eps-clip-high 0.28 "
+    )
+
+    sglang_args = (
+        "--rollout-num-gpus-per-engine 8 "
+        "--sglang-tp-size 8 "
+        "--sglang-ep-size 8 "
+        "--sglang-cuda-graph-bs 1 2 4 8 16 "
+        "--sglang-mem-fraction-static 0.7 "
+        "--sglang-server-concurrency 16 "
+        "--use-miles-router "
+    )
+
+    misc_args = (
+        "--attention-dropout 0.0 "
+        "--hidden-dropout 0.0 "
+        "--accumulate-allreduce-grads-in-fp32 "
+        "--no-check-for-nan-in-loss-and-grad "
+        "--colocate "
+        "--offload-train "
+        f"--update-weight-buffer-size {2 * 1024**3} "
+        f"--train-memory-margin-bytes {(2 if args.mode == 'debug_minimal' else 4) * 1024**3} "
+        f"--actor-num-nodes {args.num_nodes} "
+        f"--actor-num-gpus-per-node {args.num_gpus_per_node} "
+        f"--num-gpus-per-node {args.num_gpus_per_node} "
+    )
+    if args.check_weight_update_equal:
+        misc_args += "--check-weight-update-equal " "--check-weight-update-skip-list vision_tower. mm_projector. "
+
+    train_args = (
+        f"{ckpt_args} "
+        f"{rollout_args} "
+        f"{optimizer_args} "
+        f"{grpo_args} "
+        f"{U.get_default_wandb_args(__file__, run_id=args.run_id)} "
+        f"{perf_args} "
+        f"{sglang_args} "
+        f"{misc_args} "
+        f"{args.extra_args} "
+    )
+    U.execute_train(
+        train_args=train_args,
+        config=args,
+        num_gpus_per_node=args.num_gpus_per_node,
+        megatron_model_type=args.megatron_model_type,
+        extra_env_vars={"NCCL_TIMEOUT": "3600", "PYTHONPATH": args.sglang_path},
+        megatron_path=args.megatron_path,
+    )
+
+
+@app.command()
+@U.dataclass_cli
+def train(args: ScriptArgs) -> None:
+    _execute_train(args)
+
+
+if __name__ == "__main__":
+    app()

--- a/scripts/run_kimi_k3_lora.py
+++ b/scripts/run_kimi_k3_lora.py
@@ -50,14 +50,13 @@ class ScriptArgs(U.ExecuteTrainConfig):
     ep_size_override: int | None = None
     rollout_tp_size: int = 8
     rollout_ep_size: int = 1
-    rollout_max_concurrency: int = 1
+    rollout_max_concurrency: int = 64
 
     lora_rank: int = 16
     lora_alpha: int = 32
     lora_dropout: float = 0.0
     target_modules: str = _DEFAULT_TARGET_MODULES
     experts_shared_outer_loras: bool = True
-    lora_base_cpu_backup: bool = False
 
     reward_model: Literal["deterministic_random", "deepscaler", "math"] | None = None
     num_rollout: int | None = None
@@ -148,7 +147,9 @@ class ScriptArgs(U.ExecuteTrainConfig):
         if self.model_variant == "4layer":
             return 8
         # EP is bounded by the DP*CP*TP ranks inside one pipeline stage.
-        return 64 if self.pipeline_parallel_size == 1 else self.tensor_parallel_size
+        model_parallel = self.tensor_parallel_size * self.context_parallel_size * self.pipeline_parallel_size
+        data_parallel = 64 // model_parallel
+        return self.tensor_parallel_size * self.context_parallel_size * data_parallel
 
     @property
     def pipeline_layer_split(self) -> tuple[int, int]:
@@ -208,11 +209,12 @@ def _execute_train(args: ScriptArgs) -> None:
         f"--lora-dropout {args.lora_dropout} "
         f'--target-modules "{args.target_modules}" '
         "--no-gradient-accumulation-fusion "
+        # Host mirror of the rollout base weights, so releasing them does not
+        # require the trainer to re-ship the base every step.
+        "--lora-base-cpu-backup "
     )
     if args.experts_shared_outer_loras:
         lora_args += "--experts-shared-outer-loras "
-    if args.lora_base_cpu_backup:
-        lora_args += "--lora-base-cpu-backup "
 
     is_debug = args.mode == "debug_minimal"
     reward_model = args.reward_model or (
@@ -290,7 +292,7 @@ def _execute_train(args: ScriptArgs) -> None:
         "--recompute-method uniform "
         "--recompute-num-layers 1 "
         "--use-dynamic-batch-size "
-        f"--max-tokens-per-gpu {args.max_tokens_per_gpu if args.max_tokens_per_gpu is not None else (512 if args.model_variant == '4layer' else 1024)} "
+        f"--max-tokens-per-gpu {args.max_tokens_per_gpu if args.max_tokens_per_gpu is not None else (512 if args.model_variant == '4layer' else 8192)} "
         "--log-probs-chunk-size 512 "
         f"--distributed-timeout-minutes {args.distributed_timeout_minutes} "
     )
@@ -382,11 +384,7 @@ def _execute_train(args: ScriptArgs) -> None:
         f"--num-gpus-per-node {args.num_gpus_per_node} "
     )
     if args.model_variant == "4layer":
-        misc_args += "--offload-rollout-level kv_cache --no-check-for-nan-in-loss-and-grad "
-    else:
-        # Rollout weights stay resident on the GPU; only the KV cache is
-        # released for training, so there is no per-cycle base reload.
-        misc_args += "--offload-rollout-level kv_cache "
+        misc_args += "--no-check-for-nan-in-loss-and-grad "
     if args.check_weight_update_equal:
         misc_args += "--check-weight-update-equal " "--check-weight-update-skip-list vision_tower. mm_projector. "
 
@@ -417,6 +415,9 @@ def _execute_train(args: ScriptArgs) -> None:
         "NCCL_TIMEOUT": "3600",
         "PYTHONPATH": os.pathsep.join((str(Path(__file__).resolve().parents[1]), args.sglang_path)),
         "SGLANG_JIT_ROUTE_RADIX": "1",
+        # sglang's default membind forces the whole TMS weights CPU backup onto
+        # one NUMA node, which cannot hold it; keep the bind off by default.
+        "SGLANG_NUMA_BIND_V2": os.environ.get("SGLANG_NUMA_BIND_V2", "0"),
     }
     # Ray's runtime_env replaces the actor environment, so the persistent
     # Triton/Inductor JIT caches exported by the launch script are lost unless

--- a/scripts/run_kimi_k3_lora.py
+++ b/scripts/run_kimi_k3_lora.py
@@ -376,6 +376,9 @@ def _execute_train(args: ScriptArgs) -> None:
         "--accumulate-allreduce-grads-in-fp32 "
         "--colocate "
         "--offload-train "
+        # GB300: the engine weight mirror + trainer backup exceed the job
+        # cgroup, so the handoff overlap must live on the GPU instead.
+        "--colocate-memory-peak-device gpu "
         "--disable-weights-backuper "
         f"--update-weight-buffer-size {update_weight_buffer_size} "
         f"--train-memory-margin-bytes {(2 if args.mode == 'debug_minimal' else 4) * 1024**3} "

--- a/scripts/run_kimi_k3_lora.py
+++ b/scripts/run_kimi_k3_lora.py
@@ -1,0 +1,450 @@
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+import typer
+
+import miles.utils.external_utils.command_utils as U
+
+app = typer.Typer()
+
+_FOUR_LAYER_HF = "/root/models/Kimi-K3-4layer-bf16"
+_FOUR_LAYER_DCP = "/root/models/Kimi-K3-4layer-torch-dist"
+_FULL_HF = "/root/models/Kimi-K3/native"
+_FULL_DCP = "/root/models/Kimi-K3/torch_dist"
+
+_LAYERS = "decoder.layers.*"
+_DEFAULT_TARGET_MODULES = ",".join(
+    [
+        f"{_LAYERS}.self_attention.o_proj",
+        f"{_LAYERS}.self_attention.q_a_proj",
+        f"{_LAYERS}.self_attention.kv_a_proj_with_mqa",
+        f"{_LAYERS}.mlp.linear_fc1",
+        f"{_LAYERS}.mlp.linear_fc2",
+        f"{_LAYERS}.mlp.experts.linear_fc1",
+        f"{_LAYERS}.mlp.experts.linear_fc2",
+    ]
+)
+
+
+@dataclass
+class ScriptArgs(U.ExecuteTrainConfig):
+    mode: Literal["normal", "debug_minimal"] = "debug_minimal"
+    run_id: str = U.create_run_id()
+    model_variant: Literal["4layer", "full"] = "4layer"
+    task: Literal["gsm8k", "dapo-math"] = "gsm8k"
+    hf_checkpoint: str = _FOUR_LAYER_HF
+    ref_load: str = _FOUR_LAYER_DCP
+    megatron_model_type: str = "kimi-k3-4layer"
+    num_gpus_per_node: int = 8
+    data_dir: str = "/root/datasets"
+    save_dir: str = "/personal/checkpoints"
+    megatron_path: str = "/root/Megatron-LM"
+    sglang_path: str = "/root/sglang/python"
+    pipeline_parallel_size: int = 1
+    context_parallel_size: int = 1
+    # Explicit TP/EP overrides for layouts the PP-only derivation cannot express,
+    # e.g. TP4/CP2/PP4/EP8 (DP=2). None keeps the derived defaults unchanged.
+    tp_size_override: int | None = None
+    ep_size_override: int | None = None
+    rollout_tp_size: int = 8
+    rollout_ep_size: int = 1
+    rollout_max_concurrency: int = 1
+
+    lora_rank: int = 16
+    lora_alpha: int = 32
+    lora_dropout: float = 0.0
+    target_modules: str = _DEFAULT_TARGET_MODULES
+    experts_shared_outer_loras: bool = True
+    lora_base_cpu_backup: bool = False
+
+    reward_model: Literal["deterministic_random", "deepscaler", "math"] | None = None
+    num_rollout: int | None = None
+    rollout_batch_size: int | None = None
+    n_samples_per_prompt: int | None = None
+    rollout_max_response_len: int | None = None
+    sglang_max_total_tokens: int | None = None
+    global_batch_size: int | None = None
+    eval_interval: int | None = None
+    lr: float = 1e-5
+    max_tokens_per_gpu: int | None = None
+    distributed_timeout_minutes: int = 10
+    save_debug_rollout_data: str | None = None
+    enable_wandb: bool = False
+
+    check_weight_update_equal: bool = False
+    update_weight_buffer_size: int | None = None
+    extra_args: str = ""
+
+    def __post_init__(self):
+        if self.lora_rank <= 0:
+            raise ValueError(f"LoRA rank must be positive, got {self.lora_rank}")
+        if self.sglang_max_total_tokens is not None and self.sglang_max_total_tokens <= 0:
+            raise ValueError("SGLang max total tokens must be positive")
+        if self.distributed_timeout_minutes <= 0:
+            raise ValueError("Distributed timeout must be positive")
+        if self.model_variant == "4layer":
+            if self.num_nodes != 1 or self.num_gpus_per_node != 8:
+                raise NotImplementedError("The verified four-layer Kimi K3 LoRA configuration is one 8-GPU node")
+            if self.pipeline_parallel_size != 1:
+                raise NotImplementedError("Pipeline parallelism is only wired for the full model variant")
+            return
+
+        if 64 % self.rollout_tp_size != 0 or 96 % self.rollout_tp_size != 0:
+            raise ValueError(f"rollout_tp_size must divide 64 GPUs and 96 attention heads, got {self.rollout_tp_size}")
+        if self.rollout_tp_size % self.rollout_ep_size != 0 or 896 % self.rollout_ep_size != 0:
+            raise ValueError(
+                f"rollout_ep_size must divide rollout_tp_size and 896 experts, got {self.rollout_ep_size}"
+            )
+        if self.pipeline_parallel_size > 1:
+            if 64 % self.pipeline_parallel_size != 0:
+                raise ValueError(f"pipeline_parallel_size must divide 64 GPUs, got {self.pipeline_parallel_size}")
+            first, last = self.pipeline_layer_split
+            if not 1 <= last <= first:
+                raise ValueError(
+                    f"Cannot split 93 layers over pipeline_parallel_size={self.pipeline_parallel_size}: "
+                    f"first={first}, last={last}"
+                )
+
+        model_parallel = self.tensor_parallel_size * self.context_parallel_size * self.pipeline_parallel_size
+        if 64 % model_parallel != 0:
+            raise ValueError(
+                f"TP{self.tensor_parallel_size}*CP{self.context_parallel_size}*PP{self.pipeline_parallel_size}"
+                f"={model_parallel} must divide the 64 training GPUs"
+            )
+        data_parallel = 64 // model_parallel
+        non_pp_ranks = self.tensor_parallel_size * self.context_parallel_size * data_parallel
+        if non_pp_ranks % self.expert_parallel_size != 0:
+            raise ValueError(
+                f"expert_parallel_size={self.expert_parallel_size} must divide the DP*CP*TP ranks "
+                f"of one pipeline stage ({non_pp_ranks})"
+            )
+        if self.num_nodes != 16 or self.num_gpus_per_node != 4:
+            raise NotImplementedError(
+                "Full-model Kimi K3 LoRA is only validated on 16 nodes x 4 GPUs (64 training GPUs)"
+            )
+        if self.hf_checkpoint == _FOUR_LAYER_HF:
+            self.hf_checkpoint = _FULL_HF
+        if self.ref_load == _FOUR_LAYER_DCP:
+            self.ref_load = _FULL_DCP
+        if self.megatron_model_type == "kimi-k3-4layer":
+            self.megatron_model_type = "kimi-k3"
+
+    @property
+    def tensor_parallel_size(self) -> int:
+        if self.tp_size_override is not None:
+            return self.tp_size_override
+        if self.model_variant == "4layer":
+            return 8
+        if self.pipeline_parallel_size == 1:
+            return 32
+        return 64 // (self.pipeline_parallel_size * self.context_parallel_size)
+
+    @property
+    def expert_parallel_size(self) -> int:
+        if self.ep_size_override is not None:
+            return self.ep_size_override
+        if self.model_variant == "4layer":
+            return 8
+        # EP is bounded by the DP*CP*TP ranks inside one pipeline stage.
+        return 64 if self.pipeline_parallel_size == 1 else self.tensor_parallel_size
+
+    @property
+    def pipeline_layer_split(self) -> tuple[int, int]:
+        """(first, last) stage layer counts for the 93 language layers; middle
+        stages each take `first` layers."""
+        pp = self.pipeline_parallel_size
+        first = -(-93 // pp)
+        last = 93 - first * (pp - 1)
+        return first, last
+
+    @property
+    def rollout_num_gpus_per_engine(self) -> int:
+        return 8 if self.model_variant == "4layer" else self.rollout_tp_size
+
+    @property
+    def rollout_expert_parallel_size(self) -> int:
+        return 8 if self.model_variant == "4layer" else self.rollout_ep_size
+
+
+def _validate_paths(args: ScriptArgs) -> None:
+    for name, path in (("hf_checkpoint", args.hf_checkpoint), ("ref_load", args.ref_load)):
+        if not Path(path).exists():
+            raise FileNotFoundError(f"{name} does not exist: {path}")
+    if not Path(args.sglang_path, "sglang").is_dir():
+        raise FileNotFoundError(f"sglang package does not exist under sglang_path: {args.sglang_path}")
+
+
+@app.command()
+@U.dataclass_cli
+def prepare_data(args: ScriptArgs) -> None:
+    Path(args.data_dir).mkdir(parents=True, exist_ok=True)
+    dataset = "zhuzilin/gsm8k" if args.task == "gsm8k" else "zhuzilin/dapo-math-17k"
+    U.hf_download_dataset(dataset, data_dir=args.data_dir)
+
+
+def _execute_train(args: ScriptArgs) -> None:
+    _validate_paths(args)
+    if args.task == "gsm8k":
+        dataset = Path(args.data_dir) / "gsm8k" / "train.parquet"
+        input_key = "messages"
+    else:
+        dataset = Path(args.data_dir) / "dapo-math-17k" / "dapo-math-17k.jsonl"
+        input_key = "prompt"
+    if not dataset.is_file():
+        raise FileNotFoundError(f"Dataset does not exist: {dataset}; run prepare-data first")
+
+    ckpt_args = (
+        f"--hf-checkpoint {args.hf_checkpoint} "
+        f"--ref-load {args.ref_load} "
+        "--megatron-to-hf-mode raw "
+        "--model-name kimi_k3 "
+    )
+
+    lora_args = (
+        f"--lora-rank {args.lora_rank} "
+        f"--lora-alpha {args.lora_alpha} "
+        f"--lora-dropout {args.lora_dropout} "
+        f'--target-modules "{args.target_modules}" '
+        "--no-gradient-accumulation-fusion "
+    )
+    if args.experts_shared_outer_loras:
+        lora_args += "--experts-shared-outer-loras "
+    if args.lora_base_cpu_backup:
+        lora_args += "--lora-base-cpu-backup "
+
+    is_debug = args.mode == "debug_minimal"
+    reward_model = args.reward_model or (
+        "math" if args.task == "gsm8k" else ("deterministic_random" if is_debug else "deepscaler")
+    )
+    num_rollout = args.num_rollout if args.num_rollout is not None else (2 if is_debug else 3000)
+    rollout_batch_size = args.rollout_batch_size if args.rollout_batch_size is not None else (8 if is_debug else 32)
+    n_samples_per_prompt = (
+        args.n_samples_per_prompt if args.n_samples_per_prompt is not None else (2 if is_debug else 8)
+    )
+    rollout_max_response_len = (
+        args.rollout_max_response_len
+        if args.rollout_max_response_len is not None
+        else (256 if args.task == "gsm8k" else (32 if is_debug else 16384))
+    )
+    global_batch_size = args.global_batch_size if args.global_batch_size is not None else (16 if is_debug else 256)
+
+    rollout_args = (
+        f"--prompt-data {dataset} "
+        f"--input-key {input_key} "
+        "--label-key label "
+        "--apply-chat-template "
+        "--rollout-shuffle "
+        "--balance-data "
+        f"--rm-type {reward_model} "
+        f"--num-rollout {num_rollout} "
+        f"--rollout-batch-size {rollout_batch_size} "
+        f"--n-samples-per-prompt {n_samples_per_prompt} "
+        f"--rollout-max-response-len {rollout_max_response_len} "
+        "--rollout-temperature 1 "
+        f"--global-batch-size {global_batch_size} "
+        "--use-dynamic-global-batch-size "
+    )
+    if args.eval_interval is not None:
+        # Eval on a held-out benchmark that MATCHES the training task, scored by
+        # the task's own reward (--rm-type): gsm8k -> gsm8k test set; math/dapo
+        # -> AIME-2024. Pin the eval input key to the eval dataset's own column
+        # (gsm8k uses "messages", aime/dapo use "prompt") rather than inheriting
+        # the training --input-key.
+        if args.task == "gsm8k":
+            eval_name, eval_rel, eval_input_key = "gsm8k", "gsm8k/test.parquet", "messages"
+        else:
+            eval_name, eval_rel, eval_input_key = "aime", "aime-2024/aime-2024.jsonl", "prompt"
+        eval_dataset = Path(args.data_dir) / eval_rel
+        if not eval_dataset.is_file():
+            raise FileNotFoundError(f"Eval dataset does not exist: {eval_dataset}")
+        rollout_args += (
+            f"--eval-interval {args.eval_interval} "
+            f"--eval-prompt-data {eval_name} {eval_dataset} "
+            f"--eval-input-key {eval_input_key} "
+            "--n-samples-per-eval-prompt 1 "
+            "--eval-temperature 0 "
+            f"--eval-max-response-len {rollout_max_response_len} "
+        )
+    if args.save_debug_rollout_data is not None:
+        rollout_args += f"--save-debug-rollout-data {args.save_debug_rollout_data} "
+
+    pp_split_args = ""
+    if args.pipeline_parallel_size > 1:
+        first, last = args.pipeline_layer_split
+        if first != last:
+            pp_split_args = (
+                f"--decoder-first-pipeline-num-layers {first} " f"--decoder-last-pipeline-num-layers {last} "
+            )
+
+    perf_args = (
+        f"--tensor-model-parallel-size {args.tensor_parallel_size} "
+        "--sequence-parallel "
+        f"--pipeline-model-parallel-size {args.pipeline_parallel_size} "
+        f"{pp_split_args}"
+        f"--context-parallel-size {args.context_parallel_size} "
+        f"--expert-model-parallel-size {args.expert_parallel_size} "
+        "--expert-tensor-parallel-size 1 "
+        "--recompute-granularity full "
+        "--recompute-method uniform "
+        "--recompute-num-layers 1 "
+        "--use-dynamic-batch-size "
+        f"--max-tokens-per-gpu {args.max_tokens_per_gpu if args.max_tokens_per_gpu is not None else (512 if args.model_variant == '4layer' else 1024)} "
+        "--log-probs-chunk-size 512 "
+        f"--distributed-timeout-minutes {args.distributed_timeout_minutes} "
+    )
+
+    optimizer_args = (
+        "--optimizer sgd --sgd-momentum 0 --lr 1e-6 --lr-decay-style constant "
+        "--weight-decay 0 --use-distributed-optimizer "
+        if args.mode == "debug_minimal"
+        else (
+            f"--optimizer adam --lr {args.lr} --lr-decay-style constant "
+            "--weight-decay 0.1 --adam-beta1 0.9 --adam-beta2 0.98 "
+            "--optimizer-cpu-offload --optimizer-offload-fraction 0.8 "
+            "--overlap-cpu-optimizer-d2h-h2d "
+            "--use-precision-aware-optimizer --use-distributed-optimizer "
+        )
+    )
+
+    grpo_args = (
+        "--advantage-estimator grpo "
+        "--kl-loss-coef 0.0 "
+        "--kl-loss-type low_var_kl "
+        "--entropy-coef 0.0 "
+        "--eps-clip 0.2 "
+        "--eps-clip-high 0.28 "
+    )
+
+    update_weight_buffer_size = args.update_weight_buffer_size
+    if update_weight_buffer_size is None:
+        update_weight_buffer_size = 256 * 1024**2 if args.model_variant == "full" else 2 * 1024**3
+    # K3's radix extra-buffer strategy needs five KDA cache slots per
+    # running request.
+    sglang_request_capacity = args.rollout_max_concurrency if args.model_variant == "full" else 16
+    sglang_mamba_capacity = 5 * args.rollout_max_concurrency if args.model_variant == "full" else 16
+
+    graph_bs = " ".join(str(b) for b in (1, 2, 4, 8, 16, 32) if b <= max(1, args.rollout_max_concurrency))
+    sglang_args = (
+        f"--rollout-num-gpus-per-engine {args.rollout_num_gpus_per_engine} "
+        f"--sglang-tp-size {args.rollout_num_gpus_per_engine} "
+        f"--sglang-ep-size {args.rollout_expert_parallel_size} "
+        "--sglang-server-concurrency 16 "
+        f"--sglang-max-running-requests {sglang_request_capacity} "
+        f"--sglang-max-mamba-cache-size {sglang_mamba_capacity} "
+        "--sglang-lora-backend triton "
+        "--sglang-lora-strict-loading "
+        f"--sglang-max-lora-rank {args.lora_rank} "
+        "--use-miles-router "
+        # Tolerate colocate engines that are briefly slow to answer /health under
+        # long generations / weight-sync sleeps (default 3 falsely quarantined all
+        # engines at rollout 6 of the dapo 4096-response run -> "no healthy workers").
+        "--miles-router-health-check-failure-threshold 10 "
+    )
+    if args.model_variant == "full" and args.rollout_tp_size > 8:
+        # Above TP8 the per-rank Marlin MoE intermediate (3072 / moe_tp) gets
+        # tile-padded, which the virtual-experts LoRA kernel rejects; the
+        # fused_moe_lora alignment path handles the padded stride.
+        sglang_args += "--no-sglang-lora-use-virtual-experts "
+    if args.model_variant == "full":
+        sglang_args += (
+            "--sglang-lora-no-cpu-backup "
+            "--sglang-moe-runner-backend marlin "
+            "--sglang-decode-attention-backend trtllm_mla "
+            "--sglang-mamba-radix-cache-strategy extra_buffer "
+            f"--sglang-cuda-graph-bs-decode {graph_bs} "
+            "--sglang-cuda-graph-backend-prefill disabled "
+        )
+    else:
+        sglang_args += (
+            "--sglang-cuda-graph-bs 1 2 4 8 16 "
+            "--sglang-mem-fraction-static 0.7 "
+            "--sglang-moe-runner-backend triton "
+            "--sglang-disable-shared-experts-fusion "
+        )
+    if args.sglang_max_total_tokens is not None:
+        sglang_args += f"--sglang-max-total-tokens {args.sglang_max_total_tokens} "
+    if is_debug:
+        sglang_args += "--sglang-context-length 8192 "
+
+    misc_args = (
+        "--attention-dropout 0.0 "
+        "--hidden-dropout 0.0 "
+        "--accumulate-allreduce-grads-in-fp32 "
+        "--colocate "
+        "--offload-train "
+        "--disable-weights-backuper "
+        f"--update-weight-buffer-size {update_weight_buffer_size} "
+        f"--train-memory-margin-bytes {(2 if args.mode == 'debug_minimal' else 4) * 1024**3} "
+        f"--actor-num-nodes {args.num_nodes} "
+        f"--actor-num-gpus-per-node {args.num_gpus_per_node} "
+        f"--num-gpus-per-node {args.num_gpus_per_node} "
+    )
+    if args.model_variant == "4layer":
+        misc_args += "--offload-rollout-level kv_cache --no-check-for-nan-in-loss-and-grad "
+    else:
+        # Rollout weights stay resident on the GPU; only the KV cache is
+        # released for training, so there is no per-cycle base reload.
+        misc_args += "--offload-rollout-level kv_cache "
+    if args.check_weight_update_equal:
+        misc_args += "--check-weight-update-equal " "--check-weight-update-skip-list vision_tower. mm_projector. "
+
+    if args.enable_wandb:
+        wandb_args = (
+            "--use-wandb "
+            "--wandb-project miles-run_kimi_k3_lora "
+            f"--wandb-group {args.run_id} "
+            "--disable-wandb-random-suffix "
+        )
+    else:
+        wandb_args = U.get_default_wandb_args(__file__, run_id=args.run_id)
+
+    train_args = (
+        f"{ckpt_args} "
+        f"{lora_args} "
+        f"{rollout_args} "
+        f"{optimizer_args} "
+        f"{grpo_args} "
+        f"{wandb_args} "
+        f"{perf_args} "
+        f"{sglang_args} "
+        f"{misc_args} "
+        f"--save {args.save_dir}/{args.run_id} --save-interval 50 "
+        f"{args.extra_args} "
+    )
+    extra_env_vars = {
+        "NCCL_TIMEOUT": "3600",
+        "PYTHONPATH": os.pathsep.join((str(Path(__file__).resolve().parents[1]), args.sglang_path)),
+        "SGLANG_JIT_ROUTE_RADIX": "1",
+    }
+    # Ray's runtime_env replaces the actor environment, so the persistent
+    # Triton/Inductor JIT caches exported by the launch script are lost unless
+    # forwarded explicitly. Without them the trainer recompiles the KDA backward
+    # kernels every run (the ~30 min first-backward warmup).
+    # SGLANG_SKIP_SGL_KERNEL_VERSION_CHECK is forwarded the same way: sglang bases
+    # newer than the container's sgl-kernel (e.g. the DarkSharpness dark base)
+    # abort at import on the version check unless it is set.
+    for cache_var in ("TRITON_CACHE_DIR", "TORCHINDUCTOR_CACHE_DIR", "SGLANG_SKIP_SGL_KERNEL_VERSION_CHECK"):
+        cache_dir = os.environ.get(cache_var)
+        if cache_dir:
+            extra_env_vars[cache_var] = cache_dir
+
+    U.execute_train(
+        train_args=train_args,
+        config=args,
+        num_gpus_per_node=args.num_gpus_per_node,
+        megatron_model_type=args.megatron_model_type,
+        extra_env_vars=extra_env_vars,
+        megatron_path=args.megatron_path,
+    )
+
+
+@app.command()
+@U.dataclass_cli
+def train(args: ScriptArgs) -> None:
+    _execute_train(args)
+
+
+if __name__ == "__main__":
+    app()

--- a/tests/e2e/precision/test_hf_attention_cp_relayout.py
+++ b/tests/e2e/precision/test_hf_attention_cp_relayout.py
@@ -16,7 +16,7 @@ from tests.ci.ci_register import register_cuda_ci, register_rocm_ci
 register_cuda_ci(est_time=30, suite="stage-c-4-gpu-h200", labels=["precision"])
 register_rocm_ci(est_time=60, suite="stage-c-4-gpu-mi350", labels=["precision"])
 
-from miles_plugins.models.hf_attention import _packed_shard_to_zigzag, _zigzag_to_packed_shard
+from miles_plugins.models.cp_utils import packed_shard_to_zigzag, zigzag_to_packed_shard
 
 
 def setup_dist():
@@ -74,8 +74,8 @@ def test_relayout(rank: int, world_size: int):
 
     zigzag, expected_packed_shard, cu_seqlens = _build_rank_inputs(rank, world_size, device)
 
-    packed_shard = _zigzag_to_packed_shard(zigzag, cu_seqlens, cp_group, rank, world_size)
-    roundtrip = _packed_shard_to_zigzag(packed_shard, cu_seqlens, cp_group, rank, world_size)
+    packed_shard = zigzag_to_packed_shard(zigzag, cu_seqlens, cp_group, rank, world_size)
+    roundtrip = packed_shard_to_zigzag(packed_shard, cu_seqlens, cp_group, rank, world_size)
 
     packed_ok = torch.equal(packed_shard, expected_packed_shard)
     roundtrip_ok = torch.equal(roundtrip, zigzag)

--- a/tests/fast-gpu/test_quantizer_ci.py
+++ b/tests/fast-gpu/test_quantizer_ci.py
@@ -18,8 +18,10 @@ import torch
 from miles.backends.megatron_utils.megatron_to_hf.processors.quantizer_compressed_tensors import (
     quantize_params_compressed_tensors,
 )
+from miles.utils.mxfp4 import dequantize_mxfp4, quantize_mxfp4
 
 CONFIG = {
+    "format": "int-quantized",
     "config_groups": {"group_0": {"weights": {"group_size": 128, "symmetric": True}}},
     "ignore": [],  # overridden per test
 }
@@ -75,6 +77,53 @@ class TestIgnoreRulePrefixMatching:
         assert "model.layers.0.self_attn.k_proj.weight" in result_names
         # mlp param quantized
         assert "model.layers.0.mlp.gate_proj.weight_packed" in result_names
+
+
+def test_mxfp4_quantize_inverts_the_checkpoint_dequantizer():
+    """``quantize_mxfp4`` must be the exact inverse of the dequantizer used to
+    read the K3 checkpoint: any value that came out of an MXFP4 checkpoint has
+    to re-encode to the same bits, or every weight sync degrades the rollout
+    weights a little further. The magnitude thresholds, sign-bit position,
+    nibble order and exponent bias all have to agree.
+
+    Also pins the mxfp4 branch of ``quantize_params_compressed_tensors``, which
+    emits only weight_packed/weight_scale -- the int-quantized branch's extra
+    weight_shape/weight_zero_point tensors would be rejected by the receiver.
+    """
+    group_size = 32
+    packed = torch.randint(0, 256, (16, 64), dtype=torch.uint8, device="cuda")
+    scale = torch.randint(96, 144, (16, 4), dtype=torch.uint8, device="cuda")
+    weight = dequantize_mxfp4(packed, scale, group_size)
+
+    actual_packed, actual_scale = quantize_mxfp4(weight, group_size)
+    actual = dequantize_mxfp4(actual_packed, actual_scale, group_size)
+
+    torch.testing.assert_close(actual, weight, rtol=0, atol=0)
+
+    config = {
+        "format": "mxfp4-pack-quantized",
+        "config_groups": {
+            "group_0": {
+                "weights": {
+                    "group_size": group_size,
+                    "symmetric": True,
+                    "type": "float",
+                    "num_bits": 4,
+                    "scale_dtype": "torch.uint8",
+                }
+            }
+        },
+        "ignore": [],
+    }
+    results = quantize_params_compressed_tensors(
+        [("model.layers.0.experts.0.w1.weight", torch.randn(64, 64, device="cuda"))],
+        config,
+    )
+
+    assert [(name, tensor.dtype, tuple(tensor.shape)) for name, tensor in results] == [
+        ("model.layers.0.experts.0.w1.weight_packed", torch.uint8, (64, 32)),
+        ("model.layers.0.experts.0.w1.weight_scale", torch.uint8, (64, 2)),
+    ]
 
 
 if __name__ == "__main__":

--- a/tests/fast/backends/megatron_utils/test_kimi_k3_conversion.py
+++ b/tests/fast/backends/megatron_utils/test_kimi_k3_conversion.py
@@ -1,0 +1,59 @@
+from types import SimpleNamespace
+
+import torch
+
+from miles.backends.megatron_utils.megatron_to_hf.kimi_k3 import (
+    convert_kimi_k3_to_hf,
+    get_kimi_k3_atomic_update_groups,
+)
+from miles.backends.megatron_utils.update_weight.common import get_named_update_units
+
+
+def _convert(name, shape=(4, 2)):
+    param = torch.arange(torch.tensor(shape).prod()).reshape(shape)
+    return convert_kimi_k3_to_hf(SimpleNamespace(), name, param)
+
+
+def test_fused_fc1_splits_gate_before_up():
+    """Megatron fuses gate and up into one linear_fc1; HF wants them separate.
+    Which half is which is pure convention -- swapping them produces a model
+    that runs and generates plausible-looking garbage, on both the dense MLP
+    and the per-expert path.
+    """
+    dense = _convert("module.module.decoder.layers.0.mlp.linear_fc1.weight")
+    assert [name for name, _param in dense] == [
+        "language_model.model.layers.0.mlp.gate_proj.weight",
+        "language_model.model.layers.0.mlp.up_proj.weight",
+    ]
+    assert dense[0][1].tolist() == [[0, 1], [2, 3]]
+    assert dense[1][1].tolist() == [[4, 5], [6, 7]]
+
+    expert = _convert("module.module.decoder.layers.2.mlp.experts.linear_fc1.weight17")
+    assert [name for name, _param in expert] == [
+        "language_model.model.layers.2.block_sparse_moe.experts.17.w1.weight",
+        "language_model.model.layers.2.block_sparse_moe.experts.17.w3.weight",
+    ]
+    assert expert[0][1].tolist() == [[0, 1], [2, 3]]
+    assert expert[1][1].tolist() == [[4, 5], [6, 7]]
+
+
+def test_kimi_k3_atomic_group_keeps_fused_qkv_a_together():
+    """q_a_proj and kv_a_proj_with_mqa are one fused GEMM on the rollout side,
+    so they have to land in the same update unit. If the streaming chunker
+    splits them the engine sees a half-updated fusion between the two chunks.
+    """
+    prefix = "module.module.decoder.layers.3.self_attention"
+    names = [
+        f"{prefix}.q_a_layernorm.weight",
+        f"{prefix}.q_a_proj.weight",
+        f"{prefix}.kv_a_proj_with_mqa.weight",
+        f"{prefix}.q_b_proj.weight",
+    ]
+
+    units = get_named_update_units(names, get_kimi_k3_atomic_update_groups())
+
+    assert [unit.names for unit in units] == [
+        (f"{prefix}.q_a_layernorm.weight",),
+        (f"{prefix}.q_a_proj.weight", f"{prefix}.kv_a_proj_with_mqa.weight"),
+        (f"{prefix}.q_b_proj.weight",),
+    ]

--- a/tests/fast/backends/megatron_utils/test_lora_checkpoint_helpers.py
+++ b/tests/fast/backends/megatron_utils/test_lora_checkpoint_helpers.py
@@ -10,7 +10,11 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from miles.backends.megatron_utils.checkpoint import _is_megatron_checkpoint, save_checkpoint_with_lora
+from miles.backends.megatron_utils.checkpoint import (
+    _exclude_adapter_params_from_sharded_state_dict,
+    _is_megatron_checkpoint,
+    save_checkpoint_with_lora,
+)
 
 # ---------------------------------------------------------------------------
 # _is_megatron_checkpoint
@@ -92,3 +96,37 @@ class TestSaveCheckpointWithLoRA:
         save_checkpoint_with_lora(42, model, MagicMock(), MagicMock())
 
         mock_save_ckpt.assert_called_once()
+
+
+class TestExcludeAdapterParamsFromShardedStateDict:
+    def test_filters_adapters_and_restores_method(self):
+        """Loading a base checkpoint into a LoRA model must hide the adapter
+        params from Megatron's sharded state dict -- they are not in the
+        checkpoint. The wrapper patches a bound method per model chunk, so the
+        default-arg capture of ``original`` is load-bearing: a late-binding
+        closure would make every chunk call the last chunk's method. The
+        original must also come back on the error path, or a failed load leaves
+        the model permanently unable to save its adapters.
+        """
+        wrapped_model = MagicMock()
+        model = MagicMock()
+        original = MagicMock(
+            return_value={
+                "decoder.layers.0.mlp.linear_fc1.weight": object(),
+                "decoder.layers.0.mlp.linear_fc1.adapter.linear_in.weight": object(),
+                "decoder.layers.0.mlp.linear_fc1.adapter.linear_out.weight": object(),
+            }
+        )
+        model.sharded_state_dict = original
+
+        with patch(
+            "miles.backends.megatron_utils.checkpoint.unwrap_model", return_value=[model]
+        ), _exclude_adapter_params_from_sharded_state_dict([wrapped_model]):
+            assert list(model.sharded_state_dict(metadata={})) == ["decoder.layers.0.mlp.linear_fc1.weight"]
+
+        assert model.sharded_state_dict is original
+
+        with pytest.raises(RuntimeError), _exclude_adapter_params_from_sharded_state_dict([model]):
+            raise RuntimeError("load failed")
+
+        assert model.sharded_state_dict is original

--- a/tests/fast/backends/megatron_utils/test_lora_hf_weight_iterator.py
+++ b/tests/fast/backends/megatron_utils/test_lora_hf_weight_iterator.py
@@ -8,14 +8,22 @@ from tests.ci.ci_register import register_cpu_ci
 register_cpu_ci(est_time=60, suite="stage-a-cpu", labels=[])
 
 
+import json
 from argparse import Namespace
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from miles.backends.megatron_utils.update_weight.hf_weight_iterator_base import HfWeightIteratorBase
+from miles.backends.megatron_utils.update_weight.hf_weight_iterator_bridge import HfWeightIteratorBridge
+from miles.backends.megatron_utils.update_weight.hf_weight_iterator_direct import HfWeightIteratorDirect
 
 _BASE_MODULE = "miles.backends.megatron_utils.update_weight.hf_weight_iterator_base"
+
+
+class _TestIterator(HfWeightIteratorBase):
+    def get_hf_weight_chunks(self, megatron_local_weights, weight_type="base"):
+        return iter(())
 
 
 class TestHfWeightIteratorFactory:
@@ -29,7 +37,6 @@ class TestHfWeightIteratorFactory:
     @patch(f"{_BASE_MODULE}.HfWeightIteratorBase.__init__", return_value=None)
     def test_bridge_mode_creates_bridge_iterator(self, mock_init):
         """Factory should select HfWeightIteratorBridge for 'bridge' mode."""
-        from miles.backends.megatron_utils.update_weight.hf_weight_iterator_bridge import HfWeightIteratorBridge
 
         with patch.object(HfWeightIteratorBridge, "__init__", return_value=None):
             args = self._make_args("bridge")
@@ -56,3 +63,60 @@ class TestHfWeightIteratorFactory:
             HfWeightIteratorBase.create(
                 args=args, model=[MagicMock()], is_lora=False, model_name="qwen", quantization_config=None
             )
+
+
+def test_compressed_tensor_config_uses_checkpoint_packed_names(tmp_path):
+    index = {
+        "weight_map": {
+            "model.layers.0.self_attention_res_proj.weight": "model.safetensors",
+            "model.layers.0.experts.0.w1.weight_packed": "model.safetensors",
+            "model.layers.0.experts.0.w1.weight_scale": "model.safetensors",
+        }
+    }
+    (tmp_path / "model.safetensors.index.json").write_text(json.dumps(index))
+    iterator = _TestIterator(
+        Namespace(hf_checkpoint=str(tmp_path)),
+        model=[],
+        model_name="kimi_k3",
+        quantization_config={"quant_method": "compressed-tensors"},
+    )
+
+    assert iterator.quantization_config["_miles_quantized_basenames"] == {"model.layers.0.experts.0.w1"}
+
+
+def test_direct_kimi_lora_export_materializes_cpu_backup(monkeypatch):
+    parameter = object()
+    backup = MagicMock()
+    cuda_backup = object()
+    backup.cuda.return_value = cuda_backup
+    seen = {}
+
+    iterator = object.__new__(HfWeightIteratorDirect)
+    iterator.args = Namespace()
+    iterator.model = [object()]
+    iterator.model_name = "kimi_k3"
+
+    monkeypatch.setattr(
+        "miles.backends.megatron_utils.update_weight.hf_weight_iterator_direct.dist.get_rank",
+        lambda: 0,
+    )
+    monkeypatch.setattr(
+        "miles.backends.megatron_utils.update_weight.hf_weight_iterator_direct.named_params_and_buffers",
+        lambda _args, _model: iter((("module.module.decoder.layers.0.lora_adapter.weight", parameter),)),
+    )
+
+    def export(_model, *, materialize_parameter):
+        seen["value"] = materialize_parameter(parameter)
+        yield [("model.layers.0.lora_A.weight", seen["value"])]
+
+    monkeypatch.setattr("miles_plugins.models.kimi_k3.lora.export_kimi_k3_lora_hf_chunks", export)
+
+    chunks = list(
+        iterator.get_hf_weight_chunks(
+            {"module.module.decoder.layers.0.lora_adapter.weight": backup},
+            weight_type="lora",
+        )
+    )
+
+    assert chunks == [[("model.layers.0.lora_A.weight", cuda_backup)]]
+    backup.cuda.assert_called_once_with()

--- a/tests/fast/backends/megatron_utils/test_lora_utils.py
+++ b/tests/fast/backends/megatron_utils/test_lora_utils.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from miles.backends.megatron_utils.lora_utils import (
+    _configure_lora_buffer_cpu_backup,
     _get_lora_class_name,
     _is_adapter_param_name,
     build_lora_sync_config,
@@ -17,6 +18,7 @@ from miles.backends.megatron_utils.lora_utils import (
     convert_target_modules_to_megatron,
     is_lora_enabled,
     is_lora_weight_name,
+    lora_rollout_base_retained,
     parse_exclude_modules,
 )
 from miles.utils.lora import LORA_ADAPTER_NAME
@@ -216,6 +218,22 @@ class TestIsLoraEnabled:
         assert is_lora_enabled(args) is False
 
 
+@pytest.mark.parametrize(
+    "offload_rollout,offload_rollout_level,expected",
+    [
+        (False, ["kv_cache", "weight"], True),
+        (True, ["kv_cache"], True),
+        (True, ["kv_cache", "weight"], False),
+    ],
+)
+def test_lora_rollout_base_retained(offload_rollout, offload_rollout_level, expected):
+    args = Namespace(
+        offload_rollout=offload_rollout,
+        offload_rollout_level=offload_rollout_level,
+    )
+    assert lora_rollout_base_retained(args) is expected
+
+
 # ---------------------------------------------------------------------------
 # is_lora_weight_name / _is_adapter_param_name
 # ---------------------------------------------------------------------------
@@ -269,6 +287,24 @@ class TestIsAdapterParamName:
     )
     def test_negative(self, name):
         assert _is_adapter_param_name(name) is False
+
+
+@pytest.mark.parametrize("disable_param_backup", [False, True])
+def test_configure_lora_buffer_cpu_backup_preserves_param_setting(disable_param_backup):
+    """Adapter *param* buffers must keep their CPU backup so update_weights can
+    read them while the trainer sleeps; only *grad* buffers go to the
+    no-backup region. Disabling both (the original patch) leaves the weight
+    sync reading paused memory.
+    """
+    kwargs = {
+        "disable_param_buffers_cpu_backup": disable_param_backup,
+        "disable_grad_buffers_cpu_backup": False,
+    }
+
+    _configure_lora_buffer_cpu_backup(kwargs)
+
+    assert kwargs["disable_param_buffers_cpu_backup"] is disable_param_backup
+    assert kwargs["disable_grad_buffers_cpu_backup"] is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/fast/backends/megatron_utils/test_lora_weight_sync_validation.py
+++ b/tests/fast/backends/megatron_utils/test_lora_weight_sync_validation.py
@@ -24,7 +24,12 @@ from miles.backends.megatron_utils.update_weight.update_weight_from_distributed.
 from miles.backends.megatron_utils.update_weight.update_weight_from_distributed.mixin import (
     DistBucketedWeightUpdateMixin,
 )
-from miles.backends.megatron_utils.update_weight.update_weight_from_tensor import UpdateWeightFromTensor
+from miles.backends.megatron_utils.update_weight.update_weight_from_tensor import (
+    UpdateWeightFromTensor,
+    _send_to_colocated_engine,
+    _should_skip_lora_base_sync,
+    _wait_for_colocated_transfer,
+)
 from miles.utils.lora import LORA_ADAPTER_NAME
 
 _UW_MODULE = "miles.backends.megatron_utils.update_weight.update_weight_from_tensor"
@@ -72,6 +77,132 @@ def _make_args(**overrides):
     )
     defaults.update(overrides)
     return Namespace(**defaults)
+
+
+@pytest.mark.parametrize(
+    ("is_lora", "retains_rollout_base", "check_weight_update_equal", "lora_base_synced", "expected"),
+    [
+        (False, True, False, False, False),
+        (True, False, False, False, False),
+        (True, True, False, False, True),
+        (True, True, True, False, False),
+        (True, True, True, True, True),
+    ],
+)
+def test_should_skip_lora_base_sync(
+    is_lora, retains_rollout_base, check_weight_update_equal, lora_base_synced, expected
+):
+    """Skipping the base sync is only safe when the engine still holds valid
+    base weights. Skipping when it does not leaves the engine serving whatever
+    was in the weight buffers; not skipping when it does costs a full base
+    transfer every rollout.
+    """
+    assert (
+        _should_skip_lora_base_sync(
+            is_lora=is_lora,
+            retains_rollout_base=retains_rollout_base,
+            check_weight_update_equal=check_weight_update_equal,
+            lora_base_synced=lora_base_synced,
+        )
+        is expected
+    )
+
+
+def test_colocated_transfer_keeps_producers_alive_until_receiver_finishes():
+    """The producer ranks own the CUDA IPC storage the receiver is importing,
+    so they may not release it until the receiver has acked *and* every
+    producer in the engine group has reached the barrier. Reordering these
+    frees memory that is still mapped in the engine process.
+    """
+    events = []
+    group = MagicMock()
+
+    with (
+        patch(f"{_UW_MODULE}.ray.get", side_effect=lambda _refs: events.append("receiver_done") or []),
+        patch(
+            f"{_UW_MODULE}._check_weight_sync_results", side_effect=lambda *_args, **_kwargs: events.append("checked")
+        ),
+        patch(
+            f"{_UW_MODULE}.dist.barrier", side_effect=lambda **_kwargs: events.append("producer_barrier")
+        ) as barrier,
+    ):
+        _wait_for_colocated_transfer([], group, is_lora=True)
+
+    assert events == ["receiver_done", "checked", "producer_barrier"]
+    barrier.assert_called_once_with(group=group)
+
+
+@patch(f"{_UW_MODULE}.dist")
+@patch(f"{_UW_MODULE}.HfWeightIteratorBase")
+def test_ipc_group_ignores_partial_trainer_tail(mock_iter_base, mock_dist):
+    """64 trainer ranks with a 48-GPU engine leaves a 16-rank tail reserved as
+    placeholder GPU slots. Those ranks must get no gather group at all -- the
+    off-by-one that builds a short final group makes them join a collective
+    the engine ranks never enter, and the weight sync hangs.
+    """
+    mock_dist.get_world_size.return_value = 64
+    mock_dist.get_rank.return_value = 60
+    mock_iter_base.create.return_value = MagicMock()
+
+    updater = UpdateWeightFromTensor(
+        args=_make_args(rollout_num_gpus_per_engine=48),
+        model=[MagicMock()],
+        weights_getter=lambda: {},
+        model_name="kimi_k3",
+        quantization_config=None,
+    )
+
+    mock_dist.new_group.assert_called_once_with(ranks=list(range(48)), backend="gloo")
+    assert updater._ipc_gather_group is None
+    assert updater._ipc_gather_src is None
+
+
+@pytest.mark.parametrize(
+    ("rank", "expected_engine", "expected_src"),
+    [(0, 0, 0), (8, 1, 8), (16, None, None)],
+)
+@patch(f"{_UW_MODULE}.dist")
+@patch(f"{_UW_MODULE}.HfWeightIteratorBase")
+def test_two_tp8_engines_map_trainer_ranks_and_placeholders(
+    mock_iter_base, mock_dist, rank, expected_engine, expected_src
+):
+    """Companion to the partial-tail case: each trainer rank must resolve to
+    the engine that owns its GPU offset, and ranks past the last engine
+    (rank 16 of 64 with two TP8 engines) must resolve to no engine at all.
+    """
+    mock_dist.get_world_size.return_value = 64
+    mock_dist.get_rank.return_value = rank
+    mock_dist.new_group.side_effect = lambda **kwargs: tuple(kwargs["ranks"])
+    mock_iter_base.create.return_value = MagicMock()
+
+    updater = UpdateWeightFromTensor(
+        args=_make_args(
+            rollout_num_gpus_per_engine=8,
+            actor_num_nodes=16,
+            actor_num_gpus_per_node=4,
+        ),
+        model=[MagicMock()],
+        weights_getter=lambda: {},
+        model_name="kimi_k3",
+        quantization_config=None,
+        is_lora=True,
+    )
+    engines = [MagicMock(name="engine_0"), MagicMock(name="engine_1")]
+
+    updater.connect_rollout_engines(
+        engines,
+        MagicMock(),
+        engine_gpu_counts=[8, 8],
+        engine_gpu_offsets=[0, 8],
+    )
+
+    assert updater.use_distribute is False
+    if expected_engine is None:
+        assert updater._ipc_engine is None
+        assert updater._ipc_gather_group is None
+    else:
+        assert updater._ipc_engine is engines[expected_engine]
+        assert updater._ipc_gather_src == expected_src
 
 
 # ---------------------------------------------------------------------------
@@ -242,6 +373,156 @@ class TestUpdateWeightsZeroChunks:
         updater.update_weights()
 
 
+class TestUpdateWeightsSessionOrdering:
+    @patch(f"{_UW_MODULE}.torch.cuda.ipc_collect")
+    @patch(f"{_UW_MODULE}.torch.cuda.empty_cache")
+    @patch(f"{_UW_MODULE}.torch.cuda.synchronize")
+    @patch(f"{_UW_MODULE}._check_weight_sync_results")
+    @patch(f"{_UW_MODULE}.end_weight_update")
+    @patch(f"{_UW_MODULE}.begin_weight_update")
+    @patch(f"{_UW_MODULE}.get_gloo_group", return_value=MagicMock())
+    @patch(f"{_UW_MODULE}.ray")
+    @patch(f"{_UW_MODULE}.dist")
+    @patch(f"{_UW_MODULE}.HfWeightIteratorBase")
+    def test_closes_base_session_before_materializing_lora(
+        self,
+        mock_iter_base,
+        mock_dist,
+        mock_ray,
+        _mock_gloo,
+        mock_begin,
+        mock_end,
+        _mock_check,
+        mock_synchronize,
+        mock_empty_cache,
+        mock_ipc_collect,
+    ):
+        """SGLang restores the unpacked base weights for the duration of a base
+        update session. Bridge's LoRA export then runs its own TP/EP gathers,
+        and both resident at once exceeds colocated memory. The base session
+        must be closed (and the allocator drained) before the first LoRA chunk
+        is materialized -- the failure is an OOM at 64-GPU scale, invisible in
+        any single-rank test that does not assert the phase order.
+        """
+        mock_dist.get_world_size.return_value = 1
+        mock_dist.get_rank.return_value = 0
+        mock_dist.new_group.return_value = MagicMock()
+
+        events = []
+
+        def chunks(_weights, weight_type):
+            if weight_type == "base":
+                events.append("base")
+                yield SAMPLE_BASE_ONLY_WEIGHTS
+            else:
+                events.append("lora")
+                yield SAMPLE_LORA_WEIGHTS
+                yield SAMPLE_LORA_WEIGHTS
+
+        iterator = MagicMock()
+        iterator.get_hf_weight_chunks.side_effect = chunks
+        mock_iter_base.create.return_value = iterator
+        mock_end.side_effect = lambda _engines: events.append("end_base")
+        mock_synchronize.side_effect = lambda: events.append("synchronize")
+        mock_empty_cache.side_effect = lambda: events.append("empty_cache")
+        mock_ipc_collect.side_effect = lambda: events.append("ipc_collect")
+
+        args = _make_args(
+            offload_rollout=True,
+            offload_rollout_level=["kv_cache", "weight"],
+        )
+        updater = UpdateWeightFromTensor(
+            args=args,
+            model=[MagicMock()],
+            weights_getter=lambda: {},
+            model_name="qwen",
+            quantization_config=None,
+            is_lora=True,
+        )
+        updater.rollout_engines = [MagicMock()]
+        updater.use_distribute = False
+        updater._send_base_params = MagicMock(return_value=([], []))
+        updater._send_lora_params = MagicMock(return_value=([], []))
+
+        updater.update_weights()
+
+        assert events == [
+            "base",
+            "end_base",
+            "synchronize",
+            "empty_cache",
+            "lora",
+            "ipc_collect",
+            "ipc_collect",
+            "ipc_collect",
+            "empty_cache",
+        ]
+        mock_begin.assert_called_once_with(updater.rollout_engines)
+        mock_end.assert_called_once_with(updater.rollout_engines)
+
+    @patch(f"{_UW_MODULE}.torch.cuda.ipc_collect")
+    @patch(f"{_UW_MODULE}.torch.cuda.empty_cache")
+    @patch(f"{_UW_MODULE}.torch.cuda.synchronize")
+    @patch(f"{_UW_MODULE}._check_weight_sync_results")
+    @patch(f"{_UW_MODULE}.end_weight_update")
+    @patch(f"{_UW_MODULE}.begin_weight_update")
+    @patch(f"{_UW_MODULE}.get_gloo_group", return_value=MagicMock())
+    @patch(f"{_UW_MODULE}.ray")
+    @patch(f"{_UW_MODULE}.dist")
+    @patch(f"{_UW_MODULE}.HfWeightIteratorBase")
+    def test_reaps_each_lora_chunk_after_engine_barrier(
+        self,
+        mock_iter_base,
+        mock_dist,
+        mock_ray,
+        _mock_gloo,
+        _mock_begin,
+        _mock_end,
+        _mock_check,
+        _mock_synchronize,
+        _mock_empty_cache,
+        mock_ipc_collect,
+    ):
+        """Each flattened LoRA bucket is collected only after the receiver ack
+        plus the per-engine producer barrier, never before the next send."""
+        mock_dist.get_world_size.return_value = 1
+        mock_dist.get_rank.return_value = 0
+        mock_dist.new_group.return_value = MagicMock(name="ipc_group")
+
+        def chunks(_weights, weight_type):
+            if weight_type == "base":
+                return iter([])
+            return iter([SAMPLE_LORA_WEIGHTS, SAMPLE_LORA_WEIGHTS, SAMPLE_LORA_WEIGHTS])
+
+        iterator = MagicMock()
+        iterator.get_hf_weight_chunks.side_effect = chunks
+        mock_iter_base.create.return_value = iterator
+
+        updater = UpdateWeightFromTensor(
+            args=_make_args(),
+            model=[MagicMock()],
+            weights_getter=lambda: {},
+            model_name="kimi_k3",
+            quantization_config=None,
+            is_lora=True,
+        )
+        updater.rollout_engines = [MagicMock()]
+        updater.use_distribute = False
+
+        events = []
+        ipc_group = updater._ipc_gather_group
+        updater._send_lora_params = MagicMock(side_effect=lambda *_a, **_k: (events.append("send"), ([], []))[1])
+        mock_dist.barrier.side_effect = lambda group=None: events.append(
+            "engine_barrier" if group is ipc_group else "global_barrier"
+        )
+        mock_ipc_collect.side_effect = lambda: events.append("ipc_collect")
+
+        updater.update_weights(resume_generation=False)
+
+        lora_events = [e for e in events if e != "global_barrier"]
+        assert lora_events == ["send", "engine_barrier", "ipc_collect"] * 3 + ["ipc_collect"]
+
+
 # ---------------------------------------------------------------------------
 # FlattenedTensorBucket round-trip correctness
 # ---------------------------------------------------------------------------
@@ -370,8 +651,123 @@ class _FakeRemote:
 
 class _FakeEngine:
     def __init__(self, load_result=None):
+        self.load_lora_adapter_from_tensors = _FakeRemote(result=load_result)
         self.load_lora_adapter_from_distributed = _FakeRemote(result=load_result)
         self.unload_lora_adapter = _FakeRemote()
+        self.update_weight_version = _FakeRemote(result="version-ref")
+
+
+def test_colocated_lora_sync_sends_one_local_ipc_payload_per_engine_rank():
+    """Cross-repo wire contract with SGLang's
+    ``LoadLoRAAdapterFromTensorsReqInput``: one CUDA IPC payload per engine
+    rank under ``serialized_tensors`` (the old ``serialized_named_tensors``
+    shape sent rank 0's handle to every rank), and the weight version is
+    published only after the adapter is complete.
+    """
+    engine = _FakeEngine(load_result="load-ref")
+
+    with (
+        patch(f"{_UW_MODULE}.dist") as dist_mock,
+        patch(f"{_UW_MODULE}.MultiprocessingSerializer.serialize", return_value="rank0-payload"),
+    ):
+        dist_mock.get_rank.return_value = 0
+        dist_mock.get_world_size.return_value = 2
+
+        def gather_object(_local, object_gather_list, **_kwargs):
+            object_gather_list[:] = [["rank0-payload"], ["rank1-payload"]]
+
+        dist_mock.gather_object.side_effect = gather_object
+        refs, _ = _send_to_colocated_engine(
+            SAMPLE_LORA_WEIGHTS,
+            ipc_engine=engine,
+            ipc_gather_src=0,
+            ipc_gather_group=MagicMock(),
+            weight_version=7,
+            lora_config={"r": 32},
+            lora_name=LORA_ADAPTER_NAME,
+        )
+
+    assert refs == ["load-ref", "version-ref"]
+    kwargs = engine.load_lora_adapter_from_tensors.calls[0]
+    assert kwargs["serialized_tensors"] == ["rank0-payload", "rank1-payload"]
+    assert kwargs["is_first_chunk"] is True
+    assert kwargs["is_last_chunk"] is True
+    assert "serialized_named_tensors" not in kwargs
+    assert kwargs["load_format"] == "flattened_bucket"
+    assert engine.update_weight_version.calls == [{"weight_version": "7"}]
+    dist_mock.gather_object.assert_called_once()
+
+
+def test_colocated_lora_sync_does_not_finalize_an_intermediate_chunk():
+    """K3's adapter is sent in many chunks. Unload fires only on the first and
+    the version bump only on the last: unloading mid-stream drops the chunks
+    already delivered, and bumping the version early advertises a partial
+    adapter as the current policy.
+    """
+    engine = _FakeEngine(load_result="load-ref")
+
+    with (
+        patch(f"{_UW_MODULE}.dist") as dist_mock,
+        patch(f"{_UW_MODULE}.MultiprocessingSerializer.serialize", return_value="rank0-payload"),
+    ):
+        dist_mock.get_rank.return_value = 0
+        dist_mock.get_world_size.return_value = 1
+
+        def gather_object(_local, object_gather_list, **_kwargs):
+            object_gather_list[:] = [["rank0-payload"]]
+
+        dist_mock.gather_object.side_effect = gather_object
+        refs, _ = _send_to_colocated_engine(
+            SAMPLE_LORA_WEIGHTS,
+            ipc_engine=engine,
+            ipc_gather_src=0,
+            ipc_gather_group=MagicMock(),
+            weight_version=7,
+            lora_config={"r": 32},
+            lora_name=LORA_ADAPTER_NAME,
+            lora_loaded=True,
+            lora_is_first_chunk=False,
+            lora_is_last_chunk=False,
+        )
+
+    assert refs == ["load-ref"]
+    assert engine.unload_lora_adapter.calls == []
+    assert engine.update_weight_version.calls == []
+    kwargs = engine.load_lora_adapter_from_tensors.calls[0]
+    assert kwargs["is_first_chunk"] is False
+    assert kwargs["is_last_chunk"] is False
+
+
+def test_colocated_lora_sync_non_source_contributes_local_ipc_payload():
+    """``gather_object`` is collective over the engine group, so a non-source
+    rank must still build its bucket and enter the gather even though it sends
+    nothing to the engine itself. An early return on non-source ranks hangs the
+    sync instead of failing.
+    """
+    engine = _FakeEngine(load_result="load-ref")
+
+    with (
+        patch(f"{_UW_MODULE}.dist") as dist_mock,
+        patch(f"{_UW_MODULE}.FlattenedTensorBucket") as bucket_mock,
+        patch(f"{_UW_MODULE}.MultiprocessingSerializer.serialize", return_value="rank1-payload") as serialize_mock,
+    ):
+        dist_mock.get_rank.return_value = 1
+        refs, long_lived_tensors = _send_to_colocated_engine(
+            SAMPLE_LORA_WEIGHTS,
+            ipc_engine=engine,
+            ipc_gather_src=0,
+            ipc_gather_group=MagicMock(),
+            weight_version=7,
+            lora_config={"r": 32},
+            lora_name=LORA_ADAPTER_NAME,
+        )
+
+    assert refs == []
+    assert len(long_lived_tensors) == 1
+    assert set(long_lived_tensors[0]) == {"flattened_tensor", "metadata"}
+    bucket_mock.assert_called_once_with(named_tensors=SAMPLE_LORA_WEIGHTS)
+    serialize_mock.assert_called_once()
+    dist_mock.gather_object.assert_called_once()
 
 
 class TestDistLoraUpdateOrchestration:

--- a/tests/fast/backends/megatron_utils/test_quantizer_mxfp4.py
+++ b/tests/fast/backends/megatron_utils/test_quantizer_mxfp4.py
@@ -1,0 +1,21 @@
+import torch
+
+from miles.utils.mxfp4 import dequantize_mxfp4
+
+
+def test_dequantize_mxfp4_decodes_nibbles_and_e8m0_scales() -> None:
+    """Hand-computed golden values for the MXFP4 wire format: low nibble first,
+    bit 3 is the sign, magnitude indexes the e2m1 table (0, .5, 1, 1.5, 2, 3, 4,
+    6), and the uint8 scale is a base-2 exponent biased by 127. The round-trip
+    test in test_quantizer_ci.py cannot catch a consistently-wrong convention
+    here -- only fixed expected values can.
+    """
+    packed = torch.tensor([[0x10, 0x32, 0x54, 0x76]], dtype=torch.uint8)
+    scales = torch.tensor([127, 128], dtype=torch.uint8)
+    expected = torch.tensor(
+        [[0.0, 0.5, 1.0, 1.5, 4.0, 6.0, 8.0, 12.0]],
+        dtype=torch.bfloat16,
+    )
+
+    actual = dequantize_mxfp4(packed, scales, group_size=4)
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)

--- a/tests/fast/models/test_kimi_k3_kda.py
+++ b/tests/fast/models/test_kimi_k3_kda.py
@@ -1,0 +1,121 @@
+"""Boundary and aliasing contracts of the Kimi K3 KDA delta-rule core.
+
+Both cases guard failure modes that are silent in training: the run keeps
+learning, only worse, so nothing short of a numerical check catches them.
+"""
+
+import pytest
+import torch
+
+from miles_plugins.models.kimi_k3.ops import kda
+
+
+# KDA kernel construction, validated on H200: q/k/v/g scaled bf16, beta uniform on
+# [0, 1] because it is the delta rule's step size and falls outside the operator's
+# domain when negative or above 1. (The "KDA goes non-finite with random weights"
+# result is model-level -- random *projections* produce out-of-distribution q/k/v/g
+# that compound across layers -- and does not apply to the kernel in isolation.)
+_KDA_HEADS = 4
+_KDA_HEAD_DIM = 128
+_KDA_LOWER_BOUND = -5.0
+
+
+def _kda_inputs(seq_len: int, seed: int) -> dict[str, torch.Tensor]:
+    torch.manual_seed(seed)
+
+    def activation() -> torch.Tensor:
+        return torch.randn(1, seq_len, _KDA_HEADS, _KDA_HEAD_DIM, device="cuda", dtype=torch.bfloat16) * 0.5
+
+    return {
+        "q": activation(),
+        "k": activation(),
+        "v": activation(),
+        "g": activation(),
+        "beta": torch.rand(1, seq_len, _KDA_HEADS, device="cuda", dtype=torch.float32),
+        "A_log": torch.randn(_KDA_HEADS, device="cuda", dtype=torch.float32),
+        "dt_bias": torch.randn(_KDA_HEADS * _KDA_HEAD_DIM, device="cuda", dtype=torch.float32),
+    }
+
+
+def _run_kda(inputs: dict[str, torch.Tensor], cu_seqlens: torch.Tensor | None) -> torch.Tensor:
+    return kda(
+        inputs["q"],
+        inputs["k"],
+        inputs["v"],
+        inputs["g"],
+        inputs["beta"],
+        inputs["A_log"],
+        inputs["dt_bias"],
+        _KDA_LOWER_BOUND,
+        cu_seqlens=cu_seqlens,
+    )
+
+
+def _require_kda() -> None:
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA device required to run the KDA kernels")
+    pytest.importorskip("fla.ops.kda")
+
+
+def _relative_l2(actual: torch.Tensor, expected: torch.Tensor) -> float:
+    return ((actual - expected).float().norm() / expected.float().norm()).item()
+
+
+def test_kda_applies_packed_sequence_boundaries() -> None:
+    """A packed batch must reproduce, per sequence, what that sequence produces alone.
+
+    ``kda`` routes boundaries through one of two mutually exclusive channels
+    (``cu_seqlens`` off CP, ``cp_context`` under CP). A caller that selects the CP
+    channel and drops ``cu_seqlens`` -- the shape the CP-only helper had before the
+    two kernel paths were merged -- leaves the recurrence with no boundaries at all,
+    so the whole packed microbatch becomes one sequence and every sample inherits its
+    predecessors' state. Nothing raises.
+
+    Thresholds are relative because the assertion must not be satisfiable by the
+    output being small: these activations sit around 1e-3, so any absolute tolerance
+    worth the name swallows the entire signal. Measured on H200: the per-sequence
+    equality is exact, and dropping the boundaries moves the second sequence by 0.40
+    while leaving the first at exactly 0 -- the first sequence has no predecessor to
+    inherit from, which is what makes this leakage rather than noise.
+    """
+    _require_kda()
+    first_len, second_len = 96, 160
+    total = first_len + second_len
+    packed = _kda_inputs(total, seed=0)
+    packed_output = _run_kda(packed, torch.tensor([0, first_len, total], dtype=torch.int32, device="cuda"))
+
+    for offset, length in ((0, first_len), (first_len, second_len)):
+        alone = {
+            name: tensor[:, offset : offset + length] if tensor.dim() > 1 else tensor
+            for name, tensor in packed.items()
+        }
+        alone_output = _run_kda(alone, torch.tensor([0, length], dtype=torch.int32, device="cuda"))
+        torch.testing.assert_close(packed_output[:, offset : offset + length], alone_output, rtol=0, atol=0)
+
+    unbounded_output = _run_kda(packed, None)
+    assert _relative_l2(unbounded_output[:, first_len:], packed_output[:, first_len:]) > 1e-1, (
+        "dropping cu_seqlens barely moved the second sequence, so boundaries are not reaching the kernel "
+        "and the equality above passed vacuously"
+    )
+    torch.testing.assert_close(unbounded_output[:, :first_len], packed_output[:, :first_len], rtol=0, atol=0)
+
+
+def test_kda_does_not_mutate_its_inputs() -> None:
+    """The forward must leave q/k/v/g/beta untouched.
+
+    SGLang's vendored ``chunk_kda`` overwrote its ``v`` buffer with a WY-representation
+    intermediate. Any caller that reads an input back afterwards -- a manual
+    ``save_for_backward`` re-derivation being the case that bit us -- then
+    differentiates at a point the forward never evaluated, which put the q/k/g/beta
+    gradients ~110x low and near-orthogonal. Exact comparison: aliasing is a
+    mutation, not a rounding.
+    """
+    _require_kda()
+    seq_len = 256
+    inputs = _kda_inputs(seq_len, seed=1)
+    before = {name: tensor.clone() for name, tensor in inputs.items()}
+
+    _run_kda(inputs, torch.tensor([0, seq_len], dtype=torch.int32, device="cuda"))
+
+    for name, tensor in inputs.items():
+        torch.testing.assert_close(tensor, before[name], rtol=0, atol=0, msg=f"KDA forward mutated input {name}")

--- a/tests/fast/models/test_kimi_k3_lora.py
+++ b/tests/fast/models/test_kimi_k3_lora.py
@@ -1,0 +1,221 @@
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.nn as nn
+from torch.utils.checkpoint import checkpoint
+
+from miles_plugins.models.kimi_k3.lora import (
+    KimiK3LoRAAdapter,
+    _enable_full_recompute_input_grads,
+    _grouped_linear,
+    export_kimi_k3_lora_hf_chunks,
+)
+
+
+def _parameter(*shape):
+    return nn.Parameter(torch.arange(torch.tensor(shape).prod()).reshape(shape).float())
+
+
+def _mla_attention_adapter():
+    adapter = KimiK3LoRAAdapter("mla_attention", "language_model.model.layers.3.self_attn.")
+    adapter.register_parameter("q_a_lora_A", _parameter(2, 8))
+    adapter.register_parameter("q_a_lora_B", _parameter(4, 2))
+    adapter.register_parameter("kv_a_lora_A", _parameter(2, 8))
+    adapter.register_parameter("kv_a_lora_B", _parameter(6, 2))
+    adapter.register_parameter("o_lora_A", _parameter(2, 3))
+    adapter.register_parameter("o_lora_B", _parameter(8, 2))
+    return adapter
+
+
+def _expert_adapter():
+    adapter = KimiK3LoRAAdapter(
+        "experts",
+        "language_model.model.layers.4.block_sparse_moe.experts.",
+    )
+    adapter.register_parameter("w1_lora_A", _parameter(2, 8))
+    adapter.register_parameter("w3_lora_A", _parameter(2, 8))
+    adapter.register_parameter("w1_lora_B", _parameter(3, 5, 2))
+    adapter.register_parameter("w3_lora_B", _parameter(3, 5, 2))
+    adapter.register_parameter("w2_lora_A", _parameter(3, 2, 5))
+    adapter.register_parameter("w2_lora_B", _parameter(8, 2))
+    return adapter
+
+
+def _shared_expert_adapter():
+    adapter = KimiK3LoRAAdapter(
+        "shared_experts",
+        "language_model.model.layers.4.block_sparse_moe.shared_experts.",
+    )
+    adapter.register_parameter("fc1_lora_A", _parameter(2, 8))
+    adapter.register_parameter("fc1_lora_B", _parameter(10, 2))
+    adapter.register_parameter("fc2_lora_A", _parameter(2, 5))
+    adapter.register_parameter("fc2_lora_B", _parameter(8, 2))
+    return adapter
+
+
+def _dense_adapter():
+    adapter = KimiK3LoRAAdapter(
+        "dense_mlp",
+        "language_model.model.layers.3.mlp.",
+    )
+    adapter.register_parameter("fc1_lora_A", _parameter(2, 8))
+    adapter.register_parameter("fc1_lora_B", _parameter(10, 2))
+    adapter.register_parameter("fc2_lora_A", _parameter(2, 5))
+    adapter.register_parameter("fc2_lora_B", _parameter(8, 2))
+    return adapter
+
+
+def _kda_attention_adapter():
+    adapter = KimiK3LoRAAdapter(
+        "kda_attention",
+        "language_model.model.layers.4.self_attn.",
+    )
+    adapter.register_parameter("o_lora_A", _parameter(2, 3))
+    adapter.register_parameter("o_lora_B", _parameter(8, 2))
+    return adapter
+
+
+def _model_with_adapters(*, include_shared_experts=True):
+    mla_attention = _mla_attention_adapter()
+    dense = _dense_adapter()
+    kda_attention = _kda_attention_adapter()
+    experts = _expert_adapter()
+    shared_experts = _shared_expert_adapter()
+    adapters = [mla_attention, dense, kda_attention, experts]
+    if include_shared_experts:
+        adapters.append(shared_experts)
+
+    model = nn.Module()
+    model.adapters = nn.ModuleList(adapters)
+    model.decoder = SimpleNamespace(
+        layers=[
+            SimpleNamespace(
+                layer_number=4,
+                self_attention=SimpleNamespace(is_kda=False),
+                mlp=SimpleNamespace(),
+            ),
+            SimpleNamespace(
+                layer_number=5,
+                self_attention=SimpleNamespace(is_kda=True),
+                mlp=SimpleNamespace(
+                    experts=SimpleNamespace(),
+                    shared_experts=SimpleNamespace(),
+                ),
+            ),
+        ]
+    )
+    return model
+
+
+def test_native_export_is_chunked_by_adapter(monkeypatch):
+    """The exported names and shapes are the serving contract with SGLang's
+    ``experts_shared_outer_loras=True``: the shared expert factors carry a
+    leading expert_dim of 1 (w1.lora_A, w2.lora_B) while the per-expert ones
+    carry the real local expert count. Getting the expert dim wrong is a shape
+    mismatch inside the LoRA memory pool, and a wrong HF name is silently
+    dropped by strict loading.
+
+    Also covers the ``materialize_parameter`` hook, which is how the export
+    reads CPU backups while TorchMemorySaver has the parameters paused.
+    """
+    from megatron.core import parallel_state
+
+    monkeypatch.setattr(parallel_state, "get_tensor_model_parallel_world_size", lambda: 1)
+    monkeypatch.setattr(parallel_state, "get_expert_model_parallel_world_size", lambda: 1)
+
+    model = _model_with_adapters()
+    chunks = list(export_kimi_k3_lora_hf_chunks([model]))
+
+    assert len(chunks) == 5
+    attention = dict(chunks[0])
+    assert attention["language_model.model.layers.3.self_attn.q_a_proj.lora_A.weight"].shape == (2, 8)
+    assert attention["language_model.model.layers.3.self_attn.kv_a_proj_with_mqa.lora_B.weight"].shape == (
+        6,
+        2,
+    )
+    assert attention["language_model.model.layers.3.self_attn.o_proj.lora_A.weight"].shape == (2, 3)
+
+    experts = dict(chunks[3])
+    prefix = "language_model.model.layers.4.block_sparse_moe.experts."
+    assert experts[f"{prefix}w1.lora_A.weight"].shape == (1, 2, 8)
+    assert experts[f"{prefix}w1.lora_B.weight"].shape == (3, 5, 2)
+    assert experts[f"{prefix}w2.lora_A.weight"].shape == (3, 2, 5)
+    assert experts[f"{prefix}w2.lora_B.weight"].shape == (1, 8, 2)
+
+    shared_experts = dict(chunks[4])
+    prefix = "language_model.model.layers.4.block_sparse_moe.shared_experts."
+    assert shared_experts[f"{prefix}gate_proj.lora_A.weight"].shape == (2, 8)
+    assert shared_experts[f"{prefix}gate_proj.lora_B.weight"].shape == (5, 2)
+    assert shared_experts[f"{prefix}up_proj.lora_A.weight"].shape == (2, 8)
+    assert shared_experts[f"{prefix}up_proj.lora_B.weight"].shape == (5, 2)
+    assert shared_experts[f"{prefix}down_proj.lora_A.weight"].shape == (2, 5)
+    assert shared_experts[f"{prefix}down_proj.lora_B.weight"].shape == (8, 2)
+
+    backups = {id(parameter): torch.full_like(parameter, 17) for parameter in model.parameters()}
+    for chunk in export_kimi_k3_lora_hf_chunks(
+        [model], materialize_parameter=lambda parameter: backups[id(parameter)]
+    ):
+        for _name, tensor in chunk:
+            torch.testing.assert_close(tensor, torch.full_like(tensor, 17))
+
+
+def test_native_export_rejects_missing_shared_expert_adapter(monkeypatch):
+    """Completeness contract: the export enumerates the model's layers and
+    requires an adapter for each expected (kind, hf_prefix). A layer whose
+    adapter was never attached -- a new MLP type, or a PP stage built from a
+    different spec -- must fail loudly instead of exporting a partial adapter
+    that SGLang would load without complaint.
+    """
+    from megatron.core import parallel_state
+
+    monkeypatch.setattr(parallel_state, "get_tensor_model_parallel_world_size", lambda: 1)
+    monkeypatch.setattr(parallel_state, "get_expert_model_parallel_world_size", lambda: 1)
+
+    model = _model_with_adapters(include_shared_experts=False)
+
+    with pytest.raises(RuntimeError, match="adapter layout is incomplete"):
+        list(export_kimi_k3_lora_hf_chunks([model]))
+
+
+def test_grouped_linear_uses_expert_token_boundaries():
+    """The CPU fallback splits by ``tokens_per_expert`` and the CUDA path turns
+    the same list into cumulative offsets for ``grouped_mm``. Wrong boundaries
+    apply expert i's adapter to expert j's tokens -- no error, just a wrong
+    delta on every MoE layer.
+    """
+    inputs = torch.tensor([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
+    weights = torch.tensor([[[1.0, 0.0]], [[0.0, 1.0]]])
+
+    output = _grouped_linear(inputs, weights, [1, 2])
+
+    torch.testing.assert_close(output, torch.tensor([[1.0], [4.0], [6.0]]))
+
+
+def test_full_recompute_keeps_native_lora_in_autograd_graph():
+    """With ``--recompute-granularity full`` and a frozen base, nothing entering
+    the checkpointed segment requires grad, so the recomputed segment is built
+    without a graph and every native LoRA gradient comes out zero -- training
+    runs, loss moves, adapters never change. The embedding hook forces the
+    segment input to require grad without unfreezing the embedding itself, and
+    must not do so under eval.
+    """
+    model = nn.Module()
+    model.embedding = nn.Embedding.from_pretrained(torch.ones(8, 4), freeze=True)
+    model.adapter = nn.Parameter(torch.ones(4, 4))
+    model.config = SimpleNamespace(recompute_granularity="full")
+    model.pre_process = True
+    model.embedding.requires_grad_(False)
+    _enable_full_recompute_input_grads(model)
+
+    model.train()
+    hidden_states = model.embedding(torch.tensor([[1, 2]]))
+    output = checkpoint(lambda inputs: inputs @ model.adapter, hidden_states, use_reentrant=True)
+    output.sum().backward()
+
+    assert hidden_states.requires_grad
+    assert model.embedding.weight.grad is None
+    torch.testing.assert_close(model.adapter.grad, torch.full_like(model.adapter, 2.0))
+
+    model.eval()
+    assert not model.embedding(torch.tensor([[1, 2]])).requires_grad

--- a/tests/fast/models/test_kimi_k3_mbridge.py
+++ b/tests/fast/models/test_kimi_k3_mbridge.py
@@ -1,0 +1,32 @@
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from miles_plugins.mbridge.kimi_k3 import KimiK3Bridge
+
+
+@pytest.mark.parametrize("name", ("q_conv1d.weight", "k_conv1d.weight", "v_conv1d.weight", "A_log", "dt_bias"))
+def test_kda_state_stays_fp32_against_the_bridge_dtype(name):
+    """The KDA short-conv weights and the recurrence's A_log / dt_bias are fp32
+    parameters inside a bf16 model. ``_weight_to_mcore_format`` overrides the
+    bridge dtype for exactly these; losing the override silently downcasts the
+    delta-rule state during HF -> torch_dist conversion, which changes rollout
+    numerics without any load-time error. Contrast the default path, which must
+    still follow the bridge dtype.
+    """
+    bridge = object.__new__(KimiK3Bridge)
+    bridge.dtype = torch.bfloat16
+    bridge.config = SimpleNamespace(kimi_linear_num_heads=1)
+    weight = torch.tensor([0.1234567], dtype=torch.float32)
+
+    converted = bridge._weight_to_mcore_format(f"decoder.layers.0.self_attention.{name}", [weight])
+
+    assert converted.dtype == torch.float32
+    torch.testing.assert_close(converted, weight, rtol=0, atol=0)
+
+    bridge.make_vocab_size_divisible_by = None
+    assert (
+        bridge._weight_to_mcore_format("decoder.layers.0.self_attention.q_proj.weight", [weight]).dtype
+        == torch.bfloat16
+    )

--- a/tests/fast/models/test_kimi_k3_pipeline.py
+++ b/tests/fast/models/test_kimi_k3_pipeline.py
@@ -1,0 +1,55 @@
+import pytest
+import torch
+
+from miles_plugins.models.kimi_k3.pipeline import bank_num_rows, pack_stage_boundary, unpack_stage_boundary
+
+
+def test_pack_unpack_is_exact_in_both_directions() -> None:
+    """Megatron's p2p carries one hidden-states tensor, so the attention-residual
+    bank rides across the stage boundary flattened into the hidden dim. Values
+    have to survive the round trip and gradients have to route back to the right
+    side of the split -- a transposed unflatten would mix bank rows into
+    prefix_sum with no shape error. The width assertion is the only thing
+    standing between a sender/receiver row-count disagreement and silently
+    reinterpreted activations.
+    """
+    torch.manual_seed(0)
+    prefix_sum = torch.randn(5, 2, 16, dtype=torch.bfloat16)
+    block_residual = torch.randn(5, 2, 3, 16, dtype=torch.bfloat16)
+
+    packed = pack_stage_boundary(prefix_sum, block_residual)
+    assert packed.shape == (5, 2, 4 * 16)
+
+    prefix_out, bank_out = unpack_stage_boundary(packed, 16, 3)
+    torch.testing.assert_close(prefix_out, prefix_sum, rtol=0, atol=0)
+    torch.testing.assert_close(bank_out, block_residual, rtol=0, atol=0)
+
+    grad_prefix_sum = torch.randn(4, 1, 8, requires_grad=True)
+    grad_block_residual = torch.randn(4, 1, 2, 8, requires_grad=True)
+    prefix_out, bank_out = unpack_stage_boundary(pack_stage_boundary(grad_prefix_sum, grad_block_residual), 8, 2)
+    grad_prefix = torch.randn_like(prefix_out)
+    grad_bank = torch.randn_like(bank_out)
+    torch.autograd.backward([prefix_out, bank_out], [grad_prefix, grad_bank])
+
+    torch.testing.assert_close(grad_prefix_sum.grad, grad_prefix, rtol=0, atol=0)
+    torch.testing.assert_close(grad_block_residual.grad, grad_bank, rtol=0, atol=0)
+
+    with pytest.raises(AssertionError, match="stage-boundary payload width"):
+        unpack_stage_boundary(torch.zeros(2, 1, 3 * 16), 16, 3)
+
+
+def test_bank_num_rows_matches_write_schedule() -> None:
+    """The receiver sizes its unpack from ``bank_num_rows`` while the sender's
+    row count comes from the write schedule (``layer_idx % block_size == 0``).
+    The ceil-div has to agree with that schedule at every one of the 93 layers,
+    from both sides of a stage boundary -- one row off and the payload is
+    reinterpreted, not rejected.
+    """
+    block_size = 12
+    for layer_idx in range(1, 93):
+        rows_written_before = sum(1 for w in range(layer_idx) if w % block_size == 0)
+        assert bank_num_rows(layer_idx, block_size) == rows_written_before
+
+    for last_layer_of_stage in range(92):
+        rows_after_exit = last_layer_of_stage // block_size + 1
+        assert bank_num_rows(last_layer_of_stage + 1, block_size) == rows_after_exit

--- a/tests/fast/models/test_kimi_k3_script_args.py
+++ b/tests/fast/models/test_kimi_k3_script_args.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import pytest
+
+from scripts import run_kimi_k3_lora
+
+
+def _full(**kwargs):
+    return run_kimi_k3_lora.ScriptArgs(model_variant="full", num_nodes=16, num_gpus_per_node=4, **kwargs)
+
+
+# (pipeline, context, expected tp, expected ep) for every layout run in production.
+@pytest.mark.parametrize(
+    "pipeline_parallel_size,context_parallel_size,expected_tp,expected_ep",
+    [(1, 1, 32, 64), (8, 1, 8, 8), (8, 2, 4, 8)],
+)
+def test_full_model_parallel_derivation(pipeline_parallel_size, context_parallel_size, expected_tp, expected_ep):
+    args = _full(
+        pipeline_parallel_size=pipeline_parallel_size,
+        context_parallel_size=context_parallel_size,
+    )
+    assert args.tensor_parallel_size == expected_tp
+    assert args.expert_parallel_size == expected_ep
+
+
+def test_derived_ep_saturates_the_bound_post_init_validates():
+    """EP must equal the non-PP rank count of one pipeline stage, not TP.
+
+    Returning TP alone silently under-uses the bound whenever CP > 1, which is
+    why every CP run before this had to pass --ep-size-override.
+    """
+    args = _full(pipeline_parallel_size=8, context_parallel_size=2)
+    model_parallel = args.tensor_parallel_size * args.context_parallel_size * args.pipeline_parallel_size
+    data_parallel = 64 // model_parallel
+    assert args.expert_parallel_size == args.tensor_parallel_size * args.context_parallel_size * data_parallel
+
+
+def test_ep_override_wins_over_derivation():
+    args = _full(pipeline_parallel_size=8, context_parallel_size=2, ep_size_override=4)
+    assert args.expert_parallel_size == 4
+
+
+def test_tp_override_wins_and_feeds_the_ep_derivation():
+    args = _full(pipeline_parallel_size=4, context_parallel_size=1, tp_size_override=8)
+    assert args.tensor_parallel_size == 8
+    # DP is 2 here, so the stage still holds 16 non-PP ranks.
+    assert args.expert_parallel_size == 16
+
+
+def test_four_layer_variant_is_unaffected():
+    args = run_kimi_k3_lora.ScriptArgs(model_variant="4layer", num_nodes=1, num_gpus_per_node=8)
+    assert args.tensor_parallel_size == 8
+    assert args.expert_parallel_size == 8

--- a/tests/fast/ray/rollout/test_rollout_server.py
+++ b/tests/fast/ray/rollout/test_rollout_server.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+
 import pytest
 from tests.fast.ray.rollout.conftest import make_args, make_dataclass_group
 

--- a/tests/fast/rollout/rm_hub/test_rm_hub.py
+++ b/tests/fast/rollout/rm_hub/test_rm_hub.py
@@ -21,6 +21,12 @@ class TestAsyncRm:
         "rm_type,response,label,expected",
         [
             ("math", r"\boxed{42}", "42", 1),
+            (
+                "math",
+                r"<|open|>think<|sep|>work<|close|>think<|open|>response<|sep|>Answer: \boxed{42}<|close|>response",
+                "42",
+                1,
+            ),
             ("math", r"\boxed{wrong}", "42", 0),
             ("f1", "hello world", "hello world", 1.0),
             ("dapo", "Answer: 42", "42", {"score": 1.0}),

--- a/tests/fast/utils/test_http_utils.py
+++ b/tests/fast/utils/test_http_utils.py
@@ -21,14 +21,17 @@ delays (5s / 10s / 20s) without actually waiting.  The trick:
 This lets us simulate 20 seconds of polling in <1ms of real time.
 """
 
+import asyncio
 import multiprocessing
 import socket
 import threading
 import time
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
 
+import miles.utils.http_utils as http_utils
 from miles.utils.http_utils import wait_for_server_ready
 
 
@@ -194,3 +197,44 @@ class TestWaitForServerReadySimulatedDelays:
 
         # The fake clock should have advanced past the timeout
         assert fake_time[0] >= timeout
+
+
+def test_http_client_is_created_per_event_loop(monkeypatch):
+    clients = []
+
+    class FakeAsyncClient:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            self.closed = False
+            clients.append(self)
+
+        async def aclose(self):
+            self.closed = True
+
+    monkeypatch.setattr(http_utils, "_http_clients", {})
+    monkeypatch.setattr(http_utils.httpx, "AsyncClient", FakeAsyncClient)
+    http_utils.init_http_client(
+        SimpleNamespace(
+            rollout_num_gpus=64,
+            rollout_num_gpus_per_engine=48,
+            sglang_server_concurrency=16,
+            use_distributed_post=False,
+        )
+    )
+
+    async def get_client_twice():
+        first = http_utils._get_http_client()
+        second = http_utils._get_http_client()
+        return first, second
+
+    first_loop_clients = asyncio.run(get_client_twice())
+    second_loop_clients = asyncio.run(get_client_twice())
+
+    assert first_loop_clients[0] is first_loop_clients[1]
+    assert second_loop_clients[0] is second_loop_clients[1]
+    assert first_loop_clients[0] is not second_loop_clients[0]
+    assert len(clients) == 2
+    for client in clients:
+        limits = client.kwargs["limits"]
+        assert limits.max_connections == 16 * 64 // 48
+        assert limits.max_keepalive_connections == 0

--- a/tools/convert_hf_to_torch_dist.py
+++ b/tools/convert_hf_to_torch_dist.py
@@ -12,6 +12,7 @@ from megatron.training.training import get_model
 import miles_plugins.mbridge  # noqa: F401
 from mbridge import AutoBridge
 from miles.backends.megatron_utils.arguments import set_default_megatron_args
+from miles.backends.megatron_utils.fp32_param_utils import enforce_marked_param_dtypes
 from miles.backends.megatron_utils.initialize import init
 from miles.backends.megatron_utils.model_provider import get_model_provider_func
 from miles.utils.logging_utils import configure_logger_raw
@@ -55,7 +56,15 @@ def get_args():
     def ceildiv(a, b):
         return -(a // -b)
 
-    if args.pipeline_model_parallel_size == 1 and world_size > 1:
+    auto_pipeline_parallel = (
+        args.pipeline_model_parallel_size == 1
+        and args.tensor_model_parallel_size == 1
+        and args.context_parallel_size == 1
+        and args.expert_model_parallel_size == 1
+        and args.expert_tensor_parallel_size == 1
+        and world_size > 1
+    )
+    if auto_pipeline_parallel:
         pp_size = world_size
         while True:
             args.pipeline_model_parallel_size = pp_size
@@ -113,6 +122,7 @@ def main():
     args = get_args()
     init(args)
     model = get_model(get_model_provider_func(args), ModelType.encoder_or_decoder, wrap_with_ddp=False)
+    enforce_marked_param_dtypes(model)
 
     # Load model
     hf_model_path = args.hf_checkpoint

--- a/tools/convert_mxfp4_to_bf16.py
+++ b/tools/convert_mxfp4_to_bf16.py
@@ -1,0 +1,194 @@
+"""
+python tools/convert_mxfp4_to_bf16.py [-h] --model-dir MODEL_DIR --save-dir SAVE_DIR
+                                      [--device {cpu,cuda}] [--files FILE [FILE ...]]
+                                      [--shard-rank SHARD_RANK] [--num-shards NUM_SHARDS]
+                                      [--finalize-only] [--overwrite]
+
+Convert an ``mxfp4-pack-quantized`` compressed-tensors safetensors checkpoint to
+BF16, replacing every ``<name>.weight_packed`` / ``<name>.weight_scale`` pair with
+a dequantized ``<name>.weight`` and dropping ``quantization_config`` from the
+copied config.
+
+options:
+  --model-dir MODEL_DIR Directory of the HF safetensors quantized model.
+  --save-dir SAVE_DIR   Directory to save the converted BF16 model.
+  --device {cpu,cuda}   Device used to dequantize (default: cpu).
+  --files FILE [FILE ...]
+                        Specific safetensors filenames to convert (relative to
+                        model-dir). Convert all if omitted.
+  --shard-rank SHARD_RANK, --num-shards NUM_SHARDS
+                        Convert only this shard of the file list, so the run can
+                        be spread over many processes. Both or neither.
+  --finalize-only       Skip conversion; only copy metadata and rebuild the
+                        safetensors index. Run once after all shards finish.
+  --overwrite           Reconvert files that already exist in save-dir.
+
+Example:
+--------
+python tools/convert_mxfp4_to_bf16.py --model-dir /Kimi-K3/native --save-dir /Kimi-K3/bf16
+"""
+
+import argparse
+import json
+import math
+import os
+import shutil
+from pathlib import Path
+
+from safetensors.torch import safe_open, save_file
+
+from miles.utils.mxfp4 import dequantize_mxfp4
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Convert MXFP4-packed compressed-tensors weights to BF16.")
+    parser.add_argument("--model-dir", type=Path, required=True)
+    parser.add_argument("--save-dir", type=Path, required=True)
+    parser.add_argument("--device", choices=("cpu", "cuda"), default="cpu")
+    parser.add_argument("--files", nargs="+")
+    parser.add_argument("--shard-rank", type=int)
+    parser.add_argument("--num-shards", type=int)
+    parser.add_argument("--finalize-only", action="store_true")
+    parser.add_argument("--overwrite", action="store_true")
+    return parser.parse_args()
+
+
+def quantization_section(config: dict) -> dict:
+    """The config level holding ``quantization_config``: nested under
+    ``text_config`` for multimodal checkpoints, top level otherwise."""
+    return config.get("text_config", config)
+
+
+def load_group_size(model_dir: Path) -> int:
+    with (model_dir / "config.json").open() as file:
+        config = json.load(file)
+    quantization_config = quantization_section(config)["quantization_config"]
+    assert quantization_config["format"] == "mxfp4-pack-quantized", quantization_config["format"]
+    weights_config = quantization_config["config_groups"]["group_0"]["weights"]
+    assert weights_config["type"] == "float"
+    assert weights_config["num_bits"] == 4
+    assert weights_config["scale_dtype"] == "torch.uint8"
+    return int(weights_config["group_size"])
+
+
+def copy_metadata(model_dir: Path, output_dir: Path) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    for source in model_dir.iterdir():
+        if not source.is_file() or source.suffix == ".safetensors" or source.name.endswith(".index.json"):
+            continue
+        shutil.copy2(source, output_dir / source.name)
+
+    config_path = output_dir / "config.json"
+    with config_path.open() as file:
+        config = json.load(file)
+    del quantization_section(config)["quantization_config"]
+    with config_path.open("w") as file:
+        json.dump(config, file, indent=2)
+
+
+def convert_file(
+    source_path: Path,
+    output_path: Path,
+    group_size: int,
+    device: str,
+) -> None:
+    tensors = {}
+    with safe_open(source_path, framework="pt", device="cpu") as reader:
+        keys = set(reader.keys())
+        packed_keys = sorted(name for name in keys if name.endswith(".weight_packed"))
+        scale_keys = {name for name in keys if name.endswith(".weight_scale")}
+
+        for packed_name in packed_keys:
+            prefix = packed_name.removesuffix(".weight_packed")
+            scale_name = f"{prefix}.weight_scale"
+            assert scale_name in scale_keys, f"Missing scale for {packed_name}"
+            scale_keys.remove(scale_name)
+
+            weight_packed = reader.get_tensor(packed_name).to(device)
+            weight_scale = reader.get_tensor(scale_name).to(device)
+            weight = dequantize_mxfp4(weight_packed, weight_scale, group_size).cpu()
+            output_name = f"{prefix}.weight"
+            tensors[output_name] = weight
+
+        assert not scale_keys, f"Orphan MXFP4 scales in {source_path.name}: {sorted(scale_keys)}"
+        quantized_keys = set(packed_keys) | {
+            f"{name.removesuffix('.weight_packed')}.weight_scale" for name in packed_keys
+        }
+        for name in sorted(keys - quantized_keys):
+            tensor = reader.get_tensor(name)
+            tensors[name] = tensor
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    temporary_path = output_path.with_suffix(f"{output_path.suffix}.tmp")
+    save_file(tensors, temporary_path)
+    os.replace(temporary_path, output_path)
+
+
+def build_index(output_dir: Path) -> None:
+    dtype_sizes = {
+        "BF16": 2,
+        "F16": 2,
+        "F32": 4,
+        "F64": 8,
+        "I32": 4,
+        "I64": 8,
+        "U8": 1,
+    }
+    weight_map = {}
+    total_size = 0
+    for path in sorted(output_dir.glob("*.safetensors")):
+        with safe_open(path, framework="pt", device="cpu") as reader:
+            for name in reader.keys():
+                assert name not in weight_map, f"Duplicate tensor: {name}"
+                weight_map[name] = path.name
+                tensor_slice = reader.get_slice(name)
+                shape = tensor_slice.get_shape()
+                dtype = tensor_slice.get_dtype()
+                assert dtype in dtype_sizes, f"Unsupported safetensors dtype: {dtype}"
+                total_size += math.prod(shape) * dtype_sizes[dtype]
+
+    with (output_dir / "model.safetensors.index.json").open("w") as file:
+        json.dump({"metadata": {"total_size": total_size}, "weight_map": weight_map}, file, indent=2)
+
+
+def main() -> None:
+    args = parse_args()
+    assert args.model_dir.is_dir(), args.model_dir
+    assert args.save_dir != args.model_dir
+    assert (args.shard_rank is None) == (args.num_shards is None)
+    if args.num_shards is not None:
+        assert args.num_shards > 0
+        assert 0 <= args.shard_rank < args.num_shards
+        assert args.files is None, "--files cannot be combined with sharded conversion"
+
+    group_size = load_group_size(args.model_dir)
+    args.save_dir.mkdir(parents=True, exist_ok=True)
+
+    if args.finalize_only:
+        copy_metadata(args.model_dir, args.save_dir)
+        build_index(args.save_dir)
+        return
+
+    if args.shard_rank in (None, 0):
+        copy_metadata(args.model_dir, args.save_dir)
+
+    filenames = args.files or [path.name for path in sorted(args.model_dir.glob("*.safetensors"))]
+    if args.num_shards is not None:
+        filenames = filenames[args.shard_rank :: args.num_shards]
+    assert filenames, "No safetensors files found"
+    for filename in filenames:
+        source_path = args.model_dir / filename
+        output_path = args.save_dir / filename
+        assert source_path.is_file(), source_path
+        if output_path.exists() and not args.overwrite:
+            print(f"Skipping existing {output_path}", flush=True)
+            continue
+        print(f"Converting {source_path} -> {output_path}", flush=True)
+        convert_file(source_path, output_path, group_size, args.device)
+
+    if args.num_shards is None:
+        build_index(args.save_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/train.py
+++ b/train.py
@@ -1,9 +1,8 @@
 import asyncio
 import logging
 
-from sglang.srt.constants import GPU_MEMORY_TYPE_CUDA_GRAPH, GPU_MEMORY_TYPE_KV_CACHE, GPU_MEMORY_TYPE_WEIGHTS
-
 from miles.ray.placement_group import create_placement_groups, create_rollout_manager, create_training_models
+from miles.ray.rollout.rollout_manager import get_rollout_offload_tags
 from miles.utils.arguments import parse_args
 from miles.utils.async_utils import eager_create_task
 from miles.utils.audit_utils.process_identity import MainProcessIdentity
@@ -48,12 +47,14 @@ async def train(args):
     await actor_model.update_weights()
 
     if args.check_weight_update_equal:
+        compare_action = "compare" if args.check_weight_update_allow_quant_error else "compare_checksum"
         await rollout_manager.check_weights.remote(
-            action="compare",
+            action=compare_action,
             allow_quant_error=args.check_weight_update_allow_quant_error,
             selector=args.check_weight_update_selector,
             skip_list=args.check_weight_update_skip_list,
         )
+        await rollout_manager.check_weights.remote(action="clear_snapshot")
 
     if args.offload_rollout:
         await rollout_manager.onload_kv.remote()
@@ -95,12 +96,7 @@ async def train(args):
         rollout_data_ref = await rollout_manager.generate.remote(rollout_id)
 
         if args.offload_rollout:
-            offload_tags = [GPU_MEMORY_TYPE_CUDA_GRAPH]
-            if "kv_cache" in args.offload_rollout_level:
-                offload_tags.append(GPU_MEMORY_TYPE_KV_CACHE)
-            if "weight" in args.offload_rollout_level:
-                offload_tags.append(GPU_MEMORY_TYPE_WEIGHTS)
-            await rollout_manager.offload.remote(tags=offload_tags)
+            await rollout_manager.offload.remote(tags=get_rollout_offload_tags(args))
 
         if args.use_critic:
             critic_task = await eager_create_task(critic_model.train(rollout_id, rollout_data_ref))
@@ -113,12 +109,17 @@ async def train(args):
         if should_run_periodic_action(rollout_id, args.save_interval, num_rollout_per_epoch, args.num_rollout):
             await save(rollout_id)
 
-        await offload_train()
-        if args.offload_rollout:
-            await rollout_manager.onload_weights.remote()
-        await actor_model.update_weights(rollout_id=rollout_id)
-        if args.offload_rollout:
-            await rollout_manager.onload_kv.remote()
+        # The engines never generate again after the last rollout; skip the
+        # final offload/reload/update unless a final eval consumes it.
+        if rollout_id + 1 < args.num_rollout or should_run_periodic_action(
+            rollout_id, args.eval_interval, num_rollout_per_epoch
+        ):
+            await offload_train()
+            if args.offload_rollout:
+                await rollout_manager.onload_weights.remote()
+            await actor_model.update_weights(rollout_id=rollout_id)
+            if args.offload_rollout:
+                await rollout_manager.onload_kv.remote()
 
         if should_run_periodic_action(rollout_id, args.eval_interval, num_rollout_per_epoch):
             await rollout_manager.eval.remote(rollout_id)

--- a/train.py
+++ b/train.py
@@ -23,6 +23,12 @@ async def train(args):
     pgs = create_placement_groups(args)
     init_tracking(args)
 
+    if args.colocate_memory_peak_device == "gpu":
+        assert (
+            args.offload_train and args.offload_rollout
+        ), "--colocate-memory-peak-device gpu requires --offload-train and --offload-rollout"
+        assert not args.use_critic, "--colocate-memory-peak-device gpu is not wired for the critic path"
+
     # create the rollout manager, with sglang engines inside.
     # need to initialize rollout manager first to calculate num_rollout
     rollout_manager, num_rollout_per_epoch = create_rollout_manager(args, pgs["rollout"])
@@ -40,7 +46,8 @@ async def train(args):
 
     maybe_start_mini_ft_controller(args)
 
-    if args.offload_rollout:
+    if args.offload_rollout and args.colocate_memory_peak_device != "gpu":
+        # gpu mode never released the weights at init; resuming a never-released TMS region is fatal.
         await rollout_manager.onload_weights.remote()
 
     # always update weight first so that sglang has the loaded weights from training.
@@ -96,7 +103,14 @@ async def train(args):
         rollout_data_ref = await rollout_manager.generate.remote(rollout_id)
 
         if args.offload_rollout:
-            await rollout_manager.offload.remote(tags=get_rollout_offload_tags(args))
+            if args.colocate_memory_peak_device == "gpu":
+                # Overlap the handoff on the GPU so the two host copies
+                # (engine weight mirror, trainer backup) never coexist.
+                await rollout_manager.offload_kv.remote()
+                await actor_model.onload()
+                await rollout_manager.offload_weights.remote()
+            else:
+                await rollout_manager.offload.remote(tags=get_rollout_offload_tags(args))
 
         if args.use_critic:
             critic_task = await eager_create_task(critic_model.train(rollout_id, rollout_data_ref))
@@ -114,9 +128,17 @@ async def train(args):
         if rollout_id + 1 < args.num_rollout or should_run_periodic_action(
             rollout_id, args.eval_interval, num_rollout_per_epoch
         ):
-            await offload_train()
-            if args.offload_rollout:
+            if args.colocate_memory_peak_device == "gpu" and args.offload_rollout:
+                # Mirror-first handoff; the trainer returns its caches and grad
+                # buffers first — the engine resume needs the wake-time layout.
+                await actor_model.clear_memory()
+                await actor_model.offload_grad_buffer()
                 await rollout_manager.onload_weights.remote()
+                await offload_train()
+            else:
+                await offload_train()
+                if args.offload_rollout:
+                    await rollout_manager.onload_weights.remote()
             await actor_model.update_weights(rollout_id=rollout_id)
             if args.offload_rollout:
                 await rollout_manager.onload_kv.remote()

--- a/train_async.py
+++ b/train_async.py
@@ -45,12 +45,14 @@ async def train(args):
     await actor_model.update_weights()
 
     if args.check_weight_update_equal:
+        compare_action = "compare" if args.check_weight_update_allow_quant_error else "compare_checksum"
         await rollout_manager.check_weights.remote(
-            action="compare",
+            action=compare_action,
             allow_quant_error=args.check_weight_update_allow_quant_error,
             selector=args.check_weight_update_selector,
             skip_list=args.check_weight_update_skip_list,
         )
+        await rollout_manager.check_weights.remote(action="clear_snapshot")
 
     if args.eval_interval is not None and args.start_rollout_id == 0 and not args.skip_eval_before_train:
         await rollout_manager.eval.remote(0)


### PR DESCRIPTION
Stacked on the `kimi-k3` branch (#1825). One squashed commit. The persistent CUDA-IPC LoRA transfer buffer was split out to #1923.

### What

`--colocate-memory-peak-device {cpu,gpu}` (default `cpu` = existing behavior).

In colocated RL, each trainer<->rollout handoff briefly holds two host copies:
the engine's weight mirror (built when the engine releases its weights under
`--enable-weights-cpu-backup`) and the trainer's own TMS backup. On hosts where
the two together exceed the memory budget (GB300: 4x140 GB mirror + trainer
backup vs the job cgroup), `gpu` mode reorders both handoffs so the overlap
lives on the GPU instead and the host copies never coexist:

- rollout->train: drop the engine KV cache + CUDA graphs (pure GPU memory),
  wake the trainer while the engine weights are still resident, then release
  the weights — their mirror replaces the trainer's just-freed backup.
- train->rollout: the trainer returns its allocator caches and the no-backup
  LoRA grad-buffer region to the device, the engine resumes its weights, and
  only then does the trainer sleep into the space the mirror vacated.
- init: the engine weights stay resident through the trainer checkpoint load
  (their mirror cannot coexist with the load's footprint).

`RolloutManager` gains split `offload_kv`/`offload_weights`/`onload_weights`;
the trainer actor gains an idempotent `sleep`/`wake_up` pair plus
`offload_grad_buffer`; the K3 launcher hardcodes `gpu`.

### Validation

16 nodes x 4 GPU (GB300), full Kimi-K3 LoRA RL (together with #1923): both
handoffs stable cycle over cycle, host anon+shmem peaking ~770 GB of the
898 GB cgroup with a single large host copy at any time; `eval/aime`
0.367 -> 0.467 by the second eval. This is the configuration inside the
released `radixark/miles:kimi-k3` image, which the Reproduce section of
#1825 describes.
