### PR TITLE
fix(ci): unblock ROCm fork PRs at checkout

### DIFF
--- a/.github/workflows/_run-ci-rocm.yml
+++ b/.github/workflows/_run-ci-rocm.yml
@@ -15,10 +15,6 @@ on:
         # source of the image name, so a dated tag can't rot here.
         type: string
         required: true
-      checkout_ref:
-        description: Git ref to test. PR callers pass the merge ref explicitly.
-        type: string
-        required: true
       skip_dependency_install:
         # Default true: the ROCm image ships SGLang / Megatron-LM baked in.
         # Pass false to fetch and install refs (PR body ci-megatron-pr: /
@@ -71,15 +67,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.checkout_ref }}
           persist-credentials: false
-          # Callers run on pull_request_target and pass refs/pull/<n>/merge, so
-          # checkout refuses fork code by default ("pwn request"). Running the
-          # PR's code on the MI300X host is this stage's purpose; the controls
-          # that guardrail asks for are already here -- pr-test-rocm.yml admits a
-          # fork only after a maintainer adds a run-ci-* label, and fork jobs get
-          # no secrets. Without this, every fork PR fails before any test runs.
-          allow-unsafe-pr-checkout: true
 
       - name: Cleanup Ray processes
         shell: bash

--- a/.github/workflows/_run-ci-rocm.yml
+++ b/.github/workflows/_run-ci-rocm.yml
@@ -73,6 +73,13 @@ jobs:
         with:
           ref: ${{ inputs.checkout_ref }}
           persist-credentials: false
+          # Callers run on pull_request_target and pass refs/pull/<n>/merge, so
+          # checkout refuses fork code by default ("pwn request"). Running the
+          # PR's code on the MI300X host is this stage's purpose; the controls
+          # that guardrail asks for are already here -- pr-test-rocm.yml admits a
+          # fork only after a maintainer adds a run-ci-* label, and fork jobs get
+          # no secrets. Without this, every fork PR fails before any test runs.
+          allow-unsafe-pr-checkout: true
 
       - name: Cleanup Ray processes
         shell: bash

--- a/.github/workflows/pr-test-rocm.yml
+++ b/.github/workflows/pr-test-rocm.yml
@@ -13,20 +13,15 @@ name: PR Test (ROCm)
 # CUDA tests that need 8 GPUs get a standalone test_amd_<name>.py with its
 # own 4-GPU CaseConfig rather than an IS_HIP branch in the original.
 #
-# pull_request_target keeps the workflow and fork authorization on the trusted
-# base branch. A fork reaches the privileged self-hosted stage only after a
-# maintainer adds a canonical `run-ci-*` label.
-#
-# The reusable job then checks out the PR merge ref explicitly. Fork PR jobs
-# receive no repository secrets; the accepted label still authorizes their
-# code to run against the MI300X host mounts.
+# PR jobs use the same low-trust `pull_request` model as pr-test.yml: checkout
+# tests the merge commit, and GitHub withholds repository secrets from forks.
 #
 # SGLang / Megatron-LM versions are baked into the ROCm image
 # (_run-ci-rocm.yml defaults skip_dependency_install to true), so unlike
 # pr-test.yml there are no ci_megatron_pr / ci_sglang_pr inputs here.
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened, ready_for_review, labeled]
   schedule:
     # Same nightly cadence as pr-test.yml; ci_policy.py maps this exact cron.
@@ -50,28 +45,10 @@ jobs:
   resolve-ci-policy:
     runs-on: ubuntu-latest
     outputs:
-      allow_self_hosted: ${{ steps.authorize.outputs.allow_self_hosted }}
       cadence: ${{ steps.resolve.outputs.cadence }}
       raw_labels: ${{ steps.resolve.outputs.raw_labels }}
       bypass_fastfail: ${{ steps.resolve.outputs.bypass_fastfail }}
     steps:
