### PR TITLE
refactor(ci): select GPU stages from PR impact

### DIFF
--- a/.github/workflows/pr-test-rocm.yml
+++ b/.github/workflows/pr-test-rocm.yml
@@ -64,6 +64,7 @@ jobs:
       cadence: ${{ steps.resolve.outputs.cadence }}
       raw_labels: ${{ steps.resolve.outputs.raw_labels }}
       bypass_fastfail: ${{ steps.resolve.outputs.bypass_fastfail }}
+      skipped_stages: ${{ steps.resolve.outputs.skipped_stages }}
     steps:
       - name: Checkout repository
         # Deliberately not inputs.ref: this job executes ci_policy.py, so it
@@ -72,7 +73,16 @@ jobs:
         # jobs check out the release ref.
         uses: actions/checkout@v4
         with:
+          fetch-depth: 2
           persist-credentials: false
+      - name: Collect PR changed files
+        if: github.event_name == 'pull_request'
+        shell: bash
+        run: |
+          if ! git diff --name-status -z -M HEAD^1 HEAD > "$RUNNER_TEMP/changed-files.z"; then
+            rm -f "$RUNNER_TEMP/changed-files.z"
+            echo "::warning::Unable to compute PR diff; all GPU stages remain eligible."
+          fi
       - name: Resolve CI policy inputs
         id: resolve
         env:
@@ -82,6 +92,7 @@ jobs:
           # workflow_call inherits the caller's event_name, so the cadence must
           # be passed explicitly rather than inferred from the trigger.
           CADENCE_OVERRIDE: ${{ inputs.cadence || '' }}
+          CHANGED_FILES_PATH: ${{ runner.temp }}/changed-files.z
         run: python -m tests.ci.ci_policy
 
   resolve-ci-image:
@@ -106,6 +117,11 @@ jobs:
 
   stage-c-4-gpu-mi350:
     needs: [resolve-ci-policy, resolve-ci-image]
+    if: |
+      always() && !cancelled() &&
+      needs.resolve-ci-policy.result == 'success' &&
+      needs.resolve-ci-image.result == 'success' &&
+      !contains(fromJSON(needs.resolve-ci-policy.outputs.skipped_stages || '[]'), 'stage-c-4-gpu-mi350')
     # One shard per 4-GPU runner, so the pair works the suite in parallel.
     # run_suite.py balances the shards by est_time. fail-fast: false so one
     # shard's failure does not cancel the other mid-run.

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -66,9 +66,10 @@ concurrency:
   cancel-in-progress: true
 
 # `resolve-ci-policy` passes trigger-specific facts to `ci_policy.py`, which
-# owns the explicit cadence, raw labels, test scope, and fast-fail policy.
+# owns the explicit cadence, raw labels, test scope, stage selection, and
+# fast-fail policy.
 # `run_suite.py` consumes that shared policy; GPU jobs consume the shared
-# bypass output for their cross-stage gate.
+# skip list and bypass output for their job-level gates.
 #
 # Trigger type is not policy: each scheduled cron maps to an explicit cadence,
 # while workflow_dispatch remains a regular manual operation with no implicit
@@ -82,6 +83,7 @@ jobs:
       cadence: ${{ steps.resolve.outputs.cadence }}
       raw_labels: ${{ steps.resolve.outputs.raw_labels }}
       bypass_fastfail: ${{ steps.resolve.outputs.bypass_fastfail }}
+      skipped_stages: ${{ steps.resolve.outputs.skipped_stages }}
     steps:
       - name: Checkout repository
         # Deliberately not inputs.ref: this job executes ci_policy.py, so it
@@ -90,7 +92,16 @@ jobs:
         # jobs check out the release ref.
         uses: actions/checkout@v4
         with:
+          fetch-depth: 2
           persist-credentials: false
+      - name: Collect PR changed files
+        if: github.event_name == 'pull_request'
+        shell: bash
+        run: |
+          if ! git diff --name-status -z -M HEAD^1 HEAD > "$RUNNER_TEMP/changed-files.z"; then
+            rm -f "$RUNNER_TEMP/changed-files.z"
+            echo "::warning::Unable to compute PR diff; all GPU stages remain eligible."
+          fi
       - name: Resolve CI policy inputs
         id: resolve
         env:
@@ -100,6 +111,7 @@ jobs:
           # workflow_call inherits the caller's event_name, so the cadence must
           # be passed explicitly rather than inferred from the trigger.
           CADENCE_OVERRIDE: ${{ inputs.cadence || '' }}
+          CHANGED_FILES_PATH: ${{ runner.temp }}/changed-files.z
         run: python -m tests.ci.ci_policy
 
   # Resolve and build a PR image only after the fast CPU gate completes.
@@ -186,6 +198,7 @@ jobs:
       always() && !cancelled() &&
       needs.resolve-ci-policy.result == 'success' &&
       needs.resolve-ci-image.result == 'success' &&
+      !contains(fromJSON(needs.resolve-ci-policy.outputs.skipped_stages || '[]'), 'stage-b-2-gpu-h200') &&
       (needs.stage-a-cpu.result == 'success' ||
         (needs.stage-a-cpu.result == 'failure' && needs.resolve-ci-policy.outputs.bypass_fastfail == 'true'))
     uses: ./.github/workflows/_run-ci.yml
@@ -205,6 +218,7 @@ jobs:
       always() && !cancelled() &&
       needs.resolve-ci-policy.result == 'success' &&
       needs.resolve-ci-image.result == 'success' &&
+      !contains(fromJSON(needs.resolve-ci-policy.outputs.skipped_stages || '[]'), 'stage-c-8-gpu-h100') &&
       (needs.stage-a-cpu.result == 'success' ||
         (needs.stage-a-cpu.result == 'failure' && needs.resolve-ci-policy.outputs.bypass_fastfail == 'true'))
     strategy:
@@ -230,6 +244,7 @@ jobs:
       always() && !cancelled() &&
       needs.resolve-ci-policy.result == 'success' &&
       needs.resolve-ci-image.result == 'success' &&
