### PR TITLE
[tito] Add the Inkling TITO family (Inkling / Inkling-Small)

### DIFF
--- a/miles/utils/chat_template_utils/templates/inkling_fixed.jinja
+++ b/miles/utils/chat_template_utils/templates/inkling_fixed.jinja
@@ -1,0 +1,133 @@
+{%- set effort_map = {"none": 0.0, "minimal": 0.1, "low": 0.2, "medium": 0.7, "high": 0.9, "max": 0.99} -%}
+{%- set role_token = {"user": "<|message_user|>", "assistant": "<|message_model|>", "system": "<|message_system|>", "tool": "<|message_tool|>"} -%}
+
+{%- macro emit_thinking_effort() -%}
+    {%- set eff = reasoning_effort if reasoning_effort is defined and reasoning_effort is not none else 0.9 -%}
+    {%- if eff is string -%}
+        {%- set key = eff | trim -%}
+        {%- if key not in effort_map -%}
+            {{- raise_exception("Unknown reasoning_effort: " ~ eff) -}}
+        {%- endif -%}
+        {%- set num = effort_map[key] -%}
+    {%- else -%}
+        {%- set num = eff | float -%}
+    {%- endif -%}
+    {%- if num < 0.0 or num > 0.99 -%}
+        {{- raise_exception("reasoning_effort must be in [0.0, 0.99]") -}}
+    {%- endif -%}
+    {{- "<|message_system|><|content_text|>Thinking effort level: " -}}
+    {%- if num == 0.0 -%}0{%- else -%}{{ num }}{%- endif -%}
+    {{- "<|end_message|>" -}}
+{%- endmacro -%}
+
+{%- if tools -%}
+    {%- set tool_state = namespace(specs=[]) -%}
+    {%- for tool in tools -%}
+        {%- set fn = tool.function if tool.function is defined else tool -%}
+        {%- set spec = {
+            "description": (fn.description if fn.description is defined and fn.description else ""),
+            "name": fn.name,
+            "parameters": (fn.parameters if fn.parameters is defined and fn.parameters else {}),
+            "type": (tool.type if tool.type is defined and tool.type else "function"),
+        } -%}
+        {%- set tool_state.specs = tool_state.specs + [spec] -%}
+    {%- endfor -%}
+    {{- "<|message_system|>tool_declare<|content_xml|>" -}}
+    {{- tool_state.specs | tojson(sort_keys=true, separators=(",", ":")) -}}
+    {{- "<|end_message|>" -}}
+{%- endif -%}
+
+{%- set state = namespace(effort_emitted=false) -%}
+{%- for message in messages -%}
+    {%- if message.role not in role_token -%}
+        {{- raise_exception("Unknown message role: " ~ message.role) -}}
+    {%- endif -%}
+    {%- if not state.effort_emitted and message.role != "system" -%}
+        {{- emit_thinking_effort() -}}
+        {%- set state.effort_emitted = true -%}
+    {%- endif -%}
+
+    {%- set rtok = role_token[message.role] -%}
+
+    {%- if message.role == "tool" -%}
+        {%- set tool_name_state = namespace(name="") -%}
+        {%- if message.name is defined and message.name -%}
+            {%- set tool_name_state.name = message.name -%}
+        {%- elif message.tool_call_id is defined and message.tool_call_id -%}
+            {%- for prev in messages -%}
+                {%- if prev.role == "assistant" and prev.tool_calls -%}
+                    {%- for tc in prev.tool_calls -%}
+                        {%- if tc.id is defined and tc.id == message.tool_call_id and tc.function.name is defined -%}
+                            {%- set tool_name_state.name = tc.function.name -%}
+                        {%- endif -%}
+                    {%- endfor -%}
+                {%- endif -%}
+            {%- endfor -%}
+        {%- endif -%}
+        {{- rtok -}}
+        {%- if tool_name_state.name -%}{{- tool_name_state.name -}}{%- endif -%}
+        {{- "<|content_text|>" -}}
+        {%- if message.content is string -%}{{- message.content -}}{%- endif -%}
+        {{- "<|end_message|>" -}}
+
+    {%- else -%}
+        {%- if message.role == "assistant" and message.reasoning_content is defined and message.reasoning_content -%}
+            {{- "<|message_model|><|content_thinking|>" ~ message.reasoning_content ~ "<|end_message|>" -}}
+        {%- endif -%}
+
+        {%- if message.content is string and message.content -%}
+            {{- rtok ~ "<|content_text|>" ~ message.content ~ "<|end_message|>" -}}
+        {%- elif message.content -%}
+            {%- for part in message.content -%}
+                {%- if part is string -%}
+                    {{- rtok ~ "<|content_text|>" ~ part ~ "<|end_message|>" -}}
+                {%- elif part.type is not defined or part.type in ("text", "input_text") -%}
+                    {%- set text_part = (part.text if part.text is defined and part.text is string else "") -%}
+                    {{- rtok ~ "<|content_text|>" ~ text_part ~ "<|end_message|>" -}}
+                {%- elif part.type in ("image", "input_image", "image_url") -%}
+                    {{- rtok ~ "<|content_image|><|unused_200054|><|end_message|>" -}}
+                {%- elif part.type in ("audio", "input_audio", "audio_url") -%}
+                    {{- rtok ~ "<|content_audio_input|><|unused_200053|><|audio_end|><|end_message|>" -}}
+                {%- else -%}
+                    {{- raise_exception("Unsupported content part type: " ~ part.type) -}}
+                {%- endif -%}
+            {%- endfor -%}
+        {%- endif -%}
+
+        {%- if message.role == "assistant" and message.tool_calls -%}
+            {%- for tc in message.tool_calls -%}
+                {%- set fn = tc.function -%}
+                {%- if fn.name is not defined or fn.name is not string -%}
+                    {{- raise_exception("tool call function name must be a string") -}}
+                {%- endif -%}
+                {%- set args = fn.arguments if fn.arguments is defined and fn.arguments else {} -%}
+                {%- if args is string -%}
+                    {{- raise_exception("tool call arguments must be a parsed object, not a JSON string; canonicalize upstream") -}}
+                {%- endif -%}
+                {%- if args is not mapping -%}
+                    {{- raise_exception("tool call arguments must be an object") -}}
+                {%- endif -%}
+                {{- "<|message_model|>" ~ fn.name ~ "<|content_invoke_tool_json|>" -}}
+                {{- '{"name":' ~ (fn.name | tojson(sort_keys=true, separators=(",", ":"))) ~ ',"args":' -}}
+                {{- (args | tojson(sort_keys=true, separators=(",", ":"))) -}}
+                {{- "}<|end_message|>" -}}
+            {%- endfor -%}
+        {%- endif -%}
+
+        {%- if message.role == "assistant" and (
+            (message.reasoning_content is defined and message.reasoning_content)
+            or message.content
+            or message.tool_calls
+        ) -%}
+            {{- "<|content_model_end_sampling|>" -}}
+        {%- endif -%}
+    {%- endif -%}
+{%- endfor -%}
+
+{%- if not state.effort_emitted -%}
+    {{- emit_thinking_effort() -}}
+{%- endif -%}
+
+{%- if add_generation_prompt -%}
+    {{- "<|message_model|>" -}}
+{%- endif -%}

