### PR TITLE
docs: polish the Quick Start page

### DIFF
--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -12,10 +12,7 @@ This page takes you from `docker pull` to a running GRPO training job on Qwen3-4
 
 **What you will accomplish**
 
-- Start the Miles container.
-- Download a model and two math datasets.
-- Convert the model to Megatron's checkpoint format.
-- Launch a GRPO run and watch the reward climb.
+- Launch a GRPO run and watch the reward climb!
 
 Training a different model? The flow is the same — see [Models](/models/index) for
 the per-model recipes.
@@ -44,23 +41,20 @@ latest main:
 cd /root/miles && git pull && pip install -e . --no-deps
 ```
 
-Everything from here on runs inside the container.
+**Everything from here on runs inside the container.**
 
 ## Step 2: Download the model and data
 
-Three downloads: the model you will train, prompts to train on, and a benchmark to
-evaluate against.
+Three downloads:
 
 ```bash
+# The model you will train
 hf download Qwen/Qwen3-4B --local-dir /root/Qwen3-4B
+# Training prompts: 17k math problems with checkable answers
 hf download --repo-type dataset BytedTsinghua-SIA/DAPO-Math-17K --local-dir /root/dapo-math-17k
+# Eval benchmark: harder problems, evaluated on but never trained on
 hf download --repo-type dataset zhuzilin/aime-2024 --local-dir /root/aime-2024
 ```
-
-[DAPO-Math-17K](https://huggingface.co/datasets/BytedTsinghua-SIA/DAPO-Math-17K) is
-17k math problems with checkable answers.
-[AIME-2024](https://huggingface.co/datasets/zhuzilin/aime-2024) is a small, harder
-set the run evaluates on — but never trains on.
 
 ## Step 3: Convert to Megatron format
 
@@ -87,7 +81,7 @@ it.
 bash scripts/run-qwen3-4B.sh
 ```
 
-That's it — the script starts a local Ray cluster and submits the training job.
+That's it — the script starts a local Ray cluster and submits the training job!
 A few things it already does for you:
 
 - Checkpoints land in `/root/Qwen3-4B_miles/` every 20 rollouts.
@@ -96,6 +90,12 @@ A few things it already does for you:
   checkpoint.
 - The Ray dashboard at `http://localhost:8265` shows per-worker logs and GPU
   usage.
+
+And treat yourself to the [Miles dashboard](/user-guide/dashboard): add
+`--dump-details <dir> --use-miles-dashboard` to the training arguments, serve it
+with `python -m miles.dashboard.serve --dump-details <dir>`, and open
+`http://localhost:7788` to watch what every GPU was doing during a step and what
+every trajectory contained, token by token.
 
 Once the engines warm up and the first rollout completes, the log settles into
 per-rollout metric lines (values illustrative, keys abridged):

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -1,47 +1,55 @@
 ---
 title: Quick Start
-description: A working RL training job on Qwen3-4B in under an hour.
+description: A quick RL training job on Qwen3-4B in under an hour.
 ---
-This page takes you from `docker pull` to a running GRPO training job on Qwen3-4B. It
-assumes an 8-GPU node (H100 / H200 / B-series) and roughly 200 GB of disk. For other
-models, see [Models](/models/index).
+This page takes you from `docker pull` to a running GRPO training job on Qwen3-4B.
 
