### PR TITLE
feat(session): render Anthropic message responses

### DIFF
--- a/miles/rollout/session/anthropic.py
+++ b/miles/rollout/session/anthropic.py
@@ -286,8 +286,8 @@ def _response_text_blocks(content: Any) -> list[dict[str, Any]]:
         return [{"type": "text", "text": str(content)}]
     blocks: list[dict[str, Any]] = []
     for part in content:
-        if isinstance(part, Mapping) and part.get("type") == "text" and isinstance(part.get("text"), str):
-            blocks.append({"type": "text", "text": part["text"]})
+        if isinstance(part, Mapping) and part.get("type") == "text" and isinstance(text := part.get("text"), str):
+            blocks.append({"type": "text", "text": text})
     return blocks
 
 
@@ -298,25 +298,21 @@ def openai_to_anthropic_response(response: Mapping[str, Any]) -> dict[str, Any]:
     Anthropic ``stop_sequence`` field cannot be reconstructed.
     """
     response = _require_mapping(response, "response")
-    choices = response.get("choices")
-    choice = choices[0] if isinstance(choices, list) and choices else {}
+    choice = choices[0] if isinstance(choices := response.get("choices"), list) and choices else {}
     choice = choice if isinstance(choice, Mapping) else {}
     message = choice.get("message")
     message = message if isinstance(message, Mapping) else {}
 
     content: list[dict[str, Any]] = []
-    reasoning_content = message.get("reasoning_content")
-    if isinstance(reasoning_content, str) and reasoning_content:
+    if isinstance(reasoning_content := message.get("reasoning_content"), str) and reasoning_content:
         content.append({"type": "thinking", "thinking": reasoning_content})
     content.extend(_response_text_blocks(message.get("content")))
 
-    tool_calls = message.get("tool_calls")
-    if isinstance(tool_calls, list):
+    if isinstance(tool_calls := message.get("tool_calls"), list):
         for raw_tool_call in tool_calls:
             if not isinstance(raw_tool_call, Mapping):
                 continue
-            function = raw_tool_call.get("function")
-            if not isinstance(function, Mapping):
+            if not isinstance(function := raw_tool_call.get("function"), Mapping):
                 continue
             arguments = function.get("arguments", "{}")
             try:
@@ -416,8 +412,7 @@ def openai_error_to_anthropic(status_code: int, payload: Any) -> dict[str, Any]:
     """Convert an OpenAI-style error body to Anthropic's error envelope."""
     message: Any = None
     if isinstance(payload, Mapping):
-        error = payload.get("error")
-        if isinstance(error, Mapping):
+        if isinstance(error := payload.get("error"), Mapping):
             message = error.get("message")
         elif isinstance(error, str):
             message = error

--- a/miles/rollout/session/anthropic.py
+++ b/miles/rollout/session/anthropic.py
@@ -292,7 +292,11 @@ def _response_text_blocks(content: Any) -> list[dict[str, Any]]:
 
 
 def openai_to_anthropic_response(response: Mapping[str, Any]) -> dict[str, Any]:
-    """Convert one complete OpenAI chat-completion response to Anthropic form."""
+    """Convert one complete OpenAI chat-completion response to Anthropic form.
+
+    OpenAI finish reasons do not identify which stop sequence matched, so the
+    Anthropic ``stop_sequence`` field cannot be reconstructed.
+    """
     response = _require_mapping(response, "response")
     choices = response.get("choices")
     choice = choices[0] if isinstance(choices, list) and choices else {}
@@ -369,6 +373,7 @@ def render_anthropic_sse(response: Mapping[str, Any]) -> bytes:
             start_block = {"type": "text", "text": ""}
             delta = {"type": "text_delta", "text": block["text"]}
         elif block_type == "thinking":
+            # Miles has reasoning text but no Anthropic signature to replay as a signature_delta.
             start_block = {"type": "thinking", "thinking": ""}
             delta = {"type": "thinking_delta", "thinking": block["thinking"]}
         else:
@@ -427,8 +432,12 @@ def openai_error_to_anthropic(status_code: int, payload: Any) -> dict[str, Any]:
         error_type = "permission_error"
     elif status_code == 404:
         error_type = "not_found_error"
