### PR TITLE
docs: label-only sidebar groups, explicit Overview pages, scoped link color

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,6 +58,12 @@ repos:
         files: '^(examples/.*README\.md|docs/examples/.*|docs/docs\.json|scripts/tools/sync_example_docs\.py)$'
         pass_filenames: false
 
+      - id: ban-docs-nav-group-root
+        name: Ban group `root` in docs navigation (put the landing page first in `pages` with `sidebarTitle Overview` instead; see docs/README.md)
+        language: pygrep
+        entry: '"root":'
+        files: ^docs/docs\.json$
+
       - id: ban-mpu-get
         name: Ban direct mpu.get_* calls (use ParallelState)
         language: pygrep

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,9 +30,22 @@ Then open http://localhost:3000.
    the social preview text, so write one sentence that reads well on its own and stays
    under 160 characters. Mintlify renders `title` as the page's `h1`, so do not repeat it
    as a `#` heading in the body.
+
+   Convention: every landing page (a tab's `index.md` — including the site homepage —
+   a model family's `index.md`, `user-guide/environments.md`) titles itself after the
+   tab or group it fronts (`Welcome`, `User Guide`, `DeepSeek`, …): the `title` feeds
+   the `h1`, browser tab, and search results, which have no sidebar context. It then
+   adds `sidebarTitle: Overview` so the sidebar shows a short, uniform label. The
+   `sidebarTitle` is a constant — never rename it in step with the title.
 2. New pages need an entry in the `navigation` tree in `docs.json`, otherwise they won't
    show up in the sidebar — and, because indexing follows the navigation, they stay out of
    the sitemap and out of search results entirely.
+
+   Never give a navigation group a `root:` (a pre-commit hook rejects it). A rooted
+   group header doubles as a link, which makes some headers navigate and others merely
+   toggle — indistinguishable until clicked. Instead, list the group's landing page as
+   its first entry in `pages` (with `sidebarTitle: Overview`, per the convention above),
+   so every header is label-only and every navigation target is an explicit row.
 3. When linking between pages, use absolute paths: `[Quick Start](/getting-started/quick-start)`.
    Drop the `.md` extension.
 4. Do not edit anything under `examples/`. Those pages, and the Examples tab of

--- a/docs/advanced/index.md
+++ b/docs/advanced/index.md
@@ -1,5 +1,6 @@
 ---
 title: Advanced Features
+sidebarTitle: Overview
 description: Systems-level features for large-scale and long-running RL.
 ---
 This section covers the Miles features that the Core-features section of the

--- a/docs/developer/index.md
+++ b/docs/developer/index.md
@@ -1,5 +1,6 @@
 ---
 title: Developer Guide
+sidebarTitle: Overview
 description: Contribution conventions, internal architecture, dependency versions, and debugging.
 ---
 You're here because you want to change Miles, not just use it. This section is the

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -44,16 +44,11 @@
   "tabs": [
    {
     "tab": "Welcome",
-    "groups": [
-     {
-      "group": "Welcome",
-      "root": "index",
-      "pages": [
-       "getting-started/index",
-       "getting-started/installation",
-       "getting-started/quick-start"
-      ]
-     }
+    "pages": [
+     "index",
+     "getting-started/index",
+     "getting-started/installation",
+     "getting-started/quick-start"
     ]
    },
    {
@@ -61,12 +56,12 @@
     "groups": [
      {
       "group": "Models",
-      "root": "models/index",
       "pages": [
+       "models/index",
        {
         "group": "DeepSeek",
-        "root": "models/deepseek/index",
         "pages": [
+         "models/deepseek/index",
          {
           "group": "DeepSeek-V4",
           "pages": [
@@ -82,8 +77,8 @@
        },
        {
         "group": "Thinking Machines",
-        "root": "models/thinkingmachines/index",
         "pages": [
+         "models/thinkingmachines/index",
          "models/thinkingmachines/inkling",
          "models/thinkingmachines/inkling-small"
         ],
@@ -91,8 +86,8 @@
        },
        {
         "group": "Qwen",
-        "root": "models/qwen/index",
         "pages": [
+         "models/qwen/index",
          {
           "group": "Qwen3.6",
           "pages": [
@@ -123,8 +118,8 @@
        },
        {
         "group": "GLM",
-        "root": "models/glm/index",
         "pages": [
+         "models/glm/index",
          "models/glm/glm5-2",
          "models/glm/glm5",
          "models/glm/glm4-7-flash",
@@ -134,8 +129,8 @@
        },
        {
         "group": "Kimi",
-        "root": "models/kimi/index",
         "pages": [
+         "models/kimi/index",
          "models/kimi/kimi-k3",
          "models/kimi/kimi-k2.5",
          "models/kimi/kimi-k2"
@@ -144,8 +139,8 @@
        },
        {
         "group": "Nemotron",
-        "root": "models/nemotron/index",
         "pages": [
+         "models/nemotron/index",
          {
           "group": "Nemotron-3-Nano",
           "pages": [
@@ -161,8 +156,8 @@
        },
        {
         "group": "Gemma",
-        "root": "models/gemma/index",
         "pages": [
+         "models/gemma/index",
          "models/gemma/gemma-4"
         ],
         "expanded": false
@@ -174,166 +169,125 @@
    },
    {
     "tab": "User Guide",
-    "groups": [
+    "pages": [
+     "user-guide/index",
+     "user-guide/concepts",
+     "user-guide/launch-script",
+     "user-guide/argument-groups",
+     "user-guide/fully-async",
+     "user-guide/training-backend",
+     "user-guide/monitoring",
+     "user-guide/dashboard",
+     "user-guide/customization",
+     "user-guide/generate-endpoint",
+     "user-guide/agentic-rollout",
      {
-      "group": "User Guide",
-      "root": "user-guide/index",
+      "group": "Agentic Environments",
       "pages": [
-       "user-guide/concepts",
-       {
-        "group": "Launch Script",
-        "pages": [
-         "user-guide/launch-script",
-         "user-guide/argument-groups"
-        ]
-       },
-       "user-guide/fully-async",
-       "user-guide/training-backend",
-       "user-guide/monitoring",
-       "user-guide/dashboard",
-       "user-guide/customization",
-       "user-guide/generate-endpoint",
-       "user-guide/agentic-rollout",
-       {
-        "group": "Agentic Environments",
-        "root": "user-guide/environments",
-        "pages": [
-         "user-guide/harbor",
-         "user-guide/openenv",
-         "user-guide/nemo-gym",
-         "user-guide/verifiers"
-        ]
-       },
-       "user-guide/cli-reference"
+       "user-guide/environments",
+       "user-guide/harbor",
+       "user-guide/openenv",
+       "user-guide/nemo-gym",
+       "user-guide/verifiers"
       ]
-     }
+     },
+     "user-guide/cli-reference"
     ]
    },
    {
     "tab": "Advanced Features",
-    "groups": [
+    "pages": [
+     "advanced/index",
      {
-      "group": "Advanced Features",
-      "root": "advanced/index",
+      "group": "Performance",
       "pages": [
-       {
-        "group": "Performance",
-        "pages": [
-         "advanced/low-precision",
-         "advanced/int4-qat",
-         "advanced/speculative-decoding",
-         "advanced/lora",
-         "advanced/on-policy-distillation"
-        ],
-        "expanded": false
-       },
-       {
-        "group": "Scale & Reliability",
-        "pages": [
-         "advanced/fault-tolerance",
-         "advanced/pd-disaggregation",
-         "advanced/p2p-weight-transfer",
-         "advanced/disaggregated-rollout",
-         "advanced/disk-offload"
-        ],
-        "expanded": false
-       },
-       {
-        "group": "MoE & Routing",
-        "pages": [
-         "advanced/miles-router"
-        ],
-        "expanded": false
-       }
+       "advanced/low-precision",
+       "advanced/int4-qat",
+       "advanced/speculative-decoding",
+       "advanced/lora",
+       "advanced/on-policy-distillation"
+      ]
+     },
+     {
+      "group": "Scale & Reliability",
+      "pages": [
+       "advanced/fault-tolerance",
+       "advanced/pd-disaggregation",
+       "advanced/p2p-weight-transfer",
+       "advanced/disaggregated-rollout",
+       "advanced/disk-offload"
+      ]
+     },
+     {
+      "group": "MoE & Routing",
+      "pages": [
+       "advanced/miles-router"
       ]
      }
     ]
    },
    {
     "tab": "Examples",
-    "groups": [
+    "pages": [
+     "examples/index",
      {
-      "group": "Examples",
-      "root": "examples/index",
+      "group": "Recipes",
       "pages": [
-       {
-        "group": "Recipes",
-        "pages": [
-         "examples/geo3k-vlm",
-         "examples/geo3k-vlm/multi-turn",
-         "examples/multi-lora",
-         "examples/on-policy-distillation",
-         "examples/on-policy-distillation/qwen3-5-35b-selfdistill",
-         "examples/ppo",
-         "examples/retool-v2",
-         "examples/swe-agent-harbor-docker"
-        ],
-        "expanded": true
-       },
-       {
-        "group": "Infra Features",
-        "root": "examples/infra-features",
-        "pages": [
-         "examples/infra-features/fully-async",
-         "examples/infra-features/low-precision",
-         "examples/infra-features/p2p-weight-transfer",
-         "examples/infra-features/random-async",
-         "examples/infra-features/train-infer-mismatch-helper",
-         "examples/infra-features/true-on-policy"
-        ],
-        "expanded": false
-       }
+       "examples/geo3k-vlm",
+       "examples/geo3k-vlm/multi-turn",
+       "examples/multi-lora",
+       "examples/on-policy-distillation",
+       "examples/on-policy-distillation/qwen3-5-35b-selfdistill",
+       "examples/ppo",
+       "examples/retool-v2",
+       "examples/swe-agent-harbor-docker"
+      ]
+     },
+     {
+      "group": "Infra Features",
+      "pages": [
+       "examples/infra-features",
+       "examples/infra-features/fully-async",
+       "examples/infra-features/low-precision",
+       "examples/infra-features/p2p-weight-transfer",
+       "examples/infra-features/random-async",
+       "examples/infra-features/train-infer-mismatch-helper",
+       "examples/infra-features/true-on-policy"
       ]
      }
     ]
    },
    {
     "tab": "Developer Guide",
-    "groups": [
+    "pages": [
+     "developer/index",
+     "developer/contributor-guide",
+     "developer/architecture",
+     "developer/versions",
+     "developer/debug",
      {
-      "group": "Developer Guide",
-      "root": "developer/index",
+      "group": "CI",
       "pages": [
-       "developer/contributor-guide",
-       "developer/architecture",
-       "developer/versions",
-       "developer/debug",
-       {
-        "group": "CI",
-        "pages": [
-         "ci/contributor-guide",
-         "ci/00-stage",
-         "ci/01-label",
-         "ci/02-docker-build",
-         "ci/03-metric-history-gate"
-        ],
-        "expanded": false
-       }
+       "ci/contributor-guide",
+       "ci/00-stage",
+       "ci/01-label",
+       "ci/02-docker-build",
+       "ci/03-metric-history-gate"
       ]
      }
     ]
    },
    {
     "tab": "Resources",
-    "groups": [
-     {
-      "group": "Resources",
-      "pages": [
-       "blog/index",
-       "subscribe"
-      ]
-     }
+    "pages": [
+     "blog/index",
+     "subscribe"
     ]
    },
    {
     "tab": "FAQ",
-    "groups": [
-     {
-      "group": "FAQ",
-      "pages": [
-       "faq"
-      ]
-     }
+    "pages": [
+     "faq"
     ]
    }
   ]

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -1,5 +1,6 @@
 ---
 title: "Examples"
+sidebarTitle: "Overview"
 description: "These examples are runnable starting points for your own RL workflow."
 # Generated from examples/README.md by scripts/tools/sync_example_docs.py. Edit that README, not this file.
 ---

--- a/docs/examples/infra-features.md
+++ b/docs/examples/infra-features.md
@@ -1,5 +1,6 @@
 ---
 title: "Infra Features"
+sidebarTitle: "Overview"
 description: "These examples exercise runtime and infrastructure behaviour rather than a training recipe."
 # Generated from examples/infra_features/README.md by scripts/tools/sync_example_docs.py. Edit that README, not this file.
 ---

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,6 @@
 ---
-title: Miles Documentation
+title: Welcome
+sidebarTitle: Overview
 description: Miles is an open-source RL framework for large-scale LLM post-training, pairing SGLang rollout with Megatron-LM training at trillion-parameter scale.
 ---
 Miles is a high-performance, enterprise-ready reinforcement learning framework for

--- a/docs/models/deepseek/index.md
+++ b/docs/models/deepseek/index.md
@@ -1,5 +1,6 @@
 ---
 title: DeepSeek
+sidebarTitle: Overview
 description: Miles recipes for the DeepSeek family — V4 Flash, V4 Pro, and V3.2.
 ---
 Miles ships recipes for the DeepSeek family across two generations. **DeepSeek-V4** pairs sparse multi-head latent attention with a learned indexer, KV compressors, and hyper-connection routing. **DeepSeek-V3.2** keeps the V3 MoE and MLA shapes and adds DeepSeek Sparse Attention (DSA), the same attention implementation the GLM-5 recipes use. **DeepSeek-V3** itself remains available through `scripts/run_deepseek.py`.

--- a/docs/models/gemma/index.md
+++ b/docs/models/gemma/index.md
@@ -1,5 +1,6 @@
 ---
 title: Gemma
+sidebarTitle: Overview
 description: Miles recipes for Google's Gemma-4 line, trained on the base VLM checkpoint through the HF to Megatron bridge.
 ---
 Miles supports Google's Gemma-4 in both released instruction-tuned sizes. Both train as

--- a/docs/models/glm/index.md
+++ b/docs/models/glm/index.md
@@ -1,5 +1,6 @@
 ---
 title: GLM
+sidebarTitle: Overview
 description: Miles recipes for the GLM4.5, GLM4.7 Flash, GLM5, and GLM5.2 families.
 ---
 Miles ships RL recipes for every GLM generation currently in production: the GLM4.5 MoE at 106 B-A12B and 355 B-A32B, the compact GLM4.7 Flash with 64 routed experts, and the 744 B-A40B GLM5 and GLM5.2 flagships.

--- a/docs/models/index.md
+++ b/docs/models/index.md
@@ -1,5 +1,6 @@
 ---
 title: Supported Models
+sidebarTitle: Overview
 description: Per-family recipes covering weight conversion, launch flags, and parallelism choices.
 ---
 Miles ships ready-to-run recipes for every model family listed below. Each page covers

--- a/docs/models/kimi/index.md
+++ b/docs/models/kimi/index.md
@@ -1,5 +1,6 @@
 ---
 title: Kimi
+sidebarTitle: Overview
 description: Miles recipes for the Moonshot family — Kimi K2.6 / K2.5 (multimodal, 1 T / 32 B-A) and Kimi K2 / K2-Thinking.
 ---
 Miles supports Moonshot's MoE line from top to bottom. The latest Kimi K2.6 and K2.5 are natively multimodal agentic models at 1 T total / 32 B active per token, and the text-only Kimi K2 (Instruct and Thinking variants) runs at the same 1 T / 32 B scale. K2-Thinking is the canonical INT4 QAT target, and the K2.5 / K2.6 recipe trains an INT4 actor under the same QAT path.

--- a/docs/models/nemotron/index.md
+++ b/docs/models/nemotron/index.md
@@ -1,5 +1,6 @@
 ---
 title: Nemotron
+sidebarTitle: Overview
 description: Miles recipes for NVIDIA's Nemotron-3 family — Mamba+Attention(+MoE) hybrids loaded via Megatron AutoBridge.
 ---
 Miles supports NVIDIA's Nemotron-3 line: a Mamba + Attention hybrid that, in the Super tier, adds MoE and ships natively in FP8. All three variants load via the Megatron AutoBridge path, so there is no offline HF → `torch_dist` conversion step.

--- a/docs/models/qwen/index.md
+++ b/docs/models/qwen/index.md
@@ -1,5 +1,6 @@
 ---
 title: Qwen
+sidebarTitle: Overview
 description: Miles recipes for the full Qwen3, Qwen3.5, and Qwen3-Next line — dense and MoE.
 ---
 Miles ships ready-to-run RL recipes for every generation of the Qwen line: the dense Qwen3 series (0.6 B → 32 B), the Qwen3.5 family with its gated-attention architecture, the Qwen3 and Qwen3.5 MoE variants, and the Gated-Delta-Net Qwen3-Next-80B-A3B.

--- a/docs/models/thinkingmachines/index.md
+++ b/docs/models/thinkingmachines/index.md
@@ -1,5 +1,6 @@
 ---
 title: Thinking Machines
+sidebarTitle: Overview
 description: Miles recipes for Thinking Machines Lab models — Inkling (975 B), a multimodal MoE with short convolution, relative attention, and a shared-expert sink.
 ---
 Miles ships a native Megatron recipe for **Inkling**, Thinking Machines Lab's 975 B / 41 B-active multimodal mixture-of-experts model: local and global relative attention, the residual ShortConv, the shared-sink router and experts, and the image and audio encoders. The same backend drives both full-parameter and LoRA RL.

--- a/docs/style.css
+++ b/docs/style.css
@@ -17,18 +17,22 @@ html.dark {
 
 /* =============================================
    Links — internal orange, external lighter + ↗
+   Scoped to the prose container: an unscoped `a` rule is unlayered and
+   beats Mintlify's layered Tailwind colors everywhere, repainting the
+   sidebar, tabs, and on-page TOC orange and erasing the active-page
+   highlight.
    ============================================= */
-a {
+.mdx-content a {
   color: #d55816;
   text-decoration-thickness: 1px;
   text-underline-offset: 3px;
 }
 
-a:hover {
+.mdx-content a:hover {
   text-decoration-thickness: 2px;
 }
 
-a[href^="http"]:not([href*="radixark.com"])::after {
+.mdx-content a[href^="http"]:not([href*="radixark.com"])::after {
   content: "↗";
   margin-left: 0.15em;
   font-size: 0.7em;

--- a/docs/user-guide/environments.md
+++ b/docs/user-guide/environments.md
@@ -1,5 +1,6 @@
 ---
 title: Agentic Environments
+sidebarTitle: Overview
 description: How Miles trains on RL environments — datasets with rewards, self-wired environments, and optional external ecosystems.
 ---
 

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -1,5 +1,6 @@
 ---
 title: User Guide
+sidebarTitle: Overview
 description: Concepts, launch scripts, customization hooks, and a complete CLI reference.
 ---
 | Page | What it covers |

--- a/docs/user-guide/launch-script.md
+++ b/docs/user-guide/launch-script.md
@@ -1,5 +1,5 @@
 ---
-title: Structure and Usage
+title: Launch Script
 description: What a Miles launch script does when you run it, how it is structured, and the three ways to override a recipe.
 ---
 Every supported model ships as a python launch script under `scripts/`, and starting a

--- a/scripts/tools/sync_example_docs.py
+++ b/scripts/tools/sync_example_docs.py
@@ -101,8 +101,13 @@ VOID_TAGS = {"br", "hr", "img", "input"}
 
 # - **[fully_async](./fully_async)**: Demonstrates fully asynchronous rollout generation.
 INDEX_BULLET = re.compile(r"^\s*[-*]\s+\*\*\[([^\]]+)\]\(([^)]+)\)\*\*:\s*(.+?)\s*$")
-# ## [Infra Features](./infra_features) — a group root registered as a section heading.
+# ## [Infra Features](./infra_features) — a section directory registered as a heading link.
 INDEX_HEADING = re.compile(r"^#{2,}\s+\[([^\]]+)\]\(([^)]+)\)\s*$")
+
+# Directories rendered as label-only sidebar sections. Their own README becomes the
+# section's first row, labeled "Overview" — never a group `root`, which would make the
+# header itself navigate (banned by pre-commit; see docs/README.md).
+SECTION_DIRS = ("infra_features",)
 MD_LINK = re.compile(r"(!?)\[([^\]]*)\]\(\s*([^)\s]+)(\s+\"[^\"]*\")?\s*\)")
 IMG_LINK = re.compile(r"!\[([^\]]*)\]\(\s*([^)\s]+)(\s+\"[^\"]*\")?\s*\)")
 # Link text may carry one nested image ([![badge](img)](target)), which MD_LINK would
@@ -153,7 +158,7 @@ def parse_index(index_readme):
 
     Returns (descriptions, registered): one-line descriptions keyed by directory in
     bullet order, and the set of every directory the index mentions — as a bullet or,
-    for a group root like infra_features, as a section-heading link.
+    for a section directory like infra_features, as a section-heading link.
     """
     descriptions, registered = {}, set()
     for line in index_readme.read_text().splitlines():
@@ -359,9 +364,14 @@ def convert(readme_text, rel_dir, mirrored, broken):
 
 def render_page(title, description, rel_dir, body):
     source = f"{repo_dir_of(rel_dir)}/README.md"
+    # Tab and section landing pages keep their full title (h1 / SEO) but show a short,
+    # uniform "Overview" label in the sidebar (see the convention in docs/README.md).
+    landing = rel_dir == "" or rel_dir in SECTION_DIRS
+    sidebar = 'sidebarTitle: "Overview"\n' if landing else ""
     return (
         "---\n"
         f"title: {json.dumps(title, ensure_ascii=False)}\n"
+        f"{sidebar}"
         f"description: {json.dumps(description, ensure_ascii=False)}\n"
         f"# Generated from {source} by scripts/tools/sync_example_docs.py. Edit that README, not this file.\n"
         "---\n"
@@ -427,6 +437,9 @@ def build_navigation(pages, bullet_order):
     Sidebar order follows the bullet order in examples/README.md — the index README owns
     ordering along with titles and descriptions. Directories without a bullet sort last,
     alphabetically.
+
+    Emits the tab's `pages` list directly: the index page first, then label-only
+    sections whose landing page is their first row — no group `root` (see docs/README.md).
     """
     rank = {rel_dir: i for i, rel_dir in enumerate(bullet_order)}
     recipes, infra = [], []
@@ -435,13 +448,13 @@ def build_navigation(pages, bullet_order):
             continue
         page = f"examples/{slug_for(rel_dir)}"
         (infra if rel_dir.startswith("infra_features") else recipes).append(page)
-    group = {"group": "Examples", "root": "examples/index", "pages": []}
-    group["pages"].append({"group": "Recipes", "pages": recipes, "expanded": True})
+    entries = ["examples/index"]
+    entries.append({"group": "Recipes", "pages": recipes})
     if infra:
         infra_root = "examples/infra-features"
         children = [p for p in infra if p != infra_root]
-        group["pages"].append({"group": "Infra Features", "root": infra_root, "pages": children, "expanded": False})
-    return group
+        entries.append({"group": "Infra Features", "pages": [infra_root] + children})
+    return entries
 
 
 def examples_tab(config):
@@ -472,7 +485,8 @@ def main():
     except SyncError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 1
-    tab["groups"] = [build_navigation(pages, bullet_order)]
+    tab.pop("groups", None)
+    tab["pages"] = build_navigation(pages, bullet_order)
     docs_json_text = render_docs_json(config)
 
     existing = {p for p in OUT_DIR.rglob("*.md")} if OUT_DIR.exists() else set()

--- a/tests/fast/doc/test_sync_example_docs.py
+++ b/tests/fast/doc/test_sync_example_docs.py
@@ -129,13 +129,27 @@ class TestIndex:
 
     def test_navigation_follows_bullet_order(self, sync):
         pages = {"": None, "zeta": None, "alpha": None, "unlisted_b": None, "unlisted_a": None}
-        group = sync.build_navigation(pages, ["zeta", "alpha"])
-        assert group["pages"][0]["pages"] == [
-            "examples/zeta",
-            "examples/alpha",
-            "examples/unlisted-a",
-            "examples/unlisted-b",
+        entries = sync.build_navigation(pages, ["zeta", "alpha"])
+        assert entries == [
+            "examples/index",
+            {
+                "group": "Recipes",
+                "pages": [
+                    "examples/zeta",
+                    "examples/alpha",
+                    "examples/unlisted-a",
+                    "examples/unlisted-b",
+                ],
+            },
         ]
+
+    def test_section_directory_becomes_rootless_group_with_landing_first(self, sync):
+        pages = {"": None, "alpha": None, "infra_features": None, "infra_features/beta": None}
+        entries = sync.build_navigation(pages, ["alpha"])
+        assert entries[-1] == {
+            "group": "Infra Features",
+            "pages": ["examples/infra-features", "examples/infra-features/beta"],
+        }
 
 
 class TestBuildPages:


### PR DESCRIPTION
## Summary

Makes the docs sidebar behave by one legible rule: **section headers are labels, rows are pages, and the only collapsible items are the Models family catalogs.**

- **Scope the custom link color to page content** (`a` → `.mdx-content a` in `style.css`). The unscoped rule repainted the sidebar, tabs, and on-page TOC orange and drowned out the active-page highlight.
- **Remove `root` from every navigation group.** Rooted headers navigate while rootless ones only toggle — indistinguishable until clicked. Each group's landing page is now an explicit first row labeled **Overview** (via `sidebarTitle`; full `title` kept for h1/SEO).
- **Promote always-relevant groups to static, always-expanded sections** (Environments, Recipes, Infra Features, Performance, Scale & Reliability, MoE & Routing, CI). No collapse affordance at all; only the Models families remain collapsible.
- **Flatten what didn't earn a layer**: single-group tabs (Welcome, Resources, FAQ) and the two-page Launch Script group (page retitled "Structure and Usage" → "Launch Script").
- **Teach `scripts/tools/sync_example_docs.py` the same rules**: the generated Examples tab now emits the index first and label-only sections (`Recipes`, `Infra Features`) instead of rooted groups, and stamps `sidebarTitle: Overview` on the tab/section landing pages it renders.
- **Guard against regression**: conventions documented in `docs/README.md`, plus a pre-commit hook that rejects group `root:` in `docs.json`.

No pages added or removed (96 on `main` and here); `mint broken-links` unchanged from `main` (25 pre-existing).

## Before / After

**User Guide** — link-color bleed fixed; Environments becomes an always-open section with an explicit Overview row:

| Before | After |
|---|---|
| ![before](https://gist.githubusercontent.com/nblintao/53711f3c59d5c0ef53eb530b8eb3d5b6/raw/before-user-guide.png) | ![after](https://gist.githubusercontent.com/nblintao/53711f3c59d5c0ef53eb530b8eb3d5b6/raw/after-user-guide.png) |

**Advanced Features** — collapsed click-to-discover subgroups become static sections with every page visible:

| Before | After |
|---|---|
| ![before](https://gist.githubusercontent.com/nblintao/53711f3c59d5c0ef53eb530b8eb3d5b6/raw/before-advanced.png) | ![after](https://gist.githubusercontent.com/nblintao/53711f3c59d5c0ef53eb530b8eb3d5b6/raw/after-advanced.png) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
