### PR TITLE
[lora] lora-native CI suite: qwen3 / qwen3.5 / glm4.7 / glm5.2-5layer / kimi-k2.5-2layer

### DIFF
--- a/tests/ci/labels.py
+++ b/tests/ci/labels.py
@@ -26,6 +26,7 @@ KNOWN_LABELS: dict[str, str] = {
     "long": "Long-running training tests",
     "ckpt": "Checkpoint save / load tests",
     "lora": "LoRA training tests",
+    "lora-native": "Native (raw-mode) LoRA plugin e2e tests",
     "precision": "Numerical precision parity tests",
     "ft-short": "Fault-tolerance trainer comparison tests (no_failure / deterministic / with_failure)",
     "ft-long": "Fault-tolerance trainer soak tests (random-crash survival, realistic-gsm8k convergence)",

--- a/tests/e2e/lora_native/test_glm47_flash_lora_native_ci.py
+++ b/tests/e2e/lora_native/test_glm47_flash_lora_native_ci.py
@@ -1,0 +1,40 @@
+import os
+
+from scripts.run_lora_native import ScriptArgs, _prepare, _train
+from tests.ci.ci_register import register_cuda_ci
+
+# Native (raw-mode) LoRA on GLM-4.7-Flash: the MLA registry's reference model —
+# replicated q_a/kv_a down-projections plus column-parallel up-projections
+# under TP2/EP4. Covers prepare (download + torch_dist conversion) and the full
+# rollout -> train -> adapter-sync loop with the CI checkers on (cross-engine
+# logprob agreement at abs_tol 0.03, step-0 ppo_kl).
+
+register_cuda_ci(est_time=3600, suite="stage-c-8-gpu-h200", labels=["lora-native"])
+
+
+def _args() -> ScriptArgs:
+    return ScriptArgs(
+        model_name="GLM-4.7-Flash",
+        model_dir="/root/models",
+        num_nodes=1,
+        num_gpus_per_node=8,
+        num_rollout=2,
+        enable_wandb=False,
+        extra_args="--ci-test ",
+    )
+
+
+def prepare(args: ScriptArgs):
+    _prepare(args)
+
+
+def execute(args: ScriptArgs):
+    _train(args)
+
+
+if __name__ == "__main__":
+    for proxy_var in ("http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY"):
+        os.environ.pop(proxy_var, None)
+    args = _args()
+    prepare(args)
+    execute(args)

--- a/tests/e2e/lora_native/test_glm5_2_5layer_lora_native_ci.py
+++ b/tests/e2e/lora_native/test_glm5_2_5layer_lora_native_ci.py
@@ -1,0 +1,41 @@
+import os
+
+from scripts.run_glm5_2_744b_a40b_lora_native import ScriptArgs, _prepare, _train
+from tests.ci.ci_register import register_cuda_ci
+
+# Native (raw-mode) LoRA on the 5-layer GLM-5.2 prune (3 dense + 2 MoE): MLA
+# adapters alongside DSA cross-layer index sharing, TP=EP=4. Covers prepare
+# (download + single-rank torch_dist conversion — any PP split of the toy
+# starts a stage on a DSA skip layer) and the rollout -> train -> adapter-sync
+# loop. The logprobs checker is disabled like the other pruned-toy CIs: the
+# toy's rollout entropy legitimately exceeds the checker's real-model bound.
+
+register_cuda_ci(est_time=2400, suite="stage-c-4-gpu-h200", labels=["lora-native"])
+
+
+def _args() -> ScriptArgs:
+    return ScriptArgs(
+        model_name="GLM-5.2_5layer",
+        model_dir="/root/models",
+        num_nodes=1,
+        num_gpus_per_node=4,
+        num_rollout=2,
+        enable_wandb=False,
+        extra_args="--ci-test --ci-disable-logprobs-checker ",
+    )
+
+
+def prepare(args: ScriptArgs):
+    _prepare(args)
+
+
+def execute(args: ScriptArgs):
+    _train(args)
+
+
+if __name__ == "__main__":
+    for proxy_var in ("http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY"):
+        os.environ.pop(proxy_var, None)
+    args = _args()
+    prepare(args)
+    execute(args)

--- a/tests/e2e/lora_native/test_kimi_k25_2layer_lora_native_ci.py
+++ b/tests/e2e/lora_native/test_kimi_k25_2layer_lora_native_ci.py
@@ -1,0 +1,43 @@
+import os
+
+from scripts.run_lora_native import ScriptArgs, _prepare, _train
+from tests.ci.ci_register import register_cuda_ci
+
+# Native (raw-mode) LoRA on the 2-layer Kimi-K2.5 prune: MLA adapters on the
+# multimodal-shelled checkpoint. Prepare covers the whole K2.5 pipeline this
+# repo owns — INT4 -> BF16 dequant (which must strip quantization_config, or
+# SGLang serves the BF16 weights through its CompressedTensors path with a
+# context-free forward), the kimi_k25 mbridge conversion, and the
+# language_model-prefixed weight-sync naming. The logprobs checker is disabled
+# like the other pruned-toy CIs: the toy's rollout entropy legitimately exceeds
+# the checker's real-model bound.
+
+register_cuda_ci(est_time=3600, suite="stage-c-8-gpu-h200", labels=["lora-native"])
+
+
+def _args() -> ScriptArgs:
+    return ScriptArgs(
+        model_name="Kimi-K2.5-2layer",
+        model_dir="/root/models",
+        num_nodes=1,
+        num_gpus_per_node=8,
+        num_rollout=2,
+        enable_wandb=False,
+        extra_args="--ci-test --ci-disable-logprobs-checker ",
+    )
+
+
+def prepare(args: ScriptArgs):
+    _prepare(args)
+
+
+def execute(args: ScriptArgs):
+    _train(args)
+
+
+if __name__ == "__main__":
+    for proxy_var in ("http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY"):
+        os.environ.pop(proxy_var, None)
+    args = _args()
+    prepare(args)
+    execute(args)

--- a/tests/e2e/lora_native/test_qwen3_0_6b_lora_native_ci.py
+++ b/tests/e2e/lora_native/test_qwen3_0_6b_lora_native_ci.py
@@ -1,0 +1,39 @@
+import os
+
+from scripts.run_qwen3_lora_native import ScriptArgs, _prepare_download, _train
+from tests.ci.ci_register import register_cuda_ci
+
+# Smoke test for the native (raw-mode) LoRA plugin on the dense-GQA reference
+# recipe. Qwen3-0.6B on 2 GPUs with TP2+SP is the cheapest end-to-end check and
+# exercises both adapter grad-summation paths (column- and row-parallel). Full
+# rollout -> train -> adapter-sync loop with the CI checkers on (cross-engine
+# logprob agreement at abs_tol 0.03, step-0 ppo_kl).
+
+register_cuda_ci(est_time=1500, suite="stage-c-2-gpu-h200", labels=["lora-native"])
+
+
+def _args() -> ScriptArgs:
+    return ScriptArgs(
+        model_name="Qwen3-0.6B",
+        num_nodes=1,
+        num_gpus_per_node=2,
+        num_rollout=2,
+        enable_wandb=False,
+        extra_args="--ci-test ",
+    )
+
+
+def prepare(args: ScriptArgs):
+    _prepare_download(args)
+
+
+def execute(args: ScriptArgs):
+    _train(args)
+
+
+if __name__ == "__main__":
+    for proxy_var in ("http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY"):
+        os.environ.pop(proxy_var, None)
+    args = _args()
+    prepare(args)
+    execute(args)

--- a/tests/e2e/lora_native/test_qwen3_5_35b_a3b_lora_native_ci.py
+++ b/tests/e2e/lora_native/test_qwen3_5_35b_a3b_lora_native_ci.py
@@ -1,0 +1,41 @@
+import os
+
+from scripts.run_lora_native import ScriptArgs, _prepare, _train
+from tests.ci.ci_register import register_cuda_ci
+
+# Native (raw-mode) LoRA on Qwen3.5-35B-A3B: the hybrid GQA+GDN registry —
+# gated fused-QKV adapters on the full-attention layers, mixer-only layers
+# legitimately carrying none. Covers prepare (download + torch_dist
+# conversion) and the full rollout -> train -> adapter-sync loop with the CI
+# checkers on. Also guards the raw-mode GDN backward: the registry's historical
+# instability note surfaces as grad_norm explosions from step 1 if it regresses.
+
+register_cuda_ci(est_time=3600, suite="stage-c-8-gpu-h200", labels=["lora-native"])
+
+
+def _args() -> ScriptArgs:
+    return ScriptArgs(
+        model_name="Qwen3.5-35B-A3B",
+        model_dir="/root/models",
+        num_nodes=1,
+        num_gpus_per_node=8,
+        num_rollout=2,
+        enable_wandb=False,
+        extra_args="--ci-test ",
+    )
+
+
+def prepare(args: ScriptArgs):
+    _prepare(args)
+
+
+def execute(args: ScriptArgs):
+    _train(args)
+
+
+if __name__ == "__main__":
+    for proxy_var in ("http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY"):
+        os.environ.pop(proxy_var, None)
+    args = _args()
+    prepare(args)
+    execute(args)


### PR DESCRIPTION
Stacked on #2017 (base: `yusheng/lora-plugin-refactor`). Adds a `lora-native` CI suite — five e2e smoke tests, one per shipped native-LoRA registry shape, each driving the corresponding launch script's `prepare` + `train` with 2 rollouts and `--ci-test`. Trigger: `run-ci-lora-native`.

## Coverage

| test | model | GPUs / suite | shape covered |
|---|---|---|---|
| `test_qwen3_0_6b_lora_native_ci` | Qwen3-0.6B | 2 × H200 | dense GQA reference; TP2+SP exercises both adapter grad-summation paths |
| `test_qwen3_5_35b_a3b_lora_native_ci` | Qwen3.5-35B-A3B | 8 × H200 | hybrid GQA+GDN (gated fused QKV, mixer-only layers); guards the raw-mode GDN backward against regression |
| `test_glm47_flash_lora_native_ci` | GLM-4.7-Flash | 8 × H200 | MLA reference: replicated q_a/kv_a + column-parallel up-projections, TP2/EP4 |
| `test_glm5_2_5layer_lora_native_ci` | GLM-5.2 5-layer | 4 × H200 | MLA + DSA cross-layer index sharing; single-rank toy conversion |
| `test_kimi_k25_2layer_lora_native_ci` | Kimi-K2.5 2-layer | 8 × H200 | multimodal-shelled MLA: INT4→BF16 dequant (quantization_config strip), kimi_k25 mbridge conversion, `language_model.`-prefixed weight sync |

Every test covers the full native pipeline: prepare (download → dequant where needed → torch_dist conversion, gated by `preflight_native_lora`) and the rollout → train → adapter-sync loop.

## Checker policy

- Real models run with all `--ci-test` checkers enabled — notably the cross-engine `log_probs` vs `rollout_log_probs` agreement (abs_tol 0.03), which is the train/serve parity gate the four 20-rollout validation runs sat well inside (~0.01).
- The two pruned toys add `--ci-disable-logprobs-checker`, matching the existing toy CIs: their rollout entropy legitimately exceeds the checker's real-model bound (their rewards are all-zero by construction). Step-0 `ppo_kl` and completion checks remain on.

## Verified

`test_qwen3_0_6b_lora_native_ci` ran end-to-end as CI would on an idle H200 pair: exit 0, `train_rollout_logprob_abs_diff` 0.013, all checkers passing. The other four reuse launch scripts validated with 20-rollout runs on this branch (wandb `ch271828n-team/miles_lora_native`).

## Maintainer action needed

`lora-native` is registered in `tests/ci/labels.py`; per its contract the matching **`run-ci-lora-native`** label must be created in the GitHub repo settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
