### PR TITLE
fix: drop duplicated rematerialize validation call

### DIFF
--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -3288,8 +3288,6 @@ def miles_validate_args(args):
 
     _validate_rematerialize_param_from_master_weight(args)
 
-    _validate_rematerialize_param_from_master_weight(args)
-
     if args.offload_train_target == "disk":
         assert args.offload_train, "--offload-train-target=disk requires --offload-train"
         assert (


### PR DESCRIPTION
## What

Removes a duplicated call to `_validate_rematerialize_param_from_master_weight(args)` in `validate_args`: the function was invoked twice in a row with nothing in between.

## Why

The two calls are back-to-back, so the second one re-validates exactly the state the first one just validated. The function is pure validation — it either passes, raises, or performs one idempotent downgrade (`rematerialize_param_from_master_weight = False` under `--debug-train-only`) — so the second call can never do anything the first did not.

How it happened: #1572 introduced the call, and #2223 landed a second copy at the same location.

Noticed while reviewing #2375, whose description points the duplicate out but deliberately leaves the fix out of a docs PR.

## Testing

- `python3 -m py_compile miles/utils/arguments.py`
- `black==24.3.0 --check --line-length 119` on the changed file
- Behavior-preserving one-line deletion: the validation still runs exactly once, at the same point in `validate_args`.
