### PR TITLE
session: collect speculative-decoding counters

### DIFF
--- a/miles/rollout/session/samples/merge.py
+++ b/miles/rollout/session/samples/merge.py
@@ -123,6 +123,8 @@ def _compute_sample_from_openai_record(
         case "abort":
             sample.status = Sample.Status.ABORTED
 
+    if args.sglang_speculative_algorithm:
+        sample.spec_info.add(choice.get("meta_info", {}))
     sample.prefix_cache_info.add(choice.get("meta_info", {}))
     if "weight_version" in choice["meta_info"]:
         sample.weight_versions.append(choice["meta_info"]["weight_version"])

--- a/tests/fast/rollout/session/test_samples.py
+++ b/tests/fast/rollout/session/test_samples.py
@@ -16,8 +16,10 @@ from miles.utils.types import Sample
 
 # ── helpers ──────────────────────────────────────────────────────────
 
-_ARGS = SimpleNamespace(save_debug_trajectory_data=None)
-_ARGS_RECORDING = SimpleNamespace(save_debug_trajectory_data="/unused/{rollout_id}.jsonl")
+_ARGS = SimpleNamespace(save_debug_trajectory_data=None, sglang_speculative_algorithm=None)
+_ARGS_RECORDING = SimpleNamespace(
+    save_debug_trajectory_data="/unused/{rollout_id}.jsonl", sglang_speculative_algorithm=None
+)
 
 
 def _mock_tokenizer():


### PR DESCRIPTION
`rollout/spec_accept_rate` and `rollout/spec_accept_length` are always 0.0 for agentic (session/TITO) rollouts, even with EAGLE running and the engine logging a real accept length.

## Cause

`Sample.update_from_meta_info` collects three things off the direct rollout path:

```python
if args.sglang_speculative_algorithm:
    self.spec_info.add(meta_info=meta_info)
self.prefix_cache_info.add(meta_info=meta_info)
if "weight_version" in meta_info: ...
```

The session path re-derives the same fields in `_compute_sample_from_openai_record` — it carries a `# TODO unify with Sample.update_from_meta_info` right above — but copies only `prefix_cache_info` and `weight_versions`. `spec_info` is left at its zero value, and `metrics.py` averages those zeros.

Measured on a 16-node GLM-5.2 run: all 64 dumped samples of a rollout had `spec_info = {0, 0, 0, 0}` while the engines logged `accept len: 1.77`. With the counters collected, `spec_accept_length` reports 1.86-1.88.

## Note on spec_accept_rate

It stays 0.0 after this change, by data availability rather than by bug:

```
spec_verify_ct         362549   present
completion_token_num   682896   present
spec_accept_token_num       0   not in meta_info
spec_draft_token_num        0   not in meta_info
```

`spec_accept_length = completion_token_num / spec_verify_ct` works; `spec_accept_rate` needs two fields this sglang version does not send. Surfacing those would be an engine-side change.

## Test fixtures

The two `SimpleNamespace` fixtures in `tests/fast/rollout/session/test_samples.py` gain `sglang_speculative_algorithm`. This is required, not cosmetic: the new read is direct rather than via `getattr`, so without the attribute every test in that file raises `AttributeError`. `tests/fast/rollout/session` + `test_lifecycle_metadata.py`: 45 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)