### PR TITLE
Megatron: add option to upcast policy logits after chunking in megatron backend

### DIFF
--- a/miles/backends/megatron_utils/model.py
+++ b/miles/backends/megatron_utils/model.py
@@ -319,6 +319,7 @@ def forward_only(
             labels=None,
             packed_seq_params=packed_seq_params,
             loss_mask=batch["full_loss_masks"],
+            **({"fp32_output": False} if args.upcast_logits_after_chunking else {}),
             **(filter_keys(batch, ["witness_ids"]) if args.enable_witness else {}),
             **(batch["multimodal_train_inputs"] if batch["multimodal_train_inputs"] is not None else {}),
         )
@@ -513,6 +514,9 @@ def train_one_step(
                 "loss_mask": batch["full_loss_masks"],
                 **(filter_keys(batch, ["witness_ids"]) if args.enable_witness else {}),
             }
+
+            if args.upcast_logits_after_chunking:
+                forward_kwargs["fp32_output"] = False
 
             if args.enable_mtp_training:
                 forward_kwargs["mtp_kwargs"] = {"mtp_labels": batch["tokens"]}

--- a/miles/backends/training_utils/loss_hub/logit_processors.py
+++ b/miles/backends/training_utils/loss_hub/logit_processors.py
@@ -19,15 +19,13 @@ def get_responses(
 ) -> Iterator[tuple[torch.Tensor, torch.Tensor]]:
     """Yield response-aligned `(logits_chunk, tokens_chunk)` pairs per sample.
 
-    After squeezing batch dimension and applying temperature scaling, this
-    function extracts the logits and tokens corresponding to response segments
-    for each sample. When context parallelism is disabled, it slices directly
-    from the concatenated sequence. With context parallelism enabled, it
-    handles split sequences across ranks.
+    After squeezing the batch dimension, this function extracts the logits and
+    tokens corresponding to response segments for each sample. Temperature
+    scaling is deferred when chunked upcasting is enabled.
 
     Args:
         logits: Model outputs with shape `[1, T, V]` (policy) or `[1, T, 1]`
-            (value). Must be float32.
+            (value). Must be a floating-point tensor.
         args: Configuration containing `rollout_temperature` for scaling.
         unconcat_tokens: List of token tensors (prompt+response) per sample.
         total_lengths: Total sequence lengths (prompt+response) per sample.
@@ -41,8 +39,9 @@ def get_responses(
     qkv_format = args.qkv_format
 
     if not args.true_on_policy_mode:
-        # FSDP hands native bf16 here (no full-vocab fp32 buffer); chunks are upcast to fp32 downstream
-        assert logits.dtype in (torch.float32, torch.bfloat16), f"{logits.dtype}"
+        # Mixed-precision backends can hand native logits here. Chunks are
+        # upcast to FP32 downstream.
+        assert logits.dtype in (torch.float32, torch.bfloat16, torch.float16), f"{logits.dtype}"
     assert len(logits.shape) == 3, f"{logits.shape}"
 
     if qkv_format == "thd":
@@ -52,7 +51,12 @@ def get_responses(
         assert max_seq_lens is not None
         logits = logits.view(-1, logits.size(-1))
 
-    if logits.size(-1) > 1 and args.rollout_temperature > 0 and args.rollout_temperature != 1.0:
+    if (
+        not getattr(args, "upcast_logits_after_chunking", False)
+        and logits.size(-1) > 1
+        and args.rollout_temperature > 0
+        and args.rollout_temperature != 1.0
+    ):
         logits = logits.div(args.rollout_temperature)
     if args.true_on_policy_mode:
         if getattr(args, "bf16", False):
@@ -149,7 +153,7 @@ def get_log_probs_and_entropy(
 
     Args:
         logits: Policy logits with shape `[1, T, V]`.
-        args: Configuration (temperature applied in `get_responses`).
+        args: Configuration controlling temperature scaling and chunking.
         unconcat_tokens: List of token tensors per sample.
         total_lengths: Total sequence lengths per sample.
         response_lengths: Response segment lengths per sample.
@@ -165,6 +169,7 @@ def get_log_probs_and_entropy(
     """
     assert non_loss_data
     parallel_state = get_parallel_state()
