### PR TITLE
Revert "Reject --disable-weights-backuper for LoRA + colocate + offload-train" (#2077)

### DIFF
--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -3078,14 +3078,6 @@ def miles_validate_args(args):
         args.disable_grad_buffers_cpu_backup = True
         args.disable_param_buffers_cpu_backup = args.enable_weights_backuper
 
-    # patch_param_grad_buffer_for_colocate_mode_lora() forces disable_param_buffers_cpu_backup
-    # on regardless of the line above, so without the backuper there is no host copy at all and
-    # named_params_and_buffers() hands update_weights the live, paused GPU tensors. That reads
-    # unmapped memory instead of failing, so the symptom is a 30-minute gloo barrier timeout.
-    assert not (
-        not args.enable_weights_backuper and args.offload_train and args.colocate and is_lora_enabled(args)
-    ), "--disable-weights-backuper is not supported with LoRA + --colocate + --offload-train"
-
     if args.offload_train_target == "disk":
         assert args.offload_train, "--offload-train-target=disk requires --offload-train"
         assert (


### PR DESCRIPTION
## Summary

Reverts commit 7546154083e209e71292ae665fdebec181491f9f (#2077), which added a startup assert rejecting `--disable-weights-backuper` with LoRA + `--colocate` + `--offload-train`.

The assert is over-broad and currently breaks every LoRA e2e CI suite on main:

1. `--colocate` force-enables `offload_train` in `parse_args` (`miles/utils/arguments.py`: `if args.colocate: args.offload_train = True`).
2. The LoRA e2e CI scripts deliberately pass `--disable-weights-backuper` together with `--colocate`:
   - `tests/e2e/megatron/model_scripts/test_glm5_1_744b_a40b_6layer_lora_ci.py`
   - `tests/e2e/megatron/model_scripts/test_glm5_2_744b_a40b_5layer_lora_ci.py`
   - `tests/e2e/megatron/model_scripts/test_gpt_oss_20b_moe_lora_ci.py`
   - `tests/e2e/megatron/test_qwen3_5_35b_a3b_lora_ci.py`
   - `tests/e2e/megatron/model_scripts/test_inkling_small_4layer_lora_ci.py`
3. So these suites now die at argument parsing with:
   `AssertionError: --disable-weights-backuper is not supported with LoRA + --colocate + --offload-train`

First observed in https://github.com/radixark/miles/actions/runs/30958354996 — all stage-c GPU jobs failed with this AssertionError right after #2077 merged.

## Why reverting is safe

- The genuinely unrecoverable configuration (`--offload-train-target disk` without the backuper) is still rejected by the pre-existing adjacent assert in `arguments.py`.
- The flag combination banned by #2077 is exactly what the LoRA e2e CI suites have been running green for a long time.
- The failure mode #2077 was defending against (weight sync reading a paused GPU tensor when no CPU copy exists, surfacing as a 30-minute gloo timeout) is better caught at the actual fault site. The follow-up PR #2204 adds a fail-fast in `_maybe_get_cpu_backup()` (`miles/backends/megatron_utils/update_weight/common.py`) that raises immediately instead of handing back a paused tensor.

## Test plan
- [ ] LoRA e2e CI suites pass again on this branch (they currently fail at startup on main).

