### PR TITLE
[multi-lora] 2/4: registration-scoped serving identity and request routing

### DIFF
--- a/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/mixin.py
+++ b/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/mixin.py
@@ -277,7 +277,7 @@ class DistBucketedWeightUpdateMixin:
         rank transmits."""
         from megatron.bridge.peft.multi_lora_layers import expose_adapter_slot
 
-        from miles.utils.multi_lora import slot_lora_name
+        from miles.utils.multi_lora import serving_lora_name
 
         from ...multi_lora_utils import slice_lora_to_rank
 
@@ -302,7 +302,7 @@ class DistBucketedWeightUpdateMixin:
 
         self._update_multi_lora_weight_implementation(
             accumulated_named_tensors,
-            lora_name=slot_lora_name(adapter.slot),
+            lora_name=serving_lora_name(adapter.name, adapter.registration_id),
             lora_config=lora_config,
         )
 

--- a/miles/ray/multi_lora/backend.py
+++ b/miles/ray/multi_lora/backend.py
@@ -13,7 +13,7 @@ import httpx
 from miles.ray.multi_lora.registry import AdapterRegistry, AdapterState
 from miles.utils.adapter_config import AdapterRunConfig
 from miles.utils.http_utils import router_worker_base_urls
-from miles.utils.multi_lora import RID_SEPARATOR, min_groups_per_dp_split
+from miles.utils.multi_lora import min_groups_per_dp_split, rid_prefix
 
 logger = logging.getLogger(__name__)
 
@@ -150,7 +150,9 @@ class MultiLoRABackend:
     async def retire_adapters(self) -> list[str]:
         names = self.registry.retire_adapters()
         for name in names:
-            await self.abort_adapter_requests(name)
+            record = self.registry.records.get(name)
+            if record is not None:
+                await self.abort_adapter_requests(name, record.registration_id)
         return names
 
     async def free_slot(self, name: str) -> int:
@@ -158,7 +160,7 @@ class MultiLoRABackend:
         ``retire_adapters`` abort (e.g. multi-turn groups), and must not leak to the slot's next tenant."""
         record = self.registry.records.get(name)
         if record is not None and record.state is AdapterState.CLEANUP:
-            await self.abort_adapter_requests(name)
+            await self.abort_adapter_requests(name, record.registration_id)
         return self.registry.free_slot(name)
 
     async def worker_urls(self) -> list[str]:
@@ -175,8 +177,10 @@ class MultiLoRABackend:
                 continue
         return []
 
-    async def abort_adapter_requests(self, adapter_name: str) -> None:
-        prefix = f"{adapter_name}{RID_SEPARATOR}"
+    async def abort_adapter_requests(self, adapter_name: str, registration_id: str) -> None:
+        # Registration-scoped: a retiring tenant's abort must never match a
+        # same-name successor's in-flight requests (rid carries the registration).
+        prefix = rid_prefix(adapter_name, registration_id)
         urls = await self.worker_urls()
         if not urls:
             logger.warning(f"Abort for adapter '{adapter_name}': no workers discovered at {self.router_url}")

--- a/miles/rollout/generate_hub/multi_turn.py
+++ b/miles/rollout/generate_hub/multi_turn.py
@@ -51,7 +51,7 @@ async def generate(input: GenerateFnInput) -> GenerateFnOutput:
     for _turn in range(args.generate_max_turns):
         # ----------------------- Call inference endpoint -------------------------
 
-        payload, halt_status = compute_request_payload(args, sample.tokens, input.sampling_params)
+        payload, halt_status = compute_request_payload(args, sample.tokens, input.sampling_params, sample=sample)
         if payload is None:
             sample.status = halt_status
             break

--- a/miles/rollout/generate_hub/single_turn.py
+++ b/miles/rollout/generate_hub/single_turn.py
@@ -35,7 +35,11 @@ async def generate(input: GenerateFnInput) -> GenerateFnOutput:
         input_ids = prompt_ids
 
     payload, halt_status = compute_request_payload(
-        args, input_ids=input_ids, sampling_params=sampling_params, multimodal_inputs=sample.multimodal_inputs
+        args,
+        input_ids=input_ids,
+        sampling_params=sampling_params,
+        multimodal_inputs=sample.multimodal_inputs,
+        sample=sample,
     )
     if payload is None:
         sample.status = halt_status

