### PR TITLE
fix(fsdp): make --config actually apply, and reject keys it does not know

### DIFF
--- a/miles/backends/fsdp_utils/arguments.py
+++ b/miles/backends/fsdp_utils/arguments.py
@@ -1,5 +1,6 @@
 import argparse
 import dataclasses
+import difflib
 from dataclasses import dataclass
 
 import yaml
@@ -64,7 +65,7 @@ class FSDPArgs:
     config: str | None = None
 
 
-def parse_fsdp_cli(extra_args_provider=None):
+def build_fsdp_parser(extra_args_provider=None) -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser("FSDP SFT Training (miles)")
     parser.add_argument("--config", type=str, default=None, help="YAML config path")
     for f in dataclasses.fields(FSDPArgs):
@@ -94,18 +95,34 @@ def parse_fsdp_cli(extra_args_provider=None):
 
     if extra_args_provider is not None:
         parser = extra_args_provider(parser)
-    args = parser.parse_args()
-    return args
+    return parser
+
+
+def parse_fsdp_cli(extra_args_provider=None):
+    return build_fsdp_parser(extra_args_provider).parse_args()
+
+
+def reject_unknown_config_keys(data: dict, known: set[str]) -> None:
+    unknown = sorted(set(data) - known)
+    if not unknown:
+        return
+
+    described = []
+    for key in unknown:
+        close = difflib.get_close_matches(key, known, n=1)
+        described.append(f"{key!r} (did you mean {close[0]!r}?)" if close else repr(key))
+    raise ValueError(f"unknown key(s) in the YAML config: {', '.join(described)}")
 
 
 def load_fsdp_args(extra_args_provider=None):
-    args = parse_fsdp_cli(extra_args_provider)
+    parser = build_fsdp_parser(extra_args_provider)
+    args = parser.parse_args()
     if args.config:
         with open(args.config) as f:
             data = yaml.safe_load(f) or {}
-        for k, v in data.items():
-            if not hasattr(args, k):
-                setattr(args, k, v)
+        reject_unknown_config_keys(data, set(vars(args)))
+        parser.set_defaults(**data)
+        args = parser.parse_args()
     args.bf16 = not args.fp16
     return args
 

