### PR TITLE
Publish miles as the miles-rl wheel on PyPI

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -119,6 +119,36 @@ jobs:
           print(f"OK: wheel carries all expected top-level packages ({len(names)} files)")
           PY
 
+      - name: Rebuild the wheel from the sdist
+        shell: bash
+        run: |
+          set -euo pipefail
+          # `python -m build --wheel --sdist` builds both from the source tree,
+          # so it cannot tell whether the sdist is self-contained. Anyone who
+          # installs with --no-binary, or on a platform the wheel does not
+          # cover, builds from the sdist instead -- and setup.py reads
+          # requirements.txt and README.md at build time, so an sdist missing
+          # either fails before it starts. Prove it round-trips.
+          workdir=$(mktemp -d)
+          tar xzf dist/*.tar.gz -C "$workdir"
+          src=$(find "$workdir" -mindepth 1 -maxdepth 1 -type d)
+          ( cd "$src" && python -m build --wheel --outdir "$workdir/out" )
+          echo "--- wheel rebuilt from the sdist ---"
+          ls -lh "$workdir/out"
+          python - "$workdir/out" <<'PY'
+          import pathlib, sys, zipfile
+
+          wheels = list(pathlib.Path(sys.argv[1]).glob("*.whl"))
+          if len(wheels) != 1:
+              sys.exit(f"expected one wheel rebuilt from the sdist, got {wheels}")
+          names = zipfile.ZipFile(wheels[0]).namelist()
+          missing = [p for p in ("miles/", "sglang/", "megatron/", "miles_megatron_plugins/")
+                     if not any(n.startswith(p) for n in names)]
+          if missing:
+              sys.exit(f"sdist-built wheel is missing: {missing}")
+          print(f"OK: sdist round-trips to a complete wheel ({len(names)} files)")
+          PY
+
       - name: Refuse to upload a version that already exists on PyPI
         if: ${{ env.DRY_RUN != 'true' }}
         shell: bash

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,214 @@
+name: Publish miles-rl to PyPI
+
+# Builds the `miles-rl` distribution -- miles plus the patched sglang and
+# Megatron-LM sources bundled from the third_party/* submodules -- and uploads
+# it to https://pypi.org/project/miles-rl/.
+#
+# Authentication is PyPI Trusted Publishing (OIDC): PyPI is configured to trust
+# this workflow file in this repository, so there is no API token in the repo
+# secrets. See https://docs.pypi.org/trusted-publishers/.
+#
+# To cut a release: bump `version=` in setup.py (PyPI rejects re-uploads of an
+# existing version), merge, then run this workflow with dry_run=false.
+#
+# Pull requests that touch the packaging files run the build half only, so a
+# broken wheel is caught before it can reach PyPI.
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/publish-pypi.yml'
+      - '.gitmodules'
+      - 'MANIFEST.in'
+      - 'requirements.txt'
+      - 'setup.py'
+
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Build and verify only; skip the PyPI upload. Leave on until you mean to cut a release.'
+        required: false
+        type: boolean
+        default: true
+
+concurrency:
+  group: publish-pypi-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    permissions:
+      # Required by pypa/gh-action-pypi-publish for OIDC Trusted Publishing.
+      id-token: write
+      contents: read
+    env:
+      # A pull_request run has no inputs, so it is always a dry run.
+      DRY_RUN: ${{ github.event_name != 'workflow_dispatch' || inputs.dry_run }}
+      # Emit a pure `py3-none-any` wheel rather than the platform-tagged wheel
+      # setup.py builds by default. The distribution is pure Python.
+      MILES_PURE_WHEEL: '1'
+    steps:
+      - name: Checkout with submodules
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install build tooling
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+
+      - name: Read distribution name and version from setup.py
+        id: cfg
+        shell: bash
+        run: |
+          set -euo pipefail
+          name=$(python -c "import re,pathlib; print(re.search(r'\n    name=\"([^\"]+)\"', pathlib.Path('setup.py').read_text()).group(1))")
+          version=$(python -c "import re,pathlib; print(re.search(r'\n    version=\"([^\"]+)\"', pathlib.Path('setup.py').read_text()).group(1))")
+          echo "name=$name" >> "$GITHUB_OUTPUT"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Building $name==$version"
+
+      - name: Build wheel and sdist
+        run: python -m build --wheel --sdist
+
+      - name: Verify the wheel is pure and actually bundles the submodules
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          wheels=(dist/*.whl)
+          if [ ${#wheels[@]} -ne 1 ]; then
+            echo "::error::expected exactly one wheel in dist/, found ${#wheels[@]}"
+            exit 1
+          fi
+          wheel="${wheels[0]}"
+          ls -lh dist/
+
+          # A platform-tagged wheel here means MILES_PURE_WHEEL did not take
+          # effect, and the release would install on only one interpreter.
+          case "$wheel" in
+            *-py3-none-any.whl) ;;
+            *) echo "::error::wheel $wheel is not tagged py3-none-any"; exit 1 ;;
+          esac
+
+          # setup.py silently skips bundling when the submodules are missing.
+          # That is correct for `pip install -e .` in the Docker image but would
+          # publish a hollow release, so fail loudly here instead.
+          python - "$wheel" <<'PY'
+          import sys, zipfile
+
+          names = zipfile.ZipFile(sys.argv[1]).namelist()
+          required = {
+              "miles/": "miles",
+              "miles_plugins/": "miles_plugins",
+              "sglang/": "bundled sglang",
+              "megatron/": "bundled Megatron-LM",
+              "miles_megatron_plugins/": "bundled miles_megatron_plugins",
+          }
+          missing = [label for prefix, label in required.items()
+                     if not any(n.startswith(prefix) for n in names)]
+          if missing:
+              sys.exit(f"wheel is missing: {', '.join(missing)}")
+          print(f"OK: wheel carries all expected top-level packages ({len(names)} files)")
+          PY
+
+      - name: Refuse to upload a version that already exists on PyPI
+        if: ${{ env.DRY_RUN != 'true' }}
+        shell: bash
+        env:
+          NAME: ${{ steps.cfg.outputs.name }}
+          VERSION: ${{ steps.cfg.outputs.version }}
+        run: |
+          set -euo pipefail
+          # PyPI versions are immutable; fail with a clear message rather than
+          # letting the upload return an opaque 400.
+          code=$(curl -s -o /dev/null -w "%{http_code}" "https://pypi.org/pypi/${NAME}/${VERSION}/json")
+          if [ "$code" = "200" ]; then
+            echo "::error::${NAME}==${VERSION} already exists on PyPI. Bump the version in setup.py and re-run."
+            exit 1
+          fi
+          echo "${NAME}==${VERSION} is not on PyPI yet (HTTP ${code})."
+
+      - name: Publish to PyPI via Trusted Publishing
+        if: ${{ env.DRY_RUN != 'true' }}
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/
+          skip-existing: false
+          verbose: true
+
+      - name: Wait for the PyPI index to list the new version
+        if: ${{ env.DRY_RUN != 'true' }}
+        shell: bash
+        env:
+          NAME: ${{ steps.cfg.outputs.name }}
+          VERSION: ${{ steps.cfg.outputs.version }}
+        run: |
+          set -euo pipefail
+          # PyPI's index is eventually consistent; poll for up to 5 minutes so
+          # the smoke install below does not race the CDN.
+          for i in $(seq 1 30); do
+            if curl -fs "https://pypi.org/simple/${NAME}/" | grep -q "${VERSION}"; then
+              echo "Index lists ${NAME}==${VERSION} after ${i} polls."
+              exit 0
+            fi
+            sleep 10
+          done
+          echo "::error::PyPI index still missing ${NAME}==${VERSION} after 5 minutes"
+          exit 1
+
+      - name: Smoke install from PyPI
+        if: ${{ env.DRY_RUN != 'true' }}
+        shell: bash
+        env:
+          NAME: ${{ steps.cfg.outputs.name }}
+          VERSION: ${{ steps.cfg.outputs.version }}
+        run: |
+          set -euo pipefail
+          python -m venv /tmp/smoke
+          # --no-deps: this checks that the published artifact is fetchable and
+          # lays its packages down correctly. Resolving the full dependency set
+          # would drag the GPU stack onto a CPU runner without testing anything
+          # about this wheel.
+          /tmp/smoke/bin/pip install --no-deps "${NAME}==${VERSION}"
+          /tmp/smoke/bin/pip show "${NAME}"
+          # Run from outside the checkout: the repo root holds miles/ and
+          # miles_plugins/, and cwd precedes site-packages on sys.path, so
+          # staying here would resolve them from source and prove nothing.
+          cd /tmp
+          /tmp/smoke/bin/python - <<'PY'
+          import importlib.util, sys
+
+          # find_spec locates the package without executing its __init__, which
+          # would need numpy/torch that --no-deps deliberately did not install.
+          wanted = [
+              "miles",
+              "miles_plugins",
+              "miles_megatron_plugins.true_on_policy.contracts",
+              "sglang",
+              "megatron.core",
+              "megatron.training",
+          ]
+          bad = []
+          for name in wanted:
+              spec = importlib.util.find_spec(name)
+              if spec is None:
+                  bad.append(f"{name}: not found")
+                  continue
+              where = spec.origin or str(list(spec.submodule_search_locations))
+              print(f"  {name:50} -> {where}")
+              # Guard against resolving something other than the wheel we just
+              # installed (a stray copy on sys.path would hide a broken build).
+              if "site-packages" not in where:
+                  bad.append(f"{name}: resolved outside site-packages ({where})")
+          if bad:
+              sys.exit("smoke install failed:\n  " + "\n  ".join(bad))
+          print("OK: pip install from PyPI yields miles, sglang and megatron.")
+          PY

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,10 +1,12 @@
 # Files to ship in the miles-rl distribution beyond the Python sources that
 # setup.py's `packages=` already covers.
 
-# PyPI renders README.md on the project page (setup.py embeds it into the
-# wheel METADATA via long_description); listing both here keeps the sdist
-# self-contained and lets `license_files` resolve.
-include README.md LICENSE
+# Files setup.py reads at build time. Without these in the sdist, building a
+# wheel from the sdist -- what `pip install --no-binary` and any environment
+# the wheel does not cover fall back to -- dies before it starts:
+# requirements.txt feeds install_requires, README.md feeds long_description,
+# and LICENSE is resolved by license_files.
+include README.md LICENSE requirements.txt
 
 # Non-Python data files inside the bundled third_party/* sources -- JSON GEMM
 # and MoE configs, kernel templates, headers. `find_namespace_packages` picks

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,24 @@
+# Files to ship in the miles-rl distribution beyond the Python sources that
+# setup.py's `packages=` already covers.
+
+# PyPI renders README.md on the project page (setup.py embeds it into the
+# wheel METADATA via long_description); listing both here keeps the sdist
+# self-contained and lets `license_files` resolve.
+include README.md LICENSE
+
+# Non-Python data files inside the bundled third_party/* sources -- JSON GEMM
+# and MoE configs, kernel templates, headers. `find_namespace_packages` picks
+# up the packages but not these, and without them the bundled sglang and
+# Megatron-LM fail at runtime looking for their config tables.
+recursive-include third_party/sglang/python/sglang *.json *.txt *.md *.cu *.cuh *.h *.cpp *.hpp *.yaml *.yml *.j2 *.template
+recursive-include third_party/Megatron-LM/megatron *.json *.txt *.md *.cu *.cuh *.h *.cpp *.hpp *.yaml *.yml *.j2 *.template
+recursive-include third_party/Megatron-LM/miles_megatron_plugins *.json *.yaml *.yml *.txt
+
+# miles' own non-Python assets.
+recursive-include miles *.json *.yaml *.yml *.txt
+recursive-include miles_plugins *.json *.yaml *.yml *.txt
+
+# Test trees inside the bundled sources are never imported at runtime and only
+# bloat the distribution.
+prune third_party/sglang/python/sglang/test
+prune third_party/Megatron-LM/megatron/core/datasets/tests

--- a/setup.py
+++ b/setup.py
@@ -168,7 +168,7 @@ setup(
     # The PyPI distribution is `miles-rl`; plain `miles` is taken by an
     # unrelated project. Import names are unaffected (`import miles`).
     name="miles-rl",
-    version="0.2.2",
+    version="0.1",
     description="Enterprise-grade reinforcement learning for large-scale model post-training.",
     long_description=_read_long_description(),
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,40 @@
-import sys
+import os
 import platform
+import sys
+from pathlib import Path
 
-from setuptools import find_packages, setup
+from setuptools import find_namespace_packages, find_packages, setup
 from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
+
+_HERE = Path(__file__).parent
+
+# ---------------------------------------------------------------------------
+# Optional bundling of the patched sglang / Megatron-LM sources.
+#
+# `third_party/sglang` and `third_party/Megatron-LM` are git submodules. They
+# are populated only when someone opts in with `git submodule update --init`
+# (or clones with `--recurse-submodules`). A plain `git clone` -- which is what
+# docker/Dockerfile does before `pip install -e .` -- leaves them empty.
+#
+# When they are absent we build exactly the package we always built: miles and
+# miles_plugins only. Nothing is bundled and no `package_dir` entry is emitted,
+# so an editable install cannot shadow the sglang/Megatron-LM that the image
+# already installed elsewhere.
+#
+# When they are present (the wheel-publishing path) their Python sources are
+# bundled into the distribution, so `pip install miles-rl` yields a working
+# miles, sglang, megatron.* and miles_megatron_plugins in one shot.
+# ---------------------------------------------------------------------------
+_SGLANG_SRC = _HERE / "third_party" / "sglang" / "python"
+_MEGATRON_SRC = _HERE / "third_party" / "Megatron-LM"
+_BUNDLE_THIRD_PARTY = (_SGLANG_SRC / "sglang").is_dir() and (_MEGATRON_SRC / "megatron").is_dir()
+
+# The bundled sources are pure Python (sglang's compiled kernels ship
+# separately as the `sgl-kernel` PyPI package), so the published wheel must be
+# tagged `py3-none-any` or it installs on only one interpreter/platform.
+# Off by default to preserve the existing local/`pip install -e .` behaviour;
+# the publish workflow opts in.
+_PURE_WHEEL = os.environ.get("MILES_PURE_WHEEL") == "1"
 
 
 def _get_platform_tag():
@@ -22,13 +54,48 @@ def _fetch_requirements(path):
         return [r.strip() for r in fd.readlines() if r.strip() and not r.startswith("#")]
 
 
+def _read_long_description():
+    """Return the README so PyPI renders it on the project page."""
+    return _HERE.joinpath("README.md").read_text(encoding="utf-8")
+
+
+def _discover_packages():
+    """Return (packages, package_dir), bundling third_party/* when available."""
+    packages = find_packages(include=["miles*", "miles_plugins*"])
+    package_dir = {}
+
+    if not _BUNDLE_THIRD_PARTY:
+        return packages, package_dir
+
+    # `sglang` is a regular package; `megatron`, `megatron.legacy` and several
+    # sub-packages have no __init__.py, so namespace discovery is required.
+    packages += find_namespace_packages(where=str(_SGLANG_SRC), include=["sglang", "sglang.*"])
+    packages += find_namespace_packages(where=str(_MEGATRON_SRC), include=["megatron", "megatron.*"])
+    # miles_megatron_plugins lives inside the Megatron-LM repo and is packaged
+    # with megatron-core there; bundle it from the same submodule.
+    packages += find_namespace_packages(
+        where=str(_MEGATRON_SRC),
+        include=["miles_megatron_plugins", "miles_megatron_plugins.*"],
+    )
+    package_dir = {
+        "sglang": "third_party/sglang/python/sglang",
+        "megatron": "third_party/Megatron-LM/megatron",
+        "miles_megatron_plugins": "third_party/Megatron-LM/miles_megatron_plugins",
+    }
+    return packages, package_dir
+
+
 # Custom wheel class to modify the wheel name
 class bdist_wheel(_bdist_wheel):
     def finalize_options(self):
         _bdist_wheel.finalize_options(self)
-        self.root_is_pure = False
+        self.root_is_pure = _PURE_WHEEL
 
     def get_tag(self):
+        if _PURE_WHEEL:
+            # py3 (any Python 3), none (no ABI constraint), any (any platform).
+            return "py3", "none", "any"
+
         python_version = f"cp{sys.version_info.major}{sys.version_info.minor}"
         abi_tag = f"{python_version}"
         platform_tag = _get_platform_tag()
@@ -36,12 +103,30 @@ class bdist_wheel(_bdist_wheel):
         return python_version, abi_tag, platform_tag
 
 
+_packages, _package_dir = _discover_packages()
+
 # Setup configuration
 setup(
-    author="miles Team",
-    name="miles",
-    version="0.2.1",
-    packages=find_packages(include=["miles*", "miles_plugins*"]),
+    author="Miles Team",
+    author_email="miles@radixark.ai",
+    # The PyPI distribution is `miles-rl`; plain `miles` is taken by an
+    # unrelated project. Import names are unaffected (`import miles`).
+    name="miles-rl",
+    version="0.2.2",
+    description="Enterprise-grade reinforcement learning for large-scale model post-training.",
+    long_description=_read_long_description(),
+    long_description_content_type="text/markdown",
+    url="https://github.com/radixark/miles",
+    project_urls={
+        "Documentation": "https://miles.radixark.com/docs",
+        "Source": "https://github.com/radixark/miles",
+        "Issues": "https://github.com/radixark/miles/issues",
+    },
+    license="Apache-2.0",
+    license_files=("LICENSE",),
+    keywords="reinforcement-learning rlhf rl moe sglang megatron post-training",
+    packages=_packages,
+    package_dir=_package_dir,
     include_package_data=True,
     package_data={"miles.dashboard": ["static/*"]},
     install_requires=_fetch_requirements("requirements.txt"),

--- a/setup.py
+++ b/setup.py
@@ -168,7 +168,7 @@ setup(
     # The PyPI distribution is `miles-rl`; plain `miles` is taken by an
     # unrelated project. Import names are unaffected (`import miles`).
     name="miles-rl",
-    version="0.1",
+    version="0.0.3",
     description="Enterprise-grade reinforcement learning for large-scale model post-training.",
     long_description=_read_long_description(),
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 import os
 import platform
+import re
 import sys
 from pathlib import Path
 
@@ -59,6 +60,60 @@ def _read_long_description():
     return _HERE.joinpath("README.md").read_text(encoding="utf-8")
 
 
+def _project_dependencies(pyproject):
+    """Return `[project].dependencies` from a pyproject.toml, or [] if absent."""
+    if not pyproject.is_file():
+        return []
+
+    try:
+        import tomllib
+    except ModuleNotFoundError:  # Python 3.10
+        try:
+            import tomli as tomllib
+        except ModuleNotFoundError:
+            tomllib = None
+
+    if tomllib is not None:
+        with open(pyproject, "rb") as fd:
+            return tomllib.load(fd).get("project", {}).get("dependencies", [])
+
+    # No TOML parser available. The dependency array is a flat list of quoted
+    # strings, so recover it directly rather than silently shipping an empty
+    # extra that would look installable and then fail at import time.
+    text = pyproject.read_text(encoding="utf-8")
+    block = re.search(r"^dependencies\s*=\s*\[(.*?)^\]", text, re.M | re.S)
+    if block is None:
+        return []
+    return re.findall(r"['\"]([^'\"]+)['\"]", block.group(1))
+
+
+def _third_party_extras():
+    """Runtime requirements of the bundled sglang and Megatron-LM.
+
+    Bundling their source rather than depending on their published packages
+    means their dependency metadata does not come along, so it is reproduced
+    here -- read from the pinned submodules, so it tracks whatever commit
+    third_party/* points at instead of being a hand-maintained list that rots.
+
+    These stay out of install_requires on purpose. sglang pins CUDA-13 wheels
+    (flashinfer, sglang-kernel, nvidia-cutlass-dsl, flash-attn-4) that cannot
+    resolve on a CPU-only or non-Linux machine, and putting them in the base
+    requirements would make `pip install miles-rl` fail outright there rather
+    than install the parts that do work.
+    """
+    if not _BUNDLE_THIRD_PARTY:
+        return [], []
+
+    sglang_deps = _project_dependencies(_SGLANG_SRC / "pyproject.toml")
+    megatron_deps = _project_dependencies(_MEGATRON_SRC / "pyproject.toml")
+    # megatron.training imports triton at module load, but Megatron-LM's
+    # pyproject deliberately declares it as `triton; sys_platform == 'never'`
+    # -- an unsatisfiable marker, because its own images ship triton with
+    # torch. A pip install has no such image, so request it explicitly.
+    megatron_deps = list(megatron_deps) + ["triton; sys_platform == 'linux'"]
+    return sglang_deps, megatron_deps
+
+
 def _discover_packages():
     """Return (packages, package_dir), bundling third_party/* when available."""
     packages = find_packages(include=["miles*", "miles_plugins*"])
@@ -104,6 +159,7 @@ class bdist_wheel(_bdist_wheel):
 
 
 _packages, _package_dir = _discover_packages()
+_sglang_deps, _megatron_deps = _third_party_extras()
 
 # Setup configuration
 setup(
@@ -144,6 +200,11 @@ setup(
             "uvicorn>=0.41",
             "prometheus_client>=0.24",
         ],
+        # What the bundled third-party sources need in order to actually
+        # import. Linux + CUDA 13 only; see _third_party_extras().
+        "sglang": _sglang_deps,
+        "megatron": _megatron_deps,
+        "all": _sglang_deps + _megatron_deps,
     },
     python_requires=">=3.10",
     classifiers=[


### PR DESCRIPTION
Stacked on #2493 (which adds the `third_party/*` submodules). Review that one first.

## Summary

- `setup.py` bundles the Python sources from `third_party/sglang` and `third_party/Megatron-LM`
  into the distribution, so one wheel carries `miles`, `miles_plugins`, `sglang`, `megatron.*`
  and `miles_megatron_plugins`.
- Renames the distribution from `miles` to `miles-rl` and fills in the PyPI metadata
  (summary, README as the project page, license, project URLs, keywords).
- Adds `MANIFEST.in` so the bundled sources keep their non-Python data files.
- Adds `.github/workflows/publish-pypi.yml`: builds the wheel, verifies it, and uploads to PyPI
  through Trusted Publishing.
- Version `0.2.1` → `0.0.3`.

## Why

`pip install miles-rl` today gives you a snapshot from May. It has not been refreshed because
the machinery to cut a release has never lived in this repository — it was carried on a
long-lived branch that had to be dragged forward across every change to `main`. Putting it on
`main` makes a release "bump the two submodule pins, bump the version, run the workflow".

**Why bundle rather than depend.** The alternative is publishing the patched sglang and
Megatron-LM as their own packages and listing them as requirements. That needs somewhere to
publish them to, and it lets their versions drift away from the miles commit that was actually
tested against them. Bundling keeps one artifact whose contents are exactly what the submodule
pins say.

**Why the distribution is renamed.** `miles` on PyPI is an unrelated package, so the project is
`miles-rl`. Only the distribution name changes; `import miles` is unaffected, and nothing in
this repo looks the distribution up by name (no `importlib.metadata.version("miles")`, no
`pip uninstall miles`).

**Why `0.0.3`.** It continues the line already published to PyPI, where the last release was
`0.0.2`. Note this repo's `setup.py` previously said `0.2.1`, so in repo terms the string moves
backwards; that is deliberate. Nothing reads the distribution version programmatically (no
`importlib.metadata.version(...)` on it anywhere in the tree), so the only effect is what
`pip show` prints.

## Two things worth reviewing closely

**The bundling must not affect the Docker image.** `docker/Dockerfile` clones this repo without
`--recurse-submodules` and then runs `pip install -e .`, so `third_party/*` is empty there. If
`setup.py` unconditionally mapped `sglang` → `third_party/sglang/python/sglang`, that editable
install would put a non-existent path on `sys.path` ahead of the real sglang the image installs
at `/sgl-workspace/sglang`. So the bundling is conditional: when the submodule directories are
absent, `setup.py` produces exactly the package it produces on `main` today, with an empty
`package_dir`. Verified locally both ways (see the test plan).

**The wheel must be tagged `py3-none-any`.** `main`'s `bdist_wheel` emits an
interpreter/platform-specific tag (`cp312-cp312-manylinux1_x86_64`), which would restrict the
release to one Python version. The bundled sources are pure Python — sglang's compiled kernels
ship separately as `sgl-kernel` — so the publish path sets `MILES_PURE_WHEEL=1` to get a pure
tag. Default behaviour is unchanged, and the workflow hard-fails if the tag comes out wrong.

## Known caveat

Installing upstream `sglang` into the same environment after `miles-rl` will overwrite the
patched copy, since both occupy the top-level `sglang` name. This is the accepted trade-off for
a single-artifact install; `miles-rl` is expected to be the primary install in its environment.

## Test plan

Verified locally on the submodule pins from #2493:

- **Bundling off (the image's path):** with `third_party/` absent, `setup.py` yields 66 packages,
  `package_dir == {}`, and no `sglang`/`megatron`/`miles_megatron_plugins` entries. The editable
  install cannot shadow anything.
- **Bundling on:** `MILES_PURE_WHEEL=1 python -m build --wheel` produces
  `miles_rl-0.0.3-py3-none-any.whl` (13 MB, 4596 files) containing `miles` (381),
  `miles_plugins` (63), `sglang` (3640), `megatron` (492) and `miles_megatron_plugins` (15).
- **Data files survive:** 554 bundled `.json` config tables, plus `miles/dashboard/static`.
- **Fresh-venv install** of that wheel with `--no-deps` resolves `miles_megatron_plugins.true_on_policy.contracts`,
  `sglang`, `megatron.core` and `megatron.training` from `site-packages` with no `PYTHONPATH` set.
- **Workflow:** the `pull_request` trigger runs the build-and-verify half on this PR, so CI here
  is the evidence that the packaging builds. No upload happens without a manual
  `workflow_dispatch` with `dry_run=false`.

## After merge

Cutting the release is one manual `workflow_dispatch` run with `dry_run=false`. PyPI Trusted
Publishing is already registered against this repository and this workflow filename, so no
secret needs to be added.

---

## Verified end-to-end on Linux (added after review of the first draft)

The first version of this PR shipped sglang's **source** but not its **dependency metadata**, so the
wheel installed a complete sglang tree that could not be imported. Two later commits fix that; here
is the evidence, run on an H200 devbox (Ubuntu 24.04.3, glibc 2.39, Python 3.12.3) — miles' actual
target platform.

Before and after, on the same machine, in the same clean venv:

| import | `pip install miles-rl` | `pip install miles-rl[all]` |
|---|---|---|
| `miles` | OK | OK |
| `sglang` | **ModuleNotFoundError: torchvision** | OK |
| `megatron.core` | OK | OK |
| `megatron.training` | OK | OK |
| `miles_megatron_plugins.true_on_policy.contracts` | OK | OK |

All five resolve from `site-packages`, with no `PYTHONPATH` set. `torch` resolves to `2.11.0+cu130`,
matching sglang's own pin, and `from sglang.srt.entrypoints.http_server import app` works.

**The bundled sglang is the miles branch, not upstream.** The installed tree contains `/pull_weights`
(12 references in `srt/entrypoints/http_server.py`) and `RankParallelismConfig` (8 references), both
introduced by commits that exist only on `sglang-miles`. The submodule tracking branches also match
the Dockerfile exactly: `sglang-miles` against `ARG SGLANG_BRANCH`, and `radixark/Megatron-LM`
`miles-main` against `ARG MEGATRON_REPO`/`ARG MEGATRON_BRANCH`. `sglang-miles` is 36 commits on top
of upstream `v0.5.16`, the same release as `ARG SGLANG_IMAGE_TAG=v0.5.16`.

## Two limitations worth knowing

**Miles needs glibc >= 2.39 (Ubuntu 24.04+).** `requirements.txt` pins
`nvidia-resiliency-ext~=0.6.0`, which ships `manylinux_2_39` wheels from 0.5.0 onward. On Ubuntu
22.04 (glibc 2.35) pip filters those out and the install fails with a confusing "from versions:
... 0.4.1". This is pre-existing, not introduced here, but it is now user-visible via pip.

**`sglang.__version__` reports `0.0.0.dev0`.** sglang's `_version.py` is generated by its own
setuptools-scm build, which bundling does not run. Nothing in miles reads `sglang.__version__`
(checked), so this is cosmetic; restoring it would mean running sglang's build during ours.
