### PR TITLE
Address engines by base URL when the router is dp-aware

### DIFF
--- a/miles/ray/multi_lora/backend.py
+++ b/miles/ray/multi_lora/backend.py
@@ -12,6 +12,7 @@ import httpx
 
 from miles.ray.multi_lora.registry import AdapterRegistry, AdapterState
 from miles.utils.adapter_config import AdapterRunConfig
+from miles.utils.http_utils import router_worker_base_urls
 from miles.utils.multi_lora import RID_SEPARATOR, min_groups_per_dp_split
 
 logger = logging.getLogger(__name__)
@@ -169,7 +170,7 @@ class MultiLoRABackend:
             try:
                 resp = await self.client.get(f"{self.router_url}{endpoint}")
                 if resp.status_code == 200:
-                    return extract(resp.json())
+                    return router_worker_base_urls(extract(resp.json()))
             except Exception:
                 continue
         return []

--- a/miles/rollout/inference_rollout/inference_rollout_train.py
+++ b/miles/rollout/inference_rollout/inference_rollout_train.py
@@ -12,7 +12,7 @@ from miles.rollout.filter_hub.base_types import MetricGatherer, call_dynamic_fil
 from miles.rollout.generate_utils.prefill_logprobs import recompute_samples_rollout_logprobs_via_prefill
 from miles.rollout.inference_rollout.inference_rollout_common import GenerateState, generate_and_rm_group
 from miles.utils import dumper_utils
-from miles.utils.http_utils import get, post
+from miles.utils.http_utils import get, post, router_worker_base_urls
 from miles.utils.misc import as_completed_async, call_agent_abort_hook, load_function
 from miles.utils.types import Sample
 
