### PR TITLE
docs: download the DAPO jsonl mirror the launcher expects

### DIFF
--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -49,7 +49,7 @@ Three downloads:
 # The model you will train
 hf download Qwen/Qwen3-4B --local-dir /root/Qwen3-4B
 # Training prompts: 17k math problems with checkable answers
-hf download --repo-type dataset BytedTsinghua-SIA/DAPO-Math-17K --local-dir /root/dapo-math-17k
+hf download --repo-type dataset zhuzilin/dapo-math-17k --local-dir /root/dapo-math-17k
 # Eval benchmark: harder problems, evaluated on but never trained on
 hf download --repo-type dataset zhuzilin/aime-2024 --local-dir /root/aime-2024
 ```

--- a/docs/models/qwen/index.md
+++ b/docs/models/qwen/index.md
@@ -24,7 +24,7 @@ hf download Qwen/Qwen3-4B --local-dir /root/Qwen3-4B
 bash scripts/run-qwen3-4B.sh
 ```
 
-Dataset is [DAPO-Math-17k](https://huggingface.co/datasets/BytedTsinghua-SIA/DAPO-Math-17K) at `/root/dapo-math-17k/dapo-math-17k.jsonl`. See the [Qwen3 Dense](/models/qwen/qwen3) page for the full walkthrough, weight conversion, and variants.
+Dataset is [DAPO-Math-17k](https://huggingface.co/datasets/zhuzilin/dapo-math-17k) at `/root/dapo-math-17k/dapo-math-17k.jsonl`. See the [Qwen3 Dense](/models/qwen/qwen3) page for the full walkthrough, weight conversion, and variants.
 
 ## Which variant do I pick?
 


### PR DESCRIPTION
## Summary

Fixes the Quick Start dataset download so the recipe actually runs end to end. A user following the page hit this: the DAPO download command fetched a repo whose contents don't match what `scripts/run-qwen3-4B.sh` consumes.

- The page told users to download `BytedTsinghua-SIA/DAPO-Math-17K`, which today contains only `data/dapo-math-17k.parquet`, with the label nested at `reward_model.ground_truth`.
- The launcher expects `--prompt-data /root/dapo-math-17k/dapo-math-17k.jsonl` with `--input-key prompt` and a flat `--label-key label`, so the downloaded repo satisfied neither the path, the format, nor the key layout.
- `zhuzilin/dapo-math-17k` ships exactly that file: `dapo-math-17k.jsonl` whose rows are `{"prompt": [chat messages], "label": "..."}` (verified by fetching the repo tree and the first rows from the Hub). It is also the mirror every other recipe page already uses — including the AIME-2024 eval set on the same Quick Start page (`zhuzilin/aime-2024`), which is why AIME worked while DAPO didn't.

Changes:

- `docs/getting-started/quick-start.md`: download `zhuzilin/dapo-math-17k` instead of `BytedTsinghua-SIA/DAPO-Math-17K`.
- `docs/models/qwen/index.md`: point the DAPO-Math-17k link at the same mirror it names the file path of (link-only change).

No launcher changes needed — with the right repo, the existing `--prompt-data` path and keys line up.

The same audit found one more page with this class of bug (`docs/examples/reproducibility.md` downloading `openai/gsm8k`); that fix is in a follow-up PR.

## Test plan

- [x] `hf download --repo-type dataset zhuzilin/dapo-math-17k --local-dir /root/dapo-math-17k` produces `/root/dapo-math-17k/dapo-math-17k.jsonl`
- [x] Verified the jsonl rows carry `prompt` + flat `label`, matching the launcher's keys
