### PR TITLE
feat(rollout): bridge agentic generation to session server v2

### DIFF
--- a/docs/user-guide/rollout-endpoints.md
+++ b/docs/user-guide/rollout-endpoints.md
@@ -181,6 +181,14 @@ remain a `messages` list. SGLang handles templating server-side.
 
 </Warning>
 
+<Warning>
+
+**Session server v2 output is a `list[Sample]`.** With `--use-session-server v2`, `agentic_tool_call.generate` returns one sample for each selected tree leaf. The v1 session server returns one scalar `Sample`.
+
+A custom reward model (`--custom-rm-path`) receives the v2 samples in batch form. `--group-rm`, `--partial-rollout`, and `--recompute-logprobs-via-prefill` are not supported with this v2 agentic output and are rejected explicitly.
+
+</Warning>
+
 ### Optional teardown: the `abort` hook
 
 The module named by `--custom-agent-function-path` may expose an optional `abort`

--- a/miles/rollout/generate_hub/agentic_tool_call.py
+++ b/miles/rollout/generate_hub/agentic_tool_call.py
@@ -46,6 +46,7 @@ async def generate(input: GenerateFnInput) -> GenerateFnOutput:
         "agentic_tool_call.generate requires session_server_ip/session_server_ports. "
         "Pass --use-session-server to start the session server."
     )
+    use_v2 = getattr(input.args, "use_session_server", None) == "v2"
     tracer = await OpenAIEndpointTracer.create(input.args)
 
     custom_agent_function: Callable = load_function(input.args.custom_agent_function_path)
@@ -84,11 +85,11 @@ async def generate(input: GenerateFnInput) -> GenerateFnOutput:
     finally:
         # Collect even if the agent failed.
         logger.debug(f"{log_prefix} Calling collect_samples...")
+        collect_kwargs = {"max_seq_len": max_seq_len}
+        if use_v2:
+            collect_kwargs["agent_metadata"] = agent_metadata
         try:
-            result = await tracer.collect_samples(
-                input.sample,
-                max_seq_len=max_seq_len,
-            )
+            result = await tracer.collect_samples(input.sample, **collect_kwargs)
         except asyncio.TimeoutError:
             collect_timed_out = True
             logger.warning(f"{log_prefix} Timed out collecting samples", exc_info=True)
@@ -101,7 +102,7 @@ async def generate(input: GenerateFnInput) -> GenerateFnOutput:
     if collect_timed_out:
         sample = deepcopy(input.sample)
         sample.status = Sample.Status.ABORTED
-        return GenerateFnOutput(samples=sample)
+        return GenerateFnOutput(samples=[sample] if use_v2 else sample)
 
     if not result.samples:
         if result.empty_reason == "all_truncated":
@@ -110,11 +111,15 @@ async def generate(input: GenerateFnInput) -> GenerateFnOutput:
             logger.warning("No model calls recorded for sample")
         sample = deepcopy(input.sample)
         sample.status = Sample.Status.ABORTED
-        return GenerateFnOutput(samples=sample)
+        return GenerateFnOutput(samples=[sample] if use_v2 else sample)
 
     samples = result.samples
-    for s in samples:
-        s.metadata.update(agent_metadata or {})
+    if not use_v2:
+        # v1: the agent's metadata is applied driver-side. Under v2 it traveled
+        # through collect_samples and came back applied by the server-side
+        # merge (per-sample metadata/reward on the wire) — no overlay here.
+        for s in samples:
+            s.metadata.update(agent_metadata or {})
 
     # If the agent function reports wall-clock time spent outside policy generation
     # (env/tool steps), surface it on Sample.non_generation_time so throughput
@@ -123,6 +128,9 @@ async def generate(input: GenerateFnInput) -> GenerateFnOutput:
     if ngt is not None:
         for s in samples:
             s.non_generation_time = ngt
+
+    if use_v2:
+        return GenerateFnOutput(samples=samples)
 
     (sample,) = samples
     sample.metadata.update(result.session_metadata)

--- a/miles/rollout/generate_utils/openai_endpoint_utils.py
+++ b/miles/rollout/generate_utils/openai_endpoint_utils.py
@@ -7,7 +7,12 @@ import logging
 import random
 from argparse import Namespace
 
-from miles.rollout.session.samples.codec import SamplesReply, decode_samples_and_merge_input_sample
+from miles.rollout.session.samples.codec import (
+    COMPUTED_FIELDS,
+    COMPUTED_FIELDS_V2,
+    SamplesReply,
+    decode_samples_and_merge_input_sample,
+)
 from miles.utils.http_utils import post, post_bytes_no_retry
 from miles.utils.types import Sample
 
@@ -17,11 +22,21 @@ _SESSION_REQUEST_TIMEOUT = 120
 
 
 class OpenAIEndpointTracer:
-    def __init__(self, router_url: str, session_id: str, session_server_instance_id: str | None = None):
+    def __init__(
+        self,
+        router_url: str,
+        session_id: str,
+        session_server_instance_id: str | None = None,
+        samples_wire_fields: tuple[str, ...] = COMPUTED_FIELDS,
+    ):
         self.router_url = router_url
         self.session_id = session_id
         self.base_url = f"{router_url}/sessions/{session_id}"
         self.session_server_instance_id = session_server_instance_id
+        # The samples-wire allowlist must match the server's encode: v1 default,
+        # extended under --use-session-server v2 (create() selects from args;
+        # direct constructions keep v1).
+        self.samples_wire_fields = samples_wire_fields
 
     @property
     def session_server_id(self) -> str:
@@ -45,19 +60,26 @@ class OpenAIEndpointTracer:
         session_server_instance_id = instance_ids.get(session_port)
         response = await post(f"{session_url}/sessions", {}, action="post")
         session_id = response["session_id"]
+        use_v2 = getattr(args, "use_session_server", None) == "v2"
         return OpenAIEndpointTracer(
             router_url=session_url,
             session_id=session_id,
             session_server_instance_id=session_server_instance_id,
+            samples_wire_fields=COMPUTED_FIELDS_V2 if use_v2 else COMPUTED_FIELDS,
         )
 
-    async def collect_samples(self, input_sample: Sample, *, max_seq_len: int | None) -> SamplesReply:
+    async def collect_samples(
+        self, input_sample: Sample, *, max_seq_len: int | None, agent_metadata: dict | None = None
+    ) -> SamplesReply:
         """Fetch server-assembled training samples for this session."""
+        body: dict = {"max_seq_len": max_seq_len}
+        if agent_metadata is not None:
+            body["metadata"] = agent_metadata
         try:
             # `asyncio.TimeoutError` propagates after cleanup is attempted for `agentic_tool_call.generate` to handle.
             payload = await post_bytes_no_retry(
                 f"{self.base_url}/samples",
-                {"max_seq_len": max_seq_len},
+                body,
                 timeout=_SESSION_REQUEST_TIMEOUT,
             )
         finally:
@@ -69,4 +91,4 @@ class OpenAIEndpointTracer:
             except Exception as e:
                 logger.warning(f"Failed to delete session {self.session_id} after collecting samples: {e}")
 
-        return decode_samples_and_merge_input_sample(payload, input_sample)
+        return decode_samples_and_merge_input_sample(payload, input_sample, fields=self.samples_wire_fields)

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -2748,6 +2748,21 @@ def miles_validate_args(args):
             "tree serving."
         )
 
+    if args.use_session_server == "v2":
+        unsupported = [
+            flag
+            for enabled, flag in (
+                (args.group_rm, "--group-rm"),
+                (args.partial_rollout, "--partial-rollout"),
+                (args.recompute_logprobs_via_prefill, "--recompute-logprobs-via-prefill"),
+            )
+            if enabled
+        ]
+        if unsupported:
+            raise ValueError(
+                f"--use-session-server v2 does not support {', '.join(unsupported)}; v2 returns list[Sample]"
+            )
+
     if not args.use_session_server and args.tito_model != TITOTokenizerType.DEFAULT.value:
         raise ValueError(
             f"--tito-model={args.tito_model} requires --use-session-server; "

--- a/miles/utils/test_utils/session_verify_runner.py
+++ b/miles/utils/test_utils/session_verify_runner.py
@@ -181,7 +181,11 @@ def namespace_to_train_args(ns: argparse.Namespace) -> str:
             ]
         )
     if ns.use_session_server:
-        parts.append("--use-session-server")
+        # Preserve an explicit version string ("v2"); a bare True stays the bare flag.
+        if isinstance(ns.use_session_server, str):
+            parts.append(f"--use-session-server {ns.use_session_server}")
+        else:
+            parts.append("--use-session-server")
     if ns.debug_rollout_only:
         parts.append("--debug-rollout-only")
     if ns.ci_test:

