### PR TITLE
scripts: download the DAPO dataset the NPU recipe trains on

### DIFF
--- a/scripts/run_qwen3_4b_npu.py
+++ b/scripts/run_qwen3_4b_npu.py
@@ -10,9 +10,9 @@ EXTERNAL_RAY = int(os.environ.get("MILES_SCRIPT_EXTERNAL_RAY", "0"))
 TRAIN_BACKEND = os.environ.get("MILES_SCRIPT_TRAIN_BACKEND", "fsdp").lower()
 assert TRAIN_BACKEND in {"fsdp", "megatron"}
 
-DATASET_NAME = "VeraIsHere/geo3k_imgurl_processed"
-DATA_ROOT = "/root/dataset/geo3k_imgurl_processed"
-TRAIN_DATA_PATH = os.path.join(DATA_ROOT, "train.parquet")
+DATASET_NAME = "zhuzilin/dapo-math-17k"
+DATA_ROOT = "/root/datasets/dapo-math-17k"
+TRAIN_DATA_PATH = os.path.join(DATA_ROOT, "dapo-math-17k.jsonl")
 
 
 def get_megatron_model_type(model_name: str) -> str:
@@ -35,21 +35,16 @@ def prepare():
 
 
 def execute():
-    ckpt_args = "--hf-checkpoint /root/model/Qwen3-4B-Instruct-2507/ "
+    ckpt_args = f"--hf-checkpoint /root/models/{MODEL_NAME}/ "
 
     wandb_args = (
-        (
-            "--use-wandb "
-            "--wandb-project miles-dev "
-            "--wandb-group geo3k_vlm_multi_turn "
-            f"--wandb-key '{wandb_api_key}' "
-        )
+        ("--use-wandb " "--wandb-project miles-dev " "--wandb-group qwen3-4b-npu " f"--wandb-key '{wandb_api_key}' ")
         if (wandb_api_key := os.environ.get("WANDB_API_KEY"))
         else ""
     )
 
     rollout_args = (
-        "--prompt-data /root/dataset/dapo-math-17k/dapo-math-17k.jsonl "
+        f"--prompt-data {TRAIN_DATA_PATH} "
         "--input-key prompt "
         "--label-key label "
         "--apply-chat-template "
@@ -68,7 +63,7 @@ def execute():
 
     # eval_args = (
     #     "--eval-interval 20 "
-    #     f"--eval-prompt-data geo3k_eval {TRAIN_DATA_PATH}@[0:64] "
+    #     f"--eval-prompt-data dapo_eval {TRAIN_DATA_PATH}@[0:64] "
     #     "--n-samples-per-eval-prompt 1 "
     #     "--eval-max-response-len 4096 "
     #     "--eval-top-k 1 "
@@ -107,7 +102,7 @@ def execute():
 
     megatron_args = (
         "--train-backend megatron "
-        "--load /root/model/Qwen3-4B-Instruct-2507/ "
+        f"--load /root/models/{MODEL_NAME}/ "
         "--tensor-model-parallel-size 4 "
         "--sequence-parallel "
         "--pipeline-model-parallel-size 1 "


### PR DESCRIPTION
## Summary

Follow-up from the dataset-download audit behind #2398/#2399: `scripts/run_qwen3_4b_npu.py`'s `prepare()` and `execute()` disagreed about what data and model paths the run uses, so the recipe could not run end to end as written. The script appears to have been copied from the geo3k VLM multi-turn example, and several of its constants were never updated.

- **Dataset**: `prepare()` downloaded `VeraIsHere/geo3k_imgurl_processed` (used only by a commented-out eval line), while training consumed `/root/dataset/dapo-math-17k/dapo-math-17k.jsonl`, which nothing downloaded. `DATASET_NAME` / `DATA_ROOT` / `TRAIN_DATA_PATH` now point at `zhuzilin/dapo-math-17k` (root-level `dapo-math-17k.jsonl` with `prompt` + flat `label`, matching `--input-key prompt --label-key label`), and `--prompt-data` references `TRAIN_DATA_PATH` instead of a hardcoded string, so `prepare()`'s existence check now guards the file training actually reads.
- **Model path**: `prepare()` downloads to `/root/models/{MODEL_NAME}`, but `--hf-checkpoint` and `--load` pointed at `/root/model/Qwen3-4B-Instruct-2507/` — a different directory, and hardcoded so the `MILES_SCRIPT_MODEL_NAME` override never reached the training args. Both now use `f"/root/models/{MODEL_NAME}/"`.
- Leftover geo3k naming updated: the wandb group is `qwen3-4b-npu` instead of `geo3k_vlm_multi_turn`, and the commented eval stub's dataset label follows suit.

## Test plan

- [ ] `python -m py_compile scripts/run_qwen3_4b_npu.py` (done) and black 24.3.0 clean (done)
- [ ] On an NPU node: `prepare()` then `execute()` runs with no missing-file errors, training on DAPO-Math-17k
