### PR TITLE
docs: use NVIDIA's "NeMo Gym" spelling instead of "NeMo-Gym"

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -46,7 +46,7 @@ needed to run RL at trillion-parameter scale.
 ### Design, support & user experience
 
 - **Coding-agent sandboxes and examples.** [Harbor](/user-guide/harbor),
-  [OpenEnv](/user-guide/openenv), and [NeMo-Gym](/user-guide/nemo-gym) integrations,
+  [OpenEnv](/user-guide/openenv), and [NeMo Gym](/user-guide/nemo-gym) integrations,
   running local CPU sandboxes or per-episode sandboxes on
   [Daytona](https://www.daytona.io/), [E2B](https://e2b.dev/), and self-hosted
   [AgentENV](https://github.com/kvcache-ai/AgentENV) — see

--- a/docs/user-guide/environments.md
+++ b/docs/user-guide/environments.md
@@ -19,7 +19,7 @@ where the environment itself comes from:
 | Integration | Plugs in at | Guide |
 |---|---|---|
 | [Harbor](https://github.com/harbor-framework/harbor) | agent function | [guide](/user-guide/harbor) |
-| [NeMo-Gym](https://github.com/NVIDIA-NeMo/Gym) | agent function | [guide](/user-guide/nemo-gym) |
+| [NeMo Gym](https://github.com/NVIDIA-NeMo/Gym) | agent function | [guide](/user-guide/nemo-gym) |
 | [OpenEnv](https://github.com/huggingface/openenv) | agent function | [guide](/user-guide/openenv) |
 | [Strands Agents](https://strandsagents.com/) | generate function | [example](https://github.com/radixark/miles/tree/main/examples/experimental/strands_sglang) |
 | [Verifiers (Prime Intellect)](https://github.com/PrimeIntellect-ai/verifiers) | rollout function | [guide](/user-guide/verifiers) |
@@ -31,7 +31,7 @@ Sandbox providers are a different axis: they provision the task containers
 | Sandbox provider | Used within | Guide |
 |---|---|---|
 | [AgentENV](https://github.com/kvcache-ai/AgentENV) | OpenEnv | [example](https://github.com/radixark/miles/tree/main/examples/experimental/agentenv) |
-| [Daytona](https://www.daytona.io/) | OpenEnv, Harbor, NeMo-Gym | [example](https://github.com/radixark/miles/tree/main/examples/experimental/openenv) |
+| [Daytona](https://www.daytona.io/) | OpenEnv, Harbor, NeMo Gym | [example](https://github.com/radixark/miles/tree/main/examples/experimental/openenv) |
 | [E2B](https://e2b.dev/) | OpenEnv | [example](https://github.com/radixark/miles/tree/main/examples/experimental/openenv) |
 | [Modal](https://modal.com/) | OpenEnv | [example](https://github.com/radixark/miles/tree/main/examples/experimental/openenv) |
 

--- a/docs/user-guide/nemo-gym.md
+++ b/docs/user-guide/nemo-gym.md
@@ -1,22 +1,22 @@
 ---
-title: NeMo-Gym
-description: Train on NVIDIA NeMo-Gym environments through the agent-function extension point.
+title: NeMo Gym
+description: Train on NVIDIA NeMo Gym environments through the agent-function extension point.
 ---
 
-[NeMo-Gym](https://github.com/NVIDIA-NeMo/Gym) is NVIDIA's RL environment
+[NeMo Gym](https://github.com/NVIDIA-NeMo/Gym) is NVIDIA's RL environment
 ecosystem: environments are HTTP *resources servers* (code execution, search,
 SWE tasks, ...) paired with *agents* that drive an episode end-to-end and
-grade it. Task containers run through NeMo-Gym's own sandbox provider API
+grade it. Task containers run through NeMo Gym's own sandbox provider API
 (`nemo_gym.sandbox`) — Docker locally, or Daytona / Apptainer / ECS Fargate /
 OpenSandbox — selected by config, no agent changes.
 
-Miles integrates NeMo-Gym as an
+Miles integrates NeMo Gym as an
 [agent-function integration](/user-guide/environments): per sample, the agent
-function POSTs the task to a NeMo-Gym agent server's `/run` endpoint with
-`policy_base_url` set to the session's OpenAI-compatible URL. NeMo-Gym runs
+function POSTs the task to a NeMo Gym agent server's `/run` endpoint with
+`policy_base_url` set to the session's OpenAI-compatible URL. NeMo Gym runs
 its agent harness (mini-swe-agent v2 in `mini_swe_agent_2`) against that URL,
 so Miles' session server records every turn losslessly (token ids, logprobs,
-loss masks — see [Rollout Endpoints](/user-guide/rollout-endpoints)); NeMo-Gym
+loss masks — see [Rollout Endpoints](/user-guide/rollout-endpoints)); NeMo Gym
 grades the episode itself and the grade enters training through a custom
 reward hook reading `sample.metadata["reward"]`.
 
@@ -26,7 +26,7 @@ The maintained recipe is **SWE-bench GRPO with mini-swe-agent** in
 [`examples/experimental/nemo-gym`](https://github.com/radixark/miles/tree/main/examples/experimental/nemo-gym).
 In short:
 
-1. **Environment side** — on any docker-capable host, clone NeMo-Gym `main`
+1. **Environment side** — on any docker-capable host, clone NeMo Gym `main`
    (>= `fcca3a8`) and start the `mini_swe_agent_2` responses-API agent server
    with the docker sandbox provider config.
 2. **Data** — convert SWE-bench Verified to Miles prompt data with
@@ -47,6 +47,6 @@ The recipe is validated end-to-end: golden and API-policy scans on a real
 docker host, plus a 4-GPU GRPO training smoke whose episodes ran in real task
 containers with the SWE-bench harness grading them. Follow the
 [recipe README](https://github.com/radixark/miles/blob/main/examples/experimental/nemo-gym/README.md)
-for the NeMo-Gym server setup, no-GPU validation (golden scan / API-policy
+for the NeMo Gym server setup, no-GPU validation (golden scan / API-policy
 scan), the launch walkthrough, and known limitations (SWE-Gym eval specs,
 Qwen3 template soft-mismatch diagnostics).

--- a/examples/experimental/nemo-gym/README.md
+++ b/examples/experimental/nemo-gym/README.md
@@ -1,16 +1,16 @@
-# SWE-agent training via NeMo-Gym
+# SWE-agent training via NeMo Gym
 
 ## Introduction
 
 This example trains a SWE agent with Miles using NVIDIA's
-[NeMo-Gym](https://github.com/NVIDIA-NeMo/Gym) as the environment ecosystem:
-NeMo-Gym's sandbox-backed `mini_swe_agent_2` agent runs the
+[NeMo Gym](https://github.com/NVIDIA-NeMo/Gym) as the environment ecosystem:
+NeMo Gym's sandbox-backed `mini_swe_agent_2` agent runs the
 [mini-swe-agent](https://github.com/SWE-agent/mini-swe-agent) v2 harness inside
 per-task SWE-bench containers (via the `nemo_gym.sandbox` provider API) and
 grades every episode with the official SWE-bench harness; Miles owns training,
 batch orchestration, and lossless token recording.
 
-NeMo-Gym plugs in at the **agent function** layer (see the
+NeMo Gym plugs in at the **agent function** layer (see the
 [Environments guide](../../../docs/user-guide/environments.md)), the same
 shape as the Harbor and OpenEnv connectors:
 
@@ -19,7 +19,7 @@ Miles trainer ── session server (records every chat-completions turn: token
    │             ids + logprobs + loss masks, no re-tokenization)
    │  per-sample POST /run { task fields, policy_base_url = session URL }
    ▼
-NeMo-Gym responses-API agent server (mini_swe_agent_2)
+NeMo Gym responses-API agent server (mini_swe_agent_2)
    │  runs mini-swe-agent v2 against policy_base_url,
    │  per-task container via a nemo_gym.sandbox provider (docker here;
    │  daytona / apptainer / ecs_fargate / opensandbox also exist)
@@ -28,11 +28,11 @@ reward (official SWE-bench harness) ──► sample.metadata ──► reward h
 ```
 
 - `nemogym_agent_function.py` — the connector: one `/run` POST per sample.
-- `nemogym_generate.py` — reward hook (reads the NeMo-Gym grade from
+- `nemogym_generate.py` — reward hook (reads the NeMo Gym grade from
   `sample.metadata["reward"]`).
 - `eval_nemogym_via_api.py`, `tests/` — no-GPU validation tooling (below).
 
-Run the NeMo-Gym server from `main` (>= `fcca3a8`).
+Run the NeMo Gym server from `main` (>= `fcca3a8`).
 
 ## Validation status
 
@@ -48,7 +48,7 @@ ones used:
 - **GPU training smoke** (`run.py` defaults, 4x H200,
   Qwen3-4B-Instruct-2507, SWE-bench Verified prompts): 3 synchronous GRPO
   steps completed twice; every episode ran mini-swe-agent v2 in a real task
-  container on the NeMo-Gym host, the SWE-bench harness executed the task's
+  container on the NeMo Gym host, the SWE-bench harness executed the task's
   full test suite (e.g. 175/175 PASS_TO_PASS on an unresolved attempt), and
   the grade flowed back into `rollout/raw_reward`.
 
@@ -65,7 +65,7 @@ Two known limitations from the smoke run:
   recorded token ids, which stay lossless — and is a property of the
   model-family template, not of this connector.
 
-## Setting up the NeMo-Gym server
+## Setting up the NeMo Gym server
 
 Any docker-capable host works: a CPU box next to the cluster, or a container
 beside the trainer (mount `/var/run/docker.sock` and share a docker network
@@ -125,7 +125,7 @@ python download_and_process_data.py --input princeton-nlp/SWE-bench_Verified \
 Each row keeps the full SWE-bench-format instance (`instance_id`, `repo`,
 `base_commit`, `problem_statement`, ...) in `metadata`, plus `subset` /
 `split` — the agent function forwards all of it in the `/run` body, and
-NeMo-Gym selects the per-task image from it.
+NeMo Gym selects the per-task image from it.
 
 **SWE-Gym caveat**: `--input SWE-Gym/SWE-Gym --subset gym` produces the
 training dataset this recipe ultimately targets (per-task images from
@@ -146,7 +146,7 @@ skip):
 
 ```bash
 export NEMO_GYM_URL="http://<nemo-gym-host>:12000"
-# Only if the NeMo-Gym host cannot resolve the trainer's hostname (e.g. it
+# Only if the NeMo Gym host cannot resolve the trainer's hostname (e.g. it
 # reaches the trainer over a tailnet):
 export MILES_ROUTER_EXTERNAL_HOST="<trainer host/IP reachable from that host>"
 python examples/experimental/nemo-gym/run.py
@@ -175,9 +175,9 @@ with "unrecognized arguments"), and:
 
 Per sample, `agentic_tool_call` opens a session on Miles' session server and
 hands its OpenAI-compatible URL to `nemogym_agent_function.run`, which POSTs
-the task to the NeMo-Gym server's `/run` with `policy_base_url` set to that
+the task to the NeMo Gym server's `/run` with `policy_base_url` set to that
 session URL and the sampling settings mapped onto `responses_create_params`
-(`temperature`, `top_p`, `max_output_tokens`). NeMo-Gym's mini-swe-agent v2
+(`temperature`, `top_p`, `max_output_tokens`). NeMo Gym's mini-swe-agent v2
 then talks to the policy exclusively through the session URL (litellm chat
 completions), so Miles records every turn losslessly — token ids, logprobs,
 and loss masks come from the session server, not from re-tokenizing message
@@ -240,5 +240,5 @@ on CPU-only machines, in three independent layers (all three pass as of
    (server-side `eval_timeout`, default 1800s). `NEMO_GYM_RUN_TIMEOUT`
    (default 3600s) caps one episode end-to-end on the Miles side.
 4. A failed episode surfaces as `sample.metadata["eval_report"]["error"]` with
-   a traceback from the NeMo-Gym server — check there before digging into
+   a traceback from the NeMo Gym server — check there before digging into
    server logs.

--- a/examples/experimental/nemo-gym/download_and_process_data.py
+++ b/examples/experimental/nemo-gym/download_and_process_data.py
@@ -18,7 +18,7 @@ def convert_to_miles_format(
         output_path: Path to output JSONL file in Miles format
         limit: Optional limit on number of samples
         split: Dataset split name (used in metadata)
-        subset: NeMo-Gym subset controlling per-task image selection and eval
+        subset: NeMo Gym subset controlling per-task image selection and eval
             ("gym" -> SWE-Gym images, "verified" -> official SWE-bench images)
     """
     count = 0
@@ -54,7 +54,7 @@ def main():
     )
     parser.add_argument("--limit", type=int, help="Limit number of samples")
     parser.add_argument(
-        "--subset", type=str, default="gym", help='NeMo-Gym subset: "gym" (SWE-Gym) or "verified" (SWE-bench Verified)'
+        "--subset", type=str, default="gym", help='NeMo Gym subset: "gym" (SWE-Gym) or "verified" (SWE-bench Verified)'
     )
 
     args = parser.parse_args()

--- a/examples/experimental/nemo-gym/eval_nemogym_via_api.py
+++ b/examples/experimental/nemo-gym/eval_nemogym_via_api.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Validate the NeMo-Gym leg without a GPU trainer (golden / API-policy scan).
+"""Validate the NeMo Gym leg without a GPU trainer (golden / API-policy scan).
 
 Drives a running mini_swe_agent_2 server through the same ``/run`` contract
 the miles agent function uses, so a pass here validates everything except the

--- a/examples/experimental/nemo-gym/nemogym_agent_function.py
+++ b/examples/experimental/nemo-gym/nemogym_agent_function.py
@@ -1,4 +1,4 @@
-"""NeMo-Gym <-> miles adapter (agent function).
+"""NeMo Gym <-> miles adapter (agent function).
 
 Targets upstream NVIDIA-NeMo/Gym's sandbox-backed ``mini_swe_agent_2`` agent,
 which requires the per-request policy endpoint override (upstream ``main``,
@@ -7,26 +7,26 @@ which requires the per-request policy endpoint override (upstream ``main``,
 miles calls ``run`` once per sample via
 ``--custom-agent-function-path nemogym_agent_function.run`` (with
 ``--custom-generate-function-path miles.rollout.generate_hub.agentic_tool_call.generate``).
-Each call POSTs the task to the NeMo-Gym agent server's ``/run`` endpoint,
+Each call POSTs the task to the NeMo Gym agent server's ``/run`` endpoint,
 handing over the session's OpenAI-compatible URL as ``policy_base_url``.
-NeMo-Gym runs mini-swe-agent v2 in a ``nemo_gym.sandbox`` container (docker /
+NeMo Gym runs mini-swe-agent v2 in a ``nemo_gym.sandbox`` container (docker /
 daytona / apptainer / ecs_fargate / opensandbox providers) against that URL,
 so every model call goes through miles' session server and is recorded
 losslessly (token ids + logprobs + loss masks) — no re-tokenization.
 
-The NeMo-Gym environment grades the episode itself (SWE-bench harness); the
+The NeMo Gym environment grades the episode itself (SWE-bench harness); the
 returned dict is merged into ``sample.metadata`` so the reward hook
 (``--custom-rm-path nemogym_generate.reward_func``) can read
 ``metadata["reward"]``.
 
 Env vars:
-  NEMO_GYM_URL   base URL of the NeMo-Gym agent server
+  NEMO_GYM_URL   base URL of the NeMo Gym agent server
                  (default: http://localhost:12000).
   NEMO_GYM_RUN_TIMEOUT  hard wall-clock cap in seconds for one /run call
                  (default: 3600). SWE episodes pull per-task docker images on
                  first use, which can dominate early rollouts.
   MILES_ROUTER_EXTERNAL_HOST  optional host rewrite for the session URL when
-                 the NeMo-Gym server cannot resolve the trainer's hostname
+                 the NeMo Gym server cannot resolve the trainer's hostname
                  (e.g. it runs outside the trainer's docker network).
 """
 
@@ -79,7 +79,7 @@ def _resolve_session_url(base_url: str) -> str:
 
 
 def build_responses_create_params(request_kwargs: dict[str, Any]) -> dict[str, Any]:
-    """Map miles' chat-completions sampling kwargs onto NeMo-Gym's Responses-API params.
+    """Map miles' chat-completions sampling kwargs onto NeMo Gym's Responses-API params.
 
     mini_swe_agent_2 reads sampling settings exclusively from
     ``responses_create_params`` (temperature / top_p / max_output_tokens, see
@@ -101,7 +101,7 @@ async def run(
     metadata: dict[str, Any] | None = None,
     **kwargs,
 ) -> dict[str, Any] | None:
-    """Run one task instance via the NeMo-Gym mini_swe_agent_2 server.
+    """Run one task instance via the NeMo Gym mini_swe_agent_2 server.
 
     Returns the reward dict to merge into sample metadata, or None on a
     transport failure (timeout, unreachable server). On None the recorded
@@ -132,13 +132,13 @@ async def run(
             timeout=timeout_s,
         )
     except asyncio.TimeoutError:
-        logger.error(f"NeMo-Gym /run timed out after {timeout_s:.0f}s")
+        logger.error(f"NeMo Gym /run timed out after {timeout_s:.0f}s")
         return None
     except asyncio.CancelledError:
-        logger.warning("NeMo-Gym /run cancelled (sibling task failure?)")
+        logger.warning("NeMo Gym /run cancelled (sibling task failure?)")
         return None
     except Exception as e:
-        logger.error(f"NeMo-Gym /run failed: {e}")
+        logger.error(f"NeMo Gym /run failed: {e}")
         return None
 
     return {

--- a/examples/experimental/nemo-gym/nemogym_generate.py
+++ b/examples/experimental/nemo-gym/nemogym_generate.py
@@ -1,10 +1,10 @@
-"""NeMo-Gym example: reward hook.
+"""NeMo Gym example: reward hook.
 
 The generate function is provided by
     miles.rollout.generate_hub.agentic_tool_call.generate
 with --custom-agent-function-path pointing to nemogym_agent_function.run.
 
-Reward is pre-computed by the NeMo-Gym environment (SWE-bench harness) during
+Reward is pre-computed by the NeMo Gym environment (SWE-bench harness) during
 the episode and stored in sample.metadata["reward"].
 """
 
@@ -12,7 +12,7 @@ from miles.utils.types import Sample
 
 
 async def reward_func(args, samples: Sample | list[Sample], **kwargs) -> float | list[float]:
-    """Reward is pre-computed by the NeMo-Gym environment during generate()."""
+    """Reward is pre-computed by the NeMo Gym environment during generate()."""
     if isinstance(samples, list):
         return [s.metadata.get("reward", 0.0) for s in samples]
     return samples.metadata.get("reward", 0.0)

--- a/examples/experimental/nemo-gym/run.py
+++ b/examples/experimental/nemo-gym/run.py
@@ -1,7 +1,7 @@
-"""NeMo-Gym launcher (Qwen3-4B-Instruct-2507): Miles <-> mini_swe_agent_2 orchestration.
+"""NeMo Gym launcher (Qwen3-4B-Instruct-2507): Miles <-> mini_swe_agent_2 orchestration.
 
 Defaults are the exact configuration of the validated smoke run (4x H200,
-2026-07-28): 3 GRPO steps at tiny scale against a NeMo-Gym server running the
+2026-07-28): 3 GRPO steps at tiny scale against a NeMo Gym server running the
 docker sandbox provider. Scale up --num-rollout / batch sizes for real
 training.
 
@@ -50,9 +50,9 @@ class ScriptArgs(U.ExecuteTrainConfig):
     global_batch_size: int = 8
     save_interval: int = 1000
 
-    # NeMo-Gym settings
+    # NeMo Gym settings
     nemo_gym_url: str = os.environ.get("NEMO_GYM_URL", "http://localhost:12000")
-    # Trainer address reachable from the NeMo-Gym host; only needed when that
+    # Trainer address reachable from the NeMo Gym host; only needed when that
     # host cannot resolve the trainer's hostname (e.g. it dials back over a
     # tailnet).
     router_external_host: str = os.environ.get("MILES_ROUTER_EXTERNAL_HOST", "")
@@ -146,7 +146,7 @@ def execute(args: ScriptArgs):
         "--custom-rm-path nemogym_generate.reward_func "
         "--dynamic-sampling-filter-path miles.rollout.filter_hub.dynamic_sampling_filters.check_no_aborted "
         "--use-session-server "
-        # 0.0.0.0 so the NeMo-Gym host can dial in on any interface (e.g. a
+        # 0.0.0.0 so the NeMo Gym host can dial in on any interface (e.g. a
         # tailnet address); internal calls resolve it to localhost.
         "--session-server-ip 0.0.0.0 "
         "--session-server-port 30000 "

--- a/examples/experimental/nemo-gym/tests/test_nemogym_agent_function.py
+++ b/examples/experimental/nemo-gym/tests/test_nemogym_agent_function.py
@@ -1,4 +1,4 @@
-"""Offline unit tests for the NeMo-Gym adapter (no network, no GPU).
+"""Offline unit tests for the NeMo Gym adapter (no network, no GPU).
 
 Not collected by the repo-level pytest run (testpaths = ./tests); run manually
 when touching the adapter:


### PR DESCRIPTION
NVIDIA spells the product **NeMo Gym** (unhyphenated) in their own docs and repo naming; our integration guide and example used `NeMo-Gym` throughout. NVIDIA is now referencing our integration guide from their own training tutorial ([NVIDIA-NeMo/Gym#2469](https://github.com/NVIDIA-NeMo/Gym/issues/2469)), so the spelling should match theirs.

50 occurrences across 10 files, all prose.

**Deliberately unchanged**, so nothing breaks:

- directory names (`examples/experimental/nemo-gym/`)
- the docs slug `/user-guide/nemo-gym` — already linked externally from Gym#2469
- URLs, including `NVIDIA-NeMo/Gym` (never contained the hyphenated form)
- `NEMO_GYM_URL`, `--nemo-gym-url`, and `nemo_gym` package references
- the literal `nemo-gym depends on openai<=Y` uv error text in the troubleshooting section

The Python changes are docstrings, comments, one `--subset` help string, and three log messages — no behavior change.

`ruff check` passes on the changed files (`ruff format` is not part of the pre-commit gate, and disagrees with the tree on these files at the base commit too). The offline test suite could not run on this machine (`datasets` is not installed), but no test asserts on the changed strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)