### PR TITLE
Fix Restore Frozen Weights

### DIFF
--- a/miles/backends/sglang_utils/sglang_config.py
+++ b/miles/backends/sglang_utils/sglang_config.py
@@ -58,9 +58,7 @@ class ModelConfig:
                         pushed by training) is only valid for updatable models.
                         Frozen colocated models must pick ``cpu`` (host RAM
                         backup), ``disk`` (process-local backup), or ``reload``
-                        (re-read ``model_path``).  Required — there is no safe
-                        default, since each option trades host RAM against
-                        per-rollout restore latency.
+                        (re-read ``model_path``).
     """
 
     name: str
@@ -182,6 +180,7 @@ class SglangConfig:
                     num_gpus_per_engine=m.get("num_gpus_per_engine"),
                     server_groups=groups,
                     update_weights=m.get("update_weights"),
+                    weights_backup_mode=m.get("weights_backup_mode"),
                 )
             )
         return SglangConfig(models=models)

--- a/miles/backends/sglang_utils/sglang_config.py
+++ b/miles/backends/sglang_utils/sglang_config.py
@@ -35,7 +35,7 @@ class ServerGroupConfig:
         ), f"Invalid worker_type '{self.worker_type}', must be one of {valid_types}"
         assert self.num_gpus > 0, f"num_gpus must be > 0, got {self.num_gpus}"
 
-WEIGHTS_BACKUP_MODES = ("actor_sync", "cpu", "disk", "reload")
+WEIGHTS_BACKUP_MODES = ("actor_sync", "cpu", "reload")
 
 @dataclasses.dataclass
 class ModelConfig:
@@ -57,7 +57,7 @@ class ModelConfig:
                         colocated offload/onload cycle.  ``actor_sync`` (weights
                         pushed by training) is only valid for updatable models.
                         Frozen colocated models must pick ``cpu`` (host RAM
-                        backup), ``disk`` (process-local backup), or ``reload``
+                        backup), or ``reload``
                         (re-read ``model_path``).
     """
 

--- a/miles/backends/sglang_utils/sglang_config.py
+++ b/miles/backends/sglang_utils/sglang_config.py
@@ -35,6 +35,7 @@ class ServerGroupConfig:
         ), f"Invalid worker_type '{self.worker_type}', must be one of {valid_types}"
         assert self.num_gpus > 0, f"num_gpus must be > 0, got {self.num_gpus}"
 
+WEIGHTS_BACKUP_MODES = ("actor_sync", "cpu", "disk", "reload")
 
 @dataclasses.dataclass
 class ModelConfig:
@@ -52,6 +53,14 @@ class ModelConfig:
                         automatically inferred in ``resolve()``: ``True`` if
                         model_path matches ``args.hf_checkpoint``, ``False``
                         otherwise.