@@ -54,10 +54,11 @@ async def abort(state: GenerateState, pendings: set, rollout_id: int) -> list[li
 async def get_worker_urls(args: Namespace):
     if parse(sglang_router.__version__) <= parse("0.2.1") or args.use_miles_router:
         response = await get(f"http://{args.sglang_router_ip}:{args.sglang_router_port}/list_workers")
-        return response["urls"]
+        urls = response["urls"]
     else:
         response = await get(f"http://{args.sglang_router_ip}:{args.sglang_router_port}/workers")
-        return [worker["url"] for worker in response["workers"]]
+        urls = [worker["url"] for worker in response["workers"]]
+    return router_worker_base_urls(urls)
 
 
 def submit_generate_tasks(state: GenerateState, samples: list[list[Sample]]):

--- a/miles/rollout/sglang_rollout.py
+++ b/miles/rollout/sglang_rollout.py
@@ -20,7 +20,7 @@ from miles.utils import dumper_utils
 from miles.utils.async_utils import run
 from miles.utils.data import Dataset
 from miles.utils.eval_config import EvalDatasetConfig
-from miles.utils.http_utils import get, post
+from miles.utils.http_utils import get, post, router_worker_base_urls
 from miles.utils.lifecycle import TrajectoryLifecycle
 from miles.utils.lora import LORA_ADAPTER_NAME, is_lora_enabled
 from miles.utils.misc import SingletonMeta, call_agent_abort_hook, load_function
@@ -383,6 +383,7 @@ async def abort(args: Namespace, rollout_id: int) -> list[list[Sample]]:
     else:
         response = await get(f"http://{args.sglang_router_ip}:{args.sglang_router_port}/workers")
         urls = [worker["url"] for worker in response["workers"]]
+    urls = router_worker_base_urls(urls)
 
     logger.info(f"Abort request for {urls}")
     abort_tasks = [post(f"{url}/abort_request", {"abort_all": True}) for url in urls]

--- a/miles/utils/http_utils.py
+++ b/miles/utils/http_utils.py
@@ -139,6 +139,18 @@ def _wrap_ipv6(host):
         return host
 
 
+def router_worker_base_urls(urls: list[str]) -> list[str]:
+    """Strip the `@<rank>` suffix dp-aware routing adds; ranks of one engine dedupe to one address."""
+    bases = []
+    for url in urls:
+        base, sep, rank = url.rpartition("@")
+        if sep and rank.isdigit():
+            url = base
+        if url not in bases:
+            bases.append(url)
+    return bases
+
+
 def run_router(args):
     # Spawned as a fresh interpreter, so it inherits no logging config.
     configure_logger_raw("router")

--- a/tests/fast/backends/sglang_utils/test_router_dp_aware.py
+++ b/tests/fast/backends/sglang_utils/test_router_dp_aware.py
@@ -5,6 +5,7 @@ register_cpu_ci(est_time=20, suite="stage-a-cpu", labels=[])
 import argparse
 
 from miles.backends.sglang_utils.arguments import add_sglang_arguments, validate_args
+from miles.utils.http_utils import router_worker_base_urls
 
 
 def _args(argv):
@@ -26,3 +27,21 @@ def test_dp_attention_turns_on_router_dp_aware():
 
 def test_router_dp_aware_untouched_without_dp_attention():
     assert _args([]).router_dp_aware is False
+
+
+def test_dp_rank_suffix_stripped_and_engines_deduplicated():
+    # dp-aware routing reports one entry per DP rank; they share one addressable server.
+    assert router_worker_base_urls(["http://h:8080@0", "http://h:8080@1"]) == ["http://h:8080"]
+
+
+def test_plain_worker_urls_pass_through_in_order():
+    assert router_worker_base_urls(["http://h:8080", "http://h:8081"]) == ["http://h:8080", "http://h:8081"]
+
+
+def test_ipv6_dp_rank_suffix_stripped():
+    assert router_worker_base_urls(["http://[::1]:8080@0"]) == ["http://[::1]:8080"]
+
+
+def test_non_numeric_suffix_is_not_a_dp_rank():
+    # userinfo, not a rank: stripping it would change which host is addressed.
+    assert router_worker_base_urls(["http://user:pass@h:8080"]) == ["http://user:pass@h:8080"]


### PR DESCRIPTION
## Motivation

`stage-c-2-gpu-h200` has been failing on `test_glm5_744b_a40b_4layer_r3.py` ([example run](https://github.com/radixark/miles/actions/runs/30667576687/job/91279291037)). The engine is healthy the whole time — it answers `GET /health` with 200 twelve seconds into the failure — but `abort()` cannot reach it:

```text
22:00:47.353  inference_rollout_train.py:29 - Abort request for ['***1', '***0']
22:00:47.354  http_utils.py:214 - Error: All connection attempts failed, retrying... (attempt 1/60, url=***0/abort_request)
22:00:59      [SGLangEngine pid=15520] INFO: "GET /health HTTP/1.1" 200 OK
22:01:46.657  http_utils.py:218 - Max retries (60) reached, failing... (url=***0/abort_request)
              httpx.ConnectError: All connection attempts failed
```

Two worker URLs differing only in a trailing digit, for a run with `sglang_dp_size=2` and a single `SGLangEngine` process.

`sglang_engine.py` registers one plain, connectable URL per engine:

```python
                payload = {
                    "url": f"http://{self.server_host}:{self.server_port}",
                    "worker_type": self.worker_type,
                }
```

Under dp-aware routing the router expands that into one entry per DP rank and suffixes each with `@<rank>`. From sgl-router:

```rust
        assert_eq!(dp_worker.url(), "http://worker1:8080@2");
        assert_eq!(dp_worker.base_url(), "http://worker1:8080");
```

`WorkerInfo` exposes only `url`, so `GET /workers` hands back the routing identity. Miles then uses it as an HTTP base — `post(f"{url}/abort_request", ...)` — producing `http://host:port@0/abort_request`, where httpx parses `host:port` as userinfo and `0` as the hostname. Every connection attempt fails, `abort()` exhausts its 60 retries, and the exception propagates out of `generate_rollout_async` and kills the run.

The assumption that a router worker entry is an address held only because `router_dp_aware` defaults to `False` and nothing in miles ever set it — `git log -S router_dp_aware` returns exactly one commit. #2012 turns it on for every run with `--sglang-enable-dp-attention`, which is what surfaced this. dp-aware routing is correct and should stay on; the consumers are what needed updating.

## What this PR does

Adds `router_worker_base_urls()` in `http_utils` (next to `_wrap_ipv6`, the existing URL-shaping helper) and applies it at the three sites that use router worker entries as HTTP bases:

| Site | Used for |
|---|---|
| `inference_rollout/inference_rollout_train.py` `get_worker_urls` | `abort()` — the failure above — and `dumper_utils.configure_sglang` via the same helper |
| `sglang_rollout.py` `abort` | legacy-stack duplicate of the same logic |
| `ray/multi_lora/backend.py` `worker_urls` | `abort_adapter_requests` |

It mirrors the router's own `BasicWorker::normalised_url`, including the check that the suffix parses as a number, so a URL carrying userinfo is left alone. Ranks of one engine collapse to the same base, so the result is deduplicated — otherwise `abort()` would post `abort_all` once per rank to the same server.

Only `get_worker_urls`'s first consumer was actually failing today; `configure_sglang` posts `/dumper/configure` to the same URLs and would fail identically on any dp-attention run with the dumper's inference phase enabled.

## Testing

Extends `tests/fast/backends/sglang_utils/test_router_dp_aware.py` (`stage-a-cpu`) with four cases: rank suffixes stripped and engines deduplicated, plain URLs passed through in order, IPv6 hosts, and a non-numeric suffix left intact. `pre-commit run --all-files` passes.

The real check is `stage-c-2-gpu-h200` going green again — that test sets `--sglang-enable-dp-attention` with `--sglang-dp-size 2`, so it exercises the dp-aware path end to end.