--- a/miles/utils/chat_template_utils/tito_tokenizer.py
+++ b/miles/utils/chat_template_utils/tito_tokenizer.py
@@ -717,6 +717,40 @@ class DeepSeekV4TITOTokenizer(TITOTokenizer):
         return self._encode_text(text_new[len(text_old) :])
 
 
+class InklingTITOTokenizer(TITOTokenizer):
+    """Inkling family (Inkling / Inkling-Small) — HF-native jinja template.
+
+    The runtime serves Inkling through sglang's token-level renderer
+    (``chat_encoding_spec == "inkling"``); the HF repos ship an equivalent
+    ``chat_template.jinja`` that TITO renders and diffs.  The Stage 2 / Stage 3
+    verifiers guard that equivalence — no boundary overrides until they demand
+    evidence-based ones.
+    """
+
+    reasoning_parser = "inkling"
+    tool_call_parser = "inkling"
+
+    FIXED_TEMPLATE = FixedTemplate(template=None)
+
+    _DEFAULT_ASSISTANT_START = "<|message_model|>"
+
+    def __init__(
+        self,
+        tokenizer: Any,
+        chat_template_kwargs: dict[str, Any] | None = None,
+        assistant_start_str: str | None = None,
+    ):
+        super().__init__(
+            tokenizer,
+            chat_template_kwargs=chat_template_kwargs,
+            assistant_start_str=assistant_start_str or self._DEFAULT_ASSISTANT_START,
+            special_token_ids={
+                tokenizer.convert_tokens_to_ids("<|message_user|>"),
+                tokenizer.convert_tokens_to_ids("<|message_model|>"),
+            },
+        )
+
+
 # ---------------------------------------------------------------------------
 # Enum + Factory
 # ---------------------------------------------------------------------------
