### PR TITLE
Install the kubernetes toolchain the charts and the k8s provider need

### DIFF
--- a/.github/workflows/_run-cpu-ci.yml
+++ b/.github/workflows/_run-cpu-ci.yml
@@ -94,6 +94,11 @@ jobs:
           uv pip install -r requirements.txt -r tests/ci/requirements-ci-cpu.txt
           python tests/ci/verify_source_resolution.py
 
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v4.2.3
+
       - name: Resolve suite plan
         shell: bash
         run: ${{ inputs.execute_command }} --list-only

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - 'docker/Dockerfile'
+      - 'docker/install-kube-tools.sh'
       - 'docker/verify_transformer_engine.py'
       - 'requirements.txt'
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -180,8 +180,11 @@ jobs:
 
       - name: Install Python + dependencies
         run: |
-          apt-get update && apt-get install -y python3 python3-pip
-          pip3 install --break-system-packages typer
+          if ! command -v python3 >/dev/null || ! command -v pip3 >/dev/null; then
+            apt-get -o DPkg::Lock::Timeout=600 update
+            apt-get -o DPkg::Lock::Timeout=600 install -y python3 python3-pip
+          fi
+          pip3 install --break-system-packages --ignore-installed typer
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -95,7 +95,7 @@ jobs:
           # the recorded base.sha, which can lag main and pull in unrelated changes.
           # Dockerfile.rocm doesn't feed the cu13 multi-arch build this pipeline produces.
           if git diff --name-only HEAD^1 HEAD \
-              | grep -qE '^(docker/(Dockerfile|build\.py|verify_transformer_engine\.py)|requirements\.txt)$|^docker/patch/'; then
+              | grep -qE '^(docker/(Dockerfile|build\.py|install-kube-tools\.sh|verify_transformer_engine\.py)|requirements\.txt)$|^docker/patch/'; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
           else
             echo "changed=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -128,8 +128,11 @@ jobs:
       - name: Install Python + dependencies
         if: env.BUILD == 'true'
         run: |
-          apt-get update && apt-get install -y python3 python3-pip
-          pip3 install --break-system-packages typer
+          if ! command -v python3 >/dev/null || ! command -v pip3 >/dev/null; then
+            apt-get -o DPkg::Lock::Timeout=600 update
+            apt-get -o DPkg::Lock::Timeout=600 install -y python3 python3-pip
+          fi
+          pip3 install --break-system-packages --ignore-installed typer
       - name: Login to Docker Hub
         if: env.BUILD == 'true'
         uses: docker/login-action@v3

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -25,6 +25,11 @@ jobs:
           python-version: '3.10'
           cache: 'pip'
 
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v4.2.3
+
       - name: Install pre-commit
         run: pip install --upgrade pip pre-commit
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -225,6 +225,9 @@ RUN if [ "${ENABLE_CUDA_13}" = "1" ]; then \
       echo "CUDA 12 variant: keeping the base image's mooncake"; \
     fi
 
+COPY docker/install-kube-tools.sh /tmp/install-kube-tools.sh
+RUN bash /tmp/install-kube-tools.sh "${TARGETARCH}" && rm -f /tmp/install-kube-tools.sh
+
 # ====================================== Install main package ============================================
 
 ARG MILES_COMMIT=main

--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -41,6 +41,8 @@ ARG TRANSFORMER_ENGINE_REPO=https://github.com/ROCm/TransformerEngine.git
 ARG TRANSFORMER_ENGINE_BRANCH=v2.8_rocm
 ARG MOONCAKE_VERSION=0.3.12.post1
 
+ARG TARGETARCH
+
 # ======================================== Setup ================================================
 WORKDIR /root/
 
@@ -171,6 +173,9 @@ RUN pip install "typer==0.25.1" "click==8.2.1"
 
 # Pin numpy 1.x for Megatron compatibility.
 RUN pip install "numpy<2"
+
+COPY docker/install-kube-tools.sh /tmp/install-kube-tools.sh
+RUN bash /tmp/install-kube-tools.sh "${TARGETARCH}" && rm -f /tmp/install-kube-tools.sh
 
 # ====================================== Install main package ===================================
 