--- a/tests/fast/backends/test_fsdp_config_precedence.py
+++ b/tests/fast/backends/test_fsdp_config_precedence.py
@@ -1,0 +1,78 @@
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+from miles.backends.fsdp_utils.arguments import FSDPArgs, load_fsdp_args
+
+
+def _config(tmp_path: Path, **entries) -> str:
+    path = tmp_path / "fsdp.yaml"
+    path.write_text(yaml.safe_dump(entries))
+    return str(path)
+
+
+def _load(monkeypatch: pytest.MonkeyPatch, *argv: str):
+    monkeypatch.setattr(sys, "argv", ["prog", *argv])
+    return load_fsdp_args()
+
+
+def test_config_beats_the_dataclass_default(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    assert FSDPArgs.lr != 5e-5
+    args = _load(monkeypatch, "--config", _config(tmp_path, lr=5e-5))
+    assert args.lr == 5e-5
+
+
+def test_cli_beats_the_config(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    args = _load(monkeypatch, "--config", _config(tmp_path, lr=5e-5), "--lr", "7e-5")
+    assert args.lr == 7e-5
+
+
+def test_config_toggles_bools_both_ways(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    assert FSDPArgs.gradient_checkpointing is False
+    assert FSDPArgs.keep_fp32_master is True
+    args = _load(
+        monkeypatch,
+        "--config",
+        _config(tmp_path, gradient_checkpointing=True, keep_fp32_master=False),
+    )
+    assert args.gradient_checkpointing is True
+    assert args.keep_fp32_master is False
+
+
+def test_cli_beats_the_config_for_bools(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    args = _load(
+        monkeypatch,
+        "--config",
+        _config(tmp_path, gradient_checkpointing=False),
+        "--gradient-checkpointing",
+    )
+    assert args.gradient_checkpointing is True
+
+
+def test_a_key_the_parser_does_not_know_is_rejected(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="some_plugin_knob"):
+        _load(monkeypatch, "--config", _config(tmp_path, some_plugin_knob=42))
+
+
+def test_a_misspelled_key_names_the_field_it_almost_matched(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="did you mean 'weight_decay'"):
+        _load(monkeypatch, "--config", _config(tmp_path, weigth_decay=0.1))
+
+
+def test_a_valid_config_is_not_tripped_by_the_check(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    args = _load(monkeypatch, "--config", _config(tmp_path, lr=5e-5, weight_decay=0.1, gradient_checkpointing=True))
+    assert (args.lr, args.weight_decay, args.gradient_checkpointing) == (5e-5, 0.1, True)
+
+
+def test_fields_untouched_by_the_config_keep_their_defaults(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    args = _load(monkeypatch, "--config", _config(tmp_path, lr=5e-5))
+    assert args.weight_decay == FSDPArgs.weight_decay
+    assert args.keep_fp32_master == FSDPArgs.keep_fp32_master
+
+
+def test_no_config_still_lands_on_the_dataclass_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    args = _load(monkeypatch)
+    assert args.lr == FSDPArgs.lr
+    assert args.weight_decay == FSDPArgs.weight_decay


### PR DESCRIPTION
## The problem

`--config <yaml>` is documented as the FSDP backend's config mechanism (`docs/developer/experimental-features.md:59`). It did not work, in both directions at once.

`load_fsdp_args` applied a config entry only `if not hasattr(args, k)`. Since the parser registers **every** `FSDPArgs` field with argparse, that condition is never true for a declared field. Measured on `main`:

```
yaml: lr: 5e-05                    ->  args.lr = 2e-05                     ignored
yaml: gradient_checkpointing: true ->  args.gradient_checkpointing = False ignored
yaml: brand_new_key: 42            ->  args.brand_new_key = 42             accepted
```

So the config file silently dropped every key it was supposed to honor, and silently absorbed every key it was supposed to reject. A misspelled `weigth_decay` became a new attribute nobody reads, and the run continued with the default.

## Why the one-character fix is wrong

Dropping the `not` inverts one failure into another. Argparse cannot distinguish "the user typed `--lr`" from "this is the default", so an unconditional `setattr` would let the config file override an explicit command-line flag.

## The change

Split parser construction out of `parse_fsdp_cli` into `build_fsdp_parser`, then feed the YAML entries back as defaults and reparse:

```python
parser = build_fsdp_parser(extra_args_provider)
args = parser.parse_args()
if args.config:
    reject_unknown_config_keys(data, set(vars(args)))
    parser.set_defaults(**data)
    args = parser.parse_args()
```

Precedence becomes **CLI > YAML > dataclass**. Explicit flags are still genuinely parsed on the second pass, so they win.

Unknown keys now raise, with a did-you-mean from `difflib`:

```
ValueError: unknown key(s) in the YAML config: 'weigth_decay' (did you mean 'weight_decay'?)
```

The known-key set is taken from `vars(args)` after the first parse, so it is exactly one entry per registered action. That covers whatever `extra_args_provider` contributed, not just `FSDPArgs`, which matters because the real RL entrypoint passes `add_miles_arguments`.

`parse_fsdp_cli` keeps its name, signature and behavior; its two test callers are untouched.

## Breaking change worth a second look

Unknown keys used to land on the namespace. Since overrides never worked for known keys, that passthrough was the **only** thing `--config` ever actually did — so anyone using `--config` today is using precisely the path this now rejects.

Nothing in the tree passes `--config`, and the docs describe it only as a table entry. But a config carried outside the repo will now fail loudly instead of being half-ignored. That is the intent: a key the program does not know is a typo, not a feature. A genuine plugin knob should be registered through `extra_args_provider`.

## Testing

`tests/fast/backends/test_fsdp_config_precedence.py` (new) pins every tier and the rejection:

- config beats the dataclass default, for a scalar and for bools in both directions
- an explicit CLI flag beats the config
- an unknown key raises; a misspelled key names the field it almost matched
- a valid config is not tripped by the check, fields the config omits keep their defaults, and a run with no `--config` is unaffected

Two of these fail against the old logic, so they are load-bearing rather than decorative.

Verified on an H200 box against three trees, since this touches the same function as #2384: today's `main` (467 passed for all of `tests/fast/backends/`), `main` with the old YAML logic restored (the two precedence tests go red as expected), and rebased on top of #2384. The two PRs touch different parts of `build_fsdp_parser` and merge cleanly in either order.
