### PR TITLE
fix(ci): cancel PR tests after closure

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -4,7 +4,7 @@ name: PR Test
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review, labeled]
+    types: [opened, synchronize, reopened, ready_for_review, labeled, closed]
   schedule:
     # Nightly CI on main runs every enabled tag except long and ft-long, with fast-fail disabled.
     # 15:00 UTC = 08:00 PDT / 07:00 PST (cron is UTC, no DST).
@@ -38,7 +38,7 @@ permissions:
 concurrency:
   # PR updates supersede their previous run; distinct cron schedules and
   # manual operations must not cancel one another on the default branch.
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.schedule || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.number || github.event.schedule || github.run_id }}
   cancel-in-progress: true
 
 # `resolve-ci-policy` passes trigger-specific facts to `ci_policy.py`, which
@@ -52,6 +52,7 @@ concurrency:
 
 jobs:
   resolve-ci-policy:
+    if: github.event.action != 'closed'
     runs-on: ubuntu-latest
     outputs:
       cadence: ${{ steps.resolve.outputs.cadence }}
@@ -71,6 +72,7 @@ jobs:
         run: python -m tests.ci.ci_policy
 
   docker-paths:
+    if: github.event.action != 'closed'
     runs-on: ubuntu-latest
     outputs:
       changed: ${{ steps.diff.outputs.changed }}
@@ -104,7 +106,7 @@ jobs:
   # GPU fleet.
   docker-build:
     needs: [docker-paths]
-    if: always() && !cancelled()
+    if: always() && !cancelled() && github.event.action != 'closed'
     runs-on: ${{ fromJSON((needs.docker-paths.outputs.changed == 'true' && github.event.pull_request.head.repo.full_name == github.repository) && '["h200", "2gpu"]' || '["ubuntu-latest"]') }}
     timeout-minutes: 180
     outputs:

--- a/docs/ci/00-stage.md
+++ b/docs/ci/00-stage.md
@@ -32,6 +32,8 @@ Stage names follow `stage-<tier>-<gpus>-<hw>` (or `stage-<tier>-<hw>` for CPU, e
 
 In `pr-test.yml`, `tier a` (CPU fast) gates the NVIDIA GPU fleet after both resolvers; its GPU stages (`b` / `c`) all depend on both resolvers and `stage-a-cpu`, and run concurrently with each other — the `b` / `c` letters classify role, they are not a sequential pipeline. The MI300X stage has no CPU-test gate.
 
+`pr-test.yml` treats `pull_request.closed` as cancellation-only: the close event shares the PR's concurrency group, cancels any queued or running `PR Test` run, and starts no resolver or test jobs.
+
 ## What each stage does
 
 **Image resolution (`resolve-ci-image`).** In `pr-test.yml`, a small `ubuntu-latest` job reads `ci-image-tag:` from the PR description (or the `ci_image_tag` dispatch input), defaults to `dev`, validates it is a bare tag, and outputs `radixark/miles:<tag>`. The ROCm resolver uses only its dispatch input, defaults to its dated `rocm/sgl-dev` tag, and uses that same default for PR and nightly runs. Distinct from this, the **`run-ci-image` label** selects the image scope — every enabled tag except `long`, `ft-short`, and `ft-long` — which validates an image bump without selecting those domains implicitly.

--- a/tests/ci/test/test_run_suite.py
+++ b/tests/ci/test/test_run_suite.py
@@ -302,6 +302,18 @@ class TestWorkflowScopeSeam:
         workflow = self._workflow()
         assert "github.event.schedule || github.run_id" in workflow
 
+    def test_closed_pr_only_cancels_existing_run(self):
+        workflow = self._workflow()
+        assert "types: [opened, synchronize, reopened, ready_for_review, labeled, closed]" in workflow
+        assert (
+            "group: ${{ github.workflow }}-${{ github.event.number || github.event.schedule || github.run_id }}"
+            in workflow
+        )
+
+        for job_name in ("resolve-ci-policy", "docker-paths", "docker-build"):
+            job_header = workflow.split(f"  {job_name}:", 1)[1].split("    runs-on:", 1)[0]
+            assert "github.event.action != 'closed'" in job_header
+
 
 class TestRocmWorkflowScopeSeam:
     @staticmethod


### PR DESCRIPTION
## Summary
Cancel queued and running PR tests when their pull request closes.

## Symptom & Reproduction
- **Symptom:** Merged or closed pull requests leave queued or running `PR Test` jobs consuming GPU runners.
- **Reproduction:** Start a `PR Test` run, then merge or close the pull request before its queued GPU jobs finish.

## Root Cause
1. `.github/workflows/pr-test.yml` does not subscribe to `pull_request.closed`.
2. No same-group close run exists to activate `cancel-in-progress`.

## Fix
Trigger `PR Test` on `closed`, derive the PR concurrency key from `github.event.number`, and skip the closed run's root jobs so it only cancels existing work.

## Verification
- **Closed trigger:** `TestWorkflowScopeSeam.test_closed_pr_only_cancels_existing_run` locks the `closed` event subscription.
- **Concurrency key:** The same test locks the top-level PR number used by the concurrency group.
- **Closed-event guards:** The same test locks the root-job guards that make the close run cancellation-only.
- **Existing test suite:** `tests/ci/test/test_run_suite.py` passes all 72 tests.
- **Workflow validation:** The repository `check-yaml` hook passes for `.github/workflows/pr-test.yml`.

## Review Focus
- Scrutinize the `closed` trigger and `github.event.number` concurrency key in `.github/workflows/pr-test.yml`.
- Scrutinize that every root or `always()` job skips the `closed` event.