+        weights_backup_mode: How this model's weights are restored after a
+                        colocated offload/onload cycle.  ``actor_sync`` (weights
+                        pushed by training) is only valid for updatable models.
+                        Frozen colocated models must pick ``cpu`` (host RAM
+                        backup), ``disk`` (process-local backup), or ``reload``
+                        (re-read ``model_path``).  Required — there is no safe
+                        default, since each option trades host RAM against
+                        per-rollout restore latency.
     """
 
     name: str
@@ -59,6 +68,7 @@ class ModelConfig:
     num_gpus_per_engine: int | None = None
     server_groups: list[ServerGroupConfig] = dataclasses.field(default_factory=list)
     update_weights: bool | None = None
+    weights_backup_mode: str | None = None
 
     def resolve(self, args) -> None:
         """Resolve per-group defaults from model-level then args-level values."""
@@ -90,6 +100,16 @@ class ModelConfig:
                 self.update_weights = False
             else:
                 self.update_weights = True
+        if self.weights_backup_mode is not None and self.weights_backup_mode not in WEIGHTS_BACKUP_MODES:
+            raise ValueError(
+                f"Model '{self.name}': invalid weights_backup_mode="
+                f"{self.weights_backup_mode!r}; expected one of {WEIGHTS_BACKUP_MODES}."
+            )
+        if self.update_weights and self.weights_backup_mode not in (None, "actor_sync"):
+            raise ValueError(
+                f"Model '{self.name}': weights_backup_mode={self.weights_backup_mode!r} conflicts with "
+                f"update_weights=True; updatable models are restored by actor weight sync."
+            )
 
     @property
     def has_pd_disaggregation(self) -> bool:

--- a/miles/ray/rollout/rollout_server.py
+++ b/miles/ray/rollout/rollout_server.py
@@ -125,7 +125,7 @@ def _resolve_weights_backup_mode(*, model_cfg, needs_offload: bool, group_worker
             f"(needs_offload=True) but has no weight restoration source: its weights are released for the "
             f"Megatron step and it does not receive actor weight sync, so it would serve uninitialized "
             f"weights after resume. Set weights_backup_mode to one of 'cpu' (host RAM copy), "
-            f"'disk' (process-local backup), or 'reload' (re-read model_path)."
+            f"or 'reload' (re-read model_path)."
         )
     return mode
 

--- a/miles/ray/rollout/rollout_server.py
+++ b/miles/ray/rollout/rollout_server.py
@@ -53,9 +53,16 @@ def start_rollout_servers(args, pg) -> dict[str, "RolloutServer"]:
             overrides = dict(group_cfg.overrides)
             if args.offload_rollout and not needs_offload:
                 overrides.setdefault("enable_memory_saver", False)
+
+            weights_backup_mode = _resolve_weights_backup_mode(
+                model_cfg=model_cfg, needs_offload=needs_offload, group_worker_type=group_cfg.worker_type
+            )
+            if weights_backup_mode == "cpu":
+                overrides.setdefault("enable_weights_cpu_backup", True)
             logger.info(
                 f"Engine group '{group_cfg.worker_type}' gpu_offset={gpu_offset} "
-                f"(abs={group_abs_start}): needs_offload={needs_offload}"
+                f"(abs={group_abs_start}): needs_offload={needs_offload} "
+                f"update_weights={model_cfg.update_weights} weights_backup_mode={weights_backup_mode}"
             )
 
             group = ServerGroup(
@@ -75,6 +82,7 @@ def start_rollout_servers(args, pg) -> dict[str, "RolloutServer"]:
                 router_ip=router_ip,
                 router_port=router_port,
                 update_weights=model_cfg.update_weights,
+                weights_backup_mode=weights_backup_mode,
             )
             handles, new_engine_indices = group.start_engines(port_cursors)
             all_init_handles.extend(handles)
@@ -102,6 +110,24 @@ def start_rollout_servers(args, pg) -> dict[str, "RolloutServer"]:
 
     return servers
 
+def _resolve_weights_backup_mode(*, model_cfg, needs_offload: bool, group_worker_type: str) -> str:
+    """Pick how a group's weights come back after offload, failing closed if nothing can.
+    """
+    if model_cfg.update_weights:
+        return "actor_sync"
+    if not needs_offload:
+        return "actor_sync"
+
+    mode = model_cfg.weights_backup_mode
+    if mode is None or mode == "actor_sync":
+        raise ValueError(
+            f"Frozen model '{model_cfg.name}' (group '{group_worker_type}') is colocated with training "
+            f"(needs_offload=True) but has no weight restoration source: its weights are released for the "
+            f"Megatron step and it does not receive actor weight sync, so it would serve uninitialized "
+            f"weights after resume. Set weights_backup_mode to one of 'cpu' (host RAM copy), "
+            f"'disk' (process-local backup), or 'reload' (re-read model_path)."
+        )
+    return mode
 
 def _eval_sglang_overrides(args) -> dict:
     """Eval-fleet engine settings; anything absent is inherited from the rollout engines."""
@@ -272,10 +298,7 @@ class RolloutServer:
         return await asyncio.gather(*handles)
 
     async def onload(self, tags: list[str] | None = None):
-        handles = []
-        for g in self.server_groups:
-            handles.extend(g.onload(tags))
-        return await asyncio.gather(*handles)
+        return await asyncio.gather(*[g.onload(tags) for g in self.server_groups])
 
     async def check_weights(
         self, action: str, allow_quant_error: bool = False, selector: str = "all", skip_list: list[str] | None = None

--- a/miles/ray/rollout/server_group.py
+++ b/miles/ray/rollout/server_group.py
@@ -45,6 +45,8 @@ class ServerGroup:
     router_ip: str | None = None
     router_port: int | None = None
     update_weights: bool = True
+    # NOTE: Only consulted when `needs_offload` is True; otherwise weights are never released.
+    weights_backup_mode: str = "actor_sync"
 
     @property
     def nodes_per_engine(self):
@@ -225,6 +227,9 @@ class ServerGroup:
                         for engine in all_resume_engines
                     ]
                 )
+                await self._restore_weights_if_owned(
+                    tags=[GPU_MEMORY_TYPE_WEIGHTS], engines=all_resume_engines
+                )
 
         self.mark_alive(engine_indices=new_engine_indices)
 
@@ -241,22 +246,46 @@ class ServerGroup:
             if engine.is_allocated
         ]
 
-    def onload(self, tags: list[str] | None = None):
-        if not self.needs_offload:
-            return []
-        return [
-            engine.actor_handle.resume_memory_occupation.remote(tags=tags)
-            for engine in self.engines
-            if engine.is_allocated
-        ]
+    async def onload(self, tags: list[str] | None = None):
+        """Resume memory occupation, then restore weight *content* if this group owns that.
 
