### PR TITLE
docs: list Kimi-K2.6 as a P2P-supported model

### DIFF
--- a/docs/advanced/p2p-weight-transfer.md
+++ b/docs/advanced/p2p-weight-transfer.md
@@ -64,7 +64,7 @@ P2P weight transfer relies on a unified weight name mapping interface between Me
 | `Glm4MoeForCausalLM` | GLM4-MoE | GLM-4.5-Air |
 | `Glm4MoeLiteForCausalLM` | GLM4-MoE | GLM-4.7-9B-Flash |
 | `DeepseekV3ForCausalLM` | DeepSeek V3p2 | GLM-5 (744B-A40B) |
-| `DeepseekV3ForCausalLM` | DeepSeek V3 | Kimi-K2 (1T) \* |
+| `DeepseekV3ForCausalLM` | DeepSeek V3 | Kimi-K2 (1T) \*, Kimi-K2.6 (1T) |
 
 > **Note:** All the above models are tested on H100-80GB clusters.
 >


### PR DESCRIPTION
Kimi-K2.6 has been trained with P2P weight transfer, but the [Supported Model Architectures](https://miles.radixark.com/docs/advanced/p2p-weight-transfer#supported-model-architectures) table listed only Kimi-K2. It runs through the same `DeepseekV3ForCausalLM` path.

Docs-only, one line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)