### PR TITLE
fix: derive --critic-save from --save so PPO critic checkpoints are not silently skipped

### DIFF
--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -1298,7 +1298,12 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 "while the actor stays frozen. Only takes effect when --advantage-estimator is ppo.",
             )
             parser.add_argument("--critic-load", type=str, default=None, help="The checkpoint for critic model.")
-            parser.add_argument("--critic-save", type=str, default=None, help="The checkpoint for critic model.")
+            parser.add_argument(
+                "--critic-save",
+                type=str,
+                default=None,
+                help="Where to save critic checkpoints. Defaults to '<--save>_critic' when --save is set.",
+            )
             parser.add_argument("--critic-lr", type=float, default=None, help="The lr for critic model")
             parser.add_argument(
                 "--critic-lr-warmup-iters",
@@ -3076,6 +3081,9 @@ def miles_validate_args(args):
         args.critic_load = args.load
     if args.critic_lr is None:
         args.critic_lr = args.lr
+    if args.critic_save is None and args.save is not None:
+        # a sibling dir, not args.save itself: sharing a dir would clobber the actor's iteration tracker
+        args.critic_save = args.save.rstrip("/") + "_critic"
 
     if args.offload:
         args.offload_train = True

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -1302,7 +1302,8 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 "--critic-save",
                 type=str,
                 default=None,
-                help="Where to save critic checkpoints. Defaults to '<--save>_critic' when --save is set.",
+                help="Where to save critic checkpoints. If not set, it defaults to the --save path with a "
+                "'_critic' suffix appended, e.g. --save /ckpts/run1 saves the critic to /ckpts/run1_critic.",
             )
             parser.add_argument("--critic-lr", type=float, default=None, help="The lr for critic model")
             parser.add_argument(

--- a/tests/fast/utils/test_arguments.py
+++ b/tests/fast/utils/test_arguments.py
@@ -261,6 +261,33 @@ def test_dynamic_global_batch_size_requires_dynamic_batch_size():
         miles_validate_args(args)
 
 
+class TestCriticSaveDerivation:
+    def _validate(self, extra):
+        parser = argparse.ArgumentParser()
+        get_miles_extra_args_provider()(parser)
+        args = parser.parse_args(extra + ["--num-rollout", "1"] + REQUIRED_ARGS)
+        miles_validate_args(args)
+        return args
+
+    def test_derives_sibling_dir_from_save(self):
+        args = self._validate(["--advantage-estimator", "ppo", "--save", "/ckpts/run1"])
+        assert args.critic_save == "/ckpts/run1_critic"
+
+    def test_trailing_slash_is_stripped(self):
+        args = self._validate(["--advantage-estimator", "ppo", "--save", "/ckpts/run1/"])
+        assert args.critic_save == "/ckpts/run1_critic"
+
+    def test_explicit_critic_save_is_respected(self):
+        args = self._validate(
+            ["--advantage-estimator", "ppo", "--save", "/ckpts/run1", "--critic-save", "/elsewhere/critic"]
+        )
+        assert args.critic_save == "/elsewhere/critic"
+
+    def test_stays_none_without_save(self):
+        args = self._validate(["--advantage-estimator", "ppo"])
+        assert args.critic_save is None
+
+
 class TestSessionServerV2Validation:
     def _parse(self, extra):
         parser = argparse.ArgumentParser()


### PR DESCRIPTION
## Motivation

When training with `--advantage-estimator ppo`, the training loop always tries to save the critic model (`train.py` calls `save_training_model(critic_model)` on every save). The critic actor uses `args.critic_save` as its save path (`actor.py` assigns `self.args.save = self.args.critic_save` for the critic role).

However, `--critic-save` defaults to `None` and is never derived from `--save`, so a PPO run that only passes `--save` silently skips all critic checkpoints. The actor checkpoints look fine, but resuming the run restarts the critic from scratch, which breaks resumption for PPO.

Note that the sibling flags already have this kind of fallback in `miles_validate_args`: `--critic-load` falls back to `--load` and `--critic-lr` falls back to `--lr`. This PR adds the missing one for `--critic-save`.

## Modification

- In `miles_validate_args`, when `--critic-save` is unset and `--save` is set, derive it as `<save>_critic` (a sibling directory). A sibling directory is used instead of `--save` itself because actor and critic each write their own `latest_checkpointed_iteration.txt`-style tracker, so sharing one directory would clobber it.
- Update the `--critic-save` help text to document the new default.
- Add unit tests covering: derivation from `--save`, trailing-slash normalization, an explicitly passed `--critic-save` being respected, and staying `None` when `--save` is unset.

Behavior change: PPO runs that set `--save` but not `--critic-save` previously saved no critic checkpoints; they now save critic checkpoints to `<save>_critic` by default. Runs that pass `--critic-save` explicitly are unaffected.
