### PR TITLE
feat(session): pin rollout sampling overrides

### DIFF
--- a/docs/user-guide/rollout-endpoints.md
+++ b/docs/user-guide/rollout-endpoints.md
@@ -158,6 +158,11 @@ back to Anthropic JSON or server-sent events. The internal request still passes
 through the normal session recorder, so TITO checks, logprobs, retries, and v2
 trajectory branching behave the same as they do for `/v1/chat/completions`.
 
+The rollout sampling parameters are pinned when Miles creates the session. They
+override conflicting values sent later by Claude Code or another agent harness,
+so training continues to use Miles's `max_tokens`, temperature, top-p, top-k,
+seed, stop conditions, and other configured sampling controls on every turn.
+
 Anthropic server-side tools and redacted-thinking history are rejected with an
 Anthropic-format `invalid_request_error` because they cannot be represented by
 the SGLang chat-completion interface.

--- a/miles/rollout/generate_hub/agentic_tool_call.py
+++ b/miles/rollout/generate_hub/agentic_tool_call.py
@@ -35,6 +35,7 @@ from sglang.srt.entrypoints.openai.protocol import ChatCompletionRequest
 
 from miles.rollout.base_types import GenerateFnInput, GenerateFnOutput
 from miles.rollout.generate_utils.openai_endpoint_utils import OpenAIEndpointTracer
+from miles.rollout.session.request_overrides import SESSION_REQUEST_OVERRIDE_KEYS
 from miles.utils.misc import load_function
 from miles.utils.types import Sample
 
@@ -168,6 +169,5 @@ def build_chat_request_kwargs(sampling_params: dict[str, Any]) -> dict[str, Any]
                 request_kwargs[dst] = request_kwargs[src]
             request_kwargs.pop(src, None)
 
-    reserved_keys = {"model", "messages"}
-    allowed_keys = set(ChatCompletionRequest.model_fields) - reserved_keys
+    allowed_keys = set(ChatCompletionRequest.model_fields) & SESSION_REQUEST_OVERRIDE_KEYS
     return {key: value for key, value in request_kwargs.items() if key in allowed_keys and value is not None}

--- a/miles/rollout/generate_hub/agentic_tool_call.py
+++ b/miles/rollout/generate_hub/agentic_tool_call.py
@@ -47,7 +47,8 @@ async def generate(input: GenerateFnInput) -> GenerateFnOutput:
         "Pass --use-session-server to start the session server."
     )
     use_v2 = getattr(input.args, "use_session_server", None) == "v2"
