### PR TITLE
refactor(docker): cache key installation downloads with BuildKit mounts

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -177,11 +177,6 @@ jobs:
             image=moby/buildkit:latest
             network=host
 
-      - name: Install Python + dependencies
-        run: |
-          apt-get update && apt-get install -y python3 python3-pip
-          pip3 install --break-system-packages typer
-
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -125,11 +125,6 @@ jobs:
           driver-opts: |
             image=moby/buildkit:latest
             network=host
-      - name: Install Python + dependencies
-        if: env.BUILD == 'true'
-        run: |
-          apt-get update && apt-get install -y python3 python3-pip
-          pip3 install --break-system-packages typer
       - name: Login to Docker Hub
         if: env.BUILD == 'true'
         uses: docker/login-action@v3

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -188,8 +188,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     pip install multi-storage-client --no-deps
 
 COPY requirements.txt /tmp/requirements.txt
-RUN --mount=type=cache,target=/root/.cache/pip \
-    rm -rf /usr/lib/python3/dist-packages/jwt /usr/lib/python3/dist-packages/PyJWT* && pip install -r /tmp/requirements.txt
+RUN rm -rf /usr/lib/python3/dist-packages/jwt /usr/lib/python3/dist-packages/PyJWT* && pip install -r /tmp/requirements.txt
 
 # The apt copy shadows the pip one in ldconfig and the loader interleaves the two,
 # so transformer_engine gets a mixed set of libcudnn sub-libraries. The packages are

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -36,9 +36,14 @@ WORKDIR /root/
 
 # ======================================== Apt dependencies =============================================
 
-RUN apt update
+# Keep downloaded packages so the apt cache mounts below actually persist anything.
+RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
+    echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
+
 # ethtool for network diagnostics
-RUN apt install -y nvtop rsync dnsutils ethtool
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt update && apt install -y nvtop rsync dnsutils ethtool
 
 # nccl-tests for diagnostics
 RUN git clone https://github.com/NVIDIA/nccl-tests.git /tmp/nccl-tests && \
@@ -79,25 +84,32 @@ RUN pip install /tmp/wheels/flash_attn-*.whl
 # re-runs @torch.library.custom_op("flash_attn_3::...") and double-registers.
 RUN pip install /tmp/wheels/flash_attn_3-*.whl
 
-RUN pip install git+https://github.com/ISEEKYAN/mbridge.git@89eb10887887bc74853f89a4de258c0702932a1c --no-deps
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install git+https://github.com/ISEEKYAN/mbridge.git@89eb10887887bc74853f89a4de258c0702932a1c --no-deps
 
-RUN pip install flash-linear-attention==0.4.2
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install flash-linear-attention==0.4.2
 # required for DeepSeek V4
-RUN pip install tilelang==0.1.8 -f https://tile-ai.github.io/whl/nightly/cu128/
-RUN pip install --no-deps tile_kernels==1.0.0
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install tilelang==0.1.8 -f https://tile-ai.github.io/whl/nightly/cu128/
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install --no-deps tile_kernels==1.0.0
 # FlashQLA backend for Qwen GDN linear-attention layers (requires SM90+, CUDA 12.8+, PyTorch 2.8+; built on tilelang above)
-RUN pip install -v --no-build-isolation "git+https://github.com/QwenLM/FlashQLA.git"
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install -v --no-build-isolation "git+https://github.com/QwenLM/FlashQLA.git"
 # Prefer the prebuilt wheel; fall back to a source build while the current
 # arch's wheels release doesn't carry it yet (QEMU-emulated arm64 source
 # builds are the expensive path this avoids).
-RUN if ls /tmp/wheels/fast_hadamard_transform-*.whl 2>/dev/null | grep -q .; then \
+RUN --mount=type=cache,target=/root/.cache/pip \
+    if ls /tmp/wheels/fast_hadamard_transform-*.whl 2>/dev/null | grep -q .; then \
       pip install /tmp/wheels/fast_hadamard_transform-*.whl; \
     else \
       pip install "git+https://github.com/Dao-AILab/fast-hadamard-transform.git@e7706faf8d1c3b9f241e36860640ad1dac644ede" --no-build-isolation; \
     fi
 
 # Mamba kernels for nemotron_h hybrid (mamba+attention) models.
-RUN if ls /tmp/wheels/causal_conv1d-*.whl 2>/dev/null | grep -q . && \
+RUN --mount=type=cache,target=/root/.cache/pip \
+    if ls /tmp/wheels/causal_conv1d-*.whl 2>/dev/null | grep -q . && \
        ls /tmp/wheels/mamba_ssm-*.whl 2>/dev/null | grep -q .; then \
       pip install /tmp/wheels/causal_conv1d-*.whl /tmp/wheels/mamba_ssm-*.whl; \
     else \
