### PR TITLE
[1/6] feat(rollout): fingerprint logical rollout sources

### DIFF
--- a/miles/utils/source_fingerprint.py
+++ b/miles/utils/source_fingerprint.py
@@ -1,0 +1,200 @@
+import datetime
+import decimal
+import hashlib
+import os
+import struct
+import uuid
+from collections.abc import Mapping
+from enum import Enum
+from typing import cast
+
+import numpy
+import torch
+from PIL import Image
+
+
+def _digest_parts(tag: bytes, *parts: bytes) -> bytes:
+    digest = hashlib.sha256()
+    digest.update(tag)
+    for part in parts:
+        digest.update(len(part).to_bytes(8, byteorder="big"))
+        digest.update(part)
+    return digest.digest()
+
+
+def _numpy_dtype_digest(dtype: numpy.dtype[numpy.generic]) -> bytes:
+    metadata = canonical_source_digest(dtype.metadata)
+    if dtype.fields is not None:
+        fields = []
+        for name in dtype.names or ():
+            field = dtype.fields[name]
+            field_dtype = field[0]
+            offset = field[1]
+            title = field[2] if len(field) == 3 else None
+            fields.append(
+                _digest_parts(
+                    b"field",
+                    canonical_source_digest(name),
+                    _numpy_dtype_digest(field_dtype),
+                    canonical_source_digest(offset),
+                    canonical_source_digest(title),
+                )
+            )
+        return _digest_parts(
+            b"structured-dtype",
+            canonical_source_digest(dtype.itemsize),
+            canonical_source_digest(dtype.isalignedstruct),
+            metadata,
+            *fields,
+        )
+    if dtype.subdtype is not None:
+        base_dtype, shape = dtype.subdtype
+        return _digest_parts(
+            b"subarray-dtype",
+            _numpy_dtype_digest(base_dtype),
+            canonical_source_digest(shape),
+            metadata,
+        )
+    return _digest_parts(b"dtype", dtype.str.encode(), metadata)
+
+
+def _numpy_has_extended_precision(dtype: numpy.dtype[numpy.generic]) -> bool:
+    return (dtype.kind == "f" and dtype.itemsize > 8) or (dtype.kind == "c" and dtype.itemsize > 16)
+
+
+def _numpy_extended_scalar_digest(value: numpy.generic) -> bytes:
+    if value.dtype.kind == "f":
+        formatted = numpy.format_float_scientific(cast(float, value), unique=True, trim="k")
+        return _digest_parts(b"extended-float", formatted.encode())
+    if value.dtype.kind == "c":
+        complex_value = cast(complex, value)
+        formatted_real = numpy.format_float_scientific(complex_value.real, unique=True, trim="k")
+        formatted_imag = numpy.format_float_scientific(complex_value.imag, unique=True, trim="k")
+        return _digest_parts(b"extended-complex", formatted_real.encode(), formatted_imag.encode())
+    raise TypeError(f"NumPy dtype {value.dtype} is not an extended floating-point type.")
+
+
+def canonical_source_digest(value: object) -> bytes:
+    """Return a deterministic digest for one logical source value.
+
+    Args:
+        value: A source-owned scalar or nested container. Mapping and set
+            iteration order does not affect the digest.
+
+    Returns:
+        A SHA-256 digest that preserves value types and sequence order.
+
+    Raises:
+        TypeError: If the value has no stable logical representation.
+    """
+    if value is None:
+        return _digest_parts(b"none")
+    if isinstance(value, Enum):
+        enum_type = f"{value.__class__.__module__}.{value.__class__.__qualname__}"
+        return _digest_parts(b"enum", enum_type.encode(), canonical_source_digest(value.value))
+    if isinstance(value, numpy.generic):
+        if value.dtype.hasobject or value.dtype.fields is not None:
+            scalar_value = canonical_source_digest(value.tolist())
+        elif _numpy_has_extended_precision(value.dtype):
+            scalar_value = _numpy_extended_scalar_digest(value)
+        else:
+            scalar_value = value.tobytes()
+        return _digest_parts(b"numpy-scalar", _numpy_dtype_digest(value.dtype), scalar_value)
+    if isinstance(value, bool):
+        return _digest_parts(b"bool", b"1" if value else b"0")
+    if isinstance(value, int):
+        return _digest_parts(b"int", str(value).encode())
+    if isinstance(value, float):
+        return _digest_parts(b"float", struct.pack("!d", value))
+    if isinstance(value, str):
+        return _digest_parts(b"str", value.encode())
+    if isinstance(value, (bytes, bytearray, memoryview)):
+        return _digest_parts(b"bytes", bytes(value))
+    if isinstance(value, decimal.Decimal):
+        return _digest_parts(b"decimal", str(value).encode())
+    if isinstance(value, datetime.datetime):
+        return _digest_parts(b"datetime", value.isoformat().encode())
+    if isinstance(value, datetime.date):
+        return _digest_parts(b"date", value.isoformat().encode())
+    if isinstance(value, datetime.time):
+        return _digest_parts(b"time", value.isoformat().encode())
+    if isinstance(value, datetime.timedelta):
+        nanoseconds = getattr(value, "nanoseconds", 0)
+        return _digest_parts(
+            b"timedelta",
+            canonical_source_digest(value.days),
+            canonical_source_digest(value.seconds),
+            canonical_source_digest(value.microseconds),
+            canonical_source_digest(nanoseconds),
+        )
+    if isinstance(value, uuid.UUID):
+        return _digest_parts(b"uuid", value.bytes)
+    if isinstance(value, os.PathLike):
+        return _digest_parts(b"path", os.fsencode(value))
+    if isinstance(value, torch.Tensor):
+        if value.layout != torch.strided:
+            raise TypeError(f"Cannot fingerprint tensor with layout {value.layout}.")
+        if value.is_quantized:
+            raise TypeError("Cannot fingerprint quantized tensors.")
+        tensor = value.detach().resolve_conj().resolve_neg().cpu().contiguous()
+        tensor_bytes = tensor.reshape(-1).view(torch.uint8).numpy().tobytes()
+        return _digest_parts(
+            b"tensor",
+            str(tensor.dtype).encode(),
+            canonical_source_digest(tuple(tensor.shape)),
+            tensor_bytes,
+        )
+    if isinstance(value, numpy.ma.MaskedArray):
+        return _digest_parts(
+            b"masked-array",
+            _numpy_dtype_digest(value.dtype),
+            canonical_source_digest(value.shape),
+            canonical_source_digest(value.data),
+            canonical_source_digest(numpy.ma.getmaskarray(value)),
+            canonical_source_digest(value.fill_value),
+        )
+    if isinstance(value, numpy.ndarray):
+        if value.dtype.hasobject or value.dtype.fields is not None or _numpy_has_extended_precision(value.dtype):
+            array_bytes = canonical_source_digest(value.tolist())
+        else:
+            array_bytes = numpy.ascontiguousarray(value).tobytes()
+        return _digest_parts(
+            b"ndarray",
+            _numpy_dtype_digest(value.dtype),
+            canonical_source_digest(value.shape),
+            array_bytes,
+        )
+    if isinstance(value, Image.Image):
+        return _digest_parts(
+            b"image",
+            value.mode.encode(),
+            canonical_source_digest(value.size),
+            canonical_source_digest(value.format),
+            value.tobytes(),
+            canonical_source_digest(value.getpalette()),
+            canonical_source_digest(value.info),
+            value.getexif().tobytes(),
+        )
+    if isinstance(value, Mapping):
+        entries = sorted(
+            _digest_parts(b"entry", canonical_source_digest(key), canonical_source_digest(item))
+            for key, item in value.items()
+        )
+        return _digest_parts(b"mapping", *entries)
+    if isinstance(value, list):
+        return _digest_parts(b"list", *(canonical_source_digest(item) for item in value))
+    if isinstance(value, tuple):
+        return _digest_parts(b"tuple", *(canonical_source_digest(item) for item in value))
+    if isinstance(value, set):
+        return _digest_parts(
+            b"set",
+            *(sorted(canonical_source_digest(item) for item in value)),
+        )
+    if isinstance(value, frozenset):
+        return _digest_parts(
+            b"frozenset",
+            *(sorted(canonical_source_digest(item) for item in value)),
+        )
+    raise TypeError(
+        f"Cannot fingerprint rollout source value of type {value.__class__.__module__}.{value.__class__.__qualname__}."
+    )

