### PR TITLE
[AMD] ci: enable the GPT-OSS 20B MoE LoRA e2e on ROCm

### DIFF
--- a/tests/e2e/ckpt/test_qwen3_4B_ckpt.py
+++ b/tests/e2e/ckpt/test_qwen3_4B_ckpt.py
@@ -5,7 +5,7 @@ from tests.ci.ci_register import register_cuda_ci, register_rocm_ci
 import miles.utils.external_utils.command_utils as U
 
 register_cuda_ci(est_time=1400, suite="stage-c-8-gpu-h100", labels=["ckpt"])
-register_rocm_ci(est_time=1200, suite="nightly-stage-c-8-gpu-mi350", labels=["ckpt"])
+register_rocm_ci(est_time=1800, suite="nightly-stage-c-8-gpu-mi350", labels=["ckpt"])
 
 ENABLE_EVAL = bool(int(os.environ.get("MILES_TEST_ENABLE_EVAL", "1")))
 

--- a/tests/e2e/long/test_qwen2.5_0.5B_gsm8k_async.py
+++ b/tests/e2e/long/test_qwen2.5_0.5B_gsm8k_async.py
@@ -5,7 +5,7 @@ from tests.ci.ci_register import register_cuda_ci, register_rocm_ci
 import miles.utils.external_utils.command_utils as U
 
 register_cuda_ci(est_time=5400, suite="stage-c-2-gpu-h200", labels=["long"])
-register_rocm_ci(est_time=5000, suite="nightly-stage-c-2-gpu-mi350", labels=["long"])
+register_rocm_ci(est_time=5400, suite="nightly-stage-c-2-gpu-mi350", labels=["long"])
 
 MODEL_NAME = "Qwen2.5-0.5B-Instruct"
 MODEL_TYPE = "qwen2.5-0.5B"

--- a/tests/e2e/lora/test_lora_qwen2.5_0.5B.py
+++ b/tests/e2e/lora/test_lora_qwen2.5_0.5B.py
@@ -18,7 +18,7 @@ from tests.ci.ci_register import register_cuda_ci, register_rocm_ci
 import miles.utils.external_utils.command_utils as U
 
 register_cuda_ci(est_time=400, suite="stage-c-4-gpu-h200", labels=["lora"])
-register_rocm_ci(est_time=300, suite="nightly-stage-c-4-gpu-mi350", labels=["lora"])
+register_rocm_ci(est_time=500, suite="nightly-stage-c-4-gpu-mi350", labels=["lora"])
 
 
 ENABLE_EVAL = bool(int(os.environ.get("MILES_TEST_ENABLE_EVAL", "1")))

--- a/tests/e2e/megatron/model_scripts/test_gpt_oss_20b_moe_lora_ci.py
+++ b/tests/e2e/megatron/model_scripts/test_gpt_oss_20b_moe_lora_ci.py
@@ -1,6 +1,6 @@
 import os
 
-from tests.ci.ci_register import register_cuda_ci
+from tests.ci.ci_register import register_cuda_ci, register_rocm_ci
 
 import miles.utils.external_utils.command_utils as U
 
@@ -11,10 +11,14 @@ import miles.utils.external_utils.command_utils as U
 
 
 register_cuda_ci(est_time=1600, suite="stage-c-4-gpu-h200", labels=["megatron", "model-scripts", "lora"])
+register_rocm_ci(est_time=1600, suite="stage-c-4-gpu-mi350", labels=["megatron", "model-scripts", "lora"])
 
 MODEL_NAME = "gpt-oss-20b-bf16"
 MODEL_TYPE = "gpt-oss-20b"
 NUM_GPUS = 4
