### PR TITLE
docs: fix SEO gaps across the docs site

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -9,7 +9,7 @@ docs/
 ├── docs.json        # Mintlify config: navigation, theme, redirects
 ├── index.md         # Homepage
 ├── getting-started/ models/ user-guide/ advanced/
-├── examples/ developer/ platforms/ blog/
+├── examples/ developer/ ci/ blog/
 └── assets/          # Images and stylesheets
 ```
 
@@ -25,9 +25,14 @@ Then open http://localhost:3000.
 
 ## Adding or editing a page
 
-1. Add or edit a `.md` file (e.g. `models/qwen/qwen4.md`).
+1. Add or edit a `.md` file (e.g. `models/qwen/qwen4.md`). Every page needs frontmatter
+   with a `title` and a `description` — the description becomes the meta description and
+   the social preview text, so write one sentence that reads well on its own and stays
+   under 160 characters. Mintlify renders `title` as the page's `h1`, so do not repeat it
+   as a `#` heading in the body.
 2. New pages need an entry in the `navigation` tree in `docs.json`, otherwise they won't
-   show up in the sidebar.
+   show up in the sidebar — and, because indexing follows the navigation, they stay out of
+   the sitemap and out of search results entirely.
 3. When linking between pages, use absolute paths: `[Quick Start](/getting-started/quick-start)`.
    Drop the `.md` extension.
 4. Images and other assets go in `assets/` and are referenced the same way:

--- a/docs/advanced/on-policy-distillation.md
+++ b/docs/advanced/on-policy-distillation.md
@@ -1,5 +1,7 @@
-# On-Policy Distillation
-
+---
+title: On-Policy Distillation
+description: Train a student on its own rollouts with a teacher's token-level probabilities as a reverse-KL signal, composable with GRPO, PPO, and other estimators.
+---
 On-policy distillation (OPD) trains a student model on its own rollouts while using a teacher model's token-level probabilities as the distillation signal. In Miles, the teacher signal is converted into a per-token reverse-KL penalty and applied after the selected RL advantage estimator has produced token advantages. This lets the same OPD recipe compose with GRPO, PPO, REINFORCE++, GSPO, and other estimators.
 
 ## Key Arguments

--- a/docs/blog/index.md
+++ b/docs/blog/index.md
@@ -1,4 +1,5 @@
 ---
 title: Blog
