### PR TITLE
feat(ci): add weekly full-suite cadence

### DIFF
--- a/.github/workflows/pr-test-rocm.yml
+++ b/.github/workflows/pr-test-rocm.yml
@@ -25,10 +25,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review, labeled]
   schedule:
-    # Same nightly/weekly split as pr-test.yml; ci_policy.py maps each exact cron.
+    # Same UTC nightly/weekly split as pr-test.yml; ci_policy.py maps each exact cron.
     - cron: '0 15 * * 0-5'
-    - cron: '0 8 * * 6'
-      timezone: 'America/Los_Angeles'
+    - cron: '0 15 * * 6'
   workflow_dispatch:
     inputs:
       ci_image_tag:

--- a/.github/workflows/pr-test-rocm.yml
+++ b/.github/workflows/pr-test-rocm.yml
@@ -7,7 +7,8 @@ name: PR Test (ROCm)
 #
 # Test selection is explicit rather than inherited from the CUDA suites. The
 # shared CI policy selects matching register_rocm_ci() labels for PR/nightly
-# runs; manual dispatch keeps the full regular MI300X suite.
+# runs and the full label scope for weekly; manual dispatch keeps the full
+# regular MI300X suite.
 #
 # The MI300X host is split into two 4-GPU runners, so this stage is 4-GPU.
 # CUDA tests that need 8 GPUs get a standalone test_amd_<name>.py with its
@@ -24,8 +25,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review, labeled]
   schedule:
-    # Same nightly cadence as pr-test.yml; ci_policy.py maps this exact cron.
-    - cron: '0 15 * * *'
+    # Same nightly/weekly split as pr-test.yml; ci_policy.py maps each exact cron.
+    - cron: '0 15 * * 0-5'
+    - cron: '0 8 * * 6'
+      timezone: 'America/Los_Angeles'
   workflow_dispatch:
     inputs:
       ci_image_tag:
@@ -88,6 +91,7 @@ jobs:
     # shard's failure does not cancel the other mid-run.
     strategy:
       fail-fast: false
+      max-parallel: ${{ needs.resolve-ci-policy.outputs.cadence == 'weekly' && 1 || 2 }}
       matrix:
         partition_id: [0, 1]
     uses: ./.github/workflows/_run-ci-rocm.yml

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -6,9 +6,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review, labeled, closed]
   schedule:
-    # Nightly CI on main runs every enabled tag except long and ft-long, with fast-fail disabled.
-    # 15:00 UTC = 08:00 PDT / 07:00 PST (cron is UTC, no DST).
-    - cron: '0 15 * * *'
+    # Nightly runs Sunday-Friday; Saturday's run is replaced by weekly full CI.
+    - cron: '0 15 * * 0-5'
+    - cron: '0 8 * * 6'
+      timezone: 'America/Los_Angeles'
   workflow_dispatch:
     inputs:
       infinite_run:
@@ -46,9 +47,9 @@ concurrency:
 # `run_suite.py` consumes that shared policy; GPU jobs consume the shared
 # bypass output for their cross-stage gate.
 #
-# Trigger type is not policy: the current nightly cron is mapped by its exact
-# expression, while workflow_dispatch remains a regular manual operation with
-# no implicit domain scope.
+# Trigger type is not policy: each scheduled cron maps to an explicit cadence,
+# while workflow_dispatch remains a regular manual operation with no implicit
+# domain scope.
 
 jobs:
   resolve-ci-policy:
@@ -239,6 +240,7 @@ jobs:
         (needs.stage-a-cpu.result == 'failure' && needs.resolve-ci-policy.outputs.bypass_fastfail == 'true'))
     strategy:
       fail-fast: false
+      max-parallel: ${{ needs.resolve-ci-policy.outputs.cadence == 'weekly' && 1 || 2 }}
       matrix:
         partition_id: [0, 1]
     uses: ./.github/workflows/_run-ci.yml
@@ -262,6 +264,7 @@ jobs:
         (needs.stage-a-cpu.result == 'failure' && needs.resolve-ci-policy.outputs.bypass_fastfail == 'true'))
     strategy:
       fail-fast: false
+      max-parallel: ${{ needs.resolve-ci-policy.outputs.cadence == 'weekly' && 1 || 2 }}
       matrix:
         partition_id: [0, 1]
     uses: ./.github/workflows/_run-ci.yml
@@ -285,6 +288,7 @@ jobs:
         (needs.stage-a-cpu.result == 'failure' && needs.resolve-ci-policy.outputs.bypass_fastfail == 'true'))
     strategy:
       fail-fast: false
+      max-parallel: ${{ needs.resolve-ci-policy.outputs.cadence == 'weekly' && 1 || 3 }}
       matrix:
         partition_id: [0, 1, 2]
     uses: ./.github/workflows/_run-ci.yml
@@ -308,6 +312,7 @@ jobs:
         (needs.stage-a-cpu.result == 'failure' && needs.resolve-ci-policy.outputs.bypass_fastfail == 'true'))
     strategy:
       fail-fast: false
+      max-parallel: ${{ needs.resolve-ci-policy.outputs.cadence == 'weekly' && 1 || 2 }}
       matrix:
         partition_id: [0, 1]
     uses: ./.github/workflows/_run-ci.yml

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -6,10 +6,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review, labeled, closed]
   schedule:
-    # Nightly runs Sunday-Friday; Saturday's run is replaced by weekly full CI.
+    # All scheduled runs use UTC. Saturday's weekly full CI replaces nightly.
     - cron: '0 15 * * 0-5'
-    - cron: '0 8 * * 6'
-      timezone: 'America/Los_Angeles'
+    - cron: '0 15 * * 6'
   workflow_dispatch:
     inputs:
       infinite_run:

--- a/docs/ci/00-stage.md
+++ b/docs/ci/00-stage.md
@@ -6,7 +6,7 @@ A *stage* is one CI job in a Miles CI workflow. A *suite* is the `suite=` value 
 
 ## Suite → stage mapping
 
-The canonical suite list is `CI_SUITES` in `tests/ci/run_suite.py`, grouped by hardware backend (CPU / CUDA / ROCm). Cadence does not change this inventory: regular and nightly runs use the same stages. Every CPU and CUDA entry has one matching job in `pr-test.yml`; `stage-c-4-gpu-mi300x` has its matching job in `pr-test-rocm.yml`, while the MI350 suites are owned by the external nightly described below. A test picks its stage purely by `suite=`; the stage job runs `run_suite.py --suite <name>`, which collects exactly the tests carrying that suite.
+The canonical suite list is `CI_SUITES` in `tests/ci/run_suite.py`, grouped by hardware backend (CPU / CUDA / ROCm). Cadence does not change this inventory: regular, nightly, and weekly runs use the same stages. Every CPU and CUDA entry has one matching job in `pr-test.yml`; `stage-c-4-gpu-mi300x` has its matching job in `pr-test-rocm.yml`, while the MI350 suites are owned by the external nightly described below. A test picks its stage purely by `suite=`; the stage job runs `run_suite.py --suite <name>`, which collects exactly the tests carrying that suite.
 
 The mapping is kept in sync by hand on both sides:
 - A `suite=` with no matching job never runs.
@@ -33,21 +33,21 @@ In `pr-test.yml`, `tier a` (CPU fast) gates the NVIDIA GPU fleet after both reso
 
 ## What each stage does
 
-**Image resolution (`resolve-ci-image`).** In `pr-test.yml`, a small `ubuntu-latest` job reads `ci-image-tag:` from the PR description (or the `ci_image_tag` dispatch input), defaults to `dev`, validates it is a bare tag, and outputs `radixark/miles:<tag>`. The ROCm resolver uses only its dispatch input, defaults to its dated `rocm/sgl-dev` tag, and uses that same default for PR and nightly runs. Distinct from this, the **`run-ci-image` label** selects the image scope — every enabled tag except `long`, `ft-short`, and `ft-long` — which validates an image bump without selecting those domains implicitly.
+**Image resolution (`resolve-ci-image`).** In `pr-test.yml`, a small `ubuntu-latest` job reads `ci-image-tag:` from the PR description (or the `ci_image_tag` dispatch input), defaults to `dev`, validates it is a bare tag, and outputs `radixark/miles:<tag>`. The ROCm resolver uses only its dispatch input, defaults to its dated `rocm/sgl-dev` tag, and uses that same default for PR, nightly, and weekly runs. Distinct from this, the **`run-ci-image` label** selects the image scope — every enabled tag except `long`, `ft-short`, and `ft-long` — which validates an image bump without selecting those domains implicitly.
 
 **Policy resolution (`resolve-ci-policy`).**
 
 - `pull_request`, `schedule`, and `workflow_dispatch` only say how the workflow started; none itself implies a cadence or domain scope.
 - Each Miles PR workflow passes trigger facts to `tests/ci/ci_policy.py` and publishes its `cadence`, `raw_labels`, and `bypass_fastfail` outputs. That module owns trigger adaptation and the shared `resolve_policy` consumed by `run_suite.py`.
 - A PR `nightly` label maps to nightly cadence.
