### PR TITLE
Fix padded -1 index handling in GLM-5 sparse-MLA tilelang kernels

### DIFF
--- a/miles_plugins/models/glm5/ops/tilelang_sparse_mla_bwd.py
+++ b/miles_plugins/models/glm5/ops/tilelang_sparse_mla_bwd.py
@@ -148,6 +148,7 @@ def bwd(
             KV_tail_shared = T.alloc_shared([BS, D_tail], dtype)
             dO_shared = T.alloc_shared([block_H, D], dtype)
             mask = T.alloc_fragment([BS], "bool")
+            kv_i = T.alloc_fragment([BS], indices_dtype)
 
             P_shared_cast = T.alloc_shared([block_H, BS], dtype)
             dP_shared_cast = T.alloc_shared([block_H, BS], dtype)
@@ -178,6 +179,13 @@ def bwd(
                 for bi_i in T.Parallel(BS):
                     # Changed here for thd
                     mask[bi_i] = Indices[by, s_i, bz // NH, i_i * BS + bi_i] != -1
+                # A padded slot holds -1, which addresses the element *before* the tensor. The
+                # forward absorbs whatever it reads into an -inf score, but here the same bytes
+                # also reach acc_dp through dO @ KV, and acc_dp is then multiplied by an exactly
+                # zero acc_p -- so one overflowing garbage dot product is 0 * inf = NaN. Clamp
+                # the gather in range and substitute a true zero key instead.
+                for bi_i in T.Parallel(BS):
+                    kv_i[bi_i] = T.max(Indices[by, s_i, bz // NH, i_i * BS + bi_i], 0)
 
                 # Compute attention scores
                 for h_i, bi_i in T.Parallel(block_H, BS):
@@ -185,12 +193,14 @@ def bwd(
 
                 # Load KV, V for this block of indices
                 for bi_i, d_i in T.Parallel(BS, D):
-                    KV_shared[bi_i, d_i] = KV[by, Indices[by, s_i, bz // NH, i_i * BS + bi_i], bz // NH, d_i]
+                    KV_shared[bi_i, d_i] = T.if_then_else(mask[bi_i], KV[by, kv_i[bi_i], bz // NH, d_i], 0)
 
                 T.gemm(Q_shared, KV_shared, acc_p, transpose_B=True, policy=T.GemmWarpPolicy.FullCol)
 
                 for bi_i, d_i in T.Parallel(BS, D_tail):
-                    KV_tail_shared[bi_i, d_i] = KV[by, Indices[by, s_i, bz // NH, i_i * BS + bi_i], bz // NH, D + d_i]
+                    KV_tail_shared[bi_i, d_i] = T.if_then_else(
+                        mask[bi_i], KV[by, kv_i[bi_i], bz // NH, D + d_i], 0
+                    )
                 T.gemm(Q_tail_shared, KV_tail_shared, acc_p, transpose_B=True, policy=T.GemmWarpPolicy.FullCol)
 
                 for h_i, bi_i in T.Parallel(block_H, BS):
@@ -235,26 +245,19 @@ def bwd(
                         if bi_i < BS // split_store:
                             acc_dkv_tail_shared[bi_i, d_i] = acc_dkv_tail[bi_i + s * (BS // split_store), d_i]
 
+                    # Padded slots contribute an exact zero here (their P and dP columns are
+                    # zero), so the clamped address makes the atomic a no-op rather than an
+                    # out-of-bounds write into whatever allocation precedes dKV.
                     for bi_i, d_i in T.Parallel(BS // split_store, D // 4):
                         T.atomic_addx4(
-                            dKV[
-                                by,
-                                Indices[by, s_i, bz // NH, i_i * BS + bi_i + s * (BS // split_store)],
-                                bz // NH,
-                                d_i * 4,
-                            ],
+                            dKV[by, kv_i[bi_i + s * (BS // split_store)], bz // NH, d_i * 4],
                             acc_dkv_shared[bi_i, d_i * 4],
                         )
 
                     # Atomically update dKV, dKV_tail tensors
                     for bi_i, d_i in T.Parallel(BS // split_store, D_tail // 4):
                         T.atomic_addx4(
-                            dKV[
-                                by,
-                                Indices[by, s_i, bz // NH, i_i * BS + bi_i + s * (BS // split_store)],
-                                bz // NH,
-                                D + d_i * 4,
-                            ],
+                            dKV[by, kv_i[bi_i + s * (BS // split_store)], bz // NH, D + d_i * 4],
                             acc_dkv_tail_shared[bi_i, d_i * 4],
                         )
 

--- a/miles_plugins/models/glm5/ops/tilelang_sparse_mla_bwd.py
+++ b/miles_plugins/models/glm5/ops/tilelang_sparse_mla_bwd.py
@@ -198,9 +198,7 @@ def bwd(
                 T.gemm(Q_shared, KV_shared, acc_p, transpose_B=True, policy=T.GemmWarpPolicy.FullCol)
 
                 for bi_i, d_i in T.Parallel(BS, D_tail):
-                    KV_tail_shared[bi_i, d_i] = T.if_then_else(
-                        mask[bi_i], KV[by, kv_i[bi_i], bz // NH, D + d_i], 0
-                    )
+                    KV_tail_shared[bi_i, d_i] = T.if_then_else(mask[bi_i], KV[by, kv_i[bi_i], bz // NH, D + d_i], 0)
                 T.gemm(Q_tail_shared, KV_tail_shared, acc_p, transpose_B=True, policy=T.GemmWarpPolicy.FullCol)
 
                 for h_i, bi_i in T.Parallel(block_H, BS):

--- a/miles_plugins/models/glm5/ops/tilelang_sparse_mla_fwd.py
+++ b/miles_plugins/models/glm5/ops/tilelang_sparse_mla_fwd.py
@@ -89,6 +89,7 @@ def sparse_mla_fwd(
             O_shared = T.alloc_shared([H_per_block, D], dtype)
             Lse_shared = T.alloc_shared([H_per_block], accum_dtype)
             mask = T.alloc_fragment([BI], "bool")
+            kv_i = T.alloc_fragment([BI], indices_dtype)
 
             acc_o = T.alloc_fragment([H_per_block, D], accum_dtype)
             acc_s = T.alloc_fragment([H_per_block, BI], accum_dtype)
@@ -118,11 +119,17 @@ def sparse_mla_fwd(
                 for bi_i in T.Parallel(BI):
                     # Changed here for thd
                     mask[bi_i] = Indices[b_i, s_i, g_i, i_i * BI + bi_i] != -1
+                # -1 addresses the element before the tensor, so a padded slot loads whatever
+                # bytes precede KV. Those bytes are then multiplied by an exactly zero
+                # attention weight in the acc_o gemm, and 0 * inf is NaN. Clamp in range and
+                # substitute a true zero key.
+                for bi_i in T.Parallel(BI):
+                    kv_i[bi_i] = T.max(Indices[b_i, s_i, g_i, i_i * BI + bi_i], 0)
 
                 for bi_i, d_i in T.Parallel(BI, D):
-                    KV_shared[bi_i, d_i] = KV[b_i, Indices[b_i, s_i, g_i, i_i * BI + bi_i], g_i, d_i]
+                    KV_shared[bi_i, d_i] = T.if_then_else(mask[bi_i], KV[b_i, kv_i[bi_i], g_i, d_i], 0)
                 for bi_i, d_i in T.Parallel(BI, D_tail):
-                    K_tail_shared[bi_i, d_i] = KV[b_i, Indices[b_i, s_i, g_i, i_i * BI + bi_i], g_i, D + d_i]
+                    K_tail_shared[bi_i, d_i] = T.if_then_else(mask[bi_i], KV[b_i, kv_i[bi_i], g_i, D + d_i], 0)
 
                 for h_i, bi_i in T.Parallel(H_per_block, BI):
                     acc_s[h_i, bi_i] = T.if_then_else(mask[bi_i], 0, -T.infinity(acc_s.dtype))
@@ -157,7 +164,13 @@ def sparse_mla_fwd(
                 T.copy(acc_s, S_shared)
                 T.gemm(S_shared, KV_shared, acc_o, policy=T.GemmWarpPolicy.FullRow)
 
-            # Rescale
+            # Rescale. A query row whose indices are all -1 has no valid key, so sumexp is 0 and
+            # both the divide and the log2 go non-finite -- out becomes 0/0 = NaN and Lse becomes
+            # -inf, which the backward then turns into exp2(-inf - -inf) = NaN. Any row with at
+            # least one valid key has sumexp >= 1 (the running-max term is exp2(0)), so flooring
+            # here is a no-op for real rows and makes an empty row contribute an exact zero.
+            for h_i in T.Parallel(H_per_block):
+                sumexp[h_i] = T.max(sumexp[h_i], 1e-30)
             for h_i, d_i in T.Parallel(H_per_block, D):
                 acc_o[h_i, d_i] /= sumexp[h_i]
             for h_i in T.Parallel(H_per_block):


### PR DESCRIPTION
## Summary

- Fixes two NaN sources in the GLM-5 sparse-MLA tilelang kernels (`miles_plugins/models/glm5/ops/`) that surface as `train/grad_norm = nan` next to a perfectly finite loss.
- **Padded `-1` indices read (and write) out of bounds.** Top-k index tensors pad unused slots with `-1`, which addresses the element *before* the KV tensor. In the forward the garbage bytes are absorbed into a `-inf` score, but whenever the garbage overflows, the product with an exactly-zero attention weight is `0 * inf = NaN`. The backward is worse on both sides: the same bytes reach `acc_dp` through `dO @ KV` (same `0 * inf` problem), and the `dKV` update aims an `atomic_addx4` at the out-of-bounds address, corrupting whatever allocation precedes `dKV`. Fix: clamp the gather index in range and substitute a true zero key on masked slots; padded slots then contribute an exact zero everywhere, so the clamped atomic becomes a harmless no-op on row 0.
- **All-padding rows divide 0/0.** A query row whose indices are all `-1` has `sumexp = 0`, so the output rescale returns `0/0 = NaN` and the LSE becomes `-inf`, which the backward turns into `exp2(-inf - -inf) = NaN`. Fix: floor `sumexp`. Any row with at least one valid key has `sumexp >= 1`, so the floor is exactly a no-op for real rows.
- Complementary to the shared-memory-merge miscompile addressed in #1571 — the two bugs are independent and both are needed for finite gradients. Note the copy of these kernels vendored in megatron-bridge needs the same treatment for launchers that build their layer spec from the bridge provider.

## Test plan

- [x] Standalone kernel harness at production shapes (H=8, topk=2048, ragged sequence lengths, `-1` padding including all-`-1` rows): before the fix, backward returns NaN dQ/dKV rows; after, forward and backward match an fp32 reference to 3e-3 and empty rows contribute exact zeros.
- [x] 4-node GLM-5.2 744B LoRA training run with these kernels: finite `train/grad_norm` on every step (previously NaN from step 0 whenever a batch contained padded rows).
