### PR TITLE
[3/6] feat(rollout): persist and replay source reservations

### DIFF
--- a/docs/user-guide/customization.md
+++ b/docs/user-guide/customization.md
@@ -103,6 +103,12 @@ class CustomDataSource(DataSource):
     def load(self, rollout_id=None) -> None: ...
 ```
 
+A source may additionally implement `reserve_samples`, `acknowledge_reservations`, and
+`requeue_reservations`, and declare `supports_source_reservations = True`, to opt into
+owned scheduling under `--fully-async`: rollout then hands out durable reservations that
+survive a restart and settles each attempt exactly once. A source that does not declare
+support keeps the buffered legacy path.
+
 **Default:** `miles.rollout.data_source.RolloutDataSourceWithBuffer`.
 
 ### `--eval-function-path`

--- a/docs/user-guide/fully-async.md
+++ b/docs/user-guide/fully-async.md
@@ -182,6 +182,16 @@ this section apply only if your class reads them. The one decision that stays ou
 `--rollout-sample-filter-path`, which runs on the assembled batch rather than on
 individual groups.
 
+### Checkpointing source reservations
+
+Durable source reservations are checkpointed with the source. Persisting them needs
+`--save-interval`. Setting `--save-trigger-sentinel` without `--save-interval` makes the
+data source report no reservation support. Owned scheduling is off in that case, and the
+run keeps the buffered legacy path. Loading a checkpoint that holds reservations into a
+data source that cannot own reservations fails at load. When neither flag is set,
+reservations still run and nothing is ever checkpointed, so there is no reservation state
+to lose.
+
 ## Evaluation
 
 Fully async rollout changes one thing about eval: generation is always in flight, so an

--- a/miles/rollout/data_source.py
+++ b/miles/rollout/data_source.py
@@ -1,18 +1,23 @@
 import abc
 import copy
+import hashlib
 import logging
 import os
 import random
+import tempfile
 import threading
 from collections.abc import Sequence
 from pathlib import Path
-from typing import NamedTuple, NewType
+from typing import Annotated, Literal, NamedTuple, NewType
 
 import torch
+from pydantic import Field
 
 from miles.utils.data import Dataset
 from miles.utils.misc import load_function
 from miles.utils.processing_utils import load_processor, load_tokenizer
+from miles.utils.pydantic_utils import FrozenStrictBaseModel
+from miles.utils.source_fingerprint import canonical_source_digest
 from miles.utils.types import Sample
 
 logger = logging.getLogger(__name__)
@@ -32,8 +37,24 @@ class SourceReservation(NamedTuple):
     samples: tuple[Sample, ...]
 
 
-class _SourceReservationRecord(NamedTuple):
-    group_index: int
+class _SourceReservationRecord(FrozenStrictBaseModel):
+    group_index: Annotated[int, Field(strict=True, ge=0)]
+
+
+class _SourceCompatibility(FrozenStrictBaseModel):
+    materialization_schema_version: Literal[1]
+    materialized_samples_sha256: Annotated[str, Field(strict=True, pattern=r"^[0-9a-f]{64}$")]
+    dataset_size: Annotated[int, Field(strict=True, ge=0)]
+    rollout_shuffle: Annotated[bool, Field(strict=True)]
+    shuffle_seed: Annotated[int, Field(strict=True)] | None
+    shuffle_schema_version: Literal[1]
+    n_samples_per_prompt: Annotated[int, Field(strict=True, ge=1)]
+
+
+class _SourceReservationCheckpoint(FrozenStrictBaseModel):
+    schema_version: Literal[1]
+    source_compatibility: _SourceCompatibility
+    replay: tuple[_SourceReservationRecord, ...]
 
 
 class _OutstandingReservation(NamedTuple):
@@ -41,10 +62,16 @@ class _OutstandingReservation(NamedTuple):
     attempt: SourceReservation
 
 
+class _AcknowledgedReservation(NamedTuple):
+    record: _SourceReservationRecord
+    rollout_id: int
+
+
 class DataSource(abc.ABC):
     # Whether ``reserve_samples`` hands out durable source reservations. Fully
     # async rollout schedules owned work only for sources that declare support;
-    # overriding ``reserve_samples`` alone is not a capability signal.
+    # overriding ``reserve_samples`` alone is not a capability signal. A source
+    # declares support here; a configured instance may still report False.
     supports_source_reservations: bool = False
 
     @abc.abstractmethod
@@ -85,8 +112,11 @@ class DataSource(abc.ABC):
             Reservations that require explicit settlement.
 
         Implementations must return exactly ``num_groups`` reservations with
-        unique identities and declare ``supports_source_reservations = True``.
-        If this method raises, it must not transfer source ownership.
+        unique identities and declare ``supports_source_reservations = True``
+        at class level. A configured instance may still report False when its
+        arguments rule reservations out, and callers must read the attribute
+        off the instance. If this method raises, it must not transfer source
+        ownership.
 
         Raises:
             RuntimeError: If this data source does not support reservations.
@@ -138,10 +168,19 @@ class RolloutDataSource(DataSource):
         self.metadata = {}
         self._reservation_lock = threading.RLock()
         self._outstanding_reservations: dict[SourceReservationId, _OutstandingReservation] = {}
+        self._acknowledged_reservations: dict[SourceReservationId, _AcknowledgedReservation] = {}
         self._replay_reservations: list[_SourceReservationRecord] = []
+        self._last_saved_rollout_id: int | None = None
+        self._reservation_checkpoints_enabled = self.args.save_interval is not None
+        # The class declares the capability; this configuration may still rule it out.
+        self.supports_source_reservations = (
+            type(self).supports_source_reservations and self._durable_reservations_gate_error() is None
+        )
         self._durable_reservations_started = False
         self._permutation_epoch_id: int | None = None
         self._permutation: tuple[int, ...] = ()
+        self._source_compatibility: _SourceCompatibility | None = None
+        self.dataset: Dataset | None
 
         if args.rollout_global_dataset:
             tokenizer = load_tokenizer(
@@ -197,6 +236,7 @@ class RolloutDataSource(DataSource):
                 return []
             if self.dataset is not None and len(self.dataset) == 0:
                 raise ValueError("Cannot reserve samples from an empty rollout dataset.")
+            self._get_source_compatibility()
 
             replay_count = min(num_groups, len(self._replay_reservations))
             replay_records = self._replay_reservations[:replay_count]
@@ -233,10 +273,19 @@ class RolloutDataSource(DataSource):
         self._require_durable_reservations()
         self._validate_rollout_id(rollout_id)
         with self._reservation_lock:
+            if self._last_saved_rollout_id is not None and rollout_id <= self._last_saved_rollout_id:
+                raise ValueError(
+                    f"Reservation rollout_id {rollout_id} must be newer than published checkpoint {self._last_saved_rollout_id}."
+                )
             outstanding = self._get_outstanding_reservations_locked(reservations)
             for owned in outstanding:
                 reservation_id = owned.attempt.reservation_id
                 del self._outstanding_reservations[reservation_id]
+                if self._reservation_checkpoints_enabled:
+                    self._acknowledged_reservations[reservation_id] = _AcknowledgedReservation(
+                        record=owned.record,
+                        rollout_id=rollout_id,
+                    )
 
     def requeue_reservations(self, reservations: Sequence[SourceReservation]) -> None:
         """Return exact outstanding attempts for pristine replay.
@@ -276,11 +325,18 @@ class RolloutDataSource(DataSource):
             raise RuntimeError(f"Source reservations are not the current outstanding attempts: {invalid}.")
         return outstanding
 
-    def _require_durable_reservations(self) -> None:
+    def _durable_reservations_gate_error(self) -> str | None:
+        """Why this configuration rules out durable reservations, or None."""
         if not self.args.rollout_global_dataset:
-            raise RuntimeError(
-                f"{self.__class__.__name__} does not support durable source reservations when rollout_global_dataset is disabled."
-            )
+            return f"{self.__class__.__name__} does not support durable source reservations when rollout_global_dataset is disabled."
+        if not self._reservation_checkpoints_enabled and self.args.save_trigger_sentinel is not None:
+            return "Durable source reservations require a periodic save interval when a save trigger is configured."
+        return None
+
+    def _require_durable_reservations(self) -> None:
+        error = self._durable_reservations_gate_error()
+        if error is not None:
+            raise RuntimeError(error)
 
     @staticmethod
     def _validate_rollout_id(rollout_id: int) -> None:
@@ -339,6 +395,34 @@ class RolloutDataSource(DataSource):
         self.dataset.samples = [self.dataset.origin_samples[index] for index in permutation]
         self.dataset.epoch_id = epoch_id
 
+    def _build_source_compatibility(self) -> _SourceCompatibility | None:
+        if self.dataset is None:
+            return None
+        return _SourceCompatibility(
+            materialization_schema_version=1,
+            materialized_samples_sha256=self._processed_samples_sha256(),
+            dataset_size=len(self.dataset),
+            rollout_shuffle=self.args.rollout_shuffle,
+            shuffle_seed=self.args.rollout_seed if self.args.rollout_shuffle else None,
+            shuffle_schema_version=1,
+            n_samples_per_prompt=self.args.n_samples_per_prompt,
+        )
+
+    def _get_source_compatibility(self) -> _SourceCompatibility:
+        if self._source_compatibility is None:
+            source_compatibility = self._build_source_compatibility()
+            if source_compatibility is None:
+                raise RuntimeError("Durable source reservations require rollout_global_dataset.")
+            self._source_compatibility = source_compatibility
+        return self._source_compatibility
+
+    def _processed_samples_sha256(self) -> str:
+        assert self.dataset is not None
+        digest = hashlib.sha256()
+        for sample in self.dataset.origin_samples:
+            digest.update(canonical_source_digest(sample.to_dict()))
+        return digest.hexdigest()
+
     def get_samples(self, num_samples):
         with self._reservation_lock:
             if self._durable_reservations_started:
@@ -379,12 +463,8 @@ class RolloutDataSource(DataSource):
         if not self.args.rollout_global_dataset:
             return
 
+        self._validate_rollout_id(rollout_id)
         with self._reservation_lock:
-            if self._durable_reservations_started:
-                raise RuntimeError(
-                    "Cannot save source state after durable source reservations have started "
-                    "until reservation checkpointing is available."
-                )
             state_dict = {
                 "sample_offset": self.sample_offset,
                 "epoch_id": self.epoch_id,
@@ -395,7 +475,55 @@ class RolloutDataSource(DataSource):
             path = os.path.join(self.args.save, f"rollout/global_dataset_state_dict_{rollout_id}.pt")
             directory = os.path.dirname(path)
             os.makedirs(directory, exist_ok=True)
-            torch.save(state_dict, path)
+            if self._last_saved_rollout_id is not None and rollout_id < self._last_saved_rollout_id:
+                raise ValueError(
+                    f"Source checkpoint rollout_id must not move backward from {self._last_saved_rollout_id} to {rollout_id}."
+                )
+            if not self._durable_reservations_started:
+                torch.save(state_dict, path)
+                self._last_saved_rollout_id = rollout_id
+                return
+
+            if self._durable_reservations_started and not self._reservation_checkpoints_enabled:
+                raise RuntimeError("Cannot save durable source reservations without --save-interval.")
+
+            replay = [
+                *self._replay_reservations,
+                *(owned.record for owned in self._outstanding_reservations.values()),
+                *(
+                    acknowledged.record
+                    for acknowledged in self._acknowledged_reservations.values()
+                    if acknowledged.rollout_id > rollout_id
+                ),
+            ]
+            replay.sort(key=lambda record: record.group_index)
+            reservation_ids = [self._reservation_id(record) for record in replay]
+            if len(reservation_ids) != len(set(reservation_ids)):
+                raise RuntimeError(f"Source reservation ownership is duplicated at checkpoint: {reservation_ids}.")
+
+            state_dict["source_reservations"] = _SourceReservationCheckpoint(
+                schema_version=1,
+                source_compatibility=self._get_source_compatibility(),
+                replay=tuple(replay),
+            ).model_dump(mode="python")
+            descriptor, temporary_path = tempfile.mkstemp(
+                dir=directory,
+                prefix=f".{os.path.basename(path)}.",
+                suffix=".tmp",
+            )
+            os.close(descriptor)
+            try:
+                torch.save(state_dict, temporary_path)
+                os.replace(temporary_path, path)
+            finally:
+                Path(temporary_path).unlink(missing_ok=True)
+
+            self._acknowledged_reservations = {
+                reservation_id: acknowledged
+                for reservation_id, acknowledged in self._acknowledged_reservations.items()
+                if acknowledged.rollout_id > rollout_id
+            }
+            self._last_saved_rollout_id = rollout_id
 
     def load(self, rollout_id=None):
         if not self.args.rollout_global_dataset:
@@ -404,6 +532,10 @@ class RolloutDataSource(DataSource):
         if self.args.load is None:
             return
 
+        if isinstance(rollout_id, int) and not isinstance(rollout_id, bool) and rollout_id == -1:
+            return
+        if rollout_id is not None:
+            self._validate_rollout_id(rollout_id)
         path = os.path.join(self.args.load, f"rollout/global_dataset_state_dict_{rollout_id}.pt")
         if not os.path.exists(path):
             logger.info(f"Checkpoint {path} does not exist.")
@@ -413,16 +545,88 @@ class RolloutDataSource(DataSource):
             if self._durable_reservations_started:
                 raise RuntimeError("Cannot load source state after durable source reservations have started.")
             logger.info(f"load metadata from {path}")
-            logger.info(f"load metadata: {self.metadata}")
             state_dict = torch.load(path)
-            self.sample_offset = state_dict.get("sample_offset", 0)
-            self.epoch_id = state_dict.get("epoch_id", 0)
-            self.sample_group_index = state_dict.get("sample_group_index", 0)
-            self.sample_index = state_dict.get("sample_index", 0)
+            if "source_reservations" in state_dict:
+                cursor_fields = ("sample_offset", "epoch_id", "sample_group_index", "sample_index")
+                missing_cursor_fields = [field for field in cursor_fields if field not in state_dict]
+                if missing_cursor_fields:
+                    raise ValueError(f"Checkpoint is missing source cursor fields: {missing_cursor_fields}.")
+            sample_group_index = state_dict.get("sample_group_index", 0)
+            if "source_reservations" in state_dict:
+                if not self.supports_source_reservations:
+                    reason = self._durable_reservations_gate_error()
+                    if reason is None:
+                        reason = f"{self.__class__.__name__} does not support durable source reservations."
+                    raise ValueError(f"Source reservation checkpoint cannot be loaded: {reason}")
+                reservation_state = _SourceReservationCheckpoint.model_validate(state_dict["source_reservations"])
+                if reservation_state.source_compatibility != self._get_source_compatibility():
+                    raise ValueError(
+                        "Source reservation checkpoint configuration does not match the current data source."
+                    )
+                epoch_id = state_dict.get("epoch_id", 0)
+                sample_offset = state_dict.get("sample_offset", 0)
+                replay = list(reservation_state.replay)
+            else:
+                epoch_id, sample_offset = self._normalize_legacy_cursor(sample_group_index)
+                replay = []
+            sample_index = state_dict.get("sample_index", 0)
+            if "source_reservations" in state_dict:
+                for field, value in (
+                    ("sample_offset", sample_offset),
+                    ("epoch_id", epoch_id),
+                    ("sample_group_index", sample_group_index),
+                    ("sample_index", sample_index),
+                ):
+                    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+                        raise ValueError(f"Checkpoint {field} must be a nonnegative integer, got {value!r}.")
+                assert self.dataset is not None
+                dataset_size = len(self.dataset)
+                if sample_offset > dataset_size:
+                    raise ValueError(f"Checkpoint sample offset {sample_offset} exceeds dataset size {dataset_size}.")
+                if dataset_size == 0:
+                    if epoch_id != 0 or sample_offset != 0 or sample_group_index != 0:
+                        raise ValueError("An empty rollout dataset requires a zero source cursor.")
+                else:
+                    expected_group_frontier = epoch_id * dataset_size + sample_offset
+                    if sample_group_index != expected_group_frontier:
+                        raise ValueError(
+                            f"Checkpoint group frontier {sample_group_index} does not match dataset cursor at epoch {epoch_id} offset {sample_offset} for dataset size {dataset_size}."
+                        )
+                expected_sample_frontier = sample_group_index * self.args.n_samples_per_prompt
+                if sample_index != expected_sample_frontier:
+                    raise ValueError(
+                        f"Checkpoint sample frontier {sample_index} does not match group frontier {sample_group_index} with {self.args.n_samples_per_prompt} samples per prompt."
+                    )
+
+            reservation_ids = [self._reservation_id(record) for record in replay]
+            if len(reservation_ids) != len(set(reservation_ids)):
+                raise ValueError(f"Checkpoint contains duplicate source reservation identities: {reservation_ids}.")
+            if any(record.group_index < 0 or record.group_index >= sample_group_index for record in replay):
+                raise ValueError("Checkpoint contains a source reservation outside the saved group frontier.")
+
+            self.sample_offset = sample_offset
+            self.epoch_id = epoch_id
+            self.sample_group_index = sample_group_index
+            self.sample_index = sample_index
             self.metadata = state_dict.get("metadata", {})
+            self._replay_reservations = sorted(replay, key=lambda record: record.group_index)
+            self._outstanding_reservations = {}
+            self._acknowledged_reservations = {}
+            self._last_saved_rollout_id = rollout_id
+            self._durable_reservations_started = "source_reservations" in state_dict
 
             if self.args.rollout_shuffle:
                 self._set_dataset_epoch(self.epoch_id)
+
+    def _normalize_legacy_cursor(self, sample_group_index: int) -> tuple[int, int]:
+        assert self.dataset is not None
+        if len(self.dataset) == 0:
+            return 0, 0
+        return divmod(sample_group_index, len(self.dataset))
+
+    @staticmethod
+    def _reservation_id(record: _SourceReservationRecord) -> SourceReservationId:
+        return SourceReservationId(str(record.group_index))
 
 
 class RolloutDataSourceWithBuffer(RolloutDataSource):

--- a/miles/rollout/data_source.py
+++ b/miles/rollout/data_source.py
@@ -2,7 +2,11 @@ import abc
 import copy
 import logging
 import os
+import random
+import threading
+from collections.abc import Sequence
 from pathlib import Path
+from typing import NamedTuple, NewType
 
 import torch
 
@@ -13,8 +17,36 @@ from miles.utils.types import Sample
 
 logger = logging.getLogger(__name__)
 
+SourceReservationId = NewType("SourceReservationId", str)
+
+
+class SourceReservation(NamedTuple):
+    """One source-owned prompt group attempt.
+
+    Attributes:
+        reservation_id: Stable logical identity across replay attempts.
+        samples: Pristine samples for this attempt.
+    """
+
+    reservation_id: SourceReservationId
+    samples: tuple[Sample, ...]
+
+
+class _SourceReservationRecord(NamedTuple):
+    group_index: int
+
+
+class _OutstandingReservation(NamedTuple):
+    record: _SourceReservationRecord
+    attempt: SourceReservation
+
 
 class DataSource(abc.ABC):
+    # Whether ``reserve_samples`` hands out durable source reservations. Fully
+    # async rollout schedules owned work only for sources that declare support;
+    # overriding ``reserve_samples`` alone is not a capability signal.
+    supports_source_reservations: bool = False
+
     @abc.abstractmethod
     def get_samples(self, num_samples: int) -> list[list[Sample]]:
         """
@@ -43,9 +75,58 @@ class DataSource(abc.ABC):
         """Pending-sample backlog, or None for sources without a buffer."""
         return None
 
+    def reserve_samples(self, num_groups: int) -> list[SourceReservation]:
+        """Reserve pristine prompt groups for ownership-aware rollout.
+
+        Args:
+            num_groups: Number of prompt groups to reserve.
+
+        Returns:
+            Reservations that require explicit settlement.
+
+        Implementations must return exactly ``num_groups`` reservations with
+        unique identities and declare ``supports_source_reservations = True``.
+        If this method raises, it must not transfer source ownership.
+
+        Raises:
+            RuntimeError: If this data source does not support reservations.
+        """
+        raise RuntimeError(f"{self.__class__.__name__} does not support durable source reservations.")
+
+    def acknowledge_reservations(self, reservations: Sequence[SourceReservation], *, rollout_id: int) -> None:
+        """Record successful handoff of exact source reservation attempts.
+
+        Args:
+            reservations: Exact attempts to acknowledge.
+            rollout_id: Training rollout that accepted the groups.
+
+        Implementations must validate the complete batch before mutation. If
+        this method raises, every input reservation must remain outstanding.
+
+        Raises:
+            RuntimeError: If this data source does not support reservations.
+        """
+        raise RuntimeError(f"{self.__class__.__name__} does not support durable source reservations.")
+
+    def requeue_reservations(self, reservations: Sequence[SourceReservation]) -> None:
+        """Return exact source reservation attempts for pristine replay.
+
+        Args:
+            reservations: Exact attempts to requeue.
+
+        Implementations must validate the complete batch before mutation. If
+        this method raises, every input reservation must remain outstanding.
+
+        Raises:
+            RuntimeError: If this data source does not support reservations.
+        """
+        raise RuntimeError(f"{self.__class__.__name__} does not support durable source reservations.")
+
 
 # TODO may further refactor data-loading part later
 class RolloutDataSource(DataSource):
+    supports_source_reservations = True
+
     def __init__(self, args):
         self.args = args
 
@@ -55,6 +136,12 @@ class RolloutDataSource(DataSource):
         self.sample_offset = 0
         # TODO remove this
         self.metadata = {}
+        self._reservation_lock = threading.RLock()
+        self._outstanding_reservations: dict[SourceReservationId, _OutstandingReservation] = {}
+        self._replay_reservations: list[_SourceReservationRecord] = []
+        self._durable_reservations_started = False
+        self._permutation_epoch_id: int | None = None
+        self._permutation: tuple[int, ...] = ()
 
         if args.rollout_global_dataset:
             tokenizer = load_tokenizer(
@@ -84,39 +171,206 @@ class RolloutDataSource(DataSource):
                 seed=args.rollout_seed,
             )
             if self.args.rollout_shuffle:
-                self.dataset.shuffle(self.epoch_id)
+                self._set_dataset_epoch(self.epoch_id)
         else:
             self.dataset = None
 
-    def get_samples(self, num_samples):
-        # TODO further improve code
-        if self.dataset is not None:
-            if self.sample_offset + num_samples <= len(self.dataset):
-                prompt_samples = self.dataset.samples[self.sample_offset : self.sample_offset + num_samples]
-                self.sample_offset += num_samples
-            else:
-                prompt_samples = self.dataset.samples[self.sample_offset :]
-                num_samples -= len(prompt_samples)
-                self.epoch_id += 1
-                if self.args.rollout_shuffle:
-                    self.dataset.shuffle(self.epoch_id)
-                prompt_samples += self.dataset.samples[:num_samples]
-                self.sample_offset = num_samples
-        else:
-            prompt_samples = [Sample() for _ in range(num_samples)]
+    def reserve_samples(self, num_groups: int) -> list[SourceReservation]:
+        """Reserve prompt groups without settling source ownership.
 
+        Args:
+            num_groups: Number of groups to reserve.
+
+        Returns:
+            Replay attempts first, then newly admitted source groups.
+
+        Raises:
+            ValueError: If the group count or source dataset is invalid.
+            RuntimeError: If durable reservations are unavailable.
+        """
+        self._require_durable_reservations()
+
+        with self._reservation_lock:
+            if not isinstance(num_groups, int) or isinstance(num_groups, bool) or num_groups < 0:
+                raise ValueError(f"num_groups must be a nonnegative integer, got {num_groups!r}.")
+            if num_groups == 0:
+                return []
+            if self.dataset is not None and len(self.dataset) == 0:
+                raise ValueError("Cannot reserve samples from an empty rollout dataset.")
+
+            replay_count = min(num_groups, len(self._replay_reservations))
+            replay_records = self._replay_reservations[:replay_count]
+            new_count = num_groups - replay_count
+            new_records = [
+                _SourceReservationRecord(group_index=group_index)
+                for group_index in range(self.sample_group_index, self.sample_group_index + new_count)
+            ]
+            records = [*replay_records, *new_records]
+            reservations = [self._materialize_reservation(record) for record in records]
+
+            del self._replay_reservations[:replay_count]
+            for record, reservation in zip(records, reservations, strict=True):
+                self._outstanding_reservations[reservation.reservation_id] = _OutstandingReservation(
+                    record=record,
+                    attempt=reservation,
+                )
+            self._advance_source_frontier(new_records)
+            if reservations:
+                self._durable_reservations_started = True
+            return reservations
+
+    def acknowledge_reservations(self, reservations: Sequence[SourceReservation], *, rollout_id: int) -> None:
+        """Acknowledge exact attempts after a training handoff succeeds.
+
+        Args:
+            reservations: Exact outstanding reservation attempts.
+            rollout_id: Training rollout that accepted every parent group.
+
+        Raises:
+            ValueError: If the batch has duplicates or the rollout is invalid.
+            RuntimeError: If any attempt is not currently outstanding.
+        """
+        self._require_durable_reservations()
+        self._validate_rollout_id(rollout_id)
+        with self._reservation_lock:
+            outstanding = self._get_outstanding_reservations_locked(reservations)
+            for owned in outstanding:
+                reservation_id = owned.attempt.reservation_id
+                del self._outstanding_reservations[reservation_id]
+
+    def requeue_reservations(self, reservations: Sequence[SourceReservation]) -> None:
+        """Return exact outstanding attempts for pristine replay.
+
+        Args:
+            reservations: Exact attempts to reconstruct from source state.
+
+        Raises:
+            ValueError: If the batch contains duplicate identities.
+            RuntimeError: If any attempt is not currently outstanding.
+        """
+        self._require_durable_reservations()
+        with self._reservation_lock:
+            outstanding = self._get_outstanding_reservations_locked(reservations)
+            for owned in outstanding:
+                del self._outstanding_reservations[owned.attempt.reservation_id]
+                self._replay_reservations.append(owned.record)
+            self._replay_reservations.sort(key=lambda record: record.group_index)
+
+    def _get_outstanding_reservations_locked(
+        self, reservations: Sequence[SourceReservation]
+    ) -> list[_OutstandingReservation]:
+        attempts = list(reservations)
+        reservation_ids = [attempt.reservation_id for attempt in attempts]
+        if len(reservation_ids) != len(set(reservation_ids)):
+            raise ValueError(f"Reservation settlement contains duplicate identities: {reservation_ids}.")
+
+        invalid = []
+        outstanding = []
+        for attempt in attempts:
+            owned = self._outstanding_reservations.get(attempt.reservation_id)
+            if owned is None or owned.attempt is not attempt:
+                invalid.append(attempt.reservation_id)
+            else:
+                outstanding.append(owned)
+        if invalid:
+            raise RuntimeError(f"Source reservations are not the current outstanding attempts: {invalid}.")
+        return outstanding
+
+    def _require_durable_reservations(self) -> None:
+        if not self.args.rollout_global_dataset:
+            raise RuntimeError(
+                f"{self.__class__.__name__} does not support durable source reservations when rollout_global_dataset is disabled."
+            )
+
+    @staticmethod
+    def _validate_rollout_id(rollout_id: int) -> None:
+        if not isinstance(rollout_id, int) or isinstance(rollout_id, bool) or rollout_id < 0:
+            raise ValueError(f"rollout_id must be a nonnegative integer, got {rollout_id!r}.")
+
+    def _advance_source_frontier(self, records: list[_SourceReservationRecord]) -> None:
+        if not records:
+            return
+
+        self.sample_group_index += len(records)
+        self.sample_index = self.sample_group_index * self.args.n_samples_per_prompt
+        if self.dataset is not None:
+            epoch_id, epoch_offset = divmod(records[-1].group_index, len(self.dataset))
+            self.epoch_id = epoch_id
+            self.sample_offset = epoch_offset + 1
+            if self.args.rollout_shuffle:
+                self._set_dataset_epoch(epoch_id)
+
+    def _materialize_reservation(self, record: _SourceReservationRecord) -> SourceReservation:
+        assert self.dataset is not None
+        epoch_id, epoch_offset = divmod(record.group_index, len(self.dataset))
+        dataset_index = self._expected_dataset_index(epoch_id=epoch_id, epoch_offset=epoch_offset)
+        prompt_sample = self.dataset.origin_samples[dataset_index]
+        first_sample_index = record.group_index * self.args.n_samples_per_prompt
         samples = []
-        for prompt_sample in prompt_samples:
-            group = []
-            for _ in range(self.args.n_samples_per_prompt):
-                sample = copy.deepcopy(prompt_sample)
-                sample.group_index = self.sample_group_index
-                sample.index = self.sample_index
-                self.sample_index += 1
-                group.append(sample)
-            self.sample_group_index += 1
-            samples.append(group)
-        return samples
+        for sample_index in range(first_sample_index, first_sample_index + self.args.n_samples_per_prompt):
+            sample = copy.deepcopy(prompt_sample)
+            sample.group_index = record.group_index
+            sample.index = sample_index
+            samples.append(sample)
+        return SourceReservation(
+            reservation_id=SourceReservationId(str(record.group_index)),
+            samples=tuple(samples),
+        )
+
+    def _expected_dataset_index(self, *, epoch_id: int, epoch_offset: int) -> int:
+        if not self.args.rollout_shuffle:
+            return epoch_offset
+        return self._dataset_permutation(epoch_id)[epoch_offset]
+
+    def _dataset_permutation(self, epoch_id: int) -> tuple[int, ...]:
+        assert self.dataset is not None
+        if self._permutation_epoch_id == epoch_id:
+            return self._permutation
+
+        permutation = list(range(len(self.dataset)))
+        random.Random(self.args.rollout_seed + epoch_id).shuffle(permutation)
+        self._permutation_epoch_id = epoch_id
+        self._permutation = tuple(permutation)
+        return self._permutation
+
+    def _set_dataset_epoch(self, epoch_id: int) -> None:
+        assert self.dataset is not None
+        permutation = self._dataset_permutation(epoch_id)
+        self.dataset.samples = [self.dataset.origin_samples[index] for index in permutation]
+        self.dataset.epoch_id = epoch_id
+
+    def get_samples(self, num_samples):
+        with self._reservation_lock:
+            if self._durable_reservations_started:
+                raise RuntimeError("Cannot use get_samples after durable source reservations have started.")
+            # TODO further improve code
+            if self.dataset is not None:
+                if self.sample_offset + num_samples <= len(self.dataset):
+                    prompt_samples = self.dataset.samples[self.sample_offset : self.sample_offset + num_samples]
+                    self.sample_offset += num_samples
+                else:
+                    prompt_samples = self.dataset.samples[self.sample_offset :]
+                    num_samples -= len(prompt_samples)
+                    self.epoch_id += 1
+                    if self.args.rollout_shuffle:
+                        self._set_dataset_epoch(self.epoch_id)
+                    prompt_samples += self.dataset.samples[:num_samples]
+                    self.sample_offset = num_samples
+            else:
+                prompt_samples = [Sample() for _ in range(num_samples)]
+
+            samples = []
+            for prompt_sample in prompt_samples:
+                group = []
+                for _ in range(self.args.n_samples_per_prompt):
+                    sample = copy.deepcopy(prompt_sample)
+                    sample.group_index = self.sample_group_index
+                    sample.index = self.sample_index
+                    self.sample_index += 1
+                    group.append(sample)
+                self.sample_group_index += 1
+                samples.append(group)
+            return samples
 
     def add_samples(self, samples: list[list[Sample]]):
         raise RuntimeError(f"Cannot add samples to {self.__class__.__name__}. This is a read-only data source.")
@@ -125,16 +379,23 @@ class RolloutDataSource(DataSource):
         if not self.args.rollout_global_dataset:
             return
 
-        state_dict = {
-            "sample_offset": self.sample_offset,
-            "epoch_id": self.epoch_id,
-            "sample_group_index": self.sample_group_index,
-            "sample_index": self.sample_index,
-            "metadata": self.metadata,
-        }
-        path = os.path.join(self.args.save, f"rollout/global_dataset_state_dict_{rollout_id}.pt")
-        os.makedirs(os.path.dirname(path), exist_ok=True)
-        torch.save(state_dict, path)
+        with self._reservation_lock:
+            if self._durable_reservations_started:
+                raise RuntimeError(
+                    "Cannot save source state after durable source reservations have started "
+                    "until reservation checkpointing is available."
+                )
+            state_dict = {
+                "sample_offset": self.sample_offset,
+                "epoch_id": self.epoch_id,
+                "sample_group_index": self.sample_group_index,
+                "sample_index": self.sample_index,
+                "metadata": self.metadata,
+            }
+            path = os.path.join(self.args.save, f"rollout/global_dataset_state_dict_{rollout_id}.pt")
+            directory = os.path.dirname(path)
+            os.makedirs(directory, exist_ok=True)
+            torch.save(state_dict, path)
 
     def load(self, rollout_id=None):
         if not self.args.rollout_global_dataset:
@@ -148,20 +409,26 @@ class RolloutDataSource(DataSource):
             logger.info(f"Checkpoint {path} does not exist.")
             return
 
-        logger.info(f"load metadata from {path}")
-        logger.info(f"load metadata: {self.metadata}")
-        state_dict = torch.load(path)
-        self.sample_offset = state_dict.get("sample_offset", 0)
-        self.epoch_id = state_dict.get("epoch_id", 0)
-        self.sample_group_index = state_dict.get("sample_group_index", 0)
-        self.sample_index = state_dict.get("sample_index", 0)
-        self.metadata = state_dict.get("metadata", {})
+        with self._reservation_lock:
+            if self._durable_reservations_started:
+                raise RuntimeError("Cannot load source state after durable source reservations have started.")
+            logger.info(f"load metadata from {path}")
+            logger.info(f"load metadata: {self.metadata}")
+            state_dict = torch.load(path)
+            self.sample_offset = state_dict.get("sample_offset", 0)
+            self.epoch_id = state_dict.get("epoch_id", 0)
+            self.sample_group_index = state_dict.get("sample_group_index", 0)
+            self.sample_index = state_dict.get("sample_index", 0)
+            self.metadata = state_dict.get("metadata", {})
 
-        if self.args.rollout_global_dataset and self.args.rollout_shuffle:
-            self.dataset.shuffle(self.epoch_id)
+            if self.args.rollout_shuffle:
+                self._set_dataset_epoch(self.epoch_id)
 
 
 class RolloutDataSourceWithBuffer(RolloutDataSource):
+    # The retry buffer replays groups itself, so durable reservations stay off.
+    supports_source_reservations = False
+
     def __init__(self, args):
         super().__init__(args)
         self.buffer = []
@@ -169,6 +436,21 @@ class RolloutDataSourceWithBuffer(RolloutDataSource):
             self.buffer_filter = pop_first
         else:
             self.buffer_filter = load_function(self.args.buffer_filter_path)
+
+    def reserve_samples(self, num_groups: int) -> list[SourceReservation]:
+        raise RuntimeError(
+            f"{self.__class__.__name__} does not support durable source reservations because they would bypass its retry buffer."
+        )
+
+    def acknowledge_reservations(self, reservations: Sequence[SourceReservation], *, rollout_id: int) -> None:
+        raise RuntimeError(
+            f"{self.__class__.__name__} does not support durable source reservations because they would bypass its retry buffer."
+        )
+
+    def requeue_reservations(self, reservations: Sequence[SourceReservation]) -> None:
+        raise RuntimeError(
+            f"{self.__class__.__name__} does not support durable source reservations because they would bypass its retry buffer."
+        )
 
     def get_samples(self, num_samples: int) -> list[list[Sample]]:
         """

--- a/miles/rollout/data_source.py
+++ b/miles/rollout/data_source.py
@@ -2,7 +2,11 @@ import abc
 import copy
 import logging
 import os
+import random
+import threading
+from collections.abc import Sequence
 from pathlib import Path
+from typing import NamedTuple, NewType
 
 import torch
 
@@ -12,6 +16,29 @@ from miles.utils.processing_utils import load_processor, load_tokenizer
 from miles.utils.types import Sample
 
 logger = logging.getLogger(__name__)
+
+SourceReservationId = NewType("SourceReservationId", str)
+
+
+class SourceReservation(NamedTuple):
+    """One source-owned prompt group attempt.
+
+    Attributes:
+        reservation_id: Stable logical identity across replay attempts.
+        samples: Pristine samples for this attempt.
+    """
+
+    reservation_id: SourceReservationId
+    samples: tuple[Sample, ...]
+
+
+class _SourceReservationRecord(NamedTuple):
+    group_index: int
+
+
+class _OutstandingReservation(NamedTuple):
+    record: _SourceReservationRecord
+    attempt: SourceReservation
 
 
 class DataSource(abc.ABC):
@@ -43,6 +70,53 @@ class DataSource(abc.ABC):
         """Pending-sample backlog, or None for sources without a buffer."""
         return None
 
+    def reserve_samples(self, num_groups: int) -> list[SourceReservation]:
+        """Reserve pristine prompt groups for ownership-aware rollout.
+
+        Args:
+            num_groups: Number of prompt groups to reserve.
+
+        Returns:
+            Reservations that require explicit settlement.
+
+        Implementations must return exactly ``num_groups`` reservations with
+        unique identities. If this method raises, it must not transfer source
+        ownership.
+
+        Raises:
+            RuntimeError: If this data source does not support reservations.
+        """
+        raise RuntimeError(f"{self.__class__.__name__} does not support durable source reservations.")
+
+    def acknowledge_reservations(self, reservations: Sequence[SourceReservation], *, rollout_id: int) -> None:
+        """Record successful handoff of exact source reservation attempts.
+
+        Args:
+            reservations: Exact attempts to acknowledge.
+            rollout_id: Training rollout that accepted the groups.
+
+        Implementations must validate the complete batch before mutation. If
+        this method raises, every input reservation must remain outstanding.
+
+        Raises:
+            RuntimeError: If this data source does not support reservations.
+        """
+        raise RuntimeError(f"{self.__class__.__name__} does not support durable source reservations.")
+
+    def requeue_reservations(self, reservations: Sequence[SourceReservation]) -> None:
+        """Return exact source reservation attempts for pristine replay.
+
+        Args:
+            reservations: Exact attempts to requeue.
+
+        Implementations must validate the complete batch before mutation. If
+        this method raises, every input reservation must remain outstanding.
+
+        Raises:
+            RuntimeError: If this data source does not support reservations.
+        """
+        raise RuntimeError(f"{self.__class__.__name__} does not support durable source reservations.")
+
 
 # TODO may further refactor data-loading part later
 class RolloutDataSource(DataSource):
@@ -55,6 +129,12 @@ class RolloutDataSource(DataSource):
         self.sample_offset = 0
         # TODO remove this
         self.metadata = {}
+        self._reservation_lock = threading.RLock()
+        self._outstanding_reservations: dict[SourceReservationId, _OutstandingReservation] = {}
+        self._replay_reservations: list[_SourceReservationRecord] = []
+        self._durable_reservations_started = False
+        self._permutation_epoch_id: int | None = None
+        self._permutation: tuple[int, ...] = ()
 
         if args.rollout_global_dataset:
             tokenizer = load_tokenizer(
@@ -84,39 +164,206 @@ class RolloutDataSource(DataSource):
                 seed=args.rollout_seed,
             )
             if self.args.rollout_shuffle:
-                self.dataset.shuffle(self.epoch_id)
+                self._set_dataset_epoch(self.epoch_id)
         else:
             self.dataset = None
 
-    def get_samples(self, num_samples):
-        # TODO further improve code
-        if self.dataset is not None:
-            if self.sample_offset + num_samples <= len(self.dataset):
-                prompt_samples = self.dataset.samples[self.sample_offset : self.sample_offset + num_samples]
-                self.sample_offset += num_samples
-            else:
-                prompt_samples = self.dataset.samples[self.sample_offset :]
-                num_samples -= len(prompt_samples)
-                self.epoch_id += 1
-                if self.args.rollout_shuffle:
-                    self.dataset.shuffle(self.epoch_id)
-                prompt_samples += self.dataset.samples[:num_samples]
-                self.sample_offset = num_samples
-        else:
-            prompt_samples = [Sample() for _ in range(num_samples)]
+    def reserve_samples(self, num_groups: int) -> list[SourceReservation]:
+        """Reserve prompt groups without settling source ownership.
 
+        Args:
+            num_groups: Number of groups to reserve.
+
+        Returns:
+            Replay attempts first, then newly admitted source groups.
+
+        Raises:
+            ValueError: If the group count or source dataset is invalid.
+            RuntimeError: If durable reservations are unavailable.
+        """
+        self._require_durable_reservations()
+
+        with self._reservation_lock:
+            if not isinstance(num_groups, int) or isinstance(num_groups, bool) or num_groups < 0:
+                raise ValueError(f"num_groups must be a nonnegative integer, got {num_groups!r}.")
+            if num_groups == 0:
+                return []
+            if self.dataset is not None and len(self.dataset) == 0:
+                raise ValueError("Cannot reserve samples from an empty rollout dataset.")
+
+            replay_count = min(num_groups, len(self._replay_reservations))
+            replay_records = self._replay_reservations[:replay_count]
+            new_count = num_groups - replay_count
+            new_records = [
+                _SourceReservationRecord(group_index=group_index)
+                for group_index in range(self.sample_group_index, self.sample_group_index + new_count)
+            ]
+            records = [*replay_records, *new_records]
+            reservations = [self._materialize_reservation(record) for record in records]
+
+            del self._replay_reservations[:replay_count]
+            for record, reservation in zip(records, reservations, strict=True):
+                self._outstanding_reservations[reservation.reservation_id] = _OutstandingReservation(
+                    record=record,
+                    attempt=reservation,
+                )
+            self._advance_source_frontier(new_records)
+            if reservations:
+                self._durable_reservations_started = True
+            return reservations
+
+    def acknowledge_reservations(self, reservations: Sequence[SourceReservation], *, rollout_id: int) -> None:
+        """Acknowledge exact attempts after a training handoff succeeds.
+
+        Args:
+            reservations: Exact outstanding reservation attempts.
+            rollout_id: Training rollout that accepted every parent group.
+
+        Raises:
+            ValueError: If the batch has duplicates or the rollout is invalid.
+            RuntimeError: If any attempt is not currently outstanding.
+        """
+        self._require_durable_reservations()
+        self._validate_rollout_id(rollout_id)
+        with self._reservation_lock:
+            outstanding = self._get_outstanding_reservations_locked(reservations)
+            for owned in outstanding:
+                reservation_id = owned.attempt.reservation_id
+                del self._outstanding_reservations[reservation_id]
+
+    def requeue_reservations(self, reservations: Sequence[SourceReservation]) -> None:
+        """Return exact outstanding attempts for pristine replay.
+
+        Args:
+            reservations: Exact attempts to reconstruct from source state.
+
+        Raises:
+            ValueError: If the batch contains duplicate identities.
+            RuntimeError: If any attempt is not currently outstanding.
+        """
+        self._require_durable_reservations()
+        with self._reservation_lock:
+            outstanding = self._get_outstanding_reservations_locked(reservations)
+            for owned in outstanding:
+                del self._outstanding_reservations[owned.attempt.reservation_id]
+                self._replay_reservations.append(owned.record)
+            self._replay_reservations.sort(key=lambda record: record.group_index)
+
+    def _get_outstanding_reservations_locked(
+        self, reservations: Sequence[SourceReservation]
+    ) -> list[_OutstandingReservation]:
+        attempts = list(reservations)
+        reservation_ids = [attempt.reservation_id for attempt in attempts]
+        if len(reservation_ids) != len(set(reservation_ids)):
+            raise ValueError(f"Reservation settlement contains duplicate identities: {reservation_ids}.")
+
+        invalid = []
+        outstanding = []
+        for attempt in attempts:
+            owned = self._outstanding_reservations.get(attempt.reservation_id)
+            if owned is None or owned.attempt is not attempt:
+                invalid.append(attempt.reservation_id)
+            else:
+                outstanding.append(owned)
+        if invalid:
+            raise RuntimeError(f"Source reservations are not the current outstanding attempts: {invalid}.")
+        return outstanding
+
+    def _require_durable_reservations(self) -> None:
+        if not self.args.rollout_global_dataset:
+            raise RuntimeError(
+                f"{self.__class__.__name__} does not support durable source reservations when rollout_global_dataset is disabled."
+            )
+
+    @staticmethod
+    def _validate_rollout_id(rollout_id: int) -> None:
+        if not isinstance(rollout_id, int) or isinstance(rollout_id, bool) or rollout_id < 0:
+            raise ValueError(f"rollout_id must be a nonnegative integer, got {rollout_id!r}.")
+
+    def _advance_source_frontier(self, records: list[_SourceReservationRecord]) -> None:
+        if not records:
+            return
+
+        self.sample_group_index += len(records)
+        self.sample_index = self.sample_group_index * self.args.n_samples_per_prompt
+        if self.dataset is not None:
+            epoch_id, epoch_offset = divmod(records[-1].group_index, len(self.dataset))
+            self.epoch_id = epoch_id
+            self.sample_offset = epoch_offset + 1
+            if self.args.rollout_shuffle:
+                self._set_dataset_epoch(epoch_id)
+
+    def _materialize_reservation(self, record: _SourceReservationRecord) -> SourceReservation:
+        assert self.dataset is not None
+        epoch_id, epoch_offset = divmod(record.group_index, len(self.dataset))
+        dataset_index = self._expected_dataset_index(epoch_id=epoch_id, epoch_offset=epoch_offset)
+        prompt_sample = self.dataset.origin_samples[dataset_index]
+        first_sample_index = record.group_index * self.args.n_samples_per_prompt
         samples = []
-        for prompt_sample in prompt_samples:
-            group = []
-            for _ in range(self.args.n_samples_per_prompt):
-                sample = copy.deepcopy(prompt_sample)
-                sample.group_index = self.sample_group_index
-                sample.index = self.sample_index
-                self.sample_index += 1
-                group.append(sample)
-            self.sample_group_index += 1
-            samples.append(group)
-        return samples
+        for sample_index in range(first_sample_index, first_sample_index + self.args.n_samples_per_prompt):
+            sample = copy.deepcopy(prompt_sample)
+            sample.group_index = record.group_index
+            sample.index = sample_index
+            samples.append(sample)
+        return SourceReservation(
+            reservation_id=SourceReservationId(str(record.group_index)),
+            samples=tuple(samples),
+        )
+
+    def _expected_dataset_index(self, *, epoch_id: int, epoch_offset: int) -> int:
+        if not self.args.rollout_shuffle:
+            return epoch_offset
+        return self._dataset_permutation(epoch_id)[epoch_offset]
+
+    def _dataset_permutation(self, epoch_id: int) -> tuple[int, ...]:
+        assert self.dataset is not None
+        if self._permutation_epoch_id == epoch_id:
+            return self._permutation
+
+        permutation = list(range(len(self.dataset)))
+        random.Random(self.args.rollout_seed + epoch_id).shuffle(permutation)
+        self._permutation_epoch_id = epoch_id
+        self._permutation = tuple(permutation)
+        return self._permutation
+
+    def _set_dataset_epoch(self, epoch_id: int) -> None:
+        assert self.dataset is not None
+        permutation = self._dataset_permutation(epoch_id)
+        self.dataset.samples = [self.dataset.origin_samples[index] for index in permutation]
+        self.dataset.epoch_id = epoch_id
+
+    def get_samples(self, num_samples):
+        with self._reservation_lock:
+            if self._durable_reservations_started:
+                raise RuntimeError("Cannot use get_samples after durable source reservations have started.")
+            # TODO further improve code
+            if self.dataset is not None:
+                if self.sample_offset + num_samples <= len(self.dataset):
+                    prompt_samples = self.dataset.samples[self.sample_offset : self.sample_offset + num_samples]
+                    self.sample_offset += num_samples
+                else:
+                    prompt_samples = self.dataset.samples[self.sample_offset :]
+                    num_samples -= len(prompt_samples)
+                    self.epoch_id += 1
+                    if self.args.rollout_shuffle:
+                        self._set_dataset_epoch(self.epoch_id)
+                    prompt_samples += self.dataset.samples[:num_samples]
+                    self.sample_offset = num_samples
+            else:
+                prompt_samples = [Sample() for _ in range(num_samples)]
+
+            samples = []
+            for prompt_sample in prompt_samples:
+                group = []
+                for _ in range(self.args.n_samples_per_prompt):
+                    sample = copy.deepcopy(prompt_sample)
+                    sample.group_index = self.sample_group_index
+                    sample.index = self.sample_index
+                    self.sample_index += 1
+                    group.append(sample)
+                self.sample_group_index += 1
+                samples.append(group)
+            return samples
 
     def add_samples(self, samples: list[list[Sample]]):
         raise RuntimeError(f"Cannot add samples to {self.__class__.__name__}. This is a read-only data source.")
@@ -125,16 +372,23 @@ class RolloutDataSource(DataSource):
         if not self.args.rollout_global_dataset:
             return
 
-        state_dict = {
-            "sample_offset": self.sample_offset,
-            "epoch_id": self.epoch_id,
-            "sample_group_index": self.sample_group_index,
-            "sample_index": self.sample_index,
-            "metadata": self.metadata,
-        }
-        path = os.path.join(self.args.save, f"rollout/global_dataset_state_dict_{rollout_id}.pt")
-        os.makedirs(os.path.dirname(path), exist_ok=True)
-        torch.save(state_dict, path)
+        with self._reservation_lock:
+            if self._durable_reservations_started:
+                raise RuntimeError(
+                    "Cannot save source state after durable source reservations have started "
+                    "until reservation checkpointing is available."
+                )
+            state_dict = {
+                "sample_offset": self.sample_offset,
+                "epoch_id": self.epoch_id,
+                "sample_group_index": self.sample_group_index,
+                "sample_index": self.sample_index,
+                "metadata": self.metadata,
+            }
+            path = os.path.join(self.args.save, f"rollout/global_dataset_state_dict_{rollout_id}.pt")
+            directory = os.path.dirname(path)
+            os.makedirs(directory, exist_ok=True)
+            torch.save(state_dict, path)
 
     def load(self, rollout_id=None):
         if not self.args.rollout_global_dataset:
@@ -148,17 +402,20 @@ class RolloutDataSource(DataSource):
             logger.info(f"Checkpoint {path} does not exist.")
             return
 
-        logger.info(f"load metadata from {path}")
-        logger.info(f"load metadata: {self.metadata}")
-        state_dict = torch.load(path)
-        self.sample_offset = state_dict.get("sample_offset", 0)
-        self.epoch_id = state_dict.get("epoch_id", 0)
-        self.sample_group_index = state_dict.get("sample_group_index", 0)
-        self.sample_index = state_dict.get("sample_index", 0)
-        self.metadata = state_dict.get("metadata", {})
+        with self._reservation_lock:
+            if self._durable_reservations_started:
+                raise RuntimeError("Cannot load source state after durable source reservations have started.")
+            logger.info(f"load metadata from {path}")
+            logger.info(f"load metadata: {self.metadata}")
+            state_dict = torch.load(path)
+            self.sample_offset = state_dict.get("sample_offset", 0)
+            self.epoch_id = state_dict.get("epoch_id", 0)
+            self.sample_group_index = state_dict.get("sample_group_index", 0)
+            self.sample_index = state_dict.get("sample_index", 0)
+            self.metadata = state_dict.get("metadata", {})
 
-        if self.args.rollout_global_dataset and self.args.rollout_shuffle:
-            self.dataset.shuffle(self.epoch_id)
+            if self.args.rollout_shuffle:
+                self._set_dataset_epoch(self.epoch_id)
 
 
 class RolloutDataSourceWithBuffer(RolloutDataSource):
@@ -169,6 +426,21 @@ class RolloutDataSourceWithBuffer(RolloutDataSource):
             self.buffer_filter = pop_first
         else:
             self.buffer_filter = load_function(self.args.buffer_filter_path)
+
+    def reserve_samples(self, num_groups: int) -> list[SourceReservation]:
+        raise RuntimeError(
+            f"{self.__class__.__name__} does not support durable source reservations because they would bypass its retry buffer."
+        )
+
+    def acknowledge_reservations(self, reservations: Sequence[SourceReservation], *, rollout_id: int) -> None:
+        raise RuntimeError(
+            f"{self.__class__.__name__} does not support durable source reservations because they would bypass its retry buffer."
+        )
+
+    def requeue_reservations(self, reservations: Sequence[SourceReservation]) -> None:
+        raise RuntimeError(
+            f"{self.__class__.__name__} does not support durable source reservations because they would bypass its retry buffer."
+        )
 
     def get_samples(self, num_samples: int) -> list[list[Sample]]:
         """

--- a/miles/rollout/data_source.py
+++ b/miles/rollout/data_source.py
@@ -1,18 +1,23 @@
 import abc
 import copy
+import hashlib
 import logging
 import os
 import random
+import tempfile
 import threading
 from collections.abc import Sequence
 from pathlib import Path
-from typing import NamedTuple, NewType
+from typing import Annotated, Literal, NamedTuple, NewType
 
 import torch
+from pydantic import Field
 
 from miles.utils.data import Dataset
 from miles.utils.misc import load_function
 from miles.utils.processing_utils import load_processor, load_tokenizer
+from miles.utils.pydantic_utils import FrozenStrictBaseModel
+from miles.utils.source_fingerprint import canonical_source_digest
 from miles.utils.types import Sample
 
 logger = logging.getLogger(__name__)
@@ -32,13 +37,34 @@ class SourceReservation(NamedTuple):
     samples: tuple[Sample, ...]
 
 
-class _SourceReservationRecord(NamedTuple):
-    group_index: int
+class _SourceReservationRecord(FrozenStrictBaseModel):
+    group_index: Annotated[int, Field(strict=True, ge=0)]
+
+
+class _SourceCompatibility(FrozenStrictBaseModel):
+    materialization_schema_version: Literal[1]
+    materialized_samples_sha256: Annotated[str, Field(strict=True, pattern=r"^[0-9a-f]{64}$")]
+    dataset_size: Annotated[int, Field(strict=True, ge=0)]
+    rollout_shuffle: Annotated[bool, Field(strict=True)]
+    shuffle_seed: Annotated[int, Field(strict=True)] | None
+    shuffle_schema_version: Literal[1]
+    n_samples_per_prompt: Annotated[int, Field(strict=True, ge=1)]
+
+
+class _SourceReservationCheckpoint(FrozenStrictBaseModel):
+    schema_version: Literal[1]
+    source_compatibility: _SourceCompatibility
+    replay: tuple[_SourceReservationRecord, ...]
 
 
 class _OutstandingReservation(NamedTuple):
     record: _SourceReservationRecord
     attempt: SourceReservation
+
+
+class _AcknowledgedReservation(NamedTuple):
+    record: _SourceReservationRecord
+    rollout_id: int
 
 
 class DataSource(abc.ABC):
@@ -131,10 +157,15 @@ class RolloutDataSource(DataSource):
         self.metadata = {}
         self._reservation_lock = threading.RLock()
         self._outstanding_reservations: dict[SourceReservationId, _OutstandingReservation] = {}
+        self._acknowledged_reservations: dict[SourceReservationId, _AcknowledgedReservation] = {}
         self._replay_reservations: list[_SourceReservationRecord] = []
+        self._last_saved_rollout_id: int | None = None
+        self._reservation_checkpoints_enabled = self.args.save_interval is not None
         self._durable_reservations_started = False
         self._permutation_epoch_id: int | None = None
         self._permutation: tuple[int, ...] = ()
+        self._source_compatibility: _SourceCompatibility | None = None
+        self.dataset: Dataset | None
 
         if args.rollout_global_dataset:
             tokenizer = load_tokenizer(
@@ -190,6 +221,7 @@ class RolloutDataSource(DataSource):
                 return []
             if self.dataset is not None and len(self.dataset) == 0:
                 raise ValueError("Cannot reserve samples from an empty rollout dataset.")
+            self._get_source_compatibility()
 
             replay_count = min(num_groups, len(self._replay_reservations))
             replay_records = self._replay_reservations[:replay_count]
@@ -226,10 +258,19 @@ class RolloutDataSource(DataSource):
         self._require_durable_reservations()
         self._validate_rollout_id(rollout_id)
         with self._reservation_lock:
+            if self._last_saved_rollout_id is not None and rollout_id <= self._last_saved_rollout_id:
+                raise ValueError(
+                    f"Reservation rollout_id {rollout_id} must be newer than published checkpoint {self._last_saved_rollout_id}."
+                )
             outstanding = self._get_outstanding_reservations_locked(reservations)
             for owned in outstanding:
                 reservation_id = owned.attempt.reservation_id
                 del self._outstanding_reservations[reservation_id]
+                if self._reservation_checkpoints_enabled:
+                    self._acknowledged_reservations[reservation_id] = _AcknowledgedReservation(
+                        record=owned.record,
+                        rollout_id=rollout_id,
+                    )
 
     def requeue_reservations(self, reservations: Sequence[SourceReservation]) -> None:
         """Return exact outstanding attempts for pristine replay.
@@ -273,6 +314,10 @@ class RolloutDataSource(DataSource):
         if not self.args.rollout_global_dataset:
             raise RuntimeError(
                 f"{self.__class__.__name__} does not support durable source reservations when rollout_global_dataset is disabled."
+            )
+        if not self._reservation_checkpoints_enabled and self.args.save_trigger_sentinel is not None:
+            raise RuntimeError(
+                "Durable source reservations require a periodic save interval when a save trigger is configured."
             )
 
     @staticmethod
@@ -332,6 +377,34 @@ class RolloutDataSource(DataSource):
         self.dataset.samples = [self.dataset.origin_samples[index] for index in permutation]
         self.dataset.epoch_id = epoch_id
 
+    def _build_source_compatibility(self) -> _SourceCompatibility | None:
+        if self.dataset is None:
+            return None
+        return _SourceCompatibility(
+            materialization_schema_version=1,
+            materialized_samples_sha256=self._processed_samples_sha256(),
+            dataset_size=len(self.dataset),
+            rollout_shuffle=self.args.rollout_shuffle,
+            shuffle_seed=self.args.rollout_seed if self.args.rollout_shuffle else None,
+            shuffle_schema_version=1,
+            n_samples_per_prompt=self.args.n_samples_per_prompt,
+        )
+
+    def _get_source_compatibility(self) -> _SourceCompatibility:
+        if self._source_compatibility is None:
+            source_compatibility = self._build_source_compatibility()
+            if source_compatibility is None:
+                raise RuntimeError("Durable source reservations require rollout_global_dataset.")
+            self._source_compatibility = source_compatibility
+        return self._source_compatibility
+
+    def _processed_samples_sha256(self) -> str:
+        assert self.dataset is not None
+        digest = hashlib.sha256()
+        for sample in self.dataset.origin_samples:
+            digest.update(canonical_source_digest(sample.to_dict()))
+        return digest.hexdigest()
+
     def get_samples(self, num_samples):
         with self._reservation_lock:
             if self._durable_reservations_started:
@@ -372,12 +445,8 @@ class RolloutDataSource(DataSource):
         if not self.args.rollout_global_dataset:
             return
 
+        self._validate_rollout_id(rollout_id)
         with self._reservation_lock:
-            if self._durable_reservations_started:
-                raise RuntimeError(
-                    "Cannot save source state after durable source reservations have started "
-                    "until reservation checkpointing is available."
-                )
             state_dict = {
                 "sample_offset": self.sample_offset,
                 "epoch_id": self.epoch_id,
@@ -388,7 +457,55 @@ class RolloutDataSource(DataSource):
             path = os.path.join(self.args.save, f"rollout/global_dataset_state_dict_{rollout_id}.pt")
             directory = os.path.dirname(path)
             os.makedirs(directory, exist_ok=True)
-            torch.save(state_dict, path)
+            if self._last_saved_rollout_id is not None and rollout_id < self._last_saved_rollout_id:
+                raise ValueError(
+                    f"Source checkpoint rollout_id must not move backward from {self._last_saved_rollout_id} to {rollout_id}."
+                )
+            if not self._durable_reservations_started:
+                torch.save(state_dict, path)
+                self._last_saved_rollout_id = rollout_id
+                return
+
+            if self._durable_reservations_started and not self._reservation_checkpoints_enabled:
+                raise RuntimeError("Cannot save durable source reservations without a configured save trigger.")
+
+            replay = [
+                *self._replay_reservations,
+                *(owned.record for owned in self._outstanding_reservations.values()),
+                *(
+                    acknowledged.record
+                    for acknowledged in self._acknowledged_reservations.values()
+                    if acknowledged.rollout_id > rollout_id
+                ),
+            ]
+            replay.sort(key=lambda record: record.group_index)
+            reservation_ids = [self._reservation_id(record) for record in replay]
+            if len(reservation_ids) != len(set(reservation_ids)):
+                raise RuntimeError(f"Source reservation ownership is duplicated at checkpoint: {reservation_ids}.")
+
+            state_dict["source_reservations"] = _SourceReservationCheckpoint(
+                schema_version=1,
+                source_compatibility=self._get_source_compatibility(),
+                replay=tuple(replay),
+            ).model_dump(mode="python")
+            descriptor, temporary_path = tempfile.mkstemp(
+                dir=directory,
+                prefix=f".{os.path.basename(path)}.",
+                suffix=".tmp",
+            )
+            os.close(descriptor)
+            try:
+                torch.save(state_dict, temporary_path)
+                os.replace(temporary_path, path)
+            finally:
+                Path(temporary_path).unlink(missing_ok=True)
+
+            self._acknowledged_reservations = {
+                reservation_id: acknowledged
+                for reservation_id, acknowledged in self._acknowledged_reservations.items()
+                if acknowledged.rollout_id > rollout_id
+            }
+            self._last_saved_rollout_id = rollout_id
 
     def load(self, rollout_id=None):
         if not self.args.rollout_global_dataset:
@@ -397,6 +514,10 @@ class RolloutDataSource(DataSource):
         if self.args.load is None:
             return
 
+        if isinstance(rollout_id, int) and not isinstance(rollout_id, bool) and rollout_id == -1:
+            return
+        if rollout_id is not None:
+            self._validate_rollout_id(rollout_id)
         path = os.path.join(self.args.load, f"rollout/global_dataset_state_dict_{rollout_id}.pt")
         if not os.path.exists(path):
             logger.info(f"Checkpoint {path} does not exist.")
@@ -406,16 +527,83 @@ class RolloutDataSource(DataSource):
             if self._durable_reservations_started:
                 raise RuntimeError("Cannot load source state after durable source reservations have started.")
             logger.info(f"load metadata from {path}")
-            logger.info(f"load metadata: {self.metadata}")
             state_dict = torch.load(path)
-            self.sample_offset = state_dict.get("sample_offset", 0)
-            self.epoch_id = state_dict.get("epoch_id", 0)
-            self.sample_group_index = state_dict.get("sample_group_index", 0)
-            self.sample_index = state_dict.get("sample_index", 0)
+            if "source_reservations" in state_dict:
+                cursor_fields = ("sample_offset", "epoch_id", "sample_group_index", "sample_index")
+                missing_cursor_fields = [field for field in cursor_fields if field not in state_dict]
+                if missing_cursor_fields:
+                    raise ValueError(f"Checkpoint is missing source cursor fields: {missing_cursor_fields}.")
+            sample_group_index = state_dict.get("sample_group_index", 0)
+            if "source_reservations" in state_dict:
+                reservation_state = _SourceReservationCheckpoint.model_validate(state_dict["source_reservations"])
+                if reservation_state.source_compatibility != self._get_source_compatibility():
+                    raise ValueError(
+                        "Source reservation checkpoint configuration does not match the current data source."
+                    )
+                epoch_id = state_dict.get("epoch_id", 0)
+                sample_offset = state_dict.get("sample_offset", 0)
+                replay = list(reservation_state.replay)
+            else:
+                epoch_id, sample_offset = self._normalize_legacy_cursor(sample_group_index)
+                replay = []
+            sample_index = state_dict.get("sample_index", 0)
+            if "source_reservations" in state_dict:
+                for field, value in (
+                    ("sample_offset", sample_offset),
+                    ("epoch_id", epoch_id),
+                    ("sample_group_index", sample_group_index),
+                    ("sample_index", sample_index),
+                ):
+                    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+                        raise ValueError(f"Checkpoint {field} must be a nonnegative integer, got {value!r}.")
+                assert self.dataset is not None
+                dataset_size = len(self.dataset)
+                if sample_offset > dataset_size:
+                    raise ValueError(f"Checkpoint sample offset {sample_offset} exceeds dataset size {dataset_size}.")
+                if dataset_size == 0:
+                    if epoch_id != 0 or sample_offset != 0 or sample_group_index != 0:
+                        raise ValueError("An empty rollout dataset requires a zero source cursor.")
+                else:
+                    expected_group_frontier = epoch_id * dataset_size + sample_offset
+                    if sample_group_index != expected_group_frontier:
+                        raise ValueError(
+                            f"Checkpoint group frontier {sample_group_index} does not match dataset cursor at epoch {epoch_id} offset {sample_offset} for dataset size {dataset_size}."
+                        )
+                expected_sample_frontier = sample_group_index * self.args.n_samples_per_prompt
+                if sample_index != expected_sample_frontier:
+                    raise ValueError(
+                        f"Checkpoint sample frontier {sample_index} does not match group frontier {sample_group_index} with {self.args.n_samples_per_prompt} samples per prompt."
+                    )
+
+            reservation_ids = [self._reservation_id(record) for record in replay]
+            if len(reservation_ids) != len(set(reservation_ids)):
+                raise ValueError(f"Checkpoint contains duplicate source reservation identities: {reservation_ids}.")
+            if any(record.group_index < 0 or record.group_index >= sample_group_index for record in replay):
+                raise ValueError("Checkpoint contains a source reservation outside the saved group frontier.")
+
+            self.sample_offset = sample_offset
+            self.epoch_id = epoch_id
+            self.sample_group_index = sample_group_index
+            self.sample_index = sample_index
             self.metadata = state_dict.get("metadata", {})
+            self._replay_reservations = sorted(replay, key=lambda record: record.group_index)
+            self._outstanding_reservations = {}
+            self._acknowledged_reservations = {}
+            self._last_saved_rollout_id = rollout_id
+            self._durable_reservations_started = "source_reservations" in state_dict
 
             if self.args.rollout_shuffle:
                 self._set_dataset_epoch(self.epoch_id)
+
+    def _normalize_legacy_cursor(self, sample_group_index: int) -> tuple[int, int]:
+        assert self.dataset is not None
+        if len(self.dataset) == 0:
+            return 0, 0
+        return divmod(sample_group_index, len(self.dataset))
+
+    @staticmethod
+    def _reservation_id(record: _SourceReservationRecord) -> SourceReservationId:
+        return SourceReservationId(str(record.group_index))
 
 
 class RolloutDataSourceWithBuffer(RolloutDataSource):

--- a/miles/rollout/multi_lora/data_source.py
+++ b/miles/rollout/multi_lora/data_source.py
@@ -52,6 +52,7 @@ class MultiLoRAAsyncDataSource(DataSource):
                 logger.info(f"Created data source for adapter '{name}'")
                 # Post-filter dataset length; the controller derives num_step
                 # from num_epoch for adapters that didn't set it.
+                assert source.dataset is not None, "multi-LoRA rollout requires a global dataset"
                 ray.get(get_multi_lora_controller().resolve_num_step.remote(name, len(source.dataset)))
         self.update_queue(set(adapters))
 

--- a/miles/utils/source_fingerprint.py
+++ b/miles/utils/source_fingerprint.py
@@ -1,0 +1,200 @@
+import datetime
+import decimal
+import hashlib
+import os
+import struct
+import uuid
+from collections.abc import Mapping
+from enum import Enum
+from typing import cast
+
+import numpy
+import torch
+from PIL import Image
+
+
+def _digest_parts(tag: bytes, *parts: bytes) -> bytes:
+    digest = hashlib.sha256()
+    digest.update(tag)
+    for part in parts:
+        digest.update(len(part).to_bytes(8, byteorder="big"))
+        digest.update(part)
+    return digest.digest()
+
+
+def _numpy_dtype_digest(dtype: numpy.dtype[numpy.generic]) -> bytes:
+    metadata = canonical_source_digest(dtype.metadata)
+    if dtype.fields is not None:
+        fields = []
+        for name in dtype.names or ():
+            field = dtype.fields[name]
+            field_dtype = field[0]
+            offset = field[1]
+            title = field[2] if len(field) == 3 else None
+            fields.append(
+                _digest_parts(
+                    b"field",
+                    canonical_source_digest(name),
+                    _numpy_dtype_digest(field_dtype),
+                    canonical_source_digest(offset),
+                    canonical_source_digest(title),
+                )
+            )
+        return _digest_parts(
+            b"structured-dtype",
+            canonical_source_digest(dtype.itemsize),
+            canonical_source_digest(dtype.isalignedstruct),
+            metadata,
+            *fields,
+        )
+    if dtype.subdtype is not None:
+        base_dtype, shape = dtype.subdtype
+        return _digest_parts(
+            b"subarray-dtype",
+            _numpy_dtype_digest(base_dtype),
+            canonical_source_digest(shape),
+            metadata,
+        )
+    return _digest_parts(b"dtype", dtype.str.encode(), metadata)
+
+
+def _numpy_has_extended_precision(dtype: numpy.dtype[numpy.generic]) -> bool:
+    return (dtype.kind == "f" and dtype.itemsize > 8) or (dtype.kind == "c" and dtype.itemsize > 16)
+
+
+def _numpy_extended_scalar_digest(value: numpy.generic) -> bytes:
+    if value.dtype.kind == "f":
+        formatted = numpy.format_float_scientific(cast(float, value), unique=True, trim="k")
+        return _digest_parts(b"extended-float", formatted.encode())
+    if value.dtype.kind == "c":
+        complex_value = cast(complex, value)
+        formatted_real = numpy.format_float_scientific(complex_value.real, unique=True, trim="k")
+        formatted_imag = numpy.format_float_scientific(complex_value.imag, unique=True, trim="k")
+        return _digest_parts(b"extended-complex", formatted_real.encode(), formatted_imag.encode())
+    raise TypeError(f"NumPy dtype {value.dtype} is not an extended floating-point type.")
+
+
+def canonical_source_digest(value: object) -> bytes:
+    """Return a deterministic digest for one logical source value.
+
+    Args:
+        value: A source-owned scalar or nested container. Mapping and set
+            iteration order does not affect the digest.
+
+    Returns:
+        A SHA-256 digest that preserves value types and sequence order.
+
+    Raises:
+        TypeError: If the value has no stable logical representation.
+    """
+    if value is None:
+        return _digest_parts(b"none")
+    if isinstance(value, Enum):
+        enum_type = f"{value.__class__.__module__}.{value.__class__.__qualname__}"
+        return _digest_parts(b"enum", enum_type.encode(), canonical_source_digest(value.value))
+    if isinstance(value, numpy.generic):
+        if value.dtype.hasobject or value.dtype.fields is not None:
+            scalar_value = canonical_source_digest(value.tolist())
+        elif _numpy_has_extended_precision(value.dtype):
+            scalar_value = _numpy_extended_scalar_digest(value)
+        else:
+            scalar_value = value.tobytes()
+        return _digest_parts(b"numpy-scalar", _numpy_dtype_digest(value.dtype), scalar_value)
+    if isinstance(value, bool):
+        return _digest_parts(b"bool", b"1" if value else b"0")
+    if isinstance(value, int):
+        return _digest_parts(b"int", str(value).encode())
+    if isinstance(value, float):
+        return _digest_parts(b"float", struct.pack("!d", value))
+    if isinstance(value, str):
+        return _digest_parts(b"str", value.encode())
+    if isinstance(value, (bytes, bytearray, memoryview)):
+        return _digest_parts(b"bytes", bytes(value))
+    if isinstance(value, decimal.Decimal):
+        return _digest_parts(b"decimal", str(value).encode())
+    if isinstance(value, datetime.datetime):
+        return _digest_parts(b"datetime", value.isoformat().encode())
+    if isinstance(value, datetime.date):
+        return _digest_parts(b"date", value.isoformat().encode())
+    if isinstance(value, datetime.time):
+        return _digest_parts(b"time", value.isoformat().encode())
+    if isinstance(value, datetime.timedelta):
+        nanoseconds = getattr(value, "nanoseconds", 0)
+        return _digest_parts(
+            b"timedelta",
+            canonical_source_digest(value.days),
+            canonical_source_digest(value.seconds),
+            canonical_source_digest(value.microseconds),
+            canonical_source_digest(nanoseconds),
+        )
+    if isinstance(value, uuid.UUID):
+        return _digest_parts(b"uuid", value.bytes)
+    if isinstance(value, os.PathLike):
+        return _digest_parts(b"path", os.fsencode(value))
+    if isinstance(value, torch.Tensor):
+        if value.layout != torch.strided:
+            raise TypeError(f"Cannot fingerprint tensor with layout {value.layout}.")
+        if value.is_quantized:
+            raise TypeError("Cannot fingerprint quantized tensors.")
+        tensor = value.detach().resolve_conj().resolve_neg().cpu().contiguous()
+        tensor_bytes = tensor.reshape(-1).view(torch.uint8).numpy().tobytes()
+        return _digest_parts(
+            b"tensor",
+            str(tensor.dtype).encode(),
+            canonical_source_digest(tuple(tensor.shape)),
+            tensor_bytes,
+        )
+    if isinstance(value, numpy.ma.MaskedArray):
+        return _digest_parts(
+            b"masked-array",
+            _numpy_dtype_digest(value.dtype),
+            canonical_source_digest(value.shape),
+            canonical_source_digest(value.data),
+            canonical_source_digest(numpy.ma.getmaskarray(value)),
+            canonical_source_digest(value.fill_value),
+        )
+    if isinstance(value, numpy.ndarray):
+        if value.dtype.hasobject or value.dtype.fields is not None or _numpy_has_extended_precision(value.dtype):
+            array_bytes = canonical_source_digest(value.tolist())
+        else:
+            array_bytes = numpy.ascontiguousarray(value).tobytes()
+        return _digest_parts(
+            b"ndarray",
+            _numpy_dtype_digest(value.dtype),
+            canonical_source_digest(value.shape),
+            array_bytes,
+        )
+    if isinstance(value, Image.Image):
+        return _digest_parts(
+            b"image",
+            value.mode.encode(),
+            canonical_source_digest(value.size),
+            canonical_source_digest(value.format),
+            value.tobytes(),
+            canonical_source_digest(value.getpalette()),
+            canonical_source_digest(value.info),
+            value.getexif().tobytes(),
+        )
+    if isinstance(value, Mapping):
+        entries = sorted(
+            _digest_parts(b"entry", canonical_source_digest(key), canonical_source_digest(item))
+            for key, item in value.items()
+        )
+        return _digest_parts(b"mapping", *entries)
+    if isinstance(value, list):
+        return _digest_parts(b"list", *(canonical_source_digest(item) for item in value))
+    if isinstance(value, tuple):
+        return _digest_parts(b"tuple", *(canonical_source_digest(item) for item in value))
+    if isinstance(value, set):
+        return _digest_parts(
+            b"set",
+            *(sorted(canonical_source_digest(item) for item in value)),
+        )
+    if isinstance(value, frozenset):
+        return _digest_parts(
+            b"frozenset",
+            *(sorted(canonical_source_digest(item) for item in value)),
+        )
+    raise TypeError(
+        f"Cannot fingerprint rollout source value of type {value.__class__.__module__}.{value.__class__.__qualname__}."
+    )

--- a/tests/fast/rollout/test_data_source_reservations.py
+++ b/tests/fast/rollout/test_data_source_reservations.py
@@ -1,10 +1,16 @@
 import copy
 import json
+import threading
 from argparse import Namespace
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import cast
 
+import numpy
 import pytest
+import torch
+from PIL import Image
+from pydantic import ValidationError
 
 import miles.rollout.data_source as data_source_module
 from miles.rollout.data_source import (
@@ -13,6 +19,7 @@ from miles.rollout.data_source import (
     SourceReservation,
     SourceReservationId,
 )
+from miles.utils import chat_template_utils
 from miles.utils.types import Sample
 
 
@@ -84,8 +91,8 @@ def test_reservation_keeps_every_parent_slot(tmp_path: Path) -> None:
     source.acknowledge_reservations([reservation], rollout_id=0)
 
 
-@pytest.mark.parametrize("num_groups", [True, -1, 1.5, "1"])
-def test_reserve_rejects_invalid_group_count(tmp_path: Path, num_groups: object) -> None:
+@pytest.mark.parametrize("num_groups", [True, 1.5, "1"])
+def test_reserve_rejects_non_integer_group_count(tmp_path: Path, num_groups: object) -> None:
     source = RolloutDataSource(_source_args(tmp_path))
 
     with pytest.raises(
@@ -170,19 +177,6 @@ def test_requeue_reconstructs_pristine_samples_in_process(tmp_path: Path) -> Non
     assert source.reserve_samples(1) == [_reservation(0, prompt="alpha")]
 
 
-def test_requeue_replays_holes_in_source_order(tmp_path: Path) -> None:
-    source = RolloutDataSource(_source_args(tmp_path))
-    first, second, third, fourth = source.reserve_samples(4)
-    source.acknowledge_reservations([second, fourth], rollout_id=0)
-    source.requeue_reservations([third, first])
-
-    assert source.reserve_samples(3) == [
-        _reservation(0, prompt="alpha"),
-        _reservation(2, prompt="charlie"),
-        _reservation(4, prompt="alpha"),
-    ]
-
-
 def test_legacy_reads_are_rejected_after_durable_ownership_starts(tmp_path: Path) -> None:
     source = RolloutDataSource(_source_args(tmp_path))
     [reservation] = source.reserve_samples(1)
@@ -200,15 +194,560 @@ def test_legacy_reads_are_rejected_after_durable_ownership_starts(tmp_path: Path
     ]
 
 
-def test_shuffled_multi_epoch_replay_reconstructs_exact_groups(tmp_path: Path) -> None:
-    source = RolloutDataSource(_source_args(tmp_path, rollout_shuffle=True))
+def test_restart_replays_unsettled_groups_before_advancing(tmp_path: Path) -> None:
+    args = _source_args(tmp_path)
+    source = RolloutDataSource(args)
+    first, second, third = source.reserve_samples(3)
+    source.acknowledge_reservations([second], rollout_id=7)
+    source.requeue_reservations([third])
+    first.samples[0].response = "mutated after reservation"
+    third.samples[0].prompt = "also mutated"
+    source.save(rollout_id=7)
+
+    restored = RolloutDataSource(args)
+    restored.load(rollout_id=7)
+
+    replayed = restored.reserve_samples(2)
+    assert replayed == [
+        _reservation(0, prompt="alpha"),
+        _reservation(2, prompt="charlie"),
+    ]
+    restored.acknowledge_reservations(replayed, rollout_id=8)
+    assert restored.reserve_samples(1) == [_reservation(3, prompt="delta")]
+
+
+def test_load_rejects_source_configuration_mismatch(tmp_path: Path) -> None:
+    args = _source_args(tmp_path)
+    source = RolloutDataSource(args)
+    source.reserve_samples(1)
+    source.save(rollout_id=9)
+
+    incompatible_args = _source_args(tmp_path)
+    incompatible_args.n_samples_per_prompt = 3
+    restored = RolloutDataSource(incompatible_args)
+
+    with pytest.raises(
+        ValueError,
+        match="Source reservation checkpoint configuration does not match the current data source.",
+    ):
+        restored.load(rollout_id=9)
+
+
+def test_load_rejects_changed_dataset_contents_at_same_path(tmp_path: Path) -> None:
+    args = _source_args(tmp_path)
+    source = RolloutDataSource(args)
+    source.reserve_samples(1)
+    source.save(rollout_id=9)
+
+    Path(args.prompt_data).write_text(
+        "\n".join(json.dumps({"prompt": prompt}) for prompt in ("omega", "bravo", "charlie", "delta")),
+        encoding="utf-8",
+    )
+    restored = RolloutDataSource(args)
+
+    with pytest.raises(
+        ValueError,
+        match="Source reservation checkpoint configuration does not match the current data source.",
+    ):
+        restored.load(rollout_id=9)
+
+
+def test_load_accepts_changed_unused_chat_template_contents(tmp_path: Path) -> None:
+    args = _source_args(tmp_path)
+    template_path = tmp_path / "chat-template.jinja"
+    template_path.write_text("first template", encoding="utf-8")
+    args.chat_template_path = str(template_path)
+    source = RolloutDataSource(args)
+    source.reserve_samples(1)
+    source.save(rollout_id=9)
+
+    template_path.write_text("second template", encoding="utf-8")
+    restored = RolloutDataSource(args)
+    restored.load(rollout_id=9)
+
+    assert restored.reserve_samples(1) == [_reservation(0, prompt="alpha")]
+
+
+def test_load_rejects_changed_processed_samples_at_same_source_reference(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    args = _source_args(tmp_path)
+    args.apply_chat_template = True
+    processed_prompt = "first processed prompt"
+    monkeypatch.setattr(
+        chat_template_utils,
+        "apply_chat_template",
+        lambda *args, **kwargs: processed_prompt,
+    )
+    source = RolloutDataSource(args)
+    source.reserve_samples(1)
+    source.save(rollout_id=9)
+
+    processed_prompt = "second processed prompt"
+    restored = RolloutDataSource(args)
+
+    with pytest.raises(
+        ValueError,
+        match="Source reservation checkpoint configuration does not match the current data source.",
+    ):
+        restored.load(rollout_id=9)
+
+
+def test_load_rejects_changed_materialized_multimodal_payload(tmp_path: Path) -> None:
+    args = _source_args(tmp_path)
+    source = RolloutDataSource(args)
+    assert source.dataset is not None
+    source.dataset.origin_samples[0].multimodal_inputs = {
+        "images": [Image.fromarray(numpy.array([[0, 1]], dtype=numpy.uint8))]
+    }
+    source.reserve_samples(1)
+    source.save(rollout_id=9)
+
+    restored = RolloutDataSource(args)
+    assert restored.dataset is not None
+    restored.dataset.origin_samples[0].multimodal_inputs = {
+        "images": [Image.fromarray(numpy.array([[0, 2]], dtype=numpy.uint8))]
+    }
+
+    with pytest.raises(
+        ValueError,
+        match="Source reservation checkpoint configuration does not match the current data source.",
+    ):
+        restored.load(rollout_id=9)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("hf_checkpoint", "equivalent-tokenizer"),
+        ("metadata_key", "unused-metadata"),
+        ("tool_key", "unused-tools"),
+        ("apply_chat_template_kwargs", {"unused": True}),
+        ("rollout_seed", 101),
+    ],
+)
+def test_load_accepts_equivalent_materialized_source(
+    tmp_path: Path,
+    field: str,
+    value: object,
+) -> None:
+    args = _source_args(tmp_path)
+    source = RolloutDataSource(args)
+    source.reserve_samples(1)
+    source.save(rollout_id=9)
+
+    setattr(args, field, value)
+    restored = RolloutDataSource(args)
+    restored.load(rollout_id=9)
+
+    assert restored.reserve_samples(1) == [_reservation(0, prompt="alpha")]
+
+
+def test_load_accepts_equivalent_source_at_different_path(tmp_path: Path) -> None:
+    args = _source_args(tmp_path)
+    source = RolloutDataSource(args)
+    source.reserve_samples(1)
+    source.save(rollout_id=9)
+
+    equivalent_path = tmp_path / "equivalent.jsonl"
+    equivalent_path.write_bytes(Path(args.prompt_data).read_bytes())
+    args.prompt_data = str(equivalent_path)
+    restored = RolloutDataSource(args)
+    restored.load(rollout_id=9)
+
+    assert restored.reserve_samples(1) == [_reservation(0, prompt="alpha")]
+
+
+def test_load_accepts_changed_ignored_source_fields(tmp_path: Path) -> None:
+    args = _source_args(tmp_path)
+    source = RolloutDataSource(args)
+    source.reserve_samples(1)
+    source.save(rollout_id=9)
+
+    Path(args.prompt_data).write_text(
+        "\n".join(
+            json.dumps({"prompt": prompt, "ignored": "changed"}) for prompt in ("alpha", "bravo", "charlie", "delta")
+        ),
+        encoding="utf-8",
+    )
+    restored = RolloutDataSource(args)
+    restored.load(rollout_id=9)
+
+    assert restored.reserve_samples(1) == [_reservation(0, prompt="alpha")]
+
+
+def test_load_rejects_changed_shuffle_order(tmp_path: Path) -> None:
+    args = _source_args(tmp_path, rollout_shuffle=True)
+    source = RolloutDataSource(args)
+    source.reserve_samples(1)
+    source.save(rollout_id=9)
+
+    args.rollout_seed += 1
+    restored = RolloutDataSource(args)
+
+    with pytest.raises(
+        ValueError,
+        match="Source reservation checkpoint configuration does not match the current data source.",
+    ):
+        restored.load(rollout_id=9)
+
+
+def test_load_accepts_legacy_checkpoint_without_reservations(tmp_path: Path) -> None:
+    args = _source_args(tmp_path)
+    checkpoint_path = tmp_path / "rollout" / "global_dataset_state_dict_10.pt"
+    checkpoint_path.parent.mkdir()
+    torch.save(
+        {
+            "sample_offset": 2,
+            "epoch_id": 0,
+            "sample_group_index": 2,
+            "sample_index": 4,
+            "metadata": {"legacy": True},
+        },
+        checkpoint_path,
+    )
+
+    restored = RolloutDataSource(args)
+    restored.load(rollout_id=10)
+
+    assert restored.reserve_samples(1) == [_reservation(2, prompt="charlie")]
+    assert restored.metadata == {"legacy": True}
+
+
+def test_load_minus_one_is_a_noop(tmp_path: Path) -> None:
+    source = RolloutDataSource(_source_args(tmp_path))
+
+    source.load(rollout_id=-1)
+
+    assert source.get_samples(1) == [list(_reservation(0, prompt="alpha").samples)]
+
+
+def test_load_rejects_active_durable_ownership(tmp_path: Path) -> None:
+    args = _source_args(tmp_path)
+    source = RolloutDataSource(args)
+    [reservation] = source.reserve_samples(1)
+    source.save(rollout_id=10)
+
+    with pytest.raises(
+        RuntimeError,
+        match="Cannot load source state after durable source reservations have started.",
+    ):
+        source.load(rollout_id=10)
+
+    source.requeue_reservations([reservation])
+    assert source.reserve_samples(1) == [_reservation(0, prompt="alpha")]
+
+
+@pytest.mark.parametrize("missing_field", ["sample_offset", "epoch_id", "sample_group_index", "sample_index"])
+def test_load_rejects_missing_versioned_cursor_field(tmp_path: Path, missing_field: str) -> None:
+    args = _source_args(tmp_path)
+    source = RolloutDataSource(args)
+    source.reserve_samples(1)
+    source.save(rollout_id=10)
+    checkpoint_path = tmp_path / "rollout" / "global_dataset_state_dict_10.pt"
+    state = torch.load(checkpoint_path)
+    del state[missing_field]
+    torch.save(state, checkpoint_path)
+
+    restored = RolloutDataSource(args)
+    with pytest.raises(
+        ValueError,
+        match=rf"Checkpoint is missing source cursor fields: \['{missing_field}'\]\.",
+    ):
+        restored.load(rollout_id=10)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("sample_offset", True),
+        ("epoch_id", -1),
+        ("sample_group_index", 1.5),
+        ("sample_index", "2"),
+    ],
+)
+def test_load_rejects_invalid_versioned_cursor_value(
+    tmp_path: Path,
+    field: str,
+    value: object,
+) -> None:
+    args = _source_args(tmp_path)
+    source = RolloutDataSource(args)
+    source.reserve_samples(1)
+    source.save(rollout_id=10)
+    checkpoint_path = tmp_path / "rollout" / "global_dataset_state_dict_10.pt"
+    state = torch.load(checkpoint_path)
+    state[field] = value
+    torch.save(state, checkpoint_path)
+
+    restored = RolloutDataSource(args)
+    with pytest.raises(
+        ValueError,
+        match=rf"Checkpoint {field} must be a nonnegative integer, got {value!r}\.",
+    ):
+        restored.load(rollout_id=10)
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "expected_error"),
+    [
+        (
+            "sample_index",
+            0,
+            "Checkpoint sample frontier 0 does not match group frontier 1 with 2 samples per prompt.",
+        ),
+        (
+            "sample_offset",
+            5,
+            "Checkpoint sample offset 5 exceeds dataset size 4.",
+        ),
+        (
+            "epoch_id",
+            1,
+            "Checkpoint group frontier 1 does not match dataset cursor at epoch 1 offset 1 for dataset size 4.",
+        ),
+    ],
+)
+def test_load_rejects_inconsistent_versioned_cursor(
+    tmp_path: Path,
+    field: str,
+    value: int,
+    expected_error: str,
+) -> None:
+    args = _source_args(tmp_path)
+    source = RolloutDataSource(args)
+    source.reserve_samples(1)
+    source.save(rollout_id=10)
+    checkpoint_path = tmp_path / "rollout" / "global_dataset_state_dict_10.pt"
+    state = torch.load(checkpoint_path)
+    state[field] = value
+    torch.save(state, checkpoint_path)
+
+    restored = RolloutDataSource(args)
+    with pytest.raises(ValueError) as error:
+        restored.load(rollout_id=10)
+
+    assert str(error.value) == expected_error
+
+
+@pytest.mark.parametrize("group_index", [True, "1", 1.0])
+def test_load_rejects_coerced_replay_group_index(
+    tmp_path: Path,
+    group_index: object,
+) -> None:
+    args = _source_args(tmp_path)
+    source = RolloutDataSource(args)
+    source.reserve_samples(2)
+    source.save(rollout_id=10)
+    checkpoint_path = tmp_path / "rollout" / "global_dataset_state_dict_10.pt"
+    state = torch.load(checkpoint_path)
+    state["source_reservations"]["replay"][1]["group_index"] = group_index
+    torch.save(state, checkpoint_path)
+
+    restored = RolloutDataSource(args)
+    with pytest.raises(ValidationError, match="group_index"):
+        restored.load(rollout_id=10)
+
+
+def test_load_rejects_unknown_reservation_schema_version(tmp_path: Path) -> None:
+    args = _source_args(tmp_path)
+    source = RolloutDataSource(args)
+    source.reserve_samples(1)
+    source.save(rollout_id=10)
+    checkpoint_path = tmp_path / "rollout" / "global_dataset_state_dict_10.pt"
+    state = torch.load(checkpoint_path)
+    state["source_reservations"]["schema_version"] = 2
+    torch.save(state, checkpoint_path)
+
+    restored = RolloutDataSource(args)
+    with pytest.raises(ValidationError, match="schema_version"):
+        restored.load(rollout_id=10)
+
+
+def test_load_rejects_duplicate_replay_identity(tmp_path: Path) -> None:
+    args = _source_args(tmp_path)
+    source = RolloutDataSource(args)
+    source.reserve_samples(2)
+    source.save(rollout_id=10)
+    checkpoint_path = tmp_path / "rollout" / "global_dataset_state_dict_10.pt"
+    state = torch.load(checkpoint_path)
+    state["source_reservations"]["replay"][1]["group_index"] = 0
+    torch.save(state, checkpoint_path)
+
+    restored = RolloutDataSource(args)
+    with pytest.raises(
+        ValueError,
+        match=r"Checkpoint contains duplicate source reservation identities: \['0', '0'\]\.",
+    ):
+        restored.load(rollout_id=10)
+
+
+def test_load_rejects_replay_at_saved_frontier(tmp_path: Path) -> None:
+    args = _source_args(tmp_path)
+    source = RolloutDataSource(args)
+    source.reserve_samples(1)
+    source.save(rollout_id=10)
+    checkpoint_path = tmp_path / "rollout" / "global_dataset_state_dict_10.pt"
+    state = torch.load(checkpoint_path)
+    state["source_reservations"]["replay"][0]["group_index"] = 1
+    torch.save(state, checkpoint_path)
+
+    restored = RolloutDataSource(args)
+    with pytest.raises(
+        ValueError,
+        match="Checkpoint contains a source reservation outside the saved group frontier.",
+    ):
+        restored.load(rollout_id=10)
+
+
+def test_checkpoint_replays_acknowledgements_after_its_rollout_frontier(tmp_path: Path) -> None:
+    args = _source_args(tmp_path)
+    source = RolloutDataSource(args)
+    first, second, _ = source.reserve_samples(3)
+    source.acknowledge_reservations([first], rollout_id=5)
+    source.acknowledge_reservations([second], rollout_id=6)
+    source.save(rollout_id=5)
+
+    restored = RolloutDataSource(args)
+    restored.load(rollout_id=5)
+
+    assert restored.reserve_samples(2) == [
+        _reservation(1, prompt="bravo"),
+        _reservation(2, prompt="charlie"),
+    ]
+
+
+def test_acknowledge_rejects_published_rollout_id(tmp_path: Path) -> None:
+    args = _source_args(tmp_path)
+    source = RolloutDataSource(args)
+    first, second = source.reserve_samples(2)
+    source.save(rollout_id=5)
+
+    with pytest.raises(
+        ValueError,
+        match="Reservation rollout_id 5 must be newer than published checkpoint 5.",
+    ):
+        source.acknowledge_reservations([second], rollout_id=5)
+
+    source.acknowledge_reservations([first, second], rollout_id=6)
+    source.save(rollout_id=6)
+    restored = RolloutDataSource(args)
+    restored.load(rollout_id=6)
+    assert restored.reserve_samples(1) == [_reservation(2, prompt="charlie")]
+
+
+def test_save_rejects_rollout_id_regression(tmp_path: Path) -> None:
+    args = _source_args(tmp_path)
+    source = RolloutDataSource(args)
+    source.reserve_samples(1)
+    source.save(rollout_id=5)
+
+    with pytest.raises(
+        ValueError,
+        match="Source checkpoint rollout_id must not move backward from 5 to 4.",
+    ):
+        source.save(rollout_id=4)
+
+    restored = RolloutDataSource(args)
+    restored.load(rollout_id=5)
+    assert restored.reserve_samples(1) == [_reservation(0, prompt="alpha")]
+
+
+def test_legacy_save_rejects_acknowledgement_at_published_rollout_id(tmp_path: Path) -> None:
+    args = _source_args(tmp_path)
+    source = RolloutDataSource(args)
+    source.get_samples(1)
+    source.save(rollout_id=5)
+    reservation = source.reserve_samples(1)[0]
+
+    with pytest.raises(
+        ValueError,
+        match="Reservation rollout_id 5 must be newer than published checkpoint 5.",
+    ):
+        source.acknowledge_reservations([reservation], rollout_id=5)
+
+    source.acknowledge_reservations([reservation], rollout_id=6)
+
+
+def test_legacy_save_rejects_rollout_id_regression(tmp_path: Path) -> None:
+    source = RolloutDataSource(_source_args(tmp_path))
+    source.get_samples(1)
+    source.save(rollout_id=5)
+
+    with pytest.raises(
+        ValueError,
+        match="Source checkpoint rollout_id must not move backward from 5 to 4.",
+    ):
+        source.save(rollout_id=4)
+
+
+def test_legacy_source_save_preserves_checkpoint_format(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def reject_fingerprint(_source: RolloutDataSource) -> str:
+        raise AssertionError("legacy source use must not fingerprint prompt data")
+
+    monkeypatch.setattr(RolloutDataSource, "_processed_samples_sha256", reject_fingerprint)
+    args = _source_args(tmp_path)
+    source = RolloutDataSource(args)
+    assert source.get_samples(1) == [list(_reservation(0, prompt="alpha").samples)]
+
+    source.save(rollout_id=10)
+
+    checkpoint_path = tmp_path / "rollout" / "global_dataset_state_dict_10.pt"
+    assert torch.load(checkpoint_path) == {
+        "sample_offset": 1,
+        "epoch_id": 0,
+        "sample_group_index": 1,
+        "sample_index": 2,
+        "metadata": {},
+    }
+
+
+@pytest.mark.parametrize(
+    ("rollout_shuffle", "first_prompts", "restored_prompts"),
+    [
+        (False, ("alpha", "bravo", "charlie", "delta", "alpha"), ("bravo", "charlie", "delta")),
+        (True, ("alpha", "charlie", "delta", "bravo", "alpha"), ("delta", "charlie", "bravo")),
+    ],
+)
+def test_legacy_source_preserves_multi_epoch_order_across_restart(
+    tmp_path: Path,
+    rollout_shuffle: bool,
+    first_prompts: tuple[str, ...],
+    restored_prompts: tuple[str, ...],
+) -> None:
+    args = _source_args(tmp_path, rollout_shuffle=rollout_shuffle)
+    source = RolloutDataSource(args)
+
+    assert source.get_samples(5) == [
+        list(_reservation(group_index, prompt=prompt).samples) for group_index, prompt in enumerate(first_prompts)
+    ]
+    source.save(rollout_id=10)
+
+    restored = RolloutDataSource(args)
+    restored.load(rollout_id=10)
+    assert restored.get_samples(3) == [
+        list(_reservation(group_index, prompt=prompt).samples)
+        for group_index, prompt in enumerate(restored_prompts, start=5)
+    ]
+
+
+def test_shuffled_multi_epoch_reservations_reconstruct_exact_groups(tmp_path: Path) -> None:
+    args = _source_args(tmp_path, rollout_shuffle=True)
+    source = RolloutDataSource(args)
     reservations = source.reserve_samples(10)
     expected = copy.deepcopy(reservations)
     for reservation in reservations:
         reservation.samples[0].prompt = "mutated"
-    source.requeue_reservations(reservations)
+    source.save(rollout_id=11)
 
-    assert source.reserve_samples(10) == expected
+    restored = RolloutDataSource(args)
+    restored.load(rollout_id=11)
+
+    assert restored.reserve_samples(10) == expected
 
 
 def test_materialization_failure_does_not_advance_source(
@@ -237,35 +776,248 @@ def test_materialization_failure_does_not_advance_source(
     ]
 
 
-def test_non_persistent_source_rejects_durable_reservations(tmp_path: Path) -> None:
+def test_failed_save_preserves_previous_checkpoint(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     args = _source_args(tmp_path)
-    args.rollout_global_dataset = False
+    source = RolloutDataSource(args)
+    source.reserve_samples(1)
+    source.save(rollout_id=12)
+    source.reserve_samples(1)
+
+    def fail_after_partial_write(state: object, path: str) -> None:
+        Path(path).write_bytes(b"partial checkpoint")
+        raise RuntimeError("injected save failure")
+
+    monkeypatch.setattr(data_source_module.torch, "save", fail_after_partial_write)
+    with pytest.raises(RuntimeError, match="injected save failure"):
+        source.save(rollout_id=12)
+
+    restored = RolloutDataSource(args)
+    restored.load(rollout_id=12)
+    assert restored.reserve_samples(2) == [
+        _reservation(0, prompt="alpha"),
+        _reservation(1, prompt="bravo"),
+    ]
+
+
+def test_failed_checkpoint_replace_preserves_previous_checkpoint(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    args = _source_args(tmp_path)
+    source = RolloutDataSource(args)
+    source.reserve_samples(1)
+    source.save(rollout_id=12)
+    source.reserve_samples(1)
+
+    def fail_replace(_source_path: str, destination_path: str) -> None:
+        raise RuntimeError(f"injected replace failure for {destination_path}")
+
+    monkeypatch.setattr(data_source_module.os, "replace", fail_replace)
+    with pytest.raises(RuntimeError, match="injected replace failure"):
+        source.save(rollout_id=12)
+
+    restored = RolloutDataSource(args)
+    restored.load(rollout_id=12)
+    assert restored.reserve_samples(2) == [
+        _reservation(0, prompt="alpha"),
+        _reservation(1, prompt="bravo"),
+    ]
+
+
+def test_save_is_linearized_with_reservation_settlement(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    args = _source_args(tmp_path)
+    source = RolloutDataSource(args)
+    [first] = source.reserve_samples(1)
+    save_started = threading.Event()
+    allow_save = threading.Event()
+    settlement_started = threading.Event()
+    settlement_finished = threading.Event()
+    original_torch_save = torch.save
+
+    def blocking_save(state: object, path: str) -> None:
+        save_started.set()
+        assert allow_save.wait(timeout=5)
+        original_torch_save(state, path)
+
+    def settle_after_save_starts() -> None:
+        settlement_started.set()
+        source.acknowledge_reservations([first], rollout_id=1)
+        settlement_finished.set()
+
+    monkeypatch.setattr(data_source_module.torch, "save", blocking_save)
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        save_future = executor.submit(source.save, 0)
+        assert save_started.wait(timeout=5)
+        settlement_future = executor.submit(settle_after_save_starts)
+        assert settlement_started.wait(timeout=5)
+        assert not settlement_finished.wait(timeout=0.05)
+        allow_save.set()
+        save_future.result(timeout=5)
+        settlement_future.result(timeout=5)
+
+    restored = RolloutDataSource(args)
+    restored.load(rollout_id=0)
+    assert restored.reserve_samples(1) == [first]
+
+
+def test_no_checkpoint_mode_rejects_a_false_durable_save(tmp_path: Path) -> None:
+    args = _source_args(tmp_path)
+    args.save_interval = None
+    source = RolloutDataSource(args)
+    [reservation] = source.reserve_samples(1)
+    source.acknowledge_reservations([reservation], rollout_id=0)
+
+    with pytest.raises(
+        RuntimeError,
+        match="Cannot save durable source reservations without --save-interval",
+    ):
+        source.save(rollout_id=0)
+
+
+def test_sentinel_only_checkpoint_rejects_durable_reservations(tmp_path: Path) -> None:
+    args = _source_args(tmp_path)
+    args.save_interval = None
+    args.save_trigger_sentinel = str(tmp_path / "save-trigger")
     source = RolloutDataSource(args)
 
     with pytest.raises(
         RuntimeError,
-        match="RolloutDataSource does not support durable source reservations when rollout_global_dataset is disabled.",
+        match="Durable source reservations require a periodic save interval when a save trigger is configured.",
     ):
         source.reserve_samples(1)
 
+    assert source.get_samples(1) == [list(_reservation(0, prompt="alpha").samples)]
 
-def test_reservation_aware_save_fails_before_checkpoint_support(tmp_path: Path) -> None:
-    source = RolloutDataSource(_source_args(tmp_path))
-    first, second = source.reserve_samples(2)
-    source.acknowledge_reservations([first], rollout_id=0)
-    source.requeue_reservations([second])
+
+def test_no_checkpoint_mode_allows_reservations_but_refuses_to_persist_them(tmp_path: Path) -> None:
+    args = _source_args(tmp_path)
+    args.save_interval = None
+    args.save_trigger_sentinel = None
+    source = RolloutDataSource(args)
+
+    assert source.supports_source_reservations is True
+    assert source.reserve_samples(2) == [
+        _reservation(0, prompt="alpha"),
+        _reservation(1, prompt="bravo"),
+    ]
 
     with pytest.raises(
         RuntimeError,
-        match=(
-            "Cannot save source state after durable source reservations have started "
-            "until reservation checkpointing is available."
-        ),
+        match="Cannot save durable source reservations without --save-interval",
     ):
         source.save(rollout_id=0)
 
-    assert not (tmp_path / "rollout" / "global_dataset_state_dict_0.pt").exists()
-    assert source.reserve_samples(1) == [_reservation(1, prompt="bravo")]
+
+def test_resume_without_save_interval_replays_reservations_but_refuses_to_persist_them(tmp_path: Path) -> None:
+    args = _source_args(tmp_path)
+    source = RolloutDataSource(args)
+    first, second = source.reserve_samples(2)
+    source.acknowledge_reservations([second], rollout_id=4)
+    source.requeue_reservations([first])
+    source.save(rollout_id=4)
+
+    resumed_args = copy.copy(args)
+    resumed_args.save_interval = None
+    resumed_args.save_trigger_sentinel = None
+    restored = RolloutDataSource(resumed_args)
+    restored.load(rollout_id=4)
+
+    assert restored.supports_source_reservations is True
+    assert restored.reserve_samples(2) == [
+        _reservation(0, prompt="alpha"),
+        _reservation(2, prompt="charlie"),
+    ]
+
+    with pytest.raises(
+        RuntimeError,
+        match="Cannot save durable source reservations without --save-interval",
+    ):
+        restored.save(rollout_id=5)
+
+
+def test_sentinel_only_resume_refuses_a_checkpoint_holding_reservations(
+    tmp_path: Path,
+) -> None:
+    args = _source_args(tmp_path)
+    source = RolloutDataSource(args)
+    first, second = source.reserve_samples(2)
+    source.acknowledge_reservations([second], rollout_id=4)
+    source.requeue_reservations([first])
+    source.save(rollout_id=4)
+
+    resumed_args = copy.copy(args)
+    resumed_args.save_interval = None
+    resumed_args.save_trigger_sentinel = str(tmp_path / "save-trigger")
+    restored = RolloutDataSource(resumed_args)
+    assert restored.supports_source_reservations is False
+
+    with pytest.raises(
+        ValueError,
+        match=r"^Source reservation checkpoint cannot be loaded: Durable source reservations require a periodic save interval when a save trigger is configured\.$",
+    ):
+        restored.load(rollout_id=4)
+
+    assert restored.supports_source_reservations is False
+    assert (restored.epoch_id, restored.sample_offset) == (0, 0)
+    assert (restored.sample_group_index, restored.sample_index) == (0, 0)
+    assert restored.metadata == {}
+    # The replay list has no public reader on a source the gate has closed.
+    assert restored._replay_reservations == []
+    assert restored._durable_reservations_started is False
+    assert restored.get_samples(1) == [list(_reservation(0, prompt="alpha").samples)]
+
+
+def test_sentinel_only_resume_accepts_a_checkpoint_without_reservations(tmp_path: Path) -> None:
+    args = _source_args(tmp_path)
+    source = RolloutDataSource(args)
+    source.metadata = {"legacy": True}
+    source.get_samples(2)
+    source.save(rollout_id=4)
+
+    resumed_args = copy.copy(args)
+    resumed_args.save_interval = None
+    resumed_args.save_trigger_sentinel = str(tmp_path / "save-trigger")
+    restored = RolloutDataSource(resumed_args)
+    assert restored.supports_source_reservations is False
+
+    restored.load(rollout_id=4)
+
+    assert (restored.epoch_id, restored.sample_offset) == (0, 2)
+    assert (restored.sample_group_index, restored.sample_index) == (2, 4)
+    assert restored.metadata == {"legacy": True}
+    assert restored.get_samples(1) == [list(_reservation(2, prompt="charlie").samples)]
+
+
+def test_buffered_resume_refuses_a_checkpoint_holding_reservations(tmp_path: Path) -> None:
+    args = _source_args(tmp_path)
+    source = RolloutDataSource(args)
+    first, second = source.reserve_samples(2)
+    source.acknowledge_reservations([second], rollout_id=4)
+    source.requeue_reservations([first])
+    source.save(rollout_id=4)
+
+    restored = RolloutDataSourceWithBuffer(copy.copy(args))
+    assert restored.supports_source_reservations is False
+
+    with pytest.raises(
+        ValueError,
+        match=r"^Source reservation checkpoint cannot be loaded: RolloutDataSourceWithBuffer does not support durable source reservations\.$",
+    ):
+        restored.load(rollout_id=4)
+
+    assert (restored.epoch_id, restored.sample_offset) == (0, 0)
+    assert (restored.sample_group_index, restored.sample_index) == (0, 0)
+    assert restored.metadata == {}
+    # The replay list has no public reader on a source the gate has closed.
+    assert restored._replay_reservations == []
+    assert restored._durable_reservations_started is False
+    assert restored.get_samples(1) == [list(_reservation(0, prompt="alpha").samples)]
 
 
 def test_buffered_source_rejects_reservations_that_bypass_retry_buffer(tmp_path: Path) -> None:
@@ -283,3 +1035,26 @@ def test_buffered_source_rejects_reservations_that_bypass_retry_buffer(tmp_path:
 
     assert source.get_samples(1) == [retry_group]
     assert source.get_buffer_length() == 0
+
+
+def test_configured_source_reports_reservation_support(tmp_path: Path) -> None:
+    assert RolloutDataSource(_source_args(tmp_path)).supports_source_reservations is True
+
+
+def test_source_without_global_dataset_reports_no_reservation_support(tmp_path: Path) -> None:
+    args = _source_args(tmp_path)
+    args.rollout_global_dataset = False
+
+    assert RolloutDataSource(args).supports_source_reservations is False
+
+
+def test_sentinel_only_checkpoint_source_reports_no_reservation_support(tmp_path: Path) -> None:
+    args = _source_args(tmp_path)
+    args.save_interval = None
+    args.save_trigger_sentinel = str(tmp_path / "trigger")
+
+    assert RolloutDataSource(args).supports_source_reservations is False
+
+
+def test_buffered_source_reports_no_reservation_support(tmp_path: Path) -> None:
+    assert RolloutDataSourceWithBuffer(_source_args(tmp_path)).supports_source_reservations is False

--- a/tests/fast/rollout/test_data_source_reservations.py
+++ b/tests/fast/rollout/test_data_source_reservations.py
@@ -1,0 +1,285 @@
+import copy
+import json
+from argparse import Namespace
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+import miles.rollout.data_source as data_source_module
+from miles.rollout.data_source import (
+    RolloutDataSource,
+    RolloutDataSourceWithBuffer,
+    SourceReservation,
+    SourceReservationId,
+)
+from miles.utils.types import Sample
+
+
+@pytest.fixture(autouse=True)
+def patch_processors(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(data_source_module, "load_tokenizer", lambda *args, **kwargs: object())
+    monkeypatch.setattr(data_source_module, "load_processor", lambda *args, **kwargs: None)
+
+
+def _source_args(tmp_path: Path, *, rollout_shuffle: bool = False) -> Namespace:
+    prompt_path = tmp_path / "prompts.jsonl"
+    prompt_path.write_text(
+        "\n".join(json.dumps({"prompt": prompt}) for prompt in ("alpha", "bravo", "charlie", "delta")),
+        encoding="utf-8",
+    )
+    return Namespace(
+        rollout_global_dataset=True,
+        hf_checkpoint="unused",
+        chat_template_path=None,
+        dump_details=None,
+        prompt_data=str(prompt_path),
+        rollout_max_prompt_len=None,
+        input_key="prompt",
+        multimodal_keys=None,
+        label_key=None,
+        metadata_key="metadata",
+        tool_key=None,
+        apply_chat_template=False,
+        apply_chat_template_kwargs=None,
+        rollout_seed=100,
+        rollout_shuffle=rollout_shuffle,
+        n_samples_per_prompt=2,
+        save=str(tmp_path),
+        load=str(tmp_path),
+        save_interval=1,
+        save_trigger_sentinel=None,
+        buffer_filter_path=None,
+    )
+
+
+def _reservation(reservation_id: int, *, prompt: str) -> SourceReservation:
+    first_sample_index = reservation_id * 2
+    return SourceReservation(
+        reservation_id=SourceReservationId(str(reservation_id)),
+        samples=tuple(
+            Sample(group_index=reservation_id, index=sample_index, prompt=prompt)
+            for sample_index in (first_sample_index, first_sample_index + 1)
+        ),
+    )
+
+
+def test_reserve_returns_exact_pristine_groups(tmp_path: Path) -> None:
+    source = RolloutDataSource(_source_args(tmp_path))
+
+    assert source.reserve_samples(3) == [
+        _reservation(0, prompt="alpha"),
+        _reservation(1, prompt="bravo"),
+        _reservation(2, prompt="charlie"),
+    ]
+
+
+def test_reservation_keeps_every_parent_slot(tmp_path: Path) -> None:
+    source = RolloutDataSource(_source_args(tmp_path))
+    [reservation] = source.reserve_samples(1)
+
+    with pytest.raises(AttributeError, match="'tuple' object has no attribute 'pop'"):
+        cast(list[Sample], reservation.samples).pop()
+
+    source.acknowledge_reservations([reservation], rollout_id=0)
+
+
+@pytest.mark.parametrize("num_groups", [True, -1, 1.5, "1"])
+def test_reserve_rejects_invalid_group_count(tmp_path: Path, num_groups: object) -> None:
+    source = RolloutDataSource(_source_args(tmp_path))
+
+    with pytest.raises(
+        ValueError,
+        match=rf"num_groups must be a nonnegative integer, got {num_groups!r}\.",
+    ):
+        source.reserve_samples(cast(int, num_groups))
+
+    assert source.reserve_samples(1) == [_reservation(0, prompt="alpha")]
+
+
+def test_duplicate_settlement_is_atomic(tmp_path: Path) -> None:
+    source = RolloutDataSource(_source_args(tmp_path))
+    first, second = source.reserve_samples(2)
+
+    with pytest.raises(
+        ValueError,
+        match=r"Reservation settlement contains duplicate identities: \['0', '0'\]\.",
+    ):
+        source.acknowledge_reservations([first, first], rollout_id=0)
+
+    source.acknowledge_reservations([first, second], rollout_id=0)
+    assert source.reserve_samples(1) == [_reservation(2, prompt="charlie")]
+
+
+def test_reissued_reservation_rejects_stale_attempt(tmp_path: Path) -> None:
+    source = RolloutDataSource(_source_args(tmp_path))
+    [first_attempt] = source.reserve_samples(1)
+    source.requeue_reservations([first_attempt])
+
+    [second_attempt] = source.reserve_samples(1)
+    assert second_attempt == first_attempt
+    assert second_attempt is not first_attempt
+
+    with pytest.raises(
+        RuntimeError,
+        match=r"Source reservations are not the current outstanding attempts: \['0'\]\.",
+    ):
+        source.acknowledge_reservations([first_attempt], rollout_id=0)
+
+    source.acknowledge_reservations([second_attempt], rollout_id=0)
+
+
+def test_mixed_stale_settlement_leaves_valid_attempt_outstanding(tmp_path: Path) -> None:
+    source = RolloutDataSource(_source_args(tmp_path))
+    first, old_second = source.reserve_samples(2)
+    source.requeue_reservations([old_second])
+    [new_second] = source.reserve_samples(1)
+
+    with pytest.raises(
+        RuntimeError,
+        match=r"Source reservations are not the current outstanding attempts: \['1'\]\.",
+    ):
+        source.acknowledge_reservations([first, old_second], rollout_id=0)
+
+    source.acknowledge_reservations([first, new_second], rollout_id=0)
+    assert source.reserve_samples(1) == [_reservation(2, prompt="charlie")]
+
+
+def test_mixed_invalid_requeue_leaves_valid_attempt_outstanding(tmp_path: Path) -> None:
+    source = RolloutDataSource(_source_args(tmp_path))
+    [valid] = source.reserve_samples(1)
+    forged = _reservation(99, prompt="forged")
+
+    with pytest.raises(
+        RuntimeError,
+        match=r"Source reservations are not the current outstanding attempts: \['99'\]\.",
+    ):
+        source.requeue_reservations([valid, forged])
+
+    source.acknowledge_reservations([valid], rollout_id=0)
+
+
+def test_requeue_reconstructs_pristine_samples_in_process(tmp_path: Path) -> None:
+    source = RolloutDataSource(_source_args(tmp_path))
+    [first_attempt] = source.reserve_samples(1)
+    first_attempt.samples[0].prompt = "mutated"
+    first_attempt.samples[1].response = "generated"
+
+    source.requeue_reservations([first_attempt])
+
+    assert source.reserve_samples(1) == [_reservation(0, prompt="alpha")]
+
+
+def test_requeue_replays_holes_in_source_order(tmp_path: Path) -> None:
+    source = RolloutDataSource(_source_args(tmp_path))
+    first, second, third, fourth = source.reserve_samples(4)
+    source.acknowledge_reservations([second, fourth], rollout_id=0)
+    source.requeue_reservations([third, first])
+
+    assert source.reserve_samples(3) == [
+        _reservation(0, prompt="alpha"),
+        _reservation(2, prompt="charlie"),
+        _reservation(4, prompt="alpha"),
+    ]
+
+
+def test_legacy_reads_are_rejected_after_durable_ownership_starts(tmp_path: Path) -> None:
+    source = RolloutDataSource(_source_args(tmp_path))
+    [reservation] = source.reserve_samples(1)
+
+    with pytest.raises(
+        RuntimeError,
+        match="Cannot use get_samples after durable source reservations have started.",
+    ):
+        source.get_samples(1)
+
+    source.requeue_reservations([reservation])
+    assert source.reserve_samples(2) == [
+        _reservation(0, prompt="alpha"),
+        _reservation(1, prompt="bravo"),
+    ]
+
+
+def test_shuffled_multi_epoch_replay_reconstructs_exact_groups(tmp_path: Path) -> None:
+    source = RolloutDataSource(_source_args(tmp_path, rollout_shuffle=True))
+    reservations = source.reserve_samples(10)
+    expected = copy.deepcopy(reservations)
+    for reservation in reservations:
+        reservation.samples[0].prompt = "mutated"
+    source.requeue_reservations(reservations)
+
+    assert source.reserve_samples(10) == expected
+
+
+def test_materialization_failure_does_not_advance_source(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = RolloutDataSource(_source_args(tmp_path))
+    original_deepcopy = copy.deepcopy
+    copy_count = 0
+
+    def fail_during_second_group(value: object) -> object:
+        nonlocal copy_count
+        copy_count += 1
+        if copy_count == 3:
+            raise RuntimeError("injected materialization failure")
+        return original_deepcopy(value)
+
+    monkeypatch.setattr(data_source_module.copy, "deepcopy", fail_during_second_group)
+    with pytest.raises(RuntimeError, match="injected materialization failure"):
+        source.reserve_samples(2)
+
+    monkeypatch.setattr(data_source_module.copy, "deepcopy", original_deepcopy)
+    assert source.reserve_samples(2) == [
+        _reservation(0, prompt="alpha"),
+        _reservation(1, prompt="bravo"),
+    ]
+
+
+def test_non_persistent_source_rejects_durable_reservations(tmp_path: Path) -> None:
+    args = _source_args(tmp_path)
+    args.rollout_global_dataset = False
+    source = RolloutDataSource(args)
+
+    with pytest.raises(
+        RuntimeError,
+        match="RolloutDataSource does not support durable source reservations when rollout_global_dataset is disabled.",
+    ):
+        source.reserve_samples(1)
+
+
+def test_reservation_aware_save_fails_before_checkpoint_support(tmp_path: Path) -> None:
+    source = RolloutDataSource(_source_args(tmp_path))
+    first, second = source.reserve_samples(2)
+    source.acknowledge_reservations([first], rollout_id=0)
+    source.requeue_reservations([second])
+
+    with pytest.raises(
+        RuntimeError,
+        match=(
+            "Cannot save source state after durable source reservations have started "
+            "until reservation checkpointing is available."
+        ),
+    ):
+        source.save(rollout_id=0)
+
+    assert not (tmp_path / "rollout" / "global_dataset_state_dict_0.pt").exists()
+    assert source.reserve_samples(1) == [_reservation(1, prompt="bravo")]
+
+
+def test_buffered_source_rejects_reservations_that_bypass_retry_buffer(tmp_path: Path) -> None:
+    source = RolloutDataSourceWithBuffer(_source_args(tmp_path))
+    retry_group = list(_reservation(7, prompt="retry").samples)
+    source.add_samples([retry_group])
+
+    with pytest.raises(
+        RuntimeError,
+        match=(
+            "RolloutDataSourceWithBuffer does not support durable source reservations because they would bypass its retry buffer."
+        ),
+    ):
+        source.reserve_samples(1)
+
+    assert source.get_samples(1) == [retry_group]
+    assert source.get_buffer_length() == 0

--- a/tests/fast/rollout/test_data_source_reservations.py
+++ b/tests/fast/rollout/test_data_source_reservations.py
@@ -1,10 +1,16 @@
 import copy
 import json
+import threading
 from argparse import Namespace
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import cast
 
+import numpy
 import pytest
+import torch
+from PIL import Image
+from pydantic import ValidationError
 
 import miles.rollout.data_source as data_source_module
 from miles.rollout.data_source import (
@@ -13,6 +19,7 @@ from miles.rollout.data_source import (
     SourceReservation,
     SourceReservationId,
 )
+from miles.utils import chat_template_utils
 from miles.utils.types import Sample
 
 
@@ -84,8 +91,8 @@ def test_reservation_keeps_every_parent_slot(tmp_path: Path) -> None:
     source.acknowledge_reservations([reservation], rollout_id=0)
 
 
-@pytest.mark.parametrize("num_groups", [True, -1, 1.5, "1"])
-def test_reserve_rejects_invalid_group_count(tmp_path: Path, num_groups: object) -> None:
+@pytest.mark.parametrize("num_groups", [True, 1.5, "1"])
+def test_reserve_rejects_non_integer_group_count(tmp_path: Path, num_groups: object) -> None:
     source = RolloutDataSource(_source_args(tmp_path))
 
     with pytest.raises(
@@ -170,19 +177,6 @@ def test_requeue_reconstructs_pristine_samples_in_process(tmp_path: Path) -> Non
     assert source.reserve_samples(1) == [_reservation(0, prompt="alpha")]
 
 
-def test_requeue_replays_holes_in_source_order(tmp_path: Path) -> None:
-    source = RolloutDataSource(_source_args(tmp_path))
-    first, second, third, fourth = source.reserve_samples(4)
-    source.acknowledge_reservations([second, fourth], rollout_id=0)
-    source.requeue_reservations([third, first])
-
-    assert source.reserve_samples(3) == [
-        _reservation(0, prompt="alpha"),
-        _reservation(2, prompt="charlie"),
-        _reservation(4, prompt="alpha"),
-    ]
-
-
 def test_legacy_reads_are_rejected_after_durable_ownership_starts(tmp_path: Path) -> None:
     source = RolloutDataSource(_source_args(tmp_path))
     [reservation] = source.reserve_samples(1)
@@ -200,15 +194,560 @@ def test_legacy_reads_are_rejected_after_durable_ownership_starts(tmp_path: Path
     ]
 
 
-def test_shuffled_multi_epoch_replay_reconstructs_exact_groups(tmp_path: Path) -> None:
-    source = RolloutDataSource(_source_args(tmp_path, rollout_shuffle=True))
+def test_restart_replays_unsettled_groups_before_advancing(tmp_path: Path) -> None:
+    args = _source_args(tmp_path)
+    source = RolloutDataSource(args)
+    first, second, third = source.reserve_samples(3)
+    source.acknowledge_reservations([second], rollout_id=7)
+    source.requeue_reservations([third])
+    first.samples[0].response = "mutated after reservation"
+    third.samples[0].prompt = "also mutated"
+    source.save(rollout_id=7)
+
+    restored = RolloutDataSource(args)
+    restored.load(rollout_id=7)
+
+    replayed = restored.reserve_samples(2)
+    assert replayed == [
+        _reservation(0, prompt="alpha"),
+        _reservation(2, prompt="charlie"),
+    ]
+    restored.acknowledge_reservations(replayed, rollout_id=8)
+    assert restored.reserve_samples(1) == [_reservation(3, prompt="delta")]
+
+
+def test_load_rejects_source_configuration_mismatch(tmp_path: Path) -> None:
+    args = _source_args(tmp_path)
+    source = RolloutDataSource(args)
+    source.reserve_samples(1)
+    source.save(rollout_id=9)
+
+    incompatible_args = _source_args(tmp_path)
+    incompatible_args.n_samples_per_prompt = 3
+    restored = RolloutDataSource(incompatible_args)
+
+    with pytest.raises(
+        ValueError,
+        match="Source reservation checkpoint configuration does not match the current data source.",
+    ):
+        restored.load(rollout_id=9)
+
+
+def test_load_rejects_changed_dataset_contents_at_same_path(tmp_path: Path) -> None:
+    args = _source_args(tmp_path)
+    source = RolloutDataSource(args)
+    source.reserve_samples(1)
+    source.save(rollout_id=9)
+
+    Path(args.prompt_data).write_text(
+        "\n".join(json.dumps({"prompt": prompt}) for prompt in ("omega", "bravo", "charlie", "delta")),
+        encoding="utf-8",
+    )
+    restored = RolloutDataSource(args)
+
+    with pytest.raises(
+        ValueError,
+        match="Source reservation checkpoint configuration does not match the current data source.",
+    ):
+        restored.load(rollout_id=9)
+
+
+def test_load_accepts_changed_unused_chat_template_contents(tmp_path: Path) -> None:
+    args = _source_args(tmp_path)
+    template_path = tmp_path / "chat-template.jinja"
+    template_path.write_text("first template", encoding="utf-8")
+    args.chat_template_path = str(template_path)
+    source = RolloutDataSource(args)
+    source.reserve_samples(1)
+    source.save(rollout_id=9)
+
+    template_path.write_text("second template", encoding="utf-8")
+    restored = RolloutDataSource(args)
+    restored.load(rollout_id=9)
+
+    assert restored.reserve_samples(1) == [_reservation(0, prompt="alpha")]
+
+
+def test_load_rejects_changed_processed_samples_at_same_source_reference(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    args = _source_args(tmp_path)
+    args.apply_chat_template = True
+    processed_prompt = "first processed prompt"
+    monkeypatch.setattr(
+        chat_template_utils,
+        "apply_chat_template",
+        lambda *args, **kwargs: processed_prompt,
+    )
+    source = RolloutDataSource(args)
+    source.reserve_samples(1)
+    source.save(rollout_id=9)
+
+    processed_prompt = "second processed prompt"
+    restored = RolloutDataSource(args)
+
+    with pytest.raises(
+        ValueError,
+        match="Source reservation checkpoint configuration does not match the current data source.",
+    ):
+        restored.load(rollout_id=9)
+
+
+def test_load_rejects_changed_materialized_multimodal_payload(tmp_path: Path) -> None:
+    args = _source_args(tmp_path)
+    source = RolloutDataSource(args)
+    assert source.dataset is not None
+    source.dataset.origin_samples[0].multimodal_inputs = {
+        "images": [Image.fromarray(numpy.array([[0, 1]], dtype=numpy.uint8))]
+    }
+    source.reserve_samples(1)
+    source.save(rollout_id=9)
+
+    restored = RolloutDataSource(args)
+    assert restored.dataset is not None
+    restored.dataset.origin_samples[0].multimodal_inputs = {
+        "images": [Image.fromarray(numpy.array([[0, 2]], dtype=numpy.uint8))]
+    }
+
+    with pytest.raises(
+        ValueError,
+        match="Source reservation checkpoint configuration does not match the current data source.",
+    ):
+        restored.load(rollout_id=9)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("hf_checkpoint", "equivalent-tokenizer"),
+        ("metadata_key", "unused-metadata"),
+        ("tool_key", "unused-tools"),
+        ("apply_chat_template_kwargs", {"unused": True}),
+        ("rollout_seed", 101),
+    ],
+)
+def test_load_accepts_equivalent_materialized_source(
+    tmp_path: Path,
+    field: str,
+    value: object,
+) -> None:
+    args = _source_args(tmp_path)
+    source = RolloutDataSource(args)
+    source.reserve_samples(1)
+    source.save(rollout_id=9)
+
+    setattr(args, field, value)
+    restored = RolloutDataSource(args)
+    restored.load(rollout_id=9)
+
+    assert restored.reserve_samples(1) == [_reservation(0, prompt="alpha")]
+
+
+def test_load_accepts_equivalent_source_at_different_path(tmp_path: Path) -> None:
+    args = _source_args(tmp_path)
+    source = RolloutDataSource(args)
+    source.reserve_samples(1)
+    source.save(rollout_id=9)
+
+    equivalent_path = tmp_path / "equivalent.jsonl"
+    equivalent_path.write_bytes(Path(args.prompt_data).read_bytes())
+    args.prompt_data = str(equivalent_path)
+    restored = RolloutDataSource(args)
+    restored.load(rollout_id=9)
+
+    assert restored.reserve_samples(1) == [_reservation(0, prompt="alpha")]
+
+
+def test_load_accepts_changed_ignored_source_fields(tmp_path: Path) -> None:
+    args = _source_args(tmp_path)
+    source = RolloutDataSource(args)
+    source.reserve_samples(1)
+    source.save(rollout_id=9)
+
+    Path(args.prompt_data).write_text(
+        "\n".join(
+            json.dumps({"prompt": prompt, "ignored": "changed"}) for prompt in ("alpha", "bravo", "charlie", "delta")
+        ),
+        encoding="utf-8",
+    )
+    restored = RolloutDataSource(args)
+    restored.load(rollout_id=9)
+
+    assert restored.reserve_samples(1) == [_reservation(0, prompt="alpha")]
+
+
+def test_load_rejects_changed_shuffle_order(tmp_path: Path) -> None:
+    args = _source_args(tmp_path, rollout_shuffle=True)
+    source = RolloutDataSource(args)
+    source.reserve_samples(1)
+    source.save(rollout_id=9)
+
+    args.rollout_seed += 1
+    restored = RolloutDataSource(args)
+
+    with pytest.raises(
+        ValueError,
+        match="Source reservation checkpoint configuration does not match the current data source.",
+    ):
+        restored.load(rollout_id=9)
+
+
+def test_load_accepts_legacy_checkpoint_without_reservations(tmp_path: Path) -> None:
+    args = _source_args(tmp_path)
+    checkpoint_path = tmp_path / "rollout" / "global_dataset_state_dict_10.pt"
+    checkpoint_path.parent.mkdir()
+    torch.save(
+        {
+            "sample_offset": 2,
+            "epoch_id": 0,
+            "sample_group_index": 2,
+            "sample_index": 4,
+            "metadata": {"legacy": True},
+        },
+        checkpoint_path,
+    )
+
+    restored = RolloutDataSource(args)
+    restored.load(rollout_id=10)
+
+    assert restored.reserve_samples(1) == [_reservation(2, prompt="charlie")]
+    assert restored.metadata == {"legacy": True}
+
+
+def test_load_minus_one_is_a_noop(tmp_path: Path) -> None:
+    source = RolloutDataSource(_source_args(tmp_path))
+
+    source.load(rollout_id=-1)
+
+    assert source.get_samples(1) == [list(_reservation(0, prompt="alpha").samples)]
+
+
+def test_load_rejects_active_durable_ownership(tmp_path: Path) -> None:
+    args = _source_args(tmp_path)
+    source = RolloutDataSource(args)
+    [reservation] = source.reserve_samples(1)
+    source.save(rollout_id=10)
+
+    with pytest.raises(
+        RuntimeError,
+        match="Cannot load source state after durable source reservations have started.",
+    ):
+        source.load(rollout_id=10)
+
+    source.requeue_reservations([reservation])
+    assert source.reserve_samples(1) == [_reservation(0, prompt="alpha")]
+
+
+@pytest.mark.parametrize("missing_field", ["sample_offset", "epoch_id", "sample_group_index", "sample_index"])
+def test_load_rejects_missing_versioned_cursor_field(tmp_path: Path, missing_field: str) -> None:
+    args = _source_args(tmp_path)
+    source = RolloutDataSource(args)
+    source.reserve_samples(1)
+    source.save(rollout_id=10)
+    checkpoint_path = tmp_path / "rollout" / "global_dataset_state_dict_10.pt"
+    state = torch.load(checkpoint_path)
+    del state[missing_field]
+    torch.save(state, checkpoint_path)
+
+    restored = RolloutDataSource(args)
+    with pytest.raises(
+        ValueError,
+        match=rf"Checkpoint is missing source cursor fields: \['{missing_field}'\]\.",
+    ):
+        restored.load(rollout_id=10)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("sample_offset", True),
+        ("epoch_id", -1),
+        ("sample_group_index", 1.5),
+        ("sample_index", "2"),
+    ],
+)
+def test_load_rejects_invalid_versioned_cursor_value(
+    tmp_path: Path,
+    field: str,
+    value: object,
+) -> None:
+    args = _source_args(tmp_path)
+    source = RolloutDataSource(args)
+    source.reserve_samples(1)
+    source.save(rollout_id=10)
+    checkpoint_path = tmp_path / "rollout" / "global_dataset_state_dict_10.pt"
+    state = torch.load(checkpoint_path)
+    state[field] = value
+    torch.save(state, checkpoint_path)
+
+    restored = RolloutDataSource(args)
+    with pytest.raises(
+        ValueError,
+        match=rf"Checkpoint {field} must be a nonnegative integer, got {value!r}\.",
+    ):
+        restored.load(rollout_id=10)
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "expected_error"),
+    [
+        (
+            "sample_index",
+            0,
+            "Checkpoint sample frontier 0 does not match group frontier 1 with 2 samples per prompt.",
+        ),
+        (
+            "sample_offset",
+            5,
+            "Checkpoint sample offset 5 exceeds dataset size 4.",
+        ),
+        (
+            "epoch_id",
+            1,
+            "Checkpoint group frontier 1 does not match dataset cursor at epoch 1 offset 1 for dataset size 4.",
+        ),
+    ],
+)
+def test_load_rejects_inconsistent_versioned_cursor(
+    tmp_path: Path,
+    field: str,
+    value: int,
+    expected_error: str,
+) -> None:
+    args = _source_args(tmp_path)
+    source = RolloutDataSource(args)
+    source.reserve_samples(1)
+    source.save(rollout_id=10)
+    checkpoint_path = tmp_path / "rollout" / "global_dataset_state_dict_10.pt"
+    state = torch.load(checkpoint_path)
+    state[field] = value
+    torch.save(state, checkpoint_path)
+
+    restored = RolloutDataSource(args)
+    with pytest.raises(ValueError) as error:
+        restored.load(rollout_id=10)
+
+    assert str(error.value) == expected_error
+
+
+@pytest.mark.parametrize("group_index", [True, "1", 1.0])
+def test_load_rejects_coerced_replay_group_index(
+    tmp_path: Path,
+    group_index: object,
+) -> None:
+    args = _source_args(tmp_path)
+    source = RolloutDataSource(args)
+    source.reserve_samples(2)
+    source.save(rollout_id=10)
+    checkpoint_path = tmp_path / "rollout" / "global_dataset_state_dict_10.pt"
+    state = torch.load(checkpoint_path)
+    state["source_reservations"]["replay"][1]["group_index"] = group_index
+    torch.save(state, checkpoint_path)
+
+    restored = RolloutDataSource(args)
+    with pytest.raises(ValidationError, match="group_index"):
+        restored.load(rollout_id=10)
+
+
+def test_load_rejects_unknown_reservation_schema_version(tmp_path: Path) -> None:
+    args = _source_args(tmp_path)
+    source = RolloutDataSource(args)
+    source.reserve_samples(1)
+    source.save(rollout_id=10)
+    checkpoint_path = tmp_path / "rollout" / "global_dataset_state_dict_10.pt"
+    state = torch.load(checkpoint_path)
+    state["source_reservations"]["schema_version"] = 2
+    torch.save(state, checkpoint_path)
+
+    restored = RolloutDataSource(args)
+    with pytest.raises(ValidationError, match="schema_version"):
+        restored.load(rollout_id=10)
+
+
+def test_load_rejects_duplicate_replay_identity(tmp_path: Path) -> None:
+    args = _source_args(tmp_path)
+    source = RolloutDataSource(args)
+    source.reserve_samples(2)
+    source.save(rollout_id=10)
+    checkpoint_path = tmp_path / "rollout" / "global_dataset_state_dict_10.pt"
+    state = torch.load(checkpoint_path)
+    state["source_reservations"]["replay"][1]["group_index"] = 0
+    torch.save(state, checkpoint_path)
+
+    restored = RolloutDataSource(args)
+    with pytest.raises(
+        ValueError,
+        match=r"Checkpoint contains duplicate source reservation identities: \['0', '0'\]\.",
+    ):
+        restored.load(rollout_id=10)
+
+
+def test_load_rejects_replay_at_saved_frontier(tmp_path: Path) -> None:
+    args = _source_args(tmp_path)
+    source = RolloutDataSource(args)
+    source.reserve_samples(1)
+    source.save(rollout_id=10)
+    checkpoint_path = tmp_path / "rollout" / "global_dataset_state_dict_10.pt"
+    state = torch.load(checkpoint_path)
+    state["source_reservations"]["replay"][0]["group_index"] = 1
+    torch.save(state, checkpoint_path)
+
+    restored = RolloutDataSource(args)
+    with pytest.raises(
+        ValueError,
+        match="Checkpoint contains a source reservation outside the saved group frontier.",
+    ):
+        restored.load(rollout_id=10)
+
+
+def test_checkpoint_replays_acknowledgements_after_its_rollout_frontier(tmp_path: Path) -> None:
+    args = _source_args(tmp_path)
+    source = RolloutDataSource(args)
+    first, second, _ = source.reserve_samples(3)
+    source.acknowledge_reservations([first], rollout_id=5)
+    source.acknowledge_reservations([second], rollout_id=6)
+    source.save(rollout_id=5)
+
+    restored = RolloutDataSource(args)
+    restored.load(rollout_id=5)
+
+    assert restored.reserve_samples(2) == [
+        _reservation(1, prompt="bravo"),
+        _reservation(2, prompt="charlie"),
+    ]
+
+
+def test_acknowledge_rejects_published_rollout_id(tmp_path: Path) -> None:
+    args = _source_args(tmp_path)
+    source = RolloutDataSource(args)
+    first, second = source.reserve_samples(2)
+    source.save(rollout_id=5)
+
+    with pytest.raises(
+        ValueError,
+        match="Reservation rollout_id 5 must be newer than published checkpoint 5.",
+    ):
+        source.acknowledge_reservations([second], rollout_id=5)
+
+    source.acknowledge_reservations([first, second], rollout_id=6)
+    source.save(rollout_id=6)
+    restored = RolloutDataSource(args)
+    restored.load(rollout_id=6)
+    assert restored.reserve_samples(1) == [_reservation(2, prompt="charlie")]
+
+
+def test_save_rejects_rollout_id_regression(tmp_path: Path) -> None:
+    args = _source_args(tmp_path)
+    source = RolloutDataSource(args)
+    source.reserve_samples(1)
+    source.save(rollout_id=5)
+
+    with pytest.raises(
+        ValueError,
+        match="Source checkpoint rollout_id must not move backward from 5 to 4.",
+    ):
+        source.save(rollout_id=4)
+
+    restored = RolloutDataSource(args)
+    restored.load(rollout_id=5)
+    assert restored.reserve_samples(1) == [_reservation(0, prompt="alpha")]
+
+
+def test_legacy_save_rejects_acknowledgement_at_published_rollout_id(tmp_path: Path) -> None:
+    args = _source_args(tmp_path)
+    source = RolloutDataSource(args)
+    source.get_samples(1)
+    source.save(rollout_id=5)
+    reservation = source.reserve_samples(1)[0]
+
+    with pytest.raises(
+        ValueError,
+        match="Reservation rollout_id 5 must be newer than published checkpoint 5.",
+    ):
+        source.acknowledge_reservations([reservation], rollout_id=5)
+
+    source.acknowledge_reservations([reservation], rollout_id=6)
+
+
+def test_legacy_save_rejects_rollout_id_regression(tmp_path: Path) -> None:
+    source = RolloutDataSource(_source_args(tmp_path))
+    source.get_samples(1)
+    source.save(rollout_id=5)
+
+    with pytest.raises(
+        ValueError,
+        match="Source checkpoint rollout_id must not move backward from 5 to 4.",
+    ):
+        source.save(rollout_id=4)
+
+
+def test_legacy_source_save_preserves_checkpoint_format(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def reject_fingerprint(_source: RolloutDataSource) -> str:
+        raise AssertionError("legacy source use must not fingerprint prompt data")
+
+    monkeypatch.setattr(RolloutDataSource, "_processed_samples_sha256", reject_fingerprint)
+    args = _source_args(tmp_path)
+    source = RolloutDataSource(args)
+    assert source.get_samples(1) == [list(_reservation(0, prompt="alpha").samples)]
+
+    source.save(rollout_id=10)
+
+    checkpoint_path = tmp_path / "rollout" / "global_dataset_state_dict_10.pt"
+    assert torch.load(checkpoint_path) == {
+        "sample_offset": 1,
+        "epoch_id": 0,
+        "sample_group_index": 1,
+        "sample_index": 2,
+        "metadata": {},
+    }
+
+
+@pytest.mark.parametrize(
+    ("rollout_shuffle", "first_prompts", "restored_prompts"),
+    [
+        (False, ("alpha", "bravo", "charlie", "delta", "alpha"), ("bravo", "charlie", "delta")),
+        (True, ("alpha", "charlie", "delta", "bravo", "alpha"), ("delta", "charlie", "bravo")),
+    ],
+)
+def test_legacy_source_preserves_multi_epoch_order_across_restart(
+    tmp_path: Path,
+    rollout_shuffle: bool,
+    first_prompts: tuple[str, ...],
+    restored_prompts: tuple[str, ...],
+) -> None:
+    args = _source_args(tmp_path, rollout_shuffle=rollout_shuffle)
+    source = RolloutDataSource(args)
+
+    assert source.get_samples(5) == [
+        list(_reservation(group_index, prompt=prompt).samples) for group_index, prompt in enumerate(first_prompts)
+    ]
+    source.save(rollout_id=10)
+
+    restored = RolloutDataSource(args)
+    restored.load(rollout_id=10)
+    assert restored.get_samples(3) == [
+        list(_reservation(group_index, prompt=prompt).samples)
+        for group_index, prompt in enumerate(restored_prompts, start=5)
+    ]
+
+
+def test_shuffled_multi_epoch_reservations_reconstruct_exact_groups(tmp_path: Path) -> None:
+    args = _source_args(tmp_path, rollout_shuffle=True)
+    source = RolloutDataSource(args)
     reservations = source.reserve_samples(10)
     expected = copy.deepcopy(reservations)
     for reservation in reservations:
         reservation.samples[0].prompt = "mutated"
-    source.requeue_reservations(reservations)
+    source.save(rollout_id=11)
 
-    assert source.reserve_samples(10) == expected
+    restored = RolloutDataSource(args)
+    restored.load(rollout_id=11)
+
+    assert restored.reserve_samples(10) == expected
 
 
 def test_materialization_failure_does_not_advance_source(
@@ -237,35 +776,123 @@ def test_materialization_failure_does_not_advance_source(
     ]
 
 
-def test_non_persistent_source_rejects_durable_reservations(tmp_path: Path) -> None:
+def test_failed_save_preserves_previous_checkpoint(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     args = _source_args(tmp_path)
-    args.rollout_global_dataset = False
+    source = RolloutDataSource(args)
+    source.reserve_samples(1)
+    source.save(rollout_id=12)
+    source.reserve_samples(1)
+
+    def fail_after_partial_write(state: object, path: str) -> None:
+        Path(path).write_bytes(b"partial checkpoint")
+        raise RuntimeError("injected save failure")
+
+    monkeypatch.setattr(data_source_module.torch, "save", fail_after_partial_write)
+    with pytest.raises(RuntimeError, match="injected save failure"):
+        source.save(rollout_id=12)
+
+    restored = RolloutDataSource(args)
+    restored.load(rollout_id=12)
+    assert restored.reserve_samples(2) == [
+        _reservation(0, prompt="alpha"),
+        _reservation(1, prompt="bravo"),
+    ]
+
+
+def test_failed_checkpoint_replace_preserves_previous_checkpoint(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    args = _source_args(tmp_path)
+    source = RolloutDataSource(args)
+    source.reserve_samples(1)
+    source.save(rollout_id=12)
+    source.reserve_samples(1)
+
+    def fail_replace(_source_path: str, destination_path: str) -> None:
+        raise RuntimeError(f"injected replace failure for {destination_path}")
+
+    monkeypatch.setattr(data_source_module.os, "replace", fail_replace)
+    with pytest.raises(RuntimeError, match="injected replace failure"):
+        source.save(rollout_id=12)
+
+    restored = RolloutDataSource(args)
+    restored.load(rollout_id=12)
+    assert restored.reserve_samples(2) == [
+        _reservation(0, prompt="alpha"),
+        _reservation(1, prompt="bravo"),
+    ]
+
+
+def test_save_is_linearized_with_reservation_settlement(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    args = _source_args(tmp_path)
+    source = RolloutDataSource(args)
+    [first] = source.reserve_samples(1)
+    save_started = threading.Event()
+    allow_save = threading.Event()
+    settlement_started = threading.Event()
+    settlement_finished = threading.Event()
+    original_torch_save = torch.save
+
+    def blocking_save(state: object, path: str) -> None:
+        save_started.set()
+        assert allow_save.wait(timeout=5)
+        original_torch_save(state, path)
+
+    def settle_after_save_starts() -> None:
+        settlement_started.set()
+        source.acknowledge_reservations([first], rollout_id=1)
+        settlement_finished.set()
+
+    monkeypatch.setattr(data_source_module.torch, "save", blocking_save)
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        save_future = executor.submit(source.save, 0)
+        assert save_started.wait(timeout=5)
+        settlement_future = executor.submit(settle_after_save_starts)
+        assert settlement_started.wait(timeout=5)
+        assert not settlement_finished.wait(timeout=0.05)
+        allow_save.set()
+        save_future.result(timeout=5)
+        settlement_future.result(timeout=5)
+
+    restored = RolloutDataSource(args)
+    restored.load(rollout_id=0)
+    assert restored.reserve_samples(1) == [first]
+
+
+def test_no_checkpoint_mode_rejects_a_false_durable_save(tmp_path: Path) -> None:
+    args = _source_args(tmp_path)
+    args.save_interval = None
+    source = RolloutDataSource(args)
+    [reservation] = source.reserve_samples(1)
+    source.acknowledge_reservations([reservation], rollout_id=0)
+
+    with pytest.raises(
+        RuntimeError,
+        match="Cannot save durable source reservations without a configured save trigger.",
+    ):
+        source.save(rollout_id=0)
+
+
+def test_sentinel_only_checkpoint_rejects_durable_reservations(tmp_path: Path) -> None:
+    args = _source_args(tmp_path)
+    args.save_interval = None
+    args.save_trigger_sentinel = str(tmp_path / "save-trigger")
     source = RolloutDataSource(args)
 
     with pytest.raises(
         RuntimeError,
-        match="RolloutDataSource does not support durable source reservations when rollout_global_dataset is disabled.",
+        match="Durable source reservations require a periodic save interval when a save trigger is configured.",
     ):
         source.reserve_samples(1)
 
-
-def test_reservation_aware_save_fails_before_checkpoint_support(tmp_path: Path) -> None:
-    source = RolloutDataSource(_source_args(tmp_path))
-    first, second = source.reserve_samples(2)
-    source.acknowledge_reservations([first], rollout_id=0)
-    source.requeue_reservations([second])
-
-    with pytest.raises(
-        RuntimeError,
-        match=(
-            "Cannot save source state after durable source reservations have started "
-            "until reservation checkpointing is available."
-        ),
-    ):
-        source.save(rollout_id=0)
-
-    assert not (tmp_path / "rollout" / "global_dataset_state_dict_0.pt").exists()
-    assert source.reserve_samples(1) == [_reservation(1, prompt="bravo")]
+    assert source.get_samples(1) == [list(_reservation(0, prompt="alpha").samples)]
 
 
 def test_buffered_source_rejects_reservations_that_bypass_retry_buffer(tmp_path: Path) -> None:

--- a/tests/fast/utils/test_source_fingerprint.py
+++ b/tests/fast/utils/test_source_fingerprint.py
@@ -1,0 +1,76 @@
+import numpy
+import pytest
+import torch
+from PIL import Image
+
+from miles.utils.source_fingerprint import canonical_source_digest
+
+
+def test_canonical_source_digest_ignores_mapping_order() -> None:
+    first = {"prompt": "inspect", "metadata": {"left": 1, "right": 2}}
+    second = {"metadata": {"right": 2, "left": 1}, "prompt": "inspect"}
+
+    assert canonical_source_digest(first) == canonical_source_digest(second)
+
+
+def test_canonical_source_digest_distinguishes_value_types() -> None:
+    assert canonical_source_digest(True) != canonical_source_digest(1)
+    assert canonical_source_digest(b"1") != canonical_source_digest("1")
+    assert canonical_source_digest([1]) != canonical_source_digest((1,))
+
+
+def test_canonical_source_digest_normalizes_tensor_views() -> None:
+    tensor = torch.arange(6, dtype=torch.int64).reshape(2, 3)
+    noncontiguous = tensor.t().contiguous().t()
+
+    assert not noncontiguous.is_contiguous()
+    assert canonical_source_digest(tensor) == canonical_source_digest(noncontiguous)
+
+
+def test_canonical_source_digest_includes_image_payload() -> None:
+    first = Image.fromarray(numpy.array([[0, 1], [2, 3]], dtype=numpy.uint8))
+    second = Image.fromarray(numpy.array([[0, 1], [2, 4]], dtype=numpy.uint8))
+
+    assert canonical_source_digest(first) != canonical_source_digest(second)
+
+
+def test_canonical_source_digest_includes_image_metadata() -> None:
+    first = Image.new("RGB", (2, 1), color="red")
+    second = first.copy()
+    first.getexif()[274] = 1
+    second.getexif()[274] = 6
+    assert canonical_source_digest(first) != canonical_source_digest(second)
+
+    second.getexif()[274] = 1
+    first.info["icc_profile"] = b"first"
+    second.info["icc_profile"] = b"second"
+    assert canonical_source_digest(first) != canonical_source_digest(second)
+
+
+def test_canonical_source_digest_normalizes_object_arrays() -> None:
+    first = numpy.array([{"left": 1, "right": 2}, ["value"]], dtype=object)
+    second = numpy.array([{"right": 2, "left": 1}, ["value"]], dtype=object)
+
+    assert canonical_source_digest(first) == canonical_source_digest(second)
+
+
+def test_canonical_source_digest_includes_structured_dtype() -> None:
+    first = numpy.array([(1, 2)], dtype=[("left", "<i4"), ("right", "<i4")])
+    second = numpy.array([(1, 2)], dtype=[("right", "<i4"), ("left", "<i4")])
+
+    assert canonical_source_digest(first) != canonical_source_digest(second)
+
+
+def test_canonical_source_digest_rejects_quantized_tensors() -> None:
+    tensor = torch.quantize_per_tensor(torch.tensor([1.0]), scale=0.1, zero_point=0, dtype=torch.qint8)
+
+    with pytest.raises(TypeError, match="Cannot fingerprint quantized tensors."):
+        canonical_source_digest(tensor)
+
+
+def test_canonical_source_digest_rejects_unstable_values() -> None:
+    with pytest.raises(
+        TypeError,
+        match="Cannot fingerprint rollout source value of type builtins.object.",
+    ):
+        canonical_source_digest(object())


### PR DESCRIPTION
## Summary

- Persists unfinished source reservations in rollout checkpoints.
- Replays each unfinished group from its saved source position before admitting new work.
- Verifies source configuration and content before restoring ownership.

## Context

In-memory reservations do not survive a process restart. A checkpoint must record unfinished attempts, the source frontier, and enough identity information to prove that replay still refers to the same source data.

This layer extends the reservation contract from [#2249](https://github.com/radixark/miles/pull/2249). It saves outstanding work, verifies the source fingerprint from [#2247](https://github.com/radixark/miles/pull/2247), and reconstructs replay order before new groups are reserved.

[Issue #2254](https://github.com/radixark/miles/issues/2254) uses this checkpoint state to restore unfinished groups in source order.

| Layer | Upstream PR | Status | Contract |
| --- | --- | --- | --- |
| 1/6 | [#2247](https://github.com/radixark/miles/pull/2247) | Draft | Stable source fingerprint |
| 2/6 | [#2249](https://github.com/radixark/miles/pull/2249) | Draft | Source reservations |
| 3/6 | [#2250](https://github.com/radixark/miles/pull/2250) | Draft | Reservation persistence and replay |
| 4/6 | [#2251](https://github.com/radixark/miles/pull/2251) | Draft | Exact execution receipts |
| 5/6 | [#2252](https://github.com/radixark/miles/pull/2252) | Draft | Receipt-bound inference execution |
| 6/6 | [#2253](https://github.com/radixark/miles/pull/2253) | Draft | Terminal cancellation ownership |

All drafts target `main`, so GitHub shows the first two layers in this PR. Review this layer as the change after [#2249](https://github.com/radixark/miles/pull/2249). Merge the chain in order. If a parent is squash-merged or rebase-merged, the remaining branches will be rebased onto the updated `main`.

This PR adds one new commit: [`926adde3`, which persists and replays source reservations](https://github.com/radixark/miles/pull/2250/commits/926adde3cb9879debefc700a232d299be4613017). Review it against #2249. The contract requires a checkpoint to retain every unfinished group and restore it before new source admission.

## Description

- Saves outstanding, replayable, and acknowledged reservation state.
- Stores source configuration and source fingerprints needed for replay validation.
- Reconstructs the replay frontier in original source order.
- Replays unfinished attempts before reading new source groups.
- Linearizes checkpoint save with reservation acknowledgement and requeue.
- Records the legacy checkpoint frontier before durable acknowledgement begins.
- Rejects acknowledgement against an already published legacy checkpoint.
- Rejects a source checkpoint that moves backward.
- Preserves legacy checkpoint loading before reservation mode starts.
- Applies the same replay contract to the Multi-LoRA data source.

## Test plan

- [x] `tests/fast/rollout/test_data_source_reservations.py`: 70 reservation persistence and replay tests passed at exact head `27773124c` on `main` at `f2b7c7929`; four tests cover the configuration-aware `supports_source_reservations` value, and five cover resume into sources that cannot own reservations, which now fails at `load()`.
- [x] An exact composed 8xB200 validation restored reservations `0` and `1` from the saved source checkpoint before new admission and replayed them in the original order.
- [x] The composed 8xB200 run used Miles ref [`7cd212d81f`](https://github.com/ashtonchew/miles/commit/7cd212d81f6c94f72d67b4443e8c047008e4d517) with validation child [`cf512e6a8a`](https://github.com/GymPod/slime/commit/cf512e6a8a59c7c935e273dc69b9fd84c32e35a3). This evidence covers checkpoint replay in composition. Process-loss recovery and full training require separate evidence.



