### PR TITLE
[WIP] Add experimental NVFP4 fake-QAT RL recipe

### DIFF
--- a/docs/advanced/fp8-low-precision.md
+++ b/docs/advanced/fp8-low-precision.md
@@ -33,7 +33,7 @@ forward precision. ✅ = supported; ✗ = not supported.
 | **BF16**           | ✅ baseline | ✗ | ✗ | ✗ |
 | **FP8 block-wise** | ✅ | ✅ Hopper + Blackwell | ✗ | ✗ |
 | **MXFP8**          | ✅ | ✗ | ✅ Blackwell | ✗ |
-| **NVFP4**          | ✅ with precision drift | ✗ | ✗ | ✅ experimental |
+| **NVFP4**          | ✗ | ✗ | ✗ | 🚧 coming soon |
 
 Two rules enforced in the reference script
 (`scripts/run_qwen3_30b_a3b.py`):
@@ -41,8 +41,6 @@ Two rules enforced in the reference script
 * `--rollout-mxfp8` and `--rollout-fp8` are mutually exclusive.
 * `--train-mxfp8` requires `--rollout-mxfp8` (no MXFP8-train + FP8-rollout
   combo).
-* `--train-nvfp4-qat` requires `--rollout-nvfp4` and is mutually exclusive
-  with native `--train-nvfp4`.
 
 ## Unified training recipe
 
@@ -181,35 +179,14 @@ NVFP4 is FP4 E2M1 with 1D block scaling (group size 16) and a two-level scale
 reference. Today only **MoE expert GEMMs** are quantized; dense layers stay in
 their original precision.
 
-The reference script exposes two experimental training modes:
-
-* `--train-nvfp4-qat` keeps BF16 master weights and GEMMs, but applies the same
-  TE 1×16 NVFP4 quantize/dequantize operation to routed-expert FC1/FC2 weights
-  on every forward. Gradients pass through with a straight-through estimator.
-* `--train-nvfp4` uses native TE NVFP4 GEMMs and is a separate recipe; do not
-  combine it with fake QAT.
-
-Run the fake-QAT path together with NVFP4 rollout:
-
-```bash
-python scripts/run_qwen3_30b_a3b.py \
-  --hardware B200 \
-  --rollout-nvfp4 \
-  --train-nvfp4-qat
-```
-
-The script sets `OPEN_TRAINING_NVFP4_FAKE_QAT_FLAG=1` for Megatron. It also
-forwards the driver's `NVTE_*` and `FLASHINFER_*` variables, so conversion,
-training, and rollout can share the same 4over6 scope, E4M3 bound, error mode,
-and fast-math settings. The quantized checkpoint does not encode those choices;
-set both backends consistently and restore the same environment when resuming.
+The full unified NVFP4 recipe is in development.
 
 ## Hardware support
 
 | GPU | BF16 | FP8 block-wise | MXFP8 | NVFP4 |
 |---|---|---|---|---|
 | NVIDIA H100 / H200 | ✅ | ✅ | ✗ | ✗ |
-| NVIDIA B200 / B300 / GB200 / GB300 | ✅ | ✅ | ✅ | ✅ experimental |
+| NVIDIA B200 / B300 / GB200 / GB300 | ✅ | ✅ | ✅ | 🚧 in development |
 | NVIDIA A100 | ✅ | ✗ | ✗ | ✗ |
 | AMD MI300X / MI325 / MI350 / MI355X | ✅ | ✗ | ✗ | ✗ |
 
@@ -220,3 +197,4 @@ set both backends consistently and restore the same environment when resuming.
 * AMD hardware today.
 * Bring-up of a new model architecture, where clean BF16 numerics simplify
   debugging.
+

--- a/docs/advanced/fp8-low-precision.md
+++ b/docs/advanced/fp8-low-precision.md
@@ -33,7 +33,7 @@ forward precision. ✅ = supported; ✗ = not supported.
 | **BF16**           | ✅ baseline | ✗ | ✗ | ✗ |
 | **FP8 block-wise** | ✅ | ✅ Hopper + Blackwell | ✗ | ✗ |
 | **MXFP8**          | ✅ | ✗ | ✅ Blackwell | ✗ |