+    deferred_temperature = args.rollout_temperature if getattr(args, "upcast_logits_after_chunking", False) else 1.0
     log_probs_list = []
     entropy_list = []
     for logits_chunk, tokens_chunk in get_responses(
@@ -184,6 +189,7 @@ def get_log_probs_and_entropy(
             chunk_size=args.log_probs_chunk_size,
             true_on_policy=args.true_on_policy_mode,
             vocab_size=getattr(args, "vocab_size", None),
+            temperature=deferred_temperature,
         )
 
         log_probs_list.append(log_prob.squeeze(-1))

--- a/miles/backends/training_utils/loss_hub/math_utils.py
+++ b/miles/backends/training_utils/loss_hub/math_utils.py
@@ -941,6 +941,7 @@ def calculate_log_probs_and_entropy(
     chunk_size: int = -1,
     true_on_policy: bool = False,
     vocab_size: int | None = None,
+    temperature: float = 1.0,
 ):
     if true_on_policy:
         return _calculate_log_probs_and_entropy_true_on_policy(
@@ -950,6 +951,7 @@ def calculate_log_probs_and_entropy(
             with_entropy=with_entropy,
             entropy_requires_grad=entropy_requires_grad,
             vocab_size=vocab_size,
+            temperature=temperature,
         )
 
     logits = logits.contiguous()
@@ -957,11 +959,17 @@ def calculate_log_probs_and_entropy(
     # Force a copy for fp32 inputs, where the dtype conversion would otherwise alias logits.
     entropy = None
 
+    def prepare_logits(logits_chunk: torch.Tensor) -> torch.Tensor:
+        logits_chunk = logits_chunk.to(torch.float32, copy=True)
+        if temperature > 0 and temperature != 1.0:
+            logits_chunk.div_(temperature)
+        return logits_chunk
+
     def compute_entropy(logits_chunk: torch.Tensor) -> torch.Tensor:
         if entropy_requires_grad:
-            return compute_entropy_from_logits(logits_chunk.to(torch.float32, copy=True), tp_group)
+            return compute_entropy_from_logits(prepare_logits(logits_chunk), tp_group)
         with torch.no_grad():
-            return compute_entropy_from_logits(logits_chunk.detach().to(torch.float32, copy=True), tp_group)
+            return compute_entropy_from_logits(prepare_logits(logits_chunk.detach()), tp_group)
 
     if logits.size(0) != 0:
         if chunk_size > 0:
@@ -970,7 +978,7 @@ def calculate_log_probs_and_entropy(
             logits_chunks = logits.chunk(num_chunks, dim=0)
             log_probs = []
             for tokens_chunk, logits_chunk in zip(tokens_chunks, logits_chunks, strict=True):
-                log_prob = compute_log_probs(logits_chunk.to(torch.float32, copy=True), tokens_chunk, tp_group)
+                log_prob = compute_log_probs(prepare_logits(logits_chunk), tokens_chunk, tp_group)
                 log_probs.append(log_prob)
             log_prob = torch.cat(log_probs, dim=0)
             if with_entropy:
@@ -980,7 +988,7 @@ def calculate_log_probs_and_entropy(
                     entropys.append(entropy)
                 entropy = torch.cat(entropys, dim=0)
         else:
-            log_prob = compute_log_probs(logits.to(torch.float32, copy=True), tokens, tp_group)
+            log_prob = compute_log_probs(prepare_logits(logits), tokens, tp_group)
             if with_entropy:
                 entropy = compute_entropy(logits)
     else:
@@ -998,12 +1006,12 @@ def _calculate_log_probs_and_entropy_true_on_policy(
     with_entropy: bool = False,
     entropy_requires_grad: bool = True,
     vocab_size: int | None = None,
+    temperature: float = 1.0,
 ) -> tuple[torch.Tensor, torch.Tensor | None]:
     """True-on-policy log-prob and entropy computation matching SGLang's scoring contract.
 
     Args:
-        logits: Aligned local logits of shape ``[R, V_local]`` (already
-            response-sliced and temperature-scaled by ``get_responses``).
+        logits: Response-sliced local logits of shape ``[R, V_local]``.
         tokens: Target tokens of shape ``[R]``.
         tp_group: Tensor-parallel process group for vocab gather.
         with_entropy: If True, also compute entropy.
@@ -1011,6 +1019,7 @@ def _calculate_log_probs_and_entropy_true_on_policy(
             without attaching it to the autograd graph.
         vocab_size: Real tokenizer vocab size. If provided, padded logits are
             truncated after the full-vocab gather and before ``log_softmax``.
+        temperature: Temperature applied before the true-on-policy softmax.
 
     Returns:
         Tuple of ``(log_probs, entropy)`` where *log_probs* has shape ``[R]``
@@ -1020,6 +1029,9 @@ def _calculate_log_probs_and_entropy_true_on_policy(
         log_prob = logits.new_zeros((0,))
         entropy = logits.new_zeros((0,)) if with_entropy else None
         return log_prob, entropy
+
+    if temperature > 0 and temperature != 1.0:
+        logits = logits.float().div_(temperature).to(logits.dtype)
 
     full_logits = _gather_true_on_policy_full_logits(logits, tp_group, vocab_size=vocab_size)
     _maybe_dump_top_logprob_backward("full_logits", full_logits)

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -386,6 +386,11 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 "--log-probs-chunk-size", type=int, default=-1, help="Chunk size to compute log probs to save memory"
             )
             parser.add_argument(
+                "--upcast-logits-after-chunking",
+                action="store_true",
+                help="Keep Megatron outputs in the model's dtype and upcast them to FP32 after chunking for loss.",
+            )
+            parser.add_argument(
                 "--indep-dp",
                 action="store_true",
                 default=False,
@@ -2591,6 +2596,18 @@ def miles_validate_args(args):
     if args.recompute_logprobs_via_prefill:
         assert args.true_on_policy_mode, "--recompute-logprobs-via-prefill requires --true-on-policy-mode"
 
+    if args.upcast_logits_after_chunking:
+        option = "--upcast-logits-after-chunking"
+        if args.train_backend != "megatron":
+            raise ValueError(f"{option} is specific to the Megatron backend")
+        if not (args.fp16 or args.bf16):
+            raise ValueError(f"{option} requires FP16 or BF16")
+        if args.loss_type == "custom_loss":
+            raise ValueError(f"{option} does not support custom loss functions")
+        if args.entropy_coef != 0:
+            raise ValueError(
+                f"{option} is incompatible with differentiable entropy as it requires upcasting the full unchunked logits"
+            )
     if not args.use_session_server and args.tito_model != TITOTokenizerType.DEFAULT.value:
         raise ValueError(
             f"--tito-model={args.tito_model} requires --use-session-server; "

--- a/tests/fast/backends/megatron_utils/test_chunked_policy_logits.py
+++ b/tests/fast/backends/megatron_utils/test_chunked_policy_logits.py
@@ -1,0 +1,61 @@
+import pytest
+import torch
+
+from miles.backends.training_utils.loss_hub import math_utils
+
+
+def _compute_log_probs(
+    logits: torch.Tensor,
+    tokens: torch.Tensor,
+    process_group,
+) -> torch.Tensor:
+    del process_group
+    return torch.log_softmax(logits, dim=-1).gather(
+        dim=-1,
+        index=tokens.unsqueeze(-1),
+    )
+
+
+def _run_log_probs(
+    source: torch.Tensor,
+    tokens: torch.Tensor,
+    *,
+    upcast_before_chunking: bool,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    source = source.detach().clone().requires_grad_(True)
+    temperature = 0.8
+    logits = source.float().div(temperature) if upcast_before_chunking else source
+    log_probs, _ = math_utils.calculate_log_probs_and_entropy(
+        logits,
+        tokens,
+        tp_group=None,
+        chunk_size=7,
+        temperature=1.0 if upcast_before_chunking else temperature,
+    )
+    log_probs.sum().backward()
+    return log_probs.detach(), source.grad.detach()
+
+
+@pytest.mark.parametrize("source_dtype", [torch.bfloat16, torch.float16])
+def test_chunked_upcast_preserves_log_probs_and_gradients(
+    monkeypatch,
+    source_dtype: torch.dtype,
+) -> None:
+    monkeypatch.setattr(math_utils, "compute_log_probs", _compute_log_probs)
+    generator = torch.Generator().manual_seed(20260802)
+    source = torch.randn(19, 31, dtype=source_dtype, generator=generator)
+    tokens = torch.randint(0, 31, (19,), generator=generator)
+
+    baseline = _run_log_probs(
+        source,
+        tokens,
+        upcast_before_chunking=True,
+    )
+    candidate = _run_log_probs(
+        source,
+        tokens,
+        upcast_before_chunking=False,
+    )
+
+    assert torch.equal(baseline[0], candidate[0])
+    assert torch.equal(baseline[1], candidate[1])

--- a/tests/fast/utils/test_arguments.py
+++ b/tests/fast/utils/test_arguments.py
@@ -205,6 +205,25 @@ def test_custom_megatron_post_save_hook_path_requires_save():
         miles_validate_args(args)
 
 
+def test_upcast_logits_after_chunking_is_valid_for_megatron_bf16() -> None:
+    parser = argparse.ArgumentParser()
+    get_miles_extra_args_provider()(parser)
+    extra = [
+        "--upcast-logits-after-chunking",
+        "--rollout-temperature",
+        "0.8",
+        "--num-rollout",
+        "1",
+    ]
+    args = parser.parse_args(extra + REQUIRED_ARGS)
+    args.fp16 = False
+    args.bf16 = True
+
+    miles_validate_args(args)
+
+    assert args.upcast_logits_after_chunking is True
+
+
 class TestTitoFixedTemplateConfiguration:
     def _parse(self, extra):
         parser = argparse.ArgumentParser()


### PR DESCRIPTION
## Summary

  - Add `--upcast-logits-after-chunking` to keep Megatron policy logits in the model dtype until log-probability chunks are processed.
  - Defer FP32 conversion and temperature scaling to each chunk, reducing peak memory while preserving existing log-probabilities and gradients.

After enabling, I was able to run end-to-end training with Qwen3.6-27B with 120K context (TP4/PP4) on 2×8 H100 GPUs, with 1024 as the chunk size. Without deferred upcasting, 80K seemed the practical limit, with 90K OOMing precisely during FP32 logit conversion.

  ## Testing

  - Added BF16 and FP16 parity coverage for log-probabilities and gradients.
  - Passed the focused Miles test suite (76 tests).

This seems to be a large and pretty much free win (while converting the full tensor in one go should be marginally faster, I am not sure it would offset the benefits from the memory gains).

Let me know if you have any comments - and thanks for maintaining a great open-source project like Miles!