--- a/miles/rollout/generate_utils/generate_endpoint_utils.py
+++ b/miles/rollout/generate_utils/generate_endpoint_utils.py
@@ -9,6 +9,7 @@ import numpy as np
 import pybase64
 
 from miles.utils.lora import LORA_ADAPTER_NAME, lora_rollout_enabled
+from miles.utils.multi_lora import cache_extra_key, make_rid, serving_lora_name
 from miles.utils.processing_utils import encode_image_for_rollout_engine, extract_multimodal_train_inputs
 from miles.utils.types import Sample
 
@@ -49,11 +50,37 @@ def compute_routing_headers(args, sample: Sample) -> dict[str, str] | None:
     return None
 
 
+def apply_adapter_routing(
+    args,
+    payload: dict,
+    sample: Sample | None,
+    serving_version: int | None = None,
+) -> dict:
+    """Single injection point for adapter serving routing (generation AND prefill
+    scoring): registration-scoped lora_path, prefix-abortable rid, and the
+    KV-cache namespace. Child rollout code never sees slots or serving aliases.
+
+    ``serving_version`` overrides the version stamped on the sample — the live
+    upsert path passes the adapter's current published revision so a request
+    running under fresh weights never reuses a previous revision's KV.
+    """
+    ref = sample.adapter if sample is not None else None
+    if ref is not None:
+        version = ref.serving_version if serving_version is None else serving_version
+        payload["lora_path"] = serving_lora_name(ref.name, ref.registration_id)
+        payload["rid"] = make_rid(ref.name, ref.registration_id)
+        payload["extra_key"] = cache_extra_key(ref.name, ref.registration_id, version)
+    elif lora_rollout_enabled(args):
+        payload["lora_path"] = LORA_ADAPTER_NAME
+    return payload
+
+
 def compute_request_payload(
     args,
     input_ids: list[int],
     sampling_params: dict,
     multimodal_inputs: dict | None = None,
+    sample: Sample | None = None,
 ) -> tuple[dict[str, Any] | None, Sample.Status | None]:
     sampling_params = deepcopy(sampling_params)
     max_new_tokens = sampling_params.pop("max_new_tokens", args.rollout_max_response_len)
@@ -69,8 +96,7 @@ def compute_request_payload(
         "return_routed_experts": args.use_rollout_routing_replay,
         "return_indexer_topk": args.use_rollout_indexer_replay,
     }
-    if lora_rollout_enabled(args):
-        payload["lora_path"] = LORA_ADAPTER_NAME
+    apply_adapter_routing(args, payload, sample)
     if image_data := (multimodal_inputs or {}).get("images"):
         payload["image_data"] = [encode_image_for_rollout_engine(image) for image in image_data]
 

--- a/miles/rollout/generate_utils/prefill_logprobs.py
+++ b/miles/rollout/generate_utils/prefill_logprobs.py
@@ -7,15 +7,17 @@ from typing import Any
 from miles.rollout.generate_utils.generate_endpoint_utils import compute_routing_headers, policy_uses_routing_key
 from miles.utils.http_utils import post
 from miles.utils.lora import LORA_ADAPTER_NAME, lora_rollout_enabled
-from miles.utils.multi_lora import slot_lora_name
+from miles.utils.multi_lora import serving_lora_name
 from miles.utils.processing_utils import encode_image_for_rollout_engine
 from miles.utils.types import Sample
 
 
 def _lora_path_for_sample(args: Any, sample: Sample) -> str | None:
-    """Adapter name to score under: the sample slot's __miles_slot_{N} name, the fixed single-LoRA name, or None."""
+    """Adapter name to score under: the sample's registration-scoped serving name,
+    the fixed single-LoRA name, or None. Must agree with apply_adapter_routing —
+    prefill scoring runs under the same engine adapter the rollout used."""
     if sample.adapter is not None:
-        return slot_lora_name(sample.adapter.slot)
+        return serving_lora_name(sample.adapter.name, sample.adapter.registration_id)
     if lora_rollout_enabled(args):
         return LORA_ADAPTER_NAME
     return None

--- a/miles/rollout/multi_lora/data_source.py
+++ b/miles/rollout/multi_lora/data_source.py
@@ -102,7 +102,12 @@ class MultiLoRAAsyncDataSource(DataSource):
 
             adapter = adapters[name]
             config = adapter.config
-            ref = AdapterRef(name=name, slot=adapter.slot)
+            ref = AdapterRef(
+                name=name,
+                registration_id=adapter.registration_id,
+                serving_version=adapter.version,
+                slot=adapter.slot,
+            )
             reward_spec = RewardSpec(rm_type=config.rm_type, custom_rm_path=config.custom_rm_path)
             for sample in groups[0]:
                 sample.adapter = ref

--- a/miles/rollout/sglang_rollout.py
+++ b/miles/rollout/sglang_rollout.py
@@ -15,6 +15,7 @@ from tqdm import tqdm
 
 from miles.rollout.base_types import GenerateFnInput, RolloutFnEvalOutput, RolloutFnTrainOutput
 from miles.rollout.filter_hub.base_types import MetricGatherer, call_dynamic_filter
+from miles.rollout.generate_utils.generate_endpoint_utils import apply_adapter_routing
 from miles.rollout.inference_rollout.compatibility import load_generate_function
 from miles.utils import dumper_utils
 from miles.utils.async_utils import run
@@ -24,7 +25,7 @@ from miles.utils.http_utils import get, post, router_worker_base_urls
 from miles.utils.lifecycle import TrajectoryLifecycle
 from miles.utils.lora import LORA_ADAPTER_NAME, lora_rollout_enabled
 from miles.utils.misc import SingletonMeta, call_agent_abort_hook, load_function