--- a/docker/install-kube-tools.sh
+++ b/docker/install-kube-tools.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+KUBECTL_VERSION="v1.36.3"
+HELM_VERSION="v4.2.3"
+
+arch="${1:-}"
+[ -n "$arch" ] || arch="$(dpkg --print-architecture)"
+
+curl -fsSL -o /tmp/kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${arch}/kubectl"
+curl -fsSL -o /tmp/kubectl.sha256 "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${arch}/kubectl.sha256"
+echo "$(cat /tmp/kubectl.sha256)  /tmp/kubectl" | sha256sum -c -
+install -m 0755 /tmp/kubectl /usr/local/bin/kubectl
+
+curl -fsSL -o /tmp/helm.tar.gz "https://get.helm.sh/helm-${HELM_VERSION}-linux-${arch}.tar.gz"
+curl -fsSL -o /tmp/helm.tar.gz.sha256 "https://get.helm.sh/helm-${HELM_VERSION}-linux-${arch}.tar.gz.sha256sum"
+echo "$(awk '{print $1}' /tmp/helm.tar.gz.sha256)  /tmp/helm.tar.gz" | sha256sum -c -
+tar -xzf /tmp/helm.tar.gz -C /tmp
+install -m 0755 "/tmp/linux-${arch}/helm" /usr/local/bin/helm
+
+rm -rf /tmp/kubectl /tmp/kubectl.sha256 /tmp/helm.tar.gz /tmp/helm.tar.gz.sha256 "/tmp/linux-${arch}"
+
+kubectl version --client
+helm version --short

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ blobfile
 datasets
 httpx[http2]
 hypothesis>=5.40
+kubernetes_asyncio
 mcp[cli]
 memray  # needed for debugging (but is lightweight), we can put it to dev mode when using pyproject.toml
 nvidia-resiliency-ext~=0.6.0; platform_system == "Linux"


### PR DESCRIPTION
Nothing on `main` uses these yet; they land ahead of the kubernetes work so the image is ready when it does.

## What each one costs

Measured on `radixark/miles:dev` (h200 devbox, linux/amd64). "Pulled" is what a `docker pull` actually transfers, "on disk" is what the layer occupies once unpacked.

| Addition | Pulled | On disk | Notes |
| --- | --- | --- | --- |
| `kubectl` v1.36.3 | 16.9 MiB | 56.8 MiB | single static Go binary |
| `helm` v4.2.3 | 18.9 MiB | 61.3 MiB | single static Go binary |
| `kubernetes_asyncio` 36.1.0 | 2.9 MiB (wheel) | 26 MiB, plus ~21 MiB of `__pycache__` generated at install | pure python, mostly generated api clients |
| **total** | **38.7 MiB** | **~145–165 MiB** | |

`radixark/miles:dev` is currently **19.12 GB compressed**, so the pull grows by **0.2%**. The two binaries land in one layer each Dockerfile adds once, and the script deletes its tarballs inside the same `RUN`, so nothing but the binaries is committed.

## Downsides, such as they are

- `kubernetes_asyncio` pulls in **no new transitive dependency**: `aiohttp`, `certifi`, `python-dateutil`, `pyyaml`, `six` and `urllib3` are all already in the image (verified against the installed set).
- Two more build-time downloads (`dl.k8s.io`, `get.helm.sh`). Both are pinned and sha256-verified, so a corrupted or moved artifact fails the build rather than shipping silently.
- Two more versions to keep current. They sit in one script both Dockerfiles call, so a bump is one edit rather than two.
- Nothing here is imported or executed on any training path: the binaries are only run by the launcher and the chart tests, and the wheel is only imported by the k8s worker provider.

## Why it fails quietly today

- Without `kubernetes_asyncio`, the modules importing it fail at collection.
- Without `helm`, the chart tests **skip themselves** — the run reports success while covering nothing.
- Without `kubectl`, the launcher has nothing to drive inside the pod.
