### PR TITLE
[fix] drop --disable-weights-backuper from the nemotron CI test

### DIFF
--- a/tests/e2e/megatron/model_scripts/test_nemotron_3_ultra_4layer_ci.py
+++ b/tests/e2e/megatron/model_scripts/test_nemotron_3_ultra_4layer_ci.py
@@ -42,7 +42,7 @@ def _args() -> ScriptArgs:
         n_samples_per_prompt=2,
         global_batch_size=16,
         skip_saving=True,
-        extra_args=("--ci-test " "--ci-disable-logprobs-checker " "--disable-weights-backuper "),
+        extra_args=("--ci-test " "--ci-disable-logprobs-checker "),
     )
 
 


### PR DESCRIPTION
#2223 (52ac174d9) removed `--disable-weights-backuper` from `miles/utils/arguments.py` but missed the one test registration still passing it, so `test_nemotron_3_ultra_4layer_ci.py` has failed at argparse (`train.py: error: unrecognized arguments: --disable-weights-backuper`, ~93 s, before any GPU work) on every megatron-domain CI run since — first observed on [run 31223739466](https://github.com/radixark/miles/actions/runs/31223739466/job/93014745550).

`git grep disable-weights-backuper` now returns nothing.

Labeled `run-ci-model-scripts` — the smaller of the test's two domain labels (17 tests vs 43+ for `megatron`) — so the fix is verified by the suite that was failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)