### PR TITLE
[3/N] Per-rollout loss denominators and constant-divisor metric reduction

### DIFF
--- a/miles/backends/megatron_utils/actor.py
+++ b/miles/backends/megatron_utils/actor.py
@@ -38,7 +38,13 @@ from miles.utils.types import RolloutBatch
 
 from ...utils.profile_utils import TrainProfiler
 from ...utils.tensor_backper import TensorBackuper
-from ..training_utils.data import DataIterator, get_data_iterator, get_rollout_data, sync_actor_critic_data
+from ..training_utils.data import (
+    DataIterator,
+    get_data_iterator,
+    get_global_batch_sizes,
+    get_rollout_data,
+    sync_actor_critic_data,
+)
 from ..training_utils.log_utils import log_cpu_memory, log_perf_data, log_rollout_data
 from ..training_utils.loss import (
     compute_advantages_and_returns,
@@ -413,6 +419,7 @@ class MegatronTrainRayActor(TrainRayActor):
             self.opt_param_scheduler,
             data_iterator,
             num_microbatches,
+            get_global_batch_sizes(self.args, rollout_data, len(num_microbatches)),
             witness_info=None,
             attempt=0,
         )
@@ -519,6 +526,7 @@ class MegatronTrainRayActor(TrainRayActor):
                     self.opt_param_scheduler,
                     data_iterator,
                     num_microbatches,
+                    get_global_batch_sizes(self.args, rollout_data, len(num_microbatches)),
                     witness_info=witness_info,
                     attempt=attempt,
                     ft_test_action_executor=self._ft_test_action_executor,

--- a/miles/backends/megatron_utils/actor.py
+++ b/miles/backends/megatron_utils/actor.py
@@ -142,10 +142,8 @@ class MegatronTrainRayActor(TrainRayActor):
                 )
             dist.barrier(group=get_gloo_group())
 
-        # A full config (all miles.utils.dp_schedule.SCHEDULE_CONFIG_KEYS) advertises
-        # that the rollout side may precompute the DP/mbs schedule. indep_dp keeps
-        # ``{}``: dp_size can change at runtime via FT healing, so the schedule must
-        # stay on the training side (delay_split_train_data_by_dp).
+        # A full config (SCHEDULE_CONFIG_KEYS) lets the rollout side precompute the
+        # DP/mbs schedule. indep_dp keeps {}: dp_size can change via FT healing.
         self.train_parallel_config = (
             {}
             if args.indep_dp

--- a/miles/backends/megatron_utils/actor.py
+++ b/miles/backends/megatron_utils/actor.py
@@ -142,7 +142,20 @@ class MegatronTrainRayActor(TrainRayActor):
                 )
             dist.barrier(group=get_gloo_group())
 
-        self.train_parallel_config = {} if args.indep_dp else {"dp_size": get_parallel_state().intra_dp.size}
+        # A full config (all miles.utils.dp_schedule.SCHEDULE_CONFIG_KEYS) advertises
+        # that the rollout side may precompute the DP/mbs schedule. indep_dp keeps
+        # ``{}``: dp_size can change at runtime via FT healing, so the schedule must
+        # stay on the training side (delay_split_train_data_by_dp).
+        self.train_parallel_config = (
+            {}
+            if args.indep_dp
+            else {
+                "dp_size": get_parallel_state().intra_dp.size,
+                "cp_size": get_parallel_state().cp.size,
+                "vpp_size": get_parallel_state().vpp_size,
+                "microbatch_group_size_per_vp_stage": get_parallel_state().microbatch_group_size_per_vp_stage,
+            }
+        )
         dist.barrier(group=get_gloo_group())
 
         if args.offload_train:

--- a/miles/backends/megatron_utils/actor.py
+++ b/miles/backends/megatron_utils/actor.py
@@ -142,8 +142,6 @@ class MegatronTrainRayActor(TrainRayActor):
                 )
             dist.barrier(group=get_gloo_group())
 
