### PR TITLE
[6/N] Opt-in partial final training step

### DIFF
--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -946,6 +946,16 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
             )
 
             parser.add_argument(
+                "--allow-partial-train-step",
+                action="store_true",
+                default=False,
+                help=(
+                    "Train the trailing rollouts that don't fill a whole global_batch_size step as one "
+                    "smaller final step instead of dropping them (rollout-side schedule + dynamic batch "
+                    "size only). Loss normalization and the LR scheduler use the true per-step count."
+                ),
+            )
+            parser.add_argument(
                 "--use-dynamic-batch-size",
                 action="store_true",
                 default=False,

--- a/miles/utils/dp_schedule.py
+++ b/miles/utils/dp_schedule.py
@@ -103,10 +103,8 @@ def build_dp_schedule(
         f"need at least one rollout per step."
     )
 
-    # Per-step rollout counts. With --allow-partial-train-step, trailing
-    # rollouts train as one smaller final step (dynamic batch only — the
-    # static path can't satisfy its fixed-size alignment on an arbitrary
-    # remainder) instead of being dropped.
+    # --allow-partial-train-step: trailing rollouts form one smaller final step
+    # (dynamic batch only).
     step_rollout_counts = [global_batch_size] * num_steps
     leftover = len(rollout_ids) - num_steps * global_batch_size
     if leftover and getattr(args, "allow_partial_train_step", False) and args.use_dynamic_batch_size:

--- a/miles/utils/dp_schedule.py
+++ b/miles/utils/dp_schedule.py
@@ -32,6 +32,7 @@ Invariants (asserted by tests/fast/utils/test_dp_schedule.py):
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 from miles.utils.seqlen_balancing import (
@@ -39,6 +40,8 @@ from miles.utils.seqlen_balancing import (
     first_fit_decreasing_pack,
     get_seqlen_balanced_partitions,
 )
+
+logger = logging.getLogger(__name__)
 
 SCHEDULE_CONFIG_KEYS = ("dp_size", "cp_size", "vpp_size", "microbatch_group_size_per_vp_stage")
 
@@ -100,16 +103,31 @@ def build_dp_schedule(
         f"need at least one rollout per step."
     )
 
+    # Per-step rollout counts. With --allow-partial-train-step, trailing
+    # rollouts train as one smaller final step (dynamic batch only — the
+    # static path can't satisfy its fixed-size alignment on an arbitrary
+    # remainder) instead of being dropped.
+    step_rollout_counts = [global_batch_size] * num_steps
+    leftover = len(rollout_ids) - num_steps * global_batch_size
+    if leftover and getattr(args, "allow_partial_train_step", False) and args.use_dynamic_batch_size:
+        leftover_samples = sum(len(rollout_id_to_samples[rid]) for rid in rollout_ids[-leftover:])
+        if leftover_samples >= dp_size:
+            step_rollout_counts.append(leftover)
+        else:
+            logger.info(f"partial step skipped: {leftover_samples} samples < dp_size {dp_size}")
+
     partitions: list[list[int]] = [[] for _ in range(dp_size)]
     micro_batch_indices: list[list[list[int]]] = [[] for _ in range(dp_size)]
     num_microbatches: list[int] = []
     global_batch_sizes: list[int] = []
 
-    for step_i in range(num_steps):
-        step_rollouts = rollout_ids[step_i * global_batch_size : (step_i + 1) * global_batch_size]
+    rollout_cursor = 0
+    for step_i, step_rollout_count in enumerate(step_rollout_counts):
+        step_rollouts = rollout_ids[rollout_cursor : rollout_cursor + step_rollout_count]
+        rollout_cursor += step_rollout_count
         sample_indices = [pos for rid in step_rollouts for pos in rollout_id_to_samples[rid]]
         step_lengths = [total_lengths[i] for i in sample_indices]
-        global_batch_sizes.append(global_batch_size)
+        global_batch_sizes.append(step_rollout_count)
         assert len(sample_indices) >= dp_size, (
             f"step {step_i}: {len(sample_indices)} samples < dp_size {dp_size}; "
             f"each step needs at least one sample per rank."

--- a/tests/fast/utils/test_dp_schedule.py
+++ b/tests/fast/utils/test_dp_schedule.py
@@ -276,6 +276,48 @@ def test_trims_trailing_rollouts_that_dont_fill_a_step():
     )
 
 
+def test_partial_final_step_opt_in():
+    """--allow-partial-train-step: 5 rollouts, gbs=2 -> 2 full steps + 1 partial
+    step of the trailing rollout, covering every sample."""
+    rollout_indices = [0, 0, 1, 2, 2, 3, 4, 4]
+    total_lengths = [3] * 8
+    args = make_args(use_dynamic_batch_size=True, max_tokens_per_gpu=12)
+    args.allow_partial_train_step = True
+    tp = make_tp(dp_size=1)
+
+    partitions, mbi, nmb, gbs_per_step = build_dp_schedule(
+        args, tp, total_lengths, global_batch_size=2, rollout_indices=rollout_indices
+    )
+
+    assert gbs_per_step == [2, 2, 1]
+    assert len(nmb) == 3
+    assert_invariants(
+        partitions,
+        mbi,
+        nmb,
+        dp_size=1,
+        expected_global_sample_indices=range(8),
+        total_lengths=total_lengths,
+        max_per_bin=12,
+    )
+
+
+def test_partial_final_step_skipped_when_below_dp_size():
+    """A trailing rollout with fewer samples than dp_size cannot form a step."""
+    rollout_indices = [0, 0, 1, 1, 2]
+    total_lengths = [3] * 5
+    args = make_args(use_dynamic_batch_size=True, max_tokens_per_gpu=12)
+    args.allow_partial_train_step = True
+    tp = make_tp(dp_size=2)
+
+    _, _, nmb, gbs_per_step = build_dp_schedule(
+        args, tp, total_lengths, global_batch_size=2, rollout_indices=rollout_indices
+    )
+
+    assert gbs_per_step == [2]
+    assert len(nmb) == 1
+
+
 def test_rejects_when_fewer_rollouts_than_gbs():
     """gbs=4 with only 3 distinct rollouts -> cannot form one step."""
     args = make_args(use_dynamic_batch_size=True, max_tokens_per_gpu=12)


### PR DESCRIPTION
## Summary

Stacked on #1936. New opt-in flag `--allow-partial-train-step`: instead of dropping the trailing rollouts that don't fill a whole `global_batch_size` step, train them as one smaller final step. This is the endgame the series was built for — genuinely variable per-step global batch sizes.

- Rollout-side schedule + dynamic batch size only (the static path can't satisfy its fixed-size mbs alignment on an arbitrary remainder); a partial step smaller than `dp_size` samples is skipped with a log line.
- No other machinery changes: loss normalization and the LR scheduler increment already use the true per-step rollout count (from [1/N]), and the metric reduction is already count-weighted.
- Saves up to `global_batch_size - 1` rollouts per rollout batch under dynamic sampling / filtering — samples are the expensive part of RL.

## Validation

- CPU: 101 tests green, incl. partial-step opt-in coverage (uneven `[2, 2, 1]` schedule covering every sample) and the below-dp_size skip guard; default behavior unchanged when the flag is off.
- GPU e2e (Qwen2.5-0.5B gsm8k, dp8, dynamic batch, mooncake, `--ci-test`, `--global-batch-size 24 --disable-rollout-trim-samples`):

```
Rollout-side DP schedule: num_samples=32, num_rollouts=32, global_batch_sizes=[24, 8], num_microbatches=[1, 1]
```

All 3 rollout batches trained with uneven `[24, 8]` steps — the first genuinely variable global batch size training in miles — job succeeded, CI logprob asserts pass, rewards healthy (0.47-0.59). Without the flag those 8 rollouts per batch (25%) would have been discarded.
