### PR TITLE
Stop the weight-version publish from aborting in-flight generation

### DIFF
--- a/miles/backends/sglang_utils/sglang_engine.py
+++ b/miles/backends/sglang_utils/sglang_engine.py
@@ -642,9 +642,12 @@ class SGLangEngine(RayActor):
         return self._make_request("end_weight_update", {})
 
     def update_weight_version(self, weight_version: str):
+        # This endpoint aborts every in-flight request by default, which would undo
+        # the retract the pause just did. --pause-generation-mode already says what
+        # should happen to in-flight work; publishing a label must not override it.
         return self._make_request(
             "update_weight_version",
-            {"new_version": weight_version},
+            {"new_version": weight_version, "abort_all_requests": False},
         )
 
     def start_profile(

--- a/tests/fast/backends/test_update_weight_version_keeps_inflight.py
+++ b/tests/fast/backends/test_update_weight_version_keeps_inflight.py
@@ -1,0 +1,40 @@
+"""Publishing a weight version must not abort in-flight generation.
+
+SGLang's `/update_weight_version` defaults `abort_all_requests` to True. miles
+calls it as the last step of a weight update, right after
+`pause_generation(mode=retract)` deliberately preserved the in-flight requests --
+so omitting the field silently killed all of them. On a 221-step fully-async
+Qwen3-4B run that discarded ~40 groups (~1.1M decoded tokens) per step, with no
+log line anywhere, and made every surviving request single-version so staleness
+could never be observed.
+
+The omission fails silently in exactly one direction, which is why it is pinned
+here: the request still returns 200 and the training loop still converges, only
+slower and on less data.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from miles.backends.sglang_utils.sglang_engine import SGLangEngine
+
+
+def _engine() -> SGLangEngine:
+    engine = SGLangEngine.__new__(SGLangEngine)
+    engine.node_rank = 0
+    engine.server_host = "127.0.0.1"
+    engine.server_port = 30000
+    return engine
+
+
+def test_update_weight_version_does_not_abort_inflight():
+    with patch("miles.backends.sglang_utils.sglang_engine.requests.post") as post:
+        post.return_value = SimpleNamespace(
+            status_code=200, json=lambda: {}, raise_for_status=lambda: None
+        )
+        _engine().update_weight_version("7")
+
+    payload = post.call_args.kwargs["json"]
+    assert payload["new_version"] == "7"
+    # Absent is not the same as False here: the server-side default is True.
+    assert payload["abort_all_requests"] is False


### PR DESCRIPTION
## What

`SGLangEngine.update_weight_version` posted only `{"new_version": ...}`. SGLang's `UpdateWeightVersionReqInput.abort_all_requests` defaults to **True**, so the version publish at the end of `_finalize_and_resume_engines` aborted every in-flight request — immediately after `pause_generation(mode=retract)` had gone to the trouble of preserving them.

The fix is to pass `abort_all_requests=False`. `--pause-generation-mode` already declares what should happen to in-flight work, and `--fully-async` asserts that mode is not `abort`; publishing a version label should not silently overrule it.

## Evidence

Four-arm probe, one GPU, 16 concurrent long generations, replaying the miles sequence:

| sequence | aborted / 16 |
| --- | --- |
| `pause_generation(retract)` | 0 |
| `pause_generation(retract)` + `flush_cache` | 0 |
| + `update_weight_version` (as miles called it) | **16** |
| + `update_weight_version`, `abort_all_requests=False` | 0 |

The last two rows differ only in that field, so this is causation rather than correlation.

## Cost of the bug

On a 221-step fully-async Qwen3-4B run:

- ~40 groups discarded per step, against an in-flight ceiling of `rollout_batch_size = 32` — essentially everything in flight died at each update, and the retry handler recycled some to die again.
- ~1.1M already-decoded tokens thrown away per step, ~30k per group (8 samples × ~3.7k), i.e. the shape of requests killed mid-generation.
- No log line anywhere: `abort_request` logs at `debug`.
- It is also the real trigger for the `rid_to_state` `KeyError` / HTTP 500 bursts in `_wait_one_response` (255 in that run) — `abort_all` racing requests that are still being dispatched.

Also worth flagging: because in-flight requests never survived an update, no request ever spanned two weight versions, so weight staleness was structurally unobservable (`mixed_version_ratio` stayed `0.0`). Any measurement of rollout staleness taken before this fix is measuring this bug instead.


## Before / after on a real run

Same recipe, same seed, two full runs of the same length; window is steps 3–220 (n=218 each).
The only difference is this fix — the `abort_below_start_weight_version` sweep present in the
second run fires zero times, so it is a no-op here.

| | before | after |
|---|---|---|
| groups aborted in flight, per step | 39.4 | **0** |
| groups dropped at consume for staleness, per step | 1.7 | 25.2 |
| groups discarded in total | 8953 | **5491** (−39%) |
| `rollout/response_len/mean` | 3540 | **4589** (+30%) |
| `rollout/truncated_ratio` | 0.112 | **0.275** |
| response tokens actually trained on | 0.20B | **0.26B** (+30%) |
| wall clock | 5.85h | 6.40h (+9%) |
| **response tokens trained on per hour** | 0.034B/h | **0.040B/h (+19%)** |

**19% more trained tokens per hour, and 39% fewer groups thrown away.** The per-step wall clock
gets *worse*, and that is expected: each step now carries 30% more tokens because thelong responses
that used to be killed mid-flight now survive to be trained on.

**The training data was biased toward short responses.** A long generation is more likely to
still be in flight when an update lands, so it was more likely to be killed — only the fast ones
survived. Mean response length rises 30% and the truncation ratio goes from 0.11 to 0.28 once
that selection is removed. This is the consequence worth worrying about: it silently changed the
distribution the model trained on, not just the throughput.

⚠️ **`perf/rollout_time` is not a saving.** It drops from 66.7s to 1.9s per step, which looks like
64.8s of blocked time removed — but end-to-end wall clock went *up*, so that metric is a
bookkeeping shift (it measures how long the consumer waits at the buffer, and post-fix the buffer
is never empty), not recovered time. Only the tokens-per-hour row above survives the end-to-end
check.

⚠️ Per-step discarded tokens also went **up**, ~1.10M → ~1.05–1.35M, and moved from half-finished
generations killed mid-flight to finished groups dropped at consume for staleness. The remaining
consume-side waste is buffer dwell (`--async-data-buffer-capacity-factor` defaults to 2.0, so up
to 64 groups queue while 32 are consumed per step) and is a separate question from this fix.

## It hit every pause mode, including `in_place`

`_finalize_and_resume_engines` publishes the version with no branch on
`--pause-generation-mode`, so `in_place` lost its in-flight requests too -- and
`in_place` exists precisely to keep them: it leaves the KV cache alone so the
requests resume without a re-prefill. Paying that complexity bought nothing.

Two short runs of the same 4B recipe with `--pause-generation-mode in_place`,
differing only in this fix:

| per step | without the fix | with the fix |
|---|---|---|
| groups aborted in flight | 32–69 | **0** (all 8 steps) |
| tokens discarded at abort | 0.75M–1.86M | **0** |
| groups dropped for staleness | 2–16 | 28–32 |
| HTTP 500 (`rid_to_state` KeyError) | 8 | **0** |

The staleness row moves the "wrong" way for a good reason: without the fix
nothing survived long enough to go stale. Stale groups appearing is the evidence
that requests now live across an update.

The 500 row is the same bug from the other side -- `abort_all` racing requests
still being dispatched. It is pre-existing and reproducible on unmodified
upstream, but this call is what fired it in training.

## Test

`tests/fast/backends/test_update_weight_version_keeps_inflight.py` pins the payload. Verified red before the fix (`KeyError: 'abort_all_requests'`) and green after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


