### PR TITLE
examples: select fully-async with --fully-async in the GLM-5.2 Daytona recipe

### DIFF
--- a/examples/experimental/openenv/glm52_tbench2/run_glm5_2_744b_a40b_daytona.py
+++ b/examples/experimental/openenv/glm52_tbench2/run_glm5_2_744b_a40b_daytona.py
@@ -130,7 +130,7 @@ def _execute_train(args: ScriptArgs):
     )
 
     rollout_args = (
-        "--rollout-function-path miles.rollout.fully_async_rollout.FullyAsyncRolloutFn "
+        "--fully-async "
         "--pause-generation-mode in_place "
         f"--async-max-concurrent-samples {args.async_max_concurrent_samples} "
         # Free a submission slot per finished sample, not per finished group:


### PR DESCRIPTION
`run_glm5_2_744b_a40b_daytona.py` selected the fully-async rollout by pointing
`--rollout-function-path` at `FullyAsyncRolloutFn` instead of passing
`--fully-async`.

The two are mutually exclusive (`_resolve_rollout_functions` asserts
`rollout_function_path is None` under `--fully-async`), so the recipe was on the
path that skips validation.

## Why this is behavior-identical

`resolve_rollout_function_paths` ends at the same pair either way:

- before: `rollout_path = args.rollout_function_path` = `FullyAsyncRolloutFn`; `eval_path = eval_function_path or rollout_path` = same
- after: `rollout_path = standard_path`, then overridden by the `if args.fully_async` branch to `FullyAsyncRolloutFn`; `eval_path` resolves identically

`args.fully_async` is read in exactly two places (`_resolve_rollout_functions`
and the `train.py` driver guard), so nothing else in the run changes.
`--rollout-submission-granularity sample` is set explicitly by the recipe, so
the fully-async default for it is not load-bearing here either.

## What the recipe gains

The `--fully-async` incompatibility checks now apply: `--colocate`,
`--partial-rollout`, `--pause-generation-mode abort`,
`--recompute-logprobs-via-prefill`, `--rollout-all-samples-process-path`, and
multi-LoRA. The recipe passes all of them today — it sets
`--pause-generation-mode in_place`, and already exports
`MILES_EXPERIMENTAL_ROLLOUT_REFACTOR=1` and runs `train_async.py`.

## Testing

No snapshot fixture covers this recipe (`tests/snapshots/launch_scripts/`), and
`pre-commit run --all-files` passes. Not executed on hardware — the change is a
flag swap verified against `miles/utils/arguments.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)