### PR TITLE
Add Delightful Policy Gradient (DG) gating for the policy loss

### DIFF
--- a/miles/backends/training_utils/loss_hub/losses.py
+++ b/miles/backends/training_utils/loss_hub/losses.py
@@ -13,6 +13,7 @@ from miles.backends.training_utils.loss_hub.corrections import vanilla_tis_funct
 from miles.backends.training_utils.loss_hub.logit_processors import get_log_probs_and_entropy, get_values
 from miles.backends.training_utils.loss_hub.math_utils import (
     compute_approx_kl,
+    compute_delight_gate,
     compute_ess_ratio_contribution,
     compute_gspo_kl,
     compute_opsm_mask,
@@ -218,6 +219,18 @@ def policy_loss_function(
     if args.use_opsm:
         pg_loss = pg_loss * opsm_mask
 
+    # Delightful Policy Gradient (arXiv:2603.14608): rescale every per-token term
+    # by a sigmoid of delight (advantage x surprisal).  Applied to the already
+    # clipped `pg_loss` so it composes with GRPO/GSPO rather than replacing them.
+    if args.use_delight:
+        delight_gate, delight_metrics = compute_delight_gate(
+            args=args,
+            log_probs=log_probs,
+            advantages=advantages,
+            active_tokens=active_tokens,
+        )
+        pg_loss = pg_loss * delight_gate
+
     # Apply off-policy correction using importance sampling if enabled
     if args.get_mismatch_metrics or args.use_tis:
         # NOTE:
@@ -379,6 +392,10 @@ def policy_loss_function(
 
     if args.use_opsm:
         reported_loss["opsm_clipfrac"] = opsm_clipfrac
+
+    if args.use_delight:
+        for metric_key, metric_value in delight_metrics.items():
+            reported_loss[metric_key] = sum_of_sample_mean(metric_value).clone().detach()
 
     # Add OPD metrics if available
     if batch.get("opd_reverse_kl") is not None:

--- a/miles/backends/training_utils/loss_hub/math_utils.py
+++ b/miles/backends/training_utils/loss_hub/math_utils.py
@@ -14,6 +14,7 @@ from miles.backends.training_utils.cp_utils import (
     slice_loss_masks_for_local_cp,
 )
 from miles.backends.training_utils.parallel import get_parallel_state
+from miles.utils.distributed_utils import distributed_masked_whiten
 
 _LOG_RATIO_EXP_CLAMP = 20.0
 
@@ -219,6 +220,68 @@ def compute_opsm_mask(
 
     opsm_mask = torch.cat(opsm_mask_list, dim=0)
     return opsm_mask, opsm_clipfrac
+
+
+def compute_delight_gate(
+    args: Namespace,
+    log_probs: torch.Tensor,
+    advantages: torch.Tensor,
+    active_tokens: torch.Tensor,
+) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
+    """Compute the per-token Delightful Policy Gradient (DG) gate.
+
+    Follows Algorithm 1 of "Delightful Policy Gradient" (arXiv:2603.14608).
+    Each token is one action, so surprisal is the per-token quantity
+    `l_t = -log pi(a_t | h_t)`, delight is `chi_t = U_t * l_t`, and the gate is
+    `w_t = sigmoid(chi_t / eta)`.  DG replaces the standard term `g_t` with
+    `w_t * g_t`; the gate is therefore a *coefficient*, so it is detached and
+    contributes no gradient path of its own.
+
+    Under a group-relative advantage (GRPO) `U_t` is constant across a response,
+    so the gate varies within a response only through surprisal: on a
+    high-advantage response it amplifies the tokens the policy found unlikely
+    ("breakthroughs"), and on a low-advantage response it attenuates them
+    ("blunders") while leaving confident tokens near the neutral value.
+
+    Args:
+        args: Configuration providing `delight_temperature`,
+            `delight_max_surprisal`, `delight_unit_gain`, and `delight_whiten`.
+        log_probs: Current-policy per-token log-probs, concatenated `[T]`.
+        advantages: Per-token advantages, concatenated `[T]`.
+        active_tokens: Boolean mask of tokens that contribute to the loss `[T]`.
+
+    Returns:
+        Tuple of `(gate, metrics)` where `gate` is a detached `[T]` coefficient
+        and `metrics` holds detached per-token diagnostics for aggregation.
+    """
+    surprisal = (-log_probs.detach()).clamp(min=0.0, max=args.delight_max_surprisal)
+    delight = advantages.detach().float() * surprisal.float()
+
+    if args.delight_whiten:
+        # Appendix E.1: gate on standardised delight when the raw scale is
+        # uninformative.  Statistics are masked and reduced across the DP group
+        # so every micro-batch shares one normalisation.
+        delight = distributed_masked_whiten(
+            delight,
+            active_tokens.to(dtype=delight.dtype),
+            process_group=get_parallel_state().intra_dp.group,
+            shift_mean=False,
+        )
+
+    gate = torch.sigmoid(delight / args.delight_temperature)
+    if args.delight_unit_gain:
+        # 2 * sigmoid keeps the neutral (zero-delight) coefficient at 1.0 instead
+        # of 0.5, so the effective learning rate stays comparable to plain GRPO.
+        # A positive global rescale leaves the update *direction* untouched.
+        gate = 2.0 * gate
+    gate = torch.where(active_tokens, gate, gate.new_ones(()))
+
+    metrics = {
+        "delight_gate": gate.clone().detach(),
+        "delight": delight.clone().detach(),
+        "delight_surprisal": surprisal.clone().detach(),
+    }
+    return gate.detach().to(dtype=log_probs.dtype), metrics
 
 
 def compute_gspo_kl(

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -1577,6 +1577,42 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 default=1e-4,
                 help="The threshold for Off-Policy Sequence Masking (OPSM).",
             )
+            parser.add_argument(
+                "--use-delight",
+                action="store_true",
+                default=False,
+                help="Gate each per-token policy-gradient term by a sigmoid of delight "
+                "(advantage x surprisal), the Delightful Policy Gradient from "
+                "https://arxiv.org/abs/2603.14608.",
+            )
+            parser.add_argument(
+                "--delight-temperature",
+                type=float,
+                default=1.0,
+                help="Sharpness eta of the delight gate sigmoid(delight / eta). "
+                "Smaller values make the gate closer to a hard filter.",
+            )
+            parser.add_argument(
+                "--delight-max-surprisal",
+                type=float,
+                default=10.0,
+                help="Clamp per-token surprisal -log pi(a|h) before forming delight, so a "
+                "single very unlikely token cannot dominate the gate.",
+            )
+            parser.add_argument(
+                "--delight-unit-gain",
+                action="store_true",
+                default=False,
+                help="Use 2 * sigmoid so a zero-delight token keeps coefficient 1.0 instead of "
+                "0.5, holding the effective learning rate comparable to plain GRPO.",
+            )
+            parser.add_argument(
+                "--delight-whiten",
+                action="store_true",
+                default=False,
+                help="Standardise delight across the data-parallel group before gating "
+                "(Appendix E.1 of the DG paper).",
+            )
             return parser
 
         def add_on_policy_distillation_arguments(parser):


### PR DESCRIPTION
## What this does

Adds the **Delightful Policy Gradient** (DG) from [arXiv:2603.14608](https://arxiv.org/abs/2603.14608) as an opt-in reweighting of the per-token policy-gradient terms.

The idea in one sentence: standard policy gradients weight each sampled action by advantage alone, ignoring how likely that action was. DG additionally asks "did we see this coming?"

- **surprisal** `l_t = -log pi(a_t | h_t)` — how unlikely the sampled token was under the current policy
- **delight** `chi_t = U_t * l_t` — advantage times surprisal
- **gate** `w_t = sigmoid(chi_t / eta)`, which multiplies the per-token term

A rare token that led to a high advantage is a *breakthrough*: the gate opens toward 1 and the update learns hard from it. A rare token that led to a low advantage is a *blunder*: the gate closes toward 0, on the reasoning that the policy already almost never emits that token, so pushing it down further spends gradient budget for little benefit. Tokens the policy already emits confidently sit near the neutral middle.

## Why

Two pathologies the paper identifies in the plain estimator, both of which apply to our setup:

1. Within a single prompt, one rare negative-advantage sample can dominate the update direction even though the policy already avoids it.
2. Across a batch, the expected update over-allocates budget to prompts the policy already solves.

The paper reports that the second effect is not variance reduction — it persists with infinite samples — and shows gains over REINFORCE, PPO, and advantage-weighted baselines that grow with task difficulty.

## Implementation notes

- `compute_delight_gate()` in `loss_hub/math_utils.py`; wiring in `loss_hub/losses.py` immediately after `compute_policy_loss()`, alongside the existing OPSM mask.
- The gate multiplies the **already-clipped** `pg_loss`, so it composes with GRPO/GSPO and PPO clipping rather than replacing them.
- DG is defined as a gradient estimator, not a loss term. The gate is therefore **detached** — differentiating through the sigmoid and the surprisal would introduce a term the paper does not have.
- One token is one action and one prefix is one context, so surprisal is per-token. Summing surprisal over a whole response would saturate the sigmoid and degrade the gate into a hard sign-of-advantage filter.
- Surprisal is taken from the current policy's log-probs, matching the paper's definition. It is clamped (default 10.0) so a single pathological token cannot dominate, mirroring the log-density clamp the paper uses for continuous actions.
- Off by default. Logs `delight_gate`, `delight`, and `delight_surprisal` when enabled.

## Two behaviours worth knowing before tuning

**The paper's `eta = 1` is a sparse effect on an LLM.** Most tokens in a trained model have low surprisal, so the gate barely moves them. With `|advantage| = 1`, the ratio between the positive-advantage and negative-advantage coefficient is:

| per-token surprisal | 0.1 | 0.4 | 2.0 | 5.0 |
|---|---|---|---|---|
| coefficient ratio | 1.11x | 1.49x | 7.39x | 148x |

So at `eta = 1` DG acts almost entirely on the high-entropy minority of tokens. `--delight-temperature` below 1, or `--delight-whiten`, makes it act more broadly.

**Plain DG halves the effective learning rate.** At zero delight the gate is `sigmoid(0) = 0.5`, so every neutral token is scaled by half, which confounds comparison against a baseline at the same learning rate. `--delight-unit-gain` uses `2 * sigmoid` so the neutral coefficient is 1.0. A positive global rescale leaves the update *direction* unchanged, so the paper's analysis still applies. Recommended for a learning-rate-matched A/B.

**A consequence to watch.** Group-relative advantages sum to zero within a prompt group, so positive and negative pulls cancel by construction. The DG gate is asymmetric, so they no longer cancel: the net advantage weight on a balanced group comes out positive and grows with surprisal. DG therefore adds a mild self-imitation pull that preferentially raises the probability of tokens the policy currently finds unlikely, which acts like an implicit entropy bonus. Expect entropy to drift up rather than collapse, and consider reducing `--entropy-coef` or narrowing `--eps-clip-high` when enabling DG. Pass `--observe-training-entropy` to see this, since `train/entropy_loss` is otherwise not populated.

## Flags

| flag | default | meaning |
|---|---|---|
| `--use-delight` | off | enable the gate |
| `--delight-temperature` | 1.0 | sharpness `eta`; lower is closer to a hard filter |
| `--delight-max-surprisal` | 10.0 | clamp on per-token surprisal |
| `--delight-unit-gain` | off | use `2 * sigmoid` so neutral coefficient is 1.0 |
| `--delight-whiten` | off | standardise delight across the data-parallel group first |

## Status

Draft, opened for visualising the change. Not yet run end to end, and unit tests for `compute_delight_gate` are still to come. `pre-commit` passes on all touched files.
