### PR TITLE
docs(args): correct the offload flags' help text

### DIFF
--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -155,8 +155,8 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 "--offload-train",
                 action=argparse.BooleanOptionalAction,
                 help=(
-                    "Whether to offload the training actor to CPU during training. "
-                    "This will always be true when --colocate is set."
+                    "Whether to offload the training actor to CPU while the rollout engines generate. "
+                    "Defaults to true when --colocate is set; an explicit --no-offload-train is respected."
                 ),
             )
             parser.add_argument(
@@ -164,7 +164,7 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 action=argparse.BooleanOptionalAction,
                 help=(
                     "Whether to offload the rollout generator to CPU during training. "
-                    "This will always be true when --colocate is set."
+                    "Defaults to true when --colocate is set; an explicit --no-offload-rollout is respected."
                 ),
             )
 


### PR DESCRIPTION
## What

Corrects the `--help` text of `--offload-train` and `--offload-rollout` on two points:

- `--offload-train` said the training actor is offloaded "during training". The trainer is offloaded during the *other* phase — while the rollout engines generate — which is the whole point of the flag (it gates `sleep` / `wake_up` around generation). `--offload-rollout`'s phase wording was already correct and is unchanged.
- Both help strings said "This will always be true when `--colocate` is set". That overstates what the code does: the colocate branch in `validate_args` only fills the flags in when they are unset (`if args.offload_train is None`), so an explicit `--no-offload-train` / `--no-offload-rollout` survives colocate. The help now says "Defaults to true when --colocate is set; an explicit --no-... is respected."

## Why

Help strings are the first documentation anyone reads, and both errors point users in the wrong direction: one describes the wrong phase, the other tells users an escape hatch does not exist when it does. Found while fact-checking the Training Backends docs rewrite (#2375), whose "both implied by --colocate" wording matches the actual defaulting behavior — the code's own help text was the outlier.

## Testing

Help-text-only change; no behavior is touched. `python3 -m py_compile` passes and the repo-pinned `black==24.3.0 --check --line-length 119` leaves the file unchanged.
