### PR TITLE
fix(docs): grad_norm is logged before clipping, not after

### DIFF
--- a/miles/backends/training_utils/log_utils.py
+++ b/miles/backends/training_utils/log_utils.py
@@ -426,7 +426,7 @@ def log_train_step(
     Args:
         args: Configuration.
         loss_dict: Dictionary of loss metrics from aggregate_train_losses.
-        grad_norm: Gradient norm after clipping.
+        grad_norm: Global gradient L2 norm before clipping (multi-LoRA: max across stepped adapter slots).
         rollout_id: Rollout ID.
         step_id: Step ID within the rollout.
         num_steps_per_rollout: Total number of steps per rollout.

--- a/miles/backends/training_utils/log_utils.py
+++ b/miles/backends/training_utils/log_utils.py
@@ -426,7 +426,7 @@ def log_train_step(
     Args:
         args: Configuration.
         loss_dict: Dictionary of loss metrics from aggregate_train_losses.
-        grad_norm: Global gradient L2 norm before clipping (multi-LoRA: max across stepped adapter slots).
+        grad_norm: Global gradient L2 norm before clipping.
         rollout_id: Rollout ID.
         step_id: Step ID within the rollout.
         num_steps_per_rollout: Total number of steps per rollout.


### PR DESCRIPTION
## Summary

One-line docstring fix. `log_train_step`'s `Args:` block described `grad_norm` as the "Gradient norm after clipping". It is actually the norm **before** clipping.

## Why this is wrong

The value logged as `train/grad_norm` comes from Megatron's optimizer `step()`, which calls `clip_grad_norm()`. That function computes the global L2 norm first, returns *that* number, and only then rescales the gradients in place by the clipping coefficient. So the reported value is never touched by clipping — if it comes back as `3.7` with `--clip-grad 1.0`, the grads were scaled down but the metric still reads `3.7`.

This matters when reading a run: someone trusting the docstring would conclude the norm can never exceed `clip_grad`, and would therefore never notice that clipping is firing every step. The dashboard tooltip already describes the metric correctly as "global gradient norm before clipping", so the docstring was the only place carrying the wrong statement.

## Test plan

- [x] Docstring/comment only — no runtime behavior change, no test changes needed.
- [x] Verified the described semantics against the Megatron optimizer source: `clip_grad_norm()` computes the norm and returns it, then rescales the gradients in place.
- [x] Confirmed this was the only occurrence of the incorrect wording in the repo.
