### PR TITLE
docs: let tables wrap instead of silently clipping at max-content

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -69,14 +69,17 @@ pre code {
 
 /* =============================================
    Tables — readable + mobile-safe
+
+   Mintlify already wraps every table in a horizontal scroll area, so this
+   file must not size tables to `max-content`: that opts every table out of
+   wrapping and pushes the excess into a scroller whose scrollbar is hidden
+   (`scrollbar-width: none`), so the overflow reads as content silently cut
+   off rather than something you can scroll to. Let tables fill the column
+   and wrap instead; the wrapper still scrolls the rare table that genuinely
+   cannot fit.
    ============================================= */
 table {
-  display: block;
-  overflow-x: auto;
-  -webkit-overflow-scrolling: touch;
   border-collapse: collapse;
-  width: max-content;
-  max-width: 100%;
   font-size: 0.9375rem;
 }
 
@@ -84,13 +87,22 @@ th {
   background: var(--rx-table-bg);
   font-weight: 600;
   letter-spacing: 0.01em;
-  white-space: nowrap;
 }
 
 td {
   border-color: var(--rx-divider);
   vertical-align: top;
   line-height: 1.5;
+}
+
+/* Mintlify floors every cell at 150px (`[&_td]:min-w-[150px]`), which on its
+   own makes a 9-column table 1350px wide against a ~719px content column.
+   Let the content decide the column widths. This selector is unlayered, so it
+   wins over Mintlify's layered Tailwind utility despite equal specificity —
+   the same mechanism the `img` rule below relies on. */
+th,
+td {
+  min-width: 0;
 }
 
 /* =============================================


### PR DESCRIPTION
## Problem

`docs/style.css` forced every table to `width: max-content` with `white-space: nowrap` headers. This disables the browser's normal table shrink-to-fit, and the overflow spills into Mintlify's scroll wrapper — which hides its scrollbar (`scrollbar-width: none`) and paints no edge fade. Net effect: **wide tables render as content silently cut off at the right edge**, with no cue that more columns exist. The rule was presumably meant to make wide tables scrollable, but Mintlify already wraps every table in its own scroll area, so the table's own `overflow-x: auto` never triggers — the rule only delivered the harmful side effect (no wrapping), not the intended one.

Audited all **178 tables across the 70 nav pages** with headless Chrome at 1280/1440 viewports: **34 tables were clipping**, some hiding entire columns or 2000+px of prose. After this change every table wraps to fit; the one table whose min-content genuinely exceeds the content column degrades to the built-in horizontal scroll automatically.

## Fix

- Drop `display: block / overflow-x / width: max-content` from `table` and `white-space: nowrap` from `th` — restore normal table layout so columns wrap to the available width.
- Zero out Mintlify's `[&_td]:min-w-[150px]` floor (`th, td { min-width: 0 }`), which alone forces a 9-column table to ≥1350px against a ~719px content column.

No per-table markup or opt-outs needed: whether a table wraps or scrolls is decided by the browser per table (wraps when it can, scrolls only when its minimum width physically exceeds the column).

## Examples (1440px viewport; before = live site, after = this PR)

### 1. `user-guide/environments` — Integration shapes (the original report)

The 8-column comparison table showed only its first column-and-a-half; 452px hidden.

| Before | After |
|---|---|
| ![before](https://gist.githubusercontent.com/nblintao/9f467d671d70abf5805fa967ae6274df/raw/31b806334d3240e62fb4994b2d5a9eb787c66945/environments-integration-shapes--before.png) | ![after](https://gist.githubusercontent.com/nblintao/9f467d671d70abf5805fa967ae6274df/raw/31b806334d3240e62fb4994b2d5a9eb787c66945/environments-integration-shapes--after.png) |

### 2. `models/kimi/kimi-k2.5` — parallelism recipe (the deceptive case)

Before looks *complete* — 5 tidy columns, nothing suggests EP, expert-TP, `--decoder-last-pipeline-num-layers` and `--max-tokens-per-gpu` are amputated. All 8–9-column model recipe tables (Qwen3, GLM, DeepSeek, Kimi, …) had this failure mode.

| Before | After |
|---|---|
| ![before](https://gist.githubusercontent.com/nblintao/9f467d671d70abf5805fa967ae6274df/raw/31b806334d3240e62fb4994b2d5a9eb787c66945/kimi-k25-parallelism--before.png) | ![after](https://gist.githubusercontent.com/nblintao/9f467d671d70abf5805fa967ae6274df/raw/31b806334d3240e62fb4994b2d5a9eb787c66945/kimi-k25-parallelism--after.png) |

### 3. `advanced/p2p-weight-transfer` — component tables (worst offender: 2105px hidden)

Every description sentence was cut mid-word.

| Before | After |
|---|---|
| ![before](https://gist.githubusercontent.com/nblintao/9f467d671d70abf5805fa967ae6274df/raw/31b806334d3240e62fb4994b2d5a9eb787c66945/p2p-architecture-components--before.png) | ![after](https://gist.githubusercontent.com/nblintao/9f467d671d70abf5805fa967ae6274df/raw/31b806334d3240e62fb4994b2d5a9eb787c66945/p2p-architecture-components--after.png) |

### 4. `advanced/p2p-weight-transfer` — 9-column benchmark table (the remaining rough case)

The one table site-wide whose minimum width (~732px) exceeds the content column (~719px). Before, the NCCL/RDMA/Delta **result columns were entirely invisible**. After, all columns are reachable, but the trade-off is honest to show: the table gets tall (~1560px) and the class-name code chips wrap awkwardly, and the residual 13px still relies on the (cue-less) horizontal scroll. A follow-up could slim this table's columns (the `sglang Model Class` column duplicates the Supported Model Architectures table above it) — kept out of scope here since it edits page content.

| Before | After |
|---|---|
| ![before](https://gist.githubusercontent.com/nblintao/9f467d671d70abf5805fa967ae6274df/raw/31b806334d3240e62fb4994b2d5a9eb787c66945/p2p-profiling-benchmark--before.png) | ![after](https://gist.githubusercontent.com/nblintao/9f467d671d70abf5805fa967ae6274df/raw/31b806334d3240e62fb4994b2d5a9eb787c66945/p2p-profiling-benchmark--after.png) |

## Verification

- Full sweep of all 70 nav pages (178 tables) on the patched build at 1280/1440: **0 tables clipped** except the p2p benchmark above (13px at 1440 / 173px at 1280, scrollable).
- Cross-checked live-site simulation (disable old stylesheet via CSSOM + inject patched file) against `mint dev` rendering of this branch — identical numbers.
- Mobile (390px): tables that fit before still fit; previously-clipped ones now wrap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