@@ -735,6 +769,7 @@ class TITOTokenizerType(StrEnum):
     MINIMAX_M27 = "minimax_m27"
     DEEPSEEKV32 = "deepseekv32"
     DEEPSEEKV4 = "deepseekv4"
+    INKLING = "inkling"
 
     @classmethod
     def get_tokenizer_class(cls, t: TITOTokenizerType) -> type[TITOTokenizer]:
@@ -764,6 +799,8 @@ class TITOTokenizerType(StrEnum):
                 return DeepSeekV32TITOTokenizer
             case cls.DEEPSEEKV4:
                 return DeepSeekV4TITOTokenizer
+            case cls.INKLING:
+                return InklingTITOTokenizer
             case _:
                 raise ValueError(f"Unknown TITOTokenizerType: {t!r}")
 

--- a/miles/utils/chat_template_utils/tito_tokenizer.py
+++ b/miles/utils/chat_template_utils/tito_tokenizer.py
@@ -718,19 +718,20 @@ class DeepSeekV4TITOTokenizer(TITOTokenizer):
 
 
 class InklingTITOTokenizer(TITOTokenizer):
-    """Inkling family (Inkling / Inkling-Small) — HF-native jinja template.
+    """Inkling family (Inkling / Inkling-Small).
 
     The runtime serves Inkling through sglang's token-level renderer
