### PR TITLE
feat(opd): in-trainer top-k OPSD distillation loss

### DIFF
--- a/miles/backends/megatron_utils/actor.py
+++ b/miles/backends/megatron_utils/actor.py
@@ -378,11 +378,20 @@ class MegatronTrainRayActor(TrainRayActor):
         standard frozen-teacher setup for on-policy distillation.
 
         Under ``--offload-train`` the train loop sleeps the actor
-        (``torch_memory_saver.pause``, GPU memory unmapped) before update_weights.
-        ``backup()`` reads the LIVE parameters, so reading unmapped GPU memory is a
-        hard segfault with no Python exception: wake for the copy and sleep again.
-        Moving the call relative to ``torch_memory_saver.disable()`` does NOT help
-        -- disable() and pause()/resume() are different mechanisms.
+        (``torch_memory_saver.pause``, GPU memory unmapped) before update_weights,
+        and update_weights never wakes it -- so this site used to resume() the
+        actor and GPU-read its live params into the teacher backup. That is
+        silently wrong, not just risky: resume() does NOT reliably restore
+        parameter contents in the asleep window (parameters can come back
+        partially zeroed while other tensors survive), so the backup snapshots a
+        corrupt model. A corrupt teacher produces flat/uniform logits --
+        teacher_log_probs pinned at -ln(vocab_size) and opd_reverse_kl ~11-12 of
+        pure noise, i.e. the entire distillation signal destroyed while every
+        metric superficially "works". Never read self.model's GPU params inside
+        update_weights() (or any asleep-window code), not even after a resume().
+        The "actor" CPU tag is refreshed after every trained step while awake,
+        so it IS "the current actor weights" -- copy it CPU-side instead: no GPU
+        access, no resume/pause.
         """
         if not getattr(self.args, "opd_teacher_refresh_from_actor", False):
             return
@@ -391,17 +400,9 @@ class MegatronTrainRayActor(TrainRayActor):
                 "--opd-teacher-refresh-from-actor is set but no 'teacher' weight-backup tag "
                 "exists; it requires --opd-type=megatron with --opd-teacher-load."
             )
-        need_resume_for_backup = bool(self.args.offload_train and self._asleep)
-        tag = "default" if lora_rollout_enabled(self.args) else None
-        if need_resume_for_backup:
-            torch_memory_saver.resume(tag=tag)
-        try:
-            self.weights_backuper.backup("teacher")
-        finally:
-            # A failed backup must not leave the model resident: the train loop
-            # believes it is asleep and will not pause it again.
-            if need_resume_for_backup:
-                torch_memory_saver.pause(tag=tag)
+        if is_first_replica_megatron_main_rank():
+            logger.info("refreshing OPD teacher from the current actor weights (CPU copy)")
+        self.weights_backuper.copy(src_tag="actor", dst_tag="teacher")
 
     def _teacher_view_iterator(
         self, rollout_data: dict, extra_keys: tuple[str, ...] = ()

--- a/miles/backends/megatron_utils/actor.py
+++ b/miles/backends/megatron_utils/actor.py
@@ -37,7 +37,13 @@ from miles.utils.types import RolloutBatch
 
 from ...utils.profile_utils import TrainProfiler
 from ...utils.tensor_backper import TensorBackuper
-from ..training_utils.data import DataIterator, get_data_iterator, get_num_rollouts, get_rollout_data
+from ..training_utils.data import (
+    DataIterator,
+    compute_bshd_max_seq_lens,
+    get_data_iterator,
+    get_num_rollouts,
+    get_rollout_data,
+)
 from ..training_utils.log_utils import log_cpu_memory, log_perf_data, log_rollout_data
 from ..training_utils.loss import (
     compute_advantages_and_returns,
@@ -45,6 +51,7 @@ from ..training_utils.loss import (
     get_values,
     log_train_advantage_computation_event,
 )
+from ..training_utils.loss_hub.opd import topk_overlap, topk_reverse_kl
 from ..training_utils.parallel import get_parallel_state
 from ..training_utils.replay_data import fill_replay_data, register_replay_list_sequential
 from .checkpoint import load_checkpoint
@@ -357,6 +364,141 @@ class MegatronTrainRayActor(TrainRayActor):
         for m in all_replay_managers:
             m.stage = stage
 
+    def _maybe_refresh_opd_teacher_from_actor(self) -> None:
+        """``--opd-teacher-refresh-from-actor``: re-point the OPD teacher at the
+        weights the rollout engine just received (the "fresh"/self-teacher mode).
+
+        Called at the END of ``update_weights``, the only moment where "the
+        teacher == what the next rollout will generate with" is true: the engine's
+        weights change exactly here, so pinning the teacher anywhere else would
+        make it the teacher of a different policy than the one being scored.
+        ``--opd-teacher-load`` stays required as the step-0 seed.
+
+        The default (frozen) mode leaves the teacher at that seed forever -- the
+        standard frozen-teacher setup for on-policy distillation.
+
+        Under ``--offload-train`` the train loop sleeps the actor
+        (``torch_memory_saver.pause``, GPU memory unmapped) before update_weights.
+        ``backup()`` reads the LIVE parameters, so reading unmapped GPU memory is a
+        hard segfault with no Python exception: wake for the copy and sleep again.
+        Moving the call relative to ``torch_memory_saver.disable()`` does NOT help
+        -- disable() and pause()/resume() are different mechanisms.
+        """
+        if not getattr(self.args, "opd_teacher_refresh_from_actor", False):
+            return
+        if "teacher" not in self.weights_backuper.backup_tags:
+            raise ValueError(
+                "--opd-teacher-refresh-from-actor is set but no 'teacher' weight-backup tag "
+                "exists; it requires --opd-type=megatron with --opd-teacher-load."
+            )
+        need_resume_for_backup = bool(self.args.offload_train and self._asleep)
+        tag = "default" if lora_rollout_enabled(self.args) else None
+        if need_resume_for_backup:
+            torch_memory_saver.resume(tag=tag)
+        try:
+            self.weights_backuper.backup("teacher")
+        finally:
+            # A failed backup must not leave the model resident: the train loop
+            # believes it is asleep and will not pause it again.
+            if need_resume_for_backup:
+                torch_memory_saver.pause(tag=tag)
+
+    def _teacher_view_iterator(
+        self, rollout_data: dict, extra_keys: tuple[str, ...] = ()
+    ) -> tuple[list[DataIterator] | None, list[int] | None]:
+        """Build a data iterator over the experience-augmented teacher view.
+
+        Returns (None, None) when the rollout carries no teacher_tokens -- the
+        caller falls back to the student view (teacher == student input, KL ~ 0:
+        the correct signal for samples with no experience yet).
+
+        The view RIDES THE STUDENT'S per-sample microbatch schedule (the shard's
+        ``micro_batch_indices``/``num_microbatches`` are inherited verbatim below),
+        so coverage and order are identical to the student pass by construction.
+        Note a teacher microbatch holds slightly more tokens than its student
+        counterpart (the interleaved experience tokens): the rollout-side budget
+        that produced those tokens bounds the excess, and the teacher pass runs
+        under ``no_grad``. Text-only.
+        """
+        teacher_tokens = rollout_data.get("teacher_tokens")
+        if teacher_tokens is None:
+            return None, None
+        if "teacher_gather_positions" in rollout_data and not getattr(self.args, "opd_topk_in_trainer", 0):
+            # A turnhint view (hints interleaved inside the response span) can only
+            # be consumed through the position map, which ONLY the top-k-in-trainer
+            # gather passes through; the sampled-token teacher pass would silently
+            # drop the map and produce a shape-mismatched KL much later.
+            raise ValueError(
+                "rollout carries teacher_gather_positions (interleaved-hint teacher "
+                "view) but --opd-topk-in-trainer is 0: the sampled-token teacher pass "
+                "cannot consume the position map. Re-generate the batch with a "
+                "suffix-aligned teacher view, or enable --opd-topk-in-trainer."
+            )
+        teacher_total_lengths = [len(t) for t in teacher_tokens]
+        if not torch.distributed.is_initialized() or torch.distributed.get_rank() == 0:
+            student_total = sum(rollout_data["total_lengths"])
+            logger.info(
+                f"OPD teacher view: {len(teacher_tokens)} samples, "
+                f"teacher tokens {sum(teacher_total_lengths)} vs student {student_total} "
+                f"(+{sum(teacher_total_lengths) - student_total} experience tokens)"
+            )
+        view: dict = {
+            "tokens": teacher_tokens,
+            "total_lengths": teacher_total_lengths,
+            "response_lengths": rollout_data["response_lengths"],
+            "loss_masks": rollout_data["loss_masks"],
+        }
+        if "teacher_gather_positions" in rollout_data:
+            # turnhint OPD: the teacher view's response span is LONGER than the
+            # student's (hint turns interleaved inside it), so the view slices
+            # responses by its own lengths, carries the student-token position map
+            # for the gather row-select, and scatters the student loss mask onto
+            # its own span (hint-turn rows masked 0).
+            teacher_response_lengths = rollout_data["teacher_response_lengths"]
+            view["response_lengths"] = teacher_response_lengths
+            view["teacher_gather_positions"] = rollout_data["teacher_gather_positions"]
+            view["loss_masks"] = [
+                mask.new_zeros(int(t_len)).index_copy_(0, pos, mask)
+                for mask, pos, t_len in zip(
+                    rollout_data["loss_masks"],
+                    rollout_data["teacher_gather_positions"],
+                    teacher_response_lengths,
+                    strict=True,
+                )
+            ]
+        if "dynamic_global_batch_size" in rollout_data:
+            view["dynamic_global_batch_size"] = rollout_data["dynamic_global_batch_size"]
+        # Ride the SAME rollout-side schedule as the student pass (the fast-path that
+        # reuses the per-sample microbatch indices). Inheriting the shard's per-sample
+        # indices makes coverage and order identical by construction.
+        for key in ("micro_batch_indices", "num_microbatches"):
+            if key in rollout_data:
+                view[key] = rollout_data[key]
+        for key in extra_keys:
+            view[key] = rollout_data[key]
+        if self.args.qkv_format == "bshd":
+            view["max_seq_lens"] = compute_bshd_max_seq_lens(
+                self.args, get_parallel_state(), teacher_total_lengths, len(teacher_tokens)
+            )
+        return get_data_iterator(self.args, self.model, view)
+
+    def _opd_constancy_sentinel(self, rkls: list[torch.Tensor]) -> None:
+        """Fail loud if the per-pass mean OPD reverse-KL is bit-identical across
+        consecutive teacher passes -- the signature of a degenerate teacher
+        producing a constant KL regardless of input. Costs one mean per call.
+        """
+        if not rkls:
+            return
+        mean = torch.cat([r.reshape(-1).float() for r in rkls]).mean().item()
+        last = getattr(self, "_opd_last_rkl_mean", None)
+        self._opd_last_rkl_mean = mean
+        if last is not None and mean == last and mean != 0.0:
+            raise RuntimeError(
+                f"opd_reverse_kl mean bit-identical across consecutive teacher passes ({mean}): "
+                "the teacher forward is not conditioning on its input. Refusing to "
+                "train on a degenerate distillation signal."
+            )
+
     @with_logs
     def compute_log_prob(
         self,
@@ -364,6 +506,8 @@ class MegatronTrainRayActor(TrainRayActor):
         num_microbatches: list[int],
         rollout_id: int,
         store_prefix: str = "",
+        opd_topk: int = 0,
+        opd_gather_ids: bool = False,
     ) -> dict[str, list[torch.Tensor]]:
 
         with timer(f"{store_prefix}log_probs"):
@@ -375,6 +519,8 @@ class MegatronTrainRayActor(TrainRayActor):
                 num_microbatches,
                 rollout_id=rollout_id,
                 store_prefix=store_prefix,
+                opd_topk=opd_topk,
+                opd_gather_ids=opd_gather_ids,
             )
 
     @with_logs
@@ -501,20 +647,36 @@ class MegatronTrainRayActor(TrainRayActor):
                             store_prefix="ref_",
                         )
                     )
-                # Forward teacher model to get teacher_log_probs for Megatron-based OPD
+                # Forward teacher model to get teacher_log_probs for Megatron-based OPD.
+                opd_topk_in_trainer = (
+                    int(getattr(self.args, "opd_topk_in_trainer", 0) or 0)
+                    if getattr(self.args, "use_opd", False)
+                    else 0
+                )
                 if "teacher" in self.weights_backuper.backup_tags:
-                    self._set_replay_stage("fallthrough")
-                    self._switch_model("teacher")
-                    rollout_data.update(
-                        self.compute_log_prob(
-                            data_iterator,
-                            num_microbatches,
-                            rollout_id=rollout_id,
-                            store_prefix="teacher_",
+                    # In-trainer top-k OPD runs the teacher AFTER the actor pass -- it
+                    # gathers at the student's top-k ids, which the actor pass produces
+                    # below. The two mechanisms are mutually exclusive per rollout: this
+                    # branch is the pre-existing same-view teacher-KL path and is skipped
+                    # whenever opd_topk_in_trainer is active. BOTH teacher passes forward
+                    # the experience-augmented view (Sample.teacher_tokens) when the
+                    # rollout provides it -- that input asymmetry is the entire
+                    # distillation signal;
+                    # without it teacher == student and the KL is ~0 by construction.
+                    if not opd_topk_in_trainer:
+                        self._set_replay_stage("fallthrough")
+                        self._switch_model("teacher")
+                        t_iter, t_num_mbs = self._teacher_view_iterator(rollout_data)
+                        rollout_data.update(
+                            self.compute_log_prob(
+                                t_iter if t_iter is not None else data_iterator,
+                                t_num_mbs if t_num_mbs is not None else num_microbatches,
+                                rollout_id=rollout_id,
+                                store_prefix="teacher_",
+                            )
                         )
-                    )
                 self._switch_model("old_actor" if self.args.keep_old_actor else "actor")
-                if not self.args.use_rollout_logprobs or self.args.get_mismatch_metrics:
+                if not self.args.use_rollout_logprobs or self.args.get_mismatch_metrics or opd_topk_in_trainer:
                     for m in all_replay_managers:
                         if m.enabled:
                             if self._use_rollout_replay(m):
@@ -527,11 +689,91 @@ class MegatronTrainRayActor(TrainRayActor):
                             num_microbatches,
                             rollout_id=rollout_id,
                             store_prefix="",
+                            opd_topk=opd_topk_in_trainer,
                         )
                     )
                     for m in all_replay_managers:
                         if self._use_rollout_replay(m):
                             m.clear_all_forward()
+
+                if opd_topk_in_trainer and "teacher" in self.weights_backuper.backup_tags:
+                    # In-trainer top-k OPD: the teacher forwards the experience-
+                    # augmented view (teacher_tokens) and gathers at the student's
+                    # top-k ids (rollout_data["opd_topk_ids"], produced by the actor
+                    # pass above; travels inside each microbatch so per-sample
+                    # alignment is automatic).
+                    #
+                    # PP>1: forward_only returns its aggregate only on the pipeline's
+                    # last stage and {} everywhere else, so the pre-pass outputs
+                    # (opd_topk_ids/teacher_opd_*) exist on that rank alone. Every
+                    # rank must still WALK this whole block: the teacher forward is a
+                    # pipeline collective and _switch_model swaps weights on all ranks,
+                    # so returning early here deadlocks the pass. Only the parts that
+                    # INDEX pre-pass outputs are last-stage-only.
+                    is_pp_last = get_parallel_state().is_pp_last_stage
+                    assert not is_pp_last or "opd_topk_ids" in rollout_data, (
+                        "student top-k pass did not produce opd_topk_ids on the "
+                        "pipeline's last stage -- opd_topk wiring broken"
+                    )
+                    self._set_replay_stage("fallthrough")
+                    self._switch_model("teacher")
+                    t_iter, t_num_mbs = self._teacher_view_iterator(
+                        rollout_data, extra_keys=("opd_topk_ids",) if is_pp_last else ()
+                    )
+                    rollout_data.update(
+                        self.compute_log_prob(
+                            t_iter if t_iter is not None else data_iterator,
+                            t_num_mbs if t_num_mbs is not None else num_microbatches,
+                            rollout_id=rollout_id,
+                            store_prefix="teacher_",
+                            # opd_topk: the same pass also extracts the TEACHER's own
+                            # top-k ids, only to score the teacher/student top-k overlap
+                            # below (calculate_opd_topk supports top_k and gather_ids
+                            # simultaneously) -- the KL itself still gathers at the
+                            # STUDENT's ids.
+                            opd_topk=opd_topk_in_trainer,
+                            opd_gather_ids=True,
+                        )
+                    )
+                    self._switch_model("actor")
+                    # Everything below INDICES the pre-pass outputs, so it runs on the
+                    # last pipeline stage only. No collectives below this line -- it is
+                    # elementwise math over tensors this rank already holds.
+                    if is_pp_last:
+                        assert "teacher_opd_gathered_vals" in rollout_data, (
+                            "teacher OPD gather pass produced no teacher_opd_gathered_vals"
+                        )
+                        # Teacher/student top-k overlap -- the OPD health curve, must
+                        # RISE over training for the distillation to be teaching through
+                        # the tokens that matter. Logged via log_rollout_data as
+                        # rollout/opd_topk_overlap (loss-mask-weighted mean).
+                        teacher_topk_ids = rollout_data.pop("teacher_opd_topk_ids")
+                        rollout_data.pop("teacher_opd_topk_vals")  # unused; keep [R,K] floats out of metric cat/mean
+                        rollout_data["opd_topk_overlap"] = [
+                            topk_overlap(student_ids=s_ids, teacher_ids=t_ids)
+                            for s_ids, t_ids in zip(
+                                rollout_data["opd_topk_ids"], teacher_topk_ids, strict=True
+                            )
+                        ]
+                        # Paper semantics: per position, ids = student top-k, weights =
+                        # exp(student logprob) WITHOUT renormalization, with optional
+                        # pointwise clipping:
+                        #   rkl[r] = sum_k min(exp(s_k) * (s_k - t_k), clip)
+                        opd_clip = float(getattr(self.args, "opd_pointwise_clip", 0.0) or 0.0)
+                        rkls, clipfracs = [], []
+                        for s, t in zip(
+                            rollout_data["opd_topk_vals"],
+                            rollout_data["teacher_opd_gathered_vals"],
+                            strict=True,
+                        ):
+                            rkl, clipfrac = topk_reverse_kl(
+                                student_vals=s, teacher_vals=t, pointwise_clip=opd_clip
+                            )
+                            rkls.append(rkl)
+                            clipfracs.append(clipfrac)
+                        rollout_data["opd_reverse_kl"] = rkls
+                        rollout_data["opd_clipfrac"] = clipfracs
+                        self._opd_constancy_sentinel(rkls)
 
                 if self.args.use_critic:
                     if external_data is not None and get_parallel_state().is_pp_last_stage:
@@ -795,6 +1037,11 @@ class MegatronTrainRayActor(TrainRayActor):
                     self.weights_backuper.backup("rollout_actor")
                 else:
                     self.weights_backuper.backup("old_actor")
+
+            # Re-point the OPD teacher at the just-updated actor when
+            # --opd-teacher-refresh-from-actor is set (see that method's
+            # docstring for the wake/sleep rationale under --offload-train).
+            self._maybe_refresh_opd_teacher_from_actor()
 
         if self.args.rematerialize_param_from_master_weight:
             torch_memory_saver.pause(tag="param_buffer")

--- a/miles/backends/megatron_utils/model.py
+++ b/miles/backends/megatron_utils/model.py
@@ -4,6 +4,7 @@ import dataclasses
 import gc
 import logging
 import math
+import os
 from argparse import Namespace
 from collections.abc import Callable, Sequence
 from contextlib import nullcontext
@@ -248,6 +249,45 @@ def should_disable_forward_pre_hook(args: Namespace) -> bool:
 # ---------------------------------------------------------------------------
 
 
+def logits_precision_forward_kwargs(args) -> dict:
+    """Forward kwargs that stop Megatron upcasting the full logits to fp32.
+
+    ``Float16Module.forward`` upcasts its output on the pipeline last stage, which
+    for an LM head means allocating a full fp32 ``[S, V_local]`` copy of bf16
+    logits -- a multi-GiB allocation, and the one that OOM'd long-sequence
+    long-sequence training runs. It is redundant work, not just expensive: every vocab-wide
+    consumer upcasts per chunk on its own, and bf16 -> fp32 is exact, so the
+    chunk-wise result is bit-identical to a chunk of the globally-upcast tensor.
+
+    Returns an EMPTY dict when off, never ``{"fp32_output": True}``: a model that
+    is not wrapped in ``Float16Module`` has no such parameter and would raise
+    TypeError.
+
+    TWO switches enable it, because both have live callers:
+    * ``--keep-logits-in-model-precision`` -- the CLI flag.
+    * ``MILES_BF16_LOGITS=1`` in ``--train-env-vars``.
+    At ``V_local = 129280/8`` this skipped fp32 copy can be several GiB on the
+    last stage.
+
+    Reconciling them HERE, rather than at the call sites, is the point: the two
+    readers must agree, or ``fp32_output`` could be passed twice (a TypeError
+    that only fires once the flag is set).
+    """
+    enabled = (getattr(args, "keep_logits_in_model_precision", False)
+               or bool(os.environ.get("MILES_BF16_LOGITS")))
+    if not enabled:
+        return {}
+    if not (getattr(args, "bf16", False) or getattr(args, "fp16", False)):
+        raise ValueError(
+            "Keeping logits in model precision (--keep-logits-in-model-precision "
+            "or MILES_BF16_LOGITS=1) requires a half-precision model (bf16 or "
+            "fp16): without one there is no Float16Module wrapper, so there is "
+            "no output upcast to skip and `fp32_output` is not a parameter of "
+            "the module being called."
+        )
+    return {"fp32_output": False}
+
+
 @torch.no_grad()
 def forward_only(
     f: Callable[..., dict[str, list[torch.Tensor]]],
@@ -257,6 +297,8 @@ def forward_only(
     num_microbatches: Sequence[int],
     rollout_id: int,
     store_prefix: str = "",
+    opd_topk: int = 0,
+    opd_gather_ids: bool = False,
 ) -> dict[str, list[torch.Tensor]]:
     """Run forward passes only and collect non-loss outputs (e.g., logprobs).
 
