### PR TITLE
docker: keep the cu12 dependency markers after checking out sglang-miles

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -191,12 +191,22 @@ RUN rm -rf /root/.cache/pip /root/flash-attention
 # ====================================== Install sglang-miles ============================================
 
 # Install sglang from sglang-miles branch
+# The CUDA 12 sglang images sed their dependency markers from cu13 to cu12 in
+# python/pyproject.toml and never commit it, so a plain checkout aborts on the dirty
+# file. Force it, then re-apply the same rewrite: the tree we just checked out carries
+# the cu13 markers, and sglang's editable install makes them visible to every later pip
+# resolve, which would drag cu13 packages onto a cu12 image.
 RUN cd /sgl-workspace/sglang && \
     git fetch origin ${SGLANG_BRANCH} && \
     if [ -n "${SGLANG_COMMIT}" ]; then \
-      git checkout ${SGLANG_COMMIT}; \
+      git checkout -f ${SGLANG_COMMIT}; \
     else \
-      git checkout FETCH_HEAD; \
+      git checkout -f FETCH_HEAD; \
+    fi && \
+    if [ "${ENABLE_CUDA_13}" != "1" ]; then \
+      sed -i 's/cuda-python>=13\.0/cuda-python>=12,<13/' python/pyproject.toml && \
+      sed -i 's/flashinfer_python\[cu13\]/flashinfer_python[cu12]/' python/pyproject.toml && \
+      sed -i 's/nvidia-cutlass-dsl\[cu13\]/nvidia-cutlass-dsl/' python/pyproject.toml; \
     fi && \
     pip install -e "python[all]" --no-deps
 


### PR DESCRIPTION
## What breaks

`Docker Build & Push` on main fails at `Install sglang-miles`:

```
#38 [sglang 33/39] RUN cd /sgl-workspace/sglang && git fetch origin sglang-miles && ...
 * branch            sglang-miles -> FETCH_HEAD
error: Your local changes to the following files would be overwritten by checkout:
	python/pyproject.toml
Please commit your changes or stash them before you switch branches.
```

First failure: [run 30491453615](https://github.com/radixark/miles/actions/runs/30491453615) (the first release build after #1795).

## Why

sglang's own Dockerfile rewrites the dependency markers in place for CUDA 12 images and never commits the result:

```dockerfile
# sgl-project/sglang, docker/Dockerfile @ v0.5.16, L713
cd /sgl-workspace/sglang \
&& if [ "${CUDA_VERSION%%.*}" = "12" ]; then \
       sed -i 's/cuda-python>=13\.0/cuda-python>=12,<13/' python/pyproject.toml && \
       sed -i 's/flashinfer_python\[cu13\]/flashinfer_python[cu12]/' python/pyproject.toml && \
       sed -i 's/nvidia-cutlass-dsl\[cu13\]/nvidia-cutlass-dsl/' python/pyproject.toml; \
   fi \
&& python3 -m pip install --no-deps -e "python[${BUILD_TYPE}]"
```

So `v0.5.16-cu129` ships a dirty working tree and our checkout aborts. The release build is the only path that hits this: it pins `SGLANG_IMAGE_TAG=v0.5.16-cu129` in `docker/build.py`, while PR CI uses the default `v0.5.16` (cu130), which builds with `CUDA_VERSION=13.0.1` and never runs that rewrite. `v0.5.15-cu129` was clean, so this is new in the v0.5.16 CUDA 12 image rather than a regression in our tree.

## The fix

Force the checkout, then re-apply the same three rewrites when `ENABLE_CUDA_13 != 1`.

Forcing on its own is not enough. The tree we check out carries the cu13 markers, `pip install -e` publishes them as sglang's installed metadata, and every later pip resolve then sees unsatisfied cu13 requirements on a cu12 image — the same mechanism that silently downgraded cuDNN in #1836.

## Checks

- The three sed patterns match `sglang-miles`'s `python/pyproject.toml` (lines 26, 34, 48) and rewrite exactly those three lines.
- `humming-kernels[cu13]` is left alone, matching upstream — sglang's own build does not rewrite it either.
- `sglang-miles` differs from the `v0.5.16` tag in this file only by adding `xxhash`, so after the rewrite the tree matches the base image's dependency markers plus that one addition.