### PR TITLE
scripts, examples: stop forcing the deprecated Miles router in launchers

### DIFF
--- a/examples/experimental/reproducibility/run-qwen2.5-0.5B-gsm8k.sh
+++ b/examples/experimental/reproducibility/run-qwen2.5-0.5B-gsm8k.sh
@@ -126,7 +126,6 @@ ray job submit --address="http://127.0.0.1:8265" \
    --actor-num-gpus-per-node 8 \
    --colocate \
    --calculate-per-token-loss \
-   --use-miles-router \
    ${MODEL_ARGS[@]} \
    ${CKPT_ARGS[@]} \
    ${ROLLOUT_ARGS[@]} \

--- a/examples/infra_features/low_precision/run-kimi-k2-Thinking-int4.sh
+++ b/examples/infra_features/low_precision/run-kimi-k2-Thinking-int4.sh
@@ -135,7 +135,6 @@ SGLANG_ARGS=(
 
    # make every dp rank has 128 concurrency
    --sglang-server-concurrency 1024
-   --use-miles-router
 )
 
 

--- a/examples/infra_features/low_precision/run-qwen3-235B-A22B-int4.sh
+++ b/examples/infra_features/low_precision/run-qwen3-235B-A22B-int4.sh
@@ -119,7 +119,6 @@ SGLANG_ARGS=(
   #  --sglang-dp-size 4
    --sglang-ep-size 8
    --sglang-cuda-graph-bs 1 2 4 8 $(seq 16 8 256)
-   --use-miles-router
 )
 
 

--- a/examples/infra_features/low_precision/run-qwen3-30B-A3B-int4.sh
+++ b/examples/infra_features/low_precision/run-qwen3-30B-A3B-int4.sh
@@ -114,7 +114,6 @@ SGLANG_ARGS=(
    --rollout-num-gpus-per-engine 1
    --sglang-mem-fraction-static 0.7
    --sglang-cuda-graph-bs 1 2 4 8 $(seq 16 8 256)
-   --use-miles-router
 )
 
 MISC_ARGS=(

--- a/examples/infra_features/low_precision/run-qwen3-30b-a3b-fp8-two-nodes.sh
+++ b/examples/infra_features/low_precision/run-qwen3-30b-a3b-fp8-two-nodes.sh
@@ -127,7 +127,6 @@ SGLANG_ARGS=(
    --sglang-mem-fraction-static 0.6
    --sglang-cuda-graph-bs 1 2 4 8 $(seq 16 8 256)
    --sglang-expert-parallel-size 8
-   --use-miles-router
    # --use-rollout-routing-replay
 )
 

--- a/examples/infra_features/p2p_weight_transfer/run-glm4.7-flash-2node-profile.sh
+++ b/examples/infra_features/p2p_weight_transfer/run-glm4.7-flash-2node-profile.sh
@@ -181,7 +181,6 @@ run_mode() {
         --sglang-mem-fraction-static 0.7
         --sglang-ep-size 4
         --sglang-cuda-graph-bs 1 2 4 8 16
-        # --use-miles-router
         --sglang-enable-dp-attention
         --sglang-enable-dp-lm-head
     )

--- a/examples/lora/dev.sh
+++ b/examples/lora/dev.sh
@@ -144,7 +144,6 @@ ray job submit --address="http://127.0.0.1:8265" \
    --actor-num-gpus-per-node $GPUS_PER_NODE \
    --colocate \
    --calculate-per-token-loss \
-   --use-miles-router \
    ${MODEL_ARGS[@]} \
    ${CKPT_ARGS[@]} \
    ${LORA_ARGS[@]} \

--- a/examples/lora/run-kimi-k25-megatron-lora.sh
+++ b/examples/lora/run-kimi-k25-megatron-lora.sh
@@ -168,7 +168,6 @@ ray job submit --address="http://127.0.0.1:8265" \
    --actor-num-nodes 16 \
    --actor-num-gpus-per-node 8 \
    --colocate \
-   --use-miles-router \
    --update-weight-buffer-size $(( 4 * 512 * 1024 * 1024 )) \
    ${MODEL_ARGS[@]} \
    ${CKPT_ARGS[@]} \

--- a/examples/lora/run-qwen2.5-0.5B-megatron-lora.sh
+++ b/examples/lora/run-qwen2.5-0.5B-megatron-lora.sh
@@ -147,7 +147,6 @@ ray job submit --address="http://127.0.0.1:8265" \
    --actor-num-gpus-per-node $GPUS_PER_NODE \
    --colocate \
    --calculate-per-token-loss \
-   --use-miles-router \
    ${MODEL_ARGS[@]} \
    ${CKPT_ARGS[@]} \
    ${LORA_ARGS[@]} \

--- a/examples/lora/run-qwen2.5-3B-megatron-lora-disaggregated-multi-node.sh
+++ b/examples/lora/run-qwen2.5-3B-megatron-lora-disaggregated-multi-node.sh
@@ -298,7 +298,6 @@ if [ "$NODE_RANK" -eq 0 ]; then
       }' \
       -- python3 train.py \
       --calculate-per-token-loss \
-      --use-miles-router \
       ${MODEL_ARGS[@]} \
       ${CKPT_ARGS[@]} \
       ${LORA_ARGS[@]} \