@@ -271,6 +313,19 @@ def forward_only(
         num_microbatches: Number of microbatches per rollout step.
         rollout_id: Rollout identifier (selects the per-rollout dump subdirectory).
         store_prefix: Prefix to prepend to stored output keys.
+        opd_topk: In-trainer OPD student pass (--opd-topk-in-trainer) -- if > 0,
+            forwarded to get_log_probs_and_entropy so it also extracts
+            per-position top-k logprobs+ids ("opd_topk_vals"/"opd_topk_ids").
+        opd_gather_ids: In-trainer OPD teacher pass -- if True, fetch
+            "opd_topk_ids" from the data iterator (per-microbatch, produced
+            by the student pass above and carried on the teacher-view
+            iterator's rollout_data) and forward it to get_log_probs_and_entropy
+            as opd_gather_ids so the teacher gathers at exactly those ids.
+            A microbatch whose iterator carries no "opd_topk_ids" (e.g. this
+            call is not actually the in-trainer-OPD teacher pass) hands back
+            None for the key -- the data iterator tolerates an absent key by
+            design, so this flag is safe to leave off for every other
+            forward_only caller in this module.
 
     Returns:
         Aggregated outputs keyed by ``store_prefix + key``.
@@ -304,7 +359,11 @@ def forward_only(
 
         assert not return_schedule_plan, "forward_only step should never return schedule plan"
 
-        # Get the batch.
+        # Get the batch. "opd_topk_ids" is always requested -- harmless when
+        # opd_gather_ids=False or the iterator carries no such field (the data
+        # iterator returns None for an absent key, per-key, not an error), so the
+        # same get_batch call serves both the in-trainer-OPD teacher pass and every
+        # other forward_only caller.
         batch = get_batch(
             data_iterator,
             [
@@ -315,6 +374,8 @@ def forward_only(
                 "response_lengths",
                 "max_seq_lens",
                 "witness_ids",
+                "opd_topk_ids",
+                "teacher_gather_positions",
             ],
             args.data_pad_size_multiplier,
             args.qkv_format,
@@ -340,6 +401,9 @@ def forward_only(
             loss_mask=batch["full_loss_masks"],
             **(filter_keys(batch, ["witness_ids"]) if args.enable_witness else {}),
             **(batch["multimodal_train_inputs"] if batch["multimodal_train_inputs"] is not None else {}),
+            # Keep the LM head's output in model precision; the loss upcasts per
+            # chunk anyway.
+            **logits_precision_forward_kwargs(args),
         )
 
         return output_tensor, partial(
@@ -350,6 +414,15 @@ def forward_only(
             response_lengths=response_lengths,
             with_entropy=args.use_rollout_entropy,
             max_seq_lens=batch.get("max_seq_lens", None),
+            opd_topk=opd_topk,
+            # Only forward opd_topk_ids when the caller opted in (opd_gather_ids=True);
+            # batch.get is None-safe either way since the data iterator tolerates an
+            # absent key.
+            opd_gather_ids=batch.get("opd_topk_ids") if opd_gather_ids else None,
+            # in-trainer-OPD teacher pass: student-token position map into the
+            # teacher view's response span -- present only on that pass's iterator;
+            # None everywhere else.
+            opd_gather_positions=batch.get("teacher_gather_positions") if opd_gather_ids else None,
         )
 
     # Turn on evaluation mode which disables dropout.
@@ -496,6 +569,14 @@ def train_one_step(
                 "max_seq_lens",
                 "witness_ids",
                 "opd_reverse_kl",
+                # in-trainer top-k OPD under --opd-topk-placement=loss: the
+                # student's top-k ids and the teacher's logprobs at them are
+                # constants from the pre-passes, re-read here so the training
+                # forward can recompute the student side WITH gradient.
+                # Absent keys come back as None, so requesting them
+                # unconditionally is harmless.
+                "opd_topk_ids",
+                "teacher_opd_gathered_vals",
                 "rollout_mask_sums",
             ],
             args.data_pad_size_multiplier,
@@ -541,6 +622,12 @@ def train_one_step(
 
             if (x := batch["multimodal_train_inputs"]) is not None:
                 forward_kwargs.update(x)
+
+            # Same gate as the forward_only path -- deliberately the same helper,
+            # not a second copy of the condition: the two call sites must agree,
+            # or the ref/rollout log-probs and the training logits are computed in
+            # different dtypes.
+            forward_kwargs.update(logits_precision_forward_kwargs(args))
 
             output_tensor = model(**forward_kwargs)
 

--- a/miles/backends/training_utils/data.py
+++ b/miles/backends/training_utils/data.py
@@ -31,6 +31,25 @@ def _rollout_logprob_dtype(args: Namespace) -> torch.dtype:
     return torch.float32
 
 
+def compute_bshd_max_seq_lens(args, parallel_state, total_lengths, n_samples: int) -> list[int]:
+    """Padded per-sample max_seq_len list for bshd batching (shared by the main
+    rollout view and the in-trainer-OPD teacher view, which has its own,
+    typically longer, lengths -- extracted out of get_rollout_data's inline bshd
+    branch below so both call sites stay byte-identical by construction.
+
+    TODO: micro-batch wise dynamic, possibly move to @data.py:get_data_iterator
+    """
+    max_seq_len = max(total_lengths)
+    # pad to reduce memory fragmentation and maybe make the computation faster
+    pad_size = parallel_state.tp.size * args.data_pad_size_multiplier
+    max_compress_ratio = max(args.compress_ratios) if args.compress_ratios else 0
+    if max_compress_ratio:
+        local_seqlen_multiple = max_compress_ratio * (2 if parallel_state.cp.size > 1 else 1)
+        pad_size = max(pad_size, local_seqlen_multiple * parallel_state.cp.size)
+    max_seq_len = (max_seq_len + pad_size - 1) // pad_size * pad_size
+    return [max_seq_len] * n_samples
+
+
 def get_rollout_data(
     args: Namespace,
     rollout_data_ref: Box,
@@ -53,6 +72,19 @@ def get_rollout_data(
     rollout_data["loss_masks"] = [
         torch.tensor(t, dtype=torch.int, device=torch.cuda.current_device()) for t in rollout_data["loss_masks"]
     ]
+    if "teacher_tokens" in rollout_data:
+        # Experience-augmented teacher view for in-trainer OPD (text-only).
+        rollout_data["teacher_tokens"] = [
+            torch.tensor(t, dtype=torch.long, device=torch.cuda.current_device())
+            for t in rollout_data["teacher_tokens"]
+        ]
+    if "teacher_gather_positions" in rollout_data:
+        # turnhint OPD: student-token position map into the teacher view's
+        # response span (identity for suffix-aligned samples).
+        rollout_data["teacher_gather_positions"] = [
+            torch.tensor(t, dtype=torch.long, device=torch.cuda.current_device())
+            for t in rollout_data["teacher_gather_positions"]
+        ]
     if "rollout_mask_sums" in rollout_data:
         rollout_data["rollout_mask_sums"] = torch.tensor(
             rollout_data["rollout_mask_sums"], dtype=torch.float32, device=torch.cuda.current_device()
@@ -76,18 +108,9 @@ def get_rollout_data(
         ]
 
     if args.qkv_format == "bshd":
-        # TODO: micro-batch wise dynamic, possibly move to @data.py:get_data_iterator
-        max_seq_len = max(rollout_data["total_lengths"])
-
-        # pad to reduce memory fragmentation and maybe make the computation faster
-        pad_size = parallel_state.tp.size * args.data_pad_size_multiplier
-        max_compress_ratio = max(args.compress_ratios) if args.compress_ratios else 0
-        if max_compress_ratio:
-            local_seqlen_multiple = max_compress_ratio * (2 if parallel_state.cp.size > 1 else 1)
-            pad_size = max(pad_size, local_seqlen_multiple * parallel_state.cp.size)
-        max_seq_len = (max_seq_len + pad_size - 1) // pad_size * pad_size
-
-        rollout_data["max_seq_lens"] = [max_seq_len] * len(rollout_data["tokens"])
+        rollout_data["max_seq_lens"] = compute_bshd_max_seq_lens(
+            args, parallel_state, rollout_data["total_lengths"], len(rollout_data["tokens"])
+        )
 
     # Full-response SGLang OPD fields share rollout CP slicing but retain float32 precision.
     for key in ("rollout_log_probs", "teacher_log_probs", "opd_reverse_kl"):

--- a/miles/backends/training_utils/log_utils.py
+++ b/miles/backends/training_utils/log_utils.py
@@ -209,6 +209,16 @@ def log_rollout_data(rollout_id: int, args: Namespace, rollout_data: RolloutBatc
                 "step_adapter_names",
                 "step_adapter_batch_sizes",
                 "prompt_group_sizes",
+                # In-trainer top-k OPD: view/top-k payload -- structured per-token
+                # data (long token ids, [R, K] logprobs/vals) whose scalar mean is
+                # meaningless; the derived metrics (opd_reverse_kl, opd_topk_overlap,
+                # opd_clipfrac) are logged separately below.
+                "teacher_tokens",
+                "teacher_gather_positions",
+                "teacher_response_lengths",
+                "opd_topk_ids",
+                "opd_topk_vals",
+                "teacher_opd_gathered_vals",
             ]:
                 continue
             if isinstance(val, (list, tuple)):
@@ -228,6 +238,8 @@ def log_rollout_data(rollout_id: int, args: Namespace, rollout_data: RolloutBatc
                         "values",
                         "teacher_log_probs",
                         "opd_reverse_kl",
+                        "opd_topk_overlap",
+                        "opd_clipfrac",
                         "entropy",
                     ]:
                         sum_of_sample_mean = get_sum_of_sample_mean(

--- a/miles/backends/training_utils/loss.py
+++ b/miles/backends/training_utils/loss.py
@@ -8,7 +8,7 @@ from miles.backends.training_utils.loss_hub.advantages import compute_advantages
 from miles.backends.training_utils.loss_hub.logit_processors import get_log_probs_and_entropy, get_values  # noqa: F401
 from miles.backends.training_utils.loss_hub.losses import get_loss_function
 from miles.backends.training_utils.loss_hub.math_utils import compute_approx_kl
-from miles.backends.training_utils.loss_hub.opd import apply_opd_kl_to_advantages
+from miles.backends.training_utils.loss_hub.opd import apply_opd_kl_to_advantages, uses_opd_loss_placement
 from miles.backends.training_utils.parallel import get_parallel_state
 from miles.utils.audit_utils.event_logger.logger import get_event_logger, is_event_logger_initialized
 from miles.utils.audit_utils.event_logger.models import TrainAdvantageComputationEvent
@@ -98,7 +98,7 @@ def compute_advantages_and_returns(args: Namespace, rollout_data: RolloutBatch) 
     )
 
     # Apply on-policy distillation KL penalty to advantages (orthogonal to advantage estimator)
-    if args.use_opd:
+    if args.use_opd and not uses_opd_loss_placement(args):
         apply_opd_kl_to_advantages(
             args=args,
             rollout_data=rollout_data,

--- a/miles/backends/training_utils/loss_hub/logit_processors.py
+++ b/miles/backends/training_utils/loss_hub/logit_processors.py
@@ -4,7 +4,10 @@ from collections.abc import Iterator
 import torch
 
 from miles.backends.training_utils.cp_utils import allgather_cp_redistribute, get_logits_and_tokens_offset_with_cp
-from miles.backends.training_utils.loss_hub.math_utils import calculate_log_probs_and_entropy
+from miles.backends.training_utils.loss_hub.math_utils import (
+    calculate_log_probs_and_entropy,
+    calculate_opd_topk,
+)
 from miles.backends.training_utils.parallel import get_parallel_state
 
 
@@ -139,6 +142,9 @@ def get_log_probs_and_entropy(
     entropy_requires_grad: bool = True,
     non_loss_data: bool = True,
     max_seq_lens: list[int] | None = None,
+    opd_topk: int = 0,
+    opd_gather_ids: list[torch.Tensor] | None = None,
+    opd_gather_positions: list[torch.Tensor] | None = None,
 ) -> dict[str, list[torch.Tensor]]:
     """Compute per-token log-probabilities (and optionally entropy) on responses.
 
@@ -157,6 +163,19 @@ def get_log_probs_and_entropy(
         entropy_requires_grad: If False, compute entropy as an observed metric
             without attaching it to the autograd graph.
         non_loss_data: Unused; kept for API compatibility.
+        opd_topk: In-trainer OPD student pass -- if > 0, also extract per-position
+            full-vocab-normalized top-k logprobs+ids into "opd_topk_vals"/"opd_topk_ids".
+        opd_gather_ids: In-trainer OPD teacher pass -- if given (one `[R, K]` long
+            tensor per sample), gather full-vocab-normalized logprobs at these ids
+            into "opd_gathered_vals".
+        opd_gather_positions: OPD teacher pass with an interleaved hint view -- if
+            given (one `[R]` long tensor per sample, R = the STUDENT's response
+            length), the teacher view's response span is LONGER than the student's
+            (hint turns interleaved inside it); row-select the response-aligned
+            logits+tokens at these positions BEFORE any logprob/top-k/gather
+            computation so every output of this function is [R]-aligned with the
+            student. An identity arange is a semantic no-op (the uniform
+            representation suffix-aligned samples ride in a mixed batch).
 
     Returns:
         Dict with key "log_probs" mapping to a list of `[R]` tensors per
@@ -164,17 +183,41 @@ def get_log_probs_and_entropy(
         a list of `[R]` tensors.
     """
     assert non_loss_data
+    if opd_topk > 0 or opd_gather_ids is not None:
+        # In-trainer OPD needs full-vocab log-softmax per position; the CP
+        # redistribution below only covers "log_probs"/"entropy".
+        assert not getattr(args, "allgather_cp", False), "in-trainer OPD top-k does not support allgather_cp"
     parallel_state = get_parallel_state()
+    if opd_gather_positions is not None:
+        # The position map indexes the FULL response span of one sample; any
+        # CP sharding of that span would make the indices meaningless.
+        assert parallel_state.cp.size == 1, (
+            "turnhint OPD (opd_gather_positions) does not support context parallelism"
+        )
     log_probs_list = []
     entropy_list = []
-    for logits_chunk, tokens_chunk in get_responses(
-        logits,
-        args=args,
-        unconcat_tokens=unconcat_tokens,
-        total_lengths=total_lengths,
-        response_lengths=response_lengths,
-        max_seq_lens=max_seq_lens,
+    opd_topk_vals_list = []
+    opd_topk_ids_list = []
+    opd_gathered_list = []
+    for sample_idx, (logits_chunk, tokens_chunk) in enumerate(
+        get_responses(
+            logits,
+            args=args,
+            unconcat_tokens=unconcat_tokens,
+            total_lengths=total_lengths,
+            response_lengths=response_lengths,
+            max_seq_lens=max_seq_lens,
+        )
     ):
+        if opd_gather_positions is not None:
+            # OPD teacher view: keep only the rows where the STUDENT's response
+            # tokens sit; the interleaved hint-turn rows exist to condition the
+            # context, never to be scored. tokens_chunk at the selected rows ==
+            # the student's response tokens (asserted at train-data conversion),
+            # so every downstream output is [R_student]-aligned.
+            positions = opd_gather_positions[sample_idx].to(device=logits_chunk.device)
+            logits_chunk = logits_chunk[positions]
+            tokens_chunk = tokens_chunk[positions]
         log_prob, entropy = calculate_log_probs_and_entropy(
             logits_chunk,
             tokens_chunk,
@@ -190,11 +233,32 @@ def get_log_probs_and_entropy(
         if with_entropy:
             entropy_list.append(entropy)
 
+        if opd_topk > 0 or opd_gather_ids is not None:
+            opd_res = calculate_opd_topk(
+                logits_chunk,
+                parallel_state.tp.group,
+                top_k=opd_topk,
+                gather_ids=opd_gather_ids[sample_idx] if opd_gather_ids is not None else None,
+                chunk_size=args.log_probs_chunk_size,
+                vocab_size=getattr(args, "vocab_size", None),
+                dist_comm=getattr(args, "opd_topk_dist_comm", False),
+            )
+            if opd_topk > 0:
+                opd_topk_vals_list.append(opd_res["topk_vals"])
+                opd_topk_ids_list.append(opd_res["topk_ids"])
+            if opd_gather_ids is not None:
+                opd_gathered_list.append(opd_res["gathered"])
+
     res = {
         "log_probs": log_probs_list,
     }
     if with_entropy:
         res["entropy"] = entropy_list
+    if opd_topk > 0:
+        res["opd_topk_vals"] = opd_topk_vals_list
+        res["opd_topk_ids"] = opd_topk_ids_list
+    if opd_gather_ids is not None:
+        res["opd_gathered_vals"] = opd_gathered_list
 
     # we need to turn the all gather kv into zigzag ring attn kv
     if args.allgather_cp:

--- a/miles/backends/training_utils/loss_hub/losses.py
+++ b/miles/backends/training_utils/loss_hub/losses.py
@@ -18,6 +18,7 @@ from miles.backends.training_utils.loss_hub.math_utils import (
     compute_opsm_mask,
     compute_policy_loss,
 )
+from miles.backends.training_utils.loss_hub.opd import compute_opd_topk_distill, uses_opd_loss_placement
 from miles.backends.training_utils.parallel import get_parallel_state
 from miles.utils.misc import load_function
 from miles.utils.types import RolloutBatch
@@ -325,6 +326,16 @@ def policy_loss_function(
         if args.kl_loss_coef != 0:
             loss = loss + args.kl_loss_coef * kl_loss
 
+    # Loss placement of the in-trainer top-k OPD reverse KL. The ids and the
+    # teacher's logprobs at them are constants from the pre-passes; the student
+    # side is re-read from THIS forward, so the gradient of the KL is taken
+    # directly instead of riding on the score function (which averages it to
+    # zero over the action).
+    opd_distill_loss = None
+    if uses_opd_loss_placement(args):
+        opd_distill_loss = sum_of_sample_mean(torch.cat(compute_opd_topk_distill(args, batch, logits), dim=0))
+        loss = loss + args.opd_kl_coef * opd_distill_loss
+
     # make sure the gradient could backprop correctly.
     if log_probs.numel() == 0:
         loss += 0 * logits.sum()
@@ -379,6 +390,11 @@ def policy_loss_function(
 
     if args.use_opsm:
         reported_loss["opsm_clipfrac"] = opsm_clipfrac
+
+    if opd_distill_loss is not None:
+        # The raw KL, NOT scaled by opd_kl_coef -- comparable across runs that use
+        # different coefficients.
+        reported_loss["opd_distill_loss"] = opd_distill_loss.clone().detach()
 
     # Add OPD metrics if available
     if batch.get("opd_reverse_kl") is not None:

--- a/miles/backends/training_utils/loss_hub/math_utils.py
+++ b/miles/backends/training_utils/loss_hub/math_utils.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import torch
 import torch.distributed as dist
 import torch.nn.functional as F
+from torch.utils.checkpoint import checkpoint
 
 from miles.backends.training_utils.cp_utils import (
     all_gather_with_cp,
@@ -297,6 +298,55 @@ def compute_log_probs(
     logits = logits.unsqueeze(1)
     tokens = tokens.unsqueeze(1)
     return -fused_vocab_parallel_cross_entropy(logits, tokens, process_group)
+
+
+def _refuse_checkpoint_under_cuda_memory_history(site: str) -> None:
+    """Refuse to build a non-reentrant checkpoint while CUDA memory-history
+    recording is armed. The two are incompatible and the failure surfaces far
+    from its cause.
+
+    ``torch.cuda.memory._record_memory_history(stacks="all")`` (armed via
+    ``--record-memory-history`` whenever ``--profile-target`` contains
+    ``train_overall``, its default) installs a C-level hook that walks the
+    Python stack on every CUDA allocation. When an allocation happens inside a
+    ``checkpoint(use_reentrant=False)`` RECOMPUTE (an autograd engine thread,
+    inside ``saved_tensors_hooks``), the hook returns without setting a Python
+    exception and the interpreter reports ``SystemError: error return without
+    exception set`` at whichever line allocated -- naming the allocation, not
+    the recorder.
+
+    Raising here turns a multi-hour, hard-to-diagnose failure into a named one.
+    """
+    try:
+        armed = torch._C._cuda_isHistoryEnabled()
+    except Exception:  # noqa: BLE001 -- no query API, or CUDA not initialized
+        return
+    if armed:
+        raise RuntimeError(
+            f"{site}: CUDA memory-history recording is armed and this loss path "
+            "builds a checkpoint(use_reentrant=False) region. The recorder's "
+            "per-allocation Python-stack hook corrupts the interpreter error state "
+            "inside a checkpoint RECOMPUTE, surfacing as a spurious 'SystemError: "
+            "error return without exception set' at an unrelated line. Drop "
+            "--record-memory-history from the launch template."
+        )
+
+
+def _compute_log_probs_fp32(
+    logits: torch.Tensor,
+    tokens: torch.Tensor,
+    process_group: dist.ProcessGroup | None,
+) -> torch.Tensor:
+    """Run the mutating TP cross-entropy on a private fp32 copy of ``logits``.
+
+    Exists to be the *whole* callable handed to ``checkpoint()``. The fp32 copy
+    MUST be created here: build it outside and the checkpoint boundary saves it,
+    retaining exactly the ``[chunk, V_local]`` fp32 tensor the boundary was added
+    to avoid. Two things therefore live inside this function and nowhere else --
+    the upcast, and the guarantee that the fused kernel (which mutates its input
+    in forward) never sees the caller's logits.
+    """
+    return compute_log_probs(logits.to(torch.float32, copy=True), tokens, process_group)
 
 
 def _prepare_true_on_policy_full_logits(
@@ -970,7 +1020,28 @@ def calculate_log_probs_and_entropy(
             logits_chunks = logits.chunk(num_chunks, dim=0)
             log_probs = []
             for tokens_chunk, logits_chunk in zip(tokens_chunks, logits_chunks, strict=True):
-                log_prob = compute_log_probs(logits_chunk.to(torch.float32, copy=True), tokens_chunk, tp_group)
+                # Row chunking alone bounds the per-call working set but NOT what
+                # each chunk's graph retains: every chunk saves fp32 vocab-wide
+                # softmax state for backward, so after this loop the aggregate is
+                # still sum_i(C_i * V_local * 4) == S * V_local * 4 bytes at full
+                # sequence length, which is the OOM that prompted this change.
+                # Checkpointing each chunk replaces that with one chunk's worth of
+                # recomputation during backward.
+                if torch.is_grad_enabled() and logits_chunk.requires_grad:
+                    _refuse_checkpoint_under_cuda_memory_history(
+                        "calculate_log_probs_and_entropy"
+                    )
+                    log_prob = checkpoint(
+                        _compute_log_probs_fp32,
+                        logits_chunk,
+                        tokens_chunk,
+                        tp_group,
+                        use_reentrant=False,
+                    )
+                else:
+                    # ref / student / teacher scoring: no graph to shrink, so do
+                    # not pay for one. Same numbers either way.
+                    log_prob = _compute_log_probs_fp32(logits_chunk, tokens_chunk, tp_group)
                 log_probs.append(log_prob)
             log_prob = torch.cat(log_probs, dim=0)
             if with_entropy:
@@ -980,7 +1051,10 @@ def calculate_log_probs_and_entropy(
                     entropys.append(entropy)
                 entropy = torch.cat(entropys, dim=0)
         else:
-            log_prob = compute_log_probs(logits.to(torch.float32, copy=True), tokens, tp_group)
+            # chunk_size <= 0: the caller did not ask for a bounded working set,
+            # and checkpointing one full-length chunk buys no structural win -- it
+            # would recompute [S, V_local] to save [S, V_local]. Left alone.
+            log_prob = _compute_log_probs_fp32(logits, tokens, tp_group)
             if with_entropy:
                 entropy = compute_entropy(logits)
     else:
@@ -989,6 +1063,320 @@ def calculate_log_probs_and_entropy(
             entropy = logits.new_zeros((0,))
 
     return log_prob, entropy
+
+
+def _calculate_opd_topk_dist_chunk(
+    local_logits: torch.Tensor,
+    tp_group: dist.ProcessGroup,
+    *,
+    top_k: int,
+    gather_ids: torch.Tensor | None,
+    vocab_size: int | None,
+) -> dict[str, torch.Tensor]:
+    """Exact distributed top-k/gather over TP-sharded vocab logits.
+
+    Mathematically identical to full-vocab log_softmax + topk/gather, but never
+    materializes the ``[R, V_full]`` tensor: the global normalizer is a logsumexp
+    merge of per-rank partials, top-k merges ws*k local candidates, and the
+    teacher gather routes each id to the one rank whose shard holds it
+    (all-reduce sum over a zero-masked gather). Comm per chunk drops from
+    ``[R, V_full]`` to ``[R, ws*(k+1)+k]`` -- ~485x smaller at V=248320, TP4,
+    k=128.
+    """
+    ws = dist.get_world_size(tp_group)
+    rank = dist.get_rank(tp_group)
+    R, v_local = local_logits.shape
+    x = local_logits.float()
+    shard_start = rank * v_local
+    # Mask the padded vocab tail so it can never win a top-k slot and never
+    # contributes to the normalizer (same effect as the truncation the
+    # full-gather path applies after concatenation).
+    if vocab_size is not None:
+        n_valid = min(max(vocab_size - shard_start, 0), v_local)
+        if n_valid < v_local:
+            x = x.clone()
+            x[:, n_valid:] = float("-inf")
+
+    lse_local = torch.logsumexp(x, dim=-1)  # [R]
+    lse_all = torch.empty((ws, R), dtype=lse_local.dtype, device=x.device)
+    dist.all_gather_into_tensor(lse_all, lse_local.contiguous(), group=tp_group)
+    lse = torch.logsumexp(lse_all, dim=0, keepdim=False).unsqueeze(-1)  # [R, 1]
+
+    res: dict[str, torch.Tensor] = {}
+    if top_k > 0:
+        k_local = min(top_k, v_local)
+        cand_vals_local, cand_ids_local = x.topk(k_local, dim=-1)
+        cand_ids_local = cand_ids_local + shard_start
+        cand_vals = torch.empty((ws, R, k_local), dtype=cand_vals_local.dtype, device=x.device)
+        cand_ids = torch.empty((ws, R, k_local), dtype=cand_ids_local.dtype, device=x.device)
+        dist.all_gather_into_tensor(cand_vals, cand_vals_local.contiguous(), group=tp_group)
+        dist.all_gather_into_tensor(cand_ids, cand_ids_local.contiguous(), group=tp_group)
+        cand_vals = cand_vals.permute(1, 0, 2).reshape(R, ws * k_local)
+        cand_ids = cand_ids.permute(1, 0, 2).reshape(R, ws * k_local)
+        vals, idx = cand_vals.topk(top_k, dim=-1)
+        res["topk_vals"] = vals - lse
+        res["topk_ids"] = cand_ids.gather(-1, idx)
+    if gather_ids is not None:
+        gid = gather_ids.to(device=x.device)
+        in_shard = (gid >= shard_start) & (gid < shard_start + v_local)
+        local_gid = (gid - shard_start).clamp(0, v_local - 1)
+        g = x.gather(-1, local_gid)
+        g = torch.where(in_shard, g, torch.zeros_like(g))
+        dist.all_reduce(g, group=tp_group)  # each real id lives on exactly one shard
+        res["gathered"] = g - lse
+    return res
+
+
+class _ReplicatedAllGatherRows(torch.autograd.Function):
+    """All-gather a ``[R]`` tensor into ``[ws, R]`` for a loss replicated on every TP rank.
+
+    Same contract as ``_ReplicatedLossAllGatherLastDim``: every TP rank computes
+    the SAME scalar loss, so the incoming gradient is already identical on all
+    ranks and each rank keeps only its own row -- a reduce-scatter would sum
+    identical gradients and scale the local gradient by TP size.
+    """
+
+    @staticmethod
+    def forward(ctx, input_: torch.Tensor, group: dist.ProcessGroup) -> torch.Tensor:
+        ctx.rank = dist.get_rank(group)
+        world_size = dist.get_world_size(group)
+        out = torch.empty((world_size, *input_.shape), dtype=input_.dtype, device=input_.device)
+        dist.all_gather_into_tensor(out, input_.contiguous(), group=group)
+        return out
+
+    @staticmethod
+    def backward(ctx, grad_output: torch.Tensor):
+        return grad_output[ctx.rank].contiguous(), None
+
+
+class _ReplicatedAllReduceSum(torch.autograd.Function):
+    """Sum per-rank contributions into a value replicated on every TP rank.
+
+    Each rank contributes disjoint vocab-shard entries with coefficient 1 and
+    every rank then computes the same scalar loss from the reduced tensor, so
+    backward is the identity -- no second collective.
+    """
+
+    @staticmethod
+    def forward(ctx, input_: torch.Tensor, group: dist.ProcessGroup) -> torch.Tensor:
+        out = input_.contiguous().clone()
+        dist.all_reduce(out, group=group)
+        return out
+
+    @staticmethod
+    def backward(ctx, grad_output: torch.Tensor):
+        return grad_output, None
+
+
+#: Rows per chunk when the caller passes no explicit chunk size. Bounds the
+#: TRANSIENT [chunk, V_local] fp32 upcast, which is the whole point -- see
+#: calculate_opd_gather_with_grad.
+_OPD_GATHER_DEFAULT_CHUNK_ROWS = 1024
+
+
+def _opd_gather_chunk(
+    logits: torch.Tensor,
+    tp_group: dist.ProcessGroup | None,
+    gather_ids: torch.Tensor,
+    vocab_size: int | None,
+    world_size: int,
+    rank: int,
+) -> torch.Tensor:
+    x = logits.float()
+    v_local = x.size(-1)
+    shard_start = rank * v_local
+
+    if vocab_size is not None:
+        n_valid = min(max(vocab_size - shard_start, 0), v_local)
+        if n_valid < v_local:
+            # A finite floor rather than -inf, so a fully-padded shard cannot
+            # put -inf into logsumexp on a graph that will be differentiated.
+            # exp(floor - lse) underflows to 0, so the tail carries no mass and
+            # no gradient.
+            tail = torch.zeros(v_local, dtype=torch.bool, device=x.device)
+            tail[n_valid:] = True
+            x = x.masked_fill(tail, torch.finfo(x.dtype).min)
+
+    lse_local = torch.logsumexp(x, dim=-1)  # [R]
+    if world_size > 1:
+        lse = torch.logsumexp(_ReplicatedAllGatherRows.apply(lse_local, tp_group), dim=0)
+    else:
+        lse = lse_local
+
+    gid = gather_ids.to(device=x.device)
+    if world_size > 1:
+        in_shard = (gid >= shard_start) & (gid < shard_start + v_local)
+        gathered = x.gather(-1, (gid - shard_start).clamp(0, v_local - 1))
+        gathered = torch.where(in_shard, gathered, torch.zeros_like(gathered))
+        gathered = _ReplicatedAllReduceSum.apply(gathered, tp_group)
+    else:
+        gathered = x.gather(-1, gid)
+
+    return gathered - lse.unsqueeze(-1)
+
+
+def calculate_opd_gather_with_grad(
+    logits: torch.Tensor,
+    tp_group: dist.ProcessGroup | None,
+    *,
+    gather_ids: torch.Tensor,
+    vocab_size: int | None = None,
+    chunk_size: int = -1,
+) -> torch.Tensor:
+    """DIFFERENTIABLE full-vocab-normalized logprobs at ``gather_ids``.
+
+    The gradient-carrying counterpart of ``calculate_opd_topk``'s teacher gather,
+    for the loss placement of the top-k OPD KL (see
+    ``opd.compute_opd_topk_distill``). ``calculate_opd_topk`` runs under
+    ``no_grad`` and materializes the full ``[R, V]`` log-softmax; doing that on
+    the loss graph would retain an ``[R, V]`` fp32 activation per micro-batch for
+    backward (tens of GB at long responses). This routine never forms ``[R, V]``:
+
+        s_k = x[:, id_k] - logsumexp(x, dim=-1)
+
+    reads the shard-local logits (already alive as the model's output) and keeps
+    only ``[R]`` and ``[R, K]`` intermediates. Under TP the normalizer is a
+    logsumexp merge of per-rank partials and the gather routes each id to the one
+    rank whose shard holds it, both through the replicated-loss autograd
+    Functions above.
+
+    The ``[chunk, V_local]`` fp32 upcast is unavoidable for a numerically sane
+    logsumexp, but it must stay TRANSIENT: autograd would otherwise retain it for
+    backward, producing an activation too large for the backward pass. So rows are
+    chunked and each chunk is gradient-checkpointed: only the ``[chunk, K]``
+    output crosses the boundary, and the upcast is rebuilt during backward.
+    Recomputation re-runs the two collectives, which is safe because every rank
+    walks the same chunks in the same order.
+
+    Args:
+        logits: ``[R, V_local]`` response-aligned local logits (temperature
+            already applied by ``get_responses``), with grad.
+        tp_group: Tensor-parallel group, or None for TP=1.
+        gather_ids: ``[R, K]`` long, the ids to score (the STUDENT's top-k ids
+            from the pre-pass).
+        vocab_size: Real tokenizer vocab size; the padded tail is floored so it
+            can neither win mass in the normalizer nor produce a NaN gradient.
+        chunk_size: Rows per chunk; <= 0 selects
+            ``_OPD_GATHER_DEFAULT_CHUNK_ROWS``. Never "no chunking" -- an
+            unbounded chunk is the bug this replaces.
+
+    Returns:
+        ``[R, K]`` float32 logprobs, differentiable w.r.t. ``logits``.
+    """
+    if gather_ids.ndim != 2 or gather_ids.size(0) != logits.size(0):
+        raise ValueError(
+            f"OPD gather ids must be a [R, K] aligned with logits [R, V_local], got "
+            f"ids={tuple(gather_ids.shape)} logits={tuple(logits.shape)}"
+        )
+    if logits.size(0) == 0:
+        return logits.new_zeros((0, gather_ids.size(-1)), dtype=torch.float32)
+
+    world_size = dist.get_world_size(tp_group) if tp_group is not None else 1
+    rank = dist.get_rank(tp_group) if tp_group is not None else 0
+    rows = chunk_size if chunk_size > 0 else _OPD_GATHER_DEFAULT_CHUNK_ROWS
+
+    # Unconditional here, unlike the main-CE site: this routine checkpoints for
+    # ANY chunk_size, so an OPD arm always carries a recompute region.
+    _refuse_checkpoint_under_cuda_memory_history("calculate_opd_gather_with_grad")
+
+    parts = []
+    for logits_chunk, ids_chunk in zip(
+        logits.split(rows, dim=0), gather_ids.split(rows, dim=0), strict=True
+    ):
+        parts.append(
+            checkpoint(
+                _opd_gather_chunk,
+                logits_chunk,
+                tp_group,
+                ids_chunk,
+                vocab_size,
+                world_size,
+                rank,
+                use_reentrant=False,
+            )
+        )
+    return torch.cat(parts, dim=0)
+
+
+def calculate_opd_topk(
+    logits: torch.Tensor,
+    tp_group: dist.ProcessGroup | None,
+    *,
+    top_k: int = 0,
+    gather_ids: torch.Tensor | None = None,
+    chunk_size: int = -1,
+    vocab_size: int | None = None,
+    dist_comm: bool = False,
+) -> dict[str, torch.Tensor]:
+    """In-trainer OPD over response-aligned local logits ``[R, V_local]``.
+
+    Full-vocab log-softmax (TP allgather, chunked along R, under no_grad -- this
+    is a pre-pass: the ids and teacher logprobs it produces are CONSTANTS for the
+    update; the differentiable graph is rebuilt later by
+    ``calculate_opd_gather_with_grad`` re-reading the student side), then
+    per response position:
+      * ``top_k > 0``        -- student pass: top-k values+ids
+        (full-vocab-normalized logprobs, same semantics as sglang's
+        ``top_logprobs_num``) -> ``{"topk_vals", "topk_ids"}``
+      * ``gather_ids`` given -- teacher pass: gather at the student's ids
+        (``[R, K]`` long tensor) -> ``{"gathered"}``
+    """
+    assert top_k > 0 or gather_ids is not None
+    num_positions = logits.size(0)
+    if num_positions == 0:
+        res: dict[str, torch.Tensor] = {}
+        if top_k > 0:
+            res["topk_vals"] = logits.new_zeros((0, top_k), dtype=torch.float32)
+            res["topk_ids"] = torch.zeros((0, top_k), dtype=torch.long, device=logits.device)
+        if gather_ids is not None:
+            res["gathered"] = logits.new_zeros((0, gather_ids.size(-1)), dtype=torch.float32)
+        return res
+
+    # A bounded floor, never one block. ``calculate_opd_gather_with_grad``
+    # already floors at the same constant, and these two do the same thing to the
+    # same ``[R, V_local]`` tensor -- letting only one of them honour a missing
+    # ``chunk_size`` means one forgotten kwarg turns a bounded transient into a
+    # full-sequence fp32 materialization. Memory knob only: chunking cannot change
+    # the values.
+    rows = chunk_size if chunk_size > 0 else _OPD_GATHER_DEFAULT_CHUNK_ROWS
+    n_chunks = (num_positions - 1) // rows + 1
+    logits_chunks = logits.chunk(n_chunks, dim=0)
+    id_chunks = gather_ids.chunk(n_chunks, dim=0) if gather_ids is not None else [None] * len(logits_chunks)
+    parts: dict[str, list[torch.Tensor]] = {"topk_vals": [], "topk_ids": [], "gathered": []}
+    use_dist = dist_comm and tp_group is not None and dist.get_world_size(tp_group) > 1
+    with torch.no_grad():
+        for logits_chunk, ids_chunk in zip(logits_chunks, id_chunks, strict=True):
+            if use_dist:
+                chunk_res = _calculate_opd_topk_dist_chunk(
+                    logits_chunk.contiguous(),
+                    tp_group,
+                    top_k=top_k,
+                    gather_ids=ids_chunk,
+                    vocab_size=vocab_size,
+                )
+                if top_k > 0:
+                    parts["topk_vals"].append(chunk_res["topk_vals"])
+                    parts["topk_ids"].append(chunk_res["topk_ids"])
+                if ids_chunk is not None:
+                    parts["gathered"].append(chunk_res["gathered"])
+                continue
+            full_logits = _gather_true_on_policy_full_logits(
+                logits_chunk.contiguous(), tp_group, vocab_size=vocab_size
+            )
+            log_probs_full = torch.log_softmax(full_logits.float(), dim=-1)
+            if top_k > 0:
+                vals, ids = log_probs_full.topk(top_k, dim=-1)
+                parts["topk_vals"].append(vals)
+                parts["topk_ids"].append(ids)
+            if ids_chunk is not None:
+                parts["gathered"].append(log_probs_full.gather(-1, ids_chunk.to(device=log_probs_full.device)))
+    res = {}
+    if top_k > 0:
+        res["topk_vals"] = torch.cat(parts["topk_vals"], dim=0)
+        res["topk_ids"] = torch.cat(parts["topk_ids"], dim=0)
+    if gather_ids is not None:
+        res["gathered"] = torch.cat(parts["gathered"], dim=0)
+    return res
 
 
 def _calculate_log_probs_and_entropy_true_on_policy(

--- a/miles/backends/training_utils/loss_hub/opd.py
+++ b/miles/backends/training_utils/loss_hub/opd.py
@@ -2,7 +2,231 @@ from argparse import Namespace
 
 import torch
 
+from miles.backends.training_utils.loss_hub.logit_processors import get_responses
+from miles.backends.training_utils.loss_hub.math_utils import calculate_opd_gather_with_grad
+from miles.backends.training_utils.parallel import get_parallel_state
 from miles.utils.types import RolloutBatch
+
+
+def opd_topk_placement(args: Namespace) -> str:
+    """Where the in-trainer top-k OPD reverse KL enters the update.
+
+    * ``"loss"`` (default): the KL is a LOSS term
+      differentiable through the student's current logits.
+    * ``"advantage"``: the KL is subtracted from the per-token advantage. This
+      is retained ONLY as the ablation control -- the top-k sum has already
+      marginalized over the action, so it is a per-position constant and
+      ``E_a[A(r)*grad log pi(a|r)] = A(r)*0``: a (very accurate) baseline that
+      cannot teach.
+
+    Only meaningful for the in-trainer top-k path; the sampled-token OPD keeps
+    the action inside the coefficient and stays on the advantage side.
+    """
+    return str(getattr(args, "opd_topk_placement", "loss") or "loss")
+
+
+def validate_opd_topk_placement(args: Namespace) -> None:
+    """Refuse the one OPD wiring that provably cannot teach.
+
+    Advantage-side placement is legitimate ONLY for the sampled-token OPD
+    (``--opd-topk-in-trainer 0``), where the coefficient `s(a_t) - t(a_t)` keeps
+    the action inside `A` and the expected gradient is ~grad KL. Combined with
+    an in-trainer top-k the coefficient no longer depends on the sampled token,
+    so `E_a[A(a) * grad log pi(a|a)] = A(a) * 0` -- an exact baseline. This fails
+    at launch rather than at analysis time.
+    """
+    placement = opd_topk_placement(args)
+    if placement not in ("loss", "advantage"):
+        raise ValueError(f"--opd-topk-placement must be 'loss' or 'advantage', got {placement!r}.")
+    if not getattr(args, "use_opd", False):
+        return
+    if int(getattr(args, "opd_topk_in_trainer", 0) or 0) < 0:
+        raise ValueError("--opd-topk-in-trainer must be non-negative.")
+    if float(getattr(args, "opd_pointwise_clip", 0.0) or 0.0) < 0:
+        raise ValueError("--opd-pointwise-clip must be non-negative (0 disables clipping).")
+    if placement == "advantage" and int(getattr(args, "opd_topk_in_trainer", 0) or 0) > 0:
+        raise ValueError(
+            "--opd-topk-placement=advantage requires the sampled-token OPD "
+            "(--opd-topk-in-trainer 0). An in-trainer top-k reverse KL has already "
+            "marginalized over the action, so on the advantage side it is a "
+            "per-position constant with zero expected policy gradient -- a perfect "
+            "baseline that teaches nothing, and one that gets MORE perfect as the "
+            "top-k grows. Use --opd-topk-placement=loss to keep the top-k (the "
+            "differentiable loss term), or --opd-topk-in-trainer 0 to keep the "
+            "advantage side with the sampled-token estimator."
+        )
+
+
+def uses_opd_loss_placement(args: Namespace) -> bool:
+    """True when the top-k OPD KL is a loss term rather than an advantage shift."""
+    return (
+        bool(getattr(args, "use_opd", False))
+        and int(getattr(args, "opd_topk_in_trainer", 0) or 0) > 0
+        and opd_topk_placement(args) == "loss"
+    )
+
+
+def topk_reverse_kl(
+    *,
+    student_vals: torch.Tensor,
+    teacher_vals: torch.Tensor,
+    pointwise_clip: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Paper-formula in-trainer OPD reverse KL over the student's top-k ids.
+
+    rkl[r] = sum_k exp(s_k) * (s_k - t_k), NOT renormalized within the top-k.
+    ``pointwise_clip > 0`` caps each per-(position,k) contribution (a guard
+    against a single spike token hogging the KL budget) and reports the clipped
+    fraction per position.
+
+    Args:
+        student_vals: ``[R, K]`` student full-vocab-normalized logprobs at the
+            student's own top-k ids.
+        teacher_vals: ``[R, K]`` teacher logprobs gathered at the SAME ids.
+        pointwise_clip: 0 disables clipping; otherwise max per-entry
+            contribution.
+
+    Returns:
+        (rkl ``[R]``, clipfrac ``[R]``).
+    """
+    if student_vals.shape != teacher_vals.shape or student_vals.ndim != 2:
+        raise ValueError(
+            f"OPD top-k scores must share a [R, K] shape, got student={tuple(student_vals.shape)}"
+            f" teacher={tuple(teacher_vals.shape)}"
+        )
+    if pointwise_clip < 0:
+        raise ValueError(f"pointwise_clip must be >= 0, got {pointwise_clip}")
+    if not torch.isfinite(student_vals).all():
+        raise ValueError("OPD student top-k scores contain non-finite values")
+    if not torch.isfinite(teacher_vals).all():
+        raise ValueError("OPD teacher top-k scores contain non-finite values")
+
+    contributions = student_vals.exp() * (student_vals - teacher_vals)
+    if pointwise_clip == 0:
+        return contributions.sum(dim=-1), torch.zeros(
+            student_vals.shape[0], dtype=contributions.dtype, device=contributions.device
+        )
+    clipped = contributions.clamp(max=pointwise_clip)
+    clipfrac = (contributions > pointwise_clip).to(dtype=contributions.dtype).mean(dim=-1)
+    return clipped.sum(dim=-1), clipfrac
+
+
+def topk_overlap(
+    *,
+    student_ids: torch.Tensor,
+    teacher_ids: torch.Tensor,
+    chunk_size: int = 1024,
+) -> torch.Tensor:
+    """Per-position overlap fraction of the teacher's and student's top-k id sets.
+
+    ``overlap[r] = |student_ids[r] ∩ teacher_ids[r]| / K`` -- the distillation health
+    metric: distillation transfers through the student's top-k tokens, so for the
+    KL to teach anything the teacher's own top-k must increasingly coincide with
+    the student's over training -- a flat or falling curve means the knowledge
+    view is shifting the teacher's distribution away from the student's output
+    habits instead of sharpening it in place.
+
+    Args:
+        student_ids: ``[R, K]`` long, the student's top-k ids per position.
+        teacher_ids: ``[R, K]`` long, the teacher's top-k ids per position
+            (same K; each row is a set -- top-k ids are unique by construction).
+        chunk_size: rows compared per broadcast chunk (the ``[r, K, K]``
+            comparison cube is memory-bound at K=128).
+
+    Returns:
+        ``[R]`` float32 overlap fractions in [0, 1].
+    """
+    if student_ids.shape != teacher_ids.shape or student_ids.ndim != 2:
+        raise ValueError(
+            f"top-k id sets must share a [R, K] shape, got student={tuple(student_ids.shape)}"
+            f" teacher={tuple(teacher_ids.shape)}"
+        )
+    num_positions, k = student_ids.shape
+    if num_positions == 0:
+        return student_ids.new_zeros((0,), dtype=torch.float32)
+    parts = []
+    with torch.no_grad():
+        for s_chunk, t_chunk in zip(
+            student_ids.split(chunk_size, dim=0), teacher_ids.split(chunk_size, dim=0), strict=True
+        ):
+            shared = (s_chunk.unsqueeze(-1) == t_chunk.unsqueeze(-2)).any(dim=-1)
+            parts.append(shared.sum(dim=-1).to(torch.float32) / k)
+    return torch.cat(parts, dim=0)
+
+
+def compute_opd_topk_distill(
+    args: Namespace,
+    batch: RolloutBatch,
+    logits: torch.Tensor,
+) -> list[torch.Tensor]:
+    """Per-sample ``[R]`` top-k reverse KL, differentiable through ``logits``.
+
+    This is the consolidation term of the top-k distillation: the ids and the teacher's logprobs at
+    those ids are constants precomputed once per collected batch (the student
+    pre-pass and teacher gather), and the student side is re-read from THIS
+    training forward so the gradient flows:
+
+        rkl[r] = sum_k exp(s_k) * (s_k - t_k),   s_k from the live logits
+
+    Reading it against ``apply_opd_kl_to_advantages``: identical formula, but
+    there the whole thing is a detached number multiplied onto
+    ``grad log pi(sampled token)``, which averages to zero over the action. Here
+    the derivative is taken of the KL itself, so it is non-zero every step.
+
+    Args:
+        args: Needs ``qkv_format``, ``rollout_temperature`` and optionally
+            ``opd_pointwise_clip``/``vocab_size`` (``get_responses`` reads the rest).
+        batch: The micro-batch; needs ``unconcat_tokens``, ``total_lengths``,
+            ``response_lengths``, ``opd_topk_ids`` and ``teacher_opd_gathered_vals``.
+        logits: ``[1, T, V_local]`` policy logits from the training forward.
+
+    Returns:
+        One ``[R]`` tensor per sample, response-aligned and carrying grad.
+    """
+    topk_ids = batch.get("opd_topk_ids")
+    teacher_vals = batch.get("teacher_opd_gathered_vals")
+    if topk_ids is None:
+        raise ValueError(
+            "OPD loss placement requires opd_topk_ids in the training micro-batch; "
+            "the student top-k pre-pass did not run or the key was not requested."
+        )
+    if teacher_vals is None:
+        raise ValueError(
+            "OPD loss placement requires teacher_opd_gathered_vals in the training "
+            "micro-batch; the teacher gather pass did not run or the key was not requested."
+        )
+
+    tp_group = get_parallel_state().tp.group
+    pointwise_clip = float(getattr(args, "opd_pointwise_clip", 0.0) or 0.0)
+    vocab_size = getattr(args, "vocab_size", None)
+
+    rkls = []
+    for sample_idx, (logits_chunk, _tokens_chunk) in enumerate(
+        get_responses(
+            logits,
+            args=args,
+            unconcat_tokens=batch["unconcat_tokens"],
+            total_lengths=batch["total_lengths"],
+            response_lengths=batch["response_lengths"],
+            max_seq_lens=batch.get("max_seq_lens", None),
+        )
+    ):
+        student_vals = calculate_opd_gather_with_grad(
+            logits_chunk,
+            tp_group,
+            gather_ids=topk_ids[sample_idx].to(device=logits_chunk.device),
+            vocab_size=vocab_size,
+            # Same row-chunking knob the no_grad pre-pass uses; <= 0 falls back
+            # to the routine's own bounded default (never "unchunked").
+            chunk_size=int(getattr(args, "log_probs_chunk_size", -1) or -1),
+        )
+        rkl, _clipfrac = topk_reverse_kl(
+            student_vals=student_vals,
+            teacher_vals=teacher_vals[sample_idx].to(device=student_vals.device, dtype=student_vals.dtype),
+            pointwise_clip=pointwise_clip,
+        )
+        rkls.append(rkl)
+    return rkls
 
 
 def apply_opd_kl_to_advantages(

--- a/miles/ray/rollout/train_data_conversion.py
+++ b/miles/ray/rollout/train_data_conversion.py
@@ -21,6 +21,13 @@ ROLLOUT_DATA_TENSOR_DTYPES = {
     "opd_reverse_kl": "float32",
     "rollout_routed_experts": "int32",
     "rollout_indexer_topk": "int32",
+    # Experience-augmented teacher view for in-trainer top-k OPD
+    # (--opd-topk-in-trainer): privileged_prefix + response tokens.
+    "teacher_tokens": "int32",
+    # turnhint OPD: per-sample map from student response index -> position in
+    # the teacher view's own response span (identity arange when the view is
+    # suffix-aligned, so the batch representation is uniform).
+    "teacher_gather_positions": "int32",
 }
 
 ROLLOUT_DATA_VALUE_SPEC: dict[str, ValueSpec] = {
@@ -28,6 +35,7 @@ ROLLOUT_DATA_VALUE_SPEC: dict[str, ValueSpec] = {
     "partition": ValueSpec(codec="ndarray", dtype="int64"),
     "seq_witness_ids": ValueSpec(codec="ndarray", dtype="int64"),
     "response_lengths": ValueSpec(codec="ndarray", dtype="int64"),
+    "teacher_response_lengths": ValueSpec(codec="ndarray", dtype="int64"),
     "rewards": ValueSpec(codec="ndarray", dtype="float32"),
     "truncated": ValueSpec(codec="ndarray", dtype="int64"),
     "round_number": ValueSpec(codec="ndarray", dtype="int64"),
@@ -150,6 +158,84 @@ def convert_samples_to_train_data(
 
     if samples[0].opd_reverse_kl is not None:
         train_data["opd_reverse_kl"] = [sample.opd_reverse_kl for sample in samples]
+
+    if any(sample.teacher_tokens is not None for sample in samples):
+        # Experience-augmented teacher view for in-trainer OPD
+        # (--opd-topk-in-trainer). The whole KL alignment contract is "the last
+        # response_length positions of the teacher view are the SAME response
+        # tokens the student scored" -- pin it here, fail loud, before anything
+        # downstream can silently misalign.
+        #
+        # Gate on `any`, not `samples[0]`: a train-data conversion may produce a
+        # mixed batch (some samples with a teacher view, some without) when the
+        # reward post-process excludes part of the batch from teacher scoring
+        # without dropping them. A sample with no teacher view falls back to its
+        # own tokens: teacher == student for that sample only, i.e. zero forced
+        # KL contribution from a sample the teacher never scored.
+        for sample in samples:
+            if sample.teacher_tokens is None:
+                # copy, not alias: a later in-place mutation of tokens must not
+                # silently rewrite the teacher view
+                sample.teacher_tokens = list(sample.tokens)
+            r = sample.response_length
+            assert len(sample.teacher_tokens) >= r, (
+                f"teacher_tokens shorter than response for sample {sample.index}"
+            )
+            if sample.teacher_gather_positions is not None:
+                # turnhint view: hint turns are interleaved INSIDE the response,
+                # so alignment rests on the position map -- pin that the mapped
+                # positions recover exactly the student's response tokens, fail
+                # loud before anything downstream can silently gather at the wrong
+                # rows.
+                positions = sample.teacher_gather_positions
+                t_resp = sample.teacher_response_length
+                assert t_resp is not None and t_resp >= r, (
+                    f"teacher_response_length ({t_resp}) must cover the student "
+                    f"response ({r}) for sample {sample.index}"
+                )
+                assert len(positions) == r, (
+                    f"teacher_gather_positions maps {len(positions)} tokens but the "
+                    f"student response has {r} for sample {sample.index}"
+                )
+                # Positions must be in-range, strictly increasing, duplicate-free:
+                # a negative index would wrap and (when the tokens happen to match)
+                # pass the content check below while silently selecting the wrong
+                # row in the gather; a duplicate would double-count its KL term.
+                assert all(0 <= p < t_resp for p in positions) and list(positions) == sorted(
+                    set(positions)
+                ), (
+                    f"teacher_gather_positions out of range or not strictly increasing "
+                    f"for sample {sample.index} (t_resp={t_resp})"
+                )
+                span = sample.teacher_tokens[len(sample.teacher_tokens) - t_resp :]
+                assert [span[p] for p in positions] == list(
+                    sample.tokens[len(sample.tokens) - r:]
+                ), (
+                    f"teacher view's mapped positions != student response tokens "
+                    f"for sample {sample.index} -- the spliced teacher view corrupted "
+                    "the student token subsequence"
+                )
+            else:
+                assert list(sample.teacher_tokens[len(sample.teacher_tokens) - r:]) == list(
+                    sample.tokens[len(sample.tokens) - r:]
+                ), f"teacher_tokens response suffix != tokens response suffix for sample {sample.index}"
+        train_data["teacher_tokens"] = [sample.teacher_tokens for sample in samples]
+        if any(sample.teacher_gather_positions is not None for sample in samples):
+            # Uniform batch representation: suffix-aligned samples get the
+            # identity map so downstream row-selects need no per-sample
+            # special-casing (an identity select is a semantic no-op).
+            train_data["teacher_gather_positions"] = [
+                sample.teacher_gather_positions
+                if sample.teacher_gather_positions is not None
+                else list(range(sample.response_length))
+                for sample in samples
+            ]
+            train_data["teacher_response_lengths"] = [
+                sample.teacher_response_length
+                if sample.teacher_response_length is not None
+                else sample.response_length
+                for sample in samples
+            ]
 
     x = metadata.get("dynamic_global_batch_size")
     assert args.use_dynamic_global_batch_size == (x is not None)
@@ -316,6 +402,9 @@ def _package_shards(args, data: dict[str, Any], partitions) -> list[dict[str, An
             "prompt",
             "teacher_log_probs",
             "opd_reverse_kl",
+            "teacher_tokens",
+            "teacher_gather_positions",
+            "teacher_response_lengths",
             "seq_witness_ids",
             "weight_versions",
             "adapter_slots",

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -431,6 +431,20 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                     "Allocate optimizer states on CPU during checkpoint loading to prevent GPU OOM on memory spike. "
                 ),
             )
+            parser.add_argument(
+                "--keep-logits-in-model-precision",
+                action="store_true",
+                default=False,
+                help=(
+                    "Do not let Megatron's Float16Module upcast the LM head's output to fp32. "
+                    "For an LM head that upcast allocates a full fp32 [S, V_local] copy of bf16 "
+                    "logits -- a multi-GiB allocation at long sequence lengths and the one that "
+                    "OOM'd long-sequence training runs -- and it is redundant: every vocab-wide consumer upcasts "
+                    "per chunk on its own, and bf16->fp32 is exact, so the chunk-wise values are "
+                    "bit-identical. Requires bf16 or fp16. Can also be enabled via MILES_BF16_LOGITS=1 "
+                    "in --train-env-vars."
+                ),
+            )
 
             return parser
 
@@ -1678,6 +1692,75 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
             )
             parser.add_argument(
                 "--opd-teacher-ckpt-step", type=int, default=None, help="The checkpoint step for OPD teacher model."
+            )
+            parser.add_argument(
+                "--opd-topk-in-trainer",
+                type=int,
+                default=0,
+                help=(
+                    "In-trainer top-k OPD: the actor's compute_log_prob pass "
+                    "also extracts per-position top-k logprobs (full-vocab log-softmax, "
+                    "TP allgather, no_grad), and the megatron OPD teacher -- forwarding "
+                    "the experience-augmented teacher view in Sample.teacher_tokens when "
+                    "present -- gathers at those ids; reverse KL (unnormalized student_p "
+                    "weights) lands in rollout_data['opd_reverse_kl']. Requires "
+                    "--opd-type=megatron. 0 disables."
+                ),
+            )
+            parser.add_argument(
+                "--opd-topk-placement",
+                type=str,
+                choices=["loss", "advantage"],
+                default="loss",
+                help=(
+                    "Where the in-trainer top-k OPD reverse KL enters the update. "
+                    "'loss' (default): a loss term differentiable "
+                    "through the student's current logits -- the training forward "
+                    "re-reads the student side at the precomputed top-k ids. "
+                    "'advantage': subtract it from the per-token advantage. This is "
+                    "REJECTED at validate time unless --opd-topk-in-trainer is 0, i.e. "
+                    "unless the OPD is the SAMPLED-TOKEN form, whose coefficient keeps "
+                    "the action inside A. With an in-trainer top-k the sum has already "
+                    "marginalized over the action, so "
+                    "E_a[A(r)*grad log pi(a|r)] = 0 -- an exact baseline that cannot "
+                    "teach and gets MORE perfect as k grows."
+                ),
+            )
+            parser.add_argument(
+                "--opd-pointwise-clip",
+                type=float,
+                default=0.0,
+                help=(
+                    "Cap each per-(position,k) contribution of the in-trainer OPD "
+                    "reverse KL at this value (0 disables). Guards against a single "
+                    "spike token dominating. The clipped fraction is logged as "
+                    "opd_clipfrac."
+                ),
+            )
+            parser.add_argument(
+                "--opd-topk-dist-comm",
+                action="store_true",
+                help=(
+                    "Use exact distributed top-k/gather for in-trainer OPD instead of "
+                    "the full-vocab TP allgather: per-rank logsumexp merge for the "
+                    "normalizer, ws*k candidate merge for top-k, masked all-reduce for "
+                    "the teacher gather. Same values (up to fp reduction order), "
+                    "~485x less TP traffic at V=248320/TP4/k=128."
+                ),
+            )
+            parser.add_argument(
+                "--opd-teacher-refresh-from-actor",
+                action="store_true",
+                help=(
+                    "After every update_weights(), re-backup the 'teacher' tag from the "
+                    "current (just-updated) actor instead of leaving it pinned at "
+                    "--opd-teacher-load forever. Makes the teacher == the 'old actor' "
+                    "relative to the NEXT rollout batch's gradient step -- matching what "
+                    "a self-scored teacher actually is (its rollout engine only picks up "
+                    "the new weights after the next update, so the teacher must follow "
+                    "the actor to stay on-policy). --opd-teacher-load is still required "
+                    "as the step-0 seed."
+                ),
             )
             return parser
 
@@ -2947,6 +3030,25 @@ def miles_validate_args(args):
             raise ValueError("--opd-log-prob-top-k must be non-negative.")
         if args.opd_log_prob_top_k > 0 and args.opd_type != "sglang":
             raise ValueError("--opd-log-prob-top-k is currently supported only with --opd-type=sglang.")
+        # Local import to keep miles.utils free of training imports at module load.
+        from miles.backends.training_utils.loss_hub.opd import validate_opd_topk_placement
+
+        validate_opd_topk_placement(args)
+        if args.opd_topk_in_trainer > 0 and args.opd_type != "megatron":
+            raise ValueError(
+                "--opd-topk-in-trainer requires --opd-type=megatron: the top-k ids are "
+                "extracted inside the trainer and the teacher gather runs in a megatron "
+                "teacher pass. With --opd-type=sglang the sampled-token teacher logprobs "
+                "would be silently discarded and the first training microbatch would fail."
+            )
+        if args.opd_teacher_refresh_from_actor and not (
+            args.opd_type == "megatron" and args.opd_teacher_load is not None
+        ):
+            raise ValueError(
+                "--opd-teacher-refresh-from-actor requires --opd-type=megatron with "
+                "--opd-teacher-load: the refresh re-backs-up the 'teacher' tag of the "
+                "colocated megatron teacher, which only exists in that configuration."
+            )
         if args.opd_teacher_urls:
             if args.opd_type != "sglang":
                 raise ValueError("--opd-teacher-urls is only supported with --opd-type=sglang.")

--- a/miles/utils/chat_template_utils/deepseek.py
+++ b/miles/utils/chat_template_utils/deepseek.py
@@ -56,6 +56,33 @@ def _inject_tools_into_system(messages: list[dict[str, Any]], tools: list[dict[s
     return out
 
 
+def _flatten_openai_content(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Flatten OpenAI-style list-of-blocks ``content`` to the plain string the
+    official encoders require (structured input rides ``content_blocks``, which
+    this leaves untouched). Text-only by contract: a non-text block on this
+    text-only model family is a routing bug upstream -- fail loud.
+    """
+    out = []
+    for m in messages:
+        c = m.get("content")
+        if isinstance(c, list):
+            parts = []
+            for b in c:
+                if isinstance(b, str):
+                    parts.append(b)
+                elif isinstance(b, dict) and b.get("type") == "text":
+                    parts.append(b.get("text", ""))
+                else:
+                    bt = b.get("type") if isinstance(b, dict) else type(b).__name__
+                    raise ValueError(
+                        f"deepseek bridge: unsupported content block {bt!r} in role="
+                        f"{m.get('role')!r} -- this family is text-only (blocks must be 'text')"
+                    )
+            m = {**m, "content": "\n\n".join(parts)}
+        out.append(m)
+    return out
+
+
 class DeepSeekFamily:
     """Shared behavior for the DeepSeek official-encoder families."""
 
@@ -96,6 +123,17 @@ class DeepSeekFamily:
         generation-ready tails; ``add_generation_prompt=False`` strips it.
         """
         encode_config = self._build_encode_config(kwargs)
+        # The official encoders expect `content` to be a plain STRING
+        # (structured input rides the separate `content_blocks` key).
+        # OpenAI-style clients send content as a LIST of blocks --
+        # unnormalized, encode_messages dies with a "expected str instance,
+        # list found" error. HF-jinja families flatten for free; this bridge
+        # must do it explicitly. Do NOT also pre-merge role=tool messages
+        # here: encode_messages calls merge_tool_messages itself, and that
+        # merge is NOT idempotent -- a second pass replaces an already-merged
+        # user's content_blocks with an empty text block (silent tool-result
+        # loss).
+        messages = _flatten_openai_content(messages)
         if tools:
             messages = _inject_tools_into_system(messages, tools)
         rendered = self.template.encode_messages(messages, **encode_config)

--- a/miles/utils/tensor_backper.py
+++ b/miles/utils/tensor_backper.py
@@ -153,6 +153,27 @@ class _TensorBackuperMainCast(TensorBackuper):
             out[name] = backup
         return out
 
+    @torch.no_grad()
+    def copy(self, *, src_tag: str, dst_tag: str) -> None:
+        """Copy one tag's contents into another tag's pinned backup.
+
+        Only non-actor tags exist as pinned copies under main-cast (the actor
+        tag is rebuilt from master weights, never stored), so dst_tag="actor"
+        is refused. src_tag="actor" reads the current actor weights through
+        get() -- the same asleep-window-safe assembly the weight updater reads
+        (extras from the pinned backup, DDP param buffers live and mapped).
+        """
+        if dst_tag == "actor":
+            raise NotImplementedError(
+                "cannot copy into the 'actor' tag under main-cast weight rebuild: "
+                "the actor has no pinned copy to write into"
+            )
+        src = self.get(src_tag) if src_tag == "actor" else self._others.get(src_tag)
+        dst = self._others.get(dst_tag)
+        for name in dst:
+            dst[name].copy_(src[name])
+        torch.cuda.synchronize()
+
     def _compute_hashes(self) -> dict[str, str]:
         return {name: _hash_tensor_sha256(tensor) for name, tensor in self._source_getter()}
 

--- a/miles/utils/types.py
+++ b/miles/utils/types.py
@@ -53,6 +53,18 @@ class Sample:
     remove_sample: bool = False
     teacher_log_probs: list[float] | None = None  # Log probabilities from teacher model for OPD
     opd_reverse_kl: list[float] | None = None  # Precomputed per-token OPD reverse-KL estimate
+    # "turnhint" = a teacher view in which hint turns are interleaved INSIDE the
+    # response span (as opposed to prefix-only, suffix-aligned augmentation).
+    teacher_tokens: list[int] | None = None  # Experience-augmented teacher view for in-trainer OPD:
+    # privileged_prefix + response; MUST end with the same response tokens as `tokens`
+    # (the response-suffix alignment the OPD KL rests on -- asserted at train-data conversion)
+    # -- UNLESS teacher_gather_positions is set (turnhint views; alignment then
+    # rests on the position map below).
+    teacher_gather_positions: list[int] | None = None  # turnhint view: for each of the
+    # student's response tokens (in order), its position within the teacher view's OWN
+    # response span. None = suffix-aligned teacher view (begin/end/user_turn placements).
+    teacher_response_length: int | None = None  # length of the teacher view's response
+    # span (>= response_length when hint turns are interleaved). None = response_length.
 
     class Status(Enum):
         PENDING = "pending"
@@ -231,6 +243,31 @@ class Sample:
             self.rollout_log_probs = self.rollout_log_probs[:-n]
         if self.teacher_log_probs is not None:
             self.teacher_log_probs = self.teacher_log_probs[:-n]
+        if self.teacher_tokens is not None:
+            if self.teacher_gather_positions is not None:
+                # turnhint view: drop the last n student positions from the map
+                # and cut the teacher view at the first dropped student token's own
+                # position -- everything after it (including any interleaved hint
+                # turns for dropped calls) belongs to the stripped tail.
+                keep = len(self.teacher_gather_positions) - n
+                assert keep >= 0, (
+                    f"cannot strip {n} tokens: teacher_gather_positions only "
+                    f"maps {len(self.teacher_gather_positions)}"
+                )
+                teacher_resp = self.teacher_response_length
+                assert teacher_resp is not None, (
+                    "teacher_gather_positions set without teacher_response_length"
+                )
+                positions = self.teacher_gather_positions
+                cut = positions[keep] if keep < len(positions) else teacher_resp
+                self.teacher_tokens = self.teacher_tokens[: len(self.teacher_tokens) - (teacher_resp - cut)]
+                self.teacher_response_length = cut
+                self.teacher_gather_positions = self.teacher_gather_positions[:keep]
+            else:
+                # contract above: teacher_tokens MUST end with the same response
+                # suffix as `tokens` -- trimming tokens without it breaks the
+                # OPD suffix alignment asserted at train-data conversion.
+                self.teacher_tokens = self.teacher_tokens[:-n]
         if self.opd_reverse_kl is not None:
             self.opd_reverse_kl = self.opd_reverse_kl[:-n]
         if self.metadata and "opd_student_top_logprobs" in self.metadata:

--- a/miles_plugins/models/deepseek_v4/ops/kernel/tilelang_indexer_fwd.py
+++ b/miles_plugins/models/deepseek_v4/ops/kernel/tilelang_indexer_fwd.py
@@ -192,3 +192,47 @@ def batched_indexer_fwd(q, k, weights, cu_seqlen_ks, cu_seqlen_ke):
             cu_seqlen_ke,
         )
     return all_logits
+
+
+def batched_indexer_topk_chunked(q, k, weights, cu_seqlen_ks, cu_seqlen_ke, topk_fn, topk_count, q_chunk):
+    """Chunked forward+topk fusion: never materializes the full [seqlen, seqlen_kv]
+    logits tensor. Peak memory is O(q_chunk * seqlen_kv) instead of O(seqlen * seqlen_kv).
+
+    Mathematically identical to calling `batched_indexer_fwd` followed by `topk_fn`
+    on the full result: topk is row-independent (each output row depends only on
+    that row's own logits, which depend only on that row's own q/weights/cu_seqlens),
+    so chunking the query dimension cannot change any row's result.
+
+    No intermediate buffer is pre-allocated/reused across chunks --
+    `indexer_fwd_interface` allocates its own (chunk, seqlen_kv) logits tensor per
+    call (same as the unchunked path), which is consumed by `topk_fn` and then
+    freed; only one chunk's logits are ever live at once.
+
+    Args:
+        q: [seqlen, batch, heads, dim] bf16
+        k: [seqlen_kv, batch, dim] bf16
+        weights: [seqlen, batch, heads] fp32
+        cu_seqlen_ks: [seqlen] int32
+        cu_seqlen_ke: [seqlen] int32
+        topk_fn: e.g. torch_dsa_topk / flashinfer_dsa_topk (same backend as the unchunked path)
+        topk_count: int
+        q_chunk: int, query-dimension chunk size
+
+    Returns:
+        topk_indices: [batch, seqlen, topk_count] int32
+    """
+    seqlen, batch, heads, dim = q.shape
+
+    topk_indices = torch.empty(batch, seqlen, topk_count, device=q.device, dtype=torch.int32)
+    for b0 in range(0, seqlen, q_chunk):
+        b1 = min(b0 + q_chunk, seqlen)
+        for b in range(batch):
+            logits_chunk = indexer_fwd_interface(
+                q[b0:b1, b, :, :].contiguous(),
+                k[:, b, :].contiguous(),
+                weights[b0:b1, b, :].contiguous(),
+                cu_seqlen_ks[b0:b1],
+                cu_seqlen_ke[b0:b1],
+            )
+            topk_indices[b, b0:b1] = topk_fn(logits_chunk, topk_count)
+    return topk_indices

--- a/miles_plugins/models/deepseek_v4/ops/v4_indexer.py
+++ b/miles_plugins/models/deepseek_v4/ops/v4_indexer.py
@@ -1,3 +1,5 @@
+import os
+
 import einops
 import torch
 from megatron.core import parallel_state
@@ -12,11 +14,21 @@ from miles_plugins.models.deepseek_v4.ops.cp_utils import all_gather_cp, get_fre
 from miles_plugins.models.deepseek_v4.ops.kernel.tilelang_indexer_fwd import (
     _make_causal_cu_seqlens,
     batched_indexer_fwd,
+    batched_indexer_topk_chunked,
 )
 from miles_plugins.models.deepseek_v4.ops.qat import fp8_simulate_qat
 from miles_plugins.models.deepseek_v4.ops.rope import apply_rotary_emb, wrapped_precompute_freqs_cis
 from miles_plugins.models.deepseek_v4.ops.utils import rotate_activation
 from miles_plugins.models.dsa_topk import get_dsa_topk_fn
+
+# ctx128k indexer OOM workaround: the unchunked path materializes a full
+# [seqlen_global, seqlen_kv] fp32 logits tensor (S^2/compress_ratio bytes), which
+# OOMs at long context. Above this byte threshold, use the chunked fwd+topk fusion
+# instead (peak O(q_chunk * seqlen_kv) instead of O(seqlen_global * seqlen_kv)).
+# Bit-exact equivalence with the unchunked path is required; do not change the
+# threshold without re-verifying equivalence at the new target shape.
+_INDEXER_CHUNK_THRESHOLD_BYTES = int(os.environ.get("V4_INDEXER_CHUNK_THRESHOLD_BYTES", 8 * (1024**3)))
+_INDEXER_CHUNK_Q = int(os.environ.get("V4_INDEXER_CHUNK_Q", "8192"))
 
 
 class V4Indexer(MegatronModule):
@@ -128,9 +140,27 @@ class V4Indexer(MegatronModule):
             cp_rank = cp_group.rank()
             cu_ks = cu_ks[cp_rank * seqlen : (cp_rank + 1) * seqlen]
             cu_ke = cu_ke[cp_rank * seqlen : (cp_rank + 1) * seqlen]
-        index_scores = batched_indexer_fwd(q, k, weights.float(), cu_ks, cu_ke)
+        weights = weights.float()
+        # Full size across all batch elements (matches batched_indexer_fwd's
+        # all_logits = torch.empty([bsz, seqlen_global, seqlen_kv], ...) pre-allocation) --
+        # must include bsz, else the threshold under-estimates and stays too
+        # permissive when bsz > 1.
+        full_logits_bytes = bsz * seqlen_global * seqlen_kv * 4  # fp32
 
-        topk_count = min(self.index_topk, index_scores.size(-1))
-        topk_indices = get_dsa_topk_fn(self.topk_backend)(index_scores, topk_count)
+        if full_logits_bytes > _INDEXER_CHUNK_THRESHOLD_BYTES:
+            topk_indices = batched_indexer_topk_chunked(
+                q,
+                k,
+                weights,
+                cu_ks,
+                cu_ke,
+                topk_fn=get_dsa_topk_fn(self.topk_backend),
+                topk_count=min(self.index_topk, seqlen_kv),
+                q_chunk=_INDEXER_CHUNK_Q,
+            )
+        else:
+            index_scores = batched_indexer_fwd(q, k, weights, cu_ks, cu_ke)
+            topk_count = min(self.index_topk, index_scores.size(-1))
+            topk_indices = get_dsa_topk_fn(self.topk_backend)(index_scores, topk_count)
 
         return topk_indices

--- a/tests/fast-gpu/test_v4_indexer_chunked_topk.py
+++ b/tests/fast-gpu/test_v4_indexer_chunked_topk.py
@@ -1,0 +1,196 @@
+"""Chunked DSV4 indexer fwd+topk is bit-exact against the unchunked path.
+
+The unchunked path pre-allocates ``[batch, seqlen_global, seqlen_kv]`` fp32 --
+35.25 GiB at S=194560, 64.0 GiB at S=262144 -- which is the ctx128k indexer
+OOM. Above a byte threshold ``V4Indexer.forward`` switches to
+``batched_indexer_topk_chunked``, whose peak is
+``O(q_chunk * seqlen_kv)``.
+
+The equivalence argument is that top-k is row-independent: output row ``p``
+depends only on that row's logits, which depend only on ``q[p]``,
+``weights[p]``, ``cu_seqlen_ks[p]``, ``cu_seqlen_ke[p]`` and all of ``k``.
+Chunking the query dimension therefore cannot change any row. Reductions run
+over ``dim``/``heads``, never over the query axis, so this is claimed as
+BIT-exact rather than merely close -- and asserted that way here, on real
+kernels on a real GPU. A CPU mock cannot substitute: the whole risk is that
+the tilelang kernel behaves differently on a sliced/contiguous-ified query
+tensor than on the full one.
+"""
+
+from __future__ import annotations
+
+from tests.ci.ci_register import register_cuda_ci
+
+# One GPU is enough; stage-b-2-gpu-h200 is the always-run GPU bucket its
+# fast-gpu siblings use (tests/ci/run_suite.py), so this lands in CI rather
+# than in a suite name nothing schedules.
+register_cuda_ci(est_time=180, suite="stage-b-2-gpu-h200", labels=[])
+
+import pytest
+import torch
+
+try:
+    import tilelang  # noqa: F401
+except ImportError:
+    tilelang = None
+
+if tilelang is not None:
+    from miles_plugins.models.deepseek_v4.ops.kernel.tilelang_indexer_fwd import (
+        _make_causal_cu_seqlens,
+        batched_indexer_fwd,
+        batched_indexer_topk_chunked,
+    )
+    from miles_plugins.models.dsa_topk import get_dsa_topk_fn
+else:
+    _make_causal_cu_seqlens = batched_indexer_fwd = batched_indexer_topk_chunked = get_dsa_topk_fn = None
+
+
+requires_gpu = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+requires_tilelang = pytest.mark.skipif(tilelang is None, reason="tilelang not installed")
+
+
+def _make_inputs(seqlen, batch, heads, dim, compress_ratio, seed=0):
+    torch.manual_seed(seed)
+    seqlen_kv = seqlen // compress_ratio
+    q = torch.randn(seqlen, batch, heads, dim, device="cuda", dtype=torch.bfloat16)
+    k = torch.randn(seqlen_kv, batch, dim, device="cuda", dtype=torch.bfloat16)
+    weights = torch.randn(seqlen, batch, heads, device="cuda", dtype=torch.float32) * 0.01
+    cu_ks, cu_ke = _make_causal_cu_seqlens(seqlen, seqlen_kv, compress_ratio, q.device)
+    return q, k, weights, cu_ks, cu_ke, seqlen_kv
+
+
+def _unchunked(q, k, weights, cu_ks, cu_ke, topk_fn, topk_count):
+    index_scores = batched_indexer_fwd(q, k, weights, cu_ks, cu_ke)
+    return topk_fn(index_scores, topk_count)
+
+
+# (seqlen, batch, heads, dim, compress_ratio, topk, q_chunk)
+_CONFIGS = [
+    # q_chunk divides seqlen exactly
+    (512, 1, 8, 128, 4, 64, 128),
+    (512, 2, 8, 128, 4, 64, 256),
+    # q_chunk does NOT divide seqlen -- a ragged last chunk is the boundary case
+    (512, 1, 8, 128, 4, 64, 200),
+    (384, 2, 16, 128, 4, 32, 100),
+    # one chunk covering everything: must degenerate to the unchunked answer
+    (256, 1, 8, 128, 4, 32, 256),
+    # chunk larger than seqlen
+    (256, 1, 8, 128, 4, 32, 4096),
+    # q_chunk == 1: the pathological extreme
+    (64, 1, 8, 128, 4, 8, 1),
+    # C128 layer type: tiny KV, so topk exceeds the valid range for most rows
+    # and the -1 padding path is the one under test
+    (1024, 1, 16, 128, 128, 8, 256),
+    (256, 1, 8, 128, 128, 2, 64),
+]
+_IDS = [f"sq{s}_b{b}_h{h}_cr{cr}_top{tk}_qc{qc}" for s, b, h, _, cr, tk, qc in _CONFIGS]
+
+
+@requires_gpu
+@requires_tilelang
+@pytest.mark.parametrize("seqlen,batch,heads,dim,compress_ratio,topk,q_chunk", _CONFIGS, ids=_IDS)
+def test_chunked_topk_is_bit_exact(seqlen, batch, heads, dim, compress_ratio, topk, q_chunk):
+    q, k, weights, cu_ks, cu_ke, seqlen_kv = _make_inputs(seqlen, batch, heads, dim, compress_ratio)
+    topk_fn = get_dsa_topk_fn("torch")
+    topk_count = min(topk, seqlen_kv)
+
+    expected = _unchunked(q, k, weights, cu_ks, cu_ke, topk_fn, topk_count)
+    got = batched_indexer_topk_chunked(
+        q, k, weights, cu_ks, cu_ke, topk_fn=topk_fn, topk_count=topk_count, q_chunk=q_chunk
+    )
+
+    assert got.shape == expected.shape
+    assert got.dtype == expected.dtype == torch.int32
+    assert torch.equal(got, expected), (
+        "chunked indexer top-k diverged from the unchunked path: "
+        f"{(got != expected).sum().item()} of {expected.numel()} indices differ"
+    )
+
+
+@requires_gpu
+@requires_tilelang
+def test_row_order_is_preserved_across_chunk_boundaries():
+    """A transposed or off-by-one chunk write would still produce a
+    plausible-looking tensor; compare row by row so the failure names the row."""
+    seqlen, batch, heads, dim, compress_ratio, topk, q_chunk = 512, 2, 8, 128, 4, 64, 150
+    q, k, weights, cu_ks, cu_ke, seqlen_kv = _make_inputs(seqlen, batch, heads, dim, compress_ratio, seed=7)
+    topk_fn = get_dsa_topk_fn("torch")
+    topk_count = min(topk, seqlen_kv)
+
+    expected = _unchunked(q, k, weights, cu_ks, cu_ke, topk_fn, topk_count)
+    got = batched_indexer_topk_chunked(
+        q, k, weights, cu_ks, cu_ke, topk_fn=topk_fn, topk_count=topk_count, q_chunk=q_chunk
+    )
+
+    for b in range(batch):
+        for p in range(seqlen):
+            assert torch.equal(got[b, p], expected[b, p]), f"row differs at batch={b}, query position={p}"
+
+
+@requires_gpu
+@requires_tilelang
+def test_shape_and_topk_count_are_exactly_as_requested():
+    seqlen, batch, heads, dim, compress_ratio = 512, 3, 8, 128, 4
+    q, k, weights, cu_ks, cu_ke, seqlen_kv = _make_inputs(seqlen, batch, heads, dim, compress_ratio, seed=3)
+    topk_count = 37  # deliberately not a power of two and not a chunk divisor
+
+    got = batched_indexer_topk_chunked(
+        q, k, weights, cu_ks, cu_ke, topk_fn=get_dsa_topk_fn("torch"), topk_count=topk_count, q_chunk=128
+    )
+
+    assert got.shape == (batch, seqlen, topk_count)
+    assert got.dtype == torch.int32
+    assert got.device == q.device
+
+
+@requires_gpu
+@requires_tilelang
+def test_causally_masked_rows_are_padded_with_minus_one():
+    """Early query positions have fewer valid compressed groups than ``topk``.
+    Both paths mask those slots to -1; a chunked path that lost the mask would
+    emit arbitrary in-range indices and silently widen attention."""
+    seqlen, batch, heads, dim, compress_ratio, topk = 256, 1, 8, 128, 4, 64
+    q, k, weights, cu_ks, cu_ke, seqlen_kv = _make_inputs(seqlen, batch, heads, dim, compress_ratio, seed=11)
+    topk_fn = get_dsa_topk_fn("torch")
+
+    got = batched_indexer_topk_chunked(
+        q, k, weights, cu_ks, cu_ke, topk_fn=topk_fn, topk_count=topk, q_chunk=64
+    )
+
+    # query position p sees compressed groups [0, (p+1)//compress_ratio) -- so
+    # p=0 sees NONE and its whole row must be -1.
+    for p in (0, 1, 10, 63):
+        expected_valid = min((p + 1) // compress_ratio, topk)
+        row = got[0, p]
+        assert int((row != -1).sum()) == expected_valid, f"row {p}: expected {expected_valid} valid slots"
+        if expected_valid:
+            assert int(row[:expected_valid].min()) >= 0, f"row {p}: valid slots must come first"
+        else:
+            assert int((row == -1).sum()) == topk, f"row {p}: a fully masked row must be all -1"
+
+
+@requires_gpu
+@requires_tilelang
+def test_peak_memory_stays_below_the_unchunked_allocation():
+    """The reason the chunked path exists. Measured, not asserted structurally:
+    a chunked loop that still allocated the full tensor somewhere (e.g. a
+    reused buffer sized to seqlen) would pass every equivalence test above.
+    """
+    seqlen, batch, heads, dim, compress_ratio, topk, q_chunk = 4096, 1, 8, 128, 4, 128, 256
+    q, k, weights, cu_ks, cu_ke, seqlen_kv = _make_inputs(seqlen, batch, heads, dim, compress_ratio, seed=5)
+    topk_fn = get_dsa_topk_fn("torch")
+    full_logits_bytes = batch * seqlen * seqlen_kv * 4
+
+    torch.cuda.synchronize()
+    torch.cuda.reset_peak_memory_stats()
+    base = torch.cuda.memory_allocated()
+    batched_indexer_topk_chunked(
+        q, k, weights, cu_ks, cu_ke, topk_fn=topk_fn, topk_count=min(topk, seqlen_kv), q_chunk=q_chunk
+    )
+    torch.cuda.synchronize()
+    chunked_peak = torch.cuda.max_memory_allocated() - base
+
+    assert chunked_peak < full_logits_bytes, (
+        f"chunked peak {chunked_peak} B is not below the full logits tensor {full_logits_bytes} B -- "
+        "something is still materializing the quadratic score matrix"
+    )

--- a/tests/fast/backends/training_utils/loss/test_opd_topk_distill_loss.py
+++ b/tests/fast/backends/training_utils/loss/test_opd_topk_distill_loss.py
@@ -1,0 +1,563 @@
+"""The loss placement of the in-trainer top-k OPD reverse KL.
+
+Context: the top-k reverse KL was being subtracted from the ADVANTAGE. The top-k
+sum has already marginalized over the action, so `rkl[r]` is the same number
+whichever token was sampled at r, and in
+`E_a[A(r)*grad log pi(a|r)] = A(r)*E_a[grad log pi] = 0` it acts as a baseline --
+raising k makes it a *more perfect* baseline, not a stronger teacher. Putting the
+same top-k KL in the LOSS instead, differentiable through the student's current
+logits, makes it teach. These tests pin the loss placement.
+
+The `--opd-topk-placement advantage` path is retained only as the ablation
+control, and its behaviour is pinned here too so a future refactor cannot
+silently swap the two.
+"""
+
+import math
+from argparse import Namespace
+
+import pytest
+import torch
+
+from miles.backends.training_utils.cp_utils import get_sum_of_sample_mean
+from miles.backends.training_utils.loss import compute_advantages_and_returns
+from miles.backends.training_utils.loss_hub.losses import policy_loss_function
+from miles.backends.training_utils.loss_hub.math_utils import calculate_opd_gather_with_grad, calculate_opd_topk
+from miles.backends.training_utils.loss_hub.opd import compute_opd_topk_distill, validate_opd_topk_placement
+
+from .loss_test_utils import make_args, make_parallel_state
+
+
+@pytest.fixture(autouse=True)
+def _parallel_state():
+    """Single-process TP=1/CP=1 state; `compute_opd_topk_distill` reads tp.group."""
+    make_parallel_state()
+
+
+def _reference_gathered_log_probs(logits: torch.Tensor, ids: torch.Tensor, vocab_size: int | None = None):
+    full = logits.float() if vocab_size is None else logits.float()[..., :vocab_size]
+    return torch.log_softmax(full, dim=-1).gather(-1, ids)
+
+
+# ---------------------------------------------------------------------------
+# the differentiable gather primitive
+# ---------------------------------------------------------------------------
+
+
+def test_gather_with_grad_matches_full_log_softmax():
+    torch.manual_seed(0)
+    logits = torch.randn(7, 32)
+    ids = torch.randint(0, 32, (7, 5))
+
+    got = calculate_opd_gather_with_grad(logits, None, gather_ids=ids)
+
+    assert torch.allclose(got, _reference_gathered_log_probs(logits, ids), atol=1e-6)
+
+
+def test_gather_with_grad_flows_to_logits():
+    torch.manual_seed(0)
+    logits = torch.randn(7, 32, requires_grad=True)
+    ids = torch.randint(0, 32, (7, 5))
+
+    calculate_opd_gather_with_grad(logits, None, gather_ids=ids).sum().backward()
+
+    assert logits.grad is not None
+    assert torch.isfinite(logits.grad).all()
+    assert logits.grad.abs().sum() > 0
+
+
+def test_gather_with_grad_gradient_matches_autograd_reference():
+    torch.manual_seed(0)
+    base = torch.randn(4, 16)
+    ids = torch.randint(0, 16, (4, 3))
+
+    a = base.clone().requires_grad_(True)
+    calculate_opd_gather_with_grad(a, None, gather_ids=ids).pow(2).sum().backward()
+
+    b = base.clone().requires_grad_(True)
+    _reference_gathered_log_probs(b, ids).pow(2).sum().backward()
+
+    assert torch.allclose(a.grad, b.grad, atol=1e-6)
+
+
+def test_gather_with_grad_respects_vocab_padding():
+    torch.manual_seed(0)
+    logits = torch.randn(4, 32, requires_grad=True)
+    ids = torch.randint(0, 20, (4, 3))
+
+    got = calculate_opd_gather_with_grad(logits, None, gather_ids=ids, vocab_size=20)
+
+    assert torch.allclose(got, _reference_gathered_log_probs(logits, ids, vocab_size=20), atol=1e-6)
+    got.sum().backward()
+    assert torch.isfinite(logits.grad).all()
+    # the tail contributed nothing, so it receives no gradient
+    assert logits.grad[:, 20:].abs().max() == 0.0
+
+
+@pytest.mark.parametrize("chunk_size", [1, 3, 7, 64, -1])
+def test_gather_with_grad_is_invariant_to_the_row_chunk_size(chunk_size):
+    """Chunking bounds the transient [R, V] fp32 upcast; it must not change the
+    answer or the gradient.
+    """
+    torch.manual_seed(0)
+    base = torch.randn(7, 32)
+    ids = torch.randint(0, 32, (7, 5))
+
+    a = base.clone().requires_grad_(True)
+    got = calculate_opd_gather_with_grad(a, None, gather_ids=ids, chunk_size=chunk_size)
+    got.pow(2).sum().backward()
+
+    b = base.clone().requires_grad_(True)
+    _reference_gathered_log_probs(b, ids).pow(2).sum().backward()
+
+    assert torch.allclose(got, _reference_gathered_log_probs(base, ids), atol=1e-6)
+    assert torch.allclose(a.grad, b.grad, atol=1e-6)
+
+
+def test_gather_with_grad_does_not_retain_a_full_vocab_activation():
+    """The [R, V] fp32 upcast must be transient, not saved for backward.
+
+    Counts fp32 tensors of full-vocab width reachable from the autograd graph:
+    the checkpointed forward should keep only the [R] normalizer and the [R, K]
+    output, never an [R, V] block.
+    """
+    torch.manual_seed(0)
+    rows, vocab = 64, 512
+    logits = torch.randn(rows, vocab, dtype=torch.bfloat16, requires_grad=True)
+
+    out = calculate_opd_gather_with_grad(
+        logits, None, gather_ids=torch.randint(0, vocab, (rows, 4)), chunk_size=8
+    )
+
+    saved = []
+    seen, stack = set(), [out.grad_fn]
+    while stack:
+        fn = stack.pop()
+        if fn is None or id(fn) in seen:
+            continue
+        seen.add(id(fn))
+        for attr in dir(fn):
+            if attr.startswith("_saved"):
+                val = getattr(fn, attr, None)
+                if torch.is_tensor(val):
+                    saved.append(val)
+        stack.extend(nxt for nxt, _ in fn.next_functions)
+    big_fp32 = [t for t in saved if torch.is_tensor(t) and t.dtype == torch.float32 and t.numel() >= rows * vocab]
+    assert not big_fp32, f"an [R, V] fp32 activation is retained for backward: {[tuple(t.shape) for t in big_fp32]}"
+
+
+@pytest.mark.parametrize("vocab_size", [None, 20, 8, 0])
+def test_gather_with_grad_stays_finite_across_every_padding_regime(vocab_size):
+    """Including a FULLY padded shard (vocab_size=0 => n_valid=0).
+
+    The differentiable path floors the padded tail with
+    `torch.finfo(dtype).min` while the no_grad twin uses `float("-inf")`, so the
+    fully-padded shard is exactly where the two could part company. What matters
+    for THIS path is that it never emits a non-finite value or gradient, which is
+    what the finite floor is for -- pinned here for all four regimes.
+    """
+    torch.manual_seed(0)
+    rows, vocab = 6, 32
+    logits = torch.randn(rows, vocab, requires_grad=True)
+    ids = torch.randint(0, 8, (rows, 4))
+
+    out = calculate_opd_gather_with_grad(logits, None, gather_ids=ids, vocab_size=vocab_size)
+    out.sum().backward()
+
+    assert torch.isfinite(out).all()
+    assert torch.isfinite(logits.grad).all()
+
+
+@pytest.mark.parametrize("vocab_size", [None, 20, 8])
+def test_padding_does_not_widen_the_gap_to_the_no_grad_twin(vocab_size):
+    """The two paths agree to fp32 rounding, and padding does not make it worse.
+
+    They are NOT bit-identical on this (full-gather) formulation: the no_grad
+    twin does `log_softmax` then gather, this one does `x[id] - logsumexp`, and
+    fp32 reassociation costs ~2-5e-7. This test pins the weaker, universally-true
+    property: the disagreement is rounding-scale and is not amplified by the
+    padded tail.
+    """
+    torch.manual_seed(0)
+    rows, vocab = 6, 32
+    logits = torch.randn(rows, vocab)
+    ids = torch.randint(0, 8, (rows, 4))
+
+    grad_path = calculate_opd_gather_with_grad(logits.clone(), None, gather_ids=ids, vocab_size=vocab_size)
+    no_grad_path = calculate_opd_topk(logits.clone(), None, gather_ids=ids, vocab_size=vocab_size)["gathered"]
+
+    assert torch.allclose(grad_path, no_grad_path, atol=1e-6)
+
+
+def test_distill_term_honours_the_loss_mask_exactly_like_pg_loss():
+    """`opd_kl_coef`'s effective scale must be reducer/mask-identical to pg_loss."""
+    args, batch, logits, _ = _policy_loss_case("loss")
+    masks = [torch.tensor([1.0, 1.0, 0.0]), torch.tensor([1.0, 0.0])]
+    batch["loss_masks"] = masks
+    reducer = get_sum_of_sample_mean(batch["total_lengths"], batch["response_lengths"], masks, False, "thd", None)
+
+    _, log_a = policy_loss_function(args, batch, logits, reducer)
+    # make the MASKED positions disagree wildly with the teacher
+    batch["teacher_opd_gathered_vals"] = [t.clone() for t in batch["teacher_opd_gathered_vals"]]
+    batch["teacher_opd_gathered_vals"][0][2] = -50.0
+    batch["teacher_opd_gathered_vals"][1][1] = -50.0
+    _, log_b = policy_loss_function(args, batch, logits, reducer)
+
+    assert torch.allclose(log_a["opd_distill_loss"], log_b["opd_distill_loss"], atol=1e-6)
+
+
+def test_gather_empty_response_returns_empty_without_nan():
+    logits = torch.zeros(0, 32, requires_grad=True)
+    ids = torch.zeros(0, 5, dtype=torch.long)
+
+    got = calculate_opd_gather_with_grad(logits, None, gather_ids=ids)
+
+    assert got.shape == (0, 5)
+
+
+# ---------------------------------------------------------------------------
+# the distillation term: it must actually teach
+# ---------------------------------------------------------------------------
+
+
+def _distill_args(**overrides) -> Namespace:
+    d = dict(
+        qkv_format="thd",
+        rollout_temperature=1.0,
+        allgather_cp=False,
+        true_on_policy_mode=False,
+        log_probs_chunk_size=-1,
+        opd_pointwise_clip=0.0,
+        vocab_size=None,
+    )
+    d.update(overrides)
+    return Namespace(**d)
+
+
+def _single_sample_batch(logits: torch.Tensor, ids: torch.Tensor, teacher_vals: torch.Tensor) -> dict:
+    """One sample whose whole sequence is the response (prompt length 0 is not
+    representable -- `get_responses` reads logits[start-1:end-1], so give it one
+    prompt token)."""
+    response_length = ids.size(0)
+    total_length = response_length + 1
+    return {
+        "unconcat_tokens": [torch.zeros(total_length, dtype=torch.long)],
+        "total_lengths": [total_length],
+        "response_lengths": [response_length],
+        "opd_topk_ids": [ids],
+        "teacher_opd_gathered_vals": [teacher_vals],
+    }
+
+
+def test_distill_gradient_step_reduces_the_reverse_kl_to_the_teacher():
+    """The whole point: descending this loss moves the student TOWARD the teacher."""
+    torch.manual_seed(0)
+    vocab, response_length, k = 24, 6, 4
+    args = _distill_args()
+
+    teacher_log_probs = torch.log_softmax(torch.randn(response_length, vocab) * 2.0, dim=-1)
+    logits = torch.randn(1, response_length + 1, vocab, requires_grad=True)
+
+    with torch.no_grad():
+        student_lp = torch.log_softmax(logits[0, :-1], dim=-1)
+        ids = student_lp.topk(k, dim=-1).indices
+    teacher_vals = teacher_log_probs.gather(-1, ids)
+    batch = _single_sample_batch(logits, ids, teacher_vals)
+
+    def reverse_kl_now(current: torch.Tensor) -> float:
+        with torch.no_grad():
+            s = torch.log_softmax(current[0, :-1], dim=-1).gather(-1, ids)
+            return (s.exp() * (s - teacher_vals)).sum(-1).mean().item()
+
+    before = reverse_kl_now(logits)
+    for _ in range(20):
+        rkls = compute_opd_topk_distill(args, batch, logits)
+        loss = torch.cat(rkls).mean()
+        grad = torch.autograd.grad(loss, logits)[0]
+        with torch.no_grad():
+            logits -= 1.0 * grad
+    after = reverse_kl_now(logits)
+
+    assert after < before - 1e-4, f"distillation did not move the student: {before} -> {after}"
+
+
+def test_distill_is_zero_when_the_teacher_equals_the_student():
+    torch.manual_seed(0)
+    vocab, response_length, k = 16, 5, 3
+    args = _distill_args()
+    logits = torch.randn(1, response_length + 1, vocab)
+    student_lp = torch.log_softmax(logits[0, :-1], dim=-1)
+    ids = student_lp.topk(k, dim=-1).indices
+    batch = _single_sample_batch(logits, ids, student_lp.gather(-1, ids))
+
+    rkls = compute_opd_topk_distill(args, batch, logits)
+
+    assert torch.allclose(torch.cat(rkls), torch.zeros(response_length), atol=1e-6)
+
+
+def test_distill_returns_one_response_aligned_tensor_per_sample():
+    torch.manual_seed(0)
+    vocab, k = 16, 3
+    args = _distill_args()
+    response_lengths = [4, 2]
+    total_lengths = [rl + 3 for rl in response_lengths]
+    logits = torch.randn(1, sum(total_lengths), vocab)
+    ids = [torch.randint(0, vocab, (rl, k)) for rl in response_lengths]
+    teacher_vals = [torch.full((rl, k), -math.log(vocab)) for rl in response_lengths]
+    batch = {
+        "unconcat_tokens": [torch.zeros(tl, dtype=torch.long) for tl in total_lengths],
+        "total_lengths": total_lengths,
+        "response_lengths": response_lengths,
+        "opd_topk_ids": ids,
+        "teacher_opd_gathered_vals": teacher_vals,
+    }
+
+    rkls = compute_opd_topk_distill(args, batch, logits)
+
+    assert [tuple(r.shape) for r in rkls] == [(4,), (2,)]
+
+
+def test_distill_fails_loud_when_the_teacher_gather_is_missing():
+    args = _distill_args()
+    logits = torch.randn(1, 5, 16)
+    batch = _single_sample_batch(logits, torch.zeros(4, 3, dtype=torch.long), torch.zeros(4, 3))
+    del batch["teacher_opd_gathered_vals"]
+
+    with pytest.raises(ValueError, match="teacher_opd_gathered_vals"):
+        compute_opd_topk_distill(args, batch, logits)
+
+
+# ---------------------------------------------------------------------------
+# the launch gate: top-k + advantage is not a configuration, it is the bug
+# ---------------------------------------------------------------------------
+
+
+def _validate_case(**overrides) -> Namespace:
+    d = dict(use_opd=True, opd_type="megatron", opd_topk_in_trainer=256, opd_topk_placement="loss")
+    d.update(overrides)
+    return Namespace(**d)
+
+
+def test_validate_rejects_topk_on_the_advantage_side():
+    """The one combination that provably cannot teach must not be launchable."""
+    with pytest.raises(ValueError, match="sampled-token"):
+        validate_opd_topk_placement(_validate_case(opd_topk_placement="advantage"))
+
+
+def test_validate_allows_advantage_for_the_sampled_token_path():
+    validate_opd_topk_placement(_validate_case(opd_topk_in_trainer=0, opd_topk_placement="advantage"))
+
+
+def test_validate_allows_the_loss_placement_with_topk():
+    validate_opd_topk_placement(_validate_case())
+
+
+def test_validate_is_a_noop_without_opd():
+    validate_opd_topk_placement(_validate_case(use_opd=False, opd_topk_placement="advantage"))
+
+
+def test_validate_rejects_an_unknown_placement():
+    with pytest.raises(ValueError, match="opd-topk-placement"):
+        validate_opd_topk_placement(_validate_case(opd_topk_placement="lose"))
+
+
+def _policy_loss_case(placement: str, opd_kl_coef: float = 1.0):
+    """A minimal policy-loss batch carrying the in-trainer OPD top-k tensors."""
+    torch.manual_seed(0)
+    vocab, k = 20, 4
+    response_lengths = [3, 2]
+    total_lengths = [rl + 2 for rl in response_lengths]
+    logits = torch.randn(1, sum(total_lengths), vocab, requires_grad=True)
+    args = make_args(
+        use_opd=True,
+        opd_type="megatron",
+        opd_kl_coef=opd_kl_coef,
+        opd_topk_in_trainer=k,
+        opd_topk_placement=placement,
+        opd_pointwise_clip=0.0,
+        vocab_size=None,
+        entropy_coef=0.0,
+        observe_training_entropy=False,
+        # the CPU test process has no megatron, so take the non-fused log-prob path
+        true_on_policy_mode=True,
+        advantage_estimator="reinforce_plus_plus",
+    )
+    batch = {
+        "unconcat_tokens": [torch.randint(0, vocab, (tl,)) for tl in total_lengths],
+        "total_lengths": total_lengths,
+        "response_lengths": response_lengths,
+        "loss_masks": [torch.ones(rl) for rl in response_lengths],
+        "log_probs": [torch.full((rl,), -2.0) for rl in response_lengths],
+        "advantages": [torch.ones(rl) for rl in response_lengths],
+        "opd_topk_ids": [torch.randint(0, vocab, (rl, k)) for rl in response_lengths],
+        # a teacher that is very confident on ids the student is not
+        "teacher_opd_gathered_vals": [torch.full((rl, k), -0.1) for rl in response_lengths],
+    }
+    reducer = get_sum_of_sample_mean(total_lengths, response_lengths, batch["loss_masks"], False, "thd", None)
+    return args, batch, logits, reducer
+
+
+def test_policy_loss_adds_the_distill_term_and_reports_it():
+    args, batch, logits, reducer = _policy_loss_case("loss", opd_kl_coef=2.0)
+    off_args = Namespace(**{**vars(args), "opd_topk_placement": "advantage"})
+
+    loss_on, log_on = policy_loss_function(args, batch, logits, reducer)
+    loss_off, log_off = policy_loss_function(off_args, batch, logits, reducer)
+
+    assert "opd_distill_loss" in log_on
+    assert "opd_distill_loss" not in log_off
+    # the reported term is the un-scaled KL; the loss carries it at opd_kl_coef
+    assert torch.allclose(loss_on - loss_off, 2.0 * log_on["opd_distill_loss"], atol=1e-5)
+
+
+def test_policy_loss_distill_term_reaches_the_logits():
+    args, batch, logits, reducer = _policy_loss_case("loss")
+    # kill the policy-gradient part so only the distillation term can carry gradient
+    batch["advantages"] = [torch.zeros_like(a) for a in batch["advantages"]]
+
+    loss, _ = policy_loss_function(args, batch, logits, reducer)
+    loss.backward()
+
+    assert logits.grad is not None
+    assert torch.isfinite(logits.grad).all()
+    assert logits.grad.abs().sum() > 0
+
+
+def test_policy_loss_survives_a_microbatch_with_no_scorable_positions():
+    """An all-empty micro-batch must not crash on `torch.cat([])`."""
+    args, batch, logits, reducer = _policy_loss_case("loss")
+    for key in ("response_lengths",):
+        batch[key] = [0, 0]
+    for key in ("loss_masks", "log_probs", "advantages"):
+        batch[key] = [t[:0] for t in batch[key]]
+    batch["opd_topk_ids"] = [t[:0] for t in batch["opd_topk_ids"]]
+    batch["teacher_opd_gathered_vals"] = [t[:0] for t in batch["teacher_opd_gathered_vals"]]
+    reducer = get_sum_of_sample_mean(batch["total_lengths"], [0, 0], batch["loss_masks"], False, "thd", None)
+
+    loss, _ = policy_loss_function(args, batch, logits, reducer)
+    loss.backward()
+
+    assert torch.isfinite(loss)
+    assert logits.grad is not None
+
+
+def test_policy_loss_ignores_the_distill_term_under_advantage_placement():
+    args, batch, logits, reducer = _policy_loss_case("advantage")
+    batch["advantages"] = [torch.zeros_like(a) for a in batch["advantages"]]
+
+    loss, _ = policy_loss_function(args, batch, logits, reducer)
+    loss.backward()
+
+    # the advantage placement folds the KL in upstream of the loss, so with
+    # zero advantages there is nothing left to push the logits
+    assert logits.grad.abs().sum() == pytest.approx(0.0, abs=1e-6)
+
+
+def _advantage_routing_args(placement: str) -> Namespace:
+    return Namespace(
+        use_rollout_logprobs=False,
+        kl_coef=0.0,
+        kl_loss_type="k1",
+        advantage_estimator="reinforce_plus_plus",
+        gamma=1.0,
+        lambd=1.0,
+        normalize_advantages=False,
+        use_opd=True,
+        opd_type="megatron",
+        opd_kl_coef=1.0,
+        opd_topk_in_trainer=8,
+        opd_topk_placement=placement,
+    )
+
+
+def _advantage_routing_rollout_data() -> dict:
+    return {
+        "log_probs": [torch.tensor([-1.0, -1.0])],
+        "rewards": [1.0],
+        "response_lengths": [2],
+        "total_lengths": [4],
+        "loss_masks": [torch.ones(2)],
+        "opd_reverse_kl": [torch.tensor([3.0, 5.0])],
+    }
+
+
+def test_placement_loss_leaves_the_advantages_untouched():
+    make_parallel_state()
+    rollout_data = _advantage_routing_rollout_data()
+
+    compute_advantages_and_returns(_advantage_routing_args("loss"), rollout_data)
+
+    baseline = _advantage_routing_rollout_data()
+    compute_advantages_and_returns(
+        Namespace(**{**vars(_advantage_routing_args("loss")), "use_opd": False}), baseline
+    )
+    assert torch.allclose(rollout_data["advantages"][0], baseline["advantages"][0])
+
+
+def test_placement_advantage_still_subtracts_the_reverse_kl():
+    make_parallel_state()
+    rollout_data = _advantage_routing_rollout_data()
+    baseline = _advantage_routing_rollout_data()
+
+    compute_advantages_and_returns(_advantage_routing_args("advantage"), rollout_data)
+    compute_advantages_and_returns(
+        Namespace(**{**vars(_advantage_routing_args("advantage")), "use_opd": False}), baseline
+    )
+
+    delta = baseline["advantages"][0] - rollout_data["advantages"][0]
+    assert torch.allclose(delta, torch.tensor([3.0, 5.0]))
+
+
+class TestOpdTopkHasTheSameBoundedFallbackAsTheGather:
+    """`calculate_opd_topk` (no-grad pre-pass) must not materialize the whole
+    `[S, V_local]` fp32 block when the caller omits `chunk_size`.
+
+    Its sibling `calculate_opd_gather_with_grad` floors at
+    `_OPD_GATHER_DEFAULT_CHUNK_ROWS`, so "forgot the argument" costs a bounded
+    transient there. This one must agree, so a single missing kwarg cannot turn
+    into a full-sequence fp32 materialization.
+    """
+
+    def test_omitted_chunk_size_still_chunks(self, monkeypatch):
+        import miles.backends.training_utils.loss_hub.math_utils as mu
+
+        seen = []
+        real_chunk = torch.Tensor.chunk
+
+        def spy(self, chunks, dim=0):
+            if self.dim() == 2 and self.size(0) > 1:
+                seen.append(chunks)
+            return real_chunk(self, chunks, dim=dim)
+
+        monkeypatch.setattr(torch.Tensor, "chunk", spy, raising=False)
+        rows = mu._OPD_GATHER_DEFAULT_CHUNK_ROWS * 3
+        logits = torch.randn(rows, 16)
+        mu.calculate_opd_topk(logits, None, top_k=4)  # chunk_size omitted
+        assert seen and max(seen) >= 3, (
+            f"expected >= 3 chunks for {rows} rows at the bounded default, got {seen}"
+        )
+
+    def test_the_bound_matches_the_gathers_own_default(self):
+        import inspect
+
+        import miles.backends.training_utils.loss_hub.math_utils as mu
+        src = inspect.getsource(mu.calculate_opd_topk)
+        assert "_OPD_GATHER_DEFAULT_CHUNK_ROWS" in src, (
+            "the two OPD paths must share ONE bound, not two literals that drift"
+        )
+
+    def test_an_explicit_chunk_size_still_wins(self):
+        import miles.backends.training_utils.loss_hub.math_utils as mu
+        logits = torch.randn(64, 16)
+        out = mu.calculate_opd_topk(logits, None, top_k=4, chunk_size=8)
+        assert out["topk_vals"].shape == (64, 4)
+
+    def test_values_are_identical_with_and_without_the_explicit_size(self):
+        """The bound is a memory knob, never a numerics knob."""
+        import miles.backends.training_utils.loss_hub.math_utils as mu
+        torch.manual_seed(0)
+        logits = torch.randn(300, 32)
+        a = mu.calculate_opd_topk(logits, None, top_k=5)
+        b = mu.calculate_opd_topk(logits, None, top_k=5, chunk_size=7)
+        assert torch.equal(a["topk_ids"], b["topk_ids"])
+        assert torch.allclose(a["topk_vals"], b["topk_vals"], atol=0, rtol=0)

--- a/tests/fast/backends/training_utils/loss/test_opd_topk_overlap.py
+++ b/tests/fast/backends/training_utils/loss/test_opd_topk_overlap.py
@@ -1,0 +1,60 @@
+"""Tests for the teacher/student top-k id-set overlap fraction.
+
+overlap[r] = |student_topk_ids[r] ∩ teacher_topk_ids[r]| / K -- the distillation
+health metric: distillation transfers through the student's top-k tokens, so
+the teacher's own top-k must increasingly coincide with the student's as
+training progresses (a flat/falling curve means the teacher view is shifting
+the distribution instead of sharpening it).
+"""
+
+import pytest
+import torch
+
+from miles.backends.training_utils.loss_hub.opd import topk_overlap
+
+
+def test_identical_ids_give_full_overlap():
+    ids = torch.tensor([[1, 2, 3, 4], [9, 8, 7, 6]])
+    out = topk_overlap(student_ids=ids, teacher_ids=ids.clone())
+    assert torch.allclose(out, torch.ones(2))
+
+
+def test_disjoint_ids_give_zero_overlap():
+    s = torch.tensor([[1, 2, 3, 4]])
+    t = torch.tensor([[5, 6, 7, 8]])
+    assert torch.allclose(topk_overlap(student_ids=s, teacher_ids=t), torch.zeros(1))
+
+
+def test_partial_overlap_is_order_invariant():
+    s = torch.tensor([[1, 2, 3, 4]])
+    t = torch.tensor([[4, 3, 99, 98]])  # {3, 4} shared, order scrambled
+    assert torch.allclose(topk_overlap(student_ids=s, teacher_ids=t), torch.tensor([0.5]))
+
+
+def test_per_position_rows_are_independent():
+    s = torch.tensor([[1, 2], [1, 2], [1, 2]])
+    t = torch.tensor([[1, 2], [2, 9], [8, 9]])
+    out = topk_overlap(student_ids=s, teacher_ids=t)
+    assert torch.allclose(out, torch.tensor([1.0, 0.5, 0.0]))
+
+
+def test_chunking_matches_unchunked():
+    g = torch.Generator().manual_seed(7)
+    s = torch.randint(0, 50, (33, 8), generator=g)
+    t = torch.randint(0, 50, (33, 8), generator=g)
+    full = topk_overlap(student_ids=s, teacher_ids=t)
+    chunked = topk_overlap(student_ids=s, teacher_ids=t, chunk_size=5)
+    assert torch.allclose(full, chunked)
+
+
+def test_empty_positions_give_empty_result():
+    s = torch.zeros((0, 4), dtype=torch.long)
+    out = topk_overlap(student_ids=s, teacher_ids=s.clone())
+    assert out.shape == (0,)
+
+
+def test_shape_mismatch_fails_loud():
+    s = torch.tensor([[1, 2, 3]])
+    t = torch.tensor([[1, 2]])
+    with pytest.raises(ValueError, match="shape"):
+        topk_overlap(student_ids=s, teacher_ids=t)

--- a/tests/fast/backends/training_utils/loss/test_opd_topk_reverse_kl.py
+++ b/tests/fast/backends/training_utils/loss/test_opd_topk_reverse_kl.py
@@ -1,0 +1,53 @@
+"""Tests for the in-trainer OPD top-k reverse KL
+with pointwise clipping and fail-loud validation.
+
+rkl[r] = sum_k exp(s_k) * (s_k - t_k)   -- s = student full-vocab-normalized
+logprobs at the student's own top-k ids, t = teacher logprobs gathered at the
+SAME ids; NOT renormalized within the top-k.
+"""
+
+import math
+
+import pytest
+import torch
+
+from miles.backends.training_utils.loss_hub.opd import topk_reverse_kl
+
+
+def test_identical_scores_give_zero_kl():
+    s = torch.log(torch.tensor([[0.5, 0.3, 0.1], [0.6, 0.2, 0.1]]))
+    rkl, clipfrac = topk_reverse_kl(student_vals=s, teacher_vals=s.clone(), pointwise_clip=0.0)
+    assert torch.allclose(rkl, torch.zeros(2), atol=1e-6)
+    assert torch.equal(clipfrac, torch.zeros(2))
+
+
+def test_hand_computed_value():
+    s = torch.log(torch.tensor([[0.5, 0.25]]))
+    t = torch.log(torch.tensor([[0.25, 0.5]]))
+    expected = 0.5 * (math.log(0.5) - math.log(0.25)) + 0.25 * (math.log(0.25) - math.log(0.5))
+    rkl, _ = topk_reverse_kl(student_vals=s, teacher_vals=t, pointwise_clip=0.0)
+    assert torch.allclose(rkl, torch.tensor([expected]), atol=1e-6)
+
+
+def test_pointwise_clip_bounds_contributions_and_reports_fraction():
+    s = torch.log(torch.tensor([[0.9, 0.05]]))
+    t = torch.tensor([[-30.0, math.log(0.05)]])  # teacher hates the student's top choice
+    unclipped, _ = topk_reverse_kl(student_vals=s, teacher_vals=t, pointwise_clip=0.0)
+    clipped, clipfrac = topk_reverse_kl(student_vals=s, teacher_vals=t, pointwise_clip=1.0)
+    assert clipped.item() < unclipped.item()
+    assert clipped.item() <= 1.0 * s.shape[-1] + 1e-6  # each contribution capped at 1.0
+    assert clipfrac.item() == pytest.approx(0.5)  # 1 of 2 entries clipped
+
+
+def test_nonfinite_teacher_fails_loud():
+    s = torch.log(torch.tensor([[0.5, 0.5]]))
+    t = torch.tensor([[float("nan"), -1.0]])
+    with pytest.raises(ValueError, match="finite"):
+        topk_reverse_kl(student_vals=s, teacher_vals=t, pointwise_clip=0.0)
+
+
+def test_shape_mismatch_fails_loud():
+    s = torch.zeros(2, 3)
+    t = torch.zeros(2, 4)
+    with pytest.raises(ValueError, match="shape"):
+        topk_reverse_kl(student_vals=s, teacher_vals=t, pointwise_clip=0.0)


### PR DESCRIPTION
## Summary

Implements **in-trainer top-k on-policy self distillation**: the reverse KL is computed over the **student's own per-position top-k ids inside the trainer** (not at rollout), and enters the update as a **differentiable loss term**. Ships with the DeepSeek-V4 long-context memory companions needed to run this at ~128k context, plus fail-at-launch validation.

- Closes #2352 (student-top-k OPSD variant).
- Fixes #2362 (top-k KL applied as an action-independent advantage penalty has `E_a[A·∇logπ] = 0` on-policy — it is a per-position constant baseline that cannot teach. This PR puts the same top-k KL in the loss, differentiable through the student's current logits, and **rejects advantage placement at launch** whenever the in-trainer top-k is active).

## What's included

**In-trainer top-k OPSD (default off, `--opd-topk-in-trainer K`)**
- The actor's `compute_log_prob` pass extracts per-position top-k logprobs (full-vocab log-softmax, TP allgather, chunked + checkpointed, `no_grad`) → `opd_topk_ids`/`opd_topk_vals`.
- The megatron OPD teacher forwards the experience-augmented teacher view (`Sample.teacher_tokens`) and gathers at those ids → `teacher_opd_gathered_vals`.
- Reverse KL `rkl[r] = Σ_k exp(s_k)·(s_k − t_k)` (full-vocab-normalized student logprobs at the student's own top-k ids, teacher gathered at the same ids, **not** renormalized within the top-k) re-reads the student side from the training forward → a proper loss-gradient (backward = softmax − target at the top-k).
- `--opd-topk-placement {loss,advantage}` (default `loss`; `advantage` is rejected at launch with the top-k — see #2362), `--opd-pointwise-clip` spike guard (+ logged clip fraction), `--opd-topk-dist-comm` shard-local distributed top-k/gather (~485× less TP traffic at V=248320/TP4/k=128), `--opd-teacher-refresh-from-actor` (re-backup the megatron teacher from the just-updated actor after every `update_weights`).
- Teacher views may interleave hint turns inside the response span ("turnhint"): the batch carries `teacher_gather_positions`/`teacher_response_lengths` and the alignment contract (in-range, strictly increasing, content-verified against the student response) is asserted at train-data conversion.

**DSV4 / long-context memory companions**
- `--keep-logits-in-model-precision` (or `MILES_BF16_LOGITS=1`): skip `Float16Module`'s full-logits fp32 upcast — a multi-GiB `[S, V_local]` copy per forward at long context; every consumer upcasts per chunk (bf16→fp32 is exact, so chunk-wise values are bit-identical).
- Chunked DSV4 indexer fwd+topk above `V4_INDEXER_CHUNK_THRESHOLD_BYTES` (default 8 GiB): bounds the `O(S·S_kv)` fp32 logits allocation to `O(q_chunk·S_kv)`. Bit-exact by construction (top-k is row-independent; chunking only the query dim), pinned by a GPU test at `atol=0`.
- Gradient checkpointing for the chunked CE/top-k recomputation; refuses loudly under `--record-memory-history` instead of corrupting silently.
- DeepSeek chat-template bridge: flatten OpenAI-style content blocks to the plain string the official encoders require (fail-loud on non-text blocks).

## Compatibility

All new flags default off/zero; existing `--use-opd` behavior is unchanged. New flags validate at launch: top-k-in-trainer requires `--opd-type=megatron`, placement/clip/top-k sanity checks, teacher-refresh prerequisites.

## Testing

- `tests/fast/backends/training_utils/loss/test_opd_topk_reverse_kl.py` — formula, clip, padding-tail, all-pad NaN-freedom.
- `test_opd_topk_overlap.py` — teacher/student top-k id-set overlap health metric.
- `test_opd_topk_distill_loss.py` — loss placement value/grad parity vs full-vocab autograd reference (TP=1), chunk-size invariance (`atol=0`), checkpoint memory retention, gradient step reduces the reverse KL, advantage placement rejection.
- `tests/fast-gpu/test_v4_indexer_chunked_topk.py` — chunked vs unchunked indexer bit-exactness.

## Known follow-ups (happy to address in this PR or a follow-up)

- The distributed paths have been exercised at TP=4 with k in {128, 256} (V=248320) in long-context training runs -- both the full-vocab TP allgather (default) and `--opd-topk-dist-comm`. What is missing is an in-repo multi-rank GPU test pinning the ws>1 primitives (`_ReplicatedAllGatherRows`/`_ReplicatedAllReduceSum`, candidate-merge top-k) against the TP=1 reference; values/grad parity at TP=1 IS pinned by the new fast tests. A 2-rank CI test would be a good addition.
