### PR TITLE
examples: computer-use RL on HUD v6 environments

### DIFF
--- a/docs/user-guide/environments.md
+++ b/docs/user-guide/environments.md
@@ -19,6 +19,7 @@ where the environment itself comes from:
 | Integration | Plugs in at | Guide |
 |---|---|---|
 | [Harbor](https://github.com/harbor-framework/harbor) | agent function | [guide](/user-guide/harbor) |
+| [HUD](https://hud.ai) | generate function³ | [example](https://github.com/radixark/miles/tree/main/examples/experimental/hud) |
 | [NeMo Gym](https://github.com/NVIDIA-NeMo/Gym) | agent function | [guide](/user-guide/nemo-gym) |
 | [OpenEnv](https://github.com/huggingface/openenv) | agent function | [guide](/user-guide/openenv) |
 | [Strands Agents](https://strandsagents.com/) | generate function | [example](https://github.com/radixark/miles/tree/main/examples/experimental/strands_sglang) |
@@ -31,7 +32,7 @@ Sandbox providers are a different axis: they provision the task containers
 | Sandbox provider | Used within | Guide |
 |---|---|---|
 | [AgentENV](https://github.com/kvcache-ai/AgentENV) | OpenEnv | [example](https://github.com/radixark/miles/tree/main/examples/experimental/agentenv) |
-| [Daytona](https://www.daytona.io/) | OpenEnv, Harbor, NeMo Gym | [example](https://github.com/radixark/miles/tree/main/examples/experimental/openenv) |
+| [Daytona](https://www.daytona.io/) | Harbor, HUD, NeMo Gym, OpenEnv | [example](https://github.com/radixark/miles/tree/main/examples/experimental/openenv) |
 | [E2B](https://e2b.dev/) | OpenEnv | [example](https://github.com/radixark/miles/tree/main/examples/experimental/openenv) |
 | [Modal](https://modal.com/) | OpenEnv | [example](https://github.com/radixark/miles/tree/main/examples/experimental/openenv) |
 
@@ -62,3 +63,9 @@ rather than the session-server chat endpoint Miles' own recording uses.
 ² The environment may grade an episode itself (Harbor and τ-bench do); the
 score still enters training through Miles' `Sample.reward` / RM hooks, and
 group-level reward handling stays in Miles.
+
+³ HUD's harness records per-turn token ids and sampling logprobs itself when
+the inference server returns them, so the connector's job is stitching those
+into one training sequence rather than recording. Computer-use observations
+are screenshots, which Miles' session-server recording does not carry yet —
+once it does, this connector can also sit in the agent function.

--- a/examples/experimental/hud/README.md
+++ b/examples/experimental/hud/README.md
@@ -1,0 +1,97 @@
+# Computer-use RL on HUD environments
+
+A model that sees a screen and works the keyboard and mouse gets better at
+using a computer by practising: it attempts a task in a real GUI thousands of
+times, and each episode's own grade tells it which attempts were good. This
+example runs that loop on [HUD](https://hud.ai) v6 environments — any HUD env
+package whose tasks are workable through a screen trains on the same files.
+
+The split: HUD owns the episode — it boots the environment, runs the agent
+loop, and grades the result — while Miles owns training, and the two meet at
+the token ids the policy emitted. Nothing under `miles/` is modified.
+
+The worked example throughout is
+[2048](https://en.wikipedia.org/wiki/2048_%28video_game%29) — the sliding-tile
+puzzle where equal tiles merge and double, and every merge scores — played in
+a real browser from HUD's public starter (`hud init --preset browser`, no API
+key; it ships 2048, a todo app, and graded task templates for both).
+Everything named `hud2048_*` or `run_hud2048` is that recipe; the rest does
+not know which taskset it is running.
+
+| seam | file |
+|---|---|
+| `--custom-generate-function-path` | [`rollout.py`](rollout.py) — HUD run → one Miles training sample |
+| `--custom-rm-path` | [`rollout.py`](rollout.py) `reward_func` — the task template's own grade |
+| `--custom-config-path` | [`hud2048_config.yaml`](hud2048_config.yaml) |
+| the agent | [`agent.py`](agent.py) + [`computer_tool.py`](computer_tool.py) |
+| sglang ↔ HUD token contract | [`sglang_compat.py`](sglang_compat.py) |
+
+## How the pieces divide
+
+A HUD v6 task is a template inside an environment package — its first `yield`
+is the prompt, its second is the reward — and `task.run(agent, runtime=...)`
+boots the environment (one Daytona sandbox per episode, deleted on exit), runs
+the agent, and grades. On top of that this example adds three pieces, each
+reasoned about in its own file: a screen for self-hosted models
+([`computer_tool.py`](computer_tool.py) — HUD only ships computer-use tools
+for provider-native protocols), a token-id bridge to stock sglang
+([`sglang_compat.py`](sglang_compat.py)), and the stitch that turns one
+episode's per-turn token ids into one verified training sequence
+([`rollout.py`](rollout.py)).
+
+Reward shaping is choosing which task template to train on — the tradeoff, and
+why this recipe trains on `reach_score` with a retuned target, is annotated in
+[`hud2048_config.yaml`](hud2048_config.yaml).
+
+## Running it
+
+```bash
+pip install hud daytona asyncssh asyncvnc    # the harness's extra deps
+hud init v6browser --preset browser          # downloads the starter into ./v6browser
+
+# Give the page the whole screen. As scaffolded, the browser's own chrome takes
+# both the pixels the board needs and the clicks meant for it, so the policy
+# sees a cropped board and focuses the sidebar; kiosk mode removes it.
+sed -i 's/1280x800x24/1280x1200x24/; s/--window-size=1280,800/--window-size=1280,1200/;
+        s/"--no-first-run",/"--no-first-run", "--kiosk", "--disable-infobars",/' v6browser/env.py
+
+hf download Qwen/Qwen3-VL-4B-Instruct --local-dir /root/models/Qwen3-VL-4B-Instruct
+python -m examples.experimental.hud.make_hud_data \
+    --env-dir /root/v6browser --task-ids 2048-score-5000 \
+    --args-json '{"target_score": 1024}' --repeat 256 --output /root/hud2048_train.jsonl
+
+mkdir -p ~/.config/daytona && echo dtn_... > ~/.config/daytona/api_key   # sandboxes
+export MILES_SCRIPT_OUTPUT_DIR=/persistent/hud2048    # checkpoints and rollout dumps
+python -m pytest examples/experimental/hud/tests/ -q  # offline: no GPU, no network
+MILES_SCRIPT_MODE=smoke python examples/experimental/hud/run_hud2048.py   # 2 episodes
+python examples/experimental/hud/run_hud2048.py       # 8 GPUs, single node
+```
+
+Two episodes is the right size for the middle rung: the bugs a rollout finds
+are per-episode, and what a wider rollout batch *cannot* show you — reward
+spread inside a group, weight sync, hours-long stability — needs real
+training. So go from `MODE=smoke` to a short real run, not to a bigger smoke.
+
+What to expect from the full run: 20 GRPO steps take about five hours on
+8×H200 (~15 min/step, 32 episodes each). Mean episode reward roughly doubles
+(0.037 → ~0.07 against the retuned `target_score` of 1024 — a mean game score
+of about 38 → 72), by the last steps
+every episode in the batch scores, and no group loses its reward variance —
+the model learns to reliably reach the board and spend its full move budget
+rather than to play brilliantly, which is what a linear score reward buys
+first.
+
+The env snapshot is built by Daytona cloud-side from the package's
+`Dockerfile.hud` on first use and rebuilt whenever the package's content hash
+changes — a laptop and a training node each build their own unless the
+directory is byte-identical (mind stray `__pycache__`).
+
+## Pointing it at another taskset
+
+`--env-dir` and `--task-ids` are the change; any HUD env package whose tasks
+are workable through a screen runs on the same files, and the browser starter's
+todo app already does. Sizing lives in `hud2048_config.yaml`, annotated with
+what each number trades against.
+
+Keep `--sglang-tool-call-parser` matched to the model: without it, tool calls
+stay unparsed text and every episode ends at turn one.

--- a/examples/experimental/hud/agent.py
+++ b/examples/experimental/hud/agent.py
@@ -1,0 +1,43 @@
+"""The agent Miles drives HUD environments with: HUD's own OpenAI-compatible
+harness, plus the one thing it lacks for computer use -- a screen
+(:mod:`.computer_tool` explains that gap). The loop, tool plumbing, trace
+recording and token-level ``Sample`` collection are all inherited unchanged.
+"""
+
+from __future__ import annotations
+
+from examples.experimental.hud.computer_tool import ChatComputerTool, computer_tool_class
+from hud.agents.openai_compatible.agent import OpenAIChatAgent
+
+
+SYSTEM_PROMPT = """You are operating a computer through screenshots.
+
+You have at most {max_steps} turns, and a turn is the expensive thing: each one \
+re-reads the whole screen history. Actions are not -- a single computer call \
+can carry several keystrokes, played in order. So plan a few steps ahead and \
+send them together rather than one per turn.
+
+Keys go to whatever the screen has focused, so click what you mean to type \
+into before typing. Look at each screenshot to check that your last action did \
+what you expected, and change approach if it did not."""
+
+
+class ComputerChatAgent(OpenAIChatAgent):
+    """OpenAIChatAgent whose only tool is the screen.
+
+    Beyond the tool, the one thing this adds is a system prompt, because the
+    task template's prompt says *what* to do and something has to say *how* to
+    act here: chiefly that turns are scarce and keystrokes are not. Without it
+    a model spends one turn per keystroke and runs out of episode long before
+    it runs out of task.
+    """
+
+    tool_catalog = (ChatComputerTool,)
+
+    @classmethod
+    def for_shot_width(cls, shot_width: int) -> type[ComputerChatAgent]:
+        """The agent with a specific screenshot width baked into its tool."""
+        tool = computer_tool_class(shot_width)
+        if tool is ChatComputerTool:
+            return cls
+        return type(cls.__name__, (cls,), {"tool_catalog": (tool,)})

--- a/examples/experimental/hud/computer_tool.py
+++ b/examples/experimental/hud/computer_tool.py
@@ -1,0 +1,230 @@
+"""A chat-completions computer tool over HUD's rfb capability.
+
+HUD ships the screen primitives (``hud.agents.tools.rfb.RFBTool``: VNC
+screenshot, click, keys, scroll) plus provider-native facades for Claude,
+Gemini and OpenAI. Nothing serves plain ``chat.completions`` function calling
+-- which is what a self-hosted policy (sglang, vLLM) speaks. This is that
+facade, and it is the only "harness" code this example adds: the loop, the
+tool plumbing and the trace all stay HUD's.
+
+Two behaviours are training decisions rather than plumbing:
+
+- Screenshots are downscaled to ``shot_width`` before the model sees them.
+  Every turn re-prefills the whole screenshot history through the vision
+  encoder, so screenshot resolution multiplies the cost of every turn after
+  it; pick the smallest width at which the task's detail is still readable
+  (the recipe's config annotates its choice). Click coordinates arrive in the
+  downscaled frame and are scaled back to the real screen here.
+- ``press`` distinguishes keystrokes from key combos, which the underlying
+  VNC primitive does not: given several keys at once it holds them all down
+  together (a hotkey). So each element of ``keys`` is pressed separately, in
+  order -- ``["Left", "Down"]`` is two keystrokes -- and a ``+`` joins keys
+  into one combo: ``["ctrl+c"]`` is copy. Without the distinction, a model
+  batching several keystrokes into one call would land one chord instead.
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+import logging
+from typing import Any, ClassVar
+
+import mcp.types as mcp_types
+
+from hud.agents.openai.tools.computer import OPENAI_KEY_ALIASES
+from hud.agents.tools.base import AgentToolSpec, tool_err
+from hud.agents.tools.rfb import RFBTool
+from hud.types import MCPToolResult
+
+logger = logging.getLogger(__name__)
+
+
+# HUD's map covers provider spellings ("arrowright", "enter"); models also
+# emit bare direction words, and X11 keysyms are case-sensitive, so "right"
+# would be a dead key without these.
+_EXTRA_ALIASES = {"left": "Left", "right": "Right", "up": "Up", "down": "Down"}
+
+
+def to_keysym(key: str) -> str:
+    """Model-friendly key names to the X11 keysyms asyncvnc wants."""
+    k = key.strip()
+    return OPENAI_KEY_ALIASES.get(k.lower()) or _EXTRA_ALIASES.get(k.lower(), k)
+
+
+class ChatComputerTool(RFBTool):
+    """Drive the environment's screen via OpenAI-style function calling."""
+
+    name = "computer"
+    #: Width the model sees. The real screen stays at native resolution; click
+    #: coordinates are scaled back up. Configure via :func:`computer_tool_class`.
+    shot_width: ClassVar[int] = 640
+
+    description = (
+        "Control the computer's screen, mouse and keyboard. Every action "
+        "returns a screenshot taken after it, so you always see the result. "
+        "Use action='screenshot' just to look. Keys go to whatever the screen "
+        "has focused, so click the thing you mean to type into first."
+    )
+    parameters: ClassVar[dict[str, Any]] = {
+        "type": "object",
+        "properties": {
+            "action": {
+                "type": "string",
+                "enum": ["screenshot", "click", "double_click", "type", "press", "scroll", "wait"],
+                "description": "What to do.",
+            },
+            "x": {"type": "integer", "description": "click/scroll: x coordinate in the screenshot"},
+            "y": {"type": "integer", "description": "click/scroll: y coordinate in the screenshot"},
+            "button": {
+                "type": "string",
+                "enum": ["left", "middle", "right"],
+                "description": "click: default left",
+            },
+            "text": {"type": "string", "description": "type: literal text to type"},
+            "keys": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": (
+                    "press: keys pressed one after another, in order -- send "
+                    "several at once when you know the next few, e.g. "
+                    "['Left','Down','Left','Down']. An element containing '+' "
+                    "is a chord instead, e.g. ['ctrl+c']. Arrow keys: "
+                    "Left/Right/Up/Down."
+                ),
+            },
+            "scroll_y": {"type": "integer", "description": "scroll: clicks; >0 down, <0 up"},
+            "ms": {"type": "integer", "description": "wait: milliseconds"},
+        },
+        "required": ["action"],
+    }
+
+    @classmethod
+    def default_spec(cls, model: str) -> AgentToolSpec:
+        del model
+        return AgentToolSpec(api_type="function", api_name=cls.name)
+
+    def to_params(self) -> dict[str, Any]:
+        return {
+            "type": "function",
+            "function": {
+                "name": self.name,
+                "description": self.description,
+                "parameters": self.parameters,
+            },
+        }
+
+    #: Whether the pointer has established keyboard focus this episode.
+    _pointer_used: bool = False
+
+    # ---- geometry ----
+
+    @property
+    def _scale(self) -> float:
+        """Downscaled-frame -> real-screen factor."""
+        if self.shot_width and self.display_width > self.shot_width:
+            return self.display_width / self.shot_width
+        return 1.0
+
+    def _to_screen(self, v: Any) -> int:
+        return round(int(v) * self._scale)
+
+    async def _observation(self) -> MCPToolResult:
+        """A screenshot at the width the model is trained to look at."""
+        result = await self.screenshot()
+        if self._scale == 1.0:
+            return result
+        content: list[Any] = []
+        for block in result.content:
+            if isinstance(block, mcp_types.ImageContent):
+                from PIL import Image  # noqa: PLC0415 - pillow ships with the training image
+
+                img = Image.open(io.BytesIO(base64.b64decode(block.data)))
+                w = self.shot_width
+                img = img.resize((w, round(img.height * w / img.width)), Image.LANCZOS)
+                buf = io.BytesIO()
+                img.save(buf, "PNG")
+                block = mcp_types.ImageContent(
+                    type="image",
+                    mimeType="image/png",
+                    data=base64.b64encode(buf.getvalue()).decode("ascii"),
+                )
+            content.append(block)
+        return MCPToolResult(content=content)
+
+    async def _ensure_focus(self) -> None:
+        """Give the screen keyboard focus before the first typed input.
+
+        A desktop routes key events to whatever it has focused, and a freshly
+        booted one may have focused nothing -- in which case an episode that
+        opens with keystrokes silently does nothing. One click at the centre,
+        once per episode, and only before input the pointer has not already
+        established focus for.
+        """
+        if self._pointer_used:
+            return
+        self._pointer_used = True
+        await self.click(self.display_width // 2, self.display_height // 2)
+        await self.wait(200)
+
+    # ---- dispatch ----
+
+    async def execute(self, arguments: dict[str, Any]) -> MCPToolResult:
+        action = str(arguments.get("action", ""))
+        # One line per action, at INFO, because the alternative is finding out
+        # what the policy did only after the batch lands: a run whose reward
+        # stays zero is diagnosed by what it is *doing* (clicking rather than
+        # typing, say), and the harness's own log says only "-> computer".
+        logger.info("[hud act] %s %s", action, {k: v for k, v in arguments.items() if k != "action"})
+        try:
+            if action == "screenshot":
+                pass
+            elif action in ("click", "double_click"):
+                if arguments.get("x") is None or arguments.get("y") is None:
+                    return tool_err("click needs x and y")
+                await self.click(
+                    self._to_screen(arguments["x"]),
+                    self._to_screen(arguments["y"]),
+                    button=arguments.get("button") or "left",
+                    count=2 if action == "double_click" else 1,
+                )
+                self._pointer_used = True
+            elif action in ("type", "press"):
+                await self._ensure_focus()
+                if action == "type":
+                    await self.type_text(str(arguments.get("text") or ""))
+                else:
+                    keys = arguments.get("keys") or []
+                    if isinstance(keys, str):
+                        keys = [keys]
+                    if not keys:
+                        return tool_err("press needs keys, e.g. {'keys': ['Left', 'Down']}")
+                    for element in keys:
+                        chord = [to_keysym(k) for k in str(element).split("+") if k.strip()]
+                        if chord:
+                            await self.press_keys(chord)
+            elif action == "scroll":
+                await self.scroll(
+                    self._to_screen(arguments["x"]) if arguments.get("x") is not None else None,
+                    self._to_screen(arguments["y"]) if arguments.get("y") is not None else None,
+                    scroll_y=int(arguments.get("scroll_y") or 0),
+                )
+            elif action == "wait":
+                await self.wait(min(int(arguments.get("ms") or 500), 5000))
+            else:
+                return tool_err(f"unknown action {action!r}")
+            await self.wait(300)  # let the UI settle before looking
+            return await self._observation()
+        except Exception as e:  # noqa: BLE001 - a bad action must not kill the episode
+            return tool_err(f"{action} failed: {e}")
+
+
+def computer_tool_class(shot_width: int) -> type[ChatComputerTool]:
+    """The tool with a specific screenshot width baked in.
+
+    The harness constructs tools with a fixed ``(spec, client, encoding)``
+    signature, so per-run configuration has to travel on the class.
+    """
+    if shot_width == ChatComputerTool.shot_width:
+        return ChatComputerTool
+    return type("ChatComputerTool", (ChatComputerTool,), {"shot_width": shot_width})

--- a/examples/experimental/hud/hud2048_config.yaml
+++ b/examples/experimental/hud/hud2048_config.yaml
@@ -1,0 +1,47 @@
+# HUD 2048 (v6 browser starter). Sizing comes from measurements on this task;
+# the numbers and their reasons are annotated where they are set.
+#
+# The env package: `hud init v6browser --preset browser` (no API key; public
+# starter with 2048 + a todo app in real Chromium). Point hud_env_dir at it;
+# the snapshot is built cloud-side by Daytona from its Dockerfile.hud on first
+# use and rebuilt automatically whenever the package's content hash changes --
+# which also means a laptop and a training node each build their own unless
+# the directory content is byte-identical (mind stray __pycache__).
+#
+# That package needs one edit before it is trainable (README has the sed): run
+# the browser in --kiosk on a 1280x1200 desktop. As scaffolded, the browser's
+# chrome costs twice -- it crops the 4x4 board out of the viewport, and it
+# gives the policy a sidebar to click, which takes keyboard focus away from the
+# game so arrow keys do nothing. A capable model reasons its way out (zoom,
+# click the page); a small one cannot, and with every episode then scoring zero
+# there is no reward spread for RL to learn the escape from either.
+hud_env_dir: /root/v6browser
+hud_snapshot_name: miles-hud-v6browser
+
+# Turns are the expensive axis -- every turn re-prefills the whole screenshot
+# history through the vision encoder -- while keys within one press() call are
+# nearly free. Vision tokens go with screenshot *area*, so width is the lever:
+# at 512 a frame of this desktop costs ~240 of them, at 640 ~380, and the
+# difference compounds over 24 turns. 512 still resolves the tiles.
+hud_max_steps: 24
+hud_shot_width: 512
+# Room for a short thought plus a complete tool call. Too tight and a turn is
+# cut mid-JSON, which the harness answers by rewriting that turn's recorded
+# arguments -- ending the stitch early (see rollout.py) and wasting the turns
+# after it.
+hud_max_tokens_per_turn: 512
+
+# One episode = one Daytona sandbox; the gate caps them process-wide,
+# independent of rollout batch geometry. The timeout bounds an episode wedged
+# on a dead sandbox or a stalled engine -- at batch granularity one wedged
+# episode otherwise stalls the whole step.
+hud_max_sandboxes: 32
+hud_episode_timeout_s: 1800
+
+# Reward = which task template to train on. Of the starter's three 2048
+# graders, reach_score is the only always-informative one: reach_tile is a
+# step function that goes flat when a population converges on one tile
+# (zeroing GRPO's within-group variance), and near_win is binary. Its target
+# is retuned to 1024 via make_hud_data --args-json: a strong episode on this
+# move budget scores ~900, which keeps the best episodes inside the linear
+# part instead of all clipping at 1.0.

--- a/examples/experimental/hud/make_hud_data.py
+++ b/examples/experimental/hud/make_hud_data.py
@@ -1,0 +1,89 @@
+"""Build a Miles prompt jsonl from a HUD v6 taskset.
+
+A v6 task is a data row -- an env name, a template id, bound args -- minted by
+calling a template in the env package's ``tasks.py``. This walks that module's
+public ``tasks`` list and writes one Miles row per task (repeated ``--repeat``
+times: GRPO needs groups, and a taskset like the browser starter's 2048 has a
+handful of templates, not thousands of rows).
+
+The ``prompt`` column is one chat message carrying the task slug: with a
+chat-completions harness the model never sees this file -- its actual prompt
+is the template's first yield, delivered inside the environment at run time.
+Miles uses the column only to group samples of the same task (and its VLM data
+path requires the chat-message shape, hence not a bare string).
+
+    python -m examples.experimental.hud.make_hud_data \
+        --env-dir /root/v6browser --task-ids 2048-score-5000 \
+        --repeat 256 --output /root/hud2048_train.jsonl
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+
+def load_tasks(env_dir: str | Path):
+    """The env package's minted task rows (its public ``tasks`` list)."""
+    env_dir = Path(env_dir).expanduser().resolve()
+    sys.path.insert(0, str(env_dir))
+    try:
+        spec = importlib.util.spec_from_file_location("hud_env_tasks", env_dir / "tasks.py")
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return list(module.tasks)
+    finally:
+        sys.path.remove(str(env_dir))
+
+
+def task_row(task) -> dict:
+    """The part of a Task that travels to the rollout: enough to re-mint it."""
+    return {"env": task.env, "id": task.id, "args": dict(task.args or {}), "slug": task.slug}
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--env-dir", required=True, help="HUD env package (has tasks.py + Dockerfile.hud)")
+    ap.add_argument("--task-ids", nargs="*", default=None, help="slugs to include; default all")
+    ap.add_argument(
+        "--args-json",
+        default=None,
+        help=(
+            "JSON merged over each selected task's args, e.g. "
+            "'{\"target_score\": 1024}' -- how a recipe retunes a template "
+            "without editing the env package"
+        ),
+    )
+    ap.add_argument("--repeat", type=int, default=1)
+    ap.add_argument("--output", default="/root/hud_train.jsonl")
+    args = ap.parse_args()
+
+    tasks = load_tasks(args.env_dir)
+    if args.task_ids:
+        tasks = [t for t in tasks if t.slug in set(args.task_ids)]
+    if not tasks:
+        raise SystemExit(f"no tasks selected from {args.env_dir}")
+    print(f"{len(tasks)} task(s): {[t.slug for t in tasks]}")
+
+    overrides = json.loads(args.args_json) if args.args_json else {}
+    written = 0
+    with open(args.output, "w") as f:
+        for _ in range(args.repeat):
+            for t in tasks:
+                row = task_row(t)
+                row["args"] = {**row["args"], **overrides}
+                record = {
+                    "prompt": [{"role": "user", "content": t.slug}],
+                    "label": "",
+                    "metadata": {"hud_task": row},
+                }
+                f.write(json.dumps(record, ensure_ascii=False) + "\n")
+                written += 1
+    print(f"wrote {written} rows to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/experimental/hud/rollout.py
+++ b/examples/experimental/hud/rollout.py
@@ -1,0 +1,461 @@
+"""Multi-turn computer-use rollout on HUD v6 environments.
+
+The division of labour, and why this file is small:
+
+- **HUD** owns the episode: `task.run()` boots the environment (one Daytona
+  sandbox per episode, deleted on exit), runs its agent loop against our
+  policy, grades with the task template's second yield, and hands back a
+  ``Trace`` whose ``AgentStep``s carry token-level ``Sample``s -- the exact
+  prompt/output token ids and sampling logprobs of every turn, straight from
+  the inference server (see sglang_compat.py for how stock sglang serves
+  those).
+- **This file** turns one graded HUD run into one Miles training sample:
+  stitch the per-turn token ids into a single sequence with a loss mask, and
+  rebuild the vision inputs (pixel_values) from the very screenshots the
+  policy saw.
+
+Stitching leans on a property verified per episode rather than assumed: the
+server re-renders the chat template every turn, so turn k+1's prompt ids must
+start with turn k's prompt+output ids. Where that stops holding, the episode is
+kept only up to that turn -- training on a mis-stitched sequence would corrupt
+silently, and the turns before the break are still exact.
+
+One scope constraint: every sample this file emits carries at least one image
+(episodes whose kept turns predate the first screenshot are written off, and
+even write-offs carry a dummy one -- see ``_failed`` for why Miles' FSDP
+trainer requires it). Text-only HUD tasks are therefore out of scope here.
+
+Wire with:
+  --custom-generate-function-path examples.experimental.hud.rollout.generate
+  --custom-rm-path examples.experimental.hud.rollout.reward_func
+  --custom-config-path examples/experimental/hud/hud2048_config.yaml
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import io
+import logging
+import os
+import threading
+from pathlib import Path
+from typing import Any
+
+from PIL import Image as PILImage
+
+from miles.utils.types import Sample
+
+logger = logging.getLogger(__name__)
+
+_runtime = None
+_runtime_lock = threading.Lock()
+_gate: asyncio.Semaphore | None = None
+
+
+def _load_daytona_key(args: Any) -> None:
+    """Put the Daytona key in this process's environment, from a file if need be.
+
+    Reading it here rather than exporting it before launch keeps it out of Ray's
+    ``runtime_env``, which is recorded -- and echoed into job logs -- verbatim.
+    """
+    if os.environ.get("DAYTONA_API_KEY"):
+        return
+    path = getattr(args, "hud_daytona_key_file", None) or os.environ.get(
+        "DAYTONA_API_KEY_FILE", "~/.config/daytona/api_key"
+    )
+    path = Path(path).expanduser()
+    if not path.exists():
+        raise ValueError(f"no Daytona credentials: set DAYTONA_API_KEY or put a key at {path}")
+    os.environ["DAYTONA_API_KEY"] = path.read_text().strip()
+
+
+def _shared_runtime(args: Any):
+    """One DaytonaRuntime for the whole process.
+
+    Sharing matters: the runtime resolves (and, when stale, rebuilds) the env
+    snapshot once per process; per-episode instances would race on that.
+    """
+    global _runtime
+    with _runtime_lock:
+        if _runtime is None:
+            _load_daytona_key(args)
+            from daytona import Image  # noqa: PLC0415 - not part of the training image
+            from hud.eval import DaytonaRuntime  # noqa: PLC0415
+
+            dockerfile = Path(args.hud_env_dir).expanduser() / "Dockerfile.hud"
+            _runtime = DaytonaRuntime(
+                args.hud_snapshot_name,
+                image=Image.from_dockerfile(dockerfile) if dockerfile.exists() else None,
+            )
+        return _runtime
+
+
+def _sandbox_gate(args: Any) -> asyncio.Semaphore:
+    """Cap concurrent sandboxes process-wide, independent of batch geometry."""
+    global _gate
+    if _gate is None:
+        _gate = asyncio.Semaphore(int(getattr(args, "hud_max_sandboxes", 32)))
+    return _gate
+
+
+def _build_agent(args: Any, sampling_params: dict):
+    from examples.experimental.hud.agent import SYSTEM_PROMPT, ComputerChatAgent  # noqa: PLC0415
+    from examples.experimental.hud.sglang_compat import sglang_client  # noqa: PLC0415
+    from hud.agents.types import OpenAIChatConfig  # noqa: PLC0415
+
+    max_steps = int(getattr(args, "hud_max_steps", 24))
+    system_prompt = getattr(args, "hud_system_prompt", None) or SYSTEM_PROMPT
+    base_url = f"http://{args.sglang_router_ip}:{args.sglang_router_port}/v1"
+    return ComputerChatAgent.for_shot_width(int(getattr(args, "hud_shot_width", 640)))(
+        OpenAIChatConfig(
+            model_client=sglang_client(base_url),
+            model=args.hf_checkpoint,
+            system_prompt=system_prompt.format(max_steps=max_steps),
+            max_steps=max_steps,
+            completion_kwargs={
+                "max_tokens": int(getattr(args, "hud_max_tokens_per_turn", 512)),
+                "temperature": sampling_params.get("temperature", 1.0),
+                "top_p": sampling_params.get("top_p", 1.0),
+                "extra_body": {"return_token_ids": True},
+            },
+        )
+    )
+
+
+def _mint_task(meta: dict):
+    from hud import Task  # noqa: PLC0415
+
+    return Task(env=meta["env"], id=meta["id"], args=meta.get("args") or {})
+
+
+def _collect_turns(run) -> list:
+    """The turns that produced tokens, in order."""
+    from hud.agents.types import AgentStep  # noqa: PLC0415
+
+    samples = run.trace.collect(lambda s: s.sample if isinstance(s, AgentStep) else None)
+    return [s for s in samples if s is not None and s.output_token_ids]
+
+
+def _collect_images(run) -> list[PILImage.Image]:
+    """Every screenshot the policy was shown, in message order.
+
+    The computer tool returns exactly one image per successful call, and the
+    harness forwards the last image of each tool result to the model, so the
+    images the model saw are the tool results' images, in step order.
+    """
+    import mcp.types as mcp_types  # noqa: PLC0415
+    from hud.agents.types import ToolStep  # noqa: PLC0415
+
+    images: list[PILImage.Image] = []
+    for step in run.trace.steps:
+        if not isinstance(step, ToolStep) or step.result is None:
+            continue
+        last = None
+        for block in step.result.content:
+            if isinstance(block, mcp_types.ImageContent):
+                last = block
+        if last is not None:
+            images.append(PILImage.open(io.BytesIO(base64.b64decode(last.data))).convert("RGB"))
+    return images
+
+
+def _resync_whitespace(
+    tokens: list[int],
+    loss_mask: list[int],
+    logprobs: list[float],
+    prompt: list[int],
+    response_start: int,
+    tokenizer,
+) -> tuple[list[int], list[int], list[float]] | None:
+    """Realign an accumulated sequence with a re-rendered prompt that differs
+    only in whitespace, or return None.
+
+    The one benign divergence: the model emits a blank line before its tool
+    call (``text\\n\\n<tool_call>``) and the tool parser + chat template
+    re-render it with a single newline. The tokenizer merges adjacent
+    punctuation into those tokens (``".\\n\\n"`` vs ``".\\n"`` are single,
+    different tokens), so the check is on decoded *text*: at each divergence
+    a small window on both sides must become equal once whitespace is
+    stripped, and the sequences must realign exactly after it -- a real
+    history rewrite cannot pass that. The re-render's tokens are adopted
+    (masked 0, logprob 0): later turns were conditioned on the canonical
+    form, so this keeps the training sequence identical to the context the
+    policy actually saw, at the cost of a token or two of loss per
+    occurrence. The returned tokens are a verbatim prefix of ``prompt``.
+    """
+
+    def sans_ws(ids: list[int]) -> str:
+        return "".join(tokenizer.decode(ids).split())
+
+    WINDOW = 4
+    out_t: list[int] = []
+    out_m: list[int] = []
+    out_l: list[float] = []
+    i = j = 0
+    while i < len(tokens):
+        if j < len(prompt) and tokens[i] == prompt[j]:
+            out_t.append(tokens[i])
+            if i >= response_start:
+                out_m.append(loss_mask[i - response_start])
+                out_l.append(logprobs[i - response_start])
+            i += 1
+            j += 1
+            continue
+        if i < response_start:
+            return None  # the fixed first prompt was rewritten: a real break
+        # Smallest window (wi, wj) -- allowing an empty side for pure
+        # whitespace insertion/deletion -- whose texts match sans whitespace
+        # and after which the token streams realign.
+        found = None
+        for wi in range(i, min(i + WINDOW, len(tokens)) + 1):
+            for wj in range(j, min(j + WINDOW, len(prompt)) + 1):
+                if wi == i and wj == j:
+                    continue
+                if sans_ws(tokens[i:wi]) != sans_ws(prompt[j:wj]):
+                    continue
+                if wi == len(tokens) or (wj < len(prompt) and tokens[wi] == prompt[wj]):
+                    found = (wi, wj)
+                    break
+            if found:
+                break
+        if found is None:
+            return None
+        wi, wj = found
+        out_t += prompt[j:wj]
+        out_m += [0] * (wj - j)
+        out_l += [0.0] * (wj - j)
+        i, j = wi, wj
+    return out_t, out_m, out_l
+
+
+def _stitch(turns, tokenizer=None) -> tuple[list[int], list[int], list[float], int] | None:
+    """Per-turn (prompt_ids, output_ids) -> one training sequence.
+
+    Returns (tokens, loss_mask, rollout_log_probs, response_start), where the
+    mask and logprobs cover the response region (everything after the first
+    turn's prompt): 1/logprob on tokens the policy emitted, 0/0.0 on the chat
+    scaffolding and screenshots re-rendered into later prompts.
+
+    A turn whose prompt stops reproducing the accumulated sequence ends the
+    stitch: the turns before it are still exactly what the policy emitted, so
+    the episode is kept up to that point rather than thrown away. (The harness
+    rewrites a turn's history when it cannot parse the tool call it produced --
+    a turn truncated mid-JSON, say -- which is one way this happens.) One
+    divergence is tolerated because it is canonicalization, not rewriting:
+    whitespace-only differences resync via ``_resync_whitespace``.
+    """
+    tokens: list[int] = []
+    loss_mask: list[int] = []
+    logprobs: list[float] = []
+    response_start = 0
+    for k, s in enumerate(turns):
+        prompt = list(s.prompt_token_ids)
+        output = list(s.output_token_ids)
+        if k == 0:
+            tokens = prompt
+            response_start = len(prompt)
+        else:
+            if prompt[: len(tokens)] != tokens:
+                resynced = (
+                    _resync_whitespace(tokens, loss_mask, logprobs, prompt, response_start, tokenizer)
+                    if tokenizer is not None
+                    else None
+                )
+                if resynced is None:
+                    pairs = zip(tokens, prompt, strict=False)
+                    d = next((i for i, (a, b) in enumerate(pairs) if a != b), len(tokens))
+                    logger.warning(
+                        "hud stitch ends early: turn %d diverges at token %d/%d; keeping %d turn(s)",
+                        k,
+                        d,
+                        len(tokens),
+                        k,
+                    )
+                    if tokenizer is not None:
+                        lo = max(0, d - 24)
+                        logger.warning(
+                            "hud stitch divergence detail: emitted %r != re-rendered %r",
+                            tokenizer.decode(tokens[lo : d + 24]),
+                            tokenizer.decode(prompt[lo : d + 24]),
+                        )
+                    break
+                tokens, loss_mask, logprobs = resynced
+                logger.info("hud stitch resynced whitespace at turn %d", k)
+            delta = prompt[len(tokens) :]
+            tokens += delta
+            loss_mask += [0] * len(delta)
+            logprobs += [0.0] * len(delta)
+        out_lp = list(s.output_logprobs)
+        if len(out_lp) != len(output):
+            out_lp = [0.0] * len(output)
+        tokens += output
+        loss_mask += [1] * len(output)
+        logprobs += out_lp
+    if not loss_mask:
+        return None  # not one usable turn
+    return tokens, loss_mask, logprobs, response_start
+
+
+def _vision_inputs(state: Any, images: list[PILImage.Image], tokens: list[int]) -> dict | None:
+    """pixel_values/image_grid_thw for the stitched sequence, verified against it.
+
+    The trace usually holds one more screenshot than the ids: the final tool
+    call's image lands after the loop's last model call and never enters a
+    prompt. So the match is by *prefix* -- the longest run of screenshots whose
+    cumulative image-token count equals the count in the ids. Anything but an
+    exact prefix match is a processing disagreement and fails loudly.
+    """
+    if not images:
+        return None
+    import torch  # noqa: PLC0415
+
+    image_token_id = state.processor.tokenizer.convert_tokens_to_ids("<|image_pad|>")
+    actual = sum(1 for t in tokens if t == image_token_id)
+    if actual == 0:
+        return None
+
+    processed = state.processor.image_processor(images=images, return_tensors="pt")
+    grid = processed["image_grid_thw"]
+    merge = getattr(state.processor.image_processor, "merge_size", 2)
+    per_image = (torch.prod(grid, dim=-1) // (merge * merge)).tolist()
+
+    total, keep = 0, 0
+    for count in per_image:
+        if total == actual:
+            break
+        total += int(count)
+        keep += 1
+    if total != actual:
+        raise ValueError(
+            f"image token mismatch: ids have {actual}, screenshots produce "
+            f"{int(sum(per_image))} (no prefix matches)"
+        )
+    if keep == len(images):
+        return {"pixel_values": processed["pixel_values"], "image_grid_thw": grid}
+    trimmed = state.processor.image_processor(images=images[:keep], return_tensors="pt")
+    return {"pixel_values": trimmed["pixel_values"], "image_grid_thw": trimmed["image_grid_thw"]}
+
+
+def _failed(sample: Sample, reason: str, state: Any) -> Sample:
+    """A structurally valid write-off that trains on nothing.
+
+    Downstream expects every field list-shaped and consistent even for
+    write-offs (``remove_sample`` zeroes the loss but the sample still travels
+    with the batch), so a failure must not leave ``None``s behind.
+
+    The write-off carries one minimal image, not just a pad token: under FSDP
+    every rank must invoke the vision tower the same number of times per
+    microbatch, because its layers' weight all-gathers are collectives. A
+    text-only sample skips them, and the ranks that did issue them block until
+    another phase happens to post a matching call -- a many-minute stall per
+    step, or a watchdog kill under the default NCCL timeout (miles#2406). One
+    dummy screenshot's worth of image tokens keeps every sample on the same
+    collective schedule.
+    """
+    logger.warning(reason)
+    import torch  # noqa: PLC0415
+
+    tok = state.processor.tokenizer
+    processed = state.processor.image_processor(images=[PILImage.new("RGB", (64, 64))], return_tensors="pt")
+    merge = getattr(state.processor.image_processor, "merge_size", 2)
+    n_image_tokens = int(torch.prod(processed["image_grid_thw"], dim=-1).sum().item()) // (merge * merge)
+
+    sample.status = Sample.Status.FAILED
+    sample.remove_sample = True
+    sample.tokens = (
+        [tok.convert_tokens_to_ids("<|vision_start|>")]
+        + [tok.convert_tokens_to_ids("<|image_pad|>")] * n_image_tokens
+        + [tok.convert_tokens_to_ids("<|vision_end|>")]
+    )
+    sample.multimodal_train_inputs = {
+        "pixel_values": processed["pixel_values"],
+        "image_grid_thw": processed["image_grid_thw"],
+    }
+    sample.response_length = 0
+    sample.response = ""
+    sample.loss_mask = []
+    sample.rollout_log_probs = []
+    sample.metadata.setdefault("reward", 0.0)
+    return sample
+
+
+async def generate(args: Any, sample: Sample, sampling_params) -> Sample:
+    assert not args.partial_rollout, "Partial rollout is not supported for HUD rollouts."
+
+    # In-function on purpose: sglang_rollout pulls in sglang_router, which only
+    # exists on a training node; keeping it out of module scope is what lets
+    # the offline tests import everything above.
+    from miles.rollout.sglang_rollout import GenerateState  # noqa: PLC0415
+
+    state = GenerateState(args)
+    meta = (sample.metadata or {}).get("hud_task")
+    if not meta:
+        raise ValueError("no HUD task row: expected sample.metadata['hud_task'] = {env, id, args}")
+
+    task = _mint_task(meta)
+    agent = _build_agent(args, dict(sampling_params))
+    runtime = _shared_runtime(args)
+    timeout = float(getattr(args, "hud_episode_timeout_s", 1800))
+
+    async with _sandbox_gate(args):
+        try:
+            job = await task.run(agent, runtime=runtime, rollout_timeout=timeout)
+        except Exception as e:  # noqa: BLE001
+            # One episode runs one cloud sandbox, and a long run starts
+            # hundreds: a provider hiccup is a routine event, not a reason to
+            # take the rollout down. Written off with the traceback kept, so a
+            # systematic failure still shows up as a rising drop count rather
+            # than as silence.
+            logger.warning("hud episode failed to run: %s", e, exc_info=True)
+            return _failed(sample, f"hud episode errored: {type(e).__name__}", state)
+
+    run = (getattr(job, "runs", None) or [None])[0]
+    if run is None:
+        return _failed(sample, "hud episode produced no run", state)
+
+    sample.metadata["reward"] = float(run.reward or 0.0)
+    sample.metadata["hud_trace_status"] = str(run.trace.status)
+
+    turns = _collect_turns(run)
+    stitched = _stitch(turns, state.tokenizer) if turns else None
+    if stitched is None:
+        # No token data, or the prefix property broke. Either way there is
+        # nothing safe to train on in this episode.
+        return _failed(sample, f"hud episode unusable (turns={len(turns)}, stitch broke)", state)
+
+    tokens, loss_mask, logprobs, response_start = stitched
+    try:
+        vision = _vision_inputs(state, _collect_images(run), tokens)
+    except ValueError as e:
+        return _failed(sample, f"hud episode dropped: {e}", state)
+    if vision is None:
+        # The stitch ended before the first screenshot came back, so the kept
+        # turns are text-only. Written off for the same vision-tower collective
+        # parity that shapes _failed -- and there is next to nothing to learn
+        # from a turn the harness could not even parse a tool call out of.
+        return _failed(sample, "hud episode kept no screenshot", state)
+    sample.multimodal_train_inputs = vision
+
+    sample.tokens = tokens
+    sample.response_length = len(tokens) - response_start
+    sample.loss_mask = loss_mask
+    sample.rollout_log_probs = logprobs
+    sample.response = state.tokenizer.decode(tokens[response_start:], skip_special_tokens=False)
+    sample.status = Sample.Status.COMPLETED
+    logger.info(
+        "[hud %s] reward=%.3f turns=%d tokens=%d (response=%d)",
+        meta.get("slug", meta["id"]),
+        sample.metadata["reward"],
+        len(turns),
+        len(tokens),
+        sample.response_length,
+    )
+    return sample
+
+
+async def reward_func(args, samples: Sample | list[Sample], **kwargs) -> float | list[float]:
+    """Pass through the reward HUD's task template computed inside the env."""
+    if isinstance(samples, list):
+        return [s.metadata.get("reward", 0.0) for s in samples]
+    return samples.metadata.get("reward", 0.0)

--- a/examples/experimental/hud/run_hud2048.py
+++ b/examples/experimental/hud/run_hud2048.py
@@ -1,0 +1,194 @@
+"""HUD v6 2048 computer-use GRPO launcher (Qwen3-VL-4B-Instruct, FSDP, single node).
+
+Based on the CI-verified qwen3_vl FSDP recipe (tests/e2e/fsdp/
+test_qwen3_vl_4B_fsdp.py); swaps in the HUD rollout and the env-side reward.
+Prompts are task slugs (the real prompt is the task template's first yield,
+delivered inside the environment), so no --multimodal-keys: screenshots arrive
+at runtime through the harness.
+
+--sglang-tool-call-parser is load-bearing: the policy acts through OpenAI
+function calling, and without the parser its tool calls stay unparsed text,
+every episode ends at turn 1, and training silently optimizes nothing.
+
+Env knobs:
+  MILES_SCRIPT_MODEL_NAME   default Qwen3-VL-4B-Instruct
+  MILES_SCRIPT_NUM_GPUS     default 8
+  MILES_SCRIPT_NUM_ROLLOUT  default 40
+  MILES_SCRIPT_MODE         normal | debug_rollout_only (skips training)
+                            | smoke (2 episodes, rollout only)
+  MILES_SCRIPT_OUTPUT_DIR   checkpoints and rollout dumps; point at storage
+                            that outlives the node (default /root/hud2048-rl)
+
+MODE=smoke is the rung to use when checking that the plumbing works: the bugs
+a rollout batch surfaces are per-episode ones, so two episodes find them in
+four minutes where a full batch takes half an hour. What a bigger *rollout*
+batch cannot tell you -- reward spread within a group, weight sync, hours-long
+stability -- needs real training, so go there next rather than widening this.
+"""
+
+import os
+from pathlib import Path
+
+import miles.utils.external_utils.command_utils as U
+
+MODEL_NAME = os.environ.get("MILES_SCRIPT_MODEL_NAME", "Qwen3-VL-4B-Instruct")
+NUM_GPUS = int(os.environ.get("MILES_SCRIPT_NUM_GPUS", "8"))
+NUM_ROLLOUT = int(os.environ.get("MILES_SCRIPT_NUM_ROLLOUT", "40"))
+MODE = os.environ.get("MILES_SCRIPT_MODE", "normal")
+OUTPUT_DIR = os.environ.get("MILES_SCRIPT_OUTPUT_DIR", "/root/hud2048-rl")
+
+SMOKE = MODE == "smoke"
+# 4 prompts x 8 samples: the group size is what gives GRPO its within-group
+# reward spread, so it is a training parameter, not a throughput one.
+BATCH_SIZE, SAMPLES_PER_PROMPT = (1, 2) if SMOKE else (4, 8)
+
+
+def preflight() -> dict[str, str]:
+    """Check what every episode needs, before any GPU is claimed.
+
+    Both failures this catches -- a missing SDK, a missing Daytona credential --
+    would otherwise first appear inside an episode, where the sample is dropped
+    and the rollout loop simply refills: a silent churn burning GPUs instead of
+    an error. (The credential contract follows the openenv example's: workers
+    read the key from their own environment or from a file, and the launcher
+    forwards only the *path*, because worker env rides Ray's runtime_env, which
+    is echoed into driver logs and persisted in job metadata in plaintext.)
+    """
+    import importlib.util  # noqa: PLC0415 - launch-time only
+
+    for module, hint in (("hud", "pip install hud"), ("daytona", "pip install daytona")):
+        if importlib.util.find_spec(module) is None:
+            raise SystemExit(f"the rollout needs the {module} SDK: {hint}")
+
+    key_file = Path(os.environ.get("DAYTONA_API_KEY_FILE", "~/.config/daytona/api_key")).expanduser()
+    try:
+        has_file = bool(key_file.read_text().strip())
+    except OSError:
+        has_file = False
+    if has_file:
+        print(f"hud: Daytona credential: file {key_file} (forwarding the path, workers read it)")
+        return {"DAYTONA_API_KEY_FILE": str(key_file)}
+    if os.environ.get("DAYTONA_API_KEY", "").strip():
+        print("hud: Daytona credential: worker environment (DAYTONA_API_KEY assumed present there)")
+        return {}
+    raise SystemExit(
+        "the HUD sandbox needs Daytona credentials: put the key in a file "
+        f"({key_file}; DAYTONA_API_KEY_FILE overrides) or in the workers' environment "
+        "as DAYTONA_API_KEY. Provision the file with:\n"
+        "  mkdir -p ~/.config/daytona && echo dtn_... > ~/.config/daytona/api_key"
+    )
+
+
+def execute():
+    ckpt_args = f"--hf-checkpoint /root/models/{MODEL_NAME} "
+
+    rollout_args = (
+        "--prompt-data /root/hud2048_train.jsonl "
+        "--input-key prompt "
+        "--label-key label "
+        # carries the HUD task row (env, template id, args) onto Sample.metadata
+        "--metadata-key metadata "
+        "--apply-chat-template "
+        "--rollout-shuffle "
+        f"--num-rollout {1 if SMOKE else NUM_ROLLOUT} "
+        f"--rollout-batch-size {BATCH_SIZE} "
+        f"--n-samples-per-prompt {SAMPLES_PER_PROMPT} "
+        "--rollout-max-response-len 12288 "
+        "--rollout-max-context-len 16384 "
+        "--rollout-temperature 1.0 "
+        f"--global-batch-size {BATCH_SIZE * SAMPLES_PER_PROMPT} "
+    )
+
+    custom_args = (
+        "--custom-generate-function-path examples.experimental.hud.rollout.generate "
+        "--custom-rm-path examples.experimental.hud.rollout.reward_func "
+        "--custom-config-path examples/experimental/hud/hud2048_config.yaml "
+    )
+
+    # A rollout batch of long multi-image episodes is ~2GB of pixel tensors;
+    # dispatching it to the train actors keeps rank 0 busy past the default
+    # 10-minute NCCL timeout while the other ranks sit in their first
+    # collective, and the watchdog then kills the job at the end of step one.
+    fsdp_args = (
+        "--train-backend fsdp --gradient-checkpointing --update-weight-buffer-size 536870912 "
+        "--distributed-timeout-minutes 60 "
+    )
+
+    grpo_args = (
+        "--advantage-estimator grpo "
+        "--kl-loss-coef 0.00 "
+        "--kl-loss-type low_var_kl "
+        "--kl-coef 0.00 "
+        "--entropy-coef 0.00 "
+        "--eps-clip 0.2 "
+        "--eps-clip-high 0.28 "
+    )
+
+    optimizer_args = (
+        "--optimizer adam "
+        "--lr 1e-6 "
+        "--lr-decay-style constant "
+        "--weight-decay 0.1 "
+        "--adam-beta1 0.9 "
+        "--adam-beta2 0.98 "
+    )
+
+    # Telemetry. The dashboard collector is what makes a multi-hour run
+    # diagnosable after the fact; log-multi-turn adds per-turn counts and
+    # lengths, the difference between "the reward moved" and knowing how many
+    # actions produced it.
+    telemetry_args = "--use-miles-dashboard --dashboard-gpu-sample-interval 5 --log-multi-turn --log-passrate "
+
+    sglang_args = (
+        "--rollout-num-gpus-per-engine 1 "
+        "--sglang-mem-fraction-static 0.6 "
+        "--sglang-decode-log-interval 1000 "
+        "--sglang-enable-metrics "
+        "--sglang-attention-backend fa3 "
+        "--sglang-tool-call-parser qwen25 "
+        "--attn-implementation flash_attention_3 "
+    )
+
+    debug_args = "--debug-rollout-only " if MODE in ("debug_rollout_only", "smoke") else ""
+
+    misc_args = (
+        "--actor-num-nodes 1 "
+        f"--actor-num-gpus-per-node {NUM_GPUS} "
+        "--colocate "
+        # Point MILES_SCRIPT_OUTPUT_DIR at storage that outlives the node --
+        # without --save a multi-hour run leaves nothing but a metrics curve
+        # behind, and a config change means relearning from the base model.
+        f"--save {OUTPUT_DIR}/ckpt "
+        "--save-interval 5 "
+        f"--dump-details {OUTPUT_DIR}/dump "
+    )
+
+    train_args = (
+        f"{ckpt_args} "
+        f"{rollout_args} "
+        f"{custom_args} "
+        f"{optimizer_args} "
+        f"{grpo_args} "
+        f"{U.get_default_wandb_args(__file__)} "
+        f"{fsdp_args} "
+        f"{sglang_args} "
+        f"{telemetry_args} "
+        f"{debug_args} "
+        f"{misc_args} "
+    )
+
+    extra_env_vars = {"CUDA_DEVICE_MAX_CONNECTIONS": "1", **preflight()}
+    for key in ("WANDB_API_KEY", "HUD_API_KEY"):
+        if os.environ.get(key):
+            extra_env_vars[key] = os.environ[key]
+
+    U.execute_train(
+        train_args=train_args,
+        num_gpus_per_node=NUM_GPUS,
+        megatron_model_type=None,
+        extra_env_vars=extra_env_vars,
+    )
+
+
+if __name__ == "__main__":
+    execute()

--- a/examples/experimental/hud/sglang_compat.py
+++ b/examples/experimental/hud/sglang_compat.py
@@ -1,0 +1,66 @@
+"""An AsyncOpenAI client that lets stock sglang serve HUD's token-id contract.
+
+HUD's ``OpenAIChatAgent`` (with ``extra_body={"return_token_ids": True}``)
+expects each choice to carry ``token_ids`` (output) and ``prompt_token_ids``.
+sglang has both, under different names and shapes:
+
+  request:  return_prompt_token_ids=True  -> choice.prompt_token_ids
+            return_meta_info=True         -> choice.meta_info.output_token_logprobs
+                                             as (logprob, token_id, text) triples
+  (an input ``prompt_token_ids`` continuation field is not accepted; sglang
+   re-renders the chat template per turn. Verified: the rendered prompt of
+   turn k+1 starts with prompt+output of turn k, so exact stitching survives.)
+
+This transport rewrites the request flags on the way out and synthesizes
+``choice.token_ids`` on the way back. No sglang changes, no HUD changes.
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+from openai import AsyncOpenAI
+
+
+class _SglangTokenIds(httpx.AsyncBaseTransport):
+    def __init__(self) -> None:
+        self._inner = httpx.AsyncHTTPTransport()
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        is_chat = request.url.path.endswith("/chat/completions")
+        if is_chat:
+            body = json.loads(request.content or b"{}")
+            if body.pop("return_token_ids", None):
+                body["return_prompt_token_ids"] = True
+                body["return_meta_info"] = True
+            # HUD's KV-continuation field; sglang re-renders the template instead.
+            body.pop("prompt_token_ids", None)
+            content = json.dumps(body).encode()
+            headers = {k: v for k, v in request.headers.items() if k.lower() != "content-length"}
+            request = httpx.Request(request.method, request.url, headers=headers, content=content)
+
+        response = await self._inner.handle_async_request(request)
+
+        if is_chat and response.status_code == 200:
+            data = json.loads(await response.aread())
+            for choice in data.get("choices", []):
+                triples = (choice.get("meta_info") or {}).get("output_token_logprobs") or []
+                if triples and "token_ids" not in choice:
+                    choice["token_ids"] = [t[1] for t in triples]
+            content = json.dumps(data).encode()
+            headers = {
+                k: v
+                for k, v in response.headers.items()
+                if k.lower() not in ("content-length", "content-encoding", "transfer-encoding")
+            }
+            response = httpx.Response(response.status_code, headers=headers, content=content, request=request)
+        return response
+
+
+def sglang_client(base_url: str, api_key: str = "EMPTY") -> AsyncOpenAI:
+    return AsyncOpenAI(
+        api_key=api_key,
+        base_url=base_url,
+        http_client=httpx.AsyncClient(transport=_SglangTokenIds(), timeout=600),
+    )

--- a/examples/experimental/hud/tests/test_computer_tool.py
+++ b/examples/experimental/hud/tests/test_computer_tool.py
@@ -1,0 +1,130 @@
+"""Offline tests: no GPU, no network, no Daytona, no live model.
+
+computer_tool.py's translation: function-call arguments -> RFB
+primitives, with coordinate scaling and focus semantics.
+The HUD side of the seam is faked at exactly the boundary the real code
+touches.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+hud = pytest.importorskip("hud", reason="pip install hud -- the recipe's one extra dependency")
+
+from examples.experimental.hud.computer_tool import ChatComputerTool, computer_tool_class, to_keysym
+
+
+class _Recorder:
+    """Stands in for the RFB primitives; records what dispatch decided."""
+
+    def __init__(self, tool):
+        self.calls = []
+        tool.click = self._make("click")
+        tool.press_keys = self._make("press_keys")
+        tool.type_text = self._make("type_text")
+        tool.scroll = self._make("scroll")
+        tool.wait = self._make("wait")
+
+        async def _obs():
+            return "OBS"
+
+        tool._observation = _obs
+
+    def _make(self, name):
+        async def record(*a, **k):
+            self.calls.append((name, a, k))
+
+        return record
+
+
+def _tool(shot_width=640, display_width=1920, focused=True):
+    cls = computer_tool_class(shot_width)
+    tool = cls.__new__(cls)  # skip RFBTool.__init__: no live VNC in tests
+    tool.spec = cls.default_spec("m")
+    tool.client = SimpleNamespace(width=display_width, height=1080)
+    # Most tests are about translation, not the one-time focus click.
+    tool._pointer_used = focused
+    return tool
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+def test_press_sequence_is_one_call_per_key():
+    """press(['Left','Down']) must be two keystrokes; a single call with both
+    keys would be a chord (hotkey), and 2048 would see one move, not two."""
+    tool = _tool()
+    rec = _Recorder(tool)
+    _run(tool.execute({"action": "press", "keys": ["Left", "Down"]}))
+    presses = [c for c in rec.calls if c[0] == "press_keys"]
+    assert [c[1][0] for c in presses] == [["Left"], ["Down"]]
+
+
+def test_plus_means_chord():
+    tool = _tool()
+    rec = _Recorder(tool)
+    _run(tool.execute({"action": "press", "keys": ["ctrl+c"]}))
+    presses = [c for c in rec.calls if c[0] == "press_keys"]
+    assert presses[0][1][0] == ["Control_L", "c"]
+
+
+def test_first_keystroke_takes_focus_and_only_once():
+    """A screen that has focused nothing drops opening keystrokes silently, so
+    the tool establishes focus once -- and only once, since a click carries
+    meaning of its own."""
+    tool = _tool(focused=False)
+    rec = _Recorder(tool)
+    _run(tool.execute({"action": "press", "keys": ["Left"]}))
+    _run(tool.execute({"action": "press", "keys": ["Down"]}))
+    assert len([c for c in rec.calls if c[0] == "click"]) == 1
+
+
+def test_a_click_of_the_models_own_counts_as_focus():
+    """The model clicking where it means to type is the real thing; the
+    tool's fallback must not fire on top of it."""
+    tool = _tool(focused=False)
+    rec = _Recorder(tool)
+    _run(tool.execute({"action": "click", "x": 10, "y": 20}))
+    _run(tool.execute({"action": "press", "keys": ["Left"]}))
+    clicks = [c for c in rec.calls if c[0] == "click"]
+    assert len(clicks) == 1 and clicks[0][1] == (30, 60)  # the model's, scaled
+
+
+def test_key_aliases_map_to_keysyms():
+    assert to_keysym("enter") == "Return"
+    assert to_keysym("arrowleft") == "Left"
+    assert to_keysym("F5") == "F5"  # unknown keys pass through untouched
+
+
+def test_click_scales_from_shot_to_screen():
+    """The model clicks in the 640px frame it saw; the screen is 1920px."""
+    tool = _tool(shot_width=640, display_width=1920)
+    rec = _Recorder(tool)
+    _run(tool.execute({"action": "click", "x": 320, "y": 180}))
+    clicks = [c for c in rec.calls if c[0] == "click"]
+    assert clicks[0][1] == (960, 540)
+
+
+def test_unknown_action_is_an_error_not_a_crash():
+    tool = _tool()
+    _Recorder(tool)
+    result = _run(tool.execute({"action": "fly"}))
+    assert result.isError
+
+
+def test_tool_params_are_valid_function_schema():
+    tool = _tool()
+    params = tool.to_params()
+    assert params["type"] == "function"
+    assert params["function"]["name"] == "computer"
+    assert "press" in params["function"]["parameters"]["properties"]["action"]["enum"]
+
+
+def test_shot_width_travels_on_the_class():
+    assert computer_tool_class(640) is ChatComputerTool
+    assert computer_tool_class(960).shot_width == 960

--- a/examples/experimental/hud/tests/test_make_hud_data.py
+++ b/examples/experimental/hud/tests/test_make_hud_data.py
@@ -1,0 +1,23 @@
+"""Offline tests: no GPU, no network, no Daytona, no live model.
+
+make_hud_data.py's translation: a HUD task template -> one training
+row.
+The HUD side of the seam is faked at exactly the boundary the real code
+touches.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+hud = pytest.importorskip("hud", reason="pip install hud -- the recipe's one extra dependency")
+
+from examples.experimental.hud.make_hud_data import task_row
+
+
+def test_task_row_carries_what_the_rollout_needs():
+    task = SimpleNamespace(env="browser", id="2048-score", args={"target_score": 5000}, slug="s")
+    row = task_row(task)
+    assert row == {"env": "browser", "id": "2048-score", "args": {"target_score": 5000}, "slug": "s"}

--- a/examples/experimental/hud/tests/test_rollout.py
+++ b/examples/experimental/hud/tests/test_rollout.py
@@ -1,0 +1,222 @@
+"""Offline tests: no GPU, no network, no Daytona, no live model.
+
+rollout.py's translation: per-turn server token ids -> one training
+sequence with masks (including whitespace resync), the vision inputs
+verified against it, and the shape of a write-off.
+The HUD side of the seam is faked at exactly the boundary the real code
+touches.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+hud = pytest.importorskip("hud", reason="pip install hud -- the recipe's one extra dependency")
+
+from examples.experimental.hud.rollout import _stitch, _vision_inputs
+
+
+def _turn(prompt, output, logprobs=None):
+    return SimpleNamespace(
+        prompt_token_ids=prompt,
+        output_token_ids=output,
+        output_logprobs=logprobs if logprobs is not None else [-0.1] * len(output),
+        prompt_chunks=None,
+    )
+
+
+def test_stitch_two_turns_masks_only_policy_tokens():
+    """The mask is the training signal's boundary: 1 on what the policy
+    emitted, 0 on the scaffolding and screenshots re-rendered into turn 2."""
+    t0 = _turn([1, 2, 3], [10, 11])
+    t1 = _turn([1, 2, 3, 10, 11, 4, 5], [12])
+    tokens, mask, logprobs, start = _stitch([t0, t1])
+    assert tokens == [1, 2, 3, 10, 11, 4, 5, 12]
+    assert start == 3
+    assert mask == [1, 1, 0, 0, 1]  # out0, out0, delta, delta, out1
+    assert logprobs[:2] == [-0.1, -0.1] and logprobs[2:4] == [0.0, 0.0]
+    assert len(mask) == len(tokens) - start == len(logprobs)
+
+
+class _WsTokenizer:
+    """Fake tokenizer for resync tests: ids decode to fixed strings."""
+
+    VOCAB = {271: "\n\n", 198: "\n", 220: " ", 50: ".\n\n", 51: ".\n"}
+
+    def decode(self, ids, **kwargs):
+        return "".join(self.VOCAB.get(i, f"<{i}>") for i in ids)
+
+
+def test_stitch_resyncs_when_the_rerender_canonicalizes_whitespace():
+    """The model emits a blank line before its tool call; the parser + chat
+    template re-render it as a single newline. That is canonicalization, not a
+    history rewrite, so the stitch adopts the re-render's whitespace (masked
+    0) and keeps the rest of the episode."""
+    t0 = _turn([1, 2], [10, 271, 11])  # output ends "...\n\n<tool_call>"
+    t1 = _turn([1, 2, 10, 198, 11, 4, 5], [12])  # re-rendered with "\n"
+    tokens, mask, logprobs, start = _stitch([t0, t1], tokenizer=_WsTokenizer())
+    assert tokens == [1, 2, 10, 198, 11, 4, 5, 12]
+    assert start == 2
+    # out0, adopted ws (0), out0, delta, delta, out1
+    assert mask == [1, 0, 1, 0, 0, 1]
+    assert logprobs[1] == 0.0  # the adopted token carries no logprob
+
+
+def test_stitch_resync_refuses_a_real_rewrite():
+    """Non-whitespace divergence must still end the stitch, tokenizer or not."""
+    t0 = _turn([1, 2], [10, 11])
+    t1 = _turn([1, 2, 10, 99, 4], [12])  # 11 -> 99 is a real rewrite
+    tokens, mask, logprobs, start = _stitch([t0, t1], tokenizer=_WsTokenizer())
+    assert tokens == [1, 2, 10, 11]  # turn 0 only
+    assert mask == [1, 1]
+
+
+def test_stitch_resync_refuses_when_the_remainder_shifts():
+    """Whitespace at the divergence is not enough: everything after it must
+    realign exactly, otherwise the whole tail was rewritten."""
+    t0 = _turn([1, 2], [10, 271, 11])
+    t1 = _turn([1, 2, 10, 198, 77, 4], [12])  # after the ws, 11 -> 77
+    tokens, mask, logprobs, start = _stitch([t0, t1], tokenizer=_WsTokenizer())
+    assert tokens == [1, 2, 10, 271, 11]  # turn 0 kept as emitted
+
+
+def test_stitch_resyncs_punctuation_merged_whitespace_tokens():
+    """The real tokenizer merges adjacent punctuation into whitespace tokens:
+    the model's '.\\n\\n' and the re-render's '.\\n' are single, different,
+    non-pure-whitespace tokens. Sans-whitespace *text* equality is the check
+    that survives this; a per-token pure-whitespace test does not."""
+    t0 = _turn([1, 2], [10, 50, 11])  # "...URL.\n\n<tool_call>"
+    t1 = _turn([1, 2, 10, 51, 11, 4, 5], [12])  # re-rendered "...URL.\n<tool_call>"
+    tokens, mask, logprobs, start = _stitch([t0, t1], tokenizer=_WsTokenizer())
+    assert tokens == [1, 2, 10, 51, 11, 4, 5, 12]
+    assert mask == [1, 0, 1, 0, 0, 1]
+
+
+def test_stitch_resync_handles_a_whitespace_run():
+    """A two-token whitespace run collapsing to one token still realigns."""
+    t0 = _turn([1, 2], [10, 198, 198, 11])
+    t1 = _turn([1, 2, 10, 271, 11, 4], [12])
+    tokens, mask, logprobs, start = _stitch([t0, t1], tokenizer=_WsTokenizer())
+    assert tokens == [1, 2, 10, 271, 11, 4, 12]
+    assert mask == [1, 0, 1, 0, 1]
+
+
+def test_stitch_stops_at_a_rewritten_turn_and_keeps_the_rest():
+    """The harness rewrites a turn's history when it cannot parse the tool call
+    it produced. Turns before that are still exactly what the policy emitted,
+    so they are kept and the divergent turn ends the episode."""
+    t0 = _turn([1, 2, 3], [10])
+    t1 = _turn([1, 2, 99, 10, 4], [12])  # 3 -> 99: history was rewritten
+    tokens, mask, logprobs, start = _stitch([t0, t1])
+    assert tokens == [1, 2, 3, 10]  # turn 0 only
+    assert mask == [1] and start == 3
+
+
+def test_stitch_refuses_when_no_turn_survives():
+    """Nothing to train on must be a failure, not an empty sample."""
+    t0 = _turn([1, 2], [])  # no output tokens at all
+    assert _stitch([t0]) is None
+
+
+def test_stitch_single_turn():
+    tokens, mask, logprobs, start = _stitch([_turn([1, 2], [7, 8, 9])])
+    assert (tokens, start) == ([1, 2, 7, 8, 9], 2)
+    assert mask == [1, 1, 1]
+
+
+def test_stitch_pads_missing_logprobs_with_zeros():
+    tokens, mask, logprobs, _ = _stitch([_turn([1], [7, 8], logprobs=[-0.5])])  # wrong length
+    assert logprobs == [0.0, 0.0]
+
+
+# ---- vision input verification ----
+
+
+class _FakeImageProcessor:
+    merge_size = 2
+
+    def __call__(self, images, return_tensors):
+        import torch
+
+        n = len(images)
+        # each fake image -> grid (1, 4, 4) = 16 patches -> 4 image tokens
+        return {
+            "pixel_values": torch.zeros(n * 16, 8),
+            "image_grid_thw": torch.tensor([[1, 4, 4]] * n),
+        }
+
+
+def _fake_state():
+    processor = SimpleNamespace(
+        image_processor=_FakeImageProcessor(),
+        tokenizer=SimpleNamespace(convert_tokens_to_ids=lambda tok: 777),
+    )
+    return SimpleNamespace(processor=processor)
+
+
+def test_vision_inputs_verified_against_token_ids():
+    from PIL import Image
+
+    imgs = [Image.new("RGB", (8, 8)) for _ in range(2)]
+    tokens = [777] * 8 + [1, 2]  # 2 images x 4 tokens each
+    out = _vision_inputs(_fake_state(), imgs, tokens)
+    assert out["image_grid_thw"].shape[0] == 2
+
+
+def test_vision_inputs_trim_the_screenshot_the_model_never_saw():
+    """The last tool call's screenshot lands after the loop's final model call
+    and never enters a prompt, so the trace holds one more image than the ids
+    -- an exact prefix, kept; the trailing image, dropped."""
+    from PIL import Image
+
+    imgs = [Image.new("RGB", (8, 8)) for _ in range(3)]
+    tokens = [777] * 8 + [1]  # ids saw 2 of the 3 images
+    out = _vision_inputs(_fake_state(), imgs, tokens)
+    assert out["image_grid_thw"].shape[0] == 2
+
+
+def test_vision_inputs_mismatch_fails_loudly():
+    """If the ids' image-token count matches no prefix of the screenshots,
+    something upstream disagreed about processing -- training must not
+    proceed."""
+    from PIL import Image
+
+    with pytest.raises(ValueError, match="image token mismatch"):
+        _vision_inputs(_fake_state(), [Image.new("RGB", (8, 8))] * 2, [777] * 3)
+
+
+def test_vision_inputs_none_without_images():
+    assert _vision_inputs(_fake_state(), [], [1, 2]) is None
+
+
+def test_failed_sample_is_shaped_for_the_trainer():
+    """A write-off still travels with the batch, so every field the trainer
+    indexes has to be present and consistent -- a None here surfaces as a
+    TypeError deep in the training step, after the rollout is already spent."""
+    from examples.experimental.hud.rollout import _failed
+
+    sample = SimpleNamespace(metadata={}, status=None, remove_sample=False)
+    _failed(sample, "boom", state=_fake_state())
+    assert sample.remove_sample is True
+    assert sample.loss_mask == [] and sample.rollout_log_probs == []
+    assert len(sample.loss_mask) == sample.response_length  # what the trainer asserts
+    assert sample.response == ""
+    assert sample.metadata["reward"] == 0.0
+
+
+def test_failed_sample_still_exercises_the_vision_tower():
+    """Under FSDP the vision tower's weight all-gathers are collectives, so
+    every sample -- write-offs included -- must invoke it exactly once per
+    forward. A text-only write-off desynchronizes the ranks' collective
+    schedules (observed live as a ~30-minute stall per step)."""
+    from examples.experimental.hud.rollout import _failed
+
+    sample = SimpleNamespace(metadata={}, status=None, remove_sample=False)
+    _failed(sample, "boom", state=_fake_state())
+    assert sample.multimodal_train_inputs is not None
+    assert sample.multimodal_train_inputs["image_grid_thw"].shape[0] == 1
+    # fake grid (1,4,4), merge 2 -> 4 image tokens + vision_start/end
+    assert len(sample.tokens) == 6
+    assert len(sample.tokens) >= sample.response_length

--- a/examples/experimental/hud/tests/test_sglang_compat.py
+++ b/examples/experimental/hud/tests/test_sglang_compat.py
@@ -1,0 +1,69 @@
+"""Offline tests: no GPU, no network, no Daytona, no live model.
+
+sglang_compat.py's translation: the request/response rewrite between
+HUD's vLLM-flavoured token flags and stock sglang.
+The HUD side of the seam is faked at exactly the boundary the real code
+touches.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+hud = pytest.importorskip("hud", reason="pip install hud -- the recipe's one extra dependency")
+
+from examples.experimental.hud.sglang_compat import _SglangTokenIds
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+class _CannedTransport:
+    """Fake inner transport: captures the outgoing request, returns a canned
+    sglang-shaped response."""
+
+    def __init__(self, payload):
+        self.payload = payload
+        self.seen_body = None
+
+    async def handle_async_request(self, request):
+        import httpx
+
+        self.seen_body = json.loads(request.content or b"{}")
+        return httpx.Response(200, json=self.payload, request=request)
+
+
+def _roundtrip(request_body, response_payload):
+    import httpx
+
+    shim = _SglangTokenIds()
+    canned = _CannedTransport(response_payload)
+    shim._inner = canned
+    request = httpx.Request("POST", "http://x/v1/chat/completions", content=json.dumps(request_body).encode())
+    response = _run(shim.handle_async_request(request))
+    return canned.seen_body, json.loads(response.content)
+
+
+def test_shim_rewrites_flags_and_synthesizes_token_ids():
+    sent, got = _roundtrip(
+        {"model": "m", "return_token_ids": True, "prompt_token_ids": [1, 2]},
+        {"choices": [{"meta_info": {"output_token_logprobs": [[-0.1, 5, "a"], [-0.2, 6, "b"]]}}]},
+    )
+    assert "return_token_ids" not in sent and "prompt_token_ids" not in sent
+    assert sent["return_prompt_token_ids"] is True and sent["return_meta_info"] is True
+    assert got["choices"][0]["token_ids"] == [5, 6]
+
+
+def test_shim_leaves_other_endpoints_alone():
+    import httpx
+
+    shim = _SglangTokenIds()
+    canned = _CannedTransport({"data": []})
+    shim._inner = canned
+    request = httpx.Request("GET", "http://x/v1/models")
+    _run(shim.handle_async_request(request))
+    assert canned.seen_body == {}


### PR DESCRIPTION
Trains a VLM to operate a real GUI through [HUD](https://hud.ai) v6
environments. HUD owns the episode — it boots the environment (one Daytona
sandbox per episode), runs the agent loop, and grades — while Miles owns
training. Nothing under `miles/` changes.

Verified on HUD's public browser starter (`hud init --preset browser`, no API
key), training Qwen3-VL-4B-Instruct with GRPO on 8×H200.

## What had to be built, and why

HUD's harness already collects per-turn token-level samples, so the connector's
job is not recording but three narrower things:

- **A screen for self-hosted models** — HUD ships computer-use tools for
  Claude/Gemini/OpenAI's native protocols; its OpenAI-*compatible* harness, the
  one an sglang policy speaks through, has none. `computer_tool.py` puts HUD's
  own VNC primitives behind a plain function-calling schema.
- **A token-id bridge** — the harness asks for `return_token_ids`, a vLLM
  extension; stock sglang has the same data under `return_prompt_token_ids` +
  `return_meta_info`. `sglang_compat.py` is a client-side transport that
  rewrites the request and synthesizes `choice.token_ids` from the meta_info
  logprob triples. No change on either side; plausibly upstreamable to sglang.
- **The stitch** — the server re-renders the chat template every turn, so
  `rollout.py` verifies per episode that turn k+1's prompt ids start with turn
  k's prompt+output, then concatenates into one sequence with loss mask 1 on
  policy tokens and 0 on scaffolding. One divergence is tolerated because it
  is canonicalization rather than rewriting: the tool parser collapses the
  whitespace the model emitted before its tool call (`.\n\n<tool_call>` →
  `.\n<tool_call>`), so a divergence whose two sides are text-equal once
  whitespace is stripped — and whose remainder realigns token-for-token —
  adopts the re-rendered tokens with mask 0 and continues. Anything else ends
  the episode at the last verified turn. Vision inputs are rebuilt from the
  screenshots the policy saw and checked against the image-token count in the
  ids; a mismatch drops the episode loudly, because a mis-stitched sequence
  corrupts training silently.

## Layering

Dependencies run one way, and each layer is ignorant of the one above it:

| layer | files | knows nothing about |
|---|---|---|
| transport | `sglang_compat.py` | HUD |
| computer use | `computer_tool.py`, `agent.py` | which task is running |
| HUD | `rollout.py`, `make_hud_data.py` | which taskset it runs, or what its reward means |
| the 2048 recipe | `hud2048_config.yaml`, `run_hud2048.py` | — |

A change lands in one of three places by kind: a **mechanism** in the general
layers, a **number** in the recipe config (each annotated with what it trades
against), and the **reward shape** in the data — which task template to train
on, retuned via `make_hud_data.py --args-json`. No code decides reward shape.

## What makes it learnable

Four things have to be true before RL has any signal:

- **The policy has to see the task.** At the starter's default 1280x800 the
  browser's own chrome crops the 4×4 board out of the viewport *and* gives the
  policy a sidebar to click, which takes keyboard focus away from the game.
  The fix is one edit to the env package (kiosk, taller desktop; the README
  has it).
- **Turns are the scarce resource, keystrokes are not.** Every turn re-prefills
  the whole screenshot history through the vision encoder. The system prompt
  says so, and the tool takes a key *sequence* per call — one call with several
  keys would be a chord, not several moves.
- **The reward has to be shaped to the reachable range.** The starter ships
  three graders for 2048; `reach_tile` is a step function that goes flat the
  moment a population converges on one tile, zeroing GRPO's within-group
  variance. This trains on `reach_score` (linear) with the target retuned.
- **Failures must be write-offs, not exceptions.** A long run starts hundreds
  of cloud sandboxes; a provider hiccup is routine. Episodes that error or fail
  to stitch become `remove_sample` write-offs with every field shaped as the
  trainer expects — including one dummy image, because under FSDP a text-only
  microbatch skips the vision tower's weight all-gathers and desynchronizes
  the ranks' collective schedules (#2406). One bad episode costs one sample
  rather than the rollout.

## Results

20 GRPO steps, 32 episodes/step, ~15 min/step on 8×H200:

- Mean episode reward 0.037 → ~0.07 (`reach_score` against the retuned
  target 1024); by the last steps all 32 episodes in a batch score, and
  `zero_std/all_zero_percentage` stays 0 throughout — every group keeps a
  gradient.
- Behaviourally: arrow keys per episode up ~40%, malformed tool calls → 0.
  The model first learns to reliably reach the board and spend its move
  budget — what a linear score reward buys first.
- 0 rollout failures over 640 episodes; the whitespace resync recovers every
  would-be stitch break (148/148), which roughly doubles the trained tokens
  per episode in the early steps.

## Tests

28 offline cases against fakes — no GPU, no network, no Daytona, ~3s:

```
python -m pytest examples/experimental/hud/tests/ -q
```

They cover the three translations this example owns: the stitch (including
whitespace resync, the prefix break, and the trailing screenshot the policy
never saw), the tool's dispatch and coordinate scaling, and the sglang
rewrite. `MODE=smoke` runs two real episodes for what a fake cannot cover.

## Notes

- Supersedes #2371, which reached the same task through HUD's pre-v6 taskset
  format. That leg's Daytona lifecycle code and multi-turn token accounting are
  both gone here — v6's `DaytonaRuntime` and harness provide them — which also
  removes that PR's dependency on private helpers in another example.
- The Daytona credential travels as a *path*, never a value: Ray records
  `runtime_env` verbatim into driver logs and job metadata. Promoting that
  contract out of the openenv example is #2393.
- The FSDP text-only-microbatch guard this recipe carries locally belongs in
  the trainer; that's #2406.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
