### PR TITLE
Cap train-actor torch memory via MILES_TRAIN_MEMORY_FRACTION

### DIFF
--- a/miles/backends/megatron_utils/actor.py
+++ b/miles/backends/megatron_utils/actor.py
@@ -149,6 +149,15 @@ class MegatronTrainRayActor(TrainRayActor):
         self.train_parallel_config = {} if args.indep_dp else {"dp_size": get_parallel_state().intra_dp.size}
         dist.barrier(group=get_gloo_group())
 
+        # NCCL allocates outside torch's caching allocator, so allocator knobs alone
+        # cannot keep memory free for it: gc_threshold is relative to the per-process
+        # cap, which defaults to the whole device. A hard cap forces the allocator to
+        # release cached blocks instead of growing reserved until NCCL's cudaMalloc
+        # during backward finds 0 bytes free.
+        if (frac := float(os.environ.get("MILES_TRAIN_MEMORY_FRACTION", "0"))) > 0:
+            torch.cuda.set_per_process_memory_fraction(frac)
+            logger.info(f"Set torch per-process CUDA memory fraction to {frac}")
+
         if args.offload_train:
             if (x := args.train_memory_margin_bytes) > 0:
                 # --train-memory-margin-bytes can tune this


### PR DESCRIPTION
## What

Add an opt-in `MILES_TRAIN_MEMORY_FRACTION` environment variable. When set to a value > 0, the Megatron train actor calls `torch.cuda.set_per_process_memory_fraction(...)` at startup. Unset (the default) changes nothing.

## Why

NCCL allocates its buffers with `cudaMalloc`, outside torch's caching allocator, so torch's own allocator knobs cannot reliably keep memory free for it: `PYTORCH_CUDA_ALLOC_CONF=garbage_collection_threshold` is relative to the per-process cap, which defaults to the whole device. The caching allocator therefore keeps growing its reserved pool until NCCL finds 0 bytes free mid-backward, and the step dies with an OOM raised from inside NCCL even though torch's *allocated* memory is far below the device capacity.

A hard per-process cap makes the allocator release cached blocks once it reaches the cap instead of growing reserved memory without bound. On a 4-node H200 GLM-5.2 744B-A40B LoRA run this was the difference between reserved memory growing to ~113 GiB against ~57 GiB actually allocated (then NCCL OOMing during backward) and a stable run.

An env var rather than a CLI flag keeps this out of the argument surface: it is a workaround knob for tight-memory configurations, not a tuning parameter most runs should touch.
