### PR TITLE
docs: README minor changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <img src="https://raw.githubusercontent.com/radixark/miles/main/imgs/miles_logo.png" alt="Miles Logo" width="389">
 
-### **Enterprise-Grade Reinforcement Learning for Large-Scale Model Training**
+## **Enterprise-Grade Reinforcement Learning for Large-Scale Model Training**
 ### **High-Performance Rollout • Low Precision Training • Production Stability**
 
 [![GitHub Repo](https://img.shields.io/badge/github-radixark%2Fmiles-black?logo=github)](https://github.com/radixark/miles)
@@ -11,8 +11,12 @@
 
 [**Quick Start**](https://miles.radixark.com/docs/getting-started/quick-start) | [**Advanced Features**](https://miles.radixark.com/docs/advanced) | [**Developer Guide**](https://miles.radixark.com/docs/developer) | [**Documentation**](https://miles.radixark.com/docs)
 
+<br/>
+
+> *"A journey of a thousand miles begins with a single rollout."*
+
+<br/>
+
 </div>
 
 **Miles** is a high-performance, enterprise-ready reinforcement learning (RL) framework specifically optimized for **Large-Scale model Post-Training**. Miles bridges the gap between research-grade RL and production-grade reliability by integrating **SGLang** for high-throughput rollout and **Megatron-LM** for scalable training.
-
-> *"A journey of a thousand miles begins with a single rollout."*

--- a/README.md
+++ b/README.md
@@ -19,4 +19,4 @@
 
 </div>
 
-Miles is a high-performance, enterprise-ready reinforcement learning (RL) framework specifically optimized for **large-scale post-training**. Miles bridges the gap between research-grade RL and production-grade reliability by integrating **SGLang** for high-throughput rollout and **Megatron-LM** for scalable training.
+Miles is a high-performance, enterprise-ready reinforcement learning (RL) framework specifically optimized for **large-scale post-training**. Miles bridges the gap between research-grade flexibility and production-grade reliability by integrating **SGLang** for high-throughput rollout and **Megatron-LM** for scalable training.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <img src="https://raw.githubusercontent.com/radixark/miles/main/imgs/miles_logo.png" alt="Miles Logo" width="389">
 
-## **Enterprise-Grade Reinforcement Learning for Large-Scale Model Training**
+## **Enterprise-Grade Large-Scale Post-Training**
 ### **High-Performance Rollout • Low Precision Training • Production Stability**
 
 [![GitHub Repo](https://img.shields.io/badge/github-radixark%2Fmiles-black?logo=github)](https://github.com/radixark/miles)

--- a/README.md
+++ b/README.md
@@ -19,4 +19,4 @@
 
 </div>
 
-**Miles** is a high-performance, enterprise-ready reinforcement learning (RL) framework specifically optimized for **Large-Scale model Post-Training**. Miles bridges the gap between research-grade RL and production-grade reliability by integrating **SGLang** for high-throughput rollout and **Megatron-LM** for scalable training.
+Miles is a high-performance, enterprise-ready reinforcement learning (RL) framework specifically optimized for **large-scale post-training**. Miles bridges the gap between research-grade RL and production-grade reliability by integrating **SGLang** for high-throughput rollout and **Megatron-LM** for scalable training.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="https://raw.githubusercontent.com/radixark/miles/main/imgs/miles_logo.png" alt="Miles Logo" width="550">
+<img src="https://raw.githubusercontent.com/radixark/miles/main/imgs/miles_logo.png" alt="Miles Logo" width="389">
 
 ### **Enterprise-Grade Reinforcement Learning for Large-Scale Model Training**
 ### **High-Performance Rollout • Low Precision Training • Production Stability**


### PR DESCRIPTION
## Summary

Shrinks the Miles logo on the repo README and polishes the banner and intro (follow-up edits from review):

- **Logo at half the area**: the `<img>` width drops from `550` to `389`, which halves the logo area.
- **Banner heading**: the first tagline becomes an H2 and now reads "Enterprise-Grade Large-Scale Post-Training".
- **Quotation placement**: the *"A journey of a thousand miles begins with a single rollout."* quote moves up into the centered banner, right after the Quick Start nav links, with `<br/>` spacers before and after for vertical breathing room.
- **Intro wording**: "Miles" unbolded; "optimized for **Large-Scale model Post-Training**" becomes "optimized for **large-scale post-training**"; "research-grade RL" becomes "research-grade flexibility".

## Test plan

- [ ] README renders on GitHub with the smaller centered logo, the H2 tagline, and the quote inside the banner
