### PR TITLE
Skip optimizer step for adapter slots with non-finite grad norm

### DIFF
--- a/miles/backends/megatron_utils/multi_lora_optimizer.py
+++ b/miles/backends/megatron_utils/multi_lora_optimizer.py
@@ -15,25 +15,32 @@ from megatron.core.optimizer.optimizer import MegatronOptimizer
 from megatron.core.optimizer.optimizer_config import OptimizerConfig
 from megatron.core.process_groups_config import ProcessGroupCollection
 
+from miles.backends.megatron_utils.misc_utils import report_nonfinite_grads
+
 logger = logging.getLogger(__name__)
+
+
+def adapter_slot_named_parameters(model, slot: int) -> list[tuple[str, torch.nn.Parameter]]:
+    """One adapter slot's parameters with their qualified names, across model chunks."""
+    from megatron.bridge.peft.multi_lora_layers import MultiLoRALinear
+
+    named_parameters = []
+    seen = set()
+    model_chunks = model if isinstance(model, (list, tuple)) else [model]
+    for model_chunk in model_chunks:
+        for module_name, module in model_chunk.named_modules():
+            if not isinstance(module, MultiLoRALinear):
+                continue
+            for param_name, param in module.adapters[slot].named_parameters():
+                if id(param) not in seen:
+                    named_parameters.append((f"{module_name}.{param_name}", param))
+                    seen.add(id(param))
+    return named_parameters
 
 
 def adapter_slot_parameters(model, slot: int) -> list[torch.nn.Parameter]:
     """All parameters belonging to one adapter slot, across model chunks."""
-    from megatron.bridge.peft.multi_lora_layers import MultiLoRALinear
-
-    parameters = []
-    seen = set()
-    model_chunks = model if isinstance(model, (list, tuple)) else [model]
-    for model_chunk in model_chunks:
-        for module in model_chunk.modules():
-            if not isinstance(module, MultiLoRALinear):
-                continue
-            for param in module.adapters[slot].parameters():
-                if id(param) not in seen:
-                    parameters.append(param)
-                    seen.add(id(param))
-    return parameters
+    return [param for _, param in adapter_slot_named_parameters(model, slot)]
 
 
 def _adam_init_state_fn(opt, config=None):
@@ -155,35 +162,6 @@ def zero_adapter_slot_grads(model, slot: int) -> None:
             main_param.grad = None
 
 
