### PR TITLE
[Sampling Replay 1/8] Add sampling-support log-prob primitives

### DIFF
--- a/miles/backends/training_utils/loss_hub/logit_processors.py
+++ b/miles/backends/training_utils/loss_hub/logit_processors.py
@@ -7,6 +7,7 @@ from miles.backends.training_utils.cp_utils import allgather_cp_redistribute, ge
 from miles.backends.training_utils.loss_hub.math_utils import calculate_log_probs_and_entropy
 from miles.backends.training_utils.parallel import get_parallel_state
 from miles.backends.training_utils.sampling_mask import build_local_sampling_mask
+from miles.utils.sampling_mask import RolloutSamplingMask
 
 
 def _iter_response_chunks(
@@ -191,7 +192,7 @@ def get_log_probs_and_entropy(
     entropy_requires_grad: bool = True,
     non_loss_data: bool = True,
     max_seq_lens: list[int] | None = None,
-    rollout_sampling_mask: list[list[list[int]]] | None = None,
+    rollout_sampling_mask: Sequence[RolloutSamplingMask] | None = None,
 ) -> dict[str, list[torch.Tensor]]:
     """Compute per-token log-probabilities (and optionally entropy) on responses.
 
@@ -210,8 +211,8 @@ def get_log_probs_and_entropy(
         entropy_requires_grad: If False, compute entropy as an observed metric
             without attaching it to the autograd graph.
         non_loss_data: Unused; kept for API compatibility.
-        rollout_sampling_mask: Sampling-support token IDs for each response
-            token of each sample.
+        rollout_sampling_mask: One ``RolloutSamplingMask`` per sample,
+            covering every response token.
 
     Returns:
         Dict with key "log_probs" mapping to a list of `[R]` tensors per
@@ -220,6 +221,8 @@ def get_log_probs_and_entropy(
     """
     assert non_loss_data
     if rollout_sampling_mask is not None:
+        if isinstance(rollout_sampling_mask, RolloutSamplingMask):
+            raise TypeError("rollout_sampling_mask must be a sequence of RolloutSamplingMask, one per sample")
         mask_batch_size = len(rollout_sampling_mask)
         response_batch_size = len(response_lengths)
         if mask_batch_size != response_batch_size:

--- a/miles/backends/training_utils/loss_hub/logit_processors.py
+++ b/miles/backends/training_utils/loss_hub/logit_processors.py
@@ -221,14 +221,6 @@ def get_log_probs_and_entropy(
     """
     assert non_loss_data
     if rollout_sampling_mask is not None:
-        if isinstance(rollout_sampling_mask, RolloutSamplingMask):
-            raise TypeError("rollout_sampling_mask must be a sequence of RolloutSamplingMask, one per sample")
-        mask_batch_size = len(rollout_sampling_mask)
-        response_batch_size = len(response_lengths)
-        if mask_batch_size != response_batch_size:
-            raise ValueError(
-                f"sampling-mask batch size {mask_batch_size} != response batch size {response_batch_size}"
-            )
         for sample_index, (sampling_mask, response_length) in enumerate(
             zip(rollout_sampling_mask, response_lengths, strict=True)
         ):

--- a/miles/backends/training_utils/loss_hub/logit_processors.py
+++ b/miles/backends/training_utils/loss_hub/logit_processors.py
@@ -1,14 +1,15 @@
 from argparse import Namespace
-from collections.abc import Iterator
+from collections.abc import Iterator, Sequence
 
 import torch
 
 from miles.backends.training_utils.cp_utils import allgather_cp_redistribute, get_logits_and_tokens_offset_with_cp
 from miles.backends.training_utils.loss_hub.math_utils import calculate_log_probs_and_entropy
 from miles.backends.training_utils.parallel import get_parallel_state
+from miles.backends.training_utils.sampling_mask import build_local_sampling_mask
 
 
-def get_responses(
+def _iter_response_chunks(
     logits: torch.Tensor,
     *,
     args: Namespace,
@@ -16,8 +17,9 @@ def get_responses(
     total_lengths: list[int],
     response_lengths: list[int],
     max_seq_lens: list[int] | None = None,
-) -> Iterator[tuple[torch.Tensor, torch.Tensor]]:
-    """Yield response-aligned `(logits_chunk, tokens_chunk)` pairs per sample.
+    include_response_indices: bool,
+) -> Iterator[tuple[torch.Tensor, torch.Tensor, Sequence[int]]]:
+    """Yield response logits, tokens, and original response indices per sample.
 
     After squeezing batch dimension and applying temperature scaling, this
     function extracts the logits and tokens corresponding to response segments
@@ -34,9 +36,11 @@ def get_responses(
         response_lengths: Response segment lengths per sample.
 
     Yields:
-        Tuple of `(logits_chunk, tokens_chunk)` where `logits_chunk` is shape
-        `[R, V]` (policy) or `[R, 1]` (value) and `tokens_chunk` is shape `[R]`
-        (1D int64), both aligned to response tokens for one sample.
+        Tuple of `(logits_chunk, tokens_chunk, response_indices)`, where
+        `logits_chunk` is shape `[R, V]` (policy) or `[R, 1]` (value), and
+        `tokens_chunk` is shape `[R]` (1D int64). `response_indices` maps every
+        local row back to the full response. The mapping is empty when
+        `include_response_indices` is false.
     """
     qkv_format = args.qkv_format
 
@@ -78,7 +82,8 @@ def get_responses(
                 end += total_length
                 start = end - response_length
                 logits_chunk = logits[start - 1 : end - 1]
-            tokens_chunk = tokens[-response_length:]
+            tokens_chunk = tokens[-response_length:] if response_length else tokens[0:0]
+            response_indices = range(response_length) if include_response_indices else ()
         elif args.allgather_cp:
             # DSA: global concat then contiguous CP split. Each rank owns logits for
             # global positions [chunk_start, chunk_end).
@@ -98,9 +103,18 @@ def get_responses(
             if e <= s:
                 logits_chunk = logits[0:0]
                 tokens_chunk = tokens[0:0]
+                response_indices = ()
             else:
                 logits_chunk = logits[s - chunk_start : e - chunk_start]
                 tokens_chunk = tokens[(s + 1) - seq_start : (e + 1) - seq_start]
+                response_indices = (
+                    range(
+                        s - logit_global_start,
+                        e - logit_global_start,
+                    )
+                    if include_response_indices
+                    else ()
+                )
             assert logits_chunk.size(0) == tokens_chunk.size(0), f"{logits_chunk.size(0)} vs {tokens_chunk.size(0)}"
         else:
             # TODO: this is super ugly... do better abstraction.
@@ -122,9 +136,47 @@ def get_responses(
 
             logits_chunk = torch.cat([logits_0, logits_1], dim=0)
             tokens_chunk = torch.cat([tokens_0, tokens_1], dim=0)
+            if include_response_indices:
+                prompt_length = total_length - response_length
+                response_indices = [
+                    *range(
+                        tokens_offset[0][0] - prompt_length,
+                        tokens_offset[0][1] - prompt_length,
+                    ),
+                    *range(
+                        tokens_offset[1][0] - prompt_length,
+                        tokens_offset[1][1] - prompt_length,
+                    ),
+                ]
+            else:
+                response_indices = ()
 
         seq_start += total_length
 
+        if include_response_indices:
+            assert len(response_indices) == tokens_chunk.size(0)
+        yield logits_chunk, tokens_chunk, response_indices
+
+
+def get_responses(
+    logits: torch.Tensor,
+    *,
+    args: Namespace,
+    unconcat_tokens: list[torch.Tensor],
+    total_lengths: list[int],
+    response_lengths: list[int],
+    max_seq_lens: list[int] | None = None,
+) -> Iterator[tuple[torch.Tensor, torch.Tensor]]:
+    """Yield response-aligned `(logits_chunk, tokens_chunk)` pairs per sample."""
+    for logits_chunk, tokens_chunk, _ in _iter_response_chunks(
+        logits,
+        args=args,
+        unconcat_tokens=unconcat_tokens,
+        total_lengths=total_lengths,
+        response_lengths=response_lengths,
+        max_seq_lens=max_seq_lens,
+        include_response_indices=False,
+    ):
         yield logits_chunk, tokens_chunk
 
 
@@ -139,6 +191,8 @@ def get_log_probs_and_entropy(
     entropy_requires_grad: bool = True,
     non_loss_data: bool = True,
     max_seq_lens: list[int] | None = None,
+    rollout_sampling_mask_ids: Sequence[Sequence[int] | torch.Tensor] | None = None,
+    rollout_sampling_mask_offsets: Sequence[Sequence[int] | torch.Tensor] | None = None,
 ) -> dict[str, list[torch.Tensor]]:
     """Compute per-token log-probabilities (and optionally entropy) on responses.
 
@@ -157,6 +211,10 @@ def get_log_probs_and_entropy(
         entropy_requires_grad: If False, compute entropy as an observed metric
             without attaching it to the autograd graph.
         non_loss_data: Unused; kept for API compatibility.
+        rollout_sampling_mask_ids: Flattened sampling-support token IDs for
+            each sample.
+        rollout_sampling_mask_offsets: CSR offsets delimiting one support per
+            response token for each sample.
 
     Returns:
         Dict with key "log_probs" mapping to a list of `[R]` tensors per
@@ -164,17 +222,40 @@ def get_log_probs_and_entropy(
         a list of `[R]` tensors.
     """
     assert non_loss_data
+    if (rollout_sampling_mask_ids is None) != (rollout_sampling_mask_offsets is None):
+        raise ValueError("rollout sampling mask ids and offsets must either both be provided or both be omitted")
+    if rollout_sampling_mask_ids is not None:
+        mask_batch_size = len(rollout_sampling_mask_ids)
+        offsets_batch_size = len(rollout_sampling_mask_offsets)
+        response_batch_size = len(response_lengths)
+        if mask_batch_size != response_batch_size or offsets_batch_size != response_batch_size:
+            raise ValueError(
+                "sampling-mask batch sizes must match the response batch: "
+                f"ids={mask_batch_size}, offsets={offsets_batch_size}, responses={response_batch_size}"
+            )
     parallel_state = get_parallel_state()
     log_probs_list = []
     entropy_list = []
-    for logits_chunk, tokens_chunk in get_responses(
+    response_chunks = _iter_response_chunks(
         logits,
         args=args,
         unconcat_tokens=unconcat_tokens,
         total_lengths=total_lengths,
         response_lengths=response_lengths,
         max_seq_lens=max_seq_lens,
-    ):
+        include_response_indices=rollout_sampling_mask_ids is not None,
+    )
+    for sample_index, (logits_chunk, tokens_chunk, response_indices) in enumerate(response_chunks):
+        sampling_mask = None
+        if rollout_sampling_mask_ids is not None:
+            sampling_mask = build_local_sampling_mask(
+                logits_chunk,
+                rollout_sampling_mask_ids[sample_index],
+                rollout_sampling_mask_offsets[sample_index],
+                response_indices,
+                response_length=response_lengths[sample_index],
+                tp_rank=parallel_state.tp.rank,
+            )
         log_prob, entropy = calculate_log_probs_and_entropy(
             logits_chunk,
             tokens_chunk,
@@ -184,6 +265,7 @@ def get_log_probs_and_entropy(
             chunk_size=args.log_probs_chunk_size,
             true_on_policy=args.true_on_policy_mode,
             vocab_size=getattr(args, "vocab_size", None),
+            sampling_mask=sampling_mask,
         )
 
         log_probs_list.append(log_prob.squeeze(-1))

--- a/miles/backends/training_utils/loss_hub/logit_processors.py
+++ b/miles/backends/training_utils/loss_hub/logit_processors.py
@@ -191,8 +191,7 @@ def get_log_probs_and_entropy(
     entropy_requires_grad: bool = True,
     non_loss_data: bool = True,
     max_seq_lens: list[int] | None = None,
-    rollout_sampling_mask_ids: Sequence[Sequence[int] | torch.Tensor] | None = None,
-    rollout_sampling_mask_offsets: Sequence[Sequence[int] | torch.Tensor] | None = None,
+    rollout_sampling_mask: list[list[list[int]]] | None = None,
 ) -> dict[str, list[torch.Tensor]]:
     """Compute per-token log-probabilities (and optionally entropy) on responses.
 
@@ -211,10 +210,8 @@ def get_log_probs_and_entropy(
         entropy_requires_grad: If False, compute entropy as an observed metric
             without attaching it to the autograd graph.
         non_loss_data: Unused; kept for API compatibility.
-        rollout_sampling_mask_ids: Flattened sampling-support token IDs for
-            each sample.
-        rollout_sampling_mask_offsets: CSR offsets delimiting one support per
-            response token for each sample.
+        rollout_sampling_mask: Sampling-support token IDs for each response
+            token of each sample.
 
     Returns:
         Dict with key "log_probs" mapping to a list of `[R]` tensors per
@@ -222,17 +219,21 @@ def get_log_probs_and_entropy(
         a list of `[R]` tensors.
     """
     assert non_loss_data
-    if (rollout_sampling_mask_ids is None) != (rollout_sampling_mask_offsets is None):
-        raise ValueError("rollout sampling mask ids and offsets must either both be provided or both be omitted")
-    if rollout_sampling_mask_ids is not None:
-        mask_batch_size = len(rollout_sampling_mask_ids)
-        offsets_batch_size = len(rollout_sampling_mask_offsets)
+    if rollout_sampling_mask is not None:
+        mask_batch_size = len(rollout_sampling_mask)
         response_batch_size = len(response_lengths)
-        if mask_batch_size != response_batch_size or offsets_batch_size != response_batch_size:
+        if mask_batch_size != response_batch_size:
             raise ValueError(
-                "sampling-mask batch sizes must match the response batch: "
-                f"ids={mask_batch_size}, offsets={offsets_batch_size}, responses={response_batch_size}"
+                f"sampling-mask batch size {mask_batch_size} != response batch size {response_batch_size}"
             )
+        for sample_index, (sampling_mask, response_length) in enumerate(
+            zip(rollout_sampling_mask, response_lengths, strict=True)
+        ):
+            if len(sampling_mask) != response_length:
+                raise ValueError(
+                    f"sampling-mask length {len(sampling_mask)} != response length "
+                    f"{response_length} for sample {sample_index}"
+                )
     parallel_state = get_parallel_state()
     log_probs_list = []
     entropy_list = []
@@ -243,17 +244,15 @@ def get_log_probs_and_entropy(
         total_lengths=total_lengths,
         response_lengths=response_lengths,
         max_seq_lens=max_seq_lens,
-        include_response_indices=rollout_sampling_mask_ids is not None,
+        include_response_indices=rollout_sampling_mask is not None,
     )
     for sample_index, (logits_chunk, tokens_chunk, response_indices) in enumerate(response_chunks):
         sampling_mask = None
-        if rollout_sampling_mask_ids is not None:
+        if rollout_sampling_mask is not None:
             sampling_mask = build_local_sampling_mask(
                 logits_chunk,
-                rollout_sampling_mask_ids[sample_index],
-                rollout_sampling_mask_offsets[sample_index],
+                rollout_sampling_mask[sample_index],
                 response_indices,
-                response_length=response_lengths[sample_index],
                 tp_rank=parallel_state.tp.rank,
             )
         log_prob, entropy = calculate_log_probs_and_entropy(

--- a/miles/backends/training_utils/loss_hub/math_utils.py
+++ b/miles/backends/training_utils/loss_hub/math_utils.py
@@ -284,7 +284,9 @@ def compute_log_probs(
     *,
     true_on_policy_mode: bool = False,
     vocab_size: int | None = None,
+    sampling_mask: torch.Tensor | None = None,
 ):
+    logits = _apply_sampling_mask(logits, sampling_mask, inplace=not true_on_policy_mode)
     if true_on_policy_mode:
         full_logits = _gather_true_on_policy_full_logits(logits, process_group, vocab_size=vocab_size)
         log_probs = torch.log_softmax(full_logits, dim=-1)
@@ -297,6 +299,21 @@ def compute_log_probs(
     logits = logits.unsqueeze(1)
     tokens = tokens.unsqueeze(1)
     return -fused_vocab_parallel_cross_entropy(logits, tokens, process_group)
+
+
+def _apply_sampling_mask(
+    logits: torch.Tensor,
+    sampling_mask: torch.Tensor | None,
+    *,
+    inplace: bool = False,
+) -> torch.Tensor:
+    if sampling_mask is None:
+        return logits
+    if sampling_mask.shape != logits.shape:
+        raise ValueError(f"sampling mask shape {sampling_mask.shape} != logits shape {logits.shape}")
+    if inplace:
+        return logits.masked_fill_(~sampling_mask, float("-inf"))
+    return logits.masked_fill(~sampling_mask, float("-inf"))
 
 
 def _prepare_true_on_policy_full_logits(
@@ -941,6 +958,7 @@ def calculate_log_probs_and_entropy(
     chunk_size: int = -1,
     true_on_policy: bool = False,
     vocab_size: int | None = None,
+    sampling_mask: torch.Tensor | None = None,
 ):
     if true_on_policy:
         return _calculate_log_probs_and_entropy_true_on_policy(
@@ -950,6 +968,7 @@ def calculate_log_probs_and_entropy(
             with_entropy=with_entropy,
             entropy_requires_grad=entropy_requires_grad,
             vocab_size=vocab_size,
+            sampling_mask=sampling_mask,
         )
 
     logits = logits.contiguous()
@@ -968,9 +987,19 @@ def calculate_log_probs_and_entropy(
             num_chunks = (logits.size(0) - 1) // chunk_size + 1
             tokens_chunks = tokens.chunk(num_chunks, dim=0)
             logits_chunks = logits.chunk(num_chunks, dim=0)
+            sampling_mask_chunks = (
+                sampling_mask.chunk(num_chunks, dim=0) if sampling_mask is not None else [None] * num_chunks
+            )
             log_probs = []
-            for tokens_chunk, logits_chunk in zip(tokens_chunks, logits_chunks, strict=True):
-                log_prob = compute_log_probs(logits_chunk.to(torch.float32, copy=True), tokens_chunk, tp_group)
+            for tokens_chunk, logits_chunk, sampling_mask_chunk in zip(
+                tokens_chunks, logits_chunks, sampling_mask_chunks, strict=True
+            ):
+                log_prob = compute_log_probs(
+                    logits_chunk.to(torch.float32, copy=True),
+                    tokens_chunk,
+                    tp_group,
+                    sampling_mask=sampling_mask_chunk,
+                )
                 log_probs.append(log_prob)
             log_prob = torch.cat(log_probs, dim=0)
             if with_entropy:
@@ -980,7 +1009,12 @@ def calculate_log_probs_and_entropy(
                     entropys.append(entropy)
                 entropy = torch.cat(entropys, dim=0)
         else:
-            log_prob = compute_log_probs(logits.to(torch.float32, copy=True), tokens, tp_group)
+            log_prob = compute_log_probs(
+                logits.to(torch.float32, copy=True),
+                tokens,
+                tp_group,
+                sampling_mask=sampling_mask,
+            )
             if with_entropy:
                 entropy = compute_entropy(logits)
     else:
@@ -998,6 +1032,7 @@ def _calculate_log_probs_and_entropy_true_on_policy(
     with_entropy: bool = False,
     entropy_requires_grad: bool = True,
     vocab_size: int | None = None,
+    sampling_mask: torch.Tensor | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor | None]:
     """True-on-policy log-prob and entropy computation matching SGLang's scoring contract.
 
@@ -1011,6 +1046,8 @@ def _calculate_log_probs_and_entropy_true_on_policy(
             without attaching it to the autograd graph.
         vocab_size: Real tokenizer vocab size. If provided, padded logits are
             truncated after the full-vocab gather and before ``log_softmax``.
+        sampling_mask: Optional local-vocabulary support used to normalize
+            log-probabilities. Entropy remains normalized over the full vocab.
 
     Returns:
         Tuple of ``(log_probs, entropy)`` where *log_probs* has shape ``[R]``
@@ -1021,7 +1058,8 @@ def _calculate_log_probs_and_entropy_true_on_policy(
         entropy = logits.new_zeros((0,)) if with_entropy else None
         return log_prob, entropy
 
-    full_logits = _gather_true_on_policy_full_logits(logits, tp_group, vocab_size=vocab_size)
+    log_prob_logits = _apply_sampling_mask(logits, sampling_mask)
+    full_logits = _gather_true_on_policy_full_logits(log_prob_logits, tp_group, vocab_size=vocab_size)
     _maybe_dump_top_logprob_backward("full_logits", full_logits)
     log_probs_full = torch.log_softmax(full_logits, dim=-1)
     _maybe_dump_top_logprob_backward("log_probs_full", log_probs_full)
@@ -1030,7 +1068,13 @@ def _calculate_log_probs_and_entropy_true_on_policy(
 
     entropy = None
     if with_entropy:
-        entropy_log_probs = log_probs_full if entropy_requires_grad else log_probs_full.detach()
+        if sampling_mask is None:
+            entropy_log_probs = log_probs_full
+        else:
+            entropy_logits = _gather_true_on_policy_full_logits(logits, tp_group, vocab_size=vocab_size)
+            entropy_log_probs = torch.log_softmax(entropy_logits, dim=-1)
+        if not entropy_requires_grad:
+            entropy_log_probs = entropy_log_probs.detach()
         probs = entropy_log_probs.exp()
         entropy = -(probs * entropy_log_probs).sum(dim=-1)
 

--- a/miles/backends/training_utils/sampling_mask.py
+++ b/miles/backends/training_utils/sampling_mask.py
@@ -1,0 +1,87 @@
+from collections.abc import Mapping, Sequence
+
+import torch
+
+
+def get_rollout_sampling_mask(batch: Mapping[str, object]) -> tuple[object, object]:
+    """Read the complete sampling mask required by an actor scoring pass."""
+    sampling_mask_ids = batch.get("rollout_sampling_mask_ids")
+    sampling_mask_offsets = batch.get("rollout_sampling_mask_offsets")
+    if sampling_mask_ids is None or sampling_mask_offsets is None:
+        raise ValueError(
+            "truncated-sampling actor scoring requires rollout_sampling_mask_ids and rollout_sampling_mask_offsets"
+        )
+    return sampling_mask_ids, sampling_mask_offsets
+
+
+def build_local_sampling_mask(
+    logits: torch.Tensor,
+    sampling_mask_ids: Sequence[int] | torch.Tensor,
+    sampling_mask_offsets: Sequence[int] | torch.Tensor,
+    response_indices: Sequence[int] | torch.Tensor,
+    *,
+    response_length: int,
+    tp_rank: int,
+) -> torch.Tensor:
+    """Build the dense local-vocabulary mask consumed by the log-prob primitive."""
+    ids = _to_cpu_integer_tensor(sampling_mask_ids)
+    offsets = _to_cpu_integer_tensor(sampling_mask_offsets)
+    indices = _to_cpu_integer_tensor(response_indices)
+
+    if indices.numel() != logits.size(0):
+        raise ValueError(
+            f"sampling-mask rows must align with logits: indices={indices.numel()}, logits={logits.size(0)}"
+        )
+    if offsets.numel() == 0 or offsets[0] != 0 or offsets[-1] != ids.numel():
+        raise ValueError("sampling-mask offsets must start at zero and end at the flattened id count")
+    if offsets.numel() != response_length + 1:
+        raise ValueError(
+            f"sampling-mask offsets length {offsets.numel()} != response length + 1 ({response_length + 1})"
+        )
+    if torch.any(offsets[1:] <= offsets[:-1]):
+        raise ValueError("every response token must have a non-empty sampling support")
+    if torch.any(indices < 0) or torch.any(indices >= response_length):
+        raise ValueError(f"response indices must be in [0, {response_length})")
+
+    local_vocab_size = logits.size(-1)
+    vocab_start = tp_rank * local_vocab_size
+    vocab_end = vocab_start + local_vocab_size
+    mask = torch.zeros(logits.numel(), dtype=torch.bool, device=logits.device)
+    if indices.numel() == 0:
+        return mask.view_as(logits)
+
+    indices = indices.to(torch.long)
+    lengths = offsets[indices + 1] - offsets[indices]
+    # CP response rows form a small number of contiguous runs. Slice those
+    # runs on CPU, then expand and TP-filter the CSR data on the GPU.
+    run_starts = [0]
+    run_starts.extend((torch.nonzero(indices[1:] != indices[:-1] + 1).flatten() + 1).tolist())
+    run_starts.append(indices.numel())
+    selected_parts = [
+        ids[offsets[indices[start]] : offsets[indices[end - 1] + 1]]
+        for start, end in zip(run_starts[:-1], run_starts[1:], strict=True)
+    ]
+    selected_ids = selected_parts[0] if len(selected_parts) == 1 else torch.cat(selected_parts)
+
+    selected_ids = selected_ids.to(logits.device)
+    row_indices = torch.repeat_interleave(
+        torch.arange(indices.numel(), dtype=torch.long, device=logits.device),
+        lengths.to(device=logits.device, dtype=torch.long),
+    )
+    is_local = (selected_ids >= vocab_start) & (selected_ids < vocab_end)
+    flat_local_indices = row_indices[is_local] * local_vocab_size + selected_ids[is_local].to(torch.long) - vocab_start
+    mask[flat_local_indices] = True
+    return mask.view_as(logits)
+
+
+def _to_cpu_integer_tensor(values: Sequence[int] | torch.Tensor) -> torch.Tensor:
+    if isinstance(values, torch.Tensor):
+        tensor = values.detach().cpu()
+    else:
+        if isinstance(values, range):
+            tensor = torch.arange(values.start, values.stop, values.step, device="cpu")
+        else:
+            tensor = torch.as_tensor(values, device="cpu")
+    if tensor.ndim != 1 or tensor.dtype == torch.bool or torch.is_floating_point(tensor) or torch.is_complex(tensor):
+        raise ValueError("sampling-mask ids, offsets, and response indices must be one-dimensional integers")
+    return tensor

--- a/miles/backends/training_utils/sampling_mask.py
+++ b/miles/backends/training_utils/sampling_mask.py
@@ -1,45 +1,34 @@
 from collections.abc import Mapping, Sequence
+from typing import cast
 
 import torch
 
 
-def get_rollout_sampling_mask(batch: Mapping[str, object]) -> tuple[object, object]:
+def get_rollout_sampling_mask(batch: Mapping[str, object]) -> list[list[list[int]]]:
     """Read the complete sampling mask required by an actor scoring pass."""
-    sampling_mask_ids = batch.get("rollout_sampling_mask_ids")
-    sampling_mask_offsets = batch.get("rollout_sampling_mask_offsets")
-    if sampling_mask_ids is None or sampling_mask_offsets is None:
-        raise ValueError(
-            "truncated-sampling actor scoring requires rollout_sampling_mask_ids and rollout_sampling_mask_offsets"
-        )
-    return sampling_mask_ids, sampling_mask_offsets
+    sampling_mask = batch.get("rollout_sampling_mask")
+    if sampling_mask is None:
+        raise ValueError("truncated-sampling actor scoring requires rollout_sampling_mask")
+    return cast(list[list[list[int]]], sampling_mask)
 
 
 def build_local_sampling_mask(
     logits: torch.Tensor,
-    sampling_mask_ids: Sequence[int] | torch.Tensor,
-    sampling_mask_offsets: Sequence[int] | torch.Tensor,
-    response_indices: Sequence[int] | torch.Tensor,
+    sampling_mask: list[list[int]],
+    response_indices: Sequence[int],
     *,
-    response_length: int,
     tp_rank: int,
 ) -> torch.Tensor:
     """Build the dense local-vocabulary mask consumed by the log-prob primitive."""
-    ids = _to_cpu_integer_tensor(sampling_mask_ids)
-    offsets = _to_cpu_integer_tensor(sampling_mask_offsets)
     indices = _to_cpu_integer_tensor(response_indices)
 
     if indices.numel() != logits.size(0):
         raise ValueError(
             f"sampling-mask rows must align with logits: indices={indices.numel()}, logits={logits.size(0)}"
         )
-    if offsets.numel() == 0 or offsets[0] != 0 or offsets[-1] != ids.numel():
-        raise ValueError("sampling-mask offsets must start at zero and end at the flattened id count")
-    if offsets.numel() != response_length + 1:
-        raise ValueError(
-            f"sampling-mask offsets length {offsets.numel()} != response length + 1 ({response_length + 1})"
-        )
-    if torch.any(offsets[1:] <= offsets[:-1]):
+    if any(not support for support in sampling_mask):
         raise ValueError("every response token must have a non-empty sampling support")
+    response_length = len(sampling_mask)
     if torch.any(indices < 0) or torch.any(indices >= response_length):
         raise ValueError(f"response indices must be in [0, {response_length})")
 
@@ -50,23 +39,14 @@ def build_local_sampling_mask(
     if indices.numel() == 0:
         return mask.view_as(logits)
 
-    indices = indices.to(torch.long)
-    lengths = offsets[indices + 1] - offsets[indices]
-    # CP response rows form a small number of contiguous runs. Slice those
-    # runs on CPU, then expand and TP-filter the CSR data on the GPU.
-    run_starts = [0]
-    run_starts.extend((torch.nonzero(indices[1:] != indices[:-1] + 1).flatten() + 1).tolist())
-    run_starts.append(indices.numel())
-    selected_parts = [
-        ids[offsets[indices[start]] : offsets[indices[end - 1] + 1]]
-        for start, end in zip(run_starts[:-1], run_starts[1:], strict=True)
-    ]
-    selected_ids = selected_parts[0] if len(selected_parts) == 1 else torch.cat(selected_parts)
-
-    selected_ids = selected_ids.to(logits.device)
+    selected_supports = [sampling_mask[index] for index in indices.tolist()]
+    lengths = torch.tensor([len(support) for support in selected_supports], device=logits.device)
+    selected_ids = _to_cpu_integer_tensor([token_id for support in selected_supports for token_id in support]).to(
+        logits.device
+    )
     row_indices = torch.repeat_interleave(
         torch.arange(indices.numel(), dtype=torch.long, device=logits.device),
-        lengths.to(device=logits.device, dtype=torch.long),
+        lengths,
     )
     is_local = (selected_ids >= vocab_start) & (selected_ids < vocab_end)
     flat_local_indices = row_indices[is_local] * local_vocab_size + selected_ids[is_local].to(torch.long) - vocab_start
@@ -74,14 +54,13 @@ def build_local_sampling_mask(
     return mask.view_as(logits)
 
 
-def _to_cpu_integer_tensor(values: Sequence[int] | torch.Tensor) -> torch.Tensor:
-    if isinstance(values, torch.Tensor):
-        tensor = values.detach().cpu()
+def _to_cpu_integer_tensor(values: Sequence[int]) -> torch.Tensor:
+    if len(values) == 0:
+        tensor = torch.empty(0, dtype=torch.long, device="cpu")
+    elif isinstance(values, range):
+        tensor = torch.arange(values.start, values.stop, values.step, device="cpu")
     else:
-        if isinstance(values, range):
-            tensor = torch.arange(values.start, values.stop, values.step, device="cpu")
-        else:
-            tensor = torch.as_tensor(values, device="cpu")
+        tensor = torch.as_tensor(values, device="cpu")
     if tensor.ndim != 1 or tensor.dtype == torch.bool or torch.is_floating_point(tensor) or torch.is_complex(tensor):
-        raise ValueError("sampling-mask ids, offsets, and response indices must be one-dimensional integers")
+        raise ValueError("sampling-mask token ids and response indices must be one-dimensional integers")
     return tensor

--- a/miles/backends/training_utils/sampling_mask.py
+++ b/miles/backends/training_utils/sampling_mask.py
@@ -1,66 +1,56 @@
-from collections.abc import Mapping, Sequence
-from typing import cast
+from collections.abc import Sequence
 
 import torch
 
-
-def get_rollout_sampling_mask(batch: Mapping[str, object]) -> list[list[list[int]]]:
-    """Read the complete sampling mask required by an actor scoring pass."""
-    sampling_mask = batch.get("rollout_sampling_mask")
-    if sampling_mask is None:
-        raise ValueError("truncated-sampling actor scoring requires rollout_sampling_mask")
-    return cast(list[list[list[int]]], sampling_mask)
+from miles.utils.sampling_mask import RolloutSamplingMask
 
 
 def build_local_sampling_mask(
     logits: torch.Tensor,
-    sampling_mask: list[list[int]],
-    response_indices: Sequence[int],
+    sampling_mask: RolloutSamplingMask,
+    response_indices: Sequence[int] | torch.Tensor,
     *,
     tp_rank: int,
 ) -> torch.Tensor:
-    """Build the dense local-vocabulary mask consumed by the log-prob primitive."""
-    indices = _to_cpu_integer_tensor(response_indices)
+    """Build the dense local-vocabulary mask consumed by the log-prob primitive.
 
-    if indices.numel() != logits.size(0):
+    Args:
+        logits: ``[local_rows, local_vocab_size]`` response-row logits this
+            rank holds (TP vocab shard, CP row subset).
+        sampling_mask: the sample's complete sampling mask.
+        response_indices: ``[local_rows]`` global response position of each row.
+        tp_rank: this rank's index in the TP group.
+
+    Returns:
+        Bool mask shaped like ``logits``; True marks ids inside the support.
+    """
+    if isinstance(response_indices, torch.Tensor) and (
+        response_indices.ndim != 1
+        or response_indices.dtype == torch.bool
+        or torch.is_floating_point(response_indices)
+        or torch.is_complex(response_indices)
+    ):
+        raise ValueError("sampling-mask ids, offsets, and response indices must be one-dimensional integers")
+    if len(response_indices) != logits.size(0):
         raise ValueError(
-            f"sampling-mask rows must align with logits: indices={indices.numel()}, logits={logits.size(0)}"
+            f"sampling-mask rows must align with logits: indices={len(response_indices)}, logits={logits.size(0)}"
         )
-    if any(not support for support in sampling_mask):
-        raise ValueError("every response token must have a non-empty sampling support")
-    response_length = len(sampling_mask)
-    if torch.any(indices < 0) or torch.any(indices >= response_length):
-        raise ValueError(f"response indices must be in [0, {response_length})")
 
+    if logits.size(0) == 0:
+        return torch.zeros(logits.numel(), dtype=torch.bool, device=logits.device).view_as(logits)
+
+    # CP response rows form a small number of contiguous runs, so the CSR
+    # gather is a handful of CPU slices before the GPU expansion.
+    selected_ids, lengths = sampling_mask._select_masks(response_indices)
+    selected_ids = selected_ids.to(logits.device)
+    row_indices = torch.repeat_interleave(
+        torch.arange(len(response_indices), dtype=torch.long, device=logits.device),
+        lengths.to(device=logits.device, dtype=torch.long),
+    )
     local_vocab_size = logits.size(-1)
     vocab_start = tp_rank * local_vocab_size
-    vocab_end = vocab_start + local_vocab_size
-    mask = torch.zeros(logits.numel(), dtype=torch.bool, device=logits.device)
-    if indices.numel() == 0:
-        return mask.view_as(logits)
-
-    selected_supports = [sampling_mask[index] for index in indices.tolist()]
-    lengths = torch.tensor([len(support) for support in selected_supports], device=logits.device)
-    selected_ids = _to_cpu_integer_tensor([token_id for support in selected_supports for token_id in support]).to(
-        logits.device
-    )
-    row_indices = torch.repeat_interleave(
-        torch.arange(indices.numel(), dtype=torch.long, device=logits.device),
-        lengths,
-    )
-    is_local = (selected_ids >= vocab_start) & (selected_ids < vocab_end)
+    is_local = (selected_ids >= vocab_start) & (selected_ids < vocab_start + local_vocab_size)
     flat_local_indices = row_indices[is_local] * local_vocab_size + selected_ids[is_local].to(torch.long) - vocab_start
+    mask = torch.zeros(logits.numel(), dtype=torch.bool, device=logits.device)
     mask[flat_local_indices] = True
     return mask.view_as(logits)
-
-
-def _to_cpu_integer_tensor(values: Sequence[int]) -> torch.Tensor:
-    if len(values) == 0:
-        tensor = torch.empty(0, dtype=torch.long, device="cpu")
-    elif isinstance(values, range):
-        tensor = torch.arange(values.start, values.stop, values.step, device="cpu")
-    else:
-        tensor = torch.as_tensor(values, device="cpu")
-    if tensor.ndim != 1 or tensor.dtype == torch.bool or torch.is_floating_point(tensor) or torch.is_complex(tensor):
-        raise ValueError("sampling-mask token ids and response indices must be one-dimensional integers")
-    return tensor

--- a/miles/utils/sampling_mask.py
+++ b/miles/utils/sampling_mask.py
@@ -1,0 +1,129 @@
+from array import array
+from collections.abc import Sequence
+from dataclasses import InitVar, dataclass, field
+
+import torch
+
+
+@dataclass(frozen=True, eq=False)
+class RolloutSamplingMask:
+    """One sample's sampling mask: for each response position, the token ids
+    the rollout sampler could emit.
+
+    Stored in CSR form so it stays two flat integer arrays end to end:
+    ``ids`` is ``[total_support_size]`` (all supports concatenated), ``offsets``
+    is ``[num_response_tokens + 1]``, and token ``t``'s support is
+    ``ids[offsets[t] : offsets[t + 1]]``. That is the shape object-store
+    transport needs, so no per-token nesting is rebuilt on the trainer side.
+    """
+
+    ids: InitVar[Sequence[int] | torch.Tensor]
+    offsets: InitVar[Sequence[int] | torch.Tensor]
+    _ids: torch.Tensor = field(init=False, repr=False)
+    _offsets: torch.Tensor = field(init=False, repr=False)
+
+    def __post_init__(self, ids: Sequence[int] | torch.Tensor, offsets: Sequence[int] | torch.Tensor):
+        owned_ids = _to_owned_cpu_integer_tensor(ids, dtype=torch.int32)
+        owned_offsets = _to_owned_cpu_integer_tensor(offsets, dtype=torch.long)
+        if owned_offsets.numel() == 0 or owned_offsets[0] != 0 or owned_offsets[-1] != owned_ids.numel():
+            raise ValueError("sampling-mask offsets must start at zero and end at the flattened id count")
+        if torch.any(owned_offsets[1:] <= owned_offsets[:-1]):
+            raise ValueError(
+                "sampling-mask offsets must be strictly increasing: "
+                "every response token needs a non-empty sampling mask"
+            )
+        object.__setattr__(self, "_ids", owned_ids)
+        object.__setattr__(self, "_offsets", owned_offsets)
+
+    @classmethod
+    def from_mask_list(cls, mask_list: Sequence[Sequence[int]]) -> "RolloutSamplingMask":
+        """Build from one mask (the allowed token ids) per response token.
+
+        Args:
+            mask_list: ragged ``[num_response_tokens][mask_size_t]``;
+                ``mask_list[t]`` lists the token ids the sampler could emit at
+                response position ``t``. SGLang's ``output_token_sampling_mask``
+                arrives in this shape.
+        """
+        ids = []
+        offsets = [0]
+        for mask in mask_list:
+            ids.extend(mask)
+            offsets.append(len(ids))
+        return cls(ids=ids, offsets=offsets)
+
+    def __len__(self) -> int:
+        return self._offsets.numel() - 1
+
+    def _select_masks(self, token_indices: Sequence[int] | torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        """Flattened masks for the given response positions.
+
+        Args:
+            token_indices: ``[num_selected]`` response positions to read.
+
+        Returns:
+            ``(ids, lengths)`` where ``ids`` is ``[sum(lengths)]``, the selected
+            masks concatenated in ``token_indices`` order, and ``lengths`` is
+            ``[num_selected]``, each position's mask size.
+
+        The returned ids may share the mask's private storage and are only for
+        immediate read-only use by the scoring path.
+        """
+        if isinstance(token_indices, range) and token_indices.step == 1:
+            if len(token_indices) == 0:
+                return self._ids.new_empty(0), self._offsets.new_empty(0)
+            if token_indices.start < 0 or token_indices.stop > len(self):
+                raise ValueError(f"response indices must be in [0, {len(self)})")
+            start, stop = token_indices.start, token_indices.stop
+            lengths = self._offsets[start + 1 : stop + 1] - self._offsets[start:stop]
+            return self._ids[self._offsets[start] : self._offsets[stop]], lengths
+
+        indices = _to_cpu_integer_tensor(token_indices).to(torch.long)
+        if torch.any(indices < 0) or torch.any(indices >= len(self)):
+            raise ValueError(f"response indices must be in [0, {len(self)})")
+        lengths = self._offsets[indices + 1] - self._offsets[indices]
+        if indices.numel() == 0:
+            return self._ids.new_empty(0), lengths
+        run_starts = [0]
+        run_starts.extend((torch.nonzero(indices[1:] != indices[:-1] + 1).flatten() + 1).tolist())
+        run_starts.append(indices.numel())
+        parts = [
+            self._ids[self._offsets[indices[start]] : self._offsets[indices[end - 1] + 1]]
+            for start, end in zip(run_starts[:-1], run_starts[1:], strict=True)
+        ]
+        return (parts[0] if len(parts) == 1 else torch.cat(parts)), lengths
+
+
+def _to_owned_cpu_integer_tensor(
+    values: Sequence[int] | torch.Tensor,
+    *,
+    dtype: torch.dtype,
+) -> torch.Tensor:
+    if isinstance(values, torch.Tensor):
+        _validate_integer_tensor(values)
+        return values.to(device="cpu", dtype=dtype, copy=True)
+
+    if dtype == torch.int32 and len(values) > 0:
+        storage = array("i", values)
+        # frombuffer keeps this private backing array alive without copying it.
+        return torch.frombuffer(storage, dtype=torch.int32)
+
+    return torch.tensor(values, dtype=dtype, device="cpu")
+
+
+def _to_cpu_integer_tensor(values: Sequence[int] | torch.Tensor) -> torch.Tensor:
+    if isinstance(values, torch.Tensor):
+        tensor = values.detach().cpu()
+    elif len(values) == 0:
+        tensor = torch.empty(0, dtype=torch.long, device="cpu")
+    elif isinstance(values, range):
+        tensor = torch.arange(values.start, values.stop, values.step, device="cpu")
+    else:
+        tensor = torch.as_tensor(values, device="cpu")
+    _validate_integer_tensor(tensor)
+    return tensor
+
+
+def _validate_integer_tensor(tensor: torch.Tensor) -> None:
+    if tensor.ndim != 1 or tensor.dtype == torch.bool or torch.is_floating_point(tensor) or torch.is_complex(tensor):
+        raise ValueError("sampling-mask ids, offsets, and response indices must be one-dimensional integers")

--- a/tests/fast/backends/training_utils/test_sampling_mask.py
+++ b/tests/fast/backends/training_utils/test_sampling_mask.py
@@ -6,14 +6,15 @@ import torch
 from miles.backends.training_utils import cp_utils
 from miles.backends.training_utils.loss_hub import logit_processors
 from miles.backends.training_utils.loss_hub.math_utils import _calculate_log_probs_and_entropy_true_on_policy
-from miles.backends.training_utils.sampling_mask import build_local_sampling_mask, get_rollout_sampling_mask
+from miles.backends.training_utils.sampling_mask import build_local_sampling_mask
+from miles.utils.sampling_mask import RolloutSamplingMask
 
 
 def test_build_local_sampling_mask_selects_original_response_rows_and_tp_shard():
     logits = torch.zeros(2, 4)
     mask = build_local_sampling_mask(
         logits,
-        sampling_mask=[[1, 3], [4, 2], [5, 6, 7]],
+        sampling_mask=RolloutSamplingMask.from_mask_list([[1, 3], [4, 2], [5, 6, 7]]),
         response_indices=[2, 0],
         tp_rank=1,
     )
@@ -29,22 +30,53 @@ def test_build_local_sampling_mask_selects_original_response_rows_and_tp_shard()
     )
 
 
-def test_build_local_sampling_mask_requires_non_empty_support():
-    with pytest.raises(ValueError, match="every response token must have a non-empty sampling support"):
+def test_build_local_sampling_mask_rejects_out_of_range_response_index():
+    with pytest.raises(ValueError, match=r"response indices must be in \[0, 1\)"):
         build_local_sampling_mask(
             torch.zeros(1, 4),
-            sampling_mask=[[], [1]],
+            sampling_mask=RolloutSamplingMask.from_mask_list([[0]]),
+            response_indices=[1],
+            tp_rank=0,
+        )
+
+
+def test_build_local_sampling_mask_rejects_row_misalignment():
+    with pytest.raises(ValueError, match="sampling-mask rows must align with logits: indices=1, logits=2"):
+        build_local_sampling_mask(
+            torch.zeros(2, 4),
+            sampling_mask=RolloutSamplingMask.from_mask_list([[0], [1]]),
             response_indices=[0],
             tp_rank=0,
         )
 
 
-def test_build_local_sampling_mask_rejects_out_of_range_response_index():
-    with pytest.raises(ValueError, match=r"response indices must be in \[0, 1\)"):
+def test_build_local_sampling_mask_skips_selection_for_empty_local_rows(monkeypatch):
+    def unexpected_selection(*args, **kwargs):
+        raise AssertionError("empty local rows must not select sampling-mask ids")
+
+    monkeypatch.setattr(RolloutSamplingMask, "_select_masks", unexpected_selection)
+
+    mask = build_local_sampling_mask(
+        torch.zeros(0, 4),
+        sampling_mask=RolloutSamplingMask.from_mask_list([[0]]),
+        response_indices=range(0),
+        tp_rank=0,
+    )
+
+    assert mask.shape == (0, 4)
+    assert mask.dtype == torch.bool
+
+
+@pytest.mark.parametrize(
+    "response_indices",
+    [torch.tensor(0), torch.empty(0, dtype=torch.float32), torch.empty((0, 1), dtype=torch.long)],
+)
+def test_build_local_sampling_mask_validates_malformed_tensor_indices(response_indices):
+    with pytest.raises(ValueError, match="must be one-dimensional integers"):
         build_local_sampling_mask(
-            torch.zeros(1, 4),
-            sampling_mask=[[0]],
-            response_indices=[1],
+            torch.zeros(0, 4),
+            sampling_mask=RolloutSamplingMask.from_mask_list([[0]]),
+            response_indices=response_indices,
             tp_rank=0,
         )
 
@@ -101,7 +133,7 @@ def test_get_log_probs_and_entropy_applies_per_response_sampling_support(monkeyp
         unconcat_tokens=[torch.tensor([2, 0, 3])],
         total_lengths=[3],
         response_lengths=[2],
-        rollout_sampling_mask=[[[0, 2], [1, 3]]],
+        rollout_sampling_mask=[RolloutSamplingMask.from_mask_list([[0, 2], [1, 3]])],
     )
 
     expected = torch.stack(
@@ -113,9 +145,42 @@ def test_get_log_probs_and_entropy_applies_per_response_sampling_support(monkeyp
     torch.testing.assert_close(result["log_probs"][0], expected)
 
 
-def test_get_rollout_sampling_mask_fails_when_required_support_is_missing():
-    with pytest.raises(ValueError, match="truncated-sampling actor scoring requires"):
-        get_rollout_sampling_mask({})
+def test_get_log_probs_and_entropy_rejects_a_bare_mask(monkeypatch):
+    parallel_state = SimpleNamespace(
+        tp=SimpleNamespace(rank=0, group=None),
+        cp=SimpleNamespace(rank=0, size=1),
+    )
+    monkeypatch.setattr(logit_processors, "get_parallel_state", lambda: parallel_state)
+    args = SimpleNamespace(qkv_format="thd", rollout_temperature=1.0, true_on_policy_mode=False, allgather_cp=False)
+
+    with pytest.raises(TypeError, match="sequence of RolloutSamplingMask"):
+        logit_processors.get_log_probs_and_entropy(
+            torch.zeros(1, 3, 4),
+            args=args,
+            unconcat_tokens=[torch.tensor([2, 0, 3])],
+            total_lengths=[3],
+            response_lengths=[2],
+            rollout_sampling_mask=RolloutSamplingMask.from_mask_list([[0], [1]]),
+        )
+
+
+def test_get_log_probs_and_entropy_rejects_mask_shorter_than_response(monkeypatch):
+    parallel_state = SimpleNamespace(
+        tp=SimpleNamespace(rank=0, group=None),
+        cp=SimpleNamespace(rank=0, size=1),
+    )
+    monkeypatch.setattr(logit_processors, "get_parallel_state", lambda: parallel_state)
+    args = SimpleNamespace(qkv_format="thd", rollout_temperature=1.0, true_on_policy_mode=False, allgather_cp=False)
+
+    with pytest.raises(ValueError, match="sampling-mask length 1 != response length 2"):
+        logit_processors.get_log_probs_and_entropy(
+            torch.zeros(1, 3, 4),
+            args=args,
+            unconcat_tokens=[torch.tensor([2, 0, 3])],
+            total_lengths=[3],
+            response_lengths=[2],
+            rollout_sampling_mask=[RolloutSamplingMask.from_mask_list([[0]])],
+        )
 
 
 @pytest.mark.parametrize(("cp_rank", "expected_indices"), [(0, [0, 1]), (1, [2, 3])])

--- a/tests/fast/backends/training_utils/test_sampling_mask.py
+++ b/tests/fast/backends/training_utils/test_sampling_mask.py
@@ -13,10 +13,8 @@ def test_build_local_sampling_mask_selects_original_response_rows_and_tp_shard()
     logits = torch.zeros(2, 4)
     mask = build_local_sampling_mask(
         logits,
-        sampling_mask_ids=[1, 3, 4, 2, 5, 6, 7],
-        sampling_mask_offsets=[0, 2, 4, 7],
+        sampling_mask=[[1, 3], [4, 2], [5, 6, 7]],
         response_indices=[2, 0],
-        response_length=3,
         tp_rank=1,
     )
 
@@ -31,14 +29,12 @@ def test_build_local_sampling_mask_selects_original_response_rows_and_tp_shard()
     )
 
 
-def test_build_local_sampling_mask_requires_one_offset_per_response_token():
-    with pytest.raises(ValueError, match=r"offsets length 3 != response length \+ 1 \(4\)"):
+def test_build_local_sampling_mask_requires_non_empty_support():
+    with pytest.raises(ValueError, match="every response token must have a non-empty sampling support"):
         build_local_sampling_mask(
             torch.zeros(1, 4),
-            sampling_mask_ids=[0, 1],
-            sampling_mask_offsets=[0, 1, 2],
+            sampling_mask=[[], [1]],
             response_indices=[0],
-            response_length=3,
             tp_rank=0,
         )
 
@@ -47,10 +43,8 @@ def test_build_local_sampling_mask_rejects_out_of_range_response_index():
     with pytest.raises(ValueError, match=r"response indices must be in \[0, 1\)"):
         build_local_sampling_mask(
             torch.zeros(1, 4),
-            sampling_mask_ids=[0],
-            sampling_mask_offsets=[0, 1],
+            sampling_mask=[[0]],
             response_indices=[1],
-            response_length=1,
             tp_rank=0,
         )
 
@@ -107,8 +101,7 @@ def test_get_log_probs_and_entropy_applies_per_response_sampling_support(monkeyp
         unconcat_tokens=[torch.tensor([2, 0, 3])],
         total_lengths=[3],
         response_lengths=[2],
-        rollout_sampling_mask_ids=[[0, 2, 1, 3]],
-        rollout_sampling_mask_offsets=[[0, 2, 4]],
+        rollout_sampling_mask=[[[0, 2], [1, 3]]],
     )
 
     expected = torch.stack(

--- a/tests/fast/backends/training_utils/test_sampling_mask.py
+++ b/tests/fast/backends/training_utils/test_sampling_mask.py
@@ -1,0 +1,182 @@
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from miles.backends.training_utils import cp_utils
+from miles.backends.training_utils.loss_hub import logit_processors
+from miles.backends.training_utils.loss_hub.math_utils import _calculate_log_probs_and_entropy_true_on_policy
+from miles.backends.training_utils.sampling_mask import build_local_sampling_mask, get_rollout_sampling_mask
+
+
+def test_build_local_sampling_mask_selects_original_response_rows_and_tp_shard():
+    logits = torch.zeros(2, 4)
+    mask = build_local_sampling_mask(
+        logits,
+        sampling_mask_ids=[1, 3, 4, 2, 5, 6, 7],
+        sampling_mask_offsets=[0, 2, 4, 7],
+        response_indices=[2, 0],
+        response_length=3,
+        tp_rank=1,
+    )
+
+    torch.testing.assert_close(
+        mask,
+        torch.tensor(
+            [
+                [False, True, True, True],
+                [False, False, False, False],
+            ]
+        ),
+    )
+
+
+def test_build_local_sampling_mask_requires_one_offset_per_response_token():
+    with pytest.raises(ValueError, match=r"offsets length 3 != response length \+ 1 \(4\)"):
+        build_local_sampling_mask(
+            torch.zeros(1, 4),
+            sampling_mask_ids=[0, 1],
+            sampling_mask_offsets=[0, 1, 2],
+            response_indices=[0],
+            response_length=3,
+            tp_rank=0,
+        )
+
+
+def test_build_local_sampling_mask_rejects_out_of_range_response_index():
+    with pytest.raises(ValueError, match=r"response indices must be in \[0, 1\)"):
+        build_local_sampling_mask(
+            torch.zeros(1, 4),
+            sampling_mask_ids=[0],
+            sampling_mask_offsets=[0, 1],
+            response_indices=[1],
+            response_length=1,
+            tp_rank=0,
+        )
+
+
+def test_true_on_policy_masks_logprob_but_keeps_full_vocab_entropy():
+    logits = torch.tensor([[2.0, 1.0, 0.0, -1.0]], requires_grad=True)
+    tokens = torch.tensor([0])
+    sampling_mask = torch.tensor([[True, False, True, False]])
+
+    log_probs, entropy = _calculate_log_probs_and_entropy_true_on_policy(
+        logits,
+        tokens,
+        None,
+        with_entropy=True,
+        sampling_mask=sampling_mask,
+    )
+
+    expected_masked_logprob = torch.log_softmax(logits.masked_fill(~sampling_mask, float("-inf")), dim=-1)[0, 0]
+    full_log_probs = torch.log_softmax(logits, dim=-1)
+    expected_entropy = -(full_log_probs.exp() * full_log_probs).sum(dim=-1)
+    torch.testing.assert_close(log_probs, expected_masked_logprob.unsqueeze(0))
+    torch.testing.assert_close(entropy, expected_entropy)
+
+
+def test_get_log_probs_and_entropy_applies_per_response_sampling_support(monkeypatch):
+    parallel_state = SimpleNamespace(
+        tp=SimpleNamespace(rank=0, group=None),
+        cp=SimpleNamespace(rank=0, size=1),
+    )
+    monkeypatch.setattr(logit_processors, "get_parallel_state", lambda: parallel_state)
+    args = SimpleNamespace(
+        qkv_format="thd",
+        rollout_temperature=1.0,
+        true_on_policy_mode=True,
+        bf16=False,
+        fp16=False,
+        log_probs_chunk_size=-1,
+        vocab_size=4,
+        allgather_cp=False,
+    )
+    logits = torch.tensor(
+        [
+            [
+                [2.0, 1.0, 0.0, -1.0],
+                [-1.0, 0.0, 1.0, 2.0],
+                [0.0, 0.0, 0.0, 0.0],
+            ]
+        ]
+    )
+
+    result = logit_processors.get_log_probs_and_entropy(
+        logits,
+        args=args,
+        unconcat_tokens=[torch.tensor([2, 0, 3])],
+        total_lengths=[3],
+        response_lengths=[2],
+        rollout_sampling_mask_ids=[[0, 2, 1, 3]],
+        rollout_sampling_mask_offsets=[[0, 2, 4]],
+    )
+
+    expected = torch.stack(
+        [
+            torch.log_softmax(logits[0, 0, [0, 2]], dim=-1)[0],
+            torch.log_softmax(logits[0, 1, [1, 3]], dim=-1)[1],
+        ]
+    )
+    torch.testing.assert_close(result["log_probs"][0], expected)
+
+
+def test_get_rollout_sampling_mask_fails_when_required_support_is_missing():
+    with pytest.raises(ValueError, match="truncated-sampling actor scoring requires"):
+        get_rollout_sampling_mask({})
+
+
+@pytest.mark.parametrize(("cp_rank", "expected_indices"), [(0, [0, 1]), (1, [2, 3])])
+def test_allgather_cp_response_rows_keep_global_response_indices(monkeypatch, cp_rank, expected_indices):
+    parallel_state = SimpleNamespace(cp=SimpleNamespace(rank=cp_rank, size=2))
+    monkeypatch.setattr(logit_processors, "get_parallel_state", lambda: parallel_state)
+    args = SimpleNamespace(
+        qkv_format="thd",
+        rollout_temperature=1.0,
+        true_on_policy_mode=False,
+        allgather_cp=True,
+    )
+
+    response_chunks = list(
+        logit_processors._iter_response_chunks(
+            torch.zeros(1, 3, 4),
+            args=args,
+            unconcat_tokens=[torch.arange(6)],
+            total_lengths=[6],
+            response_lengths=[4],
+            include_response_indices=True,
+        )
+    )
+    logits_chunk, tokens_chunk, response_indices = response_chunks[0]
+
+    assert list(response_indices) == expected_indices
+    assert tokens_chunk.tolist() == [2 + index for index in expected_indices]
+    assert logits_chunk.size(0) == len(expected_indices)
+
+
+@pytest.mark.parametrize(("cp_rank", "expected_indices"), [(0, [4]), (1, [0, 1, 2, 3])])
+def test_zigzag_cp_response_rows_keep_global_response_indices(monkeypatch, cp_rank, expected_indices):
+    parallel_state = SimpleNamespace(cp=SimpleNamespace(rank=cp_rank, size=2))
+    monkeypatch.setattr(logit_processors, "get_parallel_state", lambda: parallel_state)
+    monkeypatch.setattr(cp_utils, "get_parallel_state", lambda: parallel_state)
+    args = SimpleNamespace(
+        qkv_format="thd",
+        rollout_temperature=1.0,
+        true_on_policy_mode=False,
+        allgather_cp=False,
+    )
+
+    response_chunks = list(
+        logit_processors._iter_response_chunks(
+            torch.zeros(1, 4, 4),
+            args=args,
+            unconcat_tokens=[torch.arange(8)],
+            total_lengths=[8],
+            response_lengths=[5],
+            include_response_indices=True,
+        )
+    )
+    logits_chunk, tokens_chunk, response_indices = response_chunks[0]
+
+    assert list(response_indices) == expected_indices
+    assert tokens_chunk.tolist() == [3 + index for index in expected_indices]
+    assert logits_chunk.size(0) == len(expected_indices)

--- a/tests/fast/backends/training_utils/test_sampling_mask.py
+++ b/tests/fast/backends/training_utils/test_sampling_mask.py
@@ -145,25 +145,6 @@ def test_get_log_probs_and_entropy_applies_per_response_sampling_support(monkeyp
     torch.testing.assert_close(result["log_probs"][0], expected)
 
 
-def test_get_log_probs_and_entropy_rejects_a_bare_mask(monkeypatch):
-    parallel_state = SimpleNamespace(
-        tp=SimpleNamespace(rank=0, group=None),
-        cp=SimpleNamespace(rank=0, size=1),
-    )
-    monkeypatch.setattr(logit_processors, "get_parallel_state", lambda: parallel_state)
-    args = SimpleNamespace(qkv_format="thd", rollout_temperature=1.0, true_on_policy_mode=False, allgather_cp=False)
-
-    with pytest.raises(TypeError, match="sequence of RolloutSamplingMask"):
-        logit_processors.get_log_probs_and_entropy(
-            torch.zeros(1, 3, 4),
-            args=args,
-            unconcat_tokens=[torch.tensor([2, 0, 3])],
-            total_lengths=[3],
-            response_lengths=[2],
-            rollout_sampling_mask=RolloutSamplingMask.from_mask_list([[0], [1]]),
-        )
-
-
 def test_get_log_probs_and_entropy_rejects_mask_shorter_than_response(monkeypatch):
     parallel_state = SimpleNamespace(
         tp=SimpleNamespace(rank=0, group=None),

--- a/tests/fast/utils/test_sampling_mask.py
+++ b/tests/fast/utils/test_sampling_mask.py
@@ -1,0 +1,83 @@
+import pytest
+import torch
+
+from miles.utils.sampling_mask import RolloutSamplingMask
+
+
+def test_rollout_sampling_mask_builds_private_int32_storage():
+    mask = RolloutSamplingMask.from_mask_list([[1, 3], [4, 2], [5, 6, 7]])
+
+    ids, lengths = mask._select_masks(range(3))
+
+    assert len(mask) == 3
+    assert ids.dtype == torch.int32
+    assert lengths.dtype == torch.long
+    assert ids.tolist() == [1, 3, 4, 2, 5, 6, 7]
+    assert lengths.tolist() == [2, 2, 3]
+    assert not hasattr(mask, "ids")
+    assert not hasattr(mask, "offsets")
+
+
+def test_rollout_sampling_mask_requires_non_empty_mask():
+    with pytest.raises(ValueError, match="every response token needs a non-empty sampling mask"):
+        RolloutSamplingMask.from_mask_list([[], [1]])
+
+
+def test_rollout_sampling_mask_owns_input_storage():
+    ids = torch.tensor([5, 7], dtype=torch.int16)
+    offsets = torch.tensor([0, 1, 2], dtype=torch.int32)
+    mask = RolloutSamplingMask(ids=ids, offsets=offsets)
+
+    ids[0] = 99
+    offsets[1] = 99
+    selected_ids, lengths = mask._select_masks(range(2))
+
+    assert selected_ids.tolist() == [5, 7]
+    assert lengths.tolist() == [1, 1]
+
+
+def test_rollout_sampling_mask_validates_csr_offsets():
+    with pytest.raises(ValueError, match="offsets must start at zero and end at the flattened id count"):
+        RolloutSamplingMask(ids=torch.tensor([0, 1]), offsets=torch.tensor([0, 1]))
+
+
+@pytest.mark.parametrize("ids", [torch.tensor([1.5]), torch.tensor([True]), torch.tensor([[1]])])
+def test_rollout_sampling_mask_rejects_non_integer_or_non_1d_tensor_ids(ids):
+    with pytest.raises(ValueError, match="must be one-dimensional integers"):
+        RolloutSamplingMask(ids=ids, offsets=[0, 1])
+
+
+def test_select_masks_slices_a_contiguous_range_and_reports_lengths():
+    mask = RolloutSamplingMask.from_mask_list([[1, 3], [4, 2], [5, 6, 7], [8]])
+
+    ids, lengths = mask._select_masks(range(1, 3))
+
+    assert ids.tolist() == [4, 2, 5, 6, 7]
+    assert lengths.tolist() == [2, 3]
+
+
+def test_select_masks_concatenates_disjoint_runs_in_order():
+    mask = RolloutSamplingMask.from_mask_list([[1, 3], [4, 2], [5, 6, 7], [8]])
+
+    ids, lengths = mask._select_masks(torch.tensor([0, 1, 3]))
+
+    assert ids.tolist() == [1, 3, 4, 2, 8]
+    assert lengths.tolist() == [2, 2, 1]
+
+
+@pytest.mark.parametrize("token_indices", [range(0), torch.empty(0, dtype=torch.long)])
+def test_select_masks_handles_no_tokens(token_indices):
+    mask = RolloutSamplingMask.from_mask_list([[1]])
+
+    ids, lengths = mask._select_masks(token_indices)
+
+    assert ids.numel() == 0
+    assert lengths.numel() == 0
+
+
+@pytest.mark.parametrize("token_indices", [range(1, 2), [1]])
+def test_select_masks_rejects_out_of_range_position(token_indices):
+    mask = RolloutSamplingMask.from_mask_list([[0]])
+
+    with pytest.raises(ValueError, match=r"response indices must be in \[0, 1\)"):
+        mask._select_masks(token_indices)


### PR DESCRIPTION
## Summary

- Add an optional per-token sampling-support mask primitive for actor log-probability computation.
- Preserve the public get_responses() two-tuple contract while deriving context-parallel response-row indices only when support replay needs them.
- Apply an optional support mask through the existing true-on-policy and fused tensor-parallel cross-entropy paths.

No production caller supplies a sampling mask in this PR, so rollout and training behavior remain unchanged.

## Why

The trainer needs a correct way to normalize actor log probabilities over the same sampling support used during rollout. This primitive intentionally landed before capture was activated: rollout log probabilities must not switch to a restricted distribution until actor scoring can use the same support.

The logical input follows rollout data directly: one list of supported token IDs per response token. The enabled path selects response rows owned by the current context-parallel rank, flattens those supports once, and builds one tensor-parallel-local boolean mask. The disabled path does not build response indices or allocate a mask.

## Sampling-support replay series

| Part | PR | Responsibility | State |
|---:|---|---|---|
| 1/8 | #2200 | TP/CP-aware masked log-probability primitive | Merged |
| 2/8 | #2595 | Compact support representation and transport | Merged |
| 3/8 | #3327 | Actor-only Megatron and FSDP integration | Open |
| 4/8 | #3328 | Native SGLang support capture | Open |
| 5/8 | #3329 | Session and agentic preservation | Open |
| 6/8 | #3330 | User-facing validation | Open |
| 7/8 | #3331 | GPU E2E | Open |
| 8/8 | #3332 | Documentation | Open |

External prerequisite: #3321 provides the SGLang v0.5.20 base. It is owned by another contributor and is not part of this numbered series.

#2596 is the [DO NOT MERGE] review umbrella for the complete stack.

## Validation

- Repository lint and formatting checks passed on every changed file.
- Focused CPU checks cover nested-support selection, tensor-parallel vocabulary filtering, validation, and empty local response shards.

## Acknowledgements

Thank you to [Zilin Zhu](https://github.com/zhuzilin) for adding top-p masking support to slime in [THUDM/slime#2102](https://github.com/THUDM/slime/pull/2102).