### PR TITLE
feat(session): serve trajectory trees behind session server v2

### DIFF
--- a/miles/rollout/session/core.py
+++ b/miles/rollout/session/core.py
@@ -318,8 +318,8 @@ class SessionCore:
 
         Flow: prepare pretokenized input_ids (lock held briefly) → proxy to
         backend (NO lock) → validate response → update trajectory checkpoint and
-        append record (lock held briefly). The lock is NOT held during the slow
-        proxy call so DELETE/other ops are not blocked if the agent disconnects.
+        append record (lock held briefly). The lock is NOT held during the long
+        inference call so DELETE/other ops are not blocked if the agent disconnects.
         """
         request_timestamp = time.time()
         session = self.registry.get_session(session_id)

--- a/miles/rollout/session/samples/codec.py
+++ b/miles/rollout/session/samples/codec.py
@@ -3,6 +3,8 @@
 Only fields in `SAMPLES_VALUE_SPEC` cross the wire. `encode_samples` packs them
 into safetensors; `decode_samples_and_merge_input_sample` overlays them onto a
 deepcopy of the input sample and merges server metadata.
+
+Tree-serving v2 selects `SAMPLES_VALUE_SPEC_V2` to carry `Sample.reward`.
 """
 
 import dataclasses
@@ -41,14 +43,22 @@ SAMPLES_VALUE_SPEC: dict[str, ValueSpec] = {
     "metadata": ValueSpec("json"),
 }
 
-# The wire allowlist, derived: only table fields cross the samples wire.
+# Tree-serving v2 adds `Sample.reward` to the wire.
+SAMPLES_VALUE_SPEC_V2: dict[str, ValueSpec] = {
+    **SAMPLES_VALUE_SPEC,
+    "reward": ValueSpec("json"),
+}
+
+# The wire allowlists, derived: only table fields cross the samples wire.
 COMPUTED_FIELDS = tuple(SAMPLES_VALUE_SPEC)
+COMPUTED_FIELDS_V2 = tuple(SAMPLES_VALUE_SPEC_V2)
 
 assert all(
-    spec.codec in ("tensor", "tensor_list", "json") for spec in SAMPLES_VALUE_SPEC.values()
+    spec.codec in ("tensor", "tensor_list", "json") for spec in SAMPLES_VALUE_SPEC_V2.values()
 ), "unknown codec in SAMPLES_VALUE_SPEC"
 
-_TENSOR_FIELDS = frozenset(field for field, spec in SAMPLES_VALUE_SPEC.items() if spec.codec != "json")
+_TENSOR_FIELDS = frozenset(field for field, spec in SAMPLES_VALUE_SPEC_V2.items() if spec.codec != "json")
+assert _TENSOR_FIELDS <= set(COMPUTED_FIELDS), "every tensor field must be on the v1 wire too"
 
 _SAMPLES_META_KEY = "_samples_meta"
 _OPD_STUDENT_TOP_LOGPROBS_KEY = "opd_student_top_logprobs"
@@ -75,14 +85,26 @@ def _asarray_wire(field: str, value, dtype: np.dtype) -> np.ndarray:
     return converted
 
 
-def encode_samples(samples: list[Sample], session_metadata: dict, empty_reason: str | None = None) -> bytes:
-    """Server side: pack assembled samples into one safetensors payload."""
+def encode_samples(
+    samples: list[Sample],
+    session_metadata: dict,
+    empty_reason: str | None = None,
+    *,
+    fields: tuple[str, ...] = COMPUTED_FIELDS,
+) -> bytes:
+    """Server side: pack assembled samples into one safetensors payload.
+
+    ``fields`` selects the wire allowlist (v1 default; the v2 server passes
+    ``COMPUTED_FIELDS_V2``) — with the default, the payload is byte-identical
+    to the pre-parameterized codec.
+    """
     tensors: dict[str, np.ndarray] = {}
     sample_metas = []
     for sample_index, sample in enumerate(samples):
         sample_meta: dict = {}
         nulls: list[str] = []
-        for field, spec in SAMPLES_VALUE_SPEC.items():
+        for field in fields:
+            spec = SAMPLES_VALUE_SPEC_V2[field]
             value = getattr(sample, field)
             if spec.codec == "json":
                 if field == "status":
@@ -112,8 +134,15 @@ def encode_samples(samples: list[Sample], session_metadata: dict, empty_reason: 
     return safetensors.numpy.save(tensors)
 
 
-def decode_samples_and_merge_input_sample(payload: bytes, input_sample: Sample) -> SamplesReply:
-    """Driver side: overlay each wire sample's computed fields onto a deepcopy of `input_sample`."""
+def decode_samples_and_merge_input_sample(
+    payload: bytes, input_sample: Sample, *, fields: tuple[str, ...] = COMPUTED_FIELDS
+) -> SamplesReply:
+    """Driver side: overlay each wire sample's computed fields onto a deepcopy of `input_sample`.
+
+    ``fields`` must match the server's encode allowlist (v1 default); extra
+    keys a newer server sent are ignored, so a v1 decode of a v2 payload
+    keeps exactly the v1 overlay semantics.
+    """
     tensors = safetensors.numpy.load(payload)  # SafetensorError propagates: invalid container
     meta_arr = tensors.pop(_SAMPLES_META_KEY)  # KeyError propagates: missing meta is malformed
     if meta_arr.ndim != 1 or meta_arr.dtype != np.uint8:
@@ -129,7 +158,8 @@ def decode_samples_and_merge_input_sample(payload: bytes, input_sample: Sample) 
         nulls = set(sample_meta["nulls"])  # KeyError propagates: missing null markers are malformed
         if nulls - _TENSOR_FIELDS:
             raise ValueError(f"null markers reference non-tensor fields: {sorted(nulls - _TENSOR_FIELDS)}")
-        for field, spec in SAMPLES_VALUE_SPEC.items():
+        for field in fields:
+            spec = SAMPLES_VALUE_SPEC_V2[field]
             if spec.codec == "json":
                 value = sample_meta[field]
                 if field == "status":
@@ -138,6 +168,11 @@ def decode_samples_and_merge_input_sample(payload: bytes, input_sample: Sample) 
                     value = list(value)
                 elif field == "prefix_cache_info":
                     value = Sample.PrefixCacheInfo.from_dict(value)
+                elif field == "reward":
+                    # Server reward is authoritative only when assigned; a null
+                    # keeps the driver input's local reward.
+                    if value is None:
+                        continue
                 elif field == "metadata":
                     if not isinstance(value, dict):
                         raise ValueError(f"metadata must be a JSON object, got {type(value).__name__}")

--- a/miles/rollout/session/sessions.py
+++ b/miles/rollout/session/sessions.py
@@ -37,8 +37,16 @@ def setup_session_routes(app, backend, args):
         chat_template_kwargs=getattr(args, "apply_chat_template_kwargs", None),
     )
 
-    registry = SessionRegistry(args, tokenizer, tito_tokenizer=tito_tokenizer)
-    core = SessionCore(backend, registry, args, session_server_instance_id)
+    use_v2 = getattr(args, "use_session_server", None) == "v2"
+    if use_v2:
+        from miles.rollout.session.v2.core import SessionCoreV2
+        from miles.rollout.session.v2.session_state import SessionRegistryV2
+
+        registry = SessionRegistryV2(args, tokenizer, tito_tokenizer=tito_tokenizer)
+        core = SessionCoreV2(backend, registry, args, session_server_instance_id)
+    else:
+        registry = SessionRegistry(args, tokenizer, tito_tokenizer=tito_tokenizer)
+        core = SessionCore(backend, registry, args, session_server_instance_id)
 
     @app.exception_handler(SessionError)
     async def session_error_handler(request: Request, exc: SessionError):
@@ -77,10 +85,11 @@ def setup_session_routes(app, backend, args):
         # Parse here so malformed input is not reported as an assembly error (422).
         body = await request.body()
         params = json.loads(body) if body else {}
-        return await core.collect_samples(
-            session_id,
-            max_seq_len=params.get("max_seq_len"),
-        )
+        if use_v2:
+            return await core.collect_samples(
+                session_id, max_seq_len=params.get("max_seq_len"), agent_metadata=params.get("metadata")
+            )
+        return await core.collect_samples(session_id, max_seq_len=params.get("max_seq_len"))
 
     @app.api_route("/sessions/{session_id}/{path:path}", methods=["GET", "POST", "PUT", "DELETE", "PATCH"])
     async def session_proxy(request: Request, session_id: str, path: str):

--- a/miles/rollout/session/v2/core.py
+++ b/miles/rollout/session/v2/core.py
@@ -1,0 +1,210 @@
+import json
+import logging
+import time
+
+from starlette.responses import Response
+
+from miles.rollout.session.core import (
+    JSON_MEDIA_TYPE,
+    ProxyRequest,
+    SessionCore,
+    _chat_client_response,
+    _render_json,
+    _samples_response,
+    extract_completion,
+    prepare_chat_request,
+    proxy_result_to_response,
+)
+from miles.rollout.session.errors import SessionNotFoundError, TokenizationError
+from miles.rollout.session.samples.codec import COMPUTED_FIELDS_V2, encode_samples
+from miles.rollout.session.types import GetSessionResponse, SessionRecord
+from miles.rollout.session.v2.session_state import (
+    SessionRegistryV2,
+    commit_generation,
+    position_for_request,
+    prepare_pretokenized,
+)
+from miles.rollout.session.v2.utils import build_leaf_material, tree_metadata
+from miles.utils.misc import load_function
+
+logger = logging.getLogger(__name__)
+
+
+class SessionCoreV2(SessionCore):
+    """``SessionCore`` with tree serving: overrides the session-semantics
+    methods (positioning/commit, metadata, samples op), inherits the
+    transport shell (health, create/delete, raw proxy)."""
+
+    def __init__(self, backend, registry: SessionRegistryV2, args, session_server_instance_id=None):
+        super().__init__(backend, registry, args, session_server_instance_id)
+        # Import-path only in production: function_registry is process-local.
+        self.sample_picker = load_function(args.session_sample_picker_path, sync_required=True)
+        self.sample_postprocessor = load_function(args.session_sample_postprocessor_path, sync_required=True)
+
+    def _session_metadata(self, session_id: str, session) -> dict:
+        """Mirrors ``core.SessionCore._session_metadata``: token ids come from
+        the active path, plus the ``tree`` block."""
+        metadata: dict = {}
+        try:
+            mismatch = self.registry.compute_session_mismatch(session)
+        except TokenizationError:
+            logger.exception("Failed to compute tito_session_mismatch for session %s", session_id)
+            mismatch = None
+        if mismatch is not None:
+            metadata["tito_session_mismatch"] = mismatch
+        metadata["accumulated_token_ids"] = session.active_token_ids()
+        metadata["max_trim_tokens"] = self.registry.tito_tokenizer.max_trim_tokens
+        metadata["tree"] = tree_metadata(session)
+        return metadata
+
+    async def get_session(self, session_id: str) -> Response:
+        """Mirrors ``core.SessionCore.get_session``, serving ``active_records()``."""
+        session = self.registry.get_session(session_id)
+        metadata = self._session_metadata(session_id, session)
+        payload = GetSessionResponse(session_id=session_id, records=session.active_records(), metadata=metadata)
+        return Response(
+            content=_render_json(payload.model_dump(mode="json")), status_code=200, media_type=JSON_MEDIA_TYPE
+        )
+
+    async def collect_samples(
+        self, session_id: str, *, max_seq_len: int | None, agent_metadata: dict | None = None
+    ) -> Response:
+        """Samples op: assemble one raw sample per leaf, then run the
+        pick/post-process hook pipeline and encode the result.
+
+        Synchronous on the server loop (no await), so the session read cannot
+        interleave with chat commits. Deterministic assembly/hook failures map
+        to 422; unknown exceptions propagate.
+        """
+        session = self.registry.get_session(session_id)
+        metadata = self._session_metadata(session_id, session)
+        if agent_metadata is not None:
+            metadata["agent"] = agent_metadata
+        if not session.tree.nodes:
+            return _samples_response(
+                encode_samples([], metadata, empty_reason="no_records", fields=COMPUTED_FIELDS_V2)
+            )
+
+        try:
+            material = build_leaf_material(
+                self.args, session, self.registry, session_id=session_id, max_seq_len=max_seq_len
+            )
+        except (AssertionError, ValueError) as exc:
+            return Response(content=str(exc).encode(), status_code=422, media_type="text/plain")
+        if not material:
+            return _samples_response(
+                encode_samples([], metadata, empty_reason="all_truncated", fields=COMPUTED_FIELDS_V2)
+            )
+
+        # Hook lane: a policy bug is a deterministic 422 carrying the hook's
+        # identity, never a masked 500 (server death stays loud).
+        try:
+            picked = self.sample_picker(material, metadata)
+            picked_ids = [id(sample) for sample in picked]
+            allowed = {id(sample) for sample in material}
+            if any(sample_id not in allowed for sample_id in picked_ids) or len(picked_ids) != len(set(picked_ids)):
+                raise ValueError(
+                    "pick hook must return a subset of its input samples without duplicates (pure selection)"
+                )
+            samples = self.sample_postprocessor(picked, metadata)
+        except Exception as exc:
+            body = (
+                f"session sample hook failed (picker={self.args.session_sample_picker_path}, "
+                f"postprocessor={self.args.session_sample_postprocessor_path}): {exc}"
+            )
+            return Response(content=body.encode(), status_code=422, media_type="text/plain")
+        if not samples:
+            return _samples_response(
+                encode_samples([], metadata, empty_reason="all_truncated", fields=COMPUTED_FIELDS_V2)
+            )
+        return _samples_response(encode_samples(samples, metadata, fields=COMPUTED_FIELDS_V2))
+
+    async def chat_completions(
+        self, session_id: str, *, method: str, query: str, headers: dict, body: bytes
+    ) -> Response:
+        """Proxy a chat completion through the backend with TITO token tracking.
+
+        Flow: prepare pretokenized input_ids (lock held briefly) → proxy to
+        backend (NO lock) → validate response → update trajectory checkpoint and
+        append record (lock held briefly). The lock is NOT held during the long
+        inference call so DELETE/other ops are not blocked if the agent disconnects.
+        """
+        request_timestamp = time.time()
+        session = self.registry.get_session(session_id)
+        if session.closing:
+            raise SessionNotFoundError(f"session not found: session_id={session_id}")
+
+        # --- Phase 1: prepare request (lock held briefly) ---
+        async with session.lock:
+            if session.closing:
+                raise SessionNotFoundError(f"session not found: session_id={session_id}")
+
+            request_body, client_stream, tito_tokenizer = prepare_chat_request(
+                body, self.args, self.registry.tito_tokenizer
+            )
+
+            request_messages = request_body.get("messages", [])
+            position_for_request(session, request_messages)
+            prompt_token_ids = prepare_pretokenized(
+                session,
+                request_messages,
+                tools=request_body.get("tools"),
+                tito_tokenizer=tito_tokenizer,
+            )
+            request_body["input_ids"] = prompt_token_ids
+            logger.debug("Using TITO input_ids: %d tokens", len(prompt_token_ids))
+
+            proxy_body = json.dumps(request_body).encode()
+            attach_parent = session.active_leaf
+        # --- lock released ---
+
+        # --- Phase 2: proxy to backend (NO lock held) ---
+        headers = {**headers, "X-SMG-Routing-Key": session_id}
+        result = await self.backend.do_proxy(
+            ProxyRequest(method=method, query=query), "v1/chat/completions", body=proxy_body, headers=headers
+        )
+
+        # Non-200 (e.g. 400 context too long) passes through unrecorded so the
+        # agent can retry or handle the error.
+        if result["status_code"] != 200:
+            return proxy_result_to_response(result)
+
+        response, choice, assistant_message, completion_token_ids = extract_completion(result)
+
+        # --- Phase 3: update state (lock held briefly) ---
+        async with session.lock:
+            if session.closing:
+                logger.warning(f"Session {session_id} closed during proxy, skipping state update")
+                return _chat_client_response(result, response, client_stream)
+
+            if session.active_leaf is not attach_parent:
+                logger.warning(
+                    f"Session {session_id} state changed during proxy "
+                    f"(the active view moved), skipping state update"
+                )
+                return _chat_client_response(result, response, client_stream)
+
+            record = SessionRecord(
+                timestamp=time.time(),
+                request_timestamp=request_timestamp,
+                method=method,
+                path="/v1/chat/completions",
+                status_code=result["status_code"],
+                request=request_body,
+                response=response,
+            )
+            commit_generation(
+                session,
+                parent=attach_parent,
+                request_messages=request_messages,
+                assistant_message=assistant_message,
+                prompt_token_ids=prompt_token_ids,
+                completion_token_ids=completion_token_ids,
+                max_trim_tokens=tito_tokenizer.max_trim_tokens,
+                record=record,
+                response_id=response.get("id", ""),
+                finish_reason=choice.get("finish_reason") or "",
+            )
+        # --- lock released ---
+
+        return _chat_client_response(result, response, client_stream)

