### PR TITLE
refactor(session): extract helpers shared by v1 and v2

### DIFF
--- a/miles/rollout/session/core.py
+++ b/miles/rollout/session/core.py
@@ -142,6 +142,92 @@ def proxy_result_to_response(result: dict) -> Response:
     return Response(content=_render_json(data), status_code=status_code, headers=headers, media_type=JSON_MEDIA_TYPE)
 
 
+def prepare_chat_request(body: bytes, args, tito_tokenizer) -> tuple:
+    """Parse and normalize a chat request body — the session-independent half
+    of chat dispatch, shared verbatim by the v1 and v2 cores. Returns
+    ``(request_body, client_stream, tito_tokenizer)``; the tokenizer may be a
+    request-scoped clone.
+    """
+    try:
+        request_body = json.loads(body) if body else {}
+    except json.JSONDecodeError as e:
+        raise MessageValidationError(f"invalid JSON body: {e}") from e
+
+    # Fake streaming: the backend must stay non-streaming (TITO needs the
+    # complete message + meta_info, and sglang rejects return_meta_info
+    # with stream=true), so pop the client's intent here and honor it
+    # when rendering the client response.
+    client_stream = bool(request_body.pop("stream", False))
+    request_body.pop("stream_options", None)
+
+    # TITO token tracking needs Miles-owned input_ids plus SGLang output
+    # metadata: logprobs=True populates meta_info.output_token_logprobs and
+    # return_meta_info wraps it in choice.meta_info. Hardcoded (not
+    # setdefault) so agent-side overrides cannot break token accumulation.
+    request_body["logprobs"] = True
+    request_body["return_meta_info"] = True
+    if getattr(args, "use_rollout_routing_replay", False):
+        request_body["return_routed_experts"] = True
+    if getattr(args, "use_rollout_indexer_replay", False):
+        request_body["return_indexer_topk"] = True
+    # Must be False so stop-token text is trimmed from assistant content;
+    # token IDs still come from logprobs below.
+    request_body["no_stop_trim"] = False
+    # Serve the adapter being trained instead of the base weights.
+    if is_lora_enabled(args):
+        request_body["lora_path"] = LORA_ADAPTER_NAME
+    # FIXME(session): Only nested `chat_template_kwargs` reach the local renderer;
+    # top-level `reasoning` and `reasoning_effort` are not mapped to template kwargs.
+    request_ctk = request_body.get("chat_template_kwargs")
+    if request_ctk is not None and not isinstance(request_ctk, dict):
+        raise MessageValidationError("chat_template_kwargs must be an object")
+    if request_ctk:
+        try:
+            tito_tokenizer = tito_tokenizer.clone_with_chat_template_kwargs(request_ctk)
+        except ValueError as e:
+            raise MessageValidationError(str(e)) from e
+    if tito_tokenizer.chat_template_kwargs:
+        request_body["chat_template_kwargs"] = dict(tito_tokenizer.chat_template_kwargs)
+    else:
+        request_body.pop("chat_template_kwargs", None)
+    return request_body, client_stream, tito_tokenizer
+
+
+def extract_completion(result: dict) -> tuple:
+    """Decode and validate the backend chat response — shared verbatim by the
+    v1 and v2 cores. Returns ``(response, choice, assistant_message,
+    completion_token_ids)``; malformed upstream payloads raise
+    ``UpstreamResponseError``.
+    """
+    response = json.loads(result["response_body"])
+    choice = response.get("choices", [{}])[0]
+
+    meta_info = choice.get("meta_info")
+    if not isinstance(meta_info, dict) or "output_token_logprobs" not in meta_info:
+        raise UpstreamResponseError("meta_info and output_token_logprobs must be in choice (requires logprobs=True)")
+    assistant_message = choice.get("message") or {}
+    if assistant_message.get("content") is None:
+        raise UpstreamResponseError(
+            "assistant message content is None, when tool call parser failed SGLang should still return "
+            "an empty content rather than None. Please check your modified SGLang version."
+        )
+
+    output_token_logprobs = meta_info["output_token_logprobs"]
+    completion_tokens = meta_info["completion_tokens"]
+
+    actual_output_logprobs_len = len(output_token_logprobs)
+    if actual_output_logprobs_len != completion_tokens:
+        raise UpstreamResponseError(
+            "invalid chat completion response: "
+            f"len(output_token_logprobs)={actual_output_logprobs_len} "
+            f"!= completion_tokens={completion_tokens}. "
+            f"Please check whether you use the correct SGLang branch which has fix the tokenizer batch decode issue."
+        )
+
+    completion_token_ids = [t[1] for t in output_token_logprobs]
+    return response, choice, assistant_message, completion_token_ids
+
+
 class SessionCore:
     """HTTP session operations over one ``SessionRegistry``."""
 
