### PR TITLE
feat(session): add the trajectory-tree data model

### DIFF
--- a/miles/rollout/session/v2/__init__.py
+++ b/miles/rollout/session/v2/__init__.py
@@ -1,0 +1,5 @@
+"""Session server v2: tree-of-trajectories serving, opt-in via --use-session-server v2.
+
+v1 (linear_trajectory + core) stays the default and is untouched; this package
+holds the entire tree implementation.
+"""

--- a/miles/rollout/session/v2/tree_trajectory.py
+++ b/miles/rollout/session/v2/tree_trajectory.py
@@ -1,0 +1,139 @@
+"""Session-as-forest data model: trajectory nodes and attach-point search.
+
+The forest is append-only and ``seq`` (commit order) is the only ordering
+key. Everything here is synchronous pure data — serving policy,
+concurrency, and tokenization live one layer up in ``session_state``.
+"""
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from miles.rollout.session.types import SessionRecord
+from miles.utils.chat_template_utils import message_matches
+
+MAX_NODES = 1024
+
+
+@dataclass
+class TrajectoryNode:
+    """End of one model generation (SessionRecord is 1:1 with the node)."""
+
+    delta_messages: list[dict[str, Any]]
+    token_ids: list[int]  # full root->node snapshot
+    completion_span: tuple[int, int]  # this node's sampled completion within token_ids
+    seq: int  # per-session logical commit order — THE ordering key
+    committed_at: float  # wall clock, decoration only (NTP-unsafe; never order by this)
+    response_id: str  # upstream response id: the agent-branch <-> leaf join key
+    record: SessionRecord
+    finish_reason: str
+    parent: "TrajectoryNode | None" = None
+    children: list["TrajectoryNode"] = field(default_factory=list, repr=False)
+
+    @property
+    def truncated(self) -> bool:
+        return self.finish_reason == "length"
+
+    def path_nodes(self) -> list["TrajectoryNode"]:
+        nodes: list[TrajectoryNode] = []
+        node: TrajectoryNode | None = self
+        while node is not None:
+            nodes.append(node)
+            node = node.parent
+        nodes.reverse()
+        return nodes
+
+    def path_messages(self) -> list[dict[str, Any]]:
+        return [message for node in self.path_nodes() for message in node.delta_messages]
+
+
+@dataclass(frozen=True)
+class AttachPoint:
+    """Result of matching a request against the tree."""
+
+    node: "TrajectoryNode | None"  # None = new root
+    matched_messages: int  # request messages consumed by the attach node's path
+    best_overlap: int  # diagnostics only: deepest overlap seen, incl. partial deltas
+
+
+class SessionTree:
+    """Forest of trajectory nodes plus the append-only commit surface."""
+
+    def __init__(self) -> None:
+        self.roots: list[TrajectoryNode] = []
+        self.nodes: list[TrajectoryNode] = []  # creation (seq) order
+
+    def leaves(self) -> list[TrajectoryNode]:
+        return [node for node in self.nodes if not node.children]
+
+    def create_node(
+        self,
+        parent: TrajectoryNode | None,
+        *,
+        delta_messages: list[dict[str, Any]],
+        token_ids: list[int],
+        completion_span: tuple[int, int],
+        committed_at: float,
+        response_id: str,
+        record: SessionRecord,
+        finish_reason: str,
+    ) -> TrajectoryNode:
+        if len(self.nodes) >= MAX_NODES:
+            raise ValueError(
+                f"node cap reached ({MAX_NODES}): the session cannot branch or extend "
+                f"further — this almost always means the harness is not replaying "
+                f"history verbatim"
+            )
+        node = TrajectoryNode(
+            delta_messages=list(delta_messages),
+            token_ids=token_ids,
+            completion_span=completion_span,
+            seq=len(self.nodes),
+            committed_at=committed_at,
+            response_id=response_id,
+            record=record,
+            finish_reason=finish_reason,
+            parent=parent,
+        )
+        self.nodes.append(node)
+        if parent is None:
+            self.roots.append(node)
+        else:
+            parent.children.append(node)
+        return node
+
+    def find_attach_point(self, request_messages: list[dict[str, Any]]) -> AttachPoint:
+        """Deepest node whose full path messages are a prefix of the request.
+
+        A node is only entered after its parent's delta is fully consumed;
+        ties on depth (twins whose deltas both match) go to the latest ``seq``.
+        Pure judgment — never mutates the forest.
+        """
+        best: TrajectoryNode | None = None
+        best_matched = -1
+        best_overlap = 0
+
+        def visit(node: TrajectoryNode, offset: int) -> None:
+            nonlocal best, best_matched, best_overlap
+            delta = node.delta_messages
+            i = 0
+            while (
+                i < len(delta)
+                and offset + i < len(request_messages)
+                and message_matches(delta[i], request_messages[offset + i])
+            ):
+                i += 1
+            best_overlap = max(best_overlap, offset + i)
+            if i < len(delta):
+                return  # partial delta: this node (and its subtree) is not a candidate
+            matched = offset + len(delta)
+            if matched > best_matched or (matched == best_matched and best is not None and node.seq > best.seq):
+                best, best_matched = node, matched
+            for child in node.children:
+                visit(child, matched)
+
+        for root in self.roots:
+            visit(root, 0)
+
+        if best is None:
+            return AttachPoint(node=None, matched_messages=0, best_overlap=best_overlap)
+        return AttachPoint(node=best, matched_messages=best_matched, best_overlap=best_overlap)

