### PR TITLE
docs(examples): add a landing README for infra_features/

### DIFF
--- a/examples/infra_features/README.md
+++ b/examples/infra_features/README.md
@@ -1,0 +1,4 @@
+The examples under this directory exercise runtime and infrastructure behaviour rather than a
+training recipe: weight transfer, low precision, train/inference agreement, and the async
+rollout loop. Reach for them when the question is how miles moves data and weights around, not
+how to train a particular model.


### PR DESCRIPTION
Stacked on #1953. One file, and a small gap the reorg left behind.

The top level `examples/README.md` links to both new groups as directory links:

```
### [infra_features](./infra_features)
### [experimental](./experimental)
```

`experimental/` has its own README, so clicking through explains what the grouping means.
`infra_features/` does not, so clicking through lands on a bare file listing. This adds the
missing counterpart in the same one paragraph shape.

It deliberately does not restate the per directory list that the top level README already
carries, so adding or moving an example stays a one place edit.

## Review notes on the rest of #1953

While looking for anything else worth stacking I checked the reorg for dangling references and
did not find any. Recording the axes so the work is not repeated:

* Filesystem path references to all 15 moved directories: clean.
* Dotted module path references (`examples.<dir>`), which a slash based grep misses: clean.
  `examples/geo3k_vlm/multi_turn/geo3k_vlm_multi_turn_config.yaml` correctly moved *and* had
  its `rollout_interaction_env_path` updated to `examples.geo3k_vlm.multi_turn.env_geo3k`.
* Mintlify doc routes (`/examples/...`), which are page routes rather than directories, so
  they are unaffected by the move: clean.
* `tests/` and `.github/`: no references to moved example paths.
* Top level README against the actual tree: every existing directory is listed, and nothing
  listed is missing.
* The two net deletions leave no references behind. `examples/retool/` is superseded by
  `examples/retool_v2/`, which already exists on `main`, and `docs/examples/retool.md` plus its
  nav entry and index Card were removed consistently. `examples/true_on_policy_vlm/` is gone
  with no leftover mentions.

One thing worth putting in the PR description rather than leaving for a reader to discover:
the change also deletes `examples/retool/` (8 files), `examples/true_on_policy_vlm/` (3 files)
and `docs/examples/retool.md`. Both removals look deliberate and are clean, but a title about
grouping does not lead anyone to expect deletions.