-    tracer = await OpenAIEndpointTracer.create(input.args)
+    request_kwargs = build_chat_request_kwargs(input.sampling_params)
+    tracer = await OpenAIEndpointTracer.create(input.args, request_overrides=request_kwargs)
 
     custom_agent_function: Callable = load_function(input.args.custom_agent_function_path)
     assert (
@@ -75,7 +76,7 @@ async def generate(input: GenerateFnInput) -> GenerateFnOutput:
         agent_metadata = await custom_agent_function(
             base_url=tracer.base_url,
             prompt=input.sample.prompt,
-            request_kwargs=build_chat_request_kwargs(input.sampling_params),
+            request_kwargs=request_kwargs,
             metadata=metadata,
         )
         logger.debug(f"{log_prefix} Agent function returned in {time.monotonic()-t_start:.1f}s")

--- a/miles/rollout/generate_utils/openai_endpoint_utils.py
+++ b/miles/rollout/generate_utils/openai_endpoint_utils.py
@@ -44,9 +44,7 @@ class OpenAIEndpointTracer:
         return self.router_url.removeprefix("http://")
 
     @staticmethod
-    async def create(
-        args: Namespace, *, request_overrides: dict | None = None
-    ) -> "OpenAIEndpointTracer":
+    async def create(args: Namespace, *, request_overrides: dict | None = None) -> "OpenAIEndpointTracer":
         session_ip = getattr(args, "session_server_ip", None)
         session_ports = getattr(args, "session_server_ports", None)
         if not session_ip or not session_ports:

--- a/miles/rollout/generate_utils/openai_endpoint_utils.py
+++ b/miles/rollout/generate_utils/openai_endpoint_utils.py
@@ -44,7 +44,9 @@ class OpenAIEndpointTracer:
         return self.router_url.removeprefix("http://")
 
     @staticmethod
-    async def create(args: Namespace):
+    async def create(
+        args: Namespace, *, request_overrides: dict | None = None
+    ) -> "OpenAIEndpointTracer":
         session_ip = getattr(args, "session_server_ip", None)
         session_ports = getattr(args, "session_server_ports", None)
         if not session_ip or not session_ports:
@@ -58,7 +60,8 @@ class OpenAIEndpointTracer:
         session_url = f"http://{session_ip}:{session_port}"
         instance_ids = getattr(args, "session_server_instance_ids", None) or {}
         session_server_instance_id = instance_ids.get(session_port)
-        response = await post(f"{session_url}/sessions", {}, action="post")
+        create_payload = {"request_overrides": request_overrides} if request_overrides else {}
+        response = await post(f"{session_url}/sessions", create_payload, action="post")
         session_id = response["session_id"]
         use_v2 = getattr(args, "use_session_server", None) == "v2"
         return OpenAIEndpointTracer(

--- a/miles/rollout/session/core.py
+++ b/miles/rollout/session/core.py
@@ -33,6 +33,7 @@ from miles.rollout.session.errors import (
     UpstreamResponseError,
 )
 from miles.rollout.session.linear_trajectory import SessionRegistry
+from miles.rollout.session.request_overrides import SESSION_REQUEST_OVERRIDE_KEYS
 from miles.rollout.session.samples.codec import encode_samples
 from miles.rollout.session.samples.merge import compute_samples_from_openai_records, truncate_samples_by_total_tokens
 from miles.rollout.session.types import GetSessionResponse, SessionRecord
@@ -41,33 +42,6 @@ from miles.utils.lora import LORA_ADAPTER_NAME, is_lora_enabled
 logger = logging.getLogger(__name__)
 
 JSON_MEDIA_TYPE = "application/json"
-
-SESSION_REQUEST_OVERRIDE_KEYS = frozenset(
-    {
-        "custom_logit_processor",
-        "custom_params",
-        "ebnf",
-        "frequency_penalty",
-        "ignore_eos",
-        "logit_bias",
-        "max_completion_tokens",
-        "max_tokens",
-        "min_p",
-        "min_tokens",
-        "n",
-        "presence_penalty",
-        "regex",
-        "repetition_penalty",
-        "response_format",
-        "seed",
-        "stop",
-        "stop_regex",
-        "stop_token_ids",
-        "temperature",
-        "top_k",
-        "top_p",
-    }
-)
 
 # Hop-by-hop / length-framing headers dropped from the upstream response so the
 # transport layer recomputes them from the body we actually send. "server" and

--- a/miles/rollout/session/core.py
+++ b/miles/rollout/session/core.py
@@ -42,6 +42,33 @@ logger = logging.getLogger(__name__)
 
 JSON_MEDIA_TYPE = "application/json"
 
+SESSION_REQUEST_OVERRIDE_KEYS = frozenset(
+    {
+        "custom_logit_processor",
+        "custom_params",
+        "ebnf",
+        "frequency_penalty",
+        "ignore_eos",
+        "logit_bias",
+        "max_completion_tokens",
+        "max_tokens",
+        "min_p",
+        "min_tokens",
+        "n",
+        "presence_penalty",
+        "regex",
+        "repetition_penalty",
+        "response_format",
+        "seed",
+        "stop",
+        "stop_regex",
+        "stop_token_ids",
+        "temperature",
+        "top_k",
+        "top_p",
+    }
+)
+
 # Hop-by-hop / length-framing headers dropped from the upstream response so the
 # transport layer recomputes them from the body we actually send. "server" and
 # "date" are dropped because our own ASGI server always emits them, so echoing
@@ -160,7 +187,7 @@ def proxy_result_to_response(result: dict) -> Response:
     return Response(content=_render_json(data), status_code=status_code, headers=headers, media_type=JSON_MEDIA_TYPE)
 
 
-def prepare_chat_request(body: bytes, args, tito_tokenizer) -> tuple:
+def prepare_chat_request(body: bytes, args, tito_tokenizer, request_overrides: dict | None = None) -> tuple:
     """Parse and normalize a chat request body — the session-independent half
     of chat dispatch, shared verbatim by the v1 and v2 cores. Returns
     ``(request_body, client_stream, tito_tokenizer)``; the tokenizer may be a
@@ -177,6 +204,11 @@ def prepare_chat_request(body: bytes, args, tito_tokenizer) -> tuple:
     # when rendering the client response.
     client_stream = bool(request_body.pop("stream", False))
     request_body.pop("stream_options", None)
+
+    # A session's rollout policy wins over values supplied by the agent harness.
+    # This is especially important for external agents such as Claude Code,
+    # which construct their own sampling parameters on every turn.
+    request_body.update(request_overrides or {})
 
     # TITO token tracking needs Miles-owned input_ids plus SGLang output
     # metadata: logprobs=True populates meta_info.output_token_logprobs and
@@ -261,8 +293,24 @@ class SessionCore:
             body["session_server_instance_id"] = self.instance_id
         return Response(content=_render_json(body), status_code=200, media_type=JSON_MEDIA_TYPE)
 
-    async def create_session(self) -> Response:
-        session_id = self.registry.create_session()
+    async def create_session(self, body: bytes = b"") -> Response:
+        try:
+            params = json.loads(body) if body else {}
+        except json.JSONDecodeError as exc:
+            raise MessageValidationError(f"invalid JSON body: {exc}") from exc
+        if not isinstance(params, dict):
+            raise MessageValidationError("session request must be an object")
+
+        request_overrides = params.get("request_overrides", {})
+        if request_overrides is None:
+            request_overrides = {}
+        if not isinstance(request_overrides, dict):
+            raise MessageValidationError("request_overrides must be an object")
+        unsupported = sorted(set(request_overrides) - SESSION_REQUEST_OVERRIDE_KEYS)
+        if unsupported:
+            raise MessageValidationError(f"unsupported session request overrides: {unsupported}")
+
+        session_id = self.registry.create_session(request_overrides)
         return Response(content=_render_json({"session_id": session_id}), status_code=200, media_type=JSON_MEDIA_TYPE)
 
     def _session_metadata(self, session_id: str, session) -> dict:
@@ -357,7 +405,7 @@ class SessionCore:
                 raise SessionNotFoundError(f"session not found: session_id={session_id}")
 
             request_body, client_stream, tito_tokenizer = prepare_chat_request(
-                body, self.args, self.registry.tito_tokenizer
+                body, self.args, self.registry.tito_tokenizer, session.request_overrides
             )
 
             request_messages = request_body.get("messages", [])

--- a/miles/rollout/session/core.py
+++ b/miles/rollout/session/core.py
@@ -33,7 +33,10 @@ from miles.rollout.session.errors import (
     UpstreamResponseError,
 )
 from miles.rollout.session.linear_trajectory import SessionRegistry
-from miles.rollout.session.request_overrides import SESSION_REQUEST_OVERRIDE_KEYS
+from miles.rollout.session.request_overrides import (
+    SESSION_REQUEST_OVERRIDE_KEYS,
+    validate_session_request_override_values,
+)
 from miles.rollout.session.samples.codec import encode_samples
 from miles.rollout.session.samples.merge import compute_samples_from_openai_records, truncate_samples_by_total_tokens
 from miles.rollout.session.types import GetSessionResponse, SessionRecord
@@ -283,6 +286,10 @@ class SessionCore:
         unsupported = sorted(set(request_overrides) - SESSION_REQUEST_OVERRIDE_KEYS)
         if unsupported:
             raise MessageValidationError(f"unsupported session request overrides: {unsupported}")
+        try:
+            validate_session_request_override_values(request_overrides)
+        except ValueError as exc:
+            raise MessageValidationError(str(exc)) from exc
 
         session_id = self.registry.create_session(request_overrides)
         return Response(content=_render_json({"session_id": session_id}), status_code=200, media_type=JSON_MEDIA_TYPE)

--- a/miles/rollout/session/linear_trajectory.py
+++ b/miles/rollout/session/linear_trajectory.py
@@ -68,6 +68,7 @@ class LinearTrajectory:
 
     lock: asyncio.Lock = field(default_factory=asyncio.Lock, repr=False, compare=False)
     closing: bool = field(default=False, repr=False, compare=False)
+    request_overrides: dict[str, Any] = field(default_factory=dict, repr=False)
     messages: list[dict[str, Any]] = field(default_factory=list)
     records: list[SessionRecord] = field(default_factory=list)
     trajectory_token_ids: list[list[int]] = field(default_factory=list)
@@ -286,9 +287,9 @@ class SessionRegistry:
         self.tito_tokenizer = tito_tokenizer
         self.comparator = tito_tokenizer.create_comparator()
 
-    def create_session(self) -> str:
+    def create_session(self, request_overrides: dict[str, Any] | None = None) -> str:
         session_id = uuid.uuid4().hex
-        self.sessions[session_id] = LinearTrajectory()
+        self.sessions[session_id] = LinearTrajectory(request_overrides=dict(request_overrides or {}))
         return session_id
 
     def get_session(self, session_id: str) -> LinearTrajectory:

--- a/miles/rollout/session/request_overrides.py
+++ b/miles/rollout/session/request_overrides.py
@@ -1,28 +1,87 @@
-"""Sampling fields that Miles may pin for every request in a session."""
+"""Sampling fields that Miles may pin for every request in a session.
 
-SESSION_REQUEST_OVERRIDE_KEYS = frozenset(
-    {
-        "custom_logit_processor",
-        "custom_params",
-        "ebnf",
-        "frequency_penalty",
-        "ignore_eos",
-        "logit_bias",
-        "max_completion_tokens",
-        "max_tokens",
-        "min_p",
-        "min_tokens",
-        "n",
-        "presence_penalty",
-        "regex",
-        "repetition_penalty",
-        "response_format",
-        "seed",
-        "stop",
-        "stop_regex",
-        "stop_token_ids",
-        "temperature",
-        "top_k",
-        "top_p",
-    }
-)
+Session overrides are authoritative: Miles applies them after translating each
+client request, so a pinned key intentionally replaces the per-turn value. This
+includes Anthropic's required ``max_tokens`` field; its client value is validated
+by the Anthropic adapter but ignored when the session pins ``max_tokens``. Omit a
+key from ``request_overrides`` when the client should control it per turn.
+"""
+
+from collections.abc import Callable, Mapping
+
+
+def _is_number(value: object) -> bool:
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
+def _is_integer(value: object) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def _is_boolean(value: object) -> bool:
+    return isinstance(value, bool)
+
+
+def _is_string(value: object) -> bool:
+    return isinstance(value, str)
+
+
+def _is_mapping(value: object) -> bool:
+    return isinstance(value, Mapping)
+
+
+def _is_logit_bias(value: object) -> bool:
+    return isinstance(value, Mapping) and all(isinstance(key, str) and _is_number(bias) for key, bias in value.items())
+
+
+def _is_string_or_string_list(value: object) -> bool:
+    return isinstance(value, str) or (isinstance(value, list) and all(isinstance(item, str) for item in value))
+
+
+def _is_string_or_nullable_string_list(value: object) -> bool:
+    return isinstance(value, str) or (
+        isinstance(value, list) and all(item is None or isinstance(item, str) for item in value)
+    )
+
+
+def _is_integer_list(value: object) -> bool:
+    return isinstance(value, list) and all(_is_integer(item) for item in value)
+
+
+_OverrideValidator = tuple[str, Callable[[object], bool], bool]
+_SESSION_REQUEST_OVERRIDE_VALIDATORS: dict[str, _OverrideValidator] = {
+    "custom_logit_processor": ("string or list of nullable strings", _is_string_or_nullable_string_list, True),
+    "custom_params": ("object", _is_mapping, True),
+    "ebnf": ("string", _is_string, True),
+    "frequency_penalty": ("number", _is_number, False),
+    "ignore_eos": ("boolean", _is_boolean, False),
+    "logit_bias": ("object with numeric values", _is_logit_bias, True),
+    "max_completion_tokens": ("integer", _is_integer, True),
+    "max_tokens": ("integer", _is_integer, True),
+    "min_p": ("number", _is_number, True),
+    "min_tokens": ("integer", _is_integer, False),
+    "presence_penalty": ("number", _is_number, False),
+    "regex": ("string", _is_string, True),
+    "repetition_penalty": ("number", _is_number, True),
+    "response_format": ("object", _is_mapping, True),
+    "seed": ("integer", _is_integer, True),
+    "stop": ("string or list of strings", _is_string_or_string_list, True),
+    "stop_regex": ("string or list of strings", _is_string_or_string_list, True),
+    "stop_token_ids": ("list of integers", _is_integer_list, True),
+    "temperature": ("number", _is_number, True),
+    "top_k": ("integer", _is_integer, True),
+    "top_p": ("number", _is_number, True),
+}
+
+SESSION_REQUEST_OVERRIDE_KEYS = frozenset(_SESSION_REQUEST_OVERRIDE_VALIDATORS)
+
+
+def validate_session_request_override_values(request_overrides: Mapping[str, object]) -> None:
+    """Reject override values whose JSON shape cannot satisfy SGLang's request model."""
+    for key, value in request_overrides.items():
+        expected, validator, nullable = _SESSION_REQUEST_OVERRIDE_VALIDATORS[key]
+        if (value is None and nullable) or validator(value):
+            continue
+        if nullable:
+            expected = f"{expected} or null"
+        raise ValueError(f"invalid session request override {key!r}: expected {expected}, got {type(value).__name__}")

--- a/miles/rollout/session/request_overrides.py
+++ b/miles/rollout/session/request_overrides.py
@@ -1,0 +1,28 @@
+"""Sampling fields that Miles may pin for every request in a session."""
+
+SESSION_REQUEST_OVERRIDE_KEYS = frozenset(
+    {
+        "custom_logit_processor",
+        "custom_params",
+        "ebnf",
+        "frequency_penalty",
+        "ignore_eos",
+        "logit_bias",
+        "max_completion_tokens",
+        "max_tokens",
+        "min_p",
+        "min_tokens",
+        "n",
+        "presence_penalty",
+        "regex",
+        "repetition_penalty",
+        "response_format",
+        "seed",
+        "stop",
+        "stop_regex",
+        "stop_token_ids",
+        "temperature",
+        "top_k",
+        "top_p",
+    }
+)

--- a/miles/rollout/session/sessions.py
+++ b/miles/rollout/session/sessions.py
@@ -57,8 +57,8 @@ def setup_session_routes(app, backend, args):
         return await core.health()
 
     @app.post("/sessions")
-    async def create_session():
-        return await core.create_session()
+    async def create_session(request: Request):
+        return await core.create_session(await request.body())
 
     @app.get("/sessions/{session_id}")
     async def get_session(session_id: str):

--- a/miles/rollout/session/v2/core.py
+++ b/miles/rollout/session/v2/core.py
@@ -148,7 +148,7 @@ class SessionCoreV2(SessionCore):
                 raise SessionNotFoundError(f"session not found: session_id={session_id}")
 
             request_body, client_stream, tito_tokenizer = prepare_chat_request(
-                body, self.args, self.registry.tito_tokenizer
+                body, self.args, self.registry.tito_tokenizer, session.request_overrides
             )
 
             request_messages = request_body.get("messages", [])

--- a/miles/rollout/session/v2/session_state.py
+++ b/miles/rollout/session/v2/session_state.py
@@ -38,6 +38,7 @@ class SessionStateV2:
 
     lock: asyncio.Lock = field(default_factory=asyncio.Lock, repr=False, compare=False)
     closing: bool = field(default=False, repr=False, compare=False)
+    request_overrides: dict[str, Any] = field(default_factory=dict, repr=False)
     tree: SessionTree = field(default_factory=SessionTree)
     active_leaf: TrajectoryNode | None = None
 
@@ -177,9 +178,9 @@ class SessionRegistryV2(SessionRegistry):
 
     sessions: dict[str, SessionStateV2]
 
-    def create_session(self) -> str:
+    def create_session(self, request_overrides: dict[str, Any] | None = None) -> str:
         session_id = uuid.uuid4().hex
-        self.sessions[session_id] = SessionStateV2()
+        self.sessions[session_id] = SessionStateV2(request_overrides=dict(request_overrides or {}))
         return session_id
 
     def compute_mismatch(self, messages: list[dict[str, Any]], token_ids: list[int], tools: Any) -> list[dict] | None:

--- a/tests/fast/rollout/generate_hub/test_agentic_v2.py
+++ b/tests/fast/rollout/generate_hub/test_agentic_v2.py
@@ -4,6 +4,7 @@ import pytest
 
 import miles.rollout.generate_hub.agentic_tool_call as agentic_tool_call
 from miles.rollout.base_types import GenerateFnInput
+from miles.rollout.session.request_overrides import SESSION_REQUEST_OVERRIDE_KEYS
 from miles.rollout.session.samples.codec import SamplesReply
 from miles.utils.types import Sample
 
@@ -107,6 +108,22 @@ async def test_sampling_params_are_pinned_and_forwarded_to_agent(monkeypatch):
     }
     assert tracer.request_overrides == expected
     assert seen["request_kwargs"] == expected
+
+
+def test_sampling_params_exclude_chat_fields_rejected_by_sessions() -> None:
+    unsupported_chat_fields = (
+        set(agentic_tool_call.ChatCompletionRequest.model_fields)
+        - SESSION_REQUEST_OVERRIDE_KEYS
+        - {"model", "messages"}
+    )
+    assert unsupported_chat_fields
+    sampling_params = {key: True for key in unsupported_chat_fields}
+    sampling_params["temperature"] = 0.7
+
+    request_kwargs = agentic_tool_call.build_chat_request_kwargs(sampling_params)
+
+    assert request_kwargs == {"temperature": 0.7}
+    assert set(request_kwargs) <= SESSION_REQUEST_OVERRIDE_KEYS
 
 
 @pytest.mark.asyncio

--- a/tests/fast/rollout/generate_hub/test_agentic_v2.py
+++ b/tests/fast/rollout/generate_hub/test_agentic_v2.py
@@ -26,7 +26,7 @@ class _Tracer:
         return self.reply
 
 
-def _generate_input(**args_kwargs) -> GenerateFnInput:
+def _generate_input(*, sampling_params: dict | None = None, **args_kwargs) -> GenerateFnInput:
     args = SimpleNamespace(
         session_server_ip="127.0.0.1",
         session_server_ports=[12345],
@@ -43,7 +43,12 @@ def _generate_input(**args_kwargs) -> GenerateFnInput:
         label="label",
         metadata={"source": "test"},
     )
-    return GenerateFnInput(state=state, sample=sample, sampling_params={}, evaluation=False)
+    return GenerateFnInput(
+        state=state,
+        sample=sample,
+        sampling_params=sampling_params or {},
+        evaluation=False,
+    )
 
 
 async def _fake_agent(**kwargs):
@@ -51,7 +56,8 @@ async def _fake_agent(**kwargs):
 
 
 def _patch_agent(monkeypatch, tracer):
-    async def fake_create(args):
+    async def fake_create(args, *, request_overrides=None):
+        tracer.request_overrides = request_overrides
         return tracer
 
     monkeypatch.setattr(agentic_tool_call.OpenAIEndpointTracer, "create", fake_create)
@@ -68,6 +74,39 @@ async def test_success_returns_list_and_forwards_agent_metadata(monkeypatch):
 
     assert output.samples == [sample]
     assert tracer.agent_metadata == {"agent_result": "done"}
+
+
+@pytest.mark.asyncio
+async def test_sampling_params_are_pinned_and_forwarded_to_agent(monkeypatch):
+    sample = Sample(status=Sample.Status.COMPLETED, response="done", response_length=1, tokens=[1])
+    tracer = _Tracer(SamplesReply(samples=[sample], session_metadata={}, empty_reason=None))
+    _patch_agent(monkeypatch, tracer)
+    seen: dict = {}
+
+    async def capture_agent(**kwargs):
+        seen.update(kwargs)
+        return {}
+
+    monkeypatch.setattr(agentic_tool_call, "load_function", lambda path: capture_agent)
+    sampling_params = {
+        "max_new_tokens": 4096,
+        "temperature": 0.7,
+        "top_p": 0.9,
+        "top_k": 20,
+        "sampling_seed": 42,
+    }
+
+    await agentic_tool_call.generate(_generate_input(sampling_params=sampling_params))
+
+    expected = {
+        "max_tokens": 4096,
+        "temperature": 0.7,
+        "top_p": 0.9,
+        "top_k": 20,
+        "seed": 42,
+    }
+    assert tracer.request_overrides == expected
+    assert seen["request_kwargs"] == expected
 
 
 @pytest.mark.asyncio

--- a/tests/fast/rollout/generate_hub/test_agentic_v2.py
+++ b/tests/fast/rollout/generate_hub/test_agentic_v2.py
@@ -126,6 +126,10 @@ def test_sampling_params_exclude_chat_fields_rejected_by_sessions() -> None:
     assert set(request_kwargs) <= SESSION_REQUEST_OVERRIDE_KEYS
 
 
+def test_session_override_allowlist_is_supported_by_sglang() -> None:
+    assert SESSION_REQUEST_OVERRIDE_KEYS <= set(agentic_tool_call.ChatCompletionRequest.model_fields)
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize("empty_reason", ["no_records", "all_truncated"])
 async def test_empty_reply_returns_aborted_list(monkeypatch, empty_reason):

--- a/tests/fast/rollout/generate_hub/test_multi_turn.py
+++ b/tests/fast/rollout/generate_hub/test_multi_turn.py
@@ -153,6 +153,8 @@ def expected_openai_request(messages: list[dict], **extra) -> dict:
         "messages": messages,
         "model": "default",
         "tools": SAMPLE_TOOLS,
+        "max_tokens": DEFAULT_SAMPLING_PARAMS["max_new_tokens"],
+        "temperature": DEFAULT_SAMPLING_PARAMS["temperature"],
         # Injected by the session route for TITO token tracking
         "logprobs": True,
         "return_meta_info": True,

--- a/tests/fast/rollout/generate_utils/test_openai_endpoint_utils.py
+++ b/tests/fast/rollout/generate_utils/test_openai_endpoint_utils.py
@@ -76,9 +76,7 @@ async def test_create_sends_session_request_overrides(monkeypatch):
         request_overrides={"max_tokens": 4096, "temperature": 0.7, "seed": 42},
     )
 