+      !contains(fromJSON(needs.resolve-ci-policy.outputs.skipped_stages || '[]'), 'stage-c-8-gpu-h200') &&
       (needs.stage-a-cpu.result == 'success' ||
         (needs.stage-a-cpu.result == 'failure' && needs.resolve-ci-policy.outputs.bypass_fastfail == 'true'))
     strategy:
@@ -255,6 +270,7 @@ jobs:
       always() && !cancelled() &&
       needs.resolve-ci-policy.result == 'success' &&
       needs.resolve-ci-image.result == 'success' &&
+      !contains(fromJSON(needs.resolve-ci-policy.outputs.skipped_stages || '[]'), 'stage-c-4-gpu-h200') &&
       (needs.stage-a-cpu.result == 'success' ||
         (needs.stage-a-cpu.result == 'failure' && needs.resolve-ci-policy.outputs.bypass_fastfail == 'true'))
     strategy:
@@ -280,6 +296,7 @@ jobs:
       always() && !cancelled() &&
       needs.resolve-ci-policy.result == 'success' &&
       needs.resolve-ci-image.result == 'success' &&
+      !contains(fromJSON(needs.resolve-ci-policy.outputs.skipped_stages || '[]'), 'stage-c-2-gpu-h200') &&
       (needs.stage-a-cpu.result == 'success' ||
         (needs.stage-a-cpu.result == 'failure' && needs.resolve-ci-policy.outputs.bypass_fastfail == 'true'))
     strategy:

--- a/docs/ci/00-stage.md
+++ b/docs/ci/00-stage.md
@@ -47,7 +47,7 @@ Distinct from image selection, the **`run-ci-image` label** selects the test sco
 **Policy resolution (`resolve-ci-policy`).**
 
 - `pull_request`, `schedule`, and `workflow_dispatch` only say how the workflow started; none itself implies a cadence or domain scope.
-- Each Miles PR workflow passes trigger facts and the PR diff to `tests/ci/ci_policy.py` and publishes its `cadence`, `raw_labels`, `bypass_fastfail`, and `skipped_stages` outputs. That module owns trigger adaptation; `run_suite.py` and the stage planner share the same registration-selection predicate.
+- Each Miles PR workflow passes trigger facts and, for PRs, the diff to `tests/ci/ci_policy.py`, which publishes the resolved policy and `skipped_stages` for `run_suite.py` and GPU job gates.
 - A PR `nightly` label maps to nightly cadence.
 - A scheduled run maps its exact UTC `github.event.schedule` cron: `0 15 * * 0-5` maps to nightly and `0 15 * * 6` maps to weekly; an unknown cron fails.
 - A manual dispatch keeps regular cadence and has no PR labels. `pr-test.yml` therefore runs the ordinary always-on selection, while the dedicated ROCm dispatch adds `--match-all-labels` to preserve its full regular MI350 run.
@@ -57,11 +57,9 @@ A **nightly** policy selects every enabled tag except `long` and `ft-long`, admi
 
 `run-ci-all` selects the full domain-tag set without changing cadence. `run-ci-image` selects every enabled tag except `long`, `ft-short`, and `ft-long`. If scope signals overlap, the precedence is `run-ci-all` > weekly/release full scope > nightly > `run-ci-image`. The resolved cadence and raw/synthetic labels are passed to `run_suite.py`, which computes one run policy (see [Labels](/ci/01-label) for the subtraction semantics).
 
-**PR GPU stage selection.** A PR GPU stage runs only when the current cadence/label policy selects at least one enabled registration in that stage and the PR affects it. A changed registered test file affects its declared local GPU suites; registered CPU-only tests, Markdown/docs paths, and the known non-GPU config/tooling affect no GPU suite. Explicit domain labels affect stages containing matching tests, while `nightly`, `run-ci-all`, and `run-ci-image` affect every stage runnable under that scope. `bypass-fastfail` is behavior-only and does not affect stage selection.
+**PR GPU stage selection.** Before runner allocation, PR GPU stages are filtered by `runnable ∩ affected`: `runnable` reuses cadence/label selection, while `affected` maps changed registered tests to their suites. Known non-GPU paths affect none; unknown, missing, or malformed diffs affect all. `nightly`, `run-ci-all`, and `run-ci-image` add their runnable stages; `bypass-fastfail` does not. CPU stages and scheduled/manual runs are not filtered.
 
-Any unclassified path is conservatively treated as affecting every GPU stage. The workflows collect a NUL-delimited `git diff --name-status -z -M HEAD^1 HEAD`, so rename endpoints and special filenames are preserved; a missing, empty, or malformed diff publishes an empty skip list and leaves the full fleet eligible. Scheduled and manual runs never prune, new workflow stages run by default, and CPU jobs are outside this selector.
-
-**Dependencies / gating.** In `pr-test.yml`, both CPU stages require only `resolve-ci-policy`. PR-image preparation is gated by `stage-a-cpu`, and the selected NVIDIA GPU stages follow image resolution; `stage-b-cpu` stays parallel and does not gate that chain. Resolved nightly, weekly, or release cadence and the `bypass-fastfail` PR label admit the chain after an actual `stage-a-cpu` failure and make each selected suite continue after a test failure; none bypasses policy or Docker/image failure or restores a pruned stage.
+**Dependencies / gating.** In `pr-test.yml`, both CPU stages require only `resolve-ci-policy`. PR-image preparation is gated by `stage-a-cpu`, and the NVIDIA GPU stages follow image resolution; `stage-b-cpu` stays parallel and does not gate that chain. Resolved nightly, weekly, or release cadence and the `bypass-fastfail` PR label admit the chain after an actual `stage-a-cpu` failure and make each suite continue after a test failure; none bypasses policy or Docker/image failure.
 
 **Runner selection.** CUDA stages request runners by label via `runs_on`, a JSON list passed through to `runs-on` — a runner must carry **all** listed labels (GPU class + count). CPU stages call `_run-cpu-ci.yml`, whose only job runs on GitHub-hosted `ubuntu-latest`, so they don't occupy GPU-fleet slots.
 

