### PR TITLE
[tml] Inkling native LoRA support

### DIFF
--- a/docs/models/thinkingmachines/index.md
+++ b/docs/models/thinkingmachines/index.md
@@ -2,7 +2,7 @@
 title: Thinking Machines
 description: Miles recipes for Thinking Machines Lab models — Inkling (975 B), a multimodal MoE with short convolution, relative attention, and a shared-expert sink.
 ---
-Miles ships a native Megatron recipe for **Inkling**, Thinking Machines Lab's 975 B / 41 B-active multimodal mixture-of-experts model: local and global relative attention, the residual ShortConv, the shared-sink router and experts, and the image and audio encoders.
+Miles ships a native Megatron recipe for **Inkling**, Thinking Machines Lab's 975 B / 41 B-active multimodal mixture-of-experts model: local and global relative attention, the residual ShortConv, the shared-sink router and experts, and the image and audio encoders. The same backend drives both full-parameter and LoRA RL.
 
 ## Variants
 
@@ -22,4 +22,4 @@ python scripts/run_inkling.py train \
    --num-nodes 16 --num-gpus-per-node 4
 ```
 
-See the [Inkling](/models/thinkingmachines/inkling) page for the architecture summary, HF → Megatron conversion, validated parallelism layouts, training attention backends, and multimodal RL.
+See the [Inkling](/models/thinkingmachines/inkling) page for the architecture summary, HF → Megatron conversion, validated parallelism layouts, training attention backends, LoRA RL, and multimodal RL.

--- a/docs/models/thinkingmachines/inkling-small.md
+++ b/docs/models/thinkingmachines/inkling-small.md
@@ -5,7 +5,7 @@ description: Launch recipe for Inkling-Small (276 B), the compact sibling of Ink
 
 ## 1. Model Introduction
 
-[Inkling-Small](https://huggingface.co/thinkingmachines/Inkling-Small) is the compact member of Thinking Machines Lab's Inkling family: a 276 B-total / 12 B-active-parameter, 42-layer multimodal MoE (256 routed + 2 shared experts, top-6 sigmoid routing) that matches — and on some benchmarks exceeds — the flagship 975 B model (e.g. SWEBench Verified 80.2 vs 77.6) at a fraction of the deployment footprint. The architecture is the same as [Inkling](/models/thinkingmachines/inkling) — ShortConv, local/global relative attention, and the shared-expert-sink MoE — so everything on the Inkling page (architecture summary, attention backends, R3 routing replay, multimodal RL) applies unchanged. This page only covers what differs: the model registry entry and the validated small-cluster launch profile.
+[Inkling-Small](https://huggingface.co/thinkingmachines/Inkling-Small) is the compact member of Thinking Machines Lab's Inkling family: a 276 B-total / 12 B-active-parameter, 42-layer multimodal MoE (256 routed + 2 shared experts, top-6 sigmoid routing) that matches — and on some benchmarks exceeds — the flagship 975 B model (e.g. SWEBench Verified 80.2 vs 77.6) at a fraction of the deployment footprint. The architecture is the same as [Inkling](/models/thinkingmachines/inkling) — ShortConv, local/global relative attention, and the shared-expert-sink MoE — so everything on the Inkling page (architecture summary, attention backends, R3 routing replay, LoRA schema, multimodal RL) applies unchanged. This page only covers what differs: the model registry entry and the validated small-cluster launch profile.
 
 ## 2. Supported Variants
 
@@ -23,12 +23,20 @@ cd /root/miles
 # Full-parameter GRPO. 276 B fits with the CPU-offloaded optimizer -
 # no NVMe streaming needed (unlike the 975 B recipe).
 python scripts/run_inkling.py train \
-   --model-name Inkling-Small --task dapo_math \
+   --model-name Inkling-Small --train-mode full --task dapo_math \
    --num-nodes 4 --num-gpus-per-node 8 \
    --lr 5e-5 --rollout-batch-size 64 --global-batch-size 128 \
    --sglang-context-length 4096 --rollout-max-response-len 2048 \
    --extra-args "--offload-train-target cpu --sglang-mem-fraction-static 0.65 \
       --optimizer-cpu-offload --overlap-cpu-optimizer-d2h-h2d --use-precision-aware-optimizer"
+
+# LoRA GRPO (rank 32, all-linear), same cluster; adapter-only weight
+# sync swaps in ~4 s per rollout.
+python scripts/run_inkling.py train \
+   --model-name Inkling-Small --train-mode lora --task dapo_math \
+   --num-nodes 4 --num-gpus-per-node 8 \
+   --lr 2e-4 --rollout-batch-size 64 --global-batch-size 128 \
+   --sglang-context-length 4096 --rollout-max-response-len 2048
 ```
 
 The model definition lives in `scripts/models/inkling-small.sh` (`MODEL_ARGS_NUM_LAYERS` overrides the layer count for sliced smoke/parity checkpoints). HF → `torch_dist` conversion uses the same tool as Inkling with this recipe file — a single 8-GPU node (TP8 EP8) converts it in one pass.
