### PR TITLE
[AMD] Enable Qwen3 FSDP hybrid-shard CI on ROCm

### DIFF
--- a/miles/backends/fsdp_utils/parallel.py
+++ b/miles/backends/fsdp_utils/parallel.py
@@ -24,11 +24,18 @@ def build_fsdp_meshes(
     )
     fsdp_mesh = dp_mesh
     if dp_replicate_size > 1:
-        fsdp_mesh = dp_mesh._unflatten(
-            0,
-            (dp_replicate_size, world_size // dp_replicate_size),
-            ("dp_replicate", "dp_shard"),
-        )
+        if hasattr(dp_mesh, "_unflatten"):
+            fsdp_mesh = dp_mesh._unflatten(
+                0,
+                (dp_replicate_size, world_size // dp_replicate_size),
+                ("dp_replicate", "dp_shard"),
+            )
+        else:
+            fsdp_mesh = init_device_mesh(
+                device_type,
+                mesh_shape=(dp_replicate_size, world_size // dp_replicate_size),
+                mesh_dim_names=("dp_replicate", "dp_shard"),
+            )
 
     return {
         "dp": dp_mesh,

--- a/tests/e2e/fsdp/test_qwen3_4B_fsdp_hybrid_shard_r2s2.py
+++ b/tests/e2e/fsdp/test_qwen3_4B_fsdp_hybrid_shard_r2s2.py
@@ -13,7 +13,6 @@ register_rocm_ci(
     est_time=600,
     suite="stage-c-4-gpu-mi300x",
     labels=["fsdp", "amd"],
-    disabled="Disable due to failure",
 )
 
 NUM_GPUS = 4


### PR DESCRIPTION
## Summary

Enable the Qwen3 FSDP hybrid-shard CI test on AMD GPUs.

ROCm’s PyTorch version does not provide the private `DeviceMesh._unflatten` method used to construct the hybrid-shard mesh. This PR adds a capability-based fallback using `init_device_mesh`.

Newer PyTorch releases continue using the existing `_unflatten` path, so behavior on NVIDIA and newer environments remains unchanged.

## Testing

Validated on 4× AMD MI355 GPUs with PyTorch 2.9.1+ROCm:

- `tests/e2e/fsdp/test_qwen3_4B_fsdp_hybrid_shard_r2s2.py`
- `tests/fast-gpu/test_fsdp_hybrid_shard.py`
  - r1s4
  - r2s2
  - r4s1

All tests passed.