### PR TITLE
[4/N] Pack-first DP schedule; global_batch_size counts rollouts

### DIFF
--- a/miles/backends/training_utils/log_utils.py
+++ b/miles/backends/training_utils/log_utils.py
@@ -135,11 +135,7 @@ def log_rollout_data(rollout_id: int, args: Namespace, rollout_data: RolloutBatc
         loss_masks = rollout_data["loss_masks"]
         total_lengths = rollout_data["total_lengths"]
         max_seq_lens = rollout_data.get("max_seq_lens", None)
-        # For per-rollout-mean metrics: each of the dp*cp gathered ranks emits
-        # count = num_rollouts / dp, so the (sum, count) reduction lands on
-        # sum_DP_full / num_rollouts — the same number train_one_step reports
-        # for the same samples. None (legacy shards) keeps count = local
-        # sample count. No-op while 1 rollout = 1 sample.
+        # per-rollout-mean count share: num_rollouts / dp (None = legacy local count)
         rollout_count_share = None
         if (global_batch_sizes := rollout_data.get("global_batch_sizes")) is not None:
             rollout_count_share = sum(global_batch_sizes) / parallel_state.intra_dp.size

--- a/miles/backends/training_utils/log_utils.py
+++ b/miles/backends/training_utils/log_utils.py
@@ -135,6 +135,14 @@ def log_rollout_data(rollout_id: int, args: Namespace, rollout_data: RolloutBatc
         loss_masks = rollout_data["loss_masks"]
         total_lengths = rollout_data["total_lengths"]
         max_seq_lens = rollout_data.get("max_seq_lens", None)
+        # For per-rollout-mean metrics: each of the dp*cp gathered ranks emits
+        # count = num_rollouts / dp, so the (sum, count) reduction lands on
+        # sum_DP_full / num_rollouts — the same number train_one_step reports
+        # for the same samples. None (legacy shards) keeps count = local
+        # sample count. No-op while 1 rollout = 1 sample.
+        rollout_count_share = None
+        if (global_batch_sizes := rollout_data.get("global_batch_sizes")) is not None:
+            rollout_count_share = sum(global_batch_sizes) / parallel_state.intra_dp.size
 
         for key, val in rollout_data.items():
             if key in [
@@ -190,6 +198,8 @@ def log_rollout_data(rollout_id: int, args: Namespace, rollout_data: RolloutBatc
                             sample_denoms=rollout_data.get("rollout_mask_sums", None),
                         )
                         per_rank_sum = cp_size * sum_of_sample_mean(tensor)
+                        if rollout_count_share is not None:
+                            count = rollout_count_share
                     else:
                         per_rank_sum = tensor.mean() * cp_size * count
                     log_dict[key] = (per_rank_sum.item(), count)

--- a/miles/ray/rollout/rollout_data_conversion.py
+++ b/miles/ray/rollout/rollout_data_conversion.py
@@ -25,9 +25,8 @@ def postprocess_rollout_data(args, data, train_parallel_config):
     while isinstance(data[0], list):
         data = list(itertools.chain.from_iterable(data))
 
-    # Compact / subagent rollouts (explicit rollout_id) must not be trimmed by
-    # sample count — cutting mid-rollout would orphan siblings. The rollout-side
-    # schedule drops whole trailing rollouts instead.
+    # Compact rollouts must not be trimmed by sample count; the schedule drops
+    # whole trailing rollouts instead.
     is_compact = any(s.rollout_id is not None for s in data)
 
     if not args.disable_rollout_trim_samples and not is_compact:

--- a/miles/ray/rollout/rollout_data_conversion.py
+++ b/miles/ray/rollout/rollout_data_conversion.py
@@ -25,7 +25,12 @@ def postprocess_rollout_data(args, data, train_parallel_config):
     while isinstance(data[0], list):
         data = list(itertools.chain.from_iterable(data))
 
-    if not args.disable_rollout_trim_samples:
+    # Compact / subagent rollouts (explicit rollout_id) must not be trimmed by
+    # sample count — cutting mid-rollout would orphan siblings. The rollout-side
+    # schedule drops whole trailing rollouts instead.
+    is_compact = any(s.rollout_id is not None for s in data)
+
+    if not args.disable_rollout_trim_samples and not is_compact:
         global_batch_size = args.global_batch_size
         if args.use_dynamic_global_batch_size:
             logger.info(f"Collected {len(data)} samples from rollout to train with dynamic global batch size")

--- a/miles/ray/rollout/train_data_conversion.py
+++ b/miles/ray/rollout/train_data_conversion.py
@@ -227,8 +227,11 @@ def can_schedule_on_rollout_side(args, data: dict[str, Any], train_parallel_conf
         return False
     if "multimodal_train_inputs" in data:
         return False
+    if "rollout_ids" not in data:
+        # custom convert_samples_to_train_data functions may not emit it
+        return False
     global_batch_size = data.get("dynamic_global_batch_size", args.global_batch_size)
-    return len(data["tokens"]) % global_batch_size == 0
+    return len(set(data["rollout_ids"])) >= global_batch_size
 
 
 def split_train_data_by_dp_scheduled(args, data: dict[str, Any], train_parallel_config: dict):
@@ -251,9 +254,11 @@ def split_train_data_by_dp_scheduled_raw(
         train_parallel_config,
         total_lengths,
         global_batch_size=global_batch_size,
+        rollout_indices=data["rollout_ids"],
     )
     logger.info(
         f"Rollout-side DP schedule: num_samples={len(total_lengths)}, "
+        f"num_rollouts={len(set(data['rollout_ids']))}, "
         f"global_batch_sizes={global_batch_sizes}, num_microbatches={num_microbatches}"
     )
 

--- a/miles/ray/rollout/train_data_conversion.py
+++ b/miles/ray/rollout/train_data_conversion.py
@@ -228,7 +228,6 @@ def can_schedule_on_rollout_side(args, data: dict[str, Any], train_parallel_conf
     if "multimodal_train_inputs" in data:
         return False
     if "rollout_ids" not in data:
-        # custom convert_samples_to_train_data functions may not emit it
         return False
     global_batch_size = data.get("dynamic_global_batch_size", args.global_batch_size)
     return len(set(data["rollout_ids"])) >= global_batch_size

--- a/miles/rollout/generate_hub/compact_split_example.py
+++ b/miles/rollout/generate_hub/compact_split_example.py
@@ -1,14 +1,4 @@
-"""Example compact generate fn: one rollout execution -> multiple training samples.
-
-Wraps single-turn generation, then splits the response into two training
-samples at the midpoint of the response tokens. Both siblings share the parent
-sample's ``rollout_id`` so the by-rollout scheduler keeps them in one training
-step and the per-rollout loss reducer counts the rollout once.
-
-This mirrors the compact / subagent pattern (multi-agent systems, thinking-token
-removal) in a form small enough for e2e validation; see
-``--custom-generate-function-path miles.rollout.generate_hub.compact_split_example.generate``.
-"""
+"""Example compact generate fn: one rollout execution -> two training samples sharing rollout_id."""
 
 import copy
 
@@ -22,8 +12,6 @@ async def generate(input: GenerateFnInput) -> GenerateFnOutput:
     sample = output.samples
     assert isinstance(sample, Sample)
 
-    # Too short to split, or aborted mid-generation: emit as-is (still stamp
-    # rollout_id so downstream accounting is uniform).
     sample.rollout_id = sample.index
     if sample.response_length < 2 or sample.status == Sample.Status.ABORTED:
         return GenerateFnOutput(samples=[sample])
@@ -37,8 +25,6 @@ async def generate(input: GenerateFnInput) -> GenerateFnOutput:
     first.loss_mask = sample.loss_mask[:cut] if sample.loss_mask is not None else None
     if first.rollout_log_probs is not None:
         first.rollout_log_probs = sample.rollout_log_probs[:cut]
-    # The reward belongs to the full rollout; both siblings carry it so
-    # advantage computation sees the rollout's outcome on every piece.
     first.status = Sample.Status.COMPLETED
 
     second = copy.deepcopy(sample)

--- a/miles/rollout/generate_hub/compact_split_example.py
+++ b/miles/rollout/generate_hub/compact_split_example.py
@@ -1,0 +1,47 @@
+"""Example compact generate fn: one rollout execution -> multiple training samples.
+
+Wraps single-turn generation, then splits the response into two training
+samples at the midpoint of the response tokens. Both siblings share the parent
+sample's ``rollout_id`` so the by-rollout scheduler keeps them in one training
+step and the per-rollout loss reducer counts the rollout once.
+
+This mirrors the compact / subagent pattern (multi-agent systems, thinking-token
+removal) in a form small enough for e2e validation; see
+``--custom-generate-function-path miles.rollout.generate_hub.compact_split_example.generate``.
+"""
+
+import copy
+
+from miles.rollout.base_types import GenerateFnInput, GenerateFnOutput
+from miles.rollout.generate_hub.single_turn import generate as single_turn_generate
+from miles.utils.types import Sample
+
+
+async def generate(input: GenerateFnInput) -> GenerateFnOutput:
+    output = await single_turn_generate(input)
+    sample = output.samples
+    assert isinstance(sample, Sample)
+
+    # Too short to split, or aborted mid-generation: emit as-is (still stamp
+    # rollout_id so downstream accounting is uniform).
+    sample.rollout_id = sample.index
+    if sample.response_length < 2 or sample.status == Sample.Status.ABORTED:
+        return GenerateFnOutput(samples=[sample])
+
+    prompt_len = len(sample.tokens) - sample.response_length
+    cut = sample.response_length // 2
+
+    first = copy.deepcopy(sample)
+    first.tokens = sample.tokens[: prompt_len + cut]
+    first.response_length = cut
+    first.loss_mask = sample.loss_mask[:cut] if sample.loss_mask is not None else None
+    if first.rollout_log_probs is not None:
+        first.rollout_log_probs = sample.rollout_log_probs[:cut]
+    # The reward belongs to the full rollout; both siblings carry it so
+    # advantage computation sees the rollout's outcome on every piece.
+    first.status = Sample.Status.COMPLETED
+
+    second = copy.deepcopy(sample)
+    second.loss_mask = [0] * cut + list(sample.loss_mask[cut:]) if sample.loss_mask is not None else None
+
+    return GenerateFnOutput(samples=[first, second])

--- a/miles/utils/dp_schedule.py
+++ b/miles/utils/dp_schedule.py
@@ -71,32 +71,8 @@ def build_dp_schedule(
     global_batch_size: int,
     rollout_indices: list[int],
 ) -> tuple[list[list[int]], list[list[list[int]]], list[int], list[int]]:
-    """Compute the per-rank DP partition and micro-batch schedule.
-
-    See module docstring for the pack-first-distribute-second strategy.
-
-    Args:
-        args: Namespace with ``micro_batch_size``, ``use_dynamic_batch_size``,
-            ``max_tokens_per_gpu``, ``balance_data``.
-        train_parallel_config: ``{"dp_size", "cp_size", "vpp_size",
-            "microbatch_group_size_per_vp_stage"}``.
-        total_lengths: token count per sample, indexed globally.
-        global_batch_size: number of rollouts (NOT training samples) per
-            training step. Number of training steps =
-            ``num_rollouts // global_batch_size``; trailing rollouts whose
-            samples don't fit are dropped.
-        rollout_indices: rollout id for each sample. Samples sharing the same
-            id are kept together in one step.
-
-    Returns:
-        ``(partitions, micro_batch_indices, num_microbatches, global_batch_sizes)``:
-          - ``partitions[r]`` — global sample indices of rank r, in mbs order;
-          - ``micro_batch_indices[r][k]`` — local indices into ``partitions[r]``
-            for the k-th mbs (flat across steps);
-          - ``num_microbatches[s]`` — mbs count for step s, same on every rank;
-          - ``global_batch_sizes[s]`` — rollout count for step s (constant
-            ``global_batch_size`` for every step).
-    """
+    """Compute per-rank ``(partitions, micro_batch_indices, num_microbatches, global_batch_sizes)``;
+    ``global_batch_size`` counts rollouts, not training samples."""
     dp_size = train_parallel_config["dp_size"]
     cp_size = train_parallel_config["cp_size"]
     vpp_size = train_parallel_config["vpp_size"] or 1
@@ -107,14 +83,8 @@ def build_dp_schedule(
         assert args.max_tokens_per_gpu is not None
         max_per_bin = args.max_tokens_per_gpu * cp_size
 
-    # mbs count per step must be divisible by (dp_size * mb_group_for_vpp) so
-    # every rank ends up with the same num_mbs and (for VPP) the per-rank mbs
-    # count is a multiple of mb_group.
     align_to = dp_size * (mb_group if vpp_size > 1 else 1)
 
-    # Group samples by rollout id (preserve first-occurrence order). All
-    # samples from one rollout stay in a single step so the per-rollout loss
-    # reducer is well-defined.
     rollout_id_to_samples: dict[int, list[int]] = {}
     for sample_pos, rid in enumerate(rollout_indices):
         rollout_id_to_samples.setdefault(rid, []).append(sample_pos)
@@ -141,8 +111,6 @@ def build_dp_schedule(
             f"each step needs at least one sample per rank."
         )
 
-        # 1. Pack samples in this step into mbs with one global pass.
-        # ``step_mbs`` indices are LOCAL into ``sample_indices``.
         step_mbs = _pack_step_into_mbs(
             step_lengths,
             use_dynamic_batch_size=args.use_dynamic_batch_size,
@@ -150,7 +118,6 @@ def build_dp_schedule(
             micro_batch_size=getattr(args, "micro_batch_size", None),
         )
 
-        # 2. Align mbs count to a multiple of ``align_to``.
         target_K = max(((len(step_mbs) + align_to - 1) // align_to) * align_to, align_to)
         if target_K != len(step_mbs):
             if args.use_dynamic_batch_size:
@@ -174,20 +141,15 @@ def build_dp_schedule(
         num_mbs_per_rank = K // dp_size
         num_microbatches.append(num_mbs_per_rank)
 
-        # 3. Distribute mbs across ranks: KK on mbs token sums when balance_data is on,
-        # otherwise a strided round-robin. Both produce ``num_mbs_per_rank`` mbs per
-        # rank (equal_size=True is what KK needs for PP to stay synced).
         if args.balance_data:
             mbs_token_sums = [sum(step_lengths[i] for i in bin_) for bin_ in step_mbs]
             rank_mbs_idx = get_seqlen_balanced_partitions(mbs_token_sums, dp_size, equal_size=True)
         else:
             rank_mbs_idx = [list(range(r, K, dp_size)) for r in range(dp_size)]
 
-        # 4. Build per-rank partitions (global sample indices) and micro_batch_indices
-        # (local indices into partitions[r]).
         for r in range(dp_size):
             for mbs_idx in rank_mbs_idx[r]:
-                mbs_locals = step_mbs[mbs_idx]  # local indices into sample_indices
+                mbs_locals = step_mbs[mbs_idx]
                 local_start = len(partitions[r])
                 partitions[r].extend(sample_indices[i] for i in mbs_locals)
                 micro_batch_indices[r].append(list(range(local_start, local_start + len(mbs_locals))))

--- a/miles/utils/dp_schedule.py
+++ b/miles/utils/dp_schedule.py
@@ -1,4 +1,34 @@
-"""Per-rollout DP/microbatch scheduling, computed on the rollout side."""
+"""Per-rollout DP/microbatch scheduling, computed on the rollout side.
+
+Pure Python (no ray/sglang imports) so it is unit-testable under CPU-only CI.
+
+The scheduling philosophy is **pack first, distribute second**:
+
+  1. Group samples by rollout id (``rollout_indices[i]``, defaulting to
+     ``samples[i].index``) and split rollouts into steps of
+     ``global_batch_size`` rollouts each. In the common case one rollout
+     emits one training sample so this is the same as a contiguous chunk;
+     under compact / subagent one rollout may emit multiple training
+     samples, in which case all of those samples stay in the same step.
+  2. For each step, pack its samples into ``K`` micro-batches with a
+     single first-fit pass (dynamic batch) or fixed-size chunking
+     (static batch).
+  3. Adjust ``K`` to a multiple of ``dp_size * (mb_group if vpp>1 else 1)``
+     by splitting the largest multi-sample bins (dynamic only).
+  4. Distribute the ``K`` mbs across ``dp_size`` ranks, ``K / dp_size``
+     each, with either a strided round-robin or a Karmarkar-Karp pass on
+     mbs token sums.
+
+Invariants (asserted by tests/fast/utils/test_dp_schedule.py):
+  - every DP rank runs the **same** ``num_microbatches`` per training step
+    (required for PP sync);
+  - every mbs (dynamic path) holds <= ``max_tokens_per_gpu * cp_size``
+    tokens, except an oversized sample, which lands alone in its own mbs;
+  - the union of per-rank sample indices equals the set of samples kept
+    after trimming trailing rollouts (every kept sample placed exactly once);
+  - flattening ``micro_batch_indices`` for a rank yields
+    ``range(num_samples_rank)``.
+"""
 
 from __future__ import annotations
 
@@ -10,10 +40,27 @@ SCHEDULE_CONFIG_KEYS = ("dp_size", "cp_size", "vpp_size", "microbatch_group_size
 
 
 def has_full_schedule_config(train_parallel_config: dict | None) -> bool:
-    """True when the backend advertised every field build_dp_schedule needs."""
+    """True when the backend advertised every field build_dp_schedule needs
+    (fsdp/torchtitan report only ``dp_size``; indep_dp reports ``{}``)."""
     if not train_parallel_config:
         return False
     return all(key in train_parallel_config for key in SCHEDULE_CONFIG_KEYS)
+
+
+def _pack_step_into_mbs(
+    step_lengths: list[int],
+    *,
+    use_dynamic_batch_size: bool,
+    max_per_bin: int | None,
+    micro_batch_size: int | None,
+) -> list[list[int]]:
+    """Group a step's samples into mbs. Returns ``mbs[k]`` = local indices into ``step_lengths``."""
+    if use_dynamic_batch_size:
+        assert max_per_bin is not None
+        return first_fit_pack(step_lengths, max_per_bin)
+    assert micro_batch_size is not None
+    n = len(step_lengths)
+    return [list(range(i, min(i + micro_batch_size, n))) for i in range(0, n, micro_batch_size)]
 
 
 def build_dp_schedule(
@@ -22,22 +69,62 @@ def build_dp_schedule(
     total_lengths: list[int],
     *,
     global_batch_size: int,
+    rollout_indices: list[int],
 ) -> tuple[list[list[int]], list[list[list[int]]], list[int], list[int]]:
-    """Compute per-rank ``(partitions, micro_batch_indices, num_microbatches, global_batch_sizes)``."""
+    """Compute the per-rank DP partition and micro-batch schedule.
+
+    See module docstring for the pack-first-distribute-second strategy.
+
+    Args:
+        args: Namespace with ``micro_batch_size``, ``use_dynamic_batch_size``,
+            ``max_tokens_per_gpu``, ``balance_data``.
+        train_parallel_config: ``{"dp_size", "cp_size", "vpp_size",
+            "microbatch_group_size_per_vp_stage"}``.
+        total_lengths: token count per sample, indexed globally.
+        global_batch_size: number of rollouts (NOT training samples) per
+            training step. Number of training steps =
+            ``num_rollouts // global_batch_size``; trailing rollouts whose
+            samples don't fit are dropped.
+        rollout_indices: rollout id for each sample. Samples sharing the same
+            id are kept together in one step.
+
+    Returns:
+        ``(partitions, micro_batch_indices, num_microbatches, global_batch_sizes)``:
+          - ``partitions[r]`` — global sample indices of rank r, in mbs order;
+          - ``micro_batch_indices[r][k]`` — local indices into ``partitions[r]``
+            for the k-th mbs (flat across steps);
+          - ``num_microbatches[s]`` — mbs count for step s, same on every rank;
+          - ``global_batch_sizes[s]`` — rollout count for step s (constant
+            ``global_batch_size`` for every step).
+    """
     dp_size = train_parallel_config["dp_size"]
     cp_size = train_parallel_config["cp_size"]
     vpp_size = train_parallel_config["vpp_size"] or 1
     mb_group = train_parallel_config["microbatch_group_size_per_vp_stage"]
 
-    assert len(total_lengths) % global_batch_size == 0, (
-        f"num_samples ({len(total_lengths)}) is not a multiple of global_batch_size "
-        f"({global_batch_size}); trim upstream before scheduling."
-    )
-    num_steps = len(total_lengths) // global_batch_size
-
+    max_per_bin = None
     if args.use_dynamic_batch_size:
         assert args.max_tokens_per_gpu is not None
         max_per_bin = args.max_tokens_per_gpu * cp_size
+
+    # mbs count per step must be divisible by (dp_size * mb_group_for_vpp) so
+    # every rank ends up with the same num_mbs and (for VPP) the per-rank mbs
+    # count is a multiple of mb_group.
+    align_to = dp_size * (mb_group if vpp_size > 1 else 1)
+
+    # Group samples by rollout id (preserve first-occurrence order). All
+    # samples from one rollout stay in a single step so the per-rollout loss
+    # reducer is well-defined.
+    rollout_id_to_samples: dict[int, list[int]] = {}
+    for sample_pos, rid in enumerate(rollout_indices):
+        rollout_id_to_samples.setdefault(rid, []).append(sample_pos)
+    rollout_ids = list(rollout_id_to_samples.keys())
+
+    num_steps = len(rollout_ids) // global_batch_size
+    assert num_steps >= 1, (
+        f"num_rollouts ({len(rollout_ids)}) < global_batch_size ({global_batch_size}); "
+        f"need at least one rollout per step."
+    )
 
     partitions: list[list[int]] = [[] for _ in range(dp_size)]
     micro_batch_indices: list[list[list[int]]] = [[] for _ in range(dp_size)]
@@ -45,39 +132,64 @@ def build_dp_schedule(
     global_batch_sizes: list[int] = []
 
     for step_i in range(num_steps):
-        step_start = step_i * global_batch_size
-        step_lengths = total_lengths[step_start : step_start + global_batch_size]
-        global_batch_sizes.append(len(step_lengths))
+        step_rollouts = rollout_ids[step_i * global_batch_size : (step_i + 1) * global_batch_size]
+        sample_indices = [pos for rid in step_rollouts for pos in rollout_id_to_samples[rid]]
+        step_lengths = [total_lengths[i] for i in sample_indices]
+        global_batch_sizes.append(global_batch_size)
+        assert len(sample_indices) >= dp_size, (
+            f"step {step_i}: {len(sample_indices)} samples < dp_size {dp_size}; "
+            f"each step needs at least one sample per rank."
+        )
 
-        if args.balance_data:
-            rank_parts = get_seqlen_balanced_partitions(step_lengths, dp_size, equal_size=True)
-        else:
-            rank_parts = [list(range(r, global_batch_size, dp_size)) for r in range(dp_size)]
+        # 1. Pack samples in this step into mbs with one global pass.
+        # ``step_mbs`` indices are LOCAL into ``sample_indices``.
+        step_mbs = _pack_step_into_mbs(
+            step_lengths,
+            use_dynamic_batch_size=args.use_dynamic_batch_size,
+            max_per_bin=max_per_bin,
+            micro_batch_size=getattr(args, "micro_batch_size", None),
+        )
 
-        if not args.use_dynamic_batch_size:
-            mbs = args.micro_batch_size
-            n = len(rank_parts[0])  # gbs / dp, same for every rank
-            assert n % mbs == 0, (
-                f"per-rank batch ({n} = global_batch_size {global_batch_size} / dp_size {dp_size}) "
-                f"is not a multiple of micro_batch_size ({mbs})"
-            )
-            rank_mbs = [[list(range(i, i + mbs)) for i in range(0, n, mbs)] for _ in range(dp_size)]
-            num_mbs_per_rank = n // mbs
-        else:
-            rank_lens = [[step_lengths[i] for i in rank_parts[r]] for r in range(dp_size)]
-            rank_mbs = [first_fit_pack(rank_lens[r], max_per_bin) for r in range(dp_size)]
-            num_mbs_per_rank = max(len(b) for b in rank_mbs)
-            if vpp_size > 1:
-                num_mbs_per_rank = max(num_mbs_per_rank // mb_group * mb_group, 1)
-            for r in range(dp_size):
-                expand_bins_by_splitting(rank_mbs[r], num_mbs_per_rank, rank_lens[r])
+        # 2. Align mbs count to a multiple of ``align_to``.
+        target_K = max(((len(step_mbs) + align_to - 1) // align_to) * align_to, align_to)
+        if target_K != len(step_mbs):
+            if args.use_dynamic_batch_size:
+                expand_bins_by_splitting(step_mbs, target_K, step_lengths)
+                assert len(step_mbs) == target_K, (
+                    f"dynamic path: could only produce {len(step_mbs)} mbs after maximal splitting; "
+                    f"need {target_K}. step {step_i} has {len(sample_indices)} samples, below the "
+                    f"alignment threshold ({align_to})."
+                )
+            else:
+                raise AssertionError(
+                    f"static path: num_mbs ({len(step_mbs)}) is not a multiple of "
+                    f"dp_size * mb_group ({align_to}); got "
+                    f"step_size={len(sample_indices)}, micro_batch_size={args.micro_batch_size}, "
+                    f"dp_size={dp_size}, mb_group={mb_group if vpp_size > 1 else 1}. "
+                    f"Splitting static mbs would break the fixed-size invariant; adjust the config "
+                    f"so step_size % (dp_size * micro_batch_size * mb_group) == 0."
+                )
 
+        K = len(step_mbs)
+        num_mbs_per_rank = K // dp_size
         num_microbatches.append(num_mbs_per_rank)
 
+        # 3. Distribute mbs across ranks: KK on mbs token sums when balance_data is on,
+        # otherwise a strided round-robin. Both produce ``num_mbs_per_rank`` mbs per
+        # rank (equal_size=True is what KK needs for PP to stay synced).
+        if args.balance_data:
+            mbs_token_sums = [sum(step_lengths[i] for i in bin_) for bin_ in step_mbs]
+            rank_mbs_idx = get_seqlen_balanced_partitions(mbs_token_sums, dp_size, equal_size=True)
+        else:
+            rank_mbs_idx = [list(range(r, K, dp_size)) for r in range(dp_size)]
+
+        # 4. Build per-rank partitions (global sample indices) and micro_batch_indices
+        # (local indices into partitions[r]).
         for r in range(dp_size):
-            for mbs_local in rank_mbs[r]:
+            for mbs_idx in rank_mbs_idx[r]:
+                mbs_locals = step_mbs[mbs_idx]  # local indices into sample_indices
                 local_start = len(partitions[r])
-                partitions[r].extend(step_start + rank_parts[r][i] for i in mbs_local)
-                micro_batch_indices[r].append(list(range(local_start, local_start + len(mbs_local))))
+                partitions[r].extend(sample_indices[i] for i in mbs_locals)
+                micro_batch_indices[r].append(list(range(local_start, local_start + len(mbs_locals))))
 
     return partitions, micro_batch_indices, num_microbatches, global_batch_sizes

--- a/tests/fast/ray/rollout/test_train_data_conversion.py
+++ b/tests/fast/ray/rollout/test_train_data_conversion.py
@@ -583,7 +583,7 @@ FULL_SCHEDULE_CONFIG = {
 }
 
 
-def _make_split_data(n: int, *, lengths: list[int] | None = None) -> dict:
+def _make_split_data(n: int, *, lengths: list[int] | None = None, rollout_ids: list[int] | None = None) -> dict:
     lengths = lengths or [2] * n
     assert len(lengths) == n
     return {
@@ -593,6 +593,7 @@ def _make_split_data(n: int, *, lengths: list[int] | None = None) -> dict:
         "truncated": [0] * n,
         "loss_masks": [[1] * length for length in lengths],
         "sample_indices": list(range(n)),
+        "rollout_ids": rollout_ids if rollout_ids is not None else list(range(n)),
     }
 
 
@@ -618,9 +619,14 @@ class TestCanScheduleOnRolloutSide:
         data["multimodal_train_inputs"] = [None] * 8
         assert not can_schedule_on_rollout_side(args, data, FULL_SCHEDULE_CONFIG)
 
-    def test_rejects_indivisible_sample_count(self):
+    def test_rejects_fewer_rollouts_than_gbs(self):
         args = make_args(balance_data=False, micro_batch_size=1, multi_lora=False)  # global_batch_size=8
-        assert not can_schedule_on_rollout_side(args, _make_split_data(10), FULL_SCHEDULE_CONFIG)
+        assert not can_schedule_on_rollout_side(args, _make_split_data(6), FULL_SCHEDULE_CONFIG)
+
+    def test_accepts_trailing_partial_step(self):
+        """Extra rollouts beyond a full step are fine — the schedule drops them."""
+        args = make_args(balance_data=False, micro_batch_size=1, multi_lora=False)  # global_batch_size=8
+        assert can_schedule_on_rollout_side(args, _make_split_data(10), FULL_SCHEDULE_CONFIG)
 
     def test_dynamic_gbs_overrides_args_gbs(self):
         args = make_args(balance_data=False, micro_batch_size=1, multi_lora=False)  # global_batch_size=8
@@ -630,24 +636,39 @@ class TestCanScheduleOnRolloutSide:
 
 
 class TestSplitTrainDataByDpScheduled:
-    def test_static_shards_match_legacy_split_plus_schedule(self):
-        """Static path: shards must be identical to the legacy split, plus the two
-        schedule keys, and the schedule must tile each shard's rows exactly."""
+    def test_static_shards_cover_all_samples(self):
+        """Static path: every sample lands in exactly one shard row, the schedule
+        tiles each shard's rows exactly, and shard rows match their partition."""
         args = make_args(balance_data=False, micro_batch_size=2, use_dynamic_batch_size=False)
         data = _make_split_data(8)
-        legacy = split_train_data_by_dp_raw(args, dict(data), dp_size=2)
         scheduled = split_train_data_by_dp_scheduled_raw(args, dict(data), train_parallel_config=FULL_SCHEDULE_CONFIG)
 
         assert len(scheduled) == 2
-        for rank, (old, new) in enumerate(zip(legacy, scheduled, strict=True)):
-            assert list(new["partition"]) == list(old["partition"]), f"rank {rank} partition changed"
-            for key in ("tokens", "response_lengths", "loss_masks", "sample_indices"):
-                assert new[key] == old[key], f"rank {rank} {key} changed"
-            # global_batch_size=8, dp=2, mbs=2 -> 2 mbs per rank, 1 step
+        seen = []
+        for new in scheduled:
+            partition = list(new["partition"])
+            seen.extend(partition)
+            assert new["tokens"] == [data["tokens"][j] for j in partition]
+            # global_batch_size=8, dp=2, mbs=2 -> 4 mbs total, 2 per rank, 1 step
             assert new["num_microbatches"] == [2]
             assert new["global_batch_sizes"] == [8]
             flat = [i for mbs in new["micro_batch_indices"] for i in mbs]
             assert flat == list(range(len(new["tokens"])))
+        assert sorted(seen) == list(range(8))
+
+    def test_compact_rollout_gbs_counts_rollouts_not_samples(self):
+        """gbs counts rollouts: 4 rollouts over 6 samples with gbs=2 -> 2 steps,
+        and every sample is still covered exactly once across shards."""
+        args = make_args(balance_data=False, micro_batch_size=1, use_dynamic_batch_size=True, max_tokens_per_gpu=8)
+        rollout_ids = [0, 1, 1, 1, 2, 3]  # rollout 1 emits 3 samples
+        data = _make_split_data(6, rollout_ids=rollout_ids)
+        data["dynamic_global_batch_size"] = 2
+        shards = split_train_data_by_dp_scheduled_raw(args, dict(data), train_parallel_config=FULL_SCHEDULE_CONFIG)
+
+        assert shards[0]["global_batch_sizes"] == [2, 2]
+        assert len(shards[0]["num_microbatches"]) == 2
+        seen = sorted(j for shard in shards for j in shard["partition"])
+        assert seen == list(range(6))
 
     def test_dynamic_schedule_respects_token_cap(self):
         args = make_args(

--- a/tests/fast/utils/test_dp_schedule.py
+++ b/tests/fast/utils/test_dp_schedule.py
@@ -1,10 +1,8 @@
 """CPU unit tests for miles.utils.dp_schedule.build_dp_schedule.
 
 The tests assert the invariants documented at the top of dp_schedule.py against
-a range of static / dynamic / VPP / oversize / balance scenarios, plus an
-equivalence check of ``num_microbatches`` against the legacy train-side
-computation (``get_minimum_num_micro_batch_size`` + DP-wide MAX) that this
-schedule replaces.
+static / dynamic / VPP / oversize / balance / compact-rollout / trailing-trim
+scenarios.
 
 Trim, dynamic-gbs resolution, and per-rank rollout_data packaging all live in
 ``train_data_conversion.split_train_data_by_dp_scheduled``; these tests just
@@ -18,7 +16,6 @@ from types import SimpleNamespace
 
 import pytest
 
-from miles.utils.data import get_minimum_num_micro_batch_size
 from miles.utils.dp_schedule import build_dp_schedule, has_full_schedule_config
 
 
@@ -46,30 +43,38 @@ def make_tp(dp_size=1, cp_size=1, vpp_size=1, microbatch_group_size_per_vp_stage
     }
 
 
-def assert_invariants(partitions, micro_batch_indices, num_microbatches, *, dp_size, total_lengths, max_per_bin=None):
-    """Check the invariants documented at the top of dp_schedule.py."""
-    expected_per_rank = len(total_lengths) // dp_size
+def assert_invariants(
+    partitions,
+    micro_batch_indices,
+    num_microbatches,
+    *,
+    dp_size,
+    expected_global_sample_indices,
+    total_lengths,
+    max_per_bin=None,
+):
+    """Check the invariants documented at the top of dp_schedule.py.
+
+    ``expected_global_sample_indices`` is the set of global sample indices
+    that should end up covered (after trim). Trailing rollouts that don't
+    fit are excluded.
+    """
     seen_global: set[int] = set()
     for r in range(dp_size):
         partition = partitions[r]
         mbi = micro_batch_indices[r]
 
-        # Same sample count per rank.
-        assert len(partition) == expected_per_rank, f"rank {r}: {len(partition)} samples, want {expected_per_rank}"
-
-        # Same num_mbs per rank (PP sync); num_microbatches is shared, so each rank's
-        # flat mbs count must match sum(num_microbatches).
+        # Same num_mbs per rank (PP sync).
         assert len(mbi) == sum(num_microbatches), f"rank {r}: mbs count mismatch"
 
-        # Flattened micro_batch_indices == range(len(partition)) (each sample covered
-        # exactly once, by exactly one mbs).
+        # Flattened micro_batch_indices == range(len(partition)).
         flat = [i for mbs in mbi for i in mbs]
         assert flat == list(range(len(partition))), f"rank {r}: micro_batch_indices don't tile [0, n)"
 
-        # Disjoint partitions whose union covers every sample.
+        # Disjoint partitions whose union covers every kept sample.
         assert seen_global.isdisjoint(partition), f"rank {r}: overlap with other ranks"
         seen_global.update(partition)
-    assert seen_global == set(range(len(total_lengths))), "some samples not assigned to any rank"
+    assert seen_global == set(expected_global_sample_indices), "covered sample set mismatch"
 
     if max_per_bin is None:
         return
@@ -84,87 +89,100 @@ def assert_invariants(partitions, micro_batch_indices, num_microbatches, *, dp_s
 
 
 def test_static_stride_single_step():
-    """Static + strided DP split, single step."""
+    """Static + strided DP split, single step (1 rollout = 1 sample)."""
     total_lengths = [10] * 16
+    rollout_indices = list(range(16))
     args = make_args(micro_batch_size=2)
     tp = make_tp(dp_size=4)
 
-    partitions, mbi, nmb, gbs_steps = build_dp_schedule(args, tp, total_lengths, global_batch_size=16)
+    partitions, mbi, nmb, gbs_per_step = build_dp_schedule(
+        args, tp, total_lengths, global_batch_size=16, rollout_indices=rollout_indices
+    )
 
     assert nmb == [2]
-    assert gbs_steps == [16]
-    assert_invariants(partitions, mbi, nmb, dp_size=4, total_lengths=total_lengths)
-
-
-def test_static_stride_matches_legacy_partition_order():
-    """Static + strided must produce exactly the legacy strided row order —
-    rank r gets rows [r, r+dp, r+2*dp, ...] in that order, contiguously chunked."""
-    total_lengths = list(range(100, 116))
-    args = make_args(micro_batch_size=2)
-    tp = make_tp(dp_size=4)
-
-    partitions, _, _, _ = build_dp_schedule(args, tp, total_lengths, global_batch_size=16)
-
-    for r in range(4):
-        assert partitions[r] == list(range(r, 16, 4)), f"rank {r} partition deviates from legacy strided order"
+    assert gbs_per_step == [16]
+    assert_invariants(
+        partitions,
+        mbi,
+        nmb,
+        dp_size=4,
+        expected_global_sample_indices=range(16),
+        total_lengths=total_lengths,
+    )
 
 
 def test_static_balance_multi_step():
-    """Static + balance_data + 2 training steps. Each rank must get gbs/dp per step."""
-    total_lengths = [1, 2, 3, 4, 5, 6, 7, 8, 8, 7, 6, 5, 4, 3, 2, 1]  # 2 steps of 8
+    """Static + balance_data + 2 training steps."""
+    total_lengths = [1, 2, 3, 4, 5, 6, 7, 8, 8, 7, 6, 5, 4, 3, 2, 1]
+    rollout_indices = list(range(16))
     args = make_args(micro_batch_size=2, balance_data=True)
     tp = make_tp(dp_size=2)
 
-    partitions, mbi, nmb, gbs_steps = build_dp_schedule(args, tp, total_lengths, global_batch_size=8)
-    assert gbs_steps == [8] * len(nmb)
+    partitions, mbi, nmb, gbs_per_step = build_dp_schedule(
+        args, tp, total_lengths, global_batch_size=8, rollout_indices=rollout_indices
+    )
 
     assert nmb == [2, 2]
-    assert_invariants(partitions, mbi, nmb, dp_size=2, total_lengths=total_lengths)
+    assert gbs_per_step == [8, 8]
+    assert_invariants(
+        partitions,
+        mbi,
+        nmb,
+        dp_size=2,
+        expected_global_sample_indices=range(16),
+        total_lengths=total_lengths,
+    )
 
 
 def test_dynamic_uniform():
     """Dynamic mbs on uniform-length samples."""
     total_lengths = [5] * 8
+    rollout_indices = list(range(8))
     args = make_args(use_dynamic_batch_size=True, max_tokens_per_gpu=10)
     tp = make_tp(dp_size=2)
 
-    partitions, mbi, nmb, gbs_steps = build_dp_schedule(args, tp, total_lengths, global_batch_size=8)
-    assert gbs_steps == [8] * len(nmb)
+    partitions, mbi, nmb, gbs_per_step = build_dp_schedule(
+        args, tp, total_lengths, global_batch_size=8, rollout_indices=rollout_indices
+    )
 
-    assert_invariants(partitions, mbi, nmb, dp_size=2, total_lengths=total_lengths, max_per_bin=10)
-
-
-def test_dynamic_skewed_lengths():
-    """Skewed lengths (the case where K-K used to over-pack a single bin)."""
-    total_lengths = [9, 9, 9, 9, 1, 1, 1, 1]
-    args = make_args(use_dynamic_batch_size=True, max_tokens_per_gpu=10)
-    tp = make_tp(dp_size=2)
-
-    partitions, mbi, nmb, gbs_steps = build_dp_schedule(args, tp, total_lengths, global_batch_size=8)
-    assert gbs_steps == [8] * len(nmb)
-
-    assert_invariants(partitions, mbi, nmb, dp_size=2, total_lengths=total_lengths, max_per_bin=10)
+    assert gbs_per_step == [8]
+    assert_invariants(
+        partitions,
+        mbi,
+        nmb,
+        dp_size=2,
+        expected_global_sample_indices=range(8),
+        total_lengths=total_lengths,
+        max_per_bin=10,
+    )
 
 
 def test_dynamic_oversized_sample_lands_alone():
-    """A single sample exceeding max_per_bin must end up alone in its mbs (with no
-    other samples crammed in)."""
-    total_lengths = [15, 3, 3, 3, 3, 3, 3, 3]  # 15 > C=10
+    """A sample larger than max_per_bin must end up alone in its mbs."""
+    total_lengths = [15, 3, 3, 3, 3, 3, 3, 3]
+    rollout_indices = list(range(8))
     args = make_args(use_dynamic_batch_size=True, max_tokens_per_gpu=10)
     tp = make_tp(dp_size=2)
 
-    partitions, mbi, nmb, gbs_steps = build_dp_schedule(args, tp, total_lengths, global_batch_size=8)
-    assert gbs_steps == [8] * len(nmb)
+    partitions, mbi, nmb, gbs_per_step = build_dp_schedule(
+        args, tp, total_lengths, global_batch_size=8, rollout_indices=rollout_indices
+    )
 
-    assert_invariants(partitions, mbi, nmb, dp_size=2, total_lengths=total_lengths, max_per_bin=10)
-    # Find the rank holding the oversized sample and verify it lives alone in some mbs.
+    assert_invariants(
+        partitions,
+        mbi,
+        nmb,
+        dp_size=2,
+        expected_global_sample_indices=range(8),
+        total_lengths=total_lengths,
+        max_per_bin=10,
+    )
     oversize_idx = total_lengths.index(15)
     found = False
     for r in range(2):
-        partition = partitions[r]
-        if oversize_idx not in partition:
+        if oversize_idx not in partitions[r]:
             continue
-        local = partition.index(oversize_idx)
+        local = partitions[r].index(oversize_idx)
         for mbs in mbi[r]:
             if local in mbs:
                 assert mbs == [local], f"oversized sample shares an mbs: {mbs}"
@@ -174,93 +192,140 @@ def test_dynamic_oversized_sample_lands_alone():
 
 def test_dynamic_with_vpp_rounds_to_mb_group():
     """num_microbatches per rank should be a multiple of mb_group when vpp_size > 1."""
-    total_lengths = [4] * 32  # 2 steps of 16; per step, ~8 bins of 8 needed at C=8
+    total_lengths = [4] * 32
+    rollout_indices = list(range(32))
     args = make_args(use_dynamic_batch_size=True, max_tokens_per_gpu=8)
     tp = make_tp(dp_size=2, vpp_size=2, microbatch_group_size_per_vp_stage=2)
 
-    partitions, mbi, nmb, gbs_steps = build_dp_schedule(args, tp, total_lengths, global_batch_size=16)
-    assert gbs_steps == [16] * len(nmb)
+    partitions, mbi, nmb, gbs_per_step = build_dp_schedule(
+        args, tp, total_lengths, global_batch_size=16, rollout_indices=rollout_indices
+    )
 
     for n in nmb:
         assert n % 2 == 0, f"num_microbatches {n} is not a multiple of mb_group=2"
-    assert_invariants(partitions, mbi, nmb, dp_size=2, total_lengths=total_lengths, max_per_bin=8)
+    assert_invariants(
+        partitions,
+        mbi,
+        nmb,
+        dp_size=2,
+        expected_global_sample_indices=range(32),
+        total_lengths=total_lengths,
+        max_per_bin=8,
+    )
 
 
-def test_static_indivisible_per_rank_batch_asserts():
-    """gbs/dp not a multiple of micro_batch_size must fail loudly, not mis-schedule."""
+def test_rollout_grouping_keeps_samples_together():
+    """compact / subagent simulation: rollout 0 emits 3 samples, rollout 1 emits 2,
+    rollout 2 emits 4. Splitter keeps every rollout's samples in a single step."""
+    rollout_indices = [0, 0, 0, 1, 1, 2, 2, 2, 2]
+    total_lengths = [3] * 9
+    args = make_args(use_dynamic_batch_size=True, max_tokens_per_gpu=12)
+    tp = make_tp(dp_size=1)
+
+    partitions, mbi, nmb, gbs_per_step = build_dp_schedule(
+        args, tp, total_lengths, global_batch_size=1, rollout_indices=rollout_indices
+    )
+
+    # 3 rollouts / 1 per step -> 3 steps, gbs constant.
+    assert gbs_per_step == [1, 1, 1]
+    # For each step, collect the samples (global indices) that landed in that step's mbs
+    # on rank 0, then verify they exactly equal the rollout's sample positions.
+    expected_per_step = [[0, 1, 2], [3, 4], [5, 6, 7, 8]]
+    rank0_partition = partitions[0]
+    mbs_cursor = 0
+    for step_i, n_mbs in enumerate(nmb):
+        step_locals = sorted(j for mbs in mbi[0][mbs_cursor : mbs_cursor + n_mbs] for j in mbs)
+        step_globals = [rank0_partition[j] for j in step_locals]
+        assert (
+            sorted(step_globals) == expected_per_step[step_i]
+        ), f"step {step_i} samples = {step_globals}, expected {expected_per_step[step_i]}"
+        mbs_cursor += n_mbs
+    assert_invariants(
+        partitions,
+        mbi,
+        nmb,
+        dp_size=1,
+        expected_global_sample_indices=range(9),
+        total_lengths=total_lengths,
+        max_per_bin=12,
+    )
+
+
+def test_trims_trailing_rollouts_that_dont_fill_a_step():
+    """5 rollouts, gbs=2 -> 2 steps x 2 rollouts; trailing rollout 4 (sample positions 6, 7)
+    is dropped."""
+    rollout_indices = [0, 0, 1, 2, 2, 3, 4, 4]
+    total_lengths = [3] * 8
+    args = make_args(use_dynamic_batch_size=True, max_tokens_per_gpu=12)
+    tp = make_tp(dp_size=1)
+
+    partitions, mbi, nmb, gbs_per_step = build_dp_schedule(
+        args, tp, total_lengths, global_batch_size=2, rollout_indices=rollout_indices
+    )
+
+    assert gbs_per_step == [2, 2]
+    # Sample positions 6 and 7 belong to the trimmed rollout 4 and must be absent.
+    assert_invariants(
+        partitions,
+        mbi,
+        nmb,
+        dp_size=1,
+        expected_global_sample_indices=range(6),
+        total_lengths=total_lengths,
+        max_per_bin=12,
+    )
+
+
+def test_rejects_when_fewer_rollouts_than_gbs():
+    """gbs=4 with only 3 distinct rollouts -> cannot form one step."""
+    args = make_args(use_dynamic_batch_size=True, max_tokens_per_gpu=12)
+    tp = make_tp(dp_size=1)
+    with pytest.raises(AssertionError, match="num_rollouts"):
+        build_dp_schedule(args, tp, [3] * 6, global_batch_size=4, rollout_indices=[0, 0, 1, 1, 2, 2])
+
+
+def test_static_misaligned_mbs_count_asserts():
+    """Static path: mbs count not a multiple of dp_size * mb_group must fail loudly."""
     args = make_args(micro_batch_size=3)
     tp = make_tp(dp_size=2)
-    with pytest.raises(AssertionError, match="micro_batch_size"):
-        build_dp_schedule(args, tp, [10] * 8, global_batch_size=8)
-
-
-def test_untrimmed_input_asserts():
-    """num_samples not a multiple of global_batch_size must fail loudly."""
-    args = make_args(micro_batch_size=1)
-    tp = make_tp(dp_size=2)
-    with pytest.raises(AssertionError, match="multiple of global_batch_size"):
-        build_dp_schedule(args, tp, [10] * 10, global_batch_size=8)
-
-
-def test_dynamic_num_microbatches_matches_legacy_train_side():
-    """The PP-sync-critical value: for the same strided partition, the rollout-side
-    schedule must produce exactly the num_microbatches the legacy train-side path
-    computed (per-rank ``get_minimum_num_micro_batch_size``, then DP-wide MAX)."""
-    rng = random.Random(42)
-    dp_size, cp_size = 4, 2
-    max_tokens_per_gpu = 512
-    global_batch_size = 32
-
-    for _ in range(50):
-        num_steps = rng.randint(1, 3)
-        total_lengths = [rng.randint(16, 1200) for _ in range(global_batch_size * num_steps)]
-
-        args = make_args(use_dynamic_batch_size=True, max_tokens_per_gpu=max_tokens_per_gpu)
-        tp = make_tp(dp_size=dp_size, cp_size=cp_size)
-        _, _, nmb, _ = build_dp_schedule(args, tp, total_lengths, global_batch_size=global_batch_size)
-
-        # Legacy: each rank r holds the strided rows of each step, computes its own
-        # first-fit bin count over its local per-step slice, and the DP group takes MAX.
-        num_local_gbs = global_batch_size // dp_size
-        legacy_nmb = []
-        for step_i in range(num_steps):
-            step = total_lengths[step_i * global_batch_size : (step_i + 1) * global_batch_size]
-            per_rank = []
-            for r in range(dp_size):
-                local = [step[i] for i in range(r, global_batch_size, dp_size)]
-                assert len(local) == num_local_gbs
-                per_rank.append(get_minimum_num_micro_batch_size(local, max_tokens_per_gpu * cp_size))
-            legacy_nmb.append(max(per_rank))
-
-        assert nmb == legacy_nmb, f"num_microbatches diverged from legacy: {nmb} vs {legacy_nmb}"
+    with pytest.raises(AssertionError, match="static path"):
+        build_dp_schedule(args, tp, [10] * 8, global_batch_size=8, rollout_indices=list(range(8)))
 
 
 def test_randomized_invariants_dynamic():
-    """Randomized sweep of the documented invariants on the dynamic path."""
+    """Randomized sweep of the documented invariants on the dynamic path,
+    including random compact rollout groupings."""
     rng = random.Random(7)
     for _ in range(30):
         dp_size = rng.choice([1, 2, 4])
         gbs = dp_size * rng.choice([2, 4, 8])
-        num_steps = rng.randint(1, 2)
-        total_lengths = [rng.randint(1, 40) for _ in range(gbs * num_steps)]
+        num_rollouts = gbs * rng.randint(1, 2) + rng.randint(0, 3)  # may leave a trailing partial step
+        rollout_indices = []
+        for rid in range(num_rollouts):
+            rollout_indices.extend([rid] * rng.randint(1, 3))
+        total_lengths = [rng.randint(1, 40) for _ in rollout_indices]
         max_tokens = rng.randint(20, 60)
         balance = rng.random() < 0.5
 
         args = make_args(use_dynamic_batch_size=True, max_tokens_per_gpu=max_tokens, balance_data=balance)
         tp = make_tp(dp_size=dp_size)
-        partitions, mbi, nmb, gbs_steps = build_dp_schedule(args, tp, total_lengths, global_batch_size=gbs)
+        partitions, mbi, nmb, gbs_per_step = build_dp_schedule(
+            args, tp, total_lengths, global_batch_size=gbs, rollout_indices=rollout_indices
+        )
 
-        assert gbs_steps == [gbs] * len(nmb)
-        assert_invariants(partitions, mbi, nmb, dp_size=dp_size, total_lengths=total_lengths, max_per_bin=max_tokens)
-
-
-def test_global_batch_sizes_one_per_step():
-    """4th return value: per-step sample count, constant in the equal-size case."""
-    args = make_args(micro_batch_size=2)
-    tp = make_tp(dp_size=2)
-    _, _, nmb, gbs_steps = build_dp_schedule(args, tp, [10] * 24, global_batch_size=8)
-    assert len(gbs_steps) == len(nmb) == 3
-    assert gbs_steps == [8, 8, 8]
+        num_steps = num_rollouts // gbs
+        assert gbs_per_step == [gbs] * num_steps
+        kept_rollouts = set(range(num_steps * gbs))
+        expected = [i for i, rid in enumerate(rollout_indices) if rid in kept_rollouts]
+        assert_invariants(
+            partitions,
+            mbi,
+            nmb,
+            dp_size=dp_size,
+            expected_global_sample_indices=expected,
+            total_lengths=total_lengths,
+            max_per_bin=max_tokens,
+        )
 
 
 def test_has_full_schedule_config():


### PR DESCRIPTION
## Summary

Stacked on #1931. Parts C+E of slime #1933 — the payoff PR of the series: the schedule packs first and distributes second, and `global_batch_size` counts ROLLOUTS instead of training samples, so compact / subagent rollouts (one execution -> N training samples) train correctly.

- `build_dp_schedule` rewritten pack-first-distribute-second: group samples by rollout id, split rollouts into steps of `global_batch_size` rollouts, pack each step's samples into `K` mbs with one global first-fit pass, align `K` to `dp_size * mb_group`, then distribute mbs across ranks (Karmarkar-Karp on mbs token sums under `balance_data`, strided otherwise). Compact rollouts stay whole within one training step; trailing rollouts that don't fill a step are dropped whole.
- Postprocess skips the sample-count trim when compact rollouts are detected (explicit `rollout_id`) — cutting mid-rollout would orphan siblings.
- `log_rollout_data` per-rollout-mean metrics count rollouts (`num_rollouts / dp`) for scheduled shards.
- New `miles/rollout/generate_hub/compact_split_example.py`: minimal compact generate fn (splits each response into two training samples sharing the parent's `rollout_id`) used for e2e validation of the whole pipeline.

Deviation from slime #1933: `--use-dynamic-global-batch-size` / `--disable-rollout-trim-samples` are kept — multi-LoRA and the legacy backend paths still use them; only the scheduled megatron path adopts the by-rollout semantics.

## Validation

- CPU: 97 tests green — schedule invariants incl. compact grouping (`test_rollout_grouping_keeps_samples_together`), whole-rollout trailing trim, randomized sweep with random rollout groupings, static misalignment assertion, plus the full PR2-PR4 batteries.
- GPU e2e on 8xH200 (`--ci-test`):

| run | topology | result |
|---|---|---|
| Qwen2.5-0.5B gsm8k short | dp8, dynamic batch, mooncake | ✅ succeeded |
| Qwen3-30B-A3B baseline | dp2 + cp2 + pp2 + ep2, metric gates | ✅ succeeded, `logprob_abs_diff` 0.0176 (branch series 0.0171-0.0178, same topology — no-op confirmed for 1 rollout = 1 sample) |
| Qwen3.5-35B-A3B (GDN) | cp2 | ✅ succeeded (see thread) |
| **compact gain demo** | 0.5B dp8 + `compact_split_example` | ✅ succeeded |

### Compact gain evidence

With the example splitter (each rollout -> 2 training samples), the schedule log reads:

```
Rollout-side DP schedule: num_samples=64, num_rollouts=32, global_batch_sizes=[32], num_microbatches=[1]
```

i.e. 32 rollout executions producing 64 training samples train as ONE step of 32 rollouts with per-rollout loss weighting. Before this series the same workload either failed validation or was treated as 64 independent samples: two training steps per rollout batch, siblings split across steps/trim boundaries, and every multi-sample rollout over-weighted in the loss proportionally to its sample count. Training over 3 rollout batches is stable (rewards 0.44-0.56, healthy logprob alignment).


### Stress test

Extreme variant (`generate_stress`, devbox-only): each rollout splits into `1 + (index % 8)` siblings (1-8, variable lengths), under **cp2** + dynamic batching with a small `--max-tokens-per-gpu 2048` so siblings scatter across micro-batches AND DP ranks, with `check_for_nan_in_loss_and_grad` on:

```
Rollout-side DP schedule: num_samples=288, num_rollouts=64, global_batch_sizes=[32, 32], num_microbatches=[3, 3]
```

64 rollout executions -> 288 training samples, still 2 steps of 32 rollouts; cross-mb/cross-rank per-rollout denominators reconstruct correctly (no NaN, stable rewards 0.52-0.62 over 3 rollout batches, job succeeded).