-    def onload_weights_from_disk(self):
+        `resume_memory_occupation` only hands back the allocation. For `cpu`/`disk` modes
+        torch_memory_saver refills it transparently; for `actor_sync` the caller's weight
+        sync refills it; for `reload` this group must re-read `model_path` itself.
+        """
+        if not self.needs_offload:
+            return
+        await asyncio.gather(
+            *[
+                engine.actor_handle.resume_memory_occupation.remote(tags=tags)
+                for engine in self.engines
+                if engine.is_allocated
+            ]
+        )
+        await self._restore_weights_if_owned(tags=tags)
+
+    def _owns_weight_restore(self, tags: list[str] | None) -> bool:
+        """True when this group must reload weights itself for the given tags."""
+        if self.weights_backup_mode != "reload":
+            return False
+        return tags is None or GPU_MEMORY_TYPE_WEIGHTS in tags
+
+    async def _restore_weights_if_owned(
+        self, tags: list[str] | None, engines: list[ServerEngine] | None = None
+    ) -> None:
+        if not self._owns_weight_restore(tags):
+            return
+        logger.info(f"Reloading weights from disk for frozen group '{self.worker_type}' ({self.model_path})")
+        await asyncio.gather(*self.onload_weights_from_disk(engines=engines))
+
+
+    def onload_weights_from_disk(self, engines: list[ServerEngine] | None = None) -> list:
         """Reload weights from ``model_path`` for non-updatable groups."""
         if not self.needs_offload or not self.model_path:
             return []
         return [
             engine.actor_handle.update_weights_from_disk.remote(self.model_path)
-            for engine in self.engines
+            for engine in (engines if engines is not None else self.engines)
             if engine.is_allocated
         ]
 

--- a/miles/ray/rollout/server_group.py
+++ b/miles/ray/rollout/server_group.py
@@ -249,7 +249,7 @@ class ServerGroup:
     async def onload(self, tags: list[str] | None = None):
         """Resume memory occupation, then restore weight *content* if this group owns that.
 