@@ -109,7 +121,8 @@ RUN if ls /tmp/wheels/causal_conv1d-*.whl 2>/dev/null | grep -q . && \
 # pull a conflicting core dist. That also drops transformer_engine_torch's own
 # runtime deps, which still have to be installed: transformer_engine.pytorch
 # imports onnxscript unconditionally (module/_common -> export -> onnx_extensions).
-RUN --mount=type=bind,source=docker/verify_transformer_engine.py,target=/tmp/verify_transformer_engine.py \
+RUN --mount=type=cache,target=/root/.cache/pip \
+    --mount=type=bind,source=docker/verify_transformer_engine.py,target=/tmp/verify_transformer_engine.py \
     if [ "${ENABLE_CUDA_13}" = "1" ]; then \
       TE_CORE_DIST=transformer_engine_cu13; \
     else \
@@ -148,28 +161,35 @@ RUN if [ "${ENABLE_CUDA_13}" = "1" ] && [ -d /tmp/patches/cu13 ]; then \
 # apex
 RUN pip install /tmp/wheels/apex-*.whl
 
-RUN git clone https://github.com/${MEGATRON_REPO}.git --recursive -b ${MEGATRON_BRANCH} Megatron-LM && \
+RUN --mount=type=cache,target=/root/.cache/pip \
+    git clone https://github.com/${MEGATRON_REPO}.git --recursive -b ${MEGATRON_BRANCH} Megatron-LM && \
     cd Megatron-LM && \
     pip install -e .
 
 # Muon optimizer support: megatron/core/optimizer/muon.py requires this for Newton-Schulz
 # orthogonalization; not on PyPI (only a dependency-confusion stub), so install from the
 # git source Megatron-LM itself pins in pyproject.toml.
-RUN pip install "git+https://github.com/NVIDIA-NeMo/Emerging-Optimizers.git@v0.1.0"
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install "git+https://github.com/NVIDIA-NeMo/Emerging-Optimizers.git@v0.1.0"
 
 # torch_memory_saver's source build needs TMS_CUDA_MAJOR; take it from torch.
 RUN TMS_CUDA_MAJOR=$(python3 -c "import torch; print(torch.version.cuda.split('.')[0])") \
     pip install git+https://github.com/fzyzcjy/torch_memory_saver.git@74d68c5e4bedf2b6774f2c92ed0f81b7c8d91ed0 --no-cache-dir --force-reinstall
-RUN pip install "nvidia-modelopt[torch]>=0.37.0" --no-build-isolation
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install "nvidia-modelopt[torch]>=0.37.0" --no-build-isolation
 # radixark/Megatron-Bridge#24 (TE 2.17 grouped-linear contract), merged to @bridge.
 # Pinned by SHA, not branch: buildkit caches this layer on the instruction text, so a
 # branch that moves leaves the old revision baked into the image with nothing to show it.
-RUN pip install git+https://github.com/radixark/Megatron-Bridge.git@7f0fb3456f8ffe47599b5fd167b454605d85f932 --no-deps --no-build-isolation
-RUN pip install megatron-energon --no-deps
-RUN pip install multi-storage-client --no-deps
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install git+https://github.com/radixark/Megatron-Bridge.git@7f0fb3456f8ffe47599b5fd167b454605d85f932 --no-deps --no-build-isolation
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install megatron-energon --no-deps
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install multi-storage-client --no-deps
 
 COPY requirements.txt /tmp/requirements.txt
-RUN rm -rf /usr/lib/python3/dist-packages/jwt /usr/lib/python3/dist-packages/PyJWT* && pip install -r /tmp/requirements.txt
+RUN --mount=type=cache,target=/root/.cache/pip \
+    rm -rf /usr/lib/python3/dist-packages/jwt /usr/lib/python3/dist-packages/PyJWT* && pip install -r /tmp/requirements.txt
 
 # The apt copy shadows the pip one in ldconfig and the loader interleaves the two,
 # so transformer_engine gets a mixed set of libcudnn sub-libraries. The packages are
