### PR TITLE
docs: add disaggregated RL rollout guide

### DIFF
--- a/docs/advanced/disaggregated-rollout.md
+++ b/docs/advanced/disaggregated-rollout.md
@@ -321,6 +321,7 @@ requires a brief engine pause.
 
 ## Acknowledgment
 
-Thanks to [Nan Jiang](https://www.nanjiangwill.com/) and the Modal team for
+Thanks to [Nan Jiang](https://www.nanjiangwill.com/),
+[Jason Mancuso](https://github.com/jvmncs), and the Modal team for
 [Stitch](https://github.com/modal-projects/stitch) and for their support in
 putting this guide together.

--- a/docs/advanced/disaggregated-rollout.md
+++ b/docs/advanced/disaggregated-rollout.md
@@ -318,3 +318,9 @@ requires a brief engine pause.
 - [P2P Weight Transfer](/advanced/p2p-weight-transfer)
 - [PD Disaggregation](/advanced/pd-disaggregation)
 - [Stitch: open-source disaggregated rollout service](https://github.com/modal-projects/stitch)
+
+## Acknowledgment
+
+Thanks to [Nan Jiang](https://www.nanjiangwill.com/) and the Modal team for
+[Stitch](https://github.com/modal-projects/stitch) and for their support in
+putting this guide together.

--- a/docs/advanced/disaggregated-rollout.md
+++ b/docs/advanced/disaggregated-rollout.md
@@ -298,29 +298,19 @@ For current disk-delta runs, miles records
 `perf/update_weights_density` and `perf/update_weights_wire_bytes` in addition
 to the normal weight-update timing.
 
-The open-source Stitch integration reports the following reference
-measurements. For Kimi K2.6, the lowest reported total is shown:
+The open-source Stitch integration reports the following reference weight
+update times:
 
-| Model | Trainer publish | Preparation while serving | Activation pause | Total update |
-|---|---:|---:|---:|---:|
-| GLM-4.7-Flash | 15.0 s | 15.8 s | 0.75 s | about 30–35 s |
-| Kimi K2.6 NVFP4 | not included | 72.5 s | 2.82 s | 75.3 s |
+| Model | Update time |
+|---|---:|
+| GLM-4.7-Flash | about 30–35 s |
+| Kimi K2.6 NVFP4 | 75.3 s |
 
-The GLM-4.7-Flash values are steady-state means from a deployment with 4 × 8
-H200 trainer GPUs and 48 × 1 H200 rollout replicas. Its deltas averaged
-0.252% changed-byte density and 0.469 GB compressed. The Kimi K2.6 result is a
-verified single update at TP4 using a synthetic XOR delta with 0.3%
-quantized-value density; its total excludes remote transfer, trainer-side delta
-generation, and one-time CPU destination initialization. In both cases,
-preparation ran while inference remained available and only activation paused
-the engine.
-
-See the source measurements for
-[GLM-4.7-Flash](https://github.com/modal-projects/stitch/blob/main/cookbook/README.md#weight-update-performance)
-and
-[Kimi K2.6 NVFP4](https://github.com/modal-projects/stitch/blob/main/README.md#measured-delta-updates).
-They are external reference measurements, not a general performance claim for
-miles, SGLang, or another rollout service.
+The GLM-4.7-Flash result is from steady-state updates in a deployment with 4 ×
+8 H200 trainer GPUs and 48 × 1 H200 rollout replicas. The Kimi K2.6 result is
+the lowest reported verified single-update time at TP4. These are external
+reference measurements, not a general performance claim for miles, SGLang, or
+another rollout service.
 
 ## Related guides
 

--- a/docs/advanced/disaggregated-rollout.md
+++ b/docs/advanced/disaggregated-rollout.md
@@ -311,12 +311,6 @@ weight delta is applied and the next weights are prepared. This makes staged
 weight updates a natural fit for fully async training, because only activation
 requires a brief engine pause.
 
-The GLM-4.7-Flash result is from steady-state updates in a deployment with 4 ×
-8 H200 trainer GPUs and 48 × 1 H200 rollout replicas. The Kimi K2.6 result is
-the lowest reported verified single-update result at TP4. These are external
-reference measurements, not a general performance claim for miles, SGLang, or
-another rollout service.
-
 ## Related guides
 
 - [Fully Async RL](/user-guide/fully-async)

--- a/docs/advanced/disaggregated-rollout.md
+++ b/docs/advanced/disaggregated-rollout.md
@@ -205,20 +205,10 @@ The rollout endpoint and the version store are separate interfaces. The
 request path should not have to carry model-sized weights, and publishing a new
 version should not require miles to enumerate the current replicas.
 
-### Reference implementation: Stitch
-
-[Stitch](https://github.com/modal-projects/stitch) is an open-source package
-that implements this service boundary. It connects miles policy publication to
-an independently scaled inference pool and implements the rollout-side
-responsibilities above: version storage and reconciliation, replica
-materialization, request admission, weight activation, and served-version
-reporting.
-
-Stitch is one implementation of the service contract, not a dependency of the
-miles training loop. The miles-side endpoint, publication, and request hooks
-are intended to remain general so another rollout system can provide the same
-version and request semantics. Stitch is also the source of the end-to-end
-weight-sync measurements in [What to measure](#what-to-measure).
+One open-source package implementing the rollout-service side is
+[Stitch](https://github.com/modal-projects/stitch). It connects miles policy
+publication and version-constrained requests to an independently managed
+rollout fleet. The miles contract remains package-agnostic.
 
 ### Policy-version requirements
 
@@ -328,3 +318,4 @@ claim for miles, SGLang, or another rollout service.
 - [Training Backends](/user-guide/training-backend)
 - [P2P Weight Transfer](/advanced/p2p-weight-transfer)
 - [PD Disaggregation](/advanced/pd-disaggregation)
+- [Stitch: open-source disaggregated rollout service](https://github.com/modal-projects/stitch)

--- a/docs/advanced/disaggregated-rollout.md
+++ b/docs/advanced/disaggregated-rollout.md
@@ -77,13 +77,15 @@ Miles-managed path:
 | Mode | Data path | Use when |
 |---|---|---|
 | `broadcast` | Gather and convert trainer weights, then broadcast them to the SGLang ranks over NCCL | Trainer and rollout ranks have NCCL connectivity; this is the default |
-| `p2p` | Convert and re-shard weights, then write them directly to rollout-rank memory over RDMA | Large disaggregated jobs where direct rank-to-rank transfer is available; see [P2P Weight Transfer](/advanced/p2p-weight-transfer) |
+| `p2p` | Convert and re-shard weights, then write them directly to rollout-rank memory over RDMA | Miles-managed, in-cluster jobs with direct rank-to-rank connectivity; see [P2P Weight Transfer](/advanced/p2p-weight-transfer) |
 | `disk-delta` | Publish changed canonical checkpoint bytes to shared storage, let rollout hosts materialize them locally, then reload | Trainer and rollout cannot share an NCCL fabric, or model-sized full-weight transfer dominates the update |
 
 These are weight synchronization choices, not different rollout APIs. In the
-first two modes, miles transfers tensors into engine runtime layouts directly.
-Disk-delta instead establishes a versioned publication boundary that can also
-be consumed by an external rollout system.
+first two modes, miles transfers tensors into known engine ranks directly.
+P2P RDMA is an in-cluster transfer optimization; it is not the external rollout
+service mechanism described later in this page. Disk-delta instead establishes
+a versioned publication boundary that can also be consumed by an external
+rollout system.
 
 ### Disk-delta publication and activation
 

--- a/docs/advanced/disaggregated-rollout.md
+++ b/docs/advanced/disaggregated-rollout.md
@@ -29,7 +29,7 @@ For miles, this boundary brings:
   by version, and record which version generated every returned trajectory.
 
 The last property is what turns remote inference capacity into an RL rollout
-service rather than an ordinary model-serving endpoint. Miles must update the
+service rather than an ordinary model-serving endpoint. miles must update the
 policy without owning every engine and must preserve the behavior-policy
 identity required for staleness control and off-policy training.
 
@@ -41,11 +41,11 @@ the prefill and decode phases inside an SGLang deployment.
 
 | Topology | Engine lifecycle | What miles talks to | Policy updates |
 |---|---|---|---|
-| Miles-managed rollout | Part of the miles job | A miles-managed router and engine handles | miles converts, transfers, pauses, updates, and resumes the engines |
+| miles-managed rollout | Part of the miles job | A miles-managed router and engine handles | miles converts, transfers, pauses, updates, and resumes the engines |
 | Attached SGLang engines | Owned by the deployment | Fixed engine addresses supplied with `--rollout-external-engine-addrs` | miles still addresses and controls each engine through its engine handle |
 | External rollout service | Independent and dynamically scaled | One stable rollout endpoint | miles publishes versions; the rollout service materializes and activates them across its replicas |
 
-Miles supports the first two topologies today. The single-endpoint external
+miles supports the first two topologies today. The single-endpoint external
 rollout service is coming soon and extends that separation from GPU placement
 to independent scaling, routing, and lifecycle.
 
@@ -54,7 +54,7 @@ launching SGLang, but miles still knows the individual engine addresses, checks
 their configuration, registers them with its router, and calls their
 weight-update lifecycle.
 
-An external rollout service is a narrower interface. Miles sends rollout
+An external rollout service is a narrower interface. miles sends rollout
 requests to one endpoint and publishes new policy versions without needing an
 engine handle for every replica. The service behind that endpoint can be
 implemented by any deployment or control-plane package that satisfies the
@@ -95,12 +95,12 @@ miles still runs the selected weight-update lifecycle.
 
 Once training and rollout use different GPUs, updated weights have to cross the
 boundary between them. `--update-weight-transfer-mode` selects the current
-Miles-managed path:
+miles-managed path:
 
 | Mode | Data path | Use when |
 |---|---|---|
 | `broadcast` | Gather and convert trainer weights, then broadcast them to the SGLang ranks over NCCL | Trainer and rollout ranks have NCCL connectivity; this is the default |
-| `p2p` | Convert and re-shard weights, then write them directly to rollout-rank memory over RDMA | Miles-managed, in-cluster jobs with direct rank-to-rank connectivity; see [P2P Weight Transfer](/advanced/p2p-weight-transfer) |
+| `p2p` | Convert and re-shard weights, then write them directly to rollout-rank memory over RDMA | miles-managed, in-cluster jobs with direct rank-to-rank connectivity; see [P2P Weight Transfer](/advanced/p2p-weight-transfer) |
 | `disk-delta` | Publish changed canonical checkpoint bytes to shared storage, let rollout hosts materialize them locally, then reload | Trainer and rollout cannot share an NCCL fabric, or model-sized full-weight transfer dominates the update |
 
 These are weight synchronization choices, not different rollout APIs. In the
@@ -130,13 +130,13 @@ The current lifecycle is:
 2. At the next update boundary, source trainer ranks gather Megatron tensors
    under their canonical Hugging Face names and compare their bytes with the
    previous snapshot.
-3. Miles publishes `weight_vNNNNNN/` with compressed changed bytes and an index
+3. miles publishes `weight_vNNNNNN/` with compressed changed bytes and an index
    containing the version, base version, delta encoding, and final-state
    checksums. Files are written atomically before the version is consumed.
 4. Each rollout host pulls the version and patches its host-local checkpoint.
    Delta application verifies the checksum of the resulting tensor, not only
    the transferred delta.
-5. Miles pauses generation, reloads the materialized checkpoint into SGLang,
+5. miles pauses generation, reloads the materialized checkpoint into SGLang,
    advances the engine weight version, and resumes generation.
 
 Pull and local materialization happen before the engine pause and can overlap
@@ -175,25 +175,25 @@ general FSDP weight-update path.
 
 The coming single-endpoint integration builds on the current disk-delta
 publication path and removes the need for miles to hold one handle per rollout
-engine. The commands above cover Miles-managed and attached-engine deployments;
+engine. The commands above cover miles-managed and attached-engine deployments;
 this section defines the external-service boundary.
 
 The intended boundary has two independent data paths:
 
 ```mermaid
 flowchart LR
-    T[Miles trainer] -->|publish policy version| S[(Version store)]
-    W[Miles rollout worker] -->|version-constrained request| G[External rollout endpoint]
+    T[miles trainer] -->|publish policy version| S[(Version store)]
+    W[miles rollout worker] -->|version-constrained request| G[External rollout endpoint]
     S -->|materialize and verify| E[Rollout replicas]
     G --> E
     E -->|trajectory and served version| W
 ```
 
-Miles does not need to know how many replicas are behind the endpoint, where
+miles does not need to know how many replicas are behind the endpoint, where
 they run, or how the service replaces them. The integration is defined by
 ownership:
 
-| Miles owns | The external rollout service owns |
+| miles owns | The external rollout service owns |
 |---|---|
 | Training state and optimizer steps | Replica placement, scaling, and health |
 | Conversion to canonical rollout-visible tensors | Materializing published versions on rollout hosts |
@@ -208,14 +208,14 @@ version should not require miles to enumerate the current replicas.
 ### Reference implementation: Stitch
 
 [Stitch](https://github.com/modal-projects/stitch) is the first open-source
-implementation being integrated with this Miles boundary. It connects miles
+implementation being integrated with this service boundary. It connects miles
 policy publication to an independently scaled inference pool and implements
 the rollout-side responsibilities above: version storage and reconciliation,
 replica materialization, request admission, weight activation, and
 served-version reporting.
 
 Stitch is one implementation of the service contract, not a dependency of the
-miles training loop. The Miles-side endpoint, publication, and request hooks
+miles training loop. The miles-side endpoint, publication, and request hooks
 are intended to remain general so another rollout system can provide the same
 version and request semantics. Stitch is also the source of the end-to-end
 weight-sync measurements in [What to measure](#what-to-measure).
@@ -239,7 +239,7 @@ generation can be replayed.
 The response reports which version served the request. For long or agentic
 trajectories, recording both the version at generation start and at generation
 end also exposes whether an activation occurred while the request was in
-flight. Miles can then attach the observed version to the sample rather than
+flight. miles can then attach the observed version to the sample rather than
 inferring it from the trainer's latest published version.
 
 ### Publication and replica convergence
@@ -271,7 +271,7 @@ Disaggregation and fully async rollout answer different questions:
 - [Fully Async RL](/user-guide/fully-async) decides how generation, buffering,
   and optimizer steps overlap.
 
-With Miles-managed engines, fully async rollout keeps generation in flight
+With miles-managed engines, fully async rollout keeps generation in flight
 while the trainer consumes completed groups and takes optimizer steps. At each
 configured update boundary, the current schedule still synchronizes the active
 generation call before invoking the weight updater. Disk-delta host
@@ -285,7 +285,7 @@ engine-local pause. Different replicas may converge at different times, so
 request constraints and served-version attribution become part of the RL data
 contract rather than optional serving metadata.
 
-Miles already uses weight versions to measure fully async sample staleness. A
+miles already uses weight versions to measure fully async sample staleness. A
 service integration must preserve that information so
 `--max-weight-staleness` and custom data-buffer policies make decisions from
 the policy that generated each sample.

--- a/docs/advanced/disaggregated-rollout.md
+++ b/docs/advanced/disaggregated-rollout.md
@@ -205,6 +205,21 @@ The rollout endpoint and the version store are separate interfaces. The
 request path should not have to carry model-sized weights, and publishing a new
 version should not require miles to enumerate the current replicas.
 
+### Reference implementation: Stitch
+
+[Stitch](https://github.com/modal-projects/stitch) is the first open-source
+implementation being integrated with this Miles boundary. It connects miles
+policy publication to an independently scaled inference pool and implements
+the rollout-side responsibilities above: version storage and reconciliation,
+replica materialization, request admission, weight activation, and
+served-version reporting.
+
+Stitch is one implementation of the service contract, not a dependency of the
+miles training loop. The Miles-side endpoint, publication, and request hooks
+are intended to remain general so another rollout system can provide the same
+version and request semantics. Stitch is also the source of the end-to-end
+weight-sync measurements in [What to measure](#what-to-measure).
+
 ### Policy-version requirements
 
 An external rollout request needs more than an inference payload. It must be
@@ -301,8 +316,8 @@ an engine for 0.75 seconds on average. The average changed-byte density was
 0.252%, producing a 0.469 GB compressed delta. The complete path took roughly
 30–35 seconds, but only activation paused inference.
 
-Those measurements come from a
-[Stitch reference deployment](https://github.com/modal-projects/stitch/blob/main/cookbook/README.md#weight-update-performance),
+Those measurements come from the open-source
+[Stitch reference integration](https://github.com/modal-projects/stitch/blob/main/cookbook/README.md#weight-update-performance),
 not from the registered miles E2E test. They illustrate why preparation and
 activation should be reported separately; they are not a general performance
 claim for miles, SGLang, or another rollout service.

--- a/docs/advanced/disaggregated-rollout.md
+++ b/docs/advanced/disaggregated-rollout.md
@@ -207,12 +207,12 @@ version should not require miles to enumerate the current replicas.
 
 ### Reference implementation: Stitch
 
-[Stitch](https://github.com/modal-projects/stitch) is the first open-source
-implementation being integrated with this service boundary. It connects miles
-policy publication to an independently scaled inference pool and implements
-the rollout-side responsibilities above: version storage and reconciliation,
-replica materialization, request admission, weight activation, and
-served-version reporting.
+[Stitch](https://github.com/modal-projects/stitch) is an open-source package
+that implements this service boundary. It connects miles policy publication to
+an independently scaled inference pool and implements the rollout-side
+responsibilities above: version storage and reconciliation, replica
+materialization, request admission, weight activation, and served-version
+reporting.
 
 Stitch is one implementation of the service contract, not a dependency of the
 miles training loop. The miles-side endpoint, publication, and request hooks

--- a/docs/advanced/disaggregated-rollout.md
+++ b/docs/advanced/disaggregated-rollout.md
@@ -306,12 +306,16 @@ weight update timings:
 | GLM-4.7-Flash | 15.8 s | 0.75 s |
 | Kimi K2.6 NVFP4 | 72.5 s | 2.82 s |
 
+Preparation does not pause the engine: rollout generation continues while the
+weight delta is applied and the next weights are prepared. This makes staged
+weight updates a natural fit for fully async training, because only activation
+requires a brief engine pause.
+
 The GLM-4.7-Flash result is from steady-state updates in a deployment with 4 ×
 8 H200 trainer GPUs and 48 × 1 H200 rollout replicas. The Kimi K2.6 result is
-the lowest reported verified single-update result at TP4. Preparation runs
-while inference remains available; the engine pause covers activation. These
-are external reference measurements, not a general performance claim for miles,
-SGLang, or another rollout service.
+the lowest reported verified single-update result at TP4. These are external
+reference measurements, not a general performance claim for miles, SGLang, or
+another rollout service.
 
 ## Related guides
 

--- a/docs/advanced/disaggregated-rollout.md
+++ b/docs/advanced/disaggregated-rollout.md
@@ -1,0 +1,289 @@
+---
+title: Disaggregated RL Rollout
+description: Run miles training and SGLang rollout on separate systems, synchronize policy versions, and define the boundary to an external rollout service.
+---
+
+Disaggregated RL rollout separates policy training from the inference resources
+that generate trajectories. In the standard miles topology, the trainer and
+SGLang engines use different GPUs inside one miles job. A stronger separation
+puts rollout behind an external service that owns its replicas, routing, and
+weight activation.
+
+Both forms solve the same placement problem, but the external-service boundary
+adds a policy-version problem: miles must publish new policies without owning
+each rollout engine, and every trajectory must still identify the policy that
+generated it.
+
+This page is about separating **RL training from rollout inference**. It is
+different from [PD disaggregation](/advanced/pd-disaggregation), which separates
+the prefill and decode phases inside an SGLang deployment.
+
+## Topologies
+
+| Topology | Who starts the engines? | What miles talks to | Weight-update ownership | Availability |
+|---|---|---|---|---|
+| Miles-managed rollout | miles | A miles-managed router and engine handles | miles converts, transfers, pauses, updates, and resumes the engines | Current `main` |
+| Attached SGLang engines | The deployment owner | Fixed engine addresses supplied with `--rollout-external-engine-addrs` | miles still addresses and controls each engine through its engine handle | Current `main` |
+| External rollout service | An independent rollout system | One rollout endpoint | miles publishes policy versions; the rollout system materializes and activates them | Miles-side integration is being upstreamed |
+
+`--rollout-external` is the second row, not the third. It prevents miles from
+launching SGLang, but miles still knows the individual engine addresses, checks
+their configuration, registers them with its router, and calls their
+weight-update lifecycle.
+
+An external rollout service is a narrower interface. Miles sends rollout
+requests to one endpoint and publishes new policy versions without needing an
+engine handle for every replica. The service behind that endpoint can be
+implemented by any deployment or control-plane package that satisfies the
+request and policy-version contracts below.
+
+## Separate trainer and rollout GPUs
+
+Disaggregated placement is the miles default. Give the trainer and rollout
+engines separate GPU counts and do not pass `--colocate`:
+
+```bash
+--actor-num-nodes 1 \
+--actor-num-gpus-per-node 8 \
+--rollout-num-gpus 8 \
+--rollout-num-gpus-per-engine 2
+```
+
+The trainer and engines remain resident on their own GPUs, so they can run at
+the same time under `train_async.py`. In a colocated job the two roles share
+GPUs and take turns; fully async rollout therefore requires the disaggregated
+layout. See [Training Backends: Choosing the GPU layout](/user-guide/training-backend#3-choosing-the-gpu-layout)
+for placement and offload behavior.
+
+To attach SGLang engines launched outside the miles Ray job, provide their
+addresses explicitly:
+
+```bash
+--rollout-external \
+--rollout-external-engine-addrs 10.0.1.10:30000 10.0.1.11:30000
+```
+
+The engines must be reachable from the miles job and must have server settings
+compatible with the rollout configuration. Because miles retains individual
+engine handles, `--rollout-external` does not hand off weight-update ownership:
+miles still runs the selected weight-update lifecycle.
+
+## Weight synchronization
+
+Once training and rollout use different GPUs, updated weights have to cross the
+boundary between them. `--update-weight-transfer-mode` selects the current
+Miles-managed path:
+
+| Mode | Data path | Use when |
+|---|---|---|
+| `broadcast` | Gather and convert trainer weights, then broadcast them to the SGLang ranks over NCCL | Trainer and rollout ranks have NCCL connectivity; this is the default |
+| `p2p` | Convert and re-shard weights, then write them directly to rollout-rank memory over RDMA | Large disaggregated jobs where direct rank-to-rank transfer is available; see [P2P Weight Transfer](/advanced/p2p-weight-transfer) |
+| `disk-delta` | Publish changed canonical checkpoint bytes to shared storage, let rollout hosts materialize them locally, then reload | Trainer and rollout cannot share an NCCL fabric, or model-sized full-weight transfer dominates the update |
+
+These are weight synchronization choices, not different rollout APIs. In the
+first two modes, miles transfers tensors into engine runtime layouts directly.
+Disk-delta instead establishes a versioned publication boundary that can also
+be consumed by an external rollout system.
+
+### Disk-delta publication and activation
+
+Enable disk-delta on a non-colocated Megatron run with a publication directory
+visible to the trainer and rollout hosts, plus a host-local checkpoint
+directory for each rollout host:
+
+```bash
+--update-weight-transfer-mode disk-delta \
+--update-weight-disk-dir /shared/miles/weight-updates \
+--update-weight-local-checkpoint-dir /local-nvme/miles-rollout-checkpoint
+```
+
+The current lifecycle is:
+
+1. On the first `update_weights()` call, miles captures a CPU snapshot from
+   `--hf-checkpoint`. No delta version is published. Each rollout host also
+   materializes the same base checkpoint in its local directory.
+2. At the next update boundary, source trainer ranks gather Megatron tensors
+   under their canonical Hugging Face names and compare their bytes with the
+   previous snapshot.
+3. Miles publishes `weight_vNNNNNN/` with compressed changed bytes and an index
+   containing the version, base version, delta encoding, and final-state
+   checksums. Files are written atomically before the version is consumed.
+4. Each rollout host pulls the version and patches its host-local checkpoint.
+   Delta application verifies the checksum of the resulting tensor, not only
+   the transferred delta.
+5. Miles pauses generation, reloads the materialized checkpoint into SGLang,
+   advances the engine weight version, and resumes generation.
+
+Pull and local materialization happen before the engine pause and can overlap
+inference. Reloading the prepared weights is the activation boundary that
+requires the pause.
+
+The default delta encoding is XOR. It produces a compact byte-wise delta but
+must be applied exactly once to the declared base version. `overwrite` stores
+changed positions and their new values; it is larger but idempotent. Both
+encodings are byte-oriented: the base and exported policy must agree on tensor
+names, dtypes, shapes, and byte layout.
+
+Each published tensor carries a checksum of its complete target state.
+`xxh3-128` is the default; `blake3` and `adler32` are also accepted. A lineage,
+layout, or checksum mismatch fails the update instead of activating a partially
+updated policy.
+
+On a POSIX shared filesystem, the published version becomes visible through
+the normal filesystem contract. Object-store-backed mounts can use
+`--custom-update-weight-post-write-path` on the miles side and
+`--sglang-custom-pull-weights-pre-read-hook` on the SGLang side to make writes
+visible before a rollout host reads them.
+
+The maintained end-to-end coverage is
+[`tests/e2e/megatron/test_qwen3_4B_disk_delta.py`](https://github.com/radixark/miles/blob/main/tests/e2e/megatron/test_qwen3_4B_disk_delta.py).
+It exercises a Qwen3-4B Megatron trainer and two SGLang rollout engines on a
+single 8-GPU node. The same storage contract supports separate hosts, but the
+registered test does not reproduce a cross-cluster deployment.
+
+Current `main` rejects disk-delta with `--colocate`, LoRA, or PD
+disaggregation. It also requires `--hf-checkpoint` to be a local checkpoint
+directory. The implementation is selected by the Megatron actor; it is not a
+general FSDP weight-update path.
+
+## External rollout service contract
+
+Current `main` does not accept a single external rollout-service URL and cannot
+publish disk deltas without Miles-managed rollout-engine handles. This section
+records the interface being upstreamed; it is not a current launch recipe.
+
+The intended boundary has two independent data paths:
+
+```mermaid
+flowchart LR
+    T[Miles trainer] -->|publish policy version| S[(Version store)]
+    W[Miles rollout worker] -->|version-constrained request| G[External rollout endpoint]
+    S -->|materialize and verify| E[Rollout replicas]
+    G --> E
+    E -->|trajectory and served version| W
+```
+
+Miles does not need to know how many replicas are behind the endpoint, where
+they run, or how the service replaces them. The integration is defined by
+ownership:
+
+| Miles owns | The external rollout service owns |
+|---|---|
+| Training state and optimizer steps | Replica placement, scaling, and health |
+| Conversion to canonical rollout-visible tensors | Materializing published versions on rollout hosts |
+| Policy version numbering and publication | Verifying lineage and final-state checksums before activation |
+| The policy-version requirement attached to each rollout request | Routing requests only to replicas that satisfy that requirement |
+| Recording the served version on returned samples | Staging, admission control, activation, and reporting the version that served a request |
+
+The rollout endpoint and the version store are separate interfaces. The
+request path should not have to carry model-sized weights, and publishing a new
+version should not require miles to enumerate the current replicas.
+
+### Policy-version requirements
+
+An external rollout request needs more than an inference payload. It must be
+able to express the policy version the caller can accept:
+
+- A **minimum version** permits any replica at or above the requested version.
+  This bounds staleness while allowing the fleet to converge gradually.
+- An **exact version** requires the replica to serve one particular policy.
+  It is useful for reproducibility, evaluation, and update validation.
+
+If no compatible replica is ready, the service returns a retryable response
+instead of silently serving an older policy. Retrying a stateful generation is
+safe only when the rollout integration defines an idempotency and session
+contract; the generic miles request path should not assume that every failed
+generation can be replayed.
+
+The response reports which version served the request. For long or agentic
+trajectories, recording both the version at generation start and at generation
+end also exposes whether an activation occurred while the request was in
+flight. Miles can then attach the observed version to the sample rather than
+inferring it from the trainer's latest published version.
+
+### Publication and replica convergence
+
+A policy version becomes eligible for rollout only after its complete artifact
+is visible. The publication contract therefore needs:
+
+1. an immutable version identifier and its base lineage;
+2. atomic visibility of the completed version;
+3. final-state checksums for every changed tensor;
+4. a way for a new or restarted replica to materialize a valid base and catch
+   up through later versions; and
+5. an activation acknowledgement before a replica advertises the new version.
+
+Disk-delta already provides version and base identity, atomic file writes, and
+final-state checksums. For an external consumer, the publication hook and
+version store must also expose the completed version as one commit boundary.
+Replica catch-up, admission, and activation belong to the external rollout
+system. Other publication formats can implement the same boundary without
+using disk-delta, as long as miles and the rollout system agree on version
+identity and rollout-visible weights.
+
+## Fully async rollout
+
+Disaggregation and fully async rollout answer different questions:
+
+- Disaggregation decides where training and rollout run and who owns the
+  rollout engines.
+- [Fully Async RL](/user-guide/fully-async) decides how generation, buffering,
+  and optimizer steps overlap.
+
+With Miles-managed engines, fully async rollout keeps generation in flight
+while the trainer consumes completed groups and takes optimizer steps. At each
+configured update boundary, the current schedule still synchronizes the active
+generation call before invoking the weight updater. Disk-delta host
+materialization occurs before the subsequent engine pause, but current `main`
+does not overlap an opaque external publication with that active generation
+call.
+
+An external rollout service allows policy publication and replica preparation
+to proceed without draining the entire fleet. Only activation needs a short
+engine-local pause. Different replicas may converge at different times, so
+request constraints and served-version attribution become part of the RL data
+contract rather than optional serving metadata.
+
+Miles already uses weight versions to measure fully async sample staleness. A
+service integration must preserve that information so
+`--max-weight-staleness` and custom data-buffer policies make decisions from
+the policy that generated each sample.
+
+## What to measure
+
+End-to-end `update_weights` time is not enough for a disaggregated service. It
+mixes phases with different effects on rollout availability:
+
+| Measurement | What it isolates |
+|---|---|
+| Trainer encode and publish | Megatron-to-HF conversion, delta construction, compression, and publication |
+| Publication size and changed-byte density | Storage and network demand per version |
+| Replica materialization | Fetch, lineage verification, delta application, and runtime-layout preparation while serving |
+| Activation pause | Time the engine cannot admit or advance generation while prepared weights become active |
+| Version convergence | Time from completed publication until the required rollout capacity advertises the version |
+| Request version lag | Difference between the requested, served, and newest published policy versions |
+
+For current disk-delta runs, miles records
+`perf/update_weights_density` and `perf/update_weights_wire_bytes` in addition
+to the normal weight-update timing.
+
+As one external reference, a fully async GLM-4.7-Flash deployment used 4 × 8
+H200 trainer GPUs and 48 × 1 H200 rollout replicas. Across its recorded
+steady-state samples, trainer XOR encode and publish averaged 15.0 seconds,
+replica preparation while serving averaged 15.8 seconds, and activation paused
+an engine for 0.75 seconds on average. The average changed-byte density was
+0.252%, producing a 0.469 GB compressed delta. The complete path took roughly
+30–35 seconds, but only activation paused inference.
+
+Those measurements come from a
+[Stitch reference deployment](https://github.com/modal-projects/stitch/blob/main/cookbook/README.md#weight-update-performance),
+not from the registered miles E2E test. They illustrate why preparation and
+activation should be reported separately; they are not a general performance
+claim for miles, SGLang, or another rollout service.
+
+## Related guides
+
+- [Fully Async RL](/user-guide/fully-async)
+- [Training Backends](/user-guide/training-backend)
+- [P2P Weight Transfer](/advanced/p2p-weight-transfer)
+- [PD Disaggregation](/advanced/pd-disaggregation)

--- a/docs/advanced/disaggregated-rollout.md
+++ b/docs/advanced/disaggregated-rollout.md
@@ -1,18 +1,37 @@
 ---
 title: Disaggregated RL Rollout
-description: Run miles training and SGLang rollout on separate systems, synchronize policy versions, and define the boundary to an external rollout service.
+description: Scale rollout independently across clusters and regions while miles preserves policy publication and version attribution.
 ---
 
-Disaggregated RL rollout separates policy training from the inference resources
-that generate trajectories. In the standard miles topology, the trainer and
-SGLang engines use different GPUs inside one miles job. A stronger separation
-puts rollout behind an external service that owns its replicas, routing, and
-weight activation.
+Policy training and rollout inference have different resource and scaling
+profiles. A trainer is a long-lived, tightly coupled cluster whose ranks step
+together. Rollout is request-driven and bursty: long and agentic trajectories
+finish at different times, demand changes over a run, and inference capacity
+may be available in different clusters, regions, or compute providers.
 
-Both forms solve the same placement problem, but the external-service boundary
-adds a policy-version problem: miles must publish new policies without owning
-each rollout engine, and every trajectory must still identify the policy that
-generated it.
+Keeping both roles inside one job ties rollout capacity to the trainer's
+placement, network, and lifecycle. Disaggregated RL rollout instead makes
+inference an independent service. The trainer remains on its stable cluster,
+while rollout replicas can scale with the live queue and draw on compute across
+the globe without joining the trainer's Ray placement group or NCCL fabric.
+
+For miles, this boundary brings:
+
+- **Independent scaling.** Add or remove rollout capacity without resizing or
+  restarting the trainer.
+- **Flexible placement.** Run inference where GPUs are available, including
+  other clusters, regions, and providers.
+- **Separate failure domains.** Replace rollout replicas without making their
+  process lifecycle part of the training job.
+- **Better asynchronous utilization.** Keep a changing pool of rollout workers
+  busy while training consumes completed trajectories.
+- **Policy correctness.** Publish immutable policy versions, constrain requests
+  by version, and record which version generated every returned trajectory.
+
+The last property is what turns remote inference capacity into an RL rollout
+service rather than an ordinary model-serving endpoint. Miles must update the
+policy without owning every engine and must preserve the behavior-policy
+identity required for staleness control and off-policy training.
 
 This page is about separating **RL training from rollout inference**. It is
 different from [PD disaggregation](/advanced/pd-disaggregation), which separates
@@ -20,11 +39,15 @@ the prefill and decode phases inside an SGLang deployment.
 
 ## Topologies
 
-| Topology | Who starts the engines? | What miles talks to | Weight-update ownership | Availability |
-|---|---|---|---|---|
-| Miles-managed rollout | miles | A miles-managed router and engine handles | miles converts, transfers, pauses, updates, and resumes the engines | Current `main` |
-| Attached SGLang engines | The deployment owner | Fixed engine addresses supplied with `--rollout-external-engine-addrs` | miles still addresses and controls each engine through its engine handle | Current `main` |
-| External rollout service | An independent rollout system | One rollout endpoint | miles publishes policy versions; the rollout system materializes and activates them | Miles-side integration is being upstreamed |
+| Topology | Engine lifecycle | What miles talks to | Policy updates |
+|---|---|---|---|
+| Miles-managed rollout | Part of the miles job | A miles-managed router and engine handles | miles converts, transfers, pauses, updates, and resumes the engines |
+| Attached SGLang engines | Owned by the deployment | Fixed engine addresses supplied with `--rollout-external-engine-addrs` | miles still addresses and controls each engine through its engine handle |
+| External rollout service | Independent and dynamically scaled | One stable rollout endpoint | miles publishes versions; the rollout service materializes and activates them across its replicas |
+
+Miles supports the first two topologies today. The single-endpoint external
+rollout service is coming soon and extends that separation from GPU placement
+to independent scaling, routing, and lifecycle.
 
 `--rollout-external` is the second row, not the third. It prevents miles from
 launching SGLang, but miles still knows the individual engine addresses, checks
@@ -150,9 +173,10 @@ general FSDP weight-update path.
 
 ## External rollout service contract
 
-Current `main` does not accept a single external rollout-service URL and cannot
-publish disk deltas without Miles-managed rollout-engine handles. This section
-records the interface being upstreamed; it is not a current launch recipe.
+The coming single-endpoint integration builds on the current disk-delta
+publication path and removes the need for miles to hold one handle per rollout
+engine. The commands above cover Miles-managed and attached-engine deployments;
+this section defines the external-service boundary.
 
 The intended boundary has two independent data paths:
 

--- a/docs/advanced/disaggregated-rollout.md
+++ b/docs/advanced/disaggregated-rollout.md
@@ -301,7 +301,7 @@ to the normal weight-update timing.
 The open-source Stitch integration reports the following reference rollout-side
 weight update timings:
 
-| Model | Preparation (including delta application) | Engine pause |
+| Model | Preparation (incl. weight delta apply) | Engine pause |
 |---|---:|---:|
 | GLM-4.7-Flash | 15.8 s | 0.75 s |
 | Kimi K2.6 NVFP4 | 72.5 s | 2.82 s |

--- a/docs/advanced/disaggregated-rollout.md
+++ b/docs/advanced/disaggregated-rollout.md
@@ -298,19 +298,20 @@ For current disk-delta runs, miles records
 `perf/update_weights_density` and `perf/update_weights_wire_bytes` in addition
 to the normal weight-update timing.
 
-The open-source Stitch integration reports the following reference weight
-update times:
+The open-source Stitch integration reports the following reference rollout-side
+weight update timings:
 
-| Model | Update time |
-|---|---:|
-| GLM-4.7-Flash | about 30–35 s |
-| Kimi K2.6 NVFP4 | 75.3 s |
+| Model | Preparation (including delta application) | Engine pause |
+|---|---:|---:|
+| GLM-4.7-Flash | 15.8 s | 0.75 s |
+| Kimi K2.6 NVFP4 | 72.5 s | 2.82 s |
 
 The GLM-4.7-Flash result is from steady-state updates in a deployment with 4 ×
 8 H200 trainer GPUs and 48 × 1 H200 rollout replicas. The Kimi K2.6 result is
-the lowest reported verified single-update time at TP4. These are external
-reference measurements, not a general performance claim for miles, SGLang, or
-another rollout service.
+the lowest reported verified single-update result at TP4. Preparation runs
+while inference remains available; the engine pause covers activation. These
+are external reference measurements, not a general performance claim for miles,
+SGLang, or another rollout service.
 
 ## Related guides
 

--- a/docs/advanced/disaggregated-rollout.md
+++ b/docs/advanced/disaggregated-rollout.md
@@ -298,19 +298,29 @@ For current disk-delta runs, miles records
 `perf/update_weights_density` and `perf/update_weights_wire_bytes` in addition
 to the normal weight-update timing.
 
-As one external reference, a fully async GLM-4.7-Flash deployment used 4 × 8
-H200 trainer GPUs and 48 × 1 H200 rollout replicas. Across its recorded
-steady-state samples, trainer XOR encode and publish averaged 15.0 seconds,
-replica preparation while serving averaged 15.8 seconds, and activation paused
-an engine for 0.75 seconds on average. The average changed-byte density was
-0.252%, producing a 0.469 GB compressed delta. The complete path took roughly
-30–35 seconds, but only activation paused inference.
+The open-source Stitch integration reports the following reference
+measurements. For Kimi K2.6, the lowest reported total is shown:
 
-Those measurements come from the open-source
-[Stitch reference integration](https://github.com/modal-projects/stitch/blob/main/cookbook/README.md#weight-update-performance),
-not from the registered miles E2E test. They illustrate why preparation and
-activation should be reported separately; they are not a general performance
-claim for miles, SGLang, or another rollout service.
+| Model | Trainer publish | Preparation while serving | Activation pause | Total update |
+|---|---:|---:|---:|---:|
+| GLM-4.7-Flash | 15.0 s | 15.8 s | 0.75 s | about 30–35 s |
+| Kimi K2.6 NVFP4 | not included | 72.5 s | 2.82 s | 75.3 s |
+
+The GLM-4.7-Flash values are steady-state means from a deployment with 4 × 8
+H200 trainer GPUs and 48 × 1 H200 rollout replicas. Its deltas averaged
+0.252% changed-byte density and 0.469 GB compressed. The Kimi K2.6 result is a
+verified single update at TP4 using a synthetic XOR delta with 0.3%
+quantized-value density; its total excludes remote transfer, trainer-side delta
+generation, and one-time CPU destination initialization. In both cases,
+preparation ran while inference remained available and only activation paused
+the engine.
+
+See the source measurements for
+[GLM-4.7-Flash](https://github.com/modal-projects/stitch/blob/main/cookbook/README.md#weight-update-performance)
+and
+[Kimi K2.6 NVFP4](https://github.com/modal-projects/stitch/blob/main/README.md#measured-delta-updates).
+They are external reference measurements, not a general performance claim for
+miles, SGLang, or another rollout service.
 
 ## Related guides
 

--- a/docs/advanced/disaggregated-rollout.md
+++ b/docs/advanced/disaggregated-rollout.md
@@ -210,6 +210,11 @@ One open-source package implementing the rollout-service side is
 publication and version-constrained requests to an independently managed
 rollout fleet. The miles contract remains package-agnostic.
 
+Stitch pins the miles revision it integrates against;
+[Miles fork](https://github.com/modal-projects/stitch/blob/main/cookbook/miles_disagg/MILES_FORK.md)
+records the trainer-side commits that pin depends on, how the same ownership
+split lands in code, and how to move the pin forward.
+
 ### Policy-version requirements
 
 An external rollout request needs more than an inference payload. It must be

--- a/docs/advanced/index.md
+++ b/docs/advanced/index.md
@@ -4,8 +4,9 @@ description: Systems-level features for large-scale and long-running RL.
 ---
 This section covers the Miles features that the Core-features section of the
 homepage points at: low-precision training (FP8 / MXFP8 / NVFP4 / INT4 QAT),
-Rollout Routing Replay for MoE, disaggregated rollout and its weight-update
-paths, fault tolerance, speculative decoding, and LoRA training and serving.
+Rollout Routing Replay for MoE, fast weight updates over P2P RDMA,
+disaggregated RL rollout through an external service, fault tolerance,
+speculative decoding, and LoRA training and serving.
 
 <CardGroup cols={2}>
 
@@ -45,8 +46,8 @@ paths, fault tolerance, speculative decoding, and LoRA training and serving.
 
   <Card title="Disaggregated RL Rollout" icon="server" href="/advanced/disaggregated-rollout">
 
-    Separate training from rollout inference, choose a weight-update path, and
-    integrate an external rollout service through policy versions.
+    Connect miles to an independently managed rollout service through policy
+    publication and versioned requests.
 
   </Card>
 

--- a/docs/advanced/index.md
+++ b/docs/advanced/index.md
@@ -46,8 +46,8 @@ speculative decoding, and LoRA training and serving.
 
   <Card title="Disaggregated RL Rollout" icon="server" href="/advanced/disaggregated-rollout">
 
-    Connect miles to an independently managed rollout service through policy
-    publication and versioned requests.
+    Scale rollout across clusters and regions through an independent service,
+    with versioned policy publication and request attribution.
 
   </Card>
 

--- a/docs/advanced/index.md
+++ b/docs/advanced/index.md
@@ -4,8 +4,8 @@ description: Systems-level features for large-scale and long-running RL.
 ---
 This section covers the Miles features that the Core-features section of the
 homepage points at: low-precision training (FP8 / MXFP8 / NVFP4 / INT4 QAT),
-Rollout Routing Replay for MoE, fast weight updates over P2P RDMA, fault
-tolerance, speculative decoding, and LoRA training and serving.
+Rollout Routing Replay for MoE, disaggregated rollout and its weight-update
+paths, fault tolerance, speculative decoding, and LoRA training and serving.
 
 <CardGroup cols={2}>
 
@@ -40,6 +40,13 @@ tolerance, speculative decoding, and LoRA training and serving.
 
     Train a student on its own rollouts while matching teacher token
     probabilities through SGLang or Megatron teacher modes.
+
+  </Card>
+
+  <Card title="Disaggregated RL Rollout" icon="server" href="/advanced/disaggregated-rollout">
+
+    Separate training from rollout inference, choose a weight-update path, and
+    integrate an external rollout service through policy versions.
 
   </Card>
 

--- a/docs/advanced/pd-disaggregation.md
+++ b/docs/advanced/pd-disaggregation.md
@@ -6,6 +6,9 @@ In a typical SGLang deployment, every engine handles both **prefill** (the
 one-shot forward over the prompt) and **decode** (the per-token autoregressive
 loop). The two phases have different compute profiles:
 
+This page covers separation inside the rollout deployment. To separate policy
+training from rollout inference, see [Disaggregated RL Rollout](/advanced/disaggregated-rollout).
+
 | Phase | Compute pattern | Bottleneck |
 |---|---|---|
 | Prefill | Long sequence × full batch | FLOPs |

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -231,9 +231,9 @@
         "group": "Scale & Reliability",
         "pages": [
          "advanced/fault-tolerance",
-         "advanced/disaggregated-rollout",
          "advanced/pd-disaggregation",
          "advanced/p2p-weight-transfer",
+         "advanced/disaggregated-rollout",
          "advanced/disk-offload"
         ],
         "expanded": false

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -231,6 +231,7 @@
         "group": "Scale & Reliability",
         "pages": [
          "advanced/fault-tolerance",
+         "advanced/disaggregated-rollout",
          "advanced/pd-disaggregation",
          "advanced/p2p-weight-transfer",
          "advanced/disk-offload"

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -163,8 +163,11 @@ size 256.
   and training. Sharing GPUs also makes the weight sync local — each rank gathers
   its shards over NCCL and hands them to its engine through IPC, no network
   involved. Disaggregated runs choose a transport with
-  `--update-weight-transfer-mode`: `broadcast` (the default, over NCCL) or `p2p`
-  (point-to-point RDMA via Mooncake; incompatible with `--colocate`).
+  `--update-weight-transfer-mode`: `broadcast` (the default, over NCCL), `p2p`
+  (point-to-point RDMA via Mooncake), or `disk-delta` (versioned deltas through
+  shared storage). All three are covered in
+  [Disaggregated RL Rollout](/advanced/disaggregated-rollout#weight-synchronization);
+  `p2p` and `disk-delta` are incompatible with `--colocate`.
 - **The reward function.** `--rm-type deepscaler` — a rule-based verifier, no
   learned reward model.
 - **KL regularization.** The frozen reference model can add a KL term to the loss;

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -165,9 +165,8 @@ size 256.
   involved. Disaggregated runs choose a transport with
   `--update-weight-transfer-mode`: `broadcast` (the default, over NCCL),
   [`p2p`](/advanced/p2p-weight-transfer) (point-to-point RDMA via Mooncake), or
-  [`disk-delta`](/advanced/disaggregated-rollout#disk-delta-publication-and-activation)
-  (versioned deltas through shared storage). `p2p` and `disk-delta` are
-  incompatible with `--colocate`.
+  [`disk-delta`](/advanced/disaggregated-rollout) (versioned deltas through
+  shared storage). `p2p` and `disk-delta` are incompatible with `--colocate`.
 - **The reward function.** `--rm-type deepscaler` — a rule-based verifier, no
   learned reward model.
 - **KL regularization.** The frozen reference model can add a KL term to the loss;

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -163,11 +163,11 @@ size 256.
   and training. Sharing GPUs also makes the weight sync local — each rank gathers
   its shards over NCCL and hands them to its engine through IPC, no network
   involved. Disaggregated runs choose a transport with
-  `--update-weight-transfer-mode`: `broadcast` (the default, over NCCL), `p2p`
-  (point-to-point RDMA via Mooncake), or `disk-delta` (versioned deltas through
-  shared storage). All three are covered in
-  [Disaggregated RL Rollout](/advanced/disaggregated-rollout#weight-synchronization);
-  `p2p` and `disk-delta` are incompatible with `--colocate`.
+  `--update-weight-transfer-mode`: `broadcast` (the default, over NCCL),
+  [`p2p`](/advanced/p2p-weight-transfer) (point-to-point RDMA via Mooncake), or
+  [`disk-delta`](/advanced/disaggregated-rollout#disk-delta-publication-and-activation)
+  (versioned deltas through shared storage). `p2p` and `disk-delta` are
+  incompatible with `--colocate`.
 - **The reward function.** `--rm-type deepscaler` — a rule-based verifier, no
   learned reward model.
 - **KL regularization.** The frozen reference model can add a KL term to the loss;

--- a/docs/user-guide/fully-async.md
+++ b/docs/user-guide/fully-async.md
@@ -88,12 +88,11 @@ the driver's step schedule:
    enough have finished yet.
 2. It runs the optimizer step while the worker keeps generating.
 3. Every `--update-weights-interval` steps it pauses generation, synchronizes the new
-   weights through the configured
-   [disaggregated weight-update path](/advanced/disaggregated-rollout#weight-synchronization),
-   and resumes. The `--pause-generation-mode` flag decides how in-flight requests
-   survive that pause: the default `retract` returns them to the waiting queue and
-   recomputes their KV cache, while `in_place` freezes them and resumes on the existing
-   cache. Passing `abort` would kill them outright, which is why fully async rejects it.
+   weights through the configured update mode, and resumes. The
+   `--pause-generation-mode` flag decides how in-flight requests survive that pause: the
+   default `retract` returns them to the waiting queue and recomputes their KV cache,
+   while `in_place` freezes them and resumes on the existing cache. Passing `abort`
+   would kill them outright, which is why fully async rejects it.
 
 Because generation spans those weight updates, the samples in one group can carry
 different weight versions. The gap between a group's oldest weight version and the

--- a/docs/user-guide/fully-async.md
+++ b/docs/user-guide/fully-async.md
@@ -87,12 +87,13 @@ the driver's step schedule:
 1. The trainer drains `--rollout-batch-size` groups from the buffer, waiting if not
    enough have finished yet.
 2. It runs the optimizer step while the worker keeps generating.
-3. Every `--update-weights-interval` steps it pauses generation, broadcasts the new
-   weights, and resumes. The `--pause-generation-mode` flag decides how in-flight
-   requests survive that pause: the default `retract` returns them to the waiting queue
-   and recomputes their KV cache, while `in_place` freezes them and resumes on the
-   existing cache. Passing `abort` would kill them outright, which is why fully async
-   rejects it.
+3. Every `--update-weights-interval` steps it pauses generation, synchronizes the new
+   weights through the configured
+   [disaggregated weight-update path](/advanced/disaggregated-rollout#weight-synchronization),
+   and resumes. The `--pause-generation-mode` flag decides how in-flight requests
+   survive that pause: the default `retract` returns them to the waiting queue and
+   recomputes their KV cache, while `in_place` freezes them and resumes on the existing
+   cache. Passing `abort` would kill them outright, which is why fully async rejects it.
 
 Because generation spans those weight updates, the samples in one group can carry
 different weight versions. The gap between a group's oldest weight version and the

--- a/docs/user-guide/training-backend.md
+++ b/docs/user-guide/training-backend.md
@@ -158,8 +158,9 @@ The layout also decides how `update_weights` gets the weights across. Colocated,
 is on the same device, so the actor hands over CUDA IPC handles and nothing crosses the
 network. Disaggregated, the weights have to travel, and `--update-weight-transfer-mode`
 picks how: `broadcast` (the default) sends them over the training-to-engine process group,
-`p2p` uses [RDMA point-to-point](/advanced/p2p-weight-transfer), and `disk-delta` publishes
-only the bytes that changed since the last sync for each engine to pull.
+`p2p` uses [RDMA point-to-point](/advanced/p2p-weight-transfer), and
+[`disk-delta`](/advanced/disaggregated-rollout#disk-delta-publication-and-activation)
+publishes only the bytes that changed since the last sync for each engine to pull.
 
 On a node with fewer than 8 usable GPUs, set `--num-gpus-per-node` too, otherwise the
 rollout side still assumes 8. And `--fully-async` cannot be colocated: its whole point is

--- a/docs/user-guide/training-backend.md
+++ b/docs/user-guide/training-backend.md
@@ -159,8 +159,8 @@ is on the same device, so the actor hands over CUDA IPC handles and nothing cros
 network. Disaggregated, the weights have to travel, and `--update-weight-transfer-mode`
 picks how: `broadcast` (the default) sends them over the training-to-engine process group,
 `p2p` uses [RDMA point-to-point](/advanced/p2p-weight-transfer), and
-[`disk-delta`](/advanced/disaggregated-rollout#disk-delta-publication-and-activation)
-publishes only the bytes that changed since the last sync for each engine to pull.
+[`disk-delta`](/advanced/disaggregated-rollout) publishes only the bytes that changed since
+the last sync for each engine to pull.
 
 On a node with fewer than 8 usable GPUs, set `--num-gpus-per-node` too, otherwise the
 rollout side still assumes 8. And `--fully-async` cannot be colocated: its whole point is


### PR DESCRIPTION
## Summary

- add an advanced guide for disaggregated RL rollout, covering miles-managed engines, attached SGLang engines, and the coming external rollout-service boundary
- explain why training and rollout should scale independently: a stable, tightly coupled trainer can draw on bursty rollout capacity across clusters, regions, and compute providers
- document the current broadcast, P2P, and disk-delta weight synchronization paths while keeping P2P RDMA distinct as an in-cluster transfer optimization
- define a package-neutral policy-version contract
- align the Advanced landing page, PD disaggregation, Quick Start, Fully Async RL, and Training Backends with the new guide

## Why

Training and rollout have different resource and scaling profiles. Training ranks form a long-lived, tightly coupled cluster, while rollout demand is bursty and can use dynamically scaled GPU capacity across the globe. Making rollout an independent service lets miles add or remove inference capacity without resizing the trainer, place rollout where GPUs are available, isolate replica failures, and keep fully async generation supplied.

That separation also requires an RL-specific correctness contract. miles must publish immutable policy versions, express version requirements on rollout requests, and record the policy that generated every returned trajectory. The guide explains that boundary and positions disk-delta as the current publication foundation rather than the core story.

miles supports managed and individually attached engines today. The single-endpoint external rollout integration is presented once as coming soon; unavailable flags are not shown as current usage.

## Validation

- `git diff --check`
- `python -m json.tool docs/docs.json`
- verified internal documentation link targets from all changed Markdown files
