### PR TITLE
args: require eval datasets only on the built-in rollout path

### DIFF
--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -2907,8 +2907,14 @@ def miles_validate_args(args):
                 args.ckpt_step = args.ref_ckpt_step
             args.start_rollout_id = 0
 
-    if args.eval_interval is not None:
-        assert args.eval_datasets, "Evaluation datasets must be configured when eval_interval is set."
+    # Only the built-in rollout path reads --eval-prompt-data. A custom rollout or eval
+    # function carries its own evaluation work (an environment taskset, a benchmark
+    # suite, ...) and is free to run without Miles-side eval datasets.
+    if args.eval_interval is not None and args.rollout_function_path is None and args.eval_function_path is None:
+        assert args.eval_datasets, (
+            "Evaluation datasets must be configured when --eval-interval is set with the built-in "
+            "rollout function. A custom --rollout-function-path / --eval-function-path supplies its own."
+        )
 
     if args.eval_num_gpus > 0:
         assert args.eval_num_gpus % args.eval_num_gpus_per_engine == 0, (

--- a/tests/fast/utils/test_arguments.py
+++ b/tests/fast/utils/test_arguments.py
@@ -668,3 +668,28 @@ class TestValidateAsyncOffPolicyCorrection:
 
     def test_non_ppo_estimators_are_unaffected(self):
         validate_async_off_policy_correction(_make_async_ppo_args(use_critic=False))
+
+
+def _eval_interval_args(*extra: str):
+    parser = argparse.ArgumentParser()
+    get_miles_extra_args_provider()(parser)
+    return parser.parse_args(["--eval-interval", "1", "--hf-checkpoint", "test/model", *extra] + REQUIRED_ARGS)
+
+
+def test_eval_interval_requires_datasets_on_the_builtin_path():
+    args = _eval_interval_args()
+
+    with pytest.raises(AssertionError, match="built-in"):
+        miles_validate_args(args)
+
+
+def test_eval_interval_needs_no_datasets_when_a_custom_rollout_function_evaluates():
+    args = _eval_interval_args("--rollout-function-path", "my_module.MyRolloutFn")
+
+    miles_validate_args(args)
+
+
+def test_eval_interval_needs_no_datasets_when_a_custom_eval_function_evaluates():
+    args = _eval_interval_args("--eval-function-path", "my_module.MyEvalFn")
+
+    miles_validate_args(args)


### PR DESCRIPTION
## Status

**Parked.** The condition this PR uses turns out not to hold up against code already in the tree (below), and the motivating case went away: #1739 no longer depends on this change. Keeping it open as a record of the analysis; worth revisiting when a second rollout function owns its evaluation set, or when the workaround #1739 ships becomes annoying enough to pay for a change to the eval path.

## Problem

`--eval-interval` asserts that `--eval-prompt-data` is configured. That is right for the built-in rollout function, which evaluates by iterating `args.eval_datasets`, but wrong for a custom rollout or eval function that carries its own evaluation work — an environment taskset, a benchmark suite — and never reads Miles-side eval datasets. Such a run has to configure a dataset it will not use, which is what the Verifiers example in #1739 now does: it names the taskset and points a placeholder `--eval-prompt-data` at the EnvConfig the taskset is defined in.

Nothing else in the eval cycle needs `eval_datasets`: `eval_function_path` defaults to `rollout_function_path`, so the custom function serves eval, and `log_eval_rollout_data` iterates the returned data dict rather than the configured datasets.

## Why the patch in this PR is not the answer

It scopes the assertion to runs that pass neither `--rollout-function-path` nor `--eval-function-path`. That proxy is wrong in both directions against current examples:

- **False negative** — `examples/fully_async/run_qwen3_5_4b_fully_async_eval.py` passes a *built-in* path explicitly (`miles.rollout.fully_async_rollout.FullyAsyncRolloutFn`) alongside `--eval-interval`. The proxy reads that as "custom" and drops the guard, though the run evaluates through the built-in path. It passes eval data today, so nothing breaks — but the classification is wrong.
- **False positive** — `examples/swe-agent/generate.py:RolloutFn` subclasses `InferenceRolloutFn` and overrides only `_call_train`, so it inherits the built-in `_call_eval` and does need eval datasets. The proxy reads it as "brings its own eval" and would let it evaluate nothing instead of failing at startup.

Deciding this statically is not really possible: whether a rollout function reaches the built-in eval path is a property of the code it calls, and Miles deliberately avoids importing custom rollout modules on the driver.

## The design that would be correct

Assert where `eval_datasets` is actually consumed (`run_eval_datasets`, and the legacy `eval_rollout`). Then the subclass above fails with a clear message at its first eval, the explicit-built-in run is classified correctly, and a function that never touches the built-in path never sees the check.

The tradeoff is that a misconfiguration surfaces at the first eval interval instead of at startup, which for RL training can be an hour in. A startup assertion for the case Miles is sure about (neither flag passed) could stay as a fast path, with the consumer-side check as the correctness backstop.

## Alternatives

| Option | Note |
|---|---|
| Dedicated opt-out flag (`--eval-without-datasets`) | Permanent flag surface for a condition that should be inferable. |
| Integrations configure a placeholder dataset | What #1739 does today: contained in one launcher, but it advertises a dataset the run does not use. |
| Leave it alone | Rollout functions that own their evaluation set keep paying the placeholder. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)