### PR TITLE
Reject --disable-weights-backuper for LoRA + colocate + offload-train

### DIFF
--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -2935,6 +2935,14 @@ def miles_validate_args(args):
         args.disable_grad_buffers_cpu_backup = True
         args.disable_param_buffers_cpu_backup = args.enable_weights_backuper
 
+    # patch_param_grad_buffer_for_colocate_mode_lora() forces disable_param_buffers_cpu_backup
+    # on regardless of the line above, so without the backuper there is no host copy at all and
+    # named_params_and_buffers() hands update_weights the live, paused GPU tensors. That reads
+    # unmapped memory instead of failing, so the symptom is a 30-minute gloo barrier timeout.
+    assert not (
+        not args.enable_weights_backuper and args.offload_train and args.colocate and is_lora_enabled(args)
+    ), "--disable-weights-backuper is not supported with LoRA + --colocate + --offload-train"
+
     if args.offload_train_target == "disk":
         assert args.offload_train, "--offload-train-target=disk requires --offload-train"
         assert (


### PR DESCRIPTION
## Summary

- Reject `--disable-weights-backuper` when LoRA + `--colocate` + `--offload-train` are combined, at argument-validation time.
- A clear assertion converts a very expensive debugging session into an immediate, actionable message.

## Failure mechanism

`patch_param_grad_buffer_for_colocate_mode_lora()` force-enables `disable_param_buffers_cpu_backup` regardless of what `miles_validate_args` decided. With `--disable-weights-backuper` on top of that, a run fails like this:

1. The training model has been "paused" — its GPU memory was released to make room for the rollout engine — and, because the backuper is off and the LoRA patch force-disables the CPU parameter backup, no copy of the base weights exists anywhere.
2. When weight sync starts, a rank tries to read those released GPU tensors (`named_params_and_buffers()` hands `update_weights` the live tensors of the paused model). This read doesn't raise an error — it just silently hangs.
3. That stuck rank never reaches the next gloo barrier. All the other ranks sit at the barrier, patiently waiting for it.
4. After 30 minutes, the barrier gives up and throws a timeout error — which blames the barrier and says nothing about the flag combination that caused it.

## Test plan

- [x] Hit the original failure mode (30-minute barrier timeout) on a 4-node GLM-5.2 LoRA colocate run with `--disable-weights-backuper`; same launch with the backuper enabled syncs weights in ~12s per update.
- [x] Verified the assertion fires for the LoRA + colocate + offload-train + no-backuper combination and stays silent for all other combinations (non-LoRA runs, LoRA with backuper, LoRA without offload).
