### PR TITLE
fix(ci): calibrate lora E2E estimates from nightly runs and halve GLM5 lora matrices

### DIFF
--- a/tests/e2e/megatron/model_scripts/test_glm5_1_744b_a40b_6layer_lora_ci.py
+++ b/tests/e2e/megatron/model_scripts/test_glm5_1_744b_a40b_6layer_lora_ci.py
@@ -6,12 +6,14 @@ from tests.ci.ci_register import register_cuda_ci
 import miles.utils.external_utils.command_utils as U
 
 # Smoke test for scripts/run_glm5_1_744b_a40b_lora.py on the 6-layer toy (full rollout ->
-# train -> save loop). Runs the MoE-expert LoRA matrix — {shared-outer + virtual-experts,
-# per-expert + no-virtual-experts} x {tilelang, megatron} — and every combination must pass.
+# train -> save loop). Runs one diagonal of the MoE-expert LoRA matrix — {tilelang +
+# shared-outer + virtual-experts, megatron + per-expert + no-virtual-experts} — and every
+# combination must pass. The GLM-5.2 5-layer sibling runs the complementary diagonal, so
+# nightly still covers all four {dsa backend} x {lora layout} cells across the pair.
 # Functionality, not accuracy; 8 GPUs (TP=EP=8).
 
 
-register_cuda_ci(est_time=2400, suite="stage-c-8-gpu-h200", labels=["megatron", "model-scripts", "lora"])
+register_cuda_ci(est_time=1300, suite="stage-c-8-gpu-h200", labels=["megatron", "model-scripts", "lora"])
 
 # skip the engine-side stacked params a frozen-base LoRA run cannot re-ship
 # (they keep their correct checkpoint values; everything else is verified)
