### PR TITLE
refactor(openenv): unify the sandbox backends onto one SandboxBackend, and add Modal

### DIFF
--- a/docs/user-guide/environments.md
+++ b/docs/user-guide/environments.md
@@ -19,11 +19,11 @@ where the environment itself comes from:
 | Integration | Plugs in at | Guide |
 |---|---|---|
 | [Harbor](https://github.com/harbor-framework/harbor) | agent function | [guide](/user-guide/harbor) |
-| [OpenEnv](https://github.com/huggingface/openenv) | agent function | [guide](/user-guide/openenv) |
 | [NeMo-Gym](https://github.com/NVIDIA-NeMo/Gym) | agent function | [guide](/user-guide/nemo-gym) |
+| [OpenEnv](https://github.com/huggingface/openenv) | agent function | [guide](/user-guide/openenv) |
 | [Strands Agents](https://strandsagents.com/) | generate function | [example](https://github.com/radixark/miles/tree/main/examples/experimental/strands_sglang) |
-| [τ-bench](https://github.com/sierra-research/tau-bench) | generate function | [example](https://github.com/radixark/miles/tree/main/examples/experimental/tau-bench) |
 | [Verifiers (Prime Intellect)](https://github.com/PrimeIntellect-ai/verifiers) | rollout function | [guide](/user-guide/verifiers) |
+| [τ-bench](https://github.com/sierra-research/tau-bench) | generate function | [example](https://github.com/radixark/miles/tree/main/examples/experimental/tau-bench) |
 
 Sandbox providers are a different axis: they provision the task containers
 *inside* a connector rather than occupying a rollout layer.
@@ -33,8 +33,9 @@ Sandbox providers are a different axis: they provision the task containers
 | [AgentENV](https://github.com/kvcache-ai/AgentENV) | OpenEnv | [example](https://github.com/radixark/miles/tree/main/examples/experimental/agentenv) |
 | [Daytona](https://www.daytona.io/) | OpenEnv, Harbor, NeMo-Gym | [example](https://github.com/radixark/miles/tree/main/examples/experimental/openenv) |
 | [E2B](https://e2b.dev/) | OpenEnv | [example](https://github.com/radixark/miles/tree/main/examples/experimental/openenv) |
+| [Modal](https://modal.com/) | OpenEnv | [example](https://github.com/radixark/miles/tree/main/examples/experimental/openenv) |
 
-All external ecosystem support is experimental.
+Everything above is experimental, and listed alphabetically.
 
 ## Integration shapes
 

--- a/docs/user-guide/openenv.md
+++ b/docs/user-guide/openenv.md
@@ -19,11 +19,13 @@ hook.
 
 The maintained end-to-end recipe is **Terminal-Bench-2 GRPO** in
 [`examples/experimental/openenv`](https://github.com/radixark/miles/tree/main/examples/experimental/openenv).
-It runs against a shared Docker env server (full per-task image fidelity) or
-per-episode cloud sandboxes built from each task's official image (no resident
-infrastructure) on a choice of providers: [Daytona](https://www.daytona.io/),
-[E2B](https://e2b.dev/), or a self-hosted, E2B-compatible
-[AgentENV](https://github.com/kvcache-ai/AgentENV) deployment. Follow the
+It gives every episode its own cloud sandbox, built from that task's official
+image so no resident infrastructure is left behind, on a choice of providers —
+[AgentENV](https://github.com/kvcache-ai/AgentENV) (self-hosted, E2B-compatible),
+[Daytona](https://www.daytona.io/), [E2B](https://e2b.dev/), or
+[Modal](https://modal.com/). One shared Docker env server is supported as well,
+for running without any sandbox platform.
+Follow the
 [recipe README](https://github.com/radixark/miles/blob/main/examples/experimental/openenv/README.md)
-for prompt-data preparation, env-server modes, launcher flags, and operational
-notes.
+for prompt-data preparation, environment options, launcher flags, and
+operational notes.

--- a/examples/experimental/agentenv/README.md
+++ b/examples/experimental/agentenv/README.md
@@ -76,7 +76,7 @@ export OPENENV_TB2_TASKS_DIR=/workspace/terminal-bench-2
 OPENENV_SANDBOX_BACKEND=agentenv python ../openenv/run-openenv-tbench2.py
 ```
 
-From here the e2b leg behaves as that recipe describes it, with each episode
+From here the e2b backend behaves as that recipe describes it, with each episode
 running in a microVM instead of a cloud sandbox: the same per-task templates,
 the same pre-baking step, the same GPU-free sanity checks. One caveat is
 specific to baking against a self-hosted server: the CLI builds tasks one

--- a/examples/experimental/openenv/README.md
+++ b/examples/experimental/openenv/README.md
@@ -11,7 +11,9 @@ This guide targets a **single H200 node with 8 GPUs**. The run is colocated
 
 ## Prerequisites
 
-- The node has Docker available (the env server launches one container per task).
+- Somewhere for the task environments to run, per step 2: an account with one of
+  the hosted sandbox providers, a self-hosted AgentENV deployment, or a Docker
+  host for the shared env server.
 - miles is installed and GLM-4.7-Flash weights are reachable (the launcher pulls
   `zai-org/GLM-4.7-Flash` from HF and converts it to `torch_dist` on first run).
 - Install the OpenEnv tbench2 env client (isolate it if its deps clash with the
@@ -31,10 +33,117 @@ python make_tbench2_data.py --tasks_dir /workspace/terminal-bench-2 --output /ro
 # add --n 8 for a small smoke subset
 ```
 
-## 2. Start the env server
+## 2. Provision the task environment
 
-Run it in a separate shell (or off-node — see note). Docker mode gives real TB2
-fidelity; it needs the Docker socket and pulls the per-task images on first use:
+Every episode gets its **own cloud sandbox**, built from the task's official
+image plus an env-server layer and deleted when the episode ends. That leaves
+no resident infrastructure behind — no Docker socket, no shared server to size
+or babysit, no cross-episode state — at the cost of one sandbox creation per
+episode. (A single shared env server is still supported; see the last
+subsection.)
+
+Terminal-Bench-2 pins a different official image per **task**, which the recipe
+honors rather than flattens. Two consequences follow on every provider: nothing
+is shared across tasks, so all 89 pay their own first build; and since those
+base images live on Docker Hub, which the providers' builders pull anonymously,
+a first full-suite build can hit Docker Hub's anonymous pull limit — build a
+few tasks at a time if it does.
+
+Whichever provider you pick, install `tbench2_env` **editable**: the recipe
+bakes the installed source into each task image, so that install must carry
+the `>=` #1012 server contract. The launcher preflights the installed source
+and fails fast on an older one.
+
+```bash
+git clone https://github.com/huggingface/OpenEnv.git   # >= the #1012 merge (04d259ea6, the full canonical contract for both modes); pin that sha if you need frozen reward semantics across a long run
+pip install -e OpenEnv/envs/tbench2_env
+```
+
+Then set two things: `OPENENV_TB2_TASKS_DIR`, the checkout to build task images
+from, and `OPENENV_SANDBOX_BACKEND`, the provider to build them on. Neither has
+a default — the provider decides whose quota a run spends and which credentials
+have to be present — so setting one without the other fails at launch.
+
+Every provider authenticates the same way: the credential in the environment
+(`DAYTONA_API_KEY`, `E2B_API_KEY`, or Modal's `MODAL_TOKEN_ID` +
+`MODAL_TOKEN_SECRET` pair), or else a file whose *path* the launcher forwards.
+It never forwards the value, which ray's `runtime_env` records in plaintext;
+the agent-function docstrings cover what that means on a multi-host cluster.
+A partially-supplied credential (one half of Modal's token pair) is treated as
+missing rather than usable.
+
+### Daytona
+
+Builds each image declaratively per episode, straight from the image
+definition: the first episode of a task pays the build and later ones hit
+Daytona's build cache, keyed by definition hash. No named snapshot is involved,
+so nothing accumulates against the org's snapshot quota — and correspondingly
+there is nothing to pre-build ahead of a run.
+
+```bash
+pip install daytona
+mkdir -p ~/.config/daytona && echo dtn_... > ~/.config/daytona/api_key   # or export DAYTONA_API_KEY
+export OPENENV_TB2_TASKS_DIR=/workspace/terminal-bench-2   # the checkout from step 1
+OPENENV_SANDBOX_BACKEND=daytona python run-openenv-tbench2.py
+```
+
+### E2B or AgentENV
+
+Builds one **named template** per task, from which every later episode
+warm-starts. The endpoint defaults to E2B Cloud; to drive a self-hosted
+[AgentENV](https://github.com/kvcache-ai/AgentENV) deployment — the Firecracker
+microVM platform whose native API *is* the E2B API — set `E2B_API_URL` and
+`E2B_SANDBOX_URL` and follow the [AgentENV recipe](../agentenv/README.md).
+`agentenv` is accepted as an alias for this backend.
+
+```bash
+pip install e2b
+export E2B_API_KEY=e2b_...     # or E2B_API_KEY_FILE (default ~/.config/e2b/api_key)
+export OPENENV_TB2_TASKS_DIR=/workspace/terminal-bench-2
+OPENENV_SANDBOX_BACKEND=e2b python run-openenv-tbench2.py
+```
+
+Because the template is a named artifact rather than a build cache, it is the
+one backend that can be built ahead of the run. Doing so is optional — the
+first episode of a task builds it inline — but that inline build occupies a
+create-concurrency slot, so an unbaked first rollout spends most of its wall
+clock building images:
+
+```bash
+python tb2_sandbox_e2b.py --tasks-dir /workspace/terminal-bench-2 --all
+```
+
+### Modal
+
+Expresses the recipe as one image layer per command, so editing the recipe
+re-runs only the layers below the edit. There is no bake step: layer hashes
+are themselves the cache key, so the first create for a task warms exactly
+what later creates hit.
+
+```bash
+pip install modal
+modal token new    # writes ~/.modal.toml; or export MODAL_TOKEN_ID + MODAL_TOKEN_SECRET
+export OPENENV_TB2_TASKS_DIR=/workspace/terminal-bench-2
+OPENENV_SANDBOX_BACKEND=modal python run-openenv-tbench2.py
+```
+
+Two things here are Modal's alone. Its sandbox timeout **cannot be extended**,
+so `OPENENV_MODAL_SANDBOX_TTL_S` is a hard ceiling on one episode and must
+exceed `OPENENV_MAX_ROLLOUT_TIME_SECONDS`; orphans are reclaimed by
+`OPENENV_MODAL_IDLE_TIMEOUT_S` rather than by a keepalive thread (the
+[materialization module](tb2_sandbox_modal.py) explains why that suffices, and
+carries the snippet for sweeping a shared workspace). And for the Docker Hub
+limit above, Modal takes registry credentials directly: hand
+`Image.from_registry` a `modal.Secret`.
+
+### Alternative: one shared env server
+
+Rather than a sandbox per episode, one long-lived server can serve them all,
+launching a container per task on its own Docker host. It is what the upstream
+TB2 harness does, and it needs no sandbox platform at all — just Docker.
+(Self-hosted AgentENV also avoids a vendor account, but is a platform you
+deploy and operate.) The cost is resident infrastructure to size and clean up
+after: see the shared-server entries under Notes.
 
 ```bash
 # Raise the open-file limit first (see Notes): the WebSocket env server holds an
@@ -45,109 +154,82 @@ TB2_MODE=docker TB2_TASKS_DIR=/workspace/terminal-bench-2 MAX_CONCURRENT_ENVS=32
     python -m tbench2_env.server.app --port 8003
 ```
 
-`MAX_CONCURRENT_ENVS` caps live sandboxes; keep it at or below the rollout batch
-concurrency. Per-task containers are heavy on disk — if you'd rather not colocate
-them with the GPU workload, run the env server on a separate Docker host and point
-the launcher at it via `--openenv-env-url http://<env-host>:8003`.
+Run it in a separate shell, and leave `OPENENV_TB2_TASKS_DIR` unset so the
+launcher uses `--openenv-env-url` instead. `MAX_CONCURRENT_ENVS` caps live
+containers; keep it at or below the rollout batch concurrency. Those containers
+are heavy on disk, so if you'd rather not colocate them with the GPU workload,
+run the server on a separate Docker host and point the launcher at it with
+`--openenv-env-url http://<env-host>:8003`. The same `>=` #1012 `tbench2_env`
+contract applies: the adapter drops every episode (with a warning) from a
+server that doesn't carry it.
 
-The installed `tbench2_env` must be `>=` the #1012 merge (04d259ea6), same as
-step 2b below; the adapter drops every episode (with a warning) from a server
-that doesn't carry that contract.
+## 3. Sanity-check the environment (optional, no GPU)
 
-### 2b. Alternative: per-episode cloud sandboxes — Daytona, E2B, or AgentENV
+Skippable — training runs without it — but a provisioning mistake skipped here
+resurfaces as a rollout that burns GPUs to score zeros. Both scripts exercise
+exactly what step 2 provisioned and honor the same `OPENENV_SANDBOX_BACKEND`,
+so both cost provider time; scope them to a few tasks unless you want the full
+sweep. [`scan_golden.py`](scan_golden.py) replays each task's official solution
+through the full sandbox and scoring path; expect 82/89 to pass, since the rest
+have upstream-broken solutions, and pass `--logs` to capture the failure
+evidence. [`eval_tbench2_via_api.py`](eval_tbench2_via_api.py) runs the same
+agentic loop with any OpenAI-compatible API standing in for the policy, which
+also gives a baseline solve-rate to compare training against.
 
-Instead of one shared env server, every episode can get its **own cloud
-sandbox**, built from the task's official image plus an env-server layer and
-deleted when the episode ends. This keeps docker mode's per-task image
-fidelity while leaving no resident infrastructure behind: no Docker socket,
-no shared server to size or babysit, no cross-episode state. It costs a
-sandbox creation per episode, plus one image or template build the first time
-each task runs, which the provider caches from then on.
-
-Whichever provider you pick, install `tbench2_env` **editable**: the recipe
-bakes the installed source into each task image, so that install must carry
-the same `>=` #1012 server contract as step 2. The launcher preflights the
-installed source and fails fast on an older one.
-
-```bash
-git clone https://github.com/huggingface/OpenEnv.git   # >= the #1012 merge (04d259ea6, the full canonical contract for both modes); pin that sha if you need frozen reward semantics across a long run
-pip install -e OpenEnv/envs/tbench2_env
-```
-
-Then skip step 2 and set two things: `OPENENV_TB2_TASKS_DIR`, the checkout to
-build task images from, and `OPENENV_SANDBOX_BACKEND`, the provider to build
-them on. Neither has a default — the provider decides whose quota a run
-spends and which credentials have to be present — so setting one without the
-other fails at launch.
-
-Both providers authenticate the same way: the key in the environment
-(`DAYTONA_API_KEY`, `E2B_API_KEY`), or else a file whose *path* the launcher
-forwards. It never forwards the value, which ray's `runtime_env` records in
-plaintext; the agent-function docstrings cover what that means on a
-multi-host cluster.
-
-**Daytona** builds each image declaratively per episode. A warm create takes
-about a minute, and the first episode of each task spends about ten minutes
-building its image, cached by definition hash after that.
+## 4. Launch training
 
 ```bash
-pip install daytona
-mkdir -p ~/.config/daytona && echo dtn_... > ~/.config/daytona/api_key   # or export DAYTONA_API_KEY
-export OPENENV_TB2_TASKS_DIR=/workspace/terminal-bench-2   # the checkout from step 1
-OPENENV_SANDBOX_BACKEND=daytona python run-openenv-tbench2.py
-```
-
-**E2B-compatible** providers (`e2b`, or `agentenv` as an alias for the same
-leg) build one named template per task, and every later episode warm-starts
-from it in seconds. The endpoint defaults to E2B Cloud; to drive a
-self-hosted [AgentENV](https://github.com/kvcache-ai/AgentENV) deployment
-instead, follow the [AgentENV recipe](../agentenv/README.md).
-
-```bash
-pip install e2b
-export E2B_API_KEY=e2b_...     # or E2B_API_KEY_FILE (default ~/.config/e2b/api_key)
 export OPENENV_TB2_TASKS_DIR=/workspace/terminal-bench-2
-OPENENV_SANDBOX_BACKEND=e2b python run-openenv-tbench2.py
+OPENENV_SANDBOX_BACKEND=e2b python run-openenv-tbench2.py   # or daytona / modal
 ```
 
-Because that template is a named artifact rather than a build cache, it can be
-built ahead of the run. Doing so is optional, since the first episode of a
-task builds it inline, but that inline build occupies a create-concurrency
-slot, so an unbaked first rollout spends most of its wall clock building
-images: `python tb2_sandbox_e2b.py --tasks-dir /workspace/terminal-bench-2 --all`.
-
-Two sanity checks run without a GPU, and both honor
-`OPENENV_SANDBOX_BACKEND`. [`scan_golden.py`](scan_golden.py) replays each
-task's official solution through the full sandbox and scoring path; expect
-82/89 to pass, since the rest have upstream-broken solutions, and pass
-`--logs` to capture the failure evidence.
-[`eval_tbench2_via_api.py`](eval_tbench2_via_api.py) runs the same agentic
-loop with any OpenAI-compatible API standing in for the policy.
-
-## 3. Launch training
+Against a shared env server instead, name its URL and leave
+`OPENENV_TB2_TASKS_DIR` unset:
 
 ```bash
 python run-openenv-tbench2.py --openenv-env-url http://localhost:8003
 ```
 
-Common overrides:
+Common overrides. Every `OPENENV_*` knob below is read **once, when the rollout
+worker imports the adapter** — a worker is a fresh process per run, so changing
+one mid-run would change nothing. The exceptions are `OPENENV_TB2_TASKS_DIR`,
+which the launcher injects through ray's `runtime_env` and each episode
+re-reads, and `OPENENV_E2B_THROTTLE_PATTERNS`, consulted each time a create
+fails.
 
 | Flag / env var | Default | Purpose |
 | --- | --- | --- |
-| `--openenv-env-url` | `http://localhost:8003` | Env server URL |
+| `--openenv-env-url` | `http://localhost:8003` | Shared env server URL; ignored in per-episode sandbox mode |
 | `--prompt-data` | `/root/tbench2_train.jsonl` | Prompt set from step 1 |
 | `--num-rollout` | (launcher) | Number of GRPO steps |
 | `OPENENV_MAX_TURNS` | `30` | Max agent turns per episode |
 | `OPENENV_MAX_ROLLOUT_TIME_SECONDS` | `3600` | Per-episode wall-clock cap; a straggler that exceeds it is terminated and scored 0 |
-| `OPENENV_TB2_TASKS_DIR` | off | Switches on per-episode sandbox mode (section 2b) and overrides `--openenv-env-url`. Point it at the terminal-bench-2 checkout from step 1 |
-| `DAYTONA_API_KEY` / `DAYTONA_API_KEY_FILE` | — / `~/.config/daytona/api_key` | Daytona key supply: the env value wins, otherwise the key file is read |
-| `OPENENV_SANDBOX_BACKEND` | — | Required whenever `OPENENV_TB2_TASKS_DIR` is set: `daytona`, `e2b`, or `agentenv` (alias for `e2b`; section 2b). Only the selected leg's `OPENENV_*` settings below are read — the others are ignored silently |
-| `E2B_API_KEY` / `E2B_API_KEY_FILE` | — / `~/.config/e2b/api_key` | E2B key supply, same file-path-forwarding contract as Daytona's |
-| `E2B_API_URL`, `E2B_SANDBOX_URL` | E2B Cloud | Endpoint overrides — point both at a self-hosted AgentENV gateway |
-| `OPENENV_DAYTONA_CREATE_CONCURRENCY` | `4` | Max in-flight creates on the daytona leg. Raise it against Daytona's creation rate limit, which the leg also retries with backoff |
-| `OPENENV_E2B_CREATE_CONCURRENCY` | `4` | Max in-flight creates on the e2b leg. Size it to what the endpoint can host — one self-hosted AgentENV machine took 16 — and use `OPENENV_E2B_THROTTLE_PATTERNS` to name additional provider errors that should count as retryable capacity limits |
 | `--dump-details <dir>` | off | Dump per-episode tokens/logprobs/masks/reward for inspection |
 | `WANDB_KEY`, `--wandb-project`, `--wandb-team` | — | W&B logging |
+
+Per-episode sandbox mode (step 2). The two switches come first, then each
+provider's credentials, then the knobs — the ones shared by every backend
+(`<BACKEND>` is `DAYTONA`, `E2B`, or `MODAL`), then each provider's own.
+
+| Flag / env var | Default | Purpose |
+| --- | --- | --- |
+| `OPENENV_TB2_TASKS_DIR` | off | Switches on per-episode sandbox mode and overrides `--openenv-env-url`. Point it at the terminal-bench-2 checkout from step 1 |
+| `OPENENV_SANDBOX_BACKEND` | — | Required whenever `OPENENV_TB2_TASKS_DIR` is set: `agentenv` (alias for `e2b`), `daytona`, `e2b`, or `modal`. Only the selected backend's settings below are read — the others are ignored silently |
+| `DAYTONA_API_KEY` / `DAYTONA_API_KEY_FILE` | — / `~/.config/daytona/api_key` | Daytona key supply: the env value wins, otherwise the key file is read |
+| `E2B_API_KEY` / `E2B_API_KEY_FILE` | — / `~/.config/e2b/api_key` | E2B key supply, on the same contract |
+| `E2B_API_URL`, `E2B_SANDBOX_URL` | E2B Cloud | Endpoint overrides — point both at a self-hosted AgentENV gateway |
+| `MODAL_TOKEN_ID` + `MODAL_TOKEN_SECRET` / `MODAL_CONFIG_PATH` | — / `~/.modal.toml` | Modal credential supply. The token PAIR must be complete; otherwise the config file's *path* is forwarded, like the other providers' key files |
+| `MODAL_PROFILE`, `MODAL_ENVIRONMENT` | profile default | Which Modal profile / workspace environment the sandboxes are created in |
+| `OPENENV_<BACKEND>_CREATE_CONCURRENCY` | `4` | Max in-flight creates. Size it to what the endpoint can host — one self-hosted AgentENV machine took 16; on Modal the ceiling above it is the plan's container concurrency |
+| `OPENENV_<BACKEND>_CREATE_MAX_RETRIES` | `8` | How many throttled creates to retry before giving up (the backoff curve itself is not tunable) |
+| `OPENENV_<BACKEND>_READY_TIMEOUT_S` | `300` | How long the env server has to answer /health after its sandbox exists |
+| `OPENENV_E2B_SANDBOX_TTL_S` | `1800` | E2B sandbox TTL, re-armed by a keepalive thread while the creating process lives (Daytona's equivalent backstop is its own auto-stop/auto-delete, not a knob) |
+| `OPENENV_E2B_THROTTLE_PATTERNS` | — | Extra comma-separated lowercase substrings that count as retryable capacity errors. Exists for self-hosted AgentENV, which words "at capacity" however its operator deployed it |
+| `OPENENV_E2B_URL_SCHEME` | `https` | Scheme for the per-sandbox URL — set `http` for a plain-HTTP self-hosted AgentENV gateway |
+| `OPENENV_MODAL_APP` | `openenv-tbench2` | App the sandboxes are created under; what a sweep scopes to in a shared workspace |
+| `OPENENV_MODAL_BUILD_LOGS` | off | Stream Modal's image-build logs. Debug-only: it drives a process-wide output manager, so never set it with creates fanned out |
+| `OPENENV_MODAL_CREATE_TIMEOUT_S` | `1800` | Build+create wall clock per Modal sandbox (the first create for a task builds its image, which Modal does not deadline itself) |
+| `OPENENV_MODAL_SANDBOX_TTL_S` / `OPENENV_MODAL_IDLE_TIMEOUT_S` | `1800` / `300` | Modal lifetimes. The TTL is a HARD ceiling (Modal timeouts cannot be extended) and must exceed `OPENENV_MAX_ROLLOUT_TIME_SECONDS`; the idle timeout is what reclaims orphans, and an open tunnel connection counts as activity |
 
 ## Notes
 
@@ -158,14 +240,15 @@ Common overrides:
 - **`_step` vs. rollout.** W&B `_step` is an internal log-call index that advances
   several times per rollout; it is **not** the training step. Read the driver log's
   `rollout N:` counter for true progress.
-- **Sandbox leakage.** Upstream OpenEnv creates task containers with `remove=False`
-  and only tears them down on a clean session close (the idle reaper is off by
-  default), so an unclean disconnect (trainer crash) can orphan containers. Sweep
-  stale TB2 containers between runs, e.g. `docker rm -f` of any older than the
-  episode wall-cap.
-- **Open-file limit.** The same unclean disconnects also leak socket FDs in the
-  env server process. On a long run under the default 1024 soft limit the accept
-  loop eventually fails every connection with `OSError: [Errno 24] Too many open
-  files`, silently throttling rollouts. Start the server with a raised limit
-  (`ulimit -n 1048576`, as in step 2); if a running server is already saturated,
-  restart it with the higher limit.
+- **Shared server: container leakage.** Upstream OpenEnv creates task containers
+  with `remove=False` and only tears them down on a clean session close (the idle
+  reaper is off by default), so an unclean disconnect (trainer crash) can orphan
+  containers. Sweep stale TB2 containers between runs, e.g. `docker rm -f` of any
+  older than the episode wall-cap. Per-episode sandboxes have no equivalent: each
+  provider arms its own TTL, so a dead caller's sandbox is reclaimed for you.
+- **Shared server: open-file limit.** The same unclean disconnects also leak
+  socket FDs in the env server process. On a long run under the default 1024 soft
+  limit the accept loop eventually fails every connection with `OSError: [Errno
+  24] Too many open files`, silently throttling rollouts. Start the server with a
+  raised limit (`ulimit -n 1048576`, as in step 2); if a running server is already
+  saturated, restart it with the higher limit.

--- a/examples/experimental/openenv/eval_tbench2_via_api.py
+++ b/examples/experimental/openenv/eval_tbench2_via_api.py
@@ -2,7 +2,7 @@
 per-episode sandboxes as the env. No GPU, no miles training pipeline.
 
 This reuses the exact agent-env loop miles runs during training
-(``openenv_agent_function._multi_turn``: reset -> {policy emits a shell command
+(``openenv_agent_function.multi_turn``: reset -> {policy emits a shell command
 -> exec -> feed output back} -> canonical tests/test.sh -> binary reward) but
 swaps miles' session-server policy for a plain API client. The machine running
 this only orchestrates; the policy runs in the cloud (e.g. DeepSeek) and each
@@ -22,18 +22,19 @@ Env vars:
   DEEPSEEK_API_KEY / POLICY_API_KEY   policy API key (required)
   POLICY_BASE_URL   OpenAI-compatible root (default https://api.deepseek.com)
   POLICY_MODEL      default deepseek-v4-flash
-  OPENENV_TB2_TASKS_DIR  per-episode sandbox mode (TB2 checkout path); with
-                    provider credentials go with it (Daytona: DAYTONA_API_KEY
-                    or ~/.config/daytona/api_key; e2b/agentenv likewise).
-  OPENENV_SANDBOX_BACKEND             required with the above: daytona / e2b /
-                    agentenv (an alias for e2b).
-                    Otherwise OPENENV_ENV_URL is used.
+  OPENENV_SANDBOX_BACKEND   per-episode sandbox mode: agentenv (an alias for
+                    e2b) / daytona / e2b / modal. Left unset, OPENENV_ENV_URL
+                    (one shared env server) is used instead.
+  OPENENV_TB2_TASKS_DIR     required with the above: the TB2 checkout to build
+                    task images from. Each backend then resolves its OWN
+                    credential exactly as it does under training -- from the
+                    environment, else its key file -- so nothing is passed
+                    through here; see the recipe README for each provider's.
   OPENENV_MAX_TURNS, OPENENV_MAX_ROLLOUT_TIME_SECONDS, ...   as in the adapter.
 
 Usage:
-  # DAYTONA_API_KEY may be omitted if ~/.config/daytona/api_key is provisioned
-  DEEPSEEK_API_KEY=sk-... DAYTONA_API_KEY=dtn_... \
-  OPENENV_TB2_TASKS_DIR=/path/to/terminal-bench-2 \
+  DEEPSEEK_API_KEY=sk-... \
+  OPENENV_SANDBOX_BACKEND=e2b OPENENV_TB2_TASKS_DIR=/path/to/terminal-bench-2 \
   python eval_tbench2_via_api.py --tasks chess-best-move --concurrency 2
   # or from make_tbench2_data.py output:
   python eval_tbench2_via_api.py --data /root/tbench2_train.jsonl
@@ -114,14 +115,9 @@ async def main() -> None:
 
         try:
             backend = sandbox_common.resolve_backend(os.getenv("OPENENV_SANDBOX_BACKEND"))
+            run_episode = sandbox_common.load_backend(backend).run_episode
         except ValueError as e:
             sys.exit(str(e))
-        if backend == "e2b":
-            import openenv_e2b_agent_function as sandbox_leg
-        else:
-            import openenv_daytona_agent_function as sandbox_leg
-
-        run_episode = sandbox_leg.run_episode
         env_desc = f"{backend} sandboxes (tasks_dir={tasks_dir})"
     else:
         run_episode = oaf.run_episode

--- a/examples/experimental/openenv/openenv_agent_function.py
+++ b/examples/experimental/openenv/openenv_agent_function.py
@@ -34,13 +34,14 @@ WORKDIR resolved server-side, verifier assets withheld. The adapter verifies
 the contract on every episode rather than trusting the deployment: an
 ``evaluate`` reply without the canonical-harness marker is treated as no
 verdict and the episode is dropped with a warning (see the guard in
-_multi_turn).
+multi_turn).
 
-Daytona-sandbox variant: ``openenv_daytona_agent_function`` (sibling module)
-is a drop-in ``--custom-agent-function-path`` alternative that runs every
-episode in its own Daytona cloud sandbox. It reuses this module's
-agent loop and training wrapper, supplying only its own run_episode (see the
-episode-wiring note below); its env vars are documented there.
+Per-episode sandbox variants: one sibling module per provider
+(``openenv_{daytona,e2b,modal}_agent_function``), each a drop-in
+``--custom-agent-function-path`` alternative that runs every episode in its
+own cloud sandbox. They reuse this module's agent loop and training wrapper,
+supplying only their own run_episode (see the episode-wiring note below);
+their env vars are documented there.
 """
 
 import asyncio
@@ -78,7 +79,7 @@ _FENCE_RE = re.compile(r"```(?:python|py|bash|sh)?\s*\n?(.*?)```", re.DOTALL | r
 _OBS_CHAR_CAP = 4000
 
 # The system prompt that teaches a policy this adapter's agent contract, i.e.
-# what _multi_turn parses: exactly one shell command per turn in a single
+# what multi_turn parses: exactly one shell command per turn in a single
 # ```bash block, TASK_COMPLETE (no code block) to stop. It lives here, next to
 # that parsing logic; make_tbench2_data.py (training prompt data) and
 # eval_tbench2_via_api.py (API-policy eval) import it so all consumers stay on
@@ -98,7 +99,7 @@ TB2_AGENT_SYSTEM_PROMPT = (
 # default 900). The default clears the server's default budget with margin;
 # raise it (and OPENENV_MAX_ROLLOUT_TIME_SECONDS) for tasks declaring larger
 # verifier budgets.
-_MESSAGE_TIMEOUT_S = float(os.getenv("OPENENV_MESSAGE_TIMEOUT_S", "1200"))
+MESSAGE_TIMEOUT_S = float(os.getenv("OPENENV_MESSAGE_TIMEOUT_S", "1200"))
 
 # Hard wall-clock cap for one episode. The per-message timeout above bounds a
 # single env op, and OPENENV_MAX_TURNS bounds the turn count, but neither bounds
@@ -161,7 +162,7 @@ def _obs_info(result: Any) -> dict:
 
 
 # Lazy import so the file loads without the env client present at import time.
-def _load_tbench2() -> dict[str, Any]:
+def load_tbench2() -> dict[str, Any]:
     from tbench2_env import Tbench2Action, Tbench2Env
 
     return {"env": Tbench2Env, "action": Tbench2Action}
@@ -171,16 +172,16 @@ _DEFAULT_ENV_URL = "http://localhost:8003"
 
 
 # --- Episode wiring -------------------------------------------------------------
-# The agent loop (_multi_turn) is shared; everything that differs between the
+# The agent loop (multi_turn) is shared; everything that differs between the
 # episode legs enters it as two keyword parameters, filled in only by each
 # module's run_episode():
 #
 #   run_body(env_cls, metadata, body)   how an env comes into being — connect to
 #                       the shared server (_shared_run_body below, capacity-
-#                       retried) vs create a Daytona sandbox
-#                       (openenv_daytona_agent_function).
+#                       retried) vs create a per-episode sandbox (the sandbox
+#                       backend modules).
 #   post_episode(env, action_cls)       optional hygiene hook (a long-lived
-#                       shared server accumulates trial dirs; a Daytona
+#                       shared server accumulates trial dirs; a per-episode
 #                       sandbox lives only for its episode and needs nothing).
 #
 # Every agent-function module exposes the same two entries: run() for miles
@@ -231,7 +232,7 @@ async def _with_env(env_cls: Any, env_url: str, body: Callable[[Any], Any]) -> A
     deadline = asyncio.get_event_loop().time() + _CAPACITY_MAX_WAIT_S
     while True:
         try:
-            async with env_cls(base_url=env_url, message_timeout_s=_MESSAGE_TIMEOUT_S) as env:
+            async with env_cls(base_url=env_url, message_timeout_s=MESSAGE_TIMEOUT_S) as env:
                 return await body(env)
         except Exception as e:
             if _is_retryable_env_error(e) and asyncio.get_event_loop().time() < deadline:
@@ -240,7 +241,7 @@ async def _with_env(env_cls: Any, env_url: str, body: Callable[[Any], Any]) -> A
             raise
 
 
-async def _multi_turn(
+async def multi_turn(
     classes: dict[str, Any],
     policy: AsyncOpenAI,
     model_name: str,
@@ -382,8 +383,8 @@ async def run_episode(
     ``(reward, agent_metrics)``; wall-clock caps and failure semantics are the
     caller's. miles goes through run() instead.
     """
-    return await _multi_turn(
-        _load_tbench2(),
+    return await multi_turn(
+        load_tbench2(),
         policy,
         model_name,
         messages,
@@ -394,7 +395,7 @@ async def run_episode(
     )
 
 
-async def _run_for_training(
+async def run_for_training(
     base_url: str,
     prompt: Any,
     request_kwargs: dict[str, Any] | None,
@@ -441,7 +442,7 @@ async def _run_for_training(
         await policy.close()
 
     # No canonical verdict (infra/harness failure or a non-canonical server,
-    # not a legitimate task failure -- see the guard in _multi_turn). Drop the
+    # not a legitimate task failure -- see the guard in multi_turn). Drop the
     # sample: returning it as reward 0.0 would inject a false negative into
     # training.
     if reward is None:
@@ -469,4 +470,4 @@ async def run(
     **kwargs,
 ) -> dict[str, Any] | None:
     """Run one OpenEnv tbench2 episode via the trained policy (shared env server)."""
-    return await _run_for_training(base_url, prompt, request_kwargs, metadata, run_episode)
+    return await run_for_training(base_url, prompt, request_kwargs, metadata, run_episode)

--- a/examples/experimental/openenv/openenv_daytona_agent_function.py
+++ b/examples/experimental/openenv/openenv_daytona_agent_function.py
@@ -36,21 +36,23 @@ Env vars (the agent-loop ones in ``openenv_agent_function`` apply too):
                      logged in plaintext. Point it at a file every node can
                      read: a dotfile, K8s Secret mount, or shared-FS path.
   OPENENV_DAYTONA_CREATE_CONCURRENCY  max in-flight sandbox creates (default 4).
-  OPENENV_DAYTONA_READY_TIMEOUT_S     server-ready wait per sandbox (default 300).
-  TB2_COMMAND_TIMEOUT_S        per-exec timeout inside the sandbox (default 900).
+  OPENENV_DAYTONA_CREATE_MAX_RETRIES  how many throttled creates to retry (default 8).
+
+Everything describing ONE sandbox — the ready deadline, and the auto-stop /
+auto-delete backstop — is documented and read in ``tb2_sandbox_daytona``, and
+the per-exec timeout inside it (TB2_COMMAND_TIMEOUT_S) in
+``tb2_sandbox_recipe``, next to the code each one steers.
 """
 
 import logging
-import os
-from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Any
 
-import openenv_agent_function as oaf
 import openenv_sandbox_common as common
 import tb2_sandbox_daytona
 
 logger = logging.getLogger(__name__)
+
 
 # Each episode materializes the per-task image declaratively from the Image
 # definition, read off the local TB2 checkout (OPENENV_TB2_TASKS_DIR); repeat
@@ -63,19 +65,9 @@ logger = logging.getLogger(__name__)
 # older install outright, and the shared agent loop's harness-marker guard
 # backstops it per episode.
 #
-# Daytona rate-limits sandbox creation (ThrottlerException: Too Many Requests).
-# A rollout fans out many episodes at once; cap in-flight creates process-wide
-# and retry throttled ones with jittered exponential backoff.
-_CREATE_CONCURRENCY = int(os.getenv("OPENENV_DAYTONA_CREATE_CONCURRENCY", "4"))
-_CREATE_MAX_RETRIES = int(os.getenv("OPENENV_DAYTONA_CREATE_MAX_RETRIES", "8"))
-_CREATE_BACKOFF_BASE_S = float(os.getenv("OPENENV_DAYTONA_CREATE_BACKOFF_BASE_S", "2.0"))
-_CREATE_BACKOFF_CAP_S = float(os.getenv("OPENENV_DAYTONA_CREATE_BACKOFF_CAP_S", "30.0"))
-_READY_TIMEOUT_S = float(os.getenv("OPENENV_DAYTONA_READY_TIMEOUT_S", "300"))
-_COMMAND_TIMEOUT_S = int(os.getenv("TB2_COMMAND_TIMEOUT_S", "900"))
-
-_get_create_sem = common.lazy_semaphore(_CREATE_CONCURRENCY)
-
-
+# Daytona rate-limits sandbox creation (ThrottlerException: Too Many Requests);
+# the shared backend caps in-flight creates process-wide and retries throttled ones
+# with jittered exponential backoff (knobs: OPENENV_DAYTONA_CREATE_*).
 def _is_throttle_error(exc: BaseException) -> bool:
     """True when a sandbox create failed only because Daytona rate-limited it.
 
@@ -93,86 +85,24 @@ def _is_throttle_error(exc: BaseException) -> bool:
             return True
     except ImportError:  # pragma: no cover - only without the daytona SDK
         pass
-    s = str(exc).lower()
-    return "throttler" in s or "too many requests" in s or "429" in s
+    return common.throttle_text(exc, "throttler")
 
 
-def _start_declarative(task_id: str, tasks_dir: str) -> tuple[Any, str]:
+def _start_sandbox(task_id: str, tasks_dir: str) -> tuple[Any, str]:
     daytona = tb2_sandbox_daytona.make_daytona()
-    sandbox, url = tb2_sandbox_daytona.create_task_sandbox(
-        daytona,
-        Path(tasks_dir) / task_id,
-        command_timeout_s=_COMMAND_TIMEOUT_S,
-        ready_timeout_s=_READY_TIMEOUT_S,
-    )
+    sandbox, url = tb2_sandbox_daytona.create_task_sandbox(daytona, Path(tasks_dir) / task_id)
     return (lambda: daytona.delete(sandbox)), url
 
 
-async def _start_task_sandbox(task_id: str) -> tuple[Any, str]:
-    """Create one sandbox for *task_id* with the env server running.
+BACKEND = common.SandboxBackend(
+    provider="Daytona",
+    start_sandbox=_start_sandbox,
+    is_throttle=_is_throttle_error,
+    logger=logger,
+    **common.backend_knobs("DAYTONA"),
+)
 
-    Returns (close_fn, base_url); close_fn deletes the sandbox. The
-    orchestration — cancel-safe create, process-wide throttling, backoff on
-    Daytona rate limits — is the provider-blind skeleton in
-    ``openenv_sandbox_common``; this leg contributes only its start hook and
-    throttle classifier.
-    """
-    return await common.start_task_sandbox(
-        task_id,
-        os.getenv("OPENENV_TB2_TASKS_DIR", "").strip(),
-        start_fn=lambda tid, tdir: _start_declarative(tid, tdir),
-        is_throttle=_is_throttle_error,
-        sem=_get_create_sem(),
-        max_retries=_CREATE_MAX_RETRIES,
-        backoff_base_s=_CREATE_BACKOFF_BASE_S,
-        backoff_cap_s=_CREATE_BACKOFF_CAP_S,
-        logger=logger,
-        provider="Daytona",
-    )
-
-
-@asynccontextmanager
-async def _episode_env(env_cls: Any, metadata: dict[str, Any]):
-    """Yield a connected env client on a fresh sandbox; delete it after."""
-    async with common.episode_env(env_cls, metadata, start=_start_task_sandbox, logger=logger) as env:
-        yield env
-
-
-async def _sandbox_run_body(env_cls: Any, metadata: dict[str, Any], body: Any) -> Any:
-    """Run *body* on a fresh sandbox for the episode's task."""
-    async with _episode_env(env_cls, metadata) as env:
-        return await body(env)
-
-
-async def run_episode(
-    policy: Any,
-    model_name: str,
-    messages: list[dict[str, str]],
-    request_kwargs: dict[str, Any],
-    metadata: dict[str, Any],
-) -> tuple[float | None, dict[str, Any]]:
-    """One episode in its own Daytona sandbox, with the caller's own
-    policy. Direct-drive entry, same contract as openenv_agent_function's.
-
-    No post-episode hygiene: the sandbox is deleted when the episode ends.
-    """
-    return await oaf._multi_turn(
-        oaf._load_tbench2(),
-        policy,
-        model_name,
-        messages,
-        request_kwargs,
-        metadata,
-        run_body=_sandbox_run_body,
-    )
-
-
-async def run(
-    base_url: str,
-    prompt: Any,
-    request_kwargs: dict[str, Any] | None = None,
-    metadata: dict[str, Any] | None = None,
-    **kwargs,
-) -> dict[str, Any] | None:
-    """Run one OpenEnv tbench2 episode in its own Daytona sandbox."""
-    return await oaf._run_for_training(base_url, prompt, request_kwargs, metadata, run_episode)
+# Module-level entry points: `--custom-agent-function-path` resolves a module
+# attribute, and the sibling tools reach run_episode the same way.
+run_episode = BACKEND.run_episode
+run = BACKEND.run

--- a/examples/experimental/openenv/openenv_e2b_agent_function.py
+++ b/examples/experimental/openenv/openenv_e2b_agent_function.py
@@ -12,7 +12,7 @@ The agent loop and training wrapper live in ``openenv_agent_function``
 (sibling module) and are reused unchanged; this module only supplies its own
 ``run_episode`` — how an env comes into being (see the episode-wiring note
 there). The image recipe lives in ``tb2_sandbox_recipe`` and its E2B
-materialization in ``tb2_sandbox_e2b``; like the Daytona leg, this variant
+materialization in ``tb2_sandbox_e2b``; like every sandbox backend, this one
 needs the pinned tbench2_env install from the README (canonical test.sh
 scoring and verifier-asset withholding built into the server).
 
@@ -21,32 +21,34 @@ Env vars (the agent-loop ones in ``openenv_agent_function`` apply too):
                     are built once per task under a recipe-digest alias
                     (first episode of a task pays the build; repeats
                     warm-start), or pre-baked via the tb2_sandbox_e2b CLI.
-  E2B_API_KEY / E2B_API_KEY_FILE   key supply, mirroring the Daytona leg's
-                    DAYTONA_API_KEY / _FILE contract (file default
-                    ~/.config/e2b/api_key; launchers forward the PATH, never
-                    the value). AgentENV accepts any non-empty key today.
+  E2B_API_KEY / E2B_API_KEY_FILE   key supply on the contract every backend
+                    shares (file default ~/.config/e2b/api_key; launchers
+                    forward the PATH, never the value). AgentENV accepts any
+                    non-empty key today.
   E2B_API_URL / E2B_SANDBOX_URL    endpoint overrides read by the SDK itself;
                     set both to target a self-hosted AgentENV.
   OPENENV_E2B_CREATE_CONCURRENCY   max in-flight sandbox creates (default 4).
-  OPENENV_E2B_READY_TIMEOUT_S      server-ready wait per sandbox (default 300).
+  OPENENV_E2B_CREATE_MAX_RETRIES   how many throttled creates to retry (default 8).
   OPENENV_E2B_THROTTLE_PATTERNS    extra comma-separated lowercase substrings
-                    classified as retryable throttling/capacity errors —
-                    self-hosted providers surface "at capacity" differently
-                    than E2B Cloud's 429s; extend without a code change.
-  TB2_COMMAND_TIMEOUT_S            per-exec timeout inside the sandbox (default 900).
+                    classified as retryable throttling/capacity errors — a
+                    self-hosted AgentENV words "at capacity" its own way, and
+                    whoever deployed it can name that without a code change.
+
+Everything describing ONE sandbox — its lifetime and the ready deadline — is
+documented and read in ``tb2_sandbox_e2b``, and the per-exec timeout inside it
+(TB2_COMMAND_TIMEOUT_S) in ``tb2_sandbox_recipe``, next to the code each one
+steers.
 """
 
 import logging
-import os
-from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Any
 
-import openenv_agent_function as oaf
 import openenv_sandbox_common as common
 import tb2_sandbox_e2b
 
 logger = logging.getLogger(__name__)
+
 
 # The sandbox's env server is the tbench2_env baked by the recipe, installed
 # per the README (at or after the huggingface/OpenEnv#1012 merge): canonical
@@ -55,24 +57,9 @@ logger = logging.getLogger(__name__)
 # older install outright, and the shared agent loop's harness-marker guard
 # backstops it per episode.
 #
-# Providers rate-limit or run out of capacity under a fanned-out rollout; cap
-# in-flight creates process-wide and retry throttled ones with jittered
-# exponential backoff.
-_CREATE_CONCURRENCY = int(os.getenv("OPENENV_E2B_CREATE_CONCURRENCY", "4"))
-_CREATE_MAX_RETRIES = int(os.getenv("OPENENV_E2B_CREATE_MAX_RETRIES", "8"))
-_CREATE_BACKOFF_BASE_S = float(os.getenv("OPENENV_E2B_CREATE_BACKOFF_BASE_S", "2.0"))
-_CREATE_BACKOFF_CAP_S = float(os.getenv("OPENENV_E2B_CREATE_BACKOFF_CAP_S", "30.0"))
-_READY_TIMEOUT_S = float(os.getenv("OPENENV_E2B_READY_TIMEOUT_S", "300"))
-_COMMAND_TIMEOUT_S = int(os.getenv("TB2_COMMAND_TIMEOUT_S", "900"))
-
-_get_create_sem = common.lazy_semaphore(_CREATE_CONCURRENCY)
-
-
-def _extra_throttle_patterns() -> tuple[str, ...]:
-    raw = os.getenv("OPENENV_E2B_THROTTLE_PATTERNS", "")
-    return tuple(p.strip().lower() for p in raw.split(",") if p.strip())
-
-
+# Providers rate-limit or run out of capacity under a fanned-out rollout; the
+# shared backend caps in-flight creates process-wide and retries throttled ones
+# with jittered exponential backoff (knobs: OPENENV_E2B_CREATE_*).
 def _is_throttle_error(exc: BaseException) -> bool:
     """True when a sandbox create failed only because the provider throttled it.
 
@@ -91,86 +78,23 @@ def _is_throttle_error(exc: BaseException) -> bool:
             return True
     except ImportError:  # pragma: no cover - only without the e2b SDK
         pass
-    s = str(exc).lower()
-    if "too many requests" in s or "429" in s or "rate limit" in s:
-        return True
-    return any(p in s for p in _extra_throttle_patterns())
+    return common.throttle_text(exc, patterns_env_var="OPENENV_E2B_THROTTLE_PATTERNS")
 
 
 def _start_sandbox(task_id: str, tasks_dir: str) -> tuple[Any, str]:
-    sandbox, url = tb2_sandbox_e2b.create_task_sandbox(
-        Path(tasks_dir) / task_id,
-        command_timeout_s=_COMMAND_TIMEOUT_S,
-        ready_timeout_s=_READY_TIMEOUT_S,
-    )
+    sandbox, url = tb2_sandbox_e2b.create_task_sandbox(Path(tasks_dir) / task_id)
     return (lambda: tb2_sandbox_e2b.kill_sandbox(sandbox)), url
 
 
-async def _start_task_sandbox(task_id: str) -> tuple[Any, str]:
-    """Create one sandbox for *task_id* with the env server running.
+BACKEND = common.SandboxBackend(
+    provider="E2B",
+    start_sandbox=_start_sandbox,
+    is_throttle=_is_throttle_error,
+    logger=logger,
+    **common.backend_knobs("E2B"),
+)
 
-    Returns (close_fn, base_url); close_fn kills the sandbox. The
-    orchestration — cancel-safe create, process-wide throttling, backoff on
-    provider rate limits — is the provider-blind skeleton in
-    ``openenv_sandbox_common``; this leg contributes only its start hook and
-    throttle classifier.
-    """
-    return await common.start_task_sandbox(
-        task_id,
-        os.getenv("OPENENV_TB2_TASKS_DIR", "").strip(),
-        start_fn=lambda tid, tdir: _start_sandbox(tid, tdir),
-        is_throttle=_is_throttle_error,
-        sem=_get_create_sem(),
-        max_retries=_CREATE_MAX_RETRIES,
-        backoff_base_s=_CREATE_BACKOFF_BASE_S,
-        backoff_cap_s=_CREATE_BACKOFF_CAP_S,
-        logger=logger,
-        provider="E2B",
-    )
-
-
-@asynccontextmanager
-async def _episode_env(env_cls: Any, metadata: dict[str, Any]):
-    """Yield a connected env client on a fresh sandbox; kill it after."""
-    async with common.episode_env(env_cls, metadata, start=_start_task_sandbox, logger=logger) as env:
-        yield env
-
-
-async def _sandbox_run_body(env_cls: Any, metadata: dict[str, Any], body: Any) -> Any:
-    """Run *body* on a fresh sandbox for the episode's task."""
-    async with _episode_env(env_cls, metadata) as env:
-        return await body(env)
-
-
-async def run_episode(
-    policy: Any,
-    model_name: str,
-    messages: list[dict[str, str]],
-    request_kwargs: dict[str, Any],
-    metadata: dict[str, Any],
-) -> tuple[float | None, dict[str, Any]]:
-    """One episode in its own E2B sandbox, with the caller's own policy.
-    Direct-drive entry, same contract as openenv_agent_function's.
-
-    No post-episode hygiene: the sandbox is killed when the episode ends.
-    """
-    return await oaf._multi_turn(
-        oaf._load_tbench2(),
-        policy,
-        model_name,
-        messages,
-        request_kwargs,
-        metadata,
-        run_body=_sandbox_run_body,
-    )
-
-
-async def run(
-    base_url: str,
-    prompt: Any,
-    request_kwargs: dict[str, Any] | None = None,
-    metadata: dict[str, Any] | None = None,
-    **kwargs,
-) -> dict[str, Any] | None:
-    """Run one OpenEnv tbench2 episode in its own E2B sandbox."""
-    return await oaf._run_for_training(base_url, prompt, request_kwargs, metadata, run_episode)
+# Module-level entry points: `--custom-agent-function-path` resolves a module
+# attribute, and the sibling tools reach run_episode the same way.
+run_episode = BACKEND.run_episode
+run = BACKEND.run

--- a/examples/experimental/openenv/openenv_launch_common.py
+++ b/examples/experimental/openenv/openenv_launch_common.py
@@ -36,6 +36,7 @@ class LaunchArgs(Protocol):
     openenv_sandbox_backend: str
     daytona_api_key_file: str
     e2b_api_key_file: str
+    modal_config_file: str
     router_external_host: str
     miles_host_ip: str
 
@@ -106,14 +107,14 @@ def optimizer_args() -> str:
 
 
 def resolve_sandbox_backend(args: LaunchArgs) -> str:
-    """The per-episode sandbox backend in effect: "" (shared env server),
-    "daytona", or "e2b".
+    """The per-episode sandbox backend in effect, or "" for the shared env server.
 
     Names and aliases resolve through openenv_sandbox_common, the canonical
-    registry: "agentenv" is an accepted alias for "e2b", because AgentENV
+    registry, so the accepted set is never enumerated twice: "agentenv" is an
+    accepted alias for "e2b", because AgentENV
     (https://github.com/kvcache-ai/AgentENV) is a self-hosted Firecracker
     microVM platform whose native API is the E2B API, so it runs on the e2b
-    leg with E2B_API_URL/E2B_SANDBOX_URL pointed at it.
+    backend with E2B_API_URL/E2B_SANDBOX_URL pointed at it.
 
     The two settings that turn this mode on come as a pair — a task checkout
     to build images from, and the provider to build them on — so naming one
@@ -137,9 +138,9 @@ def resolve_sandbox_backend(args: LaunchArgs) -> str:
 
 def agent_args(tito_model: str, sandbox_backend: str = "") -> str:
     """Agentic-rollout wiring. The TITO surface differs across models; the
-    agent function decides where episodes run — the shared env server by
-    default, per-episode sandboxes (Daytona or E2B/AgentENV) when the launcher
-    resolves a sandbox backend (see resolve_sandbox_backend)."""
+    agent function decides where episodes run — per-episode sandboxes on
+    whichever backend the launcher resolves (see resolve_sandbox_backend), else
+    the one shared env server."""
     agent_fn = sandbox_common.AGENT_FUNCTIONS.get(sandbox_backend, "openenv_agent_function.run")
     return (
         "--custom-generate-function-path miles.rollout.generate_hub.agentic_tool_call.generate "
@@ -195,42 +196,30 @@ def apply_optional_env_vars(env: dict[str, str], args: LaunchArgs) -> None:
         env["MILES_ROUTER_EXTERNAL_HOST"] = args.router_external_host
     backend = resolve_sandbox_backend(args)
     if backend:
-        if backend == "daytona":
-            _sandbox_key_supply(
-                env,
-                provider="Daytona",
-                key_env_var="DAYTONA_API_KEY",
-                file_env_var="DAYTONA_API_KEY_FILE",
-                arg_path=args.daytona_api_key_file,
-                default_path="~/.config/daytona/api_key",
-                provision_hint="mkdir -p ~/.config/daytona && echo dtn_... > ~/.config/daytona/api_key",
-            )
-            _preflight_sdk("daytona", "pip install daytona (or pip install -e '<OpenEnv>/envs/tbench2_env[daytona]')")
-        else:  # e2b (E2B Cloud or a self-hosted AgentENV endpoint)
-            _sandbox_key_supply(
-                env,
-                provider="E2B",
-                key_env_var="E2B_API_KEY",
-                file_env_var="E2B_API_KEY_FILE",
-                arg_path=args.e2b_api_key_file,
-                default_path="~/.config/e2b/api_key",
-                provision_hint="mkdir -p ~/.config/e2b && echo <key> > ~/.config/e2b/api_key"
-                "  # AgentENV accepts any non-empty key today",
-            )
-            _preflight_sdk("e2b", "pip install e2b")
-            # Endpoint overrides are read from the environment by the SDK on
-            # every worker; forward them (they are addresses, not secrets).
-            # E2B_API_URL unset means E2B Cloud; set, it usually points at a
-            # self-hosted AgentENV deployment.
-            for var in ("E2B_API_URL", "E2B_SANDBOX_URL", "E2B_DOMAIN", "OPENENV_E2B_URL_SCHEME"):
-                if os.environ.get(var, "").strip():
-                    env[var] = os.environ[var].strip()
-            endpoint = env.get("E2B_API_URL", "E2B Cloud (default)")
-            print(f"openenv: E2B endpoint: {endpoint}", flush=True)
+        spec = _PROVIDER_CREDENTIALS[backend]
+        _sandbox_key_supply(
+            env,
+            provider=spec["provider"],
+            key_env_vars=spec["key_env_vars"],
+            file_env_var=spec["file_env_var"],
+            arg_path=getattr(args, spec["arg_attr"], "") or "",
+            default_path=spec["default_path"],
+            provision_hint=spec["provision_hint"],
+        )
+        _preflight_sdk(spec["sdk"], spec["sdk_hint"])
+        # Addresses, not secrets: the SDK reads these from the environment on
+        # every worker, so forward whatever is set here BY VALUE.
+        for var in spec["forward"]:
+            value = os.environ.get(var, "").strip()
+            if value:
+                _forward_address(env, var, value)
+        if spec["target"]:
+            var, label, default_desc = spec["target"]
+            print(f"openenv: {spec['provider']} {label}: {env.get(var, default_desc)}", flush=True)
         # Preflight the env package the recipe bakes into each task image —
         # shared by every sandbox backend. The import check catches a missing
         # install; the source probe catches an install that imports fine but
-        # lacks the server features the sandbox legs score through (canonical
+        # lacks the server features the sandbox backends score through (canonical
         # tests/test.sh evaluate, TB2_WITHHOLD_TESTS) — that one would not
         # even fail per-episode, it would silently mis-score every episode.
         try:
@@ -253,22 +242,98 @@ def apply_optional_env_vars(env: dict[str, str], args: LaunchArgs) -> None:
         env["OPENENV_TB2_TASKS_DIR"] = args.openenv_tb2_tasks_dir
 
 
+# Per-provider credential shape and the address-like env vars to forward.
+# One entry per backend in openenv_sandbox_common.AGENT_MODULES; a provider is
+# added here, not by growing a branch.
+#   key_env_vars   what a worker must ALL have for the env-supply path to work
+#                  (Modal's credential is a token PAIR, not one key)
+#   file_env_var   the path-valued var the launcher forwards instead of secrets
+#   forward        addresses/selectors, safe to forward by value
+#   target         (var, label, default description) echoed so a launch says
+#                  which endpoint/environment it will actually use
+_PROVIDER_CREDENTIALS = {
+    "daytona": {
+        "provider": "Daytona",
+        "key_env_vars": ("DAYTONA_API_KEY",),
+        "file_env_var": "DAYTONA_API_KEY_FILE",
+        "arg_attr": "daytona_api_key_file",
+        "default_path": "~/.config/daytona/api_key",
+        "provision_hint": "mkdir -p ~/.config/daytona && echo dtn_... > ~/.config/daytona/api_key",
+        "sdk": "daytona",
+        "sdk_hint": "pip install daytona (or pip install -e '<OpenEnv>/envs/tbench2_env[daytona]')",
+        "forward": (),
+        "target": None,
+    },
+    "e2b": {
+        "provider": "E2B",
+        "key_env_vars": ("E2B_API_KEY",),
+        "file_env_var": "E2B_API_KEY_FILE",
+        "arg_attr": "e2b_api_key_file",
+        "default_path": "~/.config/e2b/api_key",
+        "provision_hint": "mkdir -p ~/.config/e2b && echo <key> > ~/.config/e2b/api_key"
+        "  # AgentENV accepts any non-empty key today",
+        "sdk": "e2b",
+        "sdk_hint": "pip install e2b",
+        # E2B_API_URL unset means E2B Cloud; set, it usually points at a
+        # self-hosted AgentENV deployment.
+        "forward": ("E2B_API_URL", "E2B_SANDBOX_URL", "E2B_DOMAIN", "OPENENV_E2B_URL_SCHEME"),
+        "target": ("E2B_API_URL", "endpoint", "E2B Cloud (default)"),
+    },
+    "modal": {
+        "provider": "Modal",
+        # Modal has no single API key: the SDK wants both token halves, or the
+        # config file whose path MODAL_CONFIG_PATH names.
+        "key_env_vars": ("MODAL_TOKEN_ID", "MODAL_TOKEN_SECRET"),
+        "file_env_var": "MODAL_CONFIG_PATH",
+        "arg_attr": "modal_config_file",
+        "default_path": "~/.modal.toml",
+        "provision_hint": "uv tool install modal && modal token new  # writes ~/.modal.toml",
+        "sdk": "modal",
+        "sdk_hint": "pip install modal",
+        "forward": ("MODAL_PROFILE", "MODAL_ENVIRONMENT", "OPENENV_MODAL_APP"),
+        "target": ("MODAL_ENVIRONMENT", "workspace environment", "the profile's default"),
+    },
+}
+
+
+def _forward_address(env: dict[str, str], var: str, value: str) -> None:
+    """Forward one address-like var by value, refusing one that carries a secret.
+
+    What ``forward`` names are endpoints and selectors, which is why they may
+    ride ray's runtime_env at all while a credential may not (only its PATH is
+    forwarded — see _sandbox_key_supply). A URL defeats that distinction by
+    smuggling a credential through userinfo (``https://user:token@host``), and
+    runtime_env is echoed into driver logs and persisted in job metadata in
+    plaintext, so refuse it rather than forward it. Nothing legitimately
+    forwarded here — a hostname, a scheme, a profile or app name — contains an
+    '@', so the check needs no URL parsing to be precise.
+    """
+    if "@" in value:
+        raise ValueError(
+            f"{var} looks like it embeds credentials ('@'), and anything forwarded "
+            "to rollout workers is logged in plaintext by ray. Put the credential "
+            "in the provider's key file (or the worker environment) and leave a "
+            "bare address here."
+        )
+    env[var] = value
+
+
 def _sandbox_key_supply(
     env: dict[str, str],
     *,
     provider: str,
-    key_env_var: str,
+    key_env_vars: tuple[str, ...],
     file_env_var: str,
     arg_path: str,
     default_path: str,
     provision_hint: str,
 ) -> None:
     """Key-supply contract, shared by the sandbox backends: rollout workers
-    get the provider key from their OWN environment (e.g. platform-injected)
-    or from a file they can read (a dotfile, K8s Secret mount, or shared-FS
-    path). The launcher forwards only the file PATH, never the value: worker
-    env rides ray's runtime_env, which exec_command echoes into driver logs
-    and ray persists in job metadata, all in plaintext."""
+    get the provider credential from their OWN environment (e.g.
+    platform-injected) or from a file they can read (a dotfile, K8s Secret
+    mount, or shared-FS path). The launcher forwards only the file PATH, never
+    the value: worker env rides ray's runtime_env, which exec_command echoes
+    into driver logs and ray persists in job metadata, all in plaintext."""
     key_file = Path(arg_path or default_path).expanduser()
     try:
         key_present = bool(key_file.read_text(encoding="utf-8").strip())
@@ -276,10 +341,14 @@ def _sandbox_key_supply(
         key_present = False
     # Either supply is fine; neither is fully verifiable from here (the
     # launcher cannot probe worker nodes), so echo which one is in effect.
+    # A provider whose credential is several variables (Modal's token pair) is
+    # only satisfied by having ALL of them; a partial set is a misconfiguration
+    # that would fail every episode.
+    names = " + ".join(key_env_vars)
     if key_present:
         env[file_env_var] = str(key_file)
         print(
-            f"openenv: {provider} key supply: file {key_file} "
+            f"openenv: {provider} credential supply: file {key_file} "
             "(readable here; forwarding the path, workers read it themselves)",
             flush=True,
         )
@@ -287,18 +356,18 @@ def _sandbox_key_supply(
         # An explicitly configured path that doesn't resolve on the launcher
         # is a config error; failing every episode later is far worse.
         raise ValueError(f"{file_env_var}={arg_path} is missing or empty")
-    elif os.environ.get(key_env_var, "").strip():
+    elif all(os.environ.get(var, "").strip() for var in key_env_vars):
         print(
-            f"openenv: {provider} key supply: worker environment ({key_env_var} "
-            "is set here; workers are assumed to have it in their own env — "
+            f"openenv: {provider} credential supply: worker environment ({names} "
+            "set here; workers are assumed to have them in their own env — "
             "single-host inheritance or platform-injected pod env)",
             flush=True,
         )
     else:
         raise ValueError(
-            f"the {provider} sandbox mode needs an API key: put it in a file "
+            f"the {provider} sandbox mode needs credentials: put them in a file "
             f"({key_file}; {file_env_var} overrides) or in the "
-            f"environment as {key_env_var}. Provision the file with:\n"
+            f"environment as {names}. Provision the file with:\n"
             f"  {provision_hint}"
         )
 

--- a/examples/experimental/openenv/openenv_modal_agent_function.py
+++ b/examples/experimental/openenv/openenv_modal_agent_function.py
@@ -1,0 +1,101 @@
+"""Modal-sandbox variant of the OpenEnv tbench2 agent function.
+
+A drop-in alternative to ``openenv_agent_function.run`` for
+``--custom-agent-function-path``: instead of sharing one env server
+(OPENENV_ENV_URL), every episode gets its OWN Modal sandbox — built from the
+task's OFFICIAL image plus an env server layer, terminated when the episode
+ends.
+
+The agent loop and training wrapper live in ``openenv_agent_function``, and
+everything about running episodes on per-episode sandboxes is
+``openenv_sandbox_common``'s ``SandboxBackend``. This module is only what is
+Modal-specific: how one sandbox comes into being, which of its SDK's errors are
+worth retrying, and its knobs. The image recipe lives in ``tb2_sandbox_recipe``
+and its Modal materialization in ``tb2_sandbox_modal``; like the other sandbox
+backends, this variant needs the pinned tbench2_env install from the README
+(canonical test.sh scoring and verifier-asset withholding built into the
+server).
+
+Credentials are the one place Modal does not fit the other backends' shape: there
+is no single API key, so nothing here reads or forwards one. The SDK resolves
+MODAL_TOKEN_ID + MODAL_TOKEN_SECRET from the worker's own environment, else the
+config file at MODAL_CONFIG_PATH (default ``~/.modal.toml``) — and the launcher
+forwards that PATH, never the token, on the same reasoning as the other
+providers' key files (see openenv_launch_common).
+
+Env vars (the agent-loop ones in ``openenv_agent_function`` apply too):
+  OPENENV_TB2_TASKS_DIR       path to a terminal-bench-2 checkout. The first
+                    episode of a task pays its image build; repeats hit
+                    Modal's layer cache, and all tasks share every layer but
+                    the last (see tb2_sandbox_modal.task_image).
+  MODAL_TOKEN_ID / MODAL_TOKEN_SECRET / MODAL_CONFIG_PATH   credential supply,
+                    read by the SDK itself. MODAL_PROFILE / MODAL_ENVIRONMENT
+                    select a profile / workspace environment when set.
+  OPENENV_MODAL_APP                app the sandboxes are created under
+                    (default openenv-tbench2) — what a sweep scopes to.
+  OPENENV_MODAL_CREATE_CONCURRENCY max in-flight sandbox creates (default 4).
+  OPENENV_MODAL_CREATE_MAX_RETRIES how many throttled creates to retry (default 8).
+
+Everything describing ONE sandbox — its app, lifetime, and the create/ready
+deadlines — is documented and read in ``tb2_sandbox_modal``, and the per-exec
+timeout inside it (TB2_COMMAND_TIMEOUT_S) in ``tb2_sandbox_recipe``, next to
+the code each one steers.
+"""
+
+import logging
+from pathlib import Path
+from typing import Any
+
+import openenv_sandbox_common as common
+import tb2_sandbox_modal
+
+logger = logging.getLogger(__name__)
+
+
+# The sandbox's env server is the tbench2_env baked by the recipe, installed
+# per the README (at or after the huggingface/OpenEnv#1012 merge): canonical
+# tests/test.sh scoring built into `evaluate`, task WORKDIR resolved
+# server-side, verifier assets withheld. The launcher preflight rejects an
+# older install outright, and the shared agent loop's harness-marker guard
+# backstops it per episode.
+#
+# Modal caps concurrent containers per plan; the shared backend caps in-flight
+# creates process-wide and retries throttled ones with jittered exponential
+# backoff (knobs: OPENENV_MODAL_CREATE_*).
+def _is_throttle_error(exc: BaseException) -> bool:
+    """True when a sandbox create failed only because Modal was out of room.
+
+    Modal types a hit ceiling (the plan's container concurrency, or a workspace
+    resource limit) as ResourceExhaustedError; the text match covers the same
+    condition surfacing as a message from an older SDK or a proxy.
+    """
+    # In-function import, deliberately: this is the class's only use site, it
+    # only runs on the failure path (where modal is already in sys.modules,
+    # having just raised `exc`), and offline tests must not require the SDK.
+    try:
+        from modal.exception import ResourceExhaustedError
+
+        if isinstance(exc, ResourceExhaustedError):
+            return True
+    except ImportError:  # pragma: no cover - only without the modal SDK
+        pass
+    return common.throttle_text(exc, "resource exhausted")
+
+
+def _start_sandbox(task_id: str, tasks_dir: str) -> tuple[Any, str]:
+    sandbox, url = tb2_sandbox_modal.create_task_sandbox(Path(tasks_dir) / task_id)
+    return sandbox.terminate, url
+
+
+BACKEND = common.SandboxBackend(
+    provider="Modal",
+    start_sandbox=_start_sandbox,
+    is_throttle=_is_throttle_error,
+    logger=logger,
+    **common.backend_knobs("MODAL"),
+)
+
+# Module-level entry points: `--custom-agent-function-path` resolves a module
+# attribute, and the sibling tools reach run_episode the same way.
+run_episode = BACKEND.run_episode
+run = BACKEND.run

--- a/examples/experimental/openenv/openenv_sandbox_common.py
+++ b/examples/experimental/openenv/openenv_sandbox_common.py
@@ -1,6 +1,7 @@
-"""Shared per-episode sandbox orchestration for the provider agent functions.
+"""Shared per-episode sandbox orchestration for the backend agent functions.
 
-A provider leg (``openenv_daytona_agent_function``, ``openenv_e2b_agent_function``)
+A backend module (``openenv_daytona_agent_function``,
+``openenv_e2b_agent_function``, ``openenv_modal_agent_function``)
 owns only what is genuinely provider-specific: how ONE sandbox with the env
 server comes into being (its ``tb2_sandbox_*`` materialization module), which
 errors count as retryable throttling, and its env-var knobs. Everything that
@@ -15,24 +16,28 @@ and lives here once:
                 is recorded thread-side and, on cancellation, handed to a
                 reaper that closes the orphan promptly once the create
                 finishes.
-  ``lazy_semaphore``       the create-throttle semaphore each leg passes in,
+  ``lazy_semaphore``       the create-throttle semaphore each backend passes in,
                 built on first use rather than at import.
-  ``start_task_sandbox``   process-wide create throttling (the caller's
-                semaphore) plus jittered exponential backoff on the errors the
-                caller classifies as throttling; anything else propagates
-                immediately. The semaphore is held only for the create attempt
-                and released during backoff so other episodes keep the
-                pipeline full.
-  ``episode_env``          async context manager mirroring one episode's
-                lifetime: fresh sandbox -> connected env client -> close.
+  ``SandboxBackend``       the orchestration itself. ``start_task_sandbox``
+                throttles creates process-wide (the semaphore) and retries the
+                errors the backend classifies as throttling with jittered
+                exponential backoff — anything else propagates immediately, and
+                the semaphore is held only for the create attempt and released
+                during backoff so other episodes keep the pipeline full.
+                ``episode_env`` is the async context manager mirroring one
+                episode's lifetime: fresh sandbox -> connected env client ->
+                close.
 """
 
 import asyncio
+import importlib
 import logging
+import os
 import random
 import threading
-from collections.abc import Awaitable, Callable
+from collections.abc import Callable
 from contextlib import asynccontextmanager
+from dataclasses import dataclass
 from typing import Any
 
 # A provider's "start one sandbox" hook: (task_id, tasks_dir) -> (close_fn, base_url).
@@ -40,12 +45,20 @@ StartFn = Callable[[str, str], tuple[Callable[[], None], str]]
 
 # The canonical per-episode backend registry — the launcher and the sibling
 # tools (scan_golden, eval_tbench2_via_api) all resolve through here, so the
-# accepted names and the "agentenv is the e2b leg" aliasing cannot drift.
-AGENT_FUNCTIONS = {
-    "daytona": "openenv_daytona_agent_function.run",
-    "e2b": "openenv_e2b_agent_function.run",
+# accepted names and the "agentenv is the e2b backend" aliasing cannot drift.
+# Adding a provider is one entry plus its two modules (backend + materialization).
+AGENT_MODULES = {
+    "daytona": "openenv_daytona_agent_function",
+    "e2b": "openenv_e2b_agent_function",
+    "modal": "openenv_modal_agent_function",
 }
+AGENT_FUNCTIONS = {backend: f"{module}.run" for backend, module in AGENT_MODULES.items()}
 _ALIASES = {"agentenv": "e2b"}
+
+
+def backend_names() -> str:
+    """The accepted names, for help text that must not drift from the registry."""
+    return ", ".join(sorted([*AGENT_FUNCTIONS, *_ALIASES]))
 
 
 def resolve_backend(name: str | None) -> str:
@@ -56,7 +69,7 @@ def resolve_backend(name: str | None) -> str:
     left out is a question to answer rather than one to guess at.
     """
     backend = (name or "").strip().lower()
-    allowed = ", ".join(sorted([*AGENT_FUNCTIONS, *_ALIASES]))
+    allowed = backend_names()
     if not backend:
         raise ValueError(f"no sandbox backend named; choose one of: {allowed}")
     backend = _ALIASES.get(backend, backend)
@@ -65,10 +78,21 @@ def resolve_backend(name: str | None) -> str:
     return backend
 
 
+def load_backend(name: str | None) -> "SandboxBackend":
+    """The SandboxBackend named by *name*, imported on demand.
+
+    The sibling tools (scan_golden, eval_tbench2_via_api) drive one backend
+    directly instead of through the training entry point. Resolving it here
+    means they gain a provider by naming it, not by growing an import branch
+    each — and a provider's SDK is imported only when it is the one selected.
+    """
+    return importlib.import_module(AGENT_MODULES[resolve_backend(name)]).BACKEND
+
+
 def lazy_semaphore(limit: int) -> Callable[[], asyncio.Semaphore]:
     """Return a getter for a *limit*-slot semaphore created on first call.
 
-    A leg reads its concurrency knob at import, but a semaphore constructed
+    A backend reads its concurrency knob at import, but a semaphore constructed
     then would belong to whatever loop happens to be current — the rollout
     loop does not exist yet. Deferring construction to the first episode ties
     it to the loop that actually awaits on it.
@@ -112,62 +136,181 @@ async def create_once(start_fn: StartFn, task_id: str, tasks_dir: str, *, logger
         raise
 
 
-async def start_task_sandbox(
-    task_id: str,
-    tasks_dir: str,
-    *,
-    start_fn: StartFn,
-    is_throttle: Callable[[BaseException], bool],
-    sem: asyncio.Semaphore,
-    max_retries: int,
-    backoff_base_s: float,
-    backoff_cap_s: float,
-    logger: logging.Logger,
-    provider: str,
-) -> tuple[Any, str]:
-    """Create one sandbox for *task_id* with the env server running.
+def _agent_function():
+    """``openenv_agent_function``, imported on use rather than at module scope.
 
-    Returns (close_fn, base_url). Creation is throttled process-wide and
-    retried with jittered exponential backoff on throttle errors.
+    The one lazy import in this module, and the reason is the module's other
+    callers: a provider CLI (``python tb2_sandbox_e2b.py ...``) and the
+    launcher reach this module for the backend registry alone, and neither
+    should have to have the agent loop's dependencies (openai) installed to
+    resolve a backend name.
     """
-    attempt = 0
-    while True:
+    import openenv_agent_function
+
+    return openenv_agent_function
+
+
+# Throttle text every provider shares: an HTTP 429 surfaced as a message
+# rather than a typed error. A backend adds its own vocabulary (Daytona's
+# "throttler", Modal's "resource exhausted").
+_THROTTLE_TEXT = ("too many requests", "429", "rate limit")
+
+
+def throttle_text(exc: BaseException, *extra_patterns: str, patterns_env_var: str | None = None) -> bool:
+    """True when *exc*'s message reads like throttling or exhausted capacity.
+
+    The typed-exception half of the decision stays in the backend (only it knows
+    its SDK's class); this is the half that is identical everywhere, plus the
+    backend's *extra_patterns*.
+
+    *patterns_env_var* extends the set at runtime, and exists for exactly one
+    case: an endpoint whose capacity errors are worded by whoever deployed it,
+    which is why only the e2b backend (self-hosted AgentENV) passes one.
+    """
+    s = str(exc).lower()
+    if any(p in s for p in (*_THROTTLE_TEXT, *(p.lower() for p in extra_patterns))):
+        return True
+    raw = os.getenv(patterns_env_var, "") if patterns_env_var else ""
+    return any(p in s for p in (chunk.strip().lower() for chunk in raw.split(",")) if p)
+
+
+# Backoff shape for throttled creates: jittered exponential, shared by every
+# backend. Constants rather than knobs — a rollout tunes how MANY creates are in
+# flight (create_concurrency) and how long to keep trying (max_retries), not the
+# curve between them.
+BACKOFF_BASE_S = 2.0
+BACKOFF_CAP_S = 30.0
+
+# Knob defaults shared by every backend, read from its OWN prefix so one
+# provider can be re-tuned without touching another.
+_KNOB_DEFAULTS = {
+    "create_concurrency": ("CREATE_CONCURRENCY", 4, int),
+    "max_retries": ("CREATE_MAX_RETRIES", 8, int),
+}
+
+
+def backend_knobs(env_prefix: str) -> dict[str, Any]:
+    """The create-throttling knobs for a backend, read from OPENENV_<PREFIX>_*.
+
+    Read once, at the importing module's import time: a rollout worker is a
+    fresh process per run, so a knob changed mid-run would be a knob that
+    silently did nothing.
+    """
+    return {
+        field: cast(os.getenv(f"OPENENV_{env_prefix}_{suffix}", str(default)))
+        for field, (suffix, default, cast) in _KNOB_DEFAULTS.items()
+    }
+
+
+@dataclass
+class SandboxBackend:
+    """The provider-blind half of a per-episode sandbox agent function.
+
+    Every backend is the same rollout-facing object — throttled cancel-safe
+    creates, an env client bound to one episode's sandbox, the training and
+    direct-drive entry points — around two provider-specific holes:
+    ``start_sandbox`` (how ONE sandbox with the env server comes into being)
+    and ``is_throttle`` (which of its SDK's errors are worth retrying). A backend
+    module supplies those two, its knobs, and its documentation; nothing else
+    about it can drift from its siblings because nothing else lives there.
+
+    The fields are the seams: tests substitute ``start_sandbox`` or
+    ``episode_env`` and shrink the backoff on the instance, so the knobs stay
+    patchable without a backend re-reading its environment.
+    """
+
+    provider: str
+    start_sandbox: StartFn
+    is_throttle: Callable[[BaseException], bool]
+    logger: logging.Logger
+    create_concurrency: int = _KNOB_DEFAULTS["create_concurrency"][1]
+    max_retries: int = _KNOB_DEFAULTS["max_retries"][1]
+    backoff_base_s: float = BACKOFF_BASE_S
+    backoff_cap_s: float = BACKOFF_CAP_S
+
+    def __post_init__(self) -> None:
+        self._get_sem = lazy_semaphore(self.create_concurrency)
+
+    async def start_task_sandbox(self, task_id: str) -> tuple[Any, str]:
+        """Create one sandbox for *task_id* with the env server running.
+
+        Returns (close_fn, base_url); close_fn releases the sandbox. Creation
+        is throttled process-wide (the create semaphore) and retried with
+        jittered exponential backoff on throttle errors; anything else
+        propagates immediately.
+        """
+        tasks_dir = os.getenv("OPENENV_TB2_TASKS_DIR", "").strip()
+        attempt = 0
+        while True:
+            try:
+                async with self._get_sem():
+                    return await create_once(self.start_sandbox, task_id, tasks_dir, logger=self.logger)
+            except Exception as e:
+                if not self.is_throttle(e) or attempt >= self.max_retries:
+                    raise
+                attempt += 1
+                delay = min(self.backoff_cap_s, self.backoff_base_s * (2 ** (attempt - 1))) * (0.5 + random.random())
+                self.logger.warning(
+                    f"{self.provider} create throttled for {task_id} "
+                    f"(attempt {attempt}/{self.max_retries}); retrying in {delay:.1f}s"
+                )
+                await asyncio.sleep(delay)
+
+    @asynccontextmanager
+    async def episode_env(self, env_cls: Any, metadata: dict[str, Any]):
+        """Yield a connected env client on a fresh sandbox; release it after."""
+        oaf = _agent_function()
+        task_id = metadata.get("task_id") or metadata.get("task_name")
+        if not task_id:
+            raise ValueError("the sandbox is built for one task: metadata['task_id'] is required")
+        close_fn, url = await self.start_task_sandbox(str(task_id))
         try:
-            async with sem:
-                return await create_once(start_fn, task_id, tasks_dir, logger=logger)
-        except Exception as e:
-            if not is_throttle(e) or attempt >= max_retries:
-                raise
-            attempt += 1
-            delay = min(backoff_cap_s, backoff_base_s * (2 ** (attempt - 1))) * (0.5 + random.random())
-            logger.warning(
-                f"{provider} create throttled for {task_id} (attempt {attempt}/{max_retries}); retrying in {delay:.1f}s"
-            )
-            await asyncio.sleep(delay)
+            async with env_cls(base_url=url, message_timeout_s=oaf.MESSAGE_TIMEOUT_S) as env:
+                yield env
+        finally:
+            try:
+                await asyncio.to_thread(close_fn)
+            except Exception as e:
+                self.logger.warning(f"Failed to close sandbox for {task_id}: {e}")
 
+    async def _run_body(self, env_cls: Any, metadata: dict[str, Any], body: Any) -> Any:
+        # self.episode_env, not the module function: an instance attribute
+        # substituted by a test must win here.
+        async with self.episode_env(env_cls, metadata) as env:
+            return await body(env)
 
-@asynccontextmanager
-async def episode_env(
-    env_cls: Any,
-    metadata: dict[str, Any],
-    *,
-    start: Callable[[str], Awaitable[tuple[Any, str]]],
-    logger: logging.Logger,
-):
-    """Yield a connected env client on a fresh sandbox; close it after."""
-    # Imported lazily so provider CLIs (bake) don't drag in the agent loop's
-    # dependencies (openai) just to reach this module's registry.
-    import openenv_agent_function as oaf
+    async def run_episode(
+        self,
+        policy: Any,
+        model_name: str,
+        messages: list[dict[str, str]],
+        request_kwargs: dict[str, Any],
+        metadata: dict[str, Any],
+    ) -> tuple[float | None, dict[str, Any]]:
+        """One episode in its own sandbox, with the caller's own policy.
+        Direct-drive entry, same contract as openenv_agent_function's.
 
-    task_id = metadata.get("task_id") or metadata.get("task_name")
-    if not task_id:
-        raise ValueError("the sandbox is built for one task: metadata['task_id'] is required")
-    close_fn, url = await start(str(task_id))
-    try:
-        async with env_cls(base_url=url, message_timeout_s=oaf._MESSAGE_TIMEOUT_S) as env:
-            yield env
-    finally:
-        try:
-            await asyncio.to_thread(close_fn)
-        except Exception as e:
-            logger.warning(f"Failed to close sandbox for {task_id}: {e}")
+        No post-episode hygiene: the sandbox is released when the episode ends.
+        """
+        oaf = _agent_function()
+        return await oaf.multi_turn(
+            oaf.load_tbench2(),
+            policy,
+            model_name,
+            messages,
+            request_kwargs,
+            metadata,
+            run_body=self._run_body,
+        )
+
+    async def run(
+        self,
+        base_url: str,
+        prompt: Any,
+        request_kwargs: dict[str, Any] | None = None,
+        metadata: dict[str, Any] | None = None,
+        **kwargs,
+    ) -> dict[str, Any] | None:
+        """Run one OpenEnv tbench2 episode in its own sandbox (training entry)."""
+        oaf = _agent_function()
+        return await oaf.run_for_training(base_url, prompt, request_kwargs, metadata, self.run_episode)

--- a/examples/experimental/openenv/run-openenv-tbench2.py
+++ b/examples/experimental/openenv/run-openenv-tbench2.py
@@ -1,9 +1,10 @@
 """OpenEnv Terminal-Bench-2 (tbench2) learning launcher (GLM-4.7-Flash).
 
-Drives the OpenEnv tbench2 env via ``openenv_agent_function.run`` (shared env
-server) or a per-episode sandbox agent function (set ``openenv_tb2_tasks_dir``
-plus ``--openenv-sandbox-backend daytona``, or ``e2b``/``agentenv`` for an
-E2B-compatible provider). tbench2 is
+Drives the OpenEnv tbench2 env through a per-episode sandbox agent function
+(set ``openenv_tb2_tasks_dir`` plus ``--openenv-sandbox-backend``; the registry
+in openenv_sandbox_common names the providers), or through
+``openenv_agent_function.run`` against one shared env server when neither is
+set. tbench2 is
 *multi-turn*: the adapter runs an agentic loop (reset(task_id) -> {policy emits a
 shell command -> step(exec) -> feed output back} -> evaluate) and the reward is
 the binary pytest result (1.0 all tests pass, else 0.0).
@@ -15,26 +16,29 @@ Prereqs:
     # 2. Get the TB2 task suite + build prompt-data (task_ids).
     git clone --depth 1 https://github.com/laude-institute/terminal-bench-2.git /workspace/terminal-bench-2
     python make_tbench2_data.py --tasks_dir /workspace/terminal-bench-2 --output /root/tbench2_train.jsonl
-    # 3. Serve the env. The tbench2 server supports concurrency natively via
-    #    MAX_CONCURRENT_ENVS (no wrapper needed). Choose execution mode:
-    #      TB2_MODE=docker  -> real TB2 fidelity (needs docker.sock + image pulls)
-    #      TB2_MODE=local   -> runs in-process, ignores task Dockerfiles (degraded)
+    # 3. Point the adapter at an environment. Either give every episode its own
+    #    cloud sandbox -- set OPENENV_TB2_TASKS_DIR and the backend, whose
+    #    credentials that provider then resolves itself (see the recipe README):
+    OPENENV_TB2_TASKS_DIR=/workspace/terminal-bench-2 \
+        OPENENV_SANDBOX_BACKEND=e2b python run-openenv-tbench2.py
+    #    ... or serve one shared env server and leave OPENENV_TB2_TASKS_DIR
+    #    unset. It handles concurrency natively via MAX_CONCURRENT_ENVS (no
+    #    wrapper needed); TB2_MODE=docker is real TB2 fidelity (needs
+    #    docker.sock + image pulls), TB2_MODE=local ignores task Dockerfiles.
     TB2_MODE=docker TB2_TASKS_DIR=/workspace/terminal-bench-2 MAX_CONCURRENT_ENVS=32 \
         python -m tbench2_env.server.app --port 8003
-    #    ... or skip the shared server entirely: set OPENENV_TB2_TASKS_DIR
-    #    (+ the Daytona key: DAYTONA_API_KEY in the env, or a key file at
-    #    ~/.config/daytona/api_key) and the adapter runs each episode in its
-    #    own Daytona cloud sandbox (no Docker host needed).
 
-    NOTE (open decisions before a real run): docker mode wants a Docker host with
-    disk + socket; colocating heavy per-task containers on the GPU pod is risky,
-    so the env server likely runs off-pod (use --openenv-env-url / the host
-    rewrite). The binary sparse reward also needs a task subset where the base
-    policy *sometimes* succeeds (advantage variance) -- e.g. the TB2 variance
-    band -- or GRPO sees a flat signal.
+    NOTE (open decisions before a real run): the shared server wants a Docker
+    host with disk + socket, and colocating heavy per-task containers on the GPU
+    pod is risky, so it likely runs off-pod (use --openenv-env-url / the host
+    rewrite) -- per-episode sandboxes sidestep that entirely. The binary sparse
+    reward also needs a task subset where the base policy *sometimes* succeeds
+    (advantage variance) -- e.g. the TB2 variance band -- or GRPO sees a flat
+    signal.
 
 Usage:
-    python run-openenv-tbench2.py --openenv-env-url http://<env-host>:8003
+    OPENENV_SANDBOX_BACKEND=e2b python run-openenv-tbench2.py   # or daytona / modal
+    python run-openenv-tbench2.py --openenv-env-url http://<env-host>:8003  # shared server
 """
 
 import os
@@ -81,22 +85,25 @@ class ScriptArgs(U.ExecuteTrainConfig):
     # within the limit is terminated and scored reward 0, bounding long-trajectory
     # stragglers that would otherwise stall the whole rollout batch.
     openenv_max_rollout_time_seconds: int = int(os.environ.get("OPENENV_MAX_ROLLOUT_TIME_SECONDS", "3600"))
-    # Daytona sandbox mode: every episode runs in its own cloud
-    # sandbox (the task's official image + env server layer; see the adapter
-    # docstring). Set to the TB2 checkout path; the adapter then ignores
-    # --openenv-env-url. Workers resolve the Daytona key from their own
-    # environment (DAYTONA_API_KEY, e.g. platform-injected) first, else from
-    # a key file (default ~/.config/daytona/api_key; this flag overrides the
-    # path). Only the file PATH is ever forwarded — a key value in ray
-    # runtime_env would be logged in plaintext.
+    # Per-episode sandbox mode: every episode runs in its own cloud sandbox
+    # (the task's official image + env server layer; see the adapter docstring).
+    # Set to the TB2 checkout path; the adapter then ignores --openenv-env-url.
+    # Whichever provider runs them, workers resolve its credential from their
+    # own environment (e.g. platform-injected) first, else from a file whose
+    # path the *_key_file flags below override. Only the file PATH is ever
+    # forwarded — a credential value in ray runtime_env would be logged in
+    # plaintext.
     openenv_tb2_tasks_dir: str = os.environ.get("OPENENV_TB2_TASKS_DIR", "")
     # Which per-episode sandbox provider runs the tasks_dir episodes:
-    # "daytona", "e2b" (E2B Cloud), or "agentenv" (alias for e2b — a
-    # self-hosted AgentENV deployment reached via E2B_API_URL/E2B_SANDBOX_URL).
+    # "agentenv" (alias for e2b — a self-hosted AgentENV deployment reached via
+    # E2B_API_URL/E2B_SANDBOX_URL), "daytona", "e2b" (E2B Cloud), or "modal".
     # Required whenever openenv_tb2_tasks_dir is set; there is no default.
     openenv_sandbox_backend: str = os.environ.get("OPENENV_SANDBOX_BACKEND", "")
     daytona_api_key_file: str = os.environ.get("DAYTONA_API_KEY_FILE", "")
     e2b_api_key_file: str = os.environ.get("E2B_API_KEY_FILE", "")
+    # Modal's credential is a token pair, so the file here is its config file
+    # (~/.modal.toml), forwarded by path exactly like the others' key files.
+    modal_config_file: str = os.environ.get("MODAL_CONFIG_PATH", "")
     # When set, miles dumps full per-episode agent trajectories (tokens, logprobs,
     # loss masks, reward, multi-turn messages) to <dir>/rollout_data/{rollout_id}.pt
     # for post-hoc inspection via miles.utils.debug_utils.display_debug_rollout_data.

--- a/examples/experimental/openenv/scan_golden.py
+++ b/examples/experimental/openenv/scan_golden.py
@@ -27,18 +27,14 @@ import tomllib
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import openenv_agent_function as oaf
 
-# The sandbox leg to replay through — resolved by the same registry the
+# The sandbox backend to replay through — resolved by the same registry the
 # launcher uses, so a missing or unknown provider is an error here too.
 import openenv_sandbox_common as sandbox_common
 
 try:
-    _BACKEND = sandbox_common.resolve_backend(os.getenv("OPENENV_SANDBOX_BACKEND"))
+    _backend = sandbox_common.load_backend(os.getenv("OPENENV_SANDBOX_BACKEND"))
 except ValueError as e:
     sys.exit(str(e))
-if _BACKEND == "e2b":
-    import openenv_e2b_agent_function as sandbox_leg
-else:
-    import openenv_daytona_agent_function as sandbox_leg
 
 CAP_S = float(os.getenv("GOLDEN_TASK_CAP_S", "1800"))
 
@@ -69,13 +65,13 @@ def _solution_push_commands(task_id: str) -> list[str]:
 
 
 async def golden_one(task_id: str, capture_logs: bool = False) -> tuple[str, float | None, dict]:
-    classes = oaf._load_tbench2()
+    classes = oaf.load_tbench2()
     action = classes["action"]
     t0 = time.monotonic()
     try:
 
         async def run() -> dict:
-            async with sandbox_leg._episode_env(classes["env"], {"task_id": task_id}) as env:
+            async with _backend.episode_env(classes["env"], {"task_id": task_id}) as env:
                 await env.reset(task_id=task_id)
                 t = time.monotonic()
                 # Official oracle convention (harbor OracleAgent): solution dir
@@ -152,7 +148,8 @@ async def main() -> None:
     if not os.getenv("OPENENV_TB2_TASKS_DIR", "").strip():
         sys.exit(
             "scan_golden requires the per-episode sandbox mode: set OPENENV_TB2_TASKS_DIR "
-            "and OPENENV_SANDBOX_BACKEND (daytona/e2b/agentenv), plus that provider's credentials"
+            f"and OPENENV_SANDBOX_BACKEND ({sandbox_common.backend_names()}), "
+            "plus that provider's credentials"
         )
     tasks = [t.strip() for t in args.tasks.split(",") if t.strip()]
     print(f"golden sweep | {len(tasks)} tasks | concurrency={args.concurrency}", flush=True)

--- a/examples/experimental/openenv/tb2_sandbox_daytona.py
+++ b/examples/experimental/openenv/tb2_sandbox_daytona.py
@@ -28,13 +28,20 @@ from pathlib import Path
 
 import tb2_sandbox_recipe as recipe
 from tb2_sandbox_recipe import (
-    read_task_config,
+    COMMAND_TIMEOUT_S,
     resolve_docker_image,
     sandbox_labels,
     server_cmd,
     server_layer_commands,
+    task_env_resources,
     wait_server_ready,
 )
+
+
+# Every knob describing ONE Daytona sandbox lives here, next to the create
+# that uses it; the backend module keeps only the fan-out knobs. Read at import:
+# a rollout worker is a fresh process per run.
+_READY_TIMEOUT_S = float(os.getenv("OPENENV_DAYTONA_READY_TIMEOUT_S", "300"))
 
 
 def build_task_image(task_dir: Path, docker_image: str | None = None):
@@ -55,12 +62,10 @@ def build_task_image(task_dir: Path, docker_image: str | None = None):
 def task_resources(task_dir: Path):
     from daytona import Resources
 
-    env_cfg = read_task_config(task_dir).get("environment", {})
-    return Resources(
-        cpu=max(1, int(env_cfg.get("cpus", 1))),
-        memory=max(2, int(env_cfg.get("memory_mb", 2048)) // 1024),
-        disk=max(10, int(env_cfg.get("storage_mb", 10240)) // 1024),
-    )
+    # Daytona sizes in whole GB; the recipe's floors (2048 MB / 10240 MB)
+    # guarantee the integer division never rounds to zero.
+    cpus, memory_mb, storage_mb = task_env_resources(task_dir)
+    return Resources(cpu=cpus, memory=memory_mb // 1024, disk=storage_mb // 1024)
 
 
 # Keepalive cadence: 6 beats per 30-minute auto-stop window, and up to 3
@@ -90,9 +95,13 @@ def create_task_sandbox(
     daytona,
     task_dir: Path,
     *,
-    command_timeout_s: int = 900,
+    command_timeout_s: int = COMMAND_TIMEOUT_S,
     create_timeout_s: float = 1800.0,
-    ready_timeout_s: float = 300.0,
+    ready_timeout_s: float = _READY_TIMEOUT_S,
+    # Deliberately arguments rather than env knobs, unlike the E2B/Modal TTLs:
+    # these two are Daytona's OWN auto-stop/auto-delete intervals, and the
+    # keepalive cadence below is written against them. Retuning them means
+    # rethinking the heartbeat, not turning a dial.
     auto_stop_minutes: int = 30,
     auto_delete_minutes: int = 120,
 ):
@@ -132,7 +141,10 @@ def create_task_sandbox(
         _start_keepalive(sandbox, task_dir.name)
         return sandbox, url
     except Exception:
-        daytona.delete(sandbox)
+        try:
+            daytona.delete(sandbox)
+        except Exception:
+            pass  # cleanup must not mask the real failure; auto-stop/auto-delete reclaims it
         raise
 
 

--- a/examples/experimental/openenv/tb2_sandbox_e2b.py
+++ b/examples/experimental/openenv/tb2_sandbox_e2b.py
@@ -13,8 +13,8 @@ server speaking the E2B API:
     server and this module needs no code changes; AgentENV currently accepts
     any non-empty API key.
 
-Unlike Daytona's declarative per-episode image build, E2B separates the two
-halves of a create:
+Where a provider that builds declaratively does it all in the create, E2B
+separates the two halves:
 
   ``ensure_task_template(...)``  build the per-task template once, under a
       deterministic alias derived from the task id AND a digest of the recipe
@@ -35,7 +35,6 @@ offline unit tests and non-sandbox launches must not require the SDK.
 """
 
 import argparse
-import concurrent.futures
 import hashlib
 import os
 import re
@@ -46,11 +45,12 @@ from pathlib import Path
 
 import tb2_sandbox_recipe as recipe
 from tb2_sandbox_recipe import (
-    read_task_config,
     resolve_docker_image,
+    run_with_deadline,
     sandbox_labels,
     server_cmd,
     server_layer_commands,
+    task_env_resources,
     wait_server_ready,
 )
 
@@ -93,11 +93,8 @@ def task_build_resources(task_dir: Path) -> dict[str, int]:
     E2B sizes sandboxes at template-build time (warm starts inherit the
     template's spec), so the task's requirements go here, not on create.
     """
-    env_cfg = read_task_config(task_dir).get("environment", {})
-    return {
-        "cpu_count": max(1, int(env_cfg.get("cpus", 1))),
-        "memory_mb": max(2048, int(env_cfg.get("memory_mb", 2048))),
-    }
+    cpus, memory_mb, _storage_mb = task_env_resources(task_dir)
+    return {"cpu_count": cpus, "memory_mb": memory_mb}
 
 
 def _connection_opts() -> dict:
@@ -138,7 +135,7 @@ def ensure_task_template(
     # In-function import, deliberately: the e2b SDK is an optional dependency
     # of this recipe (the launcher preflights it), so importing the module
     # must not require it — the offline tests import this file with a fake
-    # `e2b` in sys.modules, and the Daytona leg defers its SDK the same way.
+    # `e2b` in sys.modules, and the sibling backends defer their SDKs the same way.
     from e2b import Template
 
     task_dir = Path(task_dir)
@@ -165,13 +162,7 @@ def ensure_task_template(
                 **_connection_opts(),
             )
 
-        # Not a `with` block: its __exit__ joins the worker, which would wait
-        # out the very build the timeout is meant to abandon.
-        pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
-        try:
-            pool.submit(_build).result(timeout=build_timeout_s)
-        finally:
-            pool.shutdown(wait=False)
+        run_with_deadline(_build, build_timeout_s)
     return alias
 
 
@@ -195,6 +186,7 @@ def base_url(sandbox) -> str:
 # switch for orphans. 6 beats per window; up to 3 consecutive failed beats
 # (API blips) tolerated before the thread concludes the sandbox is gone.
 _SANDBOX_TTL_S = int(os.getenv("OPENENV_E2B_SANDBOX_TTL_S", "1800"))
+_READY_TIMEOUT_S = float(os.getenv("OPENENV_E2B_READY_TIMEOUT_S", "300"))
 _KEEPALIVE_INTERVAL_S = _SANDBOX_TTL_S / 6.0
 _KEEPALIVE_MAX_CONSECUTIVE_FAILURES = 3
 
@@ -219,9 +211,8 @@ def _start_keepalive(sandbox, task_id: str) -> None:
 def create_task_sandbox(
     task_dir: Path,
     *,
-    command_timeout_s: int = 900,
-    ready_timeout_s: float = 300.0,
-    ttl_s: int | None = None,
+    command_timeout_s: int = recipe.COMMAND_TIMEOUT_S,
+    ready_timeout_s: float = _READY_TIMEOUT_S,
 ):
     """Create ONE per-episode sandbox for *task_dir* from its template.
 
@@ -238,9 +229,12 @@ def create_task_sandbox(
     task_dir = Path(task_dir)
     opts = _connection_opts()
     alias = ensure_task_template(task_dir)
+    # The TTL is deliberately not a parameter: the keepalive thread re-arms
+    # _SANDBOX_TTL_S, so a different value passed here would be silently
+    # overwritten at the first beat.
     sandbox = Sandbox.create(
         template=alias,
-        timeout=ttl_s if ttl_s is not None else _SANDBOX_TTL_S,
+        timeout=_SANDBOX_TTL_S,
         metadata=sandbox_labels(task_dir),
         **opts,
     )
@@ -260,7 +254,10 @@ def create_task_sandbox(
         _start_keepalive(sandbox, task_dir.name)
         return sandbox, url
     except Exception:
-        sandbox.kill(**opts)
+        try:
+            sandbox.kill(**opts)
+        except Exception:
+            pass  # cleanup must not mask the real failure; the TTL reclaims it
         raise
 
 

--- a/examples/experimental/openenv/tb2_sandbox_modal.py
+++ b/examples/experimental/openenv/tb2_sandbox_modal.py
@@ -1,0 +1,257 @@
+"""Modal materialization of the per-task Terminal-Bench-2 sandbox recipe.
+
+The recipe itself — the shell layers that turn a task's official image into a
+combined task+env-server image — lives in ``tb2_sandbox_recipe`` (sibling
+module) and is provider-agnostic. This module is everything Modal-specific
+about turning that recipe into a running cloud sandbox:
+
+  ``task_image(...)``   the recipe as a Modal Image: the task's official image
+      pulled from its registry, then ONE LAYER PER recipe command, so an edit
+      to the recipe re-runs only the layers below it instead of the whole
+      chain. Layers are NOT shared between tasks — each task starts from its
+      own base image, which makes every hash below it unique — so each task
+      pays one cold build of the full chain (measured: ~70 s cold including
+      the registry pull, ~9 s warm).
+  ``create_task_sandbox(...)``  per-episode create: build-or-cache-hit the
+      image, start the env server as the sandbox's entrypoint, expose port
+      8000 through an encrypted tunnel, wait for /health, return
+      ``(sandbox, base_url)``. The sandbox carries the recipe's ownership tags.
+
+Orphan reclamation differs from the sibling providers by design. A Modal
+sandbox's ``timeout`` is a hard ceiling that CANNOT be extended, so the
+keepalive-thread dead-man's switch the Daytona and E2B backends use has no
+counterpart here — and needs none: ``idle_timeout`` counts an open TCP
+connection on a tunnel as activity, and an episode's entire I/O is exactly
+that (the OpenEnv client holds a WebSocket open for the episode's lifetime).
+A live episode of any length keeps its sandbox; a hard-killed caller (SIGKILL,
+OOM, node loss) drops the connection and Modal reclaims the sandbox within
+``idle_timeout``. ``timeout`` stays as the ceiling for the one case idleness
+cannot catch: an episode that hangs while still connected.
+
+There is deliberately no bake step: layer hashes ARE the cache key here, so
+the first create for a task warms exactly what later creates hit, and nothing
+a create passes could name a pre-built artifact to use instead.
+
+Sweeping leftovers by hand needs the Python API — Modal's CLI has no
+``sandbox`` subcommand. Scoping the listing to the app (``_APP_NAME``) is what
+keeps a shared workspace's other workloads out of range, and the recipe's
+ownership tags say which task and launcher each sandbox belongs to::
+
+    import asyncio, modal
+
+    async def sweep(kill=False):
+        app = await modal.App.lookup.aio("openenv-tbench2", create_if_missing=True)
+        async for sb in modal.Sandbox.list.aio(app_id=app.app_id):
+            print(sb.object_id, await sb.get_tags.aio())
+            if kill:
+                await sb.terminate.aio()
+
+    asyncio.run(sweep())
+
+All modal imports are lazy (in-function), mirroring the sibling provider
+modules: offline unit tests and non-sandbox launches must not require the SDK.
+"""
+
+import os
+import threading
+from pathlib import Path
+
+import tb2_sandbox_recipe as recipe
+from tb2_sandbox_recipe import (
+    resolve_docker_image,
+    run_with_deadline,
+    sandbox_labels,
+    server_cmd,
+    server_layer_commands,
+    task_env_resources,
+    wait_server_ready,
+)
+
+# Every knob describing ONE Modal sandbox lives here, next to the create that
+# uses it; the backend module keeps only the fan-out knobs (how many creates at
+# once, how long to keep retrying). All are read at import: a rollout worker is
+# a fresh process per run.
+#
+# The app every per-episode sandbox is created under. Modal requires one, and
+# it is what a sweep scopes to — a dedicated app keeps a shared workspace's
+# other workloads out of range.
+_APP_NAME = os.getenv("OPENENV_MODAL_APP", "openenv-tbench2")
+
+# Lifetime (see the orphan-reclamation note above). The TTL is a HARD ceiling on
+# one episode's sandbox: unlike the other backends' TTLs it cannot be extended,
+# so it must exceed the longest episode the rollout allows
+# (OPENENV_MAX_ROLLOUT_TIME_SECONDS), not merely a heartbeat interval.
+_SANDBOX_TTL_S = int(os.getenv("OPENENV_MODAL_SANDBOX_TTL_S", "1800"))
+_IDLE_TIMEOUT_S = int(os.getenv("OPENENV_MODAL_IDLE_TIMEOUT_S", "300"))
+
+# How long a create may take (the first one for a task builds the image, which
+# Modal does not deadline itself) and how long the env server then has to answer
+# /health.
+_CREATE_TIMEOUT_S = float(os.getenv("OPENENV_MODAL_CREATE_TIMEOUT_S", "1800"))
+_READY_TIMEOUT_S = float(os.getenv("OPENENV_MODAL_READY_TIMEOUT_S", "300"))
+
+# Waiting for the tunnel to be routable is part of the create, not something to
+# tune per deployment.
+_TUNNEL_TIMEOUT_S = 60.0
+
+# Build logs are worth minutes of silence when bringing up a task by hand.
+# Debug-only: enable_output() drives a PROCESS-WIDE output manager, so never
+# turn it on with creates fanned out.
+_BUILD_LOGS = bool(os.getenv("OPENENV_MODAL_BUILD_LOGS", "").strip())
+
+_ENV_SERVER_PORT = 8000
+
+
+def task_resources(task_dir: Path) -> dict[str, float | int]:
+    """Sandbox size from ``task.toml [environment]``.
+
+    Modal bills per second on ``max(request, actual)``, so the request is the
+    task's stated requirement and nothing above it. There is no disk knob to
+    map ``storage_mb`` onto — Modal sizes sandbox disk itself.
+    """
+    cpus, memory_mb, _storage_mb = task_env_resources(task_dir)
+    return {"cpu": float(cpus), "memory": memory_mb}
+
+
+def task_image(task_dir: Path, docker_image: str | None = None):
+    """The recipe as a Modal Image, one layer per recipe command.
+
+    Deliberately not one collapsed layer: Modal caches per layer, so editing
+    the recipe's tail (a task's own files) or the embedded env source re-runs
+    only the layers below the edit rather than reinstalling apt/uv as well.
+    That saving is per task, not across the suite — a task's own base image
+    makes its whole chain hash differently from every other task's.
+
+    Modal requires linux/amd64 images (all current TB2 task images are), and
+    pulls anonymously — a task image behind a private registry would need
+    ``from_registry(secret=...)``.
+    """
+    from modal import Image
+
+    task_dir = Path(task_dir)
+    image = Image.from_registry(resolve_docker_image(task_dir, docker_image))
+    for command in server_layer_commands(task_dir):
+        image = image.run_commands(command)
+    return image
+
+
+_app = None
+_app_lock = threading.Lock()
+
+
+def get_app():
+    """The shared App handle, looked up once per process.
+
+    ``App.lookup`` is a network round-trip; a rollout fans out many episodes
+    and every create would otherwise repeat it. The first caller pays it under
+    the lock, the rest reuse the handle.
+    """
+    global _app
+    with _app_lock:
+        if _app is None:
+            from modal import App
+
+            _app = App.lookup(_APP_NAME, create_if_missing=True)
+        return _app
+
+
+def base_url(sandbox, *, tunnel_timeout_s: float | None = None) -> str:
+    """The env server's externally reachable URL on port 8000.
+
+    Modal's tunnel terminates TLS and forwards at L4, so one host serves both
+    halves of the client's traffic: the HTTP health check and the WebSocket
+    (/ws) the episode runs over. Tunnel URLs are cryptographically random but
+    unauthenticated — whoever holds the URL can reach the server — which is
+    another reason the sandbox is per-episode and dies with it. (Modal's
+    connect tokens would add auth, but the env client speaks plain HTTP/WS and
+    has nowhere to carry the bearer header.)
+    """
+    timeout = _TUNNEL_TIMEOUT_S if tunnel_timeout_s is None else tunnel_timeout_s
+    return sandbox.tunnels(timeout=int(timeout))[_ENV_SERVER_PORT].url
+
+
+def _exit_detail(sandbox) -> str:
+    """Why the server never came up, when the answer is already available.
+
+    The env server IS the sandbox's main process, so a server that failed to
+    start leaves an exited sandbox whose output holds the traceback — far more
+    useful than a bare ready-timeout. Reading the stream is only safe once it
+    has ended (a live sandbox's stdout never closes, and the read would block),
+    so this reports nothing for a sandbox that is still running.
+    """
+    try:
+        code = sandbox.poll()
+        if code is None:
+            return ""
+        tail = (sandbox.stdout.read() or "")[-2000:]
+        return f"; the sandbox exited with code {code}, server output tail: {tail}"
+    except Exception:  # diagnostics must never mask the original failure
+        return ""
+
+
+def create_task_sandbox(
+    task_dir: Path,
+    *,
+    command_timeout_s: int = recipe.COMMAND_TIMEOUT_S,
+    ready_timeout_s: float = _READY_TIMEOUT_S,
+    create_timeout_s: float = _CREATE_TIMEOUT_S,
+    ttl_s: int = _SANDBOX_TTL_S,
+    idle_timeout_s: int = _IDLE_TIMEOUT_S,
+):
+    """Create ONE per-episode sandbox for *task_dir*.
+
+    Returns ``(sandbox, base_url)``. Caller must ``sandbox.terminate()`` when
+    the episode ends. The first create for a task pays the image build (Modal
+    builds as part of the create); later creates hit the layer cache.
+
+    The env server runs as the sandbox's entrypoint rather than as a follow-up
+    exec: Modal would otherwise run the task image's own CMD, and what starts
+    in this sandbox must be the recipe's decision, not the task image's. Its
+    runtime knobs stay runtime (TB2_COMMAND_TIMEOUT_S is passed per create, not
+    baked) so a change takes effect without invalidating the image cache.
+
+    *create_timeout_s* bounds the build+create wall clock, which Modal itself
+    does not deadline. The call runs on a scoped thread; on timeout this caller
+    stops waiting — freeing its create-throttle slot — and a sandbox that
+    materializes anyway is reclaimed by *idle_timeout*, since nothing will ever
+    connect to it.
+    """
+    from modal import Sandbox
+
+    task_dir = Path(task_dir)
+    cmd = server_cmd(command_timeout_s, default_task_id=task_dir.name)
+
+    def _create():
+        kwargs = dict(
+            app=get_app(),
+            image=task_image(task_dir),
+            encrypted_ports=[_ENV_SERVER_PORT],
+            timeout=int(ttl_s),
+            idle_timeout=int(idle_timeout_s),
+            tags=sandbox_labels(task_dir),
+            **task_resources(task_dir),
+        )
+        if not _BUILD_LOGS:
+            return Sandbox.create("bash", "-c", cmd, **kwargs)
+        # In-function: only the debug path needs the top-level module, and the
+        # offline tests inject a fake `modal` without enable_output.
+        import modal
+
+        with modal.enable_output():
+            return Sandbox.create("bash", "-c", cmd, **kwargs)
+
+    sandbox = run_with_deadline(_create, create_timeout_s)
+
+    try:
+        url = base_url(sandbox)
+        wait_server_ready(url, timeout_s=ready_timeout_s)
+        return sandbox, url
+    except Exception as e:
+        detail = _exit_detail(sandbox)
+        try:
+            sandbox.terminate()
+        except Exception:
+            pass  # already gone, or the API is down; idle_timeout backstops it
+        if detail:
+            raise RuntimeError(f"{task_dir.name}: env server did not come up{detail}") from e
+        raise

--- a/examples/experimental/openenv/tb2_sandbox_recipe.py
+++ b/examples/experimental/openenv/tb2_sandbox_recipe.py
@@ -36,6 +36,7 @@ tampers with container binaries could still fake a pass.
 """
 
 import base64
+import concurrent.futures
 import getpass
 import gzip
 import io
@@ -75,6 +76,12 @@ _ENV_SRC_ITEMS = (
     "server",
 )
 
+# Per-exec timeout inside the sandbox. Named after the variable the env server
+# itself reads (it is tbench2_env's contract, not ours), and owned here because
+# this is where the server's command line is built — every backend gets the same
+# value without three copies of this getenv.
+COMMAND_TIMEOUT_S = int(os.getenv("TB2_COMMAND_TIMEOUT_S", "900"))
+
 # The command to start the env server inside a task sandbox (a provider may
 # not run the image CMD — Daytona doesn't). /opt/envserver and /opt/tb2-tasks
 # are baked by server_layer_commands.
@@ -90,7 +97,7 @@ SERVER_CMD = (
 )
 
 
-def server_cmd(command_timeout_s: int = 900, default_task_id: str = "") -> str:
+def server_cmd(command_timeout_s: int = COMMAND_TIMEOUT_S, default_task_id: str = "") -> str:
     # A per-task sandbox stages exactly one task, so make it the default:
     # a reset() with no task_id resolves to the staged task rather than the
     # env's built-in headless-terminal default (which isn't present here).
@@ -107,9 +114,27 @@ def read_task_config(task_dir: Path) -> dict:
     return tomllib.loads(toml_path.read_text())
 
 
+def task_env_resources(task_dir: Path) -> tuple[int, int, int]:
+    """``(cpus, memory_mb, storage_mb)`` from ``task.toml [environment]``, floored.
+
+    The floors (1 CPU / 2048 MB memory / 10240 MB disk) are recipe policy —
+    the env server needs room to run alongside the task — applied once here so
+    the providers cannot drift apart on them. Each materialization maps these
+    onto its own units and drops what its provider does not take (Modal sizes
+    disk itself; E2B sizes everything at template-build time).
+    """
+    env_cfg = read_task_config(task_dir).get("environment", {})
+    return (
+        max(1, int(env_cfg.get("cpus", 1))),
+        max(2048, int(env_cfg.get("memory_mb", 2048))),
+        max(10240, int(env_cfg.get("storage_mb", 10240))),
+    )
+
+
 def sandbox_labels(task_dir: Path) -> dict[str, str]:
     """Ownership labels/metadata for a per-task sandbox: what it runs, and who
-    launched it. Provider-agnostic (Daytona labels, E2B metadata — same keys).
+    launched it. Provider-agnostic (Daytona labels, E2B metadata, Modal tags —
+    same keys).
 
     Sandbox APIs record no creator, so in a shared org/deployment these are
     the only attribution. ``openenv-tbench2-task`` keys sweep/cleanup tooling
@@ -177,6 +202,24 @@ def start_keepalive(beat, thread_name: str, *, interval_s: float, max_consecutiv
                 failures += 1
 
     threading.Thread(target=_run, name=thread_name, daemon=True).start()
+
+
+def run_with_deadline(fn, timeout_s: float):
+    """Run *fn* on a scoped worker thread; raise TimeoutError past *timeout_s*.
+
+    For provider calls that block across many requests with no deadline of
+    their own (an E2B template build, a Modal build+create). Deliberately not
+    a ``with ThreadPoolExecutor`` block: its ``__exit__`` joins the worker,
+    which would wait out the very call the deadline exists to abandon. On
+    timeout the provider-side work keeps cooking (and may finish) — reclaiming
+    whatever it produces is the caller's provider-specific business — but this
+    caller stops holding its locks and semaphore slots.
+    """
+    pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+    try:
+        return pool.submit(fn).result(timeout=timeout_s)
+    finally:
+        pool.shutdown(wait=False)
 
 
 def add_task_selection_args(ap) -> None:

--- a/examples/experimental/openenv/tests/test_openenv_agent_function.py
+++ b/examples/experimental/openenv/tests/test_openenv_agent_function.py
@@ -6,9 +6,9 @@ when touching the adapter:
     pytest examples/experimental/openenv/tests/ -q
 
 Covers the shared-server leg of the agent loop (this module's run_episode):
-its exec form, scoring path, and cleanup. The Daytona-sandbox leg's
-dispatch and sandbox-create machinery live in
-test_openenv_daytona_agent_function.py; the fakes below are shared with it.
+its exec form, scoring path, and cleanup. The sandbox leg's dispatch and
+sandbox-create machinery live in test_openenv_sandbox_common.py; the fakes
+below are shared with it.
 """
 
 import asyncio
@@ -98,7 +98,7 @@ def test_shared_leg_dispatch(monkeypatch):
     (the server resolves the workdir), scoring via the standard `evaluate`
     action — and the trial-dir purge (post_episode) runs, since the shared
     server outlives the episode."""
-    monkeypatch.setattr(oaf, "_load_tbench2", lambda: _CLASSES)
+    monkeypatch.setattr(oaf, "load_tbench2", lambda: _CLASSES)
 
     async def spying_with_env(env_cls, env_url, body):
         return await body(env_cls())
@@ -132,7 +132,7 @@ def test_old_server_reward_is_not_trusted(monkeypatch):
                 return _FakeResult(reward=1.0, info={"tests_passed": True, "exit_code": 0})
             return await super().step(action)
 
-    monkeypatch.setattr(oaf, "_load_tbench2", lambda: {"env": _OldServerEnv, "action": _CLASSES["action"]})
+    monkeypatch.setattr(oaf, "load_tbench2", lambda: {"env": _OldServerEnv, "action": _CLASSES["action"]})
 
     async def spying_with_env(env_cls, env_url, body):
         return await body(env_cls())

--- a/examples/experimental/openenv/tests/test_openenv_daytona_agent_function.py
+++ b/examples/experimental/openenv/tests/test_openenv_daytona_agent_function.py
@@ -5,94 +5,22 @@ when touching the adapter:
 
     pytest examples/experimental/openenv/tests/ -q
 
-Covers what a live episode cannot cheaply prove:
-  - episode dispatch: this module's run_episode passes exec commands through
-    unmodified and scores via the standard `evaluate` action;
-  - sandbox-create throttling: Daytona rate-limit errors are retried with
-    backoff and a bounded budget, anything else propagates immediately; a
-    cancel mid-create reaps the orphaned sandbox instead of leaking it.
+Covers only what is Daytona's own. Episode dispatch, create throttling, backoff
+budgets and the cancel-mid-create reaper belong to the shared SandboxBackend and are
+proven once in test_openenv_sandbox_common.py; what remains here is which of
+this SDK's errors count as throttling, and that the start hook wires the
+materialization (client, per-task dir, delete-on-close) correctly.
 """
 
-import asyncio
 import sys
-import threading
-from contextlib import asynccontextmanager
+import types
 from pathlib import Path
 
 import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-import openenv_agent_function as oaf  # noqa: E402
 import openenv_daytona_agent_function as odaf  # noqa: E402
-from test_openenv_agent_function import _CLASSES, _FakeEnv, _FakePolicy, _FakeResult  # noqa: E402
-
-
-def run_async(coro):
-    """asyncio.run with the module's loop-bound state reset (fresh loop per test)."""
-    odaf._create_sem = None
-    return asyncio.run(coro)
-
-
-# --- episode dispatch ------------------------------------------------------
-
-
-def test_daytona_leg_dispatch(monkeypatch):
-    """The daytona run_episode: exec commands pass through unmodified (the
-    server resolves the workdir), scoring via the standard `evaluate` action —
-    and unlike the shared leg, no trial-dir purge (the sandbox is deleted
-    when the episode ends)."""
-    monkeypatch.setattr(oaf, "_load_tbench2", lambda: _CLASSES)
-
-    @asynccontextmanager
-    async def fake_episode_env(env_cls, metadata):
-        yield env_cls()
-
-    monkeypatch.setattr(odaf, "_episode_env", fake_episode_env)
-
-    reward, metrics = run_async(
-        odaf.run_episode(_FakePolicy(), "m", [{"role": "system", "content": "s"}], {}, {"task_id": "t1"})
-    )
-    actions = _FakeEnv.last_actions
-    execs = [a for a in actions if a.action_type == "exec"]
-
-    assert reward == 1.0
-    assert execs[0].command == "echo hi"
-    assert any(a.action_type == "evaluate" for a in actions)
-    assert not any("/tmp/tbench2_env_runs" in (a.command or "") for a in execs)
-    assert metrics["turns"] == 2 and metrics["tool_calls"] == 1
-
-
-def test_daytona_leg_eval_error_yields_no_verdict(monkeypatch):
-    """A server-side scoring failure (`evaluate` comes back with error set and
-    no reward) surfaces as reward=None -- dropped by the training wrapper --
-    not coerced into a false-negative 0.0."""
-
-    class _EvalErrorEnv(_FakeEnv):
-        async def step(self, action):
-            if action.action_type == "evaluate":
-                self.actions.append(action)
-                res = _FakeResult()
-                res.observation.error = "toolkit timeout"
-                return res
-            return await super().step(action)
-
-    monkeypatch.setattr(oaf, "_load_tbench2", lambda: {"env": _EvalErrorEnv, "action": _CLASSES["action"]})
-
-    @asynccontextmanager
-    async def fake_episode_env(env_cls, metadata):
-        yield env_cls()
-
-    monkeypatch.setattr(odaf, "_episode_env", fake_episode_env)
-
-    reward, metrics = run_async(
-        odaf.run_episode(_FakePolicy(), "m", [{"role": "system", "content": "s"}], {}, {"task_id": "t1"})
-    )
-    assert reward is None
-    assert metrics["turns"] == 2  # the episode itself completed; only scoring failed
-
-
-# --- sandbox-create throttling ----------------------------------------------
 
 
 class _Throttled(Exception):
@@ -100,102 +28,60 @@ class _Throttled(Exception):
         return "ThrottlerException: Too Many Requests"
 
 
-def _patch_fast_backoff(monkeypatch):
-    monkeypatch.setattr(odaf, "_CREATE_BACKOFF_BASE_S", 0.001)
-    monkeypatch.setattr(odaf, "_CREATE_BACKOFF_CAP_S", 0.001)
+# --- start hook -------------------------------------------------------------
 
 
-def test_create_retries_through_throttling(monkeypatch):
-    """Throttle errors are retried (with backoff) until the create succeeds."""
-    _patch_fast_backoff(monkeypatch)
-    calls = {"n": 0}
+def test_start_hook_creates_per_task_and_closes_by_deleting(monkeypatch):
+    """The sandbox is per-task (tasks_dir/task_id) and close_fn must DELETE it:
+    a stopped-but-kept Daytona sandbox still occupies the org's quota."""
+    deleted = []
+    created = {}
 
-    def flaky_start(task_id, tasks_dir):
-        calls["n"] += 1
-        if calls["n"] <= 3:
-            raise _Throttled()
-        return (lambda: None), "http://sandbox:8000"
+    class _FakeDaytona:
+        def delete(self, sandbox):
+            deleted.append(sandbox)
 
-    monkeypatch.setattr(odaf, "_start_declarative", flaky_start)
-    monkeypatch.setenv("OPENENV_TB2_TASKS_DIR", "/nonexistent")
+    client = _FakeDaytona()
 
-    close_fn, url = run_async(odaf._start_task_sandbox("t1"))
-    assert url == "http://sandbox:8000"
-    assert calls["n"] == 4  # 3 throttled attempts + 1 success
+    def fake_create(daytona, task_dir, **kwargs):
+        created.update(daytona=daytona, task_dir=task_dir, kwargs=kwargs)
+        return "sandbox-handle", "https://preview.daytona/8000"
 
+    monkeypatch.setattr(odaf.tb2_sandbox_daytona, "make_daytona", lambda: client)
+    monkeypatch.setattr(odaf.tb2_sandbox_daytona, "create_task_sandbox", fake_create)
 
-def test_create_gives_up_after_retry_budget(monkeypatch):
-    """A create that is throttled past _CREATE_MAX_RETRIES raises the error."""
-    _patch_fast_backoff(monkeypatch)
-    monkeypatch.setattr(odaf, "_CREATE_MAX_RETRIES", 2)
-    calls = {"n": 0}
+    close_fn, url = odaf._start_sandbox("regex-chess", "/tasks")
 
-    def always_throttled(task_id, tasks_dir):
-        calls["n"] += 1
-        raise _Throttled()
-
-    monkeypatch.setattr(odaf, "_start_declarative", always_throttled)
-    monkeypatch.setenv("OPENENV_TB2_TASKS_DIR", "/nonexistent")
-
-    with pytest.raises(_Throttled):
-        run_async(odaf._start_task_sandbox("t1"))
-    assert calls["n"] == 3  # initial attempt + 2 retries
+    assert url == "https://preview.daytona/8000"
+    assert created["task_dir"] == Path("/tasks/regex-chess")
+    assert created["daytona"] is client
+    # The backend passes only what identifies the sandbox; every deadline is
+    # the materialization's own default, so the two cannot drift apart.
+    assert created["kwargs"] == {}
+    close_fn()
+    assert deleted == ["sandbox-handle"]
 
 
-def test_cancel_during_create_reaps_orphaned_sandbox(monkeypatch):
-    """Cancelling an episode mid-create must not leak the sandbox: the worker
-    thread finishes the create in the background and the reaper deletes it."""
-    started = threading.Event()
-    release = threading.Event()
-    closed = threading.Event()
-
-    def slow_start(task_id, tasks_dir):
-        started.set()
-        assert release.wait(5)
-        return (lambda: closed.set()), "http://sandbox:8000"
-
-    monkeypatch.setattr(odaf, "_start_declarative", slow_start)
-    monkeypatch.setenv("OPENENV_TB2_TASKS_DIR", "/nonexistent")
-
-    async def scenario():
-        task = asyncio.create_task(odaf._start_task_sandbox("t1"))
-        await asyncio.to_thread(started.wait, 5)
-        task.cancel()
-        with pytest.raises(asyncio.CancelledError):
-            await task
-        # Only now does the in-flight create finish — after the awaiter is gone.
-        release.set()
-
-    run_async(scenario())
-    assert closed.wait(5)  # the reaper deleted the orphan
-
-
-def test_create_non_throttle_error_propagates_immediately(monkeypatch):
-    """Anything that is not a rate-limit error must not be retried."""
-    _patch_fast_backoff(monkeypatch)
-    calls = {"n": 0}
-
-    def broken_start(task_id, tasks_dir):
-        calls["n"] += 1
-        raise RuntimeError("image build failed")
-
-    monkeypatch.setattr(odaf, "_start_declarative", broken_start)
-    monkeypatch.setenv("OPENENV_TB2_TASKS_DIR", "/nonexistent")
-
-    with pytest.raises(RuntimeError):
-        run_async(odaf._start_task_sandbox("t1"))
-    assert calls["n"] == 1
+# --- throttle classification ------------------------------------------------
 
 
 def test_is_throttle_error_classification():
     assert odaf._is_throttle_error(_Throttled())
     assert odaf._is_throttle_error(Exception("HTTP 429"))
+    assert odaf._is_throttle_error(Exception("throttler tripped"))  # this backend's own vocabulary
     assert not odaf._is_throttle_error(RuntimeError("image build failed"))
 
 
 def test_is_throttle_error_typed_daytona_class():
     """The SDK's typed rate-limit error is recognized even when its message
-    carries no throttle keywords; sibling error classes are not."""
+    carries no throttle keywords."""
     errors = pytest.importorskip("daytona.common.errors")
     assert odaf._is_throttle_error(errors.DaytonaRateLimitError("slow down"))
-    assert not odaf._is_throttle_error(errors.DaytonaValidationError("bad params"))
+
+
+def test_is_throttle_error_without_the_sdk_installed(monkeypatch):
+    """The typed check is best-effort: the backend still classifies by text when the
+    SDK (or that class) is absent, rather than failing the classification."""
+    monkeypatch.setitem(sys.modules, "daytona.common.errors", types.ModuleType("daytona.common.errors"))
+    assert odaf._is_throttle_error(Exception("HTTP 429"))
+    assert not odaf._is_throttle_error(RuntimeError("image build failed"))

--- a/examples/experimental/openenv/tests/test_openenv_e2b_agent_function.py
+++ b/examples/experimental/openenv/tests/test_openenv_e2b_agent_function.py
@@ -5,94 +5,23 @@ when touching the adapter:
 
     pytest examples/experimental/openenv/tests/ -q
 
-Covers what a live episode cannot cheaply prove:
-  - episode dispatch: this module's run_episode sends raw exec commands and
-    scores via the standard `evaluate` action;
-  - sandbox-create throttling: rate-limit errors (typed, textual, and the
-    OPENENV_E2B_THROTTLE_PATTERNS extension for self-hosted providers) are
-    retried with backoff and a bounded budget, anything else propagates
-    immediately; a cancel mid-create reaps the orphaned sandbox.
+Covers only what is E2B's own. Episode dispatch, create throttling, backoff
+budgets and the cancel-mid-create reaper belong to the shared SandboxBackend and are
+proven once in test_openenv_sandbox_common.py; what remains here is which of
+this SDK's errors count as throttling — including the env-knob extension that
+lets a self-hosted AgentENV's capacity errors be retried without a code change
+— and that the start hook wires the materialization correctly.
 """
 
-import asyncio
 import sys
-import threading
-from contextlib import asynccontextmanager
+import types
 from pathlib import Path
 
 import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-import openenv_agent_function as oaf  # noqa: E402
 import openenv_e2b_agent_function as oeaf  # noqa: E402
-from test_openenv_agent_function import _CLASSES, _FakeEnv, _FakePolicy, _FakeResult  # noqa: E402
-
-
-def run_async(coro):
-    """asyncio.run with the module's loop-bound state reset (fresh loop per test)."""
-    oeaf._create_sem = None
-    return asyncio.run(coro)
-
-
-# --- episode dispatch ------------------------------------------------------
-
-
-def test_e2b_leg_dispatch(monkeypatch):
-    """The e2b run_episode: exec raw (server resolves the workdir), scoring
-    via the standard `evaluate` action, no canonical exec, no rm-hack."""
-    monkeypatch.setattr(oaf, "_load_tbench2", lambda: _CLASSES)
-
-    @asynccontextmanager
-    async def fake_episode_env(env_cls, metadata):
-        yield env_cls()
-
-    monkeypatch.setattr(oeaf, "_episode_env", fake_episode_env)
-
-    reward, metrics = run_async(
-        oeaf.run_episode(_FakePolicy(), "m", [{"role": "system", "content": "s"}], {}, {"task_id": "t1"})
-    )
-    actions = _FakeEnv.last_actions
-    execs = [a for a in actions if a.action_type == "exec"]
-
-    assert reward == 1.0
-    assert execs[0].command == "echo hi"
-    assert any(a.action_type == "evaluate" for a in actions)
-    assert not any("test.sh" in (a.command or "") for a in execs)
-    assert not any("/tmp/tbench2_env_runs" in (a.command or "") for a in execs)
-    assert metrics["turns"] == 2 and metrics["tool_calls"] == 1
-
-
-def test_e2b_leg_eval_error_yields_no_verdict(monkeypatch):
-    """A server-side scoring failure (`evaluate` comes back with error set and
-    no reward) surfaces as reward=None -- dropped by the training wrapper --
-    not coerced into a false-negative 0.0."""
-
-    class _EvalErrorEnv(_FakeEnv):
-        async def step(self, action):
-            if action.action_type == "evaluate":
-                self.actions.append(action)
-                res = _FakeResult()
-                res.observation.error = "toolkit timeout"
-                return res
-            return await super().step(action)
-
-    monkeypatch.setattr(oaf, "_load_tbench2", lambda: {"env": _EvalErrorEnv, "action": _CLASSES["action"]})
-
-    @asynccontextmanager
-    async def fake_episode_env(env_cls, metadata):
-        yield env_cls()
-
-    monkeypatch.setattr(oeaf, "_episode_env", fake_episode_env)
-
-    reward, metrics = run_async(
-        oeaf.run_episode(_FakePolicy(), "m", [{"role": "system", "content": "s"}], {}, {"task_id": "t1"})
-    )
-    assert reward is None
-    assert metrics["turns"] == 2  # the episode itself completed; only scoring failed
-
-
-# --- sandbox-create throttling ----------------------------------------------
 
 
 class _Throttled(Exception):
@@ -100,91 +29,34 @@ class _Throttled(Exception):
         return "rate limit exceeded, please retry"
 
 
-def _patch_fast_backoff(monkeypatch):
-    monkeypatch.setattr(oeaf, "_CREATE_BACKOFF_BASE_S", 0.001)
-    monkeypatch.setattr(oeaf, "_CREATE_BACKOFF_CAP_S", 0.001)
+# --- start hook -------------------------------------------------------------
 
 
-def test_create_retries_through_throttling(monkeypatch):
-    """Throttle errors are retried (with backoff) until the create succeeds."""
-    _patch_fast_backoff(monkeypatch)
-    calls = {"n": 0}
+def test_start_hook_creates_per_task_and_closes_by_killing(monkeypatch):
+    """The sandbox is per-task (tasks_dir/task_id) and close_fn kills it — the
+    template stays, the sandbox must not."""
+    killed = []
+    created = {}
 
-    def flaky_start(task_id, tasks_dir):
-        calls["n"] += 1
-        if calls["n"] <= 3:
-            raise _Throttled()
-        return (lambda: None), "http://sandbox:8000"
+    def fake_create(task_dir, **kwargs):
+        created.update(task_dir=task_dir, kwargs=kwargs)
+        return "sandbox-handle", "https://8000-abc.e2b.app"
 
-    monkeypatch.setattr(oeaf, "_start_sandbox", flaky_start)
-    monkeypatch.setenv("OPENENV_TB2_TASKS_DIR", "/nonexistent")
+    monkeypatch.setattr(oeaf.tb2_sandbox_e2b, "create_task_sandbox", fake_create)
+    monkeypatch.setattr(oeaf.tb2_sandbox_e2b, "kill_sandbox", killed.append)
 
-    close_fn, url = run_async(oeaf._start_task_sandbox("t1"))
-    assert url == "http://sandbox:8000"
-    assert calls["n"] == 4  # 3 throttled attempts + 1 success
+    close_fn, url = oeaf._start_sandbox("regex-chess", "/tasks")
 
-
-def test_create_gives_up_after_retry_budget(monkeypatch):
-    """A create that is throttled past _CREATE_MAX_RETRIES raises the error."""
-    _patch_fast_backoff(monkeypatch)
-    monkeypatch.setattr(oeaf, "_CREATE_MAX_RETRIES", 2)
-    calls = {"n": 0}
-
-    def always_throttled(task_id, tasks_dir):
-        calls["n"] += 1
-        raise _Throttled()
-
-    monkeypatch.setattr(oeaf, "_start_sandbox", always_throttled)
-    monkeypatch.setenv("OPENENV_TB2_TASKS_DIR", "/nonexistent")
-
-    with pytest.raises(_Throttled):
-        run_async(oeaf._start_task_sandbox("t1"))
-    assert calls["n"] == 3  # initial attempt + 2 retries
+    assert url == "https://8000-abc.e2b.app"
+    assert created["task_dir"] == Path("/tasks/regex-chess")
+    # The backend passes only what identifies the sandbox; every deadline is
+    # the materialization's own default, so the two cannot drift apart.
+    assert created["kwargs"] == {}
+    close_fn()
+    assert killed == ["sandbox-handle"]
 
 
-def test_cancel_during_create_reaps_orphaned_sandbox(monkeypatch):
-    """Cancelling an episode mid-create must not leak the sandbox: the worker
-    thread finishes the create in the background and the reaper kills it."""
-    started = threading.Event()
-    release = threading.Event()
-    closed = threading.Event()
-
-    def slow_start(task_id, tasks_dir):
-        started.set()
-        assert release.wait(5)
-        return (lambda: closed.set()), "http://sandbox:8000"
-
-    monkeypatch.setattr(oeaf, "_start_sandbox", slow_start)
-    monkeypatch.setenv("OPENENV_TB2_TASKS_DIR", "/nonexistent")
-
-    async def scenario():
-        task = asyncio.create_task(oeaf._start_task_sandbox("t1"))
-        await asyncio.to_thread(started.wait, 5)
-        task.cancel()
-        with pytest.raises(asyncio.CancelledError):
-            await task
-        # Only now does the in-flight create finish — after the awaiter is gone.
-        release.set()
-
-    run_async(scenario())
-    assert closed.wait(5)  # the reaper killed the orphan
-
-
-def test_create_non_throttle_error_propagates_immediately(monkeypatch):
-    """Anything that is not a rate-limit error must not be retried."""
-    _patch_fast_backoff(monkeypatch)
-    calls = {"n": 0}
-
-    def broken_start(task_id, tasks_dir):
-        calls["n"] += 1
-        raise RuntimeError("template build failed")
-
-    monkeypatch.setattr(oeaf, "_start_sandbox", broken_start)
-    monkeypatch.setenv("OPENENV_TB2_TASKS_DIR", "/nonexistent")
-
-    with pytest.raises(RuntimeError):
-        run_async(oeaf._start_task_sandbox("t1"))
-    assert calls["n"] == 1
+# --- throttle classification ------------------------------------------------
 
 
 def test_is_throttle_error_classification(monkeypatch):
@@ -207,9 +79,19 @@ def test_is_throttle_error_extra_patterns_env(monkeypatch):
     assert not oeaf._is_throttle_error(RuntimeError("template build failed"))
 
 
-def test_is_throttle_error_typed_e2b_class():
+def test_is_throttle_error_typed_e2b_class(monkeypatch):
     """The SDK's typed rate-limit error is recognized even when its message
     carries no throttle keywords; sibling error classes are not."""
+    monkeypatch.delenv("OPENENV_E2B_THROTTLE_PATTERNS", raising=False)
     ex = pytest.importorskip("e2b.exceptions")
     assert oeaf._is_throttle_error(ex.RateLimitException("slow down"))
     assert not oeaf._is_throttle_error(ex.AuthenticationException("bad key"))
+
+
+def test_is_throttle_error_without_the_sdk_installed(monkeypatch):
+    """The typed check is best-effort: the backend still classifies by text when the
+    SDK (or that class) is absent, rather than failing the classification."""
+    monkeypatch.delenv("OPENENV_E2B_THROTTLE_PATTERNS", raising=False)
+    monkeypatch.setitem(sys.modules, "e2b.exceptions", types.ModuleType("e2b.exceptions"))
+    assert oeaf._is_throttle_error(Exception("HTTP 429"))
+    assert not oeaf._is_throttle_error(RuntimeError("template build failed"))

--- a/examples/experimental/openenv/tests/test_openenv_launch_common.py
+++ b/examples/experimental/openenv/tests/test_openenv_launch_common.py
@@ -1,0 +1,152 @@
+"""Offline unit tests for the launcher's sandbox-credential wiring.
+
+Not collected by the repo-level pytest run (testpaths = ./tests); run manually
+when touching the launcher:
+
+    pytest examples/experimental/openenv/tests/ -q
+
+The launcher is the only place that can turn a missing credential into a
+launch-time error instead of a rollout that aborts every sample and refills
+forever, so what it must get right is: never forward a secret VALUE, accept
+either supply (file path or worker env), and treat a partially-supplied
+credential (Modal's token pair) as missing rather than usable.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+import openenv_launch_common as launch  # noqa: E402
+import openenv_sandbox_common as common  # noqa: E402
+
+_SPEC_KEYS = {
+    "provider",
+    "key_env_vars",
+    "file_env_var",
+    "arg_attr",
+    "default_path",
+    "provision_hint",
+    "sdk",
+    "sdk_hint",
+    "forward",
+    "target",
+}
+
+
+# --- the credential table ---------------------------------------------------
+
+
+def test_every_backend_has_a_credential_spec():
+    """A backend registered without credential wiring would fail at launch with
+    a KeyError instead of telling the operator what to provision."""
+    assert set(launch._PROVIDER_CREDENTIALS) == set(common.AGENT_MODULES)
+
+
+@pytest.mark.parametrize("backend", sorted(launch._PROVIDER_CREDENTIALS))
+def test_credential_spec_is_complete(backend):
+    spec = launch._PROVIDER_CREDENTIALS[backend]
+    assert set(spec) == _SPEC_KEYS, backend
+    assert spec["key_env_vars"], backend
+    # The arg the launcher reads must be declared on the shared config Protocol,
+    # else a launcher can never override the path.
+    assert spec["arg_attr"] in launch.LaunchArgs.__annotations__, backend
+
+
+def test_forwarded_vars_are_addresses_not_secrets():
+    """Whatever `forward` names is forwarded BY VALUE through ray's runtime_env,
+    which is logged in plaintext — so no credential-shaped var may appear."""
+    for backend, spec in launch._PROVIDER_CREDENTIALS.items():
+        for var in spec["forward"]:
+            assert not any(word in var for word in ("KEY", "TOKEN", "SECRET")), (backend, var)
+
+
+def test_a_forwarded_url_may_not_smuggle_a_credential():
+    """The check above is on the var's NAME, which cannot see a credential
+    hidden in an endpoint's userinfo — and that value would be forwarded and
+    logged in plaintext just the same."""
+    env: dict[str, str] = {}
+    launch._forward_address(env, "E2B_API_URL", "https://agentenv.internal")
+    assert env == {"E2B_API_URL": "https://agentenv.internal"}
+
+    with pytest.raises(ValueError, match="embeds credentials"):
+        launch._forward_address({}, "E2B_API_URL", "https://user:tok@agentenv.internal")
+
+
+# --- key supply -------------------------------------------------------------
+
+
+def _supply(env, spec_name, *, arg_path="", **overrides):
+    spec = launch._PROVIDER_CREDENTIALS[spec_name]
+    kwargs = {
+        "provider": spec["provider"],
+        "key_env_vars": spec["key_env_vars"],
+        "file_env_var": spec["file_env_var"],
+        "arg_path": arg_path,
+        "default_path": spec["default_path"],
+        "provision_hint": spec["provision_hint"],
+    }
+    launch._sandbox_key_supply(env, **{**kwargs, **overrides})
+
+
+def test_readable_file_forwards_the_path_never_the_value(tmp_path):
+    key_file = tmp_path / "api_key"
+    key_file.write_text("dtn_secret_value\n")
+    env: dict[str, str] = {}
+    _supply(env, "daytona", arg_path=str(key_file))
+    assert env == {"DAYTONA_API_KEY_FILE": str(key_file)}
+    assert "dtn_secret_value" not in str(env)
+
+
+def test_configured_path_that_does_not_resolve_is_an_error(tmp_path):
+    with pytest.raises(ValueError, match="is missing or empty"):
+        _supply({}, "e2b", arg_path=str(tmp_path / "absent"))
+
+
+def test_empty_file_is_not_a_credential(tmp_path):
+    key_file = tmp_path / "api_key"
+    key_file.write_text("   \n")
+    with pytest.raises(ValueError, match="is missing or empty"):
+        _supply({}, "e2b", arg_path=str(key_file))
+
+
+def test_worker_environment_supply_is_accepted_without_forwarding(monkeypatch, tmp_path):
+    """When the launcher itself has the credential in env, workers are assumed
+    to have it too (platform-injected / single-host inheritance) and nothing is
+    forwarded."""
+    monkeypatch.setenv("DAYTONA_API_KEY", "dtn_from_env")
+    env: dict[str, str] = {}
+    _supply(env, "daytona", default_path=str(tmp_path / "absent"))
+    assert env == {}
+
+
+def test_modal_token_pair_must_be_complete(monkeypatch, tmp_path):
+    """Half a token pair is a misconfiguration, not a usable credential: it
+    would authenticate nothing and fail every episode."""
+    monkeypatch.setenv("MODAL_TOKEN_ID", "ak-123")
+    monkeypatch.delenv("MODAL_TOKEN_SECRET", raising=False)
+    with pytest.raises(ValueError, match="MODAL_TOKEN_ID \\+ MODAL_TOKEN_SECRET"):
+        _supply({}, "modal", default_path=str(tmp_path / "absent"))
+
+    monkeypatch.setenv("MODAL_TOKEN_SECRET", "as-456")
+    env: dict[str, str] = {}
+    _supply(env, "modal", default_path=str(tmp_path / "absent"))
+    assert env == {}  # the token halves are never forwarded
+
+
+def test_modal_config_file_is_forwarded_by_path(tmp_path):
+    """Modal's file is a config file rather than a bare key, but it rides the
+    same path-not-value contract."""
+    config = tmp_path / "modal.toml"
+    config.write_text('[radixark]\ntoken_id = "ak-123"\ntoken_secret = "as-456"\n')
+    env: dict[str, str] = {}
+    _supply(env, "modal", arg_path=str(config))
+    assert env == {"MODAL_CONFIG_PATH": str(config)}
+    assert "as-456" not in str(env)
+
+
+def test_missing_credential_names_what_to_provision(monkeypatch, tmp_path):
+    monkeypatch.delenv("E2B_API_KEY", raising=False)
+    with pytest.raises(ValueError, match="mkdir -p ~/.config/e2b"):
+        _supply({}, "e2b", default_path=str(tmp_path / "absent"))

--- a/examples/experimental/openenv/tests/test_openenv_modal_agent_function.py
+++ b/examples/experimental/openenv/tests/test_openenv_modal_agent_function.py
@@ -1,0 +1,82 @@
+"""Offline unit tests for the Modal-sandbox agent function (no network, no GPU).
+
+Not collected by the repo-level pytest run (testpaths = ./tests); run manually
+when touching the adapter:
+
+    pytest examples/experimental/openenv/tests/ -q
+
+Covers only what is Modal's own. Episode dispatch, create throttling, backoff
+budgets and the cancel-mid-create reaper belong to the shared SandboxBackend and are
+proven once in test_openenv_sandbox_common.py; what remains here is which of
+this SDK's errors count as capacity limits, and that the start hook wires the
+materialization (per-task dir, the build+create deadline, terminate-on-close).
+"""
+
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import openenv_modal_agent_function as omaf  # noqa: E402
+
+
+# --- start hook -------------------------------------------------------------
+
+
+def test_start_hook_creates_per_task_and_closes_by_terminating(monkeypatch):
+    """The sandbox is per-task (tasks_dir/task_id), the create carries the
+    build+create deadline this backend owns, and close_fn terminates the sandbox."""
+    created = {}
+    terminated = []
+
+    class _FakeSandbox:
+        def terminate(self):
+            terminated.append(True)
+
+    sandbox = _FakeSandbox()
+
+    def fake_create(task_dir, **kwargs):
+        created.update(task_dir=task_dir, kwargs=kwargs)
+        return sandbox, "https://abc.r5.modal.host"
+
+    monkeypatch.setattr(omaf.tb2_sandbox_modal, "create_task_sandbox", fake_create)
+
+    close_fn, url = omaf._start_sandbox("regex-chess", "/tasks")
+
+    assert url == "https://abc.r5.modal.host"
+    assert created["task_dir"] == Path("/tasks/regex-chess")
+    # The backend passes only what identifies the sandbox; every deadline is
+    # the materialization's own default, so the two cannot drift apart.
+    assert created["kwargs"] == {}
+    close_fn()
+    assert terminated == [True]
+
+
+# --- throttle classification ------------------------------------------------
+
+
+def test_is_throttle_error_classification():
+    assert omaf._is_throttle_error(Exception("HTTP 429"))
+    assert omaf._is_throttle_error(Exception("Too Many Requests"))
+    # This backend's own vocabulary: a hit container-concurrency ceiling.
+    assert omaf._is_throttle_error(Exception("RESOURCE EXHAUSTED: too many containers"))
+    assert not omaf._is_throttle_error(RuntimeError("image build failed"))
+
+
+def test_is_throttle_error_typed_modal_class():
+    """The SDK's typed capacity error is recognized even when its message
+    carries no throttle keywords; sibling error classes are not."""
+    ex = pytest.importorskip("modal.exception")
+    assert omaf._is_throttle_error(ex.ResourceExhaustedError("no capacity"))
+    assert not omaf._is_throttle_error(ex.AuthError("bad token"))
+
+
+def test_is_throttle_error_without_the_sdk_installed(monkeypatch):
+    """The typed check is best-effort: the backend still classifies by text when the
+    SDK (or that class) is absent, rather than failing the classification."""
+    monkeypatch.setitem(sys.modules, "modal.exception", types.ModuleType("modal.exception"))
+    assert omaf._is_throttle_error(Exception("HTTP 429"))
+    assert not omaf._is_throttle_error(RuntimeError("image build failed"))

--- a/examples/experimental/openenv/tests/test_openenv_sandbox_common.py
+++ b/examples/experimental/openenv/tests/test_openenv_sandbox_common.py
@@ -5,23 +5,79 @@ when touching the adapter:
 
     pytest examples/experimental/openenv/tests/ -q
 
-Covers the backend registry, whose whole job is to refuse to guess: which
-provider runs decides whose quota a rollout spends, so an unnamed or unknown
-one must fail at launch rather than resolve to whichever leg came first.
+Covers what every backend inherits, so it is proven once rather than once per
+provider:
+  - the backend registry, whose whole job is to refuse to guess: which provider
+    runs decides whose quota a rollout spends, so an unnamed or unknown one
+    must fail at launch rather than resolve to whichever backend came first;
+  - episode dispatch: a backend's run_episode sends raw exec commands and scores
+    via the standard `evaluate` action;
+  - sandbox-create throttling: throttle errors (typed by the backend, or textual)
+    are retried with backoff and a bounded budget, anything else propagates
+    immediately; a cancel mid-create reaps the orphaned sandbox.
+
+A backend's own tests cover only what is genuinely its own: which of its SDK's
+errors count as throttling, and how its start hook wires the materialization.
 """
 
+import asyncio
+import logging
 import sys
+import threading
+from contextlib import asynccontextmanager
 from pathlib import Path
 
 import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import openenv_agent_function as oaf  # noqa: E402
 import openenv_sandbox_common as common  # noqa: E402
+from test_openenv_agent_function import _CLASSES, _FakeEnv, _FakePolicy, _FakeResult  # noqa: E402
+
+logger = logging.getLogger("test-backend")
+
+
+class _Throttled(Exception):
+    def __str__(self):
+        return "rate limit exceeded, please retry"
+
+
+def _backend(**overrides) -> common.SandboxBackend:
+    """A backend whose provider-specific half is a stub.
+
+    Every real backend is this object plus a start hook and a throttle classifier,
+    so exercising it here is exercising all of them. Backoff is shrunk to keep
+    the retry tests instant.
+    """
+    spec = {
+        "provider": "Fake",
+        "start_sandbox": lambda task_id, tasks_dir: ((lambda: None), "http://sandbox:8000"),
+        "is_throttle": lambda exc: isinstance(exc, _Throttled),
+        "logger": logger,
+        "backoff_base_s": 0.001,
+        "backoff_cap_s": 0.001,
+    }
+    return common.SandboxBackend(**{**spec, **overrides})
+
+
+@asynccontextmanager
+async def _fake_episode_env(env_cls, metadata):
+    yield env_cls()
+
+
+# --- backend registry -------------------------------------------------------
 
 
 @pytest.mark.parametrize(
     ("name", "expected"),
-    [("daytona", "daytona"), ("e2b", "e2b"), ("agentenv", "e2b"), ("  E2B  ", "e2b")],
+    [
+        ("daytona", "daytona"),
+        ("e2b", "e2b"),
+        ("agentenv", "e2b"),
+        ("  E2B  ", "e2b"),
+        ("modal", "modal"),
+    ],
 )
 def test_resolve_backend_normalizes_names_and_aliases(name, expected):
     assert common.resolve_backend(name) == expected
@@ -35,7 +91,7 @@ def test_resolve_backend_refuses_to_pick_for_you(name):
 
 def test_resolve_backend_rejects_unknown_names():
     with pytest.raises(ValueError, match="unknown sandbox backend"):
-        common.resolve_backend("modal")
+        common.resolve_backend("nonesuch")
 
 
 def test_every_registered_backend_names_an_importable_target():
@@ -43,4 +99,210 @@ def test_every_registered_backend_names_an_importable_target():
     for backend, path in common.AGENT_FUNCTIONS.items():
         module, _, func = path.rpartition(".")
         assert func == "run", backend
+        assert module == common.AGENT_MODULES[backend], backend
         assert (Path(__file__).resolve().parent.parent / f"{module}.py").is_file(), backend
+
+
+@pytest.mark.parametrize("name", sorted(common.AGENT_MODULES))
+def test_every_backend_exposes_the_entry_points(name):
+    """load_backend is how the sibling tools reach a provider; the module-level
+    run/run_episode are how training and the eval driver reach it."""
+    backend = common.load_backend(name)
+    assert isinstance(backend, common.SandboxBackend)
+    module = sys.modules[common.AGENT_MODULES[name]]
+    assert module.run == backend.run
+    assert module.run_episode == backend.run_episode
+
+
+@pytest.mark.parametrize("name", sorted(common.AGENT_MODULES))
+def test_operator_facing_help_names_every_backend(name):
+    """The sibling tools tell an operator which backends exist. That list drifted
+    once already (modal was added and the help text still said daytona/e2b), so
+    it is generated from the registry where it can be, and asserted where it
+    cannot."""
+    assert name in common.backend_names()
+    root = Path(__file__).resolve().parent.parent
+    assert name in (root / "eval_tbench2_via_api.py").read_text().split('"""')[1]
+
+
+def test_backend_knobs_read_the_providers_own_prefix(monkeypatch):
+    """One provider's knobs must not move another's."""
+    monkeypatch.setenv("OPENENV_FAKE_CREATE_CONCURRENCY", "9")
+    knobs = common.backend_knobs("FAKE")
+    assert knobs["create_concurrency"] == 9
+    assert knobs["max_retries"] == 8  # unset falls back to the shared default
+
+
+@pytest.mark.parametrize("name", sorted(common.AGENT_MODULES))
+def test_every_backend_owns_its_provider_hooks(name):
+    """Each backend must supply its OWN start hook and throttle classifier;
+    inheriting a sibling's would silently run episodes on the wrong provider."""
+    backend = common.load_backend(name)
+    module = sys.modules[common.AGENT_MODULES[name]]
+    assert backend.provider  # human-readable, used in the throttle log line
+    assert backend.start_sandbox.__module__ == module.__name__
+    assert backend.is_throttle.__module__ == module.__name__
+
+
+# --- episode dispatch -------------------------------------------------------
+
+
+def test_backend_dispatch(monkeypatch):
+    """A backend's run_episode: exec raw (the server resolves the workdir), scoring
+    via the standard `evaluate` action, no canonical exec, no rm-hack."""
+    monkeypatch.setattr(oaf, "load_tbench2", lambda: _CLASSES)
+    backend = _backend()
+    backend.episode_env = _fake_episode_env
+
+    reward, metrics = asyncio.run(
+        backend.run_episode(_FakePolicy(), "m", [{"role": "system", "content": "s"}], {}, {"task_id": "t1"})
+    )
+    actions = _FakeEnv.last_actions
+    execs = [a for a in actions if a.action_type == "exec"]
+
+    assert reward == 1.0
+    assert execs[0].command == "echo hi"
+    assert any(a.action_type == "evaluate" for a in actions)
+    assert not any("test.sh" in (a.command or "") for a in execs)
+    assert not any("/tmp/tbench2_env_runs" in (a.command or "") for a in execs)
+    assert metrics["turns"] == 2 and metrics["tool_calls"] == 1
+
+
+def test_backend_eval_error_yields_no_verdict(monkeypatch):
+    """A server-side scoring failure (`evaluate` comes back with error set and
+    no reward) surfaces as reward=None -- dropped by the training wrapper --
+    not coerced into a false-negative 0.0."""
+
+    class _EvalErrorEnv(_FakeEnv):
+        async def step(self, action):
+            if action.action_type == "evaluate":
+                self.actions.append(action)
+                res = _FakeResult()
+                res.observation.error = "toolkit timeout"
+                return res
+            return await super().step(action)
+
+    monkeypatch.setattr(oaf, "load_tbench2", lambda: {"env": _EvalErrorEnv, "action": _CLASSES["action"]})
+    backend = _backend()
+    backend.episode_env = _fake_episode_env
+
+    reward, metrics = asyncio.run(
+        backend.run_episode(_FakePolicy(), "m", [{"role": "system", "content": "s"}], {}, {"task_id": "t1"})
+    )
+    assert reward is None
+    assert metrics["turns"] == 2  # the episode itself completed; only scoring failed
+
+
+def test_episode_env_requires_a_task_id():
+    """The sandbox is built for ONE task, so an episode without a task id is a
+    caller bug, not something to guess a default for."""
+    backend = _backend()
+
+    async def scenario():
+        async with backend.episode_env(_FakeEnv, {}):
+            pass
+
+    with pytest.raises(ValueError, match="task_id"):
+        asyncio.run(scenario())
+
+
+# --- sandbox-create throttling ----------------------------------------------
+
+
+def test_create_retries_through_throttling(monkeypatch):
+    """Throttle errors are retried (with backoff) until the create succeeds."""
+    calls = {"n": 0}
+
+    def flaky_start(task_id, tasks_dir):
+        calls["n"] += 1
+        if calls["n"] <= 3:
+            raise _Throttled()
+        return (lambda: None), "http://sandbox:8000"
+
+    monkeypatch.setenv("OPENENV_TB2_TASKS_DIR", "/nonexistent")
+    close_fn, url = asyncio.run(_backend(start_sandbox=flaky_start).start_task_sandbox("t1"))
+    assert url == "http://sandbox:8000"
+    assert calls["n"] == 4  # 3 throttled attempts + 1 success
+
+
+def test_create_gives_up_after_retry_budget(monkeypatch):
+    """A create that is throttled past max_retries raises the error."""
+    calls = {"n": 0}
+
+    def always_throttled(task_id, tasks_dir):
+        calls["n"] += 1
+        raise _Throttled()
+
+    monkeypatch.setenv("OPENENV_TB2_TASKS_DIR", "/nonexistent")
+    backend = _backend(start_sandbox=always_throttled, max_retries=2)
+    with pytest.raises(_Throttled):
+        asyncio.run(backend.start_task_sandbox("t1"))
+    assert calls["n"] == 3  # initial attempt + 2 retries
+
+
+def test_create_non_throttle_error_propagates_immediately(monkeypatch):
+    """Anything that is not a throttle error must not be retried."""
+    calls = {"n": 0}
+
+    def broken_start(task_id, tasks_dir):
+        calls["n"] += 1
+        raise RuntimeError("image build failed")
+
+    monkeypatch.setenv("OPENENV_TB2_TASKS_DIR", "/nonexistent")
+    with pytest.raises(RuntimeError):
+        asyncio.run(_backend(start_sandbox=broken_start).start_task_sandbox("t1"))
+    assert calls["n"] == 1
+
+
+def test_cancel_during_create_reaps_orphaned_sandbox(monkeypatch):
+    """Cancelling an episode mid-create must not leak the sandbox: the worker
+    thread finishes the create in the background and the reaper closes it."""
+    started = threading.Event()
+    release = threading.Event()
+    closed = threading.Event()
+
+    def slow_start(task_id, tasks_dir):
+        started.set()
+        assert release.wait(5)
+        return (lambda: closed.set()), "http://sandbox:8000"
+
+    monkeypatch.setenv("OPENENV_TB2_TASKS_DIR", "/nonexistent")
+    backend = _backend(start_sandbox=slow_start)
+
+    async def scenario():
+        task = asyncio.create_task(backend.start_task_sandbox("t1"))
+        await asyncio.to_thread(started.wait, 5)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        # Only now does the in-flight create finish — after the awaiter is gone.
+        release.set()
+
+    asyncio.run(scenario())
+    assert closed.wait(5)  # the reaper closed the orphan
+
+
+# --- throttle-text classification -------------------------------------------
+
+
+def test_throttle_text_matches_the_shared_vocabulary():
+    for message in ("HTTP 429", "Too Many Requests", "rate limit exceeded"):
+        assert common.throttle_text(Exception(message))
+    assert not common.throttle_text(RuntimeError("image build failed"))
+
+
+def test_throttle_text_takes_the_backends_own_patterns():
+    assert common.throttle_text(Exception("ThrottlerException"), "throttler")
+    assert not common.throttle_text(Exception("ThrottlerException"))
+
+
+def test_throttle_text_extra_patterns_env(monkeypatch):
+    """The env knob extends the retryable set for capacity errors whoever
+    deployed the endpoint words their own way (a full self-hosted pool)."""
+    env = "OPENENV_FAKE_THROTTLE_PATTERNS"
+    monkeypatch.delenv(env, raising=False)
+    assert not common.throttle_text(Exception("no node with sufficient capacity"), patterns_env_var=env)
+    monkeypatch.setenv(env, "sufficient capacity, at capacity")
+    assert common.throttle_text(Exception("no node with sufficient capacity"), patterns_env_var=env)
+    assert common.throttle_text(Exception("cluster AT CAPACITY"), patterns_env_var=env)
+    assert not common.throttle_text(RuntimeError("image build failed"), patterns_env_var=env)

--- a/examples/experimental/openenv/tests/test_tb2_sandbox_modal.py
+++ b/examples/experimental/openenv/tests/test_tb2_sandbox_modal.py
@@ -1,0 +1,246 @@
+"""Tests for the Modal sandbox half: image layering, sandbox sizing, the
+tunnel URL, and the create path's lifetime/diagnostic contract.
+
+Not collected by the repo-level pytest run (testpaths = ./tests); run manually
+when touching the recipe:
+
+    pytest examples/experimental/openenv/tests/ -q
+"""
+
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+import tb2_sandbox_modal as sandbox  # noqa: E402
+
+_COMMANDS = ("apt-get install -y curl", "curl -LsSf https://astral.sh/uv/install.sh | sh", "mkdir -p /opt/tb2-tasks")
+
+
+# --- fake modal SDK ---------------------------------------------------------
+
+
+class _FakeImage:
+    """Records layering: every run_commands call is one layer."""
+
+    def __init__(self, tag, layers=()):
+        self.tag = tag
+        self.layers = list(layers)
+
+    def run_commands(self, *commands):
+        return _FakeImage(self.tag, [*self.layers, commands])
+
+    @staticmethod
+    def from_registry(tag, **kwargs):
+        _FakeImage.from_registry_kwargs = kwargs
+        return _FakeImage(tag)
+
+
+class _FakeTunnel:
+    def __init__(self, url):
+        self.url = url
+
+
+class _FakeSandbox:
+    """Stands in for one created sandbox."""
+
+    def __init__(self, exit_code=None, output="", tunnel_url="https://abc.r5.modal.host"):
+        self._exit_code = exit_code
+        self.stdout = types.SimpleNamespace(read=lambda: output)
+        self.terminated = False
+        self.tunnel_timeout = None
+        self._tunnel_url = tunnel_url
+
+    def tunnels(self, timeout=50):
+        self.tunnel_timeout = timeout
+        return {8000: _FakeTunnel(self._tunnel_url)}
+
+    def terminate(self):
+        self.terminated = True
+
+    def poll(self):
+        return self._exit_code
+
+
+class _FakeSandboxCls:
+    created = None
+    instance = None
+
+    @staticmethod
+    def create(*args, **kwargs):
+        _FakeSandboxCls.created = {"args": args, "kwargs": kwargs}
+        return _FakeSandboxCls.instance
+
+
+class _FakeApp:
+    lookups = None
+
+    @staticmethod
+    def lookup(name, **kwargs):
+        _FakeApp.lookups.append((name, kwargs))
+        return f"app:{name}"
+
+
+@pytest.fixture
+def fake_modal(monkeypatch):
+    """Install a fake `modal` module and reset the backend's process-wide app cache."""
+    _FakeApp.lookups = []
+    _FakeSandboxCls.instance = _FakeSandbox()
+    mod = types.ModuleType("modal")
+    mod.Image = _FakeImage
+    mod.Sandbox = _FakeSandboxCls
+    mod.App = _FakeApp
+    monkeypatch.setitem(sys.modules, "modal", mod)
+    monkeypatch.setattr(sandbox, "_app", None)
+    monkeypatch.setattr(sandbox, "resolve_docker_image", lambda task_dir, override=None: "ghcr.io/laude/task:1.0")
+    monkeypatch.setattr(sandbox, "server_layer_commands", lambda task_dir: list(_COMMANDS))
+    monkeypatch.setattr(sandbox, "sandbox_labels", lambda task_dir: {"openenv-tbench2-task": task_dir.name})
+    monkeypatch.setattr(sandbox, "server_cmd", lambda timeout, default_task_id="": f"serve {default_task_id}")
+    monkeypatch.setattr(sandbox, "wait_server_ready", lambda url, timeout_s=300.0: None)
+    monkeypatch.setattr(sandbox, "task_resources", lambda task_dir: {"cpu": 2.0, "memory": 4096})
+    return mod
+
+
+# --- image layering ---------------------------------------------------------
+
+
+def test_task_image_is_one_layer_per_recipe_command(fake_modal):
+    """Per-command layers so that editing the recipe's tail re-runs only the
+    layers below the edit; collapsing the recipe into one layer would reinstall
+    apt/uv for every such change. (The saving is per task: a task's own base
+    image makes its chain hash unique, so nothing is shared across tasks.)"""
+    image = sandbox.task_image(Path("/tasks/regex-chess"))
+    assert image.tag == "ghcr.io/laude/task:1.0"
+    assert image.layers == [(c,) for c in _COMMANDS]
+
+
+def test_task_image_pulls_anonymously_by_default(fake_modal):
+    """No registry secret is passed: the TB2 task images are public, and a
+    private one would have to be opted into explicitly."""
+    sandbox.task_image(Path("/tasks/t"))
+    assert _FakeImage.from_registry_kwargs == {}
+
+
+# --- sandbox sizing ---------------------------------------------------------
+
+
+def test_task_resources_floors_and_omits_disk(tmp_path):
+    """Modal is billed on max(request, actual) so the request tracks task.toml
+    (floored by the recipe); storage_mb has no Modal counterpart and must not
+    leak in as an unexpected kwarg."""
+    (tmp_path / "task.toml").write_text("[environment]\ncpus = 4\nmemory_mb = 8192\nstorage_mb = 20480\n")
+    assert sandbox.task_resources(tmp_path) == {"cpu": 4.0, "memory": 8192}
+
+    (tmp_path / "task.toml").write_text("[environment]\n")
+    assert sandbox.task_resources(tmp_path) == {"cpu": 1.0, "memory": 2048}
+
+
+# --- app handle -------------------------------------------------------------
+
+
+def test_app_is_looked_up_once_per_process(fake_modal, monkeypatch):
+    """App.lookup is a network round-trip and a rollout fans out many episodes."""
+    monkeypatch.setenv("OPENENV_MODAL_APP", "openenv-tbench2")
+    monkeypatch.setattr(sandbox, "_APP_NAME", "openenv-tbench2")
+    assert sandbox.get_app() == "app:openenv-tbench2"
+    assert sandbox.get_app() == "app:openenv-tbench2"
+    assert _FakeApp.lookups == [("openenv-tbench2", {"create_if_missing": True})]
+
+
+# --- create path ------------------------------------------------------------
+
+
+def test_create_passes_the_lifetime_and_ownership_contract(fake_modal):
+    sandbox_obj, url = sandbox.create_task_sandbox(
+        Path("/tasks/regex-chess"), command_timeout_s=600, ttl_s=1200, idle_timeout_s=120
+    )
+    created = _FakeSandboxCls.created
+    kwargs = created["kwargs"]
+
+    assert url == "https://abc.r5.modal.host"
+    assert sandbox_obj is _FakeSandboxCls.instance
+    # The env server is the sandbox's entrypoint, not a follow-up exec: the task
+    # image's own CMD must not decide what runs here.
+    assert created["args"] == ("bash", "-c", "serve regex-chess")
+    assert kwargs["encrypted_ports"] == [8000]
+    assert kwargs["timeout"] == 1200
+    assert kwargs["idle_timeout"] == 120
+    assert kwargs["tags"] == {"openenv-tbench2-task": "regex-chess"}
+    assert kwargs["cpu"] == 2.0 and kwargs["memory"] == 4096
+    assert not sandbox_obj.terminated
+
+
+def test_create_defaults_lifetime_from_the_env_knobs(fake_modal, monkeypatch):
+    monkeypatch.setattr(sandbox, "_SANDBOX_TTL_S", 1800)
+    monkeypatch.setattr(sandbox, "_IDLE_TIMEOUT_S", 300)
+    sandbox.create_task_sandbox(Path("/tasks/t"))
+    kwargs = _FakeSandboxCls.created["kwargs"]
+    assert kwargs["timeout"] == 1800
+    assert kwargs["idle_timeout"] == 300
+
+
+def test_create_terminates_the_sandbox_when_the_server_never_comes_up(fake_modal, monkeypatch):
+    """A ready-timeout must not leak the sandbox, and the failure should carry
+    the exited server's output instead of only a timeout."""
+    _FakeSandboxCls.instance = _FakeSandbox(exit_code=1, output="Traceback: no module named tbench2_env\n")
+
+    def boom(url, timeout_s=300.0):
+        raise RuntimeError("health check timed out")
+
+    monkeypatch.setattr(sandbox, "wait_server_ready", boom)
+
+    with pytest.raises(RuntimeError, match="no module named tbench2_env"):
+        sandbox.create_task_sandbox(Path("/tasks/regex-chess"))
+    assert _FakeSandboxCls.instance.terminated
+
+
+def test_create_does_not_read_the_stream_of_a_live_sandbox(fake_modal, monkeypatch):
+    """Reading stdout of a RUNNING sandbox would block on a stream that never
+    closes, so a still-running sandbox contributes no diagnostics."""
+
+    def exploding_read():
+        raise AssertionError("stdout of a live sandbox must not be read")
+
+    _FakeSandboxCls.instance = _FakeSandbox(exit_code=None)
+    _FakeSandboxCls.instance.stdout = types.SimpleNamespace(read=exploding_read)
+
+    def boom(url, timeout_s=300.0):
+        raise RuntimeError("health check timed out")
+
+    monkeypatch.setattr(sandbox, "wait_server_ready", boom)
+
+    with pytest.raises(RuntimeError, match="health check timed out"):
+        sandbox.create_task_sandbox(Path("/tasks/t"))
+    assert _FakeSandboxCls.instance.terminated
+
+
+def test_create_enforces_the_build_wall_clock(fake_modal, monkeypatch):
+    """The first create for a task builds the image, which Modal does not
+    deadline itself; a hung build must give the slot back rather than block the
+    episode forever."""
+    import threading
+
+    release = threading.Event()
+
+    def slow_create(*args, **kwargs):
+        release.wait(10)
+        return _FakeSandboxCls.instance
+
+    monkeypatch.setattr(_FakeSandboxCls, "create", staticmethod(slow_create))
+    try:
+        with pytest.raises(TimeoutError):
+            sandbox.create_task_sandbox(Path("/tasks/t"), create_timeout_s=0.05)
+    finally:
+        release.set()
+
+
+# --- tunnel ----------------------------------------------------------------
+
+
+def test_base_url_is_the_tunnel_for_the_env_server_port(fake_modal, monkeypatch):
+    monkeypatch.setattr(sandbox, "_TUNNEL_TIMEOUT_S", 60.0)
+    sb = _FakeSandbox(tunnel_url="https://xyz.r5.modal.host")
+    assert sandbox.base_url(sb) == "https://xyz.r5.modal.host"
+    assert sb.tunnel_timeout == 60

--- a/examples/experimental/openenv/tests/test_tb2_sandbox_recipe.py
+++ b/examples/experimental/openenv/tests/test_tb2_sandbox_recipe.py
@@ -82,3 +82,13 @@ def test_server_cmd_defaults_to_the_staged_task():
     # on it, not the env's built-in headless-terminal default.
     cmd = recipe.server_cmd(default_task_id="fix-git")
     assert "TB2_DEFAULT_TASK_ID=fix-git " in cmd
+
+
+def test_task_env_resources_floors(tmp_path: Path):
+    """The floors are recipe policy, proven once here; the per-provider tests
+    pin only each materialization's unit/kwarg mapping."""
+    (tmp_path / "task.toml").write_text("[environment]\ncpus = 0\nmemory_mb = 128\nstorage_mb = 1024\n")
+    assert recipe.task_env_resources(tmp_path) == (1, 2048, 10240)
+
+    (tmp_path / "task.toml").write_text("[environment]\ncpus = 4\nmemory_mb = 8192\nstorage_mb = 20480\n")
+    assert recipe.task_env_resources(tmp_path) == (4, 8192, 20480)


### PR DESCRIPTION
> Stacked on #2237 (base is `tao/openenv-e2b-build-as-root`). Review that one first; this PR's diff is only the refactor and Modal.

Adds **Modal** as a third per-episode sandbox provider for the tbench2 recipe, and extracts what the providers had been duplicating so that adding one is two files plus a registry entry rather than a third copy of the orchestration.

## The abstraction

`openenv_sandbox_common.SandboxBackend` now owns everything provider-blind: throttled cancel-safe creates, the per-episode env client, and the training / direct-drive entry points. A backend module supplies only what is genuinely its own — how ONE sandbox comes into being, which of its SDK's errors are retryable throttling, and its knobs.

The registry (`AGENT_MODULES` / `resolve_backend` / `load_backend`) is the single place naming providers, so the launcher and the sibling tools cannot drift. `scan_golden` and `eval_tbench2_via_api` now reach a provider by naming it instead of growing an import branch each. That drift had already happened once — their help text still listed `daytona`/`e2b` after modal existed — so `backend_names()` generates it now and a test guards it.

## Modal specifics worth reviewing

- The image is **one layer per recipe command**, so a recipe edit re-runs only the layers below it.
- The env server is the sandbox **entrypoint**, not a follow-up exec, so the task image's own `CMD` cannot decide what runs.
- **No keepalive thread**, unlike the other two backends: a Modal timeout cannot be extended. Orphans are reclaimed by `idle_timeout` instead — the episode's WebSocket counts as activity, so a live episode of any length is safe and a hard-killed caller's sandbox disappears. This makes `OPENENV_MODAL_SANDBOX_TTL_S` a **hard ceiling** that must exceed `OPENENV_MAX_ROLLOUT_TIME_SECONDS`; the docs say so.

## Also here

- **Knob cleanup, 30 → 20.** Everything describing ONE sandbox moved next to the create that uses it; the backend modules keep only the fan-out knobs, read through one shared `backend_knobs(prefix)`. Adding Modal therefore cost 4 knobs, not 14.
- **A launcher guard** against a forwarded endpoint that smuggles a credential in its userinfo. `forward` values ride ray's `runtime_env`, which is echoed into driver logs in plaintext; the existing test could only check the variable's *name*, which a URL defeats.
- **`tb2_sandbox_recipe`** gains `run_with_deadline` and `task_env_resources`, which the materializations had copied. The resource floors are recipe policy and were drifting — Daytona applied them in GB, the others in MB.
- **Docs:** per-episode sandboxes are now the recipe's primary path with one shared env server as the alternative, each backend gets its own heading, and the sanity checks become their own (optional) step.

## Verification

## Verification

Offline: **100 passed, 3 skipped**; ruff + black clean at the repo-pinned versions (0.14.7 / 24.3.0).

**One episode end to end, per backend** — create → connect → `reset` over the WebSocket → `exec` → `evaluate` → close, same task (`adaptive-rejection-sampler`) everywhere:

| Backend | Endpoint | Create → connected | Total |
|---|---|---|---|
| Modal | Modal Cloud | 9 s | 23 s |
| E2B | E2B Cloud | 13 s | 26 s |
| E2B (`agentenv`) | self-hosted AgentENV | 8 s | 17 s |
| Daytona | Daytona Cloud | — | 60 s |

All four: `whoami` → `root`, the marker exec round-trips, and `evaluate` returns a verdict from `harness='tests/test.sh'` with no error. **Daytona had unit-test coverage only when this PR was opened; this is its first live run on the shared backend**, so all three providers are now confirmed on the same code path rather than two confirmed and one inferred.

**Scoring is correct, not merely present.** The single episodes above all score `0.0` — nothing solved the task — which proves a verdict comes back but not that a *correct* solution would be recognized. So each task's official solution was replayed through the full sandbox and scoring path, 5 tasks at concurrency 5:

| | Modal | E2B Cloud |
|---|---|---|
| `chess-best-move` | 1.0 | 1.0 |
| `cancel-async-tasks` | 1.0 | 1.0 |
| `count-dataset-tokens` | 1.0 | 1.0 |
| `distribution-search` | 1.0 | 1.0 |
| `bn-fit-modify` | 1.0 | 1.0 |
| **golden pass** | **5/5** (0 errored) | **5/5** (0 errored) |

Running 5 at once also exercises what a single episode never touches and what this PR moved: the process-wide create semaphore, the throttle/backoff path, and E2B's per-alias build lock. Concurrent sandboxes were observed live under the recipe's ownership tags.

**The multi-turn agent loop**, with a real policy (DeepSeek-v4-flash) driving `eval_tbench2_via_api` on E2B — this is the path through the entry points the refactor renamed:

```
[0] chess-best-move       turns=15  tool_calls=15  eval=6.5s
[0] cancel-async-tasks    turns=15  tool_calls=15  eval=17.2s
```

A turn count cannot distinguish "the model did not solve it" from "the loop burned its turns on env errors", so `cancel-async-tasks` was re-run with the full trajectory captured. **It scored 1.0** — same backend, same code path, same model, sampled at temperature 0.8. A run that reaches a passing verdict rules out the loop being broken in the run that did not.

The trajectory shows why: `reset` delivers the task's real instruction; turn 1 writes `/app/run.py`; turn 2 `cat`s it back and receives the file's actual contents (so sandbox state persists across turns and the outputs fed back are genuine, not canned); later turns run Python harnesses and get their real stdout (`started [1, 2] / cleaned [1, 2] / started==cleaned True`). The zeros above are the model, not the infrastructure.

**Nothing leaked.** After every run above, on all four endpoints:

```
modal   leftovers: []
e2b     leftovers: []
daytona leftovers: []
AgentENV leftovers: []
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


