### PR TITLE
Bump sglang to v0.5.17

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,12 +10,12 @@
 # release for the current arch picked from TARGETARCH — WHEELS_TAG_X86 on amd64,
 # WHEELS_TAG_ARM64 on arm64 (cu12-x86 overrides WHEELS_TAG_X86).
 
-ARG SGLANG_IMAGE_TAG=v0.5.16
+ARG SGLANG_IMAGE_TAG=v0.5.17
 FROM lmsysorg/sglang:${SGLANG_IMAGE_TAG} AS sglang
 
 # ======================================== Arguments =============================================
 
-ARG SGLANG_BRANCH=sglang-miles
+ARG SGLANG_BRANCH=sglang-miles-v0.5.17
 ARG SGLANG_COMMIT=""
 
 ARG MEGATRON_REPO=radixark/Megatron-LM

--- a/docker/build.py
+++ b/docker/build.py
@@ -45,7 +45,7 @@ VARIANTS = {
         "tag_postfix": "-cu12",
         "build_args": {
             "ENABLE_CUDA_13": "0",
-            "SGLANG_IMAGE_TAG": "v0.5.16-cu129",
+            "SGLANG_IMAGE_TAG": "v0.5.17-cu129",
             "WHEELS_TAG_X86": "cu129-x86_64",
         },
     },


### PR DESCRIPTION
Rebases the `sglang-miles` stack onto the `v0.5.17` tag and repoints the miles images at it.

## sglang side

`sglang-miles-v0.5.17` = 35 commits on `v0.5.17` (previous stack was 36; rollback point is `sglang-miles-v0.5.16-final`).

**Dropped:** the `#32861` Inkling tool-call cherry-pick — it is in v0.5.17, and v0.5.17's copy is newer (it extends `get_auto_tool_call_structural_tag` with `thinking_mode` / `parallel_tool_calls`), so carrying ours would regress the signature.

**Notable conflict decisions** (v0.5.17 has absorbed a fair amount of this stack, usually refactored):

- *MoE-LoRA*: `lora_active` and `_effective_tp_size` upstream are our logic rewritten — took the newer structure for 15 of 21 hunks. Kept our base-layer parameter aliasing and the MoE cuda-graph heuristic (ordered before v0.5.17's prefill-graph decision, which it feeds). One genuine conflict of intent: on a DP-attention idle forward upstream *clears* LoRA batch state while we *re-prepare* it; upstream's "zero local tokens means nothing to do" holds for dense LoRA but not for MoE, where an idle rank still runs its local experts over the gathered tokens — split on `is_moe_lora`.
- *attn_sink*: v0.5.17's `_local_attn_sink()` still caches and never refreshes, i.e. it has exactly the staleness bug our fix addresses, so our `refresh_attn_sink_cache` version was kept.
- *RowParallelLinear*: v0.5.17 added a caller-owned `output_tensor` path; our tp-invariant branch takes precedence and the unsupported combination raises rather than silently ignoring the caller's buffer.
- *tp_worker*: our session redesign removes `update_weights_from_{distributed,tensor}`, but v0.5.17's new `_deserialize_own_rank` is still used by `load_lora_adapter_from_tensors`, so it stays.
- *cohere2_moe*: v0.5.17 rewrote the config back to `__init__` style, so our dataclass adaptations no longer have a target — took upstream's file wholesale.
- *abort-by-prefix*: merged with v0.5.17's parallel-sampling child-rid resolution; a prefix abort travels as one request since the scheduler matches by prefix.

Also restored six imports the picks dropped (`torch_npu`, `ScatterMode`, `eager_on_graph`, `get_tc_piecewise_forward_context`, `attn_tp_all_gather_into_tensor`, `BaseIndexerMetadata`) plus the `_use_ag_after_qlora` module flag, and repointed `enable_deterministic_inference` to v0.5.17's namespaced accessor.

## miles side

- `docker/Dockerfile`: `SGLANG_IMAGE_TAG=v0.5.17`, `SGLANG_BRANCH=sglang-miles-v0.5.17` (switched to the stable `sglang-miles` name at merge time).
- `docker/build.py`: release variant pinned to `v0.5.17-cu129`.
- The cu12 `pyproject.toml` rewrite block was checked against v0.5.17's upstream Dockerfile — the three markers are unchanged, so the block still applies as-is.

Rust files are untouched; the local rustfmt/clippy hooks fail only because this machine has no `cargo`.