### PR TITLE
[fix] DSA indexer on Blackwell: send the DSA indexer wk unquantized

### DIFF
--- a/miles/backends/megatron_utils/megatron_to_hf/processors/quantizer_fp8.py
+++ b/miles/backends/megatron_utils/megatron_to_hf/processors/quantizer_fp8.py
@@ -80,7 +80,6 @@ def quantize_params_fp8(args, megatron_name, converted_named_params, quantizatio
         "self_attention.linear_kv_up_proj.weight",
         # DSA indexer
         "self_attention.wq_b.weight",
-        "self_attention.wk.weight",
         # linear attention
         "self_attention.linear_attn.in_proj_qkv.weight",
         "self_attention.linear_attn.in_proj_z.weight",
@@ -90,7 +89,6 @@ def quantize_params_fp8(args, megatron_name, converted_named_params, quantizatio
         "self_attention.wkv.weight",
         "self_attention.wo_b.weight",
         "self_attention.indexer.linear_wq_b.weight",
-        "self_attention.indexer.linear_wk.weight",
     ]:
         quantize_named_params = []
         for converted_name, param in converted_named_params:


### PR DESCRIPTION
The DSA indexer `wk` is quantized to fp8 before the online weight update, but its
destination in sglang is bf16 — since v0.5.16 the engine fuses `wk` and
`weights_proj` into a single bf16 `indexer.wk_weights_proj`, and dequantizes an
fp8 `wk` on the fly with plain fp32 block scales. On Blackwell the converter
emits **ue8m0-packed** scales for non-MoE linears, which that path cannot read,
so every weight sync fails:

```
  File ".../models/deepseek_common/deepseek_weight_loader.py", line 117, in _load_fused_indexer_wk
  File ".../layers/quantization/fp8_utils.py", line 1387, in block_quant_dequant
RuntimeError: The size of tensor a (6144) must match the size of tensor b (1536) at non-singleton dimension 1
```

`wk` is `[128, hidden]`, so its plain block scale is `[1, 48]`; the ue8m0
transform aligns rows to `mn=128` and packs four e8m0 values per word, giving
`[128, 12]`. `block_quant_dequant` then expands `12 x 128 = 1536` columns
against `hidden = 6144`.

This drops `wk` from the fp8 quantize list so it ships bf16, which is what the
destination holds anyway — removing a quantize/dequantize round trip rather than
working around it. `wq_b` stays quantized: it is not part of the fused parameter
and the engine keeps it fp8.

**Cost.** `wk` is `128 x hidden` per layer, ~0.75 MB more per layer in bf16;
~60 MB per sync for a 78-layer model, against a multi-hundred-GB transfer.

**Why this was not seen before.** Offline checkpoint loads are unaffected — the
on-disk fp8 checkpoint stores plain fp32 scales, and only the online path emits
ue8m0. ue8m0 requantization is Blackwell-only, and CI runs on Hopper. Before
v0.5.16 sglang kept `wk` as an fp8 parameter consumed directly by the DeepGEMM
kernel, so the packed scales matched. The bug needs all four of Blackwell, a DSA
model, sglang >= 0.5.16, and online weight update.

**Testing.** Found on GLM-5.2 744B-A40B, 16x GB300, fully-async RL with fp8
rollout: every `update_weights_from_distributed` failed at bring-up before this
change. Verification of the fixed sync on the same configuration is running; I
will post the result here.
