### PR TITLE
docs: register the pages that never made it into the nav

### DIFF
--- a/docs/advanced/on-policy-distillation.md
+++ b/docs/advanced/on-policy-distillation.md
@@ -1,5 +1,7 @@
-# On-Policy Distillation
-
+---
+title: On-Policy Distillation
+description: Train a student on its own rollouts using a teacher's token-level probabilities as a per-token reverse-KL penalty, composable with any advantage estimator.
+---
 On-policy distillation (OPD) trains a student model on its own rollouts while using a teacher model's token-level probabilities as the distillation signal. In Miles, the teacher signal is converted into a per-token reverse-KL penalty and applied after the selected RL advantage estimator has produced token advantages. This lets the same OPD recipe compose with GRPO, PPO, REINFORCE++, GSPO, and other estimators.
 
 ## Key Arguments

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -212,6 +212,7 @@
          "advanced/fp8-low-precision",
          "advanced/int4-qat",
          "advanced/speculative-decoding",
+         "advanced/on-policy-distillation",
          "advanced/lora"
         ],
         "expanded": false
@@ -272,6 +273,16 @@
        "developer/versions",
        "developer/debug",
        "developer/experimental-features"
+      ]
+     },
+     {
+      "group": "CI",
+      "pages": [
+       "ci/contributor-guide",
+       "ci/00-stage",
+       "ci/01-label",
+       "ci/02-docker-build",
+       "ci/03-metric-history-gate"
       ]
      }
     ]


### PR DESCRIPTION
## What

Six pages live under `docs/` with no entry in `docs.json`. Mintlify builds the sidebar from that file, so none of them appear in one. Each arrived in a PR that wrote the markdown and left the nav alone, which is exactly what `docs/README.md` warns about:

> New pages need an entry in the `navigation` tree in `docs.json`, otherwise they won't show up in the sidebar.

| Page | Added by | Symptom |
|---|---|---|
| `advanced/on-policy-distillation` | #994 | Reachable through a card on `advanced/index.md`, but once you land there the sidebar has no entry for it |
| `ci/contributor-guide`, `ci/00-stage`, `ci/01-label`, `ci/02-docker-build`, `ci/03-metric-history-gate` | #1312 | Nothing links to them and they are not in the nav, so they are unreachable on the site |

## Where they go

- **On-policy distillation** joins the Performance group, in the slot its card already occupies on `advanced/index.md`: after speculative decoding, before LoRA. Performance is already the loose bucket that holds LoRA, which is likewise a training-side feature rather than a throughput one.
- **The CI pages** become a `CI` group under the Developer Guide tab, mirroring how the User Guide tab carries Environments as a second group. Their own frontmatter descriptions address community contributors ("For community contributors — how to add a CI test and confirm it runs"), so they are written to be published, not internal. `ci/contributor-guide` leads because it is the entry point; the rest follow their `00`–`03` numbering.

## Also

`advanced/on-policy-distillation.md` opened with a bare `# On-Policy Distillation` rather than frontmatter, the only page in the tree that did. Mintlify reads the title and description from frontmatter, so the page had neither its own title nor a description for search and social cards. Converted to frontmatter and dropped the now-duplicate H1, matching every other page.

## Checks

Audited the whole tree against `docs.json` before and after:

| | before | after |
|---|---|---|
| markdown files with no nav entry | 7 | 1 |
| nav entries with no file | 0 | 0 |
| duplicated nav entries | 0 | 0 |
| pages with no frontmatter | 1 | 0 |
| dead internal links | 0 | 0 |
| dead image references | 0 | 0 |
| redirects with a missing destination | 0 | 0 |

The one page still outside the nav is `docs/README.md`, which documents the docs directory for contributors and should stay out.

Not touched: `advanced/index.md` shows 6 cards for 11 pages in that tab. That is deliberate, not a gap — the page says up front that it covers "the Miles features that the Core-features section of the homepage points at".

## Note for sequencing

#2396 renames `advanced/fp8-low-precision` to `advanced/low-precision`, one line above the insert this PR makes in the same Performance group. Whichever merges second will want a one-line conflict resolution.
