### PR TITLE
test(ci): run session servers on v2

### DIFF
--- a/miles/utils/test_utils/session_verify_runner.py
+++ b/miles/utils/test_utils/session_verify_runner.py
@@ -65,7 +65,7 @@ SESSION_VERIFY_INVARIANT_ARGS: dict[str, Any] = {
     "rm_type": "random",
     "custom_generate_function_path": "miles.utils.test_utils.session_verify_agent.generate",
     "custom_agent_function_path": "miles.utils.test_utils.session_verify_agent.run_agent",
-    "use_session_server": True,
+    "use_session_server": "v2",
     "debug_rollout_only": True,
     "ci_test": True,
     "colocate": True,

--- a/tests/e2e/sglang/test_session_server_multi_role/_common.py
+++ b/tests/e2e/sglang/test_session_server_multi_role/_common.py
@@ -1,19 +1,22 @@
 """Shared types and runner for multi-role session-server TITO e2e tests.
 
 Each test file in this directory owns a single ``ModelConfig`` and drives it
-through ``run_one(cfg)``.  The runner is a thin wrapper around
-``miles.utils.test_utils.session_verify_runner.run_session_verify`` with the
-model-specific GPU topology applied centrally.
+through ``run_both_versions(cfg)``. The runner applies the model-specific
+GPU topology centrally.
 """
 
 import argparse
 from dataclasses import dataclass
+from typing import Literal
 
 from miles.utils.test_utils.session_verify_runner import (
     ASSISTANT_TEXT_MISMATCH_RATIO_THRESHOLD,
     SESSION_VERIFY_INVARIANT_ARGS,
     run_session_verify,
 )
+
+SessionServerVersion = Literal["v1", "v2"]
+_SESSION_SERVER_VERSIONS: tuple[SessionServerVersion, ...] = ("v1", "v2")
 
 
 @dataclass(frozen=True)
@@ -45,8 +48,15 @@ class ModelConfig:
     tool_call_failure_mode: str = "rollback"
 
 
-def run_one(cfg: ModelConfig) -> None:
+def run_one(
+    cfg: ModelConfig,
+    *,
+    session_server_version: SessionServerVersion = "v2",
+    rollout_batch_size: int = SESSION_VERIFY_INVARIANT_ARGS["rollout_batch_size"],
+) -> None:
     invariants = dict(SESSION_VERIFY_INVARIANT_ARGS)
+    invariants["use_session_server"] = session_server_version
+    invariants["rollout_batch_size"] = rollout_batch_size
     # This harness produces one rollout batch, so its train-side batch divisor
     # must track the actual sample count when large-model lanes reduce samples.
     invariants["global_batch_size"] = invariants["rollout_batch_size"] * cfg.n_samples_per_prompt
@@ -70,3 +80,9 @@ def run_one(cfg: ModelConfig) -> None:
         **invariants,
     )
     run_session_verify(args=args)
+
+
+def run_both_versions(cfg: ModelConfig) -> None:
+    rollout_batch_size = SESSION_VERIFY_INVARIANT_ARGS["rollout_batch_size"] // len(_SESSION_SERVER_VERSIONS)
+    for version in _SESSION_SERVER_VERSIONS:
+        run_one(cfg, session_server_version=version, rollout_batch_size=rollout_batch_size)

--- a/tests/e2e/sglang/test_session_server_multi_role/test_deepseekv4.py
+++ b/tests/e2e/sglang/test_session_server_multi_role/test_deepseekv4.py
@@ -1,5 +1,5 @@
 from tests.ci.ci_register import register_cuda_ci
-from tests.e2e.sglang.test_session_server_multi_role._common import ModelConfig, run_one
+from tests.e2e.sglang.test_session_server_multi_role._common import ModelConfig, run_both_versions
 
 register_cuda_ci(est_time=1000, suite="stage-c-4-gpu-h200", labels=["sglang"])
 
