### PR TITLE
session server: assemble collect_samples off the event loop

### DIFF
--- a/miles/rollout/session/core.py
+++ b/miles/rollout/session/core.py
@@ -5,9 +5,10 @@ HTTP-agnostic: the FastAPI adapter (``sessions.py`` + ``server.py``) turns each 
 - ``chat_completions`` strips the R3 replay payloads (``routed_experts`` / ``indexer_topk``) from the client reply copy-on-write; the ``SessionRecord`` keeps the full response for the training path (``GET /sessions/{id}``).
 - ``chat_completions`` holds the per-session lock for prep and state update but not across the proxy call; ``closing`` re-checks and the ``num_assistant`` check gate concurrent DELETE/chat.
 - ``stream: true`` is served as fake streaming: the backend call stays non-streaming (TITO needs the complete message + meta_info) and the full response is re-rendered as a single SSE chunk plus ``data: [DONE]``. Errors all happen before the SSE body is built, so they keep their real status codes as JSON.
-- ``collect_samples`` assembles training Samples from the session's records on the server (compute -> truncate -> merge, synchronously on the loop like the lock-free ``get_session``); deterministic assembly failures return 422 with the assertion text.
+- ``collect_samples`` assembles training Samples from the session's records on the server (compute -> truncate -> merge -> encode) in a worker thread via ``asyncio.to_thread``, because that phase is seconds of CPU on a long agentic trajectory and this process serves every session route from a single event loop; deterministic assembly failures return 422 with the assertion text.
 """
 
+import asyncio
 import json
 import logging
 import time
@@ -271,32 +272,71 @@ class SessionCore:
             content=_render_json(payload.model_dump(mode="json")), status_code=200, media_type=JSON_MEDIA_TYPE
         )
 
+    def _assemble_samples_payload(
+        self,
+        records: list,
+        metadata: dict,
+        tokenizer,
+        max_seq_len: int | None,
+    ) -> bytes | None:
+        """CPU-bound trajectory assembly. Returns the encoded payload, or None if
+        truncation removed every sample.
+
+        Deliberately synchronous and always called off the event loop — see
+        ``collect_samples``. This walks every record and every output token of the
+        trajectory to reconcile ids against the accumulated prefix, then merges and
+        serializes, so on long agentic episodes it is seconds of straight-line
+        Python.
+        """
+        samples = compute_samples_from_openai_records(
+            self.args,
+            records,
+            tokenizer,
+            accumulated_token_ids=metadata.get("accumulated_token_ids"),
+            max_trim_tokens=metadata.get("max_trim_tokens", 0),
+        )
+        if max_seq_len is not None:
+            samples = truncate_samples_by_total_tokens(samples, max_seq_len, tokenizer)
+        if not samples:
+            return None
+        return encode_samples([merge_samples(samples, tokenizer)], metadata)
+
     async def collect_samples(self, session_id: str, *, max_seq_len: int | None) -> Response:
         """Assemble training Samples from this session's records.
 
         Validation failures return 422; unexpected errors propagate.
