### PR TITLE
fix(verifiers): align adapter with Ray runtime env

### DIFF
--- a/examples/experimental/verifiers/run.py
+++ b/examples/experimental/verifiers/run.py
@@ -23,6 +23,7 @@ import typer
 import miles.utils.external_utils.command_utils as U
 
 SCRIPT_DIR = Path(__file__).resolve().parent
+LEGACY_ROLLOUT_ENV = "MILES_USE_LEGACY_ROLLOUT_V1"
 
 
 @dataclass
@@ -76,6 +77,14 @@ def execute(args: ScriptArgs):
     if not config_path.exists():
         config_path.write_text(f'[taskset]\nid = "{args.taskset_id}"\n')
 
+    extra_env_vars = {
+        "PYTHONPATH": f"{args.megatron_path}:{SCRIPT_DIR}:{U.repo_base_dir}",
+        "VERIFIERS_CONFIG": str(config_path),
+    }
+    if LEGACY_ROLLOUT_ENV in os.environ:
+        extra_env_vars[LEGACY_ROLLOUT_ENV] = os.environ[LEGACY_ROLLOUT_ENV]
+    extra_env_vars = U.resolve_extra_env_vars(extra_env_vars, args)
+
     ckpt_args = (
         f"--hf-checkpoint {args.hf_checkpoint} "
         f"--sglang-tokenizer-path {args.sglang_tokenizer_path} "
@@ -89,7 +98,7 @@ def execute(args: ScriptArgs):
     # because PYTHONPATH carries this directory into the rollout actor.
     rollout_fn = (
         "verifiers_rollout.generate_rollout"
-        if os.environ.get("MILES_USE_LEGACY_ROLLOUT_V1") == "1"
+        if bool(int(extra_env_vars.get(LEGACY_ROLLOUT_ENV, "0")))
         else "verifiers_rollout.VerifiersRolloutFn"
     )
     rollout_args = (
@@ -164,10 +173,7 @@ def execute(args: ScriptArgs):
         num_gpus_per_node=args.num_gpus_per_node,
         megatron_model_type=args.megatron_model_type,
         megatron_path=args.megatron_path,
-        extra_env_vars={
-            "PYTHONPATH": f"{args.megatron_path}:{SCRIPT_DIR}:{U.repo_base_dir}",
-            "VERIFIERS_CONFIG": str(config_path),
-        },
+        extra_env_vars=extra_env_vars,
     )
 
 

--- a/miles/utils/external_utils/command_utils.py
+++ b/miles/utils/external_utils/command_utils.py
@@ -134,6 +134,13 @@ class ExecuteTrainConfig:
     output_dir: str = "/root/shared_data"
 
 
+def resolve_extra_env_vars(extra_env_vars: dict[str, str], config: ExecuteTrainConfig) -> dict[str, str]:
+    return {
+        **extra_env_vars,
+        **_parse_extra_env_vars(config.extra_env_vars),
+    }
+
+
 def execute_train(
     train_args: str,
     num_gpus_per_node: int,
@@ -214,8 +221,7 @@ def execute_train(
             if config.cuda_core_dump
             else {}
         ),
-        **extra_env_vars,
-        **_parse_extra_env_vars(config.extra_env_vars),
+        **resolve_extra_env_vars(extra_env_vars, config),
     }
     runtime_env_vars["PYTHONPATH"] = _pythonpath_with_sources(megatron_path, runtime_env_vars.get("PYTHONPATH"))
     runtime_env_json = json.dumps({"env_vars": runtime_env_vars})

--- a/tests/fast/examples/experimental/test_verifiers_run.py
+++ b/tests/fast/examples/experimental/test_verifiers_run.py
@@ -1,0 +1,62 @@
+import json
+import shlex
+
+import pytest
+from examples.experimental.verifiers import run
+from tests.fast.utils.command_recorder import record_commands
+
+import miles.utils.external_utils.command_utils as U
+
+LEGACY_ROLLOUT_ENV = "MILES_USE_LEGACY_ROLLOUT_V1"
+
+
+def _rollout_config(submit_command: str) -> tuple[str, dict[str, str]]:
+    argv = shlex.split(submit_command)
+    rollout_fn = argv[argv.index("--rollout-function-path") + 1]
+    runtime_env_arg = next(arg for arg in argv if arg.startswith("--runtime-env-json="))
+    runtime_env = json.loads(runtime_env_arg.split("=", 1)[1])["env_vars"]
+    return rollout_fn, runtime_env
+
+
+@pytest.mark.parametrize(
+    ("ambient_value", "extra_env_vars", "expected_rollout_fn", "expected_runtime_value"),
+    [
+        (None, "", "verifiers_rollout.VerifiersRolloutFn", None),
+        ("1", "", "verifiers_rollout.generate_rollout", "1"),
+        ("0", f"{LEGACY_ROLLOUT_ENV}=1", "verifiers_rollout.generate_rollout", "1"),
+        ("1", f"{LEGACY_ROLLOUT_ENV}=0", "verifiers_rollout.VerifiersRolloutFn", "0"),
+    ],
+)
+def test_adapter_and_ray_runtime_use_the_same_legacy_flag(
+    monkeypatch,
+    tmp_path,
+    ambient_value,
+    extra_env_vars,
+    expected_rollout_fn,
+    expected_runtime_value,
+):
+    commands = record_commands(monkeypatch)
+    monkeypatch.setattr(U, "check_has_nvlink", lambda: False)
+    monkeypatch.setenv("MILES_SCRIPT_EXTERNAL_RAY", "1")
+    monkeypatch.setenv("MILES_SCRIPT_ENABLE_RAY_SUBMIT", "1")
+    monkeypatch.setenv("MASTER_ADDR", "127.0.0.1")
+    monkeypatch.delenv("RAY_ADDRESS", raising=False)
+    monkeypatch.delenv("NCCL_NVLS_ENABLE", raising=False)
+    if ambient_value is None:
+        monkeypatch.delenv(LEGACY_ROLLOUT_ENV, raising=False)
+    else:
+        monkeypatch.setenv(LEGACY_ROLLOUT_ENV, ambient_value)
+
+    run.execute(
+        run.ScriptArgs(
+            verifiers_config=str(tmp_path / "verifiers.toml"),
+            extra_env_vars=extra_env_vars,
+        )
+    )
+
+    rollout_fn, runtime_env = _rollout_config(commands[-1])
+    assert rollout_fn == expected_rollout_fn
+    if expected_runtime_value is None:
+        assert LEGACY_ROLLOUT_ENV not in runtime_env
+    else:
+        assert runtime_env[LEGACY_ROLLOUT_ENV] == expected_runtime_value


### PR DESCRIPTION
## Summary
Keep the Verifiers rollout adapter ABI aligned with the Ray runtime flag.

## Symptom & Reproduction
- **Symptom:** `--extra-env-vars MILES_USE_LEGACY_ROLLOUT_V1=1` selected `VerifiersRolloutFn` in the launcher while Ray selected the legacy invocation ABI, causing `TypeError` on the first rollout.
- **Reproduction:** On PR #2522 head `0c34a6a76b58004e3f4fd81a3c77c24fda44f249`, `pytest -q tests/fast/examples/experimental/test_verifiers_run.py` produced `3 failed, 1 passed`; all adapter/runtime-env pairs were expected to match.

## Root Cause
1. `run.execute` chose the adapter from launcher `os.environ`.
2. `execute_train` applied `ScriptArgs.extra_env_vars` only inside Ray.
3. `RolloutManager` read Ray state and selected a different invocation ABI.

## Fix
Resolve script, ambient, and CLI environment values through one merge path before choosing the adapter, with CLI values applied last. Pass that same effective mapping to `execute_train`, so the launcher and Ray workers use one legacy-mode value without changing `RolloutManager` or either adapter ABI.

## Verification
- `pytest -q tests/fast/utils/test_command_utils.py tests/fast/examples/experimental/test_verifiers_run.py`: `75 passed`.
- `pytest -q tests/fast/launch_scripts tests/manual/launch_scripts`: `482 passed`.
- `pytest -q -rs tests/fast/rollout/test_verifiers_runtime.py tests/fast/rollout/test_verifiers_rollout.py`: `38 passed, 10 skipped`; optional paths skipped because `verifiers` or `renderers` was unavailable.
- `pre-commit run --files examples/experimental/verifiers/run.py miles/utils/external_utils/command_utils.py tests/fast/examples/experimental/test_verifiers_run.py`: all configured hooks passed.

## Review Focus
- `resolve_extra_env_vars`: CLI `config.extra_env_vars` must remain the final override.
- `examples/experimental/verifiers/run.py`: adapter selection and Ray runtime env must consume the same effective mapping.