--- a/examples/lora/run-qwen2.5-3B-megatron-lora-disaggregated.sh
+++ b/examples/lora/run-qwen2.5-3B-megatron-lora-disaggregated.sh
@@ -138,7 +138,6 @@ ray job submit --address="http://127.0.0.1:8265" \
    --actor-num-nodes 1 \
    --actor-num-gpus-per-node 1 \
    --calculate-per-token-loss \
-   --use-miles-router \
    ${MODEL_ARGS[@]} \
    ${CKPT_ARGS[@]} \
    ${LORA_ARGS[@]} \

--- a/examples/lora/run-qwen3-4b-megatron-lora-result.sh
+++ b/examples/lora/run-qwen3-4b-megatron-lora-result.sh
@@ -138,7 +138,6 @@ MISC_ARGS=(
    --actor-num-gpus-per-node ${NUM_GPUS}
    --colocate
    --calculate-per-token-loss # +fsdp
-   --use-miles-router # +fsdp
 )
 
 # launch the master node of ray in container

--- a/examples/multi_lora/run_multi_lora.py
+++ b/examples/multi_lora/run_multi_lora.py
@@ -138,7 +138,7 @@ def _train(args: ScriptArgs, service: bool):
 
     topology_args = (
         f"--actor-num-nodes 1 --actor-num-gpus-per-node {args.actor_num_gpus} "
-        f"--rollout-num-gpus {args.rollout_num_gpus} --use-miles-router "
+        f"--rollout-num-gpus {args.rollout_num_gpus} "
     )
 
     save_args = f"--save {args.save_dir} --save-interval {args.save_interval} "

--- a/scripts/run_glm5_1_744b_a40b_lora.py
+++ b/scripts/run_glm5_1_744b_a40b_lora.py
@@ -262,7 +262,7 @@ def _train(args: ScriptArgs):
 
     save_args = f"--save-interval 1 --save {load_save_path} "
 
-    misc_args = f"--attention-dropout 0.0 --hidden-dropout 0.0 --accumulate-allreduce-grads-in-fp32 --attention-softmax-in-fp32 --attention-backend flash --calculate-per-token-loss --use-miles-router --actor-num-nodes 1 --actor-num-gpus-per-node {args.num_gpus_per_node} --num-gpus-per-node {args.num_gpus_per_node} --colocate "
+    misc_args = f"--attention-dropout 0.0 --hidden-dropout 0.0 --accumulate-allreduce-grads-in-fp32 --attention-softmax-in-fp32 --attention-backend flash --calculate-per-token-loss --actor-num-nodes 1 --actor-num-gpus-per-node {args.num_gpus_per_node} --num-gpus-per-node {args.num_gpus_per_node} --colocate "
 
     wandb_args = U.get_default_wandb_args(__file__, run_id=args.run_id) if args.enable_wandb else ""
 

--- a/scripts/run_glm5_2_744b_a40b_lora.py
+++ b/scripts/run_glm5_2_744b_a40b_lora.py
@@ -293,7 +293,7 @@ def _train(args: ScriptArgs):
 
     save_args = f"--save-interval 1 --save {load_save_path} "
 