-| **NVFP4**          | ✗ | ✗ | ✗ | 🚧 coming soon |
+| **NVFP4**          | ✅ with precision drift | ✗ | ✗ | ✅ experimental |
 
 Two rules enforced in the reference script
 (`scripts/run_qwen3_30b_a3b.py`):
@@ -41,6 +41,8 @@ Two rules enforced in the reference script
 * `--rollout-mxfp8` and `--rollout-fp8` are mutually exclusive.
 * `--train-mxfp8` requires `--rollout-mxfp8` (no MXFP8-train + FP8-rollout
   combo).
+* `--train-nvfp4-qat` requires `--rollout-nvfp4` and is mutually exclusive
+  with native `--train-nvfp4`.
 
 ## Unified training recipe
 
@@ -179,14 +181,35 @@ NVFP4 is FP4 E2M1 with 1D block scaling (group size 16) and a two-level scale
 reference. Today only **MoE expert GEMMs** are quantized; dense layers stay in
 their original precision.
 
-The full unified NVFP4 recipe is in development.
+The reference script exposes two experimental training modes:
+
+* `--train-nvfp4-qat` keeps BF16 master weights and GEMMs, but applies the same
+  TE 1×16 NVFP4 quantize/dequantize operation to routed-expert FC1/FC2 weights
+  on every forward. Gradients pass through with a straight-through estimator.
+* `--train-nvfp4` uses native TE NVFP4 GEMMs and is a separate recipe; do not
+  combine it with fake QAT.
+
+Run the fake-QAT path together with NVFP4 rollout:
+
+```bash
+python scripts/run_qwen3_30b_a3b.py \
+  --hardware B200 \
+  --rollout-nvfp4 \
+  --train-nvfp4-qat
+```
+
+The script sets `OPEN_TRAINING_NVFP4_FAKE_QAT_FLAG=1` for Megatron. It also
+forwards the driver's `NVTE_*` and `FLASHINFER_*` variables, so conversion,
+training, and rollout can share the same 4over6 scope, E4M3 bound, error mode,
+and fast-math settings. The quantized checkpoint does not encode those choices;
+set both backends consistently and restore the same environment when resuming.
 
 ## Hardware support
 
 | GPU | BF16 | FP8 block-wise | MXFP8 | NVFP4 |
 |---|---|---|---|---|
 | NVIDIA H100 / H200 | ✅ | ✅ | ✗ | ✗ |
-| NVIDIA B200 / B300 / GB200 / GB300 | ✅ | ✅ | ✅ | 🚧 in development |
+| NVIDIA B200 / B300 / GB200 / GB300 | ✅ | ✅ | ✅ | ✅ experimental |
 | NVIDIA A100 | ✅ | ✗ | ✗ | ✗ |
 | AMD MI300X / MI325 / MI350 / MI355X | ✅ | ✗ | ✗ | ✗ |
 
@@ -197,4 +220,3 @@ The full unified NVFP4 recipe is in development.
 * AMD hardware today.
 * Bring-up of a new model architecture, where clean BF16 numerics simplify
   debugging.
-

--- a/scripts/run_qwen3_30b_a3b.py
+++ b/scripts/run_qwen3_30b_a3b.py
@@ -31,6 +31,7 @@ class ScriptArgs(U.ExecuteTrainConfig):
     train_fp8: bool = False
     train_mxfp8: bool = False
     train_nvfp4: bool = False
+    train_nvfp4_qat: bool = False
     enable_megatron_bridge: bool = False
     enable_mis: bool = False
     # TODO improve, should be able to override more easily