--- a/tests/fast/utils/test_source_fingerprint.py
+++ b/tests/fast/utils/test_source_fingerprint.py
@@ -1,0 +1,76 @@
+import numpy
+import pytest
+import torch
+from PIL import Image
+
+from miles.utils.source_fingerprint import canonical_source_digest
+
+
+def test_canonical_source_digest_ignores_mapping_order() -> None:
+    first = {"prompt": "inspect", "metadata": {"left": 1, "right": 2}}
+    second = {"metadata": {"right": 2, "left": 1}, "prompt": "inspect"}
+
+    assert canonical_source_digest(first) == canonical_source_digest(second)
+
+
+def test_canonical_source_digest_distinguishes_value_types() -> None:
+    assert canonical_source_digest(True) != canonical_source_digest(1)
+    assert canonical_source_digest(b"1") != canonical_source_digest("1")
+    assert canonical_source_digest([1]) != canonical_source_digest((1,))
+
+
+def test_canonical_source_digest_normalizes_tensor_views() -> None:
+    tensor = torch.arange(6, dtype=torch.int64).reshape(2, 3)
+    noncontiguous = tensor.t().contiguous().t()
+
+    assert not noncontiguous.is_contiguous()
+    assert canonical_source_digest(tensor) == canonical_source_digest(noncontiguous)
+
+
+def test_canonical_source_digest_includes_image_payload() -> None:
+    first = Image.fromarray(numpy.array([[0, 1], [2, 3]], dtype=numpy.uint8))
+    second = Image.fromarray(numpy.array([[0, 1], [2, 4]], dtype=numpy.uint8))
+
+    assert canonical_source_digest(first) != canonical_source_digest(second)
+
+
+def test_canonical_source_digest_includes_image_metadata() -> None:
+    first = Image.new("RGB", (2, 1), color="red")
+    second = first.copy()
+    first.getexif()[274] = 1
+    second.getexif()[274] = 6
+    assert canonical_source_digest(first) != canonical_source_digest(second)
+
+    second.getexif()[274] = 1
+    first.info["icc_profile"] = b"first"
+    second.info["icc_profile"] = b"second"
+    assert canonical_source_digest(first) != canonical_source_digest(second)
+
+
+def test_canonical_source_digest_normalizes_object_arrays() -> None:
+    first = numpy.array([{"left": 1, "right": 2}, ["value"]], dtype=object)
+    second = numpy.array([{"right": 2, "left": 1}, ["value"]], dtype=object)
+
+    assert canonical_source_digest(first) == canonical_source_digest(second)
+
+
+def test_canonical_source_digest_includes_structured_dtype() -> None:
+    first = numpy.array([(1, 2)], dtype=[("left", "<i4"), ("right", "<i4")])
+    second = numpy.array([(1, 2)], dtype=[("right", "<i4"), ("left", "<i4")])
+
+    assert canonical_source_digest(first) != canonical_source_digest(second)
+
+
+def test_canonical_source_digest_rejects_quantized_tensors() -> None:
+    tensor = torch.quantize_per_tensor(torch.tensor([1.0]), scale=0.1, zero_point=0, dtype=torch.qint8)
+
+    with pytest.raises(TypeError, match="Cannot fingerprint quantized tensors."):
+        canonical_source_digest(tensor)
+
+
+def test_canonical_source_digest_rejects_unstable_values() -> None:
+    with pytest.raises(
+        TypeError,
+        match="Cannot fingerprint rollout source value of type builtins.object.",
+    ):
+        canonical_source_digest(object())