--- a/tests/fast/rollout/generate_hub/test_agentic_v2.py
+++ b/tests/fast/rollout/generate_hub/test_agentic_v2.py
@@ -1,0 +1,94 @@
+from types import SimpleNamespace
+
+import pytest
+
+import miles.rollout.generate_hub.agentic_tool_call as agentic_tool_call
+from miles.rollout.base_types import GenerateFnInput
+from miles.rollout.session.samples.codec import SamplesReply
+from miles.utils.types import Sample
+
+
+class _Tracer:
+    session_id = "sid-1"
+    session_server_id = "127.0.0.1:12345"
+    session_server_instance_id = None
+    base_url = "http://127.0.0.1:12345/sessions/sid-1"
+
+    def __init__(self, reply=None, error=None):
+        self.reply = reply
+        self.error = error
+        self.agent_metadata = None
+
+    async def collect_samples(self, input_sample, *, max_seq_len, agent_metadata=None):
+        self.agent_metadata = agent_metadata
+        if self.error is not None:
+            raise self.error
+        return self.reply
+
+
+def _generate_input(**args_kwargs) -> GenerateFnInput:
+    args = SimpleNamespace(
+        session_server_ip="127.0.0.1",
+        session_server_ports=[12345],
+        custom_agent_function_path="test.fake_agent",
+        max_seq_len=None,
+        use_session_server="v2",
+        **args_kwargs,
+    )
+    state = SimpleNamespace(args=args)
+    sample = Sample(
+        group_index=3,
+        index=7,
+        prompt=[{"role": "user", "content": "hello"}],
+        label="label",
+        metadata={"source": "test"},
+    )
+    return GenerateFnInput(state=state, sample=sample, sampling_params={}, evaluation=False)
+
+
+async def _fake_agent(**kwargs):
+    return {"agent_result": "done"}
+
+
+def _patch_agent(monkeypatch, tracer):
+    async def fake_create(args):
+        return tracer
+
+    monkeypatch.setattr(agentic_tool_call.OpenAIEndpointTracer, "create", fake_create)
+    monkeypatch.setattr(agentic_tool_call, "load_function", lambda path: _fake_agent)
+
+
+@pytest.mark.asyncio
+async def test_success_returns_list_and_forwards_agent_metadata(monkeypatch):
+    sample = Sample(status=Sample.Status.COMPLETED, response="done", response_length=1, tokens=[1])
+    tracer = _Tracer(SamplesReply(samples=[sample], session_metadata={}, empty_reason=None))
+    _patch_agent(monkeypatch, tracer)
+
+    output = await agentic_tool_call.generate(_generate_input())
+
+    assert output.samples == [sample]
+    assert tracer.agent_metadata == {"agent_result": "done"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("empty_reason", ["no_records", "all_truncated"])
+async def test_empty_reply_returns_aborted_list(monkeypatch, empty_reason):
+    tracer = _Tracer(SamplesReply(samples=[], session_metadata={}, empty_reason=empty_reason))
+    _patch_agent(monkeypatch, tracer)
+    generate_input = _generate_input()
+
+    output = await agentic_tool_call.generate(generate_input)
+
+    assert isinstance(output.samples, list)
+    assert len(output.samples) == 1
+    assert output.samples[0] is not generate_input.sample
+    assert output.samples[0].status == Sample.Status.ABORTED
+
+
+@pytest.mark.asyncio
+async def test_collection_error_propagates(monkeypatch):
+    tracer = _Tracer(error=RuntimeError("samples unavailable"))
+    _patch_agent(monkeypatch, tracer)
+
+    with pytest.raises(RuntimeError, match="samples unavailable"):
+        await agentic_tool_call.generate(_generate_input())

--- a/tests/fast/rollout/generate_utils/test_openai_endpoint_utils.py
+++ b/tests/fast/rollout/generate_utils/test_openai_endpoint_utils.py
@@ -233,3 +233,66 @@ async def test_post_bytes_no_retry_transport_error_propagates_once(monkeypatch):
     with pytest.raises(ConnectionError, match="boom"):
         await post_bytes_no_retry("http://x/samples", {}, timeout=5)
     assert client.post_count == 1
+
+
+# ── v2 wire (--use-session-server v2): metadata channel + extended fields ──
+
+
+@pytest.mark.asyncio
+async def test_collect_samples_v2_payload_carries_metadata_and_decodes_extras(monkeypatch):
+    """v2 pin: the collect body gains the "metadata" key only when the caller
+    passes agent metadata, and the v2 field tuple overlays reward + merged
+    metadata; the v1 pin above (`payload == {"max_seq_len": 7}`) stays."""
+    from miles.rollout.session.samples.codec import COMPUTED_FIELDS_V2
+
+    sample = Sample()
+    sample.tokens = [1, 2, 10]
+    sample.response = "r"
+    sample.response_length = 1
+    sample.loss_mask = [1]
+    sample.rollout_log_probs = [-0.5]
+    sample.status = Sample.Status.COMPLETED
+    sample.reward = 0.75
+    sample.metadata = {"leaf": {"node_id": 1}}
+    payload = encode_samples([sample], {"max_trim_tokens": 1}, None, fields=COMPUTED_FIELDS_V2)
+
+    seen = []
+
+    async def fake_post_bytes(url, body, *, timeout):
+        seen.append(body)
+        return payload
+
+    async def fake_post(url, body, action="post"):
+        assert action == "delete"
+        return {}
+
+    monkeypatch.setattr("miles.rollout.generate_utils.openai_endpoint_utils.post_bytes_no_retry", fake_post_bytes)
+    monkeypatch.setattr("miles.rollout.generate_utils.openai_endpoint_utils.post", fake_post)
+
+    tracer = OpenAIEndpointTracer(
+        router_url="http://127.0.0.1:12345", session_id="sid-1", samples_wire_fields=COMPUTED_FIELDS_V2
+    )
+    input_sample = Sample()
+    input_sample.metadata = {"env": "keep-me"}
+    result = await tracer.collect_samples(input_sample, max_seq_len=7, agent_metadata={"reward": 0.75})
+
+    assert seen == [{"max_seq_len": 7, "metadata": {"reward": 0.75}}]
+    (decoded,) = result.samples
+    assert decoded.reward == 0.75
+    assert decoded.metadata == {"env": "keep-me", "leaf": {"node_id": 1}}
+
+
+@pytest.mark.asyncio
+async def test_create_selects_wire_fields_by_session_server_version(monkeypatch):
+    from miles.rollout.session.samples.codec import COMPUTED_FIELDS, COMPUTED_FIELDS_V2
+
+    async def fake_post(url: str, payload: dict, action: str = "post"):
+        return {"session_id": "sid-x"}
+
+    monkeypatch.setattr("miles.rollout.generate_utils.openai_endpoint_utils.post", fake_post)
+
+    def args(version):
+        return SimpleNamespace(session_server_ip="127.0.0.1", session_server_ports=[7000], use_session_server=version)
+
+    assert (await OpenAIEndpointTracer.create(args(True))).samples_wire_fields == COMPUTED_FIELDS
+    assert (await OpenAIEndpointTracer.create(args("v2"))).samples_wire_fields == COMPUTED_FIELDS_V2

--- a/tests/fast/rollout/generate_utils/test_openai_endpoint_utils.py
+++ b/tests/fast/rollout/generate_utils/test_openai_endpoint_utils.py
@@ -16,7 +16,7 @@ import pytest
 
 import miles.utils.http_utils as http_utils
 from miles.rollout.generate_utils.openai_endpoint_utils import OpenAIEndpointTracer
-from miles.rollout.session.samples.codec import encode_samples
+from miles.rollout.session.samples.codec import COMPUTED_FIELDS, COMPUTED_FIELDS_V2, encode_samples
 from miles.utils.http_utils import post_bytes_no_retry
 from miles.utils.types import Sample
 
@@ -284,8 +284,6 @@ async def test_collect_samples_v2_payload_carries_metadata_and_decodes_extras(mo
 
 @pytest.mark.asyncio
 async def test_create_selects_wire_fields_by_session_server_version(monkeypatch):
-    from miles.rollout.session.samples.codec import COMPUTED_FIELDS, COMPUTED_FIELDS_V2
-
     async def fake_post(url: str, payload: dict, action: str = "post"):
         return {"session_id": "sid-x"}
 

--- a/tests/fast/router/test_session_v1_v2_parity.py
+++ b/tests/fast/router/test_session_v1_v2_parity.py
@@ -1,0 +1,113 @@
+import pytest
+from tests.session_parity_utils import (
+    SESSION_PARITY_SEED,
+    V1,
+    V2,
+    assert_agentic_retry_trajectory_parity,
+    assert_sample_bitwise_equal,
+    run_agentic_retry_trajectories,
+)
+
+from miles.utils.test_utils.mock_sglang_server import ProcessResult, ProcessResultMetaInfo, with_mock_server
+from miles.utils.test_utils.session_verify_agent import (
+    ASSISTANT_INPUT_FOLLOWUP_TEXT,
+    FORCE_FINAL_TEXT,
+    MOCK_TOOL_RESULTS,
+    SYSTEM_REMINDER_TEXT,
+    USER_FOLLOWUP_TEXT,
+    build_initial_messages,
+)
+from miles.utils.types import Sample
+
+_MODEL = "Qwen/Qwen3-0.6B"
+_BATCH_SIZE = 16
+_REQUESTS_PER_TRAJECTORY = 9
+_AGENT_RESPONSES = {
+    "initial": ProcessResult(
+        'I will check Beijing.\n<tool_call>\n{"name": "get_weather", '
+        '"arguments": {"location": "Beijing"}}\n</tool_call>',
+        meta_info=ProcessResultMetaInfo(weight_version="w0"),
+    ),
+    "beijing_result": ProcessResult(
+        "Beijing is 22 degrees Celsius and sunny.",
+        meta_info=ProcessResultMetaInfo(weight_version="w1"),
+    ),
+    "shanghai_call": ProcessResult(
+        'I will check Shanghai.\n<tool_call>\n{"name": "get_weather", '
+        '"arguments": {"location": "Shanghai"}}\n</tool_call>',
+        meta_info=ProcessResultMetaInfo(weight_version="w2"),
+    ),
+    "shanghai_result": ProcessResult(
+        "Shanghai is 15 degrees Celsius and cloudy.",
+        meta_info=ProcessResultMetaInfo(weight_version="w3"),
+    ),
+    "rollback_retry": ProcessResult(
+        "I will answer in one sentence.",
+        meta_info=ProcessResultMetaInfo(weight_version="w4"),
+    ),
+    "force_final": ProcessResult(
+        "<final_answer>Beijing is sunny and Shanghai is cloudy.</final_answer>",
+        meta_info=ProcessResultMetaInfo(weight_version="w7"),
+    ),
+    "assistant_input": ProcessResult(
+        "<final_answer>Beijing was sunny and Shanghai was rainy.</final_answer>",
+        meta_info=ProcessResultMetaInfo(weight_version="w8"),
+    ),
+}
+_SELECTED_WEIGHT_VERSIONS = ["w0", "w1", "w2", "w3", "w4", "w7", "w8"]
+
+
+def test_agentic_v2_drop_retries_matches_v1_training_payload_bitwise():
+    v1_runs = _run_scripted_agents(V1)
+    v2_runs = _run_scripted_agents(V2)
+
+    assert len(v1_runs) == len(v2_runs) == _BATCH_SIZE
+    for index, (v1, v2) in enumerate(zip(v1_runs, v2_runs, strict=True)):
+        assert v1.samples[0].index == v2.samples[0].index == index
+        assert v1.samples[0].weight_versions == _SELECTED_WEIGHT_VERSIONS
+        assert v2.samples[0].weight_versions == _SELECTED_WEIGHT_VERSIONS
+        assert_agentic_retry_trajectory_parity(v1, v2)
+
+
+def test_sample_bitwise_comparator_distinguishes_signed_zero():
+    with pytest.raises(AssertionError, match="sample.reward is not bitwise equal"):
+        assert_sample_bitwise_equal(Sample(reward=0.0), Sample(reward=-0.0))
+
+
+def _run_scripted_agents(version: str):
+    input_samples = [
+        Sample(
+            index=index,
+            prompt=build_initial_messages(),
+            reward=0.25,
+            metadata={"source": "parity"},
+        )
+        for index in range(_BATCH_SIZE)
+    ]
+    with with_mock_server(model_name=_MODEL, process_fn=_process_agent_prompt, latency=0.05) as backend:
+        results = run_agentic_retry_trajectories(
+            backend_url=backend.url,
+            hf_checkpoint=_MODEL,
+            version=version,
+            input_samples=input_samples,
+        )
+        assert len(backend.request_log) == _BATCH_SIZE * _REQUESTS_PER_TRAJECTORY
+        assert {request["seed"] for request in backend.request_log} == {SESSION_PARITY_SEED}
+        assert backend.max_concurrent == _BATCH_SIZE
+    return results
+
+
+def _process_agent_prompt(prompt: str) -> ProcessResult:
+    if ASSISTANT_INPUT_FOLLOWUP_TEXT in prompt:
+        return _AGENT_RESPONSES["assistant_input"]
+    if FORCE_FINAL_TEXT in prompt:
+        return _AGENT_RESPONSES["force_final"]
+    if SYSTEM_REMINDER_TEXT in prompt:
+        return _AGENT_RESPONSES["rollback_retry"]
+    if MOCK_TOOL_RESULTS[1] in prompt:
+        return _AGENT_RESPONSES["shanghai_result"]
+    if USER_FOLLOWUP_TEXT in prompt:
+        return _AGENT_RESPONSES["shanghai_call"]
+    if MOCK_TOOL_RESULTS[0] in prompt:
+        return _AGENT_RESPONSES["beijing_result"]
+    return _AGENT_RESPONSES["initial"]

--- a/tests/fast/utils/test_arguments.py
+++ b/tests/fast/utils/test_arguments.py
@@ -261,6 +261,32 @@ def test_dynamic_global_batch_size_requires_dynamic_batch_size():
         miles_validate_args(args)
 
 
+class TestSessionServerV2Validation:
+    def _parse(self, extra):
+        parser = argparse.ArgumentParser()
+        get_miles_extra_args_provider()(parser)
+        return parser.parse_args(extra + ["--num-rollout", "1"] + REQUIRED_ARGS)
+
+    @pytest.mark.parametrize(
+        ("extra", "flag"),
+        [
+            (["--group-rm"], "--group-rm"),
+            (["--partial-rollout"], "--partial-rollout"),
+            (
+                ["--true-on-policy-mode", "--recompute-logprobs-via-prefill"],
+                "--recompute-logprobs-via-prefill",
+            ),
+        ],
+    )
+    def test_rejects_unsupported_list_consumers(self, extra, flag):
+        args = self._parse(["--use-session-server", "v2", *extra])
+
+        with pytest.raises(ValueError) as exc_info:
+            miles_validate_args(args)
+
+        assert str(exc_info.value) == (f"--use-session-server v2 does not support {flag}; v2 returns list[Sample]")
+
+
 class TestTitoFixedTemplateConfiguration:
     def _parse(self, extra):
         parser = argparse.ArgumentParser()

--- a/tests/session_parity_utils.py
+++ b/tests/session_parity_utils.py
@@ -1,0 +1,343 @@
+"""Shared v1/v2 session sample parity helpers."""
+
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+import enum
+import json
+import math
+import struct
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from copy import deepcopy
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import patch
+
+import httpx
+import numpy as np
+
+from miles.rollout.base_types import GenerateFnInput
+from miles.rollout.generate_hub import agentic_tool_call
+from miles.rollout.generate_utils.openai_endpoint_utils import OpenAIEndpointTracer
+from miles.rollout.session.samples.codec import SamplesReply
+from miles.rollout.session.server import SessionServer
+from miles.utils import http_utils
+from miles.utils.http_utils import find_available_port
+from miles.utils.test_utils.uvicorn_thread_server import UvicornThreadServer
+from miles.utils.types import Sample
+
+V1 = "v1"
+V2 = "v2"
+SESSION_PARITY_SEED = 20260803
+
+_CHAT_TIMEOUT_SECS = 120.0
+_PICKER_PATH = "miles.rollout.session.v2.picker_hub.drop_retries"
+_POSTPROCESSOR_PATH = "miles.rollout.session.v2.postprocessor_hub.default_postprocess"
+_RUNTIME_LIFECYCLE_KEYS = frozenset({"t0", "t1", "req_ts", "prev_t1"})
+_EXPECTED_AGENT_METADATA = {
+    "driver_events": [
+        "initial",
+        "append_tool",
+        "append_user",
+        "append_tool",
+        "append_system",
+        "rollback",
+        "rollback",
+        "force_final",
+        "append_assistant",
+    ],
+    "rollback_count": 2,
+    "user_count": 2,
+    "system_count": 1,
+    "assistant_input_count": 2,
+    "tool_result_count": 2,
+    "tool_call_count": 2,
+}
+
+
+@dataclasses.dataclass(frozen=True)
+class SessionParityRun:
+    version: str
+    samples: list[Sample]
+    session_metadata: dict[str, Any]
+    pre_collect: dict[str, Any]
+    empty_reason: str | None
+
+
+def run_agentic_retry_trajectories(
+    *,
+    backend_url: str,
+    hf_checkpoint: str,
+    version: str,
+    input_samples: list[Sample],
+) -> list[SessionParityRun]:
+    """Run a concurrent weather-agent batch through one session version."""
+    if version not in (V1, V2):
+        raise ValueError(f"unknown session version: {version}")
+
+    with _serve_session(backend_url=backend_url, hf_checkpoint=hf_checkpoint, version=version) as args:
+        collected = asyncio.run(_run_and_collect(args=args, hf_checkpoint=hf_checkpoint, input_samples=input_samples))
+
+    return [
+        SessionParityRun(
+            version=version,
+            samples=samples,
+            session_metadata=reply.session_metadata,
+            pre_collect=pre_collect,
+            empty_reason=reply.empty_reason,
+        )
+        for pre_collect, reply, samples in collected
+    ]
+
+
+async def _run_and_collect(
+    *,
+    args: SimpleNamespace,
+    hf_checkpoint: str,
+    input_samples: list[Sample],
+) -> list[tuple[dict[str, Any], SamplesReply, list[Sample]]]:
+    async with httpx.AsyncClient(timeout=None) as client:
+        with patch.object(http_utils, "_http_client", client):
+            original_collect = OpenAIEndpointTracer.collect_samples
+            collected: dict[int, tuple[dict[str, Any], SamplesReply]] = {}
+
+            async def collect_with_snapshot(
+                tracer: OpenAIEndpointTracer,
+                collected_input_sample: Sample,
+                *,
+                max_seq_len: int | None,
+                agent_metadata: dict | None = None,
+            ) -> SamplesReply:
+                response = await client.get(tracer.base_url)
+                assert response.status_code == 200, response.text
+                reply = await original_collect(
+                    tracer,
+                    collected_input_sample,
+                    max_seq_len=max_seq_len,
+                    agent_metadata=agent_metadata,
+                )
+                collected[id(collected_input_sample)] = (response.json(), reply)
+                return reply
+
+            async def generate_one(input_sample: Sample):
+                input_sample.metadata.update(
+                    {
+                        "tito_model": args.tito_model,
+                        "session_verify_cycles": args.session_verify_cycles,
+                        "tool_call_failure_mode": args.tool_call_failure_mode,
+                    }
+                )
+                generate_input = GenerateFnInput(
+                    state=SimpleNamespace(args=args),
+                    sample=input_sample,
+                    sampling_params={
+                        "model": hf_checkpoint,
+                        "temperature": 0,
+                        "sampling_seed": SESSION_PARITY_SEED,
+                        "max_new_tokens": 128,
+                    },
+                    evaluation=False,
+                )
+                output = await agentic_tool_call.generate(generate_input)
+                return input_sample, output
+
+            with patch.object(OpenAIEndpointTracer, "collect_samples", collect_with_snapshot):
+                outputs = await asyncio.gather(*(generate_one(sample) for sample in input_samples))
+
+    results = []
+    for input_sample, output in outputs:
+        samples = output.samples if isinstance(output.samples, list) else [output.samples]
+        pre_collect, reply = collected[id(input_sample)]
+        results.append((pre_collect, reply, samples))
+    return results
+
+
+def assert_agentic_retry_trajectory_parity(v1: SessionParityRun, v2: SessionParityRun) -> None:
+    """Assert agent coverage, retry topology, and training-payload parity."""
+    assert v1.version == V1
+    assert v2.version == V2
+    assert v1.empty_reason is None
+    assert v2.empty_reason is None
+    assert len(v1.samples) == 1
+    assert len(v2.samples) == 1
+    assert len(v1.pre_collect["records"]) == 7
+    assert len(v2.pre_collect["records"]) == 7
+    _assert_weather_tool_round_trip(v1.pre_collect)
+    _assert_weather_tool_round_trip(v2.pre_collect)
+
+    tree = v2.pre_collect["metadata"]["tree"]
+    assert [(node["id"], node["parent"]) for node in tree["nodes"]] == [
+        (0, None),
+        (1, 0),
+        (2, 1),
+        (3, 2),
+        (4, 3),
+        (5, 3),
+        (6, 3),
+        (7, 6),
+        (8, 7),
+    ]
+    assert [(leaf["node_id"], leaf["path_node_ids"]) for leaf in tree["leaves"]] == [
+        (4, [0, 1, 2, 3, 4]),
+        (5, [0, 1, 2, 3, 5]),
+        (8, [0, 1, 2, 3, 6, 7, 8]),
+    ]
+
+    selected_leaf = v2.samples[0].metadata["leaf"]
+    assert selected_leaf["node_id"] == 8
+    assert selected_leaf["parent"] == 7
+    assert selected_leaf["path_node_ids"] == [0, 1, 2, 3, 6, 7, 8]
+    assert selected_leaf["response_id"] == tree["nodes"][8]["response_id"]
+    assert v2.session_metadata["agent"] == _EXPECTED_AGENT_METADATA
+    for key, value in _EXPECTED_AGENT_METADATA.items():
+        assert v1.samples[0].metadata[key] == value
+        assert v2.samples[0].metadata[key] == value
+    assert v1.samples[0].metadata["max_trim_tokens"] == v2.session_metadata["max_trim_tokens"]
+
+    v2_linear_metadata = {key: value for key, value in v2.session_metadata.items() if key not in ("agent", "tree")}
+    _assert_bits_equal(v1.session_metadata, v2_linear_metadata, path="session_metadata")
+    assert_sample_bitwise_equal(
+        v1.samples[0],
+        v2.samples[0],
+        metadata_projection=_training_metadata_projection,
+    )
+
+
+def assert_sample_bitwise_equal(
+    left: Sample,
+    right: Sample,
+    *,
+    metadata_projection: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
+) -> None:
+    """Compare every declared Sample field without float tolerance."""
+    assert type(left) is type(right)
+    left_extras = set(vars(left)) - {field.name for field in dataclasses.fields(left)}
+    right_extras = set(vars(right)) - {field.name for field in dataclasses.fields(right)}
+    assert left_extras == right_extras == set()
+
+    for field in dataclasses.fields(left):
+        left_value = getattr(left, field.name)
+        right_value = getattr(right, field.name)
+        if field.name == "metadata" and metadata_projection is not None:
+            left_value = metadata_projection(left_value)
+            right_value = metadata_projection(right_value)
+        _assert_bits_equal(left_value, right_value, path=f"sample.{field.name}")
+
+
+@contextmanager
+def _serve_session(*, backend_url: str, hf_checkpoint: str, version: str) -> Iterator[SimpleNamespace]:
+    port = find_available_port(31000)
+    instance_id = f"session-parity-{version}"
+    args = SimpleNamespace(
+        miles_router_timeout=_CHAT_TIMEOUT_SECS,
+        hf_checkpoint=hf_checkpoint,
+        chat_template_path=None,
+        apply_chat_template_kwargs={"enable_thinking": False},
+        tito_model="qwen3",
+        sglang_speculative_algorithm=None,
+        use_session_server=version,
+        use_rollout_routing_replay=False,
+        use_rollout_indexer_replay=False,
+        session_server_instance_id=instance_id,
+        session_server_ip="127.0.0.1",
+        session_server_ports=[port],
+        session_server_instance_ids={port: instance_id},
+        save_debug_trajectory_data=None,
+        custom_agent_function_path="miles.utils.test_utils.session_verify_agent.run_agent",
+        max_seq_len=None,
+        session_verify_cycles=1,
+        tool_call_failure_mode="rollback",
+        session_sample_picker_path=_PICKER_PATH,
+        session_sample_postprocessor_path=_POSTPROCESSOR_PATH,
+    )
+    app = SessionServer(args, backend_url=backend_url).app
+    server = UvicornThreadServer(app, host=args.session_server_ip, port=port)
+    server.start()
+    try:
+        yield args
+    finally:
+        server.stop()
+
+
+def _training_metadata_projection(metadata: dict[str, Any]) -> dict[str, Any]:
+    projected = deepcopy(metadata)
+    projected.pop("leaf", None)
+    projected.pop("max_trim_tokens", None)
+    lifecycle = projected.get("lifecycle")
+    if lifecycle is not None:
+        segments = lifecycle if isinstance(lifecycle, list) else [lifecycle]
+        projected["lifecycle"] = [_project_lifecycle_segment(segment) for segment in segments]
+    return projected
+
+
+def _assert_weather_tool_round_trip(snapshot: dict[str, Any]) -> None:
+    records = snapshot["records"]
+    for record in records:
+        assert [tool["function"]["name"] for tool in record["request"]["tools"]] == ["get_weather"]
+
+    for call_index, result_index, location in ((0, 1, "Beijing"), (2, 3, "Shanghai")):
+        [tool_call] = records[call_index]["response"]["choices"][0]["message"]["tool_calls"]
+        assert tool_call["function"]["name"] == "get_weather"
+        assert json.loads(tool_call["function"]["arguments"]) == {"location": location}
+
+        tool_result = records[result_index]["request"]["messages"][-1]
+        assert tool_result["role"] == "tool"
+        assert tool_result["tool_call_id"] == tool_call["id"]
+
+
+def _project_lifecycle_segment(segment: dict[str, Any]) -> dict[str, Any]:
+    projected = dict(segment)
+    for key in _RUNTIME_LIFECYCLE_KEYS & projected.keys():
+        if projected[key] is not None:
+            assert type(projected[key]) in (int, float)
+            assert math.isfinite(projected[key])
+            projected[key] = "<runtime>"
+    return projected
+
+
+def _assert_bits_equal(left: Any, right: Any, *, path: str) -> None:
+    left_bits = _bit_tree(left, path=path)
+    right_bits = _bit_tree(right, path=path)
+    if left_bits != right_bits:
+        raise AssertionError(f"{path} is not bitwise equal")
+
+
+def _bit_tree(value: Any, *, path: str) -> Any:
+    if dataclasses.is_dataclass(value):
+        declared = {field.name for field in dataclasses.fields(value)}
+        extras = set(vars(value)) - declared
+        if extras:
+            raise AssertionError(f"{path} has undeclared fields: {sorted(extras)}")
+        return (
+            "dataclass",
+            type(value),
+            tuple(
+                (field.name, _bit_tree(getattr(value, field.name), path=f"{path}.{field.name}"))
+                for field in dataclasses.fields(value)
+            ),
+        )
+    if isinstance(value, np.ndarray):
+        if value.dtype.hasobject:
+            raise AssertionError(f"{path} has object dtype")
+        if not value.flags.c_contiguous:
+            raise AssertionError(f"{path} is not C-contiguous")
+        return "ndarray", value.dtype.str, value.shape, value.tobytes(order="C")
+    if isinstance(value, np.generic):
+        return "numpy-scalar", value.dtype.str, value.tobytes()
+    if isinstance(value, enum.Enum):
+        return "enum", type(value), _bit_tree(value.value, path=f"{path}.value")
+    if isinstance(value, dict):
+        items = [
+            (_bit_tree(key, path=f"{path}.<key>"), _bit_tree(item, path=f"{path}[{key!r}]"))
+            for key, item in value.items()
+        ]
+        return "dict", tuple(sorted(items, key=lambda pair: repr(pair[0])))
+    if isinstance(value, (list, tuple)):
+        return type(value), tuple(_bit_tree(item, path=f"{path}[{index}]") for index, item in enumerate(value))
+    if isinstance(value, float):
+        return "float64", struct.pack(">d", value)
+    if value is None or type(value) in (bool, int, str, bytes):
+        return type(value), value
+    raise TypeError(f"unsupported value at {path}: {type(value).__name__}")


### PR DESCRIPTION
> **Depends on:** #2127
> Stacked on the parent PR's branch. Review / merge the parent first.

## Summary

Carry agentic generation metadata through session server v2 sample collection.

## Motivation

Agentic rollout needs v2 to return per-leaf samples and agent metadata without disabling downstream reward functions or changing the established v1 collection contract.

## Usage

Run `agentic_tool_call` with `--use-session-server v2`; the agent result is sent as collection metadata and returned on each selected sample.

## Design Notes

- **Key choices:** V2 applies agent metadata during server-side postprocessing.
- V1 retains its driver-side metadata overlay.
- Unsupported v2 combinations fail argument validation before rollout.

## Verification

- **Tests added:** `test_agentic_v2.py` covers v2 collection and metadata propagation.
- **Tests added:** `test_openai_endpoint_utils.py` covers the v2 tracer wire fields.
- **Tests added:** `test_session_v1_v2_parity.py` covers mock-server parity and payload comparison helpers.
- **Tests added:** `test_arguments.py` covers the v2 compatibility contract.

## Review Focus

- Scrutinize `agentic_tool_call.py` for the v1/v2 metadata ownership split.
- Scrutinize `openai_endpoint_utils.py` for versioned collection payloads.
- Scrutinize `miles_validate_args` for precise incompatibility errors.
