### PR TITLE
refactor(ci): gate PR image builds on CPU tests

### DIFF
--- a/.claude/skills/doc-dev/SKILL.md
+++ b/.claude/skills/doc-dev/SKILL.md
@@ -75,6 +75,8 @@ A strictly behavior-preserving change, such as a rename, extraction, or reflow, 
 - Limit a document edit to the specification or description delta, and limit a code edit to the behavior in scope. A real conformance change must implement that behavior directly; do not add fallbacks, guards, or silent skips solely to appear compliant.
 - Do not use co-evolution to avoid writing down a requirement that is already known; use `--docfirst` instead.
 
+Before delivery, automatically run one subtractive simplify pass over the documentation diff against the pre-change base. For every changed hunk, name the exact in-scope behavior or responsibility delta it documents; remove the hunk if deleting it would leave the code, header, central documents, and verification consistent. Preserve untouched wording, structure, and formatting; do not expand neighboring sections, repeat a fact within the same governed surface, or retain wording introduced only for an abandoned draft.
+
 ## Outside this workflow
 
 - If neither the code nor the document is authoritative, reconcile each divergence with the user before editing.

--- a/.github/workflows/_build-pr-ci-image.yml
+++ b/.github/workflows/_build-pr-ci-image.yml
@@ -1,0 +1,95 @@
+name: PR CI Image Build
+
+on:
+  workflow_call:
+    outputs:
+      built:
+        description: Whether this call built and pushed a PR-scoped image
+        value: ${{ jobs.docker-build.outputs.built }}
+
+jobs:
+  docker-paths:
+    if: github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    outputs:
+      changed: ${{ steps.diff.outputs.changed }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+          persist-credentials: false
+      - id: diff
+        shell: bash
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}
+        run: |
+          # Cron and manual runs have no PR diff and never build a PR image.
+          if [ -z "$BASE_SHA" ]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Compare the PR merge commit with its current base (HEAD^1) rather than
+          # the recorded base.sha, which can lag main and pull in unrelated changes.
+          # Dockerfile.rocm doesn't feed the cu13 multi-arch build this pipeline produces.
+          if ! CHANGED_PATHS=$(git diff --name-only HEAD^1 HEAD); then
+            echo "::error::Failed to determine docker-relevant changes."
+            exit 1
+          fi
+          if grep -qE '^(docker/(Dockerfile|build\.py|install-kube-tools\.sh|verify_transformer_engine\.py)|requirements\.txt)$|^docker/patch/' <<< "$CHANGED_PATHS"; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  # Docker PRs build the multi-arch image after the caller's CPU gate passes.
+  # Without a relevant change this stays on a free hosted runner as a no-op;
+  # actual builds use docker-build nodes, never the GPU-suite pool.
+  docker-build:
+    needs: [docker-paths]
+    if: always() && !cancelled() && github.event.action != 'closed'
+    runs-on: ${{ fromJSON((needs.docker-paths.outputs.changed == 'true' && github.event.pull_request.head.repo.full_name == github.repository) && '["docker-build"]' || '["ubuntu-latest"]') }}
+    timeout-minutes: 180
+    outputs:
+      built: ${{ steps.build.outputs.built || 'false' }}
+    env:
+      # Forks cannot push to the registry, so they keep the released image.
+      BUILD: ${{ needs.docker-paths.outputs.changed == 'true' && github.event.pull_request.head.repo.full_name == github.repository }}
+    steps:
+      - name: Checkout repository
+        if: env.BUILD == 'true'
+        uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        if: env.BUILD == 'true'
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: |
+            image=moby/buildkit:latest
+            network=host
+      - name: Install Python + dependencies
+        if: env.BUILD == 'true'
+        run: |
+          if ! command -v python3 >/dev/null || ! command -v pip3 >/dev/null; then
+            apt-get -o DPkg::Lock::Timeout=600 update
+            apt-get -o DPkg::Lock::Timeout=600 install -y python3 python3-pip
+          fi
+          # Older pip (<23) lacks --break-system-packages; newer PEP 668
+          # systems require it. Probe instead of assuming either.
+          PIP_BSP=""
+          pip3 install --help 2>/dev/null | grep -q -- --break-system-packages && PIP_BSP="--break-system-packages"
+          pip3 install $PIP_BSP --ignore-installed typer
+      - name: Login to Docker Hub
+        if: env.BUILD == 'true'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push PR tag
+        id: build
+        if: env.BUILD == 'true'
+        run: |
+          python3 docker/build.py --variant cu13 --image-tag custom \
+            --custom-tag pr-${{ github.event.pull_request.number }} --push
+          echo "built=true" >> "$GITHUB_OUTPUT"
+      - name: Nothing to build
+        if: env.BUILD != 'true'
+        run: echo "No docker-relevant changes; suites use the released image."

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -102,91 +102,21 @@ jobs:
           CADENCE_OVERRIDE: ${{ inputs.cadence || '' }}
         run: python -m tests.ci.ci_policy
 
-  docker-paths:
-    if: github.event.action != 'closed'
-    runs-on: ubuntu-latest
-    outputs:
-      changed: ${{ steps.diff.outputs.changed }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 2
-          persist-credentials: false
-      - id: diff
-        shell: bash
-        env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}
-        run: |
-          # Cron and manual runs have no PR diff and never build a PR image.
-          if [ -z "$BASE_SHA" ]; then
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          # Compare the PR merge commit with its current base (HEAD^1) rather than
-          # the recorded base.sha, which can lag main and pull in unrelated changes.
-          # Dockerfile.rocm doesn't feed the cu13 multi-arch build this pipeline produces.
-          if git diff --name-only HEAD^1 HEAD \
-              | grep -qE '^(docker/(Dockerfile|build\.py|install-kube-tools\.sh|verify_transformer_engine\.py)|requirements\.txt)$|^docker/patch/'; then
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-          fi
-
-  # Docker PRs: build the multi-arch image first and run every suite inside it.
-  # Always runs: with nothing to build every step is a no-op on a free hosted
-  # runner; actual builds run on docker-build nodes, never the GPU-suite pool.
+  # Resolve and build a PR image only after the fast CPU gate completes.
+  # Nightly, weekly, and bypass-fastfail preserve their cross-stage exception.
   docker-build:
-    needs: [docker-paths]
-    if: always() && !cancelled() && github.event.action != 'closed'
-    runs-on: ${{ fromJSON((needs.docker-paths.outputs.changed == 'true' && github.event.pull_request.head.repo.full_name == github.repository) && '["docker-build"]' || '["ubuntu-latest"]') }}
-    timeout-minutes: 180
-    outputs:
-      built: ${{ steps.build.outputs.built || 'false' }}
-    env:
-      # Forks cannot push to the registry, so they keep the released image.
-      BUILD: ${{ needs.docker-paths.outputs.changed == 'true' && github.event.pull_request.head.repo.full_name == github.repository }}
-    steps:
-      - name: Checkout repository
-        if: env.BUILD == 'true'
-        uses: actions/checkout@v4
-      - name: Set up Docker Buildx
-        if: env.BUILD == 'true'
-        uses: docker/setup-buildx-action@v3
-        with:
-          driver-opts: |
-            image=moby/buildkit:latest
-            network=host
-      - name: Install Python + dependencies
-        if: env.BUILD == 'true'
-        run: |
-          if ! command -v python3 >/dev/null || ! command -v pip3 >/dev/null; then
-            apt-get -o DPkg::Lock::Timeout=600 update
-            apt-get -o DPkg::Lock::Timeout=600 install -y python3 python3-pip
-          fi
-          # Older pip (<23) lacks --break-system-packages; newer PEP 668
-          # systems require it. Probe instead of assuming either.
-          PIP_BSP=""
-          pip3 install --help 2>/dev/null | grep -q -- --break-system-packages && PIP_BSP="--break-system-packages"
-          pip3 install $PIP_BSP --ignore-installed typer
-      - name: Login to Docker Hub
-        if: env.BUILD == 'true'
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build and push PR tag
-        id: build
-        if: env.BUILD == 'true'
-        run: |
-          python3 docker/build.py --variant cu13 --image-tag custom \
-            --custom-tag pr-${{ github.event.pull_request.number }} --push
-          echo "built=true" >> "$GITHUB_OUTPUT"
-      - name: Nothing to build
-        if: env.BUILD != 'true'
-        run: echo "No docker-relevant changes; suites use the released image."
+    needs: [resolve-ci-policy, stage-a-cpu]
+    if: |
+      always() && !cancelled() &&
+      github.event.action != 'closed' &&
+      needs.resolve-ci-policy.result == 'success' &&
+      (needs.stage-a-cpu.result == 'success' ||
+         (needs.stage-a-cpu.result == 'failure' && needs.resolve-ci-policy.outputs.bypass_fastfail == 'true'))
+    uses: ./.github/workflows/_build-pr-ci-image.yml
+    secrets: inherit
 
-  # No `if:` guard: a real build failure must stop the suites rather than run them
-  # against a stale image.
+  # No if guard: a detector or build failure must stop the suites rather than
+  # run them against a stale image.
   resolve-ci-image:
     needs: [docker-build]
     runs-on: ubuntu-latest
@@ -222,7 +152,7 @@ jobs:
   # Uses the CPU-only reusable workflow on GitHub-hosted ubuntu-latest, so
   # fast tests do not occupy GPU-fleet runner slots.
   stage-a-cpu:
-    needs: [resolve-ci-policy, resolve-ci-image]
+    needs: [resolve-ci-policy]
     strategy:
       fail-fast: false
       matrix:
@@ -240,7 +170,7 @@ jobs:
   # Stage B: CPU-only bucket for slower CPU tests that don't fit stage-a-cpu's
   # fast budget. Always runs on PR; an empty suite still exits 0 in run_suite.py.
   stage-b-cpu:
-    needs: [resolve-ci-policy, resolve-ci-image]
+    needs: [resolve-ci-policy]
     uses: ./.github/workflows/_run-cpu-ci.yml
     with:
       ref: ${{ inputs.ref || '' }}

