### PR TITLE
[AMD] DeepSeek-V4: use the ROCm precision-parity norm path

### DIFF
--- a/scripts/amd/run_deepseek_v4.py
+++ b/scripts/amd/run_deepseek_v4.py
@@ -413,7 +413,7 @@ def _train(args: ScriptArgs):
         "SGLANG_DSV4_FP4_EXPERTS": "0",
         "SGLANG_HACK_FLASHMLA_BACKEND": "triton",
         "SGLANG_OPT_USE_TILELANG_INDEXER": "true",
-        "SGLANG_OPT_USE_COMPRESSOR_V2": "false",
+        "SGLANG_OPT_USE_JIT_NORM": "false",  # JIT norm+RoPE increases logprobdiff on ROCm
         "SGLANG_OPT_USE_FUSED_COMPRESS": "true",
         "SGLANG_HEALTH_CHECK_TIMEOUT": "120",
         "AITER_BF16_FP8_MOE_BOUND": "0",


### PR DESCRIPTION
Co-authored-with: @JessicaJiang-123

When radixark/miles#1607 landed, the 4-node run read a `train_rollout_logprob_abs_diff` of 0.045. After the `sglang-miles` was bumped the same recipe reads 0.213. Two independent SGLang changes account for it.

The first is sgl-project/sglang#29275, which flipped the producer and consumer contract for the fused RMS FP8 activation scale across the model files but left `models/deepseek_v4.py` on the old side of it, so that scale gets transposed twice. That one is being fixed upstream in sgl-project/sglang#31727.

The second issue is the compressor path. sgl-project/sglang#26208 originally added two ROCm precision fallbacks: `SGLANG_OPT_USE_COMPRESSOR_V2=false` selected the pre-V2 `CompressorHip` implementation.

radixark/miles#1607 has set `SGLANG_OPT_USE_COMPRESSOR_V2=false`. However, sgl-project/sglang#28612 removed the pre-V2 compressor selection, leaving V2 as the only implementation. Within V2, `CompressorBackendMixin.forward_unified` still selects between two numerically different norm plus rope plus store paths on ROCm:

```python
if _is_hip and not envs.SGLANG_OPT_USE_JIT_NORM.get():
    self._forward_unified_hip(...)          # Triton precision-parity path
else:
    self._forward_compress_all_in_one(...)  # fused JIT path
```

The Triton branch explicitly documents its purpose:

```text
# Step 2: norm + rope (Triton fallback for precision parity with V1)
```

`SGLANG_OPT_USE_JIT_NORM` defaults to true, so after the pre-V2 selection was removed, this launcher silently began using the fused JIT path, increasing the trainer-rollout logprob difference.

This change drops the inert `SGLANG_OPT_USE_COMPRESSOR_V2` setting and enables the remaining precision-parity path with `SGLANG_OPT_USE_JIT_NORM=false`.

## Verification

Four MI355X nodes, TP8 PP4 EP8, response length 16384, `--offload-rollout-level kv_cache`, task `dapo_aime`. All results are from step 0 with the same weights and recipe.

| Arm                                           | abs\_diff at step 0 |
| --------------------------------------------- | ------------------- |
| today's tree                                  | 0.21290             |
| plus the sgl-project/sglang#31727 scale fix | 0.13108             |
| plus `SGLANG_OPT_USE_JIT_NORM=false`          | **0.04510**         |
| healthy reference on the same setup           | 0.04482             |

With the scale fix already applied, this change reduces `train_rollout_logprob_abs_diff` from 0.13108 to 0.04510, matching the healthy reference. Applying only the compressor change, without the scale fix, gives 0.16284, so both fixes are required for the full recovery.

## Notes

The parity path reduces decode throughput because it replaces one fused launch with Triton norm plus rope, quant, and scatter.

|                                 | default JIT | parity path | change    |
| ------------------------------- | ----------- | ----------- | --------- |
| prefill throughput (token/s)    | 25758       | 25640       | -0.5%     |
| decode throughput (token/s)     | 552.3       | 508.0       | **-8.0%** |
| end-to-end throughput (token/s) | 7070        | 6640        | -6.1%     |

Measured with `sglang.bench_one_batch` on one MI355X node: TP4, batch 8, input 1024, output 64.

TODO: Fix the numerical drift in the fused JIT path so the parity fallback can be removed.