-      - name: Authorize self-hosted PR execution
-        id: authorize
-        shell: bash
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name || '' }}
-          BASE_REPOSITORY: ${{ github.repository }}
-          PR_LABELS_JSON: ${{ toJSON(github.event.pull_request.labels.*.name) }}
-        run: |
-          ALLOW_SELF_HOSTED=true
-          if [[ "$EVENT_NAME" == "pull_request_target" && "$HEAD_REPOSITORY" != "$BASE_REPOSITORY" ]]; then
-            ALLOW_SELF_HOSTED=false
-            if jq -e 'any(.[]; test("^run-ci-[A-Za-z0-9][A-Za-z0-9_.-]*$"))' <<<"$PR_LABELS_JSON" >/dev/null; then
-              ALLOW_SELF_HOSTED=true
-            fi
-          fi
-          echo "allow_self_hosted=${ALLOW_SELF_HOSTED}" >> "$GITHUB_OUTPUT"
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
@@ -79,7 +56,7 @@ jobs:
       - name: Resolve CI policy inputs
         id: resolve
         env:
-          EVENT_NAME: ${{ github.event_name == 'pull_request_target' && 'pull_request' || github.event_name }}
+          EVENT_NAME: ${{ github.event_name }}
           SCHEDULE: ${{ github.event.schedule || '' }}
           PR_LABELS_JSON: ${{ toJSON(github.event.pull_request.labels.*.name) }}
         run: python -m tests.ci.ci_policy
@@ -106,7 +83,6 @@ jobs:
 
   stage-c-4-gpu-mi300x:
     needs: [resolve-ci-policy, resolve-ci-image]
-    if: needs.resolve-ci-policy.outputs.allow_self_hosted == 'true'
     # One shard per 4-GPU runner, so the pair works the suite in parallel.
     # run_suite.py balances the shards by est_time. fail-fast: false so one
     # shard's failure does not cancel the other mid-run.
@@ -118,7 +94,6 @@ jobs:
     with:
       runs_on: '["self-hosted", "amd", "mi300x", "4gpu"]'
       container_image: ${{ needs.resolve-ci-image.outputs.container_image }}
-      checkout_ref: ${{ github.event_name == 'pull_request_target' && format('refs/pull/{0}/merge', github.event.pull_request.number) || github.sha }}
       execute_command: >-
         python tests/ci/run_suite.py --hw rocm --suite stage-c-4-gpu-mi300x
         --auto-partition-id ${{ matrix.partition_id }} --auto-partition-size 2
@@ -127,4 +102,4 @@ jobs:
         ${{ github.event_name == 'workflow_dispatch' && '--match-all-labels' || '' }}
         --enable-retry --max-attempts 2
     secrets:
-      WANDB_API_KEY: ${{ (github.event_name != 'pull_request_target' || github.event.pull_request.head.repo.full_name == github.repository) && secrets.WANDB_API_KEY || '' }}
+      WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}

--- a/docs/ci/00-stage.md
+++ b/docs/ci/00-stage.md
@@ -37,7 +37,7 @@ In `pr-test.yml`, `tier a` (CPU fast) gates the NVIDIA GPU fleet after both reso
 
 **Policy resolution (`resolve-ci-policy`).**
 
-- `pull_request` / `pull_request_target`, `schedule`, and `workflow_dispatch` only say how the workflow started; none itself implies a cadence or domain scope.
+- `pull_request`, `schedule`, and `workflow_dispatch` only say how the workflow started; none itself implies a cadence or domain scope.
 - Each Miles PR workflow passes trigger facts to `tests/ci/ci_policy.py` and publishes its `cadence`, `raw_labels`, and `bypass_fastfail` outputs. That module owns trigger adaptation and the shared `resolve_policy` consumed by `run_suite.py`.
 - A PR `nightly` label maps to nightly cadence.
 - A scheduled run maps its exact `github.event.schedule` cron: the current `0 15 * * *` entry maps to nightly, an unknown cron fails, and a future weekly entry must add its own mapping.
@@ -57,19 +57,17 @@ A **nightly** policy selects every enabled tag except `long` and `ft-long`, admi
 
 Both workflows receive `execute_command`; CUDA callers additionally pass `runs_on` and `container_image`. The reusable workflows own runner setup, dependency and source resolution, and the two command invocations (first `--list-only`, then the real run); each stage owns only which runner class, image, and command to select.
 
