### PR TITLE
examples: fix READMEs — dead links, broken list structure, missing entries

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,25 +1,26 @@
 # Examples
 
-These examples provide concrete examples to leverage miles in your own RL workflow. Some examples are just demonstrative, but most of them are verifiable with a concrete performance score.
+These examples are runnable starting points for your own RL workflow. A few are purely demonstrative, but most are verifiable against a concrete performance score.
 
-## Directory Structure
+## Recipes
 
-Training recipes live at the top level. Two subdirectories group everything else:
-`infra_features/` for runtime and infrastructure plumbing, and `experimental/` for
-recipes that are not fully verified.
-
-### Recipes
+End-to-end training workflows — the place to start.
 
 - **[fully_async](./fully_async)**: Demonstrates fully asynchronous rollout generation for higher efficiency.
-- **[geo3k_vlm](./geo3k_vlm)**: Training VLMs with FSDP using GRPO on the GEO3K dataset, single-turn and [multi-turn](./geo3k_vlm/multi_turn).
+- **[geo3k_vlm](./geo3k_vlm)**: Training VLMs with FSDP using GRPO on the GEO3K dataset.
+  - **[multi_turn](./geo3k_vlm/multi_turn)**: The same dataset over multiple turns, with the model cropping images through an interactive environment.
 - **[lora](./lora)**: LoRA fine-tuning with the Megatron backend.
 - **[multi_lora](./multi_lora)**: Fully-async multi-adapter LoRA training with a slot-keyed adapter page table.
-- **[on_policy_distillation](./on_policy_distillation)**: Example implementation for on-policy distillation, extending the reinforcement learning pipeline to support teacher–student distillation directly within on-policy training.
+- **[on_policy_distillation](./on_policy_distillation)**: Teacher–student distillation on the student's own rollouts, run inside the on-policy training loop.
+  - **[qwen3_5_35b_selfdistill](./on_policy_distillation/qwen3_5_35b_selfdistill)**: Two-phase self-distillation of Qwen3.5-35B-A3B on one 8xH200 node, with an in-process Megatron teacher.
 - **[ppo](./ppo)**: Actor-critic PPO with GAE advantages, where the critic shares the actor's train GPUs.
 - **[retool_v2](./retool_v2)**: Tool-enabled language model generation with sandboxed Python code execution interleaved with thinking.
 - **[swe-agent-harbor-docker](./swe-agent-harbor-docker)**: Trains coding and terminal agents with Harbor-managed local Docker sandboxes and verifier rewards.
 
-### [infra_features](./infra_features)
+## [Infra Features](./infra_features)
+
+Runtime and infrastructure plumbing rather than training recipes — how miles moves
+data and weights around.
 
 - **[low_precision](./infra_features/low_precision)**: Examples of FP8 training and inference, plus INT4 QAT, for improved throughput and stability.
 - **[p2p_weight_transfer](./infra_features/p2p_weight_transfer)**: Point-to-point weight transfer between training and rollout engines.
@@ -27,18 +28,21 @@ recipes that are not fully verified.
 - **[train_infer_mismatch_helper](./infra_features/train_infer_mismatch_helper)**: Algorithmic methods for rollout correction (e.g., TIS, MIS).
 - **[true_on_policy](./infra_features/true_on_policy)**: Ensures strictly equal log probabilities between inference (SGLang) and training engines.
 
-### [experimental](./experimental)
+## [Experimental](./experimental)
 
 Not fully verified — for experimental and development use.
 
+- **[agentenv](./experimental/agentenv)**: Rollouts against AgentENV, a self-hosted platform running agent sandboxes on Firecracker microVMs.
 - **[DrGRPO](./experimental/DrGRPO)**: Custom reducer for Dr.GRPO algorithm.
 - **[eval](./experimental/eval)**: Documentation and setup for evaluation environments using NeMo-Skills.
 - **[eval_multi_task](./experimental/eval_multi_task)**: Example for supporting OOD evaluation tasks, e.g., GPQA, IFBench.
 - **[formal_math](./experimental/formal_math)**: Examples related to formal math reasoning tasks, including a single round demo.
 - **[multi_agent](./experimental/multi_agent)**: Example of running multi-agent RL with `miles`.