-        # A full config (SCHEDULE_CONFIG_KEYS) lets the rollout side precompute the
-        # DP/mbs schedule. indep_dp keeps {}: dp_size can change via FT healing.
         self.train_parallel_config = (
             {}
             if args.indep_dp

--- a/miles/backends/megatron_utils/ft/indep_dp.py
+++ b/miles/backends/megatron_utils/ft/indep_dp.py
@@ -105,7 +105,11 @@ def reconfigure_indep_dp_group(
 
 
 def allreduce_grads_and_losses_across_replicas(
-    args, model: Sequence["DDP"], parallel_state: ParallelState, losses_reduced: list
+    args,
+    model: Sequence["DDP"],
+    parallel_state: ParallelState,
+    losses_reduced: list,
+    step_global_batch_size: int | None = None,
 ) -> tuple[bool, dict[str, float]]:
     assert not args.calculate_per_token_loss, "calculate_per_token_loss is not supported with indep_dp yet"
     assert parallel_state.intra_dp.size == 1, (
@@ -129,7 +133,7 @@ def allreduce_grads_and_losses_across_replicas(
     allreduce_success = True
     try:
         if mpu.is_pipeline_last_stage(ignore_virtual=True):
-            loss_reduced = aggregate_train_losses(losses_reduced)
+            loss_reduced = aggregate_train_losses(losses_reduced, step_global_batch_size)
         for model_chunk in model:
             # mimic: DistributedDataParallel.start_grad_sync
             for bucket_group in model_chunk.bucket_groups + model_chunk.expert_parallel_bucket_groups:

--- a/miles/backends/megatron_utils/model.py
+++ b/miles/backends/megatron_utils/model.py
@@ -386,6 +386,7 @@ def train_one_step(
     optimizer: MegatronOptimizer | None,
     opt_param_scheduler: OptimizerParamScheduler | None,
     num_microbatches: int,
+    step_global_batch_size: int,
     witness_info: WitnessInfo | None,
     attempt: int,
     ft_test_action_executor: FTTestActionActorExecutor | None = None,
@@ -408,6 +409,8 @@ def train_one_step(
         optimizer: Optimizer instance.
         opt_param_scheduler: LR/WD scheduler.
         num_microbatches: Number of microbatches to process.
+        step_global_batch_size: Sample count for this step (total across DP);
+            loss normalizer and LR scheduler increment.
 
     Returns:
         Tuple of (reduced loss dict, gradient norm, step outcome).
@@ -519,7 +522,14 @@ def train_one_step(
         for m, old_stage in zip(all_replay_managers, old_stages, strict=True):
             m.stage = old_stage
 
-        return output_tensor, partial(loss_function, args, batch, num_microbatches, apply_megatron_loss_scaling=True)
+        return output_tensor, partial(
+            loss_function,
+            args,
+            batch,
+            num_microbatches,
+            apply_megatron_loss_scaling=True,
+            step_global_batch_size=step_global_batch_size,
+        )
 
     # Forward pass.
     forward_backward_func = get_forward_backward_func()
@@ -587,9 +597,10 @@ def train_one_step(
             # Update parameters.
             update_successful, grad_norm, num_zeros_in_grad = optimizer.step()
 
-            # Update learning rate.
+            # Update learning rate. Use the per-step sample count so the
+            # scheduler's samples-seen counter tracks reality.
             assert update_successful
-            opt_param_scheduler.step(increment=args.global_batch_size)
+            opt_param_scheduler.step(increment=step_global_batch_size)
 
     # release grad (multi-LoRA retains accumulated grads; stepped slots were
     # zeroed selectively inside step_adapter_slots)
@@ -636,6 +647,7 @@ def train(
     opt_param_scheduler: OptimizerParamScheduler | None,
     data_iterator: Sequence[DataIterator],
     num_microbatches: Sequence[int],
+    global_batch_sizes: Sequence[int],
     witness_info: WitnessInfo | None,
     attempt: int,
     ft_test_action_executor: FTTestActionActorExecutor | None = None,
@@ -652,10 +664,17 @@ def train(
         opt_param_scheduler (OptimizerParamScheduler): LR/WD scheduler.
         data_iterator (Sequence[DataIterator]): Iterable(s) yielding training batches.
         num_microbatches (Sequence[int]): Microbatches per step in the rollout.
+        global_batch_sizes (Sequence[int]): Sample count per step (total across
+            DP); same length as ``num_microbatches``.
     """
     parallel_state = get_parallel_state()
     args = get_args()
     disable_optimizer = args.debug_disable_optimizer or optimizer is None
+
+    assert len(num_microbatches) == len(global_batch_sizes), (
+        f"num_microbatches and global_batch_sizes must have the same length, "
+        f"got {len(num_microbatches)} vs {len(global_batch_sizes)}"
+    )
 
     for iterator in data_iterator:
         iterator.reset()
@@ -736,6 +755,7 @@ def train(
             optimizer,
             opt_param_scheduler,
             num_microbatches[step_id],
+            global_batch_sizes[step_id],
             witness_info=witness_info,
             attempt=attempt,
             ft_test_action_executor=ft_test_action_executor,

--- a/miles/backends/megatron_utils/model.py
+++ b/miles/backends/megatron_utils/model.py
@@ -409,8 +409,7 @@ def train_one_step(
         optimizer: Optimizer instance.
         opt_param_scheduler: LR/WD scheduler.
         num_microbatches: Number of microbatches to process.
-        step_global_batch_size: Sample count for this step (total across DP);
-            loss normalizer and LR scheduler increment.
+        step_global_batch_size: Per-step sample count (loss normalizer + LR increment).
 
     Returns:
         Tuple of (reduced loss dict, gradient norm, step outcome).
@@ -597,8 +596,7 @@ def train_one_step(
             # Update parameters.
             update_successful, grad_norm, num_zeros_in_grad = optimizer.step()
 
-            # Update learning rate. Use the per-step sample count so the
-            # scheduler's samples-seen counter tracks reality.
+            # Update learning rate.
             assert update_successful
             opt_param_scheduler.step(increment=step_global_batch_size)
 
@@ -664,8 +662,7 @@ def train(
         opt_param_scheduler (OptimizerParamScheduler): LR/WD scheduler.
         data_iterator (Sequence[DataIterator]): Iterable(s) yielding training batches.
         num_microbatches (Sequence[int]): Microbatches per step in the rollout.
-        global_batch_sizes (Sequence[int]): Sample count per step (total across
-            DP); same length as ``num_microbatches``.
+        global_batch_sizes (Sequence[int]): Sample count per step (total across DP).
     """
     parallel_state = get_parallel_state()
     args = get_args()

--- a/miles/backends/megatron_utils/model.py
+++ b/miles/backends/megatron_utils/model.py
@@ -471,6 +471,7 @@ def train_one_step(
                 "max_seq_lens",
                 "witness_ids",
                 "opd_reverse_kl",
+                "rollout_mask_sums",
             ],
             args.data_pad_size_multiplier,
             args.qkv_format,
@@ -555,7 +556,7 @@ def train_one_step(
             ft_test_action_executor.maybe_crash(rollout_id=rollout_id, attempt=attempt)
 
         ok, indep_dp_loss_reduced = allreduce_grads_and_losses_across_replicas(
-            args, model, parallel_state, losses_reduced=losses_reduced
+            args, model, parallel_state, losses_reduced=losses_reduced, step_global_batch_size=step_global_batch_size
         )
         if not ok:
             outcome = TrainStepOutcome.DISCARDED_SHOULD_RETRY
@@ -622,7 +623,9 @@ def train_one_step(
 
         if mpu.is_pipeline_last_stage(ignore_virtual=True):
             loss_reduced = (
-                indep_dp_loss_reduced if parallel_state.indep_dp.size > 1 else aggregate_train_losses(losses_reduced)
+                indep_dp_loss_reduced
+                if parallel_state.indep_dp.size > 1
+                else aggregate_train_losses(losses_reduced, step_global_batch_size)
             )
             return loss_reduced, grad_norm, outcome
 

--- a/miles/backends/training_utils/cp_utils.py
+++ b/miles/backends/training_utils/cp_utils.py
@@ -98,18 +98,8 @@ def get_sum_of_sample_mean(
     max_seq_lens: list[int] | None = None,
     sample_denoms: list[torch.Tensor] | torch.Tensor | None = None,
 ) -> Callable[[torch.Tensor], torch.Tensor]:
-    """
-    Calculate correct sample mean for CP.
-
-    The default (``sample_denoms=None``) is the legacy per-sample mean: each
-    sample's denominator is its own ``loss_mask.sum()``. Callers that want a
-    per-rollout token-weighted mean pass precomputed per-sample denominators
-    (``rollout_mask_sums``, already GPU tensors) where every sample in the same
-    rollout carries the same value — the sum of that rollout's mask totals
-    across every sibling sample in the step. Precomputing at the step level
-    rather than per-mb is required, otherwise a rollout whose samples land in
-    different micro-batches would get a partial denominator on each side.
-    """
+    """Calculate correct sample mean for CP; ``sample_denoms`` overrides the
+    per-sample ``loss_mask.sum()`` denominators (e.g. ``rollout_mask_sums``)."""
     if sample_denoms is None:
         sample_denoms = [m.sum() for m in loss_masks]
 

--- a/miles/backends/training_utils/cp_utils.py
+++ b/miles/backends/training_utils/cp_utils.py
@@ -96,10 +96,23 @@ def get_sum_of_sample_mean(
     calculate_per_token_loss: bool = False,
     qkv_format: str = "thd",
     max_seq_lens: list[int] | None = None,
+    sample_denoms: list[torch.Tensor] | torch.Tensor | None = None,
 ) -> Callable[[torch.Tensor], torch.Tensor]:
     """
-    Calculate correct sample mean for CP
+    Calculate correct sample mean for CP.
+
+    The default (``sample_denoms=None``) is the legacy per-sample mean: each
+    sample's denominator is its own ``loss_mask.sum()``. Callers that want a
+    per-rollout token-weighted mean pass precomputed per-sample denominators
+    (``rollout_mask_sums``, already GPU tensors) where every sample in the same
+    rollout carries the same value — the sum of that rollout's mask totals
+    across every sibling sample in the step. Precomputing at the step level
+    rather than per-mb is required, otherwise a rollout whose samples land in
+    different micro-batches would get a partial denominator on each side.
     """
+    if sample_denoms is None:
+        sample_denoms = [m.sum() for m in loss_masks]
+
     parallel_state = get_parallel_state()
     cp_size = parallel_state.cp.size
     if cp_size == 1:
@@ -107,8 +120,10 @@ def get_sum_of_sample_mean(
         def sum_of_sample_mean(x: torch.Tensor) -> torch.Tensor:
             return sum(
                 [
-                    (x_i * loss_mask_i).sum() / torch.clamp_min(loss_mask_i.sum(), 1)
-                    for x_i, loss_mask_i in zip(x.split(response_lengths, dim=0), loss_masks, strict=True)
+                    (x_i * loss_mask_i).sum() / torch.clamp_min(denom, 1)
+                    for x_i, loss_mask_i, denom in zip(
+                        x.split(response_lengths, dim=0), loss_masks, sample_denoms, strict=True
+                    )
                 ]
             )
 
@@ -135,9 +150,9 @@ def get_sum_of_sample_mean(
         def sum_of_sample_mean(x: torch.Tensor) -> torch.Tensor:
             return sum(
                 [
-                    (x_i * chunked_loss_mask).sum() / torch.clamp_min(loss_mask.sum(), 1)
-                    for x_i, chunked_loss_mask, loss_mask in zip(
-                        x.split(cp_chunk_lengths, dim=0), chunked_loss_masks, loss_masks, strict=True
+                    (x_i * chunked_loss_mask).sum() / torch.clamp_min(denom, 1)
+                    for x_i, chunked_loss_mask, denom in zip(
+                        x.split(cp_chunk_lengths, dim=0), chunked_loss_masks, sample_denoms, strict=True
                     )
                 ]
             )

--- a/miles/backends/training_utils/data.py
+++ b/miles/backends/training_utils/data.py
@@ -435,8 +435,7 @@ def get_data_iterator(
         assert args.use_dynamic_global_batch_size == ("dynamic_global_batch_size" in rollout_data)
         micro_batch_indices = rollout_data["micro_batch_indices"]
         data_iterator = [
-            DataIterator(rollout_data, micro_batch_indices=micro_batch_indices)
-            for _ in range(parallel_state.vpp_size)
+            DataIterator(rollout_data, micro_batch_indices=micro_batch_indices) for _ in range(parallel_state.vpp_size)
         ]
         return data_iterator, rollout_data["num_microbatches"]
 

--- a/miles/backends/training_utils/data.py
+++ b/miles/backends/training_utils/data.py
@@ -423,10 +423,24 @@ def get_data_iterator(
     Returns `(data_iterators, num_microbatches)` where:
     - `data_iterators`: list of `DataIterator`, one per VPP stage (size 1 if VPP disabled)
     - `num_microbatches`: list[int], one per local step in the rollout (length = steps)
+
+    When the rollout side already computed the schedule
+    (``split_train_data_by_dp_scheduled``), the precomputed ``micro_batch_indices`` /
+    ``num_microbatches`` in ``rollout_data`` are consumed directly — no collectives.
     """
     expand_multimodal_rollout_data_in_place(rollout_data, qkv_format=args.qkv_format)
 
     parallel_state = get_parallel_state()
+
+    if "micro_batch_indices" in rollout_data:
+        assert args.use_dynamic_global_batch_size == ("dynamic_global_batch_size" in rollout_data)
+        micro_batch_indices = rollout_data["micro_batch_indices"]
+        data_iterator = [
+            DataIterator(rollout_data, micro_batch_indices=micro_batch_indices)
+            for _ in range(parallel_state.vpp_size)
+        ]
+        return data_iterator, rollout_data["num_microbatches"]
+
     dp_size = parallel_state.effective_dp.size
     dp_group = parallel_state.effective_dp.group
     vpp_size = parallel_state.vpp_size

--- a/miles/backends/training_utils/data.py
+++ b/miles/backends/training_utils/data.py
@@ -423,9 +423,6 @@ def get_data_iterator(
     Returns `(data_iterators, num_microbatches)` where:
     - `data_iterators`: list of `DataIterator`, one per VPP stage (size 1 if VPP disabled)
     - `num_microbatches`: list[int], one per local step in the rollout (length = steps)
-
-    A schedule precomputed on the rollout side (`micro_batch_indices` in
-    `rollout_data`) is consumed directly — no collectives.
     """
     expand_multimodal_rollout_data_in_place(rollout_data, qkv_format=args.qkv_format)
 

--- a/miles/backends/training_utils/data.py
+++ b/miles/backends/training_utils/data.py
@@ -424,9 +424,8 @@ def get_data_iterator(
     - `data_iterators`: list of `DataIterator`, one per VPP stage (size 1 if VPP disabled)
     - `num_microbatches`: list[int], one per local step in the rollout (length = steps)
 
-    When the rollout side already computed the schedule
-    (``split_train_data_by_dp_scheduled``), the precomputed ``micro_batch_indices`` /
-    ``num_microbatches`` in ``rollout_data`` are consumed directly — no collectives.
+    A schedule precomputed on the rollout side (`micro_batch_indices` in
+    `rollout_data`) is consumed directly — no collectives.
     """
     expand_multimodal_rollout_data_in_place(rollout_data, qkv_format=args.qkv_format)
 

--- a/miles/backends/training_utils/data.py
+++ b/miles/backends/training_utils/data.py
@@ -405,6 +405,14 @@ class DataIterator:
         return self
 
 
+def get_global_batch_sizes(args: Namespace, rollout_data: RolloutBatch, num_steps: int) -> list[int]:
+    """Per-step sample counts (total across DP). Precomputed by the rollout-side
+    schedule; legacy shards fall back to the constant (dynamic) global batch size."""
+    if "global_batch_sizes" in rollout_data:
+        return rollout_data["global_batch_sizes"]
+    return [rollout_data.get("dynamic_global_batch_size", args.global_batch_size)] * num_steps
+
+
 def get_data_iterator(
     args: Namespace,
     model: torch.nn.Module | Sequence[torch.nn.Module],

--- a/miles/backends/training_utils/data.py
+++ b/miles/backends/training_utils/data.py
@@ -406,8 +406,7 @@ class DataIterator:
 
 
 def get_global_batch_sizes(args: Namespace, rollout_data: RolloutBatch, num_steps: int) -> list[int]:
-    """Per-step sample counts (total across DP). Precomputed by the rollout-side
-    schedule; legacy shards fall back to the constant (dynamic) global batch size."""
+    """Per-step sample counts (total across DP)."""
     if "global_batch_sizes" in rollout_data:
         return rollout_data["global_batch_sizes"]
     return [rollout_data.get("dynamic_global_batch_size", args.global_batch_size)] * num_steps

--- a/miles/backends/training_utils/data.py
+++ b/miles/backends/training_utils/data.py
@@ -53,6 +53,12 @@ def get_rollout_data(
     rollout_data["loss_masks"] = [
         torch.tensor(t, dtype=torch.int, device=torch.cuda.current_device()) for t in rollout_data["loss_masks"]
     ]
+    if "rollout_mask_sums" in rollout_data:
+        # Promote precomputed per-rollout mask totals to GPU tensors here
+        # (matching loss_masks) so the loss reducer can just divide.
+        rollout_data["rollout_mask_sums"] = torch.tensor(
+            rollout_data["rollout_mask_sums"], dtype=torch.float32, device=torch.cuda.current_device()
+        )
     if args.enable_witness:
         seq_witness_ids = rollout_data.pop("seq_witness_ids")
         rollout_data["witness_ids"] = [

--- a/miles/backends/training_utils/data.py
+++ b/miles/backends/training_utils/data.py
@@ -54,8 +54,6 @@ def get_rollout_data(
         torch.tensor(t, dtype=torch.int, device=torch.cuda.current_device()) for t in rollout_data["loss_masks"]
     ]
     if "rollout_mask_sums" in rollout_data:
-        # Promote precomputed per-rollout mask totals to GPU tensors here
-        # (matching loss_masks) so the loss reducer can just divide.
         rollout_data["rollout_mask_sums"] = torch.tensor(
             rollout_data["rollout_mask_sums"], dtype=torch.float32, device=torch.cuda.current_device()
         )

--- a/miles/backends/training_utils/log_utils.py
+++ b/miles/backends/training_utils/log_utils.py
@@ -137,6 +137,8 @@ def log_rollout_data(rollout_id: int, args: Namespace, rollout_data: RolloutBatc
                 "witness_ids",
                 "weight_versions",
                 "metadata",
+                "num_microbatches",
+                "micro_batch_indices",
                 "n_adapters",
                 "adapter_slots",
                 "step_slots",

--- a/miles/backends/training_utils/log_utils.py
+++ b/miles/backends/training_utils/log_utils.py
@@ -23,12 +23,7 @@ logger = logging.getLogger(__name__)
 
 
 def reduce_gathered_log_dict(gathered: list[dict], dp_size: int) -> dict[str, float]:
-    """Per-key reduction of gathered per-rank log dicts.
-
-    A ``(sum, count)`` tuple reduces as ``Σsum / Σcount`` (correct when ranks
-    hold different sample counts); a plain scalar reduces as the mean across
-    ranks (legacy; correct only when every rank holds the same N samples).
-    """
+    """Per-key reduction: ``(sum, count)`` tuples as ``Σsum / Σcount``, scalars as mean."""
     reduced: dict[str, float] = {}
     for key in gathered[0]:
         values = [d[key] for d in gathered]
@@ -51,10 +46,7 @@ def gather_log_data(
     """
     Gather per-rank metrics, reduce on the DP source rank, and log.
 
-    Values are either plain scalars or ``(sum, count)`` tuples — see
-    :func:`reduce_gathered_log_dict`. The DP source rank prints and optionally
-    logs to WandB/TensorBoard with a step derived from `rollout_id` and batch
-    sizes. Returns the reduced dict on the DP source rank; returns None on others.
+    Returns the reduced dict on the DP source rank; returns None on others.
     """
 
     parallel_state = get_parallel_state()
@@ -168,8 +160,6 @@ def log_rollout_data(rollout_id: int, args: Namespace, rollout_data: RolloutBatc
                 "prompt_group_sizes",
             ]:
                 continue
-            # Emit (sum, count) so gather_log_data can do a weighted average
-            # across DP ranks instead of assuming every rank holds N samples.
             if isinstance(val, (list, tuple)):
                 if isinstance(val[0], torch.Tensor):
                     count = len(val)
@@ -196,12 +186,8 @@ def log_rollout_data(rollout_id: int, args: Namespace, rollout_data: RolloutBatc
                             qkv_format=args.qkv_format,
                             max_seq_lens=max_seq_lens,
                         )
-                        # cp_size cancels the CP division; result is the
-                        # sum-of-per-sample-means over this rank's samples.
                         per_rank_sum = cp_size * sum_of_sample_mean(tensor)
                     else:
-                        # tensor.mean() * cp_size is this rank's per-sample mean;
-                        # multiply by count to get the per-rank sum.
                         per_rank_sum = tensor.mean() * cp_size * count
                     log_dict[key] = (per_rank_sum.item(), count)
                 else:
@@ -214,7 +200,6 @@ def log_rollout_data(rollout_id: int, args: Namespace, rollout_data: RolloutBatc
                         continue
                     log_dict[key] = (sum(flat), len(flat))
             elif isinstance(val, torch.Tensor):
-                # Scalar tensor (one per rank): treat as count=1.
                 log_dict[key] = (val.float().mean().item(), 1)
             else:
                 raise ValueError(f"Unsupported type: {type(val)} for key: {key}")

--- a/miles/backends/training_utils/log_utils.py
+++ b/miles/backends/training_utils/log_utils.py
@@ -143,6 +143,7 @@ def log_rollout_data(rollout_id: int, args: Namespace, rollout_data: RolloutBatc
                 "loss_masks",
                 "sample_indices",
                 "rollout_ids",
+                "rollout_mask_sums",
                 "rollout_routed_experts",
                 "rollout_indexer_topk",
                 "max_seq_lens",
@@ -180,12 +181,17 @@ def log_rollout_data(rollout_id: int, args: Namespace, rollout_data: RolloutBatc
                         "opd_reverse_kl",
                         "entropy",
                     ]:
+                        # Same per-rollout denominators as the training loss, so
+                        # reported log_probs / returns / advantages live in the
+                        # same mean space as the gradient signal. No-op while
+                        # 1 rollout = 1 sample.
                         sum_of_sample_mean = get_sum_of_sample_mean(
                             total_lengths,
                             response_lengths,
                             loss_masks,
                             qkv_format=args.qkv_format,
                             max_seq_lens=max_seq_lens,
+                            sample_denoms=rollout_data.get("rollout_mask_sums", None),
                         )
                         per_rank_sum = cp_size * sum_of_sample_mean(tensor)
                     else:
@@ -296,8 +302,12 @@ def log_rollout_data(rollout_id: int, args: Namespace, rollout_data: RolloutBatc
             for p, val in correct_response_length_percentile.items():
                 rollout_data[f"correct_length/{p}"] = [val] * num_correct_responses
             if len(correct_entropy) > 0:
+                # NOTE: per-sample mean over the correct subset, not per-rollout —
+                # a rollout's siblings may not all be correct, and slicing
+                # ``rollout_mask_sums`` here would leave a denominator that still
+                # includes incorrect siblings.
                 sum_of_sample_mean = get_sum_of_sample_mean(
-                    correct_total_lengths, correct_response_lengths, correct_loss_masks
+                    correct_total_lengths, correct_response_lengths, correct_loss_masks, sample_denoms=None
                 )
                 correct_entropy = sum_of_sample_mean(torch.cat(correct_entropy, dim=0))
                 rollout_data["correct_entropy"] = [correct_entropy.item()] * num_correct_responses
@@ -380,6 +390,7 @@ def log_cpu_memory(rollout_id: int, args: Namespace, label: str) -> None:
 
 def aggregate_train_losses(
     losses_reduced: list[dict[str, list[str] | torch.Tensor]],
+    step_global_batch_size: int | None = None,
 ) -> dict[str, float]:
     """Aggregate loss metrics across micro-batches.
 
@@ -389,7 +400,13 @@ def aggregate_train_losses(
     Args:
         losses_reduced: List of log_dict from each micro-batch.
             Each log_dict has format: {"keys": list[str], "values": torch.Tensor}
-        parallel_state: Parallel state containing dp_group and cp_size.
+        step_global_batch_size: Sample count for this step (total across DP).
+            When set (megatron, per-rollout-mean metrics), the divisor is this
+            constant and no CP factor applies: each metric is a sum of
+            per-sample means whose CP-chunked partial numerators reconstruct
+            exactly once under the DP*CP all-reduce. None keeps the legacy
+            reduction: divisor = all-reduced ``values[0]`` (CP-inflated sample
+            count), cancelled by the ``cp_size`` multiplier.
 
     Returns:
         Dictionary mapping metric names to averaged values.
@@ -414,10 +431,16 @@ def aggregate_train_losses(
 
     loss_reduced = {}
     values = values.tolist()
-    num_samples_or_tokens = values[0]
+    if step_global_batch_size is not None and values[0] == 0:
+        # Per-rollout-mean mode: constant divisor, no CP inflation to cancel.
+        num_samples_or_tokens = step_global_batch_size
+        cp_factor = 1
+    else:
+        num_samples_or_tokens = values[0]
+        cp_factor = parallel_state.cp.size
 
     for key, value in zip(keys, values[1:], strict=False):
-        loss_reduced[key] = value * parallel_state.cp.size / num_samples_or_tokens
+        loss_reduced[key] = value * cp_factor / num_samples_or_tokens
 
     return loss_reduced
 

--- a/miles/backends/training_utils/log_utils.py
+++ b/miles/backends/training_utils/log_utils.py
@@ -181,10 +181,6 @@ def log_rollout_data(rollout_id: int, args: Namespace, rollout_data: RolloutBatc
                         "opd_reverse_kl",
                         "entropy",
                     ]:
-                        # Same per-rollout denominators as the training loss, so
-                        # reported log_probs / returns / advantages live in the
-                        # same mean space as the gradient signal. No-op while
-                        # 1 rollout = 1 sample.
                         sum_of_sample_mean = get_sum_of_sample_mean(
                             total_lengths,
                             response_lengths,
@@ -302,10 +298,7 @@ def log_rollout_data(rollout_id: int, args: Namespace, rollout_data: RolloutBatc
             for p, val in correct_response_length_percentile.items():
                 rollout_data[f"correct_length/{p}"] = [val] * num_correct_responses
             if len(correct_entropy) > 0:
-                # NOTE: per-sample mean over the correct subset, not per-rollout —
-                # a rollout's siblings may not all be correct, and slicing
-                # ``rollout_mask_sums`` here would leave a denominator that still
-                # includes incorrect siblings.
+                # per-sample mean over the correct subset, not per-rollout
                 sum_of_sample_mean = get_sum_of_sample_mean(
                     correct_total_lengths, correct_response_lengths, correct_loss_masks, sample_denoms=None
                 )
@@ -400,13 +393,8 @@ def aggregate_train_losses(
     Args:
         losses_reduced: List of log_dict from each micro-batch.
             Each log_dict has format: {"keys": list[str], "values": torch.Tensor}
-        step_global_batch_size: Sample count for this step (total across DP).
-            When set (megatron, per-rollout-mean metrics), the divisor is this
-            constant and no CP factor applies: each metric is a sum of
-            per-sample means whose CP-chunked partial numerators reconstruct
-            exactly once under the DP*CP all-reduce. None keeps the legacy
-            reduction: divisor = all-reduced ``values[0]`` (CP-inflated sample
-            count), cancelled by the ``cp_size`` multiplier.
+        step_global_batch_size: constant divisor (no CP factor); None keeps
+            the legacy values[0]-based reduction.
 
     Returns:
         Dictionary mapping metric names to averaged values.
@@ -432,7 +420,6 @@ def aggregate_train_losses(
     loss_reduced = {}
     values = values.tolist()
     if step_global_batch_size is not None and values[0] == 0:
-        # Per-rollout-mean mode: constant divisor, no CP inflation to cancel.
         num_samples_or_tokens = step_global_batch_size
         cp_factor = 1
     else:

--- a/miles/backends/training_utils/log_utils.py
+++ b/miles/backends/training_utils/log_utils.py
@@ -142,6 +142,7 @@ def log_rollout_data(rollout_id: int, args: Namespace, rollout_data: RolloutBatc
                 "multimodal_train_inputs",
                 "loss_masks",
                 "sample_indices",
+                "rollout_ids",
                 "rollout_routed_experts",
                 "rollout_indexer_topk",
                 "max_seq_lens",

--- a/miles/backends/training_utils/log_utils.py
+++ b/miles/backends/training_utils/log_utils.py
@@ -22,18 +22,39 @@ from .parallel import get_parallel_state
 logger = logging.getLogger(__name__)
 
 
+def reduce_gathered_log_dict(gathered: list[dict], dp_size: int) -> dict[str, float]:
+    """Per-key reduction of gathered per-rank log dicts.
+
+    A ``(sum, count)`` tuple reduces as ``Σsum / Σcount`` (correct when ranks
+    hold different sample counts); a plain scalar reduces as the mean across
+    ranks (legacy; correct only when every rank holds the same N samples).
+    """
+    reduced: dict[str, float] = {}
+    for key in gathered[0]:
+        values = [d[key] for d in gathered]
+        first = values[0]
+        if isinstance(first, tuple) and len(first) == 2:
+            total_sum = sum(v[0] for v in values)
+            total_count = sum(v[1] for v in values)
+            reduced[key] = total_sum / total_count if total_count else 0.0
+        else:
+            reduced[key] = sum(values) / dp_size
+    return reduced
+
+
 def gather_log_data(
     metric_name: str,
     args: Namespace,
     rollout_id: int,
-    log_dict: dict[str, float],
+    log_dict: dict[str, "float | tuple[float, float]"],
 ) -> dict[str, float] | None:
     """
-    Gather per-rank metrics, reduce by mean on the DP source rank, and log.
+    Gather per-rank metrics, reduce on the DP source rank, and log.
 
-    Expects `log_dict` to contain plain scalars. The DP source rank prints and
-    optionally logs to WandB/TensorBoard with a step derived from `rollout_id` and
-    batch sizes. Returns the reduced dict on the DP source rank; returns None on others.
+    Values are either plain scalars or ``(sum, count)`` tuples — see
+    :func:`reduce_gathered_log_dict`. The DP source rank prints and optionally
+    logs to WandB/TensorBoard with a step derived from `rollout_id` and batch
+    sizes. Returns the reduced dict on the DP source rank; returns None on others.
     """
 
     parallel_state = get_parallel_state()
@@ -60,9 +81,8 @@ def gather_log_data(
         return None
 
     if pg.rank == 0:
-        reduced_log_dict = {
-            f"{metric_name}/{key}": sum([d[key] for d in gathered_log_dict]) / pg.size for key in log_dict
-        }
+        reduced = reduce_gathered_log_dict(gathered_log_dict, pg.size)
+        reduced_log_dict = {f"{metric_name}/{key}": value for key, value in reduced.items()}
         logger.info(f"{metric_name} {rollout_id}: {reduced_log_dict}")
 
         # Calculate step once to avoid duplication
@@ -139,6 +159,7 @@ def log_rollout_data(rollout_id: int, args: Namespace, rollout_data: RolloutBatc
                 "metadata",
                 "num_microbatches",
                 "micro_batch_indices",
+                "global_batch_sizes",
                 "n_adapters",
                 "adapter_slots",
                 "step_slots",
@@ -147,16 +168,16 @@ def log_rollout_data(rollout_id: int, args: Namespace, rollout_data: RolloutBatc
                 "prompt_group_sizes",
             ]:
                 continue
-            # Upload per sample mean for each rollout value
-            # There are the following assumptions:
-            # - Each dp rank has the same number of samples
+            # Emit (sum, count) so gather_log_data can do a weighted average
+            # across DP ranks instead of assuming every rank holds N samples.
             if isinstance(val, (list, tuple)):
                 if isinstance(val[0], torch.Tensor):
+                    count = len(val)
                     # NOTE: Here we have to do the clone().detach(), otherwise the tensor will be
                     # modified in place and will cause problem for the next rollout.
-                    val = torch.cat(val).clone().detach()
-                    if val.device != loss_masks[0].device:
-                        val = val.to(loss_masks[0].device)
+                    tensor = torch.cat(val).clone().detach()
+                    if tensor.device != loss_masks[0].device:
+                        tensor = tensor.to(loss_masks[0].device)
                     if key in [
                         "log_probs",
                         "ref_log_probs",
@@ -175,9 +196,14 @@ def log_rollout_data(rollout_id: int, args: Namespace, rollout_data: RolloutBatc
                             qkv_format=args.qkv_format,
                             max_seq_lens=max_seq_lens,
                         )
-                        val = cp_size * sum_of_sample_mean(val) / len(loss_masks)
+                        # cp_size cancels the CP division; result is the
+                        # sum-of-per-sample-means over this rank's samples.
+                        per_rank_sum = cp_size * sum_of_sample_mean(tensor)
                     else:
-                        val = val.mean() * cp_size
+                        # tensor.mean() * cp_size is this rank's per-sample mean;
+                        # multiply by count to get the per-rank sum.
+                        per_rank_sum = tensor.mean() * cp_size * count
+                    log_dict[key] = (per_rank_sum.item(), count)
                 else:
                     # Flatten nested lists (e.g. list of lists from async rollout)
                     flat = val
@@ -186,12 +212,12 @@ def log_rollout_data(rollout_id: int, args: Namespace, rollout_data: RolloutBatc
                     # Skip non-numeric values (e.g. strings from async rollout metadata)
                     if flat and not isinstance(flat[0], (int, float)):
                         continue
-                    val = sum(flat) / len(flat)
+                    log_dict[key] = (sum(flat), len(flat))
             elif isinstance(val, torch.Tensor):
-                val = val.float().mean()
+                # Scalar tensor (one per rank): treat as count=1.
+                log_dict[key] = (val.float().mean().item(), 1)
             else:
                 raise ValueError(f"Unsupported type: {type(val)} for key: {key}")
-            log_dict[key] = val.item() if isinstance(val, torch.Tensor) else val
 
         reduced_log_dict = gather_log_data("rollout", args, rollout_id, log_dict)
         if args.ci_test and not args.ci_disable_logprobs_checker and reduced_log_dict is not None:

--- a/miles/backends/training_utils/loss.py
+++ b/miles/backends/training_utils/loss.py
@@ -99,6 +99,7 @@ def loss_function(
     num_microbatches: int,
     logits: torch.Tensor,
     apply_megatron_loss_scaling: bool = False,
+    step_global_batch_size: int | None = None,
 ) -> tuple[torch.Tensor, int | torch.Tensor, dict[str, list[str] | torch.Tensor]]:
     """Dispatch to the configured loss and rescale for Megatron integration.
 
@@ -114,6 +115,10 @@ def loss_function(
             keys required by the selected loss function.
         num_microbatches: Number of gradient accumulation steps.
         logits: Model outputs (policy or value head).
+        step_global_batch_size: Sample count of the current training step (total
+            across DP), used as the loss normalizer. None (fsdp/torchtitan and
+            other legacy callers) falls back to the batch's
+            ``dynamic_global_batch_size`` or ``args.global_batch_size``.
 
     Returns:
         Tuple of `(scaled_loss, normalizer, logging_dict)` where:
@@ -154,8 +159,11 @@ def loss_function(
         loss = loss + 0 * logits.sum()
 
     # Here we need to divide by cp_size because to cancel the multiply in Megatron.
-    assert args.use_dynamic_global_batch_size == ("dynamic_global_batch_size" in batch)
-    global_batch_size = batch.get("dynamic_global_batch_size", args.global_batch_size)
+    if step_global_batch_size is not None:
+        global_batch_size = step_global_batch_size
+    else:
+        assert args.use_dynamic_global_batch_size == ("dynamic_global_batch_size" in batch)
+        global_batch_size = batch.get("dynamic_global_batch_size", args.global_batch_size)
     # Multi-LoRA: samples enter the gradient buffers with weight 1; per-adapter
     # normalization (1/adapter_global_batch_size, a constant known in advance)
     # is applied to the accumulated slot gradient at optimizer-step time.

--- a/miles/backends/training_utils/loss.py
+++ b/miles/backends/training_utils/loss.py
@@ -137,6 +137,7 @@ def loss_function(
         args.calculate_per_token_loss,
         args.qkv_format,
         batch.get("max_seq_lens", None),
+        sample_denoms=batch.get("rollout_mask_sums", None),
     )
 
     func = get_loss_function(args)
@@ -181,16 +182,25 @@ def loss_function(
         if apply_megatron_loss_scaling:
             loss = loss * parallel_state.cp.size
 
+    # values[0] is the reducer's denominator after the DP*CP all-reduce. For
+    # per-token loss it must be the all-reduced token total. When the caller
+    # provides step_global_batch_size the divisor is that constant, so leave a
+    # 0 placeholder and let aggregate_train_losses substitute it; legacy
+    # callers (fsdp/torchtitan) keep the all-reduced sample count.
+    if args.calculate_per_token_loss:
+        denominator = num_tokens
+    elif step_global_batch_size is not None:
+        denominator = 0
+    else:
+        denominator = num_samples
+
     return (
         loss,
         torch.tensor(num_tokens if args.calculate_per_token_loss else 1, device=logits.device),
         {
             "keys": list(log.keys()),
             "values": torch.tensor(
-                [
-                    num_samples if not args.calculate_per_token_loss else num_tokens,
-                ]
-                + list(log.values()),
+                [denominator] + list(log.values()),
                 device=logits.device,
             ),
         },

--- a/miles/backends/training_utils/loss.py
+++ b/miles/backends/training_utils/loss.py
@@ -182,11 +182,7 @@ def loss_function(
         if apply_megatron_loss_scaling:
             loss = loss * parallel_state.cp.size
 
-    # values[0] is the reducer's denominator after the DP*CP all-reduce. For
-    # per-token loss it must be the all-reduced token total. When the caller
-    # provides step_global_batch_size the divisor is that constant, so leave a
-    # 0 placeholder and let aggregate_train_losses substitute it; legacy
-    # callers (fsdp/torchtitan) keep the all-reduced sample count.
+    # values[0]: reducer denominator; 0 = constant step_global_batch_size mode.
     if args.calculate_per_token_loss:
         denominator = num_tokens
     elif step_global_batch_size is not None:

--- a/miles/backends/training_utils/loss.py
+++ b/miles/backends/training_utils/loss.py
@@ -115,10 +115,8 @@ def loss_function(
             keys required by the selected loss function.
         num_microbatches: Number of gradient accumulation steps.
         logits: Model outputs (policy or value head).
-        step_global_batch_size: Sample count of the current training step (total
-            across DP), used as the loss normalizer. None (fsdp/torchtitan and
-            other legacy callers) falls back to the batch's
-            ``dynamic_global_batch_size`` or ``args.global_batch_size``.
+        step_global_batch_size: Per-step sample count used as the loss
+            normalizer; None falls back to the legacy batch/args value.
 
     Returns:
         Tuple of `(scaled_loss, normalizer, logging_dict)` where:

--- a/miles/backends/training_utils/loss_hub/losses.py
+++ b/miles/backends/training_utils/loss_hub/losses.py
@@ -232,11 +232,8 @@ def policy_loss_function(
             tis_func = vanilla_tis_function
         pg_loss, modified_response_masks, tis_metrics = tis_func(**tis_kwargs)
 
-        # [decouple IS and rejection] Rebuild sum_of_sample_mean with
-        # modified_response_masks for numerator correction (rejected tokens
-        # zeroed in pg_loss). Denominators stay the precomputed per-rollout
-        # totals from ``rollout_mask_sums`` (based on original loss_masks) —
-        # the same normalizer as the rest of the loss path.
+        # [decouple IS and rejection] modified masks correct the numerator only;
+        # denominators stay the precomputed rollout_mask_sums.
         sum_of_sample_mean = get_sum_of_sample_mean(
             total_lengths,
             response_lengths,

--- a/miles/backends/training_utils/loss_hub/losses.py
+++ b/miles/backends/training_utils/loss_hub/losses.py
@@ -232,8 +232,11 @@ def policy_loss_function(
             tis_func = vanilla_tis_function
         pg_loss, modified_response_masks, tis_metrics = tis_func(**tis_kwargs)
 
-        # [decouple IS and rejection] Rebuild sum_of_sample_mean with modified_response_masks for denominator correction
-        # modified_response_masks will be sliced with cp in get_sum_of_sample_mean
+        # [decouple IS and rejection] Rebuild sum_of_sample_mean with
+        # modified_response_masks for numerator correction (rejected tokens
+        # zeroed in pg_loss). Denominators stay the precomputed per-rollout
+        # totals from ``rollout_mask_sums`` (based on original loss_masks) —
+        # the same normalizer as the rest of the loss path.
         sum_of_sample_mean = get_sum_of_sample_mean(
             total_lengths,
             response_lengths,
@@ -241,6 +244,7 @@ def policy_loss_function(
             args.calculate_per_token_loss,
             args.qkv_format,
             max_seq_lens,
+            sample_denoms=batch.get("rollout_mask_sums", None),
         )
 
     # Determine pg_loss reducer: use custom if specified, otherwise default

--- a/miles/ray/rollout/rollout_data_conversion.py
+++ b/miles/ray/rollout/rollout_data_conversion.py
@@ -2,12 +2,18 @@ import itertools
 import logging
 
 from miles.utils.multi_lora import is_multi_lora_enabled
+from miles.utils.types import Sample
 
 logger = logging.getLogger(__name__)
 
 
 def postprocess_rollout_data(args, data, train_parallel_config):
     metadata = {}
+
+    # Enforce the rollout_id contract before flattening: any compact / subagent
+    # list[Sample] encountered in the nested output must have rollout_id set on
+    # every element so the loss reducer counts the rollout once instead of N times.
+    validate_rollout_id_annotated(data)
 
     # Multi-LoRA: record group boundaries (heterogeneous per-adapter group sizes)
     # and lift the collection loop's batch-level step decision out of sample metadata,
@@ -42,6 +48,38 @@ def postprocess_rollout_data(args, data, train_parallel_config):
         logger.info(f"Final collected {len(data)} samples from rollout to train")
 
     return data, metadata
+
+
+def validate_rollout_id_annotated(node, depth=0):
+    """Walk the rollout function's nested output and validate ``rollout_id`` only
+    when a compact / subagent pattern is detected.
+
+    "Compact" = the rollout function wraps multiple training samples from one
+    rollout execution into a ``list[Sample]``. In miles's convention the
+    default rollout shape is ``list[list[Sample]]`` (depth-2: prompt × rollout)
+    so its leaf ``list[Sample]`` lands at depth 1 and we skip validation,
+    preserving backward compatibility. A compact rollout adds a third level:
+    ``list[list[list[Sample]]]`` (prompt × rollout × samples-from-one-rollout),
+    so the leaf ``list[Sample]`` lands at depth >= 2. At that point we require
+    every sibling to carry a non-None ``rollout_id`` and to share the same
+    value, so the loss reducer counts the rollout once instead of N times.
+    """
+    if isinstance(node, Sample):
+        return
+    assert isinstance(node, list), f"unexpected rollout output node type: {type(node).__name__}"
+    if node and isinstance(node[0], Sample):
+        if depth >= 2 and len(node) > 1:
+            rids = [s.rollout_id for s in node]
+            missing = [i for i, r in enumerate(rids) if r is None]
+            assert not missing, (
+                f"Compact rollout returned {len(node)} samples but rollout_id is unset on "
+                f"positions {missing}. Set Sample.rollout_id on every sibling so the loss "
+                "reducer can aggregate them as one rollout instead of N."
+            )
+            assert len(set(rids)) == 1, f"Sibling samples from one compact rollout must share rollout_id; got {rids}."
+        return
+    for item in node:
+        validate_rollout_id_annotated(item, depth + 1)
 
 
 def _first_sample(group):

--- a/miles/ray/rollout/rollout_data_conversion.py
+++ b/miles/ray/rollout/rollout_data_conversion.py
@@ -10,9 +10,6 @@ logger = logging.getLogger(__name__)
 def postprocess_rollout_data(args, data, train_parallel_config):
     metadata = {}
 
-    # Enforce the rollout_id contract before flattening: any compact / subagent
-    # list[Sample] encountered in the nested output must have rollout_id set on
-    # every element so the loss reducer counts the rollout once instead of N times.
     validate_rollout_id_annotated(data)
 
     # Multi-LoRA: record group boundaries (heterogeneous per-adapter group sizes)
@@ -51,19 +48,8 @@ def postprocess_rollout_data(args, data, train_parallel_config):
 
 
 def validate_rollout_id_annotated(node, depth=0):
-    """Walk the rollout function's nested output and validate ``rollout_id`` only
-    when a compact / subagent pattern is detected.
-
-    "Compact" = the rollout function wraps multiple training samples from one
-    rollout execution into a ``list[Sample]``. In miles's convention the
-    default rollout shape is ``list[list[Sample]]`` (depth-2: prompt × rollout)
-    so its leaf ``list[Sample]`` lands at depth 1 and we skip validation,
-    preserving backward compatibility. A compact rollout adds a third level:
-    ``list[list[list[Sample]]]`` (prompt × rollout × samples-from-one-rollout),
-    so the leaf ``list[Sample]`` lands at depth >= 2. At that point we require
-    every sibling to carry a non-None ``rollout_id`` and to share the same
-    value, so the loss reducer counts the rollout once instead of N times.
-    """
+    """Require compact leaves (``list[Sample]`` at depth >= 2, >1 sibling) to
+    share a non-None ``rollout_id``; default rollout shapes skip validation."""
     if isinstance(node, Sample):
         return
     assert isinstance(node, list), f"unexpected rollout output node type: {type(node).__name__}"

--- a/miles/ray/rollout/rollout_manager.py
+++ b/miles/ray/rollout/rollout_manager.py
@@ -16,8 +16,10 @@ from miles.ray.rollout.router_manager import start_session_server
 from miles.ray.rollout.server_cell import get_cell_indexer_of_id_map
 from miles.ray.rollout.train_data_conversion import (
     ROLLOUT_DATA_VALUE_SPEC,
+    can_schedule_on_rollout_side,
     convert_samples_to_train_data,
     split_train_data_by_dp,
+    split_train_data_by_dp_scheduled,
 )
 from miles.ray.utils import Lock
 from miles.rollout.base_types import (
@@ -143,6 +145,8 @@ class RolloutManager:
         sample_indices = data.get("sample_indices")
         if self.args.delay_split_train_data_by_dp:
             data_ref = object_store.get_instance().put(value=data, value_spec=ROLLOUT_DATA_VALUE_SPEC)
+        elif can_schedule_on_rollout_side(self.args, data, self.train_parallel_config):
+            data_ref = split_train_data_by_dp_scheduled(self.args, data, self.train_parallel_config)
         else:
             data_ref = split_train_data_by_dp(self.args, data, self.train_parallel_config["dp_size"])
         return dict(sample_indices=sample_indices, data_ref=data_ref)

--- a/miles/ray/rollout/train_data_conversion.py
+++ b/miles/ray/rollout/train_data_conversion.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Any
 
 import torch
@@ -9,6 +10,8 @@ from miles.utils.object_store import ValueSpec
 from miles.utils.seqlen_balancing import get_seqlen_balanced_partitions
 from miles.utils.timer import Timer
 from miles.utils.types import Sample
+
+logger = logging.getLogger(__name__)
 
 ROLLOUT_DATA_TENSOR_DTYPES = {
     "tokens": "int32",
@@ -254,6 +257,10 @@ def split_train_data_by_dp_scheduled_raw(
         train_parallel_config,
         total_lengths,
         global_batch_size=global_batch_size,
+    )
+    logger.info(
+        f"Rollout-side DP schedule: num_samples={len(total_lengths)}, "
+        f"global_batch_size={global_batch_size}, num_microbatches={num_microbatches}"
     )
 
     shards = _package_shards(args, data, partitions)

--- a/miles/ray/rollout/train_data_conversion.py
+++ b/miles/ray/rollout/train_data_conversion.py
@@ -3,6 +3,8 @@ from typing import Any
 import torch
 
 from miles.utils import object_store
+from miles.utils.dp_schedule import build_dp_schedule, has_full_schedule_config
+from miles.utils.multi_lora import is_multi_lora_enabled
 from miles.utils.object_store import ValueSpec
 from miles.utils.seqlen_balancing import get_seqlen_balanced_partitions
 from miles.utils.timer import Timer
@@ -34,6 +36,9 @@ ROLLOUT_DATA_VALUE_SPEC: dict[str, ValueSpec] = {
     "raw_reward": ValueSpec(codec="auto"),
     "total_lengths": ValueSpec(codec="auto"),
     "dynamic_global_batch_size": ValueSpec(codec="auto"),
+    # Rollout-side precomputed mbs schedule (split_train_data_by_dp_scheduled).
+    "num_microbatches": ValueSpec(codec="auto"),
+    "micro_batch_indices": ValueSpec(codec="auto"),
 }
 
 
@@ -200,6 +205,64 @@ def split_train_data_by_dp(args, data, dp_size):
     return [store.put(value=rollout_data, value_spec=ROLLOUT_DATA_VALUE_SPEC) for rollout_data in rollout_data_list]
 
 
+def can_schedule_on_rollout_side(args, data: dict[str, Any], train_parallel_config: dict | None) -> bool:
+    """Whether the rollout side can precompute the full DP/mbs schedule.
+
+    Requires the training backend to have advertised a full schedule config
+    (megatron, non-indep_dp). Excluded on top of that:
+      - multi-LoRA — keeps the legacy per-rank scheduling with its
+        slot-contiguity handling;
+      - multimodal batches — media-token expansion on the train side changes
+        ``total_lengths`` after the schedule would have been computed, so the
+        token-cap packing must stay train-side;
+      - sample counts not divisible by the (dynamic) global batch size —
+        legacy behavior silently drops the remainder per-rank; keep it there.
+    """
+    if not has_full_schedule_config(train_parallel_config):
+        return False
+    if is_multi_lora_enabled(args):
+        return False
+    if "multimodal_train_inputs" in data:
+        return False
+    global_batch_size = data.get("dynamic_global_batch_size", args.global_batch_size)
+    return len(data["tokens"]) % global_batch_size == 0
+
+
+def split_train_data_by_dp_scheduled(args, data: dict[str, Any], train_parallel_config: dict):
+    """DP split with the micro-batch schedule precomputed on the rollout side.
+
+    Same shard layout as :func:`split_train_data_by_dp`, plus two extra keys
+    per shard consumed by ``training_utils.data.get_data_iterator``:
+      - ``num_microbatches`` — per training step, identical on every rank;
+      - ``micro_batch_indices`` — this rank's mbs schedule (local row indices).
+    """
+    shards = split_train_data_by_dp_scheduled_raw(args, data, train_parallel_config=train_parallel_config)
+    store = object_store.get_instance()
+    return [store.put(value=shard, value_spec=ROLLOUT_DATA_VALUE_SPEC) for shard in shards]
+
+
+def split_train_data_by_dp_scheduled_raw(
+    args, data: dict[str, Any], *, train_parallel_config: dict
+) -> list[dict[str, Any]]:
+    """Object-store-free core of :func:`split_train_data_by_dp_scheduled`."""
+    total_lengths = [len(t) for t in data["tokens"]]
+    data["total_lengths"] = total_lengths
+
+    global_batch_size = data.get("dynamic_global_batch_size", args.global_batch_size)
+    partitions, micro_batch_indices, num_microbatches = build_dp_schedule(
+        args,
+        train_parallel_config,
+        total_lengths,
+        global_batch_size=global_batch_size,
+    )
+
+    shards = _package_shards(args, data, partitions)
+    for rank, shard in enumerate(shards):
+        shard["num_microbatches"] = num_microbatches
+        shard["micro_batch_indices"] = micro_batch_indices[rank]
+    return shards
+
+
 def split_train_data_by_dp_raw(args, data: dict[str, Any], *, dp_size: int) -> list[dict[str, Any]]:
     """Split the train data by data parallel size."""
     total_lengths = [len(t) for t in data["tokens"]]
@@ -216,9 +279,14 @@ def split_train_data_by_dp_raw(args, data: dict[str, Any], *, dp_size: int) -> l
     if adapter_slots is not None:
         partitions = [sorted(p, key=lambda i: adapter_slots[i]) for p in partitions]
 
+    return _package_shards(args, data, partitions)
+
+
+def _package_shards(args, data: dict[str, Any], partitions) -> list[dict[str, Any]]:
+    """Package one rollout_data shard per DP rank from precomputed partitions."""
     shards = []
 
-    for i in range(dp_size):
+    for i in range(len(partitions)):
         rollout_data = {}
         partition = partitions[i]
         rollout_data["partition"] = partition

--- a/miles/ray/rollout/train_data_conversion.py
+++ b/miles/ray/rollout/train_data_conversion.py
@@ -211,15 +211,10 @@ def split_train_data_by_dp(args, data, dp_size):
 def can_schedule_on_rollout_side(args, data: dict[str, Any], train_parallel_config: dict | None) -> bool:
     """Whether the rollout side can precompute the full DP/mbs schedule.
 
-    Requires the training backend to have advertised a full schedule config
-    (megatron, non-indep_dp). Excluded on top of that:
-      - multi-LoRA — keeps the legacy per-rank scheduling with its
-        slot-contiguity handling;
-      - multimodal batches — media-token expansion on the train side changes
-        ``total_lengths`` after the schedule would have been computed, so the
-        token-cap packing must stay train-side;
-      - sample counts not divisible by the (dynamic) global batch size —
-        legacy behavior silently drops the remainder per-rank; keep it there.
+    Requires a full schedule config (megatron, non-indep_dp). Also excluded:
+    multi-LoRA (slot-contiguity stays on the legacy path), multimodal batches
+    (train-side media-token expansion changes ``total_lengths``), and sample
+    counts not divisible by the (dynamic) global batch size.
     """
     if not has_full_schedule_config(train_parallel_config):
         return False
@@ -232,12 +227,10 @@ def can_schedule_on_rollout_side(args, data: dict[str, Any], train_parallel_conf
 
 
 def split_train_data_by_dp_scheduled(args, data: dict[str, Any], train_parallel_config: dict):
-    """DP split with the micro-batch schedule precomputed on the rollout side.
+    """DP split with the mbs schedule precomputed on the rollout side.
 
-    Same shard layout as :func:`split_train_data_by_dp`, plus two extra keys
-    per shard consumed by ``training_utils.data.get_data_iterator``:
-      - ``num_microbatches`` — per training step, identical on every rank;
-      - ``micro_batch_indices`` — this rank's mbs schedule (local row indices).
+    Same shard layout as :func:`split_train_data_by_dp`, plus ``num_microbatches``
+    and ``micro_batch_indices`` consumed by ``get_data_iterator``.
     """
     shards = split_train_data_by_dp_scheduled_raw(args, data, train_parallel_config=train_parallel_config)
     store = object_store.get_instance()

--- a/miles/ray/rollout/train_data_conversion.py
+++ b/miles/ray/rollout/train_data_conversion.py
@@ -39,7 +39,6 @@ ROLLOUT_DATA_VALUE_SPEC: dict[str, ValueSpec] = {
     "raw_reward": ValueSpec(codec="auto"),
     "total_lengths": ValueSpec(codec="auto"),
     "dynamic_global_batch_size": ValueSpec(codec="auto"),
-    # Rollout-side precomputed mbs schedule (split_train_data_by_dp_scheduled).
     "num_microbatches": ValueSpec(codec="auto"),
     "micro_batch_indices": ValueSpec(codec="auto"),
 }
@@ -209,13 +208,7 @@ def split_train_data_by_dp(args, data, dp_size):
 
 
 def can_schedule_on_rollout_side(args, data: dict[str, Any], train_parallel_config: dict | None) -> bool:
-    """Whether the rollout side can precompute the full DP/mbs schedule.
-
-    Requires a full schedule config (megatron, non-indep_dp). Also excluded:
-    multi-LoRA (slot-contiguity stays on the legacy path), multimodal batches
-    (train-side media-token expansion changes ``total_lengths``), and sample
-    counts not divisible by the (dynamic) global batch size.
-    """
+    """Whether the rollout side can precompute the full DP/mbs schedule."""
     if not has_full_schedule_config(train_parallel_config):
         return False
     if is_multi_lora_enabled(args):
@@ -227,11 +220,7 @@ def can_schedule_on_rollout_side(args, data: dict[str, Any], train_parallel_conf
 
 
 def split_train_data_by_dp_scheduled(args, data: dict[str, Any], train_parallel_config: dict):
-    """DP split with the mbs schedule precomputed on the rollout side.
-
-    Same shard layout as :func:`split_train_data_by_dp`, plus ``num_microbatches``
-    and ``micro_batch_indices`` consumed by ``get_data_iterator``.
-    """
+    """DP split with the mbs schedule precomputed on the rollout side."""
     shards = split_train_data_by_dp_scheduled_raw(args, data, train_parallel_config=train_parallel_config)
     store = object_store.get_instance()
     return [store.put(value=shard, value_spec=ROLLOUT_DATA_VALUE_SPEC) for shard in shards]

--- a/miles/ray/rollout/train_data_conversion.py
+++ b/miles/ray/rollout/train_data_conversion.py
@@ -32,6 +32,7 @@ ROLLOUT_DATA_VALUE_SPEC: dict[str, ValueSpec] = {
     "truncated": ValueSpec(codec="ndarray", dtype="int64"),
     "round_number": ValueSpec(codec="ndarray", dtype="int64"),
     "sample_indices": ValueSpec(codec="ndarray", dtype="int64"),
+    "rollout_ids": ValueSpec(codec="ndarray", dtype="int64"),
     "multimodal_train_inputs": ValueSpec(codec="ragged_tensor_dict"),
     "prompt": ValueSpec(codec="msgpack_ragged"),
     "metadata": ValueSpec(codec="msgpack_ragged"),
@@ -77,6 +78,10 @@ def convert_samples_to_train_data(
         "raw_reward": raw_rewards,
         "truncated": [1 if sample.status == Sample.Status.TRUNCATED else 0 for sample in samples],
         "sample_indices": [sample.index for sample in samples],
+        # One id per rollout execution; defaults to sample.index (unique) so the
+        # default one-sample-per-rollout path is unchanged. Compact / subagent
+        # samples share their siblings' rollout_id.
+        "rollout_ids": [s.rollout_id if s.rollout_id is not None else s.index for s in samples],
     }
 
     # loss mask
@@ -290,6 +295,7 @@ def _package_shards(args, data: dict[str, Any], partitions) -> list[dict[str, An
             "loss_masks",
             "round_number",
             "sample_indices",
+            "rollout_ids",
             "rollout_log_probs",
             "rollout_routed_experts",
             "rollout_indexer_topk",

--- a/miles/ray/rollout/train_data_conversion.py
+++ b/miles/ray/rollout/train_data_conversion.py
@@ -33,6 +33,7 @@ ROLLOUT_DATA_VALUE_SPEC: dict[str, ValueSpec] = {
     "round_number": ValueSpec(codec="ndarray", dtype="int64"),
     "sample_indices": ValueSpec(codec="ndarray", dtype="int64"),
     "rollout_ids": ValueSpec(codec="ndarray", dtype="int64"),
+    "rollout_mask_sums": ValueSpec(codec="ndarray", dtype="int64"),
     "multimodal_train_inputs": ValueSpec(codec="ragged_tensor_dict"),
     "prompt": ValueSpec(codec="msgpack_ragged"),
     "metadata": ValueSpec(codec="msgpack_ragged"),
@@ -96,6 +97,22 @@ def convert_samples_to_train_data(
             sample.loss_mask = [0] * sample.response_length
         loss_masks.append(sample.loss_mask)
     train_data["loss_masks"] = loss_masks
+
+    # Per-rollout aggregate, precomputed here (where every sample of every
+    # rollout is visible) and broadcast per-sample so the per-mb loss reducer
+    # uses the correct whole-rollout denominator even when a rollout's samples
+    # land in different micro-batches:
+    #
+    #   ``rollout_mask_sums[i]`` — sum of loss-mask totals over every sample in
+    #   sample i's rollout. Used as the reducer's denominator so summing
+    #   partial contributions across mbs yields one token-weighted mean per
+    #   rollout. Equals ``sum(loss_masks[i])`` when 1 rollout = 1 sample.
+    rollout_id_list = train_data["rollout_ids"]
+    mask_sums_per_sample = [sum(m) for m in loss_masks]
+    rollout_total_mask: dict[int, int] = {}
+    for rid, ms in zip(rollout_id_list, mask_sums_per_sample, strict=True):
+        rollout_total_mask[rid] = rollout_total_mask.get(rid, 0) + ms
+    train_data["rollout_mask_sums"] = [rollout_total_mask[rid] for rid in rollout_id_list]
 
     # overwriting the raw reward
     if samples[0].metadata and "raw_reward" in samples[0].metadata:
@@ -293,6 +310,7 @@ def _package_shards(args, data: dict[str, Any], partitions) -> list[dict[str, An
             "round_number",
             "sample_indices",
             "rollout_ids",
+            "rollout_mask_sums",
             "rollout_log_probs",
             "rollout_routed_experts",
             "rollout_indexer_topk",

--- a/miles/ray/rollout/train_data_conversion.py
+++ b/miles/ray/rollout/train_data_conversion.py
@@ -98,15 +98,7 @@ def convert_samples_to_train_data(
         loss_masks.append(sample.loss_mask)
     train_data["loss_masks"] = loss_masks
 
-    # Per-rollout aggregate, precomputed here (where every sample of every
-    # rollout is visible) and broadcast per-sample so the per-mb loss reducer
-    # uses the correct whole-rollout denominator even when a rollout's samples
-    # land in different micro-batches:
-    #
-    #   ``rollout_mask_sums[i]`` — sum of loss-mask totals over every sample in
-    #   sample i's rollout. Used as the reducer's denominator so summing
-    #   partial contributions across mbs yields one token-weighted mean per
-    #   rollout. Equals ``sum(loss_masks[i])`` when 1 rollout = 1 sample.
+    # rollout_mask_sums[i]: whole-rollout loss-mask total, broadcast per sample.
     rollout_id_list = train_data["rollout_ids"]
     mask_sums_per_sample = [sum(m) for m in loss_masks]
     rollout_total_mask: dict[int, int] = {}

--- a/miles/ray/rollout/train_data_conversion.py
+++ b/miles/ray/rollout/train_data_conversion.py
@@ -78,9 +78,6 @@ def convert_samples_to_train_data(
         "raw_reward": raw_rewards,
         "truncated": [1 if sample.status == Sample.Status.TRUNCATED else 0 for sample in samples],
         "sample_indices": [sample.index for sample in samples],
-        # One id per rollout execution; defaults to sample.index (unique) so the
-        # default one-sample-per-rollout path is unchanged. Compact / subagent
-        # samples share their siblings' rollout_id.
         "rollout_ids": [s.rollout_id if s.rollout_id is not None else s.index for s in samples],
     }
 

--- a/miles/ray/rollout/train_data_conversion.py
+++ b/miles/ray/rollout/train_data_conversion.py
@@ -41,6 +41,7 @@ ROLLOUT_DATA_VALUE_SPEC: dict[str, ValueSpec] = {
     "dynamic_global_batch_size": ValueSpec(codec="auto"),
     "num_microbatches": ValueSpec(codec="auto"),
     "micro_batch_indices": ValueSpec(codec="auto"),
+    "global_batch_sizes": ValueSpec(codec="auto"),
 }
 
 
@@ -234,7 +235,7 @@ def split_train_data_by_dp_scheduled_raw(
     data["total_lengths"] = total_lengths
 
     global_batch_size = data.get("dynamic_global_batch_size", args.global_batch_size)
-    partitions, micro_batch_indices, num_microbatches = build_dp_schedule(
+    partitions, micro_batch_indices, num_microbatches, global_batch_sizes = build_dp_schedule(
         args,
         train_parallel_config,
         total_lengths,
@@ -242,13 +243,16 @@ def split_train_data_by_dp_scheduled_raw(
     )
     logger.info(
         f"Rollout-side DP schedule: num_samples={len(total_lengths)}, "
-        f"global_batch_size={global_batch_size}, num_microbatches={num_microbatches}"
+        f"global_batch_sizes={global_batch_sizes}, num_microbatches={num_microbatches}"
     )
 
     shards = _package_shards(args, data, partitions)
     for rank, shard in enumerate(shards):
         shard["num_microbatches"] = num_microbatches
         shard["micro_batch_indices"] = micro_batch_indices[rank]
+        # Per-step sample count (total across DP); the train side normalizes the
+        # loss and steps the LR scheduler by this instead of args.global_batch_size.
+        shard["global_batch_sizes"] = global_batch_sizes
     return shards
 
 

--- a/miles/ray/rollout/train_data_conversion.py
+++ b/miles/ray/rollout/train_data_conversion.py
@@ -250,8 +250,6 @@ def split_train_data_by_dp_scheduled_raw(
     for rank, shard in enumerate(shards):
         shard["num_microbatches"] = num_microbatches
         shard["micro_batch_indices"] = micro_batch_indices[rank]
-        # Per-step sample count (total across DP); the train side normalizes the
-        # loss and steps the LR scheduler by this instead of args.global_batch_size.
         shard["global_batch_sizes"] = global_batch_sizes
     return shards
 

--- a/miles/rollout/generate_utils/sample_utils.py
+++ b/miles/rollout/generate_utils/sample_utils.py
@@ -146,6 +146,7 @@ def _merge_sample_pair(a: Sample, b: Sample, tokenizer) -> Sample:
             Sample,
             group_index=_merge_equal_value("group_index"),
             index=_merge_equal_value("index"),
+            rollout_id=_merge_equal_value("rollout_id"),
             prompt=b.prompt,
             tokens=b.tokens,
             multimodal_inputs=_merge_equal_value("multimodal_inputs"),

--- a/miles/utils/dp_schedule.py
+++ b/miles/utils/dp_schedule.py
@@ -1,25 +1,13 @@
-"""Per-rollout DP/microbatch scheduling.
+"""Per-rollout DP/microbatch scheduling, computed on the rollout side.
 
-Pure-Python logic that decides, for one (already-trimmed) rollout's worth of
-sample lengths, which global sample goes to which DP rank and how each rank
-groups its samples into micro-batches. Lives outside the ray/sglang-importing
-modules so it can be unit-tested under CPU-only CI.
+Pure Python (no ray/sglang imports) so it is unit-testable under CPU-only CI.
+Trim and dynamic-gbs resolution stay on the caller's side.
 
-Trim, dynamic-global_batch_size resolution, and per-rank rollout_data
-packaging all stay on the caller's side; this module only computes the
-schedule itself.
-
-Invariants guaranteed by :func:`build_dp_schedule` (asserted by the tests):
-  - every DP rank holds the same number of samples (``num_samples // dp_size``);
-  - every DP rank runs the same ``num_microbatches`` per training step
-    (required for PP sync);
-  - every mbs holds ``<= max_tokens_per_gpu * cp_size`` tokens, with one
-    exception — an individual sample larger than that cap lands alone in its
-    own mbs (and that mbs is the only one allowed to exceed the cap);
-  - the union of per-rank sample indices equals ``range(num_samples)`` and
-    the per-rank index sets are disjoint;
-  - flattening ``micro_batch_indices`` for a rank yields
-    ``range(num_samples_rank)``.
+Invariants (asserted by tests/fast/utils/test_dp_schedule.py):
+  - equal sample count per DP rank; same ``num_microbatches`` per rank (PP sync);
+  - each mbs holds <= ``max_tokens_per_gpu * cp_size`` tokens, except an
+    oversized sample, which lands alone in its own mbs;
+  - per-rank partitions are disjoint and cover all samples exactly once.
 """
 
 from __future__ import annotations
@@ -32,11 +20,8 @@ SCHEDULE_CONFIG_KEYS = ("dp_size", "cp_size", "vpp_size", "microbatch_group_size
 
 
 def has_full_schedule_config(train_parallel_config: dict | None) -> bool:
-    """True when the training backend advertised every field build_dp_schedule needs.
-
-    Backends that don't (fsdp/torchtitan report only ``dp_size``; indep_dp reports
-    ``{}``) keep the legacy train-side scheduling path.
-    """
+    """True when the backend advertised every field build_dp_schedule needs
+    (fsdp/torchtitan report only ``dp_size``; indep_dp reports ``{}``)."""
     if not train_parallel_config:
         return False
     return all(key in train_parallel_config for key in SCHEDULE_CONFIG_KEYS)
@@ -51,34 +36,18 @@ def build_dp_schedule(
 ) -> tuple[list[list[int]], list[list[list[int]]], list[int]]:
     """Compute the per-rank DP partition and micro-batch schedule.
 
-    For each training step (chunk of ``global_batch_size`` samples):
-      a. Split samples to DP ranks with equal counts (``balance_data`` => token-
-         balanced via Karmarkar-Karp, otherwise strided).
-      b. Static path: chunk each rank's samples into mbs of ``args.micro_batch_size``.
-         Dynamic path: per-rank first-fit (``<= max_tokens_per_gpu * cp_size``), take
-         ``MAX`` across ranks for PP/VPP alignment, then expand each rank to that
-         count by splitting its largest multi-sample bins. Split halves are ``<=``
-         their parent, so the cap is preserved.
-
-    Samples are appended to ``partitions[r]`` in mbs order so each mbs occupies a
-    contiguous range of positions there; ``micro_batch_indices[r][k]`` is that range.
-
-    Args:
-        args: Namespace with ``micro_batch_size``, ``use_dynamic_batch_size``,
-            ``max_tokens_per_gpu``, ``balance_data``.
-        train_parallel_config: ``{"dp_size", "cp_size", "vpp_size",
-            "microbatch_group_size_per_vp_stage"}``.
-        total_lengths: token count per sample, length must be a multiple of
-            ``global_batch_size``.
-        global_batch_size: samples per training step.
+    Per step of ``global_batch_size`` samples: split samples to DP ranks
+    (Karmarkar-Karp if ``balance_data`` else strided), then chunk each rank into
+    mbs — fixed ``micro_batch_size`` (static) or first-fit under
+    ``max_tokens_per_gpu * cp_size`` with a DP-wide MAX + bin splitting for
+    PP/VPP alignment (dynamic).
 
     Returns:
         ``(partitions, micro_batch_indices, num_microbatches)``:
-          - ``partitions[r]`` — global sample indices going to rank r, concatenated
-            across all steps in mbs order.
-          - ``micro_batch_indices[r][k]`` — local indices into ``partitions[r]`` for
-            the k-th mbs of rank r (flat across all steps).
-          - ``num_microbatches[s]`` — mbs count for step s; same value on every rank.
+          - ``partitions[r]`` — global sample indices of rank r, in mbs order;
+          - ``micro_batch_indices[r][k]`` — local indices into ``partitions[r]``
+            for the k-th mbs (flat across steps);
+          - ``num_microbatches[s]`` — mbs count for step s, same on every rank.
     """
     dp_size = train_parallel_config["dp_size"]
     cp_size = train_parallel_config["cp_size"]

--- a/miles/utils/dp_schedule.py
+++ b/miles/utils/dp_schedule.py
@@ -1,14 +1,4 @@
-"""Per-rollout DP/microbatch scheduling, computed on the rollout side.
-
-Pure Python (no ray/sglang imports) so it is unit-testable under CPU-only CI.
-Trim and dynamic-gbs resolution stay on the caller's side.
-
-Invariants (asserted by tests/fast/utils/test_dp_schedule.py):
-  - equal sample count per DP rank; same ``num_microbatches`` per rank (PP sync);
-  - each mbs holds <= ``max_tokens_per_gpu * cp_size`` tokens, except an
-    oversized sample, which lands alone in its own mbs;
-  - per-rank partitions are disjoint and cover all samples exactly once.
-"""
+"""Per-rollout DP/microbatch scheduling, computed on the rollout side."""
 
 from __future__ import annotations
 
@@ -20,8 +10,7 @@ SCHEDULE_CONFIG_KEYS = ("dp_size", "cp_size", "vpp_size", "microbatch_group_size
 
 
 def has_full_schedule_config(train_parallel_config: dict | None) -> bool:
-    """True when the backend advertised every field build_dp_schedule needs
-    (fsdp/torchtitan report only ``dp_size``; indep_dp reports ``{}``)."""
+    """True when the backend advertised every field build_dp_schedule needs."""
     if not train_parallel_config:
         return False
     return all(key in train_parallel_config for key in SCHEDULE_CONFIG_KEYS)
@@ -34,21 +23,7 @@ def build_dp_schedule(
     *,
     global_batch_size: int,
 ) -> tuple[list[list[int]], list[list[list[int]]], list[int]]:
-    """Compute the per-rank DP partition and micro-batch schedule.
-
-    Per step of ``global_batch_size`` samples: split samples to DP ranks
-    (Karmarkar-Karp if ``balance_data`` else strided), then chunk each rank into
-    mbs — fixed ``micro_batch_size`` (static) or first-fit under
-    ``max_tokens_per_gpu * cp_size`` with a DP-wide MAX + bin splitting for
-    PP/VPP alignment (dynamic).
-
-    Returns:
-        ``(partitions, micro_batch_indices, num_microbatches)``:
-          - ``partitions[r]`` — global sample indices of rank r, in mbs order;
-          - ``micro_batch_indices[r][k]`` — local indices into ``partitions[r]``
-            for the k-th mbs (flat across steps);
-          - ``num_microbatches[s]`` — mbs count for step s, same on every rank.
-    """
+    """Compute per-rank ``(partitions, micro_batch_indices, num_microbatches)``."""
     dp_size = train_parallel_config["dp_size"]
     cp_size = train_parallel_config["cp_size"]
     vpp_size = train_parallel_config["vpp_size"] or 1
@@ -77,8 +52,6 @@ def build_dp_schedule(
         else:
             rank_parts = [list(range(r, global_batch_size, dp_size)) for r in range(dp_size)]
 
-        # rank_mbs[r][k] is one mbs of LOCAL indices into rank_parts[r] (positions
-        # within this rank's sample list, not step- or global-indices).
         if not args.use_dynamic_batch_size:
             mbs = args.micro_batch_size
             n = len(rank_parts[0])  # gbs / dp, same for every rank
@@ -93,7 +66,6 @@ def build_dp_schedule(
             rank_mbs = [first_fit_pack(rank_lens[r], max_per_bin) for r in range(dp_size)]
             num_mbs_per_rank = max(len(b) for b in rank_mbs)
             if vpp_size > 1:
-                # Match the original floor-to-mb_group rounding (with min=1).
                 num_mbs_per_rank = max(num_mbs_per_rank // mb_group * mb_group, 1)
             for r in range(dp_size):
                 expand_bins_by_splitting(rank_mbs[r], num_mbs_per_rank, rank_lens[r])

--- a/miles/utils/dp_schedule.py
+++ b/miles/utils/dp_schedule.py
@@ -1,0 +1,140 @@
+"""Per-rollout DP/microbatch scheduling.
+
+Pure-Python logic that decides, for one (already-trimmed) rollout's worth of
+sample lengths, which global sample goes to which DP rank and how each rank
+groups its samples into micro-batches. Lives outside the ray/sglang-importing
+modules so it can be unit-tested under CPU-only CI.
+
+Trim, dynamic-global_batch_size resolution, and per-rank rollout_data
+packaging all stay on the caller's side; this module only computes the
+schedule itself.
+
+Invariants guaranteed by :func:`build_dp_schedule` (asserted by the tests):
+  - every DP rank holds the same number of samples (``num_samples // dp_size``);
+  - every DP rank runs the same ``num_microbatches`` per training step
+    (required for PP sync);
+  - every mbs holds ``<= max_tokens_per_gpu * cp_size`` tokens, with one
+    exception — an individual sample larger than that cap lands alone in its
+    own mbs (and that mbs is the only one allowed to exceed the cap);
+  - the union of per-rank sample indices equals ``range(num_samples)`` and
+    the per-rank index sets are disjoint;
+  - flattening ``micro_batch_indices`` for a rank yields
+    ``range(num_samples_rank)``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from miles.utils.seqlen_balancing import expand_bins_by_splitting, first_fit_pack, get_seqlen_balanced_partitions
+
+SCHEDULE_CONFIG_KEYS = ("dp_size", "cp_size", "vpp_size", "microbatch_group_size_per_vp_stage")
+
+
+def has_full_schedule_config(train_parallel_config: dict | None) -> bool:
+    """True when the training backend advertised every field build_dp_schedule needs.
+
+    Backends that don't (fsdp/torchtitan report only ``dp_size``; indep_dp reports
+    ``{}``) keep the legacy train-side scheduling path.
+    """
+    if not train_parallel_config:
+        return False
+    return all(key in train_parallel_config for key in SCHEDULE_CONFIG_KEYS)
+
+
+def build_dp_schedule(
+    args: Any,
+    train_parallel_config: dict,
+    total_lengths: list[int],
+    *,
+    global_batch_size: int,
+) -> tuple[list[list[int]], list[list[list[int]]], list[int]]:
+    """Compute the per-rank DP partition and micro-batch schedule.
+
+    For each training step (chunk of ``global_batch_size`` samples):
+      a. Split samples to DP ranks with equal counts (``balance_data`` => token-
+         balanced via Karmarkar-Karp, otherwise strided).
+      b. Static path: chunk each rank's samples into mbs of ``args.micro_batch_size``.
+         Dynamic path: per-rank first-fit (``<= max_tokens_per_gpu * cp_size``), take
+         ``MAX`` across ranks for PP/VPP alignment, then expand each rank to that
+         count by splitting its largest multi-sample bins. Split halves are ``<=``
+         their parent, so the cap is preserved.
+
+    Samples are appended to ``partitions[r]`` in mbs order so each mbs occupies a
+    contiguous range of positions there; ``micro_batch_indices[r][k]`` is that range.
+
+    Args:
+        args: Namespace with ``micro_batch_size``, ``use_dynamic_batch_size``,
+            ``max_tokens_per_gpu``, ``balance_data``.
+        train_parallel_config: ``{"dp_size", "cp_size", "vpp_size",
+            "microbatch_group_size_per_vp_stage"}``.
+        total_lengths: token count per sample, length must be a multiple of
+            ``global_batch_size``.
+        global_batch_size: samples per training step.
+
+    Returns:
+        ``(partitions, micro_batch_indices, num_microbatches)``:
+          - ``partitions[r]`` — global sample indices going to rank r, concatenated
+            across all steps in mbs order.
+          - ``micro_batch_indices[r][k]`` — local indices into ``partitions[r]`` for
+            the k-th mbs of rank r (flat across all steps).
+          - ``num_microbatches[s]`` — mbs count for step s; same value on every rank.
+    """
+    dp_size = train_parallel_config["dp_size"]
+    cp_size = train_parallel_config["cp_size"]
+    vpp_size = train_parallel_config["vpp_size"] or 1
+    mb_group = train_parallel_config["microbatch_group_size_per_vp_stage"]
+
+    assert len(total_lengths) % global_batch_size == 0, (
+        f"num_samples ({len(total_lengths)}) is not a multiple of global_batch_size "
+        f"({global_batch_size}); trim upstream before scheduling."
+    )
+    num_steps = len(total_lengths) // global_batch_size
+
+    if args.use_dynamic_batch_size:
+        assert args.max_tokens_per_gpu is not None
+        max_per_bin = args.max_tokens_per_gpu * cp_size
+
+    partitions: list[list[int]] = [[] for _ in range(dp_size)]
+    micro_batch_indices: list[list[list[int]]] = [[] for _ in range(dp_size)]
+    num_microbatches: list[int] = []
+
+    for step_i in range(num_steps):
+        step_start = step_i * global_batch_size
+        step_lengths = total_lengths[step_start : step_start + global_batch_size]
+
+        if args.balance_data:
+            rank_parts = get_seqlen_balanced_partitions(step_lengths, dp_size, equal_size=True)
+        else:
+            rank_parts = [list(range(r, global_batch_size, dp_size)) for r in range(dp_size)]
+
+        # rank_mbs[r][k] is one mbs of LOCAL indices into rank_parts[r] (positions
+        # within this rank's sample list, not step- or global-indices).
+        if not args.use_dynamic_batch_size:
+            mbs = args.micro_batch_size
+            n = len(rank_parts[0])  # gbs / dp, same for every rank
+            assert n % mbs == 0, (
+                f"per-rank batch ({n} = global_batch_size {global_batch_size} / dp_size {dp_size}) "
+                f"is not a multiple of micro_batch_size ({mbs})"
+            )
+            rank_mbs = [[list(range(i, i + mbs)) for i in range(0, n, mbs)] for _ in range(dp_size)]
+            num_mbs_per_rank = n // mbs
+        else:
+            rank_lens = [[step_lengths[i] for i in rank_parts[r]] for r in range(dp_size)]
+            rank_mbs = [first_fit_pack(rank_lens[r], max_per_bin) for r in range(dp_size)]
+            num_mbs_per_rank = max(len(b) for b in rank_mbs)
+            if vpp_size > 1:
+                # Match the original floor-to-mb_group rounding (with min=1).
+                num_mbs_per_rank = max(num_mbs_per_rank // mb_group * mb_group, 1)
+            for r in range(dp_size):
+                expand_bins_by_splitting(rank_mbs[r], num_mbs_per_rank, rank_lens[r])
+
+        num_microbatches.append(num_mbs_per_rank)
+
+        for r in range(dp_size):
+            for mbs_local in rank_mbs[r]:
+                local_start = len(partitions[r])
+                partitions[r].extend(step_start + rank_parts[r][i] for i in mbs_local)
+                micro_batch_indices[r].append(list(range(local_start, local_start + len(mbs_local))))
+
+    return partitions, micro_batch_indices, num_microbatches

--- a/miles/utils/dp_schedule.py
+++ b/miles/utils/dp_schedule.py
@@ -22,8 +22,8 @@ def build_dp_schedule(
     total_lengths: list[int],
     *,
     global_batch_size: int,
-) -> tuple[list[list[int]], list[list[list[int]]], list[int]]:
-    """Compute per-rank ``(partitions, micro_batch_indices, num_microbatches)``."""
+) -> tuple[list[list[int]], list[list[list[int]]], list[int], list[int]]:
+    """Compute per-rank ``(partitions, micro_batch_indices, num_microbatches, global_batch_sizes)``."""
     dp_size = train_parallel_config["dp_size"]
     cp_size = train_parallel_config["cp_size"]
     vpp_size = train_parallel_config["vpp_size"] or 1
@@ -42,10 +42,12 @@ def build_dp_schedule(
     partitions: list[list[int]] = [[] for _ in range(dp_size)]
     micro_batch_indices: list[list[list[int]]] = [[] for _ in range(dp_size)]
     num_microbatches: list[int] = []
+    global_batch_sizes: list[int] = []
 
     for step_i in range(num_steps):
         step_start = step_i * global_batch_size
         step_lengths = total_lengths[step_start : step_start + global_batch_size]
+        global_batch_sizes.append(len(step_lengths))
 
         if args.balance_data:
             rank_parts = get_seqlen_balanced_partitions(step_lengths, dp_size, equal_size=True)
@@ -78,4 +80,4 @@ def build_dp_schedule(
                 partitions[r].extend(step_start + rank_parts[r][i] for i in mbs_local)
                 micro_batch_indices[r].append(list(range(local_start, local_start + len(mbs_local))))
 
-    return partitions, micro_batch_indices, num_microbatches
+    return partitions, micro_batch_indices, num_microbatches, global_batch_sizes

--- a/miles/utils/seqlen_balancing.py
+++ b/miles/utils/seqlen_balancing.py
@@ -177,6 +177,58 @@ def get_seqlen_balanced_partitions(seqlen_list: list[int], k_partitions: int, eq
     return _check_and_sort_partitions(partitions)
 
 
+def first_fit_pack(total_lengths, max_tokens_per_bin):
+    """First-fit bin packing.
+
+    Returns ``list[list[int]]`` — each bin is a list of indices into ``total_lengths``.
+    Bin sums are ``<= max_tokens_per_bin`` whenever every individual ``length`` fits;
+    an oversized sample lands alone in its own bin with sum equal to its length.
+    """
+    bins: list[list[int]] = []
+    bin_sums: list[int] = []
+    for idx, length in enumerate(total_lengths):
+        for j in range(len(bins)):
+            if bin_sums[j] + length <= max_tokens_per_bin:
+                bins[j].append(idx)
+                bin_sums[j] += length
+                break
+        else:
+            bins.append([idx])
+            bin_sums.append(length)
+    return bins
+
+
+def _split_bin_by_tokens(bin_indices: list[int], lengths) -> list[list[int]]:
+    """Split a bin's indices into two halves balanced by total tokens (LPT heuristic).
+
+    Returns ``[left, right]`` where both lists together cover ``bin_indices``. Because
+    each half is a strict subset of ``bin_indices``, both have token sums ``<=`` the
+    original bin's sum — useful when you need to grow a bin packing without ever
+    creating a bin larger than the originals.
+    """
+    halves: list[list[int]] = [[], []]
+    sums = [0, 0]
+    for idx in sorted(bin_indices, key=lambda i: -lengths[i]):
+        h = 0 if sums[0] <= sums[1] else 1
+        halves[h].append(idx)
+        sums[h] += lengths[idx]
+    return halves
+
+
+def expand_bins_by_splitting(bins: list[list[int]], target_count: int, lengths) -> None:
+    """Grow ``bins`` in place to ``target_count`` by repeatedly splitting the largest
+    multi-sample bin via :func:`_split_bin_by_tokens`. Stops early if every remaining
+    bin is a singleton (no bin can be split further)."""
+    while len(bins) < target_count:
+        candidates = [(sum(lengths[i] for i in b), idx) for idx, b in enumerate(bins) if len(b) > 1]
+        if not candidates:
+            break
+        _, idx = max(candidates)
+        left, right = _split_bin_by_tokens(bins[idx], lengths)
+        bins[idx] = left
+        bins.append(right)
+
+
 def get_reverse_idx(idx_map):
     reverse_idx_map = copy.deepcopy(idx_map)
 

--- a/miles/utils/seqlen_balancing.py
+++ b/miles/utils/seqlen_balancing.py
@@ -178,8 +178,7 @@ def get_seqlen_balanced_partitions(seqlen_list: list[int], k_partitions: int, eq
 
 
 def first_fit_pack(total_lengths, max_tokens_per_bin):
-    """First-fit bin packing; each bin is a list of indices into ``total_lengths``.
-    Bin sums stay ``<= max_tokens_per_bin``; an oversized sample lands alone."""
+    """First-fit bin packing; bins hold indices, oversized samples land alone."""
     bins: list[list[int]] = []
     bin_sums: list[int] = []
     for idx, length in enumerate(total_lengths):
@@ -195,8 +194,7 @@ def first_fit_pack(total_lengths, max_tokens_per_bin):
 
 
 def _split_bin_by_tokens(bin_indices: list[int], lengths) -> list[list[int]]:
-    """Split a bin into two token-balanced halves (LPT); each half's sum is
-    ``<=`` the parent's, so splitting never exceeds the original cap."""
+    """Split a bin into two token-balanced halves (LPT)."""
     halves: list[list[int]] = [[], []]
     sums = [0, 0]
     for idx in sorted(bin_indices, key=lambda i: -lengths[i]):
@@ -207,8 +205,7 @@ def _split_bin_by_tokens(bin_indices: list[int], lengths) -> list[list[int]]:
 
 
 def expand_bins_by_splitting(bins: list[list[int]], target_count: int, lengths) -> None:
-    """Grow ``bins`` in place to ``target_count`` by splitting the largest
-    multi-sample bin; stops early once every bin is a singleton."""
+    """Grow ``bins`` in place to ``target_count`` by splitting the largest bins."""
     while len(bins) < target_count:
         candidates = [(sum(lengths[i] for i in b), idx) for idx, b in enumerate(bins) if len(b) > 1]
         if not candidates:

--- a/miles/utils/seqlen_balancing.py
+++ b/miles/utils/seqlen_balancing.py
@@ -178,12 +178,8 @@ def get_seqlen_balanced_partitions(seqlen_list: list[int], k_partitions: int, eq
 
 
 def first_fit_pack(total_lengths, max_tokens_per_bin):
-    """First-fit bin packing.
-
-    Returns ``list[list[int]]`` — each bin is a list of indices into ``total_lengths``.
-    Bin sums are ``<= max_tokens_per_bin`` whenever every individual ``length`` fits;
-    an oversized sample lands alone in its own bin with sum equal to its length.
-    """
+    """First-fit bin packing; each bin is a list of indices into ``total_lengths``.
+    Bin sums stay ``<= max_tokens_per_bin``; an oversized sample lands alone."""
     bins: list[list[int]] = []
     bin_sums: list[int] = []
     for idx, length in enumerate(total_lengths):
@@ -199,13 +195,8 @@ def first_fit_pack(total_lengths, max_tokens_per_bin):
 
 
 def _split_bin_by_tokens(bin_indices: list[int], lengths) -> list[list[int]]:
-    """Split a bin's indices into two halves balanced by total tokens (LPT heuristic).
-
-    Returns ``[left, right]`` where both lists together cover ``bin_indices``. Because
-    each half is a strict subset of ``bin_indices``, both have token sums ``<=`` the
-    original bin's sum — useful when you need to grow a bin packing without ever
-    creating a bin larger than the originals.
-    """
+    """Split a bin into two token-balanced halves (LPT); each half's sum is
+    ``<=`` the parent's, so splitting never exceeds the original cap."""
     halves: list[list[int]] = [[], []]
     sums = [0, 0]
     for idx in sorted(bin_indices, key=lambda i: -lengths[i]):
@@ -216,9 +207,8 @@ def _split_bin_by_tokens(bin_indices: list[int], lengths) -> list[list[int]]:
 
 
 def expand_bins_by_splitting(bins: list[list[int]], target_count: int, lengths) -> None:
-    """Grow ``bins`` in place to ``target_count`` by repeatedly splitting the largest
-    multi-sample bin via :func:`_split_bin_by_tokens`. Stops early if every remaining
-    bin is a singleton (no bin can be split further)."""
+    """Grow ``bins`` in place to ``target_count`` by splitting the largest
+    multi-sample bin; stops early once every bin is a singleton."""
     while len(bins) < target_count:
         candidates = [(sum(lengths[i] for i in b), idx) for idx, b in enumerate(bins) if len(b) > 1]
         if not candidates:

--- a/miles/utils/types.py
+++ b/miles/utils/types.py
@@ -28,11 +28,8 @@ class Sample:
 
     group_index: int | None = None
     index: int | None = None
-    # Id of the rollout execution this sample came from. None falls back to
-    # ``index`` downstream, so the default path (one execution = one training
-    # sample) is unchanged. Compact / subagent rollouts that split one
-    # execution into multiple training samples must set the same rollout_id on
-    # every sibling so loss/metric aggregation counts the rollout once.
+    # Rollout execution id; None falls back to ``index``. Compact / subagent
+    # siblings must share it so the rollout is counted once.
     rollout_id: int | None = None
     # prompt
     prompt: str | list[dict[str, str]] = ""

--- a/miles/utils/types.py
+++ b/miles/utils/types.py
@@ -28,6 +28,12 @@ class Sample:
 
     group_index: int | None = None
     index: int | None = None
+    # Id of the rollout execution this sample came from. None falls back to
+    # ``index`` downstream, so the default path (one execution = one training
+    # sample) is unchanged. Compact / subagent rollouts that split one
+    # execution into multiple training samples must set the same rollout_id on
+    # every sibling so loss/metric aggregation counts the rollout once.
+    rollout_id: int | None = None
     # prompt
     prompt: str | list[dict[str, str]] = ""
     tokens: list[int] = field(default_factory=list)

--- a/tests/fast/backends/training_utils/test_reduce_gathered_log_dict.py
+++ b/tests/fast/backends/training_utils/test_reduce_gathered_log_dict.py
@@ -1,0 +1,45 @@
+"""CPU tests for the (sum, count)-aware DP metric reduction."""
+
+from __future__ import annotations
+
+import math
+
+from miles.backends.training_utils.log_utils import reduce_gathered_log_dict
+
+
+def test_scalar_values_keep_legacy_mean():
+    gathered = [{"a": 1.0}, {"a": 3.0}]
+    assert reduce_gathered_log_dict(gathered, dp_size=2) == {"a": 2.0}
+
+
+def test_tuple_values_weighted_by_count():
+    # rank0: 3 samples with sum 3.0; rank1: 1 sample with sum 5.0
+    gathered = [{"m": (3.0, 3)}, {"m": (5.0, 1)}]
+    out = reduce_gathered_log_dict(gathered, dp_size=2)
+    assert math.isclose(out["m"], 8.0 / 4)
+
+
+def test_tuple_equal_counts_match_mean_of_means():
+    """With equal per-rank counts (today's invariant) the weighted average must
+    equal the legacy mean-of-per-rank-means, so metrics stay comparable."""
+    sums = [2.0, 6.0, 4.0, 8.0]
+    count = 4
+    gathered = [{"m": (s, count)} for s in sums]
+    out = reduce_gathered_log_dict(gathered, dp_size=4)
+    legacy = sum(s / count for s in sums) / 4
+    assert math.isclose(out["m"], legacy)
+
+
+def test_zero_total_count_maps_to_zero():
+    gathered = [{"m": (0.0, 0)}, {"m": (0.0, 0)}]
+    assert reduce_gathered_log_dict(gathered, dp_size=2) == {"m": 0.0}
+
+
+def test_mixed_keys():
+    gathered = [
+        {"scalar": 1.0, "weighted": (2.0, 2)},
+        {"scalar": 3.0, "weighted": (6.0, 2)},
+    ]
+    out = reduce_gathered_log_dict(gathered, dp_size=2)
+    assert out["scalar"] == 2.0
+    assert math.isclose(out["weighted"], 2.0)

--- a/tests/fast/backends/training_utils/test_rollout_mask_sums.py
+++ b/tests/fast/backends/training_utils/test_rollout_mask_sums.py
@@ -1,0 +1,115 @@
+"""CPU tests for per-rollout loss denominators (``rollout_mask_sums``).
+
+Covers:
+- the rollout-side precomputation in ``convert_samples_to_train_data``;
+- ``get_sum_of_sample_mean(sample_denoms=...)`` — legacy per-sample mean when
+  ``None``, per-rollout token-weighted mean with precomputed denominators, and
+  the strict no-op equivalence between the two when 1 rollout = 1 sample;
+- ``aggregate_train_losses(step_global_batch_size=...)`` constant-divisor mode.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+import torch
+from tests.fast.backends.training_utils.loss.loss_test_utils import make_parallel_state
+from tests.fast.ray.rollout.conftest import make_args, make_sample
+
+from miles.backends.training_utils import log_utils
+from miles.backends.training_utils.cp_utils import get_sum_of_sample_mean
+from miles.ray.rollout.train_data_conversion import convert_samples_to_train_data
+
+
+@pytest.fixture(autouse=True)
+def _parallel_state():
+    make_parallel_state()
+
+
+def _convert(samples):
+    return convert_samples_to_train_data(
+        make_args(rewards_normalization=False),
+        samples,
+        metadata={},
+        custom_convert_samples_to_train_data_func=None,
+        custom_reward_post_process_func=None,
+    )
+
+
+class TestRolloutMaskSumsPrecompute:
+    def test_defaults_to_per_sample_mask_sums(self):
+        samples = [make_sample(index=i, response_length=n) for i, n in enumerate((2, 3, 4))]
+        out = _convert(samples)
+        assert out["rollout_mask_sums"] == [2, 3, 4]
+
+    def test_compact_siblings_share_whole_rollout_total(self):
+        samples = [make_sample(index=i, response_length=n) for i, n in enumerate((2, 3, 4))]
+        # samples 0 and 1 come from the same rollout execution
+        samples[0].rollout_id = samples[1].rollout_id = 0
+        out = _convert(samples)
+        assert out["rollout_mask_sums"] == [5, 5, 4]
+
+    def test_masked_out_tokens_excluded(self):
+        s = make_sample(index=0, response_length=4)
+        s.loss_mask = [1, 0, 1, 0]
+        out = _convert([s])
+        assert out["rollout_mask_sums"] == [2]
+
+
+class TestSampleDenoms:
+    def _masks(self, lens):
+        return [torch.ones(n, dtype=torch.int) for n in lens]
+
+    def test_none_matches_legacy_per_sample_mean(self):
+        lens = [2, 3]
+        x = torch.tensor([1.0, 3.0, 2.0, 2.0, 5.0])
+        som = get_sum_of_sample_mean(list(lens), list(lens), self._masks(lens))
+        # sample means: (1+3)/2 = 2, (2+2+5)/3 = 3
+        assert math.isclose(som(x).item(), 5.0)
+
+    def test_rollout_denoms_give_token_weighted_rollout_mean(self):
+        lens = [2, 3]
+        x = torch.tensor([1.0, 3.0, 2.0, 2.0, 5.0])
+        # both samples belong to one rollout with 5 mask tokens total
+        denoms = torch.tensor([5.0, 5.0])
+        som = get_sum_of_sample_mean(list(lens), list(lens), self._masks(lens), sample_denoms=denoms)
+        # (1+3)/5 + (2+2+5)/5 = 13/5 — one token-weighted mean for the rollout
+        assert math.isclose(som(x).item(), 13.0 / 5, rel_tol=1e-6)
+
+    def test_per_sample_denoms_equal_legacy(self):
+        """1 rollout = 1 sample: rollout_mask_sums equals each mask's own sum -> strict no-op."""
+        lens = [2, 3, 4]
+        x = torch.randn(sum(lens))
+        masks = self._masks(lens)
+        legacy = get_sum_of_sample_mean(list(lens), list(lens), masks)
+        denoms = torch.tensor([float(n) for n in lens])
+        new = get_sum_of_sample_mean(list(lens), list(lens), masks, sample_denoms=denoms)
+        assert torch.allclose(legacy(x), new(x))
+
+
+class TestAggregateTrainLossesConstantDivisor:
+    @pytest.fixture(autouse=True)
+    def _no_allreduce(self, monkeypatch):
+        monkeypatch.setattr(log_utils.MultiPGUtil, "all_reduce", staticmethod(lambda *a, **k: None))
+
+    def _mb(self, denominator, values):
+        return {"keys": list(values.keys()), "values": torch.tensor([denominator, *values.values()])}
+
+    def test_constant_divisor_mode(self):
+        # producer left the 0 placeholder -> divide by step_global_batch_size, no cp factor
+        losses = [self._mb(0, {"loss": 2.0}), self._mb(0, {"loss": 6.0})]
+        out = log_utils.aggregate_train_losses(losses, step_global_batch_size=4)
+        assert math.isclose(out["loss"], 2.0)
+
+    def test_legacy_mode_unchanged(self):
+        losses = [self._mb(2, {"loss": 2.0}), self._mb(2, {"loss": 6.0})]
+        out = log_utils.aggregate_train_losses(losses)
+        assert math.isclose(out["loss"], 2.0)
+
+    def test_legacy_values_win_when_producer_not_in_placeholder_mode(self):
+        """A non-zero values[0] (legacy producer) keeps the legacy reduction even
+        if the caller passes a step size."""
+        losses = [self._mb(4, {"loss": 8.0})]
+        out = log_utils.aggregate_train_losses(losses, step_global_batch_size=999)
+        assert math.isclose(out["loss"], 2.0)

--- a/tests/fast/ray/rollout/test_rollout_data_conversion.py
+++ b/tests/fast/ray/rollout/test_rollout_data_conversion.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 import pytest
 from tests.fast.ray.rollout.conftest import make_args, make_sample
 
-from miles.ray.rollout.rollout_data_conversion import _compute_dynamic_global_batch_size, postprocess_rollout_data
+from miles.ray.rollout.rollout_data_conversion import (
+    _compute_dynamic_global_batch_size,
+    postprocess_rollout_data,
+    validate_rollout_id_annotated,
+)
 
 
 class TestComputeDynamicGlobalBatchSize:
@@ -72,3 +76,34 @@ class TestPostprocessRolloutData:
         nested = [[make_sample(index=0), make_sample(index=1)], [make_sample(index=2)]]
         out, _meta = postprocess_rollout_data(args, nested, train_parallel_config={"dp_size": 1})
         assert len(out) == 3
+
+
+class TestValidateRolloutIdAnnotated:
+    def test_flat_list_skips_validation(self):
+        """Depth-1 leaf (flat list[Sample]) is the default rollout shape — no rollout_id required."""
+        validate_rollout_id_annotated([make_sample(index=i) for i in range(4)])
+
+    def test_default_nested_shape_skips_validation(self):
+        """list[list[Sample]] (prompt x rollout): leaf at depth 1 — no rollout_id required."""
+        validate_rollout_id_annotated([[make_sample(index=0), make_sample(index=1)]])
+
+    def test_compact_shape_requires_rollout_id(self):
+        """list[list[list[Sample]]]: leaf at depth 2 with >1 sibling requires rollout_id."""
+        compact = [[[make_sample(index=0), make_sample(index=1)]]]
+        with pytest.raises(AssertionError, match="rollout_id is unset"):
+            validate_rollout_id_annotated(compact)
+
+    def test_compact_shape_siblings_must_share_rollout_id(self):
+        a, b = make_sample(index=0), make_sample(index=1)
+        a.rollout_id, b.rollout_id = 7, 8
+        with pytest.raises(AssertionError, match="share rollout_id"):
+            validate_rollout_id_annotated([[[a, b]]])
+
+    def test_compact_shape_valid_when_annotated(self):
+        a, b = make_sample(index=0), make_sample(index=1)
+        a.rollout_id = b.rollout_id = 7
+        validate_rollout_id_annotated([[[a, b]]])
+
+    def test_compact_singleton_leaf_needs_no_annotation(self):
+        """A single-sample leaf at depth >= 2 is unambiguous — no rollout_id required."""
+        validate_rollout_id_annotated([[[make_sample(index=0)]]])

--- a/tests/fast/ray/rollout/test_train_data_conversion.py
+++ b/tests/fast/ray/rollout/test_train_data_conversion.py
@@ -11,9 +11,11 @@ from tests.fast.ray.rollout.conftest import make_args, make_sample, make_samples
 
 from miles.ray.rollout.train_data_conversion import (
     _post_process_rewards,
+    can_schedule_on_rollout_side,
     convert_samples_to_train_data,
     split_train_data_by_dp,
     split_train_data_by_dp_raw,
+    split_train_data_by_dp_scheduled_raw,
 )
 from miles.utils import object_store
 from miles.utils.types import Sample
@@ -545,3 +547,109 @@ class TestSplitTrainDataRaw:
 
         result = split_train_data_by_dp_raw(args, data, dp_size=1)
         assert "seq_witness_ids" not in result[0]
+
+
+FULL_SCHEDULE_CONFIG = {
+    "dp_size": 2,
+    "cp_size": 1,
+    "vpp_size": 1,
+    "microbatch_group_size_per_vp_stage": None,
+}
+
+
+def _make_split_data(n: int, *, lengths: list[int] | None = None) -> dict:
+    lengths = lengths or [2] * n
+    assert len(lengths) == n
+    return {
+        "tokens": [list(range(length)) for length in lengths],
+        "response_lengths": [1] * n,
+        "rewards": [0.0] * n,
+        "truncated": [0] * n,
+        "loss_masks": [[1] * length for length in lengths],
+        "sample_indices": list(range(n)),
+    }
+
+
+class TestCanScheduleOnRolloutSide:
+    def test_eligible_with_full_megatron_config(self):
+        args = make_args(balance_data=False, micro_batch_size=1, use_dynamic_batch_size=False, multi_lora=False)
+        assert can_schedule_on_rollout_side(args, _make_split_data(8), FULL_SCHEDULE_CONFIG)
+
+    def test_rejects_partial_config(self):
+        """fsdp / torchtitan advertise only dp_size; indep_dp advertises {}."""
+        args = make_args(balance_data=False, micro_batch_size=1, multi_lora=False)
+        assert not can_schedule_on_rollout_side(args, _make_split_data(8), {"dp_size": 2})
+        assert not can_schedule_on_rollout_side(args, _make_split_data(8), {})
+        assert not can_schedule_on_rollout_side(args, _make_split_data(8), None)
+
+    def test_rejects_multi_lora(self):
+        args = make_args(balance_data=False, micro_batch_size=1, multi_lora=True)
+        assert not can_schedule_on_rollout_side(args, _make_split_data(8), FULL_SCHEDULE_CONFIG)
+
+    def test_rejects_multimodal(self):
+        args = make_args(balance_data=False, micro_batch_size=1, multi_lora=False)
+        data = _make_split_data(8)
+        data["multimodal_train_inputs"] = [None] * 8
+        assert not can_schedule_on_rollout_side(args, data, FULL_SCHEDULE_CONFIG)
+
+    def test_rejects_indivisible_sample_count(self):
+        args = make_args(balance_data=False, micro_batch_size=1, multi_lora=False)  # global_batch_size=8
+        assert not can_schedule_on_rollout_side(args, _make_split_data(10), FULL_SCHEDULE_CONFIG)
+
+    def test_dynamic_gbs_overrides_args_gbs(self):
+        args = make_args(balance_data=False, micro_batch_size=1, multi_lora=False)  # global_batch_size=8
+        data = _make_split_data(6)
+        data["dynamic_global_batch_size"] = 6
+        assert can_schedule_on_rollout_side(args, data, FULL_SCHEDULE_CONFIG)
+
+
+class TestSplitTrainDataByDpScheduled:
+    def test_static_shards_match_legacy_split_plus_schedule(self):
+        """Static path: shards must be identical to the legacy split, plus the two
+        schedule keys, and the schedule must tile each shard's rows exactly."""
+        args = make_args(balance_data=False, micro_batch_size=2, use_dynamic_batch_size=False)
+        data = _make_split_data(8)
+        legacy = split_train_data_by_dp_raw(args, dict(data), dp_size=2)
+        scheduled = split_train_data_by_dp_scheduled_raw(
+            args, dict(data), train_parallel_config=FULL_SCHEDULE_CONFIG
+        )
+
+        assert len(scheduled) == 2
+        for rank, (old, new) in enumerate(zip(legacy, scheduled, strict=True)):
+            assert list(new["partition"]) == list(old["partition"]), f"rank {rank} partition changed"
+            for key in ("tokens", "response_lengths", "loss_masks", "sample_indices"):
+                assert new[key] == old[key], f"rank {rank} {key} changed"
+            # global_batch_size=8, dp=2, mbs=2 -> 2 mbs per rank, 1 step
+            assert new["num_microbatches"] == [2]
+            flat = [i for mbs in new["micro_batch_indices"] for i in mbs]
+            assert flat == list(range(len(new["tokens"])))
+
+    def test_dynamic_schedule_respects_token_cap(self):
+        args = make_args(
+            balance_data=False,
+            micro_batch_size=1,
+            use_dynamic_batch_size=True,
+            max_tokens_per_gpu=6,
+        )
+        lengths = [5, 1, 4, 2, 3, 3, 2, 4]
+        data = _make_split_data(8, lengths=lengths)
+        shards = split_train_data_by_dp_scheduled_raw(args, data, train_parallel_config=FULL_SCHEDULE_CONFIG)
+
+        nmb = shards[0]["num_microbatches"]
+        for shard in shards:
+            assert shard["num_microbatches"] == nmb, "num_microbatches must be identical on every rank"
+            assert len(shard["micro_batch_indices"]) == sum(nmb)
+            partition = list(shard["partition"])
+            for mbs in shard["micro_batch_indices"]:
+                total = sum(lengths[partition[i]] for i in mbs)
+                assert total <= 6 or len(mbs) == 1
+
+    def test_dynamic_gbs_multi_step(self):
+        """16 samples with dynamic_global_batch_size=8 -> 2 steps."""
+        args = make_args(balance_data=False, micro_batch_size=2, use_dynamic_batch_size=False)
+        data = _make_split_data(16)
+        data["dynamic_global_batch_size"] = 8
+        shards = split_train_data_by_dp_scheduled_raw(args, data, train_parallel_config=FULL_SCHEDULE_CONFIG)
+
+        assert shards[0]["num_microbatches"] == [2, 2]
+        assert shards[0]["dynamic_global_batch_size"] == 8

--- a/tests/fast/ray/rollout/test_train_data_conversion.py
+++ b/tests/fast/ray/rollout/test_train_data_conversion.py
@@ -610,9 +610,7 @@ class TestSplitTrainDataByDpScheduled:
         args = make_args(balance_data=False, micro_batch_size=2, use_dynamic_batch_size=False)
         data = _make_split_data(8)
         legacy = split_train_data_by_dp_raw(args, dict(data), dp_size=2)
-        scheduled = split_train_data_by_dp_scheduled_raw(
-            args, dict(data), train_parallel_config=FULL_SCHEDULE_CONFIG
-        )
+        scheduled = split_train_data_by_dp_scheduled_raw(args, dict(data), train_parallel_config=FULL_SCHEDULE_CONFIG)
 
         assert len(scheduled) == 2
         for rank, (old, new) in enumerate(zip(legacy, scheduled, strict=True)):

--- a/tests/fast/ray/rollout/test_train_data_conversion.py
+++ b/tests/fast/ray/rollout/test_train_data_conversion.py
@@ -619,6 +619,7 @@ class TestSplitTrainDataByDpScheduled:
                 assert new[key] == old[key], f"rank {rank} {key} changed"
             # global_batch_size=8, dp=2, mbs=2 -> 2 mbs per rank, 1 step
             assert new["num_microbatches"] == [2]
+            assert new["global_batch_sizes"] == [8]
             flat = [i for mbs in new["micro_batch_indices"] for i in mbs]
             assert flat == list(range(len(new["tokens"])))
 
@@ -651,3 +652,4 @@ class TestSplitTrainDataByDpScheduled:
 
         assert shards[0]["num_microbatches"] == [2, 2]
         assert shards[0]["dynamic_global_batch_size"] == 8
+        assert shards[0]["global_batch_sizes"] == [8, 8]

--- a/tests/fast/ray/rollout/test_train_data_conversion.py
+++ b/tests/fast/ray/rollout/test_train_data_conversion.py
@@ -146,6 +146,32 @@ class TestConvertSamplesToTrainData:
         )
         assert out["raw_reward"][0] == 9.0
 
+    def test_rollout_ids_default_to_sample_index(self):
+        args = make_args(rewards_normalization=False)
+        samples = [make_sample(index=i) for i in range(3)]
+        out = convert_samples_to_train_data(
+            args,
+            samples,
+            metadata={},
+            custom_convert_samples_to_train_data_func=None,
+            custom_reward_post_process_func=None,
+        )
+        assert out["rollout_ids"] == [0, 1, 2]
+
+    def test_rollout_ids_use_explicit_rollout_id_when_set(self):
+        args = make_args(rewards_normalization=False)
+        samples = [make_sample(index=i) for i in range(4)]
+        # two compact siblings sharing one rollout execution
+        samples[1].rollout_id = samples[2].rollout_id = 1
+        out = convert_samples_to_train_data(
+            args,
+            samples,
+            metadata={},
+            custom_convert_samples_to_train_data_func=None,
+            custom_reward_post_process_func=None,
+        )
+        assert out["rollout_ids"] == [0, 1, 1, 3]
+
     def test_custom_convert_func_short_circuits(self):
         args = make_args()
         sentinel = {"foo": "bar"}

--- a/tests/fast/utils/test_dp_schedule.py
+++ b/tests/fast/utils/test_dp_schedule.py
@@ -1,0 +1,260 @@
+"""CPU unit tests for miles.utils.dp_schedule.build_dp_schedule.
+
+The tests assert the invariants documented at the top of dp_schedule.py against
+a range of static / dynamic / VPP / oversize / balance scenarios, plus an
+equivalence check of ``num_microbatches`` against the legacy train-side
+computation (``get_minimum_num_micro_batch_size`` + DP-wide MAX) that this
+schedule replaces.
+
+Trim, dynamic-gbs resolution, and per-rank rollout_data packaging all live in
+``train_data_conversion.split_train_data_by_dp_scheduled``; these tests just
+exercise the schedule itself (``partitions`` and ``micro_batch_indices``).
+"""
+
+from __future__ import annotations
+
+import random
+from types import SimpleNamespace
+
+import pytest
+
+from miles.utils.data import get_minimum_num_micro_batch_size
+from miles.utils.dp_schedule import build_dp_schedule, has_full_schedule_config
+
+
+def make_args(
+    *,
+    micro_batch_size=1,
+    use_dynamic_batch_size=False,
+    max_tokens_per_gpu=None,
+    balance_data=False,
+):
+    return SimpleNamespace(
+        micro_batch_size=micro_batch_size,
+        use_dynamic_batch_size=use_dynamic_batch_size,
+        max_tokens_per_gpu=max_tokens_per_gpu,
+        balance_data=balance_data,
+    )
+
+
+def make_tp(dp_size=1, cp_size=1, vpp_size=1, microbatch_group_size_per_vp_stage=None):
+    return {
+        "dp_size": dp_size,
+        "cp_size": cp_size,
+        "vpp_size": vpp_size,
+        "microbatch_group_size_per_vp_stage": microbatch_group_size_per_vp_stage,
+    }
+
+
+def assert_invariants(partitions, micro_batch_indices, num_microbatches, *, dp_size, total_lengths, max_per_bin=None):
+    """Check the invariants documented at the top of dp_schedule.py."""
+    expected_per_rank = len(total_lengths) // dp_size
+    seen_global: set[int] = set()
+    for r in range(dp_size):
+        partition = partitions[r]
+        mbi = micro_batch_indices[r]
+
+        # Same sample count per rank.
+        assert len(partition) == expected_per_rank, f"rank {r}: {len(partition)} samples, want {expected_per_rank}"
+
+        # Same num_mbs per rank (PP sync); num_microbatches is shared, so each rank's
+        # flat mbs count must match sum(num_microbatches).
+        assert len(mbi) == sum(num_microbatches), f"rank {r}: mbs count mismatch"
+
+        # Flattened micro_batch_indices == range(len(partition)) (each sample covered
+        # exactly once, by exactly one mbs).
+        flat = [i for mbs in mbi for i in mbs]
+        assert flat == list(range(len(partition))), f"rank {r}: micro_batch_indices don't tile [0, n)"
+
+        # Disjoint partitions whose union covers every sample.
+        assert seen_global.isdisjoint(partition), f"rank {r}: overlap with other ranks"
+        seen_global.update(partition)
+    assert seen_global == set(range(len(total_lengths))), "some samples not assigned to any rank"
+
+    if max_per_bin is None:
+        return
+
+    # Every mbs <= max_per_bin tokens, EXCEPT a singleton bin holding an oversized sample.
+    for r in range(dp_size):
+        partition = partitions[r]
+        for mbs in micro_batch_indices[r]:
+            bin_total = sum(total_lengths[partition[i]] for i in mbs)
+            if bin_total > max_per_bin:
+                assert len(mbs) == 1, f"rank {r}: mbs sum {bin_total} > {max_per_bin} but contains {len(mbs)} samples"
+
+
+def test_static_stride_single_step():
+    """Static + strided DP split, single step."""
+    total_lengths = [10] * 16
+    args = make_args(micro_batch_size=2)
+    tp = make_tp(dp_size=4)
+
+    partitions, mbi, nmb = build_dp_schedule(args, tp, total_lengths, global_batch_size=16)
+
+    assert nmb == [2]
+    assert_invariants(partitions, mbi, nmb, dp_size=4, total_lengths=total_lengths)
+
+
+def test_static_stride_matches_legacy_partition_order():
+    """Static + strided must produce exactly the legacy strided row order —
+    rank r gets rows [r, r+dp, r+2*dp, ...] in that order, contiguously chunked."""
+    total_lengths = list(range(100, 116))
+    args = make_args(micro_batch_size=2)
+    tp = make_tp(dp_size=4)
+
+    partitions, _, _ = build_dp_schedule(args, tp, total_lengths, global_batch_size=16)
+
+    for r in range(4):
+        assert partitions[r] == list(range(r, 16, 4)), f"rank {r} partition deviates from legacy strided order"
+
+
+def test_static_balance_multi_step():
+    """Static + balance_data + 2 training steps. Each rank must get gbs/dp per step."""
+    total_lengths = [1, 2, 3, 4, 5, 6, 7, 8, 8, 7, 6, 5, 4, 3, 2, 1]  # 2 steps of 8
+    args = make_args(micro_batch_size=2, balance_data=True)
+    tp = make_tp(dp_size=2)
+
+    partitions, mbi, nmb = build_dp_schedule(args, tp, total_lengths, global_batch_size=8)
+
+    assert nmb == [2, 2]
+    assert_invariants(partitions, mbi, nmb, dp_size=2, total_lengths=total_lengths)
+
+
+def test_dynamic_uniform():
+    """Dynamic mbs on uniform-length samples."""
+    total_lengths = [5] * 8
+    args = make_args(use_dynamic_batch_size=True, max_tokens_per_gpu=10)
+    tp = make_tp(dp_size=2)
+
+    partitions, mbi, nmb = build_dp_schedule(args, tp, total_lengths, global_batch_size=8)
+
+    assert_invariants(partitions, mbi, nmb, dp_size=2, total_lengths=total_lengths, max_per_bin=10)
+
+
+def test_dynamic_skewed_lengths():
+    """Skewed lengths (the case where K-K used to over-pack a single bin)."""
+    total_lengths = [9, 9, 9, 9, 1, 1, 1, 1]
+    args = make_args(use_dynamic_batch_size=True, max_tokens_per_gpu=10)
+    tp = make_tp(dp_size=2)
+
+    partitions, mbi, nmb = build_dp_schedule(args, tp, total_lengths, global_batch_size=8)
+
+    assert_invariants(partitions, mbi, nmb, dp_size=2, total_lengths=total_lengths, max_per_bin=10)
+
+
+def test_dynamic_oversized_sample_lands_alone():
+    """A single sample exceeding max_per_bin must end up alone in its mbs (with no
+    other samples crammed in)."""
+    total_lengths = [15, 3, 3, 3, 3, 3, 3, 3]  # 15 > C=10
+    args = make_args(use_dynamic_batch_size=True, max_tokens_per_gpu=10)
+    tp = make_tp(dp_size=2)
+
+    partitions, mbi, nmb = build_dp_schedule(args, tp, total_lengths, global_batch_size=8)
+
+    assert_invariants(partitions, mbi, nmb, dp_size=2, total_lengths=total_lengths, max_per_bin=10)
+    # Find the rank holding the oversized sample and verify it lives alone in some mbs.
+    oversize_idx = total_lengths.index(15)
+    found = False
+    for r in range(2):
+        partition = partitions[r]
+        if oversize_idx not in partition:
+            continue
+        local = partition.index(oversize_idx)
+        for mbs in mbi[r]:
+            if local in mbs:
+                assert mbs == [local], f"oversized sample shares an mbs: {mbs}"
+                found = True
+    assert found
+
+
+def test_dynamic_with_vpp_rounds_to_mb_group():
+    """num_microbatches per rank should be a multiple of mb_group when vpp_size > 1."""
+    total_lengths = [4] * 32  # 2 steps of 16; per step, ~8 bins of 8 needed at C=8
+    args = make_args(use_dynamic_batch_size=True, max_tokens_per_gpu=8)
+    tp = make_tp(dp_size=2, vpp_size=2, microbatch_group_size_per_vp_stage=2)
+
+    partitions, mbi, nmb = build_dp_schedule(args, tp, total_lengths, global_batch_size=16)
+
+    for n in nmb:
+        assert n % 2 == 0, f"num_microbatches {n} is not a multiple of mb_group=2"
+    assert_invariants(partitions, mbi, nmb, dp_size=2, total_lengths=total_lengths, max_per_bin=8)
+
+
+def test_static_indivisible_per_rank_batch_asserts():
+    """gbs/dp not a multiple of micro_batch_size must fail loudly, not mis-schedule."""
+    args = make_args(micro_batch_size=3)
+    tp = make_tp(dp_size=2)
+    with pytest.raises(AssertionError, match="micro_batch_size"):
+        build_dp_schedule(args, tp, [10] * 8, global_batch_size=8)
+
+
+def test_untrimmed_input_asserts():
+    """num_samples not a multiple of global_batch_size must fail loudly."""
+    args = make_args(micro_batch_size=1)
+    tp = make_tp(dp_size=2)
+    with pytest.raises(AssertionError, match="multiple of global_batch_size"):
+        build_dp_schedule(args, tp, [10] * 10, global_batch_size=8)
+
+
+def test_dynamic_num_microbatches_matches_legacy_train_side():
+    """The PP-sync-critical value: for the same strided partition, the rollout-side
+    schedule must produce exactly the num_microbatches the legacy train-side path
+    computed (per-rank ``get_minimum_num_micro_batch_size``, then DP-wide MAX)."""
+    rng = random.Random(42)
+    dp_size, cp_size = 4, 2
+    max_tokens_per_gpu = 512
+    global_batch_size = 32
+
+    for _ in range(50):
+        num_steps = rng.randint(1, 3)
+        total_lengths = [rng.randint(16, 1200) for _ in range(global_batch_size * num_steps)]
+
+        args = make_args(use_dynamic_batch_size=True, max_tokens_per_gpu=max_tokens_per_gpu)
+        tp = make_tp(dp_size=dp_size, cp_size=cp_size)
+        _, _, nmb = build_dp_schedule(args, tp, total_lengths, global_batch_size=global_batch_size)
+
+        # Legacy: each rank r holds the strided rows of each step, computes its own
+        # first-fit bin count over its local per-step slice, and the DP group takes MAX.
+        num_local_gbs = global_batch_size // dp_size
+        legacy_nmb = []
+        for step_i in range(num_steps):
+            step = total_lengths[step_i * global_batch_size : (step_i + 1) * global_batch_size]
+            per_rank = []
+            for r in range(dp_size):
+                local = [step[i] for i in range(r, global_batch_size, dp_size)]
+                assert len(local) == num_local_gbs
+                per_rank.append(get_minimum_num_micro_batch_size(local, max_tokens_per_gpu * cp_size))
+            legacy_nmb.append(max(per_rank))
+
+        assert nmb == legacy_nmb, f"num_microbatches diverged from legacy: {nmb} vs {legacy_nmb}"
+
+
+def test_randomized_invariants_dynamic():
+    """Randomized sweep of the documented invariants on the dynamic path."""
+    rng = random.Random(7)
+    for _ in range(30):
+        dp_size = rng.choice([1, 2, 4])
+        gbs = dp_size * rng.choice([2, 4, 8])
+        num_steps = rng.randint(1, 2)
+        total_lengths = [rng.randint(1, 40) for _ in range(gbs * num_steps)]
+        max_tokens = rng.randint(20, 60)
+        balance = rng.random() < 0.5
+
+        args = make_args(use_dynamic_batch_size=True, max_tokens_per_gpu=max_tokens, balance_data=balance)
+        tp = make_tp(dp_size=dp_size)
+        partitions, mbi, nmb = build_dp_schedule(args, tp, total_lengths, global_batch_size=gbs)
+
+        assert_invariants(
+            partitions, mbi, nmb, dp_size=dp_size, total_lengths=total_lengths, max_per_bin=max_tokens
+        )
+
+
+def test_has_full_schedule_config():
+    assert has_full_schedule_config(make_tp())
+    assert not has_full_schedule_config({})
+    assert not has_full_schedule_config(None)
+    assert not has_full_schedule_config({"dp_size": 4})  # fsdp/torchtitan shape
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__]))

--- a/tests/fast/utils/test_dp_schedule.py
+++ b/tests/fast/utils/test_dp_schedule.py
@@ -244,9 +244,7 @@ def test_randomized_invariants_dynamic():
         tp = make_tp(dp_size=dp_size)
         partitions, mbi, nmb = build_dp_schedule(args, tp, total_lengths, global_batch_size=gbs)
 
-        assert_invariants(
-            partitions, mbi, nmb, dp_size=dp_size, total_lengths=total_lengths, max_per_bin=max_tokens
-        )
+        assert_invariants(partitions, mbi, nmb, dp_size=dp_size, total_lengths=total_lengths, max_per_bin=max_tokens)
 
 
 def test_has_full_schedule_config():

--- a/tests/fast/utils/test_dp_schedule.py
+++ b/tests/fast/utils/test_dp_schedule.py
@@ -89,9 +89,10 @@ def test_static_stride_single_step():
     args = make_args(micro_batch_size=2)
     tp = make_tp(dp_size=4)
 
-    partitions, mbi, nmb = build_dp_schedule(args, tp, total_lengths, global_batch_size=16)
+    partitions, mbi, nmb, gbs_steps = build_dp_schedule(args, tp, total_lengths, global_batch_size=16)
 
     assert nmb == [2]
+    assert gbs_steps == [16]
     assert_invariants(partitions, mbi, nmb, dp_size=4, total_lengths=total_lengths)
 
 
@@ -102,7 +103,7 @@ def test_static_stride_matches_legacy_partition_order():
     args = make_args(micro_batch_size=2)
     tp = make_tp(dp_size=4)
 
-    partitions, _, _ = build_dp_schedule(args, tp, total_lengths, global_batch_size=16)
+    partitions, _, _, _ = build_dp_schedule(args, tp, total_lengths, global_batch_size=16)
 
     for r in range(4):
         assert partitions[r] == list(range(r, 16, 4)), f"rank {r} partition deviates from legacy strided order"
@@ -114,7 +115,8 @@ def test_static_balance_multi_step():
     args = make_args(micro_batch_size=2, balance_data=True)
     tp = make_tp(dp_size=2)
 
-    partitions, mbi, nmb = build_dp_schedule(args, tp, total_lengths, global_batch_size=8)
+    partitions, mbi, nmb, gbs_steps = build_dp_schedule(args, tp, total_lengths, global_batch_size=8)
+    assert gbs_steps == [8] * len(nmb)
 
     assert nmb == [2, 2]
     assert_invariants(partitions, mbi, nmb, dp_size=2, total_lengths=total_lengths)
@@ -126,7 +128,8 @@ def test_dynamic_uniform():
     args = make_args(use_dynamic_batch_size=True, max_tokens_per_gpu=10)
     tp = make_tp(dp_size=2)
 
-    partitions, mbi, nmb = build_dp_schedule(args, tp, total_lengths, global_batch_size=8)
+    partitions, mbi, nmb, gbs_steps = build_dp_schedule(args, tp, total_lengths, global_batch_size=8)
+    assert gbs_steps == [8] * len(nmb)
 
     assert_invariants(partitions, mbi, nmb, dp_size=2, total_lengths=total_lengths, max_per_bin=10)
 
@@ -137,7 +140,8 @@ def test_dynamic_skewed_lengths():
     args = make_args(use_dynamic_batch_size=True, max_tokens_per_gpu=10)
     tp = make_tp(dp_size=2)
 
-    partitions, mbi, nmb = build_dp_schedule(args, tp, total_lengths, global_batch_size=8)
+    partitions, mbi, nmb, gbs_steps = build_dp_schedule(args, tp, total_lengths, global_batch_size=8)
+    assert gbs_steps == [8] * len(nmb)
 
     assert_invariants(partitions, mbi, nmb, dp_size=2, total_lengths=total_lengths, max_per_bin=10)
 
@@ -149,7 +153,8 @@ def test_dynamic_oversized_sample_lands_alone():
     args = make_args(use_dynamic_batch_size=True, max_tokens_per_gpu=10)
     tp = make_tp(dp_size=2)
 
-    partitions, mbi, nmb = build_dp_schedule(args, tp, total_lengths, global_batch_size=8)
+    partitions, mbi, nmb, gbs_steps = build_dp_schedule(args, tp, total_lengths, global_batch_size=8)
+    assert gbs_steps == [8] * len(nmb)
 
     assert_invariants(partitions, mbi, nmb, dp_size=2, total_lengths=total_lengths, max_per_bin=10)
     # Find the rank holding the oversized sample and verify it lives alone in some mbs.
@@ -173,7 +178,8 @@ def test_dynamic_with_vpp_rounds_to_mb_group():
     args = make_args(use_dynamic_batch_size=True, max_tokens_per_gpu=8)
     tp = make_tp(dp_size=2, vpp_size=2, microbatch_group_size_per_vp_stage=2)
 
-    partitions, mbi, nmb = build_dp_schedule(args, tp, total_lengths, global_batch_size=16)
+    partitions, mbi, nmb, gbs_steps = build_dp_schedule(args, tp, total_lengths, global_batch_size=16)
+    assert gbs_steps == [16] * len(nmb)
 
     for n in nmb:
         assert n % 2 == 0, f"num_microbatches {n} is not a multiple of mb_group=2"
@@ -211,7 +217,7 @@ def test_dynamic_num_microbatches_matches_legacy_train_side():
 
         args = make_args(use_dynamic_batch_size=True, max_tokens_per_gpu=max_tokens_per_gpu)
         tp = make_tp(dp_size=dp_size, cp_size=cp_size)
-        _, _, nmb = build_dp_schedule(args, tp, total_lengths, global_batch_size=global_batch_size)
+        _, _, nmb, _ = build_dp_schedule(args, tp, total_lengths, global_batch_size=global_batch_size)
 
         # Legacy: each rank r holds the strided rows of each step, computes its own
         # first-fit bin count over its local per-step slice, and the DP group takes MAX.
@@ -242,9 +248,19 @@ def test_randomized_invariants_dynamic():
 
         args = make_args(use_dynamic_batch_size=True, max_tokens_per_gpu=max_tokens, balance_data=balance)
         tp = make_tp(dp_size=dp_size)
-        partitions, mbi, nmb = build_dp_schedule(args, tp, total_lengths, global_batch_size=gbs)
+        partitions, mbi, nmb, gbs_steps = build_dp_schedule(args, tp, total_lengths, global_batch_size=gbs)
 
+        assert gbs_steps == [gbs] * len(nmb)
         assert_invariants(partitions, mbi, nmb, dp_size=dp_size, total_lengths=total_lengths, max_per_bin=max_tokens)
+
+
+def test_global_batch_sizes_one_per_step():
+    """4th return value: per-step sample count, constant in the equal-size case."""
+    args = make_args(micro_batch_size=2)
+    tp = make_tp(dp_size=2)
+    _, _, nmb, gbs_steps = build_dp_schedule(args, tp, [10] * 24, global_batch_size=8)
+    assert len(gbs_steps) == len(nmb) == 3
+    assert gbs_steps == [8, 8, 8]
 
 
 def test_has_full_schedule_config():


### PR DESCRIPTION
## Summary

Stacked on #1930. Parts B+D of slime #1933: aggregate loss and metrics per rollout instead of per sample. Strict no-op while 1 rollout = 1 sample (the default path); the semantics only change for compact / subagent rollouts that split one execution into multiple training samples.

- `convert_samples_to_train_data` precomputes `rollout_mask_sums` — whole-rollout loss-mask totals, broadcast per sample — at the step level, so a rollout whose samples land in different micro-batches still gets a full denominator. The DP split carries it; `get_rollout_data` promotes it to a GPU tensor.
- `get_sum_of_sample_mean` gains `sample_denoms`: `None` keeps the legacy per-sample mean; `rollout_mask_sums` yields one token-weighted mean per rollout.
- `loss_function` and the TIS decoupled path use the precomputed denominators. TIS note (deliberate alignment with slime #1933): modified response masks now correct the numerator only; the denominator stays the whole-rollout total from the original masks.
- `aggregate_train_losses` supports a constant `step_global_batch_size` divisor (producer leaves a `0` placeholder in `values[0]`; no CP factor — CP-chunked partial numerators reconstruct exactly once under the DP*CP all-reduce). Megatron threads it through both the normal and the indep_dp aggregation paths; fsdp / torchtitan stay on the legacy reduction.
- `log_rollout_data` token metrics use the same denominators, so reported means live in the same space as the gradient signal.

## Validation

- CPU: 84 tests green, including new `test_rollout_mask_sums.py` (precompute grouping, masked tokens, per-sample == per-rollout equivalence in the 1:1 case, constant-divisor reduction incl. legacy-producer guard), loss snapshot tests, true-on-policy dtype test.
- GPU e2e on 8xH200 (`--ci-test`, checker + metric gates on):

| run | topology | result |
|---|---|---|
| Qwen2.5-0.5B gsm8k short | dp8, dynamic batch, mooncake | ✅ succeeded |
| Qwen3-30B-A3B baseline | dp2 + cp2 + pp2 + ep2, metric gates | ✅ succeeded, `logprob_abs_diff` 0.0177 (base branch: 0.0171/0.0178 same topology) |
