### PR TITLE
fix(flops): stop assuming every HF config has intermediate_size

### DIFF
--- a/miles/backends/fsdp_utils/actor.py
+++ b/miles/backends/fsdp_utils/actor.py
@@ -119,9 +119,9 @@ class FSDPTrainRayActor(TrainRayActor):
         self.precision_policy = resolve_precision_policy(self.hf_config, self.args)
         try:
             self._flops_args = flops_args_from_hf_config(self.hf_config)
-        except (AssertionError, AttributeError, ValueError) as e:
+        except Exception as e:
             self._flops_args = None
-            logger.warning(f"MFU will not be reported: {e}")
+            logger.warning(f"MFU will not be reported, {type(self.hf_config).__name__} could not be sized: {e}")
 
         routing_replay.enable(args)
 

--- a/miles/backends/fsdp_utils/actor.py
+++ b/miles/backends/fsdp_utils/actor.py
@@ -117,7 +117,11 @@ class FSDPTrainRayActor(TrainRayActor):
             dist.barrier(group=get_gloo_group())
 
         self.precision_policy = resolve_precision_policy(self.hf_config, self.args)
-        self._flops_args = flops_args_from_hf_config(self.hf_config)
+        try:
+            self._flops_args = flops_args_from_hf_config(self.hf_config)
+        except (AssertionError, AttributeError, ValueError) as e:
+            self._flops_args = None
+            logger.warning(f"MFU will not be reported: {e}")
 
         routing_replay.enable(args)
 
@@ -441,8 +445,10 @@ class FSDPTrainRayActor(TrainRayActor):
             rollout_id=rollout_id,
             args=self.args,
             is_primary_rank=dist.get_rank() == 0,
-            compute_total_fwd_flops=lambda seq_lens: fwd_tflops_per_gpu(
-                seq_lens, self._flops_args, dist.get_world_size()
+            compute_total_fwd_flops=(
+                (lambda seq_lens: fwd_tflops_per_gpu(seq_lens, self._flops_args, dist.get_world_size()))
+                if self._flops_args is not None
+                else None
             ),
         )
 

--- a/miles/utils/flops_utils.py
+++ b/miles/utils/flops_utils.py
@@ -173,6 +173,15 @@ def flops_args_from_hf_config(config):
     if shared_ffn is None and getattr(config, "n_shared_experts", None):
         shared_ffn = config.n_shared_experts * moe_ffn
 