-**Secrets.** CPU/CUDA stages call their reusable workflow with `secrets: inherit`. The ROCm caller passes `WANDB_API_KEY` explicitly for schedules, manual runs, and same-repository PRs, but passes an empty value for fork PRs.
+**Secrets.** CPU/CUDA stages call their reusable workflow with `secrets: inherit`. The ROCm caller passes `WANDB_API_KEY` explicitly; GitHub withholds it from fork `pull_request` runs.
 
 **Sharding.** A stage with a `partition_id` matrix splits its tests across N shards; `run_suite.py` balances the shards by each test's `est_time`. Each shard is an independent job instance running the same `execute_command` with a different `--auto-partition-id`.
 
 ## ROCm PR/nightly mirror
 
-`pr-test-rocm.yml` has PR-level, exact nightly cron, and `workflow_dispatch` entry points. Its `pull_request_target` entry keeps the workflow and authorization code on the trusted base branch, while adapting the event to the same `resolve-ci-policy` path as `pr-test.yml`. It runs `stage-c-4-gpu-mi300x` through `_run-ci-rocm.yml` on two 4-GPU MI300X runners, resolves `rocm/sgl-dev:<tag>`, and splits tests into two `est_time`-balanced shards. It runs no CPU tests. SGLang and Megatron-LM come from the image, so manual dispatch exposes no dependency-ref inputs.
+`pr-test-rocm.yml` has `pull_request`, exact nightly cron, and `workflow_dispatch` entry points. PR runs use the same low-trust merge-commit model as `pr-test.yml`. It runs `stage-c-4-gpu-mi300x` through `_run-ci-rocm.yml` on two 4-GPU MI300X runners, resolves `rocm/sgl-dev:<tag>`, and splits tests into two `est_time`-balanced shards. It runs no CPU tests. SGLang and Megatron-LM come from the image, so manual dispatch exposes no dependency-ref inputs.
 
 Only tests registered with `register_rocm_ci(suite="stage-c-4-gpu-mi300x", ...)` run; CUDA registrations are not inherited. PR and nightly runs consume the shared cadence and label policy: `run-ci-amd` selects the full MI300X set, other `run-ci-*` labels can select matching subsets, and nightly cadence admits regular plus nightly-only registrations. Manual dispatch adds `--match-all-labels` and runs the full regular suite.
 
-For fork PRs, a base-branch authorization step admits the privileged MI300X stage only when the event carries a canonical `run-ci-*` label. The reusable workflow then checks out `refs/pull/<number>/merge` explicitly, so it tests the PR merge result without trusting workflow or gate code from the fork. Fork jobs receive no `WANDB_API_KEY`; same-repository PRs, schedules, and manual dispatches do not need the label gate.
-
-Checking out fork code from a `pull_request_target` job is the "pwn request" shape, so `actions/checkout` refuses it unless the step sets `allow-unsafe-pr-checkout: true`. This stage sets it deliberately: running the PR's code on the MI300X host is the entire purpose of the stage, and the two controls the guardrail asks for are already in place — a maintainer's `run-ci-*` label gates fork access, and fork jobs get no secrets. Without the flag every fork PR fails at checkout before any test runs.
+Fork PRs use GitHub's standard `pull_request` protections: checkout tests the merge commit, repository secrets are withheld, and held runs follow the shared maintainer approval flow described in [`01-label.md`](01-label.md).
 
 An 8-GPU CUDA case needs a separate 4-GPU `test_amd_<name>.py` variant rather than an `IS_HIP` branch in the original test.
 

--- a/docs/ci/00-stage.md
+++ b/docs/ci/00-stage.md
@@ -69,6 +69,8 @@ Only tests registered with `register_rocm_ci(suite="stage-c-4-gpu-mi300x", ...)`
 
 For fork PRs, a base-branch authorization step admits the privileged MI300X stage only when the event carries a canonical `run-ci-*` label. The reusable workflow then checks out `refs/pull/<number>/merge` explicitly, so it tests the PR merge result without trusting workflow or gate code from the fork. Fork jobs receive no `WANDB_API_KEY`; same-repository PRs, schedules, and manual dispatches do not need the label gate.
 
