### PR TITLE
fix(tito): prevent DeepSeek V4 system-tail mismatch

### DIFF
--- a/miles/utils/chat_template_utils/tito_tokenizer.py
+++ b/miles/utils/chat_template_utils/tito_tokenizer.py
@@ -666,6 +666,7 @@ class DeepSeekV4TITOTokenizer(TITOTokenizer):
     FIXED_TEMPLATE = FixedTemplate(
         template=None,
         extra_kwargs={"drop_thinking": False},
+        allowed_append_roles=frozenset({"tool", "user", "assistant"}),
     )
 
     _DEFAULT_ASSISTANT_START = "<｜Assistant｜>"

--- a/tests/e2e/sglang/test_session_server_multi_role/test_deepseekv4.py
+++ b/tests/e2e/sglang/test_session_server_multi_role/test_deepseekv4.py
@@ -17,6 +17,7 @@ CONFIG = ModelConfig(
     ep_size=4,
     enable_spec=True,
     cycles=2,
+    assistant_text_threshold=0.05,
     # V4 sorts tool_result blocks by the preceding assistant's tool_calls
     # order, so a sentinel tool_call_id would not roundtrip; use the
     # universal rollback recovery when the model emits no tool_calls.

--- a/tests/fast/utils/chat_template_utils/test_fixed_templates.py
+++ b/tests/fast/utils/chat_template_utils/test_fixed_templates.py
@@ -11,6 +11,7 @@ import pytest
 from miles.utils.chat_template_utils import TEMPLATE_DIR, TITOTokenizerType, resolve_fixed_chat_template
 from miles.utils.chat_template_utils.tito_tokenizer import (
     ALL_APPEND_ROLES,
+    DeepSeekV4TITOTokenizer,
     FixedTemplate,
     MinimaxM25TITOTokenizer,
     MinimaxM27TITOTokenizer,
@@ -74,7 +75,7 @@ def test_fixed_template_rejects_unknown_role():
 
 @pytest.mark.parametrize(
     "tokenizer_cls",
-    [Qwen35TITOTokenizer, MinimaxM25TITOTokenizer, MinimaxM27TITOTokenizer],
+    [DeepSeekV4TITOTokenizer, Qwen35TITOTokenizer, MinimaxM25TITOTokenizer, MinimaxM27TITOTokenizer],
 )
 def test_restricted_fixed_template_excludes_mid_session_system(tokenizer_cls):
     assert tokenizer_cls.FIXED_TEMPLATE.allowed_append_roles == frozenset({"tool", "user", "assistant"})


### PR DESCRIPTION
## Summary

Prevent unsupported DeepSeek V4 system-tail appends from causing stochastic TITO mismatches.

## Symptom & Reproduction

- **Symptom:** DeepSeek V4 Stage 3 produced assistant-text mismatch rates of `0.109375` to `0.1875` instead of `0`.
- **Reproduction:** Run `python -m pytest tests/e2e/sglang/test_session_server_multi_role/test_deepseekv4.py -q -s` with the DeepSeek V4 TP4 configuration.

## Root Cause

1. `DeepSeekV4TITOTokenizer.FIXED_TEMPLATE` inherited mid-session `system` support.
2. `encoding_dsv4.encode_messages` omits the assistant opener after a `system` tail.
3. `compute_session_mismatch` compares sampled tokens with a canonical `</think>` re-render.

## Fix

Restrict DeepSeek V4 appends to `tool`, `user`, and `assistant`, matching the encoder's generation-ready boundaries. Keep future drift visible with a V4-only `assistant_text_threshold=0.05` instead of changing parser or comparator semantics.

## Verification

- **Updated test:** `test_restricted_fixed_template_excludes_mid_session_system` covers the exact DeepSeek V4 role set.
- **Fixed-template tests:** `test_fixed_templates.py` passes 23 tests.
- **Session-verifier tests:** `test_session_verify_agent.py` passes 6 tests.
- **GPU E2E:** The 4×H200 run completes all 64 samples.
- **Mismatch metric:** Total TITO mismatch is `0.0`.
- **Assistant metric:** Assistant-text mismatch is `0.0`.

## Review Focus

- Scrutinize `DeepSeekV4TITOTokenizer.FIXED_TEMPLATE.allowed_append_roles` against the encoder's generation-ready tails.
- Confirm `assistant_text_threshold=0.05` remains local to the DeepSeek V4 E2E configuration.
