### PR TITLE
test(ci): disable router-equivalence and MiniMax-M2.7 E2E

### DIFF
--- a/tests/e2e/sglang/test_r3_router_equivalence.py
+++ b/tests/e2e/sglang/test_r3_router_equivalence.py
@@ -2,7 +2,12 @@ from tests.ci.ci_register import register_cuda_ci
 
 # Two model families run sequentially in one job, so est_time is roughly 2x
 # of a single family.
-register_cuda_ci(est_time=1000, suite="stage-c-4-gpu-h200", labels=["sglang"])
+register_cuda_ci(
+    est_time=1100,
+    suite="stage-c-4-gpu-h200",
+    labels=["sglang"],
+    disabled="Miles Router is deprecated.",
+)
 
 """E2E test: verify sglang router and miles router produce identical rollout
 routing replay results across MoE models.

--- a/tests/e2e/sglang/test_session_server_multi_role/test_minimax_m27.py
+++ b/tests/e2e/sglang/test_session_server_multi_role/test_minimax_m27.py
@@ -11,7 +11,12 @@ from tests.ci.ci_register import register_cuda_ci
 from tests.ci.metric_history import register_ci_gate
 from tests.e2e.sglang.test_session_server_multi_role._common import ModelConfig, run_both_versions
 
-register_cuda_ci(est_time=600, suite="stage-c-4-gpu-h200", labels=["sglang"])
+register_cuda_ci(
+    est_time=800,
+    suite="stage-c-4-gpu-h200",
+    labels=["sglang"],
+    disabled="MiniMax-M2.7 is deprecated.",
+)
 register_ci_gate(metric_key="rollout/tito_session_mismatch_rate/v1/assistant_text")
 register_ci_gate(metric_key="rollout/tito_session_mismatch_rate/v2/assistant_text")
 


### PR DESCRIPTION
## Summary
Disable two deprecated SGLang E2E suites on stage-c-4-gpu-h200; registrations stay visible.

## Motivation
The stage-c-4-gpu-h200 lane still schedules two SGLang suites that no longer earn their GPU time: the router equivalence test exercises the deprecated Miles Router, and the MiniMax-M2.7 multi-role session test targets a deprecated model. Mark both registrations disabled so they stay visible in the registry without consuming CI capacity, and correct est_time to observed runtimes for when they are re-enabled.

## Usage
`run_suite.py` keeps `disabled` registrations out of the enabled set (`run_suite.py:79`) and reports each one as skipped with its reason (`run_suite.py:138`); both suites drop out of stage-c-4-gpu-h200 scheduling with their files intact.

## Design Notes
- **Key choices:** mark `register_cuda_ci` with `disabled="<reason>"` instead of deleting the test files.
- `est_time` is corrected to observed runtimes (1100 for router equivalence, 800 for MiniMax-M2.7) so a re-enable schedules accurately.

## Verification
- **Tests added:** none; existing `test_run_suite.py` asserts a disabled registration is always classified as skipped, never run.

## Review Focus
- Scrutinize the two `disabled` reasons in `test_r3_router_equivalence.py` / `test_minimax_m27.py`: confirm the intent is off entirely, not a move to nightly cadence.
