### PR TITLE
[7/N] Port --balance-by-flops for FLOPs-balanced micro-batching

### DIFF
--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -946,6 +946,18 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
             )
 
             parser.add_argument(
+                "--balance-by-flops",
+                action="store_true",
+                default=False,
+                help=(
+                    "Use FLOPs-based workload estimation for micro-batch partitioning via "
+                    "Karmarkar-Karp instead of first-fit token packing, and distribute mbs "
+                    "across DP ranks by FLOPs. Captures the quadratic attention cost when "
+                    "sequence lengths vary widely. Requires --use-dynamic-batch-size. NOTE: "
+                    "FLOPs balancing does not enforce the per-mbs token cap."
+                ),
+            )
+            parser.add_argument(
                 "--allow-partial-train-step",
                 action="store_true",
                 default=False,
@@ -2699,6 +2711,9 @@ def miles_validate_args(args):
         assert args.max_tokens_per_gpu is not None, "max_tokens_per_gpu must be set when use_dynamic_batch_size is set"
         if args.log_probs_max_tokens_per_gpu is None:
             args.log_probs_max_tokens_per_gpu = args.max_tokens_per_gpu
+
+    if getattr(args, "balance_by_flops", False):
+        assert args.use_dynamic_batch_size, "--balance-by-flops requires --use-dynamic-batch-size"
 
     if args.eps_clip_high is None:
         args.eps_clip_high = args.eps_clip

--- a/miles/utils/dp_schedule.py
+++ b/miles/utils/dp_schedule.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from miles.utils.flops_utils import calculate_fwd_flops
 from miles.utils.seqlen_balancing import (
     expand_bins_by_splitting,
     first_fit_decreasing_pack,
@@ -54,16 +55,30 @@ def has_full_schedule_config(train_parallel_config: dict | None) -> bool:
     return all(key in train_parallel_config for key in SCHEDULE_CONFIG_KEYS)
 
 
+def _calculate_workloads(step_lengths, args):
+    return [calculate_fwd_flops([sl], args) for sl in step_lengths]
+
+
 def _pack_step_into_mbs(
     step_lengths: list[int],
     *,
+    args: Any,
     use_dynamic_batch_size: bool,
     max_per_bin: int | None,
     micro_batch_size: int | None,
+    balance_by_flops: bool = False,
 ) -> list[list[int]]:
     """Group a step's samples into mbs. Returns ``mbs[k]`` = local indices into ``step_lengths``."""
     if use_dynamic_batch_size:
         assert max_per_bin is not None
+        if balance_by_flops:
+            total_tokens = sum(step_lengths)
+            num_mbs = max(1, (total_tokens + max_per_bin - 1) // max_per_bin)
+            if num_mbs >= len(step_lengths):
+                return [[i] for i in range(len(step_lengths))]
+            workloads = _calculate_workloads(step_lengths, args)
+            # NOTE: FLOPs balancing does not enforce the token cap per mbs.
+            return get_seqlen_balanced_partitions(workloads, num_mbs, equal_size=False)
         return first_fit_decreasing_pack(step_lengths, max_per_bin)
     assert micro_batch_size is not None
     n = len(step_lengths)
@@ -131,11 +146,14 @@ def build_dp_schedule(
             f"each step needs at least one sample per rank."
         )
 
+        balance_by_flops = getattr(args, "balance_by_flops", False)
         step_mbs = _pack_step_into_mbs(
             step_lengths,
+            args=args,
             use_dynamic_batch_size=args.use_dynamic_batch_size,
             max_per_bin=max_per_bin,
             micro_batch_size=getattr(args, "micro_batch_size", None),
+            balance_by_flops=balance_by_flops,
         )
 
         target_K = max(((len(step_mbs) + align_to - 1) // align_to) * align_to, align_to)
@@ -161,9 +179,13 @@ def build_dp_schedule(
         num_mbs_per_rank = K // dp_size
         num_microbatches.append(num_mbs_per_rank)
 
-        if args.balance_data:
-            mbs_token_sums = [sum(step_lengths[i] for i in bin_) for bin_ in step_mbs]
-            rank_mbs_idx = get_seqlen_balanced_partitions(mbs_token_sums, dp_size, equal_size=True)
+        if args.balance_data or balance_by_flops:
+            if balance_by_flops:
+                step_workloads = _calculate_workloads(step_lengths, args)
+                mbs_weights = [sum(step_workloads[i] for i in bin_) for bin_ in step_mbs]
+            else:
+                mbs_weights = [sum(step_lengths[i] for i in bin_) for bin_ in step_mbs]
+            rank_mbs_idx = get_seqlen_balanced_partitions(mbs_weights, dp_size, equal_size=True)
         else:
             rank_mbs_idx = [list(range(r, K, dp_size)) for r in range(dp_size)]
 

--- a/tests/fast/utils/test_dp_schedule.py
+++ b/tests/fast/utils/test_dp_schedule.py
@@ -25,12 +25,28 @@ def make_args(
     use_dynamic_batch_size=False,
     max_tokens_per_gpu=None,
     balance_data=False,
+    balance_by_flops=False,
 ):
     return SimpleNamespace(
         micro_batch_size=micro_batch_size,
         use_dynamic_batch_size=use_dynamic_batch_size,
         max_tokens_per_gpu=max_tokens_per_gpu,
         balance_data=balance_data,
+        balance_by_flops=balance_by_flops,
+        # Minimal model config for calculate_fwd_flops (balance_by_flops path).
+        hidden_size=16,
+        num_attention_heads=2,
+        num_query_groups=2,
+        vocab_size=32,
+        ffn_hidden_size=64,
+        num_experts=None,
+        num_layers=2,
+        kv_channels=8,
+        q_lora_rank=None,  # no MLA in the stub config
+        kv_lora_rank=None,
+        qk_pos_emb_head_dim=0,
+        qk_head_dim=8,
+        v_head_dim=8,
     )
 
 
@@ -368,6 +384,45 @@ def test_randomized_invariants_dynamic():
             total_lengths=total_lengths,
             max_per_bin=max_tokens,
         )
+
+
+def test_balance_by_flops_packs_and_distributes():
+    """balance_by_flops: KK-on-FLOPs packing, invariants preserved (the token cap
+    is intentionally NOT enforced in this mode)."""
+    total_lengths = [10, 200, 30, 400, 50, 600, 70, 800]
+    rollout_indices = list(range(8))
+    args = make_args(use_dynamic_batch_size=True, max_tokens_per_gpu=600, balance_by_flops=True)
+    tp = make_tp(dp_size=2)
+
+    partitions, mbi, nmb, gbs_per_step = build_dp_schedule(
+        args, tp, total_lengths, global_batch_size=8, rollout_indices=rollout_indices
+    )
+
+    assert gbs_per_step == [8]
+    assert_invariants(
+        partitions,
+        mbi,
+        nmb,
+        dp_size=2,
+        expected_global_sample_indices=range(8),
+        total_lengths=total_lengths,
+        max_per_bin=None,  # cap not enforced in FLOPs mode
+    )
+
+
+def test_balance_by_flops_singleton_fallback():
+    """When ceil(total/cap) >= n samples, every sample gets its own mbs."""
+    total_lengths = [100] * 4
+    args = make_args(use_dynamic_batch_size=True, max_tokens_per_gpu=100, balance_by_flops=True)
+    tp = make_tp(dp_size=2)
+
+    partitions, mbi, nmb, _ = build_dp_schedule(
+        args, tp, total_lengths, global_batch_size=4, rollout_indices=list(range(4))
+    )
+    assert sum(nmb) * 2 == 4  # 4 singleton mbs over 2 ranks
+    for r in range(2):
+        for mbs in mbi[r]:
+            assert len(mbs) == 1
 
 
 def test_has_full_schedule_config():


### PR DESCRIPTION
## Summary

Stacked on #1937. Port of slime #2017 + #2029 (staying in sync with upstream): `--balance-by-flops` switches the dynamic-batch micro-batch partitioner from token packing to FLOPs-balanced Karmarkar-Karp, and distributes mbs across DP ranks by FLOPs weight.

- Per-sample workload = `calculate_fwd_flops` (miles's version — covers MoE, MLA/q_lora, GQA), capturing the quadratic attention term that token counts miss when sequence lengths vary widely.
- `num_mbs = ceil(total_tokens / cap)`; with at least as many mbs as samples, every sample gets its own mbs.
- Requires `--use-dynamic-batch-size` (validated at parse time). NOTE (upstream behavior, documented in the help text): FLOPs balancing does not enforce the per-mbs token cap — a partition can exceed `max_tokens_per_gpu` when the cap is tight.
- Mutually composes with the rest of the series: rollout grouping, partial steps, and FFD (FFD applies only on the non-FLOPs path).

## Validation

- CPU: 103 tests green, incl. FLOPs packing invariants (coverage/PP-sync; cap intentionally unchecked in this mode) and the singleton fallback.
- GPU e2e: Qwen2.5-0.5B gsm8k short + `--balance-by-flops` (dp8, mooncake, `--ci-test`) ✅ succeeded.
