### PR TITLE
[OPD] Accelerate external Top-K scoring with position-blocked candidate unions

### DIFF
--- a/docs/advanced/on-policy-distillation.md
+++ b/docs/advanced/on-policy-distillation.md
@@ -12,6 +12,10 @@ On-policy distillation (OPD) trains a student model on its own rollouts while us
 | `--opd-log-prob-top-k` | Number of top-k tokens retained for the Rethinking OPD token reward. `0` uses sampled-token OPD; `16` matches the paper recipe default. |
 | `--opd-top-k-strategy` | Top-k token set strategy: `only-student`, `only-teacher`, `intersection`, `union`, or `xor`. |
 | `--opd-reward-weight-mode` | Weighting scheme for top-k rewards: `student_p`, `teacher_p`, or `none`. |
+| `--opd-top-k-scoring-block-size` | Response positions grouped into one arbitrary-ID scoring request for `only-student` and `only-teacher` (default: `32`). `0` restores the legacy response-wide candidate union. |
+| `--opd-scoring-timeout` | Total deadline in seconds for one external scoring request, including in-flight queueing, retries, and transport (default: `600`). |
+| `--opd-scoring-max-inflight` | Maximum concurrent external scoring requests per process (default: `8`). `0` disables the bound. |
+| `--opd-scoring-retries` | Number of retries for a failed external request or a mixed-version blocked student-scoring attempt (default: `1`). Each external request retains its own total deadline; `0` fails after the first attempt. |
 | `--opd-teacher-load` | Path to teacher Megatron checkpoint. **Required** when `--opd-type=megatron`, **must not be set** when `--opd-type=sglang`. |
 | `--opd-teacher-ckpt-step` | Optional checkpoint step for teacher model. |
 
@@ -43,6 +47,12 @@ The token set is controlled by `--opd-top-k-strategy`:
 
 `--opd-reward-weight-mode` controls whether each selected token is weighted by student probability, teacher probability, or uniformly. For compatibility, `--opd-log-prob-top-k=0` keeps the original sampled-token OPD path.
 
+For `only-student` and `only-teacher`, Miles keeps each model's native per-position candidate rows. The opposite model is scored in bounded response-position blocks instead of receiving one union of candidate IDs from the entire response. A block of `B` positions contains at most `B*K` candidate IDs, and its result is immediately compacted back to `B*K` position-local values. This preserves the existing top-k reward exactly while preventing one long response from materializing the full response-by-global-union Cartesian product. Smaller blocks reduce response size but issue more prefix-scoring requests; SGLang's prefix cache can reuse the shared prefixes. This bounds the candidate-logprob response, not the total request body: each block still sends the growing input prefix, so smaller blocks trade candidate response size for more repeated input-ID transfer and request scheduling.
+
+For `only-teacher`, the bounded requests target the mutable student rollout router. Miles treats all blocks for one sample as an optimistic version transaction: it reads `/model_info` before the first block and accepts the assembled result only when every block reports that same `meta_info.weight_version`. If a fully asynchronous weight update lands between blocks, all partial rows are discarded and the complete student-scoring transaction is retried within `--opd-scoring-retries`; exhausting the retry budget fails loudly instead of training on mixed-version scores.
+
+With SGLang's `pause_generation_mode=retract`, an update also clears a running request's KV and accumulated input logprobs before re-prefilling it under the new weights. The transaction check adds the missing cross-request invariant: every accepted block now comes from one student snapshot. A weight update after the last block is harmless; the accepted snapshot is merely stale, which is an expected property of fully asynchronous training.
+
 ## Two Teacher Modes
 
 ### SGLang Mode (`--opd-type sglang`)
@@ -65,6 +75,7 @@ The teacher runs on an external SGLang server. Teacher log-probs are obtained du
 --opd-kl-coef 1.0
 --opd-log-prob-top-k 16
 --opd-top-k-strategy only-student
+--opd-top-k-scoring-block-size 32
 --opd-reward-weight-mode student_p
 --custom-rm-path miles.rollout.on_policy_distillation.reward_func
 --custom-reward-post-process-path miles.rollout.on_policy_distillation.post_process_rewards

--- a/examples/on_policy_distillation/README.md
+++ b/examples/on_policy_distillation/README.md
@@ -9,7 +9,28 @@ This directory contains runnable examples:
 
 - `run-qwen3-8B-opd.sh`: SGLang teacher server OPD. This script enables
   Rethinking OPD with `--opd-log-prob-top-k 16`, `--opd-top-k-strategy only-student`,
-  and `--opd-reward-weight-mode student_p`.
+  `--opd-top-k-scoring-block-size 32`, and `--opd-reward-weight-mode student_p`.
 - `run-qwen3-8B-opd-megatron.sh`: Megatron-loaded teacher OPD.
 
 Use `--opd-log-prob-top-k 0` to run the original sampled-token OPD path.
+
+The SGLang example uses Qwen3-8B as the student and Qwen3-32B as the teacher.
+Use the same official script for the two control/treatment pairs:
+
+```bash
+# Student candidate set: legacy global union, then position blocks.
+OPD_TOP_K_STRATEGY=only-student OPD_TOP_K_SCORING_BLOCK_SIZE=0 \
+  bash examples/on_policy_distillation/run-qwen3-8B-opd.sh
+OPD_TOP_K_STRATEGY=only-student OPD_TOP_K_SCORING_BLOCK_SIZE=32 \
+  bash examples/on_policy_distillation/run-qwen3-8B-opd.sh
+
+# Teacher candidate set: legacy global union, then position blocks.
+OPD_TOP_K_STRATEGY=only-teacher OPD_TOP_K_SCORING_BLOCK_SIZE=0 \
+  bash examples/on_policy_distillation/run-qwen3-8B-opd.sh
+OPD_TOP_K_STRATEGY=only-teacher OPD_TOP_K_SCORING_BLOCK_SIZE=32 \
+  bash examples/on_policy_distillation/run-qwen3-8B-opd.sh
+```
+
+`OPD_TOP_K`, `OPD_TOP_K_STRATEGY`, and `OPD_TOP_K_SCORING_BLOCK_SIZE` are environment overrides for controlled comparisons. Set `OPD_TOP_K_SCORING_BLOCK_SIZE=0` only when reproducing the legacy response-wide candidate union.
+
+For `only-teacher`, blocked opposite-model rescoring snapshots the student router's current weight version and accepts the assembled rows only when every block reports that version. A version change discards the partial rows and retries the complete student-scoring transaction; retry exhaustion fails instead of emitting mixed-version scores. This makes the blocked path safe to compose with fully asynchronous rollout while preserving its normal stale-data semantics.

--- a/examples/on_policy_distillation/run-qwen3-8B-opd.sh
+++ b/examples/on_policy_distillation/run-qwen3-8B-opd.sh
@@ -46,6 +46,10 @@ echo "HAS_NVLINK: $HAS_NVLINK (detected $NVLINK_COUNT NVLink references)"
 
 source "/root/miles/scripts/models/qwen3-8B.sh"
 