@@ -50,9 +51,18 @@ class ScriptArgs(U.ExecuteTrainConfig):
             sum((self.rollout_fp8, self.rollout_mxfp8, self.rollout_int4, self.rollout_nvfp4)) <= 1
         ), "only one rollout precision mode can be enabled"
         assert (
-            sum((self.train_fp8, self.train_mxfp8, self.train_nvfp4)) <= 1
+            sum((self.train_fp8, self.train_mxfp8, self.train_nvfp4, self.train_nvfp4_qat)) <= 1
         ), "only one train precision mode can be enabled"
-        if any((self.rollout_mxfp8, self.rollout_nvfp4, self.train_mxfp8, self.train_nvfp4)):
+        assert not self.train_nvfp4_qat or self.rollout_nvfp4, "NVFP4 QAT requires NVFP4 rollout"
+        if any(
+            (
+                self.rollout_mxfp8,
+                self.rollout_nvfp4,
+                self.train_mxfp8,
+                self.train_nvfp4,
+                self.train_nvfp4_qat,
+            )
+        ):
             assert self.hardware in ("B200", "B300", "GB200", "GB300"), "mxfp8 and nvfp4 only support Blackwell GPUs"
 
 
@@ -217,6 +227,8 @@ def execute(args: ScriptArgs):
             "OPEN_TRAINING_INT4_FAKE_QAT_FLAG": "1",
             "OPEN_TRAINING_INT4_GROUP_SIZE": "128",
         }
+    elif args.train_nvfp4_qat:
+        misc_env_vars["OPEN_TRAINING_NVFP4_FAKE_QAT_FLAG"] = "1"
 
     if args.train_fp8 or args.train_mxfp8:
         match args.hardware:


### PR DESCRIPTION
> [!WARNING]
> **Experimental / WIP.** This is the initial NVFP4 fake-QAT RL wiring and has not yet been validated on a GPU devbox.

## Summary

Adds an explicit `--train-nvfp4-qat` mode to the Qwen3 30B-A3B reference recipe, mirroring the existing INT4 QAT split between BF16 training weights and quantized rollout weights.

- Requires `--rollout-nvfp4`.
- Is mutually exclusive with native `--train-nvfp4` and the other training precision modes.
- Is limited to Blackwell hardware.
- Sets `OPEN_TRAINING_NVFP4_FAKE_QAT_FLAG=1` for the companion Megatron implementation.
- Keeps the existing NVFP4 checkpoint conversion, live weight export, and rollout paths unchanged.

## Scope and limitations

Fake quantization is limited to **routed MoE expert TE grouped FC1/FC2 weights**. Dense MLPs, shared experts, sequential or legacy experts, activations, optimizer state, parameter gather, and the native TE FP4-GEMM training path are unchanged.

The recipe keeps BF16 master weights and GEMMs while the companion Megatron change applies TE NVFP4 quantize/dequantize during each forward with straight-through gradients.

Miles continues forwarding the driver's `NVTE_*` and `FLASHINFER_*` variables so conversion, QAT, and rollout can use consistent 4over6 scope, E4M3 bounds, error mode, and fast-math settings. The quantized checkpoint does not encode those choices, so the same environment must be restored when resuming.

The current Qwen recipe uses expert tensor parallel size 1. Generic expert-TP parity is not claimed yet: with expert TP greater than 1, the fake-QAT local-shard amax can differ from full-weight rollout conversion.

## Dependencies

- Companion Megatron PR: [radixark/Megatron-LM#75](https://github.com/radixark/Megatron-LM/pull/75)
- The intended CuTe DSL W4A16 rollout path assumes [flashinfer-ai/flashinfer#4048](https://github.com/flashinfer-ai/flashinfer/pull/4048).

The dependency CI marker is intentionally deferred until the GPU validation phase.

## Validation

Passed static checks:

- `pre-commit run --files scripts/run_qwen3_30b_a3b.py`
- `git diff origin/main...HEAD --check`

Per request, no unit or functional tests, benchmarks, accuracy runs, or GPU/devbox validation were performed before opening this draft.