### PR DESCRIPTION
## Summary

- Adds a deterministic digest for source-owned rollout values.
- Preserves value type, sequence order, array and tensor representation, and image metadata.
- Provides the source identity that #2250 uses for reservation persistence.

## Context

Reservation replay must prove that a saved group still refers to the same source data after restart. Python object hashes are process-local. Mapping and set iteration order can change without changing the logical value.

This layer defines a stable digest for supported source values. The check is intentionally conservative. Resume fails closed when a material representation changes, including NumPy dtype byte order or image metadata.

[Issue #2254](https://github.com/radixark/miles/issues/2254) uses this digest to verify source identity during checkpoint replay.

| Layer | Upstream PR | Status | Contract |
| --- | --- | --- | --- |
| 1/6 | [#2247](https://github.com/radixark/miles/pull/2247) | Draft | Stable source fingerprint |
| 2/6 | [#2249](https://github.com/radixark/miles/pull/2249) | Draft | Source reservations |
| 3/6 | [#2250](https://github.com/radixark/miles/pull/2250) | Draft | Reservation persistence and replay |
| 4/6 | [#2251](https://github.com/radixark/miles/pull/2251) | Draft | Exact execution receipts |
| 5/6 | [#2252](https://github.com/radixark/miles/pull/2252) | Draft | Receipt-bound inference execution |
| 6/6 | [#2253](https://github.com/radixark/miles/pull/2253) | Draft | Terminal cancellation ownership |

The logical parent is `main`. All public drafts target `main` because GitHub cannot select an external-fork branch as an upstream base ref. Descendants appear cumulative until their parents merge. Merge the chain in order. If a parent is squash-merged or rebase-merged, the remaining branches will be rebased onto the updated `main`.

Review this layer as the source-identity utility. It owns one commit: [`78910c73` fingerprints logical rollout sources](https://github.com/radixark/miles/pull/2247/commits/78910c7351feddabbd3be8039d74c7f5d3958e1a). It only defines source identity. [#2249](https://github.com/radixark/miles/pull/2249) introduces reservation attempts, and [#2250](https://github.com/radixark/miles/pull/2250) uses the digest during checkpoint replay.

## Description

- Canonically hashes supported scalars and nested containers.
- Ignores mapping and set iteration order while preserving list, tuple, and array element order.
- Includes NumPy dtype structure, shape, metadata, byte order, and values.
- Includes tensor dtype, shape, and contiguous value bytes.
- Includes image mode, size, format, pixels, palette, metadata, and EXIF data.
- Rejects quantized tensors, unsupported tensor layouts, and values without a stable representation.

## Test plan

- [x] `tests/fast/utils/test_source_fingerprint.py`: 9 tests passed at exact head `78910c7351`.
- [x] An exact composed 8xB200 validation saved and reloaded source state through fingerprint validation before replaying reservations `0` and `1`.
- [x] The composed 8xB200 run used Miles ref [`7cd212d81f`](https://github.com/ashtonchew/miles/commit/7cd212d81f6c94f72d67b4443e8c047008e4d517) with validation child [`cf512e6a8a`](https://github.com/GymPod/slime/commit/cf512e6a8a59c7c935e273dc69b9fd84c32e35a3). This evidence covers checkpoint reload with matching fingerprints. Mismatch detection, isolated PR-head behavior, and full training require separate runs.

## Risks and follow-ups

Miles treats representation changes as source changes even when a caller considers the decoded values equivalent. This keeps replay fail closed when Miles cannot prove source identity.
