### PR TITLE
docs: point the TB2 agent-server eval at the public harbor branch

### DIFF
--- a/examples/experimental/eval/terminal_bench_via_agent_server/README.md
+++ b/examples/experimental/eval/terminal_bench_via_agent_server/README.md
@@ -16,7 +16,7 @@ training-loop rollouts interact with the same backend.
 ## Prerequisites
 
 1. **A running `miles_agent_server`** from the
-   [`shi/rebase-on-upstream-v0.7.0` branch of harbor-private][branch], with
+   [`harbor-miles-v0.20.0` branch of `harbor-framework/harbor`][branch], with
    the server's `$HARBOR_TASKS_DIR` populated with the 89 Terminal-Bench 2.0
    tasks. The server's README explains setup; the short version is:
 
@@ -52,15 +52,15 @@ training-loop rollouts interact with the same backend.
    default env var is `DEEPSEEK_API_KEY`; override with `--api-key-env` if
    you keep your key under a different variable.
 
-4. **`registry.json`** from the harbor-private checkout (so the script knows
-   what the 89 task names are). Pass its path with `--registry-path`.
+4. **`registry.json`** from that harbor checkout (so the script knows what
+   the 89 task names are). Pass its path with `--registry-path`.
 
 ## Run
 
 ```bash
 python eval_tb_deepseek_v4_pro.py \
     --server-url   http://<agent-server-host>:8080 \
-    --registry-path <path-to-harbor-private>/registry.json \
+    --registry-path <path-to-harbor>/registry.json \
     --n-trials-per-task 4 \
     --max-concurrent 16
 ```
@@ -88,8 +88,8 @@ in the jsonl).
   case the agent server itself must have `OPENAI_API_KEY` set to a real
   value, because the host agent's LiteLLM client reads it from the server
   process env (Docker agents instead receive the credential per request).
-- `--max-seq-len 65536` matches the harbor-private branch's
-  poll-steps wrapper. Lower values will trigger early
+- `--max-seq-len 65536` matches the harbor branch's poll-steps
+  wrapper. Lower values will trigger early
   `SequenceLengthLimitExceeded` exits more often, which is sometimes
   desirable for shorter-context evals.
 - `--per-request-timeout-sec 3600` is the client-side cap. The server's
@@ -116,4 +116,4 @@ print(df.group_by("instance_id").agg(
 ).sort("n_pass", descending=True))
 ```
 
-[branch]: https://github.com/radixark/harbor-private/tree/shi/rebase-on-upstream-v0.7.0
+[branch]: https://github.com/harbor-framework/harbor/tree/harbor-miles-v0.20.0

--- a/examples/experimental/eval/terminal_bench_via_agent_server/eval_tb_deepseek_v4_pro.py
+++ b/examples/experimental/eval/terminal_bench_via_agent_server/eval_tb_deepseek_v4_pro.py
@@ -4,11 +4,11 @@ This is a pure client: no training, no Ray, no Megatron. It just POSTs
 ``/run`` requests concurrently to an already-running agent server and
 aggregates the per-trial results.
 
-The agent server is expected to be the one shipped in the ``harbor-private``
-branch ``shi/rebase-on-upstream-v0.7.0`` (see that repo's README for setup),
-running with ``$HARBOR_TASKS_DIR`` populated with the 89 Terminal-Bench 2.0
-tasks. The server is dataset-agnostic; this script just resolves the 89
-task names from ``registry.json`` and dispatches one ``/run`` request per
+The agent server is expected to be the one shipped in harbor's
+``harbor-miles-v0.20.0`` branch (see that repo's README for setup), running
+with ``$HARBOR_TASKS_DIR`` populated with the 89 Terminal-Bench 2.0 tasks.
+The server is dataset-agnostic; this script just resolves the 89 task names
+from ``registry.json`` and dispatches one ``/run`` request per
 (task, trial) pair.
 
 Usage::
@@ -16,7 +16,7 @@ Usage::
     export DEEPSEEK_API_KEY=<your-key>
     python eval_tb_deepseek_v4_pro.py \\
         --server-url http://localhost:8080 \\
-        --registry-path /path/to/harbor-private/registry.json \\
+        --registry-path /path/to/harbor/registry.json \\
         --n-trials-per-task 4 \\
         --max-concurrent 16
 
@@ -53,7 +53,7 @@ def parse_args() -> argparse.Namespace:
         "--registry-path",
         type=Path,
         default=Path("registry.json"),
-        help="Path to harbor-private's registry.json (used to read the 89 TB2 task names).",
+        help="Path to harbor's registry.json (used to read the 89 TB2 task names).",
     )
     parser.add_argument(
         "--dataset-name",


### PR DESCRIPTION
`examples/experimental/eval/terminal_bench_via_agent_server` told readers to run `miles_agent_server` from a branch of `radixark/harbor-private` — a repo nobody outside the org can clone, in a public example. The Miles integration is on `harbor-miles-v0.20.0` in the public `harbor-framework/harbor`, which is the branch [`examples/swe-agent-harbor-docker`](https://github.com/radixark/miles/tree/main/examples/swe-agent-harbor-docker) and `swe-agent-harbor-daytona` already point at, so this example now points there too.

Checked against that branch before swapping the pointer — everything the example leans on is present:

- `miles_agent_server.py` at the repo root, with the `--port` / `--dashboard-port` / `--max-concurrent` / `--trials-dir` flags the setup snippet passes;
- the `poll_steps()` / `max_seq_len` truncation wrapper the `--max-seq-len 65536` note describes;
- `/api/sessions` in the dashboard app, referenced by the tuning notes;
- a root `registry.json` whose `terminal-bench` 2.0 entry holds exactly 89 tasks, in the `[{name, tasks: [{name}]}]` shape `load_task_names()` parses — so `--registry-path` works verbatim against it;
- `harbor datasets download ... --export`, used to populate `HARBOR_TASKS_DIR`.

One thing this does not change: the DeepSeek-V4-Pro numbers in the README were measured against the older private branch. The commands are compatible with `harbor-miles-v0.20.0`, but the run itself was not repeated on it.

Docs and docstrings only.