--- a/docs/ci/00-stage.md
+++ b/docs/ci/00-stage.md
@@ -47,7 +47,7 @@ Distinct from image selection, the **`run-ci-image` label** selects the test sco
 **Policy resolution (`resolve-ci-policy`).**
 
 - `pull_request`, `schedule`, and `workflow_dispatch` only say how the workflow started; none itself implies a cadence or domain scope.
-- Each Miles PR workflow passes trigger facts to `tests/ci/ci_policy.py` and publishes its `cadence`, `raw_labels`, and `bypass_fastfail` outputs. That module owns trigger adaptation and the shared `resolve_policy` consumed by `run_suite.py`.
+- Each Miles PR workflow passes trigger facts and the PR diff to `tests/ci/ci_policy.py` and publishes its `cadence`, `raw_labels`, `bypass_fastfail`, and `skipped_stages` outputs. That module owns trigger adaptation; `run_suite.py` and the stage planner share the same registration-selection predicate.
 - A PR `nightly` label maps to nightly cadence.
 - A scheduled run maps its exact UTC `github.event.schedule` cron: `0 15 * * 0-5` maps to nightly and `0 15 * * 6` maps to weekly; an unknown cron fails.
 - A manual dispatch keeps regular cadence and has no PR labels. `pr-test.yml` therefore runs the ordinary always-on selection, while the dedicated ROCm dispatch adds `--match-all-labels` to preserve its full regular MI350 run.
@@ -57,7 +57,11 @@ A **nightly** policy selects every enabled tag except `long` and `ft-long`, admi
 
 `run-ci-all` selects the full domain-tag set without changing cadence. `run-ci-image` selects every enabled tag except `long`, `ft-short`, and `ft-long`. If scope signals overlap, the precedence is `run-ci-all` > weekly/release full scope > nightly > `run-ci-image`. The resolved cadence and raw/synthetic labels are passed to `run_suite.py`, which computes one run policy (see [Labels](/ci/01-label) for the subtraction semantics).
 
-**Dependencies / gating.** In `pr-test.yml`, both CPU stages require only `resolve-ci-policy`. PR-image preparation is gated by `stage-a-cpu`, and the NVIDIA GPU stages follow image resolution; `stage-b-cpu` stays parallel and does not gate that chain. Resolved nightly, weekly, or release cadence and the `bypass-fastfail` PR label admit the chain after an actual `stage-a-cpu` failure and make each suite continue after a test failure; none bypasses policy or Docker/image failure.
+**PR GPU stage selection.** A PR GPU stage runs only when the current cadence/label policy selects at least one enabled registration in that stage and the PR affects it. A changed registered test file affects its declared local GPU suites; registered CPU-only tests, Markdown/docs paths, and the known non-GPU config/tooling affect no GPU suite. Explicit domain labels affect stages containing matching tests, while `nightly`, `run-ci-all`, and `run-ci-image` affect every stage runnable under that scope. `bypass-fastfail` is behavior-only and does not affect stage selection.
+
+Any unclassified path is conservatively treated as affecting every GPU stage. The workflows collect a NUL-delimited `git diff --name-status -z -M HEAD^1 HEAD`, so rename endpoints and special filenames are preserved; a missing, empty, or malformed diff publishes an empty skip list and leaves the full fleet eligible. Scheduled and manual runs never prune, new workflow stages run by default, and CPU jobs are outside this selector.
+
+**Dependencies / gating.** In `pr-test.yml`, both CPU stages require only `resolve-ci-policy`. PR-image preparation is gated by `stage-a-cpu`, and the selected NVIDIA GPU stages follow image resolution; `stage-b-cpu` stays parallel and does not gate that chain. Resolved nightly, weekly, or release cadence and the `bypass-fastfail` PR label admit the chain after an actual `stage-a-cpu` failure and make each selected suite continue after a test failure; none bypasses policy or Docker/image failure or restores a pruned stage.
 
 **Runner selection.** CUDA stages request runners by label via `runs_on`, a JSON list passed through to `runs-on` — a runner must carry **all** listed labels (GPU class + count). CPU stages call `_run-cpu-ci.yml`, whose only job runs on GitHub-hosted `ubuntu-latest`, so they don't occupy GPU-fleet slots.
 

--- a/docs/ci/01-label.md
+++ b/docs/ci/01-label.md
@@ -61,8 +61,6 @@ A subtraction is not a per-test veto — it only stops that label from granting 
 
 A domain label explicitly requested on the PR wins over a scope subtraction: `run-ci-image` plus `run-ci-long` or `run-ci-ft-short`, and nightly plus `run-ci-long`, add the explicitly requested tests back rather than silently dropping the request.
 
-On PRs, labels also contribute to GPU stage selection before a self-hosted runner is allocated. A domain label marks only stages containing an enabled, cadence-eligible test with that label; `nightly`, `run-ci-all`, and `run-ci-image` mark every stage runnable under their resolved scope. This is combined with changed-path impact, so a docs-only PR carrying `run-ci-megatron` runs the stages containing selected Megatron tests without restoring unrelated always-on stages. `bypass-fastfail` contributes no test scope and therefore never restores a pruned stage.
-
 ## Registration and scan scope
 
 Labels are optional; registration is not. The runner scans `tests/fast`, `tests/fast-gpu`, `tests/e2e`, `tests/ci` recursively for `test_*.py`. Every file must resolve to a registration or collection fails:
@@ -81,7 +79,7 @@ By default CI fails fast on two levels:
 - Cross-stage: GPU stages run only when `stage-a-cpu` succeeds — the `if` requires `needs.stage-a-cpu.result == 'success'`.
 - Within-stage: each suite stops at the first failure (`pytest -x` for CPU; `run_unittest_files` breaks on the first failing file for CUDA).
 
