### PR TITLE
[AMD] Enable GLM-5.2 CI on ROCm

### DIFF
--- a/miles_plugins/models/glm5/ops/tilelang_sparse_mla_fwd.py
+++ b/miles_plugins/models/glm5/ops/tilelang_sparse_mla_fwd.py
@@ -1,6 +1,7 @@
 # ruff: noqa
 # Adapted from https://github.com/tile-ai/tilelang/blob/e666d2d3cc483829c57618c9ebf2e4f4ada0819d/examples/deepseek_v32/sparse_mla_fwd.py
 import tilelang
+import torch
 from tilelang import language as T
 
 
@@ -68,6 +69,8 @@ def sparse_mla_fwd(
         REPLICATE_H = 1
 
     H_per_block = padded_H if REPLICATE_H == 1 else 64
+    # A two-stage pipeline exceeds the 160 KiB LDS limit on MI355.
+    kernel_num_stages = min(num_stages, 1) if torch.version.hip is not None else num_stages
 
     @T.prim_func
     def main(
@@ -114,7 +117,7 @@ def sparse_mla_fwd(
             T.copy(Q[b_i, s_i, H0:H1, :D], Q_shared)
             T.copy(Q[b_i, s_i, H0:H1, D:], Q_tail_shared)
 
-            for i_i in T.Pipelined(NI, num_stages=num_stages):
+            for i_i in T.Pipelined(NI, num_stages=kernel_num_stages):
                 for bi_i in T.Parallel(BI):
                     # Changed here for thd
                     mask[bi_i] = Indices[b_i, s_i, g_i, i_i * BI + bi_i] != -1

--- a/scripts/run_glm5_2_744b_a40b.py
+++ b/scripts/run_glm5_2_744b_a40b.py
@@ -61,6 +61,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
 
+import torch
 import typer
 
 import miles.utils.external_utils.command_utils as U
@@ -353,6 +354,12 @@ def _execute_train(args: ScriptArgs):
         sglang_decode_max_bs = 32
         sglang_world_size = 4 if balanced else min(8, args.num_gpus_per_node)
 
+    if torch.version.hip is not None:
+        dsa_prefill_backend = dsa_decode_backend = "tilelang"
+    else:
+        dsa_prefill_backend = "flashmla_sparse"
+        dsa_decode_backend = "flashmla_kv"
+
     sglang_args = (
         f"--rollout-num-gpus-per-engine {sglang_world_size} "
         # 0.85: measured on the full 744B, 64x GB300 (276GB). 0.75 there leaves
@@ -398,9 +405,8 @@ def _execute_train(args: ScriptArgs):
         sglang_args += "--prefill-num-servers 1 "
     sglang_args += (
         "--sglang-kv-cache-dtype fp8_e4m3 "
-        # flashmla_kv decode / flashmla_sparse prefill (GLM-5.2 recipe)
-        "--sglang-nsa-decode-backend flashmla_kv "
-        "--sglang-nsa-prefill-backend flashmla_sparse "
+        f"--sglang-nsa-decode-backend {dsa_decode_backend} "
+        f"--sglang-nsa-prefill-backend {dsa_prefill_backend} "
         "--sglang-attention-backend nsa "
         "--sglang-page-size 64 "
         f"--sglang-cuda-graph-max-bs {sglang_decode_max_bs} "

--- a/tests/e2e/megatron/model_scripts/test_glm5_2_744b_a40b_5layer_ci.py
+++ b/tests/e2e/megatron/model_scripts/test_glm5_2_744b_a40b_5layer_ci.py
@@ -1,5 +1,7 @@
 import os
 
+import torch
+
 from scripts.run_glm5_2_744b_a40b import (
     ScriptArgs,
     _convert_to_fp8,
@@ -23,7 +25,6 @@ register_rocm_ci(
     est_time=900,
     suite="stage-c-4-gpu-mi300x",
     labels=["megatron", "model-scripts", "amd"],
-    disabled="Disable due to failure",
 )
 
 register_ci_gate(metric_key="train/grad_norm")
@@ -40,7 +41,12 @@ def _args() -> ScriptArgs:
         num_gpus_per_node=4,
         num_rollout=2,
         enable_optimizer_offload=True,
-        extra_args=("--ci-test " "--ci-disable-logprobs-checker "),
+        megatron_use_deepep=torch.version.hip is None,
+        extra_args=(
+            "--ci-test "
+            "--ci-disable-logprobs-checker "
+            "--check-weight-update-skip-list rotary_emb.cos_cache rotary_emb.sin_cache "
+        ),
     )
 
 


### PR DESCRIPTION
## Summary

Enable the GLM-5.2 five-layer Megatron CI test on AMD GPUs.

The ROCm path now uses TileLang instead of CUDA-only FlashMLA, falls back to all-to-all MoE dispatch when DeepEP is unavailable, and limits TileLang pipeline staging to fit MI355 LDS. The test also excludes generated rotary caches from weight validation.

The existing NVIDIA backends and pipeline behavior remain unchanged.

## Testing

Passed `tests/e2e/megatron/model_scripts/test_glm5_2_744b_a40b_5layer_ci.py` on 4× AMD MI355 GPUs with both rollouts, training steps, checkpointing, and weight synchronization completing successfully.