-from miles.utils.multi_lora import make_rid, slot_lora_name
+from miles.utils.multi_lora import is_multi_lora_enabled, rid_prefix
 from miles.utils.processing_utils import (
     call_processor,
     encode_image_for_rollout_engine,
@@ -237,9 +238,10 @@ async def generate(args: Namespace, sample: Sample, sampling_params: dict[str, A
             )
             sample.status = Sample.Status.ABORTED
             return sample
-        payload["lora_path"] = slot_lora_name(sample.adapter.slot)
-        payload["rid"] = make_rid(sample.adapter.name)
-        payload["extra_key"] = f"{sample.adapter.name}:v{adapter.version}"
+        # Live-upsert mode: namespace the KV cache by the adapter's CURRENT
+        # published revision, not the one stamped at sample time — the request
+        # runs under the live weights.
+        apply_adapter_routing(args, payload, sample, serving_version=adapter.version)
     elif lora_rollout_enabled(args):
         payload["lora_path"] = LORA_ADAPTER_NAME
 
@@ -449,7 +451,19 @@ async def abort(args: Namespace, rollout_id: int) -> list[list[Sample]]:
     urls = router_worker_base_urls(urls)
 
     logger.info(f"Abort request for {urls}")
-    abort_tasks = [post(f"{url}/abort_request", {"abort_all": True}) for url in urls]
+    if is_multi_lora_enabled(args):
+        # Never abort_all under multi-LoRA: the engines are shared by every
+        # tenant, and this end-of-rollout cleanup must not kill other adapters'
+        # in-flight requests. Abort each live registration's rid namespace.
+        from miles.rollout.multi_lora.data_source import fetch_snapshot, sampleable
+
+        payloads = [
+            {"rid": rid_prefix(name, run.registration_id), "prefix": True}
+            for name, run in sampleable(fetch_snapshot()).items()
+        ]
+    else:
+        payloads = [{"abort_all": True}]
+    abort_tasks = [post(f"{url}/abort_request", payload) for url in urls for payload in payloads]
     abort_results = await asyncio.gather(*abort_tasks, return_exceptions=True)
     for url, result in zip(urls, abort_results, strict=False):
         if isinstance(result, Exception):

--- a/miles/utils/multi_lora.py
+++ b/miles/utils/multi_lora.py
@@ -15,9 +15,12 @@ __all__ = [
     "RID_SEPARATOR",
     "define_new_adapter_metrics",
     "is_multi_lora_enabled",
+    "cache_extra_key",
     "make_rid",
     "min_groups_per_dp_split",
     "parse_adapter",
+    "rid_prefix",
+    "serving_lora_name",
     "slot_lora_name",
     "validate_multi_lora_args",
 ]
@@ -180,12 +183,35 @@ def validate_multi_lora_args(args: Any) -> None:
     args.megatron_to_hf_mode = "bridge"
 
 
-def make_rid(adapter_name: str) -> str:
-    return f"{adapter_name}{RID_SEPARATOR}{uuid.uuid4().hex}"
+def make_rid(adapter_name: str, registration_id: str) -> str:
+    """Request id carrying the full registration: a stale tenant's prefix abort
+    can never match a same-name successor's requests."""
+    return f"{adapter_name}{RID_SEPARATOR}{registration_id}{RID_SEPARATOR}{uuid.uuid4().hex}"
+
+
+def rid_prefix(adapter_name: str, registration_id: str) -> str:
+    """Abort-by-prefix namespace for one registration of one adapter."""
+    return f"{adapter_name}{RID_SEPARATOR}{registration_id}{RID_SEPARATOR}"
 
 
 def parse_adapter(rid: str) -> str:
-    return rid.rsplit(RID_SEPARATOR, 1)[0]
+    # The separator cannot appear in adapter names, so the first segment is the name.
+    return rid.split(RID_SEPARATOR, 1)[0]
+
+
+def serving_lora_name(adapter_name: str, registration_id: str) -> str:
+    """Engine-side LoRA adapter name for one registration. Weight pushes and every
+    inference request (rollout and prefill scoring) must agree on this. The full
+    registration id is part of the identity: a re-registered name is a new tenant,
+    a new engine lora_id, and a new KV-cache namespace (anti-ABA). Never parsed
+    back — the engine registry keys on the full string."""
+    return f"__miles_adapter_{adapter_name}_{registration_id}"
+
+
+def cache_extra_key(adapter_name: str, registration_id: str, serving_version: int) -> str:
+    """KV-cache namespace: registration and serving version both enter the key, so
+    neither a re-registered name nor a republished revision can reuse stale KV."""
+    return f"{adapter_name}:{registration_id}:v{serving_version}"
 
 
 def slot_lora_name(slot: int) -> str:

--- a/miles/utils/types.py
+++ b/miles/utils/types.py
@@ -8,10 +8,22 @@ import torch
 
 @dataclass(frozen=True)
 class AdapterRef:
-    """Which LoRA adapter a sample is bound to (training slot routing, inference lora_path); ``None`` = no adapter."""
+    """Serving identity of the LoRA adapter a sample is bound to; ``None`` = no adapter.
+
+    Serving routing (lora_path / rid / KV-cache namespace) derives from
+    ``(name, registration_id)`` — a re-registered name is a new tenant with a
+    fresh namespace, so a stale abort or cache entry can never cross tenants.
+    ``serving_version`` is the adapter's published weight revision at sample
+    time.
+
+    ``slot`` is TRANSITIONAL: the trainer-side sample->slot mapping still reads
+    it; serving routing must never use it.
+    """
 
     name: str
-    slot: int
+    registration_id: str
+    serving_version: int
+    slot: int | None
 
 
 @dataclass(frozen=True)
@@ -175,7 +187,8 @@ class Sample:
         return sample
 
     def get_reward_value(self, args) -> float:
-        return self.reward if not args.reward_key else self.reward[args.reward_key]
+        reward_key = getattr(args, "reward_key", None)
+        return self.reward if not reward_key else self.reward[reward_key]
 
     @property
     def effective_response_length(self):

--- a/tests/fast/ray/multi_lora/test_controller_backend.py
+++ b/tests/fast/ray/multi_lora/test_controller_backend.py
@@ -60,7 +60,7 @@ def register_and_promote(registry: AdapterRegistry, name: str, config=None) -> N
 
 def test_rid_roundtrip_preserves_names_with_underscores():
     for name in ["a", "adapter_a", "weird__name", "x_y_z"]:
-        assert parse_adapter(make_rid(name)) == name
+        assert parse_adapter(make_rid(name, "reg1")) == name
 
 
 def test_register_starts_pending_and_push_promotes():
@@ -280,7 +280,7 @@ async def test_free_slot_reaborts_before_releasing_slot():
     backend = make_backend()
     aborted: list[str] = []
 
-    async def record_abort(name: str) -> None:
+    async def record_abort(name: str, registration_id: str) -> None:
         aborted.append(name)
 
     backend.abort_adapter_requests = record_abort
@@ -300,7 +300,7 @@ async def test_free_slot_skips_abort_when_not_in_cleanup():
     backend = make_backend()
     aborted: list[str] = []
 
-    async def record_abort(name: str) -> None:
+    async def record_abort(name: str, registration_id: str) -> None:
         aborted.append(name)
 
     backend.abort_adapter_requests = record_abort

--- a/tests/fast/ray/multi_lora/test_controller_http.py
+++ b/tests/fast/ray/multi_lora/test_controller_http.py
@@ -143,7 +143,10 @@ async def test_deregister_marks_and_retire_adapters_aborts():
 
         applied = await ctl.backend.retire_adapters()
         assert applied == ["A"]
-        assert ctl.aborts == [{"rid": f"A{RID_SEPARATOR}", "prefix": True}]
+        # Registration-scoped abort (anti-ABA): the prefix carries the retiring
+        # tenant's registration id, never the bare name.
+        registration_id = ctl.backend.registry.records["A"].registration_id
+        assert ctl.aborts == [{"rid": f"A{RID_SEPARATOR}{registration_id}{RID_SEPARATOR}", "prefix": True}]
         assert ctl.backend.registry.active_adapters() == {}
 
 

--- a/tests/fast/ray/rollout/test_multi_lora_batch_collection.py
+++ b/tests/fast/ray/rollout/test_multi_lora_batch_collection.py
@@ -79,7 +79,10 @@ def make_group(
 ) -> list[Sample]:
     samples = []
     for _ in range(adapter.config.n_samples_per_prompt):
-        sample = Sample(prompt="p", adapter=AdapterRef(adapter.name, adapter.slot))
+        sample = Sample(
+            prompt="p",
+            adapter=AdapterRef(adapter.name, registration_id="reg1", serving_version=1, slot=adapter.slot),
+        )
         if slot_version is not None:
             sample.metadata["slot_version"] = slot_version
         if registration_id is not None:

--- a/tests/fast/ray/rollout/test_multi_lora_process_group.py
+++ b/tests/fast/ray/rollout/test_multi_lora_process_group.py
@@ -48,7 +48,7 @@ async def test_process_group_stamps_submission_version(monkeypatch):
 
     monkeypatch.setattr(mod, "AdaptersCache", lambda: cache)
 
-    g = [Sample(prompt="p", adapter=AdapterRef("A", 0))]
+    g = [Sample(prompt="p", adapter=AdapterRef("A", registration_id="ra", serving_version=1, slot=0))]
     result = await process_group(None, g, {}, gen, FakeDataSource())
 
     assert result is g

--- a/tests/fast/ray/rollout/test_multi_lora_train_data.py
+++ b/tests/fast/ray/rollout/test_multi_lora_train_data.py
@@ -37,7 +37,7 @@ def adapter_group(
     group = []
     for k in range(n_samples):
         sample = make_sample(index=start_index + k, reward=rewards[k])
-        sample.adapter = AdapterRef(name, slot)
+        sample.adapter = AdapterRef(name, registration_id=f"reg-{name}", serving_version=1, slot=slot)
         sample.metadata = {"adapter_global_batch_size": adapter_global_batch_size}
         group.append(sample)
     return group

--- a/tests/fast/rollout/generate_utils/test_adapter_routing.py
+++ b/tests/fast/rollout/generate_utils/test_adapter_routing.py
@@ -1,0 +1,60 @@
+"""Registration-scoped adapter routing: the single injection point that stamps
+serving identity onto engine requests (lora_path, prefix-abortable rid, and
+the KV-cache namespace), and the live-upsert serving_version override."""
+
+from types import SimpleNamespace
+
+from miles.rollout.generate_utils.generate_endpoint_utils import apply_adapter_routing
+from miles.utils.lora import LORA_ADAPTER_NAME
+from miles.utils.multi_lora import cache_extra_key, rid_prefix, serving_lora_name
+from miles.utils.types import AdapterRef, Sample
+
+
+def make_adapter_sample(version: int = 3) -> Sample:
+    sample = Sample(prompt="p")
+    sample.adapter = AdapterRef(name="a", registration_id="reg1", serving_version=version, slot=0)
+    return sample
+
+
+def base_args(**overrides) -> SimpleNamespace:
+    defaults = dict(multi_lora=True, lora_rank=16, lora_adapter_path=None, lora_train_only=False)
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def test_routing_is_registration_scoped():
+    payload: dict = {}
+    apply_adapter_routing(base_args(), payload, make_adapter_sample())
+    assert payload["lora_path"] == serving_lora_name("a", "reg1")
+    # rid lives in the registration's abort namespace: DELETE aborts by this prefix.
+    assert payload["rid"].startswith(rid_prefix("a", "reg1"))
+    assert payload["extra_key"] == cache_extra_key("a", "reg1", 3)
+
+
+def test_serving_version_override_renames_the_kv_namespace():
+    # The live-upsert path routes under the adapter's CURRENT published
+    # revision, not the one stamped at sample-submission time.
+    payload: dict = {}
+    apply_adapter_routing(base_args(), payload, make_adapter_sample(version=3), serving_version=5)
+    assert payload["extra_key"] == cache_extra_key("a", "reg1", 5)
+    assert payload["lora_path"] == serving_lora_name("a", "reg1")
+
+
+def test_two_registrations_of_one_name_never_share_identity():
+    first, second = {}, {}
+    sample = make_adapter_sample()
+    apply_adapter_routing(base_args(), first, sample)
+    sample.adapter = AdapterRef(name="a", registration_id="reg2", serving_version=1, slot=0)
+    apply_adapter_routing(base_args(), second, sample)
+    assert first["lora_path"] != second["lora_path"]
+    assert first["extra_key"] != second["extra_key"]
+    assert first["rid"] != second["rid"]
+
+
+def test_adapterless_sample_uses_single_lora_only_when_rollout_enabled():
+    payload: dict = {}
+    apply_adapter_routing(base_args(lora_train_only=True), payload, Sample(prompt="p"))
+    assert "lora_path" not in payload
+    payload = {}
+    apply_adapter_routing(base_args(), payload, Sample(prompt="p"))
+    assert payload["lora_path"] == LORA_ADAPTER_NAME

--- a/tests/fast/rollout/generate_utils/test_prefill_logprobs.py
+++ b/tests/fast/rollout/generate_utils/test_prefill_logprobs.py
@@ -121,7 +121,7 @@ async def test_recompute_uses_per_sample_adapter_lora_path(monkeypatch):
         tokens=[10, 11, 20],
         response_length=1,
         status=Sample.Status.COMPLETED,
-        adapter=AdapterRef(name="run-a", slot=3),
+        adapter=AdapterRef(name="run-a", registration_id="ra1", serving_version=1, slot=3),
     )
     # Multi-LoRA forces lora_rank > 0, so is_lora_enabled(args) is always true.
     args = SimpleNamespace(recompute_logprobs_via_prefill=True, lora_rank=8)
@@ -140,7 +140,7 @@ async def test_recompute_uses_per_sample_adapter_lora_path(monkeypatch):
         sampling_params={},
     )
 
-    assert seen["payload"]["lora_path"] == "__miles_slot_3"
+    assert seen["payload"]["lora_path"] == "__miles_adapter_run-a_ra1"
     assert sample.rollout_log_probs == [-0.5]
 
 
@@ -153,19 +153,19 @@ async def test_recompute_samples_batches_group_by_adapter(monkeypatch):
             tokens=[10, 11, 20],
             response_length=1,
             status=Sample.Status.COMPLETED,
-            adapter=AdapterRef(name="run-a", slot=0),
+            adapter=AdapterRef(name="run-a", registration_id="ra1", serving_version=1, slot=0),
         ),
         Sample(
             tokens=[10, 11, 21],
             response_length=1,
             status=Sample.Status.COMPLETED,
-            adapter=AdapterRef(name="run-b", slot=1),
+            adapter=AdapterRef(name="run-b", registration_id="rb1", serving_version=1, slot=1),
         ),
         Sample(
             tokens=[10, 11, 22],
             response_length=1,
             status=Sample.Status.COMPLETED,
-            adapter=AdapterRef(name="run-a", slot=0),
+            adapter=AdapterRef(name="run-a", registration_id="ra1", serving_version=1, slot=0),
         ),
     ]
     args = SimpleNamespace(
@@ -196,15 +196,23 @@ async def test_recompute_samples_batches_group_by_adapter(monkeypatch):
     assert [sample.rollout_log_probs for sample in samples] == [[-20.0], [-21.0], [-22.0]]
     by_lora_path = {payload["lora_path"]: payload["input_ids"] for payload in generate_payloads}
     assert by_lora_path == {
-        "__miles_slot_0": [[10, 11, 20], [10, 11, 22]],
-        "__miles_slot_1": [[10, 11, 21]],
+        "__miles_adapter_run-a_ra1": [[10, 11, 20], [10, 11, 22]],
+        "__miles_adapter_run-b_rb1": [[10, 11, 21]],
     }
 
 
 def test_batch_payload_rejects_mixed_lora_paths():
     samples = [
-        Sample(tokens=[10, 11, 20], response_length=1, adapter=AdapterRef(name="run-a", slot=0)),
-        Sample(tokens=[10, 11, 21], response_length=1, adapter=AdapterRef(name="run-b", slot=1)),
+        Sample(
+            tokens=[10, 11, 20],
+            response_length=1,
+            adapter=AdapterRef(name="run-a", registration_id="ra1", serving_version=1, slot=0),
+        ),
+        Sample(
+            tokens=[10, 11, 21],
+            response_length=1,
+            adapter=AdapterRef(name="run-b", registration_id="rb1", serving_version=1, slot=1),
+        ),
     ]
     args = SimpleNamespace(lora_rank=8)
 


### PR DESCRIPTION
Part 2/4 of the #2137 split (stacked on #2208; diff shows only this layer).

Serving names, request ids, and KV-cache keys carry the registration id (anti-ABA): a re-registered name is a new tenant with a fresh namespace, so a stale abort, weight push, or cache entry can never cross tenants.

- `serving_lora_name` / `make_rid` / `rid_prefix` / `cache_extra_key` derive every engine-facing identity from `(name, registration_id)`.
- `apply_adapter_routing` is the single injection point for generation AND prefill scoring, with a `serving_version` override for the live-upsert path.
- `AdapterRef` carries `registration_id`/`serving_version`; weight pushes register under the registration-scoped name; retire/free_slot aborts target one registration's rid prefix; the end-of-rollout abort under multi-LoRA never `abort_all`s shared engines.
- The existing rollout path keeps working unchanged apart from the wider identity; new adapter-routing unit tests pin the scheme.

Validated: full fast suite green on this tree (4045 tests).

Series: #2208 1/4 → 2/4 (this) → 3/4 → 4/4.