### PR TITLE
Add the GLM-5.2 744B x terminal-bench-2 Daytona example

### DIFF
--- a/examples/experimental/openenv/glm52_tbench2/README.md
+++ b/examples/experimental/openenv/glm52_tbench2/README.md
@@ -1,0 +1,140 @@
+# GLM-5.2 744B-A40B — agentic RL on terminal-bench-2 (Daytona sandboxes)
+
+Fully-async RL on 16 GB300 nodes (4 GPUs each): **8 training nodes**
+(TP2/CP4/PP4/EP8, optimizer state streamed to node-local disk) and **8
+inference nodes** (one 4-GPU dp-attention fp8 sglang engine per node). Every
+episode is a multi-turn terminal agent solving one terminal-bench-2 task inside
+its **own** Daytona cloud sandbox, built from that task's official image;
+scoring is the task's canonical `tests/test.sh`.
+
+All experiment settings live in `run_glm5_2_744b_a40b_daytona.py` — its
+defaults are the reference configuration, and
+
+```bash
+python3 run_glm5_2_744b_a40b_daytona.py train --num-nodes 16
+```
+
+reproduces it. `launch_16node_slurm.sh` is a ~60-line site adapter (container +
+Ray bring-up) that forwards its own CLI args to the recipe.
+
+Reference run: 100 rollout steps in 21 h wall clock (~6.5 min/step incl. evals
+every 10), rollout truncation 0.0–0.3, prefix-cache hit rate ≈0.96, engine
+fleet fully utilized (~90–100 concurrent generating requests across 32 dp
+ranks at `--async-max-concurrent-samples 128`).
+
+## What the config does
+
+| | |
+|---|---|
+| Training | 8 nodes, TP2 / CP4 / PP4 (18-20-20-20 layer split) / EP8. CP4 splits the 131k max sequence to ~33k per rank; DP1 leaves optimizer state unsharded, so `--stream-optimizer-state-to-disk` is mandatory, not an optimization |
+| Inference | 8 nodes, one 4-GPU engine each: dp-attention (dp=4) + deepep, EAGLE 1/1/2, fp8 KV. `--sglang-config low-latency` switches to one TP8 engine per node pair with EAGLE 5/1/6 |
+| KV budget | `--sglang-mem-fraction-static 0.85` → ~553k KV tokens per dp rank. At the older 0.75 the pool was 26k tokens: trajectories hard-failed past ~26k input, 84% of samples truncated, and one long trajectory saturated a rank |
+| Async | `train_async.py` + `FullyAsyncRolloutFn`; 128 in-flight trajectories decoupled from the 64-sample train batch; `--rollout-submission-granularity sample` frees a submission slot per finished sample rather than per finished group |
+| Routing | dp-attention implies dp-aware routing (set automatically); without it, requests pile onto one dp rank per engine while the other three idle |
+| Episodes | 30 turns, 3600 s wall clock, 16k tokens/turn, 131k session; thinking at GLM-5.2's default `Reasoning Effort: Max` |
+| Eval | every 10 rollouts over a held-out tbench2 split, on the shared rollout engines (the producer pauses). 20 tasks x 2 samples has σ≈0.08 — single-eval movements below that are noise; raise `--n-samples-per-eval-prompt` to tighten |
+| Sandboxes | one per episode, deleted at episode end; labelled `openenv-tbench2-task` / `openenv-launcher` / `openenv-run-id` |
+
+Rollout mechanics are shared with other recipes and live one directory up: the
+agent loop and Daytona backend in `../openenv_daytona_agent_function.py`, the
+reward hook in `../openenv_generate.py`, dataset generation in
+`../make_tbench2_data.py`.
+
+## Prerequisites
+
+**Container image.** A miles runtime image whose sglang includes
+sgl-project/sglang#33478 (NextN unified-loader attributes — EAGLE draft load
+crashes without it) and sgl-project/sglang#33479 (DSA cuda-graph page table in
+the pausable memory region — a paused engine keeps tens of GB resident without
+it). Do not put a separate sglang checkout on `PYTHONPATH`.
+
+**Python packages**, installed in the image or once per node (the recipe
+asserts them at launch):
+
+```bash
+pip install openenv daytona fastmcp
+pip install --no-build-isolation --no-deps -e $OPENENV_ROOT/envs/tbench2_env
+```
+
+`tbench2_env` must be installed **editable from the OpenEnv checkout**, not
+from a wheel: the per-task sandbox image recipe embeds the package source
+(`pyproject.toml`, `openenv.yaml`) in the Daytona build context, and a wheel
+install into `site-packages` carries neither.
+
+**Megatron** with the streamed-optimizer checkpoint hooks
+(radixark/Megatron-LM#63); pass the checkout via `--megatron-path`.
+
+**terminal-bench-2 checkout** — task definitions; each `task.toml` names the
+official `docker_image`. Point `OPENENV_TB2_TASKS_DIR` at it.
+
+**Daytona** org with quota for `--async-max-concurrent-samples` concurrent
+sandboxes (128 in the reference config; each 2 vCPU / 4 GiB / 10 GiB). Keep
+the credential in a file outside git:
+
+```bash
+printf 'export DAYTONA_API_KEY=dtn_...\n' > ~/.daytona_env && chmod 600 ~/.daytona_env
+```
+
+Images are built per task and cached by definition hash (first episode of a
+task ~10 min, repeats ~1 min).
+
+**Model and data** under `--model-dir` / `--data-dir`:
+
+```bash
+$MODEL_DIR/GLM-5.2_torch_dist   # training; tools/convert_hf_to_torch_dist.py
+$MODEL_DIR/GLM-5.2_fp8          # rollout;  tools/convert_hf_to_fp8.py
+
+python examples/experimental/openenv/make_tbench2_data.py \
+    --tasks_dir $OPENENV_TB2_TASKS_DIR --output $DATA_DIR/tbench2_train.jsonl
+# hold out a disjoint task set as $DATA_DIR/tbench2_eval.jsonl for the eval
+```
+
+Prompt `metadata.task_id` must match a directory name in the TB2 checkout —
+that id selects the per-episode sandbox image.
+
+## Run
+
+```bash
+export MILES_ROOT=...  CONTAINER_IMAGE=...  CONTAINER_MOUNTS=...
+export DAYTONA_ENV_FILE=~/.daytona_env
+export OPENENV_TB2_TASKS_DIR=...
+export WANDB_API_KEY=...            # optional
+
+sbatch --export=ALL examples/experimental/openenv/glm52_tbench2/launch_16node_slurm.sh \
+    --model-dir $MODEL_DIR --data-dir $DATA_DIR --output-dir $OUTPUT_DIR
+```
+
+Anything after the launcher name goes to the recipe: `--num-rollout 10` for a
+short run, `--sglang-config low-latency`, `--eval-interval` to change cadence.
+Outside slurm, bring up your own Ray cluster and run the recipe command from
+the module docstring on the head node.
+
+Weights load from `--model-local-dir` (default: same as `--model-dir`);
+pre-staging both checkpoints to node-local disk saves a multi-minute NFS read
+per engine restart.
+
+## Watching it
+
+Telemetry lands under `$OUTPUT_DIR/<run_id>/dump_details`; serve the dashboard
+with `python -m miles.dashboard.serve --dump-details <dir> --follow`. Useful
+driver-log signals:
+
+```bash
+grep -E "raw_reward|truncated_ratio" run.out      # learning signal
+grep -c "episode failed" run.out                   # sandbox/env health (a few %% is normal)
+```
+
+Healthy steady state: `rollout/truncated_ratio` mostly under 0.3 (it tracks the
+hard-task mix), `queue_size` near 0, episode failures a few percent (Daytona
+connection blips; backfill absorbs them).
+
+## Debugging aids built into the recipe
+
+- `--debug-replay-data '<dir>/{rollout_id}.pt'` — replay recorded rollout
+  batches through the training side only (8 nodes, no engines, no sandboxes).
+  This is how parallelism/OOM changes are validated in minutes: the dumps under
+  `dump_details/rollout_data/` are loadable as-is.
+- `--load-from <run>/checkpoints` plus `--extra-args '--start-rollout-id 0'` —
+  score an existing checkpoint: eval runs on the loaded weights before any
+  training step. Keep `--num-rollout` equal to the source run's (the LR
+  scheduler validates it).