+- **[nemo-gym](./experimental/nemo-gym)**: SWE-agent training with NVIDIA NeMo Gym as the environment ecosystem.
 - **[openenv](./experimental/openenv)**: Rollouts against OpenEnv-hosted environments.
 - **[reproducibility](./experimental/reproducibility)**: Guides on achieving bitwise experiment reproduction using deterministic modes.
 - **[search-r1](./experimental/search-r1)**: A minimal reproduction of Search-R1, featuring multi-turn conversation and tool-calling.
 - **[strands_sglang](./experimental/strands_sglang)**: Integration example with the Strands-Agents scaffolding framework.
 - **[swe-agent-harbor-daytona](./experimental/swe-agent-harbor-daytona)**: The `swe-agent-harbor-docker` pipeline with task sandboxes hosted on Daytona instead of local Docker.
 - **[tau-bench](./experimental/tau-bench)**: Training in an agentic multi-turn tool use environment (Tau-bench).
+- **[verifiers](./experimental/verifiers)**: Training on a Prime Intellect Verifiers environment instead of a Miles prompt dataset.

--- a/examples/infra_features/README.md
+++ b/examples/infra_features/README.md
@@ -1,4 +1,6 @@
-The examples under this directory exercise runtime and infrastructure behaviour rather than a
-training recipe: weight transfer, low precision, train/inference agreement, and the async
-rollout loop. Reach for them when the question is how miles moves data and weights around, not
-how to train a particular model.
+# Infra Features
+
+These examples exercise runtime and infrastructure behaviour rather than a training recipe.
+They cover weight transfer, low precision, train/inference agreement, and the async rollout
+loop. Reach for them when the question is how miles moves data and weights around, not how to
+train a particular model.

--- a/examples/infra_features/low_precision/README.md
+++ b/examples/infra_features/low_precision/README.md
@@ -10,38 +10,38 @@ This is an example of FP8 training and FP8 inference. Under FP8 training and inf
 
 ## Quick Start
 
-1. Check if your training script is properly configured. 
+1. Check if your training script is properly configured.
 
-For training tasks, we need to add these flags:
-```bash
---fp8-format e4m3
---fp8-recipe blockwise
-# --fp8-param-gather # [optional] Currently incompatible with CPU Adam
-```
-Then ensure the `NVTE_FP8_BLOCK_SCALING_FP32_SCALES` environment variable is enabled.
+   For training tasks, we need to add these flags:
+   ```bash
+   --fp8-format e4m3
+   --fp8-recipe blockwise
+   # --fp8-param-gather # [optional] Currently incompatible with CPU Adam
+   ```
+   Then ensure the `NVTE_FP8_BLOCK_SCALING_FP32_SCALES` environment variable is enabled.
 
-Note that only `Linear` and `GroupLinear` layers in TransformerEngine use fp8 format. `embedding` and `lm_head` remain in their original precision. If `--fp8-param-gather` is not enabled, weights in TransformerEngine remain in bf16 format, only being cast to fp8 format during `GEMM` or `GroupGEMM` operations.
+   Note that only `Linear` and `GroupLinear` layers in TransformerEngine use fp8 format. `embedding` and `lm_head` remain in their original precision. If `--fp8-param-gather` is not enabled, weights in TransformerEngine remain in bf16 format, only being cast to fp8 format during `GEMM` or `GroupGEMM` operations.
 
-2. Convert your HuggingFace model weights to FP8 format. 
+2. Convert your HuggingFace model weights to FP8 format.
 
-You can use `tools/convert_hf_to_fp8.py` to convert bf16 weights to fp8 format. Ensure that the `--hf-checkpoint` parameter points to a directory where the `config.json` contains the correct `quantization_config`. miles will automatically use FP8 quantization during weight updates. 
+   You can use `tools/convert_hf_to_fp8.py` to convert bf16 weights to fp8 format. Ensure that the `--hf-checkpoint` parameter points to a directory where the `config.json` contains the correct `quantization_config`. miles will automatically use FP8 quantization during weight updates.
 
 3. Start FP8 training.
 
-```
-cd miles
+   ```bash
+   cd miles
 
