### PR TITLE
router: enable dp-aware routing under dp-attention

### DIFF
--- a/miles/backends/sglang_utils/arguments.py
+++ b/miles/backends/sglang_utils/arguments.py
@@ -153,6 +153,9 @@ def validate_args(args):
     if args.sglang_dp_size > 1:
         assert args.sglang_enable_dp_attention
 
+    if args.sglang_enable_dp_attention:
+        args.router_dp_aware = True
+
     if args.sglang_router_policy is None and args.use_session_server:
         args.sglang_router_policy = "manual"
         if args.router_assignment_mode == "random":

--- a/tests/fast/backends/sglang_utils/test_router_dp_aware.py
+++ b/tests/fast/backends/sglang_utils/test_router_dp_aware.py
@@ -1,0 +1,28 @@
+from tests.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=20, suite="stage-a-cpu", labels=[])
+
+import argparse
+
+from miles.backends.sglang_utils.arguments import add_sglang_arguments, validate_args
+
+
+def _args(argv):
+    parser = add_sglang_arguments(argparse.ArgumentParser())
+    args = parser.parse_args(argv)
+    args.rollout_num_gpus_per_engine = 4
+    args.true_on_policy_mode = False
+    args.use_session_server = False
+    # Registered by RouterArgs.add_cli_args, not by add_sglang_arguments.
+    args.router_assignment_mode = "random"
+    args.router_dp_aware = False
+    validate_args(args)
+    return args
+
+
+def test_dp_attention_turns_on_router_dp_aware():
+    assert _args(["--sglang-enable-dp-attention", "--sglang-dp-size", "4"]).router_dp_aware is True
+
+
+def test_router_dp_aware_untouched_without_dp_attention():
+    assert _args([]).router_dp_aware is False


### PR DESCRIPTION
`--enable-dp-attention` splits an engine into dp ranks, but the router only
knows the engine: its load balancing stops at the engine boundary and sglang's
internal dispatch decides which rank actually serves a request. Under the long
sticky sessions an agentic RL rollout produces, that dispatch concentrates.

Live metrics from a GLM-5.2 744B run (16x GB300, 8 engines x dp 4, session
server with `manual` + `min_load` routing):

```
engine 10.4.90.74
  dp_rank=0  num_running_reqs=0  num_queue_reqs=0
  dp_rank=1  num_running_reqs=0  num_queue_reqs=0
  dp_rank=2  num_running_reqs=1  num_queue_reqs=11
  dp_rank=3  num_running_reqs=0  num_queue_reqs=0
```

Three quarters of the engine idle while requests queue on the fourth rank.
Per-request latency rises accordingly, and on that run it pushed episodes past
the client timeout: 2194 of 2232 rollout episode failures were timeouts, and
step time ran roughly 2x the equivalent TP-only configuration.

sgl-router already exposes this as `--router-dp-aware`, and miles already
registers it via `RouterArgs.add_cli_args(..., use_router_prefix=True)` and
forwards it through `RouterArgs.from_cli_args` — it just defaults to off. Turn
it on whenever `--sglang-enable-dp-attention` is set, so each dp rank registers
with the router as its own worker and `min_load` balances at rank granularity.

The flag is meaningless without dp-attention, and every dp-attention deployment
wants it, so this is a default rather than a new knob.