-- A scheduled run maps its exact `github.event.schedule` cron: the current `0 15 * * *` entry maps to nightly, an unknown cron fails, and a future weekly entry must add its own mapping.
+- A scheduled run maps its exact `github.event.schedule` cron: `0 15 * * 0-5` maps to nightly and `0 8 * * 6` maps to weekly; an unknown cron fails.
 - A manual dispatch keeps regular cadence and has no PR labels. `pr-test.yml` therefore runs the ordinary always-on selection, while the dedicated ROCm dispatch adds `--match-all-labels` to preserve its full regular MI300X run.
 
-A **nightly** policy selects every enabled tag except `long` and `ft-long`, admits both regular and `nightly=True` registrations, and disables fast-fail. Regular cadence admits only regular registrations. Both cadences use the same stage inventory.
+A **nightly** policy selects every enabled tag except `long` and `ft-long`, admits both regular and `nightly=True` registrations, and disables fast-fail. A **weekly** policy selects every enabled tag, including `long` and `ft-long`, admits both registration types, and disables fast-fail. Regular cadence admits only regular registrations. All three cadences use the same stage inventory.
 
-`run-ci-all` selects the full domain-tag set without changing cadence. `run-ci-image` selects every enabled tag except `long`, `ft-short`, and `ft-long`. If scope signals overlap, the precedence is `run-ci-all` > nightly > `run-ci-image`. The resolved cadence and raw/synthetic labels are passed to `run_suite.py`, which computes one run policy (see [Labels](/ci/01-label) for the subtraction semantics).
+`run-ci-all` selects the full domain-tag set without changing cadence. `run-ci-image` selects every enabled tag except `long`, `ft-short`, and `ft-long`. If scope signals overlap, the precedence is `run-ci-all` > weekly > nightly > `run-ci-image`. The resolved cadence and raw/synthetic labels are passed to `run_suite.py`, which computes one run policy (see [Labels](/ci/01-label) for the subtraction semantics).
 
-**Dependencies / gating.** In `pr-test.yml`, both CPU stages require both resolvers. Its GPU stages also require both resolvers and, by default, a successful `stage-a-cpu`, so a CPU-test failure short-circuits the expensive NVIDIA fleet. Resolved nightly cadence and the `bypass-fastfail` PR label relax only the `stage-a-cpu` failure gate and make each suite continue after a test failure; neither bypasses resolver failure.
+**Dependencies / gating.** In `pr-test.yml`, both CPU stages require both resolvers. Its GPU stages also require both resolvers and, by default, a successful `stage-a-cpu`, so a CPU-test failure short-circuits the expensive NVIDIA fleet. Resolved nightly or weekly cadence and the `bypass-fastfail` PR label relax only the `stage-a-cpu` failure gate and make each suite continue after a test failure; none bypasses resolver failure.
 
 **Runner selection.** CUDA stages request runners by label via `runs_on`, a JSON list passed through to `runs-on` — a runner must carry **all** listed labels (GPU class + count). CPU stages call `_run-cpu-ci.yml`, whose only job runs on GitHub-hosted `ubuntu-latest`, so they don't occupy GPU-fleet slots.
 
@@ -61,11 +61,13 @@ Both workflows receive `execute_command`; CUDA callers additionally pass `runs_o
 
 **Sharding.** A stage with a `partition_id` matrix splits its tests across N shards; `run_suite.py` balances the shards by each test's `est_time`. Each shard is an independent job instance running the same `execute_command` with a different `--auto-partition-id`.
 
-## ROCm PR/nightly mirror
+Weekly runs keep the same shards but set each GPU matrix's `max-parallel` to one, so each stage occupies at most one matching runner. Stages remain independent: `stage-b-2-gpu-h200` and `stage-c-2-gpu-h200` may each occupy one 2-GPU runner at the same time. PR and nightly runs retain their existing matrix parallelism.
 
-`pr-test-rocm.yml` has `pull_request`, exact nightly cron, and `workflow_dispatch` entry points. PR runs use the same low-trust merge-commit model as `pr-test.yml`. It runs `stage-c-4-gpu-mi300x` through `_run-ci-rocm.yml` on two 4-GPU MI300X runners, resolves `rocm/sgl-dev:<tag>`, and splits tests into two `est_time`-balanced shards. It runs no CPU tests. SGLang and Megatron-LM come from the image, so manual dispatch exposes no dependency-ref inputs.
+## ROCm PR/nightly/weekly mirror
 
-Only tests registered with `register_rocm_ci(suite="stage-c-4-gpu-mi300x", ...)` run; CUDA registrations are not inherited. PR and nightly runs consume the shared cadence and label policy: `run-ci-amd` selects the full MI300X set, other `run-ci-*` labels can select matching subsets, and nightly cadence admits regular plus nightly-only registrations. Manual dispatch adds `--match-all-labels` and runs the full regular suite.
+`pr-test-rocm.yml` has `pull_request`, exact nightly and weekly crons, and `workflow_dispatch` entry points. PR runs use the same low-trust merge-commit model as `pr-test.yml`. It runs `stage-c-4-gpu-mi300x` through `_run-ci-rocm.yml` on two 4-GPU MI300X runners, resolves `rocm/sgl-dev:<tag>`, and splits tests into two `est_time`-balanced shards. Weekly limits that matrix to one runner at a time. It runs no CPU tests. SGLang and Megatron-LM come from the image, so manual dispatch exposes no dependency-ref inputs.
+
+Only tests registered with `register_rocm_ci(suite="stage-c-4-gpu-mi300x", ...)` run; CUDA registrations are not inherited. PR, nightly, and weekly runs consume the shared cadence and label policy: `run-ci-amd` selects the full MI300X set, other `run-ci-*` labels can select matching subsets, nightly admits regular plus `nightly=True` registrations, and weekly selects all enabled registrations. Manual dispatch adds `--match-all-labels` and runs the full regular suite.
 
 Fork PRs use GitHub's standard `pull_request` protections: checkout tests the merge commit, repository secrets are withheld, and held runs follow the shared maintainer approval flow described in [`01-label.md`](01-label.md).
 

--- a/docs/ci/00-stage.md
+++ b/docs/ci/00-stage.md
@@ -40,7 +40,7 @@ In `pr-test.yml`, `tier a` (CPU fast) gates the NVIDIA GPU fleet after both reso
 - `pull_request`, `schedule`, and `workflow_dispatch` only say how the workflow started; none itself implies a cadence or domain scope.
 - Each Miles PR workflow passes trigger facts to `tests/ci/ci_policy.py` and publishes its `cadence`, `raw_labels`, and `bypass_fastfail` outputs. That module owns trigger adaptation and the shared `resolve_policy` consumed by `run_suite.py`.
 - A PR `nightly` label maps to nightly cadence.
-- A scheduled run maps its exact `github.event.schedule` cron: `0 15 * * 0-5` maps to nightly and `0 8 * * 6` maps to weekly; an unknown cron fails.
+- A scheduled run maps its exact UTC `github.event.schedule` cron: `0 15 * * 0-5` maps to nightly and `0 15 * * 6` maps to weekly; an unknown cron fails.
 - A manual dispatch keeps regular cadence and has no PR labels. `pr-test.yml` therefore runs the ordinary always-on selection, while the dedicated ROCm dispatch adds `--match-all-labels` to preserve its full regular MI300X run.
 
 A **nightly** policy selects every enabled tag except `long` and `ft-long`, admits both regular and `nightly=True` registrations, and disables fast-fail. A **weekly** policy selects every enabled tag, including `long` and `ft-long`, admits both registration types, and disables fast-fail. Regular cadence admits only regular registrations. All three cadences use the same stage inventory.

--- a/docs/ci/01-label.md
+++ b/docs/ci/01-label.md
@@ -35,9 +35,9 @@ To add one: add the entry to `KNOWN_LABELS`, then create the matching `run-ci-<k
 
 ## Cadence eligibility
 
-There are two CI cadences: `regular`, the ordinary mode; and `nightly`, which admits `nightly=True` tests, broadens the default scope, and bypasses fast-fail.
+There are three CI cadences: `regular`, the ordinary mode; `nightly`, which admits `nightly=True` tests, broadens the default scope, and bypasses fast-fail; and `weekly`, which also admits `nightly=True` tests, selects every enabled tag, and bypasses fast-fail.
 
-`register_*_ci(nightly=True)` means the test is eligible only under nightly cadence. It does not create a separate suite inventory and does not replace domain-label filtering. A regular run selects regular registrations only; a nightly run selects regular plus nightly-only registrations, then applies the same suite and domain-label filters to both. For example, a nightly-only test carrying only `ft-long` remains outside the standard nightly scope unless `run-ci-ft-long` or `run-ci-all` explicitly includes it.
+`register_*_ci(nightly=True)` means the test is eligible under nightly and weekly cadence, but not regular cadence. It does not create a separate suite inventory and does not replace domain-label filtering. A regular run selects regular registrations only; nightly and weekly select regular plus `nightly=True` registrations, then apply their own domain-label scopes. For example, a `nightly=True` test carrying only `ft-long` remains outside the nightly scope unless `run-ci-ft-long` or `run-ci-all` explicitly includes it, while weekly includes it automatically.
 
 ## Broad CI scopes
 