-# Qwen3‑4B FP8 training (single node)
-bash examples/infra_features/low_precision/run-qwen3-4b-fp8.sh
+   # Qwen3‑4B FP8 training (single node)
+   bash examples/infra_features/low_precision/run-qwen3-4b-fp8.sh
 
-# Qwen3‑30B‑A3B FP8 training (two nodes)
-bash examples/infra_features/low_precision/run-qwen3-30b-a3b-fp8-two-nodes.sh
-```
-Following the above command will launch FP8 training. 
+   # Qwen3‑30B‑A3B FP8 training (two nodes)
+   bash examples/infra_features/low_precision/run-qwen3-30b-a3b-fp8-two-nodes.sh
+   ```
+   Following the above command will launch FP8 training.
 
-4. Use the saved checkpoint for evaluation. 
+4. Use the saved checkpoint for evaluation.
 
-Note that TransformerEngine does not specifically save FP8 quantized weights; the saved torch dist remains in original precision (usually bf16). If you want to evaluate under FP8, you need to convert the checkpoint from `torch_dist` to HuggingFace format, then convert to FP8 HuggingFace format.
+   Note that TransformerEngine does not specifically save FP8 quantized weights; the saved torch dist remains in original precision (usually bf16). If you want to evaluate under FP8, you need to convert the checkpoint from `torch_dist` to HuggingFace format, then convert to FP8 HuggingFace format.
 
 
 ## Quick Explanation

--- a/examples/infra_features/p2p_weight_transfer/README.md
+++ b/examples/infra_features/p2p_weight_transfer/README.md
@@ -3,7 +3,7 @@
 Example scripts for running P2P (RDMA) and broadcast (NCCL) weight transfer between
 Megatron training and sglang rollout engines.
 
-See [docs/en/advanced/p2p-weight-transfer.md](../../docs/en/advanced/p2p-weight-transfer.md)
+See [docs/advanced/p2p-weight-transfer.md](../../../docs/advanced/p2p-weight-transfer.md)
 for full documentation, architecture details, and profiling results.
 
 ## Quick Start

--- a/examples/retool_v2/README.md
+++ b/examples/retool_v2/README.md
@@ -1,6 +1,6 @@
 # Retool v2
 
-This example is an upgraded version of [retool](../retool), using the updated interfaces provided by the miles framework to implement multi-turn RL training with tool calls in a cleaner way.
+This example is an upgraded version of the original retool example, using the updated interfaces provided by the miles framework to implement multi-turn RL training with tool calls in a cleaner way.
 
 ## Key Differences from v1
 
@@ -28,4 +28,6 @@ Users only need to focus on business logic (tool definitions, tool execution, re
 python examples/retool_v2/run_retool_multi_turn.py
 ```
 
-For data and model preparation, refer to the [retool v1 README](../retool/README.md).
+The launch script prepares everything it needs on its own: it downloads the dapo-math-17k
+training set and the aime-2024 eval set, downloads the checkpoint, and converts it to
+`torch_dist` before training starts.


### PR DESCRIPTION
## What

Content fixes across `examples/**` READMEs. Every change stands on its own for GitHub readers; they were found while auditing the READMEs for the docs-site mirror, which lands separately on top of this PR (#2481).

- **`examples/README.md`**: register the missing `agentenv`, `nemo-gym` and `verifiers` entries; list the `multi_turn` and `qwen3_5_35b_selfdistill` sub-recipes; make group headings reader-facing (**Recipes / Infra Features / Experimental**) with a one-line lead per group, replacing the "Directory Structure" repo-layout framing.
- **`retool_v2`**: the README pointed at `examples/retool`, deleted in #1953, and deferred data/model prep to that deleted README. Now describes what `run_retool_multi_turn.py` actually does (downloads dapo-math-17k + aime-2024, converts the checkpoint itself).
- **`p2p_weight_transfer`**: the docs link used a `docs/en/` prefix that never existed in this repo and was one directory level short.
- **`low_precision`**: the numbered Quick Start steps were split by unindented paragraphs and code fences, so each step rendered detached from its own instructions (on GitHub too). Step content is now nested under its step.
- **`infra_features`**: the index README had no title; intro tightened.

## Verification

- Every link in the touched READMEs resolves against the repo tree.
- Full pre-commit run passes.

Stacked: #2481 (docs mirror mechanism) is based on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)