### PR TITLE
[DO NOT MERGE] test CI: is test_fully_async flaky on main?

### DIFF
--- a/tests/e2e/megatron/test_qwen3_30B_A3B/test_fully_async.py
+++ b/tests/e2e/megatron/test_qwen3_30B_A3B/test_fully_async.py
@@ -41,3 +41,5 @@ if __name__ == "__main__":
         os.environ.pop(proxy_var, None)
     prepare(CASE, need_fp8=CASE.use_fp8_rollout, need_int4=CASE.use_int4_rollout, all_bridge=CASE.use_bridge)
     execute(CASE, wandb_file=__file__)
+
+# CI probe: does test_fully_async fail on an unmodified main? Do not merge.


### PR DESCRIPTION
**Do not merge.** Diagnostic PR only — a comment-only change on top of unmodified `main`.

## Why

`tests/e2e/megatron/test_qwen3_30B_A3B/test_fully_async.py` has failed twice on `stage-c-8-gpu-h100 (1)` with the same signature, on two unrelated PRs (#1572, #2223), both times with `ncclUnhandledCudaError` and never with a Python-level assertion. Neither PR changes anything on the fully-async path (`colocate=False`).

This PR isolates the variable: run the same test against clean `main` and see whether it fails there too.

Labelled `run-ci-fully-async`. Will be closed once the answer is in; any fix lands in its own PR.