### PR TITLE
refactor(docker): make image builds reproducible and cacheable

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -162,7 +162,10 @@ jobs:
     if: |
       always() &&
       (github.event_name != 'schedule' || needs.check-upstream.outputs.should_build == 'true')
-    runs-on: ["h200", "2gpu"]
+    # The build itself never touches a GPU (buildx sandboxes RUN steps); docker-build
+    # nodes are CI machines carrying a second runner instance dedicated to builds, so
+    # image builds stop competing for GPU-suite runner slots.
+    runs-on: ["docker-build"]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -6,7 +6,10 @@ on:
       - main
     paths:
       - 'docker/Dockerfile'
+      - 'docker/build.py'
+      - 'docker/resolve_upstream.py'
       - 'docker/verify_transformer_engine.py'
+      - 'docker/patch/**'
       - 'requirements.txt'
 
   schedule:
@@ -67,6 +70,9 @@ jobs:
       wheels_fp_cu12_x86: ${{ steps.resolve.outputs.wheels_fp_cu12_x86 }}
       should_build: ${{ steps.resolve.outputs.should_build }}
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Restore last known upstream SHAs
         uses: actions/cache/restore@v4
         with:
@@ -82,46 +88,24 @@ jobs:
         run: |
           set -euo pipefail
 
-          # sglang (sglang-miles branch) and Megatron-LM (miles-main branch)
-          SGLANG_SHA=$(curl -sfS -H "Accept: application/vnd.github.sha" \
-            "https://api.github.com/repos/sgl-project/sglang/commits/sglang-miles")
-          MEGATRON_SHA=$(curl -sfS -H "Accept: application/vnd.github.sha" \
-            "https://api.github.com/repos/radixark/Megatron-LM/commits/miles-main")
-
-          # The miles ref the image bakes: the pushed commit on push, else main HEAD.
-          # miles stays out of the rebuild gate (pushes already trigger their own build).
+          # docker/resolve_upstream.py is the single resolver (build.py reuses it for
+          # local builds); it hard-fails on any unresolvable value. On push the image
+          # bakes the pushed commit, not main HEAD. miles stays out of the rebuild
+          # gate (pushes already trigger their own build).
+          MILES_ARG=""
           if [ "${GITHUB_EVENT_NAME}" = "push" ]; then
-            MILES_SHA="${GITHUB_SHA}"
-          else
-            MILES_SHA=$(curl -sfS -H "Accept: application/vnd.github.sha" \
-              "https://api.github.com/repos/radixark/miles/commits/main")
+            MILES_ARG="--miles-sha ${GITHUB_SHA}"
           fi
+          python3 docker/resolve_upstream.py ${MILES_ARG} > resolved.txt
+          cat resolved.txt
+          cat resolved.txt >> "$GITHUB_OUTPUT"
 
-          # Fingerprint the miles-wheels releases the images install from (sgl-router +
-          # the other prebuilt wheels). cu13 installs cu130-x86_64 / cu130-aarch64;
-          # cu12-x86 installs cu129-x86_64 — both build automatically, so track all rolling
-          # release tags they bake. Rolling tags stay fixed while assets may be replaced,
-          # so fingerprint the asset list rather than a commit SHA.
-          wheels_fp() {
-            curl -sfS "https://api.github.com/repos/yueming-yuan/miles-wheels/releases/tags/$1" \
-              | python3 -c "import sys,json,hashlib; a=json.load(sys.stdin).get('assets',[]); fp=sorted([x['name'],x['id'],x['size'],x['updated_at']] for x in a); print(hashlib.sha256(repr(fp).encode()).hexdigest() if a else '')"
-          }
-          WHEELS_CU13_X86_FP=$(wheels_fp cu130-x86_64)
-          WHEELS_CU13_ARM64_FP=$(wheels_fp cu130-aarch64)
-          WHEELS_CU12_X86_FP=$(wheels_fp cu129-x86_64)
-
-          # Empty means the resolver failed or a wheels release has no assets; fail here
-          # rather than hand the build an unpinned or unbuildable input.
-          for v in SGLANG_SHA MEGATRON_SHA MILES_SHA WHEELS_CU13_X86_FP WHEELS_CU13_ARM64_FP WHEELS_CU12_X86_FP; do
-            [ -n "${!v}" ] || { echo "resolver produced empty ${v}" >&2; exit 1; }
-          done
-
-          echo "sglang HEAD:   ${SGLANG_SHA}"
-          echo "megatron HEAD: ${MEGATRON_SHA}"
-          echo "miles ref:     ${MILES_SHA}"
-          echo "wheels FP cu13 x86:   ${WHEELS_CU13_X86_FP}"
-          echo "wheels FP cu13 arm64: ${WHEELS_CU13_ARM64_FP}"
-          echo "wheels FP cu12 x86:   ${WHEELS_CU12_X86_FP}"
+          val() { grep "^$1=" resolved.txt | cut -d= -f2; }
+          SGLANG_SHA=$(val sglang_sha)
+          MEGATRON_SHA=$(val megatron_sha)
+          WHEELS_CU13_X86_FP=$(val wheels_fp_cu13_x86)
+          WHEELS_CU13_ARM64_FP=$(val wheels_fp_cu13_arm64)
+          WHEELS_CU12_X86_FP=$(val wheels_fp_cu12_x86)
 
           # Gate: compare against the values stored at the last gated build
           SHOULD_BUILD=true
@@ -173,15 +157,9 @@ jobs:
           echo "${WHEELS_CU12_X86_FP}" >> "$CACHE_FILE"
           echo "${NOW_EPOCH}" >> "$CACHE_FILE"
 
-          {
-            echo "sglang_sha=${SGLANG_SHA}"
-            echo "megatron_sha=${MEGATRON_SHA}"
-            echo "miles_sha=${MILES_SHA}"
-            echo "wheels_fp_cu13_x86=${WHEELS_CU13_X86_FP}"
-            echo "wheels_fp_cu13_arm64=${WHEELS_CU13_ARM64_FP}"
-            echo "wheels_fp_cu12_x86=${WHEELS_CU12_X86_FP}"
-            echo "should_build=${SHOULD_BUILD}"
-          } >> "$GITHUB_OUTPUT"
+          # The six resolved values are already in GITHUB_OUTPUT (resolved.txt above);
+          # the gate verdict is the only output produced here.
+          echo "should_build=${SHOULD_BUILD}" >> "$GITHUB_OUTPUT"
 
       - name: Save upstream SHAs to cache
         if: |
@@ -220,6 +198,9 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      # The source SHAs come from resolve-upstream (the same values the rebuild gate
+      # saw); the per-variant wheels fingerprints are left to build.py, which resolves
+      # them for the release tags the variant actually installs.
       - name: Build and push
         run: |
           python3 docker/build.py \
@@ -227,6 +208,9 @@ jobs:
             --image-tag ${{ inputs.image_tag || 'dev' }} \
             --dockerfile ${{ inputs.dockerfile || 'docker/Dockerfile' }} \
             ${{ inputs.custom_tag && format('--custom-tag {0}', inputs.custom_tag) || '' }} \
+            --build-arg SGLANG_COMMIT=${{ needs.resolve-upstream.outputs.sglang_sha }} \
+            --build-arg MEGATRON_COMMIT=${{ needs.resolve-upstream.outputs.megatron_sha }} \
+            --build-arg MILES_COMMIT=${{ needs.resolve-upstream.outputs.miles_sha }} \
             --push
 
       - name: Build and push cu12-x86 (automatic builds only)
@@ -234,7 +218,11 @@ jobs:
         # image; a manual workflow_dispatch builds only the single variant the user picked.
         if: ${{ !inputs.variant }}
         run: |
-          python3 docker/build.py --variant cu12-x86 --image-tag dev --push
+          python3 docker/build.py --variant cu12-x86 --image-tag dev \
+            --build-arg SGLANG_COMMIT=${{ needs.resolve-upstream.outputs.sglang_sha }} \
+            --build-arg MEGATRON_COMMIT=${{ needs.resolve-upstream.outputs.megatron_sha }} \
+            --build-arg MILES_COMMIT=${{ needs.resolve-upstream.outputs.miles_sha }} \
+            --push
 
       - name: Point latest to current dev
         # schedule only: latest is published registry state, so — like prune — a [DEBUG]

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -9,6 +9,7 @@ on:
       - 'docker/build.py'
       - 'docker/resolve_upstream.py'
       - 'docker/fetch_wheels.py'
+      - 'docker/requirements-nodeps.txt'
       - 'docker/verify_transformer_engine.py'
       - 'docker/patch/**'
       - 'requirements.txt'

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -177,11 +177,6 @@ jobs:
             image=moby/buildkit:latest
             network=host
 
-      - name: Install Python + dependencies
-        run: |
-          apt-get update && apt-get install -y python3 python3-pip
-          pip3 install --break-system-packages typer
-
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -214,51 +209,61 @@ jobs:
 
       - name: Prune old dev tags
         if: github.event_name == 'schedule'
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        # stdlib-only python, like build.py: build nodes carry docker + stock python3,
+        # no jq and no pip-installed packages.
         run: |
-          KEEP=20
-          IMAGE=radixark/miles
+          python3 - <<'EOF'
+          import json
+          import os
+          import re
+          import urllib.error
+          import urllib.request
 
-          # Authenticate with Docker Hub API
-          TOKEN=$(curl -s -X POST "https://hub.docker.com/v2/users/login/" \
-            -H "Content-Type: application/json" \
-            -d '{"username":"${{ secrets.DOCKERHUB_USERNAME }}","password":"${{ secrets.DOCKERHUB_TOKEN }}"}' \
-            | jq -r .token)
+          KEEP = 20
+          IMAGE = "radixark/miles"
+          HUB = "https://hub.docker.com/v2"
 
-          # Keep the newest $KEEP timestamped tags matching $1, delete the rest.
+          def call(url, data=None, method=None, token=None):
+              req = urllib.request.Request(url, method=method)
+              if token:
+                  req.add_header("Authorization", f"JWT {token}")
+              if data is not None:
+                  req.add_header("Content-Type", "application/json")
+                  req.data = json.dumps(data).encode()
+              with urllib.request.urlopen(req) as resp:
+                  body = resp.read()
+                  return json.loads(body) if body else None
+
+          token = call(
+              f"{HUB}/users/login/",
+              data={"username": os.environ["DOCKERHUB_USERNAME"], "password": os.environ["DOCKERHUB_TOKEN"]},
+          )["token"]
+
+          # Keep the newest KEEP timestamped tags matching pattern, delete the rest.
           # cu13 (dev-<ts>) and cu12-x86 (dev-cu12-<ts>) are pruned as independent series.
-          prune_series() {
-            PATTERN="$1"
-            TAGS=""
-            URL="https://hub.docker.com/v2/repositories/${IMAGE}/tags/?page_size=100"
-            while [ "$URL" != "null" ] && [ -n "$URL" ]; do
-              RESP=$(curl -s -H "Authorization: JWT ${TOKEN}" "$URL")
-              PAGE_TAGS=$(echo "$RESP" | jq -r '.results[].name' | grep -E "$PATTERN" || true)
-              TAGS="${TAGS}${PAGE_TAGS}"$'\n'
-              URL=$(echo "$RESP" | jq -r '.next')
-            done
+          def prune_series(pattern):
+              tags = []
+              url = f"{HUB}/repositories/{IMAGE}/tags/?page_size=100"
+              while url:
+                  page = call(url, token=token)
+                  tags += [t["name"] for t in page["results"] if re.fullmatch(pattern, t["name"])]
+                  url = page.get("next")
+              tags.sort()
+              print(f"Found {len(tags)} tags matching {pattern}")
+              if len(tags) <= KEEP:
+                  print(f"Nothing to prune for {pattern} (keep={KEEP})")
+                  return
+              print(f"Pruning {len(tags) - KEEP} old tags matching {pattern}...")
+              for tag in tags[: len(tags) - KEEP]:
+                  try:
+                      call(f"{HUB}/repositories/{IMAGE}/tags/{tag}/", method="DELETE", token=token)
+                      print(f"  Deleted {tag}")
+                  except urllib.error.HTTPError as e:
+                      print(f"  Failed to delete {tag} (HTTP {e.code})")
 
-            SORTED=$(echo "$TAGS" | grep -v '^$' | sort)
-            COUNT=$(echo "$SORTED" | wc -l | tr -d ' ')
-            echo "Found ${COUNT} tags matching ${PATTERN}"
-            if [ "$COUNT" -le "$KEEP" ]; then
-              echo "Nothing to prune for ${PATTERN} (keep=${KEEP})"
-              return
-            fi
-
-            DELETE_COUNT=$((COUNT - KEEP))
-            echo "Pruning ${DELETE_COUNT} old tags matching ${PATTERN}..."
-            echo "$SORTED" | head -n "$DELETE_COUNT" | while read -r TAG; do
-              [ -z "$TAG" ] && continue
-              HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X DELETE \
-                -H "Authorization: JWT ${TOKEN}" \
-                "https://hub.docker.com/v2/repositories/${IMAGE}/tags/${TAG}/")
-              if [ "$HTTP_CODE" = "204" ]; then
-                echo "  Deleted ${TAG}"
-              else
-                echo "  Failed to delete ${TAG} (HTTP ${HTTP_CODE})"
-              fi
-            done
-          }
-
-          prune_series '^dev-[0-9]{12}$'
-          prune_series '^dev-cu12-[0-9]{12}$'
+          prune_series(r"dev-[0-9]{12}")
+          prune_series(r"dev-cu12-[0-9]{12}")
+          EOF

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -10,6 +10,7 @@ on:
       - 'docker/resolve_upstream.py'
       - 'docker/fetch_wheels.py'
       - 'docker/requirements-nodeps.txt'
+      - 'docker/smoke_test.py'
       - 'docker/verify_transformer_engine.py'
       - 'docker/patch/**'
       - 'requirements.txt'
@@ -203,6 +204,34 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      # Gate: boot the amd64 image on this node's GPU before anything is pushed — a
+      # broken image must never reach a tag (a --no-deps install once dropped
+      # onnxscript and shipped a green image that failed every GPU job). Built with
+      # --load from the same builder cache the push builds hit afterwards, so the
+      # gate costs one local image export plus seconds of probing. arm64 halves ship
+      # unprobed (no ARM GPU nodes); rocm variants use different recipes/hardware.
+      - name: GPU smoke gate (amd64)
+        if: ${{ !startsWith(inputs.variant, 'rocm') && inputs.variant != 'cu13-aarch64' }}
+        run: |
+          set -euo pipefail
+          for v in ${{ inputs.variant || 'cu13 cu12-x86' }}; do
+            case "$v" in
+              cu13|cu13-x86) GV=cu13-x86; TAG=radixark/miles:smoke-gate ;;
+              cu12-x86)      GV=cu12-x86; TAG=radixark/miles:smoke-gate-cu12 ;;
+              *) echo "no amd64 smoke mapping for variant $v" >&2; exit 1 ;;
+            esac
+            python3 docker/build.py --variant "$GV" --image-tag custom --custom-tag smoke-gate \
+              --build-arg SGLANG_COMMIT=${{ needs.resolve-upstream.outputs.sglang_sha }} \
+              --build-arg MEGATRON_COMMIT=${{ needs.resolve-upstream.outputs.megatron_sha }} \
+              --build-arg MILES_COMMIT=${{ needs.resolve-upstream.outputs.miles_sha }} \
+              --builder miles-builder \
+              --load
+            docker run --rm --gpus all \
+              -v "$PWD/docker/smoke_test.py:/tmp/smoke_test.py:ro" \
+              "$TAG" python3 /tmp/smoke_test.py
+            docker rmi "$TAG"
+          done
 
       # The source SHAs come from resolve-upstream (the same values the rebuild gate
       # saw); the per-variant wheels fingerprints are left to build.py, which resolves

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -185,12 +185,16 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-        with:
-          driver-opts: |
-            image=moby/buildkit:latest
-            network=host
+      - name: Ensure persistent buildx builder
+        # A named docker-container builder persists on the build node across runs and
+        # is the layer cache — correct now that every image input is pinned by
+        # SHA/fingerprint build-args. setup-buildx-action would create (and tear down)
+        # a fresh builder per run, discarding all state: every build was fully cold.
+        run: |
+          docker buildx inspect miles-builder >/dev/null 2>&1 || \
+            docker buildx create --name miles-builder --driver docker-container \
+              --driver-opt image=moby/buildkit:latest --driver-opt network=host \
+              --bootstrap
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
@@ -211,6 +215,7 @@ jobs:
             --build-arg SGLANG_COMMIT=${{ needs.resolve-upstream.outputs.sglang_sha }} \
             --build-arg MEGATRON_COMMIT=${{ needs.resolve-upstream.outputs.megatron_sha }} \
             --build-arg MILES_COMMIT=${{ needs.resolve-upstream.outputs.miles_sha }} \
+            --builder miles-builder \
             --push
 
       - name: Build and push cu12-x86 (automatic builds only)
@@ -222,6 +227,7 @@ jobs:
             --build-arg SGLANG_COMMIT=${{ needs.resolve-upstream.outputs.sglang_sha }} \
             --build-arg MEGATRON_COMMIT=${{ needs.resolve-upstream.outputs.megatron_sha }} \
             --build-arg MILES_COMMIT=${{ needs.resolve-upstream.outputs.miles_sha }} \
+            --builder miles-builder \
             --push
 
       - name: Point latest to current dev

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -52,12 +52,20 @@ on:
         default: false
 
 jobs:
-  check-upstream:
-    # Only run on schedule (or simulated schedule) — check if upstream repos have new commits
-    if: github.event_name == 'schedule' || inputs.simulate_schedule == true
+  resolve-upstream:
+    # Resolves every upstream input the image bakes: source-branch HEAD SHAs and the
+    # wheels releases' asset fingerprints. Always runs — the build consumes these values
+    # as its pinned inputs; on schedule (or simulate_schedule) they additionally gate
+    # the rebuild, so the 12-hour cron skips when nothing moved.
     runs-on: ubuntu-latest
     outputs:
-      should_build: ${{ steps.check.outputs.should_build }}
+      sglang_sha: ${{ steps.resolve.outputs.sglang_sha }}
+      megatron_sha: ${{ steps.resolve.outputs.megatron_sha }}
+      miles_sha: ${{ steps.resolve.outputs.miles_sha }}
+      wheels_fp_cu13_x86: ${{ steps.resolve.outputs.wheels_fp_cu13_x86 }}
+      wheels_fp_cu13_arm64: ${{ steps.resolve.outputs.wheels_fp_cu13_arm64 }}
+      wheels_fp_cu12_x86: ${{ steps.resolve.outputs.wheels_fp_cu12_x86 }}
+      should_build: ${{ steps.resolve.outputs.should_build }}
     steps:
       - name: Restore last known upstream SHAs
         uses: actions/cache/restore@v4
