### PR TITLE
refactor: move DeepSeek thinking kwarg aliases

### DIFF
--- a/miles/utils/chat_template_utils/deepseek.py
+++ b/miles/utils/chat_template_utils/deepseek.py
@@ -21,6 +21,8 @@ from sglang.srt.entrypoints.openai.protocol import Tool
 
 from miles.utils.chat_template_utils.templates import encoding_dsv32
 
+THINKING_MODE_KWARG_ALIASES = frozenset({"thinking_mode", "enable_thinking", "thinking"})
+
 _ASSISTANT_SP_TOKEN = "<｜Assistant｜>"
 
 

--- a/miles/utils/chat_template_utils/tito_tokenizer.py
+++ b/miles/utils/chat_template_utils/tito_tokenizer.py
@@ -590,8 +590,6 @@ class MinimaxM27TITOTokenizer(MinimaxM25TITOTokenizer):
 # DeepSeek V3.2 implementation
 # ---------------------------------------------------------------------------
 
-_DEEPSEEK_MODE_KWARG_ALIASES = frozenset({"thinking_mode", "enable_thinking", "thinking"})
-
 
 class DeepSeekV32TITOTokenizer(TITOTokenizer):
     """DeepSeek V3.2 — miles' vendored copy of the official ``encoding_dsv32``.
@@ -612,7 +610,7 @@ class DeepSeekV32TITOTokenizer(TITOTokenizer):
 
     reasoning_parser = "deepseek-v3"
     tool_call_parser = "deepseekv32"
-    chat_template_kwarg_aliases = _DEEPSEEK_MODE_KWARG_ALIASES
+    chat_template_kwarg_aliases = deepseek.THINKING_MODE_KWARG_ALIASES
 
     FIXED_TEMPLATE = FixedTemplate(
         template=None,
@@ -661,7 +659,7 @@ class DeepSeekV4TITOTokenizer(TITOTokenizer):
 
     reasoning_parser = "deepseek-v4"
     tool_call_parser = "deepseekv4"
-    chat_template_kwarg_aliases = _DEEPSEEK_MODE_KWARG_ALIASES
+    chat_template_kwarg_aliases = deepseek.THINKING_MODE_KWARG_ALIASES
 
     FIXED_TEMPLATE = FixedTemplate(
         template=None,


### PR DESCRIPTION
## Summary

Move DeepSeek thinking-mode alias vocabulary next to its resolver.

## Motivation

Keep the DeepSeek thinking-mode alias vocabulary next to the resolver that defines it. Preserve TITO's request-layer merge policy and observable behavior.

## Before / After

- **Before / After:** The alias vocabulary moved from `tito_tokenizer.py` to `deepseek.py`; its immutable value is unchanged.
- **What moved where:** `DeepSeekV32TITOTokenizer` and `DeepSeekV4TITOTokenizer` now reference `deepseek.THINKING_MODE_KWARG_ALIASES`.

## Behavior Preservation

- **How we know:** Existing request-override tests pass for DeepSeek V3.2.
- Existing request-override tests pass for DeepSeek V4.
- DeepSeek alias-resolution tests pass for DeepSeek V3.2.
- DeepSeek alias-resolution tests pass for DeepSeek V4.

## Verification

- **Existing test suite:** Six focused DeepSeek tests passed.
- Black passed for both modified files.
- Ruff passed for both modified files.

## Review Focus

- Scrutinize `THINKING_MODE_KWARG_ALIASES` ownership in `deepseek.py`.
- Scrutinize its two consumers in `tito_tokenizer.py`.
