### PR TITLE
eval: inherit rollout sglang engine args, override with --eval-sglang-*

### DIFF
--- a/docs/user-guide/cli-reference.md
+++ b/docs/user-guide/cli-reference.md
@@ -201,13 +201,14 @@ Sections mirror the launch-script argument groups.
 | `--eval-max-response-len` | int | – | Max eval response length. Inherits from rollout if unset. |
 | `--eval-temperature` | float | – | Eval temperature. Inherits from rollout if unset. |
 | `--eval-top-p` | float | – | Eval top-p. Inherits from rollout if unset. |
-| `--eval-num-gpus` | int | `0` | Dedicated eval fleet size (required for fully-async eval). `0` = shared-engine eval. |
+| `--eval-num-gpus` | int | `0` | Dedicated eval fleet size. `0` = shared-engine eval. |
 | `--eval-num-gpus-per-engine` | int | `1` | Eval engine TP, independent of rollout TP. |
 | `--eval-hf-dir` | str | – | Staging dir for per-eval HF snapshots (tmpfs recommended). Unset + `--save-hf` = reuse mode. |
 | `--eval-model-path` | str | – | Boot checkpoint for eval engines. Defaults to `--hf-checkpoint`. |
 | `--eval-max-in-flight` | int | `2` | Max concurrently pending async evals. |
 | `--eval-overflow-policy` | str | `backpressure` | At the cap: await the oldest eval, or `skip` the new point (logged as `eval/skipped_busy`). |
 | `--eval-keep-snapshots` | int | `2` | GC ring for `--eval-hf-dir`; `--save-hf` output is never deleted. |
+| `--eval-sglang-*` | – | – | Per-field override of any `--sglang-*` setting for the eval fleet only. Unset = inherit the rollout engines' value. Booleans take a `--no-` form (`--no-eval-sglang-enable-dp-attention`) so an inherited `True` can be turned off. `tp_size` is not exposed — use `--eval-num-gpus-per-engine`. |
 
 ### Performance
 

--- a/docs/user-guide/fully-async.md
+++ b/docs/user-guide/fully-async.md
@@ -150,6 +150,20 @@ snapshot (`weight_version = str(rollout_id)`), runs the standard eval datasets, 
 point lands at the right x-axis step even when it completes a few steps later
 (`eval/lag_steps` reports how late).
 
+The fleet's engines **inherit every `--sglang-*` setting** from the rollout engines, so by
+default they are configured exactly like the engines you already tuned. Override any single
+field with the matching `--eval-sglang-*` flag:
+
+```bash
+--eval-sglang-mem-fraction-static 0.9      # eval fleet is not sharing with training
+--no-eval-sglang-enable-dp-attention       # booleans take a --no- form to turn an inherited True off
+```
+
+Two fields are deliberately not inheritable: TP comes from `--eval-num-gpus-per-engine`
+(which also places the engines, so a separate `--eval-sglang-tp-size` could move one without
+the other), and the routing/indexer replay side-channels are forced off — eval samples never
+feed training, so returning routed experts is pure overhead.
+
 Two production-oriented variants:
 
 - **Reuse mode**: with `--save-hf` set and `--eval-hf-dir` unset, eval reuses the

--- a/miles/backends/sglang_utils/arguments.py
+++ b/miles/backends/sglang_utils/arguments.py
@@ -3,8 +3,6 @@ import argparse
 from sglang.srt.server_args import ServerArgs
 from miles.utils.http_utils import _wrap_ipv6
 
-EVAL_SGLANG_DEST_PREFIX = "eval_sglang_"
-
 
 # TODO: use all sglang router arguments with `--sglang-router` prefix
 def add_sglang_router_arguments(parser):