+    elif status_code == 413:
+        error_type = "request_too_large"
     elif status_code == 429:
         error_type = "rate_limit_error"
+    elif status_code == 529:
+        error_type = "overloaded_error"
     elif 400 <= status_code < 500:
         error_type = "invalid_request_error"
     else:

--- a/miles/rollout/session/anthropic.py
+++ b/miles/rollout/session/anthropic.py
@@ -8,12 +8,20 @@ isolation.
 """
 
 import json
+import uuid
 from collections.abc import Mapping
 from typing import Any
 
 
 class AnthropicProtocolError(ValueError):
     """Raised when an Anthropic request cannot be represented faithfully."""
+
+
+_STOP_REASON_MAP = {
+    "stop": "end_turn",
+    "length": "max_tokens",
+    "tool_calls": "tool_use",
+}
 
 
 def _require_mapping(value: Any, name: str) -> Mapping[str, Any]:
@@ -267,3 +275,162 @@ def anthropic_to_openai_request(request: Mapping[str, Any]) -> dict[str, Any]:
     if (tool_choice := _convert_tool_choice(request.get("tool_choice"), tools)) is not None:
         converted["tool_choice"] = tool_choice
     return converted
+
+
+def _response_text_blocks(content: Any) -> list[dict[str, Any]]:
+    if content is None:
+        return []
+    if isinstance(content, str):
+        return [{"type": "text", "text": content}] if content else []
+    if not isinstance(content, list):
+        return [{"type": "text", "text": str(content)}]
+    blocks: list[dict[str, Any]] = []
+    for part in content:
+        if isinstance(part, Mapping) and part.get("type") == "text" and isinstance(part.get("text"), str):
+            blocks.append({"type": "text", "text": part["text"]})
+    return blocks
+
+
+def openai_to_anthropic_response(response: Mapping[str, Any]) -> dict[str, Any]:
+    """Convert one complete OpenAI chat-completion response to Anthropic form."""
+    response = _require_mapping(response, "response")
+    choices = response.get("choices")
+    choice = choices[0] if isinstance(choices, list) and choices else {}
+    choice = choice if isinstance(choice, Mapping) else {}
+    message = choice.get("message")
+    message = message if isinstance(message, Mapping) else {}
+
+    content: list[dict[str, Any]] = []
+    reasoning_content = message.get("reasoning_content")
+    if isinstance(reasoning_content, str) and reasoning_content:
+        content.append({"type": "thinking", "thinking": reasoning_content})
+    content.extend(_response_text_blocks(message.get("content")))
+
+    tool_calls = message.get("tool_calls")
+    if isinstance(tool_calls, list):
+        for raw_tool_call in tool_calls:
+            if not isinstance(raw_tool_call, Mapping):
+                continue
+            function = raw_tool_call.get("function")
+            if not isinstance(function, Mapping):
+                continue
+            arguments = function.get("arguments", "{}")
+            try:
+                tool_input = json.loads(arguments) if isinstance(arguments, str) else arguments
+            except json.JSONDecodeError:
+                tool_input = {}
+            if not isinstance(tool_input, Mapping):
+                tool_input = {}
+            content.append(
+                {
+                    "type": "tool_use",
+                    "id": str(raw_tool_call.get("id") or f"toolu_{uuid.uuid4().hex}"),
+                    "name": str(function.get("name") or ""),
+                    "input": dict(tool_input),
+                }
+            )
+
+    if not content:
+        content.append({"type": "text", "text": ""})
+
+    usage = response.get("usage")
+    usage = usage if isinstance(usage, Mapping) else {}
+    finish_reason = choice.get("finish_reason") or "stop"
+    return {
+        "id": f"msg_{uuid.uuid4().hex}",
+        "type": "message",
+        "role": "assistant",
+        "content": content,
+        "model": str(response.get("model") or ""),
+        "stop_reason": _STOP_REASON_MAP.get(finish_reason, "end_turn"),
+        "stop_sequence": None,
+        "usage": {
+            "input_tokens": int(usage.get("prompt_tokens") or 0),
+            "output_tokens": int(usage.get("completion_tokens") or 0),
+        },
+    }
+
+
+def _sse_event(event_type: str, payload: Mapping[str, Any]) -> bytes:
+    data = json.dumps(payload, ensure_ascii=False, allow_nan=False, separators=(",", ":"))
+    return f"event: {event_type}\ndata: {data}\n\n".encode()
+
+
+def render_anthropic_sse(response: Mapping[str, Any]) -> bytes:
+    """Render a complete Anthropic response as one protocol-valid SSE stream."""
+    message = openai_to_anthropic_response(response)
+    start_message = {**message, "content": [], "stop_reason": None, "stop_sequence": None}
+    start_message["usage"] = {**message["usage"], "output_tokens": 0}
+    events = [_sse_event("message_start", {"type": "message_start", "message": start_message})]
+
+    for index, block in enumerate(message["content"]):
+        block_type = block["type"]
+        if block_type == "text":
+            start_block = {"type": "text", "text": ""}
+            delta = {"type": "text_delta", "text": block["text"]}
+        elif block_type == "thinking":
+            start_block = {"type": "thinking", "thinking": ""}
+            delta = {"type": "thinking_delta", "thinking": block["thinking"]}
+        else:
+            start_block = {"type": "tool_use", "id": block["id"], "name": block["name"], "input": {}}
+            delta = {
+                "type": "input_json_delta",
+                "partial_json": json.dumps(block["input"], ensure_ascii=False, separators=(",", ":")),
+            }
+        events.append(
+            _sse_event(
+                "content_block_start",
+                {"type": "content_block_start", "index": index, "content_block": start_block},
+            )
+        )
+        delta_content = delta.get("text") or delta.get("thinking") or delta.get("partial_json")
+        if block_type == "tool_use" or delta_content:
+            events.append(
+                _sse_event(
+                    "content_block_delta",
+                    {"type": "content_block_delta", "index": index, "delta": delta},
+                )
+            )
+        events.append(_sse_event("content_block_stop", {"type": "content_block_stop", "index": index}))
+
+    events.append(
+        _sse_event(
+            "message_delta",
+            {
+                "type": "message_delta",
+                "delta": {"stop_reason": message["stop_reason"], "stop_sequence": message["stop_sequence"]},
+                "usage": {"output_tokens": message["usage"]["output_tokens"]},
+            },
+        )
+    )
+    events.append(_sse_event("message_stop", {"type": "message_stop"}))
+    return b"".join(events)
+
+
+def openai_error_to_anthropic(status_code: int, payload: Any) -> dict[str, Any]:
+    """Convert an OpenAI-style error body to Anthropic's error envelope."""
+    message: Any = None
+    if isinstance(payload, Mapping):
+        error = payload.get("error")
+        if isinstance(error, Mapping):
+            message = error.get("message")
+        elif isinstance(error, str):
+            message = error
+        if message is None:
+            message = payload.get("message")
+    if not isinstance(message, str) or not message:
+        message = f"Upstream request failed with status {status_code}"
+
+    if status_code == 401:
+        error_type = "authentication_error"
+    elif status_code == 403:
+        error_type = "permission_error"
+    elif status_code == 404:
+        error_type = "not_found_error"
+    elif status_code == 429:
+        error_type = "rate_limit_error"
+    elif 400 <= status_code < 500:
+        error_type = "invalid_request_error"
+    else:
+        error_type = "api_error"
+    return {"type": "error", "error": {"type": error_type, "message": message}}

