### PR TITLE
Read the train parallel config from the driver to avoid cross-process handle passing

### DIFF
--- a/miles/ray/placement_group.py
+++ b/miles/ray/placement_group.py
@@ -131,7 +131,6 @@ async def create_training_models(args, inference_controller, rollout_executor):
         with_ref=args.kl_coef != 0 or args.use_kl_loss,
         with_opd_teacher=args.use_opd and args.opd_type == "megatron",
         inference_controller=inference_controller,
-        rollout_executor=rollout_executor,
     )
     actor_start_rollout_ids = await actor_model.init()
 
@@ -141,7 +140,6 @@ async def create_training_models(args, inference_controller, rollout_executor):
             role="critic",
             with_ref=False,
             inference_controller=None,
-            rollout_executor=None,
         )
         critic_start_rollout_ids = await critic_model.init()
     else:
@@ -153,7 +151,7 @@ async def create_training_models(args, inference_controller, rollout_executor):
     if args.start_rollout_id is None:
         args.start_rollout_id = start_rollout_ids[0]
 
-    await actor_model.set_rollout_executor()
+    await rollout_executor.set_train_parallel_config.remote(await actor_model.get_train_parallel_config())
     await rollout_executor.load.remote(args.start_rollout_id - 1)
 
     return actor_model, critic_model

--- a/miles/ray/train/cell.py
+++ b/miles/ray/train/cell.py
@@ -37,7 +37,6 @@ class TrainerCell:
         cell_id: str,
         cell_index: int,
         workers_hash: str,
-        rollout_executor: object | None,
         health_checker: BaseHealthChecker,
     ) -> None:
         self.args = args
@@ -47,7 +46,6 @@ class TrainerCell:
         self.role = role
         self.with_ref = with_ref
         self.with_opd_teacher = with_opd_teacher
-        self.rollout_executor = rollout_executor
         self.health_checker = health_checker
 
         (worker_infos,) = RayWorkerProvider.create().get_worker_infos(cell_ids=[cell_id])
@@ -106,11 +104,6 @@ class TrainerCell:
             ),
         )
 
-    async def set_rollout_executor(self):
-        if (executor := self.rollout_executor) is not None:
-            return await self.execute("set_rollout_executor", rollout_executor=executor)
-        return []
-
     # ------------------------ API :: cooperatively prepare ------------------------
 
     async def prepare_indep_dp_mode_alive(
@@ -133,8 +126,6 @@ class TrainerCell:
             indep_dp_info=indep_dp_info,
             recv_ckpt_src_rank=recv_ckpt_src_rank,
         )
-
-        await self.set_rollout_executor()
 
     # ------------------------ state transition ------------------------
 

--- a/miles/ray/train/group.py
+++ b/miles/ray/train/group.py
@@ -42,14 +42,12 @@ class TrainerController:
         args,
         *,
         inference_controller: object | None,
-        rollout_executor: object | None,
         role: str,
         with_ref: bool,
         with_opd_teacher: bool = False,
     ) -> None:
         self.args = args
         self._inference_controller = inference_controller
-        self._rollout_executor = rollout_executor
         self._role = role
         self._with_ref = with_ref
         self._with_opd_teacher = with_opd_teacher
@@ -139,7 +137,6 @@ class TrainerController:
             cell_id=cell_id,
             cell_index=cell_index,
             workers_hash=workers_hash,
-            rollout_executor=self._rollout_executor,
             health_checker=NoopHealthChecker(),
         )
 
@@ -378,8 +375,8 @@ class TrainerController:
     async def reconcile_adapters(self) -> None:
         await asyncio.gather(*[cell.execute("reconcile_adapters") for cell in self._cells])
 
-    async def set_rollout_executor(self):
-        await asyncio.gather(*[cell.set_rollout_executor() for cell in self._cells])
+    async def get_train_parallel_config(self) -> dict:
+        return (await self._execute_first_alive("get_train_parallel_config"))[0]
 
     def get_cell_statuses(self) -> dict[str, CellStatus]:
         return {cell_id: cell.cell_status() for cell_id, cell in list(self._cells_by_id.items())}