@@ -66,18 +74,28 @@ jobs:
           key: upstream-shas-
           restore-keys: upstream-shas-
 
-      - name: Check for new upstream commits
-        id: check
+      - name: Resolve upstream SHAs and wheels fingerprints
+        id: resolve
+        env:
+          # The rebuild gate applies only on these paths; push/dispatch builds are never gated.
+          GATED: ${{ github.event_name == 'schedule' || inputs.simulate_schedule == true }}
         run: |
-          SHOULD_BUILD=false
+          set -euo pipefail
 
-          # Check sglang (sglang-miles branch)
-          SGLANG_SHA=$(curl -s -H "Accept: application/vnd.github.sha" \
+          # sglang (sglang-miles branch) and Megatron-LM (miles-main branch)
+          SGLANG_SHA=$(curl -sfS -H "Accept: application/vnd.github.sha" \
             "https://api.github.com/repos/sgl-project/sglang/commits/sglang-miles")
-
-          # Check Megatron-LM (miles-main branch)
-          MEGATRON_SHA=$(curl -s -H "Accept: application/vnd.github.sha" \
+          MEGATRON_SHA=$(curl -sfS -H "Accept: application/vnd.github.sha" \
             "https://api.github.com/repos/radixark/Megatron-LM/commits/miles-main")
+
+          # The miles ref the image bakes: the pushed commit on push, else main HEAD.
+          # miles stays out of the rebuild gate (pushes already trigger their own build).
+          if [ "${GITHUB_EVENT_NAME}" = "push" ]; then
+            MILES_SHA="${GITHUB_SHA}"
+          else
+            MILES_SHA=$(curl -sfS -H "Accept: application/vnd.github.sha" \
+              "https://api.github.com/repos/radixark/miles/commits/main")
+          fi
 
           # Fingerprint the miles-wheels releases the images install from (sgl-router +
           # the other prebuilt wheels). cu13 installs cu130-x86_64 / cu130-aarch64;
@@ -85,60 +103,69 @@ jobs:
           # release tags they bake. Rolling tags stay fixed while assets may be replaced,
           # so fingerprint the asset list rather than a commit SHA.
           wheels_fp() {
-            curl -s "https://api.github.com/repos/yueming-yuan/miles-wheels/releases/tags/$1" \
+            curl -sfS "https://api.github.com/repos/yueming-yuan/miles-wheels/releases/tags/$1" \
               | python3 -c "import sys,json,hashlib; a=json.load(sys.stdin).get('assets',[]); fp=sorted([x['name'],x['id'],x['size'],x['updated_at']] for x in a); print(hashlib.sha256(repr(fp).encode()).hexdigest() if a else '')"
           }
           WHEELS_CU13_X86_FP=$(wheels_fp cu130-x86_64)
           WHEELS_CU13_ARM64_FP=$(wheels_fp cu130-aarch64)
           WHEELS_CU12_X86_FP=$(wheels_fp cu129-x86_64)
 
+          # Empty means the resolver failed or a wheels release has no assets; fail here
+          # rather than hand the build an unpinned or unbuildable input.
+          for v in SGLANG_SHA MEGATRON_SHA MILES_SHA WHEELS_CU13_X86_FP WHEELS_CU13_ARM64_FP WHEELS_CU12_X86_FP; do
+            [ -n "${!v}" ] || { echo "resolver produced empty ${v}" >&2; exit 1; }
+          done
+
           echo "sglang HEAD:   ${SGLANG_SHA}"
           echo "megatron HEAD: ${MEGATRON_SHA}"
+          echo "miles ref:     ${MILES_SHA}"
           echo "wheels FP cu13 x86:   ${WHEELS_CU13_X86_FP}"
           echo "wheels FP cu13 arm64: ${WHEELS_CU13_ARM64_FP}"
           echo "wheels FP cu12 x86:   ${WHEELS_CU12_X86_FP}"
 
-          # Compare against last known values stored in cache
+          # Gate: compare against the values stored at the last gated build
+          SHOULD_BUILD=true
           CACHE_FILE="last_upstream_shas.txt"
-          if [ -f "$CACHE_FILE" ]; then
-            LAST_SGLANG=$(sed -n '1p' "$CACHE_FILE")
-            LAST_MEGATRON=$(sed -n '2p' "$CACHE_FILE")
-            LAST_WHEELS_CU13_X86=$(sed -n '3p' "$CACHE_FILE")
-            LAST_WHEELS_CU13_ARM64=$(sed -n '4p' "$CACHE_FILE")
-            LAST_WHEELS_CU12_X86=$(sed -n '5p' "$CACHE_FILE")
-            LAST_BUILD_EPOCH=$(sed -n '6p' "$CACHE_FILE")
-          else
-            LAST_SGLANG=""
-            LAST_MEGATRON=""
-            LAST_WHEELS_CU13_X86=""
-            LAST_WHEELS_CU13_ARM64=""
-            LAST_WHEELS_CU12_X86=""
-            LAST_BUILD_EPOCH=""
-          fi
-
-          if [ "$SGLANG_SHA" != "$LAST_SGLANG" ] || [ "$MEGATRON_SHA" != "$LAST_MEGATRON" ] || [ "$WHEELS_CU13_X86_FP" != "$LAST_WHEELS_CU13_X86" ] || [ "$WHEELS_CU13_ARM64_FP" != "$LAST_WHEELS_CU13_ARM64" ] || [ "$WHEELS_CU12_X86_FP" != "$LAST_WHEELS_CU12_X86" ]; then
-            SHOULD_BUILD=true
-            echo "Upstream change detected"
-          else
-            echo "No upstream changes"
-          fi
-
-          # miles commits alone never trigger rebuilds, so bound how stale the baked
-          # miles checkout can get.
-          MAX_BUILD_AGE_SECONDS=$(( 24 * 3600 ))
           NOW_EPOCH=$(date +%s)
-          if [ "$SHOULD_BUILD" = "false" ]; then
-            if ! [ "$LAST_BUILD_EPOCH" -gt 0 ] 2>/dev/null; then
-              SHOULD_BUILD=true
-              echo "No last-build timestamp recorded; rebuilding"
-            elif [ $(( NOW_EPOCH - LAST_BUILD_EPOCH )) -ge $MAX_BUILD_AGE_SECONDS ]; then
-              SHOULD_BUILD=true
-              echo "Last build was $(( (NOW_EPOCH - LAST_BUILD_EPOCH) / 3600 ))h ago (max $(( MAX_BUILD_AGE_SECONDS / 3600 ))h); rebuilding"
+          if [ "${GATED}" = "true" ]; then
+            if [ -f "$CACHE_FILE" ]; then
+              LAST_SGLANG=$(sed -n '1p' "$CACHE_FILE")
+              LAST_MEGATRON=$(sed -n '2p' "$CACHE_FILE")
+              LAST_WHEELS_CU13_X86=$(sed -n '3p' "$CACHE_FILE")
+              LAST_WHEELS_CU13_ARM64=$(sed -n '4p' "$CACHE_FILE")
+              LAST_WHEELS_CU12_X86=$(sed -n '5p' "$CACHE_FILE")
+              LAST_BUILD_EPOCH=$(sed -n '6p' "$CACHE_FILE")
+            else
+              LAST_SGLANG=""
+              LAST_MEGATRON=""
+              LAST_WHEELS_CU13_X86=""
+              LAST_WHEELS_CU13_ARM64=""
+              LAST_WHEELS_CU12_X86=""
+              LAST_BUILD_EPOCH=""
+            fi
+            if [ "$SGLANG_SHA" != "$LAST_SGLANG" ] || [ "$MEGATRON_SHA" != "$LAST_MEGATRON" ] || [ "$WHEELS_CU13_X86_FP" != "$LAST_WHEELS_CU13_X86" ] || [ "$WHEELS_CU13_ARM64_FP" != "$LAST_WHEELS_CU13_ARM64" ] || [ "$WHEELS_CU12_X86_FP" != "$LAST_WHEELS_CU12_X86" ]; then
+              echo "Upstream change detected"
+            else
+              SHOULD_BUILD=false
+              echo "No upstream changes"
+            fi
+
+            # miles commits alone never trigger rebuilds, so bound how stale the baked
+            # miles checkout can get.
+            MAX_BUILD_AGE_SECONDS=$(( 24 * 3600 ))
+            if [ "$SHOULD_BUILD" = "false" ]; then
+              if ! [ "$LAST_BUILD_EPOCH" -gt 0 ] 2>/dev/null; then
+                SHOULD_BUILD=true
+                echo "No last-build timestamp recorded; rebuilding"
+              elif [ $(( NOW_EPOCH - LAST_BUILD_EPOCH )) -ge $MAX_BUILD_AGE_SECONDS ]; then
+                SHOULD_BUILD=true
+                echo "Last build was $(( (NOW_EPOCH - LAST_BUILD_EPOCH) / 3600 ))h ago (max $(( MAX_BUILD_AGE_SECONDS / 3600 ))h); rebuilding"
+              fi
             fi
           fi
 
-          # Save current values for next run (cached only when a build triggers,
-          # so line 6 = when the last build was kicked off).
+          # Save current values for the next gated run. The cache is only saved when a
+          # gated build triggers, so line 6 records when the last build was kicked off.
           echo "${SGLANG_SHA}" > "$CACHE_FILE"
           echo "${MEGATRON_SHA}" >> "$CACHE_FILE"
           echo "${WHEELS_CU13_X86_FP}" >> "$CACHE_FILE"
@@ -146,22 +173,32 @@ jobs:
           echo "${WHEELS_CU12_X86_FP}" >> "$CACHE_FILE"
           echo "${NOW_EPOCH}" >> "$CACHE_FILE"
 
-          echo "should_build=${SHOULD_BUILD}" >> "$GITHUB_OUTPUT"
+          {
+            echo "sglang_sha=${SGLANG_SHA}"
+            echo "megatron_sha=${MEGATRON_SHA}"
+            echo "miles_sha=${MILES_SHA}"
+            echo "wheels_fp_cu13_x86=${WHEELS_CU13_X86_FP}"
+            echo "wheels_fp_cu13_arm64=${WHEELS_CU13_ARM64_FP}"
+            echo "wheels_fp_cu12_x86=${WHEELS_CU12_X86_FP}"
+            echo "should_build=${SHOULD_BUILD}"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Save upstream SHAs to cache
-        if: steps.check.outputs.should_build == 'true'
+        if: |
+          steps.resolve.outputs.should_build == 'true' &&
+          (github.event_name == 'schedule' || inputs.simulate_schedule == true)
         uses: actions/cache/save@v4
         with:
           path: last_upstream_shas.txt
           key: upstream-shas-${{ github.run_id }}
 
   build-and-push:
-    needs: [check-upstream]
+    needs: [resolve-upstream]
     # schedule: only build if upstream changed
-    # push/dispatch: build; simulate_schedule runs the check but does not gate the manual build
-    if: |
-      always() &&
-      (github.event_name != 'schedule' || needs.check-upstream.outputs.should_build == 'true')
+    # push/dispatch: build unconditionally; simulate_schedule reports the gate signal
+    # without gating the manual build. No always(): a failed resolve blocks the build
+    # instead of letting it proceed with unpinned inputs.
+    if: github.event_name != 'schedule' || needs.resolve-upstream.outputs.should_build == 'true'
     # The build itself never touches a GPU (buildx sandboxes RUN steps); docker-build
     # nodes are CI machines carrying a second runner instance dedicated to builds, so
     # image builds stop competing for GPU-suite runner slots.

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -8,6 +8,7 @@ on:
       - 'docker/Dockerfile'
       - 'docker/build.py'
       - 'docker/resolve_upstream.py'
+      - 'docker/fetch_wheels.py'
       - 'docker/verify_transformer_engine.py'
       - 'docker/patch/**'
       - 'requirements.txt'

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -93,7 +93,7 @@ jobs:
           # the recorded base.sha, which can lag main and pull in unrelated changes.
           # Dockerfile.rocm doesn't feed the cu13 multi-arch build this pipeline produces.
           if git diff --name-only HEAD^1 HEAD \
-              | grep -qE '^(docker/(Dockerfile|build\.py|resolve_upstream\.py|fetch_wheels\.py|verify_transformer_engine\.py|requirements-nodeps\.txt)|requirements\.txt)$|^docker/patch/'; then
+              | grep -qE '^(docker/(Dockerfile|build\.py|resolve_upstream\.py|fetch_wheels\.py|smoke_test\.py|verify_transformer_engine\.py|requirements-nodeps\.txt)|requirements\.txt)$|^docker/patch/'; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
           else
             echo "changed=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -116,13 +116,16 @@ jobs:
       - name: Checkout repository
         if: env.BUILD == 'true'
         uses: actions/checkout@v4
-      - name: Set up Docker Buildx
+      - name: Ensure persistent buildx builder
+        # Same persistent named builder as docker-build.yml: the node-local layer
+        # cache serves PR builds too (inputs are SHA/fingerprint-pinned, so hits are
+        # always correct).
         if: env.BUILD == 'true'
-        uses: docker/setup-buildx-action@v3
-        with:
-          driver-opts: |
-            image=moby/buildkit:latest
-            network=host
+        run: |
+          docker buildx inspect miles-builder >/dev/null 2>&1 || \
+            docker buildx create --name miles-builder --driver docker-container \
+              --driver-opt image=moby/buildkit:latest --driver-opt network=host \
+              --bootstrap
       - name: Login to Docker Hub
         if: env.BUILD == 'true'
         uses: docker/login-action@v3
@@ -134,7 +137,8 @@ jobs:
         if: env.BUILD == 'true'
         run: |
           python3 docker/build.py --variant cu13 --image-tag custom \
-            --custom-tag pr-${{ github.event.pull_request.number }} --push
+            --custom-tag pr-${{ github.event.pull_request.number }} \
+            --builder miles-builder --push
           echo "built=true" >> "$GITHUB_OUTPUT"
       - name: Nothing to build
         if: env.BUILD != 'true'

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -93,7 +93,7 @@ jobs:
           # the recorded base.sha, which can lag main and pull in unrelated changes.
           # Dockerfile.rocm doesn't feed the cu13 multi-arch build this pipeline produces.
           if git diff --name-only HEAD^1 HEAD \
-              | grep -qE '^(docker/(Dockerfile|build\.py|resolve_upstream\.py|fetch_wheels\.py|verify_transformer_engine\.py)|requirements\.txt)$|^docker/patch/'; then
+              | grep -qE '^(docker/(Dockerfile|build\.py|resolve_upstream\.py|fetch_wheels\.py|verify_transformer_engine\.py|requirements-nodeps\.txt)|requirements\.txt)$|^docker/patch/'; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
           else
             echo "changed=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -93,7 +93,7 @@ jobs:
           # the recorded base.sha, which can lag main and pull in unrelated changes.
           # Dockerfile.rocm doesn't feed the cu13 multi-arch build this pipeline produces.
           if git diff --name-only HEAD^1 HEAD \
-              | grep -qE '^(docker/(Dockerfile|build\.py|verify_transformer_engine\.py)|requirements\.txt)$|^docker/patch/'; then
+              | grep -qE '^(docker/(Dockerfile|build\.py|resolve_upstream\.py|verify_transformer_engine\.py)|requirements\.txt)$|^docker/patch/'; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
           else
             echo "changed=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -123,11 +123,6 @@ jobs:
           driver-opts: |
             image=moby/buildkit:latest
             network=host
-      - name: Install Python + dependencies
-        if: env.BUILD == 'true'
-        run: |
-          apt-get update && apt-get install -y python3 python3-pip
-          pip3 install --break-system-packages typer
       - name: Login to Docker Hub
         if: env.BUILD == 'true'
         uses: docker/login-action@v3

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -93,7 +93,7 @@ jobs:
           # the recorded base.sha, which can lag main and pull in unrelated changes.
           # Dockerfile.rocm doesn't feed the cu13 multi-arch build this pipeline produces.
           if git diff --name-only HEAD^1 HEAD \
-              | grep -qE '^(docker/(Dockerfile|build\.py|resolve_upstream\.py|verify_transformer_engine\.py)|requirements\.txt)$|^docker/patch/'; then
+              | grep -qE '^(docker/(Dockerfile|build\.py|resolve_upstream\.py|fetch_wheels\.py|verify_transformer_engine\.py)|requirements\.txt)$|^docker/patch/'; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
           else
             echo "changed=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -100,12 +100,12 @@ jobs:
           fi
 
   # Docker PRs: build the multi-arch image first and run every suite inside it.
-  # Always runs: with nothing to build every step is a no-op and it stays off the
-  # GPU fleet.
+  # Always runs: with nothing to build every step is a no-op on a free hosted
+  # runner; actual builds run on docker-build nodes, never the GPU-suite pool.
   docker-build:
     needs: [docker-paths]
     if: always() && !cancelled()
-    runs-on: ${{ fromJSON((needs.docker-paths.outputs.changed == 'true' && github.event.pull_request.head.repo.full_name == github.repository) && '["h200", "2gpu"]' || '["ubuntu-latest"]') }}
+    runs-on: ${{ fromJSON((needs.docker-paths.outputs.changed == 'true' && github.event.pull_request.head.repo.full_name == github.repository) && '["docker-build"]' || '["ubuntu-latest"]') }}
     timeout-minutes: 180
     outputs:
       built: ${{ steps.build.outputs.built || 'false' }}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -36,9 +36,14 @@ WORKDIR /root/
 
 # ======================================== Apt dependencies =============================================
 
-RUN apt update
+# Keep downloaded packages so the apt cache mounts below actually persist anything.
+RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
+    echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
+
 # ethtool for network diagnostics
-RUN apt install -y nvtop rsync dnsutils ethtool
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt update && apt install -y nvtop rsync dnsutils ethtool
 
 # nccl-tests for diagnostics
 RUN git clone https://github.com/NVIDIA/nccl-tests.git /tmp/nccl-tests && \
@@ -79,25 +84,32 @@ RUN pip install /tmp/wheels/flash_attn-*.whl
 # re-runs @torch.library.custom_op("flash_attn_3::...") and double-registers.
 RUN pip install /tmp/wheels/flash_attn_3-*.whl
 
-RUN pip install git+https://github.com/ISEEKYAN/mbridge.git@89eb10887887bc74853f89a4de258c0702932a1c --no-deps
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install git+https://github.com/ISEEKYAN/mbridge.git@89eb10887887bc74853f89a4de258c0702932a1c --no-deps
 
-RUN pip install flash-linear-attention==0.4.2
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install flash-linear-attention==0.4.2
 # required for DeepSeek V4
-RUN pip install tilelang==0.1.8 -f https://tile-ai.github.io/whl/nightly/cu128/
-RUN pip install --no-deps tile_kernels==1.0.0
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install tilelang==0.1.8 -f https://tile-ai.github.io/whl/nightly/cu128/
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install --no-deps tile_kernels==1.0.0
 # FlashQLA backend for Qwen GDN linear-attention layers (requires SM90+, CUDA 12.8+, PyTorch 2.8+; built on tilelang above)
-RUN pip install -v --no-build-isolation "git+https://github.com/QwenLM/FlashQLA.git"
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install -v --no-build-isolation "git+https://github.com/QwenLM/FlashQLA.git"
 # Prefer the prebuilt wheel; fall back to a source build while the current
 # arch's wheels release doesn't carry it yet (QEMU-emulated arm64 source
 # builds are the expensive path this avoids).
-RUN if ls /tmp/wheels/fast_hadamard_transform-*.whl 2>/dev/null | grep -q .; then \
+RUN --mount=type=cache,target=/root/.cache/pip \
+    if ls /tmp/wheels/fast_hadamard_transform-*.whl 2>/dev/null | grep -q .; then \
       pip install /tmp/wheels/fast_hadamard_transform-*.whl; \
     else \
       pip install "git+https://github.com/Dao-AILab/fast-hadamard-transform.git@e7706faf8d1c3b9f241e36860640ad1dac644ede" --no-build-isolation; \
     fi
 
 # Mamba kernels for nemotron_h hybrid (mamba+attention) models.
-RUN if ls /tmp/wheels/causal_conv1d-*.whl 2>/dev/null | grep -q . && \
+RUN --mount=type=cache,target=/root/.cache/pip \
+    if ls /tmp/wheels/causal_conv1d-*.whl 2>/dev/null | grep -q . && \
        ls /tmp/wheels/mamba_ssm-*.whl 2>/dev/null | grep -q .; then \
       pip install /tmp/wheels/causal_conv1d-*.whl /tmp/wheels/mamba_ssm-*.whl; \
     else \
@@ -109,7 +121,8 @@ RUN if ls /tmp/wheels/causal_conv1d-*.whl 2>/dev/null | grep -q . && \
 # pull a conflicting core dist. That also drops transformer_engine_torch's own
 # runtime deps, which still have to be installed: transformer_engine.pytorch
 # imports onnxscript unconditionally (module/_common -> export -> onnx_extensions).
-RUN --mount=type=bind,source=docker/verify_transformer_engine.py,target=/tmp/verify_transformer_engine.py \
+RUN --mount=type=cache,target=/root/.cache/pip \
+    --mount=type=bind,source=docker/verify_transformer_engine.py,target=/tmp/verify_transformer_engine.py \
     if [ "${ENABLE_CUDA_13}" = "1" ]; then \
       TE_CORE_DIST=transformer_engine_cu13; \
     else \
@@ -148,28 +161,35 @@ RUN if [ "${ENABLE_CUDA_13}" = "1" ] && [ -d /tmp/patches/cu13 ]; then \
 # apex
 RUN pip install /tmp/wheels/apex-*.whl
 
-RUN git clone https://github.com/${MEGATRON_REPO}.git --recursive -b ${MEGATRON_BRANCH} Megatron-LM && \
+RUN --mount=type=cache,target=/root/.cache/pip \
+    git clone https://github.com/${MEGATRON_REPO}.git --recursive -b ${MEGATRON_BRANCH} Megatron-LM && \
     cd Megatron-LM && \
     pip install -e .
 
 # Muon optimizer support: megatron/core/optimizer/muon.py requires this for Newton-Schulz
 # orthogonalization; not on PyPI (only a dependency-confusion stub), so install from the
 # git source Megatron-LM itself pins in pyproject.toml.
-RUN pip install "git+https://github.com/NVIDIA-NeMo/Emerging-Optimizers.git@v0.1.0"
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install "git+https://github.com/NVIDIA-NeMo/Emerging-Optimizers.git@v0.1.0"
 
 # torch_memory_saver's source build needs TMS_CUDA_MAJOR; take it from torch.
 RUN TMS_CUDA_MAJOR=$(python3 -c "import torch; print(torch.version.cuda.split('.')[0])") \
     pip install git+https://github.com/fzyzcjy/torch_memory_saver.git@74d68c5e4bedf2b6774f2c92ed0f81b7c8d91ed0 --no-cache-dir --force-reinstall
-RUN pip install "nvidia-modelopt[torch]>=0.37.0" --no-build-isolation
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install "nvidia-modelopt[torch]>=0.37.0" --no-build-isolation
 # radixark/Megatron-Bridge#24 (TE 2.17 grouped-linear contract), merged to @bridge.
 # Pinned by SHA, not branch: buildkit caches this layer on the instruction text, so a
 # branch that moves leaves the old revision baked into the image with nothing to show it.
-RUN pip install git+https://github.com/radixark/Megatron-Bridge.git@7f0fb3456f8ffe47599b5fd167b454605d85f932 --no-deps --no-build-isolation
-RUN pip install megatron-energon --no-deps
-RUN pip install multi-storage-client --no-deps
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install git+https://github.com/radixark/Megatron-Bridge.git@7f0fb3456f8ffe47599b5fd167b454605d85f932 --no-deps --no-build-isolation
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install megatron-energon --no-deps
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install multi-storage-client --no-deps
 
 COPY requirements.txt /tmp/requirements.txt
-RUN rm -rf /usr/lib/python3/dist-packages/jwt /usr/lib/python3/dist-packages/PyJWT* && pip install -r /tmp/requirements.txt
+RUN --mount=type=cache,target=/root/.cache/pip \
+    rm -rf /usr/lib/python3/dist-packages/jwt /usr/lib/python3/dist-packages/PyJWT* && pip install -r /tmp/requirements.txt
 
 # The apt copy shadows the pip one in ldconfig and the loader interleaves the two,
 # so transformer_engine gets a mixed set of libcudnn sub-libraries. The packages are
@@ -179,7 +199,8 @@ RUN if [ "${ENABLE_CUDA_13}" = "1" ]; then CU=13; else CU=12; fi; \
     libcudnn9-cuda-${CU} libcudnn9-dev-cuda-${CU} libcudnn9-headers-cuda-${CU} \
   && rm -rf /var/lib/apt/lists/*
 
-RUN if [ "${ENABLE_CUDA_13}" = "1" ]; then \
+RUN --mount=type=cache,target=/root/.cache/pip \
+    if [ "${ENABLE_CUDA_13}" = "1" ]; then \
     pip install nvidia-cudnn-cu13==9.22.0.52; \
   else \
     pip install nvidia-cudnn-cu12==9.22.0.52; \
@@ -278,7 +299,8 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 #   TypeError: make_kwargs_wrapper() got an unexpected keyword argument 'map_dataclass_to_tuple'
 # Restore sglang's own pin after every other install, and fail the build loudly if it
 # does not take effect rather than shipping an image that only breaks under CI.
-RUN pip install --force-reinstall --no-deps "apache-tvm-ffi==0.1.11" && \
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install --force-reinstall --no-deps "apache-tvm-ffi==0.1.11" && \
     python3 -c "import inspect; from tvm_ffi.utils import kwargs_wrapper as k; \
 p = inspect.signature(k.make_kwargs_wrapper).parameters; \
 assert 'map_dataclass_to_tuple' in p, \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,6 +9,13 @@
 # A multi-arch build runs the recipe once per platform; it installs the wheels
 # release for the current arch picked from TARGETARCH — WHEELS_TAG_X86 on amd64,
 # WHEELS_TAG_ARM64 on arm64 (cu12-x86 overrides WHEELS_TAG_X86).
+#
+# Layers are ordered by ascending change frequency so the persistent builder's
+# cache survives as long as possible: stable tooling and pinned third-party
+# installs first, the requirements.txt resolve after them, and the fast-moving
+# source trees (Megatron → sglang → miles) last. pip never re-negotiates the
+# environment past a layer's own install: wheel/pinned layers use --no-deps and
+# the resolving layers pin everything already installed via a constraints file.
 
 ARG SGLANG_IMAGE_TAG=v0.5.16
 FROM lmsysorg/sglang:${SGLANG_IMAGE_TAG} AS sglang
@@ -88,28 +95,27 @@ RUN --mount=type=cache,target=/wheels-cache \
     rm /tmp/release.json && \
     ls -lh /tmp/wheels/
 
-# ====================================== Python dependencies ============================================
+# ============================== Prebuilt release wheels (no-deps) ==============================
 
-# flash-attn
-RUN pip install /tmp/wheels/flash_attn-*.whl
-
-# flash-attn hopper (FA3): Hopper-only (sm_90a). Coexists with FA2.
-# The wheel ships flash_attn_interface top-level (what transformer_engine imports)
+# flash-attn + flash-attn hopper (FA3, Hopper-only sm_90a, coexists with FA2) + apex +
+# int4_qat, one --no-deps layer: their runtime deps are already in the base image.
+# The FA3 wheel ships flash_attn_interface top-level (what transformer_engine imports)
 # plus a flash_attn_3.flash_attn_interface re-export shim, so there is nothing to
 # fetch separately. Do not overwrite the shim with a copy of the full module: it
 # re-runs @torch.library.custom_op("flash_attn_3::...") and double-registers.
-RUN pip install /tmp/wheels/flash_attn_3-*.whl
+RUN pip install --no-deps \
+      /tmp/wheels/flash_attn-*.whl \
+      /tmp/wheels/flash_attn_3-*.whl \
+      /tmp/wheels/apex-*.whl \
+      /tmp/wheels/fake_int4_quant_cuda-*.whl
 
-RUN --mount=type=cache,target=/root/.cache/pip \
-    pip install git+https://github.com/ISEEKYAN/mbridge.git@89eb10887887bc74853f89a4de258c0702932a1c --no-deps
+# ====================================== Pinned third-party installs ============================================
 
 RUN --mount=type=cache,target=/root/.cache/pip \
     pip install flash-linear-attention==0.4.2
 # required for DeepSeek V4
 RUN --mount=type=cache,target=/root/.cache/pip \
     pip install tilelang==0.1.8 -f https://tile-ai.github.io/whl/nightly/cu128/
-RUN --mount=type=cache,target=/root/.cache/pip \
-    pip install --no-deps tile_kernels==1.0.0
 # FlashQLA backend for Qwen GDN linear-attention layers (requires SM90+, CUDA 12.8+, PyTorch 2.8+; built on tilelang above)
 # SHA-pinned like the other git installs: an unpinned HEAD install is invisible to the
 # layer cache, which would silently freeze whatever revision the layer last built.
@@ -120,7 +126,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 # builds are the expensive path this avoids).
 RUN --mount=type=cache,target=/root/.cache/pip \
     if ls /tmp/wheels/fast_hadamard_transform-*.whl 2>/dev/null | grep -q .; then \
-      pip install /tmp/wheels/fast_hadamard_transform-*.whl; \
+      pip install --no-deps /tmp/wheels/fast_hadamard_transform-*.whl; \
     else \
       pip install "git+https://github.com/Dao-AILab/fast-hadamard-transform.git@e7706faf8d1c3b9f241e36860640ad1dac644ede" --no-build-isolation; \
     fi
@@ -176,18 +182,17 @@ RUN if [ "${ENABLE_CUDA_13}" = "1" ] && [ -d /tmp/patches/cu13 ]; then \
       done; \
     fi && rm -rf /tmp/patches
 
-# apex
-RUN pip install /tmp/wheels/apex-*.whl
-
-# Clone without -b: miles-main may be rebased, and a full clone keeps the pinned SHA
-# reachable regardless; submodules sync after the checkout so they match the pin.
+# Packages whose runtime deps are already present: one --no-deps layer, pip never
+# re-negotiates the environment for them.
+COPY docker/requirements-nodeps.txt /tmp/requirements-nodeps.txt
 RUN --mount=type=cache,target=/root/.cache/pip \
-    test -n "${MEGATRON_COMMIT}" || { echo "MEGATRON_COMMIT build-arg is required (docker/resolve_upstream.py provides it)" >&2; exit 1; } && \
-    git clone https://github.com/${MEGATRON_REPO}.git Megatron-LM && \
-    cd Megatron-LM && \
-    git checkout ${MEGATRON_COMMIT} && \
-    git submodule update --init --recursive && \
-    pip install -e .
+    pip install --no-deps -r /tmp/requirements-nodeps.txt
+
+# radixark/Megatron-Bridge#24 (TE 2.17 grouped-linear contract), merged to @bridge.
+# Pinned by SHA, not branch: buildkit caches this layer on the instruction text, so a
+# branch that moves leaves the old revision baked into the image with nothing to show it.
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install git+https://github.com/radixark/Megatron-Bridge.git@7f0fb3456f8ffe47599b5fd167b454605d85f932 --no-deps --no-build-isolation
 
 # Muon optimizer support: megatron/core/optimizer/muon.py requires this for Newton-Schulz
 # orthogonalization; not on PyPI (only a dependency-confusion stub), so install from the
@@ -196,68 +201,19 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     pip install "git+https://github.com/NVIDIA-NeMo/Emerging-Optimizers.git@v0.1.0"
 
 # torch_memory_saver's source build needs TMS_CUDA_MAJOR; take it from torch.
-RUN TMS_CUDA_MAJOR=$(python3 -c "import torch; print(torch.version.cuda.split('.')[0])") \
+RUN --mount=type=cache,target=/root/.cache/pip \
+    TMS_CUDA_MAJOR=$(python3 -c "import torch; print(torch.version.cuda.split('.')[0])") \
     pip install git+https://github.com/fzyzcjy/torch_memory_saver.git@74d68c5e4bedf2b6774f2c92ed0f81b7c8d91ed0 --no-cache-dir --force-reinstall
+
 RUN --mount=type=cache,target=/root/.cache/pip \
     pip install "nvidia-modelopt[torch]>=0.37.0" --no-build-isolation
-# radixark/Megatron-Bridge#24 (TE 2.17 grouped-linear contract), merged to @bridge.
-# Pinned by SHA, not branch: buildkit caches this layer on the instruction text, so a
-# branch that moves leaves the old revision baked into the image with nothing to show it.
-RUN --mount=type=cache,target=/root/.cache/pip \
-    pip install git+https://github.com/radixark/Megatron-Bridge.git@7f0fb3456f8ffe47599b5fd167b454605d85f932 --no-deps --no-build-isolation
-RUN --mount=type=cache,target=/root/.cache/pip \
-    pip install megatron-energon --no-deps
-RUN --mount=type=cache,target=/root/.cache/pip \
-    pip install multi-storage-client --no-deps
-
-COPY requirements.txt /tmp/requirements.txt
-RUN --mount=type=cache,target=/root/.cache/pip \
-    rm -rf /usr/lib/python3/dist-packages/jwt /usr/lib/python3/dist-packages/PyJWT* && pip install -r /tmp/requirements.txt
-
-# The apt copy shadows the pip one in ldconfig and the loader interleaves the two,
-# so transformer_engine gets a mixed set of libcudnn sub-libraries. The packages are
-# held, hence --allow-change-held-packages.
-RUN if [ "${ENABLE_CUDA_13}" = "1" ]; then CU=13; else CU=12; fi; \
-  apt-get remove -y --purge --allow-change-held-packages \
-    libcudnn9-cuda-${CU} libcudnn9-dev-cuda-${CU} libcudnn9-headers-cuda-${CU} \
-  && rm -rf /var/lib/apt/lists/*
-
-RUN --mount=type=cache,target=/root/.cache/pip \
-    if [ "${ENABLE_CUDA_13}" = "1" ]; then \
-    pip install nvidia-cudnn-cu13==9.22.0.52; \
-  else \
-    pip install nvidia-cudnn-cu12==9.22.0.52; \
-  fi
-
-
-RUN rm -rf /root/.cache/pip /root/flash-attention
-
-# ====================================== Install sglang-miles ============================================
-
-# Install sglang at the pinned sglang-miles commit. The SHA is fetched directly
-# (not via the branch name): the base image's clone is shallow and sglang-miles gets
-# rebased, so a branch fetch can't guarantee the pinned commit is reachable.
-# The CUDA 12 sglang images sed their dependency markers from cu13 to cu12 in
-# python/pyproject.toml and never commit it, so a plain checkout aborts on the dirty
-# file. Force it, then re-apply the same rewrite: the tree we just checked out carries
-# the cu13 markers, and sglang's editable install makes them visible to every later pip
-# resolve, which would drag cu13 packages onto a cu12 image.
-RUN test -n "${SGLANG_COMMIT}" || { echo "SGLANG_COMMIT build-arg is required (docker/resolve_upstream.py provides it)" >&2; exit 1; } && \
-    cd /sgl-workspace/sglang && \
-    git fetch origin ${SGLANG_COMMIT} && \
-    git checkout -f ${SGLANG_COMMIT} && \
-    if [ "${ENABLE_CUDA_13}" != "1" ]; then \
-      sed -i 's/cuda-python>=13\.0/cuda-python>=12,<13/' python/pyproject.toml && \
-      sed -i 's/flashinfer_python\[cu13\]/flashinfer_python[cu12]/' python/pyproject.toml && \
-      sed -i 's/nvidia-cutlass-dsl\[cu13\]/nvidia-cutlass-dsl/' python/pyproject.toml; \
-    fi && \
-    pip install -e "python[all]" --no-deps
 
 # =========================== Mooncake structured object store wheel ===========================
 
 # Miles' Mooncake backend requires the structured object store API. Install the selected
 # CUDA 13 wheel as one coherent Python/native package; CUDA 12 keeps its base Mooncake.
-RUN if [ "${ENABLE_CUDA_13}" = "1" ]; then \
+RUN --mount=type=cache,target=/root/.cache/pip \
+    if [ "${ENABLE_CUDA_13}" = "1" ]; then \
       set -- /tmp/wheels/mooncake_transfer_engine*-*.whl; \
       if [ "$#" -ne 1 ] || [ ! -e "$1" ]; then \
         echo "expected exactly one mooncake wheel for cu13/${TARGETARCH}" >&2; exit 1; \
@@ -267,18 +223,6 @@ RUN if [ "${ENABLE_CUDA_13}" = "1" ]; then \
     else \
       echo "CUDA 12 variant: keeping the base image's mooncake"; \
     fi
-
-# ====================================== Install main package ============================================
-
-ARG MILES_COMMIT=""
-RUN test -n "${MILES_COMMIT}" || { echo "MILES_COMMIT build-arg is required (docker/resolve_upstream.py provides it)" >&2; exit 1; } && \
-    git clone https://github.com/radixark/miles.git /root/miles && \
-    cd /root/miles && \
-    git checkout ${MILES_COMMIT} && \
-    pip install -e . --no-deps
-
-# int4_qat
-RUN pip install /tmp/wheels/fake_int4_quant_cuda-*.whl
 
 # ====================================== Install sgl-model-gateway ============================================
 #   SGL_ROUTER_USE_WHEELS=0:
@@ -312,6 +256,89 @@ RUN --mount=type=cache,target=/root/.cache/pip \
       rm -rf /root/.cargo /root/.rustup /build/sgl-model-gateway /build/gateway_wheels; \
     fi
 
+# ====================================== Miles runtime requirements ============================================
+
+# Constrained resolve: everything already installed is frozen via a constraints file
+# generated on the spot, so this layer may add packages but transitive resolution
+# cannot silently move the layers above. Packages requirements.txt itself names are
+# excluded from the freeze — its explicit pins are miles' declared contract and may
+# override a base-image version (e.g. xxhash), which a full freeze would veto.
+COPY requirements.txt /tmp/requirements.txt
+RUN --mount=type=cache,target=/root/.cache/pip \
+    rm -rf /usr/lib/python3/dist-packages/jwt /usr/lib/python3/dist-packages/PyJWT* && \
+    pip list --format=freeze | python3 -c "import sys,re; own={re.split(r'[<>=!~;\[ ]', l.strip(), 1)[0].lower().replace('_','-') for l in open('/tmp/requirements.txt') if l.strip() and not l.strip().startswith(('#','-'))}; sys.stdout.writelines(l for l in sys.stdin if l.split('==')[0].lower().replace('_','-') not in own)" > /tmp/constraints.txt && \
+    pip install -r /tmp/requirements.txt -c /tmp/constraints.txt && \
+    rm /tmp/constraints.txt
+
+# ====================================== Source trees ============================================
+# Ordered by descending stability: Megatron-LM, then sglang, then miles — the pins
+# that move most often sit deepest so their rebuilds invalidate the least.
+
+# Clone without -b: miles-main may be rebased, and a full clone keeps the pinned SHA
+# reachable regardless; submodules sync after the checkout so they match the pin.
+# The editable install resolves Megatron's deps under the same constraints discipline
+# as requirements.txt above: new packages may install, moving installed ones fails loudly.
+RUN --mount=type=cache,target=/root/.cache/pip \
+    test -n "${MEGATRON_COMMIT}" || { echo "MEGATRON_COMMIT build-arg is required (docker/resolve_upstream.py provides it)" >&2; exit 1; } && \
+    git clone https://github.com/${MEGATRON_REPO}.git Megatron-LM && \
+    cd Megatron-LM && \
+    git checkout ${MEGATRON_COMMIT} && \
+    git submodule update --init --recursive && \
+    pip list --format=freeze > /tmp/constraints.txt && \
+    pip install -e . -c /tmp/constraints.txt && \
+    rm /tmp/constraints.txt
+
+# Install sglang at the pinned sglang-miles commit. The SHA is fetched directly
+# (not via the branch name): the base image's clone is shallow and sglang-miles gets
+# rebased, so a branch fetch can't guarantee the pinned commit is reachable.
+# The CUDA 12 sglang images sed their dependency markers from cu13 to cu12 in
+# python/pyproject.toml and never commit it, so a plain checkout aborts on the dirty
+# file. Force it, then re-apply the same rewrite: the tree we just checked out carries
+# the cu13 markers, and sglang's editable install makes them visible to every later pip
+# resolve, which would drag cu13 packages onto a cu12 image.
+RUN --mount=type=cache,target=/root/.cache/pip \
+    test -n "${SGLANG_COMMIT}" || { echo "SGLANG_COMMIT build-arg is required (docker/resolve_upstream.py provides it)" >&2; exit 1; } && \
+    cd /sgl-workspace/sglang && \
+    git fetch origin ${SGLANG_COMMIT} && \
+    git checkout -f ${SGLANG_COMMIT} && \
+    if [ "${ENABLE_CUDA_13}" != "1" ]; then \
+      sed -i 's/cuda-python>=13\.0/cuda-python>=12,<13/' python/pyproject.toml && \
+      sed -i 's/flashinfer_python\[cu13\]/flashinfer_python[cu12]/' python/pyproject.toml && \
+      sed -i 's/nvidia-cutlass-dsl\[cu13\]/nvidia-cutlass-dsl/' python/pyproject.toml; \
+    fi && \
+    pip install -e "python[all]" --no-deps
+
+# ====================================== Install main package ============================================
+
+ARG MILES_COMMIT=""
+RUN --mount=type=cache,target=/root/.cache/pip \
+    test -n "${MILES_COMMIT}" || { echo "MILES_COMMIT build-arg is required (docker/resolve_upstream.py provides it)" >&2; exit 1; } && \
+    git clone https://github.com/radixark/miles.git /root/miles && \
+    cd /root/miles && \
+    git checkout ${MILES_COMMIT} && \
+    pip install -e . --no-deps
+
+# ====================================== Post-resolve forced overrides ============================================
+# Everything below deliberately contradicts some package's declared metadata, so it must
+# run after every pip resolve in this file: a resolver running later would either veto
+# these versions (under constraints) or silently undo them (unconstrained).
+
+# cudnn bump: torch 2.11+cu130 pins nvidia-cudnn-cu13==9.19.0.56, but TE needs 9.22.
+# The apt copy shadows the pip one in ldconfig and the loader interleaves the two,
+# so transformer_engine gets a mixed set of libcudnn sub-libraries. The packages are
+# held, hence --allow-change-held-packages.
+RUN if [ "${ENABLE_CUDA_13}" = "1" ]; then CU=13; else CU=12; fi; \
+  apt-get remove -y --purge --allow-change-held-packages \
+    libcudnn9-cuda-${CU} libcudnn9-dev-cuda-${CU} libcudnn9-headers-cuda-${CU} \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN --mount=type=cache,target=/root/.cache/pip \
+    if [ "${ENABLE_CUDA_13}" = "1" ]; then \
+    pip install nvidia-cudnn-cu13==9.22.0.52; \
+  else \
+    pip install nvidia-cudnn-cu12==9.22.0.52; \
+  fi
+
 # ==================== Reconcile apache-tvm-ffi with sglang's pin ====================
 # sglang v0.5.16 bumped nvidia-cutlass-dsl 4.5.2 -> 4.6.0 while leaving its
 # apache-tvm-ffi pin at 0.1.11. cutlass-dsl 4.6.0's tvm_ffi provider calls
@@ -329,7 +356,9 @@ p = inspect.signature(k.make_kwargs_wrapper).parameters; \
 assert 'map_dataclass_to_tuple' in p, \
   'apache-tvm-ffi resolves to a build too old for nvidia-cutlass-dsl 4.6.0: %s' % list(p)"
 
-RUN rm -rf /tmp/wheels
+# /root/flash-attention is baked-in base-image build residue; pip's cache lives in a
+# mount now, so there is nothing of it to clean out of the layers.
+RUN rm -rf /tmp/wheels /root/flash-attention
 
 # The cu130 sglang base ships its baked Rust toolchain outside the default PATH.
 ENV PATH="/root/.cargo/bin:${PATH}"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -67,7 +67,13 @@ RUN git clone https://github.com/NVIDIA/nccl-tests.git /tmp/nccl-tests && \
 # `wheel[s]/` is a glob — silently no-ops when wheels/ is absent (CI's path).
 COPY wheel[s]/ /tmp/wheels/
 
-RUN case "${TARGETARCH}" in \
+# The /wheels-cache mount persists downloads across builds on the node (per-arch
+# subdir); docker/fetch_wheels.py reuses a cached asset only when its release asset
+# id matches, since rolling releases replace assets under the same filename. The
+# layer itself re-runs whenever the WHEELS_FP build-arg changes.
+RUN --mount=type=cache,target=/wheels-cache \
+    --mount=type=bind,source=docker/fetch_wheels.py,target=/tmp/fetch_wheels.py \
+    case "${TARGETARCH}" in \
       amd64) WHEELS_TAG="${WHEELS_TAG_X86}"; WHEELS_FP="${WHEELS_FP_X86}" ;; \
       arm64) WHEELS_TAG="${WHEELS_TAG_ARM64}"; WHEELS_FP="${WHEELS_FP_ARM64}" ;; \
       *) echo "unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
@@ -76,12 +82,10 @@ RUN case "${TARGETARCH}" in \
       echo "wheels fingerprint build-arg for ${TARGETARCH} is required (docker/resolve_upstream.py provides it)" >&2; exit 1; \
     fi && \
     echo "Fetching wheels release ${WHEELS_TAG} (assets fingerprint ${WHEELS_FP})" && \
-    mkdir -p /tmp/wheels && \
-    curl -sL "https://api.github.com/repos/${WHEELS_REPO}/releases/tags/${WHEELS_TAG}" \
-    | python3 -c "import sys,json,subprocess,os; w='/tmp/wheels'; \
-[subprocess.run(['curl','-fSL','-o',os.path.join(w,a['name']),a['browser_download_url']],check=True) \
- for a in json.load(sys.stdin).get('assets',[]) \
- if a['name'].endswith(('.whl', '.tar.gz')) and not os.path.exists(os.path.join(w,a['name']))]" && \
+    mkdir -p /tmp/wheels "/wheels-cache/${TARGETARCH}" && \
+    curl -sfSL "https://api.github.com/repos/${WHEELS_REPO}/releases/tags/${WHEELS_TAG}" > /tmp/release.json && \
+    CACHE_DIR="/wheels-cache/${TARGETARCH}" python3 /tmp/fetch_wheels.py && \
+    rm /tmp/release.json && \
     ls -lh /tmp/wheels/
 
 # ====================================== Python dependencies ============================================

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,11 +15,14 @@ FROM lmsysorg/sglang:${SGLANG_IMAGE_TAG} AS sglang
 
 # ======================================== Arguments =============================================
 
-ARG SGLANG_BRANCH=sglang-miles
+# Source pins. All three are REQUIRED (no branch-HEAD fallback): with layer caching a
+# `git clone -b <branch>` instruction never changes text, so a moved branch would be
+# silently served from cache as last week's tree. docker/resolve_upstream.py resolves
+# current values; docker/build.py fills in any the caller didn't pass.
 ARG SGLANG_COMMIT=""
 
 ARG MEGATRON_REPO=radixark/Megatron-LM
-ARG MEGATRON_BRANCH=miles-main
+ARG MEGATRON_COMMIT=""
 
 ARG ENABLE_CUDA_13=1
 
@@ -29,6 +32,12 @@ ARG WHEELS_REPO=yueming-yuan/miles-wheels
 ARG TARGETARCH
 ARG WHEELS_TAG_X86=cu130-x86_64
 ARG WHEELS_TAG_ARM64=cu130-aarch64
+# REQUIRED per built arch: fingerprint of the rolling release's asset list (from
+# docker/resolve_upstream.py). Rolling tags keep their name while assets get replaced,
+# so this — referenced in the download RUN below — is what busts the layer cache when
+# the release content actually changed.
+ARG WHEELS_FP_X86=""
+ARG WHEELS_FP_ARM64=""
 
 # ======================================== Setup =============================================
 
@@ -59,11 +68,14 @@ RUN git clone https://github.com/NVIDIA/nccl-tests.git /tmp/nccl-tests && \
 COPY wheel[s]/ /tmp/wheels/
 
 RUN case "${TARGETARCH}" in \
-      amd64) WHEELS_TAG="${WHEELS_TAG_X86}" ;; \
-      arm64) WHEELS_TAG="${WHEELS_TAG_ARM64}" ;; \
+      amd64) WHEELS_TAG="${WHEELS_TAG_X86}"; WHEELS_FP="${WHEELS_FP_X86}" ;; \
+      arm64) WHEELS_TAG="${WHEELS_TAG_ARM64}"; WHEELS_FP="${WHEELS_FP_ARM64}" ;; \
       *) echo "unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
     esac && \
-    echo "Fetching wheels release ${WHEELS_TAG}" && \
+    if [ -z "${WHEELS_FP}" ]; then \
+      echo "wheels fingerprint build-arg for ${TARGETARCH} is required (docker/resolve_upstream.py provides it)" >&2; exit 1; \
+    fi && \
+    echo "Fetching wheels release ${WHEELS_TAG} (assets fingerprint ${WHEELS_FP})" && \
     mkdir -p /tmp/wheels && \
     curl -sL "https://api.github.com/repos/${WHEELS_REPO}/releases/tags/${WHEELS_TAG}" \
     | python3 -c "import sys,json,subprocess,os; w='/tmp/wheels'; \
@@ -95,8 +107,10 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 RUN --mount=type=cache,target=/root/.cache/pip \
     pip install --no-deps tile_kernels==1.0.0
 # FlashQLA backend for Qwen GDN linear-attention layers (requires SM90+, CUDA 12.8+, PyTorch 2.8+; built on tilelang above)
+# SHA-pinned like the other git installs: an unpinned HEAD install is invisible to the
+# layer cache, which would silently freeze whatever revision the layer last built.
 RUN --mount=type=cache,target=/root/.cache/pip \
-    pip install -v --no-build-isolation "git+https://github.com/QwenLM/FlashQLA.git"
+    pip install -v --no-build-isolation "git+https://github.com/QwenLM/FlashQLA.git@821fd9d37ede18fdc2a4e707fefe3770bfc32e58"
 # Prefer the prebuilt wheel; fall back to a source build while the current
 # arch's wheels release doesn't carry it yet (QEMU-emulated arm64 source
 # builds are the expensive path this avoids).
@@ -161,9 +175,14 @@ RUN if [ "${ENABLE_CUDA_13}" = "1" ] && [ -d /tmp/patches/cu13 ]; then \
 # apex
 RUN pip install /tmp/wheels/apex-*.whl
 
+# Clone without -b: miles-main may be rebased, and a full clone keeps the pinned SHA
+# reachable regardless; submodules sync after the checkout so they match the pin.
 RUN --mount=type=cache,target=/root/.cache/pip \
-    git clone https://github.com/${MEGATRON_REPO}.git --recursive -b ${MEGATRON_BRANCH} Megatron-LM && \
+    test -n "${MEGATRON_COMMIT}" || { echo "MEGATRON_COMMIT build-arg is required (docker/resolve_upstream.py provides it)" >&2; exit 1; } && \
+    git clone https://github.com/${MEGATRON_REPO}.git Megatron-LM && \
     cd Megatron-LM && \
+    git checkout ${MEGATRON_COMMIT} && \
+    git submodule update --init --recursive && \
     pip install -e .
 
 # Muon optimizer support: megatron/core/optimizer/muon.py requires this for Newton-Schulz
@@ -211,19 +230,18 @@ RUN rm -rf /root/.cache/pip /root/flash-attention
 
 # ====================================== Install sglang-miles ============================================
 
-# Install sglang from sglang-miles branch
+# Install sglang at the pinned sglang-miles commit. The SHA is fetched directly
+# (not via the branch name): the base image's clone is shallow and sglang-miles gets
+# rebased, so a branch fetch can't guarantee the pinned commit is reachable.
 # The CUDA 12 sglang images sed their dependency markers from cu13 to cu12 in
 # python/pyproject.toml and never commit it, so a plain checkout aborts on the dirty
 # file. Force it, then re-apply the same rewrite: the tree we just checked out carries
 # the cu13 markers, and sglang's editable install makes them visible to every later pip
 # resolve, which would drag cu13 packages onto a cu12 image.
-RUN cd /sgl-workspace/sglang && \
-    git fetch origin ${SGLANG_BRANCH} && \
-    if [ -n "${SGLANG_COMMIT}" ]; then \
-      git checkout -f ${SGLANG_COMMIT}; \
-    else \
-      git checkout -f FETCH_HEAD; \
-    fi && \
+RUN test -n "${SGLANG_COMMIT}" || { echo "SGLANG_COMMIT build-arg is required (docker/resolve_upstream.py provides it)" >&2; exit 1; } && \
+    cd /sgl-workspace/sglang && \
+    git fetch origin ${SGLANG_COMMIT} && \
+    git checkout -f ${SGLANG_COMMIT} && \
     if [ "${ENABLE_CUDA_13}" != "1" ]; then \
       sed -i 's/cuda-python>=13\.0/cuda-python>=12,<13/' python/pyproject.toml && \
       sed -i 's/flashinfer_python\[cu13\]/flashinfer_python[cu12]/' python/pyproject.toml && \
@@ -248,8 +266,9 @@ RUN if [ "${ENABLE_CUDA_13}" = "1" ]; then \
 
 # ====================================== Install main package ============================================
 
-ARG MILES_COMMIT=main
-RUN git clone https://github.com/radixark/miles.git /root/miles && \
+ARG MILES_COMMIT=""
+RUN test -n "${MILES_COMMIT}" || { echo "MILES_COMMIT build-arg is required (docker/resolve_upstream.py provides it)" >&2; exit 1; } && \
+    git clone https://github.com/radixark/miles.git /root/miles && \
     cd /root/miles && \
     git checkout ${MILES_COMMIT} && \
     pip install -e . --no-deps

--- a/docker/build-refactor-design.md
+++ b/docker/build-refactor-design.md
@@ -1,0 +1,134 @@
+# Miles Docker Build 重构设计（草稿）
+
+状态：讨论中的设计草稿。已定决策见 §3，未定分叉见 §6。证据基线：working tree `c2635a40d` + CI run [30503613452](https://github.com/radixark/miles/actions/runs/30503613452)（2026-07-30 schedule）。实现权限尚未授予——本文只记录决策，不代表任何改动已落地。
+
+参照系：`/sgl-workspace/sglang` 的 CI docker build 实践（`docker/Dockerfile`、`.github/workflows/_docker-build-and-publish.yml`、`release-whl-kernel.yml`、`_pr-test-sgl-kernel-build.yml`、`patch-docker-dev.yml`、`release-docker-dev.yml`）。
+
+## 1. 动机与决策
+
+### 1.1 实测成本（fact）
+
+- 一次自动构建的 `build-and-push` job 总计 **72 分钟**（cu13 多架构 44m + cu12-x86 27m），跑在 `["h200","2gpu"]` GPU runner 池上；触发频率 = 每天最多 2 次 cron + 每个 touch docker 路径的 main push；touch docker 的 PR 另占 ~44m（只建 cu13 的 `pr-<num>` tag）。
+- **零层缓存**：全 build 日志无一行 `CACHED`。原因：`setup-buildx-action` 的 `docker-container` driver 每次 run 新建一次性 builder，且 `docker/build.py` 无任何 `--cache-from/--cache-to`。哪怕只有 sglang-miles HEAD 动了（第 33/39 层），前面 32 层照样全部重跑。
+- cu13 的 44 分钟拆解：amd64 链 28.5m、arm64 链 41.6m（两链并行，wall clock 由 arm64 决定）+ 导出/推送 ~6.5m。
+- 单步 Top 3：mbridge pip install 在 amd64 上 13.7m（同步骤 arm64 仅 0.6m——纯 Python 包 20 倍差异 = 对 GitHub 的网络抖动，非计算）；nccl-tests 编译在 QEMU arm64 下 12.6m（x86 原生 1.4m，~9 倍 QEMU 惩罚）；基础镜像拉取每架构 2.5–2.8m。
+- cu12 与 cu13 零层共享（`FROM` tag 不同），27 分钟是完整第二遍。
+- 历史事故（fact，`docker/verify_transformer_engine.py` 注释）："a missing onnxscript shipped a green image that failed every GPU test"——scheduled build 盲推 `dev` tag，坏镜像的第一发现者是全 fleet 的红 CI。
+
+### 1.2 要决策的事
+
+把 miles 的 docker build 体系（`docker/Dockerfile` + `docker/build.py` + `docker-build.yml` + `pr-test.yml` 的 `docker-build` job）向 sglang 实践迁移，在不改变镜像内容契约的前提下压缩构建时长、消除 GPU 池占用、并把盲推改为有验证门的发布。
+
+### 1.3 成功标准
+
+- "只有上游 HEAD 动了"的常规重建从 72m 降到十几分钟量级（只重跑失效层）。
+- `requirements.txt` 改一行的重建不再连坐前面的重量层。
+- docker build 不再占用 CI 池的 GPU runner 槽位。
+- 坏镜像在 `dev` tag 晋升前被 GPU 冒烟门拦截。
+- 副产品：给定同一组 SHA 可复现同一镜像（回应 `docs/ci/02-docker-build.md` 悬置的 "Image retention (open)"）。
+
+## 2. 约束与非目标
+
+- **无原生 arm64 build 机器，短期不会有**（用户决策）。arm64 继续在 x86 机器上 QEMU 构建；优化方向是"让 QEMU 路径变薄"而非消除 QEMU。
+- **范围 = cu13 + cu12-x86**（用户决策）。ROCm 变体（`Dockerfile.rocm`、`rocm-*`）只保证不被破坏，不做优化。
+- **镜像内容契约不变**：装的东西、版本 pin 语义、`TARGETARCH` 分派 wheels 的机制保持等价。
+- **fleet 现实**：自建 runner 全是 GPU 机器；无 CPU-only build box（由此产生 §3.1 的共驻方案）。
+- 非目标：sglang 的 `workflow_call`/`tag_config` 重构（可维护性收益，非速度收益，本轮不做）；PR 侧 build 流程语义（`pr-<num>` tag、resolve-ci-image 逻辑）不动，只动它跑在哪、快不快。
+
+## 3. 已定决策
+
+每条含被否决的备选与理由。
+
+### 3.1 共驻 build node（选 B，弃 A）
+
+现 CI 机器中钉**若干台**（数量按池容量定，用户决策：可能好几台），各自加挂**第二个 runner 实例**，label `docker-build`；`docker-build.yml` 与 `pr-test.yml` 的 docker build job 的 runs-on 迁到该 label，build 落在任一 labeled 机器。机器不退出 CI 池（原 CI runner 实例照旧）。多台并存的附带收益：cu13 与 cu12-x86 可拆成两个并行 job 落不同 node，冷态 wall clock 由 72m（串行）回到 44m（取较长者）。
+
+- 依据（fact）：build 全程碰不到 GPU——buildx `docker-container` driver 不向 RUN 步骤暴露 GPU 设备，过去每次 44 分钟 build 本来就在无 GPU 沙箱里完成；`verify_transformer_engine.py` 只读 `importlib.metadata`，`TMS_CUDA_MAJOR` 读 torch 编译期常量，源码编译只需 nvcc。
+- 共存性（fact）：CI job 容器以 `--gpus all` 起（`_run-ci.yml:38`），纯设备映射无独占；默认 compute mode 下多进程共享一张卡成立。冒烟探针瞬时几百 MB、存活秒级，H200 141GB 余量下无 OOM 风险，无需选卡/等待逻辑。真正的 CI job 唯一性由原 CI runner 实例并发=1 保证。
+- 弃 A（整机退出 CI 池）：构建频率（每天 2–4 次 × 44–72m）不足以支付一台双卡 H200 的 24/7 独占；若日后观测到共驻干扰（build 编译负载拖慢同机 CI job），再升级到 A。
+- 一次性运维确认：build node 上 `nvidia-smi -q | grep "Compute Mode"` 应为 Default（若被设成 EXCLUSIVE_PROCESS/MIG 则探针共存不成立）。
+
+### 3.2 缓存后端：钉子机上的持久本地 builder（registry 缓存降为可选二级）
+
+build node 上预建持久命名 buildx builder，层缓存与 `--mount=type=cache` 内容跨 build 存活于本机。
+
+**自动 prune 卫生：推迟到后期**（用户决策：偏 heavy，放到后面做）。附加依据：sglang 的 `docker system prune -af --filter "until=72h"` 跑在专用 build node 上才安全；miles 的 build node 与 CI runner 共驻同一 docker daemon，`system prune` 会误删 CI job 复用的镜像（`radixark/miles:dev`、`pr-<num>` 等），逼 CI 重拉。日后磁盘有压力时的正确姿势是**只对命名 builder 单独** `docker buildx prune --builder <name> --filter "until=..."`（不触碰镜像存储），而非照搬 sglang 的 system prune。
+
+- 依据：sglang 本地持久缓存的前提是"build node 状态持久且定期轮到 build"（其 kernel wheel 构建钉在 `x64-kernel-build-node`，缓存在 `$HOME/.cache/sgl-kernel/buildx`）。§3.1 为多台 build node：每台各养一份本地缓存——层缓存不按时间过期，机器定期轮到 build 则稳定层常驻；代价是每台各付一次冷启动、磁盘各占一份、平均命中率随机器数稀释（build 落到久未轮到的机器就冷一截）。
+- 弃"registry 缓存为主"：本地缓存零网络开销、运维最简，少数几台机器轮换足够密时命中率可接受。registry 缓存（`--cache-to type=registry,mode=max` 推专用 cache tag）保留为二级，**启用条件具体化**：build node 数量增多或轮换稀疏导致命中率可感知下降时，或 fork PR/整组机器换代的灾备场景。
+- 参照系诚实记录（fact）：sglang **发布**镜像走 `--no-cache` 全冷（全仓 38 处），冷得起靠专用原生双架构 node + 并行 multi-stage + 重编译产物全 wheel 化；miles 无此硬件，层缓存是"专用硬件"的替代品。sglang 自己在受约束的高频路径（kernel wheel、rust CI）同样选择缓存。
+
+### 3.3 缓存失效：上游 SHA 作为 build-arg 注入（镜像变可复现构建）
+
+`check-upstream`（`docker-build.yml:69-99`）已在轮询 sglang-miles HEAD、Megatron miles-main HEAD、miles-wheels 各 rolling release 的资产指纹——现状只拿来做"要不要 build"的开关。改为：workflow 起始统一解析（sglang SHA、megatron SHA、miles SHA、wheels 指纹），经 `build.py` 透传为 build-arg；Dockerfile 对应层改为 `git checkout <SHA>`，wheels 下载层前置 `ARG WHEELS_FP` 作为缓存键。
+
+- 正确性论证：Docker 层缓存按"指令文本 + 父层"复用。现状 `git clone -b miles-main` 指令文本永不变而分支每天动——今天全冷构建掩盖了这个坑；开启层缓存后会静默复用旧 HEAD。SHA 进指令文本后：上游没动 → 命中且命中恒正确；动了 → 精确失效对应层往后。
+- 硬约束（无静默回退）：SHA build-arg 为空时 Dockerfile 必须显式失败，禁止回退到 branch HEAD——否则失效机制被静默绕过。
+- 弃"粗粒度 CACHE_BUST 参数"：clone 层之后永不命中，镜像仍不可复现。
+- 副产品：同一组 SHA → 同一镜像，可按历史 SHA 重建旧镜像；配合 image label 记录 SHA 组（参照 sglang `docker_build_metadata_args.py` 的 build-commit/build-url label 实践），回应 02 doc 的 retention 悬案。
+- 现状盘点（C3 已落地）：`SGLANG_COMMIT`/`MEGATRON_COMMIT`/`MILES_COMMIT` 均为必填 build-arg，空值硬失败；`WHEELS_FP_X86/ARM64` 按构建架构必填并被下载层引用为缓存键；解析逻辑单一来源 `docker/resolve_upstream.py`（CI 的 resolve-upstream job 与 build.py 本地自动补齐共用，指纹算法与旧 bash 逐字兼容）；wheels 指纹不由 workflow 静态传入而由 build.py 按 variant 解析（避免手动 dispatch cu12 拿到 cu13 指纹的缓存键错配）；残余未 pin 的 FlashQLA 已钉到 `821fd9d3`；`SGLANG_BRANCH`/`MEGATRON_BRANCH` args 删除（sglang 层直接 fetch SHA——基础镜像 clone 是 shallow 且 sglang-miles 会 rebase，按 branch fetch 不保证 SHA 可达；Megatron 改全量 clone + checkout + submodule 同步）。
+
+### 3.4 GPU 冒烟门：push 之前 `--load` 本地探针（C6 落地形态）
+
+实施时简化了机制：不做"先推 timestamped tag 再 imagetools 晋升"的两段式，而是 **push 之前**用同一 builder 缓存 `--load` 出 amd64 镜像到本机 docker，`docker run --gpus all` 跑 `docker/smoke_test.py`（`torch.cuda` + tensor 运算、TE/sglang/miles 真实 import、nccl-tests 二进制），探针不过则任何 tag 都不动。省掉晋升机制与 timestamped-tag 捕获，手动/自动路径统一过门；随后的 push build 全量命中 gate build 的层缓存，代价仅一次本地镜像导出 + 秒级探针（probe 后 `docker rmi` 释放）。
+
+- 边界（fact）：x86 node 只能冒烟 amd64 镜像；arm64 半边接受空缺，将来有 ARM GPU 机器再补；`rocm-*`/`cu13-aarch64` 跳过。冷构建的多架构 wall clock 略增（amd64+探针先行，arm64 随后，并行度让位于门的顺序性）。
+- GPU 在 build node 上的唯一角色就是这个门；build 本身仍然无 GPU。前置运维确认：各 build 节点 compute mode 应为 Default（`nvidia-smi -q | grep -i "compute mode"`）。
+
+### 3.5 层序重排 + 依赖单一清单 + 全面 cache mount（sglang deps/source 分层模式）
+
+参照 sglang 的两层拆分（`COPY python/pyproject.toml` + 空壳包装依赖层，源码 "LAST for better caching"）：
+
+- 层序按**变化频率升序**：稳定贵重层（apt、nccl-tests、wheels 安装、TE、apex）在前 → `requirements.txt` 依赖层居中 → 高频源码层押后（Megatron → sglang → miles → router）。目标：`requirements.txt` 改一行只重跑依赖层 + 其后的廉价源码层。
+- **pip 纪律（迁自 sglang，miles 场景下更彻底）**。sglang 的模式（fact）：全 Dockerfile 只在 `torch_deps` stage 放开求解一次（空壳包 `pip install ".[all]"`，行 249），随即 `pip freeze > constraints.txt` 冻结（行 259）；此后所有安装要么 `--no-deps`（9 处：kernel wheels、nixl、hpc-ops、最终 sglang editable 等），要么 `-c constraints.txt` 受限求解（行 594），pip 再无权移动环境。miles 连自己的大求解都没有——完整环境来自 `lmsysorg/sglang` 基础镜像，miles 的每次安装都属于"求解之后"，**默认桶就是 `--no-deps`**。
+- 收编桶型（C5 落地后的最终形态；实施时发现的边界修正见末句）：**快照即用即抛**——不设持久快照层，需要受限求解的层内就地 `pip list --format=freeze > constraints.txt` 后带 `-c` 安装（单 stage 下比 sglang 的持久 constraints 文件更简单且永远新鲜）；**no-deps 收编**分两处——release wheel 安装合并为一个 `pip install --no-deps` 层（flash-attn、flash_attn_3、apex、fake_int4；requirements 文件不支持 glob 故留在 RUN），deps 已在 base 的散包收进 `docker/requirements-nodeps.txt` 单层装完（mbridge、megatron-energon、multi-storage-client、tile_kernels——全部本就 `--no-deps`，零语义变化）；**受限求解桶**——`-r requirements.txt -c <就地 freeze>`，以及 Megatron 的 `pip install -e . -c`，冻结件冲突响亮失败而非静默重装。语义修正（首次真跑触发）：freeze 时排除 requirements.txt 自身命名的包——其显式 pin 是 miles 的契约，有权覆盖 base 版本（实例：requirements pin `xxhash==3.7.1` vs base 的 3.8.1，旧流程一直在静默降级，全量 freeze 会把这个合法覆盖一起否决）；constraints 只封"传递求解动了不相关的包"；**保留独立层**——真依赖序或特殊 flag（FlashQLA 在 tilelang 后且 `--no-build-isolation`，TE 三件套事务，tilelang 自定义 index，modelopt/Megatron-Bridge 带 flag，fallback 条件层，flash-linear-attention 与 Emerging-Optimizers 亦保留独立层）。**边界修正**：`requirements.txt` 被 setup.py 的 install_requires、CPU CI、用户安装文档共同消费，不能塞入镜像专属的 git-URL/基础设施 pin——fla 和 Emerging-Optimizers 因此不进 requirements.txt。形态说明：sglang 对散包用 Dockerfile 内联清单（一行一包 + `-c`），无 requirements 文件；文件化收编是 miles 本地化选择，两种形态缓存失效语义等价。
+- 现状隐患（本桶型消除的）：裸 `-r requirements.txt` 有权静默重装前面层的关键件（如新依赖与已装 torch 版本约束冲突时）——今天不出事仅因约束恰好满足。
+- 所有 apt/pip 步骤加 `--mount=type=cache`（持久 builder 下真正跨 build 存活）；删除 `rm -rf /root/.cache/pip` 层。
+- **wheels release 下载缓存 mount**（用户提议，采纳并修正）：下载步骤挂 `--mount=type=cache,target=/wheels-cache`，缺的资产下进缓存后 cp 进层内 `/tmp/wheels`。两个必要修正：(a) 现有 skip-if-exists 必须升级为**资产同一性检查**（按 release API 已解析的 asset `id` 比对；rolling release 同名重传是常态——check-upstream 的指纹机制即为此而生——否则持久 mount + skip-if-exists = 永久装旧 wheel 的静默事故）；(b) mount 不能直接盖 `/tmp/wheels`（会遮蔽 `COPY wheel[s]/` 本地 wheel 工作流，且 cache mount 只在声明它的 RUN 内可见，后续 `pip install /tmp/wheels/...` 层看不到）。边界与分工模型：层缓存缓存**计算**（命中=整步不执行，正确性由 BuildKit 键保证，故需 SHA 进指令文本）；cache mount 缓存**数据**（RUN 每次执行，新鲜度责任在 RUN 内程序——pip/apt 自带校验逻辑所以直接挂，curl 脚本必须自补 asset-id 检查）。判据：pull 下来的数据归 mount，装好之后的状态归层缓存。此 mount 省的是指纹变化时未变资产的重下（分钟级），不替代层缓存对安装/编译层的跳过。
+- miles 依赖清单现状（fact）：`requirements.txt` 是唯一运行时清单（`pyproject.toml` 无 dependencies 段，miles 自身 `pip install -e . --no-deps`）——地基已对，缺的是层位置和收编。
+
+### 3.6 显式架构声明
+
+Dockerfile 增加 `ARG TORCH_CUDA_ARCH_LIST`（含 nccl-tests 的对应 `NVCC_GENCODE`），按 miles 实际 fleet 收窄。矩阵宽窄待拍板（§6）。
+
+- 现状（fact）：Dockerfile 零架构声明；源码编译走各家无 GPU fallback（torch cpp_extension 探测不到 GPU 时编译全部支持架构；nccl-tests Makefile 按 CUDA 版本全架构 gencode）——能跑通但又慢又肥，QEMU 下 12.6m 的 nccl-tests 大半在编译用不到的架构。
+- 原则（对齐 sglang docker/Dockerfile:319-334）：发布镜像的架构支持是**声明的契约**，不是构建机探测的结果；靠本机 GPU 探测对发布镜像本来就是错误做法。运行时由 CUDA runtime 按实际卡从 fatbin 选 cubin/JIT PTX。
+
+## 4. 设计要点（机制细节）
+
+- **runner 拓扑**：每台 build node（H200 机器，若干台）= 原 CI runner 实例（label 照旧，接 CI job，并发 1）+ 新 build runner 实例（label `docker-build`，接 docker build job，并发 1）。单机上 build 串行排队；跨机器可并行（cu13/cu12 拆 job）。compute mode 一次性确认（§3.1）对每台 labeled 机器执行。
+- **SHA 解析点**：workflow 单一步骤解析全部上游引用（schedule/push/dispatch 三种触发统一走这条路），输出 SHA 组 → 既做 should_build 判断（对比缓存的上次值，逻辑不变）又做 build-arg 注入 + image label。
+- **`build.py` 改动**：只加两个真实需要的通道——透传任意 `--build-arg`（SHA 注入的硬前提；02 doc 已记录此缺口）、接持久 builder（`--builder <name>`，显式优于机器侧 `buildx use` 的有状态默认）。不预置 `--cache-to/--cache-from` 参数——registry 二级缓存按 §3.2 条件触发时再加，不留投机口子。改 build.py 而非 workflow 裸写 buildx 的原因：build.py 是既定的 buildx 唯一咽喉（single source of truth），绕开它会把 truth 劈进 workflow YAML、并使本地与 CI 构建路径分叉。
+- **QEMU 原则（迁自 sglang）**："编译必须原生，薄层随便 QEMU"。sglang 自己在 ubuntu-latest 上 QEMU 构建多架构 overlay 镜像（`release-docker-dev.yml`，现场生成 `FROM 镜像 + snippet` 两行 Dockerfile）——QEMU 可接受的条件是层里无编译。miles 的 arm64 链在 P2（§6 wheel 化）完成后退化为此类薄层。
+- **cu13/cu12 关系（fact）**：`FROM` tag 不同 → 零层共享，缓存各自独立；两者在同一钉子机上串行（warm 后各自收缩，串行可接受）。
+
+## 5. 实施切分与验证
+
+进度：PR-1 已落地（`18e1c4e70` runs-on 迁移 + `ec2a73cbe` 移除宿主机 apt/pip 变更、build.py 转 stdlib-only——首次真跑暴露的必要补刀）；PR-2 已落地（`3fdf5e8f2` SHA/指纹必填 pin + 单一解析器 `docker/resolve_upstream.py`；`7250cb459` 持久 `miles-builder` 开启缓存，实测同节点同输入 8min→10s、38/38 层命中）；PR-3 已落地（层序重排 + 桶收编 + 全面 cache mount + `docker/fetch_wheels.py` 资产 id 校验的下载缓存；constraints 防线两轮真实拦截：xxhash 契约覆盖、cudnn 归位 post-resolve overrides 尾部）；PR-4 已落地（`docker/smoke_test.py` + push 前 `--load` 冒烟门，见 §3.4 落地形态）。以下为原始切分记录。
+
+1. **PR-1 机器迁移**：build node 双 runner 实例 + runs-on 切换。此刀**不开层缓存**（builder 保持一次性或显式 `--no-cache`），因为 SHA 注入未落地前层缓存不安全。收益：GPU 池占用归零。验证：一次 dispatch build 全绿，产物 digest 与旧路径等价（`pip freeze` diff 为空）。
+2. **PR-2 SHA 注入 + 开启持久缓存**：`check-upstream` 重构为统一解析步骤，`build.py` 透传 build-args，Dockerfile clone 层改 SHA checkout（空 SHA 硬失败），建持久 builder（不带自动 prune，见 §3.2）。验证：同 SHA 组连打两次，第二次近全命中且 wall clock 达标；伪造单个 SHA 变化，确认只有预期层失效；`pip freeze` diff 为空。
+3. **PR-3 层序重排 + 收编 + cache mount**：§3.5 全部。验证：`requirements.txt` 改一行 → 重量层全命中；镜像内容等价性同上。
+4. **PR-4 GPU 冒烟门**：探针集 + 晋升逻辑。验证：人为破坏（如构建时卸掉 onnxscript）必须拦截。
+5. **PR-5 架构声明**：`TORCH_CUDA_ARCH_LIST`/`NVCC_GENCODE`。验证：编译时长下降；探针在 H200 实卡通过。
+6. **后续独立轨道**：P2 wheel 化（见 §6）；builder 缓存 prune 卫生（§3.2 推迟项——磁盘水位有信号后再做，形态为对命名 builder 单独 `buildx prune`）。
+
+通用验证口径：每刀前后各留一次完整 build 的分段耗时（本文 §1.1 的解析脚本可复用），镜像内容等价 = `pip freeze` diff + 关键二进制/入口存在性清单。
+
+## 6. 未定分叉与待讨论
+
+- **multi-stage 并行改造**（§3 未讨论）：miles 39 层串行链是否拆 sglang 式并行 builder stage + `COPY --from` 收集。与 §3.5 层序重排有重叠收益，需评估在"增量镜像"（基于 lmsysorg/sglang 而非裸 CUDA）场景下的边际收益是否值得复杂度。
+- **P2：QEMU 源码编译 wheel 化**（§3 未讨论）：nccl-tests、FlashQLA、fast-hadamard（arm64 fallback 路径）、TMS 等进 miles-wheels 预编译发布，使 arm64 链退化为纯装 wheel 薄层。涉及 miles-wheels repo 的构建矩阵扩展，独立轨道。附带收益：§3.5 "保留独立层"中 build 期 import 依赖类（FlashQLA 须 tilelang 先装、TMS 须 torch 在场——源码构建 `--no-build-isolation` 在当前环境跑 setup.py 所致）随 wheel 化消失，全部退化为 no-deps 桶成员；最终独立层只剩事务性替换类（TE 三件套 uninstall→triplet→补依赖→verify、mooncake/router force-reinstall、TE patch）。
+- **`TORCH_CUDA_ARCH_LIST` 矩阵宽窄**：只覆盖现役 fleet（最快最小）vs 保守全谱（现状等价，无提速）。
+- **冒烟探针集定稿**：最小集合 vs 加轻量端到端（如 sglang server 起停）。
+- **散装 pip 层收编清单**：逐包核对 flag/顺序约束后出最终清单。
+- **cu12-x86 的构建频率**：是否维持每次自动构建都跟建，或降为按需/低频（零层共享使它永远是全价构建）。
+- **mbridge 类网络抖动**（13.7m 异常）：层缓存命中后大幅摊薄；残余风险可加 pip retry 配置，暂不单独立项。
+
+## 7. 风险
+
+- **缓存稀释与冷启动**（多台 build node 形态）：单机故障不再是单点（其余 labeled 机器接管，冷但可用），代价转为每台一份冷启动与命中率稀释；机器数与轮换密度失衡时按 §3.2 条件启用 registry 二级缓存。磁盘水位按 §3.2 推迟项处理。
+- **共驻干扰**：build 编译负载（`make -j$(nproc)` 等）拖慢同机 CI job。缓解：观测；恶化则升级为方案 A（整机退出 CI 池）或限制 build 并发核数。
+- **SHA 注入接线错误**：空值/错值静默回退到 branch HEAD 会让缓存失效机制形同虚设——设计上以"空 SHA 硬失败"封死，实现时作为验收项。
+- **层缓存膨胀**：持久 builder 缓存无自动 prune（§3.2 决策）会缓慢增长——接受为已知风险，观测 build node 磁盘水位；触线时对命名 builder 单独 `buildx prune`，禁止在共驻机上 `docker system prune`。
+- **arm64 验证空缺**：冒烟门只覆盖 amd64；arm64 坏镜像仍可能盲推。接受并记录，待 ARM GPU 机器补齐。

--- a/docker/build.py
+++ b/docker/build.py
@@ -103,6 +103,7 @@ def build_and_push(
     push: bool = False,
     custom_tag: str = "",
     build_args: list[str] | None = None,
+    builder: str = "",
 ) -> None:
     config = VARIANTS[variant]
     # A variant may pin its own Dockerfile (e.g. ROCm); otherwise use the CLI default.
@@ -131,6 +132,11 @@ def build_and_push(
         "-f",
         dockerfile,
     ]
+
+    # Explicit builder selection (CI passes its persistent node-local builder);
+    # stateful `docker buildx use` defaults stay out of the picture.
+    if builder:
+        cmd += ["--builder", builder]
 
     if platforms:
         cmd += ["--platform", ",".join(platforms)]
@@ -211,6 +217,7 @@ def main() -> None:
         metavar="KEY=VALUE",
         help="Extra KEY=VALUE forwarded to docker buildx build (repeatable).",
     )
+    parser.add_argument("--builder", default="", help="buildx builder to use (default: current).")
     args = parser.parse_args()
     build_and_push(
         args.variant,
@@ -220,6 +227,7 @@ def main() -> None:
         push=args.push,
         custom_tag=args.custom_tag,
         build_args=args.build_args,
+        builder=args.builder,
     )
 
 

--- a/docker/build.py
+++ b/docker/build.py
@@ -15,6 +15,8 @@ import subprocess
 from datetime import datetime, timezone
 from pathlib import Path
 
+import resolve_upstream
+
 CACHE_DIR = "/tmp/miles-docker-cache"
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
@@ -154,6 +156,32 @@ def build_and_push(
         if "=" not in arg or not arg.split("=", 1)[0]:
             raise SystemExit(f"--build-arg expects KEY=VALUE, got {arg!r}")
         cmd += ["--build-arg", arg]
+
+    # Pinned inputs docker/Dockerfile refuses to build without (see its ARG block).
+    # CI passes the source SHAs it gated on; whatever the caller didn't pass — always
+    # the per-variant wheels fingerprints, everything on a local build — is resolved
+    # here, so one command still builds and every pin is printed.
+    if dockerfile == "docker/Dockerfile":
+        provided = set(config.get("build_args", {}))
+        provided |= {arg.split("=", 1)[0] for arg in build_args or []}
+        for arg_name, (repo, branch) in resolve_upstream.SOURCE_PINS.items():
+            if arg_name in provided:
+                continue
+            sha = resolve_upstream.git_branch_head(repo, branch)
+            print(f"resolved {arg_name}={sha} ({repo}@{branch})", flush=True)
+            cmd += ["--build-arg", f"{arg_name}={sha}"]
+        # Tag defaults mirror the Dockerfile's WHEELS_TAG_* ARGs; variants override via build_args.
+        wheels_fp_args = {
+            "linux/amd64": ("WHEELS_FP_X86", config.get("build_args", {}).get("WHEELS_TAG_X86", "cu130-x86_64")),
+            "linux/arm64": ("WHEELS_FP_ARM64", config.get("build_args", {}).get("WHEELS_TAG_ARM64", "cu130-aarch64")),
+        }
+        for platform in platforms or []:
+            arg_name, tag = wheels_fp_args[platform]
+            if arg_name in provided:
+                continue
+            fp = resolve_upstream.wheels_fingerprint(tag)
+            print(f"resolved {arg_name}={fp} (wheels release {tag})", flush=True)
+            cmd += ["--build-arg", f"{arg_name}={fp}"]
 
     for tag in tags:
         cmd += ["-t", tag]

--- a/docker/build.py
+++ b/docker/build.py
@@ -94,7 +94,13 @@ def run(cmd: list[str], dry_run: bool) -> None:
 
 
 def build_and_push(
-    variant: str, image_tag: str, dry_run: bool, dockerfile: str, push: bool = False, custom_tag: str = ""
+    variant: str,
+    image_tag: str,
+    dry_run: bool,
+    dockerfile: str,
+    push: bool = False,
+    custom_tag: str = "",
+    build_args: list[str] | None = None,
 ) -> None:
     config = VARIANTS[variant]
     # A variant may pin its own Dockerfile (e.g. ROCm); otherwise use the CLI default.
@@ -142,6 +148,13 @@ def build_and_push(
     for key, value in config.get("build_args", {}).items():
         cmd += ["--build-arg", f"{key}={value}"]
 
+    # Caller-resolved extras (e.g. CI-resolved upstream SHAs / wheels fingerprints).
+    # Appended last so an explicit passthrough wins over a variant default.
+    for arg in build_args or []:
+        if "=" not in arg or not arg.split("=", 1)[0]:
+            raise SystemExit(f"--build-arg expects KEY=VALUE, got {arg!r}")
+        cmd += ["--build-arg", arg]
+
     for tag in tags:
         cmd += ["-t", tag]
 
@@ -162,6 +175,14 @@ def main() -> None:
     parser.add_argument("--dry-run", action="store_true", help="Print commands without executing them.")
     parser.add_argument("--push", action="store_true", help="Push images to registry after building.")
     parser.add_argument("--custom-tag", default="", help="Custom tag name (required when --image-tag is custom).")
+    parser.add_argument(
+        "--build-arg",
+        dest="build_args",
+        action="append",
+        default=[],
+        metavar="KEY=VALUE",
+        help="Extra KEY=VALUE forwarded to docker buildx build (repeatable).",
+    )
     args = parser.parse_args()
     build_and_push(
         args.variant,
@@ -170,6 +191,7 @@ def main() -> None:
         args.dockerfile,
         push=args.push,
         custom_tag=args.custom_tag,
+        build_args=args.build_args,
     )
 
 

--- a/docker/build.py
+++ b/docker/build.py
@@ -9,13 +9,11 @@ Usage:
     python docker/build.py --variant cu13 --image-tag dev --dry-run
 """
 
+import argparse
 import os
 import subprocess
 from datetime import datetime, timezone
-from enum import Enum
 from pathlib import Path
-
-import typer
 
 CACHE_DIR = "/tmp/miles-docker-cache"
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -113,10 +111,10 @@ def build_and_push(
         tags = [f"{image}:{prefix}{postfix}", f"{image}:{prefix}{postfix}-{timestamp}"]
     elif image_tag == "custom":
         if not custom_tag:
-            raise typer.BadParameter("--custom-tag is required when --image-tag is custom")
+            raise SystemExit("--custom-tag is required when --image-tag is custom")
         tags = [f"{image}:{custom_tag}{postfix}"]
     else:
-        raise typer.BadParameter(f"Unknown image tag: {image_tag}")
+        raise SystemExit(f"Unknown image tag: {image_tag}")
 
     cmd = [
         "docker",
@@ -154,32 +152,26 @@ def build_and_push(
     run(cmd, dry_run)
 
 
-class Variant(str, Enum):
-    cu13 = "cu13"
-    cu13_x86 = "cu13-x86"
-    cu13_aarch64 = "cu13-aarch64"
-    cu12_x86 = "cu12-x86"
-    rocm700_mi35x = "rocm700-mi35x"
-    rocm700_mi30x = "rocm700-mi30x"
-    rocm720_mi35x = "rocm720-mi35x"
-
-
-class ImageTag(str, Enum):
-    latest = "latest"
-    dev = "dev"
-    custom = "custom"
-
-
-def main(
-    variant: Variant = typer.Option(..., help="Build variant to use."),  # noqa: B008
-    image_tag: ImageTag = typer.Option(..., help="Tag mode: latest, dev, or custom."),  # noqa: B008
-    dockerfile: str = typer.Option("docker/Dockerfile", help="Path to the Dockerfile."),  # noqa: B008
-    dry_run: bool = typer.Option(False, help="Print commands without executing them."),  # noqa: B008
-    push: bool = typer.Option(False, help="Push images to registry after building."),  # noqa: B008
-    custom_tag: str = typer.Option("", help="Custom tag name (required when --image-tag is custom)."),  # noqa: B008
-) -> None:
-    build_and_push(variant.value, image_tag.value, dry_run, dockerfile, push=push, custom_tag=custom_tag)
+# stdlib-only on purpose: this runs on bare build nodes (docker + stock python3),
+# so it must not require pip-installing anything on the host.
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Build and push Miles Docker images.")
+    parser.add_argument("--variant", required=True, choices=list(VARIANTS), help="Build variant to use.")
+    parser.add_argument("--image-tag", required=True, choices=["latest", "dev", "custom"], help="Tag mode.")
+    parser.add_argument("--dockerfile", default="docker/Dockerfile", help="Path to the Dockerfile.")
+    parser.add_argument("--dry-run", action="store_true", help="Print commands without executing them.")
+    parser.add_argument("--push", action="store_true", help="Push images to registry after building.")
+    parser.add_argument("--custom-tag", default="", help="Custom tag name (required when --image-tag is custom).")
+    args = parser.parse_args()
+    build_and_push(
+        args.variant,
+        args.image_tag,
+        args.dry_run,
+        args.dockerfile,
+        push=args.push,
+        custom_tag=args.custom_tag,
+    )
 
 
 if __name__ == "__main__":
-    typer.run(main)
+    main()

--- a/docker/build.py
+++ b/docker/build.py
@@ -101,6 +101,7 @@ def build_and_push(
     dry_run: bool,
     dockerfile: str,
     push: bool = False,
+    load: bool = False,
     custom_tag: str = "",
     build_args: list[str] | None = None,
     builder: str = "",
@@ -143,6 +144,10 @@ def build_and_push(
 
     if push:
         cmd += ["--push"]
+    if load:
+        if platforms and len(platforms) > 1:
+            raise SystemExit("--load requires a single-platform variant (buildx cannot load a manifest list)")
+        cmd += ["--load"]
 
     # Proxy args (pass through if set in environment, check both cases)
     for arg_name in ["HTTP_PROXY", "HTTPS_PROXY"]:
@@ -218,6 +223,11 @@ def main() -> None:
         help="Extra KEY=VALUE forwarded to docker buildx build (repeatable).",
     )
     parser.add_argument("--builder", default="", help="buildx builder to use (default: current).")
+    parser.add_argument(
+        "--load",
+        action="store_true",
+        help="Load the image into the local docker store (single-platform variants only).",
+    )
     args = parser.parse_args()
     build_and_push(
         args.variant,
@@ -225,6 +235,7 @@ def main() -> None:
         args.dry_run,
         args.dockerfile,
         push=args.push,
+        load=args.load,
         custom_tag=args.custom_tag,
         build_args=args.build_args,
         builder=args.builder,

--- a/docker/fetch_wheels.py
+++ b/docker/fetch_wheels.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+# doc-dev: docs/ci/02-docker-build.md
+"""Populate /tmp/wheels from a miles-wheels release, via a persistent download cache.
+
+Runs inside the wheels-download layer of docker/Dockerfile with:
+  - /tmp/release.json        the GitHub release API response for the selected tag
+  - $CACHE_DIR               a per-arch subdir of the /wheels-cache cache mount
+  - /tmp/wheels              destination; pre-existing files (a locally COPY'd
+                             wheel from <repo>/wheels/) win over the download
+
+A cached asset is reused only when its recorded release asset id matches: rolling
+releases replace assets under the same filename, so existence alone would pin
+stale wheels forever. The layer itself re-runs whenever the WHEELS_FP build-arg
+changes; this cache only saves re-downloading the assets that did not change.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+
+cache = os.environ["CACHE_DIR"]
+dest = "/tmp/wheels"
+
+for asset in json.load(open("/tmp/release.json")).get("assets", []):
+    name = asset["name"]
+    if not name.endswith((".whl", ".tar.gz")):
+        continue
+    if os.path.exists(os.path.join(dest, name)):
+        print(f"{name}: using locally provided copy")
+        continue
+    cached = os.path.join(cache, name)
+    marker = os.path.join(cache, name + ".id")
+    asset_id = str(asset["id"])
+    if os.path.exists(cached) and os.path.exists(marker) and open(marker).read().strip() == asset_id:
+        print(f"{name}: cache hit (asset id {asset_id})")
+    else:
+        print(f"{name}: downloading (asset id {asset_id})")
+        subprocess.run(
+            ["curl", "-fSL", "--retry", "3", "-o", cached, asset["browser_download_url"]],
+            check=True,
+        )
+        with open(marker, "w") as f:
+            f.write(asset_id)
+    shutil.copy(cached, os.path.join(dest, name))

--- a/docker/requirements-nodeps.txt
+++ b/docker/requirements-nodeps.txt
@@ -1,3 +1,7 @@
+# Installed by docker/Dockerfile in one layer with `pip install --no-deps -r`:
+# every entry's runtime deps are already satisfied by the base image or earlier
+# layers, and --no-deps keeps pip from re-negotiating the environment (see
+# docker/build-refactor-design.md §3.5). Not consumed outside the image build.
 git+https://github.com/ISEEKYAN/mbridge.git@89eb10887887bc74853f89a4de258c0702932a1c
 megatron-energon
 multi-storage-client

--- a/docker/requirements-nodeps.txt
+++ b/docker/requirements-nodeps.txt
@@ -1,0 +1,4 @@
+git+https://github.com/ISEEKYAN/mbridge.git@89eb10887887bc74853f89a4de258c0702932a1c
+megatron-energon
+multi-storage-client
+tile_kernels==1.0.0

--- a/docker/resolve_upstream.py
+++ b/docker/resolve_upstream.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+# doc-dev: docs/ci/02-docker-build.md
+"""Resolve the upstream inputs a Miles image bakes.
+
+Single source of truth for CI (docker-build.yml's resolve-upstream job) and for
+local builds (docker/build.py fills in any pinned build-arg it wasn't given).
+Prints one KEY=VALUE line per input; any unresolvable value is a hard error —
+the build must never fall back to an unpinned branch HEAD.
+"""
+
+import argparse
+import hashlib
+import json
+import subprocess
+import urllib.request
+
+WHEELS_REPO = "yueming-yuan/miles-wheels"
+
+# Dockerfile build-arg -> (repo, branch) for the source trees the image checks out.
+SOURCE_PINS = {
+    "SGLANG_COMMIT": ("sgl-project/sglang", "sglang-miles"),
+    "MEGATRON_COMMIT": ("radixark/Megatron-LM", "miles-main"),
+    "MILES_COMMIT": ("radixark/miles", "main"),
+}
+
+# CLI output key (consumed as resolve-upstream job outputs) per build-arg.
+OUTPUT_KEYS = {
+    "SGLANG_COMMIT": "sglang_sha",
+    "MEGATRON_COMMIT": "megatron_sha",
+    "MILES_COMMIT": "miles_sha",
+}
+
+# CLI output key -> wheels release tag, for every rolling release the automatic
+# builds install (cu13 multi-arch + cu12-x86).
+WHEELS_TAG_OUTPUTS = {
+    "wheels_fp_cu13_x86": "cu130-x86_64",
+    "wheels_fp_cu13_arm64": "cu130-aarch64",
+    "wheels_fp_cu12_x86": "cu129-x86_64",
+}
+
+
+def git_branch_head(repo: str, branch: str) -> str:
+    out = subprocess.run(
+        ["git", "ls-remote", f"https://github.com/{repo}.git", f"refs/heads/{branch}"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.split()
+    if not out:
+        raise SystemExit(f"no such branch: {repo}@{branch}")
+    return out[0]
+
+
+def wheels_fingerprint(tag: str) -> str:
+    """Fingerprint a rolling release's asset list (name/id/size/updated_at).
+
+    Rolling tags keep their name while assets get replaced, so the asset list — not
+    a commit SHA — is what identifies the release content. Must stay byte-compatible
+    with the fingerprints stored by resolve-upstream's rebuild gate.
+    """
+    url = f"https://api.github.com/repos/{WHEELS_REPO}/releases/tags/{tag}"
+    with urllib.request.urlopen(url) as resp:
+        assets = json.load(resp).get("assets", [])
+    if not assets:
+        raise SystemExit(f"wheels release {tag} has no assets")
+    fp = sorted([a["name"], a["id"], a["size"], a["updated_at"]] for a in assets)
+    return hashlib.sha256(repr(fp).encode()).hexdigest()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--miles-sha",
+        default="",
+        help="Use this miles commit instead of resolving main HEAD (CI passes the pushed commit).",
+    )
+    args = parser.parse_args()
+
+    for arg_name, (repo, branch) in SOURCE_PINS.items():
+        key = OUTPUT_KEYS[arg_name]
+        if arg_name == "MILES_COMMIT" and args.miles_sha:
+            print(f"{key}={args.miles_sha}")
+            continue
+        print(f"{key}={git_branch_head(repo, branch)}")
+    for key, tag in WHEELS_TAG_OUTPUTS.items():
+        print(f"{key}={wheels_fingerprint(tag)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/docker/smoke_test.py
+++ b/docker/smoke_test.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+# doc-dev: docs/ci/02-docker-build.md
+"""GPU smoke probe for a freshly built Miles image.
+
+Runs inside the image (docker run --gpus) on a build node, before anything is
+pushed. Seconds-scale sanity only — the deep verification is the CI suite; this
+gate exists for the failure class where a green build ships a broken runtime
+environment (e.g. TE once imported fine at build time but died at first use in
+every GPU job because a --no-deps install dropped onnxscript).
+"""
+
+import os
+
+import torch
+
+assert torch.cuda.is_available(), "no CUDA device visible in the image"
+x = torch.ones(8, device="cuda")
+assert float(x.sum()) == 8.0, "CUDA tensor math broken"
+
+import sglang  # noqa: E402,F401
+
+# The real TE import (not just metadata): pulls in onnxscript and friends.
+import transformer_engine.pytorch  # noqa: E402,F401
+
+import miles  # noqa: E402,F401
+
+assert os.path.exists("/usr/local/bin/all_reduce_perf"), "nccl-tests binaries missing"
+
+print(f"smoke OK: torch {torch.__version__}, cuda {torch.version.cuda}, " f"device {torch.cuda.get_device_name(0)}")

--- a/docs/ci/02-docker-build.md
+++ b/docs/ci/02-docker-build.md
@@ -76,7 +76,7 @@ Non-docker PRs are untouched: `docker-paths` reports no change, `docker-build` s
 The only automated builder of `radixark/miles`. Two jobs:
 
 - **`check-upstream`** (schedule / `simulate_schedule` only) — polls the inputs the image bakes: the HEAD SHA of sglang `sglang-miles` (`sgl-project/sglang`) and Megatron-LM `miles-main` (`radixark/Megatron-LM`) — the source branches it builds — plus a fingerprint of the selected `yueming-yuan/miles-wheels` rolling release, so a rebuilt sgl-router or other wheel also triggers a build (re-uploads to the same tag are caught by fingerprint, not commit SHA). It compares against the values cached from the last build and sets `should_build=true` if any moved. `miles` itself is intentionally not polled — that would rebuild far too often. This is what stops the 12-hour cron from rebuilding an unchanged image, with one staleness bound: because the image also bakes a `miles` checkout, `should_build` is forced to `true` once the last triggered build is **24h** old, so `dev` never drifts more than a day behind the `miles` repo even when sglang / Megatron / wheels are quiet. (The cache file's last line records the epoch of the last triggered build; it is only re-saved when a build fires.)
-- **`build-and-push`** (self-hosted runner) — calls `docker/build.py` to build + push, then conditionally points `latest` at the new `dev` and prunes old timestamped tags.
+- **`build-and-push`** (self-hosted `docker-build` runner) — calls `docker/build.py` to build + push, then conditionally points `latest` at the new `dev` and prunes old timestamped tags.
 
 `build-and-push` runs when `check-upstream` was skipped, or ran and reported `should_build=true`.
 

--- a/docs/ci/02-docker-build.md
+++ b/docs/ci/02-docker-build.md
@@ -63,7 +63,7 @@ A multi-arch build (`cu13`) needs Buildx's `docker-container` driver and is push
 
 Dockerfile changes are build-tested on the PR itself, before merge — `docker-build.yml` only runs after a push to `main`, so without this breakage lands on `main` first.
 
-When a PR touches `docker/Dockerfile`, `docker/build.py`, `docker/resolve_upstream.py`, `docker/fetch_wheels.py`, `docker/requirements-nodeps.txt`, `docker/verify_transformer_engine.py`, `docker/patch/**`, or `requirements.txt` (detected by the `docker-paths` job), `pr-test.yml` inserts a build in front of the test matrix:
+When a PR touches `docker/Dockerfile`, `docker/build.py`, `docker/resolve_upstream.py`, `docker/fetch_wheels.py`, `docker/smoke_test.py`, `docker/requirements-nodeps.txt`, `docker/verify_transformer_engine.py`, `docker/patch/**`, or `requirements.txt` (detected by the `docker-paths` job), `pr-test.yml` inserts a build in front of the test matrix:
 
 | Job | What it does |
 | --- | --- |
@@ -132,9 +132,10 @@ gh workflow run docker-build.yml -f variant=cu13-x86 -f image_tag=custom -f cust
 ### Steps (`build-and-push`)
 
 1. checkout → ensure the persistent `miles-builder` buildx builder (node-local layer cache; created once per node, reused by every build including PR builds) → Docker Hub login. No host package installs: `build.py` is stdlib-only, so build nodes need just docker and stock `python3`.
-2. **Build + push** via `build.py` — automatic runs build **both** `cu13` and `cu12-x86`; a manual dispatch builds only the one variant you picked.
-3. **schedule only** — point `latest`→`dev` and `latest-cu12`→`dev-cu12`.
-4. **schedule only** — prune each timestamp series to the newest 20.
+2. **GPU smoke gate** — before anything is pushed, the amd64 image is `--load`ed from the builder cache and booted on the build node's GPU running `docker/smoke_test.py` (CUDA visible + tensor math, real TE/sglang/miles imports, nccl-tests binaries). A broken image never reaches a tag; the CUDA-variant builds all pass through it (arm64 halves ship unprobed — no ARM GPU nodes; `rocm-*` and `cu13-aarch64` skip it).
+3. **Build + push** via `build.py` — automatic runs build **both** `cu13` and `cu12-x86` (amd64 layers all cache hits from the gate build); a manual dispatch builds only the one variant you picked.
+4. **schedule only** — point `latest`→`dev` and `latest-cu12`→`dev-cu12`.
+5. **schedule only** — prune each timestamp series to the newest 20.
 
 ### Push auth & permissions
 

--- a/docs/ci/02-docker-build.md
+++ b/docs/ci/02-docker-build.md
@@ -34,7 +34,7 @@ The Dockerfile is the build recipe: it provides the cu13 defaults and emits one 
 | `MEGATRON_REPO`, `SGL_ROUTER_*`                                                                        | remaining source knobs for the layered repos                                                                                                                                                                                                                                                                                                          |
 
 
-**Output** — one `radixark/miles` image for the platform buildx targets: the sglang base, then the Python dependencies declared in `requirements.txt`, Megatron-LM (`radixark/Megatron-LM@miles-main`), miles, and the prebuilt wheels (`sgl-router` among them). A multi-arch build is one `buildx` run executed once per platform — `TARGETARCH` differs each time, so each arch installs its own wheels — and buildx pushes the two as a single manifest.
+**Output** — one `radixark/miles` image for the platform buildx targets. Layer order is ascending change frequency: the sglang base, prebuilt release wheels and pinned third-party installs (TE, apex, `sgl-router` among them), the `requirements.txt` resolve (constrained so it cannot silently move anything already installed), then the fast-moving source trees last — Megatron-LM, sglang, miles (each at its required commit pin). A multi-arch build is one `buildx` run executed once per platform — `TARGETARCH` differs each time, so each arch installs its own wheels — and buildx pushes the two as a single manifest.
 
 `docker/Dockerfile.rocm` is the ROCm counterpart (build-args `GPU_ARCH` + a ROCm `SGLANG_IMAGE_TAG`; the 7.2 variants also set `APPLY_ROCR_VMMFIX=1`, which downloads the ROCr VMM-pause fix `.so` from the `WHEELS_TAG_ROCM` release and installs it — ROCm 7.0 has no such regression and leaves it off).
 
@@ -63,7 +63,7 @@ A multi-arch build (`cu13`) needs Buildx's `docker-container` driver and is push
 
 Dockerfile changes are build-tested on the PR itself, before merge — `docker-build.yml` only runs after a push to `main`, so without this breakage lands on `main` first.
 
-When a PR touches `docker/Dockerfile`, `docker/build.py`, `docker/resolve_upstream.py`, `docker/fetch_wheels.py`, `docker/verify_transformer_engine.py`, `docker/patch/**`, or `requirements.txt` (detected by the `docker-paths` job), `pr-test.yml` inserts a build in front of the test matrix:
+When a PR touches `docker/Dockerfile`, `docker/build.py`, `docker/resolve_upstream.py`, `docker/fetch_wheels.py`, `docker/requirements-nodeps.txt`, `docker/verify_transformer_engine.py`, `docker/patch/**`, or `requirements.txt` (detected by the `docker-paths` job), `pr-test.yml` inserts a build in front of the test matrix:
 
 | Job | What it does |
 | --- | --- |

--- a/docs/ci/02-docker-build.md
+++ b/docs/ci/02-docker-build.md
@@ -29,7 +29,9 @@ The Dockerfile is the build recipe: it provides the cu13 defaults and emits one 
 | `ENABLE_CUDA_13`                                                                                       | `1` = CUDA 13 (default) and installs the Mooncake wheel from the selected wheels release; `0` = CUDA 12.9 and keeps the base image's Mooncake                                                                                                                                                                                                         |
 | `WHEELS_REPO`                                                                                          | prebuilt-wheels GitHub repo (`yueming-yuan/miles-wheels`)                                                                                                                                                                                                                                                                                           |
 | `WHEELS_TAG_X86` / `WHEELS_TAG_ARM64`                                                                  | the two **complete** wheels release tags selected by `TARGETARCH` and installed **verbatim**. cu13 uses the rolling `cu130-x86_64` / `cu130-aarch64` releases; cu12-x86 overrides `WHEELS_TAG_X86` with the rolling `cu129-x86_64` release                                                                                                                                                                                              |
-| `SGLANG_BRANCH` / `SGLANG_COMMIT`, `MEGATRON_REPO` / `MEGATRON_BRANCH`, `MILES_COMMIT`, `SGL_ROUTER_*` | source pins for the layered repos                                                                                                                                                                                                                                                                                                                   |
+| `SGLANG_COMMIT` / `MEGATRON_COMMIT` / `MILES_COMMIT`                                                   | **required** exact commits for the layered source repos — the build refuses branch-HEAD fallbacks so a cached layer can never silently serve a stale tree. `docker/resolve_upstream.py` resolves current values; `build.py` fills in any the caller didn't pass                                                                                       |
+| `WHEELS_FP_X86` / `WHEELS_FP_ARM64`                                                                    | **required** per built arch: asset-list fingerprint of the selected wheels release (from `docker/resolve_upstream.py`) — the cache-buster for the download layer, since rolling tags keep their name while assets get replaced                                                                                                                        |
+| `MEGATRON_REPO`, `SGL_ROUTER_*`                                                                        | remaining source knobs for the layered repos                                                                                                                                                                                                                                                                                                          |
 
 
 **Output** — one `radixark/miles` image for the platform buildx targets: the sglang base, then the Python dependencies declared in `requirements.txt`, Megatron-LM (`radixark/Megatron-LM@miles-main`), miles, and the prebuilt wheels (`sgl-router` among them). A multi-arch build is one `buildx` run executed once per platform — `TARGETARCH` differs each time, so each arch installs its own wheels — and buildx pushes the two as a single manifest.
@@ -61,7 +63,7 @@ A multi-arch build (`cu13`) needs Buildx's `docker-container` driver and is push
 
 Dockerfile changes are build-tested on the PR itself, before merge — `docker-build.yml` only runs after a push to `main`, so without this breakage lands on `main` first.
 
-When a PR touches `docker/Dockerfile`, `docker/build.py`, `docker/verify_transformer_engine.py`, `docker/patch/**`, or `requirements.txt` (detected by the `docker-paths` job), `pr-test.yml` inserts a build in front of the test matrix:
+When a PR touches `docker/Dockerfile`, `docker/build.py`, `docker/resolve_upstream.py`, `docker/verify_transformer_engine.py`, `docker/patch/**`, or `requirements.txt` (detected by the `docker-paths` job), `pr-test.yml` inserts a build in front of the test matrix:
 
 | Job | What it does |
 | --- | --- |
@@ -75,21 +77,21 @@ Non-docker PRs are untouched: `docker-paths` reports no change, `docker-build` s
 
 The only automated builder of `radixark/miles`. Two jobs:
 
-- **`resolve-upstream`** (always runs) — resolves the inputs the image bakes: the HEAD SHAs of sglang `sglang-miles` (`sgl-project/sglang`), Megatron-LM `miles-main` (`radixark/Megatron-LM`), and miles itself (the pushed commit on push events, else `main` HEAD), plus a fingerprint of each `yueming-yuan/miles-wheels` rolling release (re-uploads to the same tag are caught by fingerprint, not commit SHA). All values are exposed as job outputs; an empty resolution fails the job. On **schedule / `simulate_schedule`** the values additionally gate the rebuild by comparing against the last gated build. Miles is intentionally excluded from the value comparison because ordinary source changes would rebuild too often, but the gate forces a build once the last triggered build is **24h** old, so `dev` never drifts more than a day behind the repo when sglang, Megatron, and wheels are quiet.
+- **`resolve-upstream`** (always runs) — runs `docker/resolve_upstream.py` (the single resolver, shared with `build.py`) to resolve the inputs the image bakes: the HEAD SHAs of sglang `sglang-miles` (`sgl-project/sglang`), Megatron-LM `miles-main` (`radixark/Megatron-LM`), and miles itself (the pushed commit on push events, else `main` HEAD), plus a fingerprint of each `yueming-yuan/miles-wheels` rolling release (re-uploads to the same tag are caught by fingerprint, not commit SHA). All values are exposed as job outputs; an empty resolution fails the job, and `build-and-push` bakes the source SHAs via `--build-arg`. On **schedule / `simulate_schedule`** the values additionally gate the rebuild by comparing against the cache from the last gated build. `miles` is intentionally excluded from the value comparison because ordinary source changes would rebuild too often, but the gate forces a build once the last triggered build is **24h** old, so `dev` never drifts more than a day behind the repo when sglang, Megatron, and wheels are quiet.
 - **`build-and-push`** (self-hosted `docker-build` runner) — calls `docker/build.py` to build + push, then conditionally points `latest` at the new `dev` and prunes old timestamped tags.
 
 `build-and-push` requires `resolve-upstream` to succeed (a failed resolve blocks the build rather than building unpinned), and on schedule additionally requires `should_build=true`.
 
 ### Triggers: automatic vs manual
 
-- **Automatic** (no human) — the **schedule** (cron 00:00 / 12:00 UTC, gated by `resolve-upstream`) and any **push to `main` that touches `docker/Dockerfile`, `docker/verify_transformer_engine.py`, or `requirements.txt`**. Both leave `--variant` empty and build **two images**: `cu13` → `radixark/miles` (multi-arch) and `cu12-x86` → `radixark/miles:dev-cu12`.
+- **Automatic** (no human) — the **schedule** (cron 00:00 / 12:00 UTC, gated by `resolve-upstream`) and any **push to `main` that touches the same docker paths the PR check watches** (see PR build check above). Both leave `--variant` empty and build **two images**: `cu13` → `radixark/miles` (multi-arch) and `cu12-x86` → `radixark/miles:dev-cu12`.
 - **Manual** — `workflow_dispatch` (pick one variant — see Trigger a build yourself below) or running `docker/build.py` locally. Only the `rocm-*` images have **no automatic path** (`cu13-x86` / `cu13-aarch64` just rebuild the same `dev` image single-arch).
 
 
 | Trigger                                     | rebuild gate (`resolve-upstream`)  | builds                | `latest` move     | prune      |
 | ------------------------------------------- | ---------------------------------- | --------------------- | ----------------- | ---------- |
-| schedule (cron 00:00 / 12:00 UTC)           | gates; build if upstream moved or last build ≥ 24h ago | `cu13` + `cu12-x86`   | yes (both)        | yes (both) |
-| push to `main` touching `docker/Dockerfile`, `docker/verify_transformer_engine.py`, or `requirements.txt` | resolves only, no gate             | `cu13` + `cu12-x86`   | no                | no         |
+| schedule (cron 00:00 / 12:00 UTC)           | gates; build if upstream moved or the last build is 24h old | `cu13` + `cu12-x86`   | yes (both)        | yes (both) |
+| push to `main` touching the watched docker paths | resolves only, no gate             | `cu13` + `cu12-x86`   | no                | no         |
 | `workflow_dispatch`                         | resolves only, no gate             | the one input variant | no                | no         |
 | `workflow_dispatch` + `simulate_schedule`   | reports the gate signal, doesn't gate | the one input variant | no                | no         |
 
@@ -141,9 +143,9 @@ Pushes use a Docker Hub credential, not your identity:
 - **Remote (CI)** — the workflow logs in with repo secrets `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN`, so you don't hold the key — you just trigger the run, which needs repo **Write** access. No approval gate, but `build-and-push` runs on a `self-hosted` runner, so it only fires when one is online.
 - **Local** — `build.py --push` uses your own `docker login`; you need push rights to the target namespace (`radixark/miles`, or `rocm/sgl-dev` for ROCm).
 
-### Pinning specific repo versions
+### Pinning specific repo versions — reproducible builds
 
-`docker/Dockerfile` takes `MEGATRON_BRANCH` / `SGLANG_COMMIT` / `MILES_COMMIT` build-args, and `build.py --build-arg` forwards arbitrary `KEY=VALUE` pairs to the build, so local pinned builds work today (e.g. `--build-arg SGLANG_COMMIT=<sha>`). `resolve-upstream` resolves the current upstream SHAs on every CI run; wiring those outputs (or `workflow_dispatch` inputs) into the build's `--build-arg` flags is the next step of the build refactor — until then CI builds still follow branch HEADs inside the Dockerfile.
+Every image is now built from exact pins: CI passes the `resolve-upstream` SHAs as `--build-arg SGLANG_COMMIT/MEGATRON_COMMIT/MILES_COMMIT`, `build.py` resolves the per-variant wheels fingerprints, and the Dockerfile hard-fails on any missing pin instead of following a branch HEAD. To rebuild a historical image, pass its pins explicitly — e.g. `python docker/build.py --variant cu13-x86 --image-tag custom --custom-tag repro --build-arg SGLANG_COMMIT=<sha> --build-arg MEGATRON_COMMIT=<sha> --build-arg MILES_COMMIT=<sha>` (wheels fingerprints only key the cache, so bit-exact wheel reproduction additionally needs the release assets to be unchanged). A plain local `build.py` run with no `--build-arg` resolves all pins itself via `docker/resolve_upstream.py` and prints each one.
 
 ## Image retention (open)
 

--- a/docs/ci/02-docker-build.md
+++ b/docs/ci/02-docker-build.md
@@ -55,7 +55,7 @@ The cu13 variants share one multi-arch CUDA base image and differ only in platfo
 
 The **Tag** column is for `--image-tag dev`, which also pushes a timestamped `dev-<YYYYMMDDHHMM>` sibling; `latest` swaps the prefix to `latest`, `custom` uses `--custom-tag`. `cu13` / `cu13-x86` / `cu13-aarch64` intentionally share `radixark/miles:dev` — the daily build runs `cu13` (multi-arch), while a single-arch variant overwrites `dev` with one arch when run alone.
 
-A multi-arch build (`cu13`) needs Buildx's `docker-container` driver and is push-only — buildx writes the manifest straight to the registry, it can't load into the local image store. Use `cu13-x86` / `cu13-aarch64` (single-platform; the arm64 one cross-builds via QEMU on an x86 host) for local single-arch iteration. Other flags: `--push`, `--dry-run`, `--dockerfile`, `--custom-tag`.
+A multi-arch build (`cu13`) needs Buildx's `docker-container` driver and is push-only — buildx writes the manifest straight to the registry, it can't load into the local image store. Use `cu13-x86` / `cu13-aarch64` (single-platform; the arm64 one cross-builds via QEMU on an x86 host) for local single-arch iteration. Other flags: `--push`, `--dry-run`, `--dockerfile`, `--custom-tag`, `--build-arg` (repeatable `KEY=VALUE` forwarded verbatim to `docker buildx build`, appended after the variant's own build-args so an explicit value wins).
 
 ## PR build check (in `pr-test.yml`)
 
@@ -75,23 +75,23 @@ Non-docker PRs are untouched: `docker-paths` reports no change, `docker-build` s
 
 The only automated builder of `radixark/miles`. Two jobs:
 
-- **`check-upstream`** (schedule / `simulate_schedule` only) — polls the inputs the image bakes: the HEAD SHA of sglang `sglang-miles` (`sgl-project/sglang`) and Megatron-LM `miles-main` (`radixark/Megatron-LM`) — the source branches it builds — plus a fingerprint of the selected `yueming-yuan/miles-wheels` rolling release, so a rebuilt sgl-router or other wheel also triggers a build (re-uploads to the same tag are caught by fingerprint, not commit SHA). It compares against the values cached from the last build and sets `should_build=true` if any moved. `miles` itself is intentionally not polled — that would rebuild far too often. This is what stops the 12-hour cron from rebuilding an unchanged image, with one staleness bound: because the image also bakes a `miles` checkout, `should_build` is forced to `true` once the last triggered build is **24h** old, so `dev` never drifts more than a day behind the `miles` repo even when sglang / Megatron / wheels are quiet. (The cache file's last line records the epoch of the last triggered build; it is only re-saved when a build fires.)
+- **`resolve-upstream`** (always runs) — resolves the inputs the image bakes: the HEAD SHAs of sglang `sglang-miles` (`sgl-project/sglang`), Megatron-LM `miles-main` (`radixark/Megatron-LM`), and miles itself (the pushed commit on push events, else `main` HEAD), plus a fingerprint of each `yueming-yuan/miles-wheels` rolling release (re-uploads to the same tag are caught by fingerprint, not commit SHA). All values are exposed as job outputs; an empty resolution fails the job. On **schedule / `simulate_schedule`** the values additionally gate the rebuild by comparing against the last gated build. Miles is intentionally excluded from the value comparison because ordinary source changes would rebuild too often, but the gate forces a build once the last triggered build is **24h** old, so `dev` never drifts more than a day behind the repo when sglang, Megatron, and wheels are quiet.
 - **`build-and-push`** (self-hosted `docker-build` runner) — calls `docker/build.py` to build + push, then conditionally points `latest` at the new `dev` and prunes old timestamped tags.
 
-`build-and-push` runs when `check-upstream` was skipped, or ran and reported `should_build=true`.
+`build-and-push` requires `resolve-upstream` to succeed (a failed resolve blocks the build rather than building unpinned), and on schedule additionally requires `should_build=true`.
 
 ### Triggers: automatic vs manual
 
-- **Automatic** (no human) — the **schedule** (cron 00:00 / 12:00 UTC, gated by `check-upstream`) and any **push to `main` that touches `docker/Dockerfile`, `docker/verify_transformer_engine.py`, or `requirements.txt`**. Both leave `--variant` empty and build **two images**: `cu13` → `radixark/miles` (multi-arch) and `cu12-x86` → `radixark/miles:dev-cu12`.
+- **Automatic** (no human) — the **schedule** (cron 00:00 / 12:00 UTC, gated by `resolve-upstream`) and any **push to `main` that touches `docker/Dockerfile`, `docker/verify_transformer_engine.py`, or `requirements.txt`**. Both leave `--variant` empty and build **two images**: `cu13` → `radixark/miles` (multi-arch) and `cu12-x86` → `radixark/miles:dev-cu12`.
 - **Manual** — `workflow_dispatch` (pick one variant — see Trigger a build yourself below) or running `docker/build.py` locally. Only the `rocm-*` images have **no automatic path** (`cu13-x86` / `cu13-aarch64` just rebuild the same `dev` image single-arch).
 
 
-| Trigger                                     | `check-upstream`                   | builds                | `latest` move     | prune      |
+| Trigger                                     | rebuild gate (`resolve-upstream`)  | builds                | `latest` move     | prune      |
 | ------------------------------------------- | ---------------------------------- | --------------------- | ----------------- | ---------- |
-| schedule (cron 00:00 / 12:00 UTC)           | runs; build if upstream moved or last build ≥ 24h ago | `cu13` + `cu12-x86`   | yes (both)        | yes (both) |
-| push to `main` touching `docker/Dockerfile`, `docker/verify_transformer_engine.py`, or `requirements.txt` | skipped                            | `cu13` + `cu12-x86`   | no                | no         |
-| `workflow_dispatch`                         | skipped                            | the one input variant | no                | no         |
-| `workflow_dispatch` + `simulate_schedule`   | runs                               | the one input variant | no                | no         |
+| schedule (cron 00:00 / 12:00 UTC)           | gates; build if upstream moved or last build ≥ 24h ago | `cu13` + `cu12-x86`   | yes (both)        | yes (both) |
+| push to `main` touching `docker/Dockerfile`, `docker/verify_transformer_engine.py`, or `requirements.txt` | resolves only, no gate             | `cu13` + `cu12-x86`   | no                | no         |
+| `workflow_dispatch`                         | resolves only, no gate             | the one input variant | no                | no         |
+| `workflow_dispatch` + `simulate_schedule`   | reports the gate signal, doesn't gate | the one input variant | no                | no         |
 
 
 ### Tags & where it pushes
@@ -108,7 +108,7 @@ What **moves a shared tag**: `--image-tag dev` overwrites `:dev` (or `:dev-cu12`
 
 ### Trigger a build yourself
 
-Manual builds run through `workflow_dispatch` — by default the image is built straight from the inputs you pass; with `simulate_schedule`, `check-upstream` runs first for signal but does not gate the manual build (see the `workflow_dispatch` rows in the table above for how this differs from schedule). Start one two ways:
+Manual builds run through `workflow_dispatch` — by default the image is built straight from the inputs you pass; with `simulate_schedule`, `resolve-upstream` additionally reports the gate signal but does not gate the manual build (see the `workflow_dispatch` rows in the table above for how this differs from schedule). Start one two ways:
 
 - **Web UI** — Actions → "Docker Build & Push" → **Run workflow**, then fill the inputs below.
 - **CLI** — `gh` dispatches on the repo's default branch; pass `--ref <branch>` to build another branch's workflow.
@@ -125,7 +125,7 @@ gh workflow run docker-build.yml -f variant=cu13-x86 -f image_tag=custom -f cust
 | `image_tag` | yes | `dev` / `latest` / `custom` |
 | `custom_tag` | no | tag name; required when `image_tag=custom` |
 | `dockerfile` | no | path to Dockerfile (default `docker/Dockerfile`) |
-| `simulate_schedule` | no | `true` runs the `check-upstream` poll first (default `false`) |
+| `simulate_schedule` | no | `true` makes `resolve-upstream` report the rebuild-gate signal (default `false`) |
 
 ### Steps (`build-and-push`)
 
@@ -143,7 +143,7 @@ Pushes use a Docker Hub credential, not your identity:
 
 ### Pinning specific repo versions
 
-`docker/Dockerfile` already takes `MEGATRON_BRANCH` / `SGLANG_COMMIT` / `MILES_COMMIT` build-args, but `build.py` does not yet forward arbitrary build-args and `workflow_dispatch` exposes no input for them — so commit-pinning from the workflow needs two changes first: a passthrough in `build.py` and matching inputs in `docker-build.yml`.
+`docker/Dockerfile` takes `MEGATRON_BRANCH` / `SGLANG_COMMIT` / `MILES_COMMIT` build-args, and `build.py --build-arg` forwards arbitrary `KEY=VALUE` pairs to the build, so local pinned builds work today (e.g. `--build-arg SGLANG_COMMIT=<sha>`). `resolve-upstream` resolves the current upstream SHAs on every CI run; wiring those outputs (or `workflow_dispatch` inputs) into the build's `--build-arg` flags is the next step of the build refactor — until then CI builds still follow branch HEADs inside the Dockerfile.
 
 ## Image retention (open)
 

--- a/docs/ci/02-docker-build.md
+++ b/docs/ci/02-docker-build.md
@@ -129,7 +129,7 @@ gh workflow run docker-build.yml -f variant=cu13-x86 -f image_tag=custom -f cust
 
 ### Steps (`build-and-push`)
 
-1. checkout → Buildx → install Python + typer → Docker Hub login.
+1. checkout → Buildx → Docker Hub login. No host package installs: `build.py` is stdlib-only, so build nodes need just docker and stock `python3`.
 2. **Build + push** via `build.py` — automatic runs build **both** `cu13` and `cu12-x86`; a manual dispatch builds only the one variant you picked.
 3. **schedule only** — point `latest`→`dev` and `latest-cu12`→`dev-cu12`.
 4. **schedule only** — prune each timestamp series to the newest 20.

--- a/docs/ci/02-docker-build.md
+++ b/docs/ci/02-docker-build.md
@@ -57,7 +57,7 @@ The cu13 variants share one multi-arch CUDA base image and differ only in platfo
 
 The **Tag** column is for `--image-tag dev`, which also pushes a timestamped `dev-<YYYYMMDDHHMM>` sibling; `latest` swaps the prefix to `latest`, `custom` uses `--custom-tag`. `cu13` / `cu13-x86` / `cu13-aarch64` intentionally share `radixark/miles:dev` — the daily build runs `cu13` (multi-arch), while a single-arch variant overwrites `dev` with one arch when run alone.
 
-A multi-arch build (`cu13`) needs Buildx's `docker-container` driver and is push-only — buildx writes the manifest straight to the registry, it can't load into the local image store. Use `cu13-x86` / `cu13-aarch64` (single-platform; the arm64 one cross-builds via QEMU on an x86 host) for local single-arch iteration. Other flags: `--push`, `--dry-run`, `--dockerfile`, `--custom-tag`, `--build-arg` (repeatable `KEY=VALUE` forwarded verbatim to `docker buildx build`, appended after the variant's own build-args so an explicit value wins).
+A multi-arch build (`cu13`) needs Buildx's `docker-container` driver and is push-only — buildx writes the manifest straight to the registry, it can't load into the local image store. Use `cu13-x86` / `cu13-aarch64` (single-platform; the arm64 one cross-builds via QEMU on an x86 host) for local single-arch iteration. Other flags: `--push`, `--dry-run`, `--dockerfile`, `--custom-tag`, `--build-arg` (repeatable `KEY=VALUE` forwarded verbatim to `docker buildx build`, appended after the variant's own build-args so an explicit value wins), `--builder` (buildx builder to use; CI passes its persistent `miles-builder`).
 
 ## PR build check (in `pr-test.yml`)
 
@@ -131,7 +131,7 @@ gh workflow run docker-build.yml -f variant=cu13-x86 -f image_tag=custom -f cust
 
 ### Steps (`build-and-push`)
 
-1. checkout → Buildx → Docker Hub login. No host package installs: `build.py` is stdlib-only, so build nodes need just docker and stock `python3`.
+1. checkout → ensure the persistent `miles-builder` buildx builder (node-local layer cache; created once per node, reused by every build including PR builds) → Docker Hub login. No host package installs: `build.py` is stdlib-only, so build nodes need just docker and stock `python3`.
 2. **Build + push** via `build.py` — automatic runs build **both** `cu13` and `cu12-x86`; a manual dispatch builds only the one variant you picked.
 3. **schedule only** — point `latest`→`dev` and `latest-cu12`→`dev-cu12`.
 4. **schedule only** — prune each timestamp series to the newest 20.

--- a/docs/ci/02-docker-build.md
+++ b/docs/ci/02-docker-build.md
@@ -63,7 +63,7 @@ A multi-arch build (`cu13`) needs Buildx's `docker-container` driver and is push
 
 Dockerfile changes are build-tested on the PR itself, before merge — `docker-build.yml` only runs after a push to `main`, so without this breakage lands on `main` first.
 
-When a PR touches `docker/Dockerfile`, `docker/build.py`, `docker/resolve_upstream.py`, `docker/verify_transformer_engine.py`, `docker/patch/**`, or `requirements.txt` (detected by the `docker-paths` job), `pr-test.yml` inserts a build in front of the test matrix:
+When a PR touches `docker/Dockerfile`, `docker/build.py`, `docker/resolve_upstream.py`, `docker/fetch_wheels.py`, `docker/verify_transformer_engine.py`, `docker/patch/**`, or `requirements.txt` (detected by the `docker-paths` job), `pr-test.yml` inserts a build in front of the test matrix:
 
 | Job | What it does |
 | --- | --- |


### PR DESCRIPTION
> **Depends on:** #2364
> Stacked on the parent PR's branch. Review / merge the parent first.

## Summary

Make Docker image builds reproducible, cacheable, and GPU-gated before publication.

## Motivation

Fully cold image builds take roughly 72 minutes and previously reported zero layer-cache hits. Persisting layers while cloning moving branch heads would silently reuse stale sources, so cache reuse must be keyed by exact source SHAs and wheel-release identity before a persistent builder can be trusted.

## Before / After

- **Before / After:** Builds replace host mutation plus moving inputs with immutable hosts, pinned inputs, persistent caches, stable dependency layers, and a pre-push GPU probe.
- **What moved where:** `docker/resolve_upstream.py` owns input resolution; `docker/build.py` owns argument validation; `docker/Dockerfile` owns cache-aware installation; `docker/smoke_test.py` and workflows own publication gating.

## Behavior Preservation

- Stack extraction changes only PR boundaries: `refactor/docker-build` remains at `043102d9382e59072aaed6297654f60c74051fae` with the same final tree and eight commits above the cache-mount parent.
- Build variants, tag modes, package pins, and source selections retain their existing contracts; formerly moving inputs become immutable build arguments.

## Verification

- Reorganization proof: per-commit patch/metadata checks passed; the final binary patch plus raw diff stayed byte-identical to the pre-reorganization range.
- Static checks: Python in-memory compile, workflow YAML parse, Dockerfile continuation, range `git diff --check`, resolver help, and `docker/build.py --variant cu13-x86 --image-tag dev --dry-run` passed.
- Stack boundary check: `git rev-list --count f9b2aeaa4b94ec2b7c44727a381956ad55712b70..043102d9382e59072aaed6297654f60c74051fae` returned `8`; the remaining diff is non-empty.

## Review Focus

- `docker/resolve_upstream.py` / `docker/build.py`: Verify every moving source and rolling wheel input reaches the Docker cache key without a silent fallback.
- `docker/Dockerfile`: Verify persistent-layer and download-cache reuse cannot serve an input under the wrong SHA, release asset identity, dependency set, or architecture.
- `.github/workflows/docker-build.yml` / `docker/smoke_test.py`: Verify publication remains downstream of the intended amd64 GPU probe and that unsupported architecture paths are explicit.
