### PR TITLE
[2/6] feat(rollout): reserve rollout source groups

### DIFF
--- a/docs/user-guide/customization.md
+++ b/docs/user-guide/customization.md
@@ -103,6 +103,12 @@ class CustomDataSource(DataSource):
     def load(self, rollout_id=None) -> None: ...
 ```
 
+A source may additionally implement `reserve_samples`, `acknowledge_reservations`, and
+`requeue_reservations`, and declare `supports_source_reservations = True`, to opt into
+owned scheduling under `--fully-async`: rollout then hands out durable reservations that
+survive a restart and settles each attempt exactly once. A source that does not declare
+support keeps the buffered legacy path.
+
 **Default:** `miles.rollout.data_source.RolloutDataSourceWithBuffer`.
 
 ### `--eval-function-path`

--- a/miles/rollout/data_source.py
+++ b/miles/rollout/data_source.py
@@ -2,7 +2,11 @@ import abc
 import copy
 import logging
 import os
+import random
+import threading
+from collections.abc import Sequence
 from pathlib import Path
+from typing import NamedTuple, NewType
 
 import torch
 
@@ -13,8 +17,36 @@ from miles.utils.types import Sample
 
 logger = logging.getLogger(__name__)
 
+SourceReservationId = NewType("SourceReservationId", str)
+
+
+class SourceReservation(NamedTuple):
+    """One source-owned prompt group attempt.
+
+    Attributes:
+        reservation_id: Stable logical identity across replay attempts.
+        samples: Pristine samples for this attempt.
+    """
+
+    reservation_id: SourceReservationId
+    samples: tuple[Sample, ...]
+
+
+class _SourceReservationRecord(NamedTuple):
+    group_index: int
+
+
+class _OutstandingReservation(NamedTuple):
+    record: _SourceReservationRecord
+    attempt: SourceReservation
+
 
 class DataSource(abc.ABC):
+    # Whether ``reserve_samples`` hands out durable source reservations. Fully
+    # async rollout schedules owned work only for sources that declare support;
+    # overriding ``reserve_samples`` alone is not a capability signal.
+    supports_source_reservations: bool = False
+
     @abc.abstractmethod
     def get_samples(self, num_samples: int) -> list[list[Sample]]:
         """
@@ -43,9 +75,58 @@ class DataSource(abc.ABC):
         """Pending-sample backlog, or None for sources without a buffer."""
         return None
 
+    def reserve_samples(self, num_groups: int) -> list[SourceReservation]:
+        """Reserve pristine prompt groups for ownership-aware rollout.
+
+        Args:
+            num_groups: Number of prompt groups to reserve.
+
+        Returns:
+            Reservations that require explicit settlement.
+
+        Implementations must return exactly ``num_groups`` reservations with
+        unique identities and declare ``supports_source_reservations = True``.
+        If this method raises, it must not transfer source ownership.
+
+        Raises:
+            RuntimeError: If this data source does not support reservations.
+        """
+        raise RuntimeError(f"{self.__class__.__name__} does not support durable source reservations.")
+
+    def acknowledge_reservations(self, reservations: Sequence[SourceReservation], *, rollout_id: int) -> None:
+        """Record successful handoff of exact source reservation attempts.
+
+        Args:
+            reservations: Exact attempts to acknowledge.
+            rollout_id: Training rollout that accepted the groups.
+
+        Implementations must validate the complete batch before mutation. If
+        this method raises, every input reservation must remain outstanding.
+
+        Raises:
+            RuntimeError: If this data source does not support reservations.
+        """
+        raise RuntimeError(f"{self.__class__.__name__} does not support durable source reservations.")
+
+    def requeue_reservations(self, reservations: Sequence[SourceReservation]) -> None:
+        """Return exact source reservation attempts for pristine replay.
+
+        Args:
+            reservations: Exact attempts to requeue.
+
+        Implementations must validate the complete batch before mutation. If
+        this method raises, every input reservation must remain outstanding.
+
+        Raises:
+            RuntimeError: If this data source does not support reservations.
+        """
+        raise RuntimeError(f"{self.__class__.__name__} does not support durable source reservations.")
+
 
 # TODO may further refactor data-loading part later
 class RolloutDataSource(DataSource):
+    supports_source_reservations = True
+
     def __init__(self, args):
         self.args = args
 
@@ -55,6 +136,12 @@ class RolloutDataSource(DataSource):
         self.sample_offset = 0
         # TODO remove this
         self.metadata = {}
+        self._reservation_lock = threading.RLock()
+        self._outstanding_reservations: dict[SourceReservationId, _OutstandingReservation] = {}
+        self._replay_reservations: list[_SourceReservationRecord] = []
+        self._durable_reservations_started = False
+        self._permutation_epoch_id: int | None = None
+        self._permutation: tuple[int, ...] = ()
 
         if args.rollout_global_dataset:
             tokenizer = load_tokenizer(
@@ -84,39 +171,206 @@ class RolloutDataSource(DataSource):
                 seed=args.rollout_seed,
             )
             if self.args.rollout_shuffle:
-                self.dataset.shuffle(self.epoch_id)
+                self._set_dataset_epoch(self.epoch_id)
         else:
             self.dataset = None
 
-    def get_samples(self, num_samples):
-        # TODO further improve code
-        if self.dataset is not None:
-            if self.sample_offset + num_samples <= len(self.dataset):
-                prompt_samples = self.dataset.samples[self.sample_offset : self.sample_offset + num_samples]
-                self.sample_offset += num_samples
-            else:
-                prompt_samples = self.dataset.samples[self.sample_offset :]
-                num_samples -= len(prompt_samples)
-                self.epoch_id += 1
-                if self.args.rollout_shuffle:
-                    self.dataset.shuffle(self.epoch_id)
-                prompt_samples += self.dataset.samples[:num_samples]
-                self.sample_offset = num_samples
-        else:
-            prompt_samples = [Sample() for _ in range(num_samples)]
+    def reserve_samples(self, num_groups: int) -> list[SourceReservation]:
+        """Reserve prompt groups without settling source ownership.
 
+        Args:
+            num_groups: Number of groups to reserve.
+
+        Returns:
+            Replay attempts first, then newly admitted source groups.
+
+        Raises:
+            ValueError: If the group count or source dataset is invalid.
+            RuntimeError: If durable reservations are unavailable.
+        """
+        self._require_durable_reservations()
+
+        with self._reservation_lock:
+            if not isinstance(num_groups, int) or isinstance(num_groups, bool) or num_groups < 0:
+                raise ValueError(f"num_groups must be a nonnegative integer, got {num_groups!r}.")
+            if num_groups == 0:
+                return []
+            if self.dataset is not None and len(self.dataset) == 0:
+                raise ValueError("Cannot reserve samples from an empty rollout dataset.")
+
+            replay_count = min(num_groups, len(self._replay_reservations))
+            replay_records = self._replay_reservations[:replay_count]
+            new_count = num_groups - replay_count
+            new_records = [
+                _SourceReservationRecord(group_index=group_index)
+                for group_index in range(self.sample_group_index, self.sample_group_index + new_count)
+            ]
+            records = [*replay_records, *new_records]
+            reservations = [self._materialize_reservation(record) for record in records]
+
+            del self._replay_reservations[:replay_count]
+            for record, reservation in zip(records, reservations, strict=True):
+                self._outstanding_reservations[reservation.reservation_id] = _OutstandingReservation(
+                    record=record,
+                    attempt=reservation,
+                )
+            self._advance_source_frontier(new_records)
+            if reservations:
+                self._durable_reservations_started = True
+            return reservations
+
+    def acknowledge_reservations(self, reservations: Sequence[SourceReservation], *, rollout_id: int) -> None:
+        """Acknowledge exact attempts after a training handoff succeeds.
+
+        Args:
+            reservations: Exact outstanding reservation attempts.
+            rollout_id: Training rollout that accepted every parent group.
+
+        Raises:
+            ValueError: If the batch has duplicates or the rollout is invalid.
+            RuntimeError: If any attempt is not currently outstanding.
+        """
+        self._require_durable_reservations()
+        self._validate_rollout_id(rollout_id)
+        with self._reservation_lock:
+            outstanding = self._get_outstanding_reservations_locked(reservations)
+            for owned in outstanding:
+                reservation_id = owned.attempt.reservation_id
+                del self._outstanding_reservations[reservation_id]
+
+    def requeue_reservations(self, reservations: Sequence[SourceReservation]) -> None:
+        """Return exact outstanding attempts for pristine replay.
+
+        Args:
+            reservations: Exact attempts to reconstruct from source state.
+
+        Raises:
+            ValueError: If the batch contains duplicate identities.
+            RuntimeError: If any attempt is not currently outstanding.
+        """
+        self._require_durable_reservations()
+        with self._reservation_lock:
+            outstanding = self._get_outstanding_reservations_locked(reservations)
+            for owned in outstanding:
+                del self._outstanding_reservations[owned.attempt.reservation_id]
+                self._replay_reservations.append(owned.record)
+            self._replay_reservations.sort(key=lambda record: record.group_index)
+
+    def _get_outstanding_reservations_locked(
+        self, reservations: Sequence[SourceReservation]
+    ) -> list[_OutstandingReservation]:
+        attempts = list(reservations)
+        reservation_ids = [attempt.reservation_id for attempt in attempts]
+        if len(reservation_ids) != len(set(reservation_ids)):
+            raise ValueError(f"Reservation settlement contains duplicate identities: {reservation_ids}.")
+
+        invalid = []
+        outstanding = []
+        for attempt in attempts:
+            owned = self._outstanding_reservations.get(attempt.reservation_id)
+            if owned is None or owned.attempt is not attempt:
+                invalid.append(attempt.reservation_id)
+            else:
+                outstanding.append(owned)
+        if invalid:
+            raise RuntimeError(f"Source reservations are not the current outstanding attempts: {invalid}.")
+        return outstanding
+
+    def _require_durable_reservations(self) -> None:
+        if not self.args.rollout_global_dataset:
+            raise RuntimeError(
+                f"{self.__class__.__name__} does not support durable source reservations when rollout_global_dataset is disabled."
+            )
+
+    @staticmethod
+    def _validate_rollout_id(rollout_id: int) -> None:
+        if not isinstance(rollout_id, int) or isinstance(rollout_id, bool) or rollout_id < 0:
+            raise ValueError(f"rollout_id must be a nonnegative integer, got {rollout_id!r}.")
+
+    def _advance_source_frontier(self, records: list[_SourceReservationRecord]) -> None:
+        if not records:
+            return
+
+        self.sample_group_index += len(records)
+        self.sample_index = self.sample_group_index * self.args.n_samples_per_prompt
+        if self.dataset is not None:
+            epoch_id, epoch_offset = divmod(records[-1].group_index, len(self.dataset))
+            self.epoch_id = epoch_id
+            self.sample_offset = epoch_offset + 1
+            if self.args.rollout_shuffle:
+                self._set_dataset_epoch(epoch_id)
+
+    def _materialize_reservation(self, record: _SourceReservationRecord) -> SourceReservation:
+        assert self.dataset is not None
+        epoch_id, epoch_offset = divmod(record.group_index, len(self.dataset))
+        dataset_index = self._expected_dataset_index(epoch_id=epoch_id, epoch_offset=epoch_offset)
+        prompt_sample = self.dataset.origin_samples[dataset_index]
+        first_sample_index = record.group_index * self.args.n_samples_per_prompt
         samples = []
-        for prompt_sample in prompt_samples:
-            group = []
-            for _ in range(self.args.n_samples_per_prompt):
-                sample = copy.deepcopy(prompt_sample)
-                sample.group_index = self.sample_group_index
-                sample.index = self.sample_index
-                self.sample_index += 1
-                group.append(sample)
-            self.sample_group_index += 1
-            samples.append(group)
-        return samples
+        for sample_index in range(first_sample_index, first_sample_index + self.args.n_samples_per_prompt):
+            sample = copy.deepcopy(prompt_sample)
+            sample.group_index = record.group_index
+            sample.index = sample_index
+            samples.append(sample)
+        return SourceReservation(
+            reservation_id=SourceReservationId(str(record.group_index)),
+            samples=tuple(samples),
+        )
+
+    def _expected_dataset_index(self, *, epoch_id: int, epoch_offset: int) -> int:
+        if not self.args.rollout_shuffle:
+            return epoch_offset
+        return self._dataset_permutation(epoch_id)[epoch_offset]
+
+    def _dataset_permutation(self, epoch_id: int) -> tuple[int, ...]:
+        assert self.dataset is not None
+        if self._permutation_epoch_id == epoch_id:
+            return self._permutation
+
+        permutation = list(range(len(self.dataset)))
+        random.Random(self.args.rollout_seed + epoch_id).shuffle(permutation)
+        self._permutation_epoch_id = epoch_id
+        self._permutation = tuple(permutation)
+        return self._permutation
+
+    def _set_dataset_epoch(self, epoch_id: int) -> None:
+        assert self.dataset is not None
+        permutation = self._dataset_permutation(epoch_id)
+        self.dataset.samples = [self.dataset.origin_samples[index] for index in permutation]
+        self.dataset.epoch_id = epoch_id
+
+    def get_samples(self, num_samples):
+        with self._reservation_lock:
+            if self._durable_reservations_started:
+                raise RuntimeError("Cannot use get_samples after durable source reservations have started.")
+            # TODO further improve code
+            if self.dataset is not None:
+                if self.sample_offset + num_samples <= len(self.dataset):
+                    prompt_samples = self.dataset.samples[self.sample_offset : self.sample_offset + num_samples]
+                    self.sample_offset += num_samples
+                else:
+                    prompt_samples = self.dataset.samples[self.sample_offset :]
+                    num_samples -= len(prompt_samples)
+                    self.epoch_id += 1
+                    if self.args.rollout_shuffle:
+                        self._set_dataset_epoch(self.epoch_id)
+                    prompt_samples += self.dataset.samples[:num_samples]
+                    self.sample_offset = num_samples
+            else:
+                prompt_samples = [Sample() for _ in range(num_samples)]
+
+            samples = []
+            for prompt_sample in prompt_samples:
+                group = []
+                for _ in range(self.args.n_samples_per_prompt):
+                    sample = copy.deepcopy(prompt_sample)
+                    sample.group_index = self.sample_group_index
+                    sample.index = self.sample_index
+                    self.sample_index += 1
+                    group.append(sample)
+                self.sample_group_index += 1
+                samples.append(group)
+            return samples
 
     def add_samples(self, samples: list[list[Sample]]):
         raise RuntimeError(f"Cannot add samples to {self.__class__.__name__}. This is a read-only data source.")
@@ -125,16 +379,23 @@ class RolloutDataSource(DataSource):
         if not self.args.rollout_global_dataset:
             return
 
-        state_dict = {
-            "sample_offset": self.sample_offset,
-            "epoch_id": self.epoch_id,
-            "sample_group_index": self.sample_group_index,
-            "sample_index": self.sample_index,
-            "metadata": self.metadata,
-        }
-        path = os.path.join(self.args.save, f"rollout/global_dataset_state_dict_{rollout_id}.pt")
-        os.makedirs(os.path.dirname(path), exist_ok=True)
-        torch.save(state_dict, path)
+        with self._reservation_lock:
+            if self._durable_reservations_started:
+                raise RuntimeError(
+                    "Cannot save source state after durable source reservations have started "
+                    "until reservation checkpointing is available."
+                )
+            state_dict = {
+                "sample_offset": self.sample_offset,
+                "epoch_id": self.epoch_id,
+                "sample_group_index": self.sample_group_index,
+                "sample_index": self.sample_index,
+                "metadata": self.metadata,
+            }
+            path = os.path.join(self.args.save, f"rollout/global_dataset_state_dict_{rollout_id}.pt")
+            directory = os.path.dirname(path)
+            os.makedirs(directory, exist_ok=True)
+            torch.save(state_dict, path)
 
     def load(self, rollout_id=None):
         if not self.args.rollout_global_dataset:
@@ -148,20 +409,26 @@ class RolloutDataSource(DataSource):
             logger.info(f"Checkpoint {path} does not exist.")
             return
 
-        logger.info(f"load metadata from {path}")
-        logger.info(f"load metadata: {self.metadata}")
-        state_dict = torch.load(path)
-        self.sample_offset = state_dict.get("sample_offset", 0)
-        self.epoch_id = state_dict.get("epoch_id", 0)
-        self.sample_group_index = state_dict.get("sample_group_index", 0)
-        self.sample_index = state_dict.get("sample_index", 0)
-        self.metadata = state_dict.get("metadata", {})
+        with self._reservation_lock:
+            if self._durable_reservations_started:
+                raise RuntimeError("Cannot load source state after durable source reservations have started.")
+            logger.info(f"load metadata from {path}")
+            logger.info(f"load metadata: {self.metadata}")
+            state_dict = torch.load(path)
+            self.sample_offset = state_dict.get("sample_offset", 0)
+            self.epoch_id = state_dict.get("epoch_id", 0)
+            self.sample_group_index = state_dict.get("sample_group_index", 0)
+            self.sample_index = state_dict.get("sample_index", 0)
+            self.metadata = state_dict.get("metadata", {})
 
-        if self.args.rollout_global_dataset and self.args.rollout_shuffle:
-            self.dataset.shuffle(self.epoch_id)
+            if self.args.rollout_shuffle:
+                self._set_dataset_epoch(self.epoch_id)
 
 
 class RolloutDataSourceWithBuffer(RolloutDataSource):
+    # The retry buffer replays groups itself, so durable reservations stay off.
+    supports_source_reservations = False
+
     def __init__(self, args):
         super().__init__(args)
         self.buffer = []
@@ -169,6 +436,21 @@ class RolloutDataSourceWithBuffer(RolloutDataSource):
             self.buffer_filter = pop_first
         else:
             self.buffer_filter = load_function(self.args.buffer_filter_path)
+
+    def reserve_samples(self, num_groups: int) -> list[SourceReservation]:
+        raise RuntimeError(
+            f"{self.__class__.__name__} does not support durable source reservations because they would bypass its retry buffer."
+        )
+
+    def acknowledge_reservations(self, reservations: Sequence[SourceReservation], *, rollout_id: int) -> None:
+        raise RuntimeError(
+            f"{self.__class__.__name__} does not support durable source reservations because they would bypass its retry buffer."
+        )
+
+    def requeue_reservations(self, reservations: Sequence[SourceReservation]) -> None:
+        raise RuntimeError(
+            f"{self.__class__.__name__} does not support durable source reservations because they would bypass its retry buffer."
+        )
 
     def get_samples(self, num_samples: int) -> list[list[Sample]]:
         """

--- a/miles/rollout/data_source.py
+++ b/miles/rollout/data_source.py
@@ -2,7 +2,11 @@ import abc
 import copy
 import logging
 import os
+import random
+import threading
+from collections.abc import Sequence
 from pathlib import Path
+from typing import NamedTuple, NewType
 
 import torch
 
@@ -12,6 +16,29 @@ from miles.utils.processing_utils import load_processor, load_tokenizer
 from miles.utils.types import Sample
 
 logger = logging.getLogger(__name__)
+
+SourceReservationId = NewType("SourceReservationId", str)
+
+
+class SourceReservation(NamedTuple):
+    """One source-owned prompt group attempt.
+
+    Attributes:
+        reservation_id: Stable logical identity across replay attempts.
+        samples: Pristine samples for this attempt.
+    """
+
+    reservation_id: SourceReservationId
+    samples: tuple[Sample, ...]
+
+
+class _SourceReservationRecord(NamedTuple):
+    group_index: int
+
+
+class _OutstandingReservation(NamedTuple):
+    record: _SourceReservationRecord
+    attempt: SourceReservation
 
 
 class DataSource(abc.ABC):
@@ -43,6 +70,53 @@ class DataSource(abc.ABC):
         """Pending-sample backlog, or None for sources without a buffer."""
         return None
 
+    def reserve_samples(self, num_groups: int) -> list[SourceReservation]:
+        """Reserve pristine prompt groups for ownership-aware rollout.
+
+        Args:
+            num_groups: Number of prompt groups to reserve.
+
+        Returns:
+            Reservations that require explicit settlement.
+
+        Implementations must return exactly ``num_groups`` reservations with
+        unique identities. If this method raises, it must not transfer source
+        ownership.
+
+        Raises:
+            RuntimeError: If this data source does not support reservations.
+        """
+        raise RuntimeError(f"{self.__class__.__name__} does not support durable source reservations.")
+
+    def acknowledge_reservations(self, reservations: Sequence[SourceReservation], *, rollout_id: int) -> None:
+        """Record successful handoff of exact source reservation attempts.
+
+        Args:
+            reservations: Exact attempts to acknowledge.
+            rollout_id: Training rollout that accepted the groups.
+
+        Implementations must validate the complete batch before mutation. If
+        this method raises, every input reservation must remain outstanding.
+
+        Raises:
+            RuntimeError: If this data source does not support reservations.
+        """
+        raise RuntimeError(f"{self.__class__.__name__} does not support durable source reservations.")
+
+    def requeue_reservations(self, reservations: Sequence[SourceReservation]) -> None:
+        """Return exact source reservation attempts for pristine replay.
+
+        Args:
+            reservations: Exact attempts to requeue.
+
+        Implementations must validate the complete batch before mutation. If
+        this method raises, every input reservation must remain outstanding.
+
+        Raises:
+            RuntimeError: If this data source does not support reservations.
+        """
+        raise RuntimeError(f"{self.__class__.__name__} does not support durable source reservations.")
+
 
 # TODO may further refactor data-loading part later
 class RolloutDataSource(DataSource):
@@ -55,6 +129,12 @@ class RolloutDataSource(DataSource):
         self.sample_offset = 0
         # TODO remove this
         self.metadata = {}
+        self._reservation_lock = threading.RLock()
+        self._outstanding_reservations: dict[SourceReservationId, _OutstandingReservation] = {}
+        self._replay_reservations: list[_SourceReservationRecord] = []
+        self._durable_reservations_started = False
+        self._permutation_epoch_id: int | None = None
+        self._permutation: tuple[int, ...] = ()
 
         if args.rollout_global_dataset:
             tokenizer = load_tokenizer(
@@ -84,39 +164,206 @@ class RolloutDataSource(DataSource):
                 seed=args.rollout_seed,
             )
             if self.args.rollout_shuffle:
-                self.dataset.shuffle(self.epoch_id)
+                self._set_dataset_epoch(self.epoch_id)
         else:
             self.dataset = None
 
-    def get_samples(self, num_samples):
-        # TODO further improve code
-        if self.dataset is not None:
-            if self.sample_offset + num_samples <= len(self.dataset):
-                prompt_samples = self.dataset.samples[self.sample_offset : self.sample_offset + num_samples]
-                self.sample_offset += num_samples
-            else:
-                prompt_samples = self.dataset.samples[self.sample_offset :]
-                num_samples -= len(prompt_samples)
-                self.epoch_id += 1
-                if self.args.rollout_shuffle:
-                    self.dataset.shuffle(self.epoch_id)
-                prompt_samples += self.dataset.samples[:num_samples]
-                self.sample_offset = num_samples
-        else:
-            prompt_samples = [Sample() for _ in range(num_samples)]
+    def reserve_samples(self, num_groups: int) -> list[SourceReservation]:
+        """Reserve prompt groups without settling source ownership.
 
+        Args:
+            num_groups: Number of groups to reserve.
+
+        Returns:
+            Replay attempts first, then newly admitted source groups.
+
+        Raises:
+            ValueError: If the group count or source dataset is invalid.
+            RuntimeError: If durable reservations are unavailable.
+        """
+        self._require_durable_reservations()
+
+        with self._reservation_lock:
+            if not isinstance(num_groups, int) or isinstance(num_groups, bool) or num_groups < 0:
+                raise ValueError(f"num_groups must be a nonnegative integer, got {num_groups!r}.")
+            if num_groups == 0:
+                return []
+            if self.dataset is not None and len(self.dataset) == 0:
+                raise ValueError("Cannot reserve samples from an empty rollout dataset.")
+
+            replay_count = min(num_groups, len(self._replay_reservations))
+            replay_records = self._replay_reservations[:replay_count]
+            new_count = num_groups - replay_count
+            new_records = [
+                _SourceReservationRecord(group_index=group_index)
+                for group_index in range(self.sample_group_index, self.sample_group_index + new_count)
+            ]
+            records = [*replay_records, *new_records]
+            reservations = [self._materialize_reservation(record) for record in records]
+
+            del self._replay_reservations[:replay_count]
+            for record, reservation in zip(records, reservations, strict=True):
+                self._outstanding_reservations[reservation.reservation_id] = _OutstandingReservation(
+                    record=record,
+                    attempt=reservation,
+                )
+            self._advance_source_frontier(new_records)
+            if reservations:
+                self._durable_reservations_started = True
+            return reservations
+
+    def acknowledge_reservations(self, reservations: Sequence[SourceReservation], *, rollout_id: int) -> None:
+        """Acknowledge exact attempts after a training handoff succeeds.
+
+        Args:
+            reservations: Exact outstanding reservation attempts.
+            rollout_id: Training rollout that accepted every parent group.
+
+        Raises:
+            ValueError: If the batch has duplicates or the rollout is invalid.
+            RuntimeError: If any attempt is not currently outstanding.
+        """
+        self._require_durable_reservations()
+        self._validate_rollout_id(rollout_id)
+        with self._reservation_lock:
+            outstanding = self._get_outstanding_reservations_locked(reservations)
+            for owned in outstanding:
+                reservation_id = owned.attempt.reservation_id
+                del self._outstanding_reservations[reservation_id]
+
+    def requeue_reservations(self, reservations: Sequence[SourceReservation]) -> None:
+        """Return exact outstanding attempts for pristine replay.
+
+        Args:
+            reservations: Exact attempts to reconstruct from source state.
+
+        Raises:
+            ValueError: If the batch contains duplicate identities.
+            RuntimeError: If any attempt is not currently outstanding.
+        """
+        self._require_durable_reservations()
+        with self._reservation_lock:
+            outstanding = self._get_outstanding_reservations_locked(reservations)
+            for owned in outstanding:
+                del self._outstanding_reservations[owned.attempt.reservation_id]
+                self._replay_reservations.append(owned.record)
+            self._replay_reservations.sort(key=lambda record: record.group_index)
+
+    def _get_outstanding_reservations_locked(
+        self, reservations: Sequence[SourceReservation]
+    ) -> list[_OutstandingReservation]:
+        attempts = list(reservations)
+        reservation_ids = [attempt.reservation_id for attempt in attempts]
+        if len(reservation_ids) != len(set(reservation_ids)):
+            raise ValueError(f"Reservation settlement contains duplicate identities: {reservation_ids}.")
+
+        invalid = []
+        outstanding = []
+        for attempt in attempts:
+            owned = self._outstanding_reservations.get(attempt.reservation_id)
+            if owned is None or owned.attempt is not attempt:
+                invalid.append(attempt.reservation_id)
+            else:
+                outstanding.append(owned)
+        if invalid:
+            raise RuntimeError(f"Source reservations are not the current outstanding attempts: {invalid}.")
+        return outstanding
+
+    def _require_durable_reservations(self) -> None:
+        if not self.args.rollout_global_dataset:
+            raise RuntimeError(
+                f"{self.__class__.__name__} does not support durable source reservations when rollout_global_dataset is disabled."
+            )
+
+    @staticmethod
+    def _validate_rollout_id(rollout_id: int) -> None:
+        if not isinstance(rollout_id, int) or isinstance(rollout_id, bool) or rollout_id < 0:
+            raise ValueError(f"rollout_id must be a nonnegative integer, got {rollout_id!r}.")
+
+    def _advance_source_frontier(self, records: list[_SourceReservationRecord]) -> None:
+        if not records:
+            return
+
+        self.sample_group_index += len(records)
+        self.sample_index = self.sample_group_index * self.args.n_samples_per_prompt
+        if self.dataset is not None:
+            epoch_id, epoch_offset = divmod(records[-1].group_index, len(self.dataset))
+            self.epoch_id = epoch_id
+            self.sample_offset = epoch_offset + 1
+            if self.args.rollout_shuffle:
+                self._set_dataset_epoch(epoch_id)
+
+    def _materialize_reservation(self, record: _SourceReservationRecord) -> SourceReservation:
+        assert self.dataset is not None
+        epoch_id, epoch_offset = divmod(record.group_index, len(self.dataset))
+        dataset_index = self._expected_dataset_index(epoch_id=epoch_id, epoch_offset=epoch_offset)
+        prompt_sample = self.dataset.origin_samples[dataset_index]
+        first_sample_index = record.group_index * self.args.n_samples_per_prompt
         samples = []
-        for prompt_sample in prompt_samples:
-            group = []
-            for _ in range(self.args.n_samples_per_prompt):
-                sample = copy.deepcopy(prompt_sample)
-                sample.group_index = self.sample_group_index
-                sample.index = self.sample_index
-                self.sample_index += 1
-                group.append(sample)
-            self.sample_group_index += 1
-            samples.append(group)
-        return samples
+        for sample_index in range(first_sample_index, first_sample_index + self.args.n_samples_per_prompt):
+            sample = copy.deepcopy(prompt_sample)
+            sample.group_index = record.group_index
+            sample.index = sample_index
+            samples.append(sample)
+        return SourceReservation(
+            reservation_id=SourceReservationId(str(record.group_index)),
+            samples=tuple(samples),
+        )
+
+    def _expected_dataset_index(self, *, epoch_id: int, epoch_offset: int) -> int:
+        if not self.args.rollout_shuffle:
+            return epoch_offset
+        return self._dataset_permutation(epoch_id)[epoch_offset]
+
+    def _dataset_permutation(self, epoch_id: int) -> tuple[int, ...]:
+        assert self.dataset is not None
+        if self._permutation_epoch_id == epoch_id:
+            return self._permutation
+
+        permutation = list(range(len(self.dataset)))
+        random.Random(self.args.rollout_seed + epoch_id).shuffle(permutation)
+        self._permutation_epoch_id = epoch_id
+        self._permutation = tuple(permutation)
+        return self._permutation
+
+    def _set_dataset_epoch(self, epoch_id: int) -> None:
+        assert self.dataset is not None
+        permutation = self._dataset_permutation(epoch_id)
+        self.dataset.samples = [self.dataset.origin_samples[index] for index in permutation]
+        self.dataset.epoch_id = epoch_id
+
+    def get_samples(self, num_samples):
+        with self._reservation_lock:
+            if self._durable_reservations_started:
+                raise RuntimeError("Cannot use get_samples after durable source reservations have started.")
+            # TODO further improve code
+            if self.dataset is not None:
+                if self.sample_offset + num_samples <= len(self.dataset):
+                    prompt_samples = self.dataset.samples[self.sample_offset : self.sample_offset + num_samples]
+                    self.sample_offset += num_samples
+                else:
+                    prompt_samples = self.dataset.samples[self.sample_offset :]
+                    num_samples -= len(prompt_samples)
+                    self.epoch_id += 1
+                    if self.args.rollout_shuffle:
+                        self._set_dataset_epoch(self.epoch_id)
+                    prompt_samples += self.dataset.samples[:num_samples]
+                    self.sample_offset = num_samples
+            else:
+                prompt_samples = [Sample() for _ in range(num_samples)]
+
+            samples = []
+            for prompt_sample in prompt_samples:
+                group = []
+                for _ in range(self.args.n_samples_per_prompt):
+                    sample = copy.deepcopy(prompt_sample)
+                    sample.group_index = self.sample_group_index
+                    sample.index = self.sample_index
+                    self.sample_index += 1
+                    group.append(sample)
+                self.sample_group_index += 1
+                samples.append(group)
+            return samples
 
     def add_samples(self, samples: list[list[Sample]]):
         raise RuntimeError(f"Cannot add samples to {self.__class__.__name__}. This is a read-only data source.")
@@ -125,16 +372,23 @@ class RolloutDataSource(DataSource):
         if not self.args.rollout_global_dataset:
             return
 
-        state_dict = {
-            "sample_offset": self.sample_offset,
-            "epoch_id": self.epoch_id,
-            "sample_group_index": self.sample_group_index,
-            "sample_index": self.sample_index,
-            "metadata": self.metadata,
-        }
-        path = os.path.join(self.args.save, f"rollout/global_dataset_state_dict_{rollout_id}.pt")
-        os.makedirs(os.path.dirname(path), exist_ok=True)
-        torch.save(state_dict, path)
+        with self._reservation_lock:
+            if self._durable_reservations_started:
+                raise RuntimeError(
+                    "Cannot save source state after durable source reservations have started "
+                    "until reservation checkpointing is available."
+                )
+            state_dict = {
+                "sample_offset": self.sample_offset,
+                "epoch_id": self.epoch_id,
+                "sample_group_index": self.sample_group_index,
+                "sample_index": self.sample_index,
+                "metadata": self.metadata,
+            }
+            path = os.path.join(self.args.save, f"rollout/global_dataset_state_dict_{rollout_id}.pt")
+            directory = os.path.dirname(path)
+            os.makedirs(directory, exist_ok=True)
+            torch.save(state_dict, path)
 
     def load(self, rollout_id=None):
         if not self.args.rollout_global_dataset:
@@ -148,17 +402,20 @@ class RolloutDataSource(DataSource):
             logger.info(f"Checkpoint {path} does not exist.")
             return
 
-        logger.info(f"load metadata from {path}")
-        logger.info(f"load metadata: {self.metadata}")
-        state_dict = torch.load(path)
-        self.sample_offset = state_dict.get("sample_offset", 0)
-        self.epoch_id = state_dict.get("epoch_id", 0)
-        self.sample_group_index = state_dict.get("sample_group_index", 0)
-        self.sample_index = state_dict.get("sample_index", 0)
-        self.metadata = state_dict.get("metadata", {})
+        with self._reservation_lock:
+            if self._durable_reservations_started:
+                raise RuntimeError("Cannot load source state after durable source reservations have started.")
+            logger.info(f"load metadata from {path}")
+            logger.info(f"load metadata: {self.metadata}")
+            state_dict = torch.load(path)
+            self.sample_offset = state_dict.get("sample_offset", 0)
+            self.epoch_id = state_dict.get("epoch_id", 0)
+            self.sample_group_index = state_dict.get("sample_group_index", 0)
+            self.sample_index = state_dict.get("sample_index", 0)
+            self.metadata = state_dict.get("metadata", {})
 
-        if self.args.rollout_global_dataset and self.args.rollout_shuffle:
-            self.dataset.shuffle(self.epoch_id)
+            if self.args.rollout_shuffle:
+                self._set_dataset_epoch(self.epoch_id)
 
 
 class RolloutDataSourceWithBuffer(RolloutDataSource):
@@ -169,6 +426,21 @@ class RolloutDataSourceWithBuffer(RolloutDataSource):
             self.buffer_filter = pop_first
         else:
             self.buffer_filter = load_function(self.args.buffer_filter_path)
+
+    def reserve_samples(self, num_groups: int) -> list[SourceReservation]:
+        raise RuntimeError(
+            f"{self.__class__.__name__} does not support durable source reservations because they would bypass its retry buffer."
+        )
+
+    def acknowledge_reservations(self, reservations: Sequence[SourceReservation], *, rollout_id: int) -> None:
+        raise RuntimeError(
+            f"{self.__class__.__name__} does not support durable source reservations because they would bypass its retry buffer."
+        )
+
+    def requeue_reservations(self, reservations: Sequence[SourceReservation]) -> None:
+        raise RuntimeError(
+            f"{self.__class__.__name__} does not support durable source reservations because they would bypass its retry buffer."
+        )
 
     def get_samples(self, num_samples: int) -> list[list[Sample]]:
         """

--- a/miles/utils/source_fingerprint.py
+++ b/miles/utils/source_fingerprint.py
@@ -1,0 +1,200 @@
+import datetime
+import decimal
+import hashlib
+import os
+import struct
+import uuid
+from collections.abc import Mapping
+from enum import Enum
+from typing import cast
+
+import numpy
+import torch
+from PIL import Image
+
+
+def _digest_parts(tag: bytes, *parts: bytes) -> bytes:
+    digest = hashlib.sha256()
+    digest.update(tag)
+    for part in parts:
+        digest.update(len(part).to_bytes(8, byteorder="big"))
+        digest.update(part)
+    return digest.digest()
+
+
+def _numpy_dtype_digest(dtype: numpy.dtype[numpy.generic]) -> bytes:
+    metadata = canonical_source_digest(dtype.metadata)
+    if dtype.fields is not None:
+        fields = []
+        for name in dtype.names or ():
+            field = dtype.fields[name]
+            field_dtype = field[0]
+            offset = field[1]
+            title = field[2] if len(field) == 3 else None
+            fields.append(
+                _digest_parts(
+                    b"field",
+                    canonical_source_digest(name),
+                    _numpy_dtype_digest(field_dtype),
+                    canonical_source_digest(offset),
+                    canonical_source_digest(title),
+                )
+            )
+        return _digest_parts(
+            b"structured-dtype",
+            canonical_source_digest(dtype.itemsize),
+            canonical_source_digest(dtype.isalignedstruct),
+            metadata,
+            *fields,
+        )
+    if dtype.subdtype is not None:
+        base_dtype, shape = dtype.subdtype
+        return _digest_parts(
+            b"subarray-dtype",
+            _numpy_dtype_digest(base_dtype),
+            canonical_source_digest(shape),
+            metadata,
+        )
+    return _digest_parts(b"dtype", dtype.str.encode(), metadata)
+
+
+def _numpy_has_extended_precision(dtype: numpy.dtype[numpy.generic]) -> bool:
+    return (dtype.kind == "f" and dtype.itemsize > 8) or (dtype.kind == "c" and dtype.itemsize > 16)
+
+
+def _numpy_extended_scalar_digest(value: numpy.generic) -> bytes:
+    if value.dtype.kind == "f":
+        formatted = numpy.format_float_scientific(cast(float, value), unique=True, trim="k")
+        return _digest_parts(b"extended-float", formatted.encode())
+    if value.dtype.kind == "c":
+        complex_value = cast(complex, value)
+        formatted_real = numpy.format_float_scientific(complex_value.real, unique=True, trim="k")
+        formatted_imag = numpy.format_float_scientific(complex_value.imag, unique=True, trim="k")
+        return _digest_parts(b"extended-complex", formatted_real.encode(), formatted_imag.encode())
+    raise TypeError(f"NumPy dtype {value.dtype} is not an extended floating-point type.")
+
+
+def canonical_source_digest(value: object) -> bytes:
+    """Return a deterministic digest for one logical source value.
+
+    Args:
+        value: A source-owned scalar or nested container. Mapping and set
+            iteration order does not affect the digest.
+
+    Returns:
+        A SHA-256 digest that preserves value types and sequence order.
+
+    Raises:
+        TypeError: If the value has no stable logical representation.
+    """
+    if value is None:
+        return _digest_parts(b"none")
+    if isinstance(value, Enum):
+        enum_type = f"{value.__class__.__module__}.{value.__class__.__qualname__}"
+        return _digest_parts(b"enum", enum_type.encode(), canonical_source_digest(value.value))
+    if isinstance(value, numpy.generic):
+        if value.dtype.hasobject or value.dtype.fields is not None:
+            scalar_value = canonical_source_digest(value.tolist())
+        elif _numpy_has_extended_precision(value.dtype):
+            scalar_value = _numpy_extended_scalar_digest(value)
+        else:
+            scalar_value = value.tobytes()
+        return _digest_parts(b"numpy-scalar", _numpy_dtype_digest(value.dtype), scalar_value)
+    if isinstance(value, bool):
+        return _digest_parts(b"bool", b"1" if value else b"0")
+    if isinstance(value, int):
+        return _digest_parts(b"int", str(value).encode())
+    if isinstance(value, float):
+        return _digest_parts(b"float", struct.pack("!d", value))
+    if isinstance(value, str):
+        return _digest_parts(b"str", value.encode())
+    if isinstance(value, (bytes, bytearray, memoryview)):
+        return _digest_parts(b"bytes", bytes(value))
+    if isinstance(value, decimal.Decimal):
+        return _digest_parts(b"decimal", str(value).encode())
+    if isinstance(value, datetime.datetime):
+        return _digest_parts(b"datetime", value.isoformat().encode())
+    if isinstance(value, datetime.date):
+        return _digest_parts(b"date", value.isoformat().encode())
+    if isinstance(value, datetime.time):
+        return _digest_parts(b"time", value.isoformat().encode())
+    if isinstance(value, datetime.timedelta):
+        nanoseconds = getattr(value, "nanoseconds", 0)
+        return _digest_parts(
+            b"timedelta",
+            canonical_source_digest(value.days),
+            canonical_source_digest(value.seconds),
+            canonical_source_digest(value.microseconds),
+            canonical_source_digest(nanoseconds),
+        )
+    if isinstance(value, uuid.UUID):
+        return _digest_parts(b"uuid", value.bytes)
+    if isinstance(value, os.PathLike):
+        return _digest_parts(b"path", os.fsencode(value))
+    if isinstance(value, torch.Tensor):
+        if value.layout != torch.strided:
+            raise TypeError(f"Cannot fingerprint tensor with layout {value.layout}.")
+        if value.is_quantized:
+            raise TypeError("Cannot fingerprint quantized tensors.")
+        tensor = value.detach().resolve_conj().resolve_neg().cpu().contiguous()
+        tensor_bytes = tensor.reshape(-1).view(torch.uint8).numpy().tobytes()
+        return _digest_parts(
+            b"tensor",
+            str(tensor.dtype).encode(),
+            canonical_source_digest(tuple(tensor.shape)),
+            tensor_bytes,
+        )
+    if isinstance(value, numpy.ma.MaskedArray):
+        return _digest_parts(
+            b"masked-array",
+            _numpy_dtype_digest(value.dtype),
+            canonical_source_digest(value.shape),
+            canonical_source_digest(value.data),
+            canonical_source_digest(numpy.ma.getmaskarray(value)),
+            canonical_source_digest(value.fill_value),
+        )
+    if isinstance(value, numpy.ndarray):
+        if value.dtype.hasobject or value.dtype.fields is not None or _numpy_has_extended_precision(value.dtype):
+            array_bytes = canonical_source_digest(value.tolist())
+        else:
+            array_bytes = numpy.ascontiguousarray(value).tobytes()
+        return _digest_parts(
+            b"ndarray",
+            _numpy_dtype_digest(value.dtype),
+            canonical_source_digest(value.shape),
+            array_bytes,
+        )
+    if isinstance(value, Image.Image):
+        return _digest_parts(
+            b"image",
+            value.mode.encode(),
+            canonical_source_digest(value.size),
+            canonical_source_digest(value.format),
+            value.tobytes(),
+            canonical_source_digest(value.getpalette()),
+            canonical_source_digest(value.info),
+            value.getexif().tobytes(),
+        )
+    if isinstance(value, Mapping):
+        entries = sorted(
+            _digest_parts(b"entry", canonical_source_digest(key), canonical_source_digest(item))
+            for key, item in value.items()
+        )
+        return _digest_parts(b"mapping", *entries)
+    if isinstance(value, list):
+        return _digest_parts(b"list", *(canonical_source_digest(item) for item in value))
+    if isinstance(value, tuple):
+        return _digest_parts(b"tuple", *(canonical_source_digest(item) for item in value))
+    if isinstance(value, set):
+        return _digest_parts(
+            b"set",
+            *(sorted(canonical_source_digest(item) for item in value)),
+        )
+    if isinstance(value, frozenset):
+        return _digest_parts(
+            b"frozenset",
+            *(sorted(canonical_source_digest(item) for item in value)),
+        )
+    raise TypeError(
+        f"Cannot fingerprint rollout source value of type {value.__class__.__module__}.{value.__class__.__qualname__}."
+    )

--- a/tests/fast/rollout/test_data_source_reservations.py
+++ b/tests/fast/rollout/test_data_source_reservations.py
@@ -1,0 +1,285 @@
+import copy
+import json
+from argparse import Namespace
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+import miles.rollout.data_source as data_source_module
+from miles.rollout.data_source import (
+    RolloutDataSource,
+    RolloutDataSourceWithBuffer,
+    SourceReservation,
+    SourceReservationId,
+)
+from miles.utils.types import Sample
+
+
+@pytest.fixture(autouse=True)
+def patch_processors(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(data_source_module, "load_tokenizer", lambda *args, **kwargs: object())
+    monkeypatch.setattr(data_source_module, "load_processor", lambda *args, **kwargs: None)
+
+
+def _source_args(tmp_path: Path, *, rollout_shuffle: bool = False) -> Namespace:
+    prompt_path = tmp_path / "prompts.jsonl"
+    prompt_path.write_text(
+        "\n".join(json.dumps({"prompt": prompt}) for prompt in ("alpha", "bravo", "charlie", "delta")),
+        encoding="utf-8",
+    )
+    return Namespace(
+        rollout_global_dataset=True,
+        hf_checkpoint="unused",
+        chat_template_path=None,
+        dump_details=None,
+        prompt_data=str(prompt_path),
+        rollout_max_prompt_len=None,
+        input_key="prompt",
+        multimodal_keys=None,
+        label_key=None,
+        metadata_key="metadata",
+        tool_key=None,
+        apply_chat_template=False,
+        apply_chat_template_kwargs=None,
+        rollout_seed=100,
+        rollout_shuffle=rollout_shuffle,
+        n_samples_per_prompt=2,
+        save=str(tmp_path),
+        load=str(tmp_path),
+        save_interval=1,
+        save_trigger_sentinel=None,
+        buffer_filter_path=None,
+    )
+
+
+def _reservation(reservation_id: int, *, prompt: str) -> SourceReservation:
+    first_sample_index = reservation_id * 2
+    return SourceReservation(
+        reservation_id=SourceReservationId(str(reservation_id)),
+        samples=tuple(
+            Sample(group_index=reservation_id, index=sample_index, prompt=prompt)
+            for sample_index in (first_sample_index, first_sample_index + 1)
+        ),
+    )
+
+
+def test_reserve_returns_exact_pristine_groups(tmp_path: Path) -> None:
+    source = RolloutDataSource(_source_args(tmp_path))
+
+    assert source.reserve_samples(3) == [
+        _reservation(0, prompt="alpha"),
+        _reservation(1, prompt="bravo"),
+        _reservation(2, prompt="charlie"),
+    ]
+
+
+def test_reservation_keeps_every_parent_slot(tmp_path: Path) -> None:
+    source = RolloutDataSource(_source_args(tmp_path))
+    [reservation] = source.reserve_samples(1)
+
+    with pytest.raises(AttributeError, match="'tuple' object has no attribute 'pop'"):
+        cast(list[Sample], reservation.samples).pop()
+
+    source.acknowledge_reservations([reservation], rollout_id=0)
+
+
+@pytest.mark.parametrize("num_groups", [True, -1, 1.5, "1"])
+def test_reserve_rejects_invalid_group_count(tmp_path: Path, num_groups: object) -> None:
+    source = RolloutDataSource(_source_args(tmp_path))
+
+    with pytest.raises(
+        ValueError,
+        match=rf"num_groups must be a nonnegative integer, got {num_groups!r}\.",
+    ):
+        source.reserve_samples(cast(int, num_groups))
+
+    assert source.reserve_samples(1) == [_reservation(0, prompt="alpha")]
+
+
+def test_duplicate_settlement_is_atomic(tmp_path: Path) -> None:
+    source = RolloutDataSource(_source_args(tmp_path))
+    first, second = source.reserve_samples(2)
+
+    with pytest.raises(
+        ValueError,
+        match=r"Reservation settlement contains duplicate identities: \['0', '0'\]\.",
+    ):
+        source.acknowledge_reservations([first, first], rollout_id=0)
+
+    source.acknowledge_reservations([first, second], rollout_id=0)
+    assert source.reserve_samples(1) == [_reservation(2, prompt="charlie")]
+
+
+def test_reissued_reservation_rejects_stale_attempt(tmp_path: Path) -> None:
+    source = RolloutDataSource(_source_args(tmp_path))
+    [first_attempt] = source.reserve_samples(1)
+    source.requeue_reservations([first_attempt])
+
+    [second_attempt] = source.reserve_samples(1)
+    assert second_attempt == first_attempt
+    assert second_attempt is not first_attempt
+
+    with pytest.raises(
+        RuntimeError,
+        match=r"Source reservations are not the current outstanding attempts: \['0'\]\.",
+    ):
+        source.acknowledge_reservations([first_attempt], rollout_id=0)
+
+    source.acknowledge_reservations([second_attempt], rollout_id=0)
+
+
+def test_mixed_stale_settlement_leaves_valid_attempt_outstanding(tmp_path: Path) -> None:
+    source = RolloutDataSource(_source_args(tmp_path))
+    first, old_second = source.reserve_samples(2)
+    source.requeue_reservations([old_second])
+    [new_second] = source.reserve_samples(1)
+
+    with pytest.raises(
+        RuntimeError,
+        match=r"Source reservations are not the current outstanding attempts: \['1'\]\.",
+    ):
+        source.acknowledge_reservations([first, old_second], rollout_id=0)
+
+    source.acknowledge_reservations([first, new_second], rollout_id=0)
+    assert source.reserve_samples(1) == [_reservation(2, prompt="charlie")]
+
+
+def test_mixed_invalid_requeue_leaves_valid_attempt_outstanding(tmp_path: Path) -> None:
+    source = RolloutDataSource(_source_args(tmp_path))
+    [valid] = source.reserve_samples(1)
+    forged = _reservation(99, prompt="forged")
+
+    with pytest.raises(
+        RuntimeError,
+        match=r"Source reservations are not the current outstanding attempts: \['99'\]\.",
+    ):
+        source.requeue_reservations([valid, forged])
+
+    source.acknowledge_reservations([valid], rollout_id=0)
+
+
+def test_requeue_reconstructs_pristine_samples_in_process(tmp_path: Path) -> None:
+    source = RolloutDataSource(_source_args(tmp_path))
+    [first_attempt] = source.reserve_samples(1)
+    first_attempt.samples[0].prompt = "mutated"
+    first_attempt.samples[1].response = "generated"
+
+    source.requeue_reservations([first_attempt])
+
+    assert source.reserve_samples(1) == [_reservation(0, prompt="alpha")]
+
+
+def test_requeue_replays_holes_in_source_order(tmp_path: Path) -> None:
+    source = RolloutDataSource(_source_args(tmp_path))
+    first, second, third, fourth = source.reserve_samples(4)
+    source.acknowledge_reservations([second, fourth], rollout_id=0)
+    source.requeue_reservations([third, first])
+
+    assert source.reserve_samples(3) == [
+        _reservation(0, prompt="alpha"),
+        _reservation(2, prompt="charlie"),
+        _reservation(4, prompt="alpha"),
+    ]
+
+
+def test_legacy_reads_are_rejected_after_durable_ownership_starts(tmp_path: Path) -> None:
+    source = RolloutDataSource(_source_args(tmp_path))
+    [reservation] = source.reserve_samples(1)
+
+    with pytest.raises(
+        RuntimeError,
+        match="Cannot use get_samples after durable source reservations have started.",
+    ):
+        source.get_samples(1)
+
+    source.requeue_reservations([reservation])
+    assert source.reserve_samples(2) == [
+        _reservation(0, prompt="alpha"),
+        _reservation(1, prompt="bravo"),
+    ]
+
+
+def test_shuffled_multi_epoch_replay_reconstructs_exact_groups(tmp_path: Path) -> None:
+    source = RolloutDataSource(_source_args(tmp_path, rollout_shuffle=True))
+    reservations = source.reserve_samples(10)
+    expected = copy.deepcopy(reservations)
+    for reservation in reservations:
+        reservation.samples[0].prompt = "mutated"
+    source.requeue_reservations(reservations)
+
+    assert source.reserve_samples(10) == expected
+
+
+def test_materialization_failure_does_not_advance_source(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = RolloutDataSource(_source_args(tmp_path))
+    original_deepcopy = copy.deepcopy
+    copy_count = 0
+
+    def fail_during_second_group(value: object) -> object:
+        nonlocal copy_count
+        copy_count += 1
+        if copy_count == 3:
+            raise RuntimeError("injected materialization failure")
+        return original_deepcopy(value)
+
+    monkeypatch.setattr(data_source_module.copy, "deepcopy", fail_during_second_group)
+    with pytest.raises(RuntimeError, match="injected materialization failure"):
+        source.reserve_samples(2)
+
+    monkeypatch.setattr(data_source_module.copy, "deepcopy", original_deepcopy)
+    assert source.reserve_samples(2) == [
+        _reservation(0, prompt="alpha"),
+        _reservation(1, prompt="bravo"),
+    ]
+
+
+def test_non_persistent_source_rejects_durable_reservations(tmp_path: Path) -> None:
+    args = _source_args(tmp_path)
+    args.rollout_global_dataset = False
+    source = RolloutDataSource(args)
+
+    with pytest.raises(
+        RuntimeError,
+        match="RolloutDataSource does not support durable source reservations when rollout_global_dataset is disabled.",
+    ):
+        source.reserve_samples(1)
+
+
+def test_reservation_aware_save_fails_before_checkpoint_support(tmp_path: Path) -> None:
+    source = RolloutDataSource(_source_args(tmp_path))
+    first, second = source.reserve_samples(2)
+    source.acknowledge_reservations([first], rollout_id=0)
+    source.requeue_reservations([second])
+
+    with pytest.raises(
+        RuntimeError,
+        match=(
+            "Cannot save source state after durable source reservations have started "
+            "until reservation checkpointing is available."
+        ),
+    ):
+        source.save(rollout_id=0)
+
+    assert not (tmp_path / "rollout" / "global_dataset_state_dict_0.pt").exists()
+    assert source.reserve_samples(1) == [_reservation(1, prompt="bravo")]
+
+
+def test_buffered_source_rejects_reservations_that_bypass_retry_buffer(tmp_path: Path) -> None:
+    source = RolloutDataSourceWithBuffer(_source_args(tmp_path))
+    retry_group = list(_reservation(7, prompt="retry").samples)
+    source.add_samples([retry_group])
+
+    with pytest.raises(
+        RuntimeError,
+        match=(
+            "RolloutDataSourceWithBuffer does not support durable source reservations because they would bypass its retry buffer."
+        ),
+    ):
+        source.reserve_samples(1)
+
+    assert source.get_samples(1) == [retry_group]
+    assert source.get_buffer_length() == 0

--- a/tests/fast/utils/test_source_fingerprint.py
+++ b/tests/fast/utils/test_source_fingerprint.py
@@ -1,0 +1,76 @@
+import numpy
+import pytest
+import torch
+from PIL import Image
+
+from miles.utils.source_fingerprint import canonical_source_digest
+
+
+def test_canonical_source_digest_ignores_mapping_order() -> None:
+    first = {"prompt": "inspect", "metadata": {"left": 1, "right": 2}}
+    second = {"metadata": {"right": 2, "left": 1}, "prompt": "inspect"}
+
+    assert canonical_source_digest(first) == canonical_source_digest(second)
+
+
+def test_canonical_source_digest_distinguishes_value_types() -> None:
+    assert canonical_source_digest(True) != canonical_source_digest(1)
+    assert canonical_source_digest(b"1") != canonical_source_digest("1")
+    assert canonical_source_digest([1]) != canonical_source_digest((1,))
+
+
+def test_canonical_source_digest_normalizes_tensor_views() -> None:
+    tensor = torch.arange(6, dtype=torch.int64).reshape(2, 3)
+    noncontiguous = tensor.t().contiguous().t()
+
+    assert not noncontiguous.is_contiguous()
+    assert canonical_source_digest(tensor) == canonical_source_digest(noncontiguous)
+
+
+def test_canonical_source_digest_includes_image_payload() -> None:
+    first = Image.fromarray(numpy.array([[0, 1], [2, 3]], dtype=numpy.uint8))
+    second = Image.fromarray(numpy.array([[0, 1], [2, 4]], dtype=numpy.uint8))
+
+    assert canonical_source_digest(first) != canonical_source_digest(second)
+
+
+def test_canonical_source_digest_includes_image_metadata() -> None:
+    first = Image.new("RGB", (2, 1), color="red")
+    second = first.copy()
+    first.getexif()[274] = 1
+    second.getexif()[274] = 6
+    assert canonical_source_digest(first) != canonical_source_digest(second)
+
+    second.getexif()[274] = 1
+    first.info["icc_profile"] = b"first"
+    second.info["icc_profile"] = b"second"
+    assert canonical_source_digest(first) != canonical_source_digest(second)
+
+
+def test_canonical_source_digest_normalizes_object_arrays() -> None:
+    first = numpy.array([{"left": 1, "right": 2}, ["value"]], dtype=object)
+    second = numpy.array([{"right": 2, "left": 1}, ["value"]], dtype=object)
+
+    assert canonical_source_digest(first) == canonical_source_digest(second)
+
+
+def test_canonical_source_digest_includes_structured_dtype() -> None:
+    first = numpy.array([(1, 2)], dtype=[("left", "<i4"), ("right", "<i4")])
+    second = numpy.array([(1, 2)], dtype=[("right", "<i4"), ("left", "<i4")])
+
+    assert canonical_source_digest(first) != canonical_source_digest(second)
+
+
+def test_canonical_source_digest_rejects_quantized_tensors() -> None:
+    tensor = torch.quantize_per_tensor(torch.tensor([1.0]), scale=0.1, zero_point=0, dtype=torch.qint8)
+
+    with pytest.raises(TypeError, match="Cannot fingerprint quantized tensors."):
+        canonical_source_digest(tensor)
+
+
+def test_canonical_source_digest_rejects_unstable_values() -> None:
+    with pytest.raises(
+        TypeError,
+        match="Cannot fingerprint rollout source value of type builtins.object.",
+    ):
+        canonical_source_digest(object())


### PR DESCRIPTION
## Summary

- Adds explicit ownership attempts for rollout source groups.
- Requires an exact current reservation object for acknowledgement or requeue.
- Prevents stale, duplicate, or foreign attempts from settling source work.

## Context

The current data source advances when it hands out a prompt group. If async rollout fails before training accepts that group, Miles needs an explicit attempt that can return the original input for replay.

A reservation binds one logical group identity to one current attempt. This layer keeps that ownership in memory. [#2247](https://github.com/radixark/miles/pull/2247) is the stack parent. [#2250](https://github.com/radixark/miles/pull/2250) first uses the fingerprint utility when it adds checkpoint persistence and restart replay.

[Issue #2254](https://github.com/radixark/miles/issues/2254) uses this attempt identity to return exact source groups for replay.

| Layer | Upstream PR | Status | Contract |
| --- | --- | --- | --- |
| 1/6 | [#2247](https://github.com/radixark/miles/pull/2247) | Draft | Stable source fingerprint |
| 2/6 | [#2249](https://github.com/radixark/miles/pull/2249) | Draft | Source reservations |
| 3/6 | [#2250](https://github.com/radixark/miles/pull/2250) | Draft | Reservation persistence and replay |
| 4/6 | [#2251](https://github.com/radixark/miles/pull/2251) | Draft | Exact execution receipts |
| 5/6 | [#2252](https://github.com/radixark/miles/pull/2252) | Draft | Receipt-bound inference execution |
| 6/6 | [#2253](https://github.com/radixark/miles/pull/2253) | Draft | Terminal cancellation ownership |

All drafts target `main`, so this PR includes the source-fingerprint commit from [#2247](https://github.com/radixark/miles/pull/2247). Review this layer as the change after #2247. Merge the chain in order. If a parent is squash-merged or rebase-merged, the remaining branches will be rebased onto the updated `main`.

This PR adds one new commit: [`c01f1389`, which reserves rollout source groups](https://github.com/radixark/miles/pull/2249/commits/c01f1389216d2f02dab21c264068a66af7e8978c). Review it against #2247. The contract allows only the exact active attempt to settle a reservation.

## Description

- Adds stable reservation IDs and attempt numbers for source groups.
- Reserves groups before rollout work starts.
- Tracks outstanding reservation attempts in source order.
- Acknowledges exact attempts after successful handoff.
- Requeues exact attempts with their original sample state.
- Rejects duplicate, stale, foreign, and already-settled attempts.
- Prevents legacy `get_samples()` access after reservation mode begins.
- Keeps the existing source cursor and sample indexing behavior.

## Test plan

- [x] `tests/fast/rollout/test_data_source_reservations.py`: 18 reservation tests passed at exact head `0ac965816` on `main` at `f2b7c7929`.
- [x] An exact composed 8xB200 validation preserved reservation IDs `0` and `1` through cancellation, requeue, checkpoint reload, and replay.
- [x] The composed 8xB200 run used Miles ref [`7cd212d81f`](https://github.com/ashtonchew/miles/commit/7cd212d81f6c94f72d67b4443e8c047008e4d517) with validation child [`cf512e6a8a`](https://github.com/GymPod/slime/commit/cf512e6a8a59c7c935e273dc69b9fd84c32e35a3). This evidence covers reservation identity in composition. Isolated PR-head and full training evidence require separate runs.

