### PR TITLE
[AMD] fix mooncake object store support

### DIFF
--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -8,7 +8,7 @@
 #    build-arg:GPU_ARCH=gfx942  SGLANG_IMAGE_TAG=v0.5.10-rocm700-mi30x
 #
 # 3. rocm720-mi35x  (gfx950, ROCm 7.2 / MI350 / MI355X)
-#    build-arg:SGLANG_IMAGE_REPO=rocm/sgl-dev  SGLANG_IMAGE_TAG=v0.5.14-rocm720-mi35x-20260627
+#    build-arg:SGLANG_IMAGE_REPO=rocm/sgl-dev  SGLANG_IMAGE_TAG=v0.5.16-rocm720-mi35x-20260730
 
 ARG SGLANG_IMAGE_REPO=lmsysorg/sglang
 ARG SGLANG_IMAGE_TAG=v0.5.10-rocm700-mi35x
@@ -39,6 +39,7 @@ ARG RCCL_TESTS_PATH=projects/rccl-tests
 
 ARG TRANSFORMER_ENGINE_REPO=https://github.com/ROCm/TransformerEngine.git
 ARG TRANSFORMER_ENGINE_BRANCH=v2.8_rocm
+ARG MOONCAKE_VERSION=0.3.12.post1
 
 # ======================================== Setup ================================================
 WORKDIR /root/
@@ -100,6 +101,11 @@ RUN pip uninstall -y transformer-engine transformer_engine transformer_engine_to
       cd /root/TransformerEngine && NVTE_FUSED_ATTN=0 pip install . --no-build-isolation -v; \
     fi
 RUN pip install /tmp/wheels/flash_attn-*.whl
+
+# make install lays down mooncake's native modules but not its pure Python files.
+RUN pip install --no-deps --target=/tmp/mc "mooncake-transfer-engine-non-cuda==${MOONCAKE_VERSION}" && \
+    cp -n /tmp/mc/mooncake/*.py "$(python3 -c 'import mooncake, os; print(os.path.dirname(mooncake.__file__))')" && \
+    rm -rf /tmp/mc
 
 RUN pip install flash-linear-attention==0.4.2
 

--- a/docker/build.py
+++ b/docker/build.py
@@ -80,7 +80,7 @@ VARIANTS = {
         "build_args": {
             "GPU_ARCH": "gfx950",
             "SGLANG_IMAGE_REPO": "rocm/sgl-dev",
-            "SGLANG_IMAGE_TAG": "v0.5.14-rocm720-mi35x-20260627",
+            "SGLANG_IMAGE_TAG": "v0.5.16-rocm720-mi35x-20260730",
             "APPLY_ROCR_VMMFIX": "1",
             "TE_USE_WHEEL": "1",
         },


### PR DESCRIPTION
Co-authored-with: @JessicaJiang-123

## Problem

On ROCm, `mooncake.structured_object_store` is missing:

```python
>>> import mooncake.structured_object_store
ModuleNotFoundError: No module named 'mooncake.structured_object_store'
```

The failure occurs when `MooncakeObjectStore` is constructed during actor startup, before the first training step, and breaks the three ROCm CI tests using the mooncake object-store backend.

## Cause

The SGLang ROCm base builds Mooncake from source with CMake and `make install`, but its install rules omit `structured_object_store.py` and other Python files. As a result, the image contains the native extensions but only 10 of the 21 Python files included in the published wheel.

The CUDA base installs Mooncake with pip and is unaffected.

Updating the ROCm base alone is insufficient:

| base | `structured_object_store` | `setup(config: dict)` | `remove(key, force)` |
|---|---|---|---|
| `v0.5.14-rocm720-mi35x-20260627` (current pin) | no | no | no |
| `v0.5.16-rocm720-mi35x-20260730` (newest) | **no** | yes | yes |

## Change

**`docker/Dockerfile.rocm`** copies the missing Python files from the published wheel. `cp -n` fills only missing files and does not overwrite the HIP-linked native installation.

**`docker/build.py`** updates `rocm720-mi35x` to the 20260730 v0.5.16 base, which provides the required native `setup(config: dict)` and `remove(key, force)` APIs.

## Verification

The image build completed successfully. Triggered the MI350 Miles test matrix (2/4/8 GPU) against `rocm/sgl-dev:miles-rocm720-mi35x-20260731`:

https://github.com/sgl-project/sglang/actions/runs/30615835947

All 14 tests passed, nothing skipped. That is the entire miles ROCm CI surface.

**`stage-c-2-gpu-mi350`, 1/1**

- `tests/e2e/long/test_qwen2.5_0.5B_gsm8k_async.py`

**`stage-c-4-gpu-mi350`, 6/6**

- `tests/e2e/lora/test_lora_qwen2.5_0.5B.py`
- `tests/e2e/megatron/test_mimo_7B_mtp_only_grad.py`
- `tests/e2e/megatron/test_qwen3_30B_A3B/test_baseline.py` (mooncake)
- `tests/e2e/megatron/test_qwen3_30B_A3B/test_r3_baseline.py`
- `tests/e2e/precision/test_hf_attention_cp_relayout.py`
- `tests/e2e/precision/test_qwen3_5_cp_correctness.py`

**`stage-c-8-gpu-mi350`, 7/7**

- `tests/e2e/ckpt/test_qwen3_4B_ckpt.py`
- `tests/e2e/sglang_config/test_sglang_config.py`
- `tests/e2e/sglang_config/test_sglang_config_mixed_offload.py`
- `tests/e2e/sglang_config/test_sglang_config_mixed_offload_ft.py`
- `tests/e2e/short/test_qwen2.5_0.5B_gsm8k_async_short.py` (mooncake)
- `tests/e2e/short/test_qwen2.5_0.5B_gsm8k_short.py` (mooncake)
- `tests/e2e/short/test_run_megatron.py`