### PR TITLE
pass the engine weight version from the trainer instead of polling the router

### DIFF
--- a/miles/backends/experimental/fsdp_utils/actor.py
+++ b/miles/backends/experimental/fsdp_utils/actor.py
@@ -589,6 +589,8 @@ class FSDPTrainRayActor(TrainRayActor):
                 ray.get(self.rollout_manager.clear_updatable_has_new_engines.remote())
 
         self.weight_updater.update_weights()
+        if dist.get_rank() == 0:
+            ray.get(self.rollout_manager.set_weight_version.remote(self.weight_updater.weight_version))
 
         if self.args.ci_test and len(rollout_engines) > 0:
             engine = random.choice(rollout_engines)

--- a/miles/backends/megatron_utils/actor.py
+++ b/miles/backends/megatron_utils/actor.py
@@ -770,6 +770,8 @@ class MegatronTrainRayActor(TrainRayActor):
             print_memory("before update_weights")
             self.weight_updater.update_weights()
             print_memory("after update_weights")
+            if dist.get_rank() == 0:
+                ray.get(self.rollout_manager.set_weight_version.remote(self.weight_updater.weight_version))
 
             if is_multi_lora_enabled(self.args):
                 from miles.backends.megatron_utils.multi_lora_utils import commit_weight_push

--- a/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/mixin.py
+++ b/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/mixin.py
@@ -336,16 +336,6 @@ class DistBucketedWeightUpdateMixin:
         out = self.__dict__.pop("update_weight_metrics", {})
         return out
 
-    def _engine_weight_version(self) -> int:
-        """What the engine fleet already serves, 0 when it has never been stamped."""
-        version = 0
-        if dist.get_rank() == 0:
-            reported = ray.get([engine.get_weight_version.remote() for engine in self.rollout_engines])
-            version = max((int(v) for v in reported if str(v).isdigit()), default=0)
-        holder = [version]  # every rank increments the counter, so they must agree on the seed
-        dist.broadcast_object_list(holder, src=0, group=get_gloo_group())
-        return holder[0]
-
     @torch.no_grad()
     def update_weights(self) -> None:
         """Orchestrate the full weight-update lifecycle.
@@ -365,10 +355,6 @@ class DistBucketedWeightUpdateMixin:
         never pushed; the remote rollout engines already load it from
         ``hf_checkpoint`` at init.
         """
-        if self.weight_version == 0:
-            # the counter is per-cell, so a cell taking over after FT failover would
-            # otherwise restart it and publish a version lower than the fleet's
-            self.weight_version = self._engine_weight_version()
         self.weight_version += 1
 
         self._pause_and_prepare_engines()

--- a/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/mixin.py
+++ b/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/mixin.py
@@ -320,7 +320,8 @@ class DistBucketedWeightUpdateMixin:
     def _finalize_and_resume_engines(self) -> None:
         """Close the weight-update session and resume rollout engines."""
         if dist.get_rank() == 0:
-            # stamp centrally: the LoRA push has no weight_version of its own
+            # not redundant with the base push, which stamps via its own weight_version
+            # argument: the LoRA push RPC has no such argument.
             ray.get(
                 [
                     engine.update_weight_version.remote(weight_version=str(self.weight_version))

--- a/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/mixin.py
+++ b/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/mixin.py
@@ -320,8 +320,7 @@ class DistBucketedWeightUpdateMixin:
     def _finalize_and_resume_engines(self) -> None:
         """Close the weight-update session and resume rollout engines."""
         if dist.get_rank() == 0:
-            # not redundant with the base push, which stamps via its own weight_version
-            # argument: the LoRA push RPC has no such argument.
+            # unify update weight version here to cover both full param and lora update
             ray.get(
                 [
                     engine.update_weight_version.remote(weight_version=str(self.weight_version))

--- a/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/mixin.py
+++ b/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/mixin.py
@@ -320,8 +320,7 @@ class DistBucketedWeightUpdateMixin:
     def _finalize_and_resume_engines(self) -> None:
         """Close the weight-update session and resume rollout engines."""
         if dist.get_rank() == 0:
-            # Stamped here rather than per transport: the LoRA push carries no version,
-            # so staleness accounting would compare against a version that never moved.
+            # here, not per transport: the LoRA push carries no version
             ray.get(
                 [
                     engine.update_weight_version.remote(weight_version=str(self.weight_version))

--- a/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/mixin.py
+++ b/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/mixin.py
@@ -320,7 +320,7 @@ class DistBucketedWeightUpdateMixin:
     def _finalize_and_resume_engines(self) -> None:
         """Close the weight-update session and resume rollout engines."""
         if dist.get_rank() == 0:
-            # here, not per transport: the LoRA push carries no version
+            # stamp centrally: the LoRA push has no weight_version of its own
             ray.get(
                 [
                     engine.update_weight_version.remote(weight_version=str(self.weight_version))

--- a/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/mixin.py
+++ b/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/mixin.py
@@ -320,6 +320,14 @@ class DistBucketedWeightUpdateMixin:
     def _finalize_and_resume_engines(self) -> None:
         """Close the weight-update session and resume rollout engines."""
         if dist.get_rank() == 0:
+            # Stamped here rather than per transport: the LoRA push carries no version,
+            # so staleness accounting would compare against a version that never moved.
+            ray.get(
+                [
+                    engine.update_weight_version.remote(weight_version=str(self.weight_version))
+                    for engine in self.rollout_engines
+                ]
+            )
             end_weight_update(self.rollout_engines)
             ray.get([engine.continue_generation.remote() for engine in self.rollout_engines])
 

--- a/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/mixin.py
+++ b/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/mixin.py
@@ -336,6 +336,16 @@ class DistBucketedWeightUpdateMixin:
         out = self.__dict__.pop("update_weight_metrics", {})
         return out
 
+    def _engine_weight_version(self) -> int:
+        """What the engine fleet already serves, 0 when it has never been stamped."""
+        version = 0
+        if dist.get_rank() == 0:
+            reported = ray.get([engine.get_weight_version.remote() for engine in self.rollout_engines])
+            version = max((int(v) for v in reported if str(v).isdigit()), default=0)
+        holder = [version]  # every rank increments the counter, so they must agree on the seed
+        dist.broadcast_object_list(holder, src=0, group=get_gloo_group())
+        return holder[0]
+
     @torch.no_grad()
     def update_weights(self) -> None:
         """Orchestrate the full weight-update lifecycle.
@@ -355,6 +365,10 @@ class DistBucketedWeightUpdateMixin:
         never pushed; the remote rollout engines already load it from
         ``hf_checkpoint`` at init.
         """
+        if self.weight_version == 0:
+            # the counter is per-cell, so a cell taking over after FT failover would
+            # otherwise restart it and publish a version lower than the fleet's
+            self.weight_version = self._engine_weight_version()
         self.weight_version += 1
 
         self._pause_and_prepare_engines()

--- a/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/p2p.py
+++ b/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/p2p.py
@@ -2,7 +2,6 @@ import logging
 from argparse import Namespace
 from collections.abc import Callable, Mapping, Sequence
 
-import ray
 import torch
 import torch.distributed as dist
 from ray.actor import ActorHandle
@@ -119,16 +118,6 @@ class UpdateWeightP2P(DistBucketedWeightUpdateMixin):
         if not self._model_registered:
             self._weight_memory_registry = register_cpu_memory(self._shared_params_dict, self._transfer_engine)
         self._model_registered = True
-
-    def _finalize_and_resume_engines(self):
-        if dist.get_rank() == 0:
-            ray.get(
-                [
-                    engine.update_weight_version.remote(weight_version=str(self.weight_version))
-                    for engine in self.rollout_engines
-                ]
-            )
-        super()._finalize_and_resume_engines()
 
     def _update_weight_implementation(
         self, converted_named_tensors: list[tuple[str, torch.Tensor]], pbar: tqdm | None = None

--- a/miles/ray/rollout/rollout_manager.py
+++ b/miles/ray/rollout/rollout_manager.py
@@ -378,12 +378,8 @@ class RolloutManager:
 
     def set_weight_version(self, weight_version: int):
         if self.weight_version is not None and weight_version < self.weight_version:
-            # a regression makes staleness negative, which admits the most off-policy groups
-            message = f"Engine weight version went backwards: {self.weight_version} -> {weight_version}"
-            # not fatal in production: this runs inside the retried update, so raising would
-            # error one cell after another until the FT quorum is gone
-            assert not self.args.ci_test, message
-            logger.warning(message)
+            # the updater counter is per-cell and not checkpointed, so FT failover restarts it
+            logger.warning(f"Engine weight version went backwards: {self.weight_version} -> {weight_version}")
         self.weight_version = weight_version
 
     def set_train_parallel_config(self, config: dict):

--- a/miles/ray/rollout/rollout_manager.py
+++ b/miles/ray/rollout/rollout_manager.py
@@ -378,10 +378,8 @@ class RolloutManager:
 
     def set_weight_version(self, weight_version: int):
         if self.weight_version is not None and weight_version < self.weight_version:
-            # a regression makes staleness negative, which admits the most off-policy groups
             message = f"Engine weight version went backwards: {self.weight_version} -> {weight_version}"
-            # only indep_dp can do this legitimately: the counter is per-cell, so a cell taking
-            # over after failover restarts it
+            # warning instead of assert when use indep_dp ft
             assert self.args.indep_dp, message
             logger.warning(message)
         self.weight_version = weight_version

--- a/miles/ray/rollout/rollout_manager.py
+++ b/miles/ray/rollout/rollout_manager.py
@@ -377,6 +377,11 @@ class RolloutManager:
         )
 
     def set_weight_version(self, weight_version: int):
+        if self.weight_version is not None and weight_version < self.weight_version:
+            # The updater counter is per-actor and not checkpointed, so an FT failover to
+            # another cell restarts it; staleness would then go negative and admit the
+            # most off-policy groups instead of filtering them.
+            logger.warning(f"Engine weight version went backwards: {self.weight_version} -> {weight_version}")
         self.weight_version = weight_version
 
     def set_train_parallel_config(self, config: dict):

--- a/miles/ray/rollout/rollout_manager.py
+++ b/miles/ray/rollout/rollout_manager.py
@@ -378,8 +378,12 @@ class RolloutManager:
 
     def set_weight_version(self, weight_version: int):
         if self.weight_version is not None and weight_version < self.weight_version:
-            # the updater counter is per-cell and not checkpointed, so FT failover restarts it
-            logger.warning(f"Engine weight version went backwards: {self.weight_version} -> {weight_version}")
+            # a regression makes staleness negative, which admits the most off-policy groups
+            message = f"Engine weight version went backwards: {self.weight_version} -> {weight_version}"
+            # not fatal in production: this runs inside the retried update, so raising would
+            # error one cell after another until the FT quorum is gone
+            assert not self.args.ci_test, message
+            logger.warning(message)
         self.weight_version = weight_version
 
     def set_train_parallel_config(self, config: dict):

--- a/miles/ray/rollout/rollout_manager.py
+++ b/miles/ray/rollout/rollout_manager.py
@@ -60,6 +60,8 @@ class RolloutManager:
 
         self.pg = pg
         self.args = args
+        # set by the training actor after each weight update
+        self.weight_version: int | None = None
         # TODO make args immutable
         init_tracking(args, primary=False, router_addr=f"http://{args.sglang_router_ip}:{args.sglang_router_port}")
         object_store.init_instance(args, contribute_segment=False)
@@ -238,7 +240,9 @@ class RolloutManager:
         else:
             if self.use_experimental_refactor:
                 data = await asyncio.to_thread(
-                    call_rollout_function, self.generate_rollout, RolloutFnTrainInput(rollout_id=rollout_id)
+                    call_rollout_function,
+                    self.generate_rollout,
+                    RolloutFnTrainInput(rollout_id=rollout_id, weight_version=self.weight_version),
                 )
             else:
                 data = await asyncio.to_thread(
@@ -371,6 +375,9 @@ class RolloutManager:
         return await srv.check_weights(
             action=action, allow_quant_error=allow_quant_error, selector=selector, skip_list=skip_list
         )
+
+    def set_weight_version(self, weight_version: int):
+        self.weight_version = weight_version
 
     def set_train_parallel_config(self, config: dict):
         self.train_parallel_config = config

--- a/miles/ray/rollout/rollout_manager.py
+++ b/miles/ray/rollout/rollout_manager.py
@@ -378,9 +378,7 @@ class RolloutManager:
 
     def set_weight_version(self, weight_version: int):
         if self.weight_version is not None and weight_version < self.weight_version:
-            # The updater counter is per-actor and not checkpointed, so an FT failover to
-            # another cell restarts it; staleness would then go negative and admit the
-            # most off-policy groups instead of filtering them.
+            # the updater counter is per-cell and not checkpointed, so FT failover restarts it
             logger.warning(f"Engine weight version went backwards: {self.weight_version} -> {weight_version}")
         self.weight_version = weight_version
 

--- a/miles/ray/rollout/rollout_manager.py
+++ b/miles/ray/rollout/rollout_manager.py
@@ -377,9 +377,9 @@ class RolloutManager:
         )
 
     def set_weight_version(self, weight_version: int):
+        # warning instead of assert when use indep_dp ft
         if self.weight_version is not None and weight_version < self.weight_version:
             message = f"Engine weight version went backwards: {self.weight_version} -> {weight_version}"
-            # warning instead of assert when use indep_dp ft
             assert self.args.indep_dp, message
             logger.warning(message)
         self.weight_version = weight_version

--- a/miles/ray/rollout/rollout_manager.py
+++ b/miles/ray/rollout/rollout_manager.py
@@ -378,8 +378,12 @@ class RolloutManager:
 
     def set_weight_version(self, weight_version: int):
         if self.weight_version is not None and weight_version < self.weight_version:
-            # the updater counter is per-cell and not checkpointed, so FT failover restarts it
-            logger.warning(f"Engine weight version went backwards: {self.weight_version} -> {weight_version}")
+            # a regression makes staleness negative, which admits the most off-policy groups
+            message = f"Engine weight version went backwards: {self.weight_version} -> {weight_version}"
+            # only indep_dp can do this legitimately: the counter is per-cell, so a cell taking
+            # over after failover restarts it
+            assert self.args.indep_dp, message
+            logger.warning(message)
         self.weight_version = weight_version
 
     def set_train_parallel_config(self, config: dict):

--- a/miles/rollout/base_types.py
+++ b/miles/rollout/base_types.py
@@ -30,6 +30,9 @@ class RolloutFnBaseInput:
 # subclassing for different data in the future
 @dataclass(frozen=True)
 class RolloutFnTrainInput(RolloutFnBaseInput):
+    # engine weight version, None before the first weight update
+    weight_version: int | None = None
+
     @property
     def evaluation(self):
         return False

--- a/miles/rollout/fully_async_rollout.py
+++ b/miles/rollout/fully_async_rollout.py
@@ -18,10 +18,7 @@ rollout engines, pausing producer submissions for the duration of the
 
 import asyncio
 import logging
-import time
 from collections.abc import Iterator
-
-import httpx
 
 from miles.rollout.base_types import (
     RolloutFnConstructorInput,
@@ -29,13 +26,13 @@ from miles.rollout.base_types import (
     RolloutFnEvalOutput,
     RolloutFnInput,
     RolloutFnOutput,
+    RolloutFnTrainInput,
     RolloutFnTrainOutput,
 )
 from miles.rollout.filter_hub.base_types import MetricGatherer, call_dynamic_filter
 from miles.rollout.inference_rollout.inference_rollout_common import GenerateState, generate_and_rm_group
 from miles.rollout.inference_rollout.inference_rollout_eval import run_eval_datasets
 from miles.rollout.submission_scheduler import make_submission_scheduler
-from miles.utils.http_utils import get
 from miles.utils.misc import load_function
 from miles.utils.types import Sample
 
@@ -43,7 +40,6 @@ logger = logging.getLogger(__name__)
 
 OUTPUT_QUEUE_MAX_GROUPS = 1000
 NO_PROGRESS_WARN_SECS = 30.0
-WEIGHT_VERSION_QUERY_TIMEOUT_SECS = 2.0
 
 # A finished group is list[Sample], or list[list[Sample]] when a generate function
 # returns multiple samples per trajectory (e.g. multi-agent).
@@ -68,32 +64,6 @@ def group_oldest_weight_version(group: Group) -> int | None:
     return min(versions) if versions else None
 
 
-class _CachedWeightVersion:
-    """Throttled query of the current engine weight version via the router's /model_info."""
-
-    def __init__(self, ttl: float = 1.0):
-        self._ttl = ttl
-        self._value: int | None = None
-        self._last_query = float("-inf")
-
-    async def get(self, args) -> int | None:
-        # Throttles failures too: the drain queries once per group, and an unreachable
-        # router would otherwise cost every one of them the full timeout.
-        if (time.monotonic() - self._last_query) < self._ttl:
-            return self._value
-        url = f"http://{args.sglang_router_ip}:{args.sglang_router_port}/model_info"
-        try:
-            data = await asyncio.wait_for(get(url), timeout=WEIGHT_VERSION_QUERY_TIMEOUT_SECS)
-            self._value = int(data["weight_version"])
-        except (httpx.HTTPError, asyncio.TimeoutError) as e:
-            # Transient router unavailability; the staleness filter is best-effort.
-            logger.debug(f"Failed to query engine weight version: {e}")
-        finally:
-            # Stamped on completion, so a router slower than the TTL still gets throttled.
-            self._last_query = time.monotonic()
-        return self._value
-
-
 class FullyAsyncRolloutFn:
     """Continuous rollout generation decoupled from training steps.
 
@@ -111,7 +81,6 @@ class FullyAsyncRolloutFn:
         self._scheduler = make_submission_scheduler(input.args, default="sample")
         self._dynamic_filter = load_function(input.args.dynamic_sampling_filter_path)
         self._sample_filter = load_function(input.args.rollout_sample_filter_path)
-        self._weight_version = _CachedWeightVersion()
         self._worker: asyncio.Task | None = None
         self._eval_prompt_dataset_cache: dict = {}
         self._producer_resumed = asyncio.Event()
@@ -125,7 +94,7 @@ class FullyAsyncRolloutFn:
             self._output = asyncio.Queue(maxsize=OUTPUT_QUEUE_MAX_GROUPS)
             self._worker = asyncio.create_task(self._worker_loop())
             logger.info("Started fully-async rollout worker")
-        return await self._drain(input.rollout_id)
+        return await self._drain(input)
 
     async def _call_eval(self, input: RolloutFnEvalInput) -> RolloutFnOutput:
         if input.generate_state is not None:
@@ -208,7 +177,7 @@ class FullyAsyncRolloutFn:
             if not queue_get.done():
                 queue_get.cancel()
 
-    async def _drain(self, rollout_id: int) -> RolloutFnTrainOutput:
+    async def _drain(self, input: RolloutFnTrainInput) -> RolloutFnTrainOutput:
         args = self.args
         assert args.rollout_global_dataset
 
@@ -232,7 +201,7 @@ class FullyAsyncRolloutFn:
 
             if args.max_weight_staleness is not None:
                 oldest = group_oldest_weight_version(group)
-                current = await self._weight_version.get(args)
+                current = input.weight_version
                 if oldest is not None and current is not None:
                     staleness = current - oldest
                     staleness_values.append(staleness)

--- a/tests/fast/rollout/test_fully_async_rollout.py
+++ b/tests/fast/rollout/test_fully_async_rollout.py
@@ -7,7 +7,6 @@ from argparse import Namespace
 from collections import deque
 from dataclasses import replace
 
-import httpx
 import pytest
 
 import miles.rollout.fully_async_rollout as fully_async
@@ -220,13 +219,7 @@ async def test_stale_group_recycled(monkeypatch):
 
     fn = make_fn(monkeypatch, make_args(rollout_batch_size=1, max_weight_staleness=2), data_source)
 
-    class FakeWeightVersion:
-        async def get(self, args):
-            return 10
-
-    fn._weight_version = FakeWeightVersion()
-
-    output = await fn(RolloutFnTrainInput(rollout_id=0))
+    output = await fn(RolloutFnTrainInput(rollout_id=0, weight_version=10))
 
     assert data_source.recycled == [stale]
     assert output.metrics["rollout/fully_async/stale_groups_recycled"] == 1
@@ -362,27 +355,17 @@ async def test_sample_filter_marks_samples_without_shrinking_the_batch(monkeypat
     assert [sample.remove_sample for sample in output.samples[0]] == [True, False]
 
 
-async def test_weight_version_throttles_failed_queries(monkeypatch):
-    """A drain queries once per group, so an unreachable router must not cost one timeout each."""
-    calls = []
+async def test_staleness_filter_off_before_the_first_weight_update(monkeypatch):
+    """weight_version is None until the trainer pushes weights; staleness is unknown, not zero."""
+    stale = make_group(1, weight_versions=["5"])
+    data_source = FakeDataSource(scripted=[stale])
+    fn = make_fn(monkeypatch, make_args(rollout_batch_size=1, max_weight_staleness=0), data_source)
 
-    async def unreachable_router(url):
-        calls.append(url)
-        raise httpx.ConnectError("router down")
+    output = await fn(RolloutFnTrainInput(rollout_id=0))
 
-    monkeypatch.setattr(fully_async, "get", unreachable_router)
-    args = make_args()
-
-    throttled = fully_async._CachedWeightVersion(ttl=60.0)
-    assert await throttled.get(args) is None
-    assert await throttled.get(args) is None
-    assert len(calls) == 1
-
-    calls.clear()
-    expired = fully_async._CachedWeightVersion(ttl=0.0)
-    assert await expired.get(args) is None
-    assert await expired.get(args) is None
-    assert len(calls) == 2
+    assert data_source.recycled == []
+    assert output.samples[0][0].group_index == 1
+    assert "rollout/fully_async/max_staleness" not in output.metrics
 
 
 async def test_worker_defaults_to_sample_granularity(monkeypatch):


### PR DESCRIPTION
`FullyAsyncRolloutFn` needs the current engine weight version to measure and bound sample staleness. Today it rediscovers it over HTTP: `_CachedWeightVersion` polls the router's `/model_info` once per drained group, behind a 1s TTL cache that also throttles failures so an unreachable router does not cost one 2s timeout per group.

That number is ours. The trainer stamps it onto the engines (`update_weight_version(weight_version=str(self.weight_version))`), so polling reads back what miles just wrote.

## Change

`weight_updater.weight_version` → `RolloutManager.set_weight_version` → `RolloutFnTrainInput.weight_version` → the drain.

- Both training actors already hold `self.rollout_manager` and already call it at rank 0 inside `update_weights` (`clear_updatable_has_new_engines`); this adds one call right after the push completes, with the same precondition.
- `RolloutFnTrainInput` gains `weight_version: int | None`, mirroring `RolloutFnEvalInput`.
- `_CachedWeightVersion` and its HTTP/timeout/TTL machinery are deleted.

Same numbering on both sides: engines are stamped from this counter and `sample.weight_versions` come back from engine `meta_info`, so `current - group_oldest_weight_version` compares like with like — that is what the `ci_test` version assertion in the actors already checks.

`None` until the first weight update, which turns the staleness filter off rather than reporting staleness 0. `train_async.py` pushes weights once before the loop, so a real run has a version before its first drain.

## Notes

- The notify lands after `update_weights()` returns, i.e. after engines resume, so a brief window under-reports staleness. Smaller than the 1s TTL it replaces.
- No longer degrades to `None` on router flakiness, and no longer needs to special-case the engines' pre-update `"default"` string.

Motivated by #2030, which moves staleness control into the fully-async data buffer and pays this HTTP round trip on every consumed group. Independent of it — this lands on main and #2030 picks it up on the next merge.

## Tests

`test_stale_group_recycled` now passes the version on the input; `test_weight_version_throttles_failed_queries` is replaced by `test_staleness_filter_off_before_the_first_weight_update`, covering the `None` case.

⚠️ Not executed: the devbox was unreachable while preparing this. Verified locally with `py_compile` and `pre-commit run --all-files` only. Please run `tests/fast/rollout/test_fully_async_rollout.py` before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
