### PR TITLE
[multi-lora] 1/4: fix optimizer builder wrapping and slot-scoped master reloads

### DIFF
--- a/miles/backends/megatron_utils/multi_lora_optimizer.py
+++ b/miles/backends/megatron_utils/multi_lora_optimizer.py
@@ -109,7 +109,11 @@ def build_multi_lora_optimizer(
             for child in children:
                 for group in child.param_groups:
                     group["miles_multi_lora_slot"] = slot
-                base_optimizers.append(child)
+                # LayerWiseDistributedOptimizer wraps raw torch optimizers itself; the
+                # MCore pinned by Megatron-Bridge rejects pre-wrapped Megatron children
+                # (TypeError). param_groups proxy to the raw groups, so the slot tags
+                # above survive the unwrap.
+                base_optimizers.append(child.optimizer)
                 init_fns.append(_adam_init_state_fn)
     finally:
         config.bf16 = reset_bf16
@@ -130,6 +134,15 @@ def build_multi_lora_optimizer(
 
 def _slot_children(optimizer, slot: int):
     return [optimizer.chained_optimizers[i] for i in optimizer.miles_slot_child_indices[slot]]
+
+
+def reload_adapter_slot_model_params(optimizer, slot: int) -> None:
+    """Refresh fp32 masters from model params for ONE slot's children only. A global
+    ``optimizer.reload_model_params()`` re-derives every resident slot's fp32 master
+    from its bf16 model weights, silently dropping the low mantissa bits other slots'
+    masters have accumulated since their last step."""
+    for child in _slot_children(optimizer, slot):
+        child.reload_model_params()
 
 
 def reset_grad_metadata_keep_grads(model_chunks) -> None:

--- a/miles/backends/megatron_utils/multi_lora_utils.py
+++ b/miles/backends/megatron_utils/multi_lora_utils.py
@@ -358,7 +358,11 @@ def _deregister_adapter(adapter: AdapterRun, args, model, optimizer) -> None:
     zero_optimizer_state_for_adapter(optimizer, model, slot)
     zero_adapter_slot_grads(model, slot)
     drop_slot_scheduler(optimizer, slot)
-    optimizer.reload_model_params()
+    # Slot-scoped: a global reload would quantize every other resident slot's fp32
+    # master through bf16.
+    from miles.backends.megatron_utils.multi_lora_optimizer import reload_adapter_slot_model_params
+
+    reload_adapter_slot_model_params(optimizer, slot)
     logger.info(f"{log_prefix} cleared optimizer state and retained grads for slot {slot}")
 
 
@@ -380,7 +384,12 @@ def load_adapters(args, model, optimizer, adapters) -> int:
         install_slot_scheduler(args, optimizer, adapter, resume_steps[adapter.name])
     if dist.is_initialized():
         dist.barrier(group=get_gloo_group())
-    optimizer.reload_model_params()
+    from miles.backends.megatron_utils.multi_lora_optimizer import reload_adapter_slot_model_params
+
+    # Slot-scoped: a global reload would quantize every other resident slot's fp32
+    # master through bf16.
+    for adapter in adapters:
+        reload_adapter_slot_model_params(optimizer, adapter.slot)
     if is_first_replica_megatron_main_rank():
         for name, step in resume_steps.items():
             if step > 0:


### PR DESCRIPTION
First of a 4-PR series splitting #2137 into reviewable pieces (the stack's final tree is byte-identical to #2137, which stays open as the integrated reference).

Two correctness fixes for the CURRENT multi-LoRA path, independent of the redesign:

- **Optimizer builder**: `build_multi_lora_optimizer` handed pre-wrapped Megatron children to `LayerWiseDistributedOptimizer`; the Megatron-Core pinned by Megatron-Bridge rejects that with a `TypeError`. Hand it the raw torch optimizers — `param_groups` proxy to the raw groups, so per-slot tags survive.
- **Slot-scoped master reloads**: deregistration/adapter-loading called the global `optimizer.reload_model_params()`, re-deriving EVERY resident slot's fp32 master from bf16 and silently dropping accumulated low mantissa bits. `reload_adapter_slot_model_params` refreshes one slot only.

Series: 1/4 (this) → #2209 2/4 identity → #2210 3/4 SlotPool/sidecars → #2211 4/4 Option 1 swap.