@@ -245,50 +331,9 @@ class SessionCore:
             if session.closing:
                 raise SessionNotFoundError(f"session not found: session_id={session_id}")
 
-            try:
-                request_body = json.loads(body) if body else {}
-            except json.JSONDecodeError as e:
-                raise MessageValidationError(f"invalid JSON body: {e}") from e
-
-            # Fake streaming: the backend must stay non-streaming (TITO needs the
-            # complete message + meta_info, and sglang rejects return_meta_info
-            # with stream=true), so pop the client's intent here and honor it
-            # when rendering the client response.
-            client_stream = bool(request_body.pop("stream", False))
-            request_body.pop("stream_options", None)
-
-            # TITO token tracking needs Miles-owned input_ids plus SGLang output
-            # metadata: logprobs=True populates meta_info.output_token_logprobs and
-            # return_meta_info wraps it in choice.meta_info. Hardcoded (not
-            # setdefault) so agent-side overrides cannot break token accumulation.
-            request_body["logprobs"] = True
-            request_body["return_meta_info"] = True
-            if getattr(self.args, "use_rollout_routing_replay", False):
-                request_body["return_routed_experts"] = True
-            if getattr(self.args, "use_rollout_indexer_replay", False):
-                request_body["return_indexer_topk"] = True
-            # Must be False so stop-token text is trimmed from assistant content;
-            # token IDs still come from logprobs below.
-            request_body["no_stop_trim"] = False
-            # Without this the engine serves the base weights, so the adapter being
-            # trained would never shape the trajectories it is scored on.
-            if is_lora_enabled(self.args):
-                request_body["lora_path"] = LORA_ADAPTER_NAME
-            # FIXME(session): Only nested `chat_template_kwargs` reach the local renderer;
-            # top-level `reasoning` and `reasoning_effort` are not mapped to template kwargs.
-            request_ctk = request_body.get("chat_template_kwargs")
-            if request_ctk is not None and not isinstance(request_ctk, dict):
-                raise MessageValidationError("chat_template_kwargs must be an object")
-            tito_tokenizer = self.registry.tito_tokenizer
-            if request_ctk:
-                try:
-                    tito_tokenizer = tito_tokenizer.clone_with_chat_template_kwargs(request_ctk)
-                except ValueError as e:
-                    raise MessageValidationError(str(e)) from e
-            if tito_tokenizer.chat_template_kwargs:
-                request_body["chat_template_kwargs"] = dict(tito_tokenizer.chat_template_kwargs)
-            else:
-                request_body.pop("chat_template_kwargs", None)
+            request_body, client_stream, tito_tokenizer = prepare_chat_request(
+                body, self.args, self.registry.tito_tokenizer
+            )
 
             request_messages = request_body.get("messages", [])
             prompt_token_ids = session.prepare_pretokenized(
@@ -314,34 +359,7 @@ class SessionCore:
         if result["status_code"] != 200:
             return proxy_result_to_response(result)
 
-        response = json.loads(result["response_body"])
-        choice = response.get("choices", [{}])[0]
-
-        meta_info = choice.get("meta_info")
-        if not isinstance(meta_info, dict) or "output_token_logprobs" not in meta_info:
-            raise UpstreamResponseError(
-                "meta_info and output_token_logprobs must be in choice (requires logprobs=True)"
-            )
-        assistant_message = choice.get("message") or {}
-        if assistant_message.get("content") is None:
-            raise UpstreamResponseError(
-                "assistant message content is None, when tool call parser failed SGLang should still return "
-                "an empty content rather than None. Please check your modified SGLang version."
-            )
-
-        output_token_logprobs = meta_info["output_token_logprobs"]
-        completion_tokens = meta_info["completion_tokens"]
-
-        actual_output_logprobs_len = len(output_token_logprobs)
-        if actual_output_logprobs_len != completion_tokens:
-            raise UpstreamResponseError(
-                "invalid chat completion response: "
-                f"len(output_token_logprobs)={actual_output_logprobs_len} "
-                f"!= completion_tokens={completion_tokens}. "
-                f"Please check whether you use the correct SGLang branch which has fix the tokenizer batch decode issue."
-            )
-
-        completion_token_ids = [t[1] for t in output_token_logprobs]
+        response, _, assistant_message, completion_token_ids = extract_completion(result)
 
         # --- Phase 3: update state (lock held briefly) ---
         async with session.lock:

--- a/miles/rollout/session/linear_trajectory.py
+++ b/miles/rollout/session/linear_trajectory.py
@@ -17,6 +17,38 @@ logger = logging.getLogger(__name__)
 MAX_ASSISTANT_ROLLBACK_STEPS = 1
 
 
+def assert_pretokenized_prefix(
+    prev: list[int],
+    all_token_ids: list[int],
+    *,
+    max_trim_tokens: int,
+    request_messages: list[dict[str, Any]],
+    assistant_message: dict[str, Any],
+) -> None:
+    """Stored token_ids must be a prefix of the new checkpoint, tolerating up
+    to *max_trim_tokens* trailing differences. Pure token-level check, shared
+    verbatim by the v1 checkpoint update and the v2 commit."""
+    if not prev:
+        return
+    check_len = len(prev) - max_trim_tokens
+    if check_len > 0 and all_token_ids[:check_len] != prev[:check_len]:
+        first_mismatch = next(
+            (i for i, (a, b) in enumerate(zip(all_token_ids[:check_len], prev[:check_len], strict=True)) if a != b),
+            min(len(all_token_ids), check_len),
+        )
+        raise TokenizationError(
+            f"pretokenized prefix mismatch: "
+            f"stored {len(prev)} tokens (checking first {check_len}, "
+            f"allowing {max_trim_tokens} trailing) are not a prefix of "
+            f"prompt_token_ids + completion_token_ids "
+            f"({len(all_token_ids)} tokens), "
+            f"first mismatch at index {first_mismatch}, "
+            f"matched {first_mismatch}/{check_len} prefix tokens\n"
+            f"request_messages={request_messages}\n"
+            f"assistant_message={assistant_message}"
+        )
+
+
 @dataclass
 class LinearTrajectory:
     """State for a linear trajectory.
@@ -114,30 +146,13 @@ class LinearTrajectory:
         Must be called under ``self.lock``.
         """
         all_token_ids = prompt_token_ids + completion_token_ids
-
-        prev = self.token_ids
-        if prev:
-            check_len = len(prev) - max_trim_tokens
-            if check_len > 0 and all_token_ids[:check_len] != prev[:check_len]:
-                first_mismatch = next(
-                    (
-                        i
-                        for i, (a, b) in enumerate(zip(all_token_ids[:check_len], prev[:check_len], strict=True))
-                        if a != b
-                    ),
-                    min(len(all_token_ids), check_len),
-                )
-                raise TokenizationError(
-                    f"pretokenized prefix mismatch: "
-                    f"stored {len(prev)} tokens (checking first {check_len}, "
-                    f"allowing {max_trim_tokens} trailing) are not a prefix of "
-                    f"prompt_token_ids + completion_token_ids "
-                    f"({len(all_token_ids)} tokens), "
-                    f"first mismatch at index {first_mismatch}, "
-                    f"matched {first_mismatch}/{check_len} prefix tokens\n"
-                    f"request_messages={request_messages}\n"
-                    f"assistant_message={assistant_message}"
-                )
+        assert_pretokenized_prefix(
+            self.token_ids,
+            all_token_ids,
+            max_trim_tokens=max_trim_tokens,
+            request_messages=request_messages,
+            assistant_message=assistant_message,
+        )
 
         self.messages = list(request_messages) + [assistant_message]
         self.trajectory_token_ids.append(all_token_ids)

--- a/tests/fast/router/conftest.py
+++ b/tests/fast/router/conftest.py
@@ -1,0 +1,8 @@
+"""Shared fixtures for router tests.
+
+The class-scoped ``router_env`` (mock SGLang upstream + session server) is
+defined in test_sessions.py; re-exported here so additive test modules can
+depend on it without importing a name their own test signatures would shadow.
+"""
+
+from tests.fast.router.test_sessions import router_env  # noqa: F401

--- a/tests/fast/router/test_sessions.py
+++ b/tests/fast/router/test_sessions.py
@@ -68,8 +68,10 @@ def router_env():
                 chat_template_path=None,
                 apply_chat_template_kwargs={"enable_thinking": False},
                 tito_model="default",
+                sglang_speculative_algorithm=None,
                 trajectory_manager="linear_trajectory",
                 session_server_instance_id=uuid.uuid4().hex,
+                save_debug_trajectory_data=None,
             )
             server_obj = SessionServer(args, backend_url=backend.url)
 