--- a/docs/ci/00-stage.md
+++ b/docs/ci/00-stage.md
@@ -18,8 +18,8 @@ Stage names follow `stage-<tier>-<gpus>-<hw>` (or `stage-<tier>-<hw>` for CPU, e
 
 | Stage / suite | Hardware | Runner labels (`runs_on`) | Shards | Depends on |
 |---|---|---|---|---|
-| `stage-a-cpu` | GitHub-hosted CPU | — (`ubuntu-latest`) | 4 | `resolve-ci-policy`, `resolve-ci-image` |
-| `stage-b-cpu` | GitHub-hosted CPU | — (`ubuntu-latest`) | 1 | `resolve-ci-policy`, `resolve-ci-image` |
+| `stage-a-cpu` | GitHub-hosted CPU | — (`ubuntu-latest`) | 4 | `resolve-ci-policy` |
+| `stage-b-cpu` | GitHub-hosted CPU | — (`ubuntu-latest`) | 1 | `resolve-ci-policy` |
 | `stage-b-2-gpu-h200` | 2× H200 | `["h200","2gpu"]` | 1 | both resolvers, `stage-a-cpu` |
 | `stage-c-2-gpu-h200` | 2× H200 | `["h200","2gpu"]` | 2 | both resolvers, `stage-a-cpu` |
 | `stage-c-4-gpu-h200` | 4× H200 | `["h200","4gpu"]` | 3 | both resolvers, `stage-a-cpu` |
@@ -30,7 +30,7 @@ Stage names follow `stage-<tier>-<gpus>-<hw>` (or `stage-<tier>-<hw>` for CPU, e
 | `nightly-stage-c-4-gpu-mi350` | 4× MI350 | external nightly | — | — |
 | `nightly-stage-c-8-gpu-mi350` | 8× MI350 | external nightly | — | — |
 
-In `pr-test.yml`, `tier a` (CPU fast) gates the NVIDIA GPU fleet after both resolvers; its GPU stages (`b` / `c`) all depend on both resolvers and `stage-a-cpu`, and run concurrently with each other — the `b` / `c` letters classify role, they are not a sequential pipeline. The MI350 stage has no CPU-test gate.
+In `pr-test.yml`, `tier a` (CPU fast) gates PR-image preparation and the NVIDIA GPU fleet; its GPU stages (`b` / `c`) all depend on both resolvers and `stage-a-cpu`, and run concurrently with each other. `stage-b-cpu` runs in parallel with `stage-a-cpu` and is not a gate — the `b` / `c` letters classify role, they are not a sequential pipeline. The MI350 stage has no CPU-test gate.
 
 `pr-test.yml` treats `pull_request.closed` as cancellation-only: the close event shares the PR's concurrency group, cancels any queued or running `PR Test` run, and starts no resolver or test jobs.
 
@@ -38,7 +38,7 @@ Both PR workflows are also reusable `workflow_call` entry points for release CI.
 
 ## What each stage does
 
-**Image resolution (`resolve-ci-image`).** In `pr-test.yml`, a small `ubuntu-latest` job takes the called workflow's `image_tag` first, then reads `ci-image-tag:` from the PR description or the `ci_image_tag` dispatch input, defaults to `dev`, validates the result is a bare tag, and outputs `radixark/miles:<tag>`. `release-branch-cut.yml` passes the prune-exempt `release-vX.Y.Z-ci` tag recorded in `release-lock.json`.
+**Image resolution (`resolve-ci-image`).** In `pr-test.yml`, this small `ubuntu-latest` job runs after the CPU-gated `_build-pr-ci-image.yml` call. It takes the called workflow's `image_tag` first, otherwise selects a freshly built PR image, then reads `ci-image-tag:` from the PR description or the `ci_image_tag` dispatch input, defaults to `dev`, validates a bare tag, and outputs `radixark/miles:<tag>`. `release-branch-cut.yml` passes the prune-exempt `release-vX.Y.Z-ci` tag recorded in `release-lock.json`.
 
 The ROCm resolver uses only its dispatch input, defaults to its undated `rocm/sgl-dev` tag, and uses that default for called release runs too.
 
@@ -57,7 +57,7 @@ A **nightly** policy selects every enabled tag except `long` and `ft-long`, admi
 
 `run-ci-all` selects the full domain-tag set without changing cadence. `run-ci-image` selects every enabled tag except `long`, `ft-short`, and `ft-long`. If scope signals overlap, the precedence is `run-ci-all` > weekly/release full scope > nightly > `run-ci-image`. The resolved cadence and raw/synthetic labels are passed to `run_suite.py`, which computes one run policy (see [Labels](/ci/01-label) for the subtraction semantics).
 
-**Dependencies / gating.** In `pr-test.yml`, both CPU stages require both resolvers. Its GPU stages also require both resolvers and, by default, a successful `stage-a-cpu`, so a CPU-test failure short-circuits the expensive NVIDIA fleet. Resolved nightly, weekly, or release cadence and the `bypass-fastfail` PR label relax only the `stage-a-cpu` failure gate and make each suite continue after a test failure; none bypasses resolver failure.
+**Dependencies / gating.** In `pr-test.yml`, both CPU stages require only `resolve-ci-policy` and start independently of image preparation. A normal run calls `_build-pr-ci-image.yml` only after `stage-a-cpu` succeeds, then resolves the image and admits the NVIDIA GPU stages; `stage-b-cpu` remains parallel and does not gate that chain. Resolved nightly, weekly, or release cadence and the `bypass-fastfail` PR label admit the Docker/image/GPU chain after an actual `stage-a-cpu` failure and make each suite continue after a test failure; they do not admit a skipped or cancelled CPU gate and do not bypass policy, Docker-path detection, build, or image-resolution failure.
 
 **Runner selection.** CUDA stages request runners by label via `runs_on`, a JSON list passed through to `runs-on` — a runner must carry **all** listed labels (GPU class + count). CPU stages call `_run-cpu-ci.yml`, whose only job runs on GitHub-hosted `ubuntu-latest`, so they don't occupy GPU-fleet slots.
 
@@ -65,11 +65,11 @@ A **nightly** policy selects every enabled tag except `long` and `ft-long`, admi
 
 CUDA and CPU dependency refs resolve in this order: explicit dispatch input or PR-body directive, committed `release-lock.json`, then the moving `sglang-miles` / `miles-main` branch heads. A called release run therefore checks out its requested Miles `ref` and consumes the lockfile on that ref unless an explicit override exists. ROCm checks out the requested Miles ref but keeps the dependencies baked into its image.
 
-**Launch.** Each CPU/CUDA stage is a thin caller of one hardware-specific reusable workflow: CPU stages use `_run-cpu-ci.yml`, while CUDA stages use `_run-ci.yml`. Each reusable workflow declares only its matching job, so GitHub does not add a skipped CPU sibling to CUDA stages or a skipped CUDA sibling to CPU stages.
+**Launch.** Each CPU/CUDA stage is a thin caller of one hardware-specific reusable workflow: CPU stages use `_run-cpu-ci.yml`, while CUDA stages use `_run-ci.yml`. The Docker path detector and PR-image builder live together in `_build-pr-ci-image.yml`; `pr-test.yml` owns its `stage-a-cpu` gate and consumes its `built` output. Each test reusable workflow declares only its matching job, so GitHub does not add a skipped CPU sibling to CUDA stages or a skipped CUDA sibling to CPU stages.
 
 Both workflows receive `execute_command` and an optional `ref`; CUDA callers additionally pass `runs_on` and `container_image`. The reusable workflows own checkout, runner setup, dependency and source resolution, and the two command invocations (first `--list-only`, then the real run); each stage owns only which runner class, image, ref, and command to select.
 
-**Secrets.** CPU/CUDA stages call their reusable workflow with `secrets: inherit`. The ROCm caller passes `WANDB_API_KEY` explicitly; GitHub withholds it from fork `pull_request` runs.
+**Secrets.** CPU/CUDA stages and the PR-image caller use `secrets: inherit`; the image workflow uses the inherited Docker Hub credentials only for a same-repository build. The ROCm caller passes `WANDB_API_KEY` explicitly; GitHub withholds it from fork `pull_request` runs.
 
 **Sharding.** A stage with a `partition_id` matrix splits its tests across N shards; `run_suite.py` balances the shards by each test's `est_time`. Each shard is an independent job instance running the same `execute_command` with a different `--auto-partition-id`.
 

--- a/docs/ci/00-stage.md
+++ b/docs/ci/00-stage.md
@@ -30,7 +30,7 @@ Stage names follow `stage-<tier>-<gpus>-<hw>` (or `stage-<tier>-<hw>` for CPU, e
 | `nightly-stage-c-4-gpu-mi350` | 4× MI350 | external nightly | — | — |
 | `nightly-stage-c-8-gpu-mi350` | 8× MI350 | external nightly | — | — |
 
-In `pr-test.yml`, `tier a` (CPU fast) gates PR-image preparation and the NVIDIA GPU fleet; its GPU stages (`b` / `c`) all depend on both resolvers and `stage-a-cpu`, and run concurrently with each other. `stage-b-cpu` runs in parallel with `stage-a-cpu` and is not a gate — the `b` / `c` letters classify role, they are not a sequential pipeline. The MI350 stage has no CPU-test gate.
+In `pr-test.yml`, `tier a` (CPU fast) gates PR-image preparation and the NVIDIA GPU fleet; its GPU stages (`b` / `c`) all depend on both resolvers and `stage-a-cpu`, and run concurrently with each other — the `b` / `c` letters classify role, they are not a sequential pipeline. The MI350 stage has no CPU-test gate.
 
 `pr-test.yml` treats `pull_request.closed` as cancellation-only: the close event shares the PR's concurrency group, cancels any queued or running `PR Test` run, and starts no resolver or test jobs.
 
@@ -38,7 +38,7 @@ Both PR workflows are also reusable `workflow_call` entry points for release CI.
 
 ## What each stage does
 
-**Image resolution (`resolve-ci-image`).** In `pr-test.yml`, this small `ubuntu-latest` job runs after the CPU-gated `_build-pr-ci-image.yml` call. It takes the called workflow's `image_tag` first, otherwise selects a freshly built PR image, then reads `ci-image-tag:` from the PR description or the `ci_image_tag` dispatch input, defaults to `dev`, validates a bare tag, and outputs `radixark/miles:<tag>`. `release-branch-cut.yml` passes the prune-exempt `release-vX.Y.Z-ci` tag recorded in `release-lock.json`.
+**Image resolution (`resolve-ci-image`).** In `pr-test.yml`, a small `ubuntu-latest` job takes the called workflow's `image_tag` first, then reads `ci-image-tag:` from the PR description or the `ci_image_tag` dispatch input, defaults to `dev`, validates the result is a bare tag, and outputs `radixark/miles:<tag>`. `release-branch-cut.yml` passes the prune-exempt `release-vX.Y.Z-ci` tag recorded in `release-lock.json`.
 
 The ROCm resolver uses only its dispatch input, defaults to its undated `rocm/sgl-dev` tag, and uses that default for called release runs too.
 
@@ -57,7 +57,7 @@ A **nightly** policy selects every enabled tag except `long` and `ft-long`, admi
 
 `run-ci-all` selects the full domain-tag set without changing cadence. `run-ci-image` selects every enabled tag except `long`, `ft-short`, and `ft-long`. If scope signals overlap, the precedence is `run-ci-all` > weekly/release full scope > nightly > `run-ci-image`. The resolved cadence and raw/synthetic labels are passed to `run_suite.py`, which computes one run policy (see [Labels](/ci/01-label) for the subtraction semantics).
 
-**Dependencies / gating.** In `pr-test.yml`, both CPU stages require only `resolve-ci-policy` and start independently of image preparation. A normal run calls `_build-pr-ci-image.yml` only after `stage-a-cpu` succeeds, then resolves the image and admits the NVIDIA GPU stages; `stage-b-cpu` remains parallel and does not gate that chain. Resolved nightly, weekly, or release cadence and the `bypass-fastfail` PR label admit the Docker/image/GPU chain after an actual `stage-a-cpu` failure and make each suite continue after a test failure; they do not admit a skipped or cancelled CPU gate and do not bypass policy, Docker-path detection, build, or image-resolution failure.
+**Dependencies / gating.** In `pr-test.yml`, both CPU stages require only `resolve-ci-policy`. PR-image preparation is gated by `stage-a-cpu`, and the NVIDIA GPU stages follow image resolution; `stage-b-cpu` stays parallel and does not gate that chain. Resolved nightly, weekly, or release cadence and the `bypass-fastfail` PR label admit the chain after an actual `stage-a-cpu` failure and make each suite continue after a test failure; none bypasses policy or Docker/image failure.
 
 **Runner selection.** CUDA stages request runners by label via `runs_on`, a JSON list passed through to `runs-on` — a runner must carry **all** listed labels (GPU class + count). CPU stages call `_run-cpu-ci.yml`, whose only job runs on GitHub-hosted `ubuntu-latest`, so they don't occupy GPU-fleet slots.
 
@@ -65,11 +65,11 @@ A **nightly** policy selects every enabled tag except `long` and `ft-long`, admi
 
 CUDA and CPU dependency refs resolve in this order: explicit dispatch input or PR-body directive, committed `release-lock.json`, then the moving `sglang-miles` / `miles-main` branch heads. A called release run therefore checks out its requested Miles `ref` and consumes the lockfile on that ref unless an explicit override exists. ROCm checks out the requested Miles ref but keeps the dependencies baked into its image.
 
-**Launch.** Each CPU/CUDA stage is a thin caller of one hardware-specific reusable workflow: CPU stages use `_run-cpu-ci.yml`, while CUDA stages use `_run-ci.yml`. The Docker path detector and PR-image builder live together in `_build-pr-ci-image.yml`; `pr-test.yml` owns its `stage-a-cpu` gate and consumes its `built` output. Each test reusable workflow declares only its matching job, so GitHub does not add a skipped CPU sibling to CUDA stages or a skipped CUDA sibling to CPU stages.
+**Launch.** Each CPU/CUDA stage is a thin caller of one hardware-specific reusable workflow: CPU stages use `_run-cpu-ci.yml`, while CUDA stages use `_run-ci.yml`. Each reusable workflow declares only its matching job, so GitHub does not add a skipped CPU sibling to CUDA stages or a skipped CUDA sibling to CPU stages.
 
 Both workflows receive `execute_command` and an optional `ref`; CUDA callers additionally pass `runs_on` and `container_image`. The reusable workflows own checkout, runner setup, dependency and source resolution, and the two command invocations (first `--list-only`, then the real run); each stage owns only which runner class, image, ref, and command to select.
 
-**Secrets.** CPU/CUDA stages and the PR-image caller use `secrets: inherit`; the image workflow uses the inherited Docker Hub credentials only for a same-repository build. The ROCm caller passes `WANDB_API_KEY` explicitly; GitHub withholds it from fork `pull_request` runs.
+**Secrets.** CPU/CUDA stages call their reusable workflow with `secrets: inherit`. The ROCm caller passes `WANDB_API_KEY` explicitly; GitHub withholds it from fork `pull_request` runs.
 
 **Sharding.** A stage with a `partition_id` matrix splits its tests across N shards; `run_suite.py` balances the shards by each test's `est_time`. Each shard is an independent job instance running the same `execute_command` with a different `--auto-partition-id`.
 

--- a/docs/ci/01-label.md
+++ b/docs/ci/01-label.md
@@ -76,12 +76,12 @@ Each `test_*.py` under `tests/fast/` is auto-registered as a CPU test (backend C
 
 By default CI fails fast on two levels:
 
-- Cross-stage: PR-image preparation and GPU stages run only when `stage-a-cpu` succeeds — their gates require `needs.stage-a-cpu.result == 'success'`.
+- Cross-stage: GPU stages run only when `stage-a-cpu` succeeds — the `if` requires `needs.stage-a-cpu.result == 'success'`.
 - Within-stage: each suite stops at the first failure (`pytest -x` for CPU; `run_unittest_files` breaks on the first failing file for CUDA).
 
 The `bypass-fastfail` PR label turns both off so one run surfaces every failure:
 
-- Cross-stage: the PR-image caller and each GPU stage consume the shared `bypass_fastfail` policy output, so the Docker/image/GPU chain runs after an actual `stage-a-cpu` failure. A skipped or cancelled CPU gate still stops the chain.
+- Cross-stage: each GPU stage consumes the shared `bypass_fastfail` policy output, so GPU stages run even after `stage-a-cpu` fails.
 - Within-stage: `run_suite.py` derives continue-on-error from the same resolved policy (drops `pytest -x`; sets `continue_on_error=True` for CUDA). The stage still ends red — it changes coverage, not the verdict.
 
 A resolved nightly, weekly, or release cadence bypasses fast-fail on both levels so a broad run surfaces every failure rather than stopping at the first. For nightly this applies equally whether the cadence came from the PR `nightly` label or the explicitly mapped nightly cron; release comes from the called workflow's explicit override. Local `--nightly` applies the same nightly selection and within-stage behavior; cross-stage gating does not exist in a local invocation.

--- a/docs/ci/01-label.md
+++ b/docs/ci/01-label.md
@@ -76,12 +76,12 @@ Each `test_*.py` under `tests/fast/` is auto-registered as a CPU test (backend C
 
 By default CI fails fast on two levels:
 
-- Cross-stage: GPU stages run only when `stage-a-cpu` succeeds — the `if` requires `needs.stage-a-cpu.result == 'success'`.
+- Cross-stage: PR-image preparation and GPU stages run only when `stage-a-cpu` succeeds — their gates require `needs.stage-a-cpu.result == 'success'`.
 - Within-stage: each suite stops at the first failure (`pytest -x` for CPU; `run_unittest_files` breaks on the first failing file for CUDA).
 
 The `bypass-fastfail` PR label turns both off so one run surfaces every failure:
 
-- Cross-stage: each GPU stage consumes the shared `bypass_fastfail` policy output, so GPU stages run even after `stage-a-cpu` fails.
+- Cross-stage: the PR-image caller and each GPU stage consume the shared `bypass_fastfail` policy output, so the Docker/image/GPU chain runs after an actual `stage-a-cpu` failure. A skipped or cancelled CPU gate still stops the chain.
 - Within-stage: `run_suite.py` derives continue-on-error from the same resolved policy (drops `pytest -x`; sets `continue_on_error=True` for CUDA). The stage still ends red — it changes coverage, not the verdict.
 
 A resolved nightly, weekly, or release cadence bypasses fast-fail on both levels so a broad run surfaces every failure rather than stopping at the first. For nightly this applies equally whether the cadence came from the PR `nightly` label or the explicitly mapped nightly cron; release comes from the called workflow's explicit override. Local `--nightly` applies the same nightly selection and within-stage behavior; cross-stage gating does not exist in a local invocation.

--- a/docs/ci/02-docker-build.md
+++ b/docs/ci/02-docker-build.md
@@ -54,19 +54,22 @@ The **Tag** column is for `--image-tag dev`, which also pushes a timestamped `de
 
 A multi-arch build (`cu13`) needs Buildx's `docker-container` driver and is push-only — buildx writes the manifest straight to the registry, it can't load into the local image store. Use `cu13-x86` / `cu13-aarch64` (single-platform; the arm64 one cross-builds via QEMU on an x86 host) for local single-arch iteration. Other flags: `--push`, `--dry-run`, `--dockerfile`, `--custom-tag`, and repeatable `--build-arg KEY=VALUE`.
 
-## PR build check (in `pr-test.yml`)
+## PR build check (`_build-pr-ci-image.yml`)
 
-Dockerfile changes are build-tested on the PR itself, before merge — `docker-build.yml` only runs after a push to `main`, so without this breakage lands on `main` first.
+Same-repository PRs that change Docker inputs are build-tested before merge; fork PRs cannot push a PR-scoped image and use normal image resolution. `docker-build.yml` only runs after a push to `main`, so without the PR check same-repository breakage lands on `main` first.
 
-When a PR touches `docker/Dockerfile`, `docker/build.py`, `docker/install-kube-tools.sh`, `docker/verify_transformer_engine.py`, `docker/patch/**`, or `requirements.txt` (detected by the `docker-paths` job), `pr-test.yml` inserts a build in front of the test matrix:
+After `stage-a-cpu` succeeds, `pr-test.yml` calls `_build-pr-ci-image.yml`; resolved nightly, weekly, or release cadence and `bypass-fastfail` retain the explicit exception that calls it after an actual CPU-gate failure. The reusable workflow owns `docker-paths` and `docker-build`, while `pr-test.yml` owns the CPU gate and image resolution.
+
+When a PR touches `docker/Dockerfile`, `docker/build.py`, `docker/install-kube-tools.sh`, `docker/verify_transformer_engine.py`, `docker/patch/**`, or `requirements.txt`, the reusable workflow builds before image resolution and the GPU matrix:
 
 | Job | What it does |
 | --- | --- |
-| `docker-build` | builds `cu13` for `linux/amd64` and `linux/arm64`, then pushes one multi-arch PR-scoped `radixark/miles:pr-<num>` tag (same-repo PRs; fork PRs skip it and test on `dev`) |
-| `resolve-ci-image` | waits for the build and resolves the CI image to `pr-<num>`, so **every GPU suite runs inside the freshly built image**; a failed build stops the matrix instead of testing the stale image. The fresh build outranks a `ci-image-tag:` PR-body directive — the directive applies only when no PR image was built (non-docker or fork PRs) |
+| `docker-paths` (`_build-pr-ci-image.yml`) | detects whether the PR changes an input to the CUDA PR image |
+| `docker-build` (`_build-pr-ci-image.yml`) | builds `cu13` for `linux/amd64` and `linux/arm64`, then pushes one multi-arch PR-scoped `radixark/miles:pr-<num>` tag (same-repository PRs; fork PRs skip the build and use normal image resolution) |
+| `resolve-ci-image` (`pr-test.yml`) | waits for the reusable call and resolves the CI image to `pr-<num>`, so **every GPU suite runs inside the freshly built image**; a detector or build failure stops the GPU chain instead of testing the stale image. The fresh build outranks a `ci-image-tag:` PR-body directive — the directive applies only when no PR image was built (non-docker or fork PRs) |
 | `delete-pr-tag` (`docker-pr-tag-cleanup.yml`) | removes the `pr-<num>` tag when the PR closes; the tag stays available for re-runs while the PR is open |
 
-Non-docker PRs are untouched: `docker-paths` reports no change, `docker-build` skips, and the matrix runs on `dev` as before.
+Non-docker PRs run both CPU stages without waiting for image preparation. After the `stage-a-cpu` gate, `docker-paths` reports no change, `docker-build` is a hosted-runner no-op, and the GPU matrix uses normal image resolution: a valid `ci-image-tag:` directive when present, otherwise `dev`.
 
 ## Rolling Docker build (`docker-build.yml`)
 

--- a/docs/ci/02-docker-build.md
+++ b/docs/ci/02-docker-build.md
@@ -54,22 +54,19 @@ The **Tag** column is for `--image-tag dev`, which also pushes a timestamped `de
 
 A multi-arch build (`cu13`) needs Buildx's `docker-container` driver and is push-only — buildx writes the manifest straight to the registry, it can't load into the local image store. Use `cu13-x86` / `cu13-aarch64` (single-platform; the arm64 one cross-builds via QEMU on an x86 host) for local single-arch iteration. Other flags: `--push`, `--dry-run`, `--dockerfile`, `--custom-tag`, and repeatable `--build-arg KEY=VALUE`.
 
-## PR build check (`_build-pr-ci-image.yml`)
+## PR build check (in `pr-test.yml`)
 
-Same-repository PRs that change Docker inputs are build-tested before merge; fork PRs cannot push a PR-scoped image and use normal image resolution. `docker-build.yml` only runs after a push to `main`, so without the PR check same-repository breakage lands on `main` first.
+Dockerfile changes are build-tested on the PR itself, before merge — `docker-build.yml` only runs after a push to `main`, so without this breakage lands on `main` first.
 
-After `stage-a-cpu` succeeds, `pr-test.yml` calls `_build-pr-ci-image.yml`; resolved nightly, weekly, or release cadence and `bypass-fastfail` retain the explicit exception that calls it after an actual CPU-gate failure. The reusable workflow owns `docker-paths` and `docker-build`, while `pr-test.yml` owns the CPU gate and image resolution.
-
-When a PR touches `docker/Dockerfile`, `docker/build.py`, `docker/install-kube-tools.sh`, `docker/verify_transformer_engine.py`, `docker/patch/**`, or `requirements.txt`, the reusable workflow builds before image resolution and the GPU matrix:
+`pr-test.yml` calls `_build-pr-ci-image.yml` after `stage-a-cpu` satisfies its success/bypass gate, while both CPU stages run without waiting for it. The reusable workflow owns `docker-paths` and `docker-build`; for changes to `docker/Dockerfile`, `docker/build.py`, `docker/install-kube-tools.sh`, `docker/verify_transformer_engine.py`, `docker/patch/**`, or `requirements.txt`, it inserts a build before the GPU matrix:
 
 | Job | What it does |
 | --- | --- |
-| `docker-paths` (`_build-pr-ci-image.yml`) | detects whether the PR changes an input to the CUDA PR image |
-| `docker-build` (`_build-pr-ci-image.yml`) | builds `cu13` for `linux/amd64` and `linux/arm64`, then pushes one multi-arch PR-scoped `radixark/miles:pr-<num>` tag (same-repository PRs; fork PRs skip the build and use normal image resolution) |
-| `resolve-ci-image` (`pr-test.yml`) | waits for the reusable call and resolves the CI image to `pr-<num>`, so **every GPU suite runs inside the freshly built image**; a detector or build failure stops the GPU chain instead of testing the stale image. The fresh build outranks a `ci-image-tag:` PR-body directive — the directive applies only when no PR image was built (non-docker or fork PRs) |
+| `docker-build` | builds `cu13` for `linux/amd64` and `linux/arm64`, then pushes one multi-arch PR-scoped `radixark/miles:pr-<num>` tag (same-repo PRs; fork PRs skip it and test on `dev`) |
+| `resolve-ci-image` | waits for the build and resolves the CI image to `pr-<num>`, so **every GPU suite runs inside the freshly built image**; a failed build stops the matrix instead of testing the stale image. The fresh build outranks a `ci-image-tag:` PR-body directive — the directive applies only when no PR image was built (non-docker or fork PRs) |
 | `delete-pr-tag` (`docker-pr-tag-cleanup.yml`) | removes the `pr-<num>` tag when the PR closes; the tag stays available for re-runs while the PR is open |
 
-Non-docker PRs run both CPU stages without waiting for image preparation. After the `stage-a-cpu` gate, `docker-paths` reports no change, `docker-build` is a hosted-runner no-op, and the GPU matrix uses normal image resolution: a valid `ci-image-tag:` directive when present, otherwise `dev`.
+Non-docker PRs are untouched: `docker-paths` reports no change, `docker-build` skips, and the matrix runs on `dev` as before.
 
 ## Rolling Docker build (`docker-build.yml`)
 

--- a/tests/ci/test/test_run_suite.py
+++ b/tests/ci/test/test_run_suite.py
@@ -273,34 +273,67 @@ class TestWorkflowScopeSeam:
             assert "--event-name" not in cmd
             assert "--continue-on-error" not in cmd
 
-    def test_both_cpu_stages_require_both_resolvers(self):
+    def test_cpu_stages_only_require_policy(self):
         workflow = self._workflow()
         stage_a = workflow.split("  stage-a-cpu:", 1)[1].split("  stage-b-cpu:", 1)[0]
         stage_b = workflow.split("  stage-b-cpu:", 1)[1].split("  stage-b-2-gpu-h200:", 1)[0]
 
-        expected = "needs: [resolve-ci-policy, resolve-ci-image]"
+        expected = "needs: [resolve-ci-policy]"
         assert expected in stage_a
         assert expected in stage_b
+        assert "resolve-ci-image" not in stage_a
+        assert "resolve-ci-image" not in stage_b
 
     def test_cpu_and_gpu_stages_use_dedicated_reusable_workflows(self):
         workflow = self._workflow()
         assert workflow.count("uses: ./.github/workflows/_run-cpu-ci.yml") == 2
         assert workflow.count("uses: ./.github/workflows/_run-ci.yml") == 5
+        assert workflow.count("uses: ./.github/workflows/_build-pr-ci-image.yml") == 1
         assert "cpu_runner" not in workflow
 
         gpu_workflow = self._reusable_workflow("_run-ci.yml")
         cpu_workflow = self._reusable_workflow("_run-cpu-ci.yml")
+        docker_workflow = self._reusable_workflow("_build-pr-ci-image.yml")
         job_id_pattern = r"^  ([A-Za-z_][A-Za-z0-9_-]*):$"
         gpu_jobs = re.findall(job_id_pattern, gpu_workflow.split("\njobs:\n", 1)[1], re.MULTILINE)
         cpu_jobs = re.findall(job_id_pattern, cpu_workflow.split("\njobs:\n", 1)[1], re.MULTILINE)
+        docker_jobs = re.findall(job_id_pattern, docker_workflow.split("\njobs:\n", 1)[1], re.MULTILINE)
         assert gpu_jobs == ["run"]
         assert cpu_jobs == ["run-cpu"]
+        assert docker_jobs == ["docker-paths", "docker-build"]
         assert "cpu_runner" not in gpu_workflow
         assert "cpu_runner" not in cpu_workflow
 
+    def test_docker_build_waits_for_cpu_gate_and_preserves_bypass(self):
+        workflow = self._workflow()
+        caller = workflow.split("  docker-build:", 1)[1].split("  resolve-ci-image:", 1)[0]
+
+        assert "needs: [resolve-ci-policy, stage-a-cpu]" in caller
+        assert "always() && !cancelled()" in caller
+        assert "github.event.action != 'closed'" in caller
+        assert "needs.resolve-ci-policy.result == 'success'" in caller
+        assert "needs.stage-a-cpu.result == 'success'" in caller
+        assert "needs.stage-a-cpu.result == 'failure'" in caller
+        assert "needs.resolve-ci-policy.outputs.bypass_fastfail == 'true'" in caller
+        assert "stage-b-cpu" not in caller
+        assert "uses: ./.github/workflows/_build-pr-ci-image.yml" in caller
+        assert "secrets: inherit" in caller
+
+    def test_docker_build_body_lives_in_reusable_workflow(self):
+        workflow = self._workflow()
+        reusable = self._reusable_workflow("_build-pr-ci-image.yml")
+
+        assert "  docker-paths:" not in workflow
+        assert "value: ${{ jobs.docker-build.outputs.built }}" in reusable
+        assert "needs: [docker-paths]" in reusable
+        assert "if ! CHANGED_PATHS=$(git diff --name-only HEAD^1 HEAD); then" in reusable
+        assert "::error::Failed to determine docker-relevant changes." in reusable
+        assert "github.event.pull_request.head.repo.full_name == github.repository" in reusable
+        assert "python3 docker/build.py --variant cu13 --image-tag custom" in reusable
+
     def test_policy_job_is_a_thin_python_adapter(self):
         workflow = self._workflow()
-        policy_block = workflow.split("resolve-ci-policy:", 1)[1].split("resolve-ci-image:", 1)[0]
+        policy_block = workflow.split("resolve-ci-policy:", 1)[1].split("  docker-build:", 1)[0]
         assert "uses: actions/checkout@v4" in policy_block
         assert "persist-credentials: false" in policy_block
         assert "run: python -m tests.ci.ci_policy" in policy_block
@@ -312,7 +345,7 @@ class TestWorkflowScopeSeam:
 
     def test_policy_job_passes_trigger_facts(self):
         workflow = self._workflow()
-        policy_block = workflow.split("resolve-ci-policy:", 1)[1].split("resolve-ci-image:", 1)[0]
+        policy_block = workflow.split("resolve-ci-policy:", 1)[1].split("  docker-build:", 1)[0]
         assert "EVENT_NAME: ${{ github.event_name }}" in policy_block
         assert "SCHEDULE: ${{ github.event.schedule || '' }}" in policy_block
         assert "PR_LABELS_JSON: ${{ toJSON(github.event.pull_request.labels.*.name) }}" in policy_block
@@ -353,10 +386,11 @@ class TestWorkflowScopeSeam:
 
     def test_gpu_gates_consume_shared_bypass_output(self):
         workflow = self._workflow()
+        gpu_stages = workflow.split("  stage-b-2-gpu-h200:", 1)[1]
         bypass_gate = "needs.resolve-ci-policy.outputs.bypass_fastfail == 'true'"
-        assert workflow.count(bypass_gate) == 5
-        assert workflow.count("needs.resolve-ci-policy.result == 'success'") == 5
-        assert workflow.count("needs.resolve-ci-image.result == 'success'") == 5
+        assert gpu_stages.count(bypass_gate) == 5
+        assert gpu_stages.count("needs.resolve-ci-policy.result == 'success'") == 5
+        assert gpu_stages.count("needs.resolve-ci-image.result == 'success'") == 5
 
     def test_non_pr_concurrency_does_not_collapse_to_ref(self):
         workflow = self._workflow()
@@ -373,9 +407,13 @@ class TestWorkflowScopeSeam:
             in workflow
         )
 
-        for job_name in ("resolve-ci-policy", "docker-paths", "docker-build"):
-            job_header = workflow.split(f"  {job_name}:", 1)[1].split("    runs-on:", 1)[0]
-            assert "github.event.action != 'closed'" in job_header
+        policy_header = workflow.split("  resolve-ci-policy:", 1)[1].split("    runs-on:", 1)[0]
+        docker_caller = workflow.split("  docker-build:", 1)[1].split("  resolve-ci-image:", 1)[0]
+        reusable = self._reusable_workflow("_build-pr-ci-image.yml")
+
+        assert "github.event.action != 'closed'" in policy_header
+        assert "github.event.action != 'closed'" in docker_caller
+        assert reusable.count("github.event.action != 'closed'") == 2
 
 
 class TestRocmWorkflowScopeSeam:


### PR DESCRIPTION
## Summary
Start CPU CI before PR image preparation while preserving release-CI behavior.

## Motivation
Miles CPU CI is frequently saturated, and both CPU stages previously waited for Docker path detection, optional image building, and image resolution before starting. This refactor prioritizes the fast CPU signal while preserving test selection, GPU image behavior, and the release workflow added to `main`.

## Before / After
- **Before / After:** Before, both CPU stages depended on image resolution. After, they depend only on CI policy; `stage-a-cpu` gates the Docker/image/GPU chain while `stage-b-cpu` remains parallel.
- **What moved where:** `docker-paths` and `docker-build` move from `pr-test.yml` into `_build-pr-ci-image.yml`, which exposes whether it built a PR image.
- **Upstream integration:** `workflow_call`, release cadence, release image/ref inputs, MI350 coverage, and the portable pip bootstrap remain intact after replay.
- **Documentation scope:** CI docs record only the changed workflow contract, and `doc-dev` removes base-relative prose not required for consistency.
- **Failure boundary:** Docker path-detection errors stop the downstream chain instead of being treated as an empty change set.

## Behavior Preservation
- `tests/ci/test/test_run_suite.py` covers PR image selection across repository origins and changed-path outcomes.
- Nightly, weekly, release, and `bypass-fastfail` continue after an actual `stage-a-cpu` failure; skipped or cancelled CPU gates stop downstream work.
- `docs/ci/01-label.md` remains byte-identical to `main`.

## Verification
- `pytest -q tests/ci/test`: 345 passed, 1 skipped.
- `skill-quality-standard/tests/validate_skill.sh` and `validate_skill.rb`: passed for `.claude/skills/doc-dev`.
- `pre-commit run --files .claude/skills/doc-dev/SKILL.md .github/workflows/_build-pr-ci-image.yml .github/workflows/pr-test.yml docs/ci/00-stage.md docs/ci/02-docker-build.md tests/ci/test/test_run_suite.py`: all applicable hooks passed.
- `git diff --check origin/main...HEAD`: passed.
- `actionlint`: not run because it is not installed.

## Review Focus
- `.github/workflows/pr-test.yml`: verify the `stage-a-cpu` result whitelist and release-cadence bypass.
- `.github/workflows/_build-pr-ci-image.yml`: verify output propagation, fork behavior, fail-closed path detection, and the portable pip bootstrap.
- `.claude/skills/doc-dev/SKILL.md`: verify the subtraction pass removes non-contract prose without allowing stale bindings.
