### PR TITLE
[feat] Support training with variable global batch size

### DIFF
--- a/miles/backends/megatron_utils/actor.py
+++ b/miles/backends/megatron_utils/actor.py
@@ -146,7 +146,16 @@ class MegatronTrainRayActor(TrainRayActor):
                 )
             dist.barrier(group=get_gloo_group())
 
-        self.train_parallel_config = {} if args.indep_dp else {"dp_size": get_parallel_state().intra_dp.size}
+        self.train_parallel_config = (
+            {}
+            if args.indep_dp
+            else {
+                "dp_size": get_parallel_state().intra_dp.size,
+                "cp_size": get_parallel_state().cp.size,
+                "vpp_size": get_parallel_state().vpp_size,
+                "microbatch_group_size_per_vp_stage": get_parallel_state().microbatch_group_size_per_vp_stage,
+            }
+        )
         dist.barrier(group=get_gloo_group())
 
         if args.offload_train:

--- a/miles/backends/megatron_utils/actor.py
+++ b/miles/backends/megatron_utils/actor.py
@@ -36,7 +36,7 @@ from miles.utils.types import RolloutBatch
 
 from ...utils.profile_utils import TrainProfiler
 from ...utils.tensor_backper import TensorBackuper
-from ..training_utils.data import DataIterator, get_data_iterator, get_rollout_data
+from ..training_utils.data import DataIterator, get_data_iterator, get_num_rollouts, get_rollout_data
 from ..training_utils.log_utils import log_cpu_memory, log_perf_data, log_rollout_data
 from ..training_utils.loss import (
     compute_advantages_and_returns,
@@ -436,6 +436,7 @@ class MegatronTrainRayActor(TrainRayActor):
             self.opt_param_scheduler,
             data_iterator,
             num_microbatches,
+            get_num_rollouts(self.args, rollout_data, len(num_microbatches)),
             witness_info=None,
             attempt=0,
         )
@@ -557,6 +558,7 @@ class MegatronTrainRayActor(TrainRayActor):
                     self.opt_param_scheduler,
                     data_iterator,
                     num_microbatches,
+                    get_num_rollouts(self.args, rollout_data, len(num_microbatches)),
                     witness_info=witness_info,
                     attempt=attempt,
                     ft_test_action_executor=self._ft_test_action_executor,

