### PR TITLE
session: tolerate args without sglang_speculative_algorithm in sample merge

### DIFF
--- a/miles/rollout/session/samples/merge.py
+++ b/miles/rollout/session/samples/merge.py
@@ -123,7 +123,7 @@ def _compute_sample_from_openai_record(
         case "abort":
             sample.status = Sample.Status.ABORTED
 
-    if args.sglang_speculative_algorithm:
+    if getattr(args, "sglang_speculative_algorithm", None):
         sample.spec_info.add(choice.get("meta_info", {}))
     sample.prefix_cache_info.add(choice.get("meta_info", {}))
     if "weight_version" in choice["meta_info"]:


### PR DESCRIPTION
#2028 added a direct `args.sglang_speculative_algorithm` read in `_compute_sample_from_openai_record`; callers whose args namespace lacks the attribute (e.g. the `generate_hub` test fixtures' SimpleNamespace) now crash with AttributeError, surfacing as `500` from `POST /sessions/<id>/samples` and failing `tests/fast/rollout/generate_hub/test_multi_turn.py` on stage-b-cpu — currently red on main-based PRs (see #1683 checks, #2032 probe). One-line fix: read it with `getattr` like the other optional knobs.