### PR TITLE
docs: rebrand environments bullet as agentic, add HUD, sync README and docs index

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,10 +88,10 @@ the largest models all live on Megatron-LM. See
   for per-GPU status and the container image for each.
 - **Wide recipe support.** GRPO, GSPO, PPO and REINFORCE++ for RL, plus SFT and
   [on-policy distillation](https://miles.radixark.com/docs/advanced/on-policy-distillation).
-- **Coding-agent environments.** Connectors for
-  [Harbor, NeMo Gym, OpenEnv, Verifiers, Strands Agents and tau-bench](https://miles.radixark.com/docs/user-guide/environments),
-  each plugging into the rollout layer that fits it, with task sandboxes on AgentENV,
-  Daytona, E2B or Modal.
+- **Agentic environments.** Train coding and computer-use agents through connectors for
+  Harbor, HUD, NeMo Gym, OpenEnv, Verifiers and more, each plugging into the rollout
+  layer that fits it, with task sandboxes on AgentENV, Daytona, E2B or Modal. See
+  [Agentic Environments](https://miles.radixark.com/docs/user-guide/environments).
 
 ## Getting Started
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -58,10 +58,10 @@ the largest models all live on Megatron-LM. See
   MI355X via ROCm. See [Supported hardware](#supported-hardware).
 - **Wide recipe support.** GRPO, GSPO, PPO and REINFORCE++ for RL, plus SFT and
   [on-policy distillation](/advanced/on-policy-distillation).
-- **Coding-agent environments.** Connectors for
-  [Harbor, NeMo Gym, OpenEnv, Verifiers, Strands Agents and tau-bench](/user-guide/environments),
-  each plugging into the rollout layer that fits it, with task sandboxes on AgentENV,
-  Daytona, E2B or Modal.
+- **Agentic environments.** Train coding and computer-use agents through connectors for
+  Harbor, HUD, NeMo Gym, OpenEnv, Verifiers and more, each plugging into the rollout
+  layer that fits it, with task sandboxes on AgentENV, Daytona, E2B or Modal. See
+  [Agentic Environments](/user-guide/environments).
 - **Comprehensive CI.** Unit suites run on every pull request, and tag-triggered end-to-end
   GPU training tests cover the supported model families on both NVIDIA and AMD runners.
 

--- a/docs/user-guide/environments.md
+++ b/docs/user-guide/environments.md
@@ -14,8 +14,9 @@ where the environment itself comes from:
   layers described in [Integration shapes](#integration-shapes); most
   environments sit in the agent function, with the session server recording
   tokens (see [Agentic Rollout (TITO)](/user-guide/agentic-rollout)).
-- **An external ecosystem** — adopt a prebuilt connector from the table below;
-  connectors occupy the same three layers.
+- **An external ecosystem** — adopt a prebuilt connector from the table below,
+  spanning coding, computer-use and tool-calling agents; connectors occupy the
+  same three layers.
 
 | Integration | Plugs in at | Guide |
 |---|---|---|


### PR DESCRIPTION
## Summary

The "What Miles runs" feature bullet in the README and docs index was labeled **Coding-agent environments**, but the [Agentic Environments](https://miles.radixark.com/docs/user-guide/environments) page it links to also covers computer-use (HUD) and tool-calling (τ-bench) connectors — and the bullet omitted HUD entirely, presumably because it didn't fit the label.

- Rename the bullet to **Agentic environments** (matching the docs page title) and lead with "Train coding and computer-use agents".
- List the headline connectors — Harbor, HUD, NeMo Gym, OpenEnv, Verifiers — and fold Strands Agents / τ-bench into "and more".
- Move the hyperlink off the connector list to a trailing "See [Agentic Environments](…)", matching the format of the neighboring Day-0 models and hardware bullets.
- Apply the same wording to `docs/index.md`, which mirrors the README.
- On the environments overview page, note that the connectors span coding, computer-use and tool-calling agents.

## Changes

| File | Change |
|---|---|
| `README.md` | Rewritten feature bullet |
| `docs/index.md` | Same bullet, with site-relative link |
| `docs/user-guide/environments.md` | One clause added to the external-ecosystem bullet |

🤖 Generated with [Claude Code](https://claude.com/claude-code)