### PR TITLE
[multi-lora] 3/4: SlotPool bind transactions and optimizer-inclusive slot sidecars

### DIFF
--- a/miles/backends/megatron_utils/multi_lora_checkpoint.py
+++ b/miles/backends/megatron_utils/multi_lora_checkpoint.py
@@ -1,0 +1,275 @@
+"""Optimizer-inclusive per-slot checkpoints: the slot swap primitive.
+
+One sidecar format serves slot swap-out/swap-in, periodic per-adapter saves,
+and the future Tinker ``save_state``/load-with-optimizer. The payload must be
+complete for numeric equivalence: bf16 slot weights, fp32
+master params (NOT re-derivable from bf16 — reloading would drop the low
+mantissa bits), Adam moments AND both step counters (per-param ``state["step"]``
+and per-group ``group["step"]`` — FusedAdam tracks bias correction per group),
+plus rank/alpha (non-persistent Bridge buffers, replayed via
+``init_adapter_slot``). The LR scheduler is NOT serialized: its clock is the
+optimizer step count, so ``install_slot_scheduler(..., resume_step)`` rebuilds
+it exactly.
+
+Stable parameter names strip the slot index (``...adapters.{slot}.`` ->
+``...adapter.``), matching the exposed-slot export convention that
+``load_adapter`` already consumes — state can move between slots and, later,
+between training clients.
+
+Distributed layout: every rank writes its own shard (tp/pp/ep-sharded weights,
+rank-owned optimizer state under the LayerWise whole-param DP scatter); each
+shard is written atomically (tmp + rename); rank 0 commits a manifest after a
+barrier. A load first validates the manifest and topology, then mutates the
+slot.
+"""
+
+import logging
+import os
+import re
+from pathlib import Path
+
+import torch
+import torch.distributed as dist
+
+logger = logging.getLogger(__name__)
+
+FORMAT = "miles-multi-lora-slot-v2"
+_SLOT_INDEX = re.compile(r"\.adapters\.(\d+)\.")
+
+
+def stable_slot_param_name(name: str, slot: int) -> str:
+    """``...adapters.{slot}.linear_in.weight`` -> ``...adapter.linear_in.weight``.
+
+    Matches the exposed-slot naming that ``load_adapter`` consumes, so the
+    weights section of a sidecar is directly loadable into ANY slot."""
+    return _SLOT_INDEX.sub(lambda m: ".adapter." if int(m.group(1)) == slot else m.group(0), name)
+
+
+def named_adapter_slot_parameters(model, slot: int):
+    """Yield (stable_name, model_param) for one slot, in deterministic
+    module-traversal order across chunks."""
+    from megatron.bridge.peft.multi_lora_layers import MultiLoRALinear
+
+    marker = f".adapters.{slot}."
+    seen: set[int] = set()
+    model_chunks = model if isinstance(model, (list, tuple)) else [model]
+    for model_chunk in model_chunks:
+        for module_name, module in model_chunk.named_modules():
+            if not isinstance(module, MultiLoRALinear):
+                continue
+            for param_name, param in module.named_parameters(prefix=module_name):
+                if marker in param_name and id(param) not in seen:
+                    seen.add(id(param))
+                    yield stable_slot_param_name(param_name, slot), param
+
+
+def _slot_adam_index(optimizer, slot: int) -> dict[int, dict]:
+    """id(main param or param) -> raw Adam state, across the slot's children."""
+    from miles.backends.megatron_utils.multi_lora_optimizer import _slot_children
+
+    index: dict[int, dict] = {}
+    for child in _slot_children(optimizer, slot):
+        raw = getattr(child, "optimizer", child)
+        for param, state in raw.state.items():
+            index[id(param)] = state
+    return index
+
+
+def _slot_group_steps(optimizer, slot: int) -> list:
+    from miles.backends.megatron_utils.multi_lora_optimizer import _slot_children
+
+    return [group.get("step", 0) for child in _slot_children(optimizer, slot) for group in child.param_groups]
+
+
+def sidecar_dir(adapter) -> Path | None:
+    save = adapter.config.save
+    return Path(save) / "slot_state" if save is not None else None
+
+
+def _shard_path(base: Path, rank: int) -> Path:
+    return base / f"shard_rank{rank:05d}.pt"
+
+
+def save_slot_state(args, model, optimizer, adapter, *, reason: str = "swap") -> Path | None:
+    """Write-through sidecar: the durable record of the slot's full
+    training state. Returns the manifest path (rank 0) or the shard path."""
+    base = sidecar_dir(adapter)
+    if base is None:
+        # Adapters without a save dir are not swap-eligible; callers
+        # must pin them instead. Reaching here is a caller bug for swaps.
+        logger.warning(f"[multilora] ({adapter.name}) no save dir; slot state NOT persisted ({reason})")
+        return None
+    base.mkdir(parents=True, exist_ok=True)
+
+    slot = adapter.slot
+    adam_index = _slot_adam_index(optimizer, slot)
+    weights: dict[str, torch.Tensor] = {}
+    masters: dict[str, torch.Tensor] = {}
+    adam_state: dict[str, dict] = {}
+    for stable_name, param in named_adapter_slot_parameters(model, slot):
+        weights[stable_name] = param.detach().cpu()
+        main = getattr(param, "main_param", None)
+        state = adam_index.get(id(main)) if main is not None else None
+        if state is None:
+            state = adam_index.get(id(param))
+        if main is not None:
+            masters[stable_name] = main.detach().cpu()
+        if state:
+            adam_state[stable_name] = {
+                key: (value.detach().cpu() if torch.is_tensor(value) else value) for key, value in state.items()
+            }
+
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    payload = {
+        "format": FORMAT,
+        "name": adapter.name,
+        "registration_id": adapter.registration_id,
+        "rank_lora": adapter.config.rank,
+        "alpha": adapter.config.alpha,
+        "weights": weights,
+        "master_params": masters,
+        "adam_state": adam_state,
+        "group_steps": _slot_group_steps(optimizer, slot),
+        "clocks": {"optimizer_step": adapter.step, "serving_version": adapter.version},
+        "topology": {
+            "rank": rank,
+            "world_size": dist.get_world_size() if dist.is_initialized() else 1,
+        },
+        "reason": reason,
+    }
+    shard = _shard_path(base, rank)
+    tmp = shard.with_suffix(".tmp")
+    torch.save(payload, tmp)
+    os.replace(tmp, shard)  # atomic per shard: a crash never leaves a torn file
+
+    if dist.is_initialized():
+        dist.barrier()
+    manifest = base / "manifest.pt"
+    if rank == 0:
+        # Committed only after every rank's shard landed; the loader treats a
+        # missing/older manifest as "no valid sidecar".
+        tmp_manifest = manifest.with_suffix(".tmp")
+        torch.save(
+            {
+                "format": FORMAT,
+                "name": adapter.name,
+                "registration_id": adapter.registration_id,
+                "optimizer_step": adapter.step,
+                "world_size": payload["topology"]["world_size"],
+            },
+            tmp_manifest,
+        )
+        os.replace(tmp_manifest, manifest)
+    if dist.is_initialized():
+        dist.barrier()
+    logger.info(f"[multilora] ({adapter.name}) slot state saved at step {adapter.step} ({reason})")
+    return manifest if rank == 0 else shard
+
+
+def find_slot_state(adapter) -> Path | None:
+    """The sidecar base dir, only if a committed manifest matches this
+    registration's world topology."""
+    base = sidecar_dir(adapter)
+    if base is None or not (base / "manifest.pt").exists():
+        return None
+    manifest = torch.load(base / "manifest.pt", map_location="cpu", weights_only=True)
+    if manifest.get("format") != FORMAT or manifest.get("name") != adapter.name:
+        return None
+    world = dist.get_world_size() if dist.is_initialized() else 1
+    if manifest.get("world_size") != world:
+        logger.warning(
+            f"[multilora] ({adapter.name}) sidecar world_size {manifest.get('world_size')} != {world}; ignoring"
+        )
+        return None
+    return base
+
+
+def load_slot_state(args, model, optimizer, adapter) -> int | None:
+    """Restore a slot from its sidecar. Ordering matters: weights ->
+    rank/alpha replay -> slot-scoped master rebuild -> overwrite masters and
+    Adam state (incl. both step counters) from the sidecar. Returns the
+    restored optimizer step, or None when no sidecar exists (the caller falls
+    back to the weights-only checkpoint path with fresh Adam state). A sidecar
+    can legitimately carry step 0 — an adapter swapped out before its first
+    optimizer step — and its restored state must not be re-initialized."""
+    from megatron.bridge.peft.multi_lora_layers import init_adapter_slot, load_adapter
+
+    from miles.backends.megatron_utils.multi_lora_optimizer import reload_adapter_slot_model_params
+
+    base = find_slot_state(adapter)
+    if base is None:
+        return None
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    shard = _shard_path(base, rank)
+    payload = torch.load(shard, map_location="cpu", weights_only=True)
+    if payload.get("format") != FORMAT or payload.get("name") != adapter.name:
+        raise ValueError(f"[multilora] ({adapter.name}) sidecar shard mismatch at {shard}")
+
+    slot = adapter.slot
+    loaded = load_adapter(model, slot, payload["weights"])
+    assert loaded > 0, f"[multilora] ({adapter.name}) sidecar restored 0 weight tensors"
+    init_adapter_slot(model, slot, rank=payload["rank_lora"], alpha=payload["alpha"])
+    # Slot-scoped: a global reload would quantize every other resident slot's
+    # fp32 master through bf16.
+    reload_adapter_slot_model_params(optimizer, slot)
+
+    adam_index = _slot_adam_index(optimizer, slot)
+    masters = payload["master_params"]
+    adam_state = payload["adam_state"]
+    for stable_name, param in named_adapter_slot_parameters(model, slot):
+        main = getattr(param, "main_param", None)
+        if main is not None and stable_name in masters:
+            main.data.copy_(masters[stable_name].to(device=main.device, dtype=main.dtype))
+        state = adam_index.get(id(main)) if main is not None else adam_index.get(id(param))
+        if state is not None and stable_name in adam_state:
+            for key, value in adam_state[stable_name].items():
+                if torch.is_tensor(value) and key in state and torch.is_tensor(state[key]):
+                    state[key].copy_(value.to(device=state[key].device, dtype=state[key].dtype))
+                else:
+                    state[key] = value
+
+    from miles.backends.megatron_utils.multi_lora_optimizer import _slot_children
+
+    saved_group_steps = payload["group_steps"]
+    groups = [g for child in _slot_children(optimizer, slot) for g in child.param_groups]
+    for group, step in zip(groups, saved_group_steps, strict=False):
+        if step:
+            group["step"] = step
+
+    restored_step = int(payload["clocks"]["optimizer_step"])
+    logger.info(f"[multilora] ({adapter.name}) slot state restored at step {restored_step}")
+    return restored_step
+
+
+def swap_out(args, model, optimizer, adapter) -> None:
+    """Persist the tenant's full state, then vacate the slot for the next
+    tenant: optimizer state and retained grads must never leak across."""
+    from megatron.bridge.peft.multi_lora_layers import clear_adapter_slot
+
+    from miles.backends.megatron_utils.multi_lora_optimizer import zero_adapter_slot_grads
+    from miles.backends.megatron_utils.multi_lora_scheduler import drop_slot_scheduler
+    from miles.backends.megatron_utils.multi_lora_utils import zero_optimizer_state_for_adapter
+
+    save_slot_state(args, model, optimizer, adapter, reason="swap")
+    clear_adapter_slot(model, adapter.slot)
+    zero_optimizer_state_for_adapter(optimizer, model, adapter.slot)
+    zero_adapter_slot_grads(model, adapter.slot)
+    drop_slot_scheduler(optimizer, adapter.slot)
+
+
+def swap_in(args, model, optimizer, adapter) -> int:
+    """Bind a tenant into a (vacated) slot: sidecar restore when one exists,
+    otherwise the weights-only registration path. Installs the scheduler at
+    the restored step (the scheduler clock IS the optimizer step count)."""
+    from miles.backends.megatron_utils.multi_lora_scheduler import install_slot_scheduler
+
+    restored_step = load_slot_state(args, model, optimizer, adapter)
+    if restored_step is None:
+        from miles.backends.megatron_utils.multi_lora_utils import _register_adapter
+
+        restored_step = _register_adapter(adapter, model)
+        from miles.backends.megatron_utils.multi_lora_optimizer import reload_adapter_slot_model_params
+
+        reload_adapter_slot_model_params(optimizer, adapter.slot)
+    install_slot_scheduler(args, optimizer, adapter, restored_step)
+    return restored_step