-For GPU stages selected to run, the `bypass-fastfail` PR label turns both off so one run surfaces every failure:
+The `bypass-fastfail` PR label turns both off so one run surfaces every failure:
 
 - Cross-stage: each GPU stage consumes the shared `bypass_fastfail` policy output, so GPU stages run even after `stage-a-cpu` fails.
 - Within-stage: `run_suite.py` derives continue-on-error from the same resolved policy (drops `pytest -x`; sets `continue_on_error=True` for CUDA). The stage still ends red — it changes coverage, not the verdict.

--- a/docs/ci/01-label.md
+++ b/docs/ci/01-label.md
@@ -61,6 +61,8 @@ A subtraction is not a per-test veto — it only stops that label from granting 
 
 A domain label explicitly requested on the PR wins over a scope subtraction: `run-ci-image` plus `run-ci-long` or `run-ci-ft-short`, and nightly plus `run-ci-long`, add the explicitly requested tests back rather than silently dropping the request.
 
+On PRs, labels also contribute to GPU stage selection before a self-hosted runner is allocated. A domain label marks only stages containing an enabled, cadence-eligible test with that label; `nightly`, `run-ci-all`, and `run-ci-image` mark every stage runnable under their resolved scope. This is combined with changed-path impact, so a docs-only PR carrying `run-ci-megatron` runs the stages containing selected Megatron tests without restoring unrelated always-on stages. `bypass-fastfail` contributes no test scope and therefore never restores a pruned stage.
+
 ## Registration and scan scope
 
 Labels are optional; registration is not. The runner scans `tests/fast`, `tests/fast-gpu`, `tests/e2e`, `tests/ci` recursively for `test_*.py`. Every file must resolve to a registration or collection fails:
@@ -79,7 +81,7 @@ By default CI fails fast on two levels:
 - Cross-stage: GPU stages run only when `stage-a-cpu` succeeds — the `if` requires `needs.stage-a-cpu.result == 'success'`.
 - Within-stage: each suite stops at the first failure (`pytest -x` for CPU; `run_unittest_files` breaks on the first failing file for CUDA).
 
-The `bypass-fastfail` PR label turns both off so one run surfaces every failure:
+For GPU stages selected to run, the `bypass-fastfail` PR label turns both off so one run surfaces every failure:
 
 - Cross-stage: each GPU stage consumes the shared `bypass_fastfail` policy output, so GPU stages run even after `stage-a-cpu` fails.
 - Within-stage: `run_suite.py` derives continue-on-error from the same resolved policy (drops `pytest -x`; sets `continue_on_error=True` for CUDA). The stage still ends red — it changes coverage, not the verdict.

--- a/tests/ci/ci_policy.py
+++ b/tests/ci/ci_policy.py
@@ -6,7 +6,7 @@ import re
 import sys
 import warnings
 from collections.abc import Iterable
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 
 from tests.ci.labels import KNOWN_LABELS
 
@@ -45,6 +45,7 @@ class WorkflowPolicy:
     cadence: str
     raw_labels: tuple[str, ...]
     bypass_fastfail: bool
+    skipped_stages: tuple[str, ...]
 
 
 def strip_run_ci_prefix(raw_labels: Iterable[str]) -> set[str]:
@@ -121,6 +122,20 @@ def resolve_policy(cadence: str, raw_labels: set[str]) -> RunPolicy:
     )
 
 
+def registration_matches_selection(
+    labels: Iterable[str],
+    nightly: bool,
+    *,
+    admit_nightly_tests: bool,
+    include_labels: Iterable[str],
+) -> bool:
+    """Return whether one registration is selected by cadence and labels."""
+    if nightly and not admit_nightly_tests:
+        return False
+    labels = set(labels)
+    return not labels or bool(labels & set(include_labels))
+
+
 def _canonical_pr_labels(pr_labels_json: str) -> tuple[str, ...]:
     try:
         labels = json.loads(pr_labels_json)
@@ -165,27 +180,51 @@ def resolve_workflow_inputs(
         cadence=cadence,
         raw_labels=raw_labels,
         bypass_fastfail=run_policy.bypass_fastfail,
+        skipped_stages=(),
     )
 
 
 def _write_github_outputs(policy: WorkflowPolicy, output_path: str) -> None:
     raw_labels = " ".join(policy.raw_labels)
     bypass_fastfail = str(policy.bypass_fastfail).lower()
+    skipped_stages = json.dumps(policy.skipped_stages, separators=(",", ":"))
     with open(output_path, "a", encoding="utf-8") as output:
         output.write(f"cadence={policy.cadence}\n")
         output.write(f"raw_labels={raw_labels}\n")
         output.write(f"bypass_fastfail={bypass_fastfail}\n")
-    print(f"Resolved CI policy: cadence={policy.cadence} labels=[{raw_labels}] bypass_fastfail={bypass_fastfail}")
+        output.write(f"skipped_stages={skipped_stages}\n")
+    print(
+        f"Resolved CI policy: cadence={policy.cadence} labels=[{raw_labels}] "
+        f"bypass_fastfail={bypass_fastfail} skipped_stages={skipped_stages}"
+    )
 
 
 def main() -> int:
     try:
+        event_name = os.environ["EVENT_NAME"]
         policy = resolve_workflow_inputs(
-            event_name=os.environ["EVENT_NAME"],
+            event_name=event_name,
             schedule=os.environ.get("SCHEDULE", ""),
             pr_labels_json=os.environ.get("PR_LABELS_JSON", ""),
             cadence_override=os.environ.get("CADENCE_OVERRIDE", ""),
         )
+        if event_name == "pull_request":
+            from tests.ci.ci_register import collect_tests, discover_ci_files
+            from tests.ci.stage_selection import read_changed_files, select_skipped_gpu_stages
+
+            changed_files = read_changed_files(os.environ.get("CHANGED_FILES_PATH", ""))
+            if changed_files is None:
+                print("Changed-file diff is unavailable or empty; GPU stage pruning is disabled.")
+            else:
+                run_policy = resolve_policy(policy.cadence, set(policy.raw_labels))
+                skipped_stages = select_skipped_gpu_stages(
+                    event_name=event_name,
+                    changed_files=changed_files,
+                    registrations=collect_tests(discover_ci_files(), sanity_check=True),
+                    run_policy=run_policy,
+                    raw_labels=policy.raw_labels,
+                )
+                policy = replace(policy, skipped_stages=skipped_stages)
     except ValueError as exc:
         print(f"::error::{exc}", file=sys.stderr)
         return 1