+OPD_TOP_K=${OPD_TOP_K:-16}
+OPD_TOP_K_STRATEGY=${OPD_TOP_K_STRATEGY:-only-student}
+OPD_TOP_K_SCORING_BLOCK_SIZE=${OPD_TOP_K_SCORING_BLOCK_SIZE:-32}
+
 
 CKPT_ARGS=(
    --hf-checkpoint /root/Qwen3-8B
@@ -106,8 +110,9 @@ GRPO_ARGS=(
    --use-opd
    --opd-type sglang
    --opd-kl-coef 1.0
-   --opd-log-prob-top-k 16
-   --opd-top-k-strategy only-student
+   --opd-log-prob-top-k "${OPD_TOP_K}"
+   --opd-top-k-strategy "${OPD_TOP_K_STRATEGY}"
+   --opd-top-k-scoring-block-size "${OPD_TOP_K_SCORING_BLOCK_SIZE}"
    --opd-reward-weight-mode student_p
    --use-kl-loss
    --kl-loss-coef 0.00
@@ -187,7 +192,6 @@ pkill -9 python
 sleep 3
 pkill -9 ray
 pkill -9 python
-
 
 
 

--- a/miles/rollout/on_policy_distillation.py
+++ b/miles/rollout/on_policy_distillation.py
@@ -1,11 +1,15 @@
+import asyncio
 import math
+import time
+import weakref
 from argparse import Namespace
 from collections.abc import Iterable
 from typing import Any
 
-import aiohttp
+import httpx
 import torch
 
+from miles.utils.http_utils import post
 from miles.utils.types import Sample
 
 TopLogprobs = list[list[Any]]
@@ -13,6 +17,12 @@ LogprobMaps = list[dict[int, float]]
 
 TOP_K_STRATEGIES = {"only-student", "only-teacher", "intersection", "union", "xor"}
 REWARD_WEIGHT_MODES = {"student_p", "teacher_p", "none"}
+
+_SCORING_RETRY_BACKOFF_S = 2.0
+
+# One semaphore per (event loop, limit) so the in-flight bound is scoped to the
+# loop actually issuing the requests and follows a changed CLI limit.
+_SCORING_SEMAPHORES: weakref.WeakKeyDictionary = weakref.WeakKeyDictionary()
 
 STUDENT_TOP_STRATEGIES = TOP_K_STRATEGIES - {"only-teacher"}
 TEACHER_TOP_STRATEGIES = TOP_K_STRATEGIES - {"only-student"}
@@ -38,7 +48,27 @@ def _get_reward_weight_mode(args: Namespace) -> str:
     return mode
 
 
-def _score_payload(input_ids: list[int], top_k: int = 0, token_ids: list[int] | None = None) -> dict[str, Any]:
+def _get_top_k_scoring_block_size(args: Namespace) -> int:
+    return max(0, int(args.opd_top_k_scoring_block_size))
+
+
+def _score_payload(
+    input_ids: list[int],
+    response_length: int,
+    top_k: int = 0,
+    token_ids: list[int] | None = None,
+) -> dict[str, Any]:
+    if not 0 <= response_length <= len(input_ids):
+        raise ValueError(
+            f"OPD scoring response window is out of bounds: response_length={response_length}, "
+            f"tokens={len(input_ids)}."
+        )
+    prompt_length = len(input_ids) - response_length
+    if prompt_length <= 0:
+        raise ValueError(
+            "OPD scoring needs at least one prompt token before the response window: "
+            f"tokens={len(input_ids)}, response_length={response_length}."
+        )
     payload = {
         "input_ids": input_ids,
         "sampling_params": {
@@ -47,7 +77,12 @@ def _score_payload(input_ids: list[int], top_k: int = 0, token_ids: list[int] | 
             "skip_special_tokens": False,
         },
         "return_logprob": True,
-        "logprob_start_len": 0,
+        # SGLang aligns input logprobs to tokens from logprob_start_len, with a
+        # placeholder first entry. Keep the complete prefix in input_ids, but
+        # only materialize logprobs from one token before the response so the
+        # reply covers exactly the response window (see
+        # generate_utils/prefill_logprobs.py for the same convention).
+        "logprob_start_len": prompt_length - 1,
     }
     if top_k > 0:
         payload["top_logprobs_num"] = top_k
@@ -60,11 +95,116 @@ def _student_score_url(args: Namespace) -> str:
     return f"http://{args.sglang_router_ip}:{args.sglang_router_port}/generate"
 
 
-async def _post_json(url: str, payload: dict[str, Any]) -> dict[str, Any]:
-    async with aiohttp.ClientSession() as session:
-        async with session.post(url, json=payload) as resp:
-            resp.raise_for_status()
-            return await resp.json()
+def _scoring_semaphore(args: Namespace) -> asyncio.Semaphore | None:
+    """Bound concurrent scoring requests per event loop.
+
+    A whole rollout batch finishes generation together, so without a bound
+    every sample's scoring request dogpiles the external server at once and
+    queue time burns each request's deadline.
+    """
+    limit = int(args.opd_scoring_max_inflight)
+    if limit <= 0:
+        return None
+    loop = asyncio.get_running_loop()
+    semaphores_by_limit = _SCORING_SEMAPHORES.setdefault(loop, {})
+    semaphore = semaphores_by_limit.get(limit)
+    if semaphore is None:
+        semaphore = asyncio.Semaphore(limit)
+        semaphores_by_limit[limit] = semaphore
+    return semaphore
+
+
+async def _scoring_request(
+    args: Namespace,
+    url: str,
+    payload: dict[str, Any],
+    *,
+    sample: Sample,
+    target: str,
+    action: str,
+) -> dict[str, Any]:
+    """Issue one scoring request through the shared HTTP client.
+
+    Adds the bounded-transport contract on top of http_utils.post: an
+    in-flight bound, a total deadline shared across retries, a bounded retry
+    policy, with failures annotated using sample identity.
+    """
+    timeout_s = float(args.opd_scoring_timeout)
+    retries = max(0, int(args.opd_scoring_retries))
+    max_attempts = retries + 1
+
+    deadline_s = time.monotonic() + timeout_s
+    semaphore = _scoring_semaphore(args)
+    semaphore_acquired = False
+    attempts = 0
+
+    def scoring_error(error: BaseException) -> RuntimeError:
+        return RuntimeError(
+            f"OPD scoring request to {url} failed after {attempts} attempt(s): {error!r} "
+            f"(target={target}, timeout={timeout_s}s, "
+            f"input_tokens={len(payload.get('input_ids', []))}, "
+            f"sample index={sample.index}, group={sample.group_index})"
+        )
+
+    try:
+        if semaphore is not None:
+            remaining_s = deadline_s - time.monotonic()
+            try:
+                if remaining_s <= 0:
+                    raise TimeoutError(f"deadline of {timeout_s}s exhausted while waiting for an in-flight slot")
+                await asyncio.wait_for(semaphore.acquire(), timeout=remaining_s)
+                semaphore_acquired = True
+            except (TimeoutError, asyncio.TimeoutError) as error:
+                raise scoring_error(error) from error
+
+        for _ in range(max_attempts):
+            remaining_s = deadline_s - time.monotonic()
+            if remaining_s <= 0:
+                error = TimeoutError(f"deadline of {timeout_s}s exhausted before the next attempt")
+                raise scoring_error(error) from error
+
+            attempts += 1
+            try:
+                # max_retries=1 gives exactly one attempt: the retry policy,
+                # attempt count and deadline are owned here where they can be
+                # bounded and reported.
+                request = (
+                    post(url, payload, max_retries=1)
+                    if action == "post"
+                    else post(url, None, max_retries=1, action=action)
+                )
+                return await asyncio.wait_for(request, timeout=remaining_s)
+            except (TimeoutError, asyncio.TimeoutError, httpx.HTTPError) as error:
+                remaining_s = deadline_s - time.monotonic()
+                if attempts >= max_attempts or remaining_s <= 0:
+                    raise scoring_error(error) from error
+                # Keep part of the remaining deadline available for the retry.
+                backoff_s = min(_SCORING_RETRY_BACKOFF_S, remaining_s / 2)
+                await asyncio.sleep(backoff_s)
+    finally:
+        if semaphore_acquired:
+            semaphore.release()
+
+
+async def _scoring_post(
+    args: Namespace,
+    url: str,
+    payload: dict[str, Any],
+    *,
+    sample: Sample,
+    target: str,
+) -> dict[str, Any]:
+    return await _scoring_request(args, url, payload, sample=sample, target=target, action="post")
+
+
+async def _scoring_get(
+    args: Namespace,
+    url: str,
+    *,
+    sample: Sample,
+    target: str,
+) -> dict[str, Any]:
+    return await _scoring_request(args, url, {}, sample=sample, target=target, action="get")
 
 
 def _top_entry_token_id(entry: list[Any]) -> int:
@@ -86,7 +226,12 @@ def _trim_input_field(meta_info: dict[str, Any], field: str, response_length: in
     if values is None:
         raise ValueError(f"Teacher response is missing meta_info.{field}.")
     # SGLang's first input logprob/top-logprob position is a placeholder.
-    return values[1:][-response_length:] if response_length > 0 else []
+    trimmed = values[1:][-response_length:] if response_length > 0 else []
+    if len(trimmed) != response_length:
+        raise ValueError(
+            f"Scoring response meta_info.{field} covers {len(trimmed)} positions, expected {response_length}."
+        )
+    return trimmed
 
 
 def _input_logprob_maps(response: dict[str, Any], field: str, response_length: int) -> LogprobMaps:
@@ -95,9 +240,45 @@ def _input_logprob_maps(response: dict[str, Any], field: str, response_length: i
     ]
 
 
-def _teacher_sampled_log_probs(response: dict[str, Any], response_length: int) -> torch.Tensor:
-    input_token_logprobs = _trim_input_field(response["meta_info"], "input_token_logprobs", response_length)
-    return torch.tensor([item[0] for item in input_token_logprobs], dtype=torch.float32)
+def _teacher_sampled_log_probs(response: dict[str, Any], sample: Sample) -> torch.Tensor:
+    """Extract exactly one finite teacher log-prob per response token.
+
+    Raises when the scored positions do not line up one-to-one with the
+    sample's response tokens, instead of silently training on shifted scores.
+    """
+    response_length = sample.response_length
+    meta_info = response.get("meta_info")
+    if not isinstance(meta_info, dict):
+        raise ValueError(
+            f"Scoring response has no meta_info dict (sample index={sample.index}, group={sample.group_index})."
+        )
+    entries = _trim_input_field(meta_info, "input_token_logprobs", response_length)
+    if response_length == 0:
+        return torch.zeros((0,), dtype=torch.float32)
+
+    response_tokens = [int(token) for token in sample.tokens[-response_length:]]
+    scored_tokens = [int(entry[1]) for entry in entries]
+    if scored_tokens != response_tokens:
+        raise ValueError(
+            "Scoring token alignment mismatch: "
+            f"expected response tail {response_tokens[:8]}... len={len(response_tokens)}, "
+            f"got {scored_tokens[:8]}... len={len(scored_tokens)} "
+            f"(sample index={sample.index}, group={sample.group_index})."
+        )
+
+    log_probs = [entry[0] for entry in entries]
+    if any(log_prob is None for log_prob in log_probs):
+        raise ValueError(
+            f"Scoring returned None for a response-token logprob "
+            f"(sample index={sample.index}, group={sample.group_index})."
+        )
+    tensor = torch.tensor([float(log_prob) for log_prob in log_probs], dtype=torch.float32)
+    if not torch.isfinite(tensor).all():
+        raise ValueError(
+            f"Scoring returned a non-finite response-token logprob "
+            f"(sample index={sample.index}, group={sample.group_index})."
+        )
+    return tensor
 
 
 def _student_top_logprobs(sample: Sample, response_length: int) -> TopLogprobs:
@@ -122,6 +303,228 @@ def _unique_ids(top_logprobs: Iterable[Iterable[list[Any]]]) -> list[int]:
             if entry is not None:
                 ids.add(_top_entry_token_id(entry))
     return sorted(ids)
+
+
+def _normalize_top_logprob_rows(
+    top_logprobs: Iterable[Iterable[list[Any]]],
+    *,
+    response_length: int,
+    top_k: int,
+    source: str,
+) -> TopLogprobs:
+    rows = list(top_logprobs)
+    if len(rows) != response_length:
+        raise ValueError(f"{source} top-k covers {len(rows)} positions, expected {response_length}.")
+
+    normalized = []
+    for position, entries in enumerate(rows):
+        row = []
+        seen_ids = set()
+        for entry in entries or []:
+            if entry is None:
+                continue
+            if not isinstance(entry, (list, tuple)) or len(entry) < 2:
+                raise ValueError(f"{source} top-k row {position} contains a malformed entry: {entry!r}.")
+            logprob = float(entry[0])
+            token_id = int(entry[1])
+            if not math.isfinite(logprob):
+                raise ValueError(f"{source} top-k row {position} contains a non-finite logprob.")
+            if token_id < 0:
+                raise ValueError(f"{source} top-k row {position} contains a negative token id: {token_id}.")
+            if token_id in seen_ids:
+                raise ValueError(f"{source} top-k row {position} contains duplicate token id {token_id}.")
+            seen_ids.add(token_id)
+            row.append([logprob, token_id])
+        if len(row) > top_k:
+            raise ValueError(
+                f"{source} top-k row {position} contains {len(row)} entries, configured top-k is {top_k}."
+            )
+        normalized.append(row)
+    return normalized
+
+
+def _top_k_scoring_blocks(top_logprobs: TopLogprobs, block_size: int) -> Iterable[tuple[int, int, list[int]]]:
+    if block_size <= 0:
+        raise ValueError("OPD top-k scoring block size must be positive.")
+    for start in range(0, len(top_logprobs), block_size):
+        end = min(start + block_size, len(top_logprobs))
+        yield start, end, _unique_ids(top_logprobs[start:end])
+
+
+def _weight_version(value: Any, *, source: str) -> str:
+    if value is None or str(value) == "":
+        raise ValueError(f"{source} did not report a usable weight_version.")
+    return str(value)
+
+
+async def _student_weight_version(args: Namespace, sample: Sample) -> str:
+    response = await _scoring_get(
+        args,
+        f"http://{args.sglang_router_ip}:{args.sglang_router_port}/model_info",
+        sample=sample,
+        target="student-version",
+    )
+    if not isinstance(response, dict) or "weight_version" not in response:
+        raise ValueError("Student model_info response is missing weight_version.")
+    return _weight_version(response["weight_version"], source="Student model_info")
+
+
+def _response_weight_version(response: dict[str, Any], *, target: str) -> str:
+    meta_info = response.get("meta_info")
+    if not isinstance(meta_info, dict) or "weight_version" not in meta_info:
+        raise ValueError(f"{target} scoring response is missing meta_info.weight_version.")
+    return _weight_version(meta_info["weight_version"], source=f"{target} scoring response")
+
+
+def _validate_block_token_alignment(
+    response: dict[str, Any],
+    sample: Sample,
+    *,
+    start: int,
+    end: int,
+    target: str,
+) -> None:
+    meta_info = response.get("meta_info")
+    if not isinstance(meta_info, dict):
+        raise ValueError(
+            f"{target} scoring response has no meta_info dict "
+            f"(sample index={sample.index}, group={sample.group_index})."
+        )
+
+    entries = _trim_input_field(meta_info, "input_token_logprobs", end - start)
+    response_start = len(sample.tokens) - sample.response_length
+    expected_tokens = [int(token) for token in sample.tokens[response_start + start : response_start + end]]
+    try:
+        scored_tokens = [int(entry[1]) for entry in entries]
+    except (IndexError, TypeError, ValueError) as error:
+        raise ValueError(
+            f"{target} scoring returned malformed token-alignment entries for response positions [{start}, {end})."
+        ) from error
+    if scored_tokens != expected_tokens:
+        raise ValueError(
+            f"{target} scoring token alignment mismatch for response positions [{start}, {end}): "
+            f"expected {expected_tokens[:8]}... len={len(expected_tokens)}, "
+            f"got {scored_tokens[:8]}... len={len(scored_tokens)} "
+            f"(sample index={sample.index}, group={sample.group_index})."
+        )
+
+
+def _compact_block_logprobs(
+    response: dict[str, Any],
+    candidate_rows: TopLogprobs,
+    *,
+    start: int,
+    end: int,
+    target: str,
+) -> TopLogprobs:
+    scored_rows = _trim_input_field(response["meta_info"], "input_token_ids_logprobs", end - start)
+    compact_rows = []
+    for position, (candidates, scored_entries) in enumerate(
+        zip(candidate_rows[start:end], scored_rows, strict=True),
+        start=start,
+    ):
+        scored_map = {}
+        for entry in scored_entries or []:
+            if entry is None or not isinstance(entry, (list, tuple)) or len(entry) < 2:
+                raise ValueError(f"{target} scoring row {position} contains a malformed candidate entry: {entry!r}.")
+            logprob = float(entry[0])
+            token_id = int(entry[1])
+            if not math.isfinite(logprob):
+                raise ValueError(
+                    f"{target} scoring row {position} contains a non-finite logprob for token id {token_id}."
+                )
+            scored_map[token_id] = logprob
+
+        compact_row = []
+        for candidate in candidates:
+            token_id = _top_entry_token_id(candidate)
+            if token_id not in scored_map:
+                raise ValueError(f"{target} scoring row {position} is missing candidate token id {token_id}.")
+            compact_row.append([scored_map[token_id], token_id])
+        compact_rows.append(compact_row)
+    return compact_rows
+
+
+async def _score_top_k_in_blocks(
+    args: Namespace,
+    url: str,
+    sample: Sample,
+    candidate_rows: TopLogprobs,
+    *,
+    target: str,
+    require_stable_weight_version: bool = False,
+) -> dict[str, Any]:
+    """Score position-local candidates without a response-wide Cartesian product.
+
+    SGLang accepts one arbitrary-ID set per request, not one set per token
+    position. Each request therefore covers a bounded response-position block,
+    uses only that block's candidate union, and immediately compacts the reply
+    back to the original per-position rows.
+    """
+    response_length = sample.response_length
+    if len(candidate_rows) != response_length:
+        raise ValueError(f"{target} candidate rows cover {len(candidate_rows)} positions, expected {response_length}.")
+    if response_length == 0:
+        return {"meta_info": {"input_token_ids_logprobs": [None]}}
+
+    block_size = _get_top_k_scoring_block_size(args)
+    if block_size <= 0:
+        raise ValueError("Blocked OPD top-k scoring requires --opd-top-k-scoring-block-size > 0.")
+
+    prompt_length = len(sample.tokens) - response_length
+    transaction_attempts = max(0, int(args.opd_scoring_retries)) + 1 if require_stable_weight_version else 1
+    last_version_error: RuntimeError | None = None
+
+    for transaction_attempt in range(1, transaction_attempts + 1):
+        expected_version = await _student_weight_version(args, sample) if require_stable_weight_version else None
+        compact_rows: TopLogprobs = [[] for _ in range(response_length)]
+        version_error = None
+
+        for start, end, candidate_ids in _top_k_scoring_blocks(candidate_rows, block_size):
+            if not candidate_ids:
+                continue
+
+            block_input_ids = sample.tokens[: prompt_length + end]
+            response = await _scoring_post(
+                args,
+                url,
+                _score_payload(block_input_ids, end - start, token_ids=candidate_ids),
+                sample=sample,
+                target=target,
+            )
+            _validate_block_token_alignment(response, sample, start=start, end=end, target=target)
+            compact_rows[start:end] = _compact_block_logprobs(
+                response,
+                candidate_rows,
+                start=start,
+                end=end,
+                target=target,
+            )
+
+            if require_stable_weight_version:
+                block_version = _response_weight_version(response, target=target)
+                if block_version != expected_version:
+                    version_error = RuntimeError(
+                        f"{target} weight version changed during blocked OPD scoring: "
+                        f"expected {expected_version!r}, got {block_version!r} for response positions "
+                        f"[{start}, {end}) (sample index={sample.index}, group={sample.group_index})."
+                    )
+                    break
+
+        if version_error is None:
+            meta_info = {"input_token_ids_logprobs": [None, *compact_rows]}
+            if expected_version is not None:
+                meta_info["weight_version"] = expected_version
+            return {"meta_info": meta_info}
+
+        last_version_error = version_error
+        if transaction_attempt < transaction_attempts:
+            await asyncio.sleep(_SCORING_RETRY_BACKOFF_S)
+
+    raise RuntimeError(
+        f"Unable to score all {target} blocks with one weight version after "
+        f"{transaction_attempts} attempt(s); refusing to assemble mixed-version scores."
+    ) from last_version_error
 
 
 def _ordered_unique(ids: Iterable[int]) -> list[int]:
@@ -272,9 +675,32 @@ def _compute_topk_reverse_kl(
 async def reward_func(args: Namespace, sample: Sample, **kwargs: Any) -> dict[str, Any]:
     top_k = _get_opd_top_k(args)
     if top_k == 0:
-        return await _post_json(args.rm_url, _score_payload(sample.tokens))
+        return await _scoring_post(
+            args,
+            args.rm_url,
+            _score_payload(sample.tokens, sample.response_length),
+            sample=sample,
+            target="teacher",
+        )
 
     strategy = _get_top_k_strategy(args)
+    block_size = _get_top_k_scoring_block_size(args)
+
+    if block_size > 0 and strategy == "only-student":
+        student_top = _normalize_top_logprob_rows(
+            _student_top_logprobs(sample, sample.response_length),
+            response_length=sample.response_length,
+            top_k=top_k,
+            source="Student",
+        )
+        teacher_response = await _score_top_k_in_blocks(
+            args,
+            args.rm_url,
+            sample,
+            student_top,
+            target="teacher",
+        )
+        return {"teacher": teacher_response}
 
     teacher_token_ids = None
     if strategy in TEACHER_ON_STUDENT_STRATEGIES:
@@ -283,19 +709,40 @@ async def reward_func(args: Namespace, sample: Sample, **kwargs: Any) -> dict[st
 
     teacher_payload = _score_payload(
         sample.tokens,
+        sample.response_length,
         top_k=top_k if strategy in TEACHER_TOP_STRATEGIES else 0,
         token_ids=teacher_token_ids,
     )
-    teacher_response = await _post_json(args.rm_url, teacher_payload)
+    teacher_response = await _scoring_post(args, args.rm_url, teacher_payload, sample=sample, target="teacher")
 
     reward_payload = {"teacher": teacher_response}
     if strategy in STUDENT_ON_TEACHER_STRATEGIES:
         teacher_top = _trim_input_field(teacher_response["meta_info"], "input_top_logprobs", sample.response_length)
-        student_token_ids = _unique_ids(teacher_top)
-        reward_payload["student_on_teacher"] = await _post_json(
-            _student_score_url(args),
-            _score_payload(sample.tokens, token_ids=student_token_ids),
-        )
+        if block_size > 0 and strategy == "only-teacher":
+            _teacher_sampled_log_probs(teacher_response, sample)
+            teacher_top = _normalize_top_logprob_rows(
+                teacher_top,
+                response_length=sample.response_length,
+                top_k=top_k,
+                source="Teacher",
+            )
+            reward_payload["student_on_teacher"] = await _score_top_k_in_blocks(
+                args,
+                _student_score_url(args),
+                sample,
+                teacher_top,
+                target="student",
+                require_stable_weight_version=True,
+            )
+        else:
+            student_token_ids = _unique_ids(teacher_top)
+            reward_payload["student_on_teacher"] = await _scoring_post(
+                args,
+                _student_score_url(args),
+                _score_payload(sample.tokens, sample.response_length, token_ids=student_token_ids),
+                sample=sample,
+                target="student",
+            )
 
     return reward_payload
 
@@ -311,7 +758,6 @@ def post_process_rewards(args: Namespace, samples: list[Sample], **kwargs: Any) 
     response position and storing a precomputed weighted reverse-KL estimate.
     """
     raw_rewards = [sample.get_reward_value(args) for sample in samples]
-    response_lengths = [sample.response_length for sample in samples]
 
     if _get_opd_top_k(args) > 0:
         for sample, reward in zip(samples, raw_rewards, strict=True):
@@ -320,8 +766,7 @@ def post_process_rewards(args: Namespace, samples: list[Sample], **kwargs: Any) 
         return scalar_rewards, scalar_rewards
 
     teacher_log_probs = [
-        _teacher_sampled_log_probs(reward, response_length)
-        for reward, response_length in zip(raw_rewards, response_lengths, strict=True)
+        _teacher_sampled_log_probs(reward, sample) for reward, sample in zip(raw_rewards, samples, strict=True)
     ]
 
     for sample, t_log_probs in zip(samples, teacher_log_probs, strict=True):

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -1381,6 +1381,39 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 help="Weighting scheme for top-k OPD token rewards.",
             )
             parser.add_argument(
+                "--opd-top-k-scoring-block-size",
+                type=int,
+                default=32,
+                help=(
+                    "Response positions per opposite-model arbitrary-ID scoring request for "
+                    "only-student and only-teacher top-k OPD. Smaller values reduce the "
+                    "candidate Cartesian product; set to 0 to use the legacy response-wide union."
+                ),
+            )
+            parser.add_argument(
+                "--opd-scoring-timeout",
+                type=float,
+                default=600.0,
+                help=("Total deadline in seconds for one external OPD scoring request, " "shared across its retries."),
+            )
+            parser.add_argument(
+                "--opd-scoring-max-inflight",
+                type=int,
+                default=8,
+                help=(
+                    "Maximum concurrent external OPD scoring requests per process. " "Set to 0 to disable the bound."
+                ),
+            )
+            parser.add_argument(
+                "--opd-scoring-retries",
+                type=int,
+                default=1,
+                help=(
+                    "Retries after a failed external OPD scoring request or a mixed-version "
+                    "blocked student-scoring attempt. Set to 0 to fail fast."
+                ),
+            )
+            parser.add_argument(
                 "--opd-teacher-load",
                 type=str,
                 default=None,
@@ -2549,6 +2582,14 @@ def miles_validate_args(args):
             raise ValueError("--opd-log-prob-top-k must be non-negative.")
         if args.opd_log_prob_top_k > 0 and args.opd_type != "sglang":
             raise ValueError("--opd-log-prob-top-k is currently supported only with --opd-type=sglang.")
+        if args.opd_top_k_scoring_block_size < 0:
+            raise ValueError("--opd-top-k-scoring-block-size must be non-negative.")
+        if args.opd_scoring_timeout <= 0:
+            raise ValueError("--opd-scoring-timeout must be positive.")
+        if args.opd_scoring_max_inflight < 0:
+            raise ValueError("--opd-scoring-max-inflight must be non-negative.")
+        if args.opd_scoring_retries < 0:
+            raise ValueError("--opd-scoring-retries must be non-negative.")
 
         if args.opd_type == "megatron":
             if args.opd_teacher_load is None:

--- a/tests/fast/rollout/test_on_policy_distillation.py
+++ b/tests/fast/rollout/test_on_policy_distillation.py
@@ -1,10 +1,18 @@
+import asyncio
 import math
 from argparse import Namespace
 
 import pytest
 from tests.ci.ci_register import register_cpu_ci
 
-from miles.rollout.on_policy_distillation import _compute_topk_reverse_kl
+import miles.rollout.on_policy_distillation as opd
+from miles.rollout.on_policy_distillation import (
+    _compute_topk_reverse_kl,
+    _score_payload,
+    _scoring_post,
+    _teacher_sampled_log_probs,
+    reward_func,
+)
 from miles.utils.types import Sample
 
 register_cpu_ci(est_time=60, suite="stage-a-cpu")
@@ -100,3 +108,376 @@ def test_topk_xor_uses_symmetric_difference_without_normalization():
     expected_1 = math.log(0.3 / 0.6) + math.log(0.1 / 0.2)
 
     assert reverse_kl.tolist() == pytest.approx([expected_0, expected_1])
+
+
+# ---------------------------------------------------------------------------
+# Scoring payload: response window
+# ---------------------------------------------------------------------------
+
+
+def test_score_payload_materializes_only_the_response_window():
+    payload = _score_payload([10, 11, 12, 13], response_length=2)
+
+    assert payload["input_ids"] == [10, 11, 12, 13]
+    # Two prompt tokens; logprobs start one token before the response window.
+    assert payload["logprob_start_len"] == 1
+    assert payload["sampling_params"]["max_new_tokens"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Sampled log-prob extraction: alignment guard
+# ---------------------------------------------------------------------------
+
+
+def _scored_sample() -> Sample:
+    return Sample(tokens=[10, 11, 12, 13], response_length=2)
+
+
+def _reply(entries: list[list]) -> dict:
+    return {"meta_info": {"input_token_logprobs": entries}}
+
+
+def test_sampled_log_probs_match_between_full_and_window_replies():
+    sample = _scored_sample()
+    full_reply = _reply([[None, 10, None], [-0.5, 11, None], [-1.0, 12, None], [-2.0, 13, None]])
+    window_reply = _reply([[None, 11, None], [-1.0, 12, None], [-2.0, 13, None]])
+
+    full = _teacher_sampled_log_probs(full_reply, sample)
+    window = _teacher_sampled_log_probs(window_reply, sample)
+
+    assert full.tolist() == window.tolist() == [-1.0, -2.0]
+
+
+def test_sampled_log_probs_reject_misaligned_tokens():
+    reply = _reply([[None, 11, None], [-1.0, 99, None], [-2.0, 13, None]])
+
+    with pytest.raises(ValueError, match="token alignment mismatch"):
+        _teacher_sampled_log_probs(reply, _scored_sample())
+
+
+# ---------------------------------------------------------------------------
+# Bounded scoring transport
+# ---------------------------------------------------------------------------
+
+
+def _scoring_args(**overrides) -> Namespace:
+    defaults = {
+        "opd_scoring_timeout": 5.0,
+        "opd_scoring_max_inflight": 0,
+        "opd_scoring_retries": 0,
+    }
+    defaults.update(overrides)
+    return Namespace(**defaults)
+
+
+def test_scoring_post_retries_after_timeout_then_succeeds(monkeypatch):
+    monkeypatch.setattr(opd, "_SCORING_RETRY_BACKOFF_S", 0.01)
+    calls = {"count": 0}
+
+    async def flaky_post(url, payload, max_retries=1):
+        calls["count"] += 1
+        if calls["count"] == 1:
+            raise TimeoutError("first attempt times out")
+        return {"ok": True}
+
+    monkeypatch.setattr(opd, "post", flaky_post)
+    sample = _scored_sample()
+
+    result = asyncio.run(
+        _scoring_post(
+            _scoring_args(opd_scoring_retries=1), "http://teacher", {"input_ids": [1]}, sample=sample, target="teacher"
+        )
+    )
+
+    assert result == {"ok": True}
+    assert calls["count"] == 2
+
+
+def test_scoring_post_shares_one_deadline_across_retries(monkeypatch):
+    monkeypatch.setattr(opd, "_SCORING_RETRY_BACKOFF_S", 0.01)
+    calls = {"count": 0}
+
+    async def hanging_post(url, payload, max_retries=1):
+        calls["count"] += 1
+        await asyncio.sleep(60)
+
+    monkeypatch.setattr(opd, "post", hanging_post)
+
+    async def run() -> float:
+        loop = asyncio.get_running_loop()
+        start = loop.time()
+        with pytest.raises(RuntimeError, match="failed after"):
+            await _scoring_post(
+                _scoring_args(opd_scoring_timeout=0.2, opd_scoring_retries=5),
+                "http://teacher",
+                {"input_ids": [1]},
+                sample=_scored_sample(),
+                target="teacher",
+            )
+        return loop.time() - start
+
+    # Five retries share the 0.2s deadline instead of each getting a fresh one.
+    assert asyncio.run(run()) < 5.0
+    assert calls["count"] == 1
+
+
+def test_scoring_post_bounds_inflight_requests(monkeypatch):
+    state = {"current": 0, "max": 0}
+
+    async def tracked_post(url, payload, max_retries=1):
+        state["current"] += 1
+        state["max"] = max(state["max"], state["current"])
+        await asyncio.sleep(0.01)
+        state["current"] -= 1
+        return {"ok": True}
+
+    monkeypatch.setattr(opd, "post", tracked_post)
+    args = _scoring_args(opd_scoring_max_inflight=1)
+
+    async def run():
+        await asyncio.gather(
+            *(
+                _scoring_post(args, "http://teacher", {"input_ids": [1]}, sample=_scored_sample(), target="teacher")
+                for _ in range(4)
+            )
+        )
+
+    asyncio.run(run())
+
+    assert state["max"] == 1
+
+
+def test_scoring_post_deadline_includes_inflight_wait(monkeypatch):
+    entered_post = asyncio.Event()
+    release_post = asyncio.Event()
+
+    async def blocked_post(url, payload, max_retries=1):
+        entered_post.set()
+        await release_post.wait()
+        return {"ok": True}
+
+    monkeypatch.setattr(opd, "post", blocked_post)
+    long_args = _scoring_args(opd_scoring_timeout=5.0, opd_scoring_max_inflight=1)
+    short_args = _scoring_args(opd_scoring_timeout=0.05, opd_scoring_max_inflight=1)
+
+    async def run():
+        first = asyncio.create_task(
+            _scoring_post(long_args, "http://teacher", {"input_ids": [1]}, sample=_scored_sample(), target="teacher")
+        )
+        await entered_post.wait()
+        with pytest.raises(RuntimeError, match="failed after 0 attempt"):
+            await _scoring_post(
+                short_args,
+                "http://teacher",
+                {"input_ids": [1]},
+                sample=_scored_sample(),
+                target="teacher",
+            )
+        release_post.set()
+        assert await first == {"ok": True}
+
+    asyncio.run(run())
+
+
+# ---------------------------------------------------------------------------
+# Position-blocked top-k scoring
+# ---------------------------------------------------------------------------
+
+
+def _blocked_top_k_args(strategy: str, *, block_size: int = 2, weight_mode: str = "student_p") -> Namespace:
+    return _scoring_args(
+        opd_log_prob_top_k=2,
+        opd_top_k_strategy=strategy,
+        opd_reward_weight_mode=weight_mode,
+        opd_top_k_scoring_block_size=block_size,
+        rm_url="http://teacher/generate",
+        sglang_router_ip="student",
+        sglang_router_port=30000,
+    )
+
+
+def _blocked_sample() -> Sample:
+    return Sample(
+        tokens=[10, 11, 12, 13, 14, 15],
+        response_length=4,
+        metadata={
+            "opd_student_top_logprobs": [
+                [_entry(0.6, 1), _entry(0.4, 2)],
+                [_entry(0.7, 2), _entry(0.3, 3)],
+                [_entry(0.8, 4), _entry(0.2, 5)],
+                [_entry(0.9, 5), _entry(0.1, 6)],
+            ]
+        },
+    )
+
+
+def _candidate_score(target: str, position: int, token_id: int) -> float:
+    target_offset = 0.2 if target == "teacher" else 0.4
+    return -(target_offset + 0.05 * position + 0.01 * token_id)
+
+
+def _blocked_reply(
+    sample: Sample,
+    payload: dict,
+    target: str,
+    *,
+    weight_version: str | None = None,
+) -> dict:
+    prompt_length = len(sample.tokens) - sample.response_length
+    start = payload["logprob_start_len"] + 1 - prompt_length
+    end = len(payload["input_ids"]) - prompt_length
+    response_tokens = sample.tokens[prompt_length + start : prompt_length + end]
+    candidate_ids = payload["token_ids_logprob"]
+    meta_info = {
+        "input_token_logprobs": [None, *[[-1.0, token_id] for token_id in response_tokens]],
+        "input_token_ids_logprobs": [
+            None,
+            *[
+                [[_candidate_score(target, position, token_id), token_id] for token_id in candidate_ids]
+                for position in range(start, end)
+            ],
+        ],
+    }
+    if weight_version is not None:
+        meta_info["weight_version"] = weight_version
+    return {"meta_info": meta_info}
+
+
+def _global_candidate_reply(sample: Sample, candidate_rows: list[list], target: str) -> dict:
+    candidate_ids = sorted({int(entry[1]) for row in candidate_rows for entry in row})
+    return {
+        "meta_info": {
+            "input_token_ids_logprobs": [
+                None,
+                *[
+                    [[_candidate_score(target, position, token_id), token_id] for token_id in candidate_ids]
+                    for position in range(sample.response_length)
+                ],
+            ]
+        }
+    }
+
+
+@pytest.mark.parametrize("weight_mode", ["student_p", "teacher_p", "none"])
+def test_only_student_block_scoring_matches_response_wide_union(monkeypatch, weight_mode):
+    sample = _blocked_sample()
+    args = _blocked_top_k_args("only-student", weight_mode=weight_mode)
+    calls = []
+
+    async def fake_scoring_post(args, url, payload, *, sample, target):
+        calls.append((url, payload, target))
+        return _blocked_reply(sample, payload, target)
+
+    monkeypatch.setattr(opd, "_scoring_post", fake_scoring_post)
+
+    blocked_payload = asyncio.run(reward_func(args, sample))
+    legacy_payload = {
+        "teacher": _global_candidate_reply(
+            sample,
+            sample.metadata["opd_student_top_logprobs"],
+            "teacher",
+        )
+    }
+
+    assert _compute_topk_reverse_kl(args, sample, blocked_payload).tolist() == pytest.approx(
+        _compute_topk_reverse_kl(args, sample, legacy_payload).tolist()
+    )
+    assert [call[1]["input_ids"] for call in calls] == [
+        sample.tokens[:4],
+        sample.tokens[:6],
+    ]
+    assert [call[1]["logprob_start_len"] for call in calls] == [1, 3]
+    assert [call[1]["token_ids_logprob"] for call in calls] == [[1, 2, 3], [4, 5, 6]]
+    compact_rows = blocked_payload["teacher"]["meta_info"]["input_token_ids_logprobs"][1:]
+    assert [len(row) for row in compact_rows] == [2, 2, 2, 2]
+
+
+@pytest.mark.parametrize("weight_mode", ["student_p", "teacher_p", "none"])
+def test_only_teacher_block_scoring_matches_response_wide_union(monkeypatch, weight_mode):
+    sample = Sample(tokens=[10, 11, 12, 13, 14, 15], response_length=4)
+    args = _blocked_top_k_args("only-teacher", weight_mode=weight_mode)
+    teacher_top = [
+        [_entry(0.6, 1), _entry(0.4, 2)],
+        [_entry(0.7, 2), _entry(0.3, 3)],
+        [_entry(0.8, 4), _entry(0.2, 5)],
+        [_entry(0.9, 5), _entry(0.1, 6)],
+    ]
+    teacher_response = {
+        "meta_info": {
+            "input_token_logprobs": [None, *[[-1.0, token_id] for token_id in sample.tokens[-4:]]],
+            "input_top_logprobs": [None, *teacher_top],
+        }
+    }
+    calls = []
+
+    async def fake_scoring_post(args, url, payload, *, sample, target):
+        calls.append((url, payload, target))
+        if target == "teacher":
+            return teacher_response
+        return _blocked_reply(sample, payload, target, weight_version="7")
+
+    async def fake_student_weight_version(args, sample):
+        return "7"
+
+    monkeypatch.setattr(opd, "_scoring_post", fake_scoring_post)
+    monkeypatch.setattr(opd, "_student_weight_version", fake_student_weight_version)
+
+    blocked_payload = asyncio.run(reward_func(args, sample))
+    legacy_payload = {
+        "teacher": teacher_response,
+        "student_on_teacher": _global_candidate_reply(sample, teacher_top, "student"),
+    }
+
+    assert _compute_topk_reverse_kl(args, sample, blocked_payload).tolist() == pytest.approx(
+        _compute_topk_reverse_kl(args, sample, legacy_payload).tolist()
+    )
+    assert len(calls) == 3
+    assert calls[0][2] == "teacher"
+    assert "token_ids_logprob" not in calls[0][1]
+    assert [call[1]["token_ids_logprob"] for call in calls[1:]] == [[1, 2, 3], [4, 5, 6]]
+    assert blocked_payload["student_on_teacher"]["meta_info"]["weight_version"] == "7"
+
+
+def test_only_teacher_retries_all_blocks_after_student_version_change(monkeypatch):
+    sample = Sample(tokens=[10, 11, 12, 13, 14, 15], response_length=4)
+    args = _blocked_top_k_args("only-teacher")
+    args.opd_scoring_retries = 1
+    teacher_top = [
+        [_entry(0.6, 1), _entry(0.4, 2)],
+        [_entry(0.7, 2), _entry(0.3, 3)],
+        [_entry(0.8, 4), _entry(0.2, 5)],
+        [_entry(0.9, 5), _entry(0.1, 6)],
+    ]
+    teacher_response = {
+        "meta_info": {
+            "input_token_logprobs": [None, *[[-1.0, token_id] for token_id in sample.tokens[-4:]]],
+            "input_top_logprobs": [None, *teacher_top],
+        }
+    }
+    expected_versions = iter(["7", "8"])
+    block_versions = iter(["7", "8", "8", "8"])
+    student_calls = []
+
+    async def fake_student_weight_version(args, sample):
+        return next(expected_versions)
+
+    async def fake_scoring_post(args, url, payload, *, sample, target):
+        if target == "teacher":
+            return teacher_response
+        student_calls.append(payload)
+        return _blocked_reply(sample, payload, target, weight_version=next(block_versions))
+
+    monkeypatch.setattr(opd, "_SCORING_RETRY_BACKOFF_S", 0)
+    monkeypatch.setattr(opd, "_student_weight_version", fake_student_weight_version)
+    monkeypatch.setattr(opd, "_scoring_post", fake_scoring_post)
+
+    reward_payload = asyncio.run(reward_func(args, sample))
+
+    assert len(student_calls) == 4
+    assert reward_payload["student_on_teacher"]["meta_info"]["weight_version"] == "8"
+    assert [payload["token_ids_logprob"] for payload in student_calls] == [
+        [1, 2, 3],
+        [4, 5, 6],
+        [1, 2, 3],
+        [4, 5, 6],
+    ]

--- a/tests/fast/utils/test_arguments.py
+++ b/tests/fast/utils/test_arguments.py
@@ -152,6 +152,37 @@ def test_recompute_logprobs_via_prefill_flag_is_parsed():
     assert args.recompute_logprobs_via_prefill is True
 
 
+def test_opd_top_k_scoring_block_size_is_parsed():
+    parser = argparse.ArgumentParser()
+    get_miles_extra_args_provider()(parser)
+
+    default_args = parser.parse_args(REQUIRED_ARGS)
+    configured_args = parser.parse_args(["--opd-top-k-scoring-block-size", "8"] + REQUIRED_ARGS)
+
+    assert default_args.opd_top_k_scoring_block_size == 32
+    assert configured_args.opd_top_k_scoring_block_size == 8
+
+
+def test_opd_top_k_scoring_block_size_must_be_non_negative():
+    parser = argparse.ArgumentParser()
+    get_miles_extra_args_provider()(parser)
+    args = parser.parse_args(
+        [
+            "--use-opd",
+            "--opd-type",
+            "sglang",
+            "--opd-top-k-scoring-block-size",
+            "-1",
+            "--num-rollout",
+            "1",
+        ]
+        + REQUIRED_ARGS
+    )
+
+    with pytest.raises(ValueError, match="--opd-top-k-scoring-block-size must be non-negative"):
+        miles_validate_args(args)
+
+
 def test_sglang_parallel_sizes_keep_server_args_destinations():
     parser = add_sglang_arguments(argparse.ArgumentParser())
     args = parser.parse_args(


### PR DESCRIPTION
## Motivation

The official SGLang Top-K OPD recipe becomes impractical for sufficiently long responses. In the validated long-thinking settings, the legacy scorer could not finish the first training step within a 600-second scoring deadline.

The bottleneck is the representation used for cross-model candidate scoring. OPD needs at most `K` candidate log-probabilities at each of `T` response positions, so the useful result has shape `[T, K]`. The legacy implementation instead unions the candidate IDs from the entire response into a set `U`, asks SGLang to evaluate every ID in `U` at every position, and receives a `[T, U]` candidate table:

```text
useful result [T, K]
        |
        v
response-wide candidate union U
        |
        v
materialize and transport [T, U]
        |
        v
discard all but [T, K]
```

The request sends the `U` candidate IDs once, but the response contains `T x U` `(logprob, token_id)` entries. Since `U` can approach `T x K`, candidate extraction and transport can grow toward `O(T^2 K)`, even though only `T x K` entries survive. This inflates temporary results, device-to-host transfer, JSON serialization, network traffic, and client parsing; it does not describe the Transformer forward complexity.

Position blocking trades one oversized scoring request for multiple smaller requests. Those requests also need explicit concurrency and end-to-end time bounds, while incomplete or misaligned scores must be rejected before they can enter training.

This PR replaces the unbounded response-wide representation with a bounded position-blocked representation and adds those operational safeguards around the external scorer. It preserves the exact `[T, K]` scores and existing OPD objective, requires no SGLang API or trainer-backend change, and reduces worst-case candidate-response growth to `O(T B K)`. In the validated non-thinking runs, the same change reduced step time by 2.7x for student-selected candidates and 3.1x for teacher-selected candidates; previously timing-out thinking settings also completed.

## What's in this PR

### 1. Why this PR uses position blocks

SGLang accepts one candidate-ID set per scoring request and evaluates it at every scored position. It cannot directly represent the different `K` candidates needed at each of `T` positions without a new position-aware scoring contract.

Adding that contract would require coordinated SGLang request and runtime changes. This PR keeps the SGLang and trainer interfaces unchanged and bounds the existing scoring representation inside Miles by grouping positions into blocks.

### 2. Replace the global union with position blocks

The response is divided into blocks of `B` consecutive positions. Each block keeps the original position-local candidate rows, but builds a union using only that block:

```text
[T, K] position-local candidates
        |
        +--> positions [0, B)     -> U0 -> score [B, U0] -> compact [B, K]
        +--> positions [B, 2B)    -> U1 -> score [B, U1] -> compact [B, K]
        +--> ...
                                                        |
                                                        v
                                                restored [T, K]
```

For a block covering positions `[start, end)`, Miles:

1. Computes `U_block = union(C_start, ..., C_end-1)`.
2. Sends the input prefix ending at `end`, sets the scored response window to the `B` block positions, and sends `token_ids_logprob=U_block`.
3. Receives `[B, U_block]` candidate log-probabilities from SGLang.
4. Selects only the original `C_t` entries from each position's returned row.
5. Compacts the block back to `[B, K]` and concatenates all blocks into `[T, K]`.

The final candidate IDs and log-probabilities are unchanged. The existing weighting modes and OPD reward calculation receive the same position-local structure as before; only the external scoring and transport strategy changes.

### 3. Make external scoring bounded and fail loudly

Position blocking issues multiple smaller requests, so Miles reuses its shared HTTP client, caps per-process concurrency, and applies one end-to-end deadline across queueing, retries, backoff, and transport. Each response is limited to the requested token window and is rejected before training if any score is missing, non-finite, or token-misaligned.

These controls are exposed through `--opd-scoring-timeout`, `--opd-scoring-max-inflight`, `--opd-scoring-retries`, and `--opd-top-k-scoring-block-size`.

## SGLang compatibility

The `only-teacher` path uses SGLang's existing `token_ids_logprob` API to rescore teacher-selected IDs on the student. This was validated together with [sgl-project/sglang#32859](https://github.com/sgl-project/sglang/pull/32859), which prevents valid host-list result rows from crashing SGLang response normalization. That fix does not change the scoring API or returned values.

## Scope

This PR does not change the `only-student` or `only-teacher` candidate semantics, Top-K reward weighting, OPD objective, gradient application, trainer backend, model-parallel topology, or SGLang API.

## Validation

The official Qwen3-8B student / Qwen3-32B teacher OPD recipe was rerun on an NVIDIA H200 GPU cluster with Top-K 16, block size 32, and up to eight scoring requests in flight.

| Strategy and template mode | Legacy response-wide union | Position blocks |
| --- | ---: | ---: |
| `only-student`, non-thinking | 6/6 steps, 289 s/step | 6/6 steps, 108 s/step (2.7x faster) |
| `only-teacher`, non-thinking | 6/6 steps, 285 s/step | 6/6 steps, 93 s/step (3.1x faster) |
| `only-student`, thinking | Failed in step 0 at the 600 s scoring deadline | Completed two test steps |
| `only-teacher`, thinking | Failed in step 0 at the 600 s scoring deadline | Completed 2/2 test steps, 492 s/step |

Thinking mode produced substantially longer responses in these runs. These results establish behavior for the tested layout and deadline; they are not a universal latency bound.

Regression coverage includes both Top-K strategies, all three reward-weight modes, position-local restoration, stable student-version assembly, response-window and token-alignment validation, and bounded deadline and retry behavior.