+
+# aiter ships no batch-prefill kernel for this model's sink and page-size combination.
+_PLATFORM_EXTRA_ARGS = "--sglang-attention-backend triton " if os.getenv("MILES_HARDWARE_PLATFORM") == "rocm" else ""
 
 # (name, experts_shared_outer_loras, virtual_experts_serving)
 _CONFIGS = [
@@ -93,7 +97,7 @@ def execute(shared_outer: bool, virtual_experts: bool):
     )
 
     misc_args = (
-        "--attention-dropout 0.0 "
+        _PLATFORM_EXTRA_ARGS + "--attention-dropout 0.0 "
         "--hidden-dropout 0.0 "
         "--qkv-format bshd "
         "--attention-backend auto "

--- a/tests/e2e/megatron/test_mimo_7B_mtp_only_grad.py
+++ b/tests/e2e/megatron/test_mimo_7B_mtp_only_grad.py
@@ -16,7 +16,7 @@ from tests.ci.ci_register import register_cuda_ci, register_rocm_ci
 import miles.utils.external_utils.command_utils as U
 
 register_cuda_ci(est_time=400, suite="stage-c-4-gpu-h200", labels=["megatron"])
-register_rocm_ci(est_time=420, suite="nightly-stage-c-4-gpu-mi350", labels=["megatron"])
+register_rocm_ci(est_time=600, suite="nightly-stage-c-4-gpu-mi350", labels=["megatron"])
 
 MODEL_NAME = "MiMo-7B-RL"
 MODEL_TYPE = "mimo-7B-rl"

--- a/tests/e2e/megatron/test_qwen3_30B_A3B/test_baseline.py
+++ b/tests/e2e/megatron/test_qwen3_30B_A3B/test_baseline.py
@@ -13,7 +13,7 @@ register_ci_gate(metric_key="train/train_rollout_kl")
 register_ci_gate(metric_key="rollout/raw_reward")
 
 register_rocm_ci(
-    est_time=900, suite="nightly-stage-c-4-gpu-mi350", labels=["megatron", "weight-update", "short", "mooncake"]
+    est_time=1400, suite="nightly-stage-c-4-gpu-mi350", labels=["megatron", "weight-update", "short", "mooncake"]
 )
 
 CASE = CaseConfig(

--- a/tests/e2e/megatron/test_qwen3_30B_A3B/test_r3_baseline.py
+++ b/tests/e2e/megatron/test_qwen3_30B_A3B/test_r3_baseline.py
@@ -5,7 +5,7 @@ from tests.ci.metric_history import register_ci_gate
 from tests.e2e.megatron.test_qwen3_30B_A3B._common import CaseConfig, execute, prepare
 
 register_cuda_ci(est_time=1200, suite="stage-c-4-gpu-h200", labels=["megatron", "replay"])
-register_rocm_ci(est_time=1500, suite="nightly-stage-c-4-gpu-mi350", labels=["megatron", "replay"])
+register_rocm_ci(est_time=1100, suite="nightly-stage-c-4-gpu-mi350", labels=["megatron", "replay"])
 
 register_ci_gate(metric_key="train/grad_norm")
 register_ci_gate(metric_key="train/ppo_kl")

--- a/tests/e2e/precision/test_hf_attention_cp_relayout.py
+++ b/tests/e2e/precision/test_hf_attention_cp_relayout.py
@@ -14,7 +14,7 @@ import torch.distributed as dist
 from tests.ci.ci_register import register_cuda_ci, register_rocm_ci
 
 register_cuda_ci(est_time=30, suite="stage-c-4-gpu-h200", labels=["precision"])
-register_rocm_ci(est_time=60, suite="nightly-stage-c-4-gpu-mi350", labels=["precision"])
+register_rocm_ci(est_time=30, suite="nightly-stage-c-4-gpu-mi350", labels=["precision"])
 
 from miles_plugins.models.hf_attention import _packed_shard_to_zigzag, _zigzag_to_packed_shard
 

--- a/tests/e2e/precision/test_qwen3_5_cp_correctness.py
+++ b/tests/e2e/precision/test_qwen3_5_cp_correctness.py
@@ -17,7 +17,7 @@ import torch.distributed as dist
 from tests.ci.ci_register import register_cuda_ci, register_rocm_ci
 
 register_cuda_ci(est_time=300, suite="stage-c-4-gpu-h200", labels=["precision"])
-register_rocm_ci(est_time=120, suite="nightly-stage-c-4-gpu-mi350", labels=["precision"])
+register_rocm_ci(est_time=140, suite="nightly-stage-c-4-gpu-mi350", labels=["precision"])
 
 
 def setup_dist():

--- a/tests/e2e/sglang_config/test_sglang_config.py
+++ b/tests/e2e/sglang_config/test_sglang_config.py
@@ -6,7 +6,7 @@ from tests.ci.ci_register import register_cuda_ci, register_rocm_ci
 import miles.utils.external_utils.command_utils as U
 
 register_cuda_ci(est_time=400, suite="stage-c-8-gpu-h100", labels=["short"])
-register_rocm_ci(est_time=600, suite="nightly-stage-c-8-gpu-mi350", labels=["short"])
+register_rocm_ci(est_time=500, suite="nightly-stage-c-8-gpu-mi350", labels=["short"])
 
 MODEL_NAME = "Qwen2.5-0.5B-Instruct"
 MODEL_TYPE = "qwen2.5-0.5B"

--- a/tests/e2e/sglang_config/test_sglang_config_mixed_offload.py
+++ b/tests/e2e/sglang_config/test_sglang_config_mixed_offload.py
@@ -21,7 +21,7 @@ from tests.ci.ci_register import register_cuda_ci, register_rocm_ci
 import miles.utils.external_utils.command_utils as U
 
 register_cuda_ci(est_time=400, suite="stage-c-8-gpu-h100", labels=["short"])
-register_rocm_ci(est_time=300, suite="nightly-stage-c-8-gpu-mi350", labels=["short"])
+register_rocm_ci(est_time=500, suite="nightly-stage-c-8-gpu-mi350", labels=["short"])
 
 MODEL_NAME = "Qwen2.5-0.5B-Instruct"
 MODEL_TYPE = "qwen2.5-0.5B"

--- a/tests/e2e/short/test_qwen2.5_0.5B_gsm8k_async_short.py
+++ b/tests/e2e/short/test_qwen2.5_0.5B_gsm8k_async_short.py
@@ -5,7 +5,7 @@ from tests.ci.ci_register import register_cuda_ci, register_rocm_ci
 import miles.utils.external_utils.command_utils as U
 
 register_cuda_ci(est_time=400, suite="stage-c-8-gpu-h100", labels=["short", "mooncake"])
-register_rocm_ci(est_time=240, suite="nightly-stage-c-8-gpu-mi350", labels=["short", "mooncake"])
+register_rocm_ci(est_time=500, suite="nightly-stage-c-8-gpu-mi350", labels=["short", "mooncake"])
 
 FEW_GPU = U.get_bool_env_var("MILES_TEST_FEW_GPU", "0")
 

--- a/tests/e2e/short/test_qwen2.5_0.5B_gsm8k_short.py
+++ b/tests/e2e/short/test_qwen2.5_0.5B_gsm8k_short.py
@@ -5,7 +5,7 @@ from tests.ci.ci_register import register_cuda_ci, register_rocm_ci
 import miles.utils.external_utils.command_utils as U
 
 register_cuda_ci(est_time=400, suite="stage-c-8-gpu-h100", labels=["short", "mooncake"])
-register_rocm_ci(est_time=360, suite="nightly-stage-c-8-gpu-mi350", labels=["short", "mooncake"])
+register_rocm_ci(est_time=500, suite="nightly-stage-c-8-gpu-mi350", labels=["short", "mooncake"])
 
 FEW_GPU = U.get_bool_env_var("MILES_TEST_FEW_GPU", "0")
 

--- a/tests/e2e/short/test_run_megatron.py
+++ b/tests/e2e/short/test_run_megatron.py
@@ -36,7 +36,7 @@ NUM_LAYERS: int = 5
 _RUN_DIR: Path = Path(tempfile.mkdtemp(prefix="test_run_megatron_"))
 
 register_cuda_ci(est_time=200, suite="stage-c-8-gpu-h100", labels=["short"])
-register_rocm_ci(est_time=2000, suite="nightly-stage-c-8-gpu-mi350", labels=["short"])
+register_rocm_ci(est_time=300, suite="nightly-stage-c-8-gpu-mi350", labels=["short"])
 
 
 @dataclasses.dataclass(frozen=True)

--- a/tests/fast-gpu/test_fsdp_hybrid_shard.py
+++ b/tests/fast-gpu/test_fsdp_hybrid_shard.py
@@ -1,8 +1,9 @@
 """FSDP2 gradient parity across r1s4, r2s2, and r4s1."""
 
-from tests.ci.ci_register import register_cuda_ci
+from tests.ci.ci_register import register_cuda_ci, register_rocm_ci
 
 register_cuda_ci(est_time=90, suite="stage-c-4-gpu-h200", labels=["fsdp"])
+register_rocm_ci(est_time=90, suite="stage-c-4-gpu-mi350", labels=["fsdp"])
 
 import os
 import subprocess


### PR DESCRIPTION
Co-author-with: @JessicaJiang-123

## Summary

Register `tests/e2e/megatron/model_scripts/test_gpt_oss_20b_moe_lora_ci.py` on the ROCm `stage-c-4-gpu-mi350` suite. The test is otherwise unchanged; both serving combinations already run as written.

The one behaviour change is that ROCm selects SGLang's triton attention backend, gated on `MILES_HARDWARE_PLATFORM`. ROCm otherwise defaults to aiter, which ships no compiled batch-prefill kernel for what gpt-oss-20b needs: a learned attention sink, a KV cache large enough to require the global-load variant, and `page_size=1` below the kernel's tile width. That variable is only set in `docker/Dockerfile.rocm`, so the argument string is empty on every CUDA image and the composed args are byte-identical there. The CUDA registration is untouched.

## Verification

Ran the test end to end on 4x MI355X with both dependencies below applied. Each combination completed and the Ray job reported success:

```text
combo PASSED: shared-outer + virtual-experts
combo PASSED: per-expert + no-virtual-experts
update_weights phase=end ok=true elapsed_s=4.6
Job 'raysubmit_wmNUyY7nFiEgEPcu' succeeded
```

`collect_tests(discover_ci_files(), sanity_check=True)` returns both a `HWBackend.CUDA` entry on `stage-c-4-gpu-h200` and a `HWBackend.ROCM` entry on `stage-c-4-gpu-mi350` for this file, and `pre-commit run` passes.

## Dependencies

Merge this last; ahead of either one it turns the mi350 suite red.

- radixark/Megatron-Bridge#29 makes the grouped-expert LoRA adapter work against ROCm's TransformerEngine. There is no PR-description directive for Bridge: `docker/Dockerfile.rocm` installs it from the `bridge` branch head, so the ROCm image needs a rebuild after it merges.
- sgl-project/sglang#34834 makes the MoE LoRA align JIT kernel build on ROCm, which the per-expert combination needs.
