### PR TITLE
HUD computer-use RL: train a VLM on HUD tasksets through a browser

### DIFF
--- a/docs/user-guide/environments.md
+++ b/docs/user-guide/environments.md
@@ -19,6 +19,7 @@ where the environment itself comes from:
 | Integration | Plugs in at | Guide |
 |---|---|---|
 | [Harbor](https://github.com/harbor-framework/harbor) | agent function | [guide](/user-guide/harbor) |
+| [HUD](https://hud.ai) | generate function³ | [example](https://github.com/radixark/miles/tree/main/examples/experimental/hud) |
 | [NeMo Gym](https://github.com/NVIDIA-NeMo/Gym) | agent function | [guide](/user-guide/nemo-gym) |
 | [OpenEnv](https://github.com/huggingface/openenv) | agent function | [guide](/user-guide/openenv) |
 | [Strands Agents](https://strandsagents.com/) | generate function | [example](https://github.com/radixark/miles/tree/main/examples/experimental/strands_sglang) |
@@ -31,7 +32,7 @@ Sandbox providers are a different axis: they provision the task containers
 | Sandbox provider | Used within | Guide |
 |---|---|---|
 | [AgentENV](https://github.com/kvcache-ai/AgentENV) | OpenEnv | [example](https://github.com/radixark/miles/tree/main/examples/experimental/agentenv) |
-| [Daytona](https://www.daytona.io/) | OpenEnv, Harbor, NeMo Gym | [example](https://github.com/radixark/miles/tree/main/examples/experimental/openenv) |
+| [Daytona](https://www.daytona.io/) | OpenEnv, Harbor, HUD, NeMo Gym | [example](https://github.com/radixark/miles/tree/main/examples/experimental/openenv) |
 | [E2B](https://e2b.dev/) | OpenEnv | [example](https://github.com/radixark/miles/tree/main/examples/experimental/openenv) |
 | [Modal](https://modal.com/) | OpenEnv | [example](https://github.com/radixark/miles/tree/main/examples/experimental/openenv) |
 
@@ -62,3 +63,10 @@ rather than the session-server chat endpoint Miles' own recording uses.
 ² The environment may grade an episode itself (Harbor and τ-bench do); the
 score still enters training through Miles' `Sample.reward` / RM hooks, and
 group-level reward handling stays in Miles.
+
+³ Which layer a connector wants can depend on the episode, not just the
+framework. HUD's connector serves computer-use tasksets, whose observations are
+screenshots, and sits in the generate function because the session server's
+recording is text-only *for now*; a text-only HUD taskset would fit the agent
+function instead. Once that recording covers images, this connector can move
+inward to the agent function as well.

--- a/examples/experimental/hud/README.md
+++ b/examples/experimental/hud/README.md
@@ -1,0 +1,103 @@
+# Computer-use RL on HUD environments
+
+Trains a VLM to operate a real GUI through [HUD](https://hud.ai) environments,
+using HUD's published tasksets as-is. Nothing under `miles/` is modified.
+
+**Result** — Qwen3-VL-4B-Instruct, GRPO, 8×H200, 32 episodes per step, 2048 in a
+browser: over 16 steps the mean game score went 200 → 865 and the *worst*
+episode of a batch went 0 → 540. The second number is the one that matters —
+a lucky episode was already worth ~800 points before training, so what training
+bought is reliability, not a higher ceiling. It plateaus around step 11 because
+~89 key presses cannot produce much more than ~950 points; `hud_keys_per_turn`
+moves that, more steps do not.
+
+| seam | file |
+|---|---|
+| `--custom-generate-function-path` | [`rollout.py`](rollout.py) — multi-turn episode loop |
+| `--custom-rm-path` | [`rollout.py`](rollout.py) `reward_func` |
+| `--custom-config-path` | [`hud2048_config.yaml`](hud2048_config.yaml) |
+| interaction env | [`hud_task_env.py`](hud_task_env.py) |
+
+Anything named `hud2048_*` or `run_hud2048` is this one taskset; the rest is not
+supposed to know which taskset it is running.
+
+## The task row is the interface
+
+A HUD taskset row describes a whole episode, so the adapter has no per-task code:
+
+```json
+{
+  "mcp_config":    {"browser": {"headers": {"Mcp-Image": "hudevals/hud-browser:0.1.6"}}},
+  "setup_tool":    {"name": "launch_app", "arguments": {"app_name": "2048"}},
+  "evaluate_tool": {"name": "evaluate", "arguments": {"name": "game_2048_max_number", ...}}
+}
+```
+
+**Format.** This reads the taskset row format the `hud-evals/*` datasets publish
+— `mcp_config`, `setup_tool`, `evaluate_tool` — which is what their environment
+images serve. HUD's current spec (v6) defines a task as a template inside an
+environment package, reached over HUD's own control channel; adding a v6 leg
+replaces `mcp_client.py`, the fetch in `make_hud_data.py` and the two tool calls
+in `hud_task_env.py`, and leaves the rollout, reward and sandbox-lifecycle
+plumbing — most of this example — unchanged.
+
+`make_hud_data.py` puts the row in the prompt file's `metadata` column;
+`--metadata-key` carries it to `Sample.metadata`; the env boots that image, makes
+that setup call, and grades with that evaluate call. The model acts by writing
+`Action: press("Left","Down")` / `click(x, y)` / `type("...")` / `done()` — plain
+text rather than tool calls, because the loss is on the tokens the policy
+generated, so an action has to *be* those tokens.
+
+## Running it
+
+```bash
+hf download Qwen/Qwen3-VL-4B-Instruct --local-dir /root/models/Qwen3-VL-4B-Instruct
+
+# 2048-basic is a one-row taskset, so --repeat fills the file with independent
+# episodes of it; a taskset with real rows uses --repeat 1.
+python -m examples.experimental.hud.make_hud_data \
+    --dataset hud-evals/2048-basic --repeat 256 --output /root/hud2048_train.jsonl
+
+export DAYTONA_API_KEY=dtn_...                        # or ~/.config/daytona/api_key
+export MILES_SCRIPT_OUTPUT_DIR=/persistent/hud2048    # checkpoints and rollout dumps
+python -m pytest examples/experimental/hud/tests/ -q  # offline: no GPU, no network
+python examples/experimental/hud/run_hud2048.py       # 8 GPUs, single node
+```
+
+Three cheaper rungs below a training run, in the order worth trying them:
+
+| | covers | costs |
+|---|---|---|
+| `pytest examples/experimental/hud/tests/` | the translation between task row, model text and MCP calls | nothing |
+| `python -m examples.experimental.hud.smoke_episode --dataset ...` | image boots, MCP answers, the row's setup and grade calls work, screenshots arrive | one sandbox |
+| `MILES_SCRIPT_MODE=debug_rollout_only python .../run_hud2048.py` | the same with a real policy driving it, no training step | GPUs |
+
+## Pointing it at another taskset
+
+`--dataset` is the only thing that changes:
+
+```bash
+python -m examples.experimental.hud.make_hud_data --dataset hud-evals/OSWorld-Gold --output ...
+```
+
+2048 is what this is verified on, end to end, through training. Other tasksets
+(`hud-evals/OSWorld-Gold`, `SheetBench-50`) need no adapter code by
+construction, but nothing beyond that is tested: their images are far heavier
+than a browser one, and a desktop task will exercise `click` / `type` where 2048
+only ever presses keys. `smoke_episode.py` is the check to run first — it costs
+one sandbox and no GPUs.
+
+The action vocabulary is the one thing that is ours rather than the row's, so it
+is also where a new taskset needs work: verbs live in `hud_task_env.py` `_do`,
+and the description the model is taught them by is `DSL_SUFFIX` in
+`make_hud_data.py`. Keys are passed through as written (`press("ctrl+c")` is a
+chord, `press("Left","Down")` a sequence), but 2048's prompt only ever advertises
+the arrows.
+
+Two knobs are worth understanding before you turn them up, because both trade
+against rollout speed: every turn re-prefills the whole screenshot history
+through the vision encoder, so `max_turns` and `hud_screenshot_width` cost more
+than they look like they do — at 960px × 14 turns a cache-missing episode
+re-prefilled ~5.5k tokens at 14 tok/s, slow enough to stall a batch behind one
+engine. `hud_inference_timeout_s` bounds that failure. The rest of the config is
+annotated in [`hud2048_config.yaml`](hud2048_config.yaml).

--- a/examples/experimental/hud/hud2048_config.yaml
+++ b/examples/experimental/hud/hud2048_config.yaml
@@ -1,0 +1,39 @@
+# HUD 2048, sized from measurements on hudevals/hud-browser:0.1.6.
+#
+# Move budget drives the signal. A random policy and a corner strategy both cap
+# at tile 8 by ~12 moves, and only separate from ~20 moves on (at 40: greedy 32
+# vs random 16). Turns are the expensive axis -- each one re-prefills the
+# screenshot history through the ViT -- while keys within a turn are nearly
+# free, so an action carries 4 keys and 24 turns buy ~92 moves for ~5.3k vision
+# tokens of context.
+#
+# Reward: the taskset grades on log2(max_tile)/log2(target), which is a
+# five-level step function. Twice in a row a population converged on one tile
+# (all 32 episodes at exactly 3/7, then at exactly 5/7), within-group variance
+# went to zero and GRPO had no gradient. hud_reward_tool switches training onto
+# the same environment's score, which is min(1, score/target_score): continuous,
+# monotone in good play, and it cannot go flat. The taskset's own grade is still
+# recorded every episode as task_reward.
+max_turns: 24
+rollout_interaction_env_path: examples.experimental.hud.hud_task_env
+hud_screenshot_width: 640
+hud_keys_per_turn: 4
+# A turn is two sentences of reasoning and one action line. Capping it keeps one
+# rambling turn from eating an episode's whole response budget, which otherwise
+# ends the episode early with most of its move budget unspent.
+hud_max_tokens_per_turn: 200
+hud_max_sandboxes: 32
+hud_sandbox_max_age_min: 20
+hud_inference_timeout_s: 600
+# target_score sets where the reward saturates, and saturation is the fourth
+# ceiling this recipe hit: at 512 an untrained policy starts near 0.34, but by
+# the time the mean reaches 0.71 some 59% of episodes score above 512, clip to
+# 1.0, and stop being distinguishable from each other -- the best half of the
+# batch carries no gradient. 1024 keeps the top of the reachable range (a strong
+# episode scores ~900) inside the linear part.
+hud_reward_tool:
+  name: evaluate
+  arguments:
+    name: game_2048_score_reached
+    arguments:
+      target_score: 1024

--- a/examples/experimental/hud/hud2048_prompt.py
+++ b/examples/experimental/hud/hud2048_prompt.py
@@ -1,0 +1,32 @@
+"""2048's briefing -- the one taskset-specific string in this recipe.
+
+It lives apart from ``make_hud_data.py`` so that file stays readable as what it
+is: a generic taskset-to-jsonl converter. A row's own ``system_prompt`` and
+``prompt`` are what normally reach the model; this substitutes for both, because
+2048's shipped prompts are written for a tool-calling browser agent and name a
+max-tile goal, while this recipe trains on score.
+
+The strategy paragraph is a deliberately imperfect prior, kept as-is. It is sound
+advice for a human playing 2048 with unlimited moves and a highest-tile goal, and
+it is wrong for this setup: an episode gets ~89 key presses and is scored on
+merges, and pressing only Left/Down wastes most of that budget on no-ops
+(measured: 48 presses -> 14 effective moves, score 60; using all four directions
+-> 48 moves, score 368). Training discovers this on its own -- Up + Right rose
+from 5% to 34% of presses while mean score went 200 -> 712 -- which is the
+clearest evidence in this recipe that the policy learns from the environment
+rather than reciting the prompt. Fixing the hint would remove that signal.
+"""
+
+import json
+from typing import Any
+
+GAME_2048_HINT = """You are playing 2048 in a browser. Tiles slide with arrow keys; equal tiles \
+merge and double. Your score grows with every merge, so keep merging.
+
+Strategy: keep your biggest tile in one corner and build a descending row toward it. Prefer Left \
+and Down. Use Right only when Left and Down both change nothing. Avoid Up, which breaks the corner."""
+
+
+def applies(setup_tool: Any) -> bool:
+    """True for rows whose setup call launches 2048."""
+    return "2048" in json.dumps(setup_tool or {})

--- a/examples/experimental/hud/hud_task_env.py
+++ b/examples/experimental/hud/hud_task_env.py
@@ -1,0 +1,295 @@
+"""Interaction environment for any HUD task, driven by the task row itself.
+
+A HUD taskset row (the format its HuggingFace datasets ship in) is:
+
+    prompt          the instruction
+    mcp_config      {"<name>": {"url": ..., "headers": {"Mcp-Image": <image>}}}
+    setup_tool      {"name": ..., "arguments": {...}}   -- one MCP call
+    evaluate_tool   {"name": ..., "arguments": {...}}   -- one MCP call, returns reward
+    system_prompt / agent_config
+
+so an episode is: bring the image up, make the setup call, loop
+{screenshot -> model -> computer call}, make the evaluate call. The row travels
+in ``sample.metadata["hud_task"]`` (see make_hud_data.py).
+
+Which image to boot, how to set the task up and how to grade it are entirely the
+row's business, so a different taskset is a data change. What this file does fix
+is the *action vocabulary*: press / click / type / done, keys passed through to
+the image's ``computer`` tool as the model wrote them. Only that vocabulary, not
+any one task, is the assumption -- a taskset needing drag or scroll adds a verb
+here, and a taskset where one turn should be one keystroke sets
+``hud_keys_per_turn: 1`` (which also turns off the use-your-whole-budget
+coaching below).
+
+The model acts through a text DSL rather than provider tool-calling, because
+the emitted tokens *are* the training signal: the loss is on the text the
+policy generates, so an action has to be text the policy generated.
+
+Reward: the row's ``evaluate_tool`` is the task's own grade and is always
+recorded as ``task_reward``. Training can optimize a denser surrogate from the
+same environment via ``hud_reward_tool`` -- for 2048 the graded metric is
+log2(max_tile)/log2(target), a five-level step function that goes flat the
+moment a population converges on one tile, while score is continuous.
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+import json
+import logging
+import re
+import time
+from typing import Any
+
+from examples.experimental.hud.sandbox import HudSandbox, get_gate, start_reaper
+from PIL import Image
+
+from miles.utils.types import Sample
+
+logger = logging.getLogger(__name__)
+
+# `Action: verb(arg, arg)` on the last such line of a response.
+_ACTION_RE = re.compile(r"Action:\s*(\w+)\s*\(([^)]*)\)", re.IGNORECASE)
+_WORD_RE = re.compile(r"[A-Za-z]+")
+_INT_RE = re.compile(r"-?\d+")
+_QUOTED_RE = re.compile(r"[\"']([^\"']*)[\"']")
+
+# Capitalization the arrow keys are known to work with. Everything else is
+# passed to the image's ``computer`` tool as the model wrote it: a whitelist here
+# would silently drop every key a desktop task needs.
+_ARROWS = {"left": "Left", "right": "Right", "up": "Up", "down": "Down"}
+
+
+def parse_keys(raw: str) -> list[list[str]]:
+    """``press`` arguments as a list of key-groups, in order.
+
+    Each group is one MCP ``press`` call. A group of several keys is a chord
+    (``"ctrl+c"``); separate arguments are pressed in sequence, which is what
+    makes a per-turn move budget mean anything -- one call with ``keys=[a,b,c]``
+    is a pyautogui hotkey, not three moves.
+
+    Quoted arguments are taken as written, so any key the image accepts works.
+    Unquoted ones fall back to arrow names only: ``press(Left and then Down)``
+    is common enough to honour, and prose is not distinguishable from key names
+    without the quotes, so pressing every word would just burn the move budget.
+    """
+    tokens = _QUOTED_RE.findall(raw)
+    if not tokens:
+        tokens = [w for w in _WORD_RE.findall(raw) if w.lower() in _ARROWS]
+    groups = []
+    for token in tokens:
+        keys = [_ARROWS.get(k.lower(), k) for k in token.split("+") if k.strip()]
+        if keys:
+            groups.append(keys)
+    return groups
+
+
+def parse_action(text: str) -> tuple[str, str] | None:
+    """The last ``Action:`` line as (verb, raw-args), or None if absent."""
+    matches = _ACTION_RE.findall(text or "")
+    if not matches:
+        return None
+    verb, raw = matches[-1]
+    return verb.lower(), raw
+
+
+def image_from_b64(data: str, width: int) -> tuple[Image.Image, int]:
+    """Decode a screenshot, downscaled to *width*. Also returns its native width,
+    which is the scale factor for click coordinates the model gives in the
+    downscaled view."""
+    img = Image.open(io.BytesIO(base64.b64decode(data))).convert("RGB")
+    native = img.width
+    if width and img.width > width:
+        img = img.resize((width, round(img.height * width / img.width)), Image.LANCZOS)
+    return img, native
+
+
+def image_of(task: dict) -> str:
+    """The container image a HUD row asks for (its ``Mcp-Image`` header)."""
+    for entry in (task.get("mcp_config") or {}).values():
+        if isinstance(entry, dict):
+            image = (entry.get("headers") or {}).get("Mcp-Image")
+            if image:
+                return image
+    raise ValueError(f"no Mcp-Image in mcp_config: {task.get('mcp_config')!r}")
+
+
+def _as_calls(spec: Any) -> list[dict]:
+    """Normalize a row's tool field: one call, a list of calls, or JSON text."""
+    if spec is None:
+        return []
+    if isinstance(spec, str):
+        spec = json.loads(spec)
+    if isinstance(spec, dict):
+        return [spec]
+    return [c for c in spec if isinstance(c, dict)]
+
+
+class HudTaskEnv:
+    """One episode against one HUD task. Synchronous by design: the rollout
+    calls it from a worker thread so its network I/O never blocks the event
+    loop shared by every concurrent episode."""
+
+    def __init__(self, sample: Sample | None, args: Any) -> None:
+        self.args = args
+        meta = (getattr(sample, "metadata", None) or {}) if sample is not None else {}
+        self.task: dict = meta.get("hud_task") or getattr(args, "hud_task", None) or {}
+        if not self.task:
+            raise ValueError("no HUD task row: expected sample.metadata['hud_task']")
+
+        self.shot_width = int(getattr(args, "hud_screenshot_width", 640))
+        self.keys_per_turn = int(getattr(args, "hud_keys_per_turn", 4))
+        self.reward_tool = getattr(args, "hud_reward_tool", None)
+        max_age = float(getattr(args, "hud_sandbox_max_age_min", 20))
+
+        self.sandbox = HudSandbox(image_of(self.task), max_age_min=max_age)
+        self.gate = get_gate(int(getattr(args, "hud_max_sandboxes", 32)))
+        start_reaper(max_age)
+
+        self.mcp = None
+        self.native_width = 0
+        self.turn = 0
+        self.actions = 0
+        self.parse_failures = 0
+        self.short_actions = 0
+
+    # ---- lifecycle ----
+
+    def reset(self):
+        self.mcp = self.sandbox.start(self.gate)
+        for call in _as_calls(self.task.get("setup_tool")):
+            result = self.mcp.call_tool(call["name"], call.get("arguments") or {})
+            logger.debug("[hud %s] setup %s -> %s", self.sandbox.run_id, call["name"], result.text[:120])
+        time.sleep(2)  # let the app paint before the first screenshot
+        self.turn = self.actions = self.parse_failures = self.short_actions = 0
+        return {}, {"run_id": self.sandbox.run_id}
+
+    def close(self):
+        try:
+            if self.mcp is not None:
+                self.mcp.close()
+        finally:
+            self.mcp = None
+            self.sandbox.delete()
+
+    # ---- interaction ----
+
+    def _screenshot(self) -> Image.Image:
+        result = self.mcp.call_tool("computer", {"action": "screenshot"})
+        if not result.image_b64:
+            raise RuntimeError(f"screenshot returned no image: {result.text[:200]!r}")
+        img, self.native_width = image_from_b64(result.image_b64, self.shot_width)
+        return img
+
+    def _do(self, verb: str, raw: str) -> str:
+        """Execute one parsed action. Returns a note to show the model, if any."""
+        if verb == "press":
+            groups = parse_keys(raw)[: self.keys_per_turn]
+            if not groups:
+                return 'No key in that action, e.g. press("Left") or press("ctrl+c"). '
+            for keys in groups:
+                self.mcp.call_tool("computer", {"action": "press", "keys": keys})
+                self.actions += 1
+                time.sleep(0.25)
+            if len(groups) < self.keys_per_turn:
+                self.short_actions += 1
+                return (
+                    f"You gave {len(groups)} key(s); give exactly {self.keys_per_turn} keys "
+                    f"per action to use the turn fully. "
+                )
+            return ""
+        if verb == "click":
+            xy = [int(v) for v in _INT_RE.findall(raw)[:2]]
+            if len(xy) < 2:
+                return "click needs two coordinates, e.g. click(840, 320). "
+            if not self.native_width:
+                return "Take Action: screenshot() before clicking, so you can see where to click. "
+            # Coordinates are in the model's downscaled view; scale back up to
+            # the screen the environment actually renders.
+            scale = self.native_width / self.shot_width if self.shot_width else 1
+            self.mcp.call_tool("computer", {"action": "click", "x": round(xy[0] * scale), "y": round(xy[1] * scale)})
+            self.actions += 1
+            time.sleep(0.4)
+            return ""
+        if verb in ("type", "write"):
+            m = _QUOTED_RE.search(raw)
+            self.mcp.call_tool("computer", {"action": "write", "text": m.group(1) if m else raw.strip()})
+            self.actions += 1
+            time.sleep(0.4)
+            return ""
+        if verb in ("screenshot", "look"):
+            return ""  # the observation below is the screenshot
+        return f'Unknown action "{verb}". '
+
+    def step(self, response_text: str):
+        self.turn += 1
+        parsed = parse_action(response_text)
+
+        if parsed is None:
+            self.parse_failures += 1
+            if self.parse_failures >= 3:
+                return {}, True, {"reason": "parse_failures"}
+            note = 'Invalid action format. Put e.g. Action: press("Left","Down") on the last line. '
+        else:
+            self.parse_failures = 0
+            verb, raw = parsed
+            if verb in ("done", "stop", "submit"):
+                return {}, True, {"reason": "done"}
+            note = self._do(verb, raw)
+
+        obs = {
+            "multi_modal_data": {"image": [self._screenshot()]},
+            "obs_str": f"{note}Turn {self.turn}, actions so far: {self.actions}. Next action?",
+        }
+        return obs, False, {}
+
+    def format_observation(self, observation: dict) -> dict:
+        content: list[dict] = []
+        for images in (observation.get("multi_modal_data") or {}).values():
+            content.extend({"type": "image", "image": img} for img in images)
+        content.append({"type": "text", "text": observation.get("obs_str", "")})
+        return {"role": "user", "content": content}
+
+    # ---- grading ----
+
+    def _grade(self, call: dict) -> dict:
+        result = self.mcp.call_tool(call["name"], call.get("arguments") or {})
+        payload = result.payload()
+        return {
+            # A grader may answer with a null reward or with content blocks
+            # rather than a string; neither should take an episode down.
+            "reward": float(payload.get("reward") or 0.0),
+            "done": bool(payload.get("done", False)),
+            "info": payload.get("info"),
+            "content": str(payload.get("content") or result.text)[:200],
+        }
+
+    def compute_final_reward(self) -> dict:
+        """Grade with the task's own evaluate_tool, plus the training surrogate.
+
+        ``task_reward`` is the number the taskset defines and the one to report;
+        ``reward`` is what GRPO optimizes and may be the denser surrogate.
+        """
+        out: dict[str, Any] = {"turns": self.turn, "actions": self.actions, "short_actions": self.short_actions}
+
+        task_calls = _as_calls(self.task.get("evaluate_tool"))
+        graded = self._grade(task_calls[0]) if task_calls else {"reward": 0.0, "info": None, "content": ""}
+        out["task_reward"] = graded["reward"]
+        out["task_grade"] = graded["content"]
+        if isinstance(graded.get("info"), dict):
+            out.update({f"task_{k}": v for k, v in graded["info"].items()})
+
+        surrogate = _as_calls(self.reward_tool)
+        if surrogate:
+            dense = self._grade(surrogate[0])
+            out["reward"] = dense["reward"]
+            if isinstance(dense.get("info"), dict):
+                out.update({f"dense_{k}": v for k, v in dense["info"].items()})
+        else:
+            out["reward"] = graded["reward"]
+        return out
+
+
+def build_env(sample: Sample | None = None, args: Any = None) -> HudTaskEnv:
+    return HudTaskEnv(sample, args)

--- a/examples/experimental/hud/make_hud_data.py
+++ b/examples/experimental/hud/make_hud_data.py
@@ -1,0 +1,146 @@
+"""Build a miles prompt jsonl from a HUD taskset on HuggingFace.
+
+The HUD row travels whole in the ``metadata`` column (miles' ``--metadata-key``
+puts it on ``Sample.metadata``), so the environment adapter needs no per-task
+code: which image to boot, how to set the task up and how to grade it all come
+from the row.
+
+    python -m examples.experimental.hud.make_hud_data \
+        --dataset hud-evals/2048-basic --repeat 256 --output /root/hud2048_train.jsonl
+
+Tasksets with a handful of rows (2048-basic ships one template) are repeated to
+fill a training file; larger ones (OSWorld-Gold, SheetBench-50) are used as-is
+and ``--repeat`` stays 1.
+
+Taskset-agnostic apart from one import: 2048 substitutes its own briefing for the
+row's prompts, and hud2048_prompt.py says why.
+"""
+
+import argparse
+import json
+import urllib.parse
+import urllib.request
+
+from examples.experimental.hud import hud2048_prompt
+
+ROWS_API = "https://datasets-server.huggingface.co/rows"
+
+# Appended to the row's own system prompt: the action vocabulary is ours (a text
+# DSL, so the tokens the loss is computed on are the tokens that acted), not
+# something the taskset can specify.
+DSL_SUFFIX = """
+
+You act by writing text. Each turn: look at the latest screenshot, think in at most 2 short \
+sentences, then put exactly ONE action on the LAST line, in one of these forms:
+Action: screenshot()
+Action: press("Left","Down","Left","Down")
+Action: click(840, 320)
+Action: type("some text")
+Action: done()
+
+{press_note}Coordinates for click are in the screenshot you were shown.
+Your very first action must be Action: screenshot() to see the screen."""
+
+
+def press_note(keys_per_turn: int) -> str:
+    """What to tell the model about multi-key actions.
+
+    Spending a turn's whole key budget is advice for a task with a move budget
+    and near-free keystrokes. It is wrong where a turn should be one deliberate
+    keystroke, so it is only said when the budget is above one.
+    """
+    if keys_per_turn <= 1:
+        return 'press takes one key, e.g. press("Enter"), or a chord, e.g. press("ctrl+c"). '
+    return (
+        f"press takes up to {keys_per_turn} keys and plays them in order -- "
+        f"you have few turns, so use all {keys_per_turn}. "
+    )
+
+
+def fetch_rows(dataset: str, split: str, limit: int) -> list[dict]:
+    rows: list[dict] = []
+    while len(rows) < limit:
+        q = urllib.parse.urlencode(
+            {
+                "dataset": dataset,
+                "config": "default",
+                "split": split,
+                "offset": len(rows),
+                "length": min(100, limit - len(rows)),
+            }
+        )
+        with urllib.request.urlopen(f"{ROWS_API}?{q}", timeout=60) as resp:
+            payload = json.load(resp)
+        batch = [r["row"] for r in payload.get("rows", [])]
+        if not batch:
+            break
+        rows.extend(batch)
+    return rows
+
+
+def as_json(value):
+    """HF ships these columns as JSON strings; keep them as objects."""
+    if isinstance(value, str):
+        try:
+            return json.loads(value)
+        except json.JSONDecodeError:
+            return value
+    return value
+
+
+def task_of(row: dict) -> dict:
+    """The part of a row the environment adapter reads at rollout time."""
+    return {
+        "id": row.get("id"),
+        "mcp_config": as_json(row.get("mcp_config")),
+        "setup_tool": as_json(row.get("setup_tool")),
+        "evaluate_tool": as_json(row.get("evaluate_tool")),
+    }
+
+
+def build_prompt(row: dict, keys_per_turn: int) -> str:
+    """A row's own prompts plus our action vocabulary.
+
+    A row carries both a system prompt (how to behave) and a prompt (what this
+    instance asks for). For most tasksets the instruction *is* the task, so both
+    go in.
+    """
+    system = row.get("system_prompt") or ""
+    instruction = row.get("prompt") or ""
+    if hud2048_prompt.applies(as_json(row.get("setup_tool"))):
+        system, instruction = hud2048_prompt.GAME_2048_HINT, ""
+    head = "\n\n".join(p for p in (system, instruction) if p)
+    return (head + DSL_SUFFIX.format(press_note=press_note(keys_per_turn))).strip()
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--dataset", default="hud-evals/2048-basic")
+    ap.add_argument("--split", default="train")
+    ap.add_argument("--limit", type=int, default=1000, help="rows to pull from the taskset")
+    ap.add_argument("--repeat", type=int, default=1, help="repeat the taskset to fill the file")
+    ap.add_argument("--keys-per-turn", type=int, default=4)
+    ap.add_argument("--output", default="/root/hud_train.jsonl")
+    args = ap.parse_args()
+
+    rows = fetch_rows(args.dataset, args.split, args.limit)
+    if not rows:
+        raise SystemExit(f"no rows from {args.dataset}")
+    print(f"fetched {len(rows)} row(s) from {args.dataset}")
+
+    written = 0
+    with open(args.output, "w") as f:
+        for _ in range(args.repeat):
+            for row in rows:
+                record = {
+                    "prompt": build_prompt(row, args.keys_per_turn),
+                    "label": "",
+                    "metadata": {"hud_task": task_of(row)},
+                }
+                f.write(json.dumps(record, ensure_ascii=False) + "\n")
+                written += 1
+    print(f"wrote {written} rows to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/experimental/hud/mcp_client.py
+++ b/examples/experimental/hud/mcp_client.py
@@ -1,0 +1,145 @@
+"""Minimal synchronous MCP client for HUD environment images.
+
+Why not the ``mcp`` SDK: the images HUD's published tasksets pin (v5-era,
+``hud-mcp-python-sdk`` 3.13.x speaking protocol 2025-06-18) reject the
+``initialize`` shape that mcp>=2 clients send, and mcp>=2 is what the training
+image already has installed for other packages. This speaks the four calls an
+environment adapter needs, over streamable HTTP, with no version coupling.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass
+
+import httpx
+
+PROTOCOL_VERSION = "2025-06-18"
+
+
+class McpError(RuntimeError):
+    """A JSON-RPC error, or a malformed reply."""
+
+
+@dataclass
+class ToolResult:
+    """The parts of an MCP ``tools/call`` result an env adapter cares about."""
+
+    text: str
+    image_b64: str | None
+    structured: dict | None
+
+    def payload(self) -> dict:
+        """Structured content, falling back to parsing the text block.
+
+        HUD's graders return their EvaluationResult in ``structuredContent``,
+        but older builds only put the JSON in a text block.
+        """
+        if isinstance(self.structured, dict):
+            return self.structured
+        try:
+            parsed = json.loads(self.text)
+        except (json.JSONDecodeError, TypeError):
+            return {}
+        return parsed if isinstance(parsed, dict) else {}
+
+
+class SyncMCP:
+    def __init__(self, base_url: str, timeout: float = 120.0) -> None:
+        self._url = base_url.rstrip("/") + "/mcp"
+        self._client = httpx.Client(timeout=timeout)
+        self._session_id: str | None = None
+        self._next_id = 0
+
+    # ---- wire ----
+
+    def _headers(self) -> dict[str, str]:
+        h = {"Content-Type": "application/json", "Accept": "application/json, text/event-stream"}
+        if self._session_id:
+            h["Mcp-Session-Id"] = self._session_id
+        return h
+
+    def _post(self, payload: dict) -> httpx.Response:
+        return self._client.post(self._url, json=payload, headers=self._headers())
+
+    @staticmethod
+    def _extract(body: str, req_id: int) -> dict:
+        """Pull the result for *req_id* out of a JSON or SSE response body."""
+        for line in body.splitlines():
+            if line.startswith("data:"):
+                line = line[len("data:") :]
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                msg = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if msg.get("id") != req_id:
+                continue
+            if "error" in msg:
+                raise McpError(str(msg["error"]))
+            return msg.get("result", {})
+        raise McpError(f"no reply for id={req_id} in {body[:200]!r}")
+
+    def _rpc(self, method: str, params: dict | None = None) -> dict:
+        self._next_id += 1
+        req_id = self._next_id
+        resp = self._post({"jsonrpc": "2.0", "id": req_id, "method": method, "params": params or {}})
+        resp.raise_for_status()
+        return self._extract(resp.text, req_id)
+
+    # ---- api ----
+
+    def initialize(self, retries: int = 8, delay: float = 4.0) -> dict:
+        """Handshake, retrying while the environment's services come up.
+
+        One session per sandbox: the fork these images carry runs its
+        ``@mcp.initialize`` hook only for the first session of a process and
+        then awaits ``None`` for later ones, so a second session gets -32602.
+        """
+        last: Exception | None = None
+        for _ in range(retries):
+            try:
+                self._next_id += 1
+                req_id = self._next_id
+                resp = self._post(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": req_id,
+                        "method": "initialize",
+                        "params": {
+                            "protocolVersion": PROTOCOL_VERSION,
+                            "capabilities": {},
+                            "clientInfo": {"name": "miles-hud", "version": "0.1"},
+                        },
+                    }
+                )
+                resp.raise_for_status()
+                if sid := resp.headers.get("mcp-session-id"):
+                    self._session_id = sid
+                result = self._extract(resp.text, req_id)
+                self._post({"jsonrpc": "2.0", "method": "notifications/initialized"})
+                return result
+            except Exception as e:  # noqa: BLE001 - services may still be booting
+                last = e
+                time.sleep(delay)
+        raise McpError(f"initialize failed after {retries} attempts: {last}")
+
+    def list_tools(self) -> list[dict]:
+        return self._rpc("tools/list").get("tools", [])
+
+    def call_tool(self, name: str, arguments: dict) -> ToolResult:
+        result = self._rpc("tools/call", {"name": name, "arguments": arguments})
+        texts: list[str] = []
+        image: str | None = None
+        for item in result.get("content", []):
+            if item.get("type") == "text":
+                texts.append(item.get("text", ""))
+            elif item.get("type") == "image":
+                image = item.get("data")
+        return ToolResult("\n".join(texts), image, result.get("structuredContent"))
+
+    def close(self) -> None:
+        self._client.close()

--- a/examples/experimental/hud/rollout.py
+++ b/examples/experimental/hud/rollout.py
@@ -1,0 +1,168 @@
+"""Multi-turn computer-use rollout for HUD environments.
+
+This calls into ``examples.geo3k_vlm.multi_turn.rollout`` at runtime: its token
+accumulation, per-turn loss masking and multimodal bookkeeping run on every turn
+of every episode here (a runtime dependency on another example, not a reference
+to one — see the FIXME below). What this file adds on top:
+
+1. The env does real network I/O (Daytona sandbox + MCP), so ``reset`` /
+   ``step`` / ``close`` run in ``asyncio.to_thread`` instead of blocking the
+   event loop that drives every concurrent episode.
+2. Per-turn generation is capped (``hud_max_tokens_per_turn``) so one rambling
+   turn cannot eat the whole episode budget.
+3. The episode reward is HUD's env-side ``evaluate`` (dense progress), graded
+   in the ``finally`` block *before* the sandbox is deleted and stashed in
+   ``sample.metadata`` for ``reward_func`` below.
+
+Wire with:
+  --custom-generate-function-path examples.experimental.hud.rollout.generate
+  --custom-rm-path examples.experimental.hud.rollout.reward_func
+  --custom-config-path examples/experimental/hud/hud2048_config.yaml
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+# FIXME(hud): private helpers of another example, imported across examples.
+# They are the multi-turn VLM engine -- token accumulation, per-turn loss
+# masking, multimodal merge, chat-template trimming for observations -- i.e. the
+# part that silently corrupts training when it is subtly wrong. Sharing one
+# implementation beats copying it, but note what sharing does *not* buy here:
+# nothing under tests/ exercises this module, and the one VLM e2e test
+# (tests/e2e/fsdp/test_qwen3_vl_4B_fsdp.py) runs single-turn, so these functions
+# have no test coverage and no API contract. Order of repayment: unit-test them
+# first, then promote to miles/rollout/generate_hub/multi_turn_vlm.py next to
+# single_turn / multi_turn / agentic_tool_call and import from both examples.
+from examples.geo3k_vlm.multi_turn.rollout import (
+    _append_to_sample,
+    _build_env,
+    _encode_observation_for_generation,
+    _finalize_sample,
+    _load_env_module,
+    _prepare_start_state,
+    _run_inference_step,
+    _should_stop_on_finish,
+    _update_budget,
+    _update_multimodal_state,
+)
+from miles.rollout.sglang_rollout import GenerateState
+from miles.utils.types import Sample
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_ENV_MODULE = "examples.experimental.hud.hud_task_env"
+
+
+async def generate(args: Any, sample: Sample, sampling_params) -> Sample:
+    assert not args.partial_rollout, "Partial rollout is not supported for interaction rollouts."
+
+    env_module = _load_env_module(getattr(args, "rollout_interaction_env_path", None) or DEFAULT_ENV_MODULE)
+    max_turns = args.max_turns
+    per_turn_cap = int(getattr(args, "hud_max_tokens_per_turn", 256))
+    state = GenerateState(args)
+    url = f"http://{args.sglang_router_ip}:{args.sglang_router_port}/generate"
+    sample.metadata = sample.metadata or {}
+    env = _build_env(env_module, sample, args)
+
+    sampling_params = sampling_params.copy()
+    current_image_data, response_tokens, budget, multimodal_train_inputs_buffer = _prepare_start_state(
+        sample, state, args, sampling_params
+    )
+    try:
+        await asyncio.to_thread(env.reset)
+        if budget is not None and budget <= 0:
+            sample.status = Sample.Status.TRUNCATED
+            return sample
+
+        infer_timeout = float(getattr(args, "hud_inference_timeout_s", 600))
+        cur_sampling_params = sampling_params
+        for turn_idx in range(max_turns):
+            cur_sampling_params["max_new_tokens"] = min(per_turn_cap, budget) if budget is not None else per_turn_cap
+
+            # Hard per-request deadline: a wedged engine otherwise hangs the
+            # episode forever (requests have no client-side timeout) and, at
+            # batch granularity, the whole rollout step (seen 2026-08-10).
+            try:
+                response_text, new_response_tokens, new_response_log_probs, finish_type = await asyncio.wait_for(
+                    _run_inference_step(url, sample.tokens, cur_sampling_params, current_image_data, state.tokenizer),
+                    timeout=infer_timeout,
+                )
+            except asyncio.TimeoutError:
+                logger.warning("hud inference timed out after %.0fs; aborting episode", infer_timeout)
+                sample.status = Sample.Status.ABORTED
+                break
+            _append_to_sample(sample, response_tokens, new_response_tokens, new_response_log_probs, loss_mask_val=1)
+            budget = _update_budget(budget, len(new_response_tokens))
+
+            # Per-turn cap hits are normal turn ends, not episode truncation.
+            if finish_type == "length" and budget is not None and budget <= 0:
+                sample.status = Sample.Status.TRUNCATED
+                break
+            if finish_type != "length" and _should_stop_on_finish(sample, finish_type):
+                break
+
+            observation, done, _step_info = await asyncio.to_thread(env.step, response_text)
+            if done:
+                sample.status = Sample.Status.COMPLETED
+                break
+
+            next_user_message = env.format_observation(observation)
+            obs_prompt_ids, obs_image_data, obs_multimodal_inputs, obs_multimodal_train_inputs = (
+                _encode_observation_for_generation(
+                    state.tokenizer,
+                    state.processor,
+                    next_user_message,
+                    sample.metadata,
+                    args.apply_chat_template,
+                    args.apply_chat_template_kwargs,
+                )
+            )
+            bos_id = state.tokenizer.bos_token_id
+            if bos_id is not None and len(obs_prompt_ids) and obs_prompt_ids[0] == bos_id:
+                obs_prompt_ids = obs_prompt_ids[1:]
+
+            obs_prompt_ids = list(obs_prompt_ids)
+            _append_to_sample(sample, response_tokens, obs_prompt_ids, [0.0] * len(obs_prompt_ids), loss_mask_val=0)
+            budget = _update_budget(budget, len(obs_prompt_ids))
+
+            current_image_data = _update_multimodal_state(
+                sample,
+                current_image_data,
+                obs_image_data,
+                obs_multimodal_inputs,
+                obs_multimodal_train_inputs,
+                multimodal_train_inputs_buffer,
+            )
+
+            if budget is not None and budget <= 0:
+                sample.status = Sample.Status.TRUNCATED
+                break
+            if turn_idx + 1 >= max_turns:
+                sample.status = Sample.Status.COMPLETED
+                break
+
+        return _finalize_sample(sample, state.tokenizer, response_tokens, multimodal_train_inputs_buffer)
+    finally:
+        # Grade before teardown: evaluate lives inside the sandbox. Truncated and
+        # aborted episodes are graded too -- partial progress is still progress,
+        # and a row whose grade is all-or-nothing simply returns 0.
+        try:
+            verdict = await asyncio.to_thread(env.compute_final_reward)
+            sample.metadata.update(verdict)
+        except Exception:  # noqa: BLE001
+            logger.exception("hud grading failed; reward defaults to 0.0")
+            sample.metadata.setdefault("reward", 0.0)
+        try:
+            await asyncio.to_thread(env.close)
+        except Exception:  # noqa: BLE001
+            pass
+
+
+async def reward_func(args, samples: Sample | list[Sample], **kwargs) -> float | list[float]:
+    """Pass through the env-computed dense reward stashed by ``generate``."""
+    if isinstance(samples, list):
+        return [s.metadata.get("reward", 0.0) for s in samples]
+    return samples.metadata.get("reward", 0.0)

--- a/examples/experimental/hud/run_hud2048.py
+++ b/examples/experimental/hud/run_hud2048.py
@@ -1,0 +1,136 @@
+"""HUD 2048 computer-use GRPO launcher (Qwen3-VL-4B-Instruct, FSDP, single node).
+
+Based on the CI-verified qwen3_vl FSDP recipe (tests/e2e/fsdp/
+test_qwen3_vl_4B_fsdp.py); swaps in the HUD multi-turn rollout, the env-side
+dense reward, and text-only prompts (screenshots arrive at runtime, so no
+--multimodal-keys). Runs the legacy rollout path — the multi-turn interaction
+engine this builds on is verified there.
+
+Env knobs:
+  MILES_SCRIPT_MODEL_NAME   default Qwen3-VL-4B-Instruct
+  MILES_SCRIPT_NUM_GPUS     default 8
+  MILES_SCRIPT_NUM_ROLLOUT  default 40
+  MILES_SCRIPT_MODE         normal | debug_rollout_only (skips training)
+  MILES_SCRIPT_OUTPUT_DIR   checkpoints and rollout dumps; point at storage
+                            that outlives the node (default /root/hud2048-rl)
+"""
+
+import os
+
+import miles.utils.external_utils.command_utils as U
+
+MODEL_NAME = os.environ.get("MILES_SCRIPT_MODEL_NAME", "Qwen3-VL-4B-Instruct")
+NUM_GPUS = int(os.environ.get("MILES_SCRIPT_NUM_GPUS", "8"))
+NUM_ROLLOUT = int(os.environ.get("MILES_SCRIPT_NUM_ROLLOUT", "40"))
+MODE = os.environ.get("MILES_SCRIPT_MODE", "normal")
+OUTPUT_DIR = os.environ.get("MILES_SCRIPT_OUTPUT_DIR", "/root/hud2048-rl")
+
+
+def execute():
+    ckpt_args = f"--hf-checkpoint /root/models/{MODEL_NAME} "
+
+    rollout_args = (
+        "--prompt-data /root/hud2048_train.jsonl "
+        "--input-key prompt "
+        "--label-key label "
+        # carries the HUD task row (image, setup, grade) onto Sample.metadata
+        "--metadata-key metadata "
+        "--apply-chat-template "
+        "--rollout-shuffle "
+        f"--num-rollout {NUM_ROLLOUT} "
+        "--rollout-batch-size 4 "
+        "--n-samples-per-prompt 8 "
+        "--rollout-max-response-len 12288 "
+        "--rollout-max-context-len 16384 "
+        "--rollout-temperature 1.0 "
+        "--global-batch-size 32 "
+    )
+
+    custom_args = (
+        "--custom-generate-function-path examples.experimental.hud.rollout.generate "
+        "--custom-rm-path examples.experimental.hud.rollout.reward_func "
+        "--custom-config-path examples/experimental/hud/hud2048_config.yaml "
+    )
+
+    fsdp_args = "--train-backend fsdp " "--gradient-checkpointing " "--update-weight-buffer-size 536870912 "
+
+    grpo_args = (
+        "--advantage-estimator grpo "
+        "--kl-loss-coef 0.00 "
+        "--kl-loss-type low_var_kl "
+        "--kl-coef 0.00 "
+        "--entropy-coef 0.00 "
+        "--eps-clip 0.2 "
+        "--eps-clip-high 0.28 "
+    )
+
+    optimizer_args = (
+        "--optimizer adam "
+        "--lr 1e-6 "
+        "--lr-decay-style constant "
+        "--weight-decay 0.1 "
+        "--adam-beta1 0.9 "
+        "--adam-beta2 0.98 "
+    )
+
+    # Telemetry. The dashboard collector is what makes a multi-hour run
+    # diagnosable after the fact: it records per-phase timing, GPU utilisation
+    # and engine metrics, which is how the ViT-prefill stall in this recipe was
+    # eventually understood. log-multi-turn adds per-turn counts and lengths,
+    # which for a computer-use episode is the difference between "the reward
+    # moved" and knowing how many actions produced it.
+    telemetry_args = "--use-miles-dashboard --dashboard-gpu-sample-interval 5 --log-multi-turn --log-passrate "
+
+    sglang_args = (
+        "--rollout-num-gpus-per-engine 1 "
+        "--sglang-mem-fraction-static 0.6 "
+        "--sglang-decode-log-interval 1000 "
+        "--sglang-enable-metrics "
+        "--sglang-attention-backend fa3 "
+        "--attn-implementation flash_attention_3 "
+    )
+
+    debug_args = "--debug-rollout-only " if MODE == "debug_rollout_only" else ""
+
+    misc_args = (
+        "--actor-num-nodes 1 "
+        f"--actor-num-gpus-per-node {NUM_GPUS} "
+        "--colocate "
+        # Point MILES_SCRIPT_OUTPUT_DIR at storage that outlives the node --
+        # without --save a multi-hour run leaves nothing but a metrics curve
+        # behind, and a config change means relearning from the base model.
+        f"--save {OUTPUT_DIR}/ckpt "
+        "--save-interval 10 "
+        f"--dump-details {OUTPUT_DIR}/dump "
+    )
+
+    train_args = (
+        f"{ckpt_args} "
+        f"{rollout_args} "
+        f"{custom_args} "
+        f"{optimizer_args} "
+        f"{grpo_args} "
+        f"{U.get_default_wandb_args(__file__)} "
+        f"{fsdp_args} "
+        f"{sglang_args} "
+        f"{telemetry_args} "
+        f"{debug_args} "
+        f"{misc_args} "
+    )
+
+    extra_env_vars = {"CUDA_DEVICE_MAX_CONNECTIONS": "1"}
+    if os.environ.get("WANDB_API_KEY"):
+        extra_env_vars["WANDB_API_KEY"] = os.environ["WANDB_API_KEY"]
+    if os.environ.get("DAYTONA_API_KEY"):
+        extra_env_vars["DAYTONA_API_KEY"] = os.environ["DAYTONA_API_KEY"]
+
+    U.execute_train(
+        train_args=train_args,
+        num_gpus_per_node=NUM_GPUS,
+        megatron_model_type=None,
+        extra_env_vars=extra_env_vars,
+    )
+
+
+if __name__ == "__main__":
+    execute()

--- a/examples/experimental/hud/sandbox.py
+++ b/examples/experimental/hud/sandbox.py
@@ -1,0 +1,240 @@
+"""Per-episode Daytona sandbox running a HUD environment image.
+
+Lifecycle, and why each piece is here:
+
+- Daytona does not run the image's CMD, and these images serve MCP over stdio
+  anyway, so ``start()`` execs the service bring-up itself (Xvfb, the
+  persistent context server, and an HTTP re-serve of the stdio MCP server) and
+  then polls the control port from outside.
+- Concurrency is capped process-wide, independent of the rollout's batch
+  geometry, so a wide batch cannot open an unbounded number of cloud sandboxes.
+- Deletion is verified rather than fire-and-forget, and a reaper sweeps
+  whatever still leaked: an earlier version trusted ``delete()``'s accepted
+  request and left a step's worth of sandboxes running every step.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import httpx
+
+from examples.experimental.hud.mcp_client import SyncMCP
+
+logger = logging.getLogger(__name__)
+
+MCP_PORT = 8765
+
+# One label value per process, so a reaper can distinguish this run's leaks from
+# a colleague's live sandboxes in the same Daytona org.
+PROC_ID = uuid.uuid4().hex[:8]
+LAUNCHER_LABEL = "miles-hud"
+
+_gate: threading.Semaphore | None = None
+_gate_lock = threading.Lock()
+_reaper_started = False
+
+_START_SCRIPT = r"""
+mkdir -p /tmp/hud
+cat > /tmp/hud/serve_http.py <<'PYEOF'
+import inspect, os
+os.environ.setdefault("DISPLAY", ":1")
+
+# The vendored hud fork runs its @mcp.initialize hook for the first MCP session
+# only and then awaits None, so any later session dies with -32602. We keep one
+# session per sandbox, but make the server survive a reconnect anyway.
+from hud.server import low_level as ll
+
+_orig = ll.InitSession.__init__
+
+def _patched(self, *a, init_fn=None, **kw):
+    if init_fn is not None:
+        inner = init_fn
+        async def wrapper(ctx):
+            res = inner(ctx)
+            if inspect.isawaitable(res):
+                await res
+        init_fn = wrapper
+    _orig(self, *a, init_fn=init_fn, **kw)
+
+ll.InitSession.__init__ = _patched
+
+from hud_controller.server import mcp
+mcp.run(transport="http", host="0.0.0.0", port=8765, show_banner=False)
+PYEOF
+cat > /tmp/hud/start_all.sh <<'SHEOF'
+#!/bin/sh
+if [ ! -e /tmp/.X11-unix/X1 ]; then Xvfb :1 -screen 0 1920x1080x24 >/dev/null 2>&1 & fi
+while [ ! -e /tmp/.X11-unix/X1 ]; do sleep 0.2; done
+export DISPLAY=:1
+cd /app
+python3 -m hud_controller.context >/tmp/hud/ctx.log 2>&1 &
+sleep 2
+python3 /tmp/hud/serve_http.py >/tmp/hud/mcp.log 2>&1 &
+SHEOF
+chmod +x /tmp/hud/start_all.sh
+nohup setsid /tmp/hud/start_all.sh >/dev/null 2>&1 &
+echo started
+"""
+
+
+def resolve_api_key() -> str:
+    """Key from the environment, else from a file.
+
+    A path is forwarded rather than a value on multi-host clusters: ray's
+    runtime_env records env values in plaintext.
+    """
+    if key := os.environ.get("DAYTONA_API_KEY"):
+        return key
+    path = os.environ.get("DAYTONA_API_KEY_FILE", "~/.config/daytona/api_key")
+    with open(os.path.expanduser(path)) as f:
+        return f.read().strip()
+
+
+def client():
+    # In-function on purpose: daytona is not in the training image's
+    # requirements, and keeping it out of module scope is what lets the offline
+    # tests import this module (and hud_task_env, which imports it) without it.
+    from daytona import Daytona, DaytonaConfig
+
+    return Daytona(DaytonaConfig(api_key=resolve_api_key()))
+
+
+def get_gate(limit: int) -> threading.Semaphore:
+    global _gate
+    with _gate_lock:
+        if _gate is None:
+            _gate = threading.Semaphore(limit)
+        return _gate
+
+
+def _reap_once(max_age_min: float) -> int:
+    """Delete this process's sandboxes older than *max_age_min*."""
+    cutoff = datetime.now(timezone.utc) - timedelta(minutes=max_age_min)
+    reaped = 0
+    try:
+        for sb in client().list():
+            labels = sb.labels or {}
+            if labels.get("launcher") != LAUNCHER_LABEL or labels.get("proc") != PROC_ID:
+                continue
+            raw = str(getattr(sb, "created_at", "") or "")
+            try:
+                created = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+            except ValueError:
+                continue
+            if created < cutoff:
+                try:
+                    sb.delete()
+                    reaped += 1
+                except Exception:  # noqa: BLE001 - next sweep retries
+                    pass
+    except Exception:  # noqa: BLE001 - never let the reaper kill the run
+        logger.warning("hud sandbox reaper sweep failed", exc_info=True)
+    if reaped:
+        logger.warning("hud sandbox reaper deleted %d leaked sandbox(es)", reaped)
+    return reaped
+
+
+def start_reaper(max_age_min: float, interval_s: float = 300.0) -> None:
+    """Start the background sweep once per process."""
+    global _reaper_started
+    with _gate_lock:
+        if _reaper_started:
+            return
+        _reaper_started = True
+
+    def loop() -> None:
+        while True:
+            time.sleep(interval_s)
+            _reap_once(max_age_min)
+
+    threading.Thread(target=loop, name="hud-sandbox-reaper", daemon=True).start()
+
+
+class HudSandbox:
+    """One sandbox, one MCP session, one episode."""
+
+    def __init__(
+        self,
+        image: str,
+        *,
+        cpu: int = 2,
+        memory_gb: int = 4,
+        disk_gb: int = 10,
+        max_age_min: float = 20.0,
+    ) -> None:
+        self.image = image
+        self.cpu = cpu
+        self.memory_gb = memory_gb
+        self.disk_gb = disk_gb
+        self.max_age_min = max_age_min
+        self.run_id = uuid.uuid4().hex[:8]
+        self._sb = None
+        self._gate: threading.Semaphore | None = None
+
+    def start(self, gate: threading.Semaphore, ready_timeout_s: float = 300.0):
+        """Create the sandbox, bring services up, return a connected SyncMCP."""
+        from daytona import CreateSandboxFromImageParams, Resources  # optional dep; see client()
+
+        gate.acquire()
+        self._gate = gate
+        t0 = time.time()
+        d = client()
+        # Daytona's own TTL is the last-resort backstop; the reaper is faster.
+        self._sb = d.create(
+            CreateSandboxFromImageParams(
+                image=self.image,
+                resources=Resources(cpu=self.cpu, memory=self.memory_gb, disk=self.disk_gb),
+                auto_stop_interval=15,
+                auto_delete_interval=30,
+                labels={"launcher": LAUNCHER_LABEL, "proc": PROC_ID, "run-id": self.run_id},
+            ),
+            timeout=600,
+        )
+        self._sb.process.exec(_START_SCRIPT, timeout=90)
+        url = self._sb.create_signed_preview_url(MCP_PORT, expires_in_seconds=86400)
+        base = url.url if hasattr(url, "url") else str(url)
+
+        deadline = time.time() + ready_timeout_s
+        with httpx.Client(timeout=10) as probe:
+            while time.time() < deadline:
+                try:
+                    probe.get(base.rstrip("/") + "/mcp")
+                    break
+                except Exception:  # noqa: BLE001 - still booting
+                    time.sleep(3)
+
+        mcp = SyncMCP(base)
+        mcp.initialize()
+        logger.info(
+            "[hud %s] sandbox %s ready in %.0fs (image=%s)",
+            self.run_id,
+            self._sb.id[:8],
+            time.time() - t0,
+            self.image,
+        )
+        return mcp
+
+    def delete(self) -> None:
+        """Delete the sandbox, confirming it is really gone."""
+        sb, self._sb = self._sb, None
+        try:
+            if sb is not None:
+                # wait=True: the fire-and-forget default returns on request
+                # acceptance, and a rejected-but-accepted request is exactly how
+                # a step's worth of sandboxes used to survive its step.
+                try:
+                    sb.delete(timeout=60, wait=True)
+                except TypeError:  # older SDKs have no wait kwarg
+                    sb.delete()
+        except Exception:  # noqa: BLE001 - the reaper is the backstop
+            logger.warning("[hud %s] sandbox delete failed; reaper will retry", self.run_id)
+        finally:
+            if self._gate is not None:
+                self._gate.release()
+                self._gate = None

--- a/examples/experimental/hud/smoke_episode.py
+++ b/examples/experimental/hud/smoke_episode.py
@@ -1,0 +1,91 @@
+"""One real episode against a real sandbox, with a scripted policy.
+
+The offline tests cover the translation logic; this covers everything they
+cannot: the image booting, MCP coming up, the task row's setup and grade calls
+working, and screenshots arriving as usable images. Run it before launching a
+training job, and after changing the image or the taskset.
+
+    python -m examples.experimental.hud.smoke_episode --dataset hud-evals/2048-basic
+"""
+
+import argparse
+import json
+import time
+from types import SimpleNamespace
+
+from examples.experimental.hud.hud_task_env import HudTaskEnv
+from examples.experimental.hud.make_hud_data import fetch_rows, task_of
+
+# Arrow keys, because they are the one vocabulary safe to send at any GUI
+# without changing state in a way that confuses the row's own grader.
+SCRIPT = [
+    "Let me look at the screen.\nAction: screenshot()",
+    'Move around.\nAction: press("Left","Down","Left","Down")',
+    'Again.\nAction: press("Left","Down","Left","Down")',
+    "this turn has no action line at all",  # parse-failure path
+    'Single key, should be flagged as short.\nAction: press("Down")',
+    'Too many keys, should be clipped.\nAction: press("Left","Down","Left","Down","Left","Down")',
+]
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--dataset", default="hud-evals/2048-basic")
+    # Off by default, so this works on any taskset: with no surrogate the row's
+    # own evaluate_tool is the reward, which every row has.
+    ap.add_argument("--target-score", type=int, help="2048 only: also grade with game_2048_score_reached")
+    args = ap.parse_args()
+
+    row = fetch_rows(args.dataset, "train", 1)[0]
+    task = task_of(row)
+    print(f"task from {args.dataset}: setup={json.dumps(task['setup_tool'])[:80]}")
+
+    env = HudTaskEnv(
+        SimpleNamespace(metadata={"hud_task": task}),
+        SimpleNamespace(
+            hud_screenshot_width=640,
+            hud_keys_per_turn=4,
+            hud_max_sandboxes=4,
+            hud_sandbox_max_age_min=20,
+            hud_reward_tool=(
+                {
+                    "name": "evaluate",
+                    "arguments": {
+                        "name": "game_2048_score_reached",
+                        "arguments": {"target_score": args.target_score},
+                    },
+                }
+                if args.target_score
+                else None
+            ),
+        ),
+    )
+
+    t0 = time.time()
+    try:
+        _, info = env.reset()
+        print(f"[{time.time() - t0:5.1f}s] reset: {info}")
+        for i, response in enumerate(SCRIPT, 1):
+            obs, done, step_info = env.step(response)
+            images = (obs.get("multi_modal_data") or {}).get("image", [])
+            print(
+                f"[{time.time() - t0:5.1f}s] step {i}: done={done} img={images[0].size if images else None} "
+                f"actions={env.actions} obs={obs.get('obs_str', '')[:58]}"
+            )
+            if done:
+                break
+        verdict = env.compute_final_reward()
+        print(f"[{time.time() - t0:5.1f}s] verdict: {json.dumps(verdict, default=str)}")
+
+        assert 0.0 <= verdict["reward"] <= 1.0, verdict
+        assert "task_reward" in verdict, "the taskset's own grade must always be recorded"
+        assert verdict["actions"] >= 9, f"scripted policy should make >=9 moves, got {verdict['actions']}"
+        assert verdict["short_actions"] == 1, verdict
+        print("SMOKE EPISODE PASSED")
+    finally:
+        env.close()
+        print(f"[{time.time() - t0:5.1f}s] sandbox released")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/experimental/hud/tests/test_hud_task_env.py
+++ b/examples/experimental/hud/tests/test_hud_task_env.py
@@ -1,0 +1,329 @@
+"""Offline tests for the HUD task adapter: no Daytona, no network, no GPU.
+
+The env's whole job is translating between three contracts -- the taskset row,
+the model's text actions, and MCP tool calls -- so these fake the MCP side and
+assert on the translation. The bugs these lock down were all found the
+expensive way, mid-training.
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+import json
+from types import SimpleNamespace
+
+import pytest
+from examples.experimental.hud import hud_task_env as env_mod
+from examples.experimental.hud.hud_task_env import HudTaskEnv, image_of, parse_action
+from examples.experimental.hud.make_hud_data import build_prompt, task_of
+from examples.experimental.hud.mcp_client import ToolResult
+from PIL import Image
+
+TASK = {
+    "id": "t1",
+    "mcp_config": {
+        "browser": {"url": "https://mcp.hud.ai/v3/mcp", "headers": {"Mcp-Image": "hudevals/hud-browser:0.1.6"}}
+    },
+    "setup_tool": {"name": "launch_app", "arguments": {"app_name": "2048"}},
+    "evaluate_tool": {"name": "evaluate", "arguments": {"name": "game_2048_max_number", "arguments": {"target": 128}}},
+}
+
+
+def _png_b64(w: int = 1920, h: int = 1080) -> str:
+    buf = io.BytesIO()
+    Image.new("RGB", (w, h), (10, 20, 30)).save(buf, "PNG")
+    return base64.b64encode(buf.getvalue()).decode()
+
+
+class FakeMCP:
+    """Records calls; answers screenshots with a real PNG and grades with JSON."""
+
+    def __init__(self, grades: dict[str, dict] | None = None) -> None:
+        self.calls: list[tuple[str, dict]] = []
+        self.grades = grades or {}
+        self.closed = False
+
+    def call_tool(self, name: str, arguments: dict) -> ToolResult:
+        self.calls.append((name, arguments))
+        if name == "computer" and arguments.get("action") == "screenshot":
+            return ToolResult("", _png_b64(), None)
+        if name == "evaluate":
+            inner = arguments.get("name") or ""
+            payload = self.grades.get(inner, {"reward": 0.0})
+            return ToolResult(json.dumps(payload), None, payload)
+        return ToolResult("ok", None, None)
+
+    def close(self) -> None:
+        self.closed = True
+
+    def presses(self) -> list[str]:
+        return [a["keys"][0] for n, a in self.calls if n == "computer" and a.get("action") == "press"]
+
+
+@pytest.fixture
+def env(monkeypatch):
+    """An env whose sandbox is stubbed out; reset() yields the FakeMCP."""
+    fake = FakeMCP(
+        grades={
+            "game_2048_max_number": {
+                "reward": 0.5714,
+                "done": False,
+                "content": "Target: 128, Highest: 16",
+                "info": {"highest_tile": 16},
+            },
+            "game_2048_score_reached": {
+                "reward": 0.37,
+                "done": False,
+                "content": "Score: 190 (target: 512)",
+                "info": {"score": 190},
+            },
+        }
+    )
+    monkeypatch.setattr(env_mod, "start_reaper", lambda *a, **k: None)
+    # The env sleeps to let apps paint and merges animate; irrelevant offline.
+    monkeypatch.setattr(env_mod.time, "sleep", lambda *_: None)
+
+    class StubSandbox:
+        run_id = "stub1234"
+
+        def __init__(self, *a, **k):
+            self.deleted = False
+
+        def start(self, gate, **k):
+            return fake
+
+        def delete(self):
+            self.deleted = True
+
+    monkeypatch.setattr(env_mod, "HudSandbox", StubSandbox)
+
+    def make(**overrides):
+        conf = {
+            "hud_screenshot_width": 640,
+            "hud_keys_per_turn": 4,
+            "hud_reward_tool": None,
+            "hud_max_sandboxes": 4,
+            "hud_sandbox_max_age_min": 20,
+        }
+        conf.update(overrides)
+        args = SimpleNamespace(**conf)
+        sample = SimpleNamespace(metadata={"hud_task": TASK})
+        e = HudTaskEnv(sample, args)
+        e.reset()
+        return e, fake
+
+    return make
+
+
+# ---- pure parsing ----
+
+
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        ('Action: press("Left","Down","Left","Down")', ("press", ["Left", "Down", "Left", "Down"])),
+        ("Thinking.\nAction: press(Left, Down)", ("press", ["Left", "Down"])),
+        ("Action: screenshot()", ("screenshot", [])),
+        # Only the LAST action line counts: models often restate the format.
+        ('Action: press("Up")\nActually no.\nAction: press("Down")', ("press", ["Down"])),
+        ("no action at all", None),
+    ],
+)
+def test_parse_action(text, expected):
+    got = parse_action(text)
+    if expected is None:
+        assert got is None
+    else:
+        verb, keys = expected
+        assert got[0] == verb
+        assert [w for w in env_mod._WORD_RE.findall(got[1])] == keys
+
+
+def test_image_of_reads_the_row_not_a_constant():
+    assert image_of(TASK) == "hudevals/hud-browser:0.1.6"
+    with pytest.raises(ValueError):
+        image_of({"mcp_config": {"x": {"headers": {}}}})
+
+
+# ---- action execution ----
+
+
+def test_four_keys_become_four_separate_presses(env):
+    """A single call with keys=[a,b,c] is a chord, not three moves, so the env
+    must issue one press per key -- this is what makes the move budget real."""
+    e, fake = env()
+    e.step('Action: press("Left","Down","Left","Down")')
+    assert fake.presses() == ["Left", "Down", "Left", "Down"]
+    assert e.actions == 4
+
+
+def test_non_arrow_keys_pass_through(env):
+    """2048 only ever needs arrows, but a whitelist here would silently drop
+    every key a desktop task needs."""
+    e, fake = env()
+    e.step('Action: press("Enter","Tab","F5","Escape")')
+    assert fake.presses() == ["Enter", "Tab", "F5", "Escape"]
+
+
+def test_plus_means_a_chord_and_separate_args_mean_a_sequence(env):
+    """One call with keys=[a,b] is a pyautogui hotkey, not two keystrokes -- so
+    the two have to be expressible apart."""
+    e, fake = env()
+    e.step('Action: press("ctrl+c","Left")')
+    pressed = [a["keys"] for n, a in fake.calls if n == "computer" and a.get("action") == "press"]
+    assert pressed == [["ctrl", "c"], ["Left"]]
+
+
+def test_unquoted_prose_does_not_become_keystrokes(env):
+    """Without quotes there is no telling a key name from a word, so only arrow
+    names count -- otherwise 'and'/'then' would each burn a move."""
+    e, fake = env()
+    e.step("Action: press(Left and then Down)")
+    assert fake.presses() == ["Left", "Down"]
+
+
+def test_extra_keys_are_clipped_to_the_cap(env):
+    e, fake = env()
+    e.step('Action: press("Left","Down","Left","Down","Left","Down")')
+    assert len(fake.presses()) == 4
+
+
+def test_short_action_is_counted_and_flagged_to_the_model(env):
+    """A model that emits one key per turn silently caps the episode's reward
+    ceiling; the note and the counter make that visible instead."""
+    e, _ = env()
+    obs, done, _ = e.step('Action: press("Left")')
+    assert not done
+    assert e.short_actions == 1
+    assert "exactly 4 keys" in obs["obs_str"]
+
+
+def test_click_scales_coordinates_back_to_the_real_screen(env):
+    """The model gives coordinates in the downscaled view it was shown; the
+    scale factor comes from the screenshot the environment actually sent."""
+    e, fake = env(hud_screenshot_width=640)
+    e.step("Action: screenshot()")
+    e.step("Action: click(320, 180)")
+    click = [a for n, a in fake.calls if n == "computer" and a.get("action") == "click"][-1]
+    assert (click["x"], click["y"]) == (960, 540)  # 640 -> 1920 is x3
+
+
+def test_click_before_any_screenshot_is_refused(env):
+    """Without a screenshot there is no scale factor, and the model has no basis
+    for the coordinates either -- clicking blind would land anywhere."""
+    e, fake = env()
+    obs, done, _ = e.step("Action: click(320, 180)")
+    assert not done
+    assert not [a for n, a in fake.calls if n == "computer" and a.get("action") == "click"]
+    assert "screenshot()" in obs["obs_str"]
+
+
+def test_done_ends_the_episode(env):
+    e, _ = env()
+    _, done, info = e.step("Action: done()")
+    assert done and info["reason"] == "done"
+
+
+def test_three_unparseable_turns_end_the_episode(env):
+    e, _ = env()
+    assert e.step("junk")[1] is False
+    assert e.step("junk")[1] is False
+    assert e.step("junk")[1] is True
+
+
+def test_observation_carries_the_downscaled_screenshot(env):
+    e, _ = env()
+    obs, _, _ = e.step("Action: screenshot()")
+    msg = e.format_observation(obs)
+    assert msg["role"] == "user"
+    images = [c["image"] for c in msg["content"] if c["type"] == "image"]
+    assert len(images) == 1 and images[0].size == (640, 360)
+
+
+# ---- setup and grading ----
+
+
+def test_setup_call_comes_from_the_row(env):
+    _, fake = env()
+    assert fake.calls[0] == ("launch_app", {"app_name": "2048"})
+
+
+def test_grade_uses_the_rows_evaluate_tool_by_default(env):
+    e, _ = env()
+    verdict = e.compute_final_reward()
+    assert verdict["reward"] == pytest.approx(0.5714)
+    assert verdict["task_reward"] == pytest.approx(0.5714)
+    assert verdict["task_highest_tile"] == 16
+
+
+def test_surrogate_reward_trains_while_the_row_grade_is_still_reported(env):
+    """Training optimizes the dense score; the taskset's own grade stays the
+    reported metric."""
+    e, _ = env(
+        hud_reward_tool={
+            "name": "evaluate",
+            "arguments": {"name": "game_2048_score_reached", "arguments": {"target_score": 512}},
+        }
+    )
+    verdict = e.compute_final_reward()
+    assert verdict["reward"] == pytest.approx(0.37)  # dense surrogate drives GRPO
+    assert verdict["task_reward"] == pytest.approx(0.5714)  # benchmark number kept
+    assert verdict["dense_score"] == 190
+
+
+def test_close_releases_the_sandbox_and_the_client(env):
+    e, fake = env()
+    e.close()
+    assert fake.closed and e.sandbox.deleted
+
+
+# ---- prompt building ----
+
+
+def test_prompt_keeps_the_rows_instruction():
+    """For any taskset but 2048 the row's prompt *is* the task, so dropping it
+    would leave the model with an action vocabulary and nothing to do."""
+    row = {
+        "system_prompt": "You operate a desktop.",
+        "prompt": "Open the spreadsheet and total column B.",
+        "setup_tool": {"name": "launch_app", "arguments": {"app_name": "calc"}},
+    }
+    prompt = build_prompt(row, keys_per_turn=4)
+    assert "Open the spreadsheet and total column B." in prompt
+    assert "You operate a desktop." in prompt
+    assert "Action: click(840, 320)" in prompt  # our DSL, not the row's
+
+
+def test_2048_row_gets_the_recipes_own_briefing():
+    """2048's shipped prompts target a tool-calling agent and a max-tile goal;
+    this recipe trains on score, so it substitutes its own."""
+    row = {
+        "system_prompt": "Use the browser tools.",
+        "prompt": "Reach the 512 tile.",
+        "setup_tool": {"name": "launch_app", "arguments": {"app_name": "2048"}},
+    }
+    prompt = build_prompt(row, keys_per_turn=4)
+    assert "Reach the 512 tile." not in prompt and "browser tools" not in prompt
+    assert "Tiles slide with arrow keys" in prompt
+
+
+def test_press_coaching_only_when_there_is_a_key_budget():
+    """Telling the model to use its whole key budget is advice for a task with a
+    move budget and near-free keystrokes. A taskset where a turn is one
+    deliberate keystroke must not be told to burn four, and needs the chord form
+    instead."""
+    row = {"prompt": "Total column B.", "setup_tool": {"name": "launch_app", "arguments": {"app_name": "calc"}}}
+    assert "use all 4" in build_prompt(row, keys_per_turn=4)
+    single = build_prompt(row, keys_per_turn=1)
+    assert "use all" not in single
+    assert "ctrl+c" in single
+
+
+def test_task_of_extracts_what_the_env_needs():
+    assert task_of({"mcp_config": json.dumps(TASK["mcp_config"]), "id": "t1"})["mcp_config"] == TASK["mcp_config"]
+
+
+def test_missing_task_row_fails_loudly():
+    with pytest.raises(ValueError, match="no HUD task row"):
+        HudTaskEnv(SimpleNamespace(metadata={}), SimpleNamespace())


### PR DESCRIPTION
Trains a VLM to operate a real GUI through [HUD](https://hud.ai) environments, using
a HUD taskset row as the task definition. Nothing under `miles/` changes.

**Result** — Qwen3-VL-4B-Instruct, GRPO, 8×H200, 32 episodes per step, 2048 in a
browser: over 16 steps mean game score went 200 → 865, and the *worst* episode of a
batch went 0 → 540. The second number is the one that matters — a lucky episode was
already worth ~800 points before training, so what training bought is reliability,
not a higher ceiling. Episodes reaching tile 64+ went 22% → 97%.

## Where it plugs in

| seam | file |
|---|---|
| `--custom-generate-function-path` | `rollout.py` — multi-turn episode loop |
| `--custom-rm-path` | `rollout.py` `reward_func` |
| `--custom-config-path` | `hud2048_config.yaml` |
| interaction env | `hud_task_env.py` |

A HUD row carries the image (`mcp_config`'s `Mcp-Image`), the setup call and the
grading call, so the adapter has no per-task code: the env boots that image, makes
that setup call, and grades with that evaluate call. Anything named `hud2048_*` or
`run_hud2048` is this one taskset; the rest is not supposed to know which taskset it
is running.

The model acts by writing `Action: press("Left","Down")` / `click(x, y)` /
`type("...")` / `done()` — plain text rather than provider tool calls, because the
loss is computed on the tokens the policy generated, so an action has to *be* those
tokens.

## Format coverage

This supports the HUD taskset row format the `hud-evals/*` datasets publish —
`mcp_config`, `setup_tool`, `evaluate_tool` — which is what their CUA tasksets ship
and what the matching environment images serve.

HUD's current spec (v6) defines a task differently: an `@env.template()` generator
inside an environment package, reached over HUD's own control channel. Supporting it
is the natural next step, and the seam for it is already in the right place — a v6
leg replaces `mcp_client.py`, the fetch in `make_hud_data.py` and the two tool calls
in `hud_task_env.py`, while the rollout, reward wiring and sandbox lifecycle, which
is most of this example, stay as they are. This PR lands that format-independent
part, plus a verified training result to carry onto v6.

## What the environment needed

Four ceilings, each found the expensive way and each annotated where it is set:

- **Move budget.** A random policy and a corner strategy both cap at tile 8 by ~12
  moves and only separate from ~20 on, so one action carries 4 keys and 24 turns buy
  ~92 moves.
- **ViT prefill.** Every turn re-prefills the screenshot history through the vision
  encoder; at 960px × 14 turns a cache-missing episode re-prefilled ~5.5k tokens at
  14 tok/s, slow enough to stall a batch behind one engine.
- **A step-function reward.** The taskset grades `log2(max_tile)/log2(target)`, five
  levels. Twice a population converged on one tile, within-group variance went to
  zero and GRPO had no gradient. Training moved onto the same environment's score
  (continuous); the taskset's own grade is still recorded every episode as
  `task_reward`.
- **Saturation.** At a mean of 0.71, 59% of a batch sat at exactly 1.0.

Diagnostic worth knowing: a mean reward on an *exact* fraction (0.428571, 0.714286)
means zero within-group variance. `rollout/advantages ≈ 0` does not reveal it — GRPO
centres advantages within each group either way.

## Sandboxes

One episode is one Daytona sandbox: a confirmed delete, a per-process reaper, and
Daytona's TTL behind that. The fire-and-forget default silently left a step's worth
of sandboxes running every step.

## Tests

25 offline cases against a fake MCP server — no GPU, no network, no Daytona, under
two seconds:

```
python -m pytest examples/experimental/hud/tests/ -q
```

They cover the three contracts this example translates between: the task row, the
model's text actions, and MCP calls. `smoke_episode.py` runs one real episode against
one real sandbox for the parts a fake cannot cover — that is the check to run when
pointing this at a different taskset, and it costs no GPUs.

## Known rough edge

`rollout.py` imports the multi-turn VLM engine from `examples/geo3k_vlm/multi_turn/`
as private helpers. Sharing one implementation of token accumulation and per-turn loss
masking beats copying it, but that engine has **no test coverage** — nothing under
`tests/` imports it, and the only VLM e2e test runs single-turn — and no API contract,
so a refactor there could break this leg silently. Unit-testing those helpers is worth
more than moving them; after that they belong in `miles/rollout/generate_hub/`.
