### PR TITLE
ci(docker): rebuild scheduled images at least once every 24h

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -106,12 +106,14 @@ jobs:
             LAST_WHEELS_CU13_X86=$(sed -n '3p' "$CACHE_FILE")
             LAST_WHEELS_CU13_ARM64=$(sed -n '4p' "$CACHE_FILE")
             LAST_WHEELS_CU12_X86=$(sed -n '5p' "$CACHE_FILE")
+            LAST_BUILD_EPOCH=$(sed -n '6p' "$CACHE_FILE")
           else
             LAST_SGLANG=""
             LAST_MEGATRON=""
             LAST_WHEELS_CU13_X86=""
             LAST_WHEELS_CU13_ARM64=""
             LAST_WHEELS_CU12_X86=""
+            LAST_BUILD_EPOCH=""
           fi
 
           if [ "$SGLANG_SHA" != "$LAST_SGLANG" ] || [ "$MEGATRON_SHA" != "$LAST_MEGATRON" ] || [ "$WHEELS_CU13_X86_FP" != "$LAST_WHEELS_CU13_X86" ] || [ "$WHEELS_CU13_ARM64_FP" != "$LAST_WHEELS_CU13_ARM64" ] || [ "$WHEELS_CU12_X86_FP" != "$LAST_WHEELS_CU12_X86" ]; then
@@ -121,12 +123,29 @@ jobs:
             echo "No upstream changes"
           fi
 
-          # Save current values for next run
+          # Staleness fallback: rebuild at least once per MAX_BUILD_AGE even with no
+          # upstream changes, so the dev image never drifts more than a day behind
+          # the miles repo itself (miles commits alone do not trigger rebuilds).
+          MAX_BUILD_AGE_SECONDS=$(( 24 * 3600 ))
+          NOW_EPOCH=$(date +%s)
+          if [ "$SHOULD_BUILD" = "false" ]; then
+            if ! [ "$LAST_BUILD_EPOCH" -gt 0 ] 2>/dev/null; then
+              SHOULD_BUILD=true
+              echo "No last-build timestamp recorded; rebuilding"
+            elif [ $(( NOW_EPOCH - LAST_BUILD_EPOCH )) -ge $MAX_BUILD_AGE_SECONDS ]; then
+              SHOULD_BUILD=true
+              echo "Last build was $(( (NOW_EPOCH - LAST_BUILD_EPOCH) / 3600 ))h ago (max $(( MAX_BUILD_AGE_SECONDS / 3600 ))h); rebuilding"
+            fi
+          fi
+
+          # Save current values for next run. The cache is only saved when a build
+          # triggers, so line 6 records when the last scheduled build was kicked off.
           echo "${SGLANG_SHA}" > "$CACHE_FILE"
           echo "${MEGATRON_SHA}" >> "$CACHE_FILE"
           echo "${WHEELS_CU13_X86_FP}" >> "$CACHE_FILE"
           echo "${WHEELS_CU13_ARM64_FP}" >> "$CACHE_FILE"
           echo "${WHEELS_CU12_X86_FP}" >> "$CACHE_FILE"
+          echo "${NOW_EPOCH}" >> "$CACHE_FILE"
 
           echo "should_build=${SHOULD_BUILD}" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -123,9 +123,8 @@ jobs:
             echo "No upstream changes"
           fi
 
-          # Staleness fallback: rebuild at least once per MAX_BUILD_AGE even with no
-          # upstream changes, so the dev image never drifts more than a day behind
-          # the miles repo itself (miles commits alone do not trigger rebuilds).
+          # miles commits alone never trigger rebuilds, so bound how stale the baked
+          # miles checkout can get.
           MAX_BUILD_AGE_SECONDS=$(( 24 * 3600 ))
           NOW_EPOCH=$(date +%s)
           if [ "$SHOULD_BUILD" = "false" ]; then
@@ -138,8 +137,8 @@ jobs:
             fi
           fi
 
-          # Save current values for next run. The cache is only saved when a build
-          # triggers, so line 6 records when the last scheduled build was kicked off.
+          # Save current values for next run (cached only when a build triggers,
+          # so line 6 = when the last build was kicked off).
           echo "${SGLANG_SHA}" > "$CACHE_FILE"
           echo "${MEGATRON_SHA}" >> "$CACHE_FILE"
           echo "${WHEELS_CU13_X86_FP}" >> "$CACHE_FILE"

