### PR TITLE
fix: use paged MLA prefill on B200

### DIFF
--- a/docs/models/glm/glm4-7-flash.md
+++ b/docs/models/glm/glm4-7-flash.md
@@ -53,11 +53,11 @@ The Python launcher does the conversion automatically.
 cd /root/miles
 bash scripts/run-glm4.7-flash.sh
 
-# Python launcher (H200 only — `hardware` literal in the dataclass)
+# Python launcher (defaults to H200; pass --hardware B200 on B200)
 python scripts/run_glm47_flash.py
 ```
 
-Defaults of the Python launcher (see `ScriptArgs`): `model_org=zai-org`, `model_name=GLM-4.7-Flash`, `num_gpus_per_node=8`, `hardware=H200`, `data_dir=/root/datasets`, `model_dir=/root/models`.
+Defaults of the Python launcher (see `ScriptArgs`): `model_org=zai-org`, `model_name=GLM-4.7-Flash`, `num_gpus_per_node=8`, `hardware=H200`, `data_dir=/root/datasets`, `model_dir=/root/models`. The `hardware` CLI also accepts `B200`.
 
 ## 5. Recipe Configuration
 
@@ -90,6 +90,8 @@ SGLANG_ARGS=(
    --use-rollout-routing-replay
 )
 ```
+
+On B200, invoke the Python launcher with `--hardware B200`; it adds `--sglang-flashinfer-mla-disable-ragged`. This avoids the unsupported FlashInfer SM100 ragged prefill path for the model's 256-dimensional QK and value heads while preserving FlashInfer's paged prefill and default decode paths. With the default `--hardware H200`, the launcher keeps automatic backend selection.
 
 ### 5.4 Optimizer
 

--- a/scripts/run_glm47_flash.py
+++ b/scripts/run_glm47_flash.py
@@ -14,7 +14,7 @@ class ScriptArgs(U.ExecuteTrainConfig):
     model_name: str = "GLM-4.7-Flash"
     megatron_model_type: str = "glm4.7-flash"
     num_gpus_per_node: int = 8
-    hardware: Literal["H200"] = "H200"
+    hardware: Literal["H200", "B200"] = "H200"
     enable_eval: bool = True
     extra_args: str = ""
     data_dir: str = "/root/datasets"
@@ -127,6 +127,9 @@ def execute(args: ScriptArgs):
         # rollout routing replay
         "--use-rollout-routing-replay "
     )
+
+    if args.hardware == "B200":
+        sglang_args += "--sglang-flashinfer-mla-disable-ragged "
 
     misc_args = (
         "--attention-dropout 0.0 "


### PR DESCRIPTION
## Summary
Use paged MLA prefill for GLM-4.7-Flash on B200.

## Symptom & Reproduction
- **Symptom:** B200 target prefill raises `Unsupported head dimensions: head_dim_qk=256, head_dim_vo=256` instead of serving `/health_generate`.
- **Reproduction:** Run `python scripts/run_glm47_flash.py --hardware B200` in the Miles B200 Docker environment.

## Root Cause
1. `fmha_cutlass_sm100.cu` rejects the model's `(256, 256)` ragged head dimensions.
2. `flashinfer_mla_backend` selects the unsupported SM100 ragged prefill path by default.

## Fix
`ScriptArgs.hardware` now accepts `B200`, and `execute` passes SGLang's existing `--sglang-flashinfer-mla-disable-ragged` flag only for B200. This selects the supported paged MLA prefill path without changing the default H200 behavior or eight-GPU topology.

## Verification
- **New / updated test:** An isolated launcher harness asserts B200-only flag emission.
- **Topology preservation:** The harness asserts the frozen GPU-topology tuple is unchanged.
- **Static check:** Python source compilation succeeds.
- **Whitespace check:** `git diff --check` succeeds.

## Review Focus
- Scrutinize the B200-only condition around `--sglang-flashinfer-mla-disable-ragged` in `execute`.
- Scrutinize `docs/models/glm/glm4-7-flash.md` for preserved H200 defaults and topology.
