### PR TITLE
feat(session): add always-branch session state

### DIFF
--- a/miles/rollout/session/errors.py
+++ b/miles/rollout/session/errors.py
@@ -5,6 +5,7 @@ Hierarchy
 SessionError (base)
 ├── SessionNotFoundError       → 404  session does not exist
 ├── MessageValidationError     → 400  messages structure/content invalid
+├── TruncatedGenerationError   → 409  extending a length-truncated generation (v2)
 ├── TokenizationError          → 500  TITO tokenizer / prefix mismatch
 └── UpstreamResponseError      → 502  SGLang response invalid or unexpected
 """
@@ -30,6 +31,14 @@ class MessageValidationError(SessionError):
     """
 
     status_code: int = 400
+
+
+class TruncatedGenerationError(SessionError):
+    """Raised when a request extends a generation that ended with
+    finish_reason='length'; only the v2 tree server raises it (v1 never
+    branches)."""
+
+    status_code: int = 409
 
 
 class TokenizationError(SessionError):

--- a/miles/rollout/session/v2/session_state.py
+++ b/miles/rollout/session/v2/session_state.py
@@ -1,0 +1,214 @@
+"""Session state over the trajectory tree: always-branch serving.
+
+This module is the serving policy on top. A request is never rejected for mismatching stored history and never
+destroys anything: it attaches at the deepest matching node, its unmatched
+suffix becomes the new branch's delta, and whatever is not a clean
+extension just grows a sibling or a new root. Whether a branch was a retry
+is decided later by the sample_picker, not here.
+
+Concurrency contract: single lock on the whole tree. A commit only appends a new
+node under the parent captured at positioning time, so concurrent
+generations from the same spot become sibling nodes instead of a conflict.
+"""
+
+import asyncio
+import logging
+import uuid
+from dataclasses import dataclass, field
+from typing import Any
+
+from miles.rollout.session.errors import MessageValidationError, TokenizationError, TruncatedGenerationError
+from miles.rollout.session.linear_trajectory import SessionRegistry, assert_pretokenized_prefix
+from miles.rollout.session.types import SessionRecord
+from miles.rollout.session.v2.tree_trajectory import SessionTree, TrajectoryNode
+from miles.utils.chat_template_utils.tito_tokenizer import TITOTokenizer
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class SessionStateV2:
+    """Per-session concurrency container plus the trajectory forest.
+
+    ``active_leaf`` is the head of the single-chain view: the path root ->
+    active_leaf is what GET /sessions, judgment, and sample assembly see.
+    ``None`` means no committed generation yet (empty view, first-turn
+    semantics — a failed first turn leaves the session fully retryable).
+    """
+
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock, repr=False, compare=False)
+    closing: bool = field(default=False, repr=False, compare=False)
+    tree: SessionTree = field(default_factory=SessionTree)
+    active_leaf: TrajectoryNode | None = None
+
+    def active_path(self) -> list[TrajectoryNode]:
+        return self.active_leaf.path_nodes() if self.active_leaf is not None else []
+
+    def active_messages(self) -> list[dict[str, Any]]:
+        return self.active_leaf.path_messages() if self.active_leaf is not None else []
+
+    def active_records(self) -> list[SessionRecord]:
+        return [node.record for node in self.active_path()]
+
+    def active_token_ids(self) -> list[int]:
+        return self.active_leaf.token_ids if self.active_leaf is not None else []
+
+
+def position_for_request(state: SessionStateV2, request_messages: list[dict[str, Any]]) -> None:
+    """Move the view (``active_leaf``) to the attach point for *request_messages*."""
+    attach = state.tree.find_attach_point(request_messages)
+
+    if attach.node is not None and attach.node.truncated:
+        raise TruncatedGenerationError(
+            "truncated generation cannot be extended: the matched node ended with "
+            "finish_reason='length' and truncation closes that path for good; "
+            "branch before the cut instead"
+        )
+
+    if attach.node is not state.active_leaf:
+        logger.info(
+            "Branching: request(%d msgs) attaches at node seq=%s "
+            "(matched %d msgs, best overlap %d), tree has %d nodes",
+            len(request_messages),
+            attach.node.seq if attach.node is not None else "<new root>",
+            attach.matched_messages,
+            attach.best_overlap,
+            len(state.tree.nodes),
+        )
+    state.active_leaf = attach.node
+
+
+def prepare_pretokenized(
+    state: SessionStateV2,
+    request_messages: list[dict[str, Any]],
+    *,
+    tools: list[dict[str, Any]] | None,
+    tito_tokenizer: TITOTokenizer,
+) -> list[int]:
+    """Pretokenized input_ids for the positioned view.
+
+    - No attach node: render the whole request from scratch.
+    - Otherwise: reuse the parent's token snapshot as-is and tokenize only
+      the new suffix on top — the shared prefix is never re-rendered.
+    """
+    parent = state.active_leaf
+    if parent is None:
+        return tito_tokenizer.apply_chat_template(
+            request_messages,
+            tools=tools,
+            add_generation_prompt=True,
+            tokenize=True,
+        )
+
+    stored = state.active_messages()
+    _validate_suffix_roles(request_messages[len(stored) :], tito_tokenizer, assistant_exempt=True)
+    return tito_tokenizer.merge_tokens(
+        old_messages=stored,
+        new_messages=request_messages,
+        pretokenized_token_ids=parent.token_ids,
+        tools=tools,
+    )
+
+
+def _validate_suffix_roles(
+    suffix: list[dict[str, Any]],
+    tito_tokenizer: TITOTokenizer,
+    *,
+    assistant_exempt: bool,
+) -> None:
+    """Carried assistants are prompt material for branches; ``assistant_exempt``
+    keeps them outside the template's append-role gate."""
+    allowed = set(tito_tokenizer.allowed_append_roles)
+    if assistant_exempt:
+        allowed |= {"assistant"}
+    for message in suffix:
+        role = message.get("role")
+        if role not in allowed:
+            raise MessageValidationError(
+                f"appended message role={role!r} not allowed "
+                f"(allowed={sorted(set(tito_tokenizer.allowed_append_roles))}); "
+                "the selected TITO fixed template does not support appending this role"
+            )
+
+
+def commit_generation(
+    state: SessionStateV2,
+    *,
+    parent: TrajectoryNode | None,
+    request_messages: list[dict[str, Any]],
+    assistant_message: dict[str, Any],
+    prompt_token_ids: list[int],
+    completion_token_ids: list[int],
+    max_trim_tokens: int,
+    record: SessionRecord,
+    response_id: str,
+    finish_reason: str,
+) -> TrajectoryNode:
+    """Validate and append one generation under *parent* (captured at
+    positioning time), then advance the view to the new node. Prefix
+    validation is byte-identical to the pre-tree checkpoint check."""
+    all_token_ids = prompt_token_ids + completion_token_ids
+    assert_pretokenized_prefix(
+        parent.token_ids if parent is not None else [],
+        all_token_ids,
+        max_trim_tokens=max_trim_tokens,
+        request_messages=request_messages,
+        assistant_message=assistant_message,
+    )
+
+    parent_messages = parent.path_messages() if parent is not None else []
+    delta = list(request_messages[len(parent_messages) :]) + [assistant_message]
+    node = state.tree.create_node(
+        parent,
+        delta_messages=delta,
+        token_ids=all_token_ids,
+        completion_span=(len(prompt_token_ids), len(all_token_ids)),
+        committed_at=record.timestamp,
+        response_id=response_id,
+        record=record,
+        finish_reason=finish_reason,
+    )
+    state.active_leaf = node
+    return node
+
+
+class SessionRegistryV2(SessionRegistry):
+    """Session ID -> session state mapping with shared tokenizer resources.
+
+    The v1 registry shell (CRUD + tokenizer resources) with the session type
+    swapped to ``SessionStateV2``; all session mutations go through the
+    module-level serving functions, called by the route handler under
+    ``SessionStateV2.lock``.
+    """
+
+    sessions: dict[str, SessionStateV2]
+
+    def create_session(self) -> str:
+        session_id = uuid.uuid4().hex
+        self.sessions[session_id] = SessionStateV2()
+        return session_id
+
+    def compute_mismatch(self, messages: list[dict[str, Any]], token_ids: list[int], tools: Any) -> list[dict] | None:
+        """Compare accumulated token IDs against canonical chat template
+        output for one path. Read-only."""
+        if not token_ids:
+            return None
+        try:
+            expected_ids = self.tito_tokenizer.apply_chat_template(
+                messages,
+                tools=tools,
+                add_generation_prompt=False,
+                tokenize=True,
+            )
+            mismatches = self.comparator.compare_sequences(expected_ids, token_ids)
+            return [m.to_dict() for m in mismatches]
+        except Exception as e:
+            raise TokenizationError(f"failed to compute tito_session_mismatch: {e}") from e
+
+    def compute_session_mismatch(self, state: SessionStateV2) -> list[dict] | None:
+        """The active-path view of ``compute_mismatch``."""
+        if state.active_leaf is None:
+            return None
+        records = state.active_records()
+        tools = records[-1].request.get("tools") if records else None
+        return self.compute_mismatch(state.active_messages(), state.active_token_ids(), tools)