-    assert seen == [
-        {"request_overrides": {"max_tokens": 4096, "temperature": 0.7, "seed": 42}}
-    ]
+    assert seen == [{"request_overrides": {"max_tokens": 4096, "temperature": 0.7, "seed": 42}}]
 
 
 @pytest.mark.asyncio

--- a/tests/fast/rollout/generate_utils/test_openai_endpoint_utils.py
+++ b/tests/fast/rollout/generate_utils/test_openai_endpoint_utils.py
@@ -61,6 +61,27 @@ async def test_create_without_instance_id_on_args(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_create_sends_session_request_overrides(monkeypatch):
+    seen: list[dict] = []
+
+    async def fake_post(url: str, payload: dict, action: str = "post"):
+        seen.append(payload)
+        return {"session_id": "session-123"}
+
+    monkeypatch.setattr("miles.rollout.generate_utils.openai_endpoint_utils.post", fake_post)
+
+    args = SimpleNamespace(session_server_ip="127.0.0.1", session_server_ports=[12345])
+    await OpenAIEndpointTracer.create(
+        args,
+        request_overrides={"max_tokens": 4096, "temperature": 0.7, "seed": 42},
+    )
+
+    assert seen == [
+        {"request_overrides": {"max_tokens": 4096, "temperature": 0.7, "seed": 42}}
+    ]
+
+
+@pytest.mark.asyncio
 async def test_create_distributes_sessions_across_port_range(monkeypatch):
     """With a multi-port range, sessions land on more than one instance, and every
     request of a session (create, samples POST, DELETE) hits the port chosen

--- a/tests/fast/rollout/session/test_request_overrides.py
+++ b/tests/fast/rollout/session/test_request_overrides.py
@@ -1,0 +1,58 @@
+import pytest
+
+from miles.rollout.session.request_overrides import validate_session_request_override_values
+
+
+def test_validate_session_request_override_values_accepts_supported_shapes() -> None:
+    validate_session_request_override_values(
+        {
+            "custom_logit_processor": ["processor", None],
+            "custom_params": {"backend": True},
+            "ebnf": None,
+            "frequency_penalty": 0.1,
+            "ignore_eos": False,
+            "logit_bias": {"42": -1.5},
+            "max_completion_tokens": None,
+            "max_tokens": 128,
+            "min_p": 0.05,
+            "min_tokens": 1,
+            "presence_penalty": 0,
+            "regex": "answer",
+            "repetition_penalty": 1.1,
+            "response_format": {"type": "json_object"},
+            "seed": 42,
+            "stop": ["done"],
+            "stop_regex": "finished",
+            "stop_token_ids": [1, 2],
+            "temperature": 0.7,
+            "top_k": 20,
+            "top_p": 0.9,
+        }
+    )
+
+
+@pytest.mark.parametrize(
+    ("key", "value", "expected"),
+    [
+        ("frequency_penalty", True, "number"),
+        ("ignore_eos", 1, "boolean"),
+        ("max_tokens", 1.5, "integer or null"),
+        ("regex", 7, "string or null"),
+        ("custom_params", [], "object or null"),
+        ("logit_bias", {"42": "high"}, "object with numeric values or null"),
+        ("stop", [1], "string or list of strings or null"),
+        ("custom_logit_processor", [1], "string or list of nullable strings or null"),
+        ("stop_token_ids", [True], "list of integers or null"),
+        ("min_tokens", None, "integer"),
+    ],
+)
+def test_validate_session_request_override_values_rejects_invalid_shapes(
+    key: str,
+    value: object,
+    expected: str,
+) -> None:
+    with pytest.raises(
+        ValueError,
+        match=rf"invalid session request override '{key}': expected {expected}, got",
+    ):
+        validate_session_request_override_values({key: value})

--- a/tests/fast/router/test_anthropic_sessions.py
+++ b/tests/fast/router/test_anthropic_sessions.py
@@ -40,6 +40,44 @@ def _request(**overrides: object) -> dict:
 
 
 class TestAnthropicSessionRoute:
+    def test_session_sampling_overrides_win_over_claude_request(self, router_env) -> None:
+        create = requests.post(
+            f"{router_env.url}/sessions",
+            json={"request_overrides": {"max_tokens": 128, "temperature": 0.4, "top_p": 0.8}},
+            timeout=5.0,
+        )
+        session_id = create.json()["session_id"]
+
+        response = _post_messages(
+            router_env.url,
+            session_id,
+            _request(max_tokens=4096, temperature=1.0, top_p=1.0),
+        )
+
+        assert response.status_code == 200
+        request = router_env.backend.request_log[-1]
+        assert request["max_tokens"] == 128
+        assert request["temperature"] == 0.4
+        assert request["top_p"] == 0.8
+
+    def test_session_rejects_non_sampling_overrides(self, router_env) -> None:
+        response = requests.post(
+            f"{router_env.url}/sessions",
+            json={"request_overrides": {"messages": []}},
+            timeout=5.0,
+        )
+
+        assert response.status_code == 400
+        assert "unsupported session request overrides" in response.json()["error"]
+
+        response = requests.post(
+            f"{router_env.url}/sessions",
+            json={"request_overrides": []},
+            timeout=5.0,
+        )
+        assert response.status_code == 400
+        assert response.json()["error"] == "request_overrides must be an object"
+
     def test_non_streaming_request_is_recorded_in_openai_form(self, router_env) -> None:
         session_id = _create_session(router_env.url)
         response = _post_messages(

--- a/tests/fast/router/test_sessions.py
+++ b/tests/fast/router/test_sessions.py
@@ -141,6 +141,34 @@ class TestSessionRoutes:
         else:
             assert response.json()["error"] == expected_error
 
+    @pytest.mark.parametrize(
+        ("request_overrides", "expected_error"),
+        [
+            (
+                {"n": 2},
+                "unsupported session request overrides: ['n']",
+            ),
+            (
+                {"temperature": "hot"},
+                "invalid session request override 'temperature': expected number or null, got str",
+            ),
+        ],
+    )
+    def test_create_session_rejects_invalid_request_overrides(
+        self,
+        router_env,
+        request_overrides: dict[str, object],
+        expected_error: str,
+    ) -> None:
+        response = requests.post(
+            f"{router_env.url}/sessions",
+            json={"request_overrides": request_overrides},
+            timeout=5.0,
+        )
+
+        assert response.status_code == 400
+        assert response.json()["error"] == expected_error
+
     def test_get_session_initial_state(self, router_env):
         session_id = requests.post(f"{router_env.url}/sessions", timeout=5.0).json()["session_id"]
 

--- a/tests/fast/router/test_sessions.py
+++ b/tests/fast/router/test_sessions.py
@@ -108,6 +108,39 @@ class TestSessionRoutes:
         assert "session_id" in data
         assert len(data["session_id"]) == 32
 
+    def test_create_session_rejects_invalid_json(self, router_env) -> None:
+        response = requests.post(
+            f"{router_env.url}/sessions",
+            data=b"{not json",
+            headers={"Content-Type": "application/json"},
+            timeout=5.0,
+        )
+
+        assert response.status_code == 400
+        assert response.json()["error"].startswith("invalid JSON body:")
+
+    @pytest.mark.parametrize(
+        ("payload", "expected_status", "expected_error"),
+        [
+            ([], 400, "session request must be an object"),
+            ({"request_overrides": None}, 200, None),
+        ],
+    )
+    def test_create_session_handles_non_object_and_null_overrides(
+        self,
+        router_env,
+        payload: object,
+        expected_status: int,
+        expected_error: str | None,
+    ) -> None:
+        response = requests.post(f"{router_env.url}/sessions", json=payload, timeout=5.0)
+
+        assert response.status_code == expected_status
+        if expected_error is None:
+            assert "session_id" in response.json()
+        else:
+            assert response.json()["error"] == expected_error
+
     def test_get_session_initial_state(self, router_env):
         session_id = requests.post(f"{router_env.url}/sessions", timeout=5.0).json()["session_id"]
 

--- a/tests/fast/router/test_sessions_v2.py
+++ b/tests/fast/router/test_sessions_v2.py
@@ -135,6 +135,27 @@ class TestAnthropicMessages:
         assert session["records"][0]["path"] == "/v1/chat/completions"
         assert len(session["metadata"]["tree"]["nodes"]) == 1
 
+    def test_session_sampling_overrides_reach_v2_backend(self, router_env) -> None:
+        session_id = requests.post(
+            f"{router_env.url}/sessions",
+            json={"request_overrides": {"max_tokens": 96, "temperature": 0.3}},
+            timeout=5.0,
+        ).json()["session_id"]
+        response = requests.post(
+            f"{router_env.url}/sessions/{session_id}/v1/messages",
+            json={
+                "model": "mock-model",
+                "max_tokens": 2048,
+                "temperature": 1.0,
+                "messages": [{"role": "user", "content": "hello"}],
+            },
+            timeout=10.0,
+        )
+
+        assert response.status_code == 200
+        assert router_env.backend.request_log[-1]["max_tokens"] == 96
+        assert router_env.backend.request_log[-1]["temperature"] == 0.3
+
 
 def test_lora_adapter_reaches_backend():
     with _serve_router({"lora_rank": 8}) as env:


### PR DESCRIPTION
## Summary

- pin Miles rollout request parameters into each session when `agentic_tool_call.generate` creates it
- apply those parameters after the agent request is parsed, so Claude Code cannot silently replace Miles's `max_tokens`, temperature, top-p, top-k, seed, stop, or other sampling controls
- document that session pins are authoritative, including the intentional replacement of Anthropic's required per-turn `max_tokens`
- share one session-override allowlist between the rollout sender and session server, preventing legal-but-session-unsupported `ChatCompletionRequest` fields from making session creation fail
- reject unsupported multi-choice `n` at session creation instead of allowing every turn to fail upstream
- validate the JSON shape of every supported pinned value at session creation, so invalid values such as `{"temperature": "hot"}` fail immediately with a clear 400 response
- support the same policy in linear sessions and v2 trajectory-tree sessions, with a narrow allowlist that rejects structural overrides such as `messages`
- update the existing agentic multi-turn expectations for the pinned `max_tokens` and `temperature` fields

## Stack

4 of 4. Depends on #2262.

This completes the Claude Code session-adapter chain:

- #2259 — Anthropic request conversion
- #2261 — Anthropic response/SSE conversion with dedicated abort detection, tool-use stop-reason enforcement, and non-finite argument sanitization
- #2262 — recorded `/v1/messages` session route with retryable JSON/SSE abort errors and full retry/TITO coverage

## Tests

- repository pre-commit hooks pass on all changed files
- 147 adapter-focused protocol, route, session-policy, tracer, and rollout-wrapper tests pass locally
- six focused session-creation cases pass, including malformed JSON, non-object bodies, `request_overrides: null`, unsupported `n`, invalid override value types, and the default empty request
- 11 focused value-shape tests cover valid nullable/scalar/container forms and invalid number, integer, boolean, string, object, and list forms
- the sender/server allowlist is asserted to be a subset of the installed SGLang `ChatCompletionRequest.model_fields`; a separate invariant confirms non-allowlisted chat fields are excluded
- the inherited protocol adapter has 100% isolated coverage: 325/325 statements and 202/202 branches
- the 529 → retry → subsequent-turn TITO-prefix-check integration flow passes

Canonical pytest invocations use normal conftest discovery. Local macOS integration validation used lightweight import stubs for SGLang and Ray because their full GPU runtime is unavailable on the host; the exercised Miles logic and mock HTTP backend are unchanged.
