### PR TITLE
feat(docker): persist verified wheel release assets

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -6,6 +6,8 @@ on:
       - main
     paths:
       - 'docker/Dockerfile'
+      - 'docker/build.py'
+      - 'docker/wheel_cache.py'
       - 'docker/verify_transformer_engine.py'
       - 'requirements.txt'
 
@@ -145,6 +147,8 @@ jobs:
       always() &&
       (github.event_name != 'schedule' || needs.check-upstream.outputs.should_build == 'true')
     runs-on: ["h200", "2gpu"]
+    env:
+      MILES_DOCKER_CACHE_DIR: /data/miles_ci/miles-docker-cache
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -93,7 +93,7 @@ jobs:
           # the recorded base.sha, which can lag main and pull in unrelated changes.
           # Dockerfile.rocm doesn't feed the cu13 multi-arch build this pipeline produces.
           if git diff --name-only HEAD^1 HEAD \
-              | grep -qE '^(docker/(Dockerfile|build\.py|verify_transformer_engine\.py)|requirements\.txt)$|^docker/patch/'; then
+              | grep -qE '^(docker/(Dockerfile|build\.py|wheel_cache\.py|verify_transformer_engine\.py)|requirements\.txt)$|^docker/patch/'; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
           else
             echo "changed=false" >> "$GITHUB_OUTPUT"
@@ -112,6 +112,7 @@ jobs:
     env:
       # Forks cannot push to the registry, so they keep the released image.
       BUILD: ${{ needs.docker-paths.outputs.changed == 'true' && github.event.pull_request.head.repo.full_name == github.repository }}
+      MILES_DOCKER_CACHE_DIR: /data/miles_ci/miles-docker-cache
     steps:
       - name: Checkout repository
         if: env.BUILD == 'true'

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,17 +1,39 @@
 # doc-dev: docs/ci/02-docker-build.md
-# Build via docker/build.py (single source of truth for build-args, platforms,
+# Build published variants via docker/build.py (source of truth for platforms
 # and tags) — see docs/ci/02-docker-build.md. Examples:
 #       python docker/build.py --variant cu13     --image-tag dev --push   # radixark/miles:dev      (amd64+arm64)
 #       python docker/build.py --variant cu13-x86 --image-tag dev --push   # radixark/miles:dev (amd64)
 #       python docker/build.py --variant cu13-aarch64 --image-tag dev --push   # radixark/miles:dev (arm64)
 #       python docker/build.py --variant cu12-x86 --image-tag dev --push   # radixark/miles:dev-cu12 (CUDA 12.9)
 #
-# A multi-arch build runs the recipe once per platform; it installs the wheels
-# release for the current arch picked from TARGETARCH — WHEELS_TAG_X86 on amd64,
-# WHEELS_TAG_ARM64 on arm64 (cu12-x86 overrides WHEELS_TAG_X86).
+# Direct builds download the selected wheels release. build.py instead injects
+# a verified per-architecture snapshot as the wheel_assets context.
 
 ARG SGLANG_IMAGE_TAG=v0.5.16
-FROM lmsysorg/sglang:${SGLANG_IMAGE_TAG} AS sglang
+FROM lmsysorg/sglang:${SGLANG_IMAGE_TAG} AS sglang_base
+
+# build.py overrides this stage with its verified wheel snapshot.
+FROM sglang_base AS wheel_assets
+
+ARG WHEELS_REPO=yueming-yuan/miles-wheels
+ARG WHEELS_TAG_X86=cu130-x86_64
+ARG WHEELS_TAG_ARM64=cu130-aarch64
+ARG TARGETARCH
+
+COPY docker/wheel_cache.py /tmp/wheel_cache.py
+RUN case "${TARGETARCH}" in \
+      amd64) WHEELS_TAG="${WHEELS_TAG_X86}" ;; \
+      arm64) WHEELS_TAG="${WHEELS_TAG_ARM64}" ;; \
+      *) echo "unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac && \
+    echo "Fetching wheels release ${WHEELS_TAG}" && \
+    python3 /tmp/wheel_cache.py \
+      --repository "${WHEELS_REPO}" \
+      --tag "${WHEELS_TAG}" \
+      --output "/${TARGETARCH}" && \
+    ls -lh "/${TARGETARCH}/"
+
+FROM sglang_base AS sglang
 
 # ======================================== Arguments =============================================
 
@@ -23,12 +45,7 @@ ARG MEGATRON_BRANCH=miles-main
 
 ARG ENABLE_CUDA_13=1
 
-ARG WHEELS_REPO=yueming-yuan/miles-wheels
-# Two complete wheels release tags (the wheels repo's own names). The build picks
-# one by TARGETARCH and installs it verbatim — no on-the-fly tag assembly here.
 ARG TARGETARCH
-ARG WHEELS_TAG_X86=cu130-x86_64
-ARG WHEELS_TAG_ARM64=cu130-aarch64
 
 # ======================================== Setup =============================================
 
@@ -49,23 +66,8 @@ RUN git clone https://github.com/NVIDIA/nccl-tests.git /tmp/nccl-tests && \
     rm -rf /tmp/nccl-tests
 
 # ====================================== Collect pre-built wheels ============================================
-# Optional: drop pre-built wheels into <miles>/wheels/ to skip the release download below.
-# `wheel[s]/` is a glob — silently no-ops when wheels/ is absent (CI's path).
-COPY wheel[s]/ /tmp/wheels/
-
-RUN case "${TARGETARCH}" in \
-      amd64) WHEELS_TAG="${WHEELS_TAG_X86}" ;; \
-      arm64) WHEELS_TAG="${WHEELS_TAG_ARM64}" ;; \
-      *) echo "unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
-    esac && \
-    echo "Fetching wheels release ${WHEELS_TAG}" && \
-    mkdir -p /tmp/wheels && \
-    curl -sL "https://api.github.com/repos/${WHEELS_REPO}/releases/tags/${WHEELS_TAG}" \
-    | python3 -c "import sys,json,subprocess,os; w='/tmp/wheels'; \
-[subprocess.run(['curl','-fSL','-o',os.path.join(w,a['name']),a['browser_download_url']],check=True) \
- for a in json.load(sys.stdin).get('assets',[]) \
- if a['name'].endswith(('.whl', '.tar.gz')) and not os.path.exists(os.path.join(w,a['name']))]" && \
-    ls -lh /tmp/wheels/
+COPY --from=wheel_assets /${TARGETARCH}/ /tmp/wheels/
+RUN ls -lh /tmp/wheels/
 
 # ====================================== Python dependencies ============================================
 

--- a/docker/build.py
+++ b/docker/build.py
@@ -11,14 +11,18 @@ Usage:
 
 import os
 import subprocess
+from contextlib import nullcontext
 from datetime import datetime, timezone
 from enum import Enum
 from pathlib import Path
 
 import typer
 
