### PR TITLE
dashboard: keep sample status/reward chips visible on the Tokens tab

### DIFF
--- a/miles/dashboard/static/conversation.js
+++ b/miles/dashboard/static/conversation.js
@@ -2,17 +2,24 @@ import { el, fmtNum } from "./app.js";
 
 const CLOSED_BY_DEFAULT = new Set(["system", "tool"]);
 
-// row: one trajectory-sidecar entry {status, reward, messages: [...]}
-// (OpenAI message shape: role/content plus optional reasoning_content,
-// tool_calls, name)
-export function renderConversation(row) {
+// sample outcome (status + reward) from the trajectory sidecar. Lives outside
+// the conversation pane so the tabbed sample view can hoist it above the tab
+// bar: the outcome describes the sample, not one rendering of it, so it has to
+// survive a switch to the Tokens tab.
+export function renderSampleChips(row) {
   const chips = [el("span", { class: "chip" }, [row.status])];
   if (row.reward !== null && row.reward !== undefined) {
     chips.push(el("span", { class: "chip" }, [`reward ${fmtNum(row.reward)}`]));
   }
+  return el("div", { class: "controls" }, chips);
+}
+
+// row: one trajectory-sidecar entry {status, reward, messages: [...]}
+// (OpenAI message shape: role/content plus optional reasoning_content,
+// tool_calls, name)
+export function renderConversation(row) {
   return el("div", { class: "panel" }, [
     el("h3", {}, ["Conversation"]),
-    el("div", { class: "controls" }, chips),
     ...row.messages.map(messageCard),
   ]);
 }

--- a/miles/dashboard/static/views_tokens.js
+++ b/miles/dashboard/static/views_tokens.js
@@ -2,7 +2,7 @@ import { createAnatomy } from "./anatomy.js";
 import { api } from "./api.js";
 import { el, fmtNum } from "./app.js";
 import { divergingColor, drawChart, hideTooltip, sequentialColor, showTooltip } from "./charts.js";
-import { renderConversation } from "./conversation.js";
+import { renderConversation, renderSampleChips } from "./conversation.js";
 
 const WINDOW_SIZES = [256, 1024, 4096];
 
@@ -118,7 +118,9 @@ export async function renderTokens(view, meta, route) {
     body.replaceChildren(name === "conversation" ? conversationPane : tokensPane);
     if (name === "tokens") startTokens();
   };
-  view.replaceChildren(...panels, tabs, body);
+  // chips sit above the tab bar, not inside either pane, so status/reward stay
+  // on screen while reading tokens
+  view.replaceChildren(...panels, renderSampleChips(conversationRow), tabs, body);
   select("conversation");
 }
 


### PR DESCRIPTION
## Summary

In the Rollouts → sample view, the `completed` / `reward X` chips vanish as soon as you switch from the **Conversation** tab to the **Tokens** tab. This moves the chips above the tab bar so they stay on screen on both tabs.

## Why

The reward is usually the thing you are trying to explain when you open the token view: you go there to see which tokens drove a `0` reward, or where the importance ratio blew up on a sample that scored well. Today you have to flip back to Conversation to remind yourself of the reward and then flip forward again, which is friction in the exact loop the view exists for. The status matters for the same reason — a `truncated` sample is read very differently from a `completed` one.

## What changed

`renderConversation()` built the two chips itself and returned them nested inside the Conversation panel. When the Tokens tab is selected, `renderTokens()` swaps that whole panel out of the DOM, so the chips went with it.

- `conversation.js` — the chip row becomes its own export, `renderSampleChips(row)`, returning a bare `.controls` row rather than being buried inside the panel. `renderConversation()` no longer renders it.
- `views_tokens.js` — `renderTokens()` renders `renderSampleChips(conversationRow)` between the lifecycle/group-nav panels and the tab bar. One instance, outside both panes, so it survives every tab switch.

Static frontend only: no API, schema, or Python change. `status` and `reward` already arrived on the trajectory-sidecar row that the view fetches. The `reward !== null && reward !== undefined` guard is carried over unchanged, so a genuine `0.0` reward still renders instead of being swallowed as falsy.

Samples with no recorded conversation are unaffected: that path renders the token pane with no tab bar, exactly as before.

## Verification

Generated a dummy dump through the real dump pipeline (`tests/fast/dashboard/dummy_dump.py`), served it with `python -m miles.dashboard.serve`, and drove the page in real Chrome via Playwright — asserting the rendered chip text and the DOM order of `#view`'s children on each tab.

| before — Tokens tab | after — Tokens tab |
| --- | --- |
| <a href="https://raw.githubusercontent.com/radixark/miles/d2ea61227ad182daf6ee53277d965ab67de5b5b4/tokens-tab/before.png"><img src="https://raw.githubusercontent.com/radixark/miles/d2ea61227ad182daf6ee53277d965ab67de5b5b4/tokens-tab/before.png" width="420"></a> | <a href="https://raw.githubusercontent.com/radixark/miles/d2ea61227ad182daf6ee53277d965ab67de5b5b4/tokens-tab/after.png"><img src="https://raw.githubusercontent.com/radixark/miles/d2ea61227ad182daf6ee53277d965ab67de5b5b4/tokens-tab/after.png" width="420"></a> |

Measured chip text, and the `#view` child order after the fix:

| case | Conversation tab | Tokens tab |
| --- | --- | --- |
| sample 0, `reward 0.0` — before this PR | `completed`, `reward 0` | *(none)* |
| sample 0, `reward 0.0` — after | `completed`, `reward 0` | `completed`, `reward 0` |
| sample 1, `reward 1.0` — after | `completed`, `reward 1` | `completed`, `reward 1` |
| sample 3, no sidecar — after | no tab bar, token pane only | no tab bar, token pane only |

`#view` children after the fix, on both tabs: `controls` (group nav) → `controls` (status/reward chips) → `tabs` → pane. The chips render exactly once — switching tabs neither drops nor duplicates them — and the browser console reports no JS errors (the only console entries are the by-design `404`s for the sample that has no conversation sidecar).

## Test plan

The repo has no JS test harness — there is no `package.json` and the dashboard's Python tests never load the static files — so the browser run above is the verification. `pre-commit` covers Python only, and no Python file is touched, so its hooks are unaffected by this change.