--- a/examples/experimental/openenv/glm52_tbench2/README.md
+++ b/examples/experimental/openenv/glm52_tbench2/README.md
@@ -42,11 +42,10 @@ reward hook in `../openenv_generate.py`, dataset generation in
 
 ## Prerequisites
 
-**Container image.** A miles runtime image whose sglang includes
-sgl-project/sglang#33478 (NextN unified-loader attributes — EAGLE draft load
-crashes without it) and sgl-project/sglang#33479 (DSA cuda-graph page table in
-the pausable memory region — a paused engine keeps tens of GB resident without
-it). Do not put a separate sglang checkout on `PYTHONPATH`.
+**Container image.** A miles runtime image with sglang from `sglang-miles`
+at 2026-08-04 or later (needs the NextN loader and pausable page-table fixes).
+Do not put a separate sglang checkout on `PYTHONPATH` — an older one shadows
+the image's.
 
 **Python packages**, installed in the image or once per node (the recipe
 asserts them at launch):

--- a/examples/experimental/openenv/glm52_tbench2/README.md
+++ b/examples/experimental/openenv/glm52_tbench2/README.md
@@ -43,9 +43,7 @@ reward hook in `../openenv_generate.py`, dataset generation in
 ## Prerequisites
 
 **Container image.** A miles runtime image with sglang from `sglang-miles`