--- a/miles/rollout/session/v2/core.py
+++ b/miles/rollout/session/v2/core.py
@@ -177,13 +177,6 @@ class SessionCoreV2(SessionCore):
                 logger.warning(f"Session {session_id} closed during proxy, skipping state update")
                 return _chat_client_response(result, response, client_stream)
 
-            if session.active_leaf is not attach_parent:
-                logger.warning(
-                    f"Session {session_id} state changed during proxy "
-                    f"(the active view moved), skipping state update"
-                )
-                return _chat_client_response(result, response, client_stream)
-
             record = SessionRecord(
                 timestamp=time.time(),
                 request_timestamp=request_timestamp,

--- a/miles/rollout/session/v2/picker_hub/__init__.py
+++ b/miles/rollout/session/v2/picker_hub/__init__.py
@@ -1,0 +1,12 @@
+"""Pick hooks for the session samples op — this is the customization point.
+
+Point ``--session-sample-picker-path`` at any ``fn(leaf_samples,
+session_metadata) -> list[Sample]``: a pure selection over the per-leaf raw
+samples (drop or reorder, never rewrite). Public inputs are each sample's
+``metadata["leaf"]`` descriptor and the structural tree tables in
+``session_metadata``. Runs synchronously inside the session server process.
+"""
+
+from miles.rollout.session.v2.picker_hub.drop_retries import drop_retries
+
+__all__ = ["drop_retries"]

--- a/miles/rollout/session/v2/picker_hub/drop_retries.py
+++ b/miles/rollout/session/v2/picker_hub/drop_retries.py
@@ -1,0 +1,86 @@
+"""The default pick hook: trim retry-superseded leaves."""
+
+import logging
+
+from miles.utils.types import Sample
+
+logger = logging.getLogger(__name__)
+
+
+def drop_retries(leaf_samples: list[Sample], session_metadata: dict) -> list[Sample]:
+    """Drop the dead leaves that retries leave behind.
+
+    When a generation goes bad, the agent re-sends the same message and the
+    conversation continues on the new branch — but the abandoned attempt is
+    still a leaf in the tree, and it must not become a training sample.
+
+    The rule, leaf by leaf: a sibling branched off the same parent after it
+    -> this leaf is the abandoned attempt, superseded by the retry: trim it.
+    No later sibling -> keep (root leaves included). Survivors are ordered by
+    checkpoint count, then commit order, both descending.
+
+    Example — turn 2 hit the length cap and the agent re-sent it (``seq`` is
+    commit order):
+
+        seq=0  turn 1: user asks, assistant answers
+        ├── seq=1  turn 2 attempt: cut off at the length cap  (leaf) -> trim
+        └── seq=2  turn 2 retry: the same user message re-sent
+            └── seq=3  turn 3: the retry path continues       (leaf) -> keep
+    """
+    nodes = {n["id"]: n for n in session_metadata["tree"]["nodes"]}
+    children: dict[int, list[int]] = {}
+    for n in session_metadata["tree"]["nodes"]:
+        if n["parent"] is not None:
+            children.setdefault(n["parent"], []).append(n["id"])
+    leaf_rows = session_metadata["tree"]["leaves"]
+
+    kept: list[Sample] = []
+    for sample in leaf_samples:
+        descriptor = sample.metadata["leaf"]
+        leaf_id, parent = descriptor["node_id"], descriptor["parent"]
+        later = [] if parent is None else [sibling for sibling in children[parent] if sibling > leaf_id]
+        if not later:
+            kept.append(sample)
+            continue
+        # Wall-clock regressions are diagnostic; `seq` is the ordering contract.
+        clock_regressions = [
+            (sibling, nodes[sibling]["committed_at"])
+            for sibling in later
+            if nodes[sibling]["committed_at"] < nodes[leaf_id]["committed_at"]
+        ]
+        if clock_regressions:
+            logger.warning(
+                "Default picker detected wall-clock rollback for superseded leaf "
+                "(response_id=%r, seq=%d, committed_at=%s); "
+                "later siblings=%s; continuing by seq",
+                descriptor["response_id"],
+                leaf_id,
+                nodes[leaf_id]["committed_at"],
+                clock_regressions,
+            )
+
+        # Length is diagnostic only; temporal supersession is decided by `seq`.
+        survivors_max = max(
+            nodes[row["node_id"]]["num_tokens"]
+            for row in leaf_rows
+            if any(sibling in row["path_node_ids"] for sibling in later)
+        )
+        if nodes[leaf_id]["num_tokens"] > survivors_max:
+            logger.warning(
+                "Default picker trimming superseded leaf (response_id=%r, seq=%d) "
+                "even though it is longer than every later sibling's deepest leaf "
+                "(%d > %d tokens); continuing by seq; use a custom picker to keep it",
+                descriptor["response_id"],
+                leaf_id,
+                nodes[leaf_id]["num_tokens"],
+                survivors_max,
+            )
+        logger.info("Default picker trimmed superseded retry leaf seq=%d", leaf_id)
+    return sorted(
+        kept,
+        key=lambda sample: (
+            len(sample.metadata["leaf"]["path_node_ids"]),
+            sample.metadata["leaf"]["node_id"],
+        ),
+        reverse=True,
+    )

--- a/miles/rollout/session/v2/postprocessor_hub/__init__.py
+++ b/miles/rollout/session/v2/postprocessor_hub/__init__.py
@@ -1,0 +1,16 @@
+"""Post-process hooks for the session samples op — this is the customization point.
+
+Point ``--session-sample-postprocessor-path`` at any ``fn(leaf_samples,
+session_metadata) -> list[Sample]``. The post-process hook finalizes the
+surviving set into training samples; it runs strictly after pick,
+synchronously inside the session server process. It never drops samples —
+selection is the picker's job (see ``picker_hub``).
+
+One module per hook, file named after the function. Custom post-processor
+ideas: reassign shared-node mask ownership by reward, broadcast advantages
+across branches.
+"""
+
+from miles.rollout.session.v2.postprocessor_hub.default_postprocess import default_postprocess
+
+__all__ = ["default_postprocess"]

--- a/miles/rollout/session/v2/postprocessor_hub/default_postprocess.py
+++ b/miles/rollout/session/v2/postprocessor_hub/default_postprocess.py
@@ -1,0 +1,59 @@
+from miles.utils.types import Sample
+
+_SERVER_OWNED_METADATA_KEYS = ("accumulated_token_ids", "tito_session_mismatch", "leaf")
+
+
+def check_input_metadata(agent_metadata: dict) -> dict:
+    return {key: value for key, value in agent_metadata.items() if key not in _SERVER_OWNED_METADATA_KEYS}
+
+
+def assign_reward(samples: list[Sample], trajectory_reward: float) -> None:
+    for sample in samples:
+        sample.reward = trajectory_reward
+
+
+def default_postprocess(leaf_samples: list[Sample], session_metadata: dict) -> list[Sample]:
+    """Finalize the leaf samples kept by the picker.
+
+    A shared completion is trainable only in the earliest committed kept leaf.
+    Ownership is computed after picking, so a dropped leaf cannot own it.
+
+    Agent metadata cannot replace server-owned fields. A provided trajectory reward is assigned to every kept sample.
+
+    Mutates each `Sample` in place and preserves picker order.
+    """
+    nodes_by_id = {node["id"]: node for node in session_metadata["tree"]["nodes"]}
+    agent_metadata = session_metadata.get("agent") or {}
+    trajectory_reward = agent_metadata.get("reward")
+    agent_sample_metadata = check_input_metadata(agent_metadata)
+
+    # Picker order may change; `node_id` preserves commit order.
+    owner_by_node_id: dict[int, int] = {}
+    for sample in leaf_samples:
+        leaf = sample.metadata["leaf"]
+        leaf_id = leaf["node_id"]
+        for node_id in leaf["path_node_ids"]:
+            owner_by_node_id[node_id] = min(leaf_id, owner_by_node_id.get(node_id, leaf_id))
+
+    processed_samples: list[Sample] = []
+    for sample in leaf_samples:
+        leaf = sample.metadata["leaf"]
+        response_start = len(sample.tokens) - sample.response_length
+        # Spans index all tokens; `loss_mask` indexes only the response.
+        # Clamp when early-stop or truncation shortens the sample.
+        for node_id in leaf["path_node_ids"]:
+            if owner_by_node_id[node_id] == leaf["node_id"]:
+                continue
+            completion_start, completion_end = nodes_by_id[node_id]["completion_span"]
+            mask_start = max(completion_start - response_start, 0)
+            mask_end = min(completion_end - response_start, sample.response_length)
+            if mask_end > mask_start:
+                sample.loss_mask[mask_start:mask_end] = [0] * (mask_end - mask_start)
+        server_metadata = {key: sample.metadata[key] for key in _SERVER_OWNED_METADATA_KEYS if key in sample.metadata}
+        sample.metadata = {**sample.metadata, **agent_sample_metadata, **server_metadata}
+        processed_samples.append(sample)
+    # Skip `assign_reward` to score downstream, or replace the scalar
+    # `agent_metadata["reward"]` for finer-grained assignment.
+    if trajectory_reward is not None:
+        assign_reward(processed_samples, trajectory_reward)
+    return processed_samples

--- a/miles/rollout/session/v2/utils.py
+++ b/miles/rollout/session/v2/utils.py
@@ -1,0 +1,87 @@
+import logging
+from argparse import Namespace
+from typing import Any
+
+from miles.rollout.generate_utils.sample_utils import merge_samples
+from miles.rollout.session.errors import TokenizationError
+from miles.rollout.session.samples.merge import compute_samples_from_openai_records, truncate_samples_by_total_tokens
+from miles.rollout.session.v2.session_state import SessionRegistryV2, SessionStateV2
+from miles.utils.types import Sample
+
+logger = logging.getLogger(__name__)
+
+
+def tree_metadata(state: SessionStateV2) -> dict:
+    """The structural layer: node and leaf tables, index-aligned with commits.
+
+    ``response_id`` is the branch<->leaf join key — the agent saw the same id
+    in each chat response, so the semantic layer can key per-branch data on it.
+    """
+    nodes = [
+        {
+            "id": node.seq,
+            "parent": node.parent.seq if node.parent is not None else None,
+            "seq": node.seq,
+            "truncated": node.truncated,
+            "committed_at": node.committed_at,
+            "completion_span": list(node.completion_span),
+            "num_tokens": len(node.token_ids),
+            "response_id": node.response_id,
+        }
+        for node in state.tree.nodes
+    ]
+    leaves = [
+        {"node_id": leaf.seq, "path_node_ids": [n.seq for n in leaf.path_nodes()]} for leaf in state.tree.leaves()
+    ]
+    return {"nodes": nodes, "leaves": leaves}
+
+
+def build_leaf_material(
+    args: Namespace,
+    state: SessionStateV2,
+    registry: SessionRegistryV2,
+    *,
+    session_id: str,
+    max_seq_len: int | None,
+) -> list[Sample]:
+    """Merge each leaf's root-to-leaf node records into one raw sample, in commit order.
+
+    Leaves whose turns all truncate away are dropped. Each sample's metadata
+    carries the ``leaf`` descriptor plus the flat TITO bookkeeping keys for
+    the downstream pick/post-process hooks.
+    """
+    material: list[Sample] = []
+    for leaf in state.tree.leaves():
+        path = leaf.path_nodes()
+        turns = compute_samples_from_openai_records(
+            args,
+            [node.record for node in path],
+            registry.tokenizer,
+            accumulated_token_ids=leaf.token_ids,
+            max_trim_tokens=registry.tito_tokenizer.max_trim_tokens,
+        )
+        if max_seq_len is not None:
+            turns = truncate_samples_by_total_tokens(turns, max_seq_len, registry.tokenizer)
+        if not turns:
+            continue
+        sample = merge_samples(turns, registry.tokenizer)
+        tools = path[-1].record.request.get("tools")
+        flat: dict[str, Any] = {
+            "accumulated_token_ids": list(leaf.token_ids),
+            "leaf": {
+                "node_id": leaf.seq,
+                "parent": leaf.parent.seq if leaf.parent is not None else None,
+                "path_node_ids": [n.seq for n in path],
+                "response_id": leaf.response_id,
+            },
+        }
+        try:
+            mismatch = registry.compute_mismatch(leaf.path_messages(), leaf.token_ids, tools)
+        except TokenizationError:
+            logger.exception("Failed to compute tito_session_mismatch for session %s", session_id)
+            mismatch = None
+        if mismatch is not None:
+            flat["tito_session_mismatch"] = mismatch
+        sample.metadata = {**(sample.metadata or {}), **flat}
+        material.append(sample)
+    return material

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -2438,10 +2438,14 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
         def add_session_arguments(parser):
             parser.add_argument(
                 "--use-session-server",
-                action="store_true",
+                nargs="?",
+                const=True,
                 default=False,
                 help="Start a standalone session server for TITO/session support. "
-                "Requires --hf-checkpoint and --chat-template-path to also be set.",
+                "Requires --hf-checkpoint and --chat-template-path to also be set. "
+                "Bare flag (or 'v1') selects the append-only linear v1 server; "
+                "'--use-session-server v2' selects the tree-serving v2 "
+                "(multi-lineage trajectories, always-branch).",
             )
             parser.add_argument(
                 "--session-server-ip",
@@ -2466,6 +2470,28 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 help="TITO tokenizer type for pretokenized prefix reuse. "
                 "Controls how token IDs are computed for messages appended after "
                 "the pretokenized prefix in multi-turn agentic sessions.",
+            )
+            parser.add_argument(
+                "--session-sample-picker-path",
+                type=str,
+                default="miles.rollout.session.v2.picker_hub.drop_retries",
+                help="v2 only. Import path of the sample-pick hook for the "
+                "session samples op: fn(leaf_samples, session_metadata) -> "
+                "list[Sample], a pure selection over the per-leaf raw samples. "
+                "Runs synchronously inside the session server process; long CPU "
+                "work stalls every session on the instance. Default: the "
+                "temporal-supersession retry trim.",
+            )
+            parser.add_argument(
+                "--session-sample-postprocessor-path",
+                type=str,
+                default="miles.rollout.session.v2.postprocessor_hub.default_postprocess",
+                help="v2 only. Import path of the post-process hook for the "
+                "session samples op: fn(leaf_samples, session_metadata) -> "
+                "list[Sample], finalizing loss masks / rewards over the picked "
+                "samples. Runs synchronously inside the session server process. "
+                "Default: exactly-once completion masking + rewards keyed by "
+                "response id.",
             )
             return parser
 
@@ -2715,13 +2741,20 @@ def miles_validate_args(args):
     if args.recompute_logprobs_via_prefill:
         assert args.true_on_policy_mode, "--recompute-logprobs-via-prefill requires --true-on-policy-mode"
 
+    if args.use_session_server not in (False, True, "v1", "v2"):
+        raise ValueError(
+            f"--use-session-server={args.use_session_server!r} is not a known session server "
+            "version; pass it bare (or 'v1') for the append-only linear server, or 'v2' for "
+            "tree serving."
+        )
+
     if not args.use_session_server and args.tito_model != TITOTokenizerType.DEFAULT.value:
         raise ValueError(
             f"--tito-model={args.tito_model} requires --use-session-server; "
             "this flag only configures the session-server TITO middleware."
         )
 
-    # DEFAULT uses the checkpoint's native or caller-provided template.  Its
+    # DEFAULT uses the checkpoint's native or caller-provided template. Its
     # maximal four-role surface is best-effort rather than a Miles-verified
     # FixedTemplate contract.
     if args.use_session_server and args.tito_model == TITOTokenizerType.DEFAULT.value:

--- a/miles/utils/misc.py
+++ b/miles/utils/misc.py
@@ -1,5 +1,6 @@
 import asyncio
 import importlib
+import inspect
 import logging
 import re
 import subprocess
@@ -44,22 +45,28 @@ function_registry = FunctionRegistry()
 
 
 # TODO may rename to `load_object` since it can be used to load things like tool_specs
-def load_function(path):
+def load_function(path, *, sync_required=False):
     """
     Load a function from registry or module.
     :param path: The path to the function, e.g. "module.submodule.function".
+    :param sync_required: Reject coroutine functions, for callers that run the
+        loaded function synchronously on an event loop.
     :return: The function object.
     """
-    if path is None:
+    if not path:
         return None
 
-    registered = function_registry.get(path)
-    if registered is not None:
-        return registered
-
-    module_path, _, attr = path.rpartition(".")
-    module = importlib.import_module(module_path)
-    return getattr(module, attr)
+    fn = function_registry.get(path)
+    if fn is None:
+        module_path, _, attr = path.rpartition(".")
+        module = importlib.import_module(module_path)
+        fn = getattr(module, attr)
+    if sync_required:
+        if not callable(fn):
+            raise ValueError(f"load_function({path!r}) did not resolve to a callable")
+        if inspect.iscoroutinefunction(fn):
+            raise ValueError(f"load_function({path!r}) resolved to an async function; a synchronous one is required")
+    return fn
 
 
 async def call_agent_abort_hook(args) -> None:

--- a/tests/fast/router/test_session_samples_op_v2.py
+++ b/tests/fast/router/test_session_samples_op_v2.py
@@ -1,0 +1,685 @@
+"""Samples-op tests: golden assembled Samples plus the op-level error/route contracts.
+
+Drives `SessionCoreV2.collect_samples` in-process against a real tokenizer (the
+`test_sessions.py` precedent), with records injected via the registry — the
+broken-chain and R3 fixtures cannot be produced through the chat path. The
+HTTP surface (route registration order, 404 mapping) is exercised through the
+real `setup_session_routes` app with a `TestClient`.
+
+The golden tests assert the exact `Sample` field values derivable from the
+two-turn records fixture — through `collect_samples` → `decode_samples_and_merge_input_sample`
+overlay → the driver-side metadata application `agentic_tool_call.generate`
+performs — including the template-field overlay and the metadata application
+order (agent metadata overrides the input's keys; session metadata, applied
+last, overrides the agent's).
+"""
+
+import json
+import logging
+import uuid
+from copy import deepcopy
+from types import SimpleNamespace
+
+import numpy as np
+import pybase64
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from tests.fast.rollout.session.test_samples import _make_record
+
+from miles.rollout.session.errors import TokenizationError
+from miles.rollout.session.samples.codec import COMPUTED_FIELDS_V2, decode_samples_and_merge_input_sample
+from miles.rollout.session.sessions import setup_session_routes
+from miles.rollout.session.v2.core import SessionCoreV2
+from miles.rollout.session.v2.session_state import SessionRegistryV2
+from miles.utils.chat_template_utils import get_tito_tokenizer
+from miles.utils.misc import function_registry
+from miles.utils.processing_utils import load_tokenizer
+from miles.utils.types import Sample
+
+NUM_LAYERS = 3
+TOPK = 2
+
+_ARGS = SimpleNamespace(
+    use_session_server="v2",
+    miles_router_timeout=30,
+    hf_checkpoint="Qwen/Qwen3-0.6B",
+    chat_template_path=None,
+    apply_chat_template_kwargs={"enable_thinking": False},
+    tito_model="default",
+    sglang_speculative_algorithm=None,
+    session_server_instance_id=uuid.uuid4().hex,
+    save_debug_trajectory_data=None,
+    session_sample_picker_path="miles.rollout.session.v2.picker_hub.drop_retries",
+    session_sample_postprocessor_path="miles.rollout.session.v2.postprocessor_hub.default_postprocess",
+    num_layers=NUM_LAYERS,
+    moe_router_topk=TOPK,
+)
+
+
+class _UnusedBackend:
+    """collect_samples never proxies; any backend call is a test bug."""
+
+    async def do_proxy(self, *args, **kwargs):
+        raise AssertionError("collect_samples must not touch the proxy backend")
+
+
+def _build_core() -> SessionCoreV2:
+    # Mirrors setup_session_routes (sessions.py): tokenizer + registry + core.
+    tokenizer = load_tokenizer(
+        _ARGS.hf_checkpoint, chat_template_path=_ARGS.chat_template_path, trust_remote_code=True
+    )
+    tito_tokenizer = get_tito_tokenizer(
+        tokenizer,
+        tokenizer_type=_ARGS.tito_model,
+        chat_template_kwargs=_ARGS.apply_chat_template_kwargs,
+    )
+    registry = SessionRegistryV2(_ARGS, tokenizer, tito_tokenizer=tito_tokenizer)
+    return SessionCoreV2(_UnusedBackend(), registry, _ARGS, _ARGS.session_server_instance_id)
+
+
+@pytest.fixture(scope="module")
+def core():
+    return _build_core()
+
+
+# ── fixtures: a two-turn trajectory with R3 / cache stats / weight versions ──
+
+
+def _r3_b64(num_tokens: int, seed: int) -> str:
+    arr = np.arange(seed, seed + num_tokens * NUM_LAYERS * TOPK, dtype=np.int32)
+    return pybase64.b64encode(arr.tobytes()).decode("ascii")
+
+
+def _two_turn_records():
+    # R3 buffer length per record = (len(prompt) + len(output) - 1) * layers * topk.
+    return [
+        _make_record(
+            prompt_token_ids=[1, 2, 3],
+            output_token_ids=[10, 11],
+            output_log_probs=[-0.125, -0.25],
+            cached_tokens=0,
+            prompt_tokens=3,
+            weight_version="w1",
+            routed_experts=_r3_b64(4, seed=0),
+        ),
+        _make_record(
+            prompt_token_ids=[1, 2, 3, 10, 11, 20, 21],
+            output_token_ids=[30, 31],
+            output_log_probs=[-0.5, -1.0],
+            cached_tokens=5,
+            prompt_tokens=7,
+            weight_version="w2",
+            routed_experts=_r3_b64(8, seed=100),
+        ),
+    ]
+
+
+_ACCUMULATED = [1, 2, 3, 10, 11, 20, 21, 30, 31]
+
+
+def _input_sample() -> Sample:
+    return Sample(
+        group_index=4,
+        index=9,
+        prompt=[{"role": "user", "content": "hi"}],
+        label="lbl",
+        reward=2.5,
+        metadata={"task": "t1", "shared_key": "from-input"},
+        routing_key="routing-sid",
+        train_metadata={"loss": "ppo"},
+        generate_function_path="gen.fn",
+    )
+
+
+# Overlapping keys lock the application order: agent overrides the input's
+# shared_key; session_metadata (applied last) overrides the agent's
+# max_trim_tokens plant.
+_AGENT_METADATA = {"shared_key": "from-agent", "agent_only": 1, "accumulated_token_ids": "agent-plant"}
+
+
+async def _make_session(core, records, accumulated) -> str:
+    response = await core.create_session()
+    sid = json.loads(response.body)["session_id"]
+    state = core.registry.sessions[sid]
+    for i, record in enumerate(records):
+        last = i == len(records) - 1
+        state.active_leaf = state.tree.create_node(
+            state.active_leaf,
+            delta_messages=[],
+            token_ids=list(accumulated) if (last and accumulated is not None) else [],
+            completion_span=(0, 0),
+            committed_at=record.timestamp,
+            response_id="",
+            record=record,
+            finish_reason="",
+        )
+    return sid
+
+
+async def _collect_via_op(core, sid, *, max_seq_len=None, agent_metadata=None):
+    response = await core.collect_samples(sid, max_seq_len=max_seq_len, agent_metadata=agent_metadata)
+    return response.status_code, response.body
+
+
+def _new_pipeline(payload, input_sample):
+    """What the driver does with the reply: decode only — per-sample metadata
+    and rewards arrive already applied by the server-side post-process."""
+    reply = decode_samples_and_merge_input_sample(payload, input_sample, fields=COMPUTED_FIELDS_V2)
+    return reply.samples, reply
+
+
+# ── golden assembly: exact expected Samples for the two-turn fixture ──
+
+
+def _expected_r3(seed: int, num_tokens: int):
+    return np.arange(seed, seed + num_tokens * NUM_LAYERS * TOPK, dtype=np.int32).reshape(num_tokens, NUM_LAYERS, TOPK)
+
+
+async def test_assembled_samples_golden_merged(core):
+    """Turns merge into one trajectory Sample; the env tokens between turns
+    get zero loss/logprob; the last turn's R3 is kept."""
+    sid = await _make_session(core, _two_turn_records(), _ACCUMULATED)
+    status, payload = await _collect_via_op(core, sid, agent_metadata=_AGENT_METADATA)
+    assert status == 200
+    samples, reply = _new_pipeline(payload, _input_sample())
+    (m,) = samples
+    tokenizer = core.registry.tokenizer
+
+    assert m.tokens == _ACCUMULATED
+    assert m.response == tokenizer.decode([10, 11]) + tokenizer.decode([20, 21]) + tokenizer.decode([30, 31])
+    assert m.response_length == 6
+    assert m.loss_mask == [1, 1, 0, 0, 1, 1]
+    assert m.rollout_log_probs == [-0.125, -0.25, 0.0, 0.0, -0.5, -1.0]
+    assert m.status == Sample.Status.COMPLETED
+    assert m.weight_versions == ["w1", "w2"]
+    assert np.array_equal(m.rollout_routed_experts, _expected_r3(100, 8))
+    assert m.prefix_cache_info.to_dict() == {"cached_tokens": 5, "total_prompt_tokens": 10}
+    # Overlay: template fields are the driver's, untouched by the wire.
+    assert m.prompt == [{"role": "user", "content": "hi"}]
+    assert m.label == "lbl"
+    assert m.reward == 2.5
+    assert m.routing_key == "routing-sid"
+    assert m.train_metadata == {"loss": "ppo"}
+    assert m.metadata["task"] == "t1"
+    # Metadata layering (server-side post-process, wire-carried): the agent's
+    # semantic layer overrides the input's shared_key; the server's flat keys
+    # land last, so the agent's accumulated_token_ids plant cannot survive.
+    assert m.metadata["shared_key"] == "from-agent"
+    assert m.metadata["agent_only"] == 1
+    assert m.metadata["accumulated_token_ids"] == _ACCUMULATED
+    assert reply.session_metadata["agent"] == _AGENT_METADATA
+
+
+async def test_truncation_golden(core):
+    """max_seq_len=8 strips one output token off the second turn (a turn-level
+    budget applied before merge): the merged sample ends TRUNCATED at 8 tokens
+    with its per-token fields (including R3) trimmed in lockstep."""
+    sid = await _make_session(core, _two_turn_records(), _ACCUMULATED)
+    status, payload = await _collect_via_op(core, sid, max_seq_len=8)
+    assert status == 200
+    samples, _ = _new_pipeline(payload, _input_sample())
+
+    (last,) = samples
+    assert last.status == Sample.Status.TRUNCATED
+    assert last.tokens == _ACCUMULATED[:8]
+    assert last.loss_mask == [1, 1, 0, 0, 1]
+    assert last.rollout_log_probs == [-0.125, -0.25, 0.0, 0.0, -0.5]
+    assert np.array_equal(last.rollout_routed_experts, _expected_r3(100, 8)[:-1])
+
+
+async def test_session_metadata_matches_get_session(core):
+    """The samples reply and the records GET must expose the same metadata dict
+    (both are built by the extracted _session_metadata helper)."""
+    sid = await _make_session(core, _two_turn_records(), _ACCUMULATED)
+    _, payload = await _collect_via_op(core, sid)
+    reply = decode_samples_and_merge_input_sample(payload, Sample(), fields=COMPUTED_FIELDS_V2)
+
+    response = await core.get_session(sid)
+    assert response.status_code == 200
+    assert reply.session_metadata == json.loads(response.body)["metadata"]
+    assert reply.session_metadata["accumulated_token_ids"] == _ACCUMULATED
+
+
+# ── empty_reason discriminator ──
+
+
+async def test_no_records_reply(core):
+    sid = await _make_session(core, [], None)
+    status, payload = await _collect_via_op(core, sid)
+    assert status == 200
+    reply = decode_samples_and_merge_input_sample(payload, Sample(), fields=COMPUTED_FIELDS_V2)
+    assert reply.samples == [] and reply.empty_reason == "no_records"
+
+
+async def test_all_truncated_reply(core):
+    # max_seq_len=2 < the first turn's prompt+1: truncate_samples_by_total_tokens
+    # drops every turn -> empty samples with the all_truncated reason; the old
+    # pipeline returns [] on the same fixture (today's ABORTED path).
+    records = _two_turn_records()
+    sid = await _make_session(core, records, _ACCUMULATED)
+    status, payload = await _collect_via_op(core, sid, max_seq_len=2)
+    assert status == 200
+    reply = decode_samples_and_merge_input_sample(payload, Sample(), fields=COMPUTED_FIELDS_V2)
+    assert reply.samples == [] and reply.empty_reason == "all_truncated"
+
+
+# ── the 422 lane ──
+
+
+async def test_broken_chain_returns_422_and_server_survives(core):
+    # The accumulated sequence carries one token the records never produced ->
+    # the cursor consistency assert fires -> 422 with the assertion text, and
+    # the server keeps serving (the failure never escapes as an unhandled 500).
+    sid = await _make_session(core, _two_turn_records(), _ACCUMULATED + [99])
+    status, payload = await _collect_via_op(core, sid)
+    assert status == 422
+    assert "cursor" in payload.decode()
+
+    health = await core.health()
+    assert health.status_code == 200
+
+
+# ── the tree data plane: branches, trims, exactly-once, rewards ──
+
+
+def _single_turn_record(prompt_ids, output_ids, weight_version="w1"):
+    return _make_record(
+        prompt_token_ids=list(prompt_ids),
+        output_token_ids=list(output_ids),
+        output_log_probs=[-0.1] * len(output_ids),
+        cached_tokens=0,
+        prompt_tokens=len(prompt_ids),
+        weight_version=weight_version,
+        routed_experts=_r3_b64(len(prompt_ids) + len(output_ids) - 1, seed=0),
+    )
+
+
+def _fabricate_node(state, parent, record, token_ids, *, completion_span, response_id="", committed_at=None):
+    return state.tree.create_node(
+        parent,
+        delta_messages=[],
+        token_ids=list(token_ids),
+        completion_span=completion_span,
+        committed_at=float(len(state.tree.nodes)) if committed_at is None else committed_at,
+        response_id=response_id,
+        record=record,
+        finish_reason="stop",
+    )
+
+
+async def _fresh_state(core):
+    response = await core.create_session()
+    sid = json.loads(response.body)["session_id"]
+    return sid, core.registry.sessions[sid]
+
+
+async def test_superseded_retry_leaf_is_trimmed(core):
+    """A childless leaf with a later sibling is retry noise: one sample out."""
+    sid, state = await _fresh_state(core)
+    root = _fabricate_node(
+        state, None, _single_turn_record([1, 2, 3], [10, 11]), [1, 2, 3, 10, 11], completion_span=(3, 5)
+    )
+    _fabricate_node(  # abandoned attempt
+        state,
+        root,
+        _single_turn_record([1, 2, 3, 10, 11, 20], [30]),
+        [1, 2, 3, 10, 11, 20, 30],
+        completion_span=(6, 7),
+    )
+    retry = _fabricate_node(  # the retry that superseded it
+        state,
+        root,
+        _single_turn_record([1, 2, 3, 10, 11, 21], [31]),
+        [1, 2, 3, 10, 11, 21, 31],
+        completion_span=(6, 7),
+    )
+    state.active_leaf = retry
+
+    status, payload = await _collect_via_op(core, sid)
+    assert status == 200
+    reply = decode_samples_and_merge_input_sample(payload, Sample(), fields=COMPUTED_FIELDS_V2)
+    (m,) = reply.samples
+    assert m.tokens == [1, 2, 3, 10, 11, 21, 31]
+
+
+@pytest.mark.parametrize("trajectory_reward", [1.0, 0.0])
+async def test_deep_abandoned_branch_survives_and_masks_shared_prefix(core, trajectory_reward):
+    """A deep abandoned branch is data (subagent shape): two samples, and the
+    shared root completion trains exactly once (earliest leaf owns it)."""
+    sid, state = await _fresh_state(core)
+    root = _fabricate_node(
+        state, None, _single_turn_record([1, 2, 3], [10, 11]), [1, 2, 3, 10, 11], completion_span=(3, 5)
+    )
+    early_mid = _fabricate_node(
+        state,
+        root,
+        _single_turn_record([1, 2, 3, 10, 11, 20], [30]),
+        [1, 2, 3, 10, 11, 20, 30],
+        completion_span=(6, 7),
+    )
+    early_leaf = _fabricate_node(
+        state,
+        early_mid,
+        _single_turn_record([1, 2, 3, 10, 11, 20, 30, 40], [50]),
+        [1, 2, 3, 10, 11, 20, 30, 40, 50],
+        completion_span=(8, 9),
+        response_id="early",
+    )
+    late_leaf = _fabricate_node(
+        state,
+        root,
+        _single_turn_record([1, 2, 3, 10, 11, 21], [31]),
+        [1, 2, 3, 10, 11, 21, 31],
+        completion_span=(6, 7),
+        response_id="late",
+    )
+    state.active_leaf = late_leaf
+
+    status, payload = await _collect_via_op(core, sid, agent_metadata={"reward": trajectory_reward})
+    assert status == 200
+    reply = decode_samples_and_merge_input_sample(payload, Sample(), fields=COMPUTED_FIELDS_V2)
+    early_sample, late_sample = reply.samples
+    assert early_sample.tokens == early_leaf.token_ids
+    assert late_sample.tokens == late_leaf.token_ids
+    # The early leaf owns the shared root completion [3,5); the late leaf masks it.
+    assert early_sample.loss_mask[:2] == [1, 1]
+    assert late_sample.loss_mask[:2] == [0, 0]
+    assert late_sample.loss_mask[-1] == 1  # its own completion still trains
+    assert [sample.reward for sample in reply.samples] == [trajectory_reward, trajectory_reward]
+    assert [sample.metadata["reward"] for sample in reply.samples] == [trajectory_reward, trajectory_reward]
+
+
+async def test_picker_warns_and_trims_longer_superseded_leaf(core, caplog):
+    """A longer superseded leaf warns, then temporal order still trims it."""
+    sid, state = await _fresh_state(core)
+    root = _fabricate_node(
+        state, None, _single_turn_record([1, 2, 3], [10, 11]), [1, 2, 3, 10, 11], completion_span=(3, 5)
+    )
+    _fabricate_node(  # abandoned but LONGER than the retry
+        state,
+        root,
+        _single_turn_record([1, 2, 3, 10, 11, 20], [30, 31, 32]),
+        [1, 2, 3, 10, 11, 20, 30, 31, 32],
+        completion_span=(6, 9),
+    )
+    retry = _fabricate_node(
+        state,
+        root,
+        _single_turn_record([1, 2, 3, 10, 11, 21], [31]),
+        [1, 2, 3, 10, 11, 21, 31],
+        completion_span=(6, 7),
+    )
+    state.active_leaf = retry
+
+    with caplog.at_level(logging.WARNING, logger="miles.rollout.session.v2.picker_hub.drop_retries"):
+        status, payload = await _collect_via_op(core, sid)
+    assert status == 200
+    reply = decode_samples_and_merge_input_sample(payload, Sample(), fields=COMPUTED_FIELDS_V2)
+    (sample,) = reply.samples
+    assert sample.tokens == retry.token_ids
+    assert "longer than every later sibling's deepest leaf" in caplog.text
+    assert "continuing by seq" in caplog.text
+
+
+async def test_picker_warns_on_wall_clock_rollback_and_trims_by_seq(core, caplog):
+    """A later `seq` with an earlier wall clock warns without changing the trim."""
+    sid, state = await _fresh_state(core)
+    root = _fabricate_node(
+        state, None, _single_turn_record([1, 2, 3], [10, 11]), [1, 2, 3, 10, 11], completion_span=(3, 5)
+    )
+    _fabricate_node(
+        state,
+        root,
+        _single_turn_record([1, 2, 3, 10, 11, 20], [30]),
+        [1, 2, 3, 10, 11, 20, 30],
+        completion_span=(6, 7),
+        committed_at=10.0,
+    )
+    retry = _fabricate_node(
+        state,
+        root,
+        _single_turn_record([1, 2, 3, 10, 11, 21], [31]),
+        [1, 2, 3, 10, 11, 21, 31],
+        completion_span=(6, 7),
+        committed_at=5.0,
+    )
+    state.active_leaf = retry
+
+    with caplog.at_level(logging.WARNING, logger="miles.rollout.session.v2.picker_hub.drop_retries"):
+        status, payload = await _collect_via_op(core, sid)
+    assert status == 200
+    reply = decode_samples_and_merge_input_sample(payload, Sample(), fields=COMPUTED_FIELDS_V2)
+    (sample,) = reply.samples
+    assert sample.tokens == retry.token_ids
+    assert "wall-clock rollback" in caplog.text
+    assert "continuing by seq" in caplog.text
+    assert "longer than every later sibling" not in caplog.text
+
+
+async def test_two_roots_yield_two_samples(core):
+    """Zero-overlap branches (subagent forest) each assemble independently."""
+    sid, state = await _fresh_state(core)
+    main = _fabricate_node(
+        state, None, _single_turn_record([1, 2, 3], [10, 11]), [1, 2, 3, 10, 11], completion_span=(3, 5)
+    )
+    sub = _fabricate_node(state, None, _single_turn_record([7, 8], [70, 71]), [7, 8, 70, 71], completion_span=(2, 4))
+    state.active_leaf = sub
+
+    status, payload = await _collect_via_op(core, sid)
+    assert status == 200
+    reply = decode_samples_and_merge_input_sample(payload, Sample(), fields=COMPUTED_FIELDS_V2)
+    first, second = reply.samples
+    assert first.tokens == sub.token_ids
+    assert second.tokens == main.token_ids
+    tree = reply.session_metadata["tree"]
+    assert [n["parent"] for n in tree["nodes"]] == [None, None]
+    assert [leaf["node_id"] for leaf in tree["leaves"]] == [main.seq, sub.seq]
+    assert [first.reward, second.reward] == [None, None]
+
+
+async def test_picker_orders_by_checkpoint_count_then_latest_commit(core):
+    sid, state = await _fresh_state(core)
+    root = _fabricate_node(state, None, _single_turn_record([1], [10]), [1, 10], completion_span=(1, 2))
+    deep = _fabricate_node(
+        state,
+        root,
+        _single_turn_record([1, 10, 20], [30]),
+        [1, 10, 20, 30],
+        completion_span=(3, 4),
+    )
+    shallow_early = _fabricate_node(
+        state,
+        None,
+        _single_turn_record([100, 101, 102, 103], [104, 105, 106, 107]),
+        [100, 101, 102, 103, 104, 105, 106, 107],
+        completion_span=(4, 8),
+    )
+    shallow_late = _fabricate_node(
+        state,
+        None,
+        _single_turn_record([200, 201, 202, 203], [204, 205, 206]),
+        [200, 201, 202, 203, 204, 205, 206],
+        completion_span=(4, 7),
+    )
+    state.active_leaf = shallow_late
+
+    status, payload = await _collect_via_op(core, sid)
+    assert status == 200
+    reply = decode_samples_and_merge_input_sample(payload, Sample(), fields=COMPUTED_FIELDS_V2)
+    assert len(deep.path_nodes()) == 2
+    assert len(shallow_early.path_nodes()) == len(shallow_late.path_nodes()) == 1
+    assert len(deep.token_ids) < len(shallow_late.token_ids) < len(shallow_early.token_ids)
+    assert [sample.metadata["leaf"]["node_id"] for sample in reply.samples] == [
+        deep.seq,
+        shallow_late.seq,
+        shallow_early.seq,
+    ]
+
+
+# ── the hook layer: custom pick/post-process, contract enforcement ──
+
+
+def _keep_all_picker(leaf_samples, session_metadata):
+    return list(leaf_samples)
+
+
+def _reverse_picker(leaf_samples, session_metadata):
+    return list(reversed(leaf_samples))
+
+
+def _duplicate_picker(leaf_samples, session_metadata):
+    return [leaf_samples[0], leaf_samples[0]]
+
+
+def _exploding_picker(leaf_samples, session_metadata):
+    raise RuntimeError("policy bug")
+
+
+def _impure_picker(leaf_samples, session_metadata):
+    return [deepcopy(leaf_samples[0])]
+
+
+async def _exploding_async_picker(leaf_samples, session_metadata):
+    return leaf_samples
+
+
+def _build_core_with_hooks(**hook_args) -> SessionCoreV2:
+    args = SimpleNamespace(**{**vars(_ARGS), **hook_args})
+    tokenizer = load_tokenizer(args.hf_checkpoint, chat_template_path=args.chat_template_path, trust_remote_code=True)
+    tito_tokenizer = get_tito_tokenizer(
+        tokenizer,
+        tokenizer_type=args.tito_model,
+        chat_template_kwargs=args.apply_chat_template_kwargs,
+    )
+    registry = SessionRegistryV2(args, tokenizer, tito_tokenizer=tito_tokenizer)
+    return SessionCoreV2(_UnusedBackend(), registry, args, args.session_server_instance_id)
+
+
+async def _retry_shaped_session(core):
+    sid, state = await _fresh_state(core)
+    root = _fabricate_node(
+        state, None, _single_turn_record([1, 2, 3], [10, 11]), [1, 2, 3, 10, 11], completion_span=(3, 5)
+    )
+    _fabricate_node(
+        state,
+        root,
+        _single_turn_record([1, 2, 3, 10, 11, 20], [30]),
+        [1, 2, 3, 10, 11, 20, 30],
+        completion_span=(6, 7),
+    )
+    retry = _fabricate_node(
+        state,
+        root,
+        _single_turn_record([1, 2, 3, 10, 11, 21], [31]),
+        [1, 2, 3, 10, 11, 21, 31],
+        completion_span=(6, 7),
+    )
+    state.active_leaf = retry
+    return sid
+
+
+async def test_custom_picker_keeps_abandoned_leaf(core):
+    """A tree-RL style picker keeps everything: the abandoned retry leaf
+    becomes a second sample instead of being trimmed."""
+    with function_registry.temporary("test_hooks.keep_all", _keep_all_picker):
+        hooked = _build_core_with_hooks(session_sample_picker_path="test_hooks.keep_all")
+        sid = await _retry_shaped_session(hooked)
+        response = await hooked.collect_samples(sid, max_seq_len=None)
+        assert response.status_code == 200
+        reply = decode_samples_and_merge_input_sample(bytes(response.body), Sample(), fields=COMPUTED_FIELDS_V2)
+        abandoned, retry = reply.samples
+        assert abandoned.tokens == [1, 2, 3, 10, 11, 20, 30]
+        assert retry.tokens == [1, 2, 3, 10, 11, 21, 31]
+        # Exactly-once over the SURVIVING set: the abandoned (earlier) leaf now
+        # owns the shared root completion; the retry masks it.
+        assert abandoned.loss_mask[:2] == [1, 1]
+        assert retry.loss_mask[:2] == [0, 0]
+
+
+async def test_custom_picker_reorder_keeps_earliest_leaf_as_owner(core):
+    with function_registry.temporary("test_hooks.reverse", _reverse_picker):
+        hooked = _build_core_with_hooks(session_sample_picker_path="test_hooks.reverse")
+        sid = await _retry_shaped_session(hooked)
+        response = await hooked.collect_samples(sid, max_seq_len=None)
+        assert response.status_code == 200
+        reply = decode_samples_and_merge_input_sample(bytes(response.body), Sample(), fields=COMPUTED_FIELDS_V2)
+        retry, abandoned = reply.samples
+        assert retry.loss_mask[:2] == [0, 0]
+        assert abandoned.loss_mask[:2] == [1, 1]
+
+
+async def test_hook_exception_maps_to_422_with_identity(core):
+    with function_registry.temporary("test_hooks.exploding", _exploding_picker):
+        hooked = _build_core_with_hooks(session_sample_picker_path="test_hooks.exploding")
+        sid = await _retry_shaped_session(hooked)
+        response = await hooked.collect_samples(sid, max_seq_len=None)
+        assert response.status_code == 422
+        body = bytes(response.body).decode()
+        assert "test_hooks.exploding" in body and "policy bug" in body
+
+
+async def test_impure_picker_maps_to_422(core):
+    with function_registry.temporary("test_hooks.impure", _impure_picker):
+        hooked = _build_core_with_hooks(session_sample_picker_path="test_hooks.impure")
+        sid = await _retry_shaped_session(hooked)
+        response = await hooked.collect_samples(sid, max_seq_len=None)
+        assert response.status_code == 422
+        assert "subset" in bytes(response.body).decode()
+
+
+async def test_duplicate_picker_maps_to_422(core):
+    with function_registry.temporary("test_hooks.duplicate", _duplicate_picker):
+        hooked = _build_core_with_hooks(session_sample_picker_path="test_hooks.duplicate")
+        sid = await _retry_shaped_session(hooked)
+        response = await hooked.collect_samples(sid, max_seq_len=None)
+        assert response.status_code == 422
+        assert "duplicates" in bytes(response.body).decode()
+
+
+async def test_agent_cannot_fill_missing_server_metadata(core, monkeypatch):
+    def fail_mismatch(*args, **kwargs):
+        raise TokenizationError("test mismatch failure")
+
+    monkeypatch.setattr(core.registry, "compute_mismatch", fail_mismatch)
+    sid = await _make_session(core, _two_turn_records(), _ACCUMULATED)
+    status, payload = await _collect_via_op(core, sid, agent_metadata={"tito_session_mismatch": ["agent-plant"]})
+    assert status == 200
+    reply = decode_samples_and_merge_input_sample(payload, Sample(), fields=COMPUTED_FIELDS_V2)
+    (sample,) = reply.samples
+    assert "tito_session_mismatch" not in sample.metadata
+
+
+def test_async_hook_rejected_at_load():
+    with function_registry.temporary("test_hooks.async_picker", _exploding_async_picker):
+        with pytest.raises(ValueError, match="async"):
+            _build_core_with_hooks(session_sample_picker_path="test_hooks.async_picker")
+
+
+# ── the HTTP surface: route order and error mapping through the real app ──
+
+
+@pytest.fixture(scope="module")
+def app_client():
+    app = FastAPI()
+    setup_session_routes(app, _UnusedBackend(), _ARGS)
+    with TestClient(app) as client:
+        yield client
+
+
+def test_missing_session_returns_404(app_client):
+    response = app_client.post(f"/sessions/{uuid.uuid4().hex}/samples", content=b'{"max_seq_len":null}')
+    assert response.status_code == 404
+    assert "not found" in response.json()["error"]
+
+
+def test_samples_route_registered_before_catch_all_proxy(app_client):
+    # The catch-all session_proxy would forward the request to the inference
+    # backend (_UnusedBackend raises); the samples route must win instead and
+    # answer with a decodable empty reply for a fresh session.
+    sid = app_client.post("/sessions").json()["session_id"]
+    response = app_client.post(f"/sessions/{sid}/samples", content=b'{"max_seq_len":null}')
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "application/octet-stream"
+    reply = decode_samples_and_merge_input_sample(response.content, Sample(), fields=COMPUTED_FIELDS_V2)
+    assert reply.empty_reason == "no_records", "catch-all session_proxy swallowed the samples route"

--- a/tests/fast/router/test_sessions_v2.py
+++ b/tests/fast/router/test_sessions_v2.py
@@ -1,0 +1,395 @@
+"""HTTP tests for session server v2 (tree serving, --use-session-server v2).
+
+The v1 HTTP surface keeps its own modules (test_sessions.py untouched at
+base + test_sessions_v1_pins.py); everything here runs against a v2-flagged
+server. The rollback pin classes mirror test_sessions_v1_pins.py so v1/v2
+behavior stays byte-comparable.
+"""
+
+import json
+import uuid
+from contextlib import contextmanager
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+import requests
+import safetensors.numpy
+from fastapi.responses import JSONResponse
+from tests.fast.router.test_sessions import _create_session, _post_chat
+
+from miles.rollout.session.server import SessionServer
+from miles.utils.http_utils import find_available_port
+from miles.utils.lora import LORA_ADAPTER_NAME
+from miles.utils.test_utils.mock_sglang_server import MockSGLangServer, ProcessResult, with_mock_server
+from miles.utils.test_utils.uvicorn_thread_server import UvicornThreadServer
+
+
+@contextmanager
+def _serve_router(extra_args: dict | None = None):
+    """A standalone v2 SessionServer with arg overrides."""
+
+    def process_fn(prompt: str) -> ProcessResult:
+        return ProcessResult(text=f"echo: {prompt}", finish_reason="stop")
+
+    with with_mock_server(process_fn=process_fn) as backend:
+        args = SimpleNamespace(
+            miles_router_timeout=30,
+            hf_checkpoint="Qwen/Qwen3-0.6B",
+            chat_template_path=None,
+            apply_chat_template_kwargs={"enable_thinking": False},
+            tito_model="default",
+            sglang_speculative_algorithm=None,
+            use_session_server="v2",
+            session_server_instance_id=uuid.uuid4().hex,
+            save_debug_trajectory_data=None,
+            session_sample_picker_path="miles.rollout.session.v2.picker_hub.drop_retries",
+            session_sample_postprocessor_path="miles.rollout.session.v2.postprocessor_hub.default_postprocess",
+            **(extra_args or {}),
+        )
+        server_obj = SessionServer(args, backend_url=backend.url)
+        port = find_available_port(31000)
+        server = UvicornThreadServer(server_obj.app, host="127.0.0.1", port=port)
+        server.start()
+        try:
+            yield SimpleNamespace(url=f"http://127.0.0.1:{port}", backend=backend)
+        finally:
+            server.stop()
+
+
+@pytest.fixture(scope="class")
+def router_env():
+    """v2 twin of test_sessions.router_env: same mock backend + R3 payloads,
+    tree serving enabled."""
+
+    def process_fn(prompt: str) -> ProcessResult:
+        return ProcessResult(text=f"echo: {prompt}", finish_reason="stop")
+
+    original_chat_response = MockSGLangServer._compute_chat_completions_response
+
+    def patched_chat_response(self, payload: dict) -> dict:
+        response = original_chat_response(self, payload)
+        choice = response["choices"][0]
+        logprobs_content = choice["logprobs"]["content"]
+        output_token_logprobs = [
+            (item["logprob"], self.tokenizer.convert_tokens_to_ids(item["token"])) for item in logprobs_content
+        ]
+        choice["meta_info"] = {
+            "output_token_logprobs": output_token_logprobs,
+            "completion_tokens": len(output_token_logprobs),
+            # R3 replay payloads: must reach the session record but never the
+            # client-facing chat response (see _strip_replay_payloads).
+            "routed_experts": [[0, 1], [2, 3]],
+            "indexer_topk": [[4], [5]],
+        }
+        return response
+
+    with patch.object(MockSGLangServer, "_compute_chat_completions_response", new=patched_chat_response):
+        with _serve_router() as env:
+            yield env
+
+
+class TestRequestChatTemplateKwargs:
+    def test_override_reaches_render_and_backend(self, router_env):
+        default_session = _create_session(router_env.url)
+        resp = _post_chat(router_env.url, default_session, {"messages": [{"role": "user", "content": "hi"}]})
+        assert resp.status_code == 200
+        default_payload = router_env.backend.request_log[-1]
+        assert default_payload["chat_template_kwargs"] == {"enable_thinking": False}
+
+        override_session = _create_session(router_env.url)
+        resp = _post_chat(
+            router_env.url,
+            override_session,
+            {
+                "messages": [{"role": "user", "content": "hi"}],
+                "chat_template_kwargs": {"enable_thinking": True},
+            },
+        )
+        assert resp.status_code == 200
+        override_payload = router_env.backend.request_log[-1]
+        assert override_payload["chat_template_kwargs"] == {"enable_thinking": True}
+        assert override_payload["input_ids"] != default_payload["input_ids"]
+
+
+def test_lora_adapter_reaches_backend():
+    with _serve_router({"lora_rank": 8}) as env:
+        session_id = _create_session(env.url)
+        response = _post_chat(env.url, session_id, {"messages": [{"role": "user", "content": "hi"}]})
+
+        assert response.status_code == 200
+        assert env.backend.request_log[-1]["lora_path"] == LORA_ADAPTER_NAME
+
+
+class TestRollbackPins:
+    """HTTP-level pins for the rollback dispatch surface (retry semantics).
+
+    These lock today's behavior before the classify/apply split rewires the
+    internals: the unit-level TestRollback suite is legitimately rewritten by
+    that split, so byte-level fidelity must live at this layer. Every 400 text
+    is asserted exactly, including interpolated numbers.
+    """
+
+    U1 = {"role": "user", "content": "What is 1+2?"}
+    T1 = {"role": "tool", "content": "tool-result-1", "tool_call_id": "t0"}
+    T1_DIFF = {"role": "tool", "content": "tool-result-DIFFERENT", "tool_call_id": "t0"}
+
+    def _turn(self, url: str, session_id: str, messages: list) -> dict:
+        resp = _post_chat(url, session_id, {"messages": messages})
+        assert resp.status_code == 200
+        return resp.json()["choices"][0]["message"]
+
+    def _get(self, url: str, session_id: str) -> dict:
+        return requests.get(f"{url}/sessions/{session_id}", timeout=5.0).json()
+
+    def _two_turn_session(self, env) -> tuple[str, dict, dict]:
+        """Stored history after this: [U1, a1, T1, a2] with 2 records."""
+        session_id = _create_session(env.url)
+        a1 = self._turn(env.url, session_id, [self.U1])
+        a2 = self._turn(env.url, session_id, [self.U1, a1, self.T1])
+        assert len(self._get(env.url, session_id)["records"]) == 2
+        return session_id, a1, a2
+
+    def test_pure_drop_retry_rolls_back_and_regenerates(self, router_env):
+        session_id, a1, _ = self._two_turn_session(router_env)
+
+        retry = _post_chat(router_env.url, session_id, {"messages": [self.U1, a1, self.T1]})
+
+        assert retry.status_code == 200
+        records = self._get(router_env.url, session_id)["records"]
+        assert len(records) == 2
+        assert records[-1]["request"]["messages"][-1] == self.T1
+
+    def test_divergent_retry_rolls_back_and_continues(self, router_env):
+        session_id, a1, _ = self._two_turn_session(router_env)
+
+        retry = _post_chat(router_env.url, session_id, {"messages": [self.U1, a1, self.T1_DIFF]})
+
+        assert retry.status_code == 200
+        records = self._get(router_env.url, session_id)["records"]
+        assert len(records) == 2
+        assert records[-1]["request"]["messages"][-1] == self.T1_DIFF
+
+    def test_deep_divergence_branches_and_keeps_both_lines(self, router_env):
+        """Was the deep-rollback 400 pin: a divergence beyond one generation now
+        branches at the deep anchor (200), the abandoned deep line stays in the
+        tree, and the samples op emits BOTH lines (deep abandons are data)."""
+        with _clean_r3_meta():
+            session_id, a1, a2 = self._two_turn_session(router_env)
+            t2 = {"role": "tool", "content": "tool-result-2", "tool_call_id": "t1"}
+            self._turn(router_env.url, session_id, [self.U1, a1, self.T1, a2, t2])
+            assert len(self._get(router_env.url, session_id)["records"]) == 3
+
+            resp = _post_chat(router_env.url, session_id, {"messages": [self.U1, a1, self.T1_DIFF]})
+
+            assert resp.status_code == 200
+            after = self._get(router_env.url, session_id)
+            # The view follows the new branch: anchor turn + the fresh generation.
+            assert len(after["records"]) == 2
+            tree = after["metadata"]["tree"]
+            assert len(tree["nodes"]) == 4
+            assert sorted(len(leaf["path_node_ids"]) for leaf in tree["leaves"]) == [2, 3]
+
+            samples = requests.post(f"{router_env.url}/sessions/{session_id}/samples", json={}, timeout=10.0)
+            assert samples.status_code == 200
+            meta = _decode_samples_meta(samples.content)
+            assert len(meta["samples"]) == 2  # the deep abandoned line still trains
+            for wire_sample in meta["samples"]:
+                # v2 serving fills SessionRecord.request_timestamp like v1 does
+                # (folding collects per-turn segments into a list).
+                lifecycle = wire_sample["metadata"]["lifecycle"]
+                segments = lifecycle if isinstance(lifecycle, list) else [lifecycle]
+                assert segments and all(seg["req_ts"] is not None for seg in segments)
+
+    def test_root_divergence_opens_new_root(self, router_env):
+        """Was the no-anchor 400 pin: divergence inside the root delta now opens
+        a second root (200); both roots produce samples."""
+        with _clean_r3_meta():
+            session_id = _create_session(router_env.url)
+            self._turn(router_env.url, session_id, [self.U1])
+
+            resp = _post_chat(
+                router_env.url, session_id, {"messages": [{"role": "user", "content": "a different opening"}]}
+            )
+
+            assert resp.status_code == 200
+            after = self._get(router_env.url, session_id)
+            assert len(after["records"]) == 1  # view follows the new root
+            tree = after["metadata"]["tree"]
+            assert [n["parent"] for n in tree["nodes"]] == [None, None]
+
+            samples = requests.post(f"{router_env.url}/sessions/{session_id}/samples", json={}, timeout=10.0)
+            assert samples.status_code == 200
+            assert len(_decode_samples_meta(samples.content)["samples"]) == 2
+
+    def test_failed_first_turn_then_different_first_request_accepted(self, router_env):
+        """A failed first turn records nothing, so a completely different first
+        request is a fresh first turn and must be accepted — the empty-session
+        accept-anything semantics that later dispatch rewrites must preserve."""
+        session_id = _create_session(router_env.url)
+
+        async def reject(self, request, compute_fn):
+            return JSONResponse(content={"error": "context too long"}, status_code=400)
+
+        with patch.object(MockSGLangServer, "_handle_generate_like_request", new=reject):
+            failed = _post_chat(router_env.url, session_id, {"messages": [self.U1]})
+        assert failed.status_code == 400
+        assert self._get(router_env.url, session_id)["records"] == []
+
+        other_first = {"role": "user", "content": "a completely different opening"}
+        resp = _post_chat(router_env.url, session_id, {"messages": [other_first]})
+        assert resp.status_code == 200
+        records = self._get(router_env.url, session_id)["records"]
+        assert len(records) == 1
+        assert records[0]["request"]["messages"] == [other_first]
+
+    def test_degenerate_extension_resend_exact_history(self, router_env):
+        session_id = _create_session(router_env.url)
+        a1 = self._turn(router_env.url, session_id, [self.U1])
+
+        resend = _post_chat(router_env.url, session_id, {"messages": [self.U1, a1]})
+
+        assert resend.status_code == 200
+        assert len(self._get(router_env.url, session_id)["records"]) == 2
+
+    def test_disallowed_append_role_400_with_rollback_side_effect(self, router_env):
+        session_id, a1, _ = self._two_turn_session(router_env)
+
+        resp = _post_chat(
+            router_env.url, session_id, {"messages": [self.U1, a1, {"role": "developer", "content": "another"}]}
+        )
+
+        assert resp.status_code == 400
+        error = resp.json()["error"]
+        assert error.endswith("; the selected TITO fixed template does not support appending this role")
+        # Characterization: today the rollback mutates BEFORE the append-only
+        # check rejects, and the 400 leaves the rolled-back state behind. The
+        # classify/apply split must keep this order.
+        assert len(self._get(router_env.url, session_id)["records"]) == 1
+
+    def test_collect_samples_after_rollback_single_sample(self, router_env):
+        from miles.rollout.session.samples.codec import decode_samples_and_merge_input_sample
+        from miles.utils.types import Sample
+
+        # The class fixture plants fake R3 replay payloads that only the
+        # records path tolerates; assembly would try to decode them. This pin
+        # is about rollback x assembly, so run it with clean meta_info.
+        fixture_response = MockSGLangServer._compute_chat_completions_response
+
+        def clean_meta_response(mock_self, payload: dict) -> dict:
+            response = fixture_response(mock_self, payload)
+            meta = response["choices"][0]["meta_info"]
+            meta.pop("routed_experts", None)
+            meta.pop("indexer_topk", None)
+            return response
+
+        with patch.object(MockSGLangServer, "_compute_chat_completions_response", new=clean_meta_response):
+            session_id, a1, _ = self._two_turn_session(router_env)
+            retry = _post_chat(router_env.url, session_id, {"messages": [self.U1, a1, self.T1]})
+            assert retry.status_code == 200
+
+            resp = requests.post(f"{router_env.url}/sessions/{session_id}/samples", json={}, timeout=10.0)
+
+        assert resp.status_code == 200
+        reply = decode_samples_and_merge_input_sample(resp.content, Sample())
+        assert reply.empty_reason is None
+        assert len(reply.samples) == 1
+        [sample] = reply.samples
+        assert sample.response_length > 0
+        assert len(sample.loss_mask) == sample.response_length
+
+    def test_few_shot_first_request_divergent_retry_rolls_back_cleanly(self, router_env):
+        """Assistants carried by the first request are prompt, not checkpoints.
+
+        Historically the rollback anchor math counted the few-shot assistant
+        as a checkpoint, so this divergent retry computed discard_count=0,
+        kept the stale second checkpoint, and answered 200 with a corrupted
+        token stream (records grew to 3). With ``prompt_assistant_count`` the
+        anchor is the generated assistant: one-step rollback + regenerate,
+        records land at 2."""
+        few_shot = [
+            {"role": "user", "content": "Q-few-shot"},
+            {"role": "assistant", "content": "A-few-shot"},
+            {"role": "user", "content": "Q-real"},
+        ]
+        session_id = _create_session(router_env.url)
+        a1 = self._turn(router_env.url, session_id, few_shot)
+        self._turn(router_env.url, session_id, [*few_shot, a1, self.T1])
+        assert len(self._get(router_env.url, session_id)["records"]) == 2
+
+        retry = _post_chat(router_env.url, session_id, {"messages": [*few_shot, a1, self.T1_DIFF]})
+
+        assert retry.status_code == 200
+        assert len(self._get(router_env.url, session_id)["records"]) == 2
+
+
+@contextmanager
+def _clean_r3_meta():
+    """The class fixture plants fake R3 replay payloads that only the records
+    path tolerates; assembly would try to decode them. Samples-op tests run
+    with clean meta_info."""
+    fixture_response = MockSGLangServer._compute_chat_completions_response
+
+    def clean_meta_response(mock_self, payload: dict) -> dict:
+        response = fixture_response(mock_self, payload)
+        meta = response["choices"][0]["meta_info"]
+        meta.pop("routed_experts", None)
+        meta.pop("indexer_topk", None)
+        return response
+
+    with patch.object(MockSGLangServer, "_compute_chat_completions_response", new=clean_meta_response):
+        yield
+
+
+def _decode_samples_meta(payload: bytes) -> dict:
+    tensors = safetensors.numpy.load(payload)
+    return json.loads(tensors["_samples_meta"].tobytes().decode("utf-8"))
+
+
+class TestTruncationAndCompaction:
+    U1 = {"role": "user", "content": "What is 1+2?"}
+    T1 = {"role": "tool", "content": "tool-result-1", "tool_call_id": "t0"}
+
+    def test_extending_truncated_generation_is_409(self, router_env):
+        session_id = _create_session(router_env.url)
+        fixture_response = MockSGLangServer._compute_chat_completions_response
+
+        def length_finish(self, payload: dict) -> dict:
+            response = fixture_response(self, payload)
+            response["choices"][0]["finish_reason"] = "length"
+            return response
+
+        with patch.object(MockSGLangServer, "_compute_chat_completions_response", new=length_finish):
+            first = _post_chat(router_env.url, session_id, {"messages": [self.U1]})
+        assert first.status_code == 200
+        a1 = first.json()["choices"][0]["message"]
+
+        extend = _post_chat(router_env.url, session_id, {"messages": [self.U1, a1, self.T1]})
+        assert extend.status_code == 409
+        assert "truncated generation cannot be extended" in extend.json()["error"]
+
+        # Branching BEFORE the cut still works: a different opening opens a new root.
+        reroot = _post_chat(router_env.url, session_id, {"messages": [{"role": "user", "content": "fresh"}]})
+        assert reroot.status_code == 200
+
+    def test_compaction_branch_with_carried_assistant(self, router_env):
+        """A branch delta carrying a client assistant (compaction) is accepted:
+        the carried assistant is prompt (loss 0 comes from assembly), and the
+        suffix render appends onto the inherited snapshot."""
+        session_id = _create_session(router_env.url)
+        first = _post_chat(router_env.url, session_id, {"messages": [self.U1]})
+        a1 = first.json()["choices"][0]["message"]
+
+        carried = {"role": "assistant", "content": "compacted summary of earlier work"}
+        resp = _post_chat(
+            router_env.url,
+            session_id,
+            {"messages": [self.U1, a1, self.T1, carried, {"role": "tool", "content": "go", "tool_call_id": "t1"}]},
+        )
+        assert resp.status_code == 200
+        meta = requests.get(f"{router_env.url}/sessions/{session_id}", timeout=5.0).json()["metadata"]
+        # Snapshot inheritance is unconditional: the carried-assistant branch
+        # commits as a child of the first generation, never as a second root.
+        nodes = meta["tree"]["nodes"]
+        assert len(nodes) == 2
+        assert nodes[1]["parent"] == nodes[0]["id"]

--- a/tests/fast/router/test_sessions_v2.py
+++ b/tests/fast/router/test_sessions_v2.py
@@ -6,8 +6,10 @@ server. The rollback pin classes mirror test_sessions_v1_pins.py so v1/v2
 behavior stays byte-comparable.
 """
 
+import asyncio
 import json
 import uuid
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from types import SimpleNamespace
 from unittest.mock import patch
@@ -21,6 +23,7 @@ from tests.fast.router.test_sessions import _create_session, _post_chat
 from miles.rollout.session.server import SessionServer
 from miles.utils.http_utils import find_available_port
 from miles.utils.lora import LORA_ADAPTER_NAME
+from miles.utils.misc import function_registry
 from miles.utils.test_utils.mock_sglang_server import MockSGLangServer, ProcessResult, with_mock_server
 from miles.utils.test_utils.uvicorn_thread_server import UvicornThreadServer
 
@@ -119,6 +122,62 @@ def test_lora_adapter_reaches_backend():
 
         assert response.status_code == 200
         assert env.backend.request_log[-1]["lora_path"] == LORA_ADAPTER_NAME
+
+
+def _keep_all_picker(leaf_samples, _session_metadata):
+    return list(leaf_samples)
+
+
+def test_concurrent_requests_from_same_parent_commit_siblings():
+    """Successful concurrent generations from one parent are both collected."""
+    picker_path = "miles.rollout.session.v2.picker_hub.drop_retries"
+    with function_registry.temporary(picker_path, _keep_all_picker):
+        with _serve_router() as env:
+            session_id = _create_session(env.url)
+            first = _post_chat(env.url, session_id, {"messages": [{"role": "user", "content": "start"}]})
+            assert first.status_code == 200
+            assistant = first.json()["choices"][0]["message"]
+            payload = {
+                "messages": [
+                    {"role": "user", "content": "start"},
+                    assistant,
+                    {"role": "user", "content": "branch"},
+                ]
+            }
+
+            arrivals = 0
+            release = None
+
+            async def wait_for_pair(self, request, compute_fn):
+                nonlocal arrivals, release
+                payload = await request.json()
+                self.request_log.append(payload)
+                if release is None:
+                    release = asyncio.Event()
+                arrivals += 1
+                if arrivals == 2:
+                    release.set()
+                await asyncio.wait_for(release.wait(), timeout=5.0)
+                return JSONResponse(content=compute_fn(payload))
+
+            with patch.object(MockSGLangServer, "_handle_generate_like_request", new=wait_for_pair):
+                with ThreadPoolExecutor(max_workers=2) as pool:
+                    futures = [pool.submit(_post_chat, env.url, session_id, payload) for _ in range(2)]
+                    responses = [future.result(timeout=10.0) for future in futures]
+
+            assert all(response.status_code == 200 for response in responses)
+            response_ids = {response.json()["id"] for response in responses}
+            tree = requests.get(f"{env.url}/sessions/{session_id}", timeout=5.0).json()["metadata"]["tree"]
+            parent_id = tree["nodes"][0]["id"]
+            children = tree["nodes"][1:]
+            assert len(children) == 2
+            assert {child["parent"] for child in children} == {parent_id}
+            assert {child["response_id"] for child in children} == response_ids
+
+            samples = requests.post(f"{env.url}/sessions/{session_id}/samples", json={}, timeout=10.0)
+            assert samples.status_code == 200
+            sample_meta = _decode_samples_meta(samples.content)
+            assert {sample["metadata"]["leaf"]["response_id"] for sample in sample_meta["samples"]} == response_ids
 
 
 class TestRollbackPins:

--- a/tests/fast/router/test_tree_assembly_invariants.py
+++ b/tests/fast/router/test_tree_assembly_invariants.py
@@ -1,0 +1,312 @@
+"""Tree-merge invariants for randomized forests and targeted edges.
+
+The independent oracle checks:
+
+1. token fields match each possibly truncated leaf snapshot;
+2. every kept completion span is trainable in exactly one surviving leaf;
+3. temporal retry trimming accepts shorter replacements;
+4. one trajectory reward reaches every kept sample;
+5. samples sort by checkpoint count, then leaf seq, descending.
+"""
+
+import json
+import random
+import uuid
+from types import SimpleNamespace
+
+import pytest
+from tests.fast.rollout.session.test_samples import _make_record
+
+from miles.rollout.session.samples.codec import COMPUTED_FIELDS_V2, decode_samples_and_merge_input_sample
+from miles.rollout.session.v2.core import SessionCoreV2
+from miles.rollout.session.v2.session_state import SessionRegistryV2
+from miles.utils.chat_template_utils import get_tito_tokenizer
+from miles.utils.processing_utils import load_tokenizer
+from miles.utils.types import Sample
+
+_ARGS = SimpleNamespace(
+    miles_router_timeout=30,
+    hf_checkpoint="Qwen/Qwen3-0.6B",
+    chat_template_path=None,
+    apply_chat_template_kwargs={"enable_thinking": False},
+    tito_model="default",
+    sglang_speculative_algorithm=None,
+    session_server_instance_id=uuid.uuid4().hex,
+    save_debug_trajectory_data=None,
+    session_sample_picker_path="miles.rollout.session.v2.picker_hub.drop_retries",
+    session_sample_postprocessor_path="miles.rollout.session.v2.postprocessor_hub.default_postprocess",
+)
+
+
+class _UnusedBackend:
+    async def do_proxy(self, *args, **kwargs):
+        raise AssertionError("collect_samples must not touch the proxy backend")
+
+
+@pytest.fixture(scope="module")
+def core():
+    tokenizer = load_tokenizer(_ARGS.hf_checkpoint, chat_template_path=None, trust_remote_code=True)
+    tito_tokenizer = get_tito_tokenizer(
+        tokenizer,
+        tokenizer_type=_ARGS.tito_model,
+        chat_template_kwargs=_ARGS.apply_chat_template_kwargs,
+    )
+    registry = SessionRegistryV2(_ARGS, tokenizer, tito_tokenizer=tito_tokenizer)
+    return SessionCoreV2(_UnusedBackend(), registry, _ARGS, _ARGS.session_server_instance_id)
+
+
+class _Grower:
+    """Grows legal trees out of synthetic records with globally unique token ids."""
+
+    def __init__(self, state):
+        self.state = state
+        self.next_token = 1
+
+    def _fresh(self, n: int) -> list[int]:
+        ids = list(range(self.next_token, self.next_token + n))
+        self.next_token += n
+        return ids
+
+    def grow(self, parent, *, env_len: int, completion_len: int, finish_reason: str = "stop"):
+        prefix = parent.token_ids if parent is not None else []
+        prompt = prefix + self._fresh(env_len)
+        completion = self._fresh(completion_len)
+        record = _make_record(prompt_token_ids=prompt, output_token_ids=completion, finish_reason=finish_reason)
+        return self.state.tree.create_node(
+            parent,
+            delta_messages=[],
+            token_ids=prompt + completion,
+            completion_span=(len(prompt), len(prompt) + len(completion)),
+            committed_at=float(len(self.state.tree.nodes)),
+            response_id=f"resp-{len(self.state.tree.nodes)}",
+            record=record,
+            finish_reason=finish_reason,
+        )
+
+
+async def _fresh_grower(core):
+    response = await core.create_session()
+    sid = json.loads(response.body)["session_id"]
+    state = core.registry.sessions[sid]
+    return sid, state, _Grower(state)
+
+
+def _oracle_pick(state):
+    """Independent re-derivation of ruling F: (kept, trimmed)."""
+    kept, trimmed = [], []
+    for leaf in state.tree.leaves():
+        if leaf.parent is None:
+            kept.append(leaf)
+            continue
+        later = [s for s in leaf.parent.children if s.seq > leaf.seq]
+        if not later:
+            kept.append(leaf)
+            continue
+        trimmed.append(leaf)
+    kept.sort(key=lambda leaf: (len(leaf.path_nodes()), leaf.seq), reverse=True)
+    return kept, trimmed
+
+
+def _oracle_owner(kept):
+    owner = {}
+    for leaf in sorted(kept, key=lambda leaf: leaf.seq):
+        for node in leaf.path_nodes():
+            owner.setdefault(node.seq, leaf.seq)
+    return owner
+
+
+def _assert_sample_legality(sample: Sample, leaf, owner: dict[int, int]) -> None:
+    snapshot = leaf.token_ids
+    assert sample.tokens == snapshot[: len(sample.tokens)], "sample tokens must be a prefix of the leaf snapshot"
+    assert len(sample.loss_mask) == sample.response_length
+    assert len(sample.rollout_log_probs) == sample.response_length
+
+    response_start = len(sample.tokens) - sample.response_length
+    trained = {response_start + i for i, bit in enumerate(sample.loss_mask) if bit == 1}
+    expected = set()
+    for node in leaf.path_nodes():
+        if owner[node.seq] != leaf.seq:
+            continue
+        lo, hi = node.completion_span
+        expected |= set(range(lo, min(hi, len(sample.tokens))))
+    # Mid-path early-stop (a non-COMPLETED turn ends the fold) may keep the
+    # sample shorter than the snapshot; trained positions must then be the
+    # owned completions clipped to the kept range.
+    expected = {p for p in expected if response_start <= p < len(sample.tokens)}
+    assert trained == expected, f"exactly-once violated: trained={sorted(trained)} expected={sorted(expected)}"
+
+
+async def _collect(core, sid, *, max_seq_len=None, agent_metadata=None):
+    response = await core.collect_samples(sid, max_seq_len=max_seq_len, agent_metadata=agent_metadata)
+    return response.status_code, bytes(response.body)
+
+
+def _grow_random_tree(grower, rng: random.Random, *, allow_shorter_retries: bool = False):
+    """Grow a random forest, optionally allowing shorter retry branches."""
+    grower.grow(None, env_len=rng.randint(1, 3), completion_len=rng.randint(1, 4))
+    for _ in range(rng.randint(2, 9)):
+        state = grower.state
+        op = rng.random()
+        leaves = state.tree.leaves()
+        if op < 0.15:  # new root (subagent)
+            grower.grow(None, env_len=rng.randint(1, 3), completion_len=rng.randint(1, 4))
+        elif op < 0.45:  # retry: supersede a random childless leaf with a sibling
+            leaf = rng.choice(leaves)
+            if leaf.parent is None:
+                grower.grow(leaf, env_len=rng.randint(1, 2), completion_len=rng.randint(1, 3))
+                continue
+            abandoned_len = len(leaf.token_ids) - len(leaf.parent.token_ids)
+            floor = 1 if allow_shorter_retries else max(1, abandoned_len)
+            grower.grow(
+                leaf.parent,
+                env_len=rng.randint(1, 2),
+                completion_len=max(floor, rng.randint(1, abandoned_len + 2)),
+            )
+        else:  # extend a random leaf
+            grower.grow(rng.choice(leaves), env_len=rng.randint(1, 2), completion_len=rng.randint(1, 3))
+
+
+@pytest.mark.parametrize("seed", range(25))
+async def test_fuzz_forest_assembly_invariants(core, seed):
+    sid, state, grower = await _fresh_grower(core)
+    rng = random.Random(seed)
+    _grow_random_tree(grower, rng)
+    state.active_leaf = state.tree.leaves()[-1]
+
+    kept, trimmed = _oracle_pick(state)
+    trajectory_reward = round(rng.random(), 3)
+
+    status, payload = await _collect(core, sid, agent_metadata={"reward": trajectory_reward})
+    assert status == 200
+    reply = decode_samples_and_merge_input_sample(payload, Sample(), fields=COMPUTED_FIELDS_V2)
+    assert len(reply.samples) == len(kept)
+    owner = _oracle_owner(kept)
+    for sample, leaf in zip(reply.samples, kept, strict=True):
+        assert sample.metadata["leaf"]["node_id"] == leaf.seq
+        _assert_sample_legality(sample, leaf, owner)
+        assert sample.reward == trajectory_reward
+    emitted = {s.metadata["leaf"]["node_id"] for s in reply.samples}
+    assert emitted.isdisjoint({leaf.seq for leaf in trimmed})
+
+
+@pytest.mark.parametrize("seed", range(50, 70))
+async def test_fuzz_shorter_replacements_assemble_legally(core, seed):
+    """Shorter replacements still assemble under the temporal trim rule."""
+    sid, state, grower = await _fresh_grower(core)
+    rng = random.Random(seed)
+    _grow_random_tree(grower, rng, allow_shorter_retries=True)
+    state.active_leaf = state.tree.leaves()[-1]
+
+    kept, _ = _oracle_pick(state)
+    status, payload = await _collect(core, sid)
+    assert status == 200
+    reply = decode_samples_and_merge_input_sample(payload, Sample(), fields=COMPUTED_FIELDS_V2)
+    assert len(reply.samples) == len(kept)
+    owner = _oracle_owner(kept)
+    for sample, leaf in zip(reply.samples, kept, strict=True):
+        _assert_sample_legality(sample, leaf, owner)
+
+
+@pytest.mark.parametrize("seed", range(25, 35))
+async def test_fuzz_forest_invariants_under_truncation(core, seed):
+    sid, state, grower = await _fresh_grower(core)
+    rng = random.Random(seed)
+    _grow_random_tree(grower, rng)
+    state.active_leaf = state.tree.leaves()[-1]
+
+    kept, _ = _oracle_pick(state)
+    max_seq_len = rng.randint(4, 12)
+
+    status, payload = await _collect(core, sid, max_seq_len=max_seq_len)
+    assert status == 200
+    reply = decode_samples_and_merge_input_sample(payload, Sample(), fields=COMPUTED_FIELDS_V2)
+    if not reply.samples:
+        assert reply.empty_reason == "all_truncated"
+        return
+    # Leaves whose every turn truncated away drop from the material; the
+    # survivors' ownership is recomputed over what remains (no orphan spans).
+    emitted_ids = [s.metadata["leaf"]["node_id"] for s in reply.samples]
+    emitted_leaves = [next(leaf for leaf in kept if leaf.seq == node_id) for node_id in emitted_ids]
+    owner = _oracle_owner(emitted_leaves)
+    for sample, leaf in zip(reply.samples, emitted_leaves, strict=True):
+        assert len(sample.tokens) <= max_seq_len
+        _assert_sample_legality(sample, leaf, owner)
+
+
+class TestTargetedEdges:
+    async def test_chained_retries_single_survivor(self, core):
+        sid, state, grower = await _fresh_grower(core)
+        root = grower.grow(None, env_len=2, completion_len=2)
+        for _ in range(3):  # three abandoned attempts, each superseded
+            grower.grow(root, env_len=1, completion_len=2)
+        survivor = grower.grow(root, env_len=1, completion_len=2)
+        state.active_leaf = survivor
+
+        status, payload = await _collect(core, sid)
+        assert status == 200
+        reply = decode_samples_and_merge_input_sample(payload, Sample(), fields=COMPUTED_FIELDS_V2)
+        (sample,) = reply.samples
+        assert sample.metadata["leaf"]["node_id"] == survivor.seq
+
+    async def test_twins_equal_length_earlier_trimmed(self, core):
+        sid, state, grower = await _fresh_grower(core)
+        root = grower.grow(None, env_len=2, completion_len=2)
+        grower.grow(root, env_len=1, completion_len=2)
+        twin_b = grower.grow(root, env_len=1, completion_len=2)
+        state.active_leaf = twin_b
+
+        status, payload = await _collect(core, sid)
+        assert status == 200
+        reply = decode_samples_and_merge_input_sample(payload, Sample(), fields=COMPUTED_FIELDS_V2)
+        (sample,) = reply.samples  # temporal rule: the earlier equal-length twin is trimmed
+        assert sample.metadata["leaf"]["node_id"] == twin_b.seq
+
+    async def test_fork_below_fork_ownership_nesting(self, core):
+        """Two nested fork points: each shared span trains exactly once, in
+        the earliest surviving leaf that contains it."""
+        sid, state, grower = await _fresh_grower(core)
+        root = grower.grow(None, env_len=2, completion_len=2)
+        mid = grower.grow(root, env_len=1, completion_len=2)
+        deep_a = grower.grow(mid, env_len=1, completion_len=2)  # earliest leaf: owns root+mid+own
+        grower.grow(deep_a, env_len=1, completion_len=2)  # extend: deep_a no longer a leaf
+        grower.grow(mid, env_len=1, completion_len=3)  # later sibling below mid
+        side = grower.grow(root, env_len=1, completion_len=4)  # sibling below root
+        state.active_leaf = side
+
+        kept, _ = _oracle_pick(state)
+        status, payload = await _collect(core, sid)
+        assert status == 200
+        reply = decode_samples_and_merge_input_sample(payload, Sample(), fields=COMPUTED_FIELDS_V2)
+        assert len(reply.samples) == len(kept)
+        owner = _oracle_owner(kept)
+        for sample, leaf in zip(reply.samples, kept, strict=True):
+            _assert_sample_legality(sample, leaf, owner)
+        # Cross-check: the union of trained spans over all samples covers each
+        # surviving-path completion exactly once.
+        span_train_count: dict[int, int] = {}
+        for sample, leaf in zip(reply.samples, kept, strict=True):
+            response_start = len(sample.tokens) - sample.response_length
+            trained = {response_start + i for i, bit in enumerate(sample.loss_mask) if bit == 1}
+            for node in leaf.path_nodes():
+                lo, hi = node.completion_span
+                if set(range(lo, hi)) <= trained:
+                    span_train_count[node.seq] = span_train_count.get(node.seq, 0) + 1
+        surviving_nodes = {node.seq for leaf in kept for node in leaf.path_nodes()}
+        assert span_train_count == {seq: 1 for seq in surviving_nodes}
+
+    async def test_midpath_length_turn_early_stops_but_stays_legal(self, core):
+        """A non-COMPLETED mid-path turn ends the fold (documented early-stop):
+        the sample stops at that turn and every trained position still lies in
+        an owned completion span."""
+        sid, state, grower = await _fresh_grower(core)
+        root = grower.grow(None, env_len=2, completion_len=2)
+        cut = grower.grow(root, env_len=1, completion_len=2, finish_reason="length")
+        leaf = grower.grow(cut, env_len=1, completion_len=2)
+        state.active_leaf = leaf
+
+        status, payload = await _collect(core, sid)
+        assert status == 200
+        reply = decode_samples_and_merge_input_sample(payload, Sample(), fields=COMPUTED_FIELDS_V2)
+        (sample,) = reply.samples
+        assert len(sample.tokens) == len(cut.token_ids)  # fold stopped at the length turn
+        _assert_sample_legality(sample, leaf, _oracle_owner([leaf]))


### PR DESCRIPTION
> **Depends on:** #2125
> Stacked on the parent PR's branch. Review / merge the parent first.

## Summary

Expose trajectory-tree collection as opt-in session server v2.

## Motivation

Users need a place to select complete trajectories and optionally assign trajectory rewards without changing normal reward-function semantics or coupling that choice to retry removal.

## Usage

Start Miles with `--use-session-server v2`; optionally replace selection with `--session-sample-picker-path` or finalization with `--session-sample-postprocessor-path`.

## Design Notes

- **Key choices:** Version dispatch selects `SessionCoreV2` only for explicit v2.
- `drop_retries` owns trajectory selection.
- `default_postprocess` finalizes the selected samples.
- A missing trajectory reward defers scoring downstream.
- Leaf ordering prefers deeper checkpoint paths, then later committed leaves.

## Verification

- **Tests added:** `test_sessions_v2.py` covers the `SessionCoreV2` HTTP contract, including LoRA adapter propagation.
- **Tests added:** `test_session_samples_op_v2.py` covers picker and postprocessor behavior.
- **Tests added:** `test_tree_assembly_invariants.py` checks assembly invariants across randomized forests.

## Review Focus

- Scrutinize `SessionCoreV2.collect_samples` for the picker-to-postprocessor boundary.
- Scrutinize `drop_retries` for complete-trajectory ordering and retry supersession.
- Scrutinize `default_postprocess` for metadata ownership, masking, and optional reward assignment.