+Checking out fork code from a `pull_request_target` job is the "pwn request" shape, so `actions/checkout` refuses it unless the step sets `allow-unsafe-pr-checkout: true`. This stage sets it deliberately: running the PR's code on the MI300X host is the entire purpose of the stage, and the two controls the guardrail asks for are already in place — a maintainer's `run-ci-*` label gates fork access, and fork jobs get no secrets. Without the flag every fork PR fails at checkout before any test runs.
+
 An 8-GPU CUDA case needs a separate 4-GPU `test_amd_<name>.py` variant rather than an `IS_HIP` branch in the original test.
 
 Both runner containers can see all eight host GPUs through `/dev/dri`. Each runner restricts itself to four GPUs with `HIP_VISIBLE_DEVICES`, which `_run-ci-rocm.yml` forwards into the container.

--- a/tests/ci/test/test_run_suite.py
+++ b/tests/ci/test/test_run_suite.py
@@ -384,6 +384,10 @@ class TestRocmWorkflowScopeSeam:
         assert "checkout_ref:" in reusable
         assert "ref: ${{ inputs.checkout_ref }}" in reusable
         assert "persist-credentials: false" in reusable
+        # Checking out a fork's merge ref from pull_request_target is refused by
+        # actions/checkout unless this opt-in is set; without it every fork PR
+        # fails at checkout before a single test runs.
+        assert "allow-unsafe-pr-checkout: true" in reusable
 
 
 # --- CLI seam: local nightly alias and invalid-suite exit behavior -----------

--- a/tests/ci/test/test_run_suite.py
+++ b/tests/ci/test/test_run_suite.py
@@ -342,18 +342,14 @@ class TestRocmWorkflowScopeSeam:
 
     def test_pr_nightly_and_dispatch_share_policy(self):
         workflow = self._workflow()
-        assert (
-            "pull_request_target:\n    types: [opened, synchronize, reopened, ready_for_review, labeled]" in workflow
-        )
+        assert "pull_request:\n    types: [opened, synchronize, reopened, ready_for_review, labeled]" in workflow
+        assert "pull_request_target:" not in workflow
         configured = set(re.findall(r"^\s+- cron: ['\"]([^'\"]+)['\"]\s*$", workflow, flags=re.MULTILINE))
         assert configured == set(SCHEDULE_POLICIES)
 
         policy_block = workflow.split("resolve-ci-policy:", 1)[1].split("resolve-ci-image:", 1)[0]
-        assert "allow_self_hosted: ${{ steps.authorize.outputs.allow_self_hosted }}" in policy_block
-        assert '"$HEAD_REPOSITORY" != "$BASE_REPOSITORY"' in policy_block
-        assert "ALLOW_SELF_HOSTED=false" in policy_block
-        assert 'test("^run-ci-[A-Za-z0-9][A-Za-z0-9_.-]*$")' in policy_block
-        assert "EVENT_NAME: ${{ github.event_name == 'pull_request_target' && 'pull_request'" in policy_block
+        assert "allow_self_hosted" not in policy_block
+        assert "EVENT_NAME: ${{ github.event_name }}" in policy_block
         assert "SCHEDULE: ${{ github.event.schedule || '' }}" in policy_block
         assert "PR_LABELS_JSON: ${{ toJSON(github.event.pull_request.labels.*.name) }}" in policy_block
         assert "run: python -m tests.ci.ci_policy" in policy_block
@@ -365,29 +361,21 @@ class TestRocmWorkflowScopeSeam:
         command = stage.split("execute_command:", 1)[1].split("secrets:", 1)[0]
 
         assert "needs: [resolve-ci-policy, resolve-ci-image]" in stage
-        assert "if: needs.resolve-ci-policy.outputs.allow_self_hosted == 'true'" in stage
+        assert "allow_self_hosted" not in stage
         assert "partition_id: [0, 1]" in stage
         assert "--auto-partition-size 2" in command