@@ -46,12 +46,13 @@ The workflow's `resolve-ci-policy` job forwards trigger-specific facts to `tests
 | Scope | Explicit source | Runs | Subtracts | Fast-fail |
 |---|---|---|---|---|
 | all | `run-ci-all` label | every enabled tag | — | determined by cadence |
+| weekly | exact weekly cron | every enabled tag | — | disabled on both levels |
 | nightly | resolved nightly cadence from the PR label, exact nightly cron, or local `--nightly` | every enabled tag except `long` and `ft-long`, incl. `ft-short` | `long`, `ft-long` | disabled on both levels (within-stage only for local runs) |
 | image | `run-ci-image` label | every enabled tag except `long` and FT tags | `long`, `ft-short`, `ft-long` | determined by cadence |
 
-Rows are in precedence order: when scope signals overlap, the higher row wins (`run-ci-all` > nightly > `run-ci-image`, the branch order of `resolve_policy`). `run-ci-all` widens only the domain scope; without nightly cadence it does not admit nightly-only registrations.
+Rows are in precedence order: when scope signals overlap, the higher row wins (`run-ci-all` > weekly > nightly > `run-ci-image`, the branch order of `resolve_policy`). `run-ci-all` widens only the domain scope; regular cadence still does not admit `nightly=True` registrations.
 
-The generic triggers carry no policy. The current nightly schedule is identified by the exact cron string `0 15 * * *`; adding a weekly schedule requires a distinct cadence mapping rather than another `event_name == "schedule"` branch. A manual dispatch uses regular cadence and no PR labels, so it receives only the ordinary always-on scope; its existing operation inputs do not imply all or nightly.
+The generic triggers carry no policy. Nightly is identified by the exact cron `0 15 * * 0-5`; weekly is identified by `0 8 * * 6` with `America/Los_Angeles` scheduling. Saturday weekly replaces that day's nightly rather than starting alongside it. A manual dispatch uses regular cadence and no PR labels, so it receives only the ordinary always-on scope; its existing operation inputs do not imply all, nightly, or weekly.
 
 A subtraction is not a per-test veto — it only stops that label from granting inclusion. A test carrying a subtracted label still runs when another of its labels is in the set, so a test that must stay outside the standard nightly scope must carry only labels that nightly subtracts.
 
@@ -80,7 +81,7 @@ The `bypass-fastfail` PR label turns both off so one run surfaces every failure:
 - Cross-stage: each GPU stage consumes the shared `bypass_fastfail` policy output, so GPU stages run even after `stage-a-cpu` fails.
 - Within-stage: `run_suite.py` derives continue-on-error from the same resolved policy (drops `pytest -x`; sets `continue_on_error=True` for CUDA). The stage still ends red — it changes coverage, not the verdict.
 
-A resolved nightly cadence bypasses fast-fail on both levels because a nightly is meant to exercise every eligible test except `long` and `ft-long` and surface every failure (one datapoint per test), not stop at the first. This applies equally whether the cadence came from the PR `nightly` label or the explicitly mapped nightly cron. Local `--nightly` applies the same selection and within-stage behavior; cross-stage gating does not exist in a local invocation.
+A resolved nightly or weekly cadence bypasses fast-fail on both levels so a scheduled broad run surfaces every failure rather than stopping at the first. For nightly this applies equally whether the cadence came from the PR `nightly` label or the explicitly mapped nightly cron. Local `--nightly` applies the same nightly selection and within-stage behavior; cross-stage gating does not exist in a local invocation.
 
 Like the scope labels, `bypass-fastfail` is a workflow-only input and is not in `KNOWN_LABELS`.
 

--- a/docs/ci/01-label.md
+++ b/docs/ci/01-label.md
@@ -52,7 +52,7 @@ The workflow's `resolve-ci-policy` job forwards trigger-specific facts to `tests
 
 Rows are in precedence order: when scope signals overlap, the higher row wins (`run-ci-all` > weekly > nightly > `run-ci-image`, the branch order of `resolve_policy`). `run-ci-all` widens only the domain scope; regular cadence still does not admit `nightly=True` registrations.
 
-The generic triggers carry no policy. Nightly is identified by the exact cron `0 15 * * 0-5`; weekly is identified by `0 8 * * 6` with `America/Los_Angeles` scheduling. Saturday weekly replaces that day's nightly rather than starting alongside it. A manual dispatch uses regular cadence and no PR labels, so it receives only the ordinary always-on scope; its existing operation inputs do not imply all, nightly, or weekly.
+The generic triggers carry no policy. All scheduled runs use UTC: nightly is identified by the exact cron `0 15 * * 0-5`, and weekly by `0 15 * * 6`. Saturday weekly replaces that day's nightly rather than starting alongside it. A manual dispatch uses regular cadence and no PR labels, so it receives only the ordinary always-on scope; its existing operation inputs do not imply all, nightly, or weekly.
 
 A subtraction is not a per-test veto — it only stops that label from granting inclusion. A test carrying a subtracted label still runs when another of its labels is in the set, so a test that must stay outside the standard nightly scope must carry only labels that nightly subtracts.
 

--- a/docs/ci/03-metric-history-gate.md
+++ b/docs/ci/03-metric-history-gate.md
@@ -59,7 +59,7 @@ register_ci_gate(metric_key="rollout/raw_reward")  # standard metric: steps + co
 Three roles, connected only by JSONL files and one DB — there is no long-lived "metrics manager"; the pipeline is per-test, driven by the harness:
 
 - **Collector (training process)** — `miles.utils.tracking_utils.TrackingManager` fans every `log()` out to all enabled backends; `WandbBackend` and `CiHistoryBackend` are parallel siblings in that registry, so wandb receives the same data independently and nothing downstream ever reads it back. `CiHistoryBackend` snapshots the fixed metric whitelist into per-process JSONL files under the harness-assigned record dir (`MILES_CI_GATE_RECORD_DIR`, injected by the CI harness; no CLI flag).
-- **Harness / finalizer (CI runner)** — `run_suite.py` builds the store from env (`NEON_DATABASE_URL`, a CI secret), resolves the nightly signal + provenance, and allocates the record dir (CUDA suites only); `ci_utils.run_unittest_files` hands each attempt its own record subdir and merges the PASSING attempt's per-process records into the merged per-run JSONL record (a metric key appearing in several processes gets its series concatenated and sorted by step); `ci_utils.run_gate_hook` then assigns identity, runs the gate, and acts on the verdict.
+- **Harness / finalizer (CI runner)** — `run_suite.py` builds the store from env (`NEON_DATABASE_URL`, a CI secret), resolves the baseline-write signal + provenance, and allocates the record dir (CUDA suites only); `ci_utils.run_unittest_files` hands each attempt its own record subdir and merges the PASSING attempt's per-process records into the merged per-run JSONL record (a metric key appearing in several processes gets its series concatenated and sorted by step); `ci_utils.run_gate_hook` then assigns identity, runs the gate, and acts on the verdict.
 - **Gate library (pure functions, read-only against storage)** — `register.py` parses `register_ci_gate` declarations out of the test file's AST at evaluation time (the call itself is a runtime no-op; nothing registers at runtime), `selection.py` picks comparison coordinates, `constraints.py` judges pass/fail, `gate.py:evaluate_gate` composes them over the store's baseline read.
 
 One CUDA test run, end to end:
@@ -73,7 +73,7 @@ flowchart TD
     end
     ci_history_backend -- "per-process JSONL snapshots<br>(whitelist only; non-finite → string markers)" --> run_unittest_files
     subgraph ci_harness["CI harness (tests/ci)"]
-        run_suite["run_suite.py<br>store from env · nightly signal · provenance · record dir"] --> run_unittest_files["run_unittest_files<br>per-attempt record subdir; merge the PASSING attempt"]
+        run_suite["run_suite.py<br>store from env · baseline-write signal · provenance · record dir"] --> run_unittest_files["run_unittest_files<br>per-attempt record subdir; merge the PASSING attempt"]
         run_unittest_files --> run_gate_hook["run_gate_hook<br>assign identity → run the gate → act on the verdict"]
     end
     gate_specs["register_ci_gate specs in the test file<br>(runtime no-op)"] -. "AST parse" .-> evaluate_gate
@@ -82,7 +82,7 @@ flowchart TD
         evaluate_gate["register → selection → constraints → evaluate_gate"]
     end
     evaluate_gate -- "recent_trusted_values (baseline read)" --> metric_store
