### PR TITLE
feat(opsd): add SGLang privileged-teacher support

### DIFF
--- a/docs/advanced/index.md
+++ b/docs/advanced/index.md
@@ -37,8 +37,8 @@ Routing Replay for MoE, speculative decoding, and LoRA training and serving.
 
   <Card title="On-Policy Distillation" icon="graduation-cap" href="/advanced/on-policy-distillation">
 
-    Train a student on its own rollouts while matching teacher token
-    probabilities through SGLang or Megatron teacher modes.
+    Add teacher guidance to RL with OPD, or train directly against a privileged
+    fixed teacher with OPSD.
 
   </Card>
 

--- a/docs/advanced/on-policy-distillation.md
+++ b/docs/advanced/on-policy-distillation.md
@@ -40,7 +40,10 @@ This avoids full-vocabulary runtime gathers. Set
 
 The stock text-only prompt builder requires `--label-key`. A custom builder
 receives `prompt`, `label`, and `metadata` keyword arguments and returns text or
-a chat conversation. Teacher scoring uses `--rollout-temperature`.
+a chat conversation. The teacher and student must use the same tokenizer and
+token-ID mapping because Miles sends student response IDs to the teacher and
+stores the teacher's compact top-k support as token IDs. Teacher scoring is a
+zero-generation prefill request and does not use `--rollout-temperature`.
 
 SGLang teachers work with both Megatron and FSDP students. Evaluation continues
 to use the configured task reward.

--- a/docs/advanced/on-policy-distillation.md
+++ b/docs/advanced/on-policy-distillation.md
@@ -1,8 +1,58 @@
 # On-Policy Distillation
 
+Miles provides two distinct on-policy distillation objectives:
+
+| Objective | Student data | Teacher context | Optimization |
+|-----------|--------------|-----------------|--------------|
+| OPD | Student rollouts | Original prompt | Adds a reverse-KL teacher penalty to an RL advantage |
+| OPSD | Student rollouts | Prompt, reference solution, and student prefix | Directly minimizes a forward-KL distillation loss |
+
+## On-Policy Self-Distillation
+
+OPSD is a pure fixed-teacher objective. The student samples a response; the
+teacher scores that exact response from a privileged prompt containing the
+reference solution. Gradients flow only through the student.
+
+Miles renormalizes both distributions over the teacher's top-k support \(S_t\)
+and clips each vocabulary contribution before summing:
+
+$$
+\mathcal{L}_t =
+\sum_{v \in S_t}
+\min\left(p_T(v)[\log p_T(v)-\log p_\theta(v)], c\right)
+$$
+
+This avoids full-vocabulary runtime gathers. Set
+`--opsd-pointwise-kl-clip 0` to disable clipping.
+
+### Configuration
+
+| Argument | Description |
+|----------|-------------|
+| `--loss-type opsd_loss` | Select OPSD. |
+| `--disable-compute-advantages-and-returns` | Required for the pure objective. |
+| `--opsd-type sglang` | Use an external SGLang fixed teacher. |
+| `--opsd-teacher-top-k` | Teacher support size; default `64`, minimum `2`. |
+| `--opsd-pointwise-kl-clip` | Per-entry upper clip; default `0.05`, `0` disables. |
+| `--opsd-teacher-url` | SGLang `/generate` endpoint. |
+| `--opsd-teacher-prompt-function-path` | Optional privileged-prompt builder. |
+| `--opsd-teacher-chat-template-kwargs` | Teacher-only chat-template JSON. |
+
+The stock text-only prompt builder requires `--label-key`. A custom builder
+receives `prompt`, `label`, and `metadata` keyword arguments and returns text or
+a chat conversation. Teacher scoring uses `--rollout-temperature`.
+
+SGLang teachers work with both Megatron and FSDP students. Evaluation continues
+to use the configured task reward.
+
+OPSD does not support additive RL objectives, dynamic teachers, multimodal or
+session rollouts, tools, or Multi-LoRA.
+
+## On-Policy Distillation
+
 On-policy distillation (OPD) trains a student model on its own rollouts while using a teacher model's token-level probabilities as the distillation signal. In Miles, the teacher signal is converted into a per-token reverse-KL penalty and applied after the selected RL advantage estimator has produced token advantages. This lets the same OPD recipe compose with GRPO, PPO, REINFORCE++, GSPO, and other estimators.
 
-## Key Arguments
+### OPD Arguments
 
 | Argument | Description |
 |----------|-------------|
@@ -17,7 +67,7 @@ On-policy distillation (OPD) trains a student model on its own rollouts while us
 | `--opd-teacher-load` | Path to teacher Megatron checkpoint. **Required** when `--opd-type=megatron`, **must not be set** when `--opd-type=sglang`. |
 | `--opd-teacher-ckpt-step` | Optional checkpoint step for teacher model. |
 
-## How It Works
+### How OPD Works
 
 OPD modifies the advantage computation by subtracting a KL penalty term that encourages the student to match the teacher's output distribution:
 