-A Miles job combines two engines: [SGLang](https://github.com/sgl-project/sglang)
-generates responses from the current policy (the *rollout*), and
-[Megatron-LM](https://github.com/NVIDIA/Megatron-LM) updates the policy from those
-responses (the *training*). In this recipe both share the same 8 GPUs.
+**What you need**
 
-## 1. Start the container
+- A node with 8 GPUs (H100 / H200 / B-series).
+- Roughly 200 GB of free disk.
+- Docker with GPU access.
+
+**What you will accomplish**
+
+- Start the Miles container.
+- Download a model and two math datasets.
+- Convert the model to Megatron's checkpoint format.
+- Launch a GRPO run and watch the reward climb.
+
+Training a different model? The flow is the same — see [Models](/models/index) for
+the per-model recipes.
+
+## Step 1: Start the container
 
 On the **host**:
 
 ```bash
 docker pull radixark/miles:latest
 docker run --rm \
-  --gpus all --ipc=host --shm-size=32g \
-  --ulimit memlock=-1 --ulimit stack=67108864 \
+  --gpus all \
+  --ipc=host \
+  --shm-size=32g \
+  --ulimit memlock=-1 \
+  --ulimit stack=67108864 \
   --network=host \
   -it radixark/miles:latest /bin/bash
 ```
 
-The flags matter: `--gpus all` exposes the GPUs, `--ipc=host` and `--shm-size=32g`
-give NCCL and Ray the shared memory they need, and `--network=host` lets you reach
-the Ray dashboard from the host.
-
-That drops you into a shell inside the container. The image ships with Miles at
-`/root/miles` and Megatron-LM at `/root/Megatron-LM`. Refresh the editable install
-so you run the latest main:
+That drops you into a shell inside the container, with Miles at `/root/miles` and
+Megatron-LM at `/root/Megatron-LM`. Refresh the editable install so you run the
+latest main:
 
 ```bash
 cd /root/miles && git pull && pip install -e . --no-deps
 ```
 
-Steps 2–4 below all run inside the container.
+Everything from here on runs inside the container.
 
-## 2. Download model and data
+## Step 2: Download the model and data
 
-Three artifacts are needed: the model you will train, a training prompt set, and an
-evaluation set.
+Three downloads: the model you will train, prompts to train on, and a benchmark to
+evaluate against.
 
 ```bash
 hf download Qwen/Qwen3-4B --local-dir /root/Qwen3-4B
@@ -49,19 +57,15 @@ hf download --repo-type dataset BytedTsinghua-SIA/DAPO-Math-17K --local-dir /roo
 hf download --repo-type dataset zhuzilin/aime-2024 --local-dir /root/aime-2024
 ```
 
-Qwen3-4B is the starting policy.
-[DAPO-Math-17K](https://huggingface.co/datasets/BytedTsinghua-SIA/DAPO-Math-17K)
-supplies the training prompts — math problems whose ground-truth labels the reward
-function checks answers against.
+[DAPO-Math-17K](https://huggingface.co/datasets/BytedTsinghua-SIA/DAPO-Math-17K) is
+17k math problems with checkable answers.
 [AIME-2024](https://huggingface.co/datasets/zhuzilin/aime-2024) is a small, harder
-benchmark used only for periodic evaluation, never for training.
+set the run evaluates on — but never trains on.
 
-## 3. Convert to Megatron format
+## Step 3: Convert to Megatron format
 
-Megatron consumes a `torch_dist` checkpoint, not the raw HuggingFace directory. The
-`source` line below loads `MODEL_ARGS`, the Megatron-side description of the
-architecture (layer count, hidden sizes, attention layout); the converter uses it to
-map the HuggingFace weights into a sharded `torch_dist` checkpoint.
+Megatron reads its own sharded checkpoint format, so convert the HuggingFace
+weights once:
 
 ```bash
 cd /root/miles
@@ -74,34 +78,27 @@ PYTHONPATH=/root/Megatron-LM python tools/convert_hf_to_torch_dist.py \
    --save /root/Qwen3-4B_torch_dist
 ```
 
-Keep the original HuggingFace directory too — the launch script still points the
-SGLang engines at it (`--hf-checkpoint`).
+Keep the original HuggingFace directory too — the rollout engines still read from
+it.
 
-## 4. Launch training
+## Step 4: Launch training
 
 ```bash
 bash scripts/run-qwen3-4B.sh
 ```
 
-The script is organized into named argument groups (`CKPT_ARGS`, `ROLLOUT_ARGS`,
-`GRPO_ARGS`, and so on) and is meant to be read and edited — it is the canonical
-place to change hyperparameters. When launched, it starts a local Ray cluster and
-submits `train.py` as a Ray job. The run is colocated (`--colocate`): the four
-SGLang engines (2 GPUs each) and the Megatron trainer share the same 8 GPUs,
-alternating between generation and training phases.
+That's it — the script starts a local Ray cluster and submits the training job.
+A few things it already does for you:
 
-A few defaults worth knowing on a first run:
+- Checkpoints land in `/root/Qwen3-4B_miles/` every 20 rollouts.
+- The policy is evaluated on AIME-2024 every 20 rollouts.
+- If the run dies, relaunch the same script — training resumes from the last
+  checkpoint.
+- The Ray dashboard at `http://localhost:8265` shows per-worker logs and GPU
+  usage.
 
-- Checkpoints are written to `/root/Qwen3-4B_miles/` every 20 rollouts
-  (`--save-interval 20`).
-- The policy is evaluated on AIME-2024 every 20 rollouts (`--eval-interval 20`).
-- If the run dies, relaunch the same script — `--load` points at the save
-  directory, so training resumes from the last checkpoint.
-- The Ray dashboard at `http://localhost:8265` shows per-worker logs and GPU usage.
-
-After the engines start up and the first rollout completes, the job log settles into
-per-rollout metric lines. The values below are illustrative, and each line carries
-more keys than shown:
+Once the engines warm up and the first rollout completes, the log settles into
+per-rollout metric lines (values illustrative, keys abridged):
 
 ```text
 perf 0: {'perf/rollout_time': 98.6, ...}
@@ -110,15 +107,16 @@ step 0: {'train/loss': 0.0021, 'train/pg_loss': 0.0018, 'train/grad_norm': 0.62,
 perf 0: {'perf/train_wait_time': 101.2, 'perf/actor_train_time': 41.3, ...}
 ```
 
-`rollout/raw_reward` is the mean reward of the freshly scored responses — the number
-to watch. The `step` line reports each optimizer step, and the two `perf` lines time
-the generation side (`perf/rollout_time`) and the training side
-(`perf/actor_train_time`) of the iteration. The same metrics go to wandb when
-`--use-wandb` is set.
+`rollout/raw_reward` is the number to watch: the mean reward of the freshly scored
+responses, drifting upward as the policy improves. You have a live RL run.
 
-## 5. What's happening
+## What's happening
 
-Each iteration runs the same four steps:
+A Miles job combines two engines: [SGLang](https://github.com/sgl-project/sglang)
+generates responses from the current policy (the *rollout*), and
+[Megatron-LM](https://github.com/NVIDIA/Megatron-LM) updates the policy from those
+responses (the *training*). In this recipe both share the same 8 GPUs, taking
+turns.
 
 ```mermaid
 flowchart LR
@@ -129,32 +127,53 @@ flowchart LR
     A -. KL .-> Ref[(Reference model)]
 ```
 
-1. Sample `rollout-batch-size` prompts from the dataset and let the SGLang engines
-   generate `n-samples-per-prompt` candidate responses for each.
-2. Score every response with the reward function — `--rm-type deepscaler` in this
-   recipe, a rule-based verifier that compares the model's final answer against the
-   dataset label.
-3. Compute the GRPO objective from the scored responses and step the optimizer. The
-   frozen reference model provides the optional KL regularization term (this recipe
-   sets `--kl-loss-coef 0.00`, so the term is off).
-4. Push the updated weights back to the SGLang engines. In this colocated recipe the
-   trainer and the engines share the same GPUs, so each rank gathers its weight shards
-   over NCCL, converts them to the HuggingFace layout, and hands them to its local
-   engine through IPC — no network transfer is involved. Disaggregated runs choose a
-   transport with `--update-weight-transfer-mode` instead: the default `broadcast`
-   sends the weights from the trainer to the engines over NCCL, while `p2p` writes
-   them point-to-point over RDMA (via the Mooncake transfer engine) rather than using
-   a collective; `p2p` cannot be combined with `--colocate`.
+Every iteration runs the same loop:
 
-The four batch-sizing knobs satisfy:
+1. Sample a batch of prompts and let the SGLang engines generate several candidate
+   responses per prompt.
+2. Score every response — the reward function checks each final answer against the
+   dataset label.
+3. Compute the GRPO objective from the scores and step the optimizer.
+4. Sync the updated weights back into the SGLang engines, and go again.
+
+The batch-sizing knobs satisfy one identity, and Miles fills in whichever side you
+leave unset:
 
 ```
 rollout_batch_size × n_samples_per_prompt
   = global_batch_size × num_steps_per_rollout
 ```
 
-Miles fills in whichever side you leave unset. In this recipe, 32 prompts × 8
-samples = 256 = one optimizer step at global batch size 256.
+In this recipe, 32 prompts × 8 samples = 256 = one optimizer step at global batch
+size 256.
+
+### The details behind each step
+
+- **The docker flags (Step 1).** `--gpus all` exposes the GPUs, `--ipc=host` and
+  `--shm-size=32g` give NCCL and Ray the shared memory they need, and
+  `--network=host` lets you reach the Ray dashboard from the host.
+- **`MODEL_ARGS` (Step 3).** The Megatron-side description of the architecture
+  (layer count, hidden sizes, attention layout). The converter uses it to map the
+  HuggingFace weights into a sharded `torch_dist` checkpoint.
+- **The launch script (Step 4).** `scripts/run-qwen3-4B.sh` is organized into named
+  argument groups (`CKPT_ARGS`, `ROLLOUT_ARGS`, `GRPO_ARGS`, and so on) and is meant
+  to be read and edited — it is the canonical place to change hyperparameters, such
+  as `--save-interval`, `--eval-interval`, or `--use-wandb` to mirror every metric
+  to wandb.
+- **Colocation.** The recipe sets `--colocate`: four SGLang engines (2 GPUs each)
+  and the Megatron trainer share the same 8 GPUs, alternating between generation
+  and training. Sharing GPUs also makes the weight sync local — each rank gathers
+  its shards over NCCL and hands them to its engine through IPC, no network
+  involved. Disaggregated runs choose a transport with
+  `--update-weight-transfer-mode`: `broadcast` (the default, over NCCL) or `p2p`
+  (point-to-point RDMA via Mooncake; incompatible with `--colocate`).
+- **The reward function.** `--rm-type deepscaler` — a rule-based verifier, no
+  learned reward model.
+- **KL regularization.** The frozen reference model can add a KL term to the loss;
+  this recipe sets `--kl-loss-coef 0.00`, so the term is off.
+- **The metric lines (Step 4).** The `step` line reports each optimizer step, and
+  the two `perf` lines time the generation side (`perf/rollout_time`) and the
+  training side (`perf/actor_train_time`) of each iteration.
 
 ## Inspecting a run
 

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -2,8 +2,6 @@
 title: Quick Start
 description: A quick RL training job on Qwen3-4B in under an hour.
 ---
-This page takes you from `docker pull` to a running GRPO training job on Qwen3-4B.
-
 **What you need**
 
 - A node with 8 GPUs (H100 / H200 / B-series).
@@ -63,9 +61,11 @@ weights once:
 
 ```bash
 cd /root/miles
+# Load MODEL_ARGS, the Megatron-side description of the architecture
 MODEL_ARGS_LINE="$(python3 miles/utils/external_utils/model_args_utils.py qwen3-4B)" || exit 1
 read -ra MODEL_ARGS <<< "${MODEL_ARGS_LINE}"
 
+# Map the HuggingFace weights into a sharded torch_dist checkpoint
 PYTHONPATH=/root/Megatron-LM python tools/convert_hf_to_torch_dist.py \
    ${MODEL_ARGS[@]} \
    --hf-checkpoint /root/Qwen3-4B \
@@ -88,14 +88,10 @@ A few things it already does for you:
 - The policy is evaluated on AIME-2024 every 20 rollouts.
 - If the run dies, relaunch the same script — training resumes from the last
   checkpoint.
-- The Ray dashboard at `http://localhost:8265` shows per-worker logs and GPU
-  usage.
-
-And treat yourself to the [Miles dashboard](/user-guide/dashboard): add
-`--dump-details <dir> --use-miles-dashboard` to the training arguments, serve it
-with `python -m miles.dashboard.serve --dump-details <dir>`, and open
-`http://localhost:7788` to watch what every GPU was doing during a step and what
-every trajectory contained, token by token.
+- The [Miles dashboard](/user-guide/dashboard) records what every GPU was doing
+  during a step and what every trajectory contained, token by token. Serve it with
+  `python -m miles.dashboard.serve --dump-details /root/Qwen3-4B_miles/dump_details`
+  and open `http://localhost:7788`.
 
 Once the engines warm up and the first rollout completes, the log settles into
 per-rollout metric lines (values illustrative, keys abridged):
@@ -147,7 +143,7 @@ rollout_batch_size × n_samples_per_prompt
 In this recipe, 32 prompts × 8 samples = 256 = one optimizer step at global batch
 size 256.
 
-### The details behind each step
+### The fine print
 
 - **The docker flags (Step 1).** `--gpus all` exposes the GPUs, `--ipc=host` and
   `--shm-size=32g` give NCCL and Ray the shared memory they need, and

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -143,7 +143,7 @@ rollout_batch_size × n_samples_per_prompt
 In this recipe, 32 prompts × 8 samples = 256 = one optimizer step at global batch
 size 256.
 
-### The fine print
+### 🔍 The fine print
 
 - **The docker flags (Step 1).** `--gpus all` exposes the GPUs, `--ipc=host` and
   `--shm-size=32g` give NCCL and Ray the shared memory they need, and
@@ -171,13 +171,13 @@ size 256.
   the two `perf` lines time the generation side (`perf/rollout_time`) and the
   training side (`perf/actor_train_time`) of each iteration.
 
-## Inspecting a run
+### Inspecting a run
 
 | Question | Where to look |
 |---|---|
 | Is the policy learning? | `rollout/raw_reward` in stdout, or wandb |
 | Rollout or train bottleneck? | `perf/rollout_time` vs. `perf/actor_train_time` |
-| Are GPUs saturated? | `nvidia-smi dmon -s u` |
+| Are GPUs saturated? | The [Miles dashboard](/user-guide/dashboard) GPU timeline |
 | SGLang internals? | Ray worker logs under `~/.ray/session_latest/logs/`; raise verbosity with `--sglang-log-level` |
 | Ranks crashing? | `~/.ray/session_latest/logs/worker-*.err` |
 

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -143,7 +143,7 @@ rollout_batch_size × n_samples_per_prompt
 In this recipe, 32 prompts × 8 samples = 256 = one optimizer step at global batch
 size 256.
 
-### 🔍 The fine print
+### The fine print 🔍
 
 - **The docker flags (Step 1).** `--gpus all` exposes the GPUs, `--ipc=host` and
   `--shm-size=32g` give NCCL and Ray the shared memory they need, and
@@ -171,7 +171,7 @@ size 256.
   the two `perf` lines time the generation side (`perf/rollout_time`) and the
   training side (`perf/actor_train_time`) of each iteration.
 
-### Inspecting a run
+### Inspecting a run 📊
 
 | Question | Where to look |
 |---|---|

--- a/scripts/run-qwen3-4B.sh
+++ b/scripts/run-qwen3-4B.sh
@@ -114,6 +114,11 @@ PROMETHEUS_ARGS=(
    # --prometheus-run-name "qwen3-4B-exp"
 )
 
+DASHBOARD_ARGS=(
+   --use-miles-dashboard
+   --dump-details /root/Qwen3-4B_miles/dump_details
+)
+
 MISC_ARGS=(
    # default dropout in megatron is 0.1
    --attention-dropout 0.0
@@ -154,4 +159,5 @@ ray job submit --address="http://127.0.0.1:8265" \
    ${EVAL_ARGS[@]} \
    ${SGLANG_ARGS[@]} \
    ${PROMETHEUS_ARGS[@]} \
+   ${DASHBOARD_ARGS[@]} \
    ${MISC_ARGS[@]}


### PR DESCRIPTION
## Summary

Polishes the docs Quick Start page (`docs/getting-started/quick-start.md`) per the suggestions in #2297. Closes #2297.

- The page description now promises "a quick RL training job" instead of "a working RL training job".
- The intro gains two bullet lists — **What you need** (8 GPUs, ~200 GB disk, Docker) and **What you will accomplish** — so readers can size up the page at a glance.
- The "A Miles job combines two engines" paragraph moves from the intro to the top of **What's happening**, where the mental model belongs.
- Section headings switch from `## 1. Start the container` to `## Step 1: Start the container` (and so on), and the `docker run` command now puts one flag per line.
- The steps themselves are leaner and friendlier: flag-by-flag explanations no longer interrupt the walkthrough.
- All technical explanations now live at the end of the page in **What's happening** (no step number), under a new "The details behind each step" list: docker flags, `MODEL_ARGS`, launch-script anatomy, colocation and weight-sync transports, the reward function, KL regularization, and the metric lines.
- The loop description in **What's happening** is shortened to four plain-language steps; the transport details that used to bloat its step 4 moved into the colocation bullet.

No content is lost — everything that was explained before is still explained, just in the right place. The "Inspecting a run" table and "Next steps" section are unchanged.

## Test plan

- [ ] Page renders correctly in the Mintlify preview (headings, mermaid diagram, tables)
- [ ] No other docs page links to the renamed `## N. …` anchors (checked: none do)
- [ ] Commands are unchanged from `main` (including the `model_args_utils.py` MODEL_ARGS line)
