### PR TITLE
Reuse one Daytona client per process instead of one per create attempt

### DIFF
--- a/examples/experimental/openenv/tb2_sandbox_daytona.py
+++ b/examples/experimental/openenv/tb2_sandbox_daytona.py
@@ -24,6 +24,7 @@ per task would only spend the org quota the declarative path exists to avoid.
 
 import os
 import shlex
+import threading
 from pathlib import Path
 
 import tb2_sandbox_recipe as recipe
@@ -157,15 +158,28 @@ def resolve_api_key() -> str:
     return recipe.resolve_api_key("DAYTONA_API_KEY", "DAYTONA_API_KEY_FILE", _DEFAULT_API_KEY_FILE)
 
 
-def make_daytona():
-    """Daytona client: key from resolve_api_key(), endpoint from optional
-    DAYTONA_API_URL. Public: callers driving create_task_sandbox() need a
-    client configured this way."""
-    from daytona import Daytona, DaytonaConfig
+_client_lock = threading.Lock()
+_client = None
 
-    return Daytona(
-        DaytonaConfig(
-            api_key=resolve_api_key(),
-            api_url=os.getenv("DAYTONA_API_URL", "https://app.daytona.io/api"),
-        )
-    )
+
+def make_daytona():
+    """The process's Daytona client: key from resolve_api_key(), endpoint from
+    optional DAYTONA_API_URL. Public: callers driving create_task_sandbox() need
+    a client configured this way.
+
+    Built once and shared: the SDK owns a connection pool and exposes no
+    close(), and this runs once per sandbox-create attempt, retries included, so
+    a client per call turns a spell of API failures into a socket leak.
+    """
+    global _client
+    with _client_lock:
+        if _client is None:
+            from daytona import Daytona, DaytonaConfig
+
+            _client = Daytona(
+                DaytonaConfig(
+                    api_key=resolve_api_key(),
+                    api_url=os.getenv("DAYTONA_API_URL", "https://app.daytona.io/api"),
+                )
+            )
+        return _client

--- a/examples/experimental/openenv/tests/test_tb2_sandbox_daytona.py
+++ b/examples/experimental/openenv/tests/test_tb2_sandbox_daytona.py
@@ -36,6 +36,27 @@ def test_sandbox_labels_explicit_launcher_and_run_id(monkeypatch):
     assert labels["openenv-run-id"] == "tb2-grpo-0717"
 
 
+def test_make_daytona_reuses_one_client(monkeypatch):
+    """One client per call is a socket leak: the SDK owns a connection pool with
+    no close(), and this runs once per create attempt, retries included."""
+    monkeypatch.setattr(sandbox, "_client", None)
+    monkeypatch.setenv("DAYTONA_API_KEY", "dtn_test")
+    built = []
+
+    class _Daytona:
+        def __init__(self, config):
+            built.append(config)
+
+    fake = type(sys)("daytona")
+    fake.Daytona = _Daytona
+    fake.DaytonaConfig = lambda **kw: kw
+    monkeypatch.setitem(sys.modules, "daytona", fake)
+
+    clients = [sandbox.make_daytona() for _ in range(5)]
+    assert len(built) == 1, "make_daytona built a client per call"
+    assert all(c is clients[0] for c in clients)
+
+
 def test_resolve_api_key_env_value_wins(monkeypatch, tmp_path: Path):
     key_file = tmp_path / "api_key"
     key_file.write_text("dtn_from_file\n")


### PR DESCRIPTION
Found while running `examples/experimental/openenv/glm52_tbench2` against `main` on 16 GB300 nodes. After 4.5 hours and 20 steps the run stopped generating: Daytona was refusing it, and its file-descriptor count was climbing without bound.

## The failure

```
14:01:32   6044 fds
14:03:27   7115 fds
14:05:28   9144 fds     ~17 fds/second, monotonic
14:06:59  10309 fds
```

```
connectionpool.py:869 - Retrying ... after connection broken by
  'SSLError(SSLEOFError(8, "[SSL: UNEXPECTED_EOF_WHILE_READING] EOF occurred in violation of protocol"))'
episode failed: Failed to create sandbox: HTTPSConnectionPool(host='app.daytona.io', ...)
```

up to 880 failures/min, and no `Decode batch` for 14 minutes.

**Not a Daytona outage.** A fresh container on the same node, at the same moment, reached the same endpoint 5/5 with a 34 ms TLS handshake, and `daytona.list()` returned 362 sandboxes in 0.3 s. The API was healthy; it was refusing that one process.

## Cause

```python
def _start_sandbox(task_id, tasks_dir):
    daytona = tb2_sandbox_daytona.make_daytona()   # a NEW client, every call
    sandbox, url = create_task_sandbox(daytona, ...)
    return (lambda: daytona.delete(sandbox)), url
```

Three things compound:

1. `Daytona` has no `close`, `__exit__` or `__enter__`, so the connection pool it owns is released only by GC.
2. The returned closure keeps the client referenced for the whole episode, so GC cannot take it early either.
3. `_start_sandbox` runs once per create **attempt**, retries included.

Together that is positive feedback: creates fail -> the backoff retries -> each retry orphans another pool -> sockets accumulate -> the edge refuses more -> more retries. At 17 fds/s the run cannot recover on its own.

## Change

Build the client once per process under a lock and share it. The key and endpoint are process-constant, and sharing is what a connection pool is for.

## Testing

- New `test_make_daytona_reuses_one_client`: five calls, one client constructed. 9 passed in that file.
- Verified on a 16-node relaunch under the same 128-concurrency workload, fd count sampled every ten minutes:

```
14:19   317      (engines still starting)
14:29   420      sandbox pool filling
14:39   430
14:49   443
14:59   435      <- went down; bounded, not monotonic
```

It converges to ~435 and oscillates in the 435-469 band over the following hours, with no `SSLEOFError` at all.

Worth noting for anyone tuning `OPENENV_DAYTONA_CREATE_MAX_RETRIES`: before this change, raising it to ride out quota contention would have *accelerated* the leak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
