### PR TITLE
docs: NeMo-Gym server no longer needs a fork branch

### DIFF
--- a/docs/user-guide/nemo-gym.md
+++ b/docs/user-guide/nemo-gym.md
@@ -20,20 +20,15 @@ loss masks — see [Rollout Endpoints](/user-guide/rollout-endpoints)); NeMo-Gym
 grades the episode itself and the grade enters training through a custom
 reward hook reading `sample.metadata["reward"]`.
 
-The per-request `policy_base_url` override is proposed upstream in
-[NVIDIA-NeMo/Gym#2166](https://github.com/NVIDIA-NeMo/Gym/pull/2166); until it
-merges, run the NeMo-Gym server from that PR's branch (upstream main plus one
-small commit pair).
-
 ## Try it
 
 The maintained recipe is **SWE-bench GRPO with mini-swe-agent** in
 [`examples/experimental/nemo-gym`](https://github.com/radixark/miles/tree/main/examples/experimental/nemo-gym).
 In short:
 
-1. **Environment side** — on any docker-capable host, clone NeMo-Gym (the
-   PR branch above until #2166 merges) and start the `mini_swe_agent_2`
-   responses-API agent server with the docker sandbox provider config.
+1. **Environment side** — on any docker-capable host, clone NeMo-Gym `main`
+   (>= `fcca3a8`) and start the `mini_swe_agent_2` responses-API agent server
+   with the docker sandbox provider config.
 2. **Data** — convert SWE-bench Verified to Miles prompt data with
    `download_and_process_data.py`; the task instance rides in each sample's
    `metadata`.

--- a/examples/experimental/nemo-gym/README.md
+++ b/examples/experimental/nemo-gym/README.md
@@ -32,11 +32,7 @@ reward (official SWE-bench harness) ──► sample.metadata ──► reward h
   `sample.metadata["reward"]`).
 - `eval_nemogym_via_api.py`, `tests/` — no-GPU validation tooling (below).
 
-The per-request `policy_base_url` override this example relies on is proposed
-upstream in [NVIDIA-NeMo/Gym#2166](https://github.com/NVIDIA-NeMo/Gym/pull/2166).
-Until it merges, run the NeMo-Gym server from the PR branch
-(`nblintao/Gym@mini-swe-agent-per-request-policy-url`, upstream main + that
-one commit pair); afterwards, use upstream directly.
+Run the NeMo-Gym server from `main` (>= `fcca3a8`).
 
 ## Validation status
 
@@ -77,8 +73,7 @@ with the trainer — that variant is not validated here). Set `NEMO_GYM_URL` to
 wherever the server listens.
 
 ```bash
-# Until NVIDIA-NeMo/Gym#2166 merges; afterwards clone NVIDIA-NeMo/Gym instead.
-git clone -b mini-swe-agent-per-request-policy-url https://github.com/nblintao/Gym.git
+git clone https://github.com/NVIDIA-NeMo/Gym.git
 cd Gym
 
 curl -LsSf https://astral.sh/uv/install.sh | sh
@@ -219,10 +214,10 @@ on CPU-only machines, in three independent layers (all three pass as of
    otherwise.
 
 3. **API-policy scan** — a real model drives full episodes through the same
-   `policy_base_url` override the trainer uses (so this also exercises the
-   NVIDIA-NeMo/Gym#2166 field end-to-end). Start the server *without* the
-   golden override and with `policy_model_name` set to the API model name
-   (e.g. `deepseek-chat`) in `env.yaml`, then:
+   `policy_base_url` override the trainer uses (so this also exercises that
+   field end-to-end). Start the server *without* the golden override and with
+   `policy_model_name` set to the API model name (e.g. `deepseek-chat`) in
+   `env.yaml`, then:
 
    ```bash
    export DEEPSEEK_API_KEY=...   # or OPENAI_API_KEY

--- a/examples/experimental/nemo-gym/eval_nemogym_via_api.py
+++ b/examples/experimental/nemo-gym/eval_nemogym_via_api.py
@@ -11,7 +11,7 @@ session server and training itself:
     python eval_nemogym_via_api.py --input swe_verified.jsonl --golden --limit 5
 
   API-policy scan (a real model drives episodes via the policy_base_url
-  override — the exact NVIDIA-NeMo/Gym#2166 field the trainer relies on):
+  override — the exact field the trainer relies on):
     export DEEPSEEK_API_KEY=$(cat ~/.config/deepseek/api_key)
     python eval_nemogym_via_api.py --input swe_verified.jsonl --limit 2 \
         --policy-base-url https://api.deepseek.com/v1

--- a/examples/experimental/nemo-gym/nemogym_agent_function.py
+++ b/examples/experimental/nemo-gym/nemogym_agent_function.py
@@ -1,9 +1,8 @@
 """NeMo-Gym <-> miles adapter (agent function).
 
 Targets upstream NVIDIA-NeMo/Gym's sandbox-backed ``mini_swe_agent_2`` agent,
-which requires the per-request policy endpoint override from
-https://github.com/NVIDIA-NeMo/Gym/pull/2166 (until it merges, run the
-NeMo-Gym server from the PR branch ``nblintao/Gym@mini-swe-agent-per-request-policy-url``).
+which requires the per-request policy endpoint override (upstream ``main``,
+>= ``fcca3a8``).
 
 miles calls ``run`` once per sample via
 ``--custom-agent-function-path nemogym_agent_function.run`` (with


### PR DESCRIPTION
The NeMo-Gym connector needs a per-request `policy_base_url` override in NeMo-Gym's responses-API agents — that is how each episode is pointed at the training session's URL. It was still a proposal when this integration landed, so the guide, the recipe README and the adapter docstring told readers to clone a fork branch (`nblintao/Gym@mini-swe-agent-per-request-policy-url`) "until it merges".

It is upstream now, so all three say `main` (>= `fcca3a8`) and the clone command points at `NVIDIA-NeMo/Gym`.

Docs and comments only.