### PR TITLE
[2/2] feat(ray): settle leased rollout publication

### DIFF
--- a/miles/ray/rollout/rollout_manager.py
+++ b/miles/ray/rollout/rollout_manager.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 import time
 from dataclasses import dataclass
+from typing import cast
 
 import ray
 from sglang.srt.constants import GPU_MEMORY_TYPE_CUDA_GRAPH, GPU_MEMORY_TYPE_KV_CACHE, GPU_MEMORY_TYPE_WEIGHTS
@@ -22,9 +23,13 @@ from miles.ray.rollout.train_data_conversion import (
 )
 from miles.ray.utils import Lock
 from miles.rollout.base_types import (
+    LeasedRolloutFnTrainOutput,
     RolloutFnConstructorInput,
     RolloutFnEvalInput,
     RolloutFnTrainInput,
+    RolloutFnTrainOutput,
+    TrainBatchLease,
+    TrainBatchRollbackReason,
     call_rollout_fn,
 )
 from miles.rollout.checkpoint_eval import CheckpointEvalFn, EvalSkip
@@ -48,6 +53,22 @@ logging.getLogger("httpcore").setLevel(logging.WARNING)
 
 
 logger = logging.getLogger(__name__)
+
+
+def _remove_train_data_refs(
+    data_ref: object_store.StoreObjectRef | list[object_store.StoreObjectRef],
+) -> None:
+    refs = data_ref if isinstance(data_ref, list) else [data_ref]
+    store = object_store.get_instance()
+    first_error: BaseException | None = None
+    for ref in refs:
+        try:
+            store.remove(ref)
+        except BaseException as error:
+            if first_error is None:
+                first_error = error
+    if first_error is not None:
+        raise first_error
 
 
 @ray.remote
@@ -150,23 +171,66 @@ class RolloutManager:
         dashboard_hooks.register_engines(self.servers)
         if (get_buffer_length := getattr(self.data_source, "get_buffer_length", None)) is not None:
             dashboard_hooks.report_data_buffer(get_buffer_length())