-at 2026-08-04 or later (needs the NextN loader and pausable page-table fixes).
-Do not put a separate sglang checkout on `PYTHONPATH` — an older one shadows
-the image's.
+at 2026-08-04 or later.
 
 **Python packages**, installed in the image or once per node (the recipe
 asserts them at launch):

--- a/examples/experimental/openenv/glm52_tbench2/launch_16node_slurm.sh
+++ b/examples/experimental/openenv/glm52_tbench2/launch_16node_slurm.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# Site adapter for run_glm5_2_744b_a40b_daytona.py: container + Ray bring-up,
+# nothing else. Every experiment setting lives in the recipe; extra arguments
+# pass straight through to it:
+#
+#   sbatch --export=ALL launch_16node_slurm.sh [--num-rollout 10 ...]
+#
+#SBATCH --nodes=16
+#SBATCH --ntasks-per-node=1
+#SBATCH --gpus-per-node=4
+#SBATCH --mem=0
+#SBATCH --time=48:00:00
+set -uo pipefail
+
+: "${MILES_ROOT:?path to this miles checkout}"
+: "${CONTAINER_IMAGE:?squashfs image with the miles runtime}"
+: "${CONTAINER_MOUNTS:?must expose the checkouts, model/data dirs and node-local scratch}"
+: "${DAYTONA_ENV_FILE:?file exporting DAYTONA_API_KEY (chmod 600, never in git)}"
+
+RECIPE=$MILES_ROOT/examples/experimental/openenv/glm52_tbench2/run_glm5_2_744b_a40b_daytona.py
+RECIPE_ARGS=$(printf '%q ' "$@")
+C="--container-image=$CONTAINER_IMAGE --container-mounts=$CONTAINER_MOUNTS --container-name=ray"
+COMMON="export PYTHONNOUSERSITE=1 RAY_memory_monitor_refresh_ms=0 PYTHONPATH=$MILES_ROOT"
+
+nodes=( $(scontrol show hostnames "$SLURM_JOB_NODELIST") )
+# Compute-fabric IP: `hostname -I` ordering varies and the management subnet
+# is not routable between nodes, so select the fabric prefix explicitly.
+head_ip=$(srun --nodes=1 --ntasks=1 -w "${nodes[0]}" hostname -I | tr ' ' '\n' | grep -E "^${FABRIC_PREFIX:-10.}" | head -1)
+ngpu_total=$(( ${#nodes[@]} * 4 ))
+echo "head=${nodes[0]} ($head_ip)  nodes=${#nodes[@]}  gpus=$ngpu_total"
+
+srun --overlap --nodes=1 --ntasks=1 --gpus-per-node=4 -w "${nodes[0]}" $C bash -c "
+  $COMMON
+  ray start --head --node-ip-address=$head_ip --port=6379 --num-gpus=4 --disable-usage-stats
+  for t in \$(seq 1 90); do
+    ray status 2>/dev/null | grep -q '/$ngpu_total\.0 GPU' && break
+    echo \"waiting for ray nodes... (\$t/90)\"; sleep 10
+  done
+  source $DAYTONA_ENV_FILE
+  export MILES_SCRIPT_EXTERNAL_RAY=1 MASTER_ADDR=$head_ip OPENENV_RUN_ID=\${OPENENV_RUN_ID:-$SLURM_JOB_ID}
+  cd $MILES_ROOT
+  python3 $RECIPE train --num-nodes $SLURM_JOB_NUM_NODES $RECIPE_ARGS
+" &
+HEAD_PID=$!
+
+# Workers retry the join: head container extraction time varies, and a single
+# `ray start` attempt can time out before the head GCS is listening.
+sleep 30
+for ((i=1; i<${#nodes[@]}; i++)); do
+  srun --overlap --nodes=1 --ntasks=1 --gpus-per-node=4 -w "${nodes[$i]}" $C bash -c "
+    $COMMON
+    until ray start --address=$head_ip:6379 --num-gpus=4 --disable-usage-stats --block; do
+      echo 'worker retry ray join...'; sleep 10
+    done" &
+done
+
+wait $HEAD_PID
+echo "=== driver exited; stopping job ==="
+scancel "$SLURM_JOB_ID"

--- a/examples/experimental/openenv/glm52_tbench2/run_glm5_2_744b_a40b_daytona.py
+++ b/examples/experimental/openenv/glm52_tbench2/run_glm5_2_744b_a40b_daytona.py
@@ -305,7 +305,7 @@ def _execute_train(args: ScriptArgs):
         # so it goes through the Ray env rather than the launcher shell.
         "TORCH_NCCL_TRACE_BUFFER_SIZE": "4096",
         "TORCH_NCCL_DUMP_ON_TIMEOUT": "1",
-        "TORCH_NCCL_DEBUG_INFO_TEMP_FILE": os.environ.get("MILES_NCCL_TRACE_PREFIX", "/tmp/nccl_trace"),
+        "TORCH_NCCL_DEBUG_INFO_TEMP_FILE": "/tmp/nccl_trace",
         "SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK": "256",
         "SGLANG_NSA_FORCE_MLA": "1",
         # Node-local caches: the NFS defaults (~/.triton, ~/.cache/tvm-ffi)

--- a/examples/experimental/openenv/glm52_tbench2/run_glm5_2_744b_a40b_daytona.py
+++ b/examples/experimental/openenv/glm52_tbench2/run_glm5_2_744b_a40b_daytona.py
@@ -1,0 +1,355 @@
+"""GLM-5.2 744B-A40B x OpenEnv terminal-bench-2 on per-task Daytona sandboxes.
+
+Fully-async RL on 16 GB300 nodes (4 GPUs each): 8 training nodes (TP2/CP4/PP4,
+optimizer state streamed to node-local disk) and 8 inference nodes (one 4-GPU
+dp-attention sglang engine per node). Every episode is a multi-turn terminal
+agent solving one terminal-bench-2 task inside its own Daytona sandbox, built
+from that task's official image; scoring is the task's canonical test.sh.
+
+The defaults below ARE the reference configuration:
+
+    python3 run_glm5_2_744b_a40b_daytona.py train --num-nodes 16
+
+reproduces it. launch_16node_slurm.sh is only a site adapter (container + Ray
+bring-up); see README.md for the environment contract and preparation steps.
+
+Env consumed here (credentials must NOT live in this file):
+    DAYTONA_API_KEY, OPENENV_TB2_TASKS_DIR, OPENENV_LAUNCHER, OPENENV_RUN_ID
+"""
+
+import importlib.util
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+import typer
+
+import miles.utils.external_utils.command_utils as U
+
+app = typer.Typer()
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+OPENENV_DIR = SCRIPT_DIR.parent
+REPO_ROOT = SCRIPT_DIR.parents[3]
+
+
+@dataclass
+class ScriptArgs(U.ExecuteTrainConfig):
+    mode: Literal["normal"] = "normal"
+    run_id: str = U.create_run_id()
+    model_name: str = "GLM-5.2"
+    megatron_model_type: str = "glm5.2-744B-A40B"
+    num_gpus_per_node: int = 4
+    fp8_rollout: bool = True
+    use_deepep: bool = False
+    megatron_use_deepep: bool = False
+    enable_mtp: bool = True
+    num_rollout: int = 100
+    extra_args: str = ""
+    data_dir: str = "/root/datasets"
+    model_dir: str = "/root/models"
+    model_local_dir: str = "/root/models"
+    megatron_path: str = "/root/Megatron-LM"
+
+    rollout_batch_size: int = 8
+    n_samples_per_prompt: int = 8
+    global_batch_size: int = 64
+    rollout_max_response_len: int = 16384
+    # Max concurrently generating trajectories, decoupled from the train batch;
+    # also sizes the Daytona pool so every in-flight trajectory has a sandbox.
+    async_max_concurrent_samples: int = 128
+    # Node-local dir for streamed optimizer state. DP1 leaves the optimizer
+    # state unsharded (~279 GB/rank), so on 276GB GPUs streaming is mandatory,
+    # not an optimization. Empty disables it (smoke runs on bigger DP only).
+    offload_train_disk_dir: str = "/scratch/opt_state"
+    save_interval: int = 100000  # effectively: only the end-of-training save
+
+    # OpenEnv / Daytona
+    prompt_data: str = ""  # default: <data_dir>/tbench2_train.jsonl
+    agent_model_name: str = os.environ.get("AGENT_MODEL_NAME", "model")
+    openenv_max_turns: int = int(os.environ.get("OPENENV_MAX_TURNS", "30"))
+    openenv_max_rollout_time_seconds: int = int(os.environ.get("OPENENV_MAX_ROLLOUT_TIME_SECONDS", "3600"))
+    openenv_tb2_tasks_dir: str = os.environ.get("OPENENV_TB2_TASKS_DIR", "")
+    openenv_daytona_create_concurrency: int = int(os.environ.get("OPENENV_DAYTONA_CREATE_CONCURRENCY", "8"))
+    openenv_launcher: str = os.environ.get("OPENENV_LAUNCHER", os.environ.get("USER", "miles"))
+    openenv_run_id: str = os.environ.get("OPENENV_RUN_ID", "")
+
+    # Eval over a held-out tbench2 split on the shared rollout engines (the
+    # producer pauses for the duration). A dedicated fleet would need GPUs
+    # this 8+8 split has none of. None disables.
+    eval_interval: int | None = 10
+    eval_prompt_data: str = ""  # default: <data_dir>/tbench2_eval.jsonl
+    n_samples_per_eval_prompt: int = 2
+    daytona_api_key: str = os.environ.get("DAYTONA_API_KEY", "")
+    # Load initial weights from this checkpoint dir instead of this run's own
+    # (empty) save path. For evaluating an existing checkpoint: point at the
+    # source run's checkpoints/, add --start-rollout-id 0 to --extra-args, and
+    # read eval_0 off the loaded weights.
+    load_from: str = ""
+    # Train-only replay of dumped rollout batches ({rollout_id} template). No
+    # engines, no sandboxes; 8 actor nodes suffice. For fast debugging of the
+    # training side (parallelism changes, OOM probes) against recorded data.
+    debug_replay_data: str = ""
+    # Engine recipe. "balanced": the GLM-5.2 cookbook serving shape -- one
+    # 4-GPU engine per node, dp-attention + deepep, EAGLE 1/1/2.
+    # "low-latency": one TP8 engine per node pair, EAGLE 5/1/6.
+    sglang_config: Literal["balanced", "low-latency"] = "balanced"
+
+    def __post_init__(self):
+        min_nodes = 8 if self.debug_replay_data else 10
+        assert (
+            self.num_nodes >= min_nodes and self.num_gpus_per_node == 4
+        ), "GB300 config: 8 train nodes plus inference nodes (4 GPUs each)"
+        assert self.daytona_api_key, "DAYTONA_API_KEY must be set in the environment"
+        if not self.prompt_data:
+            self.prompt_data = f"{self.data_dir}/tbench2_train.jsonl"
+        if self.eval_interval is not None and not self.eval_prompt_data:
+            self.eval_prompt_data = f"{self.data_dir}/tbench2_eval.jsonl"
+
+
+def _assert_openenv_deps():
+    """Fail at launch, not 20 minutes later inside a Ray actor."""
+    for mod in ("openenv", "tbench2_env", "daytona", "fastmcp"):
+        assert (
+            importlib.util.find_spec(mod) is not None
+        ), f"{mod} is not installed in this container; see README.md prerequisites"
+
+
+def _execute_train(args: ScriptArgs):
+    _assert_openenv_deps()
+
+    load_save_path = f"{args.output_dir}/{args.run_id}/checkpoints"
+    hf_name = f"{args.model_name}_fp8" if args.fp8_rollout else args.model_name
+    ckpt_args = (
+        f"--hf-checkpoint {args.model_local_dir}/{hf_name} "
+        f"--ref-load {args.model_local_dir}/{args.model_name}_torch_dist "
+        f"--load {args.load_from or load_save_path} "
+        f"--save {load_save_path} "
+        f"--save-interval {args.save_interval} "
+    )
+
+    rollout_args = (
+        "--rollout-function-path miles.rollout.fully_async_rollout.FullyAsyncRolloutFn "
+        "--pause-generation-mode in_place "
+        f"--async-max-concurrent-samples {args.async_max_concurrent_samples} "
+        # Free a submission slot per finished sample, not per finished group:
+        # with long-horizon agentic trials, waiting for each group's slowest
+        # sibling is a primary rollout-throughput limiter.
+        "--rollout-submission-granularity sample "
+        f"--prompt-data {args.prompt_data} "
+        "--input-key prompt "
+        "--apply-chat-template "
+        "--rollout-shuffle "
+        f"--num-rollout {args.num_rollout} "
+        f"--rollout-batch-size {args.rollout_batch_size} "
+        f"--n-samples-per-prompt {args.n_samples_per_prompt} "
+        f"--rollout-max-response-len {args.rollout_max_response_len} "
+        "--max-seq-len 131072 "
+        "--rollout-temperature 0.8 "
+        f"--global-batch-size {args.global_batch_size} "
+        "--balance-data "
+    )
+
+    eval_args = ""
+    if args.eval_interval is not None:
+        eval_args = (
+            f"--eval-interval {args.eval_interval} "
+            f"--eval-prompt-data tbench2 {args.eval_prompt_data} "
+            f"--n-samples-per-eval-prompt {args.n_samples_per_eval_prompt} "
+            f"--eval-max-response-len {args.rollout_max_response_len} "
+            "--eval-temperature 0.8 "
+        )
+
+    agent_args = (
+        "--custom-generate-function-path miles.rollout.generate_hub.agentic_tool_call.generate "
+        "--custom-agent-function-path openenv_daytona_agent_function.run "
+        "--custom-rm-path openenv_generate.reward_func "
+        "--dynamic-sampling-filter-path miles.rollout.filter_hub.dynamic_sampling_filters.check_no_aborted "
+        "--tito-model glm47 "
+        "--use-session-server "
+        "--session-server-port 30000 "
+    )
+
+    # 32-GPU training half. CP4 splits the 131k max sequence to ~33k per rank;
+    # TP2 (not TP1) because at TP1 the per-rank non-expert weights alone
+    # overflow 276GB at checkpoint load.
+    perf_args = (
+        "--tensor-model-parallel-size 2 "
+        "--sequence-parallel "
+        "--pipeline-model-parallel-size 4 "
+        "--decoder-first-pipeline-num-layers 18 "
+        "--decoder-last-pipeline-num-layers 20 "
+        "--context-parallel-size 4 "
+        "--expert-model-parallel-size 8 "
+        "--expert-tensor-parallel-size 1 "
+        "--recompute-granularity full "
+        "--recompute-method uniform "
+        "--recompute-num-layers 1 "
+        "--use-dynamic-batch-size "
+        "--max-tokens-per-gpu 8192 "
+        "--data-pad-size-multiplier 1024 "
+        "--log-probs-chunk-size 16384 "
+    )
+
+    grpo_args = (
+        "--advantage-estimator grpo "
+        "--kl-loss-coef 0.00 "
+        "--kl-loss-type low_var_kl "
+        "--kl-coef 0.00 "
+        "--entropy-coef 0.00 "
+        "--eps-clip 0.2 "
+        "--eps-clip-high 0.28 "
+        "--use-tis "
+        "--tis-clip-low 0.5 "
+        "--tis-clip 2.0 "
+    )
+
+    optimizer_args = (
+        "--optimizer adam "
+        "--lr 1e-6 "
+        "--lr-decay-style constant "
+        "--weight-decay 0.1 "
+        "--adam-beta1 0.9 "
+        "--adam-beta2 0.98 "
+    )
+
+    balanced = args.sglang_config == "balanced"
+    sglang_world_size = 4 if balanced else 8
+    sglang_args = (
+        f"--rollout-num-gpus-per-engine {sglang_world_size} "
+        # 0.75 leaves ~59GB per GPU unused and the KV pool at 26k tokens, which
+        # caps trajectories and starves concurrency; 0.85 gives 553k tokens and
+        # still ends steady state with 33GB spare.
+        "--sglang-mem-fraction-static 0.85 "
+        f"--sglang-ep-size {sglang_world_size} "
+        "--sglang-kv-cache-dtype fp8_e4m3 "
+        "--sglang-nsa-decode-backend flashmla_kv "
+        "--sglang-nsa-prefill-backend flashmla_sparse "
+        "--sglang-attention-backend nsa "
+        "--sglang-page-size 64 "
+        "--sglang-cuda-graph-max-bs 32 "
+        f"--sglang-max-running-requests {256 if balanced else 512} "
+        f"--sglang-chunked-prefill-size {32768 if balanced else 2048 * sglang_world_size} "
+        "--sglang-watchdog-timeout 3600 "
+        "--sglang-tool-call-parser glm47 "
+        "--sglang-reasoning-parser glm45 "
+    )
+    if balanced:
+        # dp-attention implies dp-aware routing (set in sglang_utils.arguments):
+        # min_load must see the dp ranks, or requests pile onto whichever rank
+        # sglang picks internally while the others sit idle.
+        sglang_args += "--sglang-enable-dp-attention " "--sglang-dp-size 4 " "--sglang-moe-a2a-backend deepep "
+    if args.enable_mtp:
+        steps, draft_tokens = (1, 2) if balanced else (5, 6)
+        sglang_args += (
+            "--sglang-speculative-algorithm EAGLE "
+            f"--sglang-speculative-num-steps {steps} "
+            "--sglang-speculative-eagle-topk 1 "
+            f"--sglang-speculative-num-draft-tokens {draft_tokens} "
+            "--sglang-speculative-draft-attention-backend nsa "
+        )
+    if args.fp8_rollout and not balanced:
+        sglang_args += "--sglang-moe-runner-backend flashinfer_trtllm_routed "
+
+    dashboard_args = (
+        f"--dump-details {args.output_dir}/{args.run_id}/dump_details "
+        "--use-miles-dashboard "
+        "--dashboard-sglang-scrape-mode direct "
+    )
+
+    misc_args = (
+        "--attention-dropout 0.0 "
+        "--hidden-dropout 0.0 "
+        "--accumulate-allreduce-grads-in-fp32 "
+        "--attention-softmax-in-fp32 "
+        "--attention-backend flash "
+        "--allgather-cp "
+        f"--update-weight-buffer-size {2 * 1024 ** 3} "
+        "--actor-num-nodes 8 "
+        f"--actor-num-gpus-per-node {args.num_gpus_per_node} "
+        f"--num-gpus-per-node {args.num_gpus_per_node} "
+        "--moe-token-dispatcher-type alltoall "
+        "--update-weight-transfer-mode broadcast "
+    )
+    if args.offload_train_disk_dir:
+        misc_args += f"--stream-optimizer-state-to-disk --offload-train-disk-dir {args.offload_train_disk_dir} "
+    rollout_gpus = (args.num_nodes - 8) * args.num_gpus_per_node
+    assert args.debug_replay_data or (
+        rollout_gpus > 0 and rollout_gpus % 8 == 0
+    ), f"needs 8 train nodes plus a multiple of 8 rollout GPUs; --num-nodes {args.num_nodes} gives {rollout_gpus}"
+    misc_args += f"--rollout-num-gpus {max(rollout_gpus, 8)} "
+    if args.debug_replay_data:
+        misc_args += f"--load-debug-rollout-data {args.debug_replay_data} "
+
+    train_args = (
+        f"{ckpt_args} "
+        f"{rollout_args} "
+        f"{agent_args} "
+        f"{optimizer_args} "
+        f"{grpo_args} "
+        f"{U.get_default_wandb_args(__file__, run_id=args.run_id)} "
+        f"{perf_args} "
+        f"{eval_args} "
+        f"{sglang_args} "
+        f"{dashboard_args} "
+        f"{misc_args} "
+        f"{args.extra_args} "
+    )
+
+    extra_env_vars = {
+        # FullyAsyncRolloutFn is the class-based rollout API
+        "MILES_EXPERIMENTAL_ROLLOUT_REFACTOR": "1",
+        # On a watchdog timeout every rank dumps its recent collectives, which
+        # identifies the rank that never arrived. Must reach the train actors,
+        # so it goes through the Ray env rather than the launcher shell.
+        "TORCH_NCCL_TRACE_BUFFER_SIZE": "4096",
+        "TORCH_NCCL_DUMP_ON_TIMEOUT": "1",
+        "TORCH_NCCL_DEBUG_INFO_TEMP_FILE": os.environ.get("MILES_NCCL_TRACE_PREFIX", "/tmp/nccl_trace"),
+        "SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK": "256",
+        "SGLANG_NSA_FORCE_MLA": "1",
+        # Node-local caches: the NFS defaults (~/.triton, ~/.cache/tvm-ffi)
+        # race across nodes under many-process cold compiles.
+        "TRITON_CACHE_DIR": os.environ.get("TRITON_CACHE_DIR", "/tmp/triton_cache"),
+        "TVM_FFI_CACHE_DIR": os.environ.get("TVM_FFI_CACHE_DIR", "/tmp/tvm_ffi_cache"),
+        "INDEXER_ROPE_NEOX_STYLE": "0",
+        "NVSHMEM_DISABLE_NCCL": "1",
+        # openenv_daytona_agent_function / openenv_generate import path
+        "PYTHONPATH": f"{args.megatron_path}:{OPENENV_DIR}:{os.environ.get('PYTHONPATH', '')}",
+        # OpenEnv x Daytona
+        "AGENT_MODEL_NAME": args.agent_model_name,
+        "OPENENV_MAX_TURNS": str(args.openenv_max_turns),
+        "OPENENV_MAX_ROLLOUT_TIME_SECONDS": str(args.openenv_max_rollout_time_seconds),
+        "OPENENV_TB2_TASKS_DIR": args.openenv_tb2_tasks_dir,
+        "OPENENV_DAYTONA_CREATE_CONCURRENCY": str(args.openenv_daytona_create_concurrency),
+        "OPENENV_LAUNCHER": args.openenv_launcher,
+        "OPENENV_RUN_ID": args.openenv_run_id,
+        "DAYTONA_API_KEY": args.daytona_api_key,
+    }
+
+    U.execute_train(
+        train_args=train_args,
+        config=args,
+        num_gpus_per_node=args.num_gpus_per_node,
+        megatron_model_type=args.megatron_model_type,
+        extra_env_vars=extra_env_vars,
+        megatron_path=args.megatron_path,
+        train_script="train_async.py",
+    )
+
+
+@app.callback()
+def _cli():
+    # Force subcommand mode: a single-command Typer app would otherwise
+    # swallow the command name and reject `... daytona.py train`.
+    pass
+
+
+@app.command()
+@U.dataclass_cli
+def train(args: ScriptArgs):
+    _execute_train(args)
+
+
+if __name__ == "__main__":
+    app()


### PR DESCRIPTION
**Author: Miles team**

Fully-async agentic RL on 16 GB300 nodes (4 GPUs each): **8 training nodes** (TP2/CP4/PP4/EP8, optimizer state streamed to node-local disk) and **8 inference nodes** (one 4-GPU dp-attention fp8 sglang engine per node). Every episode is a multi-turn terminal agent solving one terminal-bench-2 task inside its own Daytona sandbox built from that task's official image; scoring is the task's canonical `tests/test.sh`.

Three files under `examples/experimental/openenv/glm52_tbench2/`, next to the shared openenv agent/reward/data modules the recipe imports:

- `run_glm5_2_744b_a40b_daytona.py` — the recipe. **Its defaults are the reference configuration**: `python3 run_glm5_2_744b_a40b_daytona.py train --num-nodes 16` reproduces the reference run. Deviations (smoke sizes, engine shape, checkpoint scoring) are CLI flags, not launcher edits.
- `launch_16node_slurm.sh` — a ~60-line site adapter: container + Ray bring-up only, forwards its own CLI args to the recipe. No experiment settings live here.
- `README.md` — environment contract, preparation steps, what the config does and why.

### Performance Tuning
This PR includes several recent optimizations:
#### Memory
At the beginning, we was not able to train GLM 5.2 in 1 GB300 rack. After 3&4&5, we made it trainable with 16 GB300 nodes in colocate mode. Then, with 1&2, we make the async version trainable with 8 rollout nodes and 8 train nodes.
1. (save all the optimizer memory from GPU/CPU) Disk offload #1575 
2. (reduce the GPU peak memory from whole optimizer to bucket) NVME streaming optimizer #1793 
3. (save 100+ GB CPU memory) For colocate mode, it use rematerialization to save CPU mem #1572 
4. (save 20+ GB GPU memory, allow larger static-mem-fraction) Use gloo group in megatron disk ckpt https://github.com/radixark/Megatron-LM/pull/62
5. (save 10+ GB GPU memory) fix DSA cuda graph page table in TMS https://github.com/sgl-project/sglang/pull/33479

#### Speed
All the performance here is for 8 nodes rollout + 8 nodes train async mode. We use [miles dashboard](#1654) for all observation and perf tuning. At the beginning, we see slow rollout generation and large bubbles. After all the tuning, we make it almost fully overlapped and fully utilize the GPU resource.
1. Concurrency: Sample-level async submission #1673 & Set to 2x batch size generation concurrency. #1677 
Before this, we see running_reqs dropping over time and the rollout concurrency is too low to be balanced with training, so large bubble exists. These PRs fixed the issue.
Concurrency before:
<img width="1458" height="908" alt="img_v3_0213k_8b9deb9a-6a8b-4d86-a8a0-c4bd6e047fix" src="https://github.com/user-attachments/assets/cf314da8-ce7b-4ed9-926b-ee90bc81c2a1" />

2. Router: Default router config fixes #1657, #1351, and set router mode to hash-consistent + min_load #1690
Only with the above PRs, we still see large bubbles caused by an imbalance between engines. The hash-consistent + min_load fix it. 
Concurrency before and after:
<img width="2896" height="882" alt="image" src="https://github.com/user-attachments/assets/393eb097-0c94-464d-be49-ca96884b7c98" />

3. Engine config: Tune SGLang config to be balanced #2220

and more...

### Result
**Routing**
prefix-cache hit rate ≈0.96. Concurrency stable (as the right figure above)

**Step-time**
5-6min per step.
<img width="1238" height="640" alt="image" src="https://github.com/user-attachments/assets/543a3595-eda5-4fe2-b7c5-a1a9009d5bcb" />
**Schedule**
Rollout and training are well-overlapped.
<img width="3840" height="1922" alt="image" src="https://github.com/user-attachments/assets/3e613936-a330-4688-a9d8-dd9e820d1854" />