--- a/miles/ray/train_actor.py
+++ b/miles/ray/train_actor.py
@@ -184,7 +184,5 @@ class TrainRayActor(NodeProbeMixin):
     def _get_parallel_config(self):
         raise NotImplementedError
 
-    def set_rollout_executor(self, rollout_executor):
-        self.rollout_executor = rollout_executor
-        if self.args.rank == 0:
-            ray.get(self.rollout_executor.set_train_parallel_config.remote(self.train_parallel_config))
+    def get_train_parallel_config(self) -> dict:
+        return self.train_parallel_config

--- a/tests/fast/ray/test_placement_group.py
+++ b/tests/fast/ray/test_placement_group.py
@@ -163,11 +163,7 @@ def fake_trainer_controllers(monkeypatch: pytest.MonkeyPatch):
         events.append(("init", self._role))
         return [_TRAINER_START_ROLLOUT_ID]
 
-    async def _fake_set_rollout_executor(self: TrainerController) -> None:
-        events.append(("set_rollout_executor", self._role))
-
     monkeypatch.setattr(TrainerController, "init", _fake_init)
-    monkeypatch.setattr(TrainerController, "set_rollout_executor", _fake_set_rollout_executor)
     return SimpleNamespace(events=events)
 
 
@@ -233,7 +229,7 @@ class TestCreateTrainingModels:
 
         await create_training_models(args, object(), rollout_executor)
 
-        assert fake_trainer_controllers.events == [("init", "actor"), ("set_rollout_executor", "actor")]
+        assert fake_trainer_controllers.events == [("init", "actor")]
         assert args.start_rollout_id == _TRAINER_START_ROLLOUT_ID
         assert rollout_executor.loaded_rollout_ids == [_TRAINER_START_ROLLOUT_ID - 1]
 

--- a/tests/fast/ray/test_placement_group_shared_ppo.py
+++ b/tests/fast/ray/test_placement_group_shared_ppo.py
@@ -47,8 +47,18 @@ def test_external_rollout_only_reserves_no_local_bundles():
     assert _get_placement_group_layout(_layout_args(debug_rollout_only=True, rollout_external=True)) == (0, 0)
 
 
-async def _noop_remote(*_args, **_kwargs):
-    return None
+class _RecordingRolloutExecutor:
+    def __init__(self):
+        self.train_parallel_config = None
+        self.loaded_rollout_id = None
+        self.set_train_parallel_config = SimpleNamespace(remote=self._set_train_parallel_config)
+        self.load = SimpleNamespace(remote=self._load)
+
+    async def _set_train_parallel_config(self, config):
+        self.train_parallel_config = config
+
+    async def _load(self, rollout_id):
+        self.loaded_rollout_id = rollout_id
 
 
 async def _stop_watch() -> None:
@@ -79,8 +89,50 @@ async def _fake_init(self: TrainerController) -> list[int]:
     return [0]
 
 
-async def _fake_set_rollout_executor(self: TrainerController) -> None:
-    return None
+async def _fake_get_train_parallel_config(self: TrainerController) -> dict:
+    return {"dp_size": 2}
+
+
+def _patch_train_group(monkeypatch) -> list:
+    groups = []
+
+    class _Group:
+        def __init__(self, *, args, role, **_kwargs):
+            self.args = args
+            self.role = role
+            groups.append(self)
+
+        @classmethod
+        async def create(cls, args, **kwargs):
+            return cls(args=args, **kwargs)
+
+        async def init(self):
+            return [0]
+
+        async def get_train_parallel_config(self):
+            return {"dp_size": 2 if self.role == "actor" else 99}
+
+    monkeypatch.setattr(placement_group_module, "TrainerController", _Group)
+    return groups
+
+
+def _training_models_args(**overrides):
+    values = {
+        "actor_num_nodes": 1,
+        "actor_num_gpus_per_node": 2,
+        "critic_num_nodes": 1,
+        "critic_num_gpus_per_node": 2,
+        "use_critic": True,
+        "kl_coef": 0.1,
+        "use_kl_loss": False,
+        "use_opd": True,
+        "opd_type": "megatron",
+        "disable_param_buffers_cpu_backup": True,
+        "start_rollout_id": None,
+        "rollout_global_dataset": False,
+    }
+    values.update(overrides)
+    return Namespace(**values)
 
 
 _waited_roles: list[str] = []
