### PR TITLE
Use TransformerEngine for MXFP8 quantization

### DIFF
--- a/miles/backends/megatron_utils/megatron_to_hf/processors/quantizer_mxfp8.py
+++ b/miles/backends/megatron_utils/megatron_to_hf/processors/quantizer_mxfp8.py
@@ -1,18 +1,6 @@
-import logging
 import re
-from functools import partial
 
-
-try:
-    from flashinfer import mxfp8_quantize as flashinfer_mxfp8_quantize
-
-    mxfp8_quantize = partial(flashinfer_mxfp8_quantize, is_sf_swizzled_layout=False)
-except ImportError:
-    logger = logging.getLogger(__name__)
-    logger.warning("FlashInfer mxfp8_quantize not available; falling back to Triton.")
-    from sglang.srt.layers.quantization.fp8_utils import mxfp8_group_quantize
-
-    mxfp8_quantize = mxfp8_group_quantize
+from miles.utils.mxfp8 import mxfp8_quantize
 
 
 def quantize_params_mxfp8(args, megatron_name, converted_named_params, quantization_config):
@@ -113,13 +101,6 @@ def quantize_params_mxfp8(args, megatron_name, converted_named_params, quantizat
 
 def _quantize_param(name, weight):
     assert name.endswith(".weight"), f"Expected weight parameter, got {name}"
-    weight = weight.contiguous()
-    k = weight.shape[-1]
-    if k % 32 != 0:
-        raise ValueError(f"Last dim {k} must be divisible by 32 for MXFP8.")
-    weight_flat = weight.view(-1, k).contiguous()
-    qweight, scale = mxfp8_quantize(weight_flat)
-    qweight = qweight.view_as(weight)
-    scale = scale.view(*weight.shape[:-1], k // 32).contiguous()
+    qweight, scale = mxfp8_quantize(weight)
     scale_name = name.replace(".weight", ".weight_scale_inv")
     return [(name, qweight), (scale_name, scale)]

--- a/miles/backends/megatron_utils/sglang.py
+++ b/miles/backends/megatron_utils/sglang.py
@@ -12,12 +12,6 @@ try:
 except ImportError:
     per_block_cast_to_fp8 = None
 
-# mxfp8
-try:
-    from sglang.srt.layers.quantization.fp8_utils import mxfp8_group_quantize
-except ImportError:
-    mxfp8_group_quantize = None
-
 try:
     from sglang.srt.utils.patch_torch import monkey_patch_torch_reductions
 except ImportError:
@@ -31,7 +25,6 @@ except ImportError:
     from sglang.srt.model_executor.model_runner import FlattenedTensorBucket  # type: ignore[import]
 
 __all__ = [
-    "mxfp8_group_quantize",
     "per_block_cast_to_fp8",
     "quant_weight_ue8m0",
     "transform_scale_ue8m0",

--- a/miles/utils/mxfp8.py
+++ b/miles/utils/mxfp8.py
@@ -1,0 +1,35 @@
+import torch
+
+
+MXFP8_GROUP_SIZE = 32
+TE_MXFP8_ROW_ALIGNMENT = 32
+
+
+def mxfp8_quantize(weight: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """Quantize a tensor to rowwise MXFP8 with compact, unswizzled scales."""
+    from transformer_engine.pytorch import MXFP8Quantizer
+    from transformer_engine.pytorch.constants import TE_DType
+
+    weight = weight.contiguous()
+    k = weight.shape[-1]
+    if k % MXFP8_GROUP_SIZE != 0:
+        raise ValueError(f"Last dim {k} must be divisible by {MXFP8_GROUP_SIZE} for MXFP8.")
+
+    weight_flat = weight.view(-1, k)
+    num_rows = weight_flat.shape[0]
+    pad_rows = (-num_rows) % TE_MXFP8_ROW_ALIGNMENT
+    if pad_rows:
+        padding = torch.zeros((pad_rows, k), device=weight.device, dtype=weight.dtype)
+        weight_flat = torch.cat((weight_flat, padding), dim=0)
+
+    quantizer = MXFP8Quantizer(
+        fp8_dtype=TE_DType[torch.float8_e4m3fn],
+        rowwise=True,
+        columnwise=False,
+    )
+    quantized = quantizer.quantize(weight_flat)
+    qweight = quantized._rowwise_data[:num_rows, :k].contiguous()
+    qweight = qweight.view(torch.float8_e4m3fn).view_as(weight)
+    scale = quantized._rowwise_scale_inv[:num_rows, : k // MXFP8_GROUP_SIZE]
+    scale = scale.contiguous().view(*weight.shape[:-1], k // MXFP8_GROUP_SIZE)
+    return qweight, scale

--- a/tests/fast/backends/megatron_utils/test_hf_weight_iterator_direct.py
+++ b/tests/fast/backends/megatron_utils/test_hf_weight_iterator_direct.py
@@ -39,7 +39,6 @@ def _install_import_stubs(monkeypatch):
     sys.modules["sglang.srt.utils.patch_torch"].monkey_patch_torch_reductions = lambda: None
     sys.modules["sglang.srt.weight_sync.tensor_bucket"].FlattenedTensorBucket = object
     fp8_utils = sys.modules["sglang.srt.layers.quantization.fp8_utils"]
-    fp8_utils.mxfp8_group_quantize = lambda *args, **kwargs: None
     fp8_utils.quant_weight_ue8m0 = lambda *args, **kwargs: None
     fp8_utils.transform_scale_ue8m0 = lambda x, **kwargs: x
 

--- a/tools/convert_hf_to_mxfp8.py
+++ b/tools/convert_hf_to_mxfp8.py
@@ -11,11 +11,9 @@ Supported input checkpoint types:
 import argparse
 import gc
 import json
-import logging
 import os
 import re
 import shutil
-from functools import partial
 
 
 import safetensors
@@ -24,16 +22,8 @@ import torch
 from sglang.srt.layers.quantization.fp8_utils import block_quant_dequant
 from tqdm import tqdm
 
-try:
-    from flashinfer import mxfp8_quantize as flashinfer_mxfp8_quantize
-
-    mxfp8_quantize = partial(flashinfer_mxfp8_quantize, is_sf_swizzled_layout=False)
-except ImportError:
-    logger = logging.getLogger(__name__)
-    logger.warning("FlashInfer mxfp8_quantize not available; falling back to Triton.")
-    from sglang.srt.layers.quantization.fp8_utils import mxfp8_group_quantize
-
-    mxfp8_quantize = mxfp8_group_quantize
+from miles.utils.mxfp8 import MXFP8_GROUP_SIZE
+from miles.utils.mxfp8 import mxfp8_quantize as quantize_mxfp8
 
 
 SKIP_WEIGHT_SUBSTRINGS = (
@@ -52,7 +42,7 @@ SKIP_WEIGHT_SUBSTRINGS = (
 )
 
 SOURCE_FP8_BLOCK_SIZE = [128, 128]
-TARGET_MXFP8_BLOCK_SIZE = [1, 32]
+TARGET_MXFP8_BLOCK_SIZE = [1, MXFP8_GROUP_SIZE]
 SOURCE_FP8_SCALE_KEY_SUFFIX = ".weight_scale_inv"
 SOURCE_FP8_DTYPES = (torch.float8_e4m3fn,) + ((torch.float8_e4m3fnuz,) if hasattr(torch, "float8_e4m3fnuz") else ())
 
@@ -148,25 +138,6 @@ def should_quantize(
     if weight.shape[-1] % 32 != 0:
         return False
     return True
-
-
-def quantize_mxfp8(weight: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
-    """
-    Mirror sglang _quantize_and_swizzle_with_triton_kernel but do not swizzle scales.
-    Returns:
-      qweight: same shape as input, dtype float8_e4m3fn
-      scale:  shape = (*weight.shape[:-1], weight.shape[-1] // 32), dtype uint8
-    """
-    weight = weight.contiguous()
-    k = weight.shape[-1]
-    if k % 32 != 0:
-        raise ValueError(f"Last dim {k} must be divisible by 32 for MXFP8.")
-
-    weight_flat = weight.view(-1, k).contiguous()
-    qweight, scale = mxfp8_quantize(weight_flat)
-    qweight = qweight.view_as(weight)
-    scale = scale.view(*weight.shape[:-1], k // 32).contiguous()
-    return qweight, scale
 
 
 class ConversionResult:


### PR DESCRIPTION
@humansand

## Summary

- replace the FlashInfer/Triton MXFP8 quantizer selection with one shared TransformerEngine adapter
- reuse the TE path for both Megatron-to-HF live weight export and offline HF checkpoint conversion
- remove the obsolete SGLang `mxfp8_group_quantize` re-export and its CPU import stub

## Implementation

The shared helper lazily constructs the TransformerEngine 2.17 `MXFP8Quantizer` in rowwise-only mode. It flattens leading dimensions, pads rows to TE's 32-row requirement, and crops the quantized payload and UE8M0 scales back to the existing compact, unswizzled checkpoint contract.

Existing layer selection, BF16 carve-outs, source block-FP8 handling, tensor names, and output layouts are unchanged.

## Validation

- `pre-commit run --all-files`
- B200 devbox using `radixark/miles:dev-202607290235`
  - `python3 docker/verify_transformer_engine.py transformer_engine_cu13`
  - TransformerEngine version: `2.17.0`
  - `CUDA_VISIBLE_DEVICES=0 python3 -m pytest tests/fast-gpu/test_mxfp8_quantizer.py -xvs` (`108 passed`)
  - `CUDA_VISIBLE_DEVICES=0 python3 -m pytest tests/fast/backends/megatron_utils/test_hf_weight_iterator_direct.py -xvs` (`6 passed`)
  - DeepSeek V3.2 5-layer MXFP8 E2E: `PYTHONPATH=/root/miles python3 tests/e2e/megatron/model_scripts/test_deepseek_v32_5layer_mxfp8.py` (`passed`)
    - completed a fresh FP8 to BF16 to MXFP8 conversion with TransformerEngine 2.17.0
    - quantized weight comparison used `allow_quant_error=True`; `/weights_checker` returned HTTP 200
    - rollouts 0, 1, and 2 completed with weight versions 1, 2, and 3 and `mixed_version_ratio=0.0`
    - Ray job `raysubmit_UP189w1SijVshDUf` succeeded