-        assert "format('refs/pull/{0}/merge', github.event.pull_request.number)" in stage
+        assert "checkout_ref:" not in stage
         assert "--cadence ${{ needs.resolve-ci-policy.outputs.cadence }}" in command
         assert "--labels ${{ needs.resolve-ci-policy.outputs.raw_labels }}" in command
         assert "${{ github.event_name == 'workflow_dispatch' && '--match-all-labels' || '' }}" in command
-        secret_gate = (
-            "(github.event_name != 'pull_request_target' || "
-            "github.event.pull_request.head.repo.full_name == github.repository)"
-        )
-        assert f"WANDB_API_KEY: ${{{{ {secret_gate} && secrets.WANDB_API_KEY || '' }}}}" in stage
+        assert "WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}" in stage
         assert "--labels amd" not in command
         assert "if: github.event_name == 'workflow_dispatch'" not in workflow
 
         reusable = (Path(__file__).resolve().parents[3] / ".github" / "workflows" / "_run-ci-rocm.yml").read_text()
-        assert "checkout_ref:" in reusable
-        assert "ref: ${{ inputs.checkout_ref }}" in reusable
+        assert "checkout_ref:" not in reusable
         assert "persist-credentials: false" in reusable
-        # Checking out a fork's merge ref from pull_request_target is refused by
-        # actions/checkout unless this opt-in is set; without it every fork PR
-        # fails at checkout before a single test runs.
-        assert "allow-unsafe-pr-checkout: true" in reusable
+        assert "allow-unsafe-pr-checkout" not in reusable
 
 
 # --- CLI seam: local nightly alias and invalid-suite exit behavior -----------


### PR DESCRIPTION
## Summary
Run ROCm fork PR tests under GitHub's low-trust `pull_request` model.

## Symptom & Reproduction
- **Symptom:** On [PR #2347 at `c1396e59`](https://github.com/radixark/miles/pull/2347), both [MI300X shard 0](https://github.com/radixark/miles/actions/runs/31552618974/job/93978407205) and [shard 1](https://github.com/radixark/miles/actions/runs/31552618974/job/93978407189) failed in `actions/checkout@v4` before tests with `Refusing to check out fork pull request code from a 'pull_request_target' workflow`.
- **Reproduction:** Apply `run-ci-amd` to a fork PR; `PR Test (ROCm)` selects `refs/pull/<number>/merge` from `pull_request_target`, and checkout rejects the trusted-context fork ref.

## Root Cause
1. `pr-test-rocm.yml` used `pull_request_target` for fork PR execution.
2. `checkout_ref` selected `refs/pull/<number>/merge` from the fork.
3. `actions/checkout@v4` rejected fork code in the trusted event context.

## Fix
Use the same `pull_request` model as the NVIDIA workflow and let checkout select the PR merge commit by default. Remove the target-only authorization output, explicit checkout ref, and unsafe opt-in; GitHub now supplies the low-trust token and withholds repository secrets from fork runs while the separate approval workflow remains responsible for held runs.

## Verification
- `PYTHONDONTWRITEBYTECODE=1 pytest -p no:cacheprovider tests/ci/test/test_run_suite.py -k RocmWorkflowScopeSeam`: 2 passed, proving the event, policy inputs, checkout contract, secret mapping, manual scope, and two-shard configuration.
- `PRE_COMMIT_HOME=/tmp/miles-pr2403-pre-commit pre-commit run check-yaml --files .github/workflows/pr-test-rocm.yml .github/workflows/_run-ci-rocm.yml`: passed.
- Commit hooks on `6e331acad4`: YAML, Ruff, Black, and all repository pre-commit checks passed.

## Review Focus
- `.github/workflows/pr-test-rocm.yml`: PR jobs use `pull_request`; schedule and `workflow_dispatch` behavior remain unchanged.
- `.github/workflows/_run-ci-rocm.yml`: default checkout must resolve the PR merge commit without `allow-unsafe-pr-checkout`.
- Self-hosted runner isolation is unchanged from the NVIDIA workflow; this change fixes the event trust boundary, not persistent-runner exposure.
