### PR TITLE
dashboard: read open phase markers regardless of age

### DIFF
--- a/miles/dashboard/store.py
+++ b/miles/dashboard/store.py
@@ -721,11 +721,12 @@ class MetricStore:
 
     def _phase_events(self, t0: float | None, t1: float | None) -> list[PhaseEvent]:
         # closed phases partition by END hour (lower bound exact, slack one
-        # max phase duration FORWARD — design §17); OPEN markers partition by
-        # their START hour, so the lower bound gets the same slack BACKWARD
-        lower = None if t0 is None else t0 - self.MAX_WINDOW_S
+        # max phase duration FORWARD — design §17). OPEN markers partition by
+        # their START hour and may be arbitrarily old (a stalled run can sit
+        # in one phase for many hours), so no lower bound: the stream is
+        # low-rate enough that reading every partition stays cheap
         upper = None if t1 is None else t1 + self.MAX_WINDOW_S
-        return self._readers[Stream.PHASES].window(lower, upper)
+        return self._readers[Stream.PHASES].window(None, upper)
 
     def has_stream(self, stream: Stream) -> bool:
         if stream in self.PARTITIONED_STREAMS:

--- a/miles/dashboard/store.py
+++ b/miles/dashboard/store.py
@@ -720,11 +720,6 @@ class MetricStore:
         return lanes
 
     def _phase_events(self, t0: float | None, t1: float | None) -> list[PhaseEvent]:
-        # closed phases partition by END hour (lower bound exact, slack one
-        # max phase duration FORWARD — design §17). OPEN markers partition by
-        # their START hour and may be arbitrarily old (a stalled run can sit
-        # in one phase for many hours), so no lower bound: the stream is
-        # low-rate enough that reading every partition stays cheap
         upper = None if t1 is None else t1 + self.MAX_WINDOW_S
         return self._readers[Stream.PHASES].window(None, upper)
 


### PR DESCRIPTION
## Motivation

The compute-utilization view showed `waiting for phase data…` (and blank lane timelines) for the entire tail of a run that had stalled: a 744B run starved by rollout request timeouts finished its last train step at +3.8h and then sat in a single open `train_wait` for 11.5 hours. The phase stream is fine — the open marker is on disk — but no window after the marker's start hour could see it.

`_phase_events` selects hourly partitions with a lower bound of `t0 - MAX_WINDOW_S`, i.e. it assumes an open phase marker is at most 4h old. An open marker partitions by its START hour, so once it is older than 4h it falls out of every later window read. The renderer already knows how to draw an open phase through to the data edge (#1965) — the read side just never delivered the event.

This is exactly the situation where the phase view matters most: a fleet-wide stall rendered as "no data" instead of 100% `train_wait`.

## Modifications

Drop the lower bound on the phases partition read. The phases stream is low-rate (~40KB/h; 563KB for a 15h 16-node run), so reading every partition up to the window's upper bound stays cheap — the two high-rate streams (`gpu_util`, `engine_series`) are unaffected.

Verified on the stalled run's dump: trailing-4h fleet composition goes from empty (`waiting for phase data…`) to `{train_wait: 0.50, rollout: 0.50}`, matching the actual stall. `tests/fast/dashboard/test_store.py`: 14 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)