### PR TITLE
Fail fast when an offloaded weight has no CPU backup

### DIFF
--- a/miles/backends/megatron_utils/actor.py
+++ b/miles/backends/megatron_utils/actor.py
@@ -213,6 +213,9 @@ class MegatronTrainRayActor(TrainRayActor):
                 self.model,
                 convert_to_global_name=args.megatron_to_hf_mode == "raw",
                 translate_gpu_to_cpu=not self.args.enable_weights_backuper,
+                # Evaluated at call time: while the model is offloaded, a paused
+                # tensor without a CPU backup must fail fast instead of hanging.
+                require_cpu_backup=self._asleep,
             ),
             single_tag=None if args.enable_weights_backuper else "actor",
         )

--- a/miles/backends/megatron_utils/update_weight/common.py
+++ b/miles/backends/megatron_utils/update_weight/common.py
@@ -11,6 +11,7 @@ import torch.distributed as dist
 from megatron.core.transformer.transformer_layer import get_transformer_layer_offset
 from ray.actor import ActorHandle
 
+from miles.backends.megatron_utils.lora_utils import _is_adapter_param_name
 from miles.backends.megatron_utils.misc_utils import strip_param_name_prefix
 from miles.backends.training_utils.parallel import get_parallel_state
 from miles.utils.types import ParamInfo
@@ -291,6 +292,7 @@ def named_params_and_buffers(
     model: Sequence[torch.nn.Module],
     convert_to_global_name: bool = True,
     translate_gpu_to_cpu: bool = False,
+    require_cpu_backup: bool = False,
 ) -> Iterator[tuple[str, torch.Tensor]]:
     if convert_to_global_name:
         ans = _named_params_and_buffers_global(args, model)
@@ -298,16 +300,26 @@ def named_params_and_buffers(
         ans = _named_params_and_buffers_vanilla(model)
 
     if translate_gpu_to_cpu:
-        ans = ((name, _maybe_get_cpu_backup(tensor)) for name, tensor in ans)
+        ans = ((name, _maybe_get_cpu_backup(name, tensor, require_cpu_backup)) for name, tensor in ans)
 
     return ans
 
 
-def _maybe_get_cpu_backup(x: torch.Tensor):
+def _maybe_get_cpu_backup(name: str, x: torch.Tensor, require_cpu_backup: bool = False):
     from torch_memory_saver import torch_memory_saver
 
     if (cpu_tensor := torch_memory_saver.get_cpu_backup(x)) is not None:
         return cpu_tensor
+
+    # LoRA adapter params are deliberately kept out of the paused region (see
+    # patch_param_grad_buffer_for_colocate_mode_lora), so reading them live is fine.
+    if require_cpu_backup and x.is_cuda and not _is_adapter_param_name(name):
+        raise RuntimeError(
+            f"No CPU backup exists for '{name}' while the training model is offloaded. Reading the paused GPU "
+            f"tensor would touch unmapped memory and hang instead of failing (typically as a 30-minute gloo "
+            f"timeout at weight sync). The weights were offloaded without any host copy; check the "
+            f"--disable-weights-backuper / cpu-backup configuration."
+        )
 
     return x
 

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -3078,14 +3078,6 @@ def miles_validate_args(args):
         args.disable_grad_buffers_cpu_backup = True
         args.disable_param_buffers_cpu_backup = args.enable_weights_backuper
 
-    # patch_param_grad_buffer_for_colocate_mode_lora() forces disable_param_buffers_cpu_backup
-    # on regardless of the line above, so without the backuper there is no host copy at all and
-    # named_params_and_buffers() hands update_weights the live, paused GPU tensors. That reads
-    # unmapped memory instead of failing, so the symptom is a 30-minute gloo barrier timeout.
-    assert not (
-        not args.enable_weights_backuper and args.offload_train and args.colocate and is_lora_enabled(args)
-    ), "--disable-weights-backuper is not supported with LoRA + --colocate + --offload-train"
-
     if args.offload_train_target == "disk":
         assert args.offload_train, "--offload-train-target=disk requires --offload-train"
         assert (


### PR DESCRIPTION
## Summary

Follow-up to #2203 (now merged), which reverted #2077's over-broad startup assert.

When the training model is offloaded, `named_params_and_buffers(..., translate_gpu_to_cpu=True)` reads each weight through `torch_memory_saver.get_cpu_backup()`. If a paused tensor has **no** CPU backup, `_maybe_get_cpu_backup()` silently falls through and returns the live GPU tensor — whose memory is unmapped. Downstream readers (e.g. `_TensorBackuperNoop.get()` hashing the weights during weight sync) then touch unmapped memory, which does not fault: it hangs, surfacing only as a 30-minute gloo timeout with no indication of the root cause.

This PR makes that state fail fast at the actual fault site:

- `named_params_and_buffers()` gains a `require_cpu_backup` flag; the actor passes `self._asleep` (evaluated at call time), so the check is only armed while the model is actually offloaded.
- `_maybe_get_cpu_backup()` now raises a `RuntimeError` naming the offending weight when the check is armed and no backup exists, instead of returning a paused tensor.
- LoRA adapter params are exempt: `patch_param_grad_buffer_for_colocate_mode_lora()` deliberately keeps them out of the paused region, so reading them live while the base model is offloaded is the designed path.

## Why this cannot fire on healthy configurations

- Non-offload runs: `require_cpu_backup` is always `False` (the actor is never asleep).
- Memory-target offload runs: the train actor is launched with `TMS_INIT_ENABLE_CPU_BACKUP=1` (`miles/ray/train/actor_factory.py`), so paused weights have host backups and `get_cpu_backup()` returns them before the check is reached.
- LoRA + colocate: resident adapter params are exempt by name.
- Disk-target offload without the weights backuper is already rejected at argument parsing.

So the raise only triggers in the state that previously produced the silent hang. Unlike the startup assert from #2077 (reverted in #2203), it does not ban flag combinations that work — it verifies the actual invariant, per-tensor, at read time.

Note: `docker/npu_patch/miles.patch` carries a hunk over `_maybe_get_cpu_backup`, but that patch already fails to apply against current `main` on several unrelated files; its next regeneration should pick up this function's new shape.

## Test plan
- [ ] LoRA e2e CI suites (they exercise `translate_gpu_to_cpu=True` while offloaded via `--disable-weights-backuper` + `--colocate`) stay green.
- [ ] Non-LoRA colocate e2e suites stay green.
