### PR TITLE
fix(rollout): finalize lifecycle attempts on failure

### DIFF
--- a/miles/rollout/inference_rollout/inference_rollout_common.py
+++ b/miles/rollout/inference_rollout/inference_rollout_common.py
@@ -82,29 +82,28 @@ async def generate_and_rm(
     # generate
     log_prefix = f"[sample={getattr(sample, 'index', '?')}]"
     logger.debug(f"{log_prefix} Waiting for semaphore...")
-    async with state.generate_fn_semaphore:
-        if state.aborted:
-            sample.status = Sample.Status.ABORTED
+    try:
+        async with state.generate_fn_semaphore:
+            if state.aborted:
+                sample.status = Sample.Status.ABORTED
+                return sample
+
+            logger.debug(f"{log_prefix} Acquired semaphore, calling generate_function")
             if sink is not None:
-                sink.attempt_end(sample)
-            return sample
-
-        logger.debug(f"{log_prefix} Acquired semaphore, calling generate_function")
-        if sink is not None:
-            sink.gen_start(sample)
-        output = await state.generate_function(
-            GenerateFnInput(
-                state=state,
-                sample=sample,
-                sampling_params=deepcopy(sampling_params),
-                evaluation=evaluation,
+                sink.gen_start(sample)
+            output = await state.generate_function(
+                GenerateFnInput(
+                    state=state,
+                    sample=sample,
+                    sampling_params=deepcopy(sampling_params),
+                    evaluation=evaluation,
+                )
             )
-        )
-        sample = output.samples
-        logger.debug(f"{log_prefix} generate_function returned")
-
-    if sink is not None:
-        sink.attempt_end(sample)
+            sample = output.samples
+            logger.debug(f"{log_prefix} generate_function returned")
+    finally:
+        if sink is not None:
+            sink.attempt_end(sample)
 
     # TODO change to `if not args.group_rm: do reward model` for more clarity after the refactor below
     # for the rm that need the whole group, we will not do the rm here

--- a/tests/fast/rollout/inference_rollout/test_lifecycle_attempt.py
+++ b/tests/fast/rollout/inference_rollout/test_lifecycle_attempt.py
@@ -1,0 +1,126 @@
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from miles.rollout.base_types import GenerateFnOutput
+from miles.rollout.inference_rollout import inference_rollout_common as common
+from miles.utils.lifecycle import TrajectoryLifecycle
+from miles.utils.types import Sample
+
+
+class RecordingSink:
+    def __init__(self):
+        self.events = []
+
+    def attempt_start(self, sample):
+        self.events.append(("attempt_start", sample.index))
+
+    def gen_start(self, sample):
+        self.events.append(("gen_start", sample.index))
+
+    def attempt_end(self, sample):
+        self.events.append(("attempt_end", sample.index))
+
+
+@pytest.fixture
+def lifecycle_sink():
+    sink = RecordingSink()
+    TrajectoryLifecycle().sink = sink
+    yield sink
+    TrajectoryLifecycle().sink = None
+
+
+def make_state(generate_function):
+    args = SimpleNamespace(
+        partial_rollout=False,
+        mask_offpolicy_in_partial_rollout=False,
+        group_rm=True,
+        sglang_router_policy="round_robin",
+    )
+    return SimpleNamespace(
+        args=args,
+        generate_fn_semaphore=asyncio.Semaphore(2),
+        aborted=False,
+        generate_function=generate_function,
+    )
+
+
+async def test_attempt_ends_once_after_success(lifecycle_sink):
+    async def successful_generate(input):
+        return GenerateFnOutput(samples=input.sample)
+
+    sample = Sample(index=1)
+    result = await common.generate_and_rm(make_state(successful_generate), sample, sampling_params={})
+
+    assert result is sample
+    assert lifecycle_sink.events == [
+        ("attempt_start", 1),
+        ("gen_start", 1),
+        ("attempt_end", 1),
+    ]
+
+
+async def test_attempt_ends_once_after_abort(lifecycle_sink):
+    async def unexpected_generate(_input):
+        pytest.fail("aborted attempts must not generate")
+
+    sample = Sample(index=1)
+    state = make_state(unexpected_generate)
+    state.aborted = True
+    result = await common.generate_and_rm(state, sample, sampling_params={})
+
+    assert result is sample
+    assert sample.status == Sample.Status.ABORTED
+    assert lifecycle_sink.events == [
+        ("attempt_start", 1),
+        ("attempt_end", 1),
+    ]
+
+
+async def test_attempt_ends_when_generate_raises(lifecycle_sink):
+    async def failing_generate(_input):
+        raise RuntimeError("generate failed")
+
+    sample = Sample(index=1)
+    with pytest.raises(RuntimeError, match="generate failed"):
+        await common.generate_and_rm(make_state(failing_generate), sample, sampling_params={})
+
+    assert lifecycle_sink.events == [
+        ("attempt_start", 1),
+        ("gen_start", 1),
+        ("attempt_end", 1),
+    ]
+
+
+async def test_cancelled_group_sibling_ends_attempt(lifecycle_sink):
+    all_started = asyncio.Event()
+    never_finishes = asyncio.Event()
+    started = 0
+    cancelled = []
+
+    async def generate(input):
+        nonlocal started
+        started += 1
+        if started == 2:
+            all_started.set()
+        try:
+            await all_started.wait()
+            if input.sample.index == 1:
+                raise RuntimeError("sample failed")
+            await never_finishes.wait()
+        except asyncio.CancelledError:
+            cancelled.append(input.sample.index)
+            raise
+
+    samples = [Sample(index=1), Sample(index=2)]
+    with pytest.raises(RuntimeError, match="sample failed"):
+        await common.generate_and_rm_group(make_state(generate), samples, sampling_params={})
+
+    assert cancelled == [2]
+    for sample in samples:
+        assert [kind for kind, index in lifecycle_sink.events if index == sample.index] == [
+            "attempt_start",
+            "gen_start",
+            "attempt_end",
+        ]


### PR DESCRIPTION
> **Depends on:** #2522
> Stacked on the parent PR's branch. Review / merge the parent first.

## Summary

Finalize trajectory lifecycle attempts when class-based generation exits exceptionally.

## Symptom & Reproduction

- **Symptom:** After `gen_start()`, a generation exception or group-triggered cancellation emits no `attempt_end()`, leaving a completed dashboard trajectory marked as running ([review finding](https://github.com/radixark/miles/pull/2522#discussion_r3780439777)).
- **Reproduction:** On parent `736006a426`, `pytest -q tests/fast/rollout/inference_rollout/test_lifecycle_attempt.py` failed both exception/cancellation cases because each event sequence stopped at `attempt_start → gen_start`.

## Root Cause

1. `generate_and_rm()` calls `attempt_start()` before semaphore acquisition.
2. `attempt_end()` covered only abort and normal generation completion.
3. `generate_and_rm_group()` cancels siblings when one sample raises.
4. `generate_and_rm()` exceptional exits bypassed lifecycle finalization.

## Fix

`generate_and_rm()` now wraps semaphore acquisition and generation in `try/finally`, making the owner that opens an attempt close it exactly once on every exit. It does not catch, replace, or suppress exceptions; successful generation still finalizes after semaphore release and before reward calculation.

## Verification

- `pytest -q tests/fast/rollout/inference_rollout/test_lifecycle_attempt.py`: 4 passed across success, abort, exception, and sibling cancellation.
- `pytest -q tests/fast/rollout/inference_rollout/test_lifecycle_attempt.py tests/fast/rollout/inference_rollout/test_sample_completion_backfill.py tests/fast/dashboard/test_trajectory_sink.py tests/fast/dashboard/test_trajectory_views.py`: 33 passed.
- `pre-commit run --files miles/rollout/inference_rollout/inference_rollout_common.py tests/fast/rollout/inference_rollout/test_lifecycle_attempt.py`: all applicable hooks passed.

## Review Focus

- `generate_and_rm()` / `miles/rollout/inference_rollout/inference_rollout_common.py`: finalization remains after semaphore exit, runs once, and sees the returned samples on success.
- `test_cancelled_group_sibling_ends_attempt`: both attempts enter generation before one fails, proving the sibling cancellation cleanup path.
