### PR TITLE
docs: quick-start pre-flight checks, disk sizing, and honest timing

### DIFF
--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -1,12 +1,24 @@
 ---
 title: Quick Start
-description: A quick RL training job on Qwen3-4B in under an hour.
+description: Get an RL training job on Qwen3-4B up and running in under an hour.
 ---
 **What you need**
 
 - A node with 8 GPUs (H100 / H200 / B-series).
-- Roughly 200 GB of free disk.
+- At least 500 GB of free disk — each saved checkpoint of this 4 B model is
+  roughly 50 GB, and one lands every 20 rollouts.
 - Docker with GPU access.
+
+**Pre-flight checks**
+
+```bash
+# Driver up, all 8 GPUs listed?
+nvidia-smi
+# Docker can hand GPUs to a container?
+docker run --rm --gpus all ubuntu nvidia-smi
+# Enough free disk?
+df -h /
+```
 
 **What you will accomplish**
 

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -1,28 +1,27 @@
 ---
 title: Quick Start
-description: Get an RL training job on Qwen3-4B up and running in under an hour.
+description: Get an RL training job up and running in under an hour.
 ---
 **What you need**
 
 - A node with 8 GPUs (H100 / H200 / B-series).
-- At least 500 GB of free disk — each saved checkpoint of this 4 B model is
-  roughly 50 GB, and one lands every 20 rollouts.
+- At least 500 GB of free disk.
 - Docker with GPU access.
 
 **Pre-flight checks**
 
 ```bash
 # Driver up, all 8 GPUs listed?
-nvidia-smi
+nvidia-smi -L
 # Docker can hand GPUs to a container?
 docker run --rm --gpus all ubuntu nvidia-smi
-# Enough free disk?
-df -h /
+# Enough free disk where Docker stores data?
+df -h $(docker info -f '{{.DockerRootDir}}')
 ```
 
 **What you will accomplish**
 
-- Launch a GRPO run and watch the reward climb!
+- Launch a GRPO run on Qwen3-4B and watch the reward climb!
 
 Training a different model? The flow is the same — see [Models](/models/index) for
 the per-model recipes.

--- a/docs/index.md
+++ b/docs/index.md
@@ -108,7 +108,7 @@ and the container images for each.
 ## Start here
 
 1. **[Installation](/getting-started/installation)** — Docker, bare metal, AMD.
-2. **[Quick Start](/getting-started/quick-start)** — a working training run in under an hour.
+2. **[Quick Start](/getting-started/quick-start)** — a training job up and running in under an hour.
 3. **[Core concepts](/user-guide/concepts)** — the four objects in every Miles job.
 4. **[Launch script](/user-guide/launch-script)** — what `python scripts/run_*.py` does
    and how to override a recipe.


### PR DESCRIPTION
## Summary

Quick Start improvements per the issue. Closes #2532.

1. **Pre-flight checks.** A short command block after "What you need": `nvidia-smi -L` (driver up, one line per GPU so the count is obvious), `docker run --rm --gpus all ubuntu nvidia-smi` (the canonical nvidia-container-toolkit smoke test), and `df -h $(docker info -f '{{.DockerRootDir}}')` — the recipe's container has no volume mounts, so models and checkpoints land in the overlay layer under Docker's root dir, which is the partition that actually needs the space (host `/root` and often `/` are the wrong thing to check).
2. **Disk requirement raised: 200 GB → 500 GB.** Rationale: with Adam + the distributed optimizer, one saved checkpoint of the 4 B model carries fp32 master weights plus two fp32 moments (~12 bytes/param ≈ 48 GB) on top of the bf16 weights — roughly 50 GB per save, landing every 20 rollouts, so longer runs blow well past 200 GB.
3. **Honest timing.** The description line now reads "Get an RL training job up and running in under an hour" — the hour covers getting the job running, not finishing training. The homepage "Start here" blurb made the same ambiguous claim and is updated to match.

## Test plan

- [ ] Mintlify preview renders the pre-flight block on the Quick Start page
- [ ] The three pre-flight commands behave as described on a toolkit-equipped host