--- a/miles/rollout/session/v2/session_state.py
+++ b/miles/rollout/session/v2/session_state.py
@@ -101,7 +101,7 @@ def prepare_pretokenized(
         )
 
     stored = state.active_messages()
-    _validate_suffix_roles(request_messages[len(stored) :], tito_tokenizer, assistant_exempt=True)
+    _validate_suffix_roles(request_messages[len(stored) :], tito_tokenizer)
     return tito_tokenizer.merge_tokens(
         old_messages=stored,
         new_messages=request_messages,
@@ -113,14 +113,8 @@ def prepare_pretokenized(
 def _validate_suffix_roles(
     suffix: list[dict[str, Any]],
     tito_tokenizer: TITOTokenizer,
-    *,
-    assistant_exempt: bool,
 ) -> None:
-    """Carried assistants are prompt material for branches; ``assistant_exempt``
-    keeps them outside the template's append-role gate."""
     allowed = set(tito_tokenizer.allowed_append_roles)
-    if assistant_exempt:
-        allowed |= {"assistant"}
     for message in suffix:
         role = message.get("role")
         if role not in allowed:

--- a/tests/fast/router/test_session_state.py
+++ b/tests/fast/router/test_session_state.py
@@ -1,0 +1,934 @@
+"""Unit tests for SessionRegistryV2 and LinearTrajectory.
+
+Tests the session registry CRUD and the trajectory pretokenized state management
+logic in isolation (no HTTP server, no real tokenizer).
+"""
+
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from miles.rollout.session.errors import MessageValidationError, SessionNotFoundError, TokenizationError
+from miles.rollout.session.types import SessionRecord
+from miles.rollout.session.v2.session_state import (
+    SessionRegistryV2,
+    SessionStateV2,
+    commit_generation,
+    position_for_request,
+    prepare_pretokenized,
+)
+from miles.utils.chat_template_utils.tito_tokenizer import FixedTemplate, TITOTokenizer
+
+_MOCK_FIRST_TURN_TOKENS = [0]
+
+
+class _MockTITOTokenizer(TITOTokenizer):
+    """Stub for unit tests: returns pretokenized_token_ids unchanged (no
+    incremental tokens), renders first-turn prompts as a fixed sentinel, and
+    skips real tokenizer operations.
+    """
+
+    def create_comparator(self):
+        return None
+
+    def apply_chat_template(
+        self,
+        messages: list[dict[str, Any]],
+        *,
+        add_generation_prompt: bool,
+        tools: list[dict[str, Any]] | None = None,
+        tokenize: bool = False,
+    ) -> list[int]:
+        return list(_MOCK_FIRST_TURN_TOKENS)
+
+    def tokenize_additional_messages(
+        self,
+        old_messages: list[dict[str, Any]],
+        new_messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None = None,
+    ) -> list[int]:
+        return []
+
+    def merge_tokens(
+        self,
+        old_messages: list[dict[str, Any]],
+        new_messages: list[dict[str, Any]],
+        pretokenized_token_ids: list[int],
+        tools: list[dict[str, Any]] | None = None,
+    ) -> list[int]:
+        return list(pretokenized_token_ids)
+
+
+def _make_mock_tito(tito_cls, allowed_append_roles: list[str]) -> TITOTokenizer:
+    configured_tito_cls = type(
+        f"_Configured{tito_cls.__name__}",
+        (tito_cls,),
+        {"FIXED_TEMPLATE": FixedTemplate(allowed_append_roles=frozenset(allowed_append_roles))},
+    )
+    return configured_tito_cls(tokenizer=None, assistant_start_str="<|im_start|>assistant")
+
+
+def _make_registry(allowed_append_roles: list[str]) -> SessionRegistryV2:
+    args = SimpleNamespace()
+    mock_tito = _make_mock_tito(_MockTITOTokenizer, allowed_append_roles)
+    return SessionRegistryV2(args, tokenizer=None, tito_tokenizer=mock_tito)
+
+
+def _commit(
+    state: SessionStateV2, request_messages, assistant_message, prompt_ids, completion_ids, *, max_trim_tokens=0
+):
+    """Drive one committed generation through the serving surface (record stub)."""
+    record = SessionRecord(
+        timestamp=float(len(state.tree.nodes)),
+        method="POST",
+        path="/v1/chat/completions",
+        status_code=200,
+        request={"messages": list(request_messages)},
+        response={},
+    )
+    return commit_generation(
+        state,
+        parent=state.active_leaf,
+        request_messages=request_messages,
+        assistant_message=assistant_message,
+        prompt_token_ids=prompt_ids,
+        completion_token_ids=completion_ids,
+        max_trim_tokens=max_trim_tokens,
+        record=record,
+        response_id=f"resp-{len(state.tree.nodes)}",
+        finish_reason="stop",
+    )
+
+
+@pytest.fixture
+def registry():
+    """Tool-only registry (explicit: the ctor default is tool+user)."""
+    return _make_registry(allowed_append_roles=["tool"])
+
+
+@pytest.fixture
+def registry_with_system():
+    """Registry that allows both tool and system in appended messages."""
+    return _make_registry(allowed_append_roles=["tool", "system"])
+
+
+@pytest.fixture
+def registry_with_user():
+    """Registry that allows tool and user in appended messages."""
+    return _make_registry(allowed_append_roles=["tool", "user"])
+
+
+class TestSessionCRUD:
+    def test_create_session(self, registry: SessionRegistryV2):
+        session_id = registry.create_session()
+        assert session_id is not None
+        assert len(session_id) == 32
+        assert session_id in registry.sessions
+
+    def test_get_session(self, registry: SessionRegistryV2):
+        session_id = registry.create_session()
+        session = registry.get_session(session_id)
+        assert session.active_records() == []
+
+    def test_get_session_not_found(self, registry: SessionRegistryV2):
+        with pytest.raises(SessionNotFoundError):
+            registry.get_session("nonexistent")
+
+    def test_remove_session(self, registry: SessionRegistryV2):
+        session_id = registry.create_session()
+        registry.remove_session(session_id)  # no raise = success
+        assert session_id not in registry.sessions
+        with pytest.raises(SessionNotFoundError):
+            registry.remove_session(session_id)
+
+    def test_committed_generation_carries_its_record(self, registry: SessionRegistryV2):
+        session_id = registry.create_session()
+        session = registry.get_session(session_id)
+        node = _commit(session, [{"role": "user", "content": "hello"}], ASSISTANT_MSG_1, [1, 2], [10])
+
+        assert len(session.active_records()) == 1
+        assert session.active_records()[0] is node.record
+        assert session.active_records()[0].path == "/v1/chat/completions"
+
+    def test_append_record_missing_session(self, registry: SessionRegistryV2):
+        with pytest.raises(SessionNotFoundError):
+            registry.get_session("missing")
+
+
+# ---------------------------------------------------------------------------
+# Messages for multi-turn pretokenized tests
+# ---------------------------------------------------------------------------
+
+SYS_MSG = {"role": "system", "content": "You are a helpful assistant."}
+USER_MSG = {"role": "user", "content": "What's the weather in Beijing?"}
+ASSISTANT_MSG_1 = {
+    "role": "assistant",
+    "content": None,
+    "tool_calls": [
+        {"id": "call_1", "type": "function", "function": {"name": "get_weather", "arguments": '{"city": "Beijing"}'}}
+    ],
+}
+TOOL_MSG_1 = {"role": "tool", "content": '{"temperature": 25}', "tool_call_id": "call_1"}
+ASSISTANT_MSG_2 = {
+    "role": "assistant",
+    "content": "It's 25\u00b0C in Beijing. Let me also check Shanghai.",
+    "tool_calls": [
+        {"id": "call_2", "type": "function", "function": {"name": "get_weather", "arguments": '{"city": "Shanghai"}'}}
+    ],
+}
+TOOL_MSG_2 = {"role": "tool", "content": '{"temperature": 30}', "tool_call_id": "call_2"}
+ASSISTANT_MSG_FINAL = {"role": "assistant", "content": "Beijing is 25\u00b0C and Shanghai is 30\u00b0C."}
+RETRY_SYS_MSG = {"role": "system", "content": "Please try using the tools to answer."}
+
+
+class TestSingleUserTurnPretokenized:
+    """Test prepare_pretokenized and update_pretokenized_state across turns."""
+
+    def test_first_turn_renders_from_scratch(self, registry: SessionRegistryV2):
+        """First turn has no prior token_ids, so prepare renders from scratch."""
+        sid = registry.create_session()
+        session = registry.get_session(sid)
+        messages = [SYS_MSG, USER_MSG]
+        result = prepare_pretokenized(session, messages, tools=None, tito_tokenizer=registry.tito_tokenizer)
+        assert result == _MOCK_FIRST_TURN_TOKENS
+
+    def test_two_turn_trajectory(self, registry: SessionRegistryV2):
+        """Full 2-turn: user -> assistant(tool_call) -> tool -> final answer."""
+        sid = registry.create_session()
+        session = registry.get_session(sid)
+
+        # --- Turn 1: [sys, user] -> assistant with tool_call ---
+        turn1_messages = [SYS_MSG, USER_MSG]
+        assert (
+            prepare_pretokenized(session, turn1_messages, tools=None, tito_tokenizer=registry.tito_tokenizer)
+            == _MOCK_FIRST_TURN_TOKENS
+        )
+
+        turn1_prompt_ids = [1, 2, 3, 4, 5]
+        turn1_completion_ids = [10, 11, 12]
+        _commit(session, turn1_messages, ASSISTANT_MSG_1, turn1_prompt_ids, turn1_completion_ids, max_trim_tokens=0)
+
+        assert session.active_messages() == [SYS_MSG, USER_MSG, ASSISTANT_MSG_1]
+        assert session.active_token_ids() == [1, 2, 3, 4, 5, 10, 11, 12]
+
+        # --- Turn 2: [sys, user, assistant, tool] -> final answer ---
+        turn2_messages = [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1]
+        result = prepare_pretokenized(session, turn2_messages, tools=None, tito_tokenizer=registry.tito_tokenizer)
+        assert result == [1, 2, 3, 4, 5, 10, 11, 12]
+
+        turn2_prompt_ids = [1, 2, 3, 4, 5, 10, 11, 12, 20, 21]
+        turn2_completion_ids = [30, 31, 32]
+        _commit(
+            session, turn2_messages, ASSISTANT_MSG_FINAL, turn2_prompt_ids, turn2_completion_ids, max_trim_tokens=0
+        )
+
+        assert session.active_messages() == [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1, ASSISTANT_MSG_FINAL]
+        assert session.active_token_ids() == [1, 2, 3, 4, 5, 10, 11, 12, 20, 21, 30, 31, 32]
+
+    def test_three_turn_trajectory(self, registry: SessionRegistryV2):
+        """Full 3-turn: user -> ass(tool) -> tool -> ass(tool) -> tool -> final."""
+        sid = registry.create_session()
+        session = registry.get_session(sid)
+
+        # Turn 1
+        t1_msgs = [SYS_MSG, USER_MSG]
+        _commit(session, t1_msgs, ASSISTANT_MSG_1, [1, 2, 3], [10, 11], max_trim_tokens=0)
+
+        # Turn 2
+        t2_msgs = [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1]
+        result = prepare_pretokenized(session, t2_msgs, tools=None, tito_tokenizer=registry.tito_tokenizer)
+        assert result == [1, 2, 3, 10, 11]
+
+        _commit(session, t2_msgs, ASSISTANT_MSG_2, [1, 2, 3, 10, 11, 20, 21], [30, 31], max_trim_tokens=0)
+
+        # Turn 3
+        t3_msgs = [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1, ASSISTANT_MSG_2, TOOL_MSG_2]
+        result = prepare_pretokenized(session, t3_msgs, tools=None, tito_tokenizer=registry.tito_tokenizer)
+        assert result == [1, 2, 3, 10, 11, 20, 21, 30, 31]
+
+        _commit(
+            session, t3_msgs, ASSISTANT_MSG_FINAL, [1, 2, 3, 10, 11, 20, 21, 30, 31, 40], [50, 51], max_trim_tokens=0
+        )
+
+        assert len(session.active_messages()) == 7  # sys, user, ass1, tool1, ass2, tool2, final
+        assert session.active_token_ids() == [1, 2, 3, 10, 11, 20, 21, 30, 31, 40, 50, 51]
+
+    def test_prefix_mismatch_raises(self, registry: SessionRegistryV2):
+        """update_pretokenized_state asserts stored token_ids is prefix of new."""
+        sid = registry.create_session()
+        session = registry.get_session(sid)
+        _commit(session, [SYS_MSG, USER_MSG], ASSISTANT_MSG_1, [1, 2, 3], [10, 11], max_trim_tokens=0)
+
+        with pytest.raises(TokenizationError, match="pretokenized prefix mismatch"):
+            _commit(
+                session,
+                [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1],
+                ASSISTANT_MSG_FINAL,
+                [9, 9, 9, 20, 21],  # does NOT start with [1,2,3,10,11]
+                [30],
+                max_trim_tokens=0,
+            )
+
+    def test_disallowed_env_role_in_suffix_raises(self, registry: SessionRegistryV2):
+        """The append-role gate still guards env roles (assistants are exempt:
+        they are prompt material for compaction branches)."""
+        sid = registry.create_session()
+        session = registry.get_session(sid)
+        _commit(session, [SYS_MSG, USER_MSG], ASSISTANT_MSG_1, [1, 2, 3], [10], max_trim_tokens=0)
+
+        bad_messages = [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, {"role": "user", "content": "not allowed here"}]
+        position_for_request(session, bad_messages)
+        with pytest.raises(MessageValidationError, match="role=.user.*allowed="):
+            prepare_pretokenized(session, bad_messages, tools=None, tito_tokenizer=registry.tito_tokenizer)
+
+    def test_session_not_found_raises(self, registry: SessionRegistryV2):
+        with pytest.raises(SessionNotFoundError, match="session not found"):
+            registry.get_session("nonexistent")
+
+    def test_no_system_message(self, registry: SessionRegistryV2):
+        """Works without system message (system is optional)."""
+        sid = registry.create_session()
+        session = registry.get_session(sid)
+        msgs = [USER_MSG]
+        _commit(session, msgs, ASSISTANT_MSG_1, [1, 2], [10], max_trim_tokens=0)
+
+        t2_msgs = [USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1]
+        result = prepare_pretokenized(session, t2_msgs, tools=None, tito_tokenizer=registry.tito_tokenizer)
+        assert result == [1, 2, 10]
+
+    def test_multiple_system_messages_at_start(self, registry: SessionRegistryV2):
+        """Multiple system messages before the user message are allowed (part of stored prefix)."""
+        sid = registry.create_session()
+        session = registry.get_session(sid)
+        extra_sys = {"role": "system", "content": "Extra instructions."}
+        msgs = [SYS_MSG, extra_sys, USER_MSG]
+        result = prepare_pretokenized(session, msgs, tools=None, tito_tokenizer=registry.tito_tokenizer)
+        assert result == _MOCK_FIRST_TURN_TOKENS  # first turn, no prior tokens
+
+        _commit(session, msgs, ASSISTANT_MSG_1, [1, 2, 3, 4], [10, 11], max_trim_tokens=0)
+        assert session.active_messages() == [SYS_MSG, extra_sys, USER_MSG, ASSISTANT_MSG_1]
+
+        t2_msgs = [SYS_MSG, extra_sys, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1]
+        result = prepare_pretokenized(session, t2_msgs, tools=None, tito_tokenizer=registry.tito_tokenizer)
+        assert result == [1, 2, 3, 4, 10, 11]
+
+
+# ---------------------------------------------------------------------------
+# TestAppendRole* — allowed_append_roles policy tests
+#
+# Each class tests one configuration: tool-only, tool+system, tool+user
+# (the ctor default).  Tests verify which appended roles are accepted or
+# rejected under each allowed_append_roles setting.
+# ---------------------------------------------------------------------------
+
+
+class TestAppendRoleToolOnly:
+    """Config: allowed_append_roles=['tool']."""
+
+    def test_tool_append_allowed(self, registry: SessionRegistryV2):
+        sid = registry.create_session()
+        session = registry.get_session(sid)
+        _commit(session, [SYS_MSG, USER_MSG], ASSISTANT_MSG_1, [1, 2, 3], [10], max_trim_tokens=0)
+
+        messages = [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1]
+        result = prepare_pretokenized(session, messages, tools=None, tito_tokenizer=registry.tito_tokenizer)
+        assert isinstance(result, list)
+
+    def test_system_append_rejected(self, registry: SessionRegistryV2):
+        sid = registry.create_session()
+        session = registry.get_session(sid)
+        _commit(session, [SYS_MSG, USER_MSG], ASSISTANT_MSG_1, [1, 2, 3], [10, 11], max_trim_tokens=0)
+
+        messages = [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1, RETRY_SYS_MSG]
+        with pytest.raises(MessageValidationError, match="role='system'.*allowed="):
+            prepare_pretokenized(session, messages, tools=None, tito_tokenizer=registry.tito_tokenizer)
+
+    def test_user_append_rejected(self, registry: SessionRegistryV2):
+        sid = registry.create_session()
+        session = registry.get_session(sid)
+        _commit(session, [SYS_MSG, USER_MSG], ASSISTANT_MSG_1, [1, 2, 3], [10], max_trim_tokens=0)
+
+        messages = [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1, {"role": "user", "content": "extra"}]
+        with pytest.raises(MessageValidationError, match="role='user'.*allowed="):
+            prepare_pretokenized(session, messages, tools=None, tito_tokenizer=registry.tito_tokenizer)
+
+
+class TestAppendRoleToolSystem:
+    """Config: allowed_append_roles=['tool', 'system']."""
+
+    def test_tool_append_allowed(self, registry_with_system: SessionRegistryV2):
+        sid = registry_with_system.create_session()
+        session = registry_with_system.get_session(sid)
+        _commit(session, [SYS_MSG, USER_MSG], ASSISTANT_MSG_1, [1, 2, 3], [10], max_trim_tokens=0)
+
+        messages = [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1]
+        result = prepare_pretokenized(
+            session, messages, tools=None, tito_tokenizer=registry_with_system.tito_tokenizer
+        )
+        assert isinstance(result, list)
+
+    def test_system_append_allowed(self, registry_with_system: SessionRegistryV2):
+        sid = registry_with_system.create_session()
+        session = registry_with_system.get_session(sid)
+        _commit(session, [SYS_MSG, USER_MSG], ASSISTANT_MSG_1, [1, 2, 3], [10, 11], max_trim_tokens=0)
+
+        messages = [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1, RETRY_SYS_MSG]
+        result = prepare_pretokenized(
+            session, messages, tools=None, tito_tokenizer=registry_with_system.tito_tokenizer
+        )
+        assert result == [1, 2, 3, 10, 11]
+
+    def test_system_then_assistant_trajectory(self, registry_with_system: SessionRegistryV2):
+        """Full trajectory with a retry system message between tool-call turns."""
+        sid = registry_with_system.create_session()
+        session = registry_with_system.get_session(sid)
+
+        t1_msgs = [SYS_MSG, USER_MSG]
+        _commit(session, t1_msgs, ASSISTANT_MSG_1, [1, 2, 3], [10, 11], max_trim_tokens=0)
+
+        t2_msgs = [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1, RETRY_SYS_MSG]
+        result = prepare_pretokenized(session, t2_msgs, tools=None, tito_tokenizer=registry_with_system.tito_tokenizer)
+        assert isinstance(result, list)
+
+        _commit(session, t2_msgs, ASSISTANT_MSG_2, [1, 2, 3, 10, 11, 20, 21, 22], [30, 31], max_trim_tokens=0)
+        assert session.active_messages() == [
+            SYS_MSG,
+            USER_MSG,
+            ASSISTANT_MSG_1,
+            TOOL_MSG_1,
+            RETRY_SYS_MSG,
+            ASSISTANT_MSG_2,
+        ]
+
+        t3_msgs = [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1, RETRY_SYS_MSG, ASSISTANT_MSG_2, TOOL_MSG_2]
+        result = prepare_pretokenized(session, t3_msgs, tools=None, tito_tokenizer=registry_with_system.tito_tokenizer)
+        assert isinstance(result, list)
+
+    def test_user_append_rejected(self, registry_with_system: SessionRegistryV2):
+        sid = registry_with_system.create_session()
+        session = registry_with_system.get_session(sid)
+        _commit(session, [SYS_MSG, USER_MSG], ASSISTANT_MSG_1, [1, 2, 3], [10], max_trim_tokens=0)
+
+        messages = [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1, {"role": "user", "content": "extra"}]
+        with pytest.raises(MessageValidationError, match="role='user'.*allowed="):
+            prepare_pretokenized(session, messages, tools=None, tito_tokenizer=registry_with_system.tito_tokenizer)
+
+
+class TestAppendRoleToolUser:
+    """Config: allowed_append_roles=['tool', 'user']; user follow-ups are allowed here."""
+
+    def test_tool_append_allowed(self, registry_with_user: SessionRegistryV2):
+        sid = registry_with_user.create_session()
+        session = registry_with_user.get_session(sid)
+        _commit(session, [SYS_MSG, USER_MSG], ASSISTANT_MSG_1, [1, 2, 3], [10], max_trim_tokens=0)
+
+        messages = [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1]
+        result = prepare_pretokenized(session, messages, tools=None, tito_tokenizer=registry_with_user.tito_tokenizer)
+        assert isinstance(result, list)
+
+    def test_user_append_allowed(self, registry_with_user: SessionRegistryV2):
+        sid = registry_with_user.create_session()
+        session = registry_with_user.get_session(sid)
+        _commit(session, [SYS_MSG, USER_MSG], ASSISTANT_MSG_1, [1, 2, 3], [10], max_trim_tokens=0)
+
+        messages = [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1, {"role": "user", "content": "follow-up"}]
+        result = prepare_pretokenized(session, messages, tools=None, tito_tokenizer=registry_with_user.tito_tokenizer)
+        assert isinstance(result, list)
+
+    def test_user_then_assistant_trajectory(self, registry_with_user: SessionRegistryV2):
+        """Full trajectory: tool → user follow-up → assistant → tool → final."""
+        sid = registry_with_user.create_session()
+        session = registry_with_user.get_session(sid)
+
+        # Turn 1: [sys, user] -> assistant(tool_call)
+        t1_msgs = [SYS_MSG, USER_MSG]
+        _commit(session, t1_msgs, ASSISTANT_MSG_1, [1, 2, 3], [10, 11], max_trim_tokens=0)
+
+        # Turn 2: append tool + user follow-up -> assistant(tool_call)
+        follow_up = {"role": "user", "content": "Also check Shanghai."}
+        t2_msgs = [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1, follow_up]
+        result = prepare_pretokenized(session, t2_msgs, tools=None, tito_tokenizer=registry_with_user.tito_tokenizer)
+        assert isinstance(result, list)
+
+        _commit(session, t2_msgs, ASSISTANT_MSG_2, [1, 2, 3, 10, 11, 20, 21, 22], [30, 31], max_trim_tokens=0)
+        assert session.active_messages() == [
+            SYS_MSG,
+            USER_MSG,
+            ASSISTANT_MSG_1,
+            TOOL_MSG_1,
+            follow_up,
+            ASSISTANT_MSG_2,
+        ]
+
+        # Turn 3: append tool after the second assistant
+        t3_msgs = [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1, follow_up, ASSISTANT_MSG_2, TOOL_MSG_2]
+        result = prepare_pretokenized(session, t3_msgs, tools=None, tito_tokenizer=registry_with_user.tito_tokenizer)
+        assert isinstance(result, list)
+
+    def test_system_append_rejected(self, registry_with_user: SessionRegistryV2):
+        sid = registry_with_user.create_session()
+        session = registry_with_user.get_session(sid)
+        _commit(session, [SYS_MSG, USER_MSG], ASSISTANT_MSG_1, [1, 2, 3], [10, 11], max_trim_tokens=0)
+
+        messages = [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1, RETRY_SYS_MSG]
+        with pytest.raises(MessageValidationError, match="role='system'.*allowed="):
+            prepare_pretokenized(session, messages, tools=None, tito_tokenizer=registry_with_user.tito_tokenizer)
+
+
+class TestCarriedAssistant:
+    """Client-carried assistants in a branch suffix are prompt material and
+    inherit the attach node's snapshot like any other suffix."""
+
+    def test_carried_assistant_before_user_allowed(self):
+        mock_tito = _make_mock_tito(_MockTITOTokenizer, ["tool", "user"])
+        registry = SessionRegistryV2(SimpleNamespace(), tokenizer=None, tito_tokenizer=mock_tito)
+        sid = registry.create_session()
+        session = registry.get_session(sid)
+        _commit(session, [SYS_MSG, USER_MSG], ASSISTANT_MSG_1, [1, 2, 3], [10], max_trim_tokens=0)
+
+        carried = {"role": "assistant", "content": "carried summary"}
+        messages = [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1, carried, {"role": "user", "content": "next"}]
+        result = prepare_pretokenized(session, messages, tools=None, tito_tokenizer=registry.tito_tokenizer)
+        # The mock merge returns the pretokenized prefix unchanged: getting the
+        # snapshot back proves the merge path ran (a from-scratch render would
+        # return the first-turn sentinel) and the view stayed on the parent.
+        assert result == [1, 2, 3, 10]
+        assert session.active_leaf is session.tree.nodes[0]
+
+
+class TestRollback:
+    """Retry handling through the single-chain view over the tree.
+
+    ``judge_and_position`` never destroys anything: a legal one-step retry
+    moves ``active_leaf`` back to the anchor node (abandoned generations stay
+    in the tree, invisible to the view). Byte-level HTTP fidelity is pinned
+    by ``TestRollbackPins`` in ``test_sessions.py``; this suite covers the
+    mechanism."""
+
+    def _dispatch_and_apply(self, state, messages):
+        position_for_request(state, messages)
+
+    def test_rollback_to_first_assistant(self, registry: SessionRegistryV2):
+        """After 2 completions, a divergent retry rolls back to the first checkpoint."""
+        sid = registry.create_session()
+        state = registry.get_session(sid)
+        session = state
+
+        # Turn 1: [sys, user] -> assistant1
+        t1_msgs = [SYS_MSG, USER_MSG]
+        _commit(session, t1_msgs, ASSISTANT_MSG_1, [1, 2, 3], [10, 11], max_trim_tokens=0)
+
+        # Turn 2: [sys, user, asst1, tool1] -> assistant2
+        t2_msgs = [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1]
+        prepare_pretokenized(session, t2_msgs, tools=None, tito_tokenizer=registry.tito_tokenizer)
+        _commit(session, t2_msgs, ASSISTANT_MSG_2, [1, 2, 3, 10, 11, 20, 21], [30, 31], max_trim_tokens=0)
+
+        assert len(session.active_path()) == 2
+        assert len([n.token_ids for n in session.active_path()]) == 2
+
+        # Retry: send [sys, user, asst1, NEW_tool] - diverges after asst1
+        new_tool = {"role": "tool", "content": '{"temperature": 99}', "tool_call_id": "call_1"}
+        rollback_msgs = [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, new_tool]
+        self._dispatch_and_apply(state, rollback_msgs)
+        assert state.active_leaf is state.tree.nodes[0]
+        result = prepare_pretokenized(session, rollback_msgs, tools=None, tito_tokenizer=registry.tito_tokenizer)
+        assert isinstance(result, list)
+
+        # View rolled back to the first generation; the abandoned node stays in the tree
+        assert len(state.tree.nodes) == 2
+        assert len(session.active_path()) == 1
+        assert len([n.token_ids for n in session.active_path()]) == 1
+        assert session.active_token_ids() == [1, 2, 3, 10, 11]
+        assert session.active_messages() == [SYS_MSG, USER_MSG, ASSISTANT_MSG_1]
+
+    def test_multi_step_rollback_raises(self, registry: SessionRegistryV2):
+        """Rollback that discards >1 assistant raises MessageValidationError and leaves state unchanged."""
+        sid = registry.create_session()
+        state = registry.get_session(sid)
+        session = state
+
+        _commit(session, [SYS_MSG, USER_MSG], ASSISTANT_MSG_1, [1, 2, 3], [10, 11], max_trim_tokens=0)
+
+        t2_msgs = [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1]
+        prepare_pretokenized(session, t2_msgs, tools=None, tito_tokenizer=registry.tito_tokenizer)
+        _commit(session, t2_msgs, ASSISTANT_MSG_2, [1, 2, 3, 10, 11, 20, 21], [30, 31], max_trim_tokens=0)
+
+        t3_msgs = [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1, ASSISTANT_MSG_2, TOOL_MSG_2]
+        prepare_pretokenized(session, t3_msgs, tools=None, tito_tokenizer=registry.tito_tokenizer)
+        _commit(
+            session, t3_msgs, ASSISTANT_MSG_FINAL, [1, 2, 3, 10, 11, 20, 21, 30, 31, 40], [50, 51], max_trim_tokens=0
+        )
+
+        assert len(session.active_path()) == 3
+
+        # Snapshot state before attempted rollback
+        prev_messages = list(session.active_messages())
+        prev_token_ids = list([n.token_ids for n in session.active_path()])
+        prev_records = list(session.active_records())
+        prev_num_assistant = len(session.active_path())
+
+        # Deep divergence: the view positions at the deep anchor (node 0) and
+        # NOTHING is destroyed — the abandoned generations stay in the tree.
+        new_tool = {"role": "tool", "content": '{"alt": true}', "tool_call_id": "call_1"}
+        position_for_request(state, [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, new_tool])
+        assert state.active_leaf is state.tree.nodes[0]
+        assert len(state.tree.nodes) == prev_num_assistant  # nothing destroyed
+        assert [n.token_ids for n in state.tree.nodes] == prev_token_ids
+        assert [n.record for n in state.tree.nodes] == prev_records
+        assert state.tree.nodes[2].path_messages() == prev_messages
+
+    def test_rollback_then_continue_full_trajectory(self, registry: SessionRegistryV2):
+        """Rollback and then complete a full new trajectory from the checkpoint."""
+        sid = registry.create_session()
+        state = registry.get_session(sid)
+        session = state
+
+        # Turn 1
+        t1_msgs = [SYS_MSG, USER_MSG]
+        _commit(session, t1_msgs, ASSISTANT_MSG_1, [1, 2, 3], [10, 11], max_trim_tokens=0)
+
+        # Turn 2
+        t2_msgs = [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1]
+        prepare_pretokenized(session, t2_msgs, tools=None, tito_tokenizer=registry.tito_tokenizer)
+        _commit(session, t2_msgs, ASSISTANT_MSG_2, [1, 2, 3, 10, 11, 20], [30], max_trim_tokens=0)
+
+        # Rollback to asst1, send different tool
+        new_tool = {"role": "tool", "content": '{"retry": true}', "tool_call_id": "call_1"}
+        rollback_msgs = [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, new_tool]
+        self._dispatch_and_apply(state, rollback_msgs)
+        result = prepare_pretokenized(session, rollback_msgs, tools=None, tito_tokenizer=registry.tito_tokenizer)
+        assert isinstance(result, list)
+
+        # Continue: complete a new turn from the rolled-back state
+        _commit(session, rollback_msgs, ASSISTANT_MSG_FINAL, [1, 2, 3, 10, 11, 40, 41], [50, 51], max_trim_tokens=0)
+
+        assert len(session.active_path()) == 2
+        assert len([n.token_ids for n in session.active_path()]) == 2
+        assert session.active_token_ids() == [1, 2, 3, 10, 11, 40, 41, 50, 51]
+        assert session.active_messages() == [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, new_tool, ASSISTANT_MSG_FINAL]
+
+    def test_rollback_fewer_messages_than_stored(self, registry_with_system: SessionRegistryV2):
+        """Rollback triggered when request has strictly fewer messages than stored."""
+        sid = registry_with_system.create_session()
+        state = registry_with_system.get_session(sid)
+        session = state
+
+        # Turn 1: [sys, user] -> asst1
+        _commit(session, [SYS_MSG, USER_MSG], ASSISTANT_MSG_1, [1, 2], [10], max_trim_tokens=0)
+
+        # Turn 2: [sys, user, asst1, tool1] -> asst2
+        t2_msgs = [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1]
+        prepare_pretokenized(session, t2_msgs, tools=None, tito_tokenizer=registry_with_system.tito_tokenizer)
+        _commit(session, t2_msgs, ASSISTANT_MSG_2, [1, 2, 10, 20], [30], max_trim_tokens=0)
+        # stored messages: [sys, user, asst1, tool1, asst2] (5 messages)
+
+        # Agent retries with only [sys, user, asst1, sys_retry] (4 messages)
+        retry_msgs = [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, RETRY_SYS_MSG]
+        self._dispatch_and_apply(state, retry_msgs)
+        result = prepare_pretokenized(
+            session, retry_msgs, tools=None, tito_tokenizer=registry_with_system.tito_tokenizer
+        )
+        assert isinstance(result, list)
+
+        assert len(session.active_path()) == 1
+        assert session.active_messages() == [SYS_MSG, USER_MSG, ASSISTANT_MSG_1]
+
+    def test_rollback_to_second_assistant(self, registry: SessionRegistryV2):
+        """Rollback to the second checkpoint (skipping the third)."""
+        sid = registry.create_session()
+        state = registry.get_session(sid)
+        session = state
+
+        # 3 completions
+        _commit(session, [SYS_MSG, USER_MSG], ASSISTANT_MSG_1, [1, 2], [10], max_trim_tokens=0)
+
+        t2 = [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1]
+        prepare_pretokenized(session, t2, tools=None, tito_tokenizer=registry.tito_tokenizer)
+        _commit(session, t2, ASSISTANT_MSG_2, [1, 2, 10, 20], [30], max_trim_tokens=0)
+
+        t3 = [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1, ASSISTANT_MSG_2, TOOL_MSG_2]
+        prepare_pretokenized(session, t3, tools=None, tito_tokenizer=registry.tito_tokenizer)
+        _commit(session, t3, ASSISTANT_MSG_FINAL, [1, 2, 10, 20, 30, 40], [50], max_trim_tokens=0)
+
+        assert len(session.active_path()) == 3
+
+        # Rollback: keep up to asst2, diverge at tool2
+        new_tool = {"role": "tool", "content": '{"alt": 1}', "tool_call_id": "call_2"}
+        rollback_msgs = [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1, ASSISTANT_MSG_2, new_tool]
+        self._dispatch_and_apply(state, rollback_msgs)
+        assert state.active_leaf is state.tree.nodes[1]
+        result = prepare_pretokenized(session, rollback_msgs, tools=None, tito_tokenizer=registry.tito_tokenizer)
+        assert isinstance(result, list)
+
+        assert len(session.active_path()) == 2
+        assert len([n.token_ids for n in session.active_path()]) == 2
+        assert session.active_token_ids() == [1, 2, 10, 20, 30]
+        assert session.active_messages() == [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1, ASSISTANT_MSG_2]
+
+    def test_no_rollback_when_append_only(self, registry: SessionRegistryV2):
+        """Normal append-only flow classifies as EXTEND and mutates nothing."""
+        sid = registry.create_session()
+        state = registry.get_session(sid)
+        session = state
+
+        _commit(session, [SYS_MSG, USER_MSG], ASSISTANT_MSG_1, [1, 2], [10], max_trim_tokens=0)
+
+        # Append tool - not a rollback
+        t2_msgs = [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1]
+        position_for_request(state, t2_msgs)
+        assert state.active_leaf is state.tree.nodes[0]
+        result = prepare_pretokenized(session, t2_msgs, tools=None, tito_tokenizer=registry.tito_tokenizer)
+        assert isinstance(result, list)
+
+        # State should NOT have been rolled back
+        assert len(session.active_path()) == 1
+        assert len([n.token_ids for n in session.active_path()]) == 1
+        assert session.active_token_ids() == [1, 2, 10]
+
+    def test_rollback_no_assistant_in_prefix_raises(self, registry: SessionRegistryV2):
+        """Dispatch rejects when no assistant anchor exists in the matched prefix."""
+        sid = registry.create_session()
+        state = registry.get_session(sid)
+        session = state
+        _commit(session, [SYS_MSG, USER_MSG], ASSISTANT_MSG_1, [1, 2], [10], max_trim_tokens=0)
+
+        # Diverge inside the root delta: nothing fully matches, so the request
+        # opens a new root (the old chain stays intact in the tree).
+        bad_msgs = [SYS_MSG, {"role": "user", "content": "different question"}]
+        position_for_request(state, bad_msgs)
+        assert state.active_leaf is None
+        assert len(state.tree.nodes) == 1
+
+    def test_rollback_shrinks_record_view_in_sync(self, registry: SessionRegistryV2):
+        """The record view shrinks in sync with the token view on rollback."""
+        sid = registry.create_session()
+        state = registry.get_session(sid)
+        session = state
+
+        _commit(session, [SYS_MSG, USER_MSG], ASSISTANT_MSG_1, [1, 2], [10], max_trim_tokens=0)
+        t2 = [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1]
+        prepare_pretokenized(session, t2, tools=None, tito_tokenizer=registry.tito_tokenizer)
+        _commit(session, t2, ASSISTANT_MSG_2, [1, 2, 10, 20], [30], max_trim_tokens=0)
+
+        assert len(session.active_records()) == 2
+
+        new_tool = {"role": "tool", "content": '{"alt": 1}', "tool_call_id": "call_1"}
+        self._dispatch_and_apply(state, [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, new_tool])
+
+        assert len(session.active_records()) == 1
+        assert session.active_records()[0] is state.tree.nodes[0].record
+
+
+class TestJudgmentCountingMatrix:
+    """Counting matrix for the single-chain judgment: the step unit is the
+    GENERATION (tree node), not the message — client-carried foreign
+    assistants live inside a node's delta and are never anchors (the shape
+    the prompt-assistant fix pinned)."""
+
+    FS_USER_2 = {"role": "user", "content": "the real question"}
+
+    def _fresh(self, registry):
+        sid = registry.create_session()
+        state = registry.get_session(sid)
+        return state, state
+
+    def _two_turns(self, registry):
+        """stored: [sys, user, asst1, tool1, asst2]; 2 generations."""
+        state, session = self._fresh(registry)
+        _commit(session, [SYS_MSG, USER_MSG], ASSISTANT_MSG_1, [1, 2], [10], max_trim_tokens=0)
+        t2 = [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1]
+        prepare_pretokenized(session, t2, tools=None, tito_tokenizer=registry.tito_tokenizer)
+        _commit(session, t2, ASSISTANT_MSG_2, [1, 2, 10, 20], [30], max_trim_tokens=0)
+        return state, session
+
+    def test_empty_view_extends_anything(self, registry: SessionRegistryV2):
+        state, _ = self._fresh(registry)
+        position_for_request(state, [USER_MSG])
+        assert state.active_leaf is None
+
+    def test_strict_extension_leaves_view_alone(self, registry: SessionRegistryV2):
+        state, _ = self._two_turns(registry)
+        request = [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1, ASSISTANT_MSG_2, TOOL_MSG_2]
+        position_for_request(state, request)
+        assert state.active_leaf is state.tree.nodes[1]
+
+    def test_degenerate_equal_history_is_extend(self, registry: SessionRegistryV2):
+        state, _ = self._two_turns(registry)
+        request = [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1, ASSISTANT_MSG_2]
+        position_for_request(state, request)
+        assert state.active_leaf is state.tree.nodes[1]
+
+    def test_pure_drop_one_generation(self, registry: SessionRegistryV2):
+        """Dropping asst2 (and nothing else) is one step even though the
+        request also re-sends tool1: 2 messages beyond the anchor, 1 generation."""
+        state, _ = self._two_turns(registry)
+        position_for_request(state, [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1])
+        assert state.active_leaf is state.tree.nodes[0]
+
+    def test_divergent_one_generation(self, registry: SessionRegistryV2):
+        state, _ = self._two_turns(registry)
+        new_tool = {"role": "tool", "content": '{"alt": 1}', "tool_call_id": "call_1"}
+        position_for_request(state, [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, new_tool])
+        assert state.active_leaf is state.tree.nodes[0]
+        assert state.active_messages() == [SYS_MSG, USER_MSG, ASSISTANT_MSG_1]
+
+    def test_deep_divergence_two_generations_rejected(self, registry: SessionRegistryV2):
+        state, session = self._two_turns(registry)
+        t3 = [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1, ASSISTANT_MSG_2, TOOL_MSG_2]
+        prepare_pretokenized(session, t3, tools=None, tito_tokenizer=registry.tito_tokenizer)
+        _commit(session, t3, ASSISTANT_MSG_FINAL, [1, 2, 10, 20, 30, 40], [50], max_trim_tokens=0)
+
+        new_tool = {"role": "tool", "content": '{"alt": 1}', "tool_call_id": "call_1"}
+        position_for_request(state, [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, new_tool])
+        assert state.active_leaf is state.tree.nodes[0]  # deep anchor, no destruction
+
+    def test_no_anchor(self, registry: SessionRegistryV2):
+        state, session = self._fresh(registry)
+        _commit(session, [SYS_MSG, USER_MSG], ASSISTANT_MSG_1, [1, 2], [10], max_trim_tokens=0)
+        position_for_request(state, [SYS_MSG, {"role": "user", "content": "different"}])
+        assert state.active_leaf is None  # new root; old chain intact
+        assert len(state.tree.nodes) == 1
+
+    def test_prompt_assistant_is_not_an_anchor(self, registry: SessionRegistryV2):
+        """Few-shot first request: the anchor is the generation boundary, and
+        a divergent retry drops exactly one generation (historically this
+        computed discard_count=0 and kept a stale checkpoint)."""
+        state, session = self._fresh(registry)
+        few_shot = [USER_MSG, ASSISTANT_MSG_1, self.FS_USER_2]
+        _commit(session, few_shot, ASSISTANT_MSG_2, [1, 2], [10], max_trim_tokens=0)
+        t2 = [*few_shot, ASSISTANT_MSG_2, TOOL_MSG_2]
+        prepare_pretokenized(session, t2, tools=None, tito_tokenizer=registry.tito_tokenizer)
+        _commit(session, t2, ASSISTANT_MSG_FINAL, [1, 2, 10, 20], [30], max_trim_tokens=0)
+        # stored: [user, fs_asst, user2, asst2, tool2, final]; generations: asst2, final
+
+        new_tool = {"role": "tool", "content": '{"alt": 1}', "tool_call_id": "call_2"}
+        position_for_request(state, [*few_shot, ASSISTANT_MSG_2, new_tool])
+        assert state.active_leaf is state.tree.nodes[0]
+        assert state.active_messages() == [*few_shot, ASSISTANT_MSG_2]
+
+    def test_prefix_with_only_prompt_assistants_has_no_anchor(self, registry: SessionRegistryV2):
+        state, session = self._fresh(registry)
+        few_shot = [USER_MSG, ASSISTANT_MSG_1, self.FS_USER_2]
+        _commit(session, few_shot, ASSISTANT_MSG_2, [1, 2], [10], max_trim_tokens=0)
+
+        position_for_request(state, [USER_MSG, ASSISTANT_MSG_1, {"role": "user", "content": "changed"}])
+        assert state.active_leaf is None  # divergence inside the root delta opens a new root
+
+
+class TestUpdatePretokenizedStateMissingSession:
+    """update_pretokenized_state raises SessionNotFoundError for unknown session."""
+
+    def test_raises_on_missing_session(self, registry: SessionRegistryV2):
+        with pytest.raises(SessionNotFoundError, match="session not found"):
+            registry.get_session("nonexistent")
+
+
+class TestComputeSessionMismatch:
+    """Tests for compute_session_mismatch."""
+
+    def test_raises_for_missing_session(self, registry: SessionRegistryV2):
+        with pytest.raises(SessionNotFoundError):
+            registry.get_session("nonexistent")
+
+    def test_returns_none_for_empty_token_ids(self, registry: SessionRegistryV2):
+        sid = registry.create_session()
+        session = registry.get_session(sid)
+        assert registry.compute_session_mismatch(session) is None
+
+    def test_returns_empty_list_when_no_mismatch(self, registry: SessionRegistryV2):
+        sid = registry.create_session()
+        session = registry.get_session(sid)
+        _commit(session, [SYS_MSG, USER_MSG], ASSISTANT_MSG_1, [1, 2, 3], [10, 11], max_trim_tokens=0)
+
+        # Simulate: template returns same IDs as stored
+        registry.tito_tokenizer.apply_chat_template = MagicMock(return_value=[1, 2, 3, 10, 11])
+
+        # Need a real comparator; replace the None one
+        mock_comparator = MagicMock()
+        mock_comparator.compare_sequences.return_value = []
+        registry.comparator = mock_comparator
+
+        result = registry.compute_session_mismatch(session)
+        assert result == []
+        mock_comparator.compare_sequences.assert_called_once_with([1, 2, 3, 10, 11], [1, 2, 3, 10, 11])
+        registry.tito_tokenizer.apply_chat_template.assert_called_once_with(
+            session.active_messages(),
+            tools=None,
+            add_generation_prompt=False,
+            tokenize=True,
+        )
+
+    def test_returns_mismatch_dicts(self, registry: SessionRegistryV2):
+        sid = registry.create_session()
+        session = registry.get_session(sid)
+        _commit(session, [SYS_MSG, USER_MSG], ASSISTANT_MSG_1, [1, 2, 3], [10, 11], max_trim_tokens=0)
+
+        registry.tito_tokenizer.apply_chat_template = MagicMock(return_value=[1, 2, 99, 10, 11])
+
+        @dataclass
+        class FakeMismatch:
+            position: int
+
+            def to_dict(self):
+                return {"position": self.position, "detail": "mismatch"}
+
+        mock_comparator = MagicMock()
+        mock_comparator.compare_sequences.return_value = [FakeMismatch(position=2)]
+        registry.comparator = mock_comparator
+
+        result = registry.compute_session_mismatch(session)
+        assert result == [{"position": 2, "detail": "mismatch"}]
+
+    def test_raises_tokenization_error_on_exception(self, registry: SessionRegistryV2):
+        sid = registry.create_session()
+        session = registry.get_session(sid)
+        _commit(session, [SYS_MSG, USER_MSG], ASSISTANT_MSG_1, [1, 2, 3], [10, 11], max_trim_tokens=0)
+
+        registry.tito_tokenizer.apply_chat_template = MagicMock(side_effect=RuntimeError("tokenizer failed"))
+
+        with pytest.raises(TokenizationError, match="tokenizer failed"):
+            registry.compute_session_mismatch(session)
+
+    def test_uses_tools_from_last_record(self, registry: SessionRegistryV2):
+        sid = registry.create_session()
+        session = registry.get_session(sid)
+        _commit(session, [SYS_MSG, USER_MSG], ASSISTANT_MSG_1, [1, 2], [10], max_trim_tokens=0)
+
+        tools = [{"type": "function", "function": {"name": "get_weather"}}]
+        record = SessionRecord(
+            timestamp=1.0,
+            method="POST",
+            path="/v1/chat/completions",
+            status_code=200,
+            request={"tools": tools},
+            response={},
+        )
+        t2 = [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1]
+        commit_generation(
+            session,
+            parent=session.active_leaf,
+            request_messages=t2,
+            assistant_message=ASSISTANT_MSG_2,
+            prompt_token_ids=[1, 2, 10, 20],
+            completion_token_ids=[30],
+            max_trim_tokens=0,
+            record=record,
+            response_id="resp-tools",
+            finish_reason="stop",
+        )
+
+        mock_tokenize = MagicMock(return_value=[1, 2, 10])
+        registry.tito_tokenizer.apply_chat_template = mock_tokenize
+        mock_comparator = MagicMock()
+        mock_comparator.compare_sequences.return_value = []
+        registry.comparator = mock_comparator
+
+        registry.compute_session_mismatch(session)
+
+        # Verify tools were passed to the TITO renderer.
+        _, kwargs = mock_tokenize.call_args
+        assert kwargs["tools"] == tools
+        assert kwargs["add_generation_prompt"] is False

--- a/tests/fast/router/test_session_state.py
+++ b/tests/fast/router/test_session_state.py
@@ -1,4 +1,4 @@
-"""Unit tests for SessionRegistryV2 and LinearTrajectory.
+"""Unit tests for SessionRegistryV2 and SessionStateV2.
 
 Tests the session registry CRUD and the trajectory pretokenized state management
 logic in isolation (no HTTP server, no real tokenizer).

--- a/tests/fast/router/test_session_state.py
+++ b/tests/fast/router/test_session_state.py
@@ -483,7 +483,7 @@ class TestCarriedAssistant:
     inherit the attach node's snapshot like any other suffix."""
 
     def test_carried_assistant_before_user_allowed(self):
-        mock_tito = _make_mock_tito(_MockTITOTokenizer, ["tool", "user"])
+        mock_tito = _make_mock_tito(_MockTITOTokenizer, ["tool", "user", "assistant"])
         registry = SessionRegistryV2(SimpleNamespace(), tokenizer=None, tito_tokenizer=mock_tito)
         sid = registry.create_session()
         session = registry.get_session(sid)
@@ -497,6 +497,21 @@ class TestCarriedAssistant:
         # return the first-turn sentinel) and the view stayed on the parent.
         assert result == [1, 2, 3, 10]
         assert session.active_leaf is session.tree.nodes[0]
+
+    def test_carried_assistant_rejected_without_template_support(self, registry_with_user):
+        sid = registry_with_user.create_session()
+        session = registry_with_user.get_session(sid)
+        _commit(session, [SYS_MSG, USER_MSG], ASSISTANT_MSG_1, [1, 2, 3], [10], max_trim_tokens=0)
+
+        carried = {"role": "assistant", "content": "carried summary"}
+        messages = [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1, carried, {"role": "user", "content": "next"}]
+        with pytest.raises(MessageValidationError, match="role='assistant'.*allowed="):
+            prepare_pretokenized(
+                session,
+                messages,
+                tools=None,
+                tito_tokenizer=registry_with_user.tito_tokenizer,
+            )
 
 
 class TestRollback:


### PR DESCRIPTION
> **Depends on:** #2124
> Stacked on the parent PR's branch. Review / merge the parent first.

## Summary

Add session state that turns mismatched histories into branches instead of destructive retries.

## Motivation

Alternative agent continuations need to coexist as complete trajectories; positioning a new request must not delete or overwrite an earlier branch.

## Usage

Call `position_for_request(state, messages)` to select the deepest matching parent, then pass that parent to `commit_generation(...)` to append the new generation.

## Design Notes

- **Key choices:** `active_leaf` exposes one linear view over the retained forest.
- Commits append beneath the parent captured before generation.
- A truncated node rejects extension with `TruncatedGenerationError`.

## Verification

- **Tests added:** `test_session_state.py` covers the complete always-branch state contract.

## Review Focus

- Scrutinize `position_for_request` for branch selection without tree mutation.
- Scrutinize `commit_generation` for append-only concurrency semantics.
- Scrutinize `prepare_pretokenized` for byte-exact prefix reuse.
