### PR TITLE
scripts: enable the Miles dashboard in the quick-start launcher

### DIFF
--- a/scripts/run-qwen3-4B.sh
+++ b/scripts/run-qwen3-4B.sh
@@ -114,6 +114,11 @@ PROMETHEUS_ARGS=(
    # --prometheus-run-name "qwen3-4B-exp"
 )
 
+DASHBOARD_ARGS=(
+   --use-miles-dashboard
+   --dump-details /root/Qwen3-4B_miles/dump_details
+)
+
 MISC_ARGS=(
    # default dropout in megatron is 0.1
    --attention-dropout 0.0
@@ -154,4 +159,5 @@ ray job submit --address="http://127.0.0.1:8265" \
    ${EVAL_ARGS[@]} \
    ${SGLANG_ARGS[@]} \
    ${PROMETHEUS_ARGS[@]} \
+   ${DASHBOARD_ARGS[@]} \
    ${MISC_ARGS[@]}


### PR DESCRIPTION
## Summary

Enables the [Miles dashboard](https://miles.radixark.com/docs/user-guide/dashboard) in the quick-start launcher `scripts/run-qwen3-4B.sh`:

- Adds a `DASHBOARD_ARGS` group with `--use-miles-dashboard` and `--dump-details /root/Qwen3-4B_miles/dump_details`, and passes it to `train.py`.
- The dump path sits next to the recipe's checkpoint directory (`/root/Qwen3-4B_miles/`), following the `<output>/…/dump_details` convention used by the Python launchers.

This is the first thing a new user runs, so the run they launch should come with the dashboard's GPU timeline and token-level trajectory views out of the box — the docs Quick Start page (#2298, stacked on this PR) points readers at `python -m miles.dashboard.serve --dump-details /root/Qwen3-4B_miles/dump_details`.

Telemetry collection is fire-and-forget and adds only milliseconds per step, so the demo run's performance is unaffected. `--use-rollout-entropy` is deliberately not added: without it the launcher just logs a warning that per-token entropy is missing from the token view, and the quick-start run stays as cheap as possible.

## Test plan

- [ ] `bash -n scripts/run-qwen3-4B.sh` parses
- [ ] Quick-start run starts and writes JSONL telemetry under `/root/Qwen3-4B_miles/dump_details/dashboard/`
- [ ] `python -m miles.dashboard.serve --dump-details /root/Qwen3-4B_miles/dump_details` renders the run at `http://localhost:7788`
