### PR TITLE
fix(rollout): group session v2 leaf samples

### DIFF
--- a/miles/rollout/generate_hub/agentic_tool_call.py
+++ b/miles/rollout/generate_hub/agentic_tool_call.py
@@ -115,6 +115,7 @@ async def generate(input: GenerateFnInput) -> GenerateFnOutput:
 
     samples = result.samples
     if use_v2:
+        # FIXME: handle sample index issues.
         rollout_id = input.sample.rollout_id if input.sample.rollout_id is not None else input.sample.index
         assert rollout_id is not None, "v2 agentic samples require input Sample.rollout_id or Sample.index"
         for sample in samples:

--- a/miles/rollout/generate_hub/agentic_tool_call.py
+++ b/miles/rollout/generate_hub/agentic_tool_call.py
@@ -114,6 +114,11 @@ async def generate(input: GenerateFnInput) -> GenerateFnOutput:
         return GenerateFnOutput(samples=[sample] if use_v2 else sample)
 
     samples = result.samples
+    if use_v2:
+        rollout_id = input.sample.rollout_id if input.sample.rollout_id is not None else input.sample.index
+        assert rollout_id is not None, "v2 agentic samples require input Sample.rollout_id or Sample.index"
+        for sample in samples:
+            sample.rollout_id = rollout_id
     if not use_v2:
         # v1: the agent's metadata is applied driver-side. Under v2 it traveled
         # through collect_samples and came back applied by the server-side

--- a/tests/fast/rollout/generate_hub/test_agentic_v2.py
+++ b/tests/fast/rollout/generate_hub/test_agentic_v2.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 import pytest
 
 import miles.rollout.generate_hub.agentic_tool_call as agentic_tool_call
+from miles.ray.rollout.rollout_data_conversion import validate_compact_rollout_ids
 from miles.rollout.base_types import GenerateFnInput
 from miles.rollout.session.samples.codec import SamplesReply
 from miles.utils.types import Sample
@@ -68,6 +69,37 @@ async def test_success_returns_list_and_forwards_agent_metadata(monkeypatch):
 
     assert output.samples == [sample]
     assert tracer.agent_metadata == {"agent_result": "done"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("input_rollout_id", "expected_rollout_id"), [(None, 7), (11, 11)])
+async def test_success_assigns_shared_rollout_id_to_v2_leaves(monkeypatch, input_rollout_id, expected_rollout_id):
+    leaves = [
+        Sample(status=Sample.Status.COMPLETED, response="one", response_length=1, tokens=[1]),
+        Sample(status=Sample.Status.COMPLETED, response="two", response_length=1, tokens=[2]),
+    ]
+    tracer = _Tracer(SamplesReply(samples=leaves, session_metadata={}, empty_reason=None))
+    _patch_agent(monkeypatch, tracer)
+    generate_input = _generate_input()
+    generate_input.sample.rollout_id = input_rollout_id
+
+    output = await agentic_tool_call.generate(generate_input)
+
+    assert [sample.rollout_id for sample in output.samples] == [expected_rollout_id] * 2
+    validate_compact_rollout_ids([[output.samples]])
+
+
+@pytest.mark.asyncio
+async def test_v2_requires_input_rollout_identity(monkeypatch):
+    leaf = Sample(status=Sample.Status.COMPLETED, response="done", response_length=1, tokens=[1])
+    tracer = _Tracer(SamplesReply(samples=[leaf], session_metadata={}, empty_reason=None))
+    _patch_agent(monkeypatch, tracer)
+    generate_input = _generate_input()
+    generate_input.sample.index = None
+    generate_input.sample.rollout_id = None
+
+    with pytest.raises(AssertionError, match="require input Sample.rollout_id or Sample.index"):
+        await agentic_tool_call.generate(generate_input)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- stamp every leaf sample returned by one session-server-v2 agentic rollout with the same `rollout_id`
- preserve an explicit input `rollout_id`, with the globally assigned input `Sample.index` as the fallback
- fail early if a v2 rollout has neither identity instead of emitting samples that cannot be grouped safely

## Why

Session server v2 may return multiple trainable leaves for one environment rollout, including leaves created by compaction or subagents. Those leaves need a shared rollout identity so Miles can validate nested output, apply rollout-level masking, and treat them as siblings during downstream reward processing.

This change is independent of the reward-normalization companion PR #2369 and targets `main` directly.

## Tests

- repository-pinned pre-commit hooks on both changed files
- `uvx ruff check miles/rollout/generate_hub/agentic_tool_call.py tests/fast/rollout/generate_hub/test_agentic_v2.py`
- focused macOS run: `pytest -q --noconftest tests/fast/rollout/generate_hub/test_agentic_v2.py` (7 passed)

No README update is needed because this only fills the existing `Sample.rollout_id` contract; it adds no user-facing option.
