### PR TITLE
feat(train): skip the redundant actor log-probs forward pass for strictly on-policy runs

### DIFF
--- a/miles/backends/megatron_utils/actor.py
+++ b/miles/backends/megatron_utils/actor.py
@@ -421,6 +421,19 @@ class MegatronTrainRayActor(TrainRayActor):
         # Create data iterator for log_probs and train.
         data_iterator, num_microbatches = get_data_iterator(self.args, self.model, rollout_data)
 
+        if self.args.skip_actor_logprobs_forward:
+            if len(num_microbatches) != 1:
+                raise ValueError(
+                    f"--skip-actor-logprobs-forward requires exactly one optimizer step per rollout, "
+                    f"got {len(num_microbatches)} steps"
+                )
+            enabled_replays = [m.name for m in all_replay_managers if m.enabled]
+            if enabled_replays:
+                raise ValueError(
+                    f"--skip-actor-logprobs-forward cannot record replay data for {enabled_replays} "
+                    f"without the actor log-probs forward pass"
+                )
+
         for m in all_replay_managers:
             if self._use_rollout_replay(m):
                 fill_replay_data(
@@ -462,7 +475,9 @@ class MegatronTrainRayActor(TrainRayActor):
                         )
                     )
                 self._switch_model("old_actor" if self.args.keep_old_actor else "actor")
-                if not self.args.use_rollout_logprobs or self.args.get_mismatch_metrics:
+                if not self.args.skip_actor_logprobs_forward and (
+                    not self.args.use_rollout_logprobs or self.args.get_mismatch_metrics
+                ):
                     for m in all_replay_managers:
                         if m.enabled:
                             if self._use_rollout_replay(m):

--- a/miles/backends/training_utils/loss.py
+++ b/miles/backends/training_utils/loss.py
@@ -3,7 +3,7 @@ from argparse import Namespace
 import torch
 from torch.utils.checkpoint import checkpoint
 
-from miles.backends.training_utils.cp_utils import get_sum_of_sample_mean
+from miles.backends.training_utils.cp_utils import get_local_response_loss_masks, get_sum_of_sample_mean
 from miles.backends.training_utils.loss_hub.advantages import compute_advantages, normalize_advantages
 from miles.backends.training_utils.loss_hub.logit_processors import get_log_probs_and_entropy, get_values  # noqa: F401
 from miles.backends.training_utils.loss_hub.losses import get_loss_function
@@ -28,7 +28,9 @@ def compute_advantages_and_returns(args: Namespace, rollout_data: RolloutBatch) 
     data-parallel group using masked statistics.
 
     Early returns if both `log_probs` and `values` are None (intermediate
-    pipeline stages).
+    pipeline stages), except when `args.skip_actor_logprobs_forward` left the
+    actor log probs uncomputed on purpose — the last pipeline stage then builds
+    the zero KL from the CP-local response loss masks instead.
 
     Args:
         args: Configuration specifying estimator type, KL coefficient,
@@ -47,11 +49,18 @@ def compute_advantages_and_returns(args: Namespace, rollout_data: RolloutBatch) 
     total_lengths: list[int] = rollout_data.get("total_lengths")
     max_seq_lens: list[int] | None = rollout_data.get("max_seq_lens", None)
 
-    # return when not the last pp stage.
     if log_probs is None and values is None:
-        return
-
-    if args.kl_coef == 0 or not log_probs:
+        if not (args.skip_actor_logprobs_forward and get_parallel_state().is_pp_last_stage):
+            # not the last pp stage.
+            return
+        # The actor log-probs forward pass was intentionally skipped (the ratio is
+        # identically 1); build the zero KL on the CP-local response shapes the log
+        # probs would have had.
+        local_masks = get_local_response_loss_masks(
+            total_lengths, response_lengths, loss_masks, args.qkv_format, max_seq_lens
+        )
+        kl = [torch.zeros_like(mask, dtype=torch.float32) for mask in local_masks]
+    elif args.kl_coef == 0 or not log_probs:
         # when kl_coef is 0, we won't compute ref_log_prob
         xs = log_probs if log_probs is not None else values
         kl = [torch.zeros_like(x, dtype=torch.float32, device=x.device) for x in xs]

