### PR TITLE
feat(openenv): add Modal as a third per-episode sandbox backend

### DIFF
--- a/docs/user-guide/environments.md
+++ b/docs/user-guide/environments.md
@@ -19,11 +19,11 @@ where the environment itself comes from:
 | Integration | Plugs in at | Guide |
 |---|---|---|
 | [Harbor](https://github.com/harbor-framework/harbor) | agent function | [guide](/user-guide/harbor) |
-| [OpenEnv](https://github.com/huggingface/openenv) | agent function | [guide](/user-guide/openenv) |
 | [NeMo-Gym](https://github.com/NVIDIA-NeMo/Gym) | agent function | [guide](/user-guide/nemo-gym) |
+| [OpenEnv](https://github.com/huggingface/openenv) | agent function | [guide](/user-guide/openenv) |
 | [Strands Agents](https://strandsagents.com/) | generate function | [example](https://github.com/radixark/miles/tree/main/examples/experimental/strands_sglang) |
-| [τ-bench](https://github.com/sierra-research/tau-bench) | generate function | [example](https://github.com/radixark/miles/tree/main/examples/experimental/tau-bench) |
 | [Verifiers (Prime Intellect)](https://github.com/PrimeIntellect-ai/verifiers) | rollout function | [guide](/user-guide/verifiers) |
+| [τ-bench](https://github.com/sierra-research/tau-bench) | generate function | [example](https://github.com/radixark/miles/tree/main/examples/experimental/tau-bench) |
 
 Sandbox providers are a different axis: they provision the task containers
 *inside* a connector rather than occupying a rollout layer.
@@ -33,8 +33,9 @@ Sandbox providers are a different axis: they provision the task containers
 | [AgentENV](https://github.com/kvcache-ai/AgentENV) | OpenEnv | [example](https://github.com/radixark/miles/tree/main/examples/experimental/agentenv) |
 | [Daytona](https://www.daytona.io/) | OpenEnv, Harbor, NeMo-Gym | [example](https://github.com/radixark/miles/tree/main/examples/experimental/openenv) |
 | [E2B](https://e2b.dev/) | OpenEnv | [example](https://github.com/radixark/miles/tree/main/examples/experimental/openenv) |
+| [Modal](https://modal.com/) | OpenEnv | [example](https://github.com/radixark/miles/tree/main/examples/experimental/openenv) |
 
-All external ecosystem support is experimental.
+Everything above is experimental, and listed alphabetically.
 
 ## Integration shapes
 

--- a/docs/user-guide/openenv.md
+++ b/docs/user-guide/openenv.md
@@ -19,11 +19,13 @@ hook.
 
 The maintained end-to-end recipe is **Terminal-Bench-2 GRPO** in
 [`examples/experimental/openenv`](https://github.com/radixark/miles/tree/main/examples/experimental/openenv).
-It runs against a shared Docker env server (full per-task image fidelity) or
-per-episode cloud sandboxes built from each task's official image (no resident
-infrastructure) on a choice of providers: [Daytona](https://www.daytona.io/),
-[E2B](https://e2b.dev/), or a self-hosted, E2B-compatible
-[AgentENV](https://github.com/kvcache-ai/AgentENV) deployment. Follow the
+It gives every episode its own cloud sandbox, built from that task's official
+image so no resident infrastructure is left behind, on a choice of providers —
+[AgentENV](https://github.com/kvcache-ai/AgentENV) (self-hosted, E2B-compatible),
+[Daytona](https://www.daytona.io/), [E2B](https://e2b.dev/), or
+[Modal](https://modal.com/). One shared Docker env server is supported as well,
+for running without any sandbox platform.
+Follow the
 [recipe README](https://github.com/radixark/miles/blob/main/examples/experimental/openenv/README.md)
-for prompt-data preparation, env-server modes, launcher flags, and operational
-notes.
+for prompt-data preparation, environment options, launcher flags, and
+operational notes.

--- a/examples/experimental/agentenv/README.md
+++ b/examples/experimental/agentenv/README.md
@@ -76,7 +76,7 @@ export OPENENV_TB2_TASKS_DIR=/workspace/terminal-bench-2
 OPENENV_SANDBOX_BACKEND=agentenv python ../openenv/run-openenv-tbench2.py
 ```
 
-From here the e2b leg behaves as that recipe describes it, with each episode
+From here the e2b backend behaves as that recipe describes it, with each episode
 running in a microVM instead of a cloud sandbox: the same per-task templates,
 the same pre-baking step, the same GPU-free sanity checks. One caveat is
 specific to baking against a self-hosted server: the CLI builds tasks one

--- a/examples/experimental/openenv/README.md
+++ b/examples/experimental/openenv/README.md
@@ -11,7 +11,9 @@ This guide targets a **single H200 node with 8 GPUs**. The run is colocated
 
 ## Prerequisites
 
-- The node has Docker available (the env server launches one container per task).
+- Somewhere for the task environments to run, per step 2: an account with one of
+  the hosted sandbox providers, a self-hosted AgentENV deployment, or a Docker
+  host for the shared env server.
 - miles is installed and GLM-4.7-Flash weights are reachable (the launcher pulls
   `zai-org/GLM-4.7-Flash` from HF and converts it to `torch_dist` on first run).
 - Install the OpenEnv tbench2 env client (isolate it if its deps clash with the
@@ -31,10 +33,117 @@ python make_tbench2_data.py --tasks_dir /workspace/terminal-bench-2 --output /ro
 # add --n 8 for a small smoke subset
 ```
 
-## 2. Start the env server
+## 2. Provision the task environment
 
-Run it in a separate shell (or off-node — see note). Docker mode gives real TB2
-fidelity; it needs the Docker socket and pulls the per-task images on first use:
+Every episode gets its **own cloud sandbox**, built from the task's official
+image plus an env-server layer and deleted when the episode ends. That leaves
+no resident infrastructure behind — no Docker socket, no shared server to size
+or babysit, no cross-episode state — at the cost of one sandbox creation per
+episode. (A single shared env server is still supported; see the last
+subsection.)
+
+Terminal-Bench-2 pins a different official image per **task**, which the recipe
+honors rather than flattens. Two consequences follow on every provider: nothing
+is shared across tasks, so all 89 pay their own first build; and since those
+base images live on Docker Hub, which the providers' builders pull anonymously,
+a first full-suite build can hit Docker Hub's anonymous pull limit — build a
+few tasks at a time if it does.
+
+Whichever provider you pick, install `tbench2_env` **editable**: the recipe
+bakes the installed source into each task image, so that install must carry
+the `>=` #1012 server contract. The launcher preflights the installed source
+and fails fast on an older one.
+
+```bash
+git clone https://github.com/huggingface/OpenEnv.git   # >= the #1012 merge (04d259ea6, the full canonical contract for both modes); pin that sha if you need frozen reward semantics across a long run
+pip install -e OpenEnv/envs/tbench2_env
+```
+
+Then set two things: `OPENENV_TB2_TASKS_DIR`, the checkout to build task images
+from, and `OPENENV_SANDBOX_BACKEND`, the provider to build them on. Neither has
+a default — the provider decides whose quota a run spends and which credentials
+have to be present — so setting one without the other fails at launch.
+
+Every provider authenticates the same way: the credential in the environment
+(`DAYTONA_API_KEY`, `E2B_API_KEY`, or Modal's `MODAL_TOKEN_ID` +
+`MODAL_TOKEN_SECRET` pair), or else a file whose *path* the launcher forwards.
+It never forwards the value, which ray's `runtime_env` records in plaintext;
+the agent-function docstrings cover what that means on a multi-host cluster.
+A partially-supplied credential (one half of Modal's token pair) is treated as
+missing rather than usable.
+
+### Daytona
+
+Builds each image declaratively per episode, straight from the image
+definition: the first episode of a task pays the build and later ones hit
+Daytona's build cache, keyed by definition hash. No named snapshot is involved,
+so nothing accumulates against the org's snapshot quota — and correspondingly
+there is nothing to pre-build ahead of a run.
+
+```bash
+pip install daytona
+mkdir -p ~/.config/daytona && echo dtn_... > ~/.config/daytona/api_key   # or export DAYTONA_API_KEY
+export OPENENV_TB2_TASKS_DIR=/workspace/terminal-bench-2   # the checkout from step 1
+OPENENV_SANDBOX_BACKEND=daytona python run-openenv-tbench2.py
+```
+
+### E2B or AgentENV
+
+Builds one **named template** per task, from which every later episode
+warm-starts. The endpoint defaults to E2B Cloud; to drive a self-hosted
+[AgentENV](https://github.com/kvcache-ai/AgentENV) deployment — the Firecracker
+microVM platform whose native API *is* the E2B API — set `E2B_API_URL` and
+`E2B_SANDBOX_URL` and follow the [AgentENV recipe](../agentenv/README.md).
+`agentenv` is accepted as an alias for this backend.
+
+```bash
+pip install e2b
+export E2B_API_KEY=e2b_...     # or E2B_API_KEY_FILE (default ~/.config/e2b/api_key)
+export OPENENV_TB2_TASKS_DIR=/workspace/terminal-bench-2
+OPENENV_SANDBOX_BACKEND=e2b python run-openenv-tbench2.py
+```
+
+Because the template is a named artifact rather than a build cache, it is the
+one backend that can be built ahead of the run. Doing so is optional — the
+first episode of a task builds it inline — but that inline build occupies a
+create-concurrency slot, so an unbaked first rollout spends most of its wall
+clock building images:
+
+```bash
+python tb2_sandbox_e2b.py --tasks-dir /workspace/terminal-bench-2 --all
+```
+
+### Modal
+
+Expresses the recipe as one image layer per command, so editing the recipe
+re-runs only the layers below the edit. There is no bake step: layer hashes
+are themselves the cache key, so the first create for a task warms exactly
+what later creates hit.
+
+```bash
+pip install modal
+modal token new    # writes ~/.modal.toml; or export MODAL_TOKEN_ID + MODAL_TOKEN_SECRET
+export OPENENV_TB2_TASKS_DIR=/workspace/terminal-bench-2
+OPENENV_SANDBOX_BACKEND=modal python run-openenv-tbench2.py
+```
+
+Two things here are Modal's alone. Its sandbox timeout **cannot be extended**,
+so `OPENENV_MODAL_SANDBOX_TTL_S` is a hard ceiling on one episode and must
+exceed `OPENENV_MAX_ROLLOUT_TIME_SECONDS`; orphans are reclaimed by
+`OPENENV_MODAL_IDLE_TIMEOUT_S` rather than by a keepalive thread (the
+[materialization module](tb2_sandbox_modal.py) explains why that suffices, and
+carries the snippet for sweeping a shared workspace). And for the Docker Hub
+limit above, Modal takes registry credentials directly: hand
+`Image.from_registry` a `modal.Secret`.
+
+### Alternative: one shared env server
+
+Rather than a sandbox per episode, one long-lived server can serve them all,
+launching a container per task on its own Docker host. It is what the upstream
+TB2 harness does, and it needs no sandbox platform at all — just Docker.
+(Self-hosted AgentENV also avoids a vendor account, but is a platform you
+deploy and operate.) The cost is resident infrastructure to size and clean up
+after: see the shared-server entries under Notes.
 
 ```bash
 # Raise the open-file limit first (see Notes): the WebSocket env server holds an
@@ -45,109 +154,82 @@ TB2_MODE=docker TB2_TASKS_DIR=/workspace/terminal-bench-2 MAX_CONCURRENT_ENVS=32
     python -m tbench2_env.server.app --port 8003
 ```
 
-`MAX_CONCURRENT_ENVS` caps live sandboxes; keep it at or below the rollout batch
-concurrency. Per-task containers are heavy on disk — if you'd rather not colocate
-them with the GPU workload, run the env server on a separate Docker host and point
-the launcher at it via `--openenv-env-url http://<env-host>:8003`.
+Run it in a separate shell, and leave `OPENENV_TB2_TASKS_DIR` unset so the
+launcher uses `--openenv-env-url` instead. `MAX_CONCURRENT_ENVS` caps live
+containers; keep it at or below the rollout batch concurrency. Those containers
+are heavy on disk, so if you'd rather not colocate them with the GPU workload,
+run the server on a separate Docker host and point the launcher at it with
+`--openenv-env-url http://<env-host>:8003`. The same `>=` #1012 `tbench2_env`
+contract applies: the adapter drops every episode (with a warning) from a
+server that doesn't carry it.
 
-The installed `tbench2_env` must be `>=` the #1012 merge (04d259ea6), same as
-step 2b below; the adapter drops every episode (with a warning) from a server
-that doesn't carry that contract.
+## 3. Sanity-check the environment (optional, no GPU)
 
-### 2b. Alternative: per-episode cloud sandboxes — Daytona, E2B, or AgentENV
+Skippable — training runs without it — but a provisioning mistake skipped here
+resurfaces as a rollout that burns GPUs to score zeros. Both scripts exercise
+exactly what step 2 provisioned and honor the same `OPENENV_SANDBOX_BACKEND`,
+so both cost provider time; scope them to a few tasks unless you want the full
+sweep. [`scan_golden.py`](scan_golden.py) replays each task's official solution
+through the full sandbox and scoring path; expect 82/89 to pass, since the rest
+have upstream-broken solutions, and pass `--logs` to capture the failure
+evidence. [`eval_tbench2_via_api.py`](eval_tbench2_via_api.py) runs the same
+agentic loop with any OpenAI-compatible API standing in for the policy, which
+also gives a baseline solve-rate to compare training against.
 
-Instead of one shared env server, every episode can get its **own cloud
-sandbox**, built from the task's official image plus an env-server layer and
-deleted when the episode ends. This keeps docker mode's per-task image
-fidelity while leaving no resident infrastructure behind: no Docker socket,
-no shared server to size or babysit, no cross-episode state. It costs a
-sandbox creation per episode, plus one image or template build the first time
-each task runs, which the provider caches from then on.
-
-Whichever provider you pick, install `tbench2_env` **editable**: the recipe
-bakes the installed source into each task image, so that install must carry
-the same `>=` #1012 server contract as step 2. The launcher preflights the
-installed source and fails fast on an older one.
-
-```bash
-git clone https://github.com/huggingface/OpenEnv.git   # >= the #1012 merge (04d259ea6, the full canonical contract for both modes); pin that sha if you need frozen reward semantics across a long run
-pip install -e OpenEnv/envs/tbench2_env
-```
-
-Then skip step 2 and set two things: `OPENENV_TB2_TASKS_DIR`, the checkout to
-build task images from, and `OPENENV_SANDBOX_BACKEND`, the provider to build
-them on. Neither has a default — the provider decides whose quota a run
-spends and which credentials have to be present — so setting one without the
-other fails at launch.
-
-Both providers authenticate the same way: the key in the environment
-(`DAYTONA_API_KEY`, `E2B_API_KEY`), or else a file whose *path* the launcher
-forwards. It never forwards the value, which ray's `runtime_env` records in
-plaintext; the agent-function docstrings cover what that means on a
-multi-host cluster.
-
-**Daytona** builds each image declaratively per episode. A warm create takes
-about a minute, and the first episode of each task spends about ten minutes
-building its image, cached by definition hash after that.
+## 4. Launch training
 
 ```bash
-pip install daytona
-mkdir -p ~/.config/daytona && echo dtn_... > ~/.config/daytona/api_key   # or export DAYTONA_API_KEY
-export OPENENV_TB2_TASKS_DIR=/workspace/terminal-bench-2   # the checkout from step 1
-OPENENV_SANDBOX_BACKEND=daytona python run-openenv-tbench2.py
-```
-
-**E2B-compatible** providers (`e2b`, or `agentenv` as an alias for the same
-leg) build one named template per task, and every later episode warm-starts
-from it in seconds. The endpoint defaults to E2B Cloud; to drive a
-self-hosted [AgentENV](https://github.com/kvcache-ai/AgentENV) deployment
-instead, follow the [AgentENV recipe](../agentenv/README.md).
-
-```bash
-pip install e2b
-export E2B_API_KEY=e2b_...     # or E2B_API_KEY_FILE (default ~/.config/e2b/api_key)
 export OPENENV_TB2_TASKS_DIR=/workspace/terminal-bench-2
-OPENENV_SANDBOX_BACKEND=e2b python run-openenv-tbench2.py
+OPENENV_SANDBOX_BACKEND=e2b python run-openenv-tbench2.py   # or daytona / modal
 ```
 
-Because that template is a named artifact rather than a build cache, it can be
-built ahead of the run. Doing so is optional, since the first episode of a
-task builds it inline, but that inline build occupies a create-concurrency
-slot, so an unbaked first rollout spends most of its wall clock building
-images: `python tb2_sandbox_e2b.py --tasks-dir /workspace/terminal-bench-2 --all`.
-
-Two sanity checks run without a GPU, and both honor
-`OPENENV_SANDBOX_BACKEND`. [`scan_golden.py`](scan_golden.py) replays each
-task's official solution through the full sandbox and scoring path; expect
-82/89 to pass, since the rest have upstream-broken solutions, and pass
-`--logs` to capture the failure evidence.
-[`eval_tbench2_via_api.py`](eval_tbench2_via_api.py) runs the same agentic
-loop with any OpenAI-compatible API standing in for the policy.
-
-## 3. Launch training
+Against a shared env server instead, name its URL and leave
+`OPENENV_TB2_TASKS_DIR` unset:
 
 ```bash
 python run-openenv-tbench2.py --openenv-env-url http://localhost:8003
 ```
 
-Common overrides:
+Common overrides. Every `OPENENV_*` knob below is read **once, when the rollout
+worker imports the adapter** — a worker is a fresh process per run, so changing
+one mid-run would change nothing. The exceptions are `OPENENV_TB2_TASKS_DIR`,
+which the launcher injects through ray's `runtime_env` and each episode
+re-reads, and `OPENENV_E2B_THROTTLE_PATTERNS`, consulted each time a create
+fails.
 
 | Flag / env var | Default | Purpose |
 | --- | --- | --- |
-| `--openenv-env-url` | `http://localhost:8003` | Env server URL |
+| `--openenv-env-url` | `http://localhost:8003` | Shared env server URL; ignored in per-episode sandbox mode |
 | `--prompt-data` | `/root/tbench2_train.jsonl` | Prompt set from step 1 |
 | `--num-rollout` | (launcher) | Number of GRPO steps |
 | `OPENENV_MAX_TURNS` | `30` | Max agent turns per episode |
 | `OPENENV_MAX_ROLLOUT_TIME_SECONDS` | `3600` | Per-episode wall-clock cap; a straggler that exceeds it is terminated and scored 0 |
-| `OPENENV_TB2_TASKS_DIR` | off | Switches on per-episode sandbox mode (section 2b) and overrides `--openenv-env-url`. Point it at the terminal-bench-2 checkout from step 1 |
-| `DAYTONA_API_KEY` / `DAYTONA_API_KEY_FILE` | — / `~/.config/daytona/api_key` | Daytona key supply: the env value wins, otherwise the key file is read |
-| `OPENENV_SANDBOX_BACKEND` | — | Required whenever `OPENENV_TB2_TASKS_DIR` is set: `daytona`, `e2b`, or `agentenv` (alias for `e2b`; section 2b). Only the selected leg's `OPENENV_*` settings below are read — the others are ignored silently |
-| `E2B_API_KEY` / `E2B_API_KEY_FILE` | — / `~/.config/e2b/api_key` | E2B key supply, same file-path-forwarding contract as Daytona's |
-| `E2B_API_URL`, `E2B_SANDBOX_URL` | E2B Cloud | Endpoint overrides — point both at a self-hosted AgentENV gateway |
-| `OPENENV_DAYTONA_CREATE_CONCURRENCY` | `4` | Max in-flight creates on the daytona leg. Raise it against Daytona's creation rate limit, which the leg also retries with backoff |
-| `OPENENV_E2B_CREATE_CONCURRENCY` | `4` | Max in-flight creates on the e2b leg. Size it to what the endpoint can host — one self-hosted AgentENV machine took 16 — and use `OPENENV_E2B_THROTTLE_PATTERNS` to name additional provider errors that should count as retryable capacity limits |
 | `--dump-details <dir>` | off | Dump per-episode tokens/logprobs/masks/reward for inspection |
 | `WANDB_KEY`, `--wandb-project`, `--wandb-team` | — | W&B logging |
+
+Per-episode sandbox mode (step 2). The two switches come first, then each
+provider's credentials, then the knobs — the ones shared by every backend
+(`<BACKEND>` is `DAYTONA`, `E2B`, or `MODAL`), then each provider's own.
+
+| Flag / env var | Default | Purpose |
+| --- | --- | --- |
+| `OPENENV_TB2_TASKS_DIR` | off | Switches on per-episode sandbox mode and overrides `--openenv-env-url`. Point it at the terminal-bench-2 checkout from step 1 |
+| `OPENENV_SANDBOX_BACKEND` | — | Required whenever `OPENENV_TB2_TASKS_DIR` is set: `agentenv` (alias for `e2b`), `daytona`, `e2b`, or `modal`. Only the selected backend's settings below are read — the others are ignored silently |
+| `DAYTONA_API_KEY` / `DAYTONA_API_KEY_FILE` | — / `~/.config/daytona/api_key` | Daytona key supply: the env value wins, otherwise the key file is read |
+| `E2B_API_KEY` / `E2B_API_KEY_FILE` | — / `~/.config/e2b/api_key` | E2B key supply, on the same contract |
+| `E2B_API_URL`, `E2B_SANDBOX_URL` | E2B Cloud | Endpoint overrides — point both at a self-hosted AgentENV gateway |
+| `MODAL_TOKEN_ID` + `MODAL_TOKEN_SECRET` / `MODAL_CONFIG_PATH` | — / `~/.modal.toml` | Modal credential supply. The token PAIR must be complete; otherwise the config file's *path* is forwarded, like the other providers' key files |
+| `MODAL_PROFILE`, `MODAL_ENVIRONMENT` | profile default | Which Modal profile / workspace environment the sandboxes are created in |
+| `OPENENV_<BACKEND>_CREATE_CONCURRENCY` | `4` | Max in-flight creates. Size it to what the endpoint can host — one self-hosted AgentENV machine took 16; on Modal the ceiling above it is the plan's container concurrency |
+| `OPENENV_<BACKEND>_CREATE_MAX_RETRIES` | `8` | How many throttled creates to retry before giving up (the backoff curve itself is not tunable) |
+| `OPENENV_<BACKEND>_READY_TIMEOUT_S` | `300` | How long the env server has to answer /health after its sandbox exists |
+| `OPENENV_E2B_SANDBOX_TTL_S` | `1800` | E2B sandbox TTL, re-armed by a keepalive thread while the creating process lives (Daytona's equivalent backstop is its own auto-stop/auto-delete, not a knob) |
+| `OPENENV_E2B_THROTTLE_PATTERNS` | — | Extra comma-separated lowercase substrings that count as retryable capacity errors. Exists for self-hosted AgentENV, which words "at capacity" however its operator deployed it |
+| `OPENENV_E2B_URL_SCHEME` | `https` | Scheme for the per-sandbox URL — set `http` for a plain-HTTP self-hosted AgentENV gateway |
+| `OPENENV_MODAL_APP` | `openenv-tbench2` | App the sandboxes are created under; what a sweep scopes to in a shared workspace |
+| `OPENENV_MODAL_BUILD_LOGS` | off | Stream Modal's image-build logs. Debug-only: it drives a process-wide output manager, so never set it with creates fanned out |
+| `OPENENV_MODAL_CREATE_TIMEOUT_S` | `1800` | Build+create wall clock per Modal sandbox (the first create for a task builds its image, which Modal does not deadline itself) |
+| `OPENENV_MODAL_SANDBOX_TTL_S` / `OPENENV_MODAL_IDLE_TIMEOUT_S` | `1800` / `300` | Modal lifetimes. The TTL is a HARD ceiling (Modal timeouts cannot be extended) and must exceed `OPENENV_MAX_ROLLOUT_TIME_SECONDS`; the idle timeout is what reclaims orphans, and an open tunnel connection counts as activity |
 
 ## Notes
 
@@ -158,14 +240,15 @@ Common overrides:
 - **`_step` vs. rollout.** W&B `_step` is an internal log-call index that advances
   several times per rollout; it is **not** the training step. Read the driver log's
   `rollout N:` counter for true progress.
-- **Sandbox leakage.** Upstream OpenEnv creates task containers with `remove=False`
-  and only tears them down on a clean session close (the idle reaper is off by
-  default), so an unclean disconnect (trainer crash) can orphan containers. Sweep
-  stale TB2 containers between runs, e.g. `docker rm -f` of any older than the
-  episode wall-cap.
-- **Open-file limit.** The same unclean disconnects also leak socket FDs in the
-  env server process. On a long run under the default 1024 soft limit the accept
-  loop eventually fails every connection with `OSError: [Errno 24] Too many open
-  files`, silently throttling rollouts. Start the server with a raised limit
-  (`ulimit -n 1048576`, as in step 2); if a running server is already saturated,
-  restart it with the higher limit.
+- **Shared server: container leakage.** Upstream OpenEnv creates task containers
+  with `remove=False` and only tears them down on a clean session close (the idle
+  reaper is off by default), so an unclean disconnect (trainer crash) can orphan
+  containers. Sweep stale TB2 containers between runs, e.g. `docker rm -f` of any
+  older than the episode wall-cap. Per-episode sandboxes have no equivalent: each
+  provider arms its own TTL, so a dead caller's sandbox is reclaimed for you.
+- **Shared server: open-file limit.** The same unclean disconnects also leak
+  socket FDs in the env server process. On a long run under the default 1024 soft
+  limit the accept loop eventually fails every connection with `OSError: [Errno
+  24] Too many open files`, silently throttling rollouts. Start the server with a
+  raised limit (`ulimit -n 1048576`, as in step 2); if a running server is already
+  saturated, restart it with the higher limit.

--- a/examples/experimental/openenv/eval_tbench2_via_api.py
+++ b/examples/experimental/openenv/eval_tbench2_via_api.py
@@ -23,7 +23,7 @@ Env vars:
   POLICY_BASE_URL   OpenAI-compatible root (default https://api.deepseek.com)
   POLICY_MODEL      default deepseek-v4-flash
   OPENENV_SANDBOX_BACKEND   per-episode sandbox mode: agentenv (an alias for
-                    e2b) / daytona / e2b. Left unset, OPENENV_ENV_URL
+                    e2b) / daytona / e2b / modal. Left unset, OPENENV_ENV_URL
                     (one shared env server) is used instead.
   OPENENV_TB2_TASKS_DIR     required with the above: the TB2 checkout to build
                     task images from. Each backend then resolves its OWN

--- a/examples/experimental/openenv/openenv_agent_function.py
+++ b/examples/experimental/openenv/openenv_agent_function.py
@@ -37,7 +37,7 @@ verdict and the episode is dropped with a warning (see the guard in
 multi_turn).
 
 Per-episode sandbox variants: one sibling module per provider
-(``openenv_{daytona,e2b}_agent_function``), each a drop-in
+(``openenv_{daytona,e2b,modal}_agent_function``), each a drop-in
 ``--custom-agent-function-path`` alternative that runs every episode in its
 own cloud sandbox. They reuse this module's agent loop and training wrapper,
 supplying only their own run_episode (see the episode-wiring note below);

--- a/examples/experimental/openenv/openenv_launch_common.py
+++ b/examples/experimental/openenv/openenv_launch_common.py
@@ -36,6 +36,7 @@ class LaunchArgs(Protocol):
     openenv_sandbox_backend: str
     daytona_api_key_file: str
     e2b_api_key_file: str
+    modal_config_file: str
     router_external_host: str
     miles_host_ip: str
 
@@ -195,38 +196,26 @@ def apply_optional_env_vars(env: dict[str, str], args: LaunchArgs) -> None:
         env["MILES_ROUTER_EXTERNAL_HOST"] = args.router_external_host
     backend = resolve_sandbox_backend(args)
     if backend:
-        if backend == "daytona":
-            _sandbox_key_supply(
-                env,
-                provider="Daytona",
-                key_env_var="DAYTONA_API_KEY",
-                file_env_var="DAYTONA_API_KEY_FILE",
-                arg_path=args.daytona_api_key_file,
-                default_path="~/.config/daytona/api_key",
-                provision_hint="mkdir -p ~/.config/daytona && echo dtn_... > ~/.config/daytona/api_key",
-            )
-            _preflight_sdk("daytona", "pip install daytona (or pip install -e '<OpenEnv>/envs/tbench2_env[daytona]')")
-        else:  # e2b (E2B Cloud or a self-hosted AgentENV endpoint)
-            _sandbox_key_supply(
-                env,
-                provider="E2B",
-                key_env_var="E2B_API_KEY",
-                file_env_var="E2B_API_KEY_FILE",
-                arg_path=args.e2b_api_key_file,
-                default_path="~/.config/e2b/api_key",
-                provision_hint="mkdir -p ~/.config/e2b && echo <key> > ~/.config/e2b/api_key"
-                "  # AgentENV accepts any non-empty key today",
-            )
-            _preflight_sdk("e2b", "pip install e2b")
-            # Endpoint overrides are read from the environment by the SDK on
-            # every worker; forward them (they are addresses, not secrets).
-            # E2B_API_URL unset means E2B Cloud; set, it usually points at a
-            # self-hosted AgentENV deployment.
-            for var in ("E2B_API_URL", "E2B_SANDBOX_URL", "E2B_DOMAIN", "OPENENV_E2B_URL_SCHEME"):
-                if os.environ.get(var, "").strip():
-                    env[var] = os.environ[var].strip()
-            endpoint = env.get("E2B_API_URL", "E2B Cloud (default)")
-            print(f"openenv: E2B endpoint: {endpoint}", flush=True)
+        spec = _PROVIDER_CREDENTIALS[backend]
+        _sandbox_key_supply(
+            env,
+            provider=spec["provider"],
+            key_env_vars=spec["key_env_vars"],
+            file_env_var=spec["file_env_var"],
+            arg_path=getattr(args, spec["arg_attr"], "") or "",
+            default_path=spec["default_path"],
+            provision_hint=spec["provision_hint"],
+        )
+        _preflight_sdk(spec["sdk"], spec["sdk_hint"])
+        # Addresses, not secrets: the SDK reads these from the environment on
+        # every worker, so forward whatever is set here BY VALUE.
+        for var in spec["forward"]:
+            value = os.environ.get(var, "").strip()
+            if value:
+                _forward_address(env, var, value)
+        if spec["target"]:
+            var, label, default_desc = spec["target"]
+            print(f"openenv: {spec['provider']} {label}: {env.get(var, default_desc)}", flush=True)
         # Preflight the env package the recipe bakes into each task image —
         # shared by every sandbox backend. The import check catches a missing
         # install; the source probe catches an install that imports fine but
@@ -253,22 +242,99 @@ def apply_optional_env_vars(env: dict[str, str], args: LaunchArgs) -> None:
         env["OPENENV_TB2_TASKS_DIR"] = args.openenv_tb2_tasks_dir
 
 
+# Per-provider credential shape and the address-like env vars to forward.
+# One entry per backend in openenv_sandbox_common.AGENT_MODULES; a provider is
+# added here, not by growing a branch.
+#   key_env_vars   what a worker must ALL have for the env-supply path to work
+#                  (Modal's credential is a token PAIR, not one key)
+#   file_env_var   the path-valued var the launcher forwards instead of secrets
+#   forward        addresses/selectors, safe to forward by value
+#   target         (var, label, default description) echoed so a launch says
+#                  which endpoint/environment it will actually use
+_PROVIDER_CREDENTIALS = {
+    "daytona": {
+        "provider": "Daytona",
+        "key_env_vars": ("DAYTONA_API_KEY",),
+        "file_env_var": "DAYTONA_API_KEY_FILE",
+        "arg_attr": "daytona_api_key_file",
+        "default_path": "~/.config/daytona/api_key",
+        "provision_hint": "mkdir -p ~/.config/daytona && echo dtn_... > ~/.config/daytona/api_key",
+        "sdk": "daytona",
+        "sdk_hint": "pip install daytona (or pip install -e '<OpenEnv>/envs/tbench2_env[daytona]')",
+        "forward": (),
+        "target": None,
+    },
+    "e2b": {
+        "provider": "E2B",
+        "key_env_vars": ("E2B_API_KEY",),
+        "file_env_var": "E2B_API_KEY_FILE",
+        "arg_attr": "e2b_api_key_file",
+        "default_path": "~/.config/e2b/api_key",
+        "provision_hint": "mkdir -p ~/.config/e2b && echo <key> > ~/.config/e2b/api_key"
+        "  # AgentENV accepts any non-empty key today",
+        "sdk": "e2b",
+        "sdk_hint": "pip install e2b",
+        # E2B_API_URL unset means E2B Cloud; set, it usually points at a
+        # self-hosted AgentENV deployment.
+        "forward": ("E2B_API_URL", "E2B_SANDBOX_URL", "E2B_DOMAIN", "OPENENV_E2B_URL_SCHEME"),
+        "target": ("E2B_API_URL", "endpoint", "E2B Cloud (default)"),
+    },
+    "modal": {
+        "provider": "Modal",
+        # Modal has no single API key: the SDK wants both token halves, or the
+        # config file whose path MODAL_CONFIG_PATH names.
+        "key_env_vars": ("MODAL_TOKEN_ID", "MODAL_TOKEN_SECRET"),
+        "file_env_var": "MODAL_CONFIG_PATH",
+        "arg_attr": "modal_config_file",
+        "default_path": "~/.modal.toml",
+        "provision_hint": "uv tool install modal && modal token new  # writes ~/.modal.toml",
+        "sdk": "modal",
+        "sdk_hint": "pip install modal",
+        "forward": ("MODAL_PROFILE", "MODAL_ENVIRONMENT", "OPENENV_MODAL_APP"),
+        "target": ("MODAL_ENVIRONMENT", "workspace environment", "the profile's default"),
+    },
+}
+
+
+def _forward_address(env: dict[str, str], var: str, value: str) -> None:
+    """Forward one address-like var by value, refusing one that carries a secret.
+
+    What ``forward`` names are endpoints and selectors, which is why they may
+    ride ray's runtime_env at all while a credential may not (only its PATH is
+    forwarded — see _sandbox_key_supply). A URL defeats that distinction by
+    smuggling a credential through userinfo (``https://user:token@host``), and
+    runtime_env is echoed into driver logs and persisted in job metadata in
+    plaintext, so refuse it rather than forward it. Nothing legitimately
+    forwarded here — a hostname, a scheme, a profile or app name — contains an
+    '@', so the check needs no URL parsing to be precise.
+    """
+    if "@" in value:
+        raise ValueError(
+            f"{var} looks like it embeds credentials ('@'), and anything forwarded "
+            "to rollout workers is logged in plaintext by ray. Put the credential "
+            "in the provider's key file (or the worker environment) and leave a "
+            "bare address here."
+        )
+    env[var] = value
+
+
 def _sandbox_key_supply(
     env: dict[str, str],
     *,
     provider: str,
-    key_env_var: str,
+    key_env_vars: tuple[str, ...],
     file_env_var: str,
     arg_path: str,
     default_path: str,
     provision_hint: str,
 ) -> None:
     """Key-supply contract, shared by the sandbox backends: rollout workers
-    get the provider key from their OWN environment (e.g. platform-injected)
-    or from a file they can read (a dotfile, K8s Secret mount, or shared-FS
-    path). The launcher forwards only the file PATH, never the value: worker
-    env rides ray's runtime_env, which exec_command_cpu echoes into driver logs
-    and ray persists in job metadata, all in plaintext."""
+    get the provider credential from their OWN environment (e.g.
+    platform-injected) or from a file they can read (a dotfile, K8s Secret
+    mount, or shared-FS path). The launcher forwards only the file PATH, never
+    the value: worker env rides ray's runtime_env, which exec_command_cpu
+    echoes into driver logs and ray persists in job metadata, all in
+    plaintext."""
     key_file = Path(arg_path or default_path).expanduser()
     try:
         key_present = bool(key_file.read_text(encoding="utf-8").strip())
@@ -276,10 +342,14 @@ def _sandbox_key_supply(
         key_present = False
     # Either supply is fine; neither is fully verifiable from here (the
     # launcher cannot probe worker nodes), so echo which one is in effect.
+    # A provider whose credential is several variables (Modal's token pair) is
+    # only satisfied by having ALL of them; a partial set is a misconfiguration
+    # that would fail every episode.
+    names = " + ".join(key_env_vars)
     if key_present:
         env[file_env_var] = str(key_file)
         print(
-            f"openenv: {provider} key supply: file {key_file} "
+            f"openenv: {provider} credential supply: file {key_file} "
             "(readable here; forwarding the path, workers read it themselves)",
             flush=True,
         )
@@ -287,18 +357,18 @@ def _sandbox_key_supply(
         # An explicitly configured path that doesn't resolve on the launcher
         # is a config error; failing every episode later is far worse.
         raise ValueError(f"{file_env_var}={arg_path} is missing or empty")
-    elif os.environ.get(key_env_var, "").strip():
+    elif all(os.environ.get(var, "").strip() for var in key_env_vars):
         print(
-            f"openenv: {provider} key supply: worker environment ({key_env_var} "
-            "is set here; workers are assumed to have it in their own env — "
+            f"openenv: {provider} credential supply: worker environment ({names} "
+            "set here; workers are assumed to have them in their own env — "
             "single-host inheritance or platform-injected pod env)",
             flush=True,
         )
     else:
         raise ValueError(
-            f"the {provider} sandbox mode needs an API key: put it in a file "
+            f"the {provider} sandbox mode needs credentials: put them in a file "
             f"({key_file}; {file_env_var} overrides) or in the "
-            f"environment as {key_env_var}. Provision the file with:\n"
+            f"environment as {names}. Provision the file with:\n"
             f"  {provision_hint}"
         )
 

--- a/examples/experimental/openenv/openenv_modal_agent_function.py
+++ b/examples/experimental/openenv/openenv_modal_agent_function.py
@@ -1,0 +1,101 @@
+"""Modal-sandbox variant of the OpenEnv tbench2 agent function.
+
+A drop-in alternative to ``openenv_agent_function.run`` for
+``--custom-agent-function-path``: instead of sharing one env server
+(OPENENV_ENV_URL), every episode gets its OWN Modal sandbox — built from the
+task's OFFICIAL image plus an env server layer, terminated when the episode
+ends.
+
+The agent loop and training wrapper live in ``openenv_agent_function``, and
+everything about running episodes on per-episode sandboxes is
+``openenv_sandbox_common``'s ``SandboxBackend``. This module is only what is
+Modal-specific: how one sandbox comes into being, which of its SDK's errors are
+worth retrying, and its knobs. The image recipe lives in ``tb2_sandbox_recipe``
+and its Modal materialization in ``tb2_sandbox_modal``; like the other sandbox
+backends, this variant needs the pinned tbench2_env install from the README
+(canonical test.sh scoring and verifier-asset withholding built into the
+server).
+
+Credentials are the one place Modal does not fit the other backends' shape: there
+is no single API key, so nothing here reads or forwards one. The SDK resolves
+MODAL_TOKEN_ID + MODAL_TOKEN_SECRET from the worker's own environment, else the
+config file at MODAL_CONFIG_PATH (default ``~/.modal.toml``) — and the launcher
+forwards that PATH, never the token, on the same reasoning as the other
+providers' key files (see openenv_launch_common).
+
+Env vars (the agent-loop ones in ``openenv_agent_function`` apply too):
+  OPENENV_TB2_TASKS_DIR       path to a terminal-bench-2 checkout. The first
+                    episode of a task pays its image build; repeats hit
+                    Modal's layer cache, and all tasks share every layer but
+                    the last (see tb2_sandbox_modal.task_image).
+  MODAL_TOKEN_ID / MODAL_TOKEN_SECRET / MODAL_CONFIG_PATH   credential supply,
+                    read by the SDK itself. MODAL_PROFILE / MODAL_ENVIRONMENT
+                    select a profile / workspace environment when set.
+  OPENENV_MODAL_APP                app the sandboxes are created under
+                    (default openenv-tbench2) — what a sweep scopes to.
+  OPENENV_MODAL_CREATE_CONCURRENCY max in-flight sandbox creates (default 4).
+  OPENENV_MODAL_CREATE_MAX_RETRIES how many throttled creates to retry (default 8).
+
+Everything describing ONE sandbox — its app, lifetime, and the create/ready
+deadlines — is documented and read in ``tb2_sandbox_modal``, and the per-exec
+timeout inside it (TB2_COMMAND_TIMEOUT_S) in ``tb2_sandbox_recipe``, next to
+the code each one steers.
+"""
+
+import logging
+from pathlib import Path
+from typing import Any
+
+import openenv_sandbox_common as common
+import tb2_sandbox_modal
+
+logger = logging.getLogger(__name__)
+
+
+# The sandbox's env server is the tbench2_env baked by the recipe, installed
+# per the README (at or after the huggingface/OpenEnv#1012 merge): canonical
+# tests/test.sh scoring built into `evaluate`, task WORKDIR resolved
+# server-side, verifier assets withheld. The launcher preflight rejects an
+# older install outright, and the shared agent loop's harness-marker guard
+# backstops it per episode.
+#
+# Modal caps concurrent containers per plan; the shared backend caps in-flight
+# creates process-wide and retries throttled ones with jittered exponential
+# backoff (knobs: OPENENV_MODAL_CREATE_*).
+def _is_throttle_error(exc: BaseException) -> bool:
+    """True when a sandbox create failed only because Modal was out of room.
+
+    Modal types a hit ceiling (the plan's container concurrency, or a workspace
+    resource limit) as ResourceExhaustedError; the text match covers the same
+    condition surfacing as a message from an older SDK or a proxy.
+    """
+    # In-function import, deliberately: this is the class's only use site, it
+    # only runs on the failure path (where modal is already in sys.modules,
+    # having just raised `exc`), and offline tests must not require the SDK.
+    try:
+        from modal.exception import ResourceExhaustedError
+
+        if isinstance(exc, ResourceExhaustedError):
+            return True
+    except ImportError:  # pragma: no cover - only without the modal SDK
+        pass
+    return common.throttle_text(exc, "resource exhausted")
+
+
+def _start_sandbox(task_id: str, tasks_dir: str) -> tuple[Any, str]:
+    sandbox, url = tb2_sandbox_modal.create_task_sandbox(Path(tasks_dir) / task_id)
+    return sandbox.terminate, url
+
+
+BACKEND = common.SandboxBackend(
+    provider="Modal",
+    start_sandbox=_start_sandbox,
+    is_throttle=_is_throttle_error,
+    logger=logger,
+    **common.backend_knobs("MODAL"),
+)
+
+# Module-level entry points: `--custom-agent-function-path` resolves a module
+# attribute, and the sibling tools reach run_episode the same way.
+run_episode = BACKEND.run_episode
+run = BACKEND.run

--- a/examples/experimental/openenv/openenv_sandbox_common.py
+++ b/examples/experimental/openenv/openenv_sandbox_common.py
@@ -1,7 +1,8 @@
 """Shared per-episode sandbox orchestration for the backend agent functions.
 
 A backend module (``openenv_daytona_agent_function``,
-``openenv_e2b_agent_function``) owns only what is genuinely provider-specific: how ONE sandbox with the env
+``openenv_e2b_agent_function``, ``openenv_modal_agent_function``)
+owns only what is genuinely provider-specific: how ONE sandbox with the env
 server comes into being (its ``tb2_sandbox_*`` materialization module), which
 errors count as retryable throttling, and its env-var knobs. Everything that
 makes per-episode sandboxes safe under a fanned-out rollout is provider-blind
@@ -49,6 +50,7 @@ StartFn = Callable[[str, str], tuple[Callable[[], None], str]]
 AGENT_MODULES = {
     "daytona": "openenv_daytona_agent_function",
     "e2b": "openenv_e2b_agent_function",
+    "modal": "openenv_modal_agent_function",
 }
 AGENT_FUNCTIONS = {backend: f"{module}.run" for backend, module in AGENT_MODULES.items()}
 _ALIASES = {"agentenv": "e2b"}
@@ -150,7 +152,7 @@ def _agent_function():
 
 # Throttle text every provider shares: an HTTP 429 surfaced as a message
 # rather than a typed error. A backend adds its own vocabulary (Daytona's
-# "throttler").
+# "throttler", Modal's "resource exhausted").
 _THROTTLE_TEXT = ("too many requests", "429", "rate limit")
 
 

--- a/examples/experimental/openenv/run-openenv-tbench2.py
+++ b/examples/experimental/openenv/run-openenv-tbench2.py
@@ -1,9 +1,10 @@
 """OpenEnv Terminal-Bench-2 (tbench2) learning launcher (GLM-4.7-Flash).
 
-Drives the OpenEnv tbench2 env via ``openenv_agent_function.run`` (shared env
-server) or a per-episode sandbox agent function (set ``openenv_tb2_tasks_dir``
-plus ``--openenv-sandbox-backend daytona``, or ``e2b``/``agentenv`` for an
-E2B-compatible provider). tbench2 is
+Drives the OpenEnv tbench2 env through a per-episode sandbox agent function
+(set ``openenv_tb2_tasks_dir`` plus ``--openenv-sandbox-backend``; the registry
+in openenv_sandbox_common names the providers), or through
+``openenv_agent_function.run`` against one shared env server when neither is
+set. tbench2 is
 *multi-turn*: the adapter runs an agentic loop (reset(task_id) -> {policy emits a
 shell command -> step(exec) -> feed output back} -> evaluate) and the reward is
 the binary pytest result (1.0 all tests pass, else 0.0).
@@ -15,26 +16,29 @@ Prereqs:
     # 2. Get the TB2 task suite + build prompt-data (task_ids).
     git clone --depth 1 https://github.com/laude-institute/terminal-bench-2.git /workspace/terminal-bench-2
     python make_tbench2_data.py --tasks_dir /workspace/terminal-bench-2 --output /root/tbench2_train.jsonl
-    # 3. Serve the env. The tbench2 server supports concurrency natively via
-    #    MAX_CONCURRENT_ENVS (no wrapper needed). Choose execution mode:
-    #      TB2_MODE=docker  -> real TB2 fidelity (needs docker.sock + image pulls)
-    #      TB2_MODE=local   -> runs in-process, ignores task Dockerfiles (degraded)
+    # 3. Point the adapter at an environment. Either give every episode its own
+    #    cloud sandbox -- set OPENENV_TB2_TASKS_DIR and the backend, whose
+    #    credentials that provider then resolves itself (see the recipe README):
+    OPENENV_TB2_TASKS_DIR=/workspace/terminal-bench-2 \
+        OPENENV_SANDBOX_BACKEND=e2b python run-openenv-tbench2.py
+    #    ... or serve one shared env server and leave OPENENV_TB2_TASKS_DIR
+    #    unset. It handles concurrency natively via MAX_CONCURRENT_ENVS (no
+    #    wrapper needed); TB2_MODE=docker is real TB2 fidelity (needs
+    #    docker.sock + image pulls), TB2_MODE=local ignores task Dockerfiles.
     TB2_MODE=docker TB2_TASKS_DIR=/workspace/terminal-bench-2 MAX_CONCURRENT_ENVS=32 \
         python -m tbench2_env.server.app --port 8003
-    #    ... or skip the shared server entirely: set OPENENV_TB2_TASKS_DIR
-    #    (+ the Daytona key: DAYTONA_API_KEY in the env, or a key file at
-    #    ~/.config/daytona/api_key) and the adapter runs each episode in its
-    #    own Daytona cloud sandbox (no Docker host needed).
 
-    NOTE (open decisions before a real run): docker mode wants a Docker host with
-    disk + socket; colocating heavy per-task containers on the GPU pod is risky,
-    so the env server likely runs off-pod (use --openenv-env-url / the host
-    rewrite). The binary sparse reward also needs a task subset where the base
-    policy *sometimes* succeeds (advantage variance) -- e.g. the TB2 variance
-    band -- or GRPO sees a flat signal.
+    NOTE (open decisions before a real run): the shared server wants a Docker
+    host with disk + socket, and colocating heavy per-task containers on the GPU
+    pod is risky, so it likely runs off-pod (use --openenv-env-url / the host
+    rewrite) -- per-episode sandboxes sidestep that entirely. The binary sparse
+    reward also needs a task subset where the base policy *sometimes* succeeds
+    (advantage variance) -- e.g. the TB2 variance band -- or GRPO sees a flat
+    signal.
 
 Usage:
-    python run-openenv-tbench2.py --openenv-env-url http://<env-host>:8003
+    OPENENV_SANDBOX_BACKEND=e2b python run-openenv-tbench2.py   # or daytona / modal
+    python run-openenv-tbench2.py --openenv-env-url http://<env-host>:8003  # shared server
 """
 
 import os
@@ -81,22 +85,25 @@ class ScriptArgs(U.ExecuteTrainConfig):
     # within the limit is terminated and scored reward 0, bounding long-trajectory
     # stragglers that would otherwise stall the whole rollout batch.
     openenv_max_rollout_time_seconds: int = int(os.environ.get("OPENENV_MAX_ROLLOUT_TIME_SECONDS", "3600"))
-    # Daytona sandbox mode: every episode runs in its own cloud
-    # sandbox (the task's official image + env server layer; see the adapter
-    # docstring). Set to the TB2 checkout path; the adapter then ignores
-    # --openenv-env-url. Workers resolve the Daytona key from their own
-    # environment (DAYTONA_API_KEY, e.g. platform-injected) first, else from
-    # a key file (default ~/.config/daytona/api_key; this flag overrides the
-    # path). Only the file PATH is ever forwarded — a key value in ray
-    # runtime_env would be logged in plaintext.
+    # Per-episode sandbox mode: every episode runs in its own cloud sandbox
+    # (the task's official image + env server layer; see the adapter docstring).
+    # Set to the TB2 checkout path; the adapter then ignores --openenv-env-url.
+    # Whichever provider runs them, workers resolve its credential from their
+    # own environment (e.g. platform-injected) first, else from a file whose
+    # path the *_key_file flags below override. Only the file PATH is ever
+    # forwarded — a credential value in ray runtime_env would be logged in
+    # plaintext.
     openenv_tb2_tasks_dir: str = os.environ.get("OPENENV_TB2_TASKS_DIR", "")
     # Which per-episode sandbox provider runs the tasks_dir episodes:
-    # "daytona", "e2b" (E2B Cloud), or "agentenv" (alias for e2b — a
-    # self-hosted AgentENV deployment reached via E2B_API_URL/E2B_SANDBOX_URL).
+    # "agentenv" (alias for e2b — a self-hosted AgentENV deployment reached via
+    # E2B_API_URL/E2B_SANDBOX_URL), "daytona", "e2b" (E2B Cloud), or "modal".
     # Required whenever openenv_tb2_tasks_dir is set; there is no default.
     openenv_sandbox_backend: str = os.environ.get("OPENENV_SANDBOX_BACKEND", "")
     daytona_api_key_file: str = os.environ.get("DAYTONA_API_KEY_FILE", "")
     e2b_api_key_file: str = os.environ.get("E2B_API_KEY_FILE", "")
+    # Modal's credential is a token pair, so the file here is its config file
+    # (~/.modal.toml), forwarded by path exactly like the others' key files.
+    modal_config_file: str = os.environ.get("MODAL_CONFIG_PATH", "")
     # When set, miles dumps full per-episode agent trajectories (tokens, logprobs,
     # loss masks, reward, multi-turn messages) to <dir>/rollout_data/{rollout_id}.pt
     # for post-hoc inspection via miles.utils.debug_utils.display_debug_rollout_data.

--- a/examples/experimental/openenv/tb2_sandbox_daytona.py
+++ b/examples/experimental/openenv/tb2_sandbox_daytona.py
@@ -98,7 +98,7 @@ def create_task_sandbox(
     command_timeout_s: int = COMMAND_TIMEOUT_S,
     create_timeout_s: float = 1800.0,
     ready_timeout_s: float = _READY_TIMEOUT_S,
-    # Deliberately arguments rather than env knobs, unlike the E2B TTL:
+    # Deliberately arguments rather than env knobs, unlike the E2B/Modal TTLs:
     # these two are Daytona's OWN auto-stop/auto-delete intervals, and the
     # keepalive cadence below is written against them. Retuning them means
     # rethinking the heartbeat, not turning a dial.

--- a/examples/experimental/openenv/tb2_sandbox_modal.py
+++ b/examples/experimental/openenv/tb2_sandbox_modal.py
@@ -1,0 +1,257 @@
+"""Modal materialization of the per-task Terminal-Bench-2 sandbox recipe.
+
+The recipe itself — the shell layers that turn a task's official image into a
+combined task+env-server image — lives in ``tb2_sandbox_recipe`` (sibling
+module) and is provider-agnostic. This module is everything Modal-specific
+about turning that recipe into a running cloud sandbox:
+
+  ``task_image(...)``   the recipe as a Modal Image: the task's official image
+      pulled from its registry, then ONE LAYER PER recipe command, so an edit
+      to the recipe re-runs only the layers below it instead of the whole
+      chain. Layers are NOT shared between tasks — each task starts from its
+      own base image, which makes every hash below it unique — so each task
+      pays one cold build of the full chain (measured: ~70 s cold including
+      the registry pull, ~9 s warm).
+  ``create_task_sandbox(...)``  per-episode create: build-or-cache-hit the
+      image, start the env server as the sandbox's entrypoint, expose port
+      8000 through an encrypted tunnel, wait for /health, return
+      ``(sandbox, base_url)``. The sandbox carries the recipe's ownership tags.
+
+Orphan reclamation differs from the sibling providers by design. A Modal
+sandbox's ``timeout`` is a hard ceiling that CANNOT be extended, so the
+keepalive-thread dead-man's switch the Daytona and E2B backends use has no
+counterpart here — and needs none: ``idle_timeout`` counts an open TCP
+connection on a tunnel as activity, and an episode's entire I/O is exactly
+that (the OpenEnv client holds a WebSocket open for the episode's lifetime).
+A live episode of any length keeps its sandbox; a hard-killed caller (SIGKILL,
+OOM, node loss) drops the connection and Modal reclaims the sandbox within
+``idle_timeout``. ``timeout`` stays as the ceiling for the one case idleness
+cannot catch: an episode that hangs while still connected.
+
+There is deliberately no bake step: layer hashes ARE the cache key here, so
+the first create for a task warms exactly what later creates hit, and nothing
+a create passes could name a pre-built artifact to use instead.
+
+Sweeping leftovers by hand needs the Python API — Modal's CLI has no
+``sandbox`` subcommand. Scoping the listing to the app (``_APP_NAME``) is what
+keeps a shared workspace's other workloads out of range, and the recipe's
+ownership tags say which task and launcher each sandbox belongs to::
+
+    import asyncio, modal
+
+    async def sweep(kill=False):
+        app = await modal.App.lookup.aio("openenv-tbench2", create_if_missing=True)
+        async for sb in modal.Sandbox.list.aio(app_id=app.app_id):
+            print(sb.object_id, await sb.get_tags.aio())
+            if kill:
+                await sb.terminate.aio()
+
+    asyncio.run(sweep())
+
+All modal imports are lazy (in-function), mirroring the sibling provider
+modules: offline unit tests and non-sandbox launches must not require the SDK.
+"""
+
+import os
+import threading
+from pathlib import Path
+
+import tb2_sandbox_recipe as recipe
+from tb2_sandbox_recipe import (
+    resolve_docker_image,
+    run_with_deadline,
+    sandbox_labels,
+    server_cmd,
+    server_layer_commands,
+    task_env_resources,
+    wait_server_ready,
+)
+
+# Every knob describing ONE Modal sandbox lives here, next to the create that
+# uses it; the backend module keeps only the fan-out knobs (how many creates at
+# once, how long to keep retrying). All are read at import: a rollout worker is
+# a fresh process per run.
+#
+# The app every per-episode sandbox is created under. Modal requires one, and
+# it is what a sweep scopes to — a dedicated app keeps a shared workspace's
+# other workloads out of range.
+_APP_NAME = os.getenv("OPENENV_MODAL_APP", "openenv-tbench2")
+
+# Lifetime (see the orphan-reclamation note above). The TTL is a HARD ceiling on
+# one episode's sandbox: unlike the other backends' TTLs it cannot be extended,
+# so it must exceed the longest episode the rollout allows
+# (OPENENV_MAX_ROLLOUT_TIME_SECONDS), not merely a heartbeat interval.
+_SANDBOX_TTL_S = int(os.getenv("OPENENV_MODAL_SANDBOX_TTL_S", "1800"))
+_IDLE_TIMEOUT_S = int(os.getenv("OPENENV_MODAL_IDLE_TIMEOUT_S", "300"))
+
+# How long a create may take (the first one for a task builds the image, which
+# Modal does not deadline itself) and how long the env server then has to answer
+# /health.
+_CREATE_TIMEOUT_S = float(os.getenv("OPENENV_MODAL_CREATE_TIMEOUT_S", "1800"))
+_READY_TIMEOUT_S = float(os.getenv("OPENENV_MODAL_READY_TIMEOUT_S", "300"))
+
+# Waiting for the tunnel to be routable is part of the create, not something to
+# tune per deployment.
+_TUNNEL_TIMEOUT_S = 60.0
+
+# Build logs are worth minutes of silence when bringing up a task by hand.
+# Debug-only: enable_output() drives a PROCESS-WIDE output manager, so never
+# turn it on with creates fanned out.
+_BUILD_LOGS = bool(os.getenv("OPENENV_MODAL_BUILD_LOGS", "").strip())
+
+_ENV_SERVER_PORT = 8000
+
+
+def task_resources(task_dir: Path) -> dict[str, float | int]:
+    """Sandbox size from ``task.toml [environment]``.
+
+    Modal bills per second on ``max(request, actual)``, so the request is the
+    task's stated requirement and nothing above it. There is no disk knob to
+    map ``storage_mb`` onto — Modal sizes sandbox disk itself.
+    """
+    cpus, memory_mb, _storage_mb = task_env_resources(task_dir)
+    return {"cpu": float(cpus), "memory": memory_mb}
+
+
+def task_image(task_dir: Path, docker_image: str | None = None):
+    """The recipe as a Modal Image, one layer per recipe command.
+
+    Deliberately not one collapsed layer: Modal caches per layer, so editing
+    the recipe's tail (a task's own files) or the embedded env source re-runs
+    only the layers below the edit rather than reinstalling apt/uv as well.
+    That saving is per task, not across the suite — a task's own base image
+    makes its whole chain hash differently from every other task's.
+
+    Modal requires linux/amd64 images (all current TB2 task images are), and
+    pulls anonymously — a task image behind a private registry would need
+    ``from_registry(secret=...)``.
+    """
+    from modal import Image
+
+    task_dir = Path(task_dir)
+    image = Image.from_registry(resolve_docker_image(task_dir, docker_image))
+    for command in server_layer_commands(task_dir):
+        image = image.run_commands(command)
+    return image
+
+
+_app = None
+_app_lock = threading.Lock()
+
+
+def get_app():
+    """The shared App handle, looked up once per process.
+
+    ``App.lookup`` is a network round-trip; a rollout fans out many episodes
+    and every create would otherwise repeat it. The first caller pays it under
+    the lock, the rest reuse the handle.
+    """
+    global _app
+    with _app_lock:
+        if _app is None:
+            from modal import App
+
+            _app = App.lookup(_APP_NAME, create_if_missing=True)
+        return _app
+
+
+def base_url(sandbox, *, tunnel_timeout_s: float | None = None) -> str:
+    """The env server's externally reachable URL on port 8000.
+
+    Modal's tunnel terminates TLS and forwards at L4, so one host serves both
+    halves of the client's traffic: the HTTP health check and the WebSocket
+    (/ws) the episode runs over. Tunnel URLs are cryptographically random but
+    unauthenticated — whoever holds the URL can reach the server — which is
+    another reason the sandbox is per-episode and dies with it. (Modal's
+    connect tokens would add auth, but the env client speaks plain HTTP/WS and
+    has nowhere to carry the bearer header.)
+    """
+    timeout = _TUNNEL_TIMEOUT_S if tunnel_timeout_s is None else tunnel_timeout_s
+    return sandbox.tunnels(timeout=int(timeout))[_ENV_SERVER_PORT].url
+
+
+def _exit_detail(sandbox) -> str:
+    """Why the server never came up, when the answer is already available.
+
+    The env server IS the sandbox's main process, so a server that failed to
+    start leaves an exited sandbox whose output holds the traceback — far more
+    useful than a bare ready-timeout. Reading the stream is only safe once it
+    has ended (a live sandbox's stdout never closes, and the read would block),
+    so this reports nothing for a sandbox that is still running.
+    """
+    try:
+        code = sandbox.poll()
+        if code is None:
+            return ""
+        tail = (sandbox.stdout.read() or "")[-2000:]
+        return f"; the sandbox exited with code {code}, server output tail: {tail}"
+    except Exception:  # diagnostics must never mask the original failure
+        return ""
+
+
+def create_task_sandbox(
+    task_dir: Path,
+    *,
+    command_timeout_s: int = recipe.COMMAND_TIMEOUT_S,
+    ready_timeout_s: float = _READY_TIMEOUT_S,
+    create_timeout_s: float = _CREATE_TIMEOUT_S,
+    ttl_s: int = _SANDBOX_TTL_S,
+    idle_timeout_s: int = _IDLE_TIMEOUT_S,
+):
+    """Create ONE per-episode sandbox for *task_dir*.
+
+    Returns ``(sandbox, base_url)``. Caller must ``sandbox.terminate()`` when
+    the episode ends. The first create for a task pays the image build (Modal
+    builds as part of the create); later creates hit the layer cache.
+
+    The env server runs as the sandbox's entrypoint rather than as a follow-up
+    exec: Modal would otherwise run the task image's own CMD, and what starts
+    in this sandbox must be the recipe's decision, not the task image's. Its
+    runtime knobs stay runtime (TB2_COMMAND_TIMEOUT_S is passed per create, not
+    baked) so a change takes effect without invalidating the image cache.
+
+    *create_timeout_s* bounds the build+create wall clock, which Modal itself
+    does not deadline. The call runs on a scoped thread; on timeout this caller
+    stops waiting — freeing its create-throttle slot — and a sandbox that
+    materializes anyway is reclaimed by *idle_timeout*, since nothing will ever
+    connect to it.
+    """
+    from modal import Sandbox
+
+    task_dir = Path(task_dir)
+    cmd = server_cmd(command_timeout_s, default_task_id=task_dir.name)
+
+    def _create():
+        kwargs = dict(
+            app=get_app(),
+            image=task_image(task_dir),
+            encrypted_ports=[_ENV_SERVER_PORT],
+            timeout=int(ttl_s),
+            idle_timeout=int(idle_timeout_s),
+            tags=sandbox_labels(task_dir),
+            **task_resources(task_dir),
+        )
+        if not _BUILD_LOGS:
+            return Sandbox.create("bash", "-c", cmd, **kwargs)
+        # In-function: only the debug path needs the top-level module, and the
+        # offline tests inject a fake `modal` without enable_output.
+        import modal
+
+        with modal.enable_output():
+            return Sandbox.create("bash", "-c", cmd, **kwargs)
+
+    sandbox = run_with_deadline(_create, create_timeout_s)
+
+    try:
+        url = base_url(sandbox)
+        wait_server_ready(url, timeout_s=ready_timeout_s)
+        return sandbox, url
+    except Exception as e:
+        detail = _exit_detail(sandbox)
+        try:
+            sandbox.terminate()
+        except Exception:
+            pass  # already gone, or the API is down; idle_timeout backstops it
+        if detail:
+            raise RuntimeError(f"{task_dir.name}: env server did not come up{detail}") from e
+        raise

--- a/examples/experimental/openenv/tb2_sandbox_recipe.py
+++ b/examples/experimental/openenv/tb2_sandbox_recipe.py
@@ -120,8 +120,8 @@ def task_env_resources(task_dir: Path) -> tuple[int, int, int]:
     The floors (1 CPU / 2048 MB memory / 10240 MB disk) are recipe policy —
     the env server needs room to run alongside the task — applied once here so
     the providers cannot drift apart on them. Each materialization maps these
-    onto its own units and drops what its provider does not take (E2B, for
-    instance, sizes everything at template-build time).
+    onto its own units and drops what its provider does not take (Modal sizes
+    disk itself; E2B sizes everything at template-build time).
     """
     env_cfg = read_task_config(task_dir).get("environment", {})
     return (
@@ -133,7 +133,8 @@ def task_env_resources(task_dir: Path) -> tuple[int, int, int]:
 
 def sandbox_labels(task_dir: Path) -> dict[str, str]:
     """Ownership labels/metadata for a per-task sandbox: what it runs, and who
-    launched it. Provider-agnostic (Daytona labels, E2B metadata — same keys).
+    launched it. Provider-agnostic (Daytona labels, E2B metadata, Modal tags —
+    same keys).
 
     Sandbox APIs record no creator, so in a shared org/deployment these are
     the only attribution. ``openenv-tbench2-task`` keys sweep/cleanup tooling
@@ -207,7 +208,7 @@ def run_with_deadline(fn, timeout_s: float):
     """Run *fn* on a scoped worker thread; raise TimeoutError past *timeout_s*.
 
     For provider calls that block across many requests with no deadline of
-    their own (an E2B template build, for instance). Deliberately not
+    their own (an E2B template build, a Modal build+create). Deliberately not
     a ``with ThreadPoolExecutor`` block: its ``__exit__`` joins the worker,
     which would wait out the very call the deadline exists to abandon. On
     timeout the provider-side work keeps cooking (and may finish) — reclaiming

--- a/examples/experimental/openenv/tests/test_openenv_launch_common.py
+++ b/examples/experimental/openenv/tests/test_openenv_launch_common.py
@@ -1,0 +1,152 @@
+"""Offline unit tests for the launcher's sandbox-credential wiring.
+
+Not collected by the repo-level pytest run (testpaths = ./tests); run manually
+when touching the launcher:
+
+    pytest examples/experimental/openenv/tests/ -q
+
+The launcher is the only place that can turn a missing credential into a
+launch-time error instead of a rollout that aborts every sample and refills
+forever, so what it must get right is: never forward a secret VALUE, accept
+either supply (file path or worker env), and treat a partially-supplied
+credential (Modal's token pair) as missing rather than usable.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+import openenv_launch_common as launch  # noqa: E402
+import openenv_sandbox_common as common  # noqa: E402
+
+_SPEC_KEYS = {
+    "provider",
+    "key_env_vars",
+    "file_env_var",
+    "arg_attr",
+    "default_path",
+    "provision_hint",
+    "sdk",
+    "sdk_hint",
+    "forward",
+    "target",
+}
+
+
+# --- the credential table ---------------------------------------------------
+
+
+def test_every_backend_has_a_credential_spec():
+    """A backend registered without credential wiring would fail at launch with
+    a KeyError instead of telling the operator what to provision."""
+    assert set(launch._PROVIDER_CREDENTIALS) == set(common.AGENT_MODULES)
+
+
+@pytest.mark.parametrize("backend", sorted(launch._PROVIDER_CREDENTIALS))
+def test_credential_spec_is_complete(backend):
+    spec = launch._PROVIDER_CREDENTIALS[backend]
+    assert set(spec) == _SPEC_KEYS, backend
+    assert spec["key_env_vars"], backend
+    # The arg the launcher reads must be declared on the shared config Protocol,
+    # else a launcher can never override the path.
+    assert spec["arg_attr"] in launch.LaunchArgs.__annotations__, backend
+
+
+def test_forwarded_vars_are_addresses_not_secrets():
+    """Whatever `forward` names is forwarded BY VALUE through ray's runtime_env,
+    which is logged in plaintext — so no credential-shaped var may appear."""
+    for backend, spec in launch._PROVIDER_CREDENTIALS.items():
+        for var in spec["forward"]:
+            assert not any(word in var for word in ("KEY", "TOKEN", "SECRET")), (backend, var)
+
+
+def test_a_forwarded_url_may_not_smuggle_a_credential():
+    """The check above is on the var's NAME, which cannot see a credential
+    hidden in an endpoint's userinfo — and that value would be forwarded and
+    logged in plaintext just the same."""
+    env: dict[str, str] = {}
+    launch._forward_address(env, "E2B_API_URL", "https://agentenv.internal")
+    assert env == {"E2B_API_URL": "https://agentenv.internal"}
+
+    with pytest.raises(ValueError, match="embeds credentials"):
+        launch._forward_address({}, "E2B_API_URL", "https://user:tok@agentenv.internal")
+
+
+# --- key supply -------------------------------------------------------------
+
+
+def _supply(env, spec_name, *, arg_path="", **overrides):
+    spec = launch._PROVIDER_CREDENTIALS[spec_name]
+    kwargs = {
+        "provider": spec["provider"],
+        "key_env_vars": spec["key_env_vars"],
+        "file_env_var": spec["file_env_var"],
+        "arg_path": arg_path,
+        "default_path": spec["default_path"],
+        "provision_hint": spec["provision_hint"],
+    }
+    launch._sandbox_key_supply(env, **{**kwargs, **overrides})
+
+
+def test_readable_file_forwards_the_path_never_the_value(tmp_path):
+    key_file = tmp_path / "api_key"
+    key_file.write_text("dtn_secret_value\n")
+    env: dict[str, str] = {}
+    _supply(env, "daytona", arg_path=str(key_file))
+    assert env == {"DAYTONA_API_KEY_FILE": str(key_file)}
+    assert "dtn_secret_value" not in str(env)
+
+
+def test_configured_path_that_does_not_resolve_is_an_error(tmp_path):
+    with pytest.raises(ValueError, match="is missing or empty"):
+        _supply({}, "e2b", arg_path=str(tmp_path / "absent"))
+
+
+def test_empty_file_is_not_a_credential(tmp_path):
+    key_file = tmp_path / "api_key"
+    key_file.write_text("   \n")
+    with pytest.raises(ValueError, match="is missing or empty"):
+        _supply({}, "e2b", arg_path=str(key_file))
+
+
+def test_worker_environment_supply_is_accepted_without_forwarding(monkeypatch, tmp_path):
+    """When the launcher itself has the credential in env, workers are assumed
+    to have it too (platform-injected / single-host inheritance) and nothing is
+    forwarded."""
+    monkeypatch.setenv("DAYTONA_API_KEY", "dtn_from_env")
+    env: dict[str, str] = {}
+    _supply(env, "daytona", default_path=str(tmp_path / "absent"))
+    assert env == {}
+
+
+def test_modal_token_pair_must_be_complete(monkeypatch, tmp_path):
+    """Half a token pair is a misconfiguration, not a usable credential: it
+    would authenticate nothing and fail every episode."""
+    monkeypatch.setenv("MODAL_TOKEN_ID", "ak-123")
+    monkeypatch.delenv("MODAL_TOKEN_SECRET", raising=False)
+    with pytest.raises(ValueError, match="MODAL_TOKEN_ID \\+ MODAL_TOKEN_SECRET"):
+        _supply({}, "modal", default_path=str(tmp_path / "absent"))
+
+    monkeypatch.setenv("MODAL_TOKEN_SECRET", "as-456")
+    env: dict[str, str] = {}
+    _supply(env, "modal", default_path=str(tmp_path / "absent"))
+    assert env == {}  # the token halves are never forwarded
+
+
+def test_modal_config_file_is_forwarded_by_path(tmp_path):
+    """Modal's file is a config file rather than a bare key, but it rides the
+    same path-not-value contract."""
+    config = tmp_path / "modal.toml"
+    config.write_text('[radixark]\ntoken_id = "ak-123"\ntoken_secret = "as-456"\n')
+    env: dict[str, str] = {}
+    _supply(env, "modal", arg_path=str(config))
+    assert env == {"MODAL_CONFIG_PATH": str(config)}
+    assert "as-456" not in str(env)
+
+
+def test_missing_credential_names_what_to_provision(monkeypatch, tmp_path):
+    monkeypatch.delenv("E2B_API_KEY", raising=False)
+    with pytest.raises(ValueError, match="mkdir -p ~/.config/e2b"):
+        _supply({}, "e2b", default_path=str(tmp_path / "absent"))

--- a/examples/experimental/openenv/tests/test_openenv_modal_agent_function.py
+++ b/examples/experimental/openenv/tests/test_openenv_modal_agent_function.py
@@ -1,0 +1,82 @@
+"""Offline unit tests for the Modal-sandbox agent function (no network, no GPU).
+
+Not collected by the repo-level pytest run (testpaths = ./tests); run manually
+when touching the adapter:
+
+    pytest examples/experimental/openenv/tests/ -q
+
+Covers only what is Modal's own. Episode dispatch, create throttling, backoff
+budgets and the cancel-mid-create reaper belong to the shared SandboxBackend and are
+proven once in test_openenv_sandbox_common.py; what remains here is which of
+this SDK's errors count as capacity limits, and that the start hook wires the
+materialization (per-task dir, the build+create deadline, terminate-on-close).
+"""
+
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import openenv_modal_agent_function as omaf  # noqa: E402
+
+
+# --- start hook -------------------------------------------------------------
+
+
+def test_start_hook_creates_per_task_and_closes_by_terminating(monkeypatch):
+    """The sandbox is per-task (tasks_dir/task_id), the create carries the
+    build+create deadline this backend owns, and close_fn terminates the sandbox."""
+    created = {}
+    terminated = []
+
+    class _FakeSandbox:
+        def terminate(self):
+            terminated.append(True)
+
+    sandbox = _FakeSandbox()
+
+    def fake_create(task_dir, **kwargs):
+        created.update(task_dir=task_dir, kwargs=kwargs)
+        return sandbox, "https://abc.r5.modal.host"
+
+    monkeypatch.setattr(omaf.tb2_sandbox_modal, "create_task_sandbox", fake_create)
+
+    close_fn, url = omaf._start_sandbox("regex-chess", "/tasks")
+
+    assert url == "https://abc.r5.modal.host"
+    assert created["task_dir"] == Path("/tasks/regex-chess")
+    # The backend passes only what identifies the sandbox; every deadline is
+    # the materialization's own default, so the two cannot drift apart.
+    assert created["kwargs"] == {}
+    close_fn()
+    assert terminated == [True]
+
+
+# --- throttle classification ------------------------------------------------
+
+
+def test_is_throttle_error_classification():
+    assert omaf._is_throttle_error(Exception("HTTP 429"))
+    assert omaf._is_throttle_error(Exception("Too Many Requests"))
+    # This backend's own vocabulary: a hit container-concurrency ceiling.
+    assert omaf._is_throttle_error(Exception("RESOURCE EXHAUSTED: too many containers"))
+    assert not omaf._is_throttle_error(RuntimeError("image build failed"))
+
+
+def test_is_throttle_error_typed_modal_class():
+    """The SDK's typed capacity error is recognized even when its message
+    carries no throttle keywords; sibling error classes are not."""
+    ex = pytest.importorskip("modal.exception")
+    assert omaf._is_throttle_error(ex.ResourceExhaustedError("no capacity"))
+    assert not omaf._is_throttle_error(ex.AuthError("bad token"))
+
+
+def test_is_throttle_error_without_the_sdk_installed(monkeypatch):
+    """The typed check is best-effort: the backend still classifies by text when the
+    SDK (or that class) is absent, rather than failing the classification."""
+    monkeypatch.setitem(sys.modules, "modal.exception", types.ModuleType("modal.exception"))
+    assert omaf._is_throttle_error(Exception("HTTP 429"))
+    assert not omaf._is_throttle_error(RuntimeError("image build failed"))

--- a/examples/experimental/openenv/tests/test_openenv_sandbox_common.py
+++ b/examples/experimental/openenv/tests/test_openenv_sandbox_common.py
@@ -76,6 +76,7 @@ async def _fake_episode_env(env_cls, metadata):
         ("e2b", "e2b"),
         ("agentenv", "e2b"),
         ("  E2B  ", "e2b"),
+        ("modal", "modal"),
     ],
 )
 def test_resolve_backend_normalizes_names_and_aliases(name, expected):
@@ -116,8 +117,9 @@ def test_every_backend_exposes_the_entry_points(name):
 @pytest.mark.parametrize("name", sorted(common.AGENT_MODULES))
 def test_operator_facing_help_names_every_backend(name):
     """The sibling tools tell an operator which backends exist. That list drifted
+    once already (modal was added and the help text still said daytona/e2b), so
     it is generated from the registry where it can be, and asserted where it
-    cannot -- a list written by hand drifts the moment a backend is added."""
+    cannot."""
     assert name in common.backend_names()
     root = Path(__file__).resolve().parent.parent
     assert name in (root / "eval_tbench2_via_api.py").read_text().split('"""')[1]

--- a/examples/experimental/openenv/tests/test_tb2_sandbox_modal.py
+++ b/examples/experimental/openenv/tests/test_tb2_sandbox_modal.py
@@ -1,0 +1,245 @@
+"""Tests for the Modal sandbox half: image layering, sandbox sizing, the
+tunnel URL, and the create path's lifetime/diagnostic contract.
+
+Not collected by the repo-level pytest run (testpaths = ./tests); run manually
+when touching the recipe:
+
+    pytest examples/experimental/openenv/tests/ -q
+"""
+
+import sys
+import threading
+import types
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+import tb2_sandbox_modal as sandbox  # noqa: E402
+
+_COMMANDS = ("apt-get install -y curl", "curl -LsSf https://astral.sh/uv/install.sh | sh", "mkdir -p /opt/tb2-tasks")
+
+
+# --- fake modal SDK ---------------------------------------------------------
+
+
+class _FakeImage:
+    """Records layering: every run_commands call is one layer."""
+
+    def __init__(self, tag, layers=()):
+        self.tag = tag
+        self.layers = list(layers)
+
+    def run_commands(self, *commands):
+        return _FakeImage(self.tag, [*self.layers, commands])
+
+    @staticmethod
+    def from_registry(tag, **kwargs):
+        _FakeImage.from_registry_kwargs = kwargs
+        return _FakeImage(tag)
+
+
+class _FakeTunnel:
+    def __init__(self, url):
+        self.url = url
+
+
+class _FakeSandbox:
+    """Stands in for one created sandbox."""
+
+    def __init__(self, exit_code=None, output="", tunnel_url="https://abc.r5.modal.host"):
+        self._exit_code = exit_code
+        self.stdout = types.SimpleNamespace(read=lambda: output)
+        self.terminated = False
+        self.tunnel_timeout = None
+        self._tunnel_url = tunnel_url
+
+    def tunnels(self, timeout=50):
+        self.tunnel_timeout = timeout
+        return {8000: _FakeTunnel(self._tunnel_url)}
+
+    def terminate(self):
+        self.terminated = True
+
+    def poll(self):
+        return self._exit_code
+
+
+class _FakeSandboxCls:
+    created = None
+    instance = None
+
+    @staticmethod
+    def create(*args, **kwargs):
+        _FakeSandboxCls.created = {"args": args, "kwargs": kwargs}
+        return _FakeSandboxCls.instance
+
+
+class _FakeApp:
+    lookups = None
+
+    @staticmethod
+    def lookup(name, **kwargs):
+        _FakeApp.lookups.append((name, kwargs))
+        return f"app:{name}"
+
+
+@pytest.fixture
+def fake_modal(monkeypatch):
+    """Install a fake `modal` module and reset the backend's process-wide app cache."""
+    _FakeApp.lookups = []
+    _FakeSandboxCls.instance = _FakeSandbox()
+    mod = types.ModuleType("modal")
+    mod.Image = _FakeImage
+    mod.Sandbox = _FakeSandboxCls
+    mod.App = _FakeApp
+    monkeypatch.setitem(sys.modules, "modal", mod)
+    monkeypatch.setattr(sandbox, "_app", None)
+    monkeypatch.setattr(sandbox, "resolve_docker_image", lambda task_dir, override=None: "ghcr.io/laude/task:1.0")
+    monkeypatch.setattr(sandbox, "server_layer_commands", lambda task_dir: list(_COMMANDS))
+    monkeypatch.setattr(sandbox, "sandbox_labels", lambda task_dir: {"openenv-tbench2-task": task_dir.name})
+    monkeypatch.setattr(sandbox, "server_cmd", lambda timeout, default_task_id="": f"serve {default_task_id}")
+    monkeypatch.setattr(sandbox, "wait_server_ready", lambda url, timeout_s=300.0: None)
+    monkeypatch.setattr(sandbox, "task_resources", lambda task_dir: {"cpu": 2.0, "memory": 4096})
+    return mod
+
+
+# --- image layering ---------------------------------------------------------
+
+
+def test_task_image_is_one_layer_per_recipe_command(fake_modal):
+    """Per-command layers so that editing the recipe's tail re-runs only the
+    layers below the edit; collapsing the recipe into one layer would reinstall
+    apt/uv for every such change. (The saving is per task: a task's own base
+    image makes its chain hash unique, so nothing is shared across tasks.)"""
+    image = sandbox.task_image(Path("/tasks/regex-chess"))
+    assert image.tag == "ghcr.io/laude/task:1.0"
+    assert image.layers == [(c,) for c in _COMMANDS]
+
+
+def test_task_image_pulls_anonymously_by_default(fake_modal):
+    """No registry secret is passed: the TB2 task images are public, and a
+    private one would have to be opted into explicitly."""
+    sandbox.task_image(Path("/tasks/t"))
+    assert _FakeImage.from_registry_kwargs == {}
+
+
+# --- sandbox sizing ---------------------------------------------------------
+
+
+def test_task_resources_floors_and_omits_disk(tmp_path):
+    """Modal is billed on max(request, actual) so the request tracks task.toml
+    (floored by the recipe); storage_mb has no Modal counterpart and must not
+    leak in as an unexpected kwarg."""
+    (tmp_path / "task.toml").write_text("[environment]\ncpus = 4\nmemory_mb = 8192\nstorage_mb = 20480\n")
+    assert sandbox.task_resources(tmp_path) == {"cpu": 4.0, "memory": 8192}
+
+    (tmp_path / "task.toml").write_text("[environment]\n")
+    assert sandbox.task_resources(tmp_path) == {"cpu": 1.0, "memory": 2048}
+
+
+# --- app handle -------------------------------------------------------------
+
+
+def test_app_is_looked_up_once_per_process(fake_modal, monkeypatch):
+    """App.lookup is a network round-trip and a rollout fans out many episodes."""
+    monkeypatch.setenv("OPENENV_MODAL_APP", "openenv-tbench2")
+    monkeypatch.setattr(sandbox, "_APP_NAME", "openenv-tbench2")
+    assert sandbox.get_app() == "app:openenv-tbench2"
+    assert sandbox.get_app() == "app:openenv-tbench2"
+    assert _FakeApp.lookups == [("openenv-tbench2", {"create_if_missing": True})]
+
+
+# --- create path ------------------------------------------------------------
+
+
+def test_create_passes_the_lifetime_and_ownership_contract(fake_modal):
+    sandbox_obj, url = sandbox.create_task_sandbox(
+        Path("/tasks/regex-chess"), command_timeout_s=600, ttl_s=1200, idle_timeout_s=120
+    )
+    created = _FakeSandboxCls.created
+    kwargs = created["kwargs"]
+
+    assert url == "https://abc.r5.modal.host"
+    assert sandbox_obj is _FakeSandboxCls.instance
+    # The env server is the sandbox's entrypoint, not a follow-up exec: the task
+    # image's own CMD must not decide what runs here.
+    assert created["args"] == ("bash", "-c", "serve regex-chess")
+    assert kwargs["encrypted_ports"] == [8000]
+    assert kwargs["timeout"] == 1200
+    assert kwargs["idle_timeout"] == 120
+    assert kwargs["tags"] == {"openenv-tbench2-task": "regex-chess"}
+    assert kwargs["cpu"] == 2.0 and kwargs["memory"] == 4096
+    assert not sandbox_obj.terminated
+
+
+def test_create_defaults_lifetime_from_the_env_knobs(fake_modal, monkeypatch):
+    monkeypatch.setattr(sandbox, "_SANDBOX_TTL_S", 1800)
+    monkeypatch.setattr(sandbox, "_IDLE_TIMEOUT_S", 300)
+    sandbox.create_task_sandbox(Path("/tasks/t"))
+    kwargs = _FakeSandboxCls.created["kwargs"]
+    assert kwargs["timeout"] == 1800
+    assert kwargs["idle_timeout"] == 300
+
+
+def test_create_terminates_the_sandbox_when_the_server_never_comes_up(fake_modal, monkeypatch):
+    """A ready-timeout must not leak the sandbox, and the failure should carry
+    the exited server's output instead of only a timeout."""
+    _FakeSandboxCls.instance = _FakeSandbox(exit_code=1, output="Traceback: no module named tbench2_env\n")
+
+    def boom(url, timeout_s=300.0):
+        raise RuntimeError("health check timed out")
+
+    monkeypatch.setattr(sandbox, "wait_server_ready", boom)
+
+    with pytest.raises(RuntimeError, match="no module named tbench2_env"):
+        sandbox.create_task_sandbox(Path("/tasks/regex-chess"))
+    assert _FakeSandboxCls.instance.terminated
+
+
+def test_create_does_not_read_the_stream_of_a_live_sandbox(fake_modal, monkeypatch):
+    """Reading stdout of a RUNNING sandbox would block on a stream that never
+    closes, so a still-running sandbox contributes no diagnostics."""
+
+    def exploding_read():
+        raise AssertionError("stdout of a live sandbox must not be read")
+
+    _FakeSandboxCls.instance = _FakeSandbox(exit_code=None)
+    _FakeSandboxCls.instance.stdout = types.SimpleNamespace(read=exploding_read)
+
+    def boom(url, timeout_s=300.0):
+        raise RuntimeError("health check timed out")
+
+    monkeypatch.setattr(sandbox, "wait_server_ready", boom)
+
+    with pytest.raises(RuntimeError, match="health check timed out"):
+        sandbox.create_task_sandbox(Path("/tasks/t"))
+    assert _FakeSandboxCls.instance.terminated
+
+
+def test_create_enforces_the_build_wall_clock(fake_modal, monkeypatch):
+    """The first create for a task builds the image, which Modal does not
+    deadline itself; a hung build must give the slot back rather than block the
+    episode forever."""
+    release = threading.Event()
+
+    def slow_create(*args, **kwargs):
+        release.wait(10)
+        return _FakeSandboxCls.instance
+
+    monkeypatch.setattr(_FakeSandboxCls, "create", staticmethod(slow_create))
+    try:
+        with pytest.raises(TimeoutError):
+            sandbox.create_task_sandbox(Path("/tasks/t"), create_timeout_s=0.05)
+    finally:
+        release.set()
+
+
+# --- tunnel ----------------------------------------------------------------
+
+
+def test_base_url_is_the_tunnel_for_the_env_server_port(fake_modal, monkeypatch):
+    monkeypatch.setattr(sandbox, "_TUNNEL_TIMEOUT_S", 60.0)
+    sb = _FakeSandbox(tunnel_url="https://xyz.r5.modal.host")
+    assert sandbox.base_url(sb) == "https://xyz.r5.modal.host"
+    assert sb.tunnel_timeout == 60


### PR DESCRIPTION
> 3/3 of a stack. Base is #2275, so review **1/3** #2274 and **2/3** #2275 first; the diff here is Modal plus the docs.
> This is the state that was verified live against all four endpoints — see below.

With the shared `SandboxBackend` from 2/3 in place, a provider is its two genuinely specific parts plus a registry entry: how ONE sandbox comes into being (`tb2_sandbox_modal`) and which of its SDK's errors are retryable throttling (`openenv_modal_agent_function`). Nothing about the rollout-facing behaviour is restated — which is what the two commits below this one bought.

## Three things are Modal's own

- **One image layer per recipe command**, so editing the recipe re-runs only the layers below the edit. Layers are *not* shared across tasks — TB2 pins a different official image per task, so every chain hashes differently from the first layer down. That is a property of the benchmark, not of this backend, and it applies to Daytona and E2B equally.
- **The env server is the sandbox ENTRYPOINT**, not a follow-up exec. Modal would otherwise run the task image's own `CMD`, and what starts in the sandbox has to be the recipe's decision.
- **No keepalive thread**, unlike the other two backends, because a Modal timeout *cannot be extended*. Orphans are reclaimed by `idle_timeout` instead: an open tunnel connection counts as activity and the episode holds its WebSocket for its whole life, so a live episode of any length is safe while a hard-killed caller's sandbox disappears. The consequence worth knowing when sizing a run: `OPENENV_MODAL_SANDBOX_TTL_S` is a **hard ceiling** that must exceed `OPENENV_MAX_ROLLOUT_TIME_SECONDS`, not merely a heartbeat interval.

## Launcher credentials

This backend broke the launcher's assumption: Modal has no single API key, so the daytona/e2b if-else could not express it, and the wiring becomes a table. A partially-supplied token pair is now treated as **missing** rather than usable — half a credential authenticates nothing and would fail every episode.

Forwarded values are also checked for a credential smuggled in a URL's userinfo (`https://user:token@host`). `forward` may ride ray's `runtime_env` only because it names *addresses*, and `runtime_env` is echoed into driver logs in plaintext; the existing test checks the variable's **name**, which a URL defeats.

## Docs

Per-episode sandboxes become the recipe's primary path with one shared env server as the alternative, each backend gets its own heading, and the sanity checks become their own optional step. The old "2b. Alternative" framing dated from when there was one provider.

## Verification

Offline: **100 passed, 3 skipped**; ruff + black clean at the repo-pinned versions (0.14.7 / 24.3.0).

**One episode end to end, per backend** — create → connect → `reset` over the WebSocket → `exec` → `evaluate` → close, same task everywhere:

| Backend | Endpoint | Create → connected | Total |
|---|---|---|---|
| Modal | Modal Cloud | 9 s | 23 s |
| E2B | E2B Cloud | 13 s | 26 s |
| E2B (`agentenv`) | self-hosted AgentENV | 8 s | 17 s |
| Daytona | Daytona Cloud | — | 60 s |

All four: `whoami` → `root`, the marker exec round-trips, `evaluate` returns a verdict from `harness='tests/test.sh'` with no error.

**Scoring is correct, not merely present.** Those single episodes all score `0.0` — nothing solved the task — which proves a verdict comes back but not that a *correct* solution is recognized. So each task's official solution was replayed through the full sandbox and scoring path, 5 tasks at concurrency 5: **5/5 at reward 1.0 on Modal and 5/5 on E2B Cloud**, 0 errored. Running five at once also exercises what a single episode never touches: the process-wide create semaphore, the throttle/backoff path, and E2B's per-alias build lock.

**The multi-turn agent loop**, with a real policy (DeepSeek-v4-flash) on E2B, reached `reward=1.0` on `cancel-async-tasks`. The trajectory shows `reset` delivering the real instruction, turn 1 writing `/app/run.py`, turn 2 `cat`-ing it back and receiving the file's actual contents (so sandbox state persists across turns and the fed-back output is genuine), and later turns running Python harnesses against their real stdout.

**Nothing leaked** — after every run above, on all four endpoints:

```
modal   leftovers: []
e2b     leftovers: []
daytona leftovers: []
AgentENV leftovers: []
```


## GRPO training on merged `main`

The verification above is per-episode. This is the same code inside a real GRPO
run: 8×H200 single node, GLM-4.7-Flash, TP=4 / EP=2 colocated, on `d2e3ad9f1` —
the *merged* form of this stack rather than the branch, since the devbox image
already carried it.

Aperture: `--rollout-batch-size 2 --n-samples-per-prompt 4` (8 episodes per step),
`OPENENV_MAX_TURNS=15`, over a 4-task subset the base policy is known to
sometimes solve, so GRPO sees advantage variance instead of a flat batch.
`--num-rollout` was left at the launcher's hardcoded 40 and the run stopped once
the loop had repeated several times; nothing in the recipe was edited to run it.

Per-episode rewards, read out of `--dump-details`
(`dump/rollout_data/<rollout_id>.pt`) rather than the driver log:

| Step | Modal | E2B |
|---|---|---|
| rollout 0 | 0.000 `[0,0,0,0,0,0,0,0]` | 0.000 `[0,0,0,0,0,0,0,0]` |
| rollout 1 | 0.125 `[0,0,0,0,0,0,1,0]` | 0.250 `[0,0,1,0,0,0,0,1]` |
| rollout 2 | 0.250 `[0,0,0,0,1,0,0,1]` | 0.250 `[0,0,0,0,0,1,1,0]` |
| rollout 3 | 0.250 `[0,0,0,0,0,1,1,0]` | — |
| rollout 4 | 0.125 `[0,0,0,0,0,0,1,0]` | — |

Every train step reported `outcome=NORMAL`, and each was followed by
`update_weights_from_tensor` broadcasting 118 tensors back into SGLang — so the
loop closes: rollout → reward → train step → weight update → next rollout. That
the means are non-zero *and* varying matters more than their absolute value: an
all-zero batch yields zero advantage and would have proven nothing about the
training path.

Golden replay was also re-run per backend on this box: **Modal 4/4 at reward 1.0**
(1m46s, layer cache warm), and all four E2B templates rebuilt clean (2m57s).

**Reclamation, observed against the providers rather than reasoned about.**
Mid-run, E2B had **6 live sandboxes** during rollout 3 — the in-flight batch, not
the ~24 accumulated over all steps — each carrying its `openenv-launcher` /
`openenv-tbench2-task` labels, so per-episode cleanup works. Killing a run
mid-episode is the case that cleanup *cannot* cover, and it is the one each
provider's backstop exists for: Modal left 1 sandbox behind and it was gone after
the idle-timeout window; E2B left 3, reclaimed once the keepalive thread stopped
re-arming the TTL. Both ended at **0 live, nothing left behind**.

The credential contract shows up in the run's own logs, too. The `EXEC:` line
echoes the whole `ray job submit`, and its `--runtime-env-json` contains
`"E2B_API_KEY_FILE": "/root/.config/e2b/api_key"` — the path, never the value.
That is at once the evidence that `runtime_env` does reach plaintext logs, and
that forwarding only the path keeps the credential out of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