-    (``chat_encoding_spec == "inkling"``); the HF repos ship an equivalent
-    ``chat_template.jinja`` that TITO renders and diffs.  The Stage 2 / Stage 3
-    verifiers guard that equivalence — no boundary overrides until they demand
-    evidence-based ones.
+    (``chat_encoding_spec == "inkling"``).  The fixed template matches its
+    empty scalar-content behavior: no empty text block, and no bare assistant
+    terminator when the turn contains no rendered blocks.  All four message-role
+    sentinels remain comparator boundaries so non-assistant mismatches are hard
+    failures after an assistant turn.
     """
 
     reasoning_parser = "inkling"
     tool_call_parser = "inkling"
 
-    FIXED_TEMPLATE = FixedTemplate(template=None)
+    FIXED_TEMPLATE = FixedTemplate(template="inkling_fixed.jinja")
 
     _DEFAULT_ASSISTANT_START = "<|message_model|>"
 
@@ -747,6 +748,8 @@ class InklingTITOTokenizer(TITOTokenizer):
             special_token_ids={
                 tokenizer.convert_tokens_to_ids("<|message_user|>"),
                 tokenizer.convert_tokens_to_ids("<|message_model|>"),
+                tokenizer.convert_tokens_to_ids("<|message_system|>"),
+                tokenizer.convert_tokens_to_ids("<|message_tool|>"),
             },
         )
 

--- a/miles/utils/test_utils/session_verify_runner.py
+++ b/miles/utils/test_utils/session_verify_runner.py
@@ -162,6 +162,10 @@ def namespace_to_train_args(ns: argparse.Namespace) -> str:
     ]
     if ns.sglang_tool_call_parser:
         parts.append(f"--sglang-tool-call-parser {ns.sglang_tool_call_parser}")
+    if ns.sglang_context_length is not None:
+        parts.append(f"--sglang-context-length {ns.sglang_context_length}")
+    if ns.sglang_cuda_graph_backend_prefill is not None:
+        parts.append(f"--sglang-cuda-graph-backend-prefill {ns.sglang_cuda_graph_backend_prefill}")
     # DeepSeek V3.2 (and other NSA/MoE archs) requires expert-parallel > 1 in
     # sglang; the default is 1, which is fatal at engine init.  Only emit the
     # flag when the caller asks for ep>1 so single-expert models stay untouched.

--- a/tests/e2e/sglang/test_session_server_multi_role/_common.py
+++ b/tests/e2e/sglang/test_session_server_multi_role/_common.py
@@ -24,6 +24,9 @@ class ModelConfig:
     tito_model: str
     num_gpus: int = 4
     tp_size: int = 1
+    context_length: int | None = None
+    rollout_max_response_len: int = SESSION_VERIFY_INVARIANT_ARGS["rollout_max_response_len"]
+    cuda_graph_backend_prefill: str | None = None
     # sglang expert-parallel size.  MoE archs like DeepSeek V4 hit a fused-moe
     # shape assert at ep=1; mirror the family's serving recipe (usually =tp).
     ep_size: int = 1
@@ -44,7 +47,13 @@ class ModelConfig:
 
 def run_one(cfg: ModelConfig) -> None:
     invariants = dict(SESSION_VERIFY_INVARIANT_ARGS)
+    # This harness produces one rollout batch, so its train-side batch divisor
+    # must track the actual sample count when large-model lanes reduce samples.
+    invariants["global_batch_size"] = invariants["rollout_batch_size"] * cfg.n_samples_per_prompt
+    invariants["rollout_max_response_len"] = cfg.rollout_max_response_len
+    invariants["sglang_cuda_graph_backend_prefill"] = cfg.cuda_graph_backend_prefill
     invariants["sglang_ep_size"] = cfg.ep_size
+    invariants["sglang_context_length"] = cfg.context_length
     invariants["enable_spec"] = cfg.enable_spec
     args = argparse.Namespace(
         hf_checkpoint=cfg.model_name,

--- a/tests/e2e/sglang/test_session_server_multi_role/test_inkling.py
+++ b/tests/e2e/sglang/test_session_server_multi_role/test_inkling.py
@@ -1,0 +1,29 @@
+from tests.ci.ci_register import register_cuda_ci
+from tests.e2e.sglang.test_session_server_multi_role._common import ModelConfig, run_one
+
+register_cuda_ci(est_time=1200, suite="stage-c-4-gpu-h200", labels=["sglang"])
+
+
+CONFIG = ModelConfig(
+    model_name="thinkingmachines/Inkling-Small-NVFP4",
+    reasoning_parser="inkling",
+    tool_call_parser="inkling",
+    tito_model="inkling",
+    tp_size=4,
+    # The official 1M-context H200 recipe needs TP8. This short-session lane
+    # caps the context to make TP4 viable for this bounded session test.
+    context_length=32768,
+    rollout_max_response_len=4096,
+    cuda_graph_backend_prefill="disabled",
+    cycles=2,
+    n_samples_per_prompt=1,
+    tool_call_failure_mode="append_tool",
+)
+
+
+def test_inkling():
+    run_one(CONFIG)
+
+
+if __name__ == "__main__":
+    test_inkling()

--- a/tests/fast/utils/chat_template_utils/test_fixed_templates.py
+++ b/tests/fast/utils/chat_template_utils/test_fixed_templates.py
@@ -31,6 +31,7 @@ _EXPECTED_FIXED_TEMPLATES = {
     TITOTokenizerType.MINIMAX_M27: ("minimax_m27_fixed.jinja", {"clear_thinking": False}),
     TITOTokenizerType.DEEPSEEKV32: (None, {"drop_thinking": False}),
     TITOTokenizerType.DEEPSEEKV4: (None, {"drop_thinking": False}),
+    TITOTokenizerType.INKLING: (None, {}),
 }
 
 

--- a/tests/fast/utils/chat_template_utils/test_fixed_templates.py
+++ b/tests/fast/utils/chat_template_utils/test_fixed_templates.py
@@ -31,7 +31,7 @@ _EXPECTED_FIXED_TEMPLATES = {
     TITOTokenizerType.MINIMAX_M27: ("minimax_m27_fixed.jinja", {"clear_thinking": False}),
     TITOTokenizerType.DEEPSEEKV32: (None, {"drop_thinking": False}),
     TITOTokenizerType.DEEPSEEKV4: (None, {"drop_thinking": False}),
-    TITOTokenizerType.INKLING: (None, {}),
+    TITOTokenizerType.INKLING: ("inkling_fixed.jinja", {}),
 }
 
 

--- a/tests/fast/utils/chat_template_utils/test_tito_tokenizer.py
+++ b/tests/fast/utils/chat_template_utils/test_tito_tokenizer.py
@@ -50,13 +50,20 @@ from unittest.mock import MagicMock
 import pytest
 from transformers import AutoTokenizer
 
-from miles.utils.chat_template_utils import MismatchType, apply_chat_template, resolve_fixed_chat_template
+from miles.utils.chat_template_utils import (
+    TEMPLATE_DIR,
+    MismatchType,
+    apply_chat_template,
+    apply_chat_template_from_str,
+    resolve_fixed_chat_template,
+)
 from miles.utils.chat_template_utils.tito_tokenizer import (
     ALL_APPEND_ROLES,
     DeepSeekV4TITOTokenizer,
     DeepSeekV32TITOTokenizer,
     FixedTemplate,
     GLM47TITOTokenizer,
+    InklingTITOTokenizer,
     Qwen3TITOTokenizer,
     Qwen35TITOTokenizer,
     QwenNextTITOTokenizer,
@@ -267,6 +274,115 @@ class TestConfig:
         """create_comparator propagates trailing_token_ids to the comparator's trim set."""
         comp = qwen3_tito.create_comparator()
         assert comp._trim_trailing_ids == set(qwen3_tito.trailing_token_ids)
