### PR TITLE
fix(dashboard): zero the trainer log-probs the loss masks out

### DIFF
--- a/docs/user-guide/dashboard.md
+++ b/docs/user-guide/dashboard.md
@@ -200,6 +200,10 @@ Two things here are easy to misread:
   no statistics. That is expected, not missing data.
 * The difference between rollout and train log-probs is the true-on-policy check. It should be
   near zero. A band that is consistently non-zero is worth chasing.
+* Positions the loss ignores, such as tool output in an agentic session, have no rollout
+  log-prob because the engine never generated them. Both log-prob sides read zero there, so
+  `lp_diff` is zero and `imp_ratio` is one by construction: judge train and rollout agreement
+  on the loss-covered tokens only.
 
 ## Turning it on
 

--- a/miles/dashboard/dump_reader.py
+++ b/miles/dashboard/dump_reader.py
@@ -396,9 +396,15 @@ class DumpReader:
             return None if values is None else [float(v) for v in values[a:b]]
 
         token_ids = [int(t) for t in columns["tokens"][start:end]]
+        # A dump carries no rollout log-prob for positions the loss ignores (tool
+        # output, masked turns): the inference engine never generated them, so
+        # 0.0 is stored. Blank the trainer side the same way, otherwise lp_diff
+        # and imp_ratio score a real log-prob against that placeholder and report
+        # a disagreement of tens of nats on tokens that never train.
+        train_log_probs = None if row is None else _zero_masked(row.log_probs, row.loss_mask > 0)
         lp_diff = (
-            row.log_probs - row.rollout_log_probs
-            if row is not None and row.log_probs is not None and row.rollout_log_probs is not None
+            train_log_probs - row.rollout_log_probs
+            if row is not None and train_log_probs is not None and row.rollout_log_probs is not None
             else None
         )
         return dict(
@@ -418,7 +424,7 @@ class DumpReader:
                 else response_slice(row.rollout_log_probs) if row is not None else None
             ),
             loss_mask=None if row is None else [int(v) for v in row.loss_mask[a:b]],
-            train_log_probs=None if row is None or row.log_probs is None else response_slice(row.log_probs),
+            train_log_probs=response_slice(train_log_probs),
             ref_log_probs=None if row is None else response_slice(row.ref_log_probs),
             lp_diff=response_slice(lp_diff),
             imp_ratio=None if lp_diff is None else response_slice(lp_diff.exp()),
@@ -536,6 +542,13 @@ def _masked(values: torch.Tensor | None, mask: torch.Tensor) -> torch.Tensor | N
         return None
     selected = values[mask]
     return selected.float() if selected.numel() else None
+
+
+def _zero_masked(values: torch.Tensor | None, mask: torch.Tensor) -> torch.Tensor | None:
+    """Zero the loss-masked positions of a per-token array, keeping its length so
+    it stays aligned with the token slice it annotates (the token view needs
+    every position; only the summary statistics can drop them)."""
+    return None if values is None else torch.where(mask, values, torch.zeros_like(values))
 
 
 def _mean(values: torch.Tensor | None) -> float | None:

--- a/tests/fast/dashboard/test_dump_reader_views.py
+++ b/tests/fast/dashboard/test_dump_reader_views.py
@@ -114,6 +114,23 @@ def test_tokens_full_range(reader):
     assert payload["lp_diff"][0] == pytest.approx(float(row.log_probs[0] - row.rollout_log_probs[0]))
 
 
+def test_tokens_blank_the_trainer_side_where_the_loss_is_masked(reader):
+    """A real dump holds no rollout log-prob for positions the loss ignores (tool
+    output, masked turns), so the trainer side is blanked to match instead of
+    reporting a disagreement against that placeholder. The removed sample is
+    masked end to end; an ordinary sample must keep every dumped value."""
+    masked = reader.tokens(0, REMOVED[0])
+    assert masked["loss_mask"] and set(masked["loss_mask"]) == {0}
+    assert masked["train_log_probs"] == [0.0] * len(masked["loss_mask"])
+    assert masked["lp_diff"] == pytest.approx([-v for v in masked["rollout_log_probs"]])
+    assert masked["ref_log_probs"] is not None  # left as dumped: no view diffs it
+
+    row = reader.load_joined(0).train_rows[0]
+    unmasked = reader.tokens(0, 0)
+    assert set(unmasked["loss_mask"]) == {1}
+    assert unmasked["train_log_probs"] == pytest.approx([float(v) for v in row.log_probs])
+
+
 def test_tokens_window_straddles_response_boundary(reader):
     sample = reader.load_joined(0).samples[0]
     prompt_len = len(sample.tokens) - sample.response_length


### PR DESCRIPTION
## What this does

On the dashboard's token page, per-token `train_log_probs` are now zeroed wherever `loss_mask` is 0, so `lp_diff` reads zero and `imp_ratio` reads one on those positions. Loss-covered tokens are unchanged, and the per-sample summary statistics are unchanged as well.

## Why

A dump has no rollout log-prob for a position the loss ignores. In an agentic session most of a "response" is injected tool output, and the prompt echo and any turn excluded through `step_loss_mask` land in the same bucket: the inference engine never generated those tokens, so `0.0` is stored for them. The trainer, on the other hand, scores every position it is given.

The token view subtracted one from the other regardless, so it compared a real trainer log-prob against a placeholder. On the tokens that never train, that produced an apparent train/rollout disagreement of tens of nats, next to the roughly 0.01–0.02 seen on the tokens that do train. Two consequences:

- The numbers invite the conclusion that train and inference have diverged catastrophically, when the run is healthy. Working this out from the token page currently requires cross-referencing the `loss_mask` row by hand.
- The `lp_diff` heat map is a diverging scale normalised to the largest absolute value in the window. A single masked span at -30 flattens every real value to the neutral colour, so the view that exists to localise drift cannot show it.

Zeroing the trainer side makes both log-prob columns follow the same convention, so the heat map scales to the loss-covered tokens and a masked position renders as the neutral centre it should be.

## Scope

`ref_log_probs` is left exactly as dumped. No view derives a difference from it today, and the KL term the training loss uses is computed in the trainer, not here. If a reference-versus-trainer view is added later it will want the same treatment.

Summary statistics (`mean_abs_lp_diff`, `max_abs_lp_diff`, `mean_imp_ratio`) already select loss-covered positions before averaging, so they were correct before this change and are unaffected by it. The blanking is deliberately confined to the token view, which needs every position kept so the arrays stay aligned with the tokens they annotate.

## Verification

Executed:

- `DumpReader.tokens()` driven end to end against synthesised dumps covering three cases: a fully masked sample, a fully unmasked sample, and a mixed mask of the shape an agentic session produces. Confirmed that masked positions return `train_log_probs` 0.0, `lp_diff` 0.0 and `imp_ratio` 1.0; that loss-covered positions keep their dumped values to within float32 tolerance; and that a window starting inside the response stays aligned with `loss_mask`.
- `ruff check` and `black --line-length 119 --check` on both changed files.

Not executed locally: `tests/fast/dashboard/`. The dashboard tests import the dump pipeline, which pulls in sglang and transitively triton, and this checkout's environment cannot satisfy that on macOS. The new regression test `test_tokens_blank_the_trainer_side_where_the_loss_is_masked` therefore needs CI to confirm. Its assertions were validated against dumps built to match what the fixture produces for a removed sample, including the detail that the fixture's rollout log-probs are random rather than zero at masked positions, which is why the test asserts the derivation from `rollout_log_probs` instead of literal zeros.
