### PR TITLE
fix(session): allow Claude Code context compaction

### DIFF
--- a/miles/rollout/session/linear_trajectory.py
+++ b/miles/rollout/session/linear_trajectory.py
@@ -12,10 +12,11 @@ from miles.utils.chat_template_utils.tito_tokenizer import TITOTokenizer
 logger = logging.getLogger(__name__)
 
 
-# Claude Code may compact most of a 64-turn conversation into a short summary.
-# Bound rollback to one full harness turn budget so larger rewrites are still
-# rejected.
-MAX_ASSISTANT_ROLLBACK_STEPS = 64
+# Claude Code's --max-turns counts top-level turns, not every model checkpoint;
+# subagents and retries can therefore create substantially more checkpoints.
+# Keep a generous finite bound so legitimate compaction still cannot trigger an
+# unbounded rollback.
+MAX_ASSISTANT_ROLLBACK_STEPS = 256
 
 
 def assert_pretokenized_prefix(

--- a/miles/rollout/session/linear_trajectory.py
+++ b/miles/rollout/session/linear_trajectory.py
@@ -12,9 +12,10 @@ from miles.utils.chat_template_utils.tito_tokenizer import TITOTokenizer
 logger = logging.getLogger(__name__)
 
 
-# TODO: hardcoded to 1 for now; if multi-step rollback is actually needed,
-#  raise this limit or make it configurable and remove the restriction.
-MAX_ASSISTANT_ROLLBACK_STEPS = 1
+# Claude Code may compact most of a 64-turn conversation into a short summary.
+# Bound rollback to one full harness turn budget so larger rewrites are still
+# rejected.
+MAX_ASSISTANT_ROLLBACK_STEPS = 64
 
 
 def assert_pretokenized_prefix(
@@ -60,8 +61,8 @@ class LinearTrajectory:
     Rollback uses ``generated_checkpoint_message_ends`` instead of inferring checkpoints from message roles.
 
     The typical message sequence is: [system?, user, assistant, tool, assistant, tool, …],
-    but the agent may retry from an earlier point (e.g. re-running a tool call),
-    in which case the session is rolled back at most one assistant step.
+    but the agent may retry from an earlier point or compact a long context, in
+    which case the session rolls back to a bounded earlier checkpoint.
 
     Concurrency contract: all mutating methods must be called under ``self.lock``.
     """
@@ -92,7 +93,8 @@ class LinearTrajectory:
         """Build the full prompt input_ids for *request_messages*.
 
         Validates that *request_messages* extends the stored history, rolling
-        back at most one assistant step on agent retries, then reuses the
+        back to a bounded earlier checkpoint on retries or context compaction,
+        then reuses the
         stored token_ids as the pretokenized prefix.  When no stored checkpoint
         is left to build on — the first turn, or a retry of the first turn that
         rolled the session back to empty — renders *request_messages* from
@@ -100,8 +102,8 @@ class LinearTrajectory:
 
         Must be called under ``self.lock``.
         """
-        # 1. Detect agent retries and roll back (at most one assistant step). Retrying the
-        #    first turn rolls back to the empty checkpoint, clearing token_ids.
+        # 1. Detect retries or context compaction and roll back to a bounded
+        #    earlier checkpoint. Retrying the first turn clears token_ids.
         self._try_detect_and_rollback_to_assistant_checkpoint(request_messages)
 
         if not self.token_ids:
@@ -173,15 +175,10 @@ class LinearTrajectory:
         or to the empty checkpoint when the matching prefix holds no generated
         checkpoint at all.
 
-        Only a single-step rollback is allowed (controlled by
-        ``MAX_ASSISTANT_ROLLBACK_STEPS``).  Discarding exactly one generated
-        checkpoint means the agent is retrying from the preceding checkpoint —
-        the request shares the stored prefix up to that generated response and
-        then continues with whatever the agent chooses (same or different tool
-        result, additional messages, etc.).  Any request that would need to
-        discard more than one generated checkpoint (i.e. jump back across
-        multiple turns) is rejected with ``MessageValidationError`` and no
-        state is modified.
+        Rollback is bounded by ``MAX_ASSISTANT_ROLLBACK_STEPS``.  This covers a
+        nearby retry as well as a harness compacting a long context into a
+        summary.  A request that exceeds the bound is rejected with
+        ``MessageValidationError`` and no state is modified.
 
         Example — agent retries after the first tool call::
 

--- a/tests/fast/router/test_linear_trajectory.py
+++ b/tests/fast/router/test_linear_trajectory.py
@@ -733,8 +733,9 @@ class TestRollback:
         assert session.token_ids == [1, 2, 99]
         assert session.messages == [USER_MSG, ASSISTANT_MSG_FINAL]
 
-    def test_rollback_to_empty_beyond_one_assistant_raises(self, registry: SessionRegistry):
+    def test_configured_rollback_to_empty_limit_raises(self, registry: SessionRegistry, monkeypatch):
         """Resetting to empty is still bounded by MAX_ASSISTANT_ROLLBACK_STEPS."""
+        monkeypatch.setattr("miles.rollout.session.linear_trajectory.MAX_ASSISTANT_ROLLBACK_STEPS", 1)
         sid = registry.create_session()
         session = registry.get_session(sid)
 
@@ -745,7 +746,7 @@ class TestRollback:
         session.update_pretokenized_state(turn2, ASSISTANT_MSG_2, [1, 2, 10, 20], [30], max_trim_tokens=0)
         assert session.num_assistant == 2
 
-        # Discarding both assistants exceeds the single-step budget.
+        # Discarding both assistants exceeds the configured budget.
         with pytest.raises(MessageValidationError, match="exceeds max_assistant_rollback_steps"):
             session.prepare_pretokenized(turn1, tito_tokenizer=registry.tito_tokenizer)
 

--- a/tests/fast/router/test_linear_trajectory.py
+++ b/tests/fast/router/test_linear_trajectory.py
@@ -558,25 +558,25 @@ class TestRollback:
         assert session.records == prev_records
         assert session.num_assistant == prev_num_assistant
 
-    def test_claude_code_compaction_discards_51_assistants(self, registry: SessionRegistry):
-        """A real Claude Code compaction can rewind nearly its full turn budget."""
+    def test_claude_code_compaction_discards_177_assistants(self, registry: SessionRegistry):
+        """Claude Code subagents can create more checkpoints than its top-level turn budget."""
         sid = registry.create_session()
         session = registry.get_session(sid)
         messages = [SYS_MSG, USER_MSG]
         checkpoint_ends = []
-        for turn in range(53):
+        for turn in range(179):
             messages.append({"role": "assistant", "content": f"assistant {turn}"})
             checkpoint_ends.append(len(messages))
-            if turn < 52:
+            if turn < 178:
                 messages.append(
                     {"role": "tool", "content": f'{{"turn": {turn}}}', "tool_call_id": f"call_{turn}"}
                 )
 
         session.messages = messages
-        session.trajectory_token_ids = [[turn] for turn in range(53)]
+        session.trajectory_token_ids = [[turn] for turn in range(179)]
         session.generated_checkpoint_message_ends = checkpoint_ends
-        session.records = [MagicMock(spec=SessionRecord) for _ in range(53)]
-        session.num_assistant = 53
+        session.records = [MagicMock(spec=SessionRecord) for _ in range(179)]
+        session.num_assistant = 179
 
         compacted_tool = {"role": "tool", "content": '{"compacted": true}', "tool_call_id": "compact"}
         result = session.prepare_pretokenized(

--- a/tests/fast/router/test_linear_trajectory.py
+++ b/tests/fast/router/test_linear_trajectory.py
@@ -517,8 +517,9 @@ class TestRollback:
         assert session.token_ids == [1, 2, 3, 10, 11]
         assert session.messages == [SYS_MSG, USER_MSG, ASSISTANT_MSG_1]
 
-    def test_multi_step_rollback_raises(self, registry: SessionRegistry):
-        """Rollback that discards >1 assistant raises MessageValidationError and leaves state unchanged."""
+    def test_configured_rollback_limit_raises(self, registry: SessionRegistry, monkeypatch):
+        """Rollback beyond the configured bound leaves state unchanged."""
+        monkeypatch.setattr("miles.rollout.session.linear_trajectory.MAX_ASSISTANT_ROLLBACK_STEPS", 1)
         sid = registry.create_session()
         session = registry.get_session(sid)
 
@@ -556,6 +557,38 @@ class TestRollback:
         assert session.trajectory_token_ids == prev_token_ids
         assert session.records == prev_records
         assert session.num_assistant == prev_num_assistant
+
+    def test_claude_code_compaction_discards_51_assistants(self, registry: SessionRegistry):
+        """A real Claude Code compaction can rewind nearly its full turn budget."""
+        sid = registry.create_session()
+        session = registry.get_session(sid)
+        messages = [SYS_MSG, USER_MSG]
+        checkpoint_ends = []
+        for turn in range(53):
+            messages.append({"role": "assistant", "content": f"assistant {turn}"})
+            checkpoint_ends.append(len(messages))
+            if turn < 52:
+                messages.append(
+                    {"role": "tool", "content": f'{{"turn": {turn}}}', "tool_call_id": f"call_{turn}"}
+                )
+
+        session.messages = messages
+        session.trajectory_token_ids = [[turn] for turn in range(53)]
+        session.generated_checkpoint_message_ends = checkpoint_ends
+        session.records = [MagicMock(spec=SessionRecord) for _ in range(53)]
+        session.num_assistant = 53
+
+        compacted_tool = {"role": "tool", "content": '{"compacted": true}', "tool_call_id": "compact"}
+        result = session.prepare_pretokenized(
+            messages[:5] + [compacted_tool], tito_tokenizer=registry.tito_tokenizer
+        )
+
+        assert result == [1]
+        assert session.messages == messages[:5]
+        assert session.trajectory_token_ids == [[0], [1]]
+        assert session.generated_checkpoint_message_ends == [3, 5]
+        assert len(session.records) == 2
+        assert session.num_assistant == 2
 
     def test_rollback_then_continue_full_trajectory(self, registry: SessionRegistry):
         """Rollback and then complete a full new trajectory from the checkpoint."""


### PR DESCRIPTION
## Summary

- allow a session to roll back as many as 256 generated checkpoints
- support long-context compaction by agent harnesses such as Claude Code
- keep the rollback bounded so larger, unrelated history rewrites are rejected

## Why

Claude Code can replace most of a long conversation with a compact summary. Its `--max-turns` setting limits top-level turns, but subagents and retries can create substantially more session checkpoints. A real training rollout rewound 177 generated checkpoints; Miles previously rejected that valid compaction request with HTTP 400.

The request still has to share a validated prefix with the stored trajectory. This change only raises the existing finite rollback guard to cover observed Claude Code behavior.

## Tests

- `uvx ruff check miles/rollout/session/linear_trajectory.py tests/fast/router/test_linear_trajectory.py`
- `python3 -m pytest tests/fast/router/test_linear_trajectory.py -q` on the H200 training devbox — 46 passed
- the regression test constructs 179 generated checkpoints and verifies that discarding 177 succeeds


## Current status

Draft: follow-up hardening for long Claude Code sessions that compact context; not part of the core adapter stack.
