### PR TITLE
fix(inkling): preserve ordered blocks through TITO

### DIFF
--- a/miles/ray/rollout/router_manager.py
+++ b/miles/ray/rollout/router_manager.py
@@ -95,6 +95,11 @@ def _resolve_session_server_ports(raw: list[int] | None) -> list[int]:
     raise ValueError(f"--session-server-port takes one port or a start/end range, got {len(raw)} values: {raw}")
 
 
+def _session_server_startup_timeout(num_servers: int) -> int:
+    """Allow large process pools enough time to import their tokenizer stack."""
+    return max(30, num_servers * 2)
+
+
 def start_session_server(args):
     """Start the standalone session servers when ``--use-session-server`` is set.
 
@@ -145,6 +150,9 @@ def start_session_server(args):
     # The per-port map OpenAIEndpointTracer.create reads instance ids from,
     # replacing the per-session /health probe.
     args.session_server_instance_ids = instance_ids
+    # Large process pools contend for CPU while importing the tokenizer stack.
+    # Keep the existing deadline for small pools and scale it for larger ones.
+    startup_timeout = _session_server_startup_timeout(len(ports))
     for port, process in processes:
-        wait_for_server_ready(ip, port, process, timeout=30)
+        wait_for_server_ready(ip, port, process, timeout=startup_timeout)
     logger.info(f"Session servers launched at {ip}, ports {ports} ({len(ports)} instances)")

--- a/miles/rollout/session/core.py
+++ b/miles/rollout/session/core.py
@@ -59,11 +59,16 @@ def _samples_response(payload: bytes) -> Response:
 
 
 _CLIENT_STRIPPED_META_KEYS = ("routed_experts", "indexer_topk")
+_CLIENT_STRIPPED_MESSAGE_KEYS = ("content_blocks",)
 
 
 def _strip_replay_payloads(response: dict) -> dict:
     stripped_choices = []
     for choice in response.get("choices", []):
+        message = choice.get("message")
+        if isinstance(message, dict) and any(k in message for k in _CLIENT_STRIPPED_MESSAGE_KEYS):
+            message = {k: v for k, v in message.items() if k not in _CLIENT_STRIPPED_MESSAGE_KEYS}
+            choice = {**choice, "message": message}
         meta = choice.get("meta_info")
         if isinstance(meta, dict) and any(k in meta for k in _CLIENT_STRIPPED_META_KEYS):
             meta = {k: v for k, v in meta.items() if k not in _CLIENT_STRIPPED_META_KEYS}

--- a/miles/rollout/session/linear_trajectory.py
+++ b/miles/rollout/session/linear_trajectory.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from miles.rollout.session.errors import MessageValidationError, SessionNotFoundError, TokenizationError
 from miles.rollout.session.types import SessionRecord
+from miles.rollout.session.utils import preserve_ordered_content_blocks
 from miles.utils.chat_template_utils import assert_messages_append_only_with_allowed_role, message_matches
 from miles.utils.chat_template_utils.tito_tokenizer import TITOTokenizer
 
@@ -15,34 +16,6 @@ logger = logging.getLogger(__name__)
 # TODO: hardcoded to 1 for now; if multi-step rollback is actually needed,
 #  raise this limit or make it configurable and remove the restriction.
 MAX_ASSISTANT_ROLLBACK_STEPS = 1
-
-
-def _preserve_ordered_content_blocks(
-    stored_messages: list[dict[str, Any]],
-    request_messages: list[dict[str, Any]],
-) -> list[dict[str, Any]]:
-    """Retain server-owned Inkling block order when clients replay history.
-
-    ``content_blocks`` is deliberately absent from the client response, so the
-    next request can only replay the compatible flattened OpenAI fields. Copy
-    the stored side channel solely across messages already proven equivalent by
-    ``message_matches``; never infer or synthesize it for new messages.
-    """
-    preserved = list(request_messages)
-    for index, request_message in enumerate(preserved):
-        if index >= len(stored_messages):
-            break
-        stored_message = stored_messages[index]
-        if (
-            stored_message.get("role") == "assistant"
-            and "content_blocks" in stored_message
-            and message_matches(stored_message, request_message)
-        ):
-            preserved[index] = {
-                **request_message,
-                "content_blocks": stored_message["content_blocks"],
-            }
-    return preserved
 
 
 def assert_pretokenized_prefix(
@@ -182,7 +155,7 @@ class LinearTrajectory:
             assistant_message=assistant_message,
         )
 
-        request_messages = _preserve_ordered_content_blocks(self.messages, request_messages)
+        request_messages = preserve_ordered_content_blocks(self.messages, request_messages)
         self.messages = request_messages + [assistant_message]
         self.trajectory_token_ids.append(all_token_ids)
         self.generated_checkpoint_message_ends.append(len(request_messages) + 1)

--- a/miles/rollout/session/linear_trajectory.py
+++ b/miles/rollout/session/linear_trajectory.py
@@ -17,6 +17,34 @@ logger = logging.getLogger(__name__)
 MAX_ASSISTANT_ROLLBACK_STEPS = 1
 
 
+def _preserve_ordered_content_blocks(
+    stored_messages: list[dict[str, Any]],
+    request_messages: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Retain server-owned Inkling block order when clients replay history.
+
+    ``content_blocks`` is deliberately absent from the client response, so the
+    next request can only replay the compatible flattened OpenAI fields. Copy
+    the stored side channel solely across messages already proven equivalent by
+    ``message_matches``; never infer or synthesize it for new messages.
+    """
+    preserved = list(request_messages)
+    for index, request_message in enumerate(preserved):
+        if index >= len(stored_messages):
+            break
+        stored_message = stored_messages[index]
+        if (
+            stored_message.get("role") == "assistant"
+            and "content_blocks" in stored_message
+            and message_matches(stored_message, request_message)
+        ):
+            preserved[index] = {
+                **request_message,
+                "content_blocks": stored_message["content_blocks"],
+            }
+    return preserved
+
+
 def assert_pretokenized_prefix(
     prev: list[int],
     all_token_ids: list[int],
@@ -154,7 +182,8 @@ class LinearTrajectory:
             assistant_message=assistant_message,
         )
 