-    misc_args = f"--attention-dropout 0.0 --hidden-dropout 0.0 --accumulate-allreduce-grads-in-fp32 --attention-softmax-in-fp32 --attention-backend flash --calculate-per-token-loss --use-miles-router --actor-num-nodes 1 --actor-num-gpus-per-node {args.num_gpus_per_node} --num-gpus-per-node {args.num_gpus_per_node} --colocate "
+    misc_args = f"--attention-dropout 0.0 --hidden-dropout 0.0 --accumulate-allreduce-grads-in-fp32 --attention-softmax-in-fp32 --attention-backend flash --calculate-per-token-loss --actor-num-nodes 1 --actor-num-gpus-per-node {args.num_gpus_per_node} --num-gpus-per-node {args.num_gpus_per_node} --colocate "
 
     wandb_args = U.get_default_wandb_args(__file__, run_id=args.run_id) if args.enable_wandb else ""
 


### PR DESCRIPTION
## Summary

The Miles router is deprecated in favour of sgl-router, but 14 launcher recipes still passed `--use-miles-router` unconditionally, so **every** run started from them took the deprecated text-based routing path.

There was no way to opt out from the caller side:

- `--use-miles-router` is declared `action="store_true"` with no negated form, so it cannot be switched off by appending anything to `--extra-args` / the trailing arg list.
- None of the Python launchers expose a `ScriptArgs` field for it.

Editing the recipe was the only workaround. This PR drops the flag everywhere it was hard-coded, so `router_manager` falls through to the sgl-router branch.

**`scripts/` (2 files)** — `run_glm5_1_744b_a40b_lora.py`, `run_glm5_2_744b_a40b_lora.py`.

**`examples/` (13 files)** — the LoRA recipes (`dev.sh`, `run-kimi-k25-megatron-lora.sh`, `run-qwen2.5-0.5B-megatron-lora.sh`, `run-qwen2.5-3B-megatron-lora-disaggregated.sh`, `run-qwen2.5-3B-megatron-lora-disaggregated-multi-node.sh`, `run-qwen3-4b-megatron-lora-result.sh`), the multi-LoRA driver (`run_multi_lora.py`), the four low-precision recipes, and the reproducibility recipe. The p2p profiling recipe also had a dead commented-out occurrence, removed so the flag does not read as an option worth re-enabling.

### Deliberately out of scope

- **The argument itself.** `miles/utils/arguments.py` and all router plumbing (`router_manager.py`, `sglang_engine.py`, `dashboard/`, `router/`) are untouched. Retiring the flag is a separate decision from unpinning the recipes.
- **Tests.** `tests/e2e/sglang/test_r3_router_equivalence.py` exists specifically to compare Miles router against sgl-router, and the router/dashboard unit tests exercise the same code — removing the flag there would delete the coverage rather than modernise it. Three e2e tests pass it incidentally (`tests/e2e/lora/test_lora_qwen2.5_0.5B.py`, `tests/e2e/megatron/test_quick_start_glm4_9B.py`, `tests/e2e/megatron/test_glm5_2_744b_a40b_5layer_nvfp4.py`); happy to clean those up here if reviewers prefer tests in scope.
- **Docs.** The `/advanced/miles-router` page documents R3 rollout routing replay, not this flag.

## Test plan

- [x] `grep -rn -- "use-miles-router" scripts/ examples/` returns no matches.
- [x] `bash -n` passes on all 12 edited shell recipes; the two edited Python launchers and the multi-LoRA driver still compile.
- [x] End-to-end GRPO LoRA run of the GLM-5.2 gsm8k example on 4x H200, before and after the change:
      `python scripts/run_glm5_2_744b_a40b_lora.py train --model-name GLM-5.2_5layer --task gsm8k --num-gpus-per-node 4 --num-rollout 5`
      Both complete all 5 rollouts and save adapters. After the change the Megatron arg dump reports `use_miles_router ... False` and `router_manager` logs `Router launched at <host>:<port>` from the sgl-router branch. Train/rollout logprob parity is unchanged (max abs diff 2.2e-4 against a mean logprob of -10.2).
- [ ] The other 13 recipes are the same single-line deletion and were not individually run.
