### PR TITLE
megatron: name the tensors behind a non-finite grad norm

### DIFF
--- a/miles/backends/megatron_utils/misc_utils.py
+++ b/miles/backends/megatron_utils/misc_utils.py
@@ -1,3 +1,11 @@
+import logging
+from collections.abc import Iterable
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+
 def strip_param_name_prefix(name: str | None) -> str | None:
     if name is None:
         return None
@@ -5,3 +13,34 @@ def strip_param_name_prefix(name: str | None) -> str | None:
     while name.startswith(prefix):
         name = name.removeprefix(prefix)
     return name
+
+
+def report_nonfinite_grads(
+    named_params: Iterable[tuple[str, torch.nn.Parameter]], header: str, limit: int = 12
+) -> None:
+    """Log which of the given params' grads are non-finite (and how many are NaN), plus the ones that stayed finite.
+
+    Worth the walk: a non-finite grad norm is otherwise a bare ``train/grad_norm = nan``
+    alongside a perfectly finite loss, which says nothing about where it came from. The
+    finite minority is what localises the fault: gradients flow from the loss down, so the
+    shallowest clean tensor sits just above the layer that first went non-finite.
+    """
+    bad: list[str] = []
+    good: list[str] = []
+    n_nan = 0
+    for name, param in named_params:
+        grad = getattr(param, "main_grad", None)
+        if grad is None:
+            grad = param.grad
+        if grad is None:
+            continue
+        if torch.isfinite(grad).all():
+            good.append(name)
+            continue
+        bad.append(name)
+        n_nan += int(torch.isnan(grad).any())
+    total = len(bad) + len(good)
+    logger.error(
+        f"{header}: {len(bad)}/{total} grads are non-finite, {n_nan} of them NaN; "
+        f"first {limit} non-finite: {bad[:limit]}; all {len(good)} finite: {good[:64]}"
+    )

