### PR TITLE
[fix] Re-pack rank bins when VPP rounding lowers the mbs target

### DIFF
--- a/miles/backends/megatron_utils/actor.py
+++ b/miles/backends/megatron_utils/actor.py
@@ -140,6 +140,8 @@ class MegatronTrainRayActor(TrainRayActor):
                 )
             dist.barrier(group=get_gloo_group())
 
+        # A full config (SCHEDULE_CONFIG_KEYS) lets the rollout side precompute the
+        # DP/mbs schedule. indep_dp keeps {}: dp_size can change via FT healing.
         self.train_parallel_config = (
             {}
             if args.indep_dp

--- a/miles/backends/megatron_utils/actor.py
+++ b/miles/backends/megatron_utils/actor.py
@@ -140,10 +140,8 @@ class MegatronTrainRayActor(TrainRayActor):
                 )
             dist.barrier(group=get_gloo_group())
 
-        # A full config (all miles.utils.dp_schedule.SCHEDULE_CONFIG_KEYS) advertises
-        # that the rollout side may precompute the DP/mbs schedule. indep_dp keeps
-        # ``{}``: dp_size can change at runtime via FT healing, so the schedule must
-        # stay on the training side (delay_split_train_data_by_dp).
+        # A full config (SCHEDULE_CONFIG_KEYS) lets the rollout side precompute the
+        # DP/mbs schedule. indep_dp keeps {}: dp_size can change via FT healing.
         self.train_parallel_config = (
             {}
             if args.indep_dp

--- a/miles/backends/megatron_utils/actor.py
+++ b/miles/backends/megatron_utils/actor.py
@@ -140,8 +140,6 @@ class MegatronTrainRayActor(TrainRayActor):
                 )
             dist.barrier(group=get_gloo_group())
 
-        # A full config (SCHEDULE_CONFIG_KEYS) lets the rollout side precompute the
-        # DP/mbs schedule. indep_dp keeps {}: dp_size can change via FT healing.
         self.train_parallel_config = (
             {}
             if args.indep_dp

--- a/miles/backends/megatron_utils/actor.py
+++ b/miles/backends/megatron_utils/actor.py
@@ -140,7 +140,20 @@ class MegatronTrainRayActor(TrainRayActor):
                 )
             dist.barrier(group=get_gloo_group())
 
-        self.train_parallel_config = {} if args.indep_dp else {"dp_size": get_parallel_state().intra_dp.size}
+        # A full config (all miles.utils.dp_schedule.SCHEDULE_CONFIG_KEYS) advertises
+        # that the rollout side may precompute the DP/mbs schedule. indep_dp keeps
+        # ``{}``: dp_size can change at runtime via FT healing, so the schedule must
+        # stay on the training side (delay_split_train_data_by_dp).
+        self.train_parallel_config = (
+            {}
+            if args.indep_dp
+            else {
+                "dp_size": get_parallel_state().intra_dp.size,
+                "cp_size": get_parallel_state().cp.size,
+                "vpp_size": get_parallel_state().vpp_size,
+                "microbatch_group_size_per_vp_stage": get_parallel_state().microbatch_group_size_per_vp_stage,
+            }
+        )
         dist.barrier(group=get_gloo_group())
 
         if args.offload_train:

--- a/miles/backends/training_utils/data.py
+++ b/miles/backends/training_utils/data.py
@@ -435,8 +435,7 @@ def get_data_iterator(
         assert args.use_dynamic_global_batch_size == ("dynamic_global_batch_size" in rollout_data)
         micro_batch_indices = rollout_data["micro_batch_indices"]
         data_iterator = [
-            DataIterator(rollout_data, micro_batch_indices=micro_batch_indices)
-            for _ in range(parallel_state.vpp_size)
+            DataIterator(rollout_data, micro_batch_indices=micro_batch_indices) for _ in range(parallel_state.vpp_size)
         ]
         return data_iterator, rollout_data["num_microbatches"]
 

--- a/miles/backends/training_utils/data.py
+++ b/miles/backends/training_utils/data.py
@@ -423,10 +423,24 @@ def get_data_iterator(
     Returns `(data_iterators, num_microbatches)` where:
     - `data_iterators`: list of `DataIterator`, one per VPP stage (size 1 if VPP disabled)
     - `num_microbatches`: list[int], one per local step in the rollout (length = steps)
+
+    When the rollout side already computed the schedule
+    (``split_train_data_by_dp_scheduled``), the precomputed ``micro_batch_indices`` /
+    ``num_microbatches`` in ``rollout_data`` are consumed directly — no collectives.
     """
     expand_multimodal_rollout_data_in_place(rollout_data, qkv_format=args.qkv_format)
 
     parallel_state = get_parallel_state()
+
+    if "micro_batch_indices" in rollout_data:
+        assert args.use_dynamic_global_batch_size == ("dynamic_global_batch_size" in rollout_data)
+        micro_batch_indices = rollout_data["micro_batch_indices"]
+        data_iterator = [
+            DataIterator(rollout_data, micro_batch_indices=micro_batch_indices)
+            for _ in range(parallel_state.vpp_size)
+        ]
+        return data_iterator, rollout_data["num_microbatches"]
+
     dp_size = parallel_state.effective_dp.size
     dp_group = parallel_state.effective_dp.group
     vpp_size = parallel_state.vpp_size

--- a/miles/backends/training_utils/data.py
+++ b/miles/backends/training_utils/data.py
@@ -423,6 +423,9 @@ def get_data_iterator(
     Returns `(data_iterators, num_microbatches)` where:
     - `data_iterators`: list of `DataIterator`, one per VPP stage (size 1 if VPP disabled)
     - `num_microbatches`: list[int], one per local step in the rollout (length = steps)
+
+    A schedule precomputed on the rollout side (`micro_batch_indices` in
+    `rollout_data`) is consumed directly — no collectives.
     """
     expand_multimodal_rollout_data_in_place(rollout_data, qkv_format=args.qkv_format)
 

--- a/miles/backends/training_utils/data.py
+++ b/miles/backends/training_utils/data.py
@@ -423,9 +423,6 @@ def get_data_iterator(
     Returns `(data_iterators, num_microbatches)` where:
     - `data_iterators`: list of `DataIterator`, one per VPP stage (size 1 if VPP disabled)
     - `num_microbatches`: list[int], one per local step in the rollout (length = steps)
-
-    A schedule precomputed on the rollout side (`micro_batch_indices` in
-    `rollout_data`) is consumed directly — no collectives.
     """
     expand_multimodal_rollout_data_in_place(rollout_data, qkv_format=args.qkv_format)
 

--- a/miles/backends/training_utils/data.py
+++ b/miles/backends/training_utils/data.py
@@ -424,9 +424,8 @@ def get_data_iterator(
     - `data_iterators`: list of `DataIterator`, one per VPP stage (size 1 if VPP disabled)
     - `num_microbatches`: list[int], one per local step in the rollout (length = steps)
 
-    When the rollout side already computed the schedule
-    (``split_train_data_by_dp_scheduled``), the precomputed ``micro_batch_indices`` /
-    ``num_microbatches`` in ``rollout_data`` are consumed directly — no collectives.
+    A schedule precomputed on the rollout side (`micro_batch_indices` in
+    `rollout_data`) is consumed directly — no collectives.
     """
     expand_multimodal_rollout_data_in_place(rollout_data, qkv_format=args.qkv_format)
 

--- a/miles/backends/training_utils/log_utils.py
+++ b/miles/backends/training_utils/log_utils.py
@@ -137,6 +137,8 @@ def log_rollout_data(rollout_id: int, args: Namespace, rollout_data: RolloutBatc
                 "witness_ids",
                 "weight_versions",
                 "metadata",
+                "num_microbatches",
+                "micro_batch_indices",
                 "n_adapters",
                 "adapter_slots",
                 "step_slots",

--- a/miles/ray/rollout/rollout_manager.py
+++ b/miles/ray/rollout/rollout_manager.py
@@ -16,8 +16,10 @@ from miles.ray.rollout.router_manager import start_session_server
 from miles.ray.rollout.server_cell import get_cell_indexer_of_id_map
 from miles.ray.rollout.train_data_conversion import (
     ROLLOUT_DATA_VALUE_SPEC,
+    can_schedule_on_rollout_side,
     convert_samples_to_train_data,
     split_train_data_by_dp,
+    split_train_data_by_dp_scheduled,
 )
 from miles.ray.utils import Lock
 from miles.rollout.base_types import (
@@ -143,6 +145,8 @@ class RolloutManager:
         sample_indices = data.get("sample_indices")
         if self.args.delay_split_train_data_by_dp:
             data_ref = object_store.get_instance().put(value=data, value_spec=ROLLOUT_DATA_VALUE_SPEC)
+        elif can_schedule_on_rollout_side(self.args, data, self.train_parallel_config):
+            data_ref = split_train_data_by_dp_scheduled(self.args, data, self.train_parallel_config)
         else:
             data_ref = split_train_data_by_dp(self.args, data, self.train_parallel_config["dp_size"])
         return dict(sample_indices=sample_indices, data_ref=data_ref)

--- a/miles/ray/rollout/train_data_conversion.py
+++ b/miles/ray/rollout/train_data_conversion.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Any
 
 import torch
@@ -9,6 +10,8 @@ from miles.utils.object_store import ValueSpec
 from miles.utils.seqlen_balancing import get_seqlen_balanced_partitions
 from miles.utils.timer import Timer
 from miles.utils.types import Sample
+
+logger = logging.getLogger(__name__)
 
 ROLLOUT_DATA_TENSOR_DTYPES = {
     "tokens": "int32",
@@ -254,6 +257,10 @@ def split_train_data_by_dp_scheduled_raw(
         train_parallel_config,
         total_lengths,
         global_batch_size=global_batch_size,
+    )
+    logger.info(
+        f"Rollout-side DP schedule: num_samples={len(total_lengths)}, "
+        f"global_batch_size={global_batch_size}, num_microbatches={num_microbatches}"
     )
 
     shards = _package_shards(args, data, partitions)

--- a/miles/ray/rollout/train_data_conversion.py
+++ b/miles/ray/rollout/train_data_conversion.py
@@ -39,6 +39,7 @@ ROLLOUT_DATA_VALUE_SPEC: dict[str, ValueSpec] = {
     "raw_reward": ValueSpec(codec="auto"),
     "total_lengths": ValueSpec(codec="auto"),
     "dynamic_global_batch_size": ValueSpec(codec="auto"),
+    # Rollout-side precomputed mbs schedule (split_train_data_by_dp_scheduled).
     "num_microbatches": ValueSpec(codec="auto"),
     "micro_batch_indices": ValueSpec(codec="auto"),
 }
@@ -208,7 +209,13 @@ def split_train_data_by_dp(args, data, dp_size):
 
 
 def can_schedule_on_rollout_side(args, data: dict[str, Any], train_parallel_config: dict | None) -> bool:
-    """Whether the rollout side can precompute the full DP/mbs schedule."""
+    """Whether the rollout side can precompute the full DP/mbs schedule.
+
+    Requires a full schedule config (megatron, non-indep_dp). Also excluded:
+    multi-LoRA (slot-contiguity stays on the legacy path), multimodal batches
+    (train-side media-token expansion changes ``total_lengths``), and sample
+    counts not divisible by the (dynamic) global batch size.
+    """
     if not has_full_schedule_config(train_parallel_config):
         return False
     if is_multi_lora_enabled(args):
@@ -220,7 +227,11 @@ def can_schedule_on_rollout_side(args, data: dict[str, Any], train_parallel_conf
 
 
 def split_train_data_by_dp_scheduled(args, data: dict[str, Any], train_parallel_config: dict):
-    """DP split with the mbs schedule precomputed on the rollout side."""
+    """DP split with the mbs schedule precomputed on the rollout side.
+
+    Same shard layout as :func:`split_train_data_by_dp`, plus ``num_microbatches``
+    and ``micro_batch_indices`` consumed by ``get_data_iterator``.
+    """
     shards = split_train_data_by_dp_scheduled_raw(args, data, train_parallel_config=train_parallel_config)
     store = object_store.get_instance()
     return [store.put(value=shard, value_spec=ROLLOUT_DATA_VALUE_SPEC) for shard in shards]

--- a/miles/ray/rollout/train_data_conversion.py
+++ b/miles/ray/rollout/train_data_conversion.py
@@ -3,6 +3,8 @@ from typing import Any
 import torch
 
 from miles.utils import object_store
+from miles.utils.dp_schedule import build_dp_schedule, has_full_schedule_config
+from miles.utils.multi_lora import is_multi_lora_enabled
 from miles.utils.object_store import ValueSpec
 from miles.utils.seqlen_balancing import get_seqlen_balanced_partitions
 from miles.utils.timer import Timer
@@ -34,6 +36,9 @@ ROLLOUT_DATA_VALUE_SPEC: dict[str, ValueSpec] = {
     "raw_reward": ValueSpec(codec="auto"),
     "total_lengths": ValueSpec(codec="auto"),
     "dynamic_global_batch_size": ValueSpec(codec="auto"),
+    # Rollout-side precomputed mbs schedule (split_train_data_by_dp_scheduled).
+    "num_microbatches": ValueSpec(codec="auto"),
+    "micro_batch_indices": ValueSpec(codec="auto"),
 }
 
 
@@ -200,6 +205,64 @@ def split_train_data_by_dp(args, data, dp_size):
     return [store.put(value=rollout_data, value_spec=ROLLOUT_DATA_VALUE_SPEC) for rollout_data in rollout_data_list]
 
 
+def can_schedule_on_rollout_side(args, data: dict[str, Any], train_parallel_config: dict | None) -> bool:
+    """Whether the rollout side can precompute the full DP/mbs schedule.
+
+    Requires the training backend to have advertised a full schedule config
+    (megatron, non-indep_dp). Excluded on top of that:
+      - multi-LoRA — keeps the legacy per-rank scheduling with its
+        slot-contiguity handling;
+      - multimodal batches — media-token expansion on the train side changes
+        ``total_lengths`` after the schedule would have been computed, so the
+        token-cap packing must stay train-side;
+      - sample counts not divisible by the (dynamic) global batch size —
+        legacy behavior silently drops the remainder per-rank; keep it there.
+    """
+    if not has_full_schedule_config(train_parallel_config):
+        return False
+    if is_multi_lora_enabled(args):
+        return False
+    if "multimodal_train_inputs" in data:
+        return False
+    global_batch_size = data.get("dynamic_global_batch_size", args.global_batch_size)
+    return len(data["tokens"]) % global_batch_size == 0
+
+
+def split_train_data_by_dp_scheduled(args, data: dict[str, Any], train_parallel_config: dict):
+    """DP split with the micro-batch schedule precomputed on the rollout side.
+
+    Same shard layout as :func:`split_train_data_by_dp`, plus two extra keys
+    per shard consumed by ``training_utils.data.get_data_iterator``:
+      - ``num_microbatches`` — per training step, identical on every rank;
+      - ``micro_batch_indices`` — this rank's mbs schedule (local row indices).
+    """
+    shards = split_train_data_by_dp_scheduled_raw(args, data, train_parallel_config=train_parallel_config)
+    store = object_store.get_instance()
+    return [store.put(value=shard, value_spec=ROLLOUT_DATA_VALUE_SPEC) for shard in shards]
+
+
+def split_train_data_by_dp_scheduled_raw(
+    args, data: dict[str, Any], *, train_parallel_config: dict
+) -> list[dict[str, Any]]:
+    """Object-store-free core of :func:`split_train_data_by_dp_scheduled`."""
+    total_lengths = [len(t) for t in data["tokens"]]
+    data["total_lengths"] = total_lengths
+
+    global_batch_size = data.get("dynamic_global_batch_size", args.global_batch_size)
+    partitions, micro_batch_indices, num_microbatches = build_dp_schedule(
+        args,
+        train_parallel_config,
+        total_lengths,
+        global_batch_size=global_batch_size,
+    )
+
+    shards = _package_shards(args, data, partitions)
+    for rank, shard in enumerate(shards):
+        shard["num_microbatches"] = num_microbatches
+        shard["micro_batch_indices"] = micro_batch_indices[rank]
+    return shards
+
+
 def split_train_data_by_dp_raw(args, data: dict[str, Any], *, dp_size: int) -> list[dict[str, Any]]:
     """Split the train data by data parallel size."""
     total_lengths = [len(t) for t in data["tokens"]]
@@ -216,9 +279,14 @@ def split_train_data_by_dp_raw(args, data: dict[str, Any], *, dp_size: int) -> l
     if adapter_slots is not None:
         partitions = [sorted(p, key=lambda i: adapter_slots[i]) for p in partitions]
 
+    return _package_shards(args, data, partitions)
+
+
+def _package_shards(args, data: dict[str, Any], partitions) -> list[dict[str, Any]]:
+    """Package one rollout_data shard per DP rank from precomputed partitions."""
     shards = []
 
-    for i in range(dp_size):
+    for i in range(len(partitions)):
         rollout_data = {}
         partition = partitions[i]
         rollout_data["partition"] = partition

--- a/miles/ray/rollout/train_data_conversion.py
+++ b/miles/ray/rollout/train_data_conversion.py
@@ -211,15 +211,10 @@ def split_train_data_by_dp(args, data, dp_size):
 def can_schedule_on_rollout_side(args, data: dict[str, Any], train_parallel_config: dict | None) -> bool:
     """Whether the rollout side can precompute the full DP/mbs schedule.
 
-    Requires the training backend to have advertised a full schedule config
-    (megatron, non-indep_dp). Excluded on top of that:
-      - multi-LoRA — keeps the legacy per-rank scheduling with its
-        slot-contiguity handling;
-      - multimodal batches — media-token expansion on the train side changes
-        ``total_lengths`` after the schedule would have been computed, so the
-        token-cap packing must stay train-side;
-      - sample counts not divisible by the (dynamic) global batch size —
-        legacy behavior silently drops the remainder per-rank; keep it there.
+    Requires a full schedule config (megatron, non-indep_dp). Also excluded:
+    multi-LoRA (slot-contiguity stays on the legacy path), multimodal batches
+    (train-side media-token expansion changes ``total_lengths``), and sample
+    counts not divisible by the (dynamic) global batch size.
     """
     if not has_full_schedule_config(train_parallel_config):
         return False
@@ -232,12 +227,10 @@ def can_schedule_on_rollout_side(args, data: dict[str, Any], train_parallel_conf
 
 
 def split_train_data_by_dp_scheduled(args, data: dict[str, Any], train_parallel_config: dict):
-    """DP split with the micro-batch schedule precomputed on the rollout side.
+    """DP split with the mbs schedule precomputed on the rollout side.
 
-    Same shard layout as :func:`split_train_data_by_dp`, plus two extra keys
-    per shard consumed by ``training_utils.data.get_data_iterator``:
-      - ``num_microbatches`` — per training step, identical on every rank;
-      - ``micro_batch_indices`` — this rank's mbs schedule (local row indices).
+    Same shard layout as :func:`split_train_data_by_dp`, plus ``num_microbatches``
+    and ``micro_batch_indices`` consumed by ``get_data_iterator``.
     """
     shards = split_train_data_by_dp_scheduled_raw(args, data, train_parallel_config=train_parallel_config)
     store = object_store.get_instance()

--- a/miles/ray/rollout/train_data_conversion.py
+++ b/miles/ray/rollout/train_data_conversion.py
@@ -230,6 +230,7 @@ def split_train_data_by_dp_scheduled_raw(
     args, data: dict[str, Any], *, train_parallel_config: dict
 ) -> list[dict[str, Any]]:
     """Object-store-free core of :func:`split_train_data_by_dp_scheduled`."""
+    # "Total" means each sample's whole trajectory: prompt + response tokens.
     total_lengths = [len(t) for t in data["tokens"]]
     data["total_lengths"] = total_lengths
 
@@ -254,6 +255,7 @@ def split_train_data_by_dp_scheduled_raw(
 
 def split_train_data_by_dp_raw(args, data: dict[str, Any], *, dp_size: int) -> list[dict[str, Any]]:
     """Split the train data by data parallel size."""
+    # "Total" means each sample's whole trajectory: prompt + response tokens.
     total_lengths = [len(t) for t in data["tokens"]]
     data["total_lengths"] = total_lengths
 

--- a/miles/ray/rollout/train_data_conversion.py
+++ b/miles/ray/rollout/train_data_conversion.py
@@ -39,7 +39,6 @@ ROLLOUT_DATA_VALUE_SPEC: dict[str, ValueSpec] = {
     "raw_reward": ValueSpec(codec="auto"),
     "total_lengths": ValueSpec(codec="auto"),
     "dynamic_global_batch_size": ValueSpec(codec="auto"),
-    # Rollout-side precomputed mbs schedule (split_train_data_by_dp_scheduled).
     "num_microbatches": ValueSpec(codec="auto"),
     "micro_batch_indices": ValueSpec(codec="auto"),
 }
@@ -209,13 +208,7 @@ def split_train_data_by_dp(args, data, dp_size):
 
 
 def can_schedule_on_rollout_side(args, data: dict[str, Any], train_parallel_config: dict | None) -> bool:
-    """Whether the rollout side can precompute the full DP/mbs schedule.
-
-    Requires a full schedule config (megatron, non-indep_dp). Also excluded:
-    multi-LoRA (slot-contiguity stays on the legacy path), multimodal batches
-    (train-side media-token expansion changes ``total_lengths``), and sample
-    counts not divisible by the (dynamic) global batch size.
-    """
+    """Whether the rollout side can precompute the full DP/mbs schedule."""
     if not has_full_schedule_config(train_parallel_config):
         return False
     if is_multi_lora_enabled(args):
@@ -227,11 +220,7 @@ def can_schedule_on_rollout_side(args, data: dict[str, Any], train_parallel_conf
 
 
 def split_train_data_by_dp_scheduled(args, data: dict[str, Any], train_parallel_config: dict):
-    """DP split with the mbs schedule precomputed on the rollout side.
-
-    Same shard layout as :func:`split_train_data_by_dp`, plus ``num_microbatches``
-    and ``micro_batch_indices`` consumed by ``get_data_iterator``.
-    """
+    """DP split with the mbs schedule precomputed on the rollout side."""
     shards = split_train_data_by_dp_scheduled_raw(args, data, train_parallel_config=train_parallel_config)
     store = object_store.get_instance()
     return [store.put(value=shard, value_spec=ROLLOUT_DATA_VALUE_SPEC) for shard in shards]

--- a/miles/ray/rollout/train_data_conversion.py
+++ b/miles/ray/rollout/train_data_conversion.py
@@ -214,7 +214,8 @@ def can_schedule_on_rollout_side(args, data: dict[str, Any], train_parallel_conf
     Requires a full schedule config (megatron, non-indep_dp). Also excluded:
     multi-LoRA (slot-contiguity stays on the legacy path), multimodal batches
     (train-side media-token expansion changes ``total_lengths``), and sample
-    counts not divisible by the (dynamic) global batch size.
+    counts not divisible by the (dynamic) global batch size (the legacy path
+    silently drops the remainder per rank; keep that behavior there).
     """
     if not has_full_schedule_config(train_parallel_config):
         return False

--- a/miles/utils/dp_schedule.py
+++ b/miles/utils/dp_schedule.py
@@ -1,25 +1,13 @@
-"""Per-rollout DP/microbatch scheduling.
+"""Per-rollout DP/microbatch scheduling, computed on the rollout side.
 
-Pure-Python logic that decides, for one (already-trimmed) rollout's worth of
-sample lengths, which global sample goes to which DP rank and how each rank
-groups its samples into micro-batches. Lives outside the ray/sglang-importing
-modules so it can be unit-tested under CPU-only CI.
+Pure Python (no ray/sglang imports) so it is unit-testable under CPU-only CI.
+Trim and dynamic-gbs resolution stay on the caller's side.
 
-Trim, dynamic-global_batch_size resolution, and per-rank rollout_data
-packaging all stay on the caller's side; this module only computes the
-schedule itself.
-
-Invariants guaranteed by :func:`build_dp_schedule` (asserted by the tests):
-  - every DP rank holds the same number of samples (``num_samples // dp_size``);
-  - every DP rank runs the same ``num_microbatches`` per training step
-    (required for PP sync);
-  - every mbs holds ``<= max_tokens_per_gpu * cp_size`` tokens, with one
-    exception — an individual sample larger than that cap lands alone in its
-    own mbs (and that mbs is the only one allowed to exceed the cap);
-  - the union of per-rank sample indices equals ``range(num_samples)`` and
-    the per-rank index sets are disjoint;
-  - flattening ``micro_batch_indices`` for a rank yields
-    ``range(num_samples_rank)``.
+Invariants (asserted by tests/fast/utils/test_dp_schedule.py):
+  - equal sample count per DP rank; same ``num_microbatches`` per rank (PP sync);
+  - each mbs holds <= ``max_tokens_per_gpu * cp_size`` tokens, except an
+    oversized sample, which lands alone in its own mbs;
+  - per-rank partitions are disjoint and cover all samples exactly once.
 """
 
 from __future__ import annotations
@@ -32,11 +20,8 @@ SCHEDULE_CONFIG_KEYS = ("dp_size", "cp_size", "vpp_size", "microbatch_group_size
 
 
 def has_full_schedule_config(train_parallel_config: dict | None) -> bool:
-    """True when the training backend advertised every field build_dp_schedule needs.
-
-    Backends that don't (fsdp/torchtitan report only ``dp_size``; indep_dp reports
-    ``{}``) keep the legacy train-side scheduling path.
-    """
+    """True when the backend advertised every field build_dp_schedule needs
+    (fsdp/torchtitan report only ``dp_size``; indep_dp reports ``{}``)."""
     if not train_parallel_config:
         return False
     return all(key in train_parallel_config for key in SCHEDULE_CONFIG_KEYS)
@@ -51,34 +36,18 @@ def build_dp_schedule(
 ) -> tuple[list[list[int]], list[list[list[int]]], list[int]]:
     """Compute the per-rank DP partition and micro-batch schedule.
 
-    For each training step (chunk of ``global_batch_size`` samples):
-      a. Split samples to DP ranks with equal counts (``balance_data`` => token-
-         balanced via Karmarkar-Karp, otherwise strided).
-      b. Static path: chunk each rank's samples into mbs of ``args.micro_batch_size``.
-         Dynamic path: per-rank first-fit (``<= max_tokens_per_gpu * cp_size``), take
-         ``MAX`` across ranks for PP/VPP alignment, then expand each rank to that
-         count by splitting its largest multi-sample bins. Split halves are ``<=``
-         their parent, so the cap is preserved.
-
-    Samples are appended to ``partitions[r]`` in mbs order so each mbs occupies a
-    contiguous range of positions there; ``micro_batch_indices[r][k]`` is that range.
-
-    Args:
-        args: Namespace with ``micro_batch_size``, ``use_dynamic_batch_size``,
-            ``max_tokens_per_gpu``, ``balance_data``.
-        train_parallel_config: ``{"dp_size", "cp_size", "vpp_size",
-            "microbatch_group_size_per_vp_stage"}``.
-        total_lengths: token count per sample, length must be a multiple of
-            ``global_batch_size``.
-        global_batch_size: samples per training step.
+    Per step of ``global_batch_size`` samples: split samples to DP ranks
+    (Karmarkar-Karp if ``balance_data`` else strided), then chunk each rank into
+    mbs — fixed ``micro_batch_size`` (static) or first-fit under
+    ``max_tokens_per_gpu * cp_size`` with a DP-wide MAX + bin splitting for
+    PP/VPP alignment (dynamic).
 
     Returns:
         ``(partitions, micro_batch_indices, num_microbatches)``:
-          - ``partitions[r]`` — global sample indices going to rank r, concatenated
-            across all steps in mbs order.
-          - ``micro_batch_indices[r][k]`` — local indices into ``partitions[r]`` for
-            the k-th mbs of rank r (flat across all steps).
-          - ``num_microbatches[s]`` — mbs count for step s; same value on every rank.
+          - ``partitions[r]`` — global sample indices of rank r, in mbs order;
+          - ``micro_batch_indices[r][k]`` — local indices into ``partitions[r]``
+            for the k-th mbs (flat across steps);
+          - ``num_microbatches[s]`` — mbs count for step s, same on every rank.
     """
     dp_size = train_parallel_config["dp_size"]
     cp_size = train_parallel_config["cp_size"]

--- a/miles/utils/dp_schedule.py
+++ b/miles/utils/dp_schedule.py
@@ -1,14 +1,4 @@
-"""Per-rollout DP/microbatch scheduling, computed on the rollout side.
-
-Pure Python (no ray/sglang imports) so it is unit-testable under CPU-only CI.
-Trim and dynamic-gbs resolution stay on the caller's side.
-
-Invariants (asserted by tests/fast/utils/test_dp_schedule.py):
-  - equal sample count per DP rank; same ``num_microbatches`` per rank (PP sync);
-  - each mbs holds <= ``max_tokens_per_gpu * cp_size`` tokens, except an
-    oversized sample, which lands alone in its own mbs;
-  - per-rank partitions are disjoint and cover all samples exactly once.
-"""
+"""Per-rollout DP/microbatch scheduling, computed on the rollout side."""
 
 from __future__ import annotations
 
@@ -20,8 +10,7 @@ SCHEDULE_CONFIG_KEYS = ("dp_size", "cp_size", "vpp_size", "microbatch_group_size
 
 
 def has_full_schedule_config(train_parallel_config: dict | None) -> bool:
-    """True when the backend advertised every field build_dp_schedule needs
-    (fsdp/torchtitan report only ``dp_size``; indep_dp reports ``{}``)."""
+    """True when the backend advertised every field build_dp_schedule needs."""
     if not train_parallel_config:
         return False
     return all(key in train_parallel_config for key in SCHEDULE_CONFIG_KEYS)
@@ -34,21 +23,7 @@ def build_dp_schedule(
     *,
     global_batch_size: int,
 ) -> tuple[list[list[int]], list[list[list[int]]], list[int]]:
-    """Compute the per-rank DP partition and micro-batch schedule.
-
-    Per step of ``global_batch_size`` samples: split samples to DP ranks
-    (Karmarkar-Karp if ``balance_data`` else strided), then chunk each rank into
-    mbs — fixed ``micro_batch_size`` (static) or first-fit under
-    ``max_tokens_per_gpu * cp_size`` with a DP-wide MAX + bin splitting for
-    PP/VPP alignment (dynamic).
-
-    Returns:
-        ``(partitions, micro_batch_indices, num_microbatches)``:
-          - ``partitions[r]`` — global sample indices of rank r, in mbs order;
-          - ``micro_batch_indices[r][k]`` — local indices into ``partitions[r]``
-            for the k-th mbs (flat across steps);
-          - ``num_microbatches[s]`` — mbs count for step s, same on every rank.
-    """
+    """Compute per-rank ``(partitions, micro_batch_indices, num_microbatches)``."""
     dp_size = train_parallel_config["dp_size"]
     cp_size = train_parallel_config["cp_size"]
     vpp_size = train_parallel_config["vpp_size"] or 1
@@ -77,8 +52,6 @@ def build_dp_schedule(
         else:
             rank_parts = [list(range(r, global_batch_size, dp_size)) for r in range(dp_size)]
 
-        # rank_mbs[r][k] is one mbs of LOCAL indices into rank_parts[r] (positions
-        # within this rank's sample list, not step- or global-indices).
         if not args.use_dynamic_batch_size:
             mbs = args.micro_batch_size
             n = len(rank_parts[0])  # gbs / dp, same for every rank
@@ -93,7 +66,6 @@ def build_dp_schedule(
             rank_mbs = [first_fit_pack(rank_lens[r], max_per_bin) for r in range(dp_size)]
             num_mbs_per_rank = max(len(b) for b in rank_mbs)
             if vpp_size > 1:
-                # Match the original floor-to-mb_group rounding (with min=1).
                 num_mbs_per_rank = max(num_mbs_per_rank // mb_group * mb_group, 1)
             for r in range(dp_size):
                 expand_bins_by_splitting(rank_mbs[r], num_mbs_per_rank, rank_lens[r])

--- a/miles/utils/dp_schedule.py
+++ b/miles/utils/dp_schedule.py
@@ -96,7 +96,15 @@ def build_dp_schedule(
                 # Match the original floor-to-mb_group rounding (with min=1).
                 num_mbs_per_rank = max(num_mbs_per_rank // mb_group * mb_group, 1)
             for r in range(dp_size):
-                expand_bins_by_splitting(rank_mbs[r], num_mbs_per_rank, rank_lens[r])
+                if len(rank_mbs[r]) > num_mbs_per_rank:
+                    # VPP rounding lowered the target below this rank's cap-minimal
+                    # bin count, so the token cap is unsatisfiable; re-pack into
+                    # exactly num_mbs_per_rank token-balanced bins like the legacy
+                    # train side did after the same rounding.
+                    rank_mbs[r] = get_seqlen_balanced_partitions(rank_lens[r], num_mbs_per_rank, equal_size=False)
+                else:
+                    expand_bins_by_splitting(rank_mbs[r], num_mbs_per_rank, rank_lens[r])
+                assert len(rank_mbs[r]) == num_mbs_per_rank
 
         num_microbatches.append(num_mbs_per_rank)
 

--- a/miles/utils/dp_schedule.py
+++ b/miles/utils/dp_schedule.py
@@ -1,0 +1,140 @@
+"""Per-rollout DP/microbatch scheduling.
+
+Pure-Python logic that decides, for one (already-trimmed) rollout's worth of
+sample lengths, which global sample goes to which DP rank and how each rank
+groups its samples into micro-batches. Lives outside the ray/sglang-importing
+modules so it can be unit-tested under CPU-only CI.
+
+Trim, dynamic-global_batch_size resolution, and per-rank rollout_data
+packaging all stay on the caller's side; this module only computes the
+schedule itself.
+
+Invariants guaranteed by :func:`build_dp_schedule` (asserted by the tests):
+  - every DP rank holds the same number of samples (``num_samples // dp_size``);
+  - every DP rank runs the same ``num_microbatches`` per training step
+    (required for PP sync);
+  - every mbs holds ``<= max_tokens_per_gpu * cp_size`` tokens, with one
+    exception — an individual sample larger than that cap lands alone in its
+    own mbs (and that mbs is the only one allowed to exceed the cap);
+  - the union of per-rank sample indices equals ``range(num_samples)`` and
+    the per-rank index sets are disjoint;
+  - flattening ``micro_batch_indices`` for a rank yields
+    ``range(num_samples_rank)``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from miles.utils.seqlen_balancing import expand_bins_by_splitting, first_fit_pack, get_seqlen_balanced_partitions
+
+SCHEDULE_CONFIG_KEYS = ("dp_size", "cp_size", "vpp_size", "microbatch_group_size_per_vp_stage")
+
+
+def has_full_schedule_config(train_parallel_config: dict | None) -> bool:
+    """True when the training backend advertised every field build_dp_schedule needs.
+
+    Backends that don't (fsdp/torchtitan report only ``dp_size``; indep_dp reports
+    ``{}``) keep the legacy train-side scheduling path.
+    """
+    if not train_parallel_config:
+        return False
+    return all(key in train_parallel_config for key in SCHEDULE_CONFIG_KEYS)
+
+
+def build_dp_schedule(
+    args: Any,
+    train_parallel_config: dict,
+    total_lengths: list[int],
+    *,
+    global_batch_size: int,
+) -> tuple[list[list[int]], list[list[list[int]]], list[int]]:
+    """Compute the per-rank DP partition and micro-batch schedule.
+
+    For each training step (chunk of ``global_batch_size`` samples):
+      a. Split samples to DP ranks with equal counts (``balance_data`` => token-
+         balanced via Karmarkar-Karp, otherwise strided).
+      b. Static path: chunk each rank's samples into mbs of ``args.micro_batch_size``.
+         Dynamic path: per-rank first-fit (``<= max_tokens_per_gpu * cp_size``), take
+         ``MAX`` across ranks for PP/VPP alignment, then expand each rank to that
+         count by splitting its largest multi-sample bins. Split halves are ``<=``
+         their parent, so the cap is preserved.
+
+    Samples are appended to ``partitions[r]`` in mbs order so each mbs occupies a
+    contiguous range of positions there; ``micro_batch_indices[r][k]`` is that range.
+
+    Args:
+        args: Namespace with ``micro_batch_size``, ``use_dynamic_batch_size``,
+            ``max_tokens_per_gpu``, ``balance_data``.
+        train_parallel_config: ``{"dp_size", "cp_size", "vpp_size",
+            "microbatch_group_size_per_vp_stage"}``.
+        total_lengths: token count per sample, length must be a multiple of
+            ``global_batch_size``.
+        global_batch_size: samples per training step.
+
+    Returns:
+        ``(partitions, micro_batch_indices, num_microbatches)``:
+          - ``partitions[r]`` — global sample indices going to rank r, concatenated
+            across all steps in mbs order.
+          - ``micro_batch_indices[r][k]`` — local indices into ``partitions[r]`` for
+            the k-th mbs of rank r (flat across all steps).
+          - ``num_microbatches[s]`` — mbs count for step s; same value on every rank.
+    """
+    dp_size = train_parallel_config["dp_size"]
+    cp_size = train_parallel_config["cp_size"]
+    vpp_size = train_parallel_config["vpp_size"] or 1
+    mb_group = train_parallel_config["microbatch_group_size_per_vp_stage"]
+
+    assert len(total_lengths) % global_batch_size == 0, (
+        f"num_samples ({len(total_lengths)}) is not a multiple of global_batch_size "
+        f"({global_batch_size}); trim upstream before scheduling."
+    )
+    num_steps = len(total_lengths) // global_batch_size
+
+    if args.use_dynamic_batch_size:
+        assert args.max_tokens_per_gpu is not None
+        max_per_bin = args.max_tokens_per_gpu * cp_size
+
+    partitions: list[list[int]] = [[] for _ in range(dp_size)]
+    micro_batch_indices: list[list[list[int]]] = [[] for _ in range(dp_size)]
+    num_microbatches: list[int] = []
+
+    for step_i in range(num_steps):
+        step_start = step_i * global_batch_size
+        step_lengths = total_lengths[step_start : step_start + global_batch_size]
+
+        if args.balance_data:
+            rank_parts = get_seqlen_balanced_partitions(step_lengths, dp_size, equal_size=True)
+        else:
+            rank_parts = [list(range(r, global_batch_size, dp_size)) for r in range(dp_size)]
+
+        # rank_mbs[r][k] is one mbs of LOCAL indices into rank_parts[r] (positions
+        # within this rank's sample list, not step- or global-indices).
+        if not args.use_dynamic_batch_size:
+            mbs = args.micro_batch_size
+            n = len(rank_parts[0])  # gbs / dp, same for every rank
+            assert n % mbs == 0, (
+                f"per-rank batch ({n} = global_batch_size {global_batch_size} / dp_size {dp_size}) "
+                f"is not a multiple of micro_batch_size ({mbs})"
+            )
+            rank_mbs = [[list(range(i, i + mbs)) for i in range(0, n, mbs)] for _ in range(dp_size)]
+            num_mbs_per_rank = n // mbs
+        else:
+            rank_lens = [[step_lengths[i] for i in rank_parts[r]] for r in range(dp_size)]
+            rank_mbs = [first_fit_pack(rank_lens[r], max_per_bin) for r in range(dp_size)]
+            num_mbs_per_rank = max(len(b) for b in rank_mbs)
+            if vpp_size > 1:
+                # Match the original floor-to-mb_group rounding (with min=1).
+                num_mbs_per_rank = max(num_mbs_per_rank // mb_group * mb_group, 1)
+            for r in range(dp_size):
+                expand_bins_by_splitting(rank_mbs[r], num_mbs_per_rank, rank_lens[r])
+
+        num_microbatches.append(num_mbs_per_rank)
+
+        for r in range(dp_size):
+            for mbs_local in rank_mbs[r]:
+                local_start = len(partitions[r])
+                partitions[r].extend(step_start + rank_parts[r][i] for i in mbs_local)
+                micro_batch_indices[r].append(list(range(local_start, local_start + len(mbs_local))))
+
+    return partitions, micro_batch_indices, num_microbatches

--- a/miles/utils/dp_schedule.py
+++ b/miles/utils/dp_schedule.py
@@ -1,4 +1,14 @@
-"""Per-rollout DP/microbatch scheduling, computed on the rollout side."""
+"""Per-rollout DP/microbatch scheduling, computed on the rollout side.
+
+Pure Python (no ray/sglang imports) so it is unit-testable under CPU-only CI.
+Trim and dynamic-gbs resolution stay on the caller's side.
+
+Invariants (asserted by tests/fast/utils/test_dp_schedule.py):
+  - equal sample count per DP rank; same ``num_microbatches`` per rank (PP sync);
+  - each mbs holds <= ``max_tokens_per_gpu * cp_size`` tokens, except an
+    oversized sample, which lands alone in its own mbs;
+  - per-rank partitions are disjoint and cover all samples exactly once.
+"""
 
 from __future__ import annotations
 
@@ -10,7 +20,8 @@ SCHEDULE_CONFIG_KEYS = ("dp_size", "cp_size", "vpp_size", "microbatch_group_size
 
 
 def has_full_schedule_config(train_parallel_config: dict | None) -> bool:
-    """True when the backend advertised every field build_dp_schedule needs."""
+    """True when the backend advertised every field build_dp_schedule needs
+    (fsdp/torchtitan report only ``dp_size``; indep_dp reports ``{}``)."""
     if not train_parallel_config:
         return False
     return all(key in train_parallel_config for key in SCHEDULE_CONFIG_KEYS)
@@ -23,7 +34,21 @@ def build_dp_schedule(
     *,
     global_batch_size: int,
 ) -> tuple[list[list[int]], list[list[list[int]]], list[int]]:
-    """Compute per-rank ``(partitions, micro_batch_indices, num_microbatches)``."""
+    """Compute the per-rank DP partition and micro-batch schedule.
+
+    Per step of ``global_batch_size`` samples: split samples to DP ranks
+    (Karmarkar-Karp if ``balance_data`` else strided), then chunk each rank into
+    mbs — fixed ``micro_batch_size`` (static) or first-fit under
+    ``max_tokens_per_gpu * cp_size`` with a DP-wide MAX + bin splitting for
+    PP/VPP alignment (dynamic).
+
+    Returns:
+        ``(partitions, micro_batch_indices, num_microbatches)``:
+          - ``partitions[r]`` — global sample indices of rank r, in mbs order;
+          - ``micro_batch_indices[r][k]`` — local indices into ``partitions[r]``
+            for the k-th mbs (flat across steps);
+          - ``num_microbatches[s]`` — mbs count for step s, same on every rank.
+    """
     dp_size = train_parallel_config["dp_size"]
     cp_size = train_parallel_config["cp_size"]
     vpp_size = train_parallel_config["vpp_size"] or 1
@@ -52,6 +77,8 @@ def build_dp_schedule(
         else:
             rank_parts = [list(range(r, global_batch_size, dp_size)) for r in range(dp_size)]
 
+        # rank_mbs[r][k] is one mbs of LOCAL indices into rank_parts[r] (positions
+        # within this rank's sample list, not step- or global-indices).
         if not args.use_dynamic_batch_size:
             mbs = args.micro_batch_size
             n = len(rank_parts[0])  # gbs / dp, same for every rank
@@ -66,6 +93,7 @@ def build_dp_schedule(
             rank_mbs = [first_fit_pack(rank_lens[r], max_per_bin) for r in range(dp_size)]
             num_mbs_per_rank = max(len(b) for b in rank_mbs)
             if vpp_size > 1:
+                # Match the original floor-to-mb_group rounding (with min=1).
                 num_mbs_per_rank = max(num_mbs_per_rank // mb_group * mb_group, 1)
             for r in range(dp_size):
                 expand_bins_by_splitting(rank_mbs[r], num_mbs_per_rank, rank_lens[r])

--- a/miles/utils/seqlen_balancing.py
+++ b/miles/utils/seqlen_balancing.py
@@ -177,6 +177,58 @@ def get_seqlen_balanced_partitions(seqlen_list: list[int], k_partitions: int, eq
     return _check_and_sort_partitions(partitions)
 
 
+def first_fit_pack(total_lengths, max_tokens_per_bin):
+    """First-fit bin packing.
+
+    Returns ``list[list[int]]`` — each bin is a list of indices into ``total_lengths``.
+    Bin sums are ``<= max_tokens_per_bin`` whenever every individual ``length`` fits;
+    an oversized sample lands alone in its own bin with sum equal to its length.
+    """
+    bins: list[list[int]] = []
+    bin_sums: list[int] = []
+    for idx, length in enumerate(total_lengths):
+        for j in range(len(bins)):
+            if bin_sums[j] + length <= max_tokens_per_bin:
+                bins[j].append(idx)
+                bin_sums[j] += length
+                break
+        else:
+            bins.append([idx])
+            bin_sums.append(length)
+    return bins
+
+
+def _split_bin_by_tokens(bin_indices: list[int], lengths) -> list[list[int]]:
+    """Split a bin's indices into two halves balanced by total tokens (LPT heuristic).
+
+    Returns ``[left, right]`` where both lists together cover ``bin_indices``. Because
+    each half is a strict subset of ``bin_indices``, both have token sums ``<=`` the
+    original bin's sum — useful when you need to grow a bin packing without ever
+    creating a bin larger than the originals.
+    """
+    halves: list[list[int]] = [[], []]
+    sums = [0, 0]
+    for idx in sorted(bin_indices, key=lambda i: -lengths[i]):
+        h = 0 if sums[0] <= sums[1] else 1
+        halves[h].append(idx)
+        sums[h] += lengths[idx]
+    return halves
+
+
+def expand_bins_by_splitting(bins: list[list[int]], target_count: int, lengths) -> None:
+    """Grow ``bins`` in place to ``target_count`` by repeatedly splitting the largest
+    multi-sample bin via :func:`_split_bin_by_tokens`. Stops early if every remaining
+    bin is a singleton (no bin can be split further)."""
+    while len(bins) < target_count:
+        candidates = [(sum(lengths[i] for i in b), idx) for idx, b in enumerate(bins) if len(b) > 1]
+        if not candidates:
+            break
+        _, idx = max(candidates)
+        left, right = _split_bin_by_tokens(bins[idx], lengths)
+        bins[idx] = left
+        bins.append(right)
+
+
 def get_reverse_idx(idx_map):
     reverse_idx_map = copy.deepcopy(idx_map)
 

--- a/miles/utils/seqlen_balancing.py
+++ b/miles/utils/seqlen_balancing.py
@@ -178,7 +178,8 @@ def get_seqlen_balanced_partitions(seqlen_list: list[int], k_partitions: int, eq
 
 
 def first_fit_pack(total_lengths, max_tokens_per_bin):
-    """First-fit bin packing; bins hold indices, oversized samples land alone."""
+    """First-fit bin packing; each bin is a list of indices into ``total_lengths``.
+    Bin sums stay ``<= max_tokens_per_bin``; an oversized sample lands alone."""
     bins: list[list[int]] = []
     bin_sums: list[int] = []
     for idx, length in enumerate(total_lengths):
@@ -194,7 +195,8 @@ def first_fit_pack(total_lengths, max_tokens_per_bin):
 
 
 def _split_bin_by_tokens(bin_indices: list[int], lengths) -> list[list[int]]:
-    """Split a bin into two token-balanced halves (LPT)."""
+    """Split a bin into two token-balanced halves (LPT); each half's sum is
+    ``<=`` the parent's, so splitting never exceeds the original cap."""
     halves: list[list[int]] = [[], []]
     sums = [0, 0]
     for idx in sorted(bin_indices, key=lambda i: -lengths[i]):
@@ -205,7 +207,8 @@ def _split_bin_by_tokens(bin_indices: list[int], lengths) -> list[list[int]]:
 
 
 def expand_bins_by_splitting(bins: list[list[int]], target_count: int, lengths) -> None:
-    """Grow ``bins`` in place to ``target_count`` by splitting the largest bins."""
+    """Grow ``bins`` in place to ``target_count`` by splitting the largest
+    multi-sample bin; stops early once every bin is a singleton."""
     while len(bins) < target_count:
         candidates = [(sum(lengths[i] for i in b), idx) for idx, b in enumerate(bins) if len(b) > 1]
         if not candidates:

--- a/miles/utils/seqlen_balancing.py
+++ b/miles/utils/seqlen_balancing.py
@@ -178,8 +178,7 @@ def get_seqlen_balanced_partitions(seqlen_list: list[int], k_partitions: int, eq
 
 
 def first_fit_pack(total_lengths, max_tokens_per_bin):
-    """First-fit bin packing; each bin is a list of indices into ``total_lengths``.
-    Bin sums stay ``<= max_tokens_per_bin``; an oversized sample lands alone."""
+    """First-fit bin packing; bins hold indices, oversized samples land alone."""
     bins: list[list[int]] = []
     bin_sums: list[int] = []
     for idx, length in enumerate(total_lengths):
@@ -195,8 +194,7 @@ def first_fit_pack(total_lengths, max_tokens_per_bin):
 
 
 def _split_bin_by_tokens(bin_indices: list[int], lengths) -> list[list[int]]:
-    """Split a bin into two token-balanced halves (LPT); each half's sum is
-    ``<=`` the parent's, so splitting never exceeds the original cap."""
+    """Split a bin into two token-balanced halves (LPT)."""
     halves: list[list[int]] = [[], []]
     sums = [0, 0]
     for idx in sorted(bin_indices, key=lambda i: -lengths[i]):
@@ -207,8 +205,7 @@ def _split_bin_by_tokens(bin_indices: list[int], lengths) -> list[list[int]]:
 
 
 def expand_bins_by_splitting(bins: list[list[int]], target_count: int, lengths) -> None:
-    """Grow ``bins`` in place to ``target_count`` by splitting the largest
-    multi-sample bin; stops early once every bin is a singleton."""
+    """Grow ``bins`` in place to ``target_count`` by splitting the largest bins."""
     while len(bins) < target_count:
         candidates = [(sum(lengths[i] for i in b), idx) for idx, b in enumerate(bins) if len(b) > 1]
         if not candidates:

--- a/miles/utils/seqlen_balancing.py
+++ b/miles/utils/seqlen_balancing.py
@@ -178,12 +178,8 @@ def get_seqlen_balanced_partitions(seqlen_list: list[int], k_partitions: int, eq
 
 
 def first_fit_pack(total_lengths, max_tokens_per_bin):
-    """First-fit bin packing.
-
-    Returns ``list[list[int]]`` — each bin is a list of indices into ``total_lengths``.
-    Bin sums are ``<= max_tokens_per_bin`` whenever every individual ``length`` fits;
-    an oversized sample lands alone in its own bin with sum equal to its length.
-    """
+    """First-fit bin packing; each bin is a list of indices into ``total_lengths``.
+    Bin sums stay ``<= max_tokens_per_bin``; an oversized sample lands alone."""
     bins: list[list[int]] = []
     bin_sums: list[int] = []
     for idx, length in enumerate(total_lengths):
@@ -199,13 +195,8 @@ def first_fit_pack(total_lengths, max_tokens_per_bin):
 
 
 def _split_bin_by_tokens(bin_indices: list[int], lengths) -> list[list[int]]:
-    """Split a bin's indices into two halves balanced by total tokens (LPT heuristic).
-
-    Returns ``[left, right]`` where both lists together cover ``bin_indices``. Because
-    each half is a strict subset of ``bin_indices``, both have token sums ``<=`` the
-    original bin's sum — useful when you need to grow a bin packing without ever
-    creating a bin larger than the originals.
-    """
+    """Split a bin into two token-balanced halves (LPT); each half's sum is
+    ``<=`` the parent's, so splitting never exceeds the original cap."""
     halves: list[list[int]] = [[], []]
     sums = [0, 0]
     for idx in sorted(bin_indices, key=lambda i: -lengths[i]):
@@ -216,9 +207,8 @@ def _split_bin_by_tokens(bin_indices: list[int], lengths) -> list[list[int]]:
 
 
 def expand_bins_by_splitting(bins: list[list[int]], target_count: int, lengths) -> None:
-    """Grow ``bins`` in place to ``target_count`` by repeatedly splitting the largest
-    multi-sample bin via :func:`_split_bin_by_tokens`. Stops early if every remaining
-    bin is a singleton (no bin can be split further)."""
+    """Grow ``bins`` in place to ``target_count`` by splitting the largest
+    multi-sample bin; stops early once every bin is a singleton."""
     while len(bins) < target_count:
         candidates = [(sum(lengths[i] for i in b), idx) for idx, b in enumerate(bins) if len(b) > 1]
         if not candidates:

--- a/tests/fast/ray/rollout/test_train_data_conversion.py
+++ b/tests/fast/ray/rollout/test_train_data_conversion.py
@@ -11,9 +11,11 @@ from tests.fast.ray.rollout.conftest import make_args, make_sample, make_samples
 
 from miles.ray.rollout.train_data_conversion import (
     _post_process_rewards,
+    can_schedule_on_rollout_side,
     convert_samples_to_train_data,
     split_train_data_by_dp,
     split_train_data_by_dp_raw,
+    split_train_data_by_dp_scheduled_raw,
 )
 from miles.utils import object_store
 from miles.utils.types import Sample
@@ -545,3 +547,109 @@ class TestSplitTrainDataRaw:
 
         result = split_train_data_by_dp_raw(args, data, dp_size=1)
         assert "seq_witness_ids" not in result[0]
+
+
+FULL_SCHEDULE_CONFIG = {
+    "dp_size": 2,
+    "cp_size": 1,
+    "vpp_size": 1,
+    "microbatch_group_size_per_vp_stage": None,
+}
+
+
+def _make_split_data(n: int, *, lengths: list[int] | None = None) -> dict:
+    lengths = lengths or [2] * n
+    assert len(lengths) == n
+    return {
+        "tokens": [list(range(length)) for length in lengths],
+        "response_lengths": [1] * n,
+        "rewards": [0.0] * n,
+        "truncated": [0] * n,
+        "loss_masks": [[1] * length for length in lengths],
+        "sample_indices": list(range(n)),
+    }
+
+
+class TestCanScheduleOnRolloutSide:
+    def test_eligible_with_full_megatron_config(self):
+        args = make_args(balance_data=False, micro_batch_size=1, use_dynamic_batch_size=False, multi_lora=False)
+        assert can_schedule_on_rollout_side(args, _make_split_data(8), FULL_SCHEDULE_CONFIG)
+
+    def test_rejects_partial_config(self):
+        """fsdp / torchtitan advertise only dp_size; indep_dp advertises {}."""
+        args = make_args(balance_data=False, micro_batch_size=1, multi_lora=False)
+        assert not can_schedule_on_rollout_side(args, _make_split_data(8), {"dp_size": 2})
+        assert not can_schedule_on_rollout_side(args, _make_split_data(8), {})
+        assert not can_schedule_on_rollout_side(args, _make_split_data(8), None)
+
+    def test_rejects_multi_lora(self):
+        args = make_args(balance_data=False, micro_batch_size=1, multi_lora=True)
+        assert not can_schedule_on_rollout_side(args, _make_split_data(8), FULL_SCHEDULE_CONFIG)
+
+    def test_rejects_multimodal(self):
+        args = make_args(balance_data=False, micro_batch_size=1, multi_lora=False)
+        data = _make_split_data(8)
+        data["multimodal_train_inputs"] = [None] * 8
+        assert not can_schedule_on_rollout_side(args, data, FULL_SCHEDULE_CONFIG)
+
+    def test_rejects_indivisible_sample_count(self):
+        args = make_args(balance_data=False, micro_batch_size=1, multi_lora=False)  # global_batch_size=8
+        assert not can_schedule_on_rollout_side(args, _make_split_data(10), FULL_SCHEDULE_CONFIG)
+
+    def test_dynamic_gbs_overrides_args_gbs(self):
+        args = make_args(balance_data=False, micro_batch_size=1, multi_lora=False)  # global_batch_size=8
+        data = _make_split_data(6)
+        data["dynamic_global_batch_size"] = 6
+        assert can_schedule_on_rollout_side(args, data, FULL_SCHEDULE_CONFIG)
+
+
+class TestSplitTrainDataByDpScheduled:
+    def test_static_shards_match_legacy_split_plus_schedule(self):
+        """Static path: shards must be identical to the legacy split, plus the two
+        schedule keys, and the schedule must tile each shard's rows exactly."""
+        args = make_args(balance_data=False, micro_batch_size=2, use_dynamic_batch_size=False)
+        data = _make_split_data(8)
+        legacy = split_train_data_by_dp_raw(args, dict(data), dp_size=2)
+        scheduled = split_train_data_by_dp_scheduled_raw(
+            args, dict(data), train_parallel_config=FULL_SCHEDULE_CONFIG
+        )
+
+        assert len(scheduled) == 2
+        for rank, (old, new) in enumerate(zip(legacy, scheduled, strict=True)):
+            assert list(new["partition"]) == list(old["partition"]), f"rank {rank} partition changed"
+            for key in ("tokens", "response_lengths", "loss_masks", "sample_indices"):
+                assert new[key] == old[key], f"rank {rank} {key} changed"
+            # global_batch_size=8, dp=2, mbs=2 -> 2 mbs per rank, 1 step
+            assert new["num_microbatches"] == [2]
+            flat = [i for mbs in new["micro_batch_indices"] for i in mbs]
+            assert flat == list(range(len(new["tokens"])))
+
+    def test_dynamic_schedule_respects_token_cap(self):
+        args = make_args(
+            balance_data=False,
+            micro_batch_size=1,
+            use_dynamic_batch_size=True,
+            max_tokens_per_gpu=6,
+        )
+        lengths = [5, 1, 4, 2, 3, 3, 2, 4]
+        data = _make_split_data(8, lengths=lengths)
+        shards = split_train_data_by_dp_scheduled_raw(args, data, train_parallel_config=FULL_SCHEDULE_CONFIG)
+
+        nmb = shards[0]["num_microbatches"]
+        for shard in shards:
+            assert shard["num_microbatches"] == nmb, "num_microbatches must be identical on every rank"
+            assert len(shard["micro_batch_indices"]) == sum(nmb)
+            partition = list(shard["partition"])
+            for mbs in shard["micro_batch_indices"]:
+                total = sum(lengths[partition[i]] for i in mbs)
+                assert total <= 6 or len(mbs) == 1
+
+    def test_dynamic_gbs_multi_step(self):
+        """16 samples with dynamic_global_batch_size=8 -> 2 steps."""
+        args = make_args(balance_data=False, micro_batch_size=2, use_dynamic_batch_size=False)
+        data = _make_split_data(16)
+        data["dynamic_global_batch_size"] = 8
+        shards = split_train_data_by_dp_scheduled_raw(args, data, train_parallel_config=FULL_SCHEDULE_CONFIG)
+
+        assert shards[0]["num_microbatches"] == [2, 2]
+        assert shards[0]["dynamic_global_batch_size"] == 8

--- a/tests/fast/ray/rollout/test_train_data_conversion.py
+++ b/tests/fast/ray/rollout/test_train_data_conversion.py
@@ -610,9 +610,7 @@ class TestSplitTrainDataByDpScheduled:
         args = make_args(balance_data=False, micro_batch_size=2, use_dynamic_batch_size=False)
         data = _make_split_data(8)
         legacy = split_train_data_by_dp_raw(args, dict(data), dp_size=2)
-        scheduled = split_train_data_by_dp_scheduled_raw(
-            args, dict(data), train_parallel_config=FULL_SCHEDULE_CONFIG
-        )
+        scheduled = split_train_data_by_dp_scheduled_raw(args, dict(data), train_parallel_config=FULL_SCHEDULE_CONFIG)
 
         assert len(scheduled) == 2
         for rank, (old, new) in enumerate(zip(legacy, scheduled, strict=True)):

--- a/tests/fast/utils/test_dp_schedule.py
+++ b/tests/fast/utils/test_dp_schedule.py
@@ -1,0 +1,260 @@
+"""CPU unit tests for miles.utils.dp_schedule.build_dp_schedule.
+
+The tests assert the invariants documented at the top of dp_schedule.py against
+a range of static / dynamic / VPP / oversize / balance scenarios, plus an
+equivalence check of ``num_microbatches`` against the legacy train-side
+computation (``get_minimum_num_micro_batch_size`` + DP-wide MAX) that this
+schedule replaces.
+
+Trim, dynamic-gbs resolution, and per-rank rollout_data packaging all live in
+``train_data_conversion.split_train_data_by_dp_scheduled``; these tests just
+exercise the schedule itself (``partitions`` and ``micro_batch_indices``).
+"""
+
+from __future__ import annotations
+
+import random
+from types import SimpleNamespace
+
+import pytest
+
+from miles.utils.data import get_minimum_num_micro_batch_size
+from miles.utils.dp_schedule import build_dp_schedule, has_full_schedule_config
+
+
+def make_args(
+    *,
+    micro_batch_size=1,
+    use_dynamic_batch_size=False,
+    max_tokens_per_gpu=None,
+    balance_data=False,
+):
+    return SimpleNamespace(
+        micro_batch_size=micro_batch_size,
+        use_dynamic_batch_size=use_dynamic_batch_size,
+        max_tokens_per_gpu=max_tokens_per_gpu,
+        balance_data=balance_data,
+    )
+
+
+def make_tp(dp_size=1, cp_size=1, vpp_size=1, microbatch_group_size_per_vp_stage=None):
+    return {
+        "dp_size": dp_size,
+        "cp_size": cp_size,
+        "vpp_size": vpp_size,
+        "microbatch_group_size_per_vp_stage": microbatch_group_size_per_vp_stage,
+    }
+
+
+def assert_invariants(partitions, micro_batch_indices, num_microbatches, *, dp_size, total_lengths, max_per_bin=None):
+    """Check the invariants documented at the top of dp_schedule.py."""
+    expected_per_rank = len(total_lengths) // dp_size
+    seen_global: set[int] = set()
+    for r in range(dp_size):
+        partition = partitions[r]
+        mbi = micro_batch_indices[r]
+
+        # Same sample count per rank.
+        assert len(partition) == expected_per_rank, f"rank {r}: {len(partition)} samples, want {expected_per_rank}"
+
+        # Same num_mbs per rank (PP sync); num_microbatches is shared, so each rank's
+        # flat mbs count must match sum(num_microbatches).
+        assert len(mbi) == sum(num_microbatches), f"rank {r}: mbs count mismatch"
+
+        # Flattened micro_batch_indices == range(len(partition)) (each sample covered
+        # exactly once, by exactly one mbs).
+        flat = [i for mbs in mbi for i in mbs]
+        assert flat == list(range(len(partition))), f"rank {r}: micro_batch_indices don't tile [0, n)"
+
+        # Disjoint partitions whose union covers every sample.
+        assert seen_global.isdisjoint(partition), f"rank {r}: overlap with other ranks"
+        seen_global.update(partition)
+    assert seen_global == set(range(len(total_lengths))), "some samples not assigned to any rank"
+
+    if max_per_bin is None:
+        return
+
+    # Every mbs <= max_per_bin tokens, EXCEPT a singleton bin holding an oversized sample.
+    for r in range(dp_size):
+        partition = partitions[r]
+        for mbs in micro_batch_indices[r]:
+            bin_total = sum(total_lengths[partition[i]] for i in mbs)
+            if bin_total > max_per_bin:
+                assert len(mbs) == 1, f"rank {r}: mbs sum {bin_total} > {max_per_bin} but contains {len(mbs)} samples"
+
+
+def test_static_stride_single_step():
+    """Static + strided DP split, single step."""
+    total_lengths = [10] * 16
+    args = make_args(micro_batch_size=2)
+    tp = make_tp(dp_size=4)
+
+    partitions, mbi, nmb = build_dp_schedule(args, tp, total_lengths, global_batch_size=16)
+
+    assert nmb == [2]
+    assert_invariants(partitions, mbi, nmb, dp_size=4, total_lengths=total_lengths)
+
+
+def test_static_stride_matches_legacy_partition_order():
+    """Static + strided must produce exactly the legacy strided row order —
+    rank r gets rows [r, r+dp, r+2*dp, ...] in that order, contiguously chunked."""
+    total_lengths = list(range(100, 116))
+    args = make_args(micro_batch_size=2)
+    tp = make_tp(dp_size=4)
+
+    partitions, _, _ = build_dp_schedule(args, tp, total_lengths, global_batch_size=16)
+
+    for r in range(4):
+        assert partitions[r] == list(range(r, 16, 4)), f"rank {r} partition deviates from legacy strided order"
+
+
+def test_static_balance_multi_step():
+    """Static + balance_data + 2 training steps. Each rank must get gbs/dp per step."""
+    total_lengths = [1, 2, 3, 4, 5, 6, 7, 8, 8, 7, 6, 5, 4, 3, 2, 1]  # 2 steps of 8
+    args = make_args(micro_batch_size=2, balance_data=True)
+    tp = make_tp(dp_size=2)
+
+    partitions, mbi, nmb = build_dp_schedule(args, tp, total_lengths, global_batch_size=8)
+
+    assert nmb == [2, 2]
+    assert_invariants(partitions, mbi, nmb, dp_size=2, total_lengths=total_lengths)
+
+
+def test_dynamic_uniform():
+    """Dynamic mbs on uniform-length samples."""
+    total_lengths = [5] * 8
+    args = make_args(use_dynamic_batch_size=True, max_tokens_per_gpu=10)
+    tp = make_tp(dp_size=2)
+
+    partitions, mbi, nmb = build_dp_schedule(args, tp, total_lengths, global_batch_size=8)
+
+    assert_invariants(partitions, mbi, nmb, dp_size=2, total_lengths=total_lengths, max_per_bin=10)
+
+
+def test_dynamic_skewed_lengths():
+    """Skewed lengths (the case where K-K used to over-pack a single bin)."""
+    total_lengths = [9, 9, 9, 9, 1, 1, 1, 1]
+    args = make_args(use_dynamic_batch_size=True, max_tokens_per_gpu=10)
+    tp = make_tp(dp_size=2)
+
+    partitions, mbi, nmb = build_dp_schedule(args, tp, total_lengths, global_batch_size=8)
+
+    assert_invariants(partitions, mbi, nmb, dp_size=2, total_lengths=total_lengths, max_per_bin=10)
+
+
+def test_dynamic_oversized_sample_lands_alone():
+    """A single sample exceeding max_per_bin must end up alone in its mbs (with no
+    other samples crammed in)."""
+    total_lengths = [15, 3, 3, 3, 3, 3, 3, 3]  # 15 > C=10
+    args = make_args(use_dynamic_batch_size=True, max_tokens_per_gpu=10)
+    tp = make_tp(dp_size=2)
+
+    partitions, mbi, nmb = build_dp_schedule(args, tp, total_lengths, global_batch_size=8)
+
+    assert_invariants(partitions, mbi, nmb, dp_size=2, total_lengths=total_lengths, max_per_bin=10)
+    # Find the rank holding the oversized sample and verify it lives alone in some mbs.
+    oversize_idx = total_lengths.index(15)
+    found = False
+    for r in range(2):
+        partition = partitions[r]
+        if oversize_idx not in partition:
+            continue
+        local = partition.index(oversize_idx)
+        for mbs in mbi[r]:
+            if local in mbs:
+                assert mbs == [local], f"oversized sample shares an mbs: {mbs}"
+                found = True
+    assert found
+
+
+def test_dynamic_with_vpp_rounds_to_mb_group():
+    """num_microbatches per rank should be a multiple of mb_group when vpp_size > 1."""
+    total_lengths = [4] * 32  # 2 steps of 16; per step, ~8 bins of 8 needed at C=8
+    args = make_args(use_dynamic_batch_size=True, max_tokens_per_gpu=8)
+    tp = make_tp(dp_size=2, vpp_size=2, microbatch_group_size_per_vp_stage=2)
+
+    partitions, mbi, nmb = build_dp_schedule(args, tp, total_lengths, global_batch_size=16)
+
+    for n in nmb:
+        assert n % 2 == 0, f"num_microbatches {n} is not a multiple of mb_group=2"
+    assert_invariants(partitions, mbi, nmb, dp_size=2, total_lengths=total_lengths, max_per_bin=8)
+
+
+def test_static_indivisible_per_rank_batch_asserts():
+    """gbs/dp not a multiple of micro_batch_size must fail loudly, not mis-schedule."""
+    args = make_args(micro_batch_size=3)
+    tp = make_tp(dp_size=2)
+    with pytest.raises(AssertionError, match="micro_batch_size"):
+        build_dp_schedule(args, tp, [10] * 8, global_batch_size=8)
+
+
+def test_untrimmed_input_asserts():
+    """num_samples not a multiple of global_batch_size must fail loudly."""
+    args = make_args(micro_batch_size=1)
+    tp = make_tp(dp_size=2)
+    with pytest.raises(AssertionError, match="multiple of global_batch_size"):
+        build_dp_schedule(args, tp, [10] * 10, global_batch_size=8)
+
+
+def test_dynamic_num_microbatches_matches_legacy_train_side():
+    """The PP-sync-critical value: for the same strided partition, the rollout-side
+    schedule must produce exactly the num_microbatches the legacy train-side path
+    computed (per-rank ``get_minimum_num_micro_batch_size``, then DP-wide MAX)."""
+    rng = random.Random(42)
+    dp_size, cp_size = 4, 2
+    max_tokens_per_gpu = 512
+    global_batch_size = 32
+
+    for _ in range(50):
+        num_steps = rng.randint(1, 3)
+        total_lengths = [rng.randint(16, 1200) for _ in range(global_batch_size * num_steps)]
+
+        args = make_args(use_dynamic_batch_size=True, max_tokens_per_gpu=max_tokens_per_gpu)
+        tp = make_tp(dp_size=dp_size, cp_size=cp_size)
+        _, _, nmb = build_dp_schedule(args, tp, total_lengths, global_batch_size=global_batch_size)
+
+        # Legacy: each rank r holds the strided rows of each step, computes its own
+        # first-fit bin count over its local per-step slice, and the DP group takes MAX.
+        num_local_gbs = global_batch_size // dp_size
+        legacy_nmb = []
+        for step_i in range(num_steps):
+            step = total_lengths[step_i * global_batch_size : (step_i + 1) * global_batch_size]
+            per_rank = []
+            for r in range(dp_size):
+                local = [step[i] for i in range(r, global_batch_size, dp_size)]
+                assert len(local) == num_local_gbs
+                per_rank.append(get_minimum_num_micro_batch_size(local, max_tokens_per_gpu * cp_size))
+            legacy_nmb.append(max(per_rank))
+
+        assert nmb == legacy_nmb, f"num_microbatches diverged from legacy: {nmb} vs {legacy_nmb}"
+
+
+def test_randomized_invariants_dynamic():
+    """Randomized sweep of the documented invariants on the dynamic path."""
+    rng = random.Random(7)
+    for _ in range(30):
+        dp_size = rng.choice([1, 2, 4])
+        gbs = dp_size * rng.choice([2, 4, 8])
+        num_steps = rng.randint(1, 2)
+        total_lengths = [rng.randint(1, 40) for _ in range(gbs * num_steps)]
+        max_tokens = rng.randint(20, 60)
+        balance = rng.random() < 0.5
+
+        args = make_args(use_dynamic_batch_size=True, max_tokens_per_gpu=max_tokens, balance_data=balance)
+        tp = make_tp(dp_size=dp_size)
+        partitions, mbi, nmb = build_dp_schedule(args, tp, total_lengths, global_batch_size=gbs)
+
+        assert_invariants(
+            partitions, mbi, nmb, dp_size=dp_size, total_lengths=total_lengths, max_per_bin=max_tokens
+        )
+
+
+def test_has_full_schedule_config():
+    assert has_full_schedule_config(make_tp())
+    assert not has_full_schedule_config({})
+    assert not has_full_schedule_config(None)
+    assert not has_full_schedule_config({"dp_size": 4})  # fsdp/torchtitan shape
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__]))

--- a/tests/fast/utils/test_dp_schedule.py
+++ b/tests/fast/utils/test_dp_schedule.py
@@ -244,9 +244,7 @@ def test_randomized_invariants_dynamic():
         tp = make_tp(dp_size=dp_size)
         partitions, mbi, nmb = build_dp_schedule(args, tp, total_lengths, global_batch_size=gbs)
 
-        assert_invariants(
-            partitions, mbi, nmb, dp_size=dp_size, total_lengths=total_lengths, max_per_bin=max_tokens
-        )
+        assert_invariants(partitions, mbi, nmb, dp_size=dp_size, total_lengths=total_lengths, max_per_bin=max_tokens)
 
 
 def test_has_full_schedule_config():

--- a/tests/fast/utils/test_dp_schedule.py
+++ b/tests/fast/utils/test_dp_schedule.py
@@ -180,6 +180,46 @@ def test_dynamic_with_vpp_rounds_to_mb_group():
     assert_invariants(partitions, mbi, nmb, dp_size=2, total_lengths=total_lengths, max_per_bin=8)
 
 
+def test_dynamic_vpp_round_down_repacks_to_num_microbatches():
+    """When VPP rounding lowers the mbs target below a rank's first-fit bin count,
+    that rank must be re-packed into exactly num_microbatches bins (the legacy
+    behavior), not left holding extra bins that training would never consume.
+
+    No max_per_bin here: rounding down below the cap-minimal bin count makes the
+    token cap unsatisfiable, so merged bins may exceed it (same as legacy)."""
+    total_lengths = [9, 1, 9, 1, 9, 1, 1, 1]  # rank0 (strided) = [9,9,9,1] -> 3 first-fit bins at cap 10
+    args = make_args(use_dynamic_batch_size=True, max_tokens_per_gpu=10)
+    tp = make_tp(dp_size=2, vpp_size=2, microbatch_group_size_per_vp_stage=2)
+
+    partitions, mbi, nmb = build_dp_schedule(args, tp, total_lengths, global_batch_size=8)
+
+    assert nmb == [2]
+    assert_invariants(partitions, mbi, nmb, dp_size=2, total_lengths=total_lengths)
+
+
+def test_randomized_invariants_dynamic_vpp():
+    """Randomized sweep of the dynamic path with vpp_size > 1: every rank must end
+    with exactly sum(num_microbatches) bins even when mb_group rounding lowers the
+    target (token cap intentionally unchecked, see the regression test above)."""
+    rng = random.Random(11)
+    for _ in range(30):
+        dp_size = rng.choice([1, 2, 4])
+        gbs = dp_size * rng.choice([2, 4, 8])
+        num_steps = rng.randint(1, 2)
+        total_lengths = [rng.randint(1, 40) for _ in range(gbs * num_steps)]
+        max_tokens = rng.randint(20, 60)
+        mb_group = rng.choice([2, 3, 4])
+        balance = rng.random() < 0.5
+
+        args = make_args(use_dynamic_batch_size=True, max_tokens_per_gpu=max_tokens, balance_data=balance)
+        tp = make_tp(dp_size=dp_size, vpp_size=2, microbatch_group_size_per_vp_stage=mb_group)
+        partitions, mbi, nmb = build_dp_schedule(args, tp, total_lengths, global_batch_size=gbs)
+
+        assert_invariants(partitions, mbi, nmb, dp_size=dp_size, total_lengths=total_lengths)
+        for n in nmb:
+            assert n % mb_group == 0 or n == 1, f"num_microbatches {n} not aligned to mb_group={mb_group}"
+
+
 def test_static_indivisible_per_rank_batch_asserts():
     """gbs/dp not a multiple of micro_batch_size must fail loudly, not mis-schedule."""
     args = make_args(micro_batch_size=3)


### PR DESCRIPTION
> **Depends on:** #1927
> Stacked on the parent PR's branch. Review / merge the parent first.

## Summary
Fix silent sample drop when VPP rounding lowers the mbs target below a rank's first-fit bin count.

## Symptom & Reproduction
- **Symptom:** with `use_dynamic_batch_size` + `vpp_size > 1`, part of a rank's samples silently never reach the loss.
- **Symptom:** in multi-step rollouts, later steps additionally consume shifted micro-batches built from the leftover bins.
- **Reproduction:** `pytest tests/fast/utils/test_dp_schedule.py::test_dynamic_vpp_round_down_repacks_to_num_microbatches` — fails on the parent head (`37de7813d`): lengths `[9,1,9,1,9,1,1,1]`, `dp=2`, cap 10, `mb_group=2` give rank 0 three first-fit bins while `num_microbatches=[2]`.

## Root Cause
1. `build_dp_schedule` rounds `num_mbs_per_rank` down to a `mb_group` multiple when `vpp_size > 1`.
2. `first_fit_pack` already gave the MAX rank more bins than the rounded target.
3. `expand_bins_by_splitting` only grows a bin list; nothing merges one.
4. That rank emits more `micro_batch_indices` entries than `sum(num_microbatches)`.
5. The train loop consumes `num_microbatches[step]` bins per step, orphaning the rest.

## Fix
When a rank's first-fit bin count exceeds the rounded target, re-pack that rank into exactly `num_mbs_per_rank` token-balanced bins via `get_seqlen_balanced_partitions(equal_size=False)` — exactly what the legacy train-side path did after the same rounding, so this restores legacy semantics rather than patching around them. Other ranks keep the first-fit + split membership introduced by #1927. A per-rank bin-count assert now enforces the invariant at schedule time. `num_microbatches` values are unchanged, so the legacy-equivalence sweep still holds. Re-packed bins exceed `max_tokens_per_gpu * cp_size` when the rounded target is below the cap-minimal bin count; legacy accepted the same overflow after rounding.

## Verification
- **New / updated test:** `test_dynamic_vpp_round_down_repacks_to_num_microbatches` asserts the repro schedule ends with exactly `sum(num_microbatches)` bins per rank.
- **New / updated test:** `test_randomized_invariants_dynamic_vpp` sweeps 30 random `vpp_size=2` schedules against the documented schedule invariants.
- `tests/fast/utils/test_dp_schedule.py` (14 passed) and `tests/fast/ray/rollout/test_train_data_conversion.py` (38 passed).

## Review Focus
- Scrutinize the token-cap trade-off in `build_dp_schedule`: verify that accepting over-cap merged bins (legacy parity) is preferable to rounding up, which would diverge `num_microbatches` from legacy.
