### PR TITLE
fix(logging): redact launcher secrets

### DIFF
--- a/examples/swe-agent-harbor-docker/run.py
+++ b/examples/swe-agent-harbor-docker/run.py
@@ -12,7 +12,7 @@ import os
 import socket
 import subprocess
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Literal
 
@@ -59,7 +59,10 @@ class ScriptArgs(U.ExecuteTrainConfig):
     miles_host_ip: str = os.environ.get("MILES_HOST_IP", "")  # optional cluster/pod IP override
 
     # W&B settings
-    wandb_key: str = os.environ.get("WANDB_KEY", os.environ.get("WANDB_API_KEY", ""))
+    wandb_key: str = field(
+        default=os.environ.get("WANDB_KEY", os.environ.get("WANDB_API_KEY", "")),
+        metadata={"secret": True},
+    )
     wandb_project: str = os.environ.get("WANDB_PROJECT", "my-wandb-project")
     wandb_team: str = os.environ.get("WANDB_TEAM", "")
     wandb_run_name: str = "glm47-flash-swe-tito"

--- a/miles/utils/misc.py
+++ b/miles/utils/misc.py
@@ -2,6 +2,7 @@ import asyncio
 import importlib
 import inspect
 import logging
+import os
 import re
 import subprocess
 from collections.abc import Sequence
@@ -115,8 +116,19 @@ class SingletonMeta(type):
         SingletonMeta._instances.clear()
 
 
+_SENSITIVE_ENV_SUFFIXES = ("_KEY", "_TOKEN", "_SECRET", "_PASSWORD")
+
+
+def _redact_command(cmd: str) -> str:
+    sensitive_values = {value for key, value in os.environ.items() if value and key.upper().endswith(_SENSITIVE_ENV_SUFFIXES)}
+    for value in sorted(sensitive_values, key=len, reverse=True):
+        cmd = cmd.replace(value, "[REDACTED]")
+    return cmd
+
+
 def exec_command(cmd: str, capture_output: bool = False) -> str | None:
-    print(f"EXEC: {cmd}", flush=True)
+    redacted_cmd = _redact_command(cmd)
+    print(f"EXEC: {redacted_cmd}", flush=True)
 
     try:
         result = subprocess.run(
@@ -127,6 +139,7 @@ def exec_command(cmd: str, capture_output: bool = False) -> str | None:
             **(dict(text=True) if capture_output else {}),
         )
     except subprocess.CalledProcessError as e:
+        e.cmd = ["bash", "-c", redacted_cmd]
         if capture_output:
             print(f"{e.stdout=} {e.stderr=}")
         raise
