### PR TITLE
fix: correct generated group type annotations

### DIFF
--- a/miles/rollout/inference_rollout/inference_rollout_common.py
+++ b/miles/rollout/inference_rollout/inference_rollout_common.py
@@ -126,7 +126,7 @@ async def generate_and_rm_group(
     sampling_params: dict[str, Any],
     evaluation: bool = False,
     sample_done_callback: Callable[[], None] | None = None,
-) -> list[Sample]:
+) -> list[Sample | list[Sample]]:
     args = state.args
 
     if state.aborted:

--- a/miles/rollout/inference_rollout/inference_rollout_train.py
+++ b/miles/rollout/inference_rollout/inference_rollout_train.py
@@ -119,7 +119,7 @@ async def generate_rollout_async(
         logger.debug(f"[rollout] asyncio.wait returned: {len(done)} done, {len(pendings)} pending")
         for task in done:
             try:
-                group: list[Sample] = task.result()
+                group: list[Sample | list[Sample]] = task.result()
             except Exception as e:
                 logger.error(f"[rollout] Task raised exception: {e!r}", exc_info=True)
                 continue


### PR DESCRIPTION
## Summary
Correct generated rollout group annotations to include expanded sample lists.

## Symptom & Reproduction
- **Symptom:** `generate_and_rm_group` declares a flat `list[Sample]` even though one trajectory can expand into `list[Sample]`, so type consumers receive a false flat-only contract.
- **Reproduction:** Inspect `typing.get_type_hints(generate_and_rm_group)["return"]` while tracing the `asyncio.gather` inputs from `generate_and_rm`.

## Root Cause
1. `generate_and_rm` returns `Sample | list[Sample]` per trajectory.
2. `asyncio.gather` preserves each trajectory result inside the group list.
3. `generate_and_rm_group` and its direct sync consumer declared only `list[Sample]`.

## Fix
Declare the producer result and the direct sync consumer as `list[Sample | list[Sample]]`, matching the existing runtime shape without changing generation, ordering, reward, or filtering behavior.

## Verification
- **New / updated test:** No permanent test was needed.
- **Type contract:** A focused `get_type_hints()` assertion verifies the corrected contract.
- **Existing test suite:** 30 rollout tests verify preserved behavior.

## Review Focus
- Scrutinize the annotations in `generate_and_rm_group` and `generate_rollout_async`.
- Confirm the diff contains no runtime statement changes.
