### PR TITLE
fix: skip the --dump-details processor dump when it cannot serialise

### DIFF
--- a/miles/rollout/data_source.py
+++ b/miles/rollout/data_source.py
@@ -65,7 +65,8 @@ class RolloutDataSource(DataSource):
             # TODO move (during the refactor)
             if (d := args.dump_details) is not None:
                 tokenizer.save_pretrained(Path(d) / "tokenizer")
-                if processor:
+                # Bespoke processors (e.g. Inkling's) are not ProcessorMixin and cannot serialise.
+                if hasattr(processor, "save_pretrained"):
                     processor.save_pretrained(Path(d) / "processor")
 
             self.dataset = Dataset(


### PR DESCRIPTION
## Summary

`RolloutDataSource.__init__` dumps the tokenizer and processor next to the rollout
details whenever `--dump-details` is set. The processor branch assumed the object
is a `transformers` `ProcessorMixin` and called `save_pretrained` on it.

That assumption does not hold for every model. `load_processor` has a
model-specific branch that returns a bespoke processor class, which implements
the pieces the rollout path actually needs (`extract_media`, `__call__`) but is
not a `ProcessorMixin` and therefore has no `save_pretrained`. The generic branch
below it filters out anything that is not a `ProcessorMixin`, so only the
bespoke path can produce such an object -- and any run on that model family with
`--dump-details` died during `RolloutManager.__init__` with:

```
AttributeError: 'InklingTrainProcessor' object has no attribute 'save_pretrained'
```

Since `--use-miles-dashboard` asserts `--dump-details`, this made the dashboard
unusable for those models.

Guard on the method rather than on truthiness. Nothing reads the processor dump
(the dashboard only consumes the tokenizer dump), so skipping it when it cannot
be serialised is safe and keeps the tokenizer dump intact. `hasattr` also covers
the `processor is None` case that the previous truthiness check handled.

## Test plan

- [x] Full-parameter GRPO run on 64 H200s with `--dump-details` +
      `--use-miles-dashboard` on the affected model family: previously crashed in
      `RolloutManager.__init__`, now starts up and proceeds through weight
      loading into rollout.
- [x] Confirmed the tokenizer dump is still written, and that no code reads the
      processor dump directory.
- [ ] Existing model families that return a real `ProcessorMixin` are unaffected:
      `hasattr` is true for them, so the dump still happens.