@@ -39,4 +47,4 @@ The model definition lives in `scripts/models/inkling-small.sh` (`MODEL_ARGS_NUM
 |---|---|---|---|---|---|---|---|
 | H200 | 32 | 4 | on | 8 | 4 | 1 | `--decoder-last-pipeline-num-layers 7` (42 = 7×5 + 7) |
 
-Batch shape is configurable from the launcher (`--rollout-batch-size`, `--global-batch-size`; defaults 32/64). The validated Small runs used 64/128 with `--lr 5e-5`, producing a steadily rising dapo-math reward curve.
+Batch shape is configurable from the launcher (`--rollout-batch-size`, `--global-batch-size`; defaults 32/64). The validated Small runs used 64/128: full with `--lr 5e-5`, LoRA with `--lr 2e-4` — both produce a steadily rising dapo-math reward curve. At the launcher's conservative LoRA default (5e-6) the zero-initialised B factors take hundreds of rollouts to accumulate a visible delta-W, which reads as "not learning".

--- a/docs/models/thinkingmachines/inkling.md
+++ b/docs/models/thinkingmachines/inkling.md
@@ -7,7 +7,7 @@ The complete Inkling RL implementation is open at the Miles pull request: [`radi
 
 ## 1. Model Introduction
 
-[Inkling](https://huggingface.co/thinkingmachines/Inkling) is a mixture-of-experts transformer released by Thinking Machines Lab, with 975 B total parameters and 41 B active, a context window of up to 1 M tokens, and pretraining on 45 trillion tokens of text, images, audio and video. Its architecture introduces short convolution, attention with relative positional embedding, and a novel MoE design with a shared-expert sink. Miles implements Inkling as a native Megatron model: local and global relative attention, the residual ShortConv, the shared-sink router and experts, and the image and audio encoders.
+[Inkling](https://huggingface.co/thinkingmachines/Inkling) is a mixture-of-experts transformer released by Thinking Machines Lab, with 975 B total parameters and 41 B active, a context window of up to 1 M tokens, and pretraining on 45 trillion tokens of text, images, audio and video. Its architecture introduces short convolution, attention with relative positional embedding, and a novel MoE design with a shared-expert sink. Miles implements Inkling as a native Megatron model: local and global relative attention, the residual ShortConv, the shared-sink router and experts, and the image and audio encoders, and the same backend drives both full-parameter and LoRA RL.
 
 **Key highlights**:
 
@@ -33,7 +33,12 @@ docker pull radixark/miles:inkling
 # Full-parameter GRPO on 16 nodes x 4 GB300, inside the container
 cd /root/miles
 python scripts/run_inkling.py train \
-   --model-name Inkling --task dapo_math \
+   --model-name Inkling --train-mode full --task dapo_math \
+   --num-nodes 16 --num-gpus-per-node 4
+
+# LoRA GRPO (rank 32, all-linear), same cluster
+python scripts/run_inkling.py train \
+   --model-name Inkling --train-mode lora --task dapo_math \
    --num-nodes 16 --num-gpus-per-node 4
 ```
 
@@ -139,13 +144,23 @@ SGLANG_ARGS=(
    --sglang-enable-multimodal
    --sglang-context-length 8192
 
+   # full-parameter
    --sglang-mem-fraction-static 0.6
    --sglang-max-running-requests 64
    --sglang-max-total-tokens 327680
+
+   # LoRA (replaces the three flags above)
+   --sglang-ep-size 16
+   --no-offload-rollout --no-offload-train
+   --sglang-mem-fraction-static 0.65
+   --sglang-max-running-requests 32
+   --sglang-lora-backend triton
+   --sglang-lora-use-virtual-experts
+   --sglang-max-loras-per-batch 1
 )
 ```
 
-Weight updates stream Megatron shards into SGLang's tensor layout in bounded buckets over CUDA IPC (colocated).
+Weight updates stream Megatron shards into SGLang's tensor layout in bounded buckets over CUDA IPC (colocated). In LoRA mode only the adapter is synchronized.
 
 ### 5.5 Optimizer
 
@@ -163,14 +178,27 @@ Weight updates stream Megatron shards into SGLang's tensor layout in bounded buc
 --micro-batch-size 1
 ```
 
-Within a single GB300 rack the 975 B policy, gradients, and FP32 optimizer state exceed GPU memory, so Miles streams Megatron `DistributedOptimizer` state between a bounded GPU working set and node-local NVMe. The offload changes storage placement, not the update math. The paused training actor's weights are additionally disk-backed through `torch_memory_saver`.
+Within a single GB300 rack the 975 B policy, gradients, and FP32 optimizer state exceed GPU memory, so Miles streams Megatron `DistributedOptimizer` state between a bounded GPU working set and node-local NVMe. The offload changes storage placement, not the update math. The paused training actor's weights are additionally disk-backed through `torch_memory_saver`. LoRA training skips both offloads and uses dynamic batching (`--use-dynamic-batch-size --max-tokens-per-gpu 4096`) instead of the fixed micro-batch.
 
 <Warning title="Inkling-specific caveats">
 
-1. **Fixed micro-batches.** Dynamic token packing exposes a PP-p2p × EP-all-to-all NCCL launch-order race on varlen shapes; the launcher pins `--micro-batch-size 1`. Keep it pinned until the pad-to-fixed fix lands.
+1. **Fixed micro-batches for full-parameter runs.** Dynamic token packing exposes a PP-p2p × EP-all-to-all NCCL launch-order race on varlen shapes; the launcher pins `--micro-batch-size 1` for full-parameter training. Keep it pinned until the pad-to-fixed fix lands.
+2. **One LoRA adapter per engine.** RL serving uses `--sglang-max-loras-per-batch 1` with the triton LoRA backend and virtual experts: the engine holds exactly the current policy's adapter (see [LoRA RL](#6-lora-rl)).
 
 </Warning>
 
-## 6. Multimodal RL
+## 6. LoRA RL
 
-`--task geo3k` switches to the vision-language recipe: structured multimodal rollouts, Megatron-side vision and audio towers, and routing replay preserved across the media-expanded sequence. Each image or audio sentinel in the rendered prompt expands into its patch/frame positions before packing, and the R3 trace is indexed over the expanded sequence, so replay stays aligned even though SGLang made its routing decisions after expansion. Production recipes keep the vision and audio towers frozen and train the language model around their embeddings; training the towers is available as an experimental option. The same path supports audio inputs.
+`--train-mode lora` switches the same backend and parallel stack to adapter-only training. The base model stays frozen in both runtimes, and GRPO updates only the low-rank factors:
+
+$$
+y = Wx + \frac{\alpha}{r}\,B(Ax).
+$$
+
+The adapter follows Inkling's released LoRA schema, covering the attention, dense MLP, MoE, and LM-head projections (defaults: rank 32, `alpha = 32`, all-linear). The routed experts use a shared-outer factorization: one factor is shared across experts while the expert-specific factors follow EP sharding.
+
+After each optimizer step, Miles exports a serving-ready adapter directly from the distributed training state and hands it to the colocated SGLang worker over CUDA IPC; the frozen base is never re-transferred. This cuts the weight update from 49.4 s to 2.5 s (20×) and brings training-step time to ~85 % of full-parameter training, with no optimizer offload needed. Released Inkling adapters in safetensors format support warm starts via `--lora-adapter-path`, and per-rank adapter checkpoints allow exact training resume.
+
+## 7. Multimodal RL
+
+`--task geo3k` switches to the vision-language recipe: structured multimodal rollouts, Megatron-side vision and audio towers, and routing replay preserved across the media-expanded sequence. Each image or audio sentinel in the rendered prompt expands into its patch/frame positions before packing, and the R3 trace is indexed over the expanded sequence, so replay stays aligned even though SGLang made its routing decisions after expansion. Production recipes keep the vision and audio towers frozen and train the language model (or its adapter) around their embeddings; training the towers is available as an experimental option. The same path supports audio inputs and both full-parameter and LoRA training.

--- a/miles/backends/megatron_utils/actor.py
+++ b/miles/backends/megatron_utils/actor.py
@@ -52,7 +52,7 @@ from .ft.checkpoint_transfer import send_ckpt as _send_ckpt
 from .ft.in_memory_checkpoint import InMemoryCheckpointManager
 from .ft.indep_dp import reconfigure_indep_dp_group
 from .initialize import init, is_first_replica_megatron_main_rank
-from .lora_utils import is_lora_enabled
+from .lora_utils import is_lora_enabled, lora_rollout_enabled
 from .model import TrainStepOutcome, forward_only, initialize_model_and_optimizer, save, train
 from .parallel import verify_megatron_parallel_state
 from .replay_utils import register_replay_list_moe
@@ -255,7 +255,7 @@ class MegatronTrainRayActor(TrainRayActor):
             weights_getter=lambda: self.weights_backuper.get("actor"),
             model_name=type(self.hf_config).__name__.lower() if self.args.model_name is None else self.args.model_name,
             quantization_config=getattr(self.hf_config, "quantization_config", None),
-            is_lora=is_lora_enabled(args),
+            is_lora=lora_rollout_enabled(args),
         )
 
         # Adapters currently loaded into Megatron slots on this rank.
@@ -295,7 +295,7 @@ class MegatronTrainRayActor(TrainRayActor):
 
         destroy_process_groups()
 
-        tag = "default" if is_lora_enabled(self.args) else None
+        tag = "default" if lora_rollout_enabled(self.args) else None
         torch_memory_saver.pause(tag=tag)
 
         self._asleep = True
@@ -314,7 +314,7 @@ class MegatronTrainRayActor(TrainRayActor):
             return
         print_memory("before wake_up model")
 
-        tag = "default" if is_lora_enabled(self.args) else None
+        tag = "default" if lora_rollout_enabled(self.args) else None
         torch_memory_saver.resume(tag=tag)
 
         clear_memory()

--- a/miles/backends/megatron_utils/lora_utils.py
+++ b/miles/backends/megatron_utils/lora_utils.py
@@ -11,7 +11,7 @@ import torch
 import torch.distributed as dist
 
 from miles.backends.training_utils.parallel import get_parallel_state
-from miles.utils.lora import is_lora_enabled
+from miles.utils.lora import is_lora_enabled, lora_rollout_enabled  # noqa: F401  (re-exported)
 
 logger = logging.getLogger(__name__)
 
@@ -113,6 +113,60 @@ _SGLANG_UNSUPPORTED_HF_TARGETS = frozenset()
 def lora_base_cpu_backup_enabled(args: Namespace) -> bool:
     """LoRA + --colocate + --lora-base-cpu-backup all set."""
     return is_lora_enabled(args) and getattr(args, "colocate", False) and getattr(args, "lora_base_cpu_backup", False)
+
+
+def sglang_lora_target_all_sentinel(args) -> bool:
+    """Hand SGLang the ``"all"`` shorthand so it auto-detects module names (required for Inkling)."""
+    from miles.utils.chat_template_utils.inkling import is_inkling_checkpoint
+
+    return is_inkling_checkpoint(getattr(args, "hf_checkpoint", None) or "")
+
+
+_marked_lora_grad_params_cache: dict[int, list] = {}
+
+
+def reduce_marked_lora_grads(model: Sequence[torch.nn.Module]) -> None:
+    """Sum partial grads of replicated LoRA params over their tagged group ("tp"|"ep"), before the DP reduce-scatter."""
+    from megatron.core import parallel_state as ps
+
+    key = id(model[0]) if model else 0
+    marked = _marked_lora_grad_params_cache.get(key)
+    if marked is None:
+        marked = []
+        for chunk in model:
+            for param in chunk.parameters():
+                group_name = getattr(param, "_lora_grad_sum_group", None)
+                if group_name is not None and param.requires_grad:
+                    marked.append((param, group_name))
+        _marked_lora_grad_params_cache[key] = marked
+    if not marked:
+        return
+    groups = {
+        "tp": (ps.get_tensor_model_parallel_group(), ps.get_tensor_model_parallel_world_size()),
+        "ep": (ps.get_expert_model_parallel_group(), ps.get_expert_model_parallel_world_size()),
+    }
+    for group_name in ("tp", "ep"):
+        group, size = groups[group_name]
+        if size <= 1:
+            continue
+        grads = []
+        for param, g_name in marked:
+            if g_name != group_name:
+                continue
+            grad = getattr(param, "main_grad", None)
+            if grad is None:
+                grad = param.grad
+            if grad is not None:
+                grads.append(grad)
+        for dt in {g.dtype for g in grads}:
+            gs = [g for g in grads if g.dtype == dt]
+            if len(gs) == 1:
+                dist.all_reduce(gs[0], op=dist.ReduceOp.SUM, group=group)
+                continue
+            flat = torch._utils._flatten_dense_tensors(gs)
+            dist.all_reduce(flat, op=dist.ReduceOp.SUM, group=group)
+            for g, red in zip(gs, torch._utils._unflatten_dense_tensors(flat, gs), strict=False):
+                g.copy_(red)
 
 
 def is_lora_model(model: Sequence[torch.nn.Module]) -> bool:
@@ -365,7 +419,7 @@ def save_lora_checkpoint(
     1. **HF PEFT format** (``adapter_model.bin`` + ``adapter_config.json``) for
        external tool compatibility. Uses Megatron-Bridge's ``export_adapter_weights``
        which correctly handles fused QKV / gate-up weight splitting and TP gathering.
-    2. **Megatron-native format** (``adapter_megatron_tp{tp}_pp{pp}.pt``) for fast
+    2. **Megatron-native format** (``adapter_megatron_rank{global_rank}.pt``) for fast
        checkpoint resume without name/weight conversion. Each TP/PP rank saves its
        own shard with original parameter names.
 
@@ -388,61 +442,63 @@ def save_lora_checkpoint(
     tp_rank = parallel_state.tp.rank
     pp_rank = parallel_state.pp.rank
 
-    # Create directory on dp_rank=0, then synchronize
-    if is_dp_cp_rank_0:
-        save_path.mkdir(parents=True, exist_ok=True)
+    save_path.mkdir(parents=True, exist_ok=True)
     if dist.is_initialized():
         dist.barrier()
 
-    # ---- Megatron-native format (per TP/PP rank, fast resume) ----
-    if is_dp_cp_rank_0:
-        adapter_state: dict[str, torch.Tensor] = {}
-        for model_chunk in model:
-            for name, param in model_chunk.named_parameters():
-                if _is_adapter_param_name(name):
-                    adapter_state[name] = param.data.cpu()
+    adapter_state: dict[str, torch.Tensor] = {}
+    for model_chunk in model:
+        for name, param in model_chunk.named_parameters():
+            if _is_adapter_param_name(name):
+                adapter_state[name] = param.data.cpu()
 
-        native_path = save_path / f"adapter_megatron_tp{tp_rank}_pp{pp_rank}.pt"
-        torch.save(adapter_state, native_path)
-        logger.info(f"Saved {len(adapter_state)} adapter tensors (native) to {native_path}")
+    global_rank = dist.get_rank() if dist.is_initialized() else 0
+    native_path = save_path / f"adapter_megatron_rank{global_rank}.pt"
+    torch.save(adapter_state, native_path)
+    logger.info(f"Saved {len(adapter_state)} adapter tensors (native) to {native_path}")
 
     # ---- HF PEFT format (uses bridge for correct name/weight conversion) ----
     # Bridge export is collective: all TP ranks participate in the all-gather,
     # so every rank must call export_adapter_weights.
-    bridge = AutoBridge.from_hf_pretrained(args.hf_checkpoint, trust_remote_code=True)
+    try:
+        bridge = AutoBridge.from_hf_pretrained(args.hf_checkpoint, trust_remote_code=True)
 
-    lora_state_dict: dict[str, torch.Tensor] = {}
-    with megatron_bridge_utils.patch_megatron_model(model):
-        for hf_name, weight, _megatron_name in bridge.export_adapter_weights(
-            model,
-            cpu=True,
-            show_progress=False,
-        ):
-            lora_state_dict[hf_name] = weight
+        lora_state_dict: dict[str, torch.Tensor] = {}
+        with megatron_bridge_utils.patch_megatron_model(model):
+            for hf_name, weight, _megatron_name in bridge.export_adapter_weights(
+                model,
+                cpu=True,
+                show_progress=False,
+            ):
+                lora_state_dict[hf_name] = weight
 
-    # Only one rank writes the HF PEFT files (bridge already gathered across TP/PP)
-    if is_dp_cp_rank_0 and tp_rank == 0 and pp_rank == 0:
-        torch.save(lora_state_dict, save_path / "adapter_model.bin")
+        if is_dp_cp_rank_0 and tp_rank == 0 and pp_rank == 0:
+            torch.save(lora_state_dict, save_path / "adapter_model.bin")
 
-        target_modules_hf = (
-            convert_target_modules_to_hf(list(args.target_modules))
-            if args.target_modules
-            else ["q_proj", "k_proj", "v_proj", "o_proj", "gate_proj", "up_proj", "down_proj"]
+            target_modules_hf = (
+                convert_target_modules_to_hf(list(args.target_modules))
+                if args.target_modules
+                else ["q_proj", "k_proj", "v_proj", "o_proj", "gate_proj", "up_proj", "down_proj"]
+            )
+            config = {
+                "peft_type": "LORA",
+                "r": args.lora_rank,
+                "lora_alpha": args.lora_alpha,
+                "target_modules": target_modules_hf,
+                "lora_dropout": args.lora_dropout,
+                "bias": "none",
+                "task_type": "CAUSAL_LM",
+            }
+            with open(save_path / "adapter_config.json", "w") as f:
+                json.dump(config, f, indent=2)
+
+            os.sync()
+            logger.info(f"Saved HF PEFT adapter to {save_path} with {len(lora_state_dict)} tensors")
+    except Exception as hf_export_err:
+        logger.warning(
+            f"HF PEFT adapter export skipped ({hf_export_err}); the per-rank native "
+            f"shards + training state are sufficient for training resume."
         )
-        config = {
-            "peft_type": "LORA",
-            "r": args.lora_rank,
-            "lora_alpha": args.lora_alpha,
-            "target_modules": target_modules_hf,
-            "lora_dropout": args.lora_dropout,
-            "bias": "none",
-            "task_type": "CAUSAL_LM",
-        }
-        with open(save_path / "adapter_config.json", "w") as f:
-            json.dump(config, f, indent=2)
-
-        os.sync()
-        logger.info(f"Saved HF PEFT adapter to {save_path} with {len(lora_state_dict)} tensors")
 
     # ---- Training state (optimizer + scheduler) for resume ----
     if optimizer is not None:
@@ -500,7 +556,13 @@ def load_lora_adapter(
     pp_rank = get_parallel_state().pp.rank
 
     # ---- Try Megatron-native format first (fast, no conversion needed) ----
-    native_path = adapter_dir / f"adapter_megatron_tp{tp_rank}_pp{pp_rank}.pt"
+    global_rank = dist.get_rank() if dist.is_initialized() else 0
+    native_path = adapter_dir / f"adapter_megatron_rank{global_rank}.pt"
+    if not native_path.exists():
+        legacy = adapter_dir / f"adapter_megatron_tp{tp_rank}_pp{pp_rank}.pt"
+        if legacy.exists():
+            logger.warning(f"Using legacy tp/pp-named adapter shard {legacy}; only valid when EP<=TP")
+            native_path = legacy
     if native_path.exists():
         state_dict = torch.load(native_path, map_location="cpu", weights_only=True)
         loaded = 0
@@ -566,11 +628,14 @@ def _load_training_state(
 
 def build_lora_sync_config(args: Namespace) -> dict[str, Any]:
     """Build LoRA config dict for syncing weights to SGLang engines."""
-    target_modules_hf = (
-        target_modules_hf_for_sglang_rollout(args)
-        if args.target_modules
-        else ["q_proj", "k_proj", "v_proj", "o_proj", "gate_proj", "up_proj", "down_proj"]
-    )
+    if sglang_lora_target_all_sentinel(args):
+        target_modules_hf: Any = "all-linear"
+    else:
+        target_modules_hf = (
+            target_modules_hf_for_sglang_rollout(args)
+            if args.target_modules
+            else ["q_proj", "k_proj", "v_proj", "o_proj", "gate_proj", "up_proj", "down_proj"]
+        )
     return {
         "peft_type": "LORA",
         "r": args.lora_rank,

--- a/miles/backends/megatron_utils/model.py
+++ b/miles/backends/megatron_utils/model.py
@@ -151,7 +151,16 @@ def setup_model_and_optimizer(
     ):
         model = _setup_lora_model_via_bridge(args)
     else:
-        model = get_model(get_model_provider_func(args, role), ModelType.encoder_or_decoder)
+        provider_func = get_model_provider_func(args, role)
+        if (
+            is_lora_enabled(args)
+            and role == "actor"
+            and "inkling" in (getattr(args, "custom_model_provider_path", None) or "")
+        ):
+            from miles_plugins.models.inkling.lora import wrap_model_provider_with_inkling_lora
+
+            provider_func = wrap_model_provider_with_inkling_lora(provider_func, args)
+        model = get_model(provider_func, ModelType.encoder_or_decoder)
 
     if args.debug_disable_optimizer:
         if is_first_replica_megatron_main_rank():
@@ -643,6 +652,9 @@ def finalize_model_grads_with_empty_cache(*args, **kwargs):
     free, total = torch.cuda.mem_get_info(device)
     if free / total < 0.1:
         clear_memory()
+    from .lora_utils import reduce_marked_lora_grads
+
+    reduce_marked_lora_grads(args[0])
     return finalize_model_grads(*args, **kwargs)
 
 
@@ -992,6 +1004,22 @@ def initialize_model_and_optimizer(
         if is_first_replica_megatron_main_rank():
             logger.warning("--load %r is empty; starting from model_provider-initialized weights", load_dir)
         iteration = 0
+
+    if (
+        is_lora_enabled(args)
+        and role == "actor"
+        and args.megatron_to_hf_mode != "bridge"
+        and getattr(args, "lora_adapter_path", None)
+        and "inkling" in (getattr(args, "custom_model_provider_path", None) or "")
+    ):
+        if (Path(args.lora_adapter_path) / "adapter_model.safetensors").exists():
+            from miles_plugins.models.inkling.lora import load_inkling_lora_adapter
+
+            load_inkling_lora_adapter(model, args.lora_adapter_path)
+            if optimizer is not None:
+                # refresh the fp32 masters, or the first step() restores the
+                # pre-load init values over the adapter we just wrote
+                optimizer.reload_model_params()
 
     check_peak_gpu_memory_after_load(args)
     clear_memory()

--- a/miles/backends/megatron_utils/update_weight/hf_weight_iterator_direct.py
+++ b/miles/backends/megatron_utils/update_weight/hf_weight_iterator_direct.py
@@ -33,6 +33,12 @@ class HfWeightIteratorDirect(HfWeightIteratorBase):
     def get_hf_weight_chunks(self, megatron_local_weights, weight_type="base"):
         rank = dist.get_rank()
 
+        if weight_type == "lora":
+            from miles_plugins.models.inkling.lora import export_inkling_lora_hf_named
+
+            yield export_inkling_lora_hf_named(self.model)
+            return
+
         for megatron_local_param_infos in tqdm(
             self.megatron_local_param_info_buckets, disable=rank != 0, desc="Update weights"
         ):
@@ -168,9 +174,13 @@ def _get_megatron_local_param_infos(args: Namespace, model: Sequence[torch.nn.Mo
     pp_size = get_parallel_state().pp.size
     ep_size = get_parallel_state().ep.size
 
+    from ..lora_utils import _is_adapter_param_name
+
     param_infos = {}
     rank = dist.get_rank()
     for name, param in named_params_and_buffers(args, model):
+        if _is_adapter_param_name(name):
+            continue
         param_infos[name] = ParamInfo(
             name=name,
             dtype=param.dtype,

--- a/miles/backends/megatron_utils/update_weight/update_weight_from_tensor.py
+++ b/miles/backends/megatron_utils/update_weight/update_weight_from_tensor.py
@@ -1,5 +1,6 @@
 import hashlib
 import logging
+import math
 import os
 from argparse import Namespace
 from collections.abc import Callable, Mapping, Sequence
@@ -23,6 +24,7 @@ from miles.utils.lora import LORA_ADAPTER_NAME
 from ..sglang import FlattenedTensorBucket, MultiprocessingSerializer
 from .common import _check_weight_sync_results, begin_weight_update, end_weight_update, weight_update_selector
 from .hf_weight_iterator_base import HfWeightIteratorBase
+
 from .update_weight_from_distributed.broadcast import (
     connect_rollout_engines_from_distributed,
     disconnect_rollout_engines_from_distributed,
@@ -30,6 +32,46 @@ from .update_weight_from_distributed.broadcast import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _pp_assemble_full_adapter(
+    hf_named_tensors: list[tuple[str, torch.Tensor]],
+) -> list[tuple[str, torch.Tensor]]:
+    """Assemble the complete adapter on every PP rank (exporter gathers TP/EP but not PP)."""
+    pp_group = get_parallel_state().pp.group
+    pp_size = dist.get_world_size(group=pp_group)
+    if pp_size == 1:
+        return hf_named_tensors
+    pp_rank = dist.get_rank(group=pp_group)
+    global_ranks = dist.get_process_group_ranks(pp_group)
+    device = torch.cuda.current_device()
+
+    local_meta = [(n, tuple(t.shape), t.dtype) for n, t in hf_named_tensors]
+    all_meta: list = [None] * pp_size
+    dist.all_gather_object(all_meta, local_meta, group=pp_group)
+
+    local_by_name = {n: t for n, t in hf_named_tensors}
+    merged: dict[str, torch.Tensor] = {}
+    for src_pp, meta in enumerate(all_meta):
+        by_dtype: dict = {}
+        for n, shape, dtype in meta:
+            by_dtype.setdefault(dtype, []).append((n, shape))
+        for dtype, entries in by_dtype.items():
+            numel = sum(math.prod(shape) for _, shape in entries)
+            flat = torch.empty(numel, dtype=dtype, device=device)
+            if src_pp == pp_rank:
+                off = 0
+                for n, shape in entries:
+                    k = math.prod(shape)
+                    flat[off : off + k].copy_(local_by_name[n].reshape(-1))
+                    off += k
+            dist.broadcast(flat, src=global_ranks[src_pp], group=pp_group)
+            off = 0
+            for n, shape in entries:
+                k = math.prod(shape)
+                merged[n] = flat[off : off + k].view(shape)
+                off += k
+    return sorted(merged.items())
 
 
 class UpdateWeightFromTensor:
@@ -200,15 +242,13 @@ class UpdateWeightFromTensor:
 
         rank = dist.get_rank()
 
-        # LoRA never mutates the base. With either path that retains it on the
-        # rollout side (distributed keeps it on GPU; colocate + cpu_backup keeps
-        # a host mirror across pause/resume), we can skip the base sync entirely
-        # and the surrounding restore_weights_before_load / post_process_quantization
-        # calls that would otherwise prep / re-quantize fresh base bytes.
         # TODO: implement lora weight checker
+        colocate_base_persistent = getattr(self.args, "colocate", False) and not getattr(
+            self.args, "offload_rollout", True
+        )
         skip_base_sync = (
             self.is_lora
-            and (self.use_distribute or lora_base_cpu_backup_enabled(self.args))
+            and (self.use_distribute or lora_base_cpu_backup_enabled(self.args) or colocate_base_persistent)
             and not getattr(self.args, "check_weight_update_equal", False)
         )
 
@@ -258,10 +298,15 @@ class UpdateWeightFromTensor:
                     "the Megatron-Bridge or SGLang version is incompatible."
                 )
 
+            accumulated_named_tensors = _pp_assemble_full_adapter(accumulated_named_tensors)
+
             refs, long_lived_tensors = self._send_lora_params(accumulated_named_tensors)
             results = ray.get(refs)
             _check_weight_sync_results(results, is_lora=True)
             del long_lived_tensors
+            del accumulated_named_tensors
+            torch.cuda.ipc_collect()
+            torch.cuda.empty_cache()
 
             if not self._lora_base_synced:
                 self._lora_base_synced = True
@@ -349,20 +394,57 @@ class UpdateWeightFromTensor:
             )
         if self.use_distribute and self._is_distributed_src_rank:
             raise NotImplementedError("LoRA weight sync is not yet supported for distributed (non-colocated) engines")
-        else:
-            refs, long_lived_tensors = _send_to_colocated_engine(
-                hf_named_tensors=hf_named_tensors,
-                ipc_engine=self._ipc_engine,
-                ipc_gather_src=self._ipc_gather_src,
-                ipc_gather_group=self._ipc_gather_group,
-                selector=weight_update_selector(self.args),
-                lora_config=self._lora_config,
-                lora_name=LORA_ADAPTER_NAME,
-                lora_loaded=self._lora_loaded,
-                check_equal=getattr(self.args, "check_lora_weight_equal", False),
-            )
-            self._lora_loaded = True
-            return refs or [], long_lived_tensors
+
+        refs, long_lived_tensors = _send_to_colocated_engine(
+            hf_named_tensors=hf_named_tensors,
+            ipc_engine=self._ipc_engine,
+            ipc_gather_src=self._ipc_gather_src,
+            ipc_gather_group=self._ipc_gather_group,
+            selector=weight_update_selector(self.args),
+            lora_config=self._lora_config,
+            lora_name=LORA_ADAPTER_NAME,
+            lora_loaded=self._lora_loaded,
+            check_equal=getattr(self.args, "check_lora_weight_equal", False),
+            repack_lora_for_ipc=getattr(self.args, "offload_train", False),
+        )
+        self._lora_loaded = True
+        return refs or [], long_lived_tensors
+
+
+def _repack_onto_fresh_storage(
+    named_tensors: list[tuple[str, torch.Tensor]],
+) -> dict[str, torch.Tensor]:
+    """Copy CUDA tensors into freshly allocated flat buffers and return views onto them.
+
+    ``torch_memory_saver.region()`` is a ``torch.cuda.use_mem_pool`` context, so anything
+    allocated while building the model -- the LoRA adapter parameters included -- lives in
+    a MemPool the preloaded hook backs with cuMem. cuMem allocations cannot be exported
+    over the legacy CUDA IPC API that ``MultiprocessingSerializer`` uses, so handing their
+    storages straight to the engine fails with "CUDA error: invalid argument" on the first
+    sync. Allocating here, outside any region, gets normal caching-allocator memory whose
+    handles export fine. (This is also why the FlattenedTensorBucket path works: its
+    flattened tensor is likewise allocated at sync time.)
+
+    One buffer per (dtype, device) rather than one clone per tensor: the direct-dict
+    transport relies on the pickler memoizing storages so the engine receives a handful of
+    IPC handles instead of one per adapter tensor.
+    """
+    groups: dict[tuple[torch.dtype, torch.device], list[tuple[str, torch.Tensor]]] = {}
+    for name, tensor in named_tensors:
+        if tensor.is_cuda:
+            groups.setdefault((tensor.dtype, tensor.device), []).append((name, tensor))
+
+    views: dict[str, torch.Tensor] = {}
+    for (dtype, device), items in groups.items():
+        flat = torch.empty(sum(t.numel() for _, t in items), dtype=dtype, device=device)
+        offset = 0
+        for name, tensor in items:
+            view = flat[offset : offset + tensor.numel()].view(tensor.shape)
+            view.copy_(tensor)
+            views[name] = view
+            offset += tensor.numel()
+
+    return {name: views.get(name, tensor) for name, tensor in named_tensors}
 
 
 def _send_to_colocated_engine(
@@ -377,6 +459,7 @@ def _send_to_colocated_engine(
     lora_loaded: bool = False,
     check_equal: bool = False,
     selector: str = "all",
+    repack_lora_for_ipc: bool = False,
 ) -> tuple[list[ObjectRef], Any]:
     # Placeholder ranks (GPU slots reserved but no engine) have no gather group.
     # gather_object is only collective among group members, so we skip entirely.
@@ -387,7 +470,12 @@ def _send_to_colocated_engine(
     is_gather_src = dist.get_rank() == ipc_gather_src
     long_live_tensors = []
 
-    if getattr(FlattenedTensorBucket, "supports_multi_dtypes", False):
+    if is_lora:
+        payload = _repack_onto_fresh_storage(hf_named_tensors) if repack_lora_for_ipc else dict(hf_named_tensors)
+        long_live_tensors.append(payload)
+        converted_named_tensors_by_dtypes = {}
+        serialized_lora = MultiprocessingSerializer.serialize(payload, output_str=True)
+    elif getattr(FlattenedTensorBucket, "supports_multi_dtypes", False):
         converted_named_tensors_by_dtypes = {"dtype": hf_named_tensors}
     else:
         converted_named_tensors_by_dtypes = {}
@@ -397,7 +485,7 @@ def _send_to_colocated_engine(
                 converted_named_tensors_by_dtypes[dtype] = []
             converted_named_tensors_by_dtypes[dtype].append((name, tensor))
 
-    serialized_tensors: list = []
+    serialized_tensors: list = [serialized_lora] if is_lora else []
     for _dtype, named_tensors in converted_named_tensors_by_dtypes.items():
         flattened_tensor_bucket = FlattenedTensorBucket(named_tensors=named_tensors)
         flattened_tensor_data = {
@@ -418,13 +506,10 @@ def _send_to_colocated_engine(
     refs = []
     if is_gather_src:
         if is_lora:
-            if lora_loaded:
+            try:
                 ray.get(ipc_engine.unload_lora_adapter.remote(lora_name=lora_name))
-
-            # (Yusheng) to-do-1: update lora weights from tensors should support multiple dtypes (bf16, fp8, fp16, fp32)
-            # currently, we only support 1 type. If there are multiple dtypes, we need to serialize the tensors for each dtype.
-            # Thus, we need to apply the same way as `ipc_engine.update_weights_from_tensor` in future
-            # (Yusheng) to-do-2: need to add ci test acc here - now it will pass but fail to update lora weights
+            except Exception as _unload_err:
+                logger.debug("lora unload before load skipped: %s", _unload_err)
 
             expected_checksums = None
             if check_equal:
@@ -442,7 +527,6 @@ def _send_to_colocated_engine(
                     serialized_named_tensors=[
                         per_rank[0] if per_rank else None for per_rank in serialized_named_tensors
                     ],
-                    load_format="flattened_bucket",
                     expected_checksums=expected_checksums,
                 )
             )

--- a/miles/backends/sglang_utils/sglang_engine.py
+++ b/miles/backends/sglang_utils/sglang_engine.py
@@ -13,11 +13,15 @@ from sglang.srt.server_args import ServerArgs
 from sglang.srt.utils import kill_process_tree
 from urllib3.exceptions import NewConnectionError
 
-from miles.backends.megatron_utils.lora_utils import convert_target_modules_to_hf, lora_base_cpu_backup_enabled
+from miles.backends.megatron_utils.lora_utils import (
+    convert_target_modules_to_hf,
+    lora_base_cpu_backup_enabled,
+    sglang_lora_target_all_sentinel,
+)
 from miles.ray.ray_actor import RayActor
 from miles.utils.env_report import collect_and_print_node_env_report
 from miles.utils.http_utils import get_host_info
-from miles.utils.lora import LORA_ADAPTER_NAME, is_lora_enabled
+from miles.utils.lora import LORA_ADAPTER_NAME, lora_rollout_enabled
 from miles.utils.multi_lora import is_multi_lora_enabled
 
 logger = logging.getLogger(__name__)
@@ -367,21 +371,31 @@ class SGLangEngine(RayActor):
         self,
         lora_name: str,
         config_dict: dict,
-        serialized_named_tensors: list,
+        serialized_tensors: str | None = None,
+        serialized_named_tensors: list | None = None,
         load_format: str | None = None,
         pinned: bool = False,
         added_tokens_config: dict | None = None,
         upsert: bool = False,
         expected_checksums: dict | None = None,
     ):
-        """Load a LoRA adapter; ``serialized_named_tensors[tp_rank]`` is bytes for that TP rank.
-        With ``upsert``, the already-loaded ``lora_name`` is overwritten in place (no unload/register)."""
+        """Load a LoRA adapter from either transport (exactly one of the two).
+
+        ``serialized_named_tensors[tp_rank]`` is bytes for that TP rank; ``serialized_tensors``
+        is the whole adapter. With ``upsert``, the already-loaded ``lora_name`` is overwritten
+        in place (no unload/register).
+        """
+        if (serialized_tensors is None) == (serialized_named_tensors is None):
+            raise ValueError("pass exactly one of serialized_tensors / serialized_named_tensors")
         payload = {
             "lora_name": lora_name,
             "config_dict": config_dict,
-            "serialized_named_tensors": serialized_named_tensors,
             "pinned": pinned,
         }
+        if serialized_tensors is not None:
+            payload["serialized_tensors"] = serialized_tensors
+        else:
+            payload["serialized_named_tensors"] = serialized_named_tensors
         if upsert:
             payload["upsert"] = True
         if load_format is not None:
@@ -758,14 +772,19 @@ def _compute_server_args(
         kwargs["max_loras_per_batch"] = args.multi_lora_n_adapters
         kwargs["max_lora_rank"] = max(getattr(args, "lora_rank", 0), 1)
         kwargs["lora_target_modules"] = convert_target_modules_to_hf(args.target_modules)
-    elif is_lora_enabled(args):
+    elif lora_rollout_enabled(args):
         kwargs["enable_lora"] = True
         kwargs["max_loras_per_batch"] = 1
         kwargs["max_lora_rank"] = max(getattr(args, "lora_rank", 0), 1)
-        kwargs["lora_target_modules"] = convert_target_modules_to_hf(args.target_modules)
+        if sglang_lora_target_all_sentinel(args):
+            kwargs["lora_target_modules"] = ["all"]
+        else:
+            kwargs["lora_target_modules"] = convert_target_modules_to_hf(args.target_modules)
 
-        if args.lora_adapter_path is not None:
+        if args.lora_adapter_path is not None and kwargs.get("load_format") != "dummy":
             kwargs["lora_paths"] = {LORA_ADAPTER_NAME: args.lora_adapter_path}
+        elif args.lora_adapter_path is not None:
+            logger.info("dummy base load: skipping startup lora_paths; adapter comes via weight-sync")
         else:
             logger.info("No pre-trained LoRA adapter_path provided, will use random initial weights")
 

--- a/miles/rollout/generate_utils/generate_endpoint_utils.py
+++ b/miles/rollout/generate_utils/generate_endpoint_utils.py
@@ -8,7 +8,7 @@ from typing import Any
 import numpy as np
 import pybase64
 
-from miles.utils.lora import LORA_ADAPTER_NAME, is_lora_enabled
+from miles.utils.lora import LORA_ADAPTER_NAME, lora_rollout_enabled
 from miles.utils.processing_utils import encode_image_for_rollout_engine, extract_multimodal_train_inputs
 from miles.utils.types import Sample
 
@@ -69,7 +69,7 @@ def compute_request_payload(
         "return_routed_experts": args.use_rollout_routing_replay,
         "return_indexer_topk": args.use_rollout_indexer_replay,
     }
-    if is_lora_enabled(args):
+    if lora_rollout_enabled(args):
         payload["lora_path"] = LORA_ADAPTER_NAME
     if image_data := (multimodal_inputs or {}).get("images"):
         payload["image_data"] = [encode_image_for_rollout_engine(image) for image in image_data]

--- a/miles/rollout/generate_utils/prefill_logprobs.py
+++ b/miles/rollout/generate_utils/prefill_logprobs.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from miles.rollout.generate_utils.generate_endpoint_utils import compute_routing_headers, policy_uses_routing_key
 from miles.utils.http_utils import post
-from miles.utils.lora import LORA_ADAPTER_NAME, is_lora_enabled
+from miles.utils.lora import LORA_ADAPTER_NAME, lora_rollout_enabled
 from miles.utils.multi_lora import slot_lora_name
 from miles.utils.processing_utils import encode_image_for_rollout_engine
 from miles.utils.types import Sample
@@ -16,7 +16,7 @@ def _lora_path_for_sample(args: Any, sample: Sample) -> str | None:
     """Adapter name to score under: the sample slot's __miles_slot_{N} name, the fixed single-LoRA name, or None."""
     if sample.adapter is not None:
         return slot_lora_name(sample.adapter.slot)
-    if is_lora_enabled(args):
+    if lora_rollout_enabled(args):
         return LORA_ADAPTER_NAME
     return None
 

--- a/miles/rollout/sglang_rollout.py
+++ b/miles/rollout/sglang_rollout.py
@@ -22,7 +22,7 @@ from miles.utils.data import Dataset
 from miles.utils.eval_config import EvalDatasetConfig
 from miles.utils.http_utils import get, post, router_worker_base_urls
 from miles.utils.lifecycle import TrajectoryLifecycle
-from miles.utils.lora import LORA_ADAPTER_NAME, is_lora_enabled
+from miles.utils.lora import LORA_ADAPTER_NAME, lora_rollout_enabled
 from miles.utils.misc import SingletonMeta, call_agent_abort_hook, load_function
 from miles.utils.multi_lora import make_rid, slot_lora_name
 from miles.utils.processing_utils import (
@@ -240,7 +240,7 @@ async def generate(args: Namespace, sample: Sample, sampling_params: dict[str, A
         payload["lora_path"] = slot_lora_name(sample.adapter.slot)
         payload["rid"] = make_rid(sample.adapter.name)
         payload["extra_key"] = f"{sample.adapter.name}:v{adapter.version}"
-    elif is_lora_enabled(args):
+    elif lora_rollout_enabled(args):
         payload["lora_path"] = LORA_ADAPTER_NAME
 
     if args.use_rollout_routing_replay:

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -1581,6 +1581,17 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 ),
             )
             parser.add_argument(
+                "--lora-train-only",
+                action="store_true",
+                default=False,
+                help=(
+                    "Train LoRA adapters in Megatron but keep rollout engines on the frozen "
+                    "base policy: SGLang LoRA serving and adapter weight sync are disabled "
+                    "(only the base weights are synced). For models without SGLang LoRA "
+                    "support (e.g. Inkling native LoRA)."
+                ),
+            )
+            parser.add_argument(
                 "--experts-shared-outer-loras",
                 action="store_true",
                 default=False,
@@ -2781,10 +2792,10 @@ def miles_validate_args(args):
 
         # Training and serving must agree on shared-outer grouped-expert LoRA
         # (expert_dim=1 buffers in SGLang).
-        if args.experts_shared_outer_loras:
+        if args.experts_shared_outer_loras and hasattr(args, "sglang_experts_shared_outer_loras"):
             args.sglang_experts_shared_outer_loras = True
         assert args.experts_shared_outer_loras == bool(
-            args.sglang_experts_shared_outer_loras
+            getattr(args, "sglang_experts_shared_outer_loras", args.experts_shared_outer_loras)
         ), "experts_shared_outer_loras and sglang_experts_shared_outer_loras must agree"
 
         # the two MoE-expert adapter layouts are not checkpoint-compatible; say which one runs

--- a/miles/utils/lora.py
+++ b/miles/utils/lora.py
@@ -6,3 +6,12 @@ LORA_ADAPTER_NAME = "miles_lora"
 def is_lora_enabled(args: Namespace) -> bool:
     """Check if LoRA is enabled based on arguments."""
     return getattr(args, "lora_rank", 0) > 0 or getattr(args, "lora_adapter_path", None) is not None
+
+
+def lora_rollout_enabled(args: Namespace) -> bool:
+    """LoRA enabled AND the rollout side participates; false under --lora-train-only.
+
+    Gates everything rollout-facing: SGLang's ``enable_lora``, the per-request
+    ``lora_path``, and the adapter weight sync. Training-side LoRA is unaffected.
+    """
+    return is_lora_enabled(args) and not getattr(args, "lora_train_only", False)

--- a/miles_plugins/models/inkling/lora.py
+++ b/miles_plugins/models/inkling/lora.py
@@ -1,0 +1,759 @@
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from collections.abc import Callable
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+logger = logging.getLogger(__name__)
+
+
+class InklingLoRAAdapter(nn.Module):
+    """One module's LoRA params keyed for HF export; invisible to Megatron dist-checkpointing."""
+
+    def __init__(self, kind: str, hf_prefix: str) -> None:
+        super().__init__()
+        self.kind = kind
+        self.hf_prefix = hf_prefix
+        self.load_meta: dict[str, int] = {}
+
+    def sharded_state_dict(self, prefix="", sharded_offsets=(), metadata=None):
+        del prefix, sharded_offsets, metadata
+        return {}
+
+
+def _rmsnorm(inputs: torch.Tensor, gamma: torch.Tensor, eps: float) -> torch.Tensor:
+    """Recompute the RMSNorm fused into TELayerNormColumnParallelLinear (eager, fp32 internals)."""
+    x = inputs.float()
+    x = x * torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + eps)
+    return (x * gamma.float()).to(inputs.dtype)
+
+
+def _new_param(
+    ref_weight: torch.Tensor,
+    shape: tuple[int, ...],
+    *,
+    init: str,
+    grad_sum_group: str | None = None,
+    expert: bool = False,
+) -> nn.Parameter:
+    tensor = torch.empty(*shape, dtype=ref_weight.dtype, device=ref_weight.device)
+    if init == "zero":
+        tensor.zero_()
+    elif tensor.ndim == 2:
+        nn.init.xavier_uniform_(tensor)
+    else:
+        for expert_tensor in tensor:
+            nn.init.xavier_uniform_(expert_tensor)
+    param = nn.Parameter(tensor)
+    param.tensor_model_parallel = False
+    param.partition_dim = -1
+    param.partition_stride = 1
+    if expert:
+        param.allreduce = False
+    if grad_sum_group is not None:
+        # consumed by reduce_marked_lora_grads: replicated adapter grads need an
+        # explicit sum over the tp/ep domain Megatron does not reduce for them
+        param._lora_grad_sum_group = grad_sum_group
+    return param
+
+
+def _register_param(
+    adapter: InklingLoRAAdapter,
+    name: str,
+    ref_weight: torch.Tensor,
+    shape: tuple[int, ...],
+    *,
+    init: str = "zero",
+    grad_sum_group: str | None = None,
+    expert: bool = False,
+) -> None:
+    adapter.register_parameter(
+        name, _new_param(ref_weight, shape, init=init, grad_sum_group=grad_sum_group, expert=expert)
+    )
+
+
+def _dropout(inputs: torch.Tensor, probability: float, training: bool) -> torch.Tensor:
+    if probability and training:
+        return F.dropout(inputs, p=probability, training=True)
+    return inputs
+
+
+def _grouped_linear(inputs: torch.Tensor, weights: torch.Tensor, tokens_per_expert) -> torch.Tensor:
+    """Per-local-expert matmul over the permuted token buffer, one grouped GEMM."""
+    if inputs.is_cuda:
+        offsets = torch.as_tensor(list(tokens_per_expert), device=inputs.device, dtype=torch.int32).cumsum(
+            0, dtype=torch.int32
+        )
+        return F.grouped_mm(inputs, weights.transpose(1, 2), offs=offsets)
+    segments = torch.split(inputs, list(tokens_per_expert), dim=0)
+    return torch.cat([F.linear(segment, weights[idx]) for idx, segment in enumerate(segments)], dim=0)
+
+
+def _gather_sequence_parallel(inputs: torch.Tensor, sequence_parallel: bool) -> torch.Tensor:
+    from megatron.core.tensor_parallel.mappings import gather_from_sequence_parallel_region
+
+    return gather_from_sequence_parallel_region(inputs) if sequence_parallel else inputs
+
+
+def _reduce_row_parallel(partial: torch.Tensor, sequence_parallel: bool) -> torch.Tensor:
+    from megatron.core import parallel_state
+    from megatron.core.tensor_parallel.mappings import (
+        reduce_from_tensor_model_parallel_region,
+        reduce_scatter_to_sequence_parallel_region,
+    )
+
+    if parallel_state.get_tensor_model_parallel_world_size() <= 1:
+        return partial
+    if sequence_parallel:
+        return reduce_scatter_to_sequence_parallel_region(partial)
+    return reduce_from_tensor_model_parallel_region(partial)
+
+
+def _apply_attention_lora(attention, args, hf_prefix: str, *, scale: float, dropout: float, a_init: str) -> None:
+    from megatron.core import parallel_state
+
+    config = attention.config
+    rank = int(args.lora_rank)
+    hidden_size = config.hidden_size
+    eps = config.layernorm_epsilon
+    sequence_parallel = bool(config.sequence_parallel)
+
+    adapter = InklingLoRAAdapter("attn", hf_prefix + "attn.")
+    qkv_ref = attention.linear_qkv.weight
+    for name, out_rows in (
+        ("wq", attention.nh_l * attention.hd),
+        ("wk", attention.nkv_l * attention.hd),
+        ("wv", attention.nkv_l * attention.hd),
+        ("wr", attention.nh_l * attention.d_rel),
+    ):
+        _register_param(adapter, f"{name}_A", qkv_ref, (rank, hidden_size), init=a_init, grad_sum_group="tp")
+        _register_param(adapter, f"{name}_B", qkv_ref, (out_rows, rank))
+    proj_ref = attention.linear_proj.weight
+    _register_param(adapter, "wo_A", proj_ref, (rank, attention.nh_l * attention.hd), init=a_init)
+    _register_param(adapter, "wo_B", proj_ref, (hidden_size, rank), grad_sum_group="tp" if sequence_parallel else None)
+    adapter.load_meta = dict(
+        nh_l=attention.nh_l,
+        nkv_l=attention.nkv_l,
+        hd=attention.hd,
+        d_rel=attention.d_rel,
+        tp_rank=parallel_state.get_tensor_model_parallel_rank(),
+    )
+    attention.lora_adapter = adapter
+
+    qkv = attention.linear_qkv
+    original_qkv = qkv.forward
+
+    def qkv_forward(inputs, *forward_args, **forward_kwargs):
+        output, bias = original_qkv(inputs, *forward_args, **forward_kwargs)
+        normed = _rmsnorm(inputs, qkv.layer_norm_weight, eps)
+        normed = _dropout(_gather_sequence_parallel(normed, sequence_parallel), dropout, qkv.training)
+        joint = F.linear(normed, torch.cat([adapter.wq_A, adapter.wk_A, adapter.wv_A, adapter.wr_A], dim=0))
+        delta = torch.cat(
+            [
+                F.linear(joint[..., 0 * rank : 1 * rank], adapter.wq_B),
+                F.linear(joint[..., 1 * rank : 2 * rank], adapter.wk_B),
+                F.linear(joint[..., 2 * rank : 3 * rank], adapter.wv_B),
+                F.linear(joint[..., 3 * rank : 4 * rank], adapter.wr_B),
+            ],
+            dim=-1,
+        )
+        return torch.add(output, delta, alpha=scale), bias
+
+    qkv.forward = qkv_forward
+
+    proj = attention.linear_proj
+    original_proj = proj.forward
+
+    def proj_forward(inputs, *forward_args, **forward_kwargs):
+        output, bias = original_proj(inputs, *forward_args, **forward_kwargs)
+        local = F.linear(_dropout(inputs, dropout, proj.training), adapter.wo_A)
+        delta = F.linear(_reduce_row_parallel(local, sequence_parallel), adapter.wo_B)
+        return torch.add(output, delta, alpha=scale), bias
+
+    proj.forward = proj_forward
+
+
+def _apply_dense_mlp_lora(mlp, args, hf_prefix: str, *, scale: float, dropout: float, a_init: str) -> None:
+    from megatron.core import parallel_state
+
+    config = mlp.config
+    rank = int(args.lora_rank)
+    hidden_size = config.hidden_size
+    eps = config.layernorm_epsilon
+    sequence_parallel = bool(config.sequence_parallel)
+    dense_intermediate = config.ffn_hidden_size
+    local_intermediate = dense_intermediate // parallel_state.get_tensor_model_parallel_world_size()
+
+    adapter = InklingLoRAAdapter("dense_mlp", hf_prefix + "mlp.")
+    fc1_ref, fc2_ref = mlp.linear_fc1.weight, mlp.linear_fc2.weight
+    _register_param(adapter, "fc1_A", fc1_ref, (rank, hidden_size), init=a_init, grad_sum_group="tp")
+    _register_param(adapter, "fc1_B", fc1_ref, (2 * local_intermediate, rank))
+    _register_param(adapter, "fc2_A", fc2_ref, (rank, local_intermediate), init=a_init)
+    _register_param(adapter, "fc2_B", fc2_ref, (hidden_size, rank), grad_sum_group="tp" if sequence_parallel else None)
+    adapter.load_meta = dict(
+        dense_i=dense_intermediate,
+        i_loc=local_intermediate,
+        tp_rank=parallel_state.get_tensor_model_parallel_rank(),
+    )
+    mlp.lora_adapter = adapter
+
+    fc1 = mlp.linear_fc1
+    original_fc1 = fc1.forward
+
+    def fc1_forward(inputs, *forward_args, **forward_kwargs):
+        output, bias = original_fc1(inputs, *forward_args, **forward_kwargs)
+        normed = _rmsnorm(inputs, fc1.layer_norm_weight, eps)
+        normed = _dropout(_gather_sequence_parallel(normed, sequence_parallel), dropout, fc1.training)
+        delta = F.linear(F.linear(normed, adapter.fc1_A), adapter.fc1_B)
+        return torch.add(output, delta, alpha=scale), bias
+
+    fc1.forward = fc1_forward
+
+    fc2 = mlp.linear_fc2
+    original_fc2 = fc2.forward
+
+    def fc2_forward(inputs, *forward_args, **forward_kwargs):
+        output, bias = original_fc2(inputs, *forward_args, **forward_kwargs)
+        local = F.linear(_dropout(inputs, dropout, fc2.training), adapter.fc2_A)
+        delta = F.linear(_reduce_row_parallel(local, sequence_parallel), adapter.fc2_B)
+        return torch.add(output, delta, alpha=scale), bias
+
+    fc2.forward = fc2_forward
+
+
+def _apply_expert_lora(moe, args, hf_prefix: str, *, scale: float, dropout: float, a_init: str) -> None:
+    from megatron.core import parallel_state
+
+    config = moe.config
+    assert (getattr(config, "expert_tensor_parallel_size", 1) or 1) == 1, "Inkling LoRA assumes ETP=1"
+    rank = int(args.lora_rank)
+    hidden_size = config.hidden_size
+    moe_intermediate = config.moe_ffn_hidden_size
+    experts = moe.experts
+    num_local_experts = experts.num_local_experts
+    is_ep = parallel_state.get_expert_model_parallel_world_size() > 1
+    ep_group = "ep" if is_ep else None
+
+    adapter = InklingLoRAAdapter("experts", hf_prefix + "mlp.experts.")
+    fc1_ref, fc2_ref = experts.linear_fc1.weight0, experts.linear_fc2.weight0
+    _register_param(adapter, "w1_A", fc1_ref, (rank, hidden_size), init=a_init, grad_sum_group=ep_group, expert=is_ep)
+    _register_param(adapter, "w3_A", fc1_ref, (rank, hidden_size), init=a_init, grad_sum_group=ep_group, expert=is_ep)
+    _register_param(adapter, "w1_B", fc1_ref, (num_local_experts, moe_intermediate, rank), expert=is_ep)
+    _register_param(adapter, "w3_B", fc1_ref, (num_local_experts, moe_intermediate, rank), expert=is_ep)
+    _register_param(adapter, "w2_A", fc2_ref, (num_local_experts, rank, moe_intermediate), init=a_init, expert=is_ep)
+    _register_param(adapter, "w2_B", fc2_ref, (hidden_size, rank), grad_sum_group=ep_group, expert=is_ep)
+    adapter.load_meta = dict(
+        e_local=num_local_experts,
+        moe_i=moe_intermediate,
+        ep_rank=parallel_state.get_expert_model_parallel_rank(),
+    )
+    experts.lora_adapter = adapter
+
+    fc1 = experts.linear_fc1
+    original_fc1 = fc1.forward
+
+    def expert_fc1_forward(inputs, tokens_per_expert, *forward_args, **forward_kwargs):
+        output, bias = original_fc1(inputs, tokens_per_expert, *forward_args, **forward_kwargs)
+        dropped = _dropout(inputs, dropout, fc1.training)
+        joint = F.linear(dropped, torch.cat([adapter.w1_A, adapter.w3_A], dim=0))
+        gate = _grouped_linear(joint[..., :rank].contiguous(), adapter.w1_B, tokens_per_expert)
+        up = _grouped_linear(joint[..., rank:].contiguous(), adapter.w3_B, tokens_per_expert)
+        delta = torch.cat([gate, up], dim=-1)
+        return torch.add(output, delta, alpha=scale), bias
+
+    fc1.forward = expert_fc1_forward
+
+    fc2 = experts.linear_fc2
+    original_fc2 = fc2.forward
+
+    def expert_fc2_forward(inputs, tokens_per_expert, *forward_args, **forward_kwargs):
+        output, bias = original_fc2(inputs, tokens_per_expert, *forward_args, **forward_kwargs)
+        inner = _grouped_linear(_dropout(inputs, dropout, fc2.training), adapter.w2_A, tokens_per_expert)
+        delta = F.linear(inner, adapter.w2_B)
+        return torch.add(output, delta, alpha=scale), bias
+
+    fc2.forward = expert_fc2_forward
+
+
+def _apply_shared_experts_lora(shared, args, hf_prefix: str, *, scale: float, dropout: float, a_init: str) -> None:
+    from megatron.core import parallel_state
+
+    config = shared.config
+    rank = int(args.lora_rank)
+    hidden_size = config.hidden_size
+    sequence_parallel = bool(config.sequence_parallel)
+    moe_intermediate = config.moe_ffn_hidden_size
+    local_intermediate = moe_intermediate // parallel_state.get_tensor_model_parallel_world_size()
+    num_shared = len(shared.experts)
+
+    adapter = InklingLoRAAdapter("shared_experts", hf_prefix + "mlp.shared_experts.")
+    fc1_ref = shared.experts[0].linear_fc1.weight
+    fc2_ref = shared.experts[0].linear_fc2.weight
+    _register_param(adapter, "w1_A", fc1_ref, (rank, hidden_size), init=a_init, grad_sum_group="tp")
+    _register_param(adapter, "w3_A", fc1_ref, (rank, hidden_size), init=a_init, grad_sum_group="tp")
+    _register_param(adapter, "w1_B", fc1_ref, (num_shared, local_intermediate, rank))
+    _register_param(adapter, "w3_B", fc1_ref, (num_shared, local_intermediate, rank))
+    _register_param(adapter, "w2_A", fc2_ref, (num_shared, rank, local_intermediate), init=a_init)
+    _register_param(adapter, "w2_B", fc2_ref, (hidden_size, rank), grad_sum_group="tp" if sequence_parallel else None)
+    adapter.load_meta = dict(
+        ns=num_shared,
+        moe_i=moe_intermediate,
+        si_loc=local_intermediate,
+        tp_rank=parallel_state.get_tensor_model_parallel_rank(),
+    )
+    shared.lora_adapter = adapter
+
+    def patch_sub_expert(sub, idx: int) -> None:
+        fc1 = sub.linear_fc1
+        original_fc1 = fc1.forward
+
+        def shared_fc1_forward(inputs, *forward_args, **forward_kwargs):
+            output, bias = original_fc1(inputs, *forward_args, **forward_kwargs)
+            dropped = _dropout(_gather_sequence_parallel(inputs, sequence_parallel), dropout, fc1.training)
+            gate = F.linear(F.linear(dropped, adapter.w1_A), adapter.w1_B[idx])
+            up = F.linear(F.linear(dropped, adapter.w3_A), adapter.w3_B[idx])
+            delta = torch.cat([gate, up], dim=-1)
+            return torch.add(output, delta, alpha=scale), bias
+
+        fc1.forward = shared_fc1_forward
+
+        fc2 = sub.linear_fc2
+        original_fc2 = fc2.forward
+
+        def shared_fc2_forward(inputs, *forward_args, **forward_kwargs):
+            output, bias = original_fc2(inputs, *forward_args, **forward_kwargs)
+            local = F.linear(_dropout(inputs, dropout, fc2.training), adapter.w2_A[idx])
+            delta = F.linear(_reduce_row_parallel(local, sequence_parallel), adapter.w2_B)
+            return torch.add(output, delta, alpha=scale), bias
+
+        fc2.forward = shared_fc2_forward
+
+    for idx, sub in enumerate(shared.experts):
+        patch_sub_expert(sub, idx)
+
+
+def _apply_lm_head_lora(model, args, *, scale: float, dropout: float, a_init: str) -> None:
+    from megatron.core import parallel_state
+
+    if not getattr(model, "post_process", False) or getattr(model, "output_layer", None) is None:
+        return
+
+    config = model.config
+    rank = int(args.lora_rank)
+    hidden_size = config.hidden_size
+    sequence_parallel = bool(config.sequence_parallel)
+    output_layer = model.output_layer
+    vocab_local = output_layer.weight.shape[0]
+    mup = getattr(config.inkling, "logits_mup_width_multiplier", None)
+    mup = float(mup) if mup else None
+
+    adapter = InklingLoRAAdapter("lm_head", "language_model.lm_head.")
+    _register_param(adapter, "head_A", output_layer.weight, (rank, hidden_size), init=a_init, grad_sum_group="tp")
+    _register_param(adapter, "head_B", output_layer.weight, (vocab_local, rank))
+    adapter.load_meta = dict(vocab_local=vocab_local, tp_rank=parallel_state.get_tensor_model_parallel_rank())
+    model.lora_lm_head_adapter = adapter
+
+    original_forward = output_layer.forward
+
+    def lm_head_forward(inputs, *forward_args, **forward_kwargs):
+        output, bias = original_forward(inputs, *forward_args, **forward_kwargs)
+        scaled = inputs / mup if mup else inputs
+        scaled = _dropout(_gather_sequence_parallel(scaled, sequence_parallel), dropout, output_layer.training)
+        delta = F.linear(F.linear(scaled, adapter.head_A), adapter.head_B)
+        return torch.add(output, delta, alpha=scale), bias
+
+    output_layer.forward = lm_head_forward
+
+
+def apply_inkling_lora(model, args):
+    """Attach Inkling LoRA to ONE built model chunk (before Float16Module / DDP wrapping)."""
+    from miles.backends.megatron_utils.lora_utils import patch_param_grad_buffer_for_colocate_mode_lora
+
+    from miles_plugins.models.inkling.layers import InklingDenseMLP, InklingSelfAttention, InklingSharedExperts
+
+    if args.offload_train:
+        # keep adapter param/grad buffers out of the pausable memory-saver region
+        patch_param_grad_buffer_for_colocate_mode_lora()
+
+    rank = int(args.lora_rank)
+    assert rank > 0, "apply_inkling_lora requires --lora-rank > 0"
+    scale = float(args.lora_alpha) / float(rank)
+    dropout = float(getattr(args, "lora_dropout", 0.0) or 0.0)
+    a_init = getattr(args, "lora_A_init_method", "xavier") or "xavier"
+    lora_kwargs = dict(scale=scale, dropout=dropout, a_init=a_init)
+
+    for param in model.parameters():
+        param.requires_grad = False
+
+    for layer in model.decoder.layers:
+        layer_idx = layer.layer_number - 1
+        hf_prefix = f"language_model.layers.{layer_idx}."
+
+        attention = layer.self_attention
+        assert isinstance(
+            attention, InklingSelfAttention
+        ), f"layer {layer_idx}: unexpected attention {type(attention)}"
+        _apply_attention_lora(attention, args, hf_prefix, **lora_kwargs)
+
+        mlp = layer.mlp
+        if isinstance(mlp, InklingDenseMLP):
+            _apply_dense_mlp_lora(mlp, args, hf_prefix, **lora_kwargs)
+        else:
+            _apply_expert_lora(mlp, args, hf_prefix, **lora_kwargs)
+            if mlp.shared_experts is not None:
+                assert isinstance(mlp.shared_experts, InklingSharedExperts)
+                _apply_shared_experts_lora(mlp.shared_experts, args, hf_prefix, **lora_kwargs)
+
+    _apply_lm_head_lora(model, args, **lora_kwargs)
+
+    trainable = sum(param.numel() for param in model.parameters() if param.requires_grad)
+    total = sum(param.numel() for param in model.parameters())
+    logger.info(
+        "[inkling-lora] applied: rank=%d alpha=%s scale=%.3f dropout=%s | trainable %s / %s (%.4f%%)",
+        rank,
+        args.lora_alpha,
+        scale,
+        dropout,
+        f"{trainable:,}",
+        f"{total:,}",
+        100.0 * trainable / max(total, 1),
+    )
+    return model
+
+
+def wrap_model_provider_with_inkling_lora(provider_func, args):
+    """Wrap a miles model provider so every built chunk gets LoRA before DDP wrap."""
+
+    def wrapped(*provider_args, **provider_kwargs):
+        return apply_inkling_lora(provider_func(*provider_args, **provider_kwargs), args)
+
+    return wrapped
+
+
+def _iter_adapters(model_chunks):
+    for chunk in model_chunks:
+        module = chunk
+        while hasattr(module, "module"):
+            module = module.module
+        yield from (m for m in module.modules() if isinstance(m, InklingLoRAAdapter))
+
+
+def _load_attention_adapter(adapter, get_tensor, copy_param) -> None:
+    meta = adapter.load_meta
+    prefix = adapter.hf_prefix
+    tp_rank = meta["tp_rank"]
+    for hf_proj, a_name, b_name, rows in (
+        ("wq_du", "wq_A", "wq_B", meta["nh_l"] * meta["hd"]),
+        ("wk_dv", "wk_A", "wk_B", meta["nkv_l"] * meta["hd"]),
+        ("wv_dv", "wv_A", "wv_B", meta["nkv_l"] * meta["hd"]),
+        ("wr_du", "wr_A", "wr_B", meta["nh_l"] * meta["d_rel"]),
+    ):
+        copy_param(getattr(adapter, a_name), get_tensor(f"{prefix}{hf_proj}.lora_A.weight"))
+        full_b = get_tensor(f"{prefix}{hf_proj}.lora_B.weight")
+        copy_param(getattr(adapter, b_name), full_b[tp_rank * rows : (tp_rank + 1) * rows])
+    full_a = get_tensor(f"{prefix}wo_ud.lora_A.weight")
+    cols = meta["nh_l"] * meta["hd"]
+    copy_param(adapter.wo_A, full_a[:, tp_rank * cols : (tp_rank + 1) * cols])
+    copy_param(adapter.wo_B, get_tensor(f"{prefix}wo_ud.lora_B.weight"))
+
+
+def _load_dense_mlp_adapter(adapter, get_tensor, copy_param) -> None:
+    meta = adapter.load_meta
+    prefix = adapter.hf_prefix
+    tp_rank, dense_i, i_loc = meta["tp_rank"], meta["dense_i"], meta["i_loc"]
+    copy_param(adapter.fc1_A, get_tensor(f"{prefix}gate_up_proj.lora_A.weight"))
+    full_b = get_tensor(f"{prefix}gate_up_proj.lora_B.weight")
+    gate = full_b[:dense_i][tp_rank * i_loc : (tp_rank + 1) * i_loc]
+    up = full_b[dense_i:][tp_rank * i_loc : (tp_rank + 1) * i_loc]
+    copy_param(adapter.fc1_B, torch.cat([gate, up], dim=0))
+    full_a = get_tensor(f"{prefix}down_proj.lora_A.weight")
+    copy_param(adapter.fc2_A, full_a[:, tp_rank * i_loc : (tp_rank + 1) * i_loc])
+    copy_param(adapter.fc2_B, get_tensor(f"{prefix}down_proj.lora_B.weight"))
+
+
+def _load_experts_adapter(adapter, get_tensor, copy_param) -> None:
+    meta = adapter.load_meta
+    prefix = adapter.hf_prefix
+    lo = meta["ep_rank"] * meta["e_local"]
+    hi = lo + meta["e_local"]
+    copy_param(adapter.w1_A, get_tensor(f"{prefix}w1.lora_A.weight").squeeze(0))
+    copy_param(adapter.w3_A, get_tensor(f"{prefix}w3.lora_A.weight").squeeze(0))
+    copy_param(adapter.w1_B, get_tensor(f"{prefix}w1.lora_B.weight")[lo:hi])
+    copy_param(adapter.w3_B, get_tensor(f"{prefix}w3.lora_B.weight")[lo:hi])
+    copy_param(adapter.w2_A, get_tensor(f"{prefix}w2.lora_A.weight")[lo:hi])
+    copy_param(adapter.w2_B, get_tensor(f"{prefix}w2.lora_B.weight").squeeze(0))
+
+
+def _load_shared_experts_adapter(adapter, get_tensor, copy_param) -> None:
+    meta = adapter.load_meta
+    prefix = adapter.hf_prefix
+    tp_rank, num_shared, moe_i, si_loc = meta["tp_rank"], meta["ns"], meta["moe_i"], meta["si_loc"]
+
+    def local_rows(full: torch.Tensor, idx: int) -> torch.Tensor:
+        return full[idx * moe_i + tp_rank * si_loc : idx * moe_i + (tp_rank + 1) * si_loc]
+
+    copy_param(adapter.w1_A, get_tensor(f"{prefix}w1.lora_A.weight"))
+    copy_param(adapter.w3_A, get_tensor(f"{prefix}w3.lora_A.weight"))
+    full_b1 = get_tensor(f"{prefix}w1.lora_B.weight")
+    full_b3 = get_tensor(f"{prefix}w3.lora_B.weight")
+    copy_param(adapter.w1_B, torch.stack([local_rows(full_b1, idx) for idx in range(num_shared)]))
+    copy_param(adapter.w3_B, torch.stack([local_rows(full_b3, idx) for idx in range(num_shared)]))
+    full_a2 = get_tensor(f"{prefix}w2.lora_A.weight")
+    copy_param(
+        adapter.w2_A,
+        torch.stack(
+            [
+                full_a2[:, idx * moe_i + tp_rank * si_loc : idx * moe_i + (tp_rank + 1) * si_loc]
+                for idx in range(num_shared)
+            ]
+        ),
+    )
+    copy_param(adapter.w2_B, get_tensor(f"{prefix}w2.lora_B.weight"))
+
+
+def _load_lm_head_adapter(adapter, get_tensor, copy_param) -> None:
+    meta = adapter.load_meta
+    prefix = adapter.hf_prefix
+    tp_rank, vocab_local = meta["tp_rank"], meta["vocab_local"]
+    copy_param(adapter.head_A, get_tensor(f"{prefix}lora_A.weight"))
+    copy_param(
+        adapter.head_B, get_tensor(f"{prefix}lora_B.weight")[tp_rank * vocab_local : (tp_rank + 1) * vocab_local]
+    )
+
+
+_ADAPTER_LOADERS = {
+    "attn": _load_attention_adapter,
+    "dense_mlp": _load_dense_mlp_adapter,
+    "experts": _load_experts_adapter,
+    "shared_experts": _load_shared_experts_adapter,
+    "lm_head": _load_lm_head_adapter,
+}
+
+
+def load_inkling_lora_adapter(model_chunks, adapter_path):
+    """Load the Inkling HF-format LoRA release into the applied lora params (call AFTER load_checkpoint)."""
+    from safetensors import safe_open
+
+    path = f"{adapter_path}/adapter_model.safetensors"
+    n_loaded = 0
+    with safe_open(path, framework="pt") as f:
+        keys = set(f.keys())
+
+        def get_tensor(name: str) -> torch.Tensor:
+            assert name in keys, f"[inkling-lora] adapter tensor missing: {name}"
+            return f.get_tensor(name)
+
+        def copy_param(param: torch.Tensor, tensor: torch.Tensor) -> None:
+            nonlocal n_loaded
+            assert (
+                param.shape == tensor.shape
+            ), f"[inkling-lora] shape mismatch: param {tuple(param.shape)} vs adapter slice {tuple(tensor.shape)}"
+            with torch.no_grad():
+                param.copy_(tensor.to(dtype=param.dtype, device=param.device))
+            n_loaded += 1
+
+        for adapter in _iter_adapters(model_chunks):
+            _ADAPTER_LOADERS[adapter.kind](adapter, get_tensor, copy_param)
+    logger.info("[inkling-lora] loaded %d lora tensors from %s", n_loaded, adapter_path)
+    return n_loaded
+
+
+class _GatherBatch:
+    """Coalesce the export's per-tensor all_gathers into ONE flat all_gather per (tp|ep) group."""
+
+    class _Token:
+        __slots__ = ("batch", "kind", "index")
+
+        def __init__(self, batch: _GatherBatch, kind: str, index: int) -> None:
+            self.batch = batch
+            self.kind = kind
+            self.index = index
+
+        def get(self) -> torch.Tensor:
+            return self.batch.resolved[self.kind][self.index]
+
+    def __init__(self) -> None:
+        self.requests: dict[str, list[tuple[torch.Tensor, int]]] = {"tp": [], "ep": []}
+        self.resolved: dict[str, list[torch.Tensor]] = {"tp": [], "ep": []}
+
+    def add(self, kind: str, local: torch.Tensor, dim: int) -> _Token:
+        self.requests[kind].append((local, dim))
+        return self._Token(self, kind, len(self.requests[kind]) - 1)
+
+    def num_requests(self) -> int:
+        return sum(len(requests) for requests in self.requests.values())
+
+    def flush(self) -> int:
+        from megatron.core import parallel_state
+
+        groups = {
+            "tp": (
+                parallel_state.get_tensor_model_parallel_group,
+                parallel_state.get_tensor_model_parallel_world_size,
+            ),
+            "ep": (
+                parallel_state.get_expert_model_parallel_group,
+                parallel_state.get_expert_model_parallel_world_size,
+            ),
+        }
+        n_calls = 0
+        for kind, requests in self.requests.items():
+            if not requests:
+                continue
+            get_group, get_world_size = groups[kind]
+            world_size = get_world_size()
+            if world_size == 1:
+                self.resolved[kind] = [local for local, _dim in requests]
+                continue
+            assert len({local.dtype for local, _dim in requests}) == 1, "mixed adapter dtypes"
+            flat_parts = [local.detach().contiguous().reshape(-1) for local, _dim in requests]
+            sizes = [part.numel() for part in flat_parts]
+            flat_local = torch.cat(flat_parts)
+            gathered = flat_local.new_empty(world_size * flat_local.numel())
+            torch.distributed.all_gather_into_tensor(gathered, flat_local, group=get_group())
+            per_rank = gathered.view(world_size, flat_local.numel())
+            offset = 0
+            resolved = []
+            for (local, dim), size in zip(requests, sizes, strict=True):
+                partitions = [per_rank[rank, offset : offset + size].view(local.shape) for rank in range(world_size)]
+                resolved.append(torch.cat(partitions, dim=dim))
+                offset += size
+            self.resolved[kind] = resolved
+            n_calls += 1
+        return n_calls
+
+
+_UNPADDED_VOCAB_CACHE: list = []
+
+
+def _hf_unpadded_vocab_size():
+    """True (unpadded) vocab size from the HF config, or None if absent."""
+    if not _UNPADDED_VOCAB_CACHE:
+        value = None
+        try:
+            from megatron.training import get_args
+
+            with open(os.path.join(get_args().hf_checkpoint, "config.json"), encoding="utf-8") as f:
+                config = json.load(f)
+            value = (config.get("text_config") or config).get("unpadded_vocab_size")
+        except Exception:
+            value = None
+        _UNPADDED_VOCAB_CACHE.append(value)
+    return _UNPADDED_VOCAB_CACHE[0]
+
+
+_ExportPlan = list[tuple[str, torch.Tensor | Callable[[], torch.Tensor]]]
+
+
+def _export_attention(adapter: InklingLoRAAdapter, batch: _GatherBatch) -> _ExportPlan:
+    prefix = adapter.hf_prefix
+    plans: _ExportPlan = []
+    for hf_proj, param_a, param_b in (
+        ("wq_du", adapter.wq_A, adapter.wq_B),
+        ("wk_dv", adapter.wk_A, adapter.wk_B),
+        ("wv_dv", adapter.wv_A, adapter.wv_B),
+        ("wr_du", adapter.wr_A, adapter.wr_B),
+    ):
+        plans.append((f"{prefix}{hf_proj}.lora_A.weight", param_a))
+        plans.append((f"{prefix}{hf_proj}.lora_B.weight", batch.add("tp", param_b, 0).get))
+    plans.append((f"{prefix}wo_ud.lora_A.weight", batch.add("tp", adapter.wo_A, 1).get))
+    plans.append((f"{prefix}wo_ud.lora_B.weight", adapter.wo_B))
+    return plans
+
+
+def _export_dense_mlp(adapter: InklingLoRAAdapter, batch: _GatherBatch) -> _ExportPlan:
+    prefix = adapter.hf_prefix
+    i_loc = adapter.load_meta["i_loc"]
+    gate_token = batch.add("tp", adapter.fc1_B[:i_loc], 0)
+    up_token = batch.add("tp", adapter.fc1_B[i_loc:], 0)
+    return [
+        (f"{prefix}gate_up_proj.lora_A.weight", adapter.fc1_A),
+        (f"{prefix}gate_up_proj.lora_B.weight", lambda: torch.cat([gate_token.get(), up_token.get()], dim=0)),
+        (f"{prefix}down_proj.lora_A.weight", batch.add("tp", adapter.fc2_A, 1).get),
+        (f"{prefix}down_proj.lora_B.weight", adapter.fc2_B),
+    ]
+
+
+def _export_experts(adapter: InklingLoRAAdapter, batch: _GatherBatch) -> _ExportPlan:
+    prefix = adapter.hf_prefix
+    return [
+        (f"{prefix}w1.lora_A.weight", adapter.w1_A.unsqueeze(0)),
+        (f"{prefix}w3.lora_A.weight", adapter.w3_A.unsqueeze(0)),
+        (f"{prefix}w1.lora_B.weight", batch.add("ep", adapter.w1_B, 0).get),
+        (f"{prefix}w3.lora_B.weight", batch.add("ep", adapter.w3_B, 0).get),
+        (f"{prefix}w2.lora_A.weight", batch.add("ep", adapter.w2_A, 0).get),
+        (f"{prefix}w2.lora_B.weight", adapter.w2_B.unsqueeze(0)),
+    ]
+
+
+def _export_shared_experts(adapter: InklingLoRAAdapter, batch: _GatherBatch) -> _ExportPlan:
+    prefix = adapter.hf_prefix
+    num_shared = adapter.load_meta["ns"]
+    b1_tokens = [batch.add("tp", adapter.w1_B[idx], 0) for idx in range(num_shared)]
+    b3_tokens = [batch.add("tp", adapter.w3_B[idx], 0) for idx in range(num_shared)]
+    a2_tokens = [batch.add("tp", adapter.w2_A[idx], 1) for idx in range(num_shared)]
+    return [
+        (f"{prefix}w1.lora_A.weight", adapter.w1_A),
+        (f"{prefix}w3.lora_A.weight", adapter.w3_A),
+        (f"{prefix}w1.lora_B.weight", lambda: torch.cat([token.get() for token in b1_tokens], dim=0)),
+        (f"{prefix}w3.lora_B.weight", lambda: torch.cat([token.get() for token in b3_tokens], dim=0)),
+        (f"{prefix}w2.lora_A.weight", lambda: torch.cat([token.get() for token in a2_tokens], dim=1)),
+        (f"{prefix}w2.lora_B.weight", adapter.w2_B),
+    ]
+
+
+def _export_lm_head(adapter: InklingLoRAAdapter, batch: _GatherBatch) -> _ExportPlan:
+    prefix = adapter.hf_prefix
+    head_b_token = batch.add("tp", adapter.head_B, 0)
+
+    def head_b() -> torch.Tensor:
+        full = head_b_token.get()
+        unpadded = _hf_unpadded_vocab_size()
+        if unpadded and unpadded < full.shape[0]:
+            full = full[:unpadded]
+        return full
+
+    return [
+        (f"{prefix}lora_A.weight", adapter.head_A),
+        (f"{prefix}lora_B.weight", head_b),
+    ]
+
+
+_ADAPTER_EXPORTERS = {
+    "attn": _export_attention,
+    "dense_mlp": _export_dense_mlp,
+    "experts": _export_experts,
+    "shared_experts": _export_shared_experts,
+    "lm_head": _export_lm_head,
+}
+
+
+def export_inkling_lora_hf_named(model_chunks):
+    """Return (hf_name, full_tensor) for every applied lora param, gathered to full HF layout."""
+    start = time.perf_counter()
+    batch = _GatherBatch()
+    plans: _ExportPlan = []
+    for adapter in _iter_adapters(model_chunks):
+        plans.extend(_ADAPTER_EXPORTERS[adapter.kind](adapter, batch))
+
+    n_requests = batch.num_requests()
+    n_calls = batch.flush()
+    named_tensors = [
+        (name, (value() if callable(value) else value).detach().to(torch.bfloat16).contiguous())
+        for name, value in plans
+    ]
+    if torch.distributed.get_rank() == 0:
+        logger.info(
+            "[inkling-lora] adapter export: %d tensors, %d gathers -> %d flat all_gathers, %.1f ms",
+            len(named_tensors),
+            n_requests,
+            n_calls,
+            (time.perf_counter() - start) * 1e3,
+        )
+    return named_tensors

--- a/scripts/run_inkling.py
+++ b/scripts/run_inkling.py
@@ -8,13 +8,19 @@ Supports:
   - Inkling-4layer   4-layer slice for single-node smoke testing.
   - Inkling-Small-4layer  4-layer slice of Inkling-Small (fits the 4-GPU CI lane).
   - Inkling-Small    42-layer 276B MoE. Verified profile: 4 nodes x 8 GPUs
-                          (TP4 SP PP8 EP4, ctx 4096 / response 2048) on H200:
-                          --lr 5e-5, --rollout-batch-size 64 --global-batch-size 128
-                          (reward +0.006/rollout).
+                          (TP4 SP PP8 EP4, ctx 4096 / response 2048) on H200.
+                          Full: --lr 5e-5, --rollout-batch-size 64 --global-batch-size 128
+                          (reward +0.006/rollout). LoRA: --lr 2e-4 with the same batch
+                          shape (reward +0.011/rollout); at the 5e-6 default the
+                          zero-initialised B factors need hundreds of rollouts to
+                          accumulate a visible delta-W, which reads as "not learning".
 
-Full-parameter GRPO: the paused training actor (params, grads, optimizer
-state) spills to node-local NVMe via torch_memory_saver
-(--offload-train-target disk).
+Train modes:
+  - full   Full-parameter GRPO. The paused training actor (params, grads,
+           optimizer state) spills to node-local NVMe via torch_memory_saver
+           (--offload-train-target disk).
+  - lora   LoRA r=32 all-linear. Adapter-only weight sync; plain fp32 Adam;
+           engine serves the adapter natively (triton backend, virtual experts).
 
 Topologies:
   - colocate (default)      engines share the training GPUs; the actor sleeps
@@ -24,8 +30,8 @@ Topologies:
                             generation runs continuously in a background worker).
                             Verified profile: Inkling on 12 nodes x 4 GPUs as
                             8 train + 4 rollout (TP4 PP2 EP16), bf16 grad reduce,
-                            optimizer state streamed through NVMe. Does not
-                            serve eval.
+                            optimizer state streamed through NVMe. Full mode
+                            only; does not serve eval.
 
 Tasks:
   - dapo_math  text (dapo-math-17k), chat template, aime25 eval.
@@ -36,7 +42,7 @@ Usage patterns:
 
   1. Train on pre-staged checkpoints:
        python scripts/run_inkling.py train \
-           --model-name Inkling --task dapo_math \
+           --model-name Inkling --train-mode full --task dapo_math \
            --num-nodes 16 --num-gpus-per-node 4
 
   2. Individual steps (rsync shared -> node-local NVMe, then train):
@@ -77,6 +83,7 @@ class ScriptArgs(U.ExecuteTrainConfig):
     run_id: str = U.create_run_id()
     model_name: Literal["Inkling", "Inkling-4layer", "Inkling-Small", "Inkling-Small-4layer"] = "Inkling"
 
+    train_mode: Literal["full", "lora"] = "full"
     task: Literal["dapo_math", "geo3k"] = "dapo_math"
     fully_async: bool = False
     rollout_num_nodes: int = 4
@@ -103,6 +110,10 @@ class ScriptArgs(U.ExecuteTrainConfig):
     actor_num_nodes: int = field(init=False)
     actor_num_gpus_per_node: int = field(init=False)
 
+    lora_rank: int = 32
+    lora_alpha: int = 32
+    lora_adapter_path: str | None = None
+
     enable_r3: bool = True
 
     extra_args: str = ""
@@ -117,8 +128,9 @@ class ScriptArgs(U.ExecuteTrainConfig):
         if self.torch_dist_local is None:
             self.torch_dist_local = self.torch_dist
         if self.lr is None:
-            self.lr = 1e-6
+            self.lr = 5e-6 if self.train_mode == "lora" else 1e-6
         if self.fully_async:
+            assert self.train_mode == "full", "fully-async is only validated for full-parameter training"
             assert not self.enable_eval, "the fully-async rollout function does not serve eval"
             assert 0 < self.rollout_num_nodes < self.num_nodes
             self.colocate = False
@@ -202,7 +214,7 @@ def _train(args: ScriptArgs):
         if args.fully_async
         else f"{args.num_nodes} nodes (colocate)"
     )
-    print(f"running {args.model_name} full/{args.task} on {topology} x {args.num_gpus_per_node} GPUs")
+    print(f"running {args.model_name} {args.train_mode}/{args.task} on " f"{topology} x {args.num_gpus_per_node} GPUs")
 
     ckpt_args = (
         f"--hf-checkpoint {args.hf_checkpoint} "
@@ -282,30 +294,59 @@ def _train(args: ScriptArgs):
     perf_args = _get_parallel_config(args)
     perf_args += "--recompute-granularity full " "--recompute-method uniform " "--recompute-num-layers 1 "
 
-    if args.fully_async:
-        # disaggregated: nothing to offload, but the optimizer state does not fit
-        # the training GPUs while the step runs, so stream it through NVMe
-        optimizer_args += (
-            "--stream-optimizer-state-to-disk "
-            f"--offload-train-disk-dir {args.train_offload_disk_dir} "
-            "--offload-train-disk-chunk-mb 256 "
-        )
-        sglang_args = (
-            "--rollout-num-gpus-per-engine 16 "
-            "--sglang-mem-fraction-static 0.80 "
-            "--sglang-max-running-requests 128 "
-            "--sglang-max-total-tokens 655360 "
-            "--sglang-cuda-graph-max-bs 128 "
-        )
+    lora_args = ""
+    if args.train_mode == "full":
+        if args.fully_async:
+            # disaggregated: nothing to offload, but the optimizer state does not fit
+            # the training GPUs while the step runs, so stream it through NVMe
+            optimizer_args += (
+                "--stream-optimizer-state-to-disk "
+                f"--offload-train-disk-dir {args.train_offload_disk_dir} "
+                "--offload-train-disk-chunk-mb 256 "
+            )
+        else:
+            optimizer_args += "--offload-train-target disk " f"--offload-train-disk-dir {args.train_offload_disk_dir} "
+        perf_args += "--micro-batch-size 1 "
+        if args.fully_async:
+            sglang_args = (
+                "--rollout-num-gpus-per-engine 16 "
+                "--sglang-mem-fraction-static 0.80 "
+                "--sglang-max-running-requests 128 "
+                "--sglang-max-total-tokens 655360 "
+                "--sglang-cuda-graph-max-bs 128 "
+            )
+        else:
+            sglang_args = (
+                f"--rollout-num-gpus-per-engine {args.rollout_num_gpus_per_engine} "
+                "--sglang-mem-fraction-static 0.6 "
+                "--sglang-max-running-requests 64 "
+                "--sglang-max-total-tokens 327680 "
+            )
     else:
-        optimizer_args += "--offload-train-target disk " f"--offload-train-disk-dir {args.train_offload_disk_dir} "
+        lora_args = (
+            f"--lora-rank {args.lora_rank} "
+            f"--lora-alpha {args.lora_alpha} "
+            "--target-modules all-linear "
+            "--experts-shared-outer-loras "
+            "--sglang-lora-backend triton "
+            "--sglang-lora-use-virtual-experts "
+            "--sglang-max-loras-per-batch 1 "
+            f"--sglang-max-lora-rank {args.lora_rank} "
+        )
+        if args.lora_adapter_path is not None:
+            lora_args += f"--lora-adapter-path {args.lora_adapter_path} "
+        perf_args += "--use-dynamic-batch-size " "--max-tokens-per-gpu 4096 "
         sglang_args = (
             f"--rollout-num-gpus-per-engine {args.rollout_num_gpus_per_engine} "
-            "--sglang-mem-fraction-static 0.6 "
-            "--sglang-max-running-requests 64 "
-            "--sglang-max-total-tokens 327680 "
+            f"--sglang-ep-size {args.rollout_num_gpus_per_engine} "
+            "--sglang-mem-fraction-static 0.65 "
+            "--sglang-max-running-requests 32 "
+            "--sglang-max-total-tokens 320000 "
+            "--sglang-cuda-graph-max-bs 64 "
+            "--sglang-max-mamba-cache-size 256 "
         )
-    perf_args += "--micro-batch-size 1 "
+        if args.rollout_num_gpus_per_engine >= 16:
+            sglang_args += "--no-offload-rollout --no-offload-train "
 
     sglang_args += (
         "--sglang-attention-backend fa4 "
@@ -358,6 +399,7 @@ def _train(args: ScriptArgs):
 
     train_args = (
         f"{ckpt_args} "
+        f"{lora_args} "
         f"{rollout_args} "
         f"{eval_args} "
         f"{grpo_args} "

--- a/tests/e2e/megatron/model_scripts/test_inkling_small_4layer_lora_ci.py
+++ b/tests/e2e/megatron/model_scripts/test_inkling_small_4layer_lora_ci.py
@@ -6,11 +6,15 @@ from tests.ci.metric_history import register_ci_gate
 
 import miles.utils.external_utils.command_utils as U
 
+# Smoke test for scripts/run_inkling.py --train-mode lora on the 4-layer slice:
+# shared-outer grouped-expert LoRA served through SGLang's virtual-experts path, one
+# 4-GPU engine, adapter sync verified by checksum. Functionality, not accuracy.
+
 
 register_cuda_ci(
     est_time=1800,
     suite="stage-c-4-gpu-h200",
-    labels=["megatron", "model-scripts"],
+    labels=["megatron", "model-scripts", "lora"],
 )
 
 register_ci_gate(metric_key="train/grad_norm")
@@ -25,7 +29,7 @@ _MODEL_ORG = "CharyZeng"
 def _args() -> ScriptArgs:
     return ScriptArgs(
         model_name="Inkling-Small-4layer",
-        train_mode="full",
+        train_mode="lora",
         task="dapo_math",
         num_nodes=1,
         num_gpus_per_node=4,
@@ -36,10 +40,11 @@ def _args() -> ScriptArgs:
         extra_args=(
             "--ci-test "
             "--ci-disable-kl-checker "
-            "--check-weight-update-skip-list visual. audio. "
+            # frozen towers and the engine-derived adapter buffers never match the snapshot
+            "--check-weight-update-skip-list visual. audio. ._w1_delta ._a_cat "
             "--ci-disable-logprobs-checker "
             "--disable-weights-backuper "
-            "--offload-train-target cpu "
+            "--check-lora-weight-equal "
         ),
     )
 


### PR DESCRIPTION
Stacked on #1683 (Inkling model + full-parameter RL); this PR adds the LoRA layer on top.

Adapter-only GRPO on the same backend and parallel stack: per-module adapters following Inkling's released LoRA schema (attention, dense MLP, shared-outer routed experts, shared experts, lm head; r=32 all-linear by default). After each step the exporter assembles a serving-ready adapter from the distributed training state (one flat all_gather per TP/EP group + PP broadcast) and hands it to the colocated SGLang engine over CUDA IPC — the frozen base is never re-transferred (weight update 49.4s → 2.5s, train step ~85% of full-parameter). Includes `--lora-train-only`, warm starts via `--lora-adapter-path`, the launcher's `--train-mode lora`, and the 4-layer LoRA CI test with engine-side sha256 verification.

Validated: 4-node Inkling-Small LoRA runs with steadily rising reward and aime25 (wandb `5kb81l5d`, `hxrf9erh`); 4-layer CI green.

https://www.lmsys.org/blog/2026-07-15-inkling-day0-support