@@ -98,26 +150,11 @@ async def test_critic_role_disables_reward_kl_and_preserves_actor_args(monkeypat
     """Both training groups go through the real create(), and only the critic args are rewritten."""
     provider = _RecordingWorkerProvider()
     monkeypatch.setattr(TrainerController, "init", _fake_init)
-    monkeypatch.setattr(TrainerController, "set_rollout_executor", _fake_set_rollout_executor)
     monkeypatch.setattr(TrainerController, "_wait_expected_num_cells", _fake_wait_expected_num_cells)
+    monkeypatch.setattr(TrainerController, "get_train_parallel_config", _fake_get_train_parallel_config)
     _waited_roles.clear()
 
-    args = Namespace(
-        actor_num_nodes=1,
-        actor_num_gpus_per_node=2,
-        critic_num_nodes=1,
-        critic_num_gpus_per_node=2,
-        use_critic=True,
-        kl_coef=0.1,
-        use_kl_loss=False,
-        use_opd=True,
-        opd_type="megatron",
-        disable_param_buffers_cpu_backup=True,
-        start_rollout_id=None,
-        rollout_global_dataset=False,
-        indep_dp=False,
-        enable_witness=False,
-    )
+    args = _training_models_args(indep_dp=False, enable_witness=False)
 
     def _create(*, pool_ids: list[str] | None = None) -> _RecordingWorkerProvider:
         provider.built_for.append(list(pool_ids or []))
@@ -127,7 +164,7 @@ async def test_critic_role_disables_reward_kl_and_preserves_actor_args(monkeypat
         actor, critic = await placement_group_module.create_training_models(
             args,
             inference_controller=object(),
-            rollout_executor=SimpleNamespace(load=SimpleNamespace(remote=_noop_remote)),
+            rollout_executor=_RecordingRolloutExecutor(),
         )
 
     assert provider.built_for == [["trainer-actor"], ["trainer-critic"]]
@@ -147,3 +184,32 @@ async def test_critic_role_disables_reward_kl_and_preserves_actor_args(monkeypat
     assert critic.args.kl_coef == 0
     assert critic.args.use_opd is False
     assert critic.args.disable_param_buffers_cpu_backup is False
+
+
+async def test_train_parallel_config_travels_from_trainer_to_rollout_executor(monkeypatch):
+    """The driver reads the parallel config off the trainer and writes it into the executor."""
+    _patch_train_group(monkeypatch)
+    rollout_executor = _RecordingRolloutExecutor()
+
+    await placement_group_module.create_training_models(
+        _training_models_args(use_critic=False),
+        inference_controller=object(),
+        rollout_executor=rollout_executor,
+    )
+
+    assert rollout_executor.train_parallel_config == {"dp_size": 2}
+    assert rollout_executor.loaded_rollout_id == -1
+
+
+async def test_train_parallel_config_comes_from_the_actor_not_the_critic(monkeypatch):
+    """With a critic present, the config still comes from the actor group."""
+    _patch_train_group(monkeypatch)
+    rollout_executor = _RecordingRolloutExecutor()
+
+    await placement_group_module.create_training_models(
+        _training_models_args(use_critic=True),
+        inference_controller=object(),
+        rollout_executor=rollout_executor,
+    )
+
+    assert rollout_executor.train_parallel_config == {"dp_size": 2}

--- a/tests/fast/ray/test_train_actor.py
+++ b/tests/fast/ray/test_train_actor.py
@@ -3,20 +3,8 @@ import socket
 from types import SimpleNamespace
 
 import pytest
-from tests.fast.ray.fake_rollout_executor import FakeRolloutExecutor
-
 from miles.ray import train_actor
 from miles.ray.train_actor import TrainRayActor
-
-_TRAIN_PARALLEL_CONFIG = {"dp_size": 2, "cp_size": 1}
-
-
-def _make_actor(*, rank: int) -> TrainRayActor:
-    actor = object.__new__(TrainRayActor)
-    actor.args = SimpleNamespace(rank=rank)
-    actor.train_parallel_config = _TRAIN_PARALLEL_CONFIG
-    return actor
-
 
 class TestConstructorSignature:
     def test_positional_constructor_arguments_are_rejected(self):
@@ -53,50 +41,6 @@ class TestKillSelf:
         TrainRayActor.__new__(TrainRayActor).kill_self()
 
         assert exit_statuses == [1]
-
-
-class TestSetRolloutExecutor:
-    def _make_executor(self, published: list[object]) -> SimpleNamespace:
-        return SimpleNamespace(
-            set_train_parallel_config=SimpleNamespace(remote=lambda config: published.append(config))
-        )
-
-    def test_rank_zero_publishes_the_train_parallel_config(self, monkeypatch) -> None:
-        """On rank zero the executor handle is stored and the train parallel config is pushed to it."""
-        awaited_refs: list[str] = []
-        monkeypatch.setattr(train_actor, "ray", SimpleNamespace(get=awaited_refs.append))
-        actor = _make_actor(rank=0)
-        executor = FakeRolloutExecutor()
-
-        actor.set_rollout_executor(executor)
-
-        assert actor.rollout_executor is executor
-        assert executor.set_train_parallel_config.calls == [(_TRAIN_PARALLEL_CONFIG,)]
-        assert awaited_refs == ["object-ref-1"]
-
-    def test_only_rank_zero_configures_the_rollout_executor(self, monkeypatch) -> None:
-        """A nonzero rank stores the executor handle but issues no configuration RPC."""
-        awaited_refs: list[str] = []
-        monkeypatch.setattr(train_actor, "ray", SimpleNamespace(get=awaited_refs.append))
-        actor = _make_actor(rank=1)
-        executor = FakeRolloutExecutor()
-
-        actor.set_rollout_executor(executor)
-
-        assert actor.rollout_executor is executor
-        assert executor.set_train_parallel_config.calls == []
-        assert awaited_refs == []
-
-    def test_the_published_config_is_the_actors_own_train_parallel_config(self, monkeypatch: pytest.MonkeyPatch):
-        """The rollout side needs the trainer topology verbatim, whatever keys that topology carries."""
-        monkeypatch.setattr(train_actor, "ray", SimpleNamespace(get=lambda ref: ref))
-        published: list[object] = []
-        actor = _make_actor(rank=0)
-        actor.train_parallel_config = {"tensor_model_parallel_size": 4}
-
-        actor.set_rollout_executor(self._make_executor(published))
-
-        assert published == [{"tensor_model_parallel_size": 4}]
 
 
 class TestConfigureMasterAddrAndPort:

--- a/tests/fast/ray/train/conftest.py
+++ b/tests/fast/ray/train/conftest.py
@@ -104,7 +104,6 @@ def make_cell(
     cell_index: int = 0,
     *,
     actor_count: int = 2,
-    rollout_executor: object | None = None,
     health_checker: BaseHealthChecker | None = None,
 ) -> TrainerCell:
     fake_worker_manager.actor_count_per_cell = actor_count
@@ -115,7 +114,6 @@ def make_cell(
         cell_id=f"trainer-actor-{cell_index}",
         cell_index=cell_index,
         workers_hash="pseudo-hash-1",
-        rollout_executor=rollout_executor,
         health_checker=health_checker if health_checker is not None else NoopHealthChecker(),
     )
 

--- a/tests/fast/ray/train/dummy_actor.py
+++ b/tests/fast/ray/train/dummy_actor.py
@@ -21,6 +21,7 @@ class DummyTrainActor:
         self._train_return_value: Any = TrainStepOutput(outcome=TrainStepOutcome.NORMAL)
         self._train_return_values_per_attempt: list[Any] = []
         self._update_weights_return_value: Any = None
+        self._train_parallel_config: dict = {}
         self._heartbeat = SimpleHeartbeat()
         self._heartbeat.bump()
         self._heartbeat_fail: bool = False
@@ -33,6 +34,9 @@ class DummyTrainActor:
 
     def set_train_return_values_per_attempt(self, values: list[Any]) -> None:
         self._train_return_values_per_attempt = list(values)
+
+    def set_train_parallel_config(self, config: dict) -> None:
+        self._train_parallel_config = config
 
     def _record(self, method: str, args: tuple, kwargs: dict) -> None:
         self._calls.append((method, args, kwargs))
@@ -63,8 +67,9 @@ class DummyTrainActor:
     def reconcile_adapters(self) -> None:
         self._record("reconcile_adapters", (), {})
 
-    def set_rollout_executor(self, *args: Any, **kwargs: Any) -> None:
-        self._record("set_rollout_executor", args, kwargs)
+    def get_train_parallel_config(self) -> dict:
+        self._record("get_train_parallel_config", (), {})
+        return self._train_parallel_config
 
     def wake_up(self) -> None:
         self._record("wake_up", (), {})

--- a/tests/fast/ray/train/test_cell.py
+++ b/tests/fast/ray/train/test_cell.py
@@ -205,29 +205,6 @@ class TestAsyncInit:
         assert checker.task_started
 
 
-class TestSetRolloutExecutor:
-    async def test_a_cell_without_an_executor_issues_no_worker_rpc(self):
-        """The critic pool has no executor, and a None handle reaching a worker would break its next rollout call."""
-        cell = make_cell(actor_count=2, rollout_executor=None)
-
-        assert await cell.set_rollout_executor() == []
-
-        for handle in get_raw_actor_handles(cell):
-            calls = ray.get(handle.get_calls.remote())
-            assert [name for name, _args, _kwargs in calls] == []
-
-    async def test_present_rollout_executor_reaches_every_actor(self):
-        """A configured rollout executor handle is forwarded to every actor of the cell."""
-        cell = make_cell(actor_count=2, rollout_executor="executor-handle")
-
-        results = await cell.set_rollout_executor()
-
-        assert len(results) == 2
-        for handle in get_raw_actor_handles(cell):
-            calls = ray.get(handle.get_calls.remote())
-            assert calls == [("set_rollout_executor", (), {"rollout_executor": "executor-handle"})]
-
-
 class _EntryBarrier:
     def __init__(self, party_size: int) -> None:
         self._remaining = party_size

--- a/tests/fast/ray/train/test_group.py
+++ b/tests/fast/ray/train/test_group.py
@@ -59,7 +59,6 @@ def _make_controller(
     num_cells: int = 3,
     actor_count_per_cell: int = 1,
     inference_controller: object | None = None,
-    rollout_executor: object | None = None,
     with_ref: bool = False,
     with_opd_teacher: bool = False,
     ci_ft_test_actions: str | None = None,
@@ -78,7 +77,6 @@ def _make_controller(
         with_ref=with_ref,
         with_opd_teacher=with_opd_teacher,
         inference_controller=inference_controller,
-        rollout_executor=rollout_executor,
     )
     for cell_index in range(num_cells):
         cell = group._create_cell(
@@ -218,6 +216,30 @@ class TestExecuteFirstAlive:
             assert any(c[0] == "update_weights" for c in calls)
 
 
+class TestGetTrainParallelConfig:
+    @staticmethod
+    def _set_configs(cell, configs: list[dict]) -> None:
+        handles = cell._get_actor_handles()
+        ray.get(
+            [handle.set_train_parallel_config.remote(config) for handle, config in zip(handles, configs, strict=True)]
+        )
+
+    async def test_returns_config_of_rank_zero_of_the_first_alive_cell(self):
+        """The driver reads the config the cell's own rank 0 computed at init."""
+        group = await _make_alive_controller(num_cells=2, actor_count_per_cell=2)
+        self._set_configs(group._cells[0], [{"dp_size": 4}, {"dp_size": 99}])
+
+        assert await group.get_train_parallel_config() == {"dp_size": 4}
+
+    async def test_skips_stopped_cells(self):
+        """A stopped cell 0 must not be asked; the next alive cell answers instead."""
+        group = await _make_alive_controller(num_cells=2)
+        self._set_configs(group._cells[1], [{"dp_size": 2}])
+        await group._cells[0].stop()
+
+        assert await group.get_train_parallel_config() == {"dp_size": 2}
+
+
 class TestComputeIndepDPInfo:
     def test_all_alive(self):
         group = _make_controller(num_cells=3)
@@ -350,22 +372,6 @@ class TestRefreshCellsHealing:
             assert len(send_calls) == 2
             dst_ranks = sorted(c[2]["dst_rank"] for c in send_calls)
             assert dst_ranks == [1, 2]
-
-    async def test_healed_cell_receives_set_rollout_executor(self):
-        """A healed cell is handed the executor handle again after init."""
-        group = await _make_alive_controller(num_cells=2, rollout_executor="executor-handle")
-        await _stop_cell(group, 1)
-        _start_cell(group, 1)
-
-        await group._refresh_cells(rollout_id=0)
-
-        assert _cell(group, 1).is_alive
-        for handle in get_raw_actor_handles(_cell(group, 1)):
-            calls = ray.get(handle.get_calls.remote())
-            set_calls = [c for c in calls if c[0] == "set_rollout_executor"]
-            assert set_calls, "healed cell never received set_rollout_executor"
-            for call in set_calls:
-                assert call[2] == {"rollout_executor": "executor-handle"}
 
     async def test_pending_cell_with_stopped_cell(self):
         """Pending + stopped: only alive and pending participate, stopped excluded."""
@@ -1237,25 +1243,3 @@ class TestUpdateWeightsReachesTheWorker:
         assert inference_controller.ended_with == [{"trainer-actor-0": "workers-hash-9"}]
 
 
-class TestSetRolloutExecutorFanOut:
-    async def test_every_worker_of_every_observed_cell_receives_the_executor(self):
-        """A worker without the handle cannot ship its samples, and the run stalls on that rank alone."""
-        group = await _make_alive_controller(num_cells=3, actor_count_per_cell=2, rollout_executor="executor-handle")
-
-        await group.set_rollout_executor()
-
-        for cell in group._cells:
-            for handle in get_raw_actor_handles(cell):
-                set_calls = [c for c in ray.get(handle.get_calls.remote()) if c[0] == "set_rollout_executor"]
-                assert [c[2] for c in set_calls] == [{"rollout_executor": "executor-handle"}]
-
-    async def test_a_cell_that_refuses_the_executor_is_reported(self):
-        """Swallowing this would start the run with a rank that silently drops every sample it produces."""
-        group = await _make_alive_controller(num_cells=2, rollout_executor="executor-handle")
-        for handle in get_raw_actor_handles(_cell(group, 1)):
-            ray.get(handle.set_fail_methods.remote(["set_rollout_executor"]))
-
-        with pytest.raises(RuntimeError, match="Injected failure"):
-            await group.set_rollout_executor()
-
-        assert _cell(group, 1).is_errored

--- a/tests/fast/ray/train/test_group_create.py
+++ b/tests/fast/ray/train/test_group_create.py
@@ -74,7 +74,6 @@ async def _create_controller(*, num_cells: int) -> TrainerController:
         role="actor",
         with_ref=False,
         inference_controller=None,
-        rollout_executor=None,
     )
     await controller.init()
     return controller

--- a/tests/fast/ray/train/test_group_reconcile.py
+++ b/tests/fast/ray/train/test_group_reconcile.py
@@ -29,7 +29,6 @@ def _make_controller(*, num_cells: int = 2, indep_dp: bool = False) -> TrainerCo
     group._with_ref = False
     group._with_opd_teacher = False
     group._pool_id = _POOL_ID
-    group._rollout_executor = None
     group._health_checker_config = None
     group._health_checker_activeness = True
     group._cells_by_id = {}


### PR DESCRIPTION
Part of #1837