### PR TITLE
feat(session): serve Anthropic messages through sessions

### DIFF
--- a/docs/user-guide/rollout-endpoints.md
+++ b/docs/user-guide/rollout-endpoints.md
@@ -1,19 +1,20 @@
 ---
 title: Rollout Endpoints
-description: How Miles talks to SGLang. The /generate endpoint and the OpenAI-format /v1/chat/completions endpoint.
+description: How Miles talks to SGLang through /generate, OpenAI chat completions, and Anthropic Messages.
 ---
-Miles supports two ways for a custom rollout function to talk to SGLang. The
+Miles supports three ways for a custom rollout function to talk to SGLang. The
 `/generate` endpoint is the most direct interface; you control tokenization. The
 OpenAI-format `/v1/chat/completions` endpoint is router-session aware and fits
-agent loops with multi-turn dialogue.
+agent loops with multi-turn dialogue. The Anthropic-format `/v1/messages`
+endpoint uses the same recorded session path for agents such as Claude Code.
 
-| | `/generate` | OpenAI `/v1/chat/completions` |
-|---|---|---|
-| Input | Text or tokens | `messages` list |
-| Tokenization | Your code | SGLang |
-| Session state | Stateless | Router sessions (base_url includes `/sessions/<id>`) |
-| Best for | Tool use with custom token handling, benchmarking | Agentic loops, multi-turn dialogue |
-| Reference generator | `generate_hub/single_turn.py`, `generate_hub/multi_turn.py` | `generate_hub/agentic_tool_call.py` |
+| | `/generate` | OpenAI `/v1/chat/completions` | Anthropic `/v1/messages` |
+|---|---|---|---|
+| Input | Text or tokens | OpenAI `messages` | Anthropic `messages` and content blocks |
+| Tokenization | Your code | SGLang | SGLang |
+| Session state | Stateless | Router sessions (base_url includes `/sessions/<id>`) | Same router sessions |
+| Best for | Tool use with custom token handling, benchmarking | OpenAI-compatible agent loops | Claude Code and Anthropic-compatible agent loops |
+| Reference generator | `generate_hub/single_turn.py`, `generate_hub/multi_turn.py` | `generate_hub/agentic_tool_call.py` | Custom agent through `agentic_tool_call.py` |
 
 Both entry points are wired up through `--custom-generate-function-path`.
 