@@ -22,8 +24,6 @@ _BASE_EXTRA = (
 # (name, dsa_attention_backend, experts_shared_outer_loras, virtual_experts_serving)
 _CONFIGS = [
     ("tilelang + shared-outer + virtual-experts", "tilelang", True, True),
-    ("megatron + shared-outer + virtual-experts", "megatron", True, True),
-    ("tilelang + per-expert + no-virtual-experts", "tilelang", False, False),
     ("megatron + per-expert + no-virtual-experts", "megatron", False, False),
 ]
 

--- a/tests/e2e/megatron/model_scripts/test_glm5_2_744b_a40b_5layer_lora_ci.py
+++ b/tests/e2e/megatron/model_scripts/test_glm5_2_744b_a40b_5layer_lora_ci.py
@@ -6,12 +6,14 @@ from tests.ci.ci_register import register_cuda_ci
 import miles.utils.external_utils.command_utils as U
 
 # Smoke test for scripts/run_glm5_2_744b_a40b_lora.py on the 5-layer toy (DSA cross-layer
-# path, full rollout -> train -> save loop). Runs the MoE-expert LoRA matrix — {shared-outer +
-# virtual-experts, per-expert + no-virtual-experts} x {tilelang, megatron} — and every
-# combination must pass. Functionality, not accuracy; 4 GPUs (TP=EP=4).
+# path, full rollout -> train -> save loop). Runs one diagonal of the MoE-expert LoRA
+# matrix — {megatron + shared-outer + virtual-experts, tilelang + per-expert +
+# no-virtual-experts} — and every combination must pass. The GLM-5.1 6-layer sibling runs
+# the complementary diagonal, so nightly still covers all four {dsa backend} x {lora layout}
+# cells across the pair. Functionality, not accuracy; 4 GPUs (TP=EP=4).
 
 
-register_cuda_ci(est_time=2400, suite="stage-c-4-gpu-h200", labels=["megatron", "model-scripts", "lora"])
+register_cuda_ci(est_time=1200, suite="stage-c-4-gpu-h200", labels=["megatron", "model-scripts", "lora"])
 
 # skip the engine-side stacked params a frozen-base LoRA run cannot re-ship
 # (they keep their correct checkpoint values; everything else is verified)
@@ -21,10 +23,8 @@ _BASE_EXTRA = (
 
 # (name, dsa_attention_backend, experts_shared_outer_loras, virtual_experts_serving)
 _CONFIGS = [
-    ("tilelang + shared-outer + virtual-experts", "tilelang", True, True),
     ("megatron + shared-outer + virtual-experts", "megatron", True, True),
     ("tilelang + per-expert + no-virtual-experts", "tilelang", False, False),
-    ("megatron + per-expert + no-virtual-experts", "megatron", False, False),
 ]
 
 

--- a/tests/e2e/megatron/model_scripts/test_inkling_small_4layer_lora_ci.py
+++ b/tests/e2e/megatron/model_scripts/test_inkling_small_4layer_lora_ci.py
@@ -12,7 +12,7 @@ import miles.utils.external_utils.command_utils as U
 
 
 register_cuda_ci(
-    est_time=1800,
+    est_time=800,
     suite="stage-c-4-gpu-h200",
     labels=["megatron", "model-scripts", "lora"],
 )

--- a/tests/e2e/megatron/test_qwen3_5_35b_a3b_lora_ci.py
+++ b/tests/e2e/megatron/test_qwen3_5_35b_a3b_lora_ci.py
@@ -12,7 +12,7 @@ import miles.utils.external_utils.command_utils as U
 # combination must pass. Functionality, not accuracy; 8 GPUs (TP2, EP=8).
 
 
-register_cuda_ci(est_time=1300, suite="stage-c-8-gpu-h100", labels=["model-scripts"])
+register_cuda_ci(est_time=1300, suite="stage-c-8-gpu-h100", labels=["megatron", "model-scripts", "lora"])
 
 # (name, experts_shared_outer_loras, virtual_experts_serving)
 _CONFIGS = [

--- a/tests/e2e/megatron/test_qwen3_5_35b_a3b_lora_ci.py
+++ b/tests/e2e/megatron/test_qwen3_5_35b_a3b_lora_ci.py
@@ -12,7 +12,7 @@ import miles.utils.external_utils.command_utils as U
 # combination must pass. Functionality, not accuracy; 8 GPUs (TP2, EP=8).
 
 
-register_cuda_ci(est_time=3600, suite="stage-c-8-gpu-h100", labels=["model-scripts"])
+register_cuda_ci(est_time=1300, suite="stage-c-8-gpu-h100", labels=["model-scripts"])
 
 # (name, experts_shared_outer_loras, virtual_experts_serving)
 _CONFIGS = [


### PR DESCRIPTION
## Summary

Lora e2e est_time values were far above measured nightly runtimes (up to 3600 vs ~960s measured). This PR calibrates them from complete nightly logs and halves the two GLM5 lora matrix tests via complementary diagonals, per `.claude/skills/ci-e2e-time-tune`.

Evidence: complete job logs of nightly runs [30926155662](https://github.com/radixark/miles/actions/runs/30926155662) (Aug 4, primary) and [30754322985](https://github.com/radixark/miles/actions/runs/30754322985) (Aug 2, corroboration; night-to-night drift <2%). Proposals are `max(elapsed of passed attempts) × 1.25`, rounded up to the 100s bucket, max across both nights.

| lora test | measured | est before | est after | change |
|---|---|---|---|---|
| `megatron/test_qwen3_5_35b_a3b_lora_ci.py` | 957–966s | 3600 | **1300** | est only |
| `model_scripts/test_inkling_small_4layer_lora_ci.py` | 568s | 1800 | **800** | est only |
| `model_scripts/test_glm5_1_744b_a40b_6layer_lora_ci.py` | 1826s → ~985s | 2400 | **1300** | 4→2 combos + est |
| `model_scripts/test_glm5_2_744b_a40b_5layer_lora_ci.py` | 1793–1829s → ~896s | 2400 | **1200** | 4→2 combos + est |
| `model_scripts/test_gpt_oss_20b_moe_lora_ci.py` | 1216–1228s | 1600 | 1600 | keep |
| `lora/test_lora_qwen2.5_0.5B.py` | 281–285s | 400 | 400 | keep |

## GLM5 matrix reduction

Both GLM5 lora tests ran the full 2×2 matrix `{tilelang, megatron} × {shared-outer + virtual-experts, per-expert + no-virtual-experts}` (~430–530s per combo, with fresh ray/sglang restarts between combos). They now run **complementary diagonals**:

- GLM5.1 (6-layer, TP=EP=8): `tilelang + shared-outer + virtual-experts`, `megatron + per-expert + no-virtual-experts`
- GLM5.2 (5-layer cross-layer DSA, TP=EP=4): `megatron + shared-outer + virtual-experts`, `tilelang + per-expert + no-virtual-experts`

All four matrix cells still run nightly across the pair, and each file still exercises both DSA backends and both LoRA layouts. The two dimensions plumb into disjoint code (the DSA backend is train-side only and never reaches SGLang ServerArgs; the expert-LoRA layout never touches attention/qkv-format), so no dropped cell exercises a unique code path.

This also removes a timeout fragility: the 4-combo runs measured 1825–1829s, above the 1800s default per-file timeout — they passed only because est=2400 raised the effective timeout (`max(1800, est×1.25)`) to 3000s. The reduced runtimes clear the floor with ~2× headroom.

Net effect: ~1750 GPU-seconds saved per nightly run; lora est total 12200 → 6600s, improving LPT partition packing.

## Validation

- `run_suite.py --list-only` verified for all affected suites/partitions (stage-c-4-gpu-h200 ×3, stage-c-8-gpu-h200 ×2, stage-c-8-gpu-h100 ×2): new estimates appear, partition totals sensible.
- Evidence CSV re-derived mechanically and cross-checked against the skill formula (including bucket boundary cases); per-combo timings re-derived from raw log timestamps.
- All six lora test files are byte-identical between the evidence runs' head SHAs and this branch's base, so the measurements transfer directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)