### PR TITLE
examples: make the agent-server trial timeout configurable

### DIFF
--- a/examples/swe-agent/README.md
+++ b/examples/swe-agent/README.md
@@ -48,6 +48,19 @@ generous — agentic trials routinely run past an hour, and a short timeout kill
 them mid-episode. Verify `http://<agent-server>:30000/health` before launching
 Miles.
 
+The two per-trial timeouts must be ordered. `--agent-timeout` is the authoritative
+one: when it fires, the agent server ends the trial and frees its sandbox. The
+rollout client applies a second ceiling, `AGENT_TRIAL_TIMEOUT` (default 7200
+seconds), which has to stay above `--agent-timeout`. If the client gives up first,
+the trial is recorded as aborted while the agent server keeps running it, so the
+sandbox and its `--max-concurrent` slot stay busy for the remaining difference, and
+the aborted sample takes its whole GRPO group down with it. Raise it through the
+launcher's generic env-var hook:
+
+```bash
+python examples/swe-agent/run.py ... --extra-env-vars 'AGENT_TRIAL_TIMEOUT=10800'
+```
+
 If the trainer reaches the agent server through a proxy or an in-cluster service
 rather than directly, point `--agent-server-url` at that stable name rather than
 an ephemeral pod address. The rollout client enables TCP keepalive probes so

--- a/examples/swe-agent/swe_agent_function.py
+++ b/examples/swe-agent/swe_agent_function.py
@@ -23,7 +23,15 @@ from miles.utils.http_utils import post
 
 logger = logging.getLogger(__name__)
 
+# Backstop for an unreachable agent server; its own --agent-timeout should fire first.
+_DEFAULT_AGENT_TRIAL_TIMEOUT_S = 7200
+
 _agent_server_client: httpx.AsyncClient | None = None
+
+
+def _agent_trial_timeout_s() -> int:
+    """Per-trial ceiling for the agent-server call, overridable via AGENT_TRIAL_TIMEOUT."""
+    return int(os.environ.get("AGENT_TRIAL_TIMEOUT", _DEFAULT_AGENT_TRIAL_TIMEOUT_S))
 
 
 def _get_agent_server_client() -> httpx.AsyncClient:
@@ -102,13 +110,14 @@ async def run(
     if session_server_instance_id is not None:
         request["session_server_instance_id"] = session_server_instance_id
 
+    trial_timeout_s = _agent_trial_timeout_s()
     try:
         response = await asyncio.wait_for(
             _post_agent_server(f"{agent_server_url}/run", request),
-            timeout=3600,  # 1 hour max per trial
+            timeout=trial_timeout_s,
         )
     except asyncio.TimeoutError:
-        logger.error("Agent server call timed out after 3600s")
+        logger.error(f"Agent server call timed out after {trial_timeout_s}s")
         return None
     except asyncio.CancelledError:
         logger.warning("Agent server call cancelled (sibling task failure?)")


### PR DESCRIPTION
## Summary

Stacked on #1919 — base branch is `shi/swe-agent-daytona-example`, so review that
one first. This PR's own diff is 2 files, +24/-2.

`swe_agent_function.run` hardcoded a 3600 s ceiling on the agent-server `/run`
call, while both READMEs start the agent server with `--agent-timeout 5400`. The
httpx client is built with `timeout=None`, so that hardcoded 3600 was the
effective per-trial cap no matter what the server had been configured for — any
`--agent-timeout` above 3600 was dead configuration.

The inversion costs more than a mislabelled constant. For a trial that runs
between 60 and 90 minutes:

- the trainer records it as aborted and returns `None`;
- the agent server keeps running it, so its sandbox and one `--max-concurrent`
  slot stay occupied for up to another 30 minutes — on quota-limited sandbox
  backends that is exactly what pushes later trials into create failures;
- the aborted-sample dynamic filter rejects the **whole GRPO group** the sample
  belonged to, not just that sample. At `--rollout-batch-size 4` one late trial
  removes a quarter of the step's gradient signal.

The ceiling now comes from `AGENT_TRIAL_TIMEOUT` and defaults to 7200, above the
5400 the examples ship. The agent server's own `--agent-timeout` is therefore the
one that fires first, and it tears down its own trial and releases the sandbox;
the client ceiling is only a backstop for a server that has become unreachable.
The README records that ordering requirement, which it previously contradicted by
telling users to keep `--agent-timeout` generous.

No new launcher flag: `ExecuteTrainConfig` already forwards arbitrary env vars to
the rollout actors, so the knob is reachable as

```bash
python examples/swe-agent/run.py ... --extra-env-vars 'AGENT_TRIAL_TIMEOUT=10800'
```

The mismatch was reported by nblintao while reviewing #1919.

## Test plan

- [x] `black==24.3.0 --line-length 119 --check` and `isort --profile=black` clean
- [x] `AGENT_TRIAL_TIMEOUT` unset resolves to 7200; `=10800` to 10800; `=3600` to
      3600
- [x] `--extra-env-vars 'AGENT_TRIAL_TIMEOUT=10800'` parses to
      `{'AGENT_TRIAL_TIMEOUT': '10800'}`, confirming the knob reaches the rollout
      actors without a dedicated flag
- [ ] Not exercised end to end against a live agent server: reaching the timeout
      path now requires a trial longer than two hours. The default is a strict
      relaxation of the previous hardcoded value, so existing runs can only stop
      aborting trials they used to abort.
