### PR TITLE
[Bug Fix] Always release rollout-engine broadcast lock on failure

### DIFF
--- a/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/broadcast.py
+++ b/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/broadcast.py
@@ -105,21 +105,24 @@ class UpdateWeightFromDistributed(DistBucketedWeightUpdateMixin):
     def _update_weight_implementation(
         self, converted_named_tensors: list[tuple[str, torch.Tensor]], pbar: tqdm | None = None
     ) -> None:
-        """Lock → broadcast → clear → unlock. Lock prevents NCCL deadlock."""
-        # lock the rollout engines to prevent dead lock on broadcast.
+        """Serialize NCCL broadcasts and always release the rollout lock."""
         while not ray.get(self.rollout_engine_lock.acquire.remote()):
             time.sleep(0.1)
-        refs = update_weights_from_distributed(
-            self._group_name,
-            self._model_update_groups,
-            self.weight_version,
-            self.rollout_engines,
-            converted_named_tensors,
-            selector=self._weight_update_selector,
-        )
-        ray.get(refs)
-        converted_named_tensors.clear()
-        ray.get(self.rollout_engine_lock.release.remote())
+        try:
+            refs = update_weights_from_distributed(
+                self._group_name,
+                self._model_update_groups,
+                self.weight_version,
+                self.rollout_engines,
+                converted_named_tensors,
+                selector=self._weight_update_selector,
+            )
+            ray.get(refs)
+            converted_named_tensors.clear()
+        finally:
+            # Leaking this lock makes the next weight sync poll forever, so the
+            # release must run after both successful and failed broadcasts.
+            ray.get(self.rollout_engine_lock.release.remote())
         if pbar:
             pbar.update(1)
 