--- a/tests/fast/router/test_sessions_v1_pins.py
+++ b/tests/fast/router/test_sessions_v1_pins.py
@@ -1,0 +1,193 @@
+"""HTTP-level pins for the v1 (linear trajectory) retry/rollback surface.
+
+v1 is the default session server; these pins lock its production behavior
+byte-exactly — every 400 text asserted including interpolated numbers — so
+the opt-in v2 tree server (--use-session-server v2) can never silently
+change the default path. Additive file: the v1 implementation and its
+original test modules stay untouched.
+"""
+
+from unittest.mock import patch
+
+import requests
+from fastapi.responses import JSONResponse
+from tests.fast.router.test_sessions import _create_session, _post_chat
+
+from miles.utils.test_utils.mock_sglang_server import MockSGLangServer
+
+
+class TestRollbackPins:
+    """Byte-exact pins for the rollback dispatch surface (retry semantics)."""
+
+    U1 = {"role": "user", "content": "What is 1+2?"}
+    T1 = {"role": "tool", "content": "tool-result-1", "tool_call_id": "t0"}
+    T1_DIFF = {"role": "tool", "content": "tool-result-DIFFERENT", "tool_call_id": "t0"}
+
+    def _turn(self, url: str, session_id: str, messages: list) -> dict:
+        resp = _post_chat(url, session_id, {"messages": messages})
+        assert resp.status_code == 200
+        return resp.json()["choices"][0]["message"]
+
+    def _get(self, url: str, session_id: str) -> dict:
+        return requests.get(f"{url}/sessions/{session_id}", timeout=5.0).json()
+
+    def _two_turn_session(self, env) -> tuple[str, dict, dict]:
+        """Stored history after this: [U1, a1, T1, a2] with 2 records."""
+        session_id = _create_session(env.url)
+        a1 = self._turn(env.url, session_id, [self.U1])
+        a2 = self._turn(env.url, session_id, [self.U1, a1, self.T1])
+        assert len(self._get(env.url, session_id)["records"]) == 2
+        return session_id, a1, a2
+
+    def test_pure_drop_retry_rolls_back_and_regenerates(self, router_env):
+        session_id, a1, _ = self._two_turn_session(router_env)
+
+        retry = _post_chat(router_env.url, session_id, {"messages": [self.U1, a1, self.T1]})
+
+        assert retry.status_code == 200
+        records = self._get(router_env.url, session_id)["records"]
+        assert len(records) == 2
+        assert records[-1]["request"]["messages"][-1] == self.T1
+
+    def test_divergent_retry_rolls_back_and_continues(self, router_env):
+        session_id, a1, _ = self._two_turn_session(router_env)
+
+        retry = _post_chat(router_env.url, session_id, {"messages": [self.U1, a1, self.T1_DIFF]})
+
+        assert retry.status_code == 200
+        records = self._get(router_env.url, session_id)["records"]
+        assert len(records) == 2
+        assert records[-1]["request"]["messages"][-1] == self.T1_DIFF
+
+    def test_deep_rollback_400_byte_exact_and_state_unchanged(self, router_env):
+        session_id, a1, a2 = self._two_turn_session(router_env)
+        t2 = {"role": "tool", "content": "tool-result-2", "tool_call_id": "t1"}
+        a3 = self._turn(router_env.url, session_id, [self.U1, a1, self.T1, a2, t2])
+        before = self._get(router_env.url, session_id)
+        assert len(before["records"]) == 3
+
+        resp = _post_chat(router_env.url, session_id, {"messages": [self.U1, a1, self.T1_DIFF]})
+
+        assert resp.status_code == 400
+        assert resp.json()["error"] == (
+            "rollback failed: discard_count=2 exceeds max_assistant_rollback_steps=1 "
+            "(stored has 6 messages, request has 3 messages)"
+        )
+        after = self._get(router_env.url, session_id)
+        assert after["records"] == before["records"]
+        assert after["metadata"]["accumulated_token_ids"] == before["metadata"]["accumulated_token_ids"]
+
+        t3 = {"role": "tool", "content": "tool-result-3", "tool_call_id": "t2"}
+        extend = _post_chat(router_env.url, session_id, {"messages": [self.U1, a1, self.T1, a2, t2, a3, t3]})
+        assert extend.status_code == 200
+
+    def test_first_turn_retry_rolls_back_to_empty_and_regenerates(self, router_env):
+        session_id = _create_session(router_env.url)
+        self._turn(router_env.url, session_id, [self.U1])
+
+        resp = _post_chat(router_env.url, session_id, {"messages": [self.U1]})
+
+        assert resp.status_code == 200
+        regenerated = resp.json()["choices"][0]["message"]
+        after = self._get(router_env.url, session_id)
+        assert len(after["records"]) == 1
+        assert after["records"][0]["request"]["messages"] == [self.U1]
+
+        extend = _post_chat(router_env.url, session_id, {"messages": [self.U1, regenerated, self.T1]})
+        assert extend.status_code == 200
+
+    def test_failed_first_turn_then_different_first_request_accepted(self, router_env):
+        """A failed first turn records nothing, so a completely different first
+        request is a fresh first turn and must be accepted — the empty-session
+        accept-anything semantics that later dispatch rewrites must preserve."""
+        session_id = _create_session(router_env.url)
+
+        async def reject(self, request, compute_fn):
+            return JSONResponse(content={"error": "context too long"}, status_code=400)
+
+        with patch.object(MockSGLangServer, "_handle_generate_like_request", new=reject):
+            failed = _post_chat(router_env.url, session_id, {"messages": [self.U1]})
+        assert failed.status_code == 400
+        assert self._get(router_env.url, session_id)["records"] == []
+
+        other_first = {"role": "user", "content": "a completely different opening"}
+        resp = _post_chat(router_env.url, session_id, {"messages": [other_first]})
+        assert resp.status_code == 200
+        records = self._get(router_env.url, session_id)["records"]
+        assert len(records) == 1
+        assert records[0]["request"]["messages"] == [other_first]
+
+    def test_degenerate_extension_resend_exact_history(self, router_env):
+        session_id = _create_session(router_env.url)
+        a1 = self._turn(router_env.url, session_id, [self.U1])
+
+        resend = _post_chat(router_env.url, session_id, {"messages": [self.U1, a1]})
+
+        assert resend.status_code == 200
+        assert len(self._get(router_env.url, session_id)["records"]) == 2
+
+    def test_disallowed_append_role_400_with_rollback_side_effect(self, router_env):
+        session_id, a1, _ = self._two_turn_session(router_env)
+
+        resp = _post_chat(
+            router_env.url, session_id, {"messages": [self.U1, a1, {"role": "developer", "content": "another"}]}
+        )
+
+        assert resp.status_code == 400
+        error = resp.json()["error"]
+        assert error.endswith("; the selected TITO fixed template does not support appending this role")
+        # Characterization: today the rollback mutates BEFORE the append-only
+        # check rejects, and the 400 leaves the rolled-back state behind. Any
+        # future rework of v1 must keep this order.
+        assert len(self._get(router_env.url, session_id)["records"]) == 1
+
+    def test_collect_samples_after_rollback_single_sample(self, router_env):
+        from miles.rollout.session.samples.codec import decode_samples_and_merge_input_sample
+        from miles.utils.types import Sample
+
+        # The class fixture plants fake R3 replay payloads that only the
+        # records path tolerates; assembly would try to decode them. This pin
+        # is about rollback x assembly, so run it with clean meta_info.
+        fixture_response = MockSGLangServer._compute_chat_completions_response
+
+        def clean_meta_response(mock_self, payload: dict) -> dict:
+            response = fixture_response(mock_self, payload)
+            meta = response["choices"][0]["meta_info"]
+            meta.pop("routed_experts", None)
+            meta.pop("indexer_topk", None)
+            return response
+
+        with patch.object(MockSGLangServer, "_compute_chat_completions_response", new=clean_meta_response):
+            session_id, a1, _ = self._two_turn_session(router_env)
+            retry = _post_chat(router_env.url, session_id, {"messages": [self.U1, a1, self.T1]})
+            assert retry.status_code == 200
+
+            resp = requests.post(f"{router_env.url}/sessions/{session_id}/samples", json={}, timeout=10.0)
+
+        assert resp.status_code == 200
+        reply = decode_samples_and_merge_input_sample(resp.content, Sample())
+        assert reply.empty_reason is None
+        assert len(reply.samples) == 1
+        [sample] = reply.samples
+        assert sample.response_length > 0
+        assert len(sample.loss_mask) == sample.response_length
+
+    def test_few_shot_first_request_divergent_retry_uses_generated_checkpoint(self, router_env):
+        """Client-carried assistants stay prompt history, so only the first
+        backend-generated response anchors the divergent retry."""
+        few_shot = [
+            {"role": "user", "content": "Q-few-shot"},
+            {"role": "assistant", "content": "A-few-shot"},
+            {"role": "user", "content": "Q-real"},
+        ]
+        session_id = _create_session(router_env.url)
+        a1 = self._turn(router_env.url, session_id, few_shot)
+        self._turn(router_env.url, session_id, [*few_shot, a1, self.T1])
+        assert len(self._get(router_env.url, session_id)["records"]) == 2
+
+        retry = _post_chat(router_env.url, session_id, {"messages": [*few_shot, a1, self.T1_DIFF]})
+
+        assert retry.status_code == 200
+        records = self._get(router_env.url, session_id)["records"]
+        assert len(records) == 2
+        assert records[-1]["request"]["messages"][-1] == self.T1_DIFF


### PR DESCRIPTION
## Summary

Extract the session primitives shared by linear v1 and tree-serving v2.

## Motivation

Session v2 needs the stable token, serialization, and record-building behavior already exercised by v1, while the default v1 path must keep the same observable behavior.

## Before / After

- **Before / After:** Shared behavior lived inside the linear implementation; it now lives in reusable session helpers while v1 retains its existing call flow.
- **What moved where:** Token and record primitives move into `miles/rollout/session/core.py`.
- Linear trajectory policy remains in `linear_trajectory.py`.

## Behavior Preservation

- **How we know:** `test_sessions_v1_pins.py` adds byte-exact HTTP characterization of the v1 session wire behavior.

## Verification

- **Existing test suite:** The verified CPU suite passed with 269 tests.

## Review Focus

- Scrutinize shared primitive ownership in `core.py`.
- Scrutinize retained v1 policy in `linear_trajectory.py`.
- Scrutinize `test_sessions_v1_pins.py` for exact coverage of the preserved v1 wire behavior.