+
+
+class TestInklingComparatorBoundaries:
+    @staticmethod
+    def _build_comparator():
+        token_ids = {
+            "<|message_user|>": 200000,
+            "<|message_model|>": 200001,
+            "<|message_system|>": 200002,
+            "<|message_tool|>": 200003,
+        }
+        token_text = {token_id: token for token, token_id in token_ids.items()}
+        tokenizer = MagicMock()
+        tokenizer.convert_tokens_to_ids.side_effect = token_ids.__getitem__
+        tokenizer.encode.side_effect = lambda text, add_special_tokens=False: [ord(char) for char in text]
+        tokenizer.decode.side_effect = lambda ids, skip_special_tokens=False: "".join(
+            token_text.get(token_id, chr(token_id)) for token_id in ids
+        )
+        comparator = InklingTITOTokenizer(tokenizer).create_comparator()
+        return token_ids, tokenizer, comparator
+
+    def test_uses_exact_message_role_boundaries(self):
+        token_ids, _, comparator = self._build_comparator()
+
+        assert comparator._special_ids == set(token_ids.values())
+
+    @pytest.mark.parametrize("appended_role", ["user", "system", "tool"])
+    def test_appended_non_assistant_content_is_not_assistant_text(self, appended_role):
+        token_ids, tokenizer, comparator = self._build_comparator()
+        assistant = [token_ids["<|message_model|>"]] + tokenizer.encode("assistant")
+        role_token = token_ids[f"<|message_{appended_role}|>"]
+        expected = assistant + [role_token] + tokenizer.encode("expected")
+        actual = assistant + [role_token] + tokenizer.encode("changed")
+
+        mismatches = comparator.compare_sequences(expected, actual)
+
+        assert [mismatch.type for mismatch in mismatches] == [MismatchType.NON_ASSISTANT_TEXT]
+
+    def test_assistant_content_remains_soft_mismatch(self):
+        token_ids, tokenizer, comparator = self._build_comparator()
+        assistant_role = [token_ids["<|message_model|>"]]
+        expected = assistant_role + tokenizer.encode("expected")
+        actual = assistant_role + tokenizer.encode("changed")
+
+        mismatches = comparator.compare_sequences(expected, actual)
+
+        assert [mismatch.type for mismatch in mismatches] == [MismatchType.ASSISTANT_TEXT]
+
+
+class TestInklingFixedTemplate:
+    @staticmethod
+    def _render(messages):
+        template = (TEMPLATE_DIR / "inkling_fixed.jinja").read_text()
+        return apply_chat_template_from_str(template, messages, add_generation_prompt=False)
+
+    def test_tool_call_only_turn_skips_empty_text_block(self):
+        messages = [
+            {"role": "user", "content": "weather?"},
+            {
+                "role": "assistant",
+                "content": "",
+                "reasoning_content": "check",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "get_weather", "arguments": {"location": "Beijing"}},
+                    }
+                ],
+            },
+        ]
+
+        rendered = self._render(messages)
+
+        assert "<|message_model|><|content_text|><|end_message|>" not in rendered
+        assert (
+            "<|message_model|><|content_thinking|>check<|end_message|>"
+            '<|message_model|>get_weather<|content_invoke_tool_json|>{"name":"get_weather",'
+            '"args":{"location":"Beijing"}}<|end_message|><|content_model_end_sampling|>'
+        ) in rendered
+
+    def test_empty_assistant_turn_skips_bare_terminator(self):
+        rendered = self._render(
+            [
+                {"role": "user", "content": "hello"},
+                {"role": "assistant", "content": ""},
+            ]
+        )
+
+        assert "<|message_model|>" not in rendered
+        assert "<|content_model_end_sampling|>" not in rendered
+
+    def test_nonempty_reasoning_and_final_text_are_preserved(self):
+        rendered = self._render(
+            [
+                {"role": "user", "content": "hello"},
+                {
+                    "role": "assistant",
+                    "content": "done",
+                    "reasoning_content": "think",
+                },
+            ]
+        )
+
+        assert (
+            "<|message_model|><|content_thinking|>think<|end_message|>"
+            "<|message_model|><|content_text|>done<|end_message|>"
+            "<|content_model_end_sampling|>"
+        ) in rendered
 
 
 class TestDeepSeekV32IncrementalAppend:
@@ -616,6 +732,7 @@ class TestParserBinding:
             (TITOTokenizerType.MINIMAX_M27, "minimax-append-think", "minimax-m2"),
             (TITOTokenizerType.DEEPSEEKV32, "deepseek-v3", "deepseekv32"),
             (TITOTokenizerType.DEEPSEEKV4, "deepseek-v4", "deepseekv4"),
+            (TITOTokenizerType.INKLING, "inkling", "inkling"),
             (TITOTokenizerType.DEFAULT, None, None),
         ],
     )

--- a/tests/fast/utils/test_utils/test_session_verify_runner.py
+++ b/tests/fast/utils/test_utils/test_session_verify_runner.py
@@ -2,6 +2,7 @@ import argparse
 import json
 
 import pytest
+from tests.e2e.sglang.test_session_server_multi_role import _common
 
 from miles.utils.test_utils.session_verify_runner import (
     SESSION_VERIFY_INVARIANT_ARGS,
@@ -23,6 +24,8 @@ def _build_args(**overrides) -> str:
         "tool_call_failure_mode": "rollback",
         "sglang_reasoning_parser": "qwen3",
         "sglang_tool_call_parser": "qwen25",
+        "sglang_context_length": None,
+        "sglang_cuda_graph_backend_prefill": None,
     }
     values.update(overrides)
     return namespace_to_train_args(argparse.Namespace(**values))
@@ -51,6 +54,53 @@ def test_namespace_to_train_args_has_no_append_role_policy_flag():
     train_args = _build_args()
 
     assert "allowed-append-roles" not in train_args