-def report_nonfinite_adapter_grads(model, slot: int, limit: int = 12) -> None:
-    """Name the adapter tensors behind a non-finite slot norm.
-
-    Worth the walk: clipping scales every grad by ``clip/(norm + eps)``, so one NaN grad
-    turns the whole adapter to NaN in ``step_with_ready_grads`` with no other symptom.
-    """
-    from megatron.bridge.peft.multi_lora_layers import MultiLoRALinear
-
-    bad: list[str] = []
-    total = 0
-    for model_chunk in model if isinstance(model, (list, tuple)) else [model]:
-        for module_name, module in model_chunk.named_modules():
-            if not isinstance(module, MultiLoRALinear):
-                continue
-            for param_name, param in module.adapters[slot].named_parameters():
-                grad = getattr(param, "main_grad", None)
-                if grad is None:
-                    grad = param.grad
-                if grad is None:
-                    continue
-                total += 1
-                if not torch.isfinite(grad).all():
-                    bad.append(f"{module_name}.{param_name}")
-    logger.error(
-        f"[multi-LoRA] slot {slot} grad norm is non-finite: {len(bad)}/{total} adapter grads "
-        f"are non-finite; first {limit}: {bad[:limit]}"
-    )
-
-
 def step_adapter_slots(
     optimizer,
     model,
@@ -216,7 +194,10 @@ def step_adapter_slots(
         # clipping scales by clip/(nan + eps) and step_with_ready_grads writes NaN into every
         # tensor of the slot, so one bad microbatch permanently destroys the adapter.
         if not math.isfinite(grad_norms[slot]):
-            report_nonfinite_adapter_grads(model, slot)
+            report_nonfinite_grads(
+                adapter_slot_named_parameters(model, slot),
+                header=f"[multi-LoRA] slot {slot} grad norm is non-finite",
+            )
             zero_adapter_slot_grads(model, slot)
             continue
 

--- a/miles/backends/megatron_utils/multi_lora_optimizer.py
+++ b/miles/backends/megatron_utils/multi_lora_optimizer.py
@@ -2,6 +2,7 @@
 requires plain DDP all-reduce (use_distributed_optimizer OFF) so cross-batch gradient retention stays idempotent."""
 
 import logging
+import math
 from argparse import Namespace
 from collections.abc import Sequence
 from contextlib import contextmanager
@@ -154,6 +155,35 @@ def zero_adapter_slot_grads(model, slot: int) -> None:
             main_param.grad = None
 
 
+def report_nonfinite_adapter_grads(model, slot: int, limit: int = 12) -> None:
+    """Name the adapter tensors behind a non-finite slot norm.
+
+    Worth the walk: clipping scales every grad by ``clip/(norm + eps)``, so one NaN grad
+    turns the whole adapter to NaN in ``step_with_ready_grads`` with no other symptom.
+    """
+    from megatron.bridge.peft.multi_lora_layers import MultiLoRALinear
+
+    bad: list[str] = []
+    total = 0
+    for model_chunk in model if isinstance(model, (list, tuple)) else [model]:
+        for module_name, module in model_chunk.named_modules():
+            if not isinstance(module, MultiLoRALinear):
+                continue
+            for param_name, param in module.adapters[slot].named_parameters():
+                grad = getattr(param, "main_grad", None)
+                if grad is None:
+                    grad = param.grad
+                if grad is None:
+                    continue
+                total += 1
+                if not torch.isfinite(grad).all():
+                    bad.append(f"{module_name}.{param_name}")
+    logger.error(
+        f"[multi-LoRA] slot {slot} grad norm is non-finite: {len(bad)}/{total} adapter grads "
+        f"are non-finite; first {limit}: {bad[:limit]}"
+    )
+
+
 def step_adapter_slots(
     optimizer,
     model,
@@ -180,9 +210,18 @@ def step_adapter_slots(
             grads_for_norm += child.get_main_grads_for_grad_norm()
             slot_params += child.get_parameters()
         slot_norm = get_grad_norm_fp32(grads_for_norm, grad_stats_parallel_group=None)
+        grad_norms[slot] = float(slot_norm)
+
+        # Megatron's found_inf gate, which the multi-LoRA path otherwise bypasses. Without it
+        # clipping scales by clip/(nan + eps) and step_with_ready_grads writes NaN into every
+        # tensor of the slot, so one bad microbatch permanently destroys the adapter.
+        if not math.isfinite(grad_norms[slot]):
+            report_nonfinite_adapter_grads(model, slot)
+            zero_adapter_slot_grads(model, slot)
+            continue
+
         if clip_grad > 0.0 and slot_params:
             clip_grad_by_total_norm_fp32(slot_params, clip_grad, slot_norm, False)
-        grad_norms[slot] = float(slot_norm)
 
         for child in children:
             child.step_with_ready_grads()


### PR DESCRIPTION
## Summary

- `step_adapter_slots()` now checks the per-slot grad norm for finiteness before clipping, mirroring the `found_inf` gate that Megatron's regular optimizer step applies but the multi-LoRA chained path bypasses.
- Why: with the gate missing, one non-finite microbatch is unrecoverable — `clip_grad_by_total_norm_fp32` scales every grad by `clip/(nan + eps)` and `step_with_ready_grads` then writes NaN into every tensor of the slot, permanently destroying that adapter while the loss stays finite. The only symptom is `train/grad_norm = nan` on that step.
- On a non-finite norm the slot's step is skipped: the offending adapter tensors are named in an error log (the shared `misc_utils.report_nonfinite_grads`, fed by a new `adapter_slot_named_parameters` helper), the slot's accumulated grads are zeroed, and training continues. The norm is still recorded so the skip is visible in metrics.

Stacked on #2198, which introduces the shared `report_nonfinite_grads` reporter this PR reuses; the base is `shi/report-nonfinite-grads` and retargets to `main` automatically once #2198 merges.

## Test plan

- [x] Exercised on a 4-node GLM-5.2 LoRA agentic run: with an upstream kernel bug producing NaN grads, the ungated path bricked the adapter (all-NaN weights); with the gate the step is skipped, the log names the non-finite adapter tensors, and subsequent steps proceed with finite norms.
- [x] Normal path unchanged: same run after the kernel fix shows identical behavior to main (finite norms, clipping applied, adapters step every batch).
