### PR TITLE
docs: color nested sidebar group headers like page links

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -37,6 +37,21 @@ a[href^="http"]:not([href*="radixark.com"])::after {
 }
 
 /* =============================================
+   Sidebar — nested group headers match page links
+
+   Sidebar page rows are <a> elements, so the global link rule above
+   recolors them (this file is unlayered, which beats Mintlify's layered
+   Tailwind utilities). Nested group headers ("Launch Script", "Agentic
+   Environments") are <button> toggles, which that rule misses, leaving
+   them gray. Recolor them through Mintlify's stable data attributes; if
+   Mintlify ever renames these, the headers fall back to gray — nothing
+   breaks.
+   ============================================= */
+#navigation-items li li[data-group-tag] > button {
+  color: #d55816;
+}
+
+/* =============================================
    Nav / UI — Inter (matches RadixArk buttons)
    ============================================= */
 #navbar, button {


### PR DESCRIPTION
## Summary

On [/docs/user-guide/launch-script](https://miles.radixark.com/docs/user-guide/launch-script), the sidebar entries "Launch Script" and "Agentic Environments" render in gray while every sibling renders orange. This recolors the two group headers to match.

Root cause (found by diffing the live page's markup): both kinds of sidebar rows carry the *same* Tailwind color classes, so Mintlify itself styles them identically. The difference comes from our own `docs/style.css`: the global `a { color: #d55816 }` rule is unlayered, so it wins over Mintlify's layered Tailwind utilities and paints every sidebar page row (an `<a>`) orange — but the two nested group headers are `<button>` toggles, which that rule misses, leaving them on the theme's gray.

Fix: one rule extending the same brand color to nested group-header buttons, scoped by Mintlify's stable hooks (the `#navigation-items` container and the `data-group-tag` attribute) rather than hashed utility classes. The `li li` scoping targets only *nested* group headers, not top-level section headers. Hover keeps the brand color for the same cascade-layer reason the link rule wins. Failure mode if Mintlify ever renames these hooks: the headers quietly fall back to gray — nothing breaks.

## Test plan

- [ ] Mintlify preview: on the User Guide tab, "Launch Script" and "Agentic Environments" render in `#d55816` like their sibling links, in both light and dark mode
- [ ] Top-level section headers and the expander carets are unaffected
