### PR TITLE
[multi-lora] thinker training backend

### DIFF
--- a/miles/backends/megatron_utils/actor.py
+++ b/miles/backends/megatron_utils/actor.py
@@ -461,6 +461,11 @@ class MegatronTrainRayActor(TrainRayActor):
         witness_info: WitnessInfo | None,
         attempt: int,
     ) -> TrainStepOutcome:
+        # External batches collect per-datum logprobs for the operation result
+        # plane; the loss fills this shared side channel during the forward.
+        if rollout_data.get("batch_kind") == "external":
+            rollout_data["external_logprob_collector"] = {}
+
         # Create data iterator for log_probs and train.
         data_iterator, num_microbatches = get_data_iterator(self.args, self.model, rollout_data)
 

--- a/miles/backends/megatron_utils/actor.py
+++ b/miles/backends/megatron_utils/actor.py
@@ -461,10 +461,10 @@ class MegatronTrainRayActor(TrainRayActor):
         witness_info: WitnessInfo | None,
         attempt: int,
     ) -> TrainStepOutcome:
-        # External batches collect per-datum logprobs for the operation result
+        # Thinker batches collect per-datum logprobs for the operation result
         # plane; the loss fills this shared side channel during the forward.
-        if rollout_data.get("batch_kind") == "external":
-            rollout_data["external_logprob_collector"] = {}
+        if rollout_data.get("batch_kind") == "thinker":
+            rollout_data["thinker_logprob_collector"] = {}
 
         # Create data iterator for log_probs and train.
         data_iterator, num_microbatches = get_data_iterator(self.args, self.model, rollout_data)
@@ -485,9 +485,9 @@ class MegatronTrainRayActor(TrainRayActor):
                 )
 
         with inverse_timer("train_wait"), timer("train"):
-            # External batches carry client-supplied logprobs/advantages; the
+            # Thinker batches carry client-supplied logprobs/advantages; the
             # ref/old-policy passes and advantage computation are RL machinery.
-            if self.args.compute_advantages_and_returns and rollout_data.get("batch_kind") != "external":
+            if self.args.compute_advantages_and_returns and rollout_data.get("batch_kind") != "thinker":
                 if "ref" in self.weights_backuper.backup_tags:
                     self._set_replay_stage("fallthrough")
                     self._switch_model("ref")
@@ -610,7 +610,7 @@ class MegatronTrainRayActor(TrainRayActor):
     @with_logs
     @timer
     def execute_adapter_controls(self, operations: list[dict]) -> dict:
-        """Run data-less external operations on this rank; every rank receives
+        """Run data-less thinker operations on this rank; every rank receives
         the identical list, and the slot-sorted step order keeps the collective
         sequence identical. Only optim_step executes today: it applies the
         operation's AdamParams and steps the slot's accumulated gradients with

--- a/miles/backends/megatron_utils/actor.py
+++ b/miles/backends/megatron_utils/actor.py
@@ -604,6 +604,49 @@ class MegatronTrainRayActor(TrainRayActor):
 
     @with_logs
     @timer
+    def execute_adapter_controls(self, operations: list[dict]) -> dict:
+        """Run data-less external operations on this rank; every rank receives
+        the identical list, and the slot-sorted step order keeps the collective
+        sequence identical. Only optim_step executes today: it applies the
+        operation's AdamParams and steps the slot's accumulated gradients with
+        sum semantics (no count normalization — the loss weights own the scale)."""
+        from miles.backends.megatron_utils.multi_lora_utils.optimizer import step_adapter_slots
+
+        results: dict[str, dict] = {}
+        optim_ops = [op for op in operations if op["kind"] == "optim_step"]
+        if optim_ops:
+            adam_by_slot = {op["slot"]: (op.get("payload") or {}).get("adam_params") or {} for op in optim_ops}
+            grad_norms, vetoed = step_adapter_slots(
+                self.optimizer,
+                self.model,
+                {op["slot"]: 1 for op in optim_ops},
+                clip_grad=0.0,
+                normalize_by_count=False,
+                adam_params_by_slot=adam_by_slot,
+            )
+            for op in optim_ops:
+                slot = op["slot"]
+                if slot in vetoed:
+                    results[op["operation_id"]] = dict(
+                        ok=False, error="non-finite gradients; step vetoed and gradients cleared", category="server"
+                    )
+                else:
+                    results[op["operation_id"]] = dict(
+                        ok=True,
+                        result=dict(
+                            grad_norm=grad_norms.get(slot),
+                            learning_rate=adam_by_slot[slot].get("learning_rate", 1e-4),
+                        ),
+                    )
+        for op in operations:
+            if op["operation_id"] not in results:
+                results[op["operation_id"]] = dict(
+                    ok=False, error=f"operation kind '{op['kind']}' has no executor yet", category="server"
+                )
+        return results
+
+    @with_logs
+    @timer
     def bind_adapters(self, bind_plan: list[dict]) -> None:
         """Execute a selection's bind plan on this rank: swap-out evicted
         tenants, swap-in selected tenants that aren't resident. Sorted by name

--- a/miles/backends/megatron_utils/actor.py
+++ b/miles/backends/megatron_utils/actor.py
@@ -480,7 +480,9 @@ class MegatronTrainRayActor(TrainRayActor):
                 )
 
         with inverse_timer("train_wait"), timer("train"):
-            if self.args.compute_advantages_and_returns:
+            # External batches carry client-supplied logprobs/advantages; the
+            # ref/old-policy passes and advantage computation are RL machinery.
+            if self.args.compute_advantages_and_returns and rollout_data.get("batch_kind") != "external":
                 if "ref" in self.weights_backuper.backup_tags:
                     self._set_replay_stage("fallthrough")
                     self._switch_model("ref")

--- a/miles/backends/megatron_utils/actor.py
+++ b/miles/backends/megatron_utils/actor.py
@@ -611,14 +611,17 @@ class MegatronTrainRayActor(TrainRayActor):
     @timer
     def execute_adapter_controls(self, operations: list[dict]) -> dict:
         """Run data-less thinker operations on this rank; every rank receives
-        the identical list, and the slot-sorted step order keeps the collective
-        sequence identical. Only optim_step executes today: it applies the
-        operation's AdamParams and steps the slot's accumulated gradients with
-        sum semantics (no count normalization — the loss weights own the scale)."""
+        the identical list, and the fixed per-kind, slot-sorted order keeps the
+        collective sequence identical. optim_step applies the operation's
+        AdamParams and steps the slot's accumulated gradients with sum
+        semantics (no count normalization — the loss weights own the scale);
+        publish_snapshot stages the adapter for the next weight push (the
+        driver completes it after the push lands); save_state/load_state move
+        the slot's full training state through named immutable checkpoints."""
         from miles.backends.megatron_utils.multi_lora_utils.optimizer import step_adapter_slots
 
         results: dict[str, dict] = {}
-        optim_ops = [op for op in operations if op["kind"] == "optim_step"]
+        optim_ops = sorted((op for op in operations if op["kind"] == "optim_step"), key=lambda op: op["slot"])
         if optim_ops:
             adam_by_slot = {op["slot"]: (op.get("payload") or {}).get("adam_params") or {} for op in optim_ops}
             grad_norms, vetoed = step_adapter_slots(
@@ -643,12 +646,69 @@ class MegatronTrainRayActor(TrainRayActor):
                             learning_rate=adam_by_slot[slot].get("learning_rate", 1e-4),
                         ),
                     )
+
+        for op in sorted(
+            (op for op in operations if op["kind"] in ("publish_snapshot", "save_state", "load_state")),
+            key=lambda op: (op["kind"], op["slot"]),
+        ):
+            results[op["operation_id"]] = self._execute_thinker_state_op(op)
+
         for op in operations:
             if op["operation_id"] not in results:
                 results[op["operation_id"]] = dict(
                     ok=False, error=f"operation kind '{op['kind']}' has no executor yet", category="server"
                 )
         return results
+
+    def _execute_thinker_state_op(self, op: dict) -> dict:
+        import re
+        from dataclasses import replace as dataclass_replace
+        from pathlib import Path
+
+        from miles.backends.megatron_utils.multi_lora_utils.checkpoint import (
+            load_slot_state,
+            named_state_dir,
+            save_slot_state,
+        )
+
+        name, kind = op["name"], op["kind"]
+        run = self.loaded_adapters.get(name)
+        if run is None or run.slot != op["slot"]:
+            return dict(ok=False, error=f"adapter '{name}' is not resident in slot {op['slot']}", category="server")
+        # The registry's clocks are authoritative; the loaded view can lag.
+        run = dataclass_replace(run, step=op.get("step", run.step), version=op.get("serving_version", run.version))
+
+        if kind == "publish_snapshot":
+            # Stage the push; the driver's update_weights lands it and the
+            # operation completes with the new serving version afterwards.
+            self._multi_lora_pending_push.add(name)
+            return dict(ok=True, deferred="publish")
+
+        payload = op.get("payload") or {}
+        if kind == "save_state":
+            tag = str(payload.get("tag") or f"step_{run.step}")
+            if not re.fullmatch(r"[A-Za-z0-9._-]+", tag):
+                return dict(ok=False, error=f"invalid state tag '{tag}'", category="user")
+            base = named_state_dir(run, tag)
+            if base is None:
+                return dict(ok=False, error=f"adapter '{name}' has no save dir", category="user")
+            if (base / "manifest.pt").exists():
+                return dict(ok=False, error=f"state '{tag}' already exists; states are immutable", category="user")
+            save_slot_state(self.args, self.model, self.optimizer, run, reason=f"state:{tag}", base=base)
+            return dict(ok=True, result=dict(path=str(base), step=run.step))
+
+        assert kind == "load_state"
+        path = payload.get("path")
+        if not path:
+            return dict(ok=False, error="load_state needs a 'path'", category="user")
+        restored_step = load_slot_state(self.args, self.model, self.optimizer, run, base=Path(path))
+        if restored_step is None:
+            return dict(ok=False, error=f"no loadable state at '{path}' for adapter '{name}'", category="user")
+        # Serving invalidation: engines must never keep sampling pre-restore
+        # weights, so the restored adapter re-publishes on this iteration's push.
+        self._multi_lora_pending_push.add(name)
+        self.weights_backuper.backup("actor")
+        return dict(ok=True, result=dict(step=restored_step, path=str(path)))
 
     @with_logs
     @timer

