### PR TITLE
[AMD] Enable DeepSeek V4 FP8 CI on ROCm

### DIFF
--- a/scripts/run_deepseek_v4.py
+++ b/scripts/run_deepseek_v4.py
@@ -34,6 +34,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Literal
 
+import torch
 import typer
 
 import miles.utils.external_utils.command_utils as U
@@ -639,6 +640,9 @@ def _train(args: ScriptArgs):
         misc_args += "--transformer-impl transformer_engine " "--bf16 " "--fp8-format e4m3 " "--fp8-recipe mxfp8 "
     elif args.train_fp8:
         misc_args += "--transformer-impl transformer_engine " "--bf16 " "--fp8-format e4m3 " "--fp8-recipe blockwise "
+        if torch.version.hip is not None:
+            # ROCm TE grouped blockwise FP8 does not support fused wgrad accumulation.
+            misc_args += "--no-gradient-accumulation-fusion "
 
     if (args.train_fp8 or args.train_mxfp8) and "--te-precision-config-file" not in args.extra_args:
         misc_args += f"--te-precision-config-file " f"{U.save_to_temp_file(_DSV4_TE_PRECISION_CONFIG, 'yaml')} "

--- a/tests/e2e/megatron/model_scripts/test_deepseek_v4_flash_4layer_ci.py
+++ b/tests/e2e/megatron/model_scripts/test_deepseek_v4_flash_4layer_ci.py
@@ -9,7 +9,6 @@ register_rocm_ci(
     est_time=1900,
     suite="stage-c-4-gpu-mi300x",
     labels=["megatron", "model-scripts", "amd"],
-    disabled="Disable due to failure",
 )
 
 register_ci_gate(metric_key="train/grad_norm")


### PR DESCRIPTION
## Motivation

The DeepSeek V4 ROCm test had two blockers:

- Transformer Engine grouped blockwise FP8 does not support fused weight-gradient accumulation on ROCm.
- Weight validation reported false mismatches because SGLang interpreted AITER-shuffled FP8 weights as the logical layout and included non-persistent caches in snapshots. This is fixed by [sgl-project/sglang#34016](https://github.com/sgl-project/sglang/pull/34016).


## Changes

- Disable gradient accumulation fusion for HIP blockwise FP8 training (gated by `torch.version.hip`).
- Re-enable the DeepSeek V4 four-layer ROCm test `tests/e2e/megatron/model_scripts/test_deepseek_v4_flash_4layer_ci.py`.


## Testing

Passed the four-layer E2E test on MI355 with both rollouts completing and all checked FP8 weights reporting `num_exceed=0`.

Depends on [sgl-project/sglang#34016](https://github.com/sgl-project/sglang/pull/34016).