### PR TITLE
fix(tests): give generation fixtures the sample identity production stamps

### DIFF
--- a/tests/fast/fixtures/generation_fixtures.py
+++ b/tests/fast/fixtures/generation_fixtures.py
@@ -74,6 +74,8 @@ def listify(x):
 
 def make_sample(
     *,
+    group_index: int | None = 0,
+    index: int | None = 0,
     prompt: str | list[dict] = "What is 1+7?",
     tokens: list[int] | None = None,
     response: str = "",
@@ -82,6 +84,8 @@ def make_sample(
     multimodal_inputs: dict | None = None,
 ) -> Sample:
     return Sample(
+        group_index=group_index,
+        index=index,
         prompt=prompt,
         tokens=tokens or [],
         response=response,

--- a/tests/fast/rollout/generate_hub/test_multi_turn.py
+++ b/tests/fast/rollout/generate_hub/test_multi_turn.py
@@ -92,6 +92,8 @@ def expected_partial_sample(
     status: Sample.Status = Sample.Status.COMPLETED,
 ) -> Sample:
     return Sample(
+        group_index=0,
+        index=0,
         prompt=prompt,
         response=response,
         response_length=response_length,
@@ -105,16 +107,20 @@ def expected_partial_sample(
     )
 
 
-def verify_samples(actual: Sample | list[Sample], expected: list[ExpectedSampleInfo]):
+def verify_samples(actual: Sample | list[Sample], expected: list[ExpectedSampleInfo], *, variant: str):
     actual = listify(actual)
     assert len(actual) == len(expected)
+
+    expected_rollout_id = 0 if is_agentic_variant(variant) else None
 
     for actual_item, expected_item in zip(actual, expected, strict=True):
         actual_chunks = parse_sample_into_chunks(actual_item, TOKENIZER)
         assert actual_chunks == expected_item.chunks
+        assert actual_item.rollout_id == expected_rollout_id
 
         actual_partial = replace(
             deepcopy(actual_item),
+            rollout_id=None,
             tokens=[],
             loss_mask=[],
             rollout_log_probs=[],
@@ -210,6 +216,7 @@ class TestBasicMultiTurn:
                     ),
                 ),
             ],
+            variant=variant,
         )
 
     def test_two_turns_with_tool_call(self, variant, generation_env):
@@ -243,7 +250,7 @@ class TestBasicMultiTurn:
                 ),
             ),
         ]
-        verify_samples(result.sample, expected)
+        verify_samples(result.sample, expected, variant=variant)
 
 
 class TestExitConditions:
@@ -304,6 +311,7 @@ class TestExitConditions:
                     ),
                 ),
             ],
+            variant=variant,
         )
 
     def test_finish_reason_length_exits_and_preserves_content(self, variant, generation_env):
@@ -329,6 +337,7 @@ class TestExitConditions:
                     ),
                 ),
             ],
+            variant=variant,
         )
 
     @pytest.mark.parametrize("generation_env", [{"args_kwargs": {"generate_max_turns": 1}}], indirect=True)
@@ -367,7 +376,7 @@ class TestExitConditions:
                     ),
                 ),
             ]
-        verify_samples(result.sample, expected)
+        verify_samples(result.sample, expected, variant=variant)
 
 
 class TestRespectMaxContextLen:
@@ -387,7 +396,7 @@ class TestRespectMaxContextLen:
                 ),
             )
         ]
-        verify_samples(result.sample, expected)
+        verify_samples(result.sample, expected, variant=variant)
 
     @pytest.mark.parametrize(
         "generation_env",
@@ -426,7 +435,7 @@ class TestRespectMaxContextLen:
                 ),
             ),
         ]
-        verify_samples(result.sample, expected)
+        verify_samples(result.sample, expected, variant=variant)
 
     @pytest.mark.parametrize(
         "generation_env,expected_max_new_tokens",
@@ -495,7 +504,7 @@ class TestThreeTurn:
                 ),
             ),
         ]
-        verify_samples(result.sample, expected)
+        verify_samples(result.sample, expected, variant=variant)
 
 
 class TestRoutedExpertsMultiTurn:

--- a/tests/fast/rollout/generate_hub/test_single_turn.py
+++ b/tests/fast/rollout/generate_hub/test_single_turn.py
@@ -88,8 +88,8 @@ def expected_sample(
         loss_mask = [1] * actual_response_length if variant == "multi_turn" else None
 
     return Sample(
-        group_index=None,
-        index=None,
+        group_index=0,
+        index=0,
         prompt=prompt,
         tokens=PROMPT_TOKENS + RESPONSE_TOKENS if isinstance(tokens, _Unset) else tokens,
         multimodal_inputs=multimodal_inputs,


### PR DESCRIPTION
stage-b-cpu has been red on `test_multi_turn.py::TestBasicMultiTurn::test_single_turn_no_tool_call[agentic_tool_call]`:

```
AssertionError: v2 agentic samples require input Sample.rollout_id or Sample.index
miles/rollout/generate_hub/agentic_tool_call.py:120
```

## Root cause

#2368 made the session-v2 agentic path give every leaf of a rollout a shared `rollout_id` derived from the input sample's identity, and asserts that identity exists:

```python
rollout_id = input.sample.rollout_id if input.sample.rollout_id is not None else input.sample.index
assert rollout_id is not None, "v2 agentic samples require input Sample.rollout_id or Sample.index"
```

That invariant is real in production — every caller stamps `index` before generation:

- training: `sample.index = self.sample_index` in `miles/rollout/data_source.py`
- eval: `sample.index = sample_index` in `miles/rollout/sglang_rollout.py`

But the shared fixture `make_sample()` in `tests/fast/fixtures/generation_fixtures.py` built a `Sample` with **no identity at all** (`group_index=None, index=None`) — something no production caller produces. #2130 had already moved the `agentic_tool_call` variant onto session-server v2, so when #2368 landed, the fixture's gap turned into a failure.

Note the failure is in the *fixture*, not in #2368: `test_agentic_v2.py` deliberately covers both directions of that assert, including that it raises when identity is missing. Weakening the assert would delete intended behaviour, so this fixes the fixture instead.

## Change

- `make_sample()` stamps `group_index` / `index` the way `data_source.py` does, both overridable per test.
- The two expected-sample builders (`expected_sample` in test_single_turn, `expected_partial_sample` in test_multi_turn) carry the same identity, so the comparisons stay strict instead of ignoring these fields.
- `verify_samples()` takes the `variant`, so the `rollout_id` that v2 propagates to every leaf is **asserted** (`0` for `agentic_tool_call`, `None` otherwise) rather than silently compared as `None`.

## Verification

On an 8×H200 devbox, at this branch's diff:

| | before | after |
|---|---|---|
| the 3 `stage-b-cpu` files | 1 failed, 1 passed (`-x`) | **85 passed, 17 skipped** |
| `test_agentic_v2.py` (#2368's own tests) | 7 passed | **7 passed** |

`ruff check`, `black --check`, and `isort --check-only` are clean on all three files.

Tests only — no production code touched.