-        with timer("rollout"):
-            data, metadata, metrics = await self._get_rollout_data(rollout_id=rollout_id)
-        save_debug_rollout_data(self.args, data, rollout_id=rollout_id, evaluation=False, metadata=metadata)
-        log_rollout_data(rollout_id, self.args, data, metrics, time.time() - start_time)
-        data = convert_samples_to_train_data(
-            self.args,
-            data,
-            metadata=metadata,
-            custom_convert_samples_to_train_data_func=self.custom_convert_samples_to_train_data_func,
-            custom_reward_post_process_func=self.custom_reward_post_process_func,
-        )
-        sample_indices = data.get("sample_indices")
-        if self.args.delay_split_train_data_by_dp:
-            data_ref = object_store.get_instance().put(value=data, value_spec=ROLLOUT_DATA_VALUE_SPEC)
-        else:
-            data_ref = split_train_data_by_dp(self.args, data, self.train_parallel_config)
-        return dict(sample_indices=sample_indices, data_ref=data_ref)
+        lease: TrainBatchLease | None = None
+        try:
+            with timer("rollout"):
+                if self.args.load_debug_rollout_data is not None:
+                    data, metadata = load_debug_rollout_data(self.args, rollout_id=rollout_id)
+                    metrics = None
+                else:
+                    output = await self._get_rollout_output(rollout_id)
+                    if isinstance(output, LeasedRolloutFnTrainOutput):
+                        lease = output.lease
+                        if lease.rollout_id != rollout_id:
+                            raise ValueError(
+                                f"Leased train output for rollout {rollout_id} carries a lease "
+                                f"for rollout {lease.rollout_id}."
+                            )
+                    data = output.samples
+                    metrics = output.metrics
+                    data, metadata = postprocess_rollout_data(
+                        self.args, data, train_parallel_config=self.train_parallel_config
+                    )
+                    if RolloutDataInjectionUtil.should_inject(self.args, rollout_id):
+                        generated_data = data
+                        data, metadata = RolloutDataInjectionUtil.load(self.args, rollout_id=rollout_id)
+                        RolloutDataInjectionUtil.assert_matches_generated(
+                            self.args, generated=generated_data, injected=data, rollout_id=rollout_id
+                        )
+                        metrics = None
+            save_debug_rollout_data(self.args, data, rollout_id=rollout_id, evaluation=False, metadata=metadata)
+            log_rollout_data(rollout_id, self.args, data, metrics, time.time() - start_time)
+            data = convert_samples_to_train_data(
+                self.args,
+                data,
+                metadata=metadata,
+                custom_convert_samples_to_train_data_func=self.custom_convert_samples_to_train_data_func,
+                custom_reward_post_process_func=self.custom_reward_post_process_func,
+            )
+            sample_indices = data.get("sample_indices")
+            if self.args.delay_split_train_data_by_dp:
+                data_ref = object_store.get_instance().put(value=data, value_spec=ROLLOUT_DATA_VALUE_SPEC)
+            else:
+                data_ref = split_train_data_by_dp(self.args, data, self.train_parallel_config)
+            result = dict(sample_indices=sample_indices, data_ref=data_ref)
+        except BaseException as handoff_error:
+            if lease is not None:
+                try:
+                    lease.rollback(TrainBatchRollbackReason.HANDOFF_FAILED)
+                except BaseException as rollback_error:
+                    raise handoff_error from rollback_error
+            raise
+
+        if lease is not None:
+            try:
+                lease.commit()
+            except BaseException as commit_error:
+                try:
+                    _remove_train_data_refs(data_ref)
+                except BaseException as cleanup_error:
+                    raise commit_error from cleanup_error
+                raise
+        return result
 
     async def eval(
         self,
@@ -240,35 +304,46 @@ class RolloutManager:
     def report_eval_skip(self, rollout_id: int, reason: str) -> None:
         log_eval_skip(rollout_id, self.args, reason)
 
-    async def _get_rollout_data(self, rollout_id):
-        if self.args.load_debug_rollout_data is not None:
-            data, metadata = load_debug_rollout_data(self.args, rollout_id=rollout_id)
-            metrics = None
-        else:
-            if not self.use_legacy_rollout_v1:
-                data = await asyncio.to_thread(
+    async def _get_rollout_output(self, rollout_id: int) -> RolloutFnTrainOutput:
+        if not self.use_legacy_rollout_v1:
+            rollout_task = asyncio.create_task(
+                asyncio.to_thread(
                     call_rollout_function,
                     self.generate_rollout,
                     RolloutFnTrainInput(rollout_id=rollout_id, weight_version=self.weight_version),
                 )
-            else:
-                data = await asyncio.to_thread(
-                    call_rollout_fn, self.generate_rollout, self.args, rollout_id, self.data_source, evaluation=False
-                )
-            metrics = data.metrics
-            data = data.samples
-            data, metadata = postprocess_rollout_data(
-                self.args, data, train_parallel_config=self.train_parallel_config
             )
-            if RolloutDataInjectionUtil.should_inject(self.args, rollout_id):
-                generated_data = data
-                data, metadata = RolloutDataInjectionUtil.load(self.args, rollout_id=rollout_id)
-                RolloutDataInjectionUtil.assert_matches_generated(
-                    self.args, generated=generated_data, injected=data, rollout_id=rollout_id
+        else:
+            rollout_task = asyncio.create_task(
+                asyncio.to_thread(
+                    call_rollout_fn,
+                    self.generate_rollout,
+                    self.args,
+                    rollout_id,
+                    self.data_source,
+                    evaluation=False,
                 )
-                metrics = None
+            )
 
-        return data, metadata, metrics
+        try:
+            return await asyncio.shield(cast(asyncio.Task[RolloutFnTrainOutput], rollout_task))
+        except asyncio.CancelledError as cancellation_error:
+            if rollout_task.cancelled():
+                raise
+            try:
+                # Cancellation cannot stop the worker thread, so keep its Task shielded until settlement is possible.
+                while not rollout_task.done():
+                    try:
+                        await asyncio.shield(rollout_task)
+                    except asyncio.CancelledError:
+                        if rollout_task.cancelled():
+                            raise
+                output = rollout_task.result()
+                if isinstance(output, LeasedRolloutFnTrainOutput):
+                    output.lease.rollback(TrainBatchRollbackReason.HANDOFF_FAILED)
+            except BaseException as cleanup_error:
+                raise cancellation_error from cleanup_error
+            raise
 
     # -------------------------- checkpointing -----------------------------
 

--- a/miles/ray/rollout/train_data_conversion.py
+++ b/miles/ray/rollout/train_data_conversion.py
@@ -282,7 +282,22 @@ def split_train_data_by_dp(args, data: dict[str, Any], train_parallel_config: di
     else:
         shards = split_train_data_by_dp_raw(args, data, dp_size=train_parallel_config["dp_size"])
     store = object_store.get_instance()
-    return [store.put(value=shard, value_spec=ROLLOUT_DATA_VALUE_SPEC) for shard in shards]
+    published_refs: list[object_store.StoreObjectRef] = []
+    try:
+        for shard in shards:
+            published_refs.append(store.put(value=shard, value_spec=ROLLOUT_DATA_VALUE_SPEC))
+    except BaseException as publication_error:
+        cleanup_error: BaseException | None = None
+        for ref in published_refs:
+            try:
+                store.remove(ref)
+            except BaseException as error:
+                if cleanup_error is None:
+                    cleanup_error = error
+        if cleanup_error is not None:
+            raise publication_error from cleanup_error
+        raise
+    return published_refs
 
 
 def can_schedule_on_rollout_side(args, data: dict[str, Any], train_parallel_config: dict | None) -> bool:

--- a/miles/rollout/base_types.py
+++ b/miles/rollout/base_types.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+from abc import ABC, abstractmethod
 from argparse import Namespace
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from enum import Enum, auto
 from typing import TYPE_CHECKING, Any
 
 from miles.rollout.data_source import DataSource
@@ -49,18 +51,93 @@ class RolloutFnEvalInput(RolloutFnBaseInput):
         return True
 
 
+class TrainBatchRollbackReason(Enum):
+    """Reason that a manager could not publish a leased train batch."""
+
+    HANDOFF_FAILED = auto()
+
+
+class TrainBatchLease(ABC):
+    """Own a rollout batch until the manager's train-data publication settles.
+
+    Args:
+        rollout_id: Training rollout that requested the batch.
+
+    A successful commit records that the manager published the complete
+    train-data result. It does not confirm that a remote caller received that
+    result. Settlement may be attempted only once, including when its
+    implementation raises.
+    """
+
+    def __init__(self, rollout_id: int) -> None:
+        self._rollout_id = rollout_id
+        self._settlement_attempted = False
+
+    @property
+    def rollout_id(self) -> int:
+        """Return the rollout that acquired this batch."""
+        return self._rollout_id
+
+    def commit(self) -> None:
+        """Record successful publication of the complete train-data result.
+
+        Raises:
+            RuntimeError: If any settlement was already attempted.
+        """
+        self._claim_settlement()
+        self._commit()
+
+    @abstractmethod
+    def _commit(self) -> None:
+        """Implement publication settlement after the lease is claimed."""
+
+    def rollback(self, reason: TrainBatchRollbackReason) -> None:
+        """Return ownership after train-data publication fails.
+
+        Args:
+            reason: Why the manager could not publish the result.
+
+        Raises:
+            RuntimeError: If any settlement was already attempted.
+        """
+        self._claim_settlement()
+        self._rollback(reason)
+
+    @abstractmethod
+    def _rollback(self, reason: TrainBatchRollbackReason) -> None:
+        """Implement publication recovery after settlement is claimed."""
+
+    def _claim_settlement(self) -> None:
+        if self._settlement_attempted:
+            raise RuntimeError(f"Train batch lease for rollout {self.rollout_id} already has a settlement attempt.")
+        self._settlement_attempted = True
+
+
 # TODO make it frozen
 @dataclass
 class RolloutFnTrainOutput:
     samples: list[list[Sample]]
-    metrics: dict[str, Any] = None
+    metrics: dict[str, Any] | None = None
+
+
+@dataclass
+class LeasedRolloutFnTrainOutput(RolloutFnTrainOutput):
+    """Carry ordinary train output data with its required settlement lease.
+
+    Args:
+        samples: Generated samples grouped by source prompt.
+        metrics: Optional rollout metrics.
+        lease: Ownership to settle after the manager publishes train data.
+    """
+
+    lease: TrainBatchLease = field(kw_only=True)
 
 
 # TODO make it frozen
 @dataclass
 class RolloutFnEvalOutput:
     data: dict[str, dict[str, Any]]
-    metrics: dict[str, Any] = None
+    metrics: dict[str, Any] | None = None
 
 
 RolloutFnInput = RolloutFnTrainInput | RolloutFnEvalInput

--- a/tests/fast/ray/rollout/real_ray/test_rollout_manager.py
+++ b/tests/fast/ray/rollout/real_ray/test_rollout_manager.py
@@ -20,7 +20,27 @@ import ray
 from tests.fast.ray.rollout.conftest import make_args, make_samples_grouped
 
 from miles.ray.rollout.rollout_manager import RolloutManager
-from miles.rollout.base_types import RolloutFnEvalInput, RolloutFnEvalOutput, RolloutFnTrainInput, RolloutFnTrainOutput
+from miles.rollout.base_types import (
+    LeasedRolloutFnTrainOutput,
+    RolloutFnEvalInput,
+    RolloutFnEvalOutput,
+    RolloutFnTrainInput,
+    RolloutFnTrainOutput,
+    TrainBatchLease,
+    TrainBatchRollbackReason,
+)
+
+
+class RecordingTrainBatchLease(TrainBatchLease):
+    def __init__(self, rollout_id: int, events: list[str]) -> None:
+        super().__init__(rollout_id=rollout_id)
+        self._events = events
+
+    def _commit(self) -> None:
+        self._events.append("commit")
+
+    def _rollback(self, reason: TrainBatchRollbackReason) -> None:
+        self._events.append(f"rollback:{reason.name}")
 
 
 @pytest.fixture
@@ -625,6 +645,42 @@ class TestGenerate:
             assert "loss_masks" in partition
             # 8 samples / 2 dp = 4 per rank
             assert len(partition["tokens"]) == 4
+
+    async def test_commits_leased_output_after_every_dp_shard_is_published(
+        self,
+        ray_local_mode,
+        placement_group_factory,
+        tmp_path,
+        patch_low_level,
+        monkeypatch,
+    ):
+        args = _make_test_args(tmp_path, models=[("actor", True)])
+        args.global_batch_size = 8
+        pg = placement_group_factory(2)
+
+        manager = _make_manager(args, pg)
+        manager.train_parallel_config = {"dp_size": 2}
+
+        events: list[str] = []
+        lease = RecordingTrainBatchLease(rollout_id=42, events=events)
+        manager.generate_rollout = lambda input: LeasedRolloutFnTrainOutput(
+            samples=[make_samples_grouped(n_groups=2, group_size=4)],
+            metrics={"my_metric": 1.23},
+            lease=lease,
+        )
+        original_ray_put = ray.put
+
+        def recording_ray_put(value):
+            events.append("publish")
+            return original_ray_put(value)
+
+        monkeypatch.setattr(ray, "put", recording_ray_put)
+
+        result = await manager.generate(rollout_id=42)
+
+        assert events == ["publish", "publish", "commit"]
+        assert set(result) == {"sample_indices", "data_ref"}
+        assert len(result["data_ref"]) == 2
 
 
 @pytest.mark.asyncio

--- a/tests/fast/ray/rollout/test_rollout_manager_handoff.py
+++ b/tests/fast/ray/rollout/test_rollout_manager_handoff.py
@@ -1,0 +1,398 @@
+import asyncio
+import threading
+from collections.abc import Callable
+from contextlib import nullcontext
+from types import SimpleNamespace
+from typing import cast
+
+import pytest
+
+import miles.ray.rollout.rollout_manager as rollout_manager_mod
+from miles.ray.rollout.rollout_manager import RolloutManager
+from miles.rollout.base_types import (
+    LeasedRolloutFnTrainOutput,
+    RolloutFnTrainOutput,
+    TrainBatchLease,
+    TrainBatchRollbackReason,
+)
+
+
+class RecordingTrainBatchLease(TrainBatchLease):
+    def __init__(
+        self,
+        rollout_id: int,
+        events: list[str],
+        commit_error: BaseException | None = None,
+        rollback_error: BaseException | None = None,
+    ) -> None:
+        super().__init__(rollout_id=rollout_id)
+        self._events = events
+        self._commit_error = commit_error
+        self._rollback_error = rollback_error
+
+    def _commit(self) -> None:
+        self._events.append("commit")
+        if self._commit_error is not None:
+            raise self._commit_error
+
+    def _rollback(self, reason: TrainBatchRollbackReason) -> None:
+        self._events.append(f"rollback:{reason.name}")
+        if self._rollback_error is not None:
+            raise self._rollback_error
+
+
+@pytest.fixture
+def manager_env(monkeypatch: pytest.MonkeyPatch) -> tuple[RolloutManager, SimpleNamespace]:
+    manager_class = cast(type[RolloutManager], object.__getattribute__(RolloutManager, "__ray_actor_class__"))
+    manager = object.__new__(manager_class)
+    manager.args = SimpleNamespace(
+        ci_test=False,
+        ci_inject_rollout_data_path=None,
+        use_fault_tolerance=False,
+        load_debug_rollout_data=None,
+        delay_split_train_data_by_dp=False,
+    )
+    manager.weight_version = None
+    manager.rollout_id = -1
+    manager.servers = {}
+    manager.data_source = SimpleNamespace()
+    manager.train_parallel_config = {"dp_size": 1}
+    manager.custom_convert_samples_to_train_data_func = None
+    manager.custom_reward_post_process_func = None
+    manager.use_legacy_rollout_v1 = False
+    monkeypatch.setattr(manager, "_health_monitoring_resume", lambda: None)
+
+    monkeypatch.setattr(rollout_manager_mod.dashboard_hooks, "register_engines", lambda servers: None)
+    monkeypatch.setattr(rollout_manager_mod, "timer", lambda name: nullcontext())
+    monkeypatch.setattr(
+        rollout_manager_mod,
+        "postprocess_rollout_data",
+        lambda args, data, train_parallel_config: (data, {}),
+    )
+    monkeypatch.setattr(rollout_manager_mod, "save_debug_rollout_data", lambda *args, **kwargs: None)
+    monkeypatch.setattr(rollout_manager_mod, "log_rollout_data", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        rollout_manager_mod,
+        "convert_samples_to_train_data",
+        lambda *args, **kwargs: {"sample_indices": [5]},
+    )
+
+    return manager, manager.args
+
+
+def leased_output(lease: TrainBatchLease) -> LeasedRolloutFnTrainOutput:
+    return LeasedRolloutFnTrainOutput(samples=[], metrics={"source": "test"}, lease=lease)
+
+
+async def test_ordinary_output_preserves_existing_handoff(
+    manager_env: tuple[RolloutManager, SimpleNamespace],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager, _ = manager_env
+    manager.generate_rollout = lambda input: RolloutFnTrainOutput(samples=[], metrics=None)
+    monkeypatch.setattr(
+        rollout_manager_mod,
+        "split_train_data_by_dp",
+        lambda args, data, train_parallel_config: ["published"],
+    )
+
+    result = await manager.generate(rollout_id=5)
+
+    assert result == {"sample_indices": [5], "data_ref": ["published"]}
+
+
+async def test_rejects_a_lease_for_another_rollout(
+    manager_env: tuple[RolloutManager, SimpleNamespace],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager, _ = manager_env
+    events: list[str] = []
+    lease = RecordingTrainBatchLease(rollout_id=99, events=events)
+    manager.generate_rollout = lambda input: leased_output(lease)
+
+    def publish(*args, **kwargs):
+        events.append("publish")
+        return ["published"]
+
+    monkeypatch.setattr(rollout_manager_mod, "split_train_data_by_dp", publish)
+
+    with pytest.raises(ValueError) as error:
+        await manager.generate(rollout_id=7)
+
+    assert str(error.value) == "Leased train output for rollout 7 carries a lease for rollout 99."
+    assert events == ["rollback:HANDOFF_FAILED"]
+
+
+@pytest.mark.parametrize("rollout_is_async", [False, True])
+@pytest.mark.parametrize("delay_split_train_data_by_dp", [False, True])
+async def test_commits_lease_after_train_data_publication(
+    manager_env: tuple[RolloutManager, SimpleNamespace],
+    monkeypatch: pytest.MonkeyPatch,
+    delay_split_train_data_by_dp: bool,
+    rollout_is_async: bool,
+) -> None:
+    manager, args = manager_env
+    args.delay_split_train_data_by_dp = delay_split_train_data_by_dp
+    events: list[str] = []
+    lease = RecordingTrainBatchLease(rollout_id=7, events=events)
+    if rollout_is_async:
+
+        async def generate_rollout(input):
+            return leased_output(lease)
+
+        manager.generate_rollout = generate_rollout
+    else:
+        manager.generate_rollout = lambda input: leased_output(lease)
+
+    published_ref = "published" if delay_split_train_data_by_dp else ["published"]
+
+    def publish(*args, **kwargs):
+        events.append("publish")
+        return published_ref
+
+    if delay_split_train_data_by_dp:
+        store = SimpleNamespace(put=publish)
+        monkeypatch.setattr(rollout_manager_mod.object_store, "get_instance", lambda: store)
+    else:
+        monkeypatch.setattr(rollout_manager_mod, "split_train_data_by_dp", publish)
+
+    result = await manager.generate(rollout_id=7)
+
+    assert events == ["publish", "commit"]
+    assert result == {"sample_indices": [5], "data_ref": published_ref}
+
+
+async def test_rolls_back_when_conversion_fails(
+    manager_env: tuple[RolloutManager, SimpleNamespace],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager, _ = manager_env
+    events: list[str] = []
+    lease = RecordingTrainBatchLease(rollout_id=11, events=events)
+    manager.generate_rollout = lambda input: leased_output(lease)
+    failure = RuntimeError("conversion failed")
+
+    def fail_conversion(*args, **kwargs):
+        raise failure
+
+    monkeypatch.setattr(rollout_manager_mod, "convert_samples_to_train_data", fail_conversion)
+
+    with pytest.raises(RuntimeError) as error:
+        await manager.generate(rollout_id=11)
+
+    assert error.value is failure
+    assert events == ["rollback:HANDOFF_FAILED"]
+
+
+async def test_rolls_back_when_postprocessing_fails(
+    manager_env: tuple[RolloutManager, SimpleNamespace],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager, _ = manager_env
+    events: list[str] = []
+    lease = RecordingTrainBatchLease(rollout_id=12, events=events)
+    manager.generate_rollout = lambda input: leased_output(lease)
+    failure = RuntimeError("postprocessing failed")
+
+    def fail_postprocessing(*args, **kwargs):
+        raise failure
+
+    monkeypatch.setattr(rollout_manager_mod, "postprocess_rollout_data", fail_postprocessing)
+
+    with pytest.raises(RuntimeError) as error:
+        await manager.generate(rollout_id=12)
+
+    assert error.value is failure
+    assert events == ["rollback:HANDOFF_FAILED"]
+
+
+@pytest.mark.parametrize("use_legacy_rollout_v1", [True, False])
+@pytest.mark.parametrize("cancellation_count", [1, 2])
+async def test_cancelled_rollout_invocation_rolls_back_eventual_lease(
+    manager_env: tuple[RolloutManager, SimpleNamespace],
+    use_legacy_rollout_v1: bool,
+    cancellation_count: int,
+) -> None:
+    manager, _ = manager_env
+    manager.use_legacy_rollout_v1 = use_legacy_rollout_v1
+    events: list[str] = []
+    lease = RecordingTrainBatchLease(rollout_id=13, events=events)
+    rollout_started = threading.Event()
+    release_rollout = threading.Event()
+    rollout_finished = threading.Event()
+
+    def complete_rollout() -> LeasedRolloutFnTrainOutput:
+        rollout_started.set()
+        try:
+            assert release_rollout.wait(timeout=5)
+            return leased_output(lease)
+        finally:
+            rollout_finished.set()
+
+    if not use_legacy_rollout_v1:
+        manager.generate_rollout = lambda input: complete_rollout()
+    else:
+        manager.generate_rollout = lambda args, rollout_id, data_source, evaluation: complete_rollout()
+    generate_task = asyncio.create_task(manager.generate(rollout_id=13))
+    assert await asyncio.to_thread(rollout_started.wait, 5)
+
+    for _ in range(cancellation_count):
+        generate_task.cancel()
+        await asyncio.sleep(0)
+    release_rollout.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await generate_task
+    assert await asyncio.to_thread(rollout_finished.wait, 5)
+    assert events == ["rollback:HANDOFF_FAILED"]
+
+
+@pytest.mark.parametrize("delay_split_train_data_by_dp", [False, True])
+@pytest.mark.parametrize(
+    "failure_factory",
+    [
+        lambda: RuntimeError("publication failed"),
+        asyncio.CancelledError,
+    ],
+)
+async def test_rolls_back_when_publication_does_not_complete(
+    manager_env: tuple[RolloutManager, SimpleNamespace],
+    monkeypatch: pytest.MonkeyPatch,
+    delay_split_train_data_by_dp: bool,
+    failure_factory: Callable[[], BaseException],
+) -> None:
+    manager, args = manager_env
+    args.delay_split_train_data_by_dp = delay_split_train_data_by_dp
+    events: list[str] = []
+    lease = RecordingTrainBatchLease(rollout_id=13, events=events)
+    manager.generate_rollout = lambda input: leased_output(lease)
+    failure = failure_factory()
+
+    def fail_publication(*args, **kwargs):
+        events.append("publish")
+        raise failure
+
+    if delay_split_train_data_by_dp:
+        monkeypatch.setattr(
+            rollout_manager_mod.object_store,
+            "get_instance",
+            lambda: SimpleNamespace(put=fail_publication),
+        )
+    else:
+        monkeypatch.setattr(rollout_manager_mod, "split_train_data_by_dp", fail_publication)
+
+    with pytest.raises(type(failure)) as error:
+        await manager.generate(rollout_id=13)
+
+    assert error.value is failure
+    assert events == ["publish", "rollback:HANDOFF_FAILED"]
+
+
+async def test_preserves_handoff_error_when_rollback_fails(
+    manager_env: tuple[RolloutManager, SimpleNamespace],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager, _ = manager_env
+    events: list[str] = []
+    handoff_failure = RuntimeError("publication failed")
+    rollback_failure = RuntimeError("rollback failed")
+    lease = RecordingTrainBatchLease(
+        rollout_id=17,
+        events=events,
+        rollback_error=rollback_failure,
+    )
+    manager.generate_rollout = lambda input: leased_output(lease)
+
+    def fail_publication(args, data, train_parallel_config):
+        raise handoff_failure
+
+    monkeypatch.setattr(rollout_manager_mod, "split_train_data_by_dp", fail_publication)
+
+    with pytest.raises(RuntimeError) as error:
+        await manager.generate(rollout_id=17)
+
+    assert error.value is handoff_failure
+    assert error.value.__cause__ is rollback_failure
+    assert events == ["rollback:HANDOFF_FAILED"]
+
+
+@pytest.mark.parametrize("delay_split_train_data_by_dp", [False, True])
+async def test_failed_commit_removes_published_data_without_rollback(
+    manager_env: tuple[RolloutManager, SimpleNamespace],
+    monkeypatch: pytest.MonkeyPatch,
+    delay_split_train_data_by_dp: bool,
+) -> None:
+    manager, args = manager_env
+    args.delay_split_train_data_by_dp = delay_split_train_data_by_dp
+    events: list[str] = []
+    commit_failure = RuntimeError("commit failed")
+    lease = RecordingTrainBatchLease(
+        rollout_id=19,
+        events=events,
+        commit_error=commit_failure,
+    )
+    manager.generate_rollout = lambda input: leased_output(lease)
+
+    published_refs = ["published"] if delay_split_train_data_by_dp else ["published-0", "published-1"]
+
+    def publish(*args, **kwargs):
+        events.append("publish")
+        return published_refs[0] if delay_split_train_data_by_dp else published_refs
+
+    def remove(ref):
+        events.append(f"remove:{ref}")
+
+    store = SimpleNamespace(put=publish, remove=remove)
+    monkeypatch.setattr(rollout_manager_mod.object_store, "get_instance", lambda: store)
+    if not delay_split_train_data_by_dp:
+        monkeypatch.setattr(rollout_manager_mod, "split_train_data_by_dp", publish)
+
+    with pytest.raises(RuntimeError) as error:
+        await manager.generate(rollout_id=19)
+
+    assert error.value is commit_failure
+    expected_events = (
+        ["publish", "commit", "remove:published"]
+        if delay_split_train_data_by_dp
+        else ["publish", "commit", "remove:published-0", "remove:published-1"]
+    )
+    assert events == expected_events
+
+
+async def test_preserves_commit_error_when_published_data_cleanup_fails(
+    manager_env: tuple[RolloutManager, SimpleNamespace],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager, _ = manager_env
+    events: list[str] = []
+    commit_failure = RuntimeError("commit failed")
+    cleanup_failure = RuntimeError("cleanup failed")
+    lease = RecordingTrainBatchLease(
+        rollout_id=23,
+        events=events,
+        commit_error=commit_failure,
+    )
+    manager.generate_rollout = lambda input: leased_output(lease)
+
+    def publish(*args, **kwargs):
+        events.append("publish")
+        return ["published-0", "published-1"]
+
+    def remove(ref):
+        events.append(f"remove:{ref}")
+        if ref == "published-0":
+            raise cleanup_failure
+
+    monkeypatch.setattr(rollout_manager_mod, "split_train_data_by_dp", publish)
+    monkeypatch.setattr(
+        rollout_manager_mod.object_store,
+        "get_instance",
+        lambda: SimpleNamespace(remove=remove),
+    )
+
+    with pytest.raises(RuntimeError) as error:
+        await manager.generate(rollout_id=23)
+
+    assert error.value is commit_failure
+    assert error.value.__cause__ is cleanup_failure
+    assert events == ["publish", "commit", "remove:published-0", "remove:published-1"]

--- a/tests/fast/ray/rollout/test_train_data_conversion.py
+++ b/tests/fast/ray/rollout/test_train_data_conversion.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, call
 
 import pytest
 import ray
@@ -695,6 +695,21 @@ class TestSplitTrainDataByDp:
         parts = [ray.get(r.inner) for r in refs]
         all_indices = sorted(i for p in parts for i in p["partition"])
         assert all_indices == list(range(n))
+
+    def test_publication_failure_removes_every_published_ref_once(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        args = make_args(balance_data=False)
+        data = {"tokens": [[1], [2], [3]]}
+        published_refs = [object_store.StoreObjectRef("dp-0"), object_store.StoreObjectRef("dp-1")]
+        publication_error = RuntimeError("third shard publication failed")
+        store = MagicMock()
+        store.put.side_effect = [*published_refs, publication_error]
+        monkeypatch.setattr(object_store, "get_instance", lambda: store)
+
+        with pytest.raises(RuntimeError, match="third shard publication failed") as exc_info:
+            split_train_data_by_dp(args, data, {"dp_size": 3})
+
+        assert exc_info.value is publication_error
+        assert store.remove.call_args_list == [call(published_refs[0]), call(published_refs[1])]
 
 
 class TestSplitTrainDataRaw:

--- a/tests/fast/rollout/test_base_types.py
+++ b/tests/fast/rollout/test_base_types.py
@@ -1,0 +1,128 @@
+from tests.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="stage-a-cpu", labels=[])
+
+from collections.abc import Callable
+
+import pytest
+
+from miles.rollout.base_types import (
+    LeasedRolloutFnTrainOutput,
+    RolloutFnTrainOutput,
+    TrainBatchLease,
+    TrainBatchRollbackReason,
+)
+
+
+class RecordingTrainBatchLease(TrainBatchLease):
+    def __init__(
+        self,
+        rollout_id: int,
+        on_commit: Callable[[], None],
+        on_rollback: Callable[[TrainBatchRollbackReason], None],
+    ) -> None:
+        super().__init__(rollout_id=rollout_id)
+        self._on_commit = on_commit
+        self._on_rollback = on_rollback
+
+    def _commit(self) -> None:
+        self._on_commit()
+
+    def _rollback(self, reason: TrainBatchRollbackReason) -> None:
+        self._on_rollback(reason)
+
+
+def test_leased_output_preserves_the_ordinary_train_output_contract() -> None:
+    lease = RecordingTrainBatchLease(
+        rollout_id=3,
+        on_commit=lambda: None,
+        on_rollback=lambda reason: None,
+    )
+
+    output = LeasedRolloutFnTrainOutput(samples=[], metrics={"source": "test"}, lease=lease)
+
+    assert isinstance(output, RolloutFnTrainOutput)
+    assert output == LeasedRolloutFnTrainOutput(samples=[], metrics={"source": "test"}, lease=lease)
+
+
+def test_train_batch_lease_commits_once() -> None:
+    events: list[str] = []
+    lease = RecordingTrainBatchLease(
+        rollout_id=7,
+        on_commit=lambda: events.append("commit"),
+        on_rollback=lambda reason: events.append(f"rollback:{reason.name}"),
+    )
+
+    assert lease.rollout_id == 7
+    lease.commit()
+
+    assert events == ["commit"]
+    with pytest.raises(RuntimeError) as repeated_commit:
+        lease.commit()
+    assert str(repeated_commit.value) == "Train batch lease for rollout 7 already has a settlement attempt."
+    with pytest.raises(RuntimeError) as rollback_after_commit:
+        lease.rollback(TrainBatchRollbackReason.HANDOFF_FAILED)
+    assert str(rollback_after_commit.value) == "Train batch lease for rollout 7 already has a settlement attempt."
+
+
+def test_train_batch_lease_rolls_back_once() -> None:
+    reasons: list[TrainBatchRollbackReason] = []
+    lease = RecordingTrainBatchLease(
+        rollout_id=11,
+        on_commit=lambda: None,
+        on_rollback=reasons.append,
+    )
+
+    lease.rollback(TrainBatchRollbackReason.HANDOFF_FAILED)
+
+    assert reasons == [TrainBatchRollbackReason.HANDOFF_FAILED]
+    with pytest.raises(RuntimeError) as repeated_rollback:
+        lease.rollback(TrainBatchRollbackReason.HANDOFF_FAILED)
+    assert str(repeated_rollback.value) == "Train batch lease for rollout 11 already has a settlement attempt."
+    with pytest.raises(RuntimeError) as commit_after_rollback:
+        lease.commit()
+    assert str(commit_after_rollback.value) == "Train batch lease for rollout 11 already has a settlement attempt."
+
+
+def test_failed_commit_still_claims_the_only_settlement_attempt() -> None:
+    failure = RuntimeError("commit failed")
+
+    def fail_commit() -> None:
+        raise failure
+
+    lease = RecordingTrainBatchLease(
+        rollout_id=13,
+        on_commit=fail_commit,
+        on_rollback=lambda reason: None,
+    )
+
+    with pytest.raises(RuntimeError) as error:
+        lease.commit()
+    assert error.value is failure
+    with pytest.raises(RuntimeError) as rollback_after_failed_commit:
+        lease.rollback(TrainBatchRollbackReason.HANDOFF_FAILED)
+    assert (
+        str(rollback_after_failed_commit.value) == "Train batch lease for rollout 13 already has a settlement attempt."
+    )
+
+
+def test_failed_rollback_still_claims_the_only_settlement_attempt() -> None:
+    failure = RuntimeError("rollback failed")
+
+    def fail_rollback(reason: TrainBatchRollbackReason) -> None:
+        raise failure
+
+    lease = RecordingTrainBatchLease(
+        rollout_id=17,
+        on_commit=lambda: None,
+        on_rollback=fail_rollback,
+    )
+
+    with pytest.raises(RuntimeError) as error:
+        lease.rollback(TrainBatchRollbackReason.HANDOFF_FAILED)
+    assert error.value is failure
+    with pytest.raises(RuntimeError) as commit_after_failed_rollback:
+        lease.commit()
+    assert (
+        str(commit_after_failed_rollback.value) == "Train batch lease for rollout 17 already has a settlement attempt."
+    )


### PR DESCRIPTION
## Summary

- Commits a train-batch lease only after every data-parallel shard is published.
- Rolls the lease back when conversion or publication fails before commit.
- Removes published references if the commit callback itself fails.
- Preserves the original publication error when cleanup or settlement also fails.

## Context

Ray publication is a multi-step operation. Some object references may already exist when a later shard fails or the caller is cancelled. Source ownership can commit only after all data-parallel shards are published because training requires the full result.

This second layer applies the lease contract from [#2246](https://github.com/radixark/miles/pull/2246). It commits after all data-parallel shards are published because training requires the full result. A failure before that boundary rolls the lease back. If the commit callback fails after publication, Miles removes the published references and propagates the commit error. The code makes one settlement attempt.

[Issue #2254](https://github.com/radixark/miles/issues/2254) uses this boundary to complete manager publication before remote trainer acknowledgement begins.

| Layer | Upstream PR | Status | Contract |
| --- | --- | --- | --- |
| 1/2 | [#2246](https://github.com/radixark/miles/pull/2246) | Draft | Train-batch lease |
| 2/2 | [#2248](https://github.com/radixark/miles/pull/2248) | Draft | Manager-side Ray publication settlement |

Both drafts target `main`, so GitHub shows the parent commit from #2246 in this PR. Review this layer as the diff after #2246. The cumulative diff includes the parent. Merge #2246 first. If the parent is squash-merged or rebase-merged, this branch will be rebased onto the updated `main`.

This PR adds one new commit: [`2ac538c2`, which settles leased rollout publication](https://github.com/radixark/miles/pull/2248/commits/2ac538c2a9a8c6def15cd2d4c2698cabe3bd5b3c). Review it against #2246. The contract requires Miles to attempt one lease settlement after the manager publishes the complete result or fails before that boundary.

## Description

- Recognizes leased rollout output while ordinary rollout output keeps its existing behavior.
- Verifies that the lease belongs to the rollout being published.
- Converts and publishes the complete train-data result before calling `commit()`.
- Removes every published object reference if the commit callback fails.
- Calls `rollback(HANDOFF_FAILED)` when conversion, publication, or caller cancellation prevents a complete result.
- Shields lease settlement from caller cancellation.
- Preserves the primary handoff error and chains rollback failures.
- Preserves a commit-callback error and chains reference-cleanup failures.
- Preserves the existing train parallel scheduling configuration.

## Test plan

- [x] Focused rollout-manager handoff and train-data conversion selection: 63 tests passed at exact head `2ac538c2a9`.
- [x] `test_commits_leased_output_after_every_dp_shard_is_published` passed under local Ray.
- [x] An exact composed 8xB200 validation published two Ray references before lease commit. An injected second-shard publication failure created one reference, removed that partial result, and rolled the lease back.
- [x] The composed 8xB200 run used Miles ref [`7cd212d81f`](https://github.com/ashtonchew/miles/commit/7cd212d81f6c94f72d67b4443e8c047008e4d517) with validation child [`cf512e6a8a`](https://github.com/GymPod/slime/commit/cf512e6a8a59c7c935e273dc69b9fd84c32e35a3). This evidence covers manager-side publication settlement. #2286 owns remote trainer acknowledgement, and full training requires separate evidence.

## Risks and follow-ups

The manager commit covers manager-side publication. Remote trainer receipt requires a separate acknowledgement. Ray can report an actor failure after the actor has performed local side effects. [#2286](https://github.com/radixark/miles/pull/2286) requires that acknowledgement before Miles transfers source ownership to training.