--- a/miles/rollout/session/anthropic.py
+++ b/miles/rollout/session/anthropic.py
@@ -291,6 +291,17 @@ def _response_text_blocks(content: Any) -> list[dict[str, Any]]:
     return blocks
 
 
+def _parse_tool_input(arguments: Any) -> dict[str, Any]:
+    try:
+        tool_input = json.loads(arguments) if isinstance(arguments, str) else arguments
+        if not isinstance(tool_input, Mapping):
+            return {}
+        json.dumps(tool_input, allow_nan=False)
+    except (json.JSONDecodeError, TypeError, ValueError):
+        return {}
+    return dict(tool_input)
+
+
 def openai_to_anthropic_response(response: Mapping[str, Any]) -> dict[str, Any]:
     """Convert one complete OpenAI chat-completion response to Anthropic form.
 
@@ -300,6 +311,9 @@ def openai_to_anthropic_response(response: Mapping[str, Any]) -> dict[str, Any]:
     response = _require_mapping(response, "response")
     choice = choices[0] if isinstance(choices := response.get("choices"), list) and choices else {}
     choice = choice if isinstance(choice, Mapping) else {}
+    finish_reason = choice.get("finish_reason") or "stop"
+    if finish_reason == "abort":
+        raise AnthropicProtocolError("upstream generation was aborted")
     message = choice.get("message")
     message = message if isinstance(message, Mapping) else {}
 
@@ -314,19 +328,12 @@ def openai_to_anthropic_response(response: Mapping[str, Any]) -> dict[str, Any]:
                 continue
             if not isinstance(function := raw_tool_call.get("function"), Mapping):
                 continue
-            arguments = function.get("arguments", "{}")
-            try:
-                tool_input = json.loads(arguments) if isinstance(arguments, str) else arguments
-            except json.JSONDecodeError:
-                tool_input = {}
-            if not isinstance(tool_input, Mapping):
-                tool_input = {}
             content.append(
                 {
                     "type": "tool_use",
                     "id": str(raw_tool_call.get("id") or f"toolu_{uuid.uuid4().hex}"),
                     "name": str(function.get("name") or ""),
-                    "input": dict(tool_input),
+                    "input": _parse_tool_input(function.get("arguments", "{}")),
                 }
             )
 
@@ -335,14 +342,16 @@ def openai_to_anthropic_response(response: Mapping[str, Any]) -> dict[str, Any]:
 
     usage = response.get("usage")
     usage = usage if isinstance(usage, Mapping) else {}
-    finish_reason = choice.get("finish_reason") or "stop"
+    stop_reason = _STOP_REASON_MAP.get(finish_reason, "end_turn")
+    if stop_reason == "end_turn" and any(block["type"] == "tool_use" for block in content):
+        stop_reason = "tool_use"
     return {
         "id": f"msg_{uuid.uuid4().hex}",
         "type": "message",
         "role": "assistant",
         "content": content,
         "model": str(response.get("model") or ""),
-        "stop_reason": _STOP_REASON_MAP.get(finish_reason, "end_turn"),
+        "stop_reason": stop_reason,
         "stop_sequence": None,
         "usage": {
             "input_tokens": int(usage.get("prompt_tokens") or 0),

--- a/miles/rollout/session/anthropic.py
+++ b/miles/rollout/session/anthropic.py
@@ -17,6 +17,10 @@ class AnthropicProtocolError(ValueError):
     """Raised when an Anthropic request cannot be represented faithfully."""
 
 
+class AnthropicGenerationAbortedError(AnthropicProtocolError):
+    """Raised when Miles aborts an in-flight upstream generation."""
+
+
 _STOP_REASON_MAP = {
     "stop": "end_turn",
     "length": "max_tokens",
@@ -313,7 +317,7 @@ def openai_to_anthropic_response(response: Mapping[str, Any]) -> dict[str, Any]:
     choice = choice if isinstance(choice, Mapping) else {}
     finish_reason = choice.get("finish_reason") or "stop"
     if finish_reason == "abort":
-        raise AnthropicProtocolError("upstream generation was aborted")
+        raise AnthropicGenerationAbortedError("upstream generation was aborted")
     message = choice.get("message")
     message = message if isinstance(message, Mapping) else {}
 

--- a/tests/fast/rollout/session/test_anthropic_protocol.py
+++ b/tests/fast/rollout/session/test_anthropic_protocol.py
@@ -503,7 +503,14 @@ def test_stream_has_protocol_order_for_text_and_tool_use() -> None:
 
 @pytest.mark.parametrize(
     ("status_code", "expected_type"),
-    [(400, "invalid_request_error"), (401, "authentication_error"), (403, "permission_error"), (404, "not_found_error"), (429, "rate_limit_error"), (500, "api_error")],
+    [
+        (400, "invalid_request_error"),
+        (401, "authentication_error"),
+        (403, "permission_error"),
+        (404, "not_found_error"),
+        (429, "rate_limit_error"),
+        (500, "api_error"),
+    ],
 )
 def test_error_conversion(status_code: int, expected_type: str) -> None:
     converted = openai_error_to_anthropic(status_code, {"error": {"message": "bad request"}})

--- a/tests/fast/rollout/session/test_anthropic_protocol.py
+++ b/tests/fast/rollout/session/test_anthropic_protocol.py
@@ -454,7 +454,7 @@ def test_response_converts_reasoning_text_tools_and_usage() -> None:
         {"type": "text", "text": "Running a command."},
         {"type": "tool_use", "id": "toolu_1", "name": "bash", "input": {"command": "pwd"}},
     ]
-    assert converted["stop_reason"] == "end_turn"
+    assert converted["stop_reason"] == "tool_use"
     assert converted["usage"] == {"input_tokens": 11, "output_tokens": 7}
 
 
@@ -473,6 +473,7 @@ def test_response_converts_null_content_tool_call() -> None:
     )
 
     assert converted["content"] == [{"type": "tool_use", "id": "toolu_1", "name": "bash", "input": {"command": "pwd"}}]
+    assert converted["stop_reason"] == "tool_use"
 
 
 def test_response_skips_malformed_tool_calls_and_sanitizes_arguments() -> None:
@@ -523,6 +524,16 @@ def test_response_maps_tool_and_length_stop_reasons() -> None:
     assert openai_to_anthropic_response(length_response)["stop_reason"] == "max_tokens"
 
 
+def test_response_rejects_aborted_generation() -> None:
+    response = _response()
+    response["choices"][0]["finish_reason"] = "abort"
+
+    with pytest.raises(AnthropicProtocolError, match="upstream generation was aborted"):
+        openai_to_anthropic_response(response)
+    with pytest.raises(AnthropicProtocolError, match="upstream generation was aborted"):
+        render_anthropic_sse(response)
+
+
 def test_stream_has_protocol_order_for_text_and_tool_use() -> None:
     events = _parse_sse(
         render_anthropic_sse(
@@ -552,8 +563,28 @@ def test_stream_has_protocol_order_for_text_and_tool_use() -> None:
     ]
     assert events[4][1]["content_block"]["type"] == "tool_use"
     assert events[5][1]["delta"] == {"type": "input_json_delta", "partial_json": '{"command":"pwd"}'}
-    assert events[-2][1]["delta"]["stop_reason"] == "end_turn"
+    assert events[-2][1]["delta"]["stop_reason"] == "tool_use"
     assert events[-2][1]["usage"] == {"output_tokens": 7}
+
+
+def test_stream_sanitizes_non_finite_tool_arguments() -> None:
+    events = _parse_sse(
+        render_anthropic_sse(
+            _response(
+                content=None,
+                tool_calls=[
+                    {
+                        "id": "toolu_nan",
+                        "type": "function",
+                        "function": {"name": "bash", "arguments": '{"timeout":NaN}'},
+                    }
+                ],
+            )
+        )
+    )
+
+    tool_delta = next(payload["delta"] for event_type, payload in events if event_type == "content_block_delta")
+    assert tool_delta == {"type": "input_json_delta", "partial_json": "{}"}
 
 
 def test_stream_emits_thinking_delta() -> None:

--- a/tests/fast/rollout/session/test_anthropic_protocol.py
+++ b/tests/fast/rollout/session/test_anthropic_protocol.py
@@ -1,6 +1,14 @@
+import json
+
 import pytest
 
-from miles.rollout.session.anthropic import AnthropicProtocolError, anthropic_to_openai_request
+from miles.rollout.session.anthropic import (
+    AnthropicProtocolError,
+    anthropic_to_openai_request,
+    openai_error_to_anthropic,
+    openai_to_anthropic_response,
+    render_anthropic_sse,
+)
 
 
 def _request(**overrides: object) -> dict[str, object]:
@@ -11,6 +19,25 @@ def _request(**overrides: object) -> dict[str, object]:
     }
     request.update(overrides)
     return request
+
+
+def _response(**message_overrides: object) -> dict:
+    message = {"role": "assistant", "content": "hello back"}
+    message.update(message_overrides)
+    return {
+        "id": "chatcmpl-1",
+        "model": "glm-4.7-flash",
+        "choices": [{"index": 0, "message": message, "finish_reason": "stop"}],
+        "usage": {"prompt_tokens": 11, "completion_tokens": 7, "total_tokens": 18},
+    }
+
+
+def _parse_sse(body: bytes) -> list[tuple[str, dict]]:
+    events = []
+    for frame in body.decode().strip().split("\n\n"):
+        event_line, data_line = frame.splitlines()
+        events.append((event_line.removeprefix("event: "), json.loads(data_line.removeprefix("data: "))))
+    return events
 
 
 def test_request_converts_system_sampling_and_tools() -> None:
@@ -403,3 +430,81 @@ def test_request_rejects_unrepresentable_inputs(payload: object, error: str) -> 
         anthropic_to_openai_request(payload)
 
     assert error in str(exc_info.value)
+
+
+def test_response_converts_reasoning_text_tools_and_usage() -> None:
+    converted = openai_to_anthropic_response(
+        _response(
+            reasoning_content="I should inspect it.",
+            content="Running a command.",
+            tool_calls=[
+                {
+                    "id": "toolu_1",
+                    "type": "function",
+                    "function": {"name": "bash", "arguments": '{"command":"pwd"}'},
+                }
+            ],
+        )
+    )
+
+    assert converted["id"].startswith("msg_")
+    assert converted["type"] == "message"
+    assert converted["content"] == [
+        {"type": "thinking", "thinking": "I should inspect it."},
+        {"type": "text", "text": "Running a command."},
+        {"type": "tool_use", "id": "toolu_1", "name": "bash", "input": {"command": "pwd"}},
+    ]
+    assert converted["stop_reason"] == "end_turn"
+    assert converted["usage"] == {"input_tokens": 11, "output_tokens": 7}
+
+
+def test_response_maps_tool_and_length_stop_reasons() -> None:
+    tool_response = _response(tool_calls=[])
+    tool_response["choices"][0]["finish_reason"] = "tool_calls"
+    length_response = _response()
+    length_response["choices"][0]["finish_reason"] = "length"
+
+    assert openai_to_anthropic_response(tool_response)["stop_reason"] == "tool_use"
+    assert openai_to_anthropic_response(length_response)["stop_reason"] == "max_tokens"
+
+
+def test_stream_has_protocol_order_for_text_and_tool_use() -> None:
+    events = _parse_sse(
+        render_anthropic_sse(
+            _response(
+                content="Running.",
+                tool_calls=[
+                    {
+                        "id": "toolu_1",
+                        "type": "function",
+                        "function": {"name": "bash", "arguments": '{"command":"pwd"}'},
+                    }
+                ],
+            )
+        )
+    )
+
+    assert [event_type for event_type, _ in events] == [
+        "message_start",
+        "content_block_start",
+        "content_block_delta",
+        "content_block_stop",
+        "content_block_start",
+        "content_block_delta",
+        "content_block_stop",
+        "message_delta",
+        "message_stop",
+    ]
+    assert events[4][1]["content_block"]["type"] == "tool_use"
+    assert events[5][1]["delta"] == {"type": "input_json_delta", "partial_json": '{"command":"pwd"}'}
+    assert events[-2][1]["delta"]["stop_reason"] == "end_turn"
+    assert events[-2][1]["usage"] == {"output_tokens": 7}
+
+
+@pytest.mark.parametrize(
+    ("status_code", "expected_type"),
+    [(400, "invalid_request_error"), (401, "authentication_error"), (403, "permission_error"), (404, "not_found_error"), (429, "rate_limit_error"), (500, "api_error")],
+)
+def test_error_conversion(status_code: int, expected_type: str) -> None:
+    converted = openai_error_to_anthropic(status_code, {"error": {"message": "bad request"}})
+    assert converted == {"type": "error", "error": {"type": expected_type, "message": "bad request"}}

--- a/tests/fast/rollout/session/test_anthropic_protocol.py
+++ b/tests/fast/rollout/session/test_anthropic_protocol.py
@@ -458,6 +458,61 @@ def test_response_converts_reasoning_text_tools_and_usage() -> None:
     assert converted["usage"] == {"input_tokens": 11, "output_tokens": 7}
 
 
+def test_response_converts_null_content_tool_call() -> None:
+    converted = openai_to_anthropic_response(
+        _response(
+            content=None,
+            tool_calls=[
+                {
+                    "id": "toolu_1",
+                    "type": "function",
+                    "function": {"name": "bash", "arguments": '{"command":"pwd"}'},
+                }
+            ],
+        )
+    )
+
+    assert converted["content"] == [{"type": "tool_use", "id": "toolu_1", "name": "bash", "input": {"command": "pwd"}}]
+
+
+def test_response_skips_malformed_tool_calls_and_sanitizes_arguments() -> None:
+    converted = openai_to_anthropic_response(
+        _response(
+            content=None,
+            tool_calls=[
+                None,
+                {"id": "bad_function", "function": None},
+                {"id": "bad_json", "function": {"name": "bash", "arguments": "{"}},
+                {"id": "array_json", "function": {"name": "bash", "arguments": "[]"}},
+            ],
+        )
+    )
+
+    assert converted["content"] == [
+        {"type": "tool_use", "id": "bad_json", "name": "bash", "input": {}},
+        {"type": "tool_use", "id": "array_json", "name": "bash", "input": {}},
+    ]
+
+
+@pytest.mark.parametrize(
+    ("content", "expected"),
+    [
+        (42, [{"type": "text", "text": "42"}]),
+        (
+            [
+                {"type": "text", "text": "kept"},
+                {"type": "image_url", "image_url": {"url": "ignored"}},
+                {"type": "text", "text": 42},
+                None,
+            ],
+            [{"type": "text", "text": "kept"}],
+        ),
+    ],
+)
+def test_response_normalizes_openai_content_parts(content: object, expected: list[dict[str, str]]) -> None:
+    assert openai_to_anthropic_response(_response(content=content))["content"] == expected
+
+
 def test_response_maps_tool_and_length_stop_reasons() -> None:
     tool_response = _response(tool_calls=[])
     tool_response["choices"][0]["finish_reason"] = "tool_calls"
@@ -501,6 +556,34 @@ def test_stream_has_protocol_order_for_text_and_tool_use() -> None:
     assert events[-2][1]["usage"] == {"output_tokens": 7}
 
 
+def test_stream_emits_thinking_delta() -> None:
+    events = _parse_sse(render_anthropic_sse(_response(reasoning_content="Think first.", content=None)))
+
+    assert [event_type for event_type, _ in events] == [
+        "message_start",
+        "content_block_start",
+        "content_block_delta",
+        "content_block_stop",
+        "message_delta",
+        "message_stop",
+    ]
+    assert events[1][1]["content_block"] == {"type": "thinking", "thinking": ""}
+    assert events[2][1]["delta"] == {"type": "thinking_delta", "thinking": "Think first."}
+
+
+def test_stream_omits_delta_for_empty_content_fallback() -> None:
+    events = _parse_sse(render_anthropic_sse(_response(content="")))
+
+    assert [event_type for event_type, _ in events] == [
+        "message_start",
+        "content_block_start",
+        "content_block_stop",
+        "message_delta",
+        "message_stop",
+    ]
+    assert events[1][1]["content_block"] == {"type": "text", "text": ""}
+
+
 @pytest.mark.parametrize(
     ("status_code", "expected_type"),
     [
@@ -508,10 +591,28 @@ def test_stream_has_protocol_order_for_text_and_tool_use() -> None:
         (401, "authentication_error"),
         (403, "permission_error"),
         (404, "not_found_error"),
+        (413, "request_too_large"),
         (429, "rate_limit_error"),
         (500, "api_error"),
+        (503, "api_error"),
+        (529, "overloaded_error"),
     ],
 )
 def test_error_conversion(status_code: int, expected_type: str) -> None:
     converted = openai_error_to_anthropic(status_code, {"error": {"message": "bad request"}})
     assert converted == {"type": "error", "error": {"type": expected_type, "message": "bad request"}}
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected_message"),
+    [
+        ({"error": "string error"}, "string error"),
+        ({"message": "top-level message"}, "top-level message"),
+        ("not an object", "Upstream request failed with status 500"),
+        ({"error": {}}, "Upstream request failed with status 500"),
+    ],
+)
+def test_error_conversion_message_fallbacks(payload: object, expected_message: str) -> None:
+    converted = openai_error_to_anthropic(500, payload)
+
+    assert converted["error"]["message"] == expected_message

--- a/tests/fast/rollout/session/test_anthropic_protocol.py
+++ b/tests/fast/rollout/session/test_anthropic_protocol.py
@@ -3,6 +3,7 @@ import json
 import pytest
 
 from miles.rollout.session.anthropic import (
+    AnthropicGenerationAbortedError,
     AnthropicProtocolError,
     anthropic_to_openai_request,
     openai_error_to_anthropic,
@@ -528,9 +529,9 @@ def test_response_rejects_aborted_generation() -> None:
     response = _response()
     response["choices"][0]["finish_reason"] = "abort"
 
-    with pytest.raises(AnthropicProtocolError, match="upstream generation was aborted"):
+    with pytest.raises(AnthropicGenerationAbortedError, match="upstream generation was aborted"):
         openai_to_anthropic_response(response)
-    with pytest.raises(AnthropicProtocolError, match="upstream generation was aborted"):
+    with pytest.raises(AnthropicGenerationAbortedError, match="upstream generation was aborted"):
         render_anthropic_sse(response)
 
 


### PR DESCRIPTION
## Summary

- convert complete OpenAI chat-completion responses into Anthropic Messages responses
- preserve reasoning, text, tool calls, stop reasons, and token usage
- synthesize protocol-valid Anthropic SSE streams from Miles's complete recorded response
- reject aborted generations with a dedicated `AnthropicGenerationAbortedError` instead of disguising them as successful `end_turn` responses
- guarantee `tool_use` when a completed response contains tool-use blocks, even if upstream reports `finish_reason: stop`
- sanitize malformed and non-finite tool arguments before SSE serialization
- translate upstream errors into Anthropic error envelopes, including Anthropic-specific 413 `request_too_large` and 529 `overloaded_error` types
- use assignment expressions for response fields that are fetched and immediately validated

## Why

Miles deliberately keeps the SGLang request non-streaming so TITO can record complete token and log-probability metadata. Claude Code still expects Anthropic streaming events. This layer renders a complete recorded response as a valid `message_start` / content blocks / `message_delta` / `message_stop` stream.

An aborted Miles generation is incomplete training data. The converter raises the dedicated `AnthropicGenerationAbortedError` for `finish_reason: abort`, allowing the session route to make only that condition retryable without catching unrelated protocol failures.

## Protocol decisions

- a successful upstream response with no representable content remains a protocol-valid empty text response; HTTP failure detection and non-2xx propagation belong to the session route
- Miles receives reasoning text but no Anthropic thinking signature, so it cannot emit `signature_delta`
- OpenAI finish reasons do not identify which stop sequence matched, so `stop_sequence` remains `null`

## Stack

PR 2 of 4, stacked on #2259. The remaining PRs add the `/v1/messages` session route and Miles-owned sampling overrides.

## Tests

`python -m pytest tests/fast/rollout/session/test_anthropic_protocol.py`

`uvx pre-commit run --files miles/rollout/session/anthropic.py tests/fast/rollout/session/test_anthropic_protocol.py`

- all 62 protocol tests pass locally
- isolated coverage for `miles/rollout/session/anthropic.py`: 285/285 statements and 174/174 branches (100%)
- regression coverage includes the dedicated abort exception, `stop` plus tool calls, and non-finite JSON arguments rendered through SSE
