### PR TITLE
fix(swe-agent example): stop logging unmeasured agent metrics as zero

### DIFF
--- a/examples/swe-agent-harbor-docker/generate.py
+++ b/examples/swe-agent-harbor-docker/generate.py
@@ -44,15 +44,10 @@ async def reward_func(args, samples: Sample | list[Sample], **kwargs) -> float |
 
 
 def _collect_values(all_metrics: list[dict], key: str) -> list[float]:
-    """Values the agents actually reported for ``key``, skipping the ones that did not.
+    """Values agents reported for ``key``; agents that omit it are skipped.
 
-    Agent harnesses report different key sets: one that measures per-turn timing
-    and tool-call counts fills every key, while another may only report the
-    wall-clock totals. Substituting 0 for a key an agent never reports turns
-    "nobody measured this" into "this agent made zero tool calls", which is
-    indistinguishable on a dashboard from a real measurement. It also drags the
-    mean of a mixed batch toward zero. Callers already skip empty lists, so
-    unreported keys are left out of the log entirely.
+    Defaulting to 0 would log a fake measurement and drag the batch mean down.
+    Callers skip empty lists, so an unreported key stays out of the log.
     """
     return [value for metrics in all_metrics if (value := metrics.get(key)) is not None]
 

--- a/examples/swe-agent-harbor-docker/generate.py
+++ b/examples/swe-agent-harbor-docker/generate.py
@@ -44,7 +44,17 @@ async def reward_func(args, samples: Sample | list[Sample], **kwargs) -> float |
 
 
 def _collect_values(all_metrics: list[dict], key: str) -> list[float]:
-    return [m.get(key, 0) for m in all_metrics]
+    """Values the agents actually reported for ``key``, skipping the ones that did not.
+
+    Agent harnesses report different key sets: one that measures per-turn timing
+    and tool-call counts fills every key, while another may only report the
+    wall-clock totals. Substituting 0 for a key an agent never reports turns
+    "nobody measured this" into "this agent made zero tool calls", which is
+    indistinguishable on a dashboard from a real measurement. It also drags the
+    mean of a mixed batch toward zero. Callers already skip empty lists, so
+    unreported keys are left out of the log entirely.
+    """
+    return [value for metrics in all_metrics if (value := metrics.get(key)) is not None]
 
 
 def _agg_mean(metrics: dict, all_metrics: list[dict], keys: list[str], prefix: str = "agent/", suffix: str = "_mean"):

--- a/tests/fast/examples/swe_agent_harbor_docker/test_agent_metrics.py
+++ b/tests/fast/examples/swe_agent_harbor_docker/test_agent_metrics.py
@@ -1,0 +1,110 @@
+"""Agent metrics must reflect what an agent measured, not a default of zero.
+
+The example directory name is not a Python identifier, so the module is loaded
+by path the same way the other example tests do it.
+"""
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+GENERATE_SCRIPT = REPO_ROOT / "examples" / "swe-agent-harbor-docker" / "generate.py"
+
+# An agent that instruments every turn reports the full key set.
+FULLY_INSTRUMENTED = {
+    "turns": 30,
+    "tool_calls": 47,
+    "model_query_time_sum": 120.0,
+    "env_execution_time_sum": 60.0,
+    "eval_time": 12.0,
+    "agent_run_time": 400.0,
+    "time_per_turn": 13.3,
+    "model_query_time_avg": 4.0,
+    "env_execution_time_avg": 2.0,
+    "model_time_ratio": 0.3,
+    "env_time_ratio": 0.15,
+    "eval_time_ratio": 0.03,
+    "total_time": 500.0,
+}
+# Another agent reports only wall-clock totals: no turn, tool-call or timing breakdown.
+TOTALS_ONLY = {"eval_time": 42.8, "agent_run_time": 486.8, "total_time": 559.3}
+
+UNREPORTED_BY_TOTALS_ONLY = [
+    "agent/turns_mean",
+    "agent/turns_sum",
+    "agent/tool_calls_mean",
+    "agent/tool_calls_sum",
+    "agent/model_query_time_sum_mean",
+    "agent/env_execution_time_sum_mean",
+    "agent/time_per_turn",
+    "agent/model_query_time_avg",
+    "agent/env_execution_time_avg",
+    "agent/model_time_ratio",
+    "agent/env_time_ratio",
+    "agent/eval_time_ratio",
+]
+
+
+@pytest.fixture(scope="module")
+def generate_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("swe_agent_harbor_docker_generate", GENERATE_SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def sample_with(agent_metrics: dict) -> SimpleNamespace:
+    return SimpleNamespace(metadata={"agent_metrics": agent_metrics})
+
+
+def test_fully_instrumented_agent_reports_every_metric(generate_module: ModuleType) -> None:
+    metrics = generate_module.aggregate_agent_metrics([sample_with(FULLY_INSTRUMENTED)])
+
+    assert metrics["agent/turns_mean"] == 30
+    assert metrics["agent/tool_calls_mean"] == 47
+    assert metrics["agent/tool_calls_sum"] == 47
+    assert metrics["agent/time_per_turn"] == pytest.approx(13.3)
+    assert metrics["agent/total_time_mean"] == pytest.approx(500.0)
+
+
+def test_unreported_keys_are_omitted_rather_than_logged_as_zero(generate_module: ModuleType) -> None:
+    """A zero here is indistinguishable from an agent that made no tool calls."""
+    metrics = generate_module.aggregate_agent_metrics([sample_with(TOTALS_ONLY)])
+
+    for key in UNREPORTED_BY_TOTALS_ONLY:
+        assert key not in metrics, f"{key} was logged despite never being measured"
+
+    # What the agent did report still comes through.
+    assert metrics["agent/eval_time_mean"] == pytest.approx(42.8)
+    assert metrics["agent/agent_run_time_mean"] == pytest.approx(486.8)
+    assert metrics["agent/total_time_mean"] == pytest.approx(559.3)
+
+
+def test_mixed_batch_averages_only_over_agents_that_measured_the_key(generate_module: ModuleType) -> None:
+    """One silent agent must not halve the tool-call count of the batch."""
+    metrics = generate_module.aggregate_agent_metrics([sample_with(FULLY_INSTRUMENTED), sample_with(TOTALS_ONLY)])
+
+    assert metrics["agent/tool_calls_mean"] == 47
+    assert metrics["agent/turns_mean"] == 30
+    assert metrics["agent/time_per_turn"] == pytest.approx(13.3)
+    # Keys both agents report still average across the whole batch.
+    assert metrics["agent/total_time_mean"] == pytest.approx((500.0 + 559.3) / 2)
+    assert metrics["agent/total_time_min"] == pytest.approx(500.0)
+    assert metrics["agent/total_time_max"] == pytest.approx(559.3)
+
+
+def test_zero_is_kept_when_an_agent_actually_measures_zero(generate_module: ModuleType) -> None:
+    """Omitting unreported keys must not swallow a genuine zero measurement."""
+    metrics = generate_module.aggregate_agent_metrics([sample_with({**FULLY_INSTRUMENTED, "tool_calls": 0})])
+
+    assert metrics["agent/tool_calls_mean"] == 0
+    assert metrics["agent/tool_calls_sum"] == 0
+
+
+def test_samples_without_agent_metrics_are_ignored(generate_module: ModuleType) -> None:
+    assert generate_module.aggregate_agent_metrics([sample_with({})]) == {}
+    assert generate_module.aggregate_agent_metrics([SimpleNamespace(metadata={})]) == {}
+    assert generate_module.aggregate_agent_metrics([]) == {}


### PR DESCRIPTION
## What this does

`aggregate_agent_metrics` in the SWE-agent example now logs only the agent metrics that an agent actually reported. Previously every key an agent did not report was substituted with `0` and logged as if it had been measured.

## Why

Agent harnesses report different key sets. One that instruments every turn fills in `turns`, `tool_calls`, `model_query_time_*`, `env_execution_time_*`, `time_per_turn` and the ratios; another may report only wall-clock totals such as `agent_run_time`, `eval_time` and `total_time`.

`_collect_values` used `m.get(key, 0)`, so the second kind of agent produced a wandb panel like this:

| metric | logged | truth |
|---|---|---|
| `agent/agent_run_time_mean` | 404.0 | measured |
| `agent/eval_time_mean` | 50.8 | measured |
| `agent/total_time_mean` | 490.4 | measured |
| `agent/tool_calls_mean` | **0.0** | never measured |
| `agent/turns_mean` | **0.0** | never measured |
| `agent/model_query_time_avg` | **0.0** | never measured |
| `agent/env_execution_time_avg` | **0.0** | never measured |
| `agent/time_per_turn` | **0.0** | never measured |

A zero sitting next to real numbers reads as a measurement. On a run whose trajectories each contained 23–47 `bash_command` calls, the dashboard said the agent made none, and the flat-zero series looked like a broken agent rather than missing instrumentation.

There is a second, quieter failure. Because the default applied per sample, a mixed batch silently corrupted values that *were* measured: one sample omitting `tool_calls` halved the mean for the sample that reported 47, giving `agent/tool_calls_mean = 23.5`. That is wrong for any batch where a single trial fails to report.

After the change, an unreported key is absent from the log (wandb simply shows no series, which is honest), a genuine `0` measurement is still logged as `0`, and means are taken over the agents that measured the key.

## Verification

Executed `aggregate_agent_metrics` directly against both agent shapes before and after the change:

- fully instrumented agent: all 17 metrics identical before and after (no regression)
- totals-only agent: 12 false zeros before, 0 after; the 5 measured metrics unchanged
- mixed batch: `agent/tool_calls_mean` 23.5 before, 47.0 after

Added `tests/fast/examples/swe_agent_harbor_docker/test_agent_metrics.py` (5 tests, loaded by path like the other example tests since the directory name is not an identifier). Confirmed the tests fail on the pre-fix code — 2 failed, 3 passed — and all 5 pass with the fix.

Not covered here: the dashboard's `tool_calls` column comes from a different code path (`_tool_call_count` in `miles/dashboard/dump_reader.py`, which counts `role == "tool"` messages in `sample.prompt`) and is reported separately.
