### PR TITLE
fix(rollout): normalize rewards per rollout

### DIFF
--- a/miles/ray/rollout/train_data_conversion.py
+++ b/miles/ray/rollout/train_data_conversion.py
@@ -170,7 +170,7 @@ def _compute_rollout_mask_sums(rollout_ids: list[int], loss_masks: list[list[int
 
 
 def _reward_group_ids(args: Any, samples: list[Sample], prompt_group_sizes: list[int] | None) -> list[int]:
-    """Resolve each row's reward-normalization group without assuming fixed fanout."""
+    """Map each flattened leaf row to the prompt group normalized with it."""
     if prompt_group_sizes is not None:
         assert sum(prompt_group_sizes) == len(
             samples
@@ -182,8 +182,9 @@ def _reward_group_ids(args: Any, samples: list[Sample], prompt_group_sizes: list
         return [int(group_index) for group_index in group_indices]
 
     expected_samples = args.n_samples_per_prompt * args.rollout_batch_size
-    group_size = args.n_samples_per_prompt if len(samples) == expected_samples else len(samples)
-    return [row_index // group_size for row_index in range(len(samples))]
+    if len(samples) == expected_samples:
+        return [row_index // args.n_samples_per_prompt for row_index in range(len(samples))]
+    return [0] * len(samples)
 
 
 def _normalize_rewards_by_rollout(
@@ -192,38 +193,49 @@ def _normalize_rewards_by_rollout(
     raw_rewards: list[float],
     prompt_group_sizes: list[int] | None,
 ) -> list[float]:
-    """Normalize one reward per rollout, then broadcast its advantage to sibling rows."""
+    """Give each rollout equal weight in prompt-group reward statistics."""
     if not samples:
         return []
 
     group_ids = _reward_group_ids(args, samples, prompt_group_sizes)
-    row_keys: list[tuple[int, int | tuple[str, int]]] = []
-    rollout_rewards: dict[tuple[int, int | tuple[str, int]], float] = {}
-    group_rollout_keys: dict[int, list[tuple[int, int | tuple[str, int]]]] = {}
+    rollout_rewards_by_group: dict[int, dict[int | tuple[str, int], list[float]]] = {}
+    row_indices_by_group: dict[int, list[int]] = {}
 
     for row_index, (sample, reward, group_id) in enumerate(zip(samples, raw_rewards, group_ids, strict=True)):
-        rollout_id = sample.rollout_id if sample.rollout_id is not None else sample.index
-        rollout_key = rollout_id if rollout_id is not None else ("row", row_index)
-        key = (group_id, rollout_key)
-        if key in rollout_rewards:
-            if rollout_rewards[key] != reward:
-                raise ValueError(
-                    f"samples in reward group {group_id} with rollout_id={rollout_id} must share one reward; got {rollout_rewards[key]} and {reward}"
-                )
+        if sample.rollout_id is not None:
+            rollout_key = sample.rollout_id
+        elif sample.index is not None:
+            rollout_key = sample.index
         else:
-            rollout_rewards[key] = reward
-            group_rollout_keys.setdefault(group_id, []).append(key)
-        row_keys.append(key)
+            rollout_key = ("row", row_index)
 
-    normalized_by_rollout: dict[tuple[int, int | tuple[str, int]], float] = {}
-    for keys in group_rollout_keys.values():
-        rewards = torch.tensor([rollout_rewards[key] for key in keys], dtype=torch.float)
-        normalized = rewards - rewards.mean()
-        if args.advantage_estimator in ["grpo", "gspo"] and args.grpo_std_normalization and len(keys) > 1:
-            normalized = normalized / (rewards.std() + 1e-6)
-        normalized_by_rollout.update(zip(keys, normalized.tolist(), strict=True))
+        rewards_by_rollout = rollout_rewards_by_group.setdefault(group_id, {})
+        rewards_by_rollout.setdefault(rollout_key, []).append(reward)
+        row_indices_by_group.setdefault(group_id, []).append(row_index)
 
-    return [normalized_by_rollout[key] for key in row_keys]
+    leaf_rewards = torch.tensor(raw_rewards, dtype=torch.float)
+    normalized_rewards = torch.empty_like(leaf_rewards)
+    for group_id, rewards_by_rollout in rollout_rewards_by_group.items():
+        rollout_means = torch.tensor(
+            [
+                sum(rewards_for_rollout) / len(rewards_for_rollout)
+                for rewards_for_rollout in rewards_by_rollout.values()
+            ],
+            dtype=torch.float,
+        )
+        row_indices = row_indices_by_group[group_id]
+        normalized_group_rewards = leaf_rewards[row_indices] - rollout_means.mean()
+        if (
+            args.advantage_estimator in ["grpo", "gspo"]
+            and args.grpo_std_normalization
+            and len(rewards_by_rollout) > 1
+        ):
+            rollout_std = rollout_means.std()
+            if rollout_std > 0:
+                normalized_group_rewards = normalized_group_rewards / (rollout_std + 1e-6)
+        normalized_rewards[row_indices] = normalized_group_rewards
+
+    return normalized_rewards.tolist()
 
 
 def _post_process_rewards(

--- a/miles/ray/rollout/train_data_conversion.py
+++ b/miles/ray/rollout/train_data_conversion.py
@@ -169,6 +169,63 @@ def _compute_rollout_mask_sums(rollout_ids: list[int], loss_masks: list[list[int
     return [totals[rid] for rid in rollout_ids]
 
 
+def _reward_group_ids(args: Any, samples: list[Sample], prompt_group_sizes: list[int] | None) -> list[int]:
+    """Resolve each row's reward-normalization group without assuming fixed fanout."""
+    if prompt_group_sizes is not None:
+        assert sum(prompt_group_sizes) == len(
+            samples
+        ), f"prompt group sizes sum to {sum(prompt_group_sizes)}, but got {len(samples)} rewards"
+        return [group_id for group_id, size in enumerate(prompt_group_sizes) for _ in range(size)]
+
+    group_indices = [sample.group_index for sample in samples]
+    if all(group_index is not None for group_index in group_indices):
+        return [int(group_index) for group_index in group_indices]
+
+    expected_samples = args.n_samples_per_prompt * args.rollout_batch_size
+    group_size = args.n_samples_per_prompt if len(samples) == expected_samples else len(samples)
+    return [row_index // group_size for row_index in range(len(samples))]
+
+
+def _normalize_rewards_by_rollout(
+    args: Any,
+    samples: list[Sample],
+    raw_rewards: list[float],
+    prompt_group_sizes: list[int] | None,
+) -> list[float]:
+    """Normalize one reward per rollout, then broadcast its advantage to sibling rows."""
+    if not samples:
+        return []
+
+    group_ids = _reward_group_ids(args, samples, prompt_group_sizes)
+    row_keys: list[tuple[int, int | tuple[str, int]]] = []
+    rollout_rewards: dict[tuple[int, int | tuple[str, int]], float] = {}
+    group_rollout_keys: dict[int, list[tuple[int, int | tuple[str, int]]]] = {}
+
+    for row_index, (sample, reward, group_id) in enumerate(zip(samples, raw_rewards, group_ids, strict=True)):
+        rollout_id = sample.rollout_id if sample.rollout_id is not None else sample.index
+        rollout_key = rollout_id if rollout_id is not None else ("row", row_index)
+        key = (group_id, rollout_key)
+        if key in rollout_rewards:
+            if rollout_rewards[key] != reward:
+                raise ValueError(
+                    f"samples in reward group {group_id} with rollout_id={rollout_id} must share one reward; got {rollout_rewards[key]} and {reward}"
+                )
+        else:
+            rollout_rewards[key] = reward
+            group_rollout_keys.setdefault(group_id, []).append(key)
+        row_keys.append(key)
+
+    normalized_by_rollout: dict[tuple[int, int | tuple[str, int]], float] = {}
+    for keys in group_rollout_keys.values():
+        rewards = torch.tensor([rollout_rewards[key] for key in keys], dtype=torch.float)
+        normalized = rewards - rewards.mean()
+        if args.advantage_estimator in ["grpo", "gspo"] and args.grpo_std_normalization and len(keys) > 1:
+            normalized = normalized / (rewards.std() + 1e-6)
+        normalized_by_rollout.update(zip(keys, normalized.tolist(), strict=True))
+
+    return [normalized_by_rollout[key] for key in row_keys]
+
+
 def _post_process_rewards(
     args,
     samples: list[Sample] | list[list[Sample]],
@@ -180,38 +237,8 @@ def _post_process_rewards(
 
     raw_rewards = [sample.get_reward_value(args) for sample in samples]
     if args.advantage_estimator in ["grpo", "gspo", "reinforce_plus_plus_baseline"] and args.rewards_normalization:
-        # group norm
-        rewards = torch.tensor(raw_rewards, dtype=torch.float)
-        if prompt_group_sizes is not None:
-            # Multi-LoRA: groups may have heterogeneous sizes (per-adapter
-            # n_samples_per_prompt), so normalize within explicit boundaries.
-            assert sum(prompt_group_sizes) == len(
-                raw_rewards
-            ), f"prompt group sizes sum to {sum(prompt_group_sizes)}, but got {len(raw_rewards)} rewards"
-            normalized_groups = []
-            for group_rewards in rewards.split(prompt_group_sizes):
-                centered = group_rewards - group_rewards.mean()
-                if (
-                    args.advantage_estimator in ["grpo", "gspo"]
-                    and args.grpo_std_normalization
-                    and group_rewards.numel() > 1
-                ):
-                    centered = centered / (group_rewards.std() + 1e-6)
-                normalized_groups.append(centered)
-            return raw_rewards, torch.cat(normalized_groups).tolist()
-        if rewards.shape[-1] == args.n_samples_per_prompt * args.rollout_batch_size:
-            rewards = rewards.reshape(-1, args.n_samples_per_prompt)
-        else:
-            # when samples count are not equal in each group
-            rewards = rewards.view(-1, rewards.shape[-1])
-        mean = rewards.mean(dim=-1, keepdim=True)
-        rewards = rewards - mean
-
-        if args.advantage_estimator in ["grpo", "gspo"] and args.grpo_std_normalization:
-            std = rewards.std(dim=-1, keepdim=True)
-            rewards = rewards / (std + 1e-6)
-
-        return raw_rewards, rewards.flatten().tolist()
+        normalized_rewards = _normalize_rewards_by_rollout(args, samples, raw_rewards, prompt_group_sizes)
+        return raw_rewards, normalized_rewards
 
     return raw_rewards, raw_rewards
 

--- a/miles/ray/rollout/train_data_conversion.py
+++ b/miles/ray/rollout/train_data_conversion.py
@@ -169,22 +169,39 @@ def _compute_rollout_mask_sums(rollout_ids: list[int], loss_masks: list[list[int
     return [totals[rid] for rid in rollout_ids]
 
 
-def _reward_group_ids(args: Any, samples: list[Sample], prompt_group_sizes: list[int] | None) -> list[int]:
-    """Map each flattened leaf row to the prompt group normalized with it."""
+def _reward_group_rows(args: Any, samples: list[Sample], prompt_group_sizes: list[int] | None) -> list[list[int]]:
+    """Return the flattened row indices for each prompt reward group."""
     if prompt_group_sizes is not None:
         assert sum(prompt_group_sizes) == len(
             samples
         ), f"prompt group sizes sum to {sum(prompt_group_sizes)}, but got {len(samples)} rewards"
-        return [group_id for group_id, size in enumerate(prompt_group_sizes) for _ in range(size)]
+        groups: list[list[int]] = []
+        start = 0
+        for size in prompt_group_sizes:
+            end = start + size
+            if size > 0:
+                groups.append(list(range(start, end)))
+            start = end
+        return groups
 
     group_indices = [sample.group_index for sample in samples]
     if all(group_index is not None for group_index in group_indices):
-        return [int(group_index) for group_index in group_indices]
+        rows_by_group: dict[int, list[int]] = {}
+        for row_index, group_index in enumerate(group_indices):
+            rows_by_group.setdefault(int(group_index), []).append(row_index)
+        return list(rows_by_group.values())
 
     expected_samples = args.n_samples_per_prompt * args.rollout_batch_size
     if len(samples) == expected_samples:
-        return [row_index // args.n_samples_per_prompt for row_index in range(len(samples))]
-    return [0] * len(samples)
+        return [
+            list(range(start, start + args.n_samples_per_prompt))
+            for start in range(0, len(samples), args.n_samples_per_prompt)
+        ]
+    return [list(range(len(samples)))]
+
+
+def _trainable_token_count(sample: Sample) -> int:
+    return 0 if sample.remove_sample else sample.effective_response_length
 
 
 def _normalize_rewards_by_rollout(
@@ -193,47 +210,42 @@ def _normalize_rewards_by_rollout(
     raw_rewards: list[float],
     prompt_group_sizes: list[int] | None,
 ) -> list[float]:
-    """Give each rollout equal weight in prompt-group reward statistics."""
+    """Normalize one mainstream reward per rollout, then broadcast it to siblings."""
     if not samples:
         return []
 
-    group_ids = _reward_group_ids(args, samples, prompt_group_sizes)
-    rollout_rewards_by_group: dict[int, dict[int | tuple[str, int], list[float]]] = {}
-    row_indices_by_group: dict[int, list[int]] = {}
+    normalized_rewards = torch.empty(len(raw_rewards), dtype=torch.float)
+    for group_rows in _reward_group_rows(args, samples, prompt_group_sizes):
+        rows_by_rollout: dict[int | tuple[str, int], list[int]] = {}
+        for row_index in group_rows:
+            sample = samples[row_index]
+            if sample.rollout_id is not None:
+                rollout_key = sample.rollout_id
+            elif sample.index is not None:
+                rollout_key = sample.index
+            else:
+                rollout_key = ("row", row_index)
+            rows_by_rollout.setdefault(rollout_key, []).append(row_index)
 
-    for row_index, (sample, reward, group_id) in enumerate(zip(samples, raw_rewards, group_ids, strict=True)):
-        if sample.rollout_id is not None:
-            rollout_key = sample.rollout_id
-        elif sample.index is not None:
-            rollout_key = sample.index
-        else:
-            rollout_key = ("row", row_index)
-
-        rewards_by_rollout = rollout_rewards_by_group.setdefault(group_id, {})
-        rewards_by_rollout.setdefault(rollout_key, []).append(reward)
-        row_indices_by_group.setdefault(group_id, []).append(row_index)
-
-    leaf_rewards = torch.tensor(raw_rewards, dtype=torch.float)
-    normalized_rewards = torch.empty_like(leaf_rewards)
-    for group_id, rewards_by_rollout in rollout_rewards_by_group.items():
-        rollout_means = torch.tensor(
-            [
-                sum(rewards_for_rollout) / len(rewards_for_rollout)
-                for rewards_for_rollout in rewards_by_rollout.values()
-            ],
-            dtype=torch.float,
-        )
-        row_indices = row_indices_by_group[group_id]
-        normalized_group_rewards = leaf_rewards[row_indices] - rollout_means.mean()
-        if (
-            args.advantage_estimator in ["grpo", "gspo"]
-            and args.grpo_std_normalization
-            and len(rewards_by_rollout) > 1
-        ):
-            rollout_std = rollout_means.std()
+        rollout_row_groups = list(rows_by_rollout.values())
+        # Assume the first sample with the most trainable tokens best represents
+        # the rollout when sibling rewards differ.
+        mainstream_rows = [
+            max(rollout_rows, key=lambda row_index: _trainable_token_count(samples[row_index]))
+            for rollout_rows in rollout_row_groups
+        ]
+        rollout_rewards = torch.tensor([raw_rewards[row_index] for row_index in mainstream_rows], dtype=torch.float)
+        normalized_rollout_rewards = rollout_rewards - rollout_rewards.mean()
+        if args.advantage_estimator in ["grpo", "gspo"] and args.grpo_std_normalization and len(rollout_rewards) > 1:
+            rollout_std = rollout_rewards.std()
             if rollout_std > 0:
-                normalized_group_rewards = normalized_group_rewards / (rollout_std + 1e-6)
-        normalized_rewards[row_indices] = normalized_group_rewards
+                normalized_rollout_rewards = normalized_rollout_rewards / (rollout_std + 1e-6)
+
+        for rollout_rows, normalized_reward in zip(
+            rollout_row_groups, normalized_rollout_rewards.tolist(), strict=True
+        ):
+            for row_index in rollout_rows:
+                normalized_rewards[row_index] = normalized_reward
 
     return normalized_rewards.tolist()
 

--- a/miles/ray/rollout/train_data_conversion.py
+++ b/miles/ray/rollout/train_data_conversion.py
@@ -185,6 +185,7 @@ def _reward_group_segments(args: Any, samples: list[Sample], prompt_group_sizes:
             start = end
         return groups
 
+    # Standard rollout samples carry their prompt identity in `group_index`.
     group_indices = [sample.group_index for sample in samples]
     if all(group_index is not None for group_index in group_indices):
         segments_by_group_index: dict[int, list[int]] = {}
@@ -192,12 +193,14 @@ def _reward_group_segments(args: Any, samples: list[Sample], prompt_group_sizes:
             segments_by_group_index.setdefault(int(group_index), []).append(segment_index)
         return list(segments_by_group_index.values())
 
+    # Legacy fixed-fanout batches store each prompt's segments contiguously.
     expected_samples = args.n_samples_per_prompt * args.rollout_batch_size
     if len(samples) == expected_samples:
         return [
             list(range(start, start + args.n_samples_per_prompt))
             for start in range(0, len(samples), args.n_samples_per_prompt)
         ]
+    # Without prompt identities or a complete fixed layout, use one reward group.
     return [list(range(len(samples)))]
 
 

--- a/miles/ray/rollout/train_data_conversion.py
+++ b/miles/ray/rollout/train_data_conversion.py
@@ -169,8 +169,9 @@ def _compute_rollout_mask_sums(rollout_ids: list[int], loss_masks: list[list[int
     return [totals[rid] for rid in rollout_ids]
 
 
-def _reward_group_rows(args: Any, samples: list[Sample], prompt_group_sizes: list[int] | None) -> list[list[int]]:
+def _reward_group_segments(args: Any, samples: list[Sample], prompt_group_sizes: list[int] | None) -> list[list[int]]:
     """Return the flattened row indices for each prompt reward group."""
+    # Multi-LoRA records explicit prompt boundaries before flattening.
     if prompt_group_sizes is not None:
         assert sum(prompt_group_sizes) == len(
             samples
@@ -186,10 +187,10 @@ def _reward_group_rows(args: Any, samples: list[Sample], prompt_group_sizes: lis
 
     group_indices = [sample.group_index for sample in samples]
     if all(group_index is not None for group_index in group_indices):
-        rows_by_group: dict[int, list[int]] = {}
-        for row_index, group_index in enumerate(group_indices):
-            rows_by_group.setdefault(int(group_index), []).append(row_index)
-        return list(rows_by_group.values())
+        segments_by_group_index: dict[int, list[int]] = {}
+        for segment_index, group_index in enumerate(group_indices):
+            segments_by_group_index.setdefault(int(group_index), []).append(segment_index)
+        return list(segments_by_group_index.values())
 
     expected_samples = args.n_samples_per_prompt * args.rollout_batch_size
     if len(samples) == expected_samples:
@@ -215,37 +216,39 @@ def _normalize_rewards_by_rollout(
         return []
 
     normalized_rewards = torch.empty(len(raw_rewards), dtype=torch.float)
-    for group_rows in _reward_group_rows(args, samples, prompt_group_sizes):
-        rows_by_rollout: dict[int | tuple[str, int], list[int]] = {}
-        for row_index in group_rows:
-            sample = samples[row_index]
+    for prompt_segments in _reward_group_segments(args, samples, prompt_group_sizes):
+        segments_by_rollout_key: dict[int | tuple[str, int], list[int]] = {}
+        for segment_index in prompt_segments:
+            sample = samples[segment_index]
             if sample.rollout_id is not None:
                 rollout_key = sample.rollout_id
             elif sample.index is not None:
                 rollout_key = sample.index
             else:
-                rollout_key = ("row", row_index)
-            rows_by_rollout.setdefault(rollout_key, []).append(row_index)
+                rollout_key = ("row", segment_index)
+            segments_by_rollout_key.setdefault(rollout_key, []).append(segment_index)
 
-        rollout_row_groups = list(rows_by_rollout.values())
+        rollout_segment_groups = list(segments_by_rollout_key.values())
         # Assume the first sample with the most trainable tokens best represents
         # the rollout when sibling rewards differ.
-        mainstream_rows = [
-            max(rollout_rows, key=lambda row_index: _trainable_token_count(samples[row_index]))
-            for rollout_rows in rollout_row_groups
+        mainstream_segments = [
+            max(rollout_segments, key=lambda segment_index: _trainable_token_count(samples[segment_index]))
+            for rollout_segments in rollout_segment_groups
         ]
-        rollout_rewards = torch.tensor([raw_rewards[row_index] for row_index in mainstream_rows], dtype=torch.float)
+        rollout_rewards = torch.tensor(
+            [raw_rewards[segment_index] for segment_index in mainstream_segments], dtype=torch.float
+        )
         normalized_rollout_rewards = rollout_rewards - rollout_rewards.mean()
         if args.advantage_estimator in ["grpo", "gspo"] and args.grpo_std_normalization and len(rollout_rewards) > 1:
             rollout_std = rollout_rewards.std()
             if rollout_std > 0:
                 normalized_rollout_rewards = normalized_rollout_rewards / (rollout_std + 1e-6)
 
-        for rollout_rows, normalized_reward in zip(
-            rollout_row_groups, normalized_rollout_rewards.tolist(), strict=True
+        for rollout_segments, normalized_reward in zip(
+            rollout_segment_groups, normalized_rollout_rewards.tolist(), strict=True
         ):
-            for row_index in rollout_rows:
-                normalized_rewards[row_index] = normalized_reward
+            for segment_index in rollout_segments:
+                normalized_rewards[segment_index] = normalized_reward
 
     return normalized_rewards.tolist()
 

--- a/tests/fast/ray/rollout/test_train_data_conversion.py
+++ b/tests/fast/ray/rollout/test_train_data_conversion.py
@@ -280,9 +280,8 @@ class TestPostProcessRewards:
         expected_std = float(np.std([-1.5, -0.5, 0.5, 1.5]))
         assert abs(np.std(processed) - expected_std) < 1e-5
 
-    def test_irregular_group_size_takes_view_branch(self):
-        """When `rewards.shape[-1] != n_samples_per_prompt * rollout_batch_size`,
-        the code takes the ``rewards.view(-1, rewards.shape[-1])`` branch."""
+    def test_irregular_group_size_uses_explicit_group_index(self):
+        """Explicit group identity keeps an irregularly sized group together."""
         args = make_args(
             advantage_estimator="grpo",
             rewards_normalization=True,
@@ -295,6 +294,116 @@ class TestPostProcessRewards:
         _, processed = _post_process_rewards(args, samples, custom_reward_post_process_func=None)
         # mean is 5.0, after centering: -3, -1, 1, 3
         assert abs(sum(processed)) < 1e-5
+
+    def test_grpo_normalizes_unique_rollouts_with_unequal_fanout(self):
+        args = make_args(
+            advantage_estimator="grpo",
+            rewards_normalization=True,
+            grpo_std_normalization=False,
+            n_samples_per_prompt=2,
+            rollout_batch_size=2,
+        )
+        samples = [
+            make_sample(group_index=0, index=0, rollout_id=10, reward=0.0),
+            make_sample(group_index=0, index=1, rollout_id=11, reward=1.0),
+            make_sample(group_index=0, index=1, rollout_id=11, reward=1.0),
+            make_sample(group_index=0, index=1, rollout_id=11, reward=1.0),
+            make_sample(group_index=1, index=2, rollout_id=20, reward=2.0),
+            make_sample(group_index=1, index=2, rollout_id=20, reward=2.0),
+            make_sample(group_index=1, index=3, rollout_id=21, reward=4.0),
+        ]
+
+        raw, processed = _post_process_rewards(args, samples, custom_reward_post_process_func=None)
+
+        assert raw == [0.0, 1.0, 1.0, 1.0, 2.0, 2.0, 4.0]
+        assert processed == pytest.approx([-0.5, 0.5, 0.5, 0.5, -1.0, -1.0, 1.0])
+
+    def test_grpo_broadcasts_std_normalized_rollout_advantage(self):
+        args = make_args(
+            advantage_estimator="grpo",
+            rewards_normalization=True,
+            grpo_std_normalization=True,
+            n_samples_per_prompt=2,
+            rollout_batch_size=1,
+        )
+        samples = [
+            make_sample(group_index=0, index=0, rollout_id=10, reward=0.0),
+            make_sample(group_index=0, index=1, rollout_id=11, reward=1.0),
+            make_sample(group_index=0, index=1, rollout_id=11, reward=1.0),
+        ]
+
+        _, processed = _post_process_rewards(args, samples, custom_reward_post_process_func=None)
+
+        assert processed == pytest.approx([-(2**-0.5), 2**-0.5, 2**-0.5], abs=1e-5)
+
+    def test_rollout_siblings_must_share_reward(self):
+        args = make_args(advantage_estimator="grpo", rewards_normalization=True)
+        samples = [
+            make_sample(group_index=0, index=0, rollout_id=10, reward=0.0),
+            make_sample(group_index=0, index=0, rollout_id=10, reward=1.0),
+        ]
+
+        with pytest.raises(ValueError, match="must share one reward"):
+            _post_process_rewards(args, samples, custom_reward_post_process_func=None)
+
+    def test_prompt_group_sizes_override_reused_group_index(self):
+        args = make_args(advantage_estimator="grpo", rewards_normalization=True)
+        samples = [
+            make_sample(group_index=0, rollout_id=10, reward=0.0),
+            make_sample(group_index=0, rollout_id=11, reward=2.0),
+            make_sample(group_index=0, rollout_id=20, reward=10.0),
+            make_sample(group_index=0, rollout_id=21, reward=14.0),
+        ]
+
+        _, processed = _post_process_rewards(
+            args,
+            samples,
+            custom_reward_post_process_func=None,
+            prompt_group_sizes=[2, 2],
+        )
+
+        assert processed == pytest.approx([-1.0, 1.0, -2.0, 2.0])
+
+    @pytest.mark.parametrize(
+        ("rewards", "expected"),
+        [
+            ([0.0, 2.0, 10.0, 14.0], [-1.0, 1.0, -2.0, 2.0]),
+            ([0.0, 2.0, 4.0], [-2.0, 0.0, 2.0]),
+        ],
+    )
+    def test_missing_group_indices_use_legacy_boundaries(self, rewards, expected):
+        args = make_args(
+            advantage_estimator="grpo",
+            rewards_normalization=True,
+            n_samples_per_prompt=2,
+            rollout_batch_size=2,
+        )
+        samples = [
+            make_sample(group_index=None, rollout_id=rollout_id, reward=reward)
+            for rollout_id, reward in enumerate(rewards)
+        ]
+
+        _, processed = _post_process_rewards(args, samples, custom_reward_post_process_func=None)
+
+        assert processed == pytest.approx(expected)
+
+    def test_rows_without_rollout_identity_stay_distinct(self):
+        args = make_args(advantage_estimator="grpo", rewards_normalization=True)
+        samples = [
+            make_sample(group_index=0, index=None, rollout_id=None, reward=0.0),
+            make_sample(group_index=0, index=None, rollout_id=None, reward=2.0),
+        ]
+
+        _, processed = _post_process_rewards(args, samples, custom_reward_post_process_func=None)
+
+        assert processed == pytest.approx([-1.0, 1.0])
+
+    def test_empty_rewards_stay_empty(self):
+        args = make_args(advantage_estimator="grpo", rewards_normalization=True)
+
+        raw, processed = _post_process_rewards(args, [], custom_reward_post_process_func=None)
+
+        assert raw == processed == []
 
     def test_custom_reward_post_process_short_circuits(self):
         args = make_args(advantage_estimator="grpo", rewards_normalization=True)

--- a/tests/fast/ray/rollout/test_train_data_conversion.py
+++ b/tests/fast/ray/rollout/test_train_data_conversion.py
@@ -336,15 +336,45 @@ class TestPostProcessRewards:
 
         assert processed == pytest.approx([-(2**-0.5), 2**-0.5, 2**-0.5], abs=1e-5)
 
-    def test_rollout_siblings_must_share_reward(self):
-        args = make_args(advantage_estimator="grpo", rewards_normalization=True)
+    def test_grpo_preserves_distinct_sibling_rewards_with_rollout_weighted_stats(self):
+        args = make_args(
+            advantage_estimator="grpo",
+            rewards_normalization=True,
+            grpo_std_normalization=True,
+            n_samples_per_prompt=2,
+            rollout_batch_size=1,
+        )
         samples = [
             make_sample(group_index=0, index=0, rollout_id=10, reward=0.0),
-            make_sample(group_index=0, index=0, rollout_id=10, reward=1.0),
+            make_sample(group_index=0, index=1, rollout_id=11, reward=1.0),
+            make_sample(group_index=0, index=1, rollout_id=11, reward=3.0),
         ]
 
-        with pytest.raises(ValueError, match="must share one reward"):
-            _post_process_rewards(args, samples, custom_reward_post_process_func=None)
+        raw, processed = _post_process_rewards(args, samples, custom_reward_post_process_func=None)
+
+        assert raw == [0.0, 1.0, 3.0]
+        assert processed == pytest.approx([-(2**-0.5), 0.0, 2**0.5], abs=1e-5)
+        rollout_advantages = torch.tensor([processed[0], sum(processed[1:]) / 2])
+        assert rollout_advantages.mean().item() == pytest.approx(0.0, abs=1e-5)
+        assert rollout_advantages.std().item() == pytest.approx(1.0, abs=1e-5)
+
+    def test_grpo_skips_std_scaling_when_rollout_means_are_equal(self):
+        args = make_args(
+            advantage_estimator="grpo",
+            rewards_normalization=True,
+            grpo_std_normalization=True,
+            n_samples_per_prompt=2,
+            rollout_batch_size=1,
+        )
+        samples = [
+            make_sample(group_index=0, index=0, rollout_id=10, reward=0.0),
+            make_sample(group_index=0, index=0, rollout_id=10, reward=2.0),
+            make_sample(group_index=0, index=1, rollout_id=11, reward=1.0),
+        ]
+
+        _, processed = _post_process_rewards(args, samples, custom_reward_post_process_func=None)
+
+        assert processed == pytest.approx([-1.0, 1.0, 0.0])
 
     def test_prompt_group_sizes_override_reused_group_index(self):
         args = make_args(advantage_estimator="grpo", rewards_normalization=True)

--- a/tests/fast/ray/rollout/test_train_data_conversion.py
+++ b/tests/fast/ray/rollout/test_train_data_conversion.py
@@ -336,45 +336,75 @@ class TestPostProcessRewards:
 
         assert processed == pytest.approx([-(2**-0.5), 2**-0.5, 2**-0.5], abs=1e-5)
 
-    def test_grpo_preserves_distinct_sibling_rewards_with_rollout_weighted_stats(self):
+    def test_grpo_uses_most_trainable_sibling_reward_for_rollout(self):
         args = make_args(
             advantage_estimator="grpo",
             rewards_normalization=True,
-            grpo_std_normalization=True,
+            grpo_std_normalization=False,
             n_samples_per_prompt=2,
             rollout_batch_size=1,
         )
         samples = [
-            make_sample(group_index=0, index=0, rollout_id=10, reward=0.0),
-            make_sample(group_index=0, index=1, rollout_id=11, reward=1.0),
-            make_sample(group_index=0, index=1, rollout_id=11, reward=3.0),
+            make_sample(group_index=0, index=0, rollout_id=10, reward=0.0, loss_mask=[1, 1, 1, 1]),
+            make_sample(group_index=0, index=1, rollout_id=11, reward=2.0, loss_mask=[1, 0, 0, 0]),
+            make_sample(group_index=0, index=1, rollout_id=11, reward=6.0, loss_mask=[1, 1, 1, 0]),
         ]
 
         raw, processed = _post_process_rewards(args, samples, custom_reward_post_process_func=None)
 
-        assert raw == [0.0, 1.0, 3.0]
-        assert processed == pytest.approx([-(2**-0.5), 0.0, 2**0.5], abs=1e-5)
-        rollout_advantages = torch.tensor([processed[0], sum(processed[1:]) / 2])
-        assert rollout_advantages.mean().item() == pytest.approx(0.0, abs=1e-5)
-        assert rollout_advantages.std().item() == pytest.approx(1.0, abs=1e-5)
+        assert raw == [0.0, 2.0, 6.0]
+        assert processed == pytest.approx([-3.0, 3.0, 3.0])
 
-    def test_grpo_skips_std_scaling_when_rollout_means_are_equal(self):
+    def test_grpo_mainstream_count_matches_final_training_mask(self):
         args = make_args(
             advantage_estimator="grpo",
             rewards_normalization=True,
-            grpo_std_normalization=True,
+            grpo_std_normalization=False,
             n_samples_per_prompt=2,
             rollout_batch_size=1,
         )
         samples = [
-            make_sample(group_index=0, index=0, rollout_id=10, reward=0.0),
-            make_sample(group_index=0, index=0, rollout_id=10, reward=2.0),
-            make_sample(group_index=0, index=1, rollout_id=11, reward=1.0),
+            make_sample(
+                group_index=0,
+                index=0,
+                rollout_id=10,
+                reward=100.0,
+                response_length=8,
+                remove_sample=True,
+            ),
+            make_sample(group_index=0, index=0, rollout_id=10, reward=2.0, response_length=4),
+            make_sample(group_index=0, index=1, rollout_id=11, reward=6.0, loss_mask=[1, 1, 0, 0]),
+        ]
+
+        train_data = convert_samples_to_train_data(
+            args,
+            samples,
+            metadata={},
+            custom_convert_samples_to_train_data_func=None,
+            custom_reward_post_process_func=None,
+        )
+
+        assert train_data["raw_reward"] == [100.0, 2.0, 6.0]
+        assert train_data["rewards"] == pytest.approx([-2.0, -2.0, 2.0])
+        assert train_data["loss_masks"] == [[0] * 8, [1] * 4, [1, 1, 0, 0]]
+
+    def test_grpo_mainstream_ties_use_first_sibling(self):
+        args = make_args(
+            advantage_estimator="grpo",
+            rewards_normalization=True,
+            grpo_std_normalization=False,
+            n_samples_per_prompt=2,
+            rollout_batch_size=1,
+        )
+        samples = [
+            make_sample(group_index=0, index=0, rollout_id=10, reward=2.0, loss_mask=[0, 0, 0, 0]),
+            make_sample(group_index=0, index=0, rollout_id=10, reward=8.0, loss_mask=[0, 0, 0, 0]),
+            make_sample(group_index=0, index=1, rollout_id=11, reward=6.0, loss_mask=[1, 1, 1, 1]),
         ]
 
         _, processed = _post_process_rewards(args, samples, custom_reward_post_process_func=None)
 
-        assert processed == pytest.approx([-1.0, 1.0, 0.0])
+        assert processed == pytest.approx([-2.0, -2.0, 2.0])
 
     def test_prompt_group_sizes_override_reused_group_index(self):
         args = make_args(advantage_estimator="grpo", rewards_normalization=True)
@@ -393,6 +423,19 @@ class TestPostProcessRewards:
         )
 
         assert processed == pytest.approx([-1.0, 1.0, -2.0, 2.0])
+
+    def test_noncontiguous_group_indices_share_reward_group(self):
+        args = make_args(advantage_estimator="grpo", rewards_normalization=True)
+        samples = [
+            make_sample(group_index=0, rollout_id=10, reward=0.0),
+            make_sample(group_index=1, rollout_id=20, reward=10.0),
+            make_sample(group_index=0, rollout_id=11, reward=2.0),
+            make_sample(group_index=1, rollout_id=21, reward=14.0),
+        ]
+
+        _, processed = _post_process_rewards(args, samples, custom_reward_post_process_func=None)
+
+        assert processed == pytest.approx([-1.0, -2.0, 1.0, 2.0])
 
     @pytest.mark.parametrize(
         ("rewards", "expected"),

--- a/tests/fast/rollout/generate_hub/test_multi_turn.py
+++ b/tests/fast/rollout/generate_hub/test_multi_turn.py
@@ -115,6 +115,8 @@ def verify_samples(actual: Sample | list[Sample], expected: list[ExpectedSampleI
 
         actual_partial = replace(
             deepcopy(actual_item),
+            index=None,
+            rollout_id=None,
             tokens=[],
             loss_mask=[],
             rollout_log_probs=[],
@@ -129,6 +131,8 @@ def verify_samples(actual: Sample | list[Sample], expected: list[ExpectedSampleI
 
 
 def _run_generate(variant: str, env: GenerateEnv, sample: Sample, sampling_params: dict | None = None):
+    if is_agentic_variant(variant) and sample.index is None:
+        sample.index = 0
     return run_generate(env, sample, sampling_params, variant=variant)
 
 

--- a/tests/fast/router/test_session_v1_v2_parity.py
+++ b/tests/fast/router/test_session_v1_v2_parity.py
@@ -64,6 +64,7 @@ def test_agentic_v2_drop_retries_matches_v1_training_payload_bitwise():
     assert len(v1_runs) == len(v2_runs) == _BATCH_SIZE
     for index, (v1, v2) in enumerate(zip(v1_runs, v2_runs, strict=True)):
         assert v1.samples[0].index == v2.samples[0].index == index
+        assert v1.samples[0].rollout_id == v2.samples[0].rollout_id == index
         assert v1.samples[0].weight_versions == _SELECTED_WEIGHT_VERSIONS
         assert v2.samples[0].weight_versions == _SELECTED_WEIGHT_VERSIONS
         assert_agentic_retry_trajectory_parity(v1, v2)
@@ -78,6 +79,7 @@ def _run_scripted_agents(version: str):
     input_samples = [
         Sample(
             index=index,
+            rollout_id=index,
             prompt=build_initial_messages(),
             reward=0.25,
             metadata={"source": "parity"},


### PR DESCRIPTION
## Summary

Normalize one mainstream reward per rollout without weighting statistics by leaf fanout.

## Symptom & Reproduction

- **Symptom:** Variable session-v2 leaf fanout gives one rollout multiple segment rewards, so row-level normalization weights prompt statistics by segment count and lacks one rollout target.
- **Symptom:** At head `de5a77bef381885a6e72d748fcdf33c02bcb48e5` (merge `592e00fb3a0ce904a18a7505be6919dcfa3b3e6e`, attempt 1), [stage-b-cpu](https://github.com/radixark/miles/actions/runs/31578354263/job/94055696945) failed with `v2 agentic samples require input Sample.rollout_id or Sample.index`, and [stage-a-cpu (2)](https://github.com/radixark/miles/actions/runs/31578354263/job/94055697479) failed with `sample.rollout_id is not bitwise equal`.
- **Reproduction:** For one prompt containing rollout A reward `[0]` plus rollout B sibling rewards `[2, 6]` on respective trainable-token counts `[1, 3]`, normalization uses representatives `[0, 6]` before broadcasting rollout B's result.

## Root Cause

1. `_post_process_rewards` observed flattened segment rewards.
2. `rollout_id` siblings lacked one representative rollout reward.
3. `_normalize_rewards_by_rollout` retained conflicting sibling targets.
4. `agentic_tool_call.generate` now propagates v2 rollout identity.
5. `test_multi_turn.py` and `test_session_v1_v2_parity.py` left identity unset.

## Fix

`_reward_group_segments` restores prompt boundaries from `prompt_group_sizes`, complete `Sample.group_index` values, or the existing fixed-layout fallback. Within each prompt, `_normalize_rewards_by_rollout` selects the first sibling with the most trainable tokens as the mainstream sample, uses its raw reward as the rollout reward, computes statistics over one reward per rollout, and broadcasts the resulting advantage to every sibling. This assumes the longest trainable sibling best represents a rollout when sibling rewards differ; ties preserve input order. The session tests now assign explicit rollout identity to v2-facing fixtures and compare non-identity structure separately, matching the production contract instead of weakening it.

## Verification

- Reward post-processing properties: 21 tests passed for mainstream selection, missing masks, removed samples, stable ties, sibling broadcast, prompt boundaries, estimator branches, empty input, and property invariants.
- `tests/fast/ray/rollout/test_multi_lora_train_data.py`: 4 tests passed for heterogeneous explicit prompt groups.
- Exact PR merge SHA with the fixture patch, stage-b pytest command: 85 passed, 17 skipped.
- Exact PR merge SHA with the fixture patch, stage-a CPU partition 2: 990 passed, 5 skipped.
- Current branch focused identity regressions: 3 passed.
- `pre-commit run --files tests/fast/rollout/generate_hub/test_multi_turn.py tests/fast/router/test_session_v1_v2_parity.py`: all applicable hooks passed.
- `git diff --check 3a6634f85074d6908a34efb1393ea18aac9c1d1a d3b377b0117a995ff834085150c56f675cb248c3`: passed with no output.

## Review Focus

- `_reward_group_segments`: prompt boundaries retain `prompt_group_sizes`, `group_index`, and fixed-layout precedence.
- `_normalize_rewards_by_rollout`: each rollout contributes one reward and all siblings receive one broadcast advantage.
- Mainstream assumption: longest-trainable and first-on-tie behavior match the intended product rule.
- Session fixtures: explicit rollout identity matches the v2 contract.
