### PR TITLE
rocm: enabling  tests/e2e/megatron/model_scripts/test_glm5_2_744b_a40b_5layer_ci.py

### DIFF
--- a/miles_plugins/models/glm5/ops/tilelang_sparse_mla_bwd.py
+++ b/miles_plugins/models/glm5/ops/tilelang_sparse_mla_bwd.py
@@ -101,6 +101,7 @@ def bwd(
     indices_dtype=T.int32,
     dtype=T.bfloat16,
     accum_dtype=T.float32,
+    block_H_override=None,
 ):
     assert is_causal == True, "non-casual is not supported now"
     assert topk % block_size == 0, "otherwise will load some index=0 thus causing wrong kv to be loaded"
@@ -125,7 +126,10 @@ def bwd(
 
     H = H_kv
     padded_H = max(tilelang.math.next_power_of_2(H_kv), 16)
-    block_H = min(64, padded_H)
+    # block_H controls the H-axis tile and dominates Q/dO/dQ shared-memory
+    # footprint. Original default min(64, padded_H) targets H100 (228KB LDS);
+    # callers on gfx950 (160KB LDS) pass block_H_override=16 to fit the budget.
+    block_H = block_H_override if block_H_override is not None else min(64, padded_H)
     assert padded_H % block_H == 0
     NH = padded_H // block_H
     BS = block_size
@@ -297,7 +301,27 @@ def sparse_mla_bwd(q, kv, o, do, indices, lse, sm_scale=None, is_casual=True, re
 
     # Get kernels
     preprocess_kernel = preprocess(B, S, H, D)
-    bwd_kernel = bwd(B, S, S_kv, H, D, D_tail, topk, kv_group, sm_scale, is_casual)
+    # gfx950 (MI300/MI355) has 160KB LDS per workgroup; the default tile
+    # (block_H=64, num_stages=2) needs ~217KB. Shrink block_H to 16 and
+    # disable double-buffering on ROCm. NV path unchanged.
+    if torch.version.hip is not None:
+        bwd_kernel = bwd(
+            B,
+            S,
+            S_kv,
+            H,
+            D,
+            D_tail,
+            topk,
+            kv_group,
+            sm_scale,
+            is_casual,
+            block_size=32,
+            num_stages=1,
+            block_H_override=16,
+        )
+    else:
+        bwd_kernel = bwd(B, S, S_kv, H, D, D_tail, topk, kv_group, sm_scale, is_casual)
     postprocess_kernel = postprocess(B, S_kv, D, D_tail, kv_group)
 
     if delta is None:

--- a/miles_plugins/models/glm5/ops/tilelang_sparse_mla_fwd.py
+++ b/miles_plugins/models/glm5/ops/tilelang_sparse_mla_fwd.py
@@ -1,6 +1,7 @@
 # ruff: noqa
 # Adapted from https://github.com/tile-ai/tilelang/blob/e666d2d3cc483829c57618c9ebf2e4f4ada0819d/examples/deepseek_v32/sparse_mla_fwd.py
 import tilelang
+import torch
 from tilelang import language as T
 
 
@@ -23,6 +24,7 @@ def sparse_mla_fwd(
     block_I=64,
     num_stages=2,
     threads=256,
+    h_per_block=None,
 ):
     assert dim == tilelang.math.next_power_of_2(dim), f"haven't check padding correctness yet, dim={dim}"
     assert tail_dim == tilelang.math.next_power_of_2(
@@ -61,13 +63,19 @@ def sparse_mla_fwd(
     D = dim
     D_tail = tail_dim
 
-    if head_kv > 64:
-        assert head_kv % 64 == 0, "head_kv should be a multiple of 64"
-        REPLICATE_H = head_kv // 64
-    else:
-        REPLICATE_H = 1
-
-    H_per_block = padded_H if REPLICATE_H == 1 else 64
+    # H_per_block controls Q_shared/O_shared LDS footprint (H_per_block * D * 2 bytes).
+    # Original behavior pins it to padded_H (or 64 when head_kv > 64), which works on
+    # H100 (228KB LDS). On gfx950 (160KB LDS) the wrapper passes h_per_block=32 so
+    # Q_shared+O_shared drop from 128KB to 64KB. Pass h_per_block=None for the
+    # original H100-tuned behavior.
+    if h_per_block is None:
+        h_per_block = padded_H if head_kv <= 64 else 64
+    # Cap at padded_H so callers passing a larger override don't trip the
+    # divisibility assert below (e.g. h_per_block=32 with head_kv=16, padded_H=16).
+    h_per_block = min(h_per_block, padded_H)
+    assert padded_H % h_per_block == 0, f"padded_H={padded_H} must be divisible by h_per_block={h_per_block}"
+    H_per_block = h_per_block
+    REPLICATE_H = padded_H // H_per_block
 
     @T.prim_func
     def main(
@@ -108,7 +116,7 @@ def sparse_mla_fwd(
             q_i = s_i
             max_kv_i = q_i
 
-            H0 = g_i * padded_H + (0 if REPLICATE_H == 1 else (bx % REPLICATE_H) * 64)
+            H0 = g_i * padded_H + (0 if REPLICATE_H == 1 else (bx % REPLICATE_H) * H_per_block)
             H1 = H0 + H_per_block
 
             T.copy(Q[b_i, s_i, H0:H1, :D], Q_shared)
@@ -170,8 +178,25 @@ def sparse_mla_fwd(
 
 
 def sparse_mla_fwd_interface(
-    q, kv, indices, sm_scale=None, return_p_sum: bool = False, d_v=512, block_I=64, num_stages=2, threads=256
+    q,
+    kv,
+    indices,
+    sm_scale=None,
+    return_p_sum: bool = False,
+    d_v=512,
+    block_I=64,
+    num_stages=2,
+    threads=256,
+    h_per_block=None,
 ):
+    # gfx950 (MI300/MI355) has 160KB LDS per workgroup; the default tile
+    # (h_per_block=64, num_stages=2) needs ~231KB. Shrink the H tile and
+    # disable double-buffering on ROCm. NV path unchanged.
+    if torch.version.hip is not None:
+        if h_per_block is None:
+            h_per_block = 32
+        if num_stages > 1:
+            num_stages = 1
     q = q.unsqueeze(0)
     kv = kv.unsqueeze(0)
     indices = indices.unsqueeze(0)
@@ -202,6 +227,7 @@ def sparse_mla_fwd_interface(
         block_I=block_I,
         num_stages=num_stages,
         threads=threads,
+        h_per_block=h_per_block,
     )
     out, lse = kernel(q, kv, indices)
     out = out.squeeze(0)

--- a/tests/e2e/megatron/model_scripts/test_glm5_2_744b_a40b_5layer_ci.py
+++ b/tests/e2e/megatron/model_scripts/test_glm5_2_744b_a40b_5layer_ci.py
@@ -37,14 +37,7 @@ register_ci_gate(metric_key="rollout/raw_reward")
 def _args() -> ScriptArgs:
     extra_args = "--ci-test " "--ci-disable-logprobs-checker "
     if IS_ROCM:
-        # HIP-only indexer buffers (deepseek_v4.py registers rotary_emb.{cos,sin}_cache
-        # under `if _is_hip`) are derived from freqs_cis, so the trainer never re-ships
-        # them; their names miss sglang's `cos_sin_cache` exemption pattern.
         extra_args += "--check-weight-update-skip-list rotary_emb. "
-        # Colocate would default both to on; the torch_memory_saver free path they rely on
-        # deadlocks in the HSA runtime, so keep trainer and rollout engine resident instead.
-        # Disabling offload also leaves the memory saver un-preloaded, so the weights
-        # backuper cannot source CPU backups from it and has to keep its own host copy.
         extra_args += "--no-offload-train --no-offload-rollout "
     else:
         extra_args += "--disable-weights-backuper "

--- a/tests/e2e/megatron/model_scripts/test_glm5_2_744b_a40b_5layer_ci.py
+++ b/tests/e2e/megatron/model_scripts/test_glm5_2_744b_a40b_5layer_ci.py
@@ -10,6 +10,7 @@ from scripts.run_glm5_2_744b_a40b import (
 )
 from tests.ci.ci_register import register_cuda_ci, register_rocm_ci
 from tests.ci.metric_history import register_ci_gate
+from tests.ci.rocm_utils import IS_ROCM
 
 import miles.utils.external_utils.command_utils as U
 
@@ -34,13 +35,26 @@ register_ci_gate(metric_key="rollout/raw_reward")
 
 
 def _args() -> ScriptArgs:
+    extra_args = "--ci-test " "--ci-disable-logprobs-checker "
+    if IS_ROCM:
+        # HIP-only indexer buffers (deepseek_v4.py registers rotary_emb.{cos,sin}_cache
+        # under `if _is_hip`) are derived from freqs_cis, so the trainer never re-ships
+        # them; their names miss sglang's `cos_sin_cache` exemption pattern.
+        extra_args += "--check-weight-update-skip-list rotary_emb. "
+        # Colocate would default both to on; the torch_memory_saver free path they rely on
+        # deadlocks in the HSA runtime, so keep trainer and rollout engine resident instead.
+        # Disabling offload also leaves the memory saver un-preloaded, so the weights
+        # backuper cannot source CPU backups from it and has to keep its own host copy.
+        extra_args += "--no-offload-train --no-offload-rollout "
+    else:
+        extra_args += "--disable-weights-backuper "
     return ScriptArgs(
         model_name="GLM-5.2_5layer",
         num_nodes=1,
         num_gpus_per_node=4,
         num_rollout=2,
         enable_optimizer_offload=True,
-        extra_args=("--ci-test " "--ci-disable-logprobs-checker " "--disable-weights-backuper "),
+        extra_args=extra_args,
     )
 
 


### PR DESCRIPTION
## Summary
ROCm/gfx950 fixes for the GLM-5.2 (`glm_moe_dsa`) path: two tilelang sparse-MLA kernels that could not launch within the 160 KB LDS budget, plus the 5-layer CI test that deadlocked in the colocate offload path. All branches are gated on `torch.version.hip` / `IS_ROCM`, leaving CUDA behavior unchanged.
### `miles_plugins/models/glm5/ops/tilelang_sparse_mla_fwd.py`
- Add an `h_per_block` parameter threaded from the interface wrapper into `sparse_mla_fwd` so the H-axis tile size is caller-controlled.
- Derive `REPLICATE_H` as `padded_H // H_per_block` instead of hardcoding 64, so the `s_i` and `H0` block-index math follows automatically.
- Cap `h_per_block` at `min(h_per_block, padded_H)` so a larger caller override cannot trip the `padded_H % h_per_block == 0` assert.
- On HIP, default `h_per_block` to 32 (halving `Q_shared + O_shared` from 128 KB to 64 KB) and clamp `num_stages` to 1, since the upstream `(64, 2)` tile needs ~231 KB and will not launch.
### `miles_plugins/models/glm5/ops/tilelang_sparse_mla_bwd.py`
- Add a `block_H_override` parameter that resolves `block_H`, which dominates the Q/dO/dQ shared-memory footprint.
- On HIP, pass `block_H_override=16` with `block_size=32` and `num_stages=1`, since the default backward tile needs ~217 KB.
### `tests/e2e/megatron/model_scripts/test_glm5_2_744b_a40b_5layer_ci.py`
- Hoist `extra_args` into a local variable so flags can be appended conditionally.
- On ROCm, add `--check-weight-update-skip-list rotary_emb. ` because the HIP-only indexer buffers registered under `if _is_hip` are derived from `freqs_cis` and their names miss sglang's `cos_sin_cache` exemption pattern.
- On ROCm, add `--no-offload-train --no-offload-rollout`, since `clear_memory()`'s `empty_cache()` otherwise deadlocks all four ranks inside `TorchMemorySaver::free` busy-waiting on an HSA signal.
- Make `--disable-weights-backuper` CUDA-only, because disabling offload leaves `torch_memory_saver` un-`LD_PRELOAD`ed and the backuper then aborts with `AssertionError: TorchMemorySaver observes invalid LD_PRELOAD`.

Depends on #1618 for IS_ROCM definition