### PR TITLE
feat: add Tinker-compatible training API

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -172,6 +172,7 @@
        "user-guide/rollout-endpoints",
        "user-guide/fully-async",
        "user-guide/agentic-chat-template",
+       "user-guide/tinker-api",
        "user-guide/cli-reference"
       ]
      },

--- a/docs/user-guide/cli-reference.md
+++ b/docs/user-guide/cli-reference.md
@@ -162,6 +162,19 @@ Sections mirror the launch-script argument groups.
 | `--model-name` | str | – | Set in multi-node to avoid `transformers` file-system race. |
 | `--spec` | `<module> <fn>` | – | Plugin spec for custom architectures (e.g. `miles_plugins.models.qwen3_5 get_qwen3_5_spec`). |
 
+### Tinker-compatible API
+
+These arguments apply to the [`train_tinker.py`](/user-guide/tinker-api) service
+entrypoint.
+
+| Flag | Type | Default | Notes |
+|---|---|---|---|
+| `--tinker-model-name` | str | `--hf-checkpoint` | Public base-model name accepted from Tinker SDK clients. |
+| `--tinker-tokenizer-id` | str | `--tinker-model-name` | Tokenizer identifier returned by `get_info`. |
+| `--tinker-checkpoint-dir` | path | `SAVE/tinker` or `/tmp/miles/tinker` | Local root for training and sampler snapshots. |
+| `--tinker-api-key` | str | – | Optional key required in the SDK's `X-API-Key` header and redacted from parsed argument logs. Prefer the `TINKER_API_KEY` environment variable so the secret does not enter process arguments. Authentication is disabled when unset. |
+| `--tinker-max-concurrent-samples` | int | `256` | Sampling concurrency advertised to SDK clients. |
+
 ### Rollout: data and batching
 
 | Flag | Type | Default | Notes |

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -13,6 +13,7 @@ description: Concepts, launch script walkthrough, customization hooks, and a com
 | [Rollout Endpoints](/user-guide/rollout-endpoints) | The `/generate` endpoint and the OpenAI chat endpoint for agentic sessions. |
 | [Fully Async Rollout](/user-guide/fully-async) | Queue-backed rollout production, tuning knobs, and when to use `train_async.py`. |
 | [Agentic Chat Templates](/user-guide/agentic-chat-template) | Turning on and verifying TITO so multi-turn agentic rollout stays append-only. |
+| [Tinker-compatible API](/user-guide/tinker-api) | Run Miles as a self-hosted training and sampling data plane for the public Tinker SDK. |
 | [CLI Reference](/user-guide/cli-reference) | Every flag Miles accepts, grouped by subsystem. |
 | [Environments](/user-guide/environments) | Supplying an environment: dataset + reward, your own env via the plug points, or an external ecosystem. |
 