@@ -142,6 +143,24 @@ Standard OpenAI format:
   "return_prompt_token_ids": true
 }
 ```
+
+### Anthropic Messages for Claude Code
+
+Send Anthropic-format requests to the same session-scoped base URL:
+
+```text
+POST <base_url>/v1/messages
+```
+
+Miles translates system, text, image, thinking, tool-use, and tool-result blocks
+to an OpenAI chat-completion request. It then translates the recorded response
+back to Anthropic JSON or server-sent events. The internal request still passes
+through the normal session recorder, so TITO checks, logprobs, retries, and v2
+trajectory branching behave the same as they do for `/v1/chat/completions`.
+
+Anthropic server-side tools and redacted-thinking history are rejected with an
+Anthropic-format `invalid_request_error` because they cannot be represented by
+the SGLang chat-completion interface.
 
 <Warning>
 

--- a/miles/rollout/session/anthropic.py
+++ b/miles/rollout/session/anthropic.py
@@ -243,6 +243,59 @@ def _convert_tool_choice(tool_choice: Any, tools: list[dict[str, Any]] | None) -
     raise AnthropicProtocolError(f"unsupported tool_choice type: {choice_type!r}")
 
 
+def _json_text_matches(left: str, right: str) -> bool:
+    if left == right:
+        return True
+    try:
+        return json.loads(left) == json.loads(right)
+    except (json.JSONDecodeError, TypeError):
+        return False
+
+
+def restore_replayed_tool_arguments(messages: list[dict[str, Any]], stored_messages: list[dict[str, Any]]) -> None:
+    """Restore the model's exact JSON spelling for replayed tool calls.
+
+    Anthropic exposes ``tool_use.input`` as an object, so Claude Code cannot
+    replay the whitespace and escaping from the model's original OpenAI
+    ``function.arguments`` string. TITO needs that exact spelling because it
+    reuses the generated token prefix. Restore it only when the tool id, name,
+    and decoded JSON value all match a recorded assistant message.
+    """
+    stored_arguments: dict[tuple[str, str], str] = {}
+    for message in stored_messages:
+        if message.get("role") != "assistant":
+            continue
+        for tool_call in message.get("tool_calls") or []:
+            if not isinstance(tool_call, Mapping):
+                continue
+            function = tool_call.get("function")
+            if not isinstance(function, Mapping):
+                continue
+            tool_id = tool_call.get("id")
+            name = function.get("name")
+            arguments = function.get("arguments")
+            if isinstance(tool_id, str) and isinstance(name, str) and isinstance(arguments, str):
+                stored_arguments[(tool_id, name)] = arguments
+
+    for message in messages:
+        if message.get("role") != "assistant":
+            continue
+        for tool_call in message.get("tool_calls") or []:
+            if not isinstance(tool_call, dict):
+                continue
+            function = tool_call.get("function")
+            if not isinstance(function, dict):
+                continue
+            tool_id = tool_call.get("id")
+            name = function.get("name")
+            arguments = function.get("arguments")
+            if not isinstance(tool_id, str) or not isinstance(name, str) or not isinstance(arguments, str):
+                continue
+            original = stored_arguments.get((tool_id, name))
+            if original is not None and _json_text_matches(original, arguments):
+                function["arguments"] = original
+
+
 def anthropic_to_openai_request(request: Mapping[str, Any]) -> dict[str, Any]:
     """Convert one Anthropic Messages request to OpenAI chat-completion form."""
     request = _require_mapping(request, "request")

--- a/miles/rollout/session/core.py
+++ b/miles/rollout/session/core.py
@@ -463,18 +463,21 @@ class SessionCore:
         if openai_response.status_code != 200:
             return _anthropic_error_response(openai_response.status_code, response_body)
 
-        if client_stream:
+        try:
+            if client_stream:
+                return Response(
+                    content=render_anthropic_sse(response_body),
+                    status_code=200,
+                    headers={"cache-control": "no-cache", "x-accel-buffering": "no"},
+                    media_type="text/event-stream",
+                )
             return Response(
-                content=render_anthropic_sse(response_body),
+                content=_render_json(openai_to_anthropic_response(response_body)),
                 status_code=200,
-                headers={"cache-control": "no-cache", "x-accel-buffering": "no"},
-                media_type="text/event-stream",
+                media_type=JSON_MEDIA_TYPE,
             )
-        return Response(
-            content=_render_json(openai_to_anthropic_response(response_body)),
-            status_code=200,
-            media_type=JSON_MEDIA_TYPE,
-        )
+        except AnthropicProtocolError as exc:
+            return _anthropic_error_response(529, {"error": str(exc)})
 
     async def proxy(
         self, session_id: str, path: str, *, method: str, query: str, headers: dict, body: bytes

--- a/miles/rollout/session/core.py
+++ b/miles/rollout/session/core.py
@@ -16,8 +16,16 @@ from dataclasses import dataclass
 from starlette.responses import Response
 
 from miles.rollout.generate_utils.sample_utils import merge_samples
+from miles.rollout.session.anthropic import (
+    AnthropicProtocolError,
+    anthropic_to_openai_request,
+    openai_error_to_anthropic,
+    openai_to_anthropic_response,
+    render_anthropic_sse,
+)
 from miles.rollout.session.errors import (
     MessageValidationError,
+    SessionError,
     SessionNotFoundError,
     TokenizationError,
     UpstreamResponseError,
@@ -56,6 +64,14 @@ def _render_json(payload) -> bytes:
 def _samples_response(payload: bytes) -> Response:
     """The samples-op reply: one safetensors binary payload."""
     return Response(content=payload, status_code=200, media_type="application/octet-stream")
+
+
+def _anthropic_error_response(status_code: int, payload: object) -> Response:
+    return Response(
+        content=_render_json(openai_error_to_anthropic(status_code, payload)),
+        status_code=status_code,
+        media_type=JSON_MEDIA_TYPE,
+    )
 
 
 _CLIENT_STRIPPED_META_KEYS = ("routed_experts", "indexer_topk")
@@ -396,6 +412,58 @@ class SessionCore:
         # --- lock released ---
 
         return _chat_client_response(result, response, client_stream)
+
+    async def messages(self, session_id: str, *, method: str, query: str, headers: dict, body: bytes) -> Response:
+        """Serve Anthropic Messages through the recorded chat-completion path.
+
+        Claude Code sees Anthropic request/response shapes, while the existing
+        ``chat_completions`` implementation remains the single owner of TITO,
+        log-probability recording, rollback/branching, and concurrency rules.
+        """
+        try:
+            anthropic_request = json.loads(body) if body else {}
+        except json.JSONDecodeError as exc:
+            return _anthropic_error_response(400, {"error": f"invalid JSON body: {exc}"})
+
+        try:
+            openai_request = anthropic_to_openai_request(anthropic_request)
+        except AnthropicProtocolError as exc:
+            return _anthropic_error_response(400, {"error": str(exc)})
+
+        client_stream = bool(openai_request.pop("stream", False))
+        try:
+            openai_response = await self.chat_completions(
+                session_id,
+                method=method,
+                query=query,
+                headers=headers,
+                body=json.dumps(openai_request).encode(),
+            )
+        except SessionError as exc:
+            return _anthropic_error_response(exc.status_code, {"error": str(exc)})
+
+        try:
+            response_body = json.loads(openai_response.body)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            return _anthropic_error_response(
+                openai_response.status_code,
+                {"error": openai_response.body.decode(errors="replace")},
+            )
+        if openai_response.status_code != 200:
+            return _anthropic_error_response(openai_response.status_code, response_body)
+
+        if client_stream:
+            return Response(
+                content=render_anthropic_sse(response_body),
+                status_code=200,
+                headers={"cache-control": "no-cache", "x-accel-buffering": "no"},
+                media_type="text/event-stream",
+            )
+        return Response(
+            content=_render_json(openai_to_anthropic_response(response_body)),
+            status_code=200,
+            media_type=JSON_MEDIA_TYPE,
+        )
 
     async def proxy(
         self, session_id: str, path: str, *, method: str, query: str, headers: dict, body: bytes

--- a/miles/rollout/session/core.py
+++ b/miles/rollout/session/core.py
@@ -17,6 +17,7 @@ from starlette.responses import Response
 
 from miles.rollout.generate_utils.sample_utils import merge_samples
 from miles.rollout.session.anthropic import (
+    AnthropicGenerationAbortedError,
     AnthropicProtocolError,
     anthropic_to_openai_request,
     openai_error_to_anthropic,
@@ -476,7 +477,7 @@ class SessionCore:
                 status_code=200,
                 media_type=JSON_MEDIA_TYPE,
             )
-        except AnthropicProtocolError as exc:
+        except AnthropicGenerationAbortedError as exc:
             return _anthropic_error_response(529, {"error": str(exc)})
 
     async def proxy(

--- a/miles/rollout/session/core.py
+++ b/miles/rollout/session/core.py
@@ -22,6 +22,7 @@ from miles.rollout.session.anthropic import (
     openai_error_to_anthropic,
     openai_to_anthropic_response,
     render_anthropic_sse,
+    restore_replayed_tool_arguments,
 )
 from miles.rollout.session.errors import (
     MessageValidationError,
@@ -328,7 +329,14 @@ class SessionCore:
         return Response(status_code=204)
 
     async def chat_completions(
-        self, session_id: str, *, method: str, query: str, headers: dict, body: bytes
+        self,
+        session_id: str,
+        *,
+        method: str,
+        query: str,
+        headers: dict,
+        body: bytes,
+        restore_anthropic_arguments: bool = False,
     ) -> Response:
         """Proxy a chat completion through the backend with TITO token tracking.
 
@@ -352,6 +360,8 @@ class SessionCore:
             )
 
             request_messages = request_body.get("messages", [])
+            if restore_anthropic_arguments:
+                restore_replayed_tool_arguments(request_messages, session.messages)
             prompt_token_ids = session.prepare_pretokenized(
                 request_messages,
                 tools=request_body.get("tools"),
@@ -438,6 +448,7 @@ class SessionCore:
                 query=query,
                 headers=headers,
                 body=json.dumps(openai_request).encode(),
+                restore_anthropic_arguments=True,
             )
         except SessionError as exc:
             return _anthropic_error_response(exc.status_code, {"error": str(exc)})

--- a/miles/rollout/session/sessions.py
+++ b/miles/rollout/session/sessions.py
@@ -79,6 +79,17 @@ def setup_session_routes(app, backend, args):
             body=body,
         )
 
+    @app.post("/sessions/{session_id}/v1/messages")
+    async def messages(request: Request, session_id: str):
+        body = await request.body()
+        return await core.messages(
+            session_id,
+            method=request.method,
+            query=request.url.query,
+            headers=dict(request.headers),
+            body=body,
+        )
+
     @app.post("/sessions/{session_id}/samples")
     async def collect_samples(request: Request, session_id: str):
         # Starlette matches routes in registration order; keep this before session_proxy.

--- a/miles/rollout/session/v2/core.py
+++ b/miles/rollout/session/v2/core.py
@@ -4,6 +4,7 @@ import time
 
 from starlette.responses import Response
 
+from miles.rollout.session.anthropic import restore_replayed_tool_arguments
 from miles.rollout.session.core import (
     JSON_MEDIA_TYPE,
     ProxyRequest,
@@ -120,7 +121,14 @@ class SessionCoreV2(SessionCore):
         return _samples_response(encode_samples(samples, metadata, fields=COMPUTED_FIELDS_V2))
 
     async def chat_completions(
-        self, session_id: str, *, method: str, query: str, headers: dict, body: bytes
+        self,
+        session_id: str,
+        *,
+        method: str,
+        query: str,
+        headers: dict,
+        body: bytes,
+        restore_anthropic_arguments: bool = False,
     ) -> Response:
         """Proxy a chat completion through the backend with TITO token tracking.
 
@@ -144,6 +152,8 @@ class SessionCoreV2(SessionCore):
             )
 
             request_messages = request_body.get("messages", [])
+            if restore_anthropic_arguments:
+                restore_replayed_tool_arguments(request_messages, session.active_messages())
             position_for_request(session, request_messages)
             prompt_token_ids = prepare_pretokenized(
                 session,

--- a/tests/fast/rollout/session/test_anthropic_protocol.py
+++ b/tests/fast/rollout/session/test_anthropic_protocol.py
@@ -9,6 +9,7 @@ from miles.rollout.session.anthropic import (
     openai_error_to_anthropic,
     openai_to_anthropic_response,
     render_anthropic_sse,
+    restore_replayed_tool_arguments,
 )
 
 
@@ -253,6 +254,46 @@ def test_request_joins_thinking_and_defaults_tool_input() -> None:
             ],
         }
     ]
+
+
+def test_restore_replayed_tool_arguments_preserves_original_json_spelling() -> None:
+    stored_messages = [
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "toolu_1",
+                    "type": "function",
+                    "function": {"name": "bash", "arguments": '{"command": "pwd"}'},
+                }
+            ],
+        }
+    ]
+    replayed_messages = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "toolu_1",
+                    "type": "function",
+                    "function": {"name": "bash", "arguments": '{"command":"pwd"}'},
+                },
+                {
+                    "id": "toolu_changed",
+                    "type": "function",
+                    "function": {"name": "bash", "arguments": '{"command":"ls"}'},
+                },
+            ],
+        }
+    ]
+
+    restore_replayed_tool_arguments(replayed_messages, stored_messages)
+
+    tool_calls = replayed_messages[0]["tool_calls"]
+    assert tool_calls[0]["function"]["arguments"] == '{"command": "pwd"}'
+    assert tool_calls[1]["function"]["arguments"] == '{"command":"ls"}'
 
 
 @pytest.mark.parametrize(

--- a/tests/fast/rollout/session/test_anthropic_protocol.py
+++ b/tests/fast/rollout/session/test_anthropic_protocol.py
@@ -297,6 +297,66 @@ def test_restore_replayed_tool_arguments_preserves_original_json_spelling() -> N
 
 
 @pytest.mark.parametrize(
+    ("stored_arguments", "replayed_arguments", "expected"),
+    [
+        ('{"value":1}', '{"value":1}', '{"value":1}'),
+        ("{", "{}", "{}"),
+        ('{"value": 1}', '{"value": 2}', '{"value": 2}'),
+    ],
+)
+def test_restore_replayed_tool_arguments_handles_exact_and_nonmatching_json(
+    stored_arguments: str, replayed_arguments: str, expected: str
+) -> None:
+    stored_call = {
+        "id": "toolu_1",
+        "function": {"name": "bash", "arguments": stored_arguments},
+    }
+    replayed_call = {
+        "id": "toolu_1",
+        "function": {"name": "bash", "arguments": replayed_arguments},
+    }
+
+    restore_replayed_tool_arguments(
+        [{"role": "assistant", "tool_calls": [replayed_call]}],
+        [{"role": "assistant", "tool_calls": [stored_call]}],
+    )
+
+    assert replayed_call["function"]["arguments"] == expected
+
+
+@pytest.mark.parametrize("side", ["stored", "replayed"])
+@pytest.mark.parametrize(
+    "malformed_call",
+    [
+        None,
+        {"id": "toolu_1", "function": None},
+        {"id": 1, "function": {"name": "bash", "arguments": "{}"}},
+        {"id": "toolu_1", "function": {"name": 1, "arguments": "{}"}},
+        {"id": "toolu_1", "function": {"name": "bash", "arguments": {}}},
+    ],
+)
+def test_restore_replayed_tool_arguments_skips_malformed_calls(side: str, malformed_call: object) -> None:
+    valid_call = {
+        "id": "toolu_1",
+        "function": {"name": "bash", "arguments": '{"command":"pwd"}'},
+    }
+    stored_call = malformed_call if side == "stored" else valid_call
+    replayed_call = malformed_call if side == "replayed" else valid_call
+    stored_messages = [
+        {"role": "user", "content": "ignored"},
+        {"role": "assistant", "tool_calls": [stored_call]},
+    ]
+    replayed_messages = [
+        {"role": "user", "content": "ignored"},
+        {"role": "assistant", "tool_calls": [replayed_call]},
+    ]
+
+    restore_replayed_tool_arguments(replayed_messages, stored_messages)
+
+    assert replayed_messages[-1]["tool_calls"] == [replayed_call]
+
+
+@pytest.mark.parametrize(
     ("tool_choice", "expected"),
     [
         ({"type": "auto"}, "auto"),

--- a/tests/fast/router/test_anthropic_sessions.py
+++ b/tests/fast/router/test_anthropic_sessions.py
@@ -7,6 +7,8 @@ import requests
 from fastapi.responses import JSONResponse
 from tests.fast.router.test_sessions import router_env  # noqa: F401
 
+from miles.rollout.session.samples.codec import decode_samples_and_merge_input_sample
+from miles.utils.types import Sample
 from miles.utils.test_utils.mock_sglang_server import MockSGLangServer, ProcessResult
 
 
@@ -111,6 +113,39 @@ class TestAnthropicSessionRoute:
         assert second.status_code == 200
         records = requests.get(f"{router_env.url}/sessions/{session_id}", timeout=5.0).json()["records"]
         assert len(records) == 2
+
+    def test_anthropic_turn_collects_a_nonempty_training_sample(self, router_env) -> None:
+        session_id = _create_session(router_env.url)
+        original_chat_response = MockSGLangServer._compute_chat_completions_response
+
+        def response_without_replay_buffers(self: MockSGLangServer, payload: dict) -> dict:
+            response = original_chat_response(self, payload)
+            meta_info = response["choices"][0]["meta_info"]
+            meta_info.pop("routed_experts", None)
+            meta_info.pop("indexer_topk", None)
+            return response
+
+        with patch.object(
+            MockSGLangServer,
+            "_compute_chat_completions_response",
+            new=response_without_replay_buffers,
+        ):
+            response = _post_messages(router_env.url, session_id, _request())
+            assert response.status_code == 200
+
+            samples = requests.post(
+                f"{router_env.url}/sessions/{session_id}/samples",
+                json={},
+                timeout=10.0,
+            )
+
+        assert samples.status_code == 200
+        reply = decode_samples_and_merge_input_sample(samples.content, Sample())
+        assert reply.empty_reason is None
+        assert len(reply.samples) == 1
+        [sample] = reply.samples
+        assert sample.response_length > 0
+        assert len(sample.rollout_log_probs) == sample.response_length
 
     def test_tool_use_and_result_round_trip_passes_tito_prefix_check(self, router_env) -> None:
         session_id = _create_session(router_env.url)

--- a/tests/fast/router/test_anthropic_sessions.py
+++ b/tests/fast/router/test_anthropic_sessions.py
@@ -240,3 +240,40 @@ class TestAnthropicSessionRoute:
             "type": "error",
             "error": {"type": "overloaded_error", "message": "upstream generation was aborted"},
         }
+
+    def test_retry_after_aborted_generation_passes_tito_prefix_check(self, router_env) -> None:
+        session_id = _create_session(router_env.url)
+        original_chat_response = MockSGLangServer._compute_chat_completions_response
+        attempts = 0
+
+        def abort_once(self: MockSGLangServer, payload: dict) -> dict:
+            nonlocal attempts
+            response = original_chat_response(self, payload)
+            if attempts == 0:
+                response["choices"][0]["finish_reason"] = "abort"
+            attempts += 1
+            return response
+
+        first_request = _request()
+        with patch.object(MockSGLangServer, "_compute_chat_completions_response", new=abort_once):
+            aborted = _post_messages(router_env.url, session_id, first_request)
+            assert aborted.status_code == 529
+
+            retried = _post_messages(router_env.url, session_id, first_request)
+            assert retried.status_code == 200
+
+            next_messages = [
+                *first_request["messages"],
+                {"role": "assistant", "content": retried.json()["content"]},
+                {"role": "user", "content": "continue"},
+            ]
+            continued = _post_messages(
+                router_env.url,
+                session_id,
+                _request(messages=next_messages),
+            )
+
+        assert continued.status_code == 200
+        records = requests.get(f"{router_env.url}/sessions/{session_id}", timeout=5.0).json()["records"]
+        assert len(records) == 2
+        assert records[0]["response"]["choices"][0]["finish_reason"] == "stop"

--- a/tests/fast/router/test_anthropic_sessions.py
+++ b/tests/fast/router/test_anthropic_sessions.py
@@ -1,6 +1,7 @@
 import json
 from unittest.mock import patch
 
+import pytest
 import requests
 from fastapi.responses import JSONResponse
 from tests.fast.router.test_sessions import router_env  # noqa: F401
@@ -220,3 +221,22 @@ class TestAnthropicSessionRoute:
         }
         records = requests.get(f"{router_env.url}/sessions/{session_id}", timeout=5.0).json()["records"]
         assert records == []
+
+    @pytest.mark.parametrize("stream", [False, True])
+    def test_aborted_generation_returns_retryable_error(self, router_env, stream: bool) -> None:
+        session_id = _create_session(router_env.url)
+        original_chat_response = MockSGLangServer._compute_chat_completions_response
+
+        def aborted_response(self: MockSGLangServer, payload: dict) -> dict:
+            response = original_chat_response(self, payload)
+            response["choices"][0]["finish_reason"] = "abort"
+            return response
+
+        with patch.object(MockSGLangServer, "_compute_chat_completions_response", new=aborted_response):
+            response = _post_messages(router_env.url, session_id, _request(stream=stream))
+
+        assert response.status_code == 529
+        assert response.json() == {
+            "type": "error",
+            "error": {"type": "overloaded_error", "message": "upstream generation was aborted"},
+        }

--- a/tests/fast/router/test_anthropic_sessions.py
+++ b/tests/fast/router/test_anthropic_sessions.py
@@ -1,15 +1,15 @@
 import json
 from unittest.mock import patch
 
-# ruff: noqa: F811 -- imported pytest fixture names are injected as test arguments.
-
 import requests
 from fastapi.responses import JSONResponse
 from tests.fast.router.test_sessions import router_env  # noqa: F401
 
 from miles.rollout.session.samples.codec import decode_samples_and_merge_input_sample
-from miles.utils.types import Sample
 from miles.utils.test_utils.mock_sglang_server import MockSGLangServer, ProcessResult
+from miles.utils.types import Sample
+
+# ruff: noqa: F811 -- imported pytest fixture names are injected as test arguments.
 
 
 def _create_session(url: str) -> str:

--- a/tests/fast/router/test_anthropic_sessions.py
+++ b/tests/fast/router/test_anthropic_sessions.py
@@ -1,0 +1,187 @@
+import json
+from unittest.mock import patch
+
+# ruff: noqa: F811 -- imported pytest fixture names are injected as test arguments.
+
+import requests
+from fastapi.responses import JSONResponse
+from tests.fast.router.test_sessions import router_env  # noqa: F401
+
+from miles.utils.test_utils.mock_sglang_server import MockSGLangServer, ProcessResult
+
+
+def _create_session(url: str) -> str:
+    return requests.post(f"{url}/sessions", timeout=5.0).json()["session_id"]
+
+
+def _post_messages(url: str, session_id: str, payload: dict) -> requests.Response:
+    return requests.post(f"{url}/sessions/{session_id}/v1/messages", json=payload, timeout=10.0)
+
+
+def _parse_sse(body: str) -> list[tuple[str, dict]]:
+    events = []
+    for frame in body.strip().split("\n\n"):
+        event_line, data_line = frame.splitlines()
+        events.append((event_line.removeprefix("event: "), json.loads(data_line.removeprefix("data: "))))
+    return events
+
+
+def _request(**overrides: object) -> dict:
+    request = {
+        "model": "mock-model",
+        "max_tokens": 512,
+        "messages": [{"role": "user", "content": "hello"}],
+    }
+    request.update(overrides)
+    return request
+
+
+class TestAnthropicSessionRoute:
+    def test_non_streaming_request_is_recorded_in_openai_form(self, router_env) -> None:
+        session_id = _create_session(router_env.url)
+        response = _post_messages(
+            router_env.url,
+            session_id,
+            _request(
+                system="Be concise.",
+                temperature=0.7,
+                top_p=0.9,
+                top_k=20,
+            ),
+        )
+
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith("application/json")
+        body = response.json()
+        assert body["type"] == "message"
+        assert body["role"] == "assistant"
+        assert body["content"][0]["type"] == "text"
+
+        records = requests.get(f"{router_env.url}/sessions/{session_id}", timeout=5.0).json()["records"]
+        assert len(records) == 1
+        record = records[0]
+        assert record["path"] == "/v1/chat/completions"
+        assert record["request"]["messages"][:2] == [
+            {"role": "system", "content": "Be concise."},
+            {"role": "user", "content": "hello"},
+        ]
+        assert record["request"]["temperature"] == 0.7
+        assert record["request"]["top_p"] == 0.9
+        assert record["request"]["top_k"] == 20
+        assert record["request"]["logprobs"] is True
+        assert record["request"]["return_meta_info"] is True
+        assert "input_ids" in record["request"]
+        assert "stream" not in record["request"]
+
+    def test_streaming_response_has_anthropic_events_and_one_record(self, router_env) -> None:
+        session_id = _create_session(router_env.url)
+        response = _post_messages(router_env.url, session_id, _request(stream=True))
+
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith("text/event-stream")
+        events = _parse_sse(response.text)
+        assert [event_type for event_type, _ in events] == [
+            "message_start",
+            "content_block_start",
+            "content_block_delta",
+            "content_block_stop",
+            "message_delta",
+            "message_stop",
+        ]
+        assert events[2][1]["delta"]["type"] == "text_delta"
+        assert events[-2][1]["delta"]["stop_reason"] == "end_turn"
+
+        records = requests.get(f"{router_env.url}/sessions/{session_id}", timeout=5.0).json()["records"]
+        assert len(records) == 1
+        assert "stream" not in router_env.backend.request_log[-1]
+
+    def test_multi_turn_response_replay_passes_tito_prefix_check(self, router_env) -> None:
+        session_id = _create_session(router_env.url)
+        first_request = _request()
+        first = _post_messages(router_env.url, session_id, first_request)
+        assert first.status_code == 200
+
+        second_messages = [
+            *first_request["messages"],
+            {"role": "assistant", "content": first.json()["content"]},
+            {"role": "user", "content": "continue"},
+        ]
+        second = _post_messages(router_env.url, session_id, _request(messages=second_messages))
+
+        assert second.status_code == 200
+        records = requests.get(f"{router_env.url}/sessions/{session_id}", timeout=5.0).json()["records"]
+        assert len(records) == 2
+
+    def test_tool_use_and_result_round_trip_passes_tito_prefix_check(self, router_env) -> None:
+        session_id = _create_session(router_env.url)
+        tools = [
+            {
+                "name": "bash",
+                "description": "Run a command",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {"command": {"type": "string"}},
+                    "required": ["command"],
+                },
+            }
+        ]
+
+        def tool_call_process_fn(prompt: str) -> ProcessResult:
+            return ProcessResult(text='<tool_call>\n{"name":"bash","arguments":{"command":"pwd"}}\n</tool_call>')
+
+        first_request = _request(messages=[{"role": "user", "content": "show the directory"}], tools=tools)
+        with patch.object(router_env.backend, "process_fn", new=tool_call_process_fn):
+            first = _post_messages(router_env.url, session_id, first_request)
+        assert first.status_code == 200
+        [tool_use] = [block for block in first.json()["content"] if block["type"] == "tool_use"]
+
+        second_messages = [
+            *first_request["messages"],
+            {"role": "assistant", "content": first.json()["content"]},
+            {
+                "role": "user",
+                "content": [{"type": "tool_result", "tool_use_id": tool_use["id"], "content": "/workspace"}],
+            },
+        ]
+        with patch.object(router_env.backend, "process_fn", new=lambda prompt: ProcessResult(text="done")):
+            second = _post_messages(
+                router_env.url,
+                session_id,
+                _request(messages=second_messages, tools=tools),
+            )
+
+        assert second.status_code == 200
+        records = requests.get(f"{router_env.url}/sessions/{session_id}", timeout=5.0).json()["records"]
+        assert len(records) == 2
+        assert records[1]["request"]["messages"][-1] == {
+            "role": "tool",
+            "tool_call_id": tool_use["id"],
+            "content": "/workspace",
+        }
+
+    def test_invalid_request_uses_anthropic_error_envelope(self, router_env) -> None:
+        session_id = _create_session(router_env.url)
+        response = _post_messages(router_env.url, session_id, _request(max_tokens=0))
+
+        assert response.status_code == 400
+        assert response.json() == {
+            "type": "error",
+            "error": {"type": "invalid_request_error", "message": "max_tokens must be a positive integer"},
+        }
+
+    def test_upstream_error_uses_anthropic_envelope_and_is_not_recorded(self, router_env) -> None:
+        session_id = _create_session(router_env.url)
+
+        async def reject(self: MockSGLangServer, request: object, compute_fn: object) -> JSONResponse:
+            return JSONResponse(content={"error": {"message": "context too long"}}, status_code=400)
+
+        with patch.object(MockSGLangServer, "_handle_generate_like_request", new=reject):
+            response = _post_messages(router_env.url, session_id, _request())
+
+        assert response.status_code == 400
+        assert response.json() == {
+            "type": "error",
+            "error": {"type": "invalid_request_error", "message": "context too long"},
+        }
+        records = requests.get(f"{router_env.url}/sessions/{session_id}", timeout=5.0).json()["records"]
+        assert records == []

--- a/tests/fast/router/test_sessions_v2.py
+++ b/tests/fast/router/test_sessions_v2.py
@@ -115,6 +115,27 @@ class TestRequestChatTemplateKwargs:
         assert override_payload["input_ids"] != default_payload["input_ids"]
 
 
+class TestAnthropicMessages:
+    def test_route_records_on_the_active_tree_path(self, router_env) -> None:
+        session_id = _create_session(router_env.url)
+        response = requests.post(
+            f"{router_env.url}/sessions/{session_id}/v1/messages",
+            json={
+                "model": "mock-model",
+                "max_tokens": 128,
+                "messages": [{"role": "user", "content": "hello"}],
+            },
+            timeout=10.0,
+        )
+
+        assert response.status_code == 200
+        assert response.json()["type"] == "message"
+        session = requests.get(f"{router_env.url}/sessions/{session_id}", timeout=5.0).json()
+        assert len(session["records"]) == 1
+        assert session["records"][0]["path"] == "/v1/chat/completions"
+        assert len(session["metadata"]["tree"]["nodes"]) == 1
+
+
 def test_lora_adapter_reaches_backend():
     with _serve_router({"lora_rank": 8}) as env:
         session_id = _create_session(env.url)


### PR DESCRIPTION
## Summary

- add `POST /sessions/{session_id}/v1/messages` for Claude Code and other Anthropic-compatible clients
- route converted requests through the existing chat-completions recorder so TITO, logprobs, errors, v1 sessions, and v2 trajectory trees keep their current semantics
- return a retryable Anthropic 529 `overloaded_error` when Miles reports an aborted generation, for both JSON and SSE clients
- catch only the dedicated `AnthropicGenerationAbortedError` at render time, leaving unrelated protocol failures distinct
- restore the model's exact JSON spelling for replayed tool arguments, which prevents Anthropic's object encoding from invalidating TITO token prefixes
- return Anthropic JSON, SSE, and error envelopes, and document the endpoint
- keep pure protocol coverage under `tests/fast/rollout/session/`; HTTP route coverage remains under `tests/fast/router/`

## Stack

3 of 4. Depends on:

- #2259 — Anthropic request conversion
- #2261 — Anthropic response and SSE conversion, including dedicated abort detection, tool-use stop-reason enforcement, and non-finite argument sanitization

The final PR pins Miles rollout sampling parameters at session creation.

## Tests

- repository pre-commit hooks pass on all changed files
- 87 targeted protocol, v1 integration, and v2 integration tests pass locally
- all 76 protocol tests pass; isolated coverage for `miles/rollout/session/anthropic.py` is 325/325 statements and 202/202 branches (100%)
- defensive replay coverage includes identical JSON strings, malformed JSON, non-mapping tool calls/functions, and non-string ids/names/arguments
- the 10 v1 route tests include the complete 529 → same-request retry → subsequent-turn TITO-prefix-check cycle; the aborted record is replaced by the successful retry

Canonical pytest invocation uses normal conftest discovery:

`python -m pytest tests/fast/rollout/session/test_anthropic_protocol.py tests/fast/router/test_anthropic_sessions.py tests/fast/router/test_sessions_v2.py::TestAnthropicMessages`

Local macOS integration validation used lightweight import stubs for SGLang and Ray because their full GPU runtime is unavailable on the host; the exercised Miles route and mock HTTP backend are unchanged.