+description: Miles engineering write-ups on RL systems, post-training recipes, and performance results, published on the LMSYS blog.
 ---
 Check out Miles blog posts on the [LMSYS blog](https://www.lmsys.org/blog).

--- a/docs/ci/00-stage.md
+++ b/docs/ci/00-stage.md
@@ -2,9 +2,6 @@
 title: Stage
 description: How CI stages are defined, how a test's suite maps to a stage, and what each stage does.
 ---
-
-# Stage
-
 A *stage* is one CI job in a Miles CI workflow. A *suite* is the `suite=` value a test declares in `register_*_ci(...)`. Stage names and suite names are the same set, mapped **1:1**: a test runs in exactly the stage whose name equals its `suite`.
 
 ## Suite → stage mapping
@@ -48,7 +45,7 @@ In `pr-test.yml`, `tier a` (CPU fast) gates the NVIDIA GPU fleet after both reso
 
 A **nightly** policy selects every enabled tag except `long` and `ft-long`, admits both regular and `nightly=True` registrations, and disables fast-fail. Regular cadence admits only regular registrations. Both cadences use the same stage inventory.
 
-`run-ci-all` selects the full domain-tag set without changing cadence. `run-ci-image` selects every enabled tag except `long`, `ft-short`, and `ft-long`. If scope signals overlap, the precedence is `run-ci-all` > nightly > `run-ci-image`. The resolved cadence and raw/synthetic labels are passed to `run_suite.py`, which computes one run policy (see docs/ci/01-label.md for the subtraction semantics).
+`run-ci-all` selects the full domain-tag set without changing cadence. `run-ci-image` selects every enabled tag except `long`, `ft-short`, and `ft-long`. If scope signals overlap, the precedence is `run-ci-all` > nightly > `run-ci-image`. The resolved cadence and raw/synthetic labels are passed to `run_suite.py`, which computes one run policy (see [Labels](/ci/01-label) for the subtraction semantics).
 
 **Dependencies / gating.** In `pr-test.yml`, both CPU stages require both resolvers. Its GPU stages also require both resolvers and, by default, a successful `stage-a-cpu`, so a CPU-test failure short-circuits the expensive NVIDIA fleet. Resolved nightly cadence and the `bypass-fastfail` PR label relax only the `stage-a-cpu` failure gate and make each suite continue after a test failure; neither bypasses resolver failure.
 

--- a/docs/ci/01-label.md
+++ b/docs/ci/01-label.md
@@ -2,9 +2,6 @@
 title: Labels
 description: The three kinds of CI label — domain labels that gate tests, scope labels that broaden selection, and bypass-fastfail.
 ---
-
-# Labels
-
 A label is a GitHub PR label that changes what CI runs or how it fails. Three kinds:
 
 | Kind | Example | Effect |

--- a/docs/ci/02-docker-build.md
+++ b/docs/ci/02-docker-build.md
@@ -2,9 +2,6 @@
 title: Docker build
 description: The Dockerfiles, the build script, the remote build workflow, and how to build & push manually.
 ---
-
-# Docker build
-
 GPU CI runs inside `radixark/miles`. This doc maps which Dockerfiles exist, the script that builds them, the PR-side build check, how the remote build is triggered, and how to build & push manually.
 
 ## Dockerfiles

--- a/docs/ci/03-metric-history-gate.md
+++ b/docs/ci/03-metric-history-gate.md
@@ -1,10 +1,7 @@
 ---
 title: Metric history & regression gate
-description: How CI keeps per-test training metrics across runs and runs a historical gate against that history, plus how to add gate specs and inspect or repair hosted history through the authorized Neon workflow.
+description: How CI keeps per-test training metrics across runs, gates new numbers against that history, and how to add gate specs or repair hosted history.
 ---
-
-# Metric history & regression gate
-
 CI keeps each test's per-metric numbers from every run in our own store and runs a historical gate against that history — catching the slow drift a single run cannot see. wandb stays a write-only sink; the gate never reads from it. The baseline lives in our DB.
 
 ## Identity: what shares a baseline

--- a/docs/ci/contributor-guide.md
+++ b/docs/ci/contributor-guide.md
@@ -1,10 +1,7 @@
 ---
 title: CI Contributor Guide
-description: For community contributors — how to add a CI test and confirm it runs, how to tell an infra failure from your own, and how to report a machine issue or a flaky test.
+description: For community contributors — add a CI test and confirm it runs, tell an infra failure from your own, and report a machine issue or a flaky test.
 ---
-
-# CI Contributor Guide
-
 This guide is for contributors landing small features and fixes. It answers three things: how to add a test to CI and be sure it actually runs, how to read a red check and decide whether it's your change or the infrastructure, and how to report a machine issue or a flaky test. You never edit the CI workflow YAML to add a test — read on.
 
 ## Add a test to CI

--- a/docs/developer/contributor-guide.md
+++ b/docs/developer/contributor-guide.md
@@ -274,6 +274,7 @@ map it to a host.
 
 * **Quick questions:** the Miles channel of the [SGLang Slack](https://slack.sglang.ai).
 * **Design discussions:** a GitHub Discussion, or an Issue labeled `discussion`.
-* **CI internals:** `docs/ci/00-stage.md` (stages), `01-label.md` (label semantics),
-  `02-docker-build.md` (images), `03-metric-history-gate.md` (metric gate), and
-  `docs/ci/contributor-guide.md` for the long-form version of this section.
+* **CI internals:** [Stage](/ci/00-stage) (stages), [Labels](/ci/01-label) (label
+  semantics), [Docker build](/ci/02-docker-build) (images),
+  [Metric history & regression gate](/ci/03-metric-history-gate) (metric gate), and the
+  [CI Contributor Guide](/ci/contributor-guide) for the long-form version of this section.

--- a/docs/developer/debug.md
+++ b/docs/developer/debug.md
@@ -1,6 +1,6 @@
 ---
 title: Debugging
-description: Useful tips for debugging.
+description: Split a misbehaving run into rollout and training halves, then debug the side that is actually wrong.
 ---
 When a Miles run misbehaves, the first question is always: **rollout or training?** The
 flags on this page exist to answer it by cutting the loop into pieces you can run one at a

--- a/docs/developer/versions.md
+++ b/docs/developer/versions.md
@@ -92,8 +92,8 @@ Build one yourself with `docker/build.py`:
 python docker/build.py --variant cu13-x86 --image-tag custom --custom-tag my-experiment --push
 ```
 
-`docs/ci/02-docker-build.md` is the full reference for the build script, the workflow and
-the tag rules.
+[Docker build](/ci/02-docker-build) is the full reference for the build script, the
+workflow and the tag rules.
 
 ## What CI moves, and what it does not
 
@@ -176,4 +176,5 @@ that to stop moving underneath you, pin `ci-image-tag:` to a timestamped tag.
 - [Installation](/getting-started/installation) for pulling and running the image.
 - [Contributing](/developer/contributor-guide) for the CI labels and PR-description
   directives.
-- `docs/ci/02-docker-build.md` for the build script, workflow triggers and tag mechanics.
+- [Docker build](/ci/02-docker-build) for the build script, workflow triggers and tag
+  mechanics.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1,6 +1,7 @@
 {
- "$schema": "https://mintlify.com/schema.json",
+ "$schema": "https://mintlify.com/docs.json",
  "name": "Miles",
+ "description": "Miles is an open-source reinforcement learning framework for large-scale LLM post-training, pairing SGLang rollout with Megatron-LM training at trillion-parameter scale.",
  "theme": "mint",
  "logo": {
   "light": "/assets/images/brand/miles_logo_light.png",
@@ -11,8 +12,14 @@
  "favicon": "/assets/images/brand/miles_square.png",
  "seo": {
   "metatags": {
-   "canonical": "https://miles.radixark.com/docs",
    "og:site_name": "Miles Documentation"
+  },
+  "organization": {
+   "name": "RadixArk",
+   "url": "https://www.radixark.com",
+   "sameAs": [
+    "https://github.com/radixark"
+   ]
   }
  },
  "colors": {
@@ -212,7 +219,8 @@
          "advanced/fp8-low-precision",
          "advanced/int4-qat",
          "advanced/speculative-decoding",
-         "advanced/lora"
+         "advanced/lora",
+         "advanced/on-policy-distillation"
         ],
         "expanded": false
        },
@@ -271,7 +279,18 @@
        "developer/architecture",
        "developer/versions",
        "developer/debug",
-       "developer/experimental-features"
+       "developer/experimental-features",
+       {
+        "group": "CI",
+        "pages": [
+         "ci/contributor-guide",
+         "ci/00-stage",
+         "ci/01-label",
+         "ci/02-docker-build",
+         "ci/03-metric-history-gate"
+        ],
+        "expanded": false
+       }
       ]
      }
     ]
@@ -327,7 +346,6 @@
   "dark": "#0c0b0a",
   "light": "#faf7f4"
  },
- "url": "https://www.radixark.com",
  "contextual": {
   "options": [
    {

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,6 @@
 ---
 title: Miles Documentation
+description: Miles is an open-source RL framework for large-scale LLM post-training, pairing SGLang rollout with Megatron-LM training at trillion-parameter scale.
 ---
 Miles is a high-performance, enterprise-ready reinforcement learning (RL) framework specifically optimized for **Large-Scale model Post-Training**. It
 couples [SGLang](https://github.com/sgl-project/sglang) for high-throughput rollout with

--- a/docs/models/gpt-oss/gpt-oss.md
+++ b/docs/models/gpt-oss/gpt-oss.md
@@ -1,7 +1,7 @@
 ---
 title: GPT-OSS 20B
 sidebarTitle: GPT-OSS
-description: Megatron BF16 launcher (8 GPU, mbridge).
+description: Launch recipe for OpenAI's GPT-OSS 20B — Megatron BF16 on a single 8-GPU node, loading the MXFP4 HF checkpoint through mbridge.
 ---
 ## 1. Model Introduction
 

--- a/docs/user-guide/agentic-chat-template.md
+++ b/docs/user-guide/agentic-chat-template.md
@@ -2,9 +2,6 @@
 title: Agentic Rollout (TITO)
 description: How to turn on and verify Token-In-Token-Out (TITO) for multi-turn agentic rollout.
 ---
-
-# Agentic Rollout (TITO)
-
 Multi-turn agentic rollout in Miles runs on **TITO** (Token-In-Token-Out): each turn's token sequence is a bit-perfect prefix of the next, so the trainer sees exactly the tokens the engine produced — no re-tokenization, no drift. The *why* is in the blog ([No Token Left Behind](https://lmsys.org/blog/2026-05-13-no-token-left-behind/)); this page is *how*.
 
 Your harness only ever sends and receives **OpenAI chat messages**, never tokens. Miles keeps the per-trajectory append-only token buffer (ids + logprobs + routed experts) internally and ships it straight to training.


### PR DESCRIPTION
## Six pages were never indexed

Mintlify's `seo.indexing` defaults to `navigable`: a page missing from the `docs.json` navigation tree stays out of the sitemap and out of search results, even when the file exists and other pages link to it.

The five `docs/ci/` pages and `advanced/on-policy-distillation` were all in that state. The live sitemap carries 83 URLs and none of the six are among them — `advanced/on-policy-distillation` is even linked from a Card on `advanced/index`, so it was reachable by humans but invisible to crawlers.

All six are now in the navigation (CI as a group under Developer Guide), which takes the site from 83 to 89 indexable pages. The prose references that pointed at them by file path (`docs/ci/02-docker-build.md`) are now in-site links. The `doc-dev:` sentinel and the source-to-doc binding table keep their path form.

## Missing descriptions

The homepage shipped with **no meta description at all**, so it had none in search results and no subtitle on its social card. `blog/index` was the same. Both now have one.

## docs.json

- **Drop the site-wide `canonical`.** It pointed every page at `/docs`. I checked three live pages first: Mintlify emits a correct per-page canonical that overrides it, so this was inert today — but it is a landmine if that precedence ever changes.
- **Move `url` into a new `seo.organization` block**, which emits JSON-LD Organization data on every page. `url` is not a valid top-level key in the v2 schema, and this gives the same URL a documented purpose.
- **Add the top-level `description`**, which Mintlify uses for SEO and AEO.
- **Point `$schema` at the v2 `docs.json` schema.** The file has been in v2 format for a while but still declared the v1 `schema.json` — which is how the invalid `url` key went unnoticed.

## Page-level cleanups

Six body `h1`s that duplicated the frontmatter title are gone (Mintlify already renders `title` as the `h1`, so those pages had two). Two descriptions over the ~160-character SERP limit are tightened, and two that were too thin to describe the page are rewritten — `developer/debug` previously read only "Useful tips for debugging."

`docs/README.md` now states that `description` is required and that a missing navigation entry means the page is not indexed at all, so this does not silently regress.

## What I deliberately did not change

I started to add a site-wide `og:image` and Twitter card, and built a 1200×630 card for it. Fetching the live `<head>` showed Mintlify already generates a per-page OG card carrying each page's title and description — a static logo would have replaced something better. Dropped it.

`robots.txt`, `sitemap.xml`, and `llms.txt` / `llms-full.txt` are already served correctly and are crawler-open. Every image already has descriptive alt text. No duplicate titles or descriptions anywhere.

Out of scope, but worth a separate look: `font`, `background.light|dark`, and `logo.width` are all outside the v2 schema, and the live site loads Bricolage Grotesque + Geist from `style.css` rather than the Hanken Grotesk / Inter declared in `docs.json` — that block is dead config. Separately, `mint a11y` reports the primary `#d55816` at 4.01:1 against the light background, below WCAG AA's 4.5:1. Both change how the site looks, so I left them alone.

## Verification

`mint validate` (strict) and `mint broken-links` are both clean, run from `docs/`, after rebasing onto current main. Navigation coverage is exactly 89 files to 89 entries with no orphans in either direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)