### PR TITLE
fix(mtp): double-shift GPT-path MTP labels

### DIFF
--- a/miles/backends/megatron_utils/model.py
+++ b/miles/backends/megatron_utils/model.py
@@ -537,11 +537,7 @@ def train_one_step(
             }
 
             if args.enable_mtp_training:
-                # Megatron-core's MTP loss expects next-token-shifted labels
-                # (labels[i] == token[i+1]); it rolls -1 once more per MTP depth.
-                # Raw tokens would make the MTP target off-by-one and blow up
-                # mtp_loss against the pretrained MTP head, so pre-shift here.
-                forward_kwargs["mtp_kwargs"] = {"mtp_labels": torch.roll(batch["tokens"], shifts=-1, dims=-1)}
+                forward_kwargs["mtp_kwargs"] = {"mtp_labels": batch["tokens"]}
 
             if (x := batch["multimodal_train_inputs"]) is not None:
                 forward_kwargs.update(x)

--- a/miles_plugins/megatron_bridge/nemotron_h.py
+++ b/miles_plugins/megatron_bridge/nemotron_h.py
@@ -24,6 +24,8 @@ from __future__ import annotations
 
 import logging
 
+import torch
+
 logger = logging.getLogger(__name__)
 
 
@@ -196,12 +198,9 @@ def _install_mamba_model_loss_mask_shim() -> None:
     _orig_forward = MambaModel.forward
 
     def forward(self, *args, loss_mask=None, mtp_kwargs=None, **kwargs):
-        import torch
-
+        # process_mtp_loss expects next-token-shifted labels; miles passes raw tokens.
         mtp_labels = (mtp_kwargs or {}).get("mtp_labels")
         if mtp_labels is not None:
-            # process_mtp_loss starts from next-token-shifted labels and rolls -1
-            # once per depth; miles passes raw tokens, so shift once here.
             mtp_labels = torch.roll(mtp_labels, shifts=-1, dims=-1)
         return _orig_forward(self, *args, loss_mask=loss_mask, mtp_labels=mtp_labels, **kwargs)
 

--- a/miles_plugins/megatron_bridge/nemotron_h.py
+++ b/miles_plugins/megatron_bridge/nemotron_h.py
@@ -196,7 +196,13 @@ def _install_mamba_model_loss_mask_shim() -> None:
     _orig_forward = MambaModel.forward
 
     def forward(self, *args, loss_mask=None, mtp_kwargs=None, **kwargs):
+        import torch
+
         mtp_labels = (mtp_kwargs or {}).get("mtp_labels")
+        if mtp_labels is not None:
+            # process_mtp_loss starts from next-token-shifted labels and rolls -1
+            # once per depth; miles passes raw tokens, so shift once here.
+            mtp_labels = torch.roll(mtp_labels, shifts=-1, dims=-1)
         return _orig_forward(self, *args, loss_mask=loss_mask, mtp_labels=mtp_labels, **kwargs)
 
     MambaModel.forward = forward


### PR DESCRIPTION
The `torch.roll(-1)` pre-shift of `mtp_labels` added in #1284 matches `process_mtp_loss`'s convention (next-token-shifted labels, one more roll per depth) — the mamba/bridge path nemotron uses. But the GPT inline path in `gpt_model._postprocess` pre-rolls raw tokens itself, so the pre-shift makes every GPT MTP model train against targets off by one: [`test_mtp1_spec_v2_r3` fails](https://github.com/radixark/miles/actions/runs/30975836635/job/92210473534) with `MTP loss 14.57 > 1.0` (first surfaced on PR #1572's CI, unrelated to that PR).

Fix: pass raw tokens again and do the shift in the NemotronH forward shim — the entry point of the only path that wants the shifted convention. Net semantics for nemotron are unchanged (same shift, applied at the path-specific boundary instead of the shared one).

Convention summary after this PR: `mtp_kwargs["mtp_labels"]` always carries **raw tokens**; the GPT inline block rolls twice itself (pre-loop + per-depth), the mamba path shifts once in the shim before `process_mtp_loss` rolls per-depth.

**Verified on 8xH200, together with Megatron-LM#78 (both are required):**
- `test_mtp1_spec_v2_r3` (qwen3.5, MTP training + spec-v2 + R3, tp2/pp2/ep4): passes end to end, `mtp_loss` 0.39–0.49 (was 14.57), R3 replay check within threshold.
- Nemotron 4-layer smoke (`--ci-test`): passes, no regressions. Note its CI config does not enable `--enable-mtp-training`, so the shim path itself is covered by the convention argument above rather than CI.

Reviewer note: qwen35-labelled tests don't run on model-scripts-labelled PRs, which is how #1284 missed this — the MTP tests may deserve a broader suite/label.