+    moe_layer_freq = _moe_layer_pattern(config, num_layers, num_experts)
+    needs_dense = moe_layer_freq is None or any(f == 0 for f in moe_layer_freq)
+    needs_moe = moe_layer_freq is not None and any(f > 0 for f in moe_layer_freq)
+    if (needs_dense and dense_ffn is None) or (needs_moe and moe_ffn is None):
+        raise ValueError(
+            f"{type(config).__name__} does not expose the FFN widths the FLOPs model needs "
+            f"(dense={dense_ffn}, moe={moe_ffn}); it likely nests them under a sub-config"
+        )
+
     return SimpleNamespace(
         hidden_size=hidden_size,
         num_attention_heads=num_attention_heads,
@@ -185,7 +194,7 @@ def flops_args_from_hf_config(config):
         moe_ffn_hidden_size=moe_ffn,
         moe_router_topk=_first(config, "num_experts_per_tok", "moe_topk", default=1),
         moe_shared_expert_intermediate_size=shared_ffn,
-        moe_layer_freq=_moe_layer_pattern(config, num_layers, num_experts),
+        moe_layer_freq=moe_layer_freq,
         q_lora_rank=getattr(config, "q_lora_rank", None),
         kv_lora_rank=getattr(config, "kv_lora_rank", None),
         qk_head_dim=getattr(config, "qk_nope_head_dim", None) or 0,

--- a/miles/utils/flops_utils.py
+++ b/miles/utils/flops_utils.py
@@ -163,13 +163,15 @@ def flops_args_from_hf_config(config):
     assert num_layers is not None, f"no layer count on {type(config).__name__}; cannot size the FLOPs model"
     num_experts = _first(config, "n_routed_experts", "num_experts", "num_local_experts")
 
-    shared_ffn = getattr(config, "shared_expert_intermediate_size", None)
-    if shared_ffn is None and getattr(config, "n_shared_experts", None):
-        shared_ffn = config.n_shared_experts * config.moe_intermediate_size
+    dense_ffn = getattr(config, "intermediate_size", None)
 
     moe_ffn = getattr(config, "moe_intermediate_size", None)
     if num_experts is not None and moe_ffn is None:
-        moe_ffn = config.intermediate_size
+        moe_ffn = dense_ffn
+
+    shared_ffn = getattr(config, "shared_expert_intermediate_size", None)
+    if shared_ffn is None and getattr(config, "n_shared_experts", None):
+        shared_ffn = config.n_shared_experts * moe_ffn
 
     return SimpleNamespace(
         hidden_size=hidden_size,
@@ -177,7 +179,7 @@ def flops_args_from_hf_config(config):
         num_query_groups=_first(config, "num_key_value_heads", default=num_attention_heads),
         vocab_size=config.vocab_size,
         num_layers=num_layers,
-        ffn_hidden_size=config.intermediate_size,
+        ffn_hidden_size=dense_ffn,
         kv_channels=_first(config, "head_dim", default=hidden_size // num_attention_heads),
         num_experts=num_experts,
         moe_ffn_hidden_size=moe_ffn,

--- a/tests/fast/utils/test_flops_from_hf_config.py
+++ b/tests/fast/utils/test_flops_from_hf_config.py
@@ -113,6 +113,36 @@ def test_dense_config_keeps_no_expert_width():
     assert flops_args_from_hf_config(hf_config()).moe_ffn_hidden_size is None
 
 
+def test_all_moe_config_without_a_dense_ffn_width():
+    hf = hf_config(num_experts=256, moe_intermediate_size=512, num_experts_per_tok=8)
+    del hf.intermediate_size
+    assert_same(
+        hf,
+        megatron_args(
+            ffn_hidden_size=None,
+            num_experts=256,
+            moe_ffn_hidden_size=512,
+            moe_router_topk=8,
+            moe_layer_freq=[1] * 8,
+        ),
+    )
+
+
+def test_shared_experts_sized_from_the_borrowed_expert_width():
+    hf = hf_config(n_routed_experts=256, num_experts_per_tok=6, n_shared_experts=2, intermediate_size=2048)
+    assert_same(
+        hf,
+        megatron_args(
+            ffn_hidden_size=2048,
+            num_experts=256,
+            moe_ffn_hidden_size=2048,
+            moe_router_topk=6,
+            moe_shared_expert_intermediate_size=2 * 2048,
+            moe_layer_freq=[1] * 8,
+        ),
+    )
+
+
 def test_deepseek_style_dense_prefix_matches():
     assert_same(
         hf_config(

--- a/tests/fast/utils/test_flops_from_hf_config.py
+++ b/tests/fast/utils/test_flops_from_hf_config.py
@@ -143,6 +143,13 @@ def test_shared_experts_sized_from_the_borrowed_expert_width():
     )
 
 
+def test_a_config_that_hides_its_ffn_width_is_rejected_up_front():
+    hf = hf_config()
+    del hf.intermediate_size
+    with pytest.raises(ValueError, match="does not expose the FFN widths"):
+        flops_args_from_hf_config(hf)
+
+
 def test_deepseek_style_dense_prefix_matches():
     assert_same(
         hf_config(


### PR DESCRIPTION
## What broke

`flops_args_from_hf_config` is called unconditionally from `FSDPTrainRayActor.init` (`miles/backends/fsdp_utils/actor.py:120`), so a config it cannot read is not a missing metric — it is a crashed run, before the first step.

Two fields were read without a guard, and both are genuinely absent on architectures Miles trains today.

**1. `config.intermediate_size`, for the dense FFN width.** Qwen3.5-35B-A3B is all-MoE and carries no such field:

```
Qwen3_5MoeTextConfig
  intermediate_size      = <absent>
  moe_intermediate_size  = 512
  n_shared_experts / shared_expert_intermediate_size = 512
  num_experts            = 256
```

```
AttributeError: 'Qwen3_5MoeTextConfig' object has no attribute 'intermediate_size'.
Did you mean: 'moe_intermediate_size'?
  at miles/utils/flops_utils.py:180, from ray::FSDPTrainRayActor.init()
```

The width is only consumed when the layer pattern says some layers are dense. For this model that count is 0 of 40, so absent is a legitimate value, not an error.

**2. `config.moe_intermediate_size`, when sizing shared experts.** Found by sweeping the rest of the configs on the test box rather than by reasoning. Inkling declares `n_shared_experts` and sizes its experts with the plain `intermediate_size`, so the shared-expert branch raised the mirror-image of the first bug.

Deriving the expert width first lets the shared-expert branch reuse it, so the second case is fixed by ordering rather than by another `getattr`.

## Blast radius

Every FSDP run on an all-MoE architecture died at actor init. `tests/e2e/fsdp/r3/test_qwen3_5_35b_a3b_r3.py` has been red since #2353 merged, and because it is a GPU stage it surfaces on whichever PR happens to run next rather than on the one that caused it — #2397 is where it showed up, and nothing in that PR is related.

This is my regression from #2353. Apologies for the noise on other people's PRs.

## Verification

Swept every model config on an H200 box through the function:

| model | `ffn` | `moe` | `shared` | fwd TFLOP/GPU @4k |
|---|---|---|---|---|
| GLM-4.7-Flash | 10240 | 1536 | 1536 | 4.37 |
| Inkling-Small | 2048 | 2048 | 4096 | 1.90 |
| Qwen3-0.6B | 3072 | — | — | 0.82 |
| Qwen3-4B | 9728 | — | — | 4.59 |
| Qwen3-30B-A3B | 6144 | 768 | — | 3.72 |
| Qwen3.5-35B-A3B | — | 512 | 512 | 2.97 |

Two crash before this change; all seven resolve after. The Qwen3.5 figure cross-checks: 23.8 TFLOP for 4096 tokens against a hand estimate of `2 x 3B active x 4096` ≈ 24.6.

`tests/fast/utils/test_flops_from_hf_config.py` gains a case per bug — an all-MoE config with no dense width, and shared experts sized from a borrowed expert width. Both fail against the unfixed function, so they are load-bearing rather than decorative. 19 pass with the fix.
