### PR TITLE
Carry the rollout id on both agentic paths

### DIFF
--- a/miles/rollout/generate_hub/agentic_tool_call.py
+++ b/miles/rollout/generate_hub/agentic_tool_call.py
@@ -114,11 +114,10 @@ async def generate(input: GenerateFnInput) -> GenerateFnOutput:
         return GenerateFnOutput(samples=[sample] if use_v2 else sample)
 
     samples = result.samples
-    # FIXME: handle sample index issues.
-    rollout_id = input.sample.rollout_id if input.sample.rollout_id is not None else input.sample.index
-    if use_v2:
+    if use_v2 and len(samples) > 1:
+        # FIXME: handle sample index issues.
+        rollout_id = input.sample.rollout_id if input.sample.rollout_id is not None else input.sample.index
         assert rollout_id is not None, "v2 agentic samples require input Sample.rollout_id or Sample.index"
-    if rollout_id is not None:
         for sample in samples:
             sample.rollout_id = rollout_id
     if not use_v2:

--- a/miles/rollout/generate_hub/agentic_tool_call.py
+++ b/miles/rollout/generate_hub/agentic_tool_call.py
@@ -114,10 +114,11 @@ async def generate(input: GenerateFnInput) -> GenerateFnOutput:
         return GenerateFnOutput(samples=[sample] if use_v2 else sample)
 
     samples = result.samples
+    # FIXME: handle sample index issues.
+    rollout_id = input.sample.rollout_id if input.sample.rollout_id is not None else input.sample.index
     if use_v2:
-        # FIXME: handle sample index issues.
-        rollout_id = input.sample.rollout_id if input.sample.rollout_id is not None else input.sample.index
         assert rollout_id is not None, "v2 agentic samples require input Sample.rollout_id or Sample.index"
+    if rollout_id is not None:
         for sample in samples:
             sample.rollout_id = rollout_id
     if not use_v2:


### PR DESCRIPTION
## What breaks

- `tests/e2e/sglang/test_session_v1_v2_parity.py::test_qwen3_8b_h200_fa3_agentic_v2_drop_retries_matches_v1_training_payload_bitwise` fails on `main`:

```
AssertionError: sample.rollout_id is not bitwise equal
left = None, right = 0, path = 'sample.rollout_id'
```

- It is not flaky and not environment-dependent. The scheduled run on `main` reproduces it: [31715141995](https://github.com/radixark/miles/actions/runs/31715141995) → [`stage-c-2-gpu-h200 (0)`](https://github.com/radixark/miles/actions/runs/31715141995/job/94499981993), `Test Summary: 4/5 passed`.

## Root cause

- `miles/rollout/generate_hub/agentic_tool_call.py` stamps the rollout id **only** on the v2 branch:

```python
    samples = result.samples
    if use_v2:
        rollout_id = input.sample.rollout_id if input.sample.rollout_id is not None else input.sample.index
        assert rollout_id is not None, "v2 agentic samples require input Sample.rollout_id or Sample.index"
        for sample in samples:
            sample.rollout_id = rollout_id
```

- So v1 leaves `sample.rollout_id` at `None` while v2 sets it to the index. The parity test compares every field of the training payload, so the two paths are structurally unable to agree on this one.
- The two halves landed independently and were never reconciled:

| Change | Date | Effect |
| --- | --- | --- |
| #2129 `test(session): validate H200 v1/v2 agentic parity` | 2026-08-05 | Adds the bitwise parity test over all payload fields |
| #2368 `fix(rollout): group session v2 leaf samples` | 2026-08-11 | Adds the v2-only `sample.rollout_id` stamping |

- The rollout id is sample identity, not a v2 concept — nothing about it is specific to the session-server path.

## The fix

- Hoist the derivation out of the branch, keep the assertion where it was, and stamp whenever a value is derivable:

```python
    samples = result.samples
    rollout_id = input.sample.rollout_id if input.sample.rollout_id is not None else input.sample.index
    if use_v2:
        assert rollout_id is not None, "v2 agentic samples require input Sample.rollout_id or Sample.index"
    if rollout_id is not None:
        for sample in samples:
            sample.rollout_id = rollout_id
```

- **v2 is byte-identical in behaviour**: the same assertion still guards only that path, and `rollout_id` is non-`None` there by construction, so the new `if` is always taken.
- **v1 gains the stamp only when derivable**: if neither `rollout_id` nor `index` is set, v1 keeps its current behaviour rather than acquiring a new failure mode.

## Evidence

- The same change, applied on a chain based on `6033ac0eaf`, turns that lane green: [`stage-c-2-gpu-h200 (0)`](https://github.com/radixark/miles/actions/runs/31685938763) went from `Enabled 5 test(s)` → `4/5 passed` to `Enabled 5 test(s)` → **`5/5 passed`**, running 51 minutes, so it is a real pass rather than a skipped or no-op lane.
- `ruff check miles/rollout/generate_hub/agentic_tool_call.py` passes.

## Note for reviewers

- #2347 edits the same guard to `if use_v2 and len(samples) > 1:` for an unrelated reason. Whichever lands second will need a trivial rebase; the two intents are compatible, since the condition being narrowed there is the stamping loop rather than the derivation.
