### PR TITLE
feat: expose Claude skills to agents

### DIFF
--- a/.agents/skills
+++ b/.agents/skills
@@ -1,0 +1,1 @@
+../.claude/skills


### PR DESCRIPTION
## Summary
Expose repository skills through the standard `.agents/skills` path.

## Motivation
Make the existing .claude/skills directory discoverable through the standard .agents/skills path without duplicating skill definitions.

## Usage
`ls .agents/skills` lists the same skill directories available from `.claude/skills`.

## Design Notes
- **Key choices:** Use one relative directory symlink so both discovery paths share the same definitions.

## Verification
- **Tests added:** `test -L .agents/skills` verifies the path is a symlink.
- **Target resolution:** A `realpath` equality check verifies both paths resolve to the same directory.
- **Git storage:** A temporary-index check verifies mode `120000`.

## Review Focus
- Scrutinize the `.agents/skills` relative target for repository portability.