+
+        The assembly itself runs in a worker thread. The session server is a single
+        process with a single event loop (see ``session/server.py``) and every route
+        — chat completions, delete, and this one — shares it. Assembling a long
+        agentic trajectory is seconds of CPU, and doing that inline stalls every
+        other in-flight request for the duration.
+
+        That stall is not merely slow, it is self-amplifying: a client-side timeout
+        on this endpoint marks the sample ABORTED, and the ``check_no_aborted``
+        dynamic-sampling filter then rejects the sample's whole group, so the
+        rollout relaunches an entire group of episodes onto the server that is
+        already behind. Observed on an 8-node GLM-5.2 run once speculative decoding
+        raised episode-completion rate ~4x: sessions created ran 2.7x the expected
+        count and generation collapsed to ~1 token/s while the rollout never
+        converged.
         """
         session = self.registry.get_session(session_id)
         metadata = self._session_metadata(session_id, session)
         tokenizer = self.registry.tokenizer
         if not session.records:
             return _samples_response(encode_samples([], metadata, empty_reason="no_records"))
+        # Snapshot: the worker thread must not observe records mutating underneath it.
+        records = list(session.records)
         try:
-            samples = compute_samples_from_openai_records(
-                self.args,
-                session.records,
-                tokenizer,
-                accumulated_token_ids=metadata.get("accumulated_token_ids"),
-                max_trim_tokens=metadata.get("max_trim_tokens", 0),
+            payload = await asyncio.to_thread(
+                self._assemble_samples_payload, records, metadata, tokenizer, max_seq_len
             )
-            if max_seq_len is not None:
-                samples = truncate_samples_by_total_tokens(samples, max_seq_len, tokenizer)
-            if not samples:
-                return _samples_response(encode_samples([], metadata, empty_reason="all_truncated"))
-            samples = [merge_samples(samples, tokenizer)]
         except (AssertionError, ValueError) as exc:
             return Response(content=str(exc).encode(), status_code=422, media_type="text/plain")
-        return _samples_response(encode_samples(samples, metadata))
+        if payload is None:
+            return _samples_response(encode_samples([], metadata, empty_reason="all_truncated"))
+        return _samples_response(payload)
 
     async def delete_session(self, session_id: str) -> Response:
         session = self.registry.get_session(session_id)

--- a/tests/fast/rollout/session/test_collect_samples_nonblocking.py
+++ b/tests/fast/rollout/session/test_collect_samples_nonblocking.py
@@ -1,0 +1,119 @@
+"""collect_samples must not assemble trajectories on the event loop.
+
+The session server is one process with one event loop and every route shares it:
+chat completions, delete, and collect. Assembling a long agentic trajectory is
+seconds of straight-line CPU, so doing it inline stalls every other in-flight
+request for the duration.
+
+The stall is self-amplifying rather than merely slow. A client-side timeout on
+collect marks the sample ABORTED, and the ``check_no_aborted`` dynamic-sampling
+filter then rejects that sample's entire group, so the rollout relaunches a whole
+group of episodes onto a server that is already behind.
+"""
+
+import asyncio
+import time
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from miles.rollout.session.core import SessionCore
+
+# Long enough that a blocking implementation is unambiguous, short enough to keep
+# the test fast. Real assembly on a 76k-token trajectory is far slower than this.
+_ASSEMBLE_SECONDS = 0.5
+
+
+def _core_with_slow_assembly(monkeypatch):
+    """A SessionCore whose CPU phase blocks for _ASSEMBLE_SECONDS.
+
+    Patching _assemble_samples_payload (rather than the merge internals) keeps the
+    test pinned to the contract under test: whatever that phase costs, it must not
+    be paid on the event loop.
+    """
+    core = SessionCore.__new__(SessionCore)
+    core.args = SimpleNamespace()
+
+    session = SimpleNamespace(records=[object()], closing=False)
+    registry = MagicMock()
+    registry.get_session.return_value = session
+    registry.tokenizer = MagicMock()
+    core.registry = registry
+
+    monkeypatch.setattr(SessionCore, "_session_metadata", lambda self, sid, s: {}, raising=True)
+
+    def _slow_assemble(self, records, metadata, tokenizer, max_seq_len):
+        time.sleep(_ASSEMBLE_SECONDS)  # stands in for token reconciliation + merge
+        return b"payload"
+
+    monkeypatch.setattr(SessionCore, "_assemble_samples_payload", _slow_assemble, raising=True)
+    return core
+
+
+@pytest.mark.asyncio
+async def test_collect_samples_does_not_block_the_event_loop(monkeypatch):
+    """A concurrent coroutine must keep getting scheduled while collect runs.
+
+    Ticks are counted on a 10ms sleep. If assembly runs inline the loop is frozen
+    and almost no ticks land; off the loop, ticks accrue throughout.
+    """
+    core = _core_with_slow_assembly(monkeypatch)
+
+    ticks = 0
+
+    async def heartbeat():
+        nonlocal ticks
+        while True:
+            await asyncio.sleep(0.01)
+            ticks += 1
+
+    beat = asyncio.create_task(heartbeat())
+    try:
+        response = await core.collect_samples("sid", max_seq_len=None)
+    finally:
+        beat.cancel()
+
+    assert response.status_code == 200
+    assert response.body == b"payload"
+
+    # ~50 ticks are available across a 0.5s assembly. Require a clear majority so
+    # the test fails loudly on the inline version (which yields ~0) without being
+    # brittle about scheduler jitter.
+    assert ticks >= 25, (
+        f"event loop was starved during collect_samples: only {ticks} heartbeat ticks "
+        f"in {_ASSEMBLE_SECONDS}s -- trajectory assembly is running inline on the loop"
+    )
+
+
+@pytest.mark.asyncio
+async def test_collect_samples_all_truncated_still_returns_empty_payload(monkeypatch):
+    """The None sentinel from the worker maps back to the all_truncated reply."""
+    core = _core_with_slow_assembly(monkeypatch)
+    monkeypatch.setattr(
+        SessionCore,
+        "_assemble_samples_payload",
+        lambda self, records, metadata, tokenizer, max_seq_len: None,
+        raising=True,
+    )
+    response = await core.collect_samples("sid", max_seq_len=8)
+    assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_collect_samples_validation_error_still_maps_to_422(monkeypatch):
+    """Exceptions raised inside the worker thread must surface unchanged.
+
+    asyncio.to_thread re-raises in the awaiting coroutine, so the existing
+    AssertionError/ValueError -> 422 contract has to keep holding across the
+    thread boundary.
+    """
+    core = _core_with_slow_assembly(monkeypatch)
+
+    def _boom(self, records, metadata, tokenizer, max_seq_len):
+        raise ValueError("bad records")
+
+    monkeypatch.setattr(SessionCore, "_assemble_samples_payload", _boom, raising=True)
+    response = await core.collect_samples("sid", max_seq_len=None)
+    assert response.status_code == 422
+    assert b"bad records" in response.body


### PR DESCRIPTION
## Problem

The session server is a single process with a single event loop (`miles/rollout/session/server.py`), and every route shares it — chat completions, `DELETE`, and `collect_samples`. But `collect_samples` reconciled, truncated, merged and encoded the entire trajectory **inline on that loop**:

```python
samples = compute_samples_from_openai_records(...)   # walks every record, every output token
samples = truncate_samples_by_total_tokens(...)
samples = [merge_samples(samples, tokenizer)]
```

There is no `run_in_executor` / `to_thread` / thread pool anywhere in `miles/rollout/session/`. On a long agentic episode this is seconds of straight-line Python, and for its whole duration the server answers nothing else.

## Why it is worse than "slow"

The stall is self-amplifying. A client-side timeout on collect marks the sample `ABORTED` (`generate_hub/agentic_tool_call.py`), and the `check_no_aborted` dynamic-sampling filter then rejects **that sample's entire group** — so the rollout relaunches a whole group of episodes onto a server that is already behind.

One blocked assembly therefore costs 8 new episodes (at `n_samples_per_prompt=8`), which produce more collects, which block the loop further.

## Evidence

Observed on an 8-node GLM-5.2 744B Terminal-Bench-2 run once EAGLE speculative decoding raised episode-completion rate ~4×. Two runs died identically during the step-2 rollout:

| run | sessions created | expected | collect timeouts | failed deletes |
|---|---|---|---|---|
| A | 623 | 232 | 60 | 59 |
| B | 639 | 232 | 86 | 66 |

A control run with speculative decoding **off** held sessions to 1.1× expected with zero timeouts and zero failed deletes.

The excess matches the amplifier: 391 extra sessions ÷ 8 per group ≈ 49 rejected groups, against 60 observed collect timeouts. In both failures generation collapsed to ~1 token/s while fresh sandboxes churned — the cluster busy *starting* work it had already lost the ability to collect.

## Change

Move the CPU phase into `_assemble_samples_payload` and `await asyncio.to_thread(...)` it. `session.records` is snapshotted so the worker cannot race concurrent appends.

Response contracts are unchanged:
- `no_records` — unchanged, still on the loop (trivial)
- `all_truncated` — now signalled by a `None` sentinel returned from the worker
- `AssertionError` / `ValueError` → 422 — still holds, since `to_thread` re-raises in the awaiting coroutine

Also corrects the module docstring, which explicitly documented the old behaviour (*"synchronously on the loop like the lock-free `get_session`"*).

## Test

`tests/fast/rollout/session/test_collect_samples_nonblocking.py` counts heartbeat ticks on a concurrent coroutine while a 0.5s assembly runs. ~50 ticks are available; it requires ≥25. The inline version yields essentially zero.

Verified as a genuine regression test rather than a decorative one:

```
fixed code  → 3 passed
inline code → 1 failed, 2 passed     # the blocking test catches the bug
```

The two semantic tests (`all_truncated`, 422) pass either way, which is correct — they don't depend on threading.

Full session suite: **45 passed**.

## Notes for reviewers

- HuggingFace fast tokenizers release the GIL in Rust, so the worker thread genuinely runs in parallel rather than just deferring the stall.
- This does not change how much CPU the assembly costs, only where it is paid. A server under sustained overload will still fall behind; this removes the pathological coupling where one slow assembly times out *unrelated* requests.
- Worth considering separately: `check_no_aborted` discarding an entire group for one infrastructure-caused abort is what converts a hiccup into an avalanche. That seemed out of scope here.