@@ -179,7 +199,8 @@ RUN if [ "${ENABLE_CUDA_13}" = "1" ]; then CU=13; else CU=12; fi; \
     libcudnn9-cuda-${CU} libcudnn9-dev-cuda-${CU} libcudnn9-headers-cuda-${CU} \
   && rm -rf /var/lib/apt/lists/*
 
-RUN if [ "${ENABLE_CUDA_13}" = "1" ]; then \
+RUN --mount=type=cache,target=/root/.cache/pip \
+    if [ "${ENABLE_CUDA_13}" = "1" ]; then \
     pip install nvidia-cudnn-cu13==9.22.0.52; \
   else \
     pip install nvidia-cudnn-cu12==9.22.0.52; \
@@ -278,7 +299,8 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 #   TypeError: make_kwargs_wrapper() got an unexpected keyword argument 'map_dataclass_to_tuple'
 # Restore sglang's own pin after every other install, and fail the build loudly if it
 # does not take effect rather than shipping an image that only breaks under CI.
-RUN pip install --force-reinstall --no-deps "apache-tvm-ffi==0.1.11" && \
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install --force-reinstall --no-deps "apache-tvm-ffi==0.1.11" && \
     python3 -c "import inspect; from tvm_ffi.utils import kwargs_wrapper as k; \
 p = inspect.signature(k.make_kwargs_wrapper).parameters; \
 assert 'map_dataclass_to_tuple' in p, \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -58,6 +58,8 @@ RUN git clone https://github.com/NVIDIA/nccl-tests.git /tmp/nccl-tests && \
 # `wheel[s]/` is a glob — silently no-ops when wheels/ is absent (CI's path).
 COPY wheel[s]/ /tmp/wheels/
 
+# Do not cache rolling-release downloads unless they are resolved to an
+# immutable asset manifest and validated against it.
 RUN case "${TARGETARCH}" in \
       amd64) WHEELS_TAG="${WHEELS_TAG_X86}" ;; \
       arm64) WHEELS_TAG="${WHEELS_TAG_ARM64}" ;; \

--- a/docker/build.py
+++ b/docker/build.py
@@ -9,13 +9,11 @@ Usage:
     python docker/build.py --variant cu13 --image-tag dev --dry-run
 """
 
+import argparse
 import os
 import subprocess
 from datetime import datetime, timezone
-from enum import Enum
 from pathlib import Path
-
-import typer
 
 CACHE_DIR = "/tmp/miles-docker-cache"
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -113,10 +111,10 @@ def build_and_push(
         tags = [f"{image}:{prefix}{postfix}", f"{image}:{prefix}{postfix}-{timestamp}"]
     elif image_tag == "custom":
         if not custom_tag:
-            raise typer.BadParameter("--custom-tag is required when --image-tag is custom")
+            raise ValueError("--custom-tag is required when --image-tag is custom")
         tags = [f"{image}:{custom_tag}{postfix}"]
     else:
-        raise typer.BadParameter(f"Unknown image tag: {image_tag}")
+        raise ValueError(f"Unknown image tag: {image_tag}")
 
     cmd = [
         "docker",
@@ -154,32 +152,35 @@ def build_and_push(
     run(cmd, dry_run)
 
 
-class Variant(str, Enum):
-    cu13 = "cu13"
-    cu13_x86 = "cu13-x86"
-    cu13_aarch64 = "cu13-aarch64"
-    cu12_x86 = "cu12-x86"
-    rocm700_mi35x = "rocm700-mi35x"
-    rocm700_mi30x = "rocm700-mi30x"
-    rocm720_mi35x = "rocm720-mi35x"
-
-
-class ImageTag(str, Enum):
-    latest = "latest"
-    dev = "dev"
-    custom = "custom"
-
-
-def main(
-    variant: Variant = typer.Option(..., help="Build variant to use."),  # noqa: B008
-    image_tag: ImageTag = typer.Option(..., help="Tag mode: latest, dev, or custom."),  # noqa: B008
-    dockerfile: str = typer.Option("docker/Dockerfile", help="Path to the Dockerfile."),  # noqa: B008
-    dry_run: bool = typer.Option(False, help="Print commands without executing them."),  # noqa: B008
-    push: bool = typer.Option(False, help="Push images to registry after building."),  # noqa: B008
-    custom_tag: str = typer.Option("", help="Custom tag name (required when --image-tag is custom)."),  # noqa: B008
-) -> None:
-    build_and_push(variant.value, image_tag.value, dry_run, dockerfile, push=push, custom_tag=custom_tag)
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Build and push Miles Docker images.")
+    parser.add_argument("--variant", required=True, choices=list(VARIANTS), help="Build variant to use.")
+    parser.add_argument(
+        "--image-tag", required=True, choices=["latest", "dev", "custom"], help="Tag mode: latest, dev, or custom."
+    )
+    parser.add_argument("--dockerfile", default="docker/Dockerfile", help="Path to the Dockerfile.")
+    parser.add_argument(
+        "--dry-run",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="Print commands without executing them.",
+    )
+    parser.add_argument(
+        "--push", action=argparse.BooleanOptionalAction, default=False, help="Push images to registry after building."
+    )
+    parser.add_argument("--custom-tag", default="", help="Custom tag name (required when --image-tag is custom).")
+    args = parser.parse_args()
+    if args.image_tag == "custom" and not args.custom_tag:
+        parser.error("--custom-tag is required when --image-tag is custom")
+    build_and_push(
+        args.variant,
+        args.image_tag,
+        args.dry_run,
+        args.dockerfile,
+        push=args.push,
+        custom_tag=args.custom_tag,
+    )
 
 
 if __name__ == "__main__":
-    typer.run(main)
+    main()

--- a/docs/ci/02-docker-build.md
+++ b/docs/ci/02-docker-build.md
@@ -129,7 +129,7 @@ gh workflow run docker-build.yml -f variant=cu13-x86 -f image_tag=custom -f cust
 
 ### Steps (`build-and-push`)
 
-1. checkout → Buildx → install Python + typer → Docker Hub login.
+1. checkout → Buildx → Docker Hub login. `build.py` uses only the Python standard library, so build nodes need no host package installation.
 2. **Build + push** via `build.py` — automatic runs build **both** `cu13` and `cu12-x86`; a manual dispatch builds only the one variant you picked.
 3. **schedule only** — point `latest`→`dev` and `latest-cu12`→`dev-cu12`.
 4. **schedule only** — prune each timestamp series to the newest 20.


### PR DESCRIPTION
## Summary

Make Docker builds reuse package-manager downloads without mutating build hosts.

## Motivation

A measured cold build spent 13.7 minutes in the amd64 mbridge install while the same pure-Python step took 0.6 minutes on arm64, exposing download and network jitter rather than compute cost. The Docker gate also installed unpinned Typer into distro-managed Python on every run and failed when pip attempted to replace Debian's Rich package. The refactor reduces both network and host-state dependence while preserving dependency resolution, image contents, tags, and build commands.

## Before / After

- **Before / After:** Eligible `RUN` steps refetched apt and pip artifacts; steps attached to the same BuildKit builder can now reuse matching package-manager downloads.
- **Before / After:** Build hosts installed Python packages into the system interpreter; `docker/build.py` now uses stdlib `argparse`, so the workflows need no apt/pip bootstrap.
- **What moved where:** Apt cache retention and locked apt mounts wrap the existing apt transaction, while fetch-capable pip commands gain `/root/.cache/pip` mounts without changing their order.
- **PR Docker builds:** One `cu13` amd64+arm64 build lets both platform graphs reuse eligible builder-local downloads.
- **Automatic builds:** A shared builder lets `cu12-x86` reuse matching downloads from the preceding multi-platform `cu13` build.
- **Manual builds:** Eligible `RUN` steps reuse downloads only inside the selected CUDA variant using `docker/Dockerfile`.
- **Cache lifetime:** The workflow still creates a temporary builder per CI job; cache mounts do not survive jobs or workflow runs.

## Behavior Preservation

- `docker/Dockerfile`: Package names, versions, flags, fallback branches, dependency semantics, and installation order are unchanged.
- `requirements.txt`: `pip install -r /tmp/requirements.txt` remains outside the cache mount because it resolves an open dependency set shared with package and CI consumers.
- `docker/build.py` build requests: The same workflow inputs generate the same tags and buildx arguments.
- `docker/build.py` Boolean flags: `--no-dry-run` and `--no-push` remain accepted.
- `docker/build.py` errors: Parameter errors still exit 2.
- Local wheel-only installs and the TMS command with `--no-cache-dir` remain unchanged.
- The rolling wheels download remains unmounted; an adjacent comment records that future caching requires an immutable asset manifest and validation against it.
- Persistent builders, cache-ID partitioning, dependency locking, requirements reorganization, and layer reordering remain out of scope.

## Verification

- `git diff --check d0120463f89ab7a0f8d616395922809dd1a1967a...67b08af77f2865cbc25eddb37620d641d689455d`: passed.
- `pre-commit run --files .github/workflows/docker-build.yml .github/workflows/pr-test.yml docker/Dockerfile docker/build.py docs/ci/02-docker-build.md`: passed.
- Python in-memory compile and `yaml.safe_load` for both modified workflows: passed.
- `docker/build.py` dry runs for `cu13-x86`, `cu13-aarch64`, and `cu12-x86`: passed; generated buildx commands match the previous CLI behavior.
- Missing custom tags and invalid variants: rejected with exit code 2.
- Comment-only check against parent `c9c21be6a7a8477c641bb03aa62742526565ccb8`: passed; the final commit changes only two comment lines in `docker/Dockerfile`.
- Full Docker build: not run locally because this host lacks Docker, Buildx, and arm64 emulation; the PR Docker gate is the end-to-end authority.

## Review Focus

- Apt mounts: Confirm downloads are retained and both apt cache targets use `sharing=locked`.
- Pip mounts: Confirm only fetch-capable commands are mounted and the open `requirements.txt` install remains outside the cache.
- Rolling wheels: Confirm the release download remains unmounted until immutable asset identity and validation exist.
- `/root/.cache/pip`: Review default sharing across current architectures and CUDA variants.
- Cache lifecycle and explicit ID partitioning remain deferred.
- `docker/build.py`: Confirm stdlib parsing preserves workflow-facing CLI behavior and removes only the failing host bootstrap.
