### PR TITLE
[1/2] feat(rollout): define train batch lease settlement

### DIFF
--- a/miles/rollout/base_types.py
+++ b/miles/rollout/base_types.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+from abc import ABC, abstractmethod
 from argparse import Namespace
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from enum import Enum, auto
 from typing import TYPE_CHECKING, Any
 
 from miles.rollout.data_source import DataSource
@@ -49,18 +51,93 @@ class RolloutFnEvalInput(RolloutFnBaseInput):
         return True
 
 
+class TrainBatchRollbackReason(Enum):
+    """Reason that a manager could not publish a leased train batch."""
+
+    HANDOFF_FAILED = auto()
+
+
+class TrainBatchLease(ABC):
+    """Own a rollout batch until the manager's train-data publication settles.
+
+    Args:
+        rollout_id: Training rollout that requested the batch.
+
+    A successful commit records that the manager published the complete
+    train-data result. It does not confirm that a remote caller received that
+    result. Settlement may be attempted only once, including when its
+    implementation raises.
+    """
+
+    def __init__(self, rollout_id: int) -> None:
+        self._rollout_id = rollout_id
+        self._settlement_attempted = False
+
+    @property
+    def rollout_id(self) -> int:
+        """Return the rollout that acquired this batch."""
+        return self._rollout_id
+
+    def commit(self) -> None:
+        """Record successful publication of the complete train-data result.
+
+        Raises:
+            RuntimeError: If any settlement was already attempted.
+        """
+        self._claim_settlement()
+        self._commit()
+
+    @abstractmethod
+    def _commit(self) -> None:
+        """Implement publication settlement after the lease is claimed."""
+
+    def rollback(self, reason: TrainBatchRollbackReason) -> None:
+        """Return ownership after train-data publication fails.
+
+        Args:
+            reason: Why the manager could not publish the result.
+
+        Raises:
+            RuntimeError: If any settlement was already attempted.
+        """
+        self._claim_settlement()
+        self._rollback(reason)
+
+    @abstractmethod
+    def _rollback(self, reason: TrainBatchRollbackReason) -> None:
+        """Implement publication recovery after settlement is claimed."""
+
+    def _claim_settlement(self) -> None:
+        if self._settlement_attempted:
+            raise RuntimeError(f"Train batch lease for rollout {self.rollout_id} already has a settlement attempt.")
+        self._settlement_attempted = True
+
+
 # TODO make it frozen
 @dataclass
 class RolloutFnTrainOutput:
     samples: list[list[Sample]]
-    metrics: dict[str, Any] = None
+    metrics: dict[str, Any] | None = None
+
+
+@dataclass
+class LeasedRolloutFnTrainOutput(RolloutFnTrainOutput):
+    """Carry ordinary train output data with its required settlement lease.
+
+    Args:
+        samples: Generated samples grouped by source prompt.
+        metrics: Optional rollout metrics.
+        lease: Ownership to settle after the manager publishes train data.
+    """
+
+    lease: TrainBatchLease = field(kw_only=True)
 
 
 # TODO make it frozen
 @dataclass
 class RolloutFnEvalOutput:
     data: dict[str, dict[str, Any]]
-    metrics: dict[str, Any] = None
+    metrics: dict[str, Any] | None = None
 
 
 RolloutFnInput = RolloutFnTrainInput | RolloutFnEvalInput

