### PR TITLE
test: run MXFP8 and NVFP4 colocate E2E on 8 GPUs

### DIFF
--- a/tests/e2e/megatron/model_scripts/test_deepseek_v32_5layer_mxfp8.py
+++ b/tests/e2e/megatron/model_scripts/test_deepseek_v32_5layer_mxfp8.py
@@ -15,8 +15,7 @@ MODEL_ORG = "Pinaster"
 MODEL_NAME = "DeepSeek-V3.2-5layer"
 MODEL_TYPE = "deepseek-v32-5layer"
 NUM_GPUS = 8
-ACTOR_NUM_GPUS = 4
-ROLLOUT_NUM_GPUS = 4
+ACTOR_NUM_GPUS = 8
 ROLLOUT_GPUS_PER_ENGINE = 2
 NUM_LAYERS_AT_START_IN_BF16 = 1
 NUM_LAYERS_AT_END_IN_BF16 = 1
@@ -178,7 +177,7 @@ def execute():
         "--sglang-kv-cache-dtype bf16 "
         "--sglang-page-size 64 "
         f"--rollout-num-gpus-per-engine {ROLLOUT_GPUS_PER_ENGINE} "
-        "--sglang-fp8-gemm-backend flashinfer_trtllm "
+        "--sglang-fp8-gemm-backend flashinfer_cutlass "
         "--sglang-moe-runner-backend flashinfer_trtllm_routed "
         f"--sglang-tp-size {ROLLOUT_GPUS_PER_ENGINE} "
         f"--sglang-dp-size {ROLLOUT_GPUS_PER_ENGINE} "
@@ -230,7 +229,7 @@ def execute():
         "--actor-num-nodes 1 "
         f"--actor-num-gpus-per-node {ACTOR_NUM_GPUS} "
         f"--num-gpus-per-node {NUM_GPUS} "
-        f"--rollout-num-gpus {ROLLOUT_NUM_GPUS} "
+        "--colocate "
         "--use-fault-tolerance "
     )
 

--- a/tests/e2e/megatron/test_glm5_2_744b_a40b_5layer_nvfp4.py
+++ b/tests/e2e/megatron/test_glm5_2_744b_a40b_5layer_nvfp4.py
@@ -17,8 +17,7 @@ MODEL_ORG = "Pinaster"
 MODEL_NAME = "GLM-5.2_5layer"
 MODEL_TYPE = "glm5.2-744B-A40B_5layer"
 NUM_GPUS = 8
-ACTOR_NUM_GPUS = 4
-ROLLOUT_NUM_GPUS = 4
+ACTOR_NUM_GPUS = 8
 ROLLOUT_GPUS_PER_ENGINE = 2
 NUM_LAYERS_AT_START_IN_BF16 = 1
 NUM_LAYERS_AT_END_IN_BF16 = 1
@@ -280,7 +279,7 @@ def execute():
         "--actor-num-nodes 1 "
         f"--actor-num-gpus-per-node {ACTOR_NUM_GPUS} "
         f"--num-gpus-per-node {NUM_GPUS} "
-        f"--rollout-num-gpus {ROLLOUT_NUM_GPUS} "
+        "--colocate "
         "--use-fault-tolerance "
         "--moe-enable-deepep "
         "--moe-token-dispatcher-type flex "


### PR DESCRIPTION
## Summary

- run the DeepSeek V3.2 5-layer MXFP8 E2E with all 8 GPUs assigned to both training and rollout through `--colocate`
- use `flashinfer_cutlass` for dense MXFP8 GEMMs while retaining `flashinfer_trtllm_routed` for MoE
- run the GLM-5.2 5-layer NVFP4 E2E with the same 8-GPU training and 8-GPU colocated rollout configuration

## Validation

- `pre-commit run --all-files`
- DeepSeek V3.2 MXFP8 on 8x B200 using `radixark/miles:dev-202607310056`:
  - Ray job `raysubmit_cew7izfsDc9HMh7U` succeeded
  - completed 3/3 rollouts and 24/24 training steps with `mixed_version_ratio=0.0`
  - completed the weight-checker lifecycle and recovered the one injected rollout-engine failure
- GLM-5.2 NVFP4 on 8x B200 using the same image with FlashInfer manually upgraded to `0.6.15.post1`:
  - Ray job `raysubmit_w1uk7ceaCdTrsJ7G` succeeded
  - completed 2/2 rollouts, 2/2 training steps, and all 3 weight-update/resume cycles without a hang

The GLM-5.2 recipe disables the log-probability and weight-update equality checkers, so that run validates the colocated lifecycle and liveness rather than numerical equality.