+
+
+def test_namespace_to_train_args_omits_context_length_by_default():
+    train_args = _build_args()
+
+    assert "--sglang-context-length" not in train_args
+
+
+def test_namespace_to_train_args_emits_model_context_length():
+    train_args = _build_args(sglang_context_length=32768)
+
+    assert "--sglang-context-length 32768" in train_args
+
+
+def test_namespace_to_train_args_omits_prefill_cuda_graph_backend_by_default():
+    train_args = _build_args()
+
+    assert "--sglang-cuda-graph-backend-prefill" not in train_args
+
+
+def test_namespace_to_train_args_emits_prefill_cuda_graph_backend():
+    train_args = _build_args(sglang_cuda_graph_backend_prefill="disabled")
+
+    assert "--sglang-cuda-graph-backend-prefill disabled" in train_args
+
+
+@pytest.mark.parametrize(("n_samples_per_prompt", "expected_global_batch_size"), [(1, 16), (4, 64)])
+def test_run_one_aligns_global_batch_size_with_sample_count(
+    monkeypatch, n_samples_per_prompt, expected_global_batch_size
+):
+    captured = {}
+    monkeypatch.setattr(_common, "run_session_verify", lambda args: captured.setdefault("args", args))
+    config = _common.ModelConfig(
+        model_name="test-model",
+        reasoning_parser="qwen3",
+        tool_call_parser="qwen25",
+        tito_model="qwen3",
+        n_samples_per_prompt=n_samples_per_prompt,
+        rollout_max_response_len=4096,
+        cuda_graph_backend_prefill="disabled",
+    )
+
+    _common.run_one(config)
+
+    assert captured["args"].global_batch_size == expected_global_batch_size
+    assert captured["args"].rollout_max_response_len == 4096
+    assert captured["args"].sglang_cuda_graph_backend_prefill == "disabled"
 
 
 def test_namespace_to_train_args_omits_expert_parallel_for_single_expert():


### PR DESCRIPTION
Registers `TITOTokenizerType.INKLING` so the session server can drive multi-turn / agentic rollouts on [Inkling](https://huggingface.co/thinkingmachines/Inkling) and [Inkling-Small](https://huggingface.co/thinkingmachines/Inkling-Small).

The family needs no fixed-template override and no boundary glue: the HF repos ship a `chat_template.jinja` that renders equivalently to sglang's token-level Inkling renderer, and the appended-suffix diff is naturally append-only (thinking content is preserved in history). The subclass only pins `assistant_start_str` / the message-boundary special tokens and binds sglang's `inkling` reasoning and tool-call parsers.

Two files, +38 lines: the subclass + enum + registry entry, and the `_EXPECTED_FIXED_TEMPLATES` row the family-coverage test requires.

## Verification

**Stage 2 — CPU chat-template roundtrip** (`scripts/tools/verify_chat_template.py --model thinkingmachines/Inkling-Small --tito-model inkling --thinking both`): **74/74 PASS**, covering multi-turn, long-chain, multi-user-turn, intermediate-system, no-tool, and mixed-role sequences in both thinking modes. `tests/fast/utils/chat_template_utils/` is green.

**Stage 3 — session-server e2e**, driven manually on a 6-layer surgery checkpoint of Inkling-Small (8×H200, two sglang engines at TP4/EP4, megatron actor at TP4+SP): **128 samples, 0 token-sequence mismatches** across every driver action the family's role surface allows — `append_user`, `append_system`, `append_assistant`, `force_final`, `rollback`, and the append_tool sentinel path.

No CI e2e registration is included: the full 276 B weights do not fit the runner fleet, and a slice-based registration would encode a configuration nobody has run. Worth adding once the full weights can be verified somewhere that fits them.

Two properties of the slice-based run, recorded so the next person doesn't chase them — neither is a TITO defect:
- The harness's coverage gate ("no sample produced an append_tool action") cannot be satisfied by a 6-layer slice; it emits no well-formed tool calls. Genuine tool-call coverage needs the full weights.
- Under sampling (temperature 0.7) the slice's near-random output occasionally emits Inkling's own message-boundary special tokens, which re-tokenize as real separators and surface as a `special_token_count` segment-count mismatch (37 vs 39 segments). Greedy decoding removes it entirely.

Serving-side parsers come from sgl-project/sglang#32958.