--- a/tests/fast/backends/megatron_utils/test_update_weight_from_distributed_lock.py
+++ b/tests/fast/backends/megatron_utils/test_update_weight_from_distributed_lock.py
@@ -1,0 +1,175 @@
+"""Mock-based tests for the rollout-engine lock lifecycle in
+update_weight_from_distributed/broadcast.py.
+
+Lock.acquire (miles/ray/utils.py) is polled until it returns True, so a
+broadcast failure that skips the release makes every later weight sync spin
+forever. These tests pin lock contention, argument forwarding, and release on
+the success path and both failure paths (broadcast setup and engine-side
+completion).
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+
+from miles.backends.megatron_utils.update_weight.update_weight_from_distributed.broadcast import (
+    UpdateWeightFromDistributed,
+)
+
+_MODULE = "miles.backends.megatron_utils.update_weight.update_weight_from_distributed.broadcast"
+
+
+class _LockState:
+    """In-process stand-in for the miles.ray.utils.Lock actor."""
+
+    def __init__(self):
+        self.locked = False
+        self.release_calls = 0
+
+    def acquire(self):
+        if self.locked:
+            return False
+        self.locked = True
+        return True
+
+    def release(self):
+        # Mirrors the real actor: releasing an unheld lock is a bug.
+        assert self.locked, "Lock is not acquired, cannot release."
+        self.release_calls += 1
+        self.locked = False
+
+
+def _make_updater(lock_state: _LockState) -> UpdateWeightFromDistributed:
+    updater = object.__new__(UpdateWeightFromDistributed)
+    lock_handle = MagicMock()
+    lock_handle.acquire.remote.side_effect = lock_state.acquire
+    lock_handle.release.remote.side_effect = lock_state.release
+    updater.rollout_engine_lock = lock_handle
+    updater._group_name = "miles-pp_0"
+    updater._model_update_groups = MagicMock()
+    updater.weight_version = 0
+    updater.rollout_engines = [MagicMock()]
+    updater._weight_update_selector = "all"
+    return updater
+
+
+def _passthrough_ray_get(mock_ray, fail_on=None):
+    """ray.get returns its argument, or raises when handed the sentinel."""
+
+    def _get(ref):
+        if fail_on is not None and ref is fail_on:
+            raise RuntimeError("engine died during broadcast")
+        return ref
+
+    mock_ray.get.side_effect = _get
+
+
+def _named_tensors() -> list[tuple[str, torch.Tensor]]:
+    return [("layer.weight", torch.zeros(2, 2))]
+
+
+@patch(f"{_MODULE}.update_weights_from_distributed")
+@patch(f"{_MODULE}.ray")
+def test_success_path_releases_lock_and_clears_tensors(mock_ray, mock_update):
+    lock_state = _LockState()
+    _passthrough_ray_get(mock_ray)
+    mock_update.return_value = [MagicMock()]
+    updater = _make_updater(lock_state)
+    tensors = _named_tensors()
+    pbar = MagicMock()
+
+    updater._update_weight_implementation(tensors, pbar)
+
+    assert lock_state.locked is False
+    assert lock_state.release_calls == 1
+    assert tensors == []
+    pbar.update.assert_called_once_with(1)
+    call_args = mock_update.call_args.args
+    assert call_args[:4] == (
+        updater._group_name,
+        updater._model_update_groups,
+        updater.weight_version,
+        updater.rollout_engines,
+    )
+    assert call_args[4] is tensors
+    assert mock_update.call_args.kwargs == {"selector": "all"}
+
+
+@patch(f"{_MODULE}.time.sleep")
+@patch(f"{_MODULE}.update_weights_from_distributed")
+@patch(f"{_MODULE}.ray")
+def test_lock_contention_is_polled_until_acquired(mock_ray, mock_update, mock_sleep):
+    lock_state = _LockState()
+    lock_state.locked = True
+    _passthrough_ray_get(mock_ray)
+    mock_update.return_value = [MagicMock()]
+    updater = _make_updater(lock_state)
+
+    mock_sleep.side_effect = lambda _seconds: setattr(lock_state, "locked", False)
+
+    updater._update_weight_implementation(_named_tensors(), pbar=None)
+
+    mock_sleep.assert_called_once_with(0.1)
+    assert lock_state.locked is False
+    assert lock_state.release_calls == 1
+
+
+@patch(f"{_MODULE}.update_weights_from_distributed")
+@patch(f"{_MODULE}.ray")
+def test_broadcast_failure_releases_lock_and_propagates(mock_ray, mock_update):
+    lock_state = _LockState()
+    _passthrough_ray_get(mock_ray)
+    mock_update.side_effect = RuntimeError("NCCL broadcast failed")
+    updater = _make_updater(lock_state)
+    tensors = _named_tensors()
+    pbar = MagicMock()
+
+    with pytest.raises(RuntimeError, match="NCCL broadcast failed"):
+        updater._update_weight_implementation(tensors, pbar)
+
+    assert lock_state.locked is False
+    assert lock_state.release_calls == 1
+    assert len(tensors) == 1  # nothing was cleared on the failure path
+    pbar.update.assert_not_called()
+
+
+@patch(f"{_MODULE}.update_weights_from_distributed")
+@patch(f"{_MODULE}.ray")
+def test_engine_failure_on_refs_releases_lock_and_propagates(mock_ray, mock_update):
+    lock_state = _LockState()
+    failing_refs = [MagicMock()]
+    _passthrough_ray_get(mock_ray, fail_on=failing_refs)
+    mock_update.return_value = failing_refs
+    updater = _make_updater(lock_state)
+
+    with pytest.raises(RuntimeError, match="engine died during broadcast"):
+        updater._update_weight_implementation(_named_tensors(), pbar=None)
+
+    assert lock_state.locked is False
+    assert lock_state.release_calls == 1
+
+
+@patch(f"{_MODULE}.update_weights_from_distributed")
+@patch(f"{_MODULE}.ray")
+def test_weight_sync_succeeds_after_a_failed_one(mock_ray, mock_update):
+    lock_state = _LockState()
+    _passthrough_ray_get(mock_ray)
+    mock_update.side_effect = RuntimeError("NCCL broadcast failed")
+    updater = _make_updater(lock_state)
+
+    with pytest.raises(RuntimeError):
+        updater._update_weight_implementation(_named_tensors(), pbar=None)
+
+    # Guard before retrying: with a leaked lock the retry below would poll
+    # acquire() forever instead of failing, so assert the release explicitly.
+    assert lock_state.locked is False
+
+    mock_update.side_effect = None
+    mock_update.return_value = [MagicMock()]
+    tensors = _named_tensors()
+    updater._update_weight_implementation(tensors, pbar=None)
+
+    assert tensors == []
+    assert lock_state.locked is False
+    assert lock_state.release_calls == 2


### PR DESCRIPTION
## Motivation

`_update_weight_implementation` acquires a shared rollout-engine lock before starting a distributed weight broadcast. Previously, an exception during broadcast setup or while waiting for rollout-engine completion skipped the release.

Because `Lock.acquire()` is polled until it succeeds, a leaked lock makes the next weight sync wait forever and hides the original failure.

## What's in this PR

- Wrap broadcast submission and completion in `try/finally`.
- Release the rollout-engine lock after every successful acquire.
- Preserve success-path ordering:
  - Converted tensors are cleared only after broadcast completion.
  - The progress bar advances only after a completed sync.
- Preserve the original broadcast exception when lock release succeeds.
- Cover successful sync, lock contention, setup failure, engine-side failure, retry after failure, and argument forwarding.

## Validation

- Reran the official fully-async training recipe on an NVIDIA H200 GPU cluster through repeated weight synchronizations; training completed successfully.
- Failure-path coverage verifies that both submission and engine-side exceptions release the lock and remain visible to the caller.