@@ -29,7 +79,7 @@ Where $A_t$ is the original advantage from the base estimator (e.g., GRPO), $\la
 
 The implementation follows the additive OPD training recipe described in the [Thinking Machines OPD blog](https://thinkingmachines.ai/blog/on-policy-distillation/), with an additional SGLang top-k reward mode from [Rethinking On-Policy Distillation](https://arxiv.org/abs/2604.13016).
 
-## Rethinking OPD Top-K Reward
+### Rethinking OPD Top-K Reward
 
 SGLang OPD supports the top-k token reward recipe from [Rethinking On-Policy Distillation](https://arxiv.org/abs/2604.13016). Set `--opd-log-prob-top-k` above zero to request student rollout top-logprobs, score the same sequence with the teacher, and aggregate a weighted reverse-KL estimate over a selected token set at each response position.
 
@@ -45,9 +95,9 @@ The token set is controlled by `--opd-top-k-strategy`:
 
 `--opd-reward-weight-mode` controls whether each selected token is weighted by student probability, teacher probability, or uniformly. For compatibility, `--opd-log-prob-top-k=0` keeps the original sampled-token OPD path.
 
-## Two Teacher Modes
+### OPD Teacher Modes
 
-### SGLang Mode (`--opd-type sglang`)
+#### SGLang Mode (`--opd-type sglang`)
 
 The teacher runs on an external SGLang server. Teacher log-probs are obtained during the rollout phase.
 
@@ -130,11 +180,11 @@ The teacher model is loaded directly into Megatron via `--opd-teacher-load`. Tea
 
 > **Note**: The teacher checkpoint must be in Megatron format (`torch_dist` or `torch`). You can convert from HuggingFace format using `tools/convert_hf_to_torch_dist.py`.
 
-## Running the Examples
+### Running the OPD Examples
 
 Complete example scripts are provided in `examples/on_policy_distillation/`:
 
-### SGLang Teacher
+#### SGLang Teacher
 
 ```bash
 # 1. Download models and data
@@ -154,7 +204,7 @@ PYTHONPATH=/root/Megatron-LM python tools/convert_hf_to_torch_dist.py \
 bash examples/on_policy_distillation/run-qwen3-8B-opd.sh
 ```
 
-### Megatron Teacher
+#### Megatron Teacher
 
 ```bash
 # 1. Convert both student and teacher models to Megatron format
@@ -162,7 +212,7 @@ bash examples/on_policy_distillation/run-qwen3-8B-opd.sh
 bash examples/on_policy_distillation/run-qwen3-8B-opd-megatron.sh
 ```
 
-## Preliminary Results
+### Preliminary OPD Results
 
 Using Qwen3-8B-Base model SFT-ed on part of the [OpenThoughts3-1.2M](https://huggingface.co/datasets/open-thoughts/OpenThoughts3-1.2M) dataset, on-policy distillation with a Qwen3-32B teacher on the remaining data yields:
 
@@ -175,3 +225,4 @@ Using Qwen3-8B-Base model SFT-ed on part of the [OpenThoughts3-1.2M](https://hug
 
 - [Thinking Machines: On-Policy Distillation](https://thinkingmachines.ai/blog/on-policy-distillation/)
 - [Rethinking On-Policy Distillation](https://arxiv.org/abs/2604.13016)
+- [On-Policy Self-Distillation](https://siyan-zhao.github.io/blog/2026/opsd/)

--- a/docs/user-guide/cli-reference.md
+++ b/docs/user-guide/cli-reference.md
@@ -235,6 +235,7 @@ Sections mirror the launch-script argument groups.
 
 | Flag | Type | Default | Notes |
 |---|---|---|---|
+| `--loss-type` | enum | `policy_loss` | `policy_loss`, `sft_loss`, `opsd_loss`, or `custom_loss`. |
 | `--advantage-estimator` | enum | `grpo` | `grpo`, `gspo`, `ppo`, `reinforce_plus_plus`, `reinforce_plus_plus_baseline`, `on_policy_distillation` |
 | `--use-kl-loss` | flag | off | Compute KL vs. reference. |
 | `--kl-loss-coef` | float | `0.0` | KL weight in loss (0 means monitor). |
@@ -249,6 +250,20 @@ Sections mirror the launch-script argument groups.
 | `--calculate-per-token-loss` | flag | off | Per-token loss reduction. |
 | `--no-check-for-nan-in-loss-and-grad` | flag | off | Skip NaN/Inf guard (Megatron flag, debug only). |
 | `--true-on-policy-mode` | flag | off | Strict on-policy: reject samples from a prior policy. |
+
+#### On-policy self-distillation
+
+See [On-Policy Distillation](/advanced/on-policy-distillation) for the OPSD
+objective and constraints.
+
+| Flag | Type | Default | Notes |
+|---|---|---|---|
+| `--opsd-type` | enum | – | Fixed teacher backend. Currently `sglang`. |
+| `--opsd-teacher-url` | str | – | SGLang `/generate` endpoint. Required for OPSD. |
+| `--opsd-teacher-top-k` | int | `64` | Teacher-selected vocabulary support size; minimum `2`. |
+| `--opsd-pointwise-kl-clip` | float | `0.05` | Per-entry forward-KL upper clip; `0` disables clipping. |
+| `--opsd-teacher-prompt-function-path` | str | – | Optional privileged-prompt builder. |
+| `--opsd-teacher-chat-template-kwargs` | JSON | `{}` | Chat-template arguments applied only to the privileged prompt. |
 
 ### Optimizer
 

--- a/miles/backends/fsdp_utils/actor.py
+++ b/miles/backends/fsdp_utils/actor.py
@@ -70,6 +70,7 @@ class FSDPTrainRayActor(TrainRayActor):
         indep_dp_info: IndepDPInfo,
     ) -> int | None:  # type: ignore[override]
         super().init(args, role, with_ref, with_opd_teacher=with_opd_teacher)
+        self._is_opsd = args.loss_type == "opsd_loss"
 
         # Unsupported
         assert recv_ckpt_src_rank is None
@@ -455,17 +456,18 @@ class FSDPTrainRayActor(TrainRayActor):
             len(num_microbatches) > 0
         ), f"Invalid num_microbatches {num_microbatches} for micro_batch_size {self.args.micro_batch_size} and global_batch_size {self.args.global_batch_size}"
 
-        if self.ref_model is not None:
-            with routing_replay.stage(routing_replay.FALLTHROUGH):
-                ref_results = self._compute_log_prob("ref", data_iterator, num_microbatches, store_prefix="ref_")
-            rollout_data.update(ref_results)
+        if not self._is_opsd:
+            if self.ref_model is not None:
+                with routing_replay.stage(routing_replay.FALLTHROUGH):
+                    ref_results = self._compute_log_prob("ref", data_iterator, num_microbatches, store_prefix="ref_")
+                rollout_data.update(ref_results)
 
-        with routing_replay.stage(routing_replay.log_prob_stage(self.args)):
-            actor_results = self._compute_log_prob("actor", data_iterator, num_microbatches)
-        routing_replay.rewind()
-        rollout_data.update(actor_results)
+            with routing_replay.stage(routing_replay.log_prob_stage(self.args)):
+                actor_results = self._compute_log_prob("actor", data_iterator, num_microbatches)
+            routing_replay.rewind()
+            rollout_data.update(actor_results)
 
-        compute_advantages_and_returns(self.args, rollout_data)
+            compute_advantages_and_returns(self.args, rollout_data)
 
         log_rollout_data(rollout_id, self.args, rollout_data)
 
@@ -494,6 +496,8 @@ class FSDPTrainRayActor(TrainRayActor):
                             "returns",
                             "ref_log_probs",
                             "rollout_log_probs",
+                            "opsd_teacher_token_ids",
+                            "opsd_teacher_scores",
                         ],
                         self.args.data_pad_size_multiplier,
                         self.args.qkv_format,

--- a/miles/backends/megatron_utils/actor.py
+++ b/miles/backends/megatron_utils/actor.py
@@ -470,6 +470,9 @@ class MegatronTrainRayActor(TrainRayActor):
         witness_info: WitnessInfo | None,
         attempt: int,
     ) -> TrainStepOutcome:
+        if self.args.colocate:
+            self._switch_model("actor")
+
         # Create data iterator for log_probs and train.
         data_iterator, num_microbatches = get_data_iterator(self.args, self.model, rollout_data)
 

--- a/miles/backends/megatron_utils/model.py
+++ b/miles/backends/megatron_utils/model.py
@@ -497,6 +497,8 @@ def train_one_step(
                 "witness_ids",
                 "opd_reverse_kl",
                 "rollout_mask_sums",
+                "opsd_teacher_token_ids",
+                "opsd_teacher_scores",
             ],
             args.data_pad_size_multiplier,
             args.qkv_format,

--- a/miles/backends/training_utils/cp_utils.py
+++ b/miles/backends/training_utils/cp_utils.py
@@ -219,7 +219,7 @@ def all_gather_with_cp(
             [len] + list(tensor.shape[1:]),
             dtype=tensor.dtype,
             device=tensor.device,
-            requires_grad=True,
+            requires_grad=tensor.requires_grad,
         )
 
     # logprob should be within the range of [prompt_length - 1, total_length - 1]
@@ -243,7 +243,10 @@ def all_gather_with_cp(
         full_tensor = torch.cat([left, chunk_0, mid, chunk_1, right], dim=0)
 
     assert full_tensor.shape[0] == response_length, f"Expected {response_length}, got {full_tensor.shape}"
-    full_tensor = dist.nn.all_reduce(full_tensor, group=cp_group)
+    if full_tensor.requires_grad:
+        full_tensor = dist.nn.all_reduce(full_tensor, group=cp_group)
+    else:
+        dist.all_reduce(full_tensor, group=cp_group)
     return full_tensor
 
 

--- a/miles/backends/training_utils/data.py
+++ b/miles/backends/training_utils/data.py
@@ -31,6 +31,42 @@ def _rollout_logprob_dtype(args: Namespace) -> torch.dtype:
     return torch.float32
 
 
+def _load_opsd_support(
+    args: Namespace,
+    rollout_data: RolloutBatch,
+    key: str,
+    dtype: torch.dtype,
+) -> list[torch.Tensor]:
+    support = []
+    for index, (values, total_length, response_length) in enumerate(
+        zip(
+            rollout_data[key],
+            rollout_data["total_lengths"],
+            rollout_data["response_lengths"],
+            strict=True,
+        )
+    ):
+        tensor = torch.as_tensor(values)
+        expected_values = response_length * args.opsd_teacher_top_k
+        if tensor.numel() != expected_values:
+            raise ValueError(
+                f"OPSD {key} has an invalid flattened length: "
+                f"sample={index}, expected={expected_values}, actual={tensor.numel()}."
+            )
+        tensor = tensor.reshape(response_length, args.opsd_teacher_top_k)
+        max_seq_len = rollout_data["max_seq_lens"][index] if args.qkv_format == "bshd" else None
+        support.append(
+            slice_log_prob_with_cp(
+                tensor,
+                total_length,
+                response_length,
+                args.qkv_format,
+                max_seq_len,
+            ).to(device=torch.cuda.current_device(), dtype=dtype)
+        )
+    return support
+
+
 def get_rollout_data(
     args: Namespace,
     rollout_data_ref: Box,
@@ -114,6 +150,23 @@ def get_rollout_data(
                     )
                 )
             ]
+    has_opsd_ids = "opsd_teacher_token_ids" in rollout_data
+    has_opsd_scores = "opsd_teacher_scores" in rollout_data
+    if has_opsd_ids != has_opsd_scores:
+        raise ValueError("OPSD compact support requires both teacher token ids and scores.")
+    if has_opsd_ids:
+        rollout_data["opsd_teacher_token_ids"] = _load_opsd_support(
+            args,
+            rollout_data,
+            "opsd_teacher_token_ids",
+            torch.long,
+        )
+        rollout_data["opsd_teacher_scores"] = _load_opsd_support(
+            args,
+            rollout_data,
+            "opsd_teacher_scores",
+            torch.float32,
+        )
     if "rollout_routed_experts" in rollout_data:
         rollout_data["rollout_routed_experts"] = [torch.from_numpy(r) for r in rollout_data["rollout_routed_experts"]]
     if "rollout_indexer_topk" in rollout_data:

--- a/miles/backends/training_utils/log_utils.py
+++ b/miles/backends/training_utils/log_utils.py
@@ -209,6 +209,8 @@ def log_rollout_data(rollout_id: int, args: Namespace, rollout_data: RolloutBatc
                 "step_adapter_names",
                 "step_adapter_batch_sizes",
                 "prompt_group_sizes",
+                "opsd_teacher_token_ids",
+                "opsd_teacher_scores",
             ]:
                 continue
             if isinstance(val, (list, tuple)):

--- a/miles/backends/training_utils/loss.py
+++ b/miles/backends/training_utils/loss.py
@@ -103,7 +103,7 @@ def loss_function(
 ) -> tuple[torch.Tensor, int | torch.Tensor, dict[str, list[str] | torch.Tensor]]:
     """Dispatch to the configured loss and rescale for Megatron integration.
 
-    Selects one of "policy_loss", "value_loss", "sft_loss", or a custom loss
+    Selects one of "policy_loss", "value_loss", "sft_loss", "opsd_loss", or a custom loss
     function based on `args.loss_type`, computes the loss and metrics, then
     rescales the loss by micro-batch and parallelism factors to integrate with
     Megatron's gradient accumulation.

--- a/miles/backends/training_utils/loss_hub/losses.py
+++ b/miles/backends/training_utils/loss_hub/losses.py
@@ -10,7 +10,11 @@ from miles.backends.training_utils.cp_utils import (
     get_sum_of_sample_mean,
 )
 from miles.backends.training_utils.loss_hub.corrections import vanilla_tis_function
-from miles.backends.training_utils.loss_hub.logit_processors import get_log_probs_and_entropy, get_values
+from miles.backends.training_utils.loss_hub.logit_processors import (
+    get_log_probs_and_entropy,
+    get_responses,
+    get_values,
+)
 from miles.backends.training_utils.loss_hub.math_utils import (
     compute_approx_kl,
     compute_ess_ratio_contribution,
@@ -18,6 +22,7 @@ from miles.backends.training_utils.loss_hub.math_utils import (
     compute_opsm_mask,
     compute_policy_loss,
 )
+from miles.backends.training_utils.loss_hub.opsd import compute_topk_forward_kl, gather_selected_logits
 from miles.backends.training_utils.parallel import get_parallel_state
 from miles.utils.misc import load_function
 from miles.utils.types import RolloutBatch
@@ -477,6 +482,77 @@ def sft_loss_function(
     )
 
 
+def opsd_loss_function(
+    args: Namespace,
+    batch: RolloutBatch,
+    logits: torch.Tensor,
+    sum_of_sample_mean: Callable[[torch.Tensor], torch.Tensor],
+) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
+    response_logits = get_responses(
+        logits,
+        args=args,
+        unconcat_tokens=batch["unconcat_tokens"],
+        total_lengths=batch["total_lengths"],
+        response_lengths=batch["response_lengths"],
+        max_seq_lens=batch.get("max_seq_lens"),
+    )
+    parallel_state = get_parallel_state()
+    vocab_size = getattr(args, "vocab_size", None) or logits.shape[-1] * parallel_state.tp.size
+    losses = []
+    forward_kls = []
+    clip_fractions = []
+
+    for (student_logits, _), teacher_ids, teacher_scores in zip(
+        response_logits,
+        batch["opsd_teacher_token_ids"],
+        batch["opsd_teacher_scores"],
+        strict=True,
+    ):
+        if teacher_ids.shape != teacher_scores.shape:
+            raise ValueError(
+                "OPSD teacher token ids and scores must have matching shapes, "
+                f"got ids={tuple(teacher_ids.shape)} and scores={tuple(teacher_scores.shape)}."
+            )
+        if teacher_ids.shape[0] != student_logits.shape[0]:
+            raise ValueError(
+                "OPSD teacher support must align with the local student response, "
+                f"got teacher={teacher_ids.shape[0]} and student={student_logits.shape[0]} tokens."
+            )
+        student_scores = gather_selected_logits(
+            logits=student_logits,
+            token_ids=teacher_ids.to(device=student_logits.device),
+            process_group=parallel_state.tp.group,
+            vocab_size=vocab_size,
+        )
+        sample_loss, forward_kl, clip_fraction = compute_topk_forward_kl(
+            student_scores=student_scores.float(),
+            teacher_scores=teacher_scores.to(device=student_logits.device, dtype=torch.float32),
+            pointwise_clip=args.opsd_pointwise_kl_clip,
+        )
+        losses.append(sample_loss)
+        forward_kls.append(forward_kl)
+        clip_fractions.append(clip_fraction)
+
+    token_losses = torch.cat(losses, dim=0)
+    token_forward_kls = torch.cat(forward_kls, dim=0)
+    token_clip_fractions = torch.cat(clip_fractions, dim=0)
+    loss = sum_of_sample_mean(token_losses)
+    forward_kl = sum_of_sample_mean(token_forward_kls)
+    clip_fraction = sum_of_sample_mean(token_clip_fractions)
+
+    if token_losses.numel() == 0:
+        loss = loss + 0 * logits.sum()
+
+    return (
+        loss,
+        {
+            "loss": loss.detach().clone(),
+            "opsd_forward_kl_topk": forward_kl.detach().clone(),
+            "opsd_clip_fraction": clip_fraction.detach().clone(),
+        },
+    )
+
+
 def get_loss_function(args: Namespace) -> LossFunction:
     match args.loss_type:
         case "policy_loss":
@@ -485,6 +561,8 @@ def get_loss_function(args: Namespace) -> LossFunction:
             return value_loss_function
         case "sft_loss":
             return sft_loss_function
+        case "opsd_loss":
+            return opsd_loss_function
         case "custom_loss":
             return load_function(args.custom_loss_function_path)
         case _:

--- a/miles/backends/training_utils/loss_hub/losses.py
+++ b/miles/backends/training_utils/loss_hub/losses.py
@@ -536,12 +536,14 @@ def opsd_loss_function(
     token_losses = torch.cat(losses, dim=0)
     token_forward_kls = torch.cat(forward_kls, dim=0)
     token_clip_fractions = torch.cat(clip_fractions, dim=0)
-    loss = sum_of_sample_mean(token_losses)
-    forward_kl = sum_of_sample_mean(token_forward_kls)
-    clip_fraction = sum_of_sample_mean(token_clip_fractions)
-
     if token_losses.numel() == 0:
-        loss = loss + 0 * logits.sum()
+        loss = 0 * logits.sum()
+        forward_kl = loss.detach()
+        clip_fraction = loss.detach()
+    else:
+        loss = sum_of_sample_mean(token_losses)
+        forward_kl = sum_of_sample_mean(token_forward_kls)
+        clip_fraction = sum_of_sample_mean(token_clip_fractions)
 
     return (
         loss,

--- a/miles/backends/training_utils/loss_hub/opsd.py
+++ b/miles/backends/training_utils/loss_hub/opsd.py
@@ -1,0 +1,88 @@
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+
+
+class _ReplicatedSelectedLogitsAllReduce(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, local_values: torch.Tensor, process_group: dist.ProcessGroup) -> torch.Tensor:
+        output = local_values.clone()
+        dist.all_reduce(output, group=process_group)
+        return output
+
+    @staticmethod
+    def backward(ctx, grad_output: torch.Tensor) -> tuple[torch.Tensor, None]:
+        return grad_output, None
+
+
+def gather_selected_logits(
+    *,
+    logits: torch.Tensor,
+    token_ids: torch.Tensor,
+    process_group: dist.ProcessGroup | None,
+    vocab_size: int,
+) -> torch.Tensor:
+    if logits.ndim != 2:
+        raise ValueError(f"OPSD logits must have shape [response, vocab], got {tuple(logits.shape)}.")
+    if token_ids.ndim != 2 or token_ids.shape[0] != logits.shape[0]:
+        raise ValueError(
+            "OPSD teacher token ids must have shape [response, top_k] aligned with logits, "
+            f"got ids={tuple(token_ids.shape)} and logits={tuple(logits.shape)}."
+        )
+    if token_ids.dtype not in (torch.int32, torch.int64):
+        raise TypeError(f"OPSD teacher token ids must be integer tensors, got {token_ids.dtype}.")
+    if vocab_size <= 0:
+        raise ValueError(f"OPSD vocab_size must be positive, got {vocab_size}.")
+    if token_ids.numel() and (token_ids.min() < 0 or token_ids.max() >= vocab_size):
+        raise ValueError(f"OPSD teacher token ids must be in [0, {vocab_size}).")
+
+    world_size = dist.get_world_size(process_group) if process_group is not None else 1
+    rank = dist.get_rank(process_group) if process_group is not None else 0
+    local_vocab_size = logits.shape[-1]
+    if local_vocab_size * world_size < vocab_size:
+        raise ValueError(
+            f"OPSD padded vocabulary has {local_vocab_size * world_size} entries, smaller than vocab_size={vocab_size}."
+        )
+
+    vocab_start = rank * local_vocab_size
+    local_ids = (token_ids - vocab_start).clamp(min=0, max=local_vocab_size - 1)
+    owned = (token_ids >= vocab_start) & (token_ids < vocab_start + local_vocab_size)
+    local_values = torch.gather(logits, dim=-1, index=local_ids)
+    local_values = local_values * owned.to(dtype=local_values.dtype)
+
+    if world_size == 1:
+        return local_values
+    return _ReplicatedSelectedLogitsAllReduce.apply(local_values, process_group)
+
+
+def compute_topk_forward_kl(
+    *,
+    student_scores: torch.Tensor,
+    teacher_scores: torch.Tensor,
+    pointwise_clip: float,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    if student_scores.shape != teacher_scores.shape:
+        raise ValueError(
+            "OPSD student and teacher scores must have matching [response, top_k] shapes, "
+            f"got student={tuple(student_scores.shape)} and teacher={tuple(teacher_scores.shape)}."
+        )
+    if student_scores.ndim != 2 or student_scores.shape[-1] < 2:
+        raise ValueError(f"OPSD scores must have shape [response, top_k>=2], got {tuple(student_scores.shape)}.")
+    if pointwise_clip < 0:
+        raise ValueError(f"OPSD pointwise KL clip must be non-negative, got {pointwise_clip}.")
+    if not torch.isfinite(student_scores).all():
+        raise ValueError("OPSD student scores contain non-finite values.")
+    if not torch.isfinite(teacher_scores).all():
+        raise ValueError("OPSD teacher scores contain non-finite values.")
+
+    teacher_log_probs = F.log_softmax(teacher_scores.detach(), dim=-1)
+    student_log_probs = F.log_softmax(student_scores, dim=-1)
+    contributions = teacher_log_probs.exp() * (teacher_log_probs - student_log_probs)
+    forward_kl = contributions.sum(dim=-1)
+
+    if pointwise_clip == 0:
+        return forward_kl, forward_kl, torch.zeros_like(forward_kl)
+
+    clipped = contributions.clamp(max=pointwise_clip)
+    clip_fraction = (contributions > pointwise_clip).to(dtype=contributions.dtype).mean(dim=-1)
+    return clipped.sum(dim=-1), forward_kl, clip_fraction

--- a/miles/ray/rollout/metrics.py
+++ b/miles/ray/rollout/metrics.py
@@ -169,8 +169,9 @@ def _compute_perf_metrics_from_samples(args, samples, rollout_time):
 
 
 def _compute_zero_std_metrics(args, all_samples: list[Sample]):
-    # only compute in GRPO-like algorithms where one prompt has multiple responses
-    if args.advantage_estimator == "ppo":
+    if args.advantage_estimator == "ppo" or any(
+        isinstance(sample.get_reward_value(args), dict) for sample in all_samples
+    ):
         return {}
 
     def _is_zero_std(samples: list[Sample]):

--- a/miles/ray/rollout/metrics.py
+++ b/miles/ray/rollout/metrics.py
@@ -169,9 +169,7 @@ def _compute_perf_metrics_from_samples(args, samples, rollout_time):
 
 
 def _compute_zero_std_metrics(args, all_samples: list[Sample]):
-    if args.advantage_estimator == "ppo" or any(
-        isinstance(sample.get_reward_value(args), dict) for sample in all_samples
-    ):
+    if args.advantage_estimator == "ppo" or args.loss_type == "opsd_loss":
         return {}
 
     def _is_zero_std(samples: list[Sample]):
@@ -219,6 +217,9 @@ def _compute_prefix_cache_metrics(args, all_samples: list[Sample]):
 
 
 def _compute_reward_cat_metrics(args, all_samples: list[Sample]):
+    if args.loss_type == "opsd_loss":
+        return {}
+
     reward_cat_key = args.log_reward_category
     if reward_cat_key is None:
         return {}
@@ -241,6 +242,9 @@ def _compute_passrate_from_samples(args, all_samples: list[Sample]) -> dict[str,
     Called on the rollout side (before convert_samples_to_train_data), so
     normally all samples are present and every group is complete.
     """
+    if args.loss_type == "opsd_loss":
+        return {}
+
     group_size = args.n_samples_per_prompt
     if group_size <= 1:
         return {}

--- a/miles/ray/rollout/train_data_conversion.py
+++ b/miles/ray/rollout/train_data_conversion.py
@@ -3,6 +3,7 @@ from typing import Any
 
 import torch
 
+from miles.rollout.on_policy_self_distillation import post_process_rewards as post_process_opsd_rewards
 from miles.utils import object_store
 from miles.utils.dp_schedule import build_dp_schedule, has_full_schedule_config
 from miles.utils.multi_lora import is_multi_lora_enabled
@@ -19,6 +20,8 @@ ROLLOUT_DATA_TENSOR_DTYPES = {
     "rollout_log_probs": "float32",
     "teacher_log_probs": "float32",
     "opd_reverse_kl": "float32",
+    "opsd_teacher_token_ids": "int32",
+    "opsd_teacher_scores": "float32",
     "rollout_routed_experts": "int32",
     "rollout_indexer_topk": "int32",
 }
@@ -151,6 +154,18 @@ def convert_samples_to_train_data(
     if samples[0].opd_reverse_kl is not None:
         train_data["opd_reverse_kl"] = [sample.opd_reverse_kl for sample in samples]
 
+    has_opsd_ids = [sample.opsd_teacher_token_ids is not None for sample in samples]
+    has_opsd_scores = [sample.opsd_teacher_scores is not None for sample in samples]
+    if has_opsd_ids != has_opsd_scores or any(has_opsd_ids) != all(has_opsd_ids):
+        raise ValueError("OPSD compact support requires both token ids and scores for every sample in the batch.")
+    if all(has_opsd_ids):
+        train_data["opsd_teacher_token_ids"] = [
+            torch.as_tensor(sample.opsd_teacher_token_ids, dtype=torch.int32).reshape(-1) for sample in samples
+        ]
+        train_data["opsd_teacher_scores"] = [
+            torch.as_tensor(sample.opsd_teacher_scores, dtype=torch.float32).reshape(-1) for sample in samples
+        ]
+
     x = metadata.get("dynamic_global_batch_size")
     assert args.use_dynamic_global_batch_size == (x is not None)
     if x is not None:
@@ -175,6 +190,9 @@ def _post_process_rewards(
     custom_reward_post_process_func,
     prompt_group_sizes: list[int] | None = None,
 ):
+    if getattr(args, "loss_type", None) == "opsd_loss" and getattr(args, "opsd_type", None) == "sglang":
+        return post_process_opsd_rewards(args, samples)
+
     if (f := custom_reward_post_process_func) is not None:
         return f(args, samples)
 
@@ -316,6 +334,8 @@ def _package_shards(args, data: dict[str, Any], partitions) -> list[dict[str, An
             "prompt",
             "teacher_log_probs",
             "opd_reverse_kl",
+            "opsd_teacher_token_ids",
+            "opsd_teacher_scores",
             "seq_witness_ids",
             "weight_versions",
             "adapter_slots",

--- a/miles/rollout/data_source.py
+++ b/miles/rollout/data_source.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import torch
 
+from miles.rollout.on_policy_self_distillation import build_teacher_prompt
 from miles.utils.data import Dataset
 from miles.utils.misc import load_function
 from miles.utils.processing_utils import load_processor, load_tokenizer
@@ -69,6 +70,14 @@ class RolloutDataSource(DataSource):
                 if hasattr(processor, "save_pretrained"):
                     processor.save_pretrained(Path(d) / "processor")
 
+            teacher_prompt_builder = None
+            if args.loss_type == "opsd_loss":
+                teacher_prompt_builder = (
+                    load_function(args.opsd_teacher_prompt_function_path)
+                    if args.opsd_teacher_prompt_function_path is not None
+                    else build_teacher_prompt
+                )
+
             self.dataset = Dataset(
                 args.prompt_data,
                 tokenizer=tokenizer,
@@ -81,6 +90,10 @@ class RolloutDataSource(DataSource):
                 tool_key=args.tool_key,
                 apply_chat_template=args.apply_chat_template,
                 apply_chat_template_kwargs=args.apply_chat_template_kwargs,
+                teacher_prompt_builder=teacher_prompt_builder,
+                teacher_chat_template_kwargs=(
+                    args.opsd_teacher_chat_template_kwargs if teacher_prompt_builder is not None else None
+                ),
                 seed=args.rollout_seed,
             )
             if self.args.rollout_shuffle:

--- a/miles/rollout/inference_rollout/inference_rollout_common.py
+++ b/miles/rollout/inference_rollout/inference_rollout_common.py
@@ -107,14 +107,19 @@ async def generate_and_rm(
 
         # for multi agent system, the reward of some sample is calculated during generation.
         samples_need_reward = [sample for sample in samples if sample.reward is None]
-        await batched_async_rm(args, samples_need_reward, inplace_set_reward_field=True)
+        await batched_async_rm(
+            args,
+            samples_need_reward,
+            inplace_set_reward_field=True,
+            evaluation=evaluation,
+        )
         return samples
     else:
         if sample.status == Sample.Status.ABORTED:
             return sample
         # for multi-turn environment, a reward could be assigned to the agent.
         if sample.reward is None:
-            sample.reward = await async_rm(args, sample)
+            sample.reward = await async_rm(args, sample, evaluation=evaluation)
 
     logger.debug(f"{log_prefix} generate_and_rm complete")
     return sample
@@ -164,7 +169,7 @@ async def generate_and_rm_group(
         return group
 
     if args.group_rm:
-        await batched_async_rm(args, group, inplace_set_reward_field=True)
+        await batched_async_rm(args, group, inplace_set_reward_field=True, evaluation=evaluation)
 
     return group
 

--- a/miles/rollout/on_policy_self_distillation.py
+++ b/miles/rollout/on_policy_self_distillation.py
@@ -1,0 +1,167 @@
+import logging
+import math
+from argparse import Namespace
+from typing import Any
+
+import aiohttp
+import torch
+
+from miles.utils.types import Sample
+
+logger = logging.getLogger(__name__)
+
+Prompt = str | list[dict[str, Any]]
+
+_PRIVILEGED_CONTEXT = """
+
+Here is a reference solution:
+=== Reference Solution Begin ===
+{label}
+=== Reference Solution End ===
+
+Understand the reference solution, then solve the original problem using independent reasoning rather than copying it.
+""".strip(
+    "\n"
+)
+
+
+def build_teacher_prompt(prompt: Prompt, label: str, metadata: dict[str, Any]) -> Prompt:
+    del metadata
+    if not isinstance(label, str) or not label.strip():
+        raise ValueError("OPSD requires a non-empty text label containing the privileged reference solution.")
+
+    privileged_context = _PRIVILEGED_CONTEXT.format(label=label)
+    if isinstance(prompt, str):
+        return f"{prompt}\n\n{privileged_context}"
+
+    if not prompt or not all(isinstance(message, dict) for message in prompt):
+        raise ValueError("The default OPSD teacher prompt builder requires a non-empty chat conversation.")
+    if prompt[-1].get("role") != "user":
+        raise ValueError("The default OPSD teacher prompt builder requires a conversation ending in a user message.")
+    if any(message.get("role") == "tool" for message in prompt):
+        raise ValueError("The default OPSD teacher prompt builder does not support tool messages.")
+    if any(not isinstance(message.get("content"), str) for message in prompt):
+        raise ValueError("The default OPSD teacher prompt builder supports text-only conversation content.")
+
+    final_message = {
+        **prompt[-1],
+        "content": f"{prompt[-1]['content']}\n\n{privileged_context}",
+    }
+    return [*prompt[:-1], final_message]
+
+
+def _score_payload(input_ids: list[int], *, top_k: int, temperature: float) -> dict[str, Any]:
+    return {
+        "input_ids": input_ids,
+        "sampling_params": {
+            "temperature": temperature,
+            "max_new_tokens": 0,
+            "skip_special_tokens": False,
+        },
+        "return_logprob": True,
+        "logprob_start_len": 0,
+        "top_logprobs_num": top_k,
+    }
+
+
+def _extract_teacher_top_k(
+    response: dict[str, Any],
+    *,
+    response_length: int,
+    top_k: int,
+) -> tuple[list[list[int]], list[list[float]]]:
+    try:
+        values = response["meta_info"]["input_top_logprobs"]
+    except (KeyError, TypeError) as exc:
+        raise ValueError("OPSD teacher response is missing meta_info.input_top_logprobs.") from exc
+
+    response_values = values[-response_length:] if response_length > 0 else []
+    if len(response_values) != response_length:
+        raise ValueError(
+            f"OPSD teacher returned {len(response_values)} response positions, expected {response_length}."
+        )
+
+    token_ids = []
+    scores = []
+    for position, entries in enumerate(response_values):
+        if entries is None or len(entries) != top_k:
+            actual = 0 if entries is None else len(entries)
+            raise ValueError(f"OPSD teacher position {position} returned top_k={actual}, expected {top_k}.")
+        position_ids = [int(entry[1]) for entry in entries]
+        position_scores = [float(entry[0]) for entry in entries]
+        if len(set(position_ids)) != top_k:
+            raise ValueError(f"OPSD teacher position {position} returned duplicate token ids.")
+        if not all(math.isfinite(score) for score in position_scores):
+            raise ValueError(f"OPSD teacher position {position} returned non-finite scores.")
+        token_ids.append(position_ids)
+        scores.append(position_scores)
+
+    return token_ids, scores
+
+
+async def _post_json(
+    url: str,
+    payload: dict[str, Any],
+    *,
+    timeout_secs: int | float | None,
+) -> dict[str, Any]:
+    timeout = aiohttp.ClientTimeout(total=timeout_secs)
+    async with aiohttp.ClientSession(timeout=timeout) as session:
+        async with session.post(url, json=payload) as response:
+            response.raise_for_status()
+            return await response.json()
+
+
+async def reward_func(args: Namespace, sample: Sample, **kwargs: Any) -> dict[str, Any]:
+    del kwargs
+    if sample.privileged_prompt_tokens is None:
+        raise ValueError("OPSD SGLang scoring requires Sample.privileged_prompt_tokens.")
+
+    response_tokens = sample.tokens[-sample.response_length :] if sample.response_length > 0 else []
+    teacher_input_ids = [*sample.privileged_prompt_tokens, *response_tokens]
+    payload = _score_payload(
+        teacher_input_ids,
+        top_k=args.opsd_teacher_top_k,
+        temperature=args.rollout_temperature,
+    )
+    try:
+        response = await _post_json(
+            args.opsd_teacher_url,
+            payload,
+            timeout_secs=getattr(args, "sglang_router_request_timeout_secs", None),
+        )
+        token_ids, scores = _extract_teacher_top_k(
+            response,
+            response_length=sample.response_length,
+            top_k=args.opsd_teacher_top_k,
+        )
+    except Exception:
+        logger.exception(
+            "OPSD teacher scoring failed: sample_index=%s teacher_input_length=%d response_length=%d endpoint=%s",
+            sample.index,
+            len(teacher_input_ids),
+            sample.response_length,
+            args.opsd_teacher_url,
+        )
+        raise
+
+    return {"token_ids": token_ids, "scores": scores}
+
+
+def post_process_rewards(
+    args: Namespace,
+    samples: list[Sample],
+    **kwargs: Any,
+) -> tuple[list[float], list[float]]:
+    del kwargs
+    for sample in samples:
+        reward = sample.reward
+        if not isinstance(reward, dict) or set(reward) != {"token_ids", "scores"}:
+            raise ValueError("OPSD SGLang scoring must return compact token_ids and scores.")
+        shape = (sample.response_length, args.opsd_teacher_top_k)
+        sample.opsd_teacher_token_ids = torch.as_tensor(reward["token_ids"], dtype=torch.int64).reshape(shape)
+        sample.opsd_teacher_scores = torch.as_tensor(reward["scores"], dtype=torch.float32).reshape(shape)
+        sample.validate()
+
+    scalar_rewards = [0.0] * len(samples)
+    return scalar_rewards, scalar_rewards

--- a/miles/rollout/on_policy_self_distillation.py
+++ b/miles/rollout/on_policy_self_distillation.py
@@ -50,11 +50,11 @@ def build_teacher_prompt(prompt: Prompt, label: str, metadata: dict[str, Any]) -
     return [*prompt[:-1], final_message]
 
 
-def _score_payload(input_ids: list[int], *, top_k: int, temperature: float) -> dict[str, Any]:
+def _score_payload(input_ids: list[int], *, top_k: int) -> dict[str, Any]:
     return {
         "input_ids": input_ids,
         "sampling_params": {
-            "temperature": temperature,
+            "temperature": 0,
             "max_new_tokens": 0,
             "skip_special_tokens": False,
         },
@@ -119,11 +119,7 @@ async def reward_func(args: Namespace, sample: Sample, **kwargs: Any) -> dict[st
 
     response_tokens = sample.tokens[-sample.response_length :] if sample.response_length > 0 else []
     teacher_input_ids = [*sample.privileged_prompt_tokens, *response_tokens]
-    payload = _score_payload(
-        teacher_input_ids,
-        top_k=args.opsd_teacher_top_k,
-        temperature=args.rollout_temperature,
-    )
+    payload = _score_payload(teacher_input_ids, top_k=args.opsd_teacher_top_k)
     try:
         response = await _post_json(
             args.opsd_teacher_url,

--- a/miles/rollout/rm_hub/__init__.py
+++ b/miles/rollout/rm_hub/__init__.py
@@ -4,6 +4,7 @@ import random
 
 import aiohttp
 
+from miles.rollout.on_policy_self_distillation import reward_func as score_opsd_sample
 from miles.utils.misc import load_function
 from miles.utils.multi_lora import is_multi_lora_enabled
 from miles.utils.types import Sample
@@ -40,7 +41,10 @@ def _resolve_reward_config(args, sample: Sample) -> tuple[str | None, str]:
     return custom_rm_path, rm_type
 
 
-async def async_rm(args, sample: Sample, **kwargs):
+async def async_rm(args, sample: Sample, *, evaluation: bool = False, **kwargs):
+    if not evaluation and args.loss_type == "opsd_loss":
+        return await score_opsd_sample(args, sample, **kwargs)
+
     custom_rm_path, rm_type = _resolve_reward_config(args, sample)
 
     if custom_rm_path is not None:
@@ -90,10 +94,11 @@ async def batched_async_rm(
     args,
     samples: list[Sample],
     inplace_set_reward_field: bool = False,
+    evaluation: bool = False,
     **kwargs,
 ) -> list[int | float] | None:
     if inplace_set_reward_field:
-        rewards = await batched_async_rm(args, samples, **kwargs)
+        rewards = await batched_async_rm(args, samples, evaluation=evaluation, **kwargs)
         for sample, reward in zip(samples, rewards, strict=True):
             assert (
                 sample.reward is None
@@ -101,9 +106,10 @@ async def batched_async_rm(
             sample.reward = reward
         return None
 
-    if args.custom_rm_path is not None and not is_multi_lora_enabled(args):
+    opsd_training = not evaluation and args.loss_type == "opsd_loss"
+    if not opsd_training and args.custom_rm_path is not None and not is_multi_lora_enabled(args):
         rm_function = load_function(args.custom_rm_path)
         return await rm_function(args, samples, **kwargs)
-    tasks = [async_rm(args, sample, **kwargs) for sample in samples]
+    tasks = [async_rm(args, sample, evaluation=evaluation, **kwargs) for sample in samples]
     rewards = await asyncio.gather(*tasks)
     return rewards

--- a/miles/rollout/sglang_rollout.py
+++ b/miles/rollout/sglang_rollout.py
@@ -384,7 +384,7 @@ async def generate_and_rm(
 
         # for multi agent system, the reward of some sample is calculated during generation.
         samples_need_reward = [sample for sample in samples if sample.reward is None]
-        rewards = await batched_async_rm(args, samples_need_reward)
+        rewards = await batched_async_rm(args, samples_need_reward, evaluation=evaluation)
         for sample, reward in zip(samples_need_reward, rewards, strict=False):
             sample.reward = reward
         return samples
@@ -393,7 +393,7 @@ async def generate_and_rm(
             return sample
         # for multi-turn environment, a reward could be assigned to the agent.
         if sample.reward is None:
-            sample.reward = await async_rm(args, sample)
+            sample.reward = await async_rm(args, sample, evaluation=evaluation)
 
     return sample
 
@@ -426,7 +426,7 @@ async def generate_and_rm_group(
 
     # for the rm that need the whole group, we will do the rm here
     if not state.aborted and args.group_rm:
-        rewards = await batched_async_rm(args, group)
+        rewards = await batched_async_rm(args, group, evaluation=evaluation)
         for sample, reward in zip(group, rewards, strict=False):
             sample.reward = reward
 

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -1377,11 +1377,11 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
             parser.add_argument(
                 "--loss-type",
                 type=str,
-                choices=["policy_loss", "sft_loss", "custom_loss"],
+                choices=["policy_loss", "sft_loss", "opsd_loss", "custom_loss"],
                 default="policy_loss",
                 help=(
-                    "Choose loss type, currently support ppo policy_loss or sft_loss, "
-                    "if custom_loss is set, we will use the function path from `--custom-loss-function-path`."
+                    "Training objective: policy gradient, supervised fine-tuning, pure on-policy "
+                    "self-distillation, or the function from --custom-loss-function-path."
                 ),
             )
             parser.add_argument(
@@ -1676,6 +1676,43 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
             )
             parser.add_argument(
                 "--opd-teacher-ckpt-step", type=int, default=None, help="The checkpoint step for OPD teacher model."
+            )
+            return parser
+
+        def add_on_policy_self_distillation_arguments(parser):
+            parser.add_argument(
+                "--opsd-type",
+                choices=["sglang"],
+                default=None,
+                help="OPSD fixed-teacher execution backend.",
+            )
+            parser.add_argument(
+                "--opsd-teacher-top-k",
+                type=int,
+                default=64,
+                help="Teacher-selected vocabulary support size for truncated forward KL.",
+            )
+            parser.add_argument(
+                "--opsd-pointwise-kl-clip",
+                type=float,
+                default=0.05,
+                help="Maximum OPSD forward-KL contribution per vocabulary entry. Set to 0 to disable.",
+            )
+            parser.add_argument(
+                "--opsd-teacher-prompt-function-path",
+                default=None,
+                help="Optional function path for building the privileged teacher prompt.",
+            )
+            parser.add_argument(
+                "--opsd-teacher-chat-template-kwargs",
+                type=json.loads,
+                default="{}",
+                help="JSON kwargs applied only when rendering the privileged teacher prompt.",
+            )
+            parser.add_argument(
+                "--opsd-teacher-url",
+                default=None,
+                help="SGLang /generate endpoint for the frozen initial-policy OPSD teacher.",
             )
             return parser
 
@@ -2576,6 +2613,7 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
         parser = add_eval_arguments(parser)
         parser = add_algo_arguments(parser)
         parser = add_on_policy_distillation_arguments(parser)
+        parser = add_on_policy_self_distillation_arguments(parser)
         parser = add_lora_arguments(parser)
         parser = add_wandb_arguments(parser)
         parser = add_mlflow_arguments(parser)
@@ -2927,6 +2965,12 @@ def miles_validate_args(args):
             raise FileNotFoundError(f"--chat-template-path file not found: {args.chat_template_path}")
         args.sglang_chat_template = args.chat_template_path
 
+    opsd_enabled = args.loss_type == "opsd_loss"
+    if opsd_enabled and (args.kl_coef != 0 or args.use_kl_loss or args.entropy_coef != 0):
+        raise ValueError("OPSD is a pure objective and cannot be combined with KL or entropy objective terms.")
+    if opsd_enabled and args.use_opd:
+        raise ValueError("Pure OPSD cannot be combined with --use-opd.")
+
     if args.kl_coef != 0 or args.use_kl_loss:
         if not os.path.exists(args.ref_load):
             raise FileNotFoundError(f"ref_load {args.ref_load} does not exist, please check the path.")
@@ -2980,6 +3024,43 @@ def miles_validate_args(args):
             raise ValueError("--opd-teacher-load is set but --use-opd is not enabled. Please add --use-opd flag.")
         if args.opd_teacher_urls:
             raise ValueError("--opd-teacher-urls is set but --use-opd is not enabled. Please add --use-opd flag.")
+
+    opsd_configured = any(
+        value is not None
+        for value in (
+            args.opsd_type,
+            args.opsd_teacher_url,
+            args.opsd_teacher_prompt_function_path,
+        )
+    )
+    if not opsd_enabled and opsd_configured:
+        raise ValueError("OPSD arguments require --loss-type opsd_loss.")
+    if opsd_enabled:
+        if args.compute_advantages_and_returns:
+            raise ValueError("--loss-type opsd_loss requires --disable-compute-advantages-and-returns.")
+        if args.opsd_type is None:
+            raise ValueError("--loss-type opsd_loss requires --opsd-type.")
+        if args.opsd_teacher_top_k < 2:
+            raise ValueError("--opsd-teacher-top-k must be at least 2.")
+        if args.opsd_pointwise_kl_clip < 0:
+            raise ValueError("--opsd-pointwise-kl-clip must be non-negative.")
+        if not isinstance(args.opsd_teacher_chat_template_kwargs, dict):
+            raise ValueError("--opsd-teacher-chat-template-kwargs must decode to a JSON object.")
+        if args.label_key is None:
+            raise ValueError("--loss-type opsd_loss requires --label-key.")
+        if not args.rollout_global_dataset:
+            raise ValueError("OPSD currently requires the built-in global rollout dataset.")
+        if args.multimodal_keys:
+            raise ValueError("OPSD currently supports text-only datasets.")
+        if args.use_session_server:
+            raise ValueError("OPSD does not currently support session rollouts.")
+        if args.multi_lora_n_adapters > 0:
+            raise ValueError("OPSD does not currently support Multi-LoRA.")
+        if args.custom_reward_post_process_path is not None:
+            raise ValueError("OPSD owns reward post-processing and does not accept --custom-reward-post-process-path.")
+
+        if args.opsd_teacher_url is None:
+            raise ValueError("--opsd-type sglang requires --opsd-teacher-url.")
 
     # TODO: During loading, we need to set the start_rollout_id here.
     if args.megatron_to_hf_mode == "bridge":

--- a/miles/utils/data.py
+++ b/miles/utils/data.py
@@ -4,6 +4,8 @@ import logging
 import os
 import random
 import re
+from collections.abc import Callable
+from typing import Any
 
 import numpy as np
 
@@ -82,14 +84,14 @@ def _parse_generalized_path(s: str):
 
 
 def filter_long_prompt(origin_samples: list[Sample], tokenizer, processor, max_length: int | None) -> list[Sample]:
-    if max_length is None:
+    if max_length is None or not origin_samples:
         return origin_samples
 
     if not isinstance(origin_samples[0].prompt, str):
         logger.warning(
             "Skipping max_length check for list prompt. Set apply_chat_template=True to enable length filtering."
         )
-        return origin_samples
+        return [sample for sample in origin_samples if _privileged_prompt_within_limit(sample, max_length)]
 
     if processor:
         # Use processor only for samples with actual multimodal content; use batched tokenizer for text-only.
@@ -105,7 +107,7 @@ def filter_long_prompt(origin_samples: list[Sample], tokenizer, processor, max_l
             prompts = [s.prompt for s in text_only]
             input_ids_list = tokenizer(prompts, add_special_tokens=False)["input_ids"]
             for sample, input_ids in zip(text_only, input_ids_list, strict=True):
-                if len(input_ids) <= max_length:
+                if len(input_ids) <= max_length and _privileged_prompt_within_limit(sample, max_length):
                     filtered_samples.append(sample)
         if multimodal:
             from miles.utils.processing_utils import process_vision_info
@@ -114,7 +116,7 @@ def filter_long_prompt(origin_samples: list[Sample], tokenizer, processor, max_l
                 multimodal_inputs = process_vision_info(sample.prompt, processor)
                 processor_output = processor(text=sample.prompt, **multimodal_inputs)
                 input_ids = processor_output["input_ids"][0]
-                if len(input_ids) <= max_length:
+                if len(input_ids) <= max_length and _privileged_prompt_within_limit(sample, max_length):
                     filtered_samples.append(sample)
     else:
         prompts = [sample.prompt for sample in origin_samples]
@@ -122,12 +124,16 @@ def filter_long_prompt(origin_samples: list[Sample], tokenizer, processor, max_l
         filtered_samples = [
             sample
             for sample, input_ids in zip(origin_samples, input_ids_list, strict=True)
-            if len(input_ids) <= max_length
+            if len(input_ids) <= max_length and _privileged_prompt_within_limit(sample, max_length)
         ]
 
     logger.info(f"Filtered {len(origin_samples) - len(filtered_samples)} samples longer than max_length={max_length}.")
 
     return filtered_samples
+
+
+def _privileged_prompt_within_limit(sample: Sample, max_length: int) -> bool:
+    return sample.privileged_prompt_tokens is None or len(sample.privileged_prompt_tokens) <= max_length
 
 
 def _build_messages(data: dict, prompt_key: str, as_conversation: bool, multimodal_keys: dict = None):
@@ -199,6 +205,8 @@ class Dataset:
         seed=42,
         apply_chat_template=False,
         apply_chat_template_kwargs=None,
+        teacher_prompt_builder: Callable[[Any, str | None, dict], Any] | None = None,
+        teacher_chat_template_kwargs=None,
     ):
         origin_samples = []
         for data in read_file(path):
@@ -207,6 +215,7 @@ class Dataset:
             prompt = _build_messages(data, prompt_key, as_conversation, multimodal_keys)
 
             metadata = data.get(metadata_key) or {}
+            label = data[label_key] if label_key is not None else None
             tools = None
             if tool_key is not None and tool_key in data:
                 tools = data[tool_key]
@@ -216,6 +225,8 @@ class Dataset:
                     tools = tools.tolist()
                 assert isinstance(tools, list), f"tools must be a list, got {type(tools)} instead"
                 metadata["tools"] = tools
+            if teacher_prompt_builder is not None and tools:
+                raise ValueError("OPSD does not currently support tool-enabled dataset samples.")
 
             if apply_chat_template:
                 output_prompt = chat_template_utils.apply_chat_template(
@@ -228,6 +239,30 @@ class Dataset:
                 )
             else:
                 output_prompt = prompt
+
+            if teacher_prompt_builder is not None:
+                teacher_prompt = teacher_prompt_builder(
+                    prompt=prompt,
+                    label=label,
+                    metadata=metadata,
+                )
+                if isinstance(teacher_prompt, list):
+                    teacher_prompt = chat_template_utils.apply_chat_template(
+                        teacher_prompt,
+                        tokenizer=tokenizer,
+                        tools=tools,
+                        tokenize=False,
+                        add_generation_prompt=True,
+                        **(teacher_chat_template_kwargs or {}),
+                    )
+                if not isinstance(teacher_prompt, str):
+                    raise TypeError(
+                        "OPSD teacher prompt function must return text or a text conversation, "
+                        f"got {type(teacher_prompt).__name__}."
+                    )
+                privileged_prompt_tokens = tokenizer.encode(teacher_prompt, add_special_tokens=False)
+            else:
+                privileged_prompt_tokens = None
 
             if processor:
                 from miles.utils.processing_utils import process_vision_info
@@ -242,9 +277,10 @@ class Dataset:
             origin_samples.append(
                 Sample(
                     prompt=output_prompt,
-                    label=data[label_key] if label_key is not None else None,
+                    label=label,
                     metadata=metadata,
                     multimodal_inputs=multimodal_inputs,
+                    privileged_prompt_tokens=privileged_prompt_tokens,
                 )
             )
 

--- a/miles/utils/types.py
+++ b/miles/utils/types.py
@@ -53,6 +53,9 @@ class Sample:
     remove_sample: bool = False
     teacher_log_probs: list[float] | None = None  # Log probabilities from teacher model for OPD
     opd_reverse_kl: list[float] | None = None  # Precomputed per-token OPD reverse-KL estimate
+    privileged_prompt_tokens: list[int] | None = None
+    opsd_teacher_token_ids: torch.Tensor | numpy.ndarray | None = None
+    opsd_teacher_scores: torch.Tensor | numpy.ndarray | None = None
 
     class Status(Enum):
         PENDING = "pending"
@@ -202,6 +205,22 @@ class Sample:
             assert (
                 len(self.opd_reverse_kl) == self.response_length
             ), f"opd_reverse_kl length ({len(self.opd_reverse_kl)}) != response_length ({self.response_length})"
+        assert (self.opsd_teacher_token_ids is None) == (
+            self.opsd_teacher_scores is None
+        ), "opsd_teacher_token_ids and opsd_teacher_scores must be set together"
+        if self.opsd_teacher_token_ids is not None:
+            assert (
+                self.opsd_teacher_token_ids.shape == self.opsd_teacher_scores.shape
+            ), "OPSD teacher token ids and scores must have matching shapes"
+            assert (
+                len(self.opsd_teacher_token_ids.shape) == 2
+            ), "OPSD teacher token ids and scores must have shape [response_length, top_k]"
+            assert (
+                self.opsd_teacher_token_ids.shape[0] == self.response_length
+            ), f"OPSD teacher support length ({self.opsd_teacher_token_ids.shape[0]}) != response_length ({self.response_length})"
+            assert (
+                self.opsd_teacher_token_ids.shape[1] >= 2
+            ), "OPSD teacher top-k support must contain at least 2 tokens"
         if self.rollout_routed_experts is not None:
             actual = len(self.rollout_routed_experts)
             expect = len(self.tokens) - 1
@@ -233,6 +252,9 @@ class Sample:
             self.teacher_log_probs = self.teacher_log_probs[:-n]
         if self.opd_reverse_kl is not None:
             self.opd_reverse_kl = self.opd_reverse_kl[:-n]
+        if self.opsd_teacher_token_ids is not None:
+            self.opsd_teacher_token_ids = self.opsd_teacher_token_ids[:-n]
+            self.opsd_teacher_scores = self.opsd_teacher_scores[:-n]
         if self.metadata and "opd_student_top_logprobs" in self.metadata:
             self.metadata["opd_student_top_logprobs"] = self.metadata["opd_student_top_logprobs"][:-n]
         if self.loss_mask is not None:
@@ -260,6 +282,8 @@ class Sample:
         self.rollout_log_probs = None
         self.rollout_routed_experts = None
         self.rollout_indexer_topk = None
+        self.opsd_teacher_token_ids = None
+        self.opsd_teacher_scores = None
         self.status = Sample.Status.ABORTED
         self.non_generation_time = 0.0
         self.spec_info = Sample.SpecInfo()

--- a/tests/e2e/short/test_qwen2.5_0.5B_opsd_megatron.py
+++ b/tests/e2e/short/test_qwen2.5_0.5B_opsd_megatron.py
@@ -1,0 +1,115 @@
+import os
+
+from tests.ci.ci_register import register_cuda_ci
+from tests.e2e.sglang.utils.sglang_server import SGLangServer, start_sglang_server
+
+import miles.utils.external_utils.command_utils as U
+
+register_cuda_ci(est_time=500, suite="stage-c-2-gpu-h200", labels=["short"])
+
+MODEL_NAME = "Qwen2.5-0.5B-Instruct"
+MODEL_TYPE = "qwen2.5-0.5B"
+NUM_GPUS = 2
+NUM_TRAIN_GPUS = 1
+TEACHER_HOST = "127.0.0.1"
+TEACHER_PORT = 13141
+
+
+def prepare():
+    U.exec_command("mkdir -p /root/models /root/datasets")
+    U.exec_command(f"hf download Qwen/{MODEL_NAME} --local-dir /root/models/{MODEL_NAME}")
+    U.hf_download_dataset("zhuzilin/gsm8k")
+
+
+def execute():
+    visible_gpus = os.environ.get("CUDA_VISIBLE_DEVICES", ",".join(str(i) for i in range(NUM_GPUS))).split(",")
+    assert len(visible_gpus) >= NUM_GPUS
+    teacher_gpu = visible_gpus[NUM_TRAIN_GPUS]
+    os.environ["CUDA_VISIBLE_DEVICES"] = ",".join(visible_gpus[:NUM_TRAIN_GPUS])
+    teacher_server: SGLangServer | None = None
+
+    def launch_teacher():
+        nonlocal teacher_server
+        train_gpus = os.environ["CUDA_VISIBLE_DEVICES"]
+        os.environ["CUDA_VISIBLE_DEVICES"] = teacher_gpu
+        try:
+            teacher_server = start_sglang_server(
+                model_path=f"/root/models/{MODEL_NAME}",
+                host=TEACHER_HOST,
+                port=TEACHER_PORT,
+                enable_deterministic_inference=False,
+                extra_args=["--tp", "1", "--mem-fraction-static", "0.6"],
+            )
+        finally:
+            os.environ["CUDA_VISIBLE_DEVICES"] = train_gpus
+
+    train_args = (
+        f"--hf-checkpoint /root/models/{MODEL_NAME} "
+        "--prompt-data /root/datasets/gsm8k/train.parquet "
+        "--input-key messages "
+        "--label-key label "
+        "--apply-chat-template "
+        "--rollout-shuffle "
+        "--rm-type math "
+        "--num-rollout 2 "
+        "--rollout-batch-size 4 "
+        "--n-samples-per-prompt 1 "
+        "--rollout-max-response-len 512 "
+        "--rollout-temperature 1 "
+        "--global-batch-size 4 "
+        "--loss-type opsd_loss "
+        "--disable-compute-advantages-and-returns "
+        "--opsd-type sglang "
+        "--opsd-teacher-top-k 8 "
+        "--opsd-pointwise-kl-clip 0.05 "
+        f"--opsd-teacher-url http://{TEACHER_HOST}:{TEACHER_PORT}/generate "
+        "--optimizer adam "
+        "--lr 1e-6 "
+        "--lr-decay-style constant "
+        "--weight-decay 0.1 "
+        "--adam-beta1 0.9 "
+        "--adam-beta2 0.98 "
+        "--tensor-model-parallel-size 1 "
+        "--pipeline-model-parallel-size 1 "
+        "--context-parallel-size 1 "
+        "--expert-model-parallel-size 1 "
+        "--expert-tensor-parallel-size 1 "
+        "--use-dynamic-batch-size "
+        "--max-tokens-per-gpu 2048 "
+        "--rollout-num-gpus-per-engine 1 "
+        "--sglang-mem-fraction-static 0.6 "
+        "--use-miles-router "
+        "--attention-dropout 0.0 "
+        "--hidden-dropout 0.0 "
+        "--attention-backend flash "
+        "--actor-num-nodes 1 "
+        f"--actor-num-gpus-per-node {NUM_TRAIN_GPUS} "
+        "--colocate "
+        "--megatron-to-hf-mode bridge "
+        "--ci-test "
+        "--ci-disable-kl-checker "
+        "--eval-interval 1 "
+        "--eval-prompt-data gsm8k /root/datasets/gsm8k/test.parquet "
+        "--n-samples-per-eval-prompt 1 "
+        "--eval-max-response-len 512 "
+        "--eval-top-k 1 "
+        f"{U.get_default_wandb_args(__file__)} "
+    )
+
+    try:
+        U.execute_train(
+            train_args=train_args,
+            num_gpus_per_node=NUM_TRAIN_GPUS,
+            megatron_model_type=MODEL_TYPE,
+            before_ray_job_submit=launch_teacher,
+        )
+    finally:
+        if teacher_server is not None:
+            teacher_server.stop()
+
+
+if __name__ == "__main__":
+    prepare()
+    for proxy_variable in ("http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY"):
+        os.environ.pop(proxy_variable, None)
+    execute()

--- a/tests/e2e/short/test_qwen2.5_0.5B_opsd_sglang.py
+++ b/tests/e2e/short/test_qwen2.5_0.5B_opsd_sglang.py
@@ -1,0 +1,105 @@
+import os
+
+from tests.ci.ci_register import register_cuda_ci
+from tests.e2e.sglang.utils.sglang_server import SGLangServer, start_sglang_server
+
+import miles.utils.external_utils.command_utils as U
+
+register_cuda_ci(est_time=500, suite="stage-c-2-gpu-h200", labels=["short"])
+
+MODEL_NAME = "Qwen2.5-0.5B-Instruct"
+NUM_GPUS = 2
+NUM_TRAIN_GPUS = 1
+TEACHER_HOST = "127.0.0.1"
+TEACHER_PORT = 13141
+
+
+def prepare():
+    U.exec_command("mkdir -p /root/models /root/datasets")
+    U.exec_command(f"hf download Qwen/{MODEL_NAME} --local-dir /root/models/{MODEL_NAME}")
+    U.hf_download_dataset("zhuzilin/gsm8k")
+
+
+def execute():
+    visible_gpus = os.environ.get("CUDA_VISIBLE_DEVICES", ",".join(str(i) for i in range(NUM_GPUS))).split(",")
+    assert len(visible_gpus) >= NUM_GPUS
+    teacher_gpu = visible_gpus[NUM_TRAIN_GPUS]
+    os.environ["CUDA_VISIBLE_DEVICES"] = ",".join(visible_gpus[:NUM_TRAIN_GPUS])
+    teacher_server: SGLangServer | None = None
+
+    def launch_teacher():
+        nonlocal teacher_server
+        train_gpus = os.environ["CUDA_VISIBLE_DEVICES"]
+        os.environ["CUDA_VISIBLE_DEVICES"] = teacher_gpu
+        try:
+            teacher_server = start_sglang_server(
+                model_path=f"/root/models/{MODEL_NAME}",
+                host=TEACHER_HOST,
+                port=TEACHER_PORT,
+                enable_deterministic_inference=False,
+                extra_args=["--tp", "1", "--mem-fraction-static", "0.6"],
+            )
+        finally:
+            os.environ["CUDA_VISIBLE_DEVICES"] = train_gpus
+
+    train_args = (
+        f"--hf-checkpoint /root/models/{MODEL_NAME} "
+        "--prompt-data /root/datasets/gsm8k/train.parquet "
+        "--input-key messages "
+        "--label-key label "
+        "--apply-chat-template "
+        "--rollout-shuffle "
+        "--rm-type math "
+        "--num-rollout 2 "
+        "--rollout-batch-size 4 "
+        "--n-samples-per-prompt 1 "
+        "--rollout-max-response-len 512 "
+        "--rollout-temperature 1 "
+        "--global-batch-size 4 "
+        "--loss-type opsd_loss "
+        "--disable-compute-advantages-and-returns "
+        "--opsd-type sglang "
+        "--opsd-teacher-top-k 8 "
+        "--opsd-pointwise-kl-clip 0.05 "
+        f"--opsd-teacher-url http://{TEACHER_HOST}:{TEACHER_PORT}/generate "
+        "--optimizer adam "
+        "--lr 1e-6 "
+        "--lr-decay-style constant "
+        "--weight-decay 0.1 "
+        "--adam-beta1 0.9 "
+        "--adam-beta2 0.98 "
+        "--eval-interval 1 "
+        "--eval-prompt-data gsm8k /root/datasets/gsm8k/test.parquet "
+        "--n-samples-per-eval-prompt 1 "
+        "--eval-max-response-len 512 "
+        "--eval-top-k 1 "
+        "--rollout-num-gpus-per-engine 1 "
+        "--sglang-mem-fraction-static 0.6 "
+        "--use-miles-router "
+        "--actor-num-nodes 1 "
+        f"--actor-num-gpus-per-node {NUM_TRAIN_GPUS} "
+        "--colocate "
+        "--train-backend fsdp "
+        "--ci-test "
+        "--ci-disable-kl-checker "
+        f"{U.get_default_wandb_args(__file__)} "
+    )
+
+    try:
+        U.execute_train(
+            train_args=train_args,
+            num_gpus_per_node=NUM_TRAIN_GPUS,
+            megatron_model_type=None,
+            before_ray_job_submit=launch_teacher,
+            extra_env_vars={"MILES_EXPERIMENTAL_ROLLOUT_REFACTOR": "1"},
+        )
+    finally:
+        if teacher_server is not None:
+            teacher_server.stop()
+
+
+if __name__ == "__main__":
+    prepare()
+    for proxy_variable in ("http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY"):
+        os.environ.pop(proxy_variable, None)
+    execute()

--- a/tests/fast/backends/training_utils/loss/test_opsd.py
+++ b/tests/fast/backends/training_utils/loss/test_opsd.py
@@ -198,3 +198,28 @@ def test_opsd_loss_dispatches_and_reduces_response_aligned_top_k(vocab_size):
     torch.testing.assert_close(metrics["loss"], expected.mean())
     torch.testing.assert_close(metrics["opsd_forward_kl_topk"], expected.mean())
     torch.testing.assert_close(metrics["opsd_clip_fraction"], torch.tensor(0.0))
+
+
+def test_opsd_loss_is_finite_for_empty_responses_and_preserves_gradient_path():
+    make_parallel_state()
+    args = make_args(
+        loss_type="opsd_loss",
+        opsd_pointwise_kl_clip=0.0,
+        vocab_size=4,
+    )
+    logits = torch.randn(1, 2, 4, requires_grad=True)
+    batch = {
+        "unconcat_tokens": [torch.tensor([1, 2])],
+        "response_lengths": [0],
+        "total_lengths": [2],
+        "loss_masks": [torch.empty(0)],
+        "opsd_teacher_token_ids": [torch.empty((0, 2), dtype=torch.int64)],
+        "opsd_teacher_scores": [torch.empty((0, 2))],
+    }
+
+    loss, metrics = opsd_loss_function(args, batch, logits, torch.mean)
+
+    torch.testing.assert_close(loss, torch.tensor(0.0))
+    assert all(torch.isfinite(value) for value in metrics.values())
+    loss.backward()
+    torch.testing.assert_close(logits.grad, torch.zeros_like(logits))

--- a/tests/fast/backends/training_utils/loss/test_opsd.py
+++ b/tests/fast/backends/training_utils/loss/test_opsd.py
@@ -1,0 +1,200 @@
+import pytest
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+from tests.ci.ci_register import register_cpu_ci
+from tests.fast.backends.training_utils.loss.loss_test_utils import make_args, make_parallel_state
+from tests.fast.dist_utils import init_gloo, run_multiprocess
+
+from miles.backends.training_utils.loss_hub.losses import get_loss_function, opsd_loss_function
+from miles.backends.training_utils.loss_hub.opsd import compute_topk_forward_kl, gather_selected_logits
+
+register_cpu_ci(est_time=30, suite="stage-a-cpu")
+
+
+def _run_tensor_parallel_selected_logit_gather(rank: int, world_size: int, port: int) -> None:
+    init_gloo(rank, world_size, port=port)
+    try:
+        local_logits = (
+            torch.tensor([[0.1, 0.2], [1.0, 2.0]], requires_grad=True)
+            if rank == 0
+            else torch.tensor([[0.3, 0.4], [3.0, 4.0]], requires_grad=True)
+        )
+        token_ids = torch.tensor([[0, 3], [2, 1]])
+        selected = gather_selected_logits(
+            logits=local_logits,
+            token_ids=token_ids,
+            process_group=dist.group.WORLD,
+            vocab_size=4,
+        )
+        torch.testing.assert_close(selected, torch.tensor([[0.1, 0.4], [3.0, 2.0]]))
+        selected.sum().backward()
+        expected_gradient = (
+            torch.tensor([[1.0, 0.0], [0.0, 1.0]]) if rank == 0 else torch.tensor([[0.0, 1.0], [1.0, 0.0]])
+        )
+        torch.testing.assert_close(local_logits.grad, expected_gradient)
+    finally:
+        dist.destroy_process_group()
+
+
+def test_full_support_matches_exact_forward_kl_and_gradient():
+    student_logits = torch.tensor(
+        [[0.1, -0.2, 0.7], [1.0, -0.5, 0.0]],
+        dtype=torch.float64,
+        requires_grad=True,
+    )
+    teacher_logits = torch.tensor(
+        [[0.6, 0.3, -0.4], [-0.3, 0.8, 0.2]],
+        dtype=torch.float64,
+    )
+
+    loss, forward_kl, clip_fraction = compute_topk_forward_kl(
+        student_scores=student_logits,
+        teacher_scores=teacher_logits,
+        pointwise_clip=0.0,
+    )
+    expected_contributions = F.kl_div(
+        F.log_softmax(student_logits, dim=-1),
+        F.log_softmax(teacher_logits, dim=-1),
+        reduction="none",
+        log_target=True,
+    )
+    expected = expected_contributions.sum(dim=-1)
+
+    torch.testing.assert_close(loss, expected)
+    torch.testing.assert_close(forward_kl, expected)
+    torch.testing.assert_close(clip_fraction, torch.zeros_like(expected))
+
+    loss.sum().backward()
+    actual_gradient = student_logits.grad.clone()
+    student_logits.grad = None
+    expected.sum().backward()
+    torch.testing.assert_close(actual_gradient, student_logits.grad)
+
+
+def test_pointwise_clip_happens_before_vocabulary_reduction():
+    student_scores = torch.tensor([[8.0, -4.0, -4.0]], requires_grad=True)
+    teacher_scores = torch.tensor([[-4.0, 8.0, -4.0]])
+
+    loss, forward_kl, clip_fraction = compute_topk_forward_kl(
+        student_scores=student_scores,
+        teacher_scores=teacher_scores,
+        pointwise_clip=0.05,
+    )
+    teacher_log_probs = F.log_softmax(teacher_scores, dim=-1)
+    contributions = teacher_log_probs.exp() * (teacher_log_probs - F.log_softmax(student_scores, dim=-1))
+
+    torch.testing.assert_close(loss, contributions.clamp(max=0.05).sum(dim=-1))
+    torch.testing.assert_close(forward_kl, contributions.sum(dim=-1))
+    torch.testing.assert_close(
+        clip_fraction,
+        (contributions > 0.05).to(contributions.dtype).mean(dim=-1),
+    )
+    assert not torch.allclose(loss, forward_kl.clamp(max=0.05))
+
+
+def test_teacher_scores_are_detached():
+    student_scores = torch.tensor([[0.2, -0.1]], requires_grad=True)
+    teacher_scores = torch.tensor([[-0.2, 0.3]], requires_grad=True)
+
+    loss, _, _ = compute_topk_forward_kl(
+        student_scores=student_scores,
+        teacher_scores=teacher_scores,
+        pointwise_clip=0.0,
+    )
+    loss.sum().backward()
+
+    assert student_scores.grad is not None
+    assert teacher_scores.grad is None
+
+
+@pytest.mark.parametrize("field", ["student", "teacher"])
+def test_non_finite_scores_fail_before_loss_reduction(field):
+    student_scores = torch.tensor([[0.2, -0.1]])
+    teacher_scores = torch.tensor([[-0.2, 0.3]])
+    if field == "student":
+        student_scores[0, 0] = torch.nan
+    else:
+        teacher_scores[0, 0] = torch.inf
+
+    with pytest.raises(ValueError, match=f"OPSD {field} scores contain non-finite values"):
+        compute_topk_forward_kl(
+            student_scores=student_scores,
+            teacher_scores=teacher_scores,
+            pointwise_clip=0.0,
+        )
+
+
+def test_single_rank_selected_logit_gather_preserves_order_and_gradient():
+    logits = torch.tensor(
+        [[0.1, 0.2, 0.3, 0.4], [1.0, 2.0, 3.0, 4.0]],
+        requires_grad=True,
+    )
+    token_ids = torch.tensor([[3, 1], [0, 2]])
+
+    selected = gather_selected_logits(
+        logits=logits,
+        token_ids=token_ids,
+        process_group=None,
+        vocab_size=4,
+    )
+
+    torch.testing.assert_close(selected, torch.tensor([[0.4, 0.2], [1.0, 3.0]]))
+    selected.sum().backward()
+    torch.testing.assert_close(
+        logits.grad,
+        torch.tensor([[0.0, 1.0, 0.0, 1.0], [1.0, 0.0, 1.0, 0.0]]),
+    )
+
+
+def test_tensor_parallel_selected_logit_gather_has_unscaled_backward():
+    run_multiprocess(_run_tensor_parallel_selected_logit_gather)
+
+
+@pytest.mark.parametrize("vocab_size", [4, None])
+def test_opsd_loss_dispatches_and_reduces_response_aligned_top_k(vocab_size):
+    make_parallel_state()
+    args = make_args(
+        loss_type="opsd_loss",
+        opsd_pointwise_kl_clip=0.0,
+        vocab_size=4,
+    )
+    if vocab_size is None:
+        del args.vocab_size
+    logits = torch.tensor(
+        [
+            [
+                [9.0, 9.0, 9.0, 9.0],
+                [0.1, 0.2, 0.3, 0.4],
+                [1.0, 2.0, 3.0, 4.0],
+                [8.0, 8.0, 8.0, 8.0],
+            ]
+        ],
+        requires_grad=True,
+    )
+    teacher_ids = torch.tensor([[3, 1], [0, 2]])
+    teacher_scores = torch.tensor([[0.7, -0.1], [-0.5, 0.8]])
+    batch = {
+        "unconcat_tokens": [torch.tensor([2, 1, 3, 0])],
+        "response_lengths": [2],
+        "total_lengths": [4],
+        "loss_masks": [torch.ones(2)],
+        "opsd_teacher_token_ids": [teacher_ids],
+        "opsd_teacher_scores": [teacher_scores],
+    }
+
+    loss_function = get_loss_function(args)
+    loss, metrics = loss_function(args, batch, logits, torch.mean)
+
+    expected_student_scores = torch.tensor([[0.4, 0.2], [1.0, 3.0]])
+    expected = F.kl_div(
+        F.log_softmax(expected_student_scores, dim=-1),
+        F.log_softmax(teacher_scores, dim=-1),
+        reduction="none",
+        log_target=True,
+    ).sum(dim=-1)
+    assert loss_function is opsd_loss_function
+    torch.testing.assert_close(loss, expected.mean())
+    torch.testing.assert_close(metrics["loss"], expected.mean())
+    torch.testing.assert_close(metrics["opsd_forward_kl_topk"], expected.mean())
+    torch.testing.assert_close(metrics["opsd_clip_fraction"], torch.tensor(0.0))

--- a/tests/fast/backends/training_utils/test_opd_cp_data.py
+++ b/tests/fast/backends/training_utils/test_opd_cp_data.py
@@ -36,6 +36,7 @@ def _args(qkv_format: str) -> Namespace:
         true_on_policy_mode=False,
         bf16=False,
         fp16=False,
+        opsd_teacher_top_k=2,
     )
 
 
@@ -147,3 +148,69 @@ def test_multimodal_cp_reslices_precomputed_opd_reverse_kl(monkeypatch: pytest.M
 
     assert len(gathered_keys) == 1
     assert gathered_keys[0] is rollout_data["opd_reverse_kl"][0]
+
+
+@pytest.mark.parametrize("support_key", ["opsd_teacher_token_ids", "opsd_teacher_scores"])
+def test_opsd_rollout_data_rejects_partial_compact_support(
+    monkeypatch: pytest.MonkeyPatch,
+    support_key: str,
+) -> None:
+    rollout_data = {
+        "tokens": [list(range(4))],
+        "loss_masks": [[1, 1]],
+        "total_lengths": [4],
+        "response_lengths": [2],
+        support_key: [torch.zeros(4)],
+    }
+    monkeypatch.setattr(data_utils, "process_rollout_data", lambda *args, **kwargs: (rollout_data, object()))
+    monkeypatch.setattr(data_utils, "get_parallel_state", lambda: _parallel_state(cp_size=1))
+    monkeypatch.setattr(torch.cuda, "current_device", lambda: torch.device("cpu"))
+
+    with pytest.raises(ValueError, match="both teacher token ids and scores"):
+        data_utils.get_rollout_data(_args("thd"), object())
+
+
+@pytest.mark.parametrize(
+    ("qkv_format", "cp_size", "cp_rank", "expected_indices"),
+    [
+        ("thd", 1, 0, [0, 1, 2, 3, 4, 5, 6]),
+        ("thd", 2, 0, [6]),
+        ("thd", 2, 1, [0, 1, 2, 3, 4, 5]),
+        ("bshd", 2, 0, [0]),
+        ("bshd", 2, 1, [1, 2, 3, 4, 5, 6]),
+    ],
+)
+def test_opsd_support_reshapes_before_response_cp_slice(
+    monkeypatch: pytest.MonkeyPatch,
+    qkv_format: str,
+    cp_size: int,
+    cp_rank: int,
+    expected_indices: list[int],
+) -> None:
+    teacher_ids = torch.arange(14, dtype=torch.int32).reshape(7, 2)
+    teacher_scores = torch.arange(14, dtype=torch.float32).reshape(7, 2) / 10
+    rollout_data = {
+        "tokens": [list(range(11))],
+        "loss_masks": [[1] * 7],
+        "total_lengths": [11],
+        "response_lengths": [7],
+        "opsd_teacher_token_ids": [teacher_ids.flatten()],
+        "opsd_teacher_scores": [teacher_scores.flatten()],
+    }
+    parallel_state = _parallel_state(cp_size=cp_size, cp_rank=cp_rank)
+    monkeypatch.setattr(data_utils, "process_rollout_data", lambda *args, **kwargs: (rollout_data, object()))
+    monkeypatch.setattr(data_utils, "get_parallel_state", lambda: parallel_state)
+    monkeypatch.setattr(cp_utils, "get_parallel_state", lambda: parallel_state)
+    monkeypatch.setattr(torch.cuda, "current_device", lambda: torch.device("cpu"))
+
+    loaded, _ = data_utils.get_rollout_data(_args(qkv_format), object())
+    expected_indices_tensor = torch.tensor(expected_indices)
+
+    torch.testing.assert_close(
+        loaded["opsd_teacher_token_ids"][0],
+        teacher_ids[expected_indices_tensor].long(),
+    )
+    torch.testing.assert_close(
+        loaded["opsd_teacher_scores"][0],
+        teacher_scores[expected_indices_tensor],
+    )

--- a/tests/fast/ray/rollout/conftest.py
+++ b/tests/fast/ray/rollout/conftest.py
@@ -45,6 +45,8 @@ def make_args(**overrides: Any) -> Namespace:
         num_rollout=1,
         # batch / training
         global_batch_size=8,
+        loss_type="policy_loss",
+        opsd_type=None,
         use_dynamic_global_batch_size=False,
         wandb_always_use_train_step=False,
         disable_rollout_trim_samples=False,

--- a/tests/fast/ray/rollout/test_metrics.py
+++ b/tests/fast/ray/rollout/test_metrics.py
@@ -12,6 +12,14 @@ from miles.ray.rollout.metrics import (
 
 
 class TestComputeZeroStdMetrics:
+    def test_returns_empty_for_structured_training_signals(self):
+        args = make_args(loss_type="opsd_loss")
+        samples = make_samples_grouped(1, 2)
+        samples[0].reward = {"token_ids": [[1, 2]], "scores": [[-0.1, -0.2]]}
+        samples[1].reward = {"token_ids": [[2, 3]], "scores": [[-0.3, -0.4]]}
+
+        assert _compute_zero_std_metrics(args, samples) == {}
+
     def test_returns_empty_for_ppo_regardless_of_reward_distribution(self):
         args = make_args(advantage_estimator="ppo")
         out = _compute_zero_std_metrics(args, make_samples_grouped(2, 4, rewards=[1.0] * 8))

--- a/tests/fast/ray/rollout/test_metrics.py
+++ b/tests/fast/ray/rollout/test_metrics.py
@@ -12,13 +12,19 @@ from miles.ray.rollout.metrics import (
 
 
 class TestComputeZeroStdMetrics:
-    def test_returns_empty_for_structured_training_signals(self):
-        args = make_args(loss_type="opsd_loss")
+    def test_returns_empty_for_opsd(self):
+        args = make_args(
+            loss_type="opsd_loss",
+            log_reward_category="category",
+            n_samples_per_prompt=2,
+        )
         samples = make_samples_grouped(1, 2)
         samples[0].reward = {"token_ids": [[1, 2]], "scores": [[-0.1, -0.2]]}
         samples[1].reward = {"token_ids": [[2, 3]], "scores": [[-0.3, -0.4]]}
 
         assert _compute_zero_std_metrics(args, samples) == {}
+        assert _compute_passrate_from_samples(args, samples) == {}
+        assert not any(key.startswith("error_cat/") for key in _compute_metrics_from_samples(args, samples))
 
     def test_returns_empty_for_ppo_regardless_of_reward_distribution(self):
         args = make_args(advantage_estimator="ppo")

--- a/tests/fast/ray/rollout/test_train_data_conversion.py
+++ b/tests/fast/ray/rollout/test_train_data_conversion.py
@@ -120,6 +120,47 @@ class TestConvertSamplesToTrainData:
         )
         assert out["rollout_log_probs"][0] == [-0.1, -0.2, -0.3, -0.4]
 
+    def test_opsd_teacher_support_is_flattened_for_typed_ragged_transport(self):
+        args = make_args(
+            loss_type="opsd_loss",
+            opsd_type="sglang",
+            opsd_teacher_top_k=2,
+            rewards_normalization=False,
+        )
+        sample = make_sample(
+            response_length=2, reward={"token_ids": [[4, 2], [1, 3]], "scores": [[0.5, -0.5], [0.2, -0.2]]}
+        )
+
+        out = convert_samples_to_train_data(
+            args,
+            [sample],
+            metadata={},
+            custom_convert_samples_to_train_data_func=None,
+            custom_reward_post_process_func=None,
+        )
+
+        assert out["opsd_teacher_token_ids"][0].tolist() == [4, 2, 1, 3]
+        assert out["opsd_teacher_scores"][0].tolist() == pytest.approx([0.5, -0.5, 0.2, -0.2])
+        assert out["rewards"] == [0.0]
+
+    @pytest.mark.parametrize("present_field", ["ids", "scores"])
+    def test_opsd_teacher_support_requires_both_fields_for_every_sample(self, present_field):
+        args = make_args(rewards_normalization=False)
+        sample = make_sample()
+        if present_field == "ids":
+            sample.opsd_teacher_token_ids = torch.tensor([[4, 2], [1, 3]])
+        else:
+            sample.opsd_teacher_scores = torch.tensor([[0.5, -0.5], [0.2, -0.2]])
+
+        with pytest.raises(ValueError, match="both token ids and scores"):
+            convert_samples_to_train_data(
+                args,
+                [sample],
+                metadata={},
+                custom_convert_samples_to_train_data_func=None,
+                custom_reward_post_process_func=None,
+            )
+
     def test_optional_field_round_number_from_metadata(self):
         args = make_args(rewards_normalization=False)
         s = make_sample()
@@ -211,6 +252,17 @@ class TestConvertSamplesToTrainData:
 
 
 class TestPostProcessRewards:
+    def test_defaults_to_standard_rewards_when_opsd_fields_are_absent(self):
+        args = make_args(advantage_estimator="ppo", rewards_normalization=True)
+        del args.loss_type
+        del args.opsd_type
+        samples = make_samples_grouped(1, 2, rewards=[1.0, 2.0])
+
+        raw, processed = _post_process_rewards(args, samples, custom_reward_post_process_func=None)
+
+        assert raw == [1.0, 2.0]
+        assert processed == raw
+
     def test_ppo_path_returns_raw_rewards_unchanged(self):
         args = make_args(advantage_estimator="ppo", rewards_normalization=True)
         samples = make_samples_grouped(2, 4, rewards=[1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0])
@@ -540,7 +592,7 @@ class TestSplitTrainDataRaw:
         assert len(result[0]["seq_witness_ids"]) == 2
         assert len(result[1]["seq_witness_ids"]) == 2
 
-    def test_indexer_topk_and_opd_reverse_kl_split_across_dp(self) -> None:
+    def test_indexer_topk_and_distillation_fields_split_across_dp(self) -> None:
         """Keys from the rollout-side split (rollout_indexer_topk, opd_reverse_kl) partition per sample."""
         data = {
             "tokens": [[1, 2], [3, 4], [5, 6], [7, 8]],
@@ -548,6 +600,8 @@ class TestSplitTrainDataRaw:
             "loss_masks": [[0, 1], [0, 1], [0, 1], [0, 1]],
             "rollout_indexer_topk": [torch.tensor([i]) for i in range(4)],
             "opd_reverse_kl": [[float(i)] for i in range(4)],
+            "opsd_teacher_token_ids": [torch.tensor([i, i + 1]) for i in range(4)],
+            "opsd_teacher_scores": [torch.tensor([float(i), float(i + 1)]) for i in range(4)],
         }
 
         args = MagicMock()
@@ -559,6 +613,8 @@ class TestSplitTrainDataRaw:
         for part in result:
             assert len(part["rollout_indexer_topk"]) == 2
             assert len(part["opd_reverse_kl"]) == 2
+            assert len(part["opsd_teacher_token_ids"]) == 2
+            assert len(part["opsd_teacher_scores"]) == 2
 
     def test_no_witness_ids_when_absent(self) -> None:
         tokens = [[1, 2], [3, 4]]

--- a/tests/fast/rollout/rm_hub/test_rm_hub.py
+++ b/tests/fast/rollout/rm_hub/test_rm_hub.py
@@ -2,6 +2,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+import miles.rollout.rm_hub as rm_hub
 from miles.rollout.rm_hub import async_rm, batched_async_rm
 from miles.utils.async_utils import run
 from miles.utils.types import Sample
@@ -17,6 +18,22 @@ def mock_args():
 
 
 class TestAsyncRm:
+    def test_training_opsd_uses_teacher_scorer_but_evaluation_uses_task_reward(self, mock_args, monkeypatch):
+        async def score_opsd(args, sample, **kwargs):
+            return {"token_ids": [[7, 8]], "scores": [[-0.1, -2.0]]}
+
+        mock_args.loss_type = "opsd_loss"
+        mock_args.opsd_type = "sglang"
+        mock_args.rm_type = "math"
+        monkeypatch.setattr(rm_hub, "score_opsd_sample", score_opsd)
+        sample = Sample(prompt="", response=r"\boxed{42}", label="42")
+
+        train_reward = run(async_rm(mock_args, sample))
+        eval_reward = run(async_rm(mock_args, sample, evaluation=True))
+
+        assert train_reward == {"token_ids": [[7, 8]], "scores": [[-0.1, -2.0]]}
+        assert eval_reward == 1
+
     @pytest.mark.parametrize(
         "rm_type,response,label,expected",
         [

--- a/tests/fast/rollout/test_on_policy_self_distillation.py
+++ b/tests/fast/rollout/test_on_policy_self_distillation.py
@@ -1,0 +1,167 @@
+import math
+from argparse import Namespace
+
+import pytest
+from tests.ci.ci_register import register_cpu_ci
+
+from miles.rollout.on_policy_self_distillation import (
+    _extract_teacher_top_k,
+    _score_payload,
+    build_teacher_prompt,
+    post_process_rewards,
+    reward_func,
+)
+from miles.utils.types import Sample
+
+register_cpu_ci(est_time=30, suite="stage-a-cpu")
+
+
+def _entry(probability: float, token_id: int) -> list[float | int]:
+    return [math.log(probability), token_id]
+
+
+def test_default_teacher_prompt_augments_the_final_user_message_without_mutating_input():
+    prompt = [
+        {"role": "system", "content": "Be precise."},
+        {"role": "user", "content": "Solve 2 + 2."},
+    ]
+
+    teacher_prompt = build_teacher_prompt(prompt, "The answer is 4.", {})
+
+    assert prompt[-1]["content"] == "Solve 2 + 2."
+    assert teacher_prompt[0] == prompt[0]
+    assert teacher_prompt[-1]["role"] == "user"
+    assert "Solve 2 + 2." in teacher_prompt[-1]["content"]
+    assert "The answer is 4." in teacher_prompt[-1]["content"]
+    assert "independent reasoning" in teacher_prompt[-1]["content"]
+
+
+def test_default_teacher_prompt_supports_raw_text():
+    teacher_prompt = build_teacher_prompt("Solve 2 + 2.", "The answer is 4.", {})
+
+    assert isinstance(teacher_prompt, str)
+    assert teacher_prompt.startswith("Solve 2 + 2.")
+    assert "The answer is 4." in teacher_prompt
+
+
+def test_default_teacher_prompt_rejects_non_text_conversation_content():
+    prompt = [{"role": "user", "content": [{"type": "image", "image": "x"}]}]
+
+    with pytest.raises(ValueError, match="text-only"):
+        build_teacher_prompt(prompt, "answer", {})
+
+
+def test_default_teacher_prompt_rejects_non_text_context_messages():
+    prompt = [
+        {"role": "system", "content": [{"type": "image", "image": "x"}]},
+        {"role": "user", "content": "Solve this."},
+    ]
+
+    with pytest.raises(ValueError, match="text-only"):
+        build_teacher_prompt(prompt, "answer", {})
+
+
+def test_default_teacher_prompt_rejects_tool_messages():
+    prompt = [
+        {"role": "tool", "content": "result"},
+        {"role": "user", "content": "Finish."},
+    ]
+
+    with pytest.raises(ValueError, match="tool messages"):
+        build_teacher_prompt(prompt, "answer", {})
+
+
+def test_score_payload_requests_temperature_corrected_top_k_input_scores():
+    payload = _score_payload([1, 2, 3], top_k=8, temperature=1.1)
+
+    assert payload == {
+        "input_ids": [1, 2, 3],
+        "sampling_params": {
+            "temperature": 1.1,
+            "max_new_tokens": 0,
+            "skip_special_tokens": False,
+        },
+        "return_logprob": True,
+        "logprob_start_len": 0,
+        "top_logprobs_num": 8,
+    }
+
+
+def test_extract_teacher_top_k_keeps_only_response_aligned_positions():
+    response = {
+        "meta_info": {
+            "input_top_logprobs": [
+                None,
+                [_entry(0.7, 10), _entry(0.3, 11)],
+                [_entry(0.6, 20), _entry(0.4, 21)],
+                [_entry(0.8, 30), _entry(0.2, 31)],
+            ]
+        }
+    }
+
+    token_ids, scores = _extract_teacher_top_k(response, response_length=2, top_k=2)
+
+    assert token_ids == [[20, 21], [30, 31]]
+    assert scores[0] == pytest.approx([math.log(0.6), math.log(0.4)])
+    assert scores[1] == pytest.approx([math.log(0.8), math.log(0.2)])
+
+
+async def test_reward_func_scores_privileged_prompt_with_exact_student_response(monkeypatch):
+    seen = {}
+
+    async def post_json(url, payload, *, timeout_secs):
+        seen.update(url=url, payload=payload, timeout_secs=timeout_secs)
+        return {
+            "meta_info": {
+                "input_top_logprobs": [
+                    None,
+                    [_entry(0.7, 10), _entry(0.3, 11)],
+                    [_entry(0.6, 20), _entry(0.4, 21)],
+                    [_entry(0.8, 30), _entry(0.2, 31)],
+                    [_entry(0.9, 40), _entry(0.1, 41)],
+                ]
+            }
+        }
+
+    monkeypatch.setattr("miles.rollout.on_policy_self_distillation._post_json", post_json)
+    args = Namespace(
+        opsd_teacher_top_k=2,
+        rollout_temperature=0.8,
+        opsd_teacher_url="http://teacher/generate",
+        sglang_router_request_timeout_secs=30,
+    )
+    sample = Sample(
+        tokens=[1, 2, 30, 40],
+        response_length=2,
+        privileged_prompt_tokens=[7, 8, 9],
+    )
+
+    reward = await reward_func(args, sample)
+
+    assert seen["url"] == "http://teacher/generate"
+    assert seen["timeout_secs"] == 30
+    assert seen["payload"]["input_ids"] == [7, 8, 9, 30, 40]
+    assert seen["payload"]["sampling_params"]["temperature"] == 0.8
+    assert reward["token_ids"] == [[30, 31], [40, 41]]
+
+
+def test_post_process_rewards_moves_compact_teacher_support_onto_samples():
+    samples = [
+        Sample(
+            tokens=[1, 2, 3],
+            response_length=2,
+            reward={
+                "token_ids": [[10, 11], [20, 21]],
+                "scores": [[-0.1, -2.3], [-0.2, -1.7]],
+            },
+        )
+    ]
+
+    raw_rewards, rewards = post_process_rewards(Namespace(opsd_teacher_top_k=2), samples)
+
+    assert raw_rewards == [0.0]
+    assert rewards == [0.0]
+    assert samples[0].opsd_teacher_token_ids.tolist() == [[10, 11], [20, 21]]
+    assert samples[0].opsd_teacher_scores.tolist()[0] == pytest.approx([-0.1, -2.3])
+    assert samples[0].opsd_teacher_scores.tolist()[1] == pytest.approx([-0.2, -1.7])
+    samples[0].validate()

--- a/tests/fast/rollout/test_on_policy_self_distillation.py
+++ b/tests/fast/rollout/test_on_policy_self_distillation.py
@@ -71,13 +71,13 @@ def test_default_teacher_prompt_rejects_tool_messages():
         build_teacher_prompt(prompt, "answer", {})
 
 
-def test_score_payload_requests_temperature_corrected_top_k_input_scores():
-    payload = _score_payload([1, 2, 3], top_k=8, temperature=1.1)
+def test_score_payload_requests_top_k_input_scores_without_sampling():
+    payload = _score_payload([1, 2, 3], top_k=8)
 
     assert payload == {
         "input_ids": [1, 2, 3],
         "sampling_params": {
-            "temperature": 1.1,
+            "temperature": 0,
             "max_new_tokens": 0,
             "skip_special_tokens": False,
         },
@@ -126,7 +126,6 @@ async def test_reward_func_scores_privileged_prompt_with_exact_student_response(
     monkeypatch.setattr("miles.rollout.on_policy_self_distillation._post_json", post_json)
     args = Namespace(
         opsd_teacher_top_k=2,
-        rollout_temperature=0.8,
         opsd_teacher_url="http://teacher/generate",
         sglang_router_request_timeout_secs=30,
     )
@@ -141,7 +140,7 @@ async def test_reward_func_scores_privileged_prompt_with_exact_student_response(
     assert seen["url"] == "http://teacher/generate"
     assert seen["timeout_secs"] == 30
     assert seen["payload"]["input_ids"] == [7, 8, 9, 30, 40]
-    assert seen["payload"]["sampling_params"]["temperature"] == 0.8
+    assert seen["payload"]["sampling_params"]["temperature"] == 0
     assert reward["token_ids"] == [[30, 31], [40, 41]]
 
 

--- a/tests/fast/utils/test_opsd_arguments.py
+++ b/tests/fast/utils/test_opsd_arguments.py
@@ -1,0 +1,131 @@
+import argparse
+
+import pytest
+from tests.ci.ci_register import register_cpu_ci
+
+from miles.utils.arguments import get_miles_extra_args_provider, miles_validate_args
+
+register_cpu_ci(est_time=30, suite="stage-a-cpu")
+
+REQUIRED_ARGS = ["--rollout-batch-size", "64"]
+
+
+class TestOPSDArguments:
+    def _parse(self, extra):
+        parser = argparse.ArgumentParser()
+        get_miles_extra_args_provider()(parser)
+        return parser.parse_args(extra + ["--num-rollout", "1"] + REQUIRED_ARGS)
+
+    def test_parses_opinionated_defaults(self):
+        args = self._parse([])
+
+        assert args.opsd_type is None
+        assert args.opsd_teacher_top_k == 64
+        assert args.opsd_pointwise_kl_clip == 0.05
+        assert args.opsd_teacher_prompt_function_path is None
+        assert args.opsd_teacher_chat_template_kwargs == {}
+
+    def test_sglang_opsd_accepts_complete_pure_configuration(self):
+        args = self._parse(
+            [
+                "--loss-type",
+                "opsd_loss",
+                "--disable-compute-advantages-and-returns",
+                "--opsd-type",
+                "sglang",
+                "--opsd-teacher-url",
+                "http://127.0.0.1:13141/generate",
+                "--label-key",
+                "label",
+            ]
+        )
+
+        miles_validate_args(args)
+
+        assert args.loss_type == "opsd_loss"
+        assert args.compute_advantages_and_returns is False
+
+    def test_rejects_opsd_with_advantage_computation(self):
+        args = self._parse(
+            [
+                "--loss-type",
+                "opsd_loss",
+                "--opsd-type",
+                "sglang",
+                "--opsd-teacher-url",
+                "http://127.0.0.1:13141/generate",
+                "--label-key",
+                "label",
+            ]
+        )
+
+        with pytest.raises(ValueError, match="--disable-compute-advantages-and-returns"):
+            miles_validate_args(args)
+
+    @pytest.mark.parametrize(
+        "hybrid_args",
+        [
+            ["--kl-coef", "0.1"],
+            ["--use-kl-loss"],
+            ["--entropy-coef", "0.1"],
+        ],
+    )
+    def test_rejects_additive_rl_objective_terms(self, hybrid_args):
+        args = self._parse(
+            [
+                "--loss-type",
+                "opsd_loss",
+                "--disable-compute-advantages-and-returns",
+                "--opsd-type",
+                "sglang",
+                "--opsd-teacher-url",
+                "http://127.0.0.1:13141/generate",
+                "--label-key",
+                "label",
+                *hybrid_args,
+            ]
+        )
+
+        with pytest.raises(ValueError, match="pure objective"):
+            miles_validate_args(args)
+
+    @pytest.mark.parametrize("top_k", ["0", "1"])
+    def test_rejects_degenerate_teacher_support(self, top_k):
+        args = self._parse(
+            [
+                "--loss-type",
+                "opsd_loss",
+                "--disable-compute-advantages-and-returns",
+                "--opsd-type",
+                "sglang",
+                "--opsd-teacher-url",
+                "http://127.0.0.1:13141/generate",
+                "--opsd-teacher-top-k",
+                top_k,
+                "--label-key",
+                "label",
+            ]
+        )
+
+        with pytest.raises(ValueError, match="at least 2"):
+            miles_validate_args(args)
+
+    def test_rejects_non_object_teacher_chat_template_kwargs(self):
+        args = self._parse(
+            [
+                "--loss-type",
+                "opsd_loss",
+                "--disable-compute-advantages-and-returns",
+                "--opsd-type",
+                "sglang",
+                "--opsd-teacher-url",
+                "http://127.0.0.1:13141/generate",
+                "--opsd-teacher-chat-template-kwargs",
+                "[]",
+                "--label-key",
+                "label",
+            ]
+        )
+
+        with pytest.raises(ValueError, match="JSON object"):
+            miles_validate_args(args)

--- a/tests/fast/utils/test_opsd_dataset.py
+++ b/tests/fast/utils/test_opsd_dataset.py
@@ -1,0 +1,123 @@
+import pytest
+from tests.ci.ci_register import register_cpu_ci
+
+from miles.rollout.on_policy_self_distillation import build_teacher_prompt
+from miles.utils.data import Dataset
+
+register_cpu_ci(est_time=30, suite="stage-a-cpu")
+
+
+class _Tokenizer:
+    def encode(self, text, add_special_tokens):
+        assert add_special_tokens is False
+        return [ord(character) for character in text]
+
+    def __call__(self, prompts, add_special_tokens):
+        return {"input_ids": [self.encode(prompt, add_special_tokens) for prompt in prompts]}
+
+
+def test_dataset_materializes_and_length_filters_privileged_teacher_prompt(monkeypatch):
+    rows = [{"text": "2 + 2?", "label": "4", "metadata": {"source": "unit"}}]
+    monkeypatch.setattr("miles.utils.data.read_file", lambda _: iter(rows))
+
+    dataset = Dataset(
+        "unused.jsonl",
+        tokenizer=_Tokenizer(),
+        processor=None,
+        max_length=1000,
+        label_key="label",
+        teacher_prompt_builder=build_teacher_prompt,
+    )
+
+    sample = dataset[0]
+    expected_prompt = build_teacher_prompt("2 + 2?", "4", {"source": "unit"})
+    assert sample.privileged_prompt_tokens == _Tokenizer().encode(expected_prompt, add_special_tokens=False)
+
+    filtered_dataset = Dataset(
+        "unused.jsonl",
+        tokenizer=_Tokenizer(),
+        processor=None,
+        max_length=len("2 + 2?"),
+        label_key="label",
+        teacher_prompt_builder=build_teacher_prompt,
+    )
+    assert len(filtered_dataset) == 0
+
+
+def test_dataset_calls_custom_teacher_prompt_builder_by_keyword(monkeypatch):
+    rows = [{"text": "2 + 2?", "label": "4", "metadata": {"source": "unit"}}]
+    monkeypatch.setattr("miles.utils.data.read_file", lambda _: iter(rows))
+    received = {}
+
+    def teacher_prompt_builder(*, prompt, label, metadata):
+        received.update(prompt=prompt, label=label, metadata=metadata)
+        return "privileged"
+
+    dataset = Dataset(
+        "unused.jsonl",
+        tokenizer=_Tokenizer(),
+        processor=None,
+        max_length=None,
+        label_key="label",
+        teacher_prompt_builder=teacher_prompt_builder,
+    )
+
+    assert len(dataset) == 1
+    assert received == {
+        "prompt": "2 + 2?",
+        "label": "4",
+        "metadata": {"source": "unit"},
+    }
+
+
+def test_dataset_rejects_tool_enabled_opsd_samples(monkeypatch):
+    rows = [
+        {
+            "text": "Use the tool.",
+            "label": "done",
+            "tools": [{"type": "function", "function": {"name": "lookup"}}],
+        }
+    ]
+    monkeypatch.setattr("miles.utils.data.read_file", lambda _: iter(rows))
+
+    with pytest.raises(ValueError, match="tool-enabled"):
+        Dataset(
+            "unused.jsonl",
+            tokenizer=_Tokenizer(),
+            processor=None,
+            max_length=None,
+            label_key="label",
+            tool_key="tools",
+            teacher_prompt_builder=build_teacher_prompt,
+        )
+
+
+def test_dataset_renders_teacher_conversation_with_independent_template_kwargs(monkeypatch):
+    rows = [{"text": "2 + 2?", "label": "4"}]
+    monkeypatch.setattr("miles.utils.data.read_file", lambda _: iter(rows))
+    captured = {}
+
+    def render(messages, **kwargs):
+        captured.update(messages=messages, kwargs=kwargs)
+        return "teacher-rendered"
+
+    monkeypatch.setattr("miles.utils.data.chat_template_utils.apply_chat_template", render)
+
+    dataset = Dataset(
+        "unused.jsonl",
+        tokenizer=_Tokenizer(),
+        processor=None,
+        max_length=None,
+        label_key="label",
+        teacher_prompt_builder=lambda **_: [{"role": "user", "content": "privileged"}],
+        teacher_chat_template_kwargs={"enable_thinking": False},
+    )
+
+    assert len(dataset) == 1
+    assert captured["messages"] == [{"role": "user", "content": "privileged"}]
+    assert captured["kwargs"]["enable_thinking"] is False
+    assert captured["kwargs"]["add_generation_prompt"] is True
+    assert dataset[0].privileged_prompt_tokens == _Tokenizer().encode(
+        "teacher-rendered",
+        add_special_tokens=False,
+    )

--- a/tests/fast/utils/test_types.py
+++ b/tests/fast/utils/test_types.py
@@ -105,3 +105,27 @@ class TestStripLastOutputTokens:
         original_tokens = list(s.tokens)
         s.strip_last_output_tokens(-1, tokenizer)
         assert s.tokens == original_tokens
+
+
+class TestOPSDFields:
+    def test_validate_and_strip_response_aligned_teacher_support(self, tokenizer):
+        sample = _make_sample([1, 2], [3, 4, 5])
+        sample.privileged_prompt_tokens = [7, 8, 9]
+        sample.opsd_teacher_token_ids = numpy.array([[10, 11], [20, 21], [30, 31]], dtype=numpy.int64)
+        sample.opsd_teacher_scores = numpy.array([[-0.1, -0.2], [-0.3, -0.4], [-0.5, -0.6]])
+
+        sample.validate()
+        sample.strip_last_output_tokens(1, tokenizer)
+        sample.validate()
+
+        assert sample.privileged_prompt_tokens == [7, 8, 9]
+        assert sample.opsd_teacher_token_ids.tolist() == [[10, 11], [20, 21]]
+        assert sample.opsd_teacher_scores.tolist() == [[-0.1, -0.2], [-0.3, -0.4]]
+
+    def test_validate_rejects_mismatched_teacher_support_shapes(self):
+        sample = _make_sample([1], [2, 3])
+        sample.opsd_teacher_token_ids = numpy.array([[10, 11], [20, 21]])
+        sample.opsd_teacher_scores = numpy.array([[-0.1, -0.2]])
+
+        with pytest.raises(AssertionError, match="matching shapes"):
+            sample.validate()


### PR DESCRIPTION
## Summary

Adds on-policy self-distillation (OPSD) as a training option alongside OPD.

The student generates a response from the normal prompt. A fixed SGLang teacher scores that response under a privileged prompt. Miles then trains the student against the teacher's top-k token scores.

## Changes

- Add the OPSD loss and training data path.
- Add fixed-teacher scoring through SGLang.
- Support FSDP and Megatron student backends.
- Carry teacher token scores from rollout into training.
- Support context-parallel training.
- Add argument and dataset validation.
- Add focused unit tests, short end-to-end tests, and documentation.

The teacher remains fixed and does not receive student weight updates. It must serve the frozen initial student model, with the same tokenizer and token-ID mapping. This PR does not add a native Megatron teacher.

This follows the OPSD method described here:

https://siyan-zhao.github.io/blog/2026/opsd

## Test plan

- [x] FSDP student with a fixed SGLang teacher: two training updates on 2x H100 80GB.
- [x] Megatron student with a fixed SGLang teacher: two training updates on 2x H100 80GB.
- [x] Qwen3.5-4B FSDP student with a fixed SGLang teacher: 32 updates on 2x H200. On a fixed 128-example GSM8K subset, accuracy improved from 5.47% (7/128) to 49.22% (63/128), with a final checkpoint at update 32.
- [x] Focused unit tests.
- [x] Ruff.
- [x] `git diff --check`.

The two-update GPU runs verify both student backends. The Qwen3.5-4B run provides an initial model-quality signal, not a convergence or full-benchmark claim. It exercised the SGLang/FSDP path from the current workspace snapshot; an exact PR-head rerun remains pending.
