### PR TITLE
fix(kimi): stop forcing --attention-backend flash on an MLA model

### DIFF
--- a/docs/models/kimi/kimi-k2.5.md
+++ b/docs/models/kimi/kimi-k2.5.md
@@ -167,7 +167,7 @@ SGLANG_ARGS=(
 )
 ```
 
-The `--use-rollout-routing-replay` flag replays the rollout-time MoE routing decisions during training so the two stages stay consistent. On the Megatron side, attention uses the Flash backend (`--attention-backend flash`).
+The `--use-rollout-routing-replay` flag replays the rollout-time MoE routing decisions during training so the two stages stay consistent. On the Megatron side, attention is left to TransformerEngine (`--attention-backend auto`): forcing `flash` also disables the fused and unfused backends, and FlashAttention 2 rejects K2.5's asymmetric MLA head dims.
 
 The launcher sets the required env vars for you, including the INT4 QAT pair (`OPEN_TRAINING_INT4_FAKE_QAT_FLAG=1`, `OPEN_TRAINING_INT4_GROUP_SIZE=32`), a long NCCL timeout (`NCCL_TIMEOUT=3600`), `CUDA_DEVICE_MAX_CONNECTIONS=1`, and NVLink-gated NVLS (`NCCL_NVLS_ENABLE` follows the script's NVLink autodetection).
 

--- a/examples/lora/run-kimi-k25-megatron-lora.sh
+++ b/examples/lora/run-kimi-k25-megatron-lora.sh
@@ -145,7 +145,9 @@ MISC_ARGS=(
    # should be good for model performance
    --accumulate-allreduce-grads-in-fp32
    --attention-softmax-in-fp32
-   --attention-backend flash
+   # not flash: that also disables the fused and unfused backends, and FA2 rejects this
+   # model's asymmetric MLA head dims, so it leaves TE nothing to select without FA3
+   --attention-backend auto
    --no-check-for-nan-in-loss-and-grad
 )
 

--- a/scripts/run_kimi_k25.py
+++ b/scripts/run_kimi_k25.py
@@ -211,7 +211,9 @@ def _execute_train(args: ScriptArgs):
         # should be good for model performance
         "--accumulate-allreduce-grads-in-fp32 "
         "--attention-softmax-in-fp32 "
-        "--attention-backend flash "
+        # not flash: that also disables the fused and unfused backends, and FA2 rejects this
+        # model's asymmetric MLA head dims, so it leaves TE nothing to select without FA3
+        "--attention-backend auto "
         "--no-check-for-nan-in-loss-and-grad "
         "--colocate "
         f"--update-weight-buffer-size {4 * 512 * 1024 * 1024} "

--- a/tests/snapshots/launch_scripts/py/scripts/run_kimi_k25.py/full_train.txt
+++ b/tests/snapshots/launch_scripts/py/scripts/run_kimi_k25.py/full_train.txt
@@ -144,7 +144,7 @@ export no_proxy=127.0.0.1 && export PYTHONUNBUFFERED=1 && ray job submit
   --hidden-dropout 0.0
   --accumulate-allreduce-grads-in-fp32
   --attention-softmax-in-fp32
-  --attention-backend flash
+  --attention-backend auto
   --no-check-for-nan-in-loss-and-grad
   --colocate
   --update-weight-buffer-size 2147483648

--- a/tests/snapshots/launch_scripts/py/scripts/run_kimi_k25.py/train.txt
+++ b/tests/snapshots/launch_scripts/py/scripts/run_kimi_k25.py/train.txt
@@ -127,7 +127,7 @@ export no_proxy=127.0.0.1 && export PYTHONUNBUFFERED=1 && ray job submit
   --hidden-dropout 0.0
   --accumulate-allreduce-grads-in-fp32
   --attention-softmax-in-fp32
-  --attention-backend flash
+  --attention-backend auto
   --no-check-for-nan-in-loss-and-grad
   --colocate
   --update-weight-buffer-size 2147483648

--- a/tests/snapshots/launch_scripts/sh/examples/lora/run-kimi-k25-megatron-lora.sh.txt
+++ b/tests/snapshots/launch_scripts/sh/examples/lora/run-kimi-k25-megatron-lora.sh.txt
@@ -298,5 +298,5 @@
 "--accumulate-allreduce-grads-in-fp32"
 "--attention-softmax-in-fp32"
 "--attention-backend"
-"flash"
+"auto"
 "--no-check-for-nan-in-loss-and-grad"


### PR DESCRIPTION
## Problem

`--attention-backend flash` does not only enable FlashAttention. Megatron's `LanguageModule._set_attention_backend` turns it into

```python
check_and_set_env_variable("NVTE_FLASH_ATTN",   1, AttnBackend.flash)
check_and_set_env_variable("NVTE_FUSED_ATTN",   0, AttnBackend.flash)
check_and_set_env_variable("NVTE_UNFUSED_ATTN", 0, AttnBackend.flash)
```

so it is the one setting that leaves TransformerEngine a single candidate. Kimi-K2.5 is MLA with asymmetric head dims (qk_nope 128 + qk_rope 64 = 192 against v 128), which FlashAttention 2 refuses. Where FlashAttention 3 is also unavailable, nothing is left and the first training step exits with

```
ValueError: No dot product attention backend is available for the provided inputs.
```

naming neither the restriction nor the flag that caused it. Reproduced by driving TE's `DotProductAttention` at K2.5's head dims on ROCm 7.2 (MI350X, TE 2.14, FA 2.8.3):

```
flash: Disabling FusedAttention due to NVTE_FUSED_ATTN=0
       Disabling UnfusedDotProductAttention due to NVTE_UNFUSED_ATTN=0
       Disabling FlashAttention 2 as it does not support MLA.
       Selected backend = NoBackend                                -> ValueError
auto:  Disabling FlashAttention 2 as it does not support MLA.
       Selected backend = UnfusedDotProductAttention               -> OK
```

## Fix

Use `auto`, Megatron's default, in the two Kimi-K2.5 launchers, and update the sentence in `docs/models/kimi/kimi-k2.5.md` that documents the old value. `scripts/run_deepseek.py` already keeps the flag commented out on its MLA model with "need to comment this when using model with MLA"; this applies the same rule to K2.5.

Scope is the two recipes I ran. `scripts/run_kimi_k2.py`, `scripts/run_deepseek_v32.py` and the GLM launchers pass the same flag on models with the same head dims and are left alone.