--- a/miles/rollout/session/v2/tree_trajectory.py
+++ b/miles/rollout/session/v2/tree_trajectory.py
@@ -85,7 +85,7 @@ class SessionTree:
             )
         node = TrajectoryNode(
             delta_messages=list(delta_messages),
-            token_ids=token_ids,
+            token_ids=list(token_ids),
             completion_span=completion_span,
             seq=len(self.nodes),
             committed_at=committed_at,
@@ -112,8 +112,9 @@ class SessionTree:
         best_matched = -1
         best_overlap = 0
 
-        def visit(node: TrajectoryNode, offset: int) -> None:
-            nonlocal best, best_matched, best_overlap
+        stack = [(root, 0) for root in reversed(self.roots)]
+        while stack:
+            node, offset = stack.pop()
             delta = node.delta_messages
             i = 0
             while (
@@ -124,15 +125,11 @@ class SessionTree:
                 i += 1
             best_overlap = max(best_overlap, offset + i)
             if i < len(delta):
-                return  # partial delta: this node (and its subtree) is not a candidate
+                continue  # partial delta: this node (and its subtree) is not a candidate
             matched = offset + len(delta)
             if matched > best_matched or (matched == best_matched and best is not None and node.seq > best.seq):
                 best, best_matched = node, matched
-            for child in node.children:
-                visit(child, matched)
-
-        for root in self.roots:
-            visit(root, 0)
+            stack.extend((child, matched) for child in reversed(node.children))
 
         if best is None:
             return AttachPoint(node=None, matched_messages=0, best_overlap=best_overlap)

--- a/tests/fast/router/test_tree_trajectory.py
+++ b/tests/fast/router/test_tree_trajectory.py
@@ -1,0 +1,180 @@
+"""Unit tests for the trajectory tree: data model + attach-point search.
+
+Pure model level (no serving wiring).
+"""
+
+import pytest
+
+from miles.rollout.session.types import SessionRecord
+from miles.rollout.session.v2 import tree_trajectory
+from miles.rollout.session.v2.tree_trajectory import SessionTree
+
+SYS = {"role": "system", "content": "sys"}
+U1 = {"role": "user", "content": "q1"}
+A1 = {"role": "assistant", "content": "a1"}
+T1 = {"role": "tool", "content": "t1", "tool_call_id": "c1"}
+A2 = {"role": "assistant", "content": "a2"}
+T2 = {"role": "tool", "content": "t2", "tool_call_id": "c2"}
+A3 = {"role": "assistant", "content": "a3"}
+
+
+def _commit(tree, parent, delta, *, finish_reason="stop", committed_at=None):
+    seq = len(tree.nodes)
+    prefix = parent.token_ids if parent is not None else []
+    tokens = prefix + [100 + seq]
+    record = SessionRecord(
+        timestamp=0.0, method="POST", path="/v1/chat/completions", request={}, response={}, status_code=200
+    )
+    return tree.create_node(
+        parent,
+        delta_messages=delta,
+        token_ids=tokens,
+        completion_span=(len(tokens) - 1, len(tokens)),
+        committed_at=committed_at if committed_at is not None else float(seq),
+        response_id=f"resp-{seq}",
+        record=record,
+        finish_reason=finish_reason,
+    )
+
+
+@pytest.fixture
+def linear_tree():
+    """root n0=[sys,u1,a1] -> n1=[t1,a2] -> n2=[t2,a3]"""
+    tree = SessionTree()
+    n0 = _commit(tree, None, [SYS, U1, A1])
+    n1 = _commit(tree, n0, [T1, A2])
+    n2 = _commit(tree, n1, [T2, A3])
+    return tree, n0, n1, n2
+
+
+class TestAttachPoint:
+    def test_case1_strict_leaf_extension(self, linear_tree):
+        tree, _, _, n2 = linear_tree
+        ap = tree.find_attach_point([SYS, U1, A1, T1, A2, T2, A3, {"role": "user", "content": "next"}])
+        assert ap.node is n2
+        assert ap.matched_messages == 7
+
+    def test_case2_degenerate_resend_of_full_path(self, linear_tree):
+        tree, _, _, n2 = linear_tree
+        ap = tree.find_attach_point([SYS, U1, A1, T1, A2, T2, A3])
+        assert ap.node is n2
+        assert ap.matched_messages == 7  # empty suffix: generate a new child of n2
+
+    def test_case3_internal_node_divergence(self, linear_tree):
+        tree, _, n1, _ = linear_tree
+        t2_diff = {"role": "tool", "content": "t2-DIFF", "tool_call_id": "c2"}
+        ap = tree.find_attach_point([SYS, U1, A1, T1, A2, t2_diff])
+        assert ap.node is n1
+        assert ap.matched_messages == 5
+        assert ap.best_overlap == 5
+
+    def test_case4_divergence_inside_child_delta_attaches_parent(self, linear_tree):
+        tree, n0, _, _ = linear_tree
+        t1_diff = {"role": "tool", "content": "t1-DIFF", "tool_call_id": "c1"}
+        ap = tree.find_attach_point([SYS, U1, A1, t1_diff])
+        assert ap.node is n0
+        assert ap.matched_messages == 3
+
+    def test_case4b_divergence_inside_root_delta_is_new_root(self, linear_tree):
+        tree, _, _, _ = linear_tree
+        ap = tree.find_attach_point([SYS, {"role": "user", "content": "other"}])
+        assert ap.node is None
+        assert ap.matched_messages == 0
+        assert ap.best_overlap == 1  # sys matched before the divergence
+
+    def test_case4b_pure_prefix_of_root_delta_is_new_root(self, linear_tree):
+        """Today's no-anchor shape: resend [sys, u1] against stored [sys, u1, a1, ...]."""
+        tree, _, _, _ = linear_tree
+        ap = tree.find_attach_point([SYS, U1])
+        assert ap.node is None
+        assert ap.best_overlap == 2
+
+    def test_case5_foreign_assistant_divergence_attaches_parent(self, linear_tree):
+        """Client rewrote a2 (compaction): the rewritten assistant lands in the
+        new branch's delta; matching just stops before it."""
+        tree, n0, _, _ = linear_tree
+        a2_rewritten = {"role": "assistant", "content": "a2-compacted"}
+        ap = tree.find_attach_point([SYS, U1, A1, T1, a2_rewritten, {"role": "user", "content": "go on"}])
+        assert ap.node is n0
+        assert ap.matched_messages == 3
+        assert ap.best_overlap == 4  # sys,u1,a1 + t1 inside n1's delta
+
+    def test_case6_zero_overlap_is_new_root(self, linear_tree):
+        tree, _, _, _ = linear_tree
+        ap = tree.find_attach_point([{"role": "system", "content": "subagent"}, {"role": "user", "content": "task"}])
+        assert ap.node is None
+        assert ap.best_overlap == 0
+
+    def test_case9_twin_tie_goes_to_latest_seq(self):
+        tree = SessionTree()
+        n0 = _commit(tree, None, [SYS, U1, A1])
+        twin_a = _commit(tree, n0, [T1, A2])
+        twin_b = _commit(tree, n0, [T1, A2])  # same delta text, later seq
+        assert twin_a.seq < twin_b.seq
+        ap = tree.find_attach_point([SYS, U1, A1, T1, A2, {"role": "user", "content": "next"}])
+        assert ap.node is twin_b
+
+    def test_deepest_match_wins_across_roots(self):
+        """Two roots where one's opening is a prefix of the other's history."""
+        tree = SessionTree()
+        r1 = _commit(tree, None, [SYS, U1, A1])
+        n1 = _commit(tree, r1, [T1, A2])
+        _commit(tree, None, [SYS, U1, {"role": "assistant", "content": "other-a1"}])
+        ap = tree.find_attach_point([SYS, U1, A1, T1, A2, T2])
+        assert ap.node is n1
+
+    def test_empty_request_is_new_root(self, linear_tree):
+        tree, _, _, _ = linear_tree
+        ap = tree.find_attach_point([])
+        assert ap.node is None
+        assert ap.best_overlap == 0
+
+    def test_search_never_mutates(self, linear_tree):
+        tree, _, _, _ = linear_tree
+        before = [(n.seq, len(n.children)) for n in tree.nodes]
+        tree.find_attach_point([SYS, U1, A1, T1, A2])
+        assert [(n.seq, len(n.children)) for n in tree.nodes] == before
+
+
+class TestModel:
+    def test_case10_concurrent_commits_become_siblings(self, linear_tree):
+        tree, n0, _, _ = linear_tree
+        s1 = _commit(tree, n0, [{"role": "user", "content": "sub A"}, A2])
+        s2 = _commit(tree, n0, [{"role": "user", "content": "sub B"}, A3])
+        assert s1 in n0.children and s2 in n0.children
+        assert s1.parent is n0 and s2.parent is n0
+
+    def test_full_snapshot_and_path_helpers(self, linear_tree):
+        _, n0, n1, n2 = linear_tree
+        assert n2.token_ids[: len(n1.token_ids)] == n1.token_ids  # snapshot inherits prefix
+        assert n2.path_nodes() == [n0, n1, n2]
+        assert n2.path_messages() == [SYS, U1, A1, T1, A2, T2, A3]
+
+    def test_case7_truncated_is_derived_from_finish_reason(self):
+        tree = SessionTree()
+        node = _commit(tree, None, [U1, A1], finish_reason="length")
+        assert node.truncated
+        assert not _commit(tree, node, [T1, A2]).truncated
+
+    def test_leaves_in_creation_order(self, linear_tree):
+        tree, n0, _, n2 = linear_tree
+        side = _commit(tree, n0, [T1, {"role": "assistant", "content": "retry"}])
+        assert tree.leaves() == [n2, side]
+
+    def test_case12_node_cap_fails_loud(self, monkeypatch):
+        monkeypatch.setattr(tree_trajectory, "MAX_NODES", 2)
+        tree = SessionTree()
+        n0 = _commit(tree, None, [U1, A1])
+        _commit(tree, n0, [T1, A2])
+        with pytest.raises(ValueError, match="node cap reached"):
+            _commit(tree, n0, [T1, A3])
+
+    def test_seq_is_creation_order_not_wall_clock(self):
+        """Wall clock is decoration: ordering must survive a clock step backwards."""
+        tree = SessionTree()
+        n0 = _commit(tree, None, [SYS, U1, A1], committed_at=100.0)
+        early_clock = _commit(tree, n0, [T1, A2], committed_at=50.0)
+        later = _commit(tree, n0, [T1, A2], committed_at=99.0)
+        assert early_clock.seq < later.seq
+        ap = tree.find_attach_point([SYS, U1, A1, T1, A2, T2])
+        assert ap.node is later

--- a/tests/fast/router/test_tree_trajectory.py
+++ b/tests/fast/router/test_tree_trajectory.py
@@ -3,6 +3,8 @@
 Pure model level (no serving wiring).
 """
 
+import sys
+
 import pytest
 
 from miles.rollout.session.types import SessionRecord
@@ -135,6 +137,22 @@ class TestAttachPoint:
         tree.find_attach_point([SYS, U1, A1, T1, A2])
         assert [(n.seq, len(n.children)) for n in tree.nodes] == before
 
+    def test_search_handles_depth_beyond_recursion_limit(self):
+        tree = SessionTree()
+        parent = None
+        for _ in range(tree_trajectory.MAX_NODES):
+            parent = _commit(tree, parent, [U1])
+
+        original_limit = sys.getrecursionlimit()
+        try:
+            sys.setrecursionlimit(tree_trajectory.MAX_NODES // 2)
+            ap = tree.find_attach_point([U1] * tree_trajectory.MAX_NODES)
+        finally:
+            sys.setrecursionlimit(original_limit)
+
+        assert ap.node is parent
+        assert ap.matched_messages == tree_trajectory.MAX_NODES
+
 
 class TestModel:
     def test_case10_concurrent_commits_become_siblings(self, linear_tree):
@@ -149,6 +167,23 @@ class TestModel:
         assert n2.token_ids[: len(n1.token_ids)] == n1.token_ids  # snapshot inherits prefix
         assert n2.path_nodes() == [n0, n1, n2]
         assert n2.path_messages() == [SYS, U1, A1, T1, A2, T2, A3]
+
+    def test_token_snapshot_copies_input(self, linear_tree):
+        tree, n0, _, _ = linear_tree
+        token_ids = n0.token_ids + [999]
+        node = tree.create_node(
+            n0,
+            delta_messages=[T1, A2],
+            token_ids=token_ids,
+            completion_span=(len(n0.token_ids), len(token_ids)),
+            committed_at=3.0,
+            response_id="resp-copy",
+            record=n0.record,
+            finish_reason="stop",
+        )
+
+        token_ids.append(1000)
+        assert node.token_ids == n0.token_ids + [999]
 
     def test_case7_truncated_is_derived_from_finish_reason(self):
         tree = SessionTree()


### PR DESCRIPTION
> **Depends on:** #2123
> Stacked on the parent PR's branch. Review / merge the parent first.

## Summary

Add an append-only trajectory forest with deterministic attach-point search.

## Motivation

Session v2 must retain multiple complete trajectories instead of forcing retries and alternative continuations into one linear history.

## Usage

Use `SessionTree.create_node(parent, ...)` to append a root or child generation, then call `find_attach_point(request_messages)` to select the deepest matching path.

## Design Notes

- **Key choices:** Every node stores a full root-to-node token snapshot.
- Commit sequence `seq` is the deterministic ordering key.
- `MAX_NODES=1024` bounds one session forest.

## Verification

- **Tests added:** `test_tree_trajectory.py` covers the trajectory-tree data-model contract.

## Review Focus

- Scrutinize `SessionTree.find_attach_point` for deepest-prefix and latest-sequence tie-breaking.
- Scrutinize `TrajectoryNode.completion_span` as the loss-mask boundary carried into later layers.