--- a/miles/backends/megatron_utils/ft/indep_dp.py
+++ b/miles/backends/megatron_utils/ft/indep_dp.py
@@ -105,7 +105,11 @@ def reconfigure_indep_dp_group(
 
 
 def allreduce_grads_and_losses_across_replicas(
-    args, model: Sequence["DDP"], parallel_state: ParallelState, losses_reduced: list
+    args,
+    model: Sequence["DDP"],
+    parallel_state: ParallelState,
+    losses_reduced: list,
+    num_rollouts: int | None = None,
 ) -> tuple[bool, dict[str, float]]:
     assert not args.calculate_per_token_loss, "calculate_per_token_loss is not supported with indep_dp yet"
     assert parallel_state.intra_dp.size == 1, (
@@ -129,7 +133,7 @@ def allreduce_grads_and_losses_across_replicas(
     allreduce_success = True
     try:
         if mpu.is_pipeline_last_stage(ignore_virtual=True):
-            loss_reduced = aggregate_train_losses(losses_reduced)
+            loss_reduced = aggregate_train_losses(losses_reduced, num_rollouts)
         for model_chunk in model:
             # mimic: DistributedDataParallel.start_grad_sync
             for bucket_group in model_chunk.bucket_groups + model_chunk.expert_parallel_bucket_groups:

--- a/miles/backends/megatron_utils/model.py
+++ b/miles/backends/megatron_utils/model.py
@@ -411,6 +411,7 @@ def train_one_step(
     optimizer: MegatronOptimizer | None,
     opt_param_scheduler: OptimizerParamScheduler | None,
     num_microbatches: int,
+    num_rollouts: int,
     witness_info: WitnessInfo | None,
     attempt: int,
     ft_test_action_executor: FTTestActionActorExecutor | None = None,
@@ -433,6 +434,7 @@ def train_one_step(
         optimizer: Optimizer instance.
         opt_param_scheduler: LR/WD scheduler.
         num_microbatches: Number of microbatches to process.
+        num_rollouts: This step's rollout count (loss normalizer + LR increment).
 
     Returns:
         Tuple of (reduced loss dict, gradient norm, step outcome).
@@ -494,6 +496,7 @@ def train_one_step(
                 "max_seq_lens",
                 "witness_ids",
                 "opd_reverse_kl",
+                "rollout_mask_sums",
             ],
             args.data_pad_size_multiplier,
             args.qkv_format,
@@ -544,7 +547,14 @@ def train_one_step(
         for m, old_stage in zip(all_replay_managers, old_stages, strict=True):
             m.stage = old_stage
 
-        return output_tensor, partial(loss_function, args, batch, num_microbatches, apply_megatron_loss_scaling=True)
+        return output_tensor, partial(
+            loss_function,
+            args,
+            batch,
+            num_microbatches,
+            apply_megatron_loss_scaling=True,
+            num_rollouts=num_rollouts,
+        )
 
     # Forward pass.
     forward_backward_func = get_forward_backward_func()
@@ -570,8 +580,9 @@ def train_one_step(
         if ft_test_action_executor is not None:
             ft_test_action_executor.maybe_crash(rollout_id=rollout_id, attempt=attempt)
 
+        metric_num_rollouts = None if args.calculate_per_token_loss else num_rollouts
         ok, indep_dp_loss_reduced = allreduce_grads_and_losses_across_replicas(
-            args, model, parallel_state, losses_reduced=losses_reduced
+            args, model, parallel_state, losses_reduced=losses_reduced, num_rollouts=metric_num_rollouts
         )
         if not ok:
             outcome = TrainStepOutcome.DISCARDED_SHOULD_RETRY
@@ -614,7 +625,7 @@ def train_one_step(
 
             # Update learning rate.
             assert update_successful
-            opt_param_scheduler.step(increment=args.global_batch_size)
+            opt_param_scheduler.step(increment=num_rollouts)
 
     # release grad (multi-LoRA retains accumulated grads; stepped slots were
     # zeroed selectively inside step_adapter_slots)
@@ -637,8 +648,11 @@ def train_one_step(
             witness_dump_and_clear_stale(model=model, witness_info=witness_info, optimizer=optimizer)
 
         if mpu.is_pipeline_last_stage(ignore_virtual=True):
+            metric_num_rollouts = None if args.calculate_per_token_loss else num_rollouts
             loss_reduced = (
-                indep_dp_loss_reduced if parallel_state.indep_dp.size > 1 else aggregate_train_losses(losses_reduced)
+                indep_dp_loss_reduced
+                if parallel_state.indep_dp.size > 1
+                else aggregate_train_losses(losses_reduced, metric_num_rollouts)
             )
             return loss_reduced, grad_norm, outcome
 
@@ -664,6 +678,7 @@ def train(
     opt_param_scheduler: OptimizerParamScheduler | None,
     data_iterator: Sequence[DataIterator],
     num_microbatches: Sequence[int],
+    num_rollouts: Sequence[int],
     witness_info: WitnessInfo | None,
     attempt: int,
     ft_test_action_executor: FTTestActionActorExecutor | None = None,
@@ -680,10 +695,16 @@ def train(
         opt_param_scheduler (OptimizerParamScheduler): LR/WD scheduler.
         data_iterator (Sequence[DataIterator]): Iterable(s) yielding training batches.
         num_microbatches (Sequence[int]): Microbatches per step in the rollout.
+        num_rollouts (Sequence[int]): Rollout count per step (total across DP).
     """
     parallel_state = get_parallel_state()
     args = get_args()
     disable_optimizer = args.debug_disable_optimizer or optimizer is None
+
+    assert len(num_microbatches) == len(num_rollouts), (
+        f"num_microbatches and num_rollouts must have the same length, "
+        f"got {len(num_microbatches)} vs {len(num_rollouts)}"
+    )
 
     for iterator in data_iterator:
         iterator.reset()
@@ -764,6 +785,7 @@ def train(
             optimizer,
             opt_param_scheduler,
             num_microbatches[step_id],
+            num_rollouts[step_id],
             witness_info=witness_info,
             attempt=attempt,
             ft_test_action_executor=ft_test_action_executor,

--- a/miles/backends/training_utils/cp_utils.py
+++ b/miles/backends/training_utils/cp_utils.py
@@ -96,10 +96,15 @@ def get_sum_of_sample_mean(
     calculate_per_token_loss: bool = False,
     qkv_format: str = "thd",
     max_seq_lens: list[int] | None = None,
+    *,
+    denominators: list[torch.Tensor] | torch.Tensor | None = None,
 ) -> Callable[[torch.Tensor], torch.Tensor]:
-    """
-    Calculate correct sample mean for CP
-    """
+    """Calculate correct sample mean for CP; ``denominators`` overrides each
+    sample's own ``loss_mask.sum()`` (e.g. pass ``rollout_mask_sums`` for
+    per-rollout means)."""
+    if denominators is None:
+        denominators = [m.sum() for m in loss_masks]
+
     parallel_state = get_parallel_state()
     cp_size = parallel_state.cp.size
     if cp_size == 1:
@@ -107,8 +112,10 @@ def get_sum_of_sample_mean(
         def sum_of_sample_mean(x: torch.Tensor) -> torch.Tensor:
             return sum(
                 [
-                    (x_i * loss_mask_i).sum() / torch.clamp_min(loss_mask_i.sum(), 1)
-                    for x_i, loss_mask_i in zip(x.split(response_lengths, dim=0), loss_masks, strict=True)
+                    (x_i * loss_mask_i).sum() / torch.clamp_min(denominator, 1)
+                    for x_i, loss_mask_i, denominator in zip(
+                        x.split(response_lengths, dim=0), loss_masks, denominators, strict=True
+                    )
                 ]
             )
 
@@ -135,9 +142,9 @@ def get_sum_of_sample_mean(
         def sum_of_sample_mean(x: torch.Tensor) -> torch.Tensor:
             return sum(
                 [
-                    (x_i * chunked_loss_mask).sum() / torch.clamp_min(loss_mask.sum(), 1)
-                    for x_i, chunked_loss_mask, loss_mask in zip(
-                        x.split(cp_chunk_lengths, dim=0), chunked_loss_masks, loss_masks, strict=True
+                    (x_i * chunked_loss_mask).sum() / torch.clamp_min(denominator, 1)
+                    for x_i, chunked_loss_mask, denominator in zip(
+                        x.split(cp_chunk_lengths, dim=0), chunked_loss_masks, denominators, strict=True
                     )
                 ]
             )

--- a/miles/backends/training_utils/data.py
+++ b/miles/backends/training_utils/data.py
@@ -53,6 +53,10 @@ def get_rollout_data(
     rollout_data["loss_masks"] = [
         torch.tensor(t, dtype=torch.int, device=torch.cuda.current_device()) for t in rollout_data["loss_masks"]
     ]
+    if "rollout_mask_sums" in rollout_data:
+        rollout_data["rollout_mask_sums"] = torch.tensor(
+            rollout_data["rollout_mask_sums"], dtype=torch.float32, device=torch.cuda.current_device()
+        )
     if args.enable_witness:
         seq_witness_ids = rollout_data.pop("seq_witness_ids")
         rollout_data["witness_ids"] = [
@@ -408,6 +412,13 @@ class DataIterator:
         """Reset internal offset to the start and return self."""
         self.offset = 0
         return self
+
+
+def get_num_rollouts(args: Namespace, rollout_data: RolloutBatch, num_steps: int) -> list[int]:
+    """Per-step rollout counts (total across DP); one entry per training step."""
+    if "num_rollouts" in rollout_data:
+        return rollout_data["num_rollouts"]
+    return [rollout_data.get("dynamic_global_batch_size", args.global_batch_size)] * num_steps
 
 
 def get_data_iterator(

--- a/miles/backends/training_utils/data.py
+++ b/miles/backends/training_utils/data.py
@@ -432,6 +432,15 @@ def get_data_iterator(
     expand_multimodal_rollout_data_in_place(rollout_data, qkv_format=args.qkv_format)
 
     parallel_state = get_parallel_state()
+
+    if "micro_batch_indices" in rollout_data:
+        assert args.use_dynamic_global_batch_size == ("dynamic_global_batch_size" in rollout_data)
+        micro_batch_indices = rollout_data["micro_batch_indices"]
+        data_iterator = [
+            DataIterator(rollout_data, micro_batch_indices=micro_batch_indices) for _ in range(parallel_state.vpp_size)
+        ]
+        return data_iterator, rollout_data["num_microbatches"]
+
     dp_size = parallel_state.effective_dp.size
     dp_group = parallel_state.effective_dp.group
     vpp_size = parallel_state.vpp_size

--- a/miles/backends/training_utils/log_utils.py
+++ b/miles/backends/training_utils/log_utils.py
@@ -137,6 +137,8 @@ def log_rollout_data(rollout_id: int, args: Namespace, rollout_data: RolloutBatc
                 "witness_ids",
                 "weight_versions",
                 "metadata",
+                "num_microbatches",
+                "micro_batch_indices",
                 "n_adapters",
                 "adapter_slots",
                 "step_slots",

--- a/miles/backends/training_utils/log_utils.py
+++ b/miles/backends/training_utils/log_utils.py
@@ -22,18 +22,31 @@ from .parallel import get_parallel_state
 logger = logging.getLogger(__name__)
 
 
+def reduce_gathered_log_dict(gathered: list[dict], dp_size: int) -> dict[str, float]:
+    """Per-key reduction: ``(sum, count)`` tuples as ``Σsum / Σcount``, scalars as mean."""
+    reduced: dict[str, float] = {}
+    for key in gathered[0]:
+        values = [d[key] for d in gathered]
+        first = values[0]
+        if isinstance(first, tuple) and len(first) == 2:
+            total_sum = sum(v[0] for v in values)
+            total_count = sum(v[1] for v in values)
+            reduced[key] = total_sum / total_count if total_count else 0.0
+        else:
+            reduced[key] = sum(values) / dp_size
+    return reduced
+
+
 def gather_log_data(
     metric_name: str,
     args: Namespace,
     rollout_id: int,
-    log_dict: dict[str, float],
+    log_dict: dict[str, "float | tuple[float, float]"],
 ) -> dict[str, float] | None:
     """
-    Gather per-rank metrics, reduce by mean on the DP source rank, and log.
+    Gather per-rank metrics, reduce on the DP source rank, and log.
 
-    Expects `log_dict` to contain plain scalars. The DP source rank prints and
-    optionally logs to WandB/TensorBoard with a step derived from `rollout_id` and
-    batch sizes. Returns the reduced dict on the DP source rank; returns None on others.
+    Returns the reduced dict on the DP source rank; returns None on others.
     """
 
     parallel_state = get_parallel_state()
@@ -60,9 +73,8 @@ def gather_log_data(
         return None
 
     if pg.rank == 0:
-        reduced_log_dict = {
-            f"{metric_name}/{key}": sum([d[key] for d in gathered_log_dict]) / pg.size for key in log_dict
-        }
+        reduced = reduce_gathered_log_dict(gathered_log_dict, pg.size)
+        reduced_log_dict = {f"{metric_name}/{key}": value for key, value in reduced.items()}
         logger.info(f"{metric_name} {rollout_id}: {reduced_log_dict}")
 
         # Calculate step once to avoid duplication
@@ -123,6 +135,10 @@ def log_rollout_data(rollout_id: int, args: Namespace, rollout_data: RolloutBatc
         loss_masks = rollout_data["loss_masks"]
         total_lengths = rollout_data["total_lengths"]
         max_seq_lens = rollout_data.get("max_seq_lens", None)
+        # per-rollout-mean count share: num_rollouts / dp (None = legacy local count)
+        rollout_count_share = None
+        if (num_rollouts := rollout_data.get("num_rollouts")) is not None:
+            rollout_count_share = sum(num_rollouts) / parallel_state.intra_dp.size
 
         for key, val in rollout_data.items():
             if key in [
@@ -130,6 +146,8 @@ def log_rollout_data(rollout_id: int, args: Namespace, rollout_data: RolloutBatc
                 "multimodal_train_inputs",
                 "loss_masks",
                 "sample_indices",
+                "rollout_ids",
+                "rollout_mask_sums",
                 "rollout_routed_experts",
                 "rollout_indexer_topk",
                 "max_seq_lens",
@@ -139,6 +157,7 @@ def log_rollout_data(rollout_id: int, args: Namespace, rollout_data: RolloutBatc
                 "metadata",
                 "num_microbatches",
                 "micro_batch_indices",
+                "num_rollouts",
                 "n_adapters",
                 "adapter_slots",
                 "step_slots",
@@ -147,16 +166,14 @@ def log_rollout_data(rollout_id: int, args: Namespace, rollout_data: RolloutBatc
                 "prompt_group_sizes",
             ]:
                 continue
-            # Upload per sample mean for each rollout value
-            # There are the following assumptions:
-            # - Each dp rank has the same number of samples
             if isinstance(val, (list, tuple)):
                 if isinstance(val[0], torch.Tensor):
+                    count = len(val)
                     # NOTE: Here we have to do the clone().detach(), otherwise the tensor will be
                     # modified in place and will cause problem for the next rollout.
-                    val = torch.cat(val).clone().detach()
-                    if val.device != loss_masks[0].device:
-                        val = val.to(loss_masks[0].device)
+                    tensor = torch.cat(val).clone().detach()
+                    if tensor.device != loss_masks[0].device:
+                        tensor = tensor.to(loss_masks[0].device)
                     if key in [
                         "log_probs",
                         "ref_log_probs",
@@ -174,10 +191,14 @@ def log_rollout_data(rollout_id: int, args: Namespace, rollout_data: RolloutBatc
                             loss_masks,
                             qkv_format=args.qkv_format,
                             max_seq_lens=max_seq_lens,
+                            denominators=rollout_data.get("rollout_mask_sums", None),
                         )
-                        val = cp_size * sum_of_sample_mean(val) / len(loss_masks)
+                        per_rank_sum = cp_size * sum_of_sample_mean(tensor)
+                        if rollout_count_share is not None:
+                            count = rollout_count_share
                     else:
-                        val = val.mean() * cp_size
+                        per_rank_sum = tensor.mean() * cp_size * count
+                    log_dict[key] = (per_rank_sum.item(), count)
                 else:
                     # Flatten nested lists (e.g. list of lists from async rollout)
                     flat = val
@@ -186,12 +207,11 @@ def log_rollout_data(rollout_id: int, args: Namespace, rollout_data: RolloutBatc
                     # Skip non-numeric values (e.g. strings from async rollout metadata)
                     if flat and not isinstance(flat[0], (int, float)):
                         continue
-                    val = sum(flat) / len(flat)
+                    log_dict[key] = (sum(flat), len(flat))
             elif isinstance(val, torch.Tensor):
-                val = val.float().mean()
+                log_dict[key] = (val.float().mean().item(), 1)
             else:
                 raise ValueError(f"Unsupported type: {type(val)} for key: {key}")
-            log_dict[key] = val.item() if isinstance(val, torch.Tensor) else val
 
         reduced_log_dict = gather_log_data("rollout", args, rollout_id, log_dict)
         if args.ci_test and not args.ci_disable_logprobs_checker and reduced_log_dict is not None:
@@ -284,8 +304,9 @@ def log_rollout_data(rollout_id: int, args: Namespace, rollout_data: RolloutBatc
             for p, val in correct_response_length_percentile.items():
                 rollout_data[f"correct_length/{p}"] = [val] * num_correct_responses
             if len(correct_entropy) > 0:
+                # per-sample mean over the correct subset, not per-rollout
                 sum_of_sample_mean = get_sum_of_sample_mean(
-                    correct_total_lengths, correct_response_lengths, correct_loss_masks
+                    correct_total_lengths, correct_response_lengths, correct_loss_masks, denominators=None
                 )
                 correct_entropy = sum_of_sample_mean(torch.cat(correct_entropy, dim=0))
                 rollout_data["correct_entropy"] = [correct_entropy.item()] * num_correct_responses
@@ -368,6 +389,7 @@ def log_cpu_memory(rollout_id: int, args: Namespace, label: str) -> None:
 
 def aggregate_train_losses(
     losses_reduced: list[dict[str, list[str] | torch.Tensor]],
+    num_rollouts: int | None = None,
 ) -> dict[str, float]:
     """Aggregate loss metrics across micro-batches.
 
@@ -377,7 +399,11 @@ def aggregate_train_losses(
     Args:
         losses_reduced: List of log_dict from each micro-batch.
             Each log_dict has format: {"keys": list[str], "values": torch.Tensor}
-        parallel_state: Parallel state containing dp_group and cp_size.
+        num_rollouts: report per-rollout means — divide every metric by this
+            step's rollout count (no CP factor; CP-chunked numerators reconstruct
+            exactly once under the DP*CP all-reduce). None keeps the legacy
+            reduction: divide by the all-reduced ``values[0]`` count, cancelled
+            by ``cp_size``.
 
     Returns:
         Dictionary mapping metric names to averaged values.
@@ -402,10 +428,15 @@ def aggregate_train_losses(
 
     loss_reduced = {}
     values = values.tolist()
-    num_samples_or_tokens = values[0]
+    if num_rollouts is not None:
+        num_samples_or_tokens = num_rollouts
+        cp_factor = 1
+    else:
+        num_samples_or_tokens = values[0]
+        cp_factor = parallel_state.cp.size
 
     for key, value in zip(keys, values[1:], strict=False):
-        loss_reduced[key] = value * parallel_state.cp.size / num_samples_or_tokens
+        loss_reduced[key] = value * cp_factor / num_samples_or_tokens
 
     return loss_reduced
 

--- a/miles/backends/training_utils/loss.py
+++ b/miles/backends/training_utils/loss.py
@@ -99,6 +99,7 @@ def loss_function(
     num_microbatches: int,
     logits: torch.Tensor,
     apply_megatron_loss_scaling: bool = False,
+    num_rollouts: int | None = None,
 ) -> tuple[torch.Tensor, int | torch.Tensor, dict[str, list[str] | torch.Tensor]]:
     """Dispatch to the configured loss and rescale for Megatron integration.
 
@@ -114,6 +115,8 @@ def loss_function(
             keys required by the selected loss function.
         num_microbatches: Number of gradient accumulation steps.
         logits: Model outputs (policy or value head).
+        num_rollouts: This step's rollout count (total across DP), used as
+            the loss normalizer; None falls back to the legacy batch/args value.
 
     Returns:
         Tuple of `(scaled_loss, normalizer, logging_dict)` where:
@@ -134,6 +137,7 @@ def loss_function(
         args.calculate_per_token_loss,
         args.qkv_format,
         batch.get("max_seq_lens", None),
+        denominators=batch.get("rollout_mask_sums", None),
     )
 
     func = get_loss_function(args)
@@ -154,8 +158,11 @@ def loss_function(
         loss = loss + 0 * logits.sum()
 
     # Here we need to divide by cp_size because to cancel the multiply in Megatron.
-    assert args.use_dynamic_global_batch_size == ("dynamic_global_batch_size" in batch)
-    global_batch_size = batch.get("dynamic_global_batch_size", args.global_batch_size)
+    if num_rollouts is not None:
+        global_batch_size = num_rollouts
+    else:
+        assert args.use_dynamic_global_batch_size == ("dynamic_global_batch_size" in batch)
+        global_batch_size = batch.get("dynamic_global_batch_size", args.global_batch_size)
     # Multi-LoRA: samples enter the gradient buffers with weight 1; per-adapter
     # normalization (1/adapter_global_batch_size, a constant known in advance)
     # is applied to the accumulated slot gradient at optimizer-step time.
@@ -181,10 +188,7 @@ def loss_function(
         {
             "keys": list(log.keys()),
             "values": torch.tensor(
-                [
-                    num_samples if not args.calculate_per_token_loss else num_tokens,
-                ]
-                + list(log.values()),
+                [num_samples if not args.calculate_per_token_loss else num_tokens] + list(log.values()),
                 device=logits.device,
             ),
         },

--- a/miles/backends/training_utils/loss_hub/losses.py
+++ b/miles/backends/training_utils/loss_hub/losses.py
@@ -232,8 +232,8 @@ def policy_loss_function(
             tis_func = vanilla_tis_function
         pg_loss, modified_response_masks, tis_metrics = tis_func(**tis_kwargs)
 
-        # [decouple IS and rejection] Rebuild sum_of_sample_mean with modified_response_masks for denominator correction
-        # modified_response_masks will be sliced with cp in get_sum_of_sample_mean
+        # [decouple IS and rejection] modified masks correct the numerator only;
+        # denominators stay the precomputed rollout_mask_sums.
         sum_of_sample_mean = get_sum_of_sample_mean(
             total_lengths,
             response_lengths,
@@ -241,6 +241,7 @@ def policy_loss_function(
             args.calculate_per_token_loss,
             args.qkv_format,
             max_seq_lens,
+            denominators=batch.get("rollout_mask_sums", None),
         )
 
     # Determine pg_loss reducer: use custom if specified, otherwise default

--- a/miles/ray/rollout/rollout_data_conversion.py
+++ b/miles/ray/rollout/rollout_data_conversion.py
@@ -2,12 +2,15 @@ import itertools
 import logging
 
 from miles.utils.multi_lora import is_multi_lora_enabled
+from miles.utils.types import Sample
 
 logger = logging.getLogger(__name__)
 
 
 def postprocess_rollout_data(args, data, train_parallel_config):
     metadata = {}
+
+    validate_compact_rollout_ids(data)
 
     # Multi-LoRA: record group boundaries (heterogeneous per-adapter group sizes)
     # and lift the collection loop's batch-level step decision out of sample metadata,
@@ -22,7 +25,11 @@ def postprocess_rollout_data(args, data, train_parallel_config):
     while isinstance(data[0], list):
         data = list(itertools.chain.from_iterable(data))
 
-    if not args.disable_rollout_trim_samples:
+    # Compact rollouts must not be trimmed by sample count; the schedule drops
+    # whole trailing rollouts instead.
+    is_compact = any(s.rollout_id is not None for s in data)
+
+    if not args.disable_rollout_trim_samples and not is_compact:
         global_batch_size = args.global_batch_size
         if args.use_dynamic_global_batch_size:
             logger.info(f"Collected {len(data)} samples from rollout to train with dynamic global batch size")
@@ -42,6 +49,27 @@ def postprocess_rollout_data(args, data, train_parallel_config):
         logger.info(f"Final collected {len(data)} samples from rollout to train")
 
     return data, metadata
+
+
+def validate_compact_rollout_ids(node, depth=0):
+    """Require compact leaves (``list[Sample]`` at depth >= 2, >1 sibling) to
+    share a non-None ``rollout_id``; default rollout shapes skip validation."""
+    if isinstance(node, Sample):
+        return
+    assert isinstance(node, list), f"unexpected rollout output node type: {type(node).__name__}"
+    if node and isinstance(node[0], Sample):
+        if depth >= 2 and len(node) > 1:
+            rids = [s.rollout_id for s in node]
+            missing = [i for i, r in enumerate(rids) if r is None]
+            assert not missing, (
+                f"Compact rollout returned {len(node)} samples but rollout_id is unset on "
+                f"positions {missing}. Set Sample.rollout_id on every sibling so the loss "
+                "reducer can aggregate them as one rollout instead of N."
+            )
+            assert len(set(rids)) == 1, f"Sibling samples from one compact rollout must share rollout_id; got {rids}."
+        return
+    for item in node:
+        validate_compact_rollout_ids(item, depth + 1)
 
 
 def _first_sample(group):

--- a/miles/ray/rollout/rollout_manager.py
+++ b/miles/ray/rollout/rollout_manager.py
@@ -156,7 +156,7 @@ class RolloutManager:
         if self.args.delay_split_train_data_by_dp:
             data_ref = object_store.get_instance().put(value=data, value_spec=ROLLOUT_DATA_VALUE_SPEC)
         else:
-            data_ref = split_train_data_by_dp(self.args, data, self.train_parallel_config["dp_size"])
+            data_ref = split_train_data_by_dp(self.args, data, self.train_parallel_config)
         return dict(sample_indices=sample_indices, data_ref=data_ref)
 
     async def eval(

--- a/miles/ray/rollout/train_data_conversion.py
+++ b/miles/ray/rollout/train_data_conversion.py
@@ -32,6 +32,8 @@ ROLLOUT_DATA_VALUE_SPEC: dict[str, ValueSpec] = {
     "truncated": ValueSpec(codec="ndarray", dtype="int64"),
     "round_number": ValueSpec(codec="ndarray", dtype="int64"),
     "sample_indices": ValueSpec(codec="ndarray", dtype="int64"),
+    "rollout_ids": ValueSpec(codec="ndarray", dtype="int64"),
+    "rollout_mask_sums": ValueSpec(codec="ndarray", dtype="int64"),
     "multimodal_train_inputs": ValueSpec(codec="ragged_tensor_dict"),
     "prompt": ValueSpec(codec="msgpack_ragged"),
     "metadata": ValueSpec(codec="msgpack_ragged"),
@@ -41,6 +43,7 @@ ROLLOUT_DATA_VALUE_SPEC: dict[str, ValueSpec] = {
     "dynamic_global_batch_size": ValueSpec(codec="auto"),
     "num_microbatches": ValueSpec(codec="auto"),
     "micro_batch_indices": ValueSpec(codec="auto"),
+    "num_rollouts": ValueSpec(codec="auto"),
 }
 
 
@@ -76,6 +79,7 @@ def convert_samples_to_train_data(
         "raw_reward": raw_rewards,
         "truncated": [1 if sample.status == Sample.Status.TRUNCATED else 0 for sample in samples],
         "sample_indices": [sample.index for sample in samples],
+        "rollout_ids": [s.rollout_id if s.rollout_id is not None else s.index for s in samples],
     }
 
     # loss mask
@@ -93,6 +97,8 @@ def convert_samples_to_train_data(
             sample.loss_mask = [0] * sample.response_length
         loss_masks.append(sample.loss_mask)
     train_data["loss_masks"] = loss_masks
+
+    train_data["rollout_mask_sums"] = _compute_rollout_mask_sums(train_data["rollout_ids"], loss_masks)
 
     # overwriting the raw reward
     if samples[0].metadata and "raw_reward" in samples[0].metadata:
@@ -151,6 +157,16 @@ def convert_samples_to_train_data(
         train_data["dynamic_global_batch_size"] = x
 
     return train_data
+
+
+def _compute_rollout_mask_sums(rollout_ids: list[int], loss_masks: list[list[int]]) -> list[int]:
+    """Whole-rollout loss-mask total per sample: every sibling of one rollout carries
+    the sum over all of that rollout's samples, so the loss reducer reconstructs one
+    token-weighted mean per rollout even when siblings land in different micro-batches."""
+    totals: dict[int, int] = {}
+    for rid, mask in zip(rollout_ids, loss_masks, strict=True):
+        totals[rid] = totals.get(rid, 0) + sum(mask)
+    return [totals[rid] for rid in rollout_ids]
 
 
 def _post_process_rewards(
@@ -222,8 +238,10 @@ def can_schedule_on_rollout_side(args, data: dict[str, Any], train_parallel_conf
         return False
     if "multimodal_train_inputs" in data:
         return False
+    if "rollout_ids" not in data:
+        return False
     global_batch_size = data.get("dynamic_global_batch_size", args.global_batch_size)
-    return len(data["tokens"]) % global_batch_size == 0
+    return len(set(data["rollout_ids"])) >= global_batch_size
 
 
 def split_train_data_by_dp_scheduled_raw(
@@ -234,21 +252,23 @@ def split_train_data_by_dp_scheduled_raw(
     data["total_lengths"] = total_lengths
 
     global_batch_size = data.get("dynamic_global_batch_size", args.global_batch_size)
-    partitions, micro_batch_indices, num_microbatches = build_dp_schedule(
+    partitions, micro_batch_indices, num_microbatches, num_rollouts = build_dp_schedule(
         args,
         train_parallel_config,
         total_lengths,
         global_batch_size=global_batch_size,
+        rollout_indices=data["rollout_ids"],
     )
     logger.info(
         f"Rollout-side DP schedule: num_samples={len(total_lengths)}, "
-        f"global_batch_size={global_batch_size}, num_microbatches={num_microbatches}"
+        f"num_rollouts={num_rollouts}, num_microbatches={num_microbatches}"
     )
 
     shards = _package_shards(args, data, partitions)
     for rank, shard in enumerate(shards):
         shard["num_microbatches"] = num_microbatches
         shard["micro_batch_indices"] = micro_batch_indices[rank]
+        shard["num_rollouts"] = num_rollouts
     return shards
 
 
@@ -288,6 +308,8 @@ def _package_shards(args, data: dict[str, Any], partitions) -> list[dict[str, An
             "loss_masks",
             "round_number",
             "sample_indices",
+            "rollout_ids",
+            "rollout_mask_sums",
             "rollout_log_probs",
             "rollout_routed_experts",
             "rollout_indexer_topk",

--- a/miles/ray/rollout/train_data_conversion.py
+++ b/miles/ray/rollout/train_data_conversion.py
@@ -1,12 +1,17 @@
+import logging
 from typing import Any
 
 import torch
 
 from miles.utils import object_store
+from miles.utils.dp_schedule import build_dp_schedule, has_full_schedule_config
+from miles.utils.multi_lora import is_multi_lora_enabled
 from miles.utils.object_store import ValueSpec
 from miles.utils.seqlen_balancing import get_seqlen_balanced_partitions
 from miles.utils.timer import Timer
 from miles.utils.types import Sample
+
+logger = logging.getLogger(__name__)
 
 ROLLOUT_DATA_TENSOR_DTYPES = {
     "tokens": "int32",
@@ -34,6 +39,8 @@ ROLLOUT_DATA_VALUE_SPEC: dict[str, ValueSpec] = {
     "raw_reward": ValueSpec(codec="auto"),
     "total_lengths": ValueSpec(codec="auto"),
     "dynamic_global_batch_size": ValueSpec(codec="auto"),
+    "num_microbatches": ValueSpec(codec="auto"),
+    "micro_batch_indices": ValueSpec(codec="auto"),
 }
 
 
@@ -193,11 +200,56 @@ def _post_process_rewards(
     return raw_rewards, raw_rewards
 
 
-def split_train_data_by_dp(args, data, dp_size):
-    """Split the train data by data parallel size."""
-    rollout_data_list = split_train_data_by_dp_raw(args, data, dp_size=dp_size)
+def split_train_data_by_dp(args, data: dict[str, Any], train_parallel_config: dict | None):
+    """Split the train data across DP ranks and put the shards into the object store.
+
+    When the training backend can consume a rollout-side schedule, the shards
+    also carry the precomputed micro-batch layout; otherwise this falls back to
+    the legacy split (the training side schedules locally)."""
+    if can_schedule_on_rollout_side(args, data, train_parallel_config):
+        shards = split_train_data_by_dp_scheduled_raw(args, data, train_parallel_config=train_parallel_config)
+    else:
+        shards = split_train_data_by_dp_raw(args, data, dp_size=train_parallel_config["dp_size"])
     store = object_store.get_instance()
-    return [store.put(value=rollout_data, value_spec=ROLLOUT_DATA_VALUE_SPEC) for rollout_data in rollout_data_list]
+    return [store.put(value=shard, value_spec=ROLLOUT_DATA_VALUE_SPEC) for shard in shards]
+
+
+def can_schedule_on_rollout_side(args, data: dict[str, Any], train_parallel_config: dict | None) -> bool:
+    """Whether the rollout side can precompute the full DP/mbs schedule."""
+    if not has_full_schedule_config(train_parallel_config):
+        return False
+    if is_multi_lora_enabled(args):
+        return False
+    if "multimodal_train_inputs" in data:
+        return False
+    global_batch_size = data.get("dynamic_global_batch_size", args.global_batch_size)
+    return len(data["tokens"]) % global_batch_size == 0
+
+
+def split_train_data_by_dp_scheduled_raw(
+    args, data: dict[str, Any], *, train_parallel_config: dict
+) -> list[dict[str, Any]]:
+    """DP split with the micro-batch schedule precomputed on the rollout side."""
+    total_lengths = [len(t) for t in data["tokens"]]
+    data["total_lengths"] = total_lengths
+
+    global_batch_size = data.get("dynamic_global_batch_size", args.global_batch_size)
+    partitions, micro_batch_indices, num_microbatches = build_dp_schedule(
+        args,
+        train_parallel_config,
+        total_lengths,
+        global_batch_size=global_batch_size,
+    )
+    logger.info(
+        f"Rollout-side DP schedule: num_samples={len(total_lengths)}, "
+        f"global_batch_size={global_batch_size}, num_microbatches={num_microbatches}"
+    )
+
+    shards = _package_shards(args, data, partitions)
+    for rank, shard in enumerate(shards):
+        shard["num_microbatches"] = num_microbatches
+        shard["micro_batch_indices"] = micro_batch_indices[rank]
+    return shards
 
 
 def split_train_data_by_dp_raw(args, data: dict[str, Any], *, dp_size: int) -> list[dict[str, Any]]:
@@ -216,9 +268,14 @@ def split_train_data_by_dp_raw(args, data: dict[str, Any], *, dp_size: int) -> l
     if adapter_slots is not None:
         partitions = [sorted(p, key=lambda i: adapter_slots[i]) for p in partitions]
 
+    return _package_shards(args, data, partitions)
+
+
+def _package_shards(args, data: dict[str, Any], partitions) -> list[dict[str, Any]]:
+    """Package one rollout_data shard per DP rank from precomputed partitions."""
     shards = []
 
-    for i in range(dp_size):
+    for i in range(len(partitions)):
         rollout_data = {}
         partition = partitions[i]
         rollout_data["partition"] = partition

--- a/miles/rollout/generate_utils/sample_utils.py
+++ b/miles/rollout/generate_utils/sample_utils.py
@@ -146,6 +146,7 @@ def _merge_sample_pair(a: Sample, b: Sample, tokenizer) -> Sample:
             Sample,
             group_index=_merge_equal_value("group_index"),
             index=_merge_equal_value("index"),
+            rollout_id=_merge_equal_value("rollout_id"),
             prompt=b.prompt,
             tokens=b.tokens,
             multimodal_inputs=_merge_equal_value("multimodal_inputs"),

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -1038,6 +1038,28 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
             )
 
             parser.add_argument(
+                "--balance-by-flops",
+                action="store_true",
+                default=False,
+                help=(
+                    "Use FLOPs-based workload estimation for micro-batch partitioning via "
+                    "Karmarkar-Karp instead of first-fit token packing, and distribute mbs "
+                    "across DP ranks by FLOPs. Captures the quadratic attention cost when "
+                    "sequence lengths vary widely. Requires --use-dynamic-batch-size. NOTE: "
+                    "FLOPs balancing does not enforce the per-mbs token cap."
+                ),
+            )
+            parser.add_argument(
+                "--allow-partial-train-step",
+                action="store_true",
+                default=False,
+                help=(
+                    "Train the trailing rollouts that don't fill a whole global_batch_size step as one "
+                    "smaller final step instead of dropping them (rollout-side schedule + dynamic batch "
+                    "size only). Loss normalization and the LR scheduler use the true per-step count."
+                ),
+            )
+            parser.add_argument(
                 "--use-dynamic-batch-size",
                 action="store_true",
                 default=False,
@@ -2920,6 +2942,9 @@ def miles_validate_args(args):
         assert args.max_tokens_per_gpu is not None, "max_tokens_per_gpu must be set when use_dynamic_batch_size is set"
         if args.log_probs_max_tokens_per_gpu is None:
             args.log_probs_max_tokens_per_gpu = args.max_tokens_per_gpu
+
+    if getattr(args, "balance_by_flops", False):
+        assert args.use_dynamic_batch_size, "--balance-by-flops requires --use-dynamic-batch-size"
 
     if args.eps_clip_high is None:
         args.eps_clip_high = args.eps_clip

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -2943,6 +2943,20 @@ def miles_validate_args(args):
         if args.log_probs_max_tokens_per_gpu is None:
             args.log_probs_max_tokens_per_gpu = args.max_tokens_per_gpu
 
+    # --use-dynamic-global-batch-size has two motivations:
+    # 1. compaction/subagent rollouts: static micro-batching cannot guarantee alignment
+    #    when the physical sample count is data-dependent, so --use-dynamic-batch-size
+    #    is required.
+    # 2. multi-LoRA (auto-enabled, no compaction/subagent): the per-round sample count is
+    #    a config-shaped multiple of dp_size trained as exactly one step on the legacy
+    #    training-side schedule; static micro-batching stays valid there.
+    if args.use_dynamic_global_batch_size and not args.multi_lora:
+        assert args.use_dynamic_batch_size, (
+            "--use-dynamic-global-batch-size requires --use-dynamic-batch-size (with --max-tokens-per-gpu): "
+            "static micro-batching cannot guarantee dp_size * mb_group alignment when the physical sample count "
+            "is data-dependent; this configuration is not supported."
+        )
+
     if getattr(args, "balance_by_flops", False):
         assert args.use_dynamic_batch_size, "--balance-by-flops requires --use-dynamic-batch-size"
 

--- a/miles/utils/dp_schedule.py
+++ b/miles/utils/dp_schedule.py
@@ -1,0 +1,81 @@
+"""Per-rollout DP/microbatch scheduling, computed on the rollout side."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from miles.utils.seqlen_balancing import expand_bins_by_splitting, first_fit_pack, get_seqlen_balanced_partitions
+
+SCHEDULE_CONFIG_KEYS = ("dp_size", "cp_size", "vpp_size", "microbatch_group_size_per_vp_stage")
+
+
+def has_full_schedule_config(train_parallel_config: dict | None) -> bool:
+    """True when the backend advertised every field build_dp_schedule needs."""
+    if not train_parallel_config:
+        return False
+    return all(key in train_parallel_config for key in SCHEDULE_CONFIG_KEYS)
+
+
+def build_dp_schedule(
+    args: Any,
+    train_parallel_config: dict,
+    total_lengths: list[int],
+    *,
+    global_batch_size: int,
+) -> tuple[list[list[int]], list[list[list[int]]], list[int]]:
+    """Compute per-rank ``(partitions, micro_batch_indices, num_microbatches)``."""
+    dp_size = train_parallel_config["dp_size"]
+    cp_size = train_parallel_config["cp_size"]
+    vpp_size = train_parallel_config["vpp_size"] or 1
+    mb_group = train_parallel_config["microbatch_group_size_per_vp_stage"]
+
+    assert len(total_lengths) % global_batch_size == 0, (
+        f"num_samples ({len(total_lengths)}) is not a multiple of global_batch_size "
+        f"({global_batch_size}); trim upstream before scheduling."
+    )
+    num_steps = len(total_lengths) // global_batch_size
+
+    if args.use_dynamic_batch_size:
+        assert args.max_tokens_per_gpu is not None
+        max_per_bin = args.max_tokens_per_gpu * cp_size
+
+    partitions: list[list[int]] = [[] for _ in range(dp_size)]
+    micro_batch_indices: list[list[list[int]]] = [[] for _ in range(dp_size)]
+    num_microbatches: list[int] = []
+
+    for step_i in range(num_steps):
+        step_start = step_i * global_batch_size
+        step_lengths = total_lengths[step_start : step_start + global_batch_size]
+
+        if args.balance_data:
+            rank_parts = get_seqlen_balanced_partitions(step_lengths, dp_size, equal_size=True)
+        else:
+            rank_parts = [list(range(r, global_batch_size, dp_size)) for r in range(dp_size)]
+
+        if not args.use_dynamic_batch_size:
+            mbs = args.micro_batch_size
+            n = len(rank_parts[0])  # gbs / dp, same for every rank
+            assert n % mbs == 0, (
+                f"per-rank batch ({n} = global_batch_size {global_batch_size} / dp_size {dp_size}) "
+                f"is not a multiple of micro_batch_size ({mbs})"
+            )
+            rank_mbs = [[list(range(i, i + mbs)) for i in range(0, n, mbs)] for _ in range(dp_size)]
+            num_mbs_per_rank = n // mbs
+        else:
+            rank_lens = [[step_lengths[i] for i in rank_parts[r]] for r in range(dp_size)]
+            rank_mbs = [first_fit_pack(rank_lens[r], max_per_bin) for r in range(dp_size)]
+            num_mbs_per_rank = max(len(b) for b in rank_mbs)
+            if vpp_size > 1:
+                num_mbs_per_rank = max(num_mbs_per_rank // mb_group * mb_group, 1)
+            for r in range(dp_size):
+                expand_bins_by_splitting(rank_mbs[r], num_mbs_per_rank, rank_lens[r])
+
+        num_microbatches.append(num_mbs_per_rank)
+
+        for r in range(dp_size):
+            for mbs_local in rank_mbs[r]:
+                local_start = len(partitions[r])
+                partitions[r].extend(step_start + rank_parts[r][i] for i in mbs_local)
+                micro_batch_indices[r].append(list(range(local_start, local_start + len(mbs_local))))
+
+    return partitions, micro_batch_indices, num_microbatches

--- a/miles/utils/dp_schedule.py
+++ b/miles/utils/dp_schedule.py
@@ -39,15 +39,15 @@ def build_dp_schedule(
     vpp_size = train_parallel_config["vpp_size"] or 1
     mb_group = train_parallel_config["microbatch_group_size_per_vp_stage"]
 
-    # mbs count per step must divide evenly across ranks and, under VPP, mb groups.
+    # micro-batch count per step must divide evenly across ranks and, under VPP, mb groups.
     align_to = dp_size * (mb_group if vpp_size > 1 else 1)
 
     # Group sample positions by rollout id (first-occurrence order) so a rollout's
     # samples always land in the same training step.
-    rollout_to_samples: dict[int, list[int]] = {}
+    rollout_id_to_sample_index: dict[int, list[int]] = {}
     for sample_pos, rid in enumerate(rollout_indices):
-        rollout_to_samples.setdefault(rid, []).append(sample_pos)
-    rollout_ids = list(rollout_to_samples.keys())
+        rollout_id_to_sample_index.setdefault(rid, []).append(sample_pos)
+    rollout_ids = list(rollout_id_to_sample_index.keys())
 
     # Plan the rollout count of each training step: full steps of global_batch_size,
     # plus (under --allow-partial-train-step) one smaller final step for the trailing
@@ -60,7 +60,7 @@ def build_dp_schedule(
     num_rollouts = [global_batch_size] * num_full_steps
     leftover = len(rollout_ids) - num_full_steps * global_batch_size
     if leftover and getattr(args, "allow_partial_train_step", False) and args.use_dynamic_batch_size:
-        leftover_samples = sum(len(rollout_to_samples[rid]) for rid in rollout_ids[-leftover:])
+        leftover_samples = sum(len(rollout_id_to_sample_index[rid]) for rid in rollout_ids[-leftover:])
         if leftover_samples >= dp_size:
             num_rollouts.append(leftover)
         else:
@@ -72,68 +72,70 @@ def build_dp_schedule(
 
     step_start = 0
     for step_num_rollouts in num_rollouts:
-        step_rollouts = rollout_ids[step_start : step_start + step_num_rollouts]
+        picked_rollouts = rollout_ids[step_start : step_start + step_num_rollouts]
         step_start += step_num_rollouts
-        sample_indices = [pos for rid in step_rollouts for pos in rollout_to_samples[rid]]
+        sample_indices = [pos for rid in picked_rollouts for pos in rollout_id_to_sample_index[rid]]
         step_lengths = [total_lengths[i] for i in sample_indices]
         assert len(sample_indices) >= dp_size, (
             f"step of {step_num_rollouts} rollouts has {len(sample_indices)} samples < dp_size {dp_size}; "
             f"each step needs at least one sample per rank."
         )
 
-        # Pack the step's samples into micro-batches; step_mbs[k] holds local
+        # Pack the step's samples into micro-batches; step_micro_batches[k] holds local
         # indices into step_lengths.
         workloads = None
         if not args.use_dynamic_batch_size:
             assert args.micro_batch_size is not None
             n = len(step_lengths)
-            step_mbs = [list(range(i, min(i + args.micro_batch_size, n))) for i in range(0, n, args.micro_batch_size)]
+            step_micro_batches = [
+                list(range(i, min(i + args.micro_batch_size, n))) for i in range(0, n, args.micro_batch_size)
+            ]
         elif getattr(args, "balance_by_flops", False):
             assert args.max_tokens_per_gpu is not None
             max_per_bin = args.max_tokens_per_gpu * cp_size
             workloads = [calculate_fwd_flops([length], args) for length in step_lengths]
-            num_mbs = max(1, (sum(step_lengths) + max_per_bin - 1) // max_per_bin)
-            if num_mbs >= len(step_lengths):
-                step_mbs = [[i] for i in range(len(step_lengths))]
+            micro_batch_count = max(1, (sum(step_lengths) + max_per_bin - 1) // max_per_bin)
+            if micro_batch_count >= len(step_lengths):
+                step_micro_batches = [[i] for i in range(len(step_lengths))]
             else:
-                # NOTE: FLOPs balancing does not enforce the token cap per mbs.
-                step_mbs = get_seqlen_balanced_partitions(workloads, num_mbs, equal_size=False)
+                # NOTE: FLOPs balancing does not enforce the token cap per micro-batch.
+                step_micro_batches = get_seqlen_balanced_partitions(workloads, micro_batch_count, equal_size=False)
         else:
             assert args.max_tokens_per_gpu is not None
-            step_mbs = first_fit_decreasing_pack(step_lengths, args.max_tokens_per_gpu * cp_size)
+            step_micro_batches = first_fit_decreasing_pack(step_lengths, args.max_tokens_per_gpu * cp_size)
 
-        # Grow the mbs count to a multiple of align_to by splitting multi-sample mbs.
-        target = max((len(step_mbs) + align_to - 1) // align_to * align_to, align_to)
-        if target != len(step_mbs):
+        # Grow the micro-batch count to a multiple of align_to by splitting multi-sample micro-batches.
+        target = max((len(step_micro_batches) + align_to - 1) // align_to * align_to, align_to)
+        if target != len(step_micro_batches):
             if not args.use_dynamic_batch_size:
                 raise AssertionError(
-                    f"static path: num_mbs ({len(step_mbs)}) is not a multiple of {align_to}; "
+                    f"static path: micro-batch count ({len(step_micro_batches)}) is not a multiple of {align_to}; "
                     f"adjust the config so step_size % (dp_size * micro_batch_size * mb_group) == 0."
                 )
-            expand_bins_by_splitting(step_mbs, target, step_lengths)
+            expand_bins_by_splitting(step_micro_batches, target, step_lengths)
             assert (
-                len(step_mbs) == target
-            ), f"could only produce {len(step_mbs)} mbs after maximal splitting; need {target}."
+                len(step_micro_batches) == target
+            ), f"could only produce {len(step_micro_batches)} micro-batches after maximal splitting; need {target}."
 
-        num_microbatches.append(len(step_mbs) // dp_size)
+        num_microbatches.append(len(step_micro_batches) // dp_size)
 
-        # Distribute the mbs across DP ranks, len(step_mbs) / dp_size each: strided
-        # round-robin, or Karmarkar-Karp on mbs weights (tokens under --balance-data,
+        # Distribute the micro-batches across DP ranks, len(step_micro_batches) / dp_size each: strided
+        # round-robin, or Karmarkar-Karp on micro-batch weights (tokens under --balance-data,
         # FLOPs under --balance-by-flops).
         if args.balance_data or getattr(args, "balance_by_flops", False):
             if workloads is not None:
-                weights = [sum(workloads[i] for i in mbs) for mbs in step_mbs]
+                weights = [sum(workloads[i] for i in micro_batch) for micro_batch in step_micro_batches]
             else:
-                weights = [sum(step_lengths[i] for i in mbs) for mbs in step_mbs]
-            rank_mbs_idx = get_seqlen_balanced_partitions(weights, dp_size, equal_size=True)
+                weights = [sum(step_lengths[i] for i in micro_batch) for micro_batch in step_micro_batches]
+            rank_micro_batch_ids = get_seqlen_balanced_partitions(weights, dp_size, equal_size=True)
         else:
-            rank_mbs_idx = [list(range(rank, len(step_mbs), dp_size)) for rank in range(dp_size)]
+            rank_micro_batch_ids = [list(range(rank, len(step_micro_batches), dp_size)) for rank in range(dp_size)]
 
-        for rank, mbs_idx in enumerate(rank_mbs_idx):
-            for k in mbs_idx:
-                mbs = step_mbs[k]
+        for rank, micro_batch_ids in enumerate(rank_micro_batch_ids):
+            for k in micro_batch_ids:
+                micro_batch = step_micro_batches[k]
                 local_start = len(partitions[rank])
-                partitions[rank].extend(sample_indices[i] for i in mbs)
-                micro_batch_indices[rank].append(list(range(local_start, local_start + len(mbs))))
+                partitions[rank].extend(sample_indices[i] for i in micro_batch)
+                micro_batch_indices[rank].append(list(range(local_start, local_start + len(micro_batch))))
 
     return partitions, micro_batch_indices, num_microbatches, num_rollouts

--- a/miles/utils/dp_schedule.py
+++ b/miles/utils/dp_schedule.py
@@ -1,10 +1,18 @@
-"""Per-rollout DP/microbatch scheduling, computed on the rollout side."""
+"""Per-rollout DP/microbatch scheduling (pack first, distribute second), computed on the rollout side."""
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
-from miles.utils.seqlen_balancing import expand_bins_by_splitting, first_fit_pack, get_seqlen_balanced_partitions
+from miles.utils.flops_utils import calculate_fwd_flops
+from miles.utils.seqlen_balancing import (
+    expand_bins_by_splitting,
+    first_fit_decreasing_pack,
+    get_seqlen_balanced_partitions,
+)
+
+logger = logging.getLogger(__name__)
 
 SCHEDULE_CONFIG_KEYS = ("dp_size", "cp_size", "vpp_size", "microbatch_group_size_per_vp_stage")
 
@@ -22,60 +30,110 @@ def build_dp_schedule(
     total_lengths: list[int],
     *,
     global_batch_size: int,
-) -> tuple[list[list[int]], list[list[list[int]]], list[int]]:
-    """Compute per-rank ``(partitions, micro_batch_indices, num_microbatches)``."""
+    rollout_indices: list[int],
+) -> tuple[list[list[int]], list[list[list[int]]], list[int], list[int]]:
+    """Compute per-rank ``(partitions, micro_batch_indices, num_microbatches, num_rollouts)``;
+    ``global_batch_size`` counts rollouts, not training samples."""
     dp_size = train_parallel_config["dp_size"]
     cp_size = train_parallel_config["cp_size"]
     vpp_size = train_parallel_config["vpp_size"] or 1
     mb_group = train_parallel_config["microbatch_group_size_per_vp_stage"]
 
-    assert len(total_lengths) % global_batch_size == 0, (
-        f"num_samples ({len(total_lengths)}) is not a multiple of global_batch_size "
-        f"({global_batch_size}); trim upstream before scheduling."
-    )
-    num_steps = len(total_lengths) // global_batch_size
+    # mbs count per step must divide evenly across ranks and, under VPP, mb groups.
+    align_to = dp_size * (mb_group if vpp_size > 1 else 1)
 
-    if args.use_dynamic_batch_size:
-        assert args.max_tokens_per_gpu is not None
-        max_per_bin = args.max_tokens_per_gpu * cp_size
+    # Group sample positions by rollout id (first-occurrence order) so a rollout's
+    # samples always land in the same training step.
+    rollout_to_samples: dict[int, list[int]] = {}
+    for sample_pos, rid in enumerate(rollout_indices):
+        rollout_to_samples.setdefault(rid, []).append(sample_pos)
+    rollout_ids = list(rollout_to_samples.keys())
+
+    # Plan the rollout count of each training step: full steps of global_batch_size,
+    # plus (under --allow-partial-train-step) one smaller final step for the trailing
+    # rollouts that would otherwise be dropped.
+    num_full_steps = len(rollout_ids) // global_batch_size
+    assert num_full_steps >= 1, (
+        f"total rollouts ({len(rollout_ids)}) < global_batch_size ({global_batch_size}); "
+        f"need at least one rollout per step."
+    )
+    num_rollouts = [global_batch_size] * num_full_steps
+    leftover = len(rollout_ids) - num_full_steps * global_batch_size
+    if leftover and getattr(args, "allow_partial_train_step", False) and args.use_dynamic_batch_size:
+        leftover_samples = sum(len(rollout_to_samples[rid]) for rid in rollout_ids[-leftover:])
+        if leftover_samples >= dp_size:
+            num_rollouts.append(leftover)
+        else:
+            logger.info(f"partial step skipped: {leftover_samples} samples < dp_size {dp_size}")
 
     partitions: list[list[int]] = [[] for _ in range(dp_size)]
     micro_batch_indices: list[list[list[int]]] = [[] for _ in range(dp_size)]
     num_microbatches: list[int] = []
 
-    for step_i in range(num_steps):
-        step_start = step_i * global_batch_size
-        step_lengths = total_lengths[step_start : step_start + global_batch_size]
+    step_start = 0
+    for step_num_rollouts in num_rollouts:
+        step_rollouts = rollout_ids[step_start : step_start + step_num_rollouts]
+        step_start += step_num_rollouts
+        sample_indices = [pos for rid in step_rollouts for pos in rollout_to_samples[rid]]
+        step_lengths = [total_lengths[i] for i in sample_indices]
+        assert len(sample_indices) >= dp_size, (
+            f"step of {step_num_rollouts} rollouts has {len(sample_indices)} samples < dp_size {dp_size}; "
+            f"each step needs at least one sample per rank."
+        )
 
-        if args.balance_data:
-            rank_parts = get_seqlen_balanced_partitions(step_lengths, dp_size, equal_size=True)
-        else:
-            rank_parts = [list(range(r, global_batch_size, dp_size)) for r in range(dp_size)]
-
+        # Pack the step's samples into micro-batches; step_mbs[k] holds local
+        # indices into step_lengths.
+        workloads = None
         if not args.use_dynamic_batch_size:
-            mbs = args.micro_batch_size
-            n = len(rank_parts[0])  # gbs / dp, same for every rank
-            assert n % mbs == 0, (
-                f"per-rank batch ({n} = global_batch_size {global_batch_size} / dp_size {dp_size}) "
-                f"is not a multiple of micro_batch_size ({mbs})"
-            )
-            rank_mbs = [[list(range(i, i + mbs)) for i in range(0, n, mbs)] for _ in range(dp_size)]
-            num_mbs_per_rank = n // mbs
+            assert args.micro_batch_size is not None
+            n = len(step_lengths)
+            step_mbs = [list(range(i, min(i + args.micro_batch_size, n))) for i in range(0, n, args.micro_batch_size)]
+        elif getattr(args, "balance_by_flops", False):
+            assert args.max_tokens_per_gpu is not None
+            max_per_bin = args.max_tokens_per_gpu * cp_size
+            workloads = [calculate_fwd_flops([length], args) for length in step_lengths]
+            num_mbs = max(1, (sum(step_lengths) + max_per_bin - 1) // max_per_bin)
+            if num_mbs >= len(step_lengths):
+                step_mbs = [[i] for i in range(len(step_lengths))]
+            else:
+                # NOTE: FLOPs balancing does not enforce the token cap per mbs.
+                step_mbs = get_seqlen_balanced_partitions(workloads, num_mbs, equal_size=False)
         else:
-            rank_lens = [[step_lengths[i] for i in rank_parts[r]] for r in range(dp_size)]
-            rank_mbs = [first_fit_pack(rank_lens[r], max_per_bin) for r in range(dp_size)]
-            num_mbs_per_rank = max(len(b) for b in rank_mbs)
-            if vpp_size > 1:
-                num_mbs_per_rank = max(num_mbs_per_rank // mb_group * mb_group, 1)
-            for r in range(dp_size):
-                expand_bins_by_splitting(rank_mbs[r], num_mbs_per_rank, rank_lens[r])
+            assert args.max_tokens_per_gpu is not None
+            step_mbs = first_fit_decreasing_pack(step_lengths, args.max_tokens_per_gpu * cp_size)
 
-        num_microbatches.append(num_mbs_per_rank)
+        # Grow the mbs count to a multiple of align_to by splitting multi-sample mbs.
+        target = max((len(step_mbs) + align_to - 1) // align_to * align_to, align_to)
+        if target != len(step_mbs):
+            if not args.use_dynamic_batch_size:
+                raise AssertionError(
+                    f"static path: num_mbs ({len(step_mbs)}) is not a multiple of {align_to}; "
+                    f"adjust the config so step_size % (dp_size * micro_batch_size * mb_group) == 0."
+                )
+            expand_bins_by_splitting(step_mbs, target, step_lengths)
+            assert (
+                len(step_mbs) == target
+            ), f"could only produce {len(step_mbs)} mbs after maximal splitting; need {target}."
 
-        for r in range(dp_size):
-            for mbs_local in rank_mbs[r]:
-                local_start = len(partitions[r])
-                partitions[r].extend(step_start + rank_parts[r][i] for i in mbs_local)
-                micro_batch_indices[r].append(list(range(local_start, local_start + len(mbs_local))))
+        num_microbatches.append(len(step_mbs) // dp_size)
 
-    return partitions, micro_batch_indices, num_microbatches
+        # Distribute the mbs across DP ranks, len(step_mbs) / dp_size each: strided
+        # round-robin, or Karmarkar-Karp on mbs weights (tokens under --balance-data,
+        # FLOPs under --balance-by-flops).
+        if args.balance_data or getattr(args, "balance_by_flops", False):
+            if workloads is not None:
+                weights = [sum(workloads[i] for i in mbs) for mbs in step_mbs]
+            else:
+                weights = [sum(step_lengths[i] for i in mbs) for mbs in step_mbs]
+            rank_mbs_idx = get_seqlen_balanced_partitions(weights, dp_size, equal_size=True)
+        else:
+            rank_mbs_idx = [list(range(rank, len(step_mbs), dp_size)) for rank in range(dp_size)]
+
+        for rank, mbs_idx in enumerate(rank_mbs_idx):
+            for k in mbs_idx:
+                mbs = step_mbs[k]
+                local_start = len(partitions[rank])
+                partitions[rank].extend(sample_indices[i] for i in mbs)
+                micro_batch_indices[rank].append(list(range(local_start, local_start + len(mbs))))
+
+    return partitions, micro_batch_indices, num_microbatches, num_rollouts

--- a/miles/utils/dp_schedule.py
+++ b/miles/utils/dp_schedule.py
@@ -24,6 +24,10 @@ def has_full_schedule_config(train_parallel_config: dict | None) -> bool:
     return all(key in train_parallel_config for key in SCHEDULE_CONFIG_KEYS)
 
 
+def _calculate_workloads(step_lengths, args):
+    return [calculate_fwd_flops([sl], args) for sl in step_lengths]
+
+
 def build_dp_schedule(
     args: Any,
     train_parallel_config: dict,
@@ -39,11 +43,16 @@ def build_dp_schedule(
     vpp_size = train_parallel_config["vpp_size"] or 1
     mb_group = train_parallel_config["microbatch_group_size_per_vp_stage"]
 
-    # micro-batch count per step must divide evenly across ranks and, under VPP, mb groups.
+    # micro-batch size per step must divide evenly across dp and vpp
     align_to = dp_size * (mb_group if vpp_size > 1 else 1)
 
-    # Group sample positions by rollout id (first-occurrence order) so a rollout's
-    # samples always land in the same training step.
+    max_per_bin = None
+    if args.use_dynamic_batch_size:
+        assert args.max_tokens_per_gpu is not None
+        max_per_bin = args.max_tokens_per_gpu * cp_size
+
+    # Rollout can include multiple samples (compaction, subagent, fork, etc.)
+    # Samples in the same rollout should be trained in the same step, or dropped together.
     rollout_id_to_sample_index: dict[int, list[int]] = {}
     for sample_pos, rid in enumerate(rollout_indices):
         rollout_id_to_sample_index.setdefault(rid, []).append(sample_pos)
@@ -71,7 +80,7 @@ def build_dp_schedule(
     num_microbatches: list[int] = []
 
     step_start = 0
-    for step_num_rollouts in num_rollouts:
+    for step_i, step_num_rollouts in enumerate(num_rollouts):
         picked_rollouts = rollout_ids[step_start : step_start + step_num_rollouts]
         step_start += step_num_rollouts
         sample_indices = [pos for rid in picked_rollouts for pos in rollout_id_to_sample_index[rid]]
@@ -81,49 +90,54 @@ def build_dp_schedule(
             f"each step needs at least one sample per rank."
         )
 
-        # Pack the step's samples into micro-batches; step_micro_batches[k] holds local
-        # indices into step_lengths.
-        workloads = None
-        if not args.use_dynamic_batch_size:
+        balance_by_flops = getattr(args, "balance_by_flops", False)
+        # Shared by FLOPs-balanced packing and FLOPs-balanced distribution below.
+        workloads = _calculate_workloads(step_lengths, args) if balance_by_flops else None
+        if args.use_dynamic_batch_size:
+            # Pack under the token budget: first-fit, or FLOPs-balanced partitions under
+            # --balance-by-flops (which does not enforce the token cap per micro-batch).
+            if balance_by_flops:
+                total_tokens = sum(step_lengths)
+                micro_batch_count = max(1, (total_tokens + max_per_bin - 1) // max_per_bin)
+                if micro_batch_count >= len(step_lengths):
+                    step_micro_batches = [[i] for i in range(len(step_lengths))]
+                else:
+                    step_micro_batches = get_seqlen_balanced_partitions(workloads, micro_batch_count, equal_size=False)
+            else:
+                step_micro_batches = first_fit_decreasing_pack(step_lengths, max_per_bin)
+            # Grow the micro-batch count to a multiple of align_to by splitting multi-sample micro-batches.
+            target = max((len(step_micro_batches) + align_to - 1) // align_to * align_to, align_to)
+            if target != len(step_micro_batches):
+                expand_bins_by_splitting(step_micro_batches, target, step_lengths)
+                assert len(step_micro_batches) == target, (
+                    f"dynamic path: could only produce {len(step_micro_batches)} micro-batches after maximal "
+                    f"splitting; need {target}. step {step_i} has {len(sample_indices)} samples, below the "
+                    f"alignment threshold ({align_to})."
+                )
+        else:
+            # Fixed-size chunks of micro_batch_size samples.
             assert args.micro_batch_size is not None
             n = len(step_lengths)
             step_micro_batches = [
                 list(range(i, min(i + args.micro_batch_size, n))) for i in range(0, n, args.micro_batch_size)
             ]
-        elif getattr(args, "balance_by_flops", False):
-            assert args.max_tokens_per_gpu is not None
-            max_per_bin = args.max_tokens_per_gpu * cp_size
-            workloads = [calculate_fwd_flops([length], args) for length in step_lengths]
-            micro_batch_count = max(1, (sum(step_lengths) + max_per_bin - 1) // max_per_bin)
-            if micro_batch_count >= len(step_lengths):
-                step_micro_batches = [[i] for i in range(len(step_lengths))]
-            else:
-                # NOTE: FLOPs balancing does not enforce the token cap per micro-batch.
-                step_micro_batches = get_seqlen_balanced_partitions(workloads, micro_batch_count, equal_size=False)
-        else:
-            assert args.max_tokens_per_gpu is not None
-            step_micro_batches = first_fit_decreasing_pack(step_lengths, args.max_tokens_per_gpu * cp_size)
-
-        # Grow the micro-batch count to a multiple of align_to by splitting multi-sample micro-batches.
-        target = max((len(step_micro_batches) + align_to - 1) // align_to * align_to, align_to)
-        if target != len(step_micro_batches):
-            if not args.use_dynamic_batch_size:
+            if len(step_micro_batches) % align_to != 0:
                 raise AssertionError(
-                    f"static path: micro-batch count ({len(step_micro_batches)}) is not a multiple of {align_to}; "
-                    f"adjust the config so step_size % (dp_size * micro_batch_size * mb_group) == 0."
+                    f"static path: micro-batch count ({len(step_micro_batches)}) is not a multiple of "
+                    f"dp_size * mb_group ({align_to}); got "
+                    f"step_size={len(sample_indices)}, micro_batch_size={args.micro_batch_size}, "
+                    f"dp_size={dp_size}, mb_group={mb_group if vpp_size > 1 else 1}. "
+                    f"Splitting static micro-batches would break the fixed-size invariant; adjust the config "
+                    f"so step_size % (dp_size * micro_batch_size * mb_group) == 0."
                 )
-            expand_bins_by_splitting(step_micro_batches, target, step_lengths)
-            assert (
-                len(step_micro_batches) == target
-            ), f"could only produce {len(step_micro_batches)} micro-batches after maximal splitting; need {target}."
 
         num_microbatches.append(len(step_micro_batches) // dp_size)
 
         # Distribute the micro-batches across DP ranks, len(step_micro_batches) / dp_size each: strided
         # round-robin, or Karmarkar-Karp on micro-batch weights (tokens under --balance-data,
         # FLOPs under --balance-by-flops).
-        if args.balance_data or getattr(args, "balance_by_flops", False):
-            if workloads is not None:
+        if args.balance_data or balance_by_flops:
+            if balance_by_flops:
                 weights = [sum(workloads[i] for i in micro_batch) for micro_batch in step_micro_batches]
             else:
                 weights = [sum(step_lengths[i] for i in micro_batch) for micro_batch in step_micro_batches]

--- a/miles/utils/seqlen_balancing.py
+++ b/miles/utils/seqlen_balancing.py
@@ -177,6 +177,45 @@ def get_seqlen_balanced_partitions(seqlen_list: list[int], k_partitions: int, eq
     return _check_and_sort_partitions(partitions)
 
 
+def first_fit_pack(total_lengths, max_tokens_per_bin):
+    """First-fit bin packing; bins hold indices, oversized samples land alone."""
+    bins: list[list[int]] = []
+    bin_sums: list[int] = []
+    for idx, length in enumerate(total_lengths):
+        for j in range(len(bins)):
+            if bin_sums[j] + length <= max_tokens_per_bin:
+                bins[j].append(idx)
+                bin_sums[j] += length
+                break
+        else:
+            bins.append([idx])
+            bin_sums.append(length)
+    return bins
+
+
+def _split_bin_by_tokens(bin_indices: list[int], lengths) -> list[list[int]]:
+    """Split a bin into two token-balanced halves (LPT)."""
+    halves: list[list[int]] = [[], []]
+    sums = [0, 0]
+    for idx in sorted(bin_indices, key=lambda i: -lengths[i]):
+        h = 0 if sums[0] <= sums[1] else 1
+        halves[h].append(idx)
+        sums[h] += lengths[idx]
+    return halves
+
+
+def expand_bins_by_splitting(bins: list[list[int]], target_count: int, lengths) -> None:
+    """Grow ``bins`` in place to ``target_count`` by splitting the largest bins."""
+    while len(bins) < target_count:
+        candidates = [(sum(lengths[i] for i in b), idx) for idx, b in enumerate(bins) if len(b) > 1]
+        if not candidates:
+            break
+        _, idx = max(candidates)
+        left, right = _split_bin_by_tokens(bins[idx], lengths)
+        bins[idx] = left
+        bins.append(right)
+
+
 def get_reverse_idx(idx_map):
     reverse_idx_map = copy.deepcopy(idx_map)
 

--- a/miles/utils/seqlen_balancing.py
+++ b/miles/utils/seqlen_balancing.py
@@ -178,10 +178,21 @@ def get_seqlen_balanced_partitions(seqlen_list: list[int], k_partitions: int, eq
 
 
 def first_fit_pack(total_lengths, max_tokens_per_bin):
-    """First-fit bin packing; bins hold indices, oversized samples land alone."""
+    """First-fit bin packing in arrival order; bins hold indices, oversized samples land alone."""
+    return _first_fit(range(len(total_lengths)), total_lengths, max_tokens_per_bin)
+
+
+def first_fit_decreasing_pack(total_lengths, max_tokens_per_bin):
+    """First-fit over indices sorted by length descending (FFD); never more bins than first-fit."""
+    order = sorted(range(len(total_lengths)), key=lambda i: -total_lengths[i])
+    return _first_fit(order, total_lengths, max_tokens_per_bin)
+
+
+def _first_fit(order, total_lengths, max_tokens_per_bin) -> list[list[int]]:
     bins: list[list[int]] = []
     bin_sums: list[int] = []
-    for idx, length in enumerate(total_lengths):
+    for idx in order:
+        length = total_lengths[idx]
         for j in range(len(bins)):
             if bin_sums[j] + length <= max_tokens_per_bin:
                 bins[j].append(idx)

--- a/miles/utils/types.py
+++ b/miles/utils/types.py
@@ -28,6 +28,9 @@ class Sample:
 
     group_index: int | None = None
     index: int | None = None
+    # Rollout execution id; None falls back to ``index``. Compact / subagent
+    # siblings must share it so the rollout is counted once.
+    rollout_id: int | None = None
     # prompt
     prompt: str | list[dict[str, str]] = ""
     tokens: list[int] = field(default_factory=list)

--- a/tests/e2e/megatron/test_qwen3_30B_A3B/test_dp_attention.py
+++ b/tests/e2e/megatron/test_qwen3_30B_A3B/test_dp_attention.py
@@ -1,0 +1,38 @@
+"""E2E for sglang dp-attention x rollout-side DP schedule: with
+--sglang-enable-dp-attention the router runs dp-aware request dispatch
+(worker urls carry an @<rank> suffix, requests are hashed onto attention
+DP ranks), which reshuffles sample completion order. The rollout-side
+schedule must stay order-insensitive: grouping keys on rollout_id, so the
+training partition and per-rollout loss weighting are unchanged."""
+
+import os
+
+from tests.ci.ci_register import register_cuda_ci
+from tests.ci.metric_history import register_ci_gate
+from tests.e2e.megatron.test_qwen3_30B_A3B._common import CaseConfig, execute, prepare
+
+register_cuda_ci(est_time=1100, suite="stage-c-4-gpu-h200", labels=["megatron", "short"])
+
+register_ci_gate(metric_key="train/grad_norm")
+register_ci_gate(metric_key="train/ppo_kl")
+register_ci_gate(metric_key="train/train_rollout_logprob_abs_diff")
+register_ci_gate(metric_key="train/train_rollout_kl")
+register_ci_gate(metric_key="rollout/raw_reward")
+
+CASE = CaseConfig(
+    num_gpus_per_node=4,
+    cp_size=2,
+    pp_size=2,
+    tp_size=1,
+    ep_size=2,
+    rollout_num_gpus_per_engine=4,
+    sglang_dp_size=4,
+    sglang_enable_dp_attention=True,
+)
+
+
+if __name__ == "__main__":
+    for proxy_var in ("http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY"):
+        os.environ.pop(proxy_var, None)
+    prepare(CASE, need_fp8=CASE.use_fp8_rollout, need_int4=CASE.use_int4_rollout, all_bridge=CASE.use_bridge)
+    execute(CASE, wandb_file=__file__)

--- a/tests/e2e/megatron/test_qwen3_4B_variable_gbs.py
+++ b/tests/e2e/megatron/test_qwen3_4B_variable_gbs.py
@@ -1,0 +1,117 @@
+"""E2E for variable global batch sizes: global_batch_size does not divide the
+collected rollout count, trim is disabled, and --allow-partial-train-step
+trains the trailing rollouts as a smaller final step (e.g. steps of [24, 8]).
+Runs with cp2 so the rollout-side schedule's token cap and PP-free mbs
+alignment are exercised on a mid-size model."""
+
+import os
+
+from tests.ci.ci_register import register_cuda_ci
+
+import miles.utils.external_utils.command_utils as U
+
+register_cuda_ci(est_time=1200, suite="stage-c-4-gpu-h200", labels=["megatron"])
+
+MODEL_NAME = "Qwen3-4B"
+MODEL_TYPE = "qwen3-4B"
+NUM_GPUS = 4
+
+
+def prepare():
+    U.exec_command("mkdir -p /root/models /root/datasets")
+    U.exec_command(f"hf download Qwen/{MODEL_NAME} --local-dir /root/models/{MODEL_NAME}")
+    U.hf_download_dataset("zhuzilin/dapo-math-17k")
+    U.convert_checkpoint(model_name=MODEL_NAME, megatron_model_type=MODEL_TYPE, num_gpus_per_node=NUM_GPUS)
+
+
+def execute():
+    ckpt_args = f"--hf-checkpoint /root/models/{MODEL_NAME}/ " f"--ref-load /root/{MODEL_NAME}_torch_dist "
+
+    rollout_args = (
+        "--prompt-data /root/datasets/dapo-math-17k/dapo-math-17k.jsonl "
+        "--input-key prompt "
+        "--label-key label "
+        "--apply-chat-template "
+        "--rollout-shuffle "
+        "--rm-type deepscaler "
+        "--num-rollout 3 "
+        "--rollout-batch-size 8 "
+        "--n-samples-per-prompt 4 "
+        "--rollout-max-response-len 4096 "
+        "--rollout-temperature 0.8 "
+        # 32 rollouts per batch with gbs=24: one full step + a partial step of 8.
+        "--global-batch-size 24 "
+        "--allow-partial-train-step "
+        "--disable-rollout-trim-samples "
+    )
+
+    perf_args = (
+        "--tensor-model-parallel-size 1 "
+        "--sequence-parallel "
+        "--pipeline-model-parallel-size 1 "
+        "--context-parallel-size 2 "
+        "--recompute-granularity full "
+        "--recompute-method uniform "
+        "--recompute-num-layers 1 "
+        "--use-dynamic-batch-size "
+        "--max-tokens-per-gpu 8192 "
+    )
+
+    grpo_args = (
+        "--advantage-estimator grpo "
+        "--use-kl-loss "
+        "--kl-loss-coef 0.00 "
+        "--kl-loss-type low_var_kl "
+        "--entropy-coef 0.00 "
+        "--eps-clip 0.2 "
+        "--eps-clip-high 0.28 "
+    )
+
+    optimizer_args = (
+        "--optimizer adam "
+        "--lr 1e-6 "
+        "--lr-decay-style constant "
+        "--weight-decay 0.1 "
+        "--adam-beta1 0.9 "
+        "--adam-beta2 0.98 "
+    )
+
+    sglang_args = "--rollout-num-gpus-per-engine 2 " "--sglang-mem-fraction-static 0.7 "
+
+    misc_args = (
+        "--attention-dropout 0.0 "
+        "--hidden-dropout 0.0 "
+        "--accumulate-allreduce-grads-in-fp32 "
+        "--attention-softmax-in-fp32 "
+        "--attention-backend flash "
+        "--actor-num-nodes 1 "
+        f"--actor-num-gpus-per-node {NUM_GPUS} "
+        "--colocate "
+        "--megatron-to-hf-mode bridge "
+    )
+
+    train_args = (
+        f"{ckpt_args} "
+        f"{rollout_args} "
+        f"{optimizer_args} "
+        f"{grpo_args} "
+        f"{U.get_default_wandb_args(__file__)} "
+        f"{perf_args} "
+        f"{sglang_args} "
+        "--ci-test "
+        f"{misc_args} "
+    )
+
+    U.execute_train(
+        train_args=train_args,
+        num_gpus_per_node=NUM_GPUS,
+        megatron_model_type=MODEL_TYPE,
+        extra_env_vars={"MILES_EXPERIMENTAL_ROLLOUT_REFACTOR": "1"},
+    )
+
+
+if __name__ == "__main__":
+    prepare()
+    for proxy_var in ("http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY"):
+        os.environ.pop(proxy_var, None)
+    execute()

--- a/tests/e2e/short/test_qwen2.5_0.5B_compact_rollout.py
+++ b/tests/e2e/short/test_qwen2.5_0.5B_compact_rollout.py
@@ -1,0 +1,121 @@
+"""E2E for by-rollout accounting: a compact generate fn splits every rollout
+execution into two training samples sharing ``rollout_id``; the rollout-side
+schedule must keep siblings in one step, count steps in rollouts, and train
+with per-rollout loss weighting."""
+
+import os
+
+from tests.ci.ci_register import register_cuda_ci
+
+import miles.utils.external_utils.command_utils as U
+
+register_cuda_ci(est_time=400, suite="stage-c-8-gpu-h100", labels=["short"])
+
+MODEL_NAME = "Qwen2.5-0.5B-Instruct"
+MODEL_TYPE = "qwen2.5-0.5B"
+NUM_GPUS = 8
+
+
+def prepare():
+    U.exec_command("mkdir -p /root/models /root/datasets")
+    U.exec_command(f"hf download Qwen/{MODEL_NAME} --local-dir /root/models/{MODEL_NAME}")
+    U.hf_download_dataset("zhuzilin/gsm8k")
+
+
+def execute():
+    ckpt_args = f"--hf-checkpoint /root/models/{MODEL_NAME}/ " f"--ref-load /root/models/{MODEL_NAME}/ "
+
+    rollout_args = (
+        "--prompt-data /root/datasets/gsm8k/train.parquet "
+        "--input-key messages "
+        "--label-key label "
+        "--apply-chat-template "
+        "--rollout-shuffle "
+        "--custom-generate-function-path tests.manual.compact_split_generate.generate "
+        "--rm-type math "
+        "--num-rollout 3 "
+        "--rollout-batch-size 8 "
+        "--n-samples-per-prompt 4 "
+        "--rollout-max-response-len 1024 "
+        "--rollout-temperature 0.8 "
+        "--global-batch-size 32 "
+    )
+
+    eval_args = (
+        "--eval-interval 20 "
+        "--eval-prompt-data gsm8k /root/datasets/gsm8k/test.parquet "
+        "--n-samples-per-eval-prompt 1 "
+        "--eval-max-response-len 1024 "
+        "--eval-top-k 1 "
+    )
+
+    perf_args = (
+        "--tensor-model-parallel-size 1 "
+        "--sequence-parallel "
+        "--pipeline-model-parallel-size 1 "
+        "--context-parallel-size 1 "
+        "--expert-model-parallel-size 1 "
+        "--expert-tensor-parallel-size 1 "
+        "--use-dynamic-batch-size "
+        "--max-tokens-per-gpu 9216 "
+    )
+
+    grpo_args = (
+        "--advantage-estimator grpo "
+        "--use-kl-loss "
+        "--kl-loss-coef 0.00 "
+        "--kl-loss-type low_var_kl "
+        "--entropy-coef 0.00 "
+        "--eps-clip 0.2 "
+        "--eps-clip-high 0.28 "
+    )
+
+    optimizer_args = (
+        "--optimizer adam "
+        "--lr 1e-6 "
+        "--lr-decay-style constant "
+        "--weight-decay 0.1 "
+        "--adam-beta1 0.9 "
+        "--adam-beta2 0.98 "
+    )
+
+    sglang_args = "--rollout-num-gpus-per-engine 1 " "--sglang-mem-fraction-static 0.7 "
+
+    misc_args = (
+        "--attention-dropout 0.0 "
+        "--hidden-dropout 0.0 "
+        "--accumulate-allreduce-grads-in-fp32 "
+        "--attention-softmax-in-fp32 "
+        "--attention-backend flash "
+        "--actor-num-nodes 1 "
+        f"--actor-num-gpus-per-node {NUM_GPUS} "
+        "--colocate "
+        "--megatron-to-hf-mode bridge "
+    )
+
+    train_args = (
+        f"{ckpt_args} "
+        f"{rollout_args} "
+        f"{optimizer_args} "
+        f"{grpo_args} "
+        f"{U.get_default_wandb_args(__file__)} "
+        f"{perf_args} "
+        f"{eval_args} "
+        f"{sglang_args} "
+        "--ci-test "
+        f"{misc_args} "
+    )
+
+    U.execute_train(
+        train_args=train_args,
+        num_gpus_per_node=NUM_GPUS,
+        megatron_model_type=MODEL_TYPE,
+        extra_env_vars={"MILES_EXPERIMENTAL_ROLLOUT_REFACTOR": "1"},
+    )
+
+
+if __name__ == "__main__":
+    prepare()
+    for proxy_var in ("http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY"):
+        os.environ.pop(proxy_var, None)
+    execute()

--- a/tests/fast/backends/training_utils/test_reduce_gathered_log_dict.py
+++ b/tests/fast/backends/training_utils/test_reduce_gathered_log_dict.py
@@ -1,0 +1,45 @@
+"""CPU tests for the (sum, count)-aware DP metric reduction."""
+
+from __future__ import annotations
+
+import math
+
+from miles.backends.training_utils.log_utils import reduce_gathered_log_dict
+
+
+def test_scalar_values_keep_legacy_mean():
+    gathered = [{"a": 1.0}, {"a": 3.0}]
+    assert reduce_gathered_log_dict(gathered, dp_size=2) == {"a": 2.0}
+
+
+def test_tuple_values_weighted_by_count():
+    # rank0: 3 samples with sum 3.0; rank1: 1 sample with sum 5.0
+    gathered = [{"m": (3.0, 3)}, {"m": (5.0, 1)}]
+    out = reduce_gathered_log_dict(gathered, dp_size=2)
+    assert math.isclose(out["m"], 8.0 / 4)
+
+
+def test_tuple_equal_counts_match_mean_of_means():
+    """With equal per-rank counts (today's invariant) the weighted average must
+    equal the legacy mean-of-per-rank-means, so metrics stay comparable."""
+    sums = [2.0, 6.0, 4.0, 8.0]
+    count = 4
+    gathered = [{"m": (s, count)} for s in sums]
+    out = reduce_gathered_log_dict(gathered, dp_size=4)
+    legacy = sum(s / count for s in sums) / 4
+    assert math.isclose(out["m"], legacy)
+
+
+def test_zero_total_count_maps_to_zero():
+    gathered = [{"m": (0.0, 0)}, {"m": (0.0, 0)}]
+    assert reduce_gathered_log_dict(gathered, dp_size=2) == {"m": 0.0}
+
+
+def test_mixed_keys():
+    gathered = [
+        {"scalar": 1.0, "weighted": (2.0, 2)},
+        {"scalar": 3.0, "weighted": (6.0, 2)},
+    ]
+    out = reduce_gathered_log_dict(gathered, dp_size=2)
+    assert out["scalar"] == 2.0
+    assert math.isclose(out["weighted"], 2.0)

--- a/tests/fast/backends/training_utils/test_rollout_mask_sums.py
+++ b/tests/fast/backends/training_utils/test_rollout_mask_sums.py
@@ -1,0 +1,107 @@
+"""CPU tests for per-rollout loss denominators (``rollout_mask_sums``).
+
+Covers:
+- the rollout-side precomputation in ``convert_samples_to_train_data``;
+- ``get_sum_of_sample_mean(denominators=...)`` — legacy per-sample mean when
+  ``None``, per-rollout token-weighted mean with precomputed denominators, and
+  the strict no-op equivalence between the two when 1 rollout = 1 sample;
+- ``aggregate_train_losses(num_rollouts=...)`` per-rollout-mean reduction.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+import torch
+from tests.fast.backends.training_utils.loss.loss_test_utils import make_parallel_state
+from tests.fast.ray.rollout.conftest import make_args, make_sample
+
+from miles.backends.training_utils import log_utils
+from miles.backends.training_utils.cp_utils import get_sum_of_sample_mean
+from miles.ray.rollout.train_data_conversion import convert_samples_to_train_data
+
+
+@pytest.fixture(autouse=True)
+def _parallel_state():
+    make_parallel_state()
+
+
+def _convert(samples):
+    return convert_samples_to_train_data(
+        make_args(rewards_normalization=False),
+        samples,
+        metadata={},
+        custom_convert_samples_to_train_data_func=None,
+        custom_reward_post_process_func=None,
+    )
+
+
+class TestRolloutMaskSumsPrecompute:
+    def test_defaults_to_per_sample_mask_sums(self):
+        samples = [make_sample(index=i, response_length=n) for i, n in enumerate((2, 3, 4))]
+        out = _convert(samples)
+        assert out["rollout_mask_sums"] == [2, 3, 4]
+
+    def test_compact_siblings_share_whole_rollout_total(self):
+        samples = [make_sample(index=i, response_length=n) for i, n in enumerate((2, 3, 4))]
+        # samples 0 and 1 come from the same rollout execution
+        samples[0].rollout_id = samples[1].rollout_id = 0
+        out = _convert(samples)
+        assert out["rollout_mask_sums"] == [5, 5, 4]
+
+    def test_masked_out_tokens_excluded(self):
+        s = make_sample(index=0, response_length=4)
+        s.loss_mask = [1, 0, 1, 0]
+        out = _convert([s])
+        assert out["rollout_mask_sums"] == [2]
+
+
+class TestDenominators:
+    def _masks(self, lens):
+        return [torch.ones(n, dtype=torch.int) for n in lens]
+
+    def test_none_matches_legacy_per_sample_mean(self):
+        lens = [2, 3]
+        x = torch.tensor([1.0, 3.0, 2.0, 2.0, 5.0])
+        som = get_sum_of_sample_mean(list(lens), list(lens), self._masks(lens))
+        # sample means: (1+3)/2 = 2, (2+2+5)/3 = 3
+        assert math.isclose(som(x).item(), 5.0)
+
+    def test_rollout_denoms_give_token_weighted_rollout_mean(self):
+        lens = [2, 3]
+        x = torch.tensor([1.0, 3.0, 2.0, 2.0, 5.0])
+        # both samples belong to one rollout with 5 mask tokens total
+        denoms = torch.tensor([5.0, 5.0])
+        som = get_sum_of_sample_mean(list(lens), list(lens), self._masks(lens), denominators=denoms)
+        # (1+3)/5 + (2+2+5)/5 = 13/5 — one token-weighted mean for the rollout
+        assert math.isclose(som(x).item(), 13.0 / 5, rel_tol=1e-6)
+
+    def test_per_sample_denominators_equal_legacy(self):
+        """1 rollout = 1 sample: rollout_mask_sums equals each mask's own sum -> strict no-op."""
+        lens = [2, 3, 4]
+        x = torch.randn(sum(lens))
+        masks = self._masks(lens)
+        legacy = get_sum_of_sample_mean(list(lens), list(lens), masks)
+        denoms = torch.tensor([float(n) for n in lens])
+        new = get_sum_of_sample_mean(list(lens), list(lens), masks, denominators=denoms)
+        assert torch.allclose(legacy(x), new(x))
+
+
+class TestAggregateTrainLossesNumRollouts:
+    @pytest.fixture(autouse=True)
+    def _no_allreduce(self, monkeypatch):
+        monkeypatch.setattr(log_utils.MultiPGUtil, "all_reduce", staticmethod(lambda *a, **k: None))
+
+    def _mb(self, num_samples, values):
+        return {"keys": list(values.keys()), "values": torch.tensor([num_samples, *values.values()])}
+
+    def test_num_rollouts_overrides_sample_count(self):
+        losses = [self._mb(2, {"loss": 2.0}), self._mb(2, {"loss": 6.0})]
+        out = log_utils.aggregate_train_losses(losses, num_rollouts=4)
+        assert math.isclose(out["loss"], 2.0)
+
+    def test_legacy_reduction_without_divisor(self):
+        losses = [self._mb(2, {"loss": 2.0}), self._mb(2, {"loss": 6.0})]
+        out = log_utils.aggregate_train_losses(losses)
+        assert math.isclose(out["loss"], 2.0)

--- a/tests/fast/ray/rollout/test_rollout_data_conversion.py
+++ b/tests/fast/ray/rollout/test_rollout_data_conversion.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 import pytest
 from tests.fast.ray.rollout.conftest import make_args, make_sample
 
-from miles.ray.rollout.rollout_data_conversion import _compute_dynamic_global_batch_size, postprocess_rollout_data
+from miles.ray.rollout.rollout_data_conversion import (
+    _compute_dynamic_global_batch_size,
+    postprocess_rollout_data,
+    validate_compact_rollout_ids,
+)
 
 
 class TestComputeDynamicGlobalBatchSize:
@@ -72,3 +76,34 @@ class TestPostprocessRolloutData:
         nested = [[make_sample(index=0), make_sample(index=1)], [make_sample(index=2)]]
         out, _meta = postprocess_rollout_data(args, nested, train_parallel_config={"dp_size": 1})
         assert len(out) == 3
+
+
+class TestValidateRolloutIdAnnotated:
+    def test_flat_list_skips_validation(self):
+        """Depth-1 leaf (flat list[Sample]) is the default rollout shape — no rollout_id required."""
+        validate_compact_rollout_ids([make_sample(index=i) for i in range(4)])
+
+    def test_default_nested_shape_skips_validation(self):
+        """list[list[Sample]] (prompt x rollout): leaf at depth 1 — no rollout_id required."""
+        validate_compact_rollout_ids([[make_sample(index=0), make_sample(index=1)]])
+
+    def test_compact_shape_requires_rollout_id(self):
+        """list[list[list[Sample]]]: leaf at depth 2 with >1 sibling requires rollout_id."""
+        compact = [[[make_sample(index=0), make_sample(index=1)]]]
+        with pytest.raises(AssertionError, match="rollout_id is unset"):
+            validate_compact_rollout_ids(compact)
+
+    def test_compact_shape_siblings_must_share_rollout_id(self):
+        a, b = make_sample(index=0), make_sample(index=1)
+        a.rollout_id, b.rollout_id = 7, 8
+        with pytest.raises(AssertionError, match="share rollout_id"):
+            validate_compact_rollout_ids([[[a, b]]])
+
+    def test_compact_shape_valid_when_annotated(self):
+        a, b = make_sample(index=0), make_sample(index=1)
+        a.rollout_id = b.rollout_id = 7
+        validate_compact_rollout_ids([[[a, b]]])
+
+    def test_compact_singleton_leaf_needs_no_annotation(self):
+        """A single-sample leaf at depth >= 2 is unambiguous — no rollout_id required."""
+        validate_compact_rollout_ids([[[make_sample(index=0)]]])

--- a/tests/fast/ray/rollout/test_train_data_conversion.py
+++ b/tests/fast/ray/rollout/test_train_data_conversion.py
@@ -146,6 +146,32 @@ class TestConvertSamplesToTrainData:
         )
         assert out["raw_reward"][0] == 9.0
 
+    def test_rollout_ids_default_to_sample_index(self):
+        args = make_args(rewards_normalization=False)
+        samples = [make_sample(index=i) for i in range(3)]
+        out = convert_samples_to_train_data(
+            args,
+            samples,
+            metadata={},
+            custom_convert_samples_to_train_data_func=None,
+            custom_reward_post_process_func=None,
+        )
+        assert out["rollout_ids"] == [0, 1, 2]
+
+    def test_rollout_ids_use_explicit_rollout_id_when_set(self):
+        args = make_args(rewards_normalization=False)
+        samples = [make_sample(index=i) for i in range(4)]
+        # two compact siblings sharing one rollout execution
+        samples[1].rollout_id = samples[2].rollout_id = 1
+        out = convert_samples_to_train_data(
+            args,
+            samples,
+            metadata={},
+            custom_convert_samples_to_train_data_func=None,
+            custom_reward_post_process_func=None,
+        )
+        assert out["rollout_ids"] == [0, 1, 1, 3]
+
     def test_custom_convert_func_short_circuits(self):
         args = make_args()
         sentinel = {"foo": "bar"}
@@ -557,7 +583,7 @@ FULL_SCHEDULE_CONFIG = {
 }
 
 
-def _make_split_data(n: int, *, lengths: list[int] | None = None) -> dict:
+def _make_split_data(n: int, *, lengths: list[int] | None = None, rollout_ids: list[int] | None = None) -> dict:
     lengths = lengths or [2] * n
     assert len(lengths) == n
     return {
@@ -567,6 +593,7 @@ def _make_split_data(n: int, *, lengths: list[int] | None = None) -> dict:
         "truncated": [0] * n,
         "loss_masks": [[1] * length for length in lengths],
         "sample_indices": list(range(n)),
+        "rollout_ids": rollout_ids if rollout_ids is not None else list(range(n)),
     }
 
 
@@ -592,9 +619,14 @@ class TestCanScheduleOnRolloutSide:
         data["multimodal_train_inputs"] = [None] * 8
         assert not can_schedule_on_rollout_side(args, data, FULL_SCHEDULE_CONFIG)
 
-    def test_rejects_indivisible_sample_count(self):
+    def test_rejects_fewer_rollouts_than_gbs(self):
         args = make_args(balance_data=False, micro_batch_size=1, multi_lora=False)  # global_batch_size=8
-        assert not can_schedule_on_rollout_side(args, _make_split_data(10), FULL_SCHEDULE_CONFIG)
+        assert not can_schedule_on_rollout_side(args, _make_split_data(6), FULL_SCHEDULE_CONFIG)
+
+    def test_accepts_trailing_partial_step(self):
+        """Extra rollouts beyond a full step are fine — the schedule drops them."""
+        args = make_args(balance_data=False, micro_batch_size=1, multi_lora=False)  # global_batch_size=8
+        assert can_schedule_on_rollout_side(args, _make_split_data(10), FULL_SCHEDULE_CONFIG)
 
     def test_dynamic_gbs_overrides_args_gbs(self):
         args = make_args(balance_data=False, micro_batch_size=1, multi_lora=False)  # global_batch_size=8
@@ -604,23 +636,39 @@ class TestCanScheduleOnRolloutSide:
 
 
 class TestSplitTrainDataByDpScheduled:
-    def test_static_shards_match_legacy_split_plus_schedule(self):
-        """Static path: shards must be identical to the legacy split, plus the two
-        schedule keys, and the schedule must tile each shard's rows exactly."""
+    def test_static_shards_cover_all_samples(self):
+        """Static path: every sample lands in exactly one shard row, the schedule
+        tiles each shard's rows exactly, and shard rows match their partition."""
         args = make_args(balance_data=False, micro_batch_size=2, use_dynamic_batch_size=False)
         data = _make_split_data(8)
-        legacy = split_train_data_by_dp_raw(args, dict(data), dp_size=2)
         scheduled = split_train_data_by_dp_scheduled_raw(args, dict(data), train_parallel_config=FULL_SCHEDULE_CONFIG)
 
         assert len(scheduled) == 2
-        for rank, (old, new) in enumerate(zip(legacy, scheduled, strict=True)):
-            assert list(new["partition"]) == list(old["partition"]), f"rank {rank} partition changed"
-            for key in ("tokens", "response_lengths", "loss_masks", "sample_indices"):
-                assert new[key] == old[key], f"rank {rank} {key} changed"
-            # global_batch_size=8, dp=2, mbs=2 -> 2 mbs per rank, 1 step
+        seen = []
+        for new in scheduled:
+            partition = list(new["partition"])
+            seen.extend(partition)
+            assert new["tokens"] == [data["tokens"][j] for j in partition]
+            # global_batch_size=8, dp=2, mbs=2 -> 4 mbs total, 2 per rank, 1 step
             assert new["num_microbatches"] == [2]
+            assert new["num_rollouts"] == [8]
             flat = [i for mbs in new["micro_batch_indices"] for i in mbs]
             assert flat == list(range(len(new["tokens"])))
+        assert sorted(seen) == list(range(8))
+
+    def test_compact_rollout_gbs_counts_rollouts_not_samples(self):
+        """gbs counts rollouts: 4 rollouts over 6 samples with gbs=2 -> 2 steps,
+        and every sample is still covered exactly once across shards."""
+        args = make_args(balance_data=False, micro_batch_size=1, use_dynamic_batch_size=True, max_tokens_per_gpu=8)
+        rollout_ids = [0, 1, 1, 1, 2, 3]  # rollout 1 emits 3 samples
+        data = _make_split_data(6, rollout_ids=rollout_ids)
+        data["dynamic_global_batch_size"] = 2
+        shards = split_train_data_by_dp_scheduled_raw(args, dict(data), train_parallel_config=FULL_SCHEDULE_CONFIG)
+
+        assert shards[0]["num_rollouts"] == [2, 2]
+        assert len(shards[0]["num_microbatches"]) == 2
+        seen = sorted(j for shard in shards for j in shard["partition"])
+        assert seen == list(range(6))
 
     def test_dynamic_schedule_respects_token_cap(self):
         args = make_args(
@@ -651,3 +699,4 @@ class TestSplitTrainDataByDpScheduled:
 
         assert shards[0]["num_microbatches"] == [2, 2]
         assert shards[0]["dynamic_global_batch_size"] == 8
+        assert shards[0]["num_rollouts"] == [8, 8]

--- a/tests/fast/ray/rollout/test_train_data_conversion.py
+++ b/tests/fast/ray/rollout/test_train_data_conversion.py
@@ -11,9 +11,11 @@ from tests.fast.ray.rollout.conftest import make_args, make_sample, make_samples
 
 from miles.ray.rollout.train_data_conversion import (
     _post_process_rewards,
+    can_schedule_on_rollout_side,
     convert_samples_to_train_data,
     split_train_data_by_dp,
     split_train_data_by_dp_raw,
+    split_train_data_by_dp_scheduled_raw,
 )
 from miles.utils import object_store
 from miles.utils.types import Sample
@@ -407,7 +409,7 @@ class TestSplitTrainDataByDp:
             "loss_masks": [[1, 1]] * 4,
             "sample_indices": [0, 1, 2, 3],
         }
-        refs = split_train_data_by_dp(args, data, dp_size=2)
+        refs = split_train_data_by_dp(args, data, {"dp_size": 2})
         parts = [ray.get(r.inner) for r in refs]
         # stride: dp=0 takes [0, 2], dp=1 takes [1, 3]
         assert list(parts[0]["partition"]) == [0, 2]
@@ -425,7 +427,7 @@ class TestSplitTrainDataByDp:
             "loss_masks": [[1] * n for n in (1, 2, 3, 4)],
             "sample_indices": [0, 1, 2, 3],
         }
-        refs = split_train_data_by_dp(args, data, dp_size=2)
+        refs = split_train_data_by_dp(args, data, {"dp_size": 2})
         parts = [ray.get(r.inner) for r in refs]
         sizes = [len(p["tokens"]) for p in parts]
         assert max(sizes) - min(sizes) <= 1
@@ -442,7 +444,7 @@ class TestSplitTrainDataByDp:
             "rollout_log_probs": [[-0.1], [-0.2]],
             "round_number": [1, 2],
         }
-        refs = split_train_data_by_dp(args, data, dp_size=2)
+        refs = split_train_data_by_dp(args, data, {"dp_size": 2})
         parts = [ray.get(r.inner) for r in refs]
         assert "rollout_log_probs" in parts[0]
         assert "round_number" in parts[0]
@@ -460,7 +462,7 @@ class TestSplitTrainDataByDp:
             "raw_reward": [9.0, 8.0, 7.0, 6.0],
             "dynamic_global_batch_size": 4,
         }
-        refs = split_train_data_by_dp(args, data, dp_size=2)
+        refs = split_train_data_by_dp(args, data, {"dp_size": 2})
         parts = [ray.get(r.inner) for r in refs]
         for p in parts:
             assert p["raw_reward"] == [9.0, 8.0, 7.0, 6.0]
@@ -478,7 +480,7 @@ class TestSplitTrainDataByDp:
             "loss_masks": [[1]] * n,
             "sample_indices": list(range(n)),
         }
-        refs = split_train_data_by_dp(args, data, dp_size=4)
+        refs = split_train_data_by_dp(args, data, {"dp_size": 4})
         parts = [ray.get(r.inner) for r in refs]
         all_indices = sorted(i for p in parts for i in p["partition"])
         assert all_indices == list(range(n))
@@ -545,3 +547,107 @@ class TestSplitTrainDataRaw:
 
         result = split_train_data_by_dp_raw(args, data, dp_size=1)
         assert "seq_witness_ids" not in result[0]
+
+
+FULL_SCHEDULE_CONFIG = {
+    "dp_size": 2,
+    "cp_size": 1,
+    "vpp_size": 1,
+    "microbatch_group_size_per_vp_stage": None,
+}
+
+
+def _make_split_data(n: int, *, lengths: list[int] | None = None) -> dict:
+    lengths = lengths or [2] * n
+    assert len(lengths) == n
+    return {
+        "tokens": [list(range(length)) for length in lengths],
+        "response_lengths": [1] * n,
+        "rewards": [0.0] * n,
+        "truncated": [0] * n,
+        "loss_masks": [[1] * length for length in lengths],
+        "sample_indices": list(range(n)),
+    }
+
+
+class TestCanScheduleOnRolloutSide:
+    def test_eligible_with_full_megatron_config(self):
+        args = make_args(balance_data=False, micro_batch_size=1, use_dynamic_batch_size=False, multi_lora=False)
+        assert can_schedule_on_rollout_side(args, _make_split_data(8), FULL_SCHEDULE_CONFIG)
+
+    def test_rejects_partial_config(self):
+        """fsdp / torchtitan advertise only dp_size; indep_dp advertises {}."""
+        args = make_args(balance_data=False, micro_batch_size=1, multi_lora=False)
+        assert not can_schedule_on_rollout_side(args, _make_split_data(8), {"dp_size": 2})
+        assert not can_schedule_on_rollout_side(args, _make_split_data(8), {})
+        assert not can_schedule_on_rollout_side(args, _make_split_data(8), None)
+
+    def test_rejects_multi_lora(self):
+        args = make_args(balance_data=False, micro_batch_size=1, multi_lora=True)
+        assert not can_schedule_on_rollout_side(args, _make_split_data(8), FULL_SCHEDULE_CONFIG)
+
+    def test_rejects_multimodal(self):
+        args = make_args(balance_data=False, micro_batch_size=1, multi_lora=False)
+        data = _make_split_data(8)
+        data["multimodal_train_inputs"] = [None] * 8
+        assert not can_schedule_on_rollout_side(args, data, FULL_SCHEDULE_CONFIG)
+
+    def test_rejects_indivisible_sample_count(self):
+        args = make_args(balance_data=False, micro_batch_size=1, multi_lora=False)  # global_batch_size=8
+        assert not can_schedule_on_rollout_side(args, _make_split_data(10), FULL_SCHEDULE_CONFIG)
+
+    def test_dynamic_gbs_overrides_args_gbs(self):
+        args = make_args(balance_data=False, micro_batch_size=1, multi_lora=False)  # global_batch_size=8
+        data = _make_split_data(6)
+        data["dynamic_global_batch_size"] = 6
+        assert can_schedule_on_rollout_side(args, data, FULL_SCHEDULE_CONFIG)
+
+
+class TestSplitTrainDataByDpScheduled:
+    def test_static_shards_match_legacy_split_plus_schedule(self):
+        """Static path: shards must be identical to the legacy split, plus the two
+        schedule keys, and the schedule must tile each shard's rows exactly."""
+        args = make_args(balance_data=False, micro_batch_size=2, use_dynamic_batch_size=False)
+        data = _make_split_data(8)
+        legacy = split_train_data_by_dp_raw(args, dict(data), dp_size=2)
+        scheduled = split_train_data_by_dp_scheduled_raw(args, dict(data), train_parallel_config=FULL_SCHEDULE_CONFIG)
+
+        assert len(scheduled) == 2
+        for rank, (old, new) in enumerate(zip(legacy, scheduled, strict=True)):
+            assert list(new["partition"]) == list(old["partition"]), f"rank {rank} partition changed"
+            for key in ("tokens", "response_lengths", "loss_masks", "sample_indices"):
+                assert new[key] == old[key], f"rank {rank} {key} changed"
+            # global_batch_size=8, dp=2, mbs=2 -> 2 mbs per rank, 1 step
+            assert new["num_microbatches"] == [2]
+            flat = [i for mbs in new["micro_batch_indices"] for i in mbs]
+            assert flat == list(range(len(new["tokens"])))
+
+    def test_dynamic_schedule_respects_token_cap(self):
+        args = make_args(
+            balance_data=False,
+            micro_batch_size=1,
+            use_dynamic_batch_size=True,
+            max_tokens_per_gpu=6,
+        )
+        lengths = [5, 1, 4, 2, 3, 3, 2, 4]
+        data = _make_split_data(8, lengths=lengths)
+        shards = split_train_data_by_dp_scheduled_raw(args, data, train_parallel_config=FULL_SCHEDULE_CONFIG)
+
+        nmb = shards[0]["num_microbatches"]
+        for shard in shards:
+            assert shard["num_microbatches"] == nmb, "num_microbatches must be identical on every rank"
+            assert len(shard["micro_batch_indices"]) == sum(nmb)
+            partition = list(shard["partition"])
+            for mbs in shard["micro_batch_indices"]:
+                total = sum(lengths[partition[i]] for i in mbs)
+                assert total <= 6 or len(mbs) == 1
+
+    def test_dynamic_gbs_multi_step(self):
+        """16 samples with dynamic_global_batch_size=8 -> 2 steps."""
+        args = make_args(balance_data=False, micro_batch_size=2, use_dynamic_batch_size=False)
+        data = _make_split_data(16)
+        data["dynamic_global_batch_size"] = 8
+        shards = split_train_data_by_dp_scheduled_raw(args, data, train_parallel_config=FULL_SCHEDULE_CONFIG)
+
+        assert shards[0]["num_microbatches"] == [2, 2]
+        assert shards[0]["dynamic_global_batch_size"] == 8

--- a/tests/fast/utils/test_arguments.py
+++ b/tests/fast/utils/test_arguments.py
@@ -252,6 +252,15 @@ def test_custom_megatron_post_save_hook_path_requires_save():
         miles_validate_args(args)
 
 
+def test_dynamic_global_batch_size_requires_dynamic_batch_size():
+    parser = argparse.ArgumentParser()
+    get_miles_extra_args_provider()(parser)
+    args = parser.parse_args(["--use-dynamic-global-batch-size", "--num-rollout", "1"] + REQUIRED_ARGS)
+
+    with pytest.raises(AssertionError, match="requires --use-dynamic-batch-size"):
+        miles_validate_args(args)
+
+
 class TestTitoFixedTemplateConfiguration:
     def _parse(self, extra):
         parser = argparse.ArgumentParser()

--- a/tests/fast/utils/test_dp_schedule.py
+++ b/tests/fast/utils/test_dp_schedule.py
@@ -1,0 +1,258 @@
+"""CPU unit tests for miles.utils.dp_schedule.build_dp_schedule.
+
+The tests assert the invariants documented at the top of dp_schedule.py against
+a range of static / dynamic / VPP / oversize / balance scenarios, plus an
+equivalence check of ``num_microbatches`` against the legacy train-side
+computation (``get_minimum_num_micro_batch_size`` + DP-wide MAX) that this
+schedule replaces.
+
+Trim, dynamic-gbs resolution, and per-rank rollout_data packaging all live in
+``train_data_conversion.split_train_data_by_dp_scheduled``; these tests just
+exercise the schedule itself (``partitions`` and ``micro_batch_indices``).
+"""
+
+from __future__ import annotations
+
+import random
+from types import SimpleNamespace
+
+import pytest
+
+from miles.utils.data import get_minimum_num_micro_batch_size
+from miles.utils.dp_schedule import build_dp_schedule, has_full_schedule_config
+
+
+def make_args(
+    *,
+    micro_batch_size=1,
+    use_dynamic_batch_size=False,
+    max_tokens_per_gpu=None,
+    balance_data=False,
+):
+    return SimpleNamespace(
+        micro_batch_size=micro_batch_size,
+        use_dynamic_batch_size=use_dynamic_batch_size,
+        max_tokens_per_gpu=max_tokens_per_gpu,
+        balance_data=balance_data,
+    )
+
+
+def make_tp(dp_size=1, cp_size=1, vpp_size=1, microbatch_group_size_per_vp_stage=None):
+    return {
+        "dp_size": dp_size,
+        "cp_size": cp_size,
+        "vpp_size": vpp_size,
+        "microbatch_group_size_per_vp_stage": microbatch_group_size_per_vp_stage,
+    }
+
+
+def assert_invariants(partitions, micro_batch_indices, num_microbatches, *, dp_size, total_lengths, max_per_bin=None):
+    """Check the invariants documented at the top of dp_schedule.py."""
+    expected_per_rank = len(total_lengths) // dp_size
+    seen_global: set[int] = set()
+    for r in range(dp_size):
+        partition = partitions[r]
+        mbi = micro_batch_indices[r]
+
+        # Same sample count per rank.
+        assert len(partition) == expected_per_rank, f"rank {r}: {len(partition)} samples, want {expected_per_rank}"
+
+        # Same num_mbs per rank (PP sync); num_microbatches is shared, so each rank's
+        # flat mbs count must match sum(num_microbatches).
+        assert len(mbi) == sum(num_microbatches), f"rank {r}: mbs count mismatch"
+
+        # Flattened micro_batch_indices == range(len(partition)) (each sample covered
+        # exactly once, by exactly one mbs).
+        flat = [i for mbs in mbi for i in mbs]
+        assert flat == list(range(len(partition))), f"rank {r}: micro_batch_indices don't tile [0, n)"
+
+        # Disjoint partitions whose union covers every sample.
+        assert seen_global.isdisjoint(partition), f"rank {r}: overlap with other ranks"
+        seen_global.update(partition)
+    assert seen_global == set(range(len(total_lengths))), "some samples not assigned to any rank"
+
+    if max_per_bin is None:
+        return
+
+    # Every mbs <= max_per_bin tokens, EXCEPT a singleton bin holding an oversized sample.
+    for r in range(dp_size):
+        partition = partitions[r]
+        for mbs in micro_batch_indices[r]:
+            bin_total = sum(total_lengths[partition[i]] for i in mbs)
+            if bin_total > max_per_bin:
+                assert len(mbs) == 1, f"rank {r}: mbs sum {bin_total} > {max_per_bin} but contains {len(mbs)} samples"
+
+
+def test_static_stride_single_step():
+    """Static + strided DP split, single step."""
+    total_lengths = [10] * 16
+    args = make_args(micro_batch_size=2)
+    tp = make_tp(dp_size=4)
+
+    partitions, mbi, nmb = build_dp_schedule(args, tp, total_lengths, global_batch_size=16)
+
+    assert nmb == [2]
+    assert_invariants(partitions, mbi, nmb, dp_size=4, total_lengths=total_lengths)
+
+
+def test_static_stride_matches_legacy_partition_order():
+    """Static + strided must produce exactly the legacy strided row order —
+    rank r gets rows [r, r+dp, r+2*dp, ...] in that order, contiguously chunked."""
+    total_lengths = list(range(100, 116))
+    args = make_args(micro_batch_size=2)
+    tp = make_tp(dp_size=4)
+
+    partitions, _, _ = build_dp_schedule(args, tp, total_lengths, global_batch_size=16)
+
+    for r in range(4):
+        assert partitions[r] == list(range(r, 16, 4)), f"rank {r} partition deviates from legacy strided order"
+
+
+def test_static_balance_multi_step():
+    """Static + balance_data + 2 training steps. Each rank must get gbs/dp per step."""
+    total_lengths = [1, 2, 3, 4, 5, 6, 7, 8, 8, 7, 6, 5, 4, 3, 2, 1]  # 2 steps of 8
+    args = make_args(micro_batch_size=2, balance_data=True)
+    tp = make_tp(dp_size=2)
+
+    partitions, mbi, nmb = build_dp_schedule(args, tp, total_lengths, global_batch_size=8)
+
+    assert nmb == [2, 2]
+    assert_invariants(partitions, mbi, nmb, dp_size=2, total_lengths=total_lengths)
+
+
+def test_dynamic_uniform():
+    """Dynamic mbs on uniform-length samples."""
+    total_lengths = [5] * 8
+    args = make_args(use_dynamic_batch_size=True, max_tokens_per_gpu=10)
+    tp = make_tp(dp_size=2)
+
+    partitions, mbi, nmb = build_dp_schedule(args, tp, total_lengths, global_batch_size=8)
+
+    assert_invariants(partitions, mbi, nmb, dp_size=2, total_lengths=total_lengths, max_per_bin=10)
+
+
+def test_dynamic_skewed_lengths():
+    """Skewed lengths (the case where K-K used to over-pack a single bin)."""
+    total_lengths = [9, 9, 9, 9, 1, 1, 1, 1]
+    args = make_args(use_dynamic_batch_size=True, max_tokens_per_gpu=10)
+    tp = make_tp(dp_size=2)
+
+    partitions, mbi, nmb = build_dp_schedule(args, tp, total_lengths, global_batch_size=8)
+
+    assert_invariants(partitions, mbi, nmb, dp_size=2, total_lengths=total_lengths, max_per_bin=10)
+
+
+def test_dynamic_oversized_sample_lands_alone():
+    """A single sample exceeding max_per_bin must end up alone in its mbs (with no
+    other samples crammed in)."""
+    total_lengths = [15, 3, 3, 3, 3, 3, 3, 3]  # 15 > C=10
+    args = make_args(use_dynamic_batch_size=True, max_tokens_per_gpu=10)
+    tp = make_tp(dp_size=2)
+
+    partitions, mbi, nmb = build_dp_schedule(args, tp, total_lengths, global_batch_size=8)
+
+    assert_invariants(partitions, mbi, nmb, dp_size=2, total_lengths=total_lengths, max_per_bin=10)
+    # Find the rank holding the oversized sample and verify it lives alone in some mbs.
+    oversize_idx = total_lengths.index(15)
+    found = False
+    for r in range(2):
+        partition = partitions[r]
+        if oversize_idx not in partition:
+            continue
+        local = partition.index(oversize_idx)
+        for mbs in mbi[r]:
+            if local in mbs:
+                assert mbs == [local], f"oversized sample shares an mbs: {mbs}"
+                found = True
+    assert found
+
+
+def test_dynamic_with_vpp_rounds_to_mb_group():
+    """num_microbatches per rank should be a multiple of mb_group when vpp_size > 1."""
+    total_lengths = [4] * 32  # 2 steps of 16; per step, ~8 bins of 8 needed at C=8
+    args = make_args(use_dynamic_batch_size=True, max_tokens_per_gpu=8)
+    tp = make_tp(dp_size=2, vpp_size=2, microbatch_group_size_per_vp_stage=2)
+
+    partitions, mbi, nmb = build_dp_schedule(args, tp, total_lengths, global_batch_size=16)
+
+    for n in nmb:
+        assert n % 2 == 0, f"num_microbatches {n} is not a multiple of mb_group=2"
+    assert_invariants(partitions, mbi, nmb, dp_size=2, total_lengths=total_lengths, max_per_bin=8)
+
+
+def test_static_indivisible_per_rank_batch_asserts():
+    """gbs/dp not a multiple of micro_batch_size must fail loudly, not mis-schedule."""
+    args = make_args(micro_batch_size=3)
+    tp = make_tp(dp_size=2)
+    with pytest.raises(AssertionError, match="micro_batch_size"):
+        build_dp_schedule(args, tp, [10] * 8, global_batch_size=8)
+
+
+def test_untrimmed_input_asserts():
+    """num_samples not a multiple of global_batch_size must fail loudly."""
+    args = make_args(micro_batch_size=1)
+    tp = make_tp(dp_size=2)
+    with pytest.raises(AssertionError, match="multiple of global_batch_size"):
+        build_dp_schedule(args, tp, [10] * 10, global_batch_size=8)
+
+
+def test_dynamic_num_microbatches_matches_legacy_train_side():
+    """The PP-sync-critical value: for the same strided partition, the rollout-side
+    schedule must produce exactly the num_microbatches the legacy train-side path
+    computed (per-rank ``get_minimum_num_micro_batch_size``, then DP-wide MAX)."""
+    rng = random.Random(42)
+    dp_size, cp_size = 4, 2
+    max_tokens_per_gpu = 512
+    global_batch_size = 32
+
+    for _ in range(50):
+        num_steps = rng.randint(1, 3)
+        total_lengths = [rng.randint(16, 1200) for _ in range(global_batch_size * num_steps)]
+
+        args = make_args(use_dynamic_batch_size=True, max_tokens_per_gpu=max_tokens_per_gpu)
+        tp = make_tp(dp_size=dp_size, cp_size=cp_size)
+        _, _, nmb = build_dp_schedule(args, tp, total_lengths, global_batch_size=global_batch_size)
+
+        # Legacy: each rank r holds the strided rows of each step, computes its own
+        # first-fit bin count over its local per-step slice, and the DP group takes MAX.
+        num_local_gbs = global_batch_size // dp_size
+        legacy_nmb = []
+        for step_i in range(num_steps):
+            step = total_lengths[step_i * global_batch_size : (step_i + 1) * global_batch_size]
+            per_rank = []
+            for r in range(dp_size):
+                local = [step[i] for i in range(r, global_batch_size, dp_size)]
+                assert len(local) == num_local_gbs
+                per_rank.append(get_minimum_num_micro_batch_size(local, max_tokens_per_gpu * cp_size))
+            legacy_nmb.append(max(per_rank))
+
+        assert nmb == legacy_nmb, f"num_microbatches diverged from legacy: {nmb} vs {legacy_nmb}"
+
+
+def test_randomized_invariants_dynamic():
+    """Randomized sweep of the documented invariants on the dynamic path."""
+    rng = random.Random(7)
+    for _ in range(30):
+        dp_size = rng.choice([1, 2, 4])
+        gbs = dp_size * rng.choice([2, 4, 8])
+        num_steps = rng.randint(1, 2)
+        total_lengths = [rng.randint(1, 40) for _ in range(gbs * num_steps)]
+        max_tokens = rng.randint(20, 60)
+        balance = rng.random() < 0.5
+
+        args = make_args(use_dynamic_batch_size=True, max_tokens_per_gpu=max_tokens, balance_data=balance)
+        tp = make_tp(dp_size=dp_size)
+        partitions, mbi, nmb = build_dp_schedule(args, tp, total_lengths, global_batch_size=gbs)
+
+        assert_invariants(partitions, mbi, nmb, dp_size=dp_size, total_lengths=total_lengths, max_per_bin=max_tokens)
+
+
+def test_has_full_schedule_config():
+    assert has_full_schedule_config(make_tp())
+    assert not has_full_schedule_config({})
+    assert not has_full_schedule_config(None)
+    assert not has_full_schedule_config({"dp_size": 4})  # fsdp/torchtitan shape
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__]))

--- a/tests/fast/utils/test_dp_schedule.py
+++ b/tests/fast/utils/test_dp_schedule.py
@@ -80,11 +80,11 @@ def assert_invariants(
         partition = partitions[r]
         mbi = micro_batch_indices[r]
 
-        # Same num_mbs per rank (PP sync).
-        assert len(mbi) == sum(num_microbatches), f"rank {r}: mbs count mismatch"
+        # Same micro-batch count per rank (PP sync).
+        assert len(mbi) == sum(num_microbatches), f"rank {r}: micro-batch count mismatch"
 
         # Flattened micro_batch_indices == range(len(partition)).
-        flat = [i for mbs in mbi for i in mbs]
+        flat = [i for micro_batch in mbi for i in micro_batch]
         assert flat == list(range(len(partition))), f"rank {r}: micro_batch_indices don't tile [0, n)"
 
         # Disjoint partitions whose union covers every kept sample.
@@ -95,13 +95,15 @@ def assert_invariants(
     if max_per_bin is None:
         return
 
-    # Every mbs <= max_per_bin tokens, EXCEPT a singleton bin holding an oversized sample.
+    # Every micro-batch <= max_per_bin tokens, EXCEPT a singleton bin holding an oversized sample.
     for r in range(dp_size):
         partition = partitions[r]
-        for mbs in micro_batch_indices[r]:
-            bin_total = sum(total_lengths[partition[i]] for i in mbs)
+        for micro_batch in micro_batch_indices[r]:
+            bin_total = sum(total_lengths[partition[i]] for i in micro_batch)
             if bin_total > max_per_bin:
-                assert len(mbs) == 1, f"rank {r}: mbs sum {bin_total} > {max_per_bin} but contains {len(mbs)} samples"
+                assert (
+                    len(micro_batch) == 1
+                ), f"rank {r}: micro-batch sum {bin_total} > {max_per_bin} but contains {len(micro_batch)} samples"
 
 
 def test_static_stride_single_step():
@@ -151,7 +153,7 @@ def test_static_balance_multi_step():
 
 
 def test_dynamic_uniform():
-    """Dynamic mbs on uniform-length samples."""
+    """Dynamic micro-batching on uniform-length samples."""
     total_lengths = [5] * 8
     rollout_indices = list(range(8))
     args = make_args(use_dynamic_batch_size=True, max_tokens_per_gpu=10)
@@ -174,7 +176,7 @@ def test_dynamic_uniform():
 
 
 def test_dynamic_oversized_sample_lands_alone():
-    """A sample larger than max_per_bin must end up alone in its mbs."""
+    """A sample larger than max_per_bin must end up alone in its micro-batch."""
     total_lengths = [15, 3, 3, 3, 3, 3, 3, 3]
     rollout_indices = list(range(8))
     args = make_args(use_dynamic_batch_size=True, max_tokens_per_gpu=10)
@@ -199,9 +201,9 @@ def test_dynamic_oversized_sample_lands_alone():
         if oversize_idx not in partitions[r]:
             continue
         local = partitions[r].index(oversize_idx)
-        for mbs in mbi[r]:
-            if local in mbs:
-                assert mbs == [local], f"oversized sample shares an mbs: {mbs}"
+        for micro_batch in mbi[r]:
+            if local in micro_batch:
+                assert micro_batch == [local], f"oversized sample shares a micro-batch: {micro_batch}"
                 found = True
     assert found
 
@@ -244,18 +246,20 @@ def test_rollout_grouping_keeps_samples_together():
 
     # 3 rollouts / 1 per step -> 3 steps, gbs constant.
     assert num_rollouts_per_step == [1, 1, 1]
-    # For each step, collect the samples (global indices) that landed in that step's mbs
+    # For each step, collect the samples (global indices) that landed in that step's micro-batches
     # on rank 0, then verify they exactly equal the rollout's sample positions.
     expected_per_step = [[0, 1, 2], [3, 4], [5, 6, 7, 8]]
     rank0_partition = partitions[0]
-    mbs_cursor = 0
-    for step_i, n_mbs in enumerate(nmb):
-        step_locals = sorted(j for mbs in mbi[0][mbs_cursor : mbs_cursor + n_mbs] for j in mbs)
+    micro_batch_cursor = 0
+    for step_i, n_micro_batches in enumerate(nmb):
+        step_locals = sorted(
+            j for micro_batch in mbi[0][micro_batch_cursor : micro_batch_cursor + n_micro_batches] for j in micro_batch
+        )
         step_globals = [rank0_partition[j] for j in step_locals]
         assert (
             sorted(step_globals) == expected_per_step[step_i]
         ), f"step {step_i} samples = {step_globals}, expected {expected_per_step[step_i]}"
-        mbs_cursor += n_mbs
+        micro_batch_cursor += n_micro_batches
     assert_invariants(
         partitions,
         mbi,
@@ -342,8 +346,8 @@ def test_rejects_when_fewer_rollouts_than_gbs():
         build_dp_schedule(args, tp, [3] * 6, global_batch_size=4, rollout_indices=[0, 0, 1, 1, 2, 2])
 
 
-def test_static_misaligned_mbs_count_asserts():
-    """Static path: mbs count not a multiple of dp_size * mb_group must fail loudly."""
+def test_static_misaligned_micro_batch_count_asserts():
+    """Static path: micro_batch count not a multiple of dp_size * mb_group must fail loudly."""
     args = make_args(micro_batch_size=3)
     tp = make_tp(dp_size=2)
     with pytest.raises(AssertionError, match="static path"):
@@ -411,7 +415,7 @@ def test_balance_by_flops_packs_and_distributes():
 
 
 def test_balance_by_flops_singleton_fallback():
-    """When ceil(total/cap) >= n samples, every sample gets its own mbs."""
+    """When ceil(total/cap) >= n samples, every sample gets its own micro_batch."""
     total_lengths = [100] * 4
     args = make_args(use_dynamic_batch_size=True, max_tokens_per_gpu=100, balance_by_flops=True)
     tp = make_tp(dp_size=2)
@@ -419,10 +423,10 @@ def test_balance_by_flops_singleton_fallback():
     partitions, mbi, nmb, _ = build_dp_schedule(
         args, tp, total_lengths, global_batch_size=4, rollout_indices=list(range(4))
     )
-    assert sum(nmb) * 2 == 4  # 4 singleton mbs over 2 ranks
+    assert sum(nmb) * 2 == 4  # 4 singleton micro_batch over 2 ranks
     for r in range(2):
-        for mbs in mbi[r]:
-            assert len(mbs) == 1
+        for micro_batch in mbi[r]:
+            assert len(micro_batch) == 1
 
 
 def test_has_full_schedule_config():

--- a/tests/fast/utils/test_dp_schedule.py
+++ b/tests/fast/utils/test_dp_schedule.py
@@ -1,13 +1,11 @@
 """CPU unit tests for miles.utils.dp_schedule.build_dp_schedule.
 
 The tests assert the invariants documented at the top of dp_schedule.py against
-a range of static / dynamic / VPP / oversize / balance scenarios, plus an
-equivalence check of ``num_microbatches`` against the legacy train-side
-computation (``get_minimum_num_micro_batch_size`` + DP-wide MAX) that this
-schedule replaces.
+static / dynamic / VPP / oversize / balance / compact-rollout / trailing-trim
+scenarios.
 
 Trim, dynamic-gbs resolution, and per-rank rollout_data packaging all live in
-``train_data_conversion.split_train_data_by_dp_scheduled``; these tests just
+``train_data_conversion.split_train_data_by_dp_scheduled_raw``; these tests just
 exercise the schedule itself (``partitions`` and ``micro_batch_indices``).
 """
 
@@ -18,7 +16,6 @@ from types import SimpleNamespace
 
 import pytest
 
-from miles.utils.data import get_minimum_num_micro_batch_size
 from miles.utils.dp_schedule import build_dp_schedule, has_full_schedule_config
 
 
@@ -28,12 +25,28 @@ def make_args(
     use_dynamic_batch_size=False,
     max_tokens_per_gpu=None,
     balance_data=False,
+    balance_by_flops=False,
 ):
     return SimpleNamespace(
         micro_batch_size=micro_batch_size,
         use_dynamic_batch_size=use_dynamic_batch_size,
         max_tokens_per_gpu=max_tokens_per_gpu,
         balance_data=balance_data,
+        balance_by_flops=balance_by_flops,
+        # Minimal model config for calculate_fwd_flops (balance_by_flops path).
+        hidden_size=16,
+        num_attention_heads=2,
+        num_query_groups=2,
+        vocab_size=32,
+        ffn_hidden_size=64,
+        num_experts=None,
+        num_layers=2,
+        kv_channels=8,
+        q_lora_rank=None,  # no MLA in the stub config
+        kv_lora_rank=None,
+        qk_pos_emb_head_dim=0,
+        qk_head_dim=8,
+        v_head_dim=8,
     )
 
 
@@ -46,30 +59,38 @@ def make_tp(dp_size=1, cp_size=1, vpp_size=1, microbatch_group_size_per_vp_stage
     }
 
 
-def assert_invariants(partitions, micro_batch_indices, num_microbatches, *, dp_size, total_lengths, max_per_bin=None):
-    """Check the invariants documented at the top of dp_schedule.py."""
-    expected_per_rank = len(total_lengths) // dp_size
+def assert_invariants(
+    partitions,
+    micro_batch_indices,
+    num_microbatches,
+    *,
+    dp_size,
+    expected_global_sample_indices,
+    total_lengths,
+    max_per_bin=None,
+):
+    """Check the invariants documented at the top of dp_schedule.py.
+
+    ``expected_global_sample_indices`` is the set of global sample indices
+    that should end up covered (after trim). Trailing rollouts that don't
+    fit are excluded.
+    """
     seen_global: set[int] = set()
     for r in range(dp_size):
         partition = partitions[r]
         mbi = micro_batch_indices[r]
 
-        # Same sample count per rank.
-        assert len(partition) == expected_per_rank, f"rank {r}: {len(partition)} samples, want {expected_per_rank}"
-
-        # Same num_mbs per rank (PP sync); num_microbatches is shared, so each rank's
-        # flat mbs count must match sum(num_microbatches).
+        # Same num_mbs per rank (PP sync).
         assert len(mbi) == sum(num_microbatches), f"rank {r}: mbs count mismatch"
 
-        # Flattened micro_batch_indices == range(len(partition)) (each sample covered
-        # exactly once, by exactly one mbs).
+        # Flattened micro_batch_indices == range(len(partition)).
         flat = [i for mbs in mbi for i in mbs]
         assert flat == list(range(len(partition))), f"rank {r}: micro_batch_indices don't tile [0, n)"
 
-        # Disjoint partitions whose union covers every sample.
+        # Disjoint partitions whose union covers every kept sample.
         assert seen_global.isdisjoint(partition), f"rank {r}: overlap with other ranks"
         seen_global.update(partition)
-    assert seen_global == set(range(len(total_lengths))), "some samples not assigned to any rank"
+    assert seen_global == set(expected_global_sample_indices), "covered sample set mismatch"
 
     if max_per_bin is None:
         return
@@ -84,82 +105,100 @@ def assert_invariants(partitions, micro_batch_indices, num_microbatches, *, dp_s
 
 
 def test_static_stride_single_step():
-    """Static + strided DP split, single step."""
+    """Static + strided DP split, single step (1 rollout = 1 sample)."""
     total_lengths = [10] * 16
+    rollout_indices = list(range(16))
     args = make_args(micro_batch_size=2)
     tp = make_tp(dp_size=4)
 
-    partitions, mbi, nmb = build_dp_schedule(args, tp, total_lengths, global_batch_size=16)
+    partitions, mbi, nmb, num_rollouts_per_step = build_dp_schedule(
+        args, tp, total_lengths, global_batch_size=16, rollout_indices=rollout_indices
+    )
 
     assert nmb == [2]
-    assert_invariants(partitions, mbi, nmb, dp_size=4, total_lengths=total_lengths)
-
-
-def test_static_stride_matches_legacy_partition_order():
-    """Static + strided must produce exactly the legacy strided row order —
-    rank r gets rows [r, r+dp, r+2*dp, ...] in that order, contiguously chunked."""
-    total_lengths = list(range(100, 116))
-    args = make_args(micro_batch_size=2)
-    tp = make_tp(dp_size=4)
-
-    partitions, _, _ = build_dp_schedule(args, tp, total_lengths, global_batch_size=16)
-
-    for r in range(4):
-        assert partitions[r] == list(range(r, 16, 4)), f"rank {r} partition deviates from legacy strided order"
+    assert num_rollouts_per_step == [16]
+    assert_invariants(
+        partitions,
+        mbi,
+        nmb,
+        dp_size=4,
+        expected_global_sample_indices=range(16),
+        total_lengths=total_lengths,
+    )
 
 
 def test_static_balance_multi_step():
-    """Static + balance_data + 2 training steps. Each rank must get gbs/dp per step."""
-    total_lengths = [1, 2, 3, 4, 5, 6, 7, 8, 8, 7, 6, 5, 4, 3, 2, 1]  # 2 steps of 8
+    """Static + balance_data + 2 training steps."""
+    total_lengths = [1, 2, 3, 4, 5, 6, 7, 8, 8, 7, 6, 5, 4, 3, 2, 1]
+    rollout_indices = list(range(16))
     args = make_args(micro_batch_size=2, balance_data=True)
     tp = make_tp(dp_size=2)
 
-    partitions, mbi, nmb = build_dp_schedule(args, tp, total_lengths, global_batch_size=8)
+    partitions, mbi, nmb, num_rollouts_per_step = build_dp_schedule(
+        args, tp, total_lengths, global_batch_size=8, rollout_indices=rollout_indices
+    )
 
     assert nmb == [2, 2]
-    assert_invariants(partitions, mbi, nmb, dp_size=2, total_lengths=total_lengths)
+    assert num_rollouts_per_step == [8, 8]
+    assert_invariants(
+        partitions,
+        mbi,
+        nmb,
+        dp_size=2,
+        expected_global_sample_indices=range(16),
+        total_lengths=total_lengths,
+    )
 
 
 def test_dynamic_uniform():
     """Dynamic mbs on uniform-length samples."""
     total_lengths = [5] * 8
+    rollout_indices = list(range(8))
     args = make_args(use_dynamic_batch_size=True, max_tokens_per_gpu=10)
     tp = make_tp(dp_size=2)
 
-    partitions, mbi, nmb = build_dp_schedule(args, tp, total_lengths, global_batch_size=8)
+    partitions, mbi, nmb, num_rollouts_per_step = build_dp_schedule(
+        args, tp, total_lengths, global_batch_size=8, rollout_indices=rollout_indices
+    )
 
-    assert_invariants(partitions, mbi, nmb, dp_size=2, total_lengths=total_lengths, max_per_bin=10)
-
-
-def test_dynamic_skewed_lengths():
-    """Skewed lengths (the case where K-K used to over-pack a single bin)."""
-    total_lengths = [9, 9, 9, 9, 1, 1, 1, 1]
-    args = make_args(use_dynamic_batch_size=True, max_tokens_per_gpu=10)
-    tp = make_tp(dp_size=2)
-
-    partitions, mbi, nmb = build_dp_schedule(args, tp, total_lengths, global_batch_size=8)
-
-    assert_invariants(partitions, mbi, nmb, dp_size=2, total_lengths=total_lengths, max_per_bin=10)
+    assert num_rollouts_per_step == [8]
+    assert_invariants(
+        partitions,
+        mbi,
+        nmb,
+        dp_size=2,
+        expected_global_sample_indices=range(8),
+        total_lengths=total_lengths,
+        max_per_bin=10,
+    )
 
 
 def test_dynamic_oversized_sample_lands_alone():
-    """A single sample exceeding max_per_bin must end up alone in its mbs (with no
-    other samples crammed in)."""
-    total_lengths = [15, 3, 3, 3, 3, 3, 3, 3]  # 15 > C=10
+    """A sample larger than max_per_bin must end up alone in its mbs."""
+    total_lengths = [15, 3, 3, 3, 3, 3, 3, 3]
+    rollout_indices = list(range(8))
     args = make_args(use_dynamic_batch_size=True, max_tokens_per_gpu=10)
     tp = make_tp(dp_size=2)
 
-    partitions, mbi, nmb = build_dp_schedule(args, tp, total_lengths, global_batch_size=8)
+    partitions, mbi, nmb, num_rollouts_per_step = build_dp_schedule(
+        args, tp, total_lengths, global_batch_size=8, rollout_indices=rollout_indices
+    )
 
-    assert_invariants(partitions, mbi, nmb, dp_size=2, total_lengths=total_lengths, max_per_bin=10)
-    # Find the rank holding the oversized sample and verify it lives alone in some mbs.
+    assert_invariants(
+        partitions,
+        mbi,
+        nmb,
+        dp_size=2,
+        expected_global_sample_indices=range(8),
+        total_lengths=total_lengths,
+        max_per_bin=10,
+    )
     oversize_idx = total_lengths.index(15)
     found = False
     for r in range(2):
-        partition = partitions[r]
-        if oversize_idx not in partition:
+        if oversize_idx not in partitions[r]:
             continue
-        local = partition.index(oversize_idx)
+        local = partitions[r].index(oversize_idx)
         for mbs in mbi[r]:
             if local in mbs:
                 assert mbs == [local], f"oversized sample shares an mbs: {mbs}"
@@ -169,82 +208,221 @@ def test_dynamic_oversized_sample_lands_alone():
 
 def test_dynamic_with_vpp_rounds_to_mb_group():
     """num_microbatches per rank should be a multiple of mb_group when vpp_size > 1."""
-    total_lengths = [4] * 32  # 2 steps of 16; per step, ~8 bins of 8 needed at C=8
+    total_lengths = [4] * 32
+    rollout_indices = list(range(32))
     args = make_args(use_dynamic_batch_size=True, max_tokens_per_gpu=8)
     tp = make_tp(dp_size=2, vpp_size=2, microbatch_group_size_per_vp_stage=2)
 
-    partitions, mbi, nmb = build_dp_schedule(args, tp, total_lengths, global_batch_size=16)
+    partitions, mbi, nmb, num_rollouts_per_step = build_dp_schedule(
+        args, tp, total_lengths, global_batch_size=16, rollout_indices=rollout_indices
+    )
 
     for n in nmb:
         assert n % 2 == 0, f"num_microbatches {n} is not a multiple of mb_group=2"
-    assert_invariants(partitions, mbi, nmb, dp_size=2, total_lengths=total_lengths, max_per_bin=8)
+    assert_invariants(
+        partitions,
+        mbi,
+        nmb,
+        dp_size=2,
+        expected_global_sample_indices=range(32),
+        total_lengths=total_lengths,
+        max_per_bin=8,
+    )
 
 
-def test_static_indivisible_per_rank_batch_asserts():
-    """gbs/dp not a multiple of micro_batch_size must fail loudly, not mis-schedule."""
+def test_rollout_grouping_keeps_samples_together():
+    """compact / subagent simulation: rollout 0 emits 3 samples, rollout 1 emits 2,
+    rollout 2 emits 4. Splitter keeps every rollout's samples in a single step."""
+    rollout_indices = [0, 0, 0, 1, 1, 2, 2, 2, 2]
+    total_lengths = [3] * 9
+    args = make_args(use_dynamic_batch_size=True, max_tokens_per_gpu=12)
+    tp = make_tp(dp_size=1)
+
+    partitions, mbi, nmb, num_rollouts_per_step = build_dp_schedule(
+        args, tp, total_lengths, global_batch_size=1, rollout_indices=rollout_indices
+    )
+
+    # 3 rollouts / 1 per step -> 3 steps, gbs constant.
+    assert num_rollouts_per_step == [1, 1, 1]
+    # For each step, collect the samples (global indices) that landed in that step's mbs
+    # on rank 0, then verify they exactly equal the rollout's sample positions.
+    expected_per_step = [[0, 1, 2], [3, 4], [5, 6, 7, 8]]
+    rank0_partition = partitions[0]
+    mbs_cursor = 0
+    for step_i, n_mbs in enumerate(nmb):
+        step_locals = sorted(j for mbs in mbi[0][mbs_cursor : mbs_cursor + n_mbs] for j in mbs)
+        step_globals = [rank0_partition[j] for j in step_locals]
+        assert (
+            sorted(step_globals) == expected_per_step[step_i]
+        ), f"step {step_i} samples = {step_globals}, expected {expected_per_step[step_i]}"
+        mbs_cursor += n_mbs
+    assert_invariants(
+        partitions,
+        mbi,
+        nmb,
+        dp_size=1,
+        expected_global_sample_indices=range(9),
+        total_lengths=total_lengths,
+        max_per_bin=12,
+    )
+
+
+def test_trims_trailing_rollouts_that_dont_fill_a_step():
+    """5 rollouts, gbs=2 -> 2 steps x 2 rollouts; trailing rollout 4 (sample positions 6, 7)
+    is dropped."""
+    rollout_indices = [0, 0, 1, 2, 2, 3, 4, 4]
+    total_lengths = [3] * 8
+    args = make_args(use_dynamic_batch_size=True, max_tokens_per_gpu=12)
+    tp = make_tp(dp_size=1)
+
+    partitions, mbi, nmb, num_rollouts_per_step = build_dp_schedule(
+        args, tp, total_lengths, global_batch_size=2, rollout_indices=rollout_indices
+    )
+
+    assert num_rollouts_per_step == [2, 2]
+    # Sample positions 6 and 7 belong to the trimmed rollout 4 and must be absent.
+    assert_invariants(
+        partitions,
+        mbi,
+        nmb,
+        dp_size=1,
+        expected_global_sample_indices=range(6),
+        total_lengths=total_lengths,
+        max_per_bin=12,
+    )
+
+
+def test_partial_final_step_opt_in():
+    """--allow-partial-train-step: 5 rollouts, gbs=2 -> 2 full steps + 1 partial
+    step of the trailing rollout, covering every sample."""
+    rollout_indices = [0, 0, 1, 2, 2, 3, 4, 4]
+    total_lengths = [3] * 8
+    args = make_args(use_dynamic_batch_size=True, max_tokens_per_gpu=12)
+    args.allow_partial_train_step = True
+    tp = make_tp(dp_size=1)
+
+    partitions, mbi, nmb, num_rollouts_per_step = build_dp_schedule(
+        args, tp, total_lengths, global_batch_size=2, rollout_indices=rollout_indices
+    )
+
+    assert num_rollouts_per_step == [2, 2, 1]
+    assert len(nmb) == 3
+    assert_invariants(
+        partitions,
+        mbi,
+        nmb,
+        dp_size=1,
+        expected_global_sample_indices=range(8),
+        total_lengths=total_lengths,
+        max_per_bin=12,
+    )
+
+
+def test_partial_final_step_skipped_when_below_dp_size():
+    """A trailing rollout with fewer samples than dp_size cannot form a step."""
+    rollout_indices = [0, 0, 1, 1, 2]
+    total_lengths = [3] * 5
+    args = make_args(use_dynamic_batch_size=True, max_tokens_per_gpu=12)
+    args.allow_partial_train_step = True
+    tp = make_tp(dp_size=2)
+
+    _, _, nmb, num_rollouts_per_step = build_dp_schedule(
+        args, tp, total_lengths, global_batch_size=2, rollout_indices=rollout_indices
+    )
+
+    assert num_rollouts_per_step == [2]
+    assert len(nmb) == 1
+
+
+def test_rejects_when_fewer_rollouts_than_gbs():
+    """gbs=4 with only 3 distinct rollouts -> cannot form one step."""
+    args = make_args(use_dynamic_batch_size=True, max_tokens_per_gpu=12)
+    tp = make_tp(dp_size=1)
+    with pytest.raises(AssertionError, match="global_batch_size"):
+        build_dp_schedule(args, tp, [3] * 6, global_batch_size=4, rollout_indices=[0, 0, 1, 1, 2, 2])
+
+
+def test_static_misaligned_mbs_count_asserts():
+    """Static path: mbs count not a multiple of dp_size * mb_group must fail loudly."""
     args = make_args(micro_batch_size=3)
     tp = make_tp(dp_size=2)
-    with pytest.raises(AssertionError, match="micro_batch_size"):
-        build_dp_schedule(args, tp, [10] * 8, global_batch_size=8)
-
-
-def test_untrimmed_input_asserts():
-    """num_samples not a multiple of global_batch_size must fail loudly."""
-    args = make_args(micro_batch_size=1)
-    tp = make_tp(dp_size=2)
-    with pytest.raises(AssertionError, match="multiple of global_batch_size"):
-        build_dp_schedule(args, tp, [10] * 10, global_batch_size=8)
-
-
-def test_dynamic_num_microbatches_matches_legacy_train_side():
-    """The PP-sync-critical value: for the same strided partition, the rollout-side
-    schedule must produce exactly the num_microbatches the legacy train-side path
-    computed (per-rank ``get_minimum_num_micro_batch_size``, then DP-wide MAX)."""
-    rng = random.Random(42)
-    dp_size, cp_size = 4, 2
-    max_tokens_per_gpu = 512
-    global_batch_size = 32
-
-    for _ in range(50):
-        num_steps = rng.randint(1, 3)
-        total_lengths = [rng.randint(16, 1200) for _ in range(global_batch_size * num_steps)]
-
-        args = make_args(use_dynamic_batch_size=True, max_tokens_per_gpu=max_tokens_per_gpu)
-        tp = make_tp(dp_size=dp_size, cp_size=cp_size)
-        _, _, nmb = build_dp_schedule(args, tp, total_lengths, global_batch_size=global_batch_size)
-
-        # Legacy: each rank r holds the strided rows of each step, computes its own
-        # first-fit bin count over its local per-step slice, and the DP group takes MAX.
-        num_local_gbs = global_batch_size // dp_size
-        legacy_nmb = []
-        for step_i in range(num_steps):
-            step = total_lengths[step_i * global_batch_size : (step_i + 1) * global_batch_size]
-            per_rank = []
-            for r in range(dp_size):
-                local = [step[i] for i in range(r, global_batch_size, dp_size)]
-                assert len(local) == num_local_gbs
-                per_rank.append(get_minimum_num_micro_batch_size(local, max_tokens_per_gpu * cp_size))
-            legacy_nmb.append(max(per_rank))
-
-        assert nmb == legacy_nmb, f"num_microbatches diverged from legacy: {nmb} vs {legacy_nmb}"
+    with pytest.raises(AssertionError, match="static path"):
+        build_dp_schedule(args, tp, [10] * 8, global_batch_size=8, rollout_indices=list(range(8)))
 
 
 def test_randomized_invariants_dynamic():
-    """Randomized sweep of the documented invariants on the dynamic path."""
+    """Randomized sweep of the documented invariants on the dynamic path,
+    including random compact rollout groupings."""
     rng = random.Random(7)
     for _ in range(30):
         dp_size = rng.choice([1, 2, 4])
         gbs = dp_size * rng.choice([2, 4, 8])
-        num_steps = rng.randint(1, 2)
-        total_lengths = [rng.randint(1, 40) for _ in range(gbs * num_steps)]
+        num_rollouts = gbs * rng.randint(1, 2) + rng.randint(0, 3)  # may leave a trailing partial step
+        rollout_indices = []
+        for rid in range(num_rollouts):
+            rollout_indices.extend([rid] * rng.randint(1, 3))
+        total_lengths = [rng.randint(1, 40) for _ in rollout_indices]
         max_tokens = rng.randint(20, 60)
         balance = rng.random() < 0.5
 
         args = make_args(use_dynamic_batch_size=True, max_tokens_per_gpu=max_tokens, balance_data=balance)
         tp = make_tp(dp_size=dp_size)
-        partitions, mbi, nmb = build_dp_schedule(args, tp, total_lengths, global_batch_size=gbs)
+        partitions, mbi, nmb, num_rollouts_per_step = build_dp_schedule(
+            args, tp, total_lengths, global_batch_size=gbs, rollout_indices=rollout_indices
+        )
 
-        assert_invariants(partitions, mbi, nmb, dp_size=dp_size, total_lengths=total_lengths, max_per_bin=max_tokens)
+        num_steps = num_rollouts // gbs
+        assert num_rollouts_per_step == [gbs] * num_steps
+        kept_rollouts = set(range(num_steps * gbs))
+        expected = [i for i, rid in enumerate(rollout_indices) if rid in kept_rollouts]
+        assert_invariants(
+            partitions,
+            mbi,
+            nmb,
+            dp_size=dp_size,
+            expected_global_sample_indices=expected,
+            total_lengths=total_lengths,
+            max_per_bin=max_tokens,
+        )
+
+
+def test_balance_by_flops_packs_and_distributes():
+    """balance_by_flops: KK-on-FLOPs packing, invariants preserved (the token cap
+    is intentionally NOT enforced in this mode)."""
+    total_lengths = [10, 200, 30, 400, 50, 600, 70, 800]
+    rollout_indices = list(range(8))
+    args = make_args(use_dynamic_batch_size=True, max_tokens_per_gpu=600, balance_by_flops=True)
+    tp = make_tp(dp_size=2)
+
+    partitions, mbi, nmb, num_rollouts_per_step = build_dp_schedule(
+        args, tp, total_lengths, global_batch_size=8, rollout_indices=rollout_indices
+    )
+
+    assert num_rollouts_per_step == [8]
+    assert_invariants(
+        partitions,
+        mbi,
+        nmb,
+        dp_size=2,
+        expected_global_sample_indices=range(8),
+        total_lengths=total_lengths,
+        max_per_bin=None,  # cap not enforced in FLOPs mode
+    )
+
+
+def test_balance_by_flops_singleton_fallback():
+    """When ceil(total/cap) >= n samples, every sample gets its own mbs."""
+    total_lengths = [100] * 4
+    args = make_args(use_dynamic_batch_size=True, max_tokens_per_gpu=100, balance_by_flops=True)
+    tp = make_tp(dp_size=2)
+
+    partitions, mbi, nmb, _ = build_dp_schedule(
+        args, tp, total_lengths, global_batch_size=4, rollout_indices=list(range(4))
+    )
+    assert sum(nmb) * 2 == 4  # 4 singleton mbs over 2 ranks
+    for r in range(2):
+        for mbs in mbi[r]:
+            assert len(mbs) == 1
 
 
 def test_has_full_schedule_config():

--- a/tests/fast/utils/test_ffd_pack.py
+++ b/tests/fast/utils/test_ffd_pack.py
@@ -1,0 +1,50 @@
+"""CPU tests for first-fit-decreasing packing and its bin-count gain over first-fit."""
+
+from __future__ import annotations
+
+import random
+
+from miles.utils.seqlen_balancing import first_fit_decreasing_pack, first_fit_pack
+
+
+def _check_valid(bins, lengths, cap):
+    seen = sorted(i for b in bins for i in b)
+    assert seen == list(range(len(lengths))), "every sample packed exactly once"
+    for b in bins:
+        total = sum(lengths[i] for i in b)
+        assert total <= cap or len(b) == 1, f"bin over cap with >1 sample: {total}"
+
+
+def test_ffd_same_contract_as_first_fit():
+    rng = random.Random(3)
+    for _ in range(50):
+        n = rng.randint(1, 64)
+        cap = rng.randint(50, 400)
+        lengths = [rng.randint(1, cap * 2) for _ in range(n)]  # includes oversized
+        _check_valid(first_fit_decreasing_pack(lengths, cap), lengths, cap)
+
+
+def test_ffd_never_more_bins_than_first_fit():
+    rng = random.Random(11)
+    for _ in range(200):
+        n = rng.randint(2, 96)
+        cap = rng.randint(100, 1000)
+        lengths = [rng.randint(1, cap) for _ in range(n)]
+        ff = len(first_fit_pack(lengths, cap))
+        ffd = len(first_fit_decreasing_pack(lengths, cap))
+        assert ffd <= ff, f"FFD produced more bins ({ffd}) than FF ({ff})"
+
+
+def test_ffd_gain_on_mid_length_distribution():
+    """FFD's gain concentrates where item sizes are a sizable fraction of the
+    cap (long-response RL with roomy token budgets): measured ~3-7% fewer bins
+    for mean-length ~cap/4..cap/2 regimes, 0% for short-response regimes where
+    both packers are already optimal. Assert the mid regime keeps a >=4% edge."""
+    rng = random.Random(42)
+    cap = 9216
+    total_ff = total_ffd = 0
+    for _ in range(500):
+        lengths = [rng.randint(2000, 6000) for _ in range(32)]
+        total_ff += len(first_fit_pack(lengths, cap))
+        total_ffd += len(first_fit_decreasing_pack(lengths, cap))
+    assert total_ffd <= total_ff * 0.96, f"expected >=4% bin savings, got FF={total_ff} FFD={total_ffd}"

--- a/tests/manual/compact_split_generate.py
+++ b/tests/manual/compact_split_generate.py
@@ -1,0 +1,35 @@
+"""E2E fixture: compact generate fn splitting one rollout execution into two
+training samples that share the parent's rollout_id. Use via
+--custom-generate-function-path tests.manual.compact_split_generate.generate"""
+
+import copy
+
+from miles.rollout.base_types import GenerateFnInput, GenerateFnOutput
+from miles.rollout.generate_hub.single_turn import generate as single_turn_generate
+from miles.utils.types import Sample
+
+
+async def generate(input: GenerateFnInput) -> GenerateFnOutput:
+    output = await single_turn_generate(input)
+    sample = output.samples
+    assert isinstance(sample, Sample)
+
+    sample.rollout_id = sample.index
+    if sample.response_length < 2 or sample.status == Sample.Status.ABORTED:
+        return GenerateFnOutput(samples=[sample])
+
+    prompt_len = len(sample.tokens) - sample.response_length
+    cut = sample.response_length // 2
+
+    first = copy.deepcopy(sample)
+    first.tokens = sample.tokens[: prompt_len + cut]
+    first.response_length = cut
+    first.loss_mask = sample.loss_mask[:cut] if sample.loss_mask is not None else None
+    if first.rollout_log_probs is not None:
+        first.rollout_log_probs = sample.rollout_log_probs[:cut]
+    first.status = Sample.Status.COMPLETED
+
+    second = copy.deepcopy(sample)
+    second.loss_mask = [0] * cut + list(sample.loss_mask[cut:]) if sample.loss_mask is not None else None
+
+    return GenerateFnOutput(samples=[first, second])


### PR DESCRIPTION
## Motivation

RL rollout production is inherently variable: dynamic-sampling filters drop samples, agentic / multi-turn rollouts emit a variable number of training samples per execution, and collected batches rarely land on an exact multiple of the training batch size. The legacy pipeline assumed the opposite — a fixed `global_batch_size` counted in samples, every DP rank holding the same sample count, per-sample loss weighting. The consequences: trailing samples were trimmed away (wasted rollouts), a rollout execution that produced N training samples was counted N times in the loss (over-weighting long executions), and its sibling samples could be split across training steps or trim boundaries.

This PR first moves DP/microbatch scheduling to the rollout side (commit 1), then makes the **rollout execution the unit of accounting** end to end, and adds the packing/throughput knobs that fall out of having a global scheduler. The core design follows slime's variable-global-batch-size series ([THUDM/slime#1930](https://github.com/THUDM/slime/pull/1930), [THUDM/slime#1933](https://github.com/THUDM/slime/pull/1933)), adapted to miles's backends and constraints; the FLOPs-balanced packing ports slime [#2017](https://github.com/THUDM/slime/pull/2017)/[#2029](https://github.com/THUDM/slime/pull/2029). FFD packing and the partial final step are miles extensions on top.

## Worked examples

**1. Trailing rollouts: dropped vs trained.** 32 rollouts collected, `global_batch_size=24`:

```
before:  train [24] + drop 8            -> 25% of generation wasted
after:   train [24] + train [8]         -> --allow-partial-train-step
```

The final step is mathematically honest, not padded: its loss normalizer is 8 and the LR scheduler advances by 8, so the gradient is "the mean over these 8 rollouts" — the same estimator as a full step, just with fewer rollouts.

**2. One execution split into N samples: loss double-counting.** An agentic execution (rollout 7) is too long for one training sample, so the generate fn splits it into siblings A (500 loss tokens) and B (300); C (400 tokens) is an independent execution:

```
before:  loss = (mean(A) + mean(B) + mean(C)) / 3     -> rollout 7 counted twice
after:   loss = (sum(A)/800 + sum(B)/800 + sum(C)/400) / 2
                 \_____ = rollout 7's token mean ____/
```

`rollout_mask_sums` broadcasts the whole-rollout total (800) to every sibling as its denominator, so the execution is counted exactly once — regardless of which micro-batch, DP rank, or CP shard each sibling lands on: the partial `sum/800` contributions re-assemble under the existing all-reduce.

**3. Siblings split by a batch boundary.** 5 samples where the last two are siblings, legacy `global_batch_size=4` counted in samples:

```
before:  train [s0 s1 s2 s3a] , drop s3b     -> half an execution trained
after:   group {s0} {s1} {s2} {s3a+s3b}, gbs counts rollouts
         -> siblings enter one step together, or drop together
```

**4. Pack first, distribute second.** 6 samples of lengths `[9,7,5,3,2,1]`, token cap 10, dp2:

```
before (split by position, pack per rank):
  rank0 [9,7,5] -> bins [9][7][5]   (3 micro-batches, 21 tokens)
  rank1 [3,2,1] -> bins [3+2+1]     (1 micro-batch,    6 tokens)
  -> PP requires equal counts: rank1 idles; 21 vs 6 load skew

after (global FFD pack, then distribute):
  bins [9+1][7+3][5+2] -> split one bin to reach dp multiple ->
  rank0: [9+1][5] = 15 tokens   rank1: [7+3][2] = 12 tokens
  -> equal micro-batch counts by construction, balanced load
```

**5. The common case is a strict no-op.** With 1 rollout = 1 sample and counts divisible by `global_batch_size`, rollout groups are singletons, each denominator is the sample's own mask sum, and the loss reduces to the legacy per-sample mean term by term — verified numerically below (30B: identical `logprob_abs_diff` to main).

## Design

### Foundation: rollout-side scheduling (commit 1)


Scheduling becomes a single pure function on the rollout side, `miles/utils/dp_schedule.py::build_dp_schedule`:

- For each training step (a `global_batch_size` chunk of samples), samples are assigned to DP ranks (Karmarkar-Karp under `--balance-data`, strided otherwise), then each rank's samples are grouped into micro-batches — fixed `micro_batch_size` chunks (static) or first-fit under `max_tokens_per_gpu * cp` with a DP-wide MAX and largest-bin splitting for PP/VPP alignment (dynamic).
- The rollout manager packages the result into the per-rank data shards: each shard carries its `micro_batch_indices` plus the shared per-step `num_microbatches`. `get_data_iterator` on the training side just consumes them — the `all_reduce(MAX)` sync point is gone.
- The training backend advertises eligibility by exposing its full parallel config (`dp/cp/vpp/mb_group`). Paths that can't precompute keep the legacy train-side scheduling untouched: multi-LoRA (slot-contiguity constraints), fsdp/torchtitan, indep_dp/fault-tolerance (dp_size can change at runtime), multimodal batches (train-side media-token expansion changes sequence lengths), and non-divisible sample counts.

Being pure Python with no ray/sglang imports, the scheduler is unit-testable on CPU: invariants (full coverage, disjoint partitions, per-rank micro-batch-count equality for PP sync, token-cap respect with the oversized-sample exception, VPP rounding) are asserted across static/dynamic/balance scenarios, plus a randomized equivalence sweep showing `num_microbatches` matches the legacy train-side computation exactly.


### Variable global batch size (commit 2)


Three layers, all computed on the rollout side and shipped to trainers inside the data shards:

**1. Scheduling — pack first, distribute second.**
Samples are grouped by `Sample.rollout_id` (defaults to `sample.index`, so the classic one-sample-per-rollout path is unchanged; compact rollout functions stamp the same id on every sibling, enforced by shape validation before flattening). Training steps are formed from `global_batch_size` ROLLOUTS — a rollout's samples never split across steps. Each step's samples are packed into `K` micro-batches with one global first-fit-decreasing pass under the token cap (`max_tokens_per_gpu * cp`); `K` is aligned up to `dp_size * mb_group` by splitting the largest bins (cap-preserving); micro-batches are then distributed across DP ranks — strided, Karmarkar-Karp on micro-batch token sums (`--balance-data`), or on per-sample FLOPs estimates (`--balance-by-flops`, capturing the quadratic attention term when lengths vary widely). Trailing rollouts that don't fill a step drop whole — or, with `--allow-partial-train-step`, train as one smaller final step: genuinely variable per-step batch sizes at zero sample waste.

**2. Accounting — per-rollout loss weighting.**
`rollout_mask_sums` — the whole-rollout loss-mask total, broadcast to every sibling sample — is precomputed at the step level, where all of a rollout's samples are visible. The loss reducer divides each sample's masked contribution by its rollout's total, so partial contributions summed across micro-batches (and across DP/CP ranks under the existing all-reduce) reconstruct exactly one token-weighted mean per rollout, no matter how the packer scattered the siblings. With 1 rollout = 1 sample this equals the legacy per-sample mean exactly.

**3. Normalization and metrics — true per-step counts.**
The loss normalizer and the LR scheduler increment use the actual per-step rollout count (`num_rollouts`, threaded from the schedule through the data shards via `get_num_rollouts`), not `args.global_batch_size`, so uneven steps stay correctly scaled. Metric reduction switches from mean-of-rank-means to count-weighted `(sum, count)` aggregation, unbiased when ranks or steps hold different counts.

## Compatibility

- **Strict no-op for existing workloads** — verified numerically below.
- Legacy train-side path preserved for multi-LoRA, fsdp/torchtitan, indep_dp/fault-tolerance, and multimodal; `--use-dynamic-global-batch-size` / `--disable-rollout-trim-samples` keep working for those paths.
- One deliberate semantic change: in the TIS decoupled path, modified response masks correct the numerator only; denominators stay the precomputed rollout totals, keeping a single normalizer across the loss.

## Validation

Three dedicated CI e2e tests ship with this PR:
- `tests/e2e/short/test_qwen2.5_0.5B_compact_rollout.py` — a compact generate fn (`tests/manual/compact_split_generate.py`) splits every rollout execution into two sibling samples; validates by-rollout step accounting and per-rollout loss weighting end to end.
- `tests/e2e/megatron/test_qwen3_4B_variable_gbs.py` — `global_batch_size=24` over 32 collected rollouts with `--allow-partial-train-step` and trim disabled, under cp2: trains uneven `[24, 8]` steps.
- `tests/e2e/megatron/test_qwen3_30B_A3B/test_dp_attention.py` — sglang dp-attention (`--sglang-enable-dp-attention`, dp4) with the rollout-side schedule active: dp-aware request dispatch reshuffles sample completion order; the schedule must stay order-insensitive (grouping keys on rollout_id).

CPU: 366 tests green at the tip (schedule invariants incl. compact grouping and whole-rollout trailing trim, randomized sweeps with random rollout groupings, weighted-reduction units, loss snapshots, session merge, FFD property tests, argument validation).

GPU e2e, 8xH200, `--ci-test`:

| run | topology | result |
|---|---|---|
| Qwen2.5-0.5B gsm8k (GRPO) | dp8, dynamic batch, mooncake | ✅ green at every layer of the series |
| Qwen3-30B-A3B (GRPO) | dp2 + cp2 + pp2 + ep2, metric gates | ✅ see no-op table below |
| Qwen3.5-35B-A3B GDN (GRPO) | cp2 | ✅ succeeded |
| Qwen3-4B PPO | actor cp2 + separate critic, `num_critic_only_steps 1` | ✅ succeeded on this rebased tree |
| compact gain demo | 0.5B + `tests/manual/compact_split_generate.py` | ✅ |
| compact stress | 288 samples / 64 rollouts, cp2, tight cap | ✅ |
| partial-step demo | gbs=24, trim off | ✅ |

## Experiment results

### No-op check — 30B dp2+cp2+pp2+ep2, identical topology across the series layers

| tree | `train_rollout_logprob_abs_diff` | `grad_norm` |
|---|---|---|
| scheduling refactor only (#1927) | 0.0178 | 0.13 |
| + per-step batch-size threading | 0.0171 | 0.099 |
| + per-rollout denominators | 0.0177 | 0.099 |
| + pack-first / by-rollout steps | 0.0176 | 0.13 |

All within run-to-run sampling noise: 1-rollout-=-1-sample training is untouched.

### Compact rollout accounting (the new capability)

The compact fixture (`tests/manual/compact_split_generate.py`) splits each execution into 2 training samples sharing `rollout_id`:

```
Rollout-side DP schedule: num_samples=64, num_rollouts=[32], num_microbatches=[1]
```

32 executions → 64 samples → ONE step of 32 rollouts, per-rollout weighting; rewards stable (0.44-0.56) over 3 rollout batches. Previously this workload trained as 64 independent samples: two steps per batch, siblings split across step/trim boundaries, multi-sample rollouts over-weighted proportionally to their sample count.

Stress: `1 + (index % 8)` siblings per rollout (variable lengths), cp2, `max_tokens_per_gpu=2048` so siblings scatter across micro-batches AND DP ranks, NaN checking on:

```
Rollout-side DP schedule: num_samples=288, num_rollouts=[32, 32], num_microbatches=[3, 3]
```

No NaN, rewards 0.52-0.62, job succeeded — cross-mb/cross-rank denominators reconstruct exactly.

### Partial final step — variable gbs in action

gsm8k 0.5B, `--global-batch-size 24 --allow-partial-train-step --disable-rollout-trim-samples`:

```
Rollout-side DP schedule: num_samples=32, num_rollouts=[24, 8], num_microbatches=[1, 1]
```

Three rollout batches trained with uneven `[24, 8]` steps; the 25% of rollouts previously discarded now train; LR/loss follow the true per-step counts; CI logprob asserts pass.

### FFD packing gain (CPU sweep, 32 samples/step, 2000 steps/regime, cap 9216)

| length regime | bins saved vs first-fit |
|---|---|
| short responses (mean ~350) | 0% (both optimal) |
| lognormal mean ~2500 | 2.9% |
| lognormal mean ~4500 | 4.9% |
| uniform 2k-6k (items ~cap/2) | 6.8% |
| items ~cap | 0.6% |

Fewer bins = fewer gradient-accumulation passes per step; never worse (property-tested).

### PPO (Qwen3-4B, actor cp2 + separate critic)

- Schedule active on both actor and critic groups: `num_rollouts=[32, 32]`, micro-batches `[7,8] / [6,8] / [6,6]` across 3 rollout batches
- Critic trains through the same machinery: `critic-value_loss` 0.56 → 0.32-0.64 band, `value_clipfrac` 0.0, `critic-lr` 1e-5 as configured
- Actor rewards 0.5 → 0.72; weight sync clean