-    run_gate_hook -- "nightly: write_run(values + trusted)<br>ordinary PR: shadow verdict → log + GITHUB_STEP_SUMMARY, no write" --> metric_store
+    run_gate_hook -- "nightly or weekly: write_run(values + trusted)<br>non-writing run: shadow verdict → log + GITHUB_STEP_SUMMARY" --> metric_store
     subgraph storage
         metric_store[("MetricHistoryStore<br>SQLite offline · Neon CI/prod")]
     end
@@ -160,7 +160,7 @@ flowchart TD
 
     result --> trust
     store -- "baseline read" --> histq
-    trust -- "a trusted run's values are persisted (write_run) and become<br>future baselines — writer: the harness, on nightly-marked runs only" --> store
+    trust -- "a trusted run's values are persisted (write_run) and become<br>future baselines — writer: the harness, on baseline-writing runs only" --> store
 ```
 
 
@@ -200,12 +200,12 @@ Use $neon-access to show the 10 most recent metric-history runs for tests/e2e/me
 
 ## Trust, cleanup, who writes
 
-**Goal:** keep the baseline self-protecting — only nightly-marked runs (with recorded provenance) write at all, a nightly run whose metrics fail the gate is still persisted but flagged `trusted = false` so it never enters the baseline, and a point later found bad is revoked by one flag flip instead of deletion.
+**Goal:** keep the baseline self-protecting — only baseline-writing runs (with recorded provenance) write at all, a run whose metrics fail the gate is still persisted but flagged `trusted = false` so it never enters the baseline, and a point later found bad is revoked by one flag flip instead of deletion.
 
 - A run is `trusted` iff it passed **all** active gates. A drifting run is still recorded, with `trusted = false`, so it can't drag the baseline. A test that fails then passes on **retry** is gated on its passing attempt's metrics and trusted normally — needing a retry is not itself a trust penalty.
 - **Clean a bad point**: `mark_untrusted` = `UPDATE runs SET trusted = false` on the run. The next gate read excludes it immediately — no rebaseline, no row deletion.
-- **Nightly-marked runs write baselines** — either the `schedule` cron (on `main`, post-merge) **or** a PR carrying the `nightly` label (the PR's own pre-merge code). Provenance (`event_name`, `pr_number`) records which, so a label-PR baseline is distinguishable from a post-merge one and can be `mark_untrusted`'d if it turns out bad. Ordinary (unlabeled) PR runs are read-only and only shadow.
-- **What one nightly run writes** — one `runs` row plus one `metric_values` row per value coordinate: two specs sharing a coordinate (identical `steps` + `constraint` literals, differing only in policy metadata) collapse to a single row, so a duplicated declaration cannot double-weight the baseline mean; and a file that declares no gate writes nothing at all — `run_gate_hook` skips the write instead of leaving an empty `runs` row.
+- **Nightly and weekly runs write baselines** — either an explicitly mapped `schedule` cron (on `main`, post-merge) **or** a PR carrying the `nightly` label (the PR's own pre-merge code). Provenance (`event_name`, `pr_number`) records whether a writer was scheduled or PR-triggered, so a label-PR baseline can be `mark_untrusted`'d if it turns out bad. Ordinary (unlabeled) PR runs are read-only and only shadow.
+- **What one baseline-writing run writes** — one `runs` row plus one `metric_values` row per value coordinate: two specs sharing a coordinate (identical `steps` + `constraint` literals, differing only in policy metadata) collapse to a single row, so a duplicated declaration cannot double-weight the baseline mean; and a file that declares no gate writes nothing at all — `run_gate_hook` skips the write instead of leaving an empty `runs` row.
 
 
 
@@ -220,7 +220,7 @@ Shadow-first: collect, store, and evaluate, but **never block a PR** initially �
 **Goal:** record accepted caveats and open questions beside the behavior they qualify; planned-but-unimplemented work lives in TODO below.
 
 - A test-file edit does not reset the series: `test_file_hash` was dropped from the run-series identity because a tiny edit to a test kept wiping its whole history. A test change that genuinely shifts a metric's expected level surfaces as gate failures instead; the reset levers are manual — `mark_untrusted` the stale runs, or edit the declaration literals (new `steps_key` / `constraint_key` ⇒ fresh coordinate).
-- The nightly trigger (`schedule` cron + `nightly` label) already shipped (#1491); detection here is harness-side via `GITHUB_EVENT_NAME`, so this feature needs **no** `pr-test.yml` **edit**.
+- Baseline writing is selected by the resolved CI policy rather than inferred from `GITHUB_EVENT_NAME`; nightly and weekly write, while regular runs stay shadow-only.
 - Open: should a brand-new test's first baselines need human confirmation before counting as trusted? (v1: no.)
 
 

--- a/docs/ci/contributor-guide.md
+++ b/docs/ci/contributor-guide.md
@@ -56,7 +56,7 @@ If your file does **not** show up, check, in order:
 - `labels=[]` (or omitted) → **always-on** within the eligible cadence; with the default `nightly=False`, this includes every PR.
 - `labels=["megatron"]` → runs only when the PR carries the GitHub label **`run-ci-megatron`** (the `run-ci-` prefix is added on the PR side). This keeps the heavy GPU matrix off unrelated PRs.
 
-Cadence is independent of labels: `nightly=True` makes a registration nightly-only, while a nightly run includes both ordinary and nightly-only registrations.
+Cadence is independent of labels: `nightly=True` excludes a registration from regular cadence, while nightly and weekly runs include both ordinary and `nightly=True` registrations.
 
 So if your test is gated and you don't see it run, add the matching `run-ci-<label>` label to your PR. To force the full suite regardless of labels, a maintainer can add `run-ci-all`. Valid labels live in `tests/ci/labels.py`; using one outside that list is a hard error at collection time.
 

--- a/docs/developer/contributor-guide.md
+++ b/docs/developer/contributor-guide.md
@@ -162,7 +162,7 @@ register_cuda_ci(
 ```
 
 `register_cpu_ci`, `register_cuda_ci` and `register_rocm_ci` share that signature, plus
