### PR TITLE
Support DFlash rollouts without logprobs

### DIFF
--- a/miles/rollout/generate_utils/generate_endpoint_utils.py
+++ b/miles/rollout/generate_utils/generate_endpoint_utils.py
@@ -13,6 +13,44 @@ from miles.utils.processing_utils import encode_image_for_rollout_engine, extrac
 from miles.utils.types import Sample
 
 
+_SPECULATIVE_ALGORITHMS_WITHOUT_LOGPROBS = {"DFLASH", "DSPARK"}
+
+
+def generation_return_logprob(args) -> bool:
+    algorithm = getattr(args, "sglang_speculative_algorithm", None)
+    if isinstance(algorithm, str):
+        algorithm = algorithm.upper()
+    if algorithm not in _SPECULATIVE_ALGORITHMS_WITHOUT_LOGPROBS:
+        return True
+
+    incompatible_features = [
+        name
+        for name in (
+            "use_rollout_logprobs",
+            "use_tis",
+            "get_mismatch_metrics",
+            "recompute_logprobs_via_prefill",
+        )
+        if getattr(args, name, False)
+    ]
+    # Sampled-token OPD computes student logprobs during training. Top-k OPD also
+    # scores student tokens through the rollout server, which DFLASH/DSPARK reject.
+    if getattr(args, "use_opd", False) and (getattr(args, "opd_log_prob_top_k", 0) or 0) > 0:
+        incompatible_features.append("use_opd with opd_log_prob_top_k")
+    if incompatible_features:
+        raise ValueError(
+            f"{algorithm} speculative decoding does not support rollout logprobs required by: "
+            + ", ".join(incompatible_features)
+        )
+    return False
+
+
+def get_response_tokens_and_logprobs(output: dict[str, Any]) -> tuple[list[int], list[float] | None]:
+    if (token_logprobs := output["meta_info"].get("output_token_logprobs")) is not None:
+        return [item[1] for item in token_logprobs], [item[0] for item in token_logprobs]
+    return list(output.get("output_ids", [])), None
+
+
 # Make this an isolated function because users may want to compute their own
 def compute_prompt_ids_from_sample(state, sample, tools=None):
     prompt = sample.prompt