@@ -172,7 +185,9 @@ def exec_command_all_ray_node(
         nnodes = str(len(nodes))
 
         placeholder_pattern = re.compile(
-            "|".join(map(re.escape, ["{{node_rank}}", "{{nnodes}}", "{{master_addr}}", "{{node_ip}}"]))
+            "|".join(
+                map(re.escape, ["{{node_rank}}", "{{nnodes}}", "{{master_addr}}", "{{node_ip}}"])
+            )
         )
 
         refs = []

--- a/miles/utils/typer_utils.py
+++ b/miles/utils/typer_utils.py
@@ -33,6 +33,7 @@ def dataclass_cli(
 
     Supports field ``metadata`` keys:
     - ``"help"``: passed as ``help=`` to ``typer.Option``
+    - ``"secret"``: replaces the value with ``[REDACTED]`` in the argument table
 
     Usage::
 
@@ -90,7 +91,7 @@ def _wrap(func: _F, *, env_var_prefix: str) -> _F:
         print(f"| {'Argument':<{max_key_len}} | {'Value':<50} |")
         print(sep)
         for f in fields:
-            val = str(getattr(data, f.name))
+            val = "[REDACTED]" if f.metadata.get("secret") else str(getattr(data, f.name))
             if len(val) > 50:
                 val = val[:47] + "..."
             print(f"| {f.name:<{max_key_len}} | {val:<50} |")

--- a/tests/fast/utils/test_misc.py
+++ b/tests/fast/utils/test_misc.py
@@ -1,9 +1,10 @@
 import logging
 import os
+import subprocess
 
 import pytest
 
-from miles.utils.misc import FunctionRegistry, filter_keys, function_registry, load_function
+from miles.utils.misc import FunctionRegistry, exec_command, filter_keys, function_registry, load_function
 
 
 def _fn_a():
@@ -92,3 +93,36 @@ class TestFilterKeys:
             with pytest.raises(KeyError):
                 filter_keys(d, ["a", "missing"])
         assert any("filter_keys" in record.message for record in caplog.records)
+
+
+class TestExecCommand:
+    def test_redacts_environment_secret_without_changing_command(self, monkeypatch, capsys):
+        secret = "test-secret-that-must-not-be-logged"
+        calls = []
+        monkeypatch.setenv("TEST_API_KEY", secret)
+
+        def fake_run(args, **kwargs):
+            calls.append((args, kwargs))
+            return subprocess.CompletedProcess(args, 0)
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        exec_command(f"tool --api-key {secret}")
+
+        assert secret in calls[0][0][-1]
+        assert secret not in capsys.readouterr().out
+
+    def test_redacts_environment_secret_from_failure(self, monkeypatch):
+        secret = "test-secret-that-must-not-be-logged"
+        monkeypatch.setenv("TEST_API_KEY", secret)
+
+        def fail(args, **kwargs):
+            raise subprocess.CalledProcessError(1, args)
+
+        monkeypatch.setattr(subprocess, "run", fail)
+
+        with pytest.raises(subprocess.CalledProcessError) as exc_info:
+            exec_command(f"tool --api-key {secret}")
+
+        assert secret not in str(exc_info.value.cmd)
+        assert "[REDACTED]" in str(exc_info.value.cmd)

--- a/tests/fast/utils/test_typer_utils.py
+++ b/tests/fast/utils/test_typer_utils.py
@@ -55,6 +55,11 @@ class _AllRequiredArgs:
 
 
 @dataclasses.dataclass
+class _SecretArgs:
+    api_key: str = dataclasses.field(default="secret-value", metadata={"secret": True})
+
+
+@dataclasses.dataclass
 class _SingleFieldArgs:
     value: str = "default"
 
@@ -729,6 +734,24 @@ class TestEnvVarNaming:
         result = runner.invoke(app, [], env={"MILES_SCRIPT_MY_LONG_NAME": "from_env"})
         assert result.exit_code == 0
         assert "val=from_env" in result.stdout
+
+
+class TestSecretMetadata:
+    def test_redacts_secret_in_argument_table(self) -> None:
+        received = []
+        app = typer.Typer()
+
+        @app.command()
+        @dataclass_cli
+        def cmd(args: _SecretArgs) -> None:
+            received.append(args.api_key)
+
+        result = runner.invoke(app, ["--api-key", "override-secret"])
+
+        assert result.exit_code == 0
+        assert received == ["override-secret"]
+        assert "override-secret" not in result.stdout
+        assert "[REDACTED]" in result.stdout
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- redact values from key/token/secret/password environment variables before printing shell commands
- keep the original command unchanged for execution and sanitize it on CalledProcessError
- support secret dataclass metadata in CLI argument tables
- mark the Harbor launcher W&B key as secret

## Testing

- pytest -q tests/fast/utils/test_misc.py tests/fast/utils/test_typer_utils.py (61 passed on the Miles H200 image)
- python -m py_compile miles/utils/misc.py miles/utils/typer_utils.py examples/swe-agent-harbor-docker/run.py
- uvx ruff check examples/swe-agent-harbor-docker/run.py miles/utils/misc.py miles/utils/typer_utils.py tests/fast/utils/test_misc.py tests/fast/utils/test_typer_utils.py

## Current status

Closed at the author’s request; this logging hardening is not required for the Claude Code training path.