@@ -141,9 +139,7 @@ def _add_prefixed_server_args(parser, *, flag_prefix: str, dest_prefix: str, ski
 def collect_eval_sglang_overrides(args) -> dict:
     """``ServerArgs`` fields set via ``--eval-sglang-*``; absent means inherit ``--sglang-*``."""
     return {
-        key.removeprefix(EVAL_SGLANG_DEST_PREFIX): value
-        for key, value in vars(args).items()
-        if key.startswith(EVAL_SGLANG_DEST_PREFIX)
+        key.removeprefix("eval_sglang_"): value for key, value in vars(args).items() if key.startswith("eval_sglang_")
     }
 
 
@@ -160,7 +156,7 @@ def add_sglang_arguments(parser):
     _add_prefixed_server_args(
         parser,
         flag_prefix="eval-sglang",
-        dest_prefix=EVAL_SGLANG_DEST_PREFIX,
+        dest_prefix="eval_sglang_",
         skipped_args=_EVAL_SKIPPED_SERVER_ARGS,
         inherit=True,
     )

--- a/miles/backends/sglang_utils/arguments.py
+++ b/miles/backends/sglang_utils/arguments.py
@@ -1,5 +1,9 @@
+import argparse
+
 from sglang.srt.server_args import ServerArgs
 from miles.utils.http_utils import _wrap_ipv6
+
+EVAL_SGLANG_DEST_PREFIX = "eval_sglang_"
 
 
 # TODO: use all sglang router arguments with `--sglang-router` prefix
@@ -34,36 +38,38 @@ def add_sglang_router_arguments(parser):
     return parser
 
 
-def add_sglang_arguments(parser):
-    """
-    Add arguments to the parser for the SGLang server.
-    """
-    parser = add_sglang_router_arguments(parser)
-    parser.add_argument("--sglang-server-concurrency", type=int, default=512)
+_SKIPPED_SERVER_ARGS = [
+    "model_path",
+    "config",
+    "trust_remote_code",
+    "random_seed",
+    # memory
+    "enable_memory_saver",
+    # distributed
+    # tp_size stays exposed: scripts pass --sglang-tp-size, but the value is
+    # overridden from --rollout-num-gpus-per-engine in validate_args below.
+    "port",
+    "nnodes",
+    "node_rank",
+    "dist_init_addr",
+    "gpu_id_step",
+    "base_gpu_id",
+    "nccl_port",
+    "skip_server_warmup",
+    "enable_return_routed_experts",
+    "enable_return_indexer_topk",
+]
 
+# tp_size comes from --eval-num-gpus-per-engine, which also places the engines.
+_EVAL_SKIPPED_SERVER_ARGS = _SKIPPED_SERVER_ARGS + ["tp_size"]
+
+
+def _add_prefixed_server_args(parser, *, flag_prefix: str, dest_prefix: str, skipped_args: list[str], inherit: bool):
+    """Register ``ServerArgs.add_cli_args`` as ``--{flag_prefix}-*`` -> ``args.{dest_prefix}*``.
+
+    ``inherit=True`` defaults to SUPPRESS, so an unset flag leaves no attribute to inherit over.
+    """
     old_add_argument = parser.add_argument
-
-    skipped_args = [
-        "model_path",
-        "config",
-        "trust_remote_code",
-        "random_seed",
-        # memory
-        "enable_memory_saver",
-        # distributed
-        # tp_size stays exposed: scripts pass --sglang-tp-size, but the value is
-        # overridden from --rollout-num-gpus-per-engine in validate_args below.
-        "port",
-        "nnodes",
-        "node_rank",
-        "dist_init_addr",
-        "gpu_id_step",
-        "base_gpu_id",
-        "nccl_port",
-        "skip_server_warmup",
-        "enable_return_routed_experts",
-        "enable_return_indexer_topk",
-    ]
 
     def new_add_argument_wrapper(*name_or_flags, **kwargs):
         """
@@ -90,7 +96,7 @@ def add_sglang_arguments(parser):
         for item_flag in name_or_flags:
             if isinstance(item_flag, str) and item_flag.startswith("-"):
                 original_flag_stem = item_flag.lstrip("-")  # "foo-bar" from "--foo-bar", or "f" from "-f"
-                prefixed_item = f"--sglang-{original_flag_stem}"
+                prefixed_item = f"--{flag_prefix}-{original_flag_stem}"
                 new_name_or_flags_list.append(prefixed_item)
             else:
                 # Positional arguments or non-string items
@@ -104,9 +110,9 @@ def add_sglang_arguments(parser):
         # This ensures the attribute on the args namespace becomes, e.g., args.sglang_dest_name.
         if "dest" in final_kwargs and isinstance(final_kwargs["dest"], str):
             original_dest = final_kwargs["dest"]
-            # Avoid double prefixing if dest somehow already starts with sglang_
-            if not original_dest.startswith("sglang_"):
-                final_kwargs["dest"] = f"sglang_{original_dest}"
+            # Avoid double prefixing if dest somehow already starts with the prefix
+            if not original_dest.startswith(dest_prefix):
+                final_kwargs["dest"] = f"{dest_prefix}{original_dest}"
         elif "dest" not in final_kwargs:
             # argparse derives dest from the first alias, so store parallel sizes under SGLang's short field names.
             for item_flag in name_or_flags:
@@ -114,14 +120,50 @@ def add_sglang_arguments(parser):
                     continue
                 canonical_dest = item_flag[2:].replace("-", "_")
                 if canonical_dest in ("tp_size", "dp_size", "pp_size", "ep_size"):
-                    final_kwargs["dest"] = f"sglang_{canonical_dest}"
+                    final_kwargs["dest"] = f"{dest_prefix}{canonical_dest}"
                     break
+
+        if inherit:
+            final_kwargs["default"] = argparse.SUPPRESS
+            if final_kwargs.get("action") in ("store_true", "store_false"):
+                # store_true can only turn a field on; an override must also turn one off.
+                final_kwargs["action"] = argparse.BooleanOptionalAction
+                final_kwargs.pop("const", None)
+                final_kwargs.pop("nargs", None)
 
         old_add_argument(*new_name_or_flags_list, **final_kwargs)
 
     parser.add_argument = new_add_argument_wrapper
     ServerArgs.add_cli_args(parser)
     parser.add_argument = old_add_argument
+
+
+def collect_eval_sglang_overrides(args) -> dict:
+    """``ServerArgs`` fields set via ``--eval-sglang-*``; absent means inherit ``--sglang-*``."""
+    return {
+        key.removeprefix(EVAL_SGLANG_DEST_PREFIX): value
+        for key, value in vars(args).items()
+        if key.startswith(EVAL_SGLANG_DEST_PREFIX)
+    }
+
+
+def add_sglang_arguments(parser):
+    """
+    Add arguments to the parser for the SGLang server.
+    """
+    parser = add_sglang_router_arguments(parser)
+    parser.add_argument("--sglang-server-concurrency", type=int, default=512)
+
+    _add_prefixed_server_args(
+        parser, flag_prefix="sglang", dest_prefix="sglang_", skipped_args=_SKIPPED_SERVER_ARGS, inherit=False
+    )
+    _add_prefixed_server_args(
+        parser,
+        flag_prefix="eval-sglang",
+        dest_prefix=EVAL_SGLANG_DEST_PREFIX,
+        skipped_args=_EVAL_SKIPPED_SERVER_ARGS,
+        inherit=True,
+    )
 
     parser.add_argument(
         "--sglang-config",
@@ -133,6 +175,8 @@ def add_sglang_arguments(parser):
             "num_gpus per group, and optional per-group 'overrides' dict of "
             "ServerArgs field names that override the base --sglang-* CLI args. "
             "Placeholder groups reserve GPU slots without creating engines. "
+            "A 'name: eval' model is filled in from the --eval-* args (model_path, "
+            "num_gpus_per_engine, --eval-sglang-* overrides) wherever the YAML leaves them unset. "
             "Mutually exclusive with --prefill-num-servers."
         ),
     )

--- a/miles/backends/sglang_utils/sglang_engine.py
+++ b/miles/backends/sglang_utils/sglang_engine.py
@@ -727,9 +727,6 @@ def _compute_server_args(
         "enable_metrics": True,
     }
 
-    if sglang_overrides:
-        kwargs.update(sglang_overrides)
-
     if worker_type == "prefill":
         kwargs["disaggregation_mode"] = "prefill"
         kwargs.setdefault("load_balance_method", "round_robin")
@@ -749,7 +746,6 @@ def _compute_server_args(
         kwargs["dtype"] = "float16"
     if engine_info_bootstrap_port is not None:
         kwargs["engine_info_bootstrap_port"] = engine_info_bootstrap_port
-    external_engine_need_check_fields = [k for k in kwargs.keys() if k not in _EXTERNAL_ENGINE_SKIP_CHECK_FIELDS]
 
     if is_multi_lora_enabled(args):
         kwargs["enable_lora"] = True
@@ -778,6 +774,12 @@ def _compute_server_args(
                 "LoRA + colocate: enabling SGLang enable_weights_cpu_backup=True; "
                 "the trainer will skip per-step base weight sync."
             )
+
+    # Last, so a per-group override wins over every args-derived default above.
+    if sglang_overrides:
+        kwargs.update(sglang_overrides)
+
+    external_engine_need_check_fields = [k for k in kwargs.keys() if k not in _EXTERNAL_ENGINE_SKIP_CHECK_FIELDS]
 
     unused_keys = set(kwargs.keys())
     for attr in dataclasses.fields(ServerArgs):

--- a/miles/ray/rollout/rollout_server.py
+++ b/miles/ray/rollout/rollout_server.py
@@ -4,6 +4,7 @@ import logging
 
 import ray
 
+from miles.backends.sglang_utils.arguments import collect_eval_sglang_overrides
 from miles.backends.sglang_utils.sglang_config import ModelConfig, ServerGroupConfig, SglangConfig
 from miles.ray.rollout.addr_allocator import PortCursors
 from miles.ray.rollout.router_manager import start_router
@@ -102,6 +103,30 @@ def start_rollout_servers(args, pg) -> dict[str, "RolloutServer"]:
     return servers
 
 
+def _eval_sglang_overrides(args) -> dict:
+    """Eval-fleet engine settings; anything absent is inherited from the rollout engines."""
+    return {
+        # Eval samples never feed training, so the replay side-channels are pure overhead.
+        "enable_return_routed_experts": False,
+        "enable_return_indexer_topk": False,
+        **collect_eval_sglang_overrides(args),
+    }
+
+
+def _apply_eval_model_config(model_cfg: ModelConfig, args) -> None:
+    """Fill the eval model from the ``--eval-*`` args: YAML > ``--eval-sglang-*`` > ``--sglang-*``."""
+    if model_cfg.model_path is None:
+        model_cfg.model_path = args.eval_model_path
+    if model_cfg.update_weights is None:
+        # Never joins the training broadcast group; the fleet is synced by snapshot only.
+        model_cfg.update_weights = False
+    overrides = _eval_sglang_overrides(args)
+    for group in model_cfg.server_groups:
+        if group.num_gpus_per_engine is None:
+            group.num_gpus_per_engine = args.eval_num_gpus_per_engine
+        group.overrides = overrides | group.overrides
+
+
 def _resolve_sglang_config(args) -> SglangConfig:
     """Build a SglangConfig from args, choosing the right source."""
     eval_num_gpus = args.eval_num_gpus
@@ -119,6 +144,7 @@ def _resolve_sglang_config(args) -> SglangConfig:
                 f"--eval-num-gpus {eval_num_gpus} requires the sglang_config YAML to contain "
                 f"exactly one model named 'eval' with that many GPUs."
             )
+            _apply_eval_model_config(eval_models[0], args)
         return config
 
     if args.prefill_num_servers is not None:
@@ -134,20 +160,12 @@ def _resolve_sglang_config(args) -> SglangConfig:
         )
 
     if eval_num_gpus > 0:
-        config.models.append(
-            ModelConfig(
-                name="eval",
-                model_path=args.eval_model_path,
-                update_weights=False,
-                server_groups=[
-                    ServerGroupConfig(
-                        worker_type="regular",
-                        num_gpus=eval_num_gpus,
-                        num_gpus_per_engine=args.eval_num_gpus_per_engine,
-                    )
-                ],
-            )
+        eval_model = ModelConfig(
+            name="eval",
+            server_groups=[ServerGroupConfig(worker_type="regular", num_gpus=eval_num_gpus)],
         )
+        _apply_eval_model_config(eval_model, args)
+        config.models.append(eval_model)
     return config
 
 

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -7,7 +7,7 @@ from typing import Any
 import yaml
 from sglang_router.launch_router import RouterArgs
 
-from miles.backends.sglang_utils.arguments import add_sglang_arguments
+from miles.backends.sglang_utils.arguments import add_sglang_arguments, collect_eval_sglang_overrides
 from miles.backends.sglang_utils.arguments import validate_args as sglang_validate_args
 from miles.dashboard.args import add_dashboard_arguments, validate_dashboard_args
 from miles.utils.chat_template_utils.tito_tokenizer import TITOTokenizerType
@@ -1127,7 +1127,9 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                     "Number of GPUs for a dedicated eval engine fleet. When > 0, eval runs on "
                     "its own engines behind its own router, synced by loading HF checkpoint "
                     "snapshots (never by joining training weight updates). 0 disables the "
-                    "fleet and keeps today's shared-engine eval behavior."
+                    "fleet and keeps today's shared-engine eval behavior. The fleet's engine "
+                    "settings inherit every --sglang-* value; override individually with "
+                    "--eval-sglang-* (e.g. --eval-sglang-mem-fraction-static 0.9)."
                 ),
             )
             parser.add_argument(
@@ -2784,6 +2786,12 @@ def miles_validate_args(args):
             )
         if args.eval_model_path is None:
             args.eval_model_path = args.hf_checkpoint
+    else:
+        overrides = collect_eval_sglang_overrides(args)
+        assert not overrides, (
+            f"--eval-sglang-* configures the dedicated eval fleet, which needs --eval-num-gpus > 0. "
+            f"Got {sorted(overrides)} with --eval-num-gpus 0."
+        )
 
     if args.save_interval is not None:
         assert args.save is not None, "'--save' is required when save_interval is set."

--- a/tests/fast/backends/sglang_utils/test_compute_server_args.py
+++ b/tests/fast/backends/sglang_utils/test_compute_server_args.py
@@ -21,6 +21,9 @@ def make_args(**overrides) -> SimpleNamespace:
         use_rollout_routing_replay=False,
         use_rollout_indexer_replay=False,
         fp16=False,
+        lora_adapter_path=None,
+        multi_lora_n_adapters=1,
+        target_modules=["linear_qkv"],
     )
     defaults.update(overrides)
     return SimpleNamespace(**defaults)
@@ -28,7 +31,14 @@ def make_args(**overrides) -> SimpleNamespace:
 
 def compute(args, **kwargs) -> dict:
     server_args, _ = _compute_server_args(
-        args, rank=0, dist_init_addr="127.0.0.1:1234", nccl_port=5000, host="127.0.0.1", port=30000, **kwargs
+        args,
+        rank=0,
+        dist_init_addr="127.0.0.1:1234",
+        nccl_port=5000,
+        host="127.0.0.1",
+        port=30000,
+        base_gpu_id=0,
+        **kwargs,
     )
     return server_args
 
@@ -39,21 +49,12 @@ class TestSglangOverridePrecedence:
     def test_override_wins_over_conditional_args_defaults(self):
         args = make_args(fp16=True, use_rollout_routing_replay=True, use_rollout_indexer_replay=True)
 
-        server_args = compute(
-            args,
-            sglang_overrides={
-                "dtype": "bfloat16",
-                "enable_return_routed_experts": False,
-                "enable_return_indexer_topk": False,
-            },
-        )
+        server_args = compute(args, sglang_overrides={"dtype": "bfloat16"})
 
         assert server_args["dtype"] == "bfloat16"
-        assert server_args["enable_return_routed_experts"] is False
-        assert server_args["enable_return_indexer_topk"] is False
 
     def test_override_wins_over_lora_defaults(self):
-        args = make_args(lora_rank=8, sglang_enable_lora=False)
+        args = make_args(lora_rank=8)
 
         server_args = compute(args, sglang_overrides={"enable_lora": False})
 
@@ -68,10 +69,10 @@ class TestSglangOverridePrecedence:
         assert server_args["mem_fraction_static"] == value
 
     def test_no_overrides_keeps_args_derived_values(self):
-        args = make_args(fp16=True, use_rollout_routing_replay=True)
+        args = make_args(fp16=True, lora_rank=8)
 
         server_args = compute(args)
 
         assert server_args["dtype"] == "float16"
-        assert server_args["enable_return_routed_experts"] is True
+        assert server_args["enable_lora"] is True
         assert server_args["mem_fraction_static"] == 0.7

--- a/tests/fast/backends/sglang_utils/test_compute_server_args.py
+++ b/tests/fast/backends/sglang_utils/test_compute_server_args.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from miles.backends.sglang_utils.sglang_engine import _compute_server_args
+
+
+def make_args(**overrides) -> SimpleNamespace:
+    defaults = dict(
+        hf_checkpoint="/fake/model",
+        seed=0,
+        num_gpus_per_node=8,
+        rollout_num_gpus_per_engine=1,
+        offload_rollout=False,
+        sglang_dp_size=1,
+        sglang_pp_size=1,
+        sglang_ep_size=1,
+        sglang_mem_fraction_static=0.7,
+        use_rollout_routing_replay=False,
+        use_rollout_indexer_replay=False,
+        fp16=False,
+    )
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def compute(args, **kwargs) -> dict:
+    server_args, _ = _compute_server_args(
+        args, rank=0, dist_init_addr="127.0.0.1:1234", nccl_port=5000, host="127.0.0.1", port=30000, **kwargs
+    )
+    return server_args
+
+
+class TestSglangOverridePrecedence:
+    """An override must win over every args-derived default, including the conditional ones."""
+
+    def test_override_wins_over_conditional_args_defaults(self):
+        args = make_args(fp16=True, use_rollout_routing_replay=True, use_rollout_indexer_replay=True)
+
+        server_args = compute(
+            args,
+            sglang_overrides={
+                "dtype": "bfloat16",
+                "enable_return_routed_experts": False,
+                "enable_return_indexer_topk": False,
+            },
+        )
+
+        assert server_args["dtype"] == "bfloat16"
+        assert server_args["enable_return_routed_experts"] is False
+        assert server_args["enable_return_indexer_topk"] is False
+
+    def test_override_wins_over_lora_defaults(self):
+        args = make_args(lora_rank=8, sglang_enable_lora=False)
+
+        server_args = compute(args, sglang_overrides={"enable_lora": False})
+
+        assert server_args["enable_lora"] is False
+
+    @pytest.mark.parametrize("value", [0.5, 0.95])
+    def test_override_wins_over_base_sglang_args(self, value):
+        args = make_args(sglang_mem_fraction_static=0.7)
+
+        server_args = compute(args, sglang_overrides={"mem_fraction_static": value})
+
+        assert server_args["mem_fraction_static"] == value
+
+    def test_no_overrides_keeps_args_derived_values(self):
+        args = make_args(fp16=True, use_rollout_routing_replay=True)
+
+        server_args = compute(args)
+
+        assert server_args["dtype"] == "float16"
+        assert server_args["enable_return_routed_experts"] is True
+        assert server_args["mem_fraction_static"] == 0.7

--- a/tests/fast/ray/rollout/conftest.py
+++ b/tests/fast/ray/rollout/conftest.py
@@ -33,6 +33,7 @@ def make_args(**overrides: Any) -> Namespace:
         rollout_num_gpus_per_engine=1,
         eval_num_gpus=0,
         eval_num_gpus_per_engine=1,
+        eval_model_path=None,
         num_gpus_per_node=8,
         rollout_batch_size=8,
         n_samples_per_prompt=4,

--- a/tests/fast/ray/rollout/test_rollout_server.py
+++ b/tests/fast/ray/rollout/test_rollout_server.py
@@ -26,6 +26,84 @@ class TestRolloutServerPureFunctions:
         with pytest.raises(AssertionError, match="total GPUs"):
             _resolve_sglang_config(args)
 
+    def test_eval_fleet_inherits_rollout_engine_settings(self):
+        """The eval model carries only what makes it an eval fleet; the rest is inherited."""
+        args = make_args(eval_num_gpus=2, eval_num_gpus_per_engine=2, eval_model_path="/fake/eval-model")
+        config = _resolve_sglang_config(args)
+
+        [eval_model] = [m for m in config.models if m.name == "eval"]
+        assert eval_model.model_path == "/fake/eval-model"
+        assert eval_model.update_weights is False
+        [group] = eval_model.server_groups
+        assert (group.num_gpus, group.num_gpus_per_engine) == (2, 2)
+        # Eval samples never feed training, so the replay side-channels are forced off.
+        assert group.overrides == {"enable_return_routed_experts": False, "enable_return_indexer_topk": False}
+
+    def test_eval_sglang_overrides_reach_the_eval_group_only(self):
+        args = make_args(eval_num_gpus=2, eval_sglang_mem_fraction_static=0.95)
+        config = _resolve_sglang_config(args)
+
+        by_name = {m.name: m for m in config.models}
+        assert by_name["eval"].server_groups[0].overrides["mem_fraction_static"] == 0.95
+        assert by_name["default"].server_groups[0].overrides == {}
+
+    def test_yaml_eval_model_is_filled_from_cli_without_clobbering(self, tmp_path):
+        """Anything the YAML leaves unset falls through to the eval CLI args."""
+        cfg_path = tmp_path / "cfg.yaml"
+        cfg_path.write_text(
+            "sglang:\n"
+            "  - name: default\n"
+            "    server_groups:\n"
+            "      - worker_type: regular\n"
+            "        num_gpus: 8\n"
+            "        num_gpus_per_engine: 1\n"
+            "  - name: eval\n"
+            "    server_groups:\n"
+            "      - worker_type: regular\n"
+            "        num_gpus: 2\n"
+        )
+        args = make_args(
+            sglang_config=str(cfg_path),
+            rollout_num_gpus=8,
+            eval_num_gpus=2,
+            eval_num_gpus_per_engine=2,
+            eval_model_path="/fake/eval-model",
+            eval_sglang_mem_fraction_static=0.95,
+        )
+        config = _resolve_sglang_config(args)
+
+        [eval_model] = [m for m in config.models if m.name == "eval"]
+        assert eval_model.model_path == "/fake/eval-model"
+        # Auto-inference would give True here and put the fleet in the broadcast group.
+        assert eval_model.update_weights is False
+        [group] = eval_model.server_groups
+        assert group.num_gpus_per_engine == 2
+        assert group.overrides["mem_fraction_static"] == 0.95
+
+    def test_yaml_group_overrides_win_over_eval_cli(self, tmp_path):
+        cfg_path = tmp_path / "cfg.yaml"
+        cfg_path.write_text(
+            "sglang:\n"
+            "  - name: default\n"
+            "    server_groups:\n"
+            "      - worker_type: regular\n"
+            "        num_gpus: 8\n"
+            "  - name: eval\n"
+            "    server_groups:\n"
+            "      - worker_type: regular\n"
+            "        num_gpus: 2\n"
+            "        num_gpus_per_engine: 1\n"
+            "        overrides:\n"
+            "          mem_fraction_static: 0.5\n"
+        )
+        args = make_args(
+            sglang_config=str(cfg_path), rollout_num_gpus=8, eval_num_gpus=2, eval_sglang_mem_fraction_static=0.95
+        )
+        config = _resolve_sglang_config(args)
+
+        [eval_model] = [m for m in config.models if m.name == "eval"]
+        assert eval_model.server_groups[0].overrides["mem_fraction_static"] == 0.5
+
     def test_compute_rollout_offset_colocate_returns_zero(self):
         args = make_args(
             colocate=True,

--- a/tests/fast/utils/test_arguments.py
+++ b/tests/fast/utils/test_arguments.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 
 import pytest
 
-from miles.backends.sglang_utils.arguments import add_sglang_arguments
+from miles.backends.sglang_utils.arguments import add_sglang_arguments, collect_eval_sglang_overrides
 from miles.backends.sglang_utils.arguments import validate_args as validate_sglang_args
 from miles.utils.arguments import (
     _maybe_apply_dumper_overrides,
@@ -180,6 +180,41 @@ def test_sglang_parallel_sizes_keep_server_args_destinations():
     assert args.sglang_pp_size == 3
     assert args.sglang_ep_size == 4
     assert args.sglang_attn_cp_size == 5
+
+
+class TestEvalSglangOverrides:
+    """Unset means "inherit --sglang-*", so an unset flag must leave no attribute at all."""
+
+    def _parse(self, argv):
+        return add_sglang_arguments(argparse.ArgumentParser()).parse_args(argv)
+
+    def test_unset_flags_produce_no_overrides(self):
+        args = self._parse(["--sglang-mem-fraction-static", "0.7"])
+
+        assert collect_eval_sglang_overrides(args) == {}
+        assert not hasattr(args, "eval_sglang_mem_fraction_static")
+
+    def test_set_flag_becomes_an_override_without_touching_the_base_family(self):
+        args = self._parse(["--sglang-mem-fraction-static", "0.7", "--eval-sglang-mem-fraction-static", "0.9"])
+
+        assert collect_eval_sglang_overrides(args) == {"mem_fraction_static": 0.9}
+        assert args.sglang_mem_fraction_static == 0.7
+
+    def test_boolean_can_be_turned_back_off(self):
+        args = self._parse(["--sglang-enable-dp-attention", "--no-eval-sglang-enable-dp-attention"])
+
+        assert args.sglang_enable_dp_attention is True
+        assert collect_eval_sglang_overrides(args) == {"enable_dp_attention": False}
+
+    def test_parallel_sizes_keep_server_args_destinations(self):
+        args = self._parse(["--eval-sglang-data-parallel-size", "2", "--eval-sglang-expert-parallel-size", "4"])
+
+        assert collect_eval_sglang_overrides(args) == {"dp_size": 2, "ep_size": 4}
+
+    def test_tp_size_is_not_exposed(self):
+        """A second TP knob could move tp_size off the bundles --eval-num-gpus-per-engine placed."""
+        with pytest.raises(SystemExit):
+            self._parse(["--eval-sglang-tp-size", "2"])
 
 
 def test_custom_megatron_post_save_hook_path_is_parsed():


### PR DESCRIPTION
Stacked on #1740 (base is `zhichen/fully-async-eval` @ fc2a4bf) — merge into that branch, not `main`.

## Motivation

The eval fleet's engine config today is 4 hardcoded fields plus whatever the rollout engines happen to be set to, with no way to differ:

- **No `--eval-sglang-*` channel.** `_compute_server_args` fills every `ServerArgs` field from `args.sglang_<name>`, so `mem_fraction_static`, `attention_backend`, `context_length`, `cuda_graph_max_bs`, `dp/pp/ep` are all whatever rollout uses. An eval fleet that owns its GPUs usually wants a different `mem_fraction_static` at minimum.
- **The `--sglang-config` YAML branch returns early**, silently dropping `--eval-model-path` and `--eval-num-gpus-per-engine`. The second one is not cosmetic: `FleetEvalFn._fleet_args()` and `init_http_client` both size their concurrency off `args.eval_num_gpus_per_engine`, so under YAML the client-side semaphore and connection pool are computed for an engine count the engines don't have.
- **`update_weights` is not forced off** in the YAML branch. A `name: eval` model whose `model_path` equals `hf_checkpoint` (the common case) auto-infers `update_weights=True`, and `_get_updatable_server()` then raises `Multiple servers have update_weights=True` at the first weight update — after the fleet has already booted.

## Design

Inheritance by default, per-field override — the same shape `--eval-temperature` / `--eval-top-p` already use.

The `--sglang-*` family is not hand-written: `add_sglang_arguments` wraps `parser.add_argument` and calls `ServerArgs.add_cli_args(parser)`. That wrapper is now parameterized by prefix and called twice, so `--eval-sglang-*` costs a parameter rather than ~350 hand-written flags.

Two details make the inheritance semantics work:

- **`default=argparse.SUPPRESS`** on the eval family. `ServerArgs.add_cli_args` gives every field a real default, so a mirrored family with defaults could not tell "user asked for this" from "argparse filled in SGLang's default" — every field would read as overridden. With SUPPRESS an unset flag leaves no attribute at all, and `collect_eval_sglang_overrides(args)` is one dict comprehension over what's present.
- **`BooleanOptionalAction`** for `store_true` fields. A plain `store_true` can only ever turn something on; an override family also has to turn off what the base family enabled (`--no-eval-sglang-enable-dp-attention`).

`tp_size` stays out of the family: it comes from `--eval-num-gpus-per-engine`, which also places the engines, so a second independent knob could move `tp_size` off its bundles.

### The overrides channel had to be fixed first

The overrides ride the existing `ServerGroupConfig.overrides`, but that channel was merged too early in `_compute_server_args` — every later args-derived branch (`fp16` → `dtype`, routing/indexer replay, LoRA, disaggregation) overwrote it. The merge moves to last, so an override always wins. This also fixes YAML per-group `overrides`, which lost the same races today: `overrides: {dtype: bfloat16}` was silently beaten by `--fp16`.

### One precedence order

Both config branches now go through `_apply_eval_model_config`, giving **YAML > `--eval-sglang-*` > inherited `--sglang-*`**. A hand-written `name: eval` model composes with the CLI instead of silently replacing it, and `update_weights` is forced to `False` wherever the YAML leaves it unset.

Eval defaults that are deliberately *not* "same as rollout": the routing / indexer replay side-channels are forced off, since eval samples never feed training. (`enable_memory_saver` needs nothing — the existing `needs_offload` logic in `start_rollout_servers` already sets it `False` for groups outside the megatron GPU range, which is where the eval fleet lands. LoRA is left alone deliberately: arguably it should be off for a merged-snapshot fleet, but that is a separate semantic call and `--no-eval-sglang-enable-lora` is now available.)

## Usage

```bash
--eval-num-gpus 2
--eval-sglang-mem-fraction-static 0.9      # eval fleet is not sharing with training
--no-eval-sglang-enable-dp-attention       # turn off something rollout enabled
```

Anything not passed stays identical to the rollout engines.

## Verification

- `pre-commit run --files <changed>` green.
- New fast tests: `TestEvalSglangOverrides` (arg family semantics), `TestSglangOverridePrecedence` (`_compute_server_args` merge order), and 4 cases in `test_rollout_server.py` covering both config branches.
- No sglang in the authoring environment, so the code paths were additionally driven end-to-end against a stubbed `ServerArgs`: 15/15 on the arg family (unset leaves no attribute, set produces an override without touching the base family, booleans turn back off, `dest` pinning survives the prefix, `--eval-sglang-tp-size` rejected) and 16/16 on `_resolve_sglang_config` (both branches' precedence, `update_weights` forced off, override lands on the eval group only). **The pytest files themselves still need a run in a container with sglang installed.**
- Confirmed by AST over `sglang/srt/server_args.py` that `add_cli_args` is 357 `parser.add_argument` calls with zero `add_argument_group`, so registering it twice through the wrapper cannot produce an option-string conflict.

Side effect: `--help` grows by ~350 `--eval-sglang-*` entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)