--- a/miles/ray/multi_lora/slot_pool.py
+++ b/miles/ray/multi_lora/slot_pool.py
@@ -1,0 +1,154 @@
+"""Slot pool: trainer-slot tenancy for multi-LoRA adapters.
+
+A slot is a rented container, not an adapter identity: it holds
+the Megatron adapter weights, the per-slot optimizer state, and the per-slot
+scheduler while a tenant is bound. Registration-time binding (``bind_immediately``)
+serves today's fixed-slot lifetime and Option 1's bootstrap; bind transactions
+(``plan_bind`` / ``commit_bind`` / ``abort_bind``) serve bind-at-selection under
+slot oversubscription.
+
+All mutations must run on the controller actor's driver-sequenced path — never
+from HTTP handlers.
+"""
+
+from dataclasses import dataclass, field
+
+# (adapter name, registration id): a re-registered name is a different tenant.
+Tenant = tuple[str, str]
+
+
+@dataclass
+class SlotEntry:
+    slot: int
+    tenant: Tenant | None = None
+    # Non-empty pins make the entry non-evictable. "selected" spans a bind
+    # transaction's plan -> commit/abort window; callers with longer-lived
+    # protection needs use pin()/unpin() with their own reason.
+    pins: set = field(default_factory=set)
+    # A reservation hides the entry from further victim picks until its bind
+    # transaction commits or aborts. Without it one plan can hand the same
+    # free slot to two adapters.
+    reserved_by: str | None = None
+    proposed_tenant: Tenant | None = None
+    lru_tick: int = 0
+
+
+class SlotPool:
+    def __init__(self, n_slots: int) -> None:
+        self.entries = [SlotEntry(slot=i) for i in range(n_slots)]
+        self._tick = 0
+
+    # -------------------------- queries --------------------------
+
+    def entry_of(self, tenant: Tenant):
+        for entry in self.entries:
+            if entry.tenant == tenant:
+                return entry
+        return None
+
+    def free_slot_ids(self) -> set[int]:
+        return {e.slot for e in self.entries if e.tenant is None and e.reserved_by is None}
+
+    def bindable_count(self) -> int:
+        return sum(1 for e in self.entries if (e.tenant is None or not e.pins) and e.reserved_by is None)
+
+    # ---------------------- immediate tenancy ----------------------
+
+    def bind_immediately(self, tenant: Tenant) -> int | None:
+        """Bind to the lowest free slot, never evicting (registration/bootstrap
+        must queue rather than displace a resident tenant). None when full."""
+        entry = self._pick_victim(allow_evict=False)
+        if entry is None:
+            return None
+        entry.tenant = tenant
+        self._touch(entry)
+        return entry.slot
+
+    def release(self, tenant: Tenant) -> int | None:
+        """Return the tenant's slot to the free pool (retirement path)."""
+        entry = self.entry_of(tenant)
+        if entry is None:
+            return None
+        assert entry.reserved_by is None, f"slot {entry.slot} released mid bind-transaction"
+        entry.tenant = None
+        entry.pins.clear()
+        return entry.slot
+
+    # -------------------------- pins --------------------------
+
+    def pin(self, tenant: Tenant, reason: str) -> None:
+        if (entry := self.entry_of(tenant)) is not None:
+            entry.pins.add(reason)
+
+    def unpin(self, tenant: Tenant, reason: str) -> None:
+        if (entry := self.entry_of(tenant)) is not None:
+            entry.pins.discard(reason)
+
+    # ---------------------- bind transactions ----------------------
+
+    def plan_bind(self, txn_id: str, tenants: list[Tenant]) -> dict[Tenant, dict]:
+        """Authoritative admission for one selection: reserve a slot per tenant
+        and return {tenant: {"slot", "evict", "txn_id"}}. Keep-warm hits reserve
+        their own slots first, so a co-selected resident is never picked as an
+        eviction victim; the rest place into free or LRU-evictable slots in the
+        caller's selection order (round-robin fairness decides who is omitted
+        when the pool is short). Omitted tenants re-queue as READY. Reservations
+        are provisional until commit_bind/abort_bind."""
+        plan: dict[Tenant, dict] = {}
+        placing: list[Tenant] = []
+        for tenant in tenants:
+            if (entry := self.entry_of(tenant)) is not None:
+                if entry.reserved_by is None:
+                    self._reserve(entry, txn_id, tenant)
+                    plan[tenant] = {"slot": entry.slot, "evict": None, "txn_id": txn_id}
+                continue
+            placing.append(tenant)
+        for tenant in placing:
+            if (entry := self._pick_victim(allow_evict=True)) is None:
+                continue
+            evict = entry.tenant
+            self._reserve(entry, txn_id, tenant)
+            plan[tenant] = {"slot": entry.slot, "evict": evict, "txn_id": txn_id}
+        return plan
+
+    def commit_bind(self, txn_id: str) -> None:
+        """Reservations become tenancy. The "selected" pin only protects the
+        plan -> commit/abort window, so it clears here: committed tenants must
+        stay LRU-evictable or every slot that ever hosted a selection would be
+        pinned forever and the pool would stop admitting new tenants."""
+        for entry in self.entries:
+            if entry.reserved_by == txn_id:
+                entry.tenant = entry.proposed_tenant
+                entry.reserved_by = None
+                entry.proposed_tenant = None
+                entry.pins.discard("selected")
+                self._touch(entry)
+
+    def abort_bind(self, txn_id: str) -> None:
+        """Roll every reservation of this transaction back; evicted-in-plan
+        tenants were never actually swapped out."""
+        for entry in self.entries:
+            if entry.reserved_by == txn_id:
+                entry.reserved_by = None
+                entry.proposed_tenant = None
+                entry.pins.discard("selected")
+
+    # -------------------------- internal --------------------------
+
+    def _reserve(self, entry: SlotEntry, txn_id: str, tenant: Tenant) -> None:
+        entry.reserved_by = txn_id
+        entry.proposed_tenant = tenant
+        entry.pins.add("selected")
+
+    def _pick_victim(self, allow_evict: bool):
+        free = [e for e in self.entries if e.tenant is None and e.reserved_by is None]
+        if free:
+            return free[0]
+        if not allow_evict:
+            return None
+        idle = [e for e in self.entries if not e.pins and e.reserved_by is None]
+        return min(idle, key=lambda e: e.lru_tick, default=None)
+
+    def _touch(self, entry: SlotEntry) -> None:
+        self._tick += 1
+        entry.lru_tick = self._tick