@@ -65,7 +103,7 @@ def compute_request_payload(
     payload = {
         "input_ids": input_ids,
         "sampling_params": {**sampling_params, "max_new_tokens": max_new_tokens},
-        "return_logprob": True,
+        "return_logprob": generation_return_logprob(args),
         "return_routed_experts": args.use_rollout_routing_replay,
         "return_indexer_topk": args.use_rollout_indexer_replay,
     }
@@ -84,20 +122,19 @@ async def update_sample_from_response(
     if (len(sample.response) == 0) and not sample.tokens:
         sample.tokens = payload["input_ids"]
 
-    if x := output["meta_info"].get("output_token_logprobs"):
-        new_response_tokens = [item[1] for item in x]
-        new_response_log_probs = [item[0] for item in x]
-    else:
-        new_response_tokens, new_response_log_probs = [], []
+    new_response_tokens, new_response_log_probs = get_response_tokens_and_logprobs(output)
 
     # Update sample with tokens directly - avoiding re-tokenization
     sample.tokens = sample.tokens + new_response_tokens
     sample.response_length += len(new_response_tokens)
     sample.response += output["text"]
 
-    if sample.rollout_log_probs is None:
-        sample.rollout_log_probs = []
-    sample.rollout_log_probs += new_response_log_probs
+    if new_response_log_probs is None:
+        sample.rollout_log_probs = None
+    else:
+        if sample.rollout_log_probs is None:
+            sample.rollout_log_probs = []
+        sample.rollout_log_probs += new_response_log_probs
 
     if update_loss_mask:
         if sample.loss_mask is None:

--- a/miles/rollout/generate_utils/tool_call_utils.py
+++ b/miles/rollout/generate_utils/tool_call_utils.py
@@ -61,7 +61,8 @@ def update_sample_with_tool_responses(sample: Sample, tool_messages: list[dict[s
     sample.response_length += len(next_obs_tokens_ids)
     sample.tokens += next_obs_tokens_ids
     sample.loss_mask += [0] * len(next_obs_tokens_ids)
-    sample.rollout_log_probs += [0.0] * len(next_obs_tokens_ids)
+    if sample.rollout_log_probs is not None:
+        sample.rollout_log_probs += [0.0] * len(next_obs_tokens_ids)
 
 
 # TODO: very naive implementation, need the to-be-implemented e2e test to validate.

--- a/miles/rollout/sglang_rollout.py
+++ b/miles/rollout/sglang_rollout.py
@@ -37,8 +37,8 @@ from miles.utils.types import Sample
 from .generate_utils.generate_endpoint_utils import (
     compute_routing_headers,
     generation_return_logprob,
-    get_response_tokens_and_logprobs,
     get_indexer_topk_from_response,
+    get_response_tokens_and_logprobs,
     policy_uses_routing_key,
 )
 from .generate_utils.prefill_logprobs import recompute_samples_rollout_logprobs_via_prefill

--- a/miles/rollout/sglang_rollout.py
+++ b/miles/rollout/sglang_rollout.py
@@ -36,6 +36,8 @@ from miles.utils.types import Sample
 
 from .generate_utils.generate_endpoint_utils import (
     compute_routing_headers,
+    generation_return_logprob,
+    get_response_tokens_and_logprobs,
     get_indexer_topk_from_response,
     policy_uses_routing_key,
 )
@@ -170,7 +172,7 @@ async def generate(args: Namespace, sample: Sample, sampling_params: dict[str, A
     # Prepare payload for sglang server
     payload = {
         "sampling_params": sampling_params,
-        "return_logprob": True,
+        "return_logprob": generation_return_logprob(args),
     }
     opd_top_k = getattr(args, "opd_log_prob_top_k", 0) or 0
     opd_top_k_strategy = getattr(args, "opd_top_k_strategy", "only-student")
@@ -221,11 +223,7 @@ async def generate(args: Namespace, sample: Sample, sampling_params: dict[str, A
             sample.metadata.setdefault("opd_student_top_logprobs", [])
             sample.metadata["opd_student_top_logprobs"].extend(output_top_logprobs)
 
-    if "output_token_logprobs" in output["meta_info"]:
-        new_response_tokens = [item[1] for item in output["meta_info"]["output_token_logprobs"]]
-        new_response_log_probs = [item[0] for item in output["meta_info"]["output_token_logprobs"]]
-    else:
-        new_response_tokens, new_response_log_probs = [], []
+    new_response_tokens, new_response_log_probs = get_response_tokens_and_logprobs(output)
 
     # Update sample with tokens directly - avoiding re-tokenization
     sample.tokens = sample.tokens + new_response_tokens
@@ -237,9 +235,12 @@ async def generate(args: Namespace, sample: Sample, sampling_params: dict[str, A
         assert args.partial_rollout and args.mask_offpolicy_in_partial_rollout
         sample.loss_mask += [1] * len(new_response_tokens)
 
-    if sample.rollout_log_probs is None:
-        sample.rollout_log_probs = []
-    sample.rollout_log_probs += new_response_log_probs
+    if new_response_log_probs is None:
+        sample.rollout_log_probs = None
+    else:
+        if sample.rollout_log_probs is None:
+            sample.rollout_log_probs = []
+        sample.rollout_log_probs += new_response_log_probs
 
     if "routed_experts" in output["meta_info"]:
         sample.rollout_routed_experts = np.frombuffer(

--- a/miles/utils/test_utils/mock_sglang_server.py
+++ b/miles/utils/test_utils/mock_sglang_server.py
@@ -111,7 +111,6 @@ class MockSGLangServer:
         return JSONResponse(content=response)
 
     def _compute_generate_response(self, payload: dict) -> dict:
-        assert payload.get("return_logprob", True) is True, "MockSGLangServer requires return_logprob=True"
         input_ids = payload.get("input_ids", [])
 
         prompt_str = self.tokenizer.decode(input_ids, skip_special_tokens=False)
@@ -132,11 +131,12 @@ class MockSGLangServer:
             "prompt_tokens": prompt_tokens,
             "cached_tokens": process_result.cached_tokens,
             "completion_tokens": completion_tokens,
-            "output_token_logprobs": output_token_logprobs,
             **process_result.meta_info.to_dict(),
         }
+        if payload.get("return_logprob", True):
+            meta_info["output_token_logprobs"] = output_token_logprobs
 
-        return {"text": process_result.text, "meta_info": meta_info}
+        return {"text": process_result.text, "output_ids": output_ids, "meta_info": meta_info}
 
     def _compute_chat_completions_response(self, payload: dict) -> dict:
         messages = payload.get("messages", [])

--- a/miles/utils/test_utils/mock_sglang_server.py
+++ b/miles/utils/test_utils/mock_sglang_server.py
@@ -133,10 +133,14 @@ class MockSGLangServer:
             "completion_tokens": completion_tokens,
             **process_result.meta_info.to_dict(),
         }
-        if payload.get("return_logprob", True):
+        return_logprob = payload.get("return_logprob", True)
+        if return_logprob:
             meta_info["output_token_logprobs"] = output_token_logprobs
 
-        return {"text": process_result.text, "output_ids": output_ids, "meta_info": meta_info}
+        response = {"text": process_result.text, "meta_info": meta_info}
+        if not return_logprob:
+            response["output_ids"] = output_ids
+        return response
 
     def _compute_chat_completions_response(self, payload: dict) -> dict:
         messages = payload.get("messages", [])

--- a/tests/fast/rollout/generate_hub/test_multi_turn.py
+++ b/tests/fast/rollout/generate_hub/test_multi_turn.py
@@ -245,6 +245,28 @@ class TestBasicMultiTurn:
         ]
         verify_samples(result.sample, expected)
 
+    @pytest.mark.parametrize(
+        "generation_env",
+        [{"args_kwargs": {"sglang_speculative_algorithm": "DSPARK"}}],
+        indirect=True,
+    )
+    def test_two_turns_without_rollout_logprobs(self, variant, generation_env):
+        if is_agentic_variant(variant):
+            pytest.skip("OpenAI session generation does not use the /generate endpoint helper")
+        generation_env.mock_server.process_fn = TwoTurnStub.process_fn
+
+        S = TwoTurnStub
+        result = _run_generate(variant, generation_env, make_sample(prompt=S.PROMPT))
+
+        assert len(result.requests) == 2
+        assert all(request["return_logprob"] is False for request in result.requests)
+        sample = result.sample
+        assert sample.response == S.FIRST_RESPONSE + S.FIRST_TOOL_RESPONSE + S.SECOND_RESPONSE
+        assert sample.rollout_log_probs is None
+        assert 0 in sample.loss_mask
+        assert 1 in sample.loss_mask
+        sample.validate()
+
 
 class TestExitConditions:
     @pytest.mark.parametrize(

--- a/tests/fast/rollout/generate_hub/test_single_turn.py
+++ b/tests/fast/rollout/generate_hub/test_single_turn.py
@@ -12,7 +12,10 @@ from PIL import Image
 from tests.fast.fixtures.generation_fixtures import GenerateEnv, generation_env, listify, make_sample, run_generate
 from transformers import AutoProcessor
 
-from miles.rollout.generate_utils.generate_endpoint_utils import generation_return_logprob, get_response_tokens_and_logprobs
+from miles.rollout.generate_utils.generate_endpoint_utils import (
+    generation_return_logprob,
+    get_response_tokens_and_logprobs,
+)
 from miles.utils.processing_utils import encode_image_for_rollout_engine
 from miles.utils.test_utils.mock_sglang_server import ProcessResult, ProcessResultMetaInfo
 from miles.utils.types import Sample

--- a/tests/fast/rollout/generate_hub/test_single_turn.py
+++ b/tests/fast/rollout/generate_hub/test_single_turn.py
@@ -2,6 +2,8 @@ from tests.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=220, suite="stage-b-cpu", labels=[])
 
+from types import SimpleNamespace
+
 import numpy as np
 import pybase64
 import pytest
@@ -10,6 +12,7 @@ from PIL import Image
 from tests.fast.fixtures.generation_fixtures import GenerateEnv, generation_env, listify, make_sample, run_generate
 from transformers import AutoProcessor
 
+from miles.rollout.generate_utils.generate_endpoint_utils import generation_return_logprob, get_response_tokens_and_logprobs
 from miles.utils.processing_utils import encode_image_for_rollout_engine
 from miles.utils.test_utils.mock_sglang_server import ProcessResult, ProcessResultMetaInfo
 from miles.utils.types import Sample
@@ -128,6 +131,63 @@ def _run_generate(variant: str, env: GenerateEnv, sample: Sample | None = None, 
 
 
 # ------------------------------------ tests ----------------------------------------
+
+
+class TestSpeculativeGenerationWithoutLogprobs:
+    @pytest.mark.parametrize(
+        "generation_env",
+        [
+            pytest.param({"args_kwargs": {"sglang_speculative_algorithm": "DFLASH"}}, id="dflash"),
+            pytest.param({"args_kwargs": {"sglang_speculative_algorithm": "dspark"}}, id="lowercase-dspark"),
+        ],
+        indirect=True,
+    )
+    def test_generation_uses_output_ids_without_logprobs(self, variant, generation_env):
+        result = _run_generate(variant, generation_env)
+
+        assert len(result.requests) == 1
+        assert result.requests[0]["return_logprob"] is False
+        sample = listify(result.sample)[0]
+        assert sample.tokens == PROMPT_TOKENS + RESPONSE_TOKENS
+        assert sample.response_length == len(RESPONSE_TOKENS)
+        assert sample.rollout_log_probs is None
+        sample.validate()
+
+    @pytest.mark.parametrize(
+        "feature",
+        [
+            "use_rollout_logprobs",
+            "use_tis",
+            "get_mismatch_metrics",
+            "recompute_logprobs_via_prefill",
+        ],
+    )
+    def test_logprob_dependent_features_are_rejected(self, feature):
+        args = SimpleNamespace(sglang_speculative_algorithm="DSPARK", **{feature: True})
+
+        with pytest.raises(ValueError, match=feature):
+            generation_return_logprob(args)
+
+    def test_topk_opd_is_rejected(self):
+        args = SimpleNamespace(sglang_speculative_algorithm="DFLASH", use_opd=True, opd_log_prob_top_k=8)
+
+        with pytest.raises(ValueError, match="use_opd with opd_log_prob_top_k"):
+            generation_return_logprob(args)
+
+    def test_sampled_token_opd_does_not_require_rollout_logprobs(self):
+        args = SimpleNamespace(sglang_speculative_algorithm="DFLASH", use_opd=True, opd_log_prob_top_k=0)
+
+        assert generation_return_logprob(args) is False
+
+    def test_empty_logprob_list_is_preserved(self):
+        output = {"meta_info": {"output_token_logprobs": []}}
+
+        assert get_response_tokens_and_logprobs(output) == ([], [])
+
+    def test_empty_output_without_logprobs_stays_optional(self):
+        output = {"output_ids": [], "meta_info": {}}
+
+        assert get_response_tokens_and_logprobs(output) == ([], None)
 
 
 class TestBasicGeneration:


### PR DESCRIPTION
## Summary

@humansand

- Disable rollout logprob requests for SGLang DFLASH and DSPARK, which do not
  support `return_logprob` during speculative generation.
- Consume SGLang's top-level `output_ids` and leave rollout logprobs optional so
  the training backend can compute actor logprobs.
- Reject features that genuinely require rollout-side logprobs, while retaining
  sampled-token OPD support.
- Cover shared and legacy rollout paths, lowercase algorithm names, empty
  completions, and multi-turn tool observations.

## Root cause

Miles unconditionally sent `return_logprob=true`. SGLang's DFlash family rejects
that request before generation, so deterministic HTTP 400 responses could also
trip the router circuit breakers and surface later as HTTP 503 errors.

## Validation

- `pytest -q tests/fast/rollout/generate_hub/test_single_turn.py tests/fast/rollout/generate_hub/test_multi_turn.py -k 'SpeculativeGenerationWithoutLogprobs or two_turns_without_rollout_logprobs'`: 18 passed, 1 skipped
- `python3 -m py_compile` on all six changed Python files
- `ruff check` on all six changed Python files
- `git diff --check`
- Eight-node/64-B200 colocated DeepSeek-V4 DSPARK integration
  (`raysubmit_2jzhLgZzcvEqGfdu`): exactly three 256/256 rollout generations,
  three actor/reference-logprob and backward/optimizer steps, and four 543/543
  target-weight syncs completed with all rank phases `ok=true`
- The integration run had no HTTP 400/503 responses or fatal errors, kept MTP
  training disabled, and left the raw DSPARK drafter metadata hashes unchanged
