### PR TITLE
fix: fail at launch when static micro-batching cannot align the rollout-side DP schedule

### DIFF
--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -2944,20 +2944,17 @@ def miles_validate_args(args):
             args.log_probs_max_tokens_per_gpu = args.max_tokens_per_gpu
 
     # --use-dynamic-global-batch-size has two motivations:
-    # 1. compaction/subagent rollouts: the number of samples per rollout is unpredictable
-    #    at runtime, so steps must size themselves to the collected data. Assembling such
-    #    steps with static micro-batching is not supported yet -- no config keeps
-    #    ceil(step_size / micro_batch_size) aligned to dp_size * mb_group -- so
-    #    --use-dynamic-batch-size is required.
+    # 1. compaction/subagent rollouts: static micro-batching cannot guarantee alignment
+    #    when the physical sample count is data-dependent, so --use-dynamic-batch-size
+    #    is required.
     # 2. multi-LoRA (auto-enabled, no compaction/subagent): the per-round sample count is
     #    a config-shaped multiple of dp_size trained as exactly one step on the legacy
     #    training-side schedule; static micro-batching stays valid there.
     if args.use_dynamic_global_batch_size and not args.multi_lora:
         assert args.use_dynamic_batch_size, (
             "--use-dynamic-global-batch-size requires --use-dynamic-batch-size (with --max-tokens-per-gpu): "
-            "the per-step sample count is data-dependent, static micro-batching cannot keep the micro-batch "
-            "count aligned to dp_size * mb_group, and training would crash mid-run on build_dp_schedule's "
-            "alignment check."
+            "static micro-batching cannot guarantee dp_size * mb_group alignment when the physical sample count "
+            "is data-dependent; this configuration is not supported."
         )
 
     if getattr(args, "balance_by_flops", False):

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -2943,6 +2943,16 @@ def miles_validate_args(args):
         if args.log_probs_max_tokens_per_gpu is None:
             args.log_probs_max_tokens_per_gpu = args.max_tokens_per_gpu
 
+    # multi-LoRA auto-enables dynamic global batch size but is excluded from the
+    # rollout-side schedule, so the alignment fragility below does not apply to it.
+    if args.use_dynamic_global_batch_size and not args.multi_lora:
+        assert args.use_dynamic_batch_size, (
+            "--use-dynamic-global-batch-size requires --use-dynamic-batch-size (with --max-tokens-per-gpu). "
+            "With a data-dependent per-step sample count, static micro-batching cannot keep the "
+            "micro-batch count aligned to dp_size * mb_group; no config guarantees alignment, and "
+            "training would crash mid-run on build_dp_schedule's alignment check."
+        )
+
     if getattr(args, "balance_by_flops", False):
         assert args.use_dynamic_batch_size, "--balance-by-flops requires --use-dynamic-batch-size"
 

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -2943,14 +2943,21 @@ def miles_validate_args(args):
         if args.log_probs_max_tokens_per_gpu is None:
             args.log_probs_max_tokens_per_gpu = args.max_tokens_per_gpu
 
-    # multi-LoRA auto-enables dynamic global batch size but is excluded from the
-    # rollout-side schedule, so the alignment fragility below does not apply to it.
+    # --use-dynamic-global-batch-size has two motivations:
+    # 1. compaction/subagent rollouts: the number of samples per rollout is unpredictable
+    #    at runtime, so steps must size themselves to the collected data. Assembling such
+    #    steps with static micro-batching is not supported yet -- no config keeps
+    #    ceil(step_size / micro_batch_size) aligned to dp_size * mb_group -- so
+    #    --use-dynamic-batch-size is required.
+    # 2. multi-LoRA (auto-enabled, no compaction/subagent): the per-round sample count is
+    #    a config-shaped multiple of dp_size trained as exactly one step on the legacy
+    #    training-side schedule; static micro-batching stays valid there.
     if args.use_dynamic_global_batch_size and not args.multi_lora:
         assert args.use_dynamic_batch_size, (
-            "--use-dynamic-global-batch-size requires --use-dynamic-batch-size (with --max-tokens-per-gpu). "
-            "With a data-dependent per-step sample count, static micro-batching cannot keep the "
-            "micro-batch count aligned to dp_size * mb_group; no config guarantees alignment, and "
-            "training would crash mid-run on build_dp_schedule's alignment check."
+            "--use-dynamic-global-batch-size requires --use-dynamic-batch-size (with --max-tokens-per-gpu): "
+            "the per-step sample count is data-dependent, static micro-batching cannot keep the micro-batch "
+            "count aligned to dp_size * mb_group, and training would crash mid-run on build_dp_schedule's "
+            "alignment check."
         )
 
     if getattr(args, "balance_by_flops", False):