--- a/docs/user-guide/tinker-api.md
+++ b/docs/user-guide/tinker-api.md
@@ -1,0 +1,172 @@
+---
+title: Tinker-compatible API
+description: Use the public Tinker SDK with a Miles Megatron trainer and SGLang samplers.
+---
+
+Miles can run as a self-hosted, Tinker SDK-compatible training and sampling
+data plane. A regular `tinker.ServiceClient` talks to Miles over HTTP; Miles
+maps training requests to Megatron multi-LoRA slots and sampling requests to
+SGLang.
+
+This integration targets the public SDK's core `ServiceClient`,
+`TrainingClient`, and `SamplingClient` workflows. It is not an implementation
+of Tinker's hosted control plane.
+
+## Architecture
+
+Each `create_lora_training_client` call reserves one Miles multi-LoRA slot.
+Model operations are executed in SDK sequence order on every Megatron rank:
+
+```text
+Tinker SDK
+    |
+    +-- forward / forward_backward / optim_step --> Miles controller
+    |                                                |
+    |                                                +--> Megatron ranks
+    |
+    +-- save_weights_for_sampler ------------------> HF PEFT snapshot
+                                                     |
+                                                     +--> SGLang LoRA loader
+                                                            |
+                                                            +--> sample
+```
+
+Training requests are serialized because they share one Megatron trainer.
+Sampling requests run concurrently against immutable snapshots, so a sampler
+never observes a partially applied optimizer step.
+
+## Start a service
+
+Install Miles with Megatron-Bridge's `bridge` branch and SGLang's
+`sglang-miles` branch. Start a Ray cluster with separate trainer and rollout
+GPUs, then launch `train_tinker.py`. A runnable two-GPU Qwen example is in
+[`examples/tinker`](https://github.com/radixark/miles/tree/main/examples/tinker).
+
+The important service arguments are:
+
+| Argument | Meaning |
+| --- | --- |
+| `--tinker-model-name` | Public base-model name accepted from SDK clients. Defaults to `--hf-checkpoint`. |
+| `--tinker-tokenizer-id` | Tokenizer metadata returned by `get_info`. Defaults to the public model name. |
+| `--tinker-checkpoint-dir` | Local root for training and sampler snapshots. Defaults to `--save/tinker`, or `/tmp/miles/tinker` when `--save` is unset. |
+| `--tinker-api-key` | Optional API key checked against the SDK's `X-API-Key` header and redacted from parsed argument logs. Prefer the `TINKER_API_KEY` environment variable so it does not enter process arguments. When neither is set, authentication is disabled. |
+| `--tinker-max-concurrent-samples` | Sampling concurrency advertised to SDK clients. |
+| `--multi-lora-n-adapters` | Number of training-client adapter slots available concurrently. |
+| `--lora-rank` | Maximum rank a client may request. |
+| `--target-modules` | Superset of modules clients may enable. Include `lm_head` to support `train_unembed=True`. |
+
+`pipeline-model-parallel-size` and `context-parallel-size` must be 1, and
+`qkv-format` must be `thd`. Tensor and data parallelism are supported. Trainer
+and rollout GPUs must be disaggregated; colocated mode is rejected.
+
+## Use the official SDK
+
+```python
+import tinker
+from tinker import types
+
+service = tinker.ServiceClient(
+    base_url="http://127.0.0.1:8068",
+    api_key="local",  # any non-empty value when server auth is disabled
+)
+training = service.create_lora_training_client(
+    base_model="Qwen/Qwen3-0.6B",
+    rank=16,
+    seed=7,
+    train_attn=True,
+    train_mlp=True,
+    train_unembed=True,
+)
+
+tokens = [9707, 11, 1917]
+datum = types.Datum(
+    model_input=types.ModelInput.from_ints(tokens[:-1]),
+    loss_fn_inputs={
+        "target_tokens": tokens[1:],
+        "weights": [1.0, 1.0],
+    },
+)
+
+training.forward_backward([datum], "cross_entropy").result()
+training.optim_step(types.AdamParams(learning_rate=1e-4)).result()
+
+snapshot = training.save_weights_for_sampler("step-1").result()
+sampler = service.create_sampling_client(model_path=snapshot.path)
+result = sampler.sample(
+    prompt=types.ModelInput.from_ints(tokens),
+    num_samples=1,
+    sampling_params=types.SamplingParams(max_tokens=32, temperature=0.8),
+).result()
+```
+
+Both synchronous and asynchronous public SDK methods use the same server
+surface.
+
+## Loss contracts
+
+Only `encoded_text` model-input chunks are executable. For every datum,
+`target_tokens.shape[0]` must equal the encoded model-input length.
+Losses use Tinker's sum reduction; Miles does not divide gradients by datum or
+token count.
+
+| Loss | Required `loss_fn_inputs` | Optional config |
+| --- | --- | --- |
+| `cross_entropy` | `target_tokens`, `weights` | none |
+| `importance_sampling` | `target_tokens`, `logprobs`, `advantages` | none |
+| `ppo` | `target_tokens`, `logprobs`, `advantages` | `clip_low_threshold`, `clip_high_threshold` |
+| `cispo` | `target_tokens`, `logprobs`, `advantages` | `clip_low_threshold`, `clip_high_threshold` |
+| `dro` | `target_tokens`, `logprobs`, `advantages` | `beta` |
+
+`target_tokens` is `int64`; all other loss tensors are `float32`.
+Cross-entropy also accepts two-dimensional top-k targets and weights with
+matching shapes. RL losses require one target per position.
+
+`forward` and `forward_backward` return per-datum target logprobs plus a
+`loss:sum` metric. `forward_backward` accumulates gradients until
+`optim_step`; the optimizer call applies the SDK's Adam parameters without an
+implicit batch-size normalization. The SDK's `forward_backward_custom` is also
+supported: its client-side gradient is sent back through weighted
+cross-entropy, using the same standard endpoints.
+
+## Checkpoints and samplers
+
+`save_state` stores:
+
+- native per-rank Megatron LoRA shards;
+- an HF PEFT adapter snapshot;
+- per-slot Adam state; and
+- any gradients accumulated before the save.
+
+`load_state_with_optimizer` restores all four, including retained gradients.
+`load_state` restores weights only and resets optimizer state and gradients.
+`create_training_client_from_state` and
+`create_training_client_from_state_with_optimizer` are supported through the
+SDK weights-info flow.
+
+`save_weights_for_sampler(name)` creates a named immutable sampler snapshot.
+`save_weights_and_get_sampling_client()` creates an ephemeral one. Sampling
+supports token prompts, multiple samples, seeds, stop strings or token IDs,
+temperature, top-k, top-p, generation logprobs, prompt logprobs, and prompt
+top-k logprobs.
+
+## Compatibility boundary
+
+The current service intentionally rejects unsupported requests instead of
+silently changing their meaning:
+
+- LoRA training only; no full-parameter training.
+- Text token chunks only; no image, audio, or multimodal chunks.
+- One configured base model per service process.
+- No colocated GPUs, pipeline parallelism, context parallelism, or
+  fault-tolerant or independent-DP trainer replicas.
+- Packed THD training layout only; BSHD is rejected at startup.
+- No hosted-account, project, billing, checkpoint-listing, publishing, or
+  access-control APIs.
+- Protocol metadata, sessions, futures, and Tinker URI lookup live in the
+  controller's memory. Checkpoint files persist, but a service restart does
+  not currently rebuild URI metadata from disk.
+
+Use `GET /api/v1/healthz` for readiness. When `TINKER_API_KEY` or
+`--tinker-api-key` is set, pass the same value as `api_key` to
+`tinker.ServiceClient`. The environment variable takes precedence when both
+are present.

--- a/examples/README.md
+++ b/examples/README.md
@@ -17,6 +17,7 @@ recipes that are not fully verified.
 - **[on_policy_distillation](./on_policy_distillation)**: Example implementation for on-policy distillation, extending the reinforcement learning pipeline to support teacher–student distillation directly within on-policy training.
 - **[retool_v2](./retool_v2)**: Tool-enabled language model generation with sandboxed Python code execution interleaved with thinking.
 - **[swe-agent](./swe-agent)**: Trains coding and terminal agents with Harbor-managed sandboxes and verifier rewards.
+- **[tinker](./tinker)**: Serve Megatron LoRA training and SGLang sampling through the public Tinker Python SDK.
 
 ### [infra_features](./infra_features)
 

--- a/examples/tinker/README.md
+++ b/examples/tinker/README.md
@@ -1,0 +1,57 @@
+# Tinker SDK-compatible service
+
+Miles can expose its Megatron multi-LoRA trainer and SGLang rollout engines
+through the public [Tinker Python SDK](https://github.com/thinking-machines-lab/tinker).
+Existing Tinker data-plane code can create LoRA training clients, run losses and
+optimizer steps, checkpoint or restore state, and sample from immutable adapter
+snapshots without importing Miles.
+
+## Prerequisites
+
+- Miles and its normal Megatron dependencies.
+- Megatron-Bridge from the `bridge` branch.
+- SGLang from the `sglang-miles` branch.
+- The public Tinker SDK in the client environment (`pip install tinker`).
+- Disaggregated trainer and rollout GPUs. Pipeline and context parallel sizes
+  must both be 1, and the trainer must use the default packed THD layout.
+
+The example below uses one trainer GPU and one rollout GPU:
+
+```bash
+ray start --head --node-ip-address 127.0.0.1 --num-gpus 2 --disable-usage-stats
+
+TINKER_MODEL_PATH=/root/Qwen3-0.6B \
+MEGATRON_LM_PATH=/root/Megatron-LM \
+TINKER_API_KEY=tml-local \
+bash examples/tinker/run-qwen3-0.6b.sh
+```
+
+The service listens on `http://127.0.0.1:8068` by default. It remains alive
+until its Ray job is stopped. Set `TINKER_TRAIN_GPUS` and `TINKER_TP_SIZE` to
+exercise a larger tensor- or data-parallel trainer.
+
+## Verify with the official SDK
+
+From the node running the service:
+
+```bash
+python examples/tinker/client_smoke.py \
+  --base-url http://127.0.0.1:8068 \
+  --api-key tml-local \
+  --base-model Qwen/Qwen3-0.6B \
+  --tokenizer /root/Qwen3-0.6B
+```
+
+The smoke test exercises:
+
+1. server capabilities, sessions, and LoRA model creation;
+2. every built-in loss, top-k cross-entropy, custom loss, forward-backward, and Adam;
+3. checkpoints with retained gradients and optimizer state;
+4. exact-state restore into a second training client;
+5. weights-only restore with fresh optimizer state;
+6. named and ephemeral sampler snapshots;
+7. sampling, generation logprobs, prompt logprobs, and prompt top-k logprobs;
+8. base-model sampling.
+
+See [the Tinker API guide](../../docs/user-guide/tinker-api.md) for the
+supported loss contracts, service flags, and current compatibility boundary.

--- a/examples/tinker/client_smoke.py
+++ b/examples/tinker/client_smoke.py
@@ -1,0 +1,250 @@
+"""End-to-end smoke test using only the public Tinker Python SDK.
+
+Run this against a live ``train_tinker.py`` service. The test covers model
+creation, forward/backward, Adam, exact optimizer-state restore, weights-only
+restore, named and ephemeral sampler snapshots, sampling, and prompt logprobs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import math
+import uuid
+
+import tinker
+from tinker import types
+from transformers import AutoTokenizer
+
+logging.getLogger("tinker.lib.api_future_impl").setLevel(logging.ERROR)
+
+
+def _cross_entropy_datum(tokenizer, text: str) -> tuple[types.Datum, list[int]]:
+    tokens = tokenizer.encode(text, add_special_tokens=True)
+    if len(tokens) < 2:
+        raise ValueError("smoke-test text must tokenize to at least two tokens")
+    model_tokens = tokens[:-1]
+    datum = types.Datum(
+        model_input=types.ModelInput.from_ints(model_tokens),
+        loss_fn_inputs={
+            "target_tokens": tokens[1:],
+            "weights": [1.0] * len(model_tokens),
+        },
+    )
+    return datum, model_tokens
+
+
+def _assert_forward_output(output: types.ForwardBackwardOutput, expected_values: int) -> None:
+    assert len(output.loss_fn_outputs) == 1
+    logprobs = output.loss_fn_outputs[0]["logprobs"].data
+    assert len(logprobs) == expected_values
+    assert all(math.isfinite(value) for value in logprobs)
+    assert output.metrics is not None
+    assert math.isfinite(output.metrics["loss:sum"])
+
+
+def _assert_sample(output: types.SampleResponse, expected_samples: int) -> None:
+    assert len(output.sequences) == expected_samples
+    for sequence in output.sequences:
+        assert sequence.tokens
+        assert sequence.logprobs is not None
+        assert len(sequence.tokens) == len(sequence.logprobs)
+        assert all(math.isfinite(value) for value in sequence.logprobs)
+
+
+def _assert_values_close(left: list[float], right: list[float]) -> None:
+    assert len(left) == len(right)
+    for left_value, right_value in zip(left, right, strict=True):
+        assert math.isclose(left_value, right_value, rel_tol=1e-6, abs_tol=1e-6)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-url", default="http://127.0.0.1:8068")
+    parser.add_argument("--api-key", default="tml-local")
+    parser.add_argument("--base-model", required=True)
+    parser.add_argument("--tokenizer", required=True)
+    parser.add_argument("--rank", type=int, default=8)
+    args = parser.parse_args()
+
+    service = tinker.ServiceClient(base_url=args.base_url.rstrip("/"), api_key=args.api_key)
+    capabilities = service.get_server_capabilities()
+    supported = {model.model_name for model in capabilities.supported_models}
+    assert args.base_model in supported
+
+    tokenizer = AutoTokenizer.from_pretrained(args.tokenizer, local_files_only=True)
+    datum, prompt_tokens = _cross_entropy_datum(
+        tokenizer,
+        "Tinker-compatible training in Miles updates a LoRA adapter.",
+    )
+    data = [datum]
+    adam = types.AdamParams(
+        learning_rate=1e-4,
+        beta1=0.9,
+        beta2=0.95,
+        eps=1e-8,
+        weight_decay=0.0,
+        grad_clip_norm=1.0,
+    )
+
+    print("1/8 create LoRA training client")
+    training = service.create_lora_training_client(
+        base_model=args.base_model,
+        rank=args.rank,
+        seed=7,
+        train_mlp=True,
+        train_attn=True,
+        train_unembed=True,
+    )
+    info = training.get_info()
+    assert info.is_lora
+    assert info.lora_rank == args.rank
+
+    print("2/8 forward all public losses and run forward_backward")
+    forward = training.forward(data, "cross_entropy").result()
+    _assert_forward_output(forward, len(prompt_tokens))
+    targets = datum.loss_fn_inputs["target_tokens"].tolist()
+    baseline_logprobs = forward.loss_fn_outputs[0]["logprobs"].tolist()
+    advantages = [1.0 if index % 2 == 0 else -0.5 for index in range(len(prompt_tokens))]
+    rl_data = [
+        types.Datum(
+            model_input=datum.model_input,
+            loss_fn_inputs={
+                "target_tokens": targets,
+                "logprobs": baseline_logprobs,
+                "advantages": advantages,
+            },
+        )
+    ]
+    for loss_fn, config in [
+        ("importance_sampling", None),
+        ("ppo", {"clip_low_threshold": 0.8, "clip_high_threshold": 1.2}),
+        ("cispo", {"clip_low_threshold": 0.0, "clip_high_threshold": 4.0}),
+        ("dro", {"beta": 0.05}),
+    ]:
+        _assert_forward_output(
+            training.forward(rl_data, loss_fn, config).result(),
+            len(prompt_tokens),
+        )
+
+    topk_data = [
+        types.Datum(
+            model_input=datum.model_input,
+            loss_fn_inputs={
+                "target_tokens": [[target, target] for target in targets],
+                "weights": [[1.0, 0.0] for _ in targets],
+            },
+        )
+    ]
+    _assert_forward_output(
+        training.forward(topk_data, "cross_entropy").result(),
+        2 * len(prompt_tokens),
+    )
+    _assert_forward_output(
+        training.forward_backward(data, "cross_entropy").result(),
+        len(prompt_tokens),
+    )
+
+    def custom_loss(_data, logprobs):
+        loss = -sum(logprob.mean() for logprob in logprobs)
+        return loss, {"custom_loss": float(loss.detach())}
+
+    custom_output = training.forward_backward_custom(data, custom_loss).result()
+    assert custom_output.metrics is not None
+    assert math.isfinite(custom_output.metrics["custom_loss"])
+
+    print("3/8 save retained gradients and optimizer state")
+    suffix = uuid.uuid4().hex[:8]
+    training_state = training.save_state(f"smoke-training-{suffix}").result()
+    first_step = training.optim_step(adam).result()
+    assert first_step.metrics is not None
+    first_grad_norm = first_step.metrics["grad_norm"]
+    assert math.isfinite(first_grad_norm)
+    assert first_grad_norm > 0
+
+    print("4/8 create a second client from exact training state")
+    restored = service.create_training_client_from_state_with_optimizer(training_state.path)
+    restored_step = restored.optim_step(adam).result()
+    assert restored_step.metrics is not None
+    restored_grad_norm = restored_step.metrics["grad_norm"]
+    assert math.isfinite(restored_grad_norm)
+    print(f"    retained-gradient norm: source={first_grad_norm:.9g}, restored={restored_grad_norm:.9g}")
+    assert math.isclose(restored_grad_norm, first_grad_norm, rel_tol=1e-6, abs_tol=1e-8)
+
+    # The first checkpoint was intentionally taken before Adam had moments.
+    # Take another after one step, restore it across slots, and prove that the
+    # FP32 masters, moments, step clock, and retained gradients continue
+    # identically by comparing the next update's model outputs.
+    training.forward_backward(data, "cross_entropy").result()
+    adam_state = training.save_state(f"smoke-adam-{suffix}").result()
+    restored.load_state_with_optimizer(adam_state.path).result()
+    second_step = training.optim_step(adam).result()
+    restored_second_step = restored.optim_step(adam).result()
+    assert second_step.metrics is not None
+    assert restored_second_step.metrics is not None
+    assert math.isclose(
+        second_step.metrics["grad_norm"],
+        restored_second_step.metrics["grad_norm"],
+        rel_tol=1e-6,
+        abs_tol=1e-8,
+    )
+    source_logprobs = training.forward(data, "cross_entropy").result().loss_fn_outputs[0]["logprobs"].tolist()
+    restored_logprobs = restored.forward(data, "cross_entropy").result().loss_fn_outputs[0]["logprobs"].tolist()
+    _assert_values_close(source_logprobs, restored_logprobs)
+
+    print("5/8 weights-only restore resets optimizer and retained gradients")
+    training.load_state(training_state.path).result()
+    training.forward_backward(data, "cross_entropy").result()
+    training.optim_step(adam).result()
+
+    print("6/8 named sampler snapshot, sampling, and prompt logprobs")
+    sampler_state = training.save_weights_for_sampler(f"smoke-sampler-{suffix}").result()
+    sampler = service.create_sampling_client(model_path=sampler_state.path)
+    sample_params = types.SamplingParams(
+        max_tokens=4,
+        seed=11,
+        temperature=0.8,
+        top_k=20,
+        top_p=0.95,
+    )
+    sample = sampler.sample(
+        prompt=types.ModelInput.from_ints(prompt_tokens),
+        num_samples=2,
+        sampling_params=sample_params,
+        include_prompt_logprobs=True,
+        topk_prompt_logprobs=3,
+    ).result()
+    _assert_sample(sample, expected_samples=2)
+    assert sample.prompt_logprobs is not None
+    assert len(sample.prompt_logprobs) == len(prompt_tokens)
+    assert sample.topk_prompt_logprobs is not None
+    assert len(sample.topk_prompt_logprobs) == len(prompt_tokens)
+    computed = sampler.compute_logprobs(types.ModelInput.from_ints(prompt_tokens)).result()
+    assert len(computed) == len(prompt_tokens)
+
+    print("7/8 ephemeral sampler snapshot")
+    ephemeral = training.save_weights_and_get_sampling_client()
+    _assert_sample(
+        ephemeral.sample(
+            prompt=types.ModelInput.from_ints(prompt_tokens),
+            num_samples=1,
+            sampling_params=types.SamplingParams(max_tokens=2, seed=13),
+        ).result(),
+        expected_samples=1,
+    )
+
+    print("8/8 base-model sampling session")
+    base_sampler = service.create_sampling_client(base_model=args.base_model)
+    _assert_sample(
+        base_sampler.sample(
+            prompt=types.ModelInput.from_ints(prompt_tokens),
+            num_samples=1,
+            sampling_params=types.SamplingParams(max_tokens=2, seed=17),
+        ).result(),
+        expected_samples=1,
+    )
+    print("TINKER SDK SMOKE TEST PASSED")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/tinker/run-qwen3-0.6b.sh
+++ b/examples/tinker/run-qwen3-0.6b.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/../.." >/dev/null 2>&1 && pwd)"
+source "${REPO_ROOT}/scripts/models/qwen3-0.6B.sh"
+
+TINKER_MODEL_PATH="${TINKER_MODEL_PATH:-/root/Qwen3-0.6B}"
+TINKER_MODEL_NAME="${TINKER_MODEL_NAME:-Qwen/Qwen3-0.6B}"
+TINKER_CHECKPOINT_DIR="${TINKER_CHECKPOINT_DIR:-/root/tinker-checkpoints}"
+TINKER_API_PORT="${TINKER_API_PORT:-8068}"
+MEGATRON_LM_PATH="${MEGATRON_LM_PATH:-/root/Megatron-LM}"
+TINKER_MAX_MODELS="${TINKER_MAX_MODELS:-8}"
+TINKER_TRAIN_GPUS="${TINKER_TRAIN_GPUS:-1}"
+TINKER_ROLLOUT_GPUS="${TINKER_ROLLOUT_GPUS:-1}"
+TINKER_TP_SIZE="${TINKER_TP_SIZE:-1}"
+
+RUNTIME_ENV_JSON="$(
+  TINKER_RUNTIME_REPO_ROOT="${REPO_ROOT}" \
+  TINKER_RUNTIME_MEGATRON_LM_PATH="${MEGATRON_LM_PATH}" \
+    python3 -c '
+import json
+import os
+
+env_vars = {
+    "PYTHONPATH": (
+        os.environ["TINKER_RUNTIME_MEGATRON_LM_PATH"]
+        + ":"
+        + os.environ["TINKER_RUNTIME_REPO_ROOT"]
+    ),
+    "CUDA_DEVICE_MAX_CONNECTIONS": "1",
+    "PYTHONUNBUFFERED": "1",
+}
+if api_key := os.environ.get("TINKER_API_KEY"):
+    env_vars["TINKER_API_KEY"] = api_key
+print(json.dumps({"env_vars": env_vars}))
+'
+)"
+
+ray job submit --address=http://127.0.0.1:8265 \
+  --runtime-env-json="${RUNTIME_ENV_JSON}" \
+  -- python3 "${REPO_ROOT}/train_tinker.py" \
+  --actor-num-nodes 1 \
+  --actor-num-gpus-per-node "${TINKER_TRAIN_GPUS}" \
+  --rollout-num-gpus "${TINKER_ROLLOUT_GPUS}" \
+  --use-miles-router \
+  "${MODEL_ARGS[@]}" \
+  --hf-checkpoint "${TINKER_MODEL_PATH}" \
+  --megatron-to-hf-mode bridge \
+  --lora-rank 32 \
+  --lora-alpha 32 \
+  --lora-dropout 0.0 \
+  --target-modules q_proj,k_proj,v_proj,o_proj,gate_proj,up_proj,down_proj,lm_head \
+  --multi-lora-n-adapters "${TINKER_MAX_MODELS}" \
+  --multi-lora-idle-poll-s 1 \
+  --multi-lora-max-coalesce-wait-s 0.5 \
+  --multi-lora-api-port "${TINKER_API_PORT}" \
+  --tinker-model-name "${TINKER_MODEL_NAME}" \
+  --tinker-tokenizer-id "${TINKER_MODEL_PATH}" \
+  --tinker-checkpoint-dir "${TINKER_CHECKPOINT_DIR}" \
+  --pause-generation-mode in_place \
+  --max-weight-staleness 3 \
+  --num-rollout 1 \
+  --rollout-batch-size 1 \
+  --n-samples-per-prompt 1 \
+  --rollout-max-response-len 64 \
+  --rollout-temperature 1 \
+  --global-batch-size 1 \
+  --advantage-estimator grpo \
+  --kl-loss-coef 0.0 \
+  --kl-coef 0.0 \
+  --entropy-coef 0.0 \
+  --eps-clip 0.2 \
+  --eps-clip-high 0.28 \
+  --optimizer adam \
+  --lr 1e-4 \
+  --lr-decay-style constant \
+  --weight-decay 0.0 \
+  --adam-beta1 0.9 \
+  --adam-beta2 0.95 \
+  --tensor-model-parallel-size "${TINKER_TP_SIZE}" \
+  --pipeline-model-parallel-size 1 \
+  --context-parallel-size 1 \
+  --expert-model-parallel-size 1 \
+  --expert-tensor-parallel-size 1 \
+  --use-dynamic-batch-size \
+  --max-tokens-per-gpu 4096 \
+  --rollout-num-gpus-per-engine 1 \
+  --sglang-mem-fraction-static 0.7 \
+  --attention-dropout 0.0 \
+  --hidden-dropout 0.0 \
+  --accumulate-allreduce-grads-in-fp32 \
+  --attention-softmax-in-fp32 \
+  --attention-backend flash

--- a/miles/backends/megatron_utils/actor.py
+++ b/miles/backends/megatron_utils/actor.py
@@ -601,6 +601,22 @@ class MegatronTrainRayActor(TrainRayActor):
             for name in cleanup_names - loaded_names:
                 ray.get(get_multi_lora_controller().free_slot.remote(name))
 
+    @with_logs
+    @timer
+    def tinker_execute(self, operation: dict) -> dict | None:
+        """Execute one Tinker API operation collectively on the trainer."""
+        self._heartbeat.bump()
+        from miles.backends.megatron_utils.tinker import execute_tinker_operation
+
+        return execute_tinker_operation(
+            self.args,
+            self.model,
+            self.optimizer,
+            self.loaded_adapters,
+            self._multi_lora_pending_push,
+            operation,
+        )
+
     @timer
     def save_model(self, rollout_id: int, force_sync: bool = False) -> None:
         self._heartbeat.bump()

--- a/miles/backends/megatron_utils/bridge_lora_helpers.py
+++ b/miles/backends/megatron_utils/bridge_lora_helpers.py
@@ -10,6 +10,7 @@ import logging
 from argparse import Namespace
 from dataclasses import dataclass
 
+import torch
 from megatron.core.utils import get_attr_wrapped_model
 
 from miles.utils.hf_config import load_hf_config
@@ -31,6 +32,39 @@ class _BridgeWrapperConfig:
 
 def _ensure_model_list(model):
     return model if isinstance(model, list) else [model]
+
+
+def _add_parameterless_output_anchors(model_chunks, target_modules: list[str]) -> list[torch.nn.Module]:
+    """Give tied output layers a temporary device/dtype parameter.
+
+    Megatron omits ``output_layer.weight`` when input embeddings and the
+    unembedding are tied, passing the shared embedding weight into ``forward``
+    instead. MultiLoRALinear only needs a parameter while it constructs its
+    buffers, so install a zero-sized anchor during the Bridge transform and
+    remove it before DDP sees the model.
+    """
+    if "output_layer" not in {target.rsplit(".", 1)[-1] for target in target_modules}:
+        return []
+
+    anchored = []
+    for model_chunk in _ensure_model_list(model_chunks):
+        source = next(model_chunk.parameters(), None)
+        if source is None:
+            continue
+        for name, module in model_chunk.named_modules():
+            if name.rsplit(".", 1)[-1] != "output_layer" or next(module.parameters(), None) is not None:
+                continue
+            module.register_parameter(
+                "_miles_lora_device_anchor",
+                torch.nn.Parameter(source.new_empty(0), requires_grad=False),
+            )
+            anchored.append(module)
+    return anchored
+
+
+def _remove_parameterless_output_anchors(modules: list[torch.nn.Module]) -> None:
+    for module in modules:
+        delattr(module, "_miles_lora_device_anchor")
 
 
 def _make_value_model_hook(hidden_size: int, sequence_parallel: bool):
@@ -177,7 +211,11 @@ def _setup_lora_model_via_bridge(args: Namespace) -> list:
         lora = create_lora_instance(args)
 
     def apply_lora_hook(model_chunks):
-        transformed = lora(model_chunks, training=True)
+        anchors = _add_parameterless_output_anchors(model_chunks, lora.target_modules)
+        try:
+            transformed = lora(model_chunks, training=True)
+        finally:
+            _remove_parameterless_output_anchors(anchors)
         lora.set_params_to_save(transformed)
         return transformed
 

--- a/miles/backends/megatron_utils/lora_utils.py
+++ b/miles/backends/megatron_utils/lora_utils.py
@@ -31,6 +31,8 @@ _STANDARD_LORA_HF_TO_MEGATRON = {
     # GDN (Qwen3.5/Qwen3-Next): both slices live in the single fused megatron in_proj
     "in_proj_qkvz": "in_proj",
     "in_proj_ba": "in_proj",
+    "lm_head": "output_layer",
+    "unembed_tokens": "output_layer",
 }
 
 _STANDARD_LORA_ALL_MODULES = ["linear_qkv", "linear_proj", "linear_fc1", "linear_fc2"]
@@ -46,6 +48,8 @@ _CANONICAL_LORA_HF_TO_MEGATRON = {
     "down_proj": "linear_fc2",
     "in_proj_qkvz": "in_proj",
     "in_proj_ba": "in_proj",
+    "lm_head": "output_layer",
+    "unembed_tokens": "output_layer",
 }
 
 _CANONICAL_LORA_ALL_MODULES = [
@@ -74,6 +78,9 @@ _MEGATRON_TO_HF_MODULES = {
     "linear_fc1_up": ["up_proj"],
     # GDN linear attention: SGLang serves the fused in_proj as two modules
     "in_proj": ["in_proj_qkvz", "in_proj_ba"],
+    "output_layer": ["lm_head"],
+    "lm_head": ["lm_head"],
+    "unembed_tokens": ["lm_head"],
 }
 
 _HF_MODULE_NAMES = {
@@ -86,6 +93,8 @@ _HF_MODULE_NAMES = {
     "down_proj",
     "in_proj_qkvz",
     "in_proj_ba",
+    "lm_head",
+    "unembed_tokens",
 }
 
 # DeepSeek / Kimi MLA (HF names on checkpoint; Megatron uses linear_* from Megatron-Bridge mappings).

--- a/miles/backends/megatron_utils/multi_lora_optimizer.py
+++ b/miles/backends/megatron_utils/multi_lora_optimizer.py
@@ -17,22 +17,34 @@ from megatron.core.process_groups_config import ProcessGroupCollection
 logger = logging.getLogger(__name__)
 
 
-def adapter_slot_parameters(model, slot: int) -> list[torch.nn.Parameter]:
-    """All parameters belonging to one adapter slot, across model chunks."""
+def named_adapter_slot_parameters(model, slot: int) -> list[tuple[str, torch.nn.Parameter]]:
+    """All parameters belonging to one adapter slot, with slot-independent names.
+
+    The names deliberately stop at the ``MultiLoRALinear`` wrapper and then append
+    the adapter-local parameter name.  This makes the same logical LoRA tensor use
+    the same key in every slot, which is required when moving optimizer state
+    between Tinker training clients.
+    """
     from megatron.bridge.peft.multi_lora_layers import MultiLoRALinear
 
-    parameters = []
+    parameters: list[tuple[str, torch.nn.Parameter]] = []
     seen = set()
     model_chunks = model if isinstance(model, (list, tuple)) else [model]
-    for model_chunk in model_chunks:
-        for module in model_chunk.modules():
+    for chunk_index, model_chunk in enumerate(model_chunks):
+        for module_name, module in model_chunk.named_modules():
             if not isinstance(module, MultiLoRALinear):
                 continue
-            for param in module.adapters[slot].parameters():
+            for adapter_name, param in module.adapters[slot].named_parameters():
                 if id(param) not in seen:
-                    parameters.append(param)
+                    name = f"model{chunk_index}.{module_name}.{adapter_name}"
+                    parameters.append((name, param))
                     seen.add(id(param))
     return parameters
+
+
+def adapter_slot_parameters(model, slot: int) -> list[torch.nn.Parameter]:
+    """All parameters belonging to one adapter slot, across model chunks."""
+    return [param for _, param in named_adapter_slot_parameters(model, slot)]
 
 
 def _adam_init_state_fn(opt, config=None):
@@ -159,18 +171,22 @@ def step_adapter_slots(
     model,
     step_batch_sizes: dict[int, int],
     clip_grad: float,
+    *,
+    normalize_by_batch_size: bool = True,
 ) -> dict[int, float]:
     """Step exactly the slots in ``step_batch_sizes`` (slot -> batch size), retaining all other slots' gradients;
-    scales each slot's accumulated grad sum by 1/batch_size and returns the grad norm per stepped slot."""
+    optionally scales each slot's accumulated grad sum by 1/batch_size and returns the grad norm per stepped slot."""
     grad_norms: dict[int, float] = {}
 
     for slot, batch_size in step_batch_sizes.items():
+        if batch_size <= 0:
+            raise ValueError(f"adapter slot {slot} batch size must be positive")
         children = _slot_children(optimizer, slot)
         # Copy accumulated main_grads into the owned masters' grads, then scale the sum to the adapter-batch mean.
         for child in children:
             child.prepare_grads()
             for main_param in child.get_parameters():
-                if main_param.grad is not None:
+                if normalize_by_batch_size and main_param.grad is not None:
                     main_param.grad.mul_(1.0 / batch_size)
 
         # Per-slot grad norm over the slot's children, reduced across the whole world (whole-param DP scatter).

--- a/miles/backends/megatron_utils/multi_lora_utils.py
+++ b/miles/backends/megatron_utils/multi_lora_utils.py
@@ -296,6 +296,101 @@ def save_multi_lora_checkpoints(
             dist.barrier()
 
 
+def _tinker_module_group(base_linear_name: str) -> str:
+    """Map a Megatron module path to Tinker's attention/MLP/unembed groups."""
+    leaf = base_linear_name.rsplit(".", 1)[-1]
+    if leaf in {"output_layer", "lm_head", "unembed_tokens"}:
+        return "unembed"
+    if (
+        ".mlp." in base_linear_name
+        or ".experts." in base_linear_name
+        or leaf
+        in {
+            "linear_fc1",
+            "linear_fc1_gate",
+            "linear_fc1_up",
+            "linear_fc2",
+            "gate_proj",
+            "up_proj",
+            "down_proj",
+        }
+    ):
+        return "mlp"
+    return "attn"
+
+
+def _multi_lora_module_name(module) -> str:
+    """Return the wrapped linear name across Bridge multi-LoRA variants.
+
+    ``MultiLoRAGroupedExpertLinear`` publishes the name on the wrapper, while
+    the current dense ``MultiLoRALinear`` keeps it on each slot adapter.
+    """
+    name = getattr(module, "base_linear_name", None)
+    if isinstance(name, str) and name:
+        return name
+    adapters = getattr(module, "adapters", ())
+    if len(adapters):
+        name = getattr(adapters[0], "base_linear_name", None)
+        if isinstance(name, str) and name:
+            return name
+    raise RuntimeError(f"cannot determine wrapped linear name for {type(module).__name__}")
+
+
+def _reset_adapter_slot_with_seed(model, slot: int, seed: int) -> None:
+    """Initialize a slot reproducibly without advancing Megatron's tracked RNG streams."""
+    from megatron.bridge.peft.multi_lora_layers import (
+        MultiLoRAGroupedExpertLinear,
+        _iter_multi_lora_modules,
+    )
+    from megatron.bridge.peft.utils import ParallelLinearAdapter
+
+    parallel_state = get_parallel_state()
+    modules = sorted(_iter_multi_lora_modules(model), key=_multi_lora_module_name)
+    dense_modules = [module for module in modules if not isinstance(module, MultiLoRAGroupedExpertLinear)]
+    expert_modules = [module for module in modules if isinstance(module, MultiLoRAGroupedExpertLinear)]
+
+    def initialize(selected_modules, module_seed: int) -> None:
+        if not selected_modules:
+            return
+        torch.cuda.manual_seed(module_seed)
+        for module in selected_modules:
+            adapter = module.adapters[slot]
+            column_init = ParallelLinearAdapter._get_init_fn(None, module._column_init_method)
+            row_init = ParallelLinearAdapter._get_init_fn(None, module._row_init_method)
+            column_init(adapter.linear_in.weight.data)
+            row_init(adapter.linear_out.weight.data)
+
+    device = torch.cuda.current_device()
+    with torch.random.fork_rng(devices=[device]):
+        initialize(dense_modules, seed + 2718 + parallel_state.tp.rank)
+        initialize(
+            expert_modules,
+            seed + 1024 + 100 * parallel_state.ep.rank + parallel_state.etp.rank,
+        )
+
+
+def _apply_tinker_module_groups(config, model, slot: int) -> None:
+    """Disable slot deltas for Tinker module groups that were not requested."""
+    requested = {
+        "unembed": getattr(config, "train_unembed", True),
+        "mlp": getattr(config, "train_mlp", True),
+        "attn": getattr(config, "train_attn", True),
+    }
+    if all(requested.values()):
+        return
+
+    from megatron.bridge.peft.multi_lora_layers import _iter_multi_lora_modules
+
+    with torch.no_grad():
+        for module in _iter_multi_lora_modules(model):
+            if requested[_tinker_module_group(_multi_lora_module_name(module))]:
+                continue
+            module.alpha_values[slot] = 0
+            # Keep the exported PEFT adapter a true no-op too: SGLang has one
+            # global alpha and cannot consume Megatron's per-module alpha mask.
+            module.adapters[slot].linear_out.weight.zero_()
+
+
 def _register_adapter(adapter: AdapterRun, model) -> int:
     """Install one adapter on this rank's local model shard. Returns the step
     of the checkpoint it resumed from (0 for a fresh adapter)."""
@@ -316,6 +411,8 @@ def _register_adapter(adapter: AdapterRun, model) -> int:
     if ckpt is None:
         logger.info(f"{log_prefix} no checkpoint, starting from random init")
         step = 0
+        if (seed := getattr(config, "seed", None)) is not None:
+            _reset_adapter_slot_with_seed(model, slot, seed)
     else:
         state_dict = torch.load(ckpt, map_location="cpu", weights_only=True)
         loaded = load_adapter(model, slot, state_dict)
@@ -326,6 +423,7 @@ def _register_adapter(adapter: AdapterRun, model) -> int:
         logger.info(f"{log_prefix} loaded from {ckpt} ({loaded} tensors)")
 
     init_adapter_slot(model, slot, rank=config.rank, alpha=config.alpha)
+    _apply_tinker_module_groups(config, model, slot)
     logger.info(f"{log_prefix} installed at slot {slot}")
     return step
 

--- a/miles/backends/megatron_utils/tinker.py
+++ b/miles/backends/megatron_utils/tinker.py
@@ -1,0 +1,795 @@
+"""Megatron execution path for the Tinker-compatible API."""
+
+from __future__ import annotations
+
+import os
+from argparse import Namespace
+from pathlib import Path
+from typing import Any
+
+import ray
+import torch
+import torch.distributed as dist
+from megatron.core.pipeline_parallel import get_forward_backward_func
+from megatron.core.utils import get_model_config
+
+from miles.backends.megatron_utils.multi_lora_optimizer import (
+    _slot_children,
+    named_adapter_slot_parameters,
+    reset_grad_metadata_keep_grads,
+    step_adapter_slots,
+    zero_adapter_slot_grads,
+)
+from miles.backends.megatron_utils.tinker_loss import (
+    compute_tinker_loss,
+    tensor_data,
+    tensor_from_payload,
+    validate_and_get_targets,
+)
+from miles.backends.training_utils.loss_hub.math_utils import (
+    _gather_true_on_policy_full_logits,
+)
+from miles.backends.training_utils.parallel import get_parallel_state
+from miles.ray.multi_lora.controller import get_multi_lora_controller
+from miles.ray.tinker.protocol import TinkerError
+from miles.utils.distributed_utils import get_gloo_group
+
+
+def execute_tinker_operation(
+    args: Namespace,
+    model,
+    optimizer,
+    loaded_adapters: dict[str, object],
+    pending_push: set[str],
+    operation: dict[str, Any],
+) -> dict[str, Any] | None:
+    """Execute one serialized Tinker model operation on every Megatron rank."""
+    kind = operation["kind"]
+    payload = operation["payload"]
+    model_id = operation["model_id"]
+
+    if kind in {"forward", "forward_backward"}:
+        return _execute_forward(
+            args,
+            model,
+            payload,
+            backward=kind == "forward_backward",
+        )
+    if kind == "optim_step":
+        result = _execute_optim_step(
+            model,
+            optimizer,
+            slot=payload["slot"],
+            adam_params=payload["adam_params"],
+        )
+        pending_push.add(model_id)
+        if _is_main_rank():
+            ray.get(get_multi_lora_controller().advance_adapter_step.remote(model_id))
+            return {"_operation_kind": kind, **result}
+        return None
+    if kind in {"save_weights", "save_weights_for_sampler"}:
+        adapter = _require_loaded_adapter(loaded_adapters, model_id)
+        _save_checkpoint(
+            args,
+            model,
+            optimizer,
+            adapter=adapter,
+            model_id=model_id,
+            slot=payload["slot"],
+            checkpoint_step=payload["checkpoint_step"],
+            local_path=Path(payload["local_path"]),
+            include_optimizer=payload["include_optimizer"],
+        )
+        if _is_main_rank():
+            return {
+                "_operation_kind": kind,
+                "tinker_path": payload["tinker_path"],
+                "sampling_session_seq_id": payload.get("sampling_session_seq_id"),
+            }
+        return None
+    if kind == "load_weights":
+        adapter = _require_loaded_adapter(loaded_adapters, model_id)
+        _load_checkpoint(
+            model,
+            optimizer,
+            adapter=adapter,
+            slot=payload["slot"],
+            local_path=Path(payload["local_path"]),
+            load_optimizer=payload["optimizer"],
+        )
+        pending_push.add(model_id)
+        if _is_main_rank():
+            return {
+                "_operation_kind": kind,
+                "tinker_path": payload["tinker_path"],
+            }
+        return None
+    raise TinkerError(f"unsupported Tinker operation {kind!r}", category="user")
+
+
+def _execute_forward(
+    args: Namespace,
+    model,
+    payload: dict[str, Any],
+    *,
+    backward: bool,
+) -> dict[str, Any] | None:
+    parallel_state = get_parallel_state()
+    if parallel_state.pp.size != 1 or parallel_state.cp.size != 1:
+        raise TinkerError(
+            "the Tinker executor currently requires pipeline and context parallel size 1",
+            category="user",
+        )
+
+    pad_multiple = max(1, parallel_state.tp.size * args.data_pad_size_multiplier)
+    configured_max_tokens = getattr(args, "max_tokens_per_gpu", None)
+    max_tokens = args.seq_length if configured_max_tokens is None else configured_max_tokens
+    if max_tokens <= 0:
+        raise TinkerError("max_tokens_per_gpu must be positive", category="server")
+    validated = _validate_forward_payload(
+        payload,
+        vocab_size=getattr(args, "vocab_size", None),
+        max_sequence_length=args.seq_length,
+    )
+    for datum in validated:
+        padded_tokens = _round_up(len(datum["tokens"]), pad_multiple)
+        if padded_tokens > max_tokens:
+            raise TinkerError(
+                f"datum {datum['index']} requires {padded_tokens} padded tokens, exceeding max_tokens_per_gpu={max_tokens}",
+                category="user",
+            )
+
+    local_datums = validated[parallel_state.effective_dp.rank :: parallel_state.effective_dp.size]
+    local_batches = _build_microbatches(
+        local_datums,
+        slot=payload["slot"],
+        n_adapters=args.multi_lora_n_adapters,
+        pad_multiple=pad_multiple,
+        max_tokens=max_tokens,
+    )
+    num_microbatches = len(local_batches)
+    config = get_model_config(model[0])
+    config.timers = None
+    local_records: list[dict[str, Any]] = []
+
+    def forward_step(data_iterator, model_chunk, return_schedule_plan: bool = False):
+        if return_schedule_plan:
+            raise TinkerError("combined 1f1b is not supported by the Tinker executor", category="user")
+
+        from megatron.bridge.peft.multi_lora_layers import set_tokens_per_adapter_slot
+
+        batch = next(data_iterator)
+        batch_datums = batch["datums"]
+        set_tokens_per_adapter_slot(model_chunk, batch["adapter_token_counts"])
+        logits = model_chunk(
+            input_ids=batch["tokens"],
+            position_ids=None,
+            attention_mask=None,
+            labels=None,
+            packed_seq_params=batch["packed_seq_params"],
+            loss_mask=batch["loss_mask"],
+        )
+
+        if backward:
+
+            def loss_func(output_tensor):
+                local_loss, records = _loss_and_records(
+                    output_tensor,
+                    batch_datums,
+                    payload["loss_fn"],
+                    payload["loss_fn_config"],
+                    vocab_size=args.vocab_size,
+                )
+                local_records.extend(records)
+                # Megatron averages loss gradients over microbatches and DDP
+                # averages over replicas; undo the latter for Tinker's sum loss.
+                scaled_loss = local_loss * num_microbatches * parallel_state.intra_dp.size
+                return (
+                    scaled_loss,
+                    torch.tensor(1, dtype=torch.int64, device=scaled_loss.device),
+                    {
+                        "keys": ["loss"],
+                        "values": torch.stack(
+                            [
+                                torch.ones((), device=scaled_loss.device),
+                                local_loss.detach().to(dtype=torch.float32),
+                            ]
+                        ),
+                    },
+                )
+
+            return logits, loss_func
+
+        def collect(output_tensor, non_loss_data: bool = False):
+            assert non_loss_data
+            _local_loss, records = _loss_and_records(
+                output_tensor,
+                batch_datums,
+                payload["loss_fn"],
+                payload["loss_fn_config"],
+                vocab_size=args.vocab_size,
+            )
+            local_records.extend(records)
+            return {}
+
+        return logits, collect
+
+    if backward:
+        for model_chunk in model:
+            model_chunk.train()
+        reset_grad_metadata_keep_grads(model)
+        get_forward_backward_func()(
+            forward_step_func=forward_step,
+            data_iterator=iter(local_batches),
+            model=model,
+            num_microbatches=num_microbatches,
+            seq_length=args.seq_length,
+            micro_batch_size=1,
+            decoder_seq_length=args.decoder_seq_length,
+            forward_only=False,
+        )
+    else:
+        for model_chunk in model:
+            model_chunk.eval()
+        try:
+            with torch.no_grad():
+                get_forward_backward_func()(
+                    forward_step_func=forward_step,
+                    data_iterator=iter(local_batches),
+                    model=model,
+                    num_microbatches=num_microbatches,
+                    seq_length=args.seq_length,
+                    micro_batch_size=1,
+                    decoder_seq_length=args.decoder_seq_length,
+                    forward_only=True,
+                    collect_non_loss_data=True,
+                )
+        finally:
+            for model_chunk in model:
+                model_chunk.train()
+
+    response = _gather_forward_response(local_records, len(validated))
+    if response is not None:
+        response["_operation_kind"] = "forward_backward" if backward else "forward"
+    return response
+
+
+def _validate_forward_payload(
+    payload: dict[str, Any],
+    *,
+    vocab_size: int | None,
+    max_sequence_length: int,
+) -> list[dict[str, Any]]:
+    """Run identical validation on every rank before entering collectives."""
+    loss_fn = payload["loss_fn"]
+    loss_fn_config = payload["loss_fn_config"]
+    validated = []
+    for index, datum in enumerate(payload["data"]):
+        tokens = datum["tokens"]
+        if not tokens:
+            raise TinkerError("model_input must contain at least one token", category="user")
+        if len(tokens) > max_sequence_length:
+            raise TinkerError(
+                f"datum {index} has {len(tokens)} tokens, exceeding the configured sequence length {max_sequence_length}",
+                category="user",
+            )
+        if vocab_size is not None and any(token < 0 or token >= vocab_size for token in tokens):
+            raise TinkerError(f"datum {index} has a model-input token outside the vocabulary", category="user")
+        inputs = {name: tensor_from_payload(value, device="cpu") for name, value in datum["loss_fn_inputs"].items()}
+        targets = validate_and_get_targets(
+            inputs,
+            model_input_length=len(tokens),
+            loss_fn=loss_fn,
+        )
+        if vocab_size is not None and (bool((targets < 0).any()) or bool((targets >= vocab_size).any())):
+            raise TinkerError(f"datum {index} has a target token outside the vocabulary", category="user")
+
+        # Validate shapes/config on every rank before any rank can block in a
+        # TP/DP collective. The zero logprobs preserve the requested shape.
+        compute_tinker_loss(
+            torch.zeros_like(targets, dtype=torch.float32),
+            inputs,
+            loss_fn=loss_fn,
+            loss_fn_config=loss_fn_config,
+        )
+        validated.append(
+            {
+                "index": index,
+                "tokens": tokens,
+                "inputs": inputs,
+            }
+        )
+    return validated
+
+
+def _build_microbatches(
+    local_datums: list[dict[str, Any]],
+    *,
+    slot: int,
+    n_adapters: int,
+    pad_multiple: int,
+    max_tokens: int,
+) -> list[dict[str, Any]]:
+    """Greedily pack local datums without exceeding the per-GPU token cap."""
+    if max_tokens <= 0:
+        raise TinkerError("max_tokens_per_gpu must be positive", category="server")
+
+    groups: list[list[dict[str, Any]]] = []
+    current: list[dict[str, Any]] = []
+    current_tokens = 0
+    for datum in local_datums:
+        datum_tokens = len(datum["tokens"])
+        padded_datum_tokens = _round_up(datum_tokens, pad_multiple)
+        if padded_datum_tokens > max_tokens:
+            raise TinkerError(
+                f"datum {datum['index']} requires {padded_datum_tokens} padded tokens, exceeding max_tokens_per_gpu={max_tokens}",
+                category="user",
+            )
+        candidate_tokens = current_tokens + datum_tokens
+        if current and _round_up(candidate_tokens, pad_multiple) > max_tokens:
+            groups.append(current)
+            current = []
+            current_tokens = 0
+        current.append(datum)
+        current_tokens += datum_tokens
+    if current:
+        groups.append(current)
+    if not groups:
+        groups.append([])
+
+    return [
+        _pack_batch(
+            group,
+            slot=slot,
+            n_adapters=n_adapters,
+            pad_multiple=pad_multiple,
+        )
+        for group in groups
+    ]
+
+
+def _pack_batch(
+    local_datums: list[dict[str, Any]],
+    *,
+    slot: int,
+    n_adapters: int,
+    pad_multiple: int,
+) -> dict[str, Any]:
+    from megatron.core.packed_seq_params import PackedSeqParams
+
+    device = torch.cuda.current_device()
+    token_tensors = [torch.tensor(datum["tokens"], dtype=torch.int64, device=device) for datum in local_datums]
+    if not token_tensors:
+        token_tensors = [torch.zeros(1, dtype=torch.int64, device=device)]
+
+    cu_seqlens = [0]
+    for tokens in token_tensors:
+        cu_seqlens.append(cu_seqlens[-1] + tokens.numel())
+    packed_tokens = torch.cat(token_tensors)
+    padding = (-packed_tokens.numel()) % pad_multiple
+    if padding:
+        packed_tokens = torch.nn.functional.pad(packed_tokens, (0, padding), value=0)
+        cu_seqlens.append(cu_seqlens[-1] + padding)
+
+    cu_seqlens_tensor = torch.tensor(cu_seqlens, dtype=torch.int32, device=device)
+    max_seqlen = int((cu_seqlens_tensor[1:] - cu_seqlens_tensor[:-1]).max().item())
+    counts = torch.zeros(n_adapters, dtype=torch.int32, device=device)
+    counts[slot] = packed_tokens.numel()
+    return {
+        "datums": local_datums,
+        "tokens": packed_tokens.unsqueeze(0),
+        "loss_mask": torch.zeros_like(packed_tokens).unsqueeze(0),
+        "adapter_token_counts": counts,
+        "packed_seq_params": PackedSeqParams(
+            cu_seqlens_q=cu_seqlens_tensor,
+            cu_seqlens_kv=cu_seqlens_tensor,
+            max_seqlen_q=max_seqlen,
+            max_seqlen_kv=max_seqlen,
+            qkv_format="thd",
+        ),
+    }
+
+
+def _loss_and_records(
+    logits: torch.Tensor,
+    local_datums: list[dict[str, Any]],
+    loss_fn: str,
+    loss_fn_config: dict[str, float],
+    *,
+    vocab_size: int,
+) -> tuple[torch.Tensor, list[dict[str, Any]]]:
+    parallel_state = get_parallel_state()
+    logits = logits.squeeze(0)
+    if not local_datums:
+        return logits.sum() * 0.0, []
+
+    offset = 0
+    losses = []
+    records = []
+    for datum in local_datums:
+        inputs = {name: value.to(device=logits.device, non_blocking=True) for name, value in datum["inputs"].items()}
+        targets = inputs["target_tokens"]
+        length = len(datum["tokens"])
+        datum_logits = logits[offset : offset + length]
+        offset += length
+
+        # Tinker logprobs must match serving over the real vocabulary, not
+        # Megatron's padded vocabulary. The replicated-loss gather has a custom
+        # backward that avoids an extra TP-size gradient multiplier.
+        full_logits = _gather_true_on_policy_full_logits(
+            datum_logits,
+            parallel_state.tp.group,
+            vocab_size=vocab_size,
+        )
+        gather_index = targets.unsqueeze(-1) if targets.ndim == 1 else targets
+        target_logprobs = torch.log_softmax(full_logits.to(dtype=torch.float32), dim=-1).gather(
+            dim=-1,
+            index=gather_index,
+        )
+        if targets.ndim == 1:
+            target_logprobs = target_logprobs.squeeze(-1)
+
+        loss = compute_tinker_loss(
+            target_logprobs,
+            inputs,
+            loss_fn=loss_fn,
+            loss_fn_config=loss_fn_config,
+        )
+        losses.append(loss)
+        records.append(
+            {
+                "index": datum["index"],
+                "loss": float(loss.detach().to(dtype=torch.float32).cpu()),
+                "output": {"logprobs": tensor_data(target_logprobs)},
+            }
+        )
+    return torch.stack(losses).sum(), records
+
+
+def _round_up(value: int, multiple: int) -> int:
+    return ((value + multiple - 1) // multiple) * multiple
+
+
+def _gather_forward_response(
+    local_records: list[dict[str, Any]],
+    num_datums: int,
+) -> dict[str, Any] | None:
+    if dist.is_initialized():
+        group = get_gloo_group()
+        gathered: list[object] = [None] * dist.get_world_size(group=group)
+        dist.all_gather_object(gathered, local_records, group=group)
+        if not _is_main_rank():
+            return None
+        records = [record for rank_records in gathered for record in rank_records]
+    else:
+        records = local_records
+
+    # TP/EP ranks produce identical records. Indexing by original datum both
+    # de-duplicates those copies and restores the SDK request order.
+    by_index = {record["index"]: record for record in records}
+    if set(by_index) != set(range(num_datums)):
+        missing = sorted(set(range(num_datums)) - set(by_index))
+        raise RuntimeError(f"Tinker forward result is missing datum indices {missing}")
+    ordered = [by_index[index] for index in range(num_datums)]
+    return {
+        "loss_fn_output_type": "ArrayRecord",
+        "loss_fn_outputs": [record["output"] for record in ordered],
+        "metrics": {"loss:sum": float(sum(record["loss"] for record in ordered))},
+    }
+
+
+def _execute_optim_step(
+    model,
+    optimizer,
+    *,
+    slot: int,
+    adam_params: dict[str, float],
+) -> dict[str, Any]:
+    for child in _slot_children(optimizer, slot):
+        for group in child.param_groups:
+            group["lr"] = adam_params["learning_rate"]
+            group["betas"] = (adam_params["beta1"], adam_params["beta2"])
+            group["eps"] = adam_params["eps"]
+            group["weight_decay"] = adam_params["weight_decay"]
+
+    norms = step_adapter_slots(
+        optimizer,
+        model,
+        {slot: 1},
+        clip_grad=adam_params["grad_clip_norm"],
+        normalize_by_batch_size=False,
+    )
+    return {"metrics": {"grad_norm": norms.get(slot, 0.0)}}
+
+
+def _save_checkpoint(
+    args: Namespace,
+    model,
+    optimizer,
+    *,
+    adapter,
+    model_id: str,
+    slot: int,
+    checkpoint_step: int,
+    local_path: Path,
+    include_optimizer: bool,
+) -> None:
+    from miles.backends.megatron_utils.multi_lora_utils import save_multi_lora_checkpoints
+
+    expected = adapter.config.save / "checkpoints" / f"step_{checkpoint_step}"
+    if expected != local_path:
+        raise RuntimeError(f"Tinker checkpoint path mismatch: expected {expected}, got {local_path}")
+    save_multi_lora_checkpoints(
+        args,
+        model,
+        {model_id: checkpoint_step},
+        {model_id: adapter},
+    )
+    if not include_optimizer:
+        return
+
+    named_params = named_adapter_slot_parameters(model, slot)
+    key_by_param = {id(param): name for name, param in named_params}
+    optimizer_state: dict[str, Any] = {}
+    optimizer_groups: list[list[dict[str, Any]]] = []
+    for child in _slot_children(optimizer, slot):
+        groups = []
+        for group in child.optimizer.param_groups:
+            groups.append({key: _to_cpu_tree(value) for key, value in group.items() if key not in {"params", "miles_multi_lora_slot"}})
+        optimizer_groups.append(groups)
+        for model_param, main_param in _owned_model_main_parameters(child):
+            try:
+                name = key_by_param[id(model_param)]
+            except KeyError:
+                raise RuntimeError("optimizer owns a parameter outside the requested LoRA slot") from None
+            if name in optimizer_state:
+                raise RuntimeError(f"optimizer owns duplicate LoRA parameter {name!r}")
+            optimizer_state[name] = {
+                "main_param": main_param.detach().cpu(),
+                "state": _to_cpu_tree(child.optimizer.state.get(main_param, {})),
+            }
+
+    parallel_state = get_parallel_state()
+    state = {
+        "format_version": 2,
+        "world_size": dist.get_world_size() if dist.is_initialized() else 1,
+        "topology": _model_parallel_coordinate(parallel_state),
+        "optimizer_state": optimizer_state,
+        "optimizer_groups": optimizer_groups,
+        "retained_grads": {name: None if getattr(param, "main_grad", None) is None else param.main_grad.detach().cpu() for name, param in named_params if name in optimizer_state},
+    }
+    sidecar = local_path / f"tinker_optimizer_rank{dist.get_rank() if dist.is_initialized() else 0}.pt"
+    temporary = sidecar.with_suffix(".tmp")
+    torch.save(state, temporary)
+    os.replace(temporary, sidecar)
+    if dist.is_initialized():
+        dist.barrier(group=get_gloo_group())
+
+
+def _load_checkpoint(
+    model,
+    optimizer,
+    *,
+    adapter,
+    slot: int,
+    local_path: Path,
+    load_optimizer: bool,
+) -> None:
+    from megatron.bridge.peft.multi_lora_layers import init_adapter_slot, load_adapter
+
+    from miles.backends.megatron_utils.multi_lora_utils import (
+        _apply_tinker_module_groups,
+        megatron_shard_name,
+        zero_optimizer_state_for_adapter,
+    )
+
+    parallel_state = get_parallel_state()
+    native_path = local_path / megatron_shard_name(
+        parallel_state.tp.rank,
+        parallel_state.pp.rank,
+        parallel_state.ep.rank,
+        parallel_state.ep.size,
+    )
+    if not native_path.exists():
+        raise TinkerError(f"checkpoint shard {native_path} does not exist", category="user")
+    state_dict = torch.load(native_path, map_location="cpu", weights_only=True)
+    loaded = load_adapter(model, slot, state_dict)
+    if loaded <= 0:
+        raise TinkerError(
+            f"checkpoint shard {native_path} did not contain any compatible LoRA tensors",
+            category="user",
+        )
+    init_adapter_slot(model, slot, rank=adapter.config.rank, alpha=adapter.config.alpha)
+    _apply_tinker_module_groups(adapter.config, model, slot)
+    optimizer.reload_model_params()
+
+    if load_optimizer:
+        saved_by_rank = _load_optimizer_sidecars(local_path, parallel_state)
+        local_rank = dist.get_rank() if dist.is_initialized() else 0
+        saved = saved_by_rank[local_rank]
+        children = _slot_children(optimizer, slot)
+        if len(saved["optimizer_groups"]) != len(children):
+            raise TinkerError(
+                "checkpoint optimizer topology does not match this trainer",
+                category="user",
+            )
+        optimizer_state = _merge_optimizer_state(saved_by_rank.values())
+        retained_grads = _merge_retained_grads(saved_by_rank.values())
+        key_by_param = {id(param): name for name, param in named_adapter_slot_parameters(model, slot)}
+        owned_names = set()
+        for child, saved_groups in zip(children, saved["optimizer_groups"], strict=True):
+            if len(saved_groups) != len(child.optimizer.param_groups):
+                raise TinkerError(
+                    "checkpoint optimizer parameter-group topology does not match this trainer",
+                    category="user",
+                )
+            for group, saved_group in zip(child.optimizer.param_groups, saved_groups, strict=True):
+                group.update(_to_device_tree(saved_group, _optimizer_group_device(group)))
+            for model_param, main_param in _owned_model_main_parameters(child):
+                try:
+                    name = key_by_param[id(model_param)]
+                    parameter_state = optimizer_state[name]
+                except KeyError:
+                    raise TinkerError(
+                        "checkpoint optimizer parameters do not match this trainer",
+                        category="user",
+                    ) from None
+                owned_names.add(name)
+                main_param.data.copy_(parameter_state["main_param"].to(device=main_param.device, dtype=main_param.dtype))
+                child.optimizer.state[main_param] = _to_device_tree(
+                    parameter_state["state"],
+                    main_param.device,
+                )
+
+        zero_adapter_slot_grads(model, slot)
+        for name, param in named_adapter_slot_parameters(model, slot):
+            if name not in owned_names:
+                continue
+            if name not in retained_grads:
+                raise TinkerError(
+                    "checkpoint retained-gradient topology does not match this trainer",
+                    category="user",
+                )
+            saved_grad = retained_grads[name]
+            if saved_grad is not None:
+                if getattr(param, "main_grad", None) is None:
+                    raise TinkerError(
+                        "checkpoint contains retained gradients, but this trainer has no matching gradient buffer",
+                        category="server",
+                    )
+                param.main_grad.copy_(saved_grad.to(device=param.main_grad.device, dtype=param.main_grad.dtype))
+    else:
+        zero_optimizer_state_for_adapter(optimizer, model, slot)
+        zero_adapter_slot_grads(model, slot)
+    if dist.is_initialized():
+        dist.barrier(group=get_gloo_group())
+
+
+def _to_cpu_tree(value):
+    if isinstance(value, torch.Tensor):
+        return value.detach().cpu()
+    if isinstance(value, dict):
+        return {key: _to_cpu_tree(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_to_cpu_tree(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_to_cpu_tree(item) for item in value)
+    return value
+
+
+def _to_device_tree(value, device: torch.device):
+    if isinstance(value, torch.Tensor):
+        return value.to(device=device)
+    if isinstance(value, dict):
+        return {key: _to_device_tree(item, device) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_to_device_tree(item, device) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_to_device_tree(item, device) for item in value)
+    return value
+
+
+def _owned_model_main_parameters(child):
+    """Yield the model parameter paired with the parameter optimized by a child."""
+    for model_group, main_group in zip(
+        getattr(child, "float16_groups", ()),
+        getattr(child, "fp32_from_float16_groups", ()),
+        strict=True,
+    ):
+        yield from zip(model_group, main_group, strict=True)
+    for model_group in getattr(child, "fp32_from_fp32_groups", ()):
+        for model_param in model_group:
+            yield model_param, model_param
+
+
+def _model_parallel_coordinate(parallel_state) -> dict[str, int]:
+    return {
+        "tp": parallel_state.tp.rank,
+        "pp": parallel_state.pp.rank,
+        "cp": parallel_state.cp.rank,
+        "ep": parallel_state.ep.rank,
+        "etp": parallel_state.etp.rank,
+    }
+
+
+def _data_parallel_global_ranks(parallel_state) -> list[int]:
+    if not dist.is_initialized():
+        return [0]
+    get_ranks = getattr(dist, "get_process_group_ranks", None)
+    if get_ranks is not None:
+        return list(get_ranks(parallel_state.intra_dp.group))
+
+    coordinate = _model_parallel_coordinate(parallel_state)
+    coordinates: list[dict[str, int] | None] = [None] * dist.get_world_size()
+    dist.all_gather_object(coordinates, coordinate, group=get_gloo_group())
+    return [rank for rank, candidate in enumerate(coordinates) if candidate == coordinate]
+
+
+def _load_optimizer_sidecars(local_path: Path, parallel_state) -> dict[int, dict[str, Any]]:
+    expected_world_size = dist.get_world_size() if dist.is_initialized() else 1
+    expected_coordinate = _model_parallel_coordinate(parallel_state)
+    saved_by_rank = {}
+    for rank in _data_parallel_global_ranks(parallel_state):
+        sidecar = local_path / f"tinker_optimizer_rank{rank}.pt"
+        if not sidecar.exists():
+            raise TinkerError(
+                f"checkpoint optimizer state {sidecar} does not exist for this trainer topology",
+                category="user",
+            )
+        saved = torch.load(sidecar, map_location="cpu", weights_only=False)
+        if saved.get("format_version") != 2 or saved.get("world_size") != expected_world_size or saved.get("topology") != expected_coordinate:
+            raise TinkerError(
+                "checkpoint optimizer topology does not match this trainer",
+                category="user",
+            )
+        saved_by_rank[rank] = saved
+    return saved_by_rank
+
+
+def _merge_optimizer_state(saved_sidecars) -> dict[str, Any]:
+    merged = {}
+    for saved in saved_sidecars:
+        for name, state in saved["optimizer_state"].items():
+            if name in merged:
+                raise TinkerError(
+                    f"checkpoint contains duplicate optimizer state for {name!r}",
+                    category="server",
+                )
+            merged[name] = state
+    return merged
+
+
+def _merge_retained_grads(saved_sidecars) -> dict[str, torch.Tensor | None]:
+    """Redistribute retained gradients using the optimizer's whole-param owner.
+
+    LayerWiseDistributedOptimizer leaves a slot parameter's reduced
+    ``main_grad`` on the DP rank that owns its optimizer state. Different slots
+    can assign the same logical parameter to different ranks, so loading the
+    local rank's gradient sidecar positionally would silently lose gradients.
+    """
+    merged = {}
+    for saved in saved_sidecars:
+        for name in saved["optimizer_state"]:
+            if name in merged or name not in saved["retained_grads"]:
+                raise TinkerError(
+                    f"checkpoint contains inconsistent retained-gradient state for {name!r}",
+                    category="server",
+                )
+            merged[name] = saved["retained_grads"][name]
+    return merged
+
+
+def _optimizer_group_device(group: dict[str, Any]) -> torch.device:
+    params = group["params"]
+    return params[0].device if params else torch.device("cpu")
+
+
+def _require_loaded_adapter(loaded_adapters: dict[str, object], model_id: str):
+    try:
+        return loaded_adapters[model_id]
+    except KeyError:
+        raise TinkerError(f"model {model_id!r} is not loaded on the trainer", category="server") from None
+
+
+def _is_main_rank() -> bool:
+    return not dist.is_initialized() or dist.get_rank() == 0

--- a/miles/backends/megatron_utils/tinker_loss.py
+++ b/miles/backends/megatron_utils/tinker_loss.py
@@ -1,0 +1,159 @@
+"""Loss functions used by the Tinker-compatible Megatron executor."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping
+
+import torch
+
+from miles.ray.tinker.protocol import TinkerError
+
+_RL_INPUTS = frozenset({"target_tokens", "logprobs", "advantages"})
+_LOSS_CONFIG_KEYS = {
+    "cross_entropy": frozenset(),
+    "importance_sampling": frozenset(),
+    "ppo": frozenset({"clip_low_threshold", "clip_high_threshold"}),
+    "cispo": frozenset({"clip_low_threshold", "clip_high_threshold"}),
+    "dro": frozenset({"beta"}),
+}
+
+
+def tensor_from_payload(
+    payload: Mapping[str, object],
+    *,
+    device: torch.device | int | str,
+) -> torch.Tensor:
+    """Materialize a normalized wire tensor on the training device."""
+    dtype_name = payload["dtype"]
+    if dtype_name == "int64":
+        dtype = torch.int64
+    elif dtype_name == "float32":
+        dtype = torch.float32
+    else:
+        raise TinkerError(f"unsupported TensorData dtype {dtype_name!r}", category="user")
+    tensor = torch.tensor(payload["data"], dtype=dtype, device=device)
+    return tensor.reshape(payload["shape"])
+
+
+def validate_and_get_targets(
+    inputs: Mapping[str, torch.Tensor],
+    *,
+    model_input_length: int,
+    loss_fn: str,
+) -> torch.Tensor:
+    """Validate datum fields and return target token IDs."""
+    expected = {"target_tokens", "weights"} if loss_fn == "cross_entropy" else set(_RL_INPUTS)
+    missing = expected - set(inputs)
+    extra = set(inputs) - expected
+    if missing:
+        raise TinkerError(f"{loss_fn} requires loss_fn_inputs {sorted(missing)}", category="user")
+    if extra:
+        raise TinkerError(f"{loss_fn} does not accept loss_fn_inputs {sorted(extra)}", category="user")
+
+    targets = inputs["target_tokens"]
+    if targets.dtype != torch.int64 or targets.ndim not in (1, 2):
+        raise TinkerError("target_tokens must be an int64 tensor with shape (N,) or (N, K)", category="user")
+    if targets.ndim == 2 and targets.shape[1] == 0:
+        raise TinkerError("target_tokens top-K dimension must be positive", category="user")
+    if targets.shape[0] != model_input_length:
+        raise TinkerError(
+            f"target_tokens first dimension {targets.shape[0]} must equal model_input length {model_input_length}",
+            category="user",
+        )
+    if loss_fn != "cross_entropy" and targets.ndim != 1:
+        raise TinkerError(f"{loss_fn} requires one target token per position", category="user")
+    return targets
+
+
+def compute_tinker_loss(
+    target_logprobs: torch.Tensor,
+    inputs: Mapping[str, torch.Tensor],
+    *,
+    loss_fn: str,
+    loss_fn_config: Mapping[str, float],
+) -> torch.Tensor:
+    """Compute the exact sum-reduced public Tinker loss."""
+    if not bool(torch.isfinite(target_logprobs).all()):
+        raise TinkerError("model produced non-finite target log probabilities", category="server")
+    if loss_fn not in _LOSS_CONFIG_KEYS:
+        raise TinkerError(f"unsupported loss function {loss_fn!r}", category="user")
+    unexpected_config = set(loss_fn_config) - set(_LOSS_CONFIG_KEYS[loss_fn])
+    if unexpected_config:
+        raise TinkerError(
+            f"{loss_fn} does not accept loss_fn_config keys {sorted(unexpected_config)}",
+            category="user",
+        )
+    if any(not math.isfinite(float(value)) for value in loss_fn_config.values()):
+        raise TinkerError(f"{loss_fn} loss_fn_config values must be finite", category="user")
+
+    if loss_fn == "cross_entropy":
+        weights = _matching_float_tensor(inputs["weights"], target_logprobs, "weights")
+        return -(target_logprobs * weights).sum()
+
+    sampling_logprobs = _matching_float_tensor(inputs["logprobs"], target_logprobs, "logprobs")
+    advantages = _matching_float_tensor(inputs["advantages"], target_logprobs, "advantages")
+    log_ratio = target_logprobs - sampling_logprobs
+
+    if loss_fn == "importance_sampling":
+        return -(log_ratio.exp() * advantages).sum()
+
+    if loss_fn == "ppo":
+        low, high = _clip_thresholds(loss_fn_config, default_low=0.8, default_high=1.2)
+        ratio = log_ratio.exp()
+        objective = torch.minimum(ratio * advantages, ratio.clamp(low, high) * advantages)
+        return -objective.sum()
+
+    if loss_fn == "cispo":
+        low, high = _clip_thresholds(loss_fn_config, default_low=0.0, default_high=4.0)
+        coefficient = log_ratio.exp().clamp(low, high).detach()
+        return -(coefficient * target_logprobs * advantages).sum()
+
+    beta = float(loss_fn_config.get("beta", 0.1))
+    if beta < 0:
+        raise TinkerError("DRO beta must be non-negative", category="user")
+    objective = target_logprobs * advantages - 0.5 * beta * log_ratio.square()
+    return -objective.sum()
+
+
+def tensor_data(tensor: torch.Tensor) -> dict[str, object]:
+    """Serialize one float output tensor into the SDK's TensorData shape."""
+    value = tensor.detach().to(device="cpu", dtype=torch.float32)
+    return {
+        "data": value.reshape(-1).tolist(),
+        "dtype": "float32",
+        "shape": list(value.shape),
+    }
+
+
+def _matching_float_tensor(
+    value: torch.Tensor,
+    target: torch.Tensor,
+    name: str,
+) -> torch.Tensor:
+    if not value.is_floating_point():
+        raise TinkerError(f"{name} must be a float32 tensor", category="user")
+    if not bool(torch.isfinite(value).all()):
+        raise TinkerError(f"{name} must contain only finite values", category="user")
+    if value.shape != target.shape:
+        raise TinkerError(
+            f"{name} shape {list(value.shape)} must match target_tokens shape {list(target.shape)}",
+            category="user",
+        )
+    return value.to(dtype=torch.float32)
+
+
+def _clip_thresholds(
+    config: Mapping[str, float],
+    *,
+    default_low: float,
+    default_high: float,
+) -> tuple[float, float]:
+    low = float(config.get("clip_low_threshold", default_low))
+    high = float(config.get("clip_high_threshold", default_high))
+    if low < 0 or high < low:
+        raise TinkerError(
+            f"clip thresholds must satisfy 0 <= low <= high, got low={low}, high={high}",
+            category="user",
+        )
+    return low, high

--- a/miles/ray/actor_group.py
+++ b/miles/ray/actor_group.py
@@ -106,6 +106,14 @@ class RayTrainGroup:
         (load new, cleanup gone). Called by the trainer before generate."""
         await self._broadcast("reconcile_adapters")
 
+    async def tinker_execute(self, operation: dict) -> dict:
+        """Execute one Tinker operation on all Megatron ranks."""
+        outputs = await self._broadcast("tinker_execute", operation)
+        try:
+            return next(output for output in outputs if output is not None)
+        except StopIteration:
+            raise RuntimeError("Tinker operation returned no result from the trainer") from None
+
     async def onload(self):
         await self._broadcast("wake_up")
 

--- a/miles/ray/multi_lora/controller.py
+++ b/miles/ray/multi_lora/controller.py
@@ -100,6 +100,9 @@ class MultiLoRAController:
     def set_adapter_step(self, name: str, step: int) -> None:
         self.backend.registry.set_step(name, step)
 
+    def advance_adapter_step(self, name: str) -> int:
+        return self.backend.registry.advance_step(name)
+
     def adapter_step(self, name: str) -> int:
         return self.backend.registry.step_count(name)
 
@@ -111,6 +114,32 @@ class MultiLoRAController:
 
     def api_port(self) -> int:
         return self.server.actual_api_port
+
+    def mark_external_ready(self) -> None:
+        mark_ready = getattr(self.backend, "mark_ready", None)
+        if mark_ready is None:
+            raise RuntimeError(f"{type(self.backend).__name__} has no external readiness state")
+        mark_ready()
+
+    async def next_external_operation(self, timeout_s: float | None = None) -> dict | None:
+        """Return the next request for a service backend that owns an external
+        operation queue (for example the Tinker API)."""
+        next_operation = getattr(self.backend, "next_operation", None)
+        if next_operation is None:
+            raise RuntimeError(f"{type(self.backend).__name__} has no external operation queue")
+        return await next_operation(timeout_s)
+
+    async def complete_external_operation(self, request_id: str, result: dict | None) -> None:
+        complete_operation = getattr(self.backend, "complete_operation", None)
+        if complete_operation is None:
+            raise RuntimeError(f"{type(self.backend).__name__} cannot complete external operations")
+        await complete_operation(request_id, result)
+
+    async def fail_external_operation(self, request_id: str, error: str, category: str = "server") -> None:
+        fail_operation = getattr(self.backend, "fail_operation", None)
+        if fail_operation is None:
+            raise RuntimeError(f"{type(self.backend).__name__} cannot fail external operations")
+        await fail_operation(request_id, error, category)
 
 
 def create_multilora_controller(args, router_url: str, host: str = "0.0.0.0"):

--- a/miles/ray/multi_lora/registry.py
+++ b/miles/ray/multi_lora/registry.py
@@ -217,6 +217,14 @@ class AdapterRegistry:
             record.step = step
             record.start_step = step
 
+    def advance_step(self, name: str) -> int:
+        """Advance a service-owned adapter after one external optimizer step."""
+        record = self.find(name)
+        if record is None:
+            return 0
+        record.step += 1
+        return record.step
+
     def step_count(self, name: str) -> int:
         record = self.find(name)
         return record.step if record is not None else 0

--- a/miles/ray/tinker/__init__.py
+++ b/miles/ray/tinker/__init__.py
@@ -1,0 +1,6 @@
+"""Tinker-compatible training and sampling service for Miles."""
+
+from miles.ray.tinker.backend import TinkerBackend
+from miles.ray.tinker.http_server import TinkerHTTPServer
+
+__all__ = ["TinkerBackend", "TinkerHTTPServer"]

--- a/miles/ray/tinker/backend.py
+++ b/miles/ray/tinker/backend.py
@@ -1,0 +1,743 @@
+"""Tinker protocol backend built on Miles' multi-LoRA registry."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import logging
+import math
+from pathlib import Path
+from typing import Any
+
+from miles.ray.multi_lora.backend import MultiLoRABackend
+from miles.ray.tinker.protocol import (
+    CreateModelRequest,
+    CreateSamplingSessionRequest,
+    CreateSessionRequest,
+    ForwardBackwardRequest,
+    ForwardRequest,
+    LoadWeightsRequest,
+    OptimStepRequest,
+    SampleRequest,
+    SaveWeightsForSamplerRequest,
+    SaveWeightsRequest,
+    TinkerError,
+    UntypedAPIFuture,
+    encoded_tokens,
+    forward_payload,
+)
+from miles.ray.tinker.state import Operation, TinkerModelConfig, TinkerState
+
+logger = logging.getLogger(__name__)
+
+
+class TinkerBackend(MultiLoRABackend):
+    """Official Tinker SDK-compatible control plane.
+
+    Training operations are serialized through ``operation_queue`` and run by
+    the Miles driver on the Megatron actor group. Sampling requests run
+    concurrently against immutable SGLang LoRA snapshots.
+    """
+
+    def __init__(self, args: Any, router_url: str) -> None:
+        super().__init__(args, router_url)
+        self.state = TinkerState()
+        self.operation_queue: asyncio.Queue[Operation] = asyncio.Queue()
+        self.sample_tasks: set[asyncio.Task] = set()
+        self.sample_semaphore = asyncio.Semaphore(getattr(args, "tinker_max_concurrent_samples", 256))
+        self.loaded_sampler_adapters: set[str] = set()
+        self.ready = False
+        root = getattr(args, "tinker_checkpoint_dir", None)
+        if root is None:
+            root = Path(getattr(args, "save", None) or "/tmp/miles") / "tinker"
+        self.checkpoint_root = Path(root).expanduser().resolve()
+        self.model_name = getattr(args, "tinker_model_name", None) or str(args.hf_checkpoint).rstrip("/")
+        self.tokenizer_id = getattr(args, "tinker_tokenizer_id", None) or self.model_name
+
+    async def close(self) -> None:
+        for task in self.sample_tasks:
+            task.cancel()
+        if self.sample_tasks:
+            await asyncio.gather(*self.sample_tasks, return_exceptions=True)
+        self.sample_tasks.clear()
+        await super().close()
+
+    def mark_ready(self) -> None:
+        self.ready = True
+
+    def client_config(self) -> dict[str, Any]:
+        return {
+            "pjwt_auth_enabled": False,
+            "credential_default_source": "api_key",
+            "parallel_fwdbwd_chunks": False,
+            "proto_write_fwdbwd": False,
+            "proto_compress_fwdbwd": False,
+            "fwd_via_fwdbwd": False,
+            "sample_no_retries": False,
+            "sample_enable_stuck_detection": True,
+            "sample_max_concurrent_requests": getattr(self.args, "tinker_max_concurrent_samples", 256),
+            "use_pyqwest_transport": False,
+        }
+
+    def create_session(self, request: CreateSessionRequest) -> dict[str, Any]:
+        session = self.state.create_session(
+            tags=request.tags,
+            user_metadata=request.user_metadata,
+            sdk_version=request.sdk_version,
+            project_id=request.project_id,
+        )
+        return {"type": "create_session", "session_id": session.session_id}
+
+    def session_heartbeat(self, session_id: str) -> dict[str, str]:
+        self.state.heartbeat(session_id)
+        return {"type": "session_heartbeat"}
+
+    async def create_model(self, request: CreateModelRequest) -> UntypedAPIFuture:
+        if request.lora_config is None:
+            raise TinkerError(
+                "Miles Tinker service requires lora_config; full-parameter model creation is not supported",
+                category="user",
+            )
+        self._validate_base_model(request.base_model)
+        lora = request.lora_config
+        if not 0 < lora.rank <= self.args.lora_rank:
+            raise TinkerError(
+                f"requested LoRA rank {lora.rank} must be in [1, {self.args.lora_rank}]",
+                category="user",
+            )
+        if not (lora.train_unembed or lora.train_mlp or lora.train_attn):
+            raise TinkerError("at least one LoRA module group must be trainable", category="user")
+        self._validate_target_modules(lora.train_unembed, lora.train_mlp, lora.train_attn)
+
+        payload = request.model_dump(mode="json", exclude_none=True)
+        prospective_id = self.state.model_create_keys.get((request.session_id, request.model_seq_id))
+        if prospective_id is None:
+            save = self.checkpoint_root / "_models" / "pending"
+        else:
+            save = self.checkpoint_root / "_models" / prospective_id[1]
+        config = TinkerModelConfig(
+            rank=lora.rank,
+            alpha=lora.rank,
+            save=save,
+            seed=lora.seed,
+            train_unembed=lora.train_unembed,
+            train_mlp=lora.train_mlp,
+            train_attn=lora.train_attn,
+            user_metadata=request.user_metadata or {},
+        )
+        model, future, is_new = self.state.begin_model_create(
+            session_id=request.session_id,
+            model_seq_id=request.model_seq_id,
+            base_model=request.base_model,
+            config=config,
+            payload=payload,
+        )
+        if is_new:
+            config = TinkerModelConfig(
+                rank=config.rank,
+                alpha=config.alpha,
+                save=self.checkpoint_root / "_models" / model.model_id,
+                seed=config.seed,
+                train_unembed=config.train_unembed,
+                train_mlp=config.train_mlp,
+                train_attn=config.train_attn,
+                user_metadata=config.user_metadata,
+            )
+            model.config = config
+            try:
+                await self.register(model.model_id, config)
+            except Exception as exc:
+                self.state.rollback_model_create(model.model_id, future.request_id)
+                if isinstance(exc, RuntimeError) and "No free adapter slots" in str(exc):
+                    raise TinkerError(
+                        "no free Tinker training-client slots; increase --multi-lora-n-adapters",
+                        category="user",
+                    ) from None
+                raise
+            await self.operation_queue.put(
+                Operation(
+                    request_id=future.request_id,
+                    kind="create_model",
+                    model_id=model.model_id,
+                    payload={"model_id": model.model_id},
+                )
+            )
+        return UntypedAPIFuture(request_id=future.request_id, model_id=model.model_id)
+
+    def get_info(self, model_id: str) -> dict[str, Any]:
+        model = self.state.require_model(model_id, active=False)
+        return {
+            "type": "get_info",
+            "model_data": {
+                "arch": getattr(self.args, "model_arch", None),
+                "model_name": model.base_model,
+                "tokenizer_id": self.tokenizer_id,
+            },
+            "model_id": model.model_id,
+            "is_lora": True,
+            "lora_rank": model.config.rank,
+            "model_name": model.base_model,
+        }
+
+    async def unload_model(self, model_id: str) -> UntypedAPIFuture:
+        future, operation = self.state.begin_unload(model_id)
+        if operation is not None:
+            await self.deregister(model_id)
+            await self.operation_queue.put(operation)
+        return UntypedAPIFuture(request_id=future.request_id, model_id=model_id)
+
+    async def forward(self, request: ForwardRequest) -> UntypedAPIFuture:
+        payload = forward_payload(request.forward_input)
+        return await self._submit_model_operation(request.model_id, request.seq_id, "forward", payload)
+
+    async def forward_backward(self, request: ForwardBackwardRequest) -> UntypedAPIFuture:
+        payload = forward_payload(request.forward_backward_input)
+        return await self._submit_model_operation(request.model_id, request.seq_id, "forward_backward", payload)
+
+    async def optim_step(self, request: OptimStepRequest) -> UntypedAPIFuture:
+        params = request.adam_params
+        values = (
+            params.learning_rate,
+            params.beta1,
+            params.beta2,
+            params.eps,
+            params.weight_decay,
+            params.grad_clip_norm,
+        )
+        if not all(math.isfinite(value) for value in values):
+            raise TinkerError("Adam parameters must be finite", category="user")
+        if params.learning_rate < 0:
+            raise TinkerError("learning_rate must be non-negative", category="user")
+        if not (0 <= params.beta1 < 1 and 0 <= params.beta2 < 1):
+            raise TinkerError("Adam betas must be in [0, 1)", category="user")
+        if params.eps < 0 or params.weight_decay < 0 or params.grad_clip_norm < 0:
+            raise TinkerError("eps, weight_decay and grad_clip_norm must be non-negative", category="user")
+        return await self._submit_model_operation(
+            request.model_id,
+            request.seq_id,
+            "optim_step",
+            {"adam_params": params.model_dump(mode="json")},
+        )
+
+    async def save_weights(self, request: SaveWeightsRequest) -> UntypedAPIFuture:
+        idempotency_payload = request.model_dump(mode="json", exclude={"seq_id"})
+        seq_id, duplicate = self.state.validate_model_operation(
+            model_id=request.model_id,
+            seq_id=request.seq_id,
+            kind="save_weights",
+            payload=idempotency_payload,
+        )
+        if duplicate is not None:
+            return UntypedAPIFuture(request_id=duplicate.request_id, model_id=request.model_id)
+        checkpoint = self.state.allocate_checkpoint(
+            model_id=request.model_id,
+            seq_id=seq_id,
+            requested_name=request.path,
+            checkpoint_type="training",
+            ttl_seconds=request.ttl_seconds,
+            overwrite=request.overwrite,
+        )
+        return await self._submit_model_operation(
+            request.model_id,
+            request.seq_id,
+            "save_weights",
+            {
+                "tinker_path": checkpoint.tinker_path,
+                "local_path": str(checkpoint.local_path),
+                "checkpoint_step": checkpoint.checkpoint_step,
+                "include_optimizer": True,
+                "overwrite": request.overwrite,
+            },
+            idempotency_payload=idempotency_payload,
+        )
+
+    async def load_weights(self, request: LoadWeightsRequest) -> UntypedAPIFuture:
+        checkpoint = self.state.require_checkpoint(request.path)
+        model = self.state.require_model(request.model_id)
+        source = self.state.require_model(checkpoint.model_id, active=False)
+        if source.base_model != model.base_model:
+            raise TinkerError(
+                f"checkpoint base model {source.base_model!r} does not match {model.base_model!r}",
+                category="user",
+            )
+        if source.config.rank != model.config.rank:
+            raise TinkerError(
+                f"checkpoint LoRA rank {source.config.rank} does not match {model.config.rank}",
+                category="user",
+            )
+        source_groups = (
+            source.config.train_unembed,
+            source.config.train_mlp,
+            source.config.train_attn,
+        )
+        model_groups = (
+            model.config.train_unembed,
+            model.config.train_mlp,
+            model.config.train_attn,
+        )
+        if source_groups != model_groups:
+            raise TinkerError(
+                "checkpoint train_unembed/train_mlp/train_attn configuration does not match the target model",
+                category="user",
+            )
+        if request.optimizer and not checkpoint.include_optimizer:
+            raise TinkerError(f"checkpoint {request.path!r} has no optimizer state", category="user")
+        return await self._submit_model_operation(
+            request.model_id,
+            request.seq_id,
+            "load_weights",
+            {
+                "tinker_path": checkpoint.tinker_path,
+                "local_path": str(checkpoint.local_path),
+                "optimizer": request.optimizer,
+            },
+        )
+
+    async def save_weights_for_sampler(self, request: SaveWeightsForSamplerRequest) -> UntypedAPIFuture:
+        idempotency_payload = request.model_dump(mode="json", exclude={"seq_id"})
+        seq_id, duplicate = self.state.validate_model_operation(
+            model_id=request.model_id,
+            seq_id=request.seq_id,
+            kind="save_weights_for_sampler",
+            payload=idempotency_payload,
+        )
+        if duplicate is not None:
+            return UntypedAPIFuture(request_id=duplicate.request_id, model_id=request.model_id)
+        checkpoint = self.state.allocate_checkpoint(
+            model_id=request.model_id,
+            seq_id=seq_id,
+            requested_name=request.path,
+            checkpoint_type="sampler",
+            ttl_seconds=request.ttl_seconds,
+            overwrite=False,
+        )
+        return await self._submit_model_operation(
+            request.model_id,
+            request.seq_id,
+            "save_weights_for_sampler",
+            {
+                "tinker_path": checkpoint.tinker_path,
+                "local_path": str(checkpoint.local_path),
+                "checkpoint_step": checkpoint.checkpoint_step,
+                "include_optimizer": False,
+                "sampling_session_seq_id": request.sampling_session_seq_id,
+            },
+            idempotency_payload=idempotency_payload,
+        )
+
+    async def create_sampling_session(self, request: CreateSamplingSessionRequest) -> dict[str, str]:
+        self.state.require_session(request.session_id)
+        if request.model_path is None:
+            assert request.base_model is not None
+            self._validate_base_model(request.base_model)
+            base_model = request.base_model
+            adapter_path = None
+            adapter_name = None
+        else:
+            checkpoint = self.state.require_checkpoint(request.model_path)
+            source = self.state.require_model(checkpoint.model_id, active=False)
+            base_model = source.base_model
+            adapter_path = checkpoint.local_path
+            adapter_name = await self._ensure_sampler_loaded(checkpoint.tinker_path, adapter_path)
+
+        session, _ = self.state.create_sampling_session(
+            session_id=request.session_id,
+            sampling_session_seq_id=request.sampling_session_seq_id,
+            base_model=base_model,
+            model_path=request.model_path,
+            adapter_path=adapter_path,
+            adapter_name=adapter_name,
+            payload=request.model_dump(mode="json", exclude_none=True),
+        )
+        return {
+            "type": "create_sampling_session",
+            "sampling_session_id": session.sampling_session_id,
+        }
+
+    def get_sampler(self, sampling_session_id: str) -> dict[str, Any]:
+        try:
+            session = self.state.sampling_sessions[sampling_session_id]
+        except KeyError:
+            raise TinkerError(
+                f"sampling session {sampling_session_id!r} does not exist",
+                category="user",
+            ) from None
+        return {
+            "sampler_id": session.sampling_session_id,
+            "base_model": session.base_model,
+            "model_path": session.model_path,
+        }
+
+    async def sample(self, request: SampleRequest) -> UntypedAPIFuture:
+        payload = {
+            "num_samples": request.num_samples,
+            "prompt": encoded_tokens(request.prompt),
+            "sampling_params": request.sampling_params.model_dump(mode="json", exclude_none=True),
+            "prompt_logprobs": bool(request.prompt_logprobs),
+            "topk_prompt_logprobs": request.topk_prompt_logprobs,
+        }
+        if request.num_samples <= 0:
+            raise TinkerError("num_samples must be positive", category="user")
+        if request.topk_prompt_logprobs < 0:
+            raise TinkerError("topk_prompt_logprobs must be non-negative", category="user")
+        sampling = request.sampling_params
+        if sampling.max_tokens is not None and sampling.max_tokens < 0:
+            raise TinkerError("max_tokens must be non-negative", category="user")
+        if not math.isfinite(sampling.temperature) or sampling.temperature < 0:
+            raise TinkerError("temperature must be finite and non-negative", category="user")
+        if not math.isfinite(sampling.top_p) or not 0 < sampling.top_p <= 1:
+            raise TinkerError("top_p must be finite and in (0, 1]", category="user")
+        if sampling.top_k == 0 or sampling.top_k < -1:
+            raise TinkerError("top_k must be -1 or a positive integer", category="user")
+        prompt_length = len(payload["prompt"])
+        if prompt_length > self.args.seq_length:
+            raise TinkerError(
+                f"prompt has {prompt_length} tokens, exceeding the configured sequence length {self.args.seq_length}",
+                category="user",
+            )
+        if sampling.max_tokens is not None and prompt_length + sampling.max_tokens > self.args.seq_length:
+            raise TinkerError(
+                f"prompt plus max_tokens exceeds the configured sequence length {self.args.seq_length}",
+                category="user",
+            )
+
+        if request.sampling_session_id is not None:
+            if request.base_model is not None or request.model_path is not None:
+                raise TinkerError(
+                    "sampling_session_id cannot be combined with base_model or model_path",
+                    category="user",
+                )
+            future, operation = self.state.submit_sample(
+                sampling_session_id=request.sampling_session_id,
+                seq_id=request.seq_id,
+                payload=payload,
+            )
+        else:
+            if (request.base_model is None) == (request.model_path is None):
+                raise TinkerError(
+                    "exactly one of sampling_session_id, base_model or model_path is required",
+                    category="user",
+                )
+            adapter_path = None
+            adapter_name = None
+            if request.model_path is not None:
+                checkpoint = self.state.require_checkpoint(request.model_path)
+                adapter_path = checkpoint.local_path
+                adapter_name = await self._ensure_sampler_loaded(checkpoint.tinker_path, adapter_path)
+            else:
+                assert request.base_model is not None
+                self._validate_base_model(request.base_model)
+            future = self.state.new_future(model_id=None)
+            operation = Operation(
+                request_id=future.request_id,
+                kind="sample",
+                model_id=None,
+                payload={
+                    **payload,
+                    "adapter_path": str(adapter_path) if adapter_path is not None else None,
+                    "adapter_name": adapter_name,
+                },
+            )
+
+        if operation is not None:
+            task = asyncio.create_task(self._run_sample(operation))
+            self.sample_tasks.add(task)
+            task.add_done_callback(self.sample_tasks.discard)
+        return UntypedAPIFuture(request_id=future.request_id)
+
+    async def next_operation(self, timeout_s: float | None = None) -> dict[str, Any] | None:
+        if timeout_s is None:
+            operation = await self.operation_queue.get()
+        else:
+            try:
+                operation = await asyncio.wait_for(self.operation_queue.get(), timeout_s)
+            except TimeoutError:
+                return None
+        return operation.asdict()
+
+    async def complete_operation(self, request_id: str, result: dict[str, Any] | None) -> None:
+        future = self.state.require_future(request_id)
+        operation_model = self.state.models.get(future.model_id) if future.model_id is not None else None
+        result = result or {}
+        kind = result.pop("_operation_kind", None)
+        if kind == "create_model":
+            assert operation_model is not None
+            operation_model.status = "active"
+            response = {"type": "create_model", "model_id": operation_model.model_id}
+        elif kind == "unload_model":
+            assert operation_model is not None
+            operation_model.status = "unloaded"
+            response = {"type": "unload_model", "model_id": operation_model.model_id}
+        elif kind == "save_weights":
+            self.state.complete_checkpoint(result["tinker_path"])
+            response = {"type": "save_weights", "path": result["tinker_path"]}
+        elif kind == "load_weights":
+            response = {"type": "load_weights", "path": result["tinker_path"]}
+        elif kind == "save_weights_for_sampler":
+            tinker_path = result["tinker_path"]
+            checkpoint = self.state.complete_checkpoint(tinker_path)
+            sampling_seq_id = result.get("sampling_session_seq_id")
+            if sampling_seq_id is None:
+                response = {"type": "save_weights_for_sampler", "path": tinker_path}
+            else:
+                adapter_name = await self._ensure_sampler_loaded(tinker_path, checkpoint.local_path)
+                assert operation_model is not None
+                session, _ = self.state.create_sampling_session(
+                    session_id=operation_model.session_id,
+                    sampling_session_seq_id=sampling_seq_id,
+                    base_model=operation_model.base_model,
+                    model_path=tinker_path,
+                    adapter_path=checkpoint.local_path,
+                    adapter_name=adapter_name,
+                    payload={"model_path": tinker_path, "ephemeral": True},
+                )
+                response = {
+                    "type": "save_weights_for_sampler",
+                    "sampling_session_id": session.sampling_session_id,
+                }
+        else:
+            response = result
+        self.state.complete_future(request_id, response)
+
+    async def fail_operation(self, request_id: str, error: str, category: str = "server") -> None:
+        future = self.state.require_future(request_id)
+        model = self.state.models.get(future.model_id) if future.model_id is not None else None
+        was_loading = model is not None and model.status == "loading"
+        was_unloading = model is not None and model.status == "unloading"
+        valid_category = category if category in {"unknown", "server", "user"} else "server"
+        self.state.fail_future(request_id, error, valid_category)
+        self.state.fail_checkpoint_for_request(request_id)
+        if was_loading:
+            await self.deregister(model.model_id)
+        elif was_unloading:
+            model.status = "failed"
+
+    def retrieve_future(self, request_id: str) -> dict[str, Any]:
+        return self.state.retrieve_future(request_id)
+
+    def weights_info(self, tinker_path: str) -> dict[str, Any]:
+        checkpoint = self.state.require_checkpoint(tinker_path)
+        model = self.state.require_model(checkpoint.model_id, active=False)
+        return {
+            "base_model": model.base_model,
+            "is_lora": True,
+            "lora_rank": model.config.rank,
+            "train_unembed": model.config.train_unembed,
+            "train_mlp": model.config.train_mlp,
+            "train_attn": model.config.train_attn,
+        }
+
+    async def _submit_model_operation(
+        self,
+        model_id: str,
+        seq_id: int | None,
+        kind: str,
+        payload: dict[str, Any],
+        *,
+        idempotency_payload: dict[str, Any] | None = None,
+    ) -> UntypedAPIFuture:
+        self.state.require_model(model_id)
+        registry_record = self.registry.find(model_id)
+        if registry_record is None:
+            raise TinkerError(f"model {model_id!r} has no live adapter slot", category="server")
+        worker_payload = {**payload, "slot": registry_record.slot, "model_id": model_id}
+        future, operation = self.state.submit_model_operation(
+            model_id=model_id,
+            seq_id=seq_id,
+            kind=kind,
+            payload=worker_payload,
+            idempotency_payload=idempotency_payload,
+        )
+        if operation is not None:
+            await self.operation_queue.put(operation)
+        return UntypedAPIFuture(request_id=future.request_id, model_id=model_id)
+
+    def _validate_base_model(self, base_model: str) -> None:
+        accepted = {
+            self.model_name.rstrip("/"),
+            str(self.args.hf_checkpoint).rstrip("/"),
+            Path(str(self.args.hf_checkpoint).rstrip("/")).name,
+        }
+        if base_model.rstrip("/") not in accepted:
+            raise TinkerError(
+                f"this Miles instance serves {self.model_name!r}, not {base_model!r}",
+                category="user",
+            )
+
+    def _validate_target_modules(self, train_unembed: bool, train_mlp: bool, train_attn: bool) -> None:
+        raw_targets = getattr(self.args, "target_modules", []) or []
+        if isinstance(raw_targets, str):
+            raw_targets = [part.strip() for part in raw_targets.split(",")]
+        leaves = {str(value).rsplit(".", 1)[-1] for value in raw_targets}
+        all_linear = bool(leaves & {"all", "all-linear", "all_linear"})
+        if train_unembed and not leaves & {"output_layer", "lm_head", "unembed_tokens"}:
+            raise TinkerError(
+                "train_unembed=True requires output_layer, lm_head, or unembed_tokens in --target-modules",
+                category="user",
+            )
+        if train_attn and not (
+            all_linear
+            or leaves
+            & {
+                "linear_qkv",
+                "linear_q",
+                "linear_k",
+                "linear_v",
+                "linear_proj",
+                "q_proj",
+                "k_proj",
+                "v_proj",
+                "o_proj",
+            }
+        ):
+            raise TinkerError("train_attn=True requires attention LoRA target modules", category="user")
+        if train_mlp and not (
+            all_linear
+            or leaves
+            & {
+                "linear_fc1",
+                "linear_fc1_up",
+                "linear_fc1_gate",
+                "linear_fc2",
+                "gate_proj",
+                "up_proj",
+                "down_proj",
+            }
+        ):
+            raise TinkerError("train_mlp=True requires MLP LoRA target modules", category="user")
+
+    async def _ensure_sampler_loaded(self, tinker_path: str, adapter_path: Path) -> str:
+        # Include the immutable local snapshot path in the name. A named
+        # tinker:// URI may be overwritten by a later checkpoint, and reusing
+        # the URI-only name would leave SGLang serving the old adapter.
+        identity = f"{tinker_path}\0{adapter_path.resolve()}"
+        adapter_name = f"tinker-{hashlib.sha256(identity.encode()).hexdigest()[:24]}"
+        await self._load_sampler_adapter(adapter_name, adapter_path)
+        return adapter_name
+
+    async def _load_sampler_adapter(self, adapter_name: str, adapter_path: Path) -> None:
+        """Load or refresh one immutable adapter snapshot on every worker."""
+        urls = await self.worker_urls()
+        if not urls:
+            raise TinkerError("no SGLang workers are available for sampling", category="server")
+        assert self.client is not None
+        responses = await asyncio.gather(
+            *(
+                self.client.post(
+                    f"{url}/load_lora_adapter",
+                    json={
+                        "lora_name": adapter_name,
+                        "lora_path": str(adapter_path),
+                        "pinned": False,
+                    },
+                )
+                for url in urls
+            ),
+            return_exceptions=True,
+        )
+        failures = []
+        for response in responses:
+            if isinstance(response, Exception):
+                failures.append(str(response))
+            elif response.status_code >= 400:
+                body = response.text.lower()
+                if "already" not in body:
+                    failures.append(response.text)
+        if failures:
+            raise TinkerError(
+                f"failed to load sampler snapshot on {len(failures)}/{len(urls)} workers: {failures[0]}",
+                category="server",
+            )
+        # Deliberately issue load_lora_adapter on every use. Unpinned SGLang
+        # adapters may be evicted independently of this API actor.
+        self.loaded_sampler_adapters.add(adapter_name)
+
+    async def _run_sample(self, operation: Operation) -> None:
+        try:
+            async with self.sample_semaphore:
+                adapter_name = operation.payload.get("adapter_name")
+                adapter_path = operation.payload.get("adapter_path")
+                if adapter_name is not None and adapter_path is not None:
+                    await self._load_sampler_adapter(adapter_name, Path(adapter_path))
+                response = await self._sample_payload(operation.payload)
+            self.state.complete_future(operation.request_id, response)
+        except TinkerError as exc:
+            self.state.fail_future(operation.request_id, str(exc), exc.category)
+        except Exception as exc:
+            logger.exception("Tinker sampling request failed")
+            self.state.fail_future(operation.request_id, str(exc), "server")
+
+    async def _sample_payload(self, payload: dict[str, Any]) -> dict[str, Any]:
+        assert self.client is not None
+        params = dict(payload["sampling_params"])
+        max_tokens = params.pop("max_tokens", None)
+        sglang_params: dict[str, Any] = {
+            "temperature": params.pop("temperature", 1.0),
+            "top_k": params.pop("top_k", -1),
+            "top_p": params.pop("top_p", 1.0),
+        }
+        if max_tokens is not None:
+            sglang_params["max_new_tokens"] = max_tokens
+        seed = params.pop("seed", None)
+        stop = params.pop("stop", None)
+        if isinstance(stop, list) and (not stop or isinstance(stop[0], int)):
+            sglang_params["stop_token_ids"] = stop
+        elif stop is not None:
+            sglang_params["stop"] = stop
+        if params:
+            raise TinkerError(f"unsupported sampling parameters: {sorted(params)}", category="user")
+
+        prompt_logprobs = payload["prompt_logprobs"]
+        topk_prompt_logprobs = payload["topk_prompt_logprobs"]
+        requests = []
+        for index in range(payload["num_samples"]):
+            sample_params = dict(sglang_params)
+            if seed is not None:
+                sample_params["sampling_seed"] = seed + index
+            body = {
+                "input_ids": payload["prompt"],
+                "sampling_params": sample_params,
+                "return_logprob": True,
+                "logprob_start_len": 0 if prompt_logprobs or topk_prompt_logprobs else -1,
+                "top_logprobs_num": topk_prompt_logprobs,
+            }
+            if payload.get("adapter_name") is not None:
+                body["lora_path"] = payload["adapter_name"]
+            requests.append(self.client.post(f"{self.router_url}/generate", json=body))
+        responses = await asyncio.gather(*requests)
+        bodies = []
+        for response in responses:
+            if response.status_code >= 400:
+                raise TinkerError(f"SGLang sampling failed: {response.text}", category="server")
+            bodies.append(response.json())
+
+        sequences = []
+        for body in bodies:
+            meta = body.get("meta_info", {})
+            output_logprobs = meta.get("output_token_logprobs") or []
+            finish = meta.get("finish_reason") or {}
+            finish_type = finish.get("type") if isinstance(finish, dict) else finish
+            output_ids = body.get("output_ids")
+            if output_ids is None:
+                output_ids = [int(item[1]) for item in output_logprobs]
+            sequences.append(
+                {
+                    "stop_reason": "stop" if finish_type == "stop" else "length",
+                    "tokens": output_ids,
+                    "logprobs": [float(item[0]) for item in output_logprobs],
+                }
+            )
+
+        first_meta = bodies[0].get("meta_info", {}) if bodies else {}
+        response_body: dict[str, Any] = {
+            "type": "sample",
+            "sequences": sequences,
+            "prompt_cache_hit_tokens": int(first_meta.get("cached_tokens", first_meta.get("cache_hit_tokens", 0)) or 0),
+        }
+        if prompt_logprobs:
+            raw = first_meta.get("input_token_logprobs") or []
+            response_body["prompt_logprobs"] = [None if item[0] is None else float(item[0]) for item in raw]
+        if topk_prompt_logprobs:
+            raw_topk = first_meta.get("input_top_logprobs") or []
+            response_body["topk_prompt_logprobs"] = [None if entries is None else [(int(item[1]), float(item[0])) for item in entries] for entries in raw_topk]
+        return response_body

--- a/miles/ray/tinker/http_server.py
+++ b/miles/ray/tinker/http_server.py
@@ -1,0 +1,165 @@
+"""FastAPI surface compatible with the official Tinker Python SDK."""
+
+from __future__ import annotations
+
+import hmac
+from typing import Any
+
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import JSONResponse
+
+from miles.ray.multi_lora.http_server import MultiLoRAHTTPServer
+from miles.ray.tinker.protocol import (
+    ClientConfigRequest,
+    CreateModelRequest,
+    CreateSamplingSessionRequest,
+    CreateSessionRequest,
+    ForwardBackwardRequest,
+    ForwardRequest,
+    FutureRetrieveRequest,
+    GetInfoRequest,
+    LoadWeightsRequest,
+    OptimStepRequest,
+    SampleRequest,
+    SaveWeightsForSamplerRequest,
+    SaveWeightsRequest,
+    SessionHeartbeatRequest,
+    TelemetryRequest,
+    TinkerError,
+    UnloadModelRequest,
+    WeightsInfoRequest,
+)
+
+
+class TinkerHTTPServer(MultiLoRAHTTPServer):
+    """Tinker SDK wire API hosted by the existing controller actor."""
+
+    def create_app(self) -> FastAPI:
+        app = FastAPI(title="Miles Tinker API", version="1")
+
+        @app.exception_handler(TinkerError)
+        async def tinker_error_handler(request: Request, exc: TinkerError):
+            return JSONResponse(
+                {"error": str(exc), "category": exc.category},
+                status_code=400 if exc.category == "user" else 500,
+            )
+
+        @app.exception_handler(ValueError)
+        async def value_error_handler(request: Request, exc: ValueError):
+            return JSONResponse({"error": str(exc), "category": "user"}, status_code=400)
+
+        api_key = getattr(self.backend.args, "tinker_api_key", None)
+        if api_key:
+
+            @app.middleware("http")
+            async def authenticate(request: Request, call_next):
+                if request.url.path in {"/api/v1/healthz", "/health"}:
+                    return await call_next(request)
+                provided = request.headers.get("x-api-key")
+                if provided is None:
+                    authorization = request.headers.get("authorization", "")
+                    if authorization.startswith("Bearer "):
+                        provided = authorization.removeprefix("Bearer ")
+                if provided is None or not hmac.compare_digest(provided, api_key):
+                    return JSONResponse(
+                        {"error": "invalid API key", "category": "user"},
+                        status_code=401,
+                    )
+                return await call_next(request)
+
+        return app
+
+    def add_routes(self, app: FastAPI) -> None:
+        app.get("/health")(self.health)
+        app.get("/api/v1/healthz")(self.healthz)
+        app.get("/api/v1/get_server_capabilities")(self.get_server_capabilities)
+        app.post("/api/v1/client/config")(self.client_config)
+        app.post("/api/v1/create_session")(self.create_session)
+        app.post("/api/v1/session_heartbeat")(self.session_heartbeat)
+        app.post("/api/v1/create_model")(self.create_model)
+        app.post("/api/v1/get_info")(self.get_info)
+        app.post("/api/v1/unload_model")(self.unload_model)
+        app.post("/api/v1/forward")(self.forward)
+        app.post("/api/v1/forward_backward")(self.forward_backward)
+        app.post("/api/v1/optim_step")(self.optim_step)
+        app.post("/api/v1/save_weights")(self.save_weights)
+        app.post("/api/v1/load_weights")(self.load_weights)
+        app.post("/api/v1/save_weights_for_sampler")(self.save_weights_for_sampler)
+        app.post("/api/v1/create_sampling_session")(self.create_sampling_session)
+        app.get("/api/v1/samplers/{sampling_session_id}")(self.get_sampler)
+        app.post("/api/v1/asample")(self.asample)
+        app.post("/api/v1/retrieve_future")(self.retrieve_future)
+        app.post("/api/v1/weights_info")(self.weights_info)
+        app.post("/api/v1/telemetry")(self.telemetry)
+
+    async def health(self) -> dict[str, str]:
+        return {"status": "healthy"}
+
+    async def healthz(self) -> dict[str, str]:
+        if not getattr(self.backend, "ready", True):
+            raise HTTPException(status_code=503, detail="trainer is initializing")
+        return {"status": "ok"}
+
+    async def get_server_capabilities(self) -> dict[str, list[dict[str, Any]]]:
+        return {
+            "supported_models": [
+                {
+                    "model_name": self.backend.model_name,
+                    "max_context_length": getattr(self.backend.args, "seq_length", None),
+                }
+            ]
+        }
+
+    async def client_config(self, request: ClientConfigRequest) -> dict[str, Any]:
+        return self.backend.client_config()
+
+    async def create_session(self, request: CreateSessionRequest) -> dict[str, Any]:
+        return self.backend.create_session(request)
+
+    async def session_heartbeat(self, request: SessionHeartbeatRequest) -> dict[str, str]:
+        return self.backend.session_heartbeat(request.session_id)
+
+    async def create_model(self, request: CreateModelRequest) -> dict[str, Any]:
+        return (await self.backend.create_model(request)).model_dump(mode="json", exclude_none=True)
+
+    async def get_info(self, request: GetInfoRequest) -> dict[str, Any]:
+        return self.backend.get_info(request.model_id)
+
+    async def unload_model(self, request: UnloadModelRequest) -> dict[str, Any]:
+        return (await self.backend.unload_model(request.model_id)).model_dump(mode="json", exclude_none=True)
+
+    async def forward(self, request: ForwardRequest) -> dict[str, Any]:
+        return (await self.backend.forward(request)).model_dump(mode="json", exclude_none=True)
+
+    async def forward_backward(self, request: ForwardBackwardRequest) -> dict[str, Any]:
+        return (await self.backend.forward_backward(request)).model_dump(mode="json", exclude_none=True)
+
+    async def optim_step(self, request: OptimStepRequest) -> dict[str, Any]:
+        return (await self.backend.optim_step(request)).model_dump(mode="json", exclude_none=True)
+
+    async def save_weights(self, request: SaveWeightsRequest) -> dict[str, Any]:
+        return (await self.backend.save_weights(request)).model_dump(mode="json", exclude_none=True)
+
+    async def load_weights(self, request: LoadWeightsRequest) -> dict[str, Any]:
+        return (await self.backend.load_weights(request)).model_dump(mode="json", exclude_none=True)
+
+    async def save_weights_for_sampler(self, request: SaveWeightsForSamplerRequest) -> dict[str, Any]:
+        return (await self.backend.save_weights_for_sampler(request)).model_dump(mode="json", exclude_none=True)
+
+    async def create_sampling_session(self, request: CreateSamplingSessionRequest) -> dict[str, str]:
+        return await self.backend.create_sampling_session(request)
+
+    async def get_sampler(self, sampling_session_id: str) -> dict[str, Any]:
+        return self.backend.get_sampler(sampling_session_id)
+
+    async def asample(self, request: SampleRequest) -> dict[str, Any]:
+        return (await self.backend.sample(request)).model_dump(mode="json", exclude_none=True)
+
+    async def retrieve_future(self, request: FutureRetrieveRequest) -> dict[str, Any]:
+        return self.backend.retrieve_future(request.request_id)
+
+    async def weights_info(self, request: WeightsInfoRequest) -> dict[str, Any]:
+        return self.backend.weights_info(request.tinker_path)
+
+    async def telemetry(self, request: TelemetryRequest) -> dict[str, str]:
+        return {"status": "accepted"}

--- a/miles/ray/tinker/protocol.py
+++ b/miles/ray/tinker/protocol.py
@@ -1,0 +1,311 @@
+"""Pydantic models for the public Tinker JSON wire protocol.
+
+The service intentionally keeps these models local instead of depending on the
+Tinker SDK at runtime. This lets a Miles server accept multiple SDK releases
+while the SDK remains an optional client-side dependency.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, model_validator
+
+
+class StrictModel(BaseModel):
+    model_config = ConfigDict(extra="forbid", protected_namespaces=())
+
+
+class WireModel(BaseModel):
+    model_config = ConfigDict(extra="ignore", protected_namespaces=())
+
+
+class ClientConfigRequest(StrictModel):
+    sdk_version: str
+
+
+class CreateSessionRequest(StrictModel):
+    tags: list[str]
+    user_metadata: dict[str, Any] | None
+    sdk_version: str
+    project_id: str | None = None
+    type: Literal["create_session"] = "create_session"
+
+
+class SessionHeartbeatRequest(StrictModel):
+    session_id: str
+    type: Literal["session_heartbeat"] = "session_heartbeat"
+
+
+class LoraConfig(StrictModel):
+    rank: int
+    seed: int | None = None
+    train_unembed: bool = True
+    train_mlp: bool = True
+    train_attn: bool = True
+
+
+class CreateModelRequest(StrictModel):
+    session_id: str
+    model_seq_id: int
+    base_model: str
+    user_metadata: dict[str, Any] | None = None
+    lora_config: LoraConfig | None = None
+    type: Literal["create_model"] = "create_model"
+
+
+class GetInfoRequest(StrictModel):
+    model_id: str
+    type: Literal["get_info"] = "get_info"
+
+
+class UnloadModelRequest(StrictModel):
+    model_id: str
+    type: Literal["unload_model"] = "unload_model"
+
+
+class TensorData(StrictModel):
+    data: list[int] | list[float]
+    dtype: Literal["int64", "float32"]
+    shape: list[int] | None = None
+    sparse_crow_indices: list[int] | None = None
+    sparse_col_indices: list[int] | None = None
+
+    @model_validator(mode="after")
+    def validate_sparse_fields(self) -> TensorData:
+        sparse_fields = (self.sparse_crow_indices, self.sparse_col_indices)
+        if (sparse_fields[0] is None) != (sparse_fields[1] is None):
+            raise ValueError("sparse_crow_indices and sparse_col_indices must be set together")
+        if sparse_fields[0] is not None and (self.shape is None or len(self.shape) != 2):
+            raise ValueError("sparse TensorData requires a two-dimensional shape")
+        return self
+
+
+class ModelInputChunk(BaseModel):
+    """A permissive chunk envelope.
+
+    Encoded text is executable today. Keeping other official chunk payloads
+    parseable lets the server return a typed user error from the future instead
+    of failing request decoding with an opaque 422.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    type: str
+    tokens: list[int] | None = None
+
+
+class ModelInput(StrictModel):
+    chunks: list[ModelInputChunk]
+
+
+class Datum(StrictModel):
+    loss_fn_inputs: dict[str, TensorData]
+    model_input: ModelInput
+
+
+LossFnType = Literal["cross_entropy", "importance_sampling", "ppo", "cispo", "dro"]
+
+
+class ForwardBackwardInput(StrictModel):
+    data: list[Datum]
+    loss_fn: LossFnType
+    loss_fn_config: dict[str, float] | None = None
+
+
+class ForwardRequest(StrictModel):
+    forward_input: ForwardBackwardInput
+    model_id: str
+    seq_id: int | None = None
+
+
+class ForwardBackwardRequest(StrictModel):
+    forward_backward_input: ForwardBackwardInput
+    model_id: str
+    seq_id: int | None = None
+
+
+class AdamParams(StrictModel):
+    learning_rate: float = 0.0001
+    beta1: float = 0.9
+    beta2: float = 0.95
+    eps: float = 1e-12
+    weight_decay: float = 0.0
+    grad_clip_norm: float = 0.0
+
+
+class OptimStepRequest(StrictModel):
+    adam_params: AdamParams
+    model_id: str
+    seq_id: int | None = None
+    type: Literal["optim_step"] = "optim_step"
+
+
+class SaveWeightsRequest(StrictModel):
+    model_id: str
+    path: str | None = None
+    seq_id: int | None = None
+    ttl_seconds: int | None = None
+    overwrite: bool = False
+    type: Literal["save_weights"] = "save_weights"
+
+
+class LoadWeightsRequest(StrictModel):
+    model_id: str
+    path: str
+    optimizer: bool
+    seq_id: int | None = None
+    weights_access_token: str | None = None
+    type: Literal["load_weights"] = "load_weights"
+
+
+class SaveWeightsForSamplerRequest(StrictModel):
+    model_id: str
+    path: str | None = None
+    sampling_session_seq_id: int | None = None
+    seq_id: int | None = None
+    ttl_seconds: int | None = None
+    type: Literal["save_weights_for_sampler"] = "save_weights_for_sampler"
+
+
+class CreateSamplingSessionRequest(StrictModel):
+    session_id: str
+    sampling_session_seq_id: int
+    base_model: str | None = None
+    model_path: str | None = None
+    type: Literal["create_sampling_session"] = "create_sampling_session"
+
+    @model_validator(mode="after")
+    def validate_source(self) -> CreateSamplingSessionRequest:
+        if (self.base_model is None) == (self.model_path is None):
+            raise ValueError("exactly one of base_model or model_path must be provided")
+        return self
+
+
+class SamplingParams(StrictModel):
+    max_tokens: int | None = None
+    seed: int | None = None
+    stop: str | list[str] | list[int] | None = None
+    temperature: float = 1.0
+    top_k: int = -1
+    top_p: float = 1.0
+
+
+class SampleRequest(StrictModel):
+    num_samples: int = 1
+    prompt: ModelInput
+    sampling_params: SamplingParams
+    base_model: str | None = None
+    model_path: str | None = None
+    sampling_session_id: str | None = None
+    seq_id: int | None = None
+    prompt_logprobs: bool | None = None
+    topk_prompt_logprobs: int = 0
+    type: Literal["sample"] = "sample"
+
+
+class FutureRetrieveRequest(StrictModel):
+    request_id: str
+    allow_metadata_only: bool = False
+
+
+class WeightsInfoRequest(StrictModel):
+    tinker_path: str
+
+
+class TelemetryRequest(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+
+class UntypedAPIFuture(WireModel):
+    request_id: str
+    model_id: str | None = None
+
+
+class TinkerError(RuntimeError):
+    """An error that should be surfaced through a failed API future."""
+
+    def __init__(self, message: str, category: Literal["unknown", "server", "user"] = "user") -> None:
+        super().__init__(message)
+        self.category = category
+
+
+def encoded_tokens(model_input: ModelInput) -> list[int]:
+    tokens: list[int] = []
+    for chunk in model_input.chunks:
+        if chunk.type != "encoded_text" or chunk.tokens is None:
+            raise TinkerError(
+                f"Miles currently accepts encoded_text chunks only; got chunk type {chunk.type!r}",
+                category="user",
+            )
+        tokens.extend(chunk.tokens)
+    if not tokens:
+        raise TinkerError("model_input must contain at least one token", category="user")
+    return tokens
+
+
+def tensor_numel(tensor: TensorData) -> int:
+    if tensor.shape is None:
+        return len(tensor.data)
+    size = 1
+    for dim in tensor.shape:
+        if dim < 0:
+            raise TinkerError(f"TensorData shape contains a negative dimension: {tensor.shape}")
+        size *= dim
+    return size
+
+
+def dense_tensor_data(tensor: TensorData) -> tuple[list[int] | list[float], list[int]]:
+    """Decode dense or CSR TensorData without requiring NumPy on the API actor."""
+    shape = tensor.shape or [len(tensor.data)]
+    if tensor.sparse_crow_indices is None:
+        if tensor_numel(tensor) != len(tensor.data):
+            raise TinkerError(
+                f"TensorData data length {len(tensor.data)} does not match shape {shape}",
+                category="user",
+            )
+        return list(tensor.data), shape
+
+    assert tensor.sparse_col_indices is not None
+    rows, cols = shape
+    if rows < 0 or cols < 0:
+        raise TinkerError(f"sparse TensorData shape contains a negative dimension: {shape}", category="user")
+    crow = tensor.sparse_crow_indices
+    col = tensor.sparse_col_indices
+    if len(crow) != rows + 1 or not crow or crow[0] != 0 or crow[-1] != len(tensor.data) or any(left > right for left, right in zip(crow, crow[1:], strict=False)) or any(offset < 0 or offset > len(tensor.data) for offset in crow):
+        raise TinkerError("invalid CSR row pointers", category="user")
+    if len(col) != len(tensor.data):
+        raise TinkerError("invalid CSR column/value lengths", category="user")
+    zero: int | float = 0 if tensor.dtype == "int64" else 0.0
+    dense: list[int] | list[float] = [zero] * (rows * cols)
+    for row in range(rows):
+        for offset in range(crow[row], crow[row + 1]):
+            column = col[offset]
+            if not 0 <= column < cols:
+                raise TinkerError(f"CSR column {column} is out of range for shape {shape}", category="user")
+            dense[row * cols + column] = tensor.data[offset]
+    return dense, shape
+
+
+def tensor_payload(tensor: TensorData) -> dict[str, Any]:
+    data, shape = dense_tensor_data(tensor)
+    return {"data": data, "dtype": tensor.dtype, "shape": shape}
+
+
+def forward_payload(value: ForwardBackwardInput) -> dict[str, Any]:
+    """Normalize an SDK request into a JSON-serializable worker payload."""
+    data = []
+    for datum in value.data:
+        data.append(
+            {
+                "tokens": encoded_tokens(datum.model_input),
+                "loss_fn_inputs": {name: tensor_payload(tensor) for name, tensor in datum.loss_fn_inputs.items()},
+            }
+        )
+    if not data:
+        raise TinkerError("forward data must contain at least one Datum", category="user")
+    return {
+        "data": data,
+        "loss_fn": value.loss_fn,
+        "loss_fn_config": value.loss_fn_config or {},
+    }

--- a/miles/ray/tinker/state.py
+++ b/miles/ray/tinker/state.py
@@ -1,0 +1,530 @@
+"""In-memory state machine for the Tinker-compatible control plane."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import time
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Literal
+
+from miles.ray.tinker.protocol import TinkerError
+
+_CHECKPOINT_NAME = re.compile(r"^[A-Za-z0-9._-]+$")
+
+
+@dataclass(frozen=True)
+class TinkerModelConfig:
+    """Adapter configuration consumed by the existing multi-LoRA lifecycle."""
+
+    rank: int
+    alpha: int
+    save: Path
+    seed: int | None
+    train_unembed: bool
+    train_mlp: bool
+    train_attn: bool
+    user_metadata: dict[str, Any] = field(default_factory=dict)
+    adapter_global_batch_size: int = 1
+    num_step: int | None = None
+
+
+@dataclass
+class SessionRecord:
+    session_id: str
+    tags: list[str]
+    user_metadata: dict[str, Any] | None
+    sdk_version: str
+    project_id: str | None
+    created_at: float = field(default_factory=time.time)
+    last_heartbeat_at: float = field(default_factory=time.time)
+
+
+@dataclass
+class ModelRecord:
+    model_id: str
+    session_id: str
+    model_seq_id: int
+    base_model: str
+    config: TinkerModelConfig
+    status: Literal["loading", "active", "unloading", "unloaded", "failed"] = "loading"
+    next_seq_id: int = 1
+    checkpoint_counter: int = 0
+    created_at: float = field(default_factory=time.time)
+    last_request_at: float = field(default_factory=time.time)
+
+
+@dataclass
+class SamplingSessionRecord:
+    sampling_session_id: str
+    session_id: str
+    sampling_session_seq_id: int
+    base_model: str
+    model_path: str | None
+    adapter_path: Path | None
+    adapter_name: str | None
+    next_seq_id: int = 0
+    created_at: float = field(default_factory=time.time)
+
+
+@dataclass
+class FutureRecord:
+    request_id: str
+    model_id: str | None
+    status: Literal["pending", "completed", "failed"] = "pending"
+    response: dict[str, Any] | None = None
+    error: str | None = None
+    category: Literal["unknown", "server", "user"] = "unknown"
+    created_at: float = field(default_factory=time.time)
+    completed_at: float | None = None
+
+
+@dataclass(frozen=True)
+class Operation:
+    request_id: str
+    kind: str
+    model_id: str | None
+    payload: dict[str, Any]
+
+    def asdict(self) -> dict[str, Any]:
+        return {
+            "request_id": self.request_id,
+            "kind": self.kind,
+            "model_id": self.model_id,
+            "payload": self.payload,
+        }
+
+
+@dataclass
+class CheckpointRecord:
+    model_id: str
+    checkpoint_id: str
+    checkpoint_type: Literal["training", "sampler"]
+    tinker_path: str
+    local_path: Path
+    seq_id: int
+    checkpoint_step: int
+    include_optimizer: bool
+    status: Literal["pending", "ready", "failed"] = "pending"
+    created_at: float = field(default_factory=time.time)
+    expires_at: float | None = None
+    size_bytes: int | None = None
+
+
+def request_fingerprint(kind: str, payload: dict[str, Any]) -> str:
+    encoded = json.dumps({"kind": kind, "payload": payload}, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(encoded.encode()).hexdigest()
+
+
+class TinkerState:
+    """Controller-owned protocol state.
+
+    Ray serializes calls to the controller actor, so these transitions need no
+    process-level lock. FastAPI runs on the same actor event loop.
+    """
+
+    def __init__(self) -> None:
+        self.sessions: dict[str, SessionRecord] = {}
+        self.models: dict[str, ModelRecord] = {}
+        self.sampling_sessions: dict[str, SamplingSessionRecord] = {}
+        self.futures: dict[str, FutureRecord] = {}
+        self.checkpoints: dict[str, CheckpointRecord] = {}
+        self.model_create_keys: dict[tuple[str, int], tuple[str, str, str]] = {}
+        self.sampling_create_keys: dict[tuple[str, int], tuple[str, str]] = {}
+        self.model_request_keys: dict[tuple[str, int], tuple[str, str]] = {}
+        self.sample_request_keys: dict[tuple[str, int], tuple[str, str]] = {}
+
+    def create_session(
+        self,
+        *,
+        tags: list[str],
+        user_metadata: dict[str, Any] | None,
+        sdk_version: str,
+        project_id: str | None,
+    ) -> SessionRecord:
+        session_id = f"session-{uuid.uuid4().hex}"
+        record = SessionRecord(
+            session_id=session_id,
+            tags=list(tags),
+            user_metadata=user_metadata,
+            sdk_version=sdk_version,
+            project_id=project_id,
+        )
+        self.sessions[session_id] = record
+        return record
+
+    def heartbeat(self, session_id: str) -> None:
+        session = self.require_session(session_id)
+        session.last_heartbeat_at = time.time()
+
+    def require_session(self, session_id: str) -> SessionRecord:
+        try:
+            return self.sessions[session_id]
+        except KeyError:
+            raise TinkerError(f"session {session_id!r} does not exist", category="user") from None
+
+    def begin_model_create(
+        self,
+        *,
+        session_id: str,
+        model_seq_id: int,
+        base_model: str,
+        config: TinkerModelConfig,
+        payload: dict[str, Any],
+    ) -> tuple[ModelRecord, FutureRecord, bool]:
+        self.require_session(session_id)
+        if model_seq_id < 0:
+            raise TinkerError("model_seq_id must be non-negative", category="user")
+        key = (session_id, model_seq_id)
+        fingerprint = request_fingerprint("create_model", payload)
+        if key in self.model_create_keys:
+            old_fingerprint, model_id, request_id = self.model_create_keys[key]
+            if old_fingerprint != fingerprint:
+                raise TinkerError(
+                    f"model_seq_id {model_seq_id} was already used with a different request",
+                    category="user",
+                )
+            return self.models[model_id], self.futures[request_id], False
+
+        model_id = f"model-{uuid.uuid4().hex}"
+        model = ModelRecord(
+            model_id=model_id,
+            session_id=session_id,
+            model_seq_id=model_seq_id,
+            base_model=base_model,
+            config=config,
+        )
+        future = self.new_future(model_id=model_id)
+        self.models[model_id] = model
+        self.model_create_keys[key] = (fingerprint, model_id, future.request_id)
+        return model, future, True
+
+    def require_model(self, model_id: str, *, active: bool = True) -> ModelRecord:
+        try:
+            model = self.models[model_id]
+        except KeyError:
+            raise TinkerError(f"model {model_id!r} does not exist", category="user") from None
+        if active and model.status != "active":
+            raise TinkerError(f"model {model_id!r} is {model.status}, not active", category="user")
+        return model
+
+    def rollback_model_create(self, model_id: str, request_id: str) -> None:
+        """Remove a model-create reservation whose adapter registration failed."""
+        model = self.models.get(model_id)
+        future = self.futures.get(request_id)
+        if model is None or future is None or model.status != "loading" or future.status != "pending":
+            return
+        key = (model.session_id, model.model_seq_id)
+        reservation = self.model_create_keys.get(key)
+        if reservation is not None and reservation[1:] == (model_id, request_id):
+            self.model_create_keys.pop(key, None)
+        self.models.pop(model_id, None)
+        self.futures.pop(request_id, None)
+
+    def submit_model_operation(
+        self,
+        *,
+        model_id: str,
+        seq_id: int | None,
+        kind: str,
+        payload: dict[str, Any],
+        idempotency_payload: dict[str, Any] | None = None,
+    ) -> tuple[FutureRecord, Operation | None]:
+        actual_seq_id, duplicate = self.validate_model_operation(
+            model_id=model_id,
+            seq_id=seq_id,
+            kind=kind,
+            payload=idempotency_payload if idempotency_payload is not None else payload,
+        )
+        if duplicate is not None:
+            return duplicate, None
+
+        model = self.require_model(model_id)
+        fingerprint_payload = idempotency_payload if idempotency_payload is not None else payload
+        fingerprint = request_fingerprint(kind, fingerprint_payload)
+        key = (model_id, actual_seq_id)
+        model.next_seq_id += 1
+        model.last_request_at = time.time()
+        future = self.new_future(model_id=model_id)
+        self.model_request_keys[key] = (fingerprint, future.request_id)
+        operation = Operation(
+            request_id=future.request_id,
+            kind=kind,
+            model_id=model_id,
+            payload={**payload, "seq_id": actual_seq_id},
+        )
+        return future, operation
+
+    def validate_model_operation(
+        self,
+        *,
+        model_id: str,
+        seq_id: int | None,
+        kind: str,
+        payload: dict[str, Any],
+    ) -> tuple[int, FutureRecord | None]:
+        """Validate sequence/idempotency without mutating state.
+
+        Checkpoint operations use this before allocating a path so an invalid
+        or duplicate sequence cannot leave a phantom checkpoint behind.
+        """
+        model = self.require_model(model_id)
+        actual_seq_id = model.next_seq_id if seq_id is None else seq_id
+        if actual_seq_id < 1:
+            raise TinkerError("seq_id must be positive", category="user")
+        fingerprint = request_fingerprint(kind, payload)
+        key = (model_id, actual_seq_id)
+        if key in self.model_request_keys:
+            old_fingerprint, request_id = self.model_request_keys[key]
+            if old_fingerprint != fingerprint:
+                raise TinkerError(
+                    f"seq_id {actual_seq_id} was already used with a different request",
+                    category="user",
+                )
+            return actual_seq_id, self.futures[request_id]
+        if actual_seq_id != model.next_seq_id:
+            raise TinkerError(
+                f"expected seq_id {model.next_seq_id} for model {model_id!r}, got {actual_seq_id}",
+                category="user",
+            )
+        return actual_seq_id, None
+
+    def begin_unload(self, model_id: str) -> tuple[FutureRecord, Operation | None]:
+        model = self.require_model(model_id, active=False)
+        existing = next(
+            (future for future in self.futures.values() if future.model_id == model_id and future.response is not None and future.response.get("type") == "unload_model"),
+            None,
+        )
+        if model.status == "unloaded" and existing is not None:
+            return existing, None
+        if model.status == "unloading":
+            for future in reversed(list(self.futures.values())):
+                if future.model_id == model_id and future.status == "pending":
+                    return future, None
+        if model.status != "active":
+            raise TinkerError(f"model {model_id!r} cannot be unloaded while {model.status}", category="user")
+        model.status = "unloading"
+        future = self.new_future(model_id=model_id)
+        return future, Operation(future.request_id, "unload_model", model_id, {})
+
+    def create_sampling_session(
+        self,
+        *,
+        session_id: str,
+        sampling_session_seq_id: int,
+        base_model: str,
+        model_path: str | None,
+        adapter_path: Path | None,
+        adapter_name: str | None,
+        payload: dict[str, Any],
+    ) -> tuple[SamplingSessionRecord, bool]:
+        self.require_session(session_id)
+        if sampling_session_seq_id < 0:
+            raise TinkerError("sampling_session_seq_id must be non-negative", category="user")
+        key = (session_id, sampling_session_seq_id)
+        fingerprint = request_fingerprint("create_sampling_session", payload)
+        if key in self.sampling_create_keys:
+            old_fingerprint, sampling_session_id = self.sampling_create_keys[key]
+            if old_fingerprint != fingerprint:
+                raise TinkerError(
+                    f"sampling_session_seq_id {sampling_session_seq_id} was already used with a different request",
+                    category="user",
+                )
+            return self.sampling_sessions[sampling_session_id], False
+
+        sampling_session_id = f"sampling-session-{uuid.uuid4().hex}"
+        record = SamplingSessionRecord(
+            sampling_session_id=sampling_session_id,
+            session_id=session_id,
+            sampling_session_seq_id=sampling_session_seq_id,
+            base_model=base_model,
+            model_path=model_path,
+            adapter_path=adapter_path,
+            adapter_name=adapter_name,
+        )
+        self.sampling_sessions[sampling_session_id] = record
+        self.sampling_create_keys[key] = (fingerprint, sampling_session_id)
+        return record, True
+
+    def submit_sample(
+        self,
+        *,
+        sampling_session_id: str,
+        seq_id: int | None,
+        payload: dict[str, Any],
+    ) -> tuple[FutureRecord, Operation | None]:
+        try:
+            session = self.sampling_sessions[sampling_session_id]
+        except KeyError:
+            raise TinkerError(
+                f"sampling session {sampling_session_id!r} does not exist",
+                category="user",
+            ) from None
+        actual_seq_id = session.next_seq_id if seq_id is None else seq_id
+        if actual_seq_id < 0:
+            raise TinkerError("sampling seq_id must be non-negative", category="user")
+        fingerprint = request_fingerprint("sample", payload)
+        key = (sampling_session_id, actual_seq_id)
+        if key in self.sample_request_keys:
+            old_fingerprint, request_id = self.sample_request_keys[key]
+            if old_fingerprint != fingerprint:
+                raise TinkerError(
+                    f"sampling seq_id {actual_seq_id} was already used with a different request",
+                    category="user",
+                )
+            return self.futures[request_id], None
+        if actual_seq_id != session.next_seq_id:
+            raise TinkerError(
+                f"expected seq_id {session.next_seq_id} for sampling session {sampling_session_id!r}, got {actual_seq_id}",
+                category="user",
+            )
+
+        session.next_seq_id += 1
+        future = self.new_future(model_id=None)
+        self.sample_request_keys[key] = (fingerprint, future.request_id)
+        operation = Operation(
+            request_id=future.request_id,
+            kind="sample",
+            model_id=None,
+            payload={
+                **payload,
+                "seq_id": actual_seq_id,
+                "sampling_session_id": sampling_session_id,
+                "base_model": session.base_model,
+                "adapter_path": str(session.adapter_path) if session.adapter_path is not None else None,
+                "adapter_name": session.adapter_name,
+            },
+        )
+        return future, operation
+
+    def new_future(self, model_id: str | None) -> FutureRecord:
+        request_id = f"request-{uuid.uuid4().hex}"
+        future = FutureRecord(request_id=request_id, model_id=model_id)
+        self.futures[request_id] = future
+        return future
+
+    def complete_future(self, request_id: str, response: dict[str, Any]) -> None:
+        future = self.require_future(request_id)
+        if future.status != "pending":
+            return
+        future.status = "completed"
+        future.response = response
+        future.completed_at = time.time()
+
+    def fail_future(
+        self,
+        request_id: str,
+        error: str,
+        category: Literal["unknown", "server", "user"] = "server",
+    ) -> None:
+        future = self.require_future(request_id)
+        if future.status != "pending":
+            return
+        future.status = "failed"
+        future.error = error
+        future.category = category
+        future.completed_at = time.time()
+        if future.model_id is not None:
+            model = self.models.get(future.model_id)
+            if model is not None and model.status == "loading":
+                model.status = "failed"
+
+    def require_future(self, request_id: str) -> FutureRecord:
+        try:
+            return self.futures[request_id]
+        except KeyError:
+            raise TinkerError(f"request {request_id!r} does not exist", category="user") from None
+
+    def retrieve_future(self, request_id: str) -> dict[str, Any]:
+        future = self.require_future(request_id)
+        if future.status == "pending":
+            return {"type": "try_again", "request_id": request_id, "queue_state": "active"}
+        if future.status == "failed":
+            return {"error": future.error or "request failed", "category": future.category}
+        assert future.response is not None
+        return future.response
+
+    def allocate_checkpoint(
+        self,
+        *,
+        model_id: str,
+        seq_id: int,
+        requested_name: str | None,
+        checkpoint_type: Literal["training", "sampler"],
+        ttl_seconds: int | None,
+        overwrite: bool,
+    ) -> CheckpointRecord:
+        model = self.require_model(model_id)
+        if seq_id < 1:
+            raise TinkerError("checkpoint seq_id must be positive", category="user")
+        if ttl_seconds is not None and ttl_seconds < 0:
+            raise TinkerError("checkpoint ttl_seconds must be non-negative", category="user")
+        name = requested_name or f"checkpoint-{seq_id:06d}"
+        if not _CHECKPOINT_NAME.fullmatch(name) or name in (".", ".."):
+            raise TinkerError(
+                "checkpoint path must be a simple name containing only letters, digits, '.', '_' or '-'",
+                category="user",
+            )
+        namespace = "weights" if checkpoint_type == "training" else "sampler_weights"
+        tinker_path = f"tinker://{model_id}/{namespace}/{name}"
+        existing = self.checkpoints.get(tinker_path)
+        if existing is not None:
+            if existing.seq_id == seq_id and existing.checkpoint_type == checkpoint_type:
+                return existing
+            if not overwrite:
+                raise TinkerError(f"checkpoint {tinker_path!r} already exists", category="user")
+
+        model.checkpoint_counter += 1
+        checkpoint_step = model.checkpoint_counter
+        expires_at = None if ttl_seconds is None else time.time() + ttl_seconds
+        local_path = model.config.save / "checkpoints" / f"step_{checkpoint_step}"
+        record = CheckpointRecord(
+            model_id=model_id,
+            checkpoint_id=f"{namespace}/{name}",
+            checkpoint_type=checkpoint_type,
+            tinker_path=tinker_path,
+            local_path=local_path,
+            seq_id=seq_id,
+            checkpoint_step=checkpoint_step,
+            include_optimizer=checkpoint_type == "training",
+            expires_at=expires_at,
+        )
+        self.checkpoints[tinker_path] = record
+        return record
+
+    def require_checkpoint(self, tinker_path: str) -> CheckpointRecord:
+        try:
+            checkpoint = self.checkpoints[tinker_path]
+        except KeyError:
+            raise TinkerError(f"checkpoint {tinker_path!r} does not exist", category="user") from None
+        if checkpoint.status != "ready":
+            raise TinkerError(
+                f"checkpoint {tinker_path!r} is {checkpoint.status}",
+                category="user" if checkpoint.status == "failed" else "server",
+            )
+        if checkpoint.expires_at is not None and checkpoint.expires_at <= time.time():
+            raise TinkerError(f"checkpoint {tinker_path!r} has expired", category="user")
+        return checkpoint
+
+    def complete_checkpoint(self, tinker_path: str) -> CheckpointRecord:
+        try:
+            checkpoint = self.checkpoints[tinker_path]
+        except KeyError:
+            raise TinkerError(f"checkpoint {tinker_path!r} does not exist", category="server") from None
+        checkpoint.status = "ready"
+        return checkpoint
+
+    def fail_checkpoint_for_request(self, request_id: str) -> None:
+        sequence = next(
+            ((model_id, seq_id) for (model_id, seq_id), (_fingerprint, stored_request_id) in self.model_request_keys.items() if stored_request_id == request_id),
+            None,
+        )
+        if sequence is None:
+            return
+        model_id, seq_id = sequence
+        for checkpoint in self.checkpoints.values():
+            if checkpoint.model_id == model_id and checkpoint.seq_id == seq_id and checkpoint.status == "pending":
+                checkpoint.status = "failed"

--- a/miles/ray/train/group.py
+++ b/miles/ray/train/group.py
@@ -268,6 +268,18 @@ class RayTrainGroup:
 
         await self._maybe_log_inference_engine_weight_checksums(rollout_id=rollout_id)
 
+    async def reconcile_adapters(self) -> None:
+        """Reconcile multi-LoRA slots on the first alive trainer cell."""
+        await self._execute_first_alive("reconcile_adapters")
+
+    async def tinker_execute(self, operation: dict) -> dict:
+        """Execute one Tinker operation on all ranks of the first alive cell."""
+        outputs = await self._execute_first_alive("tinker_execute", operation)
+        try:
+            return next(output for output in outputs if output is not None)
+        except StopIteration:
+            raise RuntimeError("Tinker operation returned no result from the trainer") from None
+
     async def _maybe_log_inference_engine_weight_checksums(self, *, rollout_id: int | None) -> None:
         if not is_event_logger_initialized():
             return

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -24,6 +24,16 @@ from miles.utils.tracking_utils.ci_history import RECORD_DIR_ENV
 logger = logging.getLogger(__name__)
 
 
+class _RedactedString(str):
+    """A CLI secret that keeps its value while hiding normal log rendering."""
+
+    def __str__(self) -> str:
+        return "<redacted>"
+
+    def __repr__(self) -> str:
+        return "<redacted>"
+
+
 def reset_arg(parser, name, **kwargs):
     """
     Reset the default value of a Megatron argument.
@@ -1541,6 +1551,45 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                     "How long a generate call waits for the first poppable group before "
                     "failing with an empty-batch timeout (default: 30)."
                 ),
+            )
+            parser.add_argument(
+                "--tinker-model-name",
+                type=str,
+                default=None,
+                help=(
+                    "Public base-model identifier accepted by the Tinker-compatible API. "
+                    "Defaults to --hf-checkpoint."
+                ),
+            )
+            parser.add_argument(
+                "--tinker-tokenizer-id",
+                type=str,
+                default=None,
+                help=(
+                    "Tokenizer identifier returned to Tinker SDK clients. "
+                    "Defaults to --tinker-model-name."
+                ),
+            )
+            parser.add_argument(
+                "--tinker-checkpoint-dir",
+                type=str,
+                default=None,
+                help=(
+                    "Root directory for Tinker training and sampler snapshots "
+                    "(default: SAVE/tinker, or /tmp/miles/tinker when SAVE is unset)."
+                ),
+            )
+            parser.add_argument(
+                "--tinker-api-key",
+                type=_RedactedString,
+                default=None,
+                help="Optional API key required by the Tinker-compatible API (redacted from argument logs).",
+            )
+            parser.add_argument(
+                "--tinker-max-concurrent-samples",
+                type=int,
+                default=256,
+                help="Maximum sampling concurrency advertised to Tinker SDK clients (default: 256).",
             )
             return parser
 

--- a/tests/fast/backends/megatron_utils/test_bridge_lora_helpers.py
+++ b/tests/fast/backends/megatron_utils/test_bridge_lora_helpers.py
@@ -1,0 +1,39 @@
+import torch
+
+from miles.backends.megatron_utils.bridge_lora_helpers import (
+    _add_parameterless_output_anchors,
+    _remove_parameterless_output_anchors,
+)
+
+
+class _ParameterlessOutput(torch.nn.Module):
+    pass
+
+
+class _TiedModel(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.embedding = torch.nn.Embedding(8, 4, dtype=torch.bfloat16)
+        self.output_layer = _ParameterlessOutput()
+
+
+def test_parameterless_output_anchor_provides_device_and_dtype_temporarily():
+    model = _TiedModel()
+
+    anchored = _add_parameterless_output_anchors(model, ["linear_qkv", "output_layer"])
+
+    assert anchored == [model.output_layer]
+    anchor = next(model.output_layer.parameters())
+    assert anchor.numel() == 0
+    assert anchor.device == model.embedding.weight.device
+    assert anchor.dtype == model.embedding.weight.dtype
+
+    _remove_parameterless_output_anchors(anchored)
+    assert list(model.output_layer.parameters()) == []
+
+
+def test_parameterless_output_anchor_is_not_added_when_unembed_is_not_targeted():
+    model = _TiedModel()
+
+    assert _add_parameterless_output_anchors(model, ["linear_qkv"]) == []
+    assert list(model.output_layer.parameters()) == []

--- a/tests/fast/backends/megatron_utils/test_tinker_multi_lora_utils.py
+++ b/tests/fast/backends/megatron_utils/test_tinker_multi_lora_utils.py
@@ -1,0 +1,98 @@
+import sys
+import types
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from miles.backends.megatron_utils.multi_lora_optimizer import named_adapter_slot_parameters
+from miles.backends.megatron_utils.tinker import _merge_retained_grads
+from miles.backends.megatron_utils.multi_lora_utils import (
+    _multi_lora_module_name,
+    _tinker_module_group,
+)
+from miles.ray.tinker.protocol import TinkerError
+
+
+def test_multi_lora_module_name_supports_dense_bridge_wrapper():
+    module = SimpleNamespace(adapters=[SimpleNamespace(base_linear_name="decoder.layers.0.self_attention.linear_qkv")])
+
+    assert _multi_lora_module_name(module) == "decoder.layers.0.self_attention.linear_qkv"
+
+
+def test_multi_lora_module_name_prefers_wrapper_attribute():
+    module = SimpleNamespace(
+        base_linear_name="decoder.layers.0.mlp.experts.linear_fc1",
+        adapters=[SimpleNamespace(base_linear_name="different")],
+    )
+
+    assert _multi_lora_module_name(module) == "decoder.layers.0.mlp.experts.linear_fc1"
+
+
+def test_multi_lora_module_name_rejects_unknown_wrapper():
+    with pytest.raises(RuntimeError, match="cannot determine wrapped linear name"):
+        _multi_lora_module_name(SimpleNamespace(adapters=[]))
+
+
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [
+        ("decoder.output_layer", "unembed"),
+        ("decoder.layers.0.mlp.linear_fc1", "mlp"),
+        ("decoder.layers.0.self_attention.linear_qkv", "attn"),
+    ],
+)
+def test_tinker_module_group(name, expected):
+    assert _tinker_module_group(name) == expected
+
+
+def test_named_adapter_slot_parameters_are_stable_across_slots(monkeypatch):
+    class FakeMultiLoRALinear(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.adapters = torch.nn.ModuleList(
+                [
+                    torch.nn.Linear(2, 3, bias=False),
+                    torch.nn.Linear(2, 3, bias=False),
+                ]
+            )
+
+    stub = types.ModuleType("megatron.bridge.peft.multi_lora_layers")
+    stub.MultiLoRALinear = FakeMultiLoRALinear
+    monkeypatch.setitem(sys.modules, "megatron.bridge.peft.multi_lora_layers", stub)
+
+    model = torch.nn.Module()
+    model.projection = FakeMultiLoRALinear()
+
+    slot0 = named_adapter_slot_parameters(model, 0)
+    slot1 = named_adapter_slot_parameters(model, 1)
+
+    assert [name for name, _ in slot0] == ["model0.projection.weight"]
+    assert [name for name, _ in slot1] == ["model0.projection.weight"]
+    assert slot0[0][1] is not slot1[0][1]
+
+
+def test_retained_gradients_follow_the_optimizer_owner():
+    rank0 = {
+        "optimizer_state": {"layer_a.weight": {}},
+        "retained_grads": {"layer_a.weight": torch.tensor([1.0])},
+    }
+    rank1 = {
+        "optimizer_state": {"layer_b.weight": {}},
+        "retained_grads": {"layer_b.weight": torch.tensor([2.0])},
+    }
+
+    merged = _merge_retained_grads([rank0, rank1])
+
+    torch.testing.assert_close(merged["layer_a.weight"], torch.tensor([1.0]))
+    torch.testing.assert_close(merged["layer_b.weight"], torch.tensor([2.0]))
+
+
+def test_retained_gradient_owner_must_be_unique():
+    duplicate = {
+        "optimizer_state": {"layer.weight": {}},
+        "retained_grads": {"layer.weight": torch.tensor([1.0])},
+    }
+
+    with pytest.raises(TinkerError, match="inconsistent retained-gradient"):
+        _merge_retained_grads([duplicate, duplicate])

--- a/tests/fast/ray/tinker/__init__.py
+++ b/tests/fast/ray/tinker/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Tinker-compatible API."""

--- a/tests/fast/ray/tinker/test_backend.py
+++ b/tests/fast/ray/tinker/test_backend.py
@@ -1,0 +1,130 @@
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from miles.ray.tinker.backend import TinkerBackend
+from miles.ray.tinker.state import Operation
+
+
+class _Response:
+    status_code = 200
+    text = ""
+
+    def json(self):
+        return {
+            "output_ids": [123],
+            "meta_info": {
+                "output_token_logprobs": [[-0.25, 123]],
+                "finish_reason": {"type": "length"},
+                "input_token_logprobs": [[None, 10], [-0.5, 11]],
+                "input_top_logprobs": [None, [[-0.1, 12], [-0.2, 13]]],
+            },
+        }
+
+
+class _Client:
+    def __init__(self):
+        self.requests = []
+
+    async def post(self, url, json):
+        self.requests.append((url, json))
+        return _Response()
+
+
+@pytest.mark.asyncio
+async def test_sample_payload_maps_tinker_seed_to_sglang_sampling_seed():
+    backend = object.__new__(TinkerBackend)
+    backend.client = _Client()
+    backend.router_url = "http://router"
+    payload = {
+        "num_samples": 2,
+        "prompt": [10, 11],
+        "sampling_params": {
+            "max_tokens": 3,
+            "seed": 41,
+            "temperature": 0.7,
+            "top_k": 20,
+            "top_p": 0.9,
+        },
+        "prompt_logprobs": True,
+        "topk_prompt_logprobs": 2,
+        "adapter_name": "adapter",
+    }
+
+    output = await backend._sample_payload(payload)
+
+    assert len(backend.client.requests) == 2
+    first_params = backend.client.requests[0][1]["sampling_params"]
+    second_params = backend.client.requests[1][1]["sampling_params"]
+    assert first_params["sampling_seed"] == 41
+    assert second_params["sampling_seed"] == 42
+    assert "seed" not in first_params
+    assert first_params["max_new_tokens"] == 3
+    assert backend.client.requests[0][1]["lora_path"] == "adapter"
+    assert output["sequences"][0]["tokens"] == [123]
+    assert output["prompt_logprobs"] == [None, -0.5]
+    assert output["topk_prompt_logprobs"][1] == [(12, -0.1), (13, -0.2)]
+
+
+@pytest.mark.asyncio
+async def test_sample_payload_omits_sampling_seed_when_not_requested():
+    backend = object.__new__(TinkerBackend)
+    backend.client = _Client()
+    backend.router_url = "http://router"
+    payload = {
+        "num_samples": 1,
+        "prompt": [10],
+        "sampling_params": {},
+        "prompt_logprobs": False,
+        "topk_prompt_logprobs": 0,
+        "adapter_name": None,
+    }
+
+    await backend._sample_payload(payload)
+
+    params = backend.client.requests[0][1]["sampling_params"]
+    assert "sampling_seed" not in params
+
+
+@pytest.mark.asyncio
+async def test_run_sample_refreshes_unpinned_adapter_before_generation():
+    backend = object.__new__(TinkerBackend)
+    backend.sample_semaphore = asyncio.Semaphore(1)
+    completed = {}
+    calls = []
+
+    class _State:
+        def complete_future(self, request_id, response):
+            completed[request_id] = response
+
+        def fail_future(self, request_id, error, category):
+            raise AssertionError((request_id, error, category))
+
+    async def load_adapter(adapter_name, adapter_path):
+        calls.append(("load", adapter_name, adapter_path))
+
+    async def sample_payload(payload):
+        calls.append(("sample", payload["adapter_name"]))
+        return {"type": "sample", "sequences": []}
+
+    backend.state = _State()
+    backend._load_sampler_adapter = load_adapter
+    backend._sample_payload = sample_payload
+    operation = Operation(
+        request_id="request-1",
+        kind="sample",
+        model_id=None,
+        payload={
+            "adapter_name": "adapter-1",
+            "adapter_path": "/tmp/adapter-1",
+        },
+    )
+
+    await backend._run_sample(operation)
+
+    assert calls == [
+        ("load", "adapter-1", Path("/tmp/adapter-1")),
+        ("sample", "adapter-1"),
+    ]
+    assert completed["request-1"]["type"] == "sample"

--- a/tests/fast/ray/tinker/test_entrypoint.py
+++ b/tests/fast/ray/tinker/test_entrypoint.py
@@ -1,0 +1,78 @@
+from types import SimpleNamespace
+
+import pytest
+
+from train_tinker import (
+    _apply_api_key_environment,
+    _configure_megatron_batch_placeholder,
+    _validate_args,
+)
+
+
+def _args(**overrides):
+    values = {
+        "train_backend": "megatron",
+        "multi_lora_n_adapters": 2,
+        "indep_dp": False,
+        "colocate": False,
+        "use_fault_tolerance": False,
+        "pipeline_model_parallel_size": 1,
+        "context_parallel_size": 1,
+        "qkv_format": "thd",
+        "calculate_per_token_loss": False,
+        "lora_dropout": 0.0,
+        "attention_dropout": 0.0,
+        "hidden_dropout": 0.0,
+        "tinker_max_concurrent_samples": 256,
+        "actor_num_nodes": 1,
+        "actor_num_gpus_per_node": 2,
+        "tensor_model_parallel_size": 1,
+        "micro_batch_size": 1,
+        "global_batch_size": 1,
+        "num_rollout": 1,
+        "rollout_batch_size": 1,
+        "n_samples_per_prompt": 1,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def test_valid_service_arguments_are_accepted():
+    _validate_args(_args())
+
+
+def test_api_key_environment_is_applied_as_a_redacted_secret(monkeypatch):
+    args = _args(tinker_api_key=None)
+    monkeypatch.setenv("TINKER_API_KEY", "environment-secret")
+
+    _apply_api_key_environment(args)
+
+    assert args.tinker_api_key == "environment-secret"
+    assert str(args.tinker_api_key) == "<redacted>"
+
+
+def test_megatron_placeholder_batch_is_divisible_by_data_parallel_size():
+    args = _args(
+        actor_num_gpus_per_node=4,
+        tensor_model_parallel_size=2,
+        global_batch_size=1,
+    )
+
+    _configure_megatron_batch_placeholder(args)
+
+    assert args.global_batch_size == 2
+    assert args.num_rollout * args.rollout_batch_size * args.n_samples_per_prompt == 2
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"train_backend": "fsdp"}, "--train-backend must be megatron"),
+        ({"indep_dp": True}, "--indep-dp is not supported"),
+        ({"colocate": True}, "must be disaggregated"),
+        ({"qkv_format": "bshd"}, "--qkv-format must be thd"),
+    ],
+)
+def test_unsupported_service_topologies_are_rejected(overrides, message):
+    with pytest.raises(ValueError, match=message):
+        _validate_args(_args(**overrides))

--- a/tests/fast/ray/tinker/test_http_server.py
+++ b/tests/fast/ray/tinker/test_http_server.py
@@ -1,0 +1,55 @@
+from types import SimpleNamespace
+
+from fastapi.testclient import TestClient
+
+from miles.ray.tinker.http_server import TinkerHTTPServer
+
+
+def _client(api_key: str | None, *, ready: bool = True) -> TestClient:
+    backend = SimpleNamespace(
+        args=SimpleNamespace(tinker_api_key=api_key, seq_length=4096),
+        model_name="test/model",
+        ready=ready,
+    )
+    server = TinkerHTTPServer(backend)
+    app = server.create_app()
+    server.add_routes(app)
+    return TestClient(app)
+
+
+def test_healthz_does_not_require_authentication():
+    with _client("tml-secret") as client:
+        response = client.get("/api/v1/healthz")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+def test_healthz_is_not_ready_until_the_trainer_is_initialized():
+    with _client(None, ready=False) as client:
+        response = client.get("/api/v1/healthz")
+
+    assert response.status_code == 503
+    assert response.json() == {"detail": "trainer is initializing"}
+
+
+def test_official_sdk_api_key_header_is_authenticated():
+    with _client("tml-secret") as client:
+        unauthorized = client.get("/api/v1/get_server_capabilities")
+        authorized = client.get(
+            "/api/v1/get_server_capabilities",
+            headers={"X-API-Key": "tml-secret"},
+        )
+
+    assert unauthorized.status_code == 401
+    assert authorized.status_code == 200
+
+
+def test_bearer_header_is_accepted_for_non_sdk_clients():
+    with _client("tml-secret") as client:
+        response = client.get(
+            "/api/v1/get_server_capabilities",
+            headers={"Authorization": "Bearer tml-secret"},
+        )
+
+    assert response.status_code == 200

--- a/tests/fast/ray/tinker/test_loss.py
+++ b/tests/fast/ray/tinker/test_loss.py
@@ -1,0 +1,184 @@
+import pytest
+import torch
+
+from miles.backends.megatron_utils.tinker_loss import (
+    compute_tinker_loss,
+    tensor_data,
+    validate_and_get_targets,
+)
+from miles.ray.tinker.protocol import TinkerError
+
+
+def _rl_inputs():
+    return {
+        "target_tokens": torch.tensor([1, 2]),
+        "logprobs": torch.tensor([-0.4, -0.7]),
+        "advantages": torch.tensor([2.0, -1.0]),
+    }
+
+
+def test_cross_entropy_topk_is_sum_reduced():
+    target_logprobs = torch.tensor([[-0.1, -0.2], [-0.3, -0.4]], requires_grad=True)
+    inputs = {
+        "target_tokens": torch.tensor([[1, 2], [3, 4]]),
+        "weights": torch.tensor([[1.0, 0.5], [0.0, 2.0]]),
+    }
+
+    loss = compute_tinker_loss(
+        target_logprobs,
+        inputs,
+        loss_fn="cross_entropy",
+        loss_fn_config={},
+    )
+
+    assert loss.item() == pytest.approx(1.0)
+    loss.backward()
+    torch.testing.assert_close(target_logprobs.grad, -inputs["weights"])
+
+
+def test_importance_sampling_matches_public_formula():
+    target_logprobs = torch.tensor([-0.2, -1.0])
+    inputs = _rl_inputs()
+
+    actual = compute_tinker_loss(
+        target_logprobs,
+        inputs,
+        loss_fn="importance_sampling",
+        loss_fn_config={},
+    )
+    expected = -(torch.exp(target_logprobs - inputs["logprobs"]) * inputs["advantages"]).sum()
+    torch.testing.assert_close(actual, expected)
+
+
+def test_ppo_uses_ratio_thresholds():
+    target_logprobs = torch.tensor([0.0, 0.0])
+    inputs = {
+        "target_tokens": torch.tensor([1, 2]),
+        "logprobs": torch.log(torch.tensor([0.5, 2.0])),
+        "advantages": torch.tensor([1.0, -1.0]),
+    }
+
+    actual = compute_tinker_loss(
+        target_logprobs,
+        inputs,
+        loss_fn="ppo",
+        loss_fn_config={"clip_low_threshold": 0.8, "clip_high_threshold": 1.2},
+    )
+
+    ratio = torch.exp(target_logprobs - inputs["logprobs"])
+    expected = -torch.minimum(
+        ratio * inputs["advantages"],
+        ratio.clamp(0.8, 1.2) * inputs["advantages"],
+    ).sum()
+    torch.testing.assert_close(actual, expected)
+
+
+def test_cispo_detaches_clipped_ratio():
+    target_logprobs = torch.tensor([-0.1, -0.2], requires_grad=True)
+    inputs = _rl_inputs()
+
+    loss = compute_tinker_loss(
+        target_logprobs,
+        inputs,
+        loss_fn="cispo",
+        loss_fn_config={},
+    )
+    coefficient = torch.exp(target_logprobs.detach() - inputs["logprobs"]).clamp(0.0, 4.0)
+    loss.backward()
+
+    torch.testing.assert_close(target_logprobs.grad, -(coefficient * inputs["advantages"]))
+
+
+def test_dro_matches_public_formula():
+    target_logprobs = torch.tensor([-0.2, -1.0])
+    inputs = _rl_inputs()
+
+    actual = compute_tinker_loss(
+        target_logprobs,
+        inputs,
+        loss_fn="dro",
+        loss_fn_config={"beta": 0.05},
+    )
+    delta = target_logprobs - inputs["logprobs"]
+    expected = -(target_logprobs * inputs["advantages"] - 0.5 * 0.05 * delta.square()).sum()
+    torch.testing.assert_close(actual, expected)
+
+
+def test_target_shape_must_match_model_input():
+    with pytest.raises(TinkerError, match="must equal model_input length"):
+        validate_and_get_targets(
+            {
+                "target_tokens": torch.tensor([1, 2]),
+                "weights": torch.ones(2),
+            },
+            model_input_length=3,
+            loss_fn="cross_entropy",
+        )
+
+
+def test_cross_entropy_topk_dimension_must_be_positive():
+    with pytest.raises(TinkerError, match="top-K dimension must be positive"):
+        validate_and_get_targets(
+            {
+                "target_tokens": torch.empty((2, 0), dtype=torch.int64),
+                "weights": torch.empty((2, 0)),
+            },
+            model_input_length=2,
+            loss_fn="cross_entropy",
+        )
+
+
+@pytest.mark.parametrize(
+    ("target_logprobs", "inputs", "config", "category"),
+    [
+        (
+            torch.tensor([float("nan"), -0.2]),
+            {
+                "target_tokens": torch.tensor([1, 2]),
+                "weights": torch.ones(2),
+            },
+            {},
+            "server",
+        ),
+        (
+            torch.tensor([-0.1, -0.2]),
+            {
+                "target_tokens": torch.tensor([1, 2]),
+                "weights": torch.tensor([1.0, float("inf")]),
+            },
+            {},
+            "user",
+        ),
+        (
+            torch.tensor([-0.1, -0.2]),
+            {
+                "target_tokens": torch.tensor([1, 2]),
+                "weights": torch.ones(2),
+            },
+            {"clip_low_threshold": float("nan")},
+            "user",
+        ),
+    ],
+)
+def test_nonfinite_loss_values_are_rejected(target_logprobs, inputs, config, category):
+    loss_fn = "ppo" if config else "cross_entropy"
+    if loss_fn == "ppo":
+        inputs = _rl_inputs()
+
+    with pytest.raises(TinkerError) as exc_info:
+        compute_tinker_loss(
+            target_logprobs,
+            inputs,
+            loss_fn=loss_fn,
+            loss_fn_config=config,
+        )
+
+    assert exc_info.value.category == category
+
+
+def test_tensor_data_serializes_shape_and_float32():
+    assert tensor_data(torch.tensor([[1.0, 2.0]], dtype=torch.float64)) == {
+        "data": [1.0, 2.0],
+        "dtype": "float32",
+        "shape": [1, 2],
+    }

--- a/tests/fast/ray/tinker/test_protocol.py
+++ b/tests/fast/ray/tinker/test_protocol.py
@@ -1,0 +1,83 @@
+import pytest
+from pydantic import ValidationError
+
+from miles.ray.tinker.protocol import (
+    ModelInput,
+    ModelInputChunk,
+    SamplingParams,
+    TensorData,
+    TinkerError,
+    dense_tensor_data,
+    encoded_tokens,
+)
+
+
+def test_dense_tensor_data_decodes_csr():
+    value = TensorData(
+        data=[3.0, 4.0],
+        dtype="float32",
+        shape=[2, 3],
+        sparse_crow_indices=[0, 1, 2],
+        sparse_col_indices=[2, 0],
+    )
+
+    data, shape = dense_tensor_data(value)
+
+    assert data == [0.0, 0.0, 3.0, 4.0, 0.0, 0.0]
+    assert shape == [2, 3]
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        TensorData(
+            data=[3.0],
+            dtype="float32",
+            shape=[2, 3],
+            sparse_crow_indices=[0, 1],
+            sparse_col_indices=[2],
+        ),
+        TensorData(
+            data=[3.0],
+            dtype="float32",
+            shape=[2, 3],
+            sparse_crow_indices=[0, 1, 0],
+            sparse_col_indices=[2],
+        ),
+        TensorData(
+            data=[3.0],
+            dtype="float32",
+            shape=[2, 3],
+            sparse_crow_indices=[0, 1, 1],
+            sparse_col_indices=[3],
+        ),
+    ],
+)
+def test_dense_tensor_data_rejects_malformed_csr(value):
+    with pytest.raises(TinkerError):
+        dense_tensor_data(value)
+
+
+def test_encoded_tokens_concatenates_chunks():
+    value = ModelInput(
+        chunks=[
+            ModelInputChunk(type="encoded_text", tokens=[1, 2]),
+            ModelInputChunk(type="encoded_text", tokens=[3]),
+        ]
+    )
+
+    assert encoded_tokens(value) == [1, 2, 3]
+
+
+def test_non_text_chunk_returns_typed_user_error():
+    value = ModelInput(chunks=[ModelInputChunk(type="image", tokens=None, data="ignored")])
+
+    with pytest.raises(TinkerError) as exc_info:
+        encoded_tokens(value)
+
+    assert exc_info.value.category == "user"
+
+
+def test_sampling_params_reject_unknown_fields():
+    with pytest.raises(ValidationError, match="extra_forbidden"):
+        SamplingParams(temperature=0.5, unsupported_penalty=1.0)

--- a/tests/fast/ray/tinker/test_state.py
+++ b/tests/fast/ray/tinker/test_state.py
@@ -1,0 +1,168 @@
+from pathlib import Path
+
+import pytest
+
+from miles.ray.tinker.protocol import TinkerError
+from miles.ray.tinker.state import TinkerModelConfig, TinkerState
+
+
+def _active_model(state: TinkerState):
+    session = state.create_session(tags=[], user_metadata=None, sdk_version="test", project_id=None)
+    config = TinkerModelConfig(
+        rank=8,
+        alpha=8,
+        save=Path("/tmp/tinker-test-model"),
+        seed=1,
+        train_unembed=True,
+        train_mlp=True,
+        train_attn=True,
+    )
+    model, _future, _ = state.begin_model_create(
+        session_id=session.session_id,
+        model_seq_id=0,
+        base_model="test/model",
+        config=config,
+        payload={"base_model": "test/model"},
+    )
+    model.status = "active"
+    return model
+
+
+def test_model_operations_are_ordered_and_idempotent():
+    state = TinkerState()
+    model = _active_model(state)
+    future, operation = state.submit_model_operation(
+        model_id=model.model_id,
+        seq_id=1,
+        kind="forward",
+        payload={"value": 1},
+    )
+    duplicate, duplicate_operation = state.submit_model_operation(
+        model_id=model.model_id,
+        seq_id=1,
+        kind="forward",
+        payload={"value": 1},
+    )
+
+    assert duplicate.request_id == future.request_id
+    assert operation is not None
+    assert duplicate_operation is None
+
+    with pytest.raises(TinkerError, match="different request"):
+        state.submit_model_operation(
+            model_id=model.model_id,
+            seq_id=1,
+            kind="forward",
+            payload={"value": 2},
+        )
+    with pytest.raises(TinkerError, match="expected seq_id 2"):
+        state.submit_model_operation(
+            model_id=model.model_id,
+            seq_id=3,
+            kind="forward",
+            payload={"value": 3},
+        )
+
+
+def test_checkpoint_paths_are_sdk_uri_and_megatron_step_dir():
+    state = TinkerState()
+    model = _active_model(state)
+
+    checkpoint = state.allocate_checkpoint(
+        model_id=model.model_id,
+        seq_id=1,
+        requested_name="checkpoint-one",
+        checkpoint_type="training",
+        ttl_seconds=None,
+        overwrite=False,
+    )
+    duplicate = state.allocate_checkpoint(
+        model_id=model.model_id,
+        seq_id=1,
+        requested_name="checkpoint-one",
+        checkpoint_type="training",
+        ttl_seconds=None,
+        overwrite=False,
+    )
+
+    assert checkpoint.tinker_path == f"tinker://{model.model_id}/weights/checkpoint-one"
+    assert checkpoint.local_path == model.config.save / "checkpoints" / "step_1"
+    assert duplicate is checkpoint
+    with pytest.raises(TinkerError, match="is pending"):
+        state.require_checkpoint(checkpoint.tinker_path)
+
+    state.complete_checkpoint(checkpoint.tinker_path)
+    assert state.require_checkpoint(checkpoint.tinker_path) is checkpoint
+
+
+def test_checkpoint_validation_does_not_advance_or_allocate_on_bad_sequence():
+    state = TinkerState()
+    model = _active_model(state)
+
+    with pytest.raises(TinkerError, match="expected seq_id 1"):
+        state.validate_model_operation(
+            model_id=model.model_id,
+            seq_id=2,
+            kind="save_weights",
+            payload={"path": "bad"},
+        )
+
+    assert model.next_seq_id == 1
+    assert state.checkpoints == {}
+
+
+def test_model_create_can_be_rolled_back_after_registration_failure():
+    state = TinkerState()
+    session = state.create_session(tags=[], user_metadata=None, sdk_version="test", project_id=None)
+    config = TinkerModelConfig(
+        rank=8,
+        alpha=8,
+        save=Path("/tmp/tinker-test-model"),
+        seed=1,
+        train_unembed=True,
+        train_mlp=True,
+        train_attn=True,
+    )
+    model, future, _ = state.begin_model_create(
+        session_id=session.session_id,
+        model_seq_id=0,
+        base_model="test/model",
+        config=config,
+        payload={"base_model": "test/model"},
+    )
+
+    state.rollback_model_create(model.model_id, future.request_id)
+
+    assert model.model_id not in state.models
+    assert future.request_id not in state.futures
+    assert (session.session_id, 0) not in state.model_create_keys
+
+
+def test_sampling_sequences_start_at_zero_and_are_idempotent():
+    state = TinkerState()
+    session = state.create_session(tags=[], user_metadata=None, sdk_version="test", project_id=None)
+    sampling, _ = state.create_sampling_session(
+        session_id=session.session_id,
+        sampling_session_seq_id=0,
+        base_model="test/model",
+        model_path=None,
+        adapter_path=None,
+        adapter_name=None,
+        payload={"base_model": "test/model"},
+    )
+
+    future, operation = state.submit_sample(
+        sampling_session_id=sampling.sampling_session_id,
+        seq_id=0,
+        payload={"prompt": [1]},
+    )
+    duplicate, duplicate_operation = state.submit_sample(
+        sampling_session_id=sampling.sampling_session_id,
+        seq_id=0,
+        payload={"prompt": [1]},
+    )
+
+    assert operation is not None
+    assert operation.payload["seq_id"] == 0
+    assert duplicate.request_id == future.request_id
+    assert duplicate_operation is None

--- a/tests/fast/utils/test_tinker_arguments.py
+++ b/tests/fast/utils/test_tinker_arguments.py
@@ -1,0 +1,12 @@
+import hmac
+
+from miles.utils.arguments import _RedactedString
+
+
+def test_tinker_api_key_keeps_value_but_redacts_log_rendering():
+    secret = _RedactedString("tml-secret")
+
+    assert hmac.compare_digest(secret, "tml-secret")
+    assert str(secret) == "<redacted>"
+    assert repr(secret) == "<redacted>"
+    assert f"{secret}" == "<redacted>"

--- a/train_tinker.py
+++ b/train_tinker.py
@@ -1,0 +1,147 @@
+"""Serve Miles training and sampling through the official Tinker SDK API."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+
+import ray
+
+from miles.ray.multi_lora.controller import create_multilora_controller
+from miles.ray.placement_group import create_placement_groups, create_rollout_manager, create_training_models
+from miles.ray.tinker.protocol import TinkerError
+from miles.utils import object_store
+from miles.utils.arguments import _RedactedString, parse_args
+from miles.utils.audit_utils.process_identity import MainProcessIdentity
+from miles.utils.logging_utils import configure_logger
+from miles.utils.megatron_args_utils import compute_megatron_world_size_except_dp
+from miles.utils.tracking_utils.tracking import init_tracking
+
+logger = logging.getLogger(__name__)
+
+_TINKER_BACKEND = "miles.ray.tinker.backend.TinkerBackend"
+_TINKER_SERVER = "miles.ray.tinker.http_server.TinkerHTTPServer"
+
+
+async def main(args) -> None:
+    """Launch a long-running Tinker-compatible training service."""
+    _apply_api_key_environment(args)
+    _validate_args(args)
+    _configure_megatron_batch_placeholder(args)
+
+    args.multi_lora_backend_path = _TINKER_BACKEND
+    args.multi_lora_http_server_path = _TINKER_SERVER
+    # Tinker checkpoints are explicit API operations. Avoid an unrelated
+    # final save when a model is unloaded.
+    args.save_interval = None
+
+    configure_logger(args, source=MainProcessIdentity())
+    pgs = create_placement_groups(args)
+    object_store.init_instance(args, contribute_segment=False)
+    init_tracking(args)
+    rollout_manager, _ = create_rollout_manager(args, pgs["rollout"])
+
+    router_ip, router_port = await rollout_manager.get_router_address.remote()
+    args.sglang_router_ip, args.sglang_router_port = router_ip, router_port
+    controller = create_multilora_controller(args, f"http://{router_ip}:{router_port}")
+    actor_model = None
+    try:
+        await controller.start.remote()
+        host = await controller.http_host.remote()
+        api_port = await controller.api_port.remote()
+        logger.info(f"Tinker-compatible API listening on http://{host}:{api_port}")
+
+        actor_model, _ = await create_training_models(args, pgs, rollout_manager)
+        await controller.mark_external_ready.remote()
+        while True:
+            operation = await controller.next_external_operation.remote()
+            if operation is None:
+                continue
+            request_id = operation["request_id"]
+            try:
+                if operation["kind"] == "create_model":
+                    await actor_model.reconcile_adapters()
+                    await actor_model.update_weights()
+                    result = {"_operation_kind": "create_model"}
+                elif operation["kind"] == "unload_model":
+                    await actor_model.reconcile_adapters()
+                    result = {"_operation_kind": "unload_model"}
+                else:
+                    result = await actor_model.tinker_execute(operation)
+                await controller.complete_external_operation.remote(request_id, result)
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                cause = _unwrap_ray_error(exc)
+                category = cause.category if isinstance(cause, TinkerError) else "server"
+                logger.exception(f"Tinker operation {operation['kind']} failed")
+                await controller.fail_external_operation.remote(request_id, str(cause), category)
+                if operation["kind"] in {"create_model", "unload_model"}:
+                    try:
+                        await actor_model.reconcile_adapters()
+                    except Exception:
+                        logger.exception("Tinker adapter cleanup after failed lifecycle operation also failed")
+    finally:
+        if rollout_manager is not None:
+            await rollout_manager.dispose.remote()
+        await controller.stop.remote()
+
+
+def _unwrap_ray_error(exc: Exception) -> Exception:
+    if isinstance(exc, ray.exceptions.RayTaskError):
+        cause = getattr(exc, "cause", None)
+        if isinstance(cause, Exception):
+            return cause
+        unwrapped = exc.as_instanceof_cause()
+        if isinstance(unwrapped, Exception):
+            return unwrapped
+    return exc
+
+
+def _apply_api_key_environment(args) -> None:
+    """Prefer an environment secret so it does not appear in process arguments."""
+    if api_key := os.environ.get("TINKER_API_KEY"):
+        args.tinker_api_key = _RedactedString(api_key)
+
+
+def _configure_megatron_batch_placeholder(args) -> None:
+    """Set an initialization-only batch shape divisible by the trainer DP size."""
+    total_trainers = args.actor_num_nodes * args.actor_num_gpus_per_node
+    model_parallel_size = compute_megatron_world_size_except_dp(args)
+    data_parallel_size = total_trainers // model_parallel_size
+    micro_batch_size = args.micro_batch_size or 1
+    args.micro_batch_size = micro_batch_size
+    args.global_batch_size = micro_batch_size * data_parallel_size
+    # The regular Miles scheduler still initializes even though Tinker owns
+    # every optimizer step. Keep its one dummy iteration internally valid.
+    args.num_rollout = 1
+    args.rollout_batch_size = args.global_batch_size
+    args.n_samples_per_prompt = 1
+    args.over_sampling_batch_size = args.rollout_batch_size
+    args.num_steps_per_rollout = 1
+
+
+def _validate_args(args) -> None:
+    requirements = [
+        (args.train_backend == "megatron", "--train-backend must be megatron"),
+        (args.multi_lora_n_adapters > 0, "--multi-lora-n-adapters must be positive"),
+        (not getattr(args, "indep_dp", False), "--indep-dp is not supported"),
+        (not args.colocate, "trainer and rollout GPUs must be disaggregated"),
+        (not args.use_fault_tolerance, "fault-tolerant trainer replicas are not supported"),
+        (args.pipeline_model_parallel_size == 1, "pipeline parallel size must be 1"),
+        (args.context_parallel_size == 1, "context parallel size must be 1"),
+        (args.qkv_format == "thd", "--qkv-format must be thd"),
+        (not args.calculate_per_token_loss, "per-token-loss mode must be disabled for sum-reduced losses"),
+        (args.lora_dropout == 0.0, "--lora-dropout must be 0"),
+        (args.attention_dropout == 0.0, "--attention-dropout must be 0"),
+        (args.hidden_dropout == 0.0, "--hidden-dropout must be 0"),
+        (args.tinker_max_concurrent_samples > 0, "--tinker-max-concurrent-samples must be positive"),
+    ]
+    for valid, message in requirements:
+        if not valid:
+            raise ValueError(f"Tinker service: {message}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main(parse_args()))


### PR DESCRIPTION
## Summary

- add a self-hosted data plane compatible with the official Tinker SDK `ServiceClient`, `TrainingClient`, and `SamplingClient` routes
- back forward/backward, optimizer steps, exact training-state checkpoints, and retained gradients with Megatron multi-LoRA
- expose immutable named and ephemeral SGLang LoRA sampling snapshots, base-model sampling, auth, readiness, docs, and a runnable SDK smoke test

## Compatibility

- supports encoded-text LoRA training, CE/importance-sampling/PPO/CISPO/DRO/custom losses, top-k logprobs, Adam, module groups, seeds, unload, telemetry, and weights info
- supports DP and TP; validates and rejects unsupported PP, CP, BSHD, colocation, full fine-tuning, and non-LoRA modes at startup
- implements the official SDK core data plane, not hosted account/project/billing/admin control-plane APIs

## Validation

- `pytest -q tests/fast`: 4081 passed, 22 skipped; one Ray dashboard test collided with an already-running external Ray cluster and passed in isolation after stopping that cluster
- targeted final regression suite: 96 passed
- official Tinker SDK 0.24.0 end-to-end smoke passed with DP=2 and TP=2, including exact optimizer/retained-gradient restore and all sampling modes
- Ruff format/lint, compileall, shell syntax, docs JSON, and `git diff --check` passed

## Tested dependency heads

- Miles `main`: `2cb59235176a170480765e762e85a952e6ba72b7`
- SGLang `sglang-miles`: `3003d70f680d41c59d1b7acbf65cb47795dfd19e`
- Megatron-Bridge `bridge`: `7f0fb3456f8ffe47599b5fd167b454605d85f932`
