### PR TITLE
docs: drop the Contact button from the docs navbar

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -33,12 +33,7 @@
     "type": "github",
     "href": "https://github.com/radixark/miles"
    }
-  ],
-  "primary": {
-   "type": "button",
-   "label": "Contact",
-   "href": "mailto:miles@radixark.ai"
-  }
+  ]
  },
  "navigation": {
   "tabs": [


### PR DESCRIPTION
## Motivation

The docs site's navbar carries a primary **Contact** button pointing at `mailto:miles@radixark.ai`.

The README's "Contact Us" section, which surfaced the same address, was dropped in 780c068cb ("docs: drop the Contact Us section from the README"), leaving the docs navbar as the only place that still exposes it. This removes the button so the two stay consistent.

## Modifications

- `docs/docs.json`: drop `navbar.primary`. The GitHub link in `navbar.links` is unchanged.

`CODE_OF_CONDUCT.md` still lists the address as the conduct-report contact — that file is not part of the docs site, so it is left alone.

## Checklist

- [x] `docs/docs.json` still parses as valid JSON and matches the Mintlify schema (`navbar.primary` is optional).
- [x] No other reference to the button exists in `docs/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
