### PR TITLE
fix: quantize non-interleaved DSA indexer wk

### DIFF
--- a/miles/backends/megatron_utils/megatron_to_hf/processors/quantizer_fp8.py
+++ b/miles/backends/megatron_utils/megatron_to_hf/processors/quantizer_fp8.py
@@ -67,7 +67,7 @@ def quantize_params_fp8(args, megatron_name, converted_named_params, quantizatio
 
             return quantize_named_params
 
-    if rest in [
+    fp8_param_names = [
         "self_attention.linear_proj.weight",
         "self_attention.linear_qkv.weight",
         "mlp.linear_fc1.weight",
@@ -89,7 +89,17 @@ def quantize_params_fp8(args, megatron_name, converted_named_params, quantizatio
         "self_attention.wkv.weight",
         "self_attention.wo_b.weight",
         "self_attention.indexer.linear_wq_b.weight",
-    ]:
+    ]
+    if not getattr(args, "indexer_rope_interleave", False):
+        # Non-interleaved indexers keep wk as a standalone FP8 parameter in SGLang.
+        fp8_param_names.extend(
+            [
+                "self_attention.wk.weight",
+                "self_attention.indexer.linear_wk.weight",
+            ]
+        )
+
+    if rest in fp8_param_names:
         quantize_named_params = []
         for converted_name, param in converted_named_params:
             quantize_named_params.extend(_quantize_param(args, converted_name, param, weight_block_size))

--- a/miles/backends/megatron_utils/megatron_to_hf/processors/quantizer_mxfp8.py
+++ b/miles/backends/megatron_utils/megatron_to_hf/processors/quantizer_mxfp8.py
@@ -69,7 +69,7 @@ def quantize_params_mxfp8(args, megatron_name, converted_named_params, quantizat
 
             return quantize_named_params
 
-    if rest in [
+    mxfp8_param_names = [
         "self_attention.linear_proj.weight",
         "self_attention.linear_qkv.weight",
         "mlp.linear_fc1.weight",
@@ -81,14 +81,24 @@ def quantize_params_mxfp8(args, megatron_name, converted_named_params, quantizat
         "self_attention.linear_kv_down_proj.weight",
         "self_attention.linear_kv_up_proj.weight",
         "self_attention.wq_b.weight",
-        "self_attention.wk.weight",
         # DeepSeek V4 attention
         "self_attention.wq_a.weight",
         "self_attention.wkv.weight",
         "self_attention.wo_b.weight",
         "self_attention.indexer.linear_wq_b.weight",
-        "self_attention.indexer.linear_wk.weight",
-    ]:
+    ]
+    if not getattr(args, "indexer_rope_interleave", False):
+        # Non-interleaved indexers keep wk as a standalone quantized parameter in
+        # SGLang; interleaved ones fuse wk into the bf16 wk_weights_proj, whose
+        # loader would misread the uint8 e8m0 mxfp8 scales as integers.
+        mxfp8_param_names.extend(
+            [
+                "self_attention.wk.weight",
+                "self_attention.indexer.linear_wk.weight",
+            ]
+        )
+
+    if rest in mxfp8_param_names:
         quantize_named_params = []
         for converted_name, param in converted_named_params:
             quantize_named_params.extend(_quantize_param(converted_name, param))


### PR DESCRIPTION
## Summary

- quantize DSA indexer `wk` when `indexer_rope_interleave` is false
- keep `wk` in BF16 for interleaved indexers that use SGLang's fused BF16 destination
- apply the same condition to DeepSeek V3-style and DeepSeek V4-style parameter names

## Root cause

The Blackwell fix in #1928 removed both DSA indexer `wk` names from the FP8
quantization list unconditionally. That is correct for an interleaved/fused
indexer, where SGLang stores `wk` inside a BF16 `wk_weights_proj` parameter.

For non-interleaved indexers, SGLang instead keeps a standalone FP8 `wk`
parameter and its scale. Sending only the BF16 weight makes the loader cast it
into the FP8 parameter without updating the scale, corrupting the effective
rollout weight. The DeepSeek V3.2 FP8 weight-update check exposed this mismatch.

## Configuration behavior

The DeepSeek V3.2 and GLM-5.2 checkpoints intentionally use different indexer
RoPE layouts:

- `Pinaster/DeepSeek-V3.2-5layer` does not define
  `indexer_rope_interleave`, so Miles uses the default value `False`. Its
  SGLang indexer keeps `wk` as a standalone FP8 weight and therefore requires
  online quantization of both the weight and its scale.
- GLM-5.2 explicitly sets `indexer_rope_interleave` to `True`. Its SGLang
  indexer uses the fused BF16 `wk_weights_proj` destination, so `wk` should
  remain unquantized during the online update.

The DeepSeek V3.2 CI test does not pass this value manually. Miles reads it
from the Hugging Face checkpoint configuration, using `False` when the field
is absent. The resulting values are therefore correct for both models.

## Validation

- `pre-commit run --files miles/backends/megatron_utils/megatron_to_hf/processors/quantizer_fp8.py`
- `ruff check miles/backends/megatron_utils/megatron_to_hf/processors/quantizer_fp8.py`
- `black --check miles/backends/megatron_utils/megatron_to_hf/processors/quantizer_fp8.py`
- `python -m py_compile miles/backends/megatron_utils/megatron_to_hf/processors/quantizer_fp8.py`
