### PR TITLE
fix(fsdp): stop store_true from shadowing bool defaults in FSDPArgs

### DIFF
--- a/miles/backends/fsdp_utils/arguments.py
+++ b/miles/backends/fsdp_utils/arguments.py
@@ -80,11 +80,19 @@ def parse_fsdp_cli(extra_args_provider=None):
             arg_type = f.type
 
         if f.name == "keep_fp32_master":
-            parser.add_argument(
+            group = parser.add_mutually_exclusive_group()
+            group.add_argument(
+                "--keep-fp32-master",
+                dest=f.name,
+                action="store_true",
+                default=f.default,
+                help="Keep an FP32 master copy of the weights for bit-exact weight sync.",
+            )
+            group.add_argument(
                 "--disable-fp32-master",
                 dest=f.name,
                 action="store_false",
-                default=f.default,
+                default=argparse.SUPPRESS,
                 help="Disable the FP32 master copy to reduce memory when bit-exact weight sync is not required.",
             )
         elif arg_type is bool:

--- a/miles/backends/fsdp_utils/arguments.py
+++ b/miles/backends/fsdp_utils/arguments.py
@@ -88,7 +88,12 @@ def parse_fsdp_cli(extra_args_provider=None):
                 help="Disable the FP32 master copy to reduce memory when bit-exact weight sync is not required.",
             )
         elif arg_type is bool:
-            parser.add_argument(f"--{f.name.replace('_', '-')}", action="store_true")
+            # BooleanOptionalAction keeps the dataclass default (a bare store_true
+            # silently forces False) and adds a --no- form so True defaults stay
+            # switchable from the CLI.
+            parser.add_argument(
+                f"--{f.name.replace('_', '-')}", action=argparse.BooleanOptionalAction, default=f.default
+            )
         else:
             parser.add_argument(f"--{f.name.replace('_', '-')}", type=arg_type, default=f.default)
 

--- a/miles/backends/fsdp_utils/arguments.py
+++ b/miles/backends/fsdp_utils/arguments.py
@@ -79,23 +79,7 @@ def parse_fsdp_cli(extra_args_provider=None):
         else:
             arg_type = f.type
 
-        if f.name == "keep_fp32_master":
-            group = parser.add_mutually_exclusive_group()
-            group.add_argument(
-                "--keep-fp32-master",
-                dest=f.name,
-                action="store_true",
-                default=f.default,
-                help="Keep an FP32 master copy of the weights for bit-exact weight sync.",
-            )
-            group.add_argument(
-                "--disable-fp32-master",
-                dest=f.name,
-                action="store_false",
-                default=argparse.SUPPRESS,
-                help="Disable the FP32 master copy to reduce memory when bit-exact weight sync is not required.",
-            )
-        elif arg_type is bool:
+        if arg_type is bool:
             parser.add_argument(
                 f"--{f.name.replace('_', '-')}", action=argparse.BooleanOptionalAction, default=f.default
             )

--- a/miles/backends/fsdp_utils/arguments.py
+++ b/miles/backends/fsdp_utils/arguments.py
@@ -88,9 +88,6 @@ def parse_fsdp_cli(extra_args_provider=None):
                 help="Disable the FP32 master copy to reduce memory when bit-exact weight sync is not required.",
             )
         elif arg_type is bool:
-            # BooleanOptionalAction keeps the dataclass default (a bare store_true
-            # silently forces False) and adds a --no- form so True defaults stay
-            # switchable from the CLI.
             parser.add_argument(
                 f"--{f.name.replace('_', '-')}", action=argparse.BooleanOptionalAction, default=f.default
             )

--- a/tests/fast/backends/test_fsdp_arguments.py
+++ b/tests/fast/backends/test_fsdp_arguments.py
@@ -1,11 +1,3 @@
-"""CLI parsing for the FSDP argument dataclass.
-
-The invariant under test: what the CLI hands you with no flags passed is
-exactly the ``FSDPArgs`` dataclass defaults. A bare ``action="store_true"``
-used to force every bool to ``False``, silently flipping the two fields whose
-dataclass default is ``True``.
-"""
-
 import dataclasses
 import sys
 

--- a/tests/fast/backends/test_fsdp_arguments.py
+++ b/tests/fast/backends/test_fsdp_arguments.py
@@ -26,9 +26,15 @@ def test_cli_defaults_match_the_dataclass(monkeypatch: pytest.MonkeyPatch) -> No
 
 
 def test_true_default_bools_can_be_turned_off(monkeypatch: pytest.MonkeyPatch) -> None:
-    args = _parse(monkeypatch, "--no-fsdp-state-dict-cpu-offload", "--no-use-checkpoint-lr-scheduler")
+    args = _parse(
+        monkeypatch,
+        "--no-fsdp-state-dict-cpu-offload",
+        "--no-use-checkpoint-lr-scheduler",
+        "--no-keep-fp32-master",
+    )
     assert args.fsdp_state_dict_cpu_offload is False
     assert args.use_checkpoint_lr_scheduler is False
+    assert args.keep_fp32_master is False
 
 
 def test_false_default_bools_still_turn_on(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -37,12 +43,10 @@ def test_false_default_bools_still_turn_on(monkeypatch: pytest.MonkeyPatch) -> N
     assert args.fp16 is True
 
 
-def test_fp32_master_toggles_both_ways(monkeypatch: pytest.MonkeyPatch) -> None:
-    assert _parse(monkeypatch).keep_fp32_master is True
-    assert _parse(monkeypatch, "--disable-fp32-master").keep_fp32_master is False
-    assert _parse(monkeypatch, "--keep-fp32-master").keep_fp32_master is True
-
-
-def test_fp32_master_rejects_both_spellings_at_once(monkeypatch: pytest.MonkeyPatch) -> None:
-    with pytest.raises(SystemExit):
-        _parse(monkeypatch, "--keep-fp32-master", "--disable-fp32-master")
+def test_every_bool_gets_both_forms(monkeypatch: pytest.MonkeyPatch) -> None:
+    for field in dataclasses.fields(FSDPArgs):
+        if field.type is not bool:
+            continue
+        flag = field.name.replace("_", "-")
+        assert _parse(monkeypatch, f"--{flag}").__dict__[field.name] is True
+        assert _parse(monkeypatch, f"--no-{flag}").__dict__[field.name] is False

--- a/tests/fast/backends/test_fsdp_arguments.py
+++ b/tests/fast/backends/test_fsdp_arguments.py
@@ -14,6 +14,11 @@ def _parse(monkeypatch: pytest.MonkeyPatch, *argv: str):
 def test_cli_defaults_match_the_dataclass(monkeypatch: pytest.MonkeyPatch) -> None:
     args = _parse(monkeypatch)
     for field in dataclasses.fields(FSDPArgs):
+        assert field.default is not dataclasses.MISSING, (
+            f"{field.name} declares no plain default, so parse_fsdp_cli registers "
+            f"the dataclasses.MISSING sentinel as its CLI default; teach the parser "
+            f"about default_factory before adding a field like this"
+        )
         assert getattr(args, field.name) == field.default, (
             f"CLI default for --{field.name.replace('_', '-')} is {getattr(args, field.name)!r}, "
             f"but the dataclass declares {field.default!r}"
@@ -32,6 +37,12 @@ def test_false_default_bools_still_turn_on(monkeypatch: pytest.MonkeyPatch) -> N
     assert args.fp16 is True
 
 
-def test_disable_fp32_master_keeps_its_spelling(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_fp32_master_toggles_both_ways(monkeypatch: pytest.MonkeyPatch) -> None:
     assert _parse(monkeypatch).keep_fp32_master is True
     assert _parse(monkeypatch, "--disable-fp32-master").keep_fp32_master is False
+    assert _parse(monkeypatch, "--keep-fp32-master").keep_fp32_master is True
+
+
+def test_fp32_master_rejects_both_spellings_at_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    with pytest.raises(SystemExit):
+        _parse(monkeypatch, "--keep-fp32-master", "--disable-fp32-master")

--- a/tests/fast/backends/test_fsdp_arguments.py
+++ b/tests/fast/backends/test_fsdp_arguments.py
@@ -1,0 +1,45 @@
+"""CLI parsing for the FSDP argument dataclass.
+
+The invariant under test: what the CLI hands you with no flags passed is
+exactly the ``FSDPArgs`` dataclass defaults. A bare ``action="store_true"``
+used to force every bool to ``False``, silently flipping the two fields whose
+dataclass default is ``True``.
+"""
+
+import dataclasses
+import sys
+
+import pytest
+
+from miles.backends.fsdp_utils.arguments import FSDPArgs, parse_fsdp_cli
+
+
+def _parse(monkeypatch: pytest.MonkeyPatch, *argv: str):
+    monkeypatch.setattr(sys, "argv", ["prog", *argv])
+    return parse_fsdp_cli()
+
+
+def test_cli_defaults_match_the_dataclass(monkeypatch: pytest.MonkeyPatch) -> None:
+    args = _parse(monkeypatch)
+    for field in dataclasses.fields(FSDPArgs):
+        assert getattr(args, field.name) == field.default, (
+            f"CLI default for --{field.name.replace('_', '-')} is {getattr(args, field.name)!r}, "
+            f"but the dataclass declares {field.default!r}"
+        )
+
+
+def test_true_default_bools_can_be_turned_off(monkeypatch: pytest.MonkeyPatch) -> None:
+    args = _parse(monkeypatch, "--no-fsdp-state-dict-cpu-offload", "--no-use-checkpoint-lr-scheduler")
+    assert args.fsdp_state_dict_cpu_offload is False
+    assert args.use_checkpoint_lr_scheduler is False
+
+
+def test_false_default_bools_still_turn_on(monkeypatch: pytest.MonkeyPatch) -> None:
+    args = _parse(monkeypatch, "--gradient-checkpointing", "--fp16")
+    assert args.gradient_checkpointing is True
+    assert args.fp16 is True
+
+
+def test_disable_fp32_master_keeps_its_spelling(monkeypatch: pytest.MonkeyPatch) -> None:
+    assert _parse(monkeypatch).keep_fp32_master is True
+    assert _parse(monkeypatch, "--disable-fp32-master").keep_fp32_master is False

--- a/tests/fast/backends/test_fsdp_precision.py
+++ b/tests/fast/backends/test_fsdp_precision.py
@@ -41,7 +41,7 @@ def test_fp32_master_cli_defaults_enabled_and_can_be_disabled(monkeypatch):
     monkeypatch.setattr(sys, "argv", ["miles"])
     assert parse_fsdp_cli().keep_fp32_master
 
-    monkeypatch.setattr(sys, "argv", ["miles", "--disable-fp32-master"])
+    monkeypatch.setattr(sys, "argv", ["miles", "--no-keep-fp32-master"])
     assert not parse_fsdp_cli().keep_fp32_master
 
 


### PR DESCRIPTION
## The problem

`build_fsdp_parser` derives the CLI from `FSDPArgs`, so the dataclass reads as the source of truth for defaults. For booleans it was not. A bare `action="store_true"` carries an implicit `default=False`, which shadows whatever the field declares, and there is no way to express `False` for a field that defaults to `True`.

Two fields declare `True`, so both parsed to `False` on every run that did not pass the flag:

| field | dataclass | parsed |
| --- | --- | --- |
| `use_checkpoint_lr_scheduler` | `True` | `False` |
| `fsdp_state_dict_cpu_offload` | `True` | `False` |

`keep_fp32_master` also declares `True` and escaped only because it had a hand-written special case (`--disable-fp32-master`, `store_false`, explicit `default=f.default`) — the same bug, worked around once, for one field.

## What this is worth

Honestly: **no observable damage today.** `fsdp_state_dict_cpu_offload` has no readers anywhere in the tree, and `use_checkpoint_lr_scheduler` is only ever read by one assertion in `lr_scheduler.py` (`if override: assert not use_checkpoint`), so a constant `False` just makes that assertion always pass. Nothing about checkpointing or resume behaves differently.

The value is in stopping the bleeding. The current shape is a trap: the next `bool = True` field added to `FSDPArgs` silently becomes `False`, with no error and no warning, and the next one may well have a real consumer.

## The change

`argparse.BooleanOptionalAction` with `default=f.default`. The declared default survives, and every bool gets a `--no-` form so a `True` default stays switchable.

That also makes the `keep_fp32_master` special case redundant — it was only ever a hand-rolled version of what the generic branch now does — so it is deleted. `build_fsdp_parser` is left with one rule per type instead of one rule plus an exception.

**Breaking:** `--disable-fp32-master` becomes `--no-keep-fp32-master`. The flag landed four days ago in #2272 and nothing outside two tests referenced it: no launch script, config, doc or shell script.

## Testing

`tests/fast/backends/test_fsdp_arguments.py` (new):

- with no flags passed, every `FSDPArgs` field parses to its dataclass default
- every bool field accepts both `--x` and `--no-x`, checked by iterating the dataclass rather than by naming fields, so a new bool is covered on arrival
- a field declaring `default_factory` instead of a plain default is rejected up front. `build_fsdp_parser` does not handle that case and would register the `dataclasses.MISSING` sentinel as the CLI default; without this guard the defaults test would compare `MISSING` to `MISSING` and pass while the value is garbage

`tests/fast/backends/test_fsdp_precision.py` updated for the rename. Full `tests/fast/backends/` is green at 462 passed on an H200 box.