--- a/docs/ci/02-docker-build.md
+++ b/docs/ci/02-docker-build.md
@@ -75,7 +75,7 @@ Non-docker PRs are untouched: `docker-paths` reports no change, `docker-build` s
 
 The only automated builder of `radixark/miles`. Two jobs:
 
-- **`check-upstream`** (schedule / `simulate_schedule` only) — polls the inputs the image bakes: the HEAD SHA of sglang `sglang-miles` (`sgl-project/sglang`) and Megatron-LM `miles-main` (`radixark/Megatron-LM`) — the source branches it builds — plus a fingerprint of the selected `yueming-yuan/miles-wheels` rolling release, so a rebuilt sgl-router or other wheel also triggers a build (re-uploads to the same tag are caught by fingerprint, not commit SHA). It compares against the values cached from the last build and sets `should_build=true` if any moved. `miles` itself is intentionally not polled. This is what stops the 12-hour cron from rebuilding an unchanged image.
+- **`check-upstream`** (schedule / `simulate_schedule` only) — polls the inputs the image bakes: the HEAD SHA of sglang `sglang-miles` (`sgl-project/sglang`) and Megatron-LM `miles-main` (`radixark/Megatron-LM`) — the source branches it builds — plus a fingerprint of the selected `yueming-yuan/miles-wheels` rolling release, so a rebuilt sgl-router or other wheel also triggers a build (re-uploads to the same tag are caught by fingerprint, not commit SHA). It compares against the values cached from the last build and sets `should_build=true` if any moved. `miles` itself is intentionally not polled — that would rebuild far too often. This is what stops the 12-hour cron from rebuilding an unchanged image, with one staleness bound: because the image also bakes a `miles` checkout, `should_build` is forced to `true` once the last triggered build is **24h** old, so `dev` never drifts more than a day behind the `miles` repo even when sglang / Megatron / wheels are quiet. (The cache file's last line records the epoch of the last triggered build; it is only re-saved when a build fires.)
 - **`build-and-push`** (self-hosted runner) — calls `docker/build.py` to build + push, then conditionally points `latest` at the new `dev` and prunes old timestamped tags.
 
 `build-and-push` runs when `check-upstream` was skipped, or ran and reported `should_build=true`.
@@ -88,7 +88,7 @@ The only automated builder of `radixark/miles`. Two jobs:
 
 | Trigger                                     | `check-upstream`                   | builds                | `latest` move     | prune      |
 | ------------------------------------------- | ---------------------------------- | --------------------- | ----------------- | ---------- |
-| schedule (cron 00:00 / 12:00 UTC)           | runs; build only if upstream moved | `cu13` + `cu12-x86`   | yes (both)        | yes (both) |
+| schedule (cron 00:00 / 12:00 UTC)           | runs; build if upstream moved or last build ≥ 24h ago | `cu13` + `cu12-x86`   | yes (both)        | yes (both) |
 | push to `main` touching `docker/Dockerfile`, `docker/verify_transformer_engine.py`, or `requirements.txt` | skipped                            | `cu13` + `cu12-x86`   | no                | no         |
 | `workflow_dispatch`                         | skipped                            | the one input variant | no                | no         |
 | `workflow_dispatch` + `simulate_schedule`   | runs                               | the one input variant | no                | no         |


### PR DESCRIPTION
## What

Scheduled Docker builds (every 12h) only fire when sglang / Megatron-LM / miles-wheels move. When upstream is quiet the image is never rebuilt, so `radixark/miles:dev` silently drifts behind the miles repo itself (miles commits deliberately do not trigger rebuilds — that would rebuild far too often).

This adds a staleness fallback to `check-upstream`: if the last triggered build is **≥ 24h** old, `should_build` flips to true even with no upstream changes.

## How

The upstream-SHAs cache file gains a 6th line: the epoch when the build was last kicked off. The cache is already saved only when a build triggers, so the timestamp naturally tracks the last actual build decision — no extra API calls, no new state. Old 5-line caches (or a garbled line) read as "no timestamp" and trigger one rebuild, which migrates the file.

Upper bound discussed in the build channel; one day per @guapisolo.

## Behavior matrix

| upstream changed | last build age | builds? |
|---|---|---|
| yes | any | yes (unchanged) |
| no | < 24h | no (unchanged) |
| no | ≥ 24h | **yes (new)** |
| no | no timestamp (old cache) | **yes, once (migration)** |

Manual `workflow_dispatch` / push-to-main builds don't refresh the timestamp (they never touched this cache); worst case the next scheduled run rebuilds within a day of a manual build.