--- a/tests/fast/backends/megatron_utils/test_multi_lora_checkpoint.py
+++ b/tests/fast/backends/megatron_utils/test_multi_lora_checkpoint.py
@@ -1,0 +1,91 @@
+"""Slot-state sidecar: stable naming and manifest gating.
+
+The stable name must strip EXACTLY the target slot's index — stripping a
+co-tenant's would let one adapter's sidecar overwrite another slot's weights
+on load."""
+
+from types import SimpleNamespace
+
+import torch
+
+from miles.backends.megatron_utils.multi_lora_checkpoint import FORMAT, find_slot_state, stable_slot_param_name
+
+
+class TestStableName:
+    def test_strips_only_the_target_slot(self):
+        name = "decoder.layers.0.self_attention.linear_qkv.adapters.3.linear_in.weight"
+        assert stable_slot_param_name(name, 3) == "decoder.layers.0.self_attention.linear_qkv.adapter.linear_in.weight"
+        # A co-tenant's index must survive untouched.
+        assert stable_slot_param_name(name, 2) == name
+
+    def test_matches_exposed_export_convention(self):
+        # load_adapter consumes ".adapter." keys (the expose_adapter_slot
+        # export layout) — the sidecar weights section reuses that contract.
+        assert ".adapter." in stable_slot_param_name("m.adapters.0.linear_out.weight", 0)
+
+    def test_double_digit_slots(self):
+        name = "m.adapters.12.linear_in.weight"
+        assert stable_slot_param_name(name, 12) == "m.adapter.linear_in.weight"
+        assert stable_slot_param_name(name, 1) == name
+
+
+class TestManifestGating:
+    def _adapter(self, tmp_path, name="a"):
+        config = SimpleNamespace(save=tmp_path, rank=8, alpha=16)
+        return SimpleNamespace(name=name, registration_id="r1", slot=0, step=3, version=2, config=config)
+
+    def test_no_manifest_means_no_sidecar(self, tmp_path):
+        adapter = self._adapter(tmp_path)
+        (tmp_path / "slot_state").mkdir()
+        assert find_slot_state(adapter) is None
+
+    def test_manifest_must_match_name_and_world(self, tmp_path):
+        adapter = self._adapter(tmp_path)
+        base = tmp_path / "slot_state"
+        base.mkdir()
+        torch.save(
+            {"format": FORMAT, "name": "someone-else", "optimizer_step": 3, "world_size": 1},
+            base / "manifest.pt",
+        )
+        assert find_slot_state(adapter) is None
+
+        torch.save(
+            {"format": FORMAT, "name": "a", "optimizer_step": 3, "world_size": 1},
+            base / "manifest.pt",
+        )
+        assert find_slot_state(adapter) == base
+
+    def test_no_save_dir_means_no_sidecar(self):
+        adapter = SimpleNamespace(config=SimpleNamespace(save=None))
+        assert find_slot_state(adapter) is None
+
+
+class TestSwapInSidecarSentinel:
+    """A sidecar that exists with optimizer step 0 (an adapter swapped out
+    before its first step) must be restored as-is — only a MISSING sidecar
+    (None) may fall back to the weights-only registration re-init."""
+
+    def _swap_in_with(self, monkeypatch, load_result):
+        import miles.backends.megatron_utils.multi_lora_checkpoint as mlc
+        import miles.backends.megatron_utils.multi_lora_optimizer as mlo
+        import miles.backends.megatron_utils.multi_lora_scheduler as mls
+        import miles.backends.megatron_utils.multi_lora_utils as mlu
+
+        calls = []
+        monkeypatch.setattr(mlc, "load_slot_state", lambda *a, **k: load_result)
+        monkeypatch.setattr(mlu, "_register_adapter", lambda *a, **k: calls.append("register") or 0)
+        monkeypatch.setattr(mlo, "reload_adapter_slot_model_params", lambda *a, **k: calls.append("reload"))
+        monkeypatch.setattr(mls, "install_slot_scheduler", lambda *a, **k: calls.append("scheduler"))
+        adapter = SimpleNamespace(name="a", slot=0)
+        step = mlc.swap_in(args=SimpleNamespace(), model=[], optimizer=None, adapter=adapter)
+        return step, calls
+
+    def test_step_zero_sidecar_is_not_reinitialized(self, monkeypatch):
+        step, calls = self._swap_in_with(monkeypatch, load_result=0)
+        assert step == 0
+        assert calls == ["scheduler"]  # no register, no master re-derivation
+
+    def test_missing_sidecar_falls_back_to_registration(self, monkeypatch):
+        step, calls = self._swap_in_with(monkeypatch, load_result=None)
+        assert step == 0
+        assert calls == ["register", "reload", "scheduler"]