--- a/miles/backends/training_utils/loss_hub/losses.py
+++ b/miles/backends/training_utils/loss_hub/losses.py
@@ -76,9 +76,10 @@ def policy_loss_function(
     Args:
         args: Configuration controlling advantage estimator, clipping thresholds,
             entropy/KL coefficients, and TIS settings.
-        batch: Mini-batch containing "advantages", "log_probs" (old policy),
-            "unconcat_tokens", "response_lengths", "total_lengths", "loss_masks",
-            and optionally "ref_log_probs" and "rollout_log_probs".
+        batch: Mini-batch containing "advantages", "log_probs" (old policy;
+            absent when `args.skip_actor_logprobs_forward`), "unconcat_tokens",
+            "response_lengths", "total_lengths", "loss_masks", and optionally
+            "ref_log_probs" and "rollout_log_probs".
         logits: Policy logits with shape `[1, T, V]`.
         sum_of_sample_mean: Reduction function that averages per-sample values.
 
@@ -91,7 +92,6 @@ def policy_loss_function(
     """
     parallel_state = get_parallel_state()
     advantages = torch.cat(batch["advantages"], dim=0)
-    old_log_probs = batch["rollout_log_probs"] if args.use_rollout_logprobs else batch["log_probs"]
 
     response_lengths = batch["response_lengths"]
     total_lengths = batch["total_lengths"]
@@ -110,6 +110,11 @@ def policy_loss_function(
     )
 
     log_probs = log_probs_and_entropy["log_probs"]
+    if args.skip_actor_logprobs_forward:
+        # Strictly on-policy single-step: the training forward itself is the old policy.
+        old_log_probs = [x.detach() for x in log_probs]
+    else:
+        old_log_probs = batch["rollout_log_probs"] if args.use_rollout_logprobs else batch["log_probs"]
     train_log_probs_list = log_probs
     old_log_probs_list = old_log_probs
 

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -1256,6 +1256,18 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                     "If not set, we will use the logprobs from the actor model."
                 ),
             )
+            parser.add_argument(
+                "--skip-actor-logprobs-forward",
+                action="store_true",
+                default=False,
+                help=(
+                    "Skip the actor's standalone forward-only log-probs pass before training and use the "
+                    "training forward's own detached log probs as the old-policy log probs, making the "
+                    "importance sampling ratio exactly 1. Only valid for strictly on-policy runs with "
+                    "exactly one optimizer step per rollout; incompatible with every feature that consumes "
+                    "the recomputed log probs (see the validation in this file)."
+                ),
+            )
             # Off-Policy Correction using Importance Sampling: https://fengyao.notion.site/off-policy-rl
             parser.add_argument(
                 "--use-tis",
@@ -2866,6 +2878,9 @@ def miles_validate_args(args):
             )
         args.global_batch_size = global_batch_size
 
+    if args.skip_actor_logprobs_forward:
+        validate_skip_actor_logprobs_forward(args)
+
     # Multi-LoRA adapters carry their own n_samples_per_prompt; the per-group
     # normalization path already skips std for singleton groups.
     if args.n_samples_per_prompt == 1 and not args.multi_lora:
@@ -2947,6 +2962,63 @@ def miles_validate_args(args):
         ), "Dynamic batch size is not supported for bshd format. Please specify --micro-batch-size instead."
 
     _maybe_apply_dumper_overrides(args)
+
+
+def validate_skip_actor_logprobs_forward(args) -> None:
+    """Reject every configuration that still needs the actor's forward-only log probs.
+
+    With the skip, the training forward's own detached log probs stand in for the
+    old-policy log probs, which is only exact when (a) the training weights are the
+    policy that generated the batch's single optimizer step and (b) nothing else
+    consumes the recomputed log probs.
+    """
+    assert args.train_backend == "megatron", "--skip-actor-logprobs-forward only supports --train-backend megatron"
+    assert (
+        not args.use_rollout_logprobs
+    ), "--skip-actor-logprobs-forward is redundant with --use-rollout-logprobs, which already skips the forward pass"
+    assert (
+        not args.use_tis
+    ), "--skip-actor-logprobs-forward is incompatible with --use-tis, which reads the recomputed log probs"
+    assert (
+        not args.get_mismatch_metrics
+    ), "--skip-actor-logprobs-forward is incompatible with --get-mismatch-metrics, whose metrics are the recomputed log probs"
+    assert (
+        not args.use_opd
+    ), "--skip-actor-logprobs-forward is incompatible with --use-opd, which reads the recomputed log probs as student log probs"
+    assert (
+        not args.keep_old_actor
+    ), "--skip-actor-logprobs-forward is incompatible with --keep-old-actor, whose old-actor log probs differ from the training forward"
+    assert (
+        not args.use_critic
+    ), "--skip-actor-logprobs-forward is incompatible with the critic, whose PP data sync uses the recomputed log probs"
+    assert (
+        args.kl_coef == 0
+    ), "--skip-actor-logprobs-forward requires --kl-coef 0; KL-in-reward reads the recomputed log probs"
+    assert (
+        not args.use_rollout_entropy
+    ), "--skip-actor-logprobs-forward is incompatible with --use-rollout-entropy, whose entropy comes from the skipped pass"
+    assert (
+        not args.true_on_policy_mode
+    ), "--skip-actor-logprobs-forward is incompatible with --true-on-policy-mode; use --use-rollout-logprobs there instead"
+    assert (
+        not args.log_correct_samples
+    ), "--skip-actor-logprobs-forward is incompatible with --log-correct-samples, which reads the recomputed log probs"
+    assert (
+        args.custom_megatron_before_log_prob_hook_path is None
+    ), "--skip-actor-logprobs-forward skips the actor log-probs pass the before-log-prob hook would run in"
+    assert (
+        args.dump_details is None
+    ), "--skip-actor-logprobs-forward removes the forward-only phase that --dump-details captures"
+    assert getattr(args, "attention_dropout", 0.0) == 0.0 and getattr(args, "hidden_dropout", 0.0) == 0.0, (
+        "--skip-actor-logprobs-forward requires dropout disabled; with dropout the training forward is "
+        "stochastic and cannot stand in for the old-policy log probs"
+    )
+    if args.global_batch_size is not None and not args.use_dynamic_global_batch_size:
+        num_steps = args.rollout_batch_size * args.n_samples_per_prompt // args.global_batch_size
+        assert num_steps == 1, (
+            f"--skip-actor-logprobs-forward requires exactly one optimizer step per rollout, got {num_steps}; "
+            "the importance sampling ratio is only identically 1 for the first step after a rollout"
+        )
 
 
 def validate_async_off_policy_correction(args) -> None:

--- a/tests/fast/backends/training_utils/loss/loss_test_utils.py
+++ b/tests/fast/backends/training_utils/loss/loss_test_utils.py
@@ -72,6 +72,7 @@ _ARGS_DEFAULTS = dict(
     # compute_advantages_and_returns
     advantage_estimator="grpo",
     use_rollout_logprobs=False,
+    skip_actor_logprobs_forward=False,
     kl_coef=0.1,
     kl_loss_type="k1",
     gamma=1.0,

--- a/tests/fast/backends/training_utils/loss/test_skip_actor_logprobs_forward.py
+++ b/tests/fast/backends/training_utils/loss/test_skip_actor_logprobs_forward.py
@@ -1,0 +1,111 @@
+"""Tests for --skip-actor-logprobs-forward.
+
+With the flag, the actor's standalone forward-only log-probs pass is skipped:
+`policy_loss_function` uses the training forward's own detached log probs as
+the old-policy log probs (the importance sampling ratio is identically 1), and
+`compute_advantages_and_returns` builds the zero KL from the response loss
+masks because rollout_data carries no "log_probs".
+"""
+
+from __future__ import annotations
+
+import torch
+
+from miles.backends.training_utils.cp_utils import get_sum_of_sample_mean
+from miles.backends.training_utils.loss import compute_advantages_and_returns
+from miles.backends.training_utils.loss_hub.logit_processors import get_log_probs_and_entropy
+from miles.backends.training_utils.loss_hub.losses import policy_loss_function
+
+from .loss_test_utils import deep_clone, make_args, make_batch, make_inputs, make_parallel_state, make_rollout_data
+
+SEED = 1234
+
+
+def _make_inputs(args):
+    return make_inputs(
+        seed=SEED, batch_size=3, prompt_lens=[20, 64, 40], response_lens=[10, 48, 32], vocab_size=128, args=args
+    )
+
+
+def _run_policy_loss(args, batch, inputs):
+    logits = deep_clone(inputs["policy_logits"])
+    logits.requires_grad_(True)
+    som = get_sum_of_sample_mean(
+        batch["total_lengths"],
+        batch["response_lengths"],
+        batch["loss_masks"],
+        args.calculate_per_token_loss,
+        args.qkv_format,
+        batch.get("max_seq_lens", None),
+    )
+    loss, metrics = policy_loss_function(args, batch, logits, som)
+    loss.backward()
+    return loss.detach(), metrics, logits.grad.clone()
+
+
+def test_policy_loss_matches_explicit_on_policy_old_log_probs():
+    make_parallel_state()
+    args_skip = make_args(skip_actor_logprobs_forward=True, kl_coef=0.0)
+    inputs = _make_inputs(args_skip)
+
+    batch_skip = make_batch(inputs, "policy_loss")
+    del batch_skip["log_probs"]  # the forward-only pass never ran
+    loss_skip, metrics_skip, grad_skip = _run_policy_loss(args_skip, batch_skip, inputs)
+
+    # Baseline: what the recomputed old log probs equal in a single-step
+    # on-policy run — the training forward's own log probs.
+    args_base = make_args(kl_coef=0.0)
+    train_log_probs = get_log_probs_and_entropy(
+        deep_clone(inputs["policy_logits"]),
+        args=args_base,
+        unconcat_tokens=deep_clone(inputs["unconcat_tokens"]),
+        total_lengths=list(inputs["total_lens"]),
+        response_lengths=list(inputs["response_lens"]),
+        with_entropy=False,
+    )["log_probs"]
+    batch_base = make_batch(inputs, "policy_loss")
+    batch_base["log_probs"] = [x.detach() for x in train_log_probs]
+    loss_base, metrics_base, grad_base = _run_policy_loss(args_base, batch_base, inputs)
+
+    assert torch.equal(loss_skip, loss_base)
+    assert torch.equal(grad_skip, grad_base)
+    assert metrics_skip["ppo_kl"].item() == 0.0
+    assert metrics_skip["pg_clipfrac"].item() == 0.0
+    assert metrics_base["ppo_kl"].item() == 0.0
+
+
+def test_advantages_without_actor_log_probs_match_baseline():
+    make_parallel_state()
+    args_skip = make_args(skip_actor_logprobs_forward=True, kl_coef=0.0)
+    inputs = _make_inputs(args_skip)
+
+    rollout_skip = make_rollout_data(inputs)
+    for key in ("log_probs", "ref_log_probs", "values"):
+        del rollout_skip[key]
+    compute_advantages_and_returns(args_skip, rollout_skip)
+
+    rollout_base = make_rollout_data(inputs)
+    del rollout_base["values"]
+    compute_advantages_and_returns(make_args(kl_coef=0.0), rollout_base)
+
+    for a, b in zip(rollout_skip["advantages"], rollout_base["advantages"], strict=True):
+        assert a.shape == b.shape
+        assert torch.equal(a, b)
+    for a, b in zip(rollout_skip["returns"], rollout_base["returns"], strict=True):
+        assert torch.equal(a, b)
+
+
+def test_skip_does_not_compute_on_intermediate_pp_stage():
+    parallel_state = make_parallel_state()
+    parallel_state.is_pp_last_stage = False
+    try:
+        args_skip = make_args(skip_actor_logprobs_forward=True, kl_coef=0.0)
+        inputs = _make_inputs(args_skip)
+        rollout_data = make_rollout_data(inputs)
+        for key in ("log_probs", "ref_log_probs", "values"):
+            del rollout_data[key]
+        compute_advantages_and_returns(args_skip, rollout_data)
+        assert "advantages" not in rollout_data
+        assert "returns" not in rollout_data
+    finally:
+        make_parallel_state()

--- a/tests/fast/backends/training_utils/test_true_on_policy_loss_metrics.py
+++ b/tests/fast/backends/training_utils/test_true_on_policy_loss_metrics.py
@@ -10,6 +10,7 @@ from miles.backends.training_utils.loss_hub import losses as loss_utils
 def _make_args(*, use_rollout_logprobs: bool) -> Namespace:
     return Namespace(
         use_rollout_logprobs=use_rollout_logprobs,
+        skip_actor_logprobs_forward=False,
         use_opsm=False,
         advantage_estimator="ppo",
         get_mismatch_metrics=False,

--- a/tests/fast/utils/test_arguments.py
+++ b/tests/fast/utils/test_arguments.py
@@ -14,6 +14,7 @@ from miles.utils.arguments import (
     get_miles_extra_args_provider,
     miles_validate_args,
     validate_async_off_policy_correction,
+    validate_skip_actor_logprobs_forward,
 )
 from miles.utils.misc import function_registry
 
@@ -496,3 +497,64 @@ class TestValidateAsyncOffPolicyCorrection:
 
     def test_non_ppo_estimators_are_unaffected(self):
         validate_async_off_policy_correction(_make_async_ppo_args(use_critic=False))
+
+
+def _make_skip_actor_logprobs_args(**overrides) -> SimpleNamespace:
+    defaults = dict(
+        train_backend="megatron",
+        use_rollout_logprobs=False,
+        use_tis=False,
+        get_mismatch_metrics=False,
+        use_opd=False,
+        keep_old_actor=False,
+        use_critic=False,
+        kl_coef=0,
+        use_rollout_entropy=False,
+        true_on_policy_mode=False,
+        log_correct_samples=False,
+        custom_megatron_before_log_prob_hook_path=None,
+        dump_details=None,
+        attention_dropout=0.0,
+        hidden_dropout=0.0,
+        global_batch_size=64,
+        use_dynamic_global_batch_size=False,
+        rollout_batch_size=8,
+        n_samples_per_prompt=8,
+    )
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+class TestValidateSkipActorLogprobsForward:
+    def test_strictly_on_policy_single_step_passes(self):
+        validate_skip_actor_logprobs_forward(_make_skip_actor_logprobs_args())
+
+    @pytest.mark.parametrize(
+        "overrides",
+        [
+            dict(train_backend="fsdp"),
+            dict(use_rollout_logprobs=True),
+            dict(use_tis=True),
+            dict(get_mismatch_metrics=True),
+            dict(use_opd=True),
+            dict(keep_old_actor=True),
+            dict(use_critic=True),
+            dict(kl_coef=0.05),
+            dict(use_rollout_entropy=True),
+            dict(true_on_policy_mode=True),
+            dict(log_correct_samples=True),
+            dict(custom_megatron_before_log_prob_hook_path="pkg.mod:hook"),
+            dict(dump_details="/tmp/dump"),
+            dict(attention_dropout=0.1),
+            dict(hidden_dropout=0.1),
+            dict(global_batch_size=32),  # 8 * 8 / 32 = 2 steps per rollout
+        ],
+    )
+    def test_consumers_of_recomputed_log_probs_are_rejected(self, overrides):
+        with pytest.raises(AssertionError):
+            validate_skip_actor_logprobs_forward(_make_skip_actor_logprobs_args(**overrides))
+
+    def test_dynamic_global_batch_size_defers_step_check_to_runtime(self):
+        validate_skip_actor_logprobs_forward(
+            _make_skip_actor_logprobs_args(global_batch_size=32, use_dynamic_global_batch_size=True)
+        )


### PR DESCRIPTION
## Motivation

When a rollout is consumed in exactly one optimizer step (`num_steps_per_rollout == 1`, i.e. `rollout_batch_size * n_samples_per_prompt == global_batch_size`) and `--keep-old-actor` is not set, the actor's standalone forward-only log-probs pass in `train_actor` recomputes, with the *same weights*, exactly what the training forward computes again right after: `old_log_probs == log_probs`, so the importance sampling ratio is identically 1, clipping never fires, and the PG gradient `ratio * ∇logp * A` equals plain `∇logp * A`. The pass costs a full extra forward over the whole rollout batch (~1/3 of the train step's FLOPs) and contributes nothing but recompute noise to the ratio.

## What this PR does

Adds an opt-in flag `--skip-actor-logprobs-forward` (default off; no behavior change without it):

- `megatron_utils/actor.py`: `train_actor` skips the actor's `compute_log_prob` pass (the `ref_`/`teacher_` passes are untouched), and fails loudly at runtime if the rollout resolves to more than one optimizer step or a replay manager is enabled.
- `loss_hub/losses.py`: `policy_loss_function` uses the training forward's own detached log probs as `old_log_probs` (ratio exactly 1, gradient unchanged).
- `loss.py`: `compute_advantages_and_returns` builds the zero KL from the CP-local response loss masks on the last PP stage, since `rollout_data` no longer carries `log_probs`.
- `arguments.py`: `validate_skip_actor_logprobs_forward` rejects every configuration that still consumes the recomputed log probs — `use_rollout_logprobs` (already skips the pass, different semantics), `use_tis`, `get_mismatch_metrics`, `use_opd`, `keep_old_actor`, critic (PP data sync uses `log_probs` as the shape source for `values` broadcast), `kl_coef != 0` (KL-in-reward), `use_rollout_entropy`, `true_on_policy_mode`, `log_correct_samples`, the before-log-prob hook, `dump_details`, and nonzero dropout (the training forward would be stochastic). When the step count is statically computable it also enforces one step per rollout; with `use_dynamic_global_batch_size` the check defers to runtime.

Known observability delta when the flag is on: the per-rollout `rollout/log_probs` metric disappears (its CI checker is membership-guarded), and `ppo_kl`/`pg_clipfrac` become exactly 0 instead of measuring fwd-only-vs-train recompute noise.

## Tests

- `tests/fast/backends/training_utils/loss/test_skip_actor_logprobs_forward.py`:
  - policy loss, logits gradient, `ppo_kl`, and `pg_clipfrac` under the flag are bitwise identical to a baseline whose `batch["log_probs"]` is the training forward's own detached log probs;
  - advantages/returns computed without `log_probs` in `rollout_data` are bitwise identical to the baseline that had them (grpo, `kl_coef=0`);
  - intermediate PP stages still return without computing advantages.
- `tests/fast/utils/test_arguments.py`: `validate_skip_actor_logprobs_forward` accepts the strictly on-policy single-step config and rejects each incompatible knob.

## Follow-up (out of scope)

The experimental FSDP backend runs the same actor log-probs pass unconditionally (`fsdp_utils/actor.py`), and additionally sources its logged entropy from that pass; skipping it there needs its own treatment, so this PR gates the flag to `--train-backend megatron`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
