### PR TITLE
refactor(openenv): give the sandbox backends one SandboxBackend to share

### DIFF
--- a/examples/experimental/openenv/eval_tbench2_via_api.py
+++ b/examples/experimental/openenv/eval_tbench2_via_api.py
@@ -2,7 +2,7 @@
 per-episode sandboxes as the env. No GPU, no miles training pipeline.
 
 This reuses the exact agent-env loop miles runs during training
-(``openenv_agent_function._multi_turn``: reset -> {policy emits a shell command
+(``openenv_agent_function.multi_turn``: reset -> {policy emits a shell command
 -> exec -> feed output back} -> canonical tests/test.sh -> binary reward) but
 swaps miles' session-server policy for a plain API client. The machine running
 this only orchestrates; the policy runs in the cloud (e.g. DeepSeek) and each
@@ -22,18 +22,19 @@ Env vars:
   DEEPSEEK_API_KEY / POLICY_API_KEY   policy API key (required)
   POLICY_BASE_URL   OpenAI-compatible root (default https://api.deepseek.com)
   POLICY_MODEL      default deepseek-v4-flash
-  OPENENV_TB2_TASKS_DIR  per-episode sandbox mode (TB2 checkout path); with
-                    provider credentials go with it (Daytona: DAYTONA_API_KEY
-                    or ~/.config/daytona/api_key; e2b/agentenv likewise).
-  OPENENV_SANDBOX_BACKEND             required with the above: daytona / e2b /
-                    agentenv (an alias for e2b).
-                    Otherwise OPENENV_ENV_URL is used.
+  OPENENV_SANDBOX_BACKEND   per-episode sandbox mode: agentenv (an alias for
+                    e2b) / daytona / e2b. Left unset, OPENENV_ENV_URL
+                    (one shared env server) is used instead.
+  OPENENV_TB2_TASKS_DIR     required with the above: the TB2 checkout to build
+                    task images from. Each backend then resolves its OWN
+                    credential exactly as it does under training -- from the
+                    environment, else its key file -- so nothing is passed
+                    through here; see the recipe README for each provider's.
   OPENENV_MAX_TURNS, OPENENV_MAX_ROLLOUT_TIME_SECONDS, ...   as in the adapter.
 
 Usage:
-  # DAYTONA_API_KEY may be omitted if ~/.config/daytona/api_key is provisioned
-  DEEPSEEK_API_KEY=sk-... DAYTONA_API_KEY=dtn_... \
-  OPENENV_TB2_TASKS_DIR=/path/to/terminal-bench-2 \
+  DEEPSEEK_API_KEY=sk-... \
+  OPENENV_SANDBOX_BACKEND=e2b OPENENV_TB2_TASKS_DIR=/path/to/terminal-bench-2 \
   python eval_tbench2_via_api.py --tasks chess-best-move --concurrency 2
   # or from make_tbench2_data.py output:
   python eval_tbench2_via_api.py --data /root/tbench2_train.jsonl
@@ -49,6 +50,7 @@ from openai import AsyncOpenAI
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import openenv_agent_function as oaf  # noqa: E402
+import openenv_sandbox_common as sandbox_common  # noqa: E402
 
 
 def _load_rows(args: argparse.Namespace) -> list[dict]:
@@ -110,18 +112,11 @@ async def main() -> None:
     rows = _load_rows(args)
     tasks_dir = os.getenv("OPENENV_TB2_TASKS_DIR", "").strip()
     if tasks_dir:
-        import openenv_sandbox_common as sandbox_common
-
         try:
             backend = sandbox_common.resolve_backend(os.getenv("OPENENV_SANDBOX_BACKEND"))
+            run_episode = sandbox_common.load_backend(backend).run_episode
         except ValueError as e:
             sys.exit(str(e))
-        if backend == "e2b":
-            import openenv_e2b_agent_function as sandbox_leg
-        else:
-            import openenv_daytona_agent_function as sandbox_leg
-
-        run_episode = sandbox_leg.run_episode
         env_desc = f"{backend} sandboxes (tasks_dir={tasks_dir})"
     else:
         run_episode = oaf.run_episode

--- a/examples/experimental/openenv/openenv_agent_function.py
+++ b/examples/experimental/openenv/openenv_agent_function.py
@@ -34,13 +34,14 @@ WORKDIR resolved server-side, verifier assets withheld. The adapter verifies
 the contract on every episode rather than trusting the deployment: an
 ``evaluate`` reply without the canonical-harness marker is treated as no
 verdict and the episode is dropped with a warning (see the guard in
-_multi_turn).
+multi_turn).
 
-Daytona-sandbox variant: ``openenv_daytona_agent_function`` (sibling module)
-is a drop-in ``--custom-agent-function-path`` alternative that runs every
-episode in its own Daytona cloud sandbox. It reuses this module's
-agent loop and training wrapper, supplying only its own run_episode (see the
-episode-wiring note below); its env vars are documented there.
+Per-episode sandbox variants: one sibling module per provider
+(``openenv_{daytona,e2b}_agent_function``), each a drop-in
+``--custom-agent-function-path`` alternative that runs every episode in its
+own cloud sandbox. They reuse this module's agent loop and training wrapper,
+supplying only their own run_episode (see the episode-wiring note below);
+their env vars are documented there.
 """
 
 import asyncio
@@ -78,7 +79,7 @@ _FENCE_RE = re.compile(r"```(?:python|py|bash|sh)?\s*\n?(.*?)```", re.DOTALL | r
 _OBS_CHAR_CAP = 4000
 
 # The system prompt that teaches a policy this adapter's agent contract, i.e.
-# what _multi_turn parses: exactly one shell command per turn in a single
+# what multi_turn parses: exactly one shell command per turn in a single
 # ```bash block, TASK_COMPLETE (no code block) to stop. It lives here, next to
 # that parsing logic; make_tbench2_data.py (training prompt data) and
 # eval_tbench2_via_api.py (API-policy eval) import it so all consumers stay on
@@ -98,7 +99,7 @@ TB2_AGENT_SYSTEM_PROMPT = (
 # default 900). The default clears the server's default budget with margin;
 # raise it (and OPENENV_MAX_ROLLOUT_TIME_SECONDS) for tasks declaring larger
 # verifier budgets.
-_MESSAGE_TIMEOUT_S = float(os.getenv("OPENENV_MESSAGE_TIMEOUT_S", "1200"))
+MESSAGE_TIMEOUT_S = float(os.getenv("OPENENV_MESSAGE_TIMEOUT_S", "1200"))
 
 # Hard wall-clock cap for one episode. The per-message timeout above bounds a
 # single env op, and OPENENV_MAX_TURNS bounds the turn count, but neither bounds
@@ -161,7 +162,7 @@ def _obs_info(result: Any) -> dict:
 
 
 # Lazy import so the file loads without the env client present at import time.
-def _load_tbench2() -> dict[str, Any]:
+def load_tbench2() -> dict[str, Any]:
     from tbench2_env import Tbench2Action, Tbench2Env
 
     return {"env": Tbench2Env, "action": Tbench2Action}
@@ -171,16 +172,16 @@ _DEFAULT_ENV_URL = "http://localhost:8003"
 
 
 # --- Episode wiring -------------------------------------------------------------
-# The agent loop (_multi_turn) is shared; everything that differs between the
+# The agent loop (multi_turn) is shared; everything that differs between the
 # episode legs enters it as two keyword parameters, filled in only by each
 # module's run_episode():
 #
 #   run_body(env_cls, metadata, body)   how an env comes into being — connect to
 #                       the shared server (_shared_run_body below, capacity-
-#                       retried) vs create a Daytona sandbox
-#                       (openenv_daytona_agent_function).
+#                       retried) vs create a per-episode sandbox (the sandbox
+#                       backend modules).
 #   post_episode(env, action_cls)       optional hygiene hook (a long-lived
-#                       shared server accumulates trial dirs; a Daytona
+#                       shared server accumulates trial dirs; a per-episode
 #                       sandbox lives only for its episode and needs nothing).
 #
 # Every agent-function module exposes the same two entries: run() for miles
@@ -231,7 +232,7 @@ async def _with_env(env_cls: Any, env_url: str, body: Callable[[Any], Any]) -> A
     deadline = asyncio.get_event_loop().time() + _CAPACITY_MAX_WAIT_S
     while True:
         try:
-            async with env_cls(base_url=env_url, message_timeout_s=_MESSAGE_TIMEOUT_S) as env:
+            async with env_cls(base_url=env_url, message_timeout_s=MESSAGE_TIMEOUT_S) as env:
                 return await body(env)
         except Exception as e:
             if _is_retryable_env_error(e) and asyncio.get_event_loop().time() < deadline:
@@ -240,7 +241,7 @@ async def _with_env(env_cls: Any, env_url: str, body: Callable[[Any], Any]) -> A
             raise
 
 
-async def _multi_turn(
+async def multi_turn(
     classes: dict[str, Any],
     policy: AsyncOpenAI,
     model_name: str,
@@ -382,8 +383,8 @@ async def run_episode(
     ``(reward, agent_metrics)``; wall-clock caps and failure semantics are the
     caller's. miles goes through run() instead.
     """
-    return await _multi_turn(
-        _load_tbench2(),
+    return await multi_turn(
+        load_tbench2(),
         policy,
         model_name,
         messages,
@@ -394,7 +395,7 @@ async def run_episode(
     )
 
 
-async def _run_for_training(
+async def run_for_training(
     base_url: str,
     prompt: Any,
     request_kwargs: dict[str, Any] | None,
@@ -441,7 +442,7 @@ async def _run_for_training(
         await policy.close()
 
     # No canonical verdict (infra/harness failure or a non-canonical server,
-    # not a legitimate task failure -- see the guard in _multi_turn). Drop the
+    # not a legitimate task failure -- see the guard in multi_turn). Drop the
     # sample: returning it as reward 0.0 would inject a false negative into
     # training.
     if reward is None:
@@ -469,4 +470,4 @@ async def run(
     **kwargs,
 ) -> dict[str, Any] | None:
     """Run one OpenEnv tbench2 episode via the trained policy (shared env server)."""
-    return await _run_for_training(base_url, prompt, request_kwargs, metadata, run_episode)
+    return await run_for_training(base_url, prompt, request_kwargs, metadata, run_episode)

--- a/examples/experimental/openenv/openenv_daytona_agent_function.py
+++ b/examples/experimental/openenv/openenv_daytona_agent_function.py
@@ -36,21 +36,23 @@ Env vars (the agent-loop ones in ``openenv_agent_function`` apply too):
                      logged in plaintext. Point it at a file every node can
                      read: a dotfile, K8s Secret mount, or shared-FS path.
   OPENENV_DAYTONA_CREATE_CONCURRENCY  max in-flight sandbox creates (default 4).
-  OPENENV_DAYTONA_READY_TIMEOUT_S     server-ready wait per sandbox (default 300).
-  TB2_COMMAND_TIMEOUT_S        per-exec timeout inside the sandbox (default 900).
+  OPENENV_DAYTONA_CREATE_MAX_RETRIES  how many throttled creates to retry (default 8).
+
+Everything describing ONE sandbox — the ready deadline, and the auto-stop /
+auto-delete backstop — is documented and read in ``tb2_sandbox_daytona``, and
+the per-exec timeout inside it (TB2_COMMAND_TIMEOUT_S) in
+``tb2_sandbox_recipe``, next to the code each one steers.
 """
 
 import logging
-import os
-from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Any
 
-import openenv_agent_function as oaf
 import openenv_sandbox_common as common
 import tb2_sandbox_daytona
 
 logger = logging.getLogger(__name__)
+
 
 # Each episode materializes the per-task image declaratively from the Image
 # definition, read off the local TB2 checkout (OPENENV_TB2_TASKS_DIR); repeat
@@ -63,19 +65,9 @@ logger = logging.getLogger(__name__)
 # older install outright, and the shared agent loop's harness-marker guard
 # backstops it per episode.
 #
-# Daytona rate-limits sandbox creation (ThrottlerException: Too Many Requests).
-# A rollout fans out many episodes at once; cap in-flight creates process-wide
-# and retry throttled ones with jittered exponential backoff.
-_CREATE_CONCURRENCY = int(os.getenv("OPENENV_DAYTONA_CREATE_CONCURRENCY", "4"))
-_CREATE_MAX_RETRIES = int(os.getenv("OPENENV_DAYTONA_CREATE_MAX_RETRIES", "8"))
-_CREATE_BACKOFF_BASE_S = float(os.getenv("OPENENV_DAYTONA_CREATE_BACKOFF_BASE_S", "2.0"))
-_CREATE_BACKOFF_CAP_S = float(os.getenv("OPENENV_DAYTONA_CREATE_BACKOFF_CAP_S", "30.0"))
-_READY_TIMEOUT_S = float(os.getenv("OPENENV_DAYTONA_READY_TIMEOUT_S", "300"))
-_COMMAND_TIMEOUT_S = int(os.getenv("TB2_COMMAND_TIMEOUT_S", "900"))
-
-_get_create_sem = common.lazy_semaphore(_CREATE_CONCURRENCY)
-
-
+# Daytona rate-limits sandbox creation (ThrottlerException: Too Many Requests);
+# the shared backend caps in-flight creates process-wide and retries throttled ones
+# with jittered exponential backoff (knobs: OPENENV_DAYTONA_CREATE_*).
 def _is_throttle_error(exc: BaseException) -> bool:
     """True when a sandbox create failed only because Daytona rate-limited it.
 
@@ -93,86 +85,24 @@ def _is_throttle_error(exc: BaseException) -> bool:
             return True
     except ImportError:  # pragma: no cover - only without the daytona SDK
         pass
-    s = str(exc).lower()
-    return "throttler" in s or "too many requests" in s or "429" in s
+    return common.throttle_text(exc, "throttler")
 
 
-def _start_declarative(task_id: str, tasks_dir: str) -> tuple[Any, str]:
+def _start_sandbox(task_id: str, tasks_dir: str) -> tuple[Any, str]:
     daytona = tb2_sandbox_daytona.make_daytona()
-    sandbox, url = tb2_sandbox_daytona.create_task_sandbox(
-        daytona,
-        Path(tasks_dir) / task_id,
-        command_timeout_s=_COMMAND_TIMEOUT_S,
-        ready_timeout_s=_READY_TIMEOUT_S,
-    )
+    sandbox, url = tb2_sandbox_daytona.create_task_sandbox(daytona, Path(tasks_dir) / task_id)
     return (lambda: daytona.delete(sandbox)), url
 
 
-async def _start_task_sandbox(task_id: str) -> tuple[Any, str]:
-    """Create one sandbox for *task_id* with the env server running.
+BACKEND = common.SandboxBackend(
+    provider="Daytona",
+    start_sandbox=_start_sandbox,
+    is_throttle=_is_throttle_error,
+    logger=logger,
+    **common.backend_knobs("DAYTONA"),
+)
 
-    Returns (close_fn, base_url); close_fn deletes the sandbox. The
-    orchestration — cancel-safe create, process-wide throttling, backoff on
-    Daytona rate limits — is the provider-blind skeleton in
-    ``openenv_sandbox_common``; this leg contributes only its start hook and
-    throttle classifier.
-    """
-    return await common.start_task_sandbox(
-        task_id,
-        os.getenv("OPENENV_TB2_TASKS_DIR", "").strip(),
-        start_fn=lambda tid, tdir: _start_declarative(tid, tdir),
-        is_throttle=_is_throttle_error,
-        sem=_get_create_sem(),
-        max_retries=_CREATE_MAX_RETRIES,
-        backoff_base_s=_CREATE_BACKOFF_BASE_S,
-        backoff_cap_s=_CREATE_BACKOFF_CAP_S,
-        logger=logger,
-        provider="Daytona",
-    )
-
-
-@asynccontextmanager
-async def _episode_env(env_cls: Any, metadata: dict[str, Any]):
-    """Yield a connected env client on a fresh sandbox; delete it after."""
-    async with common.episode_env(env_cls, metadata, start=_start_task_sandbox, logger=logger) as env:
-        yield env
-
-
-async def _sandbox_run_body(env_cls: Any, metadata: dict[str, Any], body: Any) -> Any:
-    """Run *body* on a fresh sandbox for the episode's task."""
-    async with _episode_env(env_cls, metadata) as env:
-        return await body(env)
-
-
-async def run_episode(
-    policy: Any,
-    model_name: str,
-    messages: list[dict[str, str]],
-    request_kwargs: dict[str, Any],
-    metadata: dict[str, Any],
-) -> tuple[float | None, dict[str, Any]]:
-    """One episode in its own Daytona sandbox, with the caller's own
-    policy. Direct-drive entry, same contract as openenv_agent_function's.
-
-    No post-episode hygiene: the sandbox is deleted when the episode ends.
-    """
-    return await oaf._multi_turn(
-        oaf._load_tbench2(),
-        policy,
-        model_name,
-        messages,
-        request_kwargs,
-        metadata,
-        run_body=_sandbox_run_body,
-    )
-
-
-async def run(
-    base_url: str,
-    prompt: Any,
-    request_kwargs: dict[str, Any] | None = None,
-    metadata: dict[str, Any] | None = None,
-    **kwargs,
-) -> dict[str, Any] | None:
-    """Run one OpenEnv tbench2 episode in its own Daytona sandbox."""
-    return await oaf._run_for_training(base_url, prompt, request_kwargs, metadata, run_episode)
+# Module-level entry points: `--custom-agent-function-path` resolves a module
+# attribute, and the sibling tools reach run_episode the same way.
+run_episode = BACKEND.run_episode
+run = BACKEND.run

--- a/examples/experimental/openenv/openenv_e2b_agent_function.py
+++ b/examples/experimental/openenv/openenv_e2b_agent_function.py
@@ -12,7 +12,7 @@ The agent loop and training wrapper live in ``openenv_agent_function``
 (sibling module) and are reused unchanged; this module only supplies its own
 ``run_episode`` — how an env comes into being (see the episode-wiring note
 there). The image recipe lives in ``tb2_sandbox_recipe`` and its E2B
-materialization in ``tb2_sandbox_e2b``; like the Daytona leg, this variant
+materialization in ``tb2_sandbox_e2b``; like every sandbox backend, this one
 needs the pinned tbench2_env install from the README (canonical test.sh
 scoring and verifier-asset withholding built into the server).
 
@@ -21,32 +21,34 @@ Env vars (the agent-loop ones in ``openenv_agent_function`` apply too):
                     are built once per task under a recipe-digest alias
                     (first episode of a task pays the build; repeats
                     warm-start), or pre-baked via the tb2_sandbox_e2b CLI.
-  E2B_API_KEY / E2B_API_KEY_FILE   key supply, mirroring the Daytona leg's
-                    DAYTONA_API_KEY / _FILE contract (file default
-                    ~/.config/e2b/api_key; launchers forward the PATH, never
-                    the value). AgentENV accepts any non-empty key today.
+  E2B_API_KEY / E2B_API_KEY_FILE   key supply on the contract every backend
+                    shares (file default ~/.config/e2b/api_key; launchers
+                    forward the PATH, never the value). AgentENV accepts any
+                    non-empty key today.
   E2B_API_URL / E2B_SANDBOX_URL    endpoint overrides read by the SDK itself;
                     set both to target a self-hosted AgentENV.
   OPENENV_E2B_CREATE_CONCURRENCY   max in-flight sandbox creates (default 4).
-  OPENENV_E2B_READY_TIMEOUT_S      server-ready wait per sandbox (default 300).
+  OPENENV_E2B_CREATE_MAX_RETRIES   how many throttled creates to retry (default 8).
   OPENENV_E2B_THROTTLE_PATTERNS    extra comma-separated lowercase substrings
-                    classified as retryable throttling/capacity errors —
-                    self-hosted providers surface "at capacity" differently
-                    than E2B Cloud's 429s; extend without a code change.
-  TB2_COMMAND_TIMEOUT_S            per-exec timeout inside the sandbox (default 900).
+                    classified as retryable throttling/capacity errors — a
+                    self-hosted AgentENV words "at capacity" its own way, and
+                    whoever deployed it can name that without a code change.
+
+Everything describing ONE sandbox — its lifetime and the ready deadline — is
+documented and read in ``tb2_sandbox_e2b``, and the per-exec timeout inside it
+(TB2_COMMAND_TIMEOUT_S) in ``tb2_sandbox_recipe``, next to the code each one
+steers.
 """
 
 import logging
-import os
-from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Any
 
-import openenv_agent_function as oaf
 import openenv_sandbox_common as common
 import tb2_sandbox_e2b
 
 logger = logging.getLogger(__name__)
+
 
 # The sandbox's env server is the tbench2_env baked by the recipe, installed
 # per the README (at or after the huggingface/OpenEnv#1012 merge): canonical
@@ -55,24 +57,9 @@ logger = logging.getLogger(__name__)
 # older install outright, and the shared agent loop's harness-marker guard
 # backstops it per episode.
 #
-# Providers rate-limit or run out of capacity under a fanned-out rollout; cap
-# in-flight creates process-wide and retry throttled ones with jittered
-# exponential backoff.
-_CREATE_CONCURRENCY = int(os.getenv("OPENENV_E2B_CREATE_CONCURRENCY", "4"))
-_CREATE_MAX_RETRIES = int(os.getenv("OPENENV_E2B_CREATE_MAX_RETRIES", "8"))
-_CREATE_BACKOFF_BASE_S = float(os.getenv("OPENENV_E2B_CREATE_BACKOFF_BASE_S", "2.0"))
-_CREATE_BACKOFF_CAP_S = float(os.getenv("OPENENV_E2B_CREATE_BACKOFF_CAP_S", "30.0"))
-_READY_TIMEOUT_S = float(os.getenv("OPENENV_E2B_READY_TIMEOUT_S", "300"))
-_COMMAND_TIMEOUT_S = int(os.getenv("TB2_COMMAND_TIMEOUT_S", "900"))
-
-_get_create_sem = common.lazy_semaphore(_CREATE_CONCURRENCY)
-
-
-def _extra_throttle_patterns() -> tuple[str, ...]:
-    raw = os.getenv("OPENENV_E2B_THROTTLE_PATTERNS", "")
-    return tuple(p.strip().lower() for p in raw.split(",") if p.strip())
-
-
+# Providers rate-limit or run out of capacity under a fanned-out rollout; the
+# shared backend caps in-flight creates process-wide and retries throttled ones
+# with jittered exponential backoff (knobs: OPENENV_E2B_CREATE_*).
 def _is_throttle_error(exc: BaseException) -> bool:
     """True when a sandbox create failed only because the provider throttled it.
 
@@ -91,86 +78,23 @@ def _is_throttle_error(exc: BaseException) -> bool:
             return True
     except ImportError:  # pragma: no cover - only without the e2b SDK
         pass
-    s = str(exc).lower()
-    if "too many requests" in s or "429" in s or "rate limit" in s:
-        return True
-    return any(p in s for p in _extra_throttle_patterns())
+    return common.throttle_text(exc, patterns_env_var="OPENENV_E2B_THROTTLE_PATTERNS")
 
 
 def _start_sandbox(task_id: str, tasks_dir: str) -> tuple[Any, str]:
-    sandbox, url = tb2_sandbox_e2b.create_task_sandbox(
-        Path(tasks_dir) / task_id,
-        command_timeout_s=_COMMAND_TIMEOUT_S,
-        ready_timeout_s=_READY_TIMEOUT_S,
-    )
+    sandbox, url = tb2_sandbox_e2b.create_task_sandbox(Path(tasks_dir) / task_id)
     return (lambda: tb2_sandbox_e2b.kill_sandbox(sandbox)), url
 
 
-async def _start_task_sandbox(task_id: str) -> tuple[Any, str]:
-    """Create one sandbox for *task_id* with the env server running.
+BACKEND = common.SandboxBackend(
+    provider="E2B",
+    start_sandbox=_start_sandbox,
+    is_throttle=_is_throttle_error,
+    logger=logger,
+    **common.backend_knobs("E2B"),
+)
 
-    Returns (close_fn, base_url); close_fn kills the sandbox. The
-    orchestration — cancel-safe create, process-wide throttling, backoff on
-    provider rate limits — is the provider-blind skeleton in
-    ``openenv_sandbox_common``; this leg contributes only its start hook and
-    throttle classifier.
-    """
-    return await common.start_task_sandbox(
-        task_id,
-        os.getenv("OPENENV_TB2_TASKS_DIR", "").strip(),
-        start_fn=lambda tid, tdir: _start_sandbox(tid, tdir),
-        is_throttle=_is_throttle_error,
-        sem=_get_create_sem(),
-        max_retries=_CREATE_MAX_RETRIES,
-        backoff_base_s=_CREATE_BACKOFF_BASE_S,
-        backoff_cap_s=_CREATE_BACKOFF_CAP_S,
-        logger=logger,
-        provider="E2B",
-    )
-
-
-@asynccontextmanager
-async def _episode_env(env_cls: Any, metadata: dict[str, Any]):
-    """Yield a connected env client on a fresh sandbox; kill it after."""
-    async with common.episode_env(env_cls, metadata, start=_start_task_sandbox, logger=logger) as env:
-        yield env
-
-
-async def _sandbox_run_body(env_cls: Any, metadata: dict[str, Any], body: Any) -> Any:
-    """Run *body* on a fresh sandbox for the episode's task."""
-    async with _episode_env(env_cls, metadata) as env:
-        return await body(env)
-
-
-async def run_episode(
-    policy: Any,
-    model_name: str,
-    messages: list[dict[str, str]],
-    request_kwargs: dict[str, Any],
-    metadata: dict[str, Any],
-) -> tuple[float | None, dict[str, Any]]:
-    """One episode in its own E2B sandbox, with the caller's own policy.
-    Direct-drive entry, same contract as openenv_agent_function's.
-
-    No post-episode hygiene: the sandbox is killed when the episode ends.
-    """
-    return await oaf._multi_turn(
-        oaf._load_tbench2(),
-        policy,
-        model_name,
-        messages,
-        request_kwargs,
-        metadata,
-        run_body=_sandbox_run_body,
-    )
-
-
-async def run(
-    base_url: str,
-    prompt: Any,
-    request_kwargs: dict[str, Any] | None = None,
-    metadata: dict[str, Any] | None = None,
-    **kwargs,
-) -> dict[str, Any] | None:
-    """Run one OpenEnv tbench2 episode in its own E2B sandbox."""
-    return await oaf._run_for_training(base_url, prompt, request_kwargs, metadata, run_episode)
+# Module-level entry points: `--custom-agent-function-path` resolves a module
+# attribute, and the sibling tools reach run_episode the same way.
+run_episode = BACKEND.run_episode
+run = BACKEND.run

--- a/examples/experimental/openenv/openenv_launch_common.py
+++ b/examples/experimental/openenv/openenv_launch_common.py
@@ -106,14 +106,14 @@ def optimizer_args() -> str:
 
 
 def resolve_sandbox_backend(args: LaunchArgs) -> str:
-    """The per-episode sandbox backend in effect: "" (shared env server),
-    "daytona", or "e2b".
+    """The per-episode sandbox backend in effect, or "" for the shared env server.
 
     Names and aliases resolve through openenv_sandbox_common, the canonical
-    registry: "agentenv" is an accepted alias for "e2b", because AgentENV
+    registry, so the accepted set is never enumerated twice: "agentenv" is an
+    accepted alias for "e2b", because AgentENV
     (https://github.com/kvcache-ai/AgentENV) is a self-hosted Firecracker
     microVM platform whose native API is the E2B API, so it runs on the e2b
-    leg with E2B_API_URL/E2B_SANDBOX_URL pointed at it.
+    backend with E2B_API_URL/E2B_SANDBOX_URL pointed at it.
 
     The two settings that turn this mode on come as a pair — a task checkout
     to build images from, and the provider to build them on — so naming one
@@ -137,9 +137,9 @@ def resolve_sandbox_backend(args: LaunchArgs) -> str:
 
 def agent_args(tito_model: str, sandbox_backend: str = "") -> str:
     """Agentic-rollout wiring. The TITO surface differs across models; the
-    agent function decides where episodes run — the shared env server by
-    default, per-episode sandboxes (Daytona or E2B/AgentENV) when the launcher
-    resolves a sandbox backend (see resolve_sandbox_backend)."""
+    agent function decides where episodes run — per-episode sandboxes on
+    whichever backend the launcher resolves (see resolve_sandbox_backend), else
+    the one shared env server."""
     agent_fn = sandbox_common.AGENT_FUNCTIONS.get(sandbox_backend, "openenv_agent_function.run")
     return (
         "--custom-generate-function-path miles.rollout.generate_hub.agentic_tool_call.generate "
@@ -230,7 +230,7 @@ def apply_optional_env_vars(env: dict[str, str], args: LaunchArgs) -> None:
         # Preflight the env package the recipe bakes into each task image —
         # shared by every sandbox backend. The import check catches a missing
         # install; the source probe catches an install that imports fine but
-        # lacks the server features the sandbox legs score through (canonical
+        # lacks the server features the sandbox backends score through (canonical
         # tests/test.sh evaluate, TB2_WITHHOLD_TESTS) — that one would not
         # even fail per-episode, it would silently mis-score every episode.
         try:

--- a/examples/experimental/openenv/openenv_sandbox_common.py
+++ b/examples/experimental/openenv/openenv_sandbox_common.py
@@ -1,7 +1,7 @@
-"""Shared per-episode sandbox orchestration for the provider agent functions.
+"""Shared per-episode sandbox orchestration for the backend agent functions.
 
-A provider leg (``openenv_daytona_agent_function``, ``openenv_e2b_agent_function``)
-owns only what is genuinely provider-specific: how ONE sandbox with the env
+A backend module (``openenv_daytona_agent_function``,
+``openenv_e2b_agent_function``) owns only what is genuinely provider-specific: how ONE sandbox with the env
 server comes into being (its ``tb2_sandbox_*`` materialization module), which
 errors count as retryable throttling, and its env-var knobs. Everything that
 makes per-episode sandboxes safe under a fanned-out rollout is provider-blind
@@ -15,24 +15,28 @@ and lives here once:
                 is recorded thread-side and, on cancellation, handed to a
                 reaper that closes the orphan promptly once the create
                 finishes.
-  ``lazy_semaphore``       the create-throttle semaphore each leg passes in,
+  ``lazy_semaphore``       the create-throttle semaphore each backend passes in,
                 built on first use rather than at import.
-  ``start_task_sandbox``   process-wide create throttling (the caller's
-                semaphore) plus jittered exponential backoff on the errors the
-                caller classifies as throttling; anything else propagates
-                immediately. The semaphore is held only for the create attempt
-                and released during backoff so other episodes keep the
-                pipeline full.
-  ``episode_env``          async context manager mirroring one episode's
-                lifetime: fresh sandbox -> connected env client -> close.
+  ``SandboxBackend``       the orchestration itself. ``start_task_sandbox``
+                throttles creates process-wide (the semaphore) and retries the
+                errors the backend classifies as throttling with jittered
+                exponential backoff — anything else propagates immediately, and
+                the semaphore is held only for the create attempt and released
+                during backoff so other episodes keep the pipeline full.
+                ``episode_env`` is the async context manager mirroring one
+                episode's lifetime: fresh sandbox -> connected env client ->
+                close.
 """
 
 import asyncio
+import importlib
 import logging
+import os
 import random
 import threading
-from collections.abc import Awaitable, Callable
+from collections.abc import Callable
 from contextlib import asynccontextmanager
+from dataclasses import dataclass
 from typing import Any
 
 # A provider's "start one sandbox" hook: (task_id, tasks_dir) -> (close_fn, base_url).
@@ -40,12 +44,19 @@ StartFn = Callable[[str, str], tuple[Callable[[], None], str]]
 
 # The canonical per-episode backend registry — the launcher and the sibling
 # tools (scan_golden, eval_tbench2_via_api) all resolve through here, so the
-# accepted names and the "agentenv is the e2b leg" aliasing cannot drift.
-AGENT_FUNCTIONS = {
-    "daytona": "openenv_daytona_agent_function.run",
-    "e2b": "openenv_e2b_agent_function.run",
+# accepted names and the "agentenv is the e2b backend" aliasing cannot drift.
+# Adding a provider is one entry plus its two modules (backend + materialization).
+AGENT_MODULES = {
+    "daytona": "openenv_daytona_agent_function",
+    "e2b": "openenv_e2b_agent_function",
 }
+AGENT_FUNCTIONS = {backend: f"{module}.run" for backend, module in AGENT_MODULES.items()}
 _ALIASES = {"agentenv": "e2b"}
+
+
+def backend_names() -> str:
+    """The accepted names, for help text that must not drift from the registry."""
+    return ", ".join(sorted([*AGENT_FUNCTIONS, *_ALIASES]))
 
 
 def resolve_backend(name: str | None) -> str:
@@ -56,7 +67,7 @@ def resolve_backend(name: str | None) -> str:
     left out is a question to answer rather than one to guess at.
     """
     backend = (name or "").strip().lower()
-    allowed = ", ".join(sorted([*AGENT_FUNCTIONS, *_ALIASES]))
+    allowed = backend_names()
     if not backend:
         raise ValueError(f"no sandbox backend named; choose one of: {allowed}")
     backend = _ALIASES.get(backend, backend)
@@ -65,10 +76,21 @@ def resolve_backend(name: str | None) -> str:
     return backend
 
 
+def load_backend(name: str | None) -> "SandboxBackend":
+    """The SandboxBackend named by *name*, imported on demand.
+
+    The sibling tools (scan_golden, eval_tbench2_via_api) drive one backend
+    directly instead of through the training entry point. Resolving it here
+    means they gain a provider by naming it, not by growing an import branch
+    each — and a provider's SDK is imported only when it is the one selected.
+    """
+    return importlib.import_module(AGENT_MODULES[resolve_backend(name)]).BACKEND
+
+
 def lazy_semaphore(limit: int) -> Callable[[], asyncio.Semaphore]:
     """Return a getter for a *limit*-slot semaphore created on first call.
 
-    A leg reads its concurrency knob at import, but a semaphore constructed
+    A backend reads its concurrency knob at import, but a semaphore constructed
     then would belong to whatever loop happens to be current — the rollout
     loop does not exist yet. Deferring construction to the first episode ties
     it to the loop that actually awaits on it.
@@ -112,62 +134,181 @@ async def create_once(start_fn: StartFn, task_id: str, tasks_dir: str, *, logger
         raise
 
 
-async def start_task_sandbox(
-    task_id: str,
-    tasks_dir: str,
-    *,
-    start_fn: StartFn,
-    is_throttle: Callable[[BaseException], bool],
-    sem: asyncio.Semaphore,
-    max_retries: int,
-    backoff_base_s: float,
-    backoff_cap_s: float,
-    logger: logging.Logger,
-    provider: str,
-) -> tuple[Any, str]:
-    """Create one sandbox for *task_id* with the env server running.
+def _agent_function():
+    """``openenv_agent_function``, imported on use rather than at module scope.
 
-    Returns (close_fn, base_url). Creation is throttled process-wide and
-    retried with jittered exponential backoff on throttle errors.
+    The one lazy import in this module, and the reason is the module's other
+    callers: a provider CLI (``python tb2_sandbox_e2b.py ...``) and the
+    launcher reach this module for the backend registry alone, and neither
+    should have to have the agent loop's dependencies (openai) installed to
+    resolve a backend name.
     """
-    attempt = 0
-    while True:
+    import openenv_agent_function
+
+    return openenv_agent_function
+
+
+# Throttle text every provider shares: an HTTP 429 surfaced as a message
+# rather than a typed error. A backend adds its own vocabulary (Daytona's
+# "throttler").
+_THROTTLE_TEXT = ("too many requests", "429", "rate limit")
+
+
+def throttle_text(exc: BaseException, *extra_patterns: str, patterns_env_var: str | None = None) -> bool:
+    """True when *exc*'s message reads like throttling or exhausted capacity.
+
+    The typed-exception half of the decision stays in the backend (only it knows
+    its SDK's class); this is the half that is identical everywhere, plus the
+    backend's *extra_patterns*.
+
+    *patterns_env_var* extends the set at runtime, and exists for exactly one
+    case: an endpoint whose capacity errors are worded by whoever deployed it,
+    which is why only the e2b backend (self-hosted AgentENV) passes one.
+    """
+    s = str(exc).lower()
+    if any(p in s for p in (*_THROTTLE_TEXT, *(p.lower() for p in extra_patterns))):
+        return True
+    raw = os.getenv(patterns_env_var, "") if patterns_env_var else ""
+    return any(p in s for p in (chunk.strip().lower() for chunk in raw.split(",")) if p)
+
+
+# Backoff shape for throttled creates: jittered exponential, shared by every
+# backend. Constants rather than knobs — a rollout tunes how MANY creates are in
+# flight (create_concurrency) and how long to keep trying (max_retries), not the
+# curve between them.
+BACKOFF_BASE_S = 2.0
+BACKOFF_CAP_S = 30.0
+
+# Knob defaults shared by every backend, read from its OWN prefix so one
+# provider can be re-tuned without touching another.
+_KNOB_DEFAULTS = {
+    "create_concurrency": ("CREATE_CONCURRENCY", 4, int),
+    "max_retries": ("CREATE_MAX_RETRIES", 8, int),
+}
+
+
+def backend_knobs(env_prefix: str) -> dict[str, Any]:
+    """The create-throttling knobs for a backend, read from OPENENV_<PREFIX>_*.
+
+    Read once, at the importing module's import time: a rollout worker is a
+    fresh process per run, so a knob changed mid-run would be a knob that
+    silently did nothing.
+    """
+    return {
+        field: cast(os.getenv(f"OPENENV_{env_prefix}_{suffix}", str(default)))
+        for field, (suffix, default, cast) in _KNOB_DEFAULTS.items()
+    }
+
+
+@dataclass
+class SandboxBackend:
+    """The provider-blind half of a per-episode sandbox agent function.
+
+    Every backend is the same rollout-facing object — throttled cancel-safe
+    creates, an env client bound to one episode's sandbox, the training and
+    direct-drive entry points — around two provider-specific holes:
+    ``start_sandbox`` (how ONE sandbox with the env server comes into being)
+    and ``is_throttle`` (which of its SDK's errors are worth retrying). A backend
+    module supplies those two, its knobs, and its documentation; nothing else
+    about it can drift from its siblings because nothing else lives there.
+
+    The fields are the seams: tests substitute ``start_sandbox`` or
+    ``episode_env`` and shrink the backoff on the instance, so the knobs stay
+    patchable without a backend re-reading its environment.
+    """
+
+    provider: str
+    start_sandbox: StartFn
+    is_throttle: Callable[[BaseException], bool]
+    logger: logging.Logger
+    create_concurrency: int = _KNOB_DEFAULTS["create_concurrency"][1]
+    max_retries: int = _KNOB_DEFAULTS["max_retries"][1]
+    backoff_base_s: float = BACKOFF_BASE_S
+    backoff_cap_s: float = BACKOFF_CAP_S
+
+    def __post_init__(self) -> None:
+        self._get_sem = lazy_semaphore(self.create_concurrency)
+
+    async def start_task_sandbox(self, task_id: str) -> tuple[Any, str]:
+        """Create one sandbox for *task_id* with the env server running.
+
+        Returns (close_fn, base_url); close_fn releases the sandbox. Creation
+        is throttled process-wide (the create semaphore) and retried with
+        jittered exponential backoff on throttle errors; anything else
+        propagates immediately.
+        """
+        tasks_dir = os.getenv("OPENENV_TB2_TASKS_DIR", "").strip()
+        attempt = 0
+        while True:
+            try:
+                async with self._get_sem():
+                    return await create_once(self.start_sandbox, task_id, tasks_dir, logger=self.logger)
+            except Exception as e:
+                if not self.is_throttle(e) or attempt >= self.max_retries:
+                    raise
+                attempt += 1
+                delay = min(self.backoff_cap_s, self.backoff_base_s * (2 ** (attempt - 1))) * (0.5 + random.random())
+                self.logger.warning(
+                    f"{self.provider} create throttled for {task_id} "
+                    f"(attempt {attempt}/{self.max_retries}); retrying in {delay:.1f}s"
+                )
+                await asyncio.sleep(delay)
+
+    @asynccontextmanager
+    async def episode_env(self, env_cls: Any, metadata: dict[str, Any]):
+        """Yield a connected env client on a fresh sandbox; release it after."""
+        oaf = _agent_function()
+        task_id = metadata.get("task_id") or metadata.get("task_name")
+        if not task_id:
+            raise ValueError("the sandbox is built for one task: metadata['task_id'] is required")
+        close_fn, url = await self.start_task_sandbox(str(task_id))
         try:
-            async with sem:
-                return await create_once(start_fn, task_id, tasks_dir, logger=logger)
-        except Exception as e:
-            if not is_throttle(e) or attempt >= max_retries:
-                raise
-            attempt += 1
-            delay = min(backoff_cap_s, backoff_base_s * (2 ** (attempt - 1))) * (0.5 + random.random())
-            logger.warning(
-                f"{provider} create throttled for {task_id} (attempt {attempt}/{max_retries}); retrying in {delay:.1f}s"
-            )
-            await asyncio.sleep(delay)
+            async with env_cls(base_url=url, message_timeout_s=oaf.MESSAGE_TIMEOUT_S) as env:
+                yield env
+        finally:
+            try:
+                await asyncio.to_thread(close_fn)
+            except Exception as e:
+                self.logger.warning(f"Failed to close sandbox for {task_id}: {e}")
 
+    async def _run_body(self, env_cls: Any, metadata: dict[str, Any], body: Any) -> Any:
+        # self.episode_env, not the module function: an instance attribute
+        # substituted by a test must win here.
+        async with self.episode_env(env_cls, metadata) as env:
+            return await body(env)
 
-@asynccontextmanager
-async def episode_env(
-    env_cls: Any,
-    metadata: dict[str, Any],
-    *,
-    start: Callable[[str], Awaitable[tuple[Any, str]]],
-    logger: logging.Logger,
-):
-    """Yield a connected env client on a fresh sandbox; close it after."""
-    # Imported lazily so provider CLIs (bake) don't drag in the agent loop's
-    # dependencies (openai) just to reach this module's registry.
-    import openenv_agent_function as oaf
+    async def run_episode(
+        self,
+        policy: Any,
+        model_name: str,
+        messages: list[dict[str, str]],
+        request_kwargs: dict[str, Any],
+        metadata: dict[str, Any],
+    ) -> tuple[float | None, dict[str, Any]]:
+        """One episode in its own sandbox, with the caller's own policy.
+        Direct-drive entry, same contract as openenv_agent_function's.
 
-    task_id = metadata.get("task_id") or metadata.get("task_name")
-    if not task_id:
-        raise ValueError("the sandbox is built for one task: metadata['task_id'] is required")
-    close_fn, url = await start(str(task_id))
-    try:
-        async with env_cls(base_url=url, message_timeout_s=oaf._MESSAGE_TIMEOUT_S) as env:
-            yield env
-    finally:
-        try:
-            await asyncio.to_thread(close_fn)
-        except Exception as e:
-            logger.warning(f"Failed to close sandbox for {task_id}: {e}")
+        No post-episode hygiene: the sandbox is released when the episode ends.
+        """
+        oaf = _agent_function()
+        return await oaf.multi_turn(
+            oaf.load_tbench2(),
+            policy,
+            model_name,
+            messages,
+            request_kwargs,
+            metadata,
+            run_body=self._run_body,
+        )
+
+    async def run(
+        self,
+        base_url: str,
+        prompt: Any,
+        request_kwargs: dict[str, Any] | None = None,
+        metadata: dict[str, Any] | None = None,
+        **kwargs,
+    ) -> dict[str, Any] | None:
+        """Run one OpenEnv tbench2 episode in its own sandbox (training entry)."""
+        oaf = _agent_function()
+        return await oaf.run_for_training(base_url, prompt, request_kwargs, metadata, self.run_episode)

--- a/examples/experimental/openenv/scan_golden.py
+++ b/examples/experimental/openenv/scan_golden.py
@@ -27,18 +27,14 @@ import tomllib
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import openenv_agent_function as oaf
 
-# The sandbox leg to replay through — resolved by the same registry the
+# The sandbox backend to replay through — resolved by the same registry the
 # launcher uses, so a missing or unknown provider is an error here too.
 import openenv_sandbox_common as sandbox_common
 
 try:
-    _BACKEND = sandbox_common.resolve_backend(os.getenv("OPENENV_SANDBOX_BACKEND"))
+    _backend = sandbox_common.load_backend(os.getenv("OPENENV_SANDBOX_BACKEND"))
 except ValueError as e:
     sys.exit(str(e))
-if _BACKEND == "e2b":
-    import openenv_e2b_agent_function as sandbox_leg
-else:
-    import openenv_daytona_agent_function as sandbox_leg
 
 CAP_S = float(os.getenv("GOLDEN_TASK_CAP_S", "1800"))
 
@@ -69,13 +65,13 @@ def _solution_push_commands(task_id: str) -> list[str]:
 
 
 async def golden_one(task_id: str, capture_logs: bool = False) -> tuple[str, float | None, dict]:
-    classes = oaf._load_tbench2()
+    classes = oaf.load_tbench2()
     action = classes["action"]
     t0 = time.monotonic()
     try:
 
         async def run() -> dict:
-            async with sandbox_leg._episode_env(classes["env"], {"task_id": task_id}) as env:
+            async with _backend.episode_env(classes["env"], {"task_id": task_id}) as env:
                 await env.reset(task_id=task_id)
                 t = time.monotonic()
                 # Official oracle convention (harbor OracleAgent): solution dir
@@ -152,7 +148,8 @@ async def main() -> None:
     if not os.getenv("OPENENV_TB2_TASKS_DIR", "").strip():
         sys.exit(
             "scan_golden requires the per-episode sandbox mode: set OPENENV_TB2_TASKS_DIR "
-            "and OPENENV_SANDBOX_BACKEND (daytona/e2b/agentenv), plus that provider's credentials"
+            f"and OPENENV_SANDBOX_BACKEND ({sandbox_common.backend_names()}), "
+            "plus that provider's credentials"
         )
     tasks = [t.strip() for t in args.tasks.split(",") if t.strip()]
     print(f"golden sweep | {len(tasks)} tasks | concurrency={args.concurrency}", flush=True)

--- a/examples/experimental/openenv/tests/test_openenv_agent_function.py
+++ b/examples/experimental/openenv/tests/test_openenv_agent_function.py
@@ -6,9 +6,9 @@ when touching the adapter:
     pytest examples/experimental/openenv/tests/ -q
 
 Covers the shared-server leg of the agent loop (this module's run_episode):
-its exec form, scoring path, and cleanup. The Daytona-sandbox leg's
-dispatch and sandbox-create machinery live in
-test_openenv_daytona_agent_function.py; the fakes below are shared with it.
+its exec form, scoring path, and cleanup. The sandbox leg's dispatch and
+sandbox-create machinery live in test_openenv_sandbox_common.py; the fakes
+below are shared with it.
 """
 
 import asyncio
@@ -98,7 +98,7 @@ def test_shared_leg_dispatch(monkeypatch):
     (the server resolves the workdir), scoring via the standard `evaluate`
     action — and the trial-dir purge (post_episode) runs, since the shared
     server outlives the episode."""
-    monkeypatch.setattr(oaf, "_load_tbench2", lambda: _CLASSES)
+    monkeypatch.setattr(oaf, "load_tbench2", lambda: _CLASSES)
 
     async def spying_with_env(env_cls, env_url, body):
         return await body(env_cls())
@@ -132,7 +132,7 @@ def test_old_server_reward_is_not_trusted(monkeypatch):
                 return _FakeResult(reward=1.0, info={"tests_passed": True, "exit_code": 0})
             return await super().step(action)
 
-    monkeypatch.setattr(oaf, "_load_tbench2", lambda: {"env": _OldServerEnv, "action": _CLASSES["action"]})
+    monkeypatch.setattr(oaf, "load_tbench2", lambda: {"env": _OldServerEnv, "action": _CLASSES["action"]})
 
     async def spying_with_env(env_cls, env_url, body):
         return await body(env_cls())

--- a/examples/experimental/openenv/tests/test_openenv_daytona_agent_function.py
+++ b/examples/experimental/openenv/tests/test_openenv_daytona_agent_function.py
@@ -5,94 +5,22 @@ when touching the adapter:
 
     pytest examples/experimental/openenv/tests/ -q
 
-Covers what a live episode cannot cheaply prove:
-  - episode dispatch: this module's run_episode passes exec commands through
-    unmodified and scores via the standard `evaluate` action;
-  - sandbox-create throttling: Daytona rate-limit errors are retried with
-    backoff and a bounded budget, anything else propagates immediately; a
-    cancel mid-create reaps the orphaned sandbox instead of leaking it.
+Covers only what is Daytona's own. Episode dispatch, create throttling, backoff
+budgets and the cancel-mid-create reaper belong to the shared SandboxBackend and are
+proven once in test_openenv_sandbox_common.py; what remains here is which of
+this SDK's errors count as throttling, and that the start hook wires the
+materialization (client, per-task dir, delete-on-close) correctly.
 """
 
-import asyncio
 import sys
-import threading
-from contextlib import asynccontextmanager
+import types
 from pathlib import Path
 
 import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-import openenv_agent_function as oaf  # noqa: E402
 import openenv_daytona_agent_function as odaf  # noqa: E402
-from test_openenv_agent_function import _CLASSES, _FakeEnv, _FakePolicy, _FakeResult  # noqa: E402
-
-
-def run_async(coro):
-    """asyncio.run with the module's loop-bound state reset (fresh loop per test)."""
-    odaf._create_sem = None
-    return asyncio.run(coro)
-
-
-# --- episode dispatch ------------------------------------------------------
-
-
-def test_daytona_leg_dispatch(monkeypatch):
-    """The daytona run_episode: exec commands pass through unmodified (the
-    server resolves the workdir), scoring via the standard `evaluate` action —
-    and unlike the shared leg, no trial-dir purge (the sandbox is deleted
-    when the episode ends)."""
-    monkeypatch.setattr(oaf, "_load_tbench2", lambda: _CLASSES)
-
-    @asynccontextmanager
-    async def fake_episode_env(env_cls, metadata):
-        yield env_cls()
-
-    monkeypatch.setattr(odaf, "_episode_env", fake_episode_env)
-
-    reward, metrics = run_async(
-        odaf.run_episode(_FakePolicy(), "m", [{"role": "system", "content": "s"}], {}, {"task_id": "t1"})
-    )
-    actions = _FakeEnv.last_actions
-    execs = [a for a in actions if a.action_type == "exec"]
-
-    assert reward == 1.0
-    assert execs[0].command == "echo hi"
-    assert any(a.action_type == "evaluate" for a in actions)
-    assert not any("/tmp/tbench2_env_runs" in (a.command or "") for a in execs)
-    assert metrics["turns"] == 2 and metrics["tool_calls"] == 1
-
-
-def test_daytona_leg_eval_error_yields_no_verdict(monkeypatch):
-    """A server-side scoring failure (`evaluate` comes back with error set and
-    no reward) surfaces as reward=None -- dropped by the training wrapper --
-    not coerced into a false-negative 0.0."""
-
-    class _EvalErrorEnv(_FakeEnv):
-        async def step(self, action):
-            if action.action_type == "evaluate":
-                self.actions.append(action)
-                res = _FakeResult()
-                res.observation.error = "toolkit timeout"
-                return res
-            return await super().step(action)
-
-    monkeypatch.setattr(oaf, "_load_tbench2", lambda: {"env": _EvalErrorEnv, "action": _CLASSES["action"]})
-
-    @asynccontextmanager
-    async def fake_episode_env(env_cls, metadata):
-        yield env_cls()
-
-    monkeypatch.setattr(odaf, "_episode_env", fake_episode_env)
-
-    reward, metrics = run_async(
-        odaf.run_episode(_FakePolicy(), "m", [{"role": "system", "content": "s"}], {}, {"task_id": "t1"})
-    )
-    assert reward is None
-    assert metrics["turns"] == 2  # the episode itself completed; only scoring failed
-
-
-# --- sandbox-create throttling ----------------------------------------------
 
 
 class _Throttled(Exception):
@@ -100,102 +28,60 @@ class _Throttled(Exception):
         return "ThrottlerException: Too Many Requests"
 
 
-def _patch_fast_backoff(monkeypatch):
-    monkeypatch.setattr(odaf, "_CREATE_BACKOFF_BASE_S", 0.001)
-    monkeypatch.setattr(odaf, "_CREATE_BACKOFF_CAP_S", 0.001)
+# --- start hook -------------------------------------------------------------
 
 
-def test_create_retries_through_throttling(monkeypatch):
-    """Throttle errors are retried (with backoff) until the create succeeds."""
-    _patch_fast_backoff(monkeypatch)
-    calls = {"n": 0}
+def test_start_hook_creates_per_task_and_closes_by_deleting(monkeypatch):
+    """The sandbox is per-task (tasks_dir/task_id) and close_fn must DELETE it:
+    a stopped-but-kept Daytona sandbox still occupies the org's quota."""
+    deleted = []
+    created = {}
 
-    def flaky_start(task_id, tasks_dir):
-        calls["n"] += 1
-        if calls["n"] <= 3:
-            raise _Throttled()
-        return (lambda: None), "http://sandbox:8000"
+    class _FakeDaytona:
+        def delete(self, sandbox):
+            deleted.append(sandbox)
 
-    monkeypatch.setattr(odaf, "_start_declarative", flaky_start)
-    monkeypatch.setenv("OPENENV_TB2_TASKS_DIR", "/nonexistent")
+    client = _FakeDaytona()
 
-    close_fn, url = run_async(odaf._start_task_sandbox("t1"))
-    assert url == "http://sandbox:8000"
-    assert calls["n"] == 4  # 3 throttled attempts + 1 success
+    def fake_create(daytona, task_dir, **kwargs):
+        created.update(daytona=daytona, task_dir=task_dir, kwargs=kwargs)
+        return "sandbox-handle", "https://preview.daytona/8000"
 
+    monkeypatch.setattr(odaf.tb2_sandbox_daytona, "make_daytona", lambda: client)
+    monkeypatch.setattr(odaf.tb2_sandbox_daytona, "create_task_sandbox", fake_create)
 
-def test_create_gives_up_after_retry_budget(monkeypatch):
-    """A create that is throttled past _CREATE_MAX_RETRIES raises the error."""
-    _patch_fast_backoff(monkeypatch)
-    monkeypatch.setattr(odaf, "_CREATE_MAX_RETRIES", 2)
-    calls = {"n": 0}
+    close_fn, url = odaf._start_sandbox("regex-chess", "/tasks")
 
-    def always_throttled(task_id, tasks_dir):
-        calls["n"] += 1
-        raise _Throttled()
-
-    monkeypatch.setattr(odaf, "_start_declarative", always_throttled)
-    monkeypatch.setenv("OPENENV_TB2_TASKS_DIR", "/nonexistent")
-
-    with pytest.raises(_Throttled):
-        run_async(odaf._start_task_sandbox("t1"))
-    assert calls["n"] == 3  # initial attempt + 2 retries
+    assert url == "https://preview.daytona/8000"
+    assert created["task_dir"] == Path("/tasks/regex-chess")
+    assert created["daytona"] is client
+    # The backend passes only what identifies the sandbox; every deadline is
+    # the materialization's own default, so the two cannot drift apart.
+    assert created["kwargs"] == {}
+    close_fn()
+    assert deleted == ["sandbox-handle"]
 
 
-def test_cancel_during_create_reaps_orphaned_sandbox(monkeypatch):
-    """Cancelling an episode mid-create must not leak the sandbox: the worker
-    thread finishes the create in the background and the reaper deletes it."""
-    started = threading.Event()
-    release = threading.Event()
-    closed = threading.Event()
-
-    def slow_start(task_id, tasks_dir):
-        started.set()
-        assert release.wait(5)
-        return (lambda: closed.set()), "http://sandbox:8000"
-
-    monkeypatch.setattr(odaf, "_start_declarative", slow_start)
-    monkeypatch.setenv("OPENENV_TB2_TASKS_DIR", "/nonexistent")
-
-    async def scenario():
-        task = asyncio.create_task(odaf._start_task_sandbox("t1"))
-        await asyncio.to_thread(started.wait, 5)
-        task.cancel()
-        with pytest.raises(asyncio.CancelledError):
-            await task
-        # Only now does the in-flight create finish — after the awaiter is gone.
-        release.set()
-
-    run_async(scenario())
-    assert closed.wait(5)  # the reaper deleted the orphan
-
-
-def test_create_non_throttle_error_propagates_immediately(monkeypatch):
-    """Anything that is not a rate-limit error must not be retried."""
-    _patch_fast_backoff(monkeypatch)
-    calls = {"n": 0}
-
-    def broken_start(task_id, tasks_dir):
-        calls["n"] += 1
-        raise RuntimeError("image build failed")
-
-    monkeypatch.setattr(odaf, "_start_declarative", broken_start)
-    monkeypatch.setenv("OPENENV_TB2_TASKS_DIR", "/nonexistent")
-
-    with pytest.raises(RuntimeError):
-        run_async(odaf._start_task_sandbox("t1"))
-    assert calls["n"] == 1
+# --- throttle classification ------------------------------------------------
 
 
 def test_is_throttle_error_classification():
     assert odaf._is_throttle_error(_Throttled())
     assert odaf._is_throttle_error(Exception("HTTP 429"))
+    assert odaf._is_throttle_error(Exception("throttler tripped"))  # this backend's own vocabulary
     assert not odaf._is_throttle_error(RuntimeError("image build failed"))
 
 
 def test_is_throttle_error_typed_daytona_class():
     """The SDK's typed rate-limit error is recognized even when its message
-    carries no throttle keywords; sibling error classes are not."""
+    carries no throttle keywords."""
     errors = pytest.importorskip("daytona.common.errors")
     assert odaf._is_throttle_error(errors.DaytonaRateLimitError("slow down"))
-    assert not odaf._is_throttle_error(errors.DaytonaValidationError("bad params"))
+
+
+def test_is_throttle_error_without_the_sdk_installed(monkeypatch):
+    """The typed check is best-effort: the backend still classifies by text when the
+    SDK (or that class) is absent, rather than failing the classification."""
+    monkeypatch.setitem(sys.modules, "daytona.common.errors", types.ModuleType("daytona.common.errors"))
+    assert odaf._is_throttle_error(Exception("HTTP 429"))
+    assert not odaf._is_throttle_error(RuntimeError("image build failed"))

--- a/examples/experimental/openenv/tests/test_openenv_e2b_agent_function.py
+++ b/examples/experimental/openenv/tests/test_openenv_e2b_agent_function.py
@@ -5,94 +5,23 @@ when touching the adapter:
 
     pytest examples/experimental/openenv/tests/ -q
 
-Covers what a live episode cannot cheaply prove:
-  - episode dispatch: this module's run_episode sends raw exec commands and
-    scores via the standard `evaluate` action;
-  - sandbox-create throttling: rate-limit errors (typed, textual, and the
-    OPENENV_E2B_THROTTLE_PATTERNS extension for self-hosted providers) are
-    retried with backoff and a bounded budget, anything else propagates
-    immediately; a cancel mid-create reaps the orphaned sandbox.
+Covers only what is E2B's own. Episode dispatch, create throttling, backoff
+budgets and the cancel-mid-create reaper belong to the shared SandboxBackend and are
+proven once in test_openenv_sandbox_common.py; what remains here is which of
+this SDK's errors count as throttling — including the env-knob extension that
+lets a self-hosted AgentENV's capacity errors be retried without a code change
+— and that the start hook wires the materialization correctly.
 """
 
-import asyncio
 import sys
-import threading
-from contextlib import asynccontextmanager
+import types
 from pathlib import Path
 
 import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-import openenv_agent_function as oaf  # noqa: E402
 import openenv_e2b_agent_function as oeaf  # noqa: E402
-from test_openenv_agent_function import _CLASSES, _FakeEnv, _FakePolicy, _FakeResult  # noqa: E402
-
-
-def run_async(coro):
-    """asyncio.run with the module's loop-bound state reset (fresh loop per test)."""
-    oeaf._create_sem = None
-    return asyncio.run(coro)
-
-
-# --- episode dispatch ------------------------------------------------------
-
-
-def test_e2b_leg_dispatch(monkeypatch):
-    """The e2b run_episode: exec raw (server resolves the workdir), scoring
-    via the standard `evaluate` action, no canonical exec, no rm-hack."""
-    monkeypatch.setattr(oaf, "_load_tbench2", lambda: _CLASSES)
-
-    @asynccontextmanager
-    async def fake_episode_env(env_cls, metadata):
-        yield env_cls()
-
-    monkeypatch.setattr(oeaf, "_episode_env", fake_episode_env)
-
-    reward, metrics = run_async(
-        oeaf.run_episode(_FakePolicy(), "m", [{"role": "system", "content": "s"}], {}, {"task_id": "t1"})
-    )
-    actions = _FakeEnv.last_actions
-    execs = [a for a in actions if a.action_type == "exec"]
-
-    assert reward == 1.0
-    assert execs[0].command == "echo hi"
-    assert any(a.action_type == "evaluate" for a in actions)
-    assert not any("test.sh" in (a.command or "") for a in execs)
-    assert not any("/tmp/tbench2_env_runs" in (a.command or "") for a in execs)
-    assert metrics["turns"] == 2 and metrics["tool_calls"] == 1
-
-
-def test_e2b_leg_eval_error_yields_no_verdict(monkeypatch):
-    """A server-side scoring failure (`evaluate` comes back with error set and
-    no reward) surfaces as reward=None -- dropped by the training wrapper --
-    not coerced into a false-negative 0.0."""
-
-    class _EvalErrorEnv(_FakeEnv):
-        async def step(self, action):
-            if action.action_type == "evaluate":
-                self.actions.append(action)
-                res = _FakeResult()
-                res.observation.error = "toolkit timeout"
-                return res
-            return await super().step(action)
-
-    monkeypatch.setattr(oaf, "_load_tbench2", lambda: {"env": _EvalErrorEnv, "action": _CLASSES["action"]})
-
-    @asynccontextmanager
-    async def fake_episode_env(env_cls, metadata):
-        yield env_cls()
-
-    monkeypatch.setattr(oeaf, "_episode_env", fake_episode_env)
-
-    reward, metrics = run_async(
-        oeaf.run_episode(_FakePolicy(), "m", [{"role": "system", "content": "s"}], {}, {"task_id": "t1"})
-    )
-    assert reward is None
-    assert metrics["turns"] == 2  # the episode itself completed; only scoring failed
-
-
-# --- sandbox-create throttling ----------------------------------------------
 
 
 class _Throttled(Exception):
@@ -100,91 +29,34 @@ class _Throttled(Exception):
         return "rate limit exceeded, please retry"
 
 
-def _patch_fast_backoff(monkeypatch):
-    monkeypatch.setattr(oeaf, "_CREATE_BACKOFF_BASE_S", 0.001)
-    monkeypatch.setattr(oeaf, "_CREATE_BACKOFF_CAP_S", 0.001)
+# --- start hook -------------------------------------------------------------
 
 
-def test_create_retries_through_throttling(monkeypatch):
-    """Throttle errors are retried (with backoff) until the create succeeds."""
-    _patch_fast_backoff(monkeypatch)
-    calls = {"n": 0}
+def test_start_hook_creates_per_task_and_closes_by_killing(monkeypatch):
+    """The sandbox is per-task (tasks_dir/task_id) and close_fn kills it — the
+    template stays, the sandbox must not."""
+    killed = []
+    created = {}
 
-    def flaky_start(task_id, tasks_dir):
-        calls["n"] += 1
-        if calls["n"] <= 3:
-            raise _Throttled()
-        return (lambda: None), "http://sandbox:8000"
+    def fake_create(task_dir, **kwargs):
+        created.update(task_dir=task_dir, kwargs=kwargs)
+        return "sandbox-handle", "https://8000-abc.e2b.app"
 
-    monkeypatch.setattr(oeaf, "_start_sandbox", flaky_start)
-    monkeypatch.setenv("OPENENV_TB2_TASKS_DIR", "/nonexistent")
+    monkeypatch.setattr(oeaf.tb2_sandbox_e2b, "create_task_sandbox", fake_create)
+    monkeypatch.setattr(oeaf.tb2_sandbox_e2b, "kill_sandbox", killed.append)
 
-    close_fn, url = run_async(oeaf._start_task_sandbox("t1"))
-    assert url == "http://sandbox:8000"
-    assert calls["n"] == 4  # 3 throttled attempts + 1 success
+    close_fn, url = oeaf._start_sandbox("regex-chess", "/tasks")
 
-
-def test_create_gives_up_after_retry_budget(monkeypatch):
-    """A create that is throttled past _CREATE_MAX_RETRIES raises the error."""
-    _patch_fast_backoff(monkeypatch)
-    monkeypatch.setattr(oeaf, "_CREATE_MAX_RETRIES", 2)
-    calls = {"n": 0}
-
-    def always_throttled(task_id, tasks_dir):
-        calls["n"] += 1
-        raise _Throttled()
-
-    monkeypatch.setattr(oeaf, "_start_sandbox", always_throttled)
-    monkeypatch.setenv("OPENENV_TB2_TASKS_DIR", "/nonexistent")
-
-    with pytest.raises(_Throttled):
-        run_async(oeaf._start_task_sandbox("t1"))
-    assert calls["n"] == 3  # initial attempt + 2 retries
+    assert url == "https://8000-abc.e2b.app"
+    assert created["task_dir"] == Path("/tasks/regex-chess")
+    # The backend passes only what identifies the sandbox; every deadline is
+    # the materialization's own default, so the two cannot drift apart.
+    assert created["kwargs"] == {}
+    close_fn()
+    assert killed == ["sandbox-handle"]
 
 
-def test_cancel_during_create_reaps_orphaned_sandbox(monkeypatch):
-    """Cancelling an episode mid-create must not leak the sandbox: the worker
-    thread finishes the create in the background and the reaper kills it."""
-    started = threading.Event()
-    release = threading.Event()
-    closed = threading.Event()
-
-    def slow_start(task_id, tasks_dir):
-        started.set()
-        assert release.wait(5)
-        return (lambda: closed.set()), "http://sandbox:8000"
-
-    monkeypatch.setattr(oeaf, "_start_sandbox", slow_start)
-    monkeypatch.setenv("OPENENV_TB2_TASKS_DIR", "/nonexistent")
-
-    async def scenario():
-        task = asyncio.create_task(oeaf._start_task_sandbox("t1"))
-        await asyncio.to_thread(started.wait, 5)
-        task.cancel()
-        with pytest.raises(asyncio.CancelledError):
-            await task
-        # Only now does the in-flight create finish — after the awaiter is gone.
-        release.set()
-
-    run_async(scenario())
-    assert closed.wait(5)  # the reaper killed the orphan
-
-
-def test_create_non_throttle_error_propagates_immediately(monkeypatch):
-    """Anything that is not a rate-limit error must not be retried."""
-    _patch_fast_backoff(monkeypatch)
-    calls = {"n": 0}
-
-    def broken_start(task_id, tasks_dir):
-        calls["n"] += 1
-        raise RuntimeError("template build failed")
-
-    monkeypatch.setattr(oeaf, "_start_sandbox", broken_start)
-    monkeypatch.setenv("OPENENV_TB2_TASKS_DIR", "/nonexistent")
-
-    with pytest.raises(RuntimeError):
-        run_async(oeaf._start_task_sandbox("t1"))
-    assert calls["n"] == 1
+# --- throttle classification ------------------------------------------------
 
 
 def test_is_throttle_error_classification(monkeypatch):
@@ -207,9 +79,19 @@ def test_is_throttle_error_extra_patterns_env(monkeypatch):
     assert not oeaf._is_throttle_error(RuntimeError("template build failed"))
 
 
-def test_is_throttle_error_typed_e2b_class():
+def test_is_throttle_error_typed_e2b_class(monkeypatch):
     """The SDK's typed rate-limit error is recognized even when its message
     carries no throttle keywords; sibling error classes are not."""
+    monkeypatch.delenv("OPENENV_E2B_THROTTLE_PATTERNS", raising=False)
     ex = pytest.importorskip("e2b.exceptions")
     assert oeaf._is_throttle_error(ex.RateLimitException("slow down"))
     assert not oeaf._is_throttle_error(ex.AuthenticationException("bad key"))
+
+
+def test_is_throttle_error_without_the_sdk_installed(monkeypatch):
+    """The typed check is best-effort: the backend still classifies by text when the
+    SDK (or that class) is absent, rather than failing the classification."""
+    monkeypatch.delenv("OPENENV_E2B_THROTTLE_PATTERNS", raising=False)
+    monkeypatch.setitem(sys.modules, "e2b.exceptions", types.ModuleType("e2b.exceptions"))
+    assert oeaf._is_throttle_error(Exception("HTTP 429"))
+    assert not oeaf._is_throttle_error(RuntimeError("template build failed"))

--- a/examples/experimental/openenv/tests/test_openenv_sandbox_common.py
+++ b/examples/experimental/openenv/tests/test_openenv_sandbox_common.py
@@ -5,23 +5,78 @@ when touching the adapter:
 
     pytest examples/experimental/openenv/tests/ -q
 
-Covers the backend registry, whose whole job is to refuse to guess: which
-provider runs decides whose quota a rollout spends, so an unnamed or unknown
-one must fail at launch rather than resolve to whichever leg came first.
+Covers what every backend inherits, so it is proven once rather than once per
+provider:
+  - the backend registry, whose whole job is to refuse to guess: which provider
+    runs decides whose quota a rollout spends, so an unnamed or unknown one
+    must fail at launch rather than resolve to whichever backend came first;
+  - episode dispatch: a backend's run_episode sends raw exec commands and scores
+    via the standard `evaluate` action;
+  - sandbox-create throttling: throttle errors (typed by the backend, or textual)
+    are retried with backoff and a bounded budget, anything else propagates
+    immediately; a cancel mid-create reaps the orphaned sandbox.
+
+A backend's own tests cover only what is genuinely its own: which of its SDK's
+errors count as throttling, and how its start hook wires the materialization.
 """
 
+import asyncio
+import logging
 import sys
+import threading
+from contextlib import asynccontextmanager
 from pathlib import Path
 
 import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import openenv_agent_function as oaf  # noqa: E402
 import openenv_sandbox_common as common  # noqa: E402
+from test_openenv_agent_function import _CLASSES, _FakeEnv, _FakePolicy, _FakeResult  # noqa: E402
+
+logger = logging.getLogger("test-backend")
+
+
+class _Throttled(Exception):
+    def __str__(self):
+        return "rate limit exceeded, please retry"
+
+
+def _backend(**overrides) -> common.SandboxBackend:
+    """A backend whose provider-specific half is a stub.
+
+    Every real backend is this object plus a start hook and a throttle classifier,
+    so exercising it here is exercising all of them. Backoff is shrunk to keep
+    the retry tests instant.
+    """
+    spec = {
+        "provider": "Fake",
+        "start_sandbox": lambda task_id, tasks_dir: ((lambda: None), "http://sandbox:8000"),
+        "is_throttle": lambda exc: isinstance(exc, _Throttled),
+        "logger": logger,
+        "backoff_base_s": 0.001,
+        "backoff_cap_s": 0.001,
+    }
+    return common.SandboxBackend(**{**spec, **overrides})
+
+
+@asynccontextmanager
+async def _fake_episode_env(env_cls, metadata):
+    yield env_cls()
+
+
+# --- backend registry -------------------------------------------------------
 
 
 @pytest.mark.parametrize(
     ("name", "expected"),
-    [("daytona", "daytona"), ("e2b", "e2b"), ("agentenv", "e2b"), ("  E2B  ", "e2b")],
+    [
+        ("daytona", "daytona"),
+        ("e2b", "e2b"),
+        ("agentenv", "e2b"),
+        ("  E2B  ", "e2b"),
+    ],
 )
 def test_resolve_backend_normalizes_names_and_aliases(name, expected):
     assert common.resolve_backend(name) == expected
@@ -35,7 +90,7 @@ def test_resolve_backend_refuses_to_pick_for_you(name):
 
 def test_resolve_backend_rejects_unknown_names():
     with pytest.raises(ValueError, match="unknown sandbox backend"):
-        common.resolve_backend("modal")
+        common.resolve_backend("nonesuch")
 
 
 def test_every_registered_backend_names_an_importable_target():
@@ -43,4 +98,209 @@ def test_every_registered_backend_names_an_importable_target():
     for backend, path in common.AGENT_FUNCTIONS.items():
         module, _, func = path.rpartition(".")
         assert func == "run", backend
+        assert module == common.AGENT_MODULES[backend], backend
         assert (Path(__file__).resolve().parent.parent / f"{module}.py").is_file(), backend
+
+
+@pytest.mark.parametrize("name", sorted(common.AGENT_MODULES))
+def test_every_backend_exposes_the_entry_points(name):
+    """load_backend is how the sibling tools reach a provider; the module-level
+    run/run_episode are how training and the eval driver reach it."""
+    backend = common.load_backend(name)
+    assert isinstance(backend, common.SandboxBackend)
+    module = sys.modules[common.AGENT_MODULES[name]]
+    assert module.run == backend.run
+    assert module.run_episode == backend.run_episode
+
+
+@pytest.mark.parametrize("name", sorted(common.AGENT_MODULES))
+def test_operator_facing_help_names_every_backend(name):
+    """The sibling tools tell an operator which backends exist. That list drifted
+    it is generated from the registry where it can be, and asserted where it
+    cannot -- a list written by hand drifts the moment a backend is added."""
+    assert name in common.backend_names()
+    root = Path(__file__).resolve().parent.parent
+    assert name in (root / "eval_tbench2_via_api.py").read_text().split('"""')[1]
+
+
+def test_backend_knobs_read_the_providers_own_prefix(monkeypatch):
+    """One provider's knobs must not move another's."""
+    monkeypatch.setenv("OPENENV_FAKE_CREATE_CONCURRENCY", "9")
+    knobs = common.backend_knobs("FAKE")
+    assert knobs["create_concurrency"] == 9
+    assert knobs["max_retries"] == 8  # unset falls back to the shared default
+
+
+@pytest.mark.parametrize("name", sorted(common.AGENT_MODULES))
+def test_every_backend_owns_its_provider_hooks(name):
+    """Each backend must supply its OWN start hook and throttle classifier;
+    inheriting a sibling's would silently run episodes on the wrong provider."""
+    backend = common.load_backend(name)
+    module = sys.modules[common.AGENT_MODULES[name]]
+    assert backend.provider  # human-readable, used in the throttle log line
+    assert backend.start_sandbox.__module__ == module.__name__
+    assert backend.is_throttle.__module__ == module.__name__
+
+
+# --- episode dispatch -------------------------------------------------------
+
+
+def test_backend_dispatch(monkeypatch):
+    """A backend's run_episode: exec raw (the server resolves the workdir), scoring
+    via the standard `evaluate` action, no canonical exec, no rm-hack."""
+    monkeypatch.setattr(oaf, "load_tbench2", lambda: _CLASSES)
+    backend = _backend()
+    backend.episode_env = _fake_episode_env
+
+    reward, metrics = asyncio.run(
+        backend.run_episode(_FakePolicy(), "m", [{"role": "system", "content": "s"}], {}, {"task_id": "t1"})
+    )
+    actions = _FakeEnv.last_actions
+    execs = [a for a in actions if a.action_type == "exec"]
+
+    assert reward == 1.0
+    assert execs[0].command == "echo hi"
+    assert any(a.action_type == "evaluate" for a in actions)
+    assert not any("test.sh" in (a.command or "") for a in execs)
+    assert not any("/tmp/tbench2_env_runs" in (a.command or "") for a in execs)
+    assert metrics["turns"] == 2 and metrics["tool_calls"] == 1
+
+
+def test_backend_eval_error_yields_no_verdict(monkeypatch):
+    """A server-side scoring failure (`evaluate` comes back with error set and
+    no reward) surfaces as reward=None -- dropped by the training wrapper --
+    not coerced into a false-negative 0.0."""
+
+    class _EvalErrorEnv(_FakeEnv):
+        async def step(self, action):
+            if action.action_type == "evaluate":
+                self.actions.append(action)
+                res = _FakeResult()
+                res.observation.error = "toolkit timeout"
+                return res
+            return await super().step(action)
+
+    monkeypatch.setattr(oaf, "load_tbench2", lambda: {"env": _EvalErrorEnv, "action": _CLASSES["action"]})
+    backend = _backend()
+    backend.episode_env = _fake_episode_env
+
+    reward, metrics = asyncio.run(
+        backend.run_episode(_FakePolicy(), "m", [{"role": "system", "content": "s"}], {}, {"task_id": "t1"})
+    )
+    assert reward is None
+    assert metrics["turns"] == 2  # the episode itself completed; only scoring failed
+
+
+def test_episode_env_requires_a_task_id():
+    """The sandbox is built for ONE task, so an episode without a task id is a
+    caller bug, not something to guess a default for."""
+    backend = _backend()
+
+    async def scenario():
+        async with backend.episode_env(_FakeEnv, {}):
+            pass
+
+    with pytest.raises(ValueError, match="task_id"):
+        asyncio.run(scenario())
+
+
+# --- sandbox-create throttling ----------------------------------------------
+
+
+def test_create_retries_through_throttling(monkeypatch):
+    """Throttle errors are retried (with backoff) until the create succeeds."""
+    calls = {"n": 0}
+
+    def flaky_start(task_id, tasks_dir):
+        calls["n"] += 1
+        if calls["n"] <= 3:
+            raise _Throttled()
+        return (lambda: None), "http://sandbox:8000"
+
+    monkeypatch.setenv("OPENENV_TB2_TASKS_DIR", "/nonexistent")
+    close_fn, url = asyncio.run(_backend(start_sandbox=flaky_start).start_task_sandbox("t1"))
+    assert url == "http://sandbox:8000"
+    assert calls["n"] == 4  # 3 throttled attempts + 1 success
+
+
+def test_create_gives_up_after_retry_budget(monkeypatch):
+    """A create that is throttled past max_retries raises the error."""
+    calls = {"n": 0}
+
+    def always_throttled(task_id, tasks_dir):
+        calls["n"] += 1
+        raise _Throttled()
+
+    monkeypatch.setenv("OPENENV_TB2_TASKS_DIR", "/nonexistent")
+    backend = _backend(start_sandbox=always_throttled, max_retries=2)
+    with pytest.raises(_Throttled):
+        asyncio.run(backend.start_task_sandbox("t1"))
+    assert calls["n"] == 3  # initial attempt + 2 retries
+
+
+def test_create_non_throttle_error_propagates_immediately(monkeypatch):
+    """Anything that is not a throttle error must not be retried."""
+    calls = {"n": 0}
+
+    def broken_start(task_id, tasks_dir):
+        calls["n"] += 1
+        raise RuntimeError("image build failed")
+
+    monkeypatch.setenv("OPENENV_TB2_TASKS_DIR", "/nonexistent")
+    with pytest.raises(RuntimeError):
+        asyncio.run(_backend(start_sandbox=broken_start).start_task_sandbox("t1"))
+    assert calls["n"] == 1
+
+
+def test_cancel_during_create_reaps_orphaned_sandbox(monkeypatch):
+    """Cancelling an episode mid-create must not leak the sandbox: the worker
+    thread finishes the create in the background and the reaper closes it."""
+    started = threading.Event()
+    release = threading.Event()
+    closed = threading.Event()
+
+    def slow_start(task_id, tasks_dir):
+        started.set()
+        assert release.wait(5)
+        return (lambda: closed.set()), "http://sandbox:8000"
+
+    monkeypatch.setenv("OPENENV_TB2_TASKS_DIR", "/nonexistent")
+    backend = _backend(start_sandbox=slow_start)
+
+    async def scenario():
+        task = asyncio.create_task(backend.start_task_sandbox("t1"))
+        await asyncio.to_thread(started.wait, 5)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        # Only now does the in-flight create finish — after the awaiter is gone.
+        release.set()
+
+    asyncio.run(scenario())
+    assert closed.wait(5)  # the reaper closed the orphan
+
+
+# --- throttle-text classification -------------------------------------------
+
+
+def test_throttle_text_matches_the_shared_vocabulary():
+    for message in ("HTTP 429", "Too Many Requests", "rate limit exceeded"):
+        assert common.throttle_text(Exception(message))
+    assert not common.throttle_text(RuntimeError("image build failed"))
+
+
+def test_throttle_text_takes_the_backends_own_patterns():
+    assert common.throttle_text(Exception("ThrottlerException"), "throttler")
+    assert not common.throttle_text(Exception("ThrottlerException"))
+
+
+def test_throttle_text_extra_patterns_env(monkeypatch):
+    """The env knob extends the retryable set for capacity errors whoever
+    deployed the endpoint words their own way (a full self-hosted pool)."""
+    env = "OPENENV_FAKE_THROTTLE_PATTERNS"
+    monkeypatch.delenv(env, raising=False)
+    assert not common.throttle_text(Exception("no node with sufficient capacity"), patterns_env_var=env)
+    monkeypatch.setenv(env, "sufficient capacity, at capacity")
+    assert common.throttle_text(Exception("no node with sufficient capacity"), patterns_env_var=env)
+    assert common.throttle_text(Exception("cluster AT CAPACITY"), patterns_env_var=env)
+    assert not common.throttle_text(RuntimeError("image build failed"), patterns_env_var=env)


### PR DESCRIPTION
> 2/3 of a stack that adds a Modal sandbox backend. Base is #2274, so review that first; the diff here is only the abstraction.
> **1/3** #2274 · **3/3** #2276

The Daytona and E2B agent functions were two copies of the same orchestration around two genuinely different holes. Everything not provider-specific now lives once, in `openenv_sandbox_common.SandboxBackend`: throttled cancel-safe creates, the env client bound to one episode's sandbox, and the training / direct-drive entry points.

A backend module keeps only what is its own — how ONE sandbox comes into being, which of its SDK's errors are worth retrying, and its knobs — and shrinks to about a hundred lines, most of it documentation.

That matters because the copies were already diverging in ways nobody would choose deliberately: the cancel-mid-create reaper and the backoff constants were maintained per module. Anything the two must agree on is now impossible to disagree on.

**The registry** (`AGENT_MODULES` / `resolve_backend` / `load_backend` / `backend_names`) becomes the single place that names providers. The sibling tools (`scan_golden`, `eval_tbench2_via_api`) reach a backend by naming it rather than growing an import branch each, and their operator-facing help text is now generated from the registry instead of written by hand — with a test that fails if a registered backend goes unmentioned, because that drift is easy to miss in review.

**Knobs** are read through one shared `backend_knobs(prefix)`, so every backend gets the same names under its own prefix and can be tuned without touching another's.

**Four names in `openenv_agent_function`** go from protected to public (`multi_turn`, `run_for_training`, `MESSAGE_TIMEOUT_S`, `load_tbench2`). They now have a consumer outside their own module, so the leading underscore was claiming an encapsulation that no longer held.

`leg` is kept where it still means the shared-server-vs-sandbox distinction, and dropped where it had come to mean "backend".

### Why now, with only two backends

Fair question for an abstraction over two implementations. The answer is 3/3 in this stack: adding a provider on top of this is two files plus a registry entry, and none of the behaviour above is restated. Reviewing them separately is the point — this PR is the shape, that one is the payoff.

The recipe README still uses the older wording in places; it is rewritten in 3/3, alongside the third backend that motivates the restructure.

## Verification

Offline tests: **70 passed, 2 skipped**; ruff + black clean at the repo-pinned versions. Live verification for the stack is on 3/3, which is the state that was actually run against the providers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Since merging, a GRPO run on the E2B backend has exercised this abstraction end
to end (3 rollouts, all `outcome=NORMAL`, non-zero rewards, weights broadcast
back each step) — i.e. `SandboxBackend` carries a real training run and not just
the per-episode paths. Numbers are in #2276, alongside the same run on Modal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
