### PR TITLE
fix: preserve routing-replay state around MTP spec creation

### DIFF
--- a/miles/backends/megatron_utils/model_provider.py
+++ b/miles/backends/megatron_utils/model_provider.py
@@ -306,6 +306,7 @@ def get_model_provider_func(
             # hard code here to skip r3 registration for mtp layers
             # getattr is required to avoid ckpt conversion errors
             if getattr(args, "use_rollout_routing_replay", False):
+                prev_routing_replay_enabled = routing_replay_manager.enabled
                 routing_replay_manager.enabled = False
                 logger.warning(
                     "Rollout routing replay is not applicable for MTP modules, so skipped replay registration"
@@ -313,7 +314,8 @@ def get_model_provider_func(
             mtp_block_spec = get_gpt_mtp_block_spec(config, transformer_layer_spec, **mtp_kwargs)
             kwargs["mtp_block_spec"] = mtp_block_spec
             if getattr(args, "use_rollout_routing_replay", False):
-                routing_replay_manager.enabled = True
+                # restore instead of forcing True: the critic role keeps the manager disabled
+                routing_replay_manager.enabled = prev_routing_replay_enabled
 
         with build_model_context(**build_model_context_args):
             model = GPTModel(**kwargs)


### PR DESCRIPTION
## Motivation

Running PPO (`--advantage-estimator ppo`) with `--use-rollout-routing-replay` on a MoE model that has MTP layers (e.g. GLM-4.7-Flash with `mtp_num_layers=1`) crashes the critic on its first training step:

```
IndexError: pop_forward out of range: forward_index=0, len(top_indices_list)=0
```

Root cause: `routing_replay_manager` is a process-global singleton. The critic role deliberately leaves it disabled (`MegatronTrainRayActor.init` only enables replay managers for non-critic roles), because routing replay exists to align the actor's recomputed log-probs with the rollout's expert choices — the critic computes values fresh and has no log-probs to align.

However, `get_model_provider_func` brackets the MTP block-spec creation by setting `routing_replay_manager.enabled = False` and then unconditionally setting it back to `True`. That re-enable assumed the manager was enabled beforehand, which is only true for the actor. When the critic builds its model, the bracket flips the manager on as a side effect; the critic's MoE routers then register replay buffers, every training forward runs in replay mode, and the pop fails because replay data is only ever filled on the actor path.

The crash is not covered by CI: the PPO CI model (Qwen3-4B) is dense and has no MTP layers, and the bug needs the full combination of critic + MoE + MTP + `--use-rollout-routing-replay`.

## Modification

Save the manager's previous `enabled` state before the MTP bracket and restore that state afterwards, instead of forcing `True`. Behavior for the actor is unchanged (its previous state is `True`); the critic now stays disabled and computes routing fresh, which is the intended behavior.
