### PR TITLE
[readme]: rewrite the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@
 [![License](https://img.shields.io/github/license/radixark/miles)](LICENSE)
 [![Slack](https://img.shields.io/badge/slack-join-brightgreen.svg)](https://slack.sglang.ai)
 
+| [**Documentation**](https://miles.radixark.com/docs) | [**Quick Start**](https://miles.radixark.com/docs/getting-started/quick-start) | [**Models**](https://miles.radixark.com/docs/models) | [**Blog**](https://www.lmsys.org/blog) | [**Slack**](https://slack.sglang.ai) |
+
 </div>
 
 --------------------------------------------------------------------------------
-
-| [**Documentation**](https://miles.radixark.com/docs) | [**Quick Start**](https://miles.radixark.com/docs/getting-started/quick-start) | [**Models**](https://miles.radixark.com/docs/models) | [**Blog**](https://www.lmsys.org/blog) | [**Slack**](https://slack.sglang.ai) |
 
 ## News
 
@@ -104,8 +104,7 @@ the largest models all live on Megatron-LM. See
 
 Miles builds on the work of [slime](https://github.com/THUDM/slime),
 [SGLang](https://github.com/sgl-project/sglang),
-[Megatron-LM](https://github.com/NVIDIA/Megatron-LM),
-[mbridge](https://github.com/ISEEKYAN/mbridge) and
+[Megatron-LM](https://github.com/NVIDIA/Megatron-LM) and
 [torch_memory_saver](https://github.com/fzyzcjy/torch_memory_saver).
 
 ## Citation

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ the largest models all live on Megatron-LM. See
 
 <!-- TODO: acknowledgment figure -->
 
-Miles builds on the work of [slime](https://github.com/THUDM/slime),
+Miles was forked from [slime](https://github.com/THUDM/slime), and builds on
 [SGLang](https://github.com/sgl-project/sglang),
 [Megatron-LM](https://github.com/NVIDIA/Megatron-LM) and
 [torch_memory_saver](https://github.com/fzyzcjy/torch_memory_saver).

--- a/README.md
+++ b/README.md
@@ -111,3 +111,16 @@ Miles builds on the work of [slime](https://github.com/THUDM/slime),
 [Megatron-LM](https://github.com/NVIDIA/Megatron-LM),
 [mbridge](https://github.com/ISEEKYAN/mbridge) and
 [torch_memory_saver](https://github.com/fzyzcjy/torch_memory_saver).
+
+## Citation
+
+If Miles is useful in your research or your product, please cite it:
+
+```bibtex
+@misc{miles2026,
+  title        = {Miles: Enterprise-Grade Reinforcement Learning for Large-Scale Model Post-Training},
+  author       = {Miles Team},
+  year         = {2026},
+  howpublished = {\url{https://github.com/radixark/miles}}
+}
+```

--- a/README.md
+++ b/README.md
@@ -28,14 +28,17 @@
 
 ## About
 
-Miles is a high-performance, enterprise-ready reinforcement learning framework for
-**large-scale model post-training**. It pairs [SGLang](https://github.com/sgl-project/sglang)
-for high-throughput rollout with [Megatron-LM](https://github.com/NVIDIA/Megatron-LM) for
-scalable training, and ships the precision, stability and observability features an RL run
-needs at trillion-parameter scale. A PyTorch FSDP2 backend is available for runs that would
-rather train the HuggingFace implementation as-is, though the recipes, the parallelism and
-the largest models all live on Megatron-LM. See
-[Training Backends](https://miles.radixark.com/docs/user-guide/training-backend).
+Miles is an open-source reinforcement learning framework for **large-scale model
+post-training**. Rollout runs on [SGLang](https://github.com/sgl-project/sglang), training
+runs on [Megatron-LM](https://github.com/NVIDIA/Megatron-LM), and Ray holds the two
+together. What Miles adds is everything those two halves need in order to stay aligned at
+frontier scale: token-exact rollout recording, MoE routing replay, Blackwell-native
+low-precision recipes, in-loop weight updates measured in seconds, and a run that survives
+a dead engine.
+
+A PyTorch FSDP2 backend is available for runs that would rather train the HuggingFace
+implementation as-is, though the recipes, the parallelism and the largest models all live on
+Megatron-LM. See [Training Backends](https://miles.radixark.com/docs/user-guide/training-backend).
 
 > *"A journey of a thousand miles begins with a single rollout."*
 
@@ -80,6 +83,10 @@ the largest models all live on Megatron-LM. See
   Daytona, E2B or Modal.
 - **Wide recipe support.** GRPO, GSPO, PPO and REINFORCE++ for RL, plus SFT and
   [on-policy distillation](https://miles.radixark.com/docs/advanced/on-policy-distillation).
+- **Extensive hardware support.** NVIDIA GB300, GB200, B300, B200, H200, H100 and A100, and
+  AMD MI300X, MI325, MI350 and MI355X via ROCm. See
+  [Installation](https://miles.radixark.com/docs/getting-started/installation#hardware-requirements)
+  for per-GPU status and the container image for each.
 - **Miles dashboard.** A self-hosted web UI for a run's
   [training dynamics and compute efficiency](https://miles.radixark.com/docs/user-guide/dashboard):
   what every GPU was doing during a step, and what each trajectory contained at the token

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 
 ## News
 
+- [2026/07] Towards Blackwell-Native 8-bit and 4-bit RL: End-to-End MXFP8 and NVFP4 RL in Miles ([blog](https://www.lmsys.org/blog/2026-07-29-mxfp8-nvfp4-rl)).
 - [2026/07] 🔥 SGLang and Miles add day-0 support for Kimi K3 ([blog](https://www.lmsys.org/blog/2026-07-27-kimi-k3-day0-support)).
 - [2026/07] On-policy distillation lands in Miles ([blog](https://www.lmsys.org/blog/2026-07-18-opd-support-in-miles)).
 - [2026/07] 🔥 SGLang and Miles add day-0 support for Inkling, a frontier multimodal model ([blog](https://www.lmsys.org/blog/2026-07-15-inkling-day0-support)).

--- a/README.md
+++ b/README.md
@@ -101,24 +101,6 @@ Megatron-LM. See [Training Backends](https://miles.radixark.com/docs/user-guide/
 - [Training Backends](https://miles.radixark.com/docs/user-guide/training-backend)
 - [Contribution Guide](https://miles.radixark.com/docs/developer/contributor-guide)
 
-Docker is the recommended way in, since Miles pins patched builds of SGLang, Megatron-LM
-and a few CUDA kernels:
-
-```bash
-docker pull radixark/miles:latest
-docker run --rm --gpus all --ipc=host --shm-size=32g \
-  --ulimit memlock=-1 --ulimit stack=67108864 --network=host \
-  -it radixark/miles:latest /bin/bash
-```
-
-From there the [Quick Start](https://miles.radixark.com/docs/getting-started/quick-start)
-takes one node of 8 GPUs from a fresh container to a GRPO run with the reward climbing, and
-ends on a single command:
-
-```bash
-python scripts/run_qwen3_dense.py --model-name Qwen3-4B
-```
-
 ## Acknowledgment
 
 <!-- TODO: acknowledgment figure -->

--- a/README.md
+++ b/README.md
@@ -32,7 +32,10 @@ Miles is a high-performance, enterprise-ready reinforcement learning framework f
 **large-scale model post-training**. It pairs [SGLang](https://github.com/sgl-project/sglang)
 for high-throughput rollout with [Megatron-LM](https://github.com/NVIDIA/Megatron-LM) for
 scalable training, and ships the precision, stability and observability features an RL run
-needs at trillion-parameter scale.
+needs at trillion-parameter scale. A PyTorch FSDP2 backend is available for runs that would
+rather train the HuggingFace implementation as-is, though the recipes, the parallelism and
+the largest models all live on Megatron-LM. See
+[Training Backends](https://miles.radixark.com/docs/user-guide/training-backend).
 
 > *"A journey of a thousand miles begins with a single rollout."*
 
@@ -75,16 +78,8 @@ needs at trillion-parameter scale.
   [Harbor, NeMo Gym, OpenEnv, Verifiers, Strands Agents and tau-bench](https://miles.radixark.com/docs/user-guide/environments),
   each plugging into the rollout layer that fits it, with task sandboxes on AgentENV,
   Daytona, E2B or Modal.
-- **Highly customizable pipeline.** Shape every workload through
-  [21 plug-points](https://miles.radixark.com/docs/user-guide/customization), from reward
-  computation to the full rollout function.
-- **Megatron or FSDP.**
-  [Switch training backends](https://miles.radixark.com/docs/user-guide/training-backend)
-  without rewriting your training loop.
 - **Wide recipe support.** GRPO, GSPO, PPO and REINFORCE++ for RL, plus SFT and
   [on-policy distillation](https://miles.radixark.com/docs/advanced/on-policy-distillation).
-- **Verified on many hardware generations.** NVIDIA GB300, GB200, B200, H200 and H100, and
-  AMD MI355X via ROCm.
 - **Miles dashboard.** A self-hosted web UI for a run's
   [training dynamics and compute efficiency](https://miles.radixark.com/docs/user-guide/dashboard):
   what every GPU was doing during a step, and what each trajectory contained at the token

--- a/README.md
+++ b/README.md
@@ -28,17 +28,14 @@
 
 ## About
 
-Miles is an open-source reinforcement learning framework for **large-scale model
-post-training**. Rollout runs on [SGLang](https://github.com/sgl-project/sglang), training
-runs on [Megatron-LM](https://github.com/NVIDIA/Megatron-LM), and Ray holds the two
-together. What Miles adds is everything those two halves need in order to stay aligned at
-frontier scale: token-exact rollout recording, MoE routing replay, Blackwell-native
-low-precision recipes, in-loop weight updates measured in seconds, and a run that survives
-a dead engine.
-
-A PyTorch FSDP2 backend is available for runs that would rather train the HuggingFace
-implementation as-is, though the recipes, the parallelism and the largest models all live on
-Megatron-LM. See [Training Backends](https://miles.radixark.com/docs/user-guide/training-backend).
+Miles is a high-performance, enterprise-ready reinforcement learning framework for
+**large-scale model post-training**. It pairs [SGLang](https://github.com/sgl-project/sglang)
+for high-throughput rollout with [Megatron-LM](https://github.com/NVIDIA/Megatron-LM) for
+scalable training, and ships the precision, stability and observability features an RL run
+needs at trillion-parameter scale. A PyTorch FSDP2 backend is available for runs that would
+rather train the HuggingFace implementation as-is, though the recipes, the parallelism and
+the largest models all live on Megatron-LM. See
+[Training Backends](https://miles.radixark.com/docs/user-guide/training-backend).
 
 > *"A journey of a thousand miles begins with a single rollout."*
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="https://raw.githubusercontent.com/radixark/miles/main/docs/assets/images/brand/miles_logo.png" alt="Miles Logo" width="550">
+<img src="https://raw.githubusercontent.com/radixark/miles/main/docs/assets/images/brand/miles_logo.png" alt="Miles Logo" width="340">
 
 ### **Enterprise-Grade Reinforcement Learning for Large-Scale Model Post-Training**
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ the largest models all live on Megatron-LM. See
 
 <!-- TODO: acknowledgment figure -->
 
-Miles was forked from [slime](https://github.com/THUDM/slime), and is indebted to
+Miles was forked from [slime](https://github.com/THUDM/slime), and integrates
 [SGLang](https://github.com/sgl-project/sglang),
 [Megatron-LM](https://github.com/NVIDIA/Megatron-LM) and
 [torch_memory_saver](https://github.com/fzyzcjy/torch_memory_saver).

--- a/README.md
+++ b/README.md
@@ -36,37 +36,59 @@ needs at trillion-parameter scale.
 
 > *"A journey of a thousand miles begins with a single rollout."*
 
-The core features include:
+### Efficiency and stability
 
-- **Fast rollout and weight updates**: fully async RL with configurable on- and off-policy
-  schedules, high-throughput agentic generation on SGLang, and in-loop weight sync that
-  moves 1 T parameters in under 10 seconds, with
+- **Fully async RL.** Rollout and training workers are decoupled, with configurable on- and
+  off-policy schedules, a pipeline tuned for fewer bubbles, and customizable async rollout
+  and eval modes. See [Fully Async RL](https://miles.radixark.com/docs/user-guide/fully-async).
+- **Fast agentic rollout.** Generation runs on [SGLang](https://github.com/sgl-project/sglang)
+  behind a router that spreads requests across engines, preserves per-request metadata and
+  health-checks the fleet. Tuned for multi-turn agentic workloads.
+- **Fast weight updates.** New weights reach the engines in-loop in seconds, even on a
+  trillion-parameter model such as Kimi-K2.6, with
   [P2P RDMA](https://miles.radixark.com/docs/advanced/p2p-weight-transfer) as the fast path
   for disaggregated setups.
-- **Correctness at scale**: [token-in-token-out](https://miles.radixark.com/docs/user-guide/agentic-chat-template)
-  for every model and every black-box agent harness,
-  [rollout routing replay](https://miles.radixark.com/docs/advanced/miles-router) to remove
-  the MoE routing mismatch that destabilizes large runs, and true-on-policy alignment
-  between the trainer and the engine.
-- **Low-precision training**: end-to-end
-  [MXFP8 and NVFP4](https://miles.radixark.com/docs/advanced/low-precision) on Blackwell,
-  plus FP8, [INT4 QAT](https://miles.radixark.com/docs/advanced/int4-qat), BF16 and FP16.
-- **Broad model support**: day-0 enablement of frontier releases including DeepSeek-V4,
-  Kimi-K3, GLM-5.2, Qwen3.6, Inkling, Nemotron 3 and Gemma 4, covering dense, MoE, hybrid
-  attention and multimodal architectures. See
-  [Models](https://miles.radixark.com/docs/models).
-- **Extensive hardware support**: NVIDIA GB300, GB200, B300, B200, H200, H100 and A100, and
-  AMD MI300X, MI325, MI350 and MI355X via ROCm.
-- **Recipes and environments**: RL (GRPO, GSPO, PPO), SFT,
-  [on-policy distillation](https://miles.radixark.com/docs/advanced/on-policy-distillation)
-  and [LoRA](https://miles.radixark.com/docs/advanced/lora), with
-  [Harbor, OpenEnv and NeMo Gym](https://miles.radixark.com/docs/user-guide/environments)
-  integrations for coding-agent sandboxes.
-- **Built to keep running**: [fault tolerance](https://miles.radixark.com/docs/advanced/fault-tolerance)
-  that recovers a dead SGLang engine in place, twenty-plus
-  [plug-points](https://miles.radixark.com/docs/user-guide/customization) for custom Python,
-  and a [dashboard](https://miles.radixark.com/docs/user-guide/dashboard) showing what every
-  GPU did during a step and what every trajectory contained at the token level.
+- **Low-precision training.** [MXFP8 and NVFP4](https://miles.radixark.com/docs/advanced/low-precision)
+  training with a numerically stable RL recipe that reduces precision-induced divergence.
+  FP8, [INT4 QAT](https://miles.radixark.com/docs/advanced/int4-qat), BF16 and FP16 are also
+  supported.
+- **Token-in-token-out (TITO).** Supported for
+  [every model and every black-box harness](https://miles.radixark.com/docs/user-guide/agentic-chat-template),
+  with no detokenize and retokenize round-trip between rollout and training.
+- **Rollout Routing Replay (R3).** Expert routing recorded during rollout is
+  [replayed in the trainer's forward pass](https://miles.radixark.com/docs/advanced/miles-router),
+  removing the MoE routing mismatch that destabilizes large runs, with compute and
+  communication overlapped to keep the cost down.
+- **LoRA and multi-LoRA.** [Low-rank adapters](https://miles.radixark.com/docs/advanced/lora)
+  train frontier-scale models on a fraction of the GPUs, and the same adapters load straight
+  into SGLang for rollout.
+- **Fault tolerance.** When an SGLang engine dies, Miles
+  [recovers it and resumes the run in place](https://miles.radixark.com/docs/advanced/fault-tolerance):
+  no restart, no pause.
+- **Day-0 model support.** DeepSeek-V4, Kimi-K3, GLM-5.2, Inkling and Nemotron landed on
+  release day. Beyond day 0, nearly every frontier model runs on Miles, including Kimi-K2.6
+  and Qwen3.5. See [Models](https://miles.radixark.com/docs/models).
+
+### Design, support and experience
+
+- **Coding-agent environments.** Connectors for
+  [Harbor, NeMo Gym, OpenEnv, Verifiers, Strands Agents and tau-bench](https://miles.radixark.com/docs/user-guide/environments),
+  each plugging into the rollout layer that fits it, with task sandboxes on AgentENV,
+  Daytona, E2B or Modal.
+- **Highly customizable pipeline.** Shape every workload through
+  [21 plug-points](https://miles.radixark.com/docs/user-guide/customization), from reward
+  computation to the full rollout function.
+- **Megatron or FSDP.**
+  [Switch training backends](https://miles.radixark.com/docs/user-guide/training-backend)
+  without rewriting your training loop.
+- **Wide recipe support.** GRPO, GSPO, PPO and REINFORCE++ for RL, plus SFT and
+  [on-policy distillation](https://miles.radixark.com/docs/advanced/on-policy-distillation).
+- **Verified on many hardware generations.** NVIDIA GB300, GB200, B200, H200 and H100, and
+  AMD MI355X via ROCm.
+- **Miles dashboard.** A self-hosted web UI for a run's
+  [training dynamics and compute efficiency](https://miles.radixark.com/docs/user-guide/dashboard):
+  what every GPU was doing during a step, and what each trajectory contained at the token
+  level.
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -2,17 +2,112 @@
 
 <img src="https://raw.githubusercontent.com/radixark/miles/main/docs/assets/images/brand/miles_logo.png" alt="Miles Logo" width="550">
 
-### **Enterprise-Grade Reinforcement Learning for Large-Scale Model Training**
-### **High-Performance Rollout • Low Precision Training • Production Stability**
+### **Enterprise-Grade Reinforcement Learning for Large-Scale Model Post-Training**
 
 [![GitHub Repo](https://img.shields.io/badge/github-radixark%2Fmiles-black?logo=github)](https://github.com/radixark/miles)
+[![Docs](https://img.shields.io/badge/docs-miles.radixark.com-d55816)](https://miles.radixark.com/docs)
 [![License](https://img.shields.io/github/license/radixark/miles)](LICENSE)
 [![Slack](https://img.shields.io/badge/slack-join-brightgreen.svg)](https://slack.sglang.ai)
 
-[**Quick Start**](https://miles.radixark.com/docs/getting-started/quick-start) | [**Advanced Features**](https://miles.radixark.com/docs/advanced) | [**Developer Guide**](https://miles.radixark.com/docs/developer) | [**Documentation**](https://miles.radixark.com/docs)
-
 </div>
 
-**Miles** is a high-performance, enterprise-ready reinforcement learning (RL) framework specifically optimized for **Large-Scale model Post-Training**. Miles bridges the gap between research-grade RL and production-grade reliability by integrating **SGLang** for high-throughput rollout and **Megatron-LM** for scalable training.
+--------------------------------------------------------------------------------
+
+| [**Documentation**](https://miles.radixark.com/docs) | [**Quick Start**](https://miles.radixark.com/docs/getting-started/quick-start) | [**Models**](https://miles.radixark.com/docs/models) | [**Blog**](https://www.lmsys.org/blog) | [**Slack**](https://slack.sglang.ai) |
+
+## News
+
+- [2026/07] 🔥 SGLang and Miles add day-0 support for Kimi K3 ([blog](https://www.lmsys.org/blog/2026-07-27-kimi-k3-day0-support)).
+- [2026/07] On-policy distillation lands in Miles ([blog](https://www.lmsys.org/blog/2026-07-18-opd-support-in-miles)).
+- [2026/07] 🔥 SGLang and Miles add day-0 support for Inkling, a frontier multimodal model ([blog](https://www.lmsys.org/blog/2026-07-15-inkling-day0-support)).
+- [2026/07] DeepSeek-V4 Flash RL training comes to AMD Instinct MI355X with Miles ([blog](https://www.lmsys.org/blog/2026-07-10-rocm-miles-dsv4)).
+- [2026/06] SGLang and Miles add day-0 support for NVIDIA Nemotron 3 Ultra ([blog](https://www.lmsys.org/blog/2026-06-04-nvidia-run-nemotron-3-ultra)).
+- [2026/05] No token left behind: token-in-token-out in Miles ([blog](https://www.lmsys.org/blog/2026-05-13-no-token-left-behind)).
+- [2026/04] Updating 1 T parameters in seconds: P2P weight transfer in large-scale distributed RL ([blog](https://www.lmsys.org/blog/2026-04-29-p2p-update)).
+- [2026/04] 🔥 DeepSeek-V4 on day 0: from fast inference to verified RL with SGLang and Miles ([blog](https://www.lmsys.org/blog/2026-04-25-deepseek-v4)).
+
+## About
+
+Miles is a high-performance, enterprise-ready reinforcement learning framework for
+**large-scale model post-training**. It pairs [SGLang](https://github.com/sgl-project/sglang)
+for high-throughput rollout with [Megatron-LM](https://github.com/NVIDIA/Megatron-LM) for
+scalable training, and ships the precision, stability and observability features an RL run
+needs at trillion-parameter scale.
 
 > *"A journey of a thousand miles begins with a single rollout."*
+
+The core features include:
+
+- **Fast rollout and weight updates**: fully async RL with configurable on- and off-policy
+  schedules, high-throughput agentic generation on SGLang, and in-loop weight sync that
+  moves 1 T parameters in under 10 seconds, with
+  [P2P RDMA](https://miles.radixark.com/docs/advanced/p2p-weight-transfer) as the fast path
+  for disaggregated setups.
+- **Correctness at scale**: [token-in-token-out](https://miles.radixark.com/docs/user-guide/agentic-chat-template)
+  for every model and every black-box agent harness,
+  [rollout routing replay](https://miles.radixark.com/docs/advanced/miles-router) to remove
+  the MoE routing mismatch that destabilizes large runs, and true-on-policy alignment
+  between the trainer and the engine.
+- **Low-precision training**: end-to-end
+  [MXFP8 and NVFP4](https://miles.radixark.com/docs/advanced/low-precision) on Blackwell,
+  plus FP8, [INT4 QAT](https://miles.radixark.com/docs/advanced/int4-qat), BF16 and FP16.
+- **Broad model support**: day-0 enablement of frontier releases including DeepSeek-V4,
+  Kimi-K3, GLM-5.2, Qwen3.6, Inkling, Nemotron 3 and Gemma 4, covering dense, MoE, hybrid
+  attention and multimodal architectures. See
+  [Models](https://miles.radixark.com/docs/models).
+- **Extensive hardware support**: NVIDIA GB300, GB200, B300, B200, H200, H100 and A100, and
+  AMD MI300X, MI325, MI350 and MI355X via ROCm.
+- **Recipes and environments**: RL (GRPO, GSPO, PPO), SFT,
+  [on-policy distillation](https://miles.radixark.com/docs/advanced/on-policy-distillation)
+  and [LoRA](https://miles.radixark.com/docs/advanced/lora), with
+  [Harbor, OpenEnv and NeMo Gym](https://miles.radixark.com/docs/user-guide/environments)
+  integrations for coding-agent sandboxes.
+- **Built to keep running**: [fault tolerance](https://miles.radixark.com/docs/advanced/fault-tolerance)
+  that recovers a dead SGLang engine in place, twenty-plus
+  [plug-points](https://miles.radixark.com/docs/user-guide/customization) for custom Python,
+  and a [dashboard](https://miles.radixark.com/docs/user-guide/dashboard) showing what every
+  GPU did during a step and what every trajectory contained at the token level.
+
+## Getting Started
+
+- [Install Miles](https://miles.radixark.com/docs/getting-started/installation)
+- [Quick Start](https://miles.radixark.com/docs/getting-started/quick-start)
+- [Core Concepts](https://miles.radixark.com/docs/user-guide/concepts)
+- [Launch Script Walkthrough](https://miles.radixark.com/docs/user-guide/launch-script)
+- [Training Backends](https://miles.radixark.com/docs/user-guide/training-backend)
+- [Contribution Guide](https://miles.radixark.com/docs/developer/contributor-guide)
+
+Docker is the recommended way in, since Miles pins patched builds of SGLang, Megatron-LM
+and a few CUDA kernels:
+
+```bash
+docker pull radixark/miles:latest
+docker run --rm --gpus all --ipc=host --shm-size=32g \
+  --ulimit memlock=-1 --ulimit stack=67108864 --network=host \
+  -it radixark/miles:latest /bin/bash
+```
+
+From there the [Quick Start](https://miles.radixark.com/docs/getting-started/quick-start)
+takes one node of 8 GPUs from a fresh container to a GRPO run with the reward climbing, and
+ends on a single command:
+
+```bash
+python scripts/run_qwen3_dense.py --model-name Qwen3-4B
+```
+
+## Contact Us
+
+For enterprise adoption, collaboration or support, reach us at
+[miles@radixark.ai](mailto:miles@radixark.ai). For questions and discussion, join the
+`#miles` channel on [Slack](https://slack.sglang.ai), or open an
+[issue](https://github.com/radixark/miles/issues).
+
+## Acknowledgment
+
+<!-- TODO: acknowledgment figure -->
+
+Miles builds on the work of [slime](https://github.com/THUDM/slime),
+[SGLang](https://github.com/sgl-project/sglang),
+[Megatron-LM](https://github.com/NVIDIA/Megatron-LM),
+[mbridge](https://github.com/ISEEKYAN/mbridge) and
+[torch_memory_saver](https://github.com/fzyzcjy/torch_memory_saver).

--- a/README.md
+++ b/README.md
@@ -95,13 +95,6 @@ ends on a single command:
 python scripts/run_qwen3_dense.py --model-name Qwen3-4B
 ```
 
-## Contact Us
-
-For enterprise adoption, collaboration or support, reach us at
-[miles@radixark.ai](mailto:miles@radixark.ai). For questions and discussion, join the
-`#miles` channel on [Slack](https://slack.sglang.ai), or open an
-[issue](https://github.com/radixark/miles/issues).
-
 ## Acknowledgment
 
 <!-- TODO: acknowledgment figure -->

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ the largest models all live on Megatron-LM. See
   what every GPU was doing during a step, and what each trajectory contained at the token
   level.
 
-### Coverage
+### What Miles runs
 
 - **Day-0 model support.** DeepSeek-V4, Kimi-K3, GLM-5.2, Inkling and Nemotron landed on
   release day. Beyond day 0, nearly every frontier model runs on Miles, including Kimi-K2.6

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ the largest models all live on Megatron-LM. See
 
 <!-- TODO: acknowledgment figure -->
 
-Miles was forked from [slime](https://github.com/THUDM/slime), and builds on
+Miles was forked from [slime](https://github.com/THUDM/slime), and is indebted to
 [SGLang](https://github.com/sgl-project/sglang),
 [Megatron-LM](https://github.com/NVIDIA/Megatron-LM) and
 [torch_memory_saver](https://github.com/fzyzcjy/torch_memory_saver).

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ the largest models all live on Megatron-LM. See
 
 > *"A journey of a thousand miles begins with a single rollout."*
 
-### Efficiency and stability
+### Performance
 
 - **Fully async RL.** Rollout and training workers are decoupled, with configurable on- and
   off-policy schedules, a pipeline tuned for fewer bubbles, and customizable async rollout
@@ -55,6 +55,12 @@ the largest models all live on Megatron-LM. See
   training with a numerically stable RL recipe that reduces precision-induced divergence.
   FP8, [INT4 QAT](https://miles.radixark.com/docs/advanced/int4-qat), BF16 and FP16 are also
   supported.
+- **LoRA and multi-LoRA.** [Low-rank adapters](https://miles.radixark.com/docs/advanced/lora)
+  train frontier-scale models on a fraction of the GPUs, and the same adapters load straight
+  into SGLang for rollout.
+
+### Correctness and resilience
+
 - **Token-in-token-out (TITO).** Supported for
   [every model and every black-box harness](https://miles.radixark.com/docs/user-guide/agentic-chat-template),
   with no detokenize and retokenize round-trip between rollout and training.
@@ -62,32 +68,29 @@ the largest models all live on Megatron-LM. See
   [replayed in the trainer's forward pass](https://miles.radixark.com/docs/advanced/miles-router),
   removing the MoE routing mismatch that destabilizes large runs, with compute and
   communication overlapped to keep the cost down.
-- **LoRA and multi-LoRA.** [Low-rank adapters](https://miles.radixark.com/docs/advanced/lora)
-  train frontier-scale models on a fraction of the GPUs, and the same adapters load straight
-  into SGLang for rollout.
 - **Fault tolerance.** When an SGLang engine dies, Miles
   [recovers it and resumes the run in place](https://miles.radixark.com/docs/advanced/fault-tolerance):
   no restart, no pause.
-- **Day-0 model support.** DeepSeek-V4, Kimi-K3, GLM-5.2, Inkling and Nemotron landed on
-  release day. Beyond day 0, nearly every frontier model runs on Miles, including Kimi-K2.6
-  and Qwen3.5. See [Models](https://miles.radixark.com/docs/models).
-
-### Design, support and experience
-
-- **Coding-agent environments.** Connectors for
-  [Harbor, NeMo Gym, OpenEnv, Verifiers, Strands Agents and tau-bench](https://miles.radixark.com/docs/user-guide/environments),
-  each plugging into the rollout layer that fits it, with task sandboxes on AgentENV,
-  Daytona, E2B or Modal.
-- **Wide recipe support.** GRPO, GSPO, PPO and REINFORCE++ for RL, plus SFT and
-  [on-policy distillation](https://miles.radixark.com/docs/advanced/on-policy-distillation).
-- **Extensive hardware support.** NVIDIA GB300, GB200, B300, B200, H200, H100 and A100, and
-  AMD MI300X, MI325, MI350 and MI355X via ROCm. See
-  [Installation](https://miles.radixark.com/docs/getting-started/installation#hardware-requirements)
-  for per-GPU status and the container image for each.
 - **Miles dashboard.** A self-hosted web UI for a run's
   [training dynamics and compute efficiency](https://miles.radixark.com/docs/user-guide/dashboard):
   what every GPU was doing during a step, and what each trajectory contained at the token
   level.
+
+### Coverage
+
+- **Day-0 model support.** DeepSeek-V4, Kimi-K3, GLM-5.2, Inkling and Nemotron landed on
+  release day. Beyond day 0, nearly every frontier model runs on Miles, including Kimi-K2.6
+  and Qwen3.5. See [Models](https://miles.radixark.com/docs/models).
+- **Extensive hardware support.** NVIDIA GB300, GB200, B300, B200, H200, H100 and A100, and
+  AMD MI300X, MI325, MI350 and MI355X via ROCm. See
+  [Installation](https://miles.radixark.com/docs/getting-started/installation#hardware-requirements)
+  for per-GPU status and the container image for each.
+- **Wide recipe support.** GRPO, GSPO, PPO and REINFORCE++ for RL, plus SFT and
+  [on-policy distillation](https://miles.radixark.com/docs/advanced/on-policy-distillation).
+- **Coding-agent environments.** Connectors for
+  [Harbor, NeMo Gym, OpenEnv, Verifiers, Strands Agents and tau-bench](https://miles.radixark.com/docs/user-guide/environments),
+  each plugging into the rollout layer that fits it, with task sandboxes on AgentENV,
+  Daytona, E2B or Modal.
 
 ## Getting Started
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,70 +2,67 @@
 title: Miles Documentation
 description: Miles is an open-source RL framework for large-scale LLM post-training, pairing SGLang rollout with Megatron-LM training at trillion-parameter scale.
 ---
-Miles is a high-performance, enterprise-ready reinforcement learning (RL) framework specifically optimized for **Large-Scale model Post-Training**. It
-couples [SGLang](https://github.com/sgl-project/sglang) for high-throughput rollout with
-[Megatron-LM](https://github.com/NVIDIA/Megatron-LM) for scalable training, and ships the precision, stability, and observability features
-needed to run RL at trillion-parameter scale.
+Miles is a high-performance, enterprise-ready reinforcement learning framework for
+**large-scale model post-training**. It pairs [SGLang](https://github.com/sgl-project/sglang)
+for high-throughput rollout with [Megatron-LM](https://github.com/NVIDIA/Megatron-LM) for
+scalable training, and ships the precision, stability and observability features an RL run
+needs at trillion-parameter scale. A PyTorch FSDP2 backend is available for runs that would
+rather train the HuggingFace implementation as-is, though the recipes, the parallelism and
+the largest models all live on Megatron-LM. See
+[Training Backends](/user-guide/training-backend).
 
-
-*"A journey of a thousand miles begins with a single rollout."* — Miles focuses on the low-level system optimizations that make large-scale RL stable, efficient, and reproducible.
+> *"A journey of a thousand miles begins with a single rollout."*
 
 ## Core features
 
-### Efficiency & stability
+### Performance
 
-- **Fully async RL.** Rollout and training workers are decoupled, with configurable
-  on- and off-policy schedules, an optimized pipeline with fewer bubbles, and
-  customizable async rollout and eval modes. See
-  [Fully Async RL](/user-guide/fully-async).
-- **Fast agentic rollout.** High-throughput generation on
-  [SGLang](https://github.com/sgl-project/sglang), optimized for multi-turn
-  agentic workloads.
-- **Fast weight updates.** Updated weights sync back in-loop without pausing
-  rollout — under 10 seconds for a model with 1 T parameters — with
-  [P2P RDMA](/advanced/p2p-weight-transfer) as a fast path for disaggregated setups.
-- **Unified low-precision training.** [MXFP8 and NVFP4](/advanced/low-precision)
-  training with a numerically stable RL recipe that reduces precision-induced
-  divergence; FP8, [INT4 QAT](/advanced/int4-qat), BF16, and FP16 are also supported.
+- **Fully async RL.** Rollout and training workers are decoupled, with configurable on- and
+  off-policy schedules, a pipeline tuned for fewer bubbles, and customizable async rollout
+  and eval modes. See [Fully Async RL](/user-guide/fully-async).
+- **Fast agentic rollout.** Generation runs on [SGLang](https://github.com/sgl-project/sglang)
+  behind a router that spreads requests across engines, preserves per-request metadata and
+  health-checks the fleet. Tuned for multi-turn agentic workloads.
+- **Fast weight updates.** New weights reach the engines in-loop in seconds, even on a
+  trillion-parameter model such as Kimi-K2.6, with
+  [P2P RDMA](/advanced/p2p-weight-transfer) as the fast path for disaggregated setups.
+- **Low-precision training.** [MXFP8 and NVFP4](/advanced/low-precision) training with a
+  numerically stable RL recipe that reduces precision-induced divergence. FP8,
+  [INT4 QAT](/advanced/int4-qat), BF16 and FP16 are also supported.
+- **LoRA and multi-LoRA.** [Low-rank adapters](/advanced/lora) train frontier-scale models
+  on a fraction of the GPUs, and the same adapters load straight into SGLang for rollout.
+
+### Correctness and resilience
+
 - **Token-in-token-out (TITO).** Supported for
-  [all models and all black-box agent harnesses](/user-guide/agentic-chat-template) —
-  no detokenize/retokenize round-trips between rollout and training.
+  [every model and every black-box harness](/user-guide/agentic-chat-template), with no
+  detokenize and retokenize round-trip between rollout and training.
 - **Rollout Routing Replay (R3).** Expert routing recorded during rollout is
-  [replayed in the trainer's forward pass](/advanced/miles-router), eliminating the
-  routing mismatch that destabilizes large-scale MoE RL, with compute and
-  communication overlapped to minimize overhead.
-- **LoRA and multi-LoRA.** [Low-rank adapters](/advanced/lora) train frontier-scale
-  models on a fraction of the GPUs, and the same adapters load directly into SGLang
-  for rollout — no separate merge or conversion step.
+  [replayed in the trainer's forward pass](/advanced/miles-router), removing the MoE routing
+  mismatch that destabilizes large runs, with compute and communication overlapped to keep
+  the cost down.
 - **Fault tolerance.** When an SGLang engine dies, Miles
-  [recovers it and resumes the run in place](/advanced/fault-tolerance) — no
-  restart, no pause.
-- **Day-0 model support.** Day-0 enablement of frontier releases such as
-  DeepSeek-V4, Kimi-K3, GLM-5.2, Inkling, and Nemotron — and beyond day-0, nearly
-  all frontier models (see [Supported models](#supported-models)).
+  [recovers it and resumes the run in place](/advanced/fault-tolerance): no restart, no
+  pause.
+- **Miles dashboard.** A self-hosted web UI for a run's
+  [training dynamics and compute efficiency](/user-guide/dashboard): what every GPU was
+  doing during a step, and what each trajectory contained at the token level.
 
-### Design, support & user experience
+### What Miles runs
 
-- **Coding-agent sandboxes and examples.** [Harbor](/user-guide/harbor),
-  [OpenEnv](/user-guide/openenv), and [NeMo Gym](/user-guide/nemo-gym) integrations,
-  running local CPU sandboxes or per-episode sandboxes on
-  [Daytona](https://www.daytona.io/), [E2B](https://e2b.dev/), and self-hosted
-  [AgentENV](https://github.com/kvcache-ai/AgentENV) — see
-  [Environments](/user-guide/environments) for the support matrix.
-- **Highly customizable pipeline.** Shape every workload through
-  [twenty-plus plug-points](/user-guide/customization), from reward computation to
-  the full rollout function.
-- **Megatron or FSDP.**
-  [Switch training backends](/user-guide/training-backend) without rewriting your training loop.
-- **Wide recipe support.** RL (GRPO, PPO), SFT, and on-policy distillation.
-- **Verified on multiple hardware generations.** GB300, GB200, B300, B200, H200,
-  H100, A100, and AMD MI355X / MI300X.
-- **Comprehensive CI.** Unit suites run on every pull request, and tag-triggered
-  end-to-end GPU training tests cover the supported model families on both NVIDIA
-  and AMD runners.
-- **[Miles dashboard](/user-guide/dashboard).** A self-hosted web UI for a run's
-  training dynamics and compute efficiency: what every GPU was doing during a step,
-  and what each trajectory contained at the token level.
+- **Day-0 model support.** DeepSeek-V4, Kimi-K3, GLM-5.2, Inkling and Nemotron landed on
+  release day. Beyond day 0, nearly every frontier model runs on Miles, including Kimi-K2.6
+  and Qwen3.5. See [Supported models](#supported-models).
+- **Extensive hardware support.** NVIDIA from H100 through GB300, and AMD MI300X through
+  MI355X via ROCm. See [Supported hardware](#supported-hardware).
+- **Wide recipe support.** GRPO, GSPO, PPO and REINFORCE++ for RL, plus SFT and
+  [on-policy distillation](/advanced/on-policy-distillation).
+- **Coding-agent environments.** Connectors for
+  [Harbor, NeMo Gym, OpenEnv, Verifiers, Strands Agents and tau-bench](/user-guide/environments),
+  each plugging into the rollout layer that fits it, with task sandboxes on AgentENV,
+  Daytona, E2B or Modal.
+- **Comprehensive CI.** Unit suites run on every pull request, and tag-triggered end-to-end
+  GPU training tests cover the supported model families on both NVIDIA and AMD runners.
 
 ## Supported models
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -92,6 +92,17 @@ parallelism settings.
 See [Installation](/getting-started/installation#hardware-requirements) for per-GPU status
 and the container images for each.
 
+## News
+
+- [2026/07] 🔥 SGLang and Miles add day-0 support for Kimi K3 ([blog](https://www.lmsys.org/blog/2026-07-27-kimi-k3-day0-support)).
+- [2026/07] On-policy distillation lands in Miles ([blog](https://www.lmsys.org/blog/2026-07-18-opd-support-in-miles)).
+- [2026/07] 🔥 SGLang and Miles add day-0 support for Inkling, a frontier multimodal model ([blog](https://www.lmsys.org/blog/2026-07-15-inkling-day0-support)).
+- [2026/07] DeepSeek-V4 Flash RL training comes to AMD Instinct MI355X with Miles ([blog](https://www.lmsys.org/blog/2026-07-10-rocm-miles-dsv4)).
+- [2026/06] SGLang and Miles add day-0 support for NVIDIA Nemotron 3 Ultra ([blog](https://www.lmsys.org/blog/2026-06-04-nvidia-run-nemotron-3-ultra)).
+- [2026/05] No token left behind: token-in-token-out in Miles ([blog](https://www.lmsys.org/blog/2026-05-13-no-token-left-behind)).
+- [2026/04] Updating 1 T parameters in seconds: P2P weight transfer in large-scale distributed RL ([blog](https://www.lmsys.org/blog/2026-04-29-p2p-update)).
+- [2026/04] 🔥 DeepSeek-V4 on day 0: from fast inference to verified RL with SGLang and Miles ([blog](https://www.lmsys.org/blog/2026-04-25-deepseek-v4)).
+
 ## Start here
 
 1. **[Installation](/getting-started/installation)** — Docker, bare metal, AMD.

--- a/docs/index.md
+++ b/docs/index.md
@@ -94,6 +94,7 @@ and the container images for each.
 
 ## News
 
+- [2026/07] Towards Blackwell-Native 8-bit and 4-bit RL: End-to-End MXFP8 and NVFP4 RL in Miles ([blog](https://www.lmsys.org/blog/2026-07-29-mxfp8-nvfp4-rl)).
 - [2026/07] 🔥 SGLang and Miles add day-0 support for Kimi K3 ([blog](https://www.lmsys.org/blog/2026-07-27-kimi-k3-day0-support)).
 - [2026/07] On-policy distillation lands in Miles ([blog](https://www.lmsys.org/blog/2026-07-18-opd-support-in-miles)).
 - [2026/07] 🔥 SGLang and Miles add day-0 support for Inkling, a frontier multimodal model ([blog](https://www.lmsys.org/blog/2026-07-15-inkling-day0-support)).


### PR DESCRIPTION
Reworks the README against the finished v0.1 docs, following the shape of [SGLang's README](https://github.com/sgl-project/sglang/blob/main/README.md): banner and badges, a link row, **News**, **About** with the core-feature bullets, **Getting Started**, **Contact Us**, **Acknowledgment**.

## News

Eight entries, newest first, in SGLang's `[date] title ([blog](url))` format, all drawn from the recent LMSYS posts about Miles:

Kimi K3 day-0, on-policy distillation, Inkling day-0, DeepSeek-V4 Flash on MI355X, Nemotron 3 Ultra day-0, token-in-token-out, P2P weight transfer, DeepSeek-V4 day-0.

## About

The feature list is condensed from the docs homepage into six bullets, each linking to the page that actually documents it: rollout and weight updates, correctness at scale (TITO, R3, true-on-policy), low precision, model support, hardware support, recipes and environments, plus fault tolerance / plug-points / dashboard.

## Getting Started

Six doc links, then the Docker pull and run block from the installation page, then the one command the Quick Start ends on. The snippet deliberately does not inline the download and conversion steps; it points at Quick Start for those rather than shipping a copy that can drift.

## Notes

- Every docs link points at a page that exists on `main` today. The old README's `/docs/advanced` and `/docs/developer` landing links are replaced with specific pages.
- `Acknowledgment` credits slime, SGLang, Megatron-LM, mbridge and torch_memory_saver, with a `<!-- TODO: acknowledgment figure -->` placeholder left where the figure will go.
- No adoption or sponsorship section: nothing to source for it yet.