-        `resume_memory_occupation` only hands back the allocation. For `cpu`/`disk` modes
+        `resume_memory_occupation` only hands back the allocation. For `cpu` modes
         torch_memory_saver refills it transparently; for `actor_sync` the caller's weight
         sync refills it; for `reload` this group must re-read `model_path` itself.
         """
@@ -275,7 +275,7 @@ class ServerGroup:
     ) -> None:
         if not self._owns_weight_restore(tags):
             return
-        logger.info(f"Reloading weights from disk for frozen group '{self.worker_type}' ({self.model_path})")
+        logger.info(f"Reloading weights for frozen group '{self.worker_type}' ({self.model_path})")
         await asyncio.gather(*self.onload_weights_from_disk(engines=engines))
 
 

--- a/tests/fast/ray/rollout/test_config_matrix.py
+++ b/tests/fast/ray/rollout/test_config_matrix.py
@@ -6,7 +6,7 @@ import pytest
 from tests.fast.ray.rollout.conftest import make_args, make_sglang_config_yaml
 
 from miles.backends.sglang_utils.sglang_config import ModelConfig, ServerGroupConfig, SglangConfig
-from miles.ray.rollout.rollout_server import _resolve_sglang_config
+from miles.ray.rollout.rollout_server import _resolve_sglang_config, _resolve_weights_backup_mode
 
 # ----------------------------- _resolve_sglang_config matrix -----------------------------
 
@@ -134,6 +134,76 @@ class TestModelConfigResolve:
         m.resolve(args)
         assert m.update_weights is False  # not flipped
 
+
+# ----------------------------- Frozen weight restoration -----------------
+
+def _frozen_ref(weights_backup_mode: str | None = None) -> ModelConfig:
+    """A frozen reference model"""
+    return ModelConfig(
+        name="ref",
+        model_path="/ref/model",
+        update_weights=False,
+        weights_backup_mode=weights_backup_mode,
+        server_groups=[ServerGroupConfig(worker_type="regular", num_gpus=4)],
+    )
+
+class TestFrozenGroupWeightsBackupMode:
+    """A frozen colocated group must declare how its weights come back.
+    """
+
+    @pytest.mark.parametrize("mode", [None, "actor_sync"])
+    def test_frozen_colocated_without_source_is_rejected(self, mode):
+        # actor_sync is a lie for a frozen group: nothing syncs to it.
+        with pytest.raises(ValueError, match="no weight restoration source"):
+            _resolve_weights_backup_mode(
+                model_cfg=_frozen_ref(mode), needs_offload=True, group_worker_type="regular"
+            )
+
+    @pytest.mark.parametrize("mode", ["cpu", "disk", "reload"])
+    def test_frozen_colocated_accepts_explicit_source(self, mode):
+        assert (
+            _resolve_weights_backup_mode(
+                model_cfg=_frozen_ref(mode), needs_offload=True, group_worker_type="regular"
+            )
+            == mode
+        )
+
+    def test_frozen_not_colocated_needs_no_source(self):
+        # Weights are never released, so there is nothing to restore.
+        assert (
+            _resolve_weights_backup_mode(
+                model_cfg=_frozen_ref(None), needs_offload=False, group_worker_type="regular"
+            )
+            == "actor_sync"
+        )
+
+    def test_updatable_group_defaults_to_actor_sync(self):
+        m = ModelConfig(
+            name="actor",
+            update_weights=True,
+            server_groups=[ServerGroupConfig(worker_type="regular", num_gpus=4)],
+        )
+        assert (
+            _resolve_weights_backup_mode(model_cfg=m, needs_offload=True, group_worker_type="regular")
+            == "actor_sync"
+        )
+
+class TestWeightsBackupModeResolveValidation:
+    def test_invalid_mode_rejected(self):
+        m = _frozen_ref("nvme")
+        with pytest.raises(ValueError, match="invalid weights_backup_mode"):
+            m.resolve(make_args(rollout_num_gpus_per_engine=1, hf_checkpoint="/actor/model"))
+
+    def test_updatable_group_rejects_backup_mode(self):
+        # A disk reload on the student would overwrite freshly trained weights.
+        m = ModelConfig(
+            name="actor",
+            model_path="/actor/model",
+            weights_backup_mode="disk", # TODO: disk?
+            server_groups=[ServerGroupConfig(worker_type="regular", num_gpus=4)],
+        )
+        with pytest.raises(ValueError, match="conflicts with update_weights=True"):
+            m.resolve(make_args(rollout_num_gpus_per_engine=1, hf_checkpoint="/actor/model"))
 
 # ----------------------------- has_pd_disaggregation aggregation -----------------
 

--- a/tests/fast/ray/rollout/test_config_matrix.py
+++ b/tests/fast/ray/rollout/test_config_matrix.py
@@ -159,7 +159,7 @@ class TestFrozenGroupWeightsBackupMode:
                 model_cfg=_frozen_ref(mode), needs_offload=True, group_worker_type="regular"
             )
 
-    @pytest.mark.parametrize("mode", ["cpu", "disk", "reload"])
+    @pytest.mark.parametrize("mode", ["cpu", "reload"])
     def test_frozen_colocated_accepts_explicit_source(self, mode):
         assert (
             _resolve_weights_backup_mode(
@@ -195,11 +195,11 @@ class TestWeightsBackupModeResolveValidation:
             m.resolve(make_args(rollout_num_gpus_per_engine=1, hf_checkpoint="/actor/model"))
 
     def test_updatable_group_rejects_backup_mode(self):
-        # A disk reload on the student would overwrite freshly trained weights.
+        # A cpu reload on the student would overwrite freshly trained weights.
         m = ModelConfig(
             name="actor",
             model_path="/actor/model",
-            weights_backup_mode="disk",
+            weights_backup_mode="cpu",
             server_groups=[ServerGroupConfig(worker_type="regular", num_gpus=4)],
         )
         with pytest.raises(ValueError, match="conflicts with update_weights=True"):

--- a/tests/fast/ray/rollout/test_config_matrix.py
+++ b/tests/fast/ray/rollout/test_config_matrix.py
@@ -199,7 +199,7 @@ class TestWeightsBackupModeResolveValidation:
         m = ModelConfig(
             name="actor",
             model_path="/actor/model",
-            weights_backup_mode="disk", # TODO: disk?
+            weights_backup_mode="disk",
             server_groups=[ServerGroupConfig(worker_type="regular", num_gpus=4)],
         )
         with pytest.raises(ValueError, match="conflicts with update_weights=True"):

--- a/tests/fast/utils/test_sglang_config.py
+++ b/tests/fast/utils/test_sglang_config.py
@@ -1,5 +1,6 @@
 """Unit tests for SglangConfig multi-model parsing with update_weights."""
 
+from miles.backends.sglang_utils.sglang_config import SglangConfig
 from tests.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=60, suite="stage-a-cpu", labels=[])
@@ -71,6 +72,24 @@ class TestSglangConfigUpdateWeights:
         assert config.models[1].update_weights is False
         assert config.models[1].model_path == "/path/to/ref"
 
+    def test_weights_backup_mode_parsed_from_yaml(self, tmp_path):
+        path = _write_yaml(
+            {
+                "sglang": [
+                    {"name": "actor", "update_weights": True,
+                    "engine_groups": [{"worker_type": "regular", "num_gpus": 4}]},
+                    {"name": "ref", "update_weights": False, "model_path": "/path/to/ref",
+                    "weights_backup_mode": "reload",
+                    "engine_groups": [{"worker_type": "regular", "num_gpus": 2}]},
+                ]
+            },
+            tmp_path,
+        )
+        config = SglangConfig.from_yaml(path)
+        assert config.models[0].weights_backup_mode is None
+        assert config.models[1].weights_backup_mode == "reload"
+    
+
     def test_multi_model_total_gpus(self, tmp_path):
         """total_num_gpus should sum across all models."""
         from miles.backends.sglang_utils.sglang_config import SglangConfig
@@ -93,6 +112,8 @@ class TestSglangConfigUpdateWeights:
         )
         config = SglangConfig.from_yaml(path)
         assert config.total_num_gpus == 12
+
+    
 
 
 class TestGetModelUrl:

--- a/tests/fast/utils/test_sglang_config.py
+++ b/tests/fast/utils/test_sglang_config.py
@@ -72,7 +72,7 @@ class TestSglangConfigUpdateWeights:
         assert config.models[1].update_weights is False
         assert config.models[1].model_path == "/path/to/ref"
 
-    def test_weights_backup_mode_parsed_from_yaml(self, tmp_path):
+    def test_weights_backup_mode(self, tmp_path):
         path = _write_yaml(
             {
                 "sglang": [
@@ -112,9 +112,6 @@ class TestSglangConfigUpdateWeights:
         )
         config = SglangConfig.from_yaml(path)
         assert config.total_num_gpus == 12
-
-    
-
 
 class TestGetModelUrl:
     def test_get_model_url_basic(self):

--- a/tests/fast/utils/test_sglang_config.py
+++ b/tests/fast/utils/test_sglang_config.py
@@ -113,6 +113,7 @@ class TestSglangConfigUpdateWeights:
         config = SglangConfig.from_yaml(path)
         assert config.total_num_gpus == 12
 
+
 class TestGetModelUrl:
     def test_get_model_url_basic(self):
         """get_model_url should return the correct URL for a named model."""


### PR DESCRIPTION
### Issue:

Fix https://github.com/radixark/miles/issues/1958

As @zhoutong-hai pointed out,
the frozen teacher weight didn't restore correctly and the health check didn't catch this.

### Solution:

Guard the restore behaviors by checking a per-server-group config `weights_backup_mode`.

This approach avoid putting fail-fast assertion (the heuristic `log(vocab_size)` observation) in the hot path (every `onload()` after `offload()`).


### Tests:

1. `TestFrozenGroupWeightsBackupMode` & `TestWeightsBackupModeResolveValidation`
    - run ```pytest tests.fast.ray.rollout.test_config_matrix```
    - screenshot: <img width="1280" height="676" alt="Screenshot 2026-08-03 at 11 48 00 PM" src="https://github.com/user-attachments/assets/65ac9bc9-2495-4e87-82d0-4076f7812847" />

2. `TestSglangConfigUpdateWeights`
    - run ```pytest tests.fast.utils.test_sglang_config```
    - screenshot: <img width="1280" height="317" alt="Screenshot 2026-08-03 at 11 50 33 PM" src="https://github.com/user-attachments/assets/0bd37e88-acd6-4141-b496-5ba57cd77089" />