--- a/miles/utils/dp_schedule.py
+++ b/miles/utils/dp_schedule.py
@@ -43,9 +43,10 @@ def _pack_micro_batches_dynamic(
         micro_batch_count = max(1, (total_tokens + max_per_bin - 1) // max_per_bin)
         if micro_batch_count >= len(step_lengths):
             return [[i] for i in range(len(step_lengths))]
-        workloads = _calculate_workloads(step_lengths, args)
-        # NOTE: FLOPs balancing does not enforce the token cap per micro-batch.
-        return get_seqlen_balanced_partitions(workloads, micro_batch_count, equal_size=False)
+        else:
+            workloads = _calculate_workloads(step_lengths, args)
+            # NOTE: FLOPs balancing does not enforce the token cap per micro-batch.
+            return get_seqlen_balanced_partitions(workloads, micro_batch_count, equal_size=False)
     return first_fit_decreasing_pack(step_lengths, max_per_bin)
 
 
@@ -127,22 +128,20 @@ def build_dp_schedule(
                 max_per_bin=max_per_bin,
                 balance_by_flops=balance_by_flops,
             )
-        else:
-            step_micro_batches = _pack_micro_batches_static(
-                step_lengths, micro_batch_size=getattr(args, "micro_batch_size", None)
-            )
-
-        # Grow the micro-batch count to a multiple of align_to by splitting multi-sample micro-batches.
-        target = max((len(step_micro_batches) + align_to - 1) // align_to * align_to, align_to)
-        if target != len(step_micro_batches):
-            if args.use_dynamic_batch_size:
+            # Grow the micro-batch count to a multiple of align_to by splitting multi-sample micro-batches.
+            target = max((len(step_micro_batches) + align_to - 1) // align_to * align_to, align_to)
+            if target != len(step_micro_batches):
                 expand_bins_by_splitting(step_micro_batches, target, step_lengths)
                 assert len(step_micro_batches) == target, (
                     f"dynamic path: could only produce {len(step_micro_batches)} micro-batches after maximal "
                     f"splitting; need {target}. step {step_i} has {len(sample_indices)} samples, below the "
                     f"alignment threshold ({align_to})."
                 )
-            else:
+        else:
+            step_micro_batches = _pack_micro_batches_static(
+                step_lengths, micro_batch_size=getattr(args, "micro_batch_size", None)
+            )
+            if len(step_micro_batches) % align_to != 0:
                 raise AssertionError(
                     f"static path: micro-batch count ({len(step_micro_batches)}) is not a multiple of "
                     f"dp_size * mb_group ({align_to}); got "

--- a/miles/utils/dp_schedule.py
+++ b/miles/utils/dp_schedule.py
@@ -39,11 +39,11 @@ def build_dp_schedule(
     vpp_size = train_parallel_config["vpp_size"] or 1
     mb_group = train_parallel_config["microbatch_group_size_per_vp_stage"]
 
-    # micro-batch count per step must divide evenly across ranks and, under VPP, mb groups.
+    # micro-batch size per step must divide evenly across dp and vpp
     align_to = dp_size * (mb_group if vpp_size > 1 else 1)
 
-    # Group sample positions by rollout id (first-occurrence order) so a rollout's
-    # samples always land in the same training step.
+    # Rollout can include multiple samples (compaction, subagent, fork, etc.)
+    # Samples in the same rollout should be trained in the same step, or dropped together.
     rollout_id_to_sample_index: dict[int, list[int]] = {}
     for sample_pos, rid in enumerate(rollout_indices):
         rollout_id_to_sample_index.setdefault(rid, []).append(sample_pos)

--- a/miles/utils/dp_schedule.py
+++ b/miles/utils/dp_schedule.py
@@ -24,6 +24,36 @@ def has_full_schedule_config(train_parallel_config: dict | None) -> bool:
     return all(key in train_parallel_config for key in SCHEDULE_CONFIG_KEYS)
 
 
+def _calculate_workloads(step_lengths, args):
+    return [calculate_fwd_flops([sl], args) for sl in step_lengths]
+
+
+def _pack_samples_into_micro_batches(
+    step_lengths: list[int],
+    *,
+    args: Any,
+    use_dynamic_batch_size: bool,
+    max_per_bin: int | None,
+    micro_batch_size: int | None,
+    balance_by_flops: bool = False,
+) -> list[list[int]]:
+    """Group a step's samples into micro-batches. Returns ``micro_batches[k]`` = local indices into ``step_lengths``."""
+    if use_dynamic_batch_size:
+        assert max_per_bin is not None
+        if balance_by_flops:
+            total_tokens = sum(step_lengths)
+            micro_batch_count = max(1, (total_tokens + max_per_bin - 1) // max_per_bin)
+            if micro_batch_count >= len(step_lengths):
+                return [[i] for i in range(len(step_lengths))]
+            workloads = _calculate_workloads(step_lengths, args)
+            # NOTE: FLOPs balancing does not enforce the token cap per micro-batch.
+            return get_seqlen_balanced_partitions(workloads, micro_batch_count, equal_size=False)
+        return first_fit_decreasing_pack(step_lengths, max_per_bin)
+    assert micro_batch_size is not None
+    n = len(step_lengths)
+    return [list(range(i, min(i + micro_batch_size, n))) for i in range(0, n, micro_batch_size)]
+
+
 def build_dp_schedule(
     args: Any,
     train_parallel_config: dict,
@@ -41,6 +71,11 @@ def build_dp_schedule(
 
     # micro-batch size per step must divide evenly across dp and vpp
     align_to = dp_size * (mb_group if vpp_size > 1 else 1)
+
+    max_per_bin = None
+    if args.use_dynamic_batch_size:
+        assert args.max_tokens_per_gpu is not None
+        max_per_bin = args.max_tokens_per_gpu * cp_size
 
     # Rollout can include multiple samples (compaction, subagent, fork, etc.)
     # Samples in the same rollout should be trained in the same step, or dropped together.
@@ -81,28 +116,15 @@ def build_dp_schedule(
             f"each step needs at least one sample per rank."
         )
 
-        # Pack the step's samples into micro-batches; step_micro_batches[k] holds local
-        # indices into step_lengths.
-        workloads = None
-        if not args.use_dynamic_batch_size:
-            assert args.micro_batch_size is not None
-            n = len(step_lengths)
-            step_micro_batches = [
-                list(range(i, min(i + args.micro_batch_size, n))) for i in range(0, n, args.micro_batch_size)
-            ]
-        elif getattr(args, "balance_by_flops", False):
-            assert args.max_tokens_per_gpu is not None
-            max_per_bin = args.max_tokens_per_gpu * cp_size
-            workloads = [calculate_fwd_flops([length], args) for length in step_lengths]
-            micro_batch_count = max(1, (sum(step_lengths) + max_per_bin - 1) // max_per_bin)
-            if micro_batch_count >= len(step_lengths):
-                step_micro_batches = [[i] for i in range(len(step_lengths))]
-            else:
-                # NOTE: FLOPs balancing does not enforce the token cap per micro-batch.
-                step_micro_batches = get_seqlen_balanced_partitions(workloads, micro_batch_count, equal_size=False)
-        else:
-            assert args.max_tokens_per_gpu is not None
-            step_micro_batches = first_fit_decreasing_pack(step_lengths, args.max_tokens_per_gpu * cp_size)
+        balance_by_flops = getattr(args, "balance_by_flops", False)
+        step_micro_batches = _pack_samples_into_micro_batches(
+            step_lengths,
+            args=args,
+            use_dynamic_batch_size=args.use_dynamic_batch_size,
+            max_per_bin=max_per_bin,
+            micro_batch_size=getattr(args, "micro_batch_size", None),
+            balance_by_flops=balance_by_flops,
+        )
 
         # Grow the micro-batch count to a multiple of align_to by splitting multi-sample micro-batches.
         target = max((len(step_micro_batches) + align_to - 1) // align_to * align_to, align_to)
@@ -122,8 +144,9 @@ def build_dp_schedule(
         # Distribute the micro-batches across DP ranks, len(step_micro_batches) / dp_size each: strided
         # round-robin, or Karmarkar-Karp on micro-batch weights (tokens under --balance-data,
         # FLOPs under --balance-by-flops).
-        if args.balance_data or getattr(args, "balance_by_flops", False):
-            if workloads is not None:
+        if args.balance_data or balance_by_flops:
+            if balance_by_flops:
+                workloads = _calculate_workloads(step_lengths, args)
                 weights = [sum(workloads[i] for i in micro_batch) for micro_batch in step_micro_batches]
             else:
                 weights = [sum(step_lengths[i] for i in micro_batch) for micro_batch in step_micro_batches]

--- a/miles/utils/dp_schedule.py
+++ b/miles/utils/dp_schedule.py
@@ -28,27 +28,30 @@ def _calculate_workloads(step_lengths, args):
     return [calculate_fwd_flops([sl], args) for sl in step_lengths]
 
 
-def _pack_samples_into_micro_batches(
+def _pack_micro_batches_dynamic(
     step_lengths: list[int],
     *,
     args: Any,
-    use_dynamic_batch_size: bool,
-    max_per_bin: int | None,
-    micro_batch_size: int | None,
+    max_per_bin: int,
     balance_by_flops: bool = False,
 ) -> list[list[int]]:
-    """Group a step's samples into micro-batches. Returns ``micro_batches[k]`` = local indices into ``step_lengths``."""
-    if use_dynamic_batch_size:
-        assert max_per_bin is not None
-        if balance_by_flops:
-            total_tokens = sum(step_lengths)
-            micro_batch_count = max(1, (total_tokens + max_per_bin - 1) // max_per_bin)
-            if micro_batch_count >= len(step_lengths):
-                return [[i] for i in range(len(step_lengths))]
-            workloads = _calculate_workloads(step_lengths, args)
-            # NOTE: FLOPs balancing does not enforce the token cap per micro-batch.
-            return get_seqlen_balanced_partitions(workloads, micro_batch_count, equal_size=False)
-        return first_fit_decreasing_pack(step_lengths, max_per_bin)
+    """First-fit token packing, or FLOPs-balanced partitions under ``balance_by_flops``.
+    Returns ``micro_batches[k]`` = local indices into ``step_lengths``."""
+    assert max_per_bin is not None
+    if balance_by_flops:
+        total_tokens = sum(step_lengths)
+        micro_batch_count = max(1, (total_tokens + max_per_bin - 1) // max_per_bin)
+        if micro_batch_count >= len(step_lengths):
+            return [[i] for i in range(len(step_lengths))]
+        workloads = _calculate_workloads(step_lengths, args)
+        # NOTE: FLOPs balancing does not enforce the token cap per micro-batch.
+        return get_seqlen_balanced_partitions(workloads, micro_batch_count, equal_size=False)
+    return first_fit_decreasing_pack(step_lengths, max_per_bin)
+
+
+def _pack_micro_batches_static(step_lengths: list[int], *, micro_batch_size: int) -> list[list[int]]:
+    """Fixed-size chunks of ``micro_batch_size`` samples.
+    Returns ``micro_batches[k]`` = local indices into ``step_lengths``."""
     assert micro_batch_size is not None
     n = len(step_lengths)
     return [list(range(i, min(i + micro_batch_size, n))) for i in range(0, n, micro_batch_size)]
@@ -117,14 +120,17 @@ def build_dp_schedule(
         )
 
         balance_by_flops = getattr(args, "balance_by_flops", False)
-        step_micro_batches = _pack_samples_into_micro_batches(
-            step_lengths,
-            args=args,
-            use_dynamic_batch_size=args.use_dynamic_batch_size,
-            max_per_bin=max_per_bin,
-            micro_batch_size=getattr(args, "micro_batch_size", None),
-            balance_by_flops=balance_by_flops,
-        )
+        if args.use_dynamic_batch_size:
+            step_micro_batches = _pack_micro_batches_dynamic(
+                step_lengths,
+                args=args,
+                max_per_bin=max_per_bin,
+                balance_by_flops=balance_by_flops,
+            )
+        else:
+            step_micro_batches = _pack_micro_batches_static(
+                step_lengths, micro_batch_size=getattr(args, "micro_batch_size", None)
+            )
 
         # Grow the micro-batch count to a multiple of align_to by splitting multi-sample micro-batches.
         target = max((len(step_micro_batches) + align_to - 1) // align_to * align_to, align_to)

--- a/miles/utils/dp_schedule.py
+++ b/miles/utils/dp_schedule.py
@@ -28,36 +28,6 @@ def _calculate_workloads(step_lengths, args):
     return [calculate_fwd_flops([sl], args) for sl in step_lengths]
 
 
-def _pack_micro_batches_dynamic(
-    step_lengths: list[int],
-    *,
-    args: Any,
-    max_per_bin: int,
-    balance_by_flops: bool = False,
-) -> list[list[int]]:
-    """First-fit token packing, or FLOPs-balanced partitions under ``balance_by_flops``.
-    Returns ``micro_batches[k]`` = local indices into ``step_lengths``."""
-    assert max_per_bin is not None
-    if balance_by_flops:
-        total_tokens = sum(step_lengths)
-        micro_batch_count = max(1, (total_tokens + max_per_bin - 1) // max_per_bin)
-        if micro_batch_count >= len(step_lengths):
-            return [[i] for i in range(len(step_lengths))]
-        else:
-            workloads = _calculate_workloads(step_lengths, args)
-            # NOTE: FLOPs balancing does not enforce the token cap per micro-batch.
-            return get_seqlen_balanced_partitions(workloads, micro_batch_count, equal_size=False)
-    return first_fit_decreasing_pack(step_lengths, max_per_bin)
-
-
-def _pack_micro_batches_static(step_lengths: list[int], *, micro_batch_size: int) -> list[list[int]]:
-    """Fixed-size chunks of ``micro_batch_size`` samples.
-    Returns ``micro_batches[k]`` = local indices into ``step_lengths``."""
-    assert micro_batch_size is not None
-    n = len(step_lengths)
-    return [list(range(i, min(i + micro_batch_size, n))) for i in range(0, n, micro_batch_size)]
-
-
 def build_dp_schedule(
     args: Any,
     train_parallel_config: dict,
@@ -121,13 +91,20 @@ def build_dp_schedule(
         )
 
         balance_by_flops = getattr(args, "balance_by_flops", False)
+        # Shared by FLOPs-balanced packing and FLOPs-balanced distribution below.
+        workloads = _calculate_workloads(step_lengths, args) if balance_by_flops else None
         if args.use_dynamic_batch_size:
-            step_micro_batches = _pack_micro_batches_dynamic(
-                step_lengths,
-                args=args,
-                max_per_bin=max_per_bin,
-                balance_by_flops=balance_by_flops,
-            )
+            # Pack under the token budget: first-fit, or FLOPs-balanced partitions under
+            # --balance-by-flops (which does not enforce the token cap per micro-batch).
+            if balance_by_flops:
+                total_tokens = sum(step_lengths)
+                micro_batch_count = max(1, (total_tokens + max_per_bin - 1) // max_per_bin)
+                if micro_batch_count >= len(step_lengths):
+                    step_micro_batches = [[i] for i in range(len(step_lengths))]
+                else:
+                    step_micro_batches = get_seqlen_balanced_partitions(workloads, micro_batch_count, equal_size=False)
+            else:
+                step_micro_batches = first_fit_decreasing_pack(step_lengths, max_per_bin)
             # Grow the micro-batch count to a multiple of align_to by splitting multi-sample micro-batches.
             target = max((len(step_micro_batches) + align_to - 1) // align_to * align_to, align_to)
             if target != len(step_micro_batches):
@@ -138,9 +115,12 @@ def build_dp_schedule(
                     f"alignment threshold ({align_to})."
                 )
         else:
-            step_micro_batches = _pack_micro_batches_static(
-                step_lengths, micro_batch_size=getattr(args, "micro_batch_size", None)
-            )
+            # Fixed-size chunks of micro_batch_size samples.
+            assert args.micro_batch_size is not None
+            n = len(step_lengths)
+            step_micro_batches = [
+                list(range(i, min(i + args.micro_batch_size, n))) for i in range(0, n, args.micro_batch_size)
+            ]
             if len(step_micro_batches) % align_to != 0:
                 raise AssertionError(
                     f"static path: micro-batch count ({len(step_micro_batches)}) is not a multiple of "
@@ -158,7 +138,6 @@ def build_dp_schedule(
         # FLOPs under --balance-by-flops).
         if args.balance_data or balance_by_flops:
             if balance_by_flops:
-                workloads = _calculate_workloads(step_lengths, args)
                 weights = [sum(workloads[i] for i in micro_batch) for micro_batch in step_micro_batches]
             else:
                 weights = [sum(step_lengths[i] for i in micro_batch) for micro_batch in step_micro_batches]

--- a/miles/utils/dp_schedule.py
+++ b/miles/utils/dp_schedule.py
@@ -106,7 +106,7 @@ def build_dp_schedule(
     num_microbatches: list[int] = []
 
     step_start = 0
-    for step_num_rollouts in num_rollouts:
+    for step_i, step_num_rollouts in enumerate(num_rollouts):
         picked_rollouts = rollout_ids[step_start : step_start + step_num_rollouts]
         step_start += step_num_rollouts
         sample_indices = [pos for rid in picked_rollouts for pos in rollout_id_to_sample_index[rid]]
@@ -129,15 +129,22 @@ def build_dp_schedule(
         # Grow the micro-batch count to a multiple of align_to by splitting multi-sample micro-batches.
         target = max((len(step_micro_batches) + align_to - 1) // align_to * align_to, align_to)
         if target != len(step_micro_batches):
-            if not args.use_dynamic_batch_size:
-                raise AssertionError(
-                    f"static path: micro-batch count ({len(step_micro_batches)}) is not a multiple of {align_to}; "
-                    f"adjust the config so step_size % (dp_size * micro_batch_size * mb_group) == 0."
+            if args.use_dynamic_batch_size:
+                expand_bins_by_splitting(step_micro_batches, target, step_lengths)
+                assert len(step_micro_batches) == target, (
+                    f"dynamic path: could only produce {len(step_micro_batches)} micro-batches after maximal "
+                    f"splitting; need {target}. step {step_i} has {len(sample_indices)} samples, below the "
+                    f"alignment threshold ({align_to})."
                 )
-            expand_bins_by_splitting(step_micro_batches, target, step_lengths)
-            assert (
-                len(step_micro_batches) == target
-            ), f"could only produce {len(step_micro_batches)} micro-batches after maximal splitting; need {target}."
+            else:
+                raise AssertionError(
+                    f"static path: micro-batch count ({len(step_micro_batches)}) is not a multiple of "
+                    f"dp_size * mb_group ({align_to}); got "
+                    f"step_size={len(sample_indices)}, micro_batch_size={args.micro_batch_size}, "
+                    f"dp_size={dp_size}, mb_group={mb_group if vpp_size > 1 else 1}. "
+                    f"Splitting static micro-batches would break the fixed-size invariant; adjust the config "
+                    f"so step_size % (dp_size * micro_batch_size * mb_group) == 0."
+                )
 
         num_microbatches.append(len(step_micro_batches) // dp_size)
 

--- a/tests/fast/utils/test_arguments.py
+++ b/tests/fast/utils/test_arguments.py
@@ -252,6 +252,15 @@ def test_custom_megatron_post_save_hook_path_requires_save():
         miles_validate_args(args)
 
 
+def test_dynamic_global_batch_size_requires_dynamic_batch_size():
+    parser = argparse.ArgumentParser()
+    get_miles_extra_args_provider()(parser)
+    args = parser.parse_args(["--use-dynamic-global-batch-size", "--num-rollout", "1"] + REQUIRED_ARGS)
+
+    with pytest.raises(AssertionError, match="requires --use-dynamic-batch-size"):
+        miles_validate_args(args)
+
+
 class TestTitoFixedTemplateConfiguration:
     def _parse(self, extra):
         parser = argparse.ArgumentParser()


### PR DESCRIPTION
> **Depends on:** #1927
> Stacked on the parent PR's branch. Review / merge the parent first.

## Summary
Fail at launch, not mid-run, when static micro-batching cannot satisfy the DP schedule alignment.

## Symptom & Reproduction
- **Symptom:** a static-batch run under `--use-dynamic-global-batch-size` trains normally for many steps, then dies in `build_dp_schedule` with `static path: micro-batch count ... is not a multiple of dp_size * mb_group`; the message's "adjust the config" advice is unsatisfiable because `step_size` is data, not config.
- **Reproduction:** `dp_size=2`, `micro_batch_size=2`, one step whose rollouts yield 5 samples: `ceil(5/2)=3` micro-batches, `3 % 2 != 0`, raise.

## Root Cause
1. `_pack_micro_batches_static` emits `ceil(step_size / micro_batch_size)` micro-batches.
2. `step_size` varies per step under compact rollouts and `--use-dynamic-global-batch-size`.
3. `build_dp_schedule` requires the count to be a multiple of `dp_size * mb_group`.
4. The static path has no counterpart of `expand_bins_by_splitting`, so misalignment is fatal.

## Fix
`miles_validate_args` rejects `--use-dynamic-global-batch-size` without `--use-dynamic-batch-size`, turning the data-dependent mid-run death into a launch-time error. The runtime raise stays as defense in depth; the launch guard removes the only config combination that makes it fire nondeterministically. Multi-LoRA is exempt: it auto-enables dynamic global batch size but `can_schedule_on_rollout_side` excludes it, so it keeps the legacy training-side schedule. Compact rollouts with a fixed global batch size stay guarded at runtime only, because compactness is a property of the generate fn and invisible at argument-parse time. The two refactor-tail commits make each packing path own its alignment handling so the static raise sits next to the packing it protects.

## Verification
- **New / updated test:** `test_dynamic_global_batch_size_requires_dynamic_batch_size` asserts the launch-time rejection.
- **Existing suites:** `tests/fast/utils/test_arguments.py`, `test_dp_schedule.py`, `test_lora_arguments.py` — 84 passed.

## Review Focus
- Scrutinize the `not args.multi_lora` exemption in `miles_validate_args`: multi-LoRA legitimately runs static under its auto-enabled dynamic global batch size.
- Scrutinize the residual static exposure: with a fixed global batch size `step_size` is constant, so the runtime raise fires at the first schedule build or never, except when compact rollouts first appear mid-run.