-CACHE_DIR = "/tmp/miles-docker-cache"
+from wheel_cache import prepare_wheel_context
+
+DEFAULT_CACHE_DIR = Path("/tmp/miles-docker-cache")
 REPO_ROOT = Path(__file__).resolve().parent.parent
+WHEELS_REPOSITORY = "yueming-yuan/miles-wheels"
 
 VARIANTS = {
     "cu13": {
@@ -26,18 +30,24 @@ VARIANTS = {
         "platforms": ["linux/amd64", "linux/arm64"],
         "tag_postfix": "",
         "build_args": {},
+        "wheel_releases": {
+            "amd64": "cu130-x86_64",
+            "arm64": "cu130-aarch64",
+        },
     },
     "cu13-x86": {
         "image": "radixark/miles",
         "platforms": ["linux/amd64"],
         "tag_postfix": "",
         "build_args": {},
+        "wheel_releases": {"amd64": "cu130-x86_64"},
     },
     "cu13-aarch64": {
         "image": "radixark/miles",
         "platforms": ["linux/arm64"],
         "tag_postfix": "",
         "build_args": {},
+        "wheel_releases": {"arm64": "cu130-aarch64"},
     },
     "cu12-x86": {
         "image": "radixark/miles",
@@ -46,8 +56,8 @@ VARIANTS = {
         "build_args": {
             "ENABLE_CUDA_13": "0",
             "SGLANG_IMAGE_TAG": "v0.5.16-cu129",
-            "WHEELS_TAG_X86": "cu129-x86_64",
         },
+        "wheel_releases": {"amd64": "cu129-x86_64"},
     },
     "rocm700-mi35x": {
         "image": "rocm/sgl-dev",
@@ -95,6 +105,13 @@ def run(cmd: list[str], dry_run: bool) -> None:
     subprocess.run(cmd, check=True)
 
 
+def _cache_root() -> Path:
+    cache_root = Path(os.environ.get("MILES_DOCKER_CACHE_DIR", DEFAULT_CACHE_DIR)).expanduser()
+    if not cache_root.is_absolute():
+        raise typer.BadParameter(f"MILES_DOCKER_CACHE_DIR must be absolute: {cache_root}")
+    return cache_root
+
+
 def build_and_push(
     variant: str, image_tag: str, dry_run: bool, dockerfile: str, push: bool = False, custom_tag: str = ""
 ) -> None:
@@ -104,6 +121,7 @@ def build_and_push(
     image = config["image"]
     postfix = config.get("tag_postfix", "")
     platforms = config.get("platforms")
+    wheel_releases = config.get("wheel_releases")
 
     if image_tag == "latest":
         tags = [f"{image}:latest{postfix}"]
@@ -118,40 +136,51 @@ def build_and_push(
     else:
         raise typer.BadParameter(f"Unknown image tag: {image_tag}")
 
-    cmd = [
-        "docker",
-        "buildx",
-        "build",
-        "-f",
-        dockerfile,
-    ]
+    if wheel_releases and dry_run:
+        wheel_context_manager = nullcontext(_cache_root() / "snapshots" / "DRY_RUN_CONTEXT")
+    elif wheel_releases:
+        wheel_context_manager = prepare_wheel_context(WHEELS_REPOSITORY, wheel_releases, _cache_root())
+    else:
+        wheel_context_manager = nullcontext(None)
 
-    if platforms:
-        cmd += ["--platform", ",".join(platforms)]
+    with wheel_context_manager as wheel_context:
+        cmd = [
+            "docker",
+            "buildx",
+            "build",
+            "-f",
+            dockerfile,
+        ]
 
-    if push:
-        cmd += ["--push"]
+        if platforms:
+            cmd += ["--platform", ",".join(platforms)]
 
-    # Proxy args (pass through if set in environment, check both cases)
-    for arg_name in ["HTTP_PROXY", "HTTPS_PROXY"]:
-        value = os.environ.get(arg_name.lower()) or os.environ.get(arg_name)
-        if value:
-            cmd += ["--build-arg", f"{arg_name}={value}"]
+        if wheel_context is not None:
+            cmd += ["--build-context", f"wheel_assets={wheel_context}"]
 
-    cmd += ["--build-arg", "NO_PROXY=localhost,127.0.0.1"]
+        if push:
+            cmd += ["--push"]
 
-    # Variant-specific build args
-    for key, value in config.get("build_args", {}).items():
-        cmd += ["--build-arg", f"{key}={value}"]
+        # Proxy args (pass through if set in environment, check both cases)
+        for arg_name in ["HTTP_PROXY", "HTTPS_PROXY"]:
+            value = os.environ.get(arg_name.lower()) or os.environ.get(arg_name)
+            if value:
+                cmd += ["--build-arg", f"{arg_name}={value}"]
 
-    for tag in tags:
-        cmd += ["-t", tag]
+        cmd += ["--build-arg", "NO_PROXY=localhost,127.0.0.1"]
 
-    # Context is repo root
-    cmd += ["."]
+        # Variant-specific build args
+        for key, value in config.get("build_args", {}).items():
+            cmd += ["--build-arg", f"{key}={value}"]
 
-    print(f"\n=== Building {' '.join(tags)} ===", flush=True)
-    run(cmd, dry_run)
+        for tag in tags:
+            cmd += ["-t", tag]
+
+        # Context is repo root
+        cmd += ["."]
+
+        print(f"\n=== Building {' '.join(tags)} ===", flush=True)
+        run(cmd, dry_run)
 
 
 class Variant(str, Enum):

--- a/docker/wheel_cache.py
+++ b/docker/wheel_cache.py
@@ -1,0 +1,258 @@
+# doc-dev: docs/ci/02-docker-build.md
+"""Verified wheel release materialization for Docker builds."""
+
+from __future__ import annotations
+
+import argparse
+import fcntl
+import hashlib
+import json
+import os
+import re
+import shutil
+import tempfile
+import urllib.parse
+import urllib.request
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import BinaryIO
+
+_ASSET_SUFFIXES = (".whl", ".tar.gz")
+_BUFFER_SIZE = 1024 * 1024
+_REPOSITORY_RE = re.compile(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+")
+_SHA256_RE = re.compile(r"sha256:([0-9a-fA-F]{64})")
+_TARGET_ARCHES = frozenset({"amd64", "arm64"})
+
+
+class WheelCacheError(RuntimeError):
+    """Raised when a wheel release cannot be materialized safely."""
+
+
+@dataclass(frozen=True)
+class ReleaseAsset:
+    name: str
+    size: int
+    sha256: str
+    download_url: str
+
+
+def _validate_release_ref(repository: str, tag: str) -> None:
+    if not _REPOSITORY_RE.fullmatch(repository):
+        raise WheelCacheError(f"invalid wheels repository: {repository!r}")
+    if not tag or tag in {".", ".."} or "/" in tag or "\\" in tag or "\0" in tag:
+        raise WheelCacheError(f"invalid wheels release tag: {tag!r}")
+
+
+def _request(url: str, *, accept: str | None = None) -> urllib.request.Request:
+    headers = {"User-Agent": "miles-docker-build"}
+    if accept is not None:
+        headers["Accept"] = accept
+    if url.startswith("https://api.github.com/") and (token := os.environ.get("GITHUB_TOKEN")):
+        headers["Authorization"] = f"Bearer {token}"
+    return urllib.request.Request(url, headers=headers)
+
+
+def _open(request: urllib.request.Request) -> BinaryIO:
+    return urllib.request.urlopen(request)
+
+
+def fetch_release_assets(repository: str, tag: str) -> tuple[ReleaseAsset, ...]:
+    """Fetch and validate the wheel assets in one GitHub release."""
+    _validate_release_ref(repository, tag)
+    encoded_tag = urllib.parse.quote(tag, safe="")
+    url = f"https://api.github.com/repos/{repository}/releases/tags/{encoded_tag}"
+    with _open(_request(url, accept="application/vnd.github+json")) as response:
+        payload = json.load(response)
+
+    if not isinstance(payload, dict) or not isinstance(payload.get("assets"), list):
+        raise WheelCacheError(f"invalid release manifest for {repository}@{tag}")
+
+    assets: list[ReleaseAsset] = []
+    names: set[str] = set()
+    for raw_asset in payload["assets"]:
+        if not isinstance(raw_asset, dict):
+            raise WheelCacheError(f"invalid asset entry in {repository}@{tag}")
+        name = raw_asset.get("name")
+        if not isinstance(name, str):
+            raise WheelCacheError(f"asset without a valid name in {repository}@{tag}")
+        if not name.endswith(_ASSET_SUFFIXES) or raw_asset.get("state") != "uploaded":
+            continue
+        if not name or name in {".", ".."} or "/" in name or "\\" in name or "\0" in name or Path(name).name != name:
+            raise WheelCacheError(f"unsafe asset name in {repository}@{tag}: {name!r}")
+        if name in names:
+            raise WheelCacheError(f"duplicate asset name in {repository}@{tag}: {name}")
+
+        size = raw_asset.get("size")
+        if isinstance(size, bool) or not isinstance(size, int) or size < 0:
+            raise WheelCacheError(f"invalid size for {repository}@{tag} asset {name}")
+
+        digest = raw_asset.get("digest")
+        digest_match = _SHA256_RE.fullmatch(digest) if isinstance(digest, str) else None
+        if digest_match is None:
+            raise WheelCacheError(f"missing SHA256 digest for {repository}@{tag} asset {name}")
+
+        download_url = raw_asset.get("browser_download_url")
+        parsed_url = urllib.parse.urlparse(download_url) if isinstance(download_url, str) else None
+        if parsed_url is None or parsed_url.scheme != "https" or not parsed_url.netloc:
+            raise WheelCacheError(f"invalid download URL for {repository}@{tag} asset {name}")
+
+        names.add(name)
+        assets.append(
+            ReleaseAsset(
+                name=name,
+                size=size,
+                sha256=digest_match.group(1).lower(),
+                download_url=download_url,
+            )
+        )
+
+    if not assets:
+        raise WheelCacheError(f"release {repository}@{tag} has no uploaded wheel assets")
+    return tuple(sorted(assets, key=lambda asset: asset.name))
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as file:
+        while chunk := file.read(_BUFFER_SIZE):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _matches_asset(path: Path, asset: ReleaseAsset) -> bool:
+    try:
+        if path.is_symlink() or not path.is_file() or path.stat().st_size != asset.size:
+            return False
+        return _sha256(path) == asset.sha256
+    except OSError:
+        return False
+
+
+def _download_asset(asset: ReleaseAsset, target: Path) -> None:
+    file_descriptor, temporary_name = tempfile.mkstemp(
+        dir=target.parent,
+        prefix=f".{target.name}.",
+        suffix=".part",
+    )
+    temporary_path = Path(temporary_name)
+    digest = hashlib.sha256()
+    size = 0
+    try:
+        with os.fdopen(file_descriptor, "wb") as output, _open(_request(asset.download_url)) as response:
+            while chunk := response.read(_BUFFER_SIZE):
+                output.write(chunk)
+                digest.update(chunk)
+                size += len(chunk)
+        if size != asset.size or digest.hexdigest() != asset.sha256:
+            raise WheelCacheError(
+                f"downloaded asset failed SHA256 validation: {asset.name} "
+                f"(expected {asset.size} bytes/{asset.sha256}, got {size} bytes/{digest.hexdigest()})"
+            )
+        os.replace(temporary_path, target)
+    finally:
+        temporary_path.unlink(missing_ok=True)
+
+
+@contextmanager
+def _release_lock(cache_root: Path, repository: str, tag: str, target_arch: str) -> Iterator[None]:
+    lock_root = cache_root / "locks"
+    lock_root.mkdir(parents=True, exist_ok=True)
+    lock_key = hashlib.sha256(f"{repository}\0{tag}\0{target_arch}".encode()).hexdigest()
+    with (lock_root / f"{lock_key}.lock").open("a+b") as lock_file:
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+
+
+def _cache_assets(
+    cache_directory: Path,
+    assets: tuple[ReleaseAsset, ...],
+) -> tuple[tuple[Path, ...], int, int]:
+    cache_directory.mkdir(parents=True, exist_ok=True)
+    paths: list[Path] = []
+    hits = 0
+    downloads = 0
+    for asset in assets:
+        target = cache_directory / asset.name
+        if _matches_asset(target, asset):
+            hits += 1
+        else:
+            print(f"wheel cache: downloading {asset.name} ({asset.size} bytes)", flush=True)
+            _download_asset(asset, target)
+            downloads += 1
+        paths.append(target)
+    return tuple(paths), hits, downloads
+
+
+def materialize_release(
+    repository: str,
+    tag: str,
+    directory: Path,
+) -> tuple[tuple[Path, ...], int, int]:
+    """Download and verify one wheel release into a directory."""
+    return _cache_assets(directory, fetch_release_assets(repository, tag))
+
+
+@contextmanager
+def prepare_wheel_context(
+    repository: str,
+    releases: Mapping[str, str],
+    cache_root: Path,
+) -> Iterator[Path]:
+    """Yield an isolated, complete wheel snapshot for one Docker build."""
+    if not releases:
+        raise WheelCacheError("no wheel releases configured for this build")
+    unknown_arches = set(releases) - _TARGET_ARCHES
+    if unknown_arches:
+        raise WheelCacheError(f"unsupported wheel target architectures: {sorted(unknown_arches)}")
+
+    cache_root = cache_root.expanduser()
+    if not cache_root.is_absolute():
+        raise WheelCacheError(f"MILES_DOCKER_CACHE_DIR must be absolute: {cache_root}")
+    cache_root.mkdir(parents=True, exist_ok=True)
+    snapshot_root = cache_root / "snapshots"
+    snapshot_root.mkdir(parents=True, exist_ok=True)
+
+    total_hits = 0
+    total_downloads = 0
+    with tempfile.TemporaryDirectory(dir=snapshot_root, prefix="wheels-") as temporary_directory:
+        context = Path(temporary_directory)
+        for target_arch, tag in sorted(releases.items()):
+            _validate_release_ref(repository, tag)
+            with _release_lock(cache_root, repository, tag, target_arch):
+                owner, name = repository.split("/", maxsplit=1)
+                cache_directory = cache_root / "wheels" / owner / name / tag / target_arch
+                cached_paths, hits, downloads = materialize_release(repository, tag, cache_directory)
+
+                architecture_context = context / target_arch
+                architecture_context.mkdir()
+                for cached_path in cached_paths:
+                    shutil.copy2(cached_path, architecture_context / cached_path.name)
+
+                total_hits += hits
+                total_downloads += downloads
+
+        print(
+            f"wheel cache: {total_hits} hit(s), {total_downloads} download(s); snapshot ready at {context}",
+            flush=True,
+        )
+        yield context
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Download and verify one wheel release.")
+    parser.add_argument("--repository", required=True)
+    parser.add_argument("--tag", required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    _, hits, downloads = materialize_release(args.repository, args.tag, args.output)
+    print(f"wheel cache: {hits} hit(s), {downloads} download(s)", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/ci/02-docker-build.md
+++ b/docs/ci/02-docker-build.md
@@ -18,7 +18,7 @@ GPU CI runs inside `radixark/miles`. This doc maps which Dockerfiles exist, the 
 
 ### `docker/Dockerfile` — inputs & output
 
-The Dockerfile is the build recipe: it provides the cu13 defaults and emits one image. `build.py` owns the variant → build-arg overrides (see Build script), including the cu12 base and wheels release.
+The Dockerfile is the build recipe: it provides the cu13 base and wheel-release defaults, can download and verify those wheels itself, and emits one image. `build.py` owns the published variant overrides and the host-side wheel cache (see Build script), including the cu12 base and wheels.
 
 **Inputs (build-args)**
 
@@ -27,8 +27,9 @@ The Dockerfile is the build recipe: it provides the cu13 defaults and emits one 
 | ------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `SGLANG_IMAGE_TAG`                                                                                     | base `lmsysorg/sglang` image tag                                                                                                                                                                                                                                                                                                                    |
 | `ENABLE_CUDA_13`                                                                                       | `1` = CUDA 13 (default) and installs the Mooncake wheel from the selected wheels release; `0` = CUDA 12.9 and keeps the base image's Mooncake                                                                                                                                                                                                         |
-| `WHEELS_REPO`                                                                                          | prebuilt-wheels GitHub repo (`yueming-yuan/miles-wheels`)                                                                                                                                                                                                                                                                                           |
-| `WHEELS_TAG_X86` / `WHEELS_TAG_ARM64`                                                                  | the two **complete** wheels release tags selected by `TARGETARCH` and installed **verbatim**. cu13 uses the rolling `cu130-x86_64` / `cu130-aarch64` releases; cu12-x86 overrides `WHEELS_TAG_X86` with the rolling `cu129-x86_64` release                                                                                                                                                                                              |
+| `WHEELS_REPO`                                                                                          | prebuilt-wheels GitHub repo (`yueming-yuan/miles-wheels`) used by a direct Dockerfile build                                                                                                                                                                                                                                                         |
+| `WHEELS_TAG_X86` / `WHEELS_TAG_ARM64`                                                                  | complete wheel-release tags used by the Dockerfile fallback stage; cu13 defaults to `cu130-x86_64` / `cu130-aarch64`                                                                                                                                                                                                                                |
+| `TARGETARCH`                                                                                            | BuildKit-provided target architecture; selects the fallback release or the matching directory from `build.py`'s `wheel_assets` named context                                                                                                                                                                                                       |
 | `SGLANG_BRANCH` / `SGLANG_COMMIT`, `MEGATRON_REPO` / `MEGATRON_BRANCH`, `MILES_COMMIT`, `SGL_ROUTER_*` | source pins for the layered repos                                                                                                                                                                                                                                                                                                                   |
 
 
@@ -38,7 +39,7 @@ The Dockerfile is the build recipe: it provides the cu13 defaults and emits one 
 
 ## Build script
 
-`docker/build.py` builds and pushes the images. Select a build with `--variant` and a tag mode with `--image-tag {dev,latest,custom}`. A single `VARIANTS` table is the source of truth for each variant's image, target platforms, Dockerfile, and build-args.
+`docker/build.py` builds and pushes the images. Select a build with `--variant` and a tag mode with `--image-tag {dev,latest,custom}`. A single `VARIANTS` table is the source of truth for each variant's image, target platforms, Dockerfile, build-args, and CUDA wheel release tags.
 
 
 | `--variant`    | Tag (`--image-tag dev`)            | Platforms                     | Notes                                          |
@@ -51,21 +52,27 @@ The Dockerfile is the build recipe: it provides the cu13 defaults and emits one 
 | `rocm-mi350`   | `rocm/sgl-dev:miles-rocm720-mi35x` | native                        | AMD MI35x — `docker/Dockerfile.rocm`           |
 
 
-The cu13 variants share one multi-arch CUDA base image and differ only in platforms. `cu13` runs a single `buildx --platform linux/amd64,linux/arm64` — buildx builds both arches and pushes them as one manifest in a single shot, with the Dockerfile picking each layer's wheels by `TARGETARCH` (see Dockerfile inputs), so `docker pull` auto-selects by host arch.
+The cu13 variants share one multi-arch CUDA base image and differ only in platforms. `cu13` runs a single `buildx --platform linux/amd64,linux/arm64` — buildx builds both arches and pushes them as one manifest in a single shot, with the Dockerfile copying each layer's wheels from the `TARGETARCH` directory, so `docker pull` auto-selects by host arch.
 
 The **Tag** column is for `--image-tag dev`, which also pushes a timestamped `dev-<YYYYMMDDHHMM>` sibling; `latest` swaps the prefix to `latest`, `custom` uses `--custom-tag`. `cu13` / `cu13-x86` / `cu13-aarch64` intentionally share `radixark/miles:dev` — the daily build runs `cu13` (multi-arch), while a single-arch variant overwrites `dev` with one arch when run alone.
 
 A multi-arch build (`cu13`) needs Buildx's `docker-container` driver and is push-only — buildx writes the manifest straight to the registry, it can't load into the local image store. Use `cu13-x86` / `cu13-aarch64` (single-platform; the arm64 one cross-builds via QEMU on an x86 host) for local single-arch iteration. Other flags: `--push`, `--dry-run`, `--dockerfile`, `--custom-tag`.
 
+Before a CUDA build, `build.py` asks GitHub for the selected `yueming-yuan/miles-wheels` release manifest and treats each asset's SHA256 digest as authoritative. A cached file is reused only when its size and computed SHA256 match; a missing or mismatched file is downloaded to a temporary file, verified, and atomically replaced. Invalid manifests and failed verification stop before Docker starts, with no stale-cache fallback.
+
+The persistent root is `MILES_DOCKER_CACHE_DIR`, defaulting to `/tmp/miles-docker-cache` for local use. The self-hosted workflows set it to `/data/miles_ci/miles-docker-cache`, under the runner fleet's existing large-disk mount. For each build, the exact manifest assets are physically copied into a unique snapshot below that root, separated as `amd64/` and `arm64/`; cache locks are released before the long `buildx` process reads the snapshot through `--build-context wheel_assets=...`, and the snapshot is deleted when the process exits. This caches wheel artifacts only: the Buildx builder remains temporary and no Docker layer cache is persisted.
+
+`--dry-run` performs no network, hashing, or filesystem writes. A direct `docker buildx build -f docker/Dockerfile .` uses the Dockerfile's default `wheel_assets` stage, which downloads and verifies the release for `TARGETARCH`. `build.py` supplies a verified snapshot as a same-named context, so BuildKit replaces that default stage without changing the image's wheel installation path. Failure to prepare the host cache still stops `build.py` before Docker starts; it does not silently switch to the direct-download path.
+
 ## PR build check (in `pr-test.yml`)
 
 Dockerfile changes are build-tested on the PR itself, before merge — `docker-build.yml` only runs after a push to `main`, so without this breakage lands on `main` first.
 
-When a PR touches `docker/Dockerfile`, `docker/build.py`, `docker/verify_transformer_engine.py`, `docker/patch/**`, or `requirements.txt` (detected by the `docker-paths` job), `pr-test.yml` inserts a build in front of the test matrix:
+When a PR touches `docker/Dockerfile`, `docker/build.py`, `docker/wheel_cache.py`, `docker/verify_transformer_engine.py`, `docker/patch/**`, or `requirements.txt` (detected by the `docker-paths` job), `pr-test.yml` inserts a build in front of the test matrix:
 
 | Job | What it does |
 | --- | --- |
-| `docker-build` | builds `cu13` for `linux/amd64` and `linux/arm64`, then pushes one multi-arch PR-scoped `radixark/miles:pr-<num>` tag (same-repo PRs; fork PRs skip it and test on `dev`) |
+| `docker-build` | prepares both wheel snapshots from the shared host cache, builds `cu13` for `linux/amd64` and `linux/arm64`, then pushes one multi-arch PR-scoped `radixark/miles:pr-<num>` tag (same-repo PRs; fork PRs skip it and test on `dev`) |
 | `resolve-ci-image` | waits for the build and resolves the CI image to `pr-<num>`, so **every GPU suite runs inside the freshly built image**; a failed build stops the matrix instead of testing the stale image. The fresh build outranks a `ci-image-tag:` PR-body directive — the directive applies only when no PR image was built (non-docker or fork PRs) |
 | `delete-pr-tag` (`docker-pr-tag-cleanup.yml`) | removes the `pr-<num>` tag when the PR closes; the tag stays available for re-runs while the PR is open |
 
@@ -76,20 +83,20 @@ Non-docker PRs are untouched: `docker-paths` reports no change, `docker-build` s
 The only automated builder of `radixark/miles`. Two jobs:
 
 - **`check-upstream`** (schedule / `simulate_schedule` only) — polls the inputs the image bakes: the HEAD SHA of sglang `sglang-miles` (`sgl-project/sglang`) and Megatron-LM `miles-main` (`radixark/Megatron-LM`) — the source branches it builds — plus a fingerprint of the selected `yueming-yuan/miles-wheels` rolling release, so a rebuilt sgl-router or other wheel also triggers a build (re-uploads to the same tag are caught by fingerprint, not commit SHA). It compares against the values cached from the last build and sets `should_build=true` if any moved. `miles` itself is intentionally not polled. This is what stops the 12-hour cron from rebuilding an unchanged image.
-- **`build-and-push`** (self-hosted runner) — calls `docker/build.py` to build + push, then conditionally points `latest` at the new `dev` and prunes old timestamped tags.
+- **`build-and-push`** (self-hosted runner) — calls `docker/build.py` to prepare verified wheel snapshots and build + push, then conditionally points `latest` at the new `dev` and prunes old timestamped tags. Automatic cu13 and cu12 calls share the persistent artifact cache but receive separate temporary snapshots.
 
 `build-and-push` runs when `check-upstream` was skipped, or ran and reported `should_build=true`.
 
 ### Triggers: automatic vs manual
 
-- **Automatic** (no human) — the **schedule** (cron 00:00 / 12:00 UTC, gated by `check-upstream`) and any **push to `main` that touches `docker/Dockerfile`, `docker/verify_transformer_engine.py`, or `requirements.txt`**. Both leave `--variant` empty and build **two images**: `cu13` → `radixark/miles` (multi-arch) and `cu12-x86` → `radixark/miles:dev-cu12`.
+- **Automatic** (no human) — the **schedule** (cron 00:00 / 12:00 UTC, gated by `check-upstream`) and any **push to `main` that touches `docker/Dockerfile`, `docker/build.py`, `docker/wheel_cache.py`, `docker/verify_transformer_engine.py`, or `requirements.txt`**. Both leave `--variant` empty and build **two images**: `cu13` → `radixark/miles` (multi-arch) and `cu12-x86` → `radixark/miles:dev-cu12`.
 - **Manual** — `workflow_dispatch` (pick one variant — see Trigger a build yourself below) or running `docker/build.py` locally. Only the `rocm-*` images have **no automatic path** (`cu13-x86` / `cu13-aarch64` just rebuild the same `dev` image single-arch).
 
 
 | Trigger                                     | `check-upstream`                   | builds                | `latest` move     | prune      |
 | ------------------------------------------- | ---------------------------------- | --------------------- | ----------------- | ---------- |
 | schedule (cron 00:00 / 12:00 UTC)           | runs; build only if upstream moved | `cu13` + `cu12-x86`   | yes (both)        | yes (both) |
-| push to `main` touching `docker/Dockerfile`, `docker/verify_transformer_engine.py`, or `requirements.txt` | skipped                            | `cu13` + `cu12-x86`   | no                | no         |
+| push to `main` touching `docker/Dockerfile`, `docker/build.py`, `docker/wheel_cache.py`, `docker/verify_transformer_engine.py`, or `requirements.txt` | skipped                            | `cu13` + `cu12-x86`   | no                | no         |
 | `workflow_dispatch`                         | skipped                            | the one input variant | no                | no         |
 | `workflow_dispatch` + `simulate_schedule`   | runs                               | the one input variant | no                | no         |
 
@@ -130,7 +137,7 @@ gh workflow run docker-build.yml -f variant=cu13-x86 -f image_tag=custom -f cust
 ### Steps (`build-and-push`)
 
 1. checkout → Buildx → install Python + typer → Docker Hub login.
-2. **Build + push** via `build.py` — automatic runs build **both** `cu13` and `cu12-x86`; a manual dispatch builds only the one variant you picked.
+2. **Prepare wheels, build + push** via `build.py` — validate or refresh the persistent wheel cache, copy one isolated snapshot for the selected variant, then run Buildx. Automatic runs build **both** `cu13` and `cu12-x86`; a manual dispatch builds only the one variant you picked.
 3. **schedule only** — point `latest`→`dev` and `latest-cu12`→`dev-cu12`.
 4. **schedule only** — prune each timestamp series to the newest 20.
 

--- a/tests/fast/test_docker_build.py
+++ b/tests/fast/test_docker_build.py
@@ -1,0 +1,184 @@
+import importlib.util
+import sys
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+
+DOCKER_DIR = Path(__file__).resolve().parents[2] / "docker"
+sys.path.insert(0, str(DOCKER_DIR))
+SPEC = importlib.util.spec_from_file_location("miles_docker_build", DOCKER_DIR / "build.py")
+assert SPEC is not None and SPEC.loader is not None
+docker_build = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(docker_build)
+
+
+def _option_value(command: list[str], option: str) -> str:
+    return command[command.index(option) + 1]
+
+
+def test_cuda_dockerfile_has_self_contained_wheel_fallback():
+    dockerfile = (DOCKER_DIR / "Dockerfile").read_text()
+    fallback_start = dockerfile.index("FROM sglang_base AS wheel_assets")
+    final_start = dockerfile.index("FROM sglang_base AS sglang\n")
+    fallback = dockerfile[fallback_start:final_start]
+
+    assert fallback_start < final_start
+    assert f"ARG WHEELS_REPO={docker_build.WHEELS_REPOSITORY}" in fallback
+    assert f"ARG WHEELS_TAG_X86={docker_build.VARIANTS['cu13']['wheel_releases']['amd64']}" in fallback
+    assert f"ARG WHEELS_TAG_ARM64={docker_build.VARIANTS['cu13']['wheel_releases']['arm64']}" in fallback
+    assert "COPY docker/wheel_cache.py /tmp/wheel_cache.py" in fallback
+    assert "python3 /tmp/wheel_cache.py" in fallback
+    assert "COPY --from=wheel_assets /${TARGETARCH}/ /tmp/wheels/" in dockerfile[final_start:]
+
+
+@pytest.mark.parametrize("build_fails", [False, True])
+def test_cuda_build_uses_wheel_snapshot_for_the_full_build(tmp_path, monkeypatch, build_fails):
+    cache_root = tmp_path / "cache"
+    snapshot = cache_root / "snapshots" / "test-snapshot"
+    observed = {}
+
+    @contextmanager
+    def fake_prepare(repository, releases, configured_cache_root):
+        assert repository == "yueming-yuan/miles-wheels"
+        assert releases == {
+            "amd64": "cu130-x86_64",
+            "arm64": "cu130-aarch64",
+        }
+        assert configured_cache_root == cache_root
+        snapshot.mkdir(parents=True)
+        try:
+            yield snapshot
+        finally:
+            snapshot.rmdir()
+
+    expected_error = RuntimeError("docker failed")
+
+    def fake_run(command, dry_run):
+        assert not dry_run
+        assert snapshot.is_dir()
+        observed["command"] = command
+        if build_fails:
+            raise expected_error
+
+    monkeypatch.setenv("MILES_DOCKER_CACHE_DIR", str(cache_root))
+    monkeypatch.setattr(docker_build, "prepare_wheel_context", fake_prepare)
+    monkeypatch.setattr(docker_build, "run", fake_run)
+
+    if build_fails:
+        with pytest.raises(RuntimeError) as raised:
+            docker_build.build_and_push(
+                "cu13",
+                "custom",
+                False,
+                "docker/Dockerfile",
+                push=True,
+                custom_tag="test",
+            )
+        assert raised.value is expected_error
+    else:
+        docker_build.build_and_push(
+            "cu13",
+            "custom",
+            False,
+            "docker/Dockerfile",
+            push=True,
+            custom_tag="test",
+        )
+
+    assert not snapshot.exists()
+    command = observed["command"]
+    assert _option_value(command, "--platform") == "linux/amd64,linux/arm64"
+    assert _option_value(command, "--build-context") == f"wheel_assets={snapshot}"
+    assert "--push" in command
+
+
+def test_cu12_build_uses_its_verified_wheel_snapshot(tmp_path, monkeypatch):
+    cache_root = tmp_path / "cache"
+    snapshot = cache_root / "snapshots" / "cu12-snapshot"
+    observed = {}
+
+    @contextmanager
+    def fake_prepare(repository, releases, configured_cache_root):
+        assert repository == "yueming-yuan/miles-wheels"
+        assert releases == {"amd64": "cu129-x86_64"}
+        assert configured_cache_root == cache_root
+        snapshot.mkdir(parents=True)
+        yield snapshot
+
+    monkeypatch.setenv("MILES_DOCKER_CACHE_DIR", str(cache_root))
+    monkeypatch.setattr(docker_build, "prepare_wheel_context", fake_prepare)
+    monkeypatch.setattr(
+        docker_build,
+        "run",
+        lambda command, dry_run: observed.update(command=command, dry_run=dry_run),
+    )
+
+    docker_build.build_and_push(
+        "cu12-x86",
+        "custom",
+        False,
+        "docker/Dockerfile",
+        custom_tag="test",
+    )
+
+    assert not observed["dry_run"]
+    assert _option_value(observed["command"], "--build-context") == f"wheel_assets={snapshot}"
+    assert "ENABLE_CUDA_13=0" in observed["command"]
+    assert "SGLANG_IMAGE_TAG=v0.5.16-cu129" in observed["command"]
+
+
+def test_rocm_build_does_not_prepare_cuda_wheels(monkeypatch):
+    observed = {}
+    monkeypatch.setattr(
+        docker_build,
+        "prepare_wheel_context",
+        lambda *args, **kwargs: pytest.fail("ROCm build must not prepare CUDA wheels"),
+    )
+    monkeypatch.setattr(
+        docker_build,
+        "run",
+        lambda command, dry_run: observed.update(command=command, dry_run=dry_run),
+    )
+
+    docker_build.build_and_push(
+        "rocm700-mi35x",
+        "custom",
+        False,
+        "docker/Dockerfile",
+        custom_tag="test",
+    )
+
+    assert not observed["dry_run"]
+    assert "--build-context" not in observed["command"]
+    assert _option_value(observed["command"], "-f") == "docker/Dockerfile.rocm"
+
+
+def test_cuda_dry_run_has_no_cache_io(tmp_path, monkeypatch):
+    cache_root = tmp_path / "cache"
+    observed = {}
+    monkeypatch.setenv("MILES_DOCKER_CACHE_DIR", str(cache_root))
+    monkeypatch.setattr(
+        docker_build,
+        "prepare_wheel_context",
+        lambda *args, **kwargs: pytest.fail("dry-run must not prepare wheels"),
+    )
+    monkeypatch.setattr(
+        docker_build,
+        "run",
+        lambda command, dry_run: observed.update(command=command, dry_run=dry_run),
+    )
+
+    docker_build.build_and_push(
+        "cu13-x86",
+        "custom",
+        True,
+        "docker/Dockerfile",
+        custom_tag="test",
+    )
+
+    assert observed["dry_run"]
+    assert _option_value(observed["command"], "--build-context") == (
+        f"wheel_assets={cache_root / 'snapshots' / 'DRY_RUN_CONTEXT'}"
+    )
+    assert not cache_root.exists()

--- a/tests/fast/test_wheel_cache.py
+++ b/tests/fast/test_wheel_cache.py
@@ -1,0 +1,271 @@
+import hashlib
+import importlib.util
+import io
+import json
+import os
+import sys
+import threading
+from pathlib import Path
+
+import pytest
+
+DOCKER_DIR = Path(__file__).resolve().parents[2] / "docker"
+SPEC = importlib.util.spec_from_file_location("miles_wheel_cache", DOCKER_DIR / "wheel_cache.py")
+assert SPEC is not None and SPEC.loader is not None
+wheel_cache = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = wheel_cache
+SPEC.loader.exec_module(wheel_cache)
+
+
+def _asset(content: bytes, name: str = "package.whl"):
+    return wheel_cache.ReleaseAsset(
+        name=name,
+        size=len(content),
+        sha256=hashlib.sha256(content).hexdigest(),
+        download_url=f"https://github.com/example/wheels/releases/download/tag/{name}",
+    )
+
+
+def _manifest_asset(content: bytes, **overrides):
+    asset = {
+        "name": "package.whl",
+        "state": "uploaded",
+        "size": len(content),
+        "digest": f"sha256:{hashlib.sha256(content).hexdigest()}",
+        "browser_download_url": "https://github.com/example/wheels/releases/download/tag/package.whl",
+    }
+    asset.update(overrides)
+    return asset
+
+
+def _response(payload) -> io.BytesIO:
+    return io.BytesIO(json.dumps(payload).encode())
+
+
+def test_fetch_release_assets_validates_manifest(monkeypatch):
+    content = b"wheel"
+    monkeypatch.setattr(
+        wheel_cache,
+        "_open",
+        lambda request: _response(
+            {
+                "assets": [
+                    _manifest_asset(content),
+                    _manifest_asset(b"ignored", name="notes.txt", digest=None),
+                ]
+            }
+        ),
+    )
+
+    assets = wheel_cache.fetch_release_assets("example/wheels", "cu130-x86_64")
+
+    assert assets == (_asset(content),)
+
+
+@pytest.mark.parametrize(
+    "asset, error",
+    [
+        (_manifest_asset(b"wheel", name="../package.whl"), "unsafe asset name"),
+        (_manifest_asset(b"wheel", size=-1), "invalid size"),
+        (_manifest_asset(b"wheel", digest=None), "missing SHA256 digest"),
+        (_manifest_asset(b"wheel", browser_download_url="http://example.com/package.whl"), "invalid download URL"),
+    ],
+)
+def test_fetch_release_assets_rejects_unsafe_manifest(monkeypatch, asset, error):
+    monkeypatch.setattr(wheel_cache, "_open", lambda request: _response({"assets": [asset]}))
+
+    with pytest.raises(wheel_cache.WheelCacheError, match=error):
+        wheel_cache.fetch_release_assets("example/wheels", "cu130-x86_64")
+
+
+@pytest.mark.parametrize(
+    "assets, error",
+    [
+        ([], "has no uploaded wheel assets"),
+        ([_manifest_asset(b"wheel"), _manifest_asset(b"wheel")], "duplicate asset name"),
+    ],
+)
+def test_fetch_release_assets_rejects_empty_or_duplicate_assets(monkeypatch, assets, error):
+    monkeypatch.setattr(wheel_cache, "_open", lambda request: _response({"assets": assets}))
+
+    with pytest.raises(wheel_cache.WheelCacheError, match=error):
+        wheel_cache.fetch_release_assets("example/wheels", "cu130-x86_64")
+
+
+def test_matching_cached_asset_is_reused(tmp_path, monkeypatch):
+    content = b"cached wheel"
+    asset = _asset(content)
+    target = tmp_path / asset.name
+    target.write_bytes(content)
+    monkeypatch.setattr(wheel_cache, "fetch_release_assets", lambda repository, tag: (asset,))
+    monkeypatch.setattr(
+        wheel_cache,
+        "_download_asset",
+        lambda asset, target: pytest.fail("matching cache entry must not be downloaded"),
+    )
+
+    paths, hits, downloads = wheel_cache.materialize_release("example/wheels", "tag", tmp_path)
+
+    assert paths == (target,)
+    assert (hits, downloads) == (1, 0)
+
+
+def test_mismatched_cached_asset_is_atomically_replaced(tmp_path, monkeypatch):
+    stale = b"stale wheel!"
+    fresh = b"fresh wheel!"
+    asset = _asset(fresh)
+    target = tmp_path / asset.name
+    target.write_bytes(stale)
+    monkeypatch.setattr(wheel_cache, "_open", lambda request: io.BytesIO(fresh))
+
+    real_replace = os.replace
+    replacements = []
+
+    def checked_replace(source, destination):
+        source = Path(source)
+        destination = Path(destination)
+        assert source.parent == destination.parent
+        assert hashlib.sha256(source.read_bytes()).hexdigest() == asset.sha256
+        assert destination.read_bytes() == stale
+        replacements.append((source, destination))
+        real_replace(source, destination)
+
+    monkeypatch.setattr(wheel_cache.os, "replace", checked_replace)
+
+    paths, hits, downloads = wheel_cache._cache_assets(tmp_path, (asset,))
+
+    assert paths == (target,)
+    assert (hits, downloads) == (0, 1)
+    assert target.read_bytes() == fresh
+    assert len(replacements) == 1
+    assert list(tmp_path.glob("*.part")) == []
+
+
+def test_bad_download_is_not_published(tmp_path, monkeypatch):
+    stale = b"stale wheel"
+    expected = b"fresh wheel"
+    asset = _asset(expected)
+    target = tmp_path / asset.name
+    target.write_bytes(stale)
+    monkeypatch.setattr(wheel_cache, "_open", lambda request: io.BytesIO(b"corrupt"))
+
+    with pytest.raises(wheel_cache.WheelCacheError, match="failed SHA256 validation"):
+        wheel_cache._cache_assets(tmp_path, (asset,))
+
+    assert target.read_bytes() == stale
+    assert list(tmp_path.glob("*.part")) == []
+
+
+@pytest.mark.parametrize("fail_inside_context", [False, True])
+def test_wheel_context_is_a_complete_physical_copy_and_is_always_cleaned(tmp_path, monkeypatch, fail_inside_context):
+    repository = "example/wheels"
+    releases = {
+        "amd64": "x86-tag",
+        "arm64": "arm-tag",
+    }
+    contents = {
+        "x86-tag": b"x86 wheel",
+        "arm-tag": b"arm wheel",
+    }
+    assets = {tag: _asset(content, f"{tag}.whl") for tag, content in contents.items()}
+    for target_arch, tag in releases.items():
+        cache_path = tmp_path / "wheels" / "example" / "wheels" / tag / target_arch / assets[tag].name
+        cache_path.parent.mkdir(parents=True)
+        cache_path.write_bytes(contents[tag])
+
+    monkeypatch.setattr(wheel_cache, "fetch_release_assets", lambda repository, tag: (assets[tag],))
+    monkeypatch.setattr(
+        wheel_cache,
+        "_download_asset",
+        lambda asset, target: pytest.fail("matching cache entry must not be downloaded"),
+    )
+
+    context_path = None
+    expected_error = RuntimeError("build failed")
+    try:
+        with wheel_cache.prepare_wheel_context(repository, releases, tmp_path) as context:
+            context_path = context
+            assert context.parent == tmp_path / "snapshots"
+            assert sorted(path.relative_to(context) for path in context.rglob("*") if path.is_file()) == [
+                Path("amd64/x86-tag.whl"),
+                Path("arm64/arm-tag.whl"),
+            ]
+            for target_arch, tag in releases.items():
+                cached = tmp_path / "wheels" / "example" / "wheels" / tag / target_arch / assets[tag].name
+                snapshot = context / target_arch / assets[tag].name
+                assert snapshot.read_bytes() == contents[tag]
+                assert snapshot.stat().st_ino != cached.stat().st_ino
+                cached.write_bytes(b"changed after snapshot")
+                assert snapshot.read_bytes() == contents[tag]
+            if fail_inside_context:
+                raise expected_error
+    except RuntimeError as error:
+        assert fail_inside_context
+        assert error is expected_error
+
+    assert context_path is not None
+    assert not context_path.exists()
+
+
+def test_concurrent_contexts_serialize_cache_refresh(tmp_path, monkeypatch):
+    content = b"shared wheel"
+    asset = _asset(content)
+    first_fetch_entered = threading.Event()
+    release_first_fetch = threading.Event()
+    second_fetch_entered = threading.Event()
+    fetch_count = 0
+    fetch_count_lock = threading.Lock()
+    download_count = 0
+
+    def fake_fetch(repository, tag):
+        nonlocal fetch_count
+        with fetch_count_lock:
+            fetch_count += 1
+            current_fetch = fetch_count
+        if current_fetch == 1:
+            first_fetch_entered.set()
+            assert release_first_fetch.wait(timeout=5)
+        else:
+            second_fetch_entered.set()
+        return (asset,)
+
+    def fake_open(request):
+        nonlocal download_count
+        download_count += 1
+        return io.BytesIO(content)
+
+    monkeypatch.setattr(wheel_cache, "fetch_release_assets", fake_fetch)
+    monkeypatch.setattr(wheel_cache, "_open", fake_open)
+
+    def prepare(started):
+        started.set()
+        with wheel_cache.prepare_wheel_context(
+            "example/wheels",
+            {"amd64": "x86-tag"},
+            tmp_path,
+        ) as context:
+            return (context / "amd64" / asset.name).read_bytes()
+
+    first_started = threading.Event()
+    second_started = threading.Event()
+    first_result = {}
+    second_result = {}
+
+    first_thread = threading.Thread(target=lambda: first_result.setdefault("value", prepare(first_started)))
+    second_thread = threading.Thread(target=lambda: second_result.setdefault("value", prepare(second_started)))
+    first_thread.start()
+    assert first_started.wait(timeout=5)
+    assert first_fetch_entered.wait(timeout=5)
+    second_thread.start()
+    assert second_started.wait(timeout=5)
+    assert not second_fetch_entered.wait(timeout=0.1)
+    release_first_fetch.set()
+    first_thread.join(timeout=5)
+    second_thread.join(timeout=5)
+
+    assert not first_thread.is_alive()
+    assert not second_thread.is_alive()
+    assert first_result["value"] == content
+    assert second_result["value"] == content
+    assert fetch_count == 2
+    assert download_count == 1


### PR DESCRIPTION
## Summary
Persist verified wheel releases across self-hosted Docker builds.

## Motivation
CI builds repeatedly download multi-gigabyte rolling wheel releases because temporary BuildKit builders do not retain them across jobs.

Persist each release asset on the self-hosted runner only after size and SHA256 verification. Copy a complete per-build snapshot into a named context so concurrent builds do not share mutable inputs, while retaining a self-contained Dockerfile download path for direct builds.

## Usage
Run `MILES_DOCKER_CACHE_DIR=/data/miles_ci/miles-docker-cache python docker/build.py --variant cu13 --image-tag dev --push`. The first build verifies and populates the cache; later builds reuse matching assets and pass an isolated snapshot to BuildKit.

A direct `docker buildx build -f docker/Dockerfile .` remains self-contained and downloads the architecture-specific release through the fallback `wheel_assets` stage.

## Design Notes
- **Key choices:** Validate both size and SHA256 before reuse.
- **Key choices:** Materialize a complete temporary snapshot per build before releasing the cache lock.
- **Key choices:** Override the Dockerfile fallback stage with a named context when `build.py` supplies cached assets.
- **Key choices:** Isolate wheel caches per runner to prevent cross-runner cache races.

## Verification
- **Tests added:** `test_matching_cache_entry_is_reused` verifies a matching SHA256 cache hit.
- **Tests added:** `test_mismatched_cache_entry_is_redownloaded` verifies atomic replacement of a corrupt file.
- **Tests added:** `test_concurrent_contexts_serialize_cache_refresh` verifies release-lock serialization.
- **Tests added:** `test_cuda_build_uses_wheel_snapshot_for_the_full_build` verifies the isolated named context.
- **Tests added:** `test_cu12_build_uses_its_verified_wheel_snapshot` verifies the cu12 release mapping.
- **CI baseline:** [The prior in-BuildKit wheel path](https://github.com/radixark/miles/actions/runs/30411184419/job/90447450906) spent 33m34s downloading arm64 wheel assets within a 108m33s build step.
- **CI validation:** The host-prefetched build step completed in [40m45s cold-cache](https://github.com/radixark/miles/actions/runs/30492549550/job/90713941137) / [41m21s warm-cache](https://github.com/radixark/miles/actions/runs/30492549550/job/90739133295).
- **Local checks:** The focused suite passed 19 tests.
- **Local checks:** Every applicable pre-commit hook passed.

## Review Focus
- Scrutinize `materialize_release` integrity semantics under rolling releases.
- Scrutinize the `wheel_assets` stage override between `docker/Dockerfile` and `docker/build.py`.
- Scrutinize `/data/miles_ci/miles-docker-cache` concurrency assumptions on the self-hosted runner.
