### PR TITLE
fix(rollout): clear OPD response state before retry

### DIFF
--- a/miles/utils/types.py
+++ b/miles/utils/types.py
@@ -258,8 +258,11 @@ class Sample:
         self.loss_mask = None
         self.weight_versions = []
         self.rollout_log_probs = None
+        self.teacher_log_probs = None
+        self.opd_reverse_kl = None
         self.rollout_routed_experts = None
         self.rollout_indexer_topk = None
+        self.metadata.pop("opd_student_top_logprobs", None)
         self.status = Sample.Status.ABORTED
         self.non_generation_time = 0.0
         self.spec_info = Sample.SpecInfo()

--- a/tests/fast/utils/test_types.py
+++ b/tests/fast/utils/test_types.py
@@ -1,4 +1,4 @@
-"""Unit tests for Sample.strip_last_output_tokens."""
+"""Unit tests for Sample mutation helpers."""
 
 from unittest.mock import MagicMock
 
@@ -105,3 +105,17 @@ class TestStripLastOutputTokens:
         original_tokens = list(s.tokens)
         s.strip_last_output_tokens(-1, tokenizer)
         assert s.tokens == original_tokens
+
+
+def test_reset_for_retry_clears_opd_response_state():
+    sample = _make_sample([1], [2, 3])
+    sample.teacher_log_probs = [-0.1, -0.2]
+    sample.opd_reverse_kl = [0.3, 0.4]
+    sample.metadata["opd_student_top_logprobs"] = [[[-0.1, 2]], [[-0.2, 3]]]
+
+    sample.reset_for_retry()
+
+    assert sample.teacher_log_probs is None
+    assert sample.opd_reverse_kl is None
+    assert "opd_student_top_logprobs" not in sample.metadata
+    sample.validate()


### PR DESCRIPTION
## Summary

- Clear sampled-token teacher log-probabilities and precomputed OPD reverse KL when a sample is reset for retry.
- Remove response-aligned student top-logprob metadata while preserving prompt metadata.
- Add a regression test that validates the reset sample before it is regenerated.

## Problem

`Sample.reset_for_retry()` resets `response_length` to zero but previously retained OPD fields aligned to the old response. The recycled sample was therefore structurally invalid until a successful teacher rescore overwrote those fields; `Sample.validate()` failed with a teacher-logprob length mismatch.

## Test plan

- [x] `pytest --confcutdir=tests/fast/utils tests/fast/utils/test_types.py -q` (11 passed)
- [x] `ruff check miles/utils/types.py tests/fast/utils/test_types.py`
- [x] `python -m py_compile miles/utils/types.py tests/fast/utils/test_types.py`
- [x] `git diff origin/main...HEAD --check`