--- a/tests/fast/ray/multi_lora/test_slot_pool.py
+++ b/tests/fast/ray/multi_lora/test_slot_pool.py
@@ -1,0 +1,139 @@
+"""SlotPool: tenancy, reservations, and bind-transaction semantics.
+
+The double-allocation case is a design-review regression: without
+reservations, one plan_bind pass handed the same free slot to two adapters
+because the free branch only checked ``tenant is None``.
+"""
+
+from miles.ray.multi_lora.slot_pool import SlotPool
+
+
+def tenant(name: str, reg: str = "r1") -> tuple[str, str]:
+    return (name, reg)
+
+
+class TestImmediateTenancy:
+    def test_binds_lowest_free_slot(self):
+        pool = SlotPool(3)
+        assert pool.bind_immediately(tenant("a")) == 0
+        assert pool.bind_immediately(tenant("b")) == 1
+        assert pool.free_slot_ids() == {2}
+
+    def test_full_pool_returns_none_and_never_evicts(self):
+        pool = SlotPool(1)
+        assert pool.bind_immediately(tenant("a")) == 0
+        # Registration/bootstrap must queue, not displace a resident tenant.
+        assert pool.bind_immediately(tenant("b")) is None
+
+    def test_release_returns_slot_to_free_pool(self):
+        pool = SlotPool(2)
+        pool.bind_immediately(tenant("a"))
+        assert pool.release(tenant("a")) == 0
+        assert pool.free_slot_ids() == {0, 1}
+        assert pool.release(tenant("never-bound")) is None
+
+
+class TestPlanBind:
+    def test_two_unbound_adapters_get_distinct_slots(self):
+        # Double-allocation regression: the second adapter must not receive slot 0 again.
+        pool = SlotPool(2)
+        plan = pool.plan_bind("txn1", [tenant("a"), tenant("b")])
+        slots = {entry["slot"] for entry in plan.values()}
+        assert len(plan) == 2
+        assert len(slots) == 2
+
+    def test_keep_warm_hit_reuses_bound_slot_without_evict(self):
+        pool = SlotPool(2)
+        pool.bind_immediately(tenant("a"))
+        plan = pool.plan_bind("txn1", [tenant("a")])
+        assert plan[tenant("a")] == {"slot": 0, "evict": None, "txn_id": "txn1"}
+
+    def test_eviction_picks_lru_idle_tenant(self):
+        pool = SlotPool(2)
+        pool.bind_immediately(tenant("old"))
+        pool.bind_immediately(tenant("hot"))
+        pool._touch(pool.entry_of(tenant("old")))
+        pool._touch(pool.entry_of(tenant("hot")))  # "hot" is most recent
+        pool._touch(pool.entry_of(tenant("hot")))
+        plan = pool.plan_bind("txn1", [tenant("new")])
+        assert plan[tenant("new")]["evict"] == tenant("old")
+
+    def test_pinned_slots_are_not_evictable(self):
+        pool = SlotPool(1)
+        pool.bind_immediately(tenant("a"))
+        pool.pin(tenant("a"), "publish_pending")
+        assert pool.plan_bind("txn1", [tenant("b")]) == {}
+        pool.unpin(tenant("a"), "publish_pending")
+        assert tenant("b") in pool.plan_bind("txn2", [tenant("b")])
+
+    def test_overlapping_transactions_cannot_share_a_slot(self):
+        pool = SlotPool(1)
+        plan1 = pool.plan_bind("txn1", [tenant("a")])
+        plan2 = pool.plan_bind("txn2", [tenant("b")])
+        assert tenant("a") in plan1
+        assert plan2 == {}  # reserved by txn1, invisible to txn2
+
+    def test_reserved_keep_warm_slot_defers_its_tenant(self):
+        pool = SlotPool(2)
+        pool.bind_immediately(tenant("a"))
+        pool.plan_bind("txn1", [tenant("b"), tenant("a")])  # "b" may evict... nothing: free slot 1
+        # a's own slot got reserved for a; a second txn selecting "a" defers.
+        assert pool.plan_bind("txn2", [tenant("a")]) == {}
+
+    def test_admission_priority_follows_selection_order(self):
+        # When the pool is short, the caller's round-robin order decides who
+        # is omitted — not the tenants' alphabetical order.
+        pool = SlotPool(1)
+        plan = pool.plan_bind("txn1", [tenant("z"), tenant("a")])
+        assert tenant("z") in plan
+        assert tenant("a") not in plan
+
+    def test_co_selected_resident_is_never_its_plans_eviction_victim(self):
+        # Keep-warm hits reserve first: a resident tenant selected in the same
+        # plan must keep its slot rather than be evicted for an earlier-listed
+        # newcomer (churn would swap it out and back for no reason).
+        pool = SlotPool(1)
+        pool.bind_immediately(tenant("a"))
+        plan = pool.plan_bind("txn1", [tenant("b"), tenant("a")])
+        assert plan[tenant("a")] == {"slot": 0, "evict": None, "txn_id": "txn1"}
+        assert tenant("b") not in plan
+
+
+class TestCommitAbort:
+    def test_commit_transfers_tenancy(self):
+        pool = SlotPool(1)
+        pool.bind_immediately(tenant("a"))
+        plan = pool.plan_bind("txn1", [tenant("b")])
+        assert plan[tenant("b")]["evict"] == tenant("a")
+        pool.commit_bind("txn1")
+        assert pool.entry_of(tenant("b")).slot == 0
+        assert pool.entry_of(tenant("a")) is None
+
+    def test_commit_clears_selection_pin_keeping_slot_evictable(self):
+        # The "selected" pin only guards the plan -> commit window. If commit
+        # left it in place, every slot that ever hosted a selection would stay
+        # pinned forever and the pool would stop admitting new tenants.
+        pool = SlotPool(1)
+        pool.plan_bind("txn1", [tenant("a")])
+        pool.commit_bind("txn1")
+        assert pool.bindable_count() == 1
+        plan = pool.plan_bind("txn2", [tenant("b")])
+        assert plan[tenant("b")]["evict"] == tenant("a")
+
+    def test_abort_rolls_back_reservation_and_keeps_old_tenant(self):
+        pool = SlotPool(1)
+        pool.bind_immediately(tenant("a"))
+        pool.plan_bind("txn1", [tenant("b")])
+        pool.abort_bind("txn1")
+        assert pool.entry_of(tenant("a")).slot == 0
+        assert pool.entry_of(tenant("b")) is None
+        # The slot is bindable again after the rollback.
+        assert tenant("c") in pool.plan_bind("txn2", [tenant("c")])
+
+    def test_bindable_count_excludes_reserved_and_pinned(self):
+        pool = SlotPool(3)
+        pool.bind_immediately(tenant("a"))
+        pool.pin(tenant("a"), "training")
+        pool.plan_bind("txn1", [tenant("b")])
+        # slot0 pinned, slot1 reserved by txn1, slot2 free
+        assert pool.bindable_count() == 1


### PR DESCRIPTION
Part 3/4 of the #2137 split (stacked on #2209; diff shows only this layer).

Two self-contained, purely additive components for slot oversubscription — nothing is wired into the trainer loop yet (4/4 does the switch), so this layer is zero-risk to the running path:

- **SlotPool**: trainer-slot tenancy as rented containers, with transactional `plan_bind`/`commit_bind`/`abort_bind` (reservations prevent one plan from handing the same free slot to two adapters), keep-warm LRU eviction, pins, and selection-order admission.
- **Slot sidecars**: one checkpoint format for swap-out/swap-in and per-adapter saves — bf16 slot weights, fp32 masters (not re-derivable from bf16), Adam moments with both step counters, rank/alpha — in per-rank atomic shards behind a rank-0 manifest. A step-0 sidecar is a legitimate state, distinguished from a missing one.

23 unit tests pin the transaction, pin-lifecycle, naming, and sentinel semantics.

Series: #2208 → #2209 → 3/4 (this) → 4/4.