### PR TITLE
ci: authenticate CPU Hugging Face downloads

### DIFF
--- a/.github/workflows/_run-ci.yml
+++ b/.github/workflows/_run-ci.yml
@@ -271,4 +271,6 @@ jobs:
 
       - name: Run tests
         shell: bash
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: ${{ inputs.execute_command }}


### PR DESCRIPTION
## Summary
Authenticate Hugging Face downloads in GitHub-hosted CPU test execution.

## Symptom & Reproduction
- **Symptom:** `stage-b-cpu / run-cpu` fails during pytest collection with HTTP 429 while loading `Qwen/Qwen3-0.6B/config.json`.
- **Reproduction:** Run the CPU suite on `ubuntu-latest` without `HF_TOKEN`; model config resolution reaches anonymous Hub quotas.

## Root Cause
1. `run-cpu` supplies no authentication environment to `Run tests`.
2. `AutoConfig.from_pretrained` reaches Hugging Face Hub with anonymous quotas.

## Fix
Pass the existing `HF_TOKEN` secret only to the CPU `Run tests` step, authenticating collection-time Hub requests without exposing the token to setup actions.

## Verification
- **New / updated test:** `pre-commit run --files .github/workflows/_run-ci.yml` passes, including `check yaml`.

## Review Focus
- Scrutinize the `run-cpu` `Run tests` step in `.github/workflows/_run-ci.yml` for secret scope.