--- a/tests/fast/rollout/test_base_types.py
+++ b/tests/fast/rollout/test_base_types.py
@@ -1,0 +1,128 @@
+from tests.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="stage-a-cpu", labels=[])
+
+from collections.abc import Callable
+
+import pytest
+
+from miles.rollout.base_types import (
+    LeasedRolloutFnTrainOutput,
+    RolloutFnTrainOutput,
+    TrainBatchLease,
+    TrainBatchRollbackReason,
+)
+
+
+class RecordingTrainBatchLease(TrainBatchLease):
+    def __init__(
+        self,
+        rollout_id: int,
+        on_commit: Callable[[], None],
+        on_rollback: Callable[[TrainBatchRollbackReason], None],
+    ) -> None:
+        super().__init__(rollout_id=rollout_id)
+        self._on_commit = on_commit
+        self._on_rollback = on_rollback
+
+    def _commit(self) -> None:
+        self._on_commit()
+
+    def _rollback(self, reason: TrainBatchRollbackReason) -> None:
+        self._on_rollback(reason)
+
+
+def test_leased_output_preserves_the_ordinary_train_output_contract() -> None:
+    lease = RecordingTrainBatchLease(
+        rollout_id=3,
+        on_commit=lambda: None,
+        on_rollback=lambda reason: None,
+    )
+
+    output = LeasedRolloutFnTrainOutput(samples=[], metrics={"source": "test"}, lease=lease)
+
+    assert isinstance(output, RolloutFnTrainOutput)
+    assert output == LeasedRolloutFnTrainOutput(samples=[], metrics={"source": "test"}, lease=lease)
+
+
+def test_train_batch_lease_commits_once() -> None:
+    events: list[str] = []
+    lease = RecordingTrainBatchLease(
+        rollout_id=7,
+        on_commit=lambda: events.append("commit"),
+        on_rollback=lambda reason: events.append(f"rollback:{reason.name}"),
+    )
+
+    assert lease.rollout_id == 7
+    lease.commit()
+
+    assert events == ["commit"]
+    with pytest.raises(RuntimeError) as repeated_commit:
+        lease.commit()
+    assert str(repeated_commit.value) == "Train batch lease for rollout 7 already has a settlement attempt."
+    with pytest.raises(RuntimeError) as rollback_after_commit:
+        lease.rollback(TrainBatchRollbackReason.HANDOFF_FAILED)
+    assert str(rollback_after_commit.value) == "Train batch lease for rollout 7 already has a settlement attempt."
+
+
+def test_train_batch_lease_rolls_back_once() -> None:
+    reasons: list[TrainBatchRollbackReason] = []
+    lease = RecordingTrainBatchLease(
+        rollout_id=11,
+        on_commit=lambda: None,
+        on_rollback=reasons.append,
+    )
+
+    lease.rollback(TrainBatchRollbackReason.HANDOFF_FAILED)
+
+    assert reasons == [TrainBatchRollbackReason.HANDOFF_FAILED]
+    with pytest.raises(RuntimeError) as repeated_rollback:
+        lease.rollback(TrainBatchRollbackReason.HANDOFF_FAILED)
+    assert str(repeated_rollback.value) == "Train batch lease for rollout 11 already has a settlement attempt."
+    with pytest.raises(RuntimeError) as commit_after_rollback:
+        lease.commit()
+    assert str(commit_after_rollback.value) == "Train batch lease for rollout 11 already has a settlement attempt."
+
+
+def test_failed_commit_still_claims_the_only_settlement_attempt() -> None:
+    failure = RuntimeError("commit failed")
+
+    def fail_commit() -> None:
+        raise failure
+
+    lease = RecordingTrainBatchLease(
+        rollout_id=13,
+        on_commit=fail_commit,
+        on_rollback=lambda reason: None,
+    )
+
+    with pytest.raises(RuntimeError) as error:
+        lease.commit()
+    assert error.value is failure
+    with pytest.raises(RuntimeError) as rollback_after_failed_commit:
+        lease.rollback(TrainBatchRollbackReason.HANDOFF_FAILED)
+    assert (
+        str(rollback_after_failed_commit.value) == "Train batch lease for rollout 13 already has a settlement attempt."
+    )
+
+
+def test_failed_rollback_still_claims_the_only_settlement_attempt() -> None:
+    failure = RuntimeError("rollback failed")
+
+    def fail_rollback(reason: TrainBatchRollbackReason) -> None:
+        raise failure
+
+    lease = RecordingTrainBatchLease(
+        rollout_id=17,
+        on_commit=lambda: None,
+        on_rollback=fail_rollback,
+    )
+
+    with pytest.raises(RuntimeError) as error:
+        lease.rollback(TrainBatchRollbackReason.HANDOFF_FAILED)
+    assert error.value is failure
+    with pytest.raises(RuntimeError) as commit_after_failed_rollback:
+        lease.commit()
+    assert (
+        str(commit_after_failed_rollback.value) == "Train batch lease for rollout 17 already has a settlement attempt."
+    )


### PR DESCRIPTION
## Summary

- Adds an explicit lease for a generated train batch.
- Requires each lease to commit or roll back through one settlement attempt.
- Defines the ownership contract used by the Ray publication integration in [#2248](https://github.com/radixark/miles/pull/2248).

## Context

Fully async rollout cannot settle source ownership when generation returns. The rollout manager still has to convert the samples, publish the complete train-data result, and handle failures during publication.

A train-batch lease keeps ownership attached to the generated batch until manager-side publication commits or rolls back. A successful commit means that the manager published the complete result. [#2286](https://github.com/radixark/miles/pull/2286) owns remote trainer acknowledgement.

[Issue #2254](https://github.com/radixark/miles/issues/2254) uses this lease as the manager-publication contract in the foundation stack.

| Layer | Upstream PR | Status | Contract |
| --- | --- | --- | --- |
| 1/2 | [#2246](https://github.com/radixark/miles/pull/2246) | Draft | Train-batch lease |
| 2/2 | [#2248](https://github.com/radixark/miles/pull/2248) | Draft | Manager-side Ray publication settlement |

The logical parent is `main`. Both public drafts target `main` because GitHub cannot select an external-fork branch as an upstream base ref. Until this PR merges, the second PR shows this commit in Commits and Files changed. Merge the chain in order. If this PR is squash-merged or rebase-merged, the child branch will be rebased onto the updated `main`.

Review this layer as the lease contract. It owns one commit: [`fc570c20` defines train-batch settlement](https://github.com/radixark/miles/pull/2246/commits/fc570c20be36b4668753facfabfe85d4dfc133cd). This layer leaves runtime call sites unchanged. [#2248](https://github.com/radixark/miles/pull/2248) applies the contract to Ray publication.

## Description

- Adds `TrainBatchLease` with explicit `commit()` and `rollback()` operations.
- Defines `HANDOFF_FAILED` as the rollback reason for manager-side publication failure.
- Claims settlement before calling the lease implementation, so an exception cannot permit a conflicting second attempt.
- Rejects duplicate commit, duplicate rollback, and commit-after-rollback.
- Adds `LeasedRolloutFnTrainOutput` while preserving ordinary `RolloutFnTrainOutput` for callers that do not use a lease.

## Test plan

- [x] `tests/fast/rollout/test_base_types.py`: 5 train-batch lease tests passed at exact head `fc570c20be`.
- [x] An exact composed 8xB200 validation exercised one successful lease commit and one `HANDOFF_FAILED` rollback. Each lease completed one settlement path.
- [x] The composed 8xB200 run used Miles ref [`7cd212d81f`](https://github.com/ashtonchew/miles/commit/7cd212d81f6c94f72d67b4443e8c047008e4d517) with validation child [`cf512e6a8a`](https://github.com/GymPod/slime/commit/cf512e6a8a59c7c935e273dc69b9fd84c32e35a3). This evidence covers one lease commit and one rollback in composition. Isolated PR-head and full training evidence require separate runs.
