### PR TITLE
feat(harbor): route Claude Code through Anthropic sessions

### DIFF
--- a/examples/experimental/swe-agent-harbor-daytona/README.md
+++ b/examples/experimental/swe-agent-harbor-daytona/README.md
@@ -12,9 +12,10 @@ It is the `examples/swe-agent-harbor-docker` pipeline with two changes:
   Docker daemon, no local image builds, and no local disk for task images. This
   is the practical option when the trainer runs on a GPU node where you cannot
   or do not want to run Docker-in-Docker.
-- **terminus-2 agent.** terminus-2 runs as a host process and calls the model
-  endpoint itself, rather than from inside the sandbox, so the model endpoint
-  must be reachable from the agent-server host.
+- **Agent-specific API routing.** terminus-2 runs as a host process and uses the
+  session's OpenAI endpoint. Claude Code runs inside Daytona and uses the same
+  session's Anthropic endpoint, so the model endpoint must be reachable from
+  the Daytona sandbox.
 
 Everything else — TITO, the session server, GRPO, the reward path — is identical
 to `examples/swe-agent-harbor-docker`, and so is the trainer side: this example has no
@@ -74,7 +75,7 @@ Verify `http://<agent-server>:11000/health` before launching Miles.
 ## 3. Prepare data
 
 `examples/swe-agent-harbor-docker/download_and_process_data.py` converts a local JSONL into
-Miles format. For terminus-2, set the agent name accordingly:
+Miles format. Set the Harbor agent name in every record. For terminus-2:
 
 ```bash
 python examples/swe-agent-harbor-docker/download_and_process_data.py \
@@ -83,6 +84,10 @@ python examples/swe-agent-harbor-docker/download_and_process_data.py \
     --agent-name terminus-2 \
     --prompt-key instruction
 ```
+
+For Claude Code, use `--agent-name claude-code` instead. Claude Code support
+also requires a Harbor agent server that forwards each request's `base_url`,
+`model`, and API key as the corresponding Anthropic environment variables.
 
 ## 4. Launch training
 
@@ -115,13 +120,12 @@ python examples/swe-agent-harbor-docker/run.py \
 
 For a smoke test, set `--num-rollout 1`.
 
-`--router-external-host` is the address the agent server uses to reach the Miles
-session server, substituted into the base URL handed to the agent. It only has
-to resolve from the agent-server host, so a hostname is fine — use one when the
-agent server reaches the trainer over a tailnet or other overlay. Do not confuse
-it with `--miles-host-ip`, which is bound locally on the trainer and must be an
-address that already exists on one of its interfaces. Ports 30000 and 31000 must
-be reachable from the agent-server host.
+`--router-external-host` is substituted into the session URL handed to the
+agent. It must be reachable from wherever that agent makes model requests: the
+agent-server host for terminus-2, or the Daytona sandbox for Claude Code. Do not
+confuse it with `--miles-host-ip`, which is bound locally on the trainer and
+must be an address that already exists on one of its interfaces. Ports 30000
+and 31000 must be reachable from the relevant agent runtime.
 
 ## Sizing the per-turn response cap
 

--- a/examples/experimental/swe-agent-harbor-daytona/launch_agent_server.sh
+++ b/examples/experimental/swe-agent-harbor-daytona/launch_agent_server.sh
@@ -19,8 +19,8 @@ export HARBOR_DAYTONA_DISK_GB="${HARBOR_DAYTONA_DISK_GB:-10}"
 # Snapshot each task image on first use so later trials skip the build.
 export HARBOR_DAYTONA_AUTO_SNAPSHOT=1
 
-# terminus-2 runs as a host process and calls the model itself, so the model
-# endpoint must be reachable from here rather than from inside the sandbox.
+# Defaults for host-process OpenAI agents such as terminus-2. Claude Code runs
+# inside Daytona and receives its Anthropic endpoint from each trial request.
 export OPENAI_API_KEY="${OPENAI_API_KEY:-dummy}"
 export OPENAI_API_BASE="${OPENAI_API_BASE:-http://127.0.0.1:30000/v1}"
 export OPENAI_BASE_URL="$OPENAI_API_BASE"

--- a/examples/swe-agent-harbor-docker/swe_agent_function.py
+++ b/examples/swe-agent-harbor-docker/swe_agent_function.py
@@ -25,6 +25,7 @@ logger = logging.getLogger(__name__)
 
 # Backstop for an unreachable agent server; its own --agent-timeout should fire first.
 _DEFAULT_AGENT_TRIAL_TIMEOUT_S = 7200
+_CLAUDE_CODE_AGENT_NAME = "claude-code"
 
 _agent_server_client: httpx.AsyncClient | None = None
 
@@ -51,6 +52,20 @@ def _get_agent_server_client() -> httpx.AsyncClient:
             timeout=None,
         )
     return _agent_server_client
+
+
+def _agent_api_config(
+    base_url: str,
+    model_name: str,
+    agent_name: str | None,
+) -> tuple[str, str]:
+    """Return the session endpoint and model name expected by the Harbor agent."""
+    if agent_name == _CLAUDE_CODE_AGENT_NAME:
+        # Claude Code appends /v1/messages to ANTHROPIC_BASE_URL itself. Its
+        # model name is passed through the Anthropic request without a provider
+        # prefix, so it must match the name served by SGLang.
+        return base_url, model_name
+    return f"{base_url}/v1", f"openai/{model_name}"
 
 
 async def _post_agent_server(url: str, payload: dict[str, Any]) -> dict[str, Any]:
@@ -80,7 +95,11 @@ async def run(
         os.getenv("SWE_AGENT_MODEL_NAME", "model"),
     )
 
-    session_url = f"{base_url}/v1"
+    session_url, agent_model = _agent_api_config(
+        base_url=base_url,
+        model_name=model_name,
+        agent_name=metadata.get("agent_name"),
+    )
     external_host = os.getenv("MILES_ROUTER_EXTERNAL_HOST")
     if external_host:
         parsed = urlparse(session_url)
@@ -91,7 +110,7 @@ async def run(
     request: dict[str, Any] = {
         **metadata,
         "base_url": session_url,
-        "model": f"openai/{model_name}",
+        "model": agent_model,
         "sampling_params": request_kwargs,
     }
 

--- a/tests/fast/rollout/generate_hub/test_swe_agent_function.py
+++ b/tests/fast/rollout/generate_hub/test_swe_agent_function.py
@@ -1,0 +1,107 @@
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+def _load_agent_function() -> ModuleType:
+    module_path = (
+        Path(__file__).resolve().parents[4] / "examples" / "swe-agent-harbor-docker" / "swe_agent_function.py"
+    )
+    spec = importlib.util.spec_from_file_location("swe_agent_function", module_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def agent_function() -> ModuleType:
+    return _load_agent_function()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("agent_name", "expected_base_url", "expected_model"),
+    [
+        (
+            "terminus-2",
+            "http://10.0.0.1:30000/sessions/session-1/v1",
+            "openai/GLM-4.7-Flash",
+        ),
+        (
+            "claude-code",
+            "http://10.0.0.1:30000/sessions/session-1",
+            "GLM-4.7-Flash",
+        ),
+    ],
+)
+async def test_run_builds_agent_specific_api_payload(
+    agent_function: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    agent_name: str,
+    expected_base_url: str,
+    expected_model: str,
+) -> None:
+    monkeypatch.setenv("AGENT_SERVER_URL", "http://agent-server:11000")
+    monkeypatch.setenv("AGENT_MODEL_NAME", "GLM-4.7-Flash")
+    monkeypatch.delenv("MILES_ROUTER_EXTERNAL_HOST", raising=False)
+    post_agent_server = AsyncMock(return_value={"reward": 1.0})
+    monkeypatch.setattr(agent_function, "_post_agent_server", post_agent_server)
+
+    result = await agent_function.run(
+        base_url="http://10.0.0.1:30000/sessions/session-1",
+        prompt="fix the task",
+        request_kwargs={"temperature": 0.7},
+        metadata={"agent_name": agent_name, "instance_id": "task-1"},
+    )
+
+    post_agent_server.assert_awaited_once_with(
+        "http://agent-server:11000/run",
+        {
+            "agent_name": agent_name,
+            "instance_id": "task-1",
+            "base_url": expected_base_url,
+            "model": expected_model,
+            "sampling_params": {"temperature": 0.7},
+        },
+    )
+    assert result == {
+        "reward": 1.0,
+        "exit_status": "",
+        "eval_report": {},
+        "agent_metrics": {},
+    }
+
+
+@pytest.mark.asyncio
+async def test_run_rewrites_claude_code_endpoint_for_external_sandbox(
+    agent_function: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AGENT_MODEL_NAME", "GLM-4.7-Flash")
+    monkeypatch.setenv("MILES_ROUTER_EXTERNAL_HOST", "trainer.example.test")
+    post_agent_server = AsyncMock(return_value={})
+    monkeypatch.setattr(agent_function, "_post_agent_server", post_agent_server)
+
+    await agent_function.run(
+        base_url="http://10.0.0.1:30123/sessions/session-1",
+        prompt="fix the task",
+        metadata={
+            "agent_name": "claude-code",
+            "instance_id": "task-1",
+            "max_seq_len": "65536",
+            "session_server_id": "10.0.0.1:30123",
+            "session_server_instance_id": "session-server-1",
+        },
+    )
+
+    _, request = post_agent_server.await_args.args
+    assert request["base_url"] == ("http://trainer.example.test:30123/sessions/session-1")
+    assert request["model"] == "GLM-4.7-Flash"
+    assert request["max_seq_len"] == 65536
+    assert request["session_server_id"] == "trainer.example.test:30123"
+    assert request["session_server_instance_id"] == "session-server-1"


### PR DESCRIPTION
## Summary

- route `claude-code` Harbor trials to the session's Anthropic API root
- pass Claude Code the raw served model name while preserving the existing OpenAI `/v1` URL and `openai/` model prefix for all other agents
- document the different network path when Claude Code runs inside a Daytona sandbox
- add focused payload tests for Claude Code, Terminus 2, and external-host rewriting

## Why

Claude Code appends `/v1/messages` to `ANTHROPIC_BASE_URL` itself. The existing Harbor rollout function always appended `/v1` and prefixed the model with `openai/`, which is correct for OpenAI-compatible agents but produces the wrong endpoint and model for Claude Code.

## Stack

- depends on #2263
- base branch: `shi/session-sampling-overrides`
- follow-up Harbor work is still required to expose each trial's `base_url`, `model`, and API key through the corresponding Anthropic environment variables

## Testing

- `tests/fast/rollout/generate_hub/test_swe_agent_function.py` — 3 passed
- selected pre-commit hooks — passed