--- a/miles/backends/megatron_utils/model.py
+++ b/miles/backends/megatron_utils/model.py
@@ -402,6 +402,40 @@ def _zero_grads(model: Sequence[DDP], optimizer: MegatronOptimizer | None, disab
         optimizer.zero_grad()
 
 
+def _report_nonfinite_grads(model: Sequence[DDP], rollout_id: int, step_id: int, limit: int = 12) -> None:
+    """Name the trainable tensors behind a non-finite grad norm.
+
+    Worth the walk: a non-finite norm is otherwise reported as a bare ``train/grad_norm = nan``
+    alongside a perfectly finite loss, which says nothing about where it came from.
+    """
+    bad: list[str] = []
+    good: list[str] = []
+    n_nan = 0
+    for model_chunk in model:
+        for name, param in model_chunk.named_parameters():
+            if not param.requires_grad:
+                continue
+            grad = getattr(param, "main_grad", None)
+            if grad is None:
+                grad = param.grad
+            if grad is None:
+                continue
+            if torch.isfinite(grad).all():
+                good.append(name)
+                continue
+            bad.append(name)
+            n_nan += int(torch.isnan(grad).any())
+    total = len(bad) + len(good)
+    # The finite minority is what localises the fault: gradients flow from the loss down, so
+    # the shallowest clean tensor sits just above the layer that first went non-finite.
+    logger.error(
+        f"rollout {rollout_id} step {step_id}: grad norm is non-finite; {len(bad)}/{total} "
+        f"trainable grads are non-finite, {n_nan} of them NaN; "
+        f"first {limit} non-finite: {bad[:limit]}; "
+        f"all {len(good)} finite: {good[:64]}"
+    )
+
+
 def train_one_step(
     args: Namespace,
     rollout_id: int,
@@ -587,6 +621,8 @@ def train_one_step(
                 valid_step = not (torch.isnan(grad_norm) or torch.isinf(grad_norm))
             else:
                 valid_step = not (math.isnan(grad_norm) or math.isinf(grad_norm))
+            if not valid_step:
+                _report_nonfinite_grads(model, rollout_id=rollout_id, step_id=step_id)
 
     # CI check: verify only MTP parameters have non-zero gradients when truncation happens
     # This check must happen before optimizer.step() as gradients may be modified during step

--- a/miles/backends/megatron_utils/model.py
+++ b/miles/backends/megatron_utils/model.py
@@ -405,10 +405,7 @@ def _zero_grads(model: Sequence[DDP], optimizer: MegatronOptimizer | None, disab
 
 def _report_nonfinite_grads(model: Sequence[DDP], rollout_id: int, step_id: int) -> None:
     named = (
-        (name, param)
-        for model_chunk in model
-        for name, param in model_chunk.named_parameters()
-        if param.requires_grad
+        (name, param) for model_chunk in model for name, param in model_chunk.named_parameters() if param.requires_grad
     )
     report_nonfinite_grads(named, header=f"rollout {rollout_id} step {step_id}: grad norm is non-finite")
 

--- a/miles/backends/megatron_utils/model.py
+++ b/miles/backends/megatron_utils/model.py
@@ -28,6 +28,7 @@ from megatron.training.training import get_model
 from miles.backends.megatron_utils.ft.indep_dp import allreduce_grads_and_losses_across_replicas
 from miles.backends.megatron_utils.ft.types import TrainStepOutcome
 from miles.backends.megatron_utils.local_weight_checksum import dump_local_weight_checksums
+from miles.backends.megatron_utils.misc_utils import report_nonfinite_grads
 from miles.utils.audit_utils.witness.allocator import WitnessInfo
 from miles.utils.audit_utils.witness.module import witness_dump_and_clear_stale
 from miles.utils.dumper_utils import DumperMegatronUtil, DumperPhase
@@ -402,38 +403,14 @@ def _zero_grads(model: Sequence[DDP], optimizer: MegatronOptimizer | None, disab
         optimizer.zero_grad()
 
 
-def _report_nonfinite_grads(model: Sequence[DDP], rollout_id: int, step_id: int, limit: int = 12) -> None:
-    """Name the trainable tensors behind a non-finite grad norm.
-
-    Worth the walk: a non-finite norm is otherwise reported as a bare ``train/grad_norm = nan``
-    alongside a perfectly finite loss, which says nothing about where it came from.
-    """
-    bad: list[str] = []
-    good: list[str] = []
-    n_nan = 0
-    for model_chunk in model:
-        for name, param in model_chunk.named_parameters():
-            if not param.requires_grad:
-                continue
-            grad = getattr(param, "main_grad", None)
-            if grad is None:
-                grad = param.grad
-            if grad is None:
-                continue
-            if torch.isfinite(grad).all():
-                good.append(name)
-                continue
-            bad.append(name)
-            n_nan += int(torch.isnan(grad).any())
-    total = len(bad) + len(good)
-    # The finite minority is what localises the fault: gradients flow from the loss down, so
-    # the shallowest clean tensor sits just above the layer that first went non-finite.
-    logger.error(
-        f"rollout {rollout_id} step {step_id}: grad norm is non-finite; {len(bad)}/{total} "
-        f"trainable grads are non-finite, {n_nan} of them NaN; "
-        f"first {limit} non-finite: {bad[:limit]}; "
-        f"all {len(good)} finite: {good[:64]}"
+def _report_nonfinite_grads(model: Sequence[DDP], rollout_id: int, step_id: int) -> None:
+    named = (
+        (name, param)
+        for model_chunk in model
+        for name, param in model_chunk.named_parameters()
+        if param.requires_grad
     )
+    report_nonfinite_grads(named, header=f"rollout {rollout_id} step {step_id}: grad norm is non-finite")
 
 
 def train_one_step(


### PR DESCRIPTION
## What

When a training step is skipped because the grad norm is non-finite, log which trainable gradients are non-finite (and how many of those are NaN), plus the list of tensors whose gradients stayed finite. No behavior change on healthy steps.

The walk-and-log logic lives in `misc_utils.report_nonfinite_grads` so the multi-LoRA per-slot gate (#2078, stacked on this PR) can reuse it instead of carrying its own copy; `model.py` keeps a thin wrapper that feeds it every model chunk's trainable params.

## Why

Today the only symptom of a non-finite gradient is `train/grad_norm = nan` next to a perfectly finite loss, which gives no clue where the corruption entered the network.

Gradients flow from the loss downward, so the shallowest tensor with a *clean* gradient sits just above the layer that first produced a non-finite value. Printing the finite list alongside the non-finite one brackets the faulty layer immediately; the offender list alone cannot do that because it is emitted in parameter-name order.

The walk only runs on steps that are already invalid and skipped, so there is no steady-state cost.

This report is how a NaN gradient on 4-node H200 GLM-5.2 744B-A40B LoRA runs was localised to the sparse-MLA backward kernel (fixed separately in #2079).