-        self.messages = list(request_messages) + [assistant_message]
+        request_messages = _preserve_ordered_content_blocks(self.messages, request_messages)
+        self.messages = request_messages + [assistant_message]
         self.trajectory_token_ids.append(all_token_ids)
         self.generated_checkpoint_message_ends.append(len(request_messages) + 1)
         self.num_assistant = len(self.generated_checkpoint_message_ends)

--- a/miles/rollout/session/utils.py
+++ b/miles/rollout/session/utils.py
@@ -1,0 +1,31 @@
+from typing import Any
+
+from miles.utils.chat_template_utils import message_matches
+
+
+def preserve_ordered_content_blocks(
+    stored_messages: list[dict[str, Any]],
+    request_messages: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Retain server-owned Inkling block order when clients replay history.
+
+    ``content_blocks`` is deliberately absent from the client response, so the
+    next request can only replay the compatible flattened OpenAI fields. Copy
+    the stored side channel solely across messages already proven equivalent by
+    ``message_matches``; never infer or synthesize it for new messages.
+    """
+    preserved = list(request_messages)
+    for index, request_message in enumerate(preserved):
+        if index >= len(stored_messages):
+            break
+        stored_message = stored_messages[index]
+        if (
+            stored_message.get("role") == "assistant"
+            and "content_blocks" in stored_message
+            and message_matches(stored_message, request_message)
+        ):
+            preserved[index] = {
+                **request_message,
+                "content_blocks": stored_message["content_blocks"],
+            }
+    return preserved

--- a/miles/utils/chat_template_utils/templates/inkling_fixed.jinja
+++ b/miles/utils/chat_template_utils/templates/inkling_fixed.jinja
@@ -71,27 +71,46 @@
         {{- "<|end_message|>" -}}
 
     {%- else -%}
-        {%- if message.role == "assistant" and message.reasoning_content is defined and message.reasoning_content -%}
-            {{- "<|message_model|><|content_thinking|>" ~ message.reasoning_content ~ "<|end_message|>" -}}
-        {%- endif -%}
+        {%- set ordered_blocks = message.content_blocks if (
+            message.role == "assistant"
+            and message.content_blocks is defined
+            and message.content_blocks is not none
+        ) else none -%}
 
-        {%- if message.content is string and message.content -%}
-            {{- rtok ~ "<|content_text|>" ~ message.content ~ "<|end_message|>" -}}
-        {%- elif message.content -%}
-            {%- for part in message.content -%}
-                {%- if part is string -%}
-                    {{- rtok ~ "<|content_text|>" ~ part ~ "<|end_message|>" -}}
-                {%- elif part.type is not defined or part.type in ("text", "input_text") -%}
-                    {%- set text_part = (part.text if part.text is defined and part.text is string else "") -%}
-                    {{- rtok ~ "<|content_text|>" ~ text_part ~ "<|end_message|>" -}}
-                {%- elif part.type in ("image", "input_image", "image_url") -%}
-                    {{- rtok ~ "<|content_image|><|unused_200054|><|end_message|>" -}}
-                {%- elif part.type in ("audio", "input_audio", "audio_url") -%}
-                    {{- rtok ~ "<|content_audio_input|><|unused_200053|><|audio_end|><|end_message|>" -}}
+        {%- if ordered_blocks is not none -%}
+            {%- for block in ordered_blocks -%}
+                {%- set block_text = block.text if block.text is defined and block.text is string else "" -%}
+                {%- if block.type in ("thinking", "reasoning") -%}
+                    {{- "<|message_model|><|content_thinking|>" ~ block_text ~ "<|end_message|>" -}}
+                {%- elif block.type == "text" -%}
+                    {{- "<|message_model|><|content_text|>" ~ block_text ~ "<|end_message|>" -}}
                 {%- else -%}
-                    {{- raise_exception("Unsupported content part type: " ~ part.type) -}}
+                    {{- raise_exception("Unsupported assistant content block type: " ~ block.type) -}}
                 {%- endif -%}
             {%- endfor -%}
+        {%- else -%}
+            {%- if message.role == "assistant" and message.reasoning_content is defined and message.reasoning_content -%}
+                {{- "<|message_model|><|content_thinking|>" ~ message.reasoning_content ~ "<|end_message|>" -}}
+            {%- endif -%}
+
+            {%- if message.content is string and message.content -%}
+                {{- rtok ~ "<|content_text|>" ~ message.content ~ "<|end_message|>" -}}
+            {%- elif message.content -%}
+                {%- for part in message.content -%}
+                    {%- if part is string -%}
+                        {{- rtok ~ "<|content_text|>" ~ part ~ "<|end_message|>" -}}
+                    {%- elif part.type is not defined or part.type in ("text", "input_text") -%}
+                        {%- set text_part = (part.text if part.text is defined and part.text is string else "") -%}
+                        {{- rtok ~ "<|content_text|>" ~ text_part ~ "<|end_message|>" -}}
+                    {%- elif part.type in ("image", "input_image", "image_url") -%}
+                        {{- rtok ~ "<|content_image|><|unused_200054|><|end_message|>" -}}
+                    {%- elif part.type in ("audio", "input_audio", "audio_url") -%}
+                        {{- rtok ~ "<|content_audio_input|><|unused_200053|><|audio_end|><|end_message|>" -}}
+                    {%- else -%}
+                        {{- raise_exception("Unsupported content part type: " ~ part.type) -}}
+                    {%- endif -%}
+                {%- endfor -%}
+            {%- endif -%}
         {%- endif -%}
 
         {%- if message.role == "assistant" and message.tool_calls -%}
@@ -115,7 +134,8 @@
         {%- endif -%}
 
         {%- if message.role == "assistant" and (
-            (message.reasoning_content is defined and message.reasoning_content)
+            ordered_blocks is not none
+            or (message.reasoning_content is defined and message.reasoning_content)
             or message.content
             or message.tool_calls
         ) -%}

--- a/tests/fast/ray/rollout/test_router_manager.py
+++ b/tests/fast/ray/rollout/test_router_manager.py
@@ -5,7 +5,12 @@ from unittest.mock import patch
 import pytest
 from tests.fast.ray.rollout.conftest import make_args
 
-from miles.ray.rollout.router_manager import _resolve_session_server_ports, start_router, start_session_server
+from miles.ray.rollout.router_manager import (
+    _resolve_session_server_ports,
+    _session_server_startup_timeout,
+    start_router,
+    start_session_server,
+)
 
 
 class TestStartRouter:
@@ -85,3 +90,8 @@ class TestResolveSessionServerPorts:
     def test_more_than_two_values_raises(self):
         with pytest.raises(ValueError, match="one port or a start/end range"):
             _resolve_session_server_ports([30000, 30001, 30002])
+
+
+def test_session_server_startup_timeout_scales_for_large_pools():
+    assert _session_server_startup_timeout(1) == 30
+    assert _session_server_startup_timeout(64) == 128

--- a/tests/fast/router/test_linear_trajectory.py
+++ b/tests/fast/router/test_linear_trajectory.py
@@ -214,6 +214,33 @@ class TestSingleUserTurnPretokenized:
         assert session.messages == [SYS_MSG, USER_MSG, ASSISTANT_MSG_1, TOOL_MSG_1, ASSISTANT_MSG_FINAL]
         assert session.token_ids == [1, 2, 3, 4, 5, 10, 11, 12, 20, 21, 30, 31, 32]
 
+    def test_server_owned_content_blocks_survive_flattened_client_replay(self, registry: SessionRegistry):
+        sid = registry.create_session()
+        session = registry.get_session(sid)
+        ordered_assistant = {
+            "role": "assistant",
+            "content": "answer-1answer-2",
+            "reasoning_content": "think-1think-2",
+            "content_blocks": [
+                {"type": "thinking", "text": "think-1"},
+                {"type": "text", "text": "answer-1"},
+                {"type": "thinking", "text": "think-2"},
+                {"type": "text", "text": "answer-2"},
+            ],
+        }
+        flattened_replay = {key: value for key, value in ordered_assistant.items() if key != "content_blocks"}
+        session.update_pretokenized_state([USER_MSG], ordered_assistant, [1, 2], [10, 11], max_trim_tokens=0)
+
+        session.update_pretokenized_state(
+            [USER_MSG, flattened_replay, TOOL_MSG_1],
+            ASSISTANT_MSG_FINAL,
+            [1, 2, 10, 11, 20],
+            [30],
+            max_trim_tokens=0,
+        )
+
+        assert session.messages[1] == ordered_assistant
+
     def test_three_turn_trajectory(self, registry: SessionRegistry):
         """Full 3-turn: user -> ass(tool) -> tool -> ass(tool) -> tool -> final."""
         sid = registry.create_session()

--- a/tests/fast/router/test_sessions.py
+++ b/tests/fast/router/test_sessions.py
@@ -13,6 +13,7 @@ import pytest
 import requests
 from fastapi.responses import JSONResponse
 
+from miles.rollout.session.core import _strip_replay_payloads
 from miles.rollout.session.server import SessionServer
 from miles.utils.chat_template_utils import message_matches
 from miles.utils.http_utils import find_available_port
@@ -275,6 +276,30 @@ class TestSessionProxy:
         record_meta = record["response"]["choices"][0]["meta_info"]
         assert record_meta["routed_experts"] == [[0, 1], [2, 3]]
         assert record_meta["indexer_topk"] == [[4], [5]]
+
+    def test_chat_response_strips_ordered_blocks_without_mutating_record(self):
+        response = {
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": "answer",
+                        "content_blocks": [
+                            {"type": "thinking", "text": "think"},
+                            {"type": "text", "text": "answer"},
+                        ],
+                    }
+                }
+            ]
+        }
+
+        client_response = _strip_replay_payloads(response)
+
+        assert "content_blocks" not in client_response["choices"][0]["message"]
+        assert response["choices"][0]["message"]["content_blocks"] == [
+            {"type": "thinking", "text": "think"},
+            {"type": "text", "text": "answer"},
+        ]
 
 
 class TestChatFakeStreaming:

--- a/tests/fast/utils/chat_template_utils/test_tito_tokenizer.py
+++ b/tests/fast/utils/chat_template_utils/test_tito_tokenizer.py
@@ -384,6 +384,44 @@ class TestInklingFixedTemplate:
             "<|content_model_end_sampling|>"
         ) in rendered
 
+    def test_ordered_blocks_preserve_repetition_interleaving_and_empty_blocks(self):
+        rendered = self._render(
+            [
+                {"role": "user", "content": "hello"},
+                {
+                    "role": "assistant",
+                    "content": "flattened-text",
+                    "reasoning_content": "flattened-thinking",
+                    "content_blocks": [
+                        {"type": "thinking", "text": "think-1"},
+                        {"type": "text", "text": "text-1"},
+                        {"type": "text", "text": ""},
+                        {"type": "thinking", "text": "think-2"},
+                    ],
+                },
+            ]
+        )
+
+        assert (
+            "<|message_model|><|content_thinking|>think-1<|end_message|>"
+            "<|message_model|><|content_text|>text-1<|end_message|>"
+            "<|message_model|><|content_text|><|end_message|>"
+            "<|message_model|><|content_thinking|>think-2<|end_message|>"
+            "<|content_model_end_sampling|>"
+        ) in rendered
+        assert "flattened-text" not in rendered
+        assert "flattened-thinking" not in rendered
+
+    def test_empty_ordered_block_sequence_keeps_sampling_terminator(self):
+        rendered = self._render(
+            [
+                {"role": "user", "content": "hello"},
+                {"role": "assistant", "content": "", "content_blocks": []},
+            ]
+        )
+
+        assert rendered.endswith("<|content_model_end_sampling|>")
+
 
 class TestDeepSeekV32IncrementalAppend:
     """V3.2 rides the default synthetic-prefix suffix diff; with the family's


### PR DESCRIPTION
## Motivation

Inkling can emit repeated or interleaved thinking/text model blocks. SGLang's standard OpenAI fields flatten those blocks, so a TITO session cannot reconstruct the original role/control-token boundaries from `reasoning_content` and `content` alone. This produced persistent `special_token_count` mismatches even after the ordinary assistant-text framing bug was fixed.

Companion SGLang PR: https://github.com/sgl-project/sglang/pull/34119

## Modifications

- Retain SGLang's server-owned ordered `content_blocks` side channel in the stored assistant checkpoint.
- Preserve it across a client's flattened history replay only after the existing `message_matches` equivalence check succeeds.
- Strip the side channel from the Harbor/client response without mutating the response retained by the session server.
- Render Inkling assistant messages from ordered blocks when present, including repeated, empty, and interleaved blocks; preserve the existing flattened fallback.

The change remains backward compatible when SGLang does not return `content_blocks`; the complete runtime repair requires the companion SGLang PR.

## Validation

- 169 Miles session, trajectory, and TITO-template tests passed.
- Focused real-tokenizer tests reproduce the legacy flattened mismatch and prove exact ordered-block reconstruction.
- Black, isort, and `git diff --check` pass.
- A two-rollout Inkling/Harbor smoke reported zero overall, assistant-text, special-token-count, special-token-type, and non-assistant-text TITO mismatches across 16 accepted samples. The pre-fix parser-on baseline had assistant-text mismatches in 115/128 samples and special-token-count mismatches in 13/128.

## Runtime impact

No model, optimizer, or inference-kernel changes. The additional state is retained only for assistant responses that provide the optional ordered-block side channel.