### PR TITLE
docs(tito): rename the guide for agentic rollout

### DIFF
--- a/docs/user-guide/agentic-chat-template.md
+++ b/docs/user-guide/agentic-chat-template.md
@@ -1,9 +1,9 @@
 ---
-title: Agentic Chat Templates (TITO)
+title: Agentic Rollout (TITO)
 description: How to turn on and verify Token-In-Token-Out (TITO) for multi-turn agentic rollout.
 ---
 
-# Agentic Chat Templates (TITO)
+# Agentic Rollout (TITO)
 
 Multi-turn agentic rollout in Miles runs on **TITO** (Token-In-Token-Out): each turn's token sequence is a bit-perfect prefix of the next, so the trainer sees exactly the tokens the engine produced — no re-tokenization, no drift. The *why* is in the blog ([No Token Left Behind](https://lmsys.org/blog/2026-05-13-no-token-left-behind/)); this page is *how*.
 

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -12,7 +12,7 @@ description: Concepts, launch script walkthrough, customization hooks, and a com
 | [Customization](/user-guide/customization) | The 21 `--*-path` plug-points for custom Python — rollout, reward, filters, loss, hooks. |
 | [Rollout Endpoints](/user-guide/rollout-endpoints) | The `/generate` endpoint and the OpenAI chat endpoint for agentic sessions. |
 | [Fully Async Rollout](/user-guide/fully-async) | Queue-backed rollout production, tuning knobs, and when to use `train_async.py`. |
-| [Agentic Chat Templates](/user-guide/agentic-chat-template) | Turning on and verifying TITO so multi-turn agentic rollout stays append-only. |
+| [Agentic Rollout (TITO)](/user-guide/agentic-chat-template) | Turning on and verifying TITO so multi-turn agentic rollout stays append-only. |
 | [CLI Reference](/user-guide/cli-reference) | Every flag Miles accepts, grouped by subsystem. |
 | [Environments](/user-guide/environments) | Supplying an environment: dataset + reward, your own env via the plug points, or an external ecosystem. |
 

--- a/docs/user-guide/rollout-endpoints.md
+++ b/docs/user-guide/rollout-endpoints.md
@@ -256,6 +256,6 @@ inherited across turns. Each request is tokenized independently.
 ## Next
 
 - [Customization](/user-guide/customization): the full catalog of `--*-path` hooks.
-- [Agentic Chat Templates](/user-guide/agentic-chat-template): verifying that a template is
+- [Agentic Rollout (TITO)](/user-guide/agentic-chat-template): verifying that a template is
   append-only across turns.
 - [Multi-agent example](/examples/multi-agent): full agentic walkthrough.

--- a/miles/utils/chat_template_utils/tito_tokenizer.py
+++ b/miles/utils/chat_template_utils/tito_tokenizer.py
@@ -85,7 +85,7 @@ class TITOTokenizer:
     trailing_token_ids: frozenset[int] = frozenset()
     chat_template_kwarg_aliases: frozenset[str] = frozenset()
 
-    # The family's fixed renderer contract.  DEFAULT uses the model's native
+    # The family's fixed renderer contract. DEFAULT uses the model's native
     # template with the maximal best-effort append surface.
     FIXED_TEMPLATE: FixedTemplate = FixedTemplate()
 
@@ -191,7 +191,9 @@ class TITOTokenizer:
         """Compute incremental token IDs for messages appended after the
         pretokenized prefix.
 
-        Appended roles must be listed in ``self.allowed_append_roles``.  The method validates that *new_messages* is an append-only extension of *old_messages* via ``assert_messages_append_only_with_allowed_role``.
+        Appended roles must be listed in ``self.allowed_append_roles``.  The
+        method validates that *new_messages* is an append-only extension of
+        *old_messages* via ``assert_messages_append_only_with_allowed_role``.
 
         Args:
             old_messages: Previously stored messages (prefix).


### PR DESCRIPTION
> **Depends on:** #2126
> Stacked on the parent PR's branch. Review / merge the parent first.

## Summary

Rename the TITO guide around its user-facing agentic rollout purpose.

## Motivation

The documentation names TITO as the agentic rollout path while preserving the existing guide location and runtime behavior.

## Before / After

- **Before / After:** User-facing references described the page as a chat-template guide; they now name Agentic Rollout (TITO).
- **What moved where:** No file path moves.
- All user-facing references use the new terminology.

## Behavior Preservation

- **How we know:** `docs/user-guide/agentic-chat-template.md` keeps its URL.
- The tokenizer code diff changes only comments and docstrings.

## Verification

- **Existing test suite:** Pre-commit passed on the complete chain.

## Review Focus

- Scrutinize the terminology across `agentic-chat-template.md`, `index.md`, and `rollout-endpoints.md`.
- Scrutinize `tito_tokenizer.py` to confirm the diff changes prose only.
