### PR TITLE
docs: fix the gsm8k download on the reproducibility page

### DIFF
--- a/docs/examples/reproducibility.md
+++ b/docs/examples/reproducibility.md
@@ -66,7 +66,7 @@ PERF_ARGS+=(
 ### 4. Download + convert + run
 
 ```bash
-hf download --repo-type dataset openai/gsm8k         --local-dir /root/gsm8k
+hf download --repo-type dataset zhuzilin/gsm8k       --local-dir /root/gsm8k
 hf download Qwen/Qwen2.5-0.5B-Instruct               --local-dir /root/Qwen2.5-0.5B-Instruct
 
 cd /root/miles


### PR DESCRIPTION
## Summary

Follow-up to #2398, from the same audit of dataset download commands: the reproducibility page has the identical class of bug the Quick Start page had.

- `docs/examples/reproducibility.md` downloads `openai/gsm8k`, whose files live at `main/train-00000-of-00001.parquet` (and `socratic/…`), with only `question`/`answer` columns.
- The launcher the page then runs, `examples/experimental/reproducibility/run-qwen2.5-0.5B-gsm8k.sh`, expects `/root/gsm8k/train.parquet` and `/root/gsm8k/test.parquet` with `--input-key messages --label-key label` — so the download satisfies neither the paths nor the columns.
- `zhuzilin/gsm8k` serves exactly that contract: root-level `train.parquet`/`test.parquet` whose columns include `messages` and `label` (verified via the Hub tree and the datasets server). It is also the repo the example's own README (`examples/experimental/reproducibility/README.md`) already tells users to download — the docs page was the odd one out.

One-line change: the download command now fetches `zhuzilin/gsm8k`.

## Test plan

- [ ] `hf download --repo-type dataset zhuzilin/gsm8k --local-dir /root/gsm8k` produces `/root/gsm8k/train.parquet` and `test.parquet`
- [ ] `bash examples/experimental/reproducibility/run-qwen2.5-0.5B-gsm8k.sh` reads prompt data without path or key errors