--- a/miles/backends/megatron_utils/model.py
+++ b/miles/backends/megatron_utils/model.py
@@ -493,6 +493,7 @@ def train_one_step(
                 "advantages",
                 "returns",
                 "rollout_log_probs",
+                "loss_weights",
                 "max_seq_lens",
                 "witness_ids",
                 "opd_reverse_kl",

--- a/miles/backends/megatron_utils/model.py
+++ b/miles/backends/megatron_utils/model.py
@@ -494,6 +494,7 @@ def train_one_step(
                 "returns",
                 "rollout_log_probs",
                 "loss_weights",
+                "sample_indices",
                 "max_seq_lens",
                 "witness_ids",
                 "opd_reverse_kl",

--- a/miles/backends/megatron_utils/multi_lora_utils/checkpoint.py
+++ b/miles/backends/megatron_utils/multi_lora_utils/checkpoint.py
@@ -48,14 +48,23 @@ def sidecar_dir(adapter) -> Path | None:
     return Path(save) / "slot_state" if save is not None else None
 
 
+def named_state_dir(adapter, tag: str) -> Path | None:
+    """Immutable named training-state checkpoint (thinker save_state): same
+    shard format as the swap sidecar, but never overwritten by swaps."""
+    save = adapter.config.save
+    return Path(save) / "states" / tag if save is not None else None
+
+
 def _shard_path(base: Path, rank: int) -> Path:
     return base / f"shard_rank{rank:05d}.pt"
 
 
-def save_slot_state(args, model, optimizer, adapter, *, reason: str = "swap") -> Path | None:
+def save_slot_state(args, model, optimizer, adapter, *, reason: str = "swap", base: Path | None = None) -> Path | None:
     """Write-through sidecar: the durable record of the slot's full
-    training state. Returns the manifest path (rank 0) or the shard path."""
-    base = sidecar_dir(adapter)
+    training state. Returns the manifest path (rank 0) or the shard path.
+    ``base`` overrides the destination (named immutable states); the default
+    is the swap sidecar dir."""
+    base = base if base is not None else sidecar_dir(adapter)
     if base is None:
         # Adapters without a save dir are not swap-eligible; callers
         # must pin them instead. Reaching here is a caller bug for swaps.
@@ -117,10 +126,10 @@ def save_slot_state(args, model, optimizer, adapter, *, reason: str = "swap") ->
     return manifest if rank == 0 else shard
 
 
-def find_slot_state(adapter) -> Path | None:
+def find_slot_state(adapter, base: Path | None = None) -> Path | None:
     """The sidecar base dir, only if a committed manifest matches this
     registration's world topology."""
-    base = sidecar_dir(adapter)
+    base = base if base is not None else sidecar_dir(adapter)
     if base is None or not (base / "manifest.pt").exists():
         return None
     manifest = torch.load(base / "manifest.pt", map_location="cpu", weights_only=True)
@@ -135,15 +144,16 @@ def find_slot_state(adapter) -> Path | None:
     return base
 
 
-def load_slot_state(args, model, optimizer, adapter) -> int | None:
+def load_slot_state(args, model, optimizer, adapter, *, base: Path | None = None) -> int | None:
     """Restore a slot from its sidecar (weights -> rank/alpha -> optimizer
     children, in that order). Returns the restored optimizer step, or None when
-    no sidecar exists — a real step-0 sidecar must not be re-initialized."""
+    no sidecar exists — a real step-0 sidecar must not be re-initialized.
+    ``base`` restores from a named state instead of the swap sidecar."""
     from megatron.bridge.peft.multi_lora_layers import init_adapter_slot, load_adapter
 
     from miles.backends.megatron_utils.multi_lora_utils.optimizer import _slot_children
 
-    base = find_slot_state(adapter)
+    base = find_slot_state(adapter, base)
     if base is None:
         return None
     rank = dist.get_rank() if dist.is_initialized() else 0

--- a/miles/backends/megatron_utils/multi_lora_utils/optimizer.py
+++ b/miles/backends/megatron_utils/multi_lora_utils/optimizer.py
@@ -174,6 +174,24 @@ def _found_inf_anywhere(found_inf: bool) -> bool:
     return flag.item() > 0
 
 
+# Tinker-compatible per-call Adam defaults (external adapters).
+_ADAM_PARAM_DEFAULTS = dict(learning_rate=1e-4, beta1=0.9, beta2=0.95, eps=1e-12, weight_decay=0.0, grad_clip_norm=0.0)
+
+
+def apply_adam_params_to_slot(optimizer, slot: int, adam_params: dict) -> dict:
+    """Write one operation's AdamParams onto the slot's param groups; returns
+    the resolved values. External adapters install no scheduler, so nothing
+    overwrites these between operations."""
+    resolved = {**_ADAM_PARAM_DEFAULTS, **{k: v for k, v in (adam_params or {}).items() if v is not None}}
+    for child in _slot_children(optimizer, slot):
+        for group in child.param_groups:
+            group["lr"] = resolved["learning_rate"]
+            group["betas"] = (resolved["beta1"], resolved["beta2"])
+            group["eps"] = resolved["eps"]
+            group["weight_decay"] = resolved["weight_decay"]
+    return resolved
+
+
 def step_adapter_slots(
     optimizer,
     model,
@@ -181,21 +199,31 @@ def step_adapter_slots(
     clip_grad: float,
     *,
     normalize_by_count: bool = True,
+    adam_params_by_slot: dict[int, dict] | None = None,
 ) -> tuple[dict[int, float], set[int]]:
     """Step exactly the slots in ``step_counts`` (slot -> rollout-execution
     count, the loss's aggregation unit), retaining all other slots' gradients.
     Returns (grad norms, vetoed slots): a found-inf/NaN slot is not stepped,
-    its grads are cleared, and the caller must not commit or publish it."""
+    its grads are cleared, and the caller must not commit or publish it.
+
+    A slot with an ``adam_params_by_slot`` entry follows the client's contract
+    instead of the server's: its AdamParams land on the param groups first,
+    its gradient sum is never count-normalized (the loss weights own the
+    scale), and its clip is the per-call ``grad_clip_norm`` (0.0 = none)."""
     grad_norms: dict[int, float] = {}
     vetoed: set[int] = set()
+    adam_params_by_slot = adam_params_by_slot or {}
 
     for slot in sorted(step_counts):
         children = _slot_children(optimizer, slot)
+        adam = adam_params_by_slot.get(slot)
+        if adam is not None:
+            adam = apply_adam_params_to_slot(optimizer, slot, adam)
         # Copy accumulated main_grads into the owned masters' grads, then scale the sum to the per-execution mean.
         found_inf = False
         for child in children:
             found_inf = bool(child.prepare_grads()) or found_inf
-            if normalize_by_count:
+            if normalize_by_count and adam is None:
                 for main_param in child.get_parameters():
                     if main_param.grad is not None:
                         main_param.grad.mul_(1.0 / step_counts[slot])
@@ -220,8 +248,9 @@ def step_adapter_slots(
             zero_adapter_slot_grads(model, slot)
             continue
 
-        if clip_grad > 0.0 and slot_params:
-            clip_grad_by_total_norm_fp32(slot_params, clip_grad, slot_norm, False)
+        slot_clip = adam["grad_clip_norm"] if adam is not None else clip_grad
+        if slot_clip > 0.0 and slot_params:
+            clip_grad_by_total_norm_fp32(slot_params, slot_clip, slot_norm, False)
         grad_norms[slot] = float(slot_norm)
 
         for child in children:

--- a/miles/backends/megatron_utils/multi_lora_utils/optimizer.py
+++ b/miles/backends/megatron_utils/multi_lora_utils/optimizer.py
@@ -174,13 +174,13 @@ def _found_inf_anywhere(found_inf: bool) -> bool:
     return flag.item() > 0
 
 
-# Tinker-compatible per-call Adam defaults (external adapters).
+# Tinker-compatible per-call Adam defaults (thinker adapters).
 _ADAM_PARAM_DEFAULTS = dict(learning_rate=1e-4, beta1=0.9, beta2=0.95, eps=1e-12, weight_decay=0.0, grad_clip_norm=0.0)
 
 
 def apply_adam_params_to_slot(optimizer, slot: int, adam_params: dict) -> dict:
     """Write one operation's AdamParams onto the slot's param groups; returns
-    the resolved values. External adapters install no scheduler, so nothing
+    the resolved values. Thinker adapters install no scheduler, so nothing
     overwrites these between operations."""
     resolved = {**_ADAM_PARAM_DEFAULTS, **{k: v for k, v in (adam_params or {}).items() if v is not None}}
     for child in _slot_children(optimizer, slot):

--- a/miles/backends/megatron_utils/multi_lora_utils/scheduler.py
+++ b/miles/backends/megatron_utils/multi_lora_utils/scheduler.py
@@ -63,7 +63,11 @@ def build_slot_scheduler(args: Namespace, optimizer, adapter, resume_step: int) 
 
 
 def install_slot_scheduler(args: Namespace, optimizer, adapter, resume_step: int) -> None:
-    """Attach the adapter's scheduler to the optimizer, keyed by slot."""
+    """Attach the adapter's scheduler to the optimizer, keyed by slot.
+    External adapters install none: per-operation AdamParams own the LR, and a
+    schedule tick would overwrite the client's value right after each step."""
+    if getattr(adapter.config, "input_mode", "dataset") == "external":
+        return
     if not hasattr(optimizer, "miles_slot_schedulers"):
         optimizer.miles_slot_schedulers = {}
     optimizer.miles_slot_schedulers[adapter.slot] = build_slot_scheduler(args, optimizer, adapter, resume_step)
@@ -79,7 +83,10 @@ def step_slot_schedulers(optimizer, stepped_slots) -> dict[int, float]:
     Returns slot -> new learning rate, for logging."""
     lr_by_slot: dict[int, float] = {}
     for slot in stepped_slots:
-        scheduler = optimizer.miles_slot_schedulers[slot]
+        # External slots carry no scheduler (per-operation AdamParams own the LR).
+        scheduler = getattr(optimizer, "miles_slot_schedulers", {}).get(slot)
+        if scheduler is None:
+            continue
         scheduler.step(increment=1)
         if scheduler.optimizer.param_groups:  # empty on ranks owning none of the slot's params
             lr_by_slot[slot] = scheduler.optimizer.param_groups[0]["lr"]

--- a/miles/backends/megatron_utils/multi_lora_utils/scheduler.py
+++ b/miles/backends/megatron_utils/multi_lora_utils/scheduler.py
@@ -64,9 +64,9 @@ def build_slot_scheduler(args: Namespace, optimizer, adapter, resume_step: int) 
 
 def install_slot_scheduler(args: Namespace, optimizer, adapter, resume_step: int) -> None:
     """Attach the adapter's scheduler to the optimizer, keyed by slot.
-    External adapters install none: per-operation AdamParams own the LR, and a
+    Thinker adapters install none: per-operation AdamParams own the LR, and a
     schedule tick would overwrite the client's value right after each step."""
-    if getattr(adapter.config, "input_mode", "dataset") == "external":
+    if getattr(adapter.config, "input_mode", "multi-lora") == "thinker":
         return
     if not hasattr(optimizer, "miles_slot_schedulers"):
         optimizer.miles_slot_schedulers = {}
@@ -83,7 +83,7 @@ def step_slot_schedulers(optimizer, stepped_slots) -> dict[int, float]:
     Returns slot -> new learning rate, for logging."""
     lr_by_slot: dict[int, float] = {}
     for slot in stepped_slots:
-        # External slots carry no scheduler (per-operation AdamParams own the LR).
+        # Thinker slots carry no scheduler (per-operation AdamParams own the LR).
         scheduler = getattr(optimizer, "miles_slot_schedulers", {}).get(slot)
         if scheduler is None:
             continue

--- a/miles/backends/megatron_utils/multi_lora_utils/utils.py
+++ b/miles/backends/megatron_utils/multi_lora_utils/utils.py
@@ -470,19 +470,19 @@ def step_stepped_adapter_slots(args, model, optimizer, rollout_data, rollout_id:
 def commit_trained_batch(rollout_data, rollout_id: int, pending_push: set) -> None:
     """A train call landed: schedule the stepped adapters' engine push and
     commit the batch on the controller (main rank only). The stepped set ships
-    with the train data, identical on all ranks. External batches step nothing
+    with the train data, identical on all ranks. Thinker batches step nothing
     and publish nothing here: they pin their slots dirty and complete their
     forward_backward operations instead."""
     from miles.backends.megatron_utils.initialize import is_first_replica_megatron_main_rank
 
     pending_push.update(rollout_data.get("step_adapter_names", []))
-    external = rollout_data.get("batch_kind") == "external"
-    logprobs_by_op = _gather_external_logprobs(rollout_data) if external else None
+    thinker = rollout_data.get("batch_kind") == "thinker"
+    logprobs_by_op = _gather_thinker_logprobs(rollout_data) if thinker else None
     if is_first_replica_megatron_main_rank():
-        if external:
+        if thinker:
             name_by_slot = rollout_data.get("adapter_name_by_slot", {})
             ray.get(
-                get_multi_lora_controller().commit_external_batch.remote(
+                get_multi_lora_controller().commit_thinker_batch.remote(
                     sorted(name_by_slot.values()),
                     [op_id for op_id in rollout_data.get("operation_by_slot", {}).values() if op_id],
                     logprobs_by_op,
@@ -495,13 +495,13 @@ def commit_trained_batch(rollout_data, rollout_id: int, pending_push: set) -> No
         )
 
 
-def _gather_external_logprobs(rollout_data) -> dict[str, list[list[float]]]:
+def _gather_thinker_logprobs(rollout_data) -> dict[str, list[list[float]]]:
     """Merge every rank's (slot, row) logprob shards and group them per
     operation in row order. TP/CP duplicates carry identical values, so the
     merge is an idempotent dict union; rows live on exactly one DP rank."""
     from miles.utils.distributed_utils import get_gloo_group
 
-    collector = rollout_data.get("external_logprob_collector") or {}
+    collector = rollout_data.get("thinker_logprob_collector") or {}
     if dist.is_initialized():
         shards = [None] * dist.get_world_size(get_gloo_group())
         dist.all_gather_object(shards, collector, group=get_gloo_group())

--- a/miles/backends/megatron_utils/multi_lora_utils/utils.py
+++ b/miles/backends/megatron_utils/multi_lora_utils/utils.py
@@ -481,9 +481,12 @@ def commit_trained_batch(rollout_data, rollout_id: int, pending_push: set) -> No
     if is_first_replica_megatron_main_rank():
         if thinker:
             name_by_slot = rollout_data.get("adapter_name_by_slot", {})
+            # forward-only adapters accumulated nothing: no dirty pin for them.
+            forward_only = set(rollout_data.get("forward_only_slots") or ())
+            accumulated = sorted(name for slot, name in name_by_slot.items() if slot not in forward_only)
             ray.get(
                 get_multi_lora_controller().commit_thinker_batch.remote(
-                    sorted(name_by_slot.values()),
+                    accumulated,
                     [op_id for op_id in rollout_data.get("operation_by_slot", {}).values() if op_id],
                     logprobs_by_op,
                 )

--- a/miles/backends/megatron_utils/multi_lora_utils/utils.py
+++ b/miles/backends/megatron_utils/multi_lora_utils/utils.py
@@ -470,11 +470,21 @@ def step_stepped_adapter_slots(args, model, optimizer, rollout_data, rollout_id:
 def commit_trained_batch(rollout_data, rollout_id: int, pending_push: set) -> None:
     """A train call landed: schedule the stepped adapters' engine push and
     commit the batch on the controller (main rank only). The stepped set ships
-    with the train data, identical on all ranks."""
+    with the train data, identical on all ranks. External batches step nothing
+    and publish nothing here: they pin their slots dirty and complete their
+    forward_backward operations instead."""
     from miles.backends.megatron_utils.initialize import is_first_replica_megatron_main_rank
 
     pending_push.update(rollout_data.get("step_adapter_names", []))
     if is_first_replica_megatron_main_rank():
+        if rollout_data.get("batch_kind") == "external":
+            name_by_slot = rollout_data.get("adapter_name_by_slot", {})
+            ray.get(
+                get_multi_lora_controller().commit_external_batch.remote(
+                    sorted(name_by_slot.values()),
+                    [op_id for op_id in rollout_data.get("operation_by_slot", {}).values() if op_id],
+                )
+            )
         ray.get(
             get_multi_lora_controller().commit_train_selection.remote(
                 rollout_id, list(rollout_data.get("vetoed_adapter_names", []))

--- a/miles/backends/megatron_utils/multi_lora_utils/utils.py
+++ b/miles/backends/megatron_utils/multi_lora_utils/utils.py
@@ -476,13 +476,16 @@ def commit_trained_batch(rollout_data, rollout_id: int, pending_push: set) -> No
     from miles.backends.megatron_utils.initialize import is_first_replica_megatron_main_rank
 
     pending_push.update(rollout_data.get("step_adapter_names", []))
+    external = rollout_data.get("batch_kind") == "external"
+    logprobs_by_op = _gather_external_logprobs(rollout_data) if external else None
     if is_first_replica_megatron_main_rank():
-        if rollout_data.get("batch_kind") == "external":
+        if external:
             name_by_slot = rollout_data.get("adapter_name_by_slot", {})
             ray.get(
                 get_multi_lora_controller().commit_external_batch.remote(
                     sorted(name_by_slot.values()),
                     [op_id for op_id in rollout_data.get("operation_by_slot", {}).values() if op_id],
+                    logprobs_by_op,
                 )
             )
         ray.get(
@@ -490,6 +493,32 @@ def commit_trained_batch(rollout_data, rollout_id: int, pending_push: set) -> No
                 rollout_id, list(rollout_data.get("vetoed_adapter_names", []))
             )
         )
+
+
+def _gather_external_logprobs(rollout_data) -> dict[str, list[list[float]]]:
+    """Merge every rank's (slot, row) logprob shards and group them per
+    operation in row order. TP/CP duplicates carry identical values, so the
+    merge is an idempotent dict union; rows live on exactly one DP rank."""
+    from miles.utils.distributed_utils import get_gloo_group
+
+    collector = rollout_data.get("external_logprob_collector") or {}
+    if dist.is_initialized():
+        shards = [None] * dist.get_world_size(get_gloo_group())
+        dist.all_gather_object(shards, collector, group=get_gloo_group())
+        merged: dict = {}
+        for shard in shards:
+            merged.update(shard or {})
+    else:
+        merged = dict(collector)
+
+    op_by_slot = rollout_data.get("operation_by_slot", {})
+    logprobs_by_op: dict[str, list[list[float]]] = {}
+    for op_id_slot, op_id in op_by_slot.items():
+        if op_id is None:
+            continue
+        rows = sorted((row, lp) for (slot, row), lp in merged.items() if slot == op_id_slot)
+        logprobs_by_op[op_id] = [lp for _, lp in rows]
+    return logprobs_by_op
 
 
 def save_due_adapter_checkpoints(args, model) -> bool:

--- a/miles/backends/training_utils/data.py
+++ b/miles/backends/training_utils/data.py
@@ -90,7 +90,7 @@ def get_rollout_data(
         rollout_data["max_seq_lens"] = [max_seq_len] * len(rollout_data["tokens"])
 
     # Full-response SGLang OPD fields share rollout CP slicing but retain
-    # float32 precision; client-supplied external channels slice identically.
+    # float32 precision; client-supplied thinker channels slice identically.
     for key in ("rollout_log_probs", "teacher_log_probs", "opd_reverse_kl", "loss_weights", "advantages"):
         if key in rollout_data:
             dtype = _rollout_logprob_dtype(args) if key == "rollout_log_probs" else torch.float32
@@ -163,13 +163,13 @@ def get_batch(
     if "dynamic_global_batch_size" in data_iterator.rollout_data:
         batch["dynamic_global_batch_size"] = data_iterator.rollout_data["dynamic_global_batch_size"]
 
-    # External batches dispatch the loss per slot; the spec map is batch-level,
+    # Thinker batches dispatch the loss per slot; the spec map is batch-level,
     # and the logprob collector is a shared mutable side channel the loss
     # fills for the operation result plane.
     if "adapter_loss_by_slot" in data_iterator.rollout_data:
         batch["adapter_loss_by_slot"] = data_iterator.rollout_data["adapter_loss_by_slot"]
-    if "external_logprob_collector" in data_iterator.rollout_data:
-        batch["external_logprob_collector"] = data_iterator.rollout_data["external_logprob_collector"]
+    if "thinker_logprob_collector" in data_iterator.rollout_data:
+        batch["thinker_logprob_collector"] = data_iterator.rollout_data["thinker_logprob_collector"]
 
     # No-op safety net if batches reach get_batch without rollout-level preprocessing.
     expand_multimodal_rollout_data_in_place(batch, qkv_format=qkv_format)

--- a/miles/backends/training_utils/data.py
+++ b/miles/backends/training_utils/data.py
@@ -89,8 +89,9 @@ def get_rollout_data(
 
         rollout_data["max_seq_lens"] = [max_seq_len] * len(rollout_data["tokens"])
 
-    # Full-response SGLang OPD fields share rollout CP slicing but retain float32 precision.
-    for key in ("rollout_log_probs", "teacher_log_probs", "opd_reverse_kl"):
+    # Full-response SGLang OPD fields share rollout CP slicing but retain
+    # float32 precision; client-supplied external channels slice identically.
+    for key in ("rollout_log_probs", "teacher_log_probs", "opd_reverse_kl", "loss_weights", "advantages"):
         if key in rollout_data:
             dtype = _rollout_logprob_dtype(args) if key == "rollout_log_probs" else torch.float32
             rollout_data[key] = [
@@ -161,6 +162,10 @@ def get_batch(
 
     if "dynamic_global_batch_size" in data_iterator.rollout_data:
         batch["dynamic_global_batch_size"] = data_iterator.rollout_data["dynamic_global_batch_size"]
+
+    # External batches dispatch the loss per slot; the spec map is batch-level.
+    if "adapter_loss_by_slot" in data_iterator.rollout_data:
+        batch["adapter_loss_by_slot"] = data_iterator.rollout_data["adapter_loss_by_slot"]
 
     # No-op safety net if batches reach get_batch without rollout-level preprocessing.
     expand_multimodal_rollout_data_in_place(batch, qkv_format=qkv_format)

--- a/miles/backends/training_utils/data.py
+++ b/miles/backends/training_utils/data.py
@@ -163,9 +163,13 @@ def get_batch(
     if "dynamic_global_batch_size" in data_iterator.rollout_data:
         batch["dynamic_global_batch_size"] = data_iterator.rollout_data["dynamic_global_batch_size"]
 
-    # External batches dispatch the loss per slot; the spec map is batch-level.
+    # External batches dispatch the loss per slot; the spec map is batch-level,
+    # and the logprob collector is a shared mutable side channel the loss
+    # fills for the operation result plane.
     if "adapter_loss_by_slot" in data_iterator.rollout_data:
         batch["adapter_loss_by_slot"] = data_iterator.rollout_data["adapter_loss_by_slot"]
+    if "external_logprob_collector" in data_iterator.rollout_data:
+        batch["external_logprob_collector"] = data_iterator.rollout_data["external_logprob_collector"]
 
     # No-op safety net if batches reach get_batch without rollout-level preprocessing.
     expand_multimodal_rollout_data_in_place(batch, qkv_format=qkv_format)

--- a/miles/backends/training_utils/data.py
+++ b/miles/backends/training_utils/data.py
@@ -168,6 +168,8 @@ def get_batch(
     # fills for the operation result plane.
     if "adapter_loss_by_slot" in data_iterator.rollout_data:
         batch["adapter_loss_by_slot"] = data_iterator.rollout_data["adapter_loss_by_slot"]
+    if "forward_only_slots" in data_iterator.rollout_data:
+        batch["forward_only_slots"] = data_iterator.rollout_data["forward_only_slots"]
     if "thinker_logprob_collector" in data_iterator.rollout_data:
         batch["thinker_logprob_collector"] = data_iterator.rollout_data["thinker_logprob_collector"]
 

--- a/miles/backends/training_utils/loss.py
+++ b/miles/backends/training_utils/loss.py
@@ -6,7 +6,7 @@ from torch.utils.checkpoint import checkpoint
 from miles.backends.training_utils.cp_utils import get_sum_of_sample_mean
 from miles.backends.training_utils.loss_hub.advantages import compute_advantages, normalize_advantages
 from miles.backends.training_utils.loss_hub.logit_processors import get_log_probs_and_entropy, get_values  # noqa: F401
-from miles.backends.training_utils.loss_hub.losses import external_loss_function, get_loss_function
+from miles.backends.training_utils.loss_hub.losses import thinker_loss_function, get_loss_function
 from miles.backends.training_utils.loss_hub.math_utils import compute_approx_kl
 from miles.backends.training_utils.loss_hub.opd import apply_opd_kl_to_advantages
 from miles.backends.training_utils.parallel import get_parallel_state
@@ -140,10 +140,10 @@ def loss_function(
         denominators=batch.get("rollout_mask_sums", None),
     )
 
-    # External batches dispatch per slot from the BatchPlan's loss specs;
+    # Thinker batches dispatch per slot from the BatchPlan's loss specs;
     # everything else keeps the process-global args.loss_type.
     if batch.get("adapter_loss_by_slot"):
-        func = external_loss_function
+        func = thinker_loss_function
     else:
         func = get_loss_function(args)
 

--- a/miles/backends/training_utils/loss.py
+++ b/miles/backends/training_utils/loss.py
@@ -6,7 +6,7 @@ from torch.utils.checkpoint import checkpoint
 from miles.backends.training_utils.cp_utils import get_sum_of_sample_mean
 from miles.backends.training_utils.loss_hub.advantages import compute_advantages, normalize_advantages
 from miles.backends.training_utils.loss_hub.logit_processors import get_log_probs_and_entropy, get_values  # noqa: F401
-from miles.backends.training_utils.loss_hub.losses import get_loss_function
+from miles.backends.training_utils.loss_hub.losses import external_loss_function, get_loss_function
 from miles.backends.training_utils.loss_hub.math_utils import compute_approx_kl
 from miles.backends.training_utils.loss_hub.opd import apply_opd_kl_to_advantages
 from miles.backends.training_utils.parallel import get_parallel_state
@@ -140,7 +140,12 @@ def loss_function(
         denominators=batch.get("rollout_mask_sums", None),
     )
 
-    func = get_loss_function(args)
+    # External batches dispatch per slot from the BatchPlan's loss specs;
+    # everything else keeps the process-global args.loss_type.
+    if batch.get("adapter_loss_by_slot"):
+        func = external_loss_function
+    else:
+        func = get_loss_function(args)
 
     if args.recompute_loss_function:
         loss, log = checkpoint(

--- a/miles/backends/training_utils/loss.py
+++ b/miles/backends/training_utils/loss.py
@@ -6,7 +6,7 @@ from torch.utils.checkpoint import checkpoint
 from miles.backends.training_utils.cp_utils import get_sum_of_sample_mean
 from miles.backends.training_utils.loss_hub.advantages import compute_advantages, normalize_advantages
 from miles.backends.training_utils.loss_hub.logit_processors import get_log_probs_and_entropy, get_values  # noqa: F401
-from miles.backends.training_utils.loss_hub.losses import thinker_loss_function, get_loss_function
+from miles.backends.training_utils.loss_hub.losses import get_loss_function, thinker_loss_function
 from miles.backends.training_utils.loss_hub.math_utils import compute_approx_kl
 from miles.backends.training_utils.loss_hub.opd import apply_opd_kl_to_advantages
 from miles.backends.training_utils.parallel import get_parallel_state

--- a/miles/backends/training_utils/loss_hub/losses.py
+++ b/miles/backends/training_utils/loss_hub/losses.py
@@ -477,20 +477,20 @@ def sft_loss_function(
     )
 
 
-def external_loss_function(
+def thinker_loss_function(
     args: Namespace,
     batch: RolloutBatch,
     logits: torch.Tensor,
     sum_of_sample_mean: Callable[[torch.Tensor], torch.Tensor],
 ) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
-    """Client-directed per-slot losses for external batches.
+    """Client-directed per-slot losses for thinker batches.
 
     Every sample dispatches on its adapter's ``loss_spec`` from the BatchPlan:
     linear cross-entropy ``Σ(-logp·w)``, importance sampling ``-Σ(ratio·A)``,
     or the PPO clipped surrogate. Reduction is a plain token sum — chunk
     additive, so K accumulated forward_backward operations produce the same
     gradient as one, and the client's ``loss_weights`` own the scale (the
-    per-adapter 1/count step normalization never applies to external slots).
+    per-adapter 1/count step normalization never applies to thinker slots).
     """
     specs_by_slot = batch["adapter_loss_by_slot"]
     adapter_slots = batch["adapter_slots"]
@@ -514,13 +514,13 @@ def external_loss_function(
     def channel(key: str, i: int, loss_fn: str) -> torch.Tensor:
         values = batch.get(key)
         if values is None or values[i] is None:
-            raise ValueError(f"external loss '{loss_fn}' needs per-token '{key}'")
+            raise ValueError(f"thinker loss '{loss_fn}' needs per-token '{key}'")
         return values[i]
 
     # Operation result plane: per-datum target logprobs, keyed by (slot, row)
     # so one selection's adapters never collide. CP shards gather to the full
     # response; a checkpointed loss recompute overwrites idempotently.
-    collector = batch.get("external_logprob_collector")
+    collector = batch.get("thinker_logprob_collector")
     if collector is not None:
         sample_indices = batch["sample_indices"]
         for i, logp in enumerate(log_probs):
@@ -547,7 +547,7 @@ def external_loss_function(
                 surrogate = torch.minimum(surrogate, ratio.clamp(low, high) * advantages)
             sample_loss = -(surrogate * mask).sum()
         else:
-            raise ValueError(f"external adapter in slot {adapter_slots[i]} requests unknown loss_fn '{loss_fn}'")
+            raise ValueError(f"thinker adapter in slot {adapter_slots[i]} requests unknown loss_fn '{loss_fn}'")
         loss = sample_loss if loss is None else loss + sample_loss
 
     if loss is None:

--- a/miles/backends/training_utils/loss_hub/losses.py
+++ b/miles/backends/training_utils/loss_hub/losses.py
@@ -517,6 +517,18 @@ def external_loss_function(
             raise ValueError(f"external loss '{loss_fn}' needs per-token '{key}'")
         return values[i]
 
+    # Operation result plane: per-datum target logprobs, keyed by (slot, row)
+    # so one selection's adapters never collide. CP shards gather to the full
+    # response; a checkpointed loss recompute overwrites idempotently.
+    collector = batch.get("external_logprob_collector")
+    if collector is not None:
+        sample_indices = batch["sample_indices"]
+        for i, logp in enumerate(log_probs):
+            full = logp
+            if get_parallel_state().cp.size > 1:
+                full = all_gather_with_cp(logp, total_lengths[i], response_lengths[i])
+            collector[(adapter_slots[i], sample_indices[i])] = full.detach().float().cpu().tolist()
+
     loss = None
     for i, logp in enumerate(log_probs):
         spec = specs_by_slot.get(adapter_slots[i]) or {}

--- a/miles/backends/training_utils/loss_hub/losses.py
+++ b/miles/backends/training_utils/loss_hub/losses.py
@@ -477,6 +477,75 @@ def sft_loss_function(
     )
 
 
+def external_loss_function(
+    args: Namespace,
+    batch: RolloutBatch,
+    logits: torch.Tensor,
+    sum_of_sample_mean: Callable[[torch.Tensor], torch.Tensor],
+) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
+    """Client-directed per-slot losses for external batches.
+
+    Every sample dispatches on its adapter's ``loss_spec`` from the BatchPlan:
+    linear cross-entropy ``Σ(-logp·w)``, importance sampling ``-Σ(ratio·A)``,
+    or the PPO clipped surrogate. Reduction is a plain token sum — chunk
+    additive, so K accumulated forward_backward operations produce the same
+    gradient as one, and the client's ``loss_weights`` own the scale (the
+    per-adapter 1/count step normalization never applies to external slots).
+    """
+    specs_by_slot = batch["adapter_loss_by_slot"]
+    adapter_slots = batch["adapter_slots"]
+    response_lengths = batch["response_lengths"]
+    total_lengths = batch["total_lengths"]
+    max_seq_lens = batch.get("max_seq_lens", None)
+
+    log_probs = get_log_probs_and_entropy(
+        logits,
+        args=args,
+        unconcat_tokens=batch["unconcat_tokens"],
+        total_lengths=total_lengths,
+        response_lengths=response_lengths,
+        with_entropy=False,
+        max_seq_lens=max_seq_lens,
+    )["log_probs"]
+    local_masks = get_local_response_loss_masks(
+        total_lengths, response_lengths, batch["loss_masks"], args.qkv_format, max_seq_lens
+    )
+
+    def channel(key: str, i: int, loss_fn: str) -> torch.Tensor:
+        values = batch.get(key)
+        if values is None or values[i] is None:
+            raise ValueError(f"external loss '{loss_fn}' needs per-token '{key}'")
+        return values[i]
+
+    loss = None
+    for i, logp in enumerate(log_probs):
+        spec = specs_by_slot.get(adapter_slots[i]) or {}
+        loss_fn = spec.get("loss_fn", "cross_entropy")
+        config = spec.get("loss_fn_config") or {}
+        mask = local_masks[i].to(device=logp.device, dtype=logp.dtype)
+        if loss_fn == "cross_entropy":
+            sample_loss = -(logp * channel("loss_weights", i, loss_fn) * mask).sum()
+        elif loss_fn in ("importance_sampling", "ppo"):
+            ratio = torch.exp(logp - channel("rollout_log_probs", i, loss_fn))
+            advantages = channel("advantages", i, loss_fn)
+            surrogate = ratio * advantages
+            if loss_fn == "ppo":
+                low = config.get("clip_low_threshold", 0.8)
+                high = config.get("clip_high_threshold", 1.2)
+                surrogate = torch.minimum(surrogate, ratio.clamp(low, high) * advantages)
+            sample_loss = -(surrogate * mask).sum()
+        else:
+            raise ValueError(f"external adapter in slot {adapter_slots[i]} requests unknown loss_fn '{loss_fn}'")
+        loss = sample_loss if loss is None else loss + sample_loss
+
+    if loss is None:
+        loss = 0 * logits.sum()
+    # make sure the gradient could backprop correctly.
+    loss = loss + 0 * logits.sum()
+
+    return loss, {"loss": loss.clone().detach()}
+
+
 def get_loss_function(args: Namespace) -> LossFunction:
     match args.loss_type:
         case "policy_loss":

--- a/miles/backends/training_utils/loss_hub/losses.py
+++ b/miles/backends/training_utils/loss_hub/losses.py
@@ -529,8 +529,14 @@ def thinker_loss_function(
                 full = all_gather_with_cp(logp, total_lengths[i], response_lengths[i])
             collector[(adapter_slots[i], sample_indices[i])] = full.detach().float().cpu().tolist()
 
+    # forward operations only read logprobs (collected above): their samples
+    # contribute no loss term, so no gradient ever reaches their adapter.
+    forward_only_slots = set(batch.get("forward_only_slots") or ())
+
     loss = None
     for i, logp in enumerate(log_probs):
+        if adapter_slots[i] in forward_only_slots:
+            continue
         spec = specs_by_slot.get(adapter_slots[i]) or {}
         loss_fn = spec.get("loss_fn", "cross_entropy")
         config = spec.get("loss_fn_config") or {}

--- a/miles/ray/actor_group.py
+++ b/miles/ray/actor_group.py
@@ -143,7 +143,7 @@ class RayTrainGroup:
             await self._broadcast("bind_adapters", bind_plan)
 
     async def execute_adapter_controls(self, operations: list[dict]) -> dict:
-        """Multi-LoRA external mode: run data-less operations (optim_step) on
+        """Multi-LoRA thinker mode: run data-less operations (optim_step) on
         every trainer rank; the per-operation outcomes are rank-identical, so
         the first rank's map is authoritative."""
         results = await self._broadcast("execute_adapter_controls", operations)

--- a/miles/ray/actor_group.py
+++ b/miles/ray/actor_group.py
@@ -142,6 +142,13 @@ class RayTrainGroup:
         if bind_plan:
             await self._broadcast("bind_adapters", bind_plan)
 
+    async def execute_adapter_controls(self, operations: list[dict]) -> dict:
+        """Multi-LoRA external mode: run data-less operations (optim_step) on
+        every trainer rank; the per-operation outcomes are rank-identical, so
+        the first rank's map is authoritative."""
+        results = await self._broadcast("execute_adapter_controls", operations)
+        return results[0]
+
     async def onload(self):
         await self._broadcast("wake_up")
 

--- a/miles/ray/multi_lora/backend.py
+++ b/miles/ray/multi_lora/backend.py
@@ -10,6 +10,7 @@ from typing import Any
 
 import httpx
 
+from miles.ray.multi_lora.operations import OperationLedger
 from miles.ray.multi_lora.registry import AdapterRegistry, AdapterState
 from miles.utils.adapter_config import AdapterRunConfig
 from miles.utils.http_utils import router_worker_base_urls
@@ -25,6 +26,7 @@ class MultiLoRABackend:
     def __init__(self, args: Any, router_url: str) -> None:
         self.args = args
         self.registry = AdapterRegistry(args.multi_lora_n_adapters)
+        self.operations = OperationLedger()
         self.router_url = router_url.rstrip("/")
         self.client: httpx.AsyncClient | None = None
 
@@ -49,6 +51,13 @@ class MultiLoRABackend:
         """
         if config is None or not isinstance(config, AdapterRunConfig):
             return config
+
+        if config.input_mode not in ("dataset", "external"):
+            raise ValueError(f"Adapter '{name}' input_mode must be 'dataset' or 'external', got '{config.input_mode}'")
+        if config.input_mode == "external":
+            return self._resolve_external_config(name, config)
+        if config.data is None:
+            raise ValueError(f"Adapter '{name}' needs a dataset path: set 'data' (or use input_mode: external)")
 
         rank = config.rank if config.rank is not None else getattr(self.args, "lora_rank", 1)
         alpha = config.alpha if config.alpha is not None else getattr(self.args, "lora_alpha", rank)
@@ -108,11 +117,7 @@ class MultiLoRABackend:
                     f"(rollout_batch_size {rollout_batch_size} x n_samples_per_prompt {n_samples_per_prompt}), "
                     f"exceeding --multi-lora-max-adapter-global-batch-size {max_batch}"
                 )
-        save = Path(config.save) if config.save is not None else None
-        if save is None:
-            if getattr(self.args, "save", None) is None:
-                raise ValueError(f"Adapter '{name}' has no save dir: set 'save' in the adapter config or pass --save")
-            save = Path(self.args.save) / "adapters" / name
+        save = self._resolve_save(name, config)
 
         return replace(
             config,
@@ -122,6 +127,37 @@ class MultiLoRABackend:
             n_samples_per_prompt=n_samples_per_prompt,
             save=save,
         )
+
+    def _resolve_external_config(self, name: str, config: AdapterRunConfig) -> AdapterRunConfig:
+        """External adapters have no dataset, reward, or server-side batch
+        shape: clients push batches through the operation queue and end the
+        run by explicit deregistration (num_step remains an optional bound)."""
+        rank = config.rank if config.rank is not None else getattr(self.args, "lora_rank", 1)
+        alpha = config.alpha if config.alpha is not None else getattr(self.args, "lora_alpha", rank)
+        if type(rank) is not int or rank <= 0:
+            raise ValueError(f"Adapter '{name}' rank must be a positive integer")
+        if rank > getattr(self.args, "lora_rank", rank):
+            raise ValueError(f"Adapter '{name}' rank {rank} exceeds the allocated maximum rank {self.args.lora_rank}")
+        if alpha is None or alpha <= 0:
+            raise ValueError(f"Adapter '{name}' must have a positive alpha")
+        if config.data is not None:
+            raise ValueError(f"External adapter '{name}' must not set 'data'; batches arrive via operations")
+        if config.rm_type is not None or config.custom_rm_path is not None:
+            raise ValueError(f"External adapter '{name}' must not set a reward; losses come per operation")
+        if config.rollout_function_path is not None:
+            raise ValueError(f"External adapter '{name}' must not set rollout_function_path; the queue child is built in")
+        if config.num_epoch is not None:
+            raise ValueError(f"External adapter '{name}' must not set num_epoch (there is no dataset); use num_step")
+        if config.num_step is not None and (type(config.num_step) is not int or config.num_step <= 0):
+            raise ValueError(f"Adapter '{name}' num_step must be a positive integer")
+        return replace(config, rank=rank, alpha=alpha, save=self._resolve_save(name, config))
+
+    def _resolve_save(self, name: str, config: AdapterRunConfig) -> Path:
+        if config.save is not None:
+            return Path(config.save)
+        if getattr(self.args, "save", None) is None:
+            raise ValueError(f"Adapter '{name}' has no save dir: set 'save' in the adapter config or pass --save")
+        return Path(self.args.save) / "adapters" / name
 
     async def register(self, name: str, config: Any) -> dict:
         config = self.resolve_adapter_config(name, config)
@@ -140,8 +176,24 @@ class MultiLoRABackend:
         for name in names:
             record = self.registry.records.get(name)
             if record is not None:
+                # Fence before the engine abort: no operation of the dead
+                # registration may be claimed once retirement is underway.
+                self.operations.fence(name, record.registration_id)
                 await self.abort_adapter_requests(name, record.registration_id)
         return names
+
+    # ---------------- external operations ----------------
+
+    def enqueue_operation(self, name: str, operation_id: str, ordinal: int, kind: str, payload: dict | None = None) -> dict:
+        """Enqueue one client operation against the name's CURRENT registration
+        (clients address adapters by name; the resolved registration_id rides
+        the operation, so a re-registered name can never execute stale work)."""
+        record = self.registry.find(name)
+        if record is None or record.state not in (AdapterState.PENDING, AdapterState.ACTIVE):
+            raise ValueError(f"Adapter '{name}' is not accepting operations (not registered or retiring)")
+        if getattr(record.config, "input_mode", "dataset") != "external":
+            raise ValueError(f"Adapter '{name}' is a dataset run; operations apply to input_mode: external only")
+        return self.operations.enqueue(operation_id, name, record.registration_id, ordinal, kind, payload)
 
     async def free_slot(self, name: str) -> int:
         """Free the adapter's slot after one final abort round: requests can survive the

--- a/miles/ray/multi_lora/backend.py
+++ b/miles/ray/multi_lora/backend.py
@@ -240,14 +240,19 @@ class MultiLoRABackend:
                 if operation["kind"] == "optim_step":
                     self.registry.clear_dirty(operation["name"])
 
-    def commit_external_batch(self, names: list[str], operation_ids: list[str]) -> None:
+    def commit_external_batch(
+        self, names: list[str], operation_ids: list[str], logprobs_by_op: dict[str, list] | None = None
+    ) -> None:
         """An external train call landed: its slots now hold unstepped
-        gradients (pin them) and its forward_backward operations are done."""
+        gradients (pin them) and its forward_backward operations complete with
+        their per-datum target logprobs (row order = the operation's datum
+        order), which the frontend maps into ForwardBackwardOutput."""
         self.registry.mark_accumulated(names)
+        logprobs_by_op = logprobs_by_op or {}
         for operation_id in operation_ids:
             operation = self.operations.get(operation_id)
             if operation is not None and operation["state"] == "CLAIMED":
-                self.operations.complete(operation_id, None)
+                self.operations.complete(operation_id, {"logprobs": logprobs_by_op.get(operation_id)})
 
     async def free_slot(self, name: str) -> int:
         """Free the adapter's slot after one final abort round: requests can survive the

--- a/miles/ray/multi_lora/backend.py
+++ b/miles/ray/multi_lora/backend.py
@@ -53,7 +53,9 @@ class MultiLoRABackend:
             return config
 
         if config.input_mode not in ("multi-lora", "thinker"):
-            raise ValueError(f"Adapter '{name}' input_mode must be 'dataset' or 'thinker', got '{config.input_mode}'")
+            raise ValueError(
+                f"Adapter '{name}' input_mode must be 'multi-lora' or 'thinker', got '{config.input_mode}'"
+            )
         if config.input_mode == "thinker":
             return self._resolve_thinker_config(name, config)
         if config.data is None:
@@ -202,13 +204,17 @@ class MultiLoRABackend:
     # Control kinds the driver's control phase can execute today; the rest
     # (save_state / load_state / publish_snapshot) keep their queue turn until
     # their executors land.
-    EXECUTABLE_CONTROL_KINDS = ("optim_step",)
+    EXECUTABLE_CONTROL_KINDS = ("optim_step", "publish_snapshot", "save_state", "load_state")
+    # Moving state under unstepped gradients would silently drop them (no
+    # sidecar carries grads): the client must step or deregister first.
+    DIRTY_GATED_KINDS = ("save_state", "load_state")
 
     def claim_ready_control_operations(self) -> list[dict]:
         """Claim every registration whose next open operation is an executable
         control kind on a slot-resident ACTIVE adapter. Claims are strictly
         serialized per registration, so an optim_step is claimable only after
-        its preceding forward_backward batches reached terminal states."""
+        its preceding forward_backward batches reached terminal states. The
+        claimed view carries the registry's authoritative clocks."""
         ready = []
         for name, registration_id in self.operations.claimable_control_tenants():
             record = self.registry.find(name)
@@ -222,15 +228,31 @@ class MultiLoRABackend:
             operation = self.operations.claim_control_operation(
                 name, registration_id, kinds=self.EXECUTABLE_CONTROL_KINDS
             )
-            if operation is not None:
-                operation["slot"] = record.slot
-                ready.append(operation)
+            if operation is None:
+                continue
+            if operation["kind"] in self.DIRTY_GATED_KINDS and self._slot_dirty(record):
+                self.operations.fail(
+                    operation["operation_id"],
+                    f"adapter '{name}' holds unstepped gradients; optim_step (or deregister) before "
+                    f"{operation['kind']}",
+                    "user",
+                )
+                continue
+            operation["slot"] = record.slot
+            operation["step"] = record.step
+            operation["serving_version"] = record.serving_version
+            ready.append(operation)
         return ready
 
+    def _slot_dirty(self, record) -> bool:
+        entry = self.registry.slot_pool.entry_of(record.tenant)
+        return entry is not None and "dirty-grads" in entry.pins
+
     def complete_control_operations(self, results: dict[str, dict]) -> None:
-        """Book the trainer's control-phase outcomes: success advances the
-        adapter's step clock, both outcomes release the dirty-gradient pin
-        (a veto zeroes the accumulated gradients on every rank)."""
+        """Book the trainer's control-phase outcomes: an optim_step success
+        advances the adapter's step clock and either outcome releases the
+        dirty-gradient pin (a veto zeroes the accumulated gradients on every
+        rank); a load_state success repositions the step clock."""
         for operation_id, outcome in results.items():
             operation = self.operations.get(operation_id)
             if operation is None:
@@ -239,6 +261,8 @@ class MultiLoRABackend:
                 self.operations.complete(operation_id, outcome.get("result"))
                 if operation["kind"] == "optim_step":
                     self.registry.commit_thinker_step(operation["name"])
+                elif operation["kind"] == "load_state":
+                    self.registry.set_step(operation["name"], int((outcome.get("result") or {}).get("step", 0)))
             else:
                 self.operations.fail(
                     operation_id, outcome.get("error", "control operation failed"), outcome.get("category", "server")
@@ -267,6 +291,19 @@ class MultiLoRABackend:
         if record is not None and record.state is AdapterState.CLEANUP:
             await self.abort_adapter_requests(name, record.registration_id)
         return self.registry.free_slot(name)
+
+    def service_info(self) -> dict:
+        """Deployment facts a thinker frontend needs for get_server_capabilities
+        and weights_info: one base model per deployment, the rank ceiling, and
+        slot occupancy."""
+        args = self.args
+        return dict(
+            base_model=getattr(args, "hf_checkpoint", None),
+            lora_rank_max=getattr(args, "lora_rank", None),
+            n_adapters=getattr(args, "multi_lora_n_adapters", None),
+            occupied_slots=sorted(e.slot for e in self.registry.slot_pool.entries if e.tenant is not None),
+            active_adapters=sorted(self.registry.in_state(AdapterState.ACTIVE)),
+        )
 
     async def worker_urls(self) -> list[str]:
         assert self.client is not None

--- a/miles/ray/multi_lora/backend.py
+++ b/miles/ray/multi_lora/backend.py
@@ -52,12 +52,12 @@ class MultiLoRABackend:
         if config is None or not isinstance(config, AdapterRunConfig):
             return config
 
-        if config.input_mode not in ("dataset", "external"):
-            raise ValueError(f"Adapter '{name}' input_mode must be 'dataset' or 'external', got '{config.input_mode}'")
-        if config.input_mode == "external":
-            return self._resolve_external_config(name, config)
+        if config.input_mode not in ("multi-lora", "thinker"):
+            raise ValueError(f"Adapter '{name}' input_mode must be 'dataset' or 'thinker', got '{config.input_mode}'")
+        if config.input_mode == "thinker":
+            return self._resolve_thinker_config(name, config)
         if config.data is None:
-            raise ValueError(f"Adapter '{name}' needs a dataset path: set 'data' (or use input_mode: external)")
+            raise ValueError(f"Adapter '{name}' needs a dataset path: set 'data' (or use input_mode: thinker)")
 
         rank = config.rank if config.rank is not None else getattr(self.args, "lora_rank", 1)
         alpha = config.alpha if config.alpha is not None else getattr(self.args, "lora_alpha", rank)
@@ -128,8 +128,8 @@ class MultiLoRABackend:
             save=save,
         )
 
-    def _resolve_external_config(self, name: str, config: AdapterRunConfig) -> AdapterRunConfig:
-        """External adapters have no dataset, reward, or server-side batch
+    def _resolve_thinker_config(self, name: str, config: AdapterRunConfig) -> AdapterRunConfig:
+        """Thinker adapters have no dataset, reward, or server-side batch
         shape: clients push batches through the operation queue and end the
         run by explicit deregistration (num_step remains an optional bound)."""
         rank = config.rank if config.rank is not None else getattr(self.args, "lora_rank", 1)
@@ -141,15 +141,15 @@ class MultiLoRABackend:
         if alpha is None or alpha <= 0:
             raise ValueError(f"Adapter '{name}' must have a positive alpha")
         if config.data is not None:
-            raise ValueError(f"External adapter '{name}' must not set 'data'; batches arrive via operations")
+            raise ValueError(f"Thinker adapter '{name}' must not set 'data'; batches arrive via operations")
         if config.rm_type is not None or config.custom_rm_path is not None:
-            raise ValueError(f"External adapter '{name}' must not set a reward; losses come per operation")
+            raise ValueError(f"Thinker adapter '{name}' must not set a reward; losses come per operation")
         if config.rollout_function_path is not None:
             raise ValueError(
-                f"External adapter '{name}' must not set rollout_function_path; the queue child is built in"
+                f"Thinker adapter '{name}' must not set rollout_function_path; the queue child is built in"
             )
         if config.num_epoch is not None:
-            raise ValueError(f"External adapter '{name}' must not set num_epoch (there is no dataset); use num_step")
+            raise ValueError(f"Thinker adapter '{name}' must not set num_epoch (there is no dataset); use num_step")
         if config.num_step is not None and (type(config.num_step) is not int or config.num_step <= 0):
             raise ValueError(f"Adapter '{name}' num_step must be a positive integer")
         return replace(config, rank=rank, alpha=alpha, save=self._resolve_save(name, config))
@@ -184,7 +184,7 @@ class MultiLoRABackend:
                 await self.abort_adapter_requests(name, record.registration_id)
         return names
 
-    # ---------------- external operations ----------------
+    # ---------------- thinker operations ----------------
 
     def enqueue_operation(
         self, name: str, operation_id: str, ordinal: int, kind: str, payload: dict | None = None
@@ -195,8 +195,8 @@ class MultiLoRABackend:
         record = self.registry.find(name)
         if record is None or record.state not in (AdapterState.PENDING, AdapterState.ACTIVE):
             raise ValueError(f"Adapter '{name}' is not accepting operations (not registered or retiring)")
-        if getattr(record.config, "input_mode", "dataset") != "external":
-            raise ValueError(f"Adapter '{name}' is a dataset run; operations apply to input_mode: external only")
+        if getattr(record.config, "input_mode", "multi-lora") != "thinker":
+            raise ValueError(f"Adapter '{name}' is a dataset run; operations apply to input_mode: thinker only")
         return self.operations.enqueue(operation_id, name, record.registration_id, ordinal, kind, payload)
 
     # Control kinds the driver's control phase can execute today; the rest
@@ -238,7 +238,7 @@ class MultiLoRABackend:
             if outcome.get("ok"):
                 self.operations.complete(operation_id, outcome.get("result"))
                 if operation["kind"] == "optim_step":
-                    self.registry.commit_external_step(operation["name"])
+                    self.registry.commit_thinker_step(operation["name"])
             else:
                 self.operations.fail(
                     operation_id, outcome.get("error", "control operation failed"), outcome.get("category", "server")
@@ -246,10 +246,10 @@ class MultiLoRABackend:
                 if operation["kind"] == "optim_step":
                     self.registry.clear_dirty(operation["name"])
 
-    def commit_external_batch(
+    def commit_thinker_batch(
         self, names: list[str], operation_ids: list[str], logprobs_by_op: dict[str, list] | None = None
     ) -> None:
-        """An external train call landed: its slots now hold unstepped
+        """A thinker train call landed: its slots now hold unstepped
         gradients (pin them) and its forward_backward operations complete with
         their per-datum target logprobs (row order = the operation's datum
         order), which the frontend maps into ForwardBackwardOutput."""

--- a/miles/ray/multi_lora/backend.py
+++ b/miles/ray/multi_lora/backend.py
@@ -145,7 +145,9 @@ class MultiLoRABackend:
         if config.rm_type is not None or config.custom_rm_path is not None:
             raise ValueError(f"External adapter '{name}' must not set a reward; losses come per operation")
         if config.rollout_function_path is not None:
-            raise ValueError(f"External adapter '{name}' must not set rollout_function_path; the queue child is built in")
+            raise ValueError(
+                f"External adapter '{name}' must not set rollout_function_path; the queue child is built in"
+            )
         if config.num_epoch is not None:
             raise ValueError(f"External adapter '{name}' must not set num_epoch (there is no dataset); use num_step")
         if config.num_step is not None and (type(config.num_step) is not int or config.num_step <= 0):
@@ -184,7 +186,9 @@ class MultiLoRABackend:
 
     # ---------------- external operations ----------------
 
-    def enqueue_operation(self, name: str, operation_id: str, ordinal: int, kind: str, payload: dict | None = None) -> dict:
+    def enqueue_operation(
+        self, name: str, operation_id: str, ordinal: int, kind: str, payload: dict | None = None
+    ) -> dict:
         """Enqueue one client operation against the name's CURRENT registration
         (clients address adapters by name; the resolved registration_id rides
         the operation, so a re-registered name can never execute stale work)."""
@@ -236,7 +240,9 @@ class MultiLoRABackend:
                 if operation["kind"] == "optim_step":
                     self.registry.commit_external_step(operation["name"])
             else:
-                self.operations.fail(operation_id, outcome.get("error", "control operation failed"), outcome.get("category", "server"))
+                self.operations.fail(
+                    operation_id, outcome.get("error", "control operation failed"), outcome.get("category", "server")
+                )
                 if operation["kind"] == "optim_step":
                     self.registry.clear_dirty(operation["name"])
 

--- a/miles/ray/multi_lora/backend.py
+++ b/miles/ray/multi_lora/backend.py
@@ -195,6 +195,60 @@ class MultiLoRABackend:
             raise ValueError(f"Adapter '{name}' is a dataset run; operations apply to input_mode: external only")
         return self.operations.enqueue(operation_id, name, record.registration_id, ordinal, kind, payload)
 
+    # Control kinds the driver's control phase can execute today; the rest
+    # (save_state / load_state / publish_snapshot) keep their queue turn until
+    # their executors land.
+    EXECUTABLE_CONTROL_KINDS = ("optim_step",)
+
+    def claim_ready_control_operations(self) -> list[dict]:
+        """Claim every registration whose next open operation is an executable
+        control kind on a slot-resident ACTIVE adapter. Claims are strictly
+        serialized per registration, so an optim_step is claimable only after
+        its preceding forward_backward batches reached terminal states."""
+        ready = []
+        for name, registration_id in self.operations.claimable_control_tenants():
+            record = self.registry.find(name)
+            if (
+                record is None
+                or record.registration_id != registration_id
+                or record.state is not AdapterState.ACTIVE
+                or record.slot is None
+            ):
+                continue
+            operation = self.operations.claim_control_operation(
+                name, registration_id, kinds=self.EXECUTABLE_CONTROL_KINDS
+            )
+            if operation is not None:
+                operation["slot"] = record.slot
+                ready.append(operation)
+        return ready
+
+    def complete_control_operations(self, results: dict[str, dict]) -> None:
+        """Book the trainer's control-phase outcomes: success advances the
+        adapter's step clock, both outcomes release the dirty-gradient pin
+        (a veto zeroes the accumulated gradients on every rank)."""
+        for operation_id, outcome in results.items():
+            operation = self.operations.get(operation_id)
+            if operation is None:
+                continue
+            if outcome.get("ok"):
+                self.operations.complete(operation_id, outcome.get("result"))
+                if operation["kind"] == "optim_step":
+                    self.registry.commit_external_step(operation["name"])
+            else:
+                self.operations.fail(operation_id, outcome.get("error", "control operation failed"), outcome.get("category", "server"))
+                if operation["kind"] == "optim_step":
+                    self.registry.clear_dirty(operation["name"])
+
+    def commit_external_batch(self, names: list[str], operation_ids: list[str]) -> None:
+        """An external train call landed: its slots now hold unstepped
+        gradients (pin them) and its forward_backward operations are done."""
+        self.registry.mark_accumulated(names)
+        for operation_id in operation_ids:
+            operation = self.operations.get(operation_id)
+            if operation is not None and operation["state"] == "CLAIMED":
+                self.operations.complete(operation_id, None)
+
     async def free_slot(self, name: str) -> int:
         """Free the adapter's slot after one final abort round: requests can survive the
         ``retire_adapters`` abort (e.g. multi-turn groups), and must not leak to the slot's next tenant."""

--- a/miles/ray/multi_lora/controller.py
+++ b/miles/ray/multi_lora/controller.py
@@ -151,8 +151,8 @@ class MultiLoRAController:
     def complete_control_operations(self, results: dict) -> None:
         self.backend.complete_control_operations(results)
 
-    def commit_external_batch(self, names: list, operation_ids: list) -> None:
-        self.backend.commit_external_batch(list(names), list(operation_ids))
+    def commit_external_batch(self, names: list, operation_ids: list, logprobs_by_op: dict | None = None) -> None:
+        self.backend.commit_external_batch(list(names), list(operation_ids), logprobs_by_op)
 
     def set_adapter_step(self, name: str, step: int) -> None:
         self.backend.registry.set_step(name, step)

--- a/miles/ray/multi_lora/controller.py
+++ b/miles/ray/multi_lora/controller.py
@@ -118,7 +118,9 @@ class MultiLoRAController:
 
     # ---------------- external operations ----------------
 
-    def enqueue_operation(self, name: str, operation_id: str, ordinal: int, kind: str, payload: dict | None = None) -> dict:
+    def enqueue_operation(
+        self, name: str, operation_id: str, ordinal: int, kind: str, payload: dict | None = None
+    ) -> dict:
         return self.backend.enqueue_operation(name, operation_id, ordinal, kind, payload)
 
     def claim_data_operation(self, name: str, registration_id: str) -> dict | None:

--- a/miles/ray/multi_lora/controller.py
+++ b/miles/ray/multi_lora/controller.py
@@ -145,6 +145,15 @@ class MultiLoRAController:
     def ack_operation(self, operation_id: str) -> None:
         self.backend.operations.ack(operation_id)
 
+    def claim_ready_control_operations(self) -> list[dict]:
+        return self.backend.claim_ready_control_operations()
+
+    def complete_control_operations(self, results: dict) -> None:
+        self.backend.complete_control_operations(results)
+
+    def commit_external_batch(self, names: list, operation_ids: list) -> None:
+        self.backend.commit_external_batch(list(names), list(operation_ids))
+
     def set_adapter_step(self, name: str, step: int) -> None:
         self.backend.registry.set_step(name, step)
 

--- a/miles/ray/multi_lora/controller.py
+++ b/miles/ray/multi_lora/controller.py
@@ -116,6 +116,35 @@ class MultiLoRAController:
     def abort_bind(self, txn_id: str) -> None:
         self.backend.registry.abort_bind(txn_id)
 
+    # ---------------- external operations ----------------
+
+    def enqueue_operation(self, name: str, operation_id: str, ordinal: int, kind: str, payload: dict | None = None) -> dict:
+        return self.backend.enqueue_operation(name, operation_id, ordinal, kind, payload)
+
+    def claim_data_operation(self, name: str, registration_id: str) -> dict | None:
+        return self.backend.operations.claim_data_operation(name, registration_id)
+
+    def claim_control_operation(self, name: str, registration_id: str) -> dict | None:
+        return self.backend.operations.claim_control_operation(name, registration_id)
+
+    def claimable_control_tenants(self) -> list:
+        return self.backend.operations.claimable_control_tenants()
+
+    def complete_operation(self, operation_id: str, result: dict | None = None) -> None:
+        self.backend.operations.complete(operation_id, result)
+
+    def fail_operation(self, operation_id: str, error: str, category: str = "server") -> None:
+        self.backend.operations.fail(operation_id, error, category)
+
+    def cancel_operation(self, operation_id: str) -> dict:
+        return self.backend.operations.cancel(operation_id)
+
+    def get_operation(self, operation_id: str) -> dict | None:
+        return self.backend.operations.get(operation_id)
+
+    def ack_operation(self, operation_id: str) -> None:
+        self.backend.operations.ack(operation_id)
+
     def set_adapter_step(self, name: str, step: int) -> None:
         self.backend.registry.set_step(name, step)
 

--- a/miles/ray/multi_lora/controller.py
+++ b/miles/ray/multi_lora/controller.py
@@ -156,6 +156,9 @@ class MultiLoRAController:
     def commit_thinker_batch(self, names: list, operation_ids: list, logprobs_by_op: dict | None = None) -> None:
         self.backend.commit_thinker_batch(list(names), list(operation_ids), logprobs_by_op)
 
+    def service_info(self) -> dict:
+        return self.backend.service_info()
+
     def set_adapter_step(self, name: str, step: int) -> None:
         self.backend.registry.set_step(name, step)
 

--- a/miles/ray/multi_lora/controller.py
+++ b/miles/ray/multi_lora/controller.py
@@ -116,7 +116,7 @@ class MultiLoRAController:
     def abort_bind(self, txn_id: str) -> None:
         self.backend.registry.abort_bind(txn_id)
 
-    # ---------------- external operations ----------------
+    # ---------------- thinker operations ----------------
 
     def enqueue_operation(
         self, name: str, operation_id: str, ordinal: int, kind: str, payload: dict | None = None
@@ -153,8 +153,8 @@ class MultiLoRAController:
     def complete_control_operations(self, results: dict) -> None:
         self.backend.complete_control_operations(results)
 
-    def commit_external_batch(self, names: list, operation_ids: list, logprobs_by_op: dict | None = None) -> None:
-        self.backend.commit_external_batch(list(names), list(operation_ids), logprobs_by_op)
+    def commit_thinker_batch(self, names: list, operation_ids: list, logprobs_by_op: dict | None = None) -> None:
+        self.backend.commit_thinker_batch(list(names), list(operation_ids), logprobs_by_op)
 
     def set_adapter_step(self, name: str, step: int) -> None:
         self.backend.registry.set_step(name, step)

--- a/miles/ray/multi_lora/http_server.py
+++ b/miles/ray/multi_lora/http_server.py
@@ -60,6 +60,7 @@ class MultiLoRAHTTPServer:
 
     def add_routes(self, app: FastAPI) -> None:
         app.get("/health")(self.health)
+        app.get("/info")(self.service_info)
         app.get("/adapter_runs")(self.list_adapters)
         app.get("/adapter_runs/state")(self.adapter_states)  # before /adapter_runs/{name}
         app.get("/adapter_runs/{name}")(self.get_adapter)
@@ -111,6 +112,9 @@ class MultiLoRAHTTPServer:
             if status["name"] == name:
                 return status
         raise HTTPException(status_code=404, detail=f"Adapter '{name}' not registered")
+
+    async def service_info(self) -> dict:
+        return self.backend.service_info()
 
     async def register_adapter(self, request: RegisterAdapterRequest) -> dict:
         if (request.config is None) == (request.yaml_path is None):

--- a/miles/ray/multi_lora/operations.py
+++ b/miles/ray/multi_lora/operations.py
@@ -189,12 +189,17 @@ class OperationLedger:
                 tenants.append(tenant)
         return tenants
 
-    def claim_control_operation(self, name: str, registration_id: str) -> dict | None:
+    def claim_control_operation(self, name: str, registration_id: str, kinds: tuple[str, ...] | None = None) -> dict | None:
+        """Claim the next open operation when it is a control kind (optionally
+        restricted to ``kinds`` — heads of other kinds stay queued so a later
+        executor can pick them up without losing their turn)."""
         queue = self.queues.get((name, registration_id))
         if queue is None:
             return None
         op = queue.first_open()
         if op is None or op.state is not OperationState.QUEUED or op.kind not in CONTROL_KINDS:
+            return None
+        if kinds is not None and op.kind.value not in kinds:
             return None
         op.state = OperationState.CLAIMED
         return op.view()

--- a/miles/ray/multi_lora/operations.py
+++ b/miles/ray/multi_lora/operations.py
@@ -1,0 +1,279 @@
+"""Per-registration operation ledger for external (client-driven) adapters.
+
+Clients push protocol-neutral operations; data-bearing kinds ride the rollout
+selection path through the queue child rollout fn, data-less kinds execute in
+the driver's control phase. One registration is strictly serialized: an
+operation is claimable only when every earlier operation reached a terminal
+state, which is what makes per-model client ordering hold end to end.
+
+All mutations run inside the controller actor between awaits, so ledger
+methods are synchronous and atomic by construction.
+"""
+
+import logging
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+Tenant = tuple[str, str]
+
+
+class OperationKind(str, Enum):
+    FORWARD_BACKWARD = "forward_backward"
+    FORWARD = "forward"
+    OPTIM_STEP = "optim_step"
+    PUBLISH_SNAPSHOT = "publish_snapshot"
+    SAVE_STATE = "save_state"
+    LOAD_STATE = "load_state"
+
+
+# Ride the rollout/BatchPlan path (they carry Datums).
+DATA_KINDS = frozenset({OperationKind.FORWARD_BACKWARD, OperationKind.FORWARD})
+# Execute in the driver's control phase (no Datums).
+CONTROL_KINDS = frozenset(OperationKind) - DATA_KINDS
+
+
+class OperationState(str, Enum):
+    QUEUED = "QUEUED"
+    CLAIMED = "CLAIMED"
+    SUCCEEDED = "SUCCEEDED"
+    FAILED = "FAILED"
+    CANCELLED = "CANCELLED"
+
+
+TERMINAL_STATES = frozenset({OperationState.SUCCEEDED, OperationState.FAILED, OperationState.CANCELLED})
+
+
+class OperationBackpressure(RuntimeError):
+    """Queue or unacked-result capacity reached; the caller must retry later."""
+
+
+@dataclass
+class Operation:
+    operation_id: str
+    name: str
+    registration_id: str
+    # Client-assigned, strictly increasing per registration; gaps are legal
+    # (a cancelled operation leaves one).
+    ordinal: int
+    kind: OperationKind
+    payload: dict = field(default_factory=dict)
+    state: OperationState = OperationState.QUEUED
+    result: dict | None = None
+    error: str | None = None
+    # "user" (bad request / cancelled by lifecycle) or "server" (execution failure).
+    error_category: str | None = None
+
+    @property
+    def tenant(self) -> Tenant:
+        return (self.name, self.registration_id)
+
+    @property
+    def terminal(self) -> bool:
+        return self.state in TERMINAL_STATES
+
+    def view(self) -> dict:
+        return dict(
+            operation_id=self.operation_id,
+            name=self.name,
+            registration_id=self.registration_id,
+            ordinal=self.ordinal,
+            kind=self.kind.value,
+            state=self.state.value,
+            result=self.result,
+            error=self.error,
+            error_category=self.error_category,
+        )
+
+
+@dataclass
+class _RegistrationQueue:
+    """Ordinal-ordered operations of one registration, pending and terminal."""
+
+    operations: list[Operation] = field(default_factory=list)
+    last_ordinal: int | None = None
+    fenced: bool = False
+
+    def first_open(self) -> Operation | None:
+        for op in self.operations:
+            if not op.terminal:
+                return op
+        return None
+
+    def open_count(self) -> int:
+        return sum(1 for op in self.operations if not op.terminal)
+
+    def unacked_terminal_count(self) -> int:
+        return sum(1 for op in self.operations if op.terminal)
+
+
+class OperationLedger:
+    """All registrations' queues plus the operation_id index."""
+
+    def __init__(self, max_pending: int = 256, max_unacked_results: int = 4096) -> None:
+        self.max_pending = max_pending
+        self.max_unacked_results = max_unacked_results
+        self.queues: dict[Tenant, _RegistrationQueue] = {}
+        self.by_id: dict[str, Operation] = {}
+
+    # ------------------------------ enqueue ------------------------------
+
+    def enqueue(
+        self,
+        operation_id: str,
+        name: str,
+        registration_id: str,
+        ordinal: int,
+        kind: str,
+        payload: dict | None = None,
+    ) -> dict:
+        """Append one operation; idempotent on operation_id (the retry of a
+        known id returns its current state instead of a duplicate)."""
+        if (existing := self.by_id.get(operation_id)) is not None:
+            if existing.tenant != (name, registration_id) or existing.ordinal != ordinal:
+                raise ValueError(f"operation '{operation_id}' already exists with a different identity")
+            return existing.view()
+
+        queue = self.queues.setdefault((name, registration_id), _RegistrationQueue())
+        if queue.fenced:
+            raise ValueError(f"registration '{name}' ({registration_id[:8]}) is retired; operations are fenced")
+        if queue.last_ordinal is not None and ordinal <= queue.last_ordinal:
+            raise ValueError(
+                f"operation '{operation_id}' ordinal {ordinal} is not after {queue.last_ordinal}; "
+                "per-registration ordinals must arrive strictly increasing"
+            )
+        if queue.open_count() >= self.max_pending:
+            raise OperationBackpressure(f"registration '{name}' has {self.max_pending} operations pending")
+        if queue.unacked_terminal_count() >= self.max_unacked_results:
+            raise OperationBackpressure(
+                f"registration '{name}' holds {self.max_unacked_results} unacknowledged results; ack or deregister"
+            )
+
+        op = Operation(
+            operation_id=operation_id,
+            name=name,
+            registration_id=registration_id,
+            ordinal=ordinal,
+            kind=OperationKind(kind),
+            payload=payload or {},
+        )
+        queue.operations.append(op)
+        queue.last_ordinal = ordinal
+        self.by_id[operation_id] = op
+        return op.view()
+
+    # ------------------------------ claims ------------------------------
+
+    def claim_data_operation(self, name: str, registration_id: str) -> dict | None:
+        """Claim the registration's next operation when it is data-bearing.
+        Strict serialization: nothing is claimable while an earlier operation
+        is still open, so a queued optim_step can never overtake its batch."""
+        queue = self.queues.get((name, registration_id))
+        if queue is None:
+            return None
+        op = queue.first_open()
+        if op is None or op.state is not OperationState.QUEUED or op.kind not in DATA_KINDS:
+            return None
+        op.state = OperationState.CLAIMED
+        return op.view()
+
+    def claimable_control_tenants(self) -> list[Tenant]:
+        """Registrations whose next open operation is a control kind (the
+        caller filters by adapter state/slot residency before claiming)."""
+        tenants = []
+        for tenant, queue in self.queues.items():
+            op = queue.first_open()
+            if op is not None and op.state is OperationState.QUEUED and op.kind in CONTROL_KINDS:
+                tenants.append(tenant)
+        return tenants
+
+    def claim_control_operation(self, name: str, registration_id: str) -> dict | None:
+        queue = self.queues.get((name, registration_id))
+        if queue is None:
+            return None
+        op = queue.first_open()
+        if op is None or op.state is not OperationState.QUEUED or op.kind not in CONTROL_KINDS:
+            return None
+        op.state = OperationState.CLAIMED
+        return op.view()
+
+    # ------------------------------ terminals ------------------------------
+
+    def complete(self, operation_id: str, result: dict | None = None) -> None:
+        op = self._open_op(operation_id)
+        op.state = OperationState.SUCCEEDED
+        op.result = result
+
+    def fail(self, operation_id: str, error: str, category: str = "server") -> None:
+        op = self._open_op(operation_id)
+        op.state = OperationState.FAILED
+        op.error = error
+        op.error_category = category
+
+    def cancel(self, operation_id: str) -> dict:
+        """Cancel a not-yet-claimed operation; anything already claimed must
+        run to a terminal state (a half-executed optimizer mutation cannot be
+        rolled back)."""
+        op = self.by_id.get(operation_id)
+        if op is None:
+            raise KeyError(f"unknown operation '{operation_id}'")
+        if op.state is not OperationState.QUEUED:
+            raise ValueError(f"operation '{operation_id}' is {op.state.value}; only QUEUED operations cancel")
+        op.state = OperationState.CANCELLED
+        op.error = "cancelled by client"
+        op.error_category = "user"
+        return op.view()
+
+    def _open_op(self, operation_id: str) -> Operation:
+        op = self.by_id.get(operation_id)
+        if op is None:
+            raise KeyError(f"unknown operation '{operation_id}'")
+        if op.terminal:
+            raise ValueError(f"operation '{operation_id}' already terminal ({op.state.value})")
+        return op
+
+    # ------------------------------ results ------------------------------
+
+    def get(self, operation_id: str) -> dict | None:
+        op = self.by_id.get(operation_id)
+        return op.view() if op is not None else None
+
+    def ack(self, operation_id: str) -> None:
+        """Drop a terminal record the client has retrieved. Terminal records
+        are never evicted by pressure while their registration lives — the
+        enqueue backpressure cap is the knob, not result eviction."""
+        op = self.by_id.get(operation_id)
+        if op is None:
+            return
+        if not op.terminal:
+            raise ValueError(f"operation '{operation_id}' is {op.state.value}; ack applies to terminal operations")
+        self.by_id.pop(operation_id, None)
+        queue = self.queues.get(op.tenant)
+        if queue is not None:
+            queue.operations = [o for o in queue.operations if o.operation_id != operation_id]
+            if not queue.operations and queue.fenced:
+                self.queues.pop(op.tenant, None)
+
+    # ------------------------------ fencing ------------------------------
+
+    def fence(self, name: str, registration_id: str) -> list[str]:
+        """Terminal-fail every open operation of a dead registration and
+        refuse new ones. Terminal records stay retrievable until acked."""
+        queue = self.queues.get((name, registration_id))
+        if queue is None or queue.fenced:
+            return []
+        queue.fenced = True
+        failed = []
+        for op in queue.operations:
+            if not op.terminal:
+                op.state = OperationState.FAILED
+                op.error = "registration retired before the operation ran"
+                op.error_category = "user"
+                failed.append(op.operation_id)
+        return failed
+
+    def queue_view(self, name: str, registration_id: str) -> list[dict]:
+        queue = self.queues.get((name, registration_id))
+        return [op.view() for op in queue.operations] if queue is not None else []

--- a/miles/ray/multi_lora/operations.py
+++ b/miles/ray/multi_lora/operations.py
@@ -1,4 +1,4 @@
-"""Per-registration operation ledger for external (client-driven) adapters.
+"""Per-registration operation ledger for thinker (client-driven) adapters.
 
 Clients push protocol-neutral operations; data-bearing kinds ride the rollout
 selection path through the queue child rollout fn, data-less kinds execute in

--- a/miles/ray/multi_lora/operations.py
+++ b/miles/ray/multi_lora/operations.py
@@ -13,7 +13,6 @@ methods are synchronous and atomic by construction.
 import logging
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -189,7 +188,9 @@ class OperationLedger:
                 tenants.append(tenant)
         return tenants
 
-    def claim_control_operation(self, name: str, registration_id: str, kinds: tuple[str, ...] | None = None) -> dict | None:
+    def claim_control_operation(
+        self, name: str, registration_id: str, kinds: tuple[str, ...] | None = None
+    ) -> dict | None:
         """Claim the next open operation when it is a control kind (optionally
         restricted to ``kinds`` — heads of other kinds stay queued so a later
         executor can pick them up without losing their turn)."""

--- a/miles/ray/multi_lora/registry.py
+++ b/miles/ray/multi_lora/registry.py
@@ -250,6 +250,40 @@ class AdapterRegistry:
             self.deregister(name)
         return stepped
 
+    # ---------------- external operations ----------------
+
+    def mark_accumulated(self, names: list[str]) -> None:
+        """An external forward_backward landed: the slot holds unstepped
+        gradients, which no sidecar carries — pin it against eviction until an
+        optim_step consumes them (or a veto clears them)."""
+        for name in names:
+            record = self.find(name)
+            if record is not None:
+                self.slot_pool.pin(record.tenant, "dirty-grads")
+
+    def clear_dirty(self, name: str) -> None:
+        record = self.find(name)
+        if record is not None:
+            self.slot_pool.unpin(record.tenant, "dirty-grads")
+
+    def commit_external_step(self, name: str) -> int:
+        """One external optim_step applied: advance the step clock (num_step
+        remains an optional client-set bound) without scheduling any publish —
+        external weights reach the engines only via an explicit snapshot."""
+        record = self.find(name)
+        if record is None:
+            return -1
+        record.step += 1
+        self.slot_pool.unpin(record.tenant, "dirty-grads")
+        if (
+            getattr(record.config, "num_step", None) is not None
+            and record.state is AdapterState.ACTIVE
+            and (record.step - record.start_step) >= record.config.num_step
+        ):
+            logger.info(f"External adapter '{name}' reached num_step={record.config.num_step}, deregistering")
+            self.deregister(name)
+        return record.step
+
     def resolve_num_step(self, name: str, dataset_rows: int) -> None:
         """Derive num_step from num_epoch once the data source knows the
         post-filter dataset length. No-op when num_step was set explicitly."""

--- a/miles/ray/multi_lora/registry.py
+++ b/miles/ray/multi_lora/registry.py
@@ -250,10 +250,10 @@ class AdapterRegistry:
             self.deregister(name)
         return stepped
 
-    # ---------------- external operations ----------------
+    # ---------------- thinker operations ----------------
 
     def mark_accumulated(self, names: list[str]) -> None:
-        """An external forward_backward landed: the slot holds unstepped
+        """A thinker forward_backward landed: the slot holds unstepped
         gradients, which no sidecar carries — pin it against eviction until an
         optim_step consumes them (or a veto clears them)."""
         for name in names:
@@ -266,10 +266,10 @@ class AdapterRegistry:
         if record is not None:
             self.slot_pool.unpin(record.tenant, "dirty-grads")
 
-    def commit_external_step(self, name: str) -> int:
-        """One external optim_step applied: advance the step clock (num_step
+    def commit_thinker_step(self, name: str) -> int:
+        """One thinker optim_step applied: advance the step clock (num_step
         remains an optional client-set bound) without scheduling any publish —
-        external weights reach the engines only via an explicit snapshot."""
+        thinker weights reach the engines only via an explicit snapshot."""
         record = self.find(name)
         if record is None:
             return -1
@@ -280,7 +280,7 @@ class AdapterRegistry:
             and record.state is AdapterState.ACTIVE
             and (record.step - record.start_step) >= record.config.num_step
         ):
-            logger.info(f"External adapter '{name}' reached num_step={record.config.num_step}, deregistering")
+            logger.info(f"Thinker adapter '{name}' reached num_step={record.config.num_step}, deregistering")
             self.deregister(name)
         return record.step
 

--- a/miles/ray/rollout/rollout_manager.py
+++ b/miles/ray/rollout/rollout_manager.py
@@ -17,6 +17,7 @@ from miles.ray.rollout.router_manager import start_session_server
 from miles.ray.rollout.server_cell import get_cell_indexer_of_id_map
 from miles.ray.rollout.train_data_conversion import (
     ROLLOUT_DATA_VALUE_SPEC,
+    batch_plan_to_metadata,
     convert_samples_to_train_data,
     split_train_data_by_dp,
 )
@@ -156,14 +157,7 @@ class RolloutManager:
         log_rollout_data(rollout_id, self.args, data, metrics, time.time() - start_time)
         if batch_plan := control_metadata.get("batch_plan"):
             # The BatchPlan is authoritative for step decisions.
-            metadata["step_slots"] = sorted(entry["bound_slot"] for entry in batch_plan)
-            metadata["step_adapter_names"] = sorted(entry["name"] for entry in batch_plan)
-            # Normalization counts rollout executions (matching the loss), so K
-            # sibling trajectories from one execution count once.
-            metadata["step_adapter_actual_counts"] = {
-                entry["bound_slot"]: entry["actual_rollout_count"] for entry in batch_plan
-            }
-            metadata["adapter_name_by_slot"] = {entry["bound_slot"]: entry["name"] for entry in batch_plan}
+            metadata.update(batch_plan_to_metadata(batch_plan))
         data = convert_samples_to_train_data(
             self.args,
             data,

--- a/miles/ray/rollout/train_data_conversion.py
+++ b/miles/ray/rollout/train_data_conversion.py
@@ -21,6 +21,10 @@ ROLLOUT_DATA_TENSOR_DTYPES = {
     "opd_reverse_kl": "float32",
     "rollout_routed_experts": "int32",
     "rollout_indexer_topk": "int32",
+    # Client-supplied per-token channels (external adapters); the binary
+    # loss_masks stay int32, these carry the float semantics.
+    "loss_weights": "float32",
+    "advantages": "float32",
 }
 
 ROLLOUT_DATA_VALUE_SPEC: dict[str, ValueSpec] = {
@@ -47,6 +51,30 @@ ROLLOUT_DATA_VALUE_SPEC: dict[str, ValueSpec] = {
 }
 
 
+def batch_plan_to_metadata(batch_plan: list[dict]) -> dict[str, Any]:
+    """Distill one selection's BatchPlan into conversion metadata. The plan is
+    authoritative for step decisions: accumulate-only entries (external
+    forward_backward) stay out of every step_* field but keep their
+    adapter_name_by_slot row, which token routing needs."""
+    stepping = [entry for entry in batch_plan if entry.get("step_after_backward", True)]
+    metadata: dict[str, Any] = {
+        "step_slots": sorted(entry["bound_slot"] for entry in stepping),
+        "step_adapter_names": sorted(entry["name"] for entry in stepping),
+        # Normalization counts rollout executions (matching the loss), so K
+        # sibling trajectories from one execution count once.
+        "step_adapter_actual_counts": {entry["bound_slot"]: entry["actual_rollout_count"] for entry in stepping},
+        "adapter_name_by_slot": {entry["bound_slot"]: entry["name"] for entry in batch_plan},
+    }
+    kinds = {entry.get("operation_kind", "native_train") for entry in batch_plan}
+    # One selection is one kind: reward/advantage post-processing and loss
+    # dispatch gate per train call (the selection enforces this upstream).
+    assert len(kinds) == 1, f"selection mixes operation kinds {sorted(kinds)}"
+    if "native_train" not in kinds:
+        metadata["batch_kind"] = "external"
+        metadata["adapter_loss_by_slot"] = {entry["bound_slot"]: entry.get("loss_spec") or {} for entry in batch_plan}
+    return metadata
+
+
 def convert_samples_to_train_data(
     args,
     samples: list[Sample] | list[list[Sample]],
@@ -60,12 +88,18 @@ def convert_samples_to_train_data(
     if (f := custom_convert_samples_to_train_data_func) is not None:
         return f(args, samples)
 
-    raw_rewards, rewards = _post_process_rewards(
-        args,
-        samples,
-        custom_reward_post_process_func=custom_reward_post_process_func,
-        prompt_group_sizes=metadata.get("prompt_group_sizes"),
-    )
+    external = metadata.get("batch_kind") == "external"
+    if external:
+        # External batches carry no rewards: losses come from client-supplied
+        # per-token channels, never from reward post-processing.
+        raw_rewards = rewards = [0.0] * len(samples)
+    else:
+        raw_rewards, rewards = _post_process_rewards(
+            args,
+            samples,
+            custom_reward_post_process_func=custom_reward_post_process_func,
+            prompt_group_sizes=metadata.get("prompt_group_sizes"),
+        )
 
     assert len(raw_rewards) == len(samples)
     assert len(rewards) == len(samples)
@@ -130,6 +164,20 @@ def convert_samples_to_train_data(
     if samples[0].teacher_log_probs is not None:
         train_data["teacher_log_probs"] = [sample.teacher_log_probs for sample in samples]
 
+    # Client-supplied per-token channels (external adapters). Absent tensors
+    # default to no-ops so one batch may mix CE (weights) and IS/PPO
+    # (advantages) samples across adapters.
+    if any(sample.loss_weights is not None for sample in samples):
+        train_data["loss_weights"] = [
+            sample.loss_weights if sample.loss_weights is not None else [0.0] * sample.response_length
+            for sample in samples
+        ]
+    if any(sample.advantages is not None for sample in samples):
+        train_data["advantages"] = [
+            sample.advantages if sample.advantages is not None else [0.0] * sample.response_length
+            for sample in samples
+        ]
+
     if any(sample.adapter is not None for sample in samples):
         assert all(sample.adapter is not None for sample in samples), "Cannot mix adapter and adapter-less samples"
         # The bind plan is authoritative for slot routing; a stamped slot can
@@ -148,6 +196,10 @@ def convert_samples_to_train_data(
             train_data["step_adapter_actual_counts"] = actual_counts
         if (name_by_slot := metadata.get("adapter_name_by_slot")) is not None:
             train_data["adapter_name_by_slot"] = name_by_slot
+        if (loss_by_slot := metadata.get("adapter_loss_by_slot")) is not None:
+            train_data["adapter_loss_by_slot"] = loss_by_slot
+        if metadata.get("batch_kind") is not None:
+            train_data["batch_kind"] = metadata["batch_kind"]
 
     if (prompt_group_sizes := metadata.get("prompt_group_sizes")) is not None:
         train_data["prompt_group_sizes"] = prompt_group_sizes
@@ -323,6 +375,8 @@ def _package_shards(args, data: dict[str, Any], partitions) -> list[dict[str, An
             "prompt",
             "teacher_log_probs",
             "opd_reverse_kl",
+            "loss_weights",
+            "advantages",
             "seq_witness_ids",
             "weight_versions",
             "adapter_slots",
@@ -340,6 +394,8 @@ def _package_shards(args, data: dict[str, Any], partitions) -> list[dict[str, An
             "step_adapter_names",
             "step_adapter_actual_counts",
             "adapter_name_by_slot",
+            "adapter_loss_by_slot",
+            "batch_kind",
             "prompt_group_sizes",
         ]:
             if key not in data:

--- a/miles/ray/rollout/train_data_conversion.py
+++ b/miles/ray/rollout/train_data_conversion.py
@@ -66,14 +66,22 @@ def batch_plan_to_metadata(batch_plan: list[dict]) -> dict[str, Any]:
         "adapter_name_by_slot": {entry["bound_slot"]: entry["name"] for entry in batch_plan},
     }
     kinds = {entry.get("operation_kind", "multi_lora_train") for entry in batch_plan}
-    # One selection is one kind: reward/advantage post-processing and loss
-    # dispatch gate per train call (the selection enforces this upstream).
-    assert len(kinds) == 1, f"selection mixes operation kinds {sorted(kinds)}"
+    # One selection is one input mode: reward/advantage post-processing and
+    # loss dispatch gate per train call (the selection enforces this upstream).
+    # Within thinker mode, forward and forward_backward operations may share a
+    # selection — forward slots just contribute no loss term.
+    assert kinds == {"multi_lora_train"} or kinds <= {
+        "forward_backward",
+        "forward",
+    }, f"selection mixes input modes: {sorted(kinds)}"
     if "multi_lora_train" not in kinds:
         metadata["batch_kind"] = "thinker"
         metadata["adapter_loss_by_slot"] = {entry["bound_slot"]: entry.get("loss_spec") or {} for entry in batch_plan}
         # The trainer completes these operations after the batch lands.
         metadata["operation_by_slot"] = {entry["bound_slot"]: entry["operation_id"] for entry in batch_plan}
+        metadata["forward_only_slots"] = sorted(
+            entry["bound_slot"] for entry in batch_plan if entry.get("operation_kind") == "forward"
+        )
     return metadata
 
 
@@ -202,6 +210,8 @@ def convert_samples_to_train_data(
             train_data["adapter_loss_by_slot"] = loss_by_slot
         if (operation_by_slot := metadata.get("operation_by_slot")) is not None:
             train_data["operation_by_slot"] = operation_by_slot
+        if (forward_only_slots := metadata.get("forward_only_slots")) is not None:
+            train_data["forward_only_slots"] = forward_only_slots
         if metadata.get("batch_kind") is not None:
             train_data["batch_kind"] = metadata["batch_kind"]
 
@@ -400,6 +410,7 @@ def _package_shards(args, data: dict[str, Any], partitions) -> list[dict[str, An
             "adapter_name_by_slot",
             "adapter_loss_by_slot",
             "operation_by_slot",
+            "forward_only_slots",
             "batch_kind",
             "prompt_group_sizes",
         ]:

--- a/miles/ray/rollout/train_data_conversion.py
+++ b/miles/ray/rollout/train_data_conversion.py
@@ -21,7 +21,7 @@ ROLLOUT_DATA_TENSOR_DTYPES = {
     "opd_reverse_kl": "float32",
     "rollout_routed_experts": "int32",
     "rollout_indexer_topk": "int32",
-    # Client-supplied per-token channels (external adapters); the binary
+    # Client-supplied per-token channels (thinker adapters); the binary
     # loss_masks stay int32, these carry the float semantics.
     "loss_weights": "float32",
     "advantages": "float32",
@@ -53,7 +53,7 @@ ROLLOUT_DATA_VALUE_SPEC: dict[str, ValueSpec] = {
 
 def batch_plan_to_metadata(batch_plan: list[dict]) -> dict[str, Any]:
     """Distill one selection's BatchPlan into conversion metadata. The plan is
-    authoritative for step decisions: accumulate-only entries (external
+    authoritative for step decisions: accumulate-only entries (thinker
     forward_backward) stay out of every step_* field but keep their
     adapter_name_by_slot row, which token routing needs."""
     stepping = [entry for entry in batch_plan if entry.get("step_after_backward", True)]
@@ -65,12 +65,12 @@ def batch_plan_to_metadata(batch_plan: list[dict]) -> dict[str, Any]:
         "step_adapter_actual_counts": {entry["bound_slot"]: entry["actual_rollout_count"] for entry in stepping},
         "adapter_name_by_slot": {entry["bound_slot"]: entry["name"] for entry in batch_plan},
     }
-    kinds = {entry.get("operation_kind", "native_train") for entry in batch_plan}
+    kinds = {entry.get("operation_kind", "multi_lora_train") for entry in batch_plan}
     # One selection is one kind: reward/advantage post-processing and loss
     # dispatch gate per train call (the selection enforces this upstream).
     assert len(kinds) == 1, f"selection mixes operation kinds {sorted(kinds)}"
-    if "native_train" not in kinds:
-        metadata["batch_kind"] = "external"
+    if "multi_lora_train" not in kinds:
+        metadata["batch_kind"] = "thinker"
         metadata["adapter_loss_by_slot"] = {entry["bound_slot"]: entry.get("loss_spec") or {} for entry in batch_plan}
         # The trainer completes these operations after the batch lands.
         metadata["operation_by_slot"] = {entry["bound_slot"]: entry["operation_id"] for entry in batch_plan}
@@ -90,9 +90,9 @@ def convert_samples_to_train_data(
     if (f := custom_convert_samples_to_train_data_func) is not None:
         return f(args, samples)
 
-    external = metadata.get("batch_kind") == "external"
-    if external:
-        # External batches carry no rewards: losses come from client-supplied
+    thinker = metadata.get("batch_kind") == "thinker"
+    if thinker:
+        # Thinker batches carry no rewards: losses come from client-supplied
         # per-token channels, never from reward post-processing.
         raw_rewards = rewards = [0.0] * len(samples)
     else:
@@ -166,7 +166,7 @@ def convert_samples_to_train_data(
     if samples[0].teacher_log_probs is not None:
         train_data["teacher_log_probs"] = [sample.teacher_log_probs for sample in samples]
 
-    # Client-supplied per-token channels (external adapters). Absent tensors
+    # Client-supplied per-token channels (thinker adapters). Absent tensors
     # default to no-ops so one batch may mix CE (weights) and IS/PPO
     # (advantages) samples across adapters.
     if any(sample.loss_weights is not None for sample in samples):

--- a/miles/ray/rollout/train_data_conversion.py
+++ b/miles/ray/rollout/train_data_conversion.py
@@ -72,6 +72,8 @@ def batch_plan_to_metadata(batch_plan: list[dict]) -> dict[str, Any]:
     if "native_train" not in kinds:
         metadata["batch_kind"] = "external"
         metadata["adapter_loss_by_slot"] = {entry["bound_slot"]: entry.get("loss_spec") or {} for entry in batch_plan}
+        # The trainer completes these operations after the batch lands.
+        metadata["operation_by_slot"] = {entry["bound_slot"]: entry["operation_id"] for entry in batch_plan}
     return metadata
 
 
@@ -198,6 +200,8 @@ def convert_samples_to_train_data(
             train_data["adapter_name_by_slot"] = name_by_slot
         if (loss_by_slot := metadata.get("adapter_loss_by_slot")) is not None:
             train_data["adapter_loss_by_slot"] = loss_by_slot
+        if (operation_by_slot := metadata.get("operation_by_slot")) is not None:
+            train_data["operation_by_slot"] = operation_by_slot
         if metadata.get("batch_kind") is not None:
             train_data["batch_kind"] = metadata["batch_kind"]
 
@@ -395,6 +399,7 @@ def _package_shards(args, data: dict[str, Any], partitions) -> list[dict[str, An
             "step_adapter_actual_counts",
             "adapter_name_by_slot",
             "adapter_loss_by_slot",
+            "operation_by_slot",
             "batch_kind",
             "prompt_group_sizes",
         ]:

--- a/miles/rollout/generate_utils/sample_utils.py
+++ b/miles/rollout/generate_utils/sample_utils.py
@@ -160,6 +160,10 @@ def _merge_sample_pair(a: Sample, b: Sample, tokenizer) -> Sample:
             rollout_log_probs=a.rollout_log_probs + [0.0] * obs_len + b.rollout_log_probs,
             teacher_log_probs=_merge_optional_per_token("teacher_log_probs"),
             opd_reverse_kl=_merge_optional_per_token("opd_reverse_kl"),
+            # External per-token channels: response-aligned like the OPD lists;
+            # zero weight/advantage over the injected observation span.
+            loss_weights=_merge_optional_per_token("loss_weights"),
+            advantages=_merge_optional_per_token("advantages"),
             rollout_routed_experts=b.rollout_routed_experts,
             rollout_indexer_topk=b.rollout_indexer_topk,
             remove_sample=_merge_equal_value("remove_sample"),

--- a/miles/rollout/generate_utils/sample_utils.py
+++ b/miles/rollout/generate_utils/sample_utils.py
@@ -160,7 +160,7 @@ def _merge_sample_pair(a: Sample, b: Sample, tokenizer) -> Sample:
             rollout_log_probs=a.rollout_log_probs + [0.0] * obs_len + b.rollout_log_probs,
             teacher_log_probs=_merge_optional_per_token("teacher_log_probs"),
             opd_reverse_kl=_merge_optional_per_token("opd_reverse_kl"),
-            # External per-token channels: response-aligned like the OPD lists;
+            # Thinker per-token channels: response-aligned like the OPD lists;
             # zero weight/advantage over the injected observation span.
             loss_weights=_merge_optional_per_token("loss_weights"),
             advantages=_merge_optional_per_token("advantages"),

--- a/miles/rollout/multi_lora/queue_rollout_fn.py
+++ b/miles/rollout/multi_lora/queue_rollout_fn.py
@@ -100,9 +100,12 @@ class QueueChildRolloutFn:
         if not raw_samples:
             raise ValueError("forward_backward payload carries no samples")
         groups: list[list[Sample]] = []
-        for raw in raw_samples:
+        for i, raw in enumerate(raw_samples):
             raw = dict(raw)
             raw.setdefault("status", Sample.Status.COMPLETED.value)
+            # Row identity within the operation: the result plane returns
+            # per-datum logprobs in this order.
+            raw.setdefault("index", i)
             groups.append([Sample.from_dict(raw)])
         return RolloutFnTrainOutput(
             samples=self.source.stamp(groups),

--- a/miles/rollout/multi_lora/queue_rollout_fn.py
+++ b/miles/rollout/multi_lora/queue_rollout_fn.py
@@ -61,9 +61,9 @@ class QueueChildRolloutFn:
     runtime simply stays IN_FLIGHT and other adapters keep training."""
 
     def __init__(self, input: RolloutFnConstructorInput):
-        assert isinstance(input.data_source, ExternalOperationSource), (
-            "QueueChildRolloutFn serves external adapters; dataset adapters use a dataset child rollout fn"
-        )
+        assert isinstance(
+            input.data_source, ExternalOperationSource
+        ), "QueueChildRolloutFn serves external adapters; dataset adapters use a dataset child rollout fn"
         self.source: ExternalOperationSource = input.data_source
 
     async def __call__(self, input: RolloutFnTrainInput) -> RolloutFnTrainOutput:

--- a/miles/rollout/multi_lora/queue_rollout_fn.py
+++ b/miles/rollout/multi_lora/queue_rollout_fn.py
@@ -1,4 +1,4 @@
-"""Built-in child rollout fn for external adapters: one claimed
+"""Built-in child rollout fn for thinker adapters: one claimed
 forward_backward operation becomes one complete child batch. The child knows
 nothing about slots or serving aliases — like any child it just returns
 stamped samples; the operation directives ride ``RolloutFnTrainOutput.metadata``
@@ -20,8 +20,8 @@ logger = logging.getLogger(__name__)
 _CLAIM_POLL_S = 0.5
 
 
-class ExternalOperationSource:
-    """Per-registration stand-in for ``_AdapterDataSource``: external
+class ThinkerOperationSource:
+    """Per-registration stand-in for ``_AdapterDataSource``: thinker
     adapters have no dataset, so this only carries the child args and the
     current run view used for stamping serving identity."""
 
@@ -62,9 +62,9 @@ class QueueChildRolloutFn:
 
     def __init__(self, input: RolloutFnConstructorInput):
         assert isinstance(
-            input.data_source, ExternalOperationSource
-        ), "QueueChildRolloutFn serves external adapters; dataset adapters use a dataset child rollout fn"
-        self.source: ExternalOperationSource = input.data_source
+            input.data_source, ThinkerOperationSource
+        ), "QueueChildRolloutFn serves thinker adapters; dataset adapters use a dataset child rollout fn"
+        self.source: ThinkerOperationSource = input.data_source
 
     async def __call__(self, input: RolloutFnTrainInput) -> RolloutFnTrainOutput:
         from miles.ray.multi_lora.controller import get_multi_lora_controller

--- a/miles/rollout/multi_lora/queue_rollout_fn.py
+++ b/miles/rollout/multi_lora/queue_rollout_fn.py
@@ -91,14 +91,14 @@ class QueueChildRolloutFn:
                 )
 
     def _batch_from_operation(self, operation: dict) -> RolloutFnTrainOutput:
-        if operation["kind"] != "forward_backward":
-            # FORWARD executes through the forward-only trainer verb (B9); fail
-            # instead of silently training it as a backward pass.
+        # forward rides the same batch path as forward_backward; its samples
+        # contribute no loss term (zero gradients) and only return logprobs.
+        if operation["kind"] not in ("forward_backward", "forward"):
             raise ValueError(f"operation kind '{operation['kind']}' is not executable yet")
         payload = operation.get("payload") or {}
         raw_samples = payload.get("samples")
         if not raw_samples:
-            raise ValueError("forward_backward payload carries no samples")
+            raise ValueError(f"{operation['kind']} payload carries no samples")
         groups: list[list[Sample]] = []
         for i, raw in enumerate(raw_samples):
             raw = dict(raw)

--- a/miles/rollout/multi_lora/queue_rollout_fn.py
+++ b/miles/rollout/multi_lora/queue_rollout_fn.py
@@ -1,0 +1,116 @@
+"""Built-in child rollout fn for external adapters: one claimed
+forward_backward operation becomes one complete child batch. The child knows
+nothing about slots or serving aliases — like any child it just returns
+stamped samples; the operation directives ride ``RolloutFnTrainOutput.metadata``
+into the BatchPlan.
+"""
+
+import asyncio
+import copy
+import logging
+
+import ray
+
+from miles.rollout.base_types import RolloutFnConstructorInput, RolloutFnTrainInput, RolloutFnTrainOutput
+from miles.utils.adapter_config import AdapterRun
+from miles.utils.types import AdapterRef, Sample
+
+logger = logging.getLogger(__name__)
+
+_CLAIM_POLL_S = 0.5
+
+
+class ExternalOperationSource:
+    """Per-registration stand-in for ``_AdapterDataSource``: external
+    adapters have no dataset, so this only carries the child args and the
+    current run view used for stamping serving identity."""
+
+    def __init__(self, args, run: AdapterRun):
+        child_args = copy.copy(args)
+        child_args.multi_lora_adapter_identity = (run.name, run.registration_id)
+        self.args = child_args
+        self.run = run
+
+    def refresh(self, run: AdapterRun) -> None:
+        self.run = run
+
+    def stamp(self, groups: list[list[Sample]]) -> list[list[Sample]]:
+        run = self.run
+        ref = AdapterRef(
+            name=run.name,
+            registration_id=run.registration_id,
+            serving_version=run.version,
+            slot=run.slot,
+        )
+        for group in groups:
+            for sample in group:
+                sample.adapter = ref
+                sample.metadata = {**run.config.metadata, **sample.metadata}
+        return groups
+
+    def save(self, rollout_id) -> None:
+        pass
+
+    def load(self, rollout_id=None) -> None:
+        pass
+
+
+class QueueChildRolloutFn:
+    """Awaits the registration's next data-bearing operation and returns it as
+    one complete batch. Blocking while the client queue is idle is normal: the
+    runtime simply stays IN_FLIGHT and other adapters keep training."""
+
+    def __init__(self, input: RolloutFnConstructorInput):
+        assert isinstance(input.data_source, ExternalOperationSource), (
+            "QueueChildRolloutFn serves external adapters; dataset adapters use a dataset child rollout fn"
+        )
+        self.source: ExternalOperationSource = input.data_source
+
+    async def __call__(self, input: RolloutFnTrainInput) -> RolloutFnTrainOutput:
+        from miles.ray.multi_lora.controller import get_multi_lora_controller
+
+        name, registration_id = self.source.run.name, self.source.run.registration_id
+        while True:
+            operation = await asyncio.to_thread(
+                ray.get, get_multi_lora_controller().claim_data_operation.remote(name, registration_id)
+            )
+            if operation is None:
+                await asyncio.sleep(_CLAIM_POLL_S)
+                continue
+            try:
+                return self._batch_from_operation(operation)
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:  # noqa: BLE001 - a bad payload fails its op, not the adapter
+                logger.exception(f"[multilora] ({name}) operation '{operation['operation_id']}' rejected: {e}")
+                await asyncio.to_thread(
+                    ray.get,
+                    get_multi_lora_controller().fail_operation.remote(
+                        operation["operation_id"], f"invalid operation payload: {e}", "user"
+                    ),
+                )
+
+    def _batch_from_operation(self, operation: dict) -> RolloutFnTrainOutput:
+        if operation["kind"] != "forward_backward":
+            # FORWARD executes through the forward-only trainer verb (B9); fail
+            # instead of silently training it as a backward pass.
+            raise ValueError(f"operation kind '{operation['kind']}' is not executable yet")
+        payload = operation.get("payload") or {}
+        raw_samples = payload.get("samples")
+        if not raw_samples:
+            raise ValueError("forward_backward payload carries no samples")
+        groups: list[list[Sample]] = []
+        for raw in raw_samples:
+            raw = dict(raw)
+            raw.setdefault("status", Sample.Status.COMPLETED.value)
+            groups.append([Sample.from_dict(raw)])
+        return RolloutFnTrainOutput(
+            samples=self.source.stamp(groups),
+            metadata=dict(
+                operation_id=operation["operation_id"],
+                operation_kind=operation["kind"],
+                batch_id=payload.get("batch_id"),
+                step_after_backward=False,
+                loss_spec=payload.get("loss"),
+            ),
+        )

--- a/miles/rollout/multi_lora/rollout_fn.py
+++ b/miles/rollout/multi_lora/rollout_fn.py
@@ -32,6 +32,10 @@ DEFAULT_CHILD_ROLLOUT_PATH = "miles.rollout.inference_rollout.inference_rollout_
 Tenant = tuple[str, str]
 
 
+def _runtime_kind(runtime: "AdapterRolloutRuntime") -> str:
+    return getattr(runtime.run.config, "input_mode", "dataset") or "dataset"
+
+
 def leaf_sample_count(node) -> int:
     """Recursive leaf counter: multi-agent children may nest groups, so
     ``len(group)`` is not the sample count."""
@@ -329,9 +333,15 @@ class MultiLoRARolloutFn:
         collected = 0
         coalesce_deadline: float | None = None
 
+        selected_kind: str | None = None
         while True:
-            runtime = self._pop_next_ready()
+            runtime = self._pop_next_ready(kind=selected_kind)
             if runtime is not None:
+                # One selection = one kind: reward post-processing, advantage
+                # computation and loss dispatch all gate per train call, so an
+                # external batch must never share a selection with a dataset
+                # batch. Mismatched READY runtimes wait for the next selection.
+                selected_kind = _runtime_kind(runtime)
                 selected.append(runtime)
                 # Leave READY immediately or the round-robin would re-select
                 # the same batch until the target is met (duplicated samples).
@@ -368,14 +378,17 @@ class MultiLoRARolloutFn:
                 continue
         return selected
 
-    def _pop_next_ready(self) -> AdapterRolloutRuntime | None:
+    def _pop_next_ready(self, kind: str | None = None) -> AdapterRolloutRuntime | None:
         """Persistent round-robin over READY runtimes: the cursor survives
-        across selections so fast adapters cannot starve slow ones."""
+        across selections so fast adapters cannot starve slow ones. With a
+        kind, only matching runtimes qualify (selection kind partitioning)."""
         for _ in range(len(self.rotation)):
             tenant = self.rotation.popleft()
             self.rotation.append(tenant)
             runtime = self.runtimes.get(tenant)
             if runtime is not None and runtime.state == AdapterRolloutRuntime.READY:
+                if kind is not None and _runtime_kind(runtime) != kind:
+                    continue
                 return runtime
         return None
 

--- a/miles/rollout/multi_lora/rollout_fn.py
+++ b/miles/rollout/multi_lora/rollout_fn.py
@@ -142,11 +142,18 @@ class AdapterRolloutRuntime:
 
     def __init__(self, args, run: AdapterRun):
         self.run = run
-        self.data_source = _AdapterDataSource(args, run)
-        path = run.config.rollout_function_path or DEFAULT_CHILD_ROLLOUT_PATH
-        fn = load_function(path)
-        child_input = RolloutFnConstructorInput(args=self.data_source.args, data_source=self.data_source)
-        self.child_fn = fn(child_input) if inspect.isclass(fn) else fn
+        if getattr(run.config, "input_mode", "dataset") == "external":
+            from miles.rollout.multi_lora.queue_rollout_fn import ExternalOperationSource, QueueChildRolloutFn
+
+            self.data_source = ExternalOperationSource(args, run)
+            child_input = RolloutFnConstructorInput(args=self.data_source.args, data_source=self.data_source)
+            self.child_fn = QueueChildRolloutFn(child_input)
+        else:
+            self.data_source = _AdapterDataSource(args, run)
+            path = run.config.rollout_function_path or DEFAULT_CHILD_ROLLOUT_PATH
+            fn = load_function(path)
+            child_input = RolloutFnConstructorInput(args=self.data_source.args, data_source=self.data_source)
+            self.child_fn = fn(child_input) if inspect.isclass(fn) else fn
         self.state = self.IDLE
         self.ready_output: RolloutFnTrainOutput | None = None
         self.task: asyncio.Task | None = None
@@ -228,10 +235,13 @@ class MultiLoRARolloutFn:
                 continue
             runtime = AdapterRolloutRuntime(self.args, run)
             self.runtimes[tenant] = runtime
-            await asyncio.to_thread(
-                ray.get,
-                get_multi_lora_controller().resolve_num_step.remote(name, len(runtime.data_source.dataset)),
-            )
+            if getattr(run.config, "input_mode", "dataset") != "external":
+                # External runs have no dataset: num_step is client-set or
+                # unbounded, never derived from num_epoch x rows.
+                await asyncio.to_thread(
+                    ray.get,
+                    get_multi_lora_controller().resolve_num_step.remote(name, len(runtime.data_source.dataset)),
+                )
             logger.info(f"[multilora] created child runtime for '{name}' ({run.registration_id[:8]})")
         self._sync_rotation()
 
@@ -401,6 +411,9 @@ class MultiLoRARolloutFn:
             run = runtime.run
             data.extend(output.samples)
             plan_entry = plan_by_tenant[runtime.tenant]
+            # Operation directives from an external queue child; native
+            # dataset batches keep the fused step-after-backward behavior.
+            op_meta = output.metadata or {}
             batch_plan.append(
                 dict(
                     name=run.name,
@@ -410,6 +423,11 @@ class MultiLoRARolloutFn:
                     actual_sample_count=leaf_sample_count(output.samples),
                     actual_rollout_count=leaf_rollout_count(output.samples),
                     prompt_group_sizes=[leaf_sample_count([group]) for group in output.samples],
+                    operation_id=op_meta.get("operation_id"),
+                    operation_kind=op_meta.get("operation_kind", "native_train"),
+                    batch_id=op_meta.get("batch_id"),
+                    step_after_backward=op_meta.get("step_after_backward", True),
+                    loss_spec=op_meta.get("loss_spec"),
                 )
             )
             for key, value in (output.metrics or {}).items():
@@ -429,7 +447,9 @@ class MultiLoRARolloutFn:
                 metrics[f"{run.name}/rollout_reward_mean"] = reward_mean
                 logger.info(f"[multilora] ({run.name}) selected batch: n={len(rewards)} reward_mean={reward_mean:.4f}")
 
-        step_names = sorted(entry["name"] for entry in batch_plan)
+        # Accumulate-only batches (external forward_backward) are selections
+        # without a step: the registry books a step only for stepping entries.
+        step_names = sorted(entry["name"] for entry in batch_plan if entry["step_after_backward"])
         await asyncio.to_thread(
             ray.get,
             get_multi_lora_controller().record_train_selection.remote(rollout_id, step_names),

--- a/miles/rollout/multi_lora/rollout_fn.py
+++ b/miles/rollout/multi_lora/rollout_fn.py
@@ -147,7 +147,7 @@ class AdapterRolloutRuntime:
     def __init__(self, args, run: AdapterRun):
         self.run = run
         if getattr(run.config, "input_mode", "multi-lora") == "thinker":
-            from miles.rollout.multi_lora.queue_rollout_fn import ThinkerOperationSource, QueueChildRolloutFn
+            from miles.rollout.multi_lora.queue_rollout_fn import QueueChildRolloutFn, ThinkerOperationSource
 
             self.data_source = ThinkerOperationSource(args, run)
             child_input = RolloutFnConstructorInput(args=self.data_source.args, data_source=self.data_source)

--- a/miles/rollout/multi_lora/rollout_fn.py
+++ b/miles/rollout/multi_lora/rollout_fn.py
@@ -33,7 +33,7 @@ Tenant = tuple[str, str]
 
 
 def _runtime_kind(runtime: "AdapterRolloutRuntime") -> str:
-    return getattr(runtime.run.config, "input_mode", "dataset") or "dataset"
+    return getattr(runtime.run.config, "input_mode", "multi-lora") or "multi-lora"
 
 
 def leaf_sample_count(node) -> int:
@@ -146,10 +146,10 @@ class AdapterRolloutRuntime:
 
     def __init__(self, args, run: AdapterRun):
         self.run = run
-        if getattr(run.config, "input_mode", "dataset") == "external":
-            from miles.rollout.multi_lora.queue_rollout_fn import ExternalOperationSource, QueueChildRolloutFn
+        if getattr(run.config, "input_mode", "multi-lora") == "thinker":
+            from miles.rollout.multi_lora.queue_rollout_fn import ThinkerOperationSource, QueueChildRolloutFn
 
-            self.data_source = ExternalOperationSource(args, run)
+            self.data_source = ThinkerOperationSource(args, run)
             child_input = RolloutFnConstructorInput(args=self.data_source.args, data_source=self.data_source)
             self.child_fn = QueueChildRolloutFn(child_input)
         else:
@@ -239,8 +239,8 @@ class MultiLoRARolloutFn:
                 continue
             runtime = AdapterRolloutRuntime(self.args, run)
             self.runtimes[tenant] = runtime
-            if getattr(run.config, "input_mode", "dataset") != "external":
-                # External runs have no dataset: num_step is client-set or
+            if getattr(run.config, "input_mode", "multi-lora") != "thinker":
+                # Thinker runs have no dataset: num_step is client-set or
                 # unbounded, never derived from num_epoch x rows.
                 await asyncio.to_thread(
                     ray.get,
@@ -339,7 +339,7 @@ class MultiLoRARolloutFn:
             if runtime is not None:
                 # One selection = one kind: reward post-processing, advantage
                 # computation and loss dispatch all gate per train call, so an
-                # external batch must never share a selection with a dataset
+                # thinker batch must never share a selection with a dataset
                 # batch. Mismatched READY runtimes wait for the next selection.
                 selected_kind = _runtime_kind(runtime)
                 selected.append(runtime)
@@ -424,7 +424,7 @@ class MultiLoRARolloutFn:
             run = runtime.run
             data.extend(output.samples)
             plan_entry = plan_by_tenant[runtime.tenant]
-            # Operation directives from an external queue child; native
+            # Operation directives from a thinker queue child; multi-LoRA
             # dataset batches keep the fused step-after-backward behavior.
             op_meta = output.metadata or {}
             batch_plan.append(
@@ -437,7 +437,7 @@ class MultiLoRARolloutFn:
                     actual_rollout_count=leaf_rollout_count(output.samples),
                     prompt_group_sizes=[leaf_sample_count([group]) for group in output.samples],
                     operation_id=op_meta.get("operation_id"),
-                    operation_kind=op_meta.get("operation_kind", "native_train"),
+                    operation_kind=op_meta.get("operation_kind", "multi_lora_train"),
                     batch_id=op_meta.get("batch_id"),
                     step_after_backward=op_meta.get("step_after_backward", True),
                     loss_spec=op_meta.get("loss_spec"),
@@ -460,7 +460,7 @@ class MultiLoRARolloutFn:
                 metrics[f"{run.name}/rollout_reward_mean"] = reward_mean
                 logger.info(f"[multilora] ({run.name}) selected batch: n={len(rewards)} reward_mean={reward_mean:.4f}")
 
-        # Accumulate-only batches (external forward_backward) are selections
+        # Accumulate-only batches (thinker forward_backward) are selections
         # without a step: the registry books a step only for stepping entries.
         step_names = sorted(entry["name"] for entry in batch_plan if entry["step_after_backward"])
         await asyncio.to_thread(

--- a/miles/utils/adapter_config.py
+++ b/miles/utils/adapter_config.py
@@ -15,13 +15,13 @@ import yaml
 @dataclass(frozen=True)
 class AdapterRunConfig:
 
-    # Dataset path for input_mode="dataset"; must be None for "external".
+    # Dataset path for input_mode="multi-lora"; must be None for "thinker".
     data: str | None = None
 
-    # "dataset": the server generates and trains from `data` + a reward.
-    # "external": a client pushes token-level batches and optimizer operations
+    # "multi-lora": the server generates and trains from `data` + a reward.
+    # "thinker": a client pushes token-level batches and optimizer operations
     # through the controller's operation queue; no dataset, no reward.
-    input_mode: str = "dataset"
+    input_mode: str = "multi-lora"
 
     # resolves them to CLI defaults if None (--lora-rank / --lora-alpha) on register.
     rank: int | None = None
@@ -86,7 +86,7 @@ def parse_adapter_run_yaml(path: Path) -> AdapterRunConfig:
         rank=raw.get("rank"),
         alpha=raw.get("alpha"),
         data=raw.get("data"),
-        input_mode=raw.get("input_mode", "dataset"),
+        input_mode=raw.get("input_mode", "multi-lora"),
         rollout_batch_size=raw.get("rollout_batch_size"),
         n_samples_per_prompt=raw.get("n_samples_per_prompt"),
         save=Path(raw["save"]) if raw.get("save", None) else None,

--- a/miles/utils/adapter_config.py
+++ b/miles/utils/adapter_config.py
@@ -15,7 +15,13 @@ import yaml
 @dataclass(frozen=True)
 class AdapterRunConfig:
 
-    data: str
+    # Dataset path for input_mode="dataset"; must be None for "external".
+    data: str | None = None
+
+    # "dataset": the server generates and trains from `data` + a reward.
+    # "external": a client pushes token-level batches and optimizer operations
+    # through the controller's operation queue; no dataset, no reward.
+    input_mode: str = "dataset"
 
     # resolves them to CLI defaults if None (--lora-rank / --lora-alpha) on register.
     rank: int | None = None
@@ -79,7 +85,8 @@ def parse_adapter_run_yaml(path: Path) -> AdapterRunConfig:
     return AdapterRunConfig(
         rank=raw.get("rank"),
         alpha=raw.get("alpha"),
-        data=raw["data"],
+        data=raw.get("data"),
+        input_mode=raw.get("input_mode", "dataset"),
         rollout_batch_size=raw.get("rollout_batch_size"),
         n_samples_per_prompt=raw.get("n_samples_per_prompt"),
         save=Path(raw["save"]) if raw.get("save", None) else None,

--- a/miles/utils/types.py
+++ b/miles/utils/types.py
@@ -57,6 +57,11 @@ class Sample:
     remove_sample: bool = False
     teacher_log_probs: list[float] | None = None  # Log probabilities from teacher model for OPD
     opd_reverse_kl: list[float] | None = None  # Precomputed per-token OPD reverse-KL estimate
+    # Client-supplied per-token channels (external adapters): linear-CE
+    # coefficients and precomputed advantages, response-aligned like loss_mask.
+    # Distinct from the binary loss_mask — weights may be fractional or negative.
+    loss_weights: list[float] | None = None
+    advantages: list[float] | None = None
 
     class Status(Enum):
         PENDING = "pending"

--- a/miles/utils/types.py
+++ b/miles/utils/types.py
@@ -57,7 +57,7 @@ class Sample:
     remove_sample: bool = False
     teacher_log_probs: list[float] | None = None  # Log probabilities from teacher model for OPD
     opd_reverse_kl: list[float] | None = None  # Precomputed per-token OPD reverse-KL estimate
-    # Client-supplied per-token channels (external adapters): linear-CE
+    # Client-supplied per-token channels (thinker adapters): linear-CE
     # coefficients and precomputed advantages, response-aligned like loss_mask.
     # Distinct from the binary loss_mask — weights may be fractional or negative.
     loss_weights: list[float] | None = None

--- a/tests/fast/backends/megatron_utils/test_multi_lora_scheduler.py
+++ b/tests/fast/backends/megatron_utils/test_multi_lora_scheduler.py
@@ -121,3 +121,15 @@ def test_warmup_ramps_from_init_lr():
     assert slot_lr(optimizer, 0) == pytest.approx(LR / 2)  # mid-warmup
     step_n(optimizer, 0, 1)
     assert slot_lr(optimizer, 0) == pytest.approx(LR)  # warmed up
+
+
+def test_external_adapters_install_no_scheduler_and_step_skips_them():
+    from miles.utils.adapter_config import AdapterRun, AdapterRunConfig
+
+    optimizer = SimpleNamespace()  # deliberately no miles_slot_schedulers
+    adapter = AdapterRun(name="X", config=AdapterRunConfig(input_mode="external"), slot=3)
+    install_slot_scheduler(args=None, optimizer=optimizer, adapter=adapter, resume_step=0)
+    assert not hasattr(optimizer, "miles_slot_schedulers")
+    # Stepping an external slot (no scheduler installed) is a silent no-op,
+    # never a KeyError.
+    assert step_slot_schedulers(optimizer, [3]) == {}

--- a/tests/fast/backends/megatron_utils/test_multi_lora_scheduler.py
+++ b/tests/fast/backends/megatron_utils/test_multi_lora_scheduler.py
@@ -123,13 +123,13 @@ def test_warmup_ramps_from_init_lr():
     assert slot_lr(optimizer, 0) == pytest.approx(LR)  # warmed up
 
 
-def test_external_adapters_install_no_scheduler_and_step_skips_them():
+def test_thinker_adapters_install_no_scheduler_and_step_skips_them():
     from miles.utils.adapter_config import AdapterRun, AdapterRunConfig
 
     optimizer = SimpleNamespace()  # deliberately no miles_slot_schedulers
-    adapter = AdapterRun(name="X", config=AdapterRunConfig(input_mode="external"), slot=3)
+    adapter = AdapterRun(name="X", config=AdapterRunConfig(input_mode="thinker"), slot=3)
     install_slot_scheduler(args=None, optimizer=optimizer, adapter=adapter, resume_step=0)
     assert not hasattr(optimizer, "miles_slot_schedulers")
-    # Stepping an external slot (no scheduler installed) is a silent no-op,
+    # Stepping a thinker slot (no scheduler installed) is a silent no-op,
     # never a KeyError.
     assert step_slot_schedulers(optimizer, [3]) == {}

--- a/tests/fast/backends/training_utils/loss/test_external_loss.py
+++ b/tests/fast/backends/training_utils/loss/test_external_loss.py
@@ -1,0 +1,155 @@
+"""External per-slot loss dispatch: linear CE / importance sampling / PPO,
+sum-reduction (chunk-additive), per-sample slot routing, channel validation."""
+
+from tests.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=60, suite="stage-a-cpu")
+
+import pytest
+import torch
+
+from miles.backends.training_utils.loss_hub.logit_processors import get_log_probs_and_entropy
+from miles.backends.training_utils.loss_hub.losses import external_loss_function
+
+from .loss_test_utils import make_args, make_inputs, make_parallel_state
+
+VOCAB = 32
+
+
+def make_batch(seed=7, prompt_lens=(4, 6), response_lens=(3, 5)):
+    make_parallel_state()
+    args = make_args(loss_type="custom_loss")
+    inputs = make_inputs(
+        seed=seed,
+        batch_size=len(prompt_lens),
+        prompt_lens=list(prompt_lens),
+        response_lens=list(response_lens),
+        vocab_size=VOCAB,
+        args=args,
+    )
+    batch = dict(
+        unconcat_tokens=inputs["unconcat_tokens"],
+        total_lengths=inputs["total_lens"],
+        response_lengths=list(response_lens),
+        loss_masks=[torch.ones(rl, dtype=torch.int32) for rl in response_lens],
+        rollout_log_probs=inputs["rollout_log_probs"],
+        adapter_slots=[0] * len(prompt_lens),
+        adapter_loss_by_slot={0: {"loss_fn": "cross_entropy"}},
+    )
+    return args, batch, inputs["policy_logits"].requires_grad_(True)
+
+
+def reference_log_probs(args, batch, logits):
+    return get_log_probs_and_entropy(
+        logits,
+        args=args,
+        unconcat_tokens=batch["unconcat_tokens"],
+        total_lengths=batch["total_lengths"],
+        response_lengths=batch["response_lengths"],
+        with_entropy=False,
+        max_seq_lens=batch.get("max_seq_lens", None),
+    )["log_probs"]
+
+
+def run(args, batch, logits):
+    loss, metrics = external_loss_function(args, batch, logits, sum_of_sample_mean=None)
+    return loss, metrics
+
+
+def test_linear_cross_entropy_is_a_plain_weighted_sum():
+    args, batch, logits = make_batch()
+    weights = [torch.tensor([0.5, 0.0, 2.0]), torch.tensor([1.0, 1.0, 0.0, -1.0, 0.25])]
+    batch["loss_weights"] = weights
+
+    loss, metrics = run(args, batch, logits)
+    expected = sum(-(lp * w).sum() for lp, w in zip(reference_log_probs(args, batch, logits), weights, strict=True))
+    assert torch.allclose(loss, expected)
+    assert torch.allclose(metrics["loss"], expected)
+    assert loss.requires_grad
+
+
+def test_binary_mask_still_gates_tokens():
+    args, batch, logits = make_batch()
+    batch["loss_weights"] = [torch.ones(3), torch.ones(5)]
+    batch["loss_masks"] = [torch.tensor([1, 0, 1], dtype=torch.int32), torch.zeros(5, dtype=torch.int32)]
+
+    loss, _ = run(args, batch, logits)
+    lp = reference_log_probs(args, batch, logits)
+    expected = -(lp[0] * torch.tensor([1.0, 0.0, 1.0])).sum()
+    assert torch.allclose(loss, expected)
+
+
+def test_importance_sampling_and_ppo_clip():
+    args, batch, logits = make_batch()
+    advantages = [torch.tensor([1.0, -1.0, 2.0]), torch.tensor([0.5, 0.5, -0.5, 1.0, 0.0])]
+    batch["advantages"] = advantages
+    batch["adapter_loss_by_slot"] = {0: {"loss_fn": "importance_sampling"}}
+
+    loss, _ = run(args, batch, logits)
+    lp = reference_log_probs(args, batch, logits)
+    ratios = [torch.exp(l - o) for l, o in zip(lp, batch["rollout_log_probs"], strict=True)]
+    expected = sum(-(r * a).sum() for r, a in zip(ratios, advantages, strict=True))
+    assert torch.allclose(loss, expected)
+
+    batch["adapter_loss_by_slot"] = {0: {"loss_fn": "ppo", "loss_fn_config": {"clip_low_threshold": 0.9, "clip_high_threshold": 1.1}}}
+    loss_ppo, _ = run(args, batch, logits)
+    expected_ppo = sum(
+        -torch.minimum(r * a, r.clamp(0.9, 1.1) * a).sum() for r, a in zip(ratios, advantages, strict=True)
+    )
+    assert torch.allclose(loss_ppo, expected_ppo)
+    # Clipping binds somewhere, otherwise this test proves nothing.
+    assert not torch.allclose(loss_ppo, loss)
+
+
+def test_mixed_slots_dispatch_independently():
+    args, batch, logits = make_batch()
+    batch["adapter_slots"] = [0, 1]
+    batch["loss_weights"] = [torch.ones(3), torch.zeros(5)]
+    batch["advantages"] = [torch.zeros(3), torch.ones(5)]
+    batch["adapter_loss_by_slot"] = {
+        0: {"loss_fn": "cross_entropy"},
+        1: {"loss_fn": "importance_sampling"},
+    }
+
+    loss, _ = run(args, batch, logits)
+    lp = reference_log_probs(args, batch, logits)
+    ratio = torch.exp(lp[1] - batch["rollout_log_probs"][1])
+    expected = -(lp[0].sum()) + -(ratio.sum())
+    assert torch.allclose(loss, expected)
+
+
+def test_sum_reduction_is_chunk_additive():
+    # The same data as one batch vs two single-sample batches must produce the
+    # same total loss — the invariant that makes K forward_backward operations
+    # accumulate identically to one.
+    args, batch, logits = make_batch()
+    batch["loss_weights"] = [torch.ones(3) * 0.5, torch.ones(5) * 1.5]
+    full_loss, _ = run(args, batch, logits)
+
+    total = 0.0
+    offset = 0
+    for i, total_len in enumerate(batch["total_lengths"]):
+        sub_logits = logits[:, offset : offset + total_len]
+        sub = dict(
+            unconcat_tokens=[batch["unconcat_tokens"][i]],
+            total_lengths=[total_len],
+            response_lengths=[batch["response_lengths"][i]],
+            loss_masks=[batch["loss_masks"][i]],
+            loss_weights=[batch["loss_weights"][i]],
+            adapter_slots=[0],
+            adapter_loss_by_slot=batch["adapter_loss_by_slot"],
+        )
+        sub_loss, _ = run(args, sub, sub_logits)
+        total += sub_loss
+        offset += total_len
+    assert torch.allclose(full_loss, total)
+
+
+def test_missing_channel_and_unknown_loss_fail_loudly():
+    args, batch, logits = make_batch()
+    with pytest.raises(ValueError, match="needs per-token 'loss_weights'"):
+        run(args, batch, logits)
+
+    batch["adapter_loss_by_slot"] = {0: {"loss_fn": "dro"}}
+    with pytest.raises(ValueError, match="unknown loss_fn 'dro'"):
+        run(args, batch, logits)

--- a/tests/fast/backends/training_utils/loss/test_external_loss.py
+++ b/tests/fast/backends/training_utils/loss/test_external_loss.py
@@ -153,3 +153,17 @@ def test_missing_channel_and_unknown_loss_fail_loudly():
     batch["adapter_loss_by_slot"] = {0: {"loss_fn": "dro"}}
     with pytest.raises(ValueError, match="unknown loss_fn 'dro'"):
         run(args, batch, logits)
+
+
+def test_collector_captures_per_datum_logprobs_in_row_order():
+    args, batch, logits = make_batch()
+    batch["loss_weights"] = [torch.ones(3), torch.ones(5)]
+    batch["sample_indices"] = [0, 1]
+    collector: dict = {}
+    batch["external_logprob_collector"] = collector
+
+    run(args, batch, logits)
+    lp = reference_log_probs(args, batch, logits)
+    assert set(collector) == {(0, 0), (0, 1)}
+    assert collector[(0, 0)] == pytest.approx(lp[0].tolist())
+    assert collector[(0, 1)] == pytest.approx(lp[1].tolist())

--- a/tests/fast/backends/training_utils/loss/test_external_loss.py
+++ b/tests/fast/backends/training_utils/loss/test_external_loss.py
@@ -87,11 +87,13 @@ def test_importance_sampling_and_ppo_clip():
 
     loss, _ = run(args, batch, logits)
     lp = reference_log_probs(args, batch, logits)
-    ratios = [torch.exp(l - o) for l, o in zip(lp, batch["rollout_log_probs"], strict=True)]
+    ratios = [torch.exp(new - old) for new, old in zip(lp, batch["rollout_log_probs"], strict=True)]
     expected = sum(-(r * a).sum() for r, a in zip(ratios, advantages, strict=True))
     assert torch.allclose(loss, expected)
 
-    batch["adapter_loss_by_slot"] = {0: {"loss_fn": "ppo", "loss_fn_config": {"clip_low_threshold": 0.9, "clip_high_threshold": 1.1}}}
+    batch["adapter_loss_by_slot"] = {
+        0: {"loss_fn": "ppo", "loss_fn_config": {"clip_low_threshold": 0.9, "clip_high_threshold": 1.1}}
+    }
     loss_ppo, _ = run(args, batch, logits)
     expected_ppo = sum(
         -torch.minimum(r * a, r.clamp(0.9, 1.1) * a).sum() for r, a in zip(ratios, advantages, strict=True)

--- a/tests/fast/backends/training_utils/loss/test_thinker_loss.py
+++ b/tests/fast/backends/training_utils/loss/test_thinker_loss.py
@@ -169,3 +169,20 @@ def test_collector_captures_per_datum_logprobs_in_row_order():
     assert set(collector) == {(0, 0), (0, 1)}
     assert collector[(0, 0)] == pytest.approx(lp[0].tolist())
     assert collector[(0, 1)] == pytest.approx(lp[1].tolist())
+
+
+def test_forward_only_slots_collect_logprobs_without_a_loss_term():
+    args, batch, logits = make_batch()
+    batch["adapter_slots"] = [0, 1]
+    batch["loss_weights"] = [torch.ones(3), None]  # forward sample needs no channels
+    batch["adapter_loss_by_slot"] = {0: {"loss_fn": "cross_entropy"}, 1: {}}
+    batch["forward_only_slots"] = [1]
+    batch["sample_indices"] = [0, 0]
+    collector: dict = {}
+    batch["thinker_logprob_collector"] = collector
+
+    loss, _ = run(args, batch, logits)
+    lp = reference_log_probs(args, batch, logits)
+    # slot 1 contributed logprobs but no loss.
+    assert torch.allclose(loss, -(lp[0].sum()))
+    assert collector[(1, 0)] == pytest.approx(lp[1].tolist())

--- a/tests/fast/backends/training_utils/loss/test_thinker_loss.py
+++ b/tests/fast/backends/training_utils/loss/test_thinker_loss.py
@@ -1,4 +1,4 @@
-"""External per-slot loss dispatch: linear CE / importance sampling / PPO,
+"""Thinker per-slot loss dispatch: linear CE / importance sampling / PPO,
 sum-reduction (chunk-additive), per-sample slot routing, channel validation."""
 
 from tests.ci.ci_register import register_cpu_ci
@@ -9,7 +9,7 @@ import pytest
 import torch
 
 from miles.backends.training_utils.loss_hub.logit_processors import get_log_probs_and_entropy
-from miles.backends.training_utils.loss_hub.losses import external_loss_function
+from miles.backends.training_utils.loss_hub.losses import thinker_loss_function
 
 from .loss_test_utils import make_args, make_inputs, make_parallel_state
 
@@ -52,7 +52,7 @@ def reference_log_probs(args, batch, logits):
 
 
 def run(args, batch, logits):
-    loss, metrics = external_loss_function(args, batch, logits, sum_of_sample_mean=None)
+    loss, metrics = thinker_loss_function(args, batch, logits, sum_of_sample_mean=None)
     return loss, metrics
 
 
@@ -162,7 +162,7 @@ def test_collector_captures_per_datum_logprobs_in_row_order():
     batch["loss_weights"] = [torch.ones(3), torch.ones(5)]
     batch["sample_indices"] = [0, 1]
     collector: dict = {}
-    batch["external_logprob_collector"] = collector
+    batch["thinker_logprob_collector"] = collector
 
     run(args, batch, logits)
     lp = reference_log_probs(args, batch, logits)

--- a/tests/fast/ray/multi_lora/test_controller_http.py
+++ b/tests/fast/ray/multi_lora/test_controller_http.py
@@ -167,7 +167,7 @@ async def test_register_json_config_validates_to_adapter_config():
         assert Path(record.config.save) == Path("/tmp/adapters/A")
         assert record.config.input_key == "text"  # dataclass default
 
-        # 'data' is schema-optional (external mode has none) but mandatory for
+        # 'data' is schema-optional (thinker mode has none) but mandatory for
         # dataset mode, so the rejection is the backend's 400, not pydantic's 422.
         status, body = await ctl.api_post("/adapter_runs", {"name": "B", "config": {"rank": 8}})
         assert status == 400

--- a/tests/fast/ray/multi_lora/test_controller_http.py
+++ b/tests/fast/ray/multi_lora/test_controller_http.py
@@ -168,8 +168,11 @@ async def test_register_json_config_validates_to_adapter_config():
         assert Path(record.config.save) == Path("/tmp/adapters/A")
         assert record.config.input_key == "text"  # dataclass default
 
-        status, _ = await ctl.api_post("/adapter_runs", {"name": "B", "config": {"rank": 8}})
-        assert status == 422  # data is required
+        # 'data' is schema-optional (external mode has none) but mandatory for
+        # dataset mode, so the rejection is the backend's 400, not pydantic's 422.
+        status, body = await ctl.api_post("/adapter_runs", {"name": "B", "config": {"rank": 8}})
+        assert status == 400
+        assert "needs a dataset path" in body["detail"]
 
         status, _ = await ctl.api_post("/adapter_runs", {"name": "C"})
         assert status == 400  # exactly one of config/yaml_path

--- a/tests/fast/ray/multi_lora/test_controller_http.py
+++ b/tests/fast/ray/multi_lora/test_controller_http.py
@@ -19,7 +19,6 @@ from miles.ray.multi_lora.http_server import MultiLoRAHTTPServer
 from miles.utils.adapter_config import AdapterRunConfig
 from miles.utils.multi_lora import RID_SEPARATOR
 
-
 # Registration validates that the data path exists; the test file itself is a
 # convenient always-present stand-in.
 DATA_FILE = __file__

--- a/tests/fast/ray/multi_lora/test_external_registration.py
+++ b/tests/fast/ray/multi_lora/test_external_registration.py
@@ -110,3 +110,69 @@ class TestOperationRouting:
         assert view["state"] == "FAILED" and view["error_category"] == "user"
         with pytest.raises(ValueError, match="not accepting operations"):
             backend.enqueue_operation("X", "op2", 2, "forward_backward")
+
+
+class TestControlOperations:
+    def ready_backend(self, num_step=None):
+        backend = make_backend()
+        register_external(backend, num_step=num_step)
+        backend.registry.record_weight_update(["X"])  # PENDING -> ACTIVE
+        return backend
+
+    def test_claim_requires_active_and_serialization(self):
+        backend = self.ready_backend()
+        backend.enqueue_operation("X", "fb1", 1, "forward_backward", {"samples": [{}]})
+        backend.enqueue_operation("X", "opt1", 2, "optim_step", {"adam_params": {"learning_rate": 3e-4}})
+        # fb1 is still open: the optim_step must not be claimable.
+        assert backend.claim_ready_control_operations() == []
+        claimed = backend.operations.claim_data_operation("X", backend.registry.find("X").registration_id)
+        backend.operations.complete(claimed["operation_id"], None)
+        [op] = backend.claim_ready_control_operations()
+        assert op["operation_id"] == "opt1" and op["slot"] == backend.registry.find("X").slot
+
+    def test_unexecutable_kinds_keep_their_turn(self):
+        backend = self.ready_backend()
+        backend.enqueue_operation("X", "save1", 1, "save_state")
+        assert backend.claim_ready_control_operations() == []
+        assert backend.operations.get("save1")["state"] == "QUEUED"
+
+    def test_success_advances_step_and_releases_dirty_pin(self):
+        backend = self.ready_backend(num_step=2)
+        record = backend.registry.find("X")
+        backend.enqueue_operation("X", "opt1", 1, "optim_step")
+        backend.commit_external_batch(["X"], [])  # pin dirty
+        assert backend.registry.slot_pool.entry_of(record.tenant).pins == {"dirty-grads"}
+        [op] = backend.claim_ready_control_operations()
+        backend.complete_control_operations({op["operation_id"]: dict(ok=True, result={"grad_norm": 0.5})})
+        assert record.step == 1
+        assert backend.registry.slot_pool.entry_of(record.tenant).pins == set()
+        assert backend.operations.get("opt1")["result"] == {"grad_norm": 0.5}
+
+    def test_veto_fails_the_operation_and_clears_the_pin(self):
+        backend = self.ready_backend()
+        record = backend.registry.find("X")
+        backend.enqueue_operation("X", "opt1", 1, "optim_step")
+        backend.commit_external_batch(["X"], [])
+        [op] = backend.claim_ready_control_operations()
+        backend.complete_control_operations({op["operation_id"]: dict(ok=False, error="veto", category="server")})
+        assert record.step == 0  # no clock advance
+        assert backend.registry.slot_pool.entry_of(record.tenant).pins == set()
+        view = backend.operations.get("opt1")
+        assert view["state"] == "FAILED" and view["error_category"] == "server"
+
+    def test_num_step_bound_deregisters_after_the_last_step(self):
+        backend = self.ready_backend(num_step=1)
+        backend.enqueue_operation("X", "opt1", 1, "optim_step")
+        [op] = backend.claim_ready_control_operations()
+        backend.complete_control_operations({op["operation_id"]: dict(ok=True)})
+        from miles.ray.multi_lora.registry import AdapterState
+
+        assert backend.registry.records["X"].state is AdapterState.RETIRING
+
+    def test_commit_external_batch_completes_claimed_data_ops(self):
+        backend = self.ready_backend()
+        reg_id = backend.registry.find("X").registration_id
+        backend.enqueue_operation("X", "fb1", 1, "forward_backward", {"samples": [{}]})
+        backend.operations.claim_data_operation("X", reg_id)
+        backend.commit_external_batch(["X"], ["fb1"])
+        assert backend.operations.get("fb1")["state"] == "SUCCEEDED"

--- a/tests/fast/ray/multi_lora/test_external_registration.py
+++ b/tests/fast/ray/multi_lora/test_external_registration.py
@@ -176,3 +176,11 @@ class TestControlOperations:
         backend.operations.claim_data_operation("X", reg_id)
         backend.commit_external_batch(["X"], ["fb1"])
         assert backend.operations.get("fb1")["state"] == "SUCCEEDED"
+
+    def test_forward_backward_results_carry_row_ordered_logprobs(self):
+        backend = self.ready_backend()
+        reg_id = backend.registry.find("X").registration_id
+        backend.enqueue_operation("X", "fb1", 1, "forward_backward", {"samples": [{}, {}]})
+        backend.operations.claim_data_operation("X", reg_id)
+        backend.commit_external_batch(["X"], ["fb1"], {"fb1": [[-0.1, -0.2], [-0.3]]})
+        assert backend.operations.get("fb1")["result"] == {"logprobs": [[-0.1, -0.2], [-0.3]]}

--- a/tests/fast/ray/multi_lora/test_external_registration.py
+++ b/tests/fast/ray/multi_lora/test_external_registration.py
@@ -1,0 +1,112 @@
+"""External (client-driven) adapter registration and operation routing through
+MultiLoRABackend (no Ray, no HTTP I/O)."""
+
+from types import SimpleNamespace
+
+from tests.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=60, suite="stage-a-cpu")
+
+import asyncio
+
+import pytest
+
+from miles.ray.multi_lora.backend import MultiLoRABackend
+from miles.utils.adapter_config import AdapterRunConfig
+
+DATA_FILE = __file__
+
+
+def make_backend(max_adapters: int = 4) -> MultiLoRABackend:
+    args = SimpleNamespace(
+        multi_lora_n_adapters=max_adapters,
+        save="/tmp/miles-test-save",
+        lora_rank=32,
+        lora_alpha=32,
+        rollout_batch_size=16,
+        n_samples_per_prompt=4,
+        multi_lora_max_adapter_global_batch_size=256,
+    )
+    return MultiLoRABackend(args, "http://unused")
+
+
+def external_config(**overrides) -> AdapterRunConfig:
+    return AdapterRunConfig(input_mode="external", **overrides)
+
+
+def register_external(backend, name="X", **overrides) -> dict:
+    return asyncio.run(backend.register(name, external_config(**overrides)))
+
+
+class TestExternalRegistration:
+    def test_external_registers_without_data_or_reward(self):
+        backend = make_backend()
+        result = register_external(backend, rank=8, alpha=16)
+        assert result == {"name": "X", "slot": 0}
+        config = backend.registry.find("X").config
+        assert config.rank == 8 and config.alpha == 16
+        assert str(config.save).endswith("adapters/X")
+
+    def test_dataset_mode_still_requires_data(self):
+        backend = make_backend()
+        with pytest.raises(ValueError, match="needs a dataset path"):
+            asyncio.run(backend.register("D", AdapterRunConfig()))
+
+    def test_unknown_input_mode_is_rejected(self):
+        backend = make_backend()
+        with pytest.raises(ValueError, match="input_mode"):
+            asyncio.run(backend.register("D", AdapterRunConfig(input_mode="stream")))
+
+    @pytest.mark.parametrize(
+        "overrides, message",
+        [
+            (dict(data=DATA_FILE), "must not set 'data'"),
+            (dict(rm_type="math"), "must not set a reward"),
+            (dict(custom_rm_path="pkg:fn"), "must not set a reward"),
+            (dict(rollout_function_path="pkg:fn"), "must not set rollout_function_path"),
+            (dict(num_epoch=2), "must not set num_epoch"),
+            (dict(num_step=0), "num_step must be a positive integer"),
+            (dict(rank=64), "exceeds the allocated maximum rank"),
+        ],
+    )
+    def test_external_config_rejections(self, overrides, message):
+        backend = make_backend()
+        with pytest.raises(ValueError, match=message):
+            register_external(backend, **overrides)
+
+
+class TestOperationRouting:
+    def test_enqueue_resolves_the_current_registration(self):
+        backend = make_backend()
+        register_external(backend)
+        record = backend.registry.find("X")
+        view = backend.enqueue_operation("X", "op1", 1, "forward_backward", {"samples": []})
+        assert view["registration_id"] == record.registration_id
+        assert view["state"] == "QUEUED"
+
+    def test_dataset_adapters_take_no_operations(self):
+        backend = make_backend()
+        asyncio.run(backend.register("D", AdapterRunConfig(data=DATA_FILE, rm_type="math")))
+        with pytest.raises(ValueError, match="input_mode: external"):
+            backend.enqueue_operation("D", "op1", 1, "forward_backward")
+
+    def test_unregistered_name_is_rejected(self):
+        backend = make_backend()
+        with pytest.raises(ValueError, match="not accepting operations"):
+            backend.enqueue_operation("ghost", "op1", 1, "forward_backward")
+
+    def test_retirement_fences_open_operations(self, monkeypatch):
+        backend = make_backend()
+        register_external(backend)
+        backend.enqueue_operation("X", "op1", 1, "forward_backward")
+
+        async def no_abort(name, registration_id):
+            pass
+
+        monkeypatch.setattr(backend, "abort_adapter_requests", no_abort)
+        asyncio.run(backend.deregister("X"))
+        asyncio.run(backend.retire_adapters())
+        view = backend.operations.get("op1")
+        assert view["state"] == "FAILED" and view["error_category"] == "user"
+        with pytest.raises(ValueError, match="not accepting operations"):
+            backend.enqueue_operation("X", "op2", 2, "forward_backward")

--- a/tests/fast/ray/multi_lora/test_operations.py
+++ b/tests/fast/ray/multi_lora/test_operations.py
@@ -1,0 +1,152 @@
+"""Operation ledger invariants: strict per-registration serialization,
+ordinal ordering, idempotency, cancel/fence/ack semantics, backpressure."""
+
+from tests.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=60, suite="stage-a-cpu")
+
+import pytest
+
+from miles.ray.multi_lora.operations import OperationBackpressure, OperationLedger
+
+
+def enqueue(ledger, op_id, ordinal, kind="forward_backward", name="A", reg="ra", payload=None):
+    return ledger.enqueue(op_id, name, reg, ordinal, kind, payload)
+
+
+class TestEnqueue:
+    def test_ordinals_must_arrive_strictly_increasing(self):
+        ledger = OperationLedger()
+        enqueue(ledger, "op1", 1)
+        enqueue(ledger, "op3", 3)  # gaps are legal
+        with pytest.raises(ValueError, match="strictly increasing"):
+            enqueue(ledger, "op2", 2)
+
+    def test_retry_of_a_known_id_is_idempotent(self):
+        ledger = OperationLedger()
+        first = enqueue(ledger, "op1", 1)
+        retry = enqueue(ledger, "op1", 1)
+        assert retry == first
+        with pytest.raises(ValueError, match="different identity"):
+            enqueue(ledger, "op1", 9)
+
+    def test_pending_depth_backpressure(self):
+        ledger = OperationLedger(max_pending=2)
+        enqueue(ledger, "op1", 1)
+        enqueue(ledger, "op2", 2)
+        with pytest.raises(OperationBackpressure):
+            enqueue(ledger, "op3", 3)
+
+    def test_unacked_results_backpressure(self):
+        ledger = OperationLedger(max_unacked_results=1)
+        enqueue(ledger, "op1", 1)
+        ledger.claim_data_operation("A", "ra")
+        ledger.complete("op1", {"ok": True})
+        with pytest.raises(OperationBackpressure, match="unacknowledged"):
+            enqueue(ledger, "op2", 2)
+        ledger.ack("op1")
+        enqueue(ledger, "op2", 2)
+
+
+class TestSerialization:
+    def test_nothing_overtakes_an_open_operation(self):
+        # fb(1), optim(2): the control head must not be claimable while the
+        # data op is anywhere between claim and terminal — this is the ordering
+        # that makes client fb->optim sequences safe.
+        ledger = OperationLedger()
+        enqueue(ledger, "fb", 1, "forward_backward")
+        enqueue(ledger, "optim", 2, "optim_step")
+        assert ledger.claim_control_operation("A", "ra") is None
+        claimed = ledger.claim_data_operation("A", "ra")
+        assert claimed["operation_id"] == "fb"
+        assert ledger.claim_control_operation("A", "ra") is None
+        assert ledger.claim_data_operation("A", "ra") is None  # fb still open
+        ledger.complete("fb", {})
+        assert ledger.claim_control_operation("A", "ra")["operation_id"] == "optim"
+
+    def test_control_head_blocks_data_claims(self):
+        ledger = OperationLedger()
+        enqueue(ledger, "optim", 1, "optim_step")
+        enqueue(ledger, "fb", 2, "forward_backward")
+        assert ledger.claim_data_operation("A", "ra") is None
+        assert ("A", "ra") in ledger.claimable_control_tenants()
+        ledger.claim_control_operation("A", "ra")
+        ledger.complete("optim", {})
+        assert ledger.claim_data_operation("A", "ra")["operation_id"] == "fb"
+
+    def test_registrations_are_independent(self):
+        ledger = OperationLedger()
+        enqueue(ledger, "a1", 1, name="A", reg="ra")
+        enqueue(ledger, "b1", 1, name="B", reg="rb")
+        assert ledger.claim_data_operation("A", "ra")["operation_id"] == "a1"
+        assert ledger.claim_data_operation("B", "rb")["operation_id"] == "b1"
+
+
+class TestTerminals:
+    def test_cancel_applies_only_to_queued(self):
+        ledger = OperationLedger()
+        enqueue(ledger, "op1", 1)
+        enqueue(ledger, "op2", 2)
+        assert ledger.cancel("op2")["state"] == "CANCELLED"
+        ledger.claim_data_operation("A", "ra")
+        with pytest.raises(ValueError, match="only QUEUED"):
+            ledger.cancel("op1")
+
+    def test_cancelled_head_unblocks_the_next_operation(self):
+        ledger = OperationLedger()
+        enqueue(ledger, "op1", 1)
+        enqueue(ledger, "op2", 2)
+        ledger.cancel("op1")
+        assert ledger.claim_data_operation("A", "ra")["operation_id"] == "op2"
+
+    def test_fail_records_error_and_category(self):
+        ledger = OperationLedger()
+        enqueue(ledger, "op1", 1)
+        ledger.claim_data_operation("A", "ra")
+        ledger.fail("op1", "bad payload", "user")
+        view = ledger.get("op1")
+        assert view["state"] == "FAILED" and view["error_category"] == "user"
+
+    def test_double_terminal_is_rejected(self):
+        ledger = OperationLedger()
+        enqueue(ledger, "op1", 1)
+        ledger.claim_data_operation("A", "ra")
+        ledger.complete("op1", {})
+        with pytest.raises(ValueError, match="already terminal"):
+            ledger.fail("op1", "late failure")
+
+
+class TestFencing:
+    def test_fence_fails_open_ops_and_refuses_new_ones(self):
+        ledger = OperationLedger()
+        enqueue(ledger, "done", 1)
+        ledger.claim_data_operation("A", "ra")
+        ledger.complete("done", {"kept": True})
+        enqueue(ledger, "pending", 2)
+        assert ledger.fence("A", "ra") == ["pending"]
+        assert ledger.get("pending")["state"] == "FAILED"
+        assert ledger.get("pending")["error_category"] == "user"
+        # Terminal results of the dead registration stay retrievable.
+        assert ledger.get("done")["result"] == {"kept": True}
+        with pytest.raises(ValueError, match="fenced"):
+            enqueue(ledger, "late", 3)
+
+    def test_a_new_registration_of_the_same_name_starts_fresh(self):
+        ledger = OperationLedger()
+        enqueue(ledger, "old", 5, name="A", reg="ra")
+        ledger.fence("A", "ra")
+        fresh = enqueue(ledger, "new", 1, name="A", reg="rb")  # new tenant, ordinals restart
+        assert fresh["state"] == "QUEUED"
+
+
+class TestAck:
+    def test_ack_drops_only_terminal_records(self):
+        ledger = OperationLedger()
+        enqueue(ledger, "op1", 1)
+        with pytest.raises(ValueError, match="ack applies to terminal"):
+            ledger.ack("op1")
+        ledger.claim_data_operation("A", "ra")
+        ledger.complete("op1", {})
+        ledger.ack("op1")
+        assert ledger.get("op1") is None
+        ledger.ack("op1")  # idempotent

--- a/tests/fast/ray/multi_lora/test_thinker_registration.py
+++ b/tests/fast/ray/multi_lora/test_thinker_registration.py
@@ -1,4 +1,4 @@
-"""External (client-driven) adapter registration and operation routing through
+"""Thinker (client-driven) adapter registration and operation routing through
 MultiLoRABackend (no Ray, no HTTP I/O)."""
 
 from types import SimpleNamespace
@@ -30,18 +30,18 @@ def make_backend(max_adapters: int = 4) -> MultiLoRABackend:
     return MultiLoRABackend(args, "http://unused")
 
 
-def external_config(**overrides) -> AdapterRunConfig:
-    return AdapterRunConfig(input_mode="external", **overrides)
+def thinker_config(**overrides) -> AdapterRunConfig:
+    return AdapterRunConfig(input_mode="thinker", **overrides)
 
 
-def register_external(backend, name="X", **overrides) -> dict:
-    return asyncio.run(backend.register(name, external_config(**overrides)))
+def register_thinker(backend, name="X", **overrides) -> dict:
+    return asyncio.run(backend.register(name, thinker_config(**overrides)))
 
 
-class TestExternalRegistration:
-    def test_external_registers_without_data_or_reward(self):
+class TestThinkerRegistration:
+    def test_thinker_registers_without_data_or_reward(self):
         backend = make_backend()
-        result = register_external(backend, rank=8, alpha=16)
+        result = register_thinker(backend, rank=8, alpha=16)
         assert result == {"name": "X", "slot": 0}
         config = backend.registry.find("X").config
         assert config.rank == 8 and config.alpha == 16
@@ -69,16 +69,16 @@ class TestExternalRegistration:
             (dict(rank=64), "exceeds the allocated maximum rank"),
         ],
     )
-    def test_external_config_rejections(self, overrides, message):
+    def test_thinker_config_rejections(self, overrides, message):
         backend = make_backend()
         with pytest.raises(ValueError, match=message):
-            register_external(backend, **overrides)
+            register_thinker(backend, **overrides)
 
 
 class TestOperationRouting:
     def test_enqueue_resolves_the_current_registration(self):
         backend = make_backend()
-        register_external(backend)
+        register_thinker(backend)
         record = backend.registry.find("X")
         view = backend.enqueue_operation("X", "op1", 1, "forward_backward", {"samples": []})
         assert view["registration_id"] == record.registration_id
@@ -87,7 +87,7 @@ class TestOperationRouting:
     def test_dataset_adapters_take_no_operations(self):
         backend = make_backend()
         asyncio.run(backend.register("D", AdapterRunConfig(data=DATA_FILE, rm_type="math")))
-        with pytest.raises(ValueError, match="input_mode: external"):
+        with pytest.raises(ValueError, match="input_mode: thinker"):
             backend.enqueue_operation("D", "op1", 1, "forward_backward")
 
     def test_unregistered_name_is_rejected(self):
@@ -97,7 +97,7 @@ class TestOperationRouting:
 
     def test_retirement_fences_open_operations(self, monkeypatch):
         backend = make_backend()
-        register_external(backend)
+        register_thinker(backend)
         backend.enqueue_operation("X", "op1", 1, "forward_backward")
 
         async def no_abort(name, registration_id):
@@ -115,7 +115,7 @@ class TestOperationRouting:
 class TestControlOperations:
     def ready_backend(self, num_step=None):
         backend = make_backend()
-        register_external(backend, num_step=num_step)
+        register_thinker(backend, num_step=num_step)
         backend.registry.record_weight_update(["X"])  # PENDING -> ACTIVE
         return backend
 
@@ -140,7 +140,7 @@ class TestControlOperations:
         backend = self.ready_backend(num_step=2)
         record = backend.registry.find("X")
         backend.enqueue_operation("X", "opt1", 1, "optim_step")
-        backend.commit_external_batch(["X"], [])  # pin dirty
+        backend.commit_thinker_batch(["X"], [])  # pin dirty
         assert backend.registry.slot_pool.entry_of(record.tenant).pins == {"dirty-grads"}
         [op] = backend.claim_ready_control_operations()
         backend.complete_control_operations({op["operation_id"]: dict(ok=True, result={"grad_norm": 0.5})})
@@ -152,7 +152,7 @@ class TestControlOperations:
         backend = self.ready_backend()
         record = backend.registry.find("X")
         backend.enqueue_operation("X", "opt1", 1, "optim_step")
-        backend.commit_external_batch(["X"], [])
+        backend.commit_thinker_batch(["X"], [])
         [op] = backend.claim_ready_control_operations()
         backend.complete_control_operations({op["operation_id"]: dict(ok=False, error="veto", category="server")})
         assert record.step == 0  # no clock advance
@@ -169,12 +169,12 @@ class TestControlOperations:
 
         assert backend.registry.records["X"].state is AdapterState.RETIRING
 
-    def test_commit_external_batch_completes_claimed_data_ops(self):
+    def test_commit_thinker_batch_completes_claimed_data_ops(self):
         backend = self.ready_backend()
         reg_id = backend.registry.find("X").registration_id
         backend.enqueue_operation("X", "fb1", 1, "forward_backward", {"samples": [{}]})
         backend.operations.claim_data_operation("X", reg_id)
-        backend.commit_external_batch(["X"], ["fb1"])
+        backend.commit_thinker_batch(["X"], ["fb1"])
         assert backend.operations.get("fb1")["state"] == "SUCCEEDED"
 
     def test_forward_backward_results_carry_row_ordered_logprobs(self):
@@ -182,5 +182,5 @@ class TestControlOperations:
         reg_id = backend.registry.find("X").registration_id
         backend.enqueue_operation("X", "fb1", 1, "forward_backward", {"samples": [{}, {}]})
         backend.operations.claim_data_operation("X", reg_id)
-        backend.commit_external_batch(["X"], ["fb1"], {"fb1": [[-0.1, -0.2], [-0.3]]})
+        backend.commit_thinker_batch(["X"], ["fb1"], {"fb1": [[-0.1, -0.2], [-0.3]]})
         assert backend.operations.get("fb1")["result"] == {"logprobs": [[-0.1, -0.2], [-0.3]]}

--- a/tests/fast/ray/multi_lora/test_thinker_registration.py
+++ b/tests/fast/ray/multi_lora/test_thinker_registration.py
@@ -130,12 +130,6 @@ class TestControlOperations:
         [op] = backend.claim_ready_control_operations()
         assert op["operation_id"] == "opt1" and op["slot"] == backend.registry.find("X").slot
 
-    def test_unexecutable_kinds_keep_their_turn(self):
-        backend = self.ready_backend()
-        backend.enqueue_operation("X", "save1", 1, "save_state")
-        assert backend.claim_ready_control_operations() == []
-        assert backend.operations.get("save1")["state"] == "QUEUED"
-
     def test_success_advances_step_and_releases_dirty_pin(self):
         backend = self.ready_backend(num_step=2)
         record = backend.registry.find("X")
@@ -184,3 +178,59 @@ class TestControlOperations:
         backend.operations.claim_data_operation("X", reg_id)
         backend.commit_thinker_batch(["X"], ["fb1"], {"fb1": [[-0.1, -0.2], [-0.3]]})
         assert backend.operations.get("fb1")["result"] == {"logprobs": [[-0.1, -0.2], [-0.3]]}
+
+
+class TestStateAndPublishOperations:
+    def ready_backend(self):
+        backend = make_backend()
+        register_thinker(backend)
+        backend.registry.record_weight_update(["X"])
+        return backend
+
+    def test_claim_carries_authoritative_clocks(self):
+        backend = self.ready_backend()
+        backend.registry.set_step("X", 7)
+        backend.enqueue_operation("X", "pub1", 1, "publish_snapshot")
+        [op] = backend.claim_ready_control_operations()
+        assert op["kind"] == "publish_snapshot" and op["step"] == 7
+        assert op["serving_version"] == 1  # the registration push
+
+    def test_dirty_slot_fails_state_moves_but_allows_publish(self):
+        backend = self.ready_backend()
+        backend.commit_thinker_batch(["X"], [])  # pin dirty
+        backend.enqueue_operation("X", "save1", 1, "save_state", {"tag": "t0"})
+        assert backend.claim_ready_control_operations() == []
+        view = backend.operations.get("save1")
+        assert view["state"] == "FAILED" and view["error_category"] == "user"
+        assert "unstepped gradients" in view["error"]
+
+        backend.enqueue_operation("X", "pub1", 2, "publish_snapshot")
+        [op] = backend.claim_ready_control_operations()
+        assert op["operation_id"] == "pub1"  # publishing pre-step weights is fine
+
+    def test_load_state_success_repositions_the_step_clock(self):
+        backend = self.ready_backend()
+        backend.enqueue_operation("X", "load1", 1, "load_state", {"path": "/tmp/state"})
+        [op] = backend.claim_ready_control_operations()
+        backend.complete_control_operations(
+            {op["operation_id"]: dict(ok=True, result={"step": 42, "path": "/tmp/state"})}
+        )
+        record = backend.registry.find("X")
+        assert record.step == 42 and record.start_step == 42
+        assert backend.operations.get("load1")["result"]["step"] == 42
+
+    def test_publish_completion_does_not_advance_the_step_clock(self):
+        backend = self.ready_backend()
+        backend.enqueue_operation("X", "pub1", 1, "publish_snapshot")
+        [op] = backend.claim_ready_control_operations()
+        backend.complete_control_operations(
+            {op["operation_id"]: dict(ok=True, result={"serving_version": 2, "serving_name": "X@r"})}
+        )
+        assert backend.registry.find("X").step == 0
+        assert backend.operations.get("pub1")["result"]["serving_version"] == 2
+
+    def test_service_info_reports_deployment_facts(self):
+        backend = self.ready_backend()
+        info = backend.service_info()
+        assert info["n_adapters"] == 4 and info["lora_rank_max"] == 32
+        assert info["occupied_slots"] == [0] and info["active_adapters"] == ["X"]

--- a/tests/fast/ray/rollout/test_external_train_data.py
+++ b/tests/fast/ray/rollout/test_external_train_data.py
@@ -113,3 +113,18 @@ class TestExternalConversion:
             assert len(shard["loss_weights"]) == 2  # row-partitioned
             assert shard["batch_kind"] == "external"  # batch-level, replicated
             assert shard["adapter_loss_by_slot"] == {0: {"loss_fn": "ppo"}}
+
+
+def test_gather_groups_logprob_rows_per_operation():
+    from miles.backends.megatron_utils.multi_lora_utils.utils import _gather_external_logprobs
+
+    rollout_data = {
+        "external_logprob_collector": {
+            (0, 1): [-0.2],
+            (0, 0): [-0.1],
+            (1, 0): [-0.9],
+        },
+        "operation_by_slot": {0: "op-A", 1: "op-B"},
+    }
+    result = _gather_external_logprobs(rollout_data)
+    assert result == {"op-A": [[-0.1], [-0.2]], "op-B": [[-0.9]]}

--- a/tests/fast/ray/rollout/test_external_train_data.py
+++ b/tests/fast/ray/rollout/test_external_train_data.py
@@ -1,0 +1,114 @@
+"""External batches through the train-data pipeline: BatchPlan-derived
+metadata (step filtering, kind partitioning, loss specs), reward bypass, and
+client channel packaging."""
+
+import pytest
+
+from tests.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=60, suite="stage-a-cpu")
+
+from tests.fast.ray.rollout.conftest import make_args, make_sample
+
+from miles.ray.rollout.train_data_conversion import (
+    _package_shards,
+    batch_plan_to_metadata,
+    convert_samples_to_train_data,
+)
+from miles.utils.types import AdapterRef
+
+
+def plan_entry(name, slot, kind="native_train", step=True, loss_spec=None, count=2):
+    return dict(
+        name=name,
+        registration_id=f"reg-{name}",
+        bound_slot=slot,
+        evict=None,
+        actual_sample_count=count,
+        actual_rollout_count=count,
+        prompt_group_sizes=[1] * count,
+        operation_id=None if kind == "native_train" else f"op-{name}",
+        operation_kind=kind,
+        batch_id=None,
+        step_after_backward=step,
+        loss_spec=loss_spec,
+    )
+
+
+class TestBatchPlanMetadata:
+    def test_accumulate_only_entries_never_step_but_keep_routing(self):
+        plan = [
+            plan_entry("A", 0, kind="forward_backward", step=False, loss_spec={"loss_fn": "cross_entropy"}),
+            plan_entry("B", 1, kind="forward_backward", step=False, loss_spec={"loss_fn": "ppo"}),
+        ]
+        metadata = batch_plan_to_metadata(plan)
+        assert metadata["step_slots"] == [] and metadata["step_adapter_names"] == []
+        assert metadata["step_adapter_actual_counts"] == {}
+        # Token routing still needs every selected adapter's slot.
+        assert metadata["adapter_name_by_slot"] == {0: "A", 1: "B"}
+        assert metadata["batch_kind"] == "external"
+        assert metadata["adapter_loss_by_slot"] == {0: {"loss_fn": "cross_entropy"}, 1: {"loss_fn": "ppo"}}
+
+    def test_native_plan_keeps_the_fused_step_behavior(self):
+        plan = [plan_entry("A", 0), plan_entry("B", 1)]
+        metadata = batch_plan_to_metadata(plan)
+        assert metadata["step_slots"] == [0, 1]
+        assert metadata["step_adapter_actual_counts"] == {0: 2, 1: 2}
+        assert "batch_kind" not in metadata and "adapter_loss_by_slot" not in metadata
+
+    def test_mixed_kind_selection_is_a_bug(self):
+        plan = [plan_entry("A", 0), plan_entry("B", 1, kind="forward_backward", step=False)]
+        with pytest.raises(AssertionError, match="mixes operation kinds"):
+            batch_plan_to_metadata(plan)
+
+
+def external_sample(index, slot, *, loss_weights=None, advantages=None):
+    sample = make_sample(index=index, reward=None)
+    sample.adapter = AdapterRef(name="X", registration_id="reg-X", serving_version=1, slot=slot)
+    sample.loss_weights = loss_weights
+    sample.advantages = advantages
+    return sample
+
+
+def convert_external(samples, metadata):
+    return convert_samples_to_train_data(
+        make_args(multi_lora=True),
+        samples,
+        metadata=metadata,
+        custom_convert_samples_to_train_data_func=None,
+        custom_reward_post_process_func=None,
+    )
+
+
+class TestExternalConversion:
+    def test_rewards_bypass_and_channel_extraction(self):
+        plan = [plan_entry("X", 0, kind="forward_backward", step=False, loss_spec={"loss_fn": "cross_entropy"})]
+        metadata = batch_plan_to_metadata(plan)
+        samples = [
+            external_sample(0, 0, loss_weights=[0.5] * 4),
+            external_sample(1, 0, advantages=[1.0] * 4),  # no weights: defaults to zeros
+        ]
+        train_data = convert_external(samples, metadata)
+
+        # No reward post-processing ran: rewardless samples convert cleanly.
+        assert train_data["rewards"] == [0.0, 0.0]
+        assert train_data["loss_weights"] == [[0.5] * 4, [0.0] * 4]
+        assert train_data["advantages"] == [[0.0] * 4, [1.0] * 4]
+        assert train_data["batch_kind"] == "external"
+        assert train_data["adapter_loss_by_slot"] == {0: {"loss_fn": "cross_entropy"}}
+        assert train_data["step_adapter_actual_counts"] == {}
+
+    def test_shards_carry_the_external_keys(self):
+        plan = [plan_entry("X", 0, kind="forward_backward", step=False, loss_spec={"loss_fn": "ppo"})]
+        metadata = batch_plan_to_metadata(plan)
+        samples = [external_sample(i, 0, loss_weights=[1.0] * 4) for i in range(4)]
+        train_data = convert_external(samples, metadata)
+        train_data["total_lengths"] = [len(t) for t in train_data["tokens"]]
+
+        shards = _package_shards(
+            make_args(multi_lora=True, multi_lora_n_adapters=4), train_data, partitions=[[0, 2], [1, 3]]
+        )
+        for shard in shards:
+            assert len(shard["loss_weights"]) == 2  # row-partitioned
+            assert shard["batch_kind"] == "external"  # batch-level, replicated
+            assert shard["adapter_loss_by_slot"] == {0: {"loss_fn": "ppo"}}

--- a/tests/fast/ray/rollout/test_external_train_data.py
+++ b/tests/fast/ray/rollout/test_external_train_data.py
@@ -48,6 +48,7 @@ class TestBatchPlanMetadata:
         assert metadata["adapter_name_by_slot"] == {0: "A", 1: "B"}
         assert metadata["batch_kind"] == "external"
         assert metadata["adapter_loss_by_slot"] == {0: {"loss_fn": "cross_entropy"}, 1: {"loss_fn": "ppo"}}
+        assert metadata["operation_by_slot"] == {0: "op-A", 1: "op-B"}
 
     def test_native_plan_keeps_the_fused_step_behavior(self):
         plan = [plan_entry("A", 0), plan_entry("B", 1)]

--- a/tests/fast/ray/rollout/test_thinker_train_data.py
+++ b/tests/fast/ray/rollout/test_thinker_train_data.py
@@ -1,4 +1,4 @@
-"""External batches through the train-data pipeline: BatchPlan-derived
+"""Thinker batches through the train-data pipeline: BatchPlan-derived
 metadata (step filtering, kind partitioning, loss specs), reward bypass, and
 client channel packaging."""
 
@@ -18,7 +18,7 @@ from miles.ray.rollout.train_data_conversion import (
 from miles.utils.types import AdapterRef
 
 
-def plan_entry(name, slot, kind="native_train", step=True, loss_spec=None, count=2):
+def plan_entry(name, slot, kind="multi_lora_train", step=True, loss_spec=None, count=2):
     return dict(
         name=name,
         registration_id=f"reg-{name}",
@@ -27,7 +27,7 @@ def plan_entry(name, slot, kind="native_train", step=True, loss_spec=None, count
         actual_sample_count=count,
         actual_rollout_count=count,
         prompt_group_sizes=[1] * count,
-        operation_id=None if kind == "native_train" else f"op-{name}",
+        operation_id=None if kind == "multi_lora_train" else f"op-{name}",
         operation_kind=kind,
         batch_id=None,
         step_after_backward=step,
@@ -46,7 +46,7 @@ class TestBatchPlanMetadata:
         assert metadata["step_adapter_actual_counts"] == {}
         # Token routing still needs every selected adapter's slot.
         assert metadata["adapter_name_by_slot"] == {0: "A", 1: "B"}
-        assert metadata["batch_kind"] == "external"
+        assert metadata["batch_kind"] == "thinker"
         assert metadata["adapter_loss_by_slot"] == {0: {"loss_fn": "cross_entropy"}, 1: {"loss_fn": "ppo"}}
         assert metadata["operation_by_slot"] == {0: "op-A", 1: "op-B"}
 
@@ -63,7 +63,7 @@ class TestBatchPlanMetadata:
             batch_plan_to_metadata(plan)
 
 
-def external_sample(index, slot, *, loss_weights=None, advantages=None):
+def thinker_sample(index, slot, *, loss_weights=None, advantages=None):
     sample = make_sample(index=index, reward=None)
     sample.adapter = AdapterRef(name="X", registration_id="reg-X", serving_version=1, slot=slot)
     sample.loss_weights = loss_weights
@@ -71,7 +71,7 @@ def external_sample(index, slot, *, loss_weights=None, advantages=None):
     return sample
 
 
-def convert_external(samples, metadata):
+def convert_thinker(samples, metadata):
     return convert_samples_to_train_data(
         make_args(multi_lora=True),
         samples,
@@ -81,29 +81,29 @@ def convert_external(samples, metadata):
     )
 
 
-class TestExternalConversion:
+class TestThinkerConversion:
     def test_rewards_bypass_and_channel_extraction(self):
         plan = [plan_entry("X", 0, kind="forward_backward", step=False, loss_spec={"loss_fn": "cross_entropy"})]
         metadata = batch_plan_to_metadata(plan)
         samples = [
-            external_sample(0, 0, loss_weights=[0.5] * 4),
-            external_sample(1, 0, advantages=[1.0] * 4),  # no weights: defaults to zeros
+            thinker_sample(0, 0, loss_weights=[0.5] * 4),
+            thinker_sample(1, 0, advantages=[1.0] * 4),  # no weights: defaults to zeros
         ]
-        train_data = convert_external(samples, metadata)
+        train_data = convert_thinker(samples, metadata)
 
         # No reward post-processing ran: rewardless samples convert cleanly.
         assert train_data["rewards"] == [0.0, 0.0]
         assert train_data["loss_weights"] == [[0.5] * 4, [0.0] * 4]
         assert train_data["advantages"] == [[0.0] * 4, [1.0] * 4]
-        assert train_data["batch_kind"] == "external"
+        assert train_data["batch_kind"] == "thinker"
         assert train_data["adapter_loss_by_slot"] == {0: {"loss_fn": "cross_entropy"}}
         assert train_data["step_adapter_actual_counts"] == {}
 
-    def test_shards_carry_the_external_keys(self):
+    def test_shards_carry_the_thinker_keys(self):
         plan = [plan_entry("X", 0, kind="forward_backward", step=False, loss_spec={"loss_fn": "ppo"})]
         metadata = batch_plan_to_metadata(plan)
-        samples = [external_sample(i, 0, loss_weights=[1.0] * 4) for i in range(4)]
-        train_data = convert_external(samples, metadata)
+        samples = [thinker_sample(i, 0, loss_weights=[1.0] * 4) for i in range(4)]
+        train_data = convert_thinker(samples, metadata)
         train_data["total_lengths"] = [len(t) for t in train_data["tokens"]]
 
         shards = _package_shards(
@@ -111,20 +111,20 @@ class TestExternalConversion:
         )
         for shard in shards:
             assert len(shard["loss_weights"]) == 2  # row-partitioned
-            assert shard["batch_kind"] == "external"  # batch-level, replicated
+            assert shard["batch_kind"] == "thinker"  # batch-level, replicated
             assert shard["adapter_loss_by_slot"] == {0: {"loss_fn": "ppo"}}
 
 
 def test_gather_groups_logprob_rows_per_operation():
-    from miles.backends.megatron_utils.multi_lora_utils.utils import _gather_external_logprobs
+    from miles.backends.megatron_utils.multi_lora_utils.utils import _gather_thinker_logprobs
 
     rollout_data = {
-        "external_logprob_collector": {
+        "thinker_logprob_collector": {
             (0, 1): [-0.2],
             (0, 0): [-0.1],
             (1, 0): [-0.9],
         },
         "operation_by_slot": {0: "op-A", 1: "op-B"},
     }
-    result = _gather_external_logprobs(rollout_data)
+    result = _gather_thinker_logprobs(rollout_data)
     assert result == {"op-A": [[-0.1], [-0.2]], "op-B": [[-0.9]]}

--- a/tests/fast/ray/rollout/test_thinker_train_data.py
+++ b/tests/fast/ray/rollout/test_thinker_train_data.py
@@ -59,7 +59,7 @@ class TestBatchPlanMetadata:
 
     def test_mixed_kind_selection_is_a_bug(self):
         plan = [plan_entry("A", 0), plan_entry("B", 1, kind="forward_backward", step=False)]
-        with pytest.raises(AssertionError, match="mixes operation kinds"):
+        with pytest.raises(AssertionError, match="mixes input modes"):
             batch_plan_to_metadata(plan)
 
 
@@ -128,3 +128,20 @@ def test_gather_groups_logprob_rows_per_operation():
     }
     result = _gather_thinker_logprobs(rollout_data)
     assert result == {"op-A": [[-0.1], [-0.2]], "op-B": [[-0.9]]}
+
+
+class TestForwardOperations:
+    def test_forward_and_forward_backward_share_a_selection(self):
+        plan = [
+            plan_entry("A", 0, kind="forward_backward", step=False, loss_spec={"loss_fn": "cross_entropy"}),
+            plan_entry("B", 1, kind="forward", step=False),
+        ]
+        metadata = batch_plan_to_metadata(plan)
+        assert metadata["batch_kind"] == "thinker"
+        assert metadata["forward_only_slots"] == [1]
+        assert metadata["step_slots"] == []
+
+    def test_multi_lora_selection_never_mixes_with_thinker(self):
+        plan = [plan_entry("A", 0), plan_entry("B", 1, kind="forward", step=False)]
+        with pytest.raises(AssertionError, match="mixes input modes"):
+            batch_plan_to_metadata(plan)

--- a/tests/fast/rollout/multi_lora/test_option1_rollout_fn.py
+++ b/tests/fast/rollout/multi_lora/test_option1_rollout_fn.py
@@ -153,6 +153,13 @@ class TestMerge:
             actual_sample_count=4,
             actual_rollout_count=4,  # classic 1:1 — every sample is its own execution
             prompt_group_sizes=[2, 2],
+            # Native dataset batches carry no operation and keep the fused
+            # step-after-backward path.
+            operation_id=None,
+            operation_kind="native_train",
+            batch_id=None,
+            step_after_backward=True,
+            loss_spec=None,
         )
         assert plan["B"]["actual_sample_count"] == 3
         assert output.metadata["train_txn_id"]

--- a/tests/fast/rollout/multi_lora/test_option1_rollout_fn.py
+++ b/tests/fast/rollout/multi_lora/test_option1_rollout_fn.py
@@ -153,10 +153,10 @@ class TestMerge:
             actual_sample_count=4,
             actual_rollout_count=4,  # classic 1:1 — every sample is its own execution
             prompt_group_sizes=[2, 2],
-            # Native dataset batches carry no operation and keep the fused
+            # Multi-LoRA dataset batches carry no operation and keep the fused
             # step-after-backward path.
             operation_id=None,
-            operation_kind="native_train",
+            operation_kind="multi_lora_train",
             batch_id=None,
             step_after_backward=True,
             loss_spec=None,

--- a/tests/fast/rollout/multi_lora/test_queue_rollout_fn.py
+++ b/tests/fast/rollout/multi_lora/test_queue_rollout_fn.py
@@ -120,12 +120,19 @@ def test_bad_payload_fails_its_operation_and_the_child_continues(fake_ray):
     assert failed_id == "bad" and category == "user" and "no samples" in error
 
 
-def test_forward_kind_fails_until_the_forward_verb_lands(fake_ray):
-    controller = _FakeController([op("fwd", kind="forward"), op("good")])
+def test_forward_operations_build_batches_too(fake_ray):
+    controller = _FakeController(
+        [
+            op(
+                "fwd",
+                kind="forward",
+                payload={"samples": [{"prompt": "p", "tokens": [1, 2], "response_length": 1, "loss_mask": [1]}]},
+            )
+        ]
+    )
     fake_ray(controller)
     child = make_child(make_run())
     output = asyncio.run(child(RolloutFnTrainInput(rollout_id=0)))
-
-    assert output.metadata["operation_id"] == "good"
-    [(failed_id, _, category)] = controller.failed
-    assert failed_id == "fwd" and category == "user"
+    assert output.metadata["operation_kind"] == "forward"
+    assert output.metadata["step_after_backward"] is False
+    assert controller.failed == []

--- a/tests/fast/rollout/multi_lora/test_queue_rollout_fn.py
+++ b/tests/fast/rollout/multi_lora/test_queue_rollout_fn.py
@@ -14,17 +14,17 @@ import pytest
 
 import miles.rollout.multi_lora.queue_rollout_fn as queue_module
 from miles.rollout.base_types import RolloutFnConstructorInput, RolloutFnTrainInput
-from miles.rollout.multi_lora.queue_rollout_fn import ExternalOperationSource, QueueChildRolloutFn
+from miles.rollout.multi_lora.queue_rollout_fn import ThinkerOperationSource, QueueChildRolloutFn
 from miles.utils.adapter_config import AdapterRun, AdapterRunConfig
 
 
 def make_run(name="X", reg="rx", slot=3, version=2) -> AdapterRun:
-    config = AdapterRunConfig(input_mode="external", metadata={"team": "t1"})
+    config = AdapterRunConfig(input_mode="thinker", metadata={"team": "t1"})
     return AdapterRun(name=name, config=config, slot=slot, version=version, registration_id=reg)
 
 
 def make_child(run: AdapterRun) -> QueueChildRolloutFn:
-    source = ExternalOperationSource(SimpleNamespace(), run)
+    source = ThinkerOperationSource(SimpleNamespace(), run)
     return QueueChildRolloutFn(RolloutFnConstructorInput(args=source.args, data_source=source))
 
 

--- a/tests/fast/rollout/multi_lora/test_queue_rollout_fn.py
+++ b/tests/fast/rollout/multi_lora/test_queue_rollout_fn.py
@@ -14,7 +14,7 @@ import pytest
 
 import miles.rollout.multi_lora.queue_rollout_fn as queue_module
 from miles.rollout.base_types import RolloutFnConstructorInput, RolloutFnTrainInput
-from miles.rollout.multi_lora.queue_rollout_fn import ThinkerOperationSource, QueueChildRolloutFn
+from miles.rollout.multi_lora.queue_rollout_fn import QueueChildRolloutFn, ThinkerOperationSource
 from miles.utils.adapter_config import AdapterRun, AdapterRunConfig
 
 

--- a/tests/fast/rollout/multi_lora/test_queue_rollout_fn.py
+++ b/tests/fast/rollout/multi_lora/test_queue_rollout_fn.py
@@ -1,0 +1,131 @@
+"""Queue child rollout fn: one claimed forward_backward operation becomes one
+stamped batch; bad payloads fail their own operation and the child keeps
+serving; the operation directives ride the output metadata."""
+
+from types import SimpleNamespace
+
+from tests.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=60, suite="stage-a-cpu")
+
+import asyncio
+
+import pytest
+
+import miles.rollout.multi_lora.queue_rollout_fn as queue_module
+from miles.rollout.base_types import RolloutFnConstructorInput, RolloutFnTrainInput
+from miles.rollout.multi_lora.queue_rollout_fn import ExternalOperationSource, QueueChildRolloutFn
+from miles.utils.adapter_config import AdapterRun, AdapterRunConfig
+
+
+def make_run(name="X", reg="rx", slot=3, version=2) -> AdapterRun:
+    config = AdapterRunConfig(input_mode="external", metadata={"team": "t1"})
+    return AdapterRun(name=name, config=config, slot=slot, version=version, registration_id=reg)
+
+
+def make_child(run: AdapterRun) -> QueueChildRolloutFn:
+    source = ExternalOperationSource(SimpleNamespace(), run)
+    return QueueChildRolloutFn(RolloutFnConstructorInput(args=source.args, data_source=source))
+
+
+def sample_payload(n=2) -> dict:
+    return {
+        "batch_id": "batch-7",
+        "samples": [
+            {"prompt": "p", "tokens": [1, 2, 3, 4], "response_length": 2, "loss_mask": [1, 1]} for _ in range(n)
+        ],
+        "loss": {"loss_fn": "cross_entropy"},
+    }
+
+
+class _FakeController:
+    """Scripted claim results; records failures."""
+
+    def __init__(self, claims):
+        self._claims = list(claims)
+        self.failed: list[tuple] = []
+        self.claim_data_operation = SimpleNamespace(remote=lambda name, reg: self._next_claim())
+        self.fail_operation = SimpleNamespace(remote=lambda *args: self.failed.append(args))
+
+    def _next_claim(self):
+        return self._claims.pop(0) if self._claims else None
+
+
+@pytest.fixture()
+def fake_ray(monkeypatch):
+    monkeypatch.setattr(queue_module, "ray", SimpleNamespace(get=lambda ref: ref))
+    monkeypatch.setattr(queue_module, "_CLAIM_POLL_S", 0.01)
+
+    def install(controller):
+        import miles.ray.multi_lora.controller as controller_module
+
+        monkeypatch.setattr(controller_module, "get_multi_lora_controller", lambda: controller)
+
+    return install
+
+
+def op(op_id="op1", kind="forward_backward", payload=None, ordinal=1):
+    return dict(
+        operation_id=op_id,
+        name="X",
+        registration_id="rx",
+        ordinal=ordinal,
+        kind=kind,
+        payload=sample_payload() if payload is None else payload,
+        state="CLAIMED",
+        result=None,
+        error=None,
+        error_category=None,
+    )
+
+
+def test_one_operation_becomes_one_stamped_batch(fake_ray):
+    controller = _FakeController([op()])
+    fake_ray(controller)
+    child = make_child(make_run())
+    output = asyncio.run(child(RolloutFnTrainInput(rollout_id=0)))
+
+    assert len(output.samples) == 2 and all(len(group) == 1 for group in output.samples)
+    stamped = output.samples[0][0]
+    assert (stamped.adapter.name, stamped.adapter.registration_id) == ("X", "rx")
+    assert stamped.adapter.serving_version == 2 and stamped.adapter.slot == 3
+    assert stamped.metadata["team"] == "t1"  # run metadata merged in
+    assert stamped.status == stamped.Status.COMPLETED
+    assert output.metadata == dict(
+        operation_id="op1",
+        operation_kind="forward_backward",
+        batch_id="batch-7",
+        step_after_backward=False,
+        loss_spec={"loss_fn": "cross_entropy"},
+    )
+
+
+def test_child_waits_for_a_claim(fake_ray):
+    # None, None, then an operation: the child polls until work arrives.
+    controller = _FakeController([None, None, op()])
+    fake_ray(controller)
+    child = make_child(make_run())
+    output = asyncio.run(child(RolloutFnTrainInput(rollout_id=0)))
+    assert output.metadata["operation_id"] == "op1"
+
+
+def test_bad_payload_fails_its_operation_and_the_child_continues(fake_ray):
+    controller = _FakeController([op("bad", payload={"samples": []}), op("good")])
+    fake_ray(controller)
+    child = make_child(make_run())
+    output = asyncio.run(child(RolloutFnTrainInput(rollout_id=0)))
+
+    assert output.metadata["operation_id"] == "good"
+    [(failed_id, error, category)] = controller.failed
+    assert failed_id == "bad" and category == "user" and "no samples" in error
+
+
+def test_forward_kind_fails_until_the_forward_verb_lands(fake_ray):
+    controller = _FakeController([op("fwd", kind="forward"), op("good")])
+    fake_ray(controller)
+    child = make_child(make_run())
+    output = asyncio.run(child(RolloutFnTrainInput(rollout_id=0)))
+
+    assert output.metadata["operation_id"] == "good"
+    [(failed_id, _, category)] = controller.failed
+    assert failed_id == "fwd" and category == "user"

--- a/tests/fast/utils/test_adapter_config.py
+++ b/tests/fast/utils/test_adapter_config.py
@@ -11,7 +11,7 @@ from miles.utils.adapter_config import AdapterRunConfig, parse_adapter_run_yaml
 # the dataclass but missed by the parser (or this table) fails the round-trip.
 _YAML_VALUES = {
     "data": "/data/prompts.jsonl",
-    "input_mode": "dataset",
+    "input_mode": "multi-lora",
     "rank": 8,
     "alpha": 16,
     "rollout_batch_size": 4,

--- a/tests/fast/utils/test_adapter_config.py
+++ b/tests/fast/utils/test_adapter_config.py
@@ -11,6 +11,7 @@ from miles.utils.adapter_config import AdapterRunConfig, parse_adapter_run_yaml
 # the dataclass but missed by the parser (or this table) fails the round-trip.
 _YAML_VALUES = {
     "data": "/data/prompts.jsonl",
+    "input_mode": "dataset",
     "rank": 8,
     "alpha": 16,
     "rollout_batch_size": 4,

--- a/train_multi_lora_async.py
+++ b/train_multi_lora_async.py
@@ -75,6 +75,15 @@ async def main(args):
         # and only then does the data source sample them. The actor pushes only
         # stale adapter weights (newly loaded, or stepped by the last batch).
         await actor_model.reconcile_adapters()
+
+        # Control phase: data-less external operations (optim_step) execute
+        # every iteration — including the idle paths below — so a client
+        # waiting on a step never depends on another adapter generating data.
+        control_ops = await get_multi_lora_controller().claim_ready_control_operations.remote()
+        if control_ops:
+            results = await actor_model.execute_adapter_controls(control_ops)
+            await get_multi_lora_controller().complete_control_operations.remote(results)
+
         await actor_model.update_weights()
 
         # With nothing active, generate would wait forever.

--- a/train_multi_lora_async.py
+++ b/train_multi_lora_async.py
@@ -76,7 +76,7 @@ async def main(args):
         # stale adapter weights (newly loaded, or stepped by the last batch).
         await actor_model.reconcile_adapters()
 
-        # Control phase: data-less external operations (optim_step) execute
+        # Control phase: data-less thinker operations (optim_step) execute
         # every iteration — including the idle paths below — so a client
         # waiting on a step never depends on another adapter generating data.
         control_ops = await get_multi_lora_controller().claim_ready_control_operations.remote()

--- a/train_multi_lora_async.py
+++ b/train_multi_lora_async.py
@@ -14,7 +14,7 @@ from miles.utils.arguments import parse_args
 from miles.utils.audit_utils.process_identity import MainProcessIdentity
 from miles.utils.data import remove_rollout_data_refs
 from miles.utils.logging_utils import configure_logger
-from miles.utils.multi_lora import EmptyBatchTimeoutError, define_new_adapter_metrics
+from miles.utils.multi_lora import EmptyBatchTimeoutError, define_new_adapter_metrics, serving_lora_name
 from miles.utils.tracking_utils.tracking import init_tracking
 
 logger = logging.getLogger(__name__)
@@ -76,15 +76,45 @@ async def main(args):
         # stale adapter weights (newly loaded, or stepped by the last batch).
         await actor_model.reconcile_adapters()
 
-        # Control phase: data-less thinker operations (optim_step) execute
-        # every iteration — including the idle paths below — so a client
-        # waiting on a step never depends on another adapter generating data.
+        # Control phase: data-less thinker operations execute every iteration —
+        # including the idle paths below — so a client waiting on a step never
+        # depends on another adapter generating data. publish_snapshot is the
+        # exception: its barrier semantics complete only after this iteration's
+        # weight push is live, with the new serving version in the result.
         control_ops = await get_multi_lora_controller().claim_ready_control_operations.remote()
+        pending_publishes: list[dict] = []
         if control_ops:
             results = await actor_model.execute_adapter_controls(control_ops)
-            await get_multi_lora_controller().complete_control_operations.remote(results)
+            publish_ids = {op["operation_id"] for op in control_ops if op["kind"] == "publish_snapshot"}
+            deferred = {
+                op_id: outcome for op_id, outcome in results.items() if op_id in publish_ids and outcome.get("ok")
+            }
+            immediate = {op_id: outcome for op_id, outcome in results.items() if op_id not in deferred}
+            if immediate:
+                await get_multi_lora_controller().complete_control_operations.remote(immediate)
+            pending_publishes = [op for op in control_ops if op["operation_id"] in deferred]
 
         await actor_model.update_weights()
+
+        if pending_publishes:
+            post_push = await get_multi_lora_controller().snapshot.remote()
+            live = {**post_push["active"], **post_push["retiring"]}
+            completions = {}
+            for op in pending_publishes:
+                run = live.get(op["name"])
+                if run is None or run.registration_id != op["registration_id"]:
+                    completions[op["operation_id"]] = dict(
+                        ok=False, error=f"adapter '{op['name']}' retired before the publish landed", category="user"
+                    )
+                else:
+                    completions[op["operation_id"]] = dict(
+                        ok=True,
+                        result=dict(
+                            serving_version=run.version,
+                            serving_name=serving_lora_name(op["name"], op["registration_id"]),
+                        ),
+                    )
+            await get_multi_lora_controller().complete_control_operations.remote(completions)
 
         # With nothing active, generate would wait forever.
         post_update = await get_multi_lora_controller().snapshot.remote()


### PR DESCRIPTION
Stacked on #2137. Adds a **thinker** adapter mode (`input_mode: thinker`): clients push token-level training data and optimizer/checkpoint operations through a per-registration operation queue, instead of registering a dataset+reward. This is the protocol-neutral backend for a tinker-style training API; the tinker HTTP/session/future frontend comes in a later PR and needs no further backend changes.

The classic multi-lora dataset mode is unchanged (`step_after_backward=True` default; one batch = one step; per-step publish).

### Design
- One machine, two contracts: thinker mode reuses the Option 1 driver loop, `MultiLoRARolloutFn` selection, BatchPlan, SlotPool, per-slot optimizers, swap sidecar, and sglang serving identity. Forks are explicit flags, not parallel code paths.
- Operations: `FORWARD_BACKWARD | OPTIM_STEP | FORWARD | PUBLISH_SNAPSHOT | SAVE_STATE | LOAD_STATE`, per-registration FIFO with `(registration_id, ordinal)` ordering, dedup, claim/ack, cancel, and registration fencing.
- Data-bearing ops ride the existing rollout path via a built-in queue child rollout fn; data-less ops execute in a new driver control phase (runs every iteration, including idle).
- `forward_backward` accumulates only (dirty-slot pinned, no publish); `optim_step` applies per-call AdamParams with sum-reduction semantics; `save_weights_for_sampler` is the only publish path for thinker adapters and resolves after the push is visible.

### Checklist
- [x] B1 thinker adapter lifecycle (`input_mode`, `data` optional, no reward, explicit unload)
- [x] B2 operation registry/queue + driver control plan
- [x] B3 thinker Datum schema (`loss_weights`/`advantages`/clip tensors/`batch_row_id`; binary `loss_mask` untouched)
- [x] B4 per-slot loss dispatch (linear CE, importance sampling, PPO w/ per-op clip)
- [x] B5 decoupled forward_backward / optim_step (accumulate-only; optimizer-only verb; no auto-publish)
- [x] B6 per-call AdamParams + dirty-gradient pin
- [x] B7 per-operation result plane (per-token logprobs, `name:reduction` metrics, terminal semantics)
- [ ] B8 thinker admission — **deferred by design decision**: v1 requires `--multi-lora-n-adapters` ≥ concurrent thinker models (slot-bound thinker adapters bootstrap and train today; unbound registrations queue until a slot frees, never evicting). Fair LRU admission for oversubscribed long-lived thinker adapters is a follow-up once the product shape (single-tenant vs multi-client) is decided.
- [x] B9 forward verb + publish/version barrier
- [x] B10 checkpoint/load control operations (+ GET /info)
- [x] full multi-LoRA fast-suite regression (CPU, CI stage-a-cpu recipe): every stage landed green; see commit messages

### v1 scope (frontend will reject with 4xx)
text-only; sync RL/SL only (no `async_config`); 1-D shifted targets (no SDFT/top-K); CE/IS/PPO; single base model.


### Current state
An thinker adapter can already run the full accumulate/step cycle: register (`input_mode: thinker`) → enqueue `forward_backward` operations (per-token `loss_weights`/`advantages`, per-op loss spec: linear CE / importance sampling / PPO) → gradients accumulate without stepping or publishing (slot pinned dirty) → enqueue `optim_step` (per-call AdamParams, sum semantics, per-call clip) executed by the driver's control phase → results (per-datum logprobs, grad norm, applied LR) retrievable per operation until acked. `publish_snapshot` completes after the push is live (result carries the serving version + name for the sampling side); `forward` returns logprobs with zero gradient; `save_state`/`load_state` move full training state through immutable named checkpoints with serving invalidation on load. Remaining before merge: one GPU E2E smoke (thinker scenario alongside the existing 7-phase service smoke).
