### PR TITLE
Allow --stream-optimizer-state-to-disk without trainer offload

### DIFF
--- a/docs/advanced/disk-offload.md
+++ b/docs/advanced/disk-offload.md
@@ -104,10 +104,11 @@ training GPUs, which is the point when you are sizing engines against a fixed cl
   cannot help with: add `--stream-optimizer-state-to-disk`, and consider
   `--stream-optimizer-state-moment-dtype bf16` to claw back some of the I/O cost.
 
-Streaming requires `--offload-train-target=disk`; miles asserts it. The two answer the same
-pressure and are only deployed as a pair, so that is the only combination covered.
-Streaming on its own does run — it is the one case where offload has nothing to do, because
-nothing else wants the training GPUs during rollout — but nothing validates it.
+Streaming on its own is the disaggregated case: nothing else wants the training GPUs during
+rollout, so there is no actor to park and `--offload-train-target` is never read. Pass
+`--stream-optimizer-state-to-disk` alone there. Under `--offload-train`, though, the two go
+together — a run that cannot hold the optimizer state on the GPU for the step will not hold
+a pinned host copy of the whole actor either — and miles asserts that pairing.
 
 Both mechanisms share `--offload-train-disk-dir` and `--offload-train-disk-chunk-mb`. Point the
 directory at real node-local NVMe: a tmpfs mount, which `/tmp` is on many systems, keeps

--- a/docs/user-guide/training-backend.md
+++ b/docs/user-guide/training-backend.md
@@ -359,8 +359,8 @@ Memory, once the layout is set:
 
 Under `--colocate` this backend also implements `sleep` / `wake_up` by moving the model and
 the optimizer to host memory and back, gated on `--offload-train`. The deeper offload
-targets are Megatron-only: `--offload-train-target disk` asserts the Megatron backend, and
-`--stream-optimizer-state-to-disk` builds on it.
+targets are Megatron-only: both `--offload-train-target disk` and
+`--stream-optimizer-state-to-disk` assert the Megatron backend.
 
 ### 3. Precision
 

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -3336,27 +3336,29 @@ def miles_validate_args(args):
 
     _validate_rematerialize_param_from_master_weight(args)
 
+    if (args.offload_train_target == "disk" or args.stream_optimizer_state_to_disk) and (
+        args.offload_train_disk_dir is None
+    ):
+        uid = os.getuid() if hasattr(os, "getuid") else 0
+        args.offload_train_disk_dir = os.path.join(os.environ.get("SCRATCH", "/scratch"), f"miles_train_offload_{uid}")
+
     if args.offload_train_target == "disk":
         assert args.offload_train, "--offload-train-target=disk requires --offload-train"
         assert (
             args.train_backend == "megatron"
         ), "--offload-train-target=disk is only supported on the megatron backend"
         assert args.offload_train_disk_chunk_mb > 0, "--offload-train-disk-chunk-mb must be positive"
-        if args.offload_train_disk_dir is None:
-            uid = os.getuid() if hasattr(os, "getuid") else 0
-            args.offload_train_disk_dir = os.path.join(
-                os.environ.get("SCRATCH", "/scratch"), f"miles_train_offload_{uid}"
-            )
         logger.info(
             f"Train offload target=disk, dir={args.offload_train_disk_dir}, "
             f"chunk={args.offload_train_disk_chunk_mb}MB"
         )
 
     if args.stream_optimizer_state_to_disk:
-        assert args.offload_train_target == "disk", (
-            "--stream-optimizer-state-to-disk requires --offload-train-target=disk. Both answer the "
-            "same pressure and are only ever deployed as a pair, so that is the only combination "
-            "validated; streaming alone runs but is untested."
+        assert args.offload_train_target == "disk" or not args.offload_train, (
+            "--stream-optimizer-state-to-disk with --offload-train requires "
+            "--offload-train-target=disk: a run that cannot hold the optimizer state on GPU for "
+            "the duration of the step will not hold a pinned host copy of the whole actor either. "
+            "Disaggregated runs do not offload the trainer at all, and the target is unused there."
         )
         assert not args.indep_dp, (
             "--stream-optimizer-state-to-disk does not support --indep-dp: each cell has its own "


### PR DESCRIPTION
Found while running `examples/experimental/openenv/glm52_tbench2` against `main` on 16 GB300 nodes. It is the first of three blockers that stop that example; the run could not start at all.

## The failure

```
AssertionError: --stream-optimizer-state-to-disk requires --offload-train-target=disk.
Both answer the same pressure and are only ever deployed as a pair, so that is the
only combination validated; streaming alone runs but is untested.
```

## Why the coupling does not hold

The two flags answer different pressures, and `--stream-optimizer-state-to-disk`'s own help text says so:

> `--offload-train-target=disk` **cannot help there**, because pause/resume happen at phase boundaries and everything is resident again by the time Adam launches.

`--offload-train-target` is where the trainer is parked *while the rollout engines generate*, and it is read only under `--offload-train`, which defaults to true under `--colocate` and false otherwise. A disaggregated run never offloads the trainer — the engines are on their own nodes — so satisfying the assertion means switching `--offload-train` on purely to satisfy it, paying a full trainer round-trip to NVMe at every phase boundary for nothing.

That leaves streaming unusable in exactly the topology that needs it most. In the run above, DP1 leaves the optimizer state unsharded at **270 GB/rank on 276 GB GPUs**; streaming is what makes it fit:

```
nvme_stream.py:266 - NVMe optimizer state store: 120 buckets, 270.0 GB at /scratch/opt_state/...
nvme_stream.py:361 - NVMe streaming step: 120 buckets, read 90.0 GB, wrote 270.0 GB in 60.9s
model.py:635      - ft op=train_step rollout=0 step=0 outcome=NORMAL valid_step=true
```

The check has never been exercised by a run that uses streaming this way: job 1835 (2026-08-03) logged `offload_train_target ... cpu` *with* streaming on, from a checkout predating the assertion.

## Change

Scope the assertion to runs that actually offload the trainer:

```python
assert args.offload_train_target == "disk" or not args.offload_train, ...
```

and hoist the `offload_train_disk_dir` default so streaming-without-offload gets one. The NVMe store joins that path unconditionally (`miles_plugins/optimizers/nvme_stream.py:453`), so leaving it `None` was a `TypeError` inside the step.

## Testing

- `tests/e2e/megatron/test_qwen3_4B_offload_disk_stream.py` is colocate and sets both flags, so it is unaffected.
- Verified on 16x GB300: with this change the reference config parses, loads, and completes training steps with the store engaged (log lines above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
