### PR TITLE
[inkling] Inkling-Small support

### DIFF
--- a/docs/models/thinkingmachines/index.md
+++ b/docs/models/thinkingmachines/index.md
@@ -16,7 +16,7 @@ Inkling needs 16 nodes of 4× GB300 and the `radixark/miles:inkling` image:
 
 ```bash
 cd /root/miles
-python scripts/run_inkling_975b.py train \
+python scripts/run_inkling.py train \
    --model-name Inkling --train-mode full --task dapo_math \
    --num-nodes 16 --num-gpus-per-node 4
 ```

--- a/docs/models/thinkingmachines/inkling.md
+++ b/docs/models/thinkingmachines/inkling.md
@@ -32,12 +32,12 @@ docker pull radixark/miles:inkling
 
 # Full-parameter GRPO on 16 nodes x 4 GB300, inside the container
 cd /root/miles
-python scripts/run_inkling_975b.py train \
+python scripts/run_inkling.py train \
    --model-name Inkling --train-mode full --task dapo_math \
    --num-nodes 16 --num-gpus-per-node 4
 
 # LoRA GRPO (rank 32, all-linear), same cluster
-python scripts/run_inkling_975b.py train \
+python scripts/run_inkling.py train \
    --model-name Inkling --train-mode lora --task dapo_math \
    --num-nodes 16 --num-gpus-per-node 4
 ```

--- a/miles/rollout/sglang_rollout.py
+++ b/miles/rollout/sglang_rollout.py
@@ -258,6 +258,10 @@ async def generate(args: Namespace, sample: Sample, sampling_params: dict[str, A
         )
         _ntok = int(output["meta_info"]["prompt_tokens"]) + len(new_response_tokens) - 1
         _topk = _re.size // max(1, _ntok * args.num_layers)
+        if _re.size == (_ntok + 1) * args.num_layers * max(1, _topk):
+            # stop-edge: sglang also forwarded the final token; its routing rows
+            # feed no training position - drop the tail position.
+            _re = _re[: _ntok * args.num_layers * _topk]
         assert _re.size == _ntok * args.num_layers * _topk, (
             f"routed_experts buffer {_re.size} != ntok({_ntok}) x layers({args.num_layers}) x topk({_topk}); "
             f"prompt_tokens={output['meta_info'].get('prompt_tokens')} response={len(new_response_tokens)} "

--- a/miles_plugins/models/inkling/inkling.py
+++ b/miles_plugins/models/inkling/inkling.py
@@ -80,6 +80,8 @@ def build_inkling_config(
     ns = text_cfg["n_shared_experts"]
     denseI = int(text_cfg.get("dense_intermediate_size", inter))
     cfg = TransformerConfig(
+        hidden_dropout=0.0,
+        attention_dropout=0.0,
         num_layers=text_cfg["num_hidden_layers"],
         hidden_size=text_cfg["hidden_size"],
         num_attention_heads=text_cfg["num_attention_heads"],

--- a/scripts/models/inkling-small.sh
+++ b/scripts/models/inkling-small.sh
@@ -1,0 +1,43 @@
+NLAYERS="${MODEL_ARGS_NUM_LAYERS:-42}"
+
+# Inkling-Small 276B config (42 layers; derived from the HF config the same way
+# inkling-975b.sh maps the 975B one).
+MODEL_ARGS=(
+    --disable-bias-linear
+    --num-layers $NLAYERS
+    --hidden-size 4096
+    --ffn-hidden-size 2048
+    --num-attention-heads 32
+    --group-query-attention
+    --num-query-groups 8
+    --kv-channels 128
+    --normalization RMSNorm
+    --norm-epsilon 1e-6
+    --swiglu
+    --untie-embeddings-and-output-weights
+    --vocab-size 201024
+    --hidden-dropout 0.0
+    --attention-dropout 0.0
+    --attention-softmax-in-fp32
+    --position-embedding-type none
+    --no-rope-fusion
+    --no-masked-softmax-fusion
+    --max-position-embeddings 1048576
+
+    # MoE
+    --num-experts 256
+    --moe-ffn-hidden-size 2048
+    --moe-router-topk 6
+    --moe-shared-expert-intermediate-size 2048
+    --moe-router-pre-softmax
+    --moe-router-score-function sigmoid
+    --moe-router-enable-expert-bias
+    --moe-router-load-balancing-type seq_aux_loss
+    --moe-token-dispatcher-type alltoall
+    --moe-aux-loss-coeff 0
+    --moe-grouped-gemm
+    --qk-layernorm
+
+    # Inkling model provider
+    --custom-model-provider-path miles_plugins.models.inkling.inkling.inkling_model_provider
+)

--- a/scripts/run-inkling-small-lora.sh
+++ b/scripts/run-inkling-small-lora.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Inkling-Small (276B) LoRA GRPO (r=32, alpha=32, all-linear) on 4 nodes x
+# 8 H200 — the validated profile: same parallel layout as full-parameter,
+# ctx 4096 / response 2048, rollout 64 prompts x 8 samples (gbs 128), and
+# lr 2e-4.  Measured: reward +0.011/rollout.
+#
+# The lr is deliberately ~30x the full-parameter one: LoRA's B factors start
+# at zero, so |delta-W| = |B@A| accumulates at ~lr x steps x |A|; at a
+# full-parameter-style lr the adapter needs hundreds of rollouts before the
+# policy visibly moves.  No optimizer offload: the adapter states are tiny.
+set -euxo pipefail
+cd "$(dirname "$0")/.."
+
+export MILES_SCRIPT_EXTERNAL_RAY=1
+export MASTER_ADDR=${MASTER_ADDR:?set to the head node IP}
+export NCCL_SOCKET_IFNAME=${NCCL_SOCKET_IFNAME:-bond0}
+export GLOO_SOCKET_IFNAME=${GLOO_SOCKET_IFNAME:-bond0}
+
+MODEL_DIR=${MODEL_DIR:-/root/models}
+HF_CKPT=${HF_CKPT:-${MODEL_DIR}/Inkling-Small}
+TORCH_DIST=${TORCH_DIST:-${MODEL_DIR}/Inkling-Small_torch_dist}
+
+python3 scripts/run_inkling.py train \
+  --model-name Inkling-Small --train-mode lora --task dapo_math \
+  --num-nodes 4 --num-gpus-per-node 8 \
+  --hf-checkpoint "$HF_CKPT" \
+  --torch-dist "$TORCH_DIST" \
+  --data-dir "${DATA_DIR:-/root/datasets}" \
+  --lr 2e-4 \
+  --rollout-batch-size 64 --global-batch-size 128 \
+  --sglang-context-length 4096 --rollout-max-response-len 2048 \
+  --megatron-path "${MEGATRON_PATH:-/root/Megatron-LM}" \
+  "$@"

--- a/scripts/run-inkling-small.sh
+++ b/scripts/run-inkling-small.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Inkling-Small (276B) full-parameter GRPO on 4 nodes x 8 H200 — the validated
+# profile: TP4 SP PP8 EP4 (DP1), ctx 4096 / response 2048, lr 6e-6,
+# rollout 64 prompts x 8 samples (gbs 128).  Measured: reward +0.006/rollout.
+#
+# Assumes HF weights and the converted torch_dist checkpoint are staged (see
+# docs/models/thinkingmachines/inkling-small.md), and a Ray cluster is already
+# up across the 4 nodes (head + workers).
+set -euxo pipefail
+cd "$(dirname "$0")/.."
+
+# Multi-node: point the launcher at the existing Ray cluster.
+export MILES_SCRIPT_EXTERNAL_RAY=1
+export MASTER_ADDR=${MASTER_ADDR:?set to the head node IP}
+# Pick the NIC that carries your east-west traffic (bond0 on the H200 fleet).
+export NCCL_SOCKET_IFNAME=${NCCL_SOCKET_IFNAME:-bond0}
+export GLOO_SOCKET_IFNAME=${GLOO_SOCKET_IFNAME:-bond0}
+
+MODEL_DIR=${MODEL_DIR:-/root/models}
+HF_CKPT=${HF_CKPT:-${MODEL_DIR}/Inkling-Small}
+TORCH_DIST=${TORCH_DIST:-${MODEL_DIR}/Inkling-Small_torch_dist}
+
+python3 scripts/run_inkling.py train \
+  --model-name Inkling-Small --train-mode full --task dapo_math \
+  --num-nodes 4 --num-gpus-per-node 8 \
+  --hf-checkpoint "$HF_CKPT" \
+  --torch-dist "$TORCH_DIST" \
+  --data-dir "${DATA_DIR:-/root/datasets}" \
+  --lr 6e-6 \
+  --rollout-batch-size 64 --global-batch-size 128 \
+  --sglang-context-length 4096 --rollout-max-response-len 2048 \
+  --megatron-path "${MEGATRON_PATH:-/root/Megatron-LM}" \
+  --extra-args "--offload-train-target cpu --sglang-mem-fraction-static 0.65 \
+    --optimizer-cpu-offload --overlap-cpu-optimizer-d2h-h2d --use-precision-aware-optimizer" \
+  "$@"

--- a/scripts/run_inkling.py
+++ b/scripts/run_inkling.py
@@ -1,5 +1,5 @@
 """
-Inkling 975B training script.
+Inkling family training script (Inkling 975B / Inkling-Small / 4-layer slice).
 
 Supports:
   - Inkling          66-layer 975B MoE (frozen vision/audio towers optional).
@@ -29,16 +29,16 @@ Tasks:
 Usage patterns:
 
   1. Train on pre-staged checkpoints:
-       python scripts/run_inkling_975b.py train \
+       python scripts/run_inkling.py train \
            --model-name Inkling --train-mode full --task dapo_math \
            --num-nodes 16 --num-gpus-per-node 4
 
   2. Individual steps (rsync shared -> node-local NVMe, then train):
-       python scripts/run_inkling_975b.py prepare-cp --model-name Inkling
-       python scripts/run_inkling_975b.py train --model-name Inkling ...
+       python scripts/run_inkling.py prepare-cp --model-name Inkling
+       python scripts/run_inkling.py train --model-name Inkling ...
 
   3. One-shot (prepare-cp when model_local_dir differs, then train):
-       python scripts/run_inkling_975b.py full-train --model-name Inkling ...
+       python scripts/run_inkling.py full-train --model-name Inkling ...
 """
 
 from dataclasses import dataclass, field
@@ -163,7 +163,7 @@ def _get_parallel_config(args: ScriptArgs) -> str:
 
     raise NotImplementedError(
         f"No pre-set parallel config for {total_gpus} GPUs. "
-        f"Please specify your parallel config in `run_inkling_975b._get_parallel_config`."
+        f"Please specify your parallel config in `run_inkling._get_parallel_config`."
     )
 
 

--- a/scripts/run_inkling_975b.py
+++ b/scripts/run_inkling_975b.py
@@ -6,6 +6,9 @@ Supports:
                           Verified profiles: 16 nodes x 4 GPUs (TP4 PP4 EP16) and
                           12 nodes x 4 GPUs (TP4 PP3 EP16) on GB300.
   - Inkling-4layer   4-layer slice for single-node smoke testing.
+  - Inkling-Small    42-layer 276B MoE. Verified profile: 4 nodes x 8 GPUs
+                          (TP4 SP PP8 EP4, ctx 4096 / response 2048) on H200, full
+                          (--optimizer-cpu-offload trio) and lora (defaults).
 
 Train modes:
   - full   Full-parameter GRPO. Optimizer state streams through node-local NVMe
@@ -46,18 +49,21 @@ app = typer.Typer()
 _MODEL_REGISTRY = {
     "Inkling": "inkling-975b",
     "Inkling-4layer": "inkling-975b-4layer",
+    "Inkling-Small": "inkling-small",
 }
 
 
 @dataclass
 class ScriptArgs(U.ExecuteTrainConfig):
     run_id: str = U.create_run_id()
-    model_name: Literal["Inkling", "Inkling-4layer"] = "Inkling"
+    model_name: Literal["Inkling", "Inkling-4layer", "Inkling-Small"] = "Inkling"
 
     train_mode: Literal["full", "lora"] = "full"
     task: Literal["dapo_math", "geo3k"] = "dapo_math"
     enable_eval: bool = False
     num_rollout: int = 100
+    rollout_batch_size: int = 32
+    global_batch_size: int = 64
 
     hf_checkpoint: str | None = None
     torch_dist: str | None = None
@@ -111,6 +117,17 @@ def _get_parallel_config(args: ScriptArgs) -> str:
     Raises NotImplementedError for untested configurations.
     """
     total_gpus = args.actor_num_nodes * args.actor_num_gpus_per_node
+
+    if args.model_name == "Inkling-Small" and total_gpus == 32:
+        # TP4 x PP8 -> DP1; 42 = 7x5 + 7; EP<=TP*DP=4 -> 64 experts per rank.
+        return (
+            "--tensor-model-parallel-size 4 "
+            "--sequence-parallel "
+            "--pipeline-model-parallel-size 8 "
+            "--decoder-last-pipeline-num-layers 7 "
+            "--expert-model-parallel-size 4 "
+            "--expert-tensor-parallel-size 1 "
+        )
 
     if args.model_name == "Inkling-4layer" and args.actor_num_nodes == 1:
         return (
@@ -168,11 +185,11 @@ def _train(args: ScriptArgs):
         "--rollout-shuffle "
         "--rm-type math "
         f"--num-rollout {args.num_rollout} "
-        "--rollout-batch-size 32 "
+        f"--rollout-batch-size {args.rollout_batch_size} "
         "--n-samples-per-prompt 8 "
         f"--rollout-max-response-len {args.rollout_max_response_len} "
         "--rollout-temperature 1 "
-        "--global-batch-size 64 "
+        f"--global-batch-size {args.global_batch_size} "
         "--balance-data "
     )
     eval_args = ""

--- a/scripts/run_inkling_975b.py
+++ b/scripts/run_inkling_975b.py
@@ -7,8 +7,12 @@ Supports:
                           12 nodes x 4 GPUs (TP4 PP3 EP16) on GB300.
   - Inkling-4layer   4-layer slice for single-node smoke testing.
   - Inkling-Small    42-layer 276B MoE. Verified profile: 4 nodes x 8 GPUs
-                          (TP4 SP PP8 EP4, ctx 4096 / response 2048) on H200, full
-                          (--optimizer-cpu-offload trio) and lora (defaults).
+                          (TP4 SP PP8 EP4, ctx 4096 / response 2048) on H200.
+                          Full: --lr 6e-6, --rollout-batch-size 64 --global-batch-size 128
+                          (reward +0.006/rollout). LoRA: --lr 2e-4 with the same batch
+                          shape (reward +0.011/rollout); at the 5e-6 default the
+                          zero-initialised B factors need hundreds of rollouts to
+                          accumulate a visible delta-W, which reads as "not learning".
 
 Train modes:
   - full   Full-parameter GRPO. Optimizer state streams through node-local NVMe

--- a/tests/e2e/megatron/model_scripts/test_inkling_4layer_ci.py
+++ b/tests/e2e/megatron/model_scripts/test_inkling_4layer_ci.py
@@ -1,6 +1,6 @@
 import os
 
-from scripts.run_inkling_975b import _MODEL_REGISTRY, ScriptArgs, _train
+from scripts.run_inkling import _MODEL_REGISTRY, ScriptArgs, _train
 from tests.ci.ci_register import register_cuda_ci
 from tests.ci.metric_history import register_ci_gate
 

--- a/tests/e2e/megatron/model_scripts/test_inkling_4layer_lora_ci.py
+++ b/tests/e2e/megatron/model_scripts/test_inkling_4layer_lora_ci.py
@@ -1,12 +1,12 @@
 import os
 
-from scripts.run_inkling_975b import _MODEL_REGISTRY, ScriptArgs, _train
+from scripts.run_inkling import _MODEL_REGISTRY, ScriptArgs, _train
 from tests.ci.ci_register import register_cuda_ci
 from tests.ci.metric_history import register_ci_gate
 
 import miles.utils.external_utils.command_utils as U
 
-# Smoke test for scripts/run_inkling_975b.py --train-mode lora on the 4-layer slice:
+# Smoke test for scripts/run_inkling.py --train-mode lora on the 4-layer slice:
 # shared-outer grouped-expert LoRA served through SGLang's virtual-experts path, one
 # 4-GPU engine, adapter sync verified by checksum. Functionality, not accuracy.
 


### PR DESCRIPTION
Stacked on #1683. Adds launcher/recipe support for [Inkling-Small](https://huggingface.co/thinkingmachines/Inkling-Small) (276 B / 12 B active, now public under Apache 2.0).

- `scripts/models/inkling-small.sh`: 42-layer / 276 B model definition mapped from the HF config the same way `inkling-975b.sh` maps the 975 B one; `MODEL_ARGS_NUM_LAYERS` overrides the layer count for sliced smoke checkpoints.
- Registry entry + validated 4×8 H200 parallel preset (TP4 SP PP8 EP4 ETP1, `--decoder-last-pipeline-num-layers 7`).
- `--rollout-batch-size` / `--global-batch-size` become CLI args (defaults unchanged at 32/64).
- Two small hardening commits in the plugin config and the rollout path.

Validated on 4 nodes × 8 H200: full-parameter (CPU-offloaded optimizer — no NVMe streaming needed at this scale) and LoRA r=32 both train with healthy on-policy metrics (first-ministep ppo_kl ~1e-5 / ~7e-5) and a steadily rising dapo-math reward curve (+0.006/step over 30+ steps, 0.31 → 0.56).
<img width="956" height="630" alt="img_v3_02144_836bd17c-33e9-4b8c-a5ac-ec78e3da33ix" src="https://github.com/user-attachments/assets/43e44089-f908-4550-ae3b-e50f66632e66" />

<img width="946" height="620" alt="img_v3_02144_042531b8-efa4-40a5-b8d3-35a71ca0e7ix" src="https://github.com/user-attachments/assets/22eea702-bd18-45de-97b1-cf323d679d74" />


Docs: #2009.