-`nightly=True` (nightly-cadence only) and `disabled="<reason + issue link>"` (reported as
+`nightly=True` (nightly and weekly cadence only) and `disabled="<reason + issue link>"` (reported as
 skipped rather than deleted). The calls are parsed from the AST, so they must be
 top-level, literal, and unaliased.
 

--- a/tests/ci/ci_policy.py
+++ b/tests/ci/ci_policy.py
@@ -16,12 +16,14 @@ _SAFE_RUN_CI_LABEL = re.compile(r"^run-ci-[A-Za-z0-9][A-Za-z0-9_.-]*$")
 
 REGULAR_CADENCE = "regular"
 NIGHTLY_CADENCE = "nightly"
-CI_CADENCES = frozenset({REGULAR_CADENCE, NIGHTLY_CADENCE})
+WEEKLY_CADENCE = "weekly"
+CI_CADENCES = frozenset({REGULAR_CADENCE, NIGHTLY_CADENCE, WEEKLY_CADENCE})
 
 # A scheduled trigger has no policy by itself. Each configured cron must map
 # explicitly so a future cadence cannot silently inherit nightly behavior.
 SCHEDULE_POLICIES: dict[str, tuple[str, tuple[str, ...]]] = {
-    "0 15 * * *": (NIGHTLY_CADENCE, ()),
+    "0 15 * * 0-5": (NIGHTLY_CADENCE, ()),
+    "0 8 * * 6": (WEEKLY_CADENCE, ()),
 }
 
 
@@ -29,11 +31,9 @@ SCHEDULE_POLICIES: dict[str, tuple[str, tuple[str, ...]]] = {
 class RunPolicy:
     cadence: str
     include_labels: frozenset[str]
+    admit_nightly_tests: bool
     bypass_fastfail: bool
-
-    @property
-    def is_nightly(self) -> bool:
-        return self.cadence == NIGHTLY_CADENCE
+    write_baseline: bool
 
 
 @dataclass(frozen=True)
@@ -80,10 +80,12 @@ def resolve_policy(cadence: str, raw_labels: set[str]) -> RunPolicy:
     Broad scopes are large include sets:
 
     - `run-ci-all` includes every registered label.
+    - Weekly cadence includes every registered label.
     - Nightly cadence excludes `long` and `ft-long`.
     - `run-ci-image` excludes `long`, `ft-short`, and `ft-long`.
 
-    Branch order encodes the precedence `run-ci-all` > nightly > `run-ci-image`.
+    Branch order encodes the precedence `run-ci-all` > weekly > nightly >
+    `run-ci-image`.
 
     Explicitly requested `run-ci-<x>` labels are unioned in last, so an
     explicit request always wins over a scope subtraction. A subtraction is
@@ -96,7 +98,7 @@ def resolve_policy(cadence: str, raw_labels: set[str]) -> RunPolicy:
         raise ValueError("The nightly workflow label requires cadence='nightly'")
 
     requested = strip_run_ci_prefix(raw_labels) & set(KNOWN_LABELS)
-    if "run-ci-all" in raw_labels:
+    if "run-ci-all" in raw_labels or cadence == WEEKLY_CADENCE:
         scope = set(KNOWN_LABELS)
     elif cadence == NIGHTLY_CADENCE:
         scope = set(KNOWN_LABELS) - {"long", "ft-long"}
@@ -107,7 +109,9 @@ def resolve_policy(cadence: str, raw_labels: set[str]) -> RunPolicy:
     return RunPolicy(
         cadence=cadence,
         include_labels=frozenset(scope | requested),
-        bypass_fastfail=cadence == NIGHTLY_CADENCE or "bypass-fastfail" in raw_labels,
+        admit_nightly_tests=cadence in {NIGHTLY_CADENCE, WEEKLY_CADENCE},
+        bypass_fastfail=cadence in {NIGHTLY_CADENCE, WEEKLY_CADENCE} or "bypass-fastfail" in raw_labels,
+        write_baseline=cadence in {NIGHTLY_CADENCE, WEEKLY_CADENCE},
     )
 
 

--- a/tests/ci/ci_policy.py
+++ b/tests/ci/ci_policy.py
@@ -23,7 +23,7 @@ CI_CADENCES = frozenset({REGULAR_CADENCE, NIGHTLY_CADENCE, WEEKLY_CADENCE})
 # explicitly so a future cadence cannot silently inherit nightly behavior.
 SCHEDULE_POLICIES: dict[str, tuple[str, tuple[str, ...]]] = {
     "0 15 * * 0-5": (NIGHTLY_CADENCE, ()),
-    "0 8 * * 6": (WEEKLY_CADENCE, ()),
+    "0 15 * * 6": (WEEKLY_CADENCE, ()),
 }
 
 

--- a/tests/ci/ci_register.py
+++ b/tests/ci/ci_register.py
@@ -64,8 +64,8 @@ def register_cpu_ci(
     every cadence that admits it. A non-empty `labels` list gates the test on
     the resolved domain scope; a PR can include `<x>` with `run-ci-<x>`, while
     broad scopes include many domain labels at once. `nightly=True` adds a
-    cadence gate: regular runs exclude the test, while nightly runs include it
-    alongside regular registrations.
+    cadence gate: regular runs exclude the test, while nightly and weekly runs
+    include it alongside regular registrations.
     """
     return None
 

--- a/tests/ci/ci_utils.py
+++ b/tests/ci/ci_utils.py
@@ -278,13 +278,13 @@ def run_gate_hook(
     *,
     store,
     registry: CIRegistry,
-    nightly: bool,
+    write_baseline: bool,
     provenance: RunProvenance,
     now_iso: str | None = None,
 ) -> None:
     """Evaluate the history gate for one passed CUDA test and act on the verdict.
 
-    NIGHTLY-marked run -> persist the run as a trusted/untrusted baseline via
+    BASELINE-WRITING run -> persist the run as a trusted/untrusted baseline via
     `store.write_run`, one `metric_values` row per coordinate (specs sharing a
     coordinate collapse to one row); a file that declares no gate writes
     nothing at all. ORDINARY PR run -> never write; log a shadow verdict and
@@ -297,12 +297,12 @@ def run_gate_hook(
     try:
         result = evaluate_gate(filename, merged_record_path, store, registry=registry)
 
-        if nightly:
+        if write_baseline:
             if not result.metrics:
                 # Every spec yields at least one per-coordinate result, so an
                 # empty list means the file declares no gate: an empty runs row
                 # is nothing a baseline can use, so write nothing.
-                logger.info(f"[CI Gate][nightly] {filename}: no gate declared; skipping write")
+                logger.info(f"[CI Gate][baseline] {filename}: no gate declared; skipping write")
                 return
             identity = RunIdentity(
                 test_path=result.test_path,
@@ -331,7 +331,8 @@ def run_gate_hook(
                 values=values,
             )
             logger.info(
-                f"[CI Gate][nightly] {filename}: wrote baseline " f"(trusted={result.trusted}, {len(values)} value(s))"
+                f"[CI Gate][baseline] {filename}: wrote baseline "
+                f"(trusted={result.trusted}, {len(values)} value(s))"
             )
         else:
             line = _shadow_verdict_line(filename, result)
@@ -388,7 +389,7 @@ def run_unittest_files(
     max_attempts: int = 2,
     retry_wait_seconds: int = 60,
     gate_store=None,
-    gate_nightly: bool = False,
+    gate_write_baseline: bool = False,
     gate_provenance: RunProvenance | None = None,
 ):
     """
@@ -405,8 +406,8 @@ def run_unittest_files(
         retry_wait_seconds: Seconds to wait between retries (default: 60).
         gate_store: Metric-history store for the regression gate, or None to skip
                     the gate hook entirely. Built by `build_store_from_env`.
-        gate_nightly: True when this run writes trusted baselines (nightly);
-                    False for an ordinary PR run, which only logs a shadow verdict.
+        gate_write_baseline: True when this run writes a baseline; False for
+                    a non-baseline-writing run, which only logs a shadow verdict.
         gate_provenance: RunProvenance for the gate write; defaults to
                     `gate_provenance_from_env()` when None.
     """
@@ -602,7 +603,7 @@ def run_unittest_files(
                 passing_record_path,
                 store=gate_store,
                 registry=file,
-                nightly=gate_nightly,
+                write_baseline=gate_write_baseline,
                 provenance=gate_provenance or gate_provenance_from_env(),
             )
 

--- a/tests/ci/ci_utils.py
+++ b/tests/ci/ci_utils.py
@@ -330,10 +330,7 @@ def run_gate_hook(
                 trusted=result.trusted,
                 values=values,
             )
-            logger.info(
-                f"[CI Gate][baseline] {filename}: wrote baseline "
-                f"(trusted={result.trusted}, {len(values)} value(s))"
-            )
+            logger.info(f"[CI Gate][baseline] {filename}: wrote baseline")
         else:
             line = _shadow_verdict_line(filename, result)
             logger.info(line)

--- a/tests/ci/metric_history/gate.py
+++ b/tests/ci/metric_history/gate.py
@@ -22,7 +22,7 @@
 Caveats:
 
 * Do not add store writes here. Persistence is the caller's job --
-  :func:`tests.ci.ci_utils.run_gate_hook` writes rows on nightly-marked runs --
+  :func:`tests.ci.ci_utils.run_gate_hook` writes rows on baseline-writing runs --
   and the gate itself stays read-only.
 """
 

--- a/tests/ci/run_suite.py
+++ b/tests/ci/run_suite.py
@@ -53,7 +53,7 @@ def filter_tests(
     ci_tests: list[CIRegistry],
     hw: HWBackend,
     suite: str,
-    nightly: bool = False,
+    admit_nightly_tests: bool = False,
     labels: set[str] | None = None,
 ) -> tuple[list[CIRegistry], list[CIRegistry]]:
     """Filter registered tests down to the set that should run.
@@ -71,7 +71,11 @@ def filter_tests(
     if suite not in valid_suites:
         raise ValueError(f"Unknown suite {suite} for backend {hw.name}")
 
-    ci_tests = [t for t in ci_tests if t.backend == hw and t.suite == suite and (not t.nightly or nightly)]
+    ci_tests = [
+        t
+        for t in ci_tests
+        if t.backend == hw and t.suite == suite and (not t.nightly or admit_nightly_tests)
+    ]
 
     label_set: set[str] = labels or set()
     ci_tests = [t for t in ci_tests if not t.labels or (set(t.labels) & label_set)]
@@ -188,7 +192,7 @@ def run_a_suite(args):
         all_tests,
         hw,
         suite,
-        policy.is_nightly,
+        policy.admit_nightly_tests,
         labels=include_labels,
     )
 
@@ -217,9 +221,8 @@ def run_a_suite(args):
 
     # Regression-gate wiring: the store exists only when NEON_DATABASE_URL is
     # set (CI), so the gate hook is a no-op locally. The resolved cadence is
-    # also the baseline-writing signal. Provenance comes from the GitHub env.
+    # also supplies the baseline-writing signal. Provenance comes from the GitHub env.
     gate_store = build_store_from_env()
-    gate_nightly = policy.is_nightly
     gate_provenance = gate_provenance_from_env()
 
     # The gate collects only when a record directory exists. CI does not set
@@ -237,7 +240,7 @@ def run_a_suite(args):
         max_attempts=args.max_attempts,
         retry_wait_seconds=args.retry_wait_seconds,
         gate_store=gate_store,
-        gate_nightly=gate_nightly,
+        gate_write_baseline=policy.write_baseline,
         gate_provenance=gate_provenance,
     )
 

--- a/tests/ci/run_suite.py
+++ b/tests/ci/run_suite.py
@@ -71,11 +71,7 @@ def filter_tests(
     if suite not in valid_suites:
         raise ValueError(f"Unknown suite {suite} for backend {hw.name}")
 
-    ci_tests = [
-        t
-        for t in ci_tests
-        if t.backend == hw and t.suite == suite and (not t.nightly or admit_nightly_tests)
-    ]
+    ci_tests = [t for t in ci_tests if t.backend == hw and t.suite == suite and (not t.nightly or admit_nightly_tests)]
 
     label_set: set[str] = labels or set()
     ci_tests = [t for t in ci_tests if not t.labels or (set(t.labels) & label_set)]

--- a/tests/ci/test/test_ci_policy.py
+++ b/tests/ci/test/test_ci_policy.py
@@ -49,7 +49,7 @@ register_cpu_ci(est_time=1, suite="stage-a-cpu", labels=[])
             True,
         ),
         ("schedule", "0 15 * * 0-5", "not JSON", NIGHTLY_CADENCE, (), True),
-        ("schedule", "0 8 * * 6", "not JSON", WEEKLY_CADENCE, (), True),
+        ("schedule", "0 15 * * 6", "not JSON", WEEKLY_CADENCE, (), True),
         ("workflow_dispatch", "", "not JSON", REGULAR_CADENCE, (), False),
     ],
 )
@@ -94,7 +94,7 @@ def test_nightly_label_and_nightly_schedule_share_the_same_run_policy():
 
 
 def test_weekly_schedule_resolves_to_independent_full_policy():
-    scheduled = resolve_workflow_inputs("schedule", "0 8 * * 6", "not JSON")
+    scheduled = resolve_workflow_inputs("schedule", "0 15 * * 6", "not JSON")
     policy = resolve_policy(scheduled.cadence, set(scheduled.raw_labels))
 
     assert policy.cadence == WEEKLY_CADENCE

--- a/tests/ci/test/test_ci_policy.py
+++ b/tests/ci/test/test_ci_policy.py
@@ -7,7 +7,13 @@ import sys
 from pathlib import Path
 
 import pytest
-from tests.ci.ci_policy import NIGHTLY_CADENCE, REGULAR_CADENCE, resolve_policy, resolve_workflow_inputs
+from tests.ci.ci_policy import (
+    NIGHTLY_CADENCE,
+    REGULAR_CADENCE,
+    WEEKLY_CADENCE,
+    resolve_policy,
+    resolve_workflow_inputs,
+)
 from tests.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=1, suite="stage-a-cpu", labels=[])
@@ -42,7 +48,8 @@ register_cpu_ci(est_time=1, suite="stage-a-cpu", labels=[])
             ("run-ci-megatron", "nightly", "run-ci-megatron", "run-ci-a_B.c-d"),
             True,
         ),
-        ("schedule", "0 15 * * *", "not JSON", NIGHTLY_CADENCE, (), True),
+        ("schedule", "0 15 * * 0-5", "not JSON", NIGHTLY_CADENCE, (), True),
+        ("schedule", "0 8 * * 6", "not JSON", WEEKLY_CADENCE, (), True),
         ("workflow_dispatch", "", "not JSON", REGULAR_CADENCE, (), False),
     ],
 )
@@ -79,11 +86,21 @@ def test_unknown_trigger_is_rejected():
 
 def test_nightly_label_and_nightly_schedule_share_the_same_run_policy():
     labeled = resolve_workflow_inputs("pull_request", "", '["nightly"]')
-    scheduled = resolve_workflow_inputs("schedule", "0 15 * * *", "not JSON")
+    scheduled = resolve_workflow_inputs("schedule", "0 15 * * 0-5", "not JSON")
 
     assert resolve_policy(labeled.cadence, set(labeled.raw_labels)) == resolve_policy(
         scheduled.cadence, set(scheduled.raw_labels)
     )
+
+
+def test_weekly_schedule_resolves_to_independent_full_policy():
+    scheduled = resolve_workflow_inputs("schedule", "0 8 * * 6", "not JSON")
+    policy = resolve_policy(scheduled.cadence, set(scheduled.raw_labels))
+
+    assert policy.cadence == WEEKLY_CADENCE
+    assert policy.admit_nightly_tests is True
+    assert policy.bypass_fastfail is True
+    assert policy.write_baseline is True
 
 
 @pytest.mark.parametrize(

--- a/tests/ci/test/test_ci_register.py
+++ b/tests/ci/test/test_ci_register.py
@@ -3,8 +3,9 @@
 Covers the AST-collection behavior of the suite-as-runner-class refactor:
 `labels` is optional (default None ≡ []); a non-empty list of canonical
 domain labels gates the test on the resolved domain scope, while None / [] /
-omitted means always-on within an eligible cadence; `nightly=True` makes a
-registration nightly-only; `num_gpus` is gone; `labels` must be passed by
+omitted means always-on within an eligible cadence; `nightly=True` excludes a
+registration from regular cadence while nightly and weekly admit it;
+`num_gpus` is gone; `labels` must be passed by
 keyword (not as a positional third argument).
 """
 

--- a/tests/ci/test/test_gate_integration.py
+++ b/tests/ci/test/test_gate_integration.py
@@ -8,7 +8,7 @@ monkeypatched.
 Covered:
 
 * passing-attempt selection: only the PASSED attempt's record feeds the gate.
-* nightly write: a `schedule` event makes the hook persist a baseline row
+* baseline write: a policy-selected writer makes the hook persist a baseline row
   whose `trusted` flag comes from the verdict; specs sharing a coordinate
   collapse to one `metric_values` row; a no-spec file writes nothing.
 * PR no-write: a `pull_request` event writes no row and emits a shadow
@@ -182,7 +182,7 @@ class TestBuildStoreFromEnv:
 
 class TestPassingAttemptSelection:
     def test_only_passing_attempt_record_is_evaluated_and_written(self, tmp_path, store, monkeypatch):
-        # Nightly so the hook writes; assert the persisted value comes from the
+        # Baseline writer so the hook writes; assert the persisted value comes from the
         # PASSING attempt's good record, never the failed attempt's bad one.
         monkeypatch.setenv("GITHUB_EVENT_NAME", "schedule")
         test_file = _write_test_file(
@@ -207,7 +207,7 @@ class TestPassingAttemptSelection:
             good_record,
             store=store,
             registry=registry,
-            nightly=True,
+            write_baseline=True,
             provenance=PROVENANCE,
         )
 
@@ -215,10 +215,10 @@ class TestPassingAttemptSelection:
         assert rows == [(0.80,)], "only the passing attempt's value must be written"
 
 
-# --- nightly write ----------------------------------------------------------
+# --- baseline write ---------------------------------------------------------
 
 
-class TestNightlyWrite:
+class TestBaselineWrite:
     def test_nightly_writes_trusted_row_with_provenance(self, tmp_path, store, monkeypatch):
         monkeypatch.setenv("GITHUB_EVENT_NAME", "schedule")
         test_file = _write_test_file(
@@ -237,7 +237,7 @@ class TestNightlyWrite:
             record,
             store=store,
             registry=registry,
-            nightly=True,
+            write_baseline=True,
             provenance=PROVENANCE,
             now_iso="2026-06-29T00:00:00+00:00",
         )
@@ -273,7 +273,7 @@ class TestNightlyWrite:
 
     def test_nightly_writes_untrusted_when_verdict_not_trusted(self, tmp_path, store):
         # A historical failure makes the verdict not-trusted; the row is still
-        # written (nightly always writes) but flagged untrusted, so it never
+        # written (baseline writers always write) but flagged untrusted, so it never
         # pollutes a future baseline.
         test_file = _write_test_file(
             tmp_path,
@@ -299,7 +299,7 @@ class TestNightlyWrite:
             record,
             store=store,
             registry=registry,
-            nightly=True,
+            write_baseline=True,
             provenance=PROVENANCE,
             now_iso="2026-06-29T00:00:00+00:00",
         )
@@ -336,7 +336,7 @@ class TestNightlyWrite:
             record,
             store=store,
             registry=registry,
-            nightly=True,
+            write_baseline=True,
             provenance=PROVENANCE,
         )
 
@@ -361,7 +361,7 @@ class TestNightlyWrite:
             record,
             store=store,
             registry=registry,
-            nightly=True,
+            write_baseline=True,
             provenance=PROVENANCE,
         )
         assert _count_runs(store) == 0
@@ -390,7 +390,7 @@ class TestNightlyWrite:
             record,
             store=store,
             registry=registry,
-            nightly=True,
+            write_baseline=True,
             provenance=PROVENANCE,
         )
         assert _count_runs(store) == 1
@@ -425,7 +425,7 @@ class TestPrShadow:
                 record,
                 store=store,
                 registry=registry,
-                nightly=False,
+                write_baseline=False,
                 provenance=PROVENANCE,
             )
 
@@ -472,7 +472,7 @@ class TestNeverBlocks:
             record,
             store=store,
             registry=registry,
-            nightly=False,
+            write_baseline=False,
             provenance=PROVENANCE,
         )
         assert result is None
@@ -499,7 +499,7 @@ class TestNeverBlocks:
                 missing_record,
                 store=store,
                 registry=registry,
-                nightly=True,
+                write_baseline=True,
                 provenance=PROVENANCE,
             )
         assert result is None
@@ -532,7 +532,7 @@ class TestNeverBlocks:
                 record,
                 store=store,
                 registry=registry,
-                nightly=True,
+                write_baseline=True,
                 provenance=PROVENANCE,
             )
             assert result is None
@@ -544,7 +544,7 @@ class TestNeverBlocks:
 
 
 def test_hook_signature_matches_metric_sample_contract(tmp_path, store, monkeypatch):
-    # Regression guard: nightly values must be built as
+    # Regression guard: baseline values must be built as
     # MetricSample(metric_key, steps_key, constraint_key, step, current) and only
     # for metrics whose current is not None. A spec on a missing metric
     # (current None) yields a written run with zero values.
@@ -565,7 +565,7 @@ def test_hook_signature_matches_metric_sample_contract(tmp_path, store, monkeypa
         record,
         store=store,
         registry=registry,
-        nightly=True,
+        write_baseline=True,
         provenance=PROVENANCE,
     )
     assert _count_runs(store) == 1

--- a/tests/ci/test/test_run_suite.py
+++ b/tests/ci/test/test_run_suite.py
@@ -317,9 +317,11 @@ class TestWorkflowScopeSeam:
         configured = set(re.findall(r"^\s+- cron: ['\"]([^'\"]+)['\"]\s*$", workflow, flags=re.MULTILINE))
         assert configured == set(SCHEDULE_POLICIES)
 
-    def test_weekly_schedule_uses_pacific_time(self):
+    def test_scheduled_runs_use_utc_1500(self):
         workflow = self._workflow()
-        assert "    - cron: '0 8 * * 6'\n      timezone: 'America/Los_Angeles'" in workflow
+        assert "    - cron: '0 15 * * 0-5'" in workflow
+        assert "    - cron: '0 15 * * 6'" in workflow
+        assert "timezone:" not in workflow
 
     def test_weekly_serializes_each_gpu_matrix(self):
         workflow = self._workflow()
@@ -333,8 +335,7 @@ class TestWorkflowScopeSeam:
             block = workflow.split(f"  {job}:", 1)[1]
             block = re.split(r"^  [A-Za-z_][A-Za-z0-9_-]*:\s*$", block, maxsplit=1, flags=re.MULTILINE)[0]
             expected = (
-                "max-parallel: ${{ needs.resolve-ci-policy.outputs.cadence == 'weekly' "
-                f"&& 1 || {default} }}}}"
+                "max-parallel: ${{ needs.resolve-ci-policy.outputs.cadence == 'weekly' " f"&& 1 || {default} }}}}"
             )
             assert expected in block
 
@@ -379,7 +380,9 @@ class TestRocmWorkflowScopeSeam:
         assert "pull_request_target:" not in workflow
         configured = set(re.findall(r"^\s+- cron: ['\"]([^'\"]+)['\"]\s*$", workflow, flags=re.MULTILINE))
         assert configured == set(SCHEDULE_POLICIES)
-        assert "    - cron: '0 8 * * 6'\n      timezone: 'America/Los_Angeles'" in workflow
+        assert "    - cron: '0 15 * * 0-5'" in workflow
+        assert "    - cron: '0 15 * * 6'" in workflow
+        assert "timezone:" not in workflow
 
         policy_block = workflow.split("resolve-ci-policy:", 1)[1].split("resolve-ci-image:", 1)[0]
         assert "allow_self_hosted" not in policy_block
@@ -573,9 +576,7 @@ class TestRunSuitePolicyIntegration:
             return 0
 
         monkeypatch.setattr(run_suite_module, "run_unittest_files", fake_run_unittest_files)
-        result = run_suite_module.run_a_suite(
-            _run_args(hw="cuda", suite="stage-c-8-gpu-h100", cadence=WEEKLY_CADENCE)
-        )
+        result = run_suite_module.run_a_suite(_run_args(hw="cuda", suite="stage-c-8-gpu-h100", cadence=WEEKLY_CADENCE))
         assert result == 0
         assert _names(captured["tests"]) == {"tests/e2e/test_weekly.py"}
         assert captured["continue_on_error"] is True

--- a/tests/ci/test/test_run_suite.py
+++ b/tests/ci/test/test_run_suite.py
@@ -26,7 +26,14 @@ from types import SimpleNamespace
 
 import pytest
 import tests.ci.run_suite as run_suite_module
-from tests.ci.ci_policy import NIGHTLY_CADENCE, REGULAR_CADENCE, SCHEDULE_POLICIES, resolve_policy, strip_run_ci_prefix
+from tests.ci.ci_policy import (
+    NIGHTLY_CADENCE,
+    REGULAR_CADENCE,
+    SCHEDULE_POLICIES,
+    WEEKLY_CADENCE,
+    resolve_policy,
+    strip_run_ci_prefix,
+)
 from tests.ci.ci_register import CIRegistry, HWBackend, discover_ci_files, register_cpu_ci
 from tests.ci.labels import KNOWN_LABELS
 from tests.ci.run_suite import CI_SUITES, build_cpu_pytest_cmd, filter_tests
@@ -182,18 +189,22 @@ class TestResolvePolicy:
             (NIGHTLY_CADENCE, {"nightly"}, _ALL - {"long", "ft-long"}, True),
             (NIGHTLY_CADENCE, {"run-ci-image", "nightly"}, _ALL - {"long", "ft-long"}, True),
             (NIGHTLY_CADENCE, {"nightly", "run-ci-all"}, _ALL, True),
+            (WEEKLY_CADENCE, set(), _ALL, True),
+            (WEEKLY_CADENCE, {"run-ci-image"}, _ALL, True),
         ],
     )
     def test_selection_and_fastfail(self, cadence, labels, expected, bypass):
         policy = resolve_policy(cadence, labels)
         assert policy.cadence == cadence
         assert policy.include_labels == expected
-        assert policy.is_nightly is (cadence == NIGHTLY_CADENCE)
+        scheduled_cadence = cadence in {NIGHTLY_CADENCE, WEEKLY_CADENCE}
+        assert policy.admit_nightly_tests is scheduled_cadence
         assert policy.bypass_fastfail is bypass
+        assert policy.write_baseline is scheduled_cadence
 
     def test_unknown_cadence_rejected(self):
-        with pytest.raises(ValueError, match="Unknown CI cadence 'weekly'"):
-            resolve_policy("weekly", set())
+        with pytest.raises(ValueError, match="Unknown CI cadence 'hourly'"):
+            resolve_policy("hourly", set())
 
     def test_nightly_tag_and_explicit_cadence_converge(self):
         assert resolve_policy(NIGHTLY_CADENCE, {"nightly"}) == resolve_policy(NIGHTLY_CADENCE, set())
@@ -223,6 +234,7 @@ class TestResolvePolicy:
             (REGULAR_CADENCE, {"run-ci-megatron", "run-ci-typo", "bypass-fastfail"}),
             (REGULAR_CADENCE, {"run-ci-image", "run-ci-ft-short"}),
             (NIGHTLY_CADENCE, set()),
+            (WEEKLY_CADENCE, set()),
         ],
     )
     def test_include_set_stays_inside_known_labels(self, cadence, labels):
@@ -305,6 +317,27 @@ class TestWorkflowScopeSeam:
         configured = set(re.findall(r"^\s+- cron: ['\"]([^'\"]+)['\"]\s*$", workflow, flags=re.MULTILINE))
         assert configured == set(SCHEDULE_POLICIES)
 
+    def test_weekly_schedule_uses_pacific_time(self):
+        workflow = self._workflow()
+        assert "    - cron: '0 8 * * 6'\n      timezone: 'America/Los_Angeles'" in workflow
+
+    def test_weekly_serializes_each_gpu_matrix(self):
+        workflow = self._workflow()
+        normal_parallelism = {
+            "stage-c-8-gpu-h100": 2,
+            "stage-c-8-gpu-h200": 2,
+            "stage-c-4-gpu-h200": 3,
+            "stage-c-2-gpu-h200": 2,
+        }
+        for job, default in normal_parallelism.items():
+            block = workflow.split(f"  {job}:", 1)[1]
+            block = re.split(r"^  [A-Za-z_][A-Za-z0-9_-]*:\s*$", block, maxsplit=1, flags=re.MULTILINE)[0]
+            expected = (
+                "max-parallel: ${{ needs.resolve-ci-policy.outputs.cadence == 'weekly' "
+                f"&& 1 || {default} }}}}"
+            )
+            assert expected in block
+
     def test_dispatch_has_no_implicit_scope(self):
         workflow = self._workflow()
         dispatch_inputs = workflow.split("workflow_dispatch:", 1)[1].split("permissions:", 1)[0]
@@ -340,12 +373,13 @@ class TestRocmWorkflowScopeSeam:
     def _workflow() -> str:
         return (Path(__file__).resolve().parents[3] / ".github" / "workflows" / "pr-test-rocm.yml").read_text()
 
-    def test_pr_nightly_and_dispatch_share_policy(self):
+    def test_pr_schedules_and_dispatch_share_policy(self):
         workflow = self._workflow()
         assert "pull_request:\n    types: [opened, synchronize, reopened, ready_for_review, labeled]" in workflow
         assert "pull_request_target:" not in workflow
         configured = set(re.findall(r"^\s+- cron: ['\"]([^'\"]+)['\"]\s*$", workflow, flags=re.MULTILINE))
         assert configured == set(SCHEDULE_POLICIES)
+        assert "    - cron: '0 8 * * 6'\n      timezone: 'America/Los_Angeles'" in workflow
 
         policy_block = workflow.split("resolve-ci-policy:", 1)[1].split("resolve-ci-image:", 1)[0]
         assert "allow_self_hosted" not in policy_block
@@ -363,6 +397,7 @@ class TestRocmWorkflowScopeSeam:
         assert "needs: [resolve-ci-policy, resolve-ci-image]" in stage
         assert "allow_self_hosted" not in stage
         assert "partition_id: [0, 1]" in stage
+        assert "max-parallel: ${{ needs.resolve-ci-policy.outputs.cadence == 'weekly' && 1 || 2 }}" in stage
         assert "--auto-partition-size 2" in command
         assert "checkout_ref:" not in stage
         assert "--cadence ${{ needs.resolve-ci-policy.outputs.cadence }}" in command
@@ -476,10 +511,25 @@ class TestRunSuitePolicyIntegration:
             tests,
             HWBackend.CUDA,
             "stage-c-8-gpu-h100",
-            nightly=policy.is_nightly,
+            admit_nightly_tests=policy.admit_nightly_tests,
             labels=set(policy.include_labels),
         )
         assert _names(enabled) == {"tests/e2e/regular.py"}
+
+    def test_weekly_full_scope_admits_nightly_only_tests(self):
+        tests = [
+            _make("tests/e2e/regular.py", labels=["long"]),
+            _make("tests/e2e/nightly.py", labels=["ft-long"], nightly=True),
+        ]
+        policy = resolve_policy(WEEKLY_CADENCE, set())
+        enabled, _ = filter_tests(
+            tests,
+            HWBackend.CUDA,
+            "stage-c-8-gpu-h100",
+            admit_nightly_tests=policy.admit_nightly_tests,
+            labels=set(policy.include_labels),
+        )
+        assert _names(enabled) == {"tests/e2e/regular.py", "tests/e2e/nightly.py"}
 
     def test_nightly_bypass_reaches_cpu_runner(self, monkeypatch):
         tests = [_make("tests/fast/test_regular.py", backend=HWBackend.CPU, suite="stage-a-cpu")]
@@ -510,6 +560,26 @@ class TestRunSuitePolicyIntegration:
         )
         assert result == 0
         assert captured["continue_on_error"] is True
+        assert captured["gate_write_baseline"] is True
+
+    def test_weekly_policy_reaches_cuda_runner(self, monkeypatch):
+        tests = [_make("tests/e2e/test_weekly.py", suite="stage-c-8-gpu-h100", labels=["long"])]
+        self._stub_collection(monkeypatch, tests)
+        captured = {}
+
+        def fake_run_unittest_files(ci_tests, **kwargs):
+            captured["tests"] = ci_tests
+            captured.update(kwargs)
+            return 0
+
+        monkeypatch.setattr(run_suite_module, "run_unittest_files", fake_run_unittest_files)
+        result = run_suite_module.run_a_suite(
+            _run_args(hw="cuda", suite="stage-c-8-gpu-h100", cadence=WEEKLY_CADENCE)
+        )
+        assert result == 0
+        assert _names(captured["tests"]) == {"tests/e2e/test_weekly.py"}
+        assert captured["continue_on_error"] is True
+        assert captured["gate_write_baseline"] is True
 
 
 # --- discover_ci_files: location-based discovery across the CI roots --------
@@ -674,7 +744,7 @@ class TestFilterTestsBroadScopes:
             broad_scope_tests,
             HWBackend.CUDA,
             "stage-c-8-gpu-h100",
-            nightly=True,
+            admit_nightly_tests=True,
             labels=set(resolve_policy(NIGHTLY_CADENCE, set()).include_labels),
         )
         assert _names(enabled) == {
@@ -693,7 +763,7 @@ class TestFilterTestsBroadScopes:
             tests,
             HWBackend.CUDA,
             "stage-c-8-gpu-h100",
-            nightly=True,
+            admit_nightly_tests=True,
             labels=set(resolve_policy(NIGHTLY_CADENCE, set()).include_labels),
         )
         # A test whose only labels were subtracted is out of scope entirely,
@@ -756,7 +826,7 @@ class TestFilterTestsBaseDimensions:
             self._cadence_tests(),
             HWBackend.CUDA,
             "stage-c-8-gpu-h100",
-            nightly=False,
+            admit_nightly_tests=False,
             labels={"megatron"},
         )
         assert _names(enabled) == {"tests/e2e/regular.py"}
@@ -766,7 +836,7 @@ class TestFilterTestsBaseDimensions:
             self._cadence_tests(),
             HWBackend.CUDA,
             "stage-c-8-gpu-h100",
-            nightly=True,
+            admit_nightly_tests=True,
             labels={"megatron"},
         )
         assert _names(enabled) == {"tests/e2e/regular.py", "tests/e2e/nightly.py"}
@@ -780,14 +850,14 @@ class TestFilterTestsBaseDimensions:
             tests,
             HWBackend.CUDA,
             "stage-c-8-gpu-h100",
-            nightly=False,
+            admit_nightly_tests=False,
             labels={"megatron"},
         )
         _, nightly_skipped = filter_tests(
             tests,
             HWBackend.CUDA,
             "stage-c-8-gpu-h100",
-            nightly=True,
+            admit_nightly_tests=True,
             labels={"megatron"},
         )
         assert regular_skipped == []
@@ -802,14 +872,14 @@ class TestFilterTestsBaseDimensions:
             tests,
             HWBackend.CUDA,
             "stage-c-8-gpu-h100",
-            nightly=True,
+            admit_nightly_tests=True,
             labels=set(standard_policy.include_labels),
         )
         explicit, _ = filter_tests(
             tests,
             HWBackend.CUDA,
             "stage-c-8-gpu-h100",
-            nightly=True,
+            admit_nightly_tests=True,
             labels=set(explicit_policy.include_labels),
         )
         assert standard == []


### PR DESCRIPTION
## Summary
Schedule weekly full-suite CI with per-matrix GPU runner throttling.

## Motivation
Periodic full-suite coverage is needed for long and otherwise label-gated tests, but it must consume only a small slice of self-hosted GPU capacity instead of monopolizing the fleet.

## Usage
Every Saturday at 15:00 UTC, the NVIDIA and ROCm workflows resolve cadence `weekly` and run every enabled CI registration. The ordinary nightly schedule continues Sunday through Friday at 15:00 UTC.

## Design Notes
- `SCHEDULE_POLICIES` maps each exact cron to an independent cadence; weekly admits `nightly=True` registrations, includes every registered label, bypasses fast-fail, and writes metric baselines.
- GPU matrices set `max-parallel` to one only for weekly runs, preserving existing PR/nightly parallelism. Independent stages, including the singleton 2-GPU stage, may still overlap.
- Baseline persistence keeps the gate verdict and samples in the metric store while logs record completion without dynamic result details.
- Workflow, policy, registration, metric-gate, and contributor documentation evolve together under the existing `doc-dev` contracts.

## Verification
- `python -m pytest tests/ci/test -q`: 340 passed, 1 skipped, and 27 warnings on commit `2c18721a3134f8006fda22f3e218938c792f70aa`.
- `pre-commit run --all-files --show-diff-on-failure --color=always`: passed twice consecutively with an unchanged diff hash on the second run.
- Workflow YAML parsing: both `.github/workflows/pr-test.yml` and `.github/workflows/pr-test-rocm.yml` loaded successfully.
- `PYTHONPATH=. python tests/ci/run_suite.py --hw cpu --suite stage-b-cpu --cadence weekly --list-only`: resolved full weekly scope with `bypass_fastfail=True` and selected the enabled stage-b CPU tests.
- `git diff --check 456340f86873c3da37b2e6e87568156b64bf401b..2c18721a3134f8006fda22f3e218938c792f70aa`: passed.

## Review Focus
- `.github/workflows/pr-test.yml`: its 15:00 UTC schedule block remains aligned with the ROCm counterpart.
- `SCHEDULE_POLICIES`: exact cron keys match both workflow schedule strings.
- `RunPolicy`: weekly eligibility, failure collection, and baseline-writing semantics remain explicit rather than inheriting nightly by name.
- `strategy.max-parallel`: weekly consumes one runner per GPU matrix without changing concurrency for other cadences.
- `run_gate_hook`: baseline storage remains unchanged while completion logs omit gate-result details.