--- a/tests/ci/run_suite.py
+++ b/tests/ci/run_suite.py
@@ -4,7 +4,14 @@ import subprocess
 import sys
 import tempfile
 
-from tests.ci.ci_policy import CI_CADENCES, NIGHTLY_CADENCE, REGULAR_CADENCE, RunPolicy, resolve_policy
+from tests.ci.ci_policy import (
+    CI_CADENCES,
+    NIGHTLY_CADENCE,
+    REGULAR_CADENCE,
+    RunPolicy,
+    registration_matches_selection,
+    resolve_policy,
+)
 from tests.ci.ci_register import CIRegistry, HWBackend, collect_tests, discover_ci_files
 from tests.ci.ci_utils import (
     CI_GATE_RECORD_DIR_ENV,
@@ -73,10 +80,19 @@ def filter_tests(
     if suite not in valid_suites:
         raise ValueError(f"Unknown suite {suite} for backend {hw.name}")
 
-    ci_tests = [t for t in ci_tests if t.backend == hw and t.suite == suite and (not t.nightly or admit_nightly_tests)]
-
     label_set: set[str] = labels or set()
-    ci_tests = [t for t in ci_tests if not t.labels or (set(t.labels) & label_set)]
+    ci_tests = [
+        t
+        for t in ci_tests
+        if t.backend == hw
+        and t.suite == suite
+        and registration_matches_selection(
+            t.labels,
+            t.nightly,
+            admit_nightly_tests=admit_nightly_tests,
+            include_labels=label_set,
+        )
+    ]
 
     enabled_tests = [t for t in ci_tests if t.disabled is None]
     skipped_tests = [t for t in ci_tests if t.disabled is not None]

--- a/tests/ci/stage_selection.py
+++ b/tests/ci/stage_selection.py
@@ -1,0 +1,150 @@
+"""Select PR GPU stages from changed paths and the resolved test policy."""
+
+import re
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+
+from tests.ci.ci_policy import RunPolicy, registration_matches_selection, strip_run_ci_prefix
+from tests.ci.ci_register import CIRegistry
+from tests.ci.labels import KNOWN_LABELS
+
+# Only stages with jobs in the Miles PR workflows belong here; the external
+# MI350 nightly suites are not local runner-allocation targets.
+PR_GPU_STAGES = frozenset(
+    {
+        "stage-b-2-gpu-h200",
+        "stage-c-2-gpu-h200",
+        "stage-c-4-gpu-h200",
+        "stage-c-8-gpu-h100",
+        "stage-c-8-gpu-h200",
+        "stage-c-4-gpu-mi350",
+    }
+)
+
+_BROAD_PR_SCOPES = frozenset({"nightly", "run-ci-all", "run-ci-image"})
+# Keep this allowlist to paths proven not to affect GPU runtime. Every
+# unmatched path deliberately fans out to all local GPU stages.
+_NO_GPU_PATHS = frozenset({".pre-commit-config.yaml", "scripts/tools/sync_example_docs.py"})
+_NO_GPU_PREFIXES = ("docs/",)
+_NO_GPU_SUFFIXES = (".md", ".mdx")
+_STATUS = re.compile(r"^(?:[ADMTUXB]|[RC][0-9]{1,3})$")
+
+
+@dataclass(frozen=True)
+class ChangedFile:
+    status: str
+    paths: tuple[str, ...]
+
+
+def read_changed_files(path: str) -> tuple[ChangedFile, ...] | None:
+    """Parse `git diff --name-status -z`; return None when it is unusable."""
+    if not path:
+        return None
+    try:
+        data = Path(path).read_bytes()
+    except OSError:
+        return None
+    if not data or not data.endswith(b"\0"):
+        return None
+
+    try:
+        fields = [field.decode("utf-8") for field in data[:-1].split(b"\0")]
+    except UnicodeDecodeError:
+        return None
+
+    changed_files: list[ChangedFile] = []
+    index = 0
+    while index < len(fields):
+        status = fields[index]
+        index += 1
+        if _STATUS.fullmatch(status) is None:
+            return None
+
+        path_count = 2 if status[0] in {"R", "C"} else 1
+        paths = tuple(fields[index : index + path_count])
+        index += path_count
+        if len(paths) != path_count or any(not changed_path for changed_path in paths):
+            return None
+        changed_files.append(ChangedFile(status=status, paths=paths))
+
+    return tuple(changed_files) or None
+
+
+def _runnable_stages(registrations: Iterable[CIRegistry], run_policy: RunPolicy) -> set[str]:
+    return {
+        registration.suite
+        for registration in registrations
+        if registration.suite in PR_GPU_STAGES
+        and registration.disabled is None
+        and registration_matches_selection(
+            registration.labels,
+            registration.nightly,
+            admit_nightly_tests=run_policy.admit_nightly_tests,
+            include_labels=run_policy.include_labels,
+        )
+    }
+
+
+def _explicit_scope_stages(
+    registrations: Iterable[CIRegistry],
+    run_policy: RunPolicy,
+    raw_labels: Iterable[str],
+    runnable_stages: set[str],
+) -> set[str]:
+    raw_labels = set(raw_labels)
+    if raw_labels & _BROAD_PR_SCOPES:
+        return set(runnable_stages)
+
+    requested_labels = strip_run_ci_prefix(raw_labels) & set(KNOWN_LABELS)
+    return {
+        registration.suite
+        for registration in registrations
+        if registration.suite in PR_GPU_STAGES
+        and registration.disabled is None
+        and (not registration.nightly or run_policy.admit_nightly_tests)
+        and bool(set(registration.labels) & requested_labels)
+    }
+
+
+def _known_no_gpu_path(path: str) -> bool:
+    return path in _NO_GPU_PATHS or path.startswith(_NO_GPU_PREFIXES) or path.endswith(_NO_GPU_SUFFIXES)
+
+
+def _affected_stages(changed_files: Iterable[ChangedFile], registrations: Iterable[CIRegistry]) -> set[str]:
+    stages_by_file: dict[str, set[str]] = {}
+    registered_files: set[str] = set()
+    for registration in registrations:
+        registered_files.add(registration.filename)
+        if registration.suite in PR_GPU_STAGES:
+            stages_by_file.setdefault(registration.filename, set()).add(registration.suite)
+
+    affected: set[str] = set()
+    for changed_file in changed_files:
+        for path in changed_file.paths:
+            if path in registered_files:
+                affected.update(stages_by_file.get(path, ()))
+            elif _known_no_gpu_path(path):
+                continue
+            else:
+                return set(PR_GPU_STAGES)
+    return affected
+
+
+def select_skipped_gpu_stages(
+    *,
+    event_name: str,
+    changed_files: tuple[ChangedFile, ...] | None,
+    registrations: Iterable[CIRegistry],
+    run_policy: RunPolicy,
+    raw_labels: Iterable[str],
+) -> tuple[str, ...]:
+    """Return local GPU stage IDs that a workflow can safely skip."""
+    if event_name != "pull_request" or changed_files is None:
+        return ()
+
+    registrations = tuple(registrations)
+    runnable = _runnable_stages(registrations, run_policy)
+    affected = _affected_stages(changed_files, registrations)
+    affected.update(_explicit_scope_stages(registrations, run_policy, raw_labels, runnable))
+    return tuple(sorted(PR_GPU_STAGES - (runnable & affected)))

--- a/tests/ci/test/test_ci_policy.py
+++ b/tests/ci/test/test_ci_policy.py
@@ -66,6 +66,7 @@ def test_trigger_facts_resolve_to_stable_workflow_outputs(
     assert policy.cadence == cadence
     assert policy.raw_labels == raw_labels
     assert policy.bypass_fastfail is bypass_fastfail
+    assert policy.skipped_stages == ()
 
 
 @pytest.mark.parametrize("labels_json", ["{", "{}", "null", '["run-ci-megatron", 1]'])
@@ -108,13 +109,14 @@ def test_weekly_schedule_resolves_to_independent_full_policy():
     [
         (
             "[]",
-            "existing=value\ncadence=regular\nraw_labels=\nbypass_fastfail=false\n",
+            "existing=value\ncadence=regular\nraw_labels=\nbypass_fastfail=false\nskipped_stages=[]\n",
         ),
         (
             '["run-ci-megatron", "nightly", "run-ci-megatron", "ignored"]',
             "existing=value\ncadence=nightly\n"
             "raw_labels=run-ci-megatron nightly run-ci-megatron\n"
-            "bypass_fastfail=true\n",
+            "bypass_fastfail=true\n"
+            "skipped_stages=[]\n",
         ),
     ],
 )

--- a/tests/ci/test/test_run_suite.py
+++ b/tests/ci/test/test_run_suite.py
@@ -38,6 +38,7 @@ from tests.ci.ci_policy import (
 from tests.ci.ci_register import CIRegistry, HWBackend, discover_ci_files, register_cpu_ci
 from tests.ci.labels import KNOWN_LABELS
 from tests.ci.run_suite import CI_SUITES, build_cpu_pytest_cmd, filter_tests
+from tests.ci.stage_selection import PR_GPU_STAGES
 
 register_cpu_ci(est_time=1, suite="stage-a-cpu", labels=[])
 
@@ -340,6 +341,10 @@ class TestWorkflowScopeSeam:
         assert "cadence: ${{ steps.resolve.outputs.cadence }}" in policy_block
         assert "raw_labels: ${{ steps.resolve.outputs.raw_labels }}" in policy_block
         assert "bypass_fastfail: ${{ steps.resolve.outputs.bypass_fastfail }}" in policy_block
+        assert "skipped_stages: ${{ steps.resolve.outputs.skipped_stages }}" in policy_block
+        assert "fetch-depth: 2" in policy_block
+        assert "git diff --name-status -z -M HEAD^1 HEAD" in policy_block
+        assert "CHANGED_FILES_PATH: ${{ runner.temp }}/changed-files.z" in policy_block
         assert 'case "$EVENT_NAME"' not in policy_block
         assert "jq " not in policy_block
 
@@ -392,6 +397,17 @@ class TestWorkflowScopeSeam:
         assert gpu_stages.count("needs.resolve-ci-policy.result == 'success'") == 5
         assert gpu_stages.count("needs.resolve-ci-image.result == 'success'") == 5
 
+    def test_each_cuda_stage_consumes_the_fail_open_skip_list(self):
+        workflow = self._workflow()
+        cuda_stages = PR_GPU_STAGES - {"stage-c-4-gpu-mi350"}
+        for stage_name in cuda_stages:
+            block = workflow.split(f"  {stage_name}:", 1)[1]
+            block = re.split(r"^  [A-Za-z_][A-Za-z0-9_-]*:\s*$", block, maxsplit=1, flags=re.MULTILINE)[0]
+            expected = f"!contains(fromJSON(needs.resolve-ci-policy.outputs.skipped_stages || '[]'), '{stage_name}')"
+            assert expected in block
+
+        assert workflow.count("outputs.skipped_stages || '[]'") == len(cuda_stages)
+
     def test_non_pr_concurrency_does_not_collapse_to_ref(self):
         workflow = self._workflow()
         # schedule outranks the workflow_call-only inputs.ref segment, so cron
@@ -436,6 +452,9 @@ class TestRocmWorkflowScopeSeam:
         assert "EVENT_NAME: ${{ github.event_name }}" in policy_block
         assert "SCHEDULE: ${{ github.event.schedule || '' }}" in policy_block
         assert "PR_LABELS_JSON: ${{ toJSON(github.event.pull_request.labels.*.name) }}" in policy_block
+        assert "CHANGED_FILES_PATH: ${{ runner.temp }}/changed-files.z" in policy_block
+        assert "git diff --name-status -z -M HEAD^1 HEAD" in policy_block
+        assert "skipped_stages: ${{ steps.resolve.outputs.skipped_stages }}" in policy_block
         assert "run: python -m tests.ci.ci_policy" in policy_block
         assert "github.event.schedule || inputs.ref || github.run_id" in workflow
 
@@ -454,6 +473,12 @@ class TestRocmWorkflowScopeSeam:
         assert "--labels ${{ needs.resolve-ci-policy.outputs.raw_labels }}" in command
         assert "${{ github.event_name == 'workflow_dispatch' && '--match-all-labels' || '' }}" in command
         assert "WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}" in stage
+        assert "needs.resolve-ci-policy.result == 'success'" in stage
+        assert "needs.resolve-ci-image.result == 'success'" in stage
+        assert (
+            "!contains(fromJSON(needs.resolve-ci-policy.outputs.skipped_stages || '[]'), 'stage-c-4-gpu-mi350')"
+            in stage
+        )
         assert "--labels amd" not in command
         assert "if: github.event_name == 'workflow_dispatch'" not in workflow
 

--- a/tests/ci/test/test_stage_selection.py
+++ b/tests/ci/test/test_stage_selection.py
@@ -1,0 +1,194 @@
+"""Tests for PR changed-path to GPU-stage selection."""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from tests.ci.ci_policy import REGULAR_CADENCE, resolve_policy
+from tests.ci.ci_register import CIRegistry, HWBackend, register_cpu_ci
+from tests.ci.stage_selection import PR_GPU_STAGES, ChangedFile, read_changed_files, select_skipped_gpu_stages
+
+register_cpu_ci(est_time=1, suite="stage-a-cpu", labels=[])
+
+
+def _registration(
+    filename: str,
+    suite: str,
+    *,
+    labels: list[str] | None = None,
+    disabled: str | None = None,
+) -> CIRegistry:
+    backend = HWBackend.ROCM if suite == "stage-c-4-gpu-mi350" else HWBackend.CUDA
+    return CIRegistry(
+        backend=backend,
+        filename=filename,
+        est_time=1,
+        suite=suite,
+        labels=labels or [],
+        disabled=disabled,
+    )
+
+
+def _all_runnable_registrations() -> list[CIRegistry]:
+    return [_registration(f"tests/e2e/{stage}.py", stage) for stage in PR_GPU_STAGES]
+
+
+def _select(
+    changed_files: tuple[ChangedFile, ...] | None,
+    registrations: list[CIRegistry],
+    *,
+    raw_labels: tuple[str, ...] = (),
+    event_name: str = "pull_request",
+) -> tuple[str, ...]:
+    return select_skipped_gpu_stages(
+        event_name=event_name,
+        changed_files=changed_files,
+        registrations=registrations,
+        run_policy=resolve_policy(REGULAR_CADENCE, set(raw_labels)),
+        raw_labels=raw_labels,
+    )
+
+
+def test_read_changed_files_preserves_rename_ends_and_special_names(tmp_path):
+    diff_path = tmp_path / "changed-files.z"
+    diff_path.write_bytes(b"M\0docs/line\nname.md\0R100\0docs/old.md\0docs/new.md\0")
+
+    assert read_changed_files(str(diff_path)) == (
+        ChangedFile(status="M", paths=("docs/line\nname.md",)),
+        ChangedFile(status="R100", paths=("docs/old.md", "docs/new.md")),
+    )
+
+
+@pytest.mark.parametrize("payload", [b"", b"M\0docs/index.md", b"Q\0docs/index.md\0", b"M\0\xff\0"])
+def test_read_changed_files_fails_open_on_unusable_input(tmp_path, payload):
+    diff_path = tmp_path / "changed-files.z"
+    diff_path.write_bytes(payload)
+
+    assert read_changed_files(str(diff_path)) is None
+
+
+def test_docs_tooling_and_cpu_only_tests_skip_every_gpu_stage():
+    cpu_test = "tests/fast/doc/test_sync_example_docs.py"
+    registrations = [
+        _registration("tests/fast-gpu/test_always.py", "stage-b-2-gpu-h200"),
+        CIRegistry(HWBackend.CPU, cpu_test, 1, "stage-a-cpu"),
+    ]
+    changed_files = (
+        ChangedFile("M", ("docs/ci/00-stage.md",)),
+        ChangedFile("M", ("examples/README.md",)),
+        ChangedFile("M", (".pre-commit-config.yaml",)),
+        ChangedFile("M", ("scripts/tools/sync_example_docs.py",)),
+        ChangedFile("M", (cpu_test,)),
+    )
+
+    assert set(_select(changed_files, registrations)) == PR_GPU_STAGES
+
+
+def test_changed_multi_backend_test_runs_only_its_local_stages():
+    shared_test = "tests/e2e/test_shared.py"
+    registrations = [
+        _registration("tests/fast-gpu/test_always.py", "stage-b-2-gpu-h200"),
+        _registration(shared_test, "stage-c-8-gpu-h100"),
+        _registration(shared_test, "stage-c-4-gpu-mi350"),
+    ]
+
+    skipped = set(_select((ChangedFile("M", (shared_test,)),), registrations))
+
+    assert skipped == PR_GPU_STAGES - {"stage-c-8-gpu-h100", "stage-c-4-gpu-mi350"}
+
+
+def test_domain_label_adds_only_stages_with_matching_tests():
+    registrations = [
+        _registration("tests/fast-gpu/test_always.py", "stage-b-2-gpu-h200"),
+        _registration("tests/e2e/test_megatron.py", "stage-c-8-gpu-h100", labels=["megatron"]),
+    ]
+    changed_files = (ChangedFile("M", ("docs/index.md",)),)
+
+    skipped = set(_select(changed_files, registrations, raw_labels=("run-ci-megatron",)))
+
+    assert skipped == PR_GPU_STAGES - {"stage-c-8-gpu-h100"}
+
+
+def test_broad_scope_adds_every_runnable_stage():
+    registrations = [
+        _registration("tests/fast-gpu/test_always.py", "stage-b-2-gpu-h200"),
+        _registration("tests/e2e/test_megatron.py", "stage-c-8-gpu-h100", labels=["megatron"]),
+    ]
+    changed_files = (ChangedFile("M", ("docs/index.md",)),)
+
+    skipped = set(_select(changed_files, registrations, raw_labels=("run-ci-all",)))
+
+    assert skipped == PR_GPU_STAGES - {"stage-b-2-gpu-h200", "stage-c-8-gpu-h100"}
+
+
+def test_bypass_fastfail_does_not_make_a_docs_change_affect_gpu_stages():
+    registrations = [_registration("tests/fast-gpu/test_always.py", "stage-b-2-gpu-h200")]
+    changed_files = (ChangedFile("M", ("docs/index.md",)),)
+
+    assert set(_select(changed_files, registrations, raw_labels=("bypass-fastfail",))) == PR_GPU_STAGES
+
+
+def test_unknown_source_path_affects_every_runnable_gpu_stage():
+    assert (
+        _select(
+            (ChangedFile("M", ("miles/trainer.py",)),),
+            _all_runnable_registrations(),
+        )
+        == ()
+    )
+
+
+def test_rename_from_unknown_source_path_affects_every_runnable_stage():
+    changed_files = (ChangedFile("R100", ("miles/old.py", "docs/old-api.md")),)
+
+    assert _select(changed_files, _all_runnable_registrations()) == ()
+
+
+@pytest.mark.parametrize(
+    ("event_name", "changed_files"),
+    [("schedule", (ChangedFile("M", ("docs/index.md",)),)), ("workflow_dispatch", ()), ("pull_request", None)],
+)
+def test_non_pr_or_missing_diff_never_prunes(event_name, changed_files):
+    assert _select(changed_files, _all_runnable_registrations(), event_name=event_name) == ()
+
+
+def test_changed_labeled_test_without_its_label_keeps_current_selection_semantics():
+    changed_test = "tests/e2e/test_megatron.py"
+    registrations = [
+        _registration("tests/fast-gpu/test_always.py", "stage-b-2-gpu-h200"),
+        _registration(changed_test, "stage-c-8-gpu-h100", labels=["megatron"]),
+    ]
+
+    assert set(_select((ChangedFile("M", (changed_test,)),), registrations)) == PR_GPU_STAGES
+
+
+def test_cli_publishes_all_gpu_stages_for_docs_diff(tmp_path):
+    repo_root = Path(__file__).resolve().parents[3]
+    diff_path = tmp_path / "changed-files.z"
+    diff_path.write_bytes(b"M\0docs/ci/00-stage.md\0")
+    output_path = tmp_path / "github-output"
+    env = os.environ.copy()
+    env.update(
+        {
+            "EVENT_NAME": "pull_request",
+            "SCHEDULE": "",
+            "PR_LABELS_JSON": "[]",
+            "CHANGED_FILES_PATH": str(diff_path),
+            "GITHUB_OUTPUT": str(output_path),
+        }
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-m", "tests.ci.ci_policy"],
+        cwd=repo_root,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    outputs = dict(line.split("=", 1) for line in output_path.read_text().splitlines())
+    assert set(json.loads(outputs["skipped_stages"])) == PR_GPU_STAGES


### PR DESCRIPTION
> **Depends on:** #2529
> Stacked on the parent PR's branch. Review / merge the parent first.

## Summary
Select PR GPU stages from test policy and changed-path impact.

## Motivation
Every PR currently allocates all six local GPU stages before `run_suite.py` discovers whether a stage has selected tests. The docs-only proposal in [#2527](https://github.com/radixark/miles/pull/2527) exposed this cost but encoded one PR category instead of the underlying stage-selection decision. CPU jobs, test-selection semantics, and scheduled/manual/called coverage remain unchanged.

## Before / After
- **Before:** Every eligible PR starts all NVIDIA and ROCm stage callers.
- **Late filtering:** `run_suite.py` applies cadence and labels only after runner allocation.
- **After:** The policy job publishes one `skipped_stages` JSON list.
- **Selection rule:** A stage runs only when it is both runnable and affected.
- **Policy output:** `ci_policy.py` owns the workflow contract.
- **Impact planning:** `stage_selection.py` maps NUL-delimited diffs and registry metadata to local GPU stages.
- **Job gating:** Each workflow consumes the shared result before runner allocation.

## Behavior Preservation
- `registration_matches_selection` is shared by `run_suite.py` and the planner.
- Cadence, labels, nightly eligibility, and disabled-test handling retain their existing semantics.
- Unknown, missing, empty, or malformed diffs fail open.
- Scheduled, manual, and called release runs never prune.
- CPU jobs remain unchanged, and new workflow stages run by default.
- Release cadence and `workflow_call` ref/image inputs remain intact after replay.
- The local `stage-c-4-gpu-mi350` stage remains intact after replay.
- Domain labels restore only stages containing matching tests; broad scopes restore every runnable stage, while `bypass-fastfail` remains behavior-only.

## Verification
- `pytest -qq tests/ci/test`: 363 passed, 1 skipped.
- Repository pre-commit hooks passed on all nine changed files.
- `git diff --check 465bb92c7fb9f34c54c91700b5c9a2d6ad4e85f5...HEAD`: passed.
- Parent ancestry and clean-worktree checks passed.

## Review Focus
- `tests/ci/stage_selection.py`: unmatched paths and unusable diffs must never cause false-negative GPU coverage.
- `.github/workflows/pr-test.yml` / `pr-test-rocm.yml`: a missing output must default to an empty skip list before runner allocation.
- `registration_matches_selection`: planner and runtime filtering must keep identical cadence/label semantics.
