### PR TITLE
dashboard: fix phase visibility for manager events and idle processes

### DIFF
--- a/miles/dashboard/hooks.py
+++ b/miles/dashboard/hooks.py
@@ -77,6 +77,7 @@ class PhaseSink:
         self._last_flush = time.monotonic()
         self._identity: _Identity | None = None
         self._warner = RateLimitedWarner(logger)
+        self._flusher = None
 
     def begin(self, name: str, t0: float) -> None:
         """Timer.start notification: push an OPEN interval immediately (no
@@ -120,6 +121,7 @@ class PhaseSink:
                     )
                 )
                 batch = self._take_batch_if_due()
+            self._ensure_flusher()
             if batch:
                 self._handle.push_phases.remote(batch)
         except Exception:
@@ -140,6 +142,26 @@ class PhaseSink:
                 self._handle.push_phases.remote(batch)
         except Exception:
             self._warner.warn("dashboard phase sink flush failed; dropping events")
+
+    def _ensure_flusher(self) -> None:
+        """Background flush: _take_batch_if_due only runs when a new event
+        arrives, so on a process that goes idle (train ranks during a
+        shared-engine eval) the closing events of its last phases sit in the
+        buffer indefinitely and the UI shows them as still-open."""
+        if self._flusher is not None:
+            return
+        import threading
+
+        def _loop():
+            while True:
+                time.sleep(BATCH_MAX_SECONDS)
+                with self._lock:
+                    due = bool(self._buffer)
+                if due:
+                    self.flush()
+
+        self._flusher = threading.Thread(target=_loop, daemon=True, name="dashboard-phase-flush")
+        self._flusher.start()
 
 
 class TrajectorySink:

--- a/miles/dashboard/store.py
+++ b/miles/dashboard/store.py
@@ -871,6 +871,13 @@ class MetricStore:
                     if clip1 >= 0 and clip0 >= clip1:
                         continue
                     covered = {(node, gpu) for engine in window["engines"] for node, gpu in engine["gpus"]}
+                    if not covered:
+                        # External engines register without GPU identity; fall
+                        # back to every known lane on the engines' nodes.
+                        engine_nodes = {engine["addr"].split("//")[-1].split(":")[0] for engine in window["engines"]}
+                        covered = {
+                            (lane["node"], lane["gpu"]) for lane in self.lanes() if lane["node"] in engine_nodes
+                        }
                     if lanes is not None:
                         covered &= lanes
                     for node, gpu in sorted(covered):

--- a/miles/dashboard/store.py
+++ b/miles/dashboard/store.py
@@ -862,8 +862,13 @@ class MetricStore:
             if event.role == Role.ROLLOUT_MANAGER:
                 for window in windows:
                     clip0 = max(event.t0, window["t0"])
-                    clip1 = event.t1 if window["t1"] is None else min(event.t1, window["t1"])
-                    if clip0 >= clip1:
+                    if event.t1 < 0:
+                        # still-open interval: extends to the window edge (the
+                        # renderer draws open t1=-1 through to "now")
+                        clip1 = -1.0 if window["t1"] is None else window["t1"]
+                    else:
+                        clip1 = event.t1 if window["t1"] is None else min(event.t1, window["t1"])
+                    if clip1 >= 0 and clip0 >= clip1:
                         continue
                     covered = {(node, gpu) for engine in window["engines"] for node, gpu in engine["gpus"]}
                     if lanes is not None:


### PR DESCRIPTION
Two timeline bugs that together made a fully-async run's step-0 eval invisible
and mislabeled: the utilization view showed the initial weight sync's
`finalize_and_resume_engines` / `update_weights_implementation` bars stretching
across the entire eval period, with no eval band at all.

**1. Open `rollout_manager` phases were dropped.** `phases_by_lane` fans
manager-role events (e.g. `eval_rollout`) across engine lanes, but its window
clipping used `t1` directly; a still-open interval carries `t1 = -1`, so
`clip0 >= clip1` always held and the event vanished — an eval only appeared
after it finished. Train-role events already render open intervals through to
"now"; manager events now get the same semantics (open events extend to the
window edge and keep `t1 = -1` for the renderer).

**2. Engines registered without GPU identity got no lanes.** External-worker
topology snapshots carry `gpus: []`, leaving the manager fan-out with an empty
cover set even for closed intervals. When that happens the event now falls back
to every known lane on the engines' nodes (parsed from the engine address).

**3. Phase-close events from idle processes never flushed.** `PhaseSink`
batches closing events and only checks `_take_batch_if_due` when a *new* event
arrives. A process that goes quiet — train ranks during a shared-engine eval —
leaves its last closes (`update_weights`, `finalize_and_resume_engines`) in the
buffer indefinitely, and the UI draws them as still-open bars across the idle
period. A daemon thread now flushes the buffer every `BATCH_MAX_SECONDS`.

Verified on a live GLM-5.2 16x-GB300 fully-async run: before, `eval_rollout`
was absent from `/api/timeline/phases` and the weight-sync bars ran to the
right edge; after (serve restart only, fixes 1–2), the eval band renders on all
12 engine lanes with correct bounds. `tests/fast/dashboard`: 185 passed.