@@ -26,7 +26,7 @@ CONFIG = ModelConfig(
 
 
 def test_deepseekv4():
-    run_one(CONFIG)
+    run_both_versions(CONFIG)
 
 
 if __name__ == "__main__":

--- a/tests/e2e/sglang/test_session_server_multi_role/test_glm47.py
+++ b/tests/e2e/sglang/test_session_server_multi_role/test_glm47.py
@@ -1,5 +1,5 @@
 from tests.ci.ci_register import register_cuda_ci
-from tests.e2e.sglang.test_session_server_multi_role._common import ModelConfig, run_one
+from tests.e2e.sglang.test_session_server_multi_role._common import ModelConfig, run_both_versions
 
 register_cuda_ci(est_time=500, suite="stage-c-4-gpu-h200", labels=["sglang"])
 
@@ -18,7 +18,7 @@ CONFIG = ModelConfig(
 
 
 def test_glm47():
-    run_one(CONFIG)
+    run_both_versions(CONFIG)
 
 
 if __name__ == "__main__":

--- a/tests/e2e/sglang/test_session_server_multi_role/test_inkling.py
+++ b/tests/e2e/sglang/test_session_server_multi_role/test_inkling.py
@@ -1,5 +1,5 @@
 from tests.ci.ci_register import register_cuda_ci
-from tests.e2e.sglang.test_session_server_multi_role._common import ModelConfig, run_one
+from tests.e2e.sglang.test_session_server_multi_role._common import ModelConfig, run_both_versions
 
 register_cuda_ci(est_time=1200, suite="stage-c-4-gpu-h200", labels=["sglang"])
 
@@ -22,7 +22,7 @@ CONFIG = ModelConfig(
 
 
 def test_inkling():
-    run_one(CONFIG)
+    run_both_versions(CONFIG)
 
 
 if __name__ == "__main__":

--- a/tests/e2e/sglang/test_session_server_multi_role/test_minimax_m27.py
+++ b/tests/e2e/sglang/test_session_server_multi_role/test_minimax_m27.py
@@ -8,7 +8,7 @@ tests/fast/utils/chat_template_utils/.
 """
 
 from tests.ci.ci_register import register_cuda_ci
-from tests.e2e.sglang.test_session_server_multi_role._common import ModelConfig, run_one
+from tests.e2e.sglang.test_session_server_multi_role._common import ModelConfig, run_both_versions
 
 register_cuda_ci(est_time=600, suite="stage-c-4-gpu-h200", labels=["sglang"])
 
@@ -44,7 +44,7 @@ CONFIG = ModelConfig(
 
 
 def test_minimax_m27():
-    run_one(CONFIG)
+    run_both_versions(CONFIG)
 
 
 if __name__ == "__main__":

--- a/tests/e2e/sglang/test_session_server_multi_role/test_nemotron3.py
+++ b/tests/e2e/sglang/test_session_server_multi_role/test_nemotron3.py
@@ -1,5 +1,5 @@
 from tests.ci.ci_register import register_cuda_ci
-from tests.e2e.sglang.test_session_server_multi_role._common import ModelConfig, run_one
+from tests.e2e.sglang.test_session_server_multi_role._common import ModelConfig, run_both_versions
 
 register_cuda_ci(est_time=800, suite="stage-c-4-gpu-h200", labels=["sglang"])
 
@@ -31,7 +31,7 @@ CONFIG = ModelConfig(
 
 
 def test_nemotron3():
-    run_one(CONFIG)
+    run_both_versions(CONFIG)
 
 
 if __name__ == "__main__":

--- a/tests/e2e/sglang/test_session_server_multi_role/test_qwen3.py
+++ b/tests/e2e/sglang/test_session_server_multi_role/test_qwen3.py
@@ -1,5 +1,5 @@
 from tests.ci.ci_register import register_cuda_ci
-from tests.e2e.sglang.test_session_server_multi_role._common import ModelConfig, run_one
+from tests.e2e.sglang.test_session_server_multi_role._common import ModelConfig, run_both_versions
 
 register_cuda_ci(est_time=600, suite="stage-c-4-gpu-h200", labels=["sglang"])
 
@@ -19,7 +19,7 @@ CONFIG = ModelConfig(
 
 
 def test_qwen3():
-    run_one(CONFIG)
+    run_both_versions(CONFIG)
 
 
 if __name__ == "__main__":

--- a/tests/e2e/sglang/test_session_server_multi_role/test_qwen35.py
+++ b/tests/e2e/sglang/test_session_server_multi_role/test_qwen35.py
@@ -1,5 +1,5 @@
 from tests.ci.ci_register import register_cuda_ci
-from tests.e2e.sglang.test_session_server_multi_role._common import ModelConfig, run_one
+from tests.e2e.sglang.test_session_server_multi_role._common import ModelConfig, run_both_versions
 
 register_cuda_ci(est_time=500, suite="stage-c-4-gpu-h200", labels=["sglang"])
 
@@ -16,7 +16,7 @@ CONFIG = ModelConfig(
 
 
 def test_qwen35():
-    run_one(CONFIG)
+    run_both_versions(CONFIG)
 
 
 if __name__ == "__main__":

--- a/tests/fast/fixtures/generation_fixtures.py
+++ b/tests/fast/fixtures/generation_fixtures.py
@@ -2,11 +2,11 @@
 Fixtures to test custom-generate-function
 """
 
+import copy
 import uuid
 from argparse import Namespace
 from contextlib import contextmanager
 from dataclasses import dataclass
-from types import SimpleNamespace
 from typing import Any
 from unittest.mock import patch
 
@@ -63,7 +63,7 @@ def extra_argv_for_variant(
         argv += ["--generate-tool-call-parser", generate_tool_call_parser]
     elif variant == "agentic_tool_call":
         argv += ["--custom-agent-function-path", custom_agent_function_path]
-        argv += ["--use-session-server", "--tito-model", "qwen3"]
+        argv += ["--use-session-server", "v2", "--tito-model", "qwen3"]
 
     return argv
 
@@ -237,21 +237,9 @@ def with_session_server(
     # caller's per-port map, where OpenAIEndpointTracer.create reads it from.
     instance_id = uuid.uuid4().hex
     args.session_server_instance_ids = {port: instance_id}
-    server_args = SimpleNamespace(
-        miles_router_timeout=30,
-        hf_checkpoint=args.hf_checkpoint,
-        chat_template_path=args.chat_template_path,
-        tito_model=args.tito_model,
-        use_rollout_routing_replay=args.use_rollout_routing_replay,
-        sglang_speculative_algorithm=args.sglang_speculative_algorithm,
-        # Sample assembly runs inside the server, so the R3 decode shape args
-        # must reach the server namespace (set them via args_kwargs BEFORE the
-        # server starts; assigning to the driver args afterwards has no effect).
-        num_layers=getattr(args, "num_layers", None),
-        moe_router_topk=getattr(args, "moe_router_topk", None),
-        save_debug_trajectory_data=getattr(args, "save_debug_trajectory_data", None),
-        session_server_instance_id=instance_id,
-    )
+    server_args = copy.deepcopy(args)
+    server_args.miles_router_timeout = 30
+    server_args.session_server_instance_id = instance_id
     session_server = SessionServer(server_args, backend_url=backend_url)
 
     server = UvicornThreadServer(session_server.app, host="127.0.0.1", port=port)

--- a/tests/fast/fixtures/rollout_fixtures.py
+++ b/tests/fast/fixtures/rollout_fixtures.py
@@ -2,6 +2,7 @@
 Fixtures to test rollout-function
 """
 
+import copy
 import json
 from argparse import Namespace
 from collections.abc import Iterator
@@ -101,17 +102,8 @@ DEFAULT_DATA_ROWS = [{"input": "What is 1+7?", "label": "8"}]
 @contextmanager
 def _with_session_server(args: Namespace, backend_url: str) -> Iterator[UvicornThreadServer]:
     """Start a SessionServer for agentic variants that need TITO session tracking."""
-    from types import SimpleNamespace
-
-    session_args = SimpleNamespace(
-        miles_router_timeout=30,
-        hf_checkpoint=args.hf_checkpoint,
-        chat_template_path=getattr(args, "chat_template_path", None),
-        tito_model=getattr(args, "tito_model", "default"),
-        use_rollout_routing_replay=getattr(args, "use_rollout_routing_replay", False),
-        save_debug_trajectory_data=getattr(args, "save_debug_trajectory_data", None),
-        sglang_speculative_algorithm=getattr(args, "sglang_speculative_algorithm", None),
-    )
+    session_args = copy.copy(args)
+    session_args.miles_router_timeout = 30
     session_server = SessionServer(session_args, backend_url=backend_url)
     port = find_available_port(31000)
     server = UvicornThreadServer(session_server.app, host="127.0.0.1", port=port)

--- a/tests/fast/rollout/generate_hub/test_multi_turn.py
+++ b/tests/fast/rollout/generate_hub/test_multi_turn.py
@@ -123,7 +123,7 @@ def verify_samples(actual: Sample | list[Sample], expected: list[ExpectedSampleI
         # Session server populates diagnostic metadata (token IDs,
         # trim config, mismatch analysis, dashboard lifecycle timing) that
         # varies with mock setup. Strip these before comparing structure.
-        for key in ("tito_session_mismatch", "accumulated_token_ids", "max_trim_tokens", "lifecycle"):
+        for key in ("tito_session_mismatch", "accumulated_token_ids", "max_trim_tokens", "lifecycle", "leaf"):
             actual_partial.metadata.pop(key, None)
         assert actual_partial == expected_item.partial_sample
 
@@ -679,7 +679,7 @@ class TestAgentCollectionFailure:
     ):
         collect_error = asyncio.TimeoutError()
 
-        async def fail_collect(_tracer, _input_sample, *, max_seq_len):
+        async def fail_collect(_tracer, _input_sample, *, max_seq_len, agent_metadata=None):
             raise collect_error
 
         monkeypatch.setattr(
@@ -690,8 +690,8 @@ class TestAgentCollectionFailure:
         with caplog.at_level(logging.WARNING):
             result = _run_generate(variant, generation_env, input_sample)
 
-        assert isinstance(result.sample, Sample)
-        assert result.sample.status == Sample.Status.ABORTED
+        [sample] = listify(result.sample)
+        assert sample.status == Sample.Status.ABORTED
         assert input_sample.status == Sample.Status.PENDING
         assert "Timed out collecting samples" in caplog.text
 
@@ -739,5 +739,5 @@ class TestAgentNoRecords:
 
         SingletonMeta.clear_all_instances()
 
-        assert isinstance(result.sample, Sample)
-        assert result.sample.status == Sample.Status.ABORTED
+        [sample] = listify(result.sample)
+        assert sample.status == Sample.Status.ABORTED

--- a/tests/fast/rollout/inference_rollout/integration/test_multi_turn.py
+++ b/tests/fast/rollout/inference_rollout/integration/test_multi_turn.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 import pytest
-from tests.fast.fixtures.generation_fixtures import extra_argv_for_variant
+from tests.fast.fixtures.generation_fixtures import extra_argv_for_variant, listify
 from tests.fast.fixtures.rollout_fixtures import RolloutEnvConfig
 from tests.fast.rollout.inference_rollout.integration.utils import MODULAR_ROLLOUT_BASE_ARGV, load_and_call_rollout
 
@@ -56,8 +56,11 @@ def test_rollout(rollout_env, variant, test_type):
 
 def _verify_samples(variant: str, samples: list[Any]):
     assert len(samples) == 2, f"n_samples_per_prompt=2, so group should have 2 samples, got {len(samples)}"
-    for sample in samples:
-        assert isinstance(sample, Sample), f"{variant} returns a scalar Sample per generate"
+    for generated in samples:
+        [sample] = listify(generated)
+        assert isinstance(sample, Sample), f"{variant} should return Sample trajectories"
+        if variant == "agentic_tool_call":
+            assert "leaf" in sample.metadata, "session server v2 should attach leaf metadata"
         _verify_sample(sample)
 
 

--- a/tests/fast/router/session_pretokenized_test_utils.py
+++ b/tests/fast/router/session_pretokenized_test_utils.py
@@ -49,8 +49,11 @@ def make_router_env(
         hf_checkpoint=hf_checkpoint,
         chat_template_path=chat_template_path,
         tito_model=tito_model,
+        use_session_server="v2",
         use_rollout_routing_replay=False,
         sglang_speculative_algorithm=None,
+        session_sample_picker_path="miles.rollout.session.v2.picker_hub.drop_retries",
+        session_sample_postprocessor_path="miles.rollout.session.v2.postprocessor_hub.default_postprocess",
     )
     session_server = SessionServer(args, backend_url=backend.url)
 

--- a/tests/fast/router/test_session_pretokenized_e2e.py
+++ b/tests/fast/router/test_session_pretokenized_e2e.py
@@ -144,6 +144,7 @@ def test_bundled_fixed_template_session_smoke(config: FixedTemplateSmokeConfig):
 
             session_payload = fetch_session_payload(env.url, session_id)
             metadata = session_payload["metadata"]
+            assert len(metadata["tree"]["nodes"]) == turn_idx + 1
             remote_mismatch = metadata.get("tito_session_mismatch", [])
             local_mismatch = compute_local_session_mismatch(
                 tokenizer,

--- a/tests/fast/utils/test_utils/test_session_verify_runner.py
+++ b/tests/fast/utils/test_utils/test_session_verify_runner.py
@@ -50,6 +50,18 @@ def test_namespace_to_train_args_keeps_ci_test_enabled_for_fsdp_debug_rollout():
     assert "--ci-test" in train_args
 
 
+def test_namespace_to_train_args_defaults_to_session_server_v2():
+    train_args = _build_args()
+
+    assert "--use-session-server v2" in train_args
+
+
+def test_namespace_to_train_args_allows_session_server_v1():
+    train_args = _build_args(use_session_server="v1")
+
+    assert "--use-session-server v1" in train_args
+
+
 def test_namespace_to_train_args_has_no_append_role_policy_flag():
     train_args = _build_args()
 
@@ -99,8 +111,44 @@ def test_run_one_aligns_global_batch_size_with_sample_count(
     _common.run_one(config)
 
     assert captured["args"].global_batch_size == expected_global_batch_size
+    assert captured["args"].rollout_batch_size == 16
     assert captured["args"].rollout_max_response_len == 4096
     assert captured["args"].sglang_cuda_graph_backend_prefill == "disabled"
+
+
+@pytest.mark.parametrize("version", ["v1", "v2"])
+def test_run_one_uses_requested_session_server_version(monkeypatch, version):
+    captured = {}
+    monkeypatch.setattr(_common, "run_session_verify", lambda args: captured.setdefault("args", args))
+    config = _common.ModelConfig(
+        model_name="test-model",
+        reasoning_parser="qwen3",
+        tool_call_parser="qwen25",
+        tito_model="qwen3",
+    )
+
+    _common.run_one(config, session_server_version=version)
+
+    assert captured["args"].use_session_server == version
+
+
+@pytest.mark.parametrize(("n_samples_per_prompt", "expected_global_batch_size"), [(1, 8), (4, 32)])
+def test_run_both_versions_splits_rollout_batch(monkeypatch, n_samples_per_prompt, expected_global_batch_size):
+    captured = []
+    monkeypatch.setattr(_common, "run_session_verify", lambda args: captured.append(args))
+    config = _common.ModelConfig(
+        model_name="test-model",
+        reasoning_parser="qwen3",
+        tool_call_parser="qwen25",
+        tito_model="qwen3",
+        n_samples_per_prompt=n_samples_per_prompt,
+    )
+
+    _common.run_both_versions(config)
+
+    assert [args.use_session_server for args in captured] == ["v1", "v2"]
+    assert [args.rollout_batch_size for args in captured] == [8, 8]
+    assert [args.global_batch_size for args in captured] == [expected_global_batch_size] * 2
 
 
 def test_namespace_to_train_args_omits_expert_parallel_for_single_expert():


### PR DESCRIPTION
> **Depends on:** #2129
> Stacked on the parent PR's branch. Review / merge the parent first.

## Summary

Session CI exercises server v2 in generic fixtures and multi-role GPU verification.

## Motivation

Select v2 explicitly for multi-role GPU verification and generic agentic and pretokenized CPU fixtures, deep-copying nested fixture configuration before applying SessionServer-only overrides. Run each multi-role model against both server versions while halving the per-version rollout batch to keep total sample coverage unchanged. Align test assertions with v2 trajectory lists and tree metadata while preserving intentional v1 characterization coverage.

## Usage

```bash
python tests/e2e/sglang/test_session_server_multi_role/test_glm47.py
```

Each lane verifies its model on v1 followed by v2 with half-size per-version batches.

## Design Notes

- **Key choices:** shared fixture setup owns the v2 selection; explicit v1 tests stay as characterization coverage.
- `run_both_versions` halves the per-version rollout batch, keeping total sample coverage unchanged.
- Direct fixture servers receive a deep copy of the canonical parsed Namespace.

## Verification

- **Tests added:** `test_run_both_versions_splits_rollout_batch` pins the v1/v2 fan-out at per-version rollout batch 8 with global batch unchanged.
- `test_namespace_to_train_args_defaults_to_session_server_v2` pins the serialized `--use-session-server v2` flag.
- Local CPU verification: 22 verifier-runner tests pass; agentic fixture integration tests assert v2 trajectory lists.

## Review Focus

- Scrutinize `run_both_versions` in `_common.py` for the halved-batch contract.
- Scrutinize `generation_fixtures.py` for the deep-copied namespace handed to direct SessionServer instances.
- Scrutinize the remaining explicit v1 tests as intentional characterization coverage.
