### PR TITLE
fix(session): serialize concurrent Anthropic turns

### DIFF
--- a/miles/rollout/session/core.py
+++ b/miles/rollout/session/core.py
@@ -472,14 +472,19 @@ class SessionCore:
 
         client_stream = bool(openai_request.pop("stream", False))
         try:
-            openai_response = await self.chat_completions(
-                session_id,
-                method=method,
-                query=query,
-                headers=headers,
-                body=json.dumps(openai_request).encode(),
-                restore_anthropic_arguments=True,
-            )
+            session = self.registry.get_session(session_id)
+            # Claude Code may issue overlapping subagent turns against one
+            # session. Keep each complete turn ordered so its TITO state cannot
+            # change between request preparation and the response commit.
+            async with session.turn_lock:
+                openai_response = await self.chat_completions(
+                    session_id,
+                    method=method,
+                    query=query,
+                    headers=headers,
+                    body=json.dumps(openai_request).encode(),
+                    restore_anthropic_arguments=True,
+                )
         except SessionError as exc:
             return _anthropic_error_response(exc.status_code, {"error": str(exc)})
 

--- a/miles/rollout/session/linear_trajectory.py
+++ b/miles/rollout/session/linear_trajectory.py
@@ -64,9 +64,12 @@ class LinearTrajectory:
     in which case the session is rolled back at most one assistant step.
 
     Concurrency contract: all mutating methods must be called under ``self.lock``.
+    ``turn_lock`` serializes protocols that require one complete generation to
+    commit before the next turn for this session is prepared.
     """
 
     lock: asyncio.Lock = field(default_factory=asyncio.Lock, repr=False, compare=False)
+    turn_lock: asyncio.Lock = field(default_factory=asyncio.Lock, repr=False, compare=False)
     closing: bool = field(default=False, repr=False, compare=False)
     request_overrides: dict[str, Any] = field(default_factory=dict, repr=False)
     messages: list[dict[str, Any]] = field(default_factory=list)

--- a/miles/rollout/session/v2/session_state.py
+++ b/miles/rollout/session/v2/session_state.py
@@ -34,9 +34,13 @@ class SessionStateV2:
     active_leaf is what GET /sessions, judgment, and sample assembly see.
     ``None`` means no committed generation yet (empty view, first-turn
     semantics — a failed first turn leaves the session fully retryable).
+
+    ``turn_lock`` serializes protocols that require one complete generation to
+    commit before the next turn for this session is prepared.
     """
 
     lock: asyncio.Lock = field(default_factory=asyncio.Lock, repr=False, compare=False)
+    turn_lock: asyncio.Lock = field(default_factory=asyncio.Lock, repr=False, compare=False)
     closing: bool = field(default=False, repr=False, compare=False)
     request_overrides: dict[str, Any] = field(default_factory=dict, repr=False)
     tree: SessionTree = field(default_factory=SessionTree)

--- a/tests/fast/router/test_anthropic_sessions.py
+++ b/tests/fast/router/test_anthropic_sessions.py
@@ -1,4 +1,6 @@
 import json
+from concurrent.futures import ThreadPoolExecutor
+from threading import Barrier
 from unittest.mock import patch
 
 import pytest
@@ -40,6 +42,42 @@ def _request(**overrides: object) -> dict:
 
 
 class TestAnthropicSessionRoute:
+    def test_concurrent_turns_are_serialized_per_session(self, router_env, monkeypatch) -> None:
+        session_id = _create_session(router_env.url)
+        barrier = Barrier(4)
+        monkeypatch.setattr(router_env.backend, "latency", 0.2)
+        router_env.backend.reset_stats()
+
+        def post_turn() -> requests.Response:
+            barrier.wait()
+            return _post_messages(router_env.url, session_id, _request())
+
+        with ThreadPoolExecutor(max_workers=4) as pool:
+            futures = [pool.submit(post_turn) for _ in range(4)]
+            responses = [future.result() for future in futures]
+
+        assert all(response.status_code == 200 for response in responses)
+        assert len(router_env.backend.request_log) == 4
+        assert router_env.backend.max_concurrent == 1
+
+    def test_different_sessions_remain_parallel(self, router_env, monkeypatch) -> None:
+        session_ids = [_create_session(router_env.url) for _ in range(4)]
+        barrier = Barrier(len(session_ids))
+        monkeypatch.setattr(router_env.backend, "latency", 0.2)
+        router_env.backend.reset_stats()
+
+        def post_turn(session_id: str) -> requests.Response:
+            barrier.wait()
+            return _post_messages(router_env.url, session_id, _request())
+
+        with ThreadPoolExecutor(max_workers=len(session_ids)) as pool:
+            futures = [pool.submit(post_turn, session_id) for session_id in session_ids]
+            responses = [future.result() for future in futures]
+
+        assert all(response.status_code == 200 for response in responses)
+        assert len(router_env.backend.request_log) == len(session_ids)
+        assert router_env.backend.max_concurrent >= 2
+
     def test_session_sampling_overrides_win_over_claude_request(self, router_env) -> None:
         create = requests.post(
             f"{router_env.url}/sessions",


### PR DESCRIPTION
## Summary

- serialize Anthropic Messages turns per session across TITO request preparation, upstream inference, and state commit
- preserve parallel inference across different sessions and leave the direct OpenAI split-lock behavior unchanged
- give both linear and tree session state containers the same turn-ordering primitive

## Why

Claude Code can launch overlapping subagent requests through one Anthropic session. Under the split-lock flow, concurrent requests can prepare from the same checkpoint, race at commit time, and leave one response unrecorded. A later turn may then fail history reconciliation.

The Anthropic adapter represents one ordered client session, so it now queues only turns sharing that session. Independent sessions remain concurrent.

## Tests

- `pytest tests/fast/router/test_anthropic_sessions.py tests/fast/router/test_session_race_conditions.py -q` — 23 passed
- `pytest tests/fast/router/test_sessions_v2.py::TestAnthropicMessages -q` — 2 passed
- `ruff check miles/rollout/session/core.py miles/rollout/session/linear_trajectory.py miles/rollout/session/v2/session_state.py tests/fast/router/test_anthropic_sessions.py`
- Python compile check for all changed Python files

## Stack

Stacked on the Claude Code Harbor integration branch from #2281.


## Current status

Draft: follow-up hardening for overlapping Anthropic turns; not